### PR TITLE
Avoid memory overwrites in Ecal PayloadInspectors

### DIFF
--- a/CondCore/EcalPlugins/plugins/EcalIntercalibConstantsMC_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalIntercalibConstantsMC_PayloadInspector.cc
@@ -16,6 +16,7 @@
 
 #include <memory>
 #include <sstream>
+#include <array>
 
 namespace {
   enum { kEBChannels = 61200, kEEChannels = 14648 };
@@ -194,9 +195,9 @@ namespace {
 
       float xmi[3] = {0.0, 0.24, 0.76};
       float xma[3] = {0.24, 0.76, 1.00};
-      TPad** pad = new TPad*;
+      std::array<std::unique_ptr<TPad>, 3> pad;
       for (int obj = 0; obj < 3; obj++) {
-        pad[obj] = new TPad(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], 0.0, xma[obj], 0.94);
+        pad[obj] = std::make_unique<TPad>(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], 0.0, xma[obj], 0.94);
         pad[obj]->Draw();
       }
       //      EcalDrawMaps ICMap;
@@ -305,10 +306,10 @@ namespace {
 
       float xmi[3] = {0.0, 0.24, 0.76};
       float xma[3] = {0.24, 0.76, 1.00};
-      TPad** pad = new TPad*;
+      std::array<std::unique_ptr<TPad>, 3> pad;
 
       for (int obj = 0; obj < 3; obj++) {
-        pad[obj] = new TPad(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], 0.0, xma[obj], 0.94);
+        pad[obj] = std::make_unique<TPad>(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], 0.0, xma[obj], 0.94);
         pad[obj]->Draw();
       }
 
@@ -376,9 +377,9 @@ namespace {
       t1.SetTextColor(2);
       t1.DrawLatex(0.5, 0.96, Form("Ecal Intercalib Constants MC Summary, IOV %i", run));
 
-      TPad* pad = new TPad("pad", "pad", 0.0, 0.0, 1.0, 0.94);
-      pad->Draw();
-      pad->cd();
+      TPad pad("pad", "pad", 0.0, 0.0, 1.0, 0.94);
+      pad.Draw();
+      pad.cd();
       align->Draw("TEXT");
 
       drawTable(NbRows, 4);

--- a/CondCore/EcalPlugins/plugins/EcalIntercalibConstants_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalIntercalibConstants_PayloadInspector.cc
@@ -16,6 +16,7 @@
 
 #include <memory>
 #include <sstream>
+#include <array>
 
 namespace {
   enum { kEBChannels = 61200, kEEChannels = 14648 };
@@ -180,9 +181,9 @@ namespace {
 
       float xmi[3] = {0.0, 0.24, 0.76};
       float xma[3] = {0.24, 0.76, 1.00};
-      TPad** pad = new TPad*;
+      std::array<std::unique_ptr<TPad>, 3> pad;
       for (int obj = 0; obj < 3; obj++) {
-        pad[obj] = new TPad(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], 0.0, xma[obj], 0.94);
+        pad[obj] = std::make_unique<TPad>(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], 0.0, xma[obj], 0.94);
         pad[obj]->Draw();
       }
       //      EcalDrawMaps ICMap;
@@ -286,9 +287,9 @@ namespace {
       }
       float xmi[3] = {0.0, 0.24, 0.76};
       float xma[3] = {0.24, 0.76, 1.00};
-      TPad** pad = new TPad*;
+      std::array<std::unique_ptr<TPad>, 3> pad;
       for (int obj = 0; obj < 3; obj++) {
-        pad[obj] = new TPad(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], 0.0, xma[obj], 0.94);
+        pad[obj] = std::make_unique<TPad>(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], 0.0, xma[obj], 0.94);
         pad[obj]->Draw();
       }
       pad[0]->cd();
