### PR TITLE
Clean unused dependencies from BuildFiles

### DIFF
--- a/Alignment/LaserAlignment/BuildFile.xml
+++ b/Alignment/LaserAlignment/BuildFile.xml
@@ -3,7 +3,6 @@
 <use name="Alignment/CommonAlignment"/>
 <use name="Alignment/TrackerAlignment"/>
 <use name="DataFormats/Common"/>
-<use name="DataFormats/TrackingRecHit"/>
 <use name="TrackingTools/TrajectoryState"/>
 <use name="clhepheader"/>
 <use name="rootcore"/>

--- a/CommonTools/CandAlgos/plugins/BuildFile.xml
+++ b/CommonTools/CandAlgos/plugins/BuildFile.xml
@@ -8,5 +8,4 @@
   <use name="CommonTools/UtilAlgos"/>
   <use name="CommonTools/Utils"/>
   <use name="CommonTools/CandAlgos"/>
-  <use name="SimGeneral/HepPDTRecord"/>
 </library>

--- a/Configuration/Skimming/BuildFile.xml
+++ b/Configuration/Skimming/BuildFile.xml
@@ -15,7 +15,6 @@
 <use name="RecoVertex/KalmanVertexFit"/>
 <use name="TrackingTools/IPTools"/>
 <use name="MagneticField/Engine"/>
-<use name="MagneticField/ParametrizedEngine"/>
 <use name="TrackingTools/TransientTrack"/>
 <use name="TrackingTools/Records"/>
 <flags EDM_PLUGIN="1"/>

--- a/DQM/GEM/plugins/BuildFile.xml
+++ b/DQM/GEM/plugins/BuildFile.xml
@@ -2,10 +2,6 @@
   <flags EDM_PLUGIN="1"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/ParameterSet"/>
-  <use name="FWCore/Utilities"/>
   <use name="DQM/GEM"/>
   <use name="DQMServices/Core"/>
-  <use name="DataFormats/GEMDigi"/>
-  <use name="DataFormats/GEMRecHit"/>
-  <use name="Validation/MuonGEMHits"/>
 </library>

--- a/IOMC/EventVertexGenerators/test/BuildFile.xml
+++ b/IOMC/EventVertexGenerators/test/BuildFile.xml
@@ -1,11 +1,11 @@
 <environment>
+  <use name="CommonTools/UtilAlgos"/>
   <use name="DataFormats/Common"/>
   <use name="FWCore/Framework"/>
   <use name="SimDataFormats/GeneratorProducts"/>
   <use name="clhep"/>
   <use name="root"/>
   <library file="VtxTester.cc" name="VtxSmearingTest">
-    <use name="PhysicsTools/UtilAlgos"/>
     <use name="FWCore/ServiceRegistry"/>
     <flags EDM_PLUGIN="1"/>
   </library>

--- a/L1Trigger/L1TGEM/test/BuildFile.xml
+++ b/L1Trigger/L1TGEM/test/BuildFile.xml
@@ -1,7 +1,3 @@
-<use name="Geometry/GEMGeometry"/>
-<use name="DataFormats/GEMDigi"/>
-<use name="Geometry/Records"/>
-<use name="CondFormats/DataRecord"/>
 <use name="FWCore/Framework"/>
 <use name="rootgraphics"/>
 <library file="*.cc" name="GEMTriggerPrimitivesTest">

--- a/PhysicsTools/HepMCCandAlgos/test/BuildFile.xml
+++ b/PhysicsTools/HepMCCandAlgos/test/BuildFile.xml
@@ -1,6 +1,4 @@
 <library file="DummyHepMCAnalyzer.cc">
-  <use name="PhysicsTools/UtilAlgos"/>
-  <use name="FWCore/ServiceRegistry"/>
   <use name="PhysicsTools/HepMCCandAlgos"/>
   <use name="SimDataFormats/GeneratorProducts"/>
   <use name="FWCore/Framework"/>

