### PR TITLE
Buildfile cleanup: remove non-existing module.cc file

### DIFF
--- a/SimG4CMS/ShowerLibraryProducer/plugins/BuildFile.xml
+++ b/SimG4CMS/ShowerLibraryProducer/plugins/BuildFile.xml
@@ -10,4 +10,4 @@
 <use name="SimG4Core/SensitiveDetector"/>
 <flags EDM_PLUGIN="1"/>
 <library name="SimG4CMSHcalForwardLibWriter" file="HcalForwardLibWriter.cc"></library>
-<library name="SimG4CMSShowerLibraryProducerPlugins" file="HFWedgeSensitiveDetectorBuilder.cc,FiberSensitiveDetectorBuilder.cc,HFChamberSensitiveDetectorBuilder.cc,module.cc"></library>
+<library name="SimG4CMSShowerLibraryProducerPlugins" file="HFWedgeSensitiveDetectorBuilder.cc,FiberSensitiveDetectorBuilder.cc,HFChamberSensitiveDetectorBuilder.cc"></library>


### PR DESCRIPTION
https://github.com/cms-sw/cmssw/pull/34819 removed the `module.cc` file without removing its ref in the BuildFile.