### PR TITLE
Add missing include in CondDBTools.cc

### DIFF
--- a/CondCore/Utilities/src/CondDBTools.cc
+++ b/CondCore/Utilities/src/CondDBTools.cc
@@ -3,6 +3,7 @@
 #include "CondCore/CondDB/interface/ConnectionPool.h"
 //
 #include <memory>
+#include <set>
 
 namespace cond {
 


### PR DESCRIPTION
#### PR description:

Build log: https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc900/CMSSW_12_1_X_2021-08-13-1100/CondCore/Utilities

Error message:
```
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/6832eed357397f6b862ceadce6a298f6/opt/cmssw/slc7_amd64_gcc900/cms/cmssw-patch/CMSSW_12_1_X_2021-08-13-1100/src/CondCore/Utilities/src/CondDBTools.cc: In function 'size_t cond::persistency::importIovs(const string&, cond::persistency::Session&, const string&, cond::persistency::Session&, cond::Time_t, cond::Time_t, const string&, const string&, bool, bool, bool)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/6832eed357397f6b862ceadce6a298f6/opt/cmssw/slc7_amd64_gcc900/cms/cmssw-patch/CMSSW_12_1_X_2021-08-13-1100/src/CondCore/Utilities/src/CondDBTools.cc:97:12: error: 'set' is not a member of 'std'
    97 |       std::set<cond::Hash> pids;
      |            ^~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/6832eed357397f6b862ceadce6a298f6/opt/cmssw/slc7_amd64_gcc900/cms/cmssw-patch/CMSSW_12_1_X_2021-08-13-1100/src/CondCore/Utilities/src/CondDBTools.cc:4:1: note: 'std::set' is defined in header '<set>'; did you forget to '#include <set>'?
    3 | #include "CondCore/CondDB/interface/ConnectionPool.h"
  +++ |+#include <set>
    4 | //
```

Only affects CMSSW_12_1_X for some reason