### PR TITLE
Migrate FastSimulation modules to use esConsumes

### DIFF
--- a/FastSimulation/Calorimetry/interface/CalorimetryManager.h
+++ b/FastSimulation/Calorimetry/interface/CalorimetryManager.h
@@ -15,6 +15,8 @@
 
 #include "FastSimulation/Calorimetry/interface/KKCorrectionFactors.h"
 
+#include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
+
 // For the uint32_t
 //#include <boost/cstdint.hpp>
 #include <map>
@@ -37,10 +39,6 @@ class GflashAntiProtonShowerProfile;
 // FastHFshowerLibrary
 class FastHFShowerLibrary;
 
-namespace edm {
-  class ParameterSet;
-}
-
 class CalorimetryManager {
 public:
   CalorimetryManager();
@@ -48,7 +46,8 @@ public:
                      const edm::ParameterSet& fastCalo,
                      const edm::ParameterSet& MuonECALPars,
                      const edm::ParameterSet& MuonHCALPars,
-                     const edm::ParameterSet& fastGflash);
+                     const edm::ParameterSet& fastGflash,
+                     edm::ConsumesCollector&&);
   ~CalorimetryManager();
 
   // Does the real job

--- a/FastSimulation/Calorimetry/src/CalorimetryManager.cc
+++ b/FastSimulation/Calorimetry/src/CalorimetryManager.cc
@@ -2,6 +2,7 @@
 //Framework headers
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/EDMException.h"
 
 // Fast Simulation headers
 #include "FastSimulation/ParticlePropagator/interface/ParticlePropagator.h"
@@ -56,9 +57,6 @@
 //#include "DataFormats/EcalDetId/interface/EcalDetId.h"
 #include "Geometry/HcalTowerAlgo/interface/HcalGeometry.h"
 
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Utilities/interface/EDMException.h"
-
 //ROOT headers
 #include "TROOT.h"
 #include "TH1.h"
@@ -77,7 +75,8 @@ CalorimetryManager::CalorimetryManager(FSimEvent* aSimEvent,
                                        const edm::ParameterSet& fastCalo,
                                        const edm::ParameterSet& fastMuECAL,
                                        const edm::ParameterSet& fastMuHCAL,
-                                       const edm::ParameterSet& parGflash)
+                                       const edm::ParameterSet& parGflash,
+                                       edm::ConsumesCollector&& iC)
     : mySimEvent(aSimEvent),
       initialized_(false),
       theMuonEcalEffects(nullptr),
