### PR TITLE
Add Digi to the modified steps for bParking workflows

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -3297,7 +3297,7 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
 
     for step in upgradeSteps['ParkingBPH']['steps']:
         stepName = step + upgradeSteps['ParkingBPH']['suffix']
-        if 'Reco' in step and 'Run2_2018' in upgradeStepDict[step][k]['--era']:
+        if ('Reco' in step or 'Digi' in step) and 'Run2_2018' in upgradeStepDict[step][k]['--era']:
             upgradeStepDict[stepName][k] = merge([{'--era': 'Run2_2018,bParking'}, upgradeStepDict[step][k]])
 
     # setup PU

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -222,6 +222,7 @@ upgradeSteps['killStuckTBM'] = {
 }
 upgradeSteps['ParkingBPH'] = {
     'steps' : [
+        'DigiFull',
         'RecoFull',
     ],
     'PU' : [],


### PR DESCRIPTION
#### PR description:

#33996 added new collections to the RAWSIM, AODSIM and MINIAODSIM eventcontents, gated behind the bParking modifier.
However, some bParking workflows (10824.8) run step2 without the bParking modifier, which causes a ProductNotFound exception in step3.
This PR modifies PyReleaseValidation to add the bParking modifier in step2 for bParking workflows created in relval_upgrade.py

#### PR validation:

Tested on the previously failing 10824.8 workflow. Also compared the output of `runTheMatrix.py -n --ext` before and after the change and verified that the only modified workflow is 10824.8

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, as agreed in https://github.com/cms-sw/cmssw/pull/33996#issuecomment-907637588
