### PR TITLE
Get rid of a dead increment in SiStripMonitorClient

### DIFF
--- a/DQM/SiStripMonitorClient/bin/ls_cert.cc
+++ b/DQM/SiStripMonitorClient/bin/ls_cert.cc
@@ -244,7 +244,6 @@ void ls_cert_type(string iDir,
     lsd[i] = templs;
     TDirectory* tempDir = dynamic_cast<TDirectory*>(file->Get(lsdir.str().c_str()));
     tempDir->cd();
-    int j = 0;
     TIter nextTemp(tempDir->GetListOfKeys());
     TKey* keyTemp;
     while ((keyTemp = dynamic_cast<TKey*>(nextTemp()))) {
@@ -261,14 +260,13 @@ void ls_cert_type(string iDir,
           std::cout << typecert.c_str() << std::endl;
         tempvalue = atof(detvalue.c_str());
 
-        for (j = 0; j < smax; j++) {
+        for (int j = 0; j < smax; j++) {
           if (strstr(typecert.c_str(), certflag[j].c_str()) != nullptr)
             v[j][i] = tempvalue;
           if (debug)
             std::cout << "Entering value " << tempvalue << " " << v[j][i] << " for " << certflag[j].c_str()
                       << std::endl;
         }
-        j = j + 1;
       }
     }
   }


### PR DESCRIPTION
#### PR description:

Get trivially rid of a dead increment notified by the static analyzer

#### PR validation:

It compiles