### PR TITLE
Add GEM unpacker in L1Repack FullMC and temporary load of GEM geometry to hltGetConfiguration

### DIFF
--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_FullMC_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_FullMC_cff.py
@@ -25,6 +25,10 @@ import EventFilter.CSCRawToDigi.cscUnpacker_cfi
 unpackCSC = EventFilter.CSCRawToDigi.cscUnpacker_cfi.muonCSCDigis.clone(
     InputObjects = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
+import EventFilter.GEMRawToDigi.muonGEMDigis_cfi
+unpackGEM = EventFilter.GEMRawToDigi.muonGEMDigis_cfi.muonGEMDigis.clone(
+    InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+
 import EventFilter.EcalRawToDigi.EcalUnpackerData_cfi
 unpackEcal = EventFilter.EcalRawToDigi.EcalUnpackerData_cfi.ecalEBunpacker.clone(
     InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
@@ -84,6 +88,9 @@ simEmtfDigis.RPCInput            = 'unpackRPC'
 simCaloStage2Layer1Digis.ecalToken = 'unpackEcal:EcalTriggerPrimitives'
 simCaloStage2Layer1Digis.hcalToken = 'simHcalTriggerPrimitiveDigis'
 
+# GEM
+simMuonGEMPadDigis.InputCollection = 'unpackGEM'
+
 # Finally, pack the new L1T output back into RAW
 from EventFilter.L1TRawToDigi.caloStage2Raw_cfi import caloStage2Raw as packCaloStage2
 from EventFilter.L1TRawToDigi.gmtStage2Raw_cfi import gmtStage2Raw as packGmtStage2
@@ -105,6 +112,7 @@ SimL1EmulatorTask = cms.Task()
 stage2L1Trigger.toReplaceWith(SimL1EmulatorTask, cms.Task(unpackRPC
                                                           , unpackDT
                                                           , unpackCSC
+                                                          , unpackGEM
                                                           , unpackEcal
                                                           , unpackHcal
                                                           #, simEcalTriggerPrimitiveDigis

--- a/DQM/Integration/python/clients/onlinebeammonitor_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/onlinebeammonitor_dqm_sourceclient-live_cfg.py
@@ -145,6 +145,18 @@ process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 #from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
 #process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
 
+# Please *do not* delete this toGet statement as it is needed to fetch BeamSpotOnline
+# information every lumisection (instead of every run as for the other records in the GT)
+process.GlobalTag.toGet = cms.VPSet(
+  cms.PSet(
+    record = cms.string("BeamSpotOnlineLegacyObjectsRcd"),
+    refreshTime = cms.uint64(1)
+  ),
+  cms.PSet(
+    record = cms.string("BeamSpotOnlineHLTObjectsRcd"),
+    refreshTime = cms.uint64(1)
+  )
+)
 
 process.dqmcommon = cms.Sequence(process.dqmEnv
                                * process.dqmSaver * process.dqmSaverPB)

--- a/DataFormats/GEMDigi/src/classes_def.xml
+++ b/DataFormats/GEMDigi/src/classes_def.xml
@@ -42,8 +42,8 @@
 <class name="MuonDigiCollection<GEMDetId,GEMCoPadDigi>"/>
 <class name="edm::Wrapper<MuonDigiCollection<GEMDetId,GEMCoPadDigi> >" splitLevel="0"/>
 
-<class name="GEMAMC13Status" ClassVersion="-1">
- <version ClassVersion="-1" checksum="3469985462"/>
+<class name="GEMAMC13Status" ClassVersion="3">
+ <version ClassVersion="3" checksum="3469985462"/>
 </class>
 <class name="std::vector<GEMAMC13Status>"/>
 <class name="std::map<uint16_t,std::vector<GEMAMC13Status> >"/>
@@ -51,8 +51,8 @@
 <class name="MuonDigiCollection<uint16_t,GEMAMC13Status>"/>
 <class name="edm::Wrapper<MuonDigiCollection<uint16_t,GEMAMC13Status> >" splitLevel="0"/>
 
-<class name="GEMAMCStatus" ClassVersion="-1">
- <version ClassVersion="-1" checksum="2120084327"/>
+<class name="GEMAMCStatus" ClassVersion="3">
+ <version ClassVersion="3" checksum="2120084327"/>
 </class>
 <class name="std::vector<GEMAMCStatus>"/>
 <class name="std::map<uint16_t,std::vector<GEMAMCStatus> >"/>
@@ -60,8 +60,8 @@
 <class name="MuonDigiCollection<uint16_t,GEMAMCStatus>"/>
 <class name="edm::Wrapper<MuonDigiCollection<uint16_t,GEMAMCStatus> >" splitLevel="0"/>
 
-<class name="GEMOHStatus" ClassVersion="-1">
- <version ClassVersion="-1" checksum="1715607020"/>
+<class name="GEMOHStatus" ClassVersion="3">
+ <version ClassVersion="3" checksum="1715607020"/>
 </class>
 <class name="std::vector<GEMOHStatus>"/>
 <class name="std::map<GEMDetId,std::vector<GEMOHStatus> >"/>
@@ -69,8 +69,8 @@
 <class name="MuonDigiCollection<GEMDetId,GEMOHStatus>"/>
 <class name="edm::Wrapper<MuonDigiCollection<GEMDetId,GEMOHStatus> >" splitLevel="0"/>
 
-<class name="GEMVFATStatus" ClassVersion="-1">
- <version ClassVersion="-1" checksum="2994917778"/>
+<class name="GEMVFATStatus" ClassVersion="3">
+ <version ClassVersion="3" checksum="2994917778"/>
 </class>
 <class name="std::vector<GEMVFATStatus>"/>
 <class name="std::map<GEMDetId,std::vector<GEMVFATStatus> >"/>

--- a/EventFilter/EcalRawToDigi/plugins/EcalRawToDigiGPU.cc
+++ b/EventFilter/EcalRawToDigi/plugins/EcalRawToDigiGPU.cc
@@ -103,6 +103,9 @@ void EcalRawToDigiGPU::acquire(edm::Event const& event,
 
   // output cpu
   outputCPU_ = {cms::cuda::make_host_unique<uint32_t[]>(2, ctx.stream())};
+  // initialize the number of channels
+  outputCPU_.nchannels[0] = 0;
+  outputCPU_.nchannels[1] = 0;
 
   // output gpu
   outputGPU_.allocate(config_, ctx.stream());

--- a/EventFilter/GEMRawToDigi/plugins/GEMPackingTester.cc
+++ b/EventFilter/GEMRawToDigi/plugins/GEMPackingTester.cc
@@ -92,9 +92,10 @@ void GEMPackingTester::analyze(const edm::Event& iEvent, const edm::EventSetup& 
           foundDigi = true;
       }
       if (!foundDigi) {
-        cout << "simMuonGEMDigi NOT found " << gemId << " " << digi->strip() << " " << digi->bx() << endl;
+        edm::LogInfo("GEMPackingTester") << "simMuonGEMDigi NOT found " << gemId << " " << digi->strip() << " "
+                                         << digi->bx();
         for (auto unpackeddigi = packed.first; unpackeddigi != packed.second; ++unpackeddigi) {
-          cout << "rec " << unpackeddigi->strip() << " " << unpackeddigi->bx() << endl;
+          edm::LogInfo("GEMPackingTester") << "rec " << unpackeddigi->strip() << " " << unpackeddigi->bx();
         }
       }
     }

--- a/HLTrigger/Configuration/python/HLT_Fake1_cff.py
+++ b/HLTrigger/Configuration/python/HLT_Fake1_cff.py
@@ -1,13 +1,13 @@
 # hltGetConfiguration --cff --data /dev/CMSSW_12_0_0/Fake1 --type Fake1
 
-# /dev/CMSSW_12_0_0/Fake1/V4 (CMSSW_12_0_0_pre4)
+# /dev/CMSSW_12_0_0/Fake1/V5 (CMSSW_12_0_0_pre5)
 
 import FWCore.ParameterSet.Config as cms
 
 fragment = cms.ProcessFragment( "HLT" )
 
 fragment.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_12_0_0/Fake1/V4')
+  tableName = cms.string('/dev/CMSSW_12_0_0/Fake1/V5')
 )
 
 fragment.streams = cms.PSet(  A = cms.vstring( 'InitialPD' ) )

--- a/HLTrigger/Configuration/python/HLT_Fake2_cff.py
+++ b/HLTrigger/Configuration/python/HLT_Fake2_cff.py
@@ -1,13 +1,13 @@
 # hltGetConfiguration --cff --data /dev/CMSSW_12_0_0/Fake2 --type Fake2
 
-# /dev/CMSSW_12_0_0/Fake2/V4 (CMSSW_12_0_0_pre4)
+# /dev/CMSSW_12_0_0/Fake2/V5 (CMSSW_12_0_0_pre5)
 
 import FWCore.ParameterSet.Config as cms
 
 fragment = cms.ProcessFragment( "HLT" )
 
 fragment.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_12_0_0/Fake2/V4')
+  tableName = cms.string('/dev/CMSSW_12_0_0/Fake2/V5')
 )
 
 fragment.streams = cms.PSet(  A = cms.vstring( 'InitialPD' ) )

--- a/HLTrigger/Configuration/python/HLT_Fake_cff.py
+++ b/HLTrigger/Configuration/python/HLT_Fake_cff.py
@@ -1,13 +1,13 @@
 # hltGetConfiguration --cff --data /dev/CMSSW_12_0_0/Fake --type Fake
 
-# /dev/CMSSW_12_0_0/Fake/V4 (CMSSW_12_0_0_pre4)
+# /dev/CMSSW_12_0_0/Fake/V5 (CMSSW_12_0_0_pre5)
 
 import FWCore.ParameterSet.Config as cms
 
 fragment = cms.ProcessFragment( "HLT" )
 
 fragment.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_12_0_0/Fake/V4')
+  tableName = cms.string('/dev/CMSSW_12_0_0/Fake/V5')
 )
 
 fragment.streams = cms.PSet(  A = cms.vstring( 'InitialPD' ) )

--- a/HLTrigger/Configuration/python/HLT_HIon_cff.py
+++ b/HLTrigger/Configuration/python/HLT_HIon_cff.py
@@ -1,13 +1,13 @@
 # hltGetConfiguration --cff --data /dev/CMSSW_12_0_0/HIon --type HIon
 
-# /dev/CMSSW_12_0_0/HIon/V3 (CMSSW_12_0_0_pre4)
+# /dev/CMSSW_12_0_0/HIon/V5 (CMSSW_12_0_0_pre5)
 
 import FWCore.ParameterSet.Config as cms
 
 fragment = cms.ProcessFragment( "HLT" )
 
 fragment.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_12_0_0/HIon/V3')
+  tableName = cms.string('/dev/CMSSW_12_0_0/HIon/V5')
 )
 
 fragment.transferSystem = cms.PSet( 

--- a/HLTrigger/Configuration/python/HLT_PIon_cff.py
+++ b/HLTrigger/Configuration/python/HLT_PIon_cff.py
@@ -1,13 +1,13 @@
 # hltGetConfiguration --cff --data /dev/CMSSW_12_0_0/PIon --type PIon
 
-# /dev/CMSSW_12_0_0/PIon/V3 (CMSSW_12_0_0_pre4)
+# /dev/CMSSW_12_0_0/PIon/V5 (CMSSW_12_0_0_pre5)
 
 import FWCore.ParameterSet.Config as cms
 
 fragment = cms.ProcessFragment( "HLT" )
 
 fragment.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_12_0_0/PIon/V3')
+  tableName = cms.string('/dev/CMSSW_12_0_0/PIon/V5')
 )
 
 fragment.transferSystem = cms.PSet( 

--- a/HLTrigger/Configuration/python/HLT_PRef_cff.py
+++ b/HLTrigger/Configuration/python/HLT_PRef_cff.py
@@ -1,13 +1,13 @@
 # hltGetConfiguration --cff --data /dev/CMSSW_12_0_0/PRef --type PRef
 
-# /dev/CMSSW_12_0_0/PRef/V3 (CMSSW_12_0_0_pre4)
+# /dev/CMSSW_12_0_0/PRef/V5 (CMSSW_12_0_0_pre5)
 
 import FWCore.ParameterSet.Config as cms
 
 fragment = cms.ProcessFragment( "HLT" )
 
 fragment.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_12_0_0/PRef/V3')
+  tableName = cms.string('/dev/CMSSW_12_0_0/PRef/V5')
 )
 
 fragment.transferSystem = cms.PSet( 
@@ -10983,8 +10983,8 @@ fragment.HLT_HcalCalibration_v5 = cms.Path( fragment.HLTBeginSequenceCalibration
 fragment.AlCa_EcalPhiSym_v9 = cms.Path( fragment.HLTBeginSequence + fragment.hltL1sZeroBiasIorAlwaysTrueIorIsolatedBunch + fragment.hltPreAlCaEcalPhiSym + fragment.HLTDoFullUnpackingEgammaEcalSequence + fragment.hltEcalPhiSymFilter + fragment.HLTEndSequence )
 fragment.HLT_ZeroBias_FirstCollisionAfterAbortGap_v5 = cms.Path( fragment.HLTBeginSequence + fragment.hltL1sL1ZeroBiasFirstCollisionAfterAbortGap + fragment.hltPreZeroBiasFirstCollisionAfterAbortGap + fragment.HLTEndSequence )
 fragment.AlCa_HIRPCMuonNormalisation_v1 = cms.Path( fragment.HLTBeginSequence + fragment.hltL1sSingleMu7to30 + fragment.hltPreAlCaHIRPCMuonNormalisation + fragment.hltHIRPCMuonNormaL1Filtered0 + fragment.HLTMuonLocalRecoSequence + fragment.HLTEndSequence )
-fragment.AlCa_LumiPixelsCounts_Random_v1 = cms.Path( fragment.HLTBeginSequenceRandom + fragment.hltPixelTrackerHVOn + fragment.hltPreAlCaLumiPixelsCountsRandom + fragment.hltSiPixelDigis + fragment.hltSiPixelClusters + fragment.hltAlcaPixelClusterCounts + fragment.HLTEndSequence )
-fragment.AlCa_LumiPixelsCounts_ZeroBias_v1 = cms.Path( fragment.HLTBeginSequence + fragment.hltPixelTrackerHVOn + fragment.hltL1sZeroBias + fragment.hltPreAlCaLumiPixelsCountsZeroBias + fragment.hltSiPixelDigis + fragment.hltSiPixelClusters + fragment.hltAlcaPixelClusterCounts + fragment.HLTEndSequence )
+fragment.AlCa_LumiPixelsCounts_Random_v1 = cms.Path( fragment.HLTBeginSequenceRandom + fragment.hltScalersRawToDigi + fragment.hltPixelTrackerHVOn + fragment.hltPreAlCaLumiPixelsCountsRandom + fragment.hltSiPixelDigis + fragment.hltSiPixelClusters + fragment.hltAlcaPixelClusterCounts + fragment.HLTEndSequence )
+fragment.AlCa_LumiPixelsCounts_ZeroBias_v1 = cms.Path( fragment.HLTBeginSequence + fragment.hltScalersRawToDigi + fragment.hltPixelTrackerHVOn + fragment.hltL1sZeroBias + fragment.hltPreAlCaLumiPixelsCountsZeroBias + fragment.hltSiPixelDigis + fragment.hltSiPixelClusters + fragment.hltAlcaPixelClusterCounts + fragment.HLTEndSequence )
 fragment.HLTriggerFinalPath = cms.Path( fragment.hltGtStage2Digis + fragment.hltScalersRawToDigi + fragment.hltFEDSelector + fragment.hltTriggerSummaryAOD + fragment.hltTriggerSummaryRAW + fragment.hltBoolFalse )
 fragment.HLTAnalyzerEndpath = cms.EndPath( fragment.hltGtStage2Digis + fragment.hltPreHLTAnalyzerEndpath + fragment.hltL1TGlobalSummary + fragment.hltTrigReport )
 

--- a/HLTrigger/Configuration/python/Tools/confdb.py
+++ b/HLTrigger/Configuration/python/Tools/confdb.py
@@ -791,6 +791,7 @@ if 'GlobalTag' in %%(dict)s:
       self.options['esmodules'].append( "-SiStripRecHitMatcherESProducer" )
       self.options['esmodules'].append( "-SiStripQualityESProducer" )
       self.options['esmodules'].append( "-StripCPEfromTrackAngleESProducer" )
+      self.options['esmodules'].append( "-TrackerAdditionalParametersPerDetESModule" )
       self.options['esmodules'].append( "-TrackerDigiGeometryESModule" )
       self.options['esmodules'].append( "-TrackerGeometricDetESModule" )
       self.options['esmodules'].append( "-VolumeBasedMagneticFieldESProducer" )

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -129,18 +129,11 @@ def customiseFor2018Input(process):
 
     return process
 
-def customiseFor34120(process):
-    """Ensure TrackerAdditionalParametersPerDetRcd ESProducer is run"""
-    process.load("Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi")
-    return process
 
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
     
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
-
-    if menuType in ["GRun","HIon","PIon","PRef"]:
-        process = customiseFor34120(process)
 
     return process

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -131,7 +131,7 @@ def customiseFor2018Input(process):
 
 
 #temporary solution to add GEM geometry for hltGetConfiguration
-def customiseForRun3GEMGeometry(process):
+def customiseForRun3GEMGeometry34785(process):
     """Add GEM geometry to output from hltGetConfiguration"""
     process.GEMGeometryESModule = cms.ESProducer(
         "GEMGeometryESModule",
@@ -147,5 +147,6 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
     
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
+    process = customiseForRun3GEMGeometry34785(process)
 
     return process

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -130,6 +130,18 @@ def customiseFor2018Input(process):
     return process
 
 
+#temporary solution to add GEM geometry for hltGetConfiguration
+def customiseForRun3GEMGeometry(process):
+    """Add GEM geometry to output from hltGetConfiguration"""
+    process.GEMGeometryESModule = cms.ESProducer(
+        "GEMGeometryESModule",
+        fromDD4Hep = cms.bool( False ),
+        appendToDataLabel = cms.string( "" ),
+        fromDDD = cms.bool( False )
+    )
+
+    return process
+
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
     

--- a/HLTrigger/Configuration/test/OnLine_HLT_Fake.py
+++ b/HLTrigger/Configuration/test/OnLine_HLT_Fake.py
@@ -1,13 +1,13 @@
 # hltGetConfiguration --full --data /dev/CMSSW_12_0_0/Fake --type Fake --unprescale --process HLTFake --globaltag auto:run1_hlt_Fake --input file:RelVal_Raw_Fake_DATA.root
 
-# /dev/CMSSW_12_0_0/Fake/V4 (CMSSW_12_0_0_pre4)
+# /dev/CMSSW_12_0_0/Fake/V5 (CMSSW_12_0_0_pre5)
 
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "HLTFake" )
 
 process.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_12_0_0/Fake/V4')
+  tableName = cms.string('/dev/CMSSW_12_0_0/Fake/V5')
 )
 
 process.streams = cms.PSet(  A = cms.vstring( 'InitialPD' ) )

--- a/HLTrigger/Configuration/test/OnLine_HLT_Fake1.py
+++ b/HLTrigger/Configuration/test/OnLine_HLT_Fake1.py
@@ -1,13 +1,13 @@
 # hltGetConfiguration --full --data /dev/CMSSW_12_0_0/Fake1 --type Fake1 --unprescale --process HLTFake1 --globaltag auto:run2_hlt_Fake1 --input file:RelVal_Raw_Fake1_DATA.root
 
-# /dev/CMSSW_12_0_0/Fake1/V4 (CMSSW_12_0_0_pre4)
+# /dev/CMSSW_12_0_0/Fake1/V5 (CMSSW_12_0_0_pre5)
 
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "HLTFake1" )
 
 process.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_12_0_0/Fake1/V4')
+  tableName = cms.string('/dev/CMSSW_12_0_0/Fake1/V5')
 )
 
 process.streams = cms.PSet(  A = cms.vstring( 'InitialPD' ) )

