### PR TITLE
Migrate some modules in RecoTracker to esConsumes()

### DIFF
--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerEventProducer.h
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerEventProducer.h
@@ -13,6 +13,8 @@
 #include "DataFormats/SiPixelDetId/interface/PixelFEDChannel.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
 #include "DataFormats/TrackerRecHit2D/interface/VectorHit.h"
+#include "RecoTracker/MeasurementDet/interface/MeasurementTracker.h"
+#include "RecoTracker/Record/interface/CkfComponentsRecord.h"
 
 class dso_hidden MeasurementTrackerEventProducer final : public edm::stream::EDProducer<> {
 public:
@@ -37,7 +39,7 @@ protected:
 
   void getInactiveStrips(const edm::Event& event, std::vector<uint32_t>& rawInactiveDetIds) const;
 
-  std::string measurementTrackerLabel_;
+  edm::ESGetToken<MeasurementTracker, CkfComponentsRecord> measurementTrackerToken_;
   edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster>> thePixelClusterLabel;
   edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster>> theStripClusterLabel;
   edm::EDGetTokenT<edmNew::DetSetVector<Phase2TrackerCluster1D>> thePh2OTClusterLabel;
@@ -48,7 +50,7 @@ protected:
 
   std::vector<edm::EDGetTokenT<DetIdCollection>> theInactivePixelDetectorLabels;
   std::vector<edm::EDGetTokenT<PixelFEDChannelCollection>> theBadPixelFEDChannelsLabels;
-  std::string pixelCablingMapLabel_;
+  edm::ESGetToken<SiPixelFedCablingMap, SiPixelFedCablingMapRcd> pixelCablingMapToken_;
   std::vector<edm::EDGetTokenT<DetIdCollection>> theInactiveStripDetectorLabels;
 
   bool selfUpdateSkipClusters_;

--- a/RecoTracker/SingleTrackPattern/interface/CRackTrajectoryBuilder.h
+++ b/RecoTracker/SingleTrackPattern/interface/CRackTrajectoryBuilder.h
@@ -10,6 +10,7 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
@@ -27,6 +28,7 @@
 #include "RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h"
 #include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
+#include "TrackingTools/Records/interface/TransientRecHitRecord.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackExtra.h"
 #include "TrackingTools/TrackFitters/interface/KFTrajectoryFitter.h"
@@ -34,8 +36,6 @@
 #include "TrackingTools/MeasurementDet/interface/LayerMeasurements.h"
 #include "RecoTracker/MeasurementDet/interface/MeasurementTracker.h"
 #include "TrackingTools/MaterialEffects/interface/PropagatorWithMaterial.h"
-
-#include "FWCore/Framework/interface/ESHandle.h"
 
 //to sort hits by the det position
 class CompareDetY_plus {
@@ -172,7 +172,7 @@ public:
   };
 
 public:
-  CRackTrajectoryBuilder(const edm::ParameterSet& conf);
+  CRackTrajectoryBuilder(const edm::ParameterSet& conf, edm::ConsumesCollector iC);
   ~CRackTrajectoryBuilder();
 
   /// Runs the algorithm
@@ -215,8 +215,11 @@ private:
   std::pair<TrajectoryStateOnSurface, const GeomDet*> innerState(const Trajectory& traj) const;
 
 private:
-  edm::ESHandle<MagneticField> magfield;
-  edm::ESHandle<TrackerGeometry> tracker;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magfieldToken_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerToken_;
+  const edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> builderToken_;
+  const MagneticField* magfield;
+  const TrackerGeometry* tracker;
 
   PropagatorWithMaterial* thePropagator;
   PropagatorWithMaterial* thePropagatorOp;
@@ -242,7 +245,6 @@ private:
   TransientTrackingRecHit::RecHitContainer hits;
   bool seed_plus;
   std::string geometry;
-  std::string theBuilderName;
   //   TransientInitialStateEstimator*  theInitialState;
 };
 

--- a/RecoTracker/SingleTrackPattern/interface/CosmicTrajectoryBuilder.h
+++ b/RecoTracker/SingleTrackPattern/interface/CosmicTrajectoryBuilder.h
@@ -10,6 +10,7 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
@@ -28,6 +29,7 @@
 #include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
 #include "RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h"
+#include "TrackingTools/Records/interface/TransientRecHitRecord.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackExtra.h"
 #include "TrackingTools/TrackFitters/interface/KFTrajectoryFitter.h"
