### PR TITLE
[Fireworks/Geometry] Strip topolgy for sub-classes of StripTopology was not exported to RECO geometry.

### DIFF
--- a/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
+++ b/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
@@ -67,7 +67,8 @@ using Phase2TrackerTopology = PixelTopology;
       fwRecoGeometry.idToName[rawid].topology[0] = 0;                                                          \
       fwRecoGeometry.idToName[rawid].topology[1] = topo->nstrips();                                            \
       fwRecoGeometry.idToName[rawid].topology[2] = topo->stripLength();                                        \
-    } else if (const RadialStripTopology* rtop =                                                               \
+    }                                                                                                          \
+    if (const RadialStripTopology* rtop =                                                                      \
                    dynamic_cast<const RadialStripTopology*>(&(det->specificType().specificTopology()))) {      \
       fwRecoGeometry.idToName[rawid].topology[0] = 1;                                                          \
       fwRecoGeometry.idToName[rawid].topology[3] = rtop->yAxisOrientation();                                   \

--- a/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
+++ b/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
@@ -69,7 +69,7 @@ using Phase2TrackerTopology = PixelTopology;
       fwRecoGeometry.idToName[rawid].topology[2] = topo->stripLength();                                        \
     }                                                                                                          \
     if (const RadialStripTopology* rtop =                                                                      \
-                   dynamic_cast<const RadialStripTopology*>(&(det->specificType().specificTopology()))) {      \
+            dynamic_cast<const RadialStripTopology*>(&(det->specificType().specificTopology()))) {             \
       fwRecoGeometry.idToName[rawid].topology[0] = 1;                                                          \
       fwRecoGeometry.idToName[rawid].topology[3] = rtop->yAxisOrientation();                                   \
       fwRecoGeometry.idToName[rawid].topology[4] = rtop->originToIntersection();                               \


### PR DESCRIPTION
In the following commit:
https://github.com/cms-sw/cmssw/commit/d5c061c90f39a1fbe69e5924e25083c1811a1e5f
an `else` has been introduced after the if covering dynamic_cast to a base-class that led to exclusion of code that extracts topology data from sub-classes of StripTopology.
