### PR TITLE
initialize Trackster::iterationIndex_

### DIFF
--- a/DataFormats/HGCalReco/interface/Trackster.h
+++ b/DataFormats/HGCalReco/interface/Trackster.h
@@ -37,7 +37,8 @@ namespace ticl {
     enum class PCAOrdering { ascending = 0, descending };
 
     Trackster()
-        : seedIndex_(0),
+        : iterationIndex_(0),
+          seedIndex_(0),
           time_(0.f),
           timeError_(-1.f),
           regressed_energy_(0.f),


### PR DESCRIPTION
in an unrelated PR tests I noticed that the iterationIndex is changing randomly
e.g. https://github.com/cms-sw/cmssw/pull/34852#issuecomment-897783922

The proposal is to initialize to 0, but since it's a valid iteration value, I'm not so sure.
@cms-sw/hgcal-dpg-l2 please confirm if this is OK.
Thank you.
