### PR TITLE
Make operator functions 'hidden' friends of ExpressionAST

### DIFF
--- a/FastSimulation/TrackingRecHitProducer/interface/TrackerDetIdSelector.h
+++ b/FastSimulation/TrackingRecHitProducer/interface/TrackerDetIdSelector.h
@@ -15,7 +15,19 @@
 
 struct BinaryOP;
 struct UnaryOP;
+struct ExpressionAST;
 struct Nil {};
+
+namespace detail {
+  ExpressionAST opLesser(ExpressionAST const& lhs, ExpressionAST const& rhs);
+  ExpressionAST opLesserEq(ExpressionAST const& lhs, ExpressionAST const& rhs);
+  ExpressionAST opEq(ExpressionAST const& lhs, ExpressionAST const& rhs);
+  ExpressionAST opNotEq(ExpressionAST const& lhs, ExpressionAST const& rhs);
+  ExpressionAST opGreater(ExpressionAST const& lhs, ExpressionAST const& rhs);
+  ExpressionAST opGreaterEq(ExpressionAST const& lhs, ExpressionAST const& rhs);
+  ExpressionAST opAnd(ExpressionAST const& lhs, ExpressionAST const& rhs);
+  ExpressionAST opOr(ExpressionAST const& lhs, ExpressionAST const& rhs);
+}  // namespace detail
 
 struct ExpressionAST {
   typedef boost::variant<Nil,
@@ -36,16 +48,28 @@ struct ExpressionAST {
   ExpressionAST& operator!();
 
   Type expr;
-};
 
-ExpressionAST operator>(ExpressionAST const& lhs, ExpressionAST const& rhs);
-ExpressionAST operator>=(ExpressionAST const& lhs, ExpressionAST const& rhs);
-ExpressionAST operator==(ExpressionAST const& lhs, ExpressionAST const& rhs);
-ExpressionAST operator<=(ExpressionAST const& lhs, ExpressionAST const& rhs);
-ExpressionAST operator<(ExpressionAST const& lhs, ExpressionAST const& rhs);
-ExpressionAST operator!=(ExpressionAST const& lhs, ExpressionAST const& rhs);
-ExpressionAST operator&&(ExpressionAST const& lhs, ExpressionAST const& rhs);
-ExpressionAST operator||(ExpressionAST const& lhs, ExpressionAST const& rhs);
+  friend ExpressionAST operator>(ExpressionAST const& lhs, ExpressionAST const& rhs) {
+    return detail::opGreater(lhs, rhs);
+  }
+  friend ExpressionAST operator>=(ExpressionAST const& lhs, ExpressionAST const& rhs) {
+    return detail::opGreaterEq(lhs, rhs);
+  }
+  friend ExpressionAST operator==(ExpressionAST const& lhs, ExpressionAST const& rhs) { return detail::opEq(lhs, rhs); }
+  friend ExpressionAST operator!=(ExpressionAST const& lhs, ExpressionAST const& rhs) {
+    return detail::opNotEq(lhs, rhs);
+  }
+  friend ExpressionAST operator<(ExpressionAST const& lhs, ExpressionAST const& rhs) {
+    return detail::opLesser(lhs, rhs);
+  }
+  friend ExpressionAST operator<=(ExpressionAST const& lhs, ExpressionAST const& rhs) {
+    return detail::opLesserEq(lhs, rhs);
+  }
+  friend ExpressionAST operator&&(ExpressionAST const& lhs, ExpressionAST const& rhs) {
+    return detail::opAnd(lhs, rhs);
+  }
+  friend ExpressionAST operator||(ExpressionAST const& lhs, ExpressionAST const& rhs) { return detail::opOr(lhs, rhs); }
+};
 
 struct BinaryOP {
   enum class OP { GREATER, GREATER_EQUAL, EQUAL, LESS_EQUAL, LESS, NOT_EQUAL, AND, OR } op;

--- a/FastSimulation/TrackingRecHitProducer/src/TrackerDetIdSelector.cc
+++ b/FastSimulation/TrackingRecHitProducer/src/TrackerDetIdSelector.cc
@@ -80,46 +80,40 @@ const TrackerDetIdSelector::StringFunctionMap TrackerDetIdSelector::functionTabl
 }
 ;
 
