### PR TITLE
HCAL: HFShowerLibrary (reader) timing bugfix 

### DIFF
--- a/Geometry/HcalSimData/python/HFParameters_cff.py
+++ b/Geometry/HcalSimData/python/HFParameters_cff.py
@@ -19,7 +19,7 @@ HFShowerBlock = cms.PSet(
         ProbMax           = cms.double(1.0),
         CFibre            = cms.double(0.5),
         OnlyLong          = cms.bool(True),
-        IgnoreTimeShift   = cms.bool(False)
+        EqualizeTimeShift   = cms.bool(False)
 )
 
 ##
@@ -34,4 +34,4 @@ run2_common.toModify( HFShowerBlock, ProbMax = 0.5 )
 ##
 from Configuration.Eras.Modifier_run3_HFSL_cff import run3_HFSL
 run3_HFSL.toModify( HFLibraryFileBlock, FileName = 'SimG4CMS/Calo/data/HFShowerLibrary_run3_v5.root', FileVersion = 1 )
-run3_HFSL.toModify( HFShowerBlock, IgnoreTimeShift = True )
+run3_HFSL.toModify( HFShowerBlock, EqualizeTimeShift = True )

--- a/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
+++ b/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
@@ -180,11 +180,11 @@ run3_common.toModify( hcalSimParameters,
                readoutFrameSize = cms.int32(10), 
                binOfMaximum     = cms.int32(6)
               ),
-    hf1 = dict( samplingFactor = 0.35,
-                timePhase = -6.0 
+    hf1 = dict( samplingFactor = 0.36,
+                timePhase = 9.0 
                ),
-    hf2 = dict( samplingFactor = 0.35,
-                timePhase = -7.0
+    hf2 = dict( samplingFactor = 0.36,
+                timePhase = 8.0
                )
 ) 
 

--- a/SimG4CMS/Calo/interface/HFShower.h
+++ b/SimG4CMS/Calo/interface/HFShower.h
@@ -50,7 +50,7 @@ private:
 
   int chkFibre_;
   bool applyFidCut_;
-  bool ignoreTimeShift_;
+  bool equalizeTimeShift_;
   double probMax_;
   std::vector<double> gpar_;
 };

--- a/SimG4CMS/Calo/interface/HFShowerLibrary.h
+++ b/SimG4CMS/Calo/interface/HFShowerLibrary.h
@@ -72,7 +72,7 @@ private:
   std::vector<double> pmom;
 
   int fileVersion_;
-  bool ignoreTimeShift_;
+  bool equalizeTimeShift_;
   double probMax, backProb;
   double dphi, rMin, rMax;
   std::vector<double> gpar;

--- a/SimG4CMS/Calo/interface/HFShowerParam.h
+++ b/SimG4CMS/Calo/interface/HFShowerParam.h
@@ -47,7 +47,7 @@ private:
   std::unique_ptr<HFGflash> gflash_;
   bool fillHisto_;
   double pePerGeV_, edMin_, ref_index_, aperture_, attLMeanInv_;
-  bool trackEM_, ignoreTimeShift_, onlyLong_, applyFidCut_, parametrizeLast_;
+  bool trackEM_, equalizeTimeShift_, onlyLong_, applyFidCut_, parametrizeLast_;
   G4int emPDG_, epPDG_, gammaPDG_;
   std::vector<double> gpar_;
   TH1F *em_long_1_, *em_lateral_1_, *em_long_2_, *em_lateral_2_;

--- a/SimG4CMS/Calo/src/HFShower.cc
+++ b/SimG4CMS/Calo/src/HFShower.cc
@@ -114,7 +114,8 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step *aStep, double weight)
   double zCoor = localPos.z();
   double zFibre = (0.5 * gpar_[1] - zCoor - translation.z());
   double tSlice = (aStep->GetPostStepPoint()->GetGlobalTime());
-  double time = (equalizeTimeShift_) ? (fibre_->tShift(localPos, depth, -1)) : (fibre_->tShift(localPos, depth, chkFibre_));
+  double time =
+      (equalizeTimeShift_) ? (fibre_->tShift(localPos, depth, -1)) : (fibre_->tShift(localPos, depth, chkFibre_));
 
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HFShower") << "HFShower::getHits: in " << name << " Z " << zCoor << "(" << globalPos.z() << ") "

