### PR TITLE
BuildFile: use py3-sqlalchemy

### DIFF
--- a/CondTools/RunInfo/test/BuildFile.xml
+++ b/CondTools/RunInfo/test/BuildFile.xml
@@ -1,6 +1,6 @@
 <use name="CondTools/RunInfo"/>
 <architecture name="(slc|cc).*_amd64_.*">
-  <use name="py2-sqlalchemy"/>
+  <use name="py3-sqlalchemy"/>
   <test name="RunInfoStart_O2O_test" command="RunInfoStart_O2O_test.sh"/>
 </architecture>
 <test name="CondToolsRunInfoTest" command="test_runinfo.sh"/>


### PR DESCRIPTION
Due to python3 migration, the sqlalchemy tool is now called py3-sqlalchemy. this should avoid the SCRAM warning
```
****WARNING: Invalid tool py2-sqlalchemy. Please fix src/CondTools/RunInfo/test/BuildFile.xml file.
```