### PR TITLE
Better reporting of CPU timing

### DIFF
--- a/FWCore/Framework/interface/SystemTimeKeeper.h
+++ b/FWCore/Framework/interface/SystemTimeKeeper.h
@@ -26,6 +26,7 @@
 
 // user include files
 #include "FWCore/Utilities/interface/CPUTimer.h"
+#include "FWCore/Utilities/interface/ChildrenCPUTimer.h"
 #include "FWCore/Utilities/interface/WallclockTimer.h"
 
 // forward declarations
@@ -106,6 +107,7 @@ namespace edm {
     std::vector<std::vector<std::string>> m_modulesOnPaths;
 
     CPUTimer m_processingLoopTimer;
+    ChildrenCPUTimer m_processingLoopChildrenTimer;
     ProcessContext const* m_processContext;
 
     unsigned int m_minModuleID;

--- a/FWCore/Framework/src/SystemTimeKeeper.cc
+++ b/FWCore/Framework/src/SystemTimeKeeper.cc
@@ -202,9 +202,15 @@ void SystemTimeKeeper::restartModuleEvent(StreamContext const& iStream, ModuleCa
   }
 }
 
-void SystemTimeKeeper::startProcessingLoop() { m_processingLoopTimer.start(); }
+void SystemTimeKeeper::startProcessingLoop() {
+  m_processingLoopTimer.start();
+  m_processingLoopChildrenTimer.start();
+}
 
-void SystemTimeKeeper::stopProcessingLoop() { m_processingLoopTimer.stop(); }
+void SystemTimeKeeper::stopProcessingLoop() {
+  m_processingLoopTimer.stop();
+  m_processingLoopChildrenTimer.stop();
+}
 
 static void fillPathSummary(unsigned int iStartIndex,
                             unsigned int iEndIndex,
@@ -248,7 +254,7 @@ void SystemTimeKeeper::fillTriggerTimingReport(TriggerTimingReport& rep) const {
       sumEventTime += stream.realTime();
     }
     rep.eventSummary.realTime = m_processingLoopTimer.realTime();
-    rep.eventSummary.cpuTime = m_processingLoopTimer.cpuTime();
+    rep.eventSummary.cpuTime = m_processingLoopTimer.cpuTime() + m_processingLoopChildrenTimer.cpuTime();
     rep.eventSummary.sumStreamRealTime = sumEventTime;
   }
 

