### PR TITLE
Replace boost::regex with std::regex

### DIFF
--- a/CondCore/CondDB/interface/Utils.h
+++ b/CondCore/CondDB/interface/Utils.h
@@ -12,8 +12,7 @@
 #include <unistd.h>
 #include <pwd.h>
 #include <climits>
-//
-#include <boost/regex.hpp>
+#include <regex>
 
 namespace cond {
 
@@ -123,10 +122,10 @@ namespace cond {
       if (input.find("sqlite") == 0 || input.find("oracle") == 0)
         return input;
 
-      //static const boost::regex trivial("oracle://(cms_orcon_adg|cms_orcoff_prep)/([_[:alnum:]]+?)");
-      static const boost::regex short_frontier("frontier://([[:alnum:]]+?)/([_[:alnum:]]+?)");
-      static const boost::regex long_frontier("frontier://((\\([-[:alnum:]]+?=[^\\)]+?\\))+)/([_[:alnum:]]+?)");
-      static const boost::regex long_frontier_serverurl("\\(serverurl=[^\\)]+?/([[:alnum:]]+?)\\)");
+      //static const std::regex trivial("oracle://(cms_orcon_adg|cms_orcoff_prep)/([_[:alnum:]]+?)");
+      static const std::regex short_frontier("frontier://([[:alnum:]]+?)/([_[:alnum:]]+?)");
+      static const std::regex long_frontier("frontier://((\\([-[:alnum:]]+?=[^\\)]+?\\))+)/([_[:alnum:]]+?)");
+      static const std::regex long_frontier_serverurl("\\(serverurl=[^\\)]+?/([[:alnum:]]+?)\\)");
 
       static const std::map<std::string, std::string> frontierMap = {
           {"PromptProd", "cms_orcon_adg"},
@@ -136,23 +135,22 @@ namespace cond {
           {"FrontierPrep", "cms_orcoff_prep"},
       };
 
-      boost::smatch matches;
+      std::smatch matches;
 
       static const std::string technology("oracle://");
       std::string service("");
       std::string account("");
 
       bool match = false;
-      if (boost::regex_match(input, matches, short_frontier)) {
+      if (std::regex_match(input, matches, short_frontier)) {
         service = matches[1];
         account = matches[2];
         match = true;
       }
-
-      if (boost::regex_match(input, matches, long_frontier)) {
+      else if (std::regex_match(input, matches, long_frontier)) {
         std::string frontier_config(matches[1]);
-        boost::smatch matches2;
-        if (not boost::regex_search(frontier_config, matches2, long_frontier_serverurl))
+        std::smatch matches2;
+        if (not std::regex_search(frontier_config, matches2, long_frontier_serverurl))
           throwException("No serverurl in matched long frontier", "convertoToOracleConnection");
         service = matches2[1];
         account = matches[3];

--- a/CondCore/CondDB/interface/Utils.h
+++ b/CondCore/CondDB/interface/Utils.h
@@ -146,8 +146,7 @@ namespace cond {
         service = matches[1];
         account = matches[2];
         match = true;
-      }
-      else if (std::regex_match(input, matches, long_frontier)) {
+      } else if (std::regex_match(input, matches, long_frontier)) {
         std::string frontier_config(matches[1]);
         std::smatch matches2;
         if (not std::regex_search(frontier_config, matches2, long_frontier_serverurl))

--- a/CondCore/Utilities/interface/PayloadInspector.h
+++ b/CondCore/Utilities/interface/PayloadInspector.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <tuple>
 #include <vector>
+#include <set>
 #include <type_traits>
 
 #include "FWCore/Utilities/interface/GlobalIdentifier.h"


### PR DESCRIPTION
Though this does not drop the boost dependency for this package but it is a minor cleanup to replace boost::regex with std::regex. 