--- a/SimG4CMS/Calo/src/HFShower.cc
+++ b/SimG4CMS/Calo/src/HFShower.cc
@@ -114,7 +114,7 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step *aStep, double weight)
   double zCoor = localPos.z();
   double zFibre = (0.5 * gpar_[1] - zCoor - translation.z());
   double tSlice = (aStep->GetPostStepPoint()->GetGlobalTime());
-  double time = (equalizeTimeShift_) ? 0 : fibre_->tShift(localPos, depth, chkFibre_);
+  double time = (equalizeTimeShift_) ? (fibre_->tShift(lpos, depth, -1)) : (fibre_->tShift(localPos, depth, chkFibre_));
 
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HFShower") << "HFShower::getHits: in " << name << " Z " << zCoor << "(" << globalPos.z() << ") "

--- a/SimG4CMS/Calo/src/HFShower.cc
+++ b/SimG4CMS/Calo/src/HFShower.cc
@@ -114,7 +114,7 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step *aStep, double weight)
   double zCoor = localPos.z();
   double zFibre = (0.5 * gpar_[1] - zCoor - translation.z());
   double tSlice = (aStep->GetPostStepPoint()->GetGlobalTime());
-  double time = (equalizeTimeShift_) ? (fibre_->tShift(lpos, depth, -1)) : (fibre_->tShift(localPos, depth, chkFibre_));
+  double time = (equalizeTimeShift_) ? (fibre_->tShift(localPos, depth, -1)) : (fibre_->tShift(localPos, depth, chkFibre_));
 
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HFShower") << "HFShower::getHits: in " << name << " Z " << zCoor << "(" << globalPos.z() << ") "

--- a/SimG4CMS/Calo/src/HFShower.cc
+++ b/SimG4CMS/Calo/src/HFShower.cc
@@ -27,11 +27,11 @@ HFShower::HFShower(const std::string &name,
   edm::ParameterSet m_HF = p.getParameter<edm::ParameterSet>("HFShower");
   applyFidCut_ = m_HF.getParameter<bool>("ApplyFiducialCut");
   edm::ParameterSet m_HF2 = m_HF.getParameter<edm::ParameterSet>("HFShowerBlock");
-  ignoreTimeShift_ = m_HF2.getParameter<bool>("IgnoreTimeShift");
+  equalizeTimeShift_ = m_HF2.getParameter<bool>("EqualizeTimeShift");
   probMax_ = m_HF2.getParameter<double>("ProbMax");
 
   edm::LogVerbatim("HFShower") << "HFShower:: Maximum probability cut off " << probMax_ << " Check flag " << chkFibre_
-                               << " ignoreTimeShift " << ignoreTimeShift_;
+                               << " equalizeTimeShift " << equalizeTimeShift_;
 
   cherenkov_ = std::make_unique<HFCherenkov>(m_HF);
   fibre_ = std::make_unique<HFFibre>(name, hcalConstant_, hps, p);
@@ -114,7 +114,7 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step *aStep, double weight)
   double zCoor = localPos.z();
   double zFibre = (0.5 * gpar_[1] - zCoor - translation.z());
   double tSlice = (aStep->GetPostStepPoint()->GetGlobalTime());
-  double time = (ignoreTimeShift_) ? 0 : fibre_->tShift(localPos, depth, chkFibre_);
+  double time = (equalizeTimeShift_) ? 0 : fibre_->tShift(localPos, depth, chkFibre_);
 
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HFShower") << "HFShower::getHits: in " << name << " Z " << zCoor << "(" << globalPos.z() << ") "
@@ -221,7 +221,7 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step *aStep, bool forLibrar
   double tSlice = (aStep->GetPostStepPoint()->GetGlobalTime());
 
 #ifdef EDM_ML_DEBUG
-  double time = (ignoreTimeShift_) ? 0 : fibre_->tShift(localPos, depth, chkFibre_);
+  double time = (equalizeTimeShift_) ? 0 : fibre_->tShift(localPos, depth, chkFibre_);
   edm::LogVerbatim("HFShower") << "HFShower::getHits: in " << name << " Z " << zCoor << "(" << globalPos.z() << ") "
                                << zFibre << " Trans " << translation << " Time " << tSlice << " " << time
                                << "\n                  Direction " << momentumDir << " Local " << localMom;
@@ -325,7 +325,7 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step *aStep, bool forLibrar
   double zCoor = localPos.z();
   double zFibre = (0.5 * gpar_[1] - zCoor - translation.z());
   double tSlice = (aStep->GetPostStepPoint()->GetGlobalTime());