@@ -35,8 +37,6 @@
 #include "TrackingTools/MeasurementDet/interface/LayerMeasurements.h"
 #include "RecoTracker/MeasurementDet/interface/MeasurementTracker.h"
 #include "TrackingTools/MaterialEffects/interface/PropagatorWithMaterial.h"
-
-#include "FWCore/Framework/interface/ESHandle.h"
 
 #ifndef TrajectoryBuilder_CompareHitY
 #define TrajectoryBuilder_CompareHitY
@@ -76,7 +76,7 @@ class CosmicTrajectoryBuilder {
   typedef TrajectoryMeasurement TM;
 
 public:
-  CosmicTrajectoryBuilder(const edm::ParameterSet &conf);
+  CosmicTrajectoryBuilder(const edm::ParameterSet &conf, edm::ConsumesCollector iC);
   ~CosmicTrajectoryBuilder();
 
   /// Runs the algorithm
@@ -112,8 +112,11 @@ private:
   bool qualityFilter(const Trajectory &traj);
 
 private:
-  edm::ESHandle<MagneticField> magfield;
-  edm::ESHandle<TrackerGeometry> tracker;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magfieldToken_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerToken_;
+  const edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> builderToken_;
+  const MagneticField *magfield;
+  const TrackerGeometry *tracker;
 
   PropagatorWithMaterial *thePropagator;
   PropagatorWithMaterial *thePropagatorOp;
@@ -131,7 +134,6 @@ private:
   TransientTrackingRecHit::RecHitContainer hits;
   bool seed_plus;
   std::string geometry;
-  std::string theBuilderName;
 };
 
 #endif

