### PR TITLE
Restore cms::cuda::ESProduct construction without GPU

### DIFF
--- a/HeterogeneousCore/CUDACore/interface/ESProduct.h
+++ b/HeterogeneousCore/CUDACore/interface/ESProduct.h
@@ -20,10 +20,12 @@ namespace cms {
     class ESProduct {
     public:
       ESProduct() : gpuDataPerDevice_(numberOfDevices()) {
-        cms::cuda::ScopedSetDevice scopedDevice;
-        for (size_t i = 0; i < gpuDataPerDevice_.size(); ++i) {
-          scopedDevice.set(i);
-          gpuDataPerDevice_[i].m_event = getEventCache().get();
+        if (not gpuDataPerDevice_.empty()) {
+          cms::cuda::ScopedSetDevice scopedDevice;
+          for (size_t i = 0; i < gpuDataPerDevice_.size(); ++i) {
+            scopedDevice.set(i);
+            gpuDataPerDevice_[i].m_event = getEventCache().get();
+          }
         }
       }
 


### PR DESCRIPTION
#### PR description:

This PR addresses an oversight in https://github.com/cms-sw/cmssw/pull/34948 that `PixelCPEFast` ESProduct expects `cms::cuda::ESProduct` can be constructed also without GPU. The `PixelCPEFast` really needs to be changed to not require such behavior, but that may be best to be left for larger reorganization of the CUDA ESProducts. Therefore this PR does only a quick fix.

#### PR validation:

Workflow 136.885501 runs on a machine without GPU.