### PR TITLE
Correct RegionalMuon (un)packer when running on EMTF data

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFPackerOutput.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFPackerOutput.cc
@@ -20,7 +20,7 @@ namespace l1t {
       for (auto imu = muons->begin(); imu != muons->end(); imu++) {
         if (imu->processor() + 1 == board_id) {
           uint32_t firstWord(0), lastWord(0);
-          RegionalMuonRawDigiTranslator::generatePackedDataWords(*imu, firstWord, lastWord, isKalman_);
+          RegionalMuonRawDigiTranslator::generatePackedDataWords(*imu, firstWord, lastWord, isKalman_, false);
           payloadMap_[bmtfBlockID].push_back(firstWord);  //imu->link()*2+1
           payloadMap_[bmtfBlockID].push_back(lastWord);   //imu->link()*2+1
         }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFUnpackerOutput.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFUnpackerOutput.cc
@@ -67,7 +67,7 @@ namespace l1t {
 
           RegionalMuonCand muCand;
           RegionalMuonRawDigiTranslator::fillRegionalMuonCand(
-              muCand, raw_first, raw_secnd, processor, tftype::bmtf, isKalman);
+              muCand, raw_first, raw_secnd, processor, tftype::bmtf, isKalman, false);
 
           if (muCand.hwPt() == 0) {
             continue;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTSetup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTSetup.cc
@@ -43,8 +43,11 @@ namespace l1t {
       if (fed == 1402) {
         auto gmt_in_packer = static_pointer_cast<l1t::stage2::RegionalMuonGMTPacker>(
             PackerFactory::get()->make("stage2::RegionalMuonGMTPacker"));
+        if (fw >= 0x6010000) {
+          gmt_in_packer->setUseEmtfDisplacementInfo();
+        }
         if (fw >= 0x6000000) {
-          gmt_in_packer->setIsRun3();
+          gmt_in_packer->setIsKbmtf();
         }
         auto gmt_out_packer =
             static_pointer_cast<l1t::stage2::GMTMuonPacker>(PackerFactory::get()->make("stage2::GMTMuonPacker"));
@@ -86,8 +89,11 @@ namespace l1t {
       // input muons on links 36-71
       auto gmt_in_unp = static_pointer_cast<l1t::stage2::RegionalMuonGMTUnpacker>(
           UnpackerFactory::get()->make("stage2::RegionalMuonGMTUnpacker"));
+      if (fw >= 0x6010000) {
+        gmt_in_unp->setUseEmtfDisplacementInfo();
+      }
       if (fw >= 0x6000000) {
-        gmt_in_unp->setIsRun3();
+        gmt_in_unp->setIsKbmtf();
       }
 
       for (int iLink = 72; iLink < 144; iLink += 2) {

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTPacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTPacker.cc
@@ -54,7 +54,7 @@ namespace l1t {
           uint32_t msw = 0;
           uint32_t lsw = 0;
 
-          RegionalMuonRawDigiTranslator::generatePackedDataWords(*mu, lsw, msw, isRun3_);
+          RegionalMuonRawDigiTranslator::generatePackedDataWords(*mu, lsw, msw, isKbmtf_, useEmtfDisplacementInfo_);
 
           payloadMap[linkTimes2].push_back(lsw);
           payloadMap[linkTimes2].push_back(msw);

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTPacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTPacker.h
@@ -13,13 +13,15 @@ namespace l1t {
     class RegionalMuonGMTPacker : public Packer {
     public:
       Blocks pack(const edm::Event&, const PackerTokens*) override;
-      void setIsRun3() { isRun3_ = true; };
+      void setIsKbmtf() { isKbmtf_ = true; };
+      void setUseEmtfDisplacementInfo() { useEmtfDisplacementInfo_ = true; };
 
     private:
       typedef std::map<unsigned int, std::vector<uint32_t>> PayloadMap;
       void packTF(const edm::Event&, const edm::EDGetTokenT<RegionalMuonCandBxCollection>&, Blocks&);
 
-      bool isRun3_{false};
+      bool isKbmtf_{false};
+      bool useEmtfDisplacementInfo_{false};
     };
   }  // namespace stage2
 }  // namespace l1t

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.cc
@@ -102,7 +102,7 @@ namespace l1t {
             RegionalMuonCand mu;
 
             RegionalMuonRawDigiTranslator::fillRegionalMuonCand(
-                mu, raw_data_00_31, raw_data_32_63, processor, trackFinder, isRun3_);
+                mu, raw_data_00_31, raw_data_32_63, processor, trackFinder, isKbmtf_, useEmtfDisplacementInfo_);
 
             LogDebug("L1T") << "Mu" << nWord / 2 << ": eta " << mu.hwEta() << " phi " << mu.hwPhi() << " pT "
                             << mu.hwPt() << " qual " << mu.hwQual() << " sign " << mu.hwSign() << " sign valid "

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.h
@@ -10,13 +10,15 @@ namespace l1t {
     class RegionalMuonGMTUnpacker : public Unpacker {
     public:
       bool unpack(const Block& block, UnpackerCollections* coll) override;
-      void setIsRun3() { isRun3_ = true; }
+      void setIsKbmtf() { isKbmtf_ = true; }
+      void setUseEmtfDisplacementInfo() { useEmtfDisplacementInfo_ = true; }
 
     private:
       static constexpr unsigned nWords_ = 6;  // every link transmits 6 words (3 muons) per bx
       static constexpr unsigned bxzs_enable_shift_ = 1;
 
-      bool isRun3_{false};
+      bool isKbmtf_{false};
+      bool useEmtfDisplacementInfo_{false};
     };
   }  // namespace stage2
 }  // namespace l1t

--- a/EventFilter/L1TRawToDigi/python/gmtStage2Raw_cfi.py
+++ b/EventFilter/L1TRawToDigi/python/gmtStage2Raw_cfi.py
@@ -13,7 +13,7 @@ gmtStage2Raw = cms.EDProducer(
     ImdInputLabelOMTFNeg = cms.InputTag("simGmtStage2Digis", "imdMuonsOMTFNeg"),
     ImdInputLabelOMTFPos = cms.InputTag("simGmtStage2Digis", "imdMuonsOMTFPos"),
     FedId = cms.int32(1402),
-    FWId = cms.uint32(0x6000000), # FW version in GMT with displaced muon information
+    FWId = cms.uint32(0x3000000), # First used uGMT firmware version
     lenSlinkHeader = cms.untracked.int32(8),
     lenSlinkTrailer = cms.untracked.int32(8)
 )
@@ -32,4 +32,4 @@ stage2L1Trigger_2018.toModify(gmtStage2Raw, BMTFInputLabel = cms.InputTag("simBm
 
 ### Era: Run3_2021
 from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
-stage2L1Trigger_2021.toModify(gmtStage2Raw, BMTFInputLabel = cms.InputTag("simKBmtfDigis", "BMTF"), FWId = cms.uint32(0x6000000))
+stage2L1Trigger_2021.toModify(gmtStage2Raw, BMTFInputLabel = cms.InputTag("simKBmtfDigis", "BMTF"), FWId = cms.uint32(0x6010000))

--- a/L1Trigger/L1TMuon/interface/RegionalMuonRawDigiTranslator.h
+++ b/L1Trigger/L1TMuon/interface/RegionalMuonRawDigiTranslator.h
@@ -6,14 +6,21 @@
 namespace l1t {
   class RegionalMuonRawDigiTranslator {
   public:
+    static void fillRegionalMuonCand(RegionalMuonCand& mu,
+                                     uint32_t raw_data_00_31,
+                                     uint32_t raw_data_32_63,
+                                     int proc,
+                                     tftype tf,
+                                     bool isKbmtf,
+                                     bool useEmtfDisplacementInfo);
     static void fillRegionalMuonCand(
-        RegionalMuonCand& mu, uint32_t raw_data_00_31, uint32_t raw_data_32_63, int proc, tftype tf, bool isRun3);
-    static void fillRegionalMuonCand(RegionalMuonCand& mu, uint64_t dataword, int proc, tftype tf, bool isRun3);
+        RegionalMuonCand& mu, uint64_t dataword, int proc, tftype tf, bool isKbmtf, bool useEmtfDisplacementInfo);
     static void generatePackedDataWords(const RegionalMuonCand& mu,
                                         uint32_t& raw_data_00_31,
                                         uint32_t& raw_data_32_63,
-                                        bool isRun3);
-    static uint64_t generate64bitDataWord(const RegionalMuonCand& mu, bool isRun3);
+                                        bool isKbmtf,
+                                        bool useEmtfDisplacementInfo);
+    static uint64_t generate64bitDataWord(const RegionalMuonCand& mu, bool isKbmtf, bool useEmtfDisplacementInfo);
     static int generateRawTrkAddress(const RegionalMuonCand&, bool isKalman);
 
     static constexpr unsigned ptMask_ = 0x1FF;


### PR DESCRIPTION
#### PR description:

EMTF doesn't yet send displaced muon information, but unfortunately puts debug data in the fields foreseen for use by dXY and unconstrained pT. This leads to mismatches in the uGMT data-emulator DQM because we unpack these debug data, interpret them as dXY and unconstrained pT, and then proceed to run the emulator on these inputs. The emulator output therefore doesn't match the firmware output anymore as the firmware correctly ignores those data.
With this change we avoid unpacking those fields until the uGMT firmware version changes to indicate that we actually use them in the algorithm.

attn: @panoskatsoulis as the BMTF output (un)packer slightly changes too.

#### PR validation:

Ran `scram b runtests && runTheMatrix.py -l limited -i all --ibeos` successfully.
