### PR TITLE
PPS: solving issue 35033 for CTPPSPixelRecHits

### DIFF
--- a/DataFormats/CTPPSReco/interface/CTPPSPixelRecHit.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSPixelRecHit.h
@@ -1,10 +1,10 @@
 /*
  *
-* This is a part of CTPPS offline software.
-* Author:
-*   Fabrizio Ferro (ferro@ge.infn.it)
-*
-*/
+ * This is a part of CTPPS offline software.
+ * Author:
+ *   Fabrizio Ferro (ferro@ge.infn.it)
+ *
+ */
 
 #ifndef DataFormats_CTPPSReco_CTPPSPixelRecHit_H
 #define DataFormats_CTPPSReco_CTPPSPixelRecHit_H
@@ -16,10 +16,8 @@
 
 class CTPPSPixelRecHit {
 public:
-  CTPPSPixelRecHit() {}
-
-  CTPPSPixelRecHit(LocalPoint lp,
-                   LocalError le,
+  CTPPSPixelRecHit(LocalPoint lp = LocalPoint(0., 0., 0.),
+                   LocalError le = LocalError(0., 0., 0.),
                    bool edge = false,
                    bool bad = false,
                    bool rocs = false,


### PR DESCRIPTION
#### PR description:

This PR should solve issue #35033 for CTPPSPixelRecHits. It explicitily initialize LocalPoint and LocalError members of CTPPSPixelRecHit.

#### PR validation:

Running 136.885 wf with IB CMSSW_12_1_UBSAN_X_2021-08-20-2300 the error does not show up.
No changes seen in private reprocessing of Run2 data samples.

@jan-kaspar 