### PR TITLE
Updates on GEM onlineDQM due to the updates of DAQ dataformat, backport to CMSSW_11_3_X

### DIFF
--- a/DQM/GEM/interface/GEMDAQStatusSource.h
+++ b/DQM/GEM/interface/GEMDAQStatusSource.h
@@ -1,0 +1,86 @@
+#ifndef DQM_GEM_INTERFACE_GEMDAQStatusSource_h
+#define DQM_GEM_INTERFACE_GEMDAQStatusSource_h
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+#include "Validation/MuonGEMHits/interface/GEMValidationUtils.h"
+
+#include "DataFormats/GEMDigi/interface/GEMDigiCollection.h"
+#include "DataFormats/GEMDigi/interface/GEMVFATStatusCollection.h"
+#include "DataFormats/GEMDigi/interface/GEMOHStatusCollection.h"
+#include "DataFormats/GEMDigi/interface/GEMAMCStatusCollection.h"
+#include "DataFormats/GEMDigi/interface/GEMAMC13StatusCollection.h"
+
+#include "DQM/GEM/interface/GEMDQMBase.h"
+
+#include <string>
+
+//----------------------------------------------------------------------------------------------------
+
+class GEMDAQStatusSource : public GEMDQMBase {
+public:
+  explicit GEMDAQStatusSource(const edm::ParameterSet &cfg);
+  ~GEMDAQStatusSource() override{};
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+
+protected:
+  void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override{};
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+  void analyze(edm::Event const &e, edm::EventSetup const &eSetup) override;
+
+  void FillWithRiseErr(MonitorElement *h, Int_t nX, Int_t nY, Bool_t &bErr) {
+    h->Fill(nX, nY);
+    bErr = true;
+  };
+
+private:
+  int ProcessWithMEMap3(BookingHelper &bh, ME3IdsKey key) override;
+  int ProcessWithMEMap3WithChamber(BookingHelper &bh, ME4IdsKey key) override;
+
+  void SetLabelAMC13Status(MonitorElement *h2Status);
+  void SetLabelAMCStatus(MonitorElement *h2Status);
+  void SetLabelOHStatus(MonitorElement *h2Status);
+  void SetLabelVFATStatus(MonitorElement *h2Status);
+
+  edm::EDGetToken tagVFAT_;
+  edm::EDGetToken tagOH_;
+  edm::EDGetToken tagAMC_;
+  edm::EDGetToken tagAMC13_;
+
+  MonitorElement *h2AMC13Status_;
+  MonitorElement *h2AMCStatusPos_;
+  MonitorElement *h2AMCStatusNeg_;
+
+  MEMap3Inf mapStatusOH_;
+  MEMap3Inf mapStatusVFAT_;
+
+  MEMap3Inf mapStatusWarnVFATPerLayer_;
+  MEMap3Inf mapStatusErrVFATPerLayer_;
+  MEMap4Inf mapStatusVFATPerCh_;
+
+  MonitorElement *h2SummaryStatusWarning;
+  MonitorElement *h2SummaryStatusError;
+
+  Int_t nBXMin_, nBXMax_;
+
+  std::map<UInt_t, int> mapFEDIdToRe_;
+  Int_t nAMCSlots_;
+
+  int nBitAMC13_ = 10;
+  int nBitAMC_ = 12;
+  int nBitOH_ = 17;
+  int nBitVFAT_ = 7;
+};
+
+#endif  // DQM_GEM_INTERFACE_GEMDAQStatusSource_h

--- a/DQM/GEM/interface/GEMDQMBase.h
+++ b/DQM/GEM/interface/GEMDQMBase.h
@@ -74,6 +74,23 @@ public:
       return ibooker_->book2D(name, title, nbinsx, xlow, xup, nbinsy, ylow, yup);
     }
 
+    MonitorElement *bookProfile2D(TString name,
+                                  TString title,
+                                  int nbinsx,
+                                  double xlow,
+                                  double xup,
+                                  int nbinsy,
+                                  double ylow,
+                                  double yup,
+                                  double zlow,
+                                  double zup,
+                                  TString x_title = "",
+                                  TString y_title = "") {
+      name += name_suffix_;
+      title += title_suffix_ + ";" + x_title + ";" + y_title;
+      return ibooker_->bookProfile2D(name, title, nbinsx, xlow, xup, nbinsy, ylow, yup, zlow, zup);
+    }
+
   private:
     DQMStore::IBooker *ibooker_;
     const TString name_suffix_;
@@ -87,7 +104,12 @@ public:
 
     MEMapInfT(
         GEMDQMBase *pDQMBase, TString strName, TString strTitle, TString strTitleX = "", TString strTitleY = "Entries")
