### PR TITLE
LowPtElectrons: convert Seed BDTs from XML to ROOT file format

### DIFF
--- a/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronSeeds_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronSeeds_cfi.py
@@ -22,8 +22,8 @@ lowPtGsfElectronSeeds = cms.EDProducer(
             'ptbiased',
             ]),
     ModelWeights = cms.vstring([
-            'RecoEgamma/ElectronIdentification/data/LowPtElectrons/RunII_Autumn18_LowPtElectrons_unbiased.xml.gz',
-            'RecoEgamma/ElectronIdentification/data/LowPtElectrons/RunII_Autumn18_LowPtElectrons_displaced_pt_eta_biased.xml.gz',
+            'RecoEgamma/ElectronIdentification/data/LowPtElectrons/RunII_Autumn18_LowPtElectrons_unbiased.root',
+            'RecoEgamma/ElectronIdentification/data/LowPtElectrons/RunII_Autumn18_LowPtElectrons_displaced_pt_eta_biased.root',
             ]),
     ModelThresholds = thresholds("T"),
     PassThrough = cms.bool(False),


### PR DESCRIPTION
#### PR description:

This PR converts the formats (from XML to ROOT) of two files containing the weights of two BDT models used by the low pT electron seeding step in the reconstruction chain. 

The effect is to reduce the file size by a factor two for both files, and to reduce the memory consumption and CPU time when parsing the weights files. 

This was done in response to the issues raised here: https://github.com/cms-sw/cmssw/issues/34707

A similar change was made previously, but on the weights file for the BDT model used by the low pT electron ID module (as opposed to the seeding step, as above), which solved the issues raised here: https://github.com/cms-sw/cmssw/issues/28780

This PR depends on https://github.com/cms-data/RecoEgamma-ElectronIdentification/pull/22 

#### PR validation:

Local tests were made with the wf 1304.182.  

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No back port required.
