### PR TITLE
[SimCalorimetry] Avoid using private CondFormats/EcalObjects/src/classes.h

### DIFF
--- a/SimCalorimetry/EcalSimProducers/plugins/EcalCATIAGainRatiosESProducer.cc
+++ b/SimCalorimetry/EcalSimProducers/plugins/EcalCATIAGainRatiosESProducer.cc
@@ -8,7 +8,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CondFormats/DataRecord/interface/EcalCATIAGainRatiosRcd.h"
 #include "CondFormats/EcalObjects/interface/EcalCATIAGainRatios.h"
-#include "CondFormats/EcalObjects/src/classes.h"
+#include "DataFormats/EcalDigi/interface/EcalConstants.h"
 //
 // class declaration
 //

--- a/SimCalorimetry/EcalSimProducers/plugins/EcalLiteDTUPedestalsESProducer.cc
+++ b/SimCalorimetry/EcalSimProducers/plugins/EcalLiteDTUPedestalsESProducer.cc
@@ -7,7 +7,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CondFormats/DataRecord/interface/EcalLiteDTUPedestalsRcd.h"
 #include "CondFormats/EcalObjects/interface/EcalLiteDTUPedestals.h"
-#include "CondFormats/EcalObjects/src/classes.h"
 #include "DataFormats/EcalDigi/interface/EcalConstants.h"
 
 //


### PR DESCRIPTION
As reported in #34718 , this PR fixes the usage of private header
```
2 src/CondFormats/EcalObjects/src/classes.h
```