--- a/HLTrigger/Configuration/test/OnLine_HLT_Fake2.py
+++ b/HLTrigger/Configuration/test/OnLine_HLT_Fake2.py
@@ -1,13 +1,13 @@
 # hltGetConfiguration --full --data /dev/CMSSW_12_0_0/Fake2 --type Fake2 --unprescale --process HLTFake2 --globaltag auto:run2_hlt_Fake2 --input file:RelVal_Raw_Fake2_DATA.root
 
-# /dev/CMSSW_12_0_0/Fake2/V4 (CMSSW_12_0_0_pre4)
+# /dev/CMSSW_12_0_0/Fake2/V5 (CMSSW_12_0_0_pre5)
 
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "HLTFake2" )
 
 process.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_12_0_0/Fake2/V4')
+  tableName = cms.string('/dev/CMSSW_12_0_0/Fake2/V5')
 )
 
 process.streams = cms.PSet(  A = cms.vstring( 'InitialPD' ) )

--- a/HLTrigger/Configuration/test/OnLine_HLT_HIon.py
+++ b/HLTrigger/Configuration/test/OnLine_HLT_HIon.py
@@ -1,13 +1,13 @@
 # hltGetConfiguration --full --data /dev/CMSSW_12_0_0/HIon --type HIon --unprescale --process HLTHIon --globaltag auto:run3_hlt_HIon --input file:RelVal_Raw_HIon_DATA.root
 
