### PR TITLE
Revert "Fixed destruction of Geant4 simulation"

### DIFF
--- a/SimG4Core/Application/src/OscarMTMasterThread.cc
+++ b/SimG4Core/Application/src/OscarMTMasterThread.cc
@@ -184,6 +184,7 @@ void OscarMTMasterThread::stopThread() {
   // the G4 master thread can do the cleanup. Then notify the master
   // thread, and join it.
   std::unique_lock<std::mutex> lk2(m_threadMutex);
+  m_runManagerMaster.reset();
   LogDebug("OscarMTMasterThread") << "Main thread: reseted shared_ptr";
 
   m_masterThreadState = ThreadState::Destruct;


### PR DESCRIPTION
Reverts cms-sw/cmssw#35002  as this seems to cause IB failures,  see discussed in #35002 