### PR TITLE
Updates to the TTTrack/TTTrack_TrackWord DataFormats

### DIFF
--- a/DataFormats/L1TrackTrigger/BuildFile.xml
+++ b/DataFormats/L1TrackTrigger/BuildFile.xml
@@ -2,6 +2,7 @@
 <use name="DataFormats/DetId"/>
 <use name="DataFormats/GeometryCommonDetAlgo"/>
 <use name="DataFormats/GeometryVector"/>
+<use name="DataFormats/Math"/>
 <use name="DataFormats/Phase2TrackerDigi"/>
 <use name="DataFormats/SiStripDetId"/>
 <use name="DataFormats/TrackerCommon"/>

--- a/DataFormats/L1TrackTrigger/interface/TTTrack.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack.h
@@ -105,6 +105,9 @@ public:
   /// Track phi
   double phi() const;
 
+  /// Local track phi (within the sector)
+  double localPhi() const;
+
   /// Track tanL
   double tanL() const;
 
@@ -314,6 +317,11 @@ double TTTrack<T>::phi() const {
 }
 
 template <typename T>
+double TTTrack<T>::localPhi() const {
+  return TTTrack_TrackWord::localPhi(thePhi_, thePhiSector_);
+}
+
+template <typename T>
 double TTTrack<T>::d0() const {
   return theD0_;
 }
@@ -441,9 +449,17 @@ void TTTrack<T>::setTrackWordBits() {
   // missing conversion of global phi to difference from sector center phi
 
   if (theChi2_Z_ < 0) {
-    setTrackWord(
-        valid, theMomentum_, thePOCA_, theRInv_, chi2Red(), 0, chi2BendRed(), theHitPattern_, mvaQuality, mvaOther);
-
+    setTrackWord(valid,
+                 theMomentum_,
+                 thePOCA_,
+                 theRInv_,
+                 theChi2_,
+                 0,
+                 theStubPtConsistency_,
+                 theHitPattern_,
+                 mvaQuality,
+                 mvaOther,
+                 thePhiSector_);
   } else {
     setTrackWord(valid,
                  theMomentum_,
@@ -454,7 +470,8 @@ void TTTrack<T>::setTrackWordBits() {
                  chi2BendRed(),
                  theHitPattern_,
                  mvaQuality,
-                 mvaOther);
+                 mvaOther,
+                 thePhiSector_);
   }
   return;
 }

--- a/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
@@ -15,14 +15,22 @@
 
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include "DataFormats/Math/interface/deltaPhi.h"
 
 #include <ap_int.h>
 
 #include <algorithm>
 #include <array>
 #include <bitset>
+#include <cmath>
+#include <limits>
 #include <string>
 #include <vector>
