### PR TITLE
Utilities/StaticAnalyzer: Add base classes of producers to list of producers for a module

### DIFF
--- a/Utilities/StaticAnalyzers/scripts/callgraph.py
+++ b/Utilities/StaticAnalyzers/scripts/callgraph.py
@@ -12,8 +12,9 @@ except ImportError:
 topfunc = r"::(accumulate|acquire|startingNewLoop|duringLoop|endOfLoop|beginOfJob|endOfJob|produce|analyze|filter|beginLuminosityBlock|beginRun|beginStream|streamBeginRun|streamBeginLuminosityBlock|streamEndRun|streamEndLuminosityBlock|globalBeginRun|globalEndRun|globalBeginLuminosityBlock|globalEndLuminosityBlock|endRun|endRunProduce|endLuminosityBlock)\("
 topfuncre = re.compile(topfunc)
 
-baseclass = r"\b(edm::)?(one::|stream::|global::)?((DQM)?(Global|One)?ED(Producer|Filter|Analyzer|(IterateNTimes|NavigateEvents)?Looper)(Base)?|impl::(ExternalWork|Accumulator|RunWatcher|RunCacheHolder)|FromFiles|ProducerSourceBase|OutputModuleBase|InputSource|ProducerSourceFromFiles|ProducerBase|PuttableSourceBase|OutputModule|RawOutput|RawInputSource|impl::RunWatcher<edm::one::EDProducerBase>|impl::EndRunProducer<edm::one::EDProducerBase>)\b"
+baseclass = r"\b(edm::)?(one::|stream::|global::)?((DQM)?(Global|One)?ED(Producer|Filter|Analyzer|(IterateNTimes|NavigateEvents)?Looper)(Base)?|impl::(ExternalWork|Accumulator|RunWatcher|RunCacheHolder)|FromFiles|ProducerSourceBase|OutputModuleBase|InputSource|ProducerSourceFromFiles|ProducerBase|PuttableSourceBase|OutputModule|RawOutput|RawInputSource|impl::RunWatcher<edm::one::EDProducerBase>|impl::EndRunProducer<edm::one::EDProducerBase>|DQMEDHarvester)\b"
 baseclassre = re.compile(baseclass)
+assert(baseclassre.match('DQMEDHarvester'))
 assert(baseclassre.match('edm::one::impl::RunWatcher<edm::one::EDProducerBase>'))
 assert(baseclassre.match('edm::global::EDFilter::filter() virtual'))
 assert(topfuncre.search('edm::global::EDFilterBase::filter(&) const virtual'))

--- a/Utilities/StaticAnalyzers/scripts/callgraph.py
+++ b/Utilities/StaticAnalyzers/scripts/callgraph.py
@@ -82,13 +82,14 @@ with open('classes.txt.dumperall') as f:
 assert(class2base['edm::FlatRandomEGunProducer']==['edm::BaseFlatGunProducer'])
 
 for cl, basecls in class2base.items():
+    clname=cl.split('::')[-1]:
     for package, modules in module2package.items():
         for module in modules:
-            if module==cl.split('::')[-1]:
-                print(cl, basecls, package, module)
+            if module == clname
+                print(clname, basecls, package, module)
                 for basecl in basecls:
                     if not basecl in set(module2package[package]):
-                        module2package[package].append(basecl)
+                        module2package[package].append(basecl.split('::')[-1])
 
 G = nx.DiGraph()
 with open('function-calls-db.txt') as f:

--- a/Utilities/StaticAnalyzers/scripts/callgraph.py
+++ b/Utilities/StaticAnalyzers/scripts/callgraph.py
@@ -12,7 +12,7 @@ except ImportError:
 topfunc = r"::(accumulate|acquire|startingNewLoop|duringLoop|endOfLoop|beginOfJob|endOfJob|produce|analyze|filter|beginLuminosityBlock|beginRun|beginStream|streamBeginRun|streamBeginLuminosityBlock|streamEndRun|streamEndLuminosityBlock|globalBeginRun|globalEndRun|globalBeginLuminosityBlock|globalEndLuminosityBlock|endRun|endLuminosityBlock)\("
 topfuncre = re.compile(topfunc)
 
