### PR TITLE
add unit test for SiStripDQM_OfflineTkMap

### DIFF
--- a/DQM/SiStripMonitorClient/test/BuildFile.xml
+++ b/DQM/SiStripMonitorClient/test/BuildFile.xml
@@ -1,0 +1,1 @@
+<test name="testSiStripDQM_OfflineTkMap" command="test_SiStripDQM_OfflineTkMap.sh"/>

--- a/DQM/SiStripMonitorClient/test/test_SiStripDQM_OfflineTkMap.sh
+++ b/DQM/SiStripMonitorClient/test/test_SiStripDQM_OfflineTkMap.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+function die { echo $1: status $2; exit $2; }
+
+GT=`echo ${@} | python3 -c 'import Configuration.AlCa.autoCond as AC;print(AC.autoCond["run3_data_prompt"])'`
+FILE=/eos/cms/store/group/comm_dqm/DQMGUI_data/Run2018/ZeroBias/R0003191xx/DQM_V0001_R000319176__ZeroBias__Run2018B-PromptReco-v2__DQMIO.root
+
+echo "using GlobalTag: " $GT
+echo "using file: " $FILE
+cmsRun ${CMSSW_BASE}/src/DQM/SiStripMonitorClient/test/SiStripDQM_OfflineTkMap_Template_cfg_DB.py globalTag=$GT runNumber=319176 dqmFile=$FILE  detIdInfoFile=file.root  || die 'failed running SiStripDQM_OfflineTkMap_Template_cfg_DB.py' $?


### PR DESCRIPTION
#### PR description:

Add unit test to test the creation of Offline Tracker Maps.

#### PR validation:

The test currently segfaults because of the reasons at https://github.com/cms-sw/cmssw/issues/34607.
Will have to be included once the problem is fixed. 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport