### PR TITLE
Migrate classes deriving from IsoDepositExtractor to esConsumes()

### DIFF
--- a/RecoEgamma/EgammaIsolationAlgos/plugins/iso_deposit_extractors/EgammaHcalExtractor.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/iso_deposit_extractors/EgammaHcalExtractor.cc
@@ -63,6 +63,7 @@ namespace egammaisolation {
     double etLow_;
 
     edm::EDGetTokenT<HBHERecHitCollection> hcalRecHitProducerToken_;
+    edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometryToken_;
   };
 }  // namespace egammaisolation
 
@@ -79,7 +80,8 @@ EgammaHcalExtractor::EgammaHcalExtractor(const edm::ParameterSet& par, edm::Cons
     : extRadius_(par.getParameter<double>("extRadius")),
       intRadius_(par.getParameter<double>("intRadius")),
       etLow_(par.getParameter<double>("etMin")),
-      hcalRecHitProducerToken_(iC.consumes<HBHERecHitCollection>(par.getParameter<edm::InputTag>("hcalRecHits"))) {}
+      hcalRecHitProducerToken_(iC.consumes<HBHERecHitCollection>(par.getParameter<edm::InputTag>("hcalRecHits"))),
+      geometryToken_(iC.esConsumes()) {}
 
 EgammaHcalExtractor::~EgammaHcalExtractor() {}
 
@@ -90,9 +92,7 @@ reco::IsoDeposit EgammaHcalExtractor::deposit(const edm::Event& iEvent,
   auto const& hcalRecHits = iEvent.get(hcalRecHitProducerToken_);
 
   //Get Calo Geometry
-  edm::ESHandle<CaloGeometry> pG;
-  iSetup.get<CaloGeometryRecord>().get(pG);
-  const CaloGeometry* caloGeom = pG.product();
+  const CaloGeometry* caloGeom = &iSetup.getData(geometryToken_);
   CaloDualConeSelector<HBHERecHit> coneSel(intRadius_, extRadius_, caloGeom, DetId::Hcal);
 
   //Take the SC position

--- a/RecoMuon/MuonIsolation/plugins/CaloExtractor.cc
+++ b/RecoMuon/MuonIsolation/plugins/CaloExtractor.cc
@@ -1,7 +1,6 @@
 #include "CaloExtractor.h"
 
 #include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 

--- a/RecoMuon/MuonIsolation/plugins/CaloExtractorByAssociator.h
+++ b/RecoMuon/MuonIsolation/plugins/CaloExtractorByAssociator.h
@@ -25,6 +25,11 @@
 
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+
 class TrackAssociatorParameters;
 class TrackDetectorAssociator;
 class MuonServiceProxy;
@@ -99,6 +104,9 @@ namespace muonisolation {
     //! associator, its' parameters and the propagator
     TrackAssociatorParameters* theAssociatorParameters;
     TrackDetectorAssociator* theAssociator;
+
+    edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> bFieldToken_;
+    edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeomToken_;
 
     //! flag to turn on/off printing of a time report
     bool thePrintTimeReport;

--- a/RecoMuon/MuonIsolation/plugins/JetExtractor.cc
+++ b/RecoMuon/MuonIsolation/plugins/JetExtractor.cc
@@ -1,7 +1,6 @@
 #include "JetExtractor.h"
 
 #include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 

--- a/RecoMuon/MuonIsolation/plugins/PixelTrackExtractor.cc
+++ b/RecoMuon/MuonIsolation/plugins/PixelTrackExtractor.cc
@@ -8,8 +8,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
-
 using namespace edm;
 using namespace std;
 using namespace reco;


### PR DESCRIPTION
#### PR description:

Part of #31061. This should cover `CandIsoDepositProducer` and `MuIsoDepositProducer` EDModules.

Resolves https://github.com/makortel/framework/issues/244.

#### PR validation:

Code compiles.