### PR TITLE
[Reco] Removed unnecessary include statements

### DIFF
--- a/CondFormats/HGCalObjects/interface/HeterogeneousHGCalHEFCellPositionsConditions.h
+++ b/CondFormats/HGCalObjects/interface/HeterogeneousHGCalHEFCellPositionsConditions.h
@@ -10,7 +10,6 @@
 #include "CUDADataFormats/HGCal/interface/HGCConditions.h"
 #include "Geometry/HGCalCommonData/interface/HGCalDDDConstants.h"
 #include "Geometry/HGCalCommonData/interface/HGCalParameters.h"
-#include "RecoLocalCalo/HGCalRecProducers/plugins/KernelManagerHGCalCellPositions.h"
 
 namespace cpar = hgcal_conditions::parameters;
 namespace cpos = hgcal_conditions::positions;

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HeterogeneousHGCalHEFCellPositionsConditions.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HeterogeneousHGCalHEFCellPositionsConditions.cc
@@ -1,4 +1,4 @@
-#include "RecoLocalCalo/HGCalRecProducers/plugins/KernelManagerHGCalCellPositions.h"
+#include "KernelManagerHGCalCellPositions.h"
 #include "CondFormats/HGCalObjects/interface/HeterogeneousHGCalHEFCellPositionsConditions.h"
 
 HeterogeneousHGCalHEFCellPositionsConditions::HeterogeneousHGCalHEFCellPositionsConditions(

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HeterogeneousHGCalHEFCellPositionsConditions.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HeterogeneousHGCalHEFCellPositionsConditions.cc
@@ -1,3 +1,4 @@
+#include "RecoLocalCalo/HGCalRecProducers/plugins/KernelManagerHGCalCellPositions.h"
 #include "CondFormats/HGCalObjects/interface/HeterogeneousHGCalHEFCellPositionsConditions.h"
 
 HeterogeneousHGCalHEFCellPositionsConditions::HeterogeneousHGCalHEFCellPositionsConditions(


### PR DESCRIPTION
This should fix the following private header usage issue #34718 for
```
   1 src/RecoLocalCalo/HGCalRecProducers/plugins/KernelManagerHGCalCellPositions.h
```