### PR TITLE
Complete migration of TrackClassifier to esConsumes()

### DIFF
--- a/SimTracker/TrackHistory/interface/TrackClassifier.h
+++ b/SimTracker/TrackHistory/interface/TrackClassifier.h
@@ -74,6 +74,7 @@ private:
   edm::Handle<edm::HepMCProduct> mcInformation_;
 
   edm::ESHandle<ParticleDataTable> particleDataTable_;
+  edm::ESGetToken<ParticleDataTable, PDTRecord> particleDataTableToken_;
 
   edm::ESHandle<TransientTrackBuilder> transientTrackBuilder_;
   edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> transientTrackBuilderToken_;

--- a/SimTracker/TrackHistory/src/TrackClassifier.cc
+++ b/SimTracker/TrackHistory/src/TrackClassifier.cc
@@ -19,6 +19,7 @@ TrackClassifier::TrackClassifier(edm::ParameterSet const &config, edm::ConsumesC
       tracer_(config, std::move(collector)),
       quality_(config, collector),
       magneticFieldToken_(collector.esConsumes<MagneticField, IdealMagneticFieldRecord>()),
+      particleDataTableToken_(collector.esConsumes()),
       transientTrackBuilderToken_(collector.esConsumes<TransientTrackBuilder, TransientTrackRecord>()),
       tTopoHandToken_(collector.esConsumes<TrackerTopology, TrackerTopologyRcd>()) {
   collector.consumes<edm::HepMCProduct>(hepMCLabel_);
@@ -58,7 +59,7 @@ void TrackClassifier::newEvent(edm::Event const &event, edm::EventSetup const &s
   magneticField_ = setup.getHandle(magneticFieldToken_);
 
   // Get the partivle data table
-  setup.getData(particleDataTable_);
+  particleDataTable_ = setup.getHandle(particleDataTableToken_);
 
   // get the beam spot
   event.getByLabel(beamSpotLabel_, beamSpot_);


### PR DESCRIPTION
#### PR description:

Part of #31061. This is the last call deprecated `EventSetupRecord::get()` from `BDHadronTrackMonitoringAnalyzer`.

#### PR validation:

Code compiles.