### PR TITLE
Add SiStripCalCosmics ALCANANO

### DIFF
--- a/CalibTracker/SiStripCommon/BuildFile.xml
+++ b/CalibTracker/SiStripCommon/BuildFile.xml
@@ -2,8 +2,11 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/FEDRawData"/>
 <use name="DataFormats/SiStripDetId"/>
+<use name="DataFormats/TrackReco"/>
+<use name="DataFormats/TrackerRecHit2D"/>
 <use name="DataFormats/Scalers"/>
 <use name="DataFormats/OnlineMetaData"/>
+<use name="DataFormats/NanoAOD"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/Utilities"/>

--- a/CalibTracker/SiStripCommon/interface/SiStripOnTrackClusterTableProducerBase.h
+++ b/CalibTracker/SiStripCommon/interface/SiStripOnTrackClusterTableProducerBase.h
@@ -1,0 +1,56 @@
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/NanoAOD/interface/FlatTable.h"
+#include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
+
+class SiStripOnTrackClusterTableProducerBase : public edm::stream::EDProducer<> {
+public:
+  explicit SiStripOnTrackClusterTableProducerBase(const edm::ParameterSet& params)
+      : m_name(params.getParameter<std::string>("name")),
+        m_doc(params.existsAs<std::string>("doc") ? params.getParameter<std::string>("doc") : ""),
+        m_extension(params.existsAs<bool>("extension") ? params.getParameter<bool>("extension") : true),
+        m_tracks_token(consumes<edm::View<reco::Track>>(params.getParameter<edm::InputTag>("Tracks"))),
+        m_association_token(consumes<TrajTrackAssociationCollection>(params.getParameter<edm::InputTag>("Tracks"))) {
+    produces<nanoaod::FlatTable>();
+  }
+  ~SiStripOnTrackClusterTableProducerBase() override;
+
+  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) final;
+
+  struct OnTrackCluster {
+    uint32_t det;
+    const SiStripCluster* cluster;
+    const Trajectory* traj;
+    const reco::Track* track;
+    const TrajectoryMeasurement& measurement;
+    OnTrackCluster(uint32_t detId,
+                   const SiStripCluster* stripCluster,
+                   const Trajectory* trajectory,
+                   const reco::Track* track_,
+                   const TrajectoryMeasurement& measurement_)
+        : det{detId}, cluster{stripCluster}, traj{trajectory}, track{track_}, measurement{measurement_} {}
+  };
+
+  virtual void fillTable(const std::vector<OnTrackCluster>& clusters,
+                         const edm::View<reco::Track>& tracks,
+                         nanoaod::FlatTable* table,
+                         const edm::EventSetup& iSetup) = 0;
+
+  template <typename VALUES>
+  static void addColumn(nanoaod::FlatTable* table, const std::string& name, VALUES&& values, const std::string& doc) {
+    using value_type = typename std::remove_reference<VALUES>::type::value_type;
+    table->template addColumn<value_type>(name, values, doc);
+  }
+
+private:
+  const std::string m_name;
+  const std::string m_doc;
+  bool m_extension;
+
+  const edm::EDGetTokenT<edm::View<reco::Track>> m_tracks_token;
+  const edm::EDGetTokenT<TrajTrackAssociationCollection> m_association_token;
+};

--- a/CalibTracker/SiStripCommon/plugins/BuildFile.xml
+++ b/CalibTracker/SiStripCommon/plugins/BuildFile.xml
@@ -9,6 +9,7 @@
 <use name="CondFormats/RunInfo"/>
 <use name="RecoLocalTracker/SiStripClusterizer"/>
 <use name="SimDataFormats/TrackingAnalysis"/>
+<use name="DataFormats/NanoAOD"/>
 <library file="*.cc" name="CalibTrackerSiStripCommonPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/CalibTracker/SiStripCommon/plugins/SealModules.cc
+++ b/CalibTracker/SiStripCommon/plugins/SealModules.cc
@@ -24,3 +24,7 @@ DEFINE_FWK_MODULE(ShallowSimhitClustersProducer);
 DEFINE_FWK_MODULE(ShallowTracksProducer);
 DEFINE_FWK_MODULE(ShallowSimTracksProducer);
 DEFINE_FWK_MODULE(ShallowGainCalibration);
+
+#include "PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h"
+typedef SimpleFlatTableProducer<reco::Track> SimpleTrackFlatTableProducer;
+DEFINE_FWK_MODULE(SimpleTrackFlatTableProducer);

--- a/CalibTracker/SiStripCommon/plugins/SiStripLorentzAngleRunInfoTableProducer.cc
+++ b/CalibTracker/SiStripCommon/plugins/SiStripLorentzAngleRunInfoTableProducer.cc
@@ -1,0 +1,107 @@
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "DataFormats/NanoAOD/interface/FlatTable.h"
+
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "CondFormats/SiStripObjects/interface/SiStripLorentzAngle.h"
+#include "CalibTracker/Records/interface/SiStripDependentRecords.h"
+#include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+
+#include "CalibTracker/SiStripCommon/interface/ShallowTools.h"
+
+class SiStripLorentzAngleRunInfoTableProducer : public edm::global::EDProducer<edm::BeginRunProducer> {
+public:
+  explicit SiStripLorentzAngleRunInfoTableProducer(const edm::ParameterSet& params)
+      : m_name{params.getParameter<std::string>("name")},
+        m_magFieldName{params.getParameter<std::string>("magFieldName")},
+        m_doc{params.existsAs<std::string>("doc") ? params.getParameter<std::string>("doc") : ""},
+        m_tkGeomToken{esConsumes<edm::Transition::BeginRun>()},
+        m_magFieldToken{esConsumes<edm::Transition::BeginRun>()},
+        m_lorentzAngleToken{esConsumes<edm::Transition::BeginRun>()} {
+    produces<nanoaod::FlatTable, edm::Transition::BeginRun>();
+    produces<nanoaod::FlatTable, edm::Transition::BeginRun>("magField");
+  }
+
+  void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {}
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<std::string>("name", "Det");
+    desc.add<std::string>("magFieldName", "magField");
+    desc.add<std::string>("doc", "Run info for the Lorentz angle measurement");
+    descriptions.add("siStripLorentzAngleRunInfoTable", desc);
+  }
+
+  void globalBeginRunProduce(edm::Run& iRun, edm::EventSetup const& iSetup) const override;
+
+private:
+  const std::string m_name, m_magFieldName;
+  const std::string m_doc;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> m_tkGeomToken;
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> m_magFieldToken;
+  edm::ESGetToken<SiStripLorentzAngle, SiStripLorentzAngleDepRcd> m_lorentzAngleToken;
+};
+
+namespace {
+  template <typename VALUES>
+  void addColumn(nanoaod::FlatTable* table, const std::string& name, VALUES&& values, const std::string& doc) {
+    using value_type = typename std::remove_reference<VALUES>::type::value_type;
+    table->template addColumn<value_type>(name, values, doc);
+  }
+}  // namespace
+
+void SiStripLorentzAngleRunInfoTableProducer::globalBeginRunProduce(edm::Run& iRun,
+                                                                    edm::EventSetup const& iSetup) const {
+  const auto& tkGeom = iSetup.getData(m_tkGeomToken);
+  const auto& magField = iSetup.getData(m_magFieldToken);
+  const auto& lorentzAngle = iSetup.getData(m_lorentzAngleToken);
+  std::vector<uint32_t> c_rawid;
+  std::vector<float> c_globalZofunitlocalY, c_localB, c_BdotY, c_driftx, c_drifty, c_driftz, c_lorentzAngle;
+
+  auto dets = tkGeom.detsTIB();
+  dets.insert(dets.end(), tkGeom.detsTID().begin(), tkGeom.detsTID().end());
+  dets.insert(dets.end(), tkGeom.detsTOB().begin(), tkGeom.detsTOB().end());
+  dets.insert(dets.end(), tkGeom.detsTEC().begin(), tkGeom.detsTEC().end());
+  for (auto det : dets) {
+    auto detid = det->geographicalId().rawId();
+    const StripGeomDetUnit* stripDet = dynamic_cast<const StripGeomDetUnit*>(tkGeom.idToDet(det->geographicalId()));
+    if (stripDet) {
+      c_rawid.push_back(detid);
+      c_globalZofunitlocalY.push_back(stripDet->toGlobal(LocalVector(0, 1, 0)).z());
+      const auto locB = magField.inTesla(stripDet->surface().position());
+      c_localB.push_back(locB.mag());
+      c_BdotY.push_back(stripDet->surface().toLocal(locB).y());
+      const auto drift = shallow::drift(stripDet, magField, lorentzAngle);
+      c_driftx.push_back(drift.x());
+      c_drifty.push_back(drift.y());
+      c_driftz.push_back(drift.z());
+      c_lorentzAngle.push_back(lorentzAngle.getLorentzAngle(detid));
+    }
+  }
+  auto out = std::make_unique<nanoaod::FlatTable>(c_rawid.size(), m_name, false, false);
+  addColumn(out.get(), "rawid", c_rawid, "DetId");
+  addColumn(out.get(), "globalZofunitlocalY", c_globalZofunitlocalY, "z component of a local unit vector along y");
+  addColumn(out.get(), "localB", c_localB, "Local magnitude of the magnetic field");
+  addColumn(out.get(), "BdotY", c_BdotY, "Magnetic field projection on the local y axis");
+  addColumn(out.get(), "driftx", c_driftx, "x component of the drift vector");
+  addColumn(out.get(), "drifty", c_drifty, "y component of the drift vector");
+  addColumn(out.get(), "driftz", c_driftz, "z component of the drift vector");
+  addColumn(out.get(), "lorentzAngle", c_lorentzAngle, "Lorentz angle from database");
+  iRun.put(std::move(out));
+
+  auto out2 = std::make_unique<nanoaod::FlatTable>(1, m_magFieldName, true, false);
+  out2->addColumnValue<float>(
+      "origin", magField.inTesla(GlobalPoint(0, 0, 0)).z(), "z-component of the magnetic field at (0,0,0) in Tesla");
+  iRun.put(std::move(out2), "magField");
+}
+
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(SiStripLorentzAngleRunInfoTableProducer);

