### PR TITLE
Adapt CAConstants for HIon

### DIFF
--- a/RecoPixelVertexing/PixelTriplets/plugins/CAConstants.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAConstants.h
@@ -32,9 +32,10 @@ namespace caConstants {
   constexpr uint32_t maxCellsPerHit = 128 / 2;
 #else   // GPU_SMALL_EVENTS
   // tested on MC events with 55-75 pileup events
-  constexpr uint32_t maxNumberOfTuples = 24 * 1024;
+  // and extended for Heavy Ions operations (24k -> 32k tuples, 128 -> 256 cells)
+  constexpr uint32_t maxNumberOfTuples = 32 * 1024;
   constexpr uint32_t maxNumberOfDoublets = 512 * 1024;
-  constexpr uint32_t maxCellsPerHit = 128;
+  constexpr uint32_t maxCellsPerHit = 256;
 #endif  // GPU_SMALL_EVENTS
 #endif  // ONLY_PHICUT
   constexpr uint32_t maxNumOfActiveDoublets = maxNumberOfDoublets / 8;


### PR DESCRIPTION
This PR include changes needed to avoid overflow while running the patatrack pixel tracking on HIon HLT menu using 2018 PbPb data.

The changes increase the thresholds of the following CA constants:

    maxNumberOfTuples : increased from 24 * 1024 to 32 * 1024 to avoid overflow on number of tuples.
    maxCellsPerHit : increased from 128 to 256 to avoid overflow on OuterHitOfCell.

PR validation:

The changes were tested on 2018 PbPb data using the HardProbe PDs.
if this PR is a backport please specify the original PR and why you need to backport that PR:

@fwyzard