### PR TITLE
Fix uploading the EventSetup conditions to multiple CUDA devices

### DIFF
--- a/HeterogeneousCore/CUDAUtilities/interface/ScopedSetDevice.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/ScopedSetDevice.h
@@ -9,20 +9,35 @@ namespace cms {
   namespace cuda {
     class ScopedSetDevice {
     public:
-      explicit ScopedSetDevice(int newDevice) {
-        cudaCheck(cudaGetDevice(&prevDevice_));
-        cudaCheck(cudaSetDevice(newDevice));
+      // Store the original device, without setting a new one
+      ScopedSetDevice() {
+        // Store the original device
+        cudaCheck(cudaGetDevice(&originalDevice_));
       }
 
+      // Store the original device, and set a new current device
+      explicit ScopedSetDevice(int device) : ScopedSetDevice() {
+        // Change the current device
+        set(device);
+      }
+
+      // Restore the original device
       ~ScopedSetDevice() {
         // Intentionally don't check the return value to avoid
         // exceptions to be thrown. If this call fails, the process is
         // doomed anyway.
-        cudaSetDevice(prevDevice_);
+        cudaSetDevice(originalDevice_);
+      }
+
+      // Set a new current device, without changing the original device
+      // that will be restored when this object is destroyed
+      void set(int device) {
+        // Change the current device
+        cudaCheck(cudaSetDevice(device));
       }
 
     private:
-      int prevDevice_;
+      int originalDevice_;
     };
   }  // namespace cuda
 }  // namespace cms


### PR DESCRIPTION
#### PR description:

When multiple CUDA devices are available, each CUDA EventSetup object uses a different CUDA event to keep track if the conditions have been uploaded to each device. However, all events were associated to the default device, instead of the correct one, leading to a runtime error when multiple devices were used.

These changes associate to the correct CUDA device the events used to track if the conditions have been transferred.

#### PR validation:

Without this PR, running any GPU-enabled job on a system with multiple GPUs would fail with the error
```
----- Begin Fatal Exception 19-Aug-2021 10:35:57 CEST-----------------------
An exception of category 'StdException' occurred while
   [0] Processing  Event run: 1 lumi: 1 event: 6 stream: 1
   [1] Running path 'dqmoffline_step'
   [2] Prefetching for module PrimaryVertexMonitor/'pixelPVMonitor'
   [3] Prefetching for module PixelVertexProducerFromSoA/'pixelVertices'
   [4] Prefetching for module PixelVertexSoAFromCUDA/'pixelVerticesSoA@cuda'
   [5] Prefetching for module PixelVertexProducerCUDA/'pixelVerticesCUDA'
   [6] Prefetching for module CAHitNtupletCUDA/'pixelTracksCUDA'
   [7] Prefetching for module SiPixelRecHitCUDA/'siPixelRecHitsPreSplittingCUDA'
   [8] Calling method for module SiPixelRawToClusterCUDA/'siPixelClustersPreSplittingCUDA'
Exception Message:
A std::exception was thrown.

/build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/28bc67141038e9b7c17a74564c8e6173/opt/cmssw/slc7_amd64_gcc900/cms/cmssw/CMSSW_12_1_X_2021-08-15-0000/src/HeterogeneousCore/CUDACore/interface/ESProduct.h, line 80:
cudaCheck(cudaEventRecord(data.m_event.get(), cudaStream));
cudaErrorInvalidResourceHandle: invalid resource handle
----- End Fatal Exception -------------------------------------------------
```

With this PR, these jobs complete correctly.
For example, step 3 from `runTheMatrix.py -l 10824.502 -e -t4 --what gpu`:
```
$ cudaComputeCapabilities 
   0     6.1    GeForce GTX 1080 Ti
   1     6.1    GeForce GTX 1080 Ti
   2     6.1    GeForce GTX 1080 Ti
   3     6.1    GeForce GTX 1080 Ti
   4     6.1    GeForce GTX 1080 Ti
   5     6.1    GeForce GTX 1080 Ti
   6     6.1    GeForce GTX 1080 Ti
   7     6.1    GeForce GTX 1080 Ti

$ cmsRun step3_RAW2DIGI_RECO_VALIDATION_
DQM.py
%MSG-i ThreadStreamSetup:  (NoModuleName) 19-Aug-2021 10:59:19 CEST pre-events
setting # threads 4
setting # streams 4
%MSG
19-Aug-2021 10:59:32 CEST  Initiating request to open file file:step2.root
19-Aug-2021 10:59:33 CEST  Successfully opened file file:step2.root
Begin processing the 1st record. Run 1, Event 6, LumiSection 1 on stream 0 at 19-Aug-2021 10:59:40.893 CEST
Begin processing the 2nd record. Run 1, Event 2, LumiSection 1 on stream 1 at 19-Aug-2021 10:59:40.918 CEST
Begin processing the 3rd record. Run 1, Event 3, LumiSection 1 on stream 3 at 19-Aug-2021 10:59:40.918 CEST
Begin processing the 4th record. Run 1, Event 4, LumiSection 1 on stream 2 at 19-Aug-2021 10:59:40.937 CEST
Begin processing the 5th record. Run 1, Event 1, LumiSection 1 on stream 2 at 19-Aug-2021 10:59:46.703 CEST
Begin processing the 6th record. Run 1, Event 5, LumiSection 1 on stream 1 at 19-Aug-2021 10:59:46.813 CEST
Begin processing the 7th record. Run 1, Event 8, LumiSection 1 on stream 0 at 19-Aug-2021 10:59:46.851 CEST
Begin processing the 8th record. Run 1, Event 9, LumiSection 1 on stream 3 at 19-Aug-2021 10:59:46.947 CEST
Begin processing the 9th record. Run 1, Event 7, LumiSection 1 on stream 2 at 19-Aug-2021 10:59:47.269 CEST
Begin processing the 10th record. Run 1, Event 10, LumiSection 1 on stream 3 at 19-Aug-2021 10:59:47.469 CEST
19-Aug-2021 10:59:48 CEST  Closed file file:step2.root
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR:

These changes should be backported to CMSSW_12_0_X.
These changes should be backported to CMSSW_11_3_X if there are plans to use that release cycle for more online tests.
