### PR TITLE
DataFormats/FEDRawData UBSAN warning fixed

### DIFF
--- a/DataFormats/FEDRawData/src/FEDHeader.cc
+++ b/DataFormats/FEDRawData/src/FEDHeader.cc
@@ -34,8 +34,8 @@ void FEDHeader::set(unsigned char* header,
   h->eventid = (FED_SLINK_START_MARKER << FED_HCTRLID_SHIFT) | ((triggerType << FED_EVTY_SHIFT) & FED_EVTY_MASK) |
                ((lvl1ID << FED_LVL1_SHIFT) & FED_LVL1_MASK);
 
-  h->sourceid = ((bxID << FED_BXID_SHIFT) & FED_BXID_MASK) | ((sourceID << FED_SOID_SHIFT) & FED_SOID_MASK) |
-                ((version << FED_VERSION_SHIFT) & FED_VERSION_MASK);
+  h->sourceid = (((bxID & FED_BXID_WIDTH) << FED_BXID_SHIFT) & FED_BXID_MASK) |
+                ((sourceID << FED_SOID_SHIFT) & FED_SOID_MASK) | ((version << FED_VERSION_SHIFT) & FED_VERSION_MASK);
 
   if (moreHeaders)
     h->sourceid |= (FED_MORE_HEADERS_WIDTH << FED_MORE_HEADERS_SHIFT);


### PR DESCRIPTION
Fixes UBSAN warning in:
https://github.com/cms-sw/cmssw/issues/35035
12-bits are used for BX ID in the format, but a wider variable is used in C++ code. When compacted into FED header format, it would be truncated even if non-zero (which should not be the case with bx ID).

#### PR validation:
Behavior of the code doesn't change (operation is equivalent).

Fixes: #35035