-baseclass = r"\b(edm::)?(one::|stream::|global::)?((DQM)?(Global|One)?ED(Producer|Filter|Analyzer|(IterateNTimes|NavigateEvents)?Looper)(Base)?|impl::(ExternalWork|Accumulator|RunWatcher|RunCacheHolder)|FromFiles|ProducerSourceBase|OutputModuleBase|InputSource|ProducerSourceFromFiles|ProducerBase|PuttableSourceBase|OutputModule|RawOutput|RawInputSource|impl::RunWatcher<edm::one::EDProducerBase>)\b"
+baseclass = r"\b(edm::)?(one::|stream::|global::)?((DQM)?(Global|One)?ED(Producer|Filter|Analyzer|(IterateNTimes|NavigateEvents)?Looper)(Base)?|impl::(ExternalWork|Accumulator|RunWatcher|RunCacheHolder)|FromFiles|ProducerSourceBase|OutputModuleBase|InputSource|ProducerSourceFromFiles|ProducerBase|PuttableSourceBase|OutputModule|RawOutput|RawInputSource|impl::RunWatcher<edm::one::EDProducerBase>|impl::EndRunProducer<edm::one::EDProducerBase)\b"
 baseclassre = re.compile(baseclass)
 assert(baseclassre.match('edm::one::impl::RunWatcher<edm::one::EDProducerBase>'))
 assert(baseclassre.match('edm::global::EDFilter::filter() virtual'))

--- a/Utilities/StaticAnalyzers/scripts/callgraph.py
+++ b/Utilities/StaticAnalyzers/scripts/callgraph.py
@@ -12,8 +12,9 @@ except ImportError:
 topfunc = r"::(accumulate|acquire|startingNewLoop|duringLoop|endOfLoop|beginOfJob|endOfJob|produce|analyze|filter|beginLuminosityBlock|beginRun|beginStream|streamBeginRun|streamBeginLuminosityBlock|streamEndRun|streamEndLuminosityBlock|globalBeginRun|globalEndRun|globalBeginLuminosityBlock|globalEndLuminosityBlock|endRun|endLuminosityBlock)\("
 topfuncre = re.compile(topfunc)
 
-baseclass = r"\b(edm::)?(one::|stream::|global::)?((DQM)?(Global|One)?ED(Producer|Filter|Analyzer|(IterateNTimes|NavigateEvents)?Looper)(Base)?|impl::(ExternalWork|Accumulator|RunWatcher|RunCacheHolder)|FromFiles|ProducerSourceBase|OutputModuleBase|InputSource|ProducerSourceFromFiles|ProducerBase|PuttableSourceBase|OutputModule|RawOutput|RawInputSource)\b"
+baseclass = r"\b(edm::)?(one::|stream::|global::)?((DQM)?(Global|One)?ED(Producer|Filter|Analyzer|(IterateNTimes|NavigateEvents)?Looper)(Base)?|impl::(ExternalWork|Accumulator|RunWatcher|RunCacheHolder)|FromFiles|ProducerSourceBase|OutputModuleBase|InputSource|ProducerSourceFromFiles|ProducerBase|PuttableSourceBase|OutputModule|RawOutput|RawInputSource|impl::RunWatcher<edm::one::EDProducerBase>)\b"
 baseclassre = re.compile(baseclass)
+assert(baseclassre.match('edm::one::impl::RunWatcher<edm::one::EDProducerBase>'))
 assert(baseclassre.match('edm::global::EDFilter::filter() virtual'))
 assert(topfuncre.search('edm::global::EDFilterBase::filter(&) const virtual'))
 assert(not baseclassre.match('edm::BaseFlatGunProducer'))
@@ -82,11 +83,10 @@ with open('classes.txt.dumperall') as f:
 assert(class2base['edm::FlatRandomEGunProducer']==['edm::BaseFlatGunProducer'])
 
 for cl, basecls in class2base.items():
-    clname=cl.split('::')[-1]:
+    clname=cl.split('::')[-1]
     for package, modules in module2package.items():
         for module in modules:
-            if module == clname
-                print(clname, basecls, package, module)
+            if module == clname:
                 for basecl in basecls:
                     if not basecl in set(module2package[package]):
                         module2package[package].append(basecl.split('::')[-1])

--- a/Utilities/StaticAnalyzers/scripts/callgraph.py
+++ b/Utilities/StaticAnalyzers/scripts/callgraph.py
@@ -9,10 +9,10 @@ try:
 except ImportError:
     from yaml import Loader, Dumper
 
-topfunc = r"::(accumulate|acquire|startingNewLoop|duringLoop|endOfLoop|beginOfJob|endOfJob|produce|analyze|filter|beginLuminosityBlock|beginRun|beginStream|streamBeginRun|streamBeginLuminosityBlock|streamEndRun|streamEndLuminosityBlock|globalBeginRun|globalEndRun|globalBeginLuminosityBlock|globalEndLuminosityBlock|endRun|endLuminosityBlock)\("
+topfunc = r"::(accumulate|acquire|startingNewLoop|duringLoop|endOfLoop|beginOfJob|endOfJob|produce|analyze|filter|beginLuminosityBlock|beginRun|beginStream|streamBeginRun|streamBeginLuminosityBlock|streamEndRun|streamEndLuminosityBlock|globalBeginRun|globalEndRun|globalBeginLuminosityBlock|globalEndLuminosityBlock|endRun|endRunProduce|endLuminosityBlock)\("
 topfuncre = re.compile(topfunc)
 
