### PR TITLE
[12_0_X] Add HCAL tag `HcalRespCorrs_2021_v3.0_mc` to Run-3 MC GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -64,17 +64,17 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak'     : '120X_upgrade2018cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'           : '120X_mcRun3_2021_design_v3', # GT containing design conditions for Phase1 2021
+    'phase1_2021_design'           : '120X_mcRun3_2021_design_v4', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'        : '120X_mcRun3_2021_realistic_v4', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'        : '120X_mcRun3_2021_realistic_v5', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'          : '120X_mcRun3_2021cosmics_realistic_deco_v3',
+    'phase1_2021_cosmics'          : '120X_mcRun3_2021cosmics_realistic_deco_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi'     : '120X_mcRun3_2021_realistic_HI_v3',
+    'phase1_2021_realistic_hi'     : '120X_mcRun3_2021_realistic_HI_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '120X_mcRun3_2023_realistic_v4', # GT containing realistic conditions for Phase1 2023
+    'phase1_2023_realistic'        : '120X_mcRun3_2023_realistic_v5', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '120X_mcRun3_2024_realistic_v4', # GT containing realistic conditions for Phase1 2024
+    'phase1_2024_realistic'        : '120X_mcRun3_2024_realistic_v5', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             : '113X_mcRun4_realistic_v7'
 }


### PR DESCRIPTION
#### PR description:

Please see description in https://github.com/cms-sw/cmssw/pull/34922

Here is the list of differences: 
 - 120X_mcRun3_2021_design_v4
Diff: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/120X_mcRun3_2021_design_v3/120X_mcRun3_2021_design_v4
 - 120X_mcRun3_2021_realistic_v5
Diff: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/120X_mcRun3_2021_realistic_v4/120X_mcRun3_2021_realistic_v5
 - 120X_mcRun3_2021cosmics_realistic_deco_v4
Diff: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/120X_mcRun3_2021cosmics_realistic_deco_v3/120X_mcRun3_2021cosmics_realistic_deco_v4
 - 120X_mcRun3_2021_realistic_HI_v4
Diff: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/120X_mcRun3_2021_realistic_HI_v3/120X_mcRun3_2021_realistic_HI_v4
 - 120X_mcRun3_2023_realistic_v5
Diff: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/120X_mcRun3_2023_realistic_v4/120X_mcRun3_2023_realistic_v5
- 120X_mcRun3_2024_realistic_v5
Diff: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/120X_mcRun3_2024_realistic_v4/120X_mcRun3_2024_realistic_v5

The diffs are wrt the conditions in the master, and only show the differences in the requested tag, `HcalRespCorrs_2021_v3.0_mc` 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

backport of https://github.com/cms-sw/cmssw/pull/34922

cc: @mseidel42 @abdoulline
