### PR TITLE
Removed undefined use of union in getAnyPtr

### DIFF
--- a/FWCore/Utilities/interface/getAnyPtr.h
+++ b/FWCore/Utilities/interface/getAnyPtr.h
@@ -6,18 +6,8 @@
 
 namespace edm {
   template <typename T>
-  inline std::unique_ptr<T> getAnyPtr(void* p, int offset) {
-    // A union is used to avoid possible copies during the triple cast that would otherwise be needed.
-    // std::unique_ptr<T> edp(static_cast<T*>(static_cast<void *>(static_cast<unsigned char *>(p) + offset)));
-    union {
-      void* vp;
-      unsigned char* ucp;
-      T* tp;
-    } pointerUnion;
-    assert(p != nullptr);
-    pointerUnion.vp = p;
-    pointerUnion.ucp += offset;
-    return std::unique_ptr<T>(pointerUnion.tp);
+  inline std::unique_ptr<T> getAnyPtr(void *p, int offset) {
+    return std::unique_ptr<T>(static_cast<T *>(static_cast<void *>(static_cast<unsigned char *>(p) + offset)));
   }
 }  // namespace edm
 


### PR DESCRIPTION
#### PR description:

The use of cast generates the exact same assembler code.

#### PR validation:

Code compiles and the framework unit tests pass.