### PR TITLE
[DD4hep] Revise order of materials, partial backport of #34974

### DIFF
--- a/DetectorDescription/DDCMS/interface/DDParsingContext.h
+++ b/DetectorDescription/DDCMS/interface/DDParsingContext.h
@@ -27,7 +27,8 @@ namespace cms {
       namespaces.emplace_back("");
       if (makePayload) {
         rotRevMap.reserve(3000);
-        allCompMaterials.reserve(400);
+        compMaterialsVec.reserve(400);
+        compMaterialsRefs.reserve(400);
       }
     }
 
@@ -84,7 +85,8 @@ namespace cms {
     std::vector<std::string> namespaces;
 
     std::unordered_map<std::string, std::vector<CompositeMaterial>> unresolvedMaterials;
-    std::unordered_map<std::string, std::pair<double, std::vector<CompositeMaterial>>> allCompMaterials;
+    std::vector<std::pair<std::string, double>> compMaterialsVec;
+    std::unordered_map<std::string, std::vector<CompositeMaterial>> compMaterialsRefs;
     std::unordered_map<std::string, std::vector<std::string>> unresolvedVectors;
     std::unordered_map<std::string,
                        std::variant<BooleanShape<dd4hep::UnionSolid>,

--- a/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
+++ b/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
@@ -603,6 +603,9 @@ void Converter<DDLCompositeMaterial>::operator()(xml_h element) const {
 
 #endif
 
+    if (ns.context()->makePayload) {
+      ns.context()->compMaterialsVec.emplace_back(std::make_pair(nam, density));
+    }
     for (composites.reset(); composites; ++composites) {
       xml_dim_t xfrac(composites);
       xml_dim_t xfrac_mat(xfrac.child(DD_CMU(rMaterial)));
@@ -610,8 +613,7 @@ void Converter<DDLCompositeMaterial>::operator()(xml_h element) const {
       string fracname = ns.realName(xfrac_mat.nameStr());
 
       if (ns.context()->makePayload) {
-        ns.context()->allCompMaterials[nam].first = density;
-        ns.context()->allCompMaterials[nam].second.emplace_back(
+        ns.context()->compMaterialsRefs[nam].emplace_back(
             cms::DDParsingContext::CompositeMaterial(ns.prepend(fracname), fraction));
       }
       TGeoMaterial* frac_mat = mgr.GetMaterial(fracname.c_str());
@@ -2163,6 +2165,7 @@ static long load_dddefinition(Detector& det, xml_h element) {
     ns.addConstantNS("world_z", "450*m", "number");
     ns.addConstantNS("Air", "materials:Air", "string");
     ns.addConstantNS("Vacuum", "materials:Vacuum", "string");
+    ns.setContext()->debug_materials = true;
 
     string fname = xml::DocumentHandler::system_path(element);
     bool open_geometry = dddef.hasChild(DD_CMU(open_geometry)) ? dddef.child(DD_CMU(open_geometry)) : true;

--- a/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
+++ b/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
@@ -2165,7 +2165,6 @@ static long load_dddefinition(Detector& det, xml_h element) {
     ns.addConstantNS("world_z", "450*m", "number");
     ns.addConstantNS("Air", "materials:Air", "string");
     ns.addConstantNS("Vacuum", "materials:Vacuum", "string");
-    ns.setContext()->debug_materials = true;
 
     string fname = xml::DocumentHandler::system_path(element);
     bool open_geometry = dddef.hasChild(DD_CMU(open_geometry)) ? dddef.child(DD_CMU(open_geometry)) : true;

--- a/DetectorDescription/OfflineDBLoader/interface/DDCoreToDDXMLOutput.h
+++ b/DetectorDescription/OfflineDBLoader/interface/DDCoreToDDXMLOutput.h
@@ -43,8 +43,7 @@ struct DDCoreToDDXMLOutput {
 
   void element(const TGeoMaterial* element, std::ostream& xos);
   void material(const DDMaterial& material, std::ostream& xos);
-  void material(
-      const std::pair<std::string, std::pair<double, std::vector<cms::DDParsingContext::CompositeMaterial>>>& material,
+  void material(const std::string& matName, double density, const std::vector<cms::DDParsingContext::CompositeMaterial>& matRefs,
       std::ostream& xos);
 
   void rotation(const DDRotation& rotation, std::ostream& xos, const std::string& rotn = "");

--- a/DetectorDescription/OfflineDBLoader/interface/DDCoreToDDXMLOutput.h
+++ b/DetectorDescription/OfflineDBLoader/interface/DDCoreToDDXMLOutput.h
@@ -43,8 +43,10 @@ struct DDCoreToDDXMLOutput {
 
   void element(const TGeoMaterial* element, std::ostream& xos);
   void material(const DDMaterial& material, std::ostream& xos);
-  void material(const std::string& matName, double density, const std::vector<cms::DDParsingContext::CompositeMaterial>& matRefs,
-      std::ostream& xos);
+  void material(const std::string& matName,
+                double density,
+                const std::vector<cms::DDParsingContext::CompositeMaterial>& matRefs,
+                std::ostream& xos);
 
   void rotation(const DDRotation& rotation, std::ostream& xos, const std::string& rotn = "");
   void rotation(const dd4hep::Rotation3D& rotation,

--- a/DetectorDescription/OfflineDBLoader/plugins/OutputDD4hepToDDL.cc
+++ b/DetectorDescription/OfflineDBLoader/plugins/OutputDD4hepToDDL.cc
@@ -124,7 +124,7 @@ void OutputDD4hepToDDL::beginRun(const edm::Run &, edm::EventSetup const &es) {
   }
   // Output composite materials
   for (const auto &it : parsingContext->compMaterialsVec) {
-    const std::string& matName = it.first;
+    const std::string &matName = it.first;
     out.material(matName, it.second, parsingContext->compMaterialsRefs[matName], *m_xos);
   }
   (*m_xos) << "</MaterialSection>" << std::endl;

--- a/DetectorDescription/OfflineDBLoader/plugins/OutputDD4hepToDDL.cc
+++ b/DetectorDescription/OfflineDBLoader/plugins/OutputDD4hepToDDL.cc
@@ -123,8 +123,9 @@ void OutputDD4hepToDDL::beginRun(const edm::Run &, edm::EventSetup const &es) {
     out.element(dynamic_cast<const TGeoMaterial *>(iter), *m_xos);
   }
   // Output composite materials
-  for (const auto &it : parsingContext->allCompMaterials) {
-    out.material(it, *m_xos);
+  for (const auto &it : parsingContext->compMaterialsVec) {
+    const std::string& matName = it.first;
+    out.material(matName, it.second, parsingContext->compMaterialsRefs[matName], *m_xos);
   }
   (*m_xos) << "</MaterialSection>" << std::endl;
   (*m_xos) << "<RotationSection label=\"" << ns_ << "\">" << std::endl;

--- a/DetectorDescription/OfflineDBLoader/src/DDCoreToDDXMLOutput.cc
+++ b/DetectorDescription/OfflineDBLoader/src/DDCoreToDDXMLOutput.cc
@@ -610,12 +610,12 @@ void DDCoreToDDXMLOutput::material(const DDMaterial& material, std::ostream& xos
   }
 }
 
-void DDCoreToDDXMLOutput::material(
-    const std::string& matName, double density, const std::vector<cms::DDParsingContext::CompositeMaterial>& matRefs,
-    std::ostream& xos) {
+void DDCoreToDDXMLOutput::material(const std::string& matName,
+                                   double density,
+                                   const std::vector<cms::DDParsingContext::CompositeMaterial>& matRefs,
+                                   std::ostream& xos) {
   xos << "<CompositeMaterial name=\"" << matName << "\""
-      << " density=\"" << std::scientific << std::setprecision(5) << convertGPerCcToMgPerCc(density)
-      << "*mg/cm3\""
+      << " density=\"" << std::scientific << std::setprecision(5) << convertGPerCcToMgPerCc(density) << "*mg/cm3\""
       << " method=\"mixture by weight\">" << std::endl;
 
   auto compIter = matRefs.begin();

--- a/DetectorDescription/OfflineDBLoader/src/DDCoreToDDXMLOutput.cc
+++ b/DetectorDescription/OfflineDBLoader/src/DDCoreToDDXMLOutput.cc
@@ -611,15 +611,15 @@ void DDCoreToDDXMLOutput::material(const DDMaterial& material, std::ostream& xos
 }
 
 void DDCoreToDDXMLOutput::material(
-    const std::pair<std::string, std::pair<double, std::vector<cms::DDParsingContext::CompositeMaterial>>>& material,
+    const std::string& matName, double density, const std::vector<cms::DDParsingContext::CompositeMaterial>& matRefs,
     std::ostream& xos) {
-  xos << "<CompositeMaterial name=\"" << material.first << "\""
-      << " density=\"" << std::scientific << std::setprecision(5) << convertGPerCcToMgPerCc(material.second.first)
+  xos << "<CompositeMaterial name=\"" << matName << "\""
+      << " density=\"" << std::scientific << std::setprecision(5) << convertGPerCcToMgPerCc(density)
       << "*mg/cm3\""
       << " method=\"mixture by weight\">" << std::endl;
 
-  auto compIter = material.second.second.begin();
-  for (; compIter != material.second.second.end(); ++compIter) {
+  auto compIter = matRefs.begin();
+  for (; compIter != matRefs.end(); ++compIter) {
     xos << "<MaterialFraction fraction=\"" << std::fixed << std::setprecision(9) << compIter->fraction << "\">"
         << std::endl;
     xos << "<rMaterial name=\"" << compIter->name << "\"/>" << std::endl;


### PR DESCRIPTION
This PR is a partial backport for 12_0 of #34974, which revises the order of materials. Please see that PR for full details.
This PR includes only the code change to produce the DD4hep Run 3 extended geometry description DB payload with the standard order of materials. The XML changes from #34974 are not strictly necessary because the materials affected are not used in 12_0.

Note that this PR should not change any workflow. The changes in this PR affect only the tool for creating the extended geometry description DB payload, which is run manually. This PR does contain changes to the DDCMS parser, but those lines are protected by a flag that is true only when the DB payload is being created.

#### PR validation:

The extended geometry description created with this PR was checked to be identical with the existing DD4hep extended geometry description in the DB, except for re-ordering of materials. The material order was checked to ensure no materials are referenced before they are defined.