### PR TITLE
[RecoMuon] Remove unnecessary include statements to avoid private hdr deps

### DIFF
--- a/RecoMuon/MuonIdentification/test/MuonTimingValidator.cc
+++ b/RecoMuon/MuonIdentification/test/MuonTimingValidator.cc
@@ -46,10 +46,6 @@
 #include "Geometry/DTGeometry/interface/DTLayer.h"
 #include "Geometry/DTGeometry/interface/DTSuperLayer.h"
 #include "DataFormats/DTRecHit/interface/DTSLRecSegment2D.h"
-#include "RecoLocalMuon/DTSegment/src/DTSegmentUpdator.h"
-#include "RecoLocalMuon/DTSegment/src/DTSegmentCleaner.h"
-#include "RecoLocalMuon/DTSegment/src/DTHitPairForFit.h"
-#include "RecoLocalMuon/DTSegment/src/DTSegmentCand.h"
 
 #include <Geometry/CSCGeometry/interface/CSCLayer.h>
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>


### PR DESCRIPTION
This should fix the following private header usage issue #34718 for
```
      1 src/RecoLocalMuon/DTSegment/src/DTHitPairForFit.h
      1 src/RecoLocalMuon/DTSegment/src/DTSegmentCand.h
      1 src/RecoLocalMuon/DTSegment/src/DTSegmentCleaner.h
      1 src/RecoLocalMuon/DTSegment/src/DTSegmentUpdator.h
```