### PR TITLE
Run G4 workers on their own dedicated threads

### DIFF
--- a/SimG4Core/Application/interface/RunManagerMTWorker.h
+++ b/SimG4Core/Application/interface/RunManagerMTWorker.h
@@ -86,7 +86,8 @@ private:
 
   void DumpMagneticField(const G4Field*, const std::string&) const;
 
-  static void resetTLS();
+  void resetTLS();
+  int getThreadIndex() const { return m_thread_index; }
 
   Generator m_generator;
   edm::EDGetTokenT<edm::HepMCProduct> m_InToken;
@@ -111,12 +112,14 @@ private:
   edm::ParameterSet m_p;
 
   struct TLSData;
-  static thread_local TLSData* m_tls;
-  static thread_local bool dumpMF;
+  TLSData* m_tls{nullptr};
+  bool dumpMF{false};
 
   G4SimEvent* m_simEvent;
   std::unique_ptr<CMSSteppingVerbose> m_sVerbose;
   std::unordered_map<std::string, std::unique_ptr<SensitiveDetectorMakerBase>> m_sdMakers;
+
+  const int m_thread_index{-1};
 };
 
 #endif

--- a/SimG4Core/Application/interface/ThreadHandoff.h
+++ b/SimG4Core/Application/interface/ThreadHandoff.h
@@ -1,0 +1,99 @@
+#ifndef SimG4Core_Application_ThreadHandoff_h
+#define SimG4Core_Application_ThreadHandoff_h
+// -*- C++ -*-
+//
+// Package:     SimG4Core/Application
+// Class  :     ThreadHandoff
+//
+/**\class ThreadHandoff ThreadHandoff.h "SimG4Core/Application/interface/ThreadHandoff.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Mon, 16 Aug 2021 13:51:53 GMT
+//
+
+// system include files
+#include <condition_variable>
+#include <cstring> //strerror_r
+#include <exception>
+#include <mutex>
+#include <pthread.h>
+
+// user include files
+
+// forward declarations
+
+namespace omt {
+class ThreadHandoff {
+public:
+  explicit ThreadHandoff();
+  ~ThreadHandoff();
+
+  ThreadHandoff(const ThreadHandoff&) = delete;                   // stop default
+  const ThreadHandoff& operator=(const ThreadHandoff&) = delete;  // stop default
+
+  template<typename F>
+    void runAndWait(F&& iF) {
+    Functor<F> f{std::move(iF)};
+    
+    std::unique_lock<std::mutex> lck(m_mutex);
+    m_loopReady = false;
+    m_toRun = &f;
+    
+    m_threadHandoff.notify_one();
+    
+    m_threadHandoff.wait(lck, [this]() {
+        return m_loopReady;
+      });
+    auto e = f.exception();
+    if(e) { std::rethrow_exception(e); }
+  }
+
+  void stopThread() {
+    runAndWait([this]() { m_stopThread =true;});
+  }
+
+private:
+    class FunctorBase {
+  public:
+    virtual ~FunctorBase() {}
+    virtual void execute() = 0;
+  };
+  template <typename F>
+    class Functor : public FunctorBase {
+  public:
+    explicit Functor(F&& iF): m_f(std::move(iF)) {}
+    void execute() final {
+      try {
+        m_f();
+      }catch(...) {
+        m_except = std::current_exception();
+      }
+    }
+    std::exception_ptr exception() { return m_except;}
+  private:
+    F m_f;
+    std::exception_ptr m_except;
+  };
+
+
+  static void* threadLoop(void* iArgs);
+
+  // ---------- member data --------------------------------
+  pthread_t m_thread;
+  std::mutex m_mutex;
+  std::condition_variable m_threadHandoff;
+
+  FunctorBase* m_toRun{nullptr};
+  bool m_loopReady{false};
+  bool m_stopThread{false};
+
+};
+}
+#endif

--- a/SimG4Core/Application/interface/ThreadHandoff.h
+++ b/SimG4Core/Application/interface/ThreadHandoff.h
@@ -32,7 +32,7 @@
 namespace omt {
   class ThreadHandoff {
   public:
-    explicit ThreadHandoff();
+    explicit ThreadHandoff(int stackSize);
     ~ThreadHandoff();
 
     ThreadHandoff(const ThreadHandoff&) = delete;                   // stop default

--- a/SimG4Core/Application/interface/ThreadHandoff.h
+++ b/SimG4Core/Application/interface/ThreadHandoff.h
@@ -20,7 +20,7 @@
 
 // system include files
 #include <condition_variable>
-#include <cstring> //strerror_r
+#include <cstring>  //strerror_r
 #include <exception>
 #include <mutex>
 #include <pthread.h>
@@ -30,70 +30,69 @@
 // forward declarations
 
 namespace omt {
-class ThreadHandoff {
-public:
-  explicit ThreadHandoff();
-  ~ThreadHandoff();
+  class ThreadHandoff {
+  public:
+    explicit ThreadHandoff();
+    ~ThreadHandoff();
 
-  ThreadHandoff(const ThreadHandoff&) = delete;                   // stop default
-  const ThreadHandoff& operator=(const ThreadHandoff&) = delete;  // stop default
+    ThreadHandoff(const ThreadHandoff&) = delete;                   // stop default
+    const ThreadHandoff& operator=(const ThreadHandoff&) = delete;  // stop default
 
-  template<typename F>
+    template <typename F>
     void runAndWait(F&& iF) {
-    Functor<F> f{std::move(iF)};
-    
-    std::unique_lock<std::mutex> lck(m_mutex);
-    m_loopReady = false;
-    m_toRun = &f;
-    
-    m_threadHandoff.notify_one();
-    
-    m_threadHandoff.wait(lck, [this]() {
-        return m_loopReady;
-      });
-    auto e = f.exception();
-    if(e) { std::rethrow_exception(e); }
-  }
+      Functor<F> f{std::move(iF)};
 
-  void stopThread() {
-    runAndWait([this]() { m_stopThread =true;});
-  }
+      std::unique_lock<std::mutex> lck(m_mutex);
+      m_loopReady = false;
+      m_toRun = &f;
 
-private:
-    class FunctorBase {
-  public:
-    virtual ~FunctorBase() {}
-    virtual void execute() = 0;
-  };
-  template <typename F>
-    class Functor : public FunctorBase {
-  public:
-    explicit Functor(F&& iF): m_f(std::move(iF)) {}
-    void execute() final {
-      try {
-        m_f();
-      }catch(...) {
-        m_except = std::current_exception();
+      m_threadHandoff.notify_one();
+
+      m_threadHandoff.wait(lck, [this]() { return m_loopReady; });
+      auto e = f.exception();
+      if (e) {
+        std::rethrow_exception(e);
       }
     }
-    std::exception_ptr exception() { return m_except;}
+
+    void stopThread() {
+      runAndWait([this]() { m_stopThread = true; });
+    }
+
   private:
-    F m_f;
-    std::exception_ptr m_except;
+    class FunctorBase {
+    public:
+      virtual ~FunctorBase() {}
+      virtual void execute() = 0;
+    };
+    template <typename F>
+    class Functor : public FunctorBase {
+    public:
+      explicit Functor(F&& iF) : m_f(std::move(iF)) {}
+      void execute() final {
+        try {
+          m_f();
+        } catch (...) {
+          m_except = std::current_exception();
+        }
+      }
+      std::exception_ptr exception() { return m_except; }
+
+    private:
+      F m_f;
+      std::exception_ptr m_except;
+    };
+
+    static void* threadLoop(void* iArgs);
+
+    // ---------- member data --------------------------------
+    pthread_t m_thread;
+    std::mutex m_mutex;
+    std::condition_variable m_threadHandoff;
+
+    FunctorBase* m_toRun{nullptr};
+    bool m_loopReady{false};
+    bool m_stopThread{false};
   };
-
-
-  static void* threadLoop(void* iArgs);
-
-  // ---------- member data --------------------------------
-  pthread_t m_thread;
-  std::mutex m_mutex;
-  std::condition_variable m_threadHandoff;
-
-  FunctorBase* m_toRun{nullptr};
-  bool m_loopReady{false};
-  bool m_stopThread{false};
-
-};
-}
+}  // namespace omt
 #endif

--- a/SimG4Core/Application/plugins/OscarMTProducer.cc
+++ b/SimG4Core/Application/plugins/OscarMTProducer.cc
@@ -97,7 +97,8 @@ namespace {
   };
 }  // namespace
 
-OscarMTProducer::OscarMTProducer(edm::ParameterSet const& p, const OscarMTMasterThread* ms) {
+OscarMTProducer::OscarMTProducer(edm::ParameterSet const& p, const OscarMTMasterThread* ms)
+    : m_handoff{p.getUntrackedParameter<int>("workerThreadStackSize", 10 * 1024 * 1024)} {
   // Random number generation not allowed here
   StaticRandomEngineSetUnset random(nullptr);
 

--- a/SimG4Core/Application/plugins/OscarMTProducer.cc
+++ b/SimG4Core/Application/plugins/OscarMTProducer.cc
@@ -103,9 +103,9 @@ OscarMTProducer::OscarMTProducer(edm::ParameterSet const& p, const OscarMTMaster
 
   auto token = edm::ServiceRegistry::instance().presentToken();
   m_handoff.runAndWait([this, &p, token]() {
-      edm::ServiceRegistry::Operate guard{token};
-      m_runManagerWorker = std::make_unique<RunManagerMTWorker>(p, consumesCollector());
-    });
+    edm::ServiceRegistry::Operate guard{token};
+    m_runManagerWorker = std::make_unique<RunManagerMTWorker>(p, consumesCollector());
+  });
   m_masterThread = ms;
   m_masterThread->callConsumes(consumesCollector());
 
@@ -175,8 +175,10 @@ OscarMTProducer::OscarMTProducer(edm::ParameterSet const& p, const OscarMTMaster
 
 OscarMTProducer::~OscarMTProducer() {
   auto token = edm::ServiceRegistry::instance().presentToken();
-  m_handoff.runAndWait([this, token]() {       edm::ServiceRegistry::Operate guard{token};
-      m_runManagerWorker.reset(); });
+  m_handoff.runAndWait([this, token]() {
+    edm::ServiceRegistry::Operate guard{token};
+    m_runManagerWorker.reset();
+  });
 }
 
 std::unique_ptr<OscarMTMasterThread> OscarMTProducer::initializeGlobalCache(const edm::ParameterSet& iConfig) {
@@ -212,10 +214,10 @@ void OscarMTProducer::beginRun(const edm::Run&, const edm::EventSetup& es) {
   edm::LogVerbatim("SimG4CoreApplication") << "OscarMTProducer::beginRun";
   auto token = edm::ServiceRegistry::instance().presentToken();
   m_handoff.runAndWait([this, &es, token]() {
-      edm::ServiceRegistry::Operate guard{token};
-      m_runManagerWorker->beginRun(es);
-      m_runManagerWorker->initializeG4(m_masterThread->runManagerMasterPtr(), es);
-    });
+    edm::ServiceRegistry::Operate guard{token};
+    m_runManagerWorker->beginRun(es);
+    m_runManagerWorker->initializeG4(m_masterThread->runManagerMasterPtr(), es);
+  });
   edm::LogVerbatim("SimG4CoreApplication") << "OscarMTProducer::beginRun done";
 }
 
@@ -225,8 +227,9 @@ void OscarMTProducer::endRun(const edm::Run&, const edm::EventSetup&) {
   edm::LogVerbatim("SimG4CoreApplication") << "OscarMTProducer::endRun";
   auto token = edm::ServiceRegistry::instance().presentToken();
   m_handoff.runAndWait([this, token]() {
-      edm::ServiceRegistry::Operate guard{token};
-      m_runManagerWorker->endRun();});
+    edm::ServiceRegistry::Operate guard{token};
+    m_runManagerWorker->endRun();
+  });
   edm::LogVerbatim("SimG4CoreApplication") << "OscarMTProducer::endRun done";
 }
 
@@ -243,8 +246,8 @@ void OscarMTProducer::produce(edm::Event& e, const edm::EventSetup& es) {
     auto token = edm::ServiceRegistry::instance().presentToken();
     m_handoff.runAndWait([this, &e, &es, &evt, token]() {
       edm::ServiceRegistry::Operate guard{token};
-        evt = m_runManagerWorker->produce(e, es, globalCache()->runManagerMaster());
-      });
+      evt = m_runManagerWorker->produce(e, es, globalCache()->runManagerMaster());
+    });
   } catch (const SimG4Exception& simg4ex) {
     edm::LogWarning("SimG4CoreApplication") << "SimG4Exception caght! " << simg4ex.what();
 

--- a/SimG4Core/Application/src/ThreadHandoff.cc
+++ b/SimG4Core/Application/src/ThreadHandoff.cc
@@ -37,14 +37,13 @@ namespace {
 //
 using namespace omt;
 
-ThreadHandoff::ThreadHandoff() {
+ThreadHandoff::ThreadHandoff(int stackSize) {
   pthread_attr_t attr;
   int erno;
   if (0 != (erno = pthread_attr_init(&attr))) {
     throw cms::Exception("ThreadInitFailed")
         << "Failed to initialize thread attributes (" << erno << ") " << errorMessage(erno);
   }
-  const int stackSize = 10 * 1024 * 1024;
 
   if (0 != (erno = pthread_attr_setstacksize(&attr, stackSize))) {
     throw cms::Exception("ThreadStackSizeFailed")

--- a/SimG4Core/Application/src/ThreadHandoff.cc
+++ b/SimG4Core/Application/src/ThreadHandoff.cc
@@ -1,0 +1,119 @@
+// -*- C++ -*-
+//
+// Package:     SimG4Core/Application
+// Class  :     ThreadHandoff
+//
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Christopher Jones
+//         Created:  Mon, 16 Aug 2021 14:37:29 GMT
+//
+
+// system include files
+
+// user include files
+#include "SimG4Core/Application/interface/ThreadHandoff.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+//
+// constants, enums and typedefs
+//
+
+namespace {
+  std::string errorMessage(int erno) {
+      std::array<char, 1024> buffer;
+      strerror_r(erno, &buffer[0], buffer.size());
+      buffer.back() = '\0';
+      return std::string(&buffer[0]);
+  }
+}
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+using namespace omt;
+
+ThreadHandoff::ThreadHandoff() {
+    pthread_attr_t attr;
+    int erno;
+    if( 0 != (erno = pthread_attr_init(&attr)) ) {
+      throw cms::Exception("ThreadInitFailed") <<"Failed to initialize thread attributes ("
+                                               <<erno<<") "<<errorMessage(erno);
+    }
+    const int stackSize = 10*1024*1024;
+    
+    if( 0 != (erno = pthread_attr_setstacksize(&attr, stackSize) ) ){
+      throw cms::Exception("ThreadStackSizeFailed")<<"Failed to set stack size "<<stackSize<<" "<<errorMessage(erno);
+    }
+    std::unique_lock<std::mutex> lk(m_mutex);
+
+    erno  = pthread_create(&m_thread, &attr,
+                           threadLoop, this);
+    if( 0 != erno) {
+      throw cms::Exception("ThreadCreateFailed")<<" failed to create a pthread ("
+                                                <<erno<<") "
+                                                << errorMessage(erno);
+    }
+    m_loopReady=false;
+    m_threadHandoff.wait(lk, [this]() { return m_loopReady;} );
+}
+
+// ThreadHandoff::ThreadHandoff(const ThreadHandoff& rhs)
+// {
+//    // do actual copying here;
+// }
+
+ThreadHandoff::~ThreadHandoff() {
+  if(not m_stopThread) {
+    stopThread();
+  }
+  void* ret;
+  pthread_join(m_thread, &ret);
+}
+
+//
+// assignment operators
+//
+// const ThreadHandoff& ThreadHandoff::operator=(const ThreadHandoff& rhs)
+// {
+//   //An exception safe implementation is
+//   ThreadHandoff temp(rhs);
+//   swap(rhs);
+//
+//   return *this;
+// }
+
+//
+// member functions
+//
+
+//
+// const member functions
+//
+
+//
+// static member functions
+//
+void* ThreadHandoff::threadLoop(void* iArgs) {
+  auto theThis = reinterpret_cast<ThreadHandoff*>(iArgs);
+  {
+    std::unique_lock<std::mutex> lck(theThis->m_mutex);
+    theThis->m_loopReady = true;
+  }
+  theThis->m_threadHandoff.notify_one();
+  
+  std::unique_lock<std::mutex> lck(theThis->m_mutex);
+  do {
+    theThis->m_toRun=nullptr;
+    theThis->m_threadHandoff.wait(lck, [theThis]() { return nullptr != theThis->m_toRun;});
+    theThis->m_toRun->execute();
+    theThis->m_loopReady=true;
+    theThis->m_threadHandoff.notify_one();
+  } while(not theThis->m_stopThread);
+  theThis->m_loopReady=true;
+  return nullptr;
+}

--- a/SimG4Core/Application/test/test_catch2_ThreadHandoff.cc
+++ b/SimG4Core/Application/test/test_catch2_ThreadHandoff.cc
@@ -5,13 +5,11 @@
 
 using namespace omt;
 TEST_CASE("Test omt::ThreadHandoff", "[ThreadHandoff]") {
-  SECTION("Do nothing") {
-    ThreadHandoff th;
-  }
+  SECTION("Do nothing") { ThreadHandoff th; }
   SECTION("Simple") {
     ThreadHandoff th;
     bool value = false;
-    th.runAndWait([&value]() { value = true;});
+    th.runAndWait([&value]() { value = true; });
     REQUIRE(value == true);
   }
 

--- a/SimG4Core/Application/test/test_catch2_ThreadHandoff.cc
+++ b/SimG4Core/Application/test/test_catch2_ThreadHandoff.cc
@@ -1,0 +1,22 @@
+#include "SimG4Core/Application/interface/ThreadHandoff.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+using namespace omt;
+TEST_CASE("Test omt::ThreadHandoff", "[ThreadHandoff]") {
+  SECTION("Do nothing") {
+    ThreadHandoff th;
+  }
+  SECTION("Simple") {
+    ThreadHandoff th;
+    bool value = false;
+    th.runAndWait([&value]() { value = true;});
+    REQUIRE(value == true);
+  }
+
+  SECTION("Exception") {
+    ThreadHandoff th;
+    REQUIRE_THROWS_AS(th.runAndWait([]() { throw cms::Exception("Test"); }), cms::Exception);
+  }
+}


### PR DESCRIPTION
#### PR description:

Each G4 worker now runs on its own thread. Each stream has its own thread and when the stream needs to do work it blocks the TBB thread and starts up its dedicated thread.

This should allow SimWatchers to be modified to call esConsumes.
#### PR validation:

Code compiles and a simple workflow runs.