### PR TITLE
[GCC11] Fix warning: loop variable binds to a temporary

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATObjectUserDataEmbedder.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATObjectUserDataEmbedder.cc
@@ -75,7 +75,7 @@ namespace pat {
     static void fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
       edm::ParameterSetDescription desc;
       desc.add<edm::InputTag>("src");
-      for (auto&& what : {"userFloats", "userInts", "userIntFromBools", "userCands"}) {
+      for (auto &&what : {"userFloats", "userInts", "userIntFromBools", "userCands"}) {
         edm::ParameterSetDescription descNested;
         descNested.addWildcard<edm::InputTag>("*");
         desc.add<edm::ParameterSetDescription>(what, descNested);

--- a/PhysicsTools/PatAlgos/plugins/PATObjectUserDataEmbedder.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATObjectUserDataEmbedder.cc
@@ -75,7 +75,7 @@ namespace pat {
     static void fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
       edm::ParameterSetDescription desc;
       desc.add<edm::InputTag>("src");
-      for (const std::string &what : {"userFloats", "userInts", "userIntFromBools", "userCands"}) {
+      for (auto&& what : {"userFloats", "userInts", "userIntFromBools", "userCands"}) {
         edm::ParameterSetDescription descNested;
         descNested.addWildcard<edm::InputTag>("*");
         desc.add<edm::ParameterSetDescription>(what, descNested);


### PR DESCRIPTION
#### PR description:
Log file: https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc11/CMSSW_12_1_X_2021-08-11-1100/PhysicsTools/PatAlgos

```
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/014281f7054fa0c78acaef7d47194c17/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-08-11-1100/src/PhysicsTools/PatAlgos/plugins/PATObjectUserDataEmbedder.cc: In instantiation of 'static void pat::PATObjectUserDataEmbedder<T>::fillDescriptions(edm::ConfigurationDescriptions&) [with T = pat::Electron]':
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/014281f7054fa0c78acaef7d47194c17/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-08-11-1100/src/FWCore/Framework/src/WorkerMaker.h:72:24:   required from 'void edm::WorkerMaker<T>::fillDescriptions(edm::ConfigurationDescriptions&) const [with T = pat::PATObjectUserDataEmbedder<pat::Electron>]'
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/014281f7054fa0c78acaef7d47194c17/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-08-11-1100/src/FWCore/Framework/src/WorkerMaker.h:71:8:   required from here
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/014281f7054fa0c78acaef7d47194c17/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-08-11-1100/src/PhysicsTools/PatAlgos/plugins/PATObjectUserDataEmbedder.cc:78:31: warning: loop variable 'what' of type 'const string&' {aka 'const std::__cxx11::basic_string<char>&'} binds to a temporary constructed from type 'const char* const' [-Wrange-loop-construct]
    78 |       for (const std::string &what : {"userFloats", "userInts", "userIntFromBools", "userCands"}) {
      |
```

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->
