### PR TITLE
[GCC11] CalibPPS/AlignmentRelative: Fix warning: …

### DIFF
--- a/CalibPPS/AlignmentRelative/src/AlignmentTask.cc
+++ b/CalibPPS/AlignmentRelative/src/AlignmentTask.cc
@@ -531,8 +531,8 @@ void AlignmentTask::buildEqualMeanUMeanVRotZConstraints(vector<AlignmentConstrai
     }
 
     for (auto &&proj : {"U", "V"}) {
-      const auto &planes = (proj == "U") ? p.second.first : p.second.second;
-      const double c = ((proj == "U") ? -1. : +1.) / planes.size();
+      const auto &planes = (proj == string("U")) ? p.second.first : p.second.second;
+      const double c = ((proj == string("U")) ? -1. : +1.) / planes.size();
 
       for (const auto &plane : planes) {
         signed int qIdx = getQuantityIndex(qcRotZ, plane);

--- a/CalibPPS/AlignmentRelative/src/AlignmentTask.cc
+++ b/CalibPPS/AlignmentRelative/src/AlignmentTask.cc
@@ -530,7 +530,7 @@ void AlignmentTask::buildEqualMeanUMeanVRotZConstraints(vector<AlignmentConstrai
       ac.coef[qcit].Zero();
     }
 
-    for (const string &proj : {"U", "V"}) {
+    for (auto &&proj : {"U", "V"}) {
       const auto &planes = (proj == "U") ? p.second.first : p.second.second;
       const double c = ((proj == "U") ? -1. : +1.) / planes.size();
 


### PR DESCRIPTION
... loop variable binds to a temporary

#### PR description:

Log file: https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc11/CMSSW_12_1_X_2021-08-24-0900/CalibPPS/AlignmentRelative
```
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/4bd5e72fc80f5d28d5e366db42a7dbd6/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-08-24-0900/src/CalibPPS/AlignmentRelative/src/AlignmentTask.cc: In member function 'void AlignmentTask::buildEqualMeanUMeanVRotZConstraints(std::vector<AlignmentConstraint>&) const':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/4bd5e72fc80f5d28d5e366db42a7dbd6/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_1_X_2021-08-24-0900/src/CalibPPS/AlignmentRelative/src/AlignmentTask.cc:533:24: warning: loop variable 'proj' of type 'const string&' {aka 'const std::__cxx11::basic_string<char>&'} binds to a temporary constructed from type 'const char* const' [-Wrange-loop-construct]
   533 |     for (const string &proj : {"U", "V"}) {
      |                        ^~~~
```

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
