### PR TITLE
Simplify setting EDPutTokenT via call to produces

### DIFF
--- a/FWCore/Framework/interface/ProducerBase.h
+++ b/FWCore/Framework/interface/ProducerBase.h
@@ -104,15 +104,6 @@ namespace edm {
     ProducesCollector producesCollector();
     using ProductRegistryHelper::produces;
 
-    template <Transition Tr = Transition::Event>
-    [[nodiscard]] auto produces(std::string instanceName) noexcept {
-      return producesCollector().produces<Tr>(std::move(instanceName));
-    }
-    template <Transition Tr = Transition::Event>
-    [[nodiscard]] auto produces() noexcept {
-      return producesCollector().produces<Tr>();
-    }
-
   private:
     friend class EDProducer;
     friend class EDFilter;

--- a/FWCore/Framework/interface/ProducerBase.h
+++ b/FWCore/Framework/interface/ProducerBase.h
@@ -9,6 +9,7 @@ EDProducts into an Event.
 ----------------------------------------------------------------------*/
 
 #include "FWCore/Framework/interface/ProductRegistryHelper.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 #include "FWCore/Utilities/interface/ProductResolverIndex.h"
 
 #include <functional>
@@ -102,6 +103,15 @@ namespace edm {
   protected:
     ProducesCollector producesCollector();
     using ProductRegistryHelper::produces;
+
+    template <Transition Tr = Transition::Event>
+    [[nodiscard]] auto produces(std::string instanceName) noexcept {
+      return producesCollector().produces<Tr>(std::move(instanceName));
+    }
+    template <Transition Tr = Transition::Event>
+    [[nodiscard]] auto produces() noexcept {
+      return producesCollector().produces<Tr>();
+    }
 
   private:
     friend class EDProducer;

--- a/FWCore/Framework/interface/ProducesCollector.h
+++ b/FWCore/Framework/interface/ProducesCollector.h
@@ -108,7 +108,7 @@ namespace edm {
     }
 
   private:
-    //only ConsumesCollector is allowed to make an instance of this class
+    //only ProducesCollector is allowed to make an instance of this class
     friend class ProducesCollector;
 
     ProducesCollectorAdaptor(ProducesCollector iBase, std::string iLabel)

--- a/FWCore/Framework/interface/ProducesCollector.h
+++ b/FWCore/Framework/interface/ProducesCollector.h
@@ -39,6 +39,8 @@ a functor passed to the Framework with a call to callWhenNewProductsRegistered.
 namespace edm {
 
   class TypeID;
+  template <Transition B>
+  class ProducesCollectorAdaptor;
 
   class ProducesCollector {
   public:
@@ -68,6 +70,15 @@ namespace edm {
       return helper_->produces<ProductType, B>(std::move(instanceName));
     }
 
+    template <Transition Tr = Transition::Event>
+    [[nodiscard]] auto produces(std::string instanceName) noexcept {
+      return ProducesCollectorAdaptor<Tr>(*this, std::move(instanceName));
+    }
+    template <Transition Tr = Transition::Event>
+    [[nodiscard]] auto produces() noexcept {
+      return ProducesCollectorAdaptor<Tr>(*this);
+    }
+
     ProductRegistryHelper::BranchAliasSetter produces(const TypeID& id,
                                                       std::string instanceName = std::string(),
                                                       bool recordProvenance = true);
@@ -84,6 +95,28 @@ namespace edm {
     ProducesCollector(ProductRegistryHelper* helper);
 
     propagate_const<ProductRegistryHelper*> helper_;
+  };
+
+  template <Transition B>
+  class ProducesCollectorAdaptor {
+  public:
+    using Adapter = ProducesCollectorAdaptor<B>;
+
+    template <typename TYPE>
+    EDPutTokenT<TYPE> produces() {
+      return m_producer.template produces<TYPE, B>(m_label);
+    }
+
+  private:
+    //only ConsumesCollector is allowed to make an instance of this class
+    friend class ProducesCollector;
+
+    ProducesCollectorAdaptor(ProducesCollector iBase, std::string iLabel)
+        : m_producer(iBase), m_label(std::move(iLabel)) {}
+    ProducesCollectorAdaptor(ProducesCollector iBase) : m_producer(iBase), m_label() {}
+
+    ProducesCollector m_producer;
+    std::string const m_label;
   };
 
 }  // namespace edm

--- a/FWCore/Framework/interface/ProductRegistryHelper.h
+++ b/FWCore/Framework/interface/ProductRegistryHelper.h
@@ -79,6 +79,12 @@ namespace edm {
       TypeLabelItem& value_;
       EDPutTokenT<T> token_;
 
+      template <typename U>
+      EDPutTokenT<T> produces() {
+        static_assert(std::is_same_v<T, U>);
+        return token_;
+      }
+
       operator EDPutTokenT<T>() { return token_; }
       operator EDPutToken() { return EDPutToken(token_.index()); }
     };

--- a/FWCore/Framework/interface/ProductRegistryHelper.h
+++ b/FWCore/Framework/interface/ProductRegistryHelper.h
@@ -20,6 +20,9 @@ namespace edm {
   class ProductRegistry;
   struct DoNotRecordParents;
 
+  template <Transition B>
+  class ProductRegistryHelperAdaptor;
+
   class ProductRegistryHelper {
   public:
     virtual ~ProductRegistryHelper() noexcept(false);
@@ -110,6 +113,15 @@ namespace edm {
         \endcode
         should be added to the producer ctor for every product */
 
+    template <Transition Tr = Transition::Event>
+    [[nodiscard]] auto produces(std::string instanceName) noexcept {
+      return ProductRegistryHelperAdaptor<Tr>(*this, std::move(instanceName));
+    }
+    template <Transition Tr = Transition::Event>
+    [[nodiscard]] auto produces() noexcept {
+      return ProductRegistryHelperAdaptor<Tr>(*this);
+    }
+
     template <class ProductType>
     BranchAliasSetterT<ProductType> produces() {
       return produces<ProductType, InEvent>(std::string());
@@ -181,6 +193,26 @@ namespace edm {
   private:
     TypeLabelList typeLabelList_;
     std::vector<bool> recordProvenanceList_;
+  };
+
+  template <Transition B>
+  class ProductRegistryHelperAdaptor {
+  public:
+    template <typename TYPE>
+    EDPutTokenT<TYPE> produces() {
+      return m_helper.template produces<TYPE, B>(m_label);
+    }
+
+  private:
+    //only ConsumesCollector is allowed to make an instance of this class
+    friend class ProductRegistryHelper;
+
+    ProductRegistryHelperAdaptor(ProductRegistryHelper& iBase, std::string iLabel)
+        : m_helper(iBase), m_label(std::move(iLabel)) {}
+    explicit ProductRegistryHelperAdaptor(ProductRegistryHelper& iBase) : m_helper(iBase), m_label() {}
+
+    ProductRegistryHelper& m_helper;
+    std::string const m_label;
   };
 
 }  // namespace edm

--- a/FWCore/Framework/interface/ProductRegistryHelper.h
+++ b/FWCore/Framework/interface/ProductRegistryHelper.h
@@ -204,7 +204,7 @@ namespace edm {
     }
 
   private:
-    //only ConsumesCollector is allowed to make an instance of this class
+    //only ProductRegistryHelper is allowed to make an instance of this class
     friend class ProductRegistryHelper;
 
     ProductRegistryHelperAdaptor(ProductRegistryHelper& iBase, std::string iLabel)

--- a/FWCore/Framework/src/EndPathStatusInserter.cc
+++ b/FWCore/Framework/src/EndPathStatusInserter.cc
@@ -7,7 +7,7 @@
 #include <memory>
 
 namespace edm {
-  EndPathStatusInserter::EndPathStatusInserter(unsigned int) : token_{produces<EndPathStatus>()} {}
+  EndPathStatusInserter::EndPathStatusInserter(unsigned int) : token_{produces()} {}
 
   void EndPathStatusInserter::produce(StreamID, edm::Event& event, edm::EventSetup const&) const {
     //Puts a default constructed EndPathStatus

--- a/FWCore/Framework/src/PathStatusInserter.cc
+++ b/FWCore/Framework/src/PathStatusInserter.cc
@@ -7,7 +7,7 @@
 
 namespace edm {
   PathStatusInserter::PathStatusInserter(unsigned int numberOfStreams)
-      : hltPathStatus_(numberOfStreams), token_{produces<HLTPathStatus>()} {}
+      : hltPathStatus_(numberOfStreams), token_{produces()} {}
 
   void PathStatusInserter::setPathStatus(StreamID const& streamID, HLTPathStatus const& hltPathStatus) {
     hltPathStatus_[streamID.value()] = hltPathStatus;

--- a/FWCore/Framework/src/TriggerResultInserter.cc
+++ b/FWCore/Framework/src/TriggerResultInserter.cc
@@ -8,7 +8,7 @@
 
 namespace edm {
   TriggerResultInserter::TriggerResultInserter(const ParameterSet& pset, unsigned int iNStreams)
-      : resultsPerStream_(iNStreams), pset_id_(pset.id()), token_{produces<TriggerResults>()} {}
+      : resultsPerStream_(iNStreams), pset_id_(pset.id()), token_{produces()} {}
 
   void TriggerResultInserter::setTrigResultForStream(unsigned int iStreamIndex, const TrigResPtr& trptr) {
     resultsPerStream_[iStreamIndex] = trptr;

--- a/FWCore/Framework/test/Event_t.cpp
+++ b/FWCore/Framework/test/Event_t.cpp
@@ -83,7 +83,7 @@ namespace {
   template <typename T>
   class TestProducer : public edm::ProducerBase {
   public:
-    TestProducer(std::string const& productInstanceName) { token_ = produces<T>(productInstanceName); }
+    TestProducer(std::string const& productInstanceName) { token_ = produces(productInstanceName); }
     EDPutTokenT<T> token_;
   };
 }  // namespace

--- a/FWCore/Framework/test/stubs/TestGlobalFilters.cc
+++ b/FWCore/Framework/test/stubs/TestGlobalFilters.cc
@@ -503,8 +503,7 @@ namespace edmtest {
     class TestBeginProcessBlockFilter : public edm::global::EDFilter<edm::BeginProcessBlockProducer> {
     public:
       explicit TestBeginProcessBlockFilter(edm::ParameterSet const& p)
-          : trans_(p.getParameter<int>("transitions")),
-            token_(produces<unsigned int, edm::Transition::BeginProcessBlock>("begin")) {
+          : trans_(p.getParameter<int>("transitions")), token_(produces<edm::Transition::BeginProcessBlock>("begin")) {
         produces<unsigned int>();
 
         auto tag = p.getParameter<edm::InputTag>("consumesBeginProcessBlock");

--- a/FWCore/Framework/test/stubs/TestGlobalProducers.cc
+++ b/FWCore/Framework/test/stubs/TestGlobalProducers.cc
@@ -793,7 +793,7 @@ namespace edmtest {
     public:
       explicit TestAccumulator(edm::ParameterSet const& p)
           : m_expectedCount(p.getParameter<unsigned int>("expectedCount")),
-            m_putToken(produces<unsigned int, edm::Transition::EndLuminosityBlock>()) {}
+            m_putToken(produces<edm::Transition::EndLuminosityBlock>()) {}
 
       void accumulate(edm::StreamID iID, edm::Event const&, edm::EventSetup const&) const override { ++m_count; }
 

--- a/FWCore/Modules/src/LogErrorHarvester.cc
+++ b/FWCore/Modules/src/LogErrorHarvester.cc
@@ -50,7 +50,7 @@ namespace edm {
     EDPutTokenT<std::vector<ErrorSummaryEntry>> token_;
   };
 
-  LogErrorHarvester::LogErrorHarvester(ParameterSet const& iPSet) : token_{produces<std::vector<ErrorSummaryEntry>>()} {
+  LogErrorHarvester::LogErrorHarvester(ParameterSet const& iPSet) : token_{produces()} {
     const edm::TypeID endPathStatusType{typeid(edm::EndPathStatus)};
     const edm::TypeID pathStatusType{typeid(edm::PathStatus)};
     const edm::TypeID triggerResultsType{typeid(edm::TriggerResults)};

--- a/FWCore/Utilities/interface/EDPutToken.h
+++ b/FWCore/Utilities/interface/EDPutToken.h
@@ -41,22 +41,22 @@ namespace edm {
   public:
     using value_type = unsigned int;
 
-    EDPutToken() : m_value{s_uninitializedValue} {}
+    constexpr EDPutToken() noexcept : m_value{s_uninitializedValue} {}
 
     template <typename T>
-    EDPutToken(EDPutTokenT<T> iOther) : m_value{iOther.m_value} {}
+    constexpr EDPutToken(EDPutTokenT<T> iOther) noexcept : m_value{iOther.m_value} {}
 
     // ---------- const member functions ---------------------
-    value_type index() const { return m_value; }
-    bool isUninitialized() const { return m_value == s_uninitializedValue; }
+    constexpr value_type index() const noexcept { return m_value; }
+    constexpr bool isUninitialized() const noexcept { return m_value == s_uninitializedValue; }
 
   private:
     //for testing
     friend class TestEDPutToken;
 
-    static const unsigned int s_uninitializedValue = 0xFFFFFFFF;
+    static constexpr unsigned int s_uninitializedValue = 0xFFFFFFFF;
 
-    explicit EDPutToken(unsigned int iValue) : m_value(iValue) {}
+    explicit constexpr EDPutToken(unsigned int iValue) noexcept : m_value(iValue) {}
 
     // ---------- member data --------------------------------
     value_type m_value;
@@ -71,19 +71,42 @@ namespace edm {
   public:
     using value_type = EDPutToken::value_type;
 
-    EDPutTokenT() : m_value{s_uninitializedValue} {}
+    constexpr EDPutTokenT() noexcept : m_value{s_uninitializedValue} {}
+
+    constexpr EDPutTokenT(const EDPutTokenT<T>&) noexcept = default;
+    constexpr EDPutTokenT(EDPutTokenT<T>&&) noexcept = default;
+    constexpr EDPutTokenT(EDPutTokenT<T>& iToken) noexcept : EDPutTokenT(const_cast<EDPutTokenT<T> const&>(iToken)) {}
+
+    template <typename ADAPTER>
+    constexpr explicit EDPutTokenT(ADAPTER&& iAdapter) noexcept : EDPutTokenT(iAdapter.template produces<T>()) {}
+
+    constexpr EDPutTokenT& operator=(const EDPutTokenT<T>&) noexcept = default;
+    constexpr EDPutTokenT& operator=(EDPutTokenT<T>&&) noexcept = default;
+    constexpr EDPutTokenT& operator=(EDPutTokenT<T>& iOther) noexcept {
+      m_value = iOther.m_value;
+      return *this;
+    }
+
+    template <typename ADAPTER>
+    constexpr EDPutTokenT& operator=(ADAPTER&& iAdapter) noexcept {
+      EDPutTokenT<T> temp(iAdapter.template produces<T>());
+      m_value = temp.m_value;
+
+      return *this;
+    }
 
     // ---------- const member functions ---------------------
-    value_type index() const { return m_value; }
-    bool isUninitialized() const { return m_value == s_uninitializedValue; }
+    constexpr value_type index() const noexcept { return m_value; }
+    constexpr bool isUninitialized() const noexcept { return m_value == s_uninitializedValue; }
 
   private:
     //for testing
     friend class TestEDPutToken;
 
-    static const unsigned int s_uninitializedValue = 0xFFFFFFFF;
+    static constexpr unsigned int s_uninitializedValue = 0xFFFFFFFF;
 
-    explicit EDPutTokenT(unsigned int iValue) : m_value(iValue) {}
+    constexpr explicit EDPutTokenT(unsigned int iValue) noexcept : m_value(iValue) {}
+    constexpr explicit EDPutTokenT(unsigned long int iValue) noexcept : m_value(iValue) {}
 
     // ---------- member data --------------------------------
     value_type m_value;


### PR DESCRIPTION
#### PR description:

Call to `produces` does not require specifying the data product type as it will be deduced via EDPutTokenT.
Also did some minor code modernization.

#### PR validation:

Code compiles.