+
+namespace tttrack_trackword {
+  void infoTestDigitizationScheme(
+      const unsigned int, const double, const double, const unsigned int, const double, const unsigned int);
+}
 
 class TTTrack_TrackWord {
 public:
@@ -96,6 +104,10 @@ public:
   static constexpr std::array<double, 1 << TrackBitWidths::kBendChi2Size> bendChi2Bins = {
       {0.0, 0.75, 1.0, 1.5, 2.25, 3.5, 5.0, 20.0}};
 
+  // Sector constants
+  static constexpr unsigned int nSectors = 9;
+  static constexpr double sectorWidth = (2. * M_PI) / nSectors;
+
   // Track flags
   typedef ap_uint<TrackBitWidths::kValidSize> valid_t;  // valid bit
 
@@ -130,10 +142,11 @@ public:
                     double bendChi2,
                     unsigned int hitPattern,
                     unsigned int mvaQuality,
-                    unsigned int mvaOther);
+                    unsigned int mvaOther,
+                    unsigned int sector);
   TTTrack_TrackWord(unsigned int valid,
                     unsigned int rInv,
-                    unsigned int phi0,
+                    unsigned int phi0,  // local phi
                     unsigned int tanl,
                     unsigned int z0,
                     unsigned int d0,
@@ -201,11 +214,11 @@ public:
   // These functions return the unpacked and converted values
   // These functions return real numbers converted from the digitized quantities by unpacking the 96-bit track word
   bool getValid() const { return getValidWord().to_bool(); }
-  double getRinv() const { return unpackSignedValue(getRinvBits(), TrackBitWidths::kRinvSize, stepRinv); }
-  double getPhi() const { return unpackSignedValue(getPhiBits(), TrackBitWidths::kPhiSize, stepPhi0); }
-  double getTanl() const { return unpackSignedValue(getTanlBits(), TrackBitWidths::kTanlSize, stepTanL); }
-  double getZ0() const { return unpackSignedValue(getZ0Bits(), TrackBitWidths::kZ0Size, stepZ0); }
-  double getD0() const { return unpackSignedValue(getD0Bits(), TrackBitWidths::kD0Size, stepD0); }
+  double getRinv() const { return undigitizeSignedValue(getRinvBits(), TrackBitWidths::kRinvSize, stepRinv); }
+  double getPhi() const { return undigitizeSignedValue(getPhiBits(), TrackBitWidths::kPhiSize, stepPhi0); }
+  double getTanl() const { return undigitizeSignedValue(getTanlBits(), TrackBitWidths::kTanlSize, stepTanL); }
+  double getZ0() const { return undigitizeSignedValue(getZ0Bits(), TrackBitWidths::kZ0Size, stepZ0); }
+  double getD0() const { return undigitizeSignedValue(getD0Bits(), TrackBitWidths::kD0Size, stepD0); }
   double getChi2RPhi() const { return chi2RPhiBins[getChi2RPhiBits()]; }
   double getChi2RZ() const { return chi2RZBins[getChi2RZBits()]; }
   double getBendChi2() const { return bendChi2Bins[getBendChi2Bits()]; }
@@ -223,11 +236,12 @@ public:
                     double bendChi2,
                     unsigned int hitPattern,
                     unsigned int mvaQuality,
-                    unsigned int mvaOther);
+                    unsigned int mvaOther,
+                    unsigned int sector);
 
   void setTrackWord(unsigned int valid,
                     unsigned int rInv,
-                    unsigned int phi0,
+                    unsigned int phi0,  // local phi
                     unsigned int tanl,
                     unsigned int z0,
                     unsigned int d0,
@@ -240,7 +254,7 @@ public:
 
   void setTrackWord(ap_uint<TrackBitWidths::kValidSize> valid,
                     ap_uint<TrackBitWidths::kRinvSize> rInv,
-                    ap_uint<TrackBitWidths::kPhiSize> phi0,
+                    ap_uint<TrackBitWidths::kPhiSize> phi0,  // local phi
                     ap_uint<TrackBitWidths::kTanlSize> tanl,
                     ap_uint<TrackBitWidths::kZ0Size> z0,
                     ap_uint<TrackBitWidths::kD0Size> d0,
@@ -251,16 +265,36 @@ public:
                     ap_uint<TrackBitWidths::kMVAQualitySize> mvaQuality,
                     ap_uint<TrackBitWidths::kMVAOtherSize> mvaOther);
 
+  // ----------member functions (testers) ------------
+  bool singleDigitizationSchemeTest(const double floatingPointValue, const unsigned int nBits, const double lsb) const;
+  void testDigitizationScheme() const;
+
+protected:
+  // ----------protected member functions ------------
+  float localPhi(float globalPhi, unsigned int sector) const {
+    return reco::deltaPhi(globalPhi, (sector * sectorWidth));
+  }
+
 private:
   // ----------private member functions --------------
   unsigned int digitizeSignedValue(double value, unsigned int nBits, double lsb) const {
-    unsigned int digitized_value = std::floor(std::abs(value) / lsb);
-    unsigned int digitized_maximum = (1 << (nBits - 1)) - 1;  // The remove 1 bit from nBits to account for the sign
-    if (digitized_value > digitized_maximum)
-      digitized_value = digitized_maximum;
-    if (value < 0)
-      digitized_value = (1 << nBits) - digitized_value;  // two's complement encoding
-    return digitized_value;
+    // Digitize the incoming value
+    int digitizedValue = std::floor(value / lsb);
+
+    // Calculate the maxmum possible positive value given an output of nBits in size
+    int digitizedMaximum = (1 << (nBits - 1)) - 1;  // The remove 1 bit from nBits to account for the sign
+    int digitizedMinimum = -1. * (digitizedMaximum + 1);
+
+    // Saturate the digitized value
+    digitizedValue = std::clamp(digitizedValue, digitizedMinimum, digitizedMaximum);
+
+    // Do the two's compliment encoding
+    unsigned int twosValue = digitizedValue;
+    if (digitizedValue < 0) {
+      twosValue += (1 << nBits);
+    }
+
+    return twosValue;
   }
 
   template <typename T>
@@ -269,14 +303,20 @@ private:
     return (up - bins.begin() - 1);
   }
 
-  double unpackSignedValue(unsigned int bits, unsigned int nBits, double lsb) const {
-    int isign = 1;
-    unsigned int digitized_maximum = (1 << nBits) - 1;
-    if (bits & (1 << (nBits - 1))) {  // check the sign
-      isign = -1;
-      bits = (1 << (nBits + 1)) - bits;  // if negative, flip everything for two's complement encoding
+  double undigitizeSignedValue(unsigned int twosValue, unsigned int nBits, double lsb) const {
+    // Check that none of the bits above the nBits-1 bit, in a range of [0, nBits-1], are set.
+    // This makes sure that it isn't possible for the value represented by `twosValue` to be
+    //  any bigger than ((1 << nBits) - 1).
+    assert((twosValue >> nBits) == 0);
+
+    // Convert from twos compliment to C++ signed integer (normal digitized value)
+    int digitizedValue = twosValue;
+    if (twosValue & (1 << (nBits - 1))) {  // check if the twosValue is negative
+      digitizedValue -= (1 << nBits);
     }
-    return (double(bits & digitized_maximum) + 0.5) * lsb * isign;
+
+    // Convert to floating point value
+    return (double(digitizedValue) + 0.5) * lsb;
   }
 
   // ----------member data ---------------------------

--- a/DataFormats/L1TrackTrigger/test/BuildFile.xml
+++ b/DataFormats/L1TrackTrigger/test/BuildFile.xml
@@ -1,0 +1,10 @@
+<environment>
+  <test name="TestDataFormatsTTTrackTrackWord" command="cmsRun ${LOCALTOP}/src/DataFormats/L1TrackTrigger/test/testDataFormatsTTTrackTrackWord_cfg.py"/>
+  <library file="TestDataFormatsTTTrackTrackWord.cc" name="DataFormatsTTTrackTrackWordTest">
+    <flags EDM_PLUGIN="1"/>
+    <use name="FWCore/Framework"/>
+    <use name="FWCore/ParameterSet"/>
+    <use name="DataFormats/L1TrackTrigger"/>
+    <use name="DataFormats/TestObjects"/>
+  </library>
+</environment>

--- a/DataFormats/L1TrackTrigger/test/TestDataFormatsTTTrackTrackWord.cc
+++ b/DataFormats/L1TrackTrigger/test/TestDataFormatsTTTrackTrackWord.cc
@@ -1,0 +1,31 @@
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "DataFormats/TestObjects/interface/ToyProducts.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h"
+
+#include <memory>
+
+namespace trackwordtest {
+  class TTTrackTrackWordDummyOneAnalyzer : public edm::EDAnalyzer {
+  public:
+    explicit TTTrackTrackWordDummyOneAnalyzer(const edm::ParameterSet&) {}
+    ~TTTrackTrackWordDummyOneAnalyzer() {}
+
+    void analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) override {
+      TTTrack_TrackWord tw;
+      tw.testDigitizationScheme();
+    }
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      edm::ParameterSetDescription desc;
+      //to ensure distinct cfi names
+      descriptions.addWithDefaultLabel(desc);
+    }
+  };
+}  // namespace trackwordtest
+
+using trackwordtest::TTTrackTrackWordDummyOneAnalyzer;
+DEFINE_FWK_MODULE(TTTrackTrackWordDummyOneAnalyzer);

