### PR TITLE
[12.0.X] Miscellaneous fixes to  `Alignment/OflineValidation` all-in-one tool 

### DIFF
--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/offlineValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/offlineValidationTemplates.py
@@ -33,13 +33,13 @@ compressionSettings = 207
  ## Load and Configure OfflineValidation and Output File
  ##
 process.load("Alignment.OfflineValidation.TrackerOfflineValidation_.oO[offlineValidationMode]Oo._cff")
-process.TrackerOfflineValidation.oO[offlineValidationMode]Oo..compressionSettings = compressionSettings,
+process.TrackerOfflineValidation.oO[offlineValidationMode]Oo..compressionSettings = compressionSettings
 process.TrackerOfflineValidation.oO[offlineValidationMode]Oo..Tracks = 'FinalTrackRefitter'
 process.TrackerOfflineValidation.oO[offlineValidationMode]Oo..trajectoryInput = 'FinalTrackRefitter'
 process.TrackerOfflineValidation.oO[offlineValidationMode]Oo..moduleLevelHistsTransient = .oO[offlineModuleLevelHistsTransient]Oo.
 process.TrackerOfflineValidation.oO[offlineValidationMode]Oo..moduleLevelProfiles = .oO[offlineModuleLevelProfiles]Oo.
 process.TrackerOfflineValidation.oO[offlineValidationMode]Oo..stripYResiduals = .oO[stripYResiduals]Oo.
-process.TrackerOfflineValidation.oO[offlineValidationMode]Oo..maxTracks = .oO[maxtracks]Oo./ .oO[parallelJobs]Oo.
+process.TrackerOfflineValidation.oO[offlineValidationMode]Oo..maxTracks = int(.oO[maxtracks]Oo./.oO[parallelJobs]Oo.)
 process.TrackerOfflineValidation.oO[offlineValidationMode]Oo..chargeCut = .oO[chargeCut]Oo.
 """
 

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexResolutionTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexResolutionTemplates.py
@@ -9,7 +9,7 @@ runboundary = .oO[runboundary]Oo.
 isMultipleRuns=False
 if(isinstance(runboundary, (list, tuple))):
      isMultipleRuns=True
-     print "Multiple Runs are selected"
+     print("Multiple Runs are selected")
 
 if(isMultipleRuns):
      process.source.firstRun = cms.untracked.uint32(int(runboundary[0]))

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/zMuMuValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/zMuMuValidationTemplates.py
@@ -1,7 +1,6 @@
 ZMuMuValidationTemplate="""
-
+compressionSettings = 207
 ###### MuSclFit SETTINGS  ##############################################
-
 
 ### MuScleFit specific configuration
 

--- a/Alignment/OfflineValidation/test/test_all.sh
+++ b/Alignment/OfflineValidation/test/test_all.sh
@@ -158,6 +158,16 @@ validateAlignments.py -c validation_config.ini -N testingAllInOneTool --dryRun |
 
 printf "\n\n"
 
+echo " TESTING all-in-one tool configuration ..."
+FILES="$PWD/testingAllInOneTool/*_cfg.py"
+for f in $FILES
+do
+  echo "Processing $f file..."
+  python3 $FILE/$f  || die "Failure compiling test configuration" $?
+done
+
+printf "\n\n"
+
 echo " TESTING Primary Vertex Validation run-by-run submission ..."
 submitPVValidationJobs.py -j UNIT_TEST -D /HLTPhysics/Run2016C-TkAlMinBias-07Dec2018-v1/ALCARECO -i ${LOCAL_TEST_DIR}/testPVValidation_Relvals_DATA.ini -r --unitTest || die "Failure running PV Validation run-by-run submission" $?
 


### PR DESCRIPTION
backport of #34876 

#### PR description:

The goal of this PR is to fix some miscelleanous mistakes in the all-in-one template configurations introduced since the last alignment campaigns (commit 10f0cad).
I profit of the PR to enhance the unit test to check at compilation time the soundness of the python configuration produced by the test themselves (commit 7916c58 ). 

#### PR validation:

Run the `Alignment/OfflineValidation` unit tests via `scram b runtests`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

backport of  #34876 