### PR TITLE
Run3-hcx310 Put back HcalDigiProducer.cc in SimCalorimetry/HcalSimProducers/src

### DIFF
--- a/SimCalorimetry/HcalSimProducers/plugins/SealModule.cc
+++ b/SimCalorimetry/HcalSimProducers/plugins/SealModule.cc
@@ -1,0 +1,5 @@
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "SimCalorimetry/HcalSimProducers/interface/HcalDigiProducer.h"
+#include "SimGeneral/MixingModule/interface/DigiAccumulatorMixModFactory.h"
+
+DEFINE_DIGI_ACCUMULATOR(HcalDigiProducer);

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigiProducer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigiProducer.cc
@@ -73,8 +73,3 @@ void HcalDigiProducer::setQIE10NoiseSignalGenerator(HcalBaseSignalGenerator *noi
 void HcalDigiProducer::setQIE11NoiseSignalGenerator(HcalBaseSignalGenerator *noiseGenerator) {
   theDigitizer_.setQIE11NoiseSignalGenerator(noiseGenerator);
 }
-
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "SimGeneral/MixingModule/interface/DigiAccumulatorMixModFactory.h"
-
-DEFINE_DIGI_ACCUMULATOR(HcalDigiProducer);


### PR DESCRIPTION
#### PR description:

Put back HcalDigiProducer.cc in SimCalorimetry/HcalSimProducers/src to avoid the broken IB as it needs to be linkable with the mixing module (Chris Jones)

#### PR validation:

Use the runTheMatrix test workflows 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Fixes the broken IB due to #34940