### PR TITLE
Update of mkFit for 12_1_0_pre2

### DIFF
--- a/Configuration/ProcessModifiers/python/trackingMkFit_cff.py
+++ b/Configuration/ProcessModifiers/python/trackingMkFit_cff.py
@@ -18,13 +18,13 @@ trackingMkFit = cms.ModifierChain(
     trackingMkFitCommon,
     trackingMkFitInitialStepPreSplitting,
     trackingMkFitInitialStep,
-    trackingMkFitLowPtQuadStep,
+#    trackingMkFitLowPtQuadStep,       # to be enabled later
     trackingMkFitHighPtTripletStep,
-    trackingMkFitLowPtTripletStep,
+#    trackingMkFitLowPtTripletStep,    # to be enabled later
     trackingMkFitDetachedQuadStep,
 #    trackingMkFitDetachedTripletStep, # to be enabled later
 #    trackingMkFitPixelPairStep,       # to be enabled later
 #    trackingMkFitMixedTripletStep,    # to be enabled later
-    trackingMkFitPixelLessStep,
-    trackingMkFitTobTecStep,
+#    trackingMkFitPixelLessStep,       # to be enabled later
+#    trackingMkFitTobTecStep,          # to be enabled later
 )

--- a/RecoTracker/MkFit/README.md
+++ b/RecoTracker/MkFit/README.md
@@ -49,7 +49,7 @@ $ runTheMatrix.py -l <workflow(s)> --apply 2 --command "--procModifiers tracking
 * *maxCandsPerSeed:* maximum number of concurrent track candidates per given seed
 * *maxHolesPerCand:* maximum number of allowed holes on a candidate
 * *maxConsecHoles:*  maximum number of allowed consecutive holes on a candidate
-* *chi2Cut:*         chi2 cut for accepting a new hit
+* *chi2Cut_min:*     minimum chi2 cut for accepting a new hit
 * *chi2CutOverlap:*  chi2 cut for accepting an overlap hit
 * *pTCutOverlap:*    pT cut below which the overlap hits are not picked up
 
@@ -81,3 +81,5 @@ $ runTheMatrix.py -l <workflow(s)> --apply 2 --command "--procModifiers tracking
 * *c_dp_sf:* additional scaling factor for dphi cut
 * *c_dq_[012]:* dr (endcap) / dz (barrel) selection window cut (= [0]*1/pT + [1]*std::fabs(theta-pi/2) + [2])
 * *c_dq_sf:* additional scaling factor for dr (endcap) / dz (barrel) cut
+* *c_c2_[012]:* chi2 cut for accepting new hit (= [0]*1/pT + [1]*std::fabs(theta-pi/2) + [2])
+* *c_c2_sf:* additional scaling factor for chi2 cut

--- a/RecoTracker/MkFit/plugins/BuildFile.xml
+++ b/RecoTracker/MkFit/plugins/BuildFile.xml
@@ -1,6 +1,9 @@
 <library file="*.cc" name="RecoTrackerMkFitPlugins">
+  <use name="CalibFormats/SiStripObjects"/>
+  <use name="CalibTracker/Records"/>
   <use name="DataFormats/Common"/>
   <use name="DataFormats/SiStripCluster"/>
+  <use name="DataFormats/SiStripCommon"/>
   <use name="DataFormats/SiPixelCluster"/>
   <use name="DataFormats/TrackCandidate"/>
   <use name="DataFormats/TrackReco"/>
@@ -10,6 +13,7 @@
   <use name="DataFormats/TrajectorySeed"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/ParameterSet"/>
+  <use name="Geometry/CommonTopologies"/>
   <use name="Geometry/Records"/>
   <use name="Geometry/TrackerGeometryBuilder"/>
   <use name="RecoTracker/MkFit"/>

