### PR TITLE
Centralise payload ptr ownership for condition updating workflows

### DIFF
--- a/CalibCalorimetry/CaloMiscalibTools/plugins/WriteEcalMiscalibConstants.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/plugins/WriteEcalMiscalibConstants.cc
@@ -69,12 +69,12 @@ void WriteEcalMiscalibConstants::analyze(const edm::Event& iEvent, const edm::Ev
   if (poolDbService.isAvailable()) {
     if (poolDbService->isNewTagRequest(newTagRequest_)) {
       std::cout << " Creating a  new one " << std::endl;
-      poolDbService->createNewIOV<const EcalIntercalibConstants>(
-          Mcal, poolDbService->beginOfTime(), poolDbService->endOfTime(), newTagRequest_);
+      poolDbService->createNewIOV<const EcalIntercalibConstants>(*Mcal, poolDbService->beginOfTime(), newTagRequest_);
       std::cout << "Done" << std::endl;
     } else {
       std::cout << "Old One " << std::endl;
-      poolDbService->appendSinceTime<const EcalIntercalibConstants>(Mcal, poolDbService->currentTime(), newTagRequest_);
+      poolDbService->appendSinceTime<const EcalIntercalibConstants>(
+          *Mcal, poolDbService->currentTime(), newTagRequest_);
     }
   }
 }

--- a/CalibCalorimetry/CaloMiscalibTools/plugins/WriteEcalMiscalibConstantsMC.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/plugins/WriteEcalMiscalibConstantsMC.cc
@@ -69,13 +69,12 @@ void WriteEcalMiscalibConstantsMC::analyze(const edm::Event& iEvent, const edm::
   if (poolDbService.isAvailable()) {
     if (poolDbService->isNewTagRequest(newTagRequest_)) {
       std::cout << " Creating a  new one " << std::endl;
-      poolDbService->createNewIOV<const EcalIntercalibConstantsMC>(
-          Mcal, poolDbService->beginOfTime(), poolDbService->endOfTime(), newTagRequest_);
+      poolDbService->createNewIOV<const EcalIntercalibConstantsMC>(*Mcal, poolDbService->beginOfTime(), newTagRequest_);
       std::cout << "Done" << std::endl;
     } else {
       std::cout << "Old One " << std::endl;
       poolDbService->appendSinceTime<const EcalIntercalibConstantsMC>(
-          Mcal, poolDbService->currentTime(), newTagRequest_);
+          *Mcal, poolDbService->currentTime(), newTagRequest_);
     }
   }
 }

--- a/CalibTracker/SiPixelQuality/plugins/SiPixelStatusHarvester.cc
+++ b/CalibTracker/SiPixelQuality/plugins/SiPixelStatusHarvester.cc
@@ -194,7 +194,7 @@ void SiPixelStatusHarvester::dqmEndRun(const edm::Run& iRun, const edm::EventSet
     }
     if (debug_ == true) {  // only produced for debugging reason
       cond::Time_t thisIOV = (cond::Time_t)iRun.id().run();
-      poolDbService->writeOne<SiPixelQuality>(siPixelQualityPermBad, thisIOV, recordName_ + "_permanentBad");
+      poolDbService->writeOne<SiPixelQuality>(*siPixelQualityPermBad, thisIOV, recordName_ + "_permanentBad");
     }
 
     // IOV for final payloads. FEDerror25 and pcl
@@ -298,7 +298,7 @@ void SiPixelStatusHarvester::dqmEndRun(const edm::Run& iRun, const edm::EventSet
       fedError25IOV[it->first] = it->first;
 
       if (debug_ == true)  // only produced for debugging reason
-        poolDbService->writeOne<SiPixelQuality>(siPixelQuality_FEDerror25, thisIOV, recordName_ + "_FEDerror25");
+        poolDbService->writeOne<SiPixelQuality>(*siPixelQuality_FEDerror25, thisIOV, recordName_ + "_FEDerror25");
 
       delete siPixelQuality_FEDerror25;
     }
