### PR TITLE
Add HCAL tag `HcalRespCorrs_2021_v3.0_mc` to Run-3 MC GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -64,17 +64,17 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak'     : '120X_upgrade2018cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'           : '120X_mcRun3_2021_design_v3', # GT containing design conditions for Phase1 2021
+    'phase1_2021_design'           : '121X_mcRun3_2021_design_v1', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'        : '120X_mcRun3_2021_realistic_v4', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'        : '121X_mcRun3_2021_realistic_v1', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'          : '120X_mcRun3_2021cosmics_realistic_deco_v3',
+    'phase1_2021_cosmics'          : '121X_mcRun3_2021cosmics_realistic_deco_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi'     : '120X_mcRun3_2021_realistic_HI_v3',
+    'phase1_2021_realistic_hi'     : '121X_mcRun3_2021_realistic_HI_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '120X_mcRun3_2023_realistic_v4', # GT containing realistic conditions for Phase1 2023
+    'phase1_2023_realistic'        : '121X_mcRun3_2023_realistic_v1', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '120X_mcRun3_2024_realistic_v4', # GT containing realistic conditions for Phase1 2024
+    'phase1_2024_realistic'        : '121X_mcRun3_2024_realistic_v1', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             : '113X_mcRun4_realistic_v7'
 }


### PR DESCRIPTION
#### PR description:

The HCAL group requested the inclusion of the tag `HcalRespCorrs_2021_v3.0_mc` in all Run-3 MC GTs in [*]. As described in the HN message the difference between the new GTs and the current ones is simply this single-IOV MC tag. For completeness here are the links as well:

#### 2021 design MC GT
 * https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021_design_v1/120X_mcRun3_2021_design_v3

#### 2021 realistic MC GT
 * https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021_realistic_v1/120X_mcRun3_2021_realistic_v4

#### 2021 cosmics MC GT
 * https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021cosmics_realistic_deco_v1/120X_mcRun3_2021cosmics_realistic_deco_v3

#### 2021 heavy ion MC GT
 * https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021_realistic_HI_v1/120X_mcRun3_2021_realistic_HI_v3


#### 2023 realistic MC GT
 * https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2023_realistic_v1/120X_mcRun3_2023_realistic_v4

#### 2024 realistic MC GT
 * https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2024_realistic_v1/120X_mcRun3_2024_realistic_v4

More details in the presentation at the AlCaDB meeting [**].

[*] https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4444.html
[**] https://indico.cern.ch/event/1066868/#14-fix-of-hcal-response-correc

#### PR validation:

`runTheMatrix.py -l limited,7.23,159.0,11634.0,12434.0,12834.0 --ibeos -j8`

As described in the HN message:
 * Plot showing ieta (HCAL tower index) distribution of new corrections:
https://hypernews.cern.ch/HyperNews/CMS/get/AUX/2021/08/17/10:01:18-74638-HcalRespCorrs_2021_v3.0_mc.pdf

 * Closure test results with the new corrections.
https://hypernews.cern.ch/HyperNews/CMS/get/AUX/2021/08/17/10:01:18-86183-IsoTrackN105.pdf

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

A backport is expected for 12_0_X GTs as well.

cc: @mseidel42 @abdoulline