--- a/DataFormats/L1TrackTrigger/test/testDataFormatsTTTrackTrackWord_cfg.py
+++ b/DataFormats/L1TrackTrigger/test/testDataFormatsTTTrackTrackWord_cfg.py
@@ -1,0 +1,14 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("Test")
+
+process.source = cms.Source("EmptySource")
+
+process.maxEvents.input = 1
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.INFO.limit = cms.untracked.int32(1000000000)
+
+process.dummyAna = cms.EDAnalyzer("TTTrackTrackWordDummyOneAnalyzer")
+
+process.p = cms.Path(process.dummyAna)

--- a/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker.cc
+++ b/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker.cc
@@ -207,6 +207,7 @@ private:
   std::vector<float>* m_trk_pt;
   std::vector<float>* m_trk_eta;
   std::vector<float>* m_trk_phi;
+  std::vector<float>* m_trk_phi_local;
   std::vector<float>* m_trk_d0;  // (filled if nFitPar==5, else 999)
   std::vector<float>* m_trk_z0;
   std::vector<float>* m_trk_chi2;
@@ -237,6 +238,7 @@ private:
   std::vector<float>* m_trkExt_pt;
   std::vector<float>* m_trkExt_eta;
   std::vector<float>* m_trkExt_phi;
+  std::vector<float>* m_trkExt_phi_local;
   std::vector<float>* m_trkExt_d0;  // (filled if nFitPar==5, else 999)
   std::vector<float>* m_trkExt_z0;
   std::vector<float>* m_trkExt_chi2;