@@ -354,9 +355,9 @@ namespace {
       t1.SetTextColor(2);
       t1.DrawLatex(0.5, 0.96, Form("Ecal Intercalib Constants Summary, IOV %i", run));
 
-      TPad* pad = new TPad("pad", "pad", 0.0, 0.0, 1.0, 0.94);
-      pad->Draw();
-      pad->cd();
+      TPad pad("pad", "pad", 0.0, 0.0, 1.0, 0.94);
+      pad.Draw();
+      pad.cd();
       align->Draw("TEXT");
       TLine* l = new TLine;
       l->SetLineWidth(1);

--- a/CondCore/EcalPlugins/plugins/EcalIntercalibErrors_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalIntercalibErrors_PayloadInspector.cc
@@ -16,6 +16,7 @@
 
 #include <memory>
 #include <sstream>
+#include <array>
 
 namespace {
 
@@ -190,9 +191,9 @@ namespace {
 
       float xmi[3] = {0.0, 0.24, 0.76};
       float xma[3] = {0.24, 0.76, 1.00};
-      TPad** pad = new TPad*;
+      std::array<std::unique_ptr<TPad>, 3> pad;
       for (int obj = 0; obj < 3; obj++) {
-        pad[obj] = new TPad(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], 0.0, xma[obj], 0.94);
+        pad[obj] = std::make_unique<TPad>(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], 0.0, xma[obj], 0.94);
         pad[obj]->Draw();
       }
       //      EcalDrawMaps ICMap;
@@ -295,10 +296,10 @@ namespace {
 
       float xmi[3] = {0.0, 0.24, 0.76};
       float xma[3] = {0.24, 0.76, 1.00};
-      TPad** pad = new TPad*;
+      std::array<std::unique_ptr<TPad>, 3> pad;
 
       for (int obj = 0; obj < 3; obj++) {
-        pad[obj] = new TPad(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], 0.0, xma[obj], 0.94);
+        pad[obj] = std::make_unique<TPad>(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], 0.0, xma[obj], 0.94);
         pad[obj]->Draw();
       }
 
@@ -365,9 +366,9 @@ namespace {
       t1.SetTextColor(2);
       t1.DrawLatex(0.5, 0.96, Form("Ecal Intercalib Errors Summary, IOV %i", run));
 
-      TPad* pad = new TPad("pad", "pad", 0.0, 0.0, 1.0, 0.94);
-      pad->Draw();
-      pad->cd();
+      TPad pad("pad", "pad", 0.0, 0.0, 1.0, 0.94);
+      pad.Draw();
+      pad.cd();
       align->Draw("TEXT");
 
       drawTable(NbRows, 4);

--- a/CondCore/EcalPlugins/plugins/EcalLaserAPDPNRatiosRef_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalLaserAPDPNRatiosRef_PayloadInspector.cc
@@ -16,6 +16,7 @@
 
 #include <memory>
 #include <sstream>
+#include <array>
 
 namespace {
   enum { kEBChannels = 61200, kEEChannels = 14648 };
@@ -190,9 +191,9 @@ namespace {
 
       float xmi[3] = {0.0, 0.24, 0.76};
       float xma[3] = {0.24, 0.76, 1.00};
-      TPad** pad = new TPad*;
+      std::array<std::unique_ptr<TPad>, 3> pad;
       for (int obj = 0; obj < 3; obj++) {
-        pad[obj] = new TPad(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], 0.0, xma[obj], 0.94);
+        pad[obj] = std::make_unique<TPad>(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], 0.0, xma[obj], 0.94);
         pad[obj]->Draw();
       }
       //      EcalDrawMaps ICMap;
@@ -279,10 +280,10 @@ namespace {
 
       float xmi[3] = {0.0, 0.24, 0.76};
       float xma[3] = {0.24, 0.76, 1.00};
-      TPad** pad = new TPad*;
+      std::array<std::unique_ptr<TPad>, 3> pad;
 
       for (int obj = 0; obj < 3; obj++) {
-        pad[obj] = new TPad(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], 0.0, xma[obj], 0.94);
+        pad[obj] = std::make_unique<TPad>(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], 0.0, xma[obj], 0.94);
         pad[obj]->Draw();
       }
 
