### PR TITLE
Migrate module configuration in PhysicsTools{PatAlgos} to use default cfipython

### DIFF
--- a/PhysicsTools/PatAlgos/python/producersLayer1/jetProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/jetProducer_cfi.py
@@ -1,10 +1,11 @@
 import FWCore.ParameterSet.Config as cms
+import PhysicsTools.PatAlgos.PATJetProducer_cfi as _mod
 
-_patJets = cms.EDProducer("PATJetProducer",
+_patJets = _mod.PATJetProducer.clone(
     # input
-    jetSource = cms.InputTag("ak4PFJetsCHS"),
+    jetSource = "ak4PFJetsCHS",
     # add user data
-    userData = cms.PSet(
+    userData = dict(
       # add custom classes here
       userClasses = cms.PSet(
         src = cms.VInputTag('')
@@ -22,81 +23,80 @@ _patJets = cms.EDProducer("PATJetProducer",
         src = cms.VInputTag('')
       ),
       # add "inline" functions here
-      userFunctions = cms.vstring(),
-      userFunctionLabels = cms.vstring()
+      userFunctions = [],
+      userFunctionLabels = []
     ),
     # embedding of RECO items (do not use on AOD input!)
     #embedCaloTowers = cms.bool(False), # optional
     # embedding of AOD items
-    embedPFCandidates = cms.bool(False),
+    embedPFCandidates = False,
     # jet energy corrections
-    addJetCorrFactors    = cms.bool(True),
-    jetCorrFactorsSource = cms.VInputTag(cms.InputTag("patJetCorrFactors") ),
+    addJetCorrFactors    = True,
+    jetCorrFactorsSource = ["patJetCorrFactors" ],
     # btag information
-    addBTagInfo          = cms.bool(True),   ## master switch
-    addDiscriminators    = cms.bool(True),   ## addition btag discriminators
-    discriminatorSources = cms.VInputTag(
-        cms.InputTag("pfJetBProbabilityBJetTags"),
-        cms.InputTag("pfJetProbabilityBJetTags"),
-        cms.InputTag("pfTrackCountingHighEffBJetTags"),
-        cms.InputTag("pfSimpleSecondaryVertexHighEffBJetTags"),
-        cms.InputTag("pfSimpleInclusiveSecondaryVertexHighEffBJetTags"),
-        cms.InputTag("pfCombinedSecondaryVertexV2BJetTags"),
-        cms.InputTag("pfCombinedInclusiveSecondaryVertexV2BJetTags"),
-        cms.InputTag("softPFMuonBJetTags"),
-        cms.InputTag("softPFElectronBJetTags"),
-        cms.InputTag("pfCombinedMVAV2BJetTags"),
-        # CTagging
-        cms.InputTag('pfCombinedCvsLJetTags'),
-        cms.InputTag('pfCombinedCvsBJetTags'),
-        # DeepFlavour
-        cms.InputTag('pfDeepCSVJetTags:probb'),
-        cms.InputTag('pfDeepCSVJetTags:probc'),
-        cms.InputTag('pfDeepCSVJetTags:probudsg'),
-        cms.InputTag('pfDeepCSVJetTags:probbb'),
-        # New DeepFlavour (commented until available in RelVals)
-        #cms.InputTag('pfDeepFlavourJetTags:probb'),
-        #cms.InputTag('pfDeepFlavourJetTags:probbb'),
-        #cms.InputTag('pfDeepFlavourJetTags:problepb'),
-        #cms.InputTag('pfDeepFlavourJetTags:probc'),
-        #cms.InputTag('pfDeepFlavourJetTags:probuds'),
-        #cms.InputTag('pfDeepFlavourJetTags:probg')
-    ),
+    addBTagInfo          = True,   ## master switch
+    addDiscriminators    = True,   ## addition btag discriminators
+    discriminatorSources = ["pfJetBProbabilityBJetTags",
+                            "pfJetProbabilityBJetTags",
+                            "pfTrackCountingHighEffBJetTags",
+                            "pfSimpleSecondaryVertexHighEffBJetTags",
+                            "pfSimpleInclusiveSecondaryVertexHighEffBJetTags",
+                            "pfCombinedSecondaryVertexV2BJetTags",
+                            "pfCombinedInclusiveSecondaryVertexV2BJetTags",
+                            "softPFMuonBJetTags",
+                            "softPFElectronBJetTags",
+                            "pfCombinedMVAV2BJetTags",
+                            # CTagging
+                            'pfCombinedCvsLJetTags',
+                            'pfCombinedCvsBJetTags',
+                            # DeepFlavour
+                            'pfDeepCSVJetTags:probb',
+                            'pfDeepCSVJetTags:probc',
+                            'pfDeepCSVJetTags:probudsg',
+                            'pfDeepCSVJetTags:probbb',
+                            # New DeepFlavour (commented until available in RelVals)
+                            #'pfDeepFlavourJetTags:probb',
+                            #'pfDeepFlavourJetTags:probbb',
+                            #'pfDeepFlavourJetTags:problepb',
+                            #'pfDeepFlavourJetTags:probc',
+                            #'pfDeepFlavourJetTags:probuds',
+                            #'pfDeepFlavourJetTags:probg'
+                           ],
     # clone tag infos ATTENTION: these take lots of space!
     # usually the discriminators from the default algos
     # are sufficient
-    addTagInfos     = cms.bool(False),
-    tagInfoSources  = cms.VInputTag(),
+    addTagInfos     = False,
+    tagInfoSources  = [],
     # track association
-    addAssociatedTracks    = cms.bool(True),
-    trackAssociationSource = cms.InputTag("ak4JetTracksAssociatorAtVertexPF"),
+    addAssociatedTracks    = True,
+    trackAssociationSource = "ak4JetTracksAssociatorAtVertexPF",
     # jet charge
-    addJetCharge    = cms.bool(True),
-    jetChargeSource = cms.InputTag("patJetCharge"),
+    addJetCharge    = True,
+    jetChargeSource = "patJetCharge",
     # add jet ID for calo jets. This should be of type ak4JetID, ak7JetID, ...
-    addJetID = cms.bool(False),
-    jetIDMap = cms.InputTag("ak4JetID"),
+    addJetID = False,
+    jetIDMap = "ak4JetID",
     # mc matching
-    addGenPartonMatch   = cms.bool(True),                           ## switch on/off matching to quarks from hard scatterin
-    embedGenPartonMatch = cms.bool(True),                           ## switch on/off embedding of the GenParticle parton for this jet
-    genPartonMatch      = cms.InputTag("patJetPartonMatch"),        ## particles source to be used for the matching
-    addGenJetMatch      = cms.bool(True),                           ## switch on/off matching to GenJet's
-    embedGenJetMatch    = cms.bool(True),                           ## switch on/off embedding of matched genJet's
-    genJetMatch         = cms.InputTag("patJetGenJetMatch"),        ## GenJet source to be used for the matching
-    addPartonJetMatch   = cms.bool(False),                          ## switch on/off matching to PartonJet's (not implemented yet)
-    partonJetSource     = cms.InputTag("NOT_IMPLEMENTED"),          ## ParticleJet source to be used for the matching
+    addGenPartonMatch   = True,                ## switch on/off matching to quarks from hard scatterin
+    embedGenPartonMatch = True,                ## switch on/off embedding of the GenParticle parton for this jet
+    genPartonMatch      = "patJetPartonMatch", ## particles source to be used for the matching
+    addGenJetMatch      = True,                ## switch on/off matching to GenJet's
+    embedGenJetMatch    = True,                ## switch on/off embedding of matched genJet's
+    genJetMatch         = "patJetGenJetMatch", ## GenJet source to be used for the matching
+    addPartonJetMatch   = False,               ## switch on/off matching to PartonJet's (not implemented yet)
+    partonJetSource     = "NOT_IMPLEMENTED",   ## ParticleJet source to be used for the matching
     # jet flavour idetification configurables
-    getJetMCFlavour    = cms.bool(True),
-    useLegacyJetMCFlavour = cms.bool(False),
-    addJetFlavourInfo  = cms.bool(True),
-    JetPartonMapSource = cms.InputTag("patJetFlavourAssociationLegacy"),
-    JetFlavourInfoSource = cms.InputTag("patJetFlavourAssociation"),
+    getJetMCFlavour       = True,
+    useLegacyJetMCFlavour = False,
+    addJetFlavourInfo     = True,
+    JetPartonMapSource    = "patJetFlavourAssociationLegacy",
+    JetFlavourInfoSource  = "patJetFlavourAssociation",
     # efficiencies
-    addEfficiencies = cms.bool(False),
-    efficiencies    = cms.PSet(),
+    addEfficiencies = False,
+    efficiencies    = dict(),
     # resolution
-    addResolutions = cms.bool(False),
-    resolutions     = cms.PSet()
+    addResolutions  = False,
+    resolutions     = dict()
 )
 
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA

--- a/PhysicsTools/PatAlgos/python/producersLayer1/jetUpdater_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/jetUpdater_cfi.py
@@ -1,10 +1,11 @@
 import FWCore.ParameterSet.Config as cms
+import PhysicsTools.PatAlgos.PATJetUpdater_cfi as _mod
 
-updatedPatJets = cms.EDProducer("PATJetUpdater",
+updatedPatJets = _mod.PATJetUpdater.clone(
     # input
-    jetSource = cms.InputTag("slimmedJets"),
+    jetSource = "slimmedJets",
     # add user data
-    userData = cms.PSet(
+    userData = dict(
       # add custom classes here
       userClasses = cms.PSet(
         src = cms.VInputTag('')
@@ -22,24 +23,22 @@ updatedPatJets = cms.EDProducer("PATJetUpdater",
         src = cms.VInputTag('')
       ),
       # add "inline" functions here
-      userFunctions = cms.vstring(),
-      userFunctionLabels = cms.vstring()
+      userFunctions = [],
+      userFunctionLabels = []
     ),
     # sort
-    sort                 = cms.bool(True),
+    sort                 = True,
     # jet energy corrections
-    addJetCorrFactors    = cms.bool(True),
-    jetCorrFactorsSource = cms.VInputTag(cms.InputTag("updatedPatJetCorrFactors") ),
+    addJetCorrFactors    = True,
+    jetCorrFactorsSource = ["updatedPatJetCorrFactors"],
     # btag information
-    addBTagInfo          = cms.bool(True),   ## master switch
-    addDiscriminators    = cms.bool(True),   ## addition of btag discriminators
-    discriminatorSources = cms.VInputTag(),
+    addBTagInfo          = True,   ## master switch
+    addDiscriminators    = True,   ## addition of btag discriminators
+    discriminatorSources = [],
     # clone tag infos ATTENTION: these take lots of space!
     # usually the discriminators from the default algos
     # are sufficient
-    addTagInfos     = cms.bool(False),
-    tagInfoSources  = cms.VInputTag(),
-    printWarning = cms.bool(True)
+    addTagInfos     = False,
+    tagInfoSources  = [],
+    printWarning    = True
 )
-
-

--- a/PhysicsTools/PatAlgos/python/recoLayer0/jetCorrFactors_cfi.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/jetCorrFactors_cfi.py
@@ -1,28 +1,29 @@
 import FWCore.ParameterSet.Config as cms
+import PhysicsTools.PatAlgos.JetCorrFactorsProducer_cfi as _mod
 
 # module to produce jet correction factors associated in a valuemap
-patJetCorrFactors = cms.EDProducer("JetCorrFactorsProducer",
+patJetCorrFactors = _mod.JetCorrFactorsProducer.clone(
     ## the use of emf in the JEC is not yet implemented
-    emf = cms.bool(False),
+    emf = False,
     ## input collection of jets
-    src = cms.InputTag("ak4PFJetsCHS"),
+    src = "ak4PFJetsCHS",
     ## payload postfix for testing
-    payload = cms.string('AK4PFchs'),
+    payload = 'AK4PFchs',
     ## correction levels
-    levels = cms.vstring(
+    levels = [
         ## tags for the individual jet corrections; when
         ## not available the string should be set to 'none'
         'L1FastJet', 'L2Relative', 'L3Absolute',#'L5Flavor', 'L7Parton'
-    ),
+    ],
     ## define the type of L5Flavor corrections for here. These can
     ## be of type 'J' for dijet derived, or of type 'T' for ttbar
     ## derived.
-    flavorType = cms.string('J'),
+    flavorType = 'J',
     ## in case you are using JPT jets you must have specified the L1Offset
     ## corrections by a dedicated L1JPTOffset correction level. This dedi-
     ## cated correction level has an ordinary L1Offset or L1FastJet corrector
     ## as input, which needs to be specified via this additional parameter
-    extraJPTOffset = cms.string("L1FastJet"),
+    extraJPTOffset = "L1FastJet",
     ## in case that L1Offset or L1FastJet corrections are part
     ## of the parameter levels add the optional parameter
     ## primaryVertices here to specify the primary vertex
@@ -30,15 +31,15 @@ patJetCorrFactors = cms.EDProducer("JetCorrFactorsProducer",
     ## or L1FastJet correction from. This parameter will ONLY
     ## be read out if the correction level L1Offset or
     ## L1FastJet is found in levels.
-    useNPV = cms.bool(True),
-    primaryVertices = cms.InputTag('offlinePrimaryVertices'),
+    useNPV = True,
+    primaryVertices = 'offlinePrimaryVertices',
     ## in case that L1FastJet corrections are part of the
     ## parameter levels add the optional parameter rho
     ## here to specify the energy density parameter for
     ## the corresponding jet collection (this variable is
     ## typically taken from kt6PFJets).
-    useRho = cms.bool(True),
-    rho = cms.InputTag('fixedGridRhoFastjetAll'),
+    useRho = True,
+    rho = 'fixedGridRhoFastjetAll',
 )
 
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA


### PR DESCRIPTION
#### PR description: 
Optimization of the python configurations: Improve maintainability by cleaning up the duplicated and cloning from the default/reference configurations. (The previous PRs : #33207, #33307, #33352, #33543, #33563, #33671, #34007, #34091, #34009, #34155, #34371, #34480, #34543, #34571, #34817, #34818, #34834 )
 
In this PR, 3 files changed.  
        modified:   PhysicsTools/PatAlgos/python/producersLayer1/jetProducer_cfi.py
        modified:   PhysicsTools/PatAlgos/python/producersLayer1/jetUpdater_cfi.py
        modified:   PhysicsTools/PatAlgos/python/recoLayer0/jetCorrFactors_cfi.py

Update
- Replace explicit configuration with a reference from cfipython/. (migrating EDProducer("type", .. -> typeDefaylt.clone() ) 
- Remove the type specifications already presented in cfipython/fillDescriptions reference for improved syntax safety.

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_12_1_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).