### PR TITLE
[GCC11] Fix warning: loop variable creates a copy

### DIFF
--- a/FWCore/Framework/test/stubs/ToyIntProducers.cc
+++ b/FWCore/Framework/test/stubs/ToyIntProducers.cc
@@ -457,7 +457,7 @@ namespace edmtest {
     }
 
     // EventSetup is not used.
-    for (auto const tv : tokenValues_) {
+    for (auto const& tv : tokenValues_) {
       e.emplace(tv.token, tv.value);
     }
   }


### PR DESCRIPTION
Log file: https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc11/CMSSW_12_1_X_2021-08-24-0900/FWCore/Framework
```
  .../FWCore/Framework/test/stubs/ToyIntProducers.cc:460:21: warning: loop variable 'tv' creates a copy from type 'const edmtest::ManyIntProducer::TokenValue' [-Wrange-loop-construct]
   460 |     for (auto const tv : tokenValues_) {
      |                     ^~
.../FWCore/Framework/test/stubs/ToyIntProducers.cc:460:21: note: use reference type to prevent copying
  460 |     for (auto const tv : tokenValues_) {
      |                     ^~
      |                     &
```