--- a/CalibTracker/SiStripCommon/plugins/SiStripPositionCorrectionsTableProducer.cc
+++ b/CalibTracker/SiStripCommon/plugins/SiStripPositionCorrectionsTableProducer.cc
@@ -1,0 +1,75 @@
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+
+#include "RecoLocalTracker/SiStripClusterizer/interface/SiStripClusterInfo.h"
+
+#include "CalibTracker/SiStripCommon/interface/SiStripOnTrackClusterTableProducerBase.h"
+
+class SiStripPositionCorrectionsTableProducer : public SiStripOnTrackClusterTableProducerBase {
+public:
+  explicit SiStripPositionCorrectionsTableProducer(const edm::ParameterSet& params)
+      : SiStripOnTrackClusterTableProducerBase(params),
+        m_clusterInfo(consumesCollector()),
+        m_tkGeomToken{esConsumes<>()} {}
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<std::string>("name", "cluster");
+    desc.add<std::string>("doc", "On-track cluster properties for Lorentz angle and backplane correction measurement");
+    desc.add<bool>("extension", false);
+    desc.add<edm::InputTag>("Tracks", edm::InputTag{"generalTracks"});
+    descriptions.add("siStripPositionCorrectionsTable", desc);
+  }
+
+  void fillTable(const std::vector<OnTrackCluster>& clusters,
+                 const edm::View<reco::Track>& tracks,
+                 nanoaod::FlatTable* table,
+                 const edm::EventSetup& iSetup) final;
+
+private:
+  SiStripClusterInfo m_clusterInfo;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> m_tkGeomToken;
+};
+
+void SiStripPositionCorrectionsTableProducer::fillTable(const std::vector<OnTrackCluster>& clusters,
+                                                        const edm::View<reco::Track>& tracks,
+                                                        nanoaod::FlatTable* table,
+                                                        const edm::EventSetup& iSetup) {
+  const auto& tkGeom = iSetup.getData(m_tkGeomToken);
+  std::vector<uint32_t> c_nstrips;
+  std::vector<float> c_barycenter, c_variance, c_localdirx, c_localdiry, c_localdirz, c_localx, c_rhlocalx,
+      c_rhlocalxerr;
+  for (const auto clus : clusters) {
+    c_nstrips.push_back(clus.cluster->amplitudes().size());
+    m_clusterInfo.setCluster(*clus.cluster, clus.det);
+    c_variance.push_back(m_clusterInfo.variance());
+    const auto& trajState = clus.measurement.updatedState();
+    const auto trackDir = trajState.localDirection();
+    c_localdirx.push_back(trackDir.x());
+    c_localdiry.push_back(trackDir.y());
+    c_localdirz.push_back(trackDir.z());
+    const auto hit = clus.measurement.recHit()->hit();
+    const auto stripDet = dynamic_cast<const StripGeomDetUnit*>(tkGeom.idToDet(hit->geographicalId()));
+    c_barycenter.push_back(stripDet->specificTopology().localPosition(clus.cluster->barycenter()).x());
+    c_localx.push_back(stripDet->toLocal(trajState.globalPosition()).x());
+    c_rhlocalx.push_back(hit->localPosition().x());
+    c_rhlocalxerr.push_back(hit->localPositionError().xx());
+  }
+  addColumn(table, "nstrips", c_nstrips, "cluster width");
+  addColumn(table, "variance", c_variance, "Cluster variance");
+  addColumn(table, "localdirx", c_localdirx, "x component of the local track direction");
+  addColumn(table, "localdiry", c_localdiry, "y component of the local track direction");
+  addColumn(table, "localdirz", c_localdirz, "z component of the local track direction");
+  addColumn(table, "barycenter", c_barycenter, "Cluster barycenter (local x without corrections)");
+  addColumn(table, "localx", c_localx, "Track local x");
+  addColumn(table, "rhlocalx", c_rhlocalx, "RecHit local x");
+  addColumn(table, "rhlocalxerr", c_rhlocalxerr, "RecHit local x uncertainty");
+}
+
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(SiStripPositionCorrectionsTableProducer);

--- a/CalibTracker/SiStripCommon/src/SiStripOnTrackClusterTableProducerBase.cc
+++ b/CalibTracker/SiStripCommon/src/SiStripOnTrackClusterTableProducerBase.cc
@@ -1,0 +1,68 @@
+#include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit1D.h"
+
+#include "CalibTracker/SiStripCommon/interface/SiStripOnTrackClusterTableProducerBase.h"
+
+SiStripOnTrackClusterTableProducerBase::~SiStripOnTrackClusterTableProducerBase() {}
+
+namespace {
+  int findTrackIndex(const edm::View<reco::Track>& tracks, const reco::Track* track) {
+    for (auto iTr = tracks.begin(); iTr != tracks.end(); ++iTr) {
+      if (&(*iTr) == track) {
+        return iTr - tracks.begin();
+      }
+    }
+    return -2;
+  }
+}  // namespace
+
+void SiStripOnTrackClusterTableProducerBase::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  edm::Handle<edm::View<reco::Track>> tracks;
+  iEvent.getByToken(m_tracks_token, tracks);
+  edm::Handle<TrajTrackAssociationCollection> trajTrackAssociations;
+  iEvent.getByToken(m_association_token, trajTrackAssociations);
+
+  std::vector<OnTrackCluster> clusters{};
+
+  for (const auto& assoc : *trajTrackAssociations) {
+    const auto traj = assoc.key.get();
+    const auto track = assoc.val.get();
+
+    for (const auto& meas : traj->measurements()) {
+      const auto& trajState = meas.updatedState();
+      if (!trajState.isValid())
+        continue;
+
+      // there can be 2 (stereo module), 1 (no stereo module), or 0 (no strip hit) clusters per measurement
+      const auto trechit = meas.recHit()->hit();
+      const auto simple1d = dynamic_cast<const SiStripRecHit1D*>(trechit);
+      const auto simple = dynamic_cast<const SiStripRecHit2D*>(trechit);
+      const auto matched = dynamic_cast<const SiStripMatchedRecHit2D*>(trechit);
+      if (matched) {
+        clusters.emplace_back(matched->monoId(), &matched->monoCluster(), traj, track, meas);
+        clusters.emplace_back(matched->stereoId(), &matched->stereoCluster(), traj, track, meas);
+      } else if (simple) {
+        clusters.emplace_back(simple->geographicalId().rawId(), simple->cluster().get(), traj, track, meas);
+      } else if (simple1d) {
+        clusters.emplace_back(simple1d->geographicalId().rawId(), simple1d->cluster().get(), traj, track, meas);
+      }
+    }
+  }
+
+  auto out = std::make_unique<nanoaod::FlatTable>(clusters.size(), m_name, false, m_extension);
+  if (!m_extension) {
+    std::vector<int> c_trackindex;
+    c_trackindex.reserve(clusters.size());
+    std::vector<uint32_t> c_rawid;
+    c_rawid.reserve(clusters.size());
+    for (const auto clus : clusters) {
+      c_trackindex.push_back(findTrackIndex(*tracks, clus.track));
+      c_rawid.push_back(clus.det);
+    }
+    addColumn(out.get(), "trackindex", c_trackindex, "Track index");
+    addColumn(out.get(), "rawid", c_rawid, "DetId");
+  }
+  fillTable(clusters, *tracks, out.get(), iSetup);
+  iEvent.put(std::move(out));
+}