-        : pDQMBase_(pDQMBase), strName_(strName), strTitle_(strTitle), strTitleX_(strTitleX), strTitleY_(strTitleY){};
+        : pDQMBase_(pDQMBase),
+          strName_(strName),
+          strTitle_(strTitle),
+          strTitleX_(strTitleX),
+          strTitleY_(strTitleY),
+          log_category_own_(pDQMBase->log_category_){};
 
     MEMapInfT(GEMDQMBase *pDQMBase,
               TString strName,
@@ -103,10 +125,12 @@ public:
           strTitleX_(strTitleX),
           strTitleY_(strTitleY),
           bOperating_(true),
+          bIsProfile_(false),
           nBinsX_(nBinsX),
           dXL_(dXL),
           dXH_(dXH),
-          nBinsY_(-1){};
+          nBinsY_(-1),
+          log_category_own_(pDQMBase->log_category_){};
 
     MEMapInfT(GEMDQMBase *pDQMBase,
               TString strName,
@@ -120,8 +144,10 @@ public:
           strTitleX_(strTitleX),
           strTitleY_(strTitleY),
           bOperating_(true),
+          bIsProfile_(false),
           nBinsX_(-1),
-          nBinsY_(-1) {
+          nBinsY_(-1),
+          log_category_own_(pDQMBase->log_category_) {
       for (Int_t i = 0; i < (Int_t)x_binning.size(); i++)
         x_binning_.push_back(x_binning[i]);
     };
@@ -143,12 +169,46 @@ public:
           strTitleX_(strTitleX),
           strTitleY_(strTitleY),
           bOperating_(true),
+          bIsProfile_(false),
           nBinsX_(nBinsX),
           dXL_(dXL),
           dXH_(dXH),
           nBinsY_(nBinsY),
           dYL_(dYL),
-          dYH_(dYH){};
+          dYH_(dYH),
+          dZL_(0),
+          dZH_(1024),
+          log_category_own_(pDQMBase->log_category_){};
+
+    MEMapInfT(GEMDQMBase *pDQMBase,  // For TProfile2D
+              TString strName,
+              TString strTitle,
+              Int_t nBinsX,
+              Double_t dXL,
+              Double_t dXH,
+              Int_t nBinsY,
+              Double_t dYL,
+              Double_t dYH,
+              Double_t dZL,
+              Double_t dZH,
+              TString strTitleX = "",
+              TString strTitleY = "")
+        : pDQMBase_(pDQMBase),
+          strName_(strName),
+          strTitle_(strTitle),
+          strTitleX_(strTitleX),
+          strTitleY_(strTitleY),
+          bOperating_(true),
+          bIsProfile_(true),
+          nBinsX_(nBinsX),
+          dXL_(dXL),
+          dXH_(dXH),
+          nBinsY_(nBinsY),
+          dYL_(dYL),
+          dYH_(dYH),
+          dZL_(dZL),
+          dZH_(dZH),
+          log_category_own_(pDQMBase->log_category_){};
 
     //MEMapInfT(GEMDQMBase *pDQMBase,
     //          TString strName,
@@ -168,14 +228,18 @@ public:
     //      dXH_(dXH),
     //      nBinsY_(nBinsY),
     //      dYL_(dYL),
-    //      dYH_(dYH){};
+    //      dYH_(dYH),
+    //      log_category_own_(pDQMBase->log_category_){};
 
     ~MEMapInfT(){};
 
     Bool_t isOperating() { return bOperating_; };
     void SetOperating(Bool_t bOperating) { bOperating_ = bOperating; };
-    void turnOn() { bOperating_ = true; };
-    void turnOff() { bOperating_ = false; };
+    void TurnOn() { bOperating_ = true; };
+    void TurnOff() { bOperating_ = false; };
+
+    Bool_t isProfile() { return bIsProfile_; };
+    void SetProfile(Bool_t bIsProfile) { bIsProfile_ = bIsProfile; };
 
     TString GetName() { return strName_; };
     void SetName(TString strName) { strName_ = strName; };
@@ -201,6 +265,11 @@ public:
     Double_t GetBinHighEdgeY() { return dYH_; };
     void SetBinHighEdgeY(Double_t dYH) { dYH_ = dYH; };
 
+    Double_t GetBinLowEdgeZ() { return dZL_; };
+    void SetBinLowEdgeZ(Double_t dZL) { dZL_ = dZL; };
+    Double_t GetBinHighEdgeZ() { return dZH_; };
+    void SetBinHighEdgeZ(Double_t dZH) { dZH_ = dZH; };
+
     void SetBinConfX(Int_t nBins, Double_t dL = 0.5, Double_t dH = -1048576.0) {
       nBinsX_ = nBins;
       dXL_ = dL;
@@ -221,7 +290,10 @@ public:
     int bookND(BookingHelper &bh, K key) {
       if (!bOperating_)
         return 0;
-      if (nBinsY_ > 0 && nBinsX_ > 0) {
+      if (bIsProfile_) {
+        mapHist[key] = bh.bookProfile2D(
+            strName_, strTitle_, nBinsX_, dXL_, dXH_, nBinsY_, dYL_, dYH_, dZL_, dZH_, strTitleX_, strTitleY_);
+      } else if (nBinsY_ > 0 && nBinsX_ > 0) {
         mapHist[key] = bh.book2D(strName_, strTitle_, nBinsX_, dXL_, dXH_, nBinsY_, dYL_, dYH_, strTitleX_, strTitleY_);
         return 0;
       } else if (!x_binning_.empty()) {
@@ -237,13 +309,15 @@ public:
 
     dqm::impl::MonitorElement *FindHist(K key) {
       if (mapHist.find(key) == mapHist.end()) {
-        std::cout << "" << std::endl;  // FIXME: It's about sending a message
-        return nullptr;
+        edm::LogError(log_category_own_)
+            << "WARNING: Cannot find the histogram corresponing to the given key\n";  // FIXME: It's about sending a message
       }
       return mapHist[key];
     };
 
     int SetLabelForChambers(K key, Int_t nAxis, Int_t nNumBin = -1) {
+      if (!bOperating_)
+        return 0;
       if (nNumBin <= 0) {
         if (nAxis == 1)
           nNumBin = nBinsX_;
@@ -261,7 +335,11 @@ public:
       return 0;
     };
 
+    int SetLabelForIEta(K key, Int_t nAxis, Int_t nNumBin = -1) { return SetLabelForChambers(key, nAxis, nNumBin); };
+
     int SetLabelForVFATs(K key, Int_t nNumEtaPartitions, Int_t nAxis, Int_t nNumBin = -1) {
+      if (!bOperating_)
+        return 0;
       if (nNumBin <= 0) {
         if (nAxis == 1)
           nNumBin = nBinsX_;
@@ -287,20 +365,20 @@ public:
       if (hist == nullptr)
         return -999;
       hist->Fill(x);
-      return 0;
+      return 1;
     };
 
-    int Fill(K key, Double_t x, Double_t y) {
+    int Fill(K key, Double_t x, Double_t y, Double_t w = 1.0) {
       if (!bOperating_)
         return 0;
       dqm::impl::MonitorElement *hist = FindHist(key);
       if (hist == nullptr)
         return -999;
-      hist->Fill(x, y);
-      return 0;
+      hist->Fill(x, y, w);
+      return 1;
     };
 
-    int FillBits(K key, Double_t x, UInt_t bits) {
+    int FillBits(K key, Double_t x, UInt_t bits, Double_t w = 1.0) {
       if (!bOperating_)
         return 0;
       dqm::impl::MonitorElement *hist = FindHist(key);
@@ -312,11 +390,11 @@ public:
       UInt_t unMask = 0x1;
       for (Int_t i = 1; i <= nBinsY_; i++) {
         if ((unMask & bits) != 0)
-          hist->Fill(x, i);
+          hist->Fill(x, i, w);
         unMask <<= 1;
       }
 
-      return 0;
+      return 1;
     };
 
   private:
@@ -325,12 +403,16 @@ public:
     M mapHist;
     TString strName_, strTitle_, strTitleX_, strTitleY_;
     Bool_t bOperating_;
+    Bool_t bIsProfile_;
 
     std::vector<double> x_binning_;
     Int_t nBinsX_;
     Double_t dXL_, dXH_;
     Int_t nBinsY_;
     Double_t dYL_, dYH_;
+    Double_t dZL_, dZH_;
+
+    std::string log_category_own_;
   };
 
   typedef MEMapInfT<MEMap2Ids, ME2IdsKey> MEMap2Inf;
@@ -346,19 +428,19 @@ public:
                   Int_t nNumChambers,
                   Int_t nNumEtaPartitions,
                   Int_t nMaxVFAT,
-                  Int_t nNumStrip)
+                  Int_t nNumDigi)
         : nRegion_(nRegion),
           nStation_(nStation),
           nLayer_(nLayer),
           nNumChambers_(nNumChambers),
           nNumEtaPartitions_(nNumEtaPartitions),
           nMaxVFAT_(nMaxVFAT),
-          nNumStrip_(nNumStrip){};
+          nNumDigi_(nNumDigi){};
 
     bool operator==(const MEStationInfo &other) const {
       return (nRegion_ == other.nRegion_ && nStation_ == other.nStation_ && nLayer_ == other.nLayer_ &&
               nNumChambers_ == other.nNumChambers_ && nNumEtaPartitions_ == other.nNumEtaPartitions_ &&
-              nMaxVFAT_ == other.nMaxVFAT_ && nNumStrip_ == other.nNumStrip_);
+              nMaxVFAT_ == other.nMaxVFAT_ && nNumDigi_ == other.nNumDigi_);
     };
 
     Int_t nRegion_;            // the region index
@@ -366,13 +448,15 @@ public:
     Int_t nLayer_;             // the layer
     Int_t nNumChambers_;       // the number of chambers in the current station
     Int_t nNumEtaPartitions_;  // the number of eta partitions of the chambers
-    Int_t nMaxVFAT_;   // the number of all VFATs in each chamber (= # of VFATs in eta partition * nNumEtaPartitions_)
-    Int_t nNumStrip_;  // the number of strips of each VFAT
+    Int_t nMaxVFAT_;  // the number of all VFATs in each chamber (= # of VFATs in eta partition * nNumEtaPartitions_)
+    Int_t nNumDigi_;  // the number of digis of each VFAT
   };
 
 public:
   explicit GEMDQMBase(const edm::ParameterSet &cfg);
   ~GEMDQMBase() override{};
+
+  std::string log_category_;
 
 protected:
   int initGeometry(edm::EventSetup const &iSetup);
@@ -380,10 +464,12 @@ protected:
   int readRadiusEtaPartition(int nRegion, int nStation);
 
   int GenerateMEPerChamber(DQMStore::IBooker &ibooker);
-  virtual int ProcessWithMEMap2(BookingHelper &bh, ME2IdsKey key) { return 0; };             // must be overrided
-  virtual int ProcessWithMEMap3(BookingHelper &bh, ME3IdsKey key) { return 0; };             // must be overrided
-  virtual int ProcessWithMEMap4(BookingHelper &bh, ME4IdsKey key) { return 0; };             // must be overrided
-  virtual int ProcessWithMEMap3WithChamber(BookingHelper &bh, ME4IdsKey key) { return 0; };  // must be overrided
+  virtual int ProcessWithMEMap2(BookingHelper &bh, ME2IdsKey key) { return 0; };              // must be overrided
+  virtual int ProcessWithMEMap2WithEta(BookingHelper &bh, ME3IdsKey key) { return 0; };       // must be overrided
+  virtual int ProcessWithMEMap2AbsReWithEta(BookingHelper &bh, ME3IdsKey key) { return 0; };  // must be overrided
+  virtual int ProcessWithMEMap3(BookingHelper &bh, ME3IdsKey key) { return 0; };              // must be overrided
+  virtual int ProcessWithMEMap4(BookingHelper &bh, ME4IdsKey key) { return 0; };              // must be overrided
+  virtual int ProcessWithMEMap3WithChamber(BookingHelper &bh, ME4IdsKey key) { return 0; };   // must be overrided
 
   int keyToRegion(ME2IdsKey key) { return std::get<0>(key); };
   int keyToRegion(ME3IdsKey key) { return std::get<0>(key); };
@@ -394,7 +480,13 @@ protected:
   int keyToLayer(ME3IdsKey key) { return std::get<2>(key); };
   int keyToLayer(ME4IdsKey key) { return std::get<2>(key); };
   int keyToChamber(ME4IdsKey key) { return std::get<3>(key); };
+  int keyToIEta(ME3IdsKey key) { return std::get<2>(key); };
   int keyToIEta(ME4IdsKey key) { return std::get<3>(key); };
+
+  ME2IdsKey key3Tokey2(ME3IdsKey key) {
+    auto keyNew = ME2IdsKey{keyToRegion(key), keyToStation(key)};
+    return keyNew;
+  };
 
   ME3IdsKey key4Tokey3(ME4IdsKey key) {
     auto keyNew = ME3IdsKey{keyToRegion(key), keyToStation(key), keyToLayer(key)};
@@ -410,19 +502,19 @@ protected:
   int getNumEtaPartitions(const GEMStation *);
   inline int getVFATNumber(const int, const int, const int);
   inline int getVFATNumberGE11(const int, const int, const int);
-  inline int getVFATNumberByStrip(const int, const int, const int);
+  inline int getVFATNumberByDigi(const int, const int, const int);
   inline int getIEtaFromVFAT(const int station, const int vfat);
   inline int getIEtaFromVFATGE11(const int vfat);
   inline int getMaxVFAT(const int);
   inline int getDetOccXBin(const int, const int, const int);
-
-  std::string log_category_;
 
   const GEMGeometry *GEMGeometry_;
 
   std::vector<GEMChamber> gemChambers_;
 
   std::map<ME2IdsKey, bool> MEMap2Check_;
+  std::map<ME3IdsKey, bool> MEMap2WithEtaCheck_;
+  std::map<ME3IdsKey, bool> MEMap2AbsReWithEtaCheck_;
   std::map<ME3IdsKey, bool> MEMap3Check_;
   std::map<ME4IdsKey, bool> MEMap3WithChCheck_;
   std::map<ME4IdsKey, bool> MEMap4Check_;
@@ -463,11 +555,11 @@ inline int GEMDQMBase::getVFATNumber(const int station, const int ieta, const in
 }
 
 inline int GEMDQMBase::getVFATNumberGE11(const int station, const int ieta, const int vfat_phi) {
-  return vfat_phi * nNumEtaPartitionGE11_ + (8 - ieta);
+  return vfat_phi * nNumEtaPartitionGE11_ + (nNumEtaPartitionGE11_ - ieta);
 }
 
-inline int GEMDQMBase::getVFATNumberByStrip(const int station, const int ieta, const int strip) {
-  const int vfat_phi = (strip % GEMeMap::maxChan_) ? strip / GEMeMap::maxChan_ : strip / GEMeMap::maxChan_ - 1;
+inline int GEMDQMBase::getVFATNumberByDigi(const int station, const int ieta, const int digi) {
+  const int vfat_phi = digi / GEMeMap::maxChan_;
   return getVFATNumber(station, ieta, vfat_phi);
 }
 

--- a/DQM/GEM/interface/GEMDigiSource.h
+++ b/DQM/GEM/interface/GEMDigiSource.h
@@ -1,0 +1,66 @@
+#ifndef DQM_GEM_INTERFACE_GEMDigiSource_h
+#define DQM_GEM_INTERFACE_GEMDigiSource_h
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+#include "Validation/MuonGEMHits/interface/GEMValidationUtils.h"
+
+#include "DataFormats/GEMDigi/interface/GEMDigiCollection.h"
+
+#include "DataFormats/Scalers/interface/LumiScalers.h"
+
+#include "DQM/GEM/interface/GEMDQMBase.h"
+
+#include <string>
+
+//----------------------------------------------------------------------------------------------------
+
+class GEMDigiSource : public GEMDQMBase {
+public:
+  explicit GEMDigiSource(const edm::ParameterSet& cfg);
+  ~GEMDigiSource() override{};
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+protected:
+  void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override{};
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
+  void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
+
+private:
+  int ProcessWithMEMap2WithEta(BookingHelper& bh, ME3IdsKey key) override;
+  int ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) override;
+  int ProcessWithMEMap3WithChamber(BookingHelper& bh, ME4IdsKey key) override;
+
+  edm::EDGetToken tagDigi_;
+
+  edm::EDGetTokenT<LumiScalersCollection> lumiScalers_;
+
+  MEMap3Inf mapTotalDigi_layer_;
+  MEMap3Inf mapDigiOcc_ieta_;
+  MEMap3Inf mapDigiOcc_phi_;
+  MEMap3Inf mapTotalDigiPerEvtLayer_;
+  MEMap3Inf mapTotalDigiPerEvtIEta_;
+  MEMap3Inf mapBX_iEta_;
+
+  MEMap4Inf mapDigiOccPerCh_;
+
+  MonitorElement* h2SummaryOcc_;
+
+  Int_t nBXMin_, nBXMax_;
+
+  Bool_t bModeRelVal_;
+};
+
+#endif  // DQM_GEM_INTERFACE_GEMDigiSource_h

--- a/DQM/GEM/interface/GEMRecHitSource.h
+++ b/DQM/GEM/interface/GEMRecHitSource.h
@@ -1,0 +1,61 @@
+#ifndef DQM_GEM_INTERFACE_GEMRecHitSource_h
+#define DQM_GEM_INTERFACE_GEMRecHitSource_h
+
+#include "DQM/GEM/interface/GEMDQMBase.h"
+
+#include "DataFormats/GEMRecHit/interface/GEMRecHit.h"
+#include "DataFormats/GEMRecHit/interface/GEMRecHitCollection.h"
+#include "DataFormats/GEMDigi/interface/GEMDigiCollection.h"
+
+#include <string>
+
+//----------------------------------------------------------------------------------------------------
+
+class GEMRecHitSource : public GEMDQMBase {
+public:
+  explicit GEMRecHitSource(const edm::ParameterSet& cfg);
+  ~GEMRecHitSource() override{};
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+protected:
+  void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override{};
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
+  void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
+
+private:
+  int ProcessWithMEMap2WithEta(BookingHelper& bh, ME3IdsKey key) override;
+  int ProcessWithMEMap2AbsReWithEta(BookingHelper& bh, ME3IdsKey key) override;
+  int ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) override;
+  int ProcessWithMEMap3WithChamber(BookingHelper& bh, ME4IdsKey key) override;
+
+  edm::EDGetToken tagRecHit_;
+
+  int nIdxFirstDigi_;
+  int nClusterSizeBinNum_;
+
+  MEMap3Inf mapTotalRecHit_layer_;
+  MEMap3Inf mapRecHitWheel_layer_;
+  MEMap3Inf mapRecHitOcc_ieta_;
+  MEMap3Inf mapRecHitOcc_phi_;
+  MEMap3Inf mapTotalRecHitPerEvtLayer_;
+  MEMap3Inf mapTotalRecHitPerEvtIEta_;
+  MEMap3Inf mapCLSRecHit_ieta_;
+  MEMap3Inf mapCLSAverage_;
+  MEMap3Inf mapCLSOver5_;
+
+  MEMap4Inf mapCLSPerCh_;
+
+  Int_t nCLSMax_;
+  Float_t fRadiusMin_;
+  Float_t fRadiusMax_;
+
+  std::unordered_map<UInt_t, MonitorElement*> recHitME_;
+  std::unordered_map<UInt_t, MonitorElement*> VFAT_vs_ClusterSize_;
+  std::unordered_map<UInt_t, MonitorElement*> DigisFired_vs_eta_;
+  std::unordered_map<UInt_t, MonitorElement*> rh_vs_eta_;
+  std::unordered_map<UInt_t, MonitorElement*> recGlobalPos;
+
+  Bool_t bModeRelVal_;
+};
+
+#endif  // DQM_GEM_INTERFACE_GEMRecHitSource_h

--- a/DQM/GEM/plugins/GEMDAQStatusSource.cc
+++ b/DQM/GEM/plugins/GEMDAQStatusSource.cc
@@ -1,99 +1,23 @@
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/PluginManager/interface/ModuleDef.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Utilities/interface/InputTag.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
-#include "DQMServices/Core/interface/DQMStore.h"
-#include "DQMServices/Core/interface/MonitorElement.h"
-
-#include "Validation/MuonGEMHits/interface/GEMValidationUtils.h"
-
-#include "DataFormats/GEMDigi/interface/GEMDigiCollection.h"
-#include "DataFormats/GEMDigi/interface/GEMVfatStatusDigiCollection.h"
-#include "DataFormats/GEMDigi/interface/GEMGEBdataCollection.h"
-#include "DataFormats/GEMDigi/interface/GEMAMCdataCollection.h"
-#include "DataFormats/GEMDigi/interface/GEMAMC13EventCollection.h"
-
-#include "DQM/GEM/interface/GEMDQMBase.h"
-
-#include <string>
-
-//----------------------------------------------------------------------------------------------------
-
-class GEMDAQStatusSource : public GEMDQMBase {
-public:
-  explicit GEMDAQStatusSource(const edm::ParameterSet &cfg);
-  ~GEMDAQStatusSource() override{};
-  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
-
-protected:
-  void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override{};
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void analyze(edm::Event const &e, edm::EventSetup const &eSetup) override;
-
-private:
-  int ProcessWithMEMap3(BookingHelper &bh, ME3IdsKey key) override;
-  int ProcessWithMEMap3WithChamber(BookingHelper &bh, ME4IdsKey key) override;
-
-  void SetLabelAMCStatus(MonitorElement *h2Status);
-  void SetLabelGEBStatus(MonitorElement *h2Status);
-  void SetLabelVFATStatus(MonitorElement *h2Status);
-
-  edm::EDGetToken tagDigi_;
-  edm::EDGetToken tagVFAT_;
-  edm::EDGetToken tagGEB_;
-  edm::EDGetToken tagAMC_;
-  edm::EDGetToken tagAMC13_;
-
-  MonitorElement *h2AMCStatusPos_;
-  MonitorElement *h2AMCStatusNeg_;
-  MonitorElement *h2AMCNumGEBPos_;
-  MonitorElement *h2AMCNumGEBNeg_;
-
-  MEMap3Inf mapStatusGEB_;
-  MEMap3Inf mapStatusVFAT_;
-  MEMap3Inf mapGEBNumVFAT_;
-
-  MEMap3Inf mapStatusVFATPerLayer_;
-  MEMap4Inf mapStatusVFATPerCh_;
-
-  MonitorElement *h2SummaryStatus;
-
-  Int_t nBXMin_, nBXMax_;
-
-  std::map<UInt_t, int> mapFEDIdToRe_;
-  Int_t nAMCSlots_;
-
-  int nBitAMC_ = 7;
-  int nBitGEB_ = 17;
-  int nBitVFAT_ = 9;
-};
+#include "DQM/GEM/interface/GEMDAQStatusSource.h"
 
 using namespace std;
 using namespace edm;
 
 GEMDAQStatusSource::GEMDAQStatusSource(const edm::ParameterSet &cfg) : GEMDQMBase(cfg) {
-  tagDigi_ = consumes<GEMDigiCollection>(cfg.getParameter<edm::InputTag>("digisInputLabel"));
-  tagVFAT_ = consumes<GEMVfatStatusDigiCollection>(cfg.getParameter<edm::InputTag>("VFATInputLabel"));
-  tagGEB_ = consumes<GEMGEBdataCollection>(cfg.getParameter<edm::InputTag>("GEBInputLabel"));
-  tagAMC_ = consumes<GEMAMCdataCollection>(cfg.getParameter<edm::InputTag>("AMCInputLabel"));
-  tagAMC13_ = consumes<GEMAMC13EventCollection>(cfg.getParameter<edm::InputTag>("AMC13InputLabel"));
+  tagVFAT_ = consumes<GEMVFATStatusCollection>(cfg.getParameter<edm::InputTag>("VFATInputLabel"));
+  tagOH_ = consumes<GEMOHStatusCollection>(cfg.getParameter<edm::InputTag>("OHInputLabel"));
+  tagAMC_ = consumes<GEMAMCStatusCollection>(cfg.getParameter<edm::InputTag>("AMCInputLabel"));
+  tagAMC13_ = consumes<GEMAMC13StatusCollection>(cfg.getParameter<edm::InputTag>("AMC13InputLabel"));
 
   nAMCSlots_ = cfg.getParameter<Int_t>("AMCSlots");
 }
 
 void GEMDAQStatusSource::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("digisInputLabel", edm::InputTag("muonGEMDigis", ""));
-  desc.add<edm::InputTag>("VFATInputLabel", edm::InputTag("muonGEMDigis", "vfatStatus"));
-  desc.add<edm::InputTag>("GEBInputLabel", edm::InputTag("muonGEMDigis", "gebStatus"));
-  desc.add<edm::InputTag>("AMCInputLabel", edm::InputTag("muonGEMDigis", "AMCdata"));
-  desc.add<edm::InputTag>("AMC13InputLabel", edm::InputTag("muonGEMDigis", "AMC13Event"));
+  desc.add<edm::InputTag>("VFATInputLabel", edm::InputTag("muonGEMDigis", "VFATStatus"));
+  desc.add<edm::InputTag>("OHInputLabel", edm::InputTag("muonGEMDigis", "OHStatus"));
+  desc.add<edm::InputTag>("AMCInputLabel", edm::InputTag("muonGEMDigis", "AMCStatus"));
+  desc.add<edm::InputTag>("AMC13InputLabel", edm::InputTag("muonGEMDigis", "AMC13Status"));
 
   desc.add<Int_t>("AMCSlots", 13);
   desc.addUntracked<std::string>("logCategory", "GEMDAQStatusSource");
@@ -101,49 +25,69 @@ void GEMDAQStatusSource::fillDescriptions(edm::ConfigurationDescriptions &descri
   descriptions.add("GEMDAQStatusSource", desc);
 }
 
+void GEMDAQStatusSource::SetLabelAMC13Status(MonitorElement *h2Status) {
+  unsigned int unBinPos = 1;
+  h2Status->setBinLabel(unBinPos++, "Good", 2);
+  h2Status->setBinLabel(unBinPos++, "Invalid AMC", 2);
+  h2Status->setBinLabel(unBinPos++, "Invalid size", 2);
+  h2Status->setBinLabel(unBinPos++, "Fail trailer check", 2);
+  h2Status->setBinLabel(unBinPos++, "Fail fragment length", 2);
+  h2Status->setBinLabel(unBinPos++, "Fail trailer match", 2);
+  h2Status->setBinLabel(unBinPos++, "More trailer", 2);
+  h2Status->setBinLabel(unBinPos++, "CRC modified", 2);
+  h2Status->setBinLabel(unBinPos++, "S-link error", 2);
+  h2Status->setBinLabel(unBinPos++, "Wrong FED ID", 2);
+
+  h2Status->setBinLabel(1, "GE11-N", 1);
+  h2Status->setBinLabel(2, "GE11-P", 1);
+}
+
 void GEMDAQStatusSource::SetLabelAMCStatus(MonitorElement *h2Status) {
   unsigned int unBinPos = 1;
   h2Status->setBinLabel(unBinPos++, "Good", 2);
-  h2Status->setBinLabel(unBinPos++, "BC0 not locked", 2);
-  h2Status->setBinLabel(unBinPos++, "DAQ not ready", 2);
-  h2Status->setBinLabel(unBinPos++, "DAQ clock not locked", 2);
-  h2Status->setBinLabel(unBinPos++, "MMCM not locked", 2);
+  h2Status->setBinLabel(unBinPos++, "Invalid OH", 2);
   h2Status->setBinLabel(unBinPos++, "Back pressure", 2);
-  h2Status->setBinLabel(unBinPos++, "GLIB out-of-sync", 2);
+  h2Status->setBinLabel(unBinPos++, "Bad EC", 2);
+  h2Status->setBinLabel(unBinPos++, "Bad BC", 2);
+  h2Status->setBinLabel(unBinPos++, "Bad OC", 2);
+  h2Status->setBinLabel(unBinPos++, "Bad run type", 2);
+  h2Status->setBinLabel(unBinPos++, "Bad CRC", 2);
+  h2Status->setBinLabel(unBinPos++, "MMCM locked", 2);
+  h2Status->setBinLabel(unBinPos++, "DAQ clock locked", 2);
+  h2Status->setBinLabel(unBinPos++, "DAQ not ready", 2);
+  h2Status->setBinLabel(unBinPos++, "BC0 not locked", 2);
 }
 
-void GEMDAQStatusSource::SetLabelGEBStatus(MonitorElement *h2Status) {
+void GEMDAQStatusSource::SetLabelOHStatus(MonitorElement *h2Status) {
   unsigned int unBinPos = 1;
   h2Status->setBinLabel(unBinPos++, "Good", 2);
-  h2Status->setBinLabel(unBinPos++, "BX mismatch GLIB OH", 2);
-  h2Status->setBinLabel(unBinPos++, "BX mismatch GLIB VFAT", 2);
-  h2Status->setBinLabel(unBinPos++, "OOS GLIB OH", 2);
-  h2Status->setBinLabel(unBinPos++, "OOS GLIB VFAT", 2);
-  h2Status->setBinLabel(unBinPos++, "No VFAT marker", 2);
+  h2Status->setBinLabel(unBinPos++, "Event FIFO near full", 2);
+  h2Status->setBinLabel(unBinPos++, "Input FIFO near full", 2);
+  h2Status->setBinLabel(unBinPos++, "L1A FIFO near full", 2);
   h2Status->setBinLabel(unBinPos++, "Event size warn", 2);
-  h2Status->setBinLabel(unBinPos++, "L1AFIFO near full", 2);
-  h2Status->setBinLabel(unBinPos++, "InFIFO near full", 2);
-  h2Status->setBinLabel(unBinPos++, "EvtFIFO near full", 2);
+  h2Status->setBinLabel(unBinPos++, "Invalid VFAT", 2);
+  h2Status->setBinLabel(unBinPos++, "Event FIFO full", 2);
+  h2Status->setBinLabel(unBinPos++, "Input FIFO full", 2);
+  h2Status->setBinLabel(unBinPos++, "L1A FIFO full", 2);
   h2Status->setBinLabel(unBinPos++, "Event size overflow", 2);
-  h2Status->setBinLabel(unBinPos++, "L1AFIFO full", 2);
-  h2Status->setBinLabel(unBinPos++, "InFIFO full", 2);
-  h2Status->setBinLabel(unBinPos++, "EvtFIFO full", 2);
+  h2Status->setBinLabel(unBinPos++, "Invalid event", 2);
+  h2Status->setBinLabel(unBinPos++, "Out of Sync AMC vs VFAT", 2);
+  h2Status->setBinLabel(unBinPos++, "Out of Sync VFAT vs VFAT", 2);
+  h2Status->setBinLabel(unBinPos++, "BX mismatch AMC vs VFAT", 2);
+  h2Status->setBinLabel(unBinPos++, "BX mismatch VFAT vs VFAT", 2);
   h2Status->setBinLabel(unBinPos++, "Input FIFO underflow", 2);
-  h2Status->setBinLabel(unBinPos++, "Stuck data", 2);
-  h2Status->setBinLabel(unBinPos++, "Event FIFO underflow", 2);
+  h2Status->setBinLabel(unBinPos++, "Bad VFAT count", 2);
 }
 
 void GEMDAQStatusSource::SetLabelVFATStatus(MonitorElement *h2Status) {
   unsigned int unBinPos = 1;
   h2Status->setBinLabel(unBinPos++, "Good", 2);
-  h2Status->setBinLabel(unBinPos++, "CRC fail", 2);
-  h2Status->setBinLabel(unBinPos++, "b1010 fail", 2);
-  h2Status->setBinLabel(unBinPos++, "b1100 fail", 2);
-  h2Status->setBinLabel(unBinPos++, "b1110 fail", 2);
-  h2Status->setBinLabel(unBinPos++, "Hamming error", 2);
-  h2Status->setBinLabel(unBinPos++, "AFULL", 2);
-  h2Status->setBinLabel(unBinPos++, "SEUlogic", 2);
-  h2Status->setBinLabel(unBinPos++, "SUEI2C", 2);
+  h2Status->setBinLabel(unBinPos++, "Basic overflow", 2);
+  h2Status->setBinLabel(unBinPos++, "Zero-sup overflow", 2);
+  h2Status->setBinLabel(unBinPos++, "VFAT CRC error", 2);
+  h2Status->setBinLabel(unBinPos++, "Invalid header", 2);
+  h2Status->setBinLabel(unBinPos++, "AMC EC mismatch", 2);
+  h2Status->setBinLabel(unBinPos++, "AMC BC mismatch", 2);
 }
 
 void GEMDAQStatusSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &, edm::EventSetup const &iSetup) {
@@ -161,90 +105,76 @@ void GEMDAQStatusSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run con
   ibooker.cd();
   ibooker.setCurrentFolder("GEM/DAQStatus");
 
-  h2AMCStatusPos_ = ibooker.book2D("amc_statusflagPos",
-                                   "Status of AMC slots (positive region);AMC slot;",
+  h2AMC13Status_ =
+      ibooker.book2D("amc13_status", "AMC13 Status;AMC13;", 2, 0.5, 2.5, nBitAMC13_, 0.5, nBitAMC13_ + 0.5);
+  h2AMCStatusNeg_ = ibooker.book2D("amc_status_GE11-N",
+                                   "AMC Status GE11-N;AMC slot;",
                                    nAMCSlots_,
                                    -0.5,
                                    nAMCSlots_ - 0.5,
                                    nBitAMC_,
                                    0.5,
                                    nBitAMC_ + 0.5);
-  h2AMCStatusNeg_ = ibooker.book2D("amc_statusflagNeg",
-                                   "Status of AMC slots (negative region);AMC slot;",
+  h2AMCStatusPos_ = ibooker.book2D("amc_status_GE11-P",
+                                   "AMC Status GE11-P;AMC slot;",
                                    nAMCSlots_,
                                    -0.5,
                                    nAMCSlots_ - 0.5,
                                    nBitAMC_,
                                    0.5,
                                    nBitAMC_ + 0.5);
-  h2AMCNumGEBPos_ = ibooker.book2D("amc_numGEBsPos",
-                                   "Number of GEBs in AMCs (positive region);AMC slot;Number of GEBs",
-                                   nAMCSlots_,
-                                   -0.5,
-                                   nAMCSlots_ - 0.5,
-                                   41,
-                                   -0.5,
-                                   41 - 0.5);
-  h2AMCNumGEBNeg_ = ibooker.book2D("amc_numGEBsNeg",
-                                   "Number of GEBs in AMCs (negative region);AMC slot;Number of GEBs",
-                                   nAMCSlots_,
-                                   -0.5,
-                                   nAMCSlots_ - 0.5,
-                                   41,
-                                   -0.5,
-                                   41 - 0.5);
 
-  SetLabelAMCStatus(h2AMCStatusPos_);
+  SetLabelAMC13Status(h2AMC13Status_);
   SetLabelAMCStatus(h2AMCStatusNeg_);
+  SetLabelAMCStatus(h2AMCStatusPos_);
 
-  mapStatusGEB_ =
-      MEMap3Inf(this, "geb_input_status", "GEB Input Status", 36, 0.5, 36.5, nBitGEB_, 0.5, nBitGEB_ + 0.5, "Chamber");
+  mapStatusOH_ =
+      MEMap3Inf(this, "oh_status", "OptoHybrid Status", 36, 0.5, 36.5, nBitOH_, 0.5, nBitOH_ + 0.5, "Chamber");
   mapStatusVFAT_ =
-      MEMap3Inf(this, "vfat_status", "VFAT Quality Status", 24, 0.5, 24.5, nBitVFAT_, 0.5, nBitVFAT_ + 0.5, "VFAT");
-  mapGEBNumVFAT_ = MEMap3Inf(this,
-                             "geb_numVFATs",
-                             "Number of VFATs in GEBs",
-                             36,
-                             0.5,
-                             36.5,
-                             24 + 1,
-                             -0.5,
-                             24 + 0.5);  // FIXME: The maximum number of VFATs is different for each stations
+      MEMap3Inf(this, "vfat_status", "VFAT Status", 24, -0.5, 24 - 0.5, nBitVFAT_, 0.5, nBitVFAT_ + 0.5, "VFAT");
 
-  mapStatusVFATPerLayer_ = MEMap3Inf(
-      this, "vfat_statusSum", "Summary on VFAT Quality Status", 36, 0.5, 36.5, 24, 0.5, 24.5, "Chamber", "VFAT");
+  mapStatusWarnVFATPerLayer_ = MEMap3Inf(
+      this, "vfat_statusWarnSum", "VFAT reporting warnings", 36, 0.5, 36.5, 24, -0.5, 24 - 0.5, "Chamber", "VFAT");
+  mapStatusErrVFATPerLayer_ = MEMap3Inf(
+      this, "vfat_statusErrSum", "VFAT reporting errors", 36, 0.5, 36.5, 24, -0.5, 24 - 0.5, "Chamber", "VFAT");
   mapStatusVFATPerCh_ =
-      MEMap4Inf(this, "vfat_status", "VFAT Quality Status", 24, 0.5, 24.5, nBitVFAT_, 0.5, nBitVFAT_ + 0.5, "VFAT");
+      MEMap4Inf(this, "vfat_status", "VFAT Status", 24, -0.5, 24 - 0.5, nBitVFAT_, 0.5, nBitVFAT_ + 0.5, "VFAT");
 
   GenerateMEPerChamber(ibooker);
 
-  h2SummaryStatus = CreateSummaryHist(ibooker, "summaryStatus");
+  h2SummaryStatusWarning = CreateSummaryHist(ibooker, "chamberWarnings");
+  h2SummaryStatusError = CreateSummaryHist(ibooker, "chamberErrors");
+
+  h2SummaryStatusWarning->setTitle("Summary of OH or VFAT warnings of each chambers");
+  h2SummaryStatusError->setTitle("Summary of OH or VFAT errors of each chambers");
 }
 
 int GEMDAQStatusSource::ProcessWithMEMap3(BookingHelper &bh, ME3IdsKey key) {
   MEStationInfo &stationInfo = mapStationInfo_[key];
 
-  mapStatusGEB_.SetBinConfX(stationInfo.nNumChambers_);
-  mapStatusGEB_.bookND(bh, key);
-  mapStatusGEB_.SetLabelForChambers(key, 1);
+  mapStatusOH_.SetBinConfX(stationInfo.nNumChambers_);
+  mapStatusOH_.bookND(bh, key);
+  mapStatusOH_.SetLabelForChambers(key, 1);
 
-  SetLabelGEBStatus(mapStatusGEB_.FindHist(key));
+  SetLabelOHStatus(mapStatusOH_.FindHist(key));
 
-  mapStatusVFATPerLayer_.SetBinConfX(stationInfo.nNumChambers_);
-  mapStatusVFATPerLayer_.SetBinConfY(stationInfo.nMaxVFAT_);
-  mapStatusVFATPerLayer_.bookND(bh, key);
-  mapStatusVFATPerLayer_.SetLabelForChambers(key, 1);
-  mapStatusVFATPerLayer_.SetLabelForVFATs(key, stationInfo.nNumEtaPartitions_, 2);
+  mapStatusWarnVFATPerLayer_.SetBinConfX(stationInfo.nNumChambers_);
+  mapStatusWarnVFATPerLayer_.SetBinConfY(stationInfo.nMaxVFAT_, -0.5);
+  mapStatusWarnVFATPerLayer_.bookND(bh, key);
+  mapStatusWarnVFATPerLayer_.SetLabelForChambers(key, 1);
+  mapStatusWarnVFATPerLayer_.SetLabelForVFATs(key, stationInfo.nNumEtaPartitions_, 2);
 
-  mapStatusVFAT_.SetBinConfX(stationInfo.nMaxVFAT_);
+  mapStatusErrVFATPerLayer_.SetBinConfX(stationInfo.nNumChambers_);
+  mapStatusErrVFATPerLayer_.SetBinConfY(stationInfo.nMaxVFAT_, -0.5);
+  mapStatusErrVFATPerLayer_.bookND(bh, key);
+  mapStatusErrVFATPerLayer_.SetLabelForChambers(key, 1);
+  mapStatusErrVFATPerLayer_.SetLabelForVFATs(key, stationInfo.nNumEtaPartitions_, 2);
+
+  mapStatusVFAT_.SetBinConfX(stationInfo.nMaxVFAT_, -0.5);
   mapStatusVFAT_.bookND(bh, key);
   mapStatusVFAT_.SetLabelForVFATs(key, stationInfo.nNumEtaPartitions_, 1);
 
   SetLabelVFATStatus(mapStatusVFAT_.FindHist(key));
-
-  mapGEBNumVFAT_.SetBinConfX(stationInfo.nNumChambers_);
-  mapGEBNumVFAT_.bookND(bh, key);
-  mapGEBNumVFAT_.SetLabelForChambers(key, 1);
 
   return 0;
 }
@@ -253,7 +183,7 @@ int GEMDAQStatusSource::ProcessWithMEMap3WithChamber(BookingHelper &bh, ME4IdsKe
   ME3IdsKey key3 = key4Tokey3(key);
   MEStationInfo &stationInfo = mapStationInfo_[key3];
 
-  mapStatusVFATPerCh_.SetBinConfX(stationInfo.nMaxVFAT_);
+  mapStatusVFATPerCh_.SetBinConfX(stationInfo.nMaxVFAT_, -0.5);
   mapStatusVFATPerCh_.bookND(bh, key);
   mapStatusVFATPerCh_.SetLabelForVFATs(key, stationInfo.nNumEtaPartitions_, 1);
   SetLabelVFATStatus(mapStatusVFATPerCh_.FindHist(key));
@@ -262,159 +192,239 @@ int GEMDAQStatusSource::ProcessWithMEMap3WithChamber(BookingHelper &bh, ME4IdsKe
 }
 
 void GEMDAQStatusSource::analyze(edm::Event const &event, edm::EventSetup const &eventSetup) {
-  edm::Handle<GEMDigiCollection> gemDigis;
-  edm::Handle<GEMVfatStatusDigiCollection> gemVFAT;
-  edm::Handle<GEMGEBdataCollection> gemGEB;
-  edm::Handle<GEMAMCdataCollection> gemAMC;
-  edm::Handle<GEMAMC13EventCollection> gemAMC13;
+  edm::Handle<GEMVFATStatusCollection> gemVFAT;
+  edm::Handle<GEMOHStatusCollection> gemOH;
+  edm::Handle<GEMAMCStatusCollection> gemAMC;
+  edm::Handle<GEMAMC13StatusCollection> gemAMC13;
 
-  event.getByToken(tagDigi_, gemDigis);
   event.getByToken(tagVFAT_, gemVFAT);
-  event.getByToken(tagGEB_, gemGEB);
+  event.getByToken(tagOH_, gemOH);
   event.getByToken(tagAMC_, gemAMC);
   event.getByToken(tagAMC13_, gemAMC13);
 
-  std::vector<int> listAMCRegion;
+  for (auto amc13It = gemAMC13->begin(); amc13It != gemAMC13->end(); ++amc13It) {
+    int fedId = (*amc13It).first;
+    if (mapFEDIdToRe_.find(fedId) == mapFEDIdToRe_.end())
+      continue;
+    int nXBin = 0;
+    if (mapFEDIdToRe_[fedId] < 0) {
+      nXBin = 1;
+    } else if (mapFEDIdToRe_[fedId] > 0) {
+      nXBin = 2;
+    } else {
+      edm::LogError(log_category_) << "+++ Error : Unknown FED Id +++\n" << std::endl;
+      continue;
+    }
 
-  for (GEMAMC13EventCollection::DigiRangeIterator amc13It = gemAMC13->begin(); amc13It != gemAMC13->end(); ++amc13It) {
-    const GEMAMC13EventCollection::Range &range = (*amc13It).second;
+    const auto &range = (*amc13It).second;
     for (auto amc13 = range.first; amc13 != range.second; ++amc13) {
-      for (int r = 0; r < int(amc13->nAMC()); r++) {
-        listAMCRegion.push_back(mapFEDIdToRe_[(UInt_t)amc13->sourceId()]);
-      }
+      Bool_t bWarn = false;
+      Bool_t bErr = false;
+
+      GEMAMC13Status::Warnings warnings{amc13->warnings()};
+      if (warnings.InValidAMC)
+        FillWithRiseErr(h2AMC13Status_, nXBin, 2, bWarn);
+
+      GEMAMC13Status::Errors errors{amc13->errors()};
+      if (errors.InValidSize)
+        FillWithRiseErr(h2AMC13Status_, nXBin, 3, bErr);
+      if (errors.failTrailerCheck)
+        FillWithRiseErr(h2AMC13Status_, nXBin, 4, bErr);
+      if (errors.failFragmentLength)
+        FillWithRiseErr(h2AMC13Status_, nXBin, 5, bErr);
+      if (errors.failTrailerMatch)
+        FillWithRiseErr(h2AMC13Status_, nXBin, 6, bErr);
+      if (errors.moreTrailers)
+        FillWithRiseErr(h2AMC13Status_, nXBin, 7, bErr);
+      if (errors.crcModified)
+        FillWithRiseErr(h2AMC13Status_, nXBin, 8, bErr);
+      if (errors.slinkError)
+        FillWithRiseErr(h2AMC13Status_, nXBin, 9, bErr);
+      if (errors.wrongFedId)
+        FillWithRiseErr(h2AMC13Status_, nXBin, 10, bErr);
+
+      if (!bWarn && !bErr)
+        h2AMC13Status_->Fill(nXBin, 1);
     }
   }
 
-  int nIdxAMCFull = 0;
-  MonitorElement *h2AMCStatus, *h2AMCNumGEB;
+  MonitorElement *h2AMCStatus = nullptr;
 
-  for (GEMAMCdataCollection::DigiRangeIterator amcIt = gemAMC->begin(); amcIt != gemAMC->end(); ++amcIt) {
-    const GEMAMCdataCollection::Range &range = (*amcIt).second;
+  for (auto amcIt = gemAMC->begin(); amcIt != gemAMC->end(); ++amcIt) {
+    int fedId = (*amcIt).first;
+    if (mapFEDIdToRe_.find(fedId) == mapFEDIdToRe_.end())
+      continue;
+    if (mapFEDIdToRe_[fedId] < 0) {
+      h2AMCStatus = h2AMCStatusNeg_;
+    } else if (mapFEDIdToRe_[fedId] > 0) {
+      h2AMCStatus = h2AMCStatusPos_;
+    } else {
+      edm::LogError(log_category_) << "+++ Error : Unknown FED Id +++\n" << std::endl;
+      continue;
+    }
+
+    const GEMAMCStatusCollection::Range &range = (*amcIt).second;
     for (auto amc = range.first; amc != range.second; ++amc) {
-      uint64_t unBit = 1;
-      bool bErr = false;
+      Bool_t bWarn = false;
+      Bool_t bErr = false;
 
-      if (nIdxAMCFull >= (int)listAMCRegion.size()) {
-        edm::LogError(log_category_) << "+++ Error : Mismatch of the number of AMCs in AMC13 and the actual AMCs +++\n";
-        break;
-      }
+      Int_t nAMCNum = amc->amcNumber();
 
-      if (listAMCRegion[nIdxAMCFull] > 0) {
-        h2AMCStatus = h2AMCStatusPos_;
-        h2AMCNumGEB = h2AMCNumGEBPos_;
-      } else {
-        h2AMCStatus = h2AMCStatusNeg_;
-        h2AMCNumGEB = h2AMCNumGEBNeg_;
-      }
+      GEMAMCStatus::Warnings warnings{amc->warnings()};
+      if (warnings.InValidOH)
+        FillWithRiseErr(h2AMCStatus, nAMCNum, 2, bWarn);
+      if (warnings.backPressure)
+        FillWithRiseErr(h2AMCStatus, nAMCNum, 3, bWarn);
 
-      unBit++;
-      if (!amc->bc0locked()) {
-        h2AMCStatus->Fill(amc->amcNum(), unBit);
-        bErr = true;
-      }
-      unBit++;
-      if (!amc->daqReady()) {
-        h2AMCStatus->Fill(amc->amcNum(), unBit);
-        bErr = true;
-      }
-      unBit++;
-      if (!amc->daqClockLocked()) {
-        h2AMCStatus->Fill(amc->amcNum(), unBit);
-        bErr = true;
-      }
-      unBit++;
-      if (!amc->mmcmLocked()) {
-        h2AMCStatus->Fill(amc->amcNum(), unBit);
-        bErr = true;
-      }
-      unBit++;
-      if (amc->backPressure()) {
-        h2AMCStatus->Fill(amc->amcNum(), unBit);
-        bErr = true;
-      }
-      unBit++;
-      if (amc->oosGlib()) {
-        h2AMCStatus->Fill(amc->amcNum(), unBit);
-        bErr = true;
-      }
-      if (!bErr)
-        h2AMCStatus->Fill(amc->amcNum(), 1);
+      GEMAMCStatus::Errors errors{amc->errors()};
+      if (errors.badEC)
+        FillWithRiseErr(h2AMCStatus, nAMCNum, 4, bErr);
+      if (errors.badBC)
+        FillWithRiseErr(h2AMCStatus, nAMCNum, 5, bErr);
+      if (errors.badOC)
+        FillWithRiseErr(h2AMCStatus, nAMCNum, 6, bErr);
+      if (errors.badRunType)
+        FillWithRiseErr(h2AMCStatus, nAMCNum, 7, bErr);
+      if (errors.badCRC)
+        FillWithRiseErr(h2AMCStatus, nAMCNum, 8, bErr);
+      if (errors.MMCMlocked)
+        FillWithRiseErr(h2AMCStatus, nAMCNum, 9, bErr);
+      if (errors.DAQclocklocked)
+        FillWithRiseErr(h2AMCStatus, nAMCNum, 10, bErr);
+      if (errors.DAQnotReday)
+        FillWithRiseErr(h2AMCStatus, nAMCNum, 11, bErr);
+      if (errors.BC0locked)
+        FillWithRiseErr(h2AMCStatus, nAMCNum, 12, bErr);
 
-      h2AMCNumGEB->Fill(amc->amcNum(), amc->gebs()->size());
-
-      nIdxAMCFull++;
+      if (!bWarn && !bErr)
+        h2AMCStatus->Fill(nAMCNum, 1);
     }
   }
 
   // WARNING: ME4IdsKey for region, station, layer, chamber (not iEta)
-  std::map<ME4IdsKey, bool> mapChamberStatus;
+  std::map<ME4IdsKey, bool> mapChamberWarning;
+  std::map<ME4IdsKey, bool> mapChamberError;
 
-  for (GEMGEBdataCollection::DigiRangeIterator gebIt = gemGEB->begin(); gebIt != gemGEB->end(); ++gebIt) {
-    GEMDetId gid = (*gebIt).first;
+  for (auto ohIt = gemOH->begin(); ohIt != gemOH->end(); ++ohIt) {
+    GEMDetId gid = (*ohIt).first;
     ME3IdsKey key3{gid.region(), gid.station(), gid.layer()};
     ME4IdsKey key4{gid.region(), gid.station(), gid.layer(), gid.chamber()};  // WARNING: Chamber, not iEta
 
-    const GEMGEBdataCollection::Range &range = (*gebIt).second;
-    for (auto GEBStatus = range.first; GEBStatus != range.second; ++GEBStatus) {
-      uint64_t unBit = 1;
-      uint64_t unStatus = 0;
+    const GEMOHStatusCollection::Range &range = (*ohIt).second;
+    for (auto OHStatus = range.first; OHStatus != range.second; ++OHStatus) {
+      GEMOHStatus::Warnings warnings{OHStatus->warnings()};
+      if (warnings.EvtNF)
+        mapStatusOH_.Fill(key3, gid.chamber(), 2);
+      if (warnings.InNF)
+        mapStatusOH_.Fill(key3, gid.chamber(), 3);
+      if (warnings.L1aNF)
+        mapStatusOH_.Fill(key3, gid.chamber(), 4);
+      if (warnings.EvtSzW)
+        mapStatusOH_.Fill(key3, gid.chamber(), 5);
+      if (warnings.InValidVFAT)
+        mapStatusOH_.Fill(key3, gid.chamber(), 6);
 
-      unStatus |= (GEBStatus->bxmVvV() << unBit++);
-      unStatus |= (GEBStatus->bxmAvV() << unBit++);
-      unStatus |= (GEBStatus->oOScVvV() << unBit++);
-      unStatus |= (GEBStatus->oOScAvV() << unBit++);
-      unStatus |= (GEBStatus->noVFAT() << unBit++);
-      unStatus |= (GEBStatus->evtSzW() << unBit++);
-      unStatus |= (GEBStatus->l1aNF() << unBit++);
-      unStatus |= (GEBStatus->inNF() << unBit++);
-      unStatus |= (GEBStatus->evtNF() << unBit++);
-      unStatus |= (GEBStatus->evtSzOFW() << unBit++);
-      unStatus |= (GEBStatus->l1aF() << unBit++);
-      unStatus |= (GEBStatus->inF() << unBit++);
-      unStatus |= (GEBStatus->evtF() << unBit++);
-      unStatus |= (GEBStatus->inUfw() << unBit++);
-      unStatus |= (GEBStatus->stuckData() << unBit++);
-      unStatus |= (GEBStatus->evUfw() << unBit++);
+      GEMOHStatus::Errors errors{OHStatus->errors()};
+      if (errors.EvtF)
+        mapStatusOH_.Fill(key3, gid.chamber(), 7);
+      if (errors.InF)
+        mapStatusOH_.Fill(key3, gid.chamber(), 8);
+      if (errors.L1aF)
+        mapStatusOH_.Fill(key3, gid.chamber(), 9);
+      if (errors.EvtSzOFW)
+        mapStatusOH_.Fill(key3, gid.chamber(), 10);
+      if (errors.Inv)
+        mapStatusOH_.Fill(key3, gid.chamber(), 11);
+      if (errors.OOScAvV)
+        mapStatusOH_.Fill(key3, gid.chamber(), 12);
+      if (errors.OOScVvV)
+        mapStatusOH_.Fill(key3, gid.chamber(), 13);
+      if (errors.BxmAvV)
+        mapStatusOH_.Fill(key3, gid.chamber(), 14);
+      if (errors.BxmVvV)
+        mapStatusOH_.Fill(key3, gid.chamber(), 15);
+      if (errors.InUfw)
+        mapStatusOH_.Fill(key3, gid.chamber(), 16);
+      if (errors.badVFatCount)
+        mapStatusOH_.Fill(key3, gid.chamber(), 17);
 
-      if (unStatus == 0) {
-        unStatus = 0x01;  // Good
-      } else {            // Error!
-        mapChamberStatus[key4] = false;
-      }
-
-      mapStatusGEB_.FillBits(key3, gid.chamber(), unStatus);
-
-      mapGEBNumVFAT_.Fill(key3, gid.chamber(), GEBStatus->vFATs()->size());
+      Bool_t bWarn = warnings.wcodes != 0;
+      Bool_t bErr = errors.codes != 0;
+      if (!bWarn && !bErr)
+        mapStatusOH_.Fill(key3, gid.chamber(), 1);
+      if (bWarn)
+        mapChamberWarning[key4] = false;
+      if (bErr)
+        mapChamberError[key4] = false;
     }
   }
 
-  for (GEMVfatStatusDigiCollection::DigiRangeIterator vfatIt = gemVFAT->begin(); vfatIt != gemVFAT->end(); ++vfatIt) {
+  for (auto vfatIt = gemVFAT->begin(); vfatIt != gemVFAT->end(); ++vfatIt) {
     GEMDetId gid = (*vfatIt).first;
     ME3IdsKey key3{gid.region(), gid.station(), gid.layer()};
     ME4IdsKey key4Ch{gid.region(), gid.station(), gid.layer(), gid.chamber()};  // WARNING: Chamber, not iEta
-    const GEMVfatStatusDigiCollection::Range &range = (*vfatIt).second;
+    const GEMVFATStatusCollection::Range &range = (*vfatIt).second;
 
     for (auto vfatStat = range.first; vfatStat != range.second; ++vfatStat) {
-      // NOTE: nIdxVFAT starts from 1
-      Int_t nIdxVFAT = getVFATNumber(gid.station(), gid.ieta(), vfatStat->phi()) + 1;
-      uint64_t unQFVFAT = vfatStat->quality();
-      if ((unQFVFAT & ~0x1) == 0) {
-        unQFVFAT |= 0x1;  // If no error, then it should be 'Good'
-      } else {            // Error!
-        mapChamberStatus[key4Ch] = false;
-        mapStatusVFATPerLayer_.Fill(key3, gid.chamber(), nIdxVFAT);
-      }
+      Int_t nIdxVFAT = getVFATNumber(gid.station(), gid.ieta(), vfatStat->vfatPosition());
 
-      mapStatusVFAT_.FillBits(key3, nIdxVFAT, unQFVFAT);
-      mapStatusVFATPerCh_.FillBits(key4Ch, nIdxVFAT, unQFVFAT);
+      GEMVFATStatus::Warnings warnings{vfatStat->warnings()};
+      if (warnings.basicOFW)
+        mapStatusVFAT_.Fill(key3, nIdxVFAT, 2);
+      if (warnings.zeroSupOFW)
+        mapStatusVFAT_.Fill(key3, nIdxVFAT, 3);
+      if (warnings.basicOFW)
+        mapStatusVFATPerCh_.Fill(key4Ch, nIdxVFAT, 2);
+      if (warnings.zeroSupOFW)
+        mapStatusVFATPerCh_.Fill(key4Ch, nIdxVFAT, 3);
+
+      GEMVFATStatus::Errors errors{(uint8_t)vfatStat->errors()};
+      if (errors.vc)
+        mapStatusVFAT_.Fill(key3, nIdxVFAT, 4);
+      if (errors.InValidHeader)
+        mapStatusVFAT_.Fill(key3, nIdxVFAT, 5);
+      if (errors.EC)
+        mapStatusVFAT_.Fill(key3, nIdxVFAT, 6);
+      if (errors.BC)
+        mapStatusVFAT_.Fill(key3, nIdxVFAT, 7);
+      if (errors.vc)
+        mapStatusVFATPerCh_.Fill(key4Ch, nIdxVFAT, 4);
+      if (errors.InValidHeader)
+        mapStatusVFATPerCh_.Fill(key4Ch, nIdxVFAT, 5);
+      if (errors.EC)
+        mapStatusVFATPerCh_.Fill(key4Ch, nIdxVFAT, 6);
+      if (errors.BC)
+        mapStatusVFATPerCh_.Fill(key4Ch, nIdxVFAT, 7);
+
+      Bool_t bWarn = warnings.wcodes != 0;
+      Bool_t bErr = errors.codes != 0;
+      if (!bWarn && !bErr)
+        mapStatusVFAT_.Fill(key3, nIdxVFAT, 1);
+      if (!bWarn && !bErr)
+        mapStatusVFATPerCh_.Fill(key4Ch, nIdxVFAT, 1);
+      if (bWarn)
+        mapChamberWarning[key4Ch] = false;
+      if (bErr)
+        mapChamberError[key4Ch] = false;
+      if (bWarn)
+        mapStatusWarnVFATPerLayer_.Fill(key3, gid.chamber(), nIdxVFAT);
+      if (bErr)
+        mapStatusErrVFATPerLayer_.Fill(key3, gid.chamber(), nIdxVFAT);
     }
   }
 
-  // Summarizing the error occupancy
-  for (auto const &[key4, bErr] : mapChamberStatus) {
+  // Summarizing the warning occupancy
+  for (auto const &[key4, bWarning] : mapChamberWarning) {
     ME3IdsKey key3 = key4Tokey3(key4);
     Int_t nChamber = keyToChamber(key4);
-    h2SummaryStatus->Fill(nChamber, mapStationToIdx_[key3]);
+    h2SummaryStatusWarning->Fill(nChamber, mapStationToIdx_[key3]);
+  }
+
+  // Summarizing the error occupancy
+  for (auto const &[key4, bErr] : mapChamberError) {
+    ME3IdsKey key3 = key4Tokey3(key4);
+    Int_t nChamber = keyToChamber(key4);
+    h2SummaryStatusError->Fill(nChamber, mapStationToIdx_[key3]);
   }
 }
 

--- a/DQM/GEM/plugins/GEMDQMHarvester.cc
+++ b/DQM/GEM/plugins/GEMDQMHarvester.cc
@@ -35,6 +35,7 @@ protected:
   void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override{};  // Cannot use; it is called after dqmSaver
 
   void drawSummaryHistogram(edm::Service<DQMStore> &store);
+  void copyLabels(MonitorElement *h2Src, MonitorElement *h2Dst);
   void createSummaryHist(edm::Service<DQMStore> &store,
                          MonitorElement *h2Src,
                          MonitorElement *&h2Sum,
@@ -43,23 +44,27 @@ protected:
                          MonitorElement *h2Src,
                          std::string strSuffix,
                          MonitorElement *&h2Sum);
-  void refineSummaryHistogram(MonitorElement *h2Sum,
-                              MonitorElement *h2SrcOcc,
-                              MonitorElement *h2SrcCStatus,
-                              MonitorElement *h2SrcMal = nullptr,
-                              Bool_t bVarXBin = false);
+  Float_t refineSummaryHistogram(MonitorElement *h2Sum,
+                                 MonitorElement *h2SrcOcc,
+                                 MonitorElement *h2SrcStatusE,
+                                 MonitorElement *h2SrcStatusW = nullptr,
+                                 Bool_t bVarXBin = false);
 
   Float_t fReportSummary_;
   std::string strOutFile_;
 
   std::string strDirSummary_;
+  std::string strDirRecHit_;
   std::string strDirStatus_;
+
+  std::vector<std::string> listLayer_;
 };
 
 GEMDQMHarvester::GEMDQMHarvester(const edm::ParameterSet &cfg) {
   fReportSummary_ = -1.0;
   strOutFile_ = cfg.getParameter<std::string>("fromFile");
   strDirSummary_ = "GEM/EventInfo";
+  strDirRecHit_ = "GEM/RecHits";
   strDirStatus_ = "GEM/DAQStatus";
 }
 
@@ -78,50 +83,69 @@ void GEMDQMHarvester::dqmEndLuminosityBlock(DQMStore::IBooker &,
 }
 
 void GEMDQMHarvester::drawSummaryHistogram(edm::Service<DQMStore> &store) {
-  std::string strSrcDigiOcc = "GEM/digi/summaryOccDigi";
-  std::string strSrcDigiMal = "GEM/digi/summaryMalfuncDigi";
-  std::string strSrcCStatus = "GEM/DAQStatus/summaryStatus";
+  std::string strSrcDigiOcc = "GEM/Digis/summaryOccDigi";
+  std::string strSrcStatusW = "GEM/DAQStatus/chamberWarnings";
+  std::string strSrcStatusE = "GEM/DAQStatus/chamberErrors";
 
-  std::string strSrcVFATOcc = "GEM/digi/digi_det";
-  std::string strSrcVFATStatus = "GEM/DAQStatus/vfat_statusSum";
+  std::string strSrcVFATOcc = "GEM/Digis/det";
+  std::string strSrcVFATStatusW = "GEM/DAQStatus/vfat_statusWarnSum";
+  std::string strSrcVFATStatusE = "GEM/DAQStatus/vfat_statusErrSum";
 
   store->setCurrentFolder(strDirSummary_);
 
   MonitorElement *h2SrcDigiOcc = store->get(strSrcDigiOcc);
-  MonitorElement *h2SrcDigiMal = store->get(strSrcDigiMal);
-  MonitorElement *h2SrcCStatus = store->get(strSrcCStatus);
+  MonitorElement *h2SrcStatusW = store->get(strSrcStatusW);
+  MonitorElement *h2SrcStatusE = store->get(strSrcStatusE);
 
-  if (h2SrcDigiOcc != nullptr && h2SrcDigiMal != nullptr && h2SrcCStatus != nullptr) {
+  if (h2SrcDigiOcc != nullptr && h2SrcStatusW != nullptr && h2SrcStatusE != nullptr) {
     MonitorElement *h2Sum = nullptr;
-    std::vector<std::string> listLayer;
-    createSummaryHist(store, h2SrcCStatus, h2Sum, listLayer);
-    refineSummaryHistogram(h2Sum, h2SrcDigiOcc, h2SrcCStatus, h2SrcDigiMal, true);
+    createSummaryHist(store, h2SrcStatusE, h2Sum, listLayer_);
+    fReportSummary_ = refineSummaryHistogram(h2Sum, h2SrcDigiOcc, h2SrcStatusE, h2SrcStatusW, true);
 
-    for (const auto &strSuffix : listLayer) {
+    for (const auto &strSuffix : listLayer_) {
       MonitorElement *h2SrcVFATOcc = store->get(strSrcVFATOcc + strSuffix);
-      MonitorElement *h2SrcVFATStatus = store->get(strSrcVFATStatus + strSuffix);
-      if (h2SrcVFATOcc == nullptr || h2SrcVFATStatus == nullptr)
+      MonitorElement *h2SrcVFATStatusW = store->get(strSrcVFATStatusW + strSuffix);
+      MonitorElement *h2SrcVFATStatusE = store->get(strSrcVFATStatusE + strSuffix);
+      if (h2SrcVFATOcc == nullptr || h2SrcVFATStatusW == nullptr || h2SrcVFATStatusE == nullptr)
         continue;
       MonitorElement *h2SumVFAT = nullptr;
-      createSummaryVFAT(store, h2SrcVFATStatus, strSuffix, h2SumVFAT);
-      refineSummaryHistogram(h2SumVFAT, h2SrcVFATOcc, h2SrcVFATStatus);
-      h2SumVFAT->setTitle(h2SrcVFATStatus->getTitle());
-      h2SumVFAT->setXTitle(h2SrcVFATStatus->getAxisTitle(1));
-      h2SumVFAT->setYTitle(h2SrcVFATStatus->getAxisTitle(2));
+      createSummaryVFAT(store, h2SrcVFATStatusE, strSuffix, h2SumVFAT);
+      refineSummaryHistogram(h2SumVFAT, h2SrcVFATOcc, h2SrcVFATStatusE, h2SrcVFATStatusW);
+      TString strNewTitle = h2SrcVFATStatusE->getTitle();
+      h2SumVFAT->setTitle((const char *)strNewTitle.ReplaceAll("errors", "errors/warnings"));
+      h2SumVFAT->setXTitle(h2SrcVFATStatusE->getAxisTitle(1));
+      h2SumVFAT->setYTitle(h2SrcVFATStatusE->getAxisTitle(2));
     }
   }
 
   store->bookFloat("reportSummary")->Fill(fReportSummary_);
 }
 
+void GEMDQMHarvester::copyLabels(MonitorElement *h2Src, MonitorElement *h2Dst) {
+  Int_t nBinX = h2Src->getNbinsX(), nBinY = h2Src->getNbinsY();
+
+  for (Int_t i = 1; i <= nBinX; i++) {
+    h2Dst->setBinLabel(i, h2Src->getTH2F()->GetXaxis()->GetBinLabel(i), 1);
+  }
+  for (Int_t i = 1; i <= nBinY; i++) {
+    h2Dst->setBinLabel(i, h2Src->getTH2F()->GetYaxis()->GetBinLabel(i), 2);
+  }
+  h2Dst->setTitle(h2Src->getTitle());
+  h2Dst->setXTitle(h2Src->getAxisTitle(1));
+  h2Dst->setYTitle(h2Src->getAxisTitle(2));
+}
+
 void GEMDQMHarvester::createSummaryHist(edm::Service<DQMStore> &store,
                                         MonitorElement *h2Src,
                                         MonitorElement *&h2Sum,
                                         std::vector<std::string> &listLayers) {
-  store->setCurrentFolder(strDirSummary_);
+  //store->setCurrentFolder(strDirSummary_);
 
   Int_t nBinX = h2Src->getNbinsX(), nBinY = h2Src->getNbinsY();
   h2Sum = store->book2D("reportSummaryMap", "", nBinX, 0.5, nBinX + 0.5, nBinY, 0.5, nBinY + 0.5);
+  h2Sum->setTitle("Summary plot");
+  h2Sum->setXTitle("Chamber");
+  h2Sum->setYTitle("Layer");
 
   listLayers.clear();
   for (Int_t i = 1; i <= nBinX; i++)
@@ -139,24 +163,22 @@ void GEMDQMHarvester::createSummaryVFAT(edm::Service<DQMStore> &store,
                                         MonitorElement *h2Src,
                                         std::string strSuffix,
                                         MonitorElement *&h2Sum) {
-  store->setCurrentFolder(strDirStatus_);
+  //store->setCurrentFolder(strDirStatus_);
+  //store->setCurrentFolder(strDirSummary_);
 
   Int_t nBinX = h2Src->getNbinsX(), nBinY = h2Src->getNbinsY();
-  h2Sum = store->book2D("vfat_statusSummary" + strSuffix, "", nBinX, 0.5, nBinX + 0.5, nBinY, 0.5, nBinY + 0.5);
-
-  for (Int_t i = 1; i <= nBinX; i++)
-    h2Sum->setBinLabel(i, h2Src->getTH2F()->GetXaxis()->GetBinLabel(i), 1);
-  for (Int_t i = 1; i <= nBinY; i++)
-    h2Sum->setBinLabel(i, h2Src->getTH2F()->GetYaxis()->GetBinLabel(i), 2);
+  h2Sum = store->book2D("vfat_statusSummary" + strSuffix, "", nBinX, 0.5, nBinX + 0.5, nBinY, -0.5, nBinY - 0.5);
+  copyLabels(h2Src, h2Sum);
 }
 
 // FIXME: Need more study about how to summarize
-void GEMDQMHarvester::refineSummaryHistogram(MonitorElement *h2Sum,
-                                             MonitorElement *h2SrcOcc,
-                                             MonitorElement *h2SrcCStatus,
-                                             MonitorElement *h2SrcMal,
-                                             Bool_t bVarXBin) {
+Float_t GEMDQMHarvester::refineSummaryHistogram(MonitorElement *h2Sum,
+                                                MonitorElement *h2SrcOcc,
+                                                MonitorElement *h2SrcStatusE,
+                                                MonitorElement *h2SrcStatusW,
+                                                Bool_t bVarXBin) {
   Int_t nBinY = h2Sum->getNbinsY();
+  Int_t nAllBin = 0, nFineBin = 0;
   for (Int_t j = 1; j <= nBinY; j++) {
     Int_t nBinX = h2Sum->getNbinsX();
     if (bVarXBin) {
@@ -165,18 +187,25 @@ void GEMDQMHarvester::refineSummaryHistogram(MonitorElement *h2Sum,
     }
     for (Int_t i = 1; i <= nBinX; i++) {
       Float_t fOcc = h2SrcOcc->getBinContent(i, j);
-      Float_t fStatus = h2SrcCStatus->getBinContent(i, j);
-      Float_t fMal = (h2SrcMal != nullptr ? h2SrcMal->getBinContent(i, j) : 0.0);
+      Float_t fStatusWarn = (h2SrcStatusW != nullptr ? h2SrcStatusW->getBinContent(i, j) : 0.0);
+      Float_t fStatusErr = h2SrcStatusE->getBinContent(i, j);
 
       Float_t fRes = 0;
-      if (fStatus > 0 || fMal > 0)
+      if (fStatusErr > 0)
         fRes = 2;
-      else if (fOcc > 0)
+      else if (fStatusWarn > 0)
+        fRes = 3;
+      else if (fOcc > 0) {
         fRes = 1;
+        nFineBin++;
+      }
 
       h2Sum->setBinContent(i, j, fRes);
+      nAllBin++;
     }
   }
+
+  return ((Float_t)nFineBin) / nAllBin;
 }
 
 DEFINE_FWK_MODULE(GEMDQMHarvester);

--- a/DQM/GEM/plugins/GEMDigiSource.cc
+++ b/DQM/GEM/plugins/GEMDigiSource.cc
@@ -1,61 +1,4 @@
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/PluginManager/interface/ModuleDef.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Utilities/interface/InputTag.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
-#include "DQMServices/Core/interface/DQMStore.h"
-#include "DQMServices/Core/interface/MonitorElement.h"
-
-#include "Validation/MuonGEMHits/interface/GEMValidationUtils.h"
-
-#include "DataFormats/GEMDigi/interface/GEMDigiCollection.h"
-
-#include "DataFormats/Scalers/interface/LumiScalers.h"
-
-#include "DQM/GEM/interface/GEMDQMBase.h"
-
-#include <string>
-
-//----------------------------------------------------------------------------------------------------
-
-class GEMDigiSource : public GEMDQMBase {
-public:
-  explicit GEMDigiSource(const edm::ParameterSet& cfg);
-  ~GEMDigiSource() override{};
-  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-
-protected:
-  void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override{};
-  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
-  void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
-
-private:
-  int ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) override;
-  int ProcessWithMEMap3WithChamber(BookingHelper& bh, ME4IdsKey key) override;
-
-  edm::EDGetToken tagDigi_;
-
-  edm::EDGetTokenT<LumiScalersCollection> lumiScalers_;
-
-  MEMap3Inf mapTotalDigi_layer_;
-  MEMap3Inf mapStripOcc_ieta_;
-  MEMap3Inf mapStripOcc_phi_;
-  MEMap3Inf mapTotalStripPerEvt_;
-  MEMap3Inf mapBX_layer_;
-
-  MEMap4Inf mapStripOccPerCh_;
-  MEMap4Inf mapBXPerCh_;
-
-  MonitorElement *h2SummaryOcc, *h2SummaryMal;
-
-  Int_t nBXMin_, nBXMax_;
-};
+#include "DQM/GEM/interface/GEMDigiSource.h"
 
 using namespace std;
 using namespace edm;
@@ -64,12 +7,14 @@ GEMDigiSource::GEMDigiSource(const edm::ParameterSet& cfg) : GEMDQMBase(cfg) {
   tagDigi_ = consumes<GEMDigiCollection>(cfg.getParameter<edm::InputTag>("digisInputLabel"));
   lumiScalers_ = consumes<LumiScalersCollection>(
       cfg.getUntrackedParameter<edm::InputTag>("lumiCollection", edm::InputTag("scalersRawToDigi")));
+  bModeRelVal_ = cfg.getParameter<bool>("modeRelVal");
 }
 
 void GEMDigiSource::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("digisInputLabel", edm::InputTag("muonGEMDigis", ""));
   desc.addUntracked<std::string>("logCategory", "GEMDigiSource");
+  desc.add<bool>("modeRelVal", false);
   descriptions.add("GEMDigiSource", desc);
 }
 
@@ -82,65 +27,70 @@ void GEMDigiSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, 
   nBXMin_ = -10;
   nBXMax_ = 10;
 
-  mapTotalDigi_layer_ = MEMap3Inf(this, "digi_det", "Digi Occupancy", 36, 0.5, 36.5, 24, 0.5, 24.5, "Chamber", "VFAT");
-  mapStripOcc_ieta_ = MEMap3Inf(
-      this, "strip_ieta_occ", "Strip Digi Occupancy per eta partition", 8, 0.5, 8.5, "iEta", "Number of fired strips");
-  mapStripOcc_phi_ = MEMap3Inf(this,
-                               "strip_phi_occ",
-                               "Strip Digi Phi (degree) Occupancy ",
-                               108,
-                               -5,
-                               355,
-                               "#phi (degree)",
-                               "Number of fired strips");
-  mapTotalStripPerEvt_ = MEMap3Inf(this,
-                                   "total_strips_per_event",
-                                   "Total number of strip digis per event for each layers ",
-                                   50,
-                                   -0.5,
-                                   99.5,
-                                   "Number of fired strips",
-                                   "Events");
-  mapBX_layer_ =
-      MEMap3Inf(this, "bx", "Strip Digi Bunch Crossing ", 21, nBXMin_ - 0.5, nBXMax_ + 0.5, "Bunch crossing");
+  mapTotalDigi_layer_ = MEMap3Inf(this, "det", "Digi Occupancy", 36, 0.5, 36.5, 24, -0.5, 24 - 0.5, "Chamber", "VFAT");
+  mapDigiOcc_ieta_ = MEMap3Inf(this, "occ_ieta", "Digi iEta Occupancy", 8, 0.5, 8.5, "iEta", "Number of fired digis");
+  mapDigiOcc_phi_ =
+      MEMap3Inf(this, "occ_phi", "Digi Phi Occupancy", 108, -5, 355, "#phi (degree)", "Number of fired digis");
+  mapTotalDigiPerEvtLayer_ = MEMap3Inf(this,
+                                       "digis_per_layer",
+                                       "Total number of digis per event for each layers",
+                                       50,
+                                       -0.5,
+                                       99.5,
+                                       "Number of fired digis",
+                                       "Events");
+  mapTotalDigiPerEvtIEta_ = MEMap3Inf(this,
+                                      "digis_per_ieta",
+                                      "Total number of digis per event for each eta partitions",
+                                      50,
+                                      -0.5,
+                                      99.5,
+                                      "Number of fired digis",
+                                      "Events");
 
-  mapStripOccPerCh_ = MEMap4Inf(this, "strip_occ", "Strip Digi Occupancy ", 1, 0.5, 1.5, 1, 0.5, 1.5, "Strip", "iEta");
-  mapBXPerCh_ = MEMap4Inf(this,
-                          "bx_ch",
-                          "Strip Digi Bunch Crossing ",
-                          21,
-                          nBXMin_ - 0.5,
-                          nBXMax_ + 0.5,
-                          1,
-                          0.5,
-                          1.5,
-                          "Bunch crossing",
-                          "VFAT");
+  mapBX_iEta_ = MEMap3Inf(this, "bx", "Digi Bunch Crossing", 21, nBXMin_ - 0.5, nBXMax_ + 0.5, "Bunch crossing");
+
+  mapDigiOccPerCh_ = MEMap4Inf(this, "occ", "Digi Occupancy", 1, -0.5, 1.5, 1, 0.5, 1.5, "Digi", "iEta");
+
+  if (bModeRelVal_) {
+    mapTotalDigi_layer_.TurnOff();
+    mapDigiOccPerCh_.TurnOff();
+  }
 
   ibooker.cd();
-  ibooker.setCurrentFolder("GEM/digi");
+  ibooker.setCurrentFolder("GEM/Digis");
   GenerateMEPerChamber(ibooker);
 
-  h2SummaryOcc = CreateSummaryHist(ibooker, "summaryOccDigi");
-  h2SummaryMal = CreateSummaryHist(ibooker, "summaryMalfuncDigi");
+  h2SummaryOcc_ = nullptr;
+  if (!bModeRelVal_) {
+    h2SummaryOcc_ = CreateSummaryHist(ibooker, "summaryOccDigi");
+    h2SummaryOcc_->setTitle("Summary of occupancy on chambers");
+    h2SummaryOcc_->setXTitle("Chamber");
+  }
+}
+
+int GEMDigiSource::ProcessWithMEMap2WithEta(BookingHelper& bh, ME3IdsKey key) {
+  mapBX_iEta_.bookND(bh, key);
+  mapTotalDigiPerEvtIEta_.bookND(bh, key);
+
+  return 0;
 }
 
 int GEMDigiSource::ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) {
   MEStationInfo& stationInfo = mapStationInfo_[key];
 
   mapTotalDigi_layer_.SetBinConfX(stationInfo.nNumChambers_);
-  mapTotalDigi_layer_.SetBinConfY(stationInfo.nMaxVFAT_);
+  mapTotalDigi_layer_.SetBinConfY(stationInfo.nMaxVFAT_, -0.5);
   mapTotalDigi_layer_.bookND(bh, key);
   mapTotalDigi_layer_.SetLabelForChambers(key, 1);
   mapTotalDigi_layer_.SetLabelForVFATs(key, stationInfo.nNumEtaPartitions_, 2);
 
-  mapStripOcc_ieta_.SetBinConfX(stationInfo.nNumEtaPartitions_);
-  mapStripOcc_ieta_.bookND(bh, key);
-  mapTotalDigi_layer_.SetLabelForChambers(key, 1);  // For eta partitions
+  mapDigiOcc_ieta_.SetBinConfX(stationInfo.nNumEtaPartitions_);
+  mapDigiOcc_ieta_.bookND(bh, key);
+  mapDigiOcc_ieta_.SetLabelForIEta(key, 1);
 
-  mapStripOcc_phi_.bookND(bh, key);
-  mapTotalStripPerEvt_.bookND(bh, key);
-  mapBX_layer_.bookND(bh, key);
+  mapDigiOcc_phi_.bookND(bh, key);
+  mapTotalDigiPerEvtLayer_.bookND(bh, key);
 
   return 0;
 }
@@ -149,17 +99,13 @@ int GEMDigiSource::ProcessWithMEMap3WithChamber(BookingHelper& bh, ME4IdsKey key
   ME3IdsKey key3 = key4Tokey3(key);
   MEStationInfo& stationInfo = mapStationInfo_[key3];
 
-  int nNumVFATPerRoll = stationInfo.nMaxVFAT_ / stationInfo.nNumEtaPartitions_;
-  int nNumCh = stationInfo.nNumStrip_;
+  int nNumVFATPerEta = stationInfo.nMaxVFAT_ / stationInfo.nNumEtaPartitions_;
+  int nNumCh = stationInfo.nNumDigi_;
 
-  mapStripOccPerCh_.SetBinConfX(nNumCh * nNumVFATPerRoll);
-  mapStripOccPerCh_.SetBinConfY(stationInfo.nNumEtaPartitions_);
-  mapStripOccPerCh_.bookND(bh, key);
-  mapStripOccPerCh_.SetLabelForChambers(key, 2);  // For eta partitions
-
-  mapBXPerCh_.SetBinConfY(stationInfo.nMaxVFAT_);
-  mapBXPerCh_.bookND(bh, key);
-  mapBXPerCh_.SetLabelForVFATs(key, stationInfo.nNumEtaPartitions_, 2);
+  mapDigiOccPerCh_.SetBinConfX(nNumCh * nNumVFATPerEta);
+  mapDigiOccPerCh_.SetBinConfY(stationInfo.nNumEtaPartitions_);
+  mapDigiOccPerCh_.bookND(bh, key);
+  mapDigiOccPerCh_.SetLabelForIEta(key, 2);
 
   return 0;
 }
@@ -170,7 +116,8 @@ void GEMDigiSource::analyze(edm::Event const& event, edm::EventSetup const& even
   edm::Handle<LumiScalersCollection> lumiScalers;
   event.getByToken(lumiScalers_, lumiScalers);
 
-  std::map<ME3IdsKey, Int_t> total_strip_layer;
+  std::map<ME3IdsKey, Int_t> total_digi_layer;
+  std::map<ME3IdsKey, Int_t> total_digi_eta;
   for (const auto& ch : gemChambers_) {
     GEMDetId gid = ch.id();
     ME2IdsKey key2{gid.region(), gid.station()};
@@ -179,46 +126,52 @@ void GEMDigiSource::analyze(edm::Event const& event, edm::EventSetup const& even
     std::map<Int_t, bool> bTagVFAT;
     bTagVFAT.clear();
     const BoundPlane& surface = GEMGeometry_->idToDet(gid)->surface();
-    if (total_strip_layer.find(key3) == total_strip_layer.end())
-      total_strip_layer[key3] = 0;
+    if (total_digi_layer.find(key3) == total_digi_layer.end())
+      total_digi_layer[key3] = 0;
     for (auto iEta : ch.etaPartitions()) {
-      GEMDetId rId = iEta->id();
-      const auto& digis_in_det = gemDigis->get(rId);
+      GEMDetId eId = iEta->id();
+      ME3IdsKey key3IEta{gid.region(), gid.station(), eId.ieta()};
+      if (total_digi_eta.find(key3IEta) == total_digi_eta.end())
+        total_digi_eta[key3IEta] = 0;
+      const auto& digis_in_det = gemDigis->get(eId);
       for (auto d = digis_in_det.first; d != digis_in_det.second; ++d) {
         // Filling of digi occupancy
-        Int_t nIdxVFAT = getVFATNumberByStrip(gid.station(), rId.ieta(), d->strip());
-        mapTotalDigi_layer_.Fill(key3, gid.chamber(), nIdxVFAT + 1);
+        Int_t nIdxVFAT = getVFATNumberByDigi(gid.station(), eId.ieta(), d->strip());
+        mapTotalDigi_layer_.Fill(key3, gid.chamber(), nIdxVFAT);
 
-        // Filling of strip
-        mapStripOcc_ieta_.Fill(key3, rId.ieta());  // Roll
+        // Filling of digi
+        mapDigiOcc_ieta_.Fill(key3, eId.ieta());  // Eta (partition)
 
-        GlobalPoint strip_global_pos = surface.toGlobal(iEta->centreOfStrip(d->strip()));
-        Float_t fPhiDeg = ((Float_t)strip_global_pos.phi()) * 180.0 / 3.141592;
+        GlobalPoint digi_global_pos = surface.toGlobal(iEta->centreOfStrip(d->strip()));
+        Float_t fPhiDeg = ((Float_t)digi_global_pos.phi()) * 180.0 / 3.141592;
         if (fPhiDeg < -5.0)
           fPhiDeg += 360.0;
-        mapStripOcc_phi_.Fill(key3, fPhiDeg);  // Phi
+        mapDigiOcc_phi_.Fill(key3, fPhiDeg);  // Phi
 
-        mapStripOccPerCh_.Fill(key4Ch, d->strip(), rId.ieta());  // Per chamber
+        mapDigiOccPerCh_.Fill(key4Ch, d->strip(), eId.ieta());  // Per chamber
 
-        // For total strips
-        total_strip_layer[key3]++;
+        // For total digis
+        total_digi_layer[key3]++;
+        total_digi_eta[key3IEta]++;
 
         // Filling of bx
         Int_t nBX = std::min(std::max((Int_t)d->bx(), nBXMin_), nBXMax_);  // For under/overflow
         if (bTagVFAT.find(nIdxVFAT) == bTagVFAT.end()) {
-          mapBX_layer_.Fill(key3, nBX);
-          mapBXPerCh_.Fill(key4Ch, nBX, nIdxVFAT);
+          mapBX_iEta_.Fill(key3IEta, nBX);
         }
 
         // Occupancy on a chamber
-        h2SummaryOcc->Fill(gid.chamber(), mapStationToIdx_[key3]);
+        if (h2SummaryOcc_)
+          h2SummaryOcc_->Fill(gid.chamber(), mapStationToIdx_[key3]);
 
         bTagVFAT[nIdxVFAT] = true;
       }
     }
   }
-  for (auto [key, num_total_strip] : total_strip_layer)
-    mapTotalStripPerEvt_.Fill(key, num_total_strip);
+  for (auto [key, num_total_digi] : total_digi_layer)
+    mapTotalDigiPerEvtLayer_.Fill(key, num_total_digi);
+  for (auto [key, num_total_digi] : total_digi_eta)
+    mapTotalDigiPerEvtIEta_.Fill(key, num_total_digi);
 }
 
 DEFINE_FWK_MODULE(GEMDigiSource);

--- a/DQM/GEM/plugins/GEMRecHitSource.cc
+++ b/DQM/GEM/plugins/GEMRecHitSource.cc
@@ -1,56 +1,4 @@
-#include "DQM/GEM/interface/GEMDQMBase.h"
-
-#include "DataFormats/GEMRecHit/interface/GEMRecHit.h"
-#include "DataFormats/GEMRecHit/interface/GEMRecHitCollection.h"
-#include "DataFormats/GEMDigi/interface/GEMDigiCollection.h"
-
-#include <string>
-
-//----------------------------------------------------------------------------------------------------
-
-class GEMRecHitSource : public GEMDQMBase {
-public:
-  explicit GEMRecHitSource(const edm::ParameterSet& cfg);
-  ~GEMRecHitSource() override{};
-  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-
-protected:
-  void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override{};
-  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
-  void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
-
-private:
-  int ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) override;
-  int ProcessWithMEMap4(BookingHelper& bh, ME4IdsKey key) override;
-  int ProcessWithMEMap3WithChamber(BookingHelper& bh, ME4IdsKey key) override;
-
-  edm::EDGetToken tagRecHit_;
-
-  float fGlobXMin_, fGlobXMax_;
-  float fGlobYMin_, fGlobYMax_;
-
-  int nIdxFirstStrip_;
-  int nClusterSizeBinNum_;
-
-  MEMap3Inf mapTotalRecHit_layer_;
-  MEMap3Inf mapRecHitWheel_layer_;
-  MEMap3Inf mapRecHitOcc_ieta_;
-  MEMap3Inf mapRecHitOcc_phi_;
-  MEMap3Inf mapTotalRecHitPerEvt_;
-  MEMap4Inf mapCLSRecHit_ieta_;
-
-  MEMap4Inf mapCLSPerCh_;
-
-  Int_t nCLSMax_;
-  Float_t fRadiusMin_;
-  Float_t fRadiusMax_;
-
-  std::unordered_map<UInt_t, MonitorElement*> recHitME_;
-  std::unordered_map<UInt_t, MonitorElement*> VFAT_vs_ClusterSize_;
-  std::unordered_map<UInt_t, MonitorElement*> StripsFired_vs_eta_;
-  std::unordered_map<UInt_t, MonitorElement*> rh_vs_eta_;
-  std::unordered_map<UInt_t, MonitorElement*> recGlobalPos;
-};
+#include "DQM/GEM/interface/GEMRecHitSource.h"
 
 using namespace std;
 using namespace edm;
@@ -58,26 +6,18 @@ using namespace edm;
 GEMRecHitSource::GEMRecHitSource(const edm::ParameterSet& cfg) : GEMDQMBase(cfg) {
   tagRecHit_ = consumes<GEMRecHitCollection>(cfg.getParameter<edm::InputTag>("recHitsInputLabel"));
 
-  nIdxFirstStrip_ = cfg.getParameter<int>("idxFirstStrip");
+  nIdxFirstDigi_ = cfg.getParameter<int>("idxFirstDigi");
   nClusterSizeBinNum_ = cfg.getParameter<int>("ClusterSizeBinNum");
-
-  fGlobXMin_ = cfg.getParameter<double>("global_x_bound_min");
-  fGlobXMax_ = cfg.getParameter<double>("global_x_bound_max");
-  fGlobYMin_ = cfg.getParameter<double>("global_y_bound_min");
-  fGlobYMax_ = cfg.getParameter<double>("global_y_bound_max");
+  bModeRelVal_ = cfg.getParameter<bool>("modeRelVal");
 }
 
 void GEMRecHitSource::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("recHitsInputLabel", edm::InputTag("gemRecHits", ""));
 
-  desc.add<int>("idxFirstStrip", 0);
+  desc.add<int>("idxFirstDigi", 0);
   desc.add<int>("ClusterSizeBinNum", 9);
-
-  desc.add<double>("global_x_bound_min", -350);
-  desc.add<double>("global_x_bound_max", 350);
-  desc.add<double>("global_y_bound_min", -260);
-  desc.add<double>("global_y_bound_max", 260);
+  desc.add<bool>("modeRelVal", false);
 
   desc.addUntracked<std::string>("logCategory", "GEMRecHitSource");
 
@@ -93,7 +33,7 @@ void GEMRecHitSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&
   loadChambers();
 
   ibooker.cd();
-  ibooker.setCurrentFolder("GEM/recHit");
+  ibooker.setCurrentFolder("GEM/RecHits");
 
   nCLSMax_ = 10;
   fRadiusMin_ = 120.0;
@@ -101,29 +41,70 @@ void GEMRecHitSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&
   float radS = -5.0 / 180 * 3.141592;
   float radL = 355.0 / 180 * 3.141592;
 
-  mapTotalRecHit_layer_ =
-      MEMap3Inf(this, "rechit_det", "Rec. Hit Occupancy", 36, 0.5, 36.5, 8, 0.5, 8.5, "Chamber", "iEta");
-  mapRecHitWheel_layer_ =
-      MEMap3Inf(this, "rechit_wheel", "Rec. Hit Wheel Occupancy", 108, radS, radL, 8, fRadiusMin_, fRadiusMax_, "", "");
-  mapRecHitOcc_ieta_ = MEMap3Inf(
-      this, "rechit_ieta_occ", "RecHit Digi Occupancy per eta partition", 8, 0.5, 8.5, "iEta", "Number of recHits");
-  mapRecHitOcc_phi_ = MEMap3Inf(
-      this, "rechit_phi_occ", "RecHit Digi Phi (degree) Occupancy ", 108, -5, 355, "#phi (degree)", "Number of recHits");
-  mapTotalRecHitPerEvt_ = MEMap3Inf(this,
-                                    "total_rechit_per_event",
-                                    "Total number of rec. hits per event for each layers ",
-                                    50,
-                                    -0.5,
-                                    99.5,
-                                    "Number of recHits",
-                                    "Events");
-  mapCLSRecHit_ieta_ = MEMap4Inf(
-      this, "cls", "Cluster size of rec. hits", nCLSMax_, 0.5, nCLSMax_ + 0.5, "Cluster size", "Number of recHits");
+  mapTotalRecHit_layer_ = MEMap3Inf(this, "det", "RecHit Occupancy", 36, 0.5, 36.5, 8, 0.5, 8.5, "Chamber", "iEta");
+  mapRecHitWheel_layer_ = MEMap3Inf(
+      this, "rphi_occ", "RecHit R-Phi Occupancy", 108, radS, radL, 8, fRadiusMin_, fRadiusMax_, "#phi (rad)", "R [cm]");
+  mapRecHitOcc_ieta_ = MEMap3Inf(this, "occ_ieta", "RecHit iEta Occupancy", 8, 0.5, 8.5, "iEta", "Number of RecHits");
+  mapRecHitOcc_phi_ =
+      MEMap3Inf(this, "occ_phi", "RecHit Phi Occupancy", 108, -5, 355, "#phi (degree)", "Number of RecHits");
+  mapTotalRecHitPerEvtLayer_ = MEMap3Inf(this,
+                                         "rechits_per_layer",
+                                         "Total number of RecHits per event for each layers",
+                                         50,
+                                         -0.5,
+                                         99.5,
+                                         "Number of RecHits",
+                                         "Events");
+  mapTotalRecHitPerEvtIEta_ = MEMap3Inf(this,
+                                        "rechits_per_ieta",
+                                        "Total number of RecHits per event for each eta partitions",
+                                        50,
+                                        -0.5,
+                                        99.5,
+                                        "Number of RecHits",
+                                        "Events");
+  mapCLSRecHit_ieta_ = MEMap3Inf(
+      this, "cls", "Cluster size of RecHits", nCLSMax_, 0.5, nCLSMax_ + 0.5, "Cluster size", "Number of RecHits");
+  mapCLSAverage_ = MEMap3Inf(this,  // TProfile2D
+                             "rechit_average",
+                             "Average of Cluster Sizes",
+                             36,
+                             0.5,
+                             36.5,
+                             8,
+                             0.5,
+                             8.5,
+                             0,
+                             400,  // For satefy, larger than 384
+                             "Chamber",
+                             "iEta");
+  mapCLSOver5_ = MEMap3Inf(
+      this, "largeCls_occ", "Occupancy of Large Clusters (>5)", 36, 0.5, 36.5, 8, 0.5, 8.5, "Chamber", "iEta");
 
   mapCLSPerCh_ = MEMap4Inf(
-      this, "cls", "Cluster size of rec. hits", nCLSMax_, 0.5, nCLSMax_ + 0.5, 1, 0.5, 1.5, "Cluster size", "iEta");
+      this, "cls", "Cluster size of RecHits", nCLSMax_, 0.5, nCLSMax_ + 0.5, 1, 0.5, 1.5, "Cluster size", "iEta");
+
+  if (bModeRelVal_) {
+    mapTotalRecHit_layer_.TurnOff();
+    mapRecHitWheel_layer_.TurnOff();
+    mapCLSAverage_.TurnOff();
+    mapCLSOver5_.TurnOff();
+    mapCLSPerCh_.TurnOff();
+  }
 
   GenerateMEPerChamber(ibooker);
+}
+
+int GEMRecHitSource::ProcessWithMEMap2WithEta(BookingHelper& bh, ME3IdsKey key) {
+  mapTotalRecHitPerEvtIEta_.bookND(bh, key);
+
+  return 0;
+}
+
+int GEMRecHitSource::ProcessWithMEMap2AbsReWithEta(BookingHelper& bh, ME3IdsKey key) {
+  mapCLSRecHit_ieta_.bookND(bh, key);
+
+  return 0;
 }
 
 int GEMRecHitSource::ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) {
@@ -135,7 +116,7 @@ int GEMRecHitSource::ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) {
   mapTotalRecHit_layer_.SetBinConfY(stationInfo.nNumEtaPartitions_);
   mapTotalRecHit_layer_.bookND(bh, key);
   mapTotalRecHit_layer_.SetLabelForChambers(key, 1);
-  mapTotalRecHit_layer_.SetLabelForChambers(key, 2);  // No worries, it's same as the eta partition labelling
+  mapTotalRecHit_layer_.SetLabelForIEta(key, 2);
 
   mapRecHitWheel_layer_.SetBinLowEdgeX(-0.088344);  // FIXME: It could be different for other stations...
   mapRecHitWheel_layer_.SetBinHighEdgeX(-0.088344 + 2 * 3.141592);
@@ -145,15 +126,17 @@ int GEMRecHitSource::ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) {
 
   mapRecHitOcc_ieta_.SetBinConfX(stationInfo.nNumEtaPartitions_);
   mapRecHitOcc_ieta_.bookND(bh, key);
+  mapRecHitOcc_ieta_.SetLabelForIEta(key, 1);
 
   mapRecHitOcc_phi_.bookND(bh, key);
-  mapTotalRecHitPerEvt_.bookND(bh, key);
+  mapTotalRecHitPerEvtLayer_.bookND(bh, key);
 
-  return 0;
-}
-
-int GEMRecHitSource::ProcessWithMEMap4(BookingHelper& bh, ME4IdsKey key) {
-  mapCLSRecHit_ieta_.bookND(bh, key);
+  mapCLSAverage_.bookND(bh, key);
+  mapCLSOver5_.bookND(bh, key);
+  mapCLSAverage_.SetLabelForChambers(key, 1);
+  mapCLSAverage_.SetLabelForIEta(key, 2);
+  mapCLSOver5_.SetLabelForChambers(key, 1);
+  mapCLSOver5_.SetLabelForIEta(key, 2);
 
   return 0;
 }
@@ -164,7 +147,7 @@ int GEMRecHitSource::ProcessWithMEMap3WithChamber(BookingHelper& bh, ME4IdsKey k
 
   mapCLSPerCh_.SetBinConfY(stationInfo.nNumEtaPartitions_);
   mapCLSPerCh_.bookND(bh, key);
-  mapCLSPerCh_.SetLabelForChambers(key, 2);  // For eta partitions
+  mapCLSPerCh_.SetLabelForIEta(key, 2);
 
   return 0;
 }
@@ -173,21 +156,30 @@ void GEMRecHitSource::analyze(edm::Event const& event, edm::EventSetup const& ev
   edm::Handle<GEMRecHitCollection> gemRecHits;
   event.getByToken(this->tagRecHit_, gemRecHits);
   if (!gemRecHits.isValid()) {
-    edm::LogError(log_category_) << "GEM recHit is not valid.\n";
+    edm::LogError(log_category_) << "GEM RecHit is not valid.\n";
     return;
   }
+
   std::map<ME3IdsKey, Int_t> total_rechit_layer;
+  std::map<ME3IdsKey, Int_t> total_rechit_iEta;
+  std::map<ME4IdsKey, std::map<Int_t, Bool_t>> mapCLSOver5;
+
   for (const auto& ch : gemChambers_) {
     GEMDetId gid = ch.id();
+    auto chamber = gid.chamber();
     ME3IdsKey key3{gid.region(), gid.station(), gid.layer()};
     ME4IdsKey key4Ch{gid.region(), gid.station(), gid.layer(), gid.chamber()};
     MEStationInfo& stationInfo = mapStationInfo_[key3];
     for (auto ieta : ch.etaPartitions()) {
-      GEMDetId rId = ieta->id();
-      ME4IdsKey key4iEta{gid.region(), gid.station(), gid.layer(), rId.ieta()};
+      GEMDetId eId = ieta->id();
+      ME3IdsKey key3IEta{gid.region(), gid.station(), eId.ieta()};
+      ME3IdsKey key3AbsReIEta{std::abs(gid.region()), gid.station(), eId.ieta()};
+      ME4IdsKey key4IEta{gid.region(), gid.station(), gid.layer(), eId.ieta()};
+
       if (total_rechit_layer.find(key3) == total_rechit_layer.end())
         total_rechit_layer[key3] = 0;
-      const auto& recHitsRange = gemRecHits->get(rId);
+
+      const auto& recHitsRange = gemRecHits->get(eId);
       auto gemRecHit = recHitsRange.first;
       for (auto hit = gemRecHit; hit != recHitsRange.second; ++hit) {
         GlobalPoint recHitGP = GEMGeometry_->idToDet(hit->gemId())->surface().toGlobal(hit->localPosition());
@@ -195,34 +187,46 @@ void GEMRecHitSource::analyze(edm::Event const& event, edm::EventSetup const& ev
         if (fPhi < -5.0 / 180.0 * 3.141592)
           fPhi += 2 * 3.141592;
 
-        // Filling of digi occupancy
-        mapTotalRecHit_layer_.Fill(key3, gid.chamber(), rId.ieta());
+        // Filling of RecHit occupancy
+        mapTotalRecHit_layer_.Fill(key3, chamber, eId.ieta());
 
-        // Filling of wheel occupancy
-        Float_t fR = fRadiusMin_ + (fRadiusMax_ - fRadiusMin_) * (rId.ieta() - 0.5) / stationInfo.nNumEtaPartitions_;
-        if (!(fRadiusMin_ <= fR && fR <= fRadiusMax_ && -0.08726 <= fPhi && fPhi <= 6.196))
-          std::cout << fR << ", " << fPhi << std::endl;
+        // Filling of R-Phi occupancy
+        Float_t fR = fRadiusMin_ + (fRadiusMax_ - fRadiusMin_) * (eId.ieta() - 0.5) / stationInfo.nNumEtaPartitions_;
         mapRecHitWheel_layer_.Fill(key3, fPhi, fR);
 
-        // Filling of strip (iEta)
-        mapRecHitOcc_ieta_.Fill(key3, rId.ieta());
+        // Filling of RecHit (iEta)
+        mapRecHitOcc_ieta_.Fill(key3, eId.ieta());
 
-        // Filling of strip (phi)
+        // Filling of RecHit (phi)
         Float_t fPhiDeg = fPhi * 180.0 / 3.141592;
         mapRecHitOcc_phi_.Fill(key3, fPhiDeg);
 
-        // For total recHits
+        // For total RecHits
         total_rechit_layer[key3]++;
+        total_rechit_iEta[key3IEta]++;
 
         // Filling of cluster size (CLS)
-        Int_t nCLS = std::min(hit->clusterSize(), nCLSMax_);  // For overflow
-        mapCLSRecHit_ieta_.Fill(key4iEta, nCLS);
-        mapCLSPerCh_.Fill(key4Ch, rId.ieta(), nCLS);
+        Int_t nCLS = hit->clusterSize();
+        Int_t nCLSCutOff = std::min(nCLS, nCLSMax_);  // For overflow
+        mapCLSRecHit_ieta_.Fill(key3AbsReIEta, nCLSCutOff);
+        mapCLSPerCh_.Fill(key4Ch, nCLSCutOff, eId.ieta());
+        mapCLSAverage_.Fill(key3, (Double_t)chamber, (Double_t)eId.ieta(), nCLS);
+        if (nCLS > 5)
+          mapCLSOver5[key4IEta][chamber] = true;
       }
     }
   }
-  for (auto [key, num_total_rechit] : total_rechit_layer)
-    mapTotalRecHitPerEvt_.Fill(key, num_total_rechit);
+  for (auto [key, num_total_rechit] : total_rechit_layer) {
+    mapTotalRecHitPerEvtLayer_.Fill(key, num_total_rechit);
+  }
+  for (auto [key, num_total_rechit] : total_rechit_iEta) {
+    mapTotalRecHitPerEvtIEta_.Fill(key, num_total_rechit);
+  }
+  for (auto [key, mapSub] : mapCLSOver5) {
+    for (auto [chamber, b] : mapSub) {
+      mapCLSOver5_.Fill(key4Tokey3(key), chamber, keyToIEta(key));
+    }
+  }
 }
 
 DEFINE_FWK_MODULE(GEMRecHitSource);

--- a/DQM/GEM/python/GEMDQM_cff.py
+++ b/DQM/GEM/python/GEMDQM_cff.py
@@ -11,3 +11,8 @@ GEMDQM = cms.Sequence(
   *GEMDAQStatusSource
   +GEMDQMHarvester
 )
+
+GEMDQMForRelval = cms.Sequence(
+  GEMDigiSource
+  *GEMRecHitSource
+)

--- a/DQM/GEM/src/GEMDQMBase.cc
+++ b/DQM/GEM/src/GEMDQMBase.cc
@@ -78,14 +78,14 @@ int GEMDQMBase::loadChambers() {
       const int max_vfat = getMaxVFAT(station->station());  // the number of VFATs per GEMEtaPartition
       const int num_etas = getNumEtaPartitions(station);    // the number of eta partitions per GEMChamber
       const int num_vfat = num_etas * max_vfat;             // the number of VFATs per GEMChamber
-      const int num_strip = GEMeMap::maxChan_;              // the number of strips (channels) per VFAT
+      const int num_digi = GEMeMap::maxChan_;               // the number of digis (channels) per VFAT
 
       nMaxNumCh_ = std::max(nMaxNumCh_, num_superchambers);
 
       for (int layer_number = 1; layer_number <= num_layers; layer_number++) {
         ME3IdsKey key3(region_number, station_number, layer_number);
-        mapStationInfo_[key3] = MEStationInfo(
-            region_number, station_number, layer_number, num_superchambers, num_etas, num_vfat, num_strip);
+        mapStationInfo_[key3] =
+            MEStationInfo(region_number, station_number, layer_number, num_superchambers, num_etas, num_vfat, num_digi);
       }
     }
   }
@@ -129,6 +129,8 @@ dqm::impl::MonitorElement* GEMDQMBase::CreateSummaryHist(DQMStore::IBooker& iboo
 
   auto h2Res =
       ibooker.book2D(strName, "", nMaxNumCh_, 0.5, nMaxNumCh_ + 0.5, listLayers.size(), 0.5, listLayers.size() + 0.5);
+  h2Res->setXTitle("Chamber");
+  h2Res->setYTitle("Layer");
 
   if (h2Res == nullptr)
     return nullptr;
@@ -138,7 +140,13 @@ dqm::impl::MonitorElement* GEMDQMBase::CreateSummaryHist(DQMStore::IBooker& iboo
   for (Int_t i = 1; i <= (Int_t)listLayers.size(); i++) {
     auto key = listLayers[i - 1];
     auto strInfo = GEMUtils::getSuffixName(key);  // NOTE: It starts with '_'
-    auto label = Form("GE%+i/%iL%i;%s", keyToRegion(key), keyToStation(key), keyToLayer(key), strInfo.Data());
+    auto region = keyToRegion(key);
+    auto label = Form("GE%i%i-%cL%i;%s",
+                      std::abs(region),
+                      keyToStation(key),
+                      (region > 0 ? 'P' : 'M'),
+                      keyToLayer(key),
+                      strInfo.Data());
     h2Res->setBinLabel(i, label, 2);
     Int_t nNumCh = mapStationInfo_[key].nNumChambers_;
     h2Res->setBinContent(0, i, nNumCh);
@@ -149,6 +157,8 @@ dqm::impl::MonitorElement* GEMDQMBase::CreateSummaryHist(DQMStore::IBooker& iboo
 
 int GEMDQMBase::GenerateMEPerChamber(DQMStore::IBooker& ibooker) {
   MEMap2Check_.clear();
+  MEMap2WithEtaCheck_.clear();
+  MEMap2AbsReWithEtaCheck_.clear();
   MEMap3Check_.clear();
   MEMap3WithChCheck_.clear();
   MEMap4Check_.clear();
@@ -172,21 +182,40 @@ int GEMDQMBase::GenerateMEPerChamber(DQMStore::IBooker& ibooker) {
       MEMap3Check_[key3] = true;
     }
     if (!MEMap3WithChCheck_[key3WithChamber]) {
-      auto strSuffixName = GEMUtils::getSuffixName(key3) + Form("_ch%02i", gid.chamber());
-      auto strSuffixTitle = GEMUtils::getSuffixTitle(key3) + Form(" Chamber %02i", gid.chamber());
+      Int_t nCh = gid.chamber();
+      Int_t nLa = gid.layer();
+      char cLS = (nCh % 2 == 0 ? 'L' : 'S');  // FIXME: Is it general enough?
+      auto strSuffixName = GEMUtils::getSuffixName(key2) + Form("-%02iL%i-%c", nCh, nLa, cLS);
+      auto strSuffixTitle = GEMUtils::getSuffixTitle(key2) + Form("-%02iL%i-%c", nCh, nLa, cLS);
       BookingHelper bh3Ch(ibooker, strSuffixName, strSuffixTitle);
       ProcessWithMEMap3WithChamber(bh3Ch, key3WithChamber);
       MEMap3WithChCheck_[key3WithChamber] = true;
     }
     for (auto iEta : ch.etaPartitions()) {
-      GEMDetId rId = iEta->id();
-      ME4IdsKey key4{gid.region(), gid.station(), gid.layer(), rId.ieta()};
+      GEMDetId eId = iEta->id();
+      ME4IdsKey key4{gid.region(), gid.station(), gid.layer(), eId.ieta()};
+      ME3IdsKey key2WithEta{gid.region(), gid.station(), eId.ieta()};
+      ME3IdsKey key2AbsReWithEta{std::abs(gid.region()), gid.station(), eId.ieta()};
       if (!MEMap4Check_[key4]) {
-        auto strSuffixName = GEMUtils::getSuffixName(key3) + Form("_ieta%02i", rId.ieta());
-        auto strSuffixTitle = GEMUtils::getSuffixTitle(key3) + Form(" iEta %02i", rId.ieta());
+        auto strSuffixName = GEMUtils::getSuffixName(key3) + Form("-E%02i", eId.ieta());
+        auto strSuffixTitle = GEMUtils::getSuffixTitle(key3) + Form("-E%02i", eId.ieta());
         BookingHelper bh4(ibooker, strSuffixName, strSuffixTitle);
         ProcessWithMEMap4(bh4, key4);
         MEMap4Check_[key4] = true;
+      }
+      if (!MEMap2WithEtaCheck_[key2WithEta]) {
+        auto strSuffixName = GEMUtils::getSuffixName(key2) + Form("-E%02i", eId.ieta());
+        auto strSuffixTitle = GEMUtils::getSuffixTitle(key2) + Form("-E%02i", eId.ieta());
+        BookingHelper bh3(ibooker, strSuffixName, strSuffixTitle);
+        ProcessWithMEMap2WithEta(bh3, key2WithEta);
+        MEMap2WithEtaCheck_[key2WithEta] = true;
+      }
+      if (!MEMap2AbsReWithEtaCheck_[key2AbsReWithEta]) {
+        auto strSuffixName = Form("_GE%i%i-E%02i", std::abs(gid.region()), gid.station(), eId.ieta());
+        auto strSuffixTitle = Form(" GE%i%i-E%02i", std::abs(gid.region()), gid.station(), eId.ieta());
+        BookingHelper bh3(ibooker, strSuffixName, strSuffixTitle);
+        ProcessWithMEMap2AbsReWithEta(bh3, key2AbsReWithEta);
+        MEMap2AbsReWithEtaCheck_[key2AbsReWithEta] = true;
       }
     }
   }

--- a/DQM/Integration/python/clients/gem_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/gem_dqm_sourceclient-live_cfg.py
@@ -36,7 +36,7 @@ if (process.runType.getRunType() == process.runType.hi_run):
   process.muonGEMDigis.InputLabel = cms.InputTag("rawDataRepacker")
 
 process.muonGEMDigis.useDBEMap = True
-process.muonGEMDigis.unPackStatusDigis = True
+process.muonGEMDigis.keepDAQStatus = True
 
 process.path = cms.Path(
   process.muonGEMDigis *

--- a/Validation/MuonGEMHits/interface/GEMValidationUtils.h
+++ b/Validation/MuonGEMHits/interface/GEMValidationUtils.h
@@ -28,7 +28,7 @@ namespace GEMUtils {
   TString getSuffixName(Int_t region_id);
   TString getSuffixName(Int_t region_id, Int_t station_id);
   TString getSuffixName(Int_t region_id, Int_t station_id, Int_t layer_id);
-  TString getSuffixName(Int_t region_id, Int_t station_id, Int_t layer_id, Int_t roll_id);
+  TString getSuffixName(Int_t region_id, Int_t station_id, Int_t layer_id, Int_t eta_id);
 
   TString getSuffixName(const ME2IdsKey& key);
   TString getSuffixName(const ME3IdsKey& key);
@@ -37,7 +37,7 @@ namespace GEMUtils {
   TString getSuffixTitle(Int_t region_id);
   TString getSuffixTitle(Int_t region_id, Int_t station_id);
   TString getSuffixTitle(Int_t region_id, Int_t station_id, Int_t layer_id);
-  TString getSuffixTitle(Int_t region_id, Int_t station_id, Int_t layer_id, Int_t roll_id);
+  TString getSuffixTitle(Int_t region_id, Int_t station_id, Int_t layer_id, Int_t eta_id);
 
   TString getSuffixTitle(const ME2IdsKey& key);
   TString getSuffixTitle(const ME3IdsKey& key);

--- a/Validation/MuonGEMHits/src/GEMValidationUtils.cc
+++ b/Validation/MuonGEMHits/src/GEMValidationUtils.cc
@@ -5,15 +5,15 @@
 TString GEMUtils::getSuffixName(Int_t region_id) { return TString::Format("_Re%+d", region_id); }
 
 TString GEMUtils::getSuffixName(Int_t region_id, Int_t station_id) {
-  return TString::Format("_GE%+.2d", region_id * (station_id * 10 + 1));
+  return TString::Format("_GE%.2d-%c", station_id * 10 + 1, (region_id > 0 ? 'P' : 'M'));
 }
 
 TString GEMUtils::getSuffixName(Int_t region_id, Int_t station_id, Int_t layer_id) {
-  return TString::Format("_GE%+.2d_L%d", region_id * (station_id * 10 + 1), layer_id);
+  return TString::Format("_GE%.2d-%c-L%d", station_id * 10 + 1, (region_id > 0 ? 'P' : 'M'), layer_id);
 }
 
-TString GEMUtils::getSuffixName(Int_t region_id, Int_t station_id, Int_t layer_id, Int_t roll_id) {
-  return TString::Format("_GE%+.2d_L%d_iEta%d", region_id * (station_id * 10 + 1), layer_id, roll_id);
+TString GEMUtils::getSuffixName(Int_t region_id, Int_t station_id, Int_t layer_id, Int_t eta_id) {
+  return TString::Format("_GE%.2d-%c-L%d-E%d", station_id * 10 + 1, (region_id > 0 ? 'P' : 'M'), layer_id, eta_id);
 }
 
 TString GEMUtils::getSuffixName(const ME2IdsKey& key) {
@@ -27,22 +27,22 @@ TString GEMUtils::getSuffixName(const ME3IdsKey& key) {
 }
 
 TString GEMUtils::getSuffixName(const ME4IdsKey& key) {
-  auto [region_id, station_id, layer_id, roll_id] = key;
-  return getSuffixName(region_id, station_id, layer_id, roll_id);
+  auto [region_id, station_id, layer_id, eta_id] = key;
+  return getSuffixName(region_id, station_id, layer_id, eta_id);
 }
 
 TString GEMUtils::getSuffixTitle(Int_t region_id) { return TString::Format(" Region %+d", region_id); }
 
 TString GEMUtils::getSuffixTitle(Int_t region_id, Int_t station_id) {
-  return TString::Format(" GE%+.2d", region_id * (station_id * 10 + 1));
+  return TString::Format(" GE%.2d-%c", station_id * 10 + 1, (region_id > 0 ? 'P' : 'M'));
 }
 
 TString GEMUtils::getSuffixTitle(Int_t region_id, Int_t station_id, Int_t layer_id) {
-  return TString::Format(" GE%+.2d Layer %d", region_id * (station_id * 10 + 1), layer_id);
+  return TString::Format(" GE%.2d-%c-L%d", station_id * 10 + 1, (region_id > 0 ? 'P' : 'M'), layer_id);
 }
 
-TString GEMUtils::getSuffixTitle(Int_t region_id, Int_t station_id, Int_t layer_id, Int_t roll_id) {
-  return TString::Format(" GE%+.2d Layer %d iEta %d", region_id * (station_id * 10 + 1), layer_id, roll_id);
+TString GEMUtils::getSuffixTitle(Int_t region_id, Int_t station_id, Int_t layer_id, Int_t eta_id) {
+  return TString::Format(" GE%.2d-%c-L%d-E%d", station_id * 10 + 1, (region_id > 0 ? 'P' : 'M'), layer_id, eta_id);
 }
 
 TString GEMUtils::getSuffixTitle(const ME2IdsKey& key) {
@@ -56,6 +56,6 @@ TString GEMUtils::getSuffixTitle(const ME3IdsKey& key) {
 }
 
 TString GEMUtils::getSuffixTitle(const ME4IdsKey& key) {
-  auto [region_id, station_id, layer_id, roll_id] = key;
-  return getSuffixTitle(region_id, station_id, layer_id, roll_id);
+  auto [region_id, station_id, layer_id, eta_id] = key;
+  return getSuffixTitle(region_id, station_id, layer_id, eta_id);
 }


### PR DESCRIPTION
#### PR description:
Since lots of stuffs in DAQ dataformat have been changed in https://github.com/cms-sw/cmssw/pull/34504 (and #34585, the backport), the GEM onlineDQM has to be changed to adjust it. This PR is for it.

Also many of plots are rearranged, and new plots are added, which are plots of the average cluster sizes, etc..

This is the backport of #34614 to CMSSW_11_3_X.

#### PR validation:
Test are done and one can check again by `runTheMatrix` workflows

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
To CMSSW_11_3_X to be deployed on current cosmic runs (i.e., CRUZET)

@jshlee @watson-ij @hyunyong 