### PR TITLE
[GCC10] Use constexpr which fixes gcc10/ASAN build error

### DIFF
--- a/Alignment/HIPAlignmentAlgorithm/plugins/LhcTrackAnalyzer.cc
+++ b/Alignment/HIPAlignmentAlgorithm/plugins/LhcTrackAnalyzer.cc
@@ -69,7 +69,7 @@ private:
   //=======================
   void SetVarToZero();
 
-  static const int nMaxtracks_ = 3000;
+  static constexpr int nMaxtracks_ = 3000;
   int nTracks_;
   int run_;
   int event_;


### PR DESCRIPTION
This should fix GCC10/ASAN IB build/link error
```
tmp/slc7_amd64_gcc10/src/Alignment/HIPAlignmentAlgorithm/plugins/HIPAlignmentAlgorithmPlugins/LhcTrackAnalyzer.cc.o: in function `LhcTrackAnalyzer::analyze(edm::Event const&, edm::EventSetup const&)':
  LhcTrackAnalyzer.cc:(.text+0x12e0): undefined reference to `LhcTrackAnalyzer::nMaxtracks_'
```