### PR TITLE
Bug fix for track MET in MET correction tools

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -6,6 +6,8 @@ from PhysicsTools.PatAlgos.tools.helpers import getPatAlgosToolsTask, addToProce
 
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 
+from PhysicsTools.PatUtils.tools.pfforTrkMET_cff import *
+
 def miniAOD_customizeCommon(process):
     process.patMuons.isoDeposits = cms.PSet()
     process.patElectrons.isoDeposits = cms.PSet()
@@ -216,10 +218,7 @@ def miniAOD_customizeCommon(process):
     #  ==================  CHSMET 
 
     #  ==================  TrkMET 
-    process.TrkCands = cms.EDFilter("CandPtrSelector",
-                                    src=cms.InputTag("packedPFCandidates"),
-                                    cut=cms.string("charge()!=0 && pvAssociationQuality()>=4 && vertexRef().key()==0")
-                                    )
+    process.TrkCands = chargedPackedCandsForTkMet.clone()
     task.add(process.TrkCands)
 
     process.pfMetTrk = pfMet.clone(src = 'TrkCands')

--- a/PhysicsTools/PatUtils/python/tools/pfforTrkMET_cff.py
+++ b/PhysicsTools/PatUtils/python/tools/pfforTrkMET_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+chargedPackedCandsForTkMet = cms.EDFilter("CandPtrSelector",
+                                          src=cms.InputTag("packedPFCandidates"),
+                                          cut=cms.string("charge()!=0 && pvAssociationQuality()>=4 && vertexRef().key()==0")
+                                      )

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -6,6 +6,7 @@ import PhysicsTools.PatAlgos.tools.helpers as configtools
 from PhysicsTools.PatAlgos.tools.helpers import getPatAlgosToolsTask, addToProcessAndTask
 from PhysicsTools.PatAlgos.tools.jetTools import switchJetCollection
 import CommonTools.CandAlgos.candPtrProjector_cfi as _mod
+from PhysicsTools.PatUtils.tools.pfforTrkMET_cff import *
 
 
 def isValidInputTag(input):
@@ -1727,8 +1728,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         patMetModuleSequence += getattr(process, "pfCHS")
         patMetModuleSequence += getattr(process, "pfMetCHS")
         patMetModuleSequence += getattr(process, "patCHSMet")
-
-        pfTrk = cms.EDFilter("CandPtrSelector", src = cms.InputTag("packedPFCandidates"), cut = cms.string("pvAssociationQuality()>=4 && charge()!=0 && vertexRef().key()==0"))
+        
+        pfTrk = chargedPackedCandsForTkMet.clone()
         addToProcessAndTask("pfTrk", pfTrk, process, task)
         pfMetTrk = pfMet.clone(src = 'pfTrk')
         addToProcessAndTask("pfMetTrk", pfMetTrk, process, task)

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -1728,7 +1728,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         patMetModuleSequence += getattr(process, "pfMetCHS")
         patMetModuleSequence += getattr(process, "patCHSMet")
 
-        pfTrk = cms.EDFilter("CandPtrSelector", src = cms.InputTag("packedPFCandidates"), cut = cms.string("fromPV(0) > 0 && charge()!=0"))
+        pfTrk = cms.EDFilter("CandPtrSelector", src = cms.InputTag("packedPFCandidates"), cut = cms.string("pvAssociationQuality()>=4 && charge()!=0 && vertexRef().key()==0"))
         addToProcessAndTask("pfTrk", pfTrk, process, task)
         pfMetTrk = pfMet.clone(src = 'pfTrk')
         addToProcessAndTask("pfMetTrk", pfMetTrk, process, task)


### PR DESCRIPTION
#### PR description:

This PR is a fix of a longstanding bug in the calculation of the track MET in the MET correction tools that results in a wrong value in NANOAOD. 
The bug was recently (re?)discovered when trying to run MINI and NANO in a single job (see https://github.com/cms-sw/cmssw/pull/34714 )

The PF candidate filter is now in synch with the one used in the MINIAOD tools.

https://github.com/cms-sw/cmssw/blob/master/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py#L219-L222

#### PR validation:

Explicitly checked that the TrackMET value in NANOAOD is identical when you fetch the MINIAOD value or recompute it using the MET correction tool. 