@@ -350,9 +351,9 @@ namespace {
       t1.SetTextColor(2);
       t1.DrawLatex(0.5, 0.96, Form("Ecal Laser APDPN Ratios Ref Summary, IOV %i", run));
 
-      TPad* pad = new TPad("pad", "pad", 0.0, 0.0, 1.0, 0.94);
-      pad->Draw();
-      pad->cd();
+      TPad pad("pad", "pad", 0.0, 0.0, 1.0, 0.94);
+      pad.Draw();
+      pad.cd();
       align->Draw("TEXT");
 
       drawTable(NbRows, 4);

--- a/CondCore/EcalPlugins/plugins/EcalLaserAlphas_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalLaserAlphas_PayloadInspector.cc
@@ -16,6 +16,7 @@
 
 #include <memory>
 #include <sstream>
+#include <array>
 
 namespace {
   enum { kEBChannels = 61200, kEEChannels = 14648 };
@@ -185,9 +186,9 @@ namespace {
 
       float xmi[3] = {0.0, 0.24, 0.76};
       float xma[3] = {0.24, 0.76, 1.00};
-      TPad** pad = new TPad*;
+      std::array<std::unique_ptr<TPad>, 3> pad;
       for (int obj = 0; obj < 3; obj++) {
-        pad[obj] = new TPad(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], 0.0, xma[obj], 0.94);
+        pad[obj] = std::make_unique<TPad>(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], 0.0, xma[obj], 0.94);
         pad[obj]->Draw();
       }
       //      EcalDrawMaps ICMap;
@@ -293,10 +294,10 @@ namespace {
       }
       float xmi[3] = {0.0, 0.24, 0.76};
       float xma[3] = {0.24, 0.76, 1.00};
-      TPad** pad = new TPad*;
+      std::array<std::unique_ptr<TPad>, 3> pad;
 
       for (int obj = 0; obj < 3; obj++) {
-        pad[obj] = new TPad(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], 0.0, xma[obj], 0.94);
+        pad[obj] = std::make_unique<TPad>(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], 0.0, xma[obj], 0.94);
         pad[obj]->Draw();
       }
 
@@ -363,9 +364,9 @@ namespace {
       t1.SetTextColor(2);
       t1.DrawLatex(0.5, 0.96, Form("Ecal Laser Alphas Summary, IOV %i", run));
 
-      TPad* pad = new TPad("pad", "pad", 0.0, 0.0, 1.0, 0.94);
-      pad->Draw();
-      pad->cd();
+      TPad pad("pad", "pad", 0.0, 0.0, 1.0, 0.94);
+      pad.Draw();
+      pad.cd();
       align->Draw("TEXT");
 
       drawTable(NbRows, 4);

--- a/CondCore/EcalPlugins/plugins/EcalPFRecHitThresholds_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalPFRecHitThresholds_PayloadInspector.cc
@@ -15,6 +15,7 @@
 #include "TLatex.h"
 
 #include <memory>
+#include <array>
 #include <sstream>
 
 namespace {
@@ -192,9 +193,9 @@ namespace {
 
       float xmi[3] = {0.0, 0.24, 0.76};
       float xma[3] = {0.24, 0.76, 1.00};
-      TPad** pad = new TPad*;
+      std::array<std::unique_ptr<TPad>, 3> pad;
       for (int obj = 0; obj < 3; obj++) {
-        pad[obj] = new TPad(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], 0.0, xma[obj], 0.94);
+        pad[obj] = std::make_unique<TPad>(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], 0.0, xma[obj], 0.94);
         pad[obj]->Draw();
       }
       //      EcalDrawMaps ICMap;
@@ -298,10 +299,10 @@ namespace {
 
       float xmi[3] = {0.0, 0.24, 0.76};
       float xma[3] = {0.24, 0.76, 1.00};
-      TPad** pad = new TPad*;
+      std::array<std::unique_ptr<TPad>, 3> pad;
 
       for (int obj = 0; obj < 3; obj++) {
-        pad[obj] = new TPad(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], 0.0, xma[obj], 0.94);
+        pad[obj] = std::make_unique<TPad>(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], 0.0, xma[obj], 0.94);
         pad[obj]->Draw();
       }
 