--- a/SimG4CMS/Calo/BuildFile.xml
+++ b/SimG4CMS/Calo/BuildFile.xml
@@ -8,13 +8,13 @@
 <use name="DataFormats/Math"/>
 <use name="CondFormats/GeometryObjects"/>
 <use name="CondFormats/HcalObjects"/>
-<use name="CondFormats/DataRecord"/>
 <use name="SimDataFormats/SimHitMaker"/>
 <use name="SimDataFormats/CaloHit"/>
 <use name="SimDataFormats/CaloTest"/>
 <use name="Geometry/HcalCommonData"/>
 <use name="Geometry/EcalCommonData"/>
 <use name="Geometry/HGCalCommonData"/>
+<use name="Geometry/Records"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ServiceRegistry"/>

--- a/SimG4CMS/Calo/plugins/BuildFile.xml
+++ b/SimG4CMS/Calo/plugins/BuildFile.xml
@@ -1,4 +1,5 @@
 <use name="CommonTools/UtilAlgos"/>
+<use name="CondFormats/DataRecord"/>
 <use name="DataFormats/EcalDetId"/>
 <use name="DataFormats/HcalDetId"/>
 <use name="FWCore/Framework"/>
@@ -10,6 +11,7 @@
 <use name="Geometry/HcalTowerAlgo"/>
 <use name="Geometry/HGCalGeometry"/>
 <use name="Geometry/CaloTopology"/>
+<use name="Geometry/Records"/>
 <use name="SimDataFormats/CaloHit"/>
 <use name="SimDataFormats/Track"/>
 <use name="SimDataFormats/Vertex"/>

--- a/SimG4CMS/HGCalTestBeam/BuildFile.xml
+++ b/SimG4CMS/HGCalTestBeam/BuildFile.xml
@@ -1,15 +1,8 @@
 <use name="DataFormats/HcalDetId"/>
-<use name="DataFormats/ForwardDetId"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
-<use name="SimDataFormats/CaloTest"/>
-<use name="SimDataFormats/GeneratorProducts"/>
-<use name="SimDataFormats/HcalTestBeam"/>
-<use name="SimDataFormats/Track"/>
-<use name="SimDataFormats/Vertex"/>
 <use name="SimG4CMS/Calo"/>
 <use name="SimG4Core/Notification"/>
-<use name="SimG4Core/Watcher"/>
 <use name="geant4core"/>
 <use name="clhep"/>
 <use name="rootphysics"/>

--- a/SimG4CMS/HGCalTestBeam/plugins/BuildFile.xml
+++ b/SimG4CMS/HGCalTestBeam/plugins/BuildFile.xml
@@ -12,7 +12,6 @@
 <use name="SimDataFormats/HcalTestBeam"/>
 <use name="SimDataFormats/Track"/>
 <use name="SimDataFormats/Vertex"/>
-<use name="SimG4CMS/Calo"/>
 <use name="SimG4CMS/HGCalTestBeam"/>
 <use name="SimG4Core/Notification"/>
 <use name="SimG4Core/Watcher"/>

--- a/SimG4CMS/HcalTestBeam/BuildFile.xml
+++ b/SimG4CMS/HcalTestBeam/BuildFile.xml
@@ -1,10 +1,8 @@
 <use name="DataFormats/HcalDetId"/>
-<use name="DataFormats/Math"/>
 <use name="Geometry/EcalCommonData"/>
 <use name="Geometry/HcalTestBeamData"/>
 <use name="SimDataFormats/HcalTestBeam"/>
 <use name="SimG4Core/Notification"/>
-<use name="SimG4Core/Watcher"/>
 <use name="SimG4CMS/Calo"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>

--- a/SimG4CMS/HcalTestBeam/plugins/BuildFile.xml
+++ b/SimG4CMS/HcalTestBeam/plugins/BuildFile.xml
@@ -1,6 +1,5 @@
 <use name="DataFormats/HcalDetId"/>
 <use name="DataFormats/Math"/>
-<use name="Geometry/EcalCommonData"/>
 <use name="Geometry/HcalTestBeamData"/>
 <use name="SimDataFormats/HcalTestBeam"/>
 <use name="SimG4Core/Notification"/>
