### PR TITLE
Remove boost lexical_cast dependency in FWCore

### DIFF
--- a/FWCore/Modules/src/EventContentAnalyzer.cc
+++ b/FWCore/Modules/src/EventContentAnalyzer.cc
@@ -436,11 +436,6 @@ namespace edm {
     for (nameMap::const_iterator it = cumulates_.begin(), itEnd = cumulates_.end(); it != itEnd; ++it) {
       LogAbsolute("EventContent") << std::setw(6) << it->second << " occurrences of key " << it->first << std::endl;
     }
-
-    // Test boost::lexical_cast  We don't need this right now so comment it out.
-    // int k = 137;
-    // std::string ktext = boost::lexical_cast<std::string>(k);
-    // std::cout << "\nInteger " << k << " expressed as a string is |" << ktext << "|" << std::endl;
   }
 
   void EventContentAnalyzer::fillDescriptions(ConfigurationDescriptions& descriptions) {

--- a/FWCore/ParameterSet/src/types.cc
+++ b/FWCore/ParameterSet/src/types.cc
@@ -8,7 +8,6 @@
 
 #include "FWCore/ParameterSet/interface/types.h"
 
-#include "boost/lexical_cast.hpp"
 #include "FWCore/ParameterSet/src/split.h"
 #include "FWCore/Utilities/interface/Parse.h"
 #include <cctype>
@@ -459,9 +458,9 @@ bool edm::decode(double& to, std::string const& from) {
   else {
     try {
       // std::cerr << "from:" << from << std::endl;
-      to = boost::lexical_cast<double>(from);
+      to = std::stod(from);
       // std::cerr << "to:" << to << std::endl;
-    } catch (boost::bad_lexical_cast&) {
+    } catch (const std::invalid_argument&) {
       return false;
     }
   }

--- a/FWCore/ParameterSet/src/types.cc
+++ b/FWCore/ParameterSet/src/types.cc
@@ -460,7 +460,7 @@ bool edm::decode(double& to, std::string const& from) {
       // std::cerr << "from:" << from << std::endl;
       to = std::stod(from);
       // std::cerr << "to:" << to << std::endl;
-    } catch (const std::invalid_argument&) {
+    } catch (const std::exception&) {
       return false;
     }
   }

--- a/FWCore/Services/plugins/ProcInfoFetcher.cc
+++ b/FWCore/Services/plugins/ProcInfoFetcher.cc
@@ -23,7 +23,6 @@
 #include <sstream>
 //#include <stdio.h>
 #include <string>
-#include <boost/lexical_cast.hpp>
 
 #include <fcntl.h>
 #include <unistd.h>
@@ -96,27 +95,27 @@ namespace {
     int getInt() {
       const char* t = getItem();
       //std::cout <<"int '"<<t <<"'"<<std::endl;
-      return boost::lexical_cast<int>(t);
+      return std::stoi(t);
     }
     long getLong() {
       const char* t = getItem();
       //std::cout <<"long '"<<t <<"'"<<std::endl;
-      return boost::lexical_cast<long>(t);
+      return std::stol(t);
     }
     unsigned int getUInt() {
       const char* t = getItem();
       //std::cout <<"uint '"<<t <<"'"<<std::endl;
-      return boost::lexical_cast<unsigned int>(t);
+      return std::stoul(t);
     }
     unsigned long getULong() {
       const char* t = getItem();
       //std::cout <<"ulong '"<<t <<"'"<<std::endl;
-      return boost::lexical_cast<unsigned long>(t);
+      return std::stoul(t);
     }
     unsigned long long getULongLong() {
       const char* t = getItem();
       //std::cout <<"ulong '"<<t <<"'"<<std::endl;
-      return boost::lexical_cast<unsigned long long>(t);
+      return std::stoull(t);
     }
     char getChar() { return *getItem(); }
     std::string getString() { return std::string(getItem()); }
@@ -210,7 +209,7 @@ namespace edm {
               pinfo.num_threads >> pinfo.itrealvalue >> pinfo.starttime >> pinfo.vsize >> pinfo.rss >> pinfo.rlim >>
               pinfo.startcode >> pinfo.endcode >> pinfo.startstack >> pinfo.kstkesp >> pinfo.kstkeip >> pinfo.signal >>
               pinfo.blocked >> pinfo.sigignore >> pinfo.sigcatch >> pinfo.wchan;
-        } catch (boost::bad_lexical_cast& iE) {
+        } catch (const std::invalid_argument& iE) {
           LogWarning("ProcInfoFetcher") << "Parsing of Prof file failed:" << iE.what() << std::endl;
           return ProcInfo();
         }

--- a/FWCore/Services/plugins/ProcInfoFetcher.cc
+++ b/FWCore/Services/plugins/ProcInfoFetcher.cc
@@ -209,7 +209,7 @@ namespace edm {
               pinfo.num_threads >> pinfo.itrealvalue >> pinfo.starttime >> pinfo.vsize >> pinfo.rss >> pinfo.rlim >>
               pinfo.startcode >> pinfo.endcode >> pinfo.startstack >> pinfo.kstkesp >> pinfo.kstkeip >> pinfo.signal >>
               pinfo.blocked >> pinfo.sigignore >> pinfo.sigcatch >> pinfo.wchan;
-        } catch (const std::invalid_argument& iE) {
+        } catch (const std::exception& iE) {
           LogWarning("ProcInfoFetcher") << "Parsing of Prof file failed:" << iE.what() << std::endl;
           return ProcInfo();
         }

--- a/FWCore/Services/plugins/SimpleMemoryCheck.cc
+++ b/FWCore/Services/plugins/SimpleMemoryCheck.cc
@@ -52,7 +52,6 @@
 //#include <stdio.h>
 #include <string>
 //#include <string.h>
-#include <boost/lexical_cast.hpp>
 
 #include <cstdio>
 #include <atomic>

--- a/FWCore/Utilities/src/ReleaseVersion.cc
+++ b/FWCore/Utilities/src/ReleaseVersion.cc
@@ -1,7 +1,6 @@
 #include "FWCore/Utilities/interface/ReleaseVersion.h"
 
 #include "boost/algorithm/string.hpp"
-#include "boost/lexical_cast.hpp"
 
 #include <algorithm>
 #include <cassert>
@@ -33,17 +32,17 @@ namespace edm {
         /*
         if(parts.size() == 4) {
           if(releaseVersion.find("patch") != std::string::npos) {
-            patch_ = boost::lexical_cast<unsigned int>(parts[3]);
+            patch_ = std::stoul(parts[3]);
           } else if(releaseVersion.find("pre") != std::string::npos) {
-            pre_ = boost::lexical_cast<unsigned int>(parts[3]);
+            pre_ = std::stoul(parts[3]);
           } else {
             return;
           }
         }
 */
-        major_ = boost::lexical_cast<unsigned int>(parts[0]);
-        minor_ = boost::lexical_cast<unsigned int>(parts[1]);
-        //        point_ = boost::lexical_cast<unsigned int>(parts[2]);
+        major_ = std::stoul(parts[0]);
+        minor_ = std::stoul(parts[1]);
+        //        point_ = std::stoul(parts[2]);
         irregular_ = false;
       } catch (std::exception const&) {
       }


### PR DESCRIPTION
#### PR description:

Remove boost lexical cast dependency in FWCore with corresponding stl alternatives

#### PR validation:

Passed on scram -b runtests (FWCore)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@davidlange6 @vgvassilev