### PR TITLE
Fix rare crash in pixel template interpolation

### DIFF
--- a/CondFormats/SiPixelTransient/src/SiPixelTemplate.cc
+++ b/CondFormats/SiPixelTransient/src/SiPixelTemplate.cc
@@ -106,6 +106,7 @@
 #include "CondFormats/SiPixelTransient/interface/SimplePixel.h"
 #include "FWCore/Utilities/interface/FileInPath.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/isFinite.h"
 #define LOGERROR(x) LogError(x)
 #define LOGINFO(x) LogInfo(x)
 #define LOGWARNING(x) LogWarning(x)
@@ -1391,6 +1392,12 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
     if (index_id_ < 0 || index_id_ >= (int)thePixelTemp_.size()) {
       throw cms::Exception("DataCorrupt")
           << "SiPixelTemplate::interpolate can't find needed template ID = " << id << std::endl;
+    }
+
+    //check for nan's
+    if (!edm::isFinite(cotalpha) || !edm::isFinite(cotbeta)) {
+      success_ = false;
+      return success_;
     }
 #else
     assert(index_id_ >= 0 && index_id_ < (int)thePixelTemp_.size());

--- a/CondFormats/SiPixelTransient/src/SiPixelTemplate2D.cc
+++ b/CondFormats/SiPixelTransient/src/SiPixelTemplate2D.cc
@@ -40,6 +40,7 @@
 #include "CondFormats/SiPixelTransient/interface/SiPixelTemplate2D.h"
 #include "FWCore/Utilities/interface/FileInPath.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/isFinite.h"
 #define LOGERROR(x) LogError(x)
 #define LOGINFO(x) LogInfo(x)
 #define ENDL " "
@@ -679,6 +680,12 @@ bool SiPixelTemplate2D::interpolate(int id, float cotalpha, float cotbeta, float
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
       throw cms::Exception("DataCorrupt")
           << "SiPixelTemplate2D::illegal subdetector ID = " << thePixelTemp_[index_id_].head.Dtype << std::endl;
+
+      //check for nan's
+      if (!edm::isFinite(cotalpha) || !edm::isFinite(cotbeta)) {
+        success_ = false;
+        return success_;
+      }
 #else
       std::cout << "SiPixelTemplate:2D:illegal subdetector ID = " << thePixelTemp_[index_id_].head.Dtype << std::endl;
 #endif


### PR DESCRIPTION
This PR is a bugfix to address issue #34835. The crash was caused by a call to `SiPixelTemplate2D::interpolate` which had NaN track angles as inputs. The fix is just to check that the track angles are finite before proceeding with the interpolation. A similar change was applied to `SiPixelTemplate::interpolate` to avoid the potential  for the same issue. 

No changes are expected except for the extremely rare case when the input track angles are NaN's. 