@@ -9,7 +8,6 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/MessageLogger"/>
-<use name="FWCore/ServiceRegistry"/>
 <use name="CommonTools/UtilAlgos"/>
 <use name="SimG4CMS/HcalTestBeam"/>
 <use name="geant4core"/>

--- a/SimG4CMS/Muon/BuildFile.xml
+++ b/SimG4CMS/Muon/BuildFile.xml
@@ -1,6 +1,5 @@
 <use name="CondFormats/GeometryObjects"/>
 <use name="Geometry/MuonNumbering"/>
-<use name="Geometry/Records"/>
 <use name="SimG4Core/SensitiveDetector"/>
 <use name="SimG4Core/Notification"/>
 <use name="SimG4Core/Physics"/>

--- a/SimG4CMS/Muon/plugins/BuildFile.xml
+++ b/SimG4CMS/Muon/plugins/BuildFile.xml
@@ -1,8 +1,7 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
-<use name="FWCore/MessageLogger"/>
 <use name="FWCore/PluginManager"/>
-<use name="FWCore/ServiceRegistry"/>
+<use name="Geometry/Records"/>
 <use name="SimG4CMS/Muon"/>
 <use name="boost"/>
 <use name="geant4core"/>

--- a/SimG4CMS/ShowerLibraryProducer/plugins/BuildFile.xml
+++ b/SimG4CMS/ShowerLibraryProducer/plugins/BuildFile.xml
@@ -1,8 +1,6 @@
 <use name="root"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
-<use name="FWCore/MessageLogger"/>
-<use name="FWCore/ServiceRegistry"/>
 <use name="FWCore/PluginManager"/>
 <use name="Geometry/HcalCommonData"/>
 <use name="Geometry/Records"/>

--- a/SimG4CMS/Tracker/BuildFile.xml
+++ b/SimG4CMS/Tracker/BuildFile.xml
@@ -1,7 +1,6 @@
 <use name="SimG4Core/SensitiveDetector"/>
 <use name="SimG4Core/Notification"/>
 <use name="SimG4Core/Physics"/>
-<use name="Geometry/Records"/>
 <use name="Geometry/TrackerNumberingBuilder"/>
 <use name="geant4core"/>
 <use name="SimDataFormats/SimHitMaker"/>

--- a/SimG4CMS/Tracker/plugins/BuildFile.xml
+++ b/SimG4CMS/Tracker/plugins/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="Geometry/Records"/>
 <use name="SimG4CMS/Tracker"/>
 <use name="SimG4Core/SensitiveDetector"/>
 <use name="geant4core"/>

--- a/SimG4Core/Application/test/BuildFile.xml
+++ b/SimG4Core/Application/test/BuildFile.xml
@@ -1,7 +1,5 @@
 <environment>
   <use name="FWCore/Framework"/>
-  <use name="PhysicsTools/UtilAlgos"/>
-  <use name="FWCore/ServiceRegistry"/>
   <library file="SimHitCaloHitDumper.cc" name="SimHitCaloHitDumper">
     <use name="SimDataFormats/TrackingHit"/>
     <use name="SimDataFormats/CaloHit"/>

--- a/SimGeneral/Debugging/test/BuildFile.xml
+++ b/SimGeneral/Debugging/test/BuildFile.xml
@@ -8,8 +8,6 @@
   <use name="DataFormats/CSCDigi"/>
   <use name="DataFormats/RPCDigi"/>
   <use name="DataFormats/FTLDigi"/>
-  <use name="PhysicsTools/UtilAlgos"/>
-  <use name="FWCore/ServiceRegistry"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/MessageLogger"/>
   <library file="SimDigiDumper.cc" name="SimDigiDumper">


### PR DESCRIPTION
#### PR description:

Another quick BuildFile cleaning PR in the style of many before (for example https://github.com/cms-sw/cmssw/pull/34544).

This PR cleans unnecessary includes from CMSSW BuildFiles that were recently added for 12_1_0_pre1.

#### PR validation:

CMSSW compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport intended.