### PR TITLE
Use pdigi_hi_nogen for HI MC wfs

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -669,7 +669,7 @@ baseDataSetRelease=[
     'CMSSW_10_6_0-PU25ns_106X_upgrade2018_realistic_v4_FastSim-v1',# 20 - fastSim premix library UP18
     'CMSSW_10_6_0-106X_mc2017_realistic_v3-v1',         # 21 - GEN-SIM inputs for LHE-GEN-SIM 2017 workflows
     'CMSSW_10_6_0-106X_upgrade2018_realistic_v4-v1',            # 22 - GEN-SIM inputs for LHE-GEN-SIM 2018 workflows
-    'CMSSW_11_2_0_pre8-112X_mcRun3_2021_realistic_HI_v11-v1',    #23 - Run3 HI GEN-SIM for mixing
+    'CMSSW_12_1_0_pre4-121X_mcRun3_2021_realistic_HI_v10-v1',    #23 - Run3 HI GEN-SIM for mixing
     'CMSSW_11_2_0_pre8-PU_112X_upgrade2018_realistic_v4-v1', # 24 - 2018 Run-Dependent premix library
     ]
 
@@ -2551,6 +2551,19 @@ steps['RECOHI2018PPRECOMB']=merge([hiDefaults2018_ppReco,{'-s':'RAW2DIGI,L1Reco,
                                                           '--procModifiers':'genJetSubEvent',
                                                       },step3Up2015Defaults])
 
