### PR TITLE
Utilities/StaticAnalyzers: Update function dumper to not add virtual at the end of function calls

### DIFF
--- a/Utilities/StaticAnalyzers/scripts/run_class_checker.sh
+++ b/Utilities/StaticAnalyzers/scripts/run_class_checker.sh
@@ -10,7 +10,7 @@ cd ${LOCALRT}/src/Utilities/StaticAnalyzers
 scram b -j $J
 cd ${LOCALRT}/
 export USER_CXXFLAGS="-DEDM_ML_DEBUG -w"
-export USER_LLVM_CHECKERS="-enable-checker threadsafety -enable-checker optional.ClassChecker -enable-checker cms -disable-checker cms.FunctionDumper"
+export USER_LLVM_CHECKERS="-enable-checker threadsafety -enable-checker optional.ClassChecker -enable-checker cms -enable-checker deprecated -disable-checker cms.FunctionDumper"
 scram b -k -j $J checker  SCRAM_IGNORE_PACKAGES=Fireworks/% SCRAM_IGNORE_SUBDIRS=test > ${LOCALRT}/tmp/class+function-checker.log 2>&1
 cd ${LOCALRT}/tmp/
 touch check-end

--- a/Utilities/StaticAnalyzers/src/ClangCmsCheckerPluginRegister.cpp
+++ b/Utilities/StaticAnalyzers/src/ClangCmsCheckerPluginRegister.cpp
@@ -69,7 +69,7 @@ extern "C" void clang_registerCheckers(clang::ento::CheckerRegistry &registry) {
   registry.addChecker<clangcms::CatchAll>(
       "cms.CodeRules.CatchAll", "Checks for 'catch(...)' in source files", "no docs");
   registry.addChecker<clangcms::edmChecker>(
-      "cms.edmChecker",
+      "deprecated.edmChecker",
       "Flags classes inheriting from edm::EDProducer,edm::EDFilter,edm::Analyzer or edm::OutputModule",
       "no docs");
   registry.addChecker<clangcms::getByChecker>(
@@ -85,9 +85,9 @@ extern "C" void clang_registerCheckers(clang::ento::CheckerRegistry &registry) {
   registry.addChecker<clangcms::EDMPluginDumper>(
       "optional.EDMPluginDumper", "Dumps macro DEFINE_EDM_PLUGIN types", "no docs");
   registry.addChecker<clangcms::ThrUnsafeFCallChecker>(
-      "cms.ThrUnsafeFCallChecker", "Reports calls of known thread unsafe functions", "no docs");
+      "threadsafety.ThrUnsafeFCallChecker", "Reports calls of known thread unsafe functions", "no docs");
   registry.addChecker<clangcms::ESRGetChecker>(
-      "threadsafety.ESRecordGetChecker", "Checks for calls to EventSetupRecord::get", "no docs");
+      "deprecated.ESRecordGetChecker", "Checks for calls to EventSetupRecord::get", "no docs");
 }
 
 extern "C" const char clang_analyzerAPIVersionString[] = CLANG_ANALYZER_API_VERSION_STRING;

--- a/Utilities/StaticAnalyzers/src/ESRecordGetChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ESRecordGetChecker.cpp
@@ -61,7 +61,7 @@ namespace clangcms {
             "the token see "
             "https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideHowToGetDataFromES#Getting_data_from_EventSetup_wit";
       PathDiagnosticLocation CELoc = PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(), AC);
-      BugType *BT = new BugType(Checker, "EventSetupRecord::get function called", "ThreadSafety");
+      BugType *BT = new BugType(Checker, "EventSetupRecord::get function called", "Deprecated API");
       std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), CELoc);
       R->addRange(CE->getSourceRange());
       BR.emitReport(std::move(R));

