### PR TITLE
Create abstract XrdStatistics class

### DIFF
--- a/FWCore/Framework/src/defaultCmsRunServices.cc
+++ b/FWCore/Framework/src/defaultCmsRunServices.cc
@@ -24,7 +24,7 @@ namespace edm {
                                             "SiteLocalConfigService",
                                             "StatisticsSenderService",
                                             "CondorStatusService",
-                                            "XrdAdaptor::XrdStatisticsService"};
+                                            "XrdStatisticsService"};
 
     return returnValue;
   }

--- a/FWCore/Services/plugins/CondorStatusUpdater.cc
+++ b/FWCore/Services/plugins/CondorStatusUpdater.cc
@@ -12,7 +12,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/Registry.h"
 #include "Utilities/StorageFactory/interface/StorageAccount.h"
-#include "Utilities/XrdAdaptor/src/XrdStatistics.h"
+#include "Utilities/XrdAdaptor/interface/XrdStatistics.h"
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 #include <fcntl.h>
@@ -294,7 +294,7 @@ void CondorStatusService::updateImpl(time_t sinceLastUpdate) {
   }
 
   // If Xrootd was used, pull the statistics from there.
-  edm::Service<XrdAdaptor::XrdStatisticsService> xrdsvc;
+  edm::Service<xrd_adaptor::XrdStatistics> xrdsvc;
   if (xrdsvc.isAvailable()) {
     for (auto const &iter : xrdsvc->condorUpdate()) {
       std::string site = iter.first;

--- a/Utilities/XrdAdaptor/interface/XrdStatistics.h
+++ b/Utilities/XrdAdaptor/interface/XrdStatistics.h
@@ -1,0 +1,29 @@
+#ifndef Utilities_XrdAdaptor_XrdStatistics_h
+#define Utilities_XrdAdaptor_XrdStatistics_h
+
+#include <vector>
+#include <string>
+#include <chrono>
+
+namespace xrd_adaptor {
+
+  class XrdStatistics {
+  public:
+    XrdStatistics() {}
+    virtual ~XrdStatistics();
+
+    struct CondorIOStats {
+      uint64_t bytesRead{0};
+      std::chrono::nanoseconds transferTime{0};
+    };
+
+    // Provide an update of per-site transfer statistics to the CondorStatusService.
+    // Returns a mapping of "site name" to transfer statistics.  The "site name" is
+    // as self-identified by the Xrootd host; may not necessarily match up with the
+    // "CMS site name".
+    virtual std::vector<std::pair<std::string, CondorIOStats>> condorUpdate() = 0;
+  };
+
+}  // namespace xrd_adaptor
+
+#endif

--- a/Utilities/XrdAdaptor/plugins/XrdStorageMaker.cc
+++ b/Utilities/XrdAdaptor/plugins/XrdStorageMaker.cc
@@ -180,4 +180,7 @@ private:
 };
 
 DEFINE_EDM_PLUGIN(StorageMakerFactory, XrdStorageMaker, "root");
-DEFINE_FWK_SERVICE(XrdAdaptor::XrdStatisticsService);
+using XrdStatisticsMaker =
+    edm::serviceregistry::AllArgsMaker<xrd_adaptor::XrdStatistics, XrdAdaptor::XrdStatisticsService>;
+using XrdAdaptor::XrdStatisticsService;
+DEFINE_FWK_SERVICE_MAKER(XrdStatisticsService, XrdStatisticsMaker);

--- a/Utilities/XrdAdaptor/src/XrdStatistics.cc
+++ b/Utilities/XrdAdaptor/src/XrdStatistics.cc
@@ -11,6 +11,10 @@
 
 #include <chrono>
 
+namespace xrd_adaptor {
+  XrdStatistics::~XrdStatistics() {}
+}  // namespace xrd_adaptor
+
 using namespace XrdAdaptor;
 
 std::atomic<XrdSiteStatisticsInformation *> XrdSiteStatisticsInformation::m_instance;
@@ -94,7 +98,7 @@ void XrdStatisticsService::fillDescriptions(edm::ConfigurationDescriptions &desc
       ->setComment(
           "True: Add per-site Xrootd statistics to the framework job report.\n"
           "False: Collect no site-specific statistics.\n");
-  descriptions.add("XrdAdaptor::XrdStatisticsService", desc);
+  descriptions.add("XrdStatisticsService", desc);
 }
 
 XrdSiteStatistics::XrdSiteStatistics(std::string const &site)

--- a/Utilities/XrdAdaptor/src/XrdStatistics.h
+++ b/Utilities/XrdAdaptor/src/XrdStatistics.h
@@ -2,6 +2,7 @@
 #define __XRD_STATISTICS_SERVICE_H_
 
 #include "Utilities/StorageFactory/interface/IOTypes.h"
+#include "Utilities/XrdAdaptor/interface/XrdStatistics.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
 
 #include <atomic>
@@ -32,24 +33,19 @@ namespace XrdAdaptor {
  * singleton on non-CMSSW-created threads.  Services are only available to threads
  * created by CMSSW.
  */
-  class XrdStatisticsService {
+  class XrdStatisticsService : public xrd_adaptor::XrdStatistics {
   public:
     XrdStatisticsService(const edm::ParameterSet &iPS, edm::ActivityRegistry &iRegistry);
 
     void postEndJob();
 
-    void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
-
-    struct CondorIOStats {
-      uint64_t bytesRead{0};
-      std::chrono::nanoseconds transferTime{0};
-    };
+    static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
     // Provide an update of per-site transfer statistics to the CondorStatusService.
     // Returns a mapping of "site name" to transfer statistics.  The "site name" is
     // as self-identified by the Xrootd host; may not necessarily match up with the
     // "CMS site name".
-    std::vector<std::pair<std::string, CondorIOStats>> condorUpdate();
+    std::vector<std::pair<std::string, CondorIOStats>> condorUpdate() final;
   };
 
   class XrdSiteStatisticsInformation {


### PR DESCRIPTION
#### PR description:

CondorStatusUpdater now only depends on the abstract XrdStatistics interface. The `edm::Service` is now accessed only via the base class, not the concrete class.

This avoids including a header from the /src directory.


#### PR validation:

Code compiles and all framework unit tests succeed.