### PR TITLE
initialize TrackstersProducer::iterIndex_ to 0

### DIFF
--- a/RecoHGCal/TICL/plugins/TrackstersProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersProducer.cc
@@ -55,7 +55,7 @@ private:
   edm::EDGetTokenT<TICLLayerTilesHFNose> layer_clusters_tiles_hfnose_token_;
   const edm::EDGetTokenT<std::vector<TICLSeedingRegion>> seeding_regions_token_;
   const std::string itername_;
-  ticl::Trackster::IterationIndex iterIndex_ = 0;
+  ticl::Trackster::IterationIndex iterIndex_ = ticl::Trackster::IterationIndex(0);
 };
 DEFINE_FWK_MODULE(TrackstersProducer);
 

--- a/RecoHGCal/TICL/plugins/TrackstersProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersProducer.cc
@@ -55,7 +55,7 @@ private:
   edm::EDGetTokenT<TICLLayerTilesHFNose> layer_clusters_tiles_hfnose_token_;
   const edm::EDGetTokenT<std::vector<TICLSeedingRegion>> seeding_regions_token_;
   const std::string itername_;
-  ticl::Trackster::IterationIndex iterIndex_;
+  ticl::Trackster::IterationIndex iterIndex_ = 0;
 };
 DEFINE_FWK_MODULE(TrackstersProducer);
 


### PR DESCRIPTION
#34605 is an example  of using iternames which can not be decoded by RecoHGCal/TICL/plugins/TrackstersProducer.cc. E.g. `ticlTrackstersHFNoseEM` uses `EMn`.
This means that the uninitialized `TrackstersProducer::iterIndex_` is used to set the tracksters iteration. This leads to non-repeatable changes in this variable in the data outputs.

This PR sets the value to a somewhat inconvenient default of 0 to restore repeatable results in reco comparisons.

 Some better solution may be needed; to be done by some HGCAL experts 
@cms-sw/hgcal-dpg-l2 
