### PR TITLE
Migrate some modules in SimCalorimetry to esConsumes

### DIFF
--- a/SimCalorimetry/EcalSelectiveReadoutAlgos/interface/EcalSelectiveReadoutSuppressor.h
+++ b/SimCalorimetry/EcalSelectiveReadoutAlgos/interface/EcalSelectiveReadoutSuppressor.h
@@ -7,6 +7,7 @@
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CaloTopology/interface/EcalTrigTowerConstituentsMap.h"
 #include "Geometry/EcalMapping/interface/EcalElectronicsMapping.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "SimCalorimetry/EcalSelectiveReadoutAlgos/interface/EcalSelectiveReadout.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -14,13 +15,17 @@
 
 #include <memory>
 
+class CaloGeometryRecord;
+
 class EcalSelectiveReadoutSuppressor {
 public:
   /** Construtor.
    * @param params configuration from python file
    * @param settings configuration from condition DB
    */
-  EcalSelectiveReadoutSuppressor(const edm::ParameterSet& params, const EcalSRSettings* settings);
+  EcalSelectiveReadoutSuppressor(const edm::ParameterSet& params, edm::ConsumesCollector iC);
+
+  void setSettings(const EcalSRSettings* settings);
 
   enum { BARREL, ENDCAP };
 
@@ -304,5 +309,7 @@ private:
   /** Number of produced events
    */
   int ievt_;
+
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geoToken_;
 };
 #endif

--- a/SimCalorimetry/EcalSelectiveReadoutAlgos/src/EcalSelectiveReadoutSuppressor.cc
+++ b/SimCalorimetry/EcalSelectiveReadoutAlgos/src/EcalSelectiveReadoutSuppressor.cc
@@ -4,8 +4,6 @@
 #include "DataFormats/EcalDigi/interface/EBDataFrame.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