-# /dev/CMSSW_12_0_0/HIon/V3 (CMSSW_12_0_0_pre4)
+# /dev/CMSSW_12_0_0/HIon/V5 (CMSSW_12_0_0_pre5)
 
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "HLTHIon" )
 
 process.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_12_0_0/HIon/V3')
+  tableName = cms.string('/dev/CMSSW_12_0_0/HIon/V5')
 )
 
 process.transferSystem = cms.PSet( 
@@ -4523,6 +4523,9 @@ process.SteppingHelixPropagatorAny = cms.ESProducer( "SteppingHelixPropagatorESP
   ApplyRadX0Correction = cms.bool( True ),
   useMagVolumes = cms.bool( True ),
   returnTangentPlane = cms.bool( True )
+)
+process.TrackerAdditionalParametersPerDetESModule = cms.ESProducer( "TrackerAdditionalParametersPerDetESModule",
+  appendToDataLabel = cms.string( "" )
 )
 process.TrackerDigiGeometryESModule = cms.ESProducer( "TrackerDigiGeometryESModule",
   appendToDataLabel = cms.string( "" ),

--- a/HLTrigger/Configuration/test/OnLine_HLT_PIon.py
+++ b/HLTrigger/Configuration/test/OnLine_HLT_PIon.py
@@ -1,13 +1,13 @@
 # hltGetConfiguration --full --data /dev/CMSSW_12_0_0/PIon --type PIon --unprescale --process HLTPIon --globaltag auto:run3_hlt_PIon --input file:RelVal_Raw_PIon_DATA.root
 
-# /dev/CMSSW_12_0_0/PIon/V3 (CMSSW_12_0_0_pre4)
+# /dev/CMSSW_12_0_0/PIon/V5 (CMSSW_12_0_0_pre5)
 
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "HLTPIon" )
 
 process.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_12_0_0/PIon/V3')
+  tableName = cms.string('/dev/CMSSW_12_0_0/PIon/V5')
 )
 
 process.transferSystem = cms.PSet( 
@@ -3994,6 +3994,9 @@ process.SteppingHelixPropagatorAny = cms.ESProducer( "SteppingHelixPropagatorESP
   ApplyRadX0Correction = cms.bool( True ),
   useMagVolumes = cms.bool( True ),
   returnTangentPlane = cms.bool( True )
+)
+process.TrackerAdditionalParametersPerDetESModule = cms.ESProducer( "TrackerAdditionalParametersPerDetESModule",
+  appendToDataLabel = cms.string( "" )
 )
 process.TrackerDigiGeometryESModule = cms.ESProducer( "TrackerDigiGeometryESModule",
   appendToDataLabel = cms.string( "" ),

--- a/HLTrigger/Configuration/test/OnLine_HLT_PRef.py
+++ b/HLTrigger/Configuration/test/OnLine_HLT_PRef.py
@@ -1,13 +1,13 @@
 # hltGetConfiguration --full --data /dev/CMSSW_12_0_0/PRef --type PRef --unprescale --process HLTPRef --globaltag auto:run3_hlt_PRef --input file:RelVal_Raw_PRef_DATA.root
 
-# /dev/CMSSW_12_0_0/PRef/V3 (CMSSW_12_0_0_pre4)
+# /dev/CMSSW_12_0_0/PRef/V5 (CMSSW_12_0_0_pre5)
 
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "HLTPRef" )
 
 process.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_12_0_0/PRef/V3')
+  tableName = cms.string('/dev/CMSSW_12_0_0/PRef/V5')
 )
 
 process.transferSystem = cms.PSet( 
@@ -4073,6 +4073,9 @@ process.SteppingHelixPropagatorAny = cms.ESProducer( "SteppingHelixPropagatorESP
   ApplyRadX0Correction = cms.bool( True ),
   useMagVolumes = cms.bool( True ),
   returnTangentPlane = cms.bool( True )
+)
+process.TrackerAdditionalParametersPerDetESModule = cms.ESProducer( "TrackerAdditionalParametersPerDetESModule",
+  appendToDataLabel = cms.string( "" )
 )
 process.TrackerDigiGeometryESModule = cms.ESProducer( "TrackerDigiGeometryESModule",
   appendToDataLabel = cms.string( "" ),
@@ -11800,8 +11803,8 @@ process.HLT_HcalCalibration_v5 = cms.Path( process.HLTBeginSequenceCalibration +
 process.AlCa_EcalPhiSym_v9 = cms.Path( process.HLTBeginSequence + process.hltL1sZeroBiasIorAlwaysTrueIorIsolatedBunch + process.hltPreAlCaEcalPhiSym + process.HLTDoFullUnpackingEgammaEcalSequence + process.hltEcalPhiSymFilter + process.HLTEndSequence )
 process.HLT_ZeroBias_FirstCollisionAfterAbortGap_v5 = cms.Path( process.HLTBeginSequence + process.hltL1sL1ZeroBiasFirstCollisionAfterAbortGap + process.hltPreZeroBiasFirstCollisionAfterAbortGap + process.HLTEndSequence )
 process.AlCa_HIRPCMuonNormalisation_v1 = cms.Path( process.HLTBeginSequence + process.hltL1sSingleMu7to30 + process.hltPreAlCaHIRPCMuonNormalisation + process.hltHIRPCMuonNormaL1Filtered0 + process.HLTMuonLocalRecoSequence + process.HLTEndSequence )
-process.AlCa_LumiPixelsCounts_Random_v1 = cms.Path( process.HLTBeginSequenceRandom + process.hltPixelTrackerHVOn + process.hltPreAlCaLumiPixelsCountsRandom + process.hltSiPixelDigis + process.hltSiPixelClusters + process.hltAlcaPixelClusterCounts + process.HLTEndSequence )
-process.AlCa_LumiPixelsCounts_ZeroBias_v1 = cms.Path( process.HLTBeginSequence + process.hltPixelTrackerHVOn + process.hltL1sZeroBias + process.hltPreAlCaLumiPixelsCountsZeroBias + process.hltSiPixelDigis + process.hltSiPixelClusters + process.hltAlcaPixelClusterCounts + process.HLTEndSequence )
+process.AlCa_LumiPixelsCounts_Random_v1 = cms.Path( process.HLTBeginSequenceRandom + process.hltScalersRawToDigi + process.hltPixelTrackerHVOn + process.hltPreAlCaLumiPixelsCountsRandom + process.hltSiPixelDigis + process.hltSiPixelClusters + process.hltAlcaPixelClusterCounts + process.HLTEndSequence )
+process.AlCa_LumiPixelsCounts_ZeroBias_v1 = cms.Path( process.HLTBeginSequence + process.hltScalersRawToDigi + process.hltPixelTrackerHVOn + process.hltL1sZeroBias + process.hltPreAlCaLumiPixelsCountsZeroBias + process.hltSiPixelDigis + process.hltSiPixelClusters + process.hltAlcaPixelClusterCounts + process.HLTEndSequence )
 process.HLTriggerFinalPath = cms.Path( process.hltGtStage2Digis + process.hltScalersRawToDigi + process.hltFEDSelector + process.hltTriggerSummaryAOD + process.hltTriggerSummaryRAW + process.hltBoolFalse )
 process.HLTAnalyzerEndpath = cms.EndPath( process.hltGtStage2Digis + process.hltPreHLTAnalyzerEndpath + process.hltL1TGlobalSummary + process.hltTrigReport )
 process.PhysicsCommissioningOutput = cms.EndPath( process.hltGtStage2Digis + process.hltPrePhysicsCommissioningOutput + process.hltOutputPhysicsCommissioning )

--- a/HeterogeneousCore/CUDACore/interface/ESProduct.h
+++ b/HeterogeneousCore/CUDACore/interface/ESProduct.h
@@ -75,6 +75,9 @@ namespace cms {
             transferAsync(data.m_data, cudaStream);
             assert(data.m_fillingStream == nullptr);
             data.m_fillingStream = cudaStream;
+            // Record in the cudaStream an event to mark the readiness of the
+            // EventSetup data on the GPU, so other streams can check for it
+            cudaCheck(cudaEventRecord(data.m_event.get(), cudaStream));
             // Now the filling has been enqueued to the cudaStream, so we
             // can return the GPU data immediately, since all subsequent
             // work must be either enqueued to the cudaStream, or the cudaStream

--- a/PhysicsTools/NanoAOD/python/lowPtElectrons_cff.py
+++ b/PhysicsTools/NanoAOD/python/lowPtElectrons_cff.py
@@ -172,21 +172,23 @@ lowPtElectronMCTable = cms.EDProducer(
 )
 
 ################################################################################
-# Sequences
+# Tasks
 ################################################################################
 
-lowPtElectronSequence = cms.Sequence(modifiedLowPtElectrons
-                                     +updatedLowPtElectrons
-                                     +lowPtPATElectronID
-                                     +isoForLowPtEle
-                                     +updatedLowPtElectronsWithUserData
-                                     +finalLowPtElectrons)
-lowPtElectronTables = cms.Sequence(lowPtElectronTable)
-lowPtElectronMC = cms.Sequence(
-    matchingLowPtElecPhoton
-    +lowPtElectronsMCMatchForTable
-    +lowPtElectronsMCMatchForTableAlt
-    +lowPtElectronMCTable)
+lowPtElectronTask = cms.Task(modifiedLowPtElectrons,
+                             updatedLowPtElectrons,
+                             lowPtPATElectronID,
+                             isoForLowPtEle,
+                             updatedLowPtElectronsWithUserData,
+                             finalLowPtElectrons)
+
+lowPtElectronTablesTask = cms.Task(lowPtElectronTable)
+
+lowPtElectronMCTask = cms.Task(
+    matchingLowPtElecPhoton,
+    lowPtElectronsMCMatchForTable,
+    lowPtElectronsMCMatchForTableAlt,
+    lowPtElectronMCTable)
 
 ################################################################################
 # Modifiers
@@ -198,6 +200,6 @@ _modifiers = ( run2_miniAOD_80XLegacy |
                run2_nanoAOD_94X2016 |
                run2_nanoAOD_102Xv1 |
                run2_nanoAOD_106Xv1 )
-(_modifiers).toReplaceWith(lowPtElectronSequence,cms.Sequence())
-(_modifiers).toReplaceWith(lowPtElectronTables,cms.Sequence())
-(_modifiers).toReplaceWith(lowPtElectronMC,cms.Sequence())
+(_modifiers).toReplaceWith(lowPtElectronTask,cms.Task())
+(_modifiers).toReplaceWith(lowPtElectronTablesTask,cms.Task())
+(_modifiers).toReplaceWith(lowPtElectronMCTask,cms.Task())

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -62,10 +62,10 @@ lhcInfoTable = cms.EDProducer("LHCInfoProducer",
 )
 
 nanoSequenceCommon = cms.Sequence(
-        nanoMetadata + jetSequence + cms.Sequence(extraFlagsProducersTask, muonTask, tauTask, boostedTauTask) + electronSequence + lowPtElectronSequence + photonSequence +
-        cms.Sequence(vertexTablesTask,isoTrackTask) + jetLepSequence + # must be after all the leptons
+        nanoMetadata + jetSequence + cms.Sequence(extraFlagsProducersTask, muonTask, tauTask, boostedTauTask, electronTask, lowPtElectronTask, photonTask,
+        vertexTablesTask,isoTrackTask) + jetLepSequence + # must be after all the leptons
         linkedObjects  +
-        jetTables + cms.Sequence(muonTablesTask,tauTablesTask,boostedTauTablesTask) + electronTables + lowPtElectronTables + photonTables + cms.Sequence(globalTablesTask) + metTables + simpleCleanerTable + cms.Sequence(extraFlagsTableTask,isoTrackTablesTask)
+        jetTables + cms.Sequence(muonTablesTask,tauTablesTask,boostedTauTablesTask) + cms.Sequence(electronTablesTask, lowPtElectronTablesTask, photonTablesTask, globalTablesTask) + metTables + simpleCleanerTable + cms.Sequence(extraFlagsTableTask,isoTrackTablesTask)
         )
 
 nanoSequenceOnlyFullSim = cms.Sequence(triggerObjectTablesTask)
@@ -74,8 +74,8 @@ nanoSequenceOnlyData = cms.Sequence(cms.Sequence(protonTablesTask) + lhcInfoTabl
 nanoSequence = cms.Sequence(nanoSequenceCommon + nanoSequenceOnlyData + nanoSequenceOnlyFullSim)
 
 nanoSequenceFS = cms.Sequence(
-    cms.Sequence(genParticleTask,particleLevelTask) + nanoSequenceCommon + jetMC + cms.Sequence(muonMCTask) + electronMC + lowPtElectronMC + photonMC + 
-    cms.Sequence(tauMCTask,boostedTauMCTask) + metMC +
+    cms.Sequence(genParticleTask,particleLevelTask) + nanoSequenceCommon + jetMC + cms.Sequence(muonMCTask, electronMCTask, lowPtElectronMCTask, photonMCTask,
+    tauMCTask,boostedTauMCTask) + metMC +
     cms.Sequence(ttbarCatMCProducersTask,globalTablesMCTask,cms.Task(btagWeightTable),genWeightsTableTask,genVertexTablesTask,genParticleTablesTask,particleLevelTablesTask,ttbarCategoryTableTask) )
 
 # GenVertex only stored in newer MiniAOD
@@ -150,6 +150,7 @@ def nanoAOD_addDeepMET(process, addDeepMETProducer, ResponseTune_Graph):
 from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncFromMiniAOD
 from PhysicsTools.PatAlgos.slimming.puppiForMET_cff import makePuppiesFromMiniAOD
 def nanoAOD_recalibrateMETs(process,isData):
+
     # add DeepMETs
     nanoAOD_DeepMET_switch = cms.PSet(
         nanoAOD_addDeepMET_switch = cms.untracked.bool(True), # decide if DeeMET should be included in Nano
@@ -184,6 +185,9 @@ def nanoAOD_recalibrateMETs(process,isData):
     for table in process.jetTable, process.corrT1METJetTable:
         table.variables.muonSubtrFactor = Var("1-userFloat('muonSubtrRawPt')/(pt()*jecFactor('Uncorrected'))",float,doc="1-(muon-subtracted raw pt)/(raw pt)",precision=6)
     process.metTables += process.corrT1METJetTable
+
+
+#
 #    makePuppiesFromMiniAOD(process,True) # call this before in the global customizer otherwise it would reset photon IDs in VID
     nanoAOD_PuppiV15_switch = cms.PSet(
             recoMetFromPFCs = cms.untracked.bool(False),
@@ -220,18 +224,25 @@ def nanoAOD_recalibrateMETs(process,isData):
 
 from PhysicsTools.SelectorUtils.tools.vid_id_tools import *
 def nanoAOD_activateVID(process):
-    switchOnVIDElectronIdProducer(process,DataFormat.MiniAOD)
+
+    switchOnVIDElectronIdProducer(process,DataFormat.MiniAOD,electronTask)
     for modname in electron_id_modules_WorkingPoints_nanoAOD.modules:
         setupAllVIDIdsInModule(process,modname,setupVIDElectronSelection)
-    process.electronSequence.insert(process.electronSequence.index(process.bitmapVIDForEle),process.egmGsfElectronIDSequence)
+
+    electronTask_ = process.egmGsfElectronIDTask.copy()
+    electronTask_.add(electronTask.copy())
+    process.electronTask = electronTask_.copy()
     for modifier in run2_miniAOD_80XLegacy,run2_nanoAOD_94XMiniAODv1,run2_nanoAOD_94XMiniAODv2,run2_nanoAOD_94X2016,run2_nanoAOD_102Xv1,run2_nanoAOD_106Xv1:
         modifier.toModify(process.electronMVAValueMapProducer, src = "slimmedElectronsUpdated")
         modifier.toModify(process.egmGsfElectronIDs, physicsObjectSrc = "slimmedElectronsUpdated")
 
-    switchOnVIDPhotonIdProducer(process,DataFormat.MiniAOD) # do not call this to avoid resetting photon IDs in VID, if called before inside makePuppiesFromMiniAOD
+    switchOnVIDPhotonIdProducer(process,DataFormat.MiniAOD,photonTask) # do not call this to avoid resetting photon IDs in VID, if called before inside makePuppiesFromMiniAOD
     for modname in photon_id_modules_WorkingPoints_nanoAOD.modules:
         setupAllVIDIdsInModule(process,modname,setupVIDPhotonSelection)
-    process.photonSequence.insert(process.photonSequence.index(bitmapVIDForPho),process.egmPhotonIDSequence)
+
+    photonTask_ = process.egmPhotonIDTask.copy()
+    photonTask_.add(photonTask.copy())
+    process.photonTak = photonTask_.copy()
     for modifier in run2_miniAOD_80XLegacy,run2_nanoAOD_94XMiniAODv1,run2_nanoAOD_94XMiniAODv2,run2_nanoAOD_94X2016,run2_nanoAOD_102Xv1:
         modifier.toModify(process.photonMVAValueMapProducer, src = "slimmedPhotonsTo106X")
         modifier.toModify(process.egmPhotonIDs, physicsObjectSrc = "slimmedPhotonsTo106X")

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -65,7 +65,7 @@ nanoSequenceCommon = cms.Sequence(
         nanoMetadata + jetSequence + cms.Sequence(extraFlagsProducersTask, muonTask, tauTask, boostedTauTask, electronTask, lowPtElectronTask, photonTask,
         vertexTablesTask,isoTrackTask) + jetLepSequence + # must be after all the leptons
         linkedObjects  +
-        jetTables + cms.Sequence(muonTablesTask,tauTablesTask,boostedTauTablesTask) + cms.Sequence(electronTablesTask, lowPtElectronTablesTask, photonTablesTask, globalTablesTask) + metTables + simpleCleanerTable + cms.Sequence(extraFlagsTableTask,isoTrackTablesTask)
+        jetTables + cms.Sequence(muonTablesTask, tauTablesTask, boostedTauTablesTask, electronTablesTask, lowPtElectronTablesTask, photonTablesTask, globalTablesTask) + metTables + simpleCleanerTable + cms.Sequence(extraFlagsTableTask,isoTrackTablesTask)
         )
 
 nanoSequenceOnlyFullSim = cms.Sequence(triggerObjectTablesTask)
@@ -242,7 +242,7 @@ def nanoAOD_activateVID(process):
 
     photonTask_ = process.egmPhotonIDTask.copy()
     photonTask_.add(photonTask.copy())
-    process.photonTak = photonTask_.copy()
+    process.photonTask = photonTask_.copy()
     for modifier in run2_miniAOD_80XLegacy,run2_nanoAOD_94XMiniAODv1,run2_nanoAOD_94XMiniAODv2,run2_nanoAOD_94X2016,run2_nanoAOD_102Xv1:
         modifier.toModify(process.photonMVAValueMapProducer, src = "slimmedPhotonsTo106X")
         modifier.toModify(process.egmPhotonIDs, physicsObjectSrc = "slimmedPhotonsTo106X")

--- a/PhysicsTools/NanoAOD/python/photons_cff.py
+++ b/PhysicsTools/NanoAOD/python/photons_cff.py
@@ -113,6 +113,7 @@ run2_miniAOD_80XLegacy.toModify(calibratedPatPhotonsNano,
                                 correctionFile = cms.string("EgammaAnalysis/ElectronTools/data/ScalesSmearings/Legacy2016_07Aug2017_FineEtaR9_v3_ele_unc")
 )
 
+
 slimmedPhotonsWithUserData = cms.EDProducer("PATPhotonUserDataEmbedder",
     src = cms.InputTag("slimmedPhotons"),
     userFloats = cms.PSet(
@@ -139,12 +140,12 @@ slimmedPhotonsWithUserData = cms.EDProducer("PATPhotonUserDataEmbedder",
     ),
     userInts = cms.PSet(
         VIDNestedWPBitmap = cms.InputTag("bitmapVIDForPho"),
-        VIDNestedWPBitmap_Spring16V2p2 = cms.InputTag("bitmapVIDForPhoSpring16V2p2"),
         seedGain = cms.InputTag("seedGainPho"),
     )
 )
 
-for modifier in run2_egamma_2016, run2_egamma_2017, run2_egamma_2018, run2_miniAOD_80XLegacy, run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2, run2_nanoAOD_102Xv1:
+
+for modifier in run2_egamma_2016, run2_egamma_2017, run2_egamma_2018:
     modifier.toModify(slimmedPhotonsWithUserData.userFloats,
                       ecalEnergyErrPostCorrNew = cms.InputTag("calibratedPatPhotonsNano","ecalEnergyErrPostCorr"),
                       ecalEnergyPreCorrNew     = cms.InputTag("calibratedPatPhotonsNano","ecalEnergyPreCorr"),
@@ -206,22 +207,6 @@ photonTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
         mvaID_Fall17V1p1 = Var("userFloat('mvaID_Fall17V1p1')",float,doc="MVA ID score, Fall17V1p1",precision=10),
         mvaID_WP90 = Var("userInt('mvaID_WP90')",bool,doc="MVA ID WP90, Fall17V2"),
         mvaID_WP80 = Var("userInt('mvaID_WP80')",bool,doc="MVA ID WP80, Fall17V2"),
-        cutBased_Spring16V2p2 = Var(
-            "userInt('cutID_Spring16_loose')+userInt('cutID_Spring16_medium')+userInt('cutID_Spring16_tight')",
-            int,
-            doc="cut-based ID bitmap, Spring16V2p2, (0:fail, 1:loose, 2:medium, 3:tight)"
-        ),
-        mvaID_Spring16nonTrigV1 = Var(
-            "userFloat('mvaID_Spring16nonTrigV1')",
-            float,
-            doc="MVA ID score, Spring16nonTrigV1",
-            precision=10
-        ),
-        vidNestedWPBitmap_Spring16V2p2 = Var(
-            "userInt('VIDNestedWPBitmap_Spring16V2p2')",
-            int,
-            doc="Spring16V2p2 " + make_bitmapVID_docstring(photon_id_modules_WorkingPoints_nanoAOD_Spring16V2p2)
-        ),
         pfRelIso03_chg = Var("userFloat('PFIsoChg')/pt",float,doc="PF relative isolation dR=0.3, charged component (with rho*EA PU corrections)"),
         pfRelIso03_all = Var("userFloat('PFIsoAll')/pt",float,doc="PF relative isolation dR=0.3, total (with rho*EA PU corrections)"),
         hoe = Var("hadronicOverEm()",float,doc="H over E",precision=8),
@@ -233,7 +218,7 @@ photonTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
 
 
 #these eras need to make the energy correction, hence the "New"
-for modifier in run2_egamma_2016,run2_egamma_2017,run2_egamma_2018,run2_nanoAOD_94XMiniAODv1, run2_miniAOD_80XLegacy, run2_nanoAOD_102Xv1,run2_nanoAOD_94XMiniAODv2:
+for modifier in run2_egamma_2016, run2_egamma_2017, run2_egamma_2018 :
     modifier.toModify(photonTable.variables,
         pt = Var("pt*userFloat('ecalEnergyPostCorrNew')/userFloat('ecalEnergyPreCorrNew')", float, precision=-1, doc="p_{T}"),
         energyErr = Var("userFloat('ecalEnergyErrPostCorrNew')",float,doc="energy error of the cluster from regression",precision=6),
@@ -249,13 +234,30 @@ for modifier in run2_nanoAOD_94X2016,:
                       
     )
 
-# only add the Spring16 IDs for 2016 nano
-(~(run2_nanoAOD_94X2016 | run2_miniAOD_80XLegacy)).toModify(photonTable.variables,
-    cutBased_Spring16V2p2 = None,
-    mvaID_Spring16nonTrigV1 = None,
-    vidNestedWPBitmap_Spring16V2p2 = None,
-)
+for modifier in run2_nanoAOD_94X2016, run2_miniAOD_80XLegacy:
+    modifier.toModify(slimmedPhotonsWithUserData.userInts,
+        VIDNestedWPBitmap_Spring16V2p2 = cms.InputTag("bitmapVIDForPhoSpring16V2p2"),
+    )
 
+for modifier in run2_nanoAOD_94X2016, run2_miniAOD_80XLegacy:
+   modifier.toModify(photonTable.variables,
+        cutBased_Spring16V2p2 = Var(
+            "userInt('cutID_Spring16_loose')+userInt('cutID_Spring16_medium')+userInt('cutID_Spring16_tight')",
+            int,
+            doc="cut-based ID bitmap, Spring16V2p2, (0:fail, 1:loose, 2:medium, 3:tight)"
+        ),
+        vidNestedWPBitmap_Spring16V2p2 = Var(
+            "userInt('VIDNestedWPBitmap_Spring16V2p2')",
+            int,
+            doc="Spring16V2p2 " + make_bitmapVID_docstring(photon_id_modules_WorkingPoints_nanoAOD_Spring16V2p2)
+        ),
+        mvaID_Spring16nonTrigV1 = Var(
+            "userFloat('mvaID_Spring16nonTrigV1')",
+            float,
+            doc="MVA ID score, Spring16nonTrigV1",
+            precision=10
+        ),
+    )
 
 photonsMCMatchForTable = cms.EDProducer("MCMatcher",  # cut on deltaR, deltaPt/Pt; pick best by deltaR
     src         = photonTable.src,                 # final reco collection
@@ -297,7 +299,7 @@ for modifier in run2_miniAOD_80XLegacy,run2_nanoAOD_94XMiniAODv1,run2_nanoAOD_94
 
 
 ##adding 4 most imp scale & smearing variables to table
-for modifier in run2_nanoAOD_106Xv1,run2_nanoAOD_106Xv2,run2_egamma_2016,run2_egamma_2017,run2_egamma_2018,run2_miniAOD_80XLegacy, run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2,run2_nanoAOD_102Xv1:
+for modifier in run2_egamma_2016, run2_egamma_2017, run2_egamma_2018:
     modifier.toModify(photonTable.variables,
                       dEscaleUp=Var("userFloat('ecalEnergyPostCorrNew') - userFloat('energyScaleUpNew')", float, doc="ecal energy scale shifted 1 sigma up (adding gain/stat/syst in quadrature)", precision=8),
                       dEscaleDown=Var("userFloat('ecalEnergyPostCorrNew') - userFloat('energyScaleDownNew')", float, doc="ecal energy scale shifted 1 sigma down (adding gain/stat/syst in quadrature)", precision=8),
@@ -313,60 +315,20 @@ for modifier in run2_nanoAOD_94X2016,:
                       dEsigmaDown=Var("userFloat('ecalEnergyPostCorr') - userFloat('energySigmaDown')", float,  doc="ecal energy smearing value shifted 1 sigma up", precision=8),
     )
 
-photonSequence = cms.Sequence(
-        bitmapVIDForPho + \
-        bitmapVIDForPhoSpring16V2p2 + \
-        isoForPho + \
-        seedGainPho + \
-        slimmedPhotonsWithUserData + \
-        finalPhotons
-)
-
-photonTables = cms.Sequence ( photonTable)
-photonMC = cms.Sequence(photonsMCMatchForTable + photonMCTable)
+photonTask = cms.Task(bitmapVIDForPho, isoForPho, seedGainPho, calibratedPatPhotonsNano, slimmedPhotonsWithUserData, finalPhotons)
+photonTablesTask = cms.Task(photonTable)
+photonMCTask = cms.Task(photonsMCMatchForTable, photonMCTable)
 
 from RecoEgamma.EgammaIsolationAlgos.egmPhotonIsolationMiniAOD_cff import egmPhotonIsolation
 from RecoEgamma.PhotonIdentification.photonIDValueMapProducer_cff import photonIDValueMapProducer
 
-_withUpdatePho_sequence = photonSequence.copy() ###copy first for non-ULs else it just takes the UL sequence
+_withUpdatePho_Task = cms.Task(egmPhotonIsolation,photonIDValueMapProducer,slimmedPhotonsTo106X)
+_withUpdatePho_Task.add(photonTask.copy())
 
-
-###UL to be done first
-_withUL16preVFPScale_sequence = photonSequence.copy()
-_withUL16preVFPScale_sequence.replace(slimmedPhotonsWithUserData, calibratedPatPhotonsNano  + slimmedPhotonsWithUserData)
-(run2_egamma_2016 & tracker_apv_vfp30_2016).toReplaceWith(photonSequence, _withUL16preVFPScale_sequence)
-
-_withUL16postVFPScale_sequence = photonSequence.copy()
-_withUL16postVFPScale_sequence.replace(slimmedPhotonsWithUserData, calibratedPatPhotonsNano  + slimmedPhotonsWithUserData)
-(run2_egamma_2016 & ~tracker_apv_vfp30_2016).toReplaceWith(photonSequence, _withUL16postVFPScale_sequence)
-
-_withUL17Scale_sequence = photonSequence.copy()
-_withUL17Scale_sequence.replace(slimmedPhotonsWithUserData, calibratedPatPhotonsNano  + slimmedPhotonsWithUserData)
-run2_egamma_2017.toReplaceWith(photonSequence, _withUL17Scale_sequence)
-
-_withUL18Scale_sequence = photonSequence.copy()
-_withUL18Scale_sequence.replace(slimmedPhotonsWithUserData, calibratedPatPhotonsNano  + slimmedPhotonsWithUserData)
-run2_egamma_2018.toReplaceWith(photonSequence, _withUL18Scale_sequence)
-
-
-_updatePhoTo106X_sequence =cms.Sequence(egmPhotonIsolation + photonIDValueMapProducer + slimmedPhotonsTo106X)
-_withUpdatePho_sequence.insert(0,_updatePhoTo106X_sequence)
 for modifier in run2_nanoAOD_94XMiniAODv2,run2_nanoAOD_94X2016 ,run2_nanoAOD_102Xv1,run2_nanoAOD_94XMiniAODv1:
-    modifier.toReplaceWith(photonSequence, _withUpdatePho_sequence)
+    modifier.toReplaceWith(photonTask, _withUpdatePho_Task)
 
-
-_with80XScale_sequence = _withUpdatePho_sequence.copy()
-_with80XScale_sequence.replace(slimmedPhotonsWithUserData, calibratedPatPhotonsNano  + slimmedPhotonsWithUserData)
-run2_miniAOD_80XLegacy.toReplaceWith(photonSequence, _with80XScale_sequence)
-
-_with94Xv1Scale_sequence = _withUpdatePho_sequence.copy()
-_with94Xv1Scale_sequence.replace(slimmedPhotonsWithUserData, calibratedPatPhotonsNano + slimmedPhotonsWithUserData)
-run2_nanoAOD_94XMiniAODv1.toReplaceWith(photonSequence, _with94Xv1Scale_sequence)
-
-_with94Xv2Scale_sequence = _withUpdatePho_sequence.copy()
-_with94Xv2Scale_sequence.replace(slimmedPhotonsWithUserData, calibratedPatPhotonsNano + slimmedPhotonsWithUserData)
-run2_nanoAOD_94XMiniAODv2.toReplaceWith(photonSequence, _with94Xv2Scale_sequence)
-
-_with102Xv1Scale_sequence = photonSequence.copy()
-_with102Xv1Scale_sequence.replace(slimmedPhotonsWithUserData, calibratedPatPhotonsNano + slimmedPhotonsWithUserData)
-run2_nanoAOD_102Xv1.toReplaceWith(photonSequence, _with102Xv1Scale_sequence)
+for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016:
+    _withSpring16V2p2_Task = cms.Task(bitmapVIDForPhoSpring16V2p2)
+    _withSpring16V2p2_Task.add(_withUpdatePho_Task.copy())
+    modifier.toReplaceWith(photonTask, _withSpring16V2p2_Task)

--- a/PhysicsTools/NanoAOD/python/photons_cff.py
+++ b/PhysicsTools/NanoAOD/python/photons_cff.py
@@ -145,7 +145,7 @@ slimmedPhotonsWithUserData = cms.EDProducer("PATPhotonUserDataEmbedder",
 )
 
 
-for modifier in run2_egamma_2016, run2_egamma_2017, run2_egamma_2018, run2_miniAOD_80XLegacy, run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2, run2_nanoAOD_102Xv1:
+for modifier in run2_egamma_2016, run2_egamma_2017, run2_egamma_2018:
     modifier.toModify(slimmedPhotonsWithUserData.userFloats,
                       ecalEnergyErrPostCorrNew = cms.InputTag("calibratedPatPhotonsNano","ecalEnergyErrPostCorr"),
                       ecalEnergyPreCorrNew     = cms.InputTag("calibratedPatPhotonsNano","ecalEnergyPreCorr"),
@@ -218,7 +218,7 @@ photonTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
 
 
 #these eras need to make the energy correction, hence the "New"
-for modifier in run2_egamma_2016,run2_egamma_2017,run2_egamma_2018,run2_nanoAOD_94XMiniAODv1, run2_miniAOD_80XLegacy, run2_nanoAOD_102Xv1,run2_nanoAOD_94XMiniAODv2:
+for modifier in run2_egamma_2016, run2_egamma_2017, run2_egamma_2018 :
     modifier.toModify(photonTable.variables,
         pt = Var("pt*userFloat('ecalEnergyPostCorrNew')/userFloat('ecalEnergyPreCorrNew')", float, precision=-1, doc="p_{T}"),
         energyErr = Var("userFloat('ecalEnergyErrPostCorrNew')",float,doc="energy error of the cluster from regression",precision=6),
@@ -299,7 +299,7 @@ for modifier in run2_miniAOD_80XLegacy,run2_nanoAOD_94XMiniAODv1,run2_nanoAOD_94
 
 
 ##adding 4 most imp scale & smearing variables to table
-for modifier in run2_nanoAOD_106Xv1,run2_nanoAOD_106Xv2,run2_egamma_2016,run2_egamma_2017,run2_egamma_2018,run2_miniAOD_80XLegacy, run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2,run2_nanoAOD_102Xv1:
+for modifier in run2_egamma_2016, run2_egamma_2017, run2_egamma_2018:
     modifier.toModify(photonTable.variables,
                       dEscaleUp=Var("userFloat('ecalEnergyPostCorrNew') - userFloat('energyScaleUpNew')", float, doc="ecal energy scale shifted 1 sigma up (adding gain/stat/syst in quadrature)", precision=8),
                       dEscaleDown=Var("userFloat('ecalEnergyPostCorrNew') - userFloat('energyScaleDownNew')", float, doc="ecal energy scale shifted 1 sigma down (adding gain/stat/syst in quadrature)", precision=8),

--- a/PhysicsTools/NanoAOD/python/photons_cff.py
+++ b/PhysicsTools/NanoAOD/python/photons_cff.py
@@ -113,6 +113,7 @@ run2_miniAOD_80XLegacy.toModify(calibratedPatPhotonsNano,
                                 correctionFile = cms.string("EgammaAnalysis/ElectronTools/data/ScalesSmearings/Legacy2016_07Aug2017_FineEtaR9_v3_ele_unc")
 )
 
+
 slimmedPhotonsWithUserData = cms.EDProducer("PATPhotonUserDataEmbedder",
     src = cms.InputTag("slimmedPhotons"),
     userFloats = cms.PSet(
@@ -139,10 +140,10 @@ slimmedPhotonsWithUserData = cms.EDProducer("PATPhotonUserDataEmbedder",
     ),
     userInts = cms.PSet(
         VIDNestedWPBitmap = cms.InputTag("bitmapVIDForPho"),
-        VIDNestedWPBitmap_Spring16V2p2 = cms.InputTag("bitmapVIDForPhoSpring16V2p2"),
         seedGain = cms.InputTag("seedGainPho"),
     )
 )
+
 
 for modifier in run2_egamma_2016, run2_egamma_2017, run2_egamma_2018, run2_miniAOD_80XLegacy, run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2, run2_nanoAOD_102Xv1:
     modifier.toModify(slimmedPhotonsWithUserData.userFloats,
@@ -206,22 +207,6 @@ photonTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
         mvaID_Fall17V1p1 = Var("userFloat('mvaID_Fall17V1p1')",float,doc="MVA ID score, Fall17V1p1",precision=10),
         mvaID_WP90 = Var("userInt('mvaID_WP90')",bool,doc="MVA ID WP90, Fall17V2"),
         mvaID_WP80 = Var("userInt('mvaID_WP80')",bool,doc="MVA ID WP80, Fall17V2"),
-        cutBased_Spring16V2p2 = Var(
-            "userInt('cutID_Spring16_loose')+userInt('cutID_Spring16_medium')+userInt('cutID_Spring16_tight')",
-            int,
-            doc="cut-based ID bitmap, Spring16V2p2, (0:fail, 1:loose, 2:medium, 3:tight)"
-        ),
-        mvaID_Spring16nonTrigV1 = Var(
-            "userFloat('mvaID_Spring16nonTrigV1')",
-            float,
-            doc="MVA ID score, Spring16nonTrigV1",
-            precision=10
-        ),
-        vidNestedWPBitmap_Spring16V2p2 = Var(
-            "userInt('VIDNestedWPBitmap_Spring16V2p2')",
-            int,
-            doc="Spring16V2p2 " + make_bitmapVID_docstring(photon_id_modules_WorkingPoints_nanoAOD_Spring16V2p2)
-        ),
         pfRelIso03_chg = Var("userFloat('PFIsoChg')/pt",float,doc="PF relative isolation dR=0.3, charged component (with rho*EA PU corrections)"),
         pfRelIso03_all = Var("userFloat('PFIsoAll')/pt",float,doc="PF relative isolation dR=0.3, total (with rho*EA PU corrections)"),
         hoe = Var("hadronicOverEm()",float,doc="H over E",precision=8),
@@ -249,13 +234,30 @@ for modifier in run2_nanoAOD_94X2016,:
                       
     )
 
-# only add the Spring16 IDs for 2016 nano
-(~(run2_nanoAOD_94X2016 | run2_miniAOD_80XLegacy)).toModify(photonTable.variables,
-    cutBased_Spring16V2p2 = None,
-    mvaID_Spring16nonTrigV1 = None,
-    vidNestedWPBitmap_Spring16V2p2 = None,
-)
+for modifier in run2_nanoAOD_94X2016, run2_miniAOD_80XLegacy:
+    modifier.toModify(slimmedPhotonsWithUserData.userInts,
+        VIDNestedWPBitmap_Spring16V2p2 = cms.InputTag("bitmapVIDForPhoSpring16V2p2"),
+    )
 
+for modifier in run2_nanoAOD_94X2016, run2_miniAOD_80XLegacy:
+   modifier.toModify(photonTable.variables,
+        cutBased_Spring16V2p2 = Var(
+            "userInt('cutID_Spring16_loose')+userInt('cutID_Spring16_medium')+userInt('cutID_Spring16_tight')",
+            int,
+            doc="cut-based ID bitmap, Spring16V2p2, (0:fail, 1:loose, 2:medium, 3:tight)"
+        ),
+        vidNestedWPBitmap_Spring16V2p2 = Var(
+            "userInt('VIDNestedWPBitmap_Spring16V2p2')",
+            int,
+            doc="Spring16V2p2 " + make_bitmapVID_docstring(photon_id_modules_WorkingPoints_nanoAOD_Spring16V2p2)
+        ),
+        mvaID_Spring16nonTrigV1 = Var(
+            "userFloat('mvaID_Spring16nonTrigV1')",
+            float,
+            doc="MVA ID score, Spring16nonTrigV1",
+            precision=10
+        ),
+    )
 
 photonsMCMatchForTable = cms.EDProducer("MCMatcher",  # cut on deltaR, deltaPt/Pt; pick best by deltaR
     src         = photonTable.src,                 # final reco collection
@@ -313,60 +315,20 @@ for modifier in run2_nanoAOD_94X2016,:
                       dEsigmaDown=Var("userFloat('ecalEnergyPostCorr') - userFloat('energySigmaDown')", float,  doc="ecal energy smearing value shifted 1 sigma up", precision=8),
     )
 
-photonSequence = cms.Sequence(
-        bitmapVIDForPho + \
-        bitmapVIDForPhoSpring16V2p2 + \
-        isoForPho + \
-        seedGainPho + \
-        slimmedPhotonsWithUserData + \
-        finalPhotons
-)
-
-photonTables = cms.Sequence ( photonTable)
-photonMC = cms.Sequence(photonsMCMatchForTable + photonMCTable)
+photonTask = cms.Task(bitmapVIDForPho, isoForPho, seedGainPho, calibratedPatPhotonsNano, slimmedPhotonsWithUserData, finalPhotons)
+photonTablesTask = cms.Task(photonTable)
+photonMCTask = cms.Task(photonsMCMatchForTable, photonMCTable)
 
 from RecoEgamma.EgammaIsolationAlgos.egmPhotonIsolationMiniAOD_cff import egmPhotonIsolation
 from RecoEgamma.PhotonIdentification.photonIDValueMapProducer_cff import photonIDValueMapProducer
 
-_withUpdatePho_sequence = photonSequence.copy() ###copy first for non-ULs else it just takes the UL sequence
+_withUpdatePho_Task = cms.Task(egmPhotonIsolation,photonIDValueMapProducer,slimmedPhotonsTo106X)
+_withUpdatePho_Task.add(photonTask.copy())
 
-
-###UL to be done first
-_withUL16preVFPScale_sequence = photonSequence.copy()
-_withUL16preVFPScale_sequence.replace(slimmedPhotonsWithUserData, calibratedPatPhotonsNano  + slimmedPhotonsWithUserData)
-(run2_egamma_2016 & tracker_apv_vfp30_2016).toReplaceWith(photonSequence, _withUL16preVFPScale_sequence)
-
-_withUL16postVFPScale_sequence = photonSequence.copy()
-_withUL16postVFPScale_sequence.replace(slimmedPhotonsWithUserData, calibratedPatPhotonsNano  + slimmedPhotonsWithUserData)
-(run2_egamma_2016 & ~tracker_apv_vfp30_2016).toReplaceWith(photonSequence, _withUL16postVFPScale_sequence)
-
-_withUL17Scale_sequence = photonSequence.copy()
-_withUL17Scale_sequence.replace(slimmedPhotonsWithUserData, calibratedPatPhotonsNano  + slimmedPhotonsWithUserData)
-run2_egamma_2017.toReplaceWith(photonSequence, _withUL17Scale_sequence)
-
-_withUL18Scale_sequence = photonSequence.copy()
-_withUL18Scale_sequence.replace(slimmedPhotonsWithUserData, calibratedPatPhotonsNano  + slimmedPhotonsWithUserData)
-run2_egamma_2018.toReplaceWith(photonSequence, _withUL18Scale_sequence)
-
-
-_updatePhoTo106X_sequence =cms.Sequence(egmPhotonIsolation + photonIDValueMapProducer + slimmedPhotonsTo106X)
-_withUpdatePho_sequence.insert(0,_updatePhoTo106X_sequence)
 for modifier in run2_nanoAOD_94XMiniAODv2,run2_nanoAOD_94X2016 ,run2_nanoAOD_102Xv1,run2_nanoAOD_94XMiniAODv1:
-    modifier.toReplaceWith(photonSequence, _withUpdatePho_sequence)
+    modifier.toReplaceWith(photonTask, _withUpdatePho_Task)
 
-
-_with80XScale_sequence = _withUpdatePho_sequence.copy()
-_with80XScale_sequence.replace(slimmedPhotonsWithUserData, calibratedPatPhotonsNano  + slimmedPhotonsWithUserData)
-run2_miniAOD_80XLegacy.toReplaceWith(photonSequence, _with80XScale_sequence)
-
-_with94Xv1Scale_sequence = _withUpdatePho_sequence.copy()
-_with94Xv1Scale_sequence.replace(slimmedPhotonsWithUserData, calibratedPatPhotonsNano + slimmedPhotonsWithUserData)
-run2_nanoAOD_94XMiniAODv1.toReplaceWith(photonSequence, _with94Xv1Scale_sequence)
-
-_with94Xv2Scale_sequence = _withUpdatePho_sequence.copy()
-_with94Xv2Scale_sequence.replace(slimmedPhotonsWithUserData, calibratedPatPhotonsNano + slimmedPhotonsWithUserData)
-run2_nanoAOD_94XMiniAODv2.toReplaceWith(photonSequence, _with94Xv2Scale_sequence)
-
-_with102Xv1Scale_sequence = photonSequence.copy()
-_with102Xv1Scale_sequence.replace(slimmedPhotonsWithUserData, calibratedPatPhotonsNano + slimmedPhotonsWithUserData)
-run2_nanoAOD_102Xv1.toReplaceWith(photonSequence, _with102Xv1Scale_sequence)
+for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016:
+    _withSpring16V2p2_Task = cms.Task(bitmapVIDForPhoSpring16V2p2)
+    _withSpring16V2p2_Task.add(_withUpdatePho_Task.copy())
+    modifier.toReplaceWith(photonTask, _withSpring16V2p2_Task)

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitProducerGPU.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitProducerGPU.cc
@@ -213,7 +213,9 @@ void EcalUncalibRecHitProducerGPU::acquire(edm::Event const& event,
 
   if ((neb_ > configParameters_.maxNumberHitsEB) || (nee_ > configParameters_.maxNumberHitsEE)) {
     edm::LogError("EcalUncalibRecHitProducerGPU")
-        << "max number of channels exceeded. See options 'maxNumberHitsEB and maxNumberHitsEE' ";
+        << "Max number of channels exceeded in barrel or endcap. Number of barrel channels: " << neb_
+        << " with maxNumberHitsEB=" << configParameters_.maxNumberHitsEB << ", number of endcap channels: " << nee_
+        << " with maxNumberHitsEE=" << configParameters_.maxNumberHitsEE;
   }
 
   // conditions

--- a/SimG4CMS/Calo/src/HCalSD.cc
+++ b/SimG4CMS/Calo/src/HCalSD.cc
@@ -137,6 +137,8 @@ HCalSD::HCalSD(const std::string& name,
   if (forTBHC) {
     useHF = false;
     matNames.emplace_back("Scintillator");
+  } else {
+    matNames = hcalSimConstants_->hcalsimpar()->hcalMaterialNames_;
   }
 
   HcalNumberingScheme* scheme;
@@ -508,11 +510,13 @@ double HCalSD::getEnergyDeposit(const G4Step* aStep) {
       }
     }
   }
+  double wt0(1.0);
   if (useBirk) {
     const G4Material* mat = aStep->GetPreStepPoint()->GetMaterial();
     if (isItScintillator(mat))
-      weight_ *= getAttenuation(aStep, birk1, birk2, birk3);
+      wt0 = getAttenuation(aStep, birk1, birk2, birk3);
   }
+  weight_ *= wt0;
   double wt1 = getResponseWt(theTrack);
   double wt2 = theTrack->GetWeight();
   double edep = weight_ * wt1 * destep;
@@ -521,7 +525,7 @@ double HCalSD::getEnergyDeposit(const G4Step* aStep) {
   }
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HcalSim") << "HCalSD: edep= " << edep << " Det: " << det + 2 << " depth= " << depth_
-                              << " weight= " << weight_ << " wt1= " << wt1 << " wt2= " << wt2;
+                              << " weight= " << weight_ << " wt0= " << wt0 << " wt1= " << wt1 << " wt2= " << wt2;
 #endif
   return edep;
 }

--- a/SimG4CMS/Calo/test/python/minbias_cfg.py
+++ b/SimG4CMS/Calo/test/python/minbias_cfg.py
@@ -13,6 +13,7 @@ process.load("Configuration.EventContent.EventContent_cff")
 process.load('Configuration.StandardSequences.Generator_cff')
 process.load('Configuration.StandardSequences.SimIdeal_cff')
 process.load("SimG4CMS.Calo.CaloSimHitStudy_cfi")
+process.load("SimG4CMS.Calo.hcalSimHitDump_cfi")
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.autoCond import autoCond
@@ -21,6 +22,7 @@ process.GlobalTag.globaltag = autoCond['run2_mc']
 if 'MessageLogger' in process.__dict__:
     process.MessageLogger.G4cerr=dict()
     process.MessageLogger.HitStudy=dict()
+    process.MessageLogger.HcalSim=dict()
 
 process.source = cms.Source("EmptySource")
 
@@ -55,13 +57,14 @@ process.output = cms.OutputModule("PoolOutputModule",
 
 process.generation_step = cms.Path(process.pgen)
 process.simulation_step = cms.Path(process.psim)
-process.analysis_step   = cms.Path(process.CaloSimHitStudy)
+process.analysis_step   = cms.Path(process.CaloSimHitStudy+process.hcalSimHitDump)
 process.out_step = cms.EndPath(process.output)
 
 process.generator.pythiaHepMCVerbosity = False
 process.generator.pythiaPylistVerbosity = 0
 process.g4SimHits.Physics.type = 'SimG4Core/Physics/FTFP_BERT_EMM'
 process.CaloSimHitStudy.TestNumbering = True
+process.hcalSimHitDump.MaxEvent = 5
 
 # process.g4SimHits.ECalSD.IgnoreTrackID      = True
 # process.g4SimHits.HCalSD.IgnoreTrackID      = True

--- a/Validation/RecoTrack/python/plotting/plotting.py
+++ b/Validation/RecoTrack/python/plotting/plotting.py
@@ -446,12 +446,12 @@ def _getYminMaxAroundMedian(obj, coverage, coverageRange=None):
     if nvals < 2:
         # Take median and +- 1 values
         if len(yvals) % 2 == 0:
-            half = len(yvals)/2
+            half = len(yvals) // 2
             return ( yvals[half-1], yvals[half] )
         else:
-            middle = len(yvals)/2
+            middle = len(yvals) // 2
             return ( yvals[middle-1], yvals[middle+1] )
-    ind_min = (len(yvals)-nvals)/2
+    ind_min = (len(yvals)-nvals) // 2
     ind_max = len(yvals)-1 - ind_min
 
     return (yvals[ind_min], yvals[ind_max])


### PR DESCRIPTION
#### PR description:

Move to https://github.com/cms-sw/cmssw/pull/34788

This PR is to fix two issues when L1REPACK is used for Run3. The error messages w/o this PR is mentioned at the end of the PR description.
(1) no GEM unpacker defined in SimL1EmulatorRepack. It is solved in this PR.
(2) when hltGetConfiguration is used, GEM geometry is not loaded properly. This PR introduced a temporary fix.

#### PR validation:
The RAW input can be picked from `/afs/cern.ch/user/s/srimanob/public/ForGEML1T/step2.root`. It is a RAW file produced from CMSSW_12_0_0_pre4 with wf 11634.21.

To test (1), the following cmsDriver run fine.
`cmsDriver.py --process reHLT -s L1REPACK:FullMC,HLT:@relval2021 --conditions auto:phase1_2021_realistic --datatier GEN-SIM-RAW -n -1 --eventcontent RAWSIM --geometry DB:Extended --era Run3 --filein file:step2.root --fileout file:step3_reHLT.root --python reHLT_ProdLike_2021.py --no_exec`

To test (2), the following config can run fine.
`hltGetConfiguration /dev/CMSSW_12_0_0/GRun/V2 --process reHLT --globaltag auto:phase1_2021_realistic  --mc --unprescale --paths HLTriggerFirstPath,HLT_IsoMu24_v13,HLT_Mu50_v13,HLTriggerFinalPath --output minimal --input file:step2.root --l1-emulator FullMC --customise HLTrigger/Configuration/customizeHLTforCMSSW.customiseForRun3GEMGeometry > test_reHLT.py`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
Not a backport, and no need of backport

#### Note
Issue of (1): solved in this PR
```
----- Begin Fatal Exception 05-Aug-2021 05:33:59 CEST-----------------------
An exception of category 'ProductNotFound' occurred while
   [0] Processing  Event run: 1 lumi: 1 event: 1 stream: 0
   [1] Running path 'HLTAnalyzerEndpath'
   [2] Prefetching for module L1TRawToDigi/'hltGtStage2Digis'
   [3] Prefetching for module RawDataCollectorByLabel/'rawDataCollector'
   [4] Prefetching for module L1TDigiToRaw/'packGmtStage2'
   [5] Prefetching for module L1TMuonOverlapTrackProducer/'simOmtfDigis'
   [6] Prefetching for module CSCTriggerPrimitivesProducer/'simCscTriggerPrimitiveDigis'
   [7] Prefetching for module GEMPadDigiClusterProducer/'simMuonGEMPadDigiClusters'
   [8] Calling method for module GEMPadDigiProducer/'simMuonGEMPadDigis'
Exception Message:
Principal::getByToken: Found zero products matching all criteria
Looking for type: MuonDigiCollection<GEMDetId,GEMDigi>
Looking for module label: simMuonGEMDigis
Looking for productInstanceName: 
```

Issue of (2): temporary solution is provided for now
```
----- Begin Fatal Exception 05-Aug-2021 05:59:31 CEST-----------------------
An exception of category 'NoProxyException' occurred while
   [0] Processing  stream begin Run run: 1 stream: 1
   [1] Calling method for module GEMPadDigiClusterProducer/'simMuonGEMPadDigiClusters'
Exception Message:
No data of type "GEMGeometry" with label "" in record "MuonGeometryRecord"
 Please add an ESSource or ESProducer to your job which can deliver this data.
----- End Fatal Exception -------------------------------------------------
----- Begin Fatal Exception 05-Aug-2021 05:59:31 CEST-----------------------
An exception of category 'NoProxyException' occurred while
   [0] Processing  stream begin Run run: 1 stream: 3
   [1] Calling method for module GEMPadDigiProducer/'simMuonGEMPadDigis'
Exception Message:
No data of type "GEMGeometry" with label "" in record "MuonGeometryRecord"
 Please add an ESSource or ESProducer to your job which can deliver this data.
----- End Fatal Exception -------------------------------------------------
```