-ExpressionAST operator>(ExpressionAST const& lhs, ExpressionAST const& rhs) {
-  ExpressionAST ast = BinaryOP(BinaryOP::OP::GREATER, lhs, rhs);
-  return ast;
-}
+namespace detail {
+  ExpressionAST opGreater(ExpressionAST const& lhs, ExpressionAST const& rhs) {
+    return BinaryOP(BinaryOP::OP::GREATER, lhs, rhs);
+  }
 
-ExpressionAST operator>=(ExpressionAST const& lhs, ExpressionAST const& rhs) {
-  ExpressionAST ast = BinaryOP(BinaryOP::OP::GREATER_EQUAL, lhs, rhs);
-  return ast;
-}
+  ExpressionAST opGreaterEq(ExpressionAST const& lhs, ExpressionAST const& rhs) {
+    return BinaryOP(BinaryOP::OP::GREATER_EQUAL, lhs, rhs);
+  }
 
-ExpressionAST operator==(ExpressionAST const& lhs, ExpressionAST const& rhs) {
-  ExpressionAST ast = BinaryOP(BinaryOP::OP::EQUAL, lhs, rhs);
-  return ast;
-}
+  ExpressionAST opEq(ExpressionAST const& lhs, ExpressionAST const& rhs) {
+    return BinaryOP(BinaryOP::OP::EQUAL, lhs, rhs);
+  }
 
-ExpressionAST operator<=(ExpressionAST const& lhs, ExpressionAST const& rhs) {
-  ExpressionAST ast = BinaryOP(BinaryOP::OP::LESS_EQUAL, lhs, rhs);
-  return ast;
-}
+  ExpressionAST opLesserEq(ExpressionAST const& lhs, ExpressionAST const& rhs) {
+    return BinaryOP(BinaryOP::OP::LESS_EQUAL, lhs, rhs);
+  }
 
-ExpressionAST operator<(ExpressionAST const& lhs, ExpressionAST const& rhs) {
-  ExpressionAST ast = BinaryOP(::BinaryOP::OP::LESS, lhs, rhs);
-  return ast;
-}
+  ExpressionAST opLesser(ExpressionAST const& lhs, ExpressionAST const& rhs) {
+    return BinaryOP(::BinaryOP::OP::LESS, lhs, rhs);
+  }
 
-ExpressionAST operator!=(ExpressionAST const& lhs, ExpressionAST const& rhs) {
-  ExpressionAST ast = BinaryOP(BinaryOP::OP::NOT_EQUAL, lhs, rhs);
-  return ast;
-}
+  ExpressionAST opNotEq(ExpressionAST const& lhs, ExpressionAST const& rhs) {
+    return BinaryOP(BinaryOP::OP::NOT_EQUAL, lhs, rhs);
+  }
 
-ExpressionAST operator&&(ExpressionAST const& lhs, ExpressionAST const& rhs) {
-  ExpressionAST ast = BinaryOP(BinaryOP::OP::AND, lhs, rhs);
-  return ast;
-}
+  ExpressionAST opAnd(ExpressionAST const& lhs, ExpressionAST const& rhs) {
+    return BinaryOP(BinaryOP::OP::AND, lhs, rhs);
+  }
 
-ExpressionAST operator||(ExpressionAST const& lhs, ExpressionAST const& rhs) {
-  ExpressionAST ast = BinaryOP(BinaryOP::OP::OR, lhs, rhs);
-  return ast;
-}
+  ExpressionAST opOr(ExpressionAST const& lhs, ExpressionAST const& rhs) {
+    return BinaryOP(BinaryOP::OP::OR, lhs, rhs);
+  }
 
+}  // namespace detail
 ExpressionAST& ExpressionAST::operator!() {
   expr = UnaryOP(UnaryOP::OP::NEG, expr);
   return *this;


### PR DESCRIPTION
#### PR description:

The friends are now only available for argument dependent lookup if an ExpressionAST is directly being used. This avoids having an implicit conversion of arguments to ExpressionAST from happening.

This fixes a gcc 11 compilation problem.

#### PR validation:

The code compiles under gcc 11.

fixes #34775