### PR TITLE
Initalize flag in SiStripQualityChecker

### DIFF
--- a/DQM/SiStripMonitorClient/src/SiStripQualityChecker.cc
+++ b/DQM/SiStripMonitorClient/src/SiStripQualityChecker.cc
@@ -230,7 +230,7 @@ void SiStripQualityChecker::fillDetectorStatus(DQMStore& dqm_store, const SiStri
       continue;
     dqm_store.cd(dname);
     ++xbin;
-    float flag;
+    float flag = 0;
     fillSubDetStatus(dqm_store, cabling, local_mes, xbin, flag);
     global_flag += flag;
   }


### PR DESCRIPTION
#### PR description:

"flag" could have been used uninitialized if the parameter "GlobalStatusFilling" is defined below 1: this would let the `global_flag` in an undefined state, as well as the histo filled with it.

The initial value of 0 makes sense, as it will not increment `global_flag` , instead of letting it undefined

#### PR validation:

It compiles