### PR TITLE
(DAQ) input source - minimum starting lumisection (113X - backport)

### DIFF
--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -172,6 +172,7 @@ namespace evf {
     void createProcessingNotificationMaybe() const;
     int readLastLSEntry(std::string const& file);
     unsigned int getLumisectionToStart() const;
+    unsigned int getStartLumisectionFromEnv() const { return startFromLS_; }
     void setDeleteTracking(std::mutex* fileDeleteLock,
                            std::list<std::pair<int, std::unique_ptr<InputFile>>>* filesToDelete) {
       fileDeleteLockPtr_ = fileDeleteLock;

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -123,7 +123,7 @@ namespace evf {
       socket_ = std::make_unique<boost::asio::ip::tcp::socket>(io_service_);
     }
 
-    char* startFromLSPtr = std::getenv("FFF_STARTFROMLS");
+    char* startFromLSPtr = std::getenv("FFF_START_LUMISECTION");
     if (startFromLSPtr) {
       try {
         startFromLS_ = boost::lexical_cast<unsigned int>(std::string(startFromLSPtr));
@@ -1863,7 +1863,7 @@ namespace evf {
     std::string fileprefix = run_dir_ + "/" + run_string_ + "_ls";
     std::string fullpath;
     struct stat buf;
-    unsigned int lscount = startFromLS_;
+    unsigned int lscount = 1;
     do {
       std::stringstream ss;
       ss << fileprefix << std::setfill('0') << std::setw(4) << lscount << "_EoLS.jsn";

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -921,7 +921,21 @@ void FedRawDataInputSource::readSupervisor() {
           } else {
             //new file service
             if (currentLumiSection == 0 && !alwaysStartFromFirstLS_) {
-              if (ls < 100) {
+              if (daqDirector_->getStartLumisectionFromEnv() > 1) {
+                //start transitions from LS specified by env, continue if not reached
+                if (ls < daqDirector_->getStartLumisectionFromEnv()) {
+                  //skip file if from earlier LS than specified by env
+                  if (rawFd != -1) {
+                    close(rawFd);
+                    rawFd = -1;
+                  }
+                  status = evf::EvFDaqDirector::noFile;
+                  continue;
+                } else {
+                  std::unique_ptr<InputFile> inf(new InputFile(evf::EvFDaqDirector::newLumi, ls));
+                  fileQueue_.push(std::move(inf));
+                }
+              } else if (ls < 100) {
                 //look at last LS file on disk to start from that lumisection (only within first 100 LS)
                 unsigned int lsToStart = daqDirector_->getLumisectionToStart();
 


### PR DESCRIPTION
#### PR description:

Adds a minimum starting lumisection parameter as environment variable. Source will ignore data or EoL markers from earlier lumisections if provided from file broker.
This targets Hilton, so that skipping to LS with input data can be facilitated.

Another variable of similar name, which was unused, is removed.

#### PR validation:

Mechanism was tested in a live filter farm test system (BU-FU) and shown to work as intended.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of #34912 