### PR TITLE
[GCC11] Fix warning: loop variable binds to temporary

### DIFF
--- a/Validation/CTPPS/plugins/CTPPSProtonReconstructionPlotter.cc
+++ b/Validation/CTPPS/plugins/CTPPSProtonReconstructionPlotter.cc
@@ -504,9 +504,9 @@ CTPPSProtonReconstructionPlotter::CTPPSProtonReconstructionPlotter(const edm::Pa
       p_y_R_diffNF_vs_y_R_N_(new TProfile("p_y_R_diffNF_vs_y_R_N", ";y_{RN};y_{RF} - y_{RN}", 100, -20., +20.)),
 
       n_non_empty_events_(0) {
-  for (const std::string &sector : {"45", "56"}) {
-    const unsigned int arm = (sector == "45") ? 0 : 1;
-    association_cuts_[arm].load(ps.getParameterSet("association_cuts_" + sector));
+  for (auto &&sector : {"45", "56"}) {
+    const unsigned int arm = (sector == string("45")) ? 0 : 1;
+    association_cuts_[arm].load(ps.getParameterSet(string("association_cuts_") + sector));
   }
 }
 


### PR DESCRIPTION
Log file: https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc11/CMSSW_12_1_X_2021-08-24-0900/Validation/CTPPS
```
.../Validation/CTPPS/plugins/CTPPSProtonReconstructionPlotter.cc: In constructor 'CTPPSProtonReconstructionPlotter::CTPPSProtonReconstructionPlotter(const edm::ParameterSet&)':
  .../Validation/CTPPS/plugins/CTPPSProtonReconstructionPlotter.cc:507:27: warning: loop variable 'sector' of type 'const string&' {aka 'const std::__cxx11::basic_string<char>&'} binds to a temporary constructed from type 'const char* const' [-Wrange-loop-construct]
   507 |   for (const std::string &sector : {"45", "56"}) {
      |                           ^~~~~~
```