--- a/RecoTracker/SingleTrackPattern/src/CosmicTrackFinder.cc
+++ b/RecoTracker/SingleTrackPattern/src/CosmicTrackFinder.cc
@@ -26,7 +26,7 @@
 namespace cms {
 
   CosmicTrackFinder::CosmicTrackFinder(edm::ParameterSet const& conf)
-      : cosmicTrajectoryBuilder_(conf), crackTrajectoryBuilder_(conf) {
+      : cosmicTrajectoryBuilder_(conf, consumesCollector()), crackTrajectoryBuilder_(conf, consumesCollector()) {
     geometry = conf.getUntrackedParameter<std::string>("GeometricStructure", "STANDARD");
     useHitsSplitting_ = conf.getParameter<bool>("useHitsSplitting");
     matchedrecHitsToken_ =
@@ -76,8 +76,6 @@ namespace cms {
     // Step B: create empty output collection
     auto output = std::make_unique<TrackCandidateCollection>();
 
-    edm::ESHandle<TrackerGeometry> tracker;
-    es.get<TrackerDigiGeometryRecord>().get(tracker);
     edm::LogVerbatim("CosmicTrackFinder") << "========== Cosmic Track Finder Info ==========";
     edm::LogVerbatim("CosmicTrackFinder") << " Numbers of Seeds " << (*seed).size();
     if (!(*seed).empty()) {

--- a/RecoTracker/SpecialSeedGenerators/interface/SimpleCosmicBONSeeder.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/SimpleCosmicBONSeeder.h
@@ -63,9 +63,11 @@ public:
 
 private:
   edm::ParameterSet conf_;
-  std::string builderName;
 
-  edm::EDGetTokenT<SeedingLayerSetsHits> seedingLayerToken_;
+  const edm::EDGetTokenT<SeedingLayerSetsHits> seedingLayerToken_;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magfieldToken_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerToken_;
+  const edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> ttrhBuilderToken_;
   GlobalTrackingRegion region_;
   double pMin_;
   bool writeTriplets_;
@@ -75,9 +77,8 @@ private:
 
   uint32_t tripletsVerbosity_, seedVerbosity_, helixVerbosity_;
 
-  edm::ESHandle<MagneticField> magfield;
-  edm::ESHandle<TrackerGeometry> tracker;
-  edm::ESHandle<TransientTrackingRecHitBuilder> TTTRHBuilder;
+  const MagneticField *magfield;
+  const TrackerGeometry *tracker;
   TkClonerImpl cloner;  // FIXME
   KFUpdator *theUpdator;
   PropagatorWithMaterial *thePropagatorAl;

--- a/RecoTracker/SpecialSeedGenerators/src/OutsideInMuonSeeder.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/OutsideInMuonSeeder.cc
@@ -8,7 +8,6 @@
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
@@ -62,22 +61,23 @@ private:
   /// How much to rescale errors from STA
   const double errorRescaling_;
 
-  const std::string trackerPropagatorName_;
-  const std::string muonPropagatorName_;
-  edm::EDGetTokenT<MeasurementTrackerEvent> measurementTrackerTag_;
-  const std::string measurementTrackerName_;
-  const std::string estimatorName_;
-  const std::string updatorName_;
+  const edm::ESGetToken<Propagator, TrackingComponentsRecord> trackerPropagatorToken_;
+  const edm::ESGetToken<Propagator, TrackingComponentsRecord> muonPropagatorToken_;
+  const edm::EDGetTokenT<MeasurementTrackerEvent> measurementTrackerTag_;
+  const edm::ESGetToken<Chi2MeasurementEstimatorBase, TrackingComponentsRecord> estimatorToken_;
+  const edm::ESGetToken<TrajectoryStateUpdator, TrackingComponentsRecord> updatorToken_;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magfieldToken_;
+  const edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> geometryToken_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tkGeometryToken_;
 
   float const minEtaForTEC_;
   float const maxEtaForTOB_;
 
-  edm::ESHandle<MagneticField> magfield_;
-  edm::ESHandle<Propagator> muonPropagator_;
-  edm::ESHandle<Propagator> trackerPropagator_;
-  edm::ESHandle<GlobalTrackingGeometry> geometry_;
-  edm::ESHandle<Chi2MeasurementEstimatorBase> estimator_;
-  edm::ESHandle<TrajectoryStateUpdator> updator_;
+  const MagneticField* magfield_;
+  const Propagator* muonPropagator_;
+  const GlobalTrackingGeometry* geometry_;
+  const Chi2MeasurementEstimatorBase* estimator_;
+  const TrajectoryStateUpdator* updator_;
 
   /// Dump deug information
   const bool debug_;
@@ -98,11 +98,14 @@ OutsideInMuonSeeder::OutsideInMuonSeeder(const edm::ParameterSet &iConfig)
       hitsToTry_(iConfig.getParameter<int32_t>("hitsToTry")),
       fromVertex_(iConfig.getParameter<bool>("fromVertex")),
       errorRescaling_(iConfig.getParameter<double>("errorRescaleFactor")),
-      trackerPropagatorName_(iConfig.getParameter<std::string>("trackerPropagator")),
-      muonPropagatorName_(iConfig.getParameter<std::string>("muonPropagator")),
+      trackerPropagatorToken_(esConsumes(edm::ESInputTag("", iConfig.getParameter<std::string>("trackerPropagator")))),
+  muonPropagatorToken_(esConsumes(edm::ESInputTag("", iConfig.getParameter<std::string>("muonPropagator")))),
       measurementTrackerTag_(consumes<MeasurementTrackerEvent>(edm::InputTag("MeasurementTrackerEvent"))),
-      estimatorName_(iConfig.getParameter<std::string>("hitCollector")),
-      updatorName_("KFUpdator"),
+  estimatorToken_(esConsumes(edm::ESInputTag("", iConfig.getParameter<std::string>("hitCollector")))),
+  updatorToken_(esConsumes(edm::ESInputTag("", "KFUpdator"))),
+  magfieldToken_(esConsumes()),
+  geometryToken_(esConsumes()),
+  tkGeometryToken_(esConsumes()),
       minEtaForTEC_(iConfig.getParameter<double>("minEtaForTEC")),
       maxEtaForTOB_(iConfig.getParameter<double>("maxEtaForTOB")),
       debug_(iConfig.getUntrackedParameter<bool>("debug", false)) {
@@ -113,18 +116,17 @@ void OutsideInMuonSeeder::produce(edm::Event &iEvent, const edm::EventSetup &iSe
   using namespace edm;
   using namespace std;
 
-  iSetup.get<IdealMagneticFieldRecord>().get(magfield_);
-  iSetup.get<TrackingComponentsRecord>().get(trackerPropagatorName_, trackerPropagator_);
-  iSetup.get<TrackingComponentsRecord>().get(muonPropagatorName_, muonPropagator_);
-  iSetup.get<GlobalTrackingGeometryRecord>().get(geometry_);
-  iSetup.get<TrackingComponentsRecord>().get(estimatorName_, estimator_);
-  iSetup.get<TrackingComponentsRecord>().get(updatorName_, updator_);
+  magfield_ = &iSetup.getData(magfieldToken_);
+  auto const& trackerPropagator = iSetup.getData(trackerPropagatorToken_);
+  muonPropagator_ = &iSetup.getData(muonPropagatorToken_);
+  geometry_ = &iSetup.getData(geometryToken_);
+  estimator_ = &iSetup.getData(estimatorToken_);
+  updator_ = &iSetup.getData(updatorToken_);
 
   Handle<MeasurementTrackerEvent> measurementTracker;
   iEvent.getByToken(measurementTrackerTag_, measurementTracker);
 
-  ESHandle<TrackerGeometry> tmpTkGeometry;
-  iSetup.get<TrackerDigiGeometryRecord>().get(tmpTkGeometry);
+  const auto& tmpTkGeometry = iSetup.getData(tkGeometryToken_);
 
   Handle<View<reco::Muon>> src;
   iEvent.getByToken(src_, src);
@@ -142,7 +144,7 @@ void OutsideInMuonSeeder::produce(edm::Event &iEvent, const edm::EventSetup &iSe
     // very same direction every single time.
     std::unique_ptr<Propagator> pmuon_cloned =
         SetPropagationDirection(*muonPropagator_, fromVertex_ ? alongMomentum : oppositeToMomentum);
-    std::unique_ptr<Propagator> ptracker_cloned = SetPropagationDirection(*trackerPropagator_, alongMomentum);
+    std::unique_ptr<Propagator> ptracker_cloned = SetPropagationDirection(trackerPropagator, alongMomentum);
 
     int sizeBefore = out->size();
     if (debug_)
@@ -151,8 +153,8 @@ void OutsideInMuonSeeder::produce(edm::Event &iEvent, const edm::EventSetup &iSe
     const reco::Track &tk = *mu.outerTrack();
 
     TrajectoryStateOnSurface state =
-        fromVertex_ ? TrajectoryStateOnSurface(trajectoryStateTransform::initialFreeState(tk, magfield_.product()))
-                    : trajectoryStateTransform::innerStateOnSurface(tk, *geometry_, magfield_.product());
+        fromVertex_ ? TrajectoryStateOnSurface(trajectoryStateTransform::initialFreeState(tk, magfield_))
+                    : trajectoryStateTransform::innerStateOnSurface(tk, *geometry_, magfield_);
 
     if (std::abs(tk.eta()) < maxEtaForTOB_) {
       std::vector<BarrelDetLayer const *> const &tob = measurementTracker->geometricSearchTracker()->tobLayers();
@@ -171,10 +173,10 @@ void OutsideInMuonSeeder::produce(edm::Event &iEvent, const edm::EventSetup &iSe
       }
     }
     if (tk.eta() > minEtaForTEC_) {
-      const auto &forwLayers = tmpTkGeometry->isThere(GeomDetEnumerators::P2OTEC)
+      const auto &forwLayers = tmpTkGeometry.isThere(GeomDetEnumerators::P2OTEC)
                                    ? measurementTracker->geometricSearchTracker()->posTidLayers()
                                    : measurementTracker->geometricSearchTracker()->posTecLayers();
-      if (tmpTkGeometry->isThere(GeomDetEnumerators::P2OTEC)) {
+      if (tmpTkGeometry.isThere(GeomDetEnumerators::P2OTEC)) {
         LogDebug("OutsideInMuonSeeder") << "\n We are using the Phase2 Outer Tracker (defined as a TID+). ";
       }
       LogTrace("OutsideInMuonSeeder") << "\n ==== TEC+ tot layers " << forwLayers.size() << " ====" << std::endl;
@@ -195,10 +197,10 @@ void OutsideInMuonSeeder::produce(edm::Event &iEvent, const edm::EventSetup &iSe
       }
     }
     if (tk.eta() < -minEtaForTEC_) {
-      const auto &forwLayers = tmpTkGeometry->isThere(GeomDetEnumerators::P2OTEC)
+      const auto &forwLayers = tmpTkGeometry.isThere(GeomDetEnumerators::P2OTEC)
                                    ? measurementTracker->geometricSearchTracker()->negTidLayers()
                                    : measurementTracker->geometricSearchTracker()->negTecLayers();
-      if (tmpTkGeometry->isThere(GeomDetEnumerators::P2OTEC)) {
+      if (tmpTkGeometry.isThere(GeomDetEnumerators::P2OTEC)) {
         LogDebug("OutsideInMuonSeeder") << "\n We are using the Phase2 Outer Tracker (defined as a TID-). ";
       }
       LogTrace("OutsideInMuonSeeder") << "\n ==== TEC- tot layers " << forwLayers.size() << " ====" << std::endl;
@@ -295,7 +297,7 @@ int OutsideInMuonSeeder::doLayer(const GeometricSearchDet &layer,
 }
 
 void OutsideInMuonSeeder::doDebug(const reco::Track &tk) const {
-  TrajectoryStateOnSurface tsos = trajectoryStateTransform::innerStateOnSurface(tk, *geometry_, &*magfield_);
+  TrajectoryStateOnSurface tsos = trajectoryStateTransform::innerStateOnSurface(tk, *geometry_, magfield_);
   std::unique_ptr<Propagator> pmuon_cloned = SetPropagationDirection(*muonPropagator_, alongMomentum);
   for (unsigned int i = 0; i < tk.recHitsSize(); ++i) {
     const TrackingRecHit *hit = &*tk.recHit(i);

--- a/RecoTracker/SpecialSeedGenerators/src/OutsideInMuonSeeder.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/OutsideInMuonSeeder.cc
@@ -73,11 +73,11 @@ private:
   float const minEtaForTEC_;
   float const maxEtaForTOB_;
 
-  const MagneticField* magfield_;
-  const Propagator* muonPropagator_;
-  const GlobalTrackingGeometry* geometry_;
-  const Chi2MeasurementEstimatorBase* estimator_;
-  const TrajectoryStateUpdator* updator_;
+  const MagneticField *magfield_;
+  const Propagator *muonPropagator_;
+  const GlobalTrackingGeometry *geometry_;
+  const Chi2MeasurementEstimatorBase *estimator_;
+  const TrajectoryStateUpdator *updator_;
 
   /// Dump deug information
   const bool debug_;
@@ -99,13 +99,13 @@ OutsideInMuonSeeder::OutsideInMuonSeeder(const edm::ParameterSet &iConfig)
       fromVertex_(iConfig.getParameter<bool>("fromVertex")),
       errorRescaling_(iConfig.getParameter<double>("errorRescaleFactor")),
       trackerPropagatorToken_(esConsumes(edm::ESInputTag("", iConfig.getParameter<std::string>("trackerPropagator")))),
-  muonPropagatorToken_(esConsumes(edm::ESInputTag("", iConfig.getParameter<std::string>("muonPropagator")))),
+      muonPropagatorToken_(esConsumes(edm::ESInputTag("", iConfig.getParameter<std::string>("muonPropagator")))),
       measurementTrackerTag_(consumes<MeasurementTrackerEvent>(edm::InputTag("MeasurementTrackerEvent"))),
-  estimatorToken_(esConsumes(edm::ESInputTag("", iConfig.getParameter<std::string>("hitCollector")))),
-  updatorToken_(esConsumes(edm::ESInputTag("", "KFUpdator"))),
-  magfieldToken_(esConsumes()),
-  geometryToken_(esConsumes()),
-  tkGeometryToken_(esConsumes()),
+      estimatorToken_(esConsumes(edm::ESInputTag("", iConfig.getParameter<std::string>("hitCollector")))),
+      updatorToken_(esConsumes(edm::ESInputTag("", "KFUpdator"))),
+      magfieldToken_(esConsumes()),
+      geometryToken_(esConsumes()),
+      tkGeometryToken_(esConsumes()),
       minEtaForTEC_(iConfig.getParameter<double>("minEtaForTEC")),
       maxEtaForTOB_(iConfig.getParameter<double>("maxEtaForTOB")),
       debug_(iConfig.getUntrackedParameter<bool>("debug", false)) {
@@ -117,7 +117,7 @@ void OutsideInMuonSeeder::produce(edm::Event &iEvent, const edm::EventSetup &iSe
   using namespace std;
 
   magfield_ = &iSetup.getData(magfieldToken_);
-  auto const& trackerPropagator = iSetup.getData(trackerPropagatorToken_);
+  auto const &trackerPropagator = iSetup.getData(trackerPropagatorToken_);
   muonPropagator_ = &iSetup.getData(muonPropagatorToken_);
   geometry_ = &iSetup.getData(geometryToken_);
   estimator_ = &iSetup.getData(estimatorToken_);
@@ -126,7 +126,7 @@ void OutsideInMuonSeeder::produce(edm::Event &iEvent, const edm::EventSetup &iSe
   Handle<MeasurementTrackerEvent> measurementTracker;
   iEvent.getByToken(measurementTrackerTag_, measurementTracker);
 
-  const auto& tmpTkGeometry = iSetup.getData(tkGeometryToken_);
+  const auto &tmpTkGeometry = iSetup.getData(tkGeometryToken_);
 
   Handle<View<reco::Muon>> src;
   iEvent.getByToken(src_, src);

--- a/RecoTracker/TkSeedGenerator/plugins/DeepCoreSeedGenerator.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/DeepCoreSeedGenerator.cc
@@ -99,27 +99,24 @@ public:
   static constexpr int Npar = 5;      //Number of track parameter
 
 private:
-  void beginJob();
   void produce(edm::Event&, const edm::EventSetup&) override;
-  void endJob();
 
   // ----------member data ---------------------------
   std::string propagatorName_;
-  edm::ESHandle<MagneticField> magfield_;
-  edm::ESHandle<GlobalTrackingGeometry> geometry_;
-  edm::ESHandle<Propagator> propagator_;
+  const GlobalTrackingGeometry* geometry_ = nullptr;
 
   edm::EDGetTokenT<std::vector<reco::Vertex>> vertices_;
   edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster>> pixelClusters_;
   edm::Handle<edmNew::DetSetVector<SiPixelCluster>> inputPixelClusters_;
   edm::EDGetTokenT<edm::View<reco::Candidate>> cores_;
+  const edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> geometryToken_;
+  const edm::ESGetToken<PixelClusterParameterEstimator, TkPixelCPERecord> pixelCPEToken_;
   const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
 
   double ptMin_;
   double deltaR_;
   double chargeFracMin_;
   double centralMIPCharge_;
-  std::string pixelCPE_;
   std::string weightfilename_;
   std::vector<std::string> inputTensorName_;
   std::vector<std::string> outputTensorName_;
@@ -166,12 +163,13 @@ DeepCoreSeedGenerator::DeepCoreSeedGenerator(const edm::ParameterSet& iConfig, c
       pixelClusters_(
           consumes<edmNew::DetSetVector<SiPixelCluster>>(iConfig.getParameter<edm::InputTag>("pixelClusters"))),
       cores_(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("cores"))),
+      geometryToken_(esConsumes()),
+      pixelCPEToken_(esConsumes(edm::ESInputTag("", iConfig.getParameter<std::string>("pixelCPE")))),
       topoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd>()),
       ptMin_(iConfig.getParameter<double>("ptMin")),
       deltaR_(iConfig.getParameter<double>("deltaR")),
       chargeFracMin_(iConfig.getParameter<double>("chargeFractionMin")),
       centralMIPCharge_(iConfig.getParameter<double>("centralMIPCharge")),
-      pixelCPE_(iConfig.getParameter<std::string>("pixelCPE")),
       weightfilename_(iConfig.getParameter<edm::FileInPath>("weightFile").fullPath()),
       inputTensorName_(iConfig.getParameter<std::vector<std::string>>("inputTensorName")),
       outputTensorName_(iConfig.getParameter<std::vector<std::string>>("outputTensorName")),
@@ -199,18 +197,13 @@ void DeepCoreSeedGenerator::produce(edm::Event& iEvent, const edm::EventSetup& i
   using namespace edm;
   using namespace reco;
 
-  iSetup.get<IdealMagneticFieldRecord>().get(magfield_);
-  iSetup.get<GlobalTrackingGeometryRecord>().get(geometry_);
-  iSetup.get<TrackingComponentsRecord>().get("AnalyticalPropagator", propagator_);
+  geometry_ = &iSetup.getData(geometryToken_);
 
   const auto& inputPixelClusters_ = iEvent.get(pixelClusters_);
   const auto& vertices = iEvent.get(vertices_);
   const auto& cores = iEvent.get(cores_);
 
-  edm::ESHandle<PixelClusterParameterEstimator> pixelCPEhandle;
-  const PixelClusterParameterEstimator* pixelCPE;
-  iSetup.get<TkPixelCPERecord>().get(pixelCPE_, pixelCPEhandle);
-  pixelCPE = pixelCPEhandle.product();
+  const PixelClusterParameterEstimator* pixelCPE = &iSetup.getData(pixelCPEToken_);
 
   const TrackerTopology* const tTopo = &iSetup.getData(topoToken_);
   auto output = std::make_unique<edmNew::DetSetVector<SiPixelCluster>>();
@@ -548,12 +541,6 @@ std::unique_ptr<DeepCoreCache> DeepCoreSeedGenerator::initializeGlobalCache(cons
 }
 
 void DeepCoreSeedGenerator::globalEndJob(DeepCoreCache* cache) { delete cache->graph_def; }
-
-// ------------ method called once each job just before starting event loop  ------------
-void DeepCoreSeedGenerator::beginJob() {}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void DeepCoreSeedGenerator::endJob() {}
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void DeepCoreSeedGenerator::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/RecoTracker/TkSeedingLayers/interface/SeedingLayerSetsBuilder.h
+++ b/RecoTracker/TkSeedingLayers/interface/SeedingLayerSetsBuilder.h
@@ -36,7 +36,6 @@ class SeedingLayerSetsBuilder {
 public:
   using SeedingLayerId = std::tuple<GeomDetEnumerators::SubDetector, TrackerDetSide, int>;
 
-  SeedingLayerSetsBuilder() = default;
   SeedingLayerSetsBuilder(const edm::ParameterSet& cfg,
                           edm::ConsumesCollector& iC,
                           const edm::InputTag& fastsimHitTag);  //FastSim specific constructor

--- a/RecoTracker/TkSeedingLayers/interface/SeedingLayerSetsBuilder.h
+++ b/RecoTracker/TkSeedingLayers/interface/SeedingLayerSetsBuilder.h
@@ -27,6 +27,10 @@ class TrackerRecoGeometryRecord;
 class TransientRecHitRecord;
 class TransientTrackingRecHitBuilder;
 class DetLayer;
+class TrackerTopology;
+class TrackerTopologyRcd;
+class GeometricSearchTracker;
+class TrackerRecoGeometryRecord;
 
 class SeedingLayerSetsBuilder {
 public:
@@ -68,6 +72,8 @@ private:
   edm::ESWatcher<TrackerRecoGeometryRecord> geometryWatcher_;
   edm::ESWatcher<TransientRecHitRecord> trhWatcher_;
   edm::EDGetTokenT<FastTrackerRecHitCollection> fastSimrecHitsToken_;
+  const edm::ESGetToken<GeometricSearchTracker, TrackerRecoGeometryRecord> trackerToken_;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopologyToken_;
   struct LayerSpec {
     LayerSpec(unsigned short index,
               const std::string& layerName,
@@ -82,6 +88,7 @@ private:
     std::string pixelHitProducer;
     bool usePixelHitProducer;
     const std::string hitBuilder;
+    const edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> hitBuilderToken;
 
     GeomDetEnumerators::SubDetector subdet;
     TrackerDetSide side;

--- a/RecoTracker/TkSeedingLayers/src/HitExtractorPIX.cc
+++ b/RecoTracker/TkSeedingLayers/src/HitExtractorPIX.cc
@@ -1,13 +1,10 @@
 #include "HitExtractorPIX.h"
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "TrackingTools/DetLayers/interface/DetLayer.h"
 
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/Event.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 
 #include <iostream>
 using namespace ctfseeding;
@@ -17,7 +14,10 @@ HitExtractorPIX::HitExtractorPIX(TrackerDetSide side,
                                  int idLayer,
                                  const std::string& hitProducer,
                                  edm::ConsumesCollector& iC)
-    : theHitProducer(iC.consumes<SiPixelRecHitCollection>(hitProducer)), theSide(side), theIdLayer(idLayer) {}
+    : theHitProducer(iC.consumes<SiPixelRecHitCollection>(hitProducer)),
+      theTtopo(iC.esConsumes()),
+      theSide(side),
+      theIdLayer(idLayer) {}
 
 void HitExtractorPIX::useSkipClusters_(const edm::InputTag& m, edm::ConsumesCollector& iC) {
   theSkipClusters = iC.consumes<SkipClustersCollection>(m);
@@ -28,9 +28,7 @@ HitExtractor::Hits HitExtractorPIX::hits(const TkTransientTrackingRecHitBuilder&
                                          const edm::EventSetup& es) const {
   HitExtractor::Hits result;
 
-  edm::ESHandle<TrackerTopology> httopo;
-  es.get<TrackerTopologyRcd>().get(httopo);
-  const TrackerTopology& ttopo = *httopo;
+  const TrackerTopology& ttopo = es.getData(theTtopo);
 
   edm::Handle<SiPixelRecHitCollection> pixelHits;
   ev.getByToken(theHitProducer, pixelHits);

--- a/RecoTracker/TkSeedingLayers/src/HitExtractorPIX.h
+++ b/RecoTracker/TkSeedingLayers/src/HitExtractorPIX.h
@@ -9,6 +9,8 @@
 
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
 namespace ctfseeding {
   class HitExtractorPIX final : public HitExtractor {
@@ -26,6 +28,7 @@ namespace ctfseeding {
 
     edm::EDGetTokenT<SkipClustersCollection> theSkipClusters;
     edm::EDGetTokenT<SiPixelRecHitCollection> theHitProducer;
+    edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> theTtopo;
     TrackerDetSide theSide;
     int theIdLayer;
   };

--- a/RecoTracker/TkSeedingLayers/src/HitExtractorSTRP.cc
+++ b/RecoTracker/TkSeedingLayers/src/HitExtractorSTRP.cc
@@ -1,21 +1,15 @@
 #include "HitExtractorSTRP.h"
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "TrackingTools/DetLayers/interface/DetLayer.h"
 
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/Event.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 
 #include "DataFormats/Common/interface/ContainerMask.h"
 
 #include "TrackingTools/TransientTrackingRecHit/interface/TrackingRecHitProjector.h"
 #include "RecoTracker/TransientTrackingRecHit/interface/ProjectedRecHit2D.h"
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "Geometry/Records/interface/TrackerTopologyRcd.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/SiStripCluster/interface/SiStripClusterTools.h"
 
 #include <tuple>
@@ -29,13 +23,15 @@ using namespace edm;
 HitExtractorSTRP::HitExtractorSTRP(GeomDetEnumerators::SubDetector subdet,
                                    TrackerDetSide side,
                                    int idLayer,
-                                   float iminGoodCharge)
+                                   float iminGoodCharge,
+                                   edm::ConsumesCollector& iC)
     : theLayerSubDet(subdet),
       theSide(side),
       theIdLayer(idLayer),
       minAbsZ(0),
       theMinRing(1),
       theMaxRing(0),
+      theTtopo(iC.esConsumes()),
       hasMatchedHits(false),
       hasRPhiHits(false),
       hasStereoHits(false),
@@ -190,9 +186,7 @@ HitExtractor::Hits HitExtractorSTRP::hits(const TkTransientTrackingRecHitBuilder
   unsigned int cleanFrom = 0;
 
   //Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  es.get<TrackerTopologyRcd>().get(tTopoHandle);
-  const TrackerTopology* const tTopo = tTopoHandle.product();
+  const TrackerTopology* const tTopo = &es.getData(theTtopo);
 
   //
   // TIB

--- a/RecoTracker/TkSeedingLayers/src/HitExtractorSTRP.h
+++ b/RecoTracker/TkSeedingLayers/src/HitExtractorSTRP.h
@@ -9,6 +9,8 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2DCollection.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2DCollection.h"
 #include "DataFormats/TrackerRecHit2D/interface/VectorHit.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
 #include <vector>
 #include <tuple>
@@ -25,7 +27,11 @@ namespace ctfseeding {
   public:
     typedef SiStripRecHit2D::ClusterRef SiStripClusterRef;
 
-    HitExtractorSTRP(GeomDetEnumerators::SubDetector subdet, TrackerDetSide side, int idLayer, float iminGoodCharge);
+    HitExtractorSTRP(GeomDetEnumerators::SubDetector subdet,
+                     TrackerDetSide side,
+                     int idLayer,
+                     float iminGoodCharge,
+                     edm::ConsumesCollector& iC);
     ~HitExtractorSTRP() override {}
 
     HitExtractor::Hits hits(const TkTransientTrackingRecHitBuilder& ttrhBuilder,
@@ -93,6 +99,7 @@ namespace ctfseeding {
     edm::EDGetTokenT<SiStripRecHit2DCollection> theRPhiHits;
     edm::EDGetTokenT<SiStripRecHit2DCollection> theStereoHits;
     edm::EDGetTokenT<VectorHitCollection> theVectorHits;
+    edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> theTtopo;
     bool hasMatchedHits;
     bool hasRPhiHits;
     bool hasStereoHits;

--- a/RecoTracker/TkTrackingRegions/plugins/PixelInactiveAreaFinder.h
+++ b/RecoTracker/TkTrackingRegions/plugins/PixelInactiveAreaFinder.h
@@ -8,6 +8,8 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/VecArray.h"
+#include "CondFormats/DataRecord/interface/SiPixelQualityRcd.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 
 #include "AreaSeededTrackingRegionsBuilder.h"
@@ -87,6 +89,9 @@ private:
 
   std::vector<edm::EDGetTokenT<DetIdCollection> > inactivePixelDetectorTokens_;
   std::vector<edm::EDGetTokenT<PixelFEDChannelCollection> > badPixelFEDChannelsTokens_;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeometryToken_;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopologyToken_;
+  edm::ESGetToken<SiPixelQuality, SiPixelQualityRcd> pixelQualityToken_;
 
   // Output type aliases
   using DetGroupSpanContainerPair = std::pair<DetGroupSpanContainer, DetGroupSpanContainer>;


### PR DESCRIPTION
#### PR description:

Part of #31061. These are fairly straightforward ones, and should cover the following modules
* `SeedingLayersEDProducer`
* `PixelInactiveAreaTrackingRegionsSeedingLayersProducer`
* `DeepCoreSeedGenerator`
* `OutsideInMuonSeeder`
* `SimpleCosmicBONSeeder`
* `cms::CosmicTrackFinder`
* `MeasurementTrackerEventProducer`

#### PR validation:

~~Code compiles.~~ Limited matrix runs.