### PR TITLE
MTD reconstruction: replace specific forward layer with the general mother class

### DIFF
--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -16,9 +16,7 @@
 #include "DataFormats/TrackerRecHit2D/interface/MTDTrackingRecHit.h"
 
 #include "RecoMTD/DetLayers/interface/MTDTrayBarrelLayer.h"
-#include "RecoMTD/DetLayers/interface/MTDDetTray.h"
-#include "RecoMTD/DetLayers/interface/MTDRingForwardDoubleLayer.h"
-#include "RecoMTD/DetLayers/interface/MTDDetRing.h"
+#include "TrackingTools/DetLayers/interface/ForwardDetLayer.h"
 
 #include "DataFormats/ForwardDetId/interface/BTLDetId.h"
 #include "DataFormats/ForwardDetId/interface/ETLDetId.h"
@@ -886,7 +884,7 @@ TransientTrackingRecHit::ConstRecHitContainer TrackExtenderWithMTDT<TrackCollect
   TransientTrackingRecHit::ConstRecHitContainer output;
   bestHit = MTDHitMatchingInfo();
   for (const DetLayer* ilay : layers) {
-    const BoundDisk& disk = static_cast<const MTDRingForwardDoubleLayer*>(ilay)->specificSurface();
+    const BoundDisk& disk = static_cast<const ForwardDetLayer*>(ilay)->specificSurface();
     const double diskZ = disk.position().z();
 
     if (tsos.globalPosition().z() * diskZ < 0)


### PR DESCRIPTION
#### PR description:

This PR is meant to address the issue #35036 as far as RecoMTD is concerned. 
While introducing the new forward sector geometry for ETL, I overlooked the fact that the old ring double layer was explicitly invoked just to get the sign of the z coordinate within the ```tryETLlayers``` method. This can be generalized by casting the specific layer into the mother class ```ForwardDetLayer``` which is enough to get the ```BoundDisk```, and I expect this update should address the problem (to be verified).

I took the opportunity to remove a few apparently unnecessary headers included.

#### PR validation:

Test wf 34634.0 does not show any difference in its DQM output.