--- a/RecoTracker/MkFit/plugins/MkFitEventOfHitsProducer.cc
+++ b/RecoTracker/MkFit/plugins/MkFitEventOfHitsProducer.cc
@@ -95,7 +95,7 @@ void MkFitEventOfHitsProducer::produce(edm::StreamID iID, edm::Event& iEvent, co
       const auto q2 = isBarrel ? surf.zSpan().second : surf.rSpan().second;
       if (bs.BadModule)
         deadvectors[ilay].push_back({surf.phiSpan().first, surf.phiSpan().second, q1, q2});
-      else { //assume that BadApvs are filled in sync with BadFibers
+      else {  //assume that BadApvs are filled in sync with BadFibers
         auto const& topo = dynamic_cast<const StripTopology&>(trackerGeom.idToDet(detid)->topology());
         int firstApv = -1;
         int lastApv = -1;
@@ -106,15 +106,16 @@ void MkFitEventOfHitsProducer::produce(edm::StreamID iID, edm::Event& iEvent, co
           float phi1 = firstPoint.phi();
           float phi2 = lastPoint.phi();
           if (reco::deltaPhi(phi1, phi2) > 0)
-	    std::swap(phi1, phi2);
-          LogTrace("SiStripBadComponents")<<"insert bad range "<<first<<" to "<<last<<" "<<phi1<<" "<<phi2;
+            std::swap(phi1, phi2);
+          LogTrace("SiStripBadComponents")
+              << "insert bad range " << first << " to " << last << " " << phi1 << " " << phi2;
           dv.push_back({phi1, phi2, q1, q2});
         };
 
         for (int apv = 0; apv < 6; ++apv) {
           const bool isBad = bs.BadApvs & (1 << apv);
           if (isBad)
-            LogTrace("SiStripBadComponents")<<"bad apv "<<apv<<" on "<<bs.detid;
+            LogTrace("SiStripBadComponents") << "bad apv " << apv << " on " << bs.detid;
           if (isBad) {
             if (lastApv == -1) {
               firstApv = apv;

--- a/RecoTracker/MkFit/plugins/MkFitEventOfHitsProducer.cc
+++ b/RecoTracker/MkFit/plugins/MkFitEventOfHitsProducer.cc
@@ -66,7 +66,7 @@ void MkFitEventOfHitsProducer::fillDescriptions(edm::ConfigurationDescriptions& 
 
   desc.add("pixelHits", edm::InputTag{"mkFitSiPixelHits"});
   desc.add("stripHits", edm::InputTag{"mkFitSiStripHits"});
-  desc.add("useStripStripQualityDB", false)->setComment("Use SiStrip quality DB information");
+  desc.add("useStripStripQualityDB", true)->setComment("Use SiStrip quality DB information");
 
   descriptions.addWithDefaultLabel(desc);
 }


### PR DESCRIPTION
#### PR description:

This PR follows #34395 and updates mkFit for physics validation in CMSSW_12_1_0_pre2 (https://its.cern.ch/jira/browse/PDMVRELVALS-130).

In detail, this PR includes:
- update usage of SiStrip quality DB information for mkFit;
- enable usage of SiStrip quality DB information for mkFit;
- enable by default only InitialStepPreSplitting, InitialStep, HighPtTripletStep and DetachedQuadStep in trackingMkFit procModifier;
- other technical optimizations.

It requires cms-sw/cmsdist#7217 and cms-data/RecoTracker-MkFit#3

Developments have been presented at Tracking POG (https://indico.cern.ch/event/1065324/#3-mkfit-status-report) and agreed with PPD (https://indico.cern.ch/event/1063451/#8-mkfit-report).


#### PR validation:

MTV results for tracking-only validation in TTbar RelVal (with mkFit enabled for 4 iterations as specified above):
- on /RelValTTbar_14TeV/CMSSW_12_0_0_pre6-PU_120X_mcRun3_2021_realistic_v4-v1/GEN-SIM-DIGI-RAW: https://mmasciov.web.cern.ch/mmasciov/MkFitCMSSW/MTV_mkFitPR_TTbarPU/
- on /RelValTTbar_14TeV/CMSSW_12_0_0_pre6-PU_120X_mcRun3_2021_realistic_v4_JIRA_129-v1/GEN-SIM-DIGI-RAW: https://mmasciov.web.cern.ch/mmasciov/MkFitCMSSW/MTV_mkFitPR_TTbarPU_JIRA129/

FYI @mtosi @vmariani @mmusich
(@slava77 @makortel)
