### PR TITLE
Fix the mergeLHE.py script

### DIFF
--- a/GeneratorInterface/LHEInterface/scripts/mergeLHE.py
+++ b/GeneratorInterface/LHEInterface/scripts/mergeLHE.py
@@ -196,7 +196,7 @@ class DefaultLHEMerger(BaseLHEMerger):
             for i in range(len(self._f)):
                 header = []
                 line = next(self._f[i])
-                while not line.startswith('<init>') and not line.startswith('<init '):
+                while not re.search('\s*<init(>|\s)', line):
                     header.append(line)
                     line = next(self._f[i])
                 # 'header' includes all contents before reaches <init>
@@ -207,7 +207,7 @@ class DefaultLHEMerger(BaseLHEMerger):
             for i in range(len(self._f)):
                 init = []
                 line = next(self._f[i])
-                while not line.startswith('</init>'):
+                while not re.search('\s*</init>', line):
                     init.append(line)
                     line = next(self._f[i])
                 # 'init_str' includes all contents inside <init>...</init>
@@ -220,9 +220,9 @@ class DefaultLHEMerger(BaseLHEMerger):
                     nevent = 0
                     while True:
                         line = next(self._f[i])
-                        if line.startswith('</event>'):
+                        if re.search('\s*</event>', line):
                             nevent += 1
-                        if line.startswith('</LesHouchesEvents>'):
+                        if re.search('\s*</LesHouchesEvents>', line):
                             break
                         _fwtmp.write(line)
                     self._nevent.append(nevent)
@@ -253,7 +253,7 @@ class DefaultLHEMerger(BaseLHEMerger):
                     sign = lambda x: -1 if x < 0 else 1
                     for line in ftmp:
                         event_line += 1
-                        if line.startswith('<event'):
+                        if re.search('\s*<event.*>', line):
                             event_line = 0
                         if event_line == 1:
                             # modify the XWGTUP appeared in the first line of the
@@ -261,8 +261,8 @@ class DefaultLHEMerger(BaseLHEMerger):
                             orig_wgt = float(line.split()[2])
                             fw.write(re.sub(r'(^\s*\S+\s+\S+\s+)\S+(.+)', r'\g<1>%+.7E\g<2>' \
                                 % (sign(orig_wgt) * self._uwgt), line))
-                        elif line.startswith('<wgt '):
-                            addi_wgt_str = re.search(r'^\<wgt.*\>\s*(\S+)\s*\<\/wgt\>', line).group(1)
+                        elif re.search('\s*<wgt.*>.*</wgt>', line):
+                            addi_wgt_str = re.search(r'\<wgt.*\>\s*(\S+)\s*\<\/wgt\>', line).group(1)
                             fw.write(line.replace(
                                 addi_wgt_str, '%+.7E' % (float(addi_wgt_str) / orig_wgt * self._uwgt)))
                         else:


### PR DESCRIPTION
#### PR description:
 
Fix the regex to match the LHE tags in the `mergeLHE.py` script.

Now we are capable to match the tag if it has leading spaces. The issue is discussed in https://github.com/cms-sw/cmssw/issues/34531#issuecomment-892005200

#### PR validation:

Validation done based on https://github.com/colizz/mergelhe_validate indicated by `mergeLHE.py -h` .

A backport to 10_6_X is also needed.