### PR TITLE
Migrate module configuration in RecoVertex to use default cfipython

### DIFF
--- a/RecoVertex/PrimaryVertexProducer/python/OfflinePixel3DPrimaryVertices_cfi.py
+++ b/RecoVertex/PrimaryVertexProducer/python/OfflinePixel3DPrimaryVertices_cfi.py
@@ -1,34 +1,23 @@
 import FWCore.ParameterSet.Config as cms
+import RecoVertex.PrimaryVertexProducer.primaryVertexProducer_cfi as _mod
 
-pixelVertices = cms.EDProducer("PrimaryVertexProducer",
+pixelVertices = _mod.primaryVertexProducer.clone(
+    TrackLabel = "pixelTracks",
 
-    verbose = cms.untracked.bool(False),
-    TrackLabel = cms.InputTag("pixelTracks"),
-    beamSpotLabel = cms.InputTag("offlineBeamSpot"),
-                                        
-    TkFilterParameters = cms.PSet(
-        algorithm=cms.string('filter'),
-        maxNormalizedChi2 = cms.double(100.0),
-        minPixelLayersWithHits=cms.int32(3),
-        minSiliconLayersWithHits = cms.int32(3),
-        maxD0Significance = cms.double(100.0), 
-        minPt = cms.double(0.0),
-        maxEta = cms.double(100.),
-        trackQuality = cms.string("any")
+    TkFilterParameters = dict(
+        maxNormalizedChi2 = 100.0,
+        minPixelLayersWithHits=3,
+        minSiliconLayersWithHits = 3,
+        maxD0Significance = 100.0, 
+        maxEta = 100.,
     ),
 
-    TkClusParameters = cms.PSet(
-        algorithm = cms.string('DA_vect'),
-        TkDAClusParameters = cms.PSet(
-            dzCutOff = cms.double(4.0),
-            d0CutOff = cms.double(3.0),
-            Tmin = cms.double(2.4),
-            Tpurge = cms.double(2.0),
-            Tstop = cms.double(0.5),
-            coolingFactor = cms.double(0.6),
-            vertexSize = cms.double(0.01),
-            zmerge = cms.double(0.01),
-            uniquetrkweight = cms.double(0.9)
+    TkClusParameters = dict(
+        TkDAClusParameters = dict(
+            dzCutOff = 4.0,
+            Tmin = 2.4,
+            vertexSize = 0.01,
+            uniquetrkweight = 0.9
         )
     ),
 
@@ -42,9 +31,4 @@ pixelVertices = cms.EDProducer("PrimaryVertexProducer",
                )
       ]
     )
-                                        
-
-                                        
 )
-
-

--- a/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVerticesFromCosmicTracks_cfi.py
+++ b/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVerticesFromCosmicTracks_cfi.py
@@ -11,7 +11,6 @@ offlinePrimaryVerticesFromCosmicTracks = _mod.primaryVertexProducer.clone(
         maxD0Significance = 5.0, ## keep most primary tracks
         maxD0Error = 10.0,
         maxDzError = 10.0,
-        minPt = 0.0, ## better for softish events
         maxEta = 5.0, 
         minPixelLayersWithHits = 2, ## hits > 2
     ),

--- a/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVerticesFromCosmicTracks_cfi.py
+++ b/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVerticesFromCosmicTracks_cfi.py
@@ -1,28 +1,25 @@
 import FWCore.ParameterSet.Config as cms
+import RecoVertex.PrimaryVertexProducer.primaryVertexProducer_cfi as _mod
 
-offlinePrimaryVerticesFromCosmicTracks = cms.EDProducer("PrimaryVertexProducer",
-
-    verbose = cms.untracked.bool(False),
-    TrackLabel = cms.InputTag("ctfWithMaterialTracksP5"),
-    beamSpotLabel = cms.InputTag("offlineBeamSpot"),
+offlinePrimaryVerticesFromCosmicTracks = _mod.primaryVertexProducer.clone(
+    TrackLabel    = "ctfWithMaterialTracksP5",
+    beamSpotLabel = "offlineBeamSpot",
                                         
-    TkFilterParameters = cms.PSet(
-        algorithm=cms.string('filter'),
-        maxNormalizedChi2 = cms.double(5.0),
-        minSiliconLayersWithHits = cms.int32(7), ## hits > 7
-        maxD0Significance = cms.double(5.0), ## keep most primary tracks
-        maxD0Error = cms.double(10.0),
-        maxDzError = cms.double(10.0),
-        minPt = cms.double(0.0), ## better for softish events
-        maxEta = cms.double(5.0), 
-        minPixelLayersWithHits = cms.int32(2), ## hits > 2
-        trackQuality = cms.string("any")
+    TkFilterParameters = dict(
+        maxNormalizedChi2 = 5.0,
+        minSiliconLayersWithHits = 7, ## hits > 7
+        maxD0Significance = 5.0, ## keep most primary tracks
+        maxD0Error = 10.0,
+        maxDzError = 10.0,
+        minPt = 0.0, ## better for softish events
+        maxEta = 5.0, 
+        minPixelLayersWithHits = 2, ## hits > 2
     ),
 
-    TkClusParameters = cms.PSet(
-        algorithm   = cms.string("gap"),
-        TkGapClusParameters = cms.PSet( 
-            zSeparation = cms.double(0.1) ## 1 mm max separation betw. clusters
+    TkClusParameters = dict(
+        algorithm   = "gap",
+        TkGapClusParameters = dict( 
+            zSeparation = 0.1 ## 1 mm max separation betw. clusters
         )
     ),
 
@@ -36,9 +33,4 @@ offlinePrimaryVerticesFromCosmicTracks = cms.EDProducer("PrimaryVertexProducer",
                )
       ]
     )
-                                        
-
-                                        
 )
-
-


### PR DESCRIPTION
#### PR description: 
Optimization of the python configurations: Improve maintainability by cleaning up the duplicated and cloning from the default/reference configurations. (The previous PRs : #33207, #33307, #33352, #33543, #33563, #33671, #34007, #34091, #34009, #34155, #34371, #34480, #34543, #34571 )
 
In this PR, 2 files changed.  
        modified:   RecoVertex/PrimaryVertexProducer/python/OfflinePixel3DPrimaryVertices_cfi.py
        modified:   RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVerticesFromCosmicTracks_cfi.py

Update
- Replace explicit configuration with a reference from cfipython/. (migrating EDProducer("type", .. -> typeDefaylt.clone() ) 
- Remove the type specifications already presented in cfipython/fillDescriptions reference for improved syntax safety.
- Remove the duplicated parameters that are exactly the same value in cfipython reference.

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_12_0_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).