### PR TITLE
Adding protections to PATTriggerProducer when the path has zero filters: 12_1

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATTriggerProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerProducer.cc
@@ -469,16 +469,22 @@ void PATTriggerProducer::produce(Event& iEvent, const EventSetup& iSetup) {
       for (size_t indexPath = 0; indexPath < sizePaths; ++indexPath) {
         const std::string& namePath = pathNames.at(indexPath);
         unsigned indexLastFilterPathModules(handleTriggerResults->index(indexPath) + 1);
-        while (indexLastFilterPathModules > 0) {
-          --indexLastFilterPathModules;
-          const std::string& labelLastFilterPathModules(hltConfig.moduleLabel(indexPath, indexLastFilterPathModules));
-          unsigned indexLastFilterFilters =
-              handleTriggerEvent->filterIndex(InputTag(labelLastFilterPathModules, "", nameProcess_));
-          if (indexLastFilterFilters < sizeFilters) {
-            if (hltConfig.moduleType(labelLastFilterPathModules) == "HLTBool")
-              continue;
-            break;
+        const unsigned sizeModulesPath(hltConfig.size(indexPath));
+        //protection for paths with zero filters (needed for reco, digi, etc paths)
+        if (sizeModulesPath != 0) {
+          while (indexLastFilterPathModules > 0) {
+            --indexLastFilterPathModules;
+            const std::string& labelLastFilterPathModules(hltConfig.moduleLabel(indexPath, indexLastFilterPathModules));
+            unsigned indexLastFilterFilters =
+                handleTriggerEvent->filterIndex(InputTag(labelLastFilterPathModules, "", nameProcess_));
+            if (indexLastFilterFilters < sizeFilters) {
+              if (hltConfig.moduleType(labelLastFilterPathModules) == "HLTBool")
+                continue;
+              break;
+            }
           }
+        } else {
+          indexLastFilterPathModules = 0;
         }
         TriggerPath triggerPath(namePath,
                                 indexPath,
@@ -489,8 +495,8 @@ void PATTriggerProducer::produce(Event& iEvent, const EventSetup& iSetup) {
                                 indexLastFilterPathModules,
                                 hltConfig.saveTagsModules(namePath).size());
         // add module names to path and states' map
-        const unsigned sizeModulesPath(hltConfig.size(indexPath));
-        assert(indexLastFilterPathModules < sizeModulesPath);
+
+        assert(indexLastFilterPathModules < sizeModulesPath || sizeModulesPath == 0);
         std::map<unsigned, std::string> indicesModules;
         for (size_t iM = 0; iM < sizeModulesPath; ++iM) {
           const std::string& nameModule(hltConfig.moduleLabel(indexPath, iM));


### PR DESCRIPTION
#### PR description:

As reported by @aescalante , PATTriggerProducer throws an out of bounds exception when run in " onlyStandAlone = cms.bool(False)" mode. 

This is because there code assumes an HLT path will have at least one filter and has no protections for the case of a path having no filters. While this assumption seems reasonable, all HLT paths should have at least one filter (eg a prescale module) although personally I wouldnt assume this, in practice it fails as things like reconstruction_step and digi_step are also paths and have no filters

Therefore if PATTriggerProducer is run on data in full mode where the HLT was run together with other steps, it will fail.  Note in production we use onlyStandAlone=True

This PR checks that a path has filters before accessing them. 

No physics changes are expected, only  changes is now workflows that crashed should now succeed. 

#### PR validation:

Test config from Alberto now runs.

