### PR TITLE
Common digi packing for CPU and GPU implementations

### DIFF
--- a/DataFormats/SiPixelDetId/README.md
+++ b/DataFormats/SiPixelDetId/README.md
@@ -1,11 +1,18 @@
-2016.05.11 ATricomi+EMigliore (INFN) changes in PixelChannelIdentifier.cc 
-Change PixelChannelIdentifier::thePacking() to have indexes spanning the full module in case of small pixels (phase II InnerPixel)
+Changes - timeline
+##### 2016.05.11 ATricomi+EMigliore (INFN) changes in PixelChannelIdentifier.cc 
+- Change PixelChannelIdentifier::thePacking() to have indexes spanning the full module in case of small pixels (phase II InnerPixel)
 
-PixelChannelIdentifier::thePacking( 11, 11, 0, 10); // It was row=8,col=9, time=4, adc=11
+##### 2021.08.16. Reserve one bit for the flag in pixel digi packing - see PRs #34509 and #34662
+- Change packing from (11, **11**, **0**, 10) -> (11, **10**, **1**, 10), reducing row x column to 2048x1024; and time -> flag
 
-Reserved bits
-row = 11 -> 2^11-1 = 2047
-col = 11 -> 2^11-1 = 2047
-time = 0 (not used)
-adc = 10 -> 2^10-1 = 1023
+---
 
+#### PixelChannelIdentifier::thePacking( 11, 10, 1, 10); // row, column, flag, adc
+// Before phase II changes, it was row=8,col=9, time=4, adc=11  
+// Before introducing the flag, it was row=11, col=11, time=0, adc=10
+
+#### Reserved bits:
+- row = 11 -> 2^11-1 = 2047
+- col = 10 -> 2^10-1 = 1023
+- flag = 1 -> 0/1
+- adc = 10 -> 2^10-1 = 1023

--- a/DataFormats/SiPixelDetId/interface/PixelChannelIdentifier.h
+++ b/DataFormats/SiPixelDetId/interface/PixelChannelIdentifier.h
@@ -2,6 +2,7 @@
 #define DATAFORMATS_PIXELCHANMNELIDENTIFIER_H
 
 #include <utility>
+#include <cstdint>
 
 namespace pixelchanelidentifierimpl {
   /**
@@ -10,7 +11,7 @@ namespace pixelchanelidentifierimpl {
 
   class Packing {
   public:
-    using PackedDigiType = unsigned int;
+    using PackedDigiType = uint32_t;
 
     // Constructor: pre-computes masks and shifts from field widths
     constexpr Packing(unsigned int row_w, unsigned int column_w, unsigned int flag_w, unsigned int adc_w)
@@ -30,14 +31,14 @@ namespace pixelchanelidentifierimpl {
           max_column(column_mask),
           max_adc(adc_mask) {}
 
-    const int row_width;
-    const int column_width;
-    const int adc_width;
+    const uint32_t row_width;
+    const uint32_t column_width;
+    const uint32_t adc_width;
 
-    const int row_shift;
-    const int column_shift;
-    const int flag_shift;
-    const int adc_shift;
+    const uint32_t row_shift;
+    const uint32_t column_shift;
+    const uint32_t flag_shift;
+    const uint32_t adc_shift;
 
     const PackedDigiType row_mask;
     const PackedDigiType column_mask;

--- a/DataFormats/SiPixelDetId/interface/PixelChannelIdentifier.h
+++ b/DataFormats/SiPixelDetId/interface/PixelChannelIdentifier.h
@@ -1,10 +1,10 @@
-#ifndef DATAFORMATS_PIXELCHANMNELIDENTIFIER_H
-#define DATAFORMATS_PIXELCHANMNELIDENTIFIER_H
+#ifndef DataFormats_SiPixelDetId_interface_PixelChannelIdentifier_h
+#define DataFormats_SiPixelDetId_interface_PixelChannelIdentifier_h
 
 #include <utility>
 #include <cstdint>
 
-namespace pixelchanelidentifierimpl {
+namespace pixelchannelidentifierimpl {
   /**
    * Pack the pixel information to use less memory
    */
@@ -50,7 +50,7 @@ namespace pixelchanelidentifierimpl {
     const int max_column;
     const int max_adc;
   };
-}  // namespace pixelchanelidentifierimpl
+}  // namespace pixelchannelidentifierimpl
 
 class PixelChannelIdentifier {
 public:
@@ -65,7 +65,7 @@ public:
 
   static int pixelToChannel(int row, int col) { return (row << thePacking.column_width) | col; }
 
-  using Packing = pixelchanelidentifierimpl::Packing;
+  using Packing = pixelchannelidentifierimpl::Packing;
 
 public:
   constexpr static Packing packing() { return Packing(8, 9, 4, 11); }
@@ -73,4 +73,4 @@ public:
   constexpr static Packing thePacking = {11, 10, 1, 10};
 };
 
-#endif
+#endif  // DataFormats_SiPixelDetId_interface_PixelChannelIdentifier_h

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.h
@@ -57,13 +57,11 @@ namespace pixelgpudetails {
     uint32_t col;
   };
 
-  __host__ __device__ inline constexpr pixelchanelidentifierimpl::Packing packing() {
-    return pixelchanelidentifierimpl::Packing(11, 10, 1, 10);
-  }
+  inline constexpr pixelchanelidentifierimpl::Packing packing() { return PixelChannelIdentifier::thePacking; }
 
-  __host__ __device__ inline uint32_t pack(uint32_t row, uint32_t col, uint32_t adc, uint32_t flag = 0) {
+  inline constexpr uint32_t pack(uint32_t row, uint32_t col, uint32_t adc, uint32_t flag = 0) {
     constexpr pixelchanelidentifierimpl::Packing thePacking = packing();
-    adc = std::min(adc, thePacking.max_adc);
+    adc = std::min(adc, uint32_t(thePacking.max_adc));
 
     return (row << thePacking.row_shift) | (col << thePacking.column_shift) | (adc << thePacking.adc_shift);
   }

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.h
@@ -57,17 +57,17 @@ namespace pixelgpudetails {
     uint32_t col;
   };
 
-  inline constexpr pixelchanelidentifierimpl::Packing packing() { return PixelChannelIdentifier::thePacking; }
+  inline constexpr pixelchannelidentifierimpl::Packing packing() { return PixelChannelIdentifier::thePacking; }
 
   inline constexpr uint32_t pack(uint32_t row, uint32_t col, uint32_t adc, uint32_t flag = 0) {
-    constexpr pixelchanelidentifierimpl::Packing thePacking = packing();
+    constexpr pixelchannelidentifierimpl::Packing thePacking = packing();
     adc = std::min(adc, uint32_t(thePacking.max_adc));
 
     return (row << thePacking.row_shift) | (col << thePacking.column_shift) | (adc << thePacking.adc_shift);
   }
 
   constexpr uint32_t pixelToChannel(int row, int col) {
-    constexpr pixelchanelidentifierimpl::Packing thePacking = packing();
+    constexpr pixelchannelidentifierimpl::Packing thePacking = packing();
     return (row << thePacking.column_width) | col;
   }
 


### PR DESCRIPTION
#### PR description:

Follow up to PRs #34509 and #34662.
1. Update documentation of SiPixelDetId
2. Propose merging of CPU and GPU SiPixelDigi packing

If I understood correctly, the GPU implementation doesn't use the packing only to transfer it back to the CPU for validation or other purposes. If so, it makes even more sense to merge the two packing classes.

#### PR validation:

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
