### PR TITLE
Created setupSiteLocalConfig

### DIFF
--- a/FWCore/Services/bin/cmsGetFnConnect.cc
+++ b/FWCore/Services/bin/cmsGetFnConnect.cc
@@ -13,8 +13,7 @@
 #include "FWCore/Catalog/interface/SiteLocalConfig.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
-#include "FWCore/Services/src/SiteLocalConfigService.h"
-#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
+#include "FWCore/Services/interface/setupSiteLocalConfig.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include <iostream>
 #include <cstring>
@@ -27,11 +26,7 @@ int main(int argc, char* argv[]) {
   }
 
   try {
-    std::unique_ptr<edm::SiteLocalConfig> slcptr =
-        std::make_unique<edm::service::SiteLocalConfigService>(edm::ParameterSet());
-    auto slc = std::make_shared<edm::serviceregistry::ServiceWrapper<edm::SiteLocalConfig> >(std::move(slcptr));
-    edm::ServiceToken slcToken = edm::ServiceRegistry::createContaining(slc);
-    edm::ServiceRegistry::Operate operate(slcToken);
+    auto operate = edm::setupSiteLocalConfig();
 
     edm::Service<edm::SiteLocalConfig> localconfservice;
 

--- a/FWCore/Services/interface/setupSiteLocalConfig.h
+++ b/FWCore/Services/interface/setupSiteLocalConfig.h
@@ -1,0 +1,16 @@
+#ifndef FWCore_Services_setupSiteLocalConfig_h
+#define FWCore_Services_setupSiteLocalConfig_h
+
+/** \function edm::setupSiteLocalConfig
+
+  Description: Setups up the SiteLocalConfig service.
+
+  Usage:
+*/
+
+#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
+
+namespace edm {
+  ServiceRegistry::Operate setupSiteLocalConfig();
+}  // namespace edm
+#endif

--- a/FWCore/Services/src/setupSiteLocalConfig.cc
+++ b/FWCore/Services/src/setupSiteLocalConfig.cc
@@ -1,0 +1,22 @@
+///////////////////////////////////////
+//
+// data catalogs are filled in "parse"
+//
+///////////////////////////////////////
+
+//<<<<<< INCLUDES                                                       >>>>>>
+
+#include "FWCore/Services/src/SiteLocalConfigService.h"
+#include "FWCore/Services/interface/setupSiteLocalConfig.h"
+
+#include <memory>
+
+namespace edm {
+  ServiceRegistry::Operate setupSiteLocalConfig() {
+    std::unique_ptr<edm::SiteLocalConfig> slcptr =
+        std::make_unique<edm::service::SiteLocalConfigService>(edm::ParameterSet());
+    auto slc = std::make_shared<edm::serviceregistry::ServiceWrapper<edm::SiteLocalConfig> >(std::move(slcptr));
+    edm::ServiceToken slcToken = edm::ServiceRegistry::createContaining(slc);
+    return edm::ServiceRegistry::Operate(slcToken);
+  }
+}  // namespace edm

--- a/IOPool/Common/bin/EdmCopyUtil.cpp
+++ b/IOPool/Common/bin/EdmCopyUtil.cpp
@@ -14,18 +14,13 @@
 #include "Utilities/StorageFactory/interface/Storage.h"
 #include "Utilities/StorageFactory/interface/StorageFactory.h"
 #include "FWCore/Utilities/interface/Exception.h"
-#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
-#include "FWCore/Services/src/SiteLocalConfigService.h"
+#include "FWCore/Services/interface/setupSiteLocalConfig.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Catalog/interface/InputFileCatalog.h"
 #include "FWCore/Catalog/interface/SiteLocalConfig.h"
 
 static int copy_files(const boost::program_options::variables_map& vm) {
-  std::unique_ptr<edm::SiteLocalConfig> slcptr =
-      std::make_unique<edm::service::SiteLocalConfigService>(edm::ParameterSet());
-  auto slc = std::make_shared<edm::serviceregistry::ServiceWrapper<edm::SiteLocalConfig> >(std::move(slcptr));
-  edm::ServiceToken slcToken = edm::ServiceRegistry::createContaining(slc);
-  edm::ServiceRegistry::Operate operate(slcToken);
+  auto operate = edm::setupSiteLocalConfig();
 
   auto in = (vm.count("file") ? vm["file"].as<std::vector<std::string> >() : std::vector<std::string>());
 

--- a/IOPool/Common/bin/EdmFileUtil.cpp
+++ b/IOPool/Common/bin/EdmFileUtil.cpp
@@ -17,7 +17,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
-#include "FWCore/Services/src/SiteLocalConfigService.h"
+#include "FWCore/Services/interface/setupSiteLocalConfig.h"
 #include "FWCore/Utilities/interface/Adler32Calculator.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
@@ -76,11 +76,7 @@ int main(int argc, char* argv[]) {
 
   int rc = 0;
   try {
-    std::unique_ptr<edm::SiteLocalConfig> slcptr =
-        std::make_unique<edm::service::SiteLocalConfigService>(edm::ParameterSet());
-    auto slc = std::make_shared<edm::serviceregistry::ServiceWrapper<edm::SiteLocalConfig> >(std::move(slcptr));
-    edm::ServiceToken slcToken = edm::ServiceRegistry::createContaining(slc);
-    edm::ServiceRegistry::Operate operate(slcToken);
+    auto operate = edm::setupSiteLocalConfig();
 
     std::vector<std::string> in =
         (vm.count("file") ? vm["file"].as<std::vector<std::string> >() : std::vector<std::string>());

--- a/IOPool/Common/bin/EdmProvDump.cc
+++ b/IOPool/Common/bin/EdmProvDump.cc
@@ -13,8 +13,7 @@
 #include "FWCore/Catalog/interface/InputFileCatalog.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/Registry.h"
-#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
-#include "FWCore/Services/src/SiteLocalConfigService.h"
+#include "FWCore/Services/interface/setupSiteLocalConfig.h"
 
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/Utilities/interface/Exception.h"
@@ -333,11 +332,7 @@ void HistoryNode::printTopLevelPSetsHistory(ParameterSetMap const& iPSM,
 namespace {
   std::unique_ptr<TFile> makeTFileWithLookup(std::string const& filename) {
     // See if it is a logical file name.
-    std::unique_ptr<edm::SiteLocalConfig> slcptr =
-        std::make_unique<edm::service::SiteLocalConfigService>(edm::ParameterSet());
-    auto slc = std::make_shared<edm::serviceregistry::ServiceWrapper<edm::SiteLocalConfig>>(std::move(slcptr));
-    edm::ServiceToken slcToken = edm::ServiceRegistry::createContaining(slc);
-    edm::ServiceRegistry::Operate operate(slcToken);
+    auto operate = edm::setupSiteLocalConfig();
     std::string override;
     std::vector<std::string> fileNames;
     fileNames.push_back(filename);

--- a/IOPool/Streamer/test/ReadStreamerFile.cpp
+++ b/IOPool/Streamer/test/ReadStreamerFile.cpp
@@ -33,7 +33,7 @@ Disclaimer: Most of the code here is randomly written during
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
-#include "FWCore/Services/src/SiteLocalConfigService.h"
+#include "FWCore/Services/interface/setupSiteLocalConfig.h"
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 
 #include <iostream>
@@ -71,11 +71,7 @@ int readSingleStream(bool verbose) {
 
 int readMultipleStreams(bool verbose) {
   try {
-    std::unique_ptr<edm::SiteLocalConfig> slcptr =
-        std::make_unique<edm::service::SiteLocalConfigService>(edm::ParameterSet());
-    auto slc = std::make_shared<edm::serviceregistry::ServiceWrapper<edm::SiteLocalConfig> >(std::move(slcptr));
-    edm::ServiceToken slcToken = edm::ServiceRegistry::createContaining(slc);
-    edm::ServiceRegistry::Operate operate(slcToken);
+    auto operate = edm::setupSiteLocalConfig();
 
     int evCount = 0;
     std::vector<std::string> streamFiles;
@@ -122,11 +118,7 @@ int readMultipleStreams(bool verbose) {
 
 int readInvalidLFN(bool verbose) {
   try {
-    std::unique_ptr<edm::SiteLocalConfig> slcptr =
-        std::make_unique<edm::service::SiteLocalConfigService>(edm::ParameterSet());
-    auto slc = std::make_shared<edm::serviceregistry::ServiceWrapper<edm::SiteLocalConfig> >(std::move(slcptr));
-    edm::ServiceToken slcToken = edm::ServiceRegistry::createContaining(slc);
-    edm::ServiceRegistry::Operate operate(slcToken);
+    auto operate = edm::setupSiteLocalConfig();
 
     int evCount = 0;
     std::vector<std::string> streamFiles;


### PR DESCRIPTION
#### PR description:

This function should be used rather than setting up SiteLocalConfigService by hand. This avoids having other packages incude FWCore/Services/src/SiteLocalConfigService.h.

#### PR validation:

Code compiles.