### PR TITLE
Add GEM unpacker in L1Repack FullMC and temporary load of GEM geometry to hltGetConfiguration

### DIFF
--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_FullMC_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_FullMC_cff.py
@@ -25,6 +25,10 @@ import EventFilter.CSCRawToDigi.cscUnpacker_cfi
 unpackCSC = EventFilter.CSCRawToDigi.cscUnpacker_cfi.muonCSCDigis.clone(
     InputObjects = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
+import EventFilter.GEMRawToDigi.muonGEMDigis_cfi
+unpackGEM = EventFilter.GEMRawToDigi.muonGEMDigis_cfi.muonGEMDigis.clone(
+    InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+
 import EventFilter.EcalRawToDigi.EcalUnpackerData_cfi
 unpackEcal = EventFilter.EcalRawToDigi.EcalUnpackerData_cfi.ecalEBunpacker.clone(
     InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
@@ -84,6 +88,9 @@ simEmtfDigis.RPCInput            = 'unpackRPC'
 simCaloStage2Layer1Digis.ecalToken = 'unpackEcal:EcalTriggerPrimitives'
 simCaloStage2Layer1Digis.hcalToken = 'simHcalTriggerPrimitiveDigis'
 
+# GEM
+simMuonGEMPadDigis.InputCollection = 'unpackGEM'
+
 # Finally, pack the new L1T output back into RAW
 from EventFilter.L1TRawToDigi.caloStage2Raw_cfi import caloStage2Raw as packCaloStage2
 from EventFilter.L1TRawToDigi.gmtStage2Raw_cfi import gmtStage2Raw as packGmtStage2
@@ -105,6 +112,7 @@ SimL1EmulatorTask = cms.Task()
 stage2L1Trigger.toReplaceWith(SimL1EmulatorTask, cms.Task(unpackRPC
                                                           , unpackDT
                                                           , unpackCSC
+                                                          , unpackGEM
                                                           , unpackEcal
                                                           , unpackHcal
                                                           #, simEcalTriggerPrimitiveDigis

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -133,16 +133,17 @@ def customiseFor2018Input(process):
 def customiseForRun3GEMGeometry34788(process):
     """Add GEM geometry to output from hltGetConfiguration"""
     process.load("Geometry.GEMGeometryBuilder.gemGeometryDB_cfi")
-    
-    return process
+
 
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
     
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
-    
+
+    # GEM
+    from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
     if menuType in ["GRun","HIon","PIon","PRef"]:
-        process = customiseForRun3GEMGeometry34788(process)
+        addCustomiseForRun3GEMGeometry34788_ = (~dd4hep).makeProcessModifier( customiseForRun3GEMGeometry34788 )
 
     return process

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -147,6 +147,6 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
 
     # temporary for GEM
     if menuType in ["GRun","HIon","PIon","PRef"]:
-        (~dd4hep).makeProcessModifier(customiseFor34788)
+        (~dd4hep).makeProcessModifier(customiseFor34788).apply(process)
 
     return process

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -132,7 +132,7 @@ def customiseFor2018Input(process):
 #temporary solution to add GEM geometry for hltGetConfiguration
 def customiseForRun3GEMGeometry34788(process):
     """Add GEM geometry to output from hltGetConfiguration"""
-    process.GEMGeometryESModule = cms.ESProducer(
+    process.gemGeometry = cms.ESProducer(
         "GEMGeometryESModule",
         fromDD4Hep = cms.bool( False ),
         appendToDataLabel = cms.string( "" ),

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -3,6 +3,9 @@ import FWCore.ParameterSet.Config as cms
 # helper fuctions
 from HLTrigger.Configuration.common import *
 
+# dd4hep
+from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
+
 # add one customisation function per PR
 # - put the PR number into the name of the function
 # - add a short comment
@@ -130,10 +133,11 @@ def customiseFor2018Input(process):
 
 
 #temporary solution to add GEM geometry for hltGetConfiguration
-def customiseForRun3GEMGeometry34788(process):
+def customiseFor34788(process):
     """Add GEM geometry to output from hltGetConfiguration"""
     process.load("Geometry.GEMGeometryBuilder.gemGeometryDB_cfi")
 
+    return process
 
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
@@ -141,9 +145,8 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
 
-    # GEM
-    from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
+    # temporary for GEM
     if menuType in ["GRun","HIon","PIon","PRef"]:
-        addCustomiseForRun3GEMGeometry34788_ = (~dd4hep).makeProcessModifier( customiseForRun3GEMGeometry34788 )
+        (~dd4hep).makeProcessModifier(customiseFor34788)
 
     return process

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -132,12 +132,9 @@ def customiseFor2018Input(process):
 #temporary solution to add GEM geometry for hltGetConfiguration
 def customiseForRun3GEMGeometry34788(process):
     """Add GEM geometry to output from hltGetConfiguration"""
-    process.gemGeometry = cms.ESProducer(
-        "GEMGeometryESModule",
-        fromDD4Hep = cms.bool( False ),
-        appendToDataLabel = cms.string( "" ),
-        fromDDD = cms.bool( False )
-    )
+    process.load("Geometry.GEMGeometryBuilder.gemGeometryDB_cfi")
+    
+    return process
 
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -129,10 +129,23 @@ def customiseFor2018Input(process):
     return process
 
 
+#temporary solution to add GEM geometry for hltGetConfiguration
+def customiseForRun3GEMGeometry34788(process):
+    """Add GEM geometry to output from hltGetConfiguration"""
+    process.GEMGeometryESModule = cms.ESProducer(
+        "GEMGeometryESModule",
+        fromDD4Hep = cms.bool( False ),
+        appendToDataLabel = cms.string( "" ),
+        fromDDD = cms.bool( False )
+    )
+
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
     
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
+    
+    if menuType in ["GRun","HIon","PIon","PRef"]:
+        process = customiseForRun3GEMGeometry34788(process)
 
     return process


### PR DESCRIPTION
#### PR description:
It was https://github.com/cms-sw/cmssw/pull/34785
This PR is to fix two issues when L1REPACK is used for Run3. The error messages w/o this PR is mentioned at the end of the PR description.
(1) no GEM unpacker defined in SimL1EmulatorRepack. It is solved in this PR.
(2) when hltGetConfiguration is used, GEM geometry is not loaded properly. This PR introduced a temporary fix.

Next step:
Following the comment on https://github.com/cms-sw/cmssw/pull/34785#issuecomment-893221496

#### PR validation:
To test (1), the following cmsDriver run fine.
`cmsDriver.py --process reHLT -s L1REPACK:FullMC,HLT:@relval2021 --conditions auto:phase1_2021_realistic --datatier GEN-SIM-RAW -n -1 --eventcontent RAWSIM --geometry DB:Extended --era Run3 --filein file:step2.root --fileout file:step3_reHLT.root --python reHLT_ProdLike_2021.py --no_exec`

To test (2), the following config can run fine.
`hltGetConfiguration /dev/CMSSW_12_1_0/GRun/V1 --process reHLT --globaltag auto:phase1_2021_realistic --mc --unprescale --paths HLTriggerFirstPath,HLT_IsoMu24_v13,HLT_Mu50_v13,HLTriggerFinalPath --output minimal --input file:step2.root --l1-emulator FullMC > tmp.py`

Test cover also DD4hep (wf 11634.911), as `GEMGeometryESModule` will be loaded twice.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
Not a backport, and no need of backport

#### Note
Issue of (1): solved in this PR
```
----- Begin Fatal Exception 05-Aug-2021 05:33:59 CEST-----------------------
An exception of category 'ProductNotFound' occurred while
   [0] Processing  Event run: 1 lumi: 1 event: 1 stream: 0
   [1] Running path 'HLTAnalyzerEndpath'
   [2] Prefetching for module L1TRawToDigi/'hltGtStage2Digis'
   [3] Prefetching for module RawDataCollectorByLabel/'rawDataCollector'
   [4] Prefetching for module L1TDigiToRaw/'packGmtStage2'
   [5] Prefetching for module L1TMuonOverlapTrackProducer/'simOmtfDigis'
   [6] Prefetching for module CSCTriggerPrimitivesProducer/'simCscTriggerPrimitiveDigis'
   [7] Prefetching for module GEMPadDigiClusterProducer/'simMuonGEMPadDigiClusters'
   [8] Calling method for module GEMPadDigiProducer/'simMuonGEMPadDigis'
Exception Message:
Principal::getByToken: Found zero products matching all criteria
Looking for type: MuonDigiCollection<GEMDetId,GEMDigi>
Looking for module label: simMuonGEMDigis
Looking for productInstanceName: 
```

Issue of (2): temporary solution is provided for now
```
----- Begin Fatal Exception 05-Aug-2021 05:59:31 CEST-----------------------
An exception of category 'NoProxyException' occurred while
   [0] Processing  stream begin Run run: 1 stream: 1
   [1] Calling method for module GEMPadDigiClusterProducer/'simMuonGEMPadDigiClusters'
Exception Message:
No data of type "GEMGeometry" with label "" in record "MuonGeometryRecord"
 Please add an ESSource or ESProducer to your job which can deliver this data.
----- End Fatal Exception -------------------------------------------------
----- Begin Fatal Exception 05-Aug-2021 05:59:31 CEST-----------------------
An exception of category 'NoProxyException' occurred while
   [0] Processing  stream begin Run run: 1 stream: 3
   [1] Calling method for module GEMPadDigiProducer/'simMuonGEMPadDigis'
Exception Message:
No data of type "GEMGeometry" with label "" in record "MuonGeometryRecord"
 Please add an ESSource or ESProducer to your job which can deliver this data.
----- End Fatal Exception -------------------------------------------------
```