### PR TITLE
Fix loop in PFJetIDSelectionFunctor

### DIFF
--- a/PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h
+++ b/PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h
@@ -412,7 +412,7 @@ public:  // interface
       double e_muf = 0.0;
       nch = 0;
       nconstituents = 0;
-      for (reco::Jet::const_iterator ibegin = basicJet->begin(), iend = patJet->end(), isub = ibegin; isub != iend;
+      for (reco::Jet::const_iterator ibegin = basicJet->begin(), iend = basicJet->end(), isub = ibegin; isub != iend;
            ++isub) {
         reco::PFJet const *pfsub = dynamic_cast<reco::PFJet const *>(&*isub);
         e_chf += pfsub->chargedHadronEnergy();


### PR DESCRIPTION
#### PR description:

The end iterator was not from the same container as the begin.
This was found by gcc 11.

#### PR validation:

Code compiles.

fixes #34760 