### PR TITLE
use esConsumes in PhysicsTools/PatAlgos modules

### DIFF
--- a/PhysicsTools/PatAlgos/interface/KinResolutionsLoader.h
+++ b/PhysicsTools/PatAlgos/interface/KinResolutionsLoader.h
@@ -5,13 +5,16 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
+#include "FWCore/Utilities/interface/ESGetToken.h"
+
 #include "PhysicsTools/PatAlgos/interface/KinematicResolutionProvider.h"
+#include "PhysicsTools/PatAlgos/interface/KinematicResolutionRcd.h"
 
 namespace pat {
   namespace helper {
@@ -21,7 +24,7 @@ namespace pat {
       KinResolutionsLoader() {}
 
       /// Constructor from a PSet
-      KinResolutionsLoader(const edm::ParameterSet &iConfig);
+      KinResolutionsLoader(const edm::ParameterSet &iConfig, edm::ConsumesCollector);
 
       /// 'true' if this there is at least one efficiency configured
       bool enabled() const { return !patlabels_.empty(); }
@@ -40,15 +43,15 @@ namespace pat {
       /// Labels of the resolutions in PAT
       std::vector<std::string> patlabels_;
       /// Labels of the KinematicResolutionProvider in the EventSetup
-      std::vector<std::string> eslabels_;
+      std::vector<edm::ESGetToken<KinematicResolutionProvider, KinematicResolutionRcd>> estokens_;
       /// Handles to the EventSetup
-      std::vector<edm::ESHandle<KinematicResolutionProvider> > handles_;
+      std::vector<KinematicResolutionProvider const *> resolutions_;
     };  // class
 
     template <typename T>
     void KinResolutionsLoader::setResolutions(pat::PATObject<T> &obj) const {
       for (size_t i = 0, n = patlabels_.size(); i < n; ++i) {
-        obj.setKinResolution(handles_[i]->getResolution(obj), patlabels_[i]);
+        obj.setKinResolution(resolutions_[i]->getResolution(obj), patlabels_[i]);
       }
     }
 

--- a/PhysicsTools/PatAlgos/interface/KinematicResolutionProvider.h
+++ b/PhysicsTools/PatAlgos/interface/KinematicResolutionProvider.h
@@ -21,16 +21,10 @@ namespace reco {
 namespace pat {
   class CandKinResolution;
 }
-namespace edm {
-  class ParameterSet;
-  class EventSetup;
-}  // namespace edm
 
 class KinematicResolutionProvider {
 public:
   virtual ~KinematicResolutionProvider() = default;
-  /// everything that needs to be done before the event loop
-  virtual void setup(const edm::EventSetup &iSetup) const {}
   /// get a CandKinResolution object from the service; this
   /// function needs to be implemented by any derived class
   virtual pat::CandKinResolution getResolution(const reco::Candidate &c) const = 0;

--- a/PhysicsTools/PatAlgos/interface/VertexingHelper.h
+++ b/PhysicsTools/PatAlgos/interface/VertexingHelper.h
@@ -22,6 +22,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"
 
 #include "PhysicsTools/UtilAlgos/interface/ParameterAdapter.h"
 namespace reco {
@@ -82,6 +83,7 @@ namespace pat {
       edm::Handle<reco::VertexCollection> vertexHandle_;
       /// use tracks inside candidates
       bool useTracks_;
+      edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> ttToken_;
       edm::ESHandle<TransientTrackBuilder> ttBuilder_;
 
       //--------- Tools for reading vertex associations (playback mode) -----

--- a/PhysicsTools/PatAlgos/plugins/PATCompositeCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATCompositeCandidateProducer.cc
@@ -72,7 +72,8 @@ PATCompositeCandidateProducer::PATCompositeCandidateProducer(const ParameterSet&
 
   // Resolution configurables
   if (addResolutions_) {
-    resolutionLoader_ = pat::helper::KinResolutionsLoader(iConfig.getParameter<edm::ParameterSet>("resolutions"));
+    resolutionLoader_ =
+        pat::helper::KinResolutionsLoader(iConfig.getParameter<edm::ParameterSet>("resolutions"), consumesCollector());
   }
 
   // produces vector of particles

--- a/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
@@ -339,7 +339,8 @@ PATElectronProducer::PATElectronProducer(const edm::ParameterSet& iConfig)
   }
   // resolution configurables
   if (addResolutions_) {
-    resolutionLoader_ = pat::helper::KinResolutionsLoader(iConfig.getParameter<edm::ParameterSet>("resolutions"));
+    resolutionLoader_ =
+        pat::helper::KinResolutionsLoader(iConfig.getParameter<edm::ParameterSet>("resolutions"), consumesCollector());
   }
   if (addPuppiIsolation_) {
     //puppi

--- a/PhysicsTools/PatAlgos/plugins/PATGenericParticleProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATGenericParticleProducer.cc
@@ -149,7 +149,8 @@ PATGenericParticleProducer::PATGenericParticleProducer(const edm::ParameterSet& 
   // Resolution configurables
   addResolutions_ = iConfig.getParameter<bool>("addResolutions");
   if (addResolutions_) {
-    resolutionLoader_ = pat::helper::KinResolutionsLoader(iConfig.getParameter<edm::ParameterSet>("resolutions"));
+    resolutionLoader_ =
+        pat::helper::KinResolutionsLoader(iConfig.getParameter<edm::ParameterSet>("resolutions"), consumesCollector());
   }
 
   if (iConfig.exists("vertexing")) {

--- a/PhysicsTools/PatAlgos/plugins/PATJetProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATJetProducer.cc
@@ -184,7 +184,8 @@ PATJetProducer::PATJetProducer(const edm::ParameterSet &iConfig)
   // Resolution configurables
   addResolutions_ = iConfig.getParameter<bool>("addResolutions");
   if (addResolutions_) {
-    resolutionLoader_ = pat::helper::KinResolutionsLoader(iConfig.getParameter<edm::ParameterSet>("resolutions"));
+    resolutionLoader_ =
+        pat::helper::KinResolutionsLoader(iConfig.getParameter<edm::ParameterSet>("resolutions"), consumesCollector());
   }
   if (discriminatorTags_.empty()) {
     addDiscriminators_ = false;

--- a/PhysicsTools/PatAlgos/plugins/PATJetSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATJetSlimmer.cc
@@ -29,7 +29,6 @@ namespace pat {
     ~PATJetSlimmer() override {}
 
     void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
-    void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) final;
 
   private:
     edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection>> pf2pc_;
@@ -71,14 +70,12 @@ pat::PATJetSlimmer::PATJetSlimmer(const edm::ParameterSet& iConfig)
   produces<std::vector<pat::Jet>>();
 }
 
-void pat::PATJetSlimmer::beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup& iSetup) {
-  if (modifyJet_)
-    jetModifier_->setEventContent(iSetup);
-}
-
 void pat::PATJetSlimmer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
   using namespace std;
+
+  if (modifyJet_)
+    jetModifier_->setEventContent(iSetup);
 
   Handle<View<pat::Jet>> src;
   iEvent.getByToken(jets_, src);

--- a/PhysicsTools/PatAlgos/plugins/PATMETProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMETProducer.cc
@@ -98,7 +98,8 @@ PATMETProducer::PATMETProducer(const edm::ParameterSet& iConfig) : useUserData_(
   // Resolution configurables
   addResolutions_ = iConfig.getParameter<bool>("addResolutions");
   if (addResolutions_) {
-    resolutionLoader_ = pat::helper::KinResolutionsLoader(iConfig.getParameter<edm::ParameterSet>("resolutions"));
+    resolutionLoader_ =
+        pat::helper::KinResolutionsLoader(iConfig.getParameter<edm::ParameterSet>("resolutions"), consumesCollector());
   }
 
   // Check to see if the user wants to add user data

--- a/PhysicsTools/PatAlgos/plugins/PATMETProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMETProducer.cc
@@ -25,6 +25,8 @@
 #include "PhysicsTools/PatAlgos/interface/KinResolutionsLoader.h"
 #include "PhysicsTools/PatAlgos/interface/PATUserDataHelper.h"
 #include "RecoMET/METAlgorithms/interface/METSignificance.h"
+#include "CondFormats/DataRecord/interface/JetResolutionRcd.h"
+#include "CondFormats/DataRecord/interface/JetResolutionScaleFactorRcd.h"
 
 #include <memory>
 
@@ -65,10 +67,10 @@ namespace pat {
     edm::EDGetTokenT<edm::View<reco::Candidate>> pfCandToken_;
     std::vector<edm::EDGetTokenT<edm::View<reco::Candidate>>> lepTokens_;
     edm::EDGetTokenT<double> rhoToken_;
-    std::string jetResPtType_;
-    std::string jetResPhiType_;
-    std::string jetSFType_;
     edm::EDGetTokenT<edm::ValueMap<float>> weightsToken_;
+    edm::ESGetToken<JME::JetResolutionObject, JetResolutionRcd> jetResPtToken_;
+    edm::ESGetToken<JME::JetResolutionObject, JetResolutionRcd> jetResPhiToken_;
+    edm::ESGetToken<JME::JetResolutionObject, JetResolutionScaleFactorRcd> jetSFToken_;
 
     const reco::METCovMatrix getMETCovMatrix(const edm::Event& event,
                                              const edm::EventSetup& iSetup,
@@ -115,15 +117,18 @@ PATMETProducer::PATMETProducer(const edm::ParameterSet& iConfig) : useUserData_(
       weightsToken_ = consumes<edm::ValueMap<float>>(srcWeights);
     metSigAlgo_ = new metsig::METSignificance(iConfig);
     rhoToken_ = consumes<double>(iConfig.getParameter<edm::InputTag>("srcRho"));
-    jetSFType_ = iConfig.getParameter<std::string>("srcJetSF");
-    jetResPtType_ = iConfig.getParameter<std::string>("srcJetResPt");
-    jetResPhiType_ = iConfig.getParameter<std::string>("srcJetResPhi");
     jetToken_ = consumes<edm::View<reco::Jet>>(iConfig.getParameter<edm::InputTag>("srcJets"));
     pfCandToken_ = consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("srcPFCands"));
     std::vector<edm::InputTag> srcLeptonsTags = iConfig.getParameter<std::vector<edm::InputTag>>("srcLeptons");
     for (std::vector<edm::InputTag>::const_iterator it = srcLeptonsTags.begin(); it != srcLeptonsTags.end(); it++) {
       lepTokens_.push_back(consumes<edm::View<reco::Candidate>>(*it));
     }
+    auto jetSFType = iConfig.getParameter<std::string>("srcJetSF");
+    auto jetResPtType = iConfig.getParameter<std::string>("srcJetResPt");
+    auto jetResPhiType = iConfig.getParameter<std::string>("srcJetResPhi");
+    jetResPtToken_ = esConsumes(edm::ESInputTag("", jetResPtType));
+    jetResPhiToken_ = esConsumes(edm::ESInputTag("", jetResPhiType));
+    jetSFToken_ = esConsumes(edm::ESInputTag("", jetSFType));
   }
 
   // produces vector of mets
@@ -255,9 +260,9 @@ const reco::METCovMatrix PATMETProducer::getMETCovMatrix(const edm::Event& event
   if (!weightsToken_.isUninitialized())
     event.getByToken(weightsToken_, weights);
 
-  JME::JetResolution resPtObj = JME::JetResolution::get(iSetup, jetResPtType_);
-  JME::JetResolution resPhiObj = JME::JetResolution::get(iSetup, jetResPhiType_);
-  JME::JetResolutionScaleFactor resSFObj = JME::JetResolutionScaleFactor::get(iSetup, jetSFType_);
+  JME::JetResolution resPtObj = iSetup.getData(jetResPtToken_);
+  JME::JetResolution resPhiObj = iSetup.getData(jetResPhiToken_);
+  JME::JetResolutionScaleFactor resSFObj = iSetup.getData(jetSFToken_);
 
   //Compute the covariance matrix and fill it
   const edm::ValueMap<float>* weightsPtr = nullptr;

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -403,7 +403,8 @@ PATMuonProducer::PATMuonProducer(const edm::ParameterSet& iConfig, PATMuonHeavyO
   // resolutions
   addResolutions_ = iConfig.getParameter<bool>("addResolutions");
   if (addResolutions_) {
-    resolutionLoader_ = pat::helper::KinResolutionsLoader(iConfig.getParameter<edm::ParameterSet>("resolutions"));
+    resolutionLoader_ =
+        pat::helper::KinResolutionsLoader(iConfig.getParameter<edm::ParameterSet>("resolutions"), consumesCollector());
   }
   // puppi
   addPuppiIsolation_ = iConfig.getParameter<bool>("addPuppiIsolation");

--- a/PhysicsTools/PatAlgos/plugins/PATMuonSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonSlimmer.cc
@@ -28,7 +28,6 @@ namespace pat {
     ~PATMuonSlimmer() override {}
 
     void produce(edm::Event &iEvent, const edm::EventSetup &iSetup) override;
-    void beginLuminosityBlock(const edm::LuminosityBlock &, const edm::EventSetup &) final;
 
   private:
     const edm::EDGetTokenT<pat::MuonCollection> src_;
@@ -85,14 +84,12 @@ pat::PATMuonSlimmer::PATMuonSlimmer(const edm::ParameterSet &iConfig)
   }
 }
 
-void pat::PATMuonSlimmer::beginLuminosityBlock(const edm::LuminosityBlock &, const edm::EventSetup &iSetup) {
-  if (modifyMuon_)
-    muonModifier_->setEventContent(iSetup);
-}
-
 void pat::PATMuonSlimmer::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   using namespace edm;
   using namespace std;
+
+  if (modifyMuon_)
+    muonModifier_->setEventContent(iSetup);
 
   Handle<pat::MuonCollection> src;
   iEvent.getByToken(src_, src);

--- a/PhysicsTools/PatAlgos/plugins/PATPFParticleProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPFParticleProducer.cc
@@ -96,7 +96,8 @@ PATPFParticleProducer::PATPFParticleProducer(const edm::ParameterSet& iConfig)
   // Resolution configurables
   addResolutions_ = iConfig.getParameter<bool>("addResolutions");
   if (addResolutions_) {
-    resolutionLoader_ = pat::helper::KinResolutionsLoader(iConfig.getParameter<edm::ParameterSet>("resolutions"));
+    resolutionLoader_ =
+        pat::helper::KinResolutionsLoader(iConfig.getParameter<edm::ParameterSet>("resolutions"), consumesCollector());
   }
 
   // Check to see if the user wants to add user data

--- a/PhysicsTools/PatAlgos/plugins/PATPhotonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPhotonProducer.cc
@@ -289,7 +289,8 @@ PATPhotonProducer::PATPhotonProducer(const edm::ParameterSet& iConfig)
   // Resolution configurables
   addResolutions_ = iConfig.getParameter<bool>("addResolutions");
   if (addResolutions_) {
-    resolutionLoader_ = pat::helper::KinResolutionsLoader(iConfig.getParameter<edm::ParameterSet>("resolutions"));
+    resolutionLoader_ =
+        pat::helper::KinResolutionsLoader(iConfig.getParameter<edm::ParameterSet>("resolutions"), consumesCollector());
   }
   // Check to see if the user wants to add user data
   if (useUserData_) {

--- a/PhysicsTools/PatAlgos/plugins/PATTauProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTauProducer.cc
@@ -273,7 +273,8 @@ PATTauProducer::PATTauProducer(const edm::ParameterSet& iConfig)
   // Resolution configurables
   addResolutions_ = iConfig.getParameter<bool>("addResolutions");
   if (addResolutions_) {
-    resolutionLoader_ = pat::helper::KinResolutionsLoader(iConfig.getParameter<edm::ParameterSet>("resolutions"));
+    resolutionLoader_ =
+        pat::helper::KinResolutionsLoader(iConfig.getParameter<edm::ParameterSet>("resolutions"), consumesCollector());
   }
   // Check to see if the user wants to add user data
   if (useUserData_) {

--- a/PhysicsTools/PatAlgos/plugins/PATTauSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTauSlimmer.cc
@@ -22,7 +22,6 @@ namespace pat {
     ~PATTauSlimmer() override {}
 
     void produce(edm::Event &iEvent, const edm::EventSetup &iSetup) override;
-    void beginLuminosityBlock(const edm::LuminosityBlock &, const edm::EventSetup &) final;
 
   private:
     const edm::EDGetTokenT<edm::View<pat::Tau>> src_;
@@ -54,14 +53,12 @@ pat::PATTauSlimmer::PATTauSlimmer(const edm::ParameterSet &iConfig)
   produces<std::vector<pat::Tau>>();
 }
 
-void pat::PATTauSlimmer::beginLuminosityBlock(const edm::LuminosityBlock &, const edm::EventSetup &iSetup) {
-  if (modifyTau_)
-    tauModifier_->setEventContent(iSetup);
-}
-
 void pat::PATTauSlimmer::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   using namespace edm;
   using namespace std;
+
+  if (modifyTau_)
+    tauModifier_->setEventContent(iSetup);
 
   Handle<View<pat::Tau>> src;
   iEvent.getByToken(src_, src);

--- a/PhysicsTools/PatAlgos/src/KinResolutionsLoader.cc
+++ b/PhysicsTools/PatAlgos/src/KinResolutionsLoader.cc
@@ -5,17 +5,17 @@
 
 using pat::helper::KinResolutionsLoader;
 
-KinResolutionsLoader::KinResolutionsLoader(const edm::ParameterSet &iConfig) {
+KinResolutionsLoader::KinResolutionsLoader(const edm::ParameterSet &iConfig, edm::ConsumesCollector iCollector) {
   // Get the names (sorted)
   patlabels_ = iConfig.getParameterNamesForType<std::string>();
 
   // get the InputTags
-  for (std::vector<std::string>::const_iterator it = patlabels_.begin(), ed = patlabels_.end(); it != ed; ++it) {
-    eslabels_.push_back(iConfig.getParameter<std::string>(*it));
+  estokens_.reserve(patlabels_.size());
+  for (auto const &label : patlabels_) {
+    estokens_.emplace_back(iCollector.esConsumes(edm::ESInputTag("", iConfig.getParameter<std::string>(label))));
   }
-
-  // prepare the Handles
-  handles_.resize(patlabels_.size());
+  // prepare the resolutions
+  resolutions_.resize(patlabels_.size());
 
   // 'default' maps to empty string
   for (std::vector<std::string>::iterator it = patlabels_.begin(), ed = patlabels_.end(); it != ed; ++it) {
@@ -26,8 +26,7 @@ KinResolutionsLoader::KinResolutionsLoader(const edm::ParameterSet &iConfig) {
 
 void KinResolutionsLoader::newEvent(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   for (size_t i = 0, n = patlabels_.size(); i < n; ++i) {
-    iSetup.get<KinematicResolutionRcd>().get(eslabels_[i], handles_[i]);
-    handles_[i]->setup(iSetup);
+    resolutions_[i] = &iSetup.getData(estokens_[i]);
   }
 }
 

--- a/PhysicsTools/PatAlgos/src/VertexingHelper.cc
+++ b/PhysicsTools/PatAlgos/src/VertexingHelper.cc
@@ -33,6 +33,9 @@ pat::helper::VertexingHelper::VertexingHelper(const edm::ParameterSet &iConfig, 
   } else {
     enabled_ = false;
   }
+  if (!playback_) {
+    ttToken_ = iC.esConsumes(edm::ESInputTag("", "TransientTrackBuilder"));
+  }
 }
 
 void pat::helper::VertexingHelper::newEvent(const edm::Event &iEvent) {
@@ -46,7 +49,7 @@ void pat::helper::VertexingHelper::newEvent(const edm::Event &iEvent) {
 void pat::helper::VertexingHelper::newEvent(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   newEvent(iEvent);
   if (!playback_)
-    iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", ttBuilder_);
+    ttBuilder_ = iSetup.getHandle(ttToken_);
 }
 
 pat::VertexAssociation pat::helper::VertexingHelper::associate(const reco::Candidate &c) const {

--- a/RecoEgamma/EgammaTools/plugins/EGRegressionModifierV3.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGRegressionModifierV3.cc
@@ -63,6 +63,7 @@ private:
   bool useClosestToCentreSeedCrysDef_;
   float maxRawEnergyForLowPtEBSigma_;
   float maxRawEnergyForLowPtEESigma_;
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeomToken_;
   edm::ESHandle<CaloGeometry> caloGeomHandle_;
 };
 
@@ -81,6 +82,9 @@ EGRegressionModifierV3::EGRegressionModifierV3(const edm::ParameterSet& conf, ed
   if (conf.exists("phoRegs")) {
     phoRegs_ = std::make_unique<PhoRegs>(conf.getParameterSet("phoRegs"), cc);
   }
+  if (useClosestToCentreSeedCrysDef_) {
+    caloGeomToken_ = cc.esConsumes();
+  }
 }
 
 EGRegressionModifierV3::~EGRegressionModifierV3() {}
@@ -92,8 +96,9 @@ void EGRegressionModifierV3::setEventContent(const edm::EventSetup& iSetup) {
     eleRegs_->setEventContent(iSetup);
   if (phoRegs_)
     phoRegs_->setEventContent(iSetup);
-  if (useClosestToCentreSeedCrysDef_)
-    iSetup.get<CaloGeometryRecord>().get(caloGeomHandle_);
+  if (useClosestToCentreSeedCrysDef_) {
+    caloGeomHandle_ = iSetup.getHandle(caloGeomToken_);
+  }
 }
 
 void EGRegressionModifierV3::modifyObject(reco::GsfElectron& ele) const {


### PR DESCRIPTION
#### PR description:

Converted all modules to use missing esConsumes.  

#### PR validation:

Code compiles.