### PR TITLE
CondCore/Utilities: cleaned up dependencies from CondCore/CondDB details

### DIFF
--- a/CondCore/Utilities/bin/conddb_test_gt_perf.cpp
+++ b/CondCore/Utilities/bin/conddb_test_gt_perf.cpp
@@ -2,8 +2,6 @@
 #include "CondCore/CondDB/interface/IOVProxy.h"
 #include "CondCore/CondDB/interface/GTProxy.h"
 
-#include "CondCore/CondDB/src/IOVSchema.cc"
-
 #include "CondCore/Utilities/interface/Utilities.h"
 #include "CondCore/Utilities/interface/CondDBImport.h"
 #include <iostream>
@@ -188,12 +186,6 @@ bool cond::UntypedPayloadProxy::get(cond::Time_t targetTime, bool debug) {
     } else {
       if (debug)
         std::cout << "Loaded payload of type \"" << payloadType << "\" (" << m_buffer.size() << " bytes)" << std::endl;
-    }
-    // check if hash is correct:
-    cond::Hash localHash = cond::persistency::makeHash(payloadType, m_buffer);
-    if (localHash != m_data->current.payloadId) {
-      std::cout << "ERROR: payload of type " << payloadType << " with id " << m_data->current.payloadId
-                << " in DB has wrong local hash: " << localHash << std::endl;
     }
   }
   return loaded;

--- a/CondCore/Utilities/src/CondDBTools.cc
+++ b/CondCore/Utilities/src/CondDBTools.cc
@@ -2,10 +2,6 @@
 #include "CondCore/Utilities/interface/CondDBImport.h"
 #include "CondCore/CondDB/interface/ConnectionPool.h"
 //
-#include "CondCore/CondDB/src/DbCore.h"
-//
-#include <boost/regex.hpp>
-
 #include <memory>
 
 namespace cond {


### PR DESCRIPTION
#### PR description:

The aim of this PR is to remove the dependencies from the CondCore/CondDB src files. The   concerned header files are:
- CondCore/CondDB/src/DbCore.h: not required
- CondCore/CondDB/src/IOVSchema.cc: used for a check that is outside the scope of the concerned test 
#### PR validation:

Unit and integration test