--- a/CalibTracker/SiStripCommon/test/MakeCalibrationTrees/produceCalibrationTree_CosmicsLABP_cfg.py
+++ b/CalibTracker/SiStripCommon/test/MakeCalibrationTrees/produceCalibrationTree_CosmicsLABP_cfg.py
@@ -1,0 +1,173 @@
+from __future__ import print_function
+import FWCore.ParameterSet.Config as cms
+from FWCore.ParameterSet.VarParsing import VarParsing
+
+###################################################################
+# Setup 'standard' options
+###################################################################
+options = VarParsing()
+
+options.register('conditionGT',
+                 "auto:run2_data",
+                 VarParsing.multiplicity.singleton,
+                 VarParsing.varType.string,
+                 "condition global tag for the job (\"auto:run2_data\" is default)")
+
+options.register('conditionOverwrite',
+                 "",
+                 VarParsing.multiplicity.singleton,
+                 VarParsing.varType.string,
+                 "configuration to overwrite the condition into the GT (\"\" is default)")
+
+options.register('inputCollection',
+                 "ALCARECOSiStripCalMinBias",
+                 VarParsing.multiplicity.singleton,
+                 VarParsing.varType.string,
+                 "collections to be used for input (\"ALCARECOSiStripCalMinBias\" is default, use 'generalTracks' for prompt reco and 'ctfWithMaterialTracksP5' for cosmic reco)")
+
+options.register('outputFile',
+                 "calibTreeTest.root",
+                 VarParsing.multiplicity.singleton,
+                 VarParsing.varType.string,
+                 "name for the output root file (\"calibTreeTest.root\" is default)")
+
+options.register('inputFiles',
+                 '/store/data/Run2018D/Cosmics/ALCARECO/SiStripCalCosmics-UL18-v1/40000/0346DCE4-0C70-1344-A7EB-D488B627208C.root',
+                 VarParsing.multiplicity.list,
+                 VarParsing.varType.string,
+                 "file to process")
+
+options.register('maxEvents',
+                 -1,
+                 VarParsing.multiplicity.singleton,
+                 VarParsing.varType.int,
+                 "number of events to process (\"-1\" for all)")
+
+options.register('runNumber',
+                 -1,
+                 VarParsing.multiplicity.singleton,
+                 VarParsing.varType.int,
+                 "run number to process (\"-1\" for all)")
+
+options.register('cosmicTriggers', '',
+                 VarParsing.multiplicity.list,
+                 VarParsing.varType.string,
+                 'cosmic triggers')
+
+options.parseArguments()
+###################################################################
+# To use the prompt reco dataset please use 'generalTracks' as inputCollection
+# To use the cosmic reco dataset please use 'ctfWithMaterialTracksP5' as inputCollection
+
+
+process = cms.Process('CALIB')
+process.load('Configuration/StandardSequences/MagneticField_cff')
+process.load('Configuration.Geometry.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, options.conditionGT, options.conditionOverwrite)
+
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.StandardSequences.Services_cff')
+
+process.maxEvents = cms.untracked.PSet(input=cms.untracked.int32(options.maxEvents))
+
+process.source = cms.Source("PoolSource", fileNames=cms.untracked.vstring(options.inputFiles))
+if options.runNumber != -1:
+   if 'Cosmics' not in options.inputCollection:  # FIXME: this should be improved
+      print("Restricting to the following events :")
+      print('%s:1-%s:MAX'%(options.runNumber,options.runNumber))
+      process.source.eventsToProcess = cms.untracked.VEventRange('%s:1-%s:MAX'%(options.runNumber,options.runNumber))
+   else:
+      print("Restricting to the following lumis for Cosmic runs only:")
+      print('%s:1-%s:MAX'%(options.runNumber,options.runNumber))
+      process.source.lumisToProcess = cms.untracked.VLuminosityBlockRange('%s:1-%s:MAX'%(options.runNumber,options.runNumber))
+
+process.options = cms.untracked.PSet(
+        wantSummary = cms.untracked.bool(True)
+        )
+process.MessageLogger.cerr.FwkReport.reportEvery = 10000
+
+inTracks = cms.InputTag(options.inputCollection)
+
+process.load('CalibTracker.SiStripCommon.prescaleEvent_cfi')
+process.load('CalibTracker.Configuration.Filter_Refit_cff')
+## use CalibrationTracks (for clusters) and CalibrationTracksRefit (for tracks)
+process.CalibrationTracks.src = inTracks
+tracksForCalib = cms.InputTag("CalibrationTracksRefit")
+
+process.prescaleEvent.prescale = 1
+process.load("CalibTracker.SiStripCommon.SiStripBFieldFilter_cfi")
+
+from HLTrigger.HLTfilters.triggerResultsFilter_cfi import triggerResultsFilter
+
+process.IsolatedMuonFilter = triggerResultsFilter.clone(
+        triggerConditions = cms.vstring("HLT_IsoMu20_*"),
+        hltResults = cms.InputTag("TriggerResults", "", "HLT"),
+        l1tResults = cms.InputTag(""),
+        throw = cms.bool(False)
+        )
+if len(options.cosmicTriggers) > 0:
+    print("Cosmic triggers: {0}".format(", ".join(options.cosmicTriggers)))
+    process.IsolatedMuonFilter.triggerConditions = cms.vstring(options.cosmicTriggers)
+else:
+    print("Cosmic triggers: {0} (default)".format(", ".join(process.IsolatedMuonFilter.triggerConditions)))
+    print("Argument passed: {0}".format(options.cosmicTriggers))
+
+process.TkCalSeq = cms.Sequence(
+        process.prescaleEvent*
+        process.IsolatedMuonFilter*
+        process.siStripBFieldOnFilter*
+        process.CalibrationTracks,
+        cms.Task(process.MeasurementTrackerEvent),
+        cms.Task(process.offlineBeamSpot),
+        cms.Task(process.CalibrationTracksRefit)
+        )
+
+process.load("PhysicsTools.NanoAOD.nano_cff")
+process.load("PhysicsTools.NanoAOD.NanoAODEDMEventContent_cff")
+
+## as a test: it should be possible to add tracks fully at configuration level (+ declaring the plugin)
+from PhysicsTools.NanoAOD.common_cff import *
+## this is equivalent to ShallowTrackProducer as configured for the gain calibration
+process.tracksTable = cms.EDProducer("SimpleTrackFlatTableProducer",
+        src=tracksForCalib,
+        cut=cms.string(""),
+        name=cms.string("track"),
+        doc=cms.string("SiStripCalMinBias ALCARECO tracks"),
+        singleton=cms.bool(False),
+        extension=cms.bool(False),
+        variables=cms.PSet(
+            chi2ndof=Var("chi2()/ndof", float),
+            pt=Var("pt()", float),
+            hitsvalid=Var("numberOfValidHits()", int), ## unsigned?
+            phi=Var("phi()", float),
+            eta=Var("eta()", float),
+            )
+        )
+process.load("CalibTracker.SiStripCommon.siStripPositionCorrectionsTable_cfi")
+process.siStripPositionCorrectionsTable.Tracks = tracksForCalib
+process.load("CalibTracker.SiStripCommon.siStripLorentzAngleRunInfoTable_cfi")
+
+siStripCalCosmicsNanoTables = cms.Task(
+        process.nanoMetadata,
+        process.tracksTable,
+        process.siStripPositionCorrectionsTable,
+        process.siStripLorentzAngleRunInfoTable
+        )
+
+process.nanoCTPath = cms.Path(process.TkCalSeq, siStripCalCosmicsNanoTables)
+
+process.out = cms.OutputModule("NanoAODOutputModule",
+        fileName=cms.untracked.string(options.outputFile),
+        outputCommands=process.NANOAODEventContent.outputCommands+[
+            "drop edmTriggerResults_*_*_*"
+            ],
+        SelectEvents=cms.untracked.PSet(
+            SelectEvents=cms.vstring("nanoCTPath")
+            )
+        )
+process.end = cms.EndPath(process.out)
+
+process.schedule = cms.Schedule(process.nanoCTPath, process.end)

--- a/CalibTracker/SiStripCommon/test/MakeCalibrationTrees/produceCalibrationTree_CosmicsLABP_cfg.py
+++ b/CalibTracker/SiStripCommon/test/MakeCalibrationTrees/produceCalibrationTree_CosmicsLABP_cfg.py
@@ -75,7 +75,7 @@ process.maxEvents = cms.untracked.PSet(input=cms.untracked.int32(options.maxEven
 
 process.source = cms.Source("PoolSource", fileNames=cms.untracked.vstring(options.inputFiles))
 if options.runNumber != -1:
-   if 'Cosmics' not in options.inputCollection:  # FIXME: this should be improved
+   if 'Cosmics' not in options.inputCollection:
       print("Restricting to the following events :")
       print('%s:1-%s:MAX'%(options.runNumber,options.runNumber))
       process.source.eventsToProcess = cms.untracked.VEventRange('%s:1-%s:MAX'%(options.runNumber,options.runNumber))

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalCosmicsNano_Output_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalCosmicsNano_Output_cff.py
@@ -1,0 +1,17 @@
+import FWCore.ParameterSet.Config as cms
+
+# AlCaNano for track based calibration using Cosmics events
+from PhysicsTools.NanoAOD.NanoAODEDMEventContent_cff import NANOAODEventContent
+OutALCARECOSiStripCalCosmicsNano_noDrop = cms.PSet(
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('pathALCARECOSiStripCalCosmicsNano')
+    ),
+    outputCommands=cms.untracked.vstring(
+        'keep nanoaodFlatTable_*Table_*_*',
+        'keep nanoaodMergeableCounterTable_*Table_*_*',
+        'keep nanoaodUniqueString_nanoMetadata_*_*',
+        )
+    )
+import copy
+OutALCARECOSiStripCalCosmicsNano = copy.deepcopy(OutALCARECOSiStripCalCosmicsNano_noDrop)
+OutALCARECOSiStripCalCosmicsNano.outputCommands.insert(0, "drop *")

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalCosmicsNano_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalCosmicsNano_cff.py
@@ -1,0 +1,65 @@
+import FWCore.ParameterSet.Config as cms
+
+from Calibration.TkAlCaRecoProducers.ALCARECOSiStripCalCosmics_cff import ALCARECOSiStripCalCosmics
+from CalibTracker.SiStripCommon.prescaleEvent_cfi import prescaleEvent
+from HLTrigger.HLTfilters.triggerResultsFilter_cfi import triggerResultsFilter
+from CalibTracker.SiStripCommon.SiStripBFieldFilter_cfi import siStripBFieldOnFilter
+
+ALCARECOSiStripCalCosmicsNanoPrescale = prescaleEvent.clone(prescale=1)
+
+ALCARECOSiStripCalCosmicsNanoHLT = triggerResultsFilter.clone(
+        triggerConditions=cms.vstring("HLT_L1SingleMuCosmics_v*"),
+        hltResults=cms.InputTag("TriggerResults", "", "HLT"),
+        l1tResults=cms.InputTag(""),
+        throw=cms.bool(False)
+        )
+
+from CalibTracker.Configuration.Filter_Refit_cff import CalibrationTracks, CalibrationTracksRefit, MeasurementTrackerEvent, offlineBeamSpot
+
+ALCARECOSiStripCalCosmicsNanoCalibTracks = CalibrationTracks.clone(src=cms.InputTag("ALCARECOSiStripCalCosmics"))
+ALCARECOSiStripCalCosmicsNanoCalibTracksRefit = CalibrationTracksRefit.clone(
+        src=cms.InputTag("ALCARECOSiStripCalCosmicsNanoCalibTracks")
+        )
+
+ALCARECOSiStripCalCosmicsNanoTkCalSeq = cms.Sequence(
+        ALCARECOSiStripCalCosmicsNanoPrescale*
+        ALCARECOSiStripCalCosmicsNanoHLT*
+        siStripBFieldOnFilter*
+        ALCARECOSiStripCalCosmicsNanoCalibTracks,
+        cms.Task(MeasurementTrackerEvent),
+        cms.Task(offlineBeamSpot),
+        cms.Task(ALCARECOSiStripCalCosmicsNanoCalibTracksRefit)
+        )
+
+from PhysicsTools.NanoAOD.common_cff import *
+from PhysicsTools.NanoAOD.nano_cff import nanoMetadata
+from CalibTracker.SiStripCommon.siStripPositionCorrectionsTable_cfi import siStripPositionCorrectionsTable
+from CalibTracker.SiStripCommon.siStripLorentzAngleRunInfoTable_cfi import siStripLorentzAngleRunInfoTable
+
+ALCARECOSiStripCalCosmicsNanoTracksTable = cms.EDProducer("SimpleTrackFlatTableProducer",
+        src=cms.InputTag("ALCARECOSiStripCalCosmicsNanoCalibTracksRefit"),
+        cut=cms.string(""),
+        name=cms.string("track"),
+        doc=cms.string("SiStripCalCosmics ALCARECO tracks"),
+        singleton=cms.bool(False),
+        extension=cms.bool(False),
+        variables=cms.PSet(
+            chi2ndof=Var("chi2()/ndof", float),
+            pt=Var("pt()", float),
+            hitsvalid=Var("numberOfValidHits()", int), ## unsigned?
+            phi=Var("phi()", float),
+            eta=Var("eta()", float),
+            )
+        )
+
+ALCARECOSiStripCalCosmicsNanoMeasTable = siStripPositionCorrectionsTable.clone(
+        Tracks=cms.InputTag("ALCARECOSiStripCalCosmicsNanoCalibTracksRefit"))
+
+ALCARECOSiStripCalCosmicsNanoTables = cms.Task(
+        nanoMetadata,
+        ALCARECOSiStripCalCosmicsNanoTracksTable,
+        ALCARECOSiStripCalCosmicsNanoMeasTable,
+        siStripLorentzAngleRunInfoTable
+        )
+
+seqALCARECOSiStripCalCosmicsNano = cms.Sequence(ALCARECOSiStripCalCosmicsNanoTkCalSeq, ALCARECOSiStripCalCosmicsNanoTables)

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalCosmicsNano_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalCosmicsNano_cff.py
@@ -3,7 +3,6 @@ import FWCore.ParameterSet.Config as cms
 from Calibration.TkAlCaRecoProducers.ALCARECOSiStripCalCosmics_cff import ALCARECOSiStripCalCosmics
 from CalibTracker.SiStripCommon.prescaleEvent_cfi import prescaleEvent
 from HLTrigger.HLTfilters.triggerResultsFilter_cfi import triggerResultsFilter
-from CalibTracker.SiStripCommon.SiStripBFieldFilter_cfi import siStripBFieldOnFilter
 
 ALCARECOSiStripCalCosmicsNanoPrescale = prescaleEvent.clone(prescale=1)
 
@@ -24,7 +23,6 @@ ALCARECOSiStripCalCosmicsNanoCalibTracksRefit = CalibrationTracksRefit.clone(
 ALCARECOSiStripCalCosmicsNanoTkCalSeq = cms.Sequence(
         ALCARECOSiStripCalCosmicsNanoPrescale*
         ALCARECOSiStripCalCosmicsNanoHLT*
-        siStripBFieldOnFilter*
         ALCARECOSiStripCalCosmicsNanoCalibTracks,
         cms.Task(MeasurementTrackerEvent),
         cms.Task(offlineBeamSpot),

--- a/Configuration/DataProcessing/test/run_CfgTest.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest.sh
@@ -21,6 +21,12 @@ do
      runTest "${LOCAL_TEST_DIR}/RunAlcaHarvesting.py --scenario $scenario --lfn /store/whatever --dataset /A/B/C --global-tag GLOBALTAG --workflows=BeamSpotByRun,BeamSpotByLumi,SiStripQuality"
 done
 
+declare -a arr=("cosmicsEra_Run2_2018" "cosmicsHybridEra_Run2_2018" "cosmicsEra_Run3")
+for scenario in "${arr[@]}"
+do
+     runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario $scenario --global-tag GLOBALTAG --lfn /store/whatever --fevt --dqmio  --alcareco SiStripCalCosmicsNano "
+done
+
 declare -a arr=("HeavyIonsEra_Run2_2018")
 for scenario in "${arr[@]}"
 do

--- a/Configuration/EventContent/python/AlCaRecoOutput_cff.py
+++ b/Configuration/EventContent/python/AlCaRecoOutput_cff.py
@@ -53,6 +53,7 @@ from Calibration.TkAlCaRecoProducers.ALCARECOSiStripCalZeroBias_Output_cff impor
 from CalibTracker.SiPixelQuality.ALCARECOSiPixelCalZeroBias_Output_cff import *
 # AlCaReco for tracker calibration using Cosmics events
 from Calibration.TkAlCaRecoProducers.ALCARECOSiStripCalCosmics_Output_cff import *
+from Calibration.TkAlCaRecoProducers.ALCARECOSiStripCalCosmicsNano_Output_cff import *
 from Calibration.TkAlCaRecoProducers.ALCARECOSiPixelCalCosmics_Output_cff import *
 
 # AlCaReco for tracker based alignment using beam halo

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2597,11 +2597,11 @@ steps['ALCACOSD']={'--conditions':'auto:run1_data',
                    '-s':'ALCA:TkAlCosmics0T+MuAlGlobalCosmics+HcalCalHOCosmics+DQM'
                    }
 
-steps['ALCACOSDRUN2']=merge([{'--conditions':'auto:run2_data','--era':'Run2_2016','-s':'ALCA:SiPixelCalCosmics+TkAlCosmics0T+SiStripCalCosmics+MuAlGlobalCosmics+HcalCalHOCosmics+DQM'},steps['ALCACOSD']])
+steps['ALCACOSDRUN2']=merge([{'--conditions':'auto:run2_data','--era':'Run2_2016','-s':'ALCA:SiPixelCalCosmics+TkAlCosmics0T+SiStripCalCosmics+SiStripCalCosmicsNano+MuAlGlobalCosmics+HcalCalHOCosmics+DQM'},steps['ALCACOSD']])
 
-steps['ALCACOSDRUN3']=merge([{'--conditions':'auto:run3_data','--era':'Run3','-s':'ALCA:SiPixelCalCosmics+TkAlCosmics0T+SiStripCalCosmics+MuAlGlobalCosmics+HcalCalHOCosmics+DQM'},steps['ALCACOSD']])
-steps['ALCACOSDPROMPTRUN3']=merge([{'--conditions':'auto:run3_data_prompt','--era':'Run3','-s':'ALCA:SiPixelCalCosmics+TkAlCosmics0T+SiStripCalCosmics+MuAlGlobalCosmics+HcalCalHOCosmics+DQM'},steps['ALCACOSD']])
-steps['ALCACOSDEXPRUN3']=merge([{'--conditions':'auto:run3_data_express','--era':'Run3','-s':'ALCA:SiPixelCalCosmics+TkAlCosmics0T+SiStripCalCosmics+MuAlGlobalCosmics+HcalCalHOCosmics+DQM'},steps['ALCACOSD']])
+steps['ALCACOSDRUN3']=merge([{'--conditions':'auto:run3_data','--era':'Run3','-s':'ALCA:SiPixelCalCosmics+TkAlCosmics0T+SiStripCalCosmics+SiStripCalCosmicsNano+MuAlGlobalCosmics+HcalCalHOCosmics+DQM'},steps['ALCACOSD']])
+steps['ALCACOSDPROMPTRUN3']=merge([{'--conditions':'auto:run3_data_prompt','--era':'Run3','-s':'ALCA:SiPixelCalCosmics+TkAlCosmics0T+SiStripCalCosmics+SiStripCalCosmicsNano+MuAlGlobalCosmics+HcalCalHOCosmics+DQM'},steps['ALCACOSD']])
+steps['ALCACOSDEXPRUN3']=merge([{'--conditions':'auto:run3_data_express','--era':'Run3','-s':'ALCA:SiPixelCalCosmics+TkAlCosmics0T+SiStripCalCosmics+SiStripCalCosmicsNano+MuAlGlobalCosmics+HcalCalHOCosmics+DQM'},steps['ALCACOSD']])
 
 steps['ALCAPROMPT']={'-s':'ALCA:PromptCalibProd',
                      '--filein':'file:TkAlMinBias.root',
@@ -2658,10 +2658,10 @@ steps['ALCABH_UP21']=merge([{'--conditions':'auto:phase1_2021_cosmics','-s':'ALC
 
 steps['ALCAHAL']=merge([{'-s':'ALCA:TkAlBeamHalo+MuAlBeamHaloOverlaps+MuAlBeamHalo'},step4Up2015Defaults])
 steps['ALCACOS_UP15']=merge([{'--conditions':'auto:run2_mc_cosmics','-s':'ALCA:TkAlBeamHalo+MuAlBeamHaloOverlaps+MuAlBeamHalo'},step4Up2015Defaults])
-steps['ALCACOS_UP16']=merge([{'--conditions':'auto:run2_mc_cosmics','-s':'ALCA:TkAlCosmics0T+SiStripCalCosmics+SiPixelCalCosmics+TkAlBeamHalo+MuAlBeamHaloOverlaps+MuAlBeamHalo','--era':'Run2_2016'},step4Up2015Defaults])
-steps['ALCACOS_UP17']=merge([{'--conditions':'auto:phase1_2017_cosmics','-s':'ALCA:TkAlCosmics0T+SiStripCalCosmics+SiPixelCalCosmics+TkAlBeamHalo+MuAlBeamHaloOverlaps+MuAlBeamHalo','--era':'Run2_2017'},step4Up2015Defaults])
-steps['ALCACOS_UP18']=merge([{'--conditions':'auto:phase1_2018_cosmics','-s':'ALCA:TkAlCosmics0T+SiStripCalCosmics+SiPixelCalCosmics+TkAlBeamHalo+MuAlBeamHaloOverlaps+MuAlBeamHalo','--era':'Run2_2018'},step4Up2015Defaults])
-steps['ALCACOS_UP21']=merge([{'--conditions':'auto:phase1_2021_cosmics','-s':'ALCA:TkAlCosmics0T+SiStripCalCosmics+SiPixelCalCosmics+TkAlBeamHalo+MuAlBeamHaloOverlaps+MuAlBeamHalo','--era':'Run3'},step4Up2015Defaults])
+steps['ALCACOS_UP16']=merge([{'--conditions':'auto:run2_mc_cosmics','-s':'ALCA:TkAlCosmics0T+SiStripCalCosmics+SiStripCalCosmicsNano+SiPixelCalCosmics+TkAlBeamHalo+MuAlBeamHaloOverlaps+MuAlBeamHalo','--era':'Run2_2016'},step4Up2015Defaults])
+steps['ALCACOS_UP17']=merge([{'--conditions':'auto:phase1_2017_cosmics','-s':'ALCA:TkAlCosmics0T+SiStripCalCosmics+SiStripCalCosmicsNano+SiPixelCalCosmics+TkAlBeamHalo+MuAlBeamHaloOverlaps+MuAlBeamHalo','--era':'Run2_2017'},step4Up2015Defaults])
+steps['ALCACOS_UP18']=merge([{'--conditions':'auto:phase1_2018_cosmics','-s':'ALCA:TkAlCosmics0T+SiStripCalCosmics+SiStripCalCosmicsNano+SiPixelCalCosmics+TkAlBeamHalo+MuAlBeamHaloOverlaps+MuAlBeamHalo','--era':'Run2_2018'},step4Up2015Defaults])
+steps['ALCACOS_UP21']=merge([{'--conditions':'auto:phase1_2021_cosmics','-s':'ALCA:TkAlCosmics0T+SiStripCalCosmics+SiStripCalCosmicsNano+SiPixelCalCosmics+TkAlBeamHalo+MuAlBeamHaloOverlaps+MuAlBeamHalo','--era':'Run3'},step4Up2015Defaults])
 steps['ALCACOS_UP21_0T']=merge([{'--magField':'0T','--conditions':'auto:phase1_2021_cosmics_0T'},steps['ALCACOS_UP21']])
 steps['ALCAHARVD']={'-s':'ALCAHARVEST:BeamSpotByRun+BeamSpotByLumi+SiStripQuality',
                     '--conditions':'auto:run1_data',

--- a/Configuration/StandardSequences/python/AlCaRecoStreams_cff.py
+++ b/Configuration/StandardSequences/python/AlCaRecoStreams_cff.py
@@ -51,6 +51,7 @@ from Calibration.TkAlCaRecoProducers.ALCARECOSiStripCalZeroBias_cff import *
 from CalibTracker.SiPixelQuality.ALCARECOSiPixelCalZeroBias_cff import *
 # AlCaReco for tracker calibration using Cosmics events
 from Calibration.TkAlCaRecoProducers.ALCARECOSiStripCalCosmics_cff import *
+from Calibration.TkAlCaRecoProducers.ALCARECOSiStripCalCosmicsNano_cff import *
 
 ###############################################################
 # LUMI Calibration
@@ -184,6 +185,7 @@ pathALCARECOSiPixelCalSingleMuonTight = cms.Path(seqALCARECOSiPixelCalSingleMuon
 pathALCARECOSiPixelCalCosmics = cms.Path(seqALCARECOSiPixelCalCosmics)
 pathALCARECOSiStripCalMinBias = cms.Path(seqALCARECOSiStripCalMinBias*ALCARECOSiStripCalMinBiasDQM)
 pathALCARECOSiStripCalCosmics = cms.Path(seqALCARECOSiStripCalCosmics)
+pathALCARECOSiStripCalCosmicsNano = cms.Path(seqALCARECOSiStripCalCosmics*seqALCARECOSiStripCalCosmicsNano)
 pathALCARECOSiStripCalMinBiasAAG = cms.Path(seqALCARECOSiStripCalMinBiasAAG*ALCARECOSiStripCalMinBiasAAGDQM)
 pathALCARECOSiStripCalSmallBiasScan = cms.Path(seqALCARECOSiStripCalSmallBiasScan)
 pathALCARECOSiStripCalZeroBias = cms.Path(seqALCARECOSiStripCalZeroBias*ALCARECOSiStripCalZeroBiasDQM)
@@ -441,6 +443,15 @@ ALCARECOStreamSiStripCalCosmics = cms.FilteredStream(
 	content = OutALCARECOSiStripCalCosmics.outputCommands,
 	selectEvents = OutALCARECOSiStripCalCosmics.SelectEvents,
 	dataTier = cms.untracked.string('ALCARECO')
+	)
+
+ALCARECOStreamSiStripCalCosmicsNano = cms.FilteredStream(
+	responsible = "Pieter David",
+	name = "SiStripCalCosmicsNano",
+	paths  = (pathALCARECOSiStripCalCosmicsNano),
+	content = OutALCARECOSiStripCalCosmicsNano.outputCommands,
+	selectEvents = OutALCARECOSiStripCalCosmicsNano.SelectEvents,
+	dataTier = cms.untracked.string("NANOAOD")
 	)
 
 ALCARECOStreamSiStripCalZeroBias = cms.FilteredStream(

--- a/PhysicsTools/NanoAOD/test/inspectNanoFile.py
+++ b/PhysicsTools/NanoAOD/test/inspectNanoFile.py
@@ -15,6 +15,10 @@ class FileData:
             setattr(self,k,v)
         self.Events = self.trees["Events"]
         self.nevents = self.Events["entries"]
+        self.Runs = self.trees["Runs"]
+        self.nruns = self.Runs["entries"]
+        self.LuminosityBlocks = self.trees["LuminosityBlocks"]
+        self.nluminosityblocks = self.LuminosityBlocks["entries"]
 
 class Branch:
     def __init__(self, tree, branch):
@@ -87,13 +91,13 @@ def inspectRootFile(infile):
     filesize = os.path.getsize(infile)/1024.0
     tfile = ROOT.TFile.Open(infile)
     trees = {}
-    for treeName in "Events", "Runs", "Lumis":
+    for treeName in "Events", "Runs", "LuminosityBlocks":
         toplevelDoc={}
         tree = tfile.Get(treeName)
         entries = tree.GetEntries()
         trees[treeName] = tree
         branchList = tree.GetListOfBranches()
-        allbranches = [ Branch(tree,branchList.At(i)) for i in range(branchList.GetSize()) ]
+        allbranches = [ Branch(tree, br) for br in branchList ]
         branchmap = dict((b.name,b) for b in allbranches)
         branchgroups = {}
         # make list of counters and countees
@@ -149,7 +153,6 @@ def inspectRootFile(infile):
                 branchgroups = dict(bg.toJSON() for bg in branchgroups.values()),
             )
         c1.Close()
-        break # only Event tree for now
     tfile.Close()
     return dict(filename = os.path.basename(infile), filesize = filesize, trees = trees)
 
@@ -175,11 +178,13 @@ def makeSurvey(treeName, treeData):
         runningtotal += s['tot']
     return (survey, "\n,\t".join(scriptdata))
   
-def writeSizeReport(fileData, stream):
+def writeSizeReport(fileData, trees, stream):
     filename = fileData.filename
     filesize = fileData.filesize
     events = fileData.nevents
-    survey, scriptdata = makeSurvey("Events", filedata.Events)
+    surveys = {}
+    for treename, treeData in trees.items():
+        surveys[treename] = makeSurvey(treename, treeData)
     title = "%s (%.3f Mb, %d events, %.2f kb/event)" % (filename, filesize/1024.0, events, filesize/events)
     stream.write("""
     <html>
@@ -194,87 +199,115 @@ def writeSizeReport(fileData, stream):
     </head>
     <body>
     <a name="top" id="top"><h1>{title}</h1></a>
-    <canvas id="mainCanvas" width="800" height="300">[No canvas support]</canvas>
-    <script type="text/javascript">
-    var data = [ {scriptdata} ];
-    """.format(title = title, scriptdata = scriptdata)); ## must split into two write calls, since the javascript confounds str.format
+    """.format(title=title))
+    stream.write("\n".join("""
+    <h1>{treename} data</h1>
+    <canvas id="{treename}Canvas" width="800" height="300">[No canvas support]</canvas>
+    """.format(treename=treename) for treename in surveys.keys()))
+    stream.write('    <script type="text/javascript">\n')
+    stream.write("\n".join("""
+        var data_{treename} = [ {scriptdata} ];
+        """.format(treename=treename, scriptdata=scriptdata)
+        for treename, (_, scriptdata) in surveys.items()))
     stream.write("""
-    window.onload = function() {
-        values = [];
-        labels = [];
-        keys   = [];
-        tips   = [];
-        for (var i = 0; i < data.length; i++) {
-            values.push( data[i].size );
-            labels.push( data[i].label );
-            keys.push( data[i].label );
-            tips.push( data[i].tip );
-        }
-        var chart = new RGraph.Pie("mainCanvas", values)
-                    .Set('exploded', 7)
-                    .Set('tooltips', tips)
-                    .Set('tooltips.event', 'onmousemove')
-                    .Set('key', labels)
-                    .Set('key.position.graph.boxed', false)
-                    .Draw();
-    }
+        window.onload = function() {{
+            {0}
+        }}
     </script>
-    <h1>Event data</h1>
-    <table>
-    """); 
+    """.format(
+            "\n".join("""
+            values = [];
+            labels = [];
+            keys   = [];
+            tips   = [];
+            for (var i = 0; i < data_{treename}.length; i++) {{
+                values.push( data_{treename}[i].size );
+                labels.push( data_{treename}[i].label );
+                keys.push( data_{treename}[i].label );
+                tips.push( data_{treename}[i].tip );
+            }}
+            var chart_{treename} = new RGraph.Pie("{treename}Canvas", values)
+                        .Set('exploded', 7)
+                        .Set('tooltips', tips)
+                        .Set('tooltips.event', 'onmousemove')
+                        .Set('key', labels)
+                        .Set('key.position.graph.boxed', false)
+                        .Draw();
+            """.format(treename=treename, scriptdata=scriptdata)
+            for treename, (_, scriptdata) in surveys.items())))
+
+    if len(trees) > 1:
+        stream.write("    <h1>Collections summary</h1>\n")
+    stream.write("    <table>\n")
     stream.write("<tr class='header'><th>" + "</th><th>".join([ "collection", "kind", "vars", "items/evt", "kb/evt", "b/item", "plot", "%" ]) + "</th><th colspan=\"2\">cumulative %</th></tr>\n");
-    grandtotal = filedata.Events['allsize']; runningtotal = 0
-    for s in survey:
-        stream.write("<th title=\"%s\"><a href='#%s'>%s</a></th><td style='text-align : left;'>%s</td><td>%d</td>" % (s['doc'],s['name'],s['name'],s['kind'].lower(),len(s['subs'])))
-        stream.write("<td>%.2f</td><td>%.3f</td><td>%.1f</td>" % (s['entries']/events, s['tot']/events, s['tot']/s['entries']*1024 if s['entries'] else 0))
-        stream.write("<td class=\"img\"><img src='http://gpetrucc.web.cern.ch/gpetrucc/micro/blue-dot.gif' width='%d' height='%d' /></td>" % (s['tot']/grandtotal*200,10))
-        stream.write("<td>%.1f%%</td>" % ( s['tot']/grandtotal * 100.0))
-        stream.write("<td>%.1f%%</td>" % ( (runningtotal+s['tot'])/grandtotal * 100.0))
-        stream.write("<td>%.1f%%</td>" % ( (grandtotal-runningtotal)/grandtotal * 100.0))
+    runningtotal = 0
+    for treename, (survey, _) in surveys.items():
+        treetotal = trees[treename]['allsize']
+        treerunningtotal = 0
+        for s in survey:
+            stream.write("<tr><th title=\"%s\"><a href='#%s'>%s</a></th><td style='text-align : left;'>%s</td><td>%d</td>" % (s['doc'],s['name'],s['name'],s['kind'].lower(),len(s['subs'])))
+            stream.write("<td>%.2f</td><td>%.3f</td><td>%.1f</td>" % (s['entries']/events, s['tot']/events, s['tot']/s['entries']*1024 if s['entries'] else 0))
+            stream.write("<td class=\"img\"><img src='http://gpetrucc.web.cern.ch/gpetrucc/micro/blue-dot.gif' width='%d' height='%d' /></td>" % (s['tot']/treetotal*200,10))
+            stream.write("<td>%.1f%%</td>" % ( s['tot']/treetotal * 100.0))
+            stream.write("<td>%.1f%%</td>" % ( (runningtotal+s['tot'])/treetotal * 100.0))
+            stream.write("<td>%.1f%%</td>" % ( (treetotal-runningtotal)/treetotal * 100.0))
+            stream.write("</tr>\n")
+            treerunningtotal += s['tot']
+        runningtotal += treerunningtotal
+
+        # all known data
+        stream.write("<tr><th>All %s data</th>" % treename)
+        stream.write("<td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td><b>%.2f</b></td><td>&nbsp;</td>"  % (treetotal/events))
+        stream.write("<td class=\"img\"><img src=\"http://gpetrucc.web.cern.ch/gpetrucc/micro/green-dot.gif\" width='%d' height='10' />" % ( treetotal/filesize*100.0))
+        stream.write("</td><td>%.1f%%<sup>a</sup></td>" % (treetotal/filesize*100.0))
         stream.write("</tr>\n")
-        runningtotal += s['tot'];
 
-    # all known data
-    stream.write("<th>All Event data</th>")
-    stream.write("<td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td><b>%.2f</b></td><td>&nbsp;</td>"  % (grandtotal/events))
-    stream.write("<td class=\"img\"><img src=\"http://gpetrucc.web.cern.ch/gpetrucc/micro/green-dot.gif\" width='%d' height='10' />" % ( grandtotal/filesize*100.0))
-    stream.write("</td><td>%.1f%%<sup>a</sup></td>" % (grandtotal/filesize*100.0))
-    stream.write("</tr>\n")
+        if treename == "Events":
+            # non-event
+            stream.write("<tr><th>Non per-event data or overhead</th>")
+            stream.write("<td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>%.2f</td><td>&nbsp;</td>" % ( (filesize-treetotal)/events))
+            stream.write("<td class=\"img\"><img src='http://gpetrucc.web.cern.ch/gpetrucc/micro/red-dot.gif' width='%d' height='%d' /></td>" % ( (filesize-treetotal)/filesize * 100, 10 ))
+            stream.write("<td>%.1f%%<sup>a</sup></td>" % ( (filesize-treetotal)/filesize * 100.0 ))
+            stream.write("</tr>\n")
 
-    # other, unknown overhead
-    stream.write("<th>Non per-event data or overhead</th>")
-    stream.write("<td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>%.2f</td><td>&nbsp;</td>" % ( (filesize-grandtotal)/events))
-    stream.write("<td class=\"img\"><img src='http://gpetrucc.web.cern.ch/gpetrucc/micro/red-dot.gif' width='%d' height='%d' /></td>" % ( (filesize-grandtotal)/filesize * 100, 10 ))
-    stream.write("<td>%.1f%%<sup>a</sup></td>" % ( (filesize-grandtotal)/filesize * 100.0 ))
-    stream.write("</tr>\n")
+    if len(surveys) > 1:
+        # other, unknown overhead
+        stream.write("<tr><th>Overhead</th>")
+        stream.write("<td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>%.2f</td><td>&nbsp;</td>" % ( (filesize-runningtotal)/events))
+        stream.write("<td class=\"img\"><img src='http://gpetrucc.web.cern.ch/gpetrucc/micro/red-dot.gif' width='%d' height='%d' /></td>" % ( (filesize-runningtotal)/filesize * 100, 10 ))
+        stream.write("<td>%.1f%%<sup>a</sup></td>" % ( (filesize-runningtotal)/filesize * 100.0 ))
+        stream.write("</tr>\n")
 
     # all file
-    stream.write("<th>File size</th>")
+    stream.write("<tr><th>File size</th>")
     stream.write("<td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td><b>%.2f</b></td><td>&nbsp;</td>" % (filesize/events))
     stream.write("<td>&nbsp;</td><td>&nbsp;</td></tr>\n")
 
     stream.write("""
     </table>
-    Note: size percentages of individual event products are relative to the total size of Event data only.<br />
+    Note: size percentages of individual event products are relative to the total size of Event data only (or equivalent for non-Events trees).<br />
     Percentages with <sup>a</sup> are instead relative to the full file size.
-    <h1>Events detail</h1>
     """)
-    for s in sorted(survey, key = lambda s : s['name']):
-        stream.write("<h2><a name='%s' id='%s'>%s</a> (%.1f items/evt, %.3f kb/evt) <sup><a href=\"#top\">[back to top]</a></sup></h2>" % (s['name'], s['name'], s['name'], s['entries']/events, s['tot']/events))
-        stream.write("<table>\n")
-        stream.write("<tr class='header'><th>" + "</th><th>".join( [ "branch", "kind", "b/event", "b/item", "plot", "%" ]) + "</th></tr>\n")
-        subs = [ fileData.Events['branches'][b] for b in s['subs'] ]
-        for b in sorted(subs, key = lambda s : - s['tot']):
-            stream.write("<th title=\"%s\">%s</th><td style='text-align : left;'>%s</td><td>%.1f</td><td>%.1f</td>" % (b['doc'],b['name'], b['kind'], b['tot']/events*1024, b['tot']/s['entries']*1024 if s['entries'] else 0))
-            stream.write("<td class=\"img\"><img src='http://gpetrucc.web.cern.ch/gpetrucc/micro/blue-dot.gif' width='%d' height='%d' /></td>" % ( b['tot']/s['tot']*200, 10 ))
-            stream.write("<td>%.1f%%</td>" % (b['tot']/s['tot'] * 100.0))
-            stream.write("</tr>\n")
-        stream.write("</table>\n")
+    for treename, treeData in trees.items():
+        stream.write("""
+        <h1>%s detail</h1>
+        """ % treename)
+        for s in sorted(surveys[treename][0], key = lambda s : s['name']):
+            stream.write("<h2><a name='%s' id='%s'>%s</a> (%.1f items/evt, %.3f kb/evt) <sup><a href=\"#top\">[back to top]</a></sup></h2>" % (s['name'], s['name'], s['name'], s['entries']/events, s['tot']/events))
+            stream.write("<table>\n")
+            stream.write("<tr class='header'><th>" + "</th><th>".join( [ "branch", "kind", "b/event", "b/item", "plot", "%" ]) + "</th></tr>\n")
+            subs = [ treeData['branches'][b] for b in s['subs'] ]
+            for b in sorted(subs, key = lambda s : - s['tot']):
+                stream.write("<tr><th title=\"%s\">%s</th><td style='text-align : left;'>%s</td><td>%.1f</td><td>%.1f</td>" % (b['doc'],b['name'], b['kind'], b['tot']/events*1024, b['tot']/s['entries']*1024 if s['entries'] else 0))
+                stream.write("<td class=\"img\"><img src='http://gpetrucc.web.cern.ch/gpetrucc/micro/blue-dot.gif' width='%d' height='%d' /></td>" % ( b['tot']/s['tot']*200, 10 ))
+                stream.write("<td>%.1f%%</td>" % (b['tot']/s['tot'] * 100.0))
+                stream.write("</tr>\n")
+            stream.write("</table>\n")
     stream.write("""
     </body></html>
     """)
 
-def writeDocReport(fileData, stream):
+def writeDocReport(fileName, trees, stream):
     stream.write( """
     <html>
     <head>
@@ -282,95 +315,115 @@ def writeDocReport(fileData, stream):
         <link rel="stylesheet" type="text/css" href="http://gpetrucc.web.cern.ch/gpetrucc/micro/patsize.css" />
     </head>
     <body>
-    <h1>Content</h1>
-    <table>
-    """.format(filename=fileData.filename))
-    stream.write( "<tr class='header'><th>Collection</th><th>Description</th></tr>\n" )
-    groups = list(fileData.Events['branchgroups'].values())
-    groups.sort(key = lambda s : s['name'])
-    for s in groups:
-        stream.write( "<th><a href='#%s'>%s</a></th><td style='text-align : left;'>%s</td></tr>\n" % (s['name'],s['name'],s['doc']) )
-    stream.write( "</table>\n\n<h1>Events detail</h1>\n" )
-    for s in groups:
-        stream.write( "<h2><a name='%s' id='%s'>%s</a> <sup><a href=\"#top\">[back to top]</a></sup></h2>\n" % (s['name'], s['name'], s['name']) )
-        stream.write( "<table>\n" )
-        stream.write( "<tr class='header'><th>Object property</th><th>Type</th><th>Description</th></tr>\n" )
-        subs = [ fileData.Events['branches'][b] for b in s['subs'] ]
-        for b in sorted(subs, key = lambda s : s['name']):
-            stream.write( "<th>%s</th><td style='text-align : left;'>%s</td><td style='text-align : left;'>%s</td>" % (b['name'], b['kind'], b['doc']) )
-            stream.write( "</tr>\n" )
-        stream.write( "</table>\n" )
+    """.format(filename=fileName))
+    for treename, treeData in trees.items():
+        stream.write("""
+        <h1>{treename} Content</h1>
+        <table>
+        """.format(treename=treename))
+        stream.write( "<tr class='header'><th>Collection</th><th>Description</th></tr>\n" )
+        groups = list(treeData['branchgroups'].values())
+        groups.sort(key = lambda s : s['name'])
+        for s in groups:
+            stream.write( "<th><a href='#%s'>%s</a></th><td style='text-align : left;'>%s</td></tr>\n" % (s['name'],s['name'],s['doc']) )
+        stream.write("</table>\n\n<h1>{treename} detail</h1>\n".format(treename=treename))
+        for s in groups:
+            stream.write( "<h2><a name='%s' id='%s'>%s</a> <sup><a href=\"#top\">[back to top]</a></sup></h2>\n" % (s['name'], s['name'], s['name']) )
+            stream.write( "<table>\n" )
+            stream.write( "<tr class='header'><th>Object property</th><th>Type</th><th>Description</th></tr>\n" )
+            subs = [ treeData['branches'][b] for b in s['subs'] ]
+            for b in sorted(subs, key = lambda s : s['name']):
+                stream.write( "<th>%s</th><td style='text-align : left;'>%s</td><td style='text-align : left;'>%s</td>" % (b['name'], b['kind'], b['doc']) )
+                stream.write( "</tr>\n" )
+            stream.write( "</table>\n" )
     stream.write( """
     </body></html>
     """ )
 
-def writeMarkdownSizeReport(fileData, stream):
+def writeMarkdownSizeReport(fileData, trees, stream):
     filename = fileData.filename
     filesize = fileData.filesize
     events = fileData.nevents
-    survey, _ = makeSurvey("Events", filedata.Events)
+    surveys = {}
+    for treename, treeData in trees.items():
+        surveys[treename] = makeSurvey(treename, treeData)[0]
 
     stream.write("**%s (%.3f Mb, %d events, %.2f kb/event)**\n" % (filename, filesize/1024.0, events, filesize/events))
-    stream.write("\n# Event data\n")
+    stream.write("\n# Event data\n" if len(trees) == 1 else "\n# Collection data\n")
     stream.write("| collection | kind | vars | items/evt | kb/evt | b/item | plot	| % | ascending cumulative % | descending cumulative % |\n")
     stream.write("| - | - | - | - | - | - | - | - | - | - |\n")
-    grandtotal = filedata.Events['allsize']; runningtotal = 0
-    for s in survey:
-        stream.write("| [**%s**](#%s '%s') | %s | %d" % (s['name'], s['name'].lower(), s['doc'].replace('|', '\|').replace('\'', '\"'), s['kind'].lower(), len(s['subs'])))
-        stream.write("| %.2f|%.3f|%.1f" % (s['entries']/events, s['tot']/events, s['tot'] / s['entries'] * 1024 if s['entries'] else 0))
-        stream.write("| <img src='http://gpetrucc.web.cern.ch/gpetrucc/micro/blue-dot.gif' width='%d' height='%d' />" % (s['tot'] / grandtotal * 200, 10))
-        stream.write("| %.1f%%" % (s['tot'] / grandtotal * 100.0))
-        stream.write("| %.1f%%" % ((runningtotal+s['tot'])/grandtotal * 100.0))
-        stream.write("| %.1f%% |\n" % ((grandtotal-runningtotal)/grandtotal * 100.0))
-        runningtotal += s['tot']
+    runningtotal = 0
+    for treename, survey in surveys.items():
+        treetotal = trees[treename]['allsize']
+        treerunningtotal = 0
+        for s in survey:
+            stream.write("| [**%s**](#%s '%s') | %s | %d" % (s['name'], s['name'].lower(), s['doc'].replace('|', '\|').replace('\'', '\"'), s['kind'].lower(), len(s['subs'])))
+            stream.write("| %.2f|%.3f|%.1f" % (s['entries']/events, s['tot']/events, s['tot'] / s['entries'] * 1024 if s['entries'] else 0))
+            stream.write("| <img src='http://gpetrucc.web.cern.ch/gpetrucc/micro/blue-dot.gif' width='%d' height='%d' />" % (s['tot'] / treetotal * 200, 10))
+            stream.write("| %.1f%%" % (s['tot'] / treetotal * 100.0))
+            stream.write("| %.1f%%" % ((runningtotal+s['tot'])/treetotal * 100.0))
+            stream.write("| %.1f%% |\n" % ((treetotal-runningtotal)/treetotal * 100.0))
+            runningtotal += s['tot']
 
-    # all known data
-    stream.write("**All Event data**")
-    stream.write("| | | | **%.2f**"  % (grandtotal/events))
-    stream.write("| | <img src='http://gpetrucc.web.cern.ch/gpetrucc/micro/green-dot.gif' width='%d' height='%d' />" % (grandtotal / filesize * 100.0, 10))
-    stream.write("| %.1f%%<sup>a</sup> | | |\n" % (grandtotal/filesize * 100.0))
+        # all known data
+        stream.write("**All %s data**" % treename)
+        stream.write("| | | | **%.2f**"  % (treetotal/events))
+        stream.write("| | <img src='http://gpetrucc.web.cern.ch/gpetrucc/micro/green-dot.gif' width='%d' height='%d' />" % (treetotal / filesize * 100.0, 10))
+        stream.write("| %.1f%%<sup>a</sup> | | |\n" % (treetotal/filesize * 100.0))
 
-    # other, unknown overhead
-    stream.write("**Non per-event data or overhead**")
-    stream.write("| | | | %.2f" % ((filesize-grandtotal)/events))
-    stream.write("| | <img src='http://gpetrucc.web.cern.ch/gpetrucc/micro/red-dot.gif' width='%d' height='%d' />" % ((filesize - grandtotal) / filesize * 100, 10))
-    stream.write("| %.1f%%<sup>a</sup> | | |\n" % ((filesize-grandtotal)/filesize * 100.0))
+        if treename == "Events":
+            # non-event
+            stream.write("**Non per-event data or overhead**")
+            stream.write("| | | | %.2f" % ((filesize-treetotal)/events))
+            stream.write("| | <img src='http://gpetrucc.web.cern.ch/gpetrucc/micro/red-dot.gif' width='%d' height='%d' />" % ((filesize - treetotal) / filesize * 100, 10))
+            stream.write("| %.1f%%<sup>a</sup> | | |\n" % ((filesize-treetotal)/filesize * 100.0))
+
+    if len(surveys) > 1:
+        # other, unknown overhead
+        stream.write("**Overhead**")
+        stream.write("| | | | %.2f" % ((filesize-runningtotal)/events))
+        stream.write("| | <img src='http://gpetrucc.web.cern.ch/gpetrucc/micro/red-dot.gif' width='%d' height='%d' />" % ((filesize - runningtotal) / filesize * 100, 10))
+        stream.write("| %.1f%%<sup>a</sup> | | |\n" % ((filesize-runningtotal)/filesize * 100.0))
 
     # all file
     stream.write("**File size**")
     stream.write("| | | | **%.2f**" % (filesize/events))
     stream.write("| | | | | |\n\n")
 
-    stream.write("Note: size percentages of individual event products are relative to the total size of Event data only.\\\n")
+    stream.write("Note: size percentages of individual event products are relative to the total size of Event data only (or equivalent for non-Events trees).\\\n")
     stream.write("Percentages with <sup>a</sup> are instead relative to the full file size.\n\n")
 
-    stream.write("# Events detail\n")
-    for s in sorted(survey, key=lambda s: s['name']):
-        stream.write("## <a id='%s'></a>%s (%.1f items/evt, %.3f kb/evt) [<sup>[back to top]</sup>](#event-data)\n" % (s['name'].lower(), s['name'], s['entries'] / events, s['tot'] / events))
-        stream.write("| branch | kind | b/event | b/item | plot | % |\n")
-        stream.write("| - | - | - | - | - | - |\n")
-        subs = [fileData.Events['branches'][b] for b in s['subs']]
-        for b in sorted(subs, key = lambda s: - s['tot']):
-            stream.write("| <b title='%s'>%s</b> | %s | %.1f | %.1f" % (b['doc'].replace('|', '\|').replace('\'', '\"'), b['name'], b['kind'], b['tot'] / events * 1024, b['tot'] / s['entries'] * 1024 if s['entries'] else 0))
-            stream.write("| <img src='http://gpetrucc.web.cern.ch/gpetrucc/micro/blue-dot.gif' width='%d' height='%d' />" % (b['tot'] / s['tot'] * 200, 10))
-            stream.write("| %.1f%% |\n" % (b['tot'] / s['tot'] * 100.0))
+    for treename, survey in surveys.items():
+        stream.write("# %s detail\n" % treename)
+        for s in sorted(survey, key=lambda s: s['name']):
+            stream.write("## <a id='%s'></a>%s (%.1f items/evt, %.3f kb/evt) [<sup>[back to top]</sup>](#event-data)\n" % (s['name'].lower(), s['name'], s['entries'] / events, s['tot'] / events))
+            stream.write("| branch | kind | b/event | b/item | plot | % |\n")
+            stream.write("| - | - | - | - | - | - |\n")
+            subs = [trees[treename]['branches'][b] for b in s['subs']]
+            for b in sorted(subs, key = lambda s: - s['tot']):
+                stream.write("| <b title='%s'>%s</b> | %s | %.1f | %.1f" % (b['doc'].replace('|', '\|').replace('\'', '\"'), b['name'], b['kind'], b['tot'] / events * 1024, b['tot'] / s['entries'] * 1024 if s['entries'] else 0))
+                stream.write("| <img src='http://gpetrucc.web.cern.ch/gpetrucc/micro/blue-dot.gif' width='%d' height='%d' />" % (b['tot'] / s['tot'] * 200, 10))
+                stream.write("| %.1f%% |\n" % (b['tot'] / s['tot'] * 100.0))
+            stream.write("\n")
 
-def writeMarkdownDocReport(fileData, stream):
-    stream.write("# Content\n")
-    stream.write("\n| Collection | Description |\n")
-    stream.write("| - | - |\n")
-    groups = fileData.Events['branchgroups'].values()
-    groups.sort(key = lambda s : s['name'])
-    for s in groups:
-        stream.write("| [**%s**](#%s) | %s |\n" % (s['name'], s['name'].lower(), s['doc']))
-    stream.write("\n# Events detail\n")
-    for s in groups:
-        stream.write("\n## <a id='%s'></a>%s [<sup>[back to top]</sup>](#content)\n" % (s['name'].lower(), s['name']))
-        stream.write("| Object property | Type | Description |\n")
-        stream.write("| - | - | - |\n")
-        subs = [fileData.Events['branches'][b] for b in s['subs']]
-        for b in sorted(subs, key = lambda s : s['name']):
-            stream.write("| **%s** | %s| %s |\n" % (b['name'], b['kind'], b['doc']))
+def writeMarkdownDocReport(trees, stream):
+    for treename, treeData in trees.items():
+        stream.write("# %s Content\n" % treename)
+        stream.write("\n| Collection | Description |\n")
+        stream.write("| - | - |\n")
+        groups = list(treeData['branchgroups'].values())
+        groups.sort(key = lambda s : s['name'])
+        for s in groups:
+            stream.write("| [**%s**](#%s) | %s |\n" % (s['name'], s['name'].lower(), s['doc']))
+        stream.write("\n# %s detail\n" % treename)
+        for s in groups:
+            stream.write("\n## <a id='%s'></a>%s [<sup>[back to top]</sup>](#content)\n" % (s['name'].lower(), s['name']))
+            stream.write("| Object property | Type | Description |\n")
+            stream.write("| - | - | - |\n")
+            subs = [treeData['branches'][b] for b in s['subs']]
+            for b in sorted(subs, key = lambda s : s['name']):
+                stream.write("| **%s** | %s| %s |\n" % (b['name'], b['kind'], b['doc']))
+        stream.write("\n")
 
 def _maybeOpen(filename):
     return open(filename, 'w') if filename != "-" else sys.stdout
@@ -395,15 +448,23 @@ if __name__ == '__main__':
     if options.json:
         json.dump(filedata._json, _maybeOpen(options.json), indent=4)
         sys.stderr.write("JSON output saved to %s\n" % options.json)
+
+    treedata = {}  # trees for (HTML or markdown) doc report
+    if len(filedata.Runs["branches"]) > 1:  # default: run number
+        treedata["Runs"] = filedata.Runs
+    if len(filedata.LuminosityBlocks["branches"]) > 2:  # default: run number, lumiblock
+        treedata["LuminosityBlocks"] = filedata.LuminosityBlocks
+    treedata["Events"] = filedata.Events
+
     if options.doc:
-        writeDocReport(filedata, _maybeOpen(options.doc))
+        writeDocReport(filedata.filename, treedata, _maybeOpen(options.doc))
         sys.stderr.write("HTML documentation saved to %s\n" % options.doc)
     if options.size:
-        writeSizeReport(filedata, _maybeOpen(options.size))
+        writeSizeReport(filedata, treedata, _maybeOpen(options.size))
         sys.stderr.write("HTML size report saved to %s\n" % options.size)
     if options.docmd:
-        writeMarkdownDocReport(filedata, _maybeOpen(options.docmd))
+        writeMarkdownDocReport(treedata, _maybeOpen(options.docmd))
         sys.stderr.write("Markdown documentation saved to %s\n" % options.docmd)
     if options.sizemd:
-        writeMarkdownSizeReport(filedata, _maybeOpen(options.sizemd))
+        writeMarkdownSizeReport(filedata, treedata, _maybeOpen(options.sizemd))
         sys.stderr.write("Markdown size report saved to %s\n" % options.sizemd)


### PR DESCRIPTION
#### PR description:

This PR adds NanoAOD-style output for the SiStripCalCosmics ALCARECO (introduced in https://github.com/cms-sw/cmssw/pull/26032), based on the existing configuration (which was run by the DPG) to make flat trees for the Lorentz angle and backplane correction measurement, and taking advantage of the changes in https://github.com/cms-sw/cmssw/pull/33565 .
The code adds a plugin for per-run per-module information about the magnetic field etc., uses a `SimpleFlatTableProducer` for per-track information, and adds a plugin that stores the necessary per-cluster information (split in a base class that gets the clusters, and a subclass that stores the variables for the Lorentz angle and backplane correction - another subclass will be used for the gains tree).
This is a very small ALCARECO, so the size is small in both cases (the flat format is about the same size as the EDM format), but it has been extensively validated, and provides an interesting case to discuss the configuration and possibility of central production.
As a minimal solution to add this to cmsDriver I added a `SiStripCalCosmicsNano` ALCARECO based on the existing `SiStripCalCosmics`, and changed the code to insert a `NanoAODOutputModule` if the dataTier of a FilteredStream is NANOAOD. That seems to work (it can be tested with the `ALCA:SiStripCalCosmicsNano` step, which is also added to the relevant matrix workflows by this PR), but something less ad-hoc may be preferred - please provide input, this is the reason why the PR is marked as "work in progress".
The idea (discussed with XPOG) is to have this integrated for testing at T0 with CRAFT in October, so depending on if that works out and which release is used there, a backport to the 12_0 branch may be needed.

#### PR validation:

Event-by-event comparison for 2018 cosmics by @robervalwalsh , see [these slides](https://indico.cern.ch/event/992968/contributions/4424055/attachments/2270726/3856338/20210624_NanoAOD_CalibTrees.pdf)

CC: @robervalwalsh @mdelcourt @ataliercio @jandrejk @mmusich @tsusa @mariadalfonso @gouskos 