### PR TITLE
Fixed destruction of Geant4 simulation

### DIFF
--- a/SimG4Core/Application/src/OscarMTMasterThread.cc
+++ b/SimG4Core/Application/src/OscarMTMasterThread.cc
@@ -184,7 +184,6 @@ void OscarMTMasterThread::stopThread() {
   // the G4 master thread can do the cleanup. Then notify the master
   // thread, and join it.
   std::unique_lock<std::mutex> lk2(m_threadMutex);
-  m_runManagerMaster.reset();
   LogDebug("OscarMTMasterThread") << "Main thread: reseted shared_ptr";
 
   m_masterThreadState = ThreadState::Destruct;


### PR DESCRIPTION
#### PR description:
When an exception happens there may be situations, when the real trace of the problem is shadowing by destruction of Geant4. This fix is a backport of  #34820 which fix the issue #34271.

Should not affect mainstream production.

#### PR validation:
private

