### PR TITLE
[DQM] Remove unnecessary include statements to avoid private header dep

### DIFF
--- a/DQM/CastorMonitor/interface/CastorRecHitMonitor.h
+++ b/DQM/CastorMonitor/interface/CastorRecHitMonitor.h
@@ -13,7 +13,6 @@
 #include "DataFormats/JetReco/interface/CastorJetID.h"
 #include "DataFormats/JetReco/interface/Jet.h"
 #include "RecoJets/JetProducers/interface/CastorJetIDHelper.h"
-#include "RecoJets/JetProducers/plugins/CastorJetIDProducer.h"
 
 #include "DataFormats/Common/interface/TriggerResults.h"
 


### PR DESCRIPTION
Unnecessary include `RecoJets/JetProducers/plugins/CastorJetIDProducer.h`  cleanup. 
This should fix the following private header usage issue #34718 for
```
2 src/RecoJets/JetProducers/plugins/CastorJetIDProducer.h
```