### PR TITLE
HCAL: fixing pulse containment correction algorithm for Run3 trigger primitives

### DIFF
--- a/CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h
+++ b/CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h
@@ -69,6 +69,7 @@ public:
   void set1TSContainHE(bool contain1TSHE) { contain1TSHE_ = contain1TSHE; }
   void setContainPhaseHB(double containPhaseNSHB) { containPhaseNSHB_ = containPhaseNSHB; }
   void setContainPhaseHE(double containPhaseNSHE) { containPhaseNSHE_ = containPhaseNSHE; }
+  void setApplyFixPCC(double applyFixPCC) { applyFixPCC_ = applyFixPCC; }
   void setOverrideDBweightsAndFilterHB(bool overrideDBweightsAndFilterHB) {
     overrideDBweightsAndFilterHB_ = overrideDBweightsAndFilterHB;
   }
@@ -122,6 +123,7 @@ private:
   bool contain1TSHB_, contain1TSHE_;
   double containPhaseNSHB_ = 6.0;
   double containPhaseNSHE_ = 6.0;
+  bool applyFixPCC_;
   double linearLSB_QIE8_, linearLSB_QIE11_, linearLSB_QIE11Overlap_;
   std::unique_ptr<HcalPulseContainmentManager> pulseCorr_;
   bool overrideDBweightsAndFilterHB_ = false;

--- a/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
+++ b/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
@@ -63,6 +63,7 @@ HcaluLUTTPGCoder::HcaluLUTTPGCoder()
       allLinear_{},
       contain1TSHB_{},
       contain1TSHE_{},
+      applyFixPCC_{},
       linearLSB_QIE8_{},
       linearLSB_QIE11_{},
       linearLSB_QIE11Overlap_{} {}
@@ -78,6 +79,7 @@ void HcaluLUTTPGCoder::init(const HcalTopology* top, const HcalTimeSlew* delay) 
   allLinear_ = false;
   contain1TSHB_ = false;
   contain1TSHE_ = false;
+  applyFixPCC_ = false;
   linearLSB_QIE8_ = 1.;
   linearLSB_QIE11_ = 1.;
   linearLSB_QIE11Overlap_ = 1.;
@@ -333,6 +335,7 @@ void HcaluLUTTPGCoder::update(const HcalDbService& conditions) {
   assert(metadata != nullptr);
   float nominalgain_ = metadata->getNominalGain();
 
+  pulseCorr_ = std::make_unique<HcalPulseContainmentManager>(MaximumFractionalError, applyFixPCC_);
   pulseCorr_->beginRun(&conditions, delay_);
 
   make_cosh_ieta_map();

--- a/CalibCalorimetry/HcalTPGEventSetup/src/HcalTPGCoderULUT.cc
+++ b/CalibCalorimetry/HcalTPGEventSetup/src/HcalTPGCoderULUT.cc
@@ -59,6 +59,7 @@ private:
   bool read_FGLut_, read_Ascii_, read_XML_, LUTGenerationMode_, linearLUTs_;
   bool contain1TSHB_, contain1TSHE_;
   double containPhaseNSHB_, containPhaseNSHE_;
+  bool applyFixPCC_;
   bool overrideDBweightsAndFilterHB_, overrideDBweightsAndFilterHE_;
   double linearLSB_QIE8_, linearLSB_QIE11Overlap_, linearLSB_QIE11_;
   int maskBit_;
@@ -86,6 +87,7 @@ HcalTPGCoderULUT::HcalTPGCoderULUT(const edm::ParameterSet& iConfig) {
   contain1TSHE_ = iConfig.getParameter<bool>("contain1TSHE");
   containPhaseNSHB_ = iConfig.getParameter<double>("containPhaseNSHB");
   containPhaseNSHE_ = iConfig.getParameter<double>("containPhaseNSHE");
+  applyFixPCC_ = iConfig.getParameter<bool>("applyFixPCC");
   overrideDBweightsAndFilterHB_ = iConfig.getParameter<bool>("overrideDBweightsAndFilterHB");
   overrideDBweightsAndFilterHE_ = iConfig.getParameter<bool>("overrideDBweightsAndFilterHE");
 
@@ -122,6 +124,8 @@ void HcalTPGCoderULUT::buildCoder(const HcalTopology* topo, const HcalTimeSlew* 
 
   theCoder->setContainPhaseHB(containPhaseNSHB_);
   theCoder->setContainPhaseHE(containPhaseNSHE_);
+
+  theCoder->setApplyFixPCC(applyFixPCC_);
 
   if (read_Ascii_ || read_XML_) {
     edm::LogInfo("HCAL") << "Using ASCII/XML LUTs" << ifilename_.fullPath() << " for HcalTPGCoderULUT initialization";

--- a/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cff.py
+++ b/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cff.py
@@ -19,6 +19,7 @@ HcalTPGCoderULUT = cms.ESProducer("HcalTPGCoderULUT",
     contain1TSHE = cms.bool(False),
     containPhaseNSHE = cms.double(6.0),
     containPhaseNSHB = cms.double(6.0),
+    applyFixPCC = cms.bool(False),
     overrideDBweightsAndFilterHB = cms.bool(False),
     overrideDBweightsAndFilterHE = cms.bool(False),
     tpScales = tpScales,
@@ -33,5 +34,6 @@ HcalTrigTowerGeometryESProducer = cms.ESProducer("HcalTrigTowerGeometryESProduce
 
 run2_HCAL_2018.toModify(CaloTPGTranscoder, linearLUTs=cms.bool(True))
 run2_HCAL_2018.toModify(HcalTPGCoderULUT, linearLUTs=cms.bool(True))
+run3_common.toModify(HcalTPGCoderULUT, applyFixPCC=cms.bool(True))
 pp_on_AA.toModify(CaloTPGTranscoder, FG_HF_thresholds = cms.vuint32(15, 19))
 pp_on_AA.toModify(HcalTPGCoderULUT, FG_HF_thresholds = cms.vuint32(15, 19))


### PR DESCRIPTION
#### PR description:

This PR is the follow-up of the previous PR #34572, to switch on the functionality of fixing Pulse containment correction algorithm for the trigger primitive energy reconstruction using PFA1' scheme in Run3 condition. The configurable parameter, `applyFixPCC` is only turned on in Run 3 condition by `run3_common` modifier, and apply the fix described in #34572. The impact by this PR is presented in [the presentation](https://indico.cern.ch/event/1061449/contributions/4460835/attachments/2286772/3886949/Comissioning_1TS_Scheme_21Jul23.pdf). The agreement between the Trigger Primitive energy for PFA1' and the RecHit energy for MAHI in high energy is achieved by this change in Run3 MC. 


#### PR validation:

A basic technical test was performed: runTheMatrix.py -l limited -i all --ibeos

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport. It can be backported to 11_3_X after this PR is revised and merged.
