### PR TITLE
[GCC 11] Fix "this pointer is null" in RecoJets/JetProducers PileupJetIdAlgo

### DIFF
--- a/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
@@ -664,7 +664,7 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
   }
 
   internalId_.dRLeadCent_ = reco::deltaR(*jet, *lLead);
-  if (lSecond == nullptr) {
+  if (lSecond != nullptr) {
     internalId_.dRLead2nd_ = reco::deltaR(*jet, *lSecond);
   }
   internalId_.dRMean_ /= jetPt;


### PR DESCRIPTION
#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

Log file: https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc11/CMSSW_12_1_X_2021-08-02-1100/RecoJets/JetProducers
Error message:
```
In function 'constexpr decltype (t1.eta()) reco::deltaR2(const T1&, const T2&) [with T1 = reco::Jet; T2 = reco::Candidate]',
    inlined from 'constexpr decltype (t1.eta()) reco::deltaR(const T1&, const T2&) [with T1 = reco::Jet; T2 = reco::Candidate]' at /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/e3e3f354f3bbc00899d20eeb240b2272/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-08-02-1100/src/DataFormats/Math/interface/deltaR.h:31:21,
    inlined from 'PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet*, float, const reco::Vertex*, const VertexCollection&, double, bool)' at /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/e3e3f354f3bbc00899d20eeb240b2272/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-08-02-1100/src/RecoJets/JetProducers/src/PileupJetIdAlgo.cc:668:42:
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/e3e3f354f3bbc00899d20eeb240b2272/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-08-02-1100/src/DataFormats/Math/interface/deltaR.h:19:22: error: 'this' pointer is null [-Werror=nonnull]
    19 |     Float p2 = t2.phi();
      |                ~~~~~~^~
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/e3e3f354f3bbc00899d20eeb240b2272/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-08-02-1100/src/DataFormats/Math/interface/deltaR.h:21:22: error: 'this' pointer is null [-Werror=nonnull]
    21 |     Float e2 = t2.eta();
      |                ~~~~~~^~
```
#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
