### PR TITLE
[Reco] Removed unnecessary include statements

### DIFF
--- a/HLTrigger/Egamma/plugins/HLTDisplacedEgammaFilter.cc
+++ b/HLTrigger/Egamma/plugins/HLTDisplacedEgammaFilter.cc
@@ -6,14 +6,11 @@
  */
 
 #include "HLTDisplacedEgammaFilter.h"
-
 #include "DataFormats/Common/interface/Handle.h"
-
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "DataFormats/RecoCandidate/interface/RecoEcalCandidate.h"
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h"
-#include "RecoTracker/TrackProducer/plugins/TrackProducer.h"
 #include "DataFormats/Math/interface/LorentzVector.h"
 
 //

--- a/HLTrigger/Muon/plugins/BuildFile.xml
+++ b/HLTrigger/Muon/plugins/BuildFile.xml
@@ -21,4 +21,5 @@
 <use name="RecoMuon/MuonIsolation"/>
 <use name="TrackingTools/PatternTools"/>
 <use name="TrackingTools/TransientTrack"/>
+<use name="RecoTracker/FinalTrackSelectors"/>
 <flags EDM_PLUGIN="1"/>

--- a/HLTrigger/Muon/plugins/HLTMuonTrackSelector.h
+++ b/HLTrigger/Muon/plugins/HLTMuonTrackSelector.h
@@ -12,7 +12,7 @@
 * 
 */
 
-#include "RecoTracker/FinalTrackSelectors/src/TrackCollectionCloner.cc"
+#include "RecoTracker/FinalTrackSelectors/interface/TrackCollectionCloner.h"
 
 #include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHitGPUKernel.cu
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHitGPUKernel.cu
@@ -9,7 +9,6 @@
 #include "CUDADataFormats/SiPixelCluster/interface/gpuClusteringConstants.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
-#include "RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.h"
 
 #include "PixelRecHitGPUKernel.h"
 #include "gpuPixelRecHits.h"

--- a/RecoPixelVertexing/PixelLowPtUtilities/src/StripSubClusterShapeTrajectoryFilter.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/StripSubClusterShapeTrajectoryFilter.cc
@@ -22,7 +22,6 @@
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeHitFilter.h"
 #include "RecoTracker/Record/interface/CkfComponentsRecord.h"
-#include "RecoTracker/MeasurementDet/src/TkMeasurementDetSet.h"
 #include "RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h"
 #include "TrackingTools/PatternTools/interface/TempTrajectory.h"
 #include "TrackingTools/PatternTools/interface/Trajectory.h"

--- a/RecoTracker/ConversionSeedGenerators/plugins/HitPairGeneratorFromLayerPairForPhotonConversion.cc
+++ b/RecoTracker/ConversionSeedGenerators/plugins/HitPairGeneratorFromLayerPairForPhotonConversion.cc
@@ -9,7 +9,6 @@
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegionBase.h"
 #include "RecoTracker/TkHitPairs/interface/OrderedHitPairs.h"
-#include "RecoTracker/TkHitPairs/src/InnerDeltaPhi.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"

--- a/RecoTracker/ConversionSeedGenerators/plugins/HitQuadrupletGeneratorFromLayerPairForPhotonConversion.cc
+++ b/RecoTracker/ConversionSeedGenerators/plugins/HitQuadrupletGeneratorFromLayerPairForPhotonConversion.cc
@@ -9,7 +9,6 @@
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegionBase.h"
 #include "RecoTracker/TkHitPairs/interface/OrderedHitPairs.h"
-#include "RecoTracker/TkHitPairs/src/InnerDeltaPhi.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"

--- a/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc
@@ -8,7 +8,7 @@
 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "RecoPixelVertexing/PixelTriplets/plugins/ThirdHitCorrection.h"
+#include "RecoTracker/TkMSParametrization/interface/PixelRecoUtilities.h"
 #include "RecoTracker/TkHitPairs/interface/RecHitsSortedInPhi.h"
 
 #include "CommonTools/RecoAlgos/interface/KDTreeLinkerAlgo.h"


### PR DESCRIPTION
This should fix the following private header usage issue #34718 for
```
      1 src/RecoPixelVertexing/PixelTriplets/plugins/ThirdHitCorrection.h
      1 src/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.h
      1 src/RecoTracker/FinalTrackSelectors/src/TrackCollectionCloner.cc
      1 src/RecoTracker/MeasurementDet/src/TkMeasurementDetSet.h
      2 src/RecoTracker/TkHitPairs/src/InnerDeltaPhi.h
      1 src/RecoTracker/TrackProducer/plugins/TrackProducer.h
```