### PR TITLE
[12.0.X] do not produce NaNs in SiPixelActionExecutor

### DIFF
--- a/DQM/SiPixelMonitorClient/src/SiPixelActionExecutor.cc
+++ b/DQM/SiPixelMonitorClient/src/SiPixelActionExecutor.cc
@@ -1875,9 +1875,9 @@ void SiPixelActionExecutor::normaliseAvDigiOcc(DQMStore::IBooker &iBooker, DQMSt
   float averageFPIXOcc = totalDigisFPIX / 8.;
   for (int i = 1; i != 41; i++) {
     if (i < 33)
-      roccupancyPlot->setBinContent(i, roccupancyPlot->getBinContent(i) / averageBPIXOcc);
+      roccupancyPlot->setBinContent(i, averageBPIXOcc != 0. ? roccupancyPlot->getBinContent(i) / averageBPIXOcc : 0.);
     else
-      roccupancyPlot->setBinContent(i, roccupancyPlot->getBinContent(i) / averageFPIXOcc);
+      roccupancyPlot->setBinContent(i, averageFPIXOcc != 0. ? roccupancyPlot->getBinContent(i) / averageFPIXOcc : 0.);
   }
 
   iGetter.setCurrentFolder(iBooker.pwd());
@@ -1903,10 +1903,13 @@ void SiPixelActionExecutor::normaliseAvDigiOccVsLumi(DQMStore::IBooker &iBooker,
   float averageBPIXOcc = totalDigisBPIX / 32.;
   float averageFPIXOcc = totalDigisFPIX / 8.;
   for (int i = 1; i != 41; i++) {
-    if (i < 33)
-      avgfedDigiOccvsLumi->setBinContent(lumisec, i, avgfedDigiOccvsLumi->getBinContent(lumisec, i) / averageBPIXOcc);
-    else
-      avgfedDigiOccvsLumi->setBinContent(lumisec, i, avgfedDigiOccvsLumi->getBinContent(lumisec, i) / averageFPIXOcc);
+    if (i < 33) {
+      avgfedDigiOccvsLumi->setBinContent(
+          lumisec, i, averageBPIXOcc != 0. ? avgfedDigiOccvsLumi->getBinContent(lumisec, i) / averageBPIXOcc : 0.);
+    } else {
+      avgfedDigiOccvsLumi->setBinContent(
+          lumisec, i, averageFPIXOcc != 0. ? avgfedDigiOccvsLumi->getBinContent(lumisec, i) / averageFPIXOcc : 0.);
+    }
   }
 
   iGetter.setCurrentFolder(iBooker.pwd());

--- a/DQM/SiPixelMonitorDigi/src/SiPixelDigiSource.cc
+++ b/DQM/SiPixelMonitorDigi/src/SiPixelDigiSource.cc
@@ -137,11 +137,12 @@ void SiPixelDigiSource::globalEndLuminosityBlock(const edm::LuminosityBlock& lb,
           averageDigiOccupancy->Fill(
               i,
               averageOcc);  // "modOn" basically mean Online DQM, in this case fill histos with actual value of digi fraction per fed for each ten lumisections
-        if (avgfedDigiOccvsLumi && thisls % 5 == 0)
+        if (avgfedDigiOccvsLumi && thisls % 5 == 0) {
           avgfedDigiOccvsLumi->setBinContent(
               int(thisls / 5),
               i + 1,
               averageOcc);  //fill with the mean over 5 lumisections, previous code was filling this histo only with last event of each 10th lumisection
+        }
       }
     }
 


### PR DESCRIPTION
backport of #34900

#### PR description:

Title says is all, related to issue https://github.com/cms-sw/cmssw/issues/34890

#### PR validation:

Run wf 8.0 with `runTheMatrix.py -l 8.0 -j 8` and inspected output DQM ROOT file.

| averageDigiOccupancy | avgfedDigiOccvsLumi |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/5082376/129624168-f54f6b82-b116-4c84-97cf-2e25f29066a5.png)  | ![image](https://user-images.githubusercontent.com/5082376/129624199-61022db7-6271-42a2-a154-2680f738dd40.png) |

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

backport of #34900