+steps['RECOHI2021MIX']=merge([hiDefaults2021_ppReco,{'-s':'RAW2DIGI,L1Reco,RECO,EI,PAT,VALIDATION:@standardValidationNoHLTHiMix+@miniAODValidation,DQM:@standardDQMFakeHLT+@miniAODDQM',
+                                                     '--pileup':'HiMix',
+                                                     '--pileup_input':'das:/RelValHydjetQ_B12_5020GeV_2021_ppReco/%s/GEN-SIM'%(baseDataSetRelease[23])
+                                                 },step3Up2015Defaults])
+
+
+steps['RECOHIMIX']=merge([hiDefaults2018_ppReco,{'-s':'RAW2DIGI,L1Reco,RECO,EI,PAT,VALIDATION:@standardValidationNoHLTHiMix+@miniAODValidation,DQM:@standardDQMFakeHLT+@miniAODDQM',
+                                                 '--era':'Run2_2018_pp_on_AA',
+                                                 '--pileup':'HiMix',
+                                                 '--pileup_input':'das:/RelValHydjetQ_B12_5020GeV_2018/%s/GEN-SIM'%(baseDataSetRelease[9])
+                                             },step3Up2015Defaults])
+
+
 steps['REMINIAODHI2018PPRECO']=merge([{'-s':'PAT,VALIDATION:@miniAODValidation,DQM:@miniAODDQM',
                                        '--datatier':'MINIAODSIM,DQMIO',
                                        '--eventcontent':'MINIAODSIM,DQM',
@@ -2720,8 +2733,6 @@ steps['ALCAHARVDTE']={'-s':'ALCAHARVEST:%s'%(autoPCL['PromptCalibProdEcalPedesta
                      '--filein':'file:PromptCalibProdEcalPedestals.root'}
 
 steps['RECOHISt4']=steps['RECOHI2015']
-steps['RECOHI2021MIX']=merge([steps['RECOHI2021PPRECO'],{'--pileup':'HiMix','--pileup_input':'das:/RelValHydjetQ_B12_5020GeV_2021_ppReco/%s/GEN-SIM'%(baseDataSetRelease[23])}])
-steps['RECOHIMIX']=merge([steps['RECOHI2018PPRECO'],{'--pileup':'HiMix','--pileup_input':'das:/RelValHydjetQ_B12_5020GeV_2018/%s/GEN-SIM'%(baseDataSetRelease[9])}])
 
 steps['ALCANZS']=merge([{'-s':'ALCA:HcalCalMinBias','--mc':''},step4Defaults])
 steps['HARVESTGEN']={'-s':'HARVESTING:genHarvesting',

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1717,14 +1717,14 @@ steps['RESIM']=merge([{'-s':'reGEN,reSIM','-n':10},steps['DIGI']])
 #steps['RESIMDIGI']=merge([{'-s':'reGEN,reSIM,DIGI,L1,DIGI2RAW,HLT:@fake,RAW2DIGI,L1Reco','-n':10,'--restoreRNDSeeds':'','--process':'HLT'},steps['DIGI']])
 
 
-steps['DIGIHI2021PPRECO']=merge([{'-s':'DIGI:pdigi_hi,L1,DIGI2RAW,HLT:@fake2'}, hiDefaults2021_ppReco, {'--pileup':'HiMixNoPU'}, step2Upg2015Defaults])
-steps['DIGIHI2018PPRECO']=merge([{'-s':'DIGI:pdigi_hi,L1,DIGI2RAW,HLT:HIon'}, hiDefaults2018_ppReco, {'--pileup':'HiMixNoPU'}, step2Upg2015Defaults])
-steps['DIGIHI2018']=merge([{'-s':'DIGI:pdigi_hi,L1,DIGI2RAW,HLT:@fake2'}, hiDefaults2018, {'--pileup':'HiMixNoPU'}, step2Upg2015Defaults])
-steps['DIGIHI2017']=merge([{'-s':'DIGI:pdigi_hi,L1,DIGI2RAW,HLT:@fake2'}, hiDefaults2017, step2Upg2015Defaults])
-steps['DIGIHI2015']=merge([{'-s':'DIGI:pdigi_hi,L1,DIGI2RAW,HLT:@fake'}, hiDefaults2015, {'--pileup':'HiMixNoPU'}, step2Upg2015Defaults])
-steps['DIGIHI2011']=merge([{'-s':'DIGI:pdigi_hi,L1,DIGI2RAW,HLT:@fake'}, hiDefaults2011, {'--pileup':'HiMixNoPU'}, step2Defaults])
-steps['DIGIHI2021MIX']=merge([{'-s':'DIGI:pdigi_hi,L1,DIGI2RAW,HLT:@fake2', '-n':2}, hiDefaults2021_ppReco, {'--pileup':'HiMix'}, PUHI2021, step2Upg2015Defaults])
-steps['DIGIHIMIX']=merge([{'-s':'DIGI:pdigi_hi,L1,DIGI2RAW,HLT:@fake2', '-n':2}, hiDefaults2018_ppReco, {'--pileup':'HiMix'}, PUHI, step2Upg2015Defaults])
+steps['DIGIHI2021PPRECO']=merge([{'-s':'DIGI:pdigi_hi_nogen,L1,DIGI2RAW,HLT:@fake2'}, hiDefaults2021_ppReco, {'--pileup':'HiMixNoPU'}, step2Upg2015Defaults])
+steps['DIGIHI2018PPRECO']=merge([{'-s':'DIGI:pdigi_hi_nogen,L1,DIGI2RAW,HLT:HIon'}, hiDefaults2018_ppReco, {'--pileup':'HiMixNoPU'}, step2Upg2015Defaults])
+steps['DIGIHI2018']=merge([{'-s':'DIGI:pdigi_hi_nogen,L1,DIGI2RAW,HLT:@fake2'}, hiDefaults2018, {'--pileup':'HiMixNoPU'}, step2Upg2015Defaults])
+steps['DIGIHI2017']=merge([{'-s':'DIGI:pdigi_hi_nogen,L1,DIGI2RAW,HLT:@fake2'}, hiDefaults2017, step2Upg2015Defaults])
+steps['DIGIHI2015']=merge([{'-s':'DIGI:pdigi_hi_nogen,L1,DIGI2RAW,HLT:@fake'}, hiDefaults2015, {'--pileup':'HiMixNoPU'}, step2Upg2015Defaults])
+steps['DIGIHI2011']=merge([{'-s':'DIGI:pdigi_hi_nogen,L1,DIGI2RAW,HLT:@fake'}, hiDefaults2011, {'--pileup':'HiMixNoPU'}, step2Defaults])
+steps['DIGIHI2021MIX']=merge([{'-s':'DIGI:pdigi_hi_nogen,L1,DIGI2RAW,HLT:@fake2', '-n':2}, hiDefaults2021_ppReco, {'--pileup':'HiMix'}, PUHI2021, step2Upg2015Defaults])
+steps['DIGIHIMIX']=merge([{'-s':'DIGI:pdigi_hi_nogen,L1,DIGI2RAW,HLT:@fake2', '-n':2}, hiDefaults2018_ppReco, {'--pileup':'HiMix'}, PUHI, step2Upg2015Defaults])
 
 steps['DIGIPPREF2017']=merge([{'-s':'DIGI:pdigi_valid,L1,DIGI2RAW,HLT:@fake2'}, ppRefDefaults2017, step2Upg2015Defaults])
 

--- a/Configuration/StandardSequences/python/Validation_cff.py
+++ b/Configuration/StandardSequences/python/Validation_cff.py
@@ -56,6 +56,17 @@ validationNoHLT.remove(condDataValidation) # foca d'ovatta !
 validation = cms.Sequence(validationNoHLT
                          *hltvalidation)
 
+validationNoHLTHiMix = cms.Sequence(
+                               genvalid_all_hiMix
+                               *globaldigisanalyze
+                               *globalhitsanalyze
+                               *globalrechitsanalyze
+                               *globalValidation)
+validationNoHLTHiMix.remove(condDataValidation) # foca d'ovatta !
+validationHiMix = cms.Sequence(validationNoHLTHiMix
+                               *hltvalidation)
+
+
 _validation_fastsim = validation.copy()
 for _entry in [globaldigisanalyze,globalhitsanalyze,globalrechitsanalyze,hltvalidation]:
     _validation_fastsim.remove(_entry)

--- a/Validation/Configuration/python/autoValidation.py
+++ b/Validation/Configuration/python/autoValidation.py
@@ -15,6 +15,8 @@ autoValidation = { 'liteTracking' : ['prevalidationLiteTracking','validationLite
                    'miniAODValidation' : ['prevalidationMiniAOD','validationMiniAOD','validationHarvestingMiniAOD'],
                    'standardValidation' : ['prevalidation','validation','validationHarvesting'],
                    'standardValidationNoHLT' : ['prevalidationNoHLT','validationNoHLT','validationHarvestingNoHLT'],
+                   'standardValidationHiMix' : ['prevalidation','validationHiMix','validationHarvesting'],
+                   'standardValidationNoHLTHiMix' : ['prevalidationNoHLT','validationNoHLTHiMix','validationHarvestingNoHLT'],
                    'HGCalValidation' : ['globalPrevalidationHGCal', 'globalValidationHGCal', 'hgcalValidatorPostProcessor'],
                    'MTDValidation' : ['', 'globalValidationMTD', 'mtdValidationPostProcessor'],
                    'OuterTrackerValidation' : ['', 'globalValidationOuterTracker', 'postValidationOuterTracker'],

--- a/Validation/EventGenerator/interface/BasicGenParticleValidation.h
+++ b/Validation/EventGenerator/interface/BasicGenParticleValidation.h
@@ -51,6 +51,7 @@ private:
   double matchPr_;
 
   unsigned int verbosity_;
+  bool signalParticlesOnly_;
 
   MonitorElement *nEvt;
 

--- a/Validation/EventGenerator/plugins/BasicGenParticleValidation.cc
+++ b/Validation/EventGenerator/plugins/BasicGenParticleValidation.cc
@@ -18,7 +18,8 @@ BasicGenParticleValidation::BasicGenParticleValidation(const edm::ParameterSet& 
       genparticleCollection_(iPSet.getParameter<edm::InputTag>("genparticleCollection")),
       genjetCollection_(iPSet.getParameter<edm::InputTag>("genjetsCollection")),
       matchPr_(iPSet.getParameter<double>("matchingPrecision")),
-      verbosity_(iPSet.getUntrackedParameter<unsigned int>("verbosity", 0)) {
+      verbosity_(iPSet.getUntrackedParameter<unsigned int>("verbosity", 0)),
+      signalParticlesOnly_(iPSet.getParameter<bool>("signalParticlesOnly")) {
   hepmcCollectionToken_ = consumes<HepMCProduct>(hepmcCollection_);
   genparticleCollectionToken_ = consumes<reco::GenParticleCollection>(genparticleCollection_);
   genjetCollectionToken_ = consumes<reco::GenJetCollection>(genjetCollection_);
@@ -147,6 +148,13 @@ void BasicGenParticleValidation::analyze(const edm::Event& iEvent, const edm::Ev
 
   unsigned int nReco = particles.size();
   unsigned int nHepMC = hepmcGPCollection.size();
+
+  if (signalParticlesOnly_) {
+    for (unsigned int i = 0; i < particles.size(); ++i) {
+      if (particles[i]->collisionId() != 0)
+        nReco -= 1;
+    }
+  }
 
   genPMultiplicity->Fill(std::log10(nReco), weight);
 

--- a/Validation/EventGenerator/python/BasicGenParticleValidation_cfi.py
+++ b/Validation/EventGenerator/python/BasicGenParticleValidation_cfi.py
@@ -7,5 +7,8 @@ basicGenParticleValidation = DQMEDAnalyzer('BasicGenParticleValidation',
     genjetsCollection = cms.InputTag("ak4GenJets",""),
     matchingPrecision = cms.double(0.001),
     verbosity = cms.untracked.uint32(0),
-    UseWeightFromHepMC = cms.bool(True)
+    UseWeightFromHepMC = cms.bool(True),
+    signalParticlesOnly = cms.bool(False)
 )
+
+basicGenParticleValidationHiMix = basicGenParticleValidation.clone(signalParticlesOnly = True)

--- a/Validation/EventGenerator/python/BasicGenValidation_cff.py
+++ b/Validation/EventGenerator/python/BasicGenValidation_cff.py
@@ -31,6 +31,7 @@ from Validation.EventGenerator.BPhysicsValidation_cfi  import *
 
 # define sequences...
 basicGenTest_seq = cms.Sequence(basicHepMCValidation+basicGenParticleValidation)
+basicGenTestHiMix_seq = cms.Sequence(basicHepMCValidation+basicGenParticleValidationHiMix)
 duplicationChecker_seq = cms.Sequence(duplicationChecker)
 mbueAndqcdValidation_seq = cms.Sequence(mbueAndqcd_seq)
 drellYanValidation_seq = cms.Sequence(drellYanEleValidation+drellYanMuoValidation)
@@ -50,4 +51,5 @@ genvalid_w = cms.Sequence(basicGenTest_seq+mbueAndqcdValidation_seq+wValidation_
 genvalid_top = cms.Sequence(basicGenTest_seq+mbueAndqcdValidation_seq+TTbarfull_seq)
 genvalid_higgs = cms.Sequence(basicGenTest_seq+mbueAndqcdValidation_seq+higgsvalidation_seq)
 genvalid_all = cms.Sequence(basicGenTest_seq+mbueAndqcdValidation_seq+drellYanValidation_seq+wValidation_seq+tauValidation_seq+TTbarfull_seq+higgsValidation+bphysics)
+genvalid_all_hiMix = cms.Sequence(basicGenTestHiMix_seq+mbueAndqcdValidation_seq+drellYanValidation_seq+wValidation_seq+tauValidation_seq+TTbarfull_seq+higgsValidation+bphysics)
 genvalid_all_and_dup_check = cms.Sequence(duplicationChecker_seq+genvalid_all)


### PR DESCRIPTION
#### PR description:

This PR switches to the DIGI:pdigi_hi_nogen for heavy-ion MC RelVal workflows.

Back in #24199 the option DIGI:pdigi_hi_nogen was introduced.
The previously used pdigi_hi option adds some heavy-ion generator level quantities, such as npart and ncoll, to the output. 
The 'nogen' extension prevents gen collections from being reproduced in the digi step.
Most heavy-ion MC requests use an event overlay workflow, with a crossing frame to mix the gen info from the signal and background events. 
If the gen info is reproduced at the digi step, we lose the gen info from the background event.
The pdigi_hi_nogen has long been the default option in official MC, but we neglected to switch to this option in the RelVal workflows, which occasionally leads to confusion. 
This PR fixes that. 

2nd commit:  A new validation sequence for the heavy-ion event overlay workflow is added.  It ignores genParticles that are not from collisionID = 0 (the signal event)

#### PR validation:

Tested on wf 159 and 301

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport needed


