### PR TITLE
migrate `AlignmentProducer` to event consumes

### DIFF
--- a/Alignment/CommonAlignmentProducer/plugins/AlignmentProducer.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/AlignmentProducer.cc
@@ -15,6 +15,13 @@ AlignmentProducer::AlignmentProducer(const edm::ParameterSet &config)
       maxLoops_{config.getUntrackedParameter<unsigned int>("maxLoops")} {
   edm::LogInfo("Alignment") << "@SUB=AlignmentProducer::AlignmentProducer";
 
+  // do now all the consumes
+  trajTrackAssociationCollectionToken_ = consumes<TrajTrackAssociationCollection>(tjTkAssociationMapTag_);
+  bsToken_ = consumes<reco::BeamSpot>(beamSpotTag_);
+  tkFittedLasBeamCollectionToken_ = consumes<TkFittedLasBeamCollection>(tkLasBeamTag_);
+  tsosVectorCollectionToken_ = consumes<TsosVectorCollection>(tkLasBeamTag_);
+  aliClusterValueMapToken_ = consumes<AliClusterValueMap>(clusterValueMapTag_);
+
   // Tell the framework what data is being produced
   if (doTracker_) {
     setWhatProduced(this, &AlignmentProducer::produceTracker);

--- a/Alignment/CommonAlignmentProducer/plugins/AlignmentProducer.h
+++ b/Alignment/CommonAlignmentProducer/plugins/AlignmentProducer.h
@@ -58,33 +58,39 @@ private:
   bool getAliClusterValueMap(const edm::Event&, edm::Handle<AliClusterValueMap>&) override;
 
   const unsigned int maxLoops_;  /// Number of loops to loop
+
+  edm::EDGetTokenT<TrajTrackAssociationCollection> trajTrackAssociationCollectionToken_;
+  edm::EDGetTokenT<reco::BeamSpot> bsToken_;
+  edm::EDGetTokenT<TkFittedLasBeamCollection> tkFittedLasBeamCollectionToken_;
+  edm::EDGetTokenT<TsosVectorCollection> tsosVectorCollectionToken_;
+  edm::EDGetTokenT<AliClusterValueMap> aliClusterValueMapToken_;
 };
 
 //------------------------------------------------------------------------------
 inline bool AlignmentProducer::getTrajTrackAssociationCollection(const edm::Event& event,
                                                                  edm::Handle<TrajTrackAssociationCollection>& result) {
-  return event.getByLabel(tjTkAssociationMapTag_, result);
+  return event.getByToken(trajTrackAssociationCollectionToken_, result);
 }
 
 //------------------------------------------------------------------------------
 inline bool AlignmentProducer::getBeamSpot(const edm::Event& event, edm::Handle<reco::BeamSpot>& result) {
-  return event.getByLabel(beamSpotTag_, result);
+  return event.getByToken(bsToken_, result);
 }
 
 //------------------------------------------------------------------------------
 inline bool AlignmentProducer::getTkFittedLasBeamCollection(const edm::Run& run,
                                                             edm::Handle<TkFittedLasBeamCollection>& result) {
-  return run.getByLabel(tkLasBeamTag_, result);
+  return run.getByToken(tkFittedLasBeamCollectionToken_, result);
 }
 
 //------------------------------------------------------------------------------
 inline bool AlignmentProducer::getTsosVectorCollection(const edm::Run& run, edm::Handle<TsosVectorCollection>& result) {
-  return run.getByLabel(tkLasBeamTag_, result);
+  return run.getByToken(tsosVectorCollectionToken_, result);
 }
 
 //------------------------------------------------------------------------------
 inline bool AlignmentProducer::getAliClusterValueMap(const edm::Event& event, edm::Handle<AliClusterValueMap>& result) {
-  return event.getByLabel(clusterValueMapTag_, result);
+  return event.getByToken(aliClusterValueMapToken_, result);
 }
 
 #endif


### PR DESCRIPTION
#### PR description:

Title says it all, migrate `AlignmentProducer` to event consumes, as it is already done for `AlignmentProducerAsAnalyzer.cc`

https://github.com/cms-sw/cmssw/blob/bd636b971df1a282d7b54759fb83e91d336590ac/Alignment/CommonAlignmentProducer/plugins/AlignmentProducerAsAnalyzer.cc#L21-L25

#### PR validation:

Run unit tests `scram b runtests` also using `Alignment/TrackerAlignment` package. 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Will need to be backported to support HipPy alignment algorithm.