-
 // Geometry
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
@@ -29,13 +27,8 @@ using namespace std;
 const int EcalSelectiveReadoutSuppressor::nFIRTaps = 6;
 
 EcalSelectiveReadoutSuppressor::EcalSelectiveReadoutSuppressor(const edm::ParameterSet& params,
-                                                               const EcalSRSettings* settings)
-    : ttThresOnCompressedEt_(false), ievt_(0) {
-  firstFIRSample = settings->ecalDccZs1stSample_[0];
-  weights = settings->dccNormalizedWeights_[0];
-  symetricZS = settings->symetricZS_[0];
-  actions_ = settings->actions_;
-
+                                                               edm::ConsumesCollector iC)
+    : ttThresOnCompressedEt_(false), ievt_(0), geoToken_(iC.esConsumes()) {
   int defTtf = params.getParameter<int>("defaultTtf");
   if (defTtf < 0 || defTtf > 7) {
     throw cms::Exception("InvalidParameter") << "Value of EcalSelectiveReadoutProducer module parameter defaultTtf, "
@@ -43,6 +36,29 @@ EcalSelectiveReadoutSuppressor::EcalSelectiveReadoutSuppressor(const edm::Parame
   } else {
     defaultTtf_ = (EcalSelectiveReadout::ttFlag_t)defTtf;
   }
+
+  trigPrimBypass_ = params.getParameter<bool>("trigPrimBypass");
+  trigPrimBypassMode_ = params.getParameter<int>("trigPrimBypassMode");
+  trigPrimBypassWithPeakFinder_ = params.getParameter<bool>("trigPrimBypassWithPeakFinder");
+  trigPrimBypassLTH_ = params.getParameter<double>("trigPrimBypassLTH");
+  trigPrimBypassHTH_ = params.getParameter<double>("trigPrimBypassHTH");
+  if (trigPrimBypass_) {
+    edm::LogWarning("Digitization") << "Beware a simplified trigger primitive "
+                                       "computation is used for the ECAL selective readout";
+    if (trigPrimBypassMode_ != 0 && trigPrimBypassMode_ != 1) {
+      throw cms::Exception("InvalidParameter")
+          << "Invalid value for EcalSelectiveReadoutProducer parameter 'trigPrimBypassMode_'."
+             " Valid values are 0 and 1.\n";
+    }
+    ttThresOnCompressedEt_ = (trigPrimBypassMode_ == 1);
+  }
+}
+
+void EcalSelectiveReadoutSuppressor::setSettings(const EcalSRSettings* settings) {
+  firstFIRSample = settings->ecalDccZs1stSample_[0];
+  weights = settings->dccNormalizedWeights_[0];
+  symetricZS = settings->symetricZS_[0];
+  actions_ = settings->actions_;
 
   //online configuration has only 4 actions flags, the 4 'forced' flags being the same with the force
   //bit set to 1. Extends the actions vector for case of online-type configuration:
@@ -76,21 +92,6 @@ EcalSelectiveReadoutSuppressor::EcalSelectiveReadoutSuppressor(const edm::Parame
                      settings->srpLowInterestChannelZS_[ee],
                      settings->srpHighInterestChannelZS_[eb],
                      settings->srpHighInterestChannelZS_[ee]);
-  trigPrimBypass_ = params.getParameter<bool>("trigPrimBypass");
-  trigPrimBypassMode_ = params.getParameter<int>("trigPrimBypassMode");
-  trigPrimBypassWithPeakFinder_ = params.getParameter<bool>("trigPrimBypassWithPeakFinder");
-  trigPrimBypassLTH_ = params.getParameter<double>("trigPrimBypassLTH");
-  trigPrimBypassHTH_ = params.getParameter<double>("trigPrimBypassHTH");
-  if (trigPrimBypass_) {
-    edm::LogWarning("Digitization") << "Beware a simplified trigger primitive "
-                                       "computation is used for the ECAL selective readout";
-    if (trigPrimBypassMode_ != 0 && trigPrimBypassMode_ != 1) {
-      throw cms::Exception("InvalidParameter")
-          << "Invalid value for EcalSelectiveReadoutProducer parameter 'trigPrimBypassMode_'."
-             " Valid values are 0 and 1.\n";
-    }
-    ttThresOnCompressedEt_ = (trigPrimBypassMode_ == 1);
-  }
 }
 
 void EcalSelectiveReadoutSuppressor::setTriggerMap(const EcalTrigTowerConstituentsMap* map) {
@@ -443,10 +444,9 @@ void EcalSelectiveReadoutSuppressor::setTtFlags(const edm::EventSetup& es,
   const CaloSubdetectorGeometry* eeGeometry = nullptr;
   const CaloSubdetectorGeometry* ebGeometry = nullptr;
   //  if(eeGeometry==0 || ebGeometry==0){
-  edm::ESHandle<CaloGeometry> geoHandle;
-  es.get<CaloGeometryRecord>().get(geoHandle);
-  eeGeometry = (*geoHandle).getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
-  ebGeometry = (*geoHandle).getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
+  auto const& geo = es.getData(geoToken_);
+  eeGeometry = geo.getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
+  ebGeometry = geo.getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
   //  }
 
   //init trigPrim array:

--- a/SimCalorimetry/EcalSelectiveReadoutProducers/interface/EcalSelectiveReadoutProducer.h
+++ b/SimCalorimetry/EcalSelectiveReadoutProducers/interface/EcalSelectiveReadoutProducer.h
@@ -85,7 +85,7 @@ private:
   void printTTFlags(const EcalTrigPrimDigiCollection& tp, std::ostream& os) const;
 
 private:
-  std::unique_ptr<EcalSelectiveReadoutSuppressor> suppressor_;
+  EcalSelectiveReadoutSuppressor suppressor_;
   std::string digiProducer_;         // name of module/plugin/producer making digis
   std::string ebdigiCollection_;     // secondary name given to collection of input digis
   std::string eedigiCollection_;     // secondary name given to collection of input digis
@@ -100,7 +100,8 @@ private:
   const CaloGeometry* theGeometry;
   const EcalTrigTowerConstituentsMap* theTriggerTowerMap;
   const EcalElectronicsMapping* theElecMap;
-  edm::ParameterSet params_;
+
+  bool suppressorSettingsSet_ = false;
 
   bool trigPrimBypass_;
 

--- a/SimCalorimetry/EcalZeroSuppressionProducers/interface/ESZeroSuppressionProducer.h
+++ b/SimCalorimetry/EcalZeroSuppressionProducers/interface/ESZeroSuppressionProducer.h
@@ -26,14 +26,13 @@ public:
   void produce(edm::Event &event, const edm::EventSetup &eventSetup) override;
 
 private:
-  std::string digiProducer_;
-  std::string ESdigiCollection_;
-  std::string ESZSdigiCollection_;
+  const std::string digiProducer_;
+  const std::string ESdigiCollection_;
+  const std::string ESZSdigiCollection_;
 
-  edm::ESHandle<ESThresholds> esthresholds_;
-  edm::ESHandle<ESPedestals> espeds_;
-
-  edm::EDGetTokenT<ESDigiCollection> ES_token;
+  const edm::EDGetTokenT<ESDigiCollection> ES_token;
+  const edm::ESGetToken<ESThresholds, ESThresholdsRcd> esthresholdsToken_;
+  const edm::ESGetToken<ESPedestals, ESPedestalsRcd> espedsToken_;
 };
 
 #endif

--- a/SimCalorimetry/EcalZeroSuppressionProducers/src/ESZeroSuppressionProducer.cc
+++ b/SimCalorimetry/EcalZeroSuppressionProducers/src/ESZeroSuppressionProducer.cc
@@ -2,21 +2,21 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "SimCalorimetry/EcalZeroSuppressionProducers/interface/ESZeroSuppressionProducer.h"
 
-ESZeroSuppressionProducer::ESZeroSuppressionProducer(const edm::ParameterSet &ps) :
-  digiProducer_(ps.getParameter<std::string>("digiProducer")),
-  ESdigiCollection_(ps.getParameter<std::string>("ESdigiCollection")),
-  ESZSdigiCollection_(ps.getParameter<std::string>("ESZSdigiCollection")),
-  ES_token(consumes<ESDigiCollection>(edm::InputTag(digiProducer_))),
-  esthresholdsToken_(esConsumes()),
-  espedsToken_(esConsumes()) {
+ESZeroSuppressionProducer::ESZeroSuppressionProducer(const edm::ParameterSet &ps)
+    : digiProducer_(ps.getParameter<std::string>("digiProducer")),
+      ESdigiCollection_(ps.getParameter<std::string>("ESdigiCollection")),
+      ESZSdigiCollection_(ps.getParameter<std::string>("ESZSdigiCollection")),
+      ES_token(consumes<ESDigiCollection>(edm::InputTag(digiProducer_))),
+      esthresholdsToken_(esConsumes()),
+      espedsToken_(esConsumes()) {
   produces<ESDigiCollection>(ESZSdigiCollection_);
 }
 
 ESZeroSuppressionProducer::~ESZeroSuppressionProducer() {}
 
 void ESZeroSuppressionProducer::produce(edm::Event &event, const edm::EventSetup &eventSetup) {
-  const ESThresholds& thresholds = eventSetup.getData(esthresholdsToken_);
-  const ESPedestals& pedestals = eventSetup.getData(espedsToken_);
+  const ESThresholds &thresholds = eventSetup.getData(esthresholdsToken_);
+  const ESPedestals &pedestals = eventSetup.getData(espedsToken_);
 
   float ts2Threshold = thresholds.getTS2Threshold();
 

--- a/SimCalorimetry/EcalZeroSuppressionProducers/src/ESZeroSuppressionProducer.cc
+++ b/SimCalorimetry/EcalZeroSuppressionProducers/src/ESZeroSuppressionProducer.cc
@@ -2,27 +2,23 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "SimCalorimetry/EcalZeroSuppressionProducers/interface/ESZeroSuppressionProducer.h"
 
-ESZeroSuppressionProducer::ESZeroSuppressionProducer(const edm::ParameterSet &ps) {
-  digiProducer_ = ps.getParameter<std::string>("digiProducer");
-  ESdigiCollection_ = ps.getParameter<std::string>("ESdigiCollection");
-  ESZSdigiCollection_ = ps.getParameter<std::string>("ESZSdigiCollection");
-
+ESZeroSuppressionProducer::ESZeroSuppressionProducer(const edm::ParameterSet &ps) :
+  digiProducer_(ps.getParameter<std::string>("digiProducer")),
+  ESdigiCollection_(ps.getParameter<std::string>("ESdigiCollection")),
+  ESZSdigiCollection_(ps.getParameter<std::string>("ESZSdigiCollection")),
+  ES_token(consumes<ESDigiCollection>(edm::InputTag(digiProducer_))),
+  esthresholdsToken_(esConsumes()),
+  espedsToken_(esConsumes()) {
   produces<ESDigiCollection>(ESZSdigiCollection_);
-
-  ES_token = consumes<ESDigiCollection>(edm::InputTag(digiProducer_));
-  ;
 }
 
 ESZeroSuppressionProducer::~ESZeroSuppressionProducer() {}
 
 void ESZeroSuppressionProducer::produce(edm::Event &event, const edm::EventSetup &eventSetup) {
-  eventSetup.get<ESThresholdsRcd>().get(esthresholds_);
-  const ESThresholds *thresholds = esthresholds_.product();
+  const ESThresholds& thresholds = eventSetup.getData(esthresholdsToken_);
+  const ESPedestals& pedestals = eventSetup.getData(espedsToken_);
 
-  eventSetup.get<ESPedestalsRcd>().get(espeds_);
-  const ESPedestals *pedestals = espeds_.product();
-
-  float ts2Threshold = thresholds->getTS2Threshold();
+  float ts2Threshold = thresholds.getTS2Threshold();
 
   edm::Handle<ESDigiCollection> ESDigis;
 
@@ -39,7 +35,7 @@ void ESZeroSuppressionProducer::produce(edm::Event &event, const edm::EventSetup
     for (ESDigiCollection::const_iterator i(ESDigis->begin()); i != ESDigis->end(); ++i) {
       ESDataFrame dataframe = (*i);
 
-      ESPedestals::const_iterator it_ped = pedestals->find(dataframe.id());
+      ESPedestals::const_iterator it_ped = pedestals.find(dataframe.id());
 
       if (dataframe.sample(1).adc() > (ts2Threshold + it_ped->getMean())) {
         // std::cout<<dataframe.sample(1).adc()<<"


### PR DESCRIPTION
#### PR description:

Part of #31061. The `EcalSelectiveReadoutSuppressor` (used by `EcalSelectiveReadoutProducer`) required some reorganization in order to be constructed in the constructor of `EcalSelectiveReadoutProducer` so that the `edm::ConsumesCollector` can be passed to it.

#### PR validation:

Code compiles.