@@ -93,7 +92,7 @@ CalorimetryManager::CalorimetryManager(FSimEvent* aSimEvent,
   theAntiProtonProfile = new GflashAntiProtonShowerProfile(parGflash);
 
   // FastHFShowerLibrary
-  theHFShowerLibrary = new FastHFShowerLibrary(fastCalo);
+  theHFShowerLibrary = new FastHFShowerLibrary(fastCalo, std::move(iC));
 
   readParameters(fastCalo);
 

--- a/FastSimulation/EventProducer/interface/FamosManager.h
+++ b/FastSimulation/EventProducer/interface/FamosManager.h
@@ -2,6 +2,7 @@
 #define FastSimulation_EventProducer_FamosManager_H
 
 #include "DataFormats/HepMCCandidate/interface/GenParticleFwd.h"
+#include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
 #include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
 #include <string>
 
@@ -10,9 +11,6 @@ namespace HepMC {
 }
 
 namespace edm {
-  class ParameterSet;
-  class EventSetup;
-  class Run;
   class HepMCProduct;
 }  // namespace edm
 
@@ -29,7 +27,7 @@ class TrackerTopology;
 class FamosManager {
 public:
   /// Constructor
-  FamosManager(edm::ParameterSet const& p);
+  FamosManager(edm::ParameterSet const& p, edm::ConsumesCollector&&);
 
   /// Destructor
   ~FamosManager();

--- a/FastSimulation/EventProducer/src/FamosManager.cc
+++ b/FastSimulation/EventProducer/src/FamosManager.cc
@@ -42,7 +42,7 @@
 
 using namespace HepMC;
 
-FamosManager::FamosManager(edm::ParameterSet const& p)
+FamosManager::FamosManager(edm::ParameterSet const& p, edm::ConsumesCollector&& iC)
     : iEvent(0),
       myCalorimetry(nullptr),
       m_pUseMagneticField(p.getParameter<bool>("UseMagneticField")),
@@ -66,7 +66,8 @@ FamosManager::FamosManager(edm::ParameterSet const& p)
                                            p.getParameter<edm::ParameterSet>("Calorimetry"),
                                            p.getParameter<edm::ParameterSet>("MaterialEffectsForMuonsInECAL"),
                                            p.getParameter<edm::ParameterSet>("MaterialEffectsForMuonsInHCAL"),
-                                           p.getParameter<edm::ParameterSet>("GFlash"));
+                                           p.getParameter<edm::ParameterSet>("GFlash"),
+                                           std::move(iC));
 }
 
 FamosManager::~FamosManager() {

--- a/FastSimulation/EventProducer/src/FamosProducer.cc
+++ b/FastSimulation/EventProducer/src/FamosProducer.cc
@@ -48,7 +48,7 @@ FamosProducer::FamosProducer(edm::ParameterSet const& p) {
   sourceToken = consumes<edm::HepMCProduct>(sourceLabel);
 
   // famos manager
-  famosManager_ = new FamosManager(p);
+  famosManager_ = new FamosManager(p, consumesCollector());
 }
 
 FamosProducer::~FamosProducer() { delete famosManager_; }

--- a/FastSimulation/EventProducer/src/FamosProducer.cc
+++ b/FastSimulation/EventProducer/src/FamosProducer.cc
@@ -1,3 +1,4 @@
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/EventSetup.h"

--- a/FastSimulation/ShowerDevelopment/interface/FastHFShowerLibrary.h
+++ b/FastSimulation/ShowerDevelopment/interface/FastHFShowerLibrary.h
@@ -6,9 +6,8 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 
 #include "FastSimulation/Utilities/interface/FamosDebug.h"
 
@@ -18,6 +17,8 @@
 #include "SimG4CMS/Calo/interface/CaloHitID.h"
 #include "Geometry/HcalCommonData/interface/HcalNumberingFromDDD.h"
 #include "Geometry/HcalCommonData/interface/HcalDDDSimConstants.h"
+#include "Geometry/HcalCommonData/interface/HcalSimulationConstants.h"
+#include "Geometry/Records/interface/HcalSimNumberingRecord.h"
 #include "SimG4CMS/Calo/interface/HcalNumberingScheme.h"
 #include "G4ThreeVector.hh"
 
@@ -38,8 +39,8 @@ class RandomEngineAndDistribution;
 class FastHFShowerLibrary {
 public:
   // Constructor and Destructor
-  FastHFShowerLibrary(edm::ParameterSet const& p);
-  ~FastHFShowerLibrary() { ; }
+  FastHFShowerLibrary(edm::ParameterSet const&, edm::ConsumesCollector&&);
+  ~FastHFShowerLibrary() {}
 
 public:
   void const initHFShowerLibrary(const edm::EventSetup&);
@@ -60,5 +61,8 @@ private:
 
   bool applyFidCut;
   std::string name;
+
+  const edm::ESGetToken<HcalDDDSimConstants, HcalSimNumberingRecord> hcalDDDSimConstantsESToken_;
+  const edm::ESGetToken<HcalSimulationConstants, HcalSimNumberingRecord> hcalSimulationConstantsESToken_;
 };
 #endif

--- a/FastSimulation/SimplifiedGeometryPropagator/interface/Geometry.h
+++ b/FastSimulation/SimplifiedGeometryPropagator/interface/Geometry.h
@@ -4,22 +4,20 @@
 #include "DataFormats/Math/interface/LorentzVector.h"
 #include "FastSimulation/SimplifiedGeometryPropagator/interface/ForwardSimplifiedGeometry.h"
 #include "FastSimulation/SimplifiedGeometryPropagator/interface/BarrelSimplifiedGeometry.h"
+#include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
+#include "RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h"
 
 ///////////////////////////////////////////////
 // Author: L. Vanelderen, S. Kurz
 // Date: 29 May 2017
 //////////////////////////////////////////////////////////
 
-class GeometricSearchTracker;
-class MagneticField;
-
 #include <vector>
-
-namespace edm {
-  //class ParameterSet;
-  class EventSetup;
-}  // namespace edm
 
 namespace fastsim {
   class InteractionModel;
@@ -32,7 +30,7 @@ namespace fastsim {
   class Geometry {
   public:
     //! Constructor.
-    Geometry(const edm::ParameterSet& cfg);
+    Geometry(const edm::ParameterSet&, edm::ConsumesCollector&&);
 
     //! Default destructor.
     ~Geometry();
@@ -168,6 +166,9 @@ namespace fastsim {
     const bool forwardBoundary_;                         //!< Hack to interface "old" calo to "new" tracking
     const edm::ParameterSet trackerBarrelBoundaryCfg_;   //!< Hack to interface "old" calo to "new" tracking
     const edm::ParameterSet trackerForwardBoundaryCfg_;  //!< Hack to interface "old" calo to "new" tracking
+
+    edm::ESGetToken<GeometricSearchTracker, TrackerRecoGeometryRecord> geometricSearchTrackerESToken_;
+    edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magneticFieldESToken_;
   };
   std::ostream& operator<<(std::ostream& os, const fastsim::Geometry& geometry);
 }  // namespace fastsim

--- a/FastSimulation/SimplifiedGeometryPropagator/plugins/FastTrackDeDxProducer.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/plugins/FastTrackDeDxProducer.cc
@@ -26,13 +26,13 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
 #include "Geometry/CommonDetUnit/interface/GluedGeomDet.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/TrackReco/interface/DeDxData.h"
@@ -71,7 +71,7 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  void beginRun(edm::Run const& run, const edm::EventSetup&) override;
+  void beginRun(edm::Run const&, const edm::EventSetup&) override;
   void produce(edm::Event&, const edm::EventSetup&) override;
 
   void makeCalibrationMap(const TrackerGeometry& tkGeom);
@@ -82,7 +82,6 @@ private:
                   int& NClusterSaturating);
 
   // ----------member data ---------------------------
-  //BaseDeDxEstimator*               m_estimator;
 
   std::unique_ptr<BaseDeDxEstimator> m_estimator;
 
@@ -100,7 +99,7 @@ private:
 
   edm::EDGetTokenT<edm::PSimHitContainer> simHitsToken;
   edm::EDGetTokenT<FastTrackerRecHitRefCollection> simHit2RecHitMapToken;
-  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tkGeomToken;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tkGeomToken;
 
   bool usePixel;
   bool useStrip;
@@ -139,8 +138,7 @@ void FastTrackDeDxProducer::fillDescriptions(edm::ConfigurationDescriptions& des
 FastTrackDeDxProducer::FastTrackDeDxProducer(const edm::ParameterSet& iConfig)
     : simHitsToken(consumes<edm::PSimHitContainer>(iConfig.getParameter<edm::InputTag>("simHits"))),
       simHit2RecHitMapToken(
-          consumes<FastTrackerRecHitRefCollection>(iConfig.getParameter<edm::InputTag>("simHit2RecHitMap"))),
-      tkGeomToken(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()) {
+          consumes<FastTrackerRecHitRefCollection>(iConfig.getParameter<edm::InputTag>("simHit2RecHitMap"))) {
   produces<ValueMap<DeDxData>>();
 
   auto cCollector = consumesCollector();
@@ -183,22 +181,25 @@ FastTrackDeDxProducer::FastTrackDeDxProducer(const edm::ParameterSet& iConfig)
   if (!usePixel && !useStrip)
     throw cms::Exception("fastsim::SimplifiedGeometry::FastTrackDeDxProducer.cc")
         << " neither pixel hits nor strips hits will be used to compute de/dx";
+
+  if (useCalibration) {
+    tkGeomToken = esConsumes<edm::Transition::BeginRun>();
+  }
 }
 
 // ------------ method called once each job just before starting event loop  ------------
 void FastTrackDeDxProducer::beginRun(edm::Run const& run, const edm::EventSetup& iSetup) {
   if (useCalibration && calibGains.empty()) {
-    edm::ESHandle<TrackerGeometry> tkGeom;
-    iSetup.get<TrackerDigiGeometryRecord>().get(tkGeom);
-    m_off = tkGeom->offsetDU(GeomDetEnumerators::PixelBarrel);  //index start at the first pixel
+    auto const& tkGeom = iSetup.getData(tkGeomToken);
+    m_off = tkGeom.offsetDU(GeomDetEnumerators::PixelBarrel);  //index start at the first pixel
 
-    DeDxTools::makeCalibrationMap(m_calibrationPath, *tkGeom, calibGains, m_off);
+    DeDxTools::makeCalibrationMap(m_calibrationPath, tkGeom, calibGains, m_off);
   }
 
   m_estimator->beginRun(run, iSetup);
 }
 
-void FastTrackDeDxProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void FastTrackDeDxProducer::produce(edm::Event& iEvent, const edm::EventSetup&) {
   auto trackDeDxEstimateAssociation = std::make_unique<ValueMap<DeDxData>>();
   ValueMap<DeDxData>::Filler filler(*trackDeDxEstimateAssociation);
 

--- a/FastSimulation/TrackingRecHitProducer/interface/TrackingRecHitAlgorithm.h
+++ b/FastSimulation/TrackingRecHitProducer/interface/TrackingRecHitAlgorithm.h
@@ -2,8 +2,12 @@
 #define FastSimulation_TrackingRecHitProducer_TrackingRecHitAlgorithm_H
 
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
 #include "FWCore/Framework/interface/ProducerBase.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FastSimulation/TrackingRecHitProducer/interface/TrackingRecHitProduct.h"
 
 #include "FastSimulation/Utilities/interface/RandomEngineAndDistribution.h"
@@ -15,14 +19,6 @@
 #include <string>
 #include <memory>
 
-namespace edm {
-  class Event;
-  class EventSetup;
-  class ParameterSet;
-  class ConsumesCollector;
-  class Stream;
-}  // namespace edm
-
 class TrackingRecHitAlgorithm {
 private:
   const std::string _name;
@@ -30,6 +26,9 @@ private:
   const TrackerTopology* _trackerTopology;
   const TrackerGeometry* _trackerGeometry;
   const TrackerGeometry* _misalignedTrackerGeometry;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopologyESToken_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeometryESToken_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> misalignedTrackerGeometryESToken_;
   std::shared_ptr<RandomEngineAndDistribution> _randomEngine;
 
 public:


### PR DESCRIPTION
#### PR description:

Migrate FastSimulation modules to use esConsumes

#### PR validation:

Depends on existing tests
