### PR TITLE
[HGCAL] Improve validation scripts

### DIFF
--- a/Validation/HGCalValidation/interface/HGCalValidator.h
+++ b/Validation/HGCalValidation/interface/HGCalValidator.h
@@ -69,7 +69,7 @@ protected:
   const bool doCaloParticlePlots_;
   const bool doCaloParticleSelection_;
   const bool doSimClustersPlots_;
-  edm::InputTag label_SimClustersPlots_;
+  edm::InputTag label_SimClustersPlots_, label_SimClustersLevel_;
   const bool doLayerClustersPlots_;
   edm::InputTag label_LCToCPLinking_;
   const bool doTrackstersPlots_;

--- a/Validation/HGCalValidation/interface/HGCalValidator.h
+++ b/Validation/HGCalValidation/interface/HGCalValidator.h
@@ -71,7 +71,7 @@ protected:
   const bool doSimClustersPlots_;
   edm::InputTag label_SimClustersPlots_, label_SimClustersLevel_;
   const bool doLayerClustersPlots_;
-  edm::InputTag label_LCToCPLinking_;
+  edm::InputTag label_layerClustersPlots_, label_LCToCPLinking_;
   const bool doTrackstersPlots_;
   edm::InputTag label_TSToCPLinking_;
   std::vector<edm::InputTag> label_clustersmask;

--- a/Validation/HGCalValidation/interface/HGCalValidator.h
+++ b/Validation/HGCalValidation/interface/HGCalValidator.h
@@ -69,6 +69,7 @@ protected:
   const bool doCaloParticlePlots_;
   const bool doCaloParticleSelection_;
   const bool doSimClustersPlots_;
+  edm::InputTag label_SimClustersPlots_;
   const bool doLayerClustersPlots_;
   edm::InputTag label_LCToCPLinking_;
   const bool doTrackstersPlots_;

--- a/Validation/HGCalValidation/plugins/HGCalValidator.cc
+++ b/Validation/HGCalValidation/plugins/HGCalValidator.cc
@@ -20,6 +20,7 @@ HGCalValidator::HGCalValidator(const edm::ParameterSet& pset)
       doCaloParticleSelection_(pset.getUntrackedParameter<bool>("doCaloParticleSelection")),
       doSimClustersPlots_(pset.getUntrackedParameter<bool>("doSimClustersPlots")),
       label_SimClustersPlots_(pset.getParameter<edm::InputTag>("label_SimClusters")),
+      label_SimClustersLevel_(pset.getParameter<edm::InputTag>("label_SimClustersLevel")),
       doLayerClustersPlots_(pset.getUntrackedParameter<bool>("doLayerClustersPlots")),
       label_LCToCPLinking_(pset.getParameter<edm::InputTag>("label_LCToCPLinking")),
       doTrackstersPlots_(pset.getUntrackedParameter<bool>("doTrackstersPlots")),
