### PR TITLE
Migrate RecoTracker/CkfPattern, and ClusterShapeTrajectoryFilter to esConsumes

### DIFF
--- a/RecoEgamma/EgammaPhotonAlgos/interface/ConversionTrackFinder.h
+++ b/RecoEgamma/EgammaPhotonAlgos/interface/ConversionTrackFinder.h
@@ -30,7 +30,9 @@ class TrackerGeometry;
 
 class ConversionTrackFinder {
 public:
-  ConversionTrackFinder(const edm::ParameterSet& config, const BaseCkfTrajectoryBuilder* trajectoryBuilder);
+  ConversionTrackFinder(const edm::ParameterSet& config,
+                        const BaseCkfTrajectoryBuilder* trajectoryBuilder,
+                        edm::ConsumesCollector iC);
 
   virtual ~ConversionTrackFinder();
 

--- a/RecoEgamma/EgammaPhotonAlgos/interface/InOutConversionTrackFinder.h
+++ b/RecoEgamma/EgammaPhotonAlgos/interface/InOutConversionTrackFinder.h
@@ -27,7 +27,9 @@ class TrajectoryCleanerBySharedHits;
 
 class InOutConversionTrackFinder : public ConversionTrackFinder {
 public:
-  InOutConversionTrackFinder(const edm::ParameterSet& config, const BaseCkfTrajectoryBuilder* trajectoryBuilder);
+  InOutConversionTrackFinder(const edm::ParameterSet& config,
+                             const BaseCkfTrajectoryBuilder* trajectoryBuilder,
+                             edm::ConsumesCollector iC);
 
   ~InOutConversionTrackFinder() override;
   std::vector<Trajectory> tracks(const TrajectorySeedCollection& seeds,

--- a/RecoEgamma/EgammaPhotonAlgos/interface/OutInConversionTrackFinder.h
+++ b/RecoEgamma/EgammaPhotonAlgos/interface/OutInConversionTrackFinder.h
@@ -29,7 +29,9 @@ class TrajectoryCleanerBySharedHits;
 
 class OutInConversionTrackFinder : public ConversionTrackFinder {
 public:
-  OutInConversionTrackFinder(const edm::ParameterSet& config, const BaseCkfTrajectoryBuilder* trajectoryBuilder);
+  OutInConversionTrackFinder(const edm::ParameterSet& config,
+                             const BaseCkfTrajectoryBuilder* trajectoryBuilder,
+                             edm::ConsumesCollector iC);
 
   ~OutInConversionTrackFinder() override;
 

--- a/RecoEgamma/EgammaPhotonAlgos/src/ConversionTrackFinder.cc
+++ b/RecoEgamma/EgammaPhotonAlgos/src/ConversionTrackFinder.cc
@@ -14,10 +14,11 @@
 #include <sstream>
 
 ConversionTrackFinder::ConversionTrackFinder(const edm::ParameterSet& conf,
-                                             const BaseCkfTrajectoryBuilder* trajectoryBuilder)
+                                             const BaseCkfTrajectoryBuilder* trajectoryBuilder,
+                                             edm::ConsumesCollector iC)
     : theCkfTrajectoryBuilder_(trajectoryBuilder),
       theInitialState_(new TransientInitialStateEstimator(
-          conf.getParameter<edm::ParameterSet>("TransientInitialStateEstimatorParameters"))),
+          conf.getParameter<edm::ParameterSet>("TransientInitialStateEstimatorParameters"), iC)),
       theTrackerGeom_(nullptr),
       theUpdator_(nullptr),
       thePropagator_(nullptr) {

--- a/RecoEgamma/EgammaPhotonAlgos/src/InOutConversionTrackFinder.cc
+++ b/RecoEgamma/EgammaPhotonAlgos/src/InOutConversionTrackFinder.cc
@@ -18,8 +18,9 @@
 #include <sstream>
 
 InOutConversionTrackFinder::InOutConversionTrackFinder(const edm::ParameterSet& conf,
-                                                       const BaseCkfTrajectoryBuilder* trajectoryBuilder)
-    : ConversionTrackFinder(conf, trajectoryBuilder) {
+                                                       const BaseCkfTrajectoryBuilder* trajectoryBuilder,
+                                                       edm::ConsumesCollector iC)
+    : ConversionTrackFinder(conf, trajectoryBuilder, iC) {
   theTrajectoryCleaner_ = new TrajectoryCleanerBySharedHits(conf);
 
   // get the seed cleaner

--- a/RecoEgamma/EgammaPhotonAlgos/src/OutInConversionTrackFinder.cc
+++ b/RecoEgamma/EgammaPhotonAlgos/src/OutInConversionTrackFinder.cc
@@ -18,8 +18,9 @@
 #include "Utilities/General/interface/precomputed_value_sort.h"
 
 OutInConversionTrackFinder::OutInConversionTrackFinder(const edm::ParameterSet& conf,
-                                                       const BaseCkfTrajectoryBuilder* trajectoryBuilder)
-    : ConversionTrackFinder(conf, trajectoryBuilder) {
+                                                       const BaseCkfTrajectoryBuilder* trajectoryBuilder,
+                                                       edm::ConsumesCollector iC)
+    : ConversionTrackFinder(conf, trajectoryBuilder, iC) {
   theTrajectoryCleaner_ = new TrajectoryCleanerBySharedHits(conf);
 
   // get the seed cleaner

--- a/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackCandidateProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackCandidateProducer.cc
@@ -145,9 +145,9 @@ ConversionTrackCandidateProducer::ConversionTrackCandidateProducer(const edm::Pa
       theTrajectoryBuilder_(createBaseCkfTrajectoryBuilder(
           config.getParameter<edm::ParameterSet>("TrajectoryBuilderPSet"), consumesCollector())),
       outInSeedFinder_{config, consumesCollector()},
-      outInTrackFinder_{config, theTrajectoryBuilder_.get()},
+      outInTrackFinder_{config, theTrajectoryBuilder_.get(), consumesCollector()},
       inOutSeedFinder_{config, consumesCollector()},
-      inOutTrackFinder_{config, theTrajectoryBuilder_.get()} {
+      inOutTrackFinder_{config, theTrajectoryBuilder_.get(), consumesCollector()} {
   OutInTrackCandidateCollection_ = config.getParameter<std::string>("outInTrackCandidateCollection");
   InOutTrackCandidateCollection_ = config.getParameter<std::string>("inOutTrackCandidateCollection");
 

--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeTrajectoryFilter.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeTrajectoryFilter.h
@@ -36,6 +36,7 @@ public:
 
 private:
   edm::EDGetTokenT<SiPixelClusterShapeCache> theCacheToken;
+  edm::ESGetToken<ClusterShapeHitFilter, TrajectoryFilter::Record> theFilterToken;
   const SiPixelClusterShapeCache* theCache;
   const ClusterShapeHitFilter* theFilter;
 };

--- a/RecoPixelVertexing/PixelLowPtUtilities/src/ClusterShapeTrajectoryFilter.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/ClusterShapeTrajectoryFilter.cc
@@ -6,14 +6,12 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 #include "TrackingTools/PatternTools/interface/TempTrajectory.h"
 
-#include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
@@ -37,18 +35,14 @@ using namespace std;
 /*****************************************************************************/
 ClusterShapeTrajectoryFilter::ClusterShapeTrajectoryFilter(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC)
     : theCacheToken(iC.consumes<SiPixelClusterShapeCache>(iConfig.getParameter<edm::InputTag>("cacheSrc"))),
+      theFilterToken(iC.esConsumes(edm::ESInputTag("", "ClusterShapeHitFilter"))),
       theFilter(nullptr) {}
 
 ClusterShapeTrajectoryFilter::~ClusterShapeTrajectoryFilter() {}
 
 void ClusterShapeTrajectoryFilter::setEvent(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  edm::ESHandle<ClusterShapeHitFilter> shape;
-  iSetup.get<TrajectoryFilter::Record>().get("ClusterShapeHitFilter", shape);
-  theFilter = shape.product();
-
-  edm::Handle<SiPixelClusterShapeCache> cache;
-  iEvent.getByToken(theCacheToken, cache);
-  theCache = cache.product();
+  theFilter = &iSetup.getData(theFilterToken);
+  theCache = &iEvent.get(theCacheToken);
 }
 
 /*****************************************************************************/

--- a/RecoTracker/CkfPattern/interface/BaseCkfTrajectoryBuilder.h
+++ b/RecoTracker/CkfPattern/interface/BaseCkfTrajectoryBuilder.h
@@ -3,8 +3,10 @@
 
 #include "TrackingTools/PatternTools/interface/TrajectoryMeasurement.h"
 #include "TrackingTools/PatternTools/interface/TrajectoryBuilder.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeed.h"
 
 #include <cassert>
@@ -26,6 +28,7 @@ class TrajectoryMeasurement;
 class TrajectoryContainer;
 class TrajectoryStateOnSurface;
 class TrajectoryFitter;
+class TransientRecHitRecord;
 class TransientTrackingRecHitBuilder;
 class Trajectory;
 class TempTrajectory;
@@ -65,6 +68,7 @@ public:
 
   // Claims ownership of TrajectoryFilter pointers
   BaseCkfTrajectoryBuilder(const edm::ParameterSet& conf,
+                           edm::ConsumesCollector iC,
                            std::unique_ptr<TrajectoryFilter> filter,
                            std::unique_ptr<TrajectoryFilter> inOutFilter = nullptr);
   BaseCkfTrajectoryBuilder(const BaseCkfTrajectoryBuilder&) = delete;
@@ -182,11 +186,11 @@ private:
   std::unique_ptr<TrajectoryFilter> theInOutFilter; /** Filter used at end of in-out tracking */
 
   // for EventSetup
-  const std::string theUpdatorName;
-  const std::string thePropagatorAlongName;
-  const std::string thePropagatorOppositeName;
-  const std::string theEstimatorName;
-  const std::string theRecHitBuilderName;
+  const edm::ESGetToken<TrajectoryStateUpdator, TrackingComponentsRecord> theUpdatorToken;
+  const edm::ESGetToken<Propagator, TrackingComponentsRecord> thePropagatorAlongToken;
+  const edm::ESGetToken<Propagator, TrackingComponentsRecord> thePropagatorOppositeToken;
+  const edm::ESGetToken<Chi2MeasurementEstimatorBase, TrackingComponentsRecord> theEstimatorToken;
+  const edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> theRecHitBuilderToken;
 };
 
 #endif

--- a/RecoTracker/CkfPattern/interface/CkfTrackCandidateMakerBase.h
+++ b/RecoTracker/CkfPattern/interface/CkfTrackCandidateMakerBase.h
@@ -2,7 +2,6 @@
 #define CkfTrackCandidateMakerBase_h
 
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
@@ -29,6 +28,8 @@
 #include <memory>
 
 class TransientInitialStateEstimator;
+class NavigationSchoolRecord;
+class TrackerDigiGeometryRecord;
 
 namespace cms {
   class CkfTrackCandidateMakerBase {
@@ -54,13 +55,16 @@ namespace cms {
 
     std::unique_ptr<BaseCkfTrajectoryBuilder> theTrajectoryBuilder;
 
-    std::string theTrajectoryCleanerName;
+    edm::ESGetToken<TrajectoryCleaner, TrajectoryCleaner::Record> theTrajectoryCleanerToken;
     const TrajectoryCleaner* theTrajectoryCleaner;
 
     std::unique_ptr<TransientInitialStateEstimator> theInitialState;
 
-    std::string theNavigationSchoolName;
+    edm::ESGetToken<NavigationSchool, NavigationSchoolRecord> theNavigationSchoolToken;
     const NavigationSchool* theNavigationSchool;
+
+    edm::ESGetToken<Propagator, TrackingComponentsRecord> thePropagatorToken;
+    edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> theTrackerToken;
 
     std::unique_ptr<RedundantSeedCleaner> theSeedCleaner;
 

--- a/RecoTracker/CkfPattern/interface/CkfTrackCandidateMakerBase.h
+++ b/RecoTracker/CkfPattern/interface/CkfTrackCandidateMakerBase.h
@@ -59,10 +59,6 @@ namespace cms {
 
     std::unique_ptr<TransientInitialStateEstimator> theInitialState;
 
-    const std::string theMagFieldName;
-    edm::ESHandle<MagneticField> theMagField;
-    edm::ESHandle<GeometricSearchTracker> theGeomSearchTracker;
-
     std::string theNavigationSchoolName;
     const NavigationSchool* theNavigationSchool;
 

--- a/RecoTracker/CkfPattern/interface/CkfTrajectoryBuilder.h
+++ b/RecoTracker/CkfPattern/interface/CkfTrajectoryBuilder.h
@@ -35,8 +35,10 @@ public:
   typedef std::vector<Trajectory> TrajectoryContainer;
   typedef std::vector<TempTrajectory> TempTrajectoryContainer;
 
-  CkfTrajectoryBuilder(const edm::ParameterSet& conf, edm::ConsumesCollector& iC);
-  CkfTrajectoryBuilder(const edm::ParameterSet& conf, std::unique_ptr<TrajectoryFilter> filter);
+  CkfTrajectoryBuilder(const edm::ParameterSet& conf, edm::ConsumesCollector iC);
+  CkfTrajectoryBuilder(const edm::ParameterSet& conf,
+                       edm::ConsumesCollector iC,
+                       std::unique_ptr<TrajectoryFilter> filter);
 
   ~CkfTrajectoryBuilder() override {}
 

--- a/RecoTracker/CkfPattern/interface/CkfTrajectoryBuilder.h
+++ b/RecoTracker/CkfPattern/interface/CkfTrajectoryBuilder.h
@@ -10,7 +10,6 @@ class TrajectorySeed;
 class TrajectoryStateOnSurface;
 class TrajectoryFilter;
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Event.h"

--- a/RecoTracker/CkfPattern/interface/TransientInitialStateEstimator.h
+++ b/RecoTracker/CkfPattern/interface/TransientInitialStateEstimator.h
@@ -1,6 +1,7 @@
 #ifndef TransientInitialStateEstimator_H
 #define TransientInitialStateEstimator_H
 
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
@@ -24,14 +25,14 @@ class TransientInitialStateEstimator {
 public:
   typedef TrajectoryStateOnSurface TSOS;
 
-  TransientInitialStateEstimator(const edm::ParameterSet& conf);
+  TransientInitialStateEstimator(const edm::ParameterSet& conf, edm::ConsumesCollector iC);
   void setEventSetup(const edm::EventSetup& es, const TkClonerImpl& hc);
 
   std::pair<TrajectoryStateOnSurface, const GeomDet*> innerState(const Trajectory& traj, bool doBackFit = true) const;
 
 private:
-  const std::string thePropagatorAlongName;
-  const std::string thePropagatorOppositeName;
+  const edm::ESGetToken<Propagator, TrackingComponentsRecord> thePropagatorAlongToken;
+  const edm::ESGetToken<Propagator, TrackingComponentsRecord> thePropagatorOppositeToken;
   const Propagator* thePropagatorAlong;
   const Propagator* thePropagatorOpposite;  // not used? can we remove it?
   TkClonerImpl theHitCloner;

--- a/RecoTracker/CkfPattern/plugins/CkfTrackCandidateMaker.h
+++ b/RecoTracker/CkfPattern/plugins/CkfTrackCandidateMaker.h
@@ -3,7 +3,6 @@
 
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/RecoTracker/CkfPattern/plugins/CkfTrajectoryMaker.h
+++ b/RecoTracker/CkfPattern/plugins/CkfTrajectoryMaker.h
@@ -3,7 +3,6 @@
 
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc
@@ -111,6 +111,7 @@ namespace {
 
 GroupedCkfTrajectoryBuilder::GroupedCkfTrajectoryBuilder(const edm::ParameterSet& conf, edm::ConsumesCollector& iC)
     : BaseCkfTrajectoryBuilder(conf,
+                               iC,
                                BaseCkfTrajectoryBuilder::createTrajectoryFilter(
                                    conf.getParameter<edm::ParameterSet>("trajectoryFilter"), iC),
                                conf.getParameter<bool>("useSameTrajFilter")

--- a/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.h
+++ b/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.h
@@ -1,7 +1,6 @@
 #ifndef GroupedCkfTrajectoryBuilder_H
 #define GroupedCkfTrajectoryBuilder_H
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 

--- a/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
+++ b/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
@@ -72,8 +72,6 @@ namespace cms {
         theTrajectoryCleaner(nullptr),
         theInitialState(std::make_unique<TransientInitialStateEstimator>(
             conf.getParameter<ParameterSet>("TransientInitialStateEstimatorParameters"))),
-        theMagFieldName(conf.exists("SimpleMagneticField") ? conf.getParameter<std::string>("SimpleMagneticField")
-                                                           : ""),
         theNavigationSchoolName(conf.getParameter<std::string>("NavigationSchool")),
         theNavigationSchool(nullptr),
         maxSeedsBeforeCleaning_(0),
@@ -126,11 +124,6 @@ namespace cms {
 
   void CkfTrackCandidateMakerBase::setEventSetup(const edm::EventSetup& es) {
     //services
-    es.get<TrackerRecoGeometryRecord>().get(theGeomSearchTracker);
-    es.get<IdealMagneticFieldRecord>().get(theMagFieldName, theMagField);
-    //    edm::ESInputTag mfESInputTag(mfName);
-    //    es.get<IdealMagneticFieldRecord>().get(mfESInputTag,theMagField );
-
     edm::ESHandle<TrajectoryCleaner> trajectoryCleanerH;
     es.get<TrajectoryCleaner::Record>().get(theTrajectoryCleanerName, trajectoryCleanerH);
     theTrajectoryCleaner = trajectoryCleanerH.product();

--- a/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
+++ b/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
@@ -1,5 +1,4 @@
 #include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/isFinite.h"
@@ -68,12 +67,15 @@ namespace cms {
         theMaxNSeeds(conf.getParameter<unsigned int>("maxNSeeds")),
         theTrajectoryBuilder(
             createBaseCkfTrajectoryBuilder(conf.getParameter<edm::ParameterSet>("TrajectoryBuilderPSet"), iC)),
-        theTrajectoryCleanerName(conf.getParameter<std::string>("TrajectoryCleaner")),
+        theTrajectoryCleanerToken(
+            iC.esConsumes(edm::ESInputTag("", conf.getParameter<std::string>("TrajectoryCleaner")))),
         theTrajectoryCleaner(nullptr),
         theInitialState(std::make_unique<TransientInitialStateEstimator>(
             conf.getParameter<ParameterSet>("TransientInitialStateEstimatorParameters"))),
-        theNavigationSchoolName(conf.getParameter<std::string>("NavigationSchool")),
+        theNavigationSchoolToken(
+            iC.esConsumes(edm::ESInputTag("", conf.getParameter<std::string>("NavigationSchool")))),
         theNavigationSchool(nullptr),
+        thePropagatorToken(iC.esConsumes(edm::ESInputTag("", "AnyDirectionAnalyticalPropagator"))),
         maxSeedsBeforeCleaning_(0),
         theMTELabel(iC.consumes<MeasurementTrackerEvent>(conf.getParameter<edm::InputTag>("MeasurementTrackerEvent"))),
         skipClusters_(false),
@@ -109,6 +111,12 @@ namespace cms {
     }
 #endif
 
+#ifdef EDM_ML_DEBUG
+    if (theTrackCandidateOutput) {
+      theTrackerToken = iC.esConsumes();
+    }
+#endif
+
 #ifdef VI_REPRODUCIBLE
     std::cout << "CkfTrackCandidateMaker in reproducible setting" << std::endl;
     assert(nullptr == theSeedCleaner);
@@ -124,13 +132,9 @@ namespace cms {
 
   void CkfTrackCandidateMakerBase::setEventSetup(const edm::EventSetup& es) {
     //services
-    edm::ESHandle<TrajectoryCleaner> trajectoryCleanerH;
-    es.get<TrajectoryCleaner::Record>().get(theTrajectoryCleanerName, trajectoryCleanerH);
-    theTrajectoryCleaner = trajectoryCleanerH.product();
+    theTrajectoryCleaner = &es.getData(theTrajectoryCleanerToken);
 
-    edm::ESHandle<NavigationSchool> navigationSchoolH;
-    es.get<NavigationSchoolRecord>().get(theNavigationSchoolName, navigationSchoolH);
-    theNavigationSchool = navigationSchoolH.product();
+    theNavigationSchool = &es.getData(theNavigationSchoolToken);
     theTrajectoryBuilder->setNavigationSchool(theNavigationSchool);
   }
 
@@ -143,8 +147,7 @@ namespace cms {
     // NavigationSetter setter( *theNavigationSchool);
 
     // propagator
-    edm::ESHandle<Propagator> thePropagator;
-    es.get<TrackingComponentsRecord>().get("AnyDirectionAnalyticalPropagator", thePropagator);
+    auto const& propagator = es.getData(thePropagatorToken);
 
     // method for Debugging
     printHitsDebugger(e);
@@ -498,7 +501,7 @@ namespace cms {
           if (useSplitting && (initState.second != recHits.front().det()) && recHits.front().det()) {
             LogDebug("CkfPattern") << "propagating to hit front in case of splitting.";
             TrajectoryStateOnSurface&& propagated =
-                thePropagator->propagate(initState.first, recHits.front().det()->surface());
+                propagator.propagate(initState.first, recHits.front().det()->surface());
             if (!propagated.isValid())
               continue;
             state = trajectoryStateTransform::persistentState(propagated, recHits.front().rawId());
@@ -510,11 +513,10 @@ namespace cms {
         }
       }  //output trackcandidates
 
-      edm::ESHandle<TrackerGeometry> tracker;
-      es.get<TrackerDigiGeometryRecord>().get(tracker);
-      LogTrace("CkfPattern|TrackingRegressionTest") << "========== CkfTrackCandidateMaker Info =========="
-                                                    << "number of Seed: " << collseed->size() << '\n'
-                                                    << PrintoutHelper::regressionTest(*tracker, unsmoothedResult);
+      LogTrace("CkfPattern|TrackingRegressionTest")
+          << "========== CkfTrackCandidateMaker Info =========="
+          << "number of Seed: " << collseed->size() << '\n'
+          << PrintoutHelper::regressionTest(es.getData(theTrackerToken), unsmoothedResult);
 
       assert(viTotHits >= 0);  // just to use it...
       // std::cout << "VICkfPattern result " << output->size() << " " << viTotHits << std::endl;

--- a/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
+++ b/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
@@ -71,7 +71,7 @@ namespace cms {
             iC.esConsumes(edm::ESInputTag("", conf.getParameter<std::string>("TrajectoryCleaner")))),
         theTrajectoryCleaner(nullptr),
         theInitialState(std::make_unique<TransientInitialStateEstimator>(
-            conf.getParameter<ParameterSet>("TransientInitialStateEstimatorParameters"))),
+            conf.getParameter<ParameterSet>("TransientInitialStateEstimatorParameters"), iC)),
         theNavigationSchoolToken(
             iC.esConsumes(edm::ESInputTag("", conf.getParameter<std::string>("NavigationSchool")))),
         theNavigationSchool(nullptr),

--- a/RecoTracker/CkfPattern/src/CkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/src/CkfTrajectoryBuilder.cc
@@ -26,13 +26,16 @@
 
 using namespace std;
 
-CkfTrajectoryBuilder::CkfTrajectoryBuilder(const edm::ParameterSet& conf, edm::ConsumesCollector& iC)
+CkfTrajectoryBuilder::CkfTrajectoryBuilder(const edm::ParameterSet& conf, edm::ConsumesCollector iC)
     : CkfTrajectoryBuilder(conf,
+                           iC,
                            BaseCkfTrajectoryBuilder::createTrajectoryFilter(
                                conf.getParameter<edm::ParameterSet>("trajectoryFilter"), iC)) {}
 
-CkfTrajectoryBuilder::CkfTrajectoryBuilder(const edm::ParameterSet& conf, std::unique_ptr<TrajectoryFilter> filter)
-    : BaseCkfTrajectoryBuilder(conf, std::move(filter)) {
+CkfTrajectoryBuilder::CkfTrajectoryBuilder(const edm::ParameterSet& conf,
+                                           edm::ConsumesCollector iC,
+                                           std::unique_ptr<TrajectoryFilter> filter)
+    : BaseCkfTrajectoryBuilder(conf, iC, std::move(filter)) {
   theMaxCand = conf.getParameter<int>("maxCand");
   theLostHitPenalty = conf.getParameter<double>("lostHitPenalty");
   theIntermediateCleaning = conf.getParameter<bool>("intermediateCleaning");

--- a/RecoTracker/CkfPattern/src/TransientInitialStateEstimator.cc
+++ b/RecoTracker/CkfPattern/src/TransientInitialStateEstimator.cc
@@ -1,7 +1,6 @@
 #include "RecoTracker/CkfPattern/interface/TransientInitialStateEstimator.h"
 
 #include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -18,23 +17,19 @@
 
 using namespace std;
 
-TransientInitialStateEstimator::TransientInitialStateEstimator(const edm::ParameterSet& conf)
-    : thePropagatorAlongName(conf.getParameter<std::string>("propagatorAlongTISE")),
-      thePropagatorOppositeName(conf.getParameter<std::string>("propagatorOppositeTISE")),
+TransientInitialStateEstimator::TransientInitialStateEstimator(const edm::ParameterSet& conf, edm::ConsumesCollector iC)
+    : thePropagatorAlongToken(
+          iC.esConsumes(edm::ESInputTag("", conf.getParameter<std::string>("propagatorAlongTISE")))),
+      thePropagatorOppositeToken(
+          iC.esConsumes(edm::ESInputTag("", conf.getParameter<std::string>("propagatorOppositeTISE")))),
       thePropagatorAlong(nullptr),
       thePropagatorOpposite(nullptr),
       theNumberMeasurementsForFit(conf.getParameter<int>("numberMeasurementsForFit")) {}
 
 void TransientInitialStateEstimator::setEventSetup(const edm::EventSetup& es, const TkClonerImpl& hc) {
   theHitCloner = hc;
-
-  edm::ESHandle<Propagator> halong;
-  edm::ESHandle<Propagator> hopposite;
-
-  es.get<TrackingComponentsRecord>().get(thePropagatorAlongName, halong);
-  es.get<TrackingComponentsRecord>().get(thePropagatorOppositeName, hopposite);
-  thePropagatorAlong = halong.product();
-  thePropagatorOpposite = hopposite.product();
+  thePropagatorAlong = &es.getData(thePropagatorAlongToken);
+  thePropagatorOpposite = &es.getData(thePropagatorOppositeToken);
 }
 
 std::pair<TrajectoryStateOnSurface, const GeomDet*> TransientInitialStateEstimator::innerState(const Trajectory& traj,

--- a/RecoTracker/DebugTools/plugins/CkfDebugTrajectoryBuilder.h
+++ b/RecoTracker/DebugTools/plugins/CkfDebugTrajectoryBuilder.h
@@ -8,8 +8,8 @@
 
 class CkfDebugTrajectoryBuilder : public CkfTrajectoryBuilder {
 public:
-  CkfDebugTrajectoryBuilder(const edm::ParameterSet& conf)
-      : CkfTrajectoryBuilder(conf, std::unique_ptr<TrajectoryFilter>{}) {
+  CkfDebugTrajectoryBuilder(const edm::ParameterSet& conf, edm::ConsumesCollector iC)
+      : CkfTrajectoryBuilder(conf, iC, std::unique_ptr<TrajectoryFilter>{}) {
     //edm::LogVerbatim("CkfDebugger") <<"CkfDebugTrajectoryBuilder::CkfDebugTrajectoryBuilder";
   }
 


### PR DESCRIPTION
#### PR description:

Part of #31061. The EDModules `CkfTrackCandidateMaker` and `CkfTrajectoryMaker` are not currently reported by the "SA EventSetupRecord::get called" module list in IBs (the tool is being improved for that), so it is possible that I missed some helpers classes from other packages. I did migrate the `ClusterShapeTrajectoryFilter` that was pointed our by the IB list (for `ConversionTrackCandidateProducer` that is otherwise left for later).

Migration of `TransientInitialStateEstimator` had knock-on effects in `RecoEgamma/EgammaPhotonAlgos` and `RecoEgamma/EgammaPhotonProducers`.

#### PR validation:

Code compiles.