### PR TITLE
TkDQM: Fix tracker maps for run3

### DIFF
--- a/DQM/SiStripMonitorClient/plugins/SiStripOfflineDQM.cc
+++ b/DQM/SiStripMonitorClient/plugins/SiStripOfflineDQM.cc
@@ -37,6 +37,7 @@
 
 //Run Info
 #include "CondFormats/RunInfo/interface/RunInfo.h"
+#include "DQMServices/Core/interface/LegacyIOHelper.h"
 
 #include <iostream>
 #include <iomanip>
@@ -202,8 +203,10 @@ bool SiStripOfflineDQM::openInputFile(DQMStore& dqm_store) {
   if (inputFileName_.empty())
     return false;
   edm::LogInfo("OpenFile") << "SiStripOfflineDQM::openInputFile: Accessing root File" << inputFileName_;
-  dqm_store.open(inputFileName_, false);
-  return true;
+  dqm::harvesting::DQMStore* temp = dynamic_cast<dqm::harvesting::DQMStore*>(&dqm_store);
+  LegacyIOHelper leo(temp);
+  return leo.open(inputFileName_);
+  //return true;
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/DQM/SiStripMonitorClient/plugins/SiStripOfflineDQM.cc
+++ b/DQM/SiStripMonitorClient/plugins/SiStripOfflineDQM.cc
@@ -200,13 +200,13 @@ void SiStripOfflineDQM::endJob() {
 }
 
 bool SiStripOfflineDQM::openInputFile(DQMStore& dqm_store) {
-  if (inputFileName_.empty())
+  if (inputFileName_.empty()) {
     return false;
+  }
   edm::LogInfo("OpenFile") << "SiStripOfflineDQM::openInputFile: Accessing root File" << inputFileName_;
   dqm::harvesting::DQMStore* temp = dynamic_cast<dqm::harvesting::DQMStore*>(&dqm_store);
   LegacyIOHelper leo(temp);
   return leo.open(inputFileName_);
-  //return true;
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/DQM/SiStripMonitorClient/src/SiStripTrackerMapCreator.cc
+++ b/DQM/SiStripMonitorClient/src/SiStripTrackerMapCreator.cc
@@ -150,6 +150,9 @@ void SiStripTrackerMapCreator::createForOffline(const edm::ParameterSet& tkmapPs
                                    << " with range set to 0.0 - 1.0";
     trackerMap_->save(true, 0.0, 1.0, map_type + namesuffix + ".svg");
     trackerMap_->save(true, 0.0, 1.0, map_type + namesuffix + ".png", 4500, 2400);
+    // reset the map name to ResidualsMean to restore the
+    // correct behaviour for the summary file creation
+    map_type = "ResidualsMean";
   } else {
     edm::LogInfo("TkMapToBeSaved") << "Ready to save TkMap " << map_type << namesuffix << " with range set to "
                                    << tkMapMin_ << " - " << tkMapMax_;

--- a/DQM/SiStripMonitorClient/test/BuildFile.xml
+++ b/DQM/SiStripMonitorClient/test/BuildFile.xml
@@ -1,0 +1,4 @@
+<bin name="testSiStripDQM_OfflineTkMap" file="TestDriver.cpp">
+  <flags TEST_RUNNER_ARGS="/bin/bash DQM/SiStripMonitorClient/test test_SiStripDQM_OfflineTkMap.sh"/>
+  <use name="FWCore/Utilities"/>
+</bin>

--- a/DQM/SiStripMonitorClient/test/TestDriver.cpp
+++ b/DQM/SiStripMonitorClient/test/TestDriver.cpp
@@ -1,0 +1,2 @@
+#include "FWCore/Utilities/interface/TestHelper.h"
+RUNTEST()

--- a/DQM/SiStripMonitorClient/test/test_SiStripDQM_OfflineTkMap.sh
+++ b/DQM/SiStripMonitorClient/test/test_SiStripDQM_OfflineTkMap.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+function die { echo $1: status $2; exit $2; }
+GT=`echo ${@} | python3 -c 'import Configuration.AlCa.autoCond as AC;print(AC.autoCond["run3_data_prompt"])'`
+RUN="319176"
+DQMFILE="/store/group/comm_dqm/DQMGUI_data/Run2018/ZeroBias/R0003191xx/DQM_V0001_R000319176__ZeroBias__Run2018B-PromptReco-v2__DQMIO.root"
+COMMMAND=`xrdfs cms-xrd-global.cern.ch locate $DQMFILE`
+STATUS=$?
+echo "xrdfs command status = "$STATUS
+if [ $STATUS -eq 0 ]; then
+    echo "Using file ${DQMFILE} and run ${RUN}. Running in ${LOCAL_TEST_DIR}."
+    (cmsRun "${LOCAL_TEST_DIR}/SiStripDQM_OfflineTkMap_Template_cfg_DB.py" globalTag="$GT" runNumber="$RUN" dqmFile=" root://cms-xrd-global.cern.ch//$DQMFILE" detIdInfoFile="file.root") || die 'failed running SiStripDQM_OfflineTkMap_Template_cfg_DB.py' $?
+else 
+  die "SKIPPING test, file ${DQMFILE} not found" 0
+fi

--- a/DQMServices/Core/interface/LegacyIOHelper.h
+++ b/DQMServices/Core/interface/LegacyIOHelper.h
@@ -2,17 +2,8 @@
 #define DQMSERVICES_CORE_LEGACYIOHELPER_H
 
 #include "DQMServices/Core/interface/DQMStore.h"
-#include <iostream>
-#include <string>
-#include "TFile.h"
 #include "TROOT.h"
-#include "TKey.h"
-#include "TClass.h"
-#include "TSystem.h"
-#include "TBufferFile.h"
-#include <sstream>
-#include <utility>
-#include <set>
+
 // This class encapsulates the TDirectory based file format used for DQMGUI
 // uploads and many other use cases.
 // This should be part of `DQMFileSaver`, however since DQMServices/Components

--- a/DQMServices/Core/interface/LegacyIOHelper.h
+++ b/DQMServices/Core/interface/LegacyIOHelper.h
@@ -68,7 +68,7 @@ private:
     if (pos != std::string::npos) {
       dirpath.erase(pos, rsummary.length());
     }
-    std::cout << dirpath << std::endl;
+    //std::cout << dirpath << std::endl;
     meName = dirpath;
   }
   bool readdir(TDirectory *dir, const std::string& toppath);

--- a/DQMServices/Core/interface/LegacyIOHelper.h
+++ b/DQMServices/Core/interface/LegacyIOHelper.h
@@ -2,17 +2,17 @@
 #define DQMSERVICES_CORE_LEGACYIOHELPER_H
 
 #include "DQMServices/Core/interface/DQMStore.h"
-#include<iostream>
-#include<string>
+#include <iostream>
+#include <string>
 #include "TFile.h"
 #include "TROOT.h"
 #include "TKey.h"
 #include "TClass.h"
 #include "TSystem.h"
 #include "TBufferFile.h"
-#include<sstream>
-#include<utility>
-#include<set>
+#include <sstream>
+#include <utility>
+#include <set>
 // This class encapsulates the TDirectory based file format used for DQMGUI
 // uploads and many other use cases.
 // This should be part of `DQMFileSaver`, however since DQMServices/Components
@@ -27,13 +27,13 @@ public:
   typedef dqm::implementation::DQMStore DQMStore;
   typedef dqm::legacy::MonitorElement MonitorElement;
 
-  typedef dqm::harvesting::DQMStore HDQMStore;
-  typedef dqm::harvesting::MonitorElement HMonitorElement;
+  typedef dqm::harvesting::DQMStore HarvestedDQMStore;
+  typedef dqm::harvesting::MonitorElement HarvestedMonitorElement;
 
-  using MEMap = std::set<HMonitorElement*>;
+  using MEMap = std::set<HarvestedMonitorElement*>;
 
   LegacyIOHelper(DQMStore* dqmstore) : dbe_(dqmstore){};
-  LegacyIOHelper(HDQMStore* hdqmstore) : dbe_(hdqmstore){};
+  LegacyIOHelper(HarvestedDQMStore* hdqmstore) : dbe_(hdqmstore){};
   // Replace or append to `filename`, a TDirectory ROOT file. If a run number
   // is passed, the paths are rewritten to the "Run Summary" format used by
   // DQMGUI. The run number does not affect which MEs are saved; this code only
@@ -48,13 +48,11 @@ public:
             bool saveall = true,
             std::string const& fileupdate = "RECREATE");
 
-  bool open(std::string const& filename,
-            std::string const& path = "",
-            uint32_t const run = 0);
+  bool open(std::string const& filename, std::string const& path = "", uint32_t const run = 0);
 
 private:
-  template<class T>
-    void getMEName(T* h, const std::string& toppath, std::string& meName){
+  template <class T>
+  void getMEName(T* h, const std::string& toppath, std::string& meName) {
     std::ostringstream fullpath;
     fullpath << gDirectory->GetPath() << "/" << h->GetName();
     std::string dirpath = fullpath.str();
@@ -68,10 +66,9 @@ private:
     if (pos != std::string::npos) {
       dirpath.erase(pos, rsummary.length());
     }
-    //std::cout << dirpath << std::endl;
     meName = dirpath;
   }
-  bool readdir(TDirectory *dir, const std::string& toppath);
+  bool readdir(TDirectory* dir, const std::string& toppath);
   bool createDirectoryIfNeededAndCd(const std::string& path);
   DQMStore* dbe_;
   MEMap data_;

--- a/DQMServices/Core/interface/LegacyIOHelper.h
+++ b/DQMServices/Core/interface/LegacyIOHelper.h
@@ -2,7 +2,17 @@
 #define DQMSERVICES_CORE_LEGACYIOHELPER_H
 
 #include "DQMServices/Core/interface/DQMStore.h"
-
+#include<iostream>
+#include<string>
+#include "TFile.h"
+#include "TROOT.h"
+#include "TKey.h"
+#include "TClass.h"
+#include "TSystem.h"
+#include "TBufferFile.h"
+#include<sstream>
+#include<utility>
+#include<set>
 // This class encapsulates the TDirectory based file format used for DQMGUI
 // uploads and many other use cases.
 // This should be part of `DQMFileSaver`, however since DQMServices/Components
@@ -16,8 +26,14 @@ public:
   // use internal type here since we call this from the DQMStore itself.
   typedef dqm::implementation::DQMStore DQMStore;
   typedef dqm::legacy::MonitorElement MonitorElement;
-  LegacyIOHelper(DQMStore* dqmstore) : dbe_(dqmstore){};
 
+  typedef dqm::harvesting::DQMStore HDQMStore;
+  typedef dqm::harvesting::MonitorElement HMonitorElement;
+
+  using MEMap = std::set<HMonitorElement*>;
+
+  LegacyIOHelper(DQMStore* dqmstore) : dbe_(dqmstore){};
+  LegacyIOHelper(HDQMStore* hdqmstore) : dbe_(hdqmstore){};
   // Replace or append to `filename`, a TDirectory ROOT file. If a run number
   // is passed, the paths are rewritten to the "Run Summary" format used by
   // DQMGUI. The run number does not affect which MEs are saved; this code only
@@ -32,9 +48,33 @@ public:
             bool saveall = true,
             std::string const& fileupdate = "RECREATE");
 
+  bool open(std::string const& filename,
+            std::string const& path = "",
+            uint32_t const run = 0);
+
 private:
+  template<class T>
+    void getMEName(T* h, const std::string& toppath, std::string& meName){
+    std::ostringstream fullpath;
+    fullpath << gDirectory->GetPath() << "/" << h->GetName();
+    std::string dirpath = fullpath.str();
+    // Search for the substring in string
+    size_t pos = dirpath.find(toppath);
+    if (pos != std::string::npos) {
+      dirpath.erase(pos, toppath.length());
+    }
+    std::string rsummary = "/Run summary";
+    pos = dirpath.find(rsummary);
+    if (pos != std::string::npos) {
+      dirpath.erase(pos, rsummary.length());
+    }
+    std::cout << dirpath << std::endl;
+    meName = dirpath;
+  }
+  bool readdir(TDirectory *dir, const std::string& toppath);
   bool createDirectoryIfNeededAndCd(const std::string& path);
   DQMStore* dbe_;
+  MEMap data_;
 };
 
 #endif