@@ -556,12 +556,12 @@ void SiPixelStatusHarvester::dqmEndRun(const edm::Run& iRun, const edm::EventSet
       edm::LuminosityBlockID lu(iRun.id().run(), endLumiBlock_ + 1);
       cond::Time_t thisIOV = (cond::Time_t)(lu.value());
       if (!SiPixelStatusHarvester::equal(lastPrompt, siPixelQualityPermBad))
-        poolDbService->writeOne<SiPixelQuality>(siPixelQualityPermBad, thisIOV, recordName_ + "_prompt");
+        poolDbService->writeOne<SiPixelQuality>(*siPixelQualityPermBad, thisIOV, recordName_ + "_prompt");
 
       // add empty bad components to last lumi+1 IF AND ONLY IF the last payload of other is not equal to empty
       SiPixelQuality* siPixelQualityDummy = new SiPixelQuality();
       if (!SiPixelStatusHarvester::equal(lastOther, siPixelQualityDummy))
-        poolDbService->writeOne<SiPixelQuality>(siPixelQualityDummy, thisIOV, recordName_ + "_other");
+        poolDbService->writeOne<SiPixelQuality>(*siPixelQualityDummy, thisIOV, recordName_ + "_other");
 
       delete siPixelQualityDummy;
     }
@@ -657,12 +657,12 @@ void SiPixelStatusHarvester::constructTag(std::map<int, SiPixelQuality*> siPixel
 
     SiPixelQuality* thisPayload = qIt->second;
     if (qIt == siPixelQualityTag.begin())
-      poolDbService->writeOne<SiPixelQuality>(thisPayload, thisIOV, recordName_ + "_" + tagName);
+      poolDbService->writeOne<SiPixelQuality>(*thisPayload, thisIOV, recordName_ + "_" + tagName);
     else {
       SiPixelQuality* prevPayload = (std::prev(qIt))->second;
       if (!SiPixelStatusHarvester::equal(thisPayload,
                                          prevPayload))  // only append newIOV if this payload differs wrt last
-        poolDbService->writeOne<SiPixelQuality>(thisPayload, thisIOV, recordName_ + "_" + tagName);
+        poolDbService->writeOne<SiPixelQuality>(*thisPayload, thisIOV, recordName_ + "_" + tagName);
     }
   }
 }

--- a/CalibTracker/SiStripESProducers/plugins/DBWriter/DummyCondDBWriter.h
+++ b/CalibTracker/SiStripESProducers/plugins/DBWriter/DummyCondDBWriter.h
@@ -68,7 +68,7 @@ void DummyCondDBWriter<TObject, TObjectO, TRecord>::endRun(const edm::Run& run, 
     else
       Time_ = iConfig_.getUntrackedParameter<uint32_t>("OpenIovAtTime", 1);
 
-    dbservice->writeOne(obj.release(), Time_, rcdName);
+    dbservice->writeOne(*obj, Time_, rcdName);
   } else {
     edm::LogError("SiStripFedCablingBuilder") << "Service is unavailable" << std::endl;
   }

