### PR TITLE
[GCC11] Fix warnings: loop variable binds to a temporary

### DIFF
--- a/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
+++ b/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
@@ -112,8 +112,8 @@ void QGLikelihoodDBWriter::beginJob() {
 
   // The ROOT file contains the binning for each variable, needed to set up the binning grid
   std::map<TString, std::vector<float>> gridOfBins;
-  for (const TString& binVariable : {"eta", "pt", "rho"}) {
-    if (!getVectorFromFile(f, gridOfBins[binVariable], binVariable + "Bins")) {
+  for (auto &&binVariable : {"eta", "pt", "rho"}) {
+    if (!getVectorFromFile(f, gridOfBins[binVariable], TString(binVariable) + "Bins")) {
       edm::LogError("NoBins") << "Missing bin information for " << binVariable << " in input file" << std::endl;
       return;
     }
@@ -124,13 +124,13 @@ void QGLikelihoodDBWriter::beginJob() {
   // Here we do not store the copies, but try to extend the range of the neighbouring category (will result in less comparisons during application phase)
   std::map<std::vector<int>, TH1*> pdfs;
   std::map<std::vector<int>, QGLikelihoodCategory> categories;
-  for (const TString& type : {"gluon", "quark"}) {
-    int qgIndex = (type == "gluon");  // Keep numbering same as in RecoJets/JetAlgorithms/src/QGLikelihoodCalculator.cc
-    for (const TString& likelihoodVar : {"mult", "ptD", "axis2"}) {
+  for (auto &&type : {"gluon", "quark"}) {
+    int qgIndex = (TString(type) == "gluon");  // Keep numbering same as in RecoJets/JetAlgorithms/src/QGLikelihoodCalculator.cc
+    for (auto &&likelihoodVar : {"mult", "ptD", "axis2"}) {
       int varIndex =
-          (likelihoodVar == "mult"
+          (TString(likelihoodVar) == "mult"
                ? 0
-               : (likelihoodVar == "ptD" ? 1 : 2));  // Keep order same as in RecoJets/JetProducers/plugins/QGTagger.cc
+               : (TString(likelihoodVar) == "ptD" ? 1 : 2));  // Keep order same as in RecoJets/JetProducers/plugins/QGTagger.cc
       for (int i = 0; i < (int)gridOfBins["eta"].size() - 1; ++i) {
         for (int j = 0; j < (int)gridOfBins["pt"].size() - 1; ++j) {
           for (int k = 0; k < (int)gridOfBins["rho"].size() - 1; ++k) {
@@ -144,8 +144,8 @@ void QGLikelihoodDBWriter::beginJob() {
             category.QGIndex = qgIndex;
             category.VarIndex = varIndex;
 
-            TString key =
-                TString::Format(likelihoodVar + "/" + likelihoodVar + "_" + type + "_eta%d_pt%d_rho%d", i, j, k);
+            TString key =                
+                TString::Format("%s/%s_%s_eta%d_pt%d_rho%d", likelihoodVar, likelihoodVar, type, i, j, k);
             TH1* pdf = (TH1*)f->Get(key);
             if (!pdf) {
               edm::LogError("NoPDF") << "Could not found pdf with key  " << key << " in input file" << std::endl;

--- a/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
+++ b/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
@@ -127,7 +127,7 @@ void QGLikelihoodDBWriter::beginJob() {
   std::map<std::vector<int>, QGLikelihoodCategory> categories;
   for (auto&& type : {"gluon", "quark"}) {
     // Keep numbering same as in RecoJets/JetAlgorithms/src/QGLikelihoodCalculator.cc
-    int qgIndex = strcpm(type, "gluon") == 0 ? 1 : 0;
+    int qgIndex = strcmp(type, "gluon") == 0 ? 1 : 0;
     for (auto&& likelihoodVar : {"mult", "ptD", "axis2"}) {
       // Keep order same as in RecoJets/JetProducers/plugins/QGTagger.cc
       int varIndex = (strcmp(likelihoodVar, "mult") == 0

--- a/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
+++ b/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
@@ -112,7 +112,7 @@ void QGLikelihoodDBWriter::beginJob() {
 
   // The ROOT file contains the binning for each variable, needed to set up the binning grid
   std::map<TString, std::vector<float>> gridOfBins;
-  for (auto &&binVariable : {"eta", "pt", "rho"}) {
+  for (auto&& binVariable : {"eta", "pt", "rho"}) {
     if (!getVectorFromFile(f, gridOfBins[binVariable], TString(binVariable) + "Bins")) {
       edm::LogError("NoBins") << "Missing bin information for " << binVariable << " in input file" << std::endl;
       return;
@@ -124,9 +124,9 @@ void QGLikelihoodDBWriter::beginJob() {
   // Here we do not store the copies, but try to extend the range of the neighbouring category (will result in less comparisons during application phase)
   std::map<std::vector<int>, TH1*> pdfs;
   std::map<std::vector<int>, QGLikelihoodCategory> categories;
-  for (auto &&type : {"gluon", "quark"}) {
+  for (auto&& type : {"gluon", "quark"}) {
     int qgIndex = (TString(type) == "gluon");  // Keep numbering same as in RecoJets/JetAlgorithms/src/QGLikelihoodCalculator.cc
-    for (auto &&likelihoodVar : {"mult", "ptD", "axis2"}) {
+    for (auto&& likelihoodVar : {"mult", "ptD", "axis2"}) {
       int varIndex =
           (TString(likelihoodVar) == "mult"
                ? 0
@@ -144,8 +144,7 @@ void QGLikelihoodDBWriter::beginJob() {
             category.QGIndex = qgIndex;
             category.VarIndex = varIndex;
 
-            TString key =                
-                TString::Format("%s/%s_%s_eta%d_pt%d_rho%d", likelihoodVar, likelihoodVar, type, i, j, k);
+            TString key = TString::Format("%s/%s_%s_eta%d_pt%d_rho%d", likelihoodVar, likelihoodVar, type, i, j, k);
             TH1* pdf = (TH1*)f->Get(key);
             if (!pdf) {
               edm::LogError("NoPDF") << "Could not found pdf with key  " << key << " in input file" << std::endl;

--- a/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
+++ b/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
@@ -125,12 +125,14 @@ void QGLikelihoodDBWriter::beginJob() {
   std::map<std::vector<int>, TH1*> pdfs;
   std::map<std::vector<int>, QGLikelihoodCategory> categories;
   for (auto&& type : {"gluon", "quark"}) {
-    int qgIndex = (TString(type) == "gluon");  // Keep numbering same as in RecoJets/JetAlgorithms/src/QGLikelihoodCalculator.cc
+    int qgIndex =
+        (TString(type) == "gluon");  // Keep numbering same as in RecoJets/JetAlgorithms/src/QGLikelihoodCalculator.cc
     for (auto&& likelihoodVar : {"mult", "ptD", "axis2"}) {
-      int varIndex =
-          (TString(likelihoodVar) == "mult"
-               ? 0
-               : (TString(likelihoodVar) == "ptD" ? 1 : 2));  // Keep order same as in RecoJets/JetProducers/plugins/QGTagger.cc
+      int varIndex = (TString(likelihoodVar) == "mult"
+                          ? 0
+                          : (TString(likelihoodVar) == "ptD"
+                                 ? 1
+                                 : 2));  // Keep order same as in RecoJets/JetProducers/plugins/QGTagger.cc
       for (int i = 0; i < (int)gridOfBins["eta"].size() - 1; ++i) {
         for (int j = 0; j < (int)gridOfBins["pt"].size() - 1; ++j) {
           for (int k = 0; k < (int)gridOfBins["rho"].size() - 1; ++k) {

--- a/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
+++ b/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
@@ -126,8 +126,8 @@ void QGLikelihoodDBWriter::beginJob() {
   std::map<std::vector<int>, TH1*> pdfs;
   std::map<std::vector<int>, QGLikelihoodCategory> categories;
   for (auto&& type : {"gluon", "quark"}) {
+    // Keep numbering same as in RecoJets/JetAlgorithms/src/QGLikelihoodCalculator.cc
     int qgIndex = strcpm(type, "gluon") == 0 ? 1 : 0;
-        (TString(type) == "gluon");  // Keep numbering same as in RecoJets/JetAlgorithms/src/QGLikelihoodCalculator.cc
     for (auto&& likelihoodVar : {"mult", "ptD", "axis2"}) {
       // Keep order same as in RecoJets/JetProducers/plugins/QGTagger.cc
       int varIndex = (strcmp(likelihoodVar, "mult") == 0

--- a/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
+++ b/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
@@ -129,11 +129,11 @@ void QGLikelihoodDBWriter::beginJob() {
     int qgIndex = strcpm(type, "gluon") == 0 ? 1 : 0;
         (TString(type) == "gluon");  // Keep numbering same as in RecoJets/JetAlgorithms/src/QGLikelihoodCalculator.cc
     for (auto&& likelihoodVar : {"mult", "ptD", "axis2"}) {
+      // Keep order same as in RecoJets/JetProducers/plugins/QGTagger.cc
       int varIndex = (strcmp(likelihoodVar, "mult") == 0
                           ? 0
                           : (strcmp(likelihoodVar, "ptD") == 0
-                                 ? 1
-                                 : 2));  // Keep order same as in RecoJets/JetProducers/plugins/QGTagger.cc
+                                 ? 1 : 2));        
       for (int i = 0; i < (int)gridOfBins["eta"].size() - 1; ++i) {
         for (int j = 0; j < (int)gridOfBins["pt"].size() - 1; ++j) {
           for (int k = 0; k < (int)gridOfBins["rho"].size() - 1; ++k) {

--- a/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
+++ b/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
@@ -11,6 +11,7 @@
 #include <vector>
 #include <memory>
 #include <string>
+#include <string.h>
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -125,12 +126,12 @@ void QGLikelihoodDBWriter::beginJob() {
   std::map<std::vector<int>, TH1*> pdfs;
   std::map<std::vector<int>, QGLikelihoodCategory> categories;
   for (auto&& type : {"gluon", "quark"}) {
-    int qgIndex =
+    int qgIndex = strcpm(type, "gluon") == 0 ? 1 : 0;
         (TString(type) == "gluon");  // Keep numbering same as in RecoJets/JetAlgorithms/src/QGLikelihoodCalculator.cc
     for (auto&& likelihoodVar : {"mult", "ptD", "axis2"}) {
-      int varIndex = (TString(likelihoodVar) == "mult"
+      int varIndex = (strcmp(likelihoodVar, "mult") == 0
                           ? 0
-                          : (TString(likelihoodVar) == "ptD"
+                          : (strcmp(likelihoodVar, "ptD") == 0
                                  ? 1
                                  : 2));  // Keep order same as in RecoJets/JetProducers/plugins/QGTagger.cc
       for (int i = 0; i < (int)gridOfBins["eta"].size() - 1; ++i) {

--- a/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
+++ b/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
@@ -1,26 +1,26 @@
 // Author: Benedikt Hegner, Tom Cornelis
 // Email:  benedikt.hegner@cern.ch, tom.cornelis@cern.ch
 
-#include "TFile.h"
-#include "TVector.h"
-#include "TList.h"
-#include "TKey.h"
-#include "TH1.h"
-#include <sstream>
-#include <cstdlib>
-#include <vector>
-#include <memory>
-#include <string>
-#include <string.h>
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 #include "CondFormats/JetMETObjects/interface/QGLikelihoodObject.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "TFile.h"
+#include "TH1.h"
+#include "TKey.h"
+#include "TList.h"
+#include "TVector.h"
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
 
 class QGLikelihoodDBWriter : public edm::EDAnalyzer {
 public:
@@ -130,10 +130,7 @@ void QGLikelihoodDBWriter::beginJob() {
     int qgIndex = strcmp(type, "gluon") == 0 ? 1 : 0;
     for (auto&& likelihoodVar : {"mult", "ptD", "axis2"}) {
       // Keep order same as in RecoJets/JetProducers/plugins/QGTagger.cc
-      int varIndex = (strcmp(likelihoodVar, "mult") == 0
-                          ? 0
-                          : (strcmp(likelihoodVar, "ptD") == 0
-                                 ? 1 : 2));        
+      int varIndex = (strcmp(likelihoodVar, "mult") == 0 ? 0 : (strcmp(likelihoodVar, "ptD") == 0 ? 1 : 2));
       for (int i = 0; i < (int)gridOfBins["eta"].size() - 1; ++i) {
         for (int j = 0; j < (int)gridOfBins["pt"].size() - 1; ++j) {
           for (int k = 0; k < (int)gridOfBins["rho"].size() - 1; ++k) {


### PR DESCRIPTION
Log file: https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc11/CMSSW_12_1_X_2021-08-24-0900/JetMETCorrections/Modules
```
 .../JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc:115:23: warning: loop variable 'binVariable' of type 'const TString&' binds to a temporary constructed from type 'const char* const' [-Wrange-loop-construct]
   115 |   for (const TString& binVariable : {"eta", "pt", "rho"}) {
      |                       ^~~~~~~~~~~
.../JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc:115:23: note: use non-reference type 'const TString' to make the copy explicit or 'const char* const&' to prevent copying
 .../JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc:127:23: warning: loop variable 'type' of type 'const TString&' binds to a temporary constructed from type 'const char* const' [-Wrange-loop-construct]
   127 |   for (const TString& type : {"gluon", "quark"}) {
      |                       ^~~~
.../JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc:127:23: note: use non-reference type 'const TString' to make the copy explicit or 'const char* const&' to prevent copying
 .../JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc:129:25: warning: loop variable 'likelihoodVar' of type 'const TString&' binds to a temporary constructed from type 'const char* const' [-Wrange-loop-construct]
   129 |     for (const TString& likelihoodVar : {"mult", "ptD", "axis2"}) {
      |                         ^~~~~~~~~~~~~
```