--- a/Utilities/StaticAnalyzers/src/FunctionDumper.cpp
+++ b/Utilities/StaticAnalyzers/src/FunctionDumper.cpp
@@ -137,10 +137,7 @@ namespace clangcms {
     fixAnonNS(mname);
     std::string tname = "function-dumper.txt.unsorted";
     std::string ostring;
-    if (MD->isVirtual())
-      ostring = "function '" + mdname + "' " + "calls function '" + mname + " virtual'\n";
-    else
-      ostring = "function '" + mdname + "' " + "calls function '" + mname + "'\n";
+    ostring = "function '" + mdname + "' " + "calls function '" + mname + "'\n";
     support::writeLog(ostring, tname);
 
     VisitChildren(CXE);
@@ -166,10 +163,7 @@ namespace clangcms {
     mname = support::getQualifiedName(*FD);
     std::string tname = "function-dumper.txt.unsorted";
     std::string ostring;
-    if (FD->isVirtualAsWritten() || FD->isPure())
-      ostring = "function '" + mdname + "' " + "calls function '" + mname + " virtual'\n";
-    else
-      ostring = "function '" + mdname + "' " + "calls function '" + mname + "'\n";
+    ostring = "function '" + mdname + "' " + "calls function '" + mname + "'\n";
     support::writeLog(ostring, tname);
 
     VisitChildren(CE);
@@ -194,7 +188,7 @@ namespace clangcms {
     for (auto I = MD->begin_overridden_methods(), E = MD->end_overridden_methods(); I != E; ++I) {
       std::string oname = support::getQualifiedName(*(*I));
       walker.fixAnonNS(oname);
-      std::string ostring = "function '" + mname + "' " + "overrides function '" + oname + " virtual'\n";
+      std::string ostring = "function '" + mname + "' " + "overrides function '" + oname + "'\n";
       support::writeLog(ostring, tname);
     }
     return;

--- a/Utilities/StaticAnalyzers/src/edmChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/edmChecker.cpp
@@ -27,7 +27,7 @@ namespace clangcms {
         BR.EmitBasicReport(RD,
                            this,
                            "inherits from edm::EDProducer,edm::EDFilter,edm::EDAnalyzer, or edm::OutputModule",
-                           "ThreadSafety",
+                           "Deprecated API",
                            os.str(),
                            ELoc);
       }

--- a/Utilities/StaticAnalyzers/src/getByChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/getByChecker.cpp
@@ -101,7 +101,7 @@ namespace clangcms {
 
       //			llvm::errs()<<os.str()<<"\n";
       PathDiagnosticLocation CELoc = PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(), AC);
-      BugType *BT = new BugType(Checker, "edm::getByLabel or edm::getManyByType called", "optional");
+      BugType *BT = new BugType(Checker, "edm::getByLabel or edm::getManyByType called", "Deprecated API");
       std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), CELoc);
       R->addRange(CE->getSourceRange());
       BR.emitReport(std::move(R));
@@ -124,7 +124,7 @@ namespace clangcms {
           //				(*I)->printPretty(llvm::errs(),0,Policy);
           //				llvm::errs()<<" "<<qtname<<"\n";
           PathDiagnosticLocation CELoc = PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(), AC);
-          BugType *BT = new BugType(Checker, "function call with argument of type edm::Event", "optional");
+          BugType *BT = new BugType(Checker, "function call with argument of type edm::Event", "Deprecated API");
           std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), CELoc);
           R->addRange(CE->getSourceRange());
           BR.emitReport(std::move(R));


### PR DESCRIPTION
Utilities/StaticAnalyzers: Update function dumper to not add virtual at the end of function calls.
Change category of some checks to deprecated "Deprecated API"

#### PR description:

The addition of virtual at the end of the function call printout was causing 
`function 'cms::CkfTrackCandidateMaker::produce(edm::Event &, const edm::EventSetup &)' calls function 'cms::CkfTrackCandidateMakerBase::produceBase(edm::Event &, const edm::EventSetup &) virtual'
function `

to not be linked to 

`function 'cms::CkfTrackCandidateMakerBase::produceBase(edm::Event &, const edm::EventSetup &)' calls function 'edm::eventsetup::EventSetupRecord::get<class edm::ESHandle<class TrackerGeometry>>(class edm::ESHandle<class TrackerGeometry> &) const'`

This prevented the call stack from being reported in the ESR::get() report.