-baseclass = r"\b(edm::)?(one::|stream::|global::)?((DQM)?(Global|One)?ED(Producer|Filter|Analyzer|(IterateNTimes|NavigateEvents)?Looper)(Base)?|impl::(ExternalWork|Accumulator|RunWatcher|RunCacheHolder)|FromFiles|ProducerSourceBase|OutputModuleBase|InputSource|ProducerSourceFromFiles|ProducerBase|PuttableSourceBase|OutputModule|RawOutput|RawInputSource|impl::RunWatcher<edm::one::EDProducerBase>|impl::EndRunProducer<edm::one::EDProducerBase)\b"
+baseclass = r"\b(edm::)?(one::|stream::|global::)?((DQM)?(Global|One)?ED(Producer|Filter|Analyzer|(IterateNTimes|NavigateEvents)?Looper)(Base)?|impl::(ExternalWork|Accumulator|RunWatcher|RunCacheHolder)|FromFiles|ProducerSourceBase|OutputModuleBase|InputSource|ProducerSourceFromFiles|ProducerBase|PuttableSourceBase|OutputModule|RawOutput|RawInputSource|impl::RunWatcher<edm::one::EDProducerBase>|impl::EndRunProducer<edm::one::EDProducerBase>)\b"
 baseclassre = re.compile(baseclass)
 assert(baseclassre.match('edm::one::impl::RunWatcher<edm::one::EDProducerBase>'))
 assert(baseclassre.match('edm::global::EDFilter::filter() virtual'))
@@ -82,14 +82,25 @@ with open('classes.txt.dumperall') as f:
 
 assert(class2base['edm::FlatRandomEGunProducer']==['edm::BaseFlatGunProducer'])
 
-for cl, basecls in class2base.items():
-    clname=cl.split('::')[-1]
-    for package, modules in module2package.items():
-        for module in modules:
+
+bmodules=[]
+for package, modules in module2package.items():
+    for module in modules:
+        for cl in class2base.keys():
+            clname=cl.split('::')[-1]
             if module == clname:
-                for basecl in basecls:
+                for basecl in class2base[cl]:
                     if not basecl in set(module2package[package]):
-                        module2package[package].append(basecl.split('::')[-1])
+                        module2package[package].append(basecl)
+                    if not basecl in set(bmodules):
+                        bmodules.append(basecl)
+
+
+bmods='|'.join(bmodules)
+bmods_regex=r'\b(' + bmods+ r'QQQQQQQQ)\b'
+comp_bmods_regex=re.compile(bmods_regex)
+n=comp_bmods_regex.search("function 'edm::BaseFlatGunProducer::beginRun(const edm::Run &, const class edm::EventSetup &)' calls function 'edm::EventSetup::getData<class edm::ESHandle<class HepPDT::ParticleDataTable>>(class edm::ESHandle<class HepPDT::ParticleDataTable> &) const'")
+assert(n)
 
 G = nx.DiGraph()
 with open('function-calls-db.txt') as f:
@@ -104,7 +115,7 @@ with open('function-calls-db.txt') as f:
         if fields[2] == ' overrides function ':
             if baseclassre.match(fields[3]):
                 G.add_edge(fields[1], fields[3], kind=' overrides function ')
-                if topfuncre.search(fields[1]) and comp_mods_regex.search(fields[1]):
+                if topfuncre.search(fields[1]) and (comp_mods_regex.search(fields[1]) or comp_bmods_regex.search(fields[1])):
                     toplevelfuncs.add(fields[1])
             else:
                 G.add_edge(fields[3], fields[1], kind=' overriden function calls function ')
@@ -132,7 +143,7 @@ for tfunc in toplevelfuncs:
 report = dict()
 for key in sorted(set(module2package.keys())):
     for value in sorted(set(module2package[key])):
-        if comp_mods_regex.match(value):
+        if comp_mods_regex.match(value) or comp_bmods_regex.match(value):
             regex_str = r'\b%s\b'%value
             vre=re.compile(regex_str)
             for callstack in sorted(callstacks):

--- a/Utilities/StaticAnalyzers/scripts/callgraph.py
+++ b/Utilities/StaticAnalyzers/scripts/callgraph.py
@@ -12,7 +12,7 @@ except ImportError:
 topfunc = r"::(accumulate|acquire|startingNewLoop|duringLoop|endOfLoop|beginOfJob|endOfJob|produce|analyze|filter|beginLuminosityBlock|beginRun|beginStream|streamBeginRun|streamBeginLuminosityBlock|streamEndRun|streamEndLuminosityBlock|globalBeginRun|globalEndRun|globalBeginLuminosityBlock|globalEndLuminosityBlock|endRun|endRunProduce|endLuminosityBlock)\("
 topfuncre = re.compile(topfunc)
 
