### PR TITLE
[Validation] Removed unnecessary include statements

### DIFF
--- a/Validation/RecoMuon/plugins/MuonTrackValidator.cc
+++ b/Validation/RecoMuon/plugins/MuonTrackValidator.cc
@@ -11,8 +11,6 @@
 #include "SimTracker/Records/interface/TrackAssociatorRecord.h"
 #include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
 #include "TrackingTools/PatternTools/interface/TSCBLBuilderNoMaterial.h"
-#include "SimTracker/TrackAssociation/plugins/ParametersDefinerForTPESProducer.h"
-#include "SimTracker/TrackAssociation/plugins/CosmicParametersDefinerForTPESProducer.h"
 #include "SimTracker/TrackAssociation/interface/TrackingParticleIP.h"
 
 #include "TMath.h"

--- a/Validation/RecoTrack/plugins/MultiTrackValidator.cc
+++ b/Validation/RecoTrack/plugins/MultiTrackValidator.cc
@@ -20,8 +20,6 @@
 #include "SimDataFormats/EncodedEventId/interface/EncodedEventId.h"
 #include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
 #include "TrackingTools/PatternTools/interface/TSCBLBuilderNoMaterial.h"
-#include "SimTracker/TrackAssociation/plugins/ParametersDefinerForTPESProducer.h"
-#include "SimTracker/TrackAssociation/plugins/CosmicParametersDefinerForTPESProducer.h"
 #include "SimTracker/TrackAssociation/interface/TrackingParticleIP.h"
 
 #include "DataFormats/TrackReco/interface/DeDxData.h"

--- a/Validation/RecoTrack/plugins/MultiTrackValidatorGenPs.cc
+++ b/Validation/RecoTrack/plugins/MultiTrackValidatorGenPs.cc
@@ -17,8 +17,6 @@
 #include "SimDataFormats/EncodedEventId/interface/EncodedEventId.h"
 #include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
 #include "TrackingTools/PatternTools/interface/TSCBLBuilderNoMaterial.h"
-#include "SimTracker/TrackAssociation/plugins/ParametersDefinerForTPESProducer.h"
-#include "SimTracker/TrackAssociation/plugins/CosmicParametersDefinerForTPESProducer.h"
 
 #include "DataFormats/TrackReco/interface/DeDxData.h"
 #include "DataFormats/Common/interface/ValueMap.h"

--- a/Validation/SiTrackerPhase2V/plugins/Phase2TrackerValidateDigi.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2TrackerValidateDigi.cc
@@ -38,11 +38,12 @@
 
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 #include "SimDataFormats/TrackerDigiSimLink/interface/PixelDigiSimLink.h"
-#include "SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerFwd.h"
 
 // DQM Histograming
 #include "DQMServices/Core/interface/MonitorElement.h"
 #include "DQM/SiTrackerPhase2/interface/TrackerPhase2DQMUtil.h"
+
+using Phase2TrackerGeomDetUnit = PixelGeomDetUnit;
 
 //
 // constructors


### PR DESCRIPTION
This should fix the following private header usage issue #34718 for
```
      1 src/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerFwd.h
      3 src/SimTracker/TrackAssociation/plugins/CosmicParametersDefinerForTPESProducer.h
      4 src/SimTracker/TrackAssociation/plugins/ParametersDefinerForTPESProducer.h
```