@@ -368,9 +369,9 @@ namespace {
       t1.SetTextColor(2);
       t1.DrawLatex(0.5, 0.96, Form("Ecal PFRec Hit Thresholds Summary, IOV %i", run));
 
-      TPad* pad = new TPad("pad", "pad", 0.0, 0.0, 1.0, 0.94);
-      pad->Draw();
-      pad->cd();
+      TPad pad("pad", "pad", 0.0, 0.0, 1.0, 0.94);
+      pad.Draw();
+      pad.cd();
       align->Draw("TEXT");
 
       drawTable(NbRows, 4);

--- a/CondCore/EcalPlugins/plugins/EcalTPGCrystalStatus_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalTPGCrystalStatus_PayloadInspector.cc
@@ -14,6 +14,8 @@
 #include "TLatex.h"
 
 #include <string>
+#include <memory>
+#include <array>
 
 namespace {
   enum { kEBChannels = 61200, kEEChannels = 14648, kSides = 2 };
@@ -30,7 +32,7 @@ namespace {
       setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
       TH2F* barrel = new TH2F("EB", "EB TPG Crystal Status", MAX_IPHI, 0, MAX_IPHI, 2 * MAX_IETA, -MAX_IETA, MAX_IETA);
       TH2F* endc_p = new TH2F("EE+", "EE+ TPG Crystal Status", IX_MAX, IX_MIN, IX_MAX + 1, IY_MAX, IY_MIN, IY_MAX + 1);
       TH2F* endc_m = new TH2F("EE-", "EE- TPG Crystal Status", IX_MAX, IX_MIN, IX_MAX + 1, IY_MAX, IY_MIN, IY_MAX + 1);
@@ -100,9 +102,9 @@ namespace {
       float xma[3] = {1.0, 0.5, 1.0};
       float ymi[3] = {0.47, 0.0, 0.0};
       float yma[3] = {0.94, 0.47, 0.47};
-      TPad** pad = new TPad*;
+      std::array<std::unique_ptr<TPad>, 3> pad;
       for (int obj = 0; obj < 3; obj++) {
-        pad[obj] = new TPad(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], ymi[obj], xma[obj], yma[obj]);
+        pad[obj] = std::make_unique<TPad>(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], ymi[obj], xma[obj], yma[obj]);
         pad[obj]->Draw();
       }
 
@@ -248,9 +250,9 @@ namespace {
       float xma[3] = {1.0, 0.5, 1.0};
       float ymi[3] = {0.47, 0.0, 0.0};
       float yma[3] = {0.94, 0.47, 0.47};
-      std::vector<TPad*> pad;
+      std::vector<std::unique_ptr<TPad>> pad;
       for (int obj = 0; obj < 3; obj++) {
-        pad.push_back(new TPad(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], ymi[obj], xma[obj], yma[obj]));
+        pad.emplace_back(new TPad(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], ymi[obj], xma[obj], yma[obj]));
         pad[obj]->Draw();
       }
 
@@ -282,7 +284,7 @@ namespace {
       setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
       auto iov = iovs.front();  //get reference to 1st element in the vector iovs
       std::shared_ptr<EcalTPGCrystalStatus> payload =
           fetchPayload(std::get<1>(iov));   //std::get<1>(iov) refers to the Hash in the tuple iov
@@ -349,9 +351,9 @@ namespace {
       t1.SetTextColor(2);
       t1.DrawLatex(0.5, 0.96, Form("EcalTPGCrystalStatus Error Summary, IOV %i", run));
 
-      TPad* pad = new TPad("pad", "pad", 0.0, 0.0, 1.0, 0.94);
-      pad->Draw();
-      pad->cd();
+      TPad pad("pad", "pad", 0.0, 0.0, 1.0, 0.94);
+      pad.Draw();
+      pad.cd();
       align->Draw("TEXT");
 
       drawTable(NbRows, NbColumns);

--- a/CondCore/EcalPlugins/plugins/EcalTPGFineGrainStripEE_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalTPGFineGrainStripEE_PayloadInspector.cc
@@ -15,6 +15,8 @@
 #include "TLatex.h"
 
 #include <string>
+#include <memory>
+#include <array>
 
 namespace {
   enum { NTCC = 108, NTower = 28, NStrip = 5, NXtal = 5 };
@@ -164,9 +166,9 @@ namespace {
 
       float ymi[4] = {0.47, 0.47, 0.0, 0.0};
       float yma[4] = {0.94, 0.94, 0.47, 0.47};
-      TPad** pad = new TPad*;
+      std::array<std::unique_ptr<TPad>, 4> pad;
       for (int obj = 0; obj < 4; obj++) {
-        pad[obj] = new TPad(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], ymi[obj], xma[obj], yma[obj]);
+        pad[obj] = std::make_unique<TPad>(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], ymi[obj], xma[obj], yma[obj]);
         pad[obj]->Draw();
       }
 
@@ -192,7 +194,6 @@ namespace {
 
       canvas.SaveAs(ImageName.c_str());
 
-      delete pad;
       delete endc_lut_p;
       delete endc_lut_m;
       delete endc_thresh_p;

--- a/CondCore/EcalPlugins/plugins/EcalTPGStripStatus_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalTPGStripStatus_PayloadInspector.cc
@@ -15,6 +15,8 @@
 #include "TLatex.h"
 
 #include <string>
+#include <array>
+#include <memory>
 
 namespace {
   enum { NTCC = 108, NTower = 28, NStrip = 5, NXtal = 5 };
@@ -138,9 +140,9 @@ namespace {
 
       float xmi[2] = {0.0, 0.5};
       float xma[2] = {0.5, 1.0};
-      TPad** pad = new TPad*;
+      std::array<std::unique_ptr<TPad>, 2> pad;
       for (int obj = 0; obj < 2; obj++) {
-        pad[obj] = new TPad(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], 0.0, xma[obj], 0.94);
+        pad[obj] = std::make_unique<TPad>(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], 0.0, xma[obj], 0.94);
         pad[obj]->Draw();
       }
 
@@ -365,9 +367,9 @@ namespace {
 
       float xmi[2] = {0.0, 0.5};
       float xma[2] = {0.5, 1.0};
-      TPad** pad = new TPad*;
+      std::array<std::unique_ptr<TPad>, 2> pad;
       for (int obj = 0; obj < 2; obj++) {
-        pad[obj] = new TPad(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], 0.0, xma[obj], 0.94);
+        pad[obj] = std::make_unique<TPad>(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], 0.0, xma[obj], 0.94);
         pad[obj]->Draw();
       }
 
@@ -442,9 +444,9 @@ namespace {
       t1.SetTextColor(2);
       t1.DrawLatex(0.5, 0.96, Form("Endcap:Number of masked Trigger Strips, IOV %i", run));
 
-      TPad* pad = new TPad("pad", "pad", 0.0, 0.0, 1.0, 0.94);
-      pad->Draw();
-      pad->cd();
+      TPad pad("pad", "pad", 0.0, 0.0, 1.0, 0.94);
+      pad.Draw();
+      pad.cd();
       align->Draw("TEXT");
 
       drawTable(NbRows, NbColumns);

--- a/CondCore/EcalPlugins/plugins/EcalTimeCalibConstants_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalTimeCalibConstants_PayloadInspector.cc
@@ -16,6 +16,7 @@
 
 #include <memory>
 #include <sstream>
+#include <array>
 
 namespace {
 
@@ -191,9 +192,9 @@ namespace {
 
       float xmi[3] = {0.0, 0.24, 0.76};
       float xma[3] = {0.24, 0.76, 1.00};
-      TPad** pad = new TPad*;
+      std::array<std::unique_ptr<TPad>, 3> pad;
       for (int obj = 0; obj < 3; obj++) {
-        pad[obj] = new TPad(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], 0.0, xma[obj], 0.94);
+        pad[obj] = std::make_unique<TPad>(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], 0.0, xma[obj], 0.94);
         pad[obj]->Draw();
       }
       //      EcalDrawMaps ICMap;
@@ -297,10 +298,10 @@ namespace {
 
       float xmi[3] = {0.0, 0.24, 0.76};
       float xma[3] = {0.24, 0.76, 1.00};
-      TPad** pad = new TPad*;
+      std::array<std::unique_ptr<TPad>, 3> pad;
 
       for (int obj = 0; obj < 3; obj++) {
-        pad[obj] = new TPad(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], 0.0, xma[obj], 0.94);
+        pad[obj] = std::make_unique<TPad>(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], 0.0, xma[obj], 0.94);
         pad[obj]->Draw();
       }
 
@@ -367,9 +368,9 @@ namespace {
       t1.SetTextColor(2);
       t1.DrawLatex(0.5, 0.96, Form("Ecal Time Calib Constants Summary, IOV %i", run));
 
-      TPad* pad = new TPad("pad", "pad", 0.0, 0.0, 1.0, 0.94);
-      pad->Draw();
-      pad->cd();
+      TPad pad("pad", "pad", 0.0, 0.0, 1.0, 0.94);
+      pad.Draw();
+      pad.cd();
       align->Draw("TEXT");
 
       drawTable(NbRows, 4);

--- a/CondCore/EcalPlugins/plugins/EcalTimeCalibErrors_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalTimeCalibErrors_PayloadInspector.cc
@@ -16,6 +16,7 @@
 
 #include <memory>
 #include <sstream>
+#include <array>
 
 namespace {
 
@@ -193,9 +194,9 @@ namespace {
 
       float xmi[3] = {0.0, 0.24, 0.76};
       float xma[3] = {0.24, 0.76, 1.00};
-      TPad** pad = new TPad*;
+      std::array<std::unique_ptr<TPad>, 3> pad;
       for (int obj = 0; obj < 3; obj++) {
-        pad[obj] = new TPad(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], 0.0, xma[obj], 0.94);
+        pad[obj] = std::make_unique<TPad>(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], 0.0, xma[obj], 0.94);
         pad[obj]->Draw();
       }
       //      EcalDrawMaps ICMap;
@@ -301,10 +302,10 @@ namespace {
       }
       float xmi[3] = {0.0, 0.24, 0.76};
       float xma[3] = {0.24, 0.76, 1.00};
-      TPad** pad = new TPad*;
+      std::array<std::unique_ptr<TPad>, 3> pad;
 
       for (int obj = 0; obj < 3; obj++) {
-        pad[obj] = new TPad(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], 0.0, xma[obj], 0.94);
+        pad[obj] = std::make_unique<TPad>(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], 0.0, xma[obj], 0.94);
         pad[obj]->Draw();
       }
 
@@ -371,9 +372,9 @@ namespace {
       t1.SetTextColor(2);
       t1.DrawLatex(0.5, 0.96, Form("Ecal Time Calib Errors Summary, IOV %i", run));
 
-      TPad* pad = new TPad("pad", "pad", 0.0, 0.0, 1.0, 0.94);
-      pad->Draw();
-      pad->cd();
+      TPad pad("pad", "pad", 0.0, 0.0, 1.0, 0.94);
+      pad.Draw();
+      pad.cd();
       align->Draw("TEXT");
 
       drawTable(NbRows, 4);

--- a/CondCore/EcalPlugins/plugins/EcalWeightXtalGroups_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalWeightXtalGroups_PayloadInspector.cc
@@ -14,6 +14,8 @@
 #include "TLatex.h"
 
 #include <string>
+#include <memory>
+#include <array>
 
 namespace {
 
@@ -100,9 +102,9 @@ namespace {
 
       float xmi[3] = {0.0, 0.24, 0.76};
       float xma[3] = {0.24, 0.76, 1.00};
-      TPad** pad = new TPad*;
+      std::array<std::unique_ptr<TPad>, 3> pad;
       for (int obj = 0; obj < 3; obj++) {
-        pad[obj] = new TPad(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], 0.0, xma[obj], 0.94);
+        pad[obj] = std::make_unique<TPad>(Form("p_%i", obj), Form("p_%i", obj), xmi[obj], 0.0, xma[obj], 0.94);
         pad[obj]->Draw();
       }
       //      EcalDrawMaps ICMap;


### PR DESCRIPTION
#### PR description:

- Use std::array to properly assign memory for multiple TPads.
- This problem was found by gcc 11.

#### PR validation:

Code compiles under gcc 11.

fixes makortel/framework#241