### PR TITLE
Initialize member var in class DQClient

### DIFF
--- a/DQM/HcalCommon/src/DQClient.cc
+++ b/DQM/HcalCommon/src/DQClient.cc
@@ -8,6 +8,7 @@ namespace hcaldqm {
                      edm::ConsumesCollector &iC)
       : DQModule(ps),
         _taskname(taskname),
+        _totalLS(0),
         _maxProcessedLS(0),
         hcalDbServiceToken_(iC.esConsumes<HcalDbService, HcalDbRecord, edm::Transition::BeginRun>()),
         runInfoToken_(iC.esConsumes<RunInfo, RunInfoRcd, edm::Transition::BeginRun>()),


### PR DESCRIPTION
#### PR description:

This inits `_totalLS` bc it wasn't
Related to this 
https://github.com/cms-sw/cmssw/issues/35004#issuecomment-905474667

https://github.com/cms-sw/cmssw/blob/3a5e558609b0e6f30f9001479d3038ec773a016e/DQM/HcalCommon/src/DQClient.cc#L109

#### PR validation:

Ran 11643.0 with and without the change to check if the complaint disappear, it does