@@ -499,6 +501,7 @@ void L1TrackObjectNtupleMaker::beginJob() {
   m_trk_pt = new std::vector<float>;
   m_trk_eta = new std::vector<float>;
   m_trk_phi = new std::vector<float>;
+  m_trk_phi_local = new std::vector<float>;
   m_trk_z0 = new std::vector<float>;
   m_trk_d0 = new std::vector<float>;
   m_trk_chi2 = new std::vector<float>;
@@ -528,6 +531,7 @@ void L1TrackObjectNtupleMaker::beginJob() {
   m_trkExt_pt = new std::vector<float>;
   m_trkExt_eta = new std::vector<float>;
   m_trkExt_phi = new std::vector<float>;
+  m_trkExt_phi_local = new std::vector<float>;
   m_trkExt_z0 = new std::vector<float>;
   m_trkExt_d0 = new std::vector<float>;
   m_trkExt_chi2 = new std::vector<float>;
@@ -687,6 +691,7 @@ void L1TrackObjectNtupleMaker::beginJob() {
     eventTree->Branch("trk_pt", &m_trk_pt);
     eventTree->Branch("trk_eta", &m_trk_eta);
     eventTree->Branch("trk_phi", &m_trk_phi);
+    eventTree->Branch("trk_phi_local", &m_trk_phi_local);
     eventTree->Branch("trk_d0", &m_trk_d0);
     eventTree->Branch("trk_z0", &m_trk_z0);
     eventTree->Branch("trk_chi2", &m_trk_chi2);
@@ -723,6 +728,7 @@ void L1TrackObjectNtupleMaker::beginJob() {
     eventTree->Branch("trkExt_pt", &m_trkExt_pt);
     eventTree->Branch("trkExt_eta", &m_trkExt_eta);
     eventTree->Branch("trkExt_phi", &m_trkExt_phi);
+    eventTree->Branch("trkExt_phi_local", &m_trkExt_phi_local);
     eventTree->Branch("trkExt_d0", &m_trkExt_d0);
     eventTree->Branch("trkExt_z0", &m_trkExt_z0);
     eventTree->Branch("trkExt_chi2", &m_trkExt_chi2);
@@ -935,6 +941,7 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
     m_trk_pt->clear();
     m_trk_eta->clear();
     m_trk_phi->clear();
+    m_trk_phi_local->clear();
     m_trk_d0->clear();
     m_trk_z0->clear();
     m_trk_chi2->clear();
@@ -965,6 +972,7 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
     m_trkExt_pt->clear();
     m_trkExt_eta->clear();
     m_trkExt_phi->clear();
+    m_trkExt_phi_local->clear();
     m_trkExt_d0->clear();
     m_trkExt_z0->clear();
     m_trkExt_chi2->clear();
@@ -1346,6 +1354,7 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
       float tmp_trk_pt = iterL1Track->momentum().perp();
       float tmp_trk_eta = iterL1Track->momentum().eta();
       float tmp_trk_phi = iterL1Track->momentum().phi();
+      float tmp_trk_phi_local = iterL1Track->localPhi();
       float tmp_trk_z0 = iterL1Track->z0();            //cm
       int tmp_trk_nFitPars = iterL1Track->nFitPars();  //4 or 5
 
@@ -1438,6 +1447,7 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
       m_trk_pt->push_back(tmp_trk_pt);
       m_trk_eta->push_back(tmp_trk_eta);
       m_trk_phi->push_back(tmp_trk_phi);
+      m_trk_phi_local->push_back(tmp_trk_phi_local);
       m_trk_z0->push_back(tmp_trk_z0);
       if (tmp_trk_nFitPars == 5)
         m_trk_d0->push_back(tmp_trk_d0);
@@ -1527,6 +1537,7 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
       float tmp_trk_pt = iterL1Track->momentum().perp();
       float tmp_trk_eta = iterL1Track->momentum().eta();
       float tmp_trk_phi = iterL1Track->momentum().phi();
+      float tmp_trk_phi_local = iterL1Track->localPhi();
       float tmp_trk_z0 = iterL1Track->z0();            //cm
       int tmp_trk_nFitPars = iterL1Track->nFitPars();  //4 or 5
 
@@ -1619,6 +1630,7 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
       m_trkExt_pt->push_back(tmp_trk_pt);
       m_trkExt_eta->push_back(tmp_trk_eta);
       m_trkExt_phi->push_back(tmp_trk_phi);
+      m_trkExt_phi_local->push_back(tmp_trk_phi_local);
       m_trkExt_z0->push_back(tmp_trk_z0);
       if (tmp_trk_nFitPars == 5)
         m_trkExt_d0->push_back(tmp_trk_d0);


### PR DESCRIPTION
#### PR description:

This PR does several things:
1. It fixes an issue with the track parameter digitization for the TTTrack_TrackWord data format. Previously the functions were overly complex and off by 1 bit; a problem which grew every time you went back and forth between digitized and undigitized value.
2. Converts from global to local phi during construction and setting of parameters and allow the TTTrack class to make use of this function from the base class.
3. Adds a new function to test the output of the digitize and undigitize functions. Also making sure that going back and forth doesn't introduce an ever growing offset.
4. Adds some code to unit test the TTTrack_TrackWord; specifically the digitize and undigitize functions.

#### PR validation:

All needed code checks and code format checks have been performed. The code compiles after running `git cms-checkdeps -a`. I also used the newly added unit tests to verify the correctness of the digitize and undigitize functions. Both returned the expected values. Additionally, I produced an L1TrackObject ntuple and the local phi value looks correct.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is being forward ported from https://github.com/cms-l1t-offline/cmssw/pull/940. It is fully signed off by all relevant parties in the phase2 upgrade software group. It's just waiting to be merged there. This forward port was requested by the L1 track trigger group so that they can use these changes as well.

@tomalin 