### PR TITLE
Fix uploading the EventSetup conditions to multiple CUDA devices [12.0.x]

### DIFF
--- a/HeterogeneousCore/CUDACore/interface/ESProduct.h
+++ b/HeterogeneousCore/CUDACore/interface/ESProduct.h
@@ -20,10 +20,12 @@ namespace cms {
     class ESProduct {
     public:
       ESProduct() : gpuDataPerDevice_(numberOfDevices()) {
-        cms::cuda::ScopedSetDevice scopedDevice;
-        for (size_t i = 0; i < gpuDataPerDevice_.size(); ++i) {
-          scopedDevice.set(i);
-          gpuDataPerDevice_[i].m_event = getEventCache().get();
+        if (not gpuDataPerDevice_.empty()) {
+          cms::cuda::ScopedSetDevice scopedDevice;
+          for (size_t i = 0; i < gpuDataPerDevice_.size(); ++i) {
+            scopedDevice.set(i);
+            gpuDataPerDevice_[i].m_event = getEventCache().get();
+          }
         }
       }
 

--- a/HeterogeneousCore/CUDAUtilities/interface/ScopedSetDevice.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/ScopedSetDevice.h
@@ -9,20 +9,35 @@ namespace cms {
   namespace cuda {
     class ScopedSetDevice {
     public:
-      explicit ScopedSetDevice(int newDevice) {
-        cudaCheck(cudaGetDevice(&prevDevice_));
-        cudaCheck(cudaSetDevice(newDevice));
+      // Store the original device, without setting a new one
+      ScopedSetDevice() {
+        // Store the original device
+        cudaCheck(cudaGetDevice(&originalDevice_));
       }
 
+      // Store the original device, and set a new current device
+      explicit ScopedSetDevice(int device) : ScopedSetDevice() {
+        // Change the current device
+        set(device);
+      }
+
+      // Restore the original device
       ~ScopedSetDevice() {
         // Intentionally don't check the return value to avoid
         // exceptions to be thrown. If this call fails, the process is
         // doomed anyway.
-        cudaSetDevice(prevDevice_);
+        cudaSetDevice(originalDevice_);
+      }
+
+      // Set a new current device, without changing the original device
+      // that will be restored when this object is destroyed
+      void set(int device) {
+        // Change the current device
+        cudaCheck(cudaSetDevice(device));
       }
 
     private:
-      int prevDevice_;
+      int originalDevice_;
     };
   }  // namespace cuda
 }  // namespace cms


### PR DESCRIPTION
#### PR description:

When multiple CUDA devices are available, each CUDA EventSetup object uses a different CUDA event to keep track if the conditions have been uploaded to each device. However, all events were associated to the default device, instead of the correct one, leading to a runtime error when multiple devices were used.

These changes associate to the correct CUDA device the events used to track if the conditions have been transferred.

#### PR validation:

See #34948 .

#### If this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of #34948 .