### PR TITLE
Add support for the gpu modifier at HLT

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -415,10 +415,12 @@ upgradeWFs['mlpf'].step3 = {
 #   - 2021 conditions, TTbar
 #   - 2021 conditions, Z->mumu,
 class PatatrackWorkflow(UpgradeWorkflow):
-    def __init__(self, reco, harvest, **kwargs):
+    def __init__(self, digi = {}, reco = {}, harvest = {}, **kwargs):
         # adapt the parameters for the UpgradeWorkflow init method
         super(PatatrackWorkflow, self).__init__(
             steps = [
+                'Digi',
+                'DigiTrigger',
                 'Reco',
                 'HARVEST',
                 'RecoFakeHLT',
@@ -428,6 +430,7 @@ class PatatrackWorkflow(UpgradeWorkflow):
             ],
             PU = [],
             **kwargs)
+        self.__digi = digi
         self.__reco = reco
         self.__reco.update({
             '--datatier':     'GEN-SIM-RECO,DQMIO',
@@ -452,13 +455,18 @@ class PatatrackWorkflow(UpgradeWorkflow):
         return result
 
     def setup_(self, step, stepName, stepDict, k, properties):
-        if 'Reco' in step:
+        if 'Digi' in step:
+            stepDict[stepName][k] = merge([self.__digi, stepDict[step][k]])
+        elif 'Reco' in step:
             stepDict[stepName][k] = merge([self.__reco, stepDict[step][k]])
         elif 'HARVEST' in step:
             stepDict[stepName][k] = merge([self.__harvest, stepDict[step][k]])
 
 
 upgradeWFs['PatatrackPixelOnlyCPU'] = PatatrackWorkflow(
+    digi = {
+        # there is no customisation for enabling the Patatrack pixel quadruplets running only on the CPU
+    },
     reco = {
         '-s': 'RAW2DIGI:RawToDigi_pixelOnly,RECO:reconstruction_pixelTrackingOnly,VALIDATION:@pixelTrackingOnlyValidation,DQM:@pixelTrackingOnlyDQM',
         '--procModifiers': 'pixelNtupletFit'
@@ -471,6 +479,9 @@ upgradeWFs['PatatrackPixelOnlyCPU'] = PatatrackWorkflow(
 )
 
 upgradeWFs['PatatrackPixelOnlyGPU'] = PatatrackWorkflow(
+    digi = {
+        '--procModifiers': 'gpu'
+    },
     reco = {
         '-s': 'RAW2DIGI:RawToDigi_pixelOnly,RECO:reconstruction_pixelTrackingOnly,VALIDATION:@pixelTrackingOnlyValidation,DQM:@pixelTrackingOnlyDQM',
         '--procModifiers': 'pixelNtupletFit,gpu'
@@ -483,6 +494,9 @@ upgradeWFs['PatatrackPixelOnlyGPU'] = PatatrackWorkflow(
 )
 
 upgradeWFs['PatatrackPixelOnlyTripletsCPU'] = PatatrackWorkflow(
+    digi = {
+        # there is no customisation for enabling the Patatrack pixel triplets running only on the CPU
+    },
     reco = {
         '-s': 'RAW2DIGI:RawToDigi_pixelOnly,RECO:reconstruction_pixelTrackingOnly,VALIDATION:@pixelTrackingOnlyValidation,DQM:@pixelTrackingOnlyDQM',
         '--procModifiers': 'pixelNtupletFit',
@@ -496,6 +510,10 @@ upgradeWFs['PatatrackPixelOnlyTripletsCPU'] = PatatrackWorkflow(
 )
 
 upgradeWFs['PatatrackPixelOnlyTripletsGPU'] = PatatrackWorkflow(
+    digi = {
+        '--procModifiers': 'gpu',
+        '--customise': 'HLTrigger/Configuration/customizeHLTforPatatrack.enablePatatrackPixelTriplets'
+    },
     reco = {
         '-s': 'RAW2DIGI:RawToDigi_pixelOnly,RECO:reconstruction_pixelTrackingOnly,VALIDATION:@pixelTrackingOnlyValidation,DQM:@pixelTrackingOnlyDQM',
         '--procModifiers': 'pixelNtupletFit,gpu',
@@ -520,6 +538,9 @@ upgradeWFs['PatatrackECALOnlyCPU'] = PatatrackWorkflow(
 )
 
 upgradeWFs['PatatrackECALOnlyGPU'] = PatatrackWorkflow(
+    digi = {
+        '--procModifiers': 'gpu'
+    },
     reco = {
         '-s': 'RAW2DIGI:RawToDigi_ecalOnly,RECO:reconstruction_ecalOnly,VALIDATION:@ecalOnlyValidation,DQM:@ecalOnly',
         '--procModifiers': 'gpu'
@@ -543,6 +564,9 @@ upgradeWFs['PatatrackHCALOnlyCPU'] = PatatrackWorkflow(
 )
 
 upgradeWFs['PatatrackHCALOnlyGPU'] = PatatrackWorkflow(
+    digi = {
+        '--procModifiers': 'gpu'
+    },
     reco = {
         '-s': 'RAW2DIGI:RawToDigi_hcalOnly,RECO:reconstruction_hcalOnly,VALIDATION:@hcalOnlyValidation,DQM:@hcalOnly+@hcal2Only',
         '--procModifiers': 'gpu'

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -1,5 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
+# modifiers
+from Configuration.ProcessModifiers.gpu_cff import gpu
+
 # helper fuctions
 from HLTrigger.Configuration.common import *
 
@@ -132,6 +135,10 @@ def customiseFor2018Input(process):
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
     
+    # if the gpu modifier is enabled, make the Pixel, ECAL and HCAL reconstruction offloadable to a GPU
+    from HLTrigger.Configuration.customizeHLTforPatatrack import customizeHLTforPatatrack
+    gpu.makeProcessModifier(customizeHLTforPatatrack).apply(process)
+
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
 

--- a/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
+++ b/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
@@ -131,51 +131,50 @@ def customisePixelLocalReconstruction(process):
         src = "hltSiPixelClustersCUDA"
     )
 
-    # convert the pixel digis errors to the legacy format
-    from EventFilter.SiPixelRawToDigi.siPixelDigiErrorsFromSoA_cfi import siPixelDigiErrorsFromSoA as _siPixelDigiErrorsFromSoA
-    process.hltSiPixelDigiErrors = _siPixelDigiErrorsFromSoA.clone(
-        digiErrorSoASrc = "hltSiPixelDigiErrorsSoA",
-        UsePhase1 = True
-    )
-
     # copy the pixel digis (except errors) and clusters to the host
     from EventFilter.SiPixelRawToDigi.siPixelDigisSoAFromCUDA_cfi import siPixelDigisSoAFromCUDA as _siPixelDigisSoAFromCUDA
     process.hltSiPixelDigisSoA = _siPixelDigisSoAFromCUDA.clone(
         src = "hltSiPixelClustersCUDA"
     )
 
-    # convert the pixel digis (except errors) and clusters to the legacy format
-    from RecoLocalTracker.SiPixelClusterizer.siPixelDigisClustersFromSoA_cfi import siPixelDigisClustersFromSoA as _siPixelDigisClustersFromSoA
-    process.hltSiPixelDigisClusters = _siPixelDigisClustersFromSoA.clone(
-        src = "hltSiPixelDigisSoA"
-    )
+    # reconstruct the pixel digis on the cpu
+    process.hltSiPixelDigisLegacy = process.hltSiPixelDigis.clone()
 
-    # SwitchProducer wrapping the legacy pixel digis producer or an alias combining the pixel digis information converted from SoA
+    # SwitchProducer wrapping a subset of the legacy pixel digis producer, or the conversion of the pixel digis errors to the legacy format
+    from EventFilter.SiPixelRawToDigi.siPixelDigiErrorsFromSoA_cfi import siPixelDigiErrorsFromSoA as _siPixelDigiErrorsFromSoA
     process.hltSiPixelDigis = SwitchProducerCUDA(
         # legacy producer
-        cpu = process.hltSiPixelDigis,
-        # alias used to access products from multiple conversion modules
-        cuda = cms.EDAlias(
-            hltSiPixelDigisClusters = cms.VPSet(
-                cms.PSet(type = cms.string("PixelDigiedmDetSetVector"))
-            ),
-            hltSiPixelDigiErrors = cms.VPSet(
+        cpu = cms.EDAlias(
+            hltSiPixelDigisLegacy = cms.VPSet(
                 cms.PSet(type = cms.string("DetIdedmEDCollection")),
                 cms.PSet(type = cms.string("SiPixelRawDataErroredmDetSetVector")),
                 cms.PSet(type = cms.string("PixelFEDChanneledmNewDetSetVector"))
             )
+        ),
+        # conversion from SoA to legacy format
+        cuda = _siPixelDigiErrorsFromSoA.clone(
+            digiErrorSoASrc = "hltSiPixelDigiErrorsSoA",
+            UsePhase1 = True
         )
     )
 
-    # SwitchProducer wrapping the legacy pixel cluster producer or an alias for the pixel clusters information converted from SoA
+    # reconstruct the pixel clusters on the cpu
+    process.hltSiPixelClustersLegacy = process.hltSiPixelClusters.clone()
+
+    # SwitchProducer wrapping a subset of the legacy pixel cluster producer, or the conversion of the pixel digis (except errors) and clusters to the legacy format
+    from RecoLocalTracker.SiPixelClusterizer.siPixelDigisClustersFromSoA_cfi import siPixelDigisClustersFromSoA as _siPixelDigisClustersFromSoA
     process.hltSiPixelClusters = SwitchProducerCUDA(
         # legacy producer
-        cpu = process.hltSiPixelClusters,
-        # alias used to access products from multiple conversion modules
-        cuda = cms.EDAlias(
-            hltSiPixelDigisClusters = cms.VPSet(
+        cpu = cms.EDAlias(
+            hltSiPixelClustersLegacy = cms.VPSet(
                 cms.PSet(type = cms.string("SiPixelClusteredmNewDetSetVector"))
             )
+        ),
+        # conversion from SoA to legacy format
+        cuda = _siPixelDigisClustersFromSoA.clone(
+            src = "hltSiPixelDigisSoA",
+            produceDigis = False,
+            storeDigis = False,
         )
     )
 
@@ -191,7 +190,7 @@ def customisePixelLocalReconstruction(process):
     process.hltSiPixelRecHits = SwitchProducerCUDA(
         # legacy producer
         cpu = process.hltSiPixelRecHits,
-        # converter to legacy format
+        # conversion from SoA to legacy format
         cuda = _siPixelRecHitFromCUDA.clone(
             pixelRecHitSrc = "hltSiPixelRecHitsCUDA",
             src = "hltSiPixelClusters"
@@ -206,11 +205,11 @@ def customisePixelLocalReconstruction(process):
           process.hltSiPixelClustersCUDA,                   # reconstruct the pixel digis and clusters on the gpu
           process.hltSiPixelRecHitsCUDA,                    # reconstruct the pixel rechits on the gpu
           process.hltSiPixelDigisSoA,                       # copy the pixel digis (except errors) and clusters to the host
-          process.hltSiPixelDigisClusters,                  # convert the pixel digis (except errors) and clusters to the legacy format
           process.hltSiPixelDigiErrorsSoA,                  # copy the pixel digis errors to the host
-          process.hltSiPixelDigiErrors,                     # convert the pixel digis errors to the legacy format
-          process.hltSiPixelDigis,                          # SwitchProducer wrapping the legacy pixel digis producer or an alias combining the pixel digis information converted from SoA
-          process.hltSiPixelClusters,                       # SwitchProducer wrapping the legacy pixel cluster producer or an alias for the pixel clusters information converted from SoA
+          process.hltSiPixelDigisLegacy,                    # legacy pixel digis producer
+          process.hltSiPixelDigis,                          # SwitchProducer wrapping a subset of the legacy pixel digis producer, or the conversion of the pixel digis errors from SoA
+          process.hltSiPixelClustersLegacy,                 # legacy pixel cluster producer
+          process.hltSiPixelClusters,                       # SwitchProducer wrapping a subset of the legacy pixel cluster producer, or the conversion of the pixel digis (except errors) and clusters from SoA
           process.hltSiPixelClustersCache,                  # legacy module, used by the legacy pixel quadruplet producer
           process.hltSiPixelRecHits)                        # SwitchProducer wrapping the legacy pixel rechit producer or the transfer of the pixel rechits to the host and the conversion from SoA
 


### PR DESCRIPTION
#### PR description:

When the `gpu` modifier is enabled, make the Pixel, ECAL and HCAL reconstruction running at HLT offloadable to a GPU.

#### PR validation:

Tested with
```bash
cmsDriver.py reHLT \
    --processName reHLT \
    -s HLT:@relval2021 \
    --conditions 120X_mcRun3_2021_realistic_v4 \
    --datatier GEN-SIM-DIGI-RAW \
    -n 10 \
    --eventcontent FEVTDEBUGHLT \
    --geometry DB:Extended \
    --era Run3 \
    --procModifiers gpu \
    --filein /store/relval/CMSSW_12_0_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_120X_mcRun3_2021_realistic_v4_JIRA_129-v1/00000/79c06ed5-929b-4a57-a4f2-1ae90e6b38c5.root
```

With this change, the `customizeHLTforPatatrack()` customisation will be tested as part of the `.502`, `.512` and `.522` GPU workflows, and `customizeHLTforPatatrackTriplets()` with the `.506` workflow.