### PR TITLE
Add additional paths to customizeHLTIter0ToMkFit

### DIFF
--- a/RecoTracker/MkFit/python/customizeHLTIter0ToMkFit.py
+++ b/RecoTracker/MkFit/python/customizeHLTIter0ToMkFit.py
@@ -68,12 +68,11 @@ def customizeHLTIter0ToMkFit(process):
     )
 
     process.HLTDoLocalStripSequence += process.hltSiStripRecHits
-    process.HLTIterativeTrackingIteration0.replace(process.hltIter0PFlowCkfTrackCandidates,
-                                                   process.hltIter0PFlowCkfTrackCandidatesMkFitSiPixelHits +
-                                                   process.hltIter0PFlowCkfTrackCandidatesMkFitSiStripHits +
-                                                   process.hltIter0PFlowCkfTrackCandidatesMkFitEventOfHits +
-                                                   process.hltIter0PFlowCkfTrackCandidatesMkFitSeeds +
-                                                   process.hltIter0PFlowCkfTrackCandidatesMkFit +
-                                                   process.hltIter0PFlowCkfTrackCandidates)
+
+    replaceWith = process.hltIter0PFlowCkfTrackCandidatesMkFitSiPixelHits + process.hltIter0PFlowCkfTrackCandidatesMkFitSiStripHits + process.hltIter0PFlowCkfTrackCandidatesMkFitEventOfHits + process.hltIter0PFlowCkfTrackCandidatesMkFitSeeds + process.hltIter0PFlowCkfTrackCandidatesMkFit + process.hltIter0PFlowCkfTrackCandidates
+
+    process.HLTIterativeTrackingIteration0.replace(process.hltIter0PFlowCkfTrackCandidates, replaceWith)
+    process.HLT_IsoTrackHB_v4.replace(process.hltIter0PFlowCkfTrackCandidates, replaceWith)
+    process.HLT_IsoTrackHE_v4.replace(process.hltIter0PFlowCkfTrackCandidates, replaceWith)
 
     return process

--- a/RecoTracker/MkFit/python/customizeHLTIter0ToMkFit.py
+++ b/RecoTracker/MkFit/python/customizeHLTIter0ToMkFit.py
@@ -69,7 +69,12 @@ def customizeHLTIter0ToMkFit(process):
 
     process.HLTDoLocalStripSequence += process.hltSiStripRecHits
 
-    replaceWith = process.hltIter0PFlowCkfTrackCandidatesMkFitSiPixelHits + process.hltIter0PFlowCkfTrackCandidatesMkFitSiStripHits + process.hltIter0PFlowCkfTrackCandidatesMkFitEventOfHits + process.hltIter0PFlowCkfTrackCandidatesMkFitSeeds + process.hltIter0PFlowCkfTrackCandidatesMkFit + process.hltIter0PFlowCkfTrackCandidates
+    replaceWith = (process.hltIter0PFlowCkfTrackCandidatesMkFitSiPixelHits + 
+                   process.hltIter0PFlowCkfTrackCandidatesMkFitSiStripHits + 
+                   process.hltIter0PFlowCkfTrackCandidatesMkFitEventOfHits + 
+                   process.hltIter0PFlowCkfTrackCandidatesMkFitSeeds + 
+                   process.hltIter0PFlowCkfTrackCandidatesMkFit + 
+                   process.hltIter0PFlowCkfTrackCandidates)
 
     process.HLTIterativeTrackingIteration0.replace(process.hltIter0PFlowCkfTrackCandidates, replaceWith)
     process.HLT_IsoTrackHB_v4.replace(process.hltIter0PFlowCkfTrackCandidates, replaceWith)


### PR DESCRIPTION
#### PR description:

The other paths also include hltIter0PFlowCkfTrackCandidates and need the change in order to be self-consistent.
The inconsistency was found by #34735
#### PR validation:

I ran workflow 11634.7 with this change and the changes from #34735 and it now runs fine.