### PR TITLE
[GCC11] Fix warning: 'result' is used uninitialized

### DIFF
--- a/SimDataFormats/DigiSimLinks/src/DTDigiSimLink.cc
+++ b/SimDataFormats/DigiSimLinks/src/DTDigiSimLink.cc
@@ -22,7 +22,7 @@ DTDigiSimLink::DTDigiSimLink()
     : theWire(0), theDigiNumber(0), theTDCBase(32), theCounts(0), theSimTrackId(0), theEventId(0) {}
 
 DTDigiSimLink::ChannelType DTDigiSimLink::channel() const {
-  ChannelPacking result = {.wi = theWire, .num = theDigiNumber };
+  ChannelPacking result = {.wi = theWire, .num = theDigiNumber};
   DTDigiSimLink::ChannelType* p_result = reinterpret_cast<DTDigiSimLink::ChannelType*>(&result);
   return *p_result;
 }

--- a/SimDataFormats/DigiSimLinks/src/DTDigiSimLink.cc
+++ b/SimDataFormats/DigiSimLinks/src/DTDigiSimLink.cc
@@ -22,9 +22,7 @@ DTDigiSimLink::DTDigiSimLink()
     : theWire(0), theDigiNumber(0), theTDCBase(32), theCounts(0), theSimTrackId(0), theEventId(0) {}
 
 DTDigiSimLink::ChannelType DTDigiSimLink::channel() const {
-  ChannelPacking result;
-  result.wi = theWire;
-  result.num = theDigiNumber;
+  ChannelPacking result = {.wi = theWire, .num = theDigiNumber };
   DTDigiSimLink::ChannelType* p_result = reinterpret_cast<DTDigiSimLink::ChannelType*>(&result);
   return *p_result;
 }


### PR DESCRIPTION
Log file: https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc11/CMSSW_12_1_X_2021-08-24-0900/SimDataFormats/DigiSimLinks
```
.../src/SimDataFormats/DigiSimLinks/src/DTDigiSimLink.cc: In member function 'DTDigiSimLink::ChannelType DTDigiSimLink::channel() const':
  .../src/SimDataFormats/DigiSimLinks/src/DTDigiSimLink.cc:29:11: warning: 'result' is used uninitialized [-Wuninitialized]
    29 |   return *p_result;
      |           ^~~~~~~~
.../src/SimDataFormats/DigiSimLinks/src/DTDigiSimLink.cc:25:18: note: 'result' declared here
   25 |   ChannelPacking result;
      |                  ^~~~~~
```