--- a/DQMServices/Core/src/LegacyIOHelper.cc
+++ b/DQMServices/Core/src/LegacyIOHelper.cc
@@ -1,4 +1,5 @@
 #include "DQMServices/Core/interface/LegacyIOHelper.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <cstdio>
 #include <cfloat>
@@ -165,14 +166,14 @@ bool LegacyIOHelper::createDirectoryIfNeededAndCd(const std::string &path) {
   return true;
 }
 
-bool LegacyIOHelper::readdir(TDirectory *dir, const std::string& toppath) {
+bool LegacyIOHelper::readdir(TDirectory *dir, const std::string &toppath) {
   TDirectory *dirsav = gDirectory;
-  //cout << "Inside:" << gDirectory->GetPath() << std::endl;
+  LogDebug("LegacyIOHelper") << "Inside:" << gDirectory->GetPath() << std::endl;
   TIter next(dir->GetListOfKeys());
   TKey *key;
-  while ((key = (TKey*)next())) {
+  while ((key = (TKey *)next())) {
     if (key->IsFolder()) {
-      //cout << key->GetName() << std::endl;
+      LogDebug("LegacyIOHelper") << key->GetName() << std::endl;
       dir->cd(key->GetName());
       TDirectory *subdir = gDirectory;
       readdir(subdir, toppath);
@@ -181,92 +182,85 @@ bool LegacyIOHelper::readdir(TDirectory *dir, const std::string& toppath) {
     } else {
       TClass *cl = gROOT->GetClass(key->GetClassName());
       std::string meName;
-      if(cl->InheritsFrom("TProfile")) {
-	TProfile *h = dynamic_cast<TProfile*>(key->ReadObject<TProfile>()->Clone());
-	h->SetDirectory(0);
-	if(h) {
-	  getMEName<TProfile>(h, toppath, meName);
-	  data_.insert(dbe_->bookProfile(meName, h));
-	}
+      if (cl->InheritsFrom("TProfile")) {
+        TProfile *h = dynamic_cast<TProfile *>(key->ReadObject<TProfile>()->Clone());
+        h->SetDirectory(nullptr);
+        if (h) {
+          getMEName<TProfile>(h, toppath, meName);
+          data_.insert(dbe_->bookProfile(meName, h));
+        }
+      } else if (cl->InheritsFrom("TProfile2D")) {
+        TProfile2D *h = dynamic_cast<TProfile2D *>(key->ReadObject<TProfile2D>()->Clone());
+        h->SetDirectory(nullptr);
+        if (h) {
+          getMEName<TProfile2D>(h, toppath, meName);
+          data_.insert(dbe_->bookProfile2D(meName, h));
+        }
+      } else if (cl->InheritsFrom("TH1F")) {
+        TH1F *h = dynamic_cast<TH1F *>(key->ReadObject<TH1F>()->Clone());
+        h->SetDirectory(nullptr);
+        if (h) {
+          getMEName<TH1F>(h, toppath, meName);
+          data_.insert(dbe_->book1D(meName, h));
+        }
+      } else if (cl->InheritsFrom("TH1S")) {
+        TH1S *h = dynamic_cast<TH1S *>(key->ReadObject<TH1S>()->Clone());
+        h->SetDirectory(nullptr);
+        if (h) {
+          getMEName<TH1S>(h, toppath, meName);
+          data_.insert(dbe_->book1S(meName, h));
+        }
+      } else if (cl->InheritsFrom("TH1D")) {
+        TH1D *h = dynamic_cast<TH1D *>(key->ReadObject<TH1D>()->Clone());
+        h->SetDirectory(nullptr);
+        if (h) {
+          getMEName<TH1D>(h, toppath, meName);
+          data_.insert(dbe_->book1DD(meName, h));
+        }
+      } else if (cl->InheritsFrom("TH2F")) {
+        TH2F *h = dynamic_cast<TH2F *>(key->ReadObject<TH2F>()->Clone());
+        h->SetDirectory(nullptr);
+        if (h) {
+          getMEName<TH2F>(h, toppath, meName);
+          data_.insert(dbe_->book2D(meName, h));
+        }
+      } else if (cl->InheritsFrom("TH2S")) {
+        TH2S *h = dynamic_cast<TH2S *>(key->ReadObject<TH2S>()->Clone());
+        h->SetDirectory(nullptr);
+        if (h) {
+          getMEName<TH2S>(h, toppath, meName);
+          data_.insert(dbe_->book2S(meName, h));
+        }
+      } else if (cl->InheritsFrom("TH2D")) {
+        TH2D *h = dynamic_cast<TH2D *>(key->ReadObject<TH2D>()->Clone());
+        h->SetDirectory(nullptr);
+        if (h) {
+          getMEName<TH2D>(h, toppath, meName);
+          data_.insert(dbe_->book2DD(meName, h));
+        }
+      } else if (cl->InheritsFrom("TH3F")) {
+        TH3F *h = dynamic_cast<TH3F *>(key->ReadObject<TH3F>()->Clone());
+        h->SetDirectory(nullptr);
+        if (h) {
+          getMEName<TH3F>(h, toppath, meName);
+          data_.insert(dbe_->book3D(meName, h));
+        }
       }
-      else if(cl->InheritsFrom("TProfile2D")) {
-	TProfile2D *h =  dynamic_cast<TProfile2D*>(key->ReadObject<TProfile2D>()->Clone());
-	h->SetDirectory(0);
-	if(h) {
-	  getMEName<TProfile2D>(h, toppath, meName);
-	  data_.insert(dbe_->bookProfile2D(meName, h));
-	}
-      }
-      else if(cl->InheritsFrom("TH1F")) {
-	TH1F *h =  dynamic_cast<TH1F*>(key->ReadObject<TH1F>()->Clone());
-	h->SetDirectory(0);
-	if(h) {
-	  getMEName<TH1F>(h, toppath, meName);
-	  data_.insert(dbe_->book1D(meName, h));
-	}
-      }
-      else if(cl->InheritsFrom("TH1S")) {
-	TH1S *h = dynamic_cast<TH1S*>(key->ReadObject<TH1S>()->Clone());
-	h->SetDirectory(0);
-	if(h) {
-	  getMEName<TH1S>(h, toppath, meName);
-	  data_.insert(dbe_->book1S(meName, h));
-	}
-      }
-      else if(cl->InheritsFrom("TH1D")) {
-	TH1D *h = dynamic_cast<TH1D*>(key->ReadObject<TH1D>()->Clone());
-	h->SetDirectory(0);
-	if(h) {
-	  getMEName<TH1D>(h, toppath, meName);
-	  data_.insert(dbe_->book1DD(meName, h));
-	}
-      }
-      else if(cl->InheritsFrom("TH2F")) {
-	TH2F *h = dynamic_cast<TH2F*>(key->ReadObject<TH2F>()->Clone());
-	h->SetDirectory(0);
-	if(h) { 
-	  getMEName<TH2F>(h, toppath, meName);
-	  data_.insert(dbe_->book2D(meName, h));
-	}	  
-      }
-      else if(cl->InheritsFrom("TH2S")) {
-	TH2S *h =dynamic_cast<TH2S*>(key->ReadObject<TH2S>()->Clone());
-	h->SetDirectory(0);
-	if(h) {
-	  getMEName<TH2S>(h, toppath, meName);
-	  data_.insert(dbe_->book2S(meName, h));
-	}
-      }
-      else if(cl->InheritsFrom("TH2D")) {
-	TH2D *h = dynamic_cast<TH2D*>(key->ReadObject<TH2D>()->Clone());
-	h->SetDirectory(0);
-	if(h) {
-	  getMEName<TH2D>(h, toppath, meName);
-	  data_.insert(dbe_->book2DD(meName, h));
-	}
-      }
-      else if(cl->InheritsFrom("TH3F")) {
-	TH3F *h = dynamic_cast<TH3F*>(key->ReadObject<TH3F>()->Clone());
-	h->SetDirectory(0);
-	if(h) {
-	  getMEName<TH3F>(h, toppath, meName);
-	  data_.insert(dbe_->book3D(meName, h));
-	}
-      }
-
     }
   }
-  if(!data_.empty()) return true;
+  if (!data_.empty())
+    return true;
   return false;
 }
 
-bool LegacyIOHelper::open(std::string const& filename, std::string const& path, uint32_t const run){
-  TFile* f1 = TFile::Open(filename.c_str());
-  if(!f1) return false;
+bool LegacyIOHelper::open(std::string const &filename, std::string const &path, uint32_t const run) {
+  TFile *f1 = TFile::Open(filename.c_str());
+  if (!f1)
+    return false;
   std::ostringstream toppath;
   toppath << filename << ":/DQMData/Run " << run << "/";
   std::string dirpath = toppath.str();
-  std::cout << dirpath << std::endl;
+  edm::LogPrint("LegacyIOHelper") << dirpath << std::endl;
   bool flag = readdir(f1, dirpath);
   f1->Close();
   return flag;

--- a/DQMServices/Core/src/LegacyIOHelper.cc
+++ b/DQMServices/Core/src/LegacyIOHelper.cc
@@ -9,6 +9,7 @@
 #include "TString.h"
 #include "TSystem.h"
 #include "TFile.h"
+#include "TKey.h"
 #include <sys/stat.h>
 
 void LegacyIOHelper::save(std::string const &filename,

--- a/DQMServices/Core/src/LegacyIOHelper.cc
+++ b/DQMServices/Core/src/LegacyIOHelper.cc
@@ -182,63 +182,72 @@ bool LegacyIOHelper::readdir(TDirectory *dir, const std::string& toppath) {
       TClass *cl = gROOT->GetClass(key->GetClassName());
       std::string meName;
       if(cl->InheritsFrom("TProfile")) {
-	TProfile *h = key->ReadObject<TProfile>();
+	TProfile *h = dynamic_cast<TProfile*>(key->ReadObject<TProfile>()->Clone());
+	h->SetDirectory(0);
 	if(h) {
 	  getMEName<TProfile>(h, toppath, meName);
 	  data_.insert(dbe_->bookProfile(meName, h));
 	}
       }
       else if(cl->InheritsFrom("TProfile2D")) {
-	TProfile2D *h = key->ReadObject<TProfile2D>();
+	TProfile2D *h =  dynamic_cast<TProfile2D*>(key->ReadObject<TProfile2D>()->Clone());
+	h->SetDirectory(0);
 	if(h) {
 	  getMEName<TProfile2D>(h, toppath, meName);
 	  data_.insert(dbe_->bookProfile2D(meName, h));
 	}
       }
       else if(cl->InheritsFrom("TH1F")) {
-	TH1F *h = key->ReadObject<TH1F>();
+	TH1F *h =  dynamic_cast<TH1F*>(key->ReadObject<TH1F>()->Clone());
+	h->SetDirectory(0);
 	if(h) {
 	  getMEName<TH1F>(h, toppath, meName);
 	  data_.insert(dbe_->book1D(meName, h));
 	}
       }
       else if(cl->InheritsFrom("TH1S")) {
-	TH1S *h = key->ReadObject<TH1S>();
+	TH1S *h = dynamic_cast<TH1S*>(key->ReadObject<TH1S>()->Clone());
+	h->SetDirectory(0);
 	if(h) {
 	  getMEName<TH1S>(h, toppath, meName);
 	  data_.insert(dbe_->book1S(meName, h));
 	}
       }
       else if(cl->InheritsFrom("TH1D")) {
-	TH1D *h = key->ReadObject<TH1D>();
+	TH1D *h = dynamic_cast<TH1D*>(key->ReadObject<TH1D>()->Clone());
+	h->SetDirectory(0);
 	if(h) {
 	  getMEName<TH1D>(h, toppath, meName);
 	  data_.insert(dbe_->book1DD(meName, h));
 	}
       }
       else if(cl->InheritsFrom("TH2F")) {
-	TH2F *h = key->ReadObject<TH2F>();
+	TH2F *h = dynamic_cast<TH2F*>(key->ReadObject<TH2F>()->Clone());
+	h->SetDirectory(0);
 	if(h) { 
 	  getMEName<TH2F>(h, toppath, meName);
 	  data_.insert(dbe_->book2D(meName, h));
 	}	  
       }
       else if(cl->InheritsFrom("TH2S")) {
-	TH2S *h = key->ReadObject<TH2S>();
+	TH2S *h =dynamic_cast<TH2S*>(key->ReadObject<TH2S>()->Clone());
+	h->SetDirectory(0);
 	if(h) {
 	  getMEName<TH2S>(h, toppath, meName);
 	  data_.insert(dbe_->book2S(meName, h));
 	}
       }
       else if(cl->InheritsFrom("TH2D")) {
-	TH2D *h = key->ReadObject<TH2D>();
+	TH2D *h = dynamic_cast<TH2D*>(key->ReadObject<TH2D>()->Clone());
+	h->SetDirectory(0);
 	if(h) {
 	  getMEName<TH2D>(h, toppath, meName);
 	  data_.insert(dbe_->book2DD(meName, h));
 	}
       }
       else if(cl->InheritsFrom("TH3F")) {
-	TH3F *h = key->ReadObject<TH3F>();
+	TH3F *h = dynamic_cast<TH3F*>(key->ReadObject<TH3F>()->Clone());
+	h->SetDirectory(0);
 	if(h) {
 	  getMEName<TH3F>(h, toppath, meName);
 	  data_.insert(dbe_->book3D(meName, h));
@@ -258,5 +267,7 @@ bool LegacyIOHelper::open(std::string const& filename, std::string const& path, 
   toppath << filename << ":/DQMData/Run " << run << "/";
   std::string dirpath = toppath.str();
   std::cout << dirpath << std::endl;
-  return readdir(f1, dirpath);
+  bool flag = readdir(f1, dirpath);
+  f1->Close();
+  return flag;
 }


### PR DESCRIPTION
#### PR description:
This PR is aimed at resolving #34607 . The reading capability of a ```TDirectory``` based ROOT file is enabled in the LegacyIOHelper and that is used by the ```SiStripOfflineDQM``` module. In addition, this PR adds a unit test for the offline TkMap creation. 
Thanks to @mmusich for debugging several aspects of the changes. Some bug fixes for some of the TkMaps are expected which can come as a separate PR later.
#### PR validation:

The updates have been tested privately and Tracker Maps are getting produced with DQM harvested root file as an input.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
Backport will be done for 11_3 and 12_0. 