-  double time = (ignoreTimeShift_) ? 0 : fibre_->tShift(localPos, depth, chkFibre_);
+  double time = (equalizeTimeShift_) ? 0 : fibre_->tShift(localPos, depth, chkFibre_);
 
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HFShower") << "HFShower::getHits(SL): in " << name << " Z " << zCoor << "(" << globalPos.z() << ") "

--- a/SimG4CMS/Calo/src/HFShowerLibrary.cc
+++ b/SimG4CMS/Calo/src/HFShowerLibrary.cc
@@ -28,7 +28,7 @@ HFShowerLibrary::HFShowerLibrary(const std::string& name,
   edm::ParameterSet m_HF =
       (p.getParameter<edm::ParameterSet>("HFShower")).getParameter<edm::ParameterSet>("HFShowerBlock");
   probMax = m_HF.getParameter<double>("ProbMax");
-  ignoreTimeShift_ = m_HF.getParameter<bool>("IgnoreTimeShift");
+  equalizeTimeShift_ = m_HF.getParameter<bool>("equalizeTimeShift");
 
   edm::ParameterSet m_HS =
       (p.getParameter<edm::ParameterSet>("HFShowerLibrary")).getParameter<edm::ParameterSet>("HFLibraryFileBlock");
@@ -113,7 +113,7 @@ HFShowerLibrary::HFShowerLibrary(const std::string& name,
                                << " entries\n HFShowerLibrary::No packing information - Assume x, y, z are not in "
                                   "packed form\n Maximum probability cut off "
                                << probMax << "  Back propagation of light probability " << backProb
-                               << " Flag for ignoring Time Shift " << ignoreTimeShift_;
+                               << " Flag for equalizing Time Shift for different eta " << equalizeTimeShift_;
 
   fibre_ = std::make_unique<HFFibre>(name, hcalConstant_, hps, p);
   photo = new HFShowerPhotonCollection;
@@ -298,11 +298,12 @@ std::vector<HFShowerLibrary::Hit> HFShowerLibrary::fillHits(const G4ThreeVector&
 #endif
       if (rInside(r) && r1 <= exp(-p * zv) && r2 <= probMax * weight && dfir > gpar[5] && zz >= gpar[4] &&
           zz <= gpar[4] + gpar[1] && r3 <= backProb && (depth != 2 || zz >= gpar[4] + gpar[0])) {
-        double tdiff = (ignoreTimeShift_) ? 0 : (fibre_->tShift(lpos, depth, 1));
+        double tdiff = (equalizeTimeShift_) ? (fibre_->tShift(lpos, depth, -1)) : (fibre_->tShift(lpos, depth, 1));
         oneHit.position = pos;
         oneHit.depth = depth;
         oneHit.time = (tSlice + (pe[i].t()) + tdiff);
         hit.push_back(oneHit);
+
 #ifdef EDM_ML_DEBUG
         edm::LogVerbatim("HFShower") << "HFShowerLibrary: Final Hit " << nHit << " position " << (hit[nHit].position)
                                      << " Depth " << (hit[nHit].depth) << " Time " << tSlice << ":" << pe[i].t() << ":"
@@ -318,7 +319,7 @@ std::vector<HFShowerLibrary::Hit> HFShowerLibrary::fillHits(const G4ThreeVector&
         r1 = G4UniformRand();
         r2 = G4UniformRand();
         if (rInside(r) && r1 <= exp(-p * zv) && r2 <= probMax && dfir > gpar[5]) {
-          double tdiff = (ignoreTimeShift_) ? 0 : (fibre_->tShift(lpos, 2, 1));
+          double tdiff = (equalizeTimeShift_) ? (fibre_->tShift(lpos, 2, -1)) : (fibre_->tShift(lpos, 2, 1));
           oneHit.position = pos;
           oneHit.depth = 2;
           oneHit.time = (tSlice + (pe[i].t()) + tdiff);

--- a/SimG4CMS/Calo/src/HFShowerLibrary.cc
+++ b/SimG4CMS/Calo/src/HFShowerLibrary.cc
@@ -28,7 +28,7 @@ HFShowerLibrary::HFShowerLibrary(const std::string& name,
   edm::ParameterSet m_HF =
       (p.getParameter<edm::ParameterSet>("HFShower")).getParameter<edm::ParameterSet>("HFShowerBlock");
   probMax = m_HF.getParameter<double>("ProbMax");
-  equalizeTimeShift_ = m_HF.getParameter<bool>("equalizeTimeShift");
+  equalizeTimeShift_ = m_HF.getParameter<bool>("EqualizeTimeShift");
 
   edm::ParameterSet m_HS =
       (p.getParameter<edm::ParameterSet>("HFShowerLibrary")).getParameter<edm::ParameterSet>("HFLibraryFileBlock");

--- a/SimG4CMS/Calo/src/HFShowerParam.cc
+++ b/SimG4CMS/Calo/src/HFShowerParam.cc
@@ -38,7 +38,7 @@ HFShowerParam::HFShowerParam(const std::string& name,
   bool useShowerLibrary = m_HF.getParameter<bool>("UseShowerLibrary");
   bool useGflash = m_HF.getParameter<bool>("UseHFGflash");
   edMin_ = m_HF.getParameter<double>("EminLibrary");
-  ignoreTimeShift_ = m_HF2.getParameter<bool>("IgnoreTimeShift");
+  equalizeTimeShift_ = m_HF2.getParameter<bool>("EqualizeTimeShift");
   onlyLong_ = m_HF2.getParameter<bool>("OnlyLong");
   ref_index_ = m_HF.getParameter<double>("RefIndex");
   double lambdaMean = m_HF.getParameter<double>("LambdaMean");
@@ -52,7 +52,7 @@ HFShowerParam::HFShowerParam(const std::string& name,
                                << ", ref. index of fibre " << ref_index_ << ", Track EM Flag " << trackEM_ << ", edMin "
                                << edMin_ << " GeV, use of Short fibre info in"
                                << " shower library set to " << !(onlyLong_)
-                               << " ignore flag for time shift in fire is set to " << ignoreTimeShift_
+                               << " equalize flag for time shift in fibre is set to " << equalizeTimeShift_
                                << ", use of parametrization for last part set to " << parametrizeLast_
                                << ", Mean lambda " << lambdaMean << ", aperture (cutoff) " << aperture_
                                << ", Application of Fiducial Cut " << applyFidCut_;
@@ -266,7 +266,7 @@ std::vector<HFShowerParam::Hit> HFShowerParam::getHits(const G4Step* aStep, doub
                   << "HFShowerParam:Extra exclusion " << r2 << ">" << weight << " " << (r2 > weight);
 #endif
               if (r2 < weight) {
-                double time = (ignoreTimeShift_) ? 0 : fibre_->tShift(localPoint, depth, 0);
+                double time = (equalizeTimeShift_) ? 0 : fibre_->tShift(localPoint, depth, 0);
 
                 hit.position = hitSL[i].position;
                 hit.depth = depth;
@@ -302,7 +302,7 @@ std::vector<HFShowerParam::Hit> HFShowerParam::getHits(const G4Step* aStep, doub
         path = "Rest";
         edep *= pePerGeV_;
         double tSlice = (aStep->GetPostStepPoint()->GetGlobalTime());
-        double time = (ignoreTimeShift_) ? 0 : fibre_->tShift(localPoint, 1, 0);  // remaining part
+        double time = (equalizeTimeShift_) ? 0 : fibre_->tShift(localPoint, 1, 0);  // remaining part
         bool ok = true;
         if (applyFidCut_) {  // @@ For showerlibrary no z-cut for Short (no z)
           int npmt = HFFibreFiducial::PMTNumber(hitPoint);
@@ -328,7 +328,7 @@ std::vector<HFShowerParam::Hit> HFShowerParam::getHits(const G4Step* aStep, doub
           }
 #endif
           if (zz >= gpar_[0]) {
-            time = (ignoreTimeShift_) ? 0 : fibre_->tShift(localPoint, 2, 0);
+            time = (equalizeTimeShift_) ? 0 : fibre_->tShift(localPoint, 2, 0);
             hit.depth = 2;
             hit.time = tSlice + time;
             hits.push_back(hit);


### PR DESCRIPTION
#### PR description:

Included is a variaiton of light propagation time in (the same) fibers for p.e.'s from different locations.
Previous version mistakenly omitted this component (making light propagation time identical for differently located p.e.'s)      

#### PR validation:
runTheMatrix.py -l limited 

private 2021 particle-gun test wrt 12_0_0_pre4 (old HF ShowerLibrary) shows a good agreement after HF timePhase re-tuning (as a part of this PR)
https://cms-cpt-software.web.cern.ch/cms-cpt-software/General/Validation/SVSuite/HCAL/calo_scan_single_pi/12_1_X/12_1_X_2021-08-03-2300+timefixHF_run3_vs_12_0_0_pre4_run3_SinglePi/


#### NB: may need to be backported to 12_0_X 