--- a/CalibTracker/SiStripESProducers/plugins/DBWriter/SiStripFedCablingManipulator.cc
+++ b/CalibTracker/SiStripESProducers/plugins/DBWriter/SiStripFedCablingManipulator.cc
@@ -41,12 +41,12 @@ void SiStripFedCablingManipulator::endRun(const edm::Run& run, const edm::EventS
       edm::LogInfo("SiStripFedCablingManipulator") << "first request for storing objects with Record "
                                                    << "SiStripFedCablingRcd"
                                                    << " at time " << Time_ << std::endl;
-      dbservice->createNewIOV<SiStripFedCabling>(obj.release(), Time_, dbservice->endOfTime(), "SiStripFedCablingRcd");
+      dbservice->createNewIOV<SiStripFedCabling>(*obj, Time_, "SiStripFedCablingRcd");
     } else {
       edm::LogInfo("SiStripFedCablingManipulator") << "appending a new object to existing tag "
                                                    << "SiStripFedCablingRcd"
                                                    << " in since mode " << std::endl;
-      dbservice->appendSinceTime<SiStripFedCabling>(obj.release(), Time_, "SiStripFedCablingRcd");
+      dbservice->appendSinceTime<SiStripFedCabling>(*obj, Time_, "SiStripFedCablingRcd");
     }
   } else {
     edm::LogError("SiStripFedCablingManipulator") << "Service is unavailable" << std::endl;

--- a/Calibration/LumiAlCaRecoProducers/plugins/CorrPCCProducer.cc
+++ b/Calibration/LumiAlCaRecoProducers/plugins/CorrPCCProducer.cc
@@ -580,8 +580,6 @@ void CorrPCCProducer::dqmEndRunProduce(edm::Run const& runSeg, const edm::EventS
       throw std::runtime_error("PoolDBService required.");
     }
 
-    delete pccCorrections;
-
     histoFile->cd();
     corrlumiAvg_h->Write();
     scaleFactorAvg_h->Write();

--- a/CommonTools/ConditionDBWriter/interface/ConditionDBWriter.h
+++ b/CommonTools/ConditionDBWriter/interface/ConditionDBWriter.h
@@ -333,7 +333,7 @@ private:
     edm::LogInfo("ConditionDBWriter") << "appending a new object to tag " << Record_ << " in since mode " << std::endl;
 
     // The Framework will take control over the DB object now, therefore the release.
-    mydbservice->writeOne<T>(objPointer.release(), since, Record_);
+    mydbservice->writeOne<T>(*objPointer, since, Record_);
   }
 
   void setTime() {

--- a/CommonTools/ConditionDBWriter/interface/ConditionDBWriter.h
+++ b/CommonTools/ConditionDBWriter/interface/ConditionDBWriter.h
@@ -332,7 +332,6 @@ private:
 
     edm::LogInfo("ConditionDBWriter") << "appending a new object to tag " << Record_ << " in since mode " << std::endl;
 
-    // The Framework will take control over the DB object now, therefore the release.
     mydbservice->writeOne<T>(*objPointer, since, Record_);
   }
 

