### PR TITLE
[L1TTrackMatch] Remove unnecessary include statements to avoid private hdr dep

### DIFF
--- a/L1Trigger/L1TTrackMatch/plugins/L1FastTrackingJetProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1FastTrackingJetProducer.cc
@@ -33,11 +33,12 @@
 // geometry
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "RecoJets/JetProducers/plugins/VirtualJetProducer.h"
 
 //mc
 #include "SimTracker/TrackTriggerAssociation/interface/TTTrackAssociationMap.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
+
+#include <fastjet/JetDefinition.hh>
 
 #include <string>
 #include "TMath.h"

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackFastJetProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackFastJetProducer.cc
@@ -32,7 +32,8 @@
 // geometry
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "RecoJets/JetProducers/plugins/VirtualJetProducer.h"
+
+#include <fastjet/JetDefinition.hh>
 
 #include <string>
 #include "TMath.h"


### PR DESCRIPTION
Unnecessary include `RecoJets/JetProducers/plugins/VirtualJetProducer.h`  cleanup. 
This should fix the following private header usage issue #34718 for
```
2 src/RecoJets/JetProducers/plugins/VirtualJetProducer.h
```