### PR TITLE
Migrate leftover ECAL DQM codes to ESConsumes

### DIFF
--- a/DQM/EcalMonitorDbModule/interface/EcalCondDBReader.h
+++ b/DQM/EcalMonitorDbModule/interface/EcalCondDBReader.h
@@ -5,6 +5,7 @@
 #include "DQM/EcalCommon/interface/MESet.h"
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
 #include "OnlineDB/EcalCondDB/interface/EcalCondDBInterface.h"
+#include "Geometry/EcalMapping/interface/EcalMappingRcd.h"
 
 class EcalCondDBReader : public DQMEDHarvester {
 public:
@@ -46,6 +47,7 @@ private:
 
   int verbosity_;
   bool executed_;
+  edm::ESGetToken<EcalElectronicsMapping, EcalMappingRcd> elecMapHandle;
 };
 
 #endif

--- a/DQM/EcalMonitorDbModule/interface/EcalDQMStatusWriter.h
+++ b/DQM/EcalMonitorDbModule/interface/EcalDQMStatusWriter.h
@@ -1,7 +1,7 @@
 #ifndef EcalDQMStatusWriter_H
 #define EcalDQMStatusWriter_H
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "CondFormats/EcalObjects/interface/EcalDQMChannelStatus.h"
 #include "CondFormats/EcalObjects/interface/EcalDQMTowerStatus.h"
@@ -11,14 +11,14 @@
 
 #include <fstream>
 