--- a/CondCore/DBOutputService/interface/OnlineDBOutputService.h
+++ b/CondCore/DBOutputService/interface/OnlineDBOutputService.h
@@ -37,7 +37,7 @@ namespace cond {
 
       //
       template <typename PayloadType>
-      bool writeForNextLumisection(const PayloadType* payload, const std::string& recordName) {
+      bool writeForNextLumisection(const PayloadType& payload, const std::string& recordName) {
         cond::Time_t targetTime = getLastLumiProcessed() + m_latencyInLumisections;
         auto t0 = std::chrono::high_resolution_clock::now();
         logger().logInfo() << "Updating lumisection " << targetTime;
@@ -71,6 +71,15 @@ namespace cond {
         auto t_lat = std::chrono::duration_cast<std::chrono::microseconds>(t4 - t0).count();
         logger().logInfo() << "Total update time: " << t_lat << " microsecs.";
         return ret;
+      }
+
+      //
+      template <typename PayloadType>
+      bool writeForNextLumisection(const PayloadType* payloadPtr, const std::string& recordName) {
+        if (!payloadPtr)
+          throwException("Provided payload pointer is invalid.", "OnlineDBOutputService::writeForNextLumisection");
+        std::unique_ptr<const PayloadType> payload(payloadPtr);
+        return writeForNextLumisection<PayloadType>(*payload, recordName);
       }
 
     private:

--- a/CondCore/DBOutputService/interface/PoolDBOutputService.h
+++ b/CondCore/DBOutputService/interface/PoolDBOutputService.h
@@ -105,7 +105,7 @@ namespace cond {
         return thePayloadHash;
       }
 
-      // warning: takes over the ownership of pointer "payload"
+      // warning: takes over the ownership of pointer "payload". Deprecated. Please move to the above referece-based function
       template <typename T>
       Hash writeOne(const T* payloadPtr, Time_t time, const std::string& recordName) {
         if (!payloadPtr)
@@ -115,7 +115,6 @@ namespace cond {
         return writeOne<T>(*payload, time, recordName);
       }
 
-      // warning: unlike the previous method, do NOT take over the ownership of payload pointers!
       template <typename T>
       void writeMany(const std::map<Time_t, std::shared_ptr<T> >& iovAndPayloads, const std::string& recordName) {
         if (iovAndPayloads.empty())
@@ -192,8 +191,7 @@ namespace cond {
         scope.close();
       }
 
-      // this one we need to avoid to adapt client code around... to be removed in the long term!
-      // warning: takes over the ownership of pointer "payload"
+      // warning: takes over the ownership of pointer "payload" - deprecated. Please move to the above reference-based function
       template <typename T>
       void createNewIOV(const T* payloadPtr, cond::Time_t firstSinceTime, cond::Time_t, const std::string& recordName) {
         if (!payloadPtr)
@@ -220,7 +218,7 @@ namespace cond {
         scope.close();
       }
 
-      // warning: takes over the ownership of pointer "payload"
+      // warning: takes over the ownership of pointer "payload" - deprecated. Please move to the above reference-based function
       template <typename T>
       void appendSinceTime(const T* payloadPtr, cond::Time_t sinceTime, const std::string& recordName) {
         if (!payloadPtr)

--- a/CondCore/DBOutputService/src/PoolDBOutputService.cc
+++ b/CondCore/DBOutputService/src/PoolDBOutputService.cc
@@ -287,10 +287,8 @@ bool cond::service::PoolDBOutputService::appendSinceTime(const std::string& payl
                                                          cond::Time_t time,
                                                          Record& myrecord) {
   m_logger.logInfo() << "Updating existing tag " << myrecord.m_tag << ", adding iov with since " << time;
-  std::string payloadType("");
   try {
     cond::persistency::IOVEditor editor = m_session.editIov(myrecord.m_tag);
-    payloadType = editor.payloadType();
     editor.insert(time, payloadId);
     cond::UserLogInfo a = this->lookUpUserLogInfo(myrecord.m_idName);
     editor.flush(a.usertext);

--- a/CondFormats/MFObjects/test/MagFieldConfigDBWriter.cc
+++ b/CondFormats/MFObjects/test/MagFieldConfigDBWriter.cc
@@ -45,10 +45,10 @@ void MagFieldConfigDBWriter::endJob() {
     try {
       if (dbOutputSvc->isNewTagRequest(record)) {
         //create mode
-        dbOutputSvc->writeOne<MagFieldConfig>(conf, dbOutputSvc->beginOfTime(), record);
+        dbOutputSvc->writeOne<MagFieldConfig>(*conf, dbOutputSvc->beginOfTime(), record);
       } else {
         //append mode. Note: correct PoolDBESSource must be loaded
-        dbOutputSvc->writeOne<MagFieldConfig>(conf, dbOutputSvc->currentTime(), record);
+        dbOutputSvc->writeOne<MagFieldConfig>(*conf, dbOutputSvc->currentTime(), record);
       }
     } catch (const cond::Exception& er) {
       std::cout << er.what() << std::endl;

--- a/CondTools/RunInfo/interface/LHCInfoPopConSourceHandler.h
+++ b/CondTools/RunInfo/interface/LHCInfoPopConSourceHandler.h
@@ -47,7 +47,6 @@ private:
   std::unique_ptr<LHCInfo> m_fillPayload;
   std::shared_ptr<LHCInfo> m_prevPayload;
   std::vector<std::pair<cond::Time_t, std::shared_ptr<LHCInfo> > > m_tmpBuffer;
-  std::vector<std::shared_ptr<LHCInfo> > m_payloadBuffer;
   bool m_lastPayloadEmpty = false;
 };
 

--- a/CondTools/SiPixel/test/SiPixelGainCalibrationReadDQMFile.cc
+++ b/CondTools/SiPixel/test/SiPixelGainCalibrationReadDQMFile.cc
@@ -459,24 +459,20 @@ void SiPixelGainCalibrationReadDQMFile::fillDatabase(const edm::EventSetup &iSet
     if (record_ == "SiPixelGainCalibrationForHLTRcd") {
       std::cout << "now doing SiPixelGainCalibrationForHLTRcd payload..." << std::endl;
       if (mydbservice->isNewTagRequest(record_)) {
-        mydbservice->createNewIOV<SiPixelGainCalibrationForHLT>(theGainCalibrationDbInputHLT.release(),
-                                                                mydbservice->beginOfTime(),
-                                                                mydbservice->endOfTime(),
-                                                                "SiPixelGainCalibrationForHLTRcd");
+        mydbservice->createNewIOV<SiPixelGainCalibrationForHLT>(
+            *theGainCalibrationDbInputHLT, mydbservice->beginOfTime(), "SiPixelGainCalibrationForHLTRcd");
       } else {
         mydbservice->appendSinceTime<SiPixelGainCalibrationForHLT>(
-            theGainCalibrationDbInputHLT.release(), mydbservice->currentTime(), "SiPixelGainCalibrationForHLTRcd");
+            *theGainCalibrationDbInputHLT, mydbservice->currentTime(), "SiPixelGainCalibrationForHLTRcd");
       }
     } else if (record_ == "SiPixelGainCalibrationOfflineRcd") {
       std::cout << "now doing SiPixelGainCalibrationOfflineRcd payload..." << std::endl;
       if (mydbservice->isNewTagRequest(record_)) {
-        mydbservice->createNewIOV<SiPixelGainCalibrationOffline>(theGainCalibrationDbInputOffline.release(),
-                                                                 mydbservice->beginOfTime(),
-                                                                 mydbservice->endOfTime(),
-                                                                 "SiPixelGainCalibrationOfflineRcd");
+        mydbservice->createNewIOV<SiPixelGainCalibrationOffline>(
+            *theGainCalibrationDbInputOffline, mydbservice->beginOfTime(), "SiPixelGainCalibrationOfflineRcd");
       } else {
         mydbservice->appendSinceTime<SiPixelGainCalibrationOffline>(
-            theGainCalibrationDbInputOffline.release(), mydbservice->currentTime(), "SiPixelGainCalibrationOfflineRcd");
+            *theGainCalibrationDbInputOffline, mydbservice->currentTime(), "SiPixelGainCalibrationOfflineRcd");
       }
     }
     edm::LogInfo(" --- all OK");

--- a/CondTools/SiStrip/plugins/SiStripApvSimulationParametersBuilder.cc
+++ b/CondTools/SiStrip/plugins/SiStripApvSimulationParametersBuilder.cc
@@ -23,10 +23,10 @@ void SiStripApvSimulationParametersBuilder::analyze(const edm::Event&, const edm
   if (mydbservice.isAvailable()) {
     if (mydbservice->isNewTagRequest("SiStripApvSimulationParametersRcd")) {
       mydbservice->createNewIOV<SiStripApvSimulationParameters>(
-          obj.get(), mydbservice->beginOfTime(), mydbservice->endOfTime(), "SiStripApvSimulationParametersRcd");
+          *obj, mydbservice->beginOfTime(), "SiStripApvSimulationParametersRcd");
     } else {
       mydbservice->appendSinceTime<SiStripApvSimulationParameters>(
-          obj.get(), mydbservice->currentTime(), "SiStripApvSimulationParametersRcd");
+          *obj, mydbservice->currentTime(), "SiStripApvSimulationParametersRcd");
     }
   } else {
     edm::LogError("SiStripApvSimulationParametersBuilder") << "Service is unavailable";

--- a/CondTools/SiStrip/plugins/SiStripBadChannelBuilder.cc
+++ b/CondTools/SiStrip/plugins/SiStripBadChannelBuilder.cc
@@ -79,11 +79,10 @@ std::unique_ptr<SiStripBadStrip> SiStripBadChannelBuilder::getNewObject() {
 
   if (mydbservice.isAvailable()) {
     if (mydbservice->isNewTagRequest("SiStripBadStripRcd")) {
-      mydbservice->createNewIOV<SiStripBadStrip>(
-          obj.get(), mydbservice->beginOfTime(), mydbservice->endOfTime(), "SiStripBadStripRcd");
+      mydbservice->createNewIOV<SiStripBadStrip>(*obj, mydbservice->beginOfTime(), "SiStripBadStripRcd");
     } else {
-      //mydbservice->createNewIOV<SiStripBadStrip>(obj.get(),mydbservice->currentTime(),"SiStripBadStripRcd");
-      mydbservice->appendSinceTime<SiStripBadStrip>(obj.get(), mydbservice->currentTime(), "SiStripBadStripRcd");
+      //mydbservice->createNewIOV<SiStripBadStrip>(*obj, mydbservice->currentTime(),"SiStripBadStripRcd");
+      mydbservice->appendSinceTime<SiStripBadStrip>(*obj, mydbservice->currentTime(), "SiStripBadStripRcd");
     }
   } else {
     edm::LogError("SiStripBadStripBuilder") << "Service is unavailable" << std::endl;

--- a/IOMC/EventVertexGenerators/src/BeamProfile2DB.cc
+++ b/IOMC/EventVertexGenerators/src/BeamProfile2DB.cc
@@ -103,8 +103,7 @@ void BeamProfile2DB::beginJob() {}
 // ------------ method called once each job just after ending the event loop  ------------
 void BeamProfile2DB::endJob() {
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
-  poolDbService->createNewIOV<SimBeamSpotObjects>(
-      &beamSpot_, poolDbService->beginOfTime(), poolDbService->endOfTime(), "SimBeamSpotObjectsRcd");
+  poolDbService->createNewIOV<SimBeamSpotObjects>(beamSpot_, poolDbService->beginOfTime(), "SimBeamSpotObjectsRcd");
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------

--- a/RecoHI/HiJetAlgos/plugins/UETableProducer.cc
+++ b/RecoHI/HiJetAlgos/plugins/UETableProducer.cc
@@ -202,19 +202,18 @@ void UETableProducer::endJob() {
       jme_payload->push_back(JetCorrectorParametersCollection::L1Offset, parameter);
 
       if (pool->isNewTagRequest("JetCorrectionsRecord")) {
-        pool->createNewIOV<JetCorrectorParametersCollection>(
-            jme_payload.get(), pool->beginOfTime(), pool->endOfTime(), "JetCorrectionsRecord");
+        pool->createNewIOV<JetCorrectorParametersCollection>(*jme_payload, pool->beginOfTime(), "JetCorrectionsRecord");
       } else {
         pool->appendSinceTime<JetCorrectorParametersCollection>(
-            jme_payload.get(), pool->currentTime(), "JetCorrectionsRecord");
+            *jme_payload, pool->currentTime(), "JetCorrectionsRecord");
       }
     } else {
       ue_predictor_pf->values = ue_vec;
 
       if (pool->isNewTagRequest("HeavyIonUERcd")) {
-        pool->createNewIOV<UETable>(ue_predictor_pf.get(), pool->beginOfTime(), pool->endOfTime(), "HeavyIonUERcd");
+        pool->createNewIOV<UETable>(*ue_predictor_pf, pool->beginOfTime(), "HeavyIonUERcd");
       } else {
-        pool->appendSinceTime<UETable>(ue_predictor_pf.get(), pool->currentTime(), "HeavyIonUERcd");
+        pool->appendSinceTime<UETable>(*ue_predictor_pf, pool->currentTime(), "HeavyIonUERcd");
       }
     }
   }


### PR DESCRIPTION
#### PR description:

A review of the overall CMSSW client code of the DBOutputService interface for creating/updating condition data sets (sequences of pairs iov/payload ), has found that the clients are mostly assuming (wrongly) the service to take over the ownership, resulting in a generalised memory leak.  
Only few classes are currently implementing the policy correctly. 
To cope with that, I propose the following changes:
1. Implement a centralised policy in the service, taking over (as expected by most of the clients) the payload pointer ownership. This will happen by calling the already existing function signatures accepting a pointer as input: writeOne, createNewIOV, appendSinceTime. The called function will take care to free the allocated memory. For the caller, no change is strictly required if it does not free the memory after the call.
2. Introduce a new set of methods with a reference-based signature for writeOne, createNewIOV and appendSinceTime.
These new methods are used in this PR to migrate the code of the clients already holding the payload ptr ownership. In addition, all of the other clients, currently not freeing the payload memory,  will be asked to move to this interface. This change will improve the overall memory management and the code readability.
3. Introduce a new method "writeMany" scoped to the atomic update of many iovs/payloads. In this PR, this is used for a new implementation of the PopCon workflow. 
4.  Modify the PopCon interface to provide a safer memory management: on the side of the existing vector m_to_transfer holding bare payload pointers has been added a new container ("m_iovs") of payloads based on shared_ptr. The client of PopCon are expected to migrate their code to replace the use of m_to_tranfer in favour of m_iovs.

#### PR validation:

Unit tests/Integration test/O2O tests

