### PR TITLE
Migrate module configuration in RecoPixelVertexing to use default cfipython

### DIFF
--- a/RecoPixelVertexing/PixelLowPtUtilities/python/AllPixelTracks_cfi.py
+++ b/RecoPixelVertexing/PixelLowPtUtilities/python/AllPixelTracks_cfi.py
@@ -3,13 +3,12 @@ import FWCore.ParameterSet.Config as cms
 from RecoPixelVertexing.PixelLowPtUtilities.clusterShapeTrackFilter_cfi import clusterShapeTrackFilter
 from RecoPixelVertexing.PixelLowPtUtilities.trackFitter_cfi import trackFitter
 from RecoPixelVertexing.PixelLowPtUtilities.trackCleaner_cfi import trackCleaner
+import RecoPixelVertexing.PixelTrackFitting.pixelTracks_cfi as _mod
 
 ##########################
 # The base for all steps
-allPixelTracks = cms.EDProducer("PixelTrackProducer",
-
-    passLabel  = cms.string(''),
-
+allPixelTracks = _mod.pixelTracks.clone(
+    passLabel  = '',
     # Region
     RegionFactoryPSet = cms.PSet(
         ComponentName = cms.string('GlobalTrackingRegionWithVerticesProducer'),
@@ -27,7 +26,6 @@ allPixelTracks = cms.EDProducer("PixelTrackProducer",
             nSigmaZ          = cms.double(3.0)
         )
     ),
-     
     # Ordered hits
     OrderedHitsFactoryPSet = cms.PSet(
         ComponentName = cms.string('StandardHitTripletGenerator'),
@@ -45,7 +43,7 @@ allPixelTracks = cms.EDProducer("PixelTrackProducer",
     ),
 
     # Filter
-    Filter = cms.InputTag("clusterShapeTrackFilter"),
+    Filter = "clusterShapeTrackFilter",
 
     # Cleaner
     CleanerPSet = cms.string("trackCleaner"),


### PR DESCRIPTION
#### PR description: 
Optimization of the python configurations: Improve maintainability by cleaning up the duplicated and cloning from the default/reference configurations. (The previous PRs : #33207, #33307, #33352, #33543, #33563, #33671, #34007, #34091, #34009, #34155, #34371, #34480, #34543, #34571 )
 
In this PR, 1 file changed.  
        modified:   RecoPixelVertexing/PixelLowPtUtilities/python/AllPixelTracks_cfi.py

Update
- Replace explicit configuration with a reference from cfipython/. (migrating EDProducer("type", .. -> typeDefaylt.clone() ) 
- Remove the type specifications already presented in cfipython/fillDescriptions reference for improved syntax safety.

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_12_0_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).