### PR TITLE
Migrate module configuration in RecoTauTag to use default cfipython

### DIFF
--- a/RecoTauTag/RecoTau/python/PATTauDiscriminationByMVAIsolationRun2_cff.py
+++ b/RecoTauTag/RecoTau/python/PATTauDiscriminationByMVAIsolationRun2_cff.py
@@ -3,28 +3,25 @@ import FWCore.ParameterSet.Config as cms
 from RecoTauTag.RecoTau.TauDiscriminatorTools import noPrediscriminants
 from RecoTauTag.RecoTau.PATTauDiscriminantCutMultiplexer_cfi import *
 
+import RecoTauTag.RecoTau.patTauDiscriminationByMVAIsolationRun2_cfi as _mod
 # make sure to load the database containing the mva inputs before using the producers below
 # e.g. process.load('RecoTauTag.Configuration.loadRecoTauTagMVAsFromPrepDB_cfi') as in
 # RecoTauTag.Configuration.HPSPFTaus_cff
 
-patDiscriminationByIsolationMVArun2v1raw = cms.EDProducer("PATTauDiscriminationByMVAIsolationRun2",
-
+patDiscriminationByIsolationMVArun2v1raw = _mod.patTauDiscriminationByMVAIsolationRun2.clone(
     # tau collection to discriminate
-    PATTauProducer = cms.InputTag('replaceMeByTauCollectionToBeUsed'), # in MiniAOD: slimmedTaus
+    PATTauProducer = 'replaceMeByTauCollectionToBeUsed', # in MiniAOD: slimmedTaus
     Prediscriminants = noPrediscriminants,
-    loadMVAfromDB = cms.bool(True),
-    inputFileName = cms.FileInPath("RecoTauTag/RecoTau/data/emptyMVAinputFile"), # the filename for MVA if it is not loaded from DB
-    mvaName = cms.string("replaceMeByNameOfMVATraining"), # e.g. RecoTauTag_tauIdMVADBoldDMwLTv1
-    mvaOpt = cms.string("replaceMeByMVAOption"), # e.g. DBoldDMwLT
-    
+    loadMVAfromDB = True,
+    inputFileName = "RecoTauTag/RecoTau/data/emptyMVAinputFile", # the filename for MVA if it is not loaded from DB
+    mvaName = "replaceMeByNameOfMVATraining", # e.g. RecoTauTag_tauIdMVADBoldDMwLTv1
+    mvaOpt = "replaceMeByMVAOption", # e.g. DBoldDMwLT
     # change these only if input isolation sums changed for the MVA training you want to use
-    srcChargedIsoPtSum = cms.string('chargedIsoPtSum'),
-    srcNeutralIsoPtSum = cms.string('neutralIsoPtSum'),
-    srcPUcorrPtSum = cms.string('puCorrPtSum'),
-    srcPhotonPtSumOutsideSignalCone = cms.string('photonPtSumOutsideSignalCone'),
-    srcFootprintCorrection = cms.string('footprintCorrection'),
-
-    verbosity = cms.int32(0)
+    srcChargedIsoPtSum = 'chargedIsoPtSum',
+    srcNeutralIsoPtSum = 'neutralIsoPtSum',
+    srcPUcorrPtSum = 'puCorrPtSum',
+    srcPhotonPtSumOutsideSignalCone = 'photonPtSumOutsideSignalCone',
+    srcFootprintCorrection = 'footprintCorrection',
 )
 
 patDiscriminationByIsolationMVArun2v1 = patTauDiscriminantCutMultiplexer.clone(

--- a/RecoTauTag/RecoTau/python/PFRecoTauDiscriminationByMVAIsolation2_cff.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauDiscriminationByMVAIsolation2_cff.py
@@ -2,30 +2,28 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoTauTag.RecoTau.recoTauDiscriminantCutMultiplexerDefault_cfi import recoTauDiscriminantCutMultiplexerDefault
 from RecoTauTag.Configuration.HPSPFTaus_cff import hpsPFTauBasicDiscriminators
+import RecoTauTag.RecoTau.pfRecoTauDiscriminationByIsolationMVA2_cfi as _mod
 
-discriminationByIsolationMVA2raw = cms.EDProducer("PFRecoTauDiscriminationByIsolationMVA2",
-
+discriminationByIsolationMVA2raw = _mod.pfRecoTauDiscriminationByIsolationMVA2.clone(
     # tau collection to discriminate
-    PFTauProducer = cms.InputTag('pfTauProducer'),
+    PFTauProducer = 'pfTauProducer',
 
     # Require leading pion ensures that:
     #  1) these is at least one track above threshold (0.5 GeV) in the signal cone
     #  2) a track OR a pi-zero in the signal cone has pT > 5 GeV
     Prediscriminants = requireLeadTrack,
-    loadMVAfromDB = cms.bool(True),
-    inputFileName = cms.FileInPath("RecoTauTag/RecoTau/data/emptyMVAinputFile"), # the filename for MVA if it is not loaded from DB
-    mvaName = cms.string("tauIdMVAnewDMwLT"),
-    mvaOpt = cms.string("newDMwLT"),
+    loadMVAfromDB = True,
+    inputFileName = "RecoTauTag/RecoTau/data/emptyMVAinputFile", # the filename for MVA if it is not loaded from DB
+    mvaName = "tauIdMVAnewDMwLT",
+    mvaOpt  = "newDMwLT",
 
     # NOTE: tau lifetime reconstruction sequence needs to be run before
-    srcTauTransverseImpactParameters = cms.InputTag(''),
+    srcTauTransverseImpactParameters = '',
     
-    srcBasicTauDiscriminators = cms.InputTag('hpsPFTauBasicDiscriminators'),
-    srcChargedIsoPtSumIndex = cms.int32(0),
-    srcNeutralIsoPtSumIndex = cms.int32(1),
-    srcPUcorrPtSumIndex = cms.int32(5),
-
-    verbosity = cms.int32(0)
+    srcBasicTauDiscriminators = 'hpsPFTauBasicDiscriminators',
+    srcChargedIsoPtSumIndex = 0,
+    srcNeutralIsoPtSumIndex = 1,
+    srcPUcorrPtSumIndex = 5,
 )
 
 discriminationByIsolationMVA2 = recoTauDiscriminantCutMultiplexerDefault.clone(

--- a/RecoTauTag/RecoTau/python/PFRecoTauTagInfoProducer_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauTagInfoProducer_cfi.py
@@ -1,46 +1,41 @@
 import FWCore.ParameterSet.Config as cms
-import copy
 from RecoTauTag.RecoTau.PFRecoTauQualityCuts_cfi import PFTauQualityCuts
+import RecoTauTag.RecoTau.pfRecoTauTagInfoProducer_cfi as _mod
 
-pfRecoTauTagInfoProducer = cms.EDProducer("PFRecoTauTagInfoProducer",
-
+pfRecoTauTagInfoProducer = _mod.pfRecoTauTagInfoProducer.clone(
     # These values set the minimum pt quality requirements
-    #  for the various constituent types
-    ChargedHadrCand_tkminPt    = cms.double(0.5),  # charged PF objects
-    tkminPt                    = cms.double(0.5),  # track (non-PF) objects
-    NeutrHadrCand_HcalclusMinEt = cms.double(1.0),  # PF neutral hadrons (HCAL)
-    GammaCand_EcalclusMinEt     = cms.double(1.0),  # PF gamma candidates (ECAL)
+    # for the various constituent types
+    ChargedHadrCand_tkminPt     = 0.5,  # charged PF objects
+    tkminPt                     = 0.5,  # track (non-PF) objects
+    NeutrHadrCand_HcalclusMinEt = 1.0,  # PF neutral hadrons (HCAL)
+    GammaCand_EcalclusMinEt     = 1.0,  # PF gamma candidates (ECAL)
 
     # The size of the delta R cone used to collect objects from the jet
-    ChargedHadrCand_AssociationCone   = cms.double(0.8),
-
-    PVProducer                    = PFTauQualityCuts.primaryVertexSrc,
-    UsePVconstraint               = cms.bool(True),
-    PFCandidateProducer           = cms.InputTag('particleFlow'),
-    PFJetTracksAssociatorProducer = cms.InputTag('ak4PFJetTracksAssociatorAtVertex'),
+    ChargedHadrCand_AssociationCone   = 0.8,
+    PVProducer                        = PFTauQualityCuts.primaryVertexSrc,
 
     # Quality cuts for tracks (non-PF, from JetTracksAssociator)
-    tkminTrackerHitsn = cms.int32(3),
-    tkmaxChi2         = cms.double(100.0),
-    tkPVmaxDZ         = cms.double(0.2), ##considered if UsePVconstraint is true
-    tkminPixelHitsn   = cms.int32(0),
-    tkmaxipt          = cms.double(0.03),
+    tkminTrackerHitsn = 3,
+    tkmaxChi2         = 100.0,
+    tkPVmaxDZ         = 0.2, ##considered if UsePVconstraint is true
+    tkminPixelHitsn   = 0,
+    tkmaxipt          = 0.03,
 
     # Quality cuts for PFCharged Hadron candidates (taken from their underlying recTrack)
-    ChargedHadrCand_tkminTrackerHitsn = cms.int32(3),
-    ChargedHadrCand_tkmaxChi2         = cms.double(100.0),
-    ChargedHadrCand_tkmaxipt          = cms.double(0.03),
-    ChargedHadrCand_tkminPixelHitsn   = cms.int32(0),
-    ChargedHadrCand_tkPVmaxDZ         = cms.double(0.2), ##considered if UsePVconstraint is true
+    ChargedHadrCand_tkminTrackerHitsn = 3,
+    ChargedHadrCand_tkmaxChi2         = 100.0,
+    ChargedHadrCand_tkmaxipt          = 0.03,
+    ChargedHadrCand_tkminPixelHitsn   = 0,
+    ChargedHadrCand_tkPVmaxDZ         = 0.2, ##considered if UsePVconstraint is true
 
     # Smear vertex
-    smearedPVsigmaY               = cms.double(0.0015),
-    smearedPVsigmaX               = cms.double(0.0015),
-    smearedPVsigmaZ               = cms.double(0.005),
+    smearedPVsigmaY               = 0.0015,
+    smearedPVsigmaX               = 0.0015,
+    smearedPVsigmaZ               = 0.005,
 )
 
 # PF TauTag info seeded from the Inside-Out jet producer
-pfRecoTauTagInfoProducerInsideOut                                 = copy.deepcopy(pfRecoTauTagInfoProducer)
-pfRecoTauTagInfoProducerInsideOut.PFJetTracksAssociatorProducer   = cms.InputTag('insideOutJetTracksAssociatorAtVertex')
-pfRecoTauTagInfoProducerInsideOut.ChargedHadrCand_AssociationCone = cms.double(1.0)
-
+pfRecoTauTagInfoProducerInsideOut = pfRecoTauTagInfoProducer.clone(
+    PFJetTracksAssociatorProducer   = 'insideOutJetTracksAssociatorAtVertex',
+    ChargedHadrCand_AssociationCone = 1.0
+)

--- a/RecoTauTag/RecoTau/python/PFTauPrimaryVertexProducer_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFTauPrimaryVertexProducer_cfi.py
@@ -1,20 +1,14 @@
 import FWCore.ParameterSet.Config as cms
 from RecoTauTag.RecoTau.PFRecoTauQualityCuts_cfi import PFTauQualityCuts
-PFTauPrimaryVertexProducer = cms.EDProducer("PFTauPrimaryVertexProducer",
-                                            PFTauTag =  cms.InputTag("hpsPFTauProducer"),
-                                            ElectronTag = cms.InputTag("MyElectrons"),
-                                            MuonTag = cms.InputTag("MyMuons"),
-                                            PVTag = cms.InputTag("offlinePrimaryVertices"),
-                                            beamSpot = cms.InputTag("offlineBeamSpot"),
-                                            #Algorithm: 0 - use tau-jet vertex, 1 - use vertex[0]
-                                            Algorithm = cms.int32(0),
-                                            qualityCuts = PFTauQualityCuts,
-                                            useBeamSpot = cms.bool(True),
-                                            RemoveMuonTracks = cms.bool(False),
-                                            RemoveElectronTracks = cms.bool(False),
-                                            useSelectedTaus = cms.bool(False),
-                                            discriminators = cms.VPSet(cms.PSet(discriminator = cms.InputTag('hpsPFTauDiscriminationByDecayModeFinding'),
-                                            selectionCut = cms.double(0.5))),
-                                            cut = cms.string("pt > 18.0 & abs(eta)<2.3")
-                                            )
+import RecoTauTag.RecoTau.pfTauPrimaryVertexProducer_cfi as _mod
 
+PFTauPrimaryVertexProducer = _mod.pfTauPrimaryVertexProducer.clone(
+    #Algorithm: 0 - use tau-jet vertex, 1 - use vertex[0]
+    qualityCuts = PFTauQualityCuts,
+    discriminators = cms.VPSet(
+        cms.PSet(
+            discriminator = cms.InputTag('hpsPFTauDiscriminationByDecayModeFinding'),
+            selectionCut = cms.double(0.5)
+        )
+    ),
+)


### PR DESCRIPTION
#### PR description: 
Optimization of the python configurations: Improve maintainability by cleaning up the duplicated and cloning from the default/reference configurations. (The previous PRs : #33207, #33307, #33352, #33543, #33563, #33671, #34007, #34091, #34009, #34155, #34371, #34480, #34543, #34571, #34817, #34818 )
 
In this PR, 4 files changed.  
        modified:   RecoTauTag/RecoTau/python/PATTauDiscriminationByMVAIsolationRun2_cff.py
        modified:   RecoTauTag/RecoTau/python/PFRecoTauDiscriminationByMVAIsolation2_cff.py
        modified:   RecoTauTag/RecoTau/python/PFRecoTauTagInfoProducer_cfi.py
        modified:   RecoTauTag/RecoTau/python/PFTauPrimaryVertexProducer_cfi.py


Update
- Replace explicit configuration with a reference from cfipython/. (migrating EDProducer("type", .. -> typeDefaylt.clone() ) 
- Remove the type specifications already presented in cfipython/fillDescriptions reference for improved syntax safety.
- Remove the duplicated parameters that are exactly the same value in cfipython reference.

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_12_1_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).