--- a/FWCore/Utilities/interface/ChildrenCPUTimer.h
+++ b/FWCore/Utilities/interface/ChildrenCPUTimer.h
@@ -1,0 +1,59 @@
+#ifndef FWCore_Utilities_ChildrenCPUTimer_h
+#define FWCore_Utilities_ChildrenCPUTimer_h
+// -*- C++ -*-
+//
+// Package:     Utilities
+// Class  :     ChildrenCPUTimer
+//
+/**\class ChildrenCPUTimer ChildrenCPUTimer.h FWCore/Utilities/interface/ChildrenCPUTimer.h
+
+ Description: Timer which measures the CPU time for child processes
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Sun Apr 16 20:32:13 EDT 2006
+//
+
+// system include files
+#include <sys/time.h>
+
+// user include files
+
+// forward declarations
+namespace edm {
+  class ChildrenCPUTimer {
+  public:
+    ChildrenCPUTimer();
+    ~ChildrenCPUTimer();
+    ChildrenCPUTimer(ChildrenCPUTimer&&) = default;
+    ChildrenCPUTimer(const ChildrenCPUTimer&) = delete;
+    ChildrenCPUTimer& operator=(const ChildrenCPUTimer&) = delete;
+
+    // ---------- const member functions ---------------------
+    double cpuTime() const;
+
+    // ---------- static member functions --------------------
+
+    // ---------- member functions ---------------------------
+    void start();
+    double stop();  //returns delta time
+    void reset();
+
+    void add(double t);
+
+  private:
+    double calculateDeltaTime() const;
+
+    // ---------- member data --------------------------------
+    enum State { kRunning, kStopped } state_;
+    struct timeval startCPUTime_;
+
+    double accumulatedCPUTime_;
+  };
+}  // namespace edm
+
+#endif

--- a/FWCore/Utilities/src/ChildrenCPUTimer.cc
+++ b/FWCore/Utilities/src/ChildrenCPUTimer.cc
@@ -1,0 +1,110 @@
+// -*- C++ -*-
+//
+// Package:     Utilities
+// Class  :     ChildrenCPUTimer
+//
+// Implementation:
+//     <Notes on implementation>
+//
+// Original Author:  Chris Jones
+//         Created:  Sun Apr 16 20:32:20 EDT 2006
+//
+
+// system include files
+#include <sys/resource.h>
+#include <cerrno>
+
+// user include files
+#include "FWCore/Utilities/interface/ChildrenCPUTimer.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+//
+// constants, enums and typedefs
+//
+using namespace edm;
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+ChildrenCPUTimer::ChildrenCPUTimer() : state_(kStopped), startCPUTime_(), accumulatedCPUTime_(0) {
+  startCPUTime_.tv_sec = 0;
+  startCPUTime_.tv_usec = 0;
+}
+
+// ChildrenCPUTimer::ChildrenCPUTimer(ChildrenCPUTimer const& rhs) {
+//    // do actual copying here;
+// }
+
+ChildrenCPUTimer::~ChildrenCPUTimer() {}
+
+//
+// assignment operators
+//
+// ChildrenCPUTimer const& ChildrenCPUTimer::operator=(ChildrenCPUTimer const& rhs) {
+//   //An exception safe implementation is
+//   ChildrenCPUTimer temp(rhs);
+//   swap(rhs);
+//
+//   return *this;
+// }
+
+//
+// member functions
+//
+void ChildrenCPUTimer::start() {
+  if (kStopped == state_) {
+    rusage theUsage;
+    if (0 != getrusage(RUSAGE_CHILDREN, &theUsage)) {
+      throw cms::Exception("ChildrenCPUTimerFailed") << errno;
+    }
+    startCPUTime_.tv_sec = theUsage.ru_stime.tv_sec + theUsage.ru_utime.tv_sec;
+    startCPUTime_.tv_usec = theUsage.ru_stime.tv_usec + theUsage.ru_utime.tv_usec;
+    state_ = kRunning;
+  }
+}
+
+double ChildrenCPUTimer::stop() {
+  if (kRunning == state_) {
+    auto t = calculateDeltaTime();
+    accumulatedCPUTime_ += t;
+
+    state_ = kStopped;
+    return t;
+  }
+  return 0.;
+}
+
+void ChildrenCPUTimer::reset() { accumulatedCPUTime_ = 0; }
+
+void ChildrenCPUTimer::add(double t) { accumulatedCPUTime_ += t; }
+
+double ChildrenCPUTimer::calculateDeltaTime() const {
+  double returnValue;
+  double const microsecToSec = 1E-6;
+
+  rusage theUsage;
+  if (0 != getrusage(RUSAGE_CHILDREN, &theUsage)) {
+    throw cms::Exception("CPUTimerFailed") << errno;
+  }
+
+  returnValue = theUsage.ru_stime.tv_sec + theUsage.ru_utime.tv_sec - startCPUTime_.tv_sec +
+                microsecToSec * (theUsage.ru_stime.tv_usec + theUsage.ru_utime.tv_usec - startCPUTime_.tv_usec);
+  return returnValue;
+}
+//
+// const member functions
+//
+double ChildrenCPUTimer::cpuTime() const {
+  if (kStopped == state_) {
+    return accumulatedCPUTime_;
+  }
+  return accumulatedCPUTime_ + calculateDeltaTime();
+}
+
+//
+// static member functions
+//

--- a/FWCore/Utilities/src/ChildrenCPUTimer.cc
+++ b/FWCore/Utilities/src/ChildrenCPUTimer.cc
@@ -35,22 +35,7 @@ ChildrenCPUTimer::ChildrenCPUTimer() : state_(kStopped), startCPUTime_(), accumu
   startCPUTime_.tv_usec = 0;
 }
 
-// ChildrenCPUTimer::ChildrenCPUTimer(ChildrenCPUTimer const& rhs) {
-//    // do actual copying here;
-// }
-
 ChildrenCPUTimer::~ChildrenCPUTimer() {}
-
-//
-// assignment operators
-//
-// ChildrenCPUTimer const& ChildrenCPUTimer::operator=(ChildrenCPUTimer const& rhs) {
-//   //An exception safe implementation is
-//   ChildrenCPUTimer temp(rhs);
-//   swap(rhs);
-//
-//   return *this;
-// }
 
 //
 // member functions


### PR DESCRIPTION

#### PR description:

- The Timing service reported CPU time for child processes as part of the total CPU time, but not as part of the loop time.
- The timing summary did not account for child processes at all.

#### PR validation:

Code compiles.