### PR TITLE
[12_0_X] Backport the fix on the workflow 537 and the mergeLHE.py script

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1542,7 +1542,7 @@ steps['sherpa_ttbar_2j_MENLOPS_13TeV_MASTER']=genvalid('sherpa_ttbar_2j_MENLOPS_
 
 #Herwig7
 steps['TTbar_13TeV_Pow_herwig7']=genvalid('Configuration/Generator/python/TT_13TeV_Pow_Herwig7_cff',step1LHEGenDQM)
-steps['DYToLL012Jets_5FS_TuneCH3_13TeV_amcatnloFxFx_herwig7']=genvalid('Configuration/Generator/python/DYToLL012Jets_5FS_TuneCH3_13TeV_amcatnloFxFx_herwig7_cff',step1LHEGenDQM)
+steps['DYToLL012Jets_5FS_TuneCH3_13TeV_amcatnloFxFx_herwig7']=genvalid('Configuration/Generator/python/DYToLL012Jets_5FS_TuneCH3_13TeV_amcatnloFxFx_herwig7_cff',merge([{'-n':'12'},step1LHEGenDQM]))
 steps['DYToLL01234Jets_5FS_TuneCH3_13TeV_madgraphMLM_herwig7']=genvalid('Configuration/Generator/python/DYToLL01234Jets_5FS_TuneCH3_13TeV_madgraphMLM_herwig7_cff',step1LHEGenDQM)
 
 

--- a/GeneratorInterface/LHEInterface/scripts/mergeLHE.py
+++ b/GeneratorInterface/LHEInterface/scripts/mergeLHE.py
@@ -196,7 +196,7 @@ class DefaultLHEMerger(BaseLHEMerger):
             for i in range(len(self._f)):
                 header = []
                 line = next(self._f[i])
-                while not line.startswith('<init>') and not line.startswith('<init '):
+                while not re.search('\s*<init(>|\s)', line):
                     header.append(line)
                     line = next(self._f[i])
                 # 'header' includes all contents before reaches <init>
@@ -207,7 +207,7 @@ class DefaultLHEMerger(BaseLHEMerger):
             for i in range(len(self._f)):
                 init = []
                 line = next(self._f[i])
-                while not line.startswith('</init>'):
+                while not re.search('\s*</init>', line):
                     init.append(line)
                     line = next(self._f[i])
                 # 'init_str' includes all contents inside <init>...</init>
@@ -220,9 +220,9 @@ class DefaultLHEMerger(BaseLHEMerger):
                     nevent = 0
                     while True:
                         line = next(self._f[i])
-                        if line.startswith('</event>'):
+                        if re.search('\s*</event>', line):
                             nevent += 1
-                        if line.startswith('</LesHouchesEvents>'):
+                        if re.search('\s*</LesHouchesEvents>', line):
                             break
                         _fwtmp.write(line)
                     self._nevent.append(nevent)
@@ -253,7 +253,7 @@ class DefaultLHEMerger(BaseLHEMerger):
                     sign = lambda x: -1 if x < 0 else 1
                     for line in ftmp:
                         event_line += 1
-                        if line.startswith('<event'):
+                        if re.search('\s*<event.*>', line):
                             event_line = 0
                         if event_line == 1:
                             # modify the XWGTUP appeared in the first line of the
@@ -261,8 +261,8 @@ class DefaultLHEMerger(BaseLHEMerger):
                             orig_wgt = float(line.split()[2])
                             fw.write(re.sub(r'(^\s*\S+\s+\S+\s+)\S+(.+)', r'\g<1>%+.7E\g<2>' \
                                 % (sign(orig_wgt) * self._uwgt), line))
-                        elif line.startswith('<wgt '):
-                            addi_wgt_str = re.search(r'^\<wgt.*\>\s*(\S+)\s*\<\/wgt\>', line).group(1)
+                        elif re.search('\s*<wgt.*>.*</wgt>', line):
+                            addi_wgt_str = re.search(r'\<wgt.*\>\s*(\S+)\s*\<\/wgt\>', line).group(1)
                             fw.write(line.replace(
                                 addi_wgt_str, '%+.7E' % (float(addi_wgt_str) / orig_wgt * self._uwgt)))
                         else:


### PR DESCRIPTION
#### PR description:

Backport of 
  1. 2e7e1c0ca67865630b9aae21948cf75b6ffad0e5 in #34710 
  2. #34804

The first helps to fix the workflow 537 in the 4-thread mode. The issue is identified in https://github.com/cms-sw/cmssw/issues/34531. The error is caused by a physics issue in the generator meaning that generating merely 2 events may probabilistically cause zero x-section.

The second is a relevant fix to make the `mergeLHE.py` script more generalized (the script is called in workflow 537), as also discussed in https://github.com/cms-sw/cmssw/issues/34531.


#### PR validation:

Workflow 537 works in the 4-thread mode.