### PR TITLE
Correct labels for a Trigger plot in ECAL DQM

### DIFF
--- a/DQM/EcalMonitorTasks/python/TrigPrimTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/TrigPrimTask_cfi.py
@@ -267,14 +267,14 @@ ecalTrigPrimTask = cms.untracked.PSet(
         ),
         RealvEmulEt = cms.untracked.PSet(
             kind = cms.untracked.string('TH2F'),
-            yaxis = cms.untracked.PSet(
+            xaxis = cms.untracked.PSet(
                 high = cms.untracked.double(256.0),
                 nbins = cms.untracked.int32(128),
                 low = cms.untracked.double(0.0),
                 title = cms.untracked.string('Real data TP Et (ADC)')
             ),
             otype = cms.untracked.string('Ecal3P'),
-            xaxis = cms.untracked.PSet(
+            yaxis = cms.untracked.PSet(
                 high = cms.untracked.double(256.0),
                 nbins = cms.untracked.int32(128),
                 low = cms.untracked.double(0.0),


### PR DESCRIPTION
#### PR description:

This PR addresses a bug that was observed in the 2D trigger plot Real Vs Emulated Tp digis, where the x and y axis labels were swapped. This has been fixed.

#### PR validation:

The changes have been validated by running an offline ECAL DQM workflow on a 2018 run and uploading the output file to a test Gui. It now displays the correct labels.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
N/A