### PR TITLE
[GCC11] Fix "this pointer is null" in class FWRecoGeometryESProducer of Fireworks/Geometry

### DIFF
--- a/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
+++ b/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
@@ -60,38 +60,38 @@ void FWRecoGeometryESProducer::ADD_PIXEL_TOPOLOGY(unsigned int rawid,
 using Phase2TrackerGeomDetUnit = PixelGeomDetUnit;
 using Phase2TrackerTopology = PixelTopology;
 
-#define ADD_SISTRIP_TOPOLOGY(rawid, detUnit)                                                               \
-  const StripGeomDetUnit* det = dynamic_cast<const StripGeomDetUnit*>(detUnit);                            \
-  if (det) {                                                                                               \
-    if (const StripTopology* topo = dynamic_cast<const StripTopology*>(&det->specificTopology())) {        \
-      fwRecoGeometry.idToName[rawid].topology[0] = 0;                                                      \
-      fwRecoGeometry.idToName[rawid].topology[1] = topo->nstrips();                                        \
-      fwRecoGeometry.idToName[rawid].topology[2] = topo->stripLength();                                    \
-    } else if (const RadialStripTopology* rtop =                                                           \
-                   dynamic_cast<const RadialStripTopology*>(&(det->specificType().specificTopology()))) {  \
-      fwRecoGeometry.idToName[rawid].topology[0] = 1;                                                      \
-      fwRecoGeometry.idToName[rawid].topology[3] = rtop->yAxisOrientation();                               \
-      fwRecoGeometry.idToName[rawid].topology[4] = rtop->originToIntersection();                           \
-      fwRecoGeometry.idToName[rawid].topology[5] = rtop->phiOfOneEdge();                                   \
-      fwRecoGeometry.idToName[rawid].topology[6] = rtop->angularWidth();                                   \
-    } else if (const RectangularStripTopology* topo =                                                      \
+#define ADD_SISTRIP_TOPOLOGY(rawid, detUnit)                                                                   \
+  const StripGeomDetUnit* det = dynamic_cast<const StripGeomDetUnit*>(detUnit);                                \
+  if (det) {                                                                                                   \
+    if (const StripTopology* topo = dynamic_cast<const StripTopology*>(&det->specificTopology())) {            \
+      fwRecoGeometry.idToName[rawid].topology[0] = 0;                                                          \
+      fwRecoGeometry.idToName[rawid].topology[1] = topo->nstrips();                                            \
+      fwRecoGeometry.idToName[rawid].topology[2] = topo->stripLength();                                        \
+    } else if (const RadialStripTopology* rtop =                                                               \
+                   dynamic_cast<const RadialStripTopology*>(&(det->specificType().specificTopology()))) {      \
+      fwRecoGeometry.idToName[rawid].topology[0] = 1;                                                          \
+      fwRecoGeometry.idToName[rawid].topology[3] = rtop->yAxisOrientation();                                   \
+      fwRecoGeometry.idToName[rawid].topology[4] = rtop->originToIntersection();                               \
+      fwRecoGeometry.idToName[rawid].topology[5] = rtop->phiOfOneEdge();                                       \
+      fwRecoGeometry.idToName[rawid].topology[6] = rtop->angularWidth();                                       \
+    } else if (const RectangularStripTopology* topo =                                                          \
                    dynamic_cast<const RectangularStripTopology*>(&(det->specificType().specificTopology()))) { \
-      fwRecoGeometry.idToName[rawid].topology[0] = 2;                                                      \
-      fwRecoGeometry.idToName[rawid].topology[3] = topo->pitch();                                          \
-    } else if (const TrapezoidalStripTopology* topo =                                                      \
+      fwRecoGeometry.idToName[rawid].topology[0] = 2;                                                          \
+      fwRecoGeometry.idToName[rawid].topology[3] = topo->pitch();                                              \
+    } else if (const TrapezoidalStripTopology* topo =                                                          \
                    dynamic_cast<const TrapezoidalStripTopology*>(&(det->specificType().specificTopology()))) { \
-      fwRecoGeometry.idToName[rawid].topology[0] = 3;                                                      \
-      fwRecoGeometry.idToName[rawid].topology[3] = topo->pitch();                                          \
-    }                                                                                                      \
-  } else {                                                                                                 \
-    const Phase2TrackerGeomDetUnit* det = dynamic_cast<const Phase2TrackerGeomDetUnit*>(detUnit);          \
-    if (det) {                                                                                             \
-      if (const Phase2TrackerTopology* topo =                                                              \
-              dynamic_cast<const Phase2TrackerTopology*>(&(det->specificTopology()))) {                    \
-        fwRecoGeometry.idToName[rawid].topology[0] = topo->pitch().first;                                  \
-        fwRecoGeometry.idToName[rawid].topology[1] = topo->pitch().second;                                 \
-      }                                                                                                    \
-    }                                                                                                      \
+      fwRecoGeometry.idToName[rawid].topology[0] = 3;                                                          \
+      fwRecoGeometry.idToName[rawid].topology[3] = topo->pitch();                                              \
+    }                                                                                                          \
+  } else {                                                                                                     \
+    const Phase2TrackerGeomDetUnit* det = dynamic_cast<const Phase2TrackerGeomDetUnit*>(detUnit);              \
+    if (det) {                                                                                                 \
+      if (const Phase2TrackerTopology* topo =                                                                  \
+              dynamic_cast<const Phase2TrackerTopology*>(&(det->specificTopology()))) {                        \
+        fwRecoGeometry.idToName[rawid].topology[0] = topo->pitch().first;                                      \
+        fwRecoGeometry.idToName[rawid].topology[1] = topo->pitch().second;                                     \
+      }                                                                                                        \
+    }                                                                                                          \
   }
 
 namespace {

--- a/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
+++ b/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
@@ -74,10 +74,12 @@ using Phase2TrackerTopology = PixelTopology;
       fwRecoGeometry.idToName[rawid].topology[4] = rtop->originToIntersection();                           \
       fwRecoGeometry.idToName[rawid].topology[5] = rtop->phiOfOneEdge();                                   \
       fwRecoGeometry.idToName[rawid].topology[6] = rtop->angularWidth();                                   \
-    } else if (dynamic_cast<const RectangularStripTopology*>(&(det->specificType().specificTopology()))) { \
+    } else if (const RectangularStripTopology* topo =                                                      \
+                   dynamic_cast<const RectangularStripTopology*>(&(det->specificType().specificTopology()))) { \
       fwRecoGeometry.idToName[rawid].topology[0] = 2;                                                      \
       fwRecoGeometry.idToName[rawid].topology[3] = topo->pitch();                                          \
-    } else if (dynamic_cast<const TrapezoidalStripTopology*>(&(det->specificType().specificTopology()))) { \
+    } else if (const TrapezoidalStripTopology* topo =                                                      \
+                   dynamic_cast<const TrapezoidalStripTopology*>(&(det->specificType().specificTopology()))) { \
       fwRecoGeometry.idToName[rawid].topology[0] = 3;                                                      \
       fwRecoGeometry.idToName[rawid].topology[3] = topo->pitch();                                          \
     }                                                                                                      \


### PR DESCRIPTION
Error log: https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc11/CMSSW_12_1_X_2021-08-09-1100/Fireworks/Geometry
Error message:
```
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/ada76bbef987ba1823d9aebd3a0b2f87/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-08-09-1100/src/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc: In member function 'void FWRecoGeometryESProducer::addTIBGeometry(FWRecoGeometry&)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/ada76bbef987ba1823d9aebd3a0b2f87/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-08-09-1100/src/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc:79:63: error: 'this' pointer is null [-Werror=nonnull]
    79 |       fwRecoGeometry.idToName[rawid].topology[3] = topo->pitch();                                          \
      |                                                    ~~~~~~~~~~~^~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/ada76bbef987ba1823d9aebd3a0b2f87/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-08-09-1100/src/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc:420:7: note: in expansion of macro 'ADD_SISTRIP_TOPOLOGY'
  420 |       ADD_SISTRIP_TOPOLOGY(current, m_trackerGeom->idToDet(detid));
      |       ^~~~~~~~~~~~~~~~~~~~
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/ada76bbef987ba1823d9aebd3a0b2f87/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-08-09-1100/src/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc:82:63: error: 'this' pointer is null [-Werror=nonnull]
    82 |       fwRecoGeometry.idToName[rawid].topology[3] = topo->pitch();                                          \
      |                                                    ~~~~~~~~~~~^~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/ada76bbef987ba1823d9aebd3a0b2f87/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-08-09-1100/src/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc:420:7: note: in expansion of macro 'ADD_SISTRIP_TOPOLOGY'
  420 |       ADD_SISTRIP_TOPOLOGY(current, m_trackerGeom->idToDet(detid));
      |       ^~~~~~~~~~~~~~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/ada76bbef987ba1823d9aebd3a0b2f87/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-08-09-1100/src/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc: In member function 'void FWRecoGeometryESProducer::addTOBGeometry(FWRecoGeometry&)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/ada76bbef987ba1823d9aebd3a0b2f87/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-08-09-1100/src/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc:79:63: error: 'this' pointer is null [-Werror=nonnull]
    79 |       fwRecoGeometry.idToName[rawid].topology[3] = topo->pitch();                                          \
      |                                                    ~~~~~~~~~~~^~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/ada76bbef987ba1823d9aebd3a0b2f87/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-08-09-1100/src/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc:438:7: note: in expansion of macro 'ADD_SISTRIP_TOPOLOGY'
  438 |       ADD_SISTRIP_TOPOLOGY(current, m_trackerGeom->idToDet(detid));
      |       ^~~~~~~~~~~~~~~~~~~~
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/ada76bbef987ba1823d9aebd3a0b2f87/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-08-09-1100/src/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc:82:63: error: 'this' pointer is null [-Werror=nonnull]
    82 |       fwRecoGeometry.idToName[rawid].topology[3] = topo->pitch();                                          \
      |                                                    ~~~~~~~~~~~^~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/ada76bbef987ba1823d9aebd3a0b2f87/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-08-09-1100/src/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc:438:7: note: in expansion of macro 'ADD_SISTRIP_TOPOLOGY'
  438 |       ADD_SISTRIP_TOPOLOGY(current, m_trackerGeom->idToDet(detid));
      |       ^~~~~~~~~~~~~~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/ada76bbef987ba1823d9aebd3a0b2f87/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-08-09-1100/src/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc: In member function 'void FWRecoGeometryESProducer::addTIDGeometry(FWRecoGeometry&)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/ada76bbef987ba1823d9aebd3a0b2f87/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-08-09-1100/src/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc:79:63: error: 'this' pointer is null [-Werror=nonnull]
    79 |       fwRecoGeometry.idToName[rawid].topology[3] = topo->pitch();                                          \
      |                                                    ~~~~~~~~~~~^~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/ada76bbef987ba1823d9aebd3a0b2f87/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-08-09-1100/src/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc:456:7: note: in expansion of macro 'ADD_SISTRIP_TOPOLOGY'
  456 |       ADD_SISTRIP_TOPOLOGY(current, m_trackerGeom->idToDet(detid));
      |       ^~~~~~~~~~~~~~~~~~~~
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/ada76bbef987ba1823d9aebd3a0b2f87/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-08-09-1100/src/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc:82:63: error: 'this' pointer is null [-Werror=nonnull]
    82 |       fwRecoGeometry.idToName[rawid].topology[3] = topo->pitch();                                          \
      |                                                    ~~~~~~~~~~~^~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/ada76bbef987ba1823d9aebd3a0b2f87/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-08-09-1100/src/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc:456:7: note: in expansion of macro 'ADD_SISTRIP_TOPOLOGY'
  456 |       ADD_SISTRIP_TOPOLOGY(current, m_trackerGeom->idToDet(detid));
      |       ^~~~~~~~~~~~~~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/ada76bbef987ba1823d9aebd3a0b2f87/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-08-09-1100/src/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc: In member function 'void FWRecoGeometryESProducer::addTECGeometry(FWRecoGeometry&)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/ada76bbef987ba1823d9aebd3a0b2f87/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-08-09-1100/src/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc:79:63: error: 'this' pointer is null [-Werror=nonnull]
    79 |       fwRecoGeometry.idToName[rawid].topology[3] = topo->pitch();                                          \
      |                                                    ~~~~~~~~~~~^~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/ada76bbef987ba1823d9aebd3a0b2f87/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-08-09-1100/src/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc:474:7: note: in expansion of macro 'ADD_SISTRIP_TOPOLOGY'
  474 |       ADD_SISTRIP_TOPOLOGY(current, m_trackerGeom->idToDet(detid));
      |       ^~~~~~~~~~~~~~~~~~~~
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/ada76bbef987ba1823d9aebd3a0b2f87/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-08-09-1100/src/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc:82:63: error: 'this' pointer is null [-Werror=nonnull]
    82 |       fwRecoGeometry.idToName[rawid].topology[3] = topo->pitch();                                          \
      |                                                    ~~~~~~~~~~~^~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/ada76bbef987ba1823d9aebd3a0b2f87/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-08-09-1100/src/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc:474:7: note: in expansion of macro 'ADD_SISTRIP_TOPOLOGY'
  474 |       ADD_SISTRIP_TOPOLOGY(current, m_trackerGeom->idToDet(detid));
      |       ^~~~~~~~~~~~~~~~~~~~
cc1plus: some warnings being treated as errors
  gmake: *** [tmp/slc7_amd64_gcc11/src/Fireworks/Geometry/src/FireworksGeometry/FWRecoGeometryESProducer.cc.o] Error 1
```
#### PR description:

Added missing assignment of `dynamic_cast` for `RectangularStripTopology` and `TrapezoidalStripTopology` in `ADD_SISTRIP_TOPOLOGY` macro

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