-baseclass = r"\b(edm::)?(one::|stream::|global::)?((DQM)?(Global|One)?ED(Producer|Filter|Analyzer|(IterateNTimes|NavigateEvents)?Looper)(Base)?|impl::(ExternalWork|Accumulator|RunWatcher|RunCacheHolder)|FromFiles|ProducerSourceBase|OutputModuleBase|InputSource|ProducerSourceFromFiles|ProducerBase|PuttableSourceBase|OutputModule|RawOutput|RawInputSource|impl::RunWatcher<edm::one::EDProducerBase>|impl::EndRunProducer<edm::one::EDProducerBase>|DQMEDHarvester|AlignmentProducerBase|BMixingModule|TrackProducerBase|TauDiscriminationProducerBase|cms::CkfTrackCandidateMakerBase)\b"
+baseclass = r"\b(edm::)?(one::|stream::|global::)?((DQM)?(Global|One)?ED(Producer|Filter|Analyzer|(IterateNTimes|NavigateEvents)?Looper)(Base)?|impl::(ExternalWork|Accumulator|RunWatcher|RunCacheHolder)|FromFiles|ProducerSourceBase|OutputModuleBase|InputSource|ProducerSourceFromFiles|ProducerBase|PuttableSourceBase|OutputModule|RawOutput|RawInputSource|impl::RunWatcher<edm::one::EDProducerBase>|impl::EndRunProducer<edm::one::EDProducerBase>|DQMEDHarvester|AlignmentProducerBase|BMixingModule|TrackProducerBase|cms::CkfTrackCandidateMakerBase)\b"
 baseclassre = re.compile(baseclass)
 assert(baseclassre.match('DQMEDHarvester'))
 assert(baseclassre.match('edm::one::impl::RunWatcher<edm::one::EDProducerBase>'))

--- a/Utilities/StaticAnalyzers/scripts/callgraph.py
+++ b/Utilities/StaticAnalyzers/scripts/callgraph.py
@@ -12,7 +12,7 @@ except ImportError:
 topfunc = r"::(accumulate|acquire|startingNewLoop|duringLoop|endOfLoop|beginOfJob|endOfJob|produce|analyze|filter|beginLuminosityBlock|beginRun|beginStream|streamBeginRun|streamBeginLuminosityBlock|streamEndRun|streamEndLuminosityBlock|globalBeginRun|globalEndRun|globalBeginLuminosityBlock|globalEndLuminosityBlock|endRun|endRunProduce|endLuminosityBlock)\("
 topfuncre = re.compile(topfunc)
 
-baseclass = r"\b(edm::)?(one::|stream::|global::)?((DQM)?(Global|One)?ED(Producer|Filter|Analyzer|(IterateNTimes|NavigateEvents)?Looper)(Base)?|impl::(ExternalWork|Accumulator|RunWatcher|RunCacheHolder)|FromFiles|ProducerSourceBase|OutputModuleBase|InputSource|ProducerSourceFromFiles|ProducerBase|PuttableSourceBase|OutputModule|RawOutput|RawInputSource|impl::RunWatcher<edm::one::EDProducerBase>|impl::EndRunProducer<edm::one::EDProducerBase>|DQMEDHarvester)\b"
+baseclass = r"\b(edm::)?(one::|stream::|global::)?((DQM)?(Global|One)?ED(Producer|Filter|Analyzer|(IterateNTimes|NavigateEvents)?Looper)(Base)?|impl::(ExternalWork|Accumulator|RunWatcher|RunCacheHolder)|FromFiles|ProducerSourceBase|OutputModuleBase|InputSource|ProducerSourceFromFiles|ProducerBase|PuttableSourceBase|OutputModule|RawOutput|RawInputSource|impl::RunWatcher<edm::one::EDProducerBase>|impl::EndRunProducer<edm::one::EDProducerBase>|DQMEDHarvester|AlignmentProducerBase|BMixingModule|TrackProducerBase|TauDiscriminationProducerBase|cms::CkfTrackCandidateMakerBase)\b"
 baseclassre = re.compile(baseclass)
 assert(baseclassre.match('DQMEDHarvester'))
 assert(baseclassre.match('edm::one::impl::RunWatcher<edm::one::EDProducerBase>'))


### PR DESCRIPTION
This allows the report for EventSetupRecord::get calls to include top level functions called from base classes that do not have overrides in derived class. 