### PR TITLE
Better handling of timeout in FWCore/SharedMemory [10_6]

### DIFF
--- a/FWCore/SharedMemory/interface/ControllerChannel.h
+++ b/FWCore/SharedMemory/interface/ControllerChannel.h
@@ -59,15 +59,12 @@ namespace edm::shared_memory {
       iF();
       using namespace boost::posix_time;
       //std::cout << id_ << " waiting for external process" << std::endl;
-      *transitionID_ = std::numeric_limits<unsigned long long>::max();
-      if (not cndToMain_.timed_wait(lock, microsec_clock::universal_time() + seconds(maxWaitInSeconds_))) {
+      if (not wait(lock)) {
         //std::cout << id_ << " FAILED waiting for external process" << std::endl;
-        if (*transitionID_ == std::numeric_limits<unsigned long long>::max()) {
-          *stop_ = true;
-          throw cms::Exception("ExternalFailed")
-              << "Failed waiting for external process while setting up the process. Timed out after "
-              << maxWaitInSeconds_ << " seconds.";
-        }
+        *stop_ = true;
+        throw cms::Exception("ExternalFailed")
+            << "Failed waiting for external process while setting up the process. Timed out after " << maxWaitInSeconds_
+            << " seconds.";
       } else {
         //std::cout << id_ << " done waiting for external process" << std::endl;
       }
@@ -82,24 +79,19 @@ namespace edm::shared_memory {
       scoped_lock<named_mutex> lock(mutex_);
       iF();
       using namespace boost::posix_time;
-      *transitionID_ = std::numeric_limits<unsigned long long>::max();
       //std::cout << id_ << " waiting for external process" << std::endl;
       bool shouldContinue = true;
       long long int retryCount = 0;
       do {
-        if (not cndToMain_.timed_wait(lock, microsec_clock::universal_time() + seconds(maxWaitInSeconds_))) {
-          if (*transitionID_ == std::numeric_limits<unsigned long long>::max()) {
-            if (not iRetry()) {
-              *stop_ = true;
-              throw cms::Exception("ExternalFailed")
-                  << "Failed waiting for external process while setting up the process. Timed out after "
-                  << maxWaitInSeconds_ << " seconds with " << retryCount << " retries.";
-            }
-            //std::cerr<<"retrying\n";
-            ++retryCount;
-          } else {
-            shouldContinue = false;
+        if (not wait(lock)) {
+          if (not iRetry()) {
+            *stop_ = true;
+            throw cms::Exception("ExternalFailed")
+                << "Failed waiting for external process while setting up the process. Timed out after "
+                << maxWaitInSeconds_ << " seconds with " << retryCount << " retries.";
           }
+          //std::cerr<<"retrying\n";
+          ++retryCount;
         } else {
           shouldContinue = false;
         }
@@ -112,8 +104,7 @@ namespace edm::shared_memory {
 
       //std::cout << id_ << " taking from lock" << std::endl;
       scoped_lock<named_mutex> lock(mutex_);
-
-      if (not wait(lock, iTrans, iTransitionID) and *transitionID_ == iTransitionID) {
+      if (not wait(lock, iTrans, iTransitionID)) {
         return false;
       }
       //std::cout <<id_<<"running doTranstion command"<<std::endl;
@@ -127,15 +118,14 @@ namespace edm::shared_memory {
 
       //std::cout << id_ << " taking from lock" << std::endl;
       scoped_lock<named_mutex> lock(mutex_);
-      if (not wait(lock, iTrans, iTransitionID) and *transitionID_ == iTransitionID) {
+      if (not wait(lock, iTrans, iTransitionID)) {
         if (not iRetry()) {
           return false;
         }
         bool shouldContinue = true;
         do {
           using namespace boost::posix_time;
-          if (not cndToMain_.timed_wait(lock, microsec_clock::universal_time() + seconds(maxWaitInSeconds_)) and
-              *transitionID_ == iTransitionID) {
+          if (not continueWait(lock)) {
             if (not iRetry()) {
               return false;
             }
@@ -170,7 +160,20 @@ namespace edm::shared_memory {
     //should only be called after calling `doTransition`
     bool shouldKeepEvent() const { return *keepEvent_; }
 
+    unsigned int maxWaitInSeconds() const noexcept { return maxWaitInSeconds_; }
+
   private:
+    struct CheckWorkerStatus {
+      const unsigned long long initValue_;
+      const unsigned long long* ptr_;
+
+      [[nodiscard]] bool workerFinished() const noexcept { return initValue_ != *ptr_; }
+    };
+
+    [[nodiscard]] CheckWorkerStatus initCheckWorkerStatus(unsigned long long* iPtr) const noexcept {
+      return {*iPtr, iPtr};
+    }
+
     static BufferInfo* bufferInfo(const char* iWhich, boost::interprocess::managed_shared_memory& mem);
 
     std::string uniqueName(std::string iBase) const;
@@ -178,6 +181,8 @@ namespace edm::shared_memory {
     bool wait(boost::interprocess::scoped_lock<boost::interprocess::named_mutex>& lock,
               edm::Transition iTrans,
               unsigned long long iTransID);
+    bool wait(boost::interprocess::scoped_lock<boost::interprocess::named_mutex>& lock);
+    bool continueWait(boost::interprocess::scoped_lock<boost::interprocess::named_mutex>& lock);
 
     // ---------- member data --------------------------------
     int id_;

--- a/FWCore/SharedMemory/interface/WorkerChannel.h
+++ b/FWCore/SharedMemory/interface/WorkerChannel.h
@@ -55,7 +55,6 @@ namespace edm::shared_memory {
     ///Matches the ControllerChannel::setupWorker call
     void workerSetupDone() {
       //The controller is waiting for the worker to be setup
-      *transitionID_ = 0;
       notifyController();
     }
 
@@ -83,7 +82,8 @@ namespace edm::shared_memory {
 
     ///These are here for expert use
     void notifyController() {
-      *transitionID_ = (*transitionID_ == 0 ? 1 : 0);
+      //change in transitionID_ used to signal worker finished
+      *transitionID_ = ~(*transitionID_);
       cndToController_.notify_all();
     }
     void waitForController() { cndFromController_.wait(lock_); }

--- a/FWCore/SharedMemory/interface/WorkerChannel.h
+++ b/FWCore/SharedMemory/interface/WorkerChannel.h
@@ -55,6 +55,7 @@ namespace edm::shared_memory {
     ///Matches the ControllerChannel::setupWorker call
     void workerSetupDone() {
       //The controller is waiting for the worker to be setup
+      *transitionID_ = 0;
       notifyController();
     }
 
@@ -63,6 +64,9 @@ namespace edm::shared_memory {
      */
     template <typename F>
     void handleTransitions(F&& iF) {
+      if (stopRequested()) {
+        return;
+      }
       while (true) {
         waitForController();
         if (stopRequested()) {
@@ -78,7 +82,10 @@ namespace edm::shared_memory {
     void shouldKeepEvent(bool iChoice) { *keepEvent_ = iChoice; }
 
     ///These are here for expert use
-    void notifyController() { cndToController_.notify_all(); }
+    void notifyController() {
+      *transitionID_ = (*transitionID_ == 0 ? 1 : 0);
+      cndToController_.notify_all();
+    }
     void waitForController() { cndFromController_.wait(lock_); }
 
     // ---------- const member functions ---------------------------

--- a/FWCore/SharedMemory/test/BuildFile.xml
+++ b/FWCore/SharedMemory/test/BuildFile.xml
@@ -8,6 +8,27 @@
   <use name="FWCore/Utilities"/>
 </bin>
 
+<bin file="test_channels_okTimeout.cc" name="testFWCoreSharedMemoryChannelsOkTimeout">
+  <use name="FWCore/SharedMemory"/>
+  <use name="FWCore/Utilities"/>
+</bin>
+
+<bin file="test_channels_startupTimeout.cc" name="testFWCoreSharedMemoryChannelsStartupTimeout">
+  <use name="FWCore/SharedMemory"/>
+  <use name="FWCore/Utilities"/>
+</bin>
+
+<bin file="test_channels_transitionTimeout.cc" name="testFWCoreSharedMemoryChannelsTransitionTimeout">
+  <use name="FWCore/SharedMemory"/>
+  <use name="FWCore/Utilities"/>
+</bin>
+
+<bin file="test_channels_retry.cc" name="testFWCoreSharedMemoryChannelsRetry">
+  <use name="FWCore/SharedMemory"/>
+  <use name="FWCore/Utilities"/>
+</bin>
+
+
 <bin file="test_monitorthread.cc" name="testFWCoreSharedMemoryMonitorThread">
   <use name="FWCore/SharedMemory"/>
   <use name="FWCore/Utilities"/>

--- a/FWCore/SharedMemory/test/controller.h
+++ b/FWCore/SharedMemory/test/controller.h
@@ -1,0 +1,95 @@
+#if !defined(TEST_CONTROLLER)
+#define TEST_CONTROLLER
+#include "FWCore/SharedMemory/interface/ControllerChannel.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include <memory>
+#include <string>
+#include <stdio.h>
+int controller(int argc, char** argv, unsigned int iTimeout) {
+  using namespace edm::shared_memory;
+
+  ControllerChannel channel("TestChannel", 0, iTimeout);
+
+  //Pipe has to close AFTER we tell the worker to stop
+  auto closePipe = [](FILE* iFile) { pclose(iFile); };
+  std::unique_ptr<FILE, decltype(closePipe)> pipe(nullptr, closePipe);
+
+  auto stopWorkerCmd = [](ControllerChannel* iChannel) { iChannel->stopWorker(); };
+  std::unique_ptr<ControllerChannel, decltype(stopWorkerCmd)> stopWorkerGuard(&channel, stopWorkerCmd);
+
+  {
+    std::string command(argv[0]);
+    command += " ";
+    command += channel.sharedMemoryName();
+    command += " ";
+    command += channel.uniqueID();
+    //make sure output is flushed before popen does any writing
+    fflush(stdout);
+    fflush(stderr);
+
+    channel.setupWorker([&]() {
+      pipe.reset(popen(command.c_str(), "w"));
+
+      if (not pipe) {
+        throw cms::Exception("PipeFailed") << "pipe failed to open " << command;
+      }
+    });
+  }
+  {
+    *channel.toWorkerBufferInfo() = {0, 0};
+    auto result = channel.doTransition(
+        [&]() {
+          if (channel.fromWorkerBufferInfo()->index_ != 1) {
+            throw cms::Exception("BadValue") << "wrong index value of fromWorkerBufferInfo "
+                                             << static_cast<int>(channel.fromWorkerBufferInfo()->index_);
+          }
+          if (channel.fromWorkerBufferInfo()->identifier_ != 1) {
+            throw cms::Exception("BadValue")
+                << "wrong identifier value of fromWorkerBufferInfo " << channel.fromWorkerBufferInfo()->identifier_;
+          }
+          if (not channel.shouldKeepEvent()) {
+            throw cms::Exception("BadValue") << "told not to keep event";
+          }
+        },
+        edm::Transition::Event,
+        2);
+    if (not result) {
+      throw cms::Exception("TimeOut") << "doTransition timed out";
+    }
+  }
+  {
+    *channel.toWorkerBufferInfo() = {1, 1};
+    auto result = channel.doTransition(
+        [&]() {
+          if (channel.fromWorkerBufferInfo()->index_ != 0) {
+            throw cms::Exception("BadValue") << "wrong index value of fromWorkerBufferInfo "
+                                             << static_cast<int>(channel.fromWorkerBufferInfo()->index_);
+          }
+          if (channel.fromWorkerBufferInfo()->identifier_ != 2) {
+            throw cms::Exception("BadValue")
+                << "wrong identifier value of fromWorkerBufferInfo " << channel.fromWorkerBufferInfo()->identifier_;
+          }
+          if (channel.shouldKeepEvent()) {
+            throw cms::Exception("BadValue") << "told to keep event";
+          }
+        },
+        edm::Transition::Event,
+        3);
+    if (not result) {
+      throw cms::Exception("TimeOut") << "doTransition timed out";
+    }
+  }
+
+  {
+    auto result = channel.doTransition([&]() {}, edm::Transition::EndLuminosityBlock, 1);
+    if (not result) {
+      throw cms::Exception("TimeOut") << "doTransition timed out";
+    }
+  }
+
+  //std::cout <<"controller going to stop"<<std::endl;
+  return 0;
+}
+
+#endif

--- a/FWCore/SharedMemory/test/test_channels.cc
+++ b/FWCore/SharedMemory/test/test_channels.cc
@@ -6,174 +6,16 @@
 #include <string>
 #include <stdio.h>
 #include <cassert>
+
+#include "controller.h"
+#include "worker.h"
 namespace {
-  int controller(int argc, char** argv) {
-    using namespace edm::shared_memory;
-
-    ControllerChannel channel("TestChannel", 0, 60);
-
-    //Pipe has to close AFTER we tell the worker to stop
-    auto closePipe = [](FILE* iFile) { pclose(iFile); };
-    std::unique_ptr<FILE, decltype(closePipe)> pipe(nullptr, closePipe);
-
-    auto stopWorkerCmd = [](ControllerChannel* iChannel) { iChannel->stopWorker(); };
-    std::unique_ptr<ControllerChannel, decltype(stopWorkerCmd)> stopWorkerGuard(&channel, stopWorkerCmd);
-
-    {
-      std::string command(argv[0]);
-      command += " ";
-      command += channel.sharedMemoryName();
-      command += " ";
-      command += channel.uniqueID();
-      //make sure output is flushed before popen does any writing
-      fflush(stdout);
-      fflush(stderr);
-
-      channel.setupWorker([&]() {
-        pipe.reset(popen(command.c_str(), "w"));
-
-        if (not pipe) {
-          throw cms::Exception("PipeFailed") << "pipe failed to open " << command;
-        }
-      });
-    }
-    {
-      *channel.toWorkerBufferInfo() = {0, 0};
-      auto result = channel.doTransition(
-          [&]() {
-            if (channel.fromWorkerBufferInfo()->index_ != 1) {
-              throw cms::Exception("BadValue") << "wrong index value of fromWorkerBufferInfo "
-                                               << static_cast<int>(channel.fromWorkerBufferInfo()->index_);
-            }
-            if (channel.fromWorkerBufferInfo()->identifier_ != 1) {
-              throw cms::Exception("BadValue")
-                  << "wrong identifier value of fromWorkerBufferInfo " << channel.fromWorkerBufferInfo()->identifier_;
-            }
-            if (not channel.shouldKeepEvent()) {
-              throw cms::Exception("BadValue") << "told not to keep event";
-            }
-          },
-          edm::Transition::Event,
-          2);
-      if (not result) {
-        throw cms::Exception("TimeOut") << "doTransition timed out";
-      }
-    }
-    {
-      *channel.toWorkerBufferInfo() = {1, 1};
-      auto result = channel.doTransition(
-          [&]() {
-            if (channel.fromWorkerBufferInfo()->index_ != 0) {
-              throw cms::Exception("BadValue") << "wrong index value of fromWorkerBufferInfo "
-                                               << static_cast<int>(channel.fromWorkerBufferInfo()->index_);
-            }
-            if (channel.fromWorkerBufferInfo()->identifier_ != 2) {
-              throw cms::Exception("BadValue")
-                  << "wrong identifier value of fromWorkerBufferInfo " << channel.fromWorkerBufferInfo()->identifier_;
-            }
-            if (channel.shouldKeepEvent()) {
-              throw cms::Exception("BadValue") << "told to keep event";
-            }
-          },
-          edm::Transition::Event,
-          3);
-      if (not result) {
-        throw cms::Exception("TimeOut") << "doTransition timed out";
-      }
-    }
-
-    {
-      auto result = channel.doTransition([&]() {}, edm::Transition::EndLuminosityBlock, 1);
-      if (not result) {
-        throw cms::Exception("TimeOut") << "doTransition timed out";
-      }
-    }
-
-    //std::cout <<"controller going to stop"<<std::endl;
-    return 0;
-  }
-
-  int worker(int argc, char** argv) {
-    using namespace edm::shared_memory;
-
-    assert(argc == 3);
-    WorkerChannel channel(argv[1], argv[2]);
-
-    //std::cerr<<"worker setup\n";
-    channel.workerSetupDone();
-
-    int transitionCount = 0;
-    channel.handleTransitions([&](edm::Transition iTransition, unsigned long long iTransitionID) {
-      switch (transitionCount) {
-        case 0: {
-          if (iTransition != edm::Transition::Event) {
-            throw cms::Exception("BadValue") << "wrong transition received " << static_cast<int>(iTransition);
-          }
-          if (iTransitionID != 2ULL) {
-            throw cms::Exception("BadValue") << "wrong transitionID received " << static_cast<int>(iTransitionID);
-          }
-
-          if (channel.toWorkerBufferInfo()->index_ != 0) {
-            throw cms::Exception("BadValue")
-                << "wrong toWorkerBufferInfo index received " << static_cast<int>(channel.toWorkerBufferInfo()->index_);
-          }
-          if (channel.toWorkerBufferInfo()->identifier_ != 0) {
-            throw cms::Exception("BadValue")
-                << "wrong toWorkerBufferInfo identifier received " << channel.toWorkerBufferInfo()->identifier_;
-          }
-          *channel.fromWorkerBufferInfo() = {1, 1};
-          channel.shouldKeepEvent(true);
-          break;
-        }
-
-        case 1: {
-          if (iTransition != edm::Transition::Event) {
-            throw cms::Exception("BadValue") << "wrong transition received " << static_cast<int>(iTransition);
-          }
-          if (iTransitionID != 3ULL) {
-            throw cms::Exception("BadValue") << "wrong transitionID received " << static_cast<int>(iTransitionID);
-          }
-
-          if (channel.toWorkerBufferInfo()->index_ != 1) {
-            throw cms::Exception("BadValue")
-                << "wrong toWorkerBufferInfo index received " << static_cast<int>(channel.toWorkerBufferInfo()->index_);
-          }
-          if (channel.toWorkerBufferInfo()->identifier_ != 1) {
-            throw cms::Exception("BadValue")
-                << "wrong toWorkerBufferInfo identifier received " << channel.toWorkerBufferInfo()->identifier_;
-          }
-          *channel.fromWorkerBufferInfo() = {2, 0};
-          channel.shouldKeepEvent(false);
-          break;
-        }
-
-        case 2: {
-          if (iTransition != edm::Transition::EndLuminosityBlock) {
-            throw cms::Exception("BadValue") << "wrong transition received " << static_cast<int>(iTransition);
-          }
-          if (iTransitionID != 1ULL) {
-            throw cms::Exception("BadValue") << "wrong transitionID received " << static_cast<int>(iTransitionID);
-          }
-          break;
-        }
-        default: {
-          throw cms::Exception("MissingStop") << "stopRequested not set";
-        }
-      }
-      ++transitionCount;
-    });
-    if (transitionCount != 3) {
-      throw cms::Exception("MissingStop") << "stop requested too soon " << transitionCount;
-    }
-    return 0;
-  }
   const char* jobType(bool isWorker) {
     if (isWorker) {
       return "Worker";
     }
     return "Controller";
   }
-
 }  // namespace
 
 int main(int argc, char** argv) {
@@ -181,10 +23,10 @@ int main(int argc, char** argv) {
   int retValue = 0;
   try {
     if (argc > 1) {
-      retValue = worker(argc, argv);
+      retValue = worker(argc, argv, WorkerType::kStandard);
     } else {
       isWorker = false;
-      retValue = controller(argc, argv);
+      retValue = controller(argc, argv, 60);
     }
   } catch (std::exception const& iException) {
     std::cerr << "Caught exception\n" << iException.what() << "\n";

--- a/FWCore/SharedMemory/test/test_channels_okTimeout.cc
+++ b/FWCore/SharedMemory/test/test_channels_okTimeout.cc
@@ -1,0 +1,215 @@
+#include "FWCore/SharedMemory/interface/ControllerChannel.h"
+#include "FWCore/SharedMemory/interface/WorkerChannel.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include <memory>
+#include <string>
+#include <stdio.h>
+#include <cassert>
+#include <thread>
+
+namespace {
+  int controller(int argc, char** argv) {
+    using namespace edm::shared_memory;
+
+    ControllerChannel channel("TestChannel", 0, 5);
+
+    //Pipe has to close AFTER we tell the worker to stop
+    auto closePipe = [](FILE* iFile) { pclose(iFile); };
+    std::unique_ptr<FILE, decltype(closePipe)> pipe(nullptr, closePipe);
+
+    auto stopWorkerCmd = [](ControllerChannel* iChannel) { iChannel->stopWorker(); };
+    std::unique_ptr<ControllerChannel, decltype(stopWorkerCmd)> stopWorkerGuard(&channel, stopWorkerCmd);
+
+    {
+      std::string command(argv[0]);
+      command += " ";
+      command += channel.sharedMemoryName();
+      command += " ";
+      command += channel.uniqueID();
+      //make sure output is flushed before popen does any writing
+      fflush(stdout);
+      fflush(stderr);
+
+      channel.setupWorker([&]() {
+        pipe.reset(popen(command.c_str(), "w"));
+
+        if (not pipe) {
+          throw cms::Exception("PipeFailed") << "pipe failed to open " << command;
+        }
+      });
+    }
+    {
+      *channel.toWorkerBufferInfo() = {0, 0};
+      auto result = channel.doTransition(
+          [&]() {
+            if (channel.fromWorkerBufferInfo()->index_ != 1) {
+              throw cms::Exception("BadValue") << "wrong index value of fromWorkerBufferInfo "
+                                               << static_cast<int>(channel.fromWorkerBufferInfo()->index_);
+            }
+            if (channel.fromWorkerBufferInfo()->identifier_ != 1) {
+              throw cms::Exception("BadValue")
+                  << "wrong identifier value of fromWorkerBufferInfo " << channel.fromWorkerBufferInfo()->identifier_;
+            }
+            if (not channel.shouldKeepEvent()) {
+              throw cms::Exception("BadValue") << "told not to keep event";
+            }
+          },
+          edm::Transition::Event,
+          2);
+      if (not result) {
+        throw cms::Exception("TimeOut") << "doTransition timed out";
+      }
+    }
+    {
+      *channel.toWorkerBufferInfo() = {1, 1};
+      auto result = channel.doTransition(
+          [&]() {
+            if (channel.fromWorkerBufferInfo()->index_ != 0) {
+              throw cms::Exception("BadValue") << "wrong index value of fromWorkerBufferInfo "
+                                               << static_cast<int>(channel.fromWorkerBufferInfo()->index_);
+            }
+            if (channel.fromWorkerBufferInfo()->identifier_ != 2) {
+              throw cms::Exception("BadValue")
+                  << "wrong identifier value of fromWorkerBufferInfo " << channel.fromWorkerBufferInfo()->identifier_;
+            }
+            if (channel.shouldKeepEvent()) {
+              throw cms::Exception("BadValue") << "told to keep event";
+            }
+          },
+          edm::Transition::Event,
+          3);
+      if (not result) {
+        throw cms::Exception("TimeOut") << "doTransition timed out";
+      }
+    }
+
+    {
+      auto result = channel.doTransition([&]() {}, edm::Transition::EndLuminosityBlock, 1);
+      if (not result) {
+        throw cms::Exception("TimeOut") << "doTransition timed out";
+      }
+    }
+
+    //std::cout <<"controller going to stop"<<std::endl;
+    return 0;
+  }
+
+  int worker(int argc, char** argv) {
+    using namespace edm::shared_memory;
+
+    assert(argc == 3);
+    WorkerChannel channel(argv[1], argv[2]);
+
+    //simulate long time setting up
+    using namespace std::chrono_literals;
+    std::this_thread::sleep_for(20s);
+
+    //std::cerr<<"worker setup\n";
+    channel.workerSetupDone();
+
+    std::this_thread::sleep_for(20s);
+
+    int transitionCount = 0;
+    channel.handleTransitions([&](edm::Transition iTransition, unsigned long long iTransitionID) {
+      using namespace std::chrono_literals;
+      std::this_thread::sleep_for(20s);
+
+      switch (transitionCount) {
+        case 0: {
+          if (iTransition != edm::Transition::Event) {
+            throw cms::Exception("BadValue") << "wrong transition received " << static_cast<int>(iTransition);
+          }
+          if (iTransitionID != 2ULL) {
+            throw cms::Exception("BadValue") << "wrong transitionID received " << static_cast<int>(iTransitionID);
+          }
+
+          if (channel.toWorkerBufferInfo()->index_ != 0) {
+            throw cms::Exception("BadValue")
+                << "wrong toWorkerBufferInfo index received " << static_cast<int>(channel.toWorkerBufferInfo()->index_);
+          }
+          if (channel.toWorkerBufferInfo()->identifier_ != 0) {
+            throw cms::Exception("BadValue")
+                << "wrong toWorkerBufferInfo identifier received " << channel.toWorkerBufferInfo()->identifier_;
+          }
+          *channel.fromWorkerBufferInfo() = {1, 1};
+          channel.shouldKeepEvent(true);
+          break;
+        }
+
+        case 1: {
+          if (iTransition != edm::Transition::Event) {
+            throw cms::Exception("BadValue") << "wrong transition received " << static_cast<int>(iTransition);
+          }
+          if (iTransitionID != 3ULL) {
+            throw cms::Exception("BadValue") << "wrong transitionID received " << static_cast<int>(iTransitionID);
+          }
+
+          if (channel.toWorkerBufferInfo()->index_ != 1) {
+            throw cms::Exception("BadValue")
+                << "wrong toWorkerBufferInfo index received " << static_cast<int>(channel.toWorkerBufferInfo()->index_);
+          }
+          if (channel.toWorkerBufferInfo()->identifier_ != 1) {
+            throw cms::Exception("BadValue")
+                << "wrong toWorkerBufferInfo identifier received " << channel.toWorkerBufferInfo()->identifier_;
+          }
+          *channel.fromWorkerBufferInfo() = {2, 0};
+          channel.shouldKeepEvent(false);
+          break;
+        }
+
+        case 2: {
+          if (iTransition != edm::Transition::EndLuminosityBlock) {
+            throw cms::Exception("BadValue") << "wrong transition received " << static_cast<int>(iTransition);
+          }
+          if (iTransitionID != 1ULL) {
+            throw cms::Exception("BadValue") << "wrong transitionID received " << static_cast<int>(iTransitionID);
+          }
+          break;
+        }
+        default: {
+          throw cms::Exception("MissingStop") << "stopRequested not set";
+        }
+      }
+      ++transitionCount;
+    });
+    if (transitionCount != 3) {
+      throw cms::Exception("MissingStop") << "stop requested too soon " << transitionCount;
+    }
+    return 0;
+  }
+  const char* jobType(bool isWorker) {
+    if (isWorker) {
+      return "Worker";
+    }
+    return "Controller";
+  }
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  bool isWorker = true;
+  int retValue = 0;
+  try {
+    if (argc > 1) {
+      retValue = worker(argc, argv);
+    } else {
+      isWorker = false;
+      retValue = controller(argc, argv);
+    }
+  } catch (std::exception const& iException) {
+    std::cerr << "Caught exception\n" << iException.what() << "\n";
+    if (isWorker) {
+      std::cerr << "in worker\n";
+    } else {
+      std::cerr << "in controller\n";
+    }
+    return 1;
+  }
+  if (0 == retValue) {
+    std::cout << jobType(isWorker) << " success" << std::endl;
+  } else {
+    std::cout << jobType(isWorker) << " failed" << std::endl;
+  }
+  return 0;
+}

--- a/FWCore/SharedMemory/test/test_channels_okTimeout.cc
+++ b/FWCore/SharedMemory/test/test_channels_okTimeout.cc
@@ -8,183 +8,16 @@
 #include <cassert>
 #include <thread>
 
+#include "controller.h"
+#include "worker.h"
 namespace {
-  int controller(int argc, char** argv) {
-    using namespace edm::shared_memory;
 
-    ControllerChannel channel("TestChannel", 0, 5);
-
-    //Pipe has to close AFTER we tell the worker to stop
-    auto closePipe = [](FILE* iFile) { pclose(iFile); };
-    std::unique_ptr<FILE, decltype(closePipe)> pipe(nullptr, closePipe);
-
-    auto stopWorkerCmd = [](ControllerChannel* iChannel) { iChannel->stopWorker(); };
-    std::unique_ptr<ControllerChannel, decltype(stopWorkerCmd)> stopWorkerGuard(&channel, stopWorkerCmd);
-
-    {
-      std::string command(argv[0]);
-      command += " ";
-      command += channel.sharedMemoryName();
-      command += " ";
-      command += channel.uniqueID();
-      //make sure output is flushed before popen does any writing
-      fflush(stdout);
-      fflush(stderr);
-
-      channel.setupWorker([&]() {
-        pipe.reset(popen(command.c_str(), "w"));
-
-        if (not pipe) {
-          throw cms::Exception("PipeFailed") << "pipe failed to open " << command;
-        }
-      });
-    }
-    {
-      *channel.toWorkerBufferInfo() = {0, 0};
-      auto result = channel.doTransition(
-          [&]() {
-            if (channel.fromWorkerBufferInfo()->index_ != 1) {
-              throw cms::Exception("BadValue") << "wrong index value of fromWorkerBufferInfo "
-                                               << static_cast<int>(channel.fromWorkerBufferInfo()->index_);
-            }
-            if (channel.fromWorkerBufferInfo()->identifier_ != 1) {
-              throw cms::Exception("BadValue")
-                  << "wrong identifier value of fromWorkerBufferInfo " << channel.fromWorkerBufferInfo()->identifier_;
-            }
-            if (not channel.shouldKeepEvent()) {
-              throw cms::Exception("BadValue") << "told not to keep event";
-            }
-          },
-          edm::Transition::Event,
-          2);
-      if (not result) {
-        throw cms::Exception("TimeOut") << "doTransition timed out";
-      }
-    }
-    {
-      *channel.toWorkerBufferInfo() = {1, 1};
-      auto result = channel.doTransition(
-          [&]() {
-            if (channel.fromWorkerBufferInfo()->index_ != 0) {
-              throw cms::Exception("BadValue") << "wrong index value of fromWorkerBufferInfo "
-                                               << static_cast<int>(channel.fromWorkerBufferInfo()->index_);
-            }
-            if (channel.fromWorkerBufferInfo()->identifier_ != 2) {
-              throw cms::Exception("BadValue")
-                  << "wrong identifier value of fromWorkerBufferInfo " << channel.fromWorkerBufferInfo()->identifier_;
-            }
-            if (channel.shouldKeepEvent()) {
-              throw cms::Exception("BadValue") << "told to keep event";
-            }
-          },
-          edm::Transition::Event,
-          3);
-      if (not result) {
-        throw cms::Exception("TimeOut") << "doTransition timed out";
-      }
-    }
-
-    {
-      auto result = channel.doTransition([&]() {}, edm::Transition::EndLuminosityBlock, 1);
-      if (not result) {
-        throw cms::Exception("TimeOut") << "doTransition timed out";
-      }
-    }
-
-    //std::cout <<"controller going to stop"<<std::endl;
-    return 0;
-  }
-
-  int worker(int argc, char** argv) {
-    using namespace edm::shared_memory;
-
-    assert(argc == 3);
-    WorkerChannel channel(argv[1], argv[2]);
-
-    //simulate long time setting up
-    using namespace std::chrono_literals;
-    std::this_thread::sleep_for(20s);
-
-    //std::cerr<<"worker setup\n";
-    channel.workerSetupDone();
-
-    std::this_thread::sleep_for(20s);
-
-    int transitionCount = 0;
-    channel.handleTransitions([&](edm::Transition iTransition, unsigned long long iTransitionID) {
-      using namespace std::chrono_literals;
-      std::this_thread::sleep_for(20s);
-
-      switch (transitionCount) {
-        case 0: {
-          if (iTransition != edm::Transition::Event) {
-            throw cms::Exception("BadValue") << "wrong transition received " << static_cast<int>(iTransition);
-          }
-          if (iTransitionID != 2ULL) {
-            throw cms::Exception("BadValue") << "wrong transitionID received " << static_cast<int>(iTransitionID);
-          }
-
-          if (channel.toWorkerBufferInfo()->index_ != 0) {
-            throw cms::Exception("BadValue")
-                << "wrong toWorkerBufferInfo index received " << static_cast<int>(channel.toWorkerBufferInfo()->index_);
-          }
-          if (channel.toWorkerBufferInfo()->identifier_ != 0) {
-            throw cms::Exception("BadValue")
-                << "wrong toWorkerBufferInfo identifier received " << channel.toWorkerBufferInfo()->identifier_;
-          }
-          *channel.fromWorkerBufferInfo() = {1, 1};
-          channel.shouldKeepEvent(true);
-          break;
-        }
-
-        case 1: {
-          if (iTransition != edm::Transition::Event) {
-            throw cms::Exception("BadValue") << "wrong transition received " << static_cast<int>(iTransition);
-          }
-          if (iTransitionID != 3ULL) {
-            throw cms::Exception("BadValue") << "wrong transitionID received " << static_cast<int>(iTransitionID);
-          }
-
-          if (channel.toWorkerBufferInfo()->index_ != 1) {
-            throw cms::Exception("BadValue")
-                << "wrong toWorkerBufferInfo index received " << static_cast<int>(channel.toWorkerBufferInfo()->index_);
-          }
-          if (channel.toWorkerBufferInfo()->identifier_ != 1) {
-            throw cms::Exception("BadValue")
-                << "wrong toWorkerBufferInfo identifier received " << channel.toWorkerBufferInfo()->identifier_;
-          }
-          *channel.fromWorkerBufferInfo() = {2, 0};
-          channel.shouldKeepEvent(false);
-          break;
-        }
-
-        case 2: {
-          if (iTransition != edm::Transition::EndLuminosityBlock) {
-            throw cms::Exception("BadValue") << "wrong transition received " << static_cast<int>(iTransition);
-          }
-          if (iTransitionID != 1ULL) {
-            throw cms::Exception("BadValue") << "wrong transitionID received " << static_cast<int>(iTransitionID);
-          }
-          break;
-        }
-        default: {
-          throw cms::Exception("MissingStop") << "stopRequested not set";
-        }
-      }
-      ++transitionCount;
-    });
-    if (transitionCount != 3) {
-      throw cms::Exception("MissingStop") << "stop requested too soon " << transitionCount;
-    }
-    return 0;
-  }
   const char* jobType(bool isWorker) {
     if (isWorker) {
       return "Worker";
     }
     return "Controller";
   }
-
 }  // namespace
 
 int main(int argc, char** argv) {
@@ -192,10 +25,10 @@ int main(int argc, char** argv) {
   int retValue = 0;
   try {
     if (argc > 1) {
-      retValue = worker(argc, argv);
+      retValue = worker(argc, argv, WorkerType::kOKTimeout);
     } else {
       isWorker = false;
-      retValue = controller(argc, argv);
+      retValue = controller(argc, argv, 5);
     }
   } catch (std::exception const& iException) {
     std::cerr << "Caught exception\n" << iException.what() << "\n";

--- a/FWCore/SharedMemory/test/test_channels_retry.cc
+++ b/FWCore/SharedMemory/test/test_channels_retry.cc
@@ -1,0 +1,240 @@
+#include "FWCore/SharedMemory/interface/ControllerChannel.h"
+#include "FWCore/SharedMemory/interface/WorkerChannel.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include <memory>
+#include <string>
+#include <stdio.h>
+#include <cassert>
+#include <thread>
+namespace {
+  int controller(int argc, char** argv) {
+    using namespace edm::shared_memory;
+
+    ControllerChannel channel("TestChannel", 0, 5);
+
+    //Pipe has to close AFTER we tell the worker to stop
+    auto closePipe = [](FILE* iFile) { pclose(iFile); };
+    std::unique_ptr<FILE, decltype(closePipe)> pipe(nullptr, closePipe);
+
+    auto stopWorkerCmd = [](ControllerChannel* iChannel) { iChannel->stopWorker(); };
+    std::unique_ptr<ControllerChannel, decltype(stopWorkerCmd)> stopWorkerGuard(&channel, stopWorkerCmd);
+
+    {
+      std::string command(argv[0]);
+      command += " ";
+      command += channel.sharedMemoryName();
+      command += " ";
+      command += channel.uniqueID();
+      //make sure output is flushed before popen does any writing
+      fflush(stdout);
+      fflush(stderr);
+
+      channel.setupWorkerWithRetry(
+          [&]() {
+            pipe.reset(popen(command.c_str(), "w"));
+
+            if (not pipe) {
+              throw cms::Exception("PipeFailed") << "pipe failed to open " << command;
+            }
+          },
+          []() {
+            std::cerr << " retry requested\n";
+            return true;
+          });
+    }
+    {
+      *channel.toWorkerBufferInfo() = {0, 0};
+      auto result = channel.doTransitionWithRetry(
+          [&]() {
+            if (channel.fromWorkerBufferInfo()->index_ != 1) {
+              throw cms::Exception("BadValue") << "wrong index value of fromWorkerBufferInfo "
+                                               << static_cast<int>(channel.fromWorkerBufferInfo()->index_);
+            }
+            if (channel.fromWorkerBufferInfo()->identifier_ != 1) {
+              throw cms::Exception("BadValue")
+                  << "wrong identifier value of fromWorkerBufferInfo " << channel.fromWorkerBufferInfo()->identifier_;
+            }
+            if (not channel.shouldKeepEvent()) {
+              throw cms::Exception("BadValue") << "told not to keep event";
+            }
+          },
+          []() {
+            std::cerr << " retry requested 0\n";
+            return true;
+          },
+          edm::Transition::Event,
+          2);
+      if (not result) {
+        throw cms::Exception("TimeOut") << "doTransition timed out";
+      }
+    }
+    {
+      *channel.toWorkerBufferInfo() = {1, 1};
+      auto result = channel.doTransitionWithRetry(
+          [&]() {
+            if (channel.fromWorkerBufferInfo()->index_ != 0) {
+              throw cms::Exception("BadValue") << "wrong index value of fromWorkerBufferInfo "
+                                               << static_cast<int>(channel.fromWorkerBufferInfo()->index_);
+            }
+            if (channel.fromWorkerBufferInfo()->identifier_ != 2) {
+              throw cms::Exception("BadValue")
+                  << "wrong identifier value of fromWorkerBufferInfo " << channel.fromWorkerBufferInfo()->identifier_;
+            }
+            if (channel.shouldKeepEvent()) {
+              throw cms::Exception("BadValue") << "told to keep event";
+            }
+          },
+          []() {
+            std::cerr << " retry requested 1\n";
+            return true;
+          },
+
+          edm::Transition::Event,
+          3);
+      if (not result) {
+        throw cms::Exception("TimeOut") << "doTransition timed out";
+      }
+    }
+
+    {
+      auto result = channel.doTransitionWithRetry([&]() {},
+                                                  []() {
+                                                    std::cerr << " retry requested 2\n";
+                                                    return true;
+                                                  },
+                                                  edm::Transition::EndLuminosityBlock,
+                                                  1);
+      if (not result) {
+        throw cms::Exception("TimeOut") << "doTransition timed out";
+      }
+    }
+
+    //std::cout <<"controller going to stop"<<std::endl;
+    return 0;
+  }
+
+  int worker(int argc, char** argv) {
+    using namespace edm::shared_memory;
+
+    using namespace std::chrono_literals;
+    std::this_thread::sleep_for(20s);
+    assert(argc == 3);
+    WorkerChannel channel(argv[1], argv[2]);
+
+    std::cerr << "worker setup\n";
+    using namespace std::chrono_literals;
+    std::this_thread::sleep_for(15s);
+
+    std::cerr << "  worker setup awake\n";
+
+    channel.workerSetupDone();
+    std::cerr << "workerSetupDone finished\n";
+
+    using namespace std::chrono_literals;
+    std::this_thread::sleep_for(15s);
+
+    int transitionCount = 0;
+    channel.handleTransitions([&](edm::Transition iTransition, unsigned long long iTransitionID) {
+      std::cerr << " transition\n";
+      using namespace std::chrono_literals;
+      std::this_thread::sleep_for(15s);
+
+      switch (transitionCount) {
+        case 0: {
+          if (iTransition != edm::Transition::Event) {
+            throw cms::Exception("BadValue") << "wrong transition received " << static_cast<int>(iTransition);
+          }
+          if (iTransitionID != 2ULL) {
+            throw cms::Exception("BadValue") << "wrong transitionID received " << static_cast<int>(iTransitionID);
+          }
+
+          if (channel.toWorkerBufferInfo()->index_ != 0) {
+            throw cms::Exception("BadValue")
+                << "wrong toWorkerBufferInfo index received " << static_cast<int>(channel.toWorkerBufferInfo()->index_);
+          }
+          if (channel.toWorkerBufferInfo()->identifier_ != 0) {
+            throw cms::Exception("BadValue")
+                << "wrong toWorkerBufferInfo identifier received " << channel.toWorkerBufferInfo()->identifier_;
+          }
+          *channel.fromWorkerBufferInfo() = {1, 1};
+          channel.shouldKeepEvent(true);
+          break;
+        }
+
+        case 1: {
+          if (iTransition != edm::Transition::Event) {
+            throw cms::Exception("BadValue") << "wrong transition received " << static_cast<int>(iTransition);
+          }
+          if (iTransitionID != 3ULL) {
+            throw cms::Exception("BadValue") << "wrong transitionID received " << static_cast<int>(iTransitionID);
+          }
+
+          if (channel.toWorkerBufferInfo()->index_ != 1) {
+            throw cms::Exception("BadValue")
+                << "wrong toWorkerBufferInfo index received " << static_cast<int>(channel.toWorkerBufferInfo()->index_);
+          }
+          if (channel.toWorkerBufferInfo()->identifier_ != 1) {
+            throw cms::Exception("BadValue")
+                << "wrong toWorkerBufferInfo identifier received " << channel.toWorkerBufferInfo()->identifier_;
+          }
+          *channel.fromWorkerBufferInfo() = {2, 0};
+          channel.shouldKeepEvent(false);
+          break;
+        }
+
+        case 2: {
+          if (iTransition != edm::Transition::EndLuminosityBlock) {
+            throw cms::Exception("BadValue") << "wrong transition received " << static_cast<int>(iTransition);
+          }
+          if (iTransitionID != 1ULL) {
+            throw cms::Exception("BadValue") << "wrong transitionID received " << static_cast<int>(iTransitionID);
+          }
+          break;
+        }
+        default: {
+          throw cms::Exception("MissingStop") << "stopRequested not set";
+        }
+      }
+      ++transitionCount;
+    });
+    if (transitionCount != 3) {
+      throw cms::Exception("MissingStop") << "stop requested too soon " << transitionCount;
+    }
+    return 0;
+  }
+  const char* jobType(bool isWorker) {
+    if (isWorker) {
+      return "Worker";
+    }
+    return "Controller";
+  }
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  bool isWorker = true;
+  int retValue = 0;
+  try {
+    if (argc > 1) {
+      retValue = worker(argc, argv);
+    } else {
+      isWorker = false;
+      retValue = controller(argc, argv);
+    }
+  } catch (std::exception const& iException) {
+    std::cerr << "Caught exception\n" << iException.what() << "\n";
+    if (isWorker) {
+      std::cerr << "in worker\n";
+    } else {
+      std::cerr << "in controller\n";
+    }
+    return 1;
+  }
+  if (0 == retValue) {
+    std::cout << jobType(isWorker) << " success" << std::endl;
+  } else {
+    std::cout << jobType(isWorker) << " failed" << std::endl;
+  }
+  return 0;
+}

--- a/FWCore/SharedMemory/test/test_channels_startupTimeout.cc
+++ b/FWCore/SharedMemory/test/test_channels_startupTimeout.cc
@@ -8,178 +8,15 @@
 #include <cassert>
 #include <thread>
 
+#include "controller.h"
+#include "worker.h"
 namespace {
-  int controller(int argc, char** argv) {
-    using namespace edm::shared_memory;
-
-    ControllerChannel channel("TestChannel", 0, 5);
-
-    //Pipe has to close AFTER we tell the worker to stop
-    auto closePipe = [](FILE* iFile) { pclose(iFile); };
-    std::unique_ptr<FILE, decltype(closePipe)> pipe(nullptr, closePipe);
-
-    auto stopWorkerCmd = [](ControllerChannel* iChannel) { iChannel->stopWorker(); };
-    std::unique_ptr<ControllerChannel, decltype(stopWorkerCmd)> stopWorkerGuard(&channel, stopWorkerCmd);
-
-    {
-      std::string command(argv[0]);
-      command += " ";
-      command += channel.sharedMemoryName();
-      command += " ";
-      command += channel.uniqueID();
-      //make sure output is flushed before popen does any writing
-      fflush(stdout);
-      fflush(stderr);
-
-      channel.setupWorker([&]() {
-        pipe.reset(popen(command.c_str(), "w"));
-
-        if (not pipe) {
-          throw cms::Exception("PipeFailed") << "pipe failed to open " << command;
-        }
-      });
-    }
-    {
-      *channel.toWorkerBufferInfo() = {0, 0};
-      auto result = channel.doTransition(
-          [&]() {
-            if (channel.fromWorkerBufferInfo()->index_ != 1) {
-              throw cms::Exception("BadValue") << "wrong index value of fromWorkerBufferInfo "
-                                               << static_cast<int>(channel.fromWorkerBufferInfo()->index_);
-            }
-            if (channel.fromWorkerBufferInfo()->identifier_ != 1) {
-              throw cms::Exception("BadValue")
-                  << "wrong identifier value of fromWorkerBufferInfo " << channel.fromWorkerBufferInfo()->identifier_;
-            }
-            if (not channel.shouldKeepEvent()) {
-              throw cms::Exception("BadValue") << "told not to keep event";
-            }
-          },
-          edm::Transition::Event,
-          2);
-      if (not result) {
-        throw cms::Exception("TimeOut") << "doTransition timed out";
-      }
-    }
-    {
-      *channel.toWorkerBufferInfo() = {1, 1};
-      auto result = channel.doTransition(
-          [&]() {
-            if (channel.fromWorkerBufferInfo()->index_ != 0) {
-              throw cms::Exception("BadValue") << "wrong index value of fromWorkerBufferInfo "
-                                               << static_cast<int>(channel.fromWorkerBufferInfo()->index_);
-            }
-            if (channel.fromWorkerBufferInfo()->identifier_ != 2) {
-              throw cms::Exception("BadValue")
-                  << "wrong identifier value of fromWorkerBufferInfo " << channel.fromWorkerBufferInfo()->identifier_;
-            }
-            if (channel.shouldKeepEvent()) {
-              throw cms::Exception("BadValue") << "told to keep event";
-            }
-          },
-          edm::Transition::Event,
-          3);
-      if (not result) {
-        throw cms::Exception("TimeOut") << "doTransition timed out";
-      }
-    }
-
-    {
-      auto result = channel.doTransition([&]() {}, edm::Transition::EndLuminosityBlock, 1);
-      if (not result) {
-        throw cms::Exception("TimeOut") << "doTransition timed out";
-      }
-    }
-
-    //std::cout <<"controller going to stop"<<std::endl;
-    return 0;
-  }
-
-  int worker(int argc, char** argv) {
-    using namespace edm::shared_memory;
-
-    //Take too long before openning the worker channel
-    using namespace std::chrono_literals;
-    std::this_thread::sleep_for(20s);
-
-    assert(argc == 3);
-    WorkerChannel channel(argv[1], argv[2]);
-
-    //std::cerr<<"worker setup\n";
-    channel.workerSetupDone();
-
-    int transitionCount = 0;
-    channel.handleTransitions([&](edm::Transition iTransition, unsigned long long iTransitionID) {
-      switch (transitionCount) {
-        case 0: {
-          if (iTransition != edm::Transition::Event) {
-            throw cms::Exception("BadValue") << "wrong transition received " << static_cast<int>(iTransition);
-          }
-          if (iTransitionID != 2ULL) {
-            throw cms::Exception("BadValue") << "wrong transitionID received " << static_cast<int>(iTransitionID);
-          }
-
-          if (channel.toWorkerBufferInfo()->index_ != 0) {
-            throw cms::Exception("BadValue")
-                << "wrong toWorkerBufferInfo index received " << static_cast<int>(channel.toWorkerBufferInfo()->index_);
-          }
-          if (channel.toWorkerBufferInfo()->identifier_ != 0) {
-            throw cms::Exception("BadValue")
-                << "wrong toWorkerBufferInfo identifier received " << channel.toWorkerBufferInfo()->identifier_;
-          }
-          *channel.fromWorkerBufferInfo() = {1, 1};
-          channel.shouldKeepEvent(true);
-          break;
-        }
-
-        case 1: {
-          if (iTransition != edm::Transition::Event) {
-            throw cms::Exception("BadValue") << "wrong transition received " << static_cast<int>(iTransition);
-          }
-          if (iTransitionID != 3ULL) {
-            throw cms::Exception("BadValue") << "wrong transitionID received " << static_cast<int>(iTransitionID);
-          }
-
-          if (channel.toWorkerBufferInfo()->index_ != 1) {
-            throw cms::Exception("BadValue")
-                << "wrong toWorkerBufferInfo index received " << static_cast<int>(channel.toWorkerBufferInfo()->index_);
-          }
-          if (channel.toWorkerBufferInfo()->identifier_ != 1) {
-            throw cms::Exception("BadValue")
-                << "wrong toWorkerBufferInfo identifier received " << channel.toWorkerBufferInfo()->identifier_;
-          }
-          *channel.fromWorkerBufferInfo() = {2, 0};
-          channel.shouldKeepEvent(false);
-          break;
-        }
-
-        case 2: {
-          if (iTransition != edm::Transition::EndLuminosityBlock) {
-            throw cms::Exception("BadValue") << "wrong transition received " << static_cast<int>(iTransition);
-          }
-          if (iTransitionID != 1ULL) {
-            throw cms::Exception("BadValue") << "wrong transitionID received " << static_cast<int>(iTransitionID);
-          }
-          break;
-        }
-        default: {
-          throw cms::Exception("MissingStop") << "stopRequested not set";
-        }
-      }
-      ++transitionCount;
-    });
-    if (transitionCount != 3) {
-      throw cms::Exception("MissingStop") << "stop requested too soon " << transitionCount;
-    }
-    return 0;
-  }
   const char* jobType(bool isWorker) {
     if (isWorker) {
       return "Worker";
     }
     return "Controller";
   }
-
 }  // namespace
 
 int main(int argc, char** argv) {
@@ -187,10 +24,10 @@ int main(int argc, char** argv) {
   int retValue = 0;
   try {
     if (argc > 1) {
-      retValue = worker(argc, argv);
+      retValue = worker(argc, argv, WorkerType::kStartupTimeout);
     } else {
       isWorker = false;
-      retValue = controller(argc, argv);
+      retValue = controller(argc, argv, 5);
     }
   } catch (cms::Exception const& iException) {
     if (iException.category() != "ExternalFailed") {

--- a/FWCore/SharedMemory/test/test_channels_startupTimeout.cc
+++ b/FWCore/SharedMemory/test/test_channels_startupTimeout.cc
@@ -1,0 +1,217 @@
+#include "FWCore/SharedMemory/interface/ControllerChannel.h"
+#include "FWCore/SharedMemory/interface/WorkerChannel.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include <memory>
+#include <string>
+#include <stdio.h>
+#include <cassert>
+#include <thread>
+
+namespace {
+  int controller(int argc, char** argv) {
+    using namespace edm::shared_memory;
+
+    ControllerChannel channel("TestChannel", 0, 5);
+
+    //Pipe has to close AFTER we tell the worker to stop
+    auto closePipe = [](FILE* iFile) { pclose(iFile); };
+    std::unique_ptr<FILE, decltype(closePipe)> pipe(nullptr, closePipe);
+
+    auto stopWorkerCmd = [](ControllerChannel* iChannel) { iChannel->stopWorker(); };
+    std::unique_ptr<ControllerChannel, decltype(stopWorkerCmd)> stopWorkerGuard(&channel, stopWorkerCmd);
+
+    {
+      std::string command(argv[0]);
+      command += " ";
+      command += channel.sharedMemoryName();
+      command += " ";
+      command += channel.uniqueID();
+      //make sure output is flushed before popen does any writing
+      fflush(stdout);
+      fflush(stderr);
+
+      channel.setupWorker([&]() {
+        pipe.reset(popen(command.c_str(), "w"));
+
+        if (not pipe) {
+          throw cms::Exception("PipeFailed") << "pipe failed to open " << command;
+        }
+      });
+    }
+    {
+      *channel.toWorkerBufferInfo() = {0, 0};
+      auto result = channel.doTransition(
+          [&]() {
+            if (channel.fromWorkerBufferInfo()->index_ != 1) {
+              throw cms::Exception("BadValue") << "wrong index value of fromWorkerBufferInfo "
+                                               << static_cast<int>(channel.fromWorkerBufferInfo()->index_);
+            }
+            if (channel.fromWorkerBufferInfo()->identifier_ != 1) {
+              throw cms::Exception("BadValue")
+                  << "wrong identifier value of fromWorkerBufferInfo " << channel.fromWorkerBufferInfo()->identifier_;
+            }
+            if (not channel.shouldKeepEvent()) {
+              throw cms::Exception("BadValue") << "told not to keep event";
+            }
+          },
+          edm::Transition::Event,
+          2);
+      if (not result) {
+        throw cms::Exception("TimeOut") << "doTransition timed out";
+      }
+    }
+    {
+      *channel.toWorkerBufferInfo() = {1, 1};
+      auto result = channel.doTransition(
+          [&]() {
+            if (channel.fromWorkerBufferInfo()->index_ != 0) {
+              throw cms::Exception("BadValue") << "wrong index value of fromWorkerBufferInfo "
+                                               << static_cast<int>(channel.fromWorkerBufferInfo()->index_);
+            }
+            if (channel.fromWorkerBufferInfo()->identifier_ != 2) {
+              throw cms::Exception("BadValue")
+                  << "wrong identifier value of fromWorkerBufferInfo " << channel.fromWorkerBufferInfo()->identifier_;
+            }
+            if (channel.shouldKeepEvent()) {
+              throw cms::Exception("BadValue") << "told to keep event";
+            }
+          },
+          edm::Transition::Event,
+          3);
+      if (not result) {
+        throw cms::Exception("TimeOut") << "doTransition timed out";
+      }
+    }
+
+    {
+      auto result = channel.doTransition([&]() {}, edm::Transition::EndLuminosityBlock, 1);
+      if (not result) {
+        throw cms::Exception("TimeOut") << "doTransition timed out";
+      }
+    }
+
+    //std::cout <<"controller going to stop"<<std::endl;
+    return 0;
+  }
+
+  int worker(int argc, char** argv) {
+    using namespace edm::shared_memory;
+
+    //Take too long before openning the worker channel
+    using namespace std::chrono_literals;
+    std::this_thread::sleep_for(20s);
+
+    assert(argc == 3);
+    WorkerChannel channel(argv[1], argv[2]);
+
+    //std::cerr<<"worker setup\n";
+    channel.workerSetupDone();
+
+    int transitionCount = 0;
+    channel.handleTransitions([&](edm::Transition iTransition, unsigned long long iTransitionID) {
+      switch (transitionCount) {
+        case 0: {
+          if (iTransition != edm::Transition::Event) {
+            throw cms::Exception("BadValue") << "wrong transition received " << static_cast<int>(iTransition);
+          }
+          if (iTransitionID != 2ULL) {
+            throw cms::Exception("BadValue") << "wrong transitionID received " << static_cast<int>(iTransitionID);
+          }
+
+          if (channel.toWorkerBufferInfo()->index_ != 0) {
+            throw cms::Exception("BadValue")
+                << "wrong toWorkerBufferInfo index received " << static_cast<int>(channel.toWorkerBufferInfo()->index_);
+          }
+          if (channel.toWorkerBufferInfo()->identifier_ != 0) {
+            throw cms::Exception("BadValue")
+                << "wrong toWorkerBufferInfo identifier received " << channel.toWorkerBufferInfo()->identifier_;
+          }
+          *channel.fromWorkerBufferInfo() = {1, 1};
+          channel.shouldKeepEvent(true);
+          break;
+        }
+
+        case 1: {
+          if (iTransition != edm::Transition::Event) {
+            throw cms::Exception("BadValue") << "wrong transition received " << static_cast<int>(iTransition);
+          }
+          if (iTransitionID != 3ULL) {
+            throw cms::Exception("BadValue") << "wrong transitionID received " << static_cast<int>(iTransitionID);
+          }
+
+          if (channel.toWorkerBufferInfo()->index_ != 1) {
+            throw cms::Exception("BadValue")
+                << "wrong toWorkerBufferInfo index received " << static_cast<int>(channel.toWorkerBufferInfo()->index_);
+          }
+          if (channel.toWorkerBufferInfo()->identifier_ != 1) {
+            throw cms::Exception("BadValue")
+                << "wrong toWorkerBufferInfo identifier received " << channel.toWorkerBufferInfo()->identifier_;
+          }
+          *channel.fromWorkerBufferInfo() = {2, 0};
+          channel.shouldKeepEvent(false);
+          break;
+        }
+
+        case 2: {
+          if (iTransition != edm::Transition::EndLuminosityBlock) {
+            throw cms::Exception("BadValue") << "wrong transition received " << static_cast<int>(iTransition);
+          }
+          if (iTransitionID != 1ULL) {
+            throw cms::Exception("BadValue") << "wrong transitionID received " << static_cast<int>(iTransitionID);
+          }
+          break;
+        }
+        default: {
+          throw cms::Exception("MissingStop") << "stopRequested not set";
+        }
+      }
+      ++transitionCount;
+    });
+    if (transitionCount != 3) {
+      throw cms::Exception("MissingStop") << "stop requested too soon " << transitionCount;
+    }
+    return 0;
+  }
+  const char* jobType(bool isWorker) {
+    if (isWorker) {
+      return "Worker";
+    }
+    return "Controller";
+  }
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  bool isWorker = true;
+  int retValue = 0;
+  try {
+    if (argc > 1) {
+      retValue = worker(argc, argv);
+    } else {
+      isWorker = false;
+      retValue = controller(argc, argv);
+    }
+  } catch (cms::Exception const& iException) {
+    if (iException.category() != "ExternalFailed") {
+      throw;
+    } else {
+      std::cout << "expected failure occurred\n";
+      return 0;
+    }
+  } catch (std::exception const& iException) {
+    std::cerr << "Caught exception\n" << iException.what() << "\n";
+    if (isWorker) {
+      std::cerr << "in worker\n";
+    } else {
+      std::cerr << "in controller\n";
+    }
+    return 1;
+  }
+  if (0 == retValue) {
+    std::cout << jobType(isWorker) << " success" << std::endl;
+  } else {
+    std::cout << jobType(isWorker) << " failed" << std::endl;
+  }
+  return 1;
+}

--- a/FWCore/SharedMemory/test/test_channels_transitionTimeout.cc
+++ b/FWCore/SharedMemory/test/test_channels_transitionTimeout.cc
@@ -1,0 +1,109 @@
+#include "FWCore/SharedMemory/interface/ControllerChannel.h"
+#include "FWCore/SharedMemory/interface/WorkerChannel.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include <memory>
+#include <string>
+#include <stdio.h>
+#include <cassert>
+#include <thread>
+
+namespace {
+  int controller(int argc, char** argv) {
+    using namespace edm::shared_memory;
+
+    ControllerChannel channel("TestChannel", 0, 5);
+
+    //Pipe has to close AFTER we tell the worker to stop
+    auto closePipe = [](FILE* iFile) { pclose(iFile); };
+    std::unique_ptr<FILE, decltype(closePipe)> pipe(nullptr, closePipe);
+
+    auto stopWorkerCmd = [](ControllerChannel* iChannel) { iChannel->stopWorker(); };
+    std::unique_ptr<ControllerChannel, decltype(stopWorkerCmd)> stopWorkerGuard(&channel, stopWorkerCmd);
+
+    {
+      std::string command(argv[0]);
+      command += " ";
+      command += channel.sharedMemoryName();
+      command += " ";
+      command += channel.uniqueID();
+      //make sure output is flushed before popen does any writing
+      fflush(stdout);
+      fflush(stderr);
+
+      channel.setupWorker([&]() {
+        pipe.reset(popen(command.c_str(), "w"));
+
+        if (not pipe) {
+          throw cms::Exception("PipeFailed") << "pipe failed to open " << command;
+        }
+      });
+    }
+    {
+      *channel.toWorkerBufferInfo() = {0, 0};
+      auto result = channel.doTransition([&]() { /*job will fail before calling*/ }, edm::Transition::Event, 2);
+      if (not result) {
+        //this should happen as we should time out
+        throw cms::Exception("TimeOut") << "doTransition timed out";
+      }
+    }
+    //std::cout <<"controller going to stop"<<std::endl;
+    return 0;
+  }
+
+  int worker(int argc, char** argv) {
+    using namespace edm::shared_memory;
+
+    assert(argc == 3);
+    WorkerChannel channel(argv[1], argv[2]);
+
+    //std::cerr<<"worker setup\n";
+    channel.workerSetupDone();
+
+    channel.handleTransitions(
+        [&](edm::Transition iTransition, unsigned long long iTransitionID) { throw cms::Exception("BAD"); });
+    return 0;
+  }
+  const char* jobType(bool isWorker) {
+    if (isWorker) {
+      return "Worker";
+    }
+    return "Controller";
+  }
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  bool isWorker = true;
+  int retValue = 0;
+  try {
+    if (argc > 1) {
+      retValue = worker(argc, argv);
+    } else {
+      isWorker = false;
+      retValue = controller(argc, argv);
+    }
+  } catch (cms::Exception const& iException) {
+    if (iException.category() != "TimeOut") {
+      std::cerr << "Caught exception\n" << iException.what() << "\n";
+      return 1;
+    } else {
+      std::cout << "expected failure occurred\n";
+      return 0;
+    }
+  } catch (std::exception const& iException) {
+    std::cerr << "Caught exception\n" << iException.what() << "\n";
+    if (isWorker) {
+      std::cerr << "in worker\n";
+    } else {
+      std::cerr << "in controller\n";
+    }
+    return 1;
+  }
+  if (0 == retValue) {
+    std::cout << jobType(isWorker) << " success" << std::endl;
+  } else {
+    std::cout << jobType(isWorker) << " failed" << std::endl;
+  }
+  return 1;
+}

--- a/FWCore/SharedMemory/test/worker.h
+++ b/FWCore/SharedMemory/test/worker.h
@@ -1,0 +1,105 @@
+#if !defined(TEST_WORKER)
+#define TEST_WORKER
+#include "FWCore/SharedMemory/interface/WorkerChannel.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include <memory>
+#include <string>
+#include <stdio.h>
+#include <cassert>
+#include <thread>
+
+enum class WorkerType { kStandard, kOKTimeout, kStartupTimeout };
+
+int worker(int argc, char** argv, WorkerType iType) {
+  using namespace edm::shared_memory;
+
+  using namespace std::chrono_literals;
+  if (iType == WorkerType::kStartupTimeout) {
+    //Take too long before openning the worker channel
+    std::this_thread::sleep_for(20s);
+  }
+
+  assert(argc == 3);
+  WorkerChannel channel(argv[1], argv[2]);
+
+  if (iType == WorkerType::kOKTimeout) {
+    //simulate long time setting up
+    std::this_thread::sleep_for(20s);
+  }
+  //std::cerr<<"worker setup\n";
+  channel.workerSetupDone();
+
+  if (iType == WorkerType::kOKTimeout) {
+    std::this_thread::sleep_for(20s);
+  }
+  int transitionCount = 0;
+  channel.handleTransitions([&](edm::Transition iTransition, unsigned long long iTransitionID) {
+    if (iType == WorkerType::kOKTimeout) {
+      using namespace std::chrono_literals;
+      std::this_thread::sleep_for(20s);
+    }
+    switch (transitionCount) {
+      case 0: {
+        if (iTransition != edm::Transition::Event) {
+          throw cms::Exception("BadValue") << "wrong transition received " << static_cast<int>(iTransition);
+        }
+        if (iTransitionID != 2ULL) {
+          throw cms::Exception("BadValue") << "wrong transitionID received " << static_cast<int>(iTransitionID);
+        }
+
+        if (channel.toWorkerBufferInfo()->index_ != 0) {
+          throw cms::Exception("BadValue")
+              << "wrong toWorkerBufferInfo index received " << static_cast<int>(channel.toWorkerBufferInfo()->index_);
+        }
+        if (channel.toWorkerBufferInfo()->identifier_ != 0) {
+          throw cms::Exception("BadValue")
+              << "wrong toWorkerBufferInfo identifier received " << channel.toWorkerBufferInfo()->identifier_;
+        }
+        *channel.fromWorkerBufferInfo() = {1, 1};
+        channel.shouldKeepEvent(true);
+        break;
+      }
+
+      case 1: {
+        if (iTransition != edm::Transition::Event) {
+          throw cms::Exception("BadValue") << "wrong transition received " << static_cast<int>(iTransition);
+        }
+        if (iTransitionID != 3ULL) {
+          throw cms::Exception("BadValue") << "wrong transitionID received " << static_cast<int>(iTransitionID);
+        }
+
+        if (channel.toWorkerBufferInfo()->index_ != 1) {
+          throw cms::Exception("BadValue")
+              << "wrong toWorkerBufferInfo index received " << static_cast<int>(channel.toWorkerBufferInfo()->index_);
+        }
+        if (channel.toWorkerBufferInfo()->identifier_ != 1) {
+          throw cms::Exception("BadValue")
+              << "wrong toWorkerBufferInfo identifier received " << channel.toWorkerBufferInfo()->identifier_;
+        }
+        *channel.fromWorkerBufferInfo() = {2, 0};
+        channel.shouldKeepEvent(false);
+        break;
+      }
+
+      case 2: {
+        if (iTransition != edm::Transition::EndLuminosityBlock) {
+          throw cms::Exception("BadValue") << "wrong transition received " << static_cast<int>(iTransition);
+        }
+        if (iTransitionID != 1ULL) {
+          throw cms::Exception("BadValue") << "wrong transitionID received " << static_cast<int>(iTransitionID);
+        }
+        break;
+      }
+      default: {
+        throw cms::Exception("MissingStop") << "stopRequested not set";
+      }
+    }
+    ++transitionCount;
+  });
+  if (transitionCount != 3) {
+    throw cms::Exception("MissingStop") << "stop requested too soon " << transitionCount;
+  }
+  return 0;
+}
+#endif


### PR DESCRIPTION
#### PR description:

The call to timed_wait will still take just as long as it takes the Worker to complete but will then return false if that time was longer than the set wait time.
Now we use transitionID_ to signify if the worker did the work and if it did, we ignore the timeout.
Added new retry methods which allow user control of what to do if a timeout does happen.

#### PR validation:

code compiles and package unit tests all succeed.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
This is a backport of #34815. This will be need to improve the performance for the ultra-legacy reprocessing.