-class EcalDQMStatusWriter : public edm::EDAnalyzer {
+class EcalDQMStatusWriter : public edm::one::EDAnalyzer<> {
 public:
   EcalDQMStatusWriter(edm::ParameterSet const &);
   ~EcalDQMStatusWriter() override {}
 
 private:
   void analyze(edm::Event const &, edm::EventSetup const &) override;
-  void beginRun(edm::Run const &, edm::EventSetup const &) override;
+  void beginRun(edm::Run const &, edm::EventSetup const &);
 
   EcalDQMChannelStatus channelStatus_;
   EcalDQMTowerStatus towerStatus_;

--- a/DQM/EcalMonitorDbModule/interface/EcalDQMStatusWriter.h
+++ b/DQM/EcalMonitorDbModule/interface/EcalDQMStatusWriter.h
@@ -28,6 +28,7 @@ private:
   EcalElectronicsMapping const *electronicsMap;
   void setElectronicsMap(edm::EventSetup const &);
   EcalElectronicsMapping const *GetElectronicsMap();
+  edm::ESGetToken<EcalElectronicsMapping, EcalMappingRcd> elecMapHandle;
 };
 
 #endif

--- a/DQM/EcalMonitorDbModule/plugins/EcalCondDBReader.cc
+++ b/DQM/EcalMonitorDbModule/plugins/EcalCondDBReader.cc
@@ -9,15 +9,14 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
-#include "Geometry/EcalMapping/interface/EcalMappingRcd.h"
-
 EcalCondDBReader::EcalCondDBReader(edm::ParameterSet const &_ps)
     : db_(nullptr),
       monIOV_(),
       worker_(nullptr),
       formula_(_ps.getUntrackedParameter<std::string>("formula")),
       meSet_(ecaldqm::createMESet(_ps.getUntrackedParameterSet("plot"))),
-      verbosity_(_ps.getUntrackedParameter<int>("verbosity")) {
+      verbosity_(_ps.getUntrackedParameter<int>("verbosity")),
+      elecMapHandle(esConsumes<edm::Transition::EndRun>()) {
   std::string table(_ps.getUntrackedParameter<std::string>("table"));
   edm::ParameterSet const &workerParams(_ps.getUntrackedParameterSet("workerParams"));
 
@@ -160,9 +159,7 @@ void EcalCondDBReader::dqmEndRun(DQMStore::IBooker &_ibooker,
 }
 
 void EcalCondDBReader::setElectronicsMap(edm::EventSetup const &_es) {
-  edm::ESHandle<EcalElectronicsMapping> elecMapHandle;
-  _es.get<EcalMappingRcd>().get(elecMapHandle);
-  electronicsMap = elecMapHandle.product();
+  electronicsMap = &_es.getData(elecMapHandle);
 }
 
 EcalElectronicsMapping const *EcalCondDBReader::GetElectronicsMap() {

--- a/DQM/EcalMonitorDbModule/plugins/EcalCondDBReader.cc
+++ b/DQM/EcalMonitorDbModule/plugins/EcalCondDBReader.cc
@@ -158,9 +158,7 @@ void EcalCondDBReader::dqmEndRun(DQMStore::IBooker &_ibooker,
     meSet_->setBinContent(getEcalDQMSetupObjects(), vItr->first, vItr->second);
 }
 
-void EcalCondDBReader::setElectronicsMap(edm::EventSetup const &_es) {
-  electronicsMap = &_es.getData(elecMapHandle);
-}
+void EcalCondDBReader::setElectronicsMap(edm::EventSetup const &_es) { electronicsMap = &_es.getData(elecMapHandle); }
 
 EcalElectronicsMapping const *EcalCondDBReader::GetElectronicsMap() {
   if (!electronicsMap)

--- a/DQM/EcalMonitorDbModule/plugins/EcalDQMStatusWriter.cc
+++ b/DQM/EcalMonitorDbModule/plugins/EcalDQMStatusWriter.cc
@@ -13,8 +13,8 @@
 
 EcalDQMStatusWriter::EcalDQMStatusWriter(edm::ParameterSet const &_ps)
     : channelStatus_(),
-      towerStatus_(), 
-      firstRun_(_ps.getUntrackedParameter<unsigned>("firstRun")), 
+      towerStatus_(),
+      firstRun_(_ps.getUntrackedParameter<unsigned>("firstRun")),
       inputFile_(_ps.getUntrackedParameter<std::string>("inputFile")),
       elecMapHandle(esConsumes<edm::Transition::BeginRun>()) {
   if (!inputFile_.is_open())
@@ -42,7 +42,6 @@ void EcalDQMStatusWriter::analyze(edm::Event const &, edm::EventSetup const &_es
 }
 
 void EcalDQMStatusWriter::setElectronicsMap(edm::EventSetup const &_es) {
-
   electronicsMap = &_es.getData(elecMapHandle);
 }
 

--- a/DQM/EcalMonitorDbModule/plugins/EcalDQMStatusWriter.cc
+++ b/DQM/EcalMonitorDbModule/plugins/EcalDQMStatusWriter.cc
@@ -13,9 +13,10 @@
 
 EcalDQMStatusWriter::EcalDQMStatusWriter(edm::ParameterSet const &_ps)
     : channelStatus_(),
-      towerStatus_(),
-      firstRun_(_ps.getUntrackedParameter<unsigned>("firstRun")),
-      inputFile_(_ps.getUntrackedParameter<std::string>("inputFile")) {
+      towerStatus_(), 
+      firstRun_(_ps.getUntrackedParameter<unsigned>("firstRun")), 
+      inputFile_(_ps.getUntrackedParameter<std::string>("inputFile")),
+      elecMapHandle(esConsumes<edm::Transition::BeginRun>()) {
   if (!inputFile_.is_open())
     throw cms::Exception("Invalid input for EcalDQMStatusWriter");
 }
@@ -41,9 +42,8 @@ void EcalDQMStatusWriter::analyze(edm::Event const &, edm::EventSetup const &_es
 }
 
 void EcalDQMStatusWriter::setElectronicsMap(edm::EventSetup const &_es) {
-  edm::ESHandle<EcalElectronicsMapping> elecMapHandle;
-  _es.get<EcalMappingRcd>().get(elecMapHandle);
-  electronicsMap = elecMapHandle.product();
+
+  electronicsMap = &_es.getData(elecMapHandle);
 }
 
 EcalElectronicsMapping const *EcalDQMStatusWriter::GetElectronicsMap() {


### PR DESCRIPTION
#### PR description:

This PR addresses the migration of leftover ECAL DQM/* codes to use esConsumes as mentioned here: #31061

#### PR validation:

Validation done by running `scram build checker` where the warnings with respect to the ESConsumes go away and also validated by running the relval workflow 136.874 using the runTheMatrix script
`runTheMatrix.py -l 136.874 --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
N/A