@@ -124,7 +125,7 @@ void HGCalValidator::bookHistograms(DQMStore::IBooker& ibook,
   //Booking histograms concerning with simClusters
   if (doSimClustersPlots_) {
     ibook.cd();
-    ibook.setCurrentFolder(dirName_ + label_SimClustersPlots_.label() + "/ClusterLevel");
+    ibook.setCurrentFolder(dirName_ + label_SimClustersPlots_.label() + "/" + label_SimClustersLevel_.label());
     histoProducerAlgo_->bookSimClusterHistos(
         ibook, histograms.histoProducerAlgo, totallayers_to_monitor_, thicknesses_to_monitor_);
 

--- a/Validation/HGCalValidation/plugins/HGCalValidator.cc
+++ b/Validation/HGCalValidation/plugins/HGCalValidator.cc
@@ -19,6 +19,7 @@ HGCalValidator::HGCalValidator(const edm::ParameterSet& pset)
       doCaloParticlePlots_(pset.getUntrackedParameter<bool>("doCaloParticlePlots")),
       doCaloParticleSelection_(pset.getUntrackedParameter<bool>("doCaloParticleSelection")),
       doSimClustersPlots_(pset.getUntrackedParameter<bool>("doSimClustersPlots")),
+      label_SimClustersPlots_(pset.getParameter<edm::InputTag>("label_SimClusters")),
       doLayerClustersPlots_(pset.getUntrackedParameter<bool>("doLayerClustersPlots")),
       label_LCToCPLinking_(pset.getParameter<edm::InputTag>("label_LCToCPLinking")),
       doTrackstersPlots_(pset.getUntrackedParameter<bool>("doTrackstersPlots")),
@@ -123,14 +124,14 @@ void HGCalValidator::bookHistograms(DQMStore::IBooker& ibook,
   //Booking histograms concerning with simClusters
   if (doSimClustersPlots_) {
     ibook.cd();
-    ibook.setCurrentFolder(dirName_ + "simClusters/ClusterLevel");
+    ibook.setCurrentFolder(dirName_ + label_SimClustersPlots_.label() + "/ClusterLevel");
     histoProducerAlgo_->bookSimClusterHistos(
         ibook, histograms.histoProducerAlgo, totallayers_to_monitor_, thicknesses_to_monitor_);
 
     for (unsigned int ws = 0; ws < label_clustersmask.size(); ws++) {
       ibook.cd();
       InputTag algo = label_clustersmask[ws];
-      string dirName = dirName_ + "simClusters/";
+      string dirName = dirName_ + label_SimClustersPlots_.label() + "/";
       if (!algo.process().empty())
         dirName += algo.process() + "_";
       LogDebug("HGCalValidator") << dirName << "\n";

--- a/Validation/HGCalValidation/plugins/HGCalValidator.cc
+++ b/Validation/HGCalValidation/plugins/HGCalValidator.cc
@@ -22,6 +22,7 @@ HGCalValidator::HGCalValidator(const edm::ParameterSet& pset)
       label_SimClustersPlots_(pset.getParameter<edm::InputTag>("label_SimClusters")),
       label_SimClustersLevel_(pset.getParameter<edm::InputTag>("label_SimClustersLevel")),
       doLayerClustersPlots_(pset.getUntrackedParameter<bool>("doLayerClustersPlots")),
+      label_layerClustersPlots_(pset.getParameter<edm::InputTag>("label_layerClusterPlots")),
       label_LCToCPLinking_(pset.getParameter<edm::InputTag>("label_LCToCPLinking")),
       doTrackstersPlots_(pset.getUntrackedParameter<bool>("doTrackstersPlots")),
       label_TSToCPLinking_(pset.getParameter<edm::InputTag>("label_TSToCPLinking")),
@@ -159,19 +160,19 @@ void HGCalValidator::bookHistograms(DQMStore::IBooker& ibook,
   //Booking histograms concerning with hgcal layer clusters
   if (doLayerClustersPlots_) {
     ibook.cd();
-    ibook.setCurrentFolder(dirName_ + "hgcalLayerClusters/ClusterLevel");
+    ibook.setCurrentFolder(dirName_ + label_layerClustersPlots_.label() + "/ClusterLevel");
     histoProducerAlgo_->bookClusterHistos_ClusterLevel(ibook,
                                                        histograms.histoProducerAlgo,
                                                        totallayers_to_monitor_,
                                                        thicknesses_to_monitor_,
                                                        cummatbudinxo_.fullPath());
     ibook.cd();
-    ibook.setCurrentFolder(dirName_ + "hgcalLayerClusters/" + label_LCToCPLinking_.label());
+    ibook.setCurrentFolder(dirName_ + label_layerClustersPlots_.label() + "/" + label_LCToCPLinking_.label());
     histoProducerAlgo_->bookClusterHistos_LCtoCP_association(
         ibook, histograms.histoProducerAlgo, totallayers_to_monitor_);
 
     ibook.cd();
-    ibook.setCurrentFolder(dirName_ + "hgcalLayerClusters/CellLevel");
+    ibook.setCurrentFolder(dirName_ + label_layerClustersPlots_.label() + "/CellLevel");
     histoProducerAlgo_->bookClusterHistos_CellLevel(
         ibook, histograms.histoProducerAlgo, totallayers_to_monitor_, thicknesses_to_monitor_);
   }

--- a/Validation/HGCalValidation/python/HGCalValidator_cfi.py
+++ b/Validation/HGCalValidation/python/HGCalValidator_cfi.py
@@ -40,6 +40,7 @@ hgcalValidator = DQMEDAnalyzer(
     #SimCluster related plots
     doSimClustersPlots = cms.untracked.bool(True),
     label_SimClusters = cms.InputTag("SimClusters"),
+    label_SimClustersLevel = cms.InputTag("ClusterLevel"),
     #Layer Cluster related plots
     doLayerClustersPlots = cms.untracked.bool(True),
     label_LCToCPLinking = cms.InputTag("LCToCP_association"),

--- a/Validation/HGCalValidation/python/HGCalValidator_cfi.py
+++ b/Validation/HGCalValidation/python/HGCalValidator_cfi.py
@@ -39,6 +39,7 @@ hgcalValidator = DQMEDAnalyzer(
     doCaloParticleSelection = cms.untracked.bool(True),
     #SimCluster related plots
     doSimClustersPlots = cms.untracked.bool(True),
+    label_SimClusters = cms.InputTag("SimClusters"),
     #Layer Cluster related plots
     doLayerClustersPlots = cms.untracked.bool(True),
     label_LCToCPLinking = cms.InputTag("LCToCP_association"),

--- a/Validation/HGCalValidation/python/HGCalValidator_cfi.py
+++ b/Validation/HGCalValidation/python/HGCalValidator_cfi.py
@@ -43,6 +43,7 @@ hgcalValidator = DQMEDAnalyzer(
     label_SimClustersLevel = cms.InputTag("ClusterLevel"),
     #Layer Cluster related plots
     doLayerClustersPlots = cms.untracked.bool(True),
+    label_layerClusterPlots = cms.InputTag("hgcalLayerClusters"),
     label_LCToCPLinking = cms.InputTag("LCToCP_association"),
     #Trackster related plots
     doTrackstersPlots = cms.untracked.bool(True),

--- a/Validation/HGCalValidation/python/PostProcessorHGCAL_cfi.py
+++ b/Validation/HGCalValidation/python/PostProcessorHGCAL_cfi.py
@@ -37,8 +37,8 @@ eff_simclusters.extend(["fake_phi_layer{:02d} 'LayerCluster Fake Rate vs #phi La
 eff_simclusters.extend(["merge_eta_layer{:02d} 'LayerCluster Merge Rate vs #eta Layer{:02d} in z-' NumMerge_LayerCluster_in_SimCluster_Eta_perlayer{:02d} Denom_LayerCluster_in_SimCluster_Eta_perlayer{:02d}".format(i, i%maxlayerzm+1, i, i) if (i<maxlayerzm) else "merge_eta_layer{:02d} 'LayerCluster Merge Rate vs #eta Layer{:02d} in z+' NumMerge_LayerCluster_in_SimCluster_Eta_perlayer{:02d} Denom_LayerCluster_in_SimCluster_Eta_perlayer{:02d}".format(i, i%maxlayerzm+1, i, i) for i in range(maxlayerzp) ])
 eff_simclusters.extend(["merge_phi_layer{:02d} 'LayerCluster Merge Rate vs #phi Layer{:02d} in z-' NumMerge_LayerCluster_in_SimCluster_Phi_perlayer{:02d} Denom_LayerCluster_in_SimCluster_Phi_perlayer{:02d}".format(i, i%maxlayerzm+1, i, i) if (i<maxlayerzm) else "merge_phi_layer{:02d} 'LayerCluster Merge Rate vs #phi Layer{:02d} in z+' NumMerge_LayerCluster_in_SimCluster_Phi_perlayer{:02d} Denom_LayerCluster_in_SimCluster_Phi_perlayer{:02d}".format(i, i%maxlayerzm+1, i, i) for i in range(maxlayerzp) ])
 
-subdirsSim = [prefix+'simClusters/ticlTracksters'+iteration+'/' for iteration in ticlIterLabelsMerge]
-subdirsSim.extend([prefix+'simClusters/ticlSimTracksters'])
+subdirsSim = [prefix + hgcalValidator.label_SimClusters._InputTag__moduleLabel + '/ticlTracksters'+iteration+'/' for iteration in ticlIterLabelsMerge]
+subdirsSim.extend([prefix + hgcalValidator.label_SimClusters._InputTag__moduleLabel + '/ticlSimTracksters'])
 postProcessorHGCALsimclusters= DQMEDHarvester('DQMGenericClient',
     subDirs = cms.untracked.vstring(subdirsSim),
     efficiency = cms.vstring(eff_simclusters),

--- a/Validation/HGCalValidation/python/PostProcessorHGCAL_cfi.py
+++ b/Validation/HGCalValidation/python/PostProcessorHGCAL_cfi.py
@@ -19,7 +19,7 @@ eff_layers.extend(["merge_phi_layer{:02d} 'LayerCluster Merge Rate vs #phi Layer
 
 lcToCP_linking = hgcalValidator.label_LCToCPLinking._InputTag__moduleLabel
 postProcessorHGCALlayerclusters= DQMEDHarvester('DQMGenericClient',
-    subDirs = cms.untracked.vstring(prefix+'hgcalLayerClusters/' + lcToCP_linking),
+    subDirs = cms.untracked.vstring(prefix + hgcalValidator.label_layerClusterPlots._InputTag__moduleLabel + '/' + lcToCP_linking),
     efficiency = cms.vstring(eff_layers),
     resolution = cms.vstring(),
     cumulativeDists = cms.untracked.vstring(),

--- a/Validation/HGCalValidation/python/hgcalPlots.py
+++ b/Validation/HGCalValidation/python/hgcalPlots.py
@@ -2271,7 +2271,7 @@ lc_zplus_extended = [
   _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_BH_zplus
 ]
 
-def append_hgcalLayerClustersPlots(collection = "hgcalLayerClusters", name_collection = layerClustersLabel, extended = False):
+def append_hgcalLayerClustersPlots(collection = hgcalValidator.label_layerClusterPlots._InputTag__moduleLabel, name_collection = layerClustersLabel, extended = False):
   print('extended : ',extended)
   regions_ClusterLevel       = ["General: Cluster Level", "Z-minus: Cluster Level", "Z-plus: Cluster Level"]
   regions_CellLevel          = ["Z-minus: Cell Level", "Z-plus: Cell Level"]

--- a/Validation/HGCalValidation/python/hgcalPlots.py
+++ b/Validation/HGCalValidation/python/hgcalPlots.py
@@ -2412,7 +2412,7 @@ sc_ticltracksters = [
 hgcalSimClustersPlotter = Plotter()
 
 def append_hgcalSimClustersPlots(collection, name_collection):
-  if collection == "ClusterLevel":
+  if collection == hgcalValidator.label_SimClustersLevel._InputTag__moduleLabel:
       hgcalSimClustersPlotter.append(collection, [
                   _hgcalsimClustersFolders(collection)
                   ], PlotFolder(

--- a/Validation/HGCalValidation/python/hgcalPlots.py
+++ b/Validation/HGCalValidation/python/hgcalPlots.py
@@ -16,6 +16,7 @@ import Validation.RecoTrack.plotting.plotting as plotting
 import Validation.RecoTrack.plotting.validation as validation
 import Validation.RecoTrack.plotting.html as html
 
+from Validation.HGCalValidation.HGCalValidator_cfi import hgcalValidator
 from Validation.HGCalValidation.PostProcessorHGCAL_cfi import tsToCP_linking, lcToCP_linking
 
 #To be able to spot any issues both in -z and +z a layer id was introduced
@@ -2319,7 +2320,7 @@ def append_hgcalLayerClustersPlots(collection = "hgcalLayerClusters", name_colle
 
 #=================================================================================================
 def _hgcalsimClustersFolders(lastDirName):
-    return "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/simClusters/"+lastDirName
+    return "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/" + hgcalValidator.label_SimClusters._InputTag__moduleLabel + "/"+lastDirName
 
 sc_clusterlevel = [
   # number of layer clusters per event in a) 120um, b) 200um, c) 300um, d) scint

--- a/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
+++ b/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
@@ -53,7 +53,7 @@ def main(opts):
     #layerClusters
     def plot_LC():
         hgclayclus = [hgcalPlots.hgcalLayerClustersPlotter]
-        hgcalPlots.append_hgcalLayerClustersPlots("hgcalLayerClusters", "Layer Clusters", extendedFlag)
+        hgcalPlots.append_hgcalLayerClustersPlots(hgcalValidator.label_layerClusterPlots._InputTag__moduleLabel, "Layer Clusters", extendedFlag)
         val.doPlots(hgclayclus, plotterDrawArgs=drawArgs)
 
     #simClusters

--- a/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
+++ b/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
@@ -15,7 +15,8 @@ simClustersIters = ["ClusterLevel","ticlSimTracksters"]
 trackstersIters = ['ticlTracksters'+iteration for iteration in ticlIterLabelsMerge]
 trackstersIters.extend(["ticlSimTracksters"])
 
-hitLabel = 'recHits'
+hitCalLabel = 'hitCalibration'
+hitValLabel = 'hitValidation'
 layerClustersLabel = 'layerClusters'
 trackstersLabel = 'tracksters'
 trackstersWithEdgesLabel = 'trackstersWithEdges'
@@ -23,7 +24,7 @@ simLabel = 'simulation'
 allLabel = 'all'
 
 collection_choices = [allLabel]
-collection_choices.extend([hitLabel]+[layerClustersLabel]+[trackstersLabel]+[trackstersWithEdgesLabel]+[simLabel])
+collection_choices.extend([hitCalLabel]+[hitValLabel]+[layerClustersLabel]+[trackstersLabel]+[trackstersWithEdgesLabel]+[simLabel])
 
 def main(opts):
 
@@ -101,7 +102,7 @@ def main(opts):
         val.doPlots(hgchitcalib, plotterDrawArgs=drawArgs)
 
 
-    plotDict = {hitLabel:[plot_hitVal, plot_hitCal], layerClustersLabel:[plot_LC], trackstersLabel:[plot_Tst], trackstersWithEdgesLabel:[plot_TstEdges], simLabel:[plot_SC, plot_CP]}
+    plotDict = {hitCalLabel:[plot_hitCal], hitValLabel:[plot_hitVal], layerClustersLabel:[plot_LC], trackstersLabel:[plot_Tst], trackstersWithEdgesLabel:[plot_TstEdges], simLabel:[plot_SC, plot_CP]}
 
     if (opts.collection != allLabel):
         for task in plotDict[opts.collection]:

--- a/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
+++ b/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
@@ -8,10 +8,11 @@ from time import time
 from RecoHGCal.TICL.iterativeTICL_cff import ticlIterLabels, ticlIterLabelsMerge
 
 from Validation.RecoTrack.plotting.validation import SeparateValidation, SimpleValidation, SimpleSample
+from Validation.HGCalValidation.HGCalValidator_cfi import hgcalValidator
 import Validation.HGCalValidation.hgcalPlots as hgcalPlots
 import Validation.RecoTrack.plotting.plotting as plotting
 
-simClustersIters = ["ClusterLevel","ticlSimTracksters"]
+simClustersIters = [hgcalValidator.label_SimClustersLevel._InputTag__moduleLabel, "ticlSimTracksters"]
 trackstersIters = ['ticlTracksters'+iteration for iteration in ticlIterLabelsMerge]
 trackstersIters.extend(["ticlSimTracksters"])
 

--- a/Validation/RecoTrack/python/plotting/validation.py
+++ b/Validation/RecoTrack/python/plotting/validation.py
@@ -1274,7 +1274,6 @@ class SimpleValidation:
         for plotterFolder, dqmSubFolder in plotterInstance.iterFolders(limitSubFoldersOnlyTo=limitSubFoldersOnlyTo):
             if sample is not None and not _processPlotsForSample(plotterFolder, sample):
                 continue
-            return_dict[iProc] = None
             p = multiprocessing.Process(target=self._doPlots, args=(plotterFolder, dqmSubFolder, iProc, return_dict))
             proc.append((plotterFolder, dqmSubFolder, p))
             p.start()


### PR DESCRIPTION
#### PR description:

This PR removes most of the duplicated hardcoded labels in the HGCal validation scripts, and parallelizes the plot creation across different DQM folders. 
No changes are expected in the output, except for a `simClusters` -> `SimClusters` renaming of a DQM folder.

#### PR validation:

`makeHGCalValidationPlots.py --collection tracksters`