### PR TITLE
Initialize enum field in CaloPoint class

### DIFF
--- a/FastSimulation/CaloGeometryTools/src/CaloPoint.cc
+++ b/FastSimulation/CaloGeometryTools/src/CaloPoint.cc
@@ -24,10 +24,12 @@ CaloPoint::CaloPoint(const DetId& cell, CaloDirection side, const XYZPoint& posi
 CaloPoint::CaloPoint(DetId::Detector det, const XYZPoint& position) : XYZPoint(position), detector_(det) {
   subdetector_ = 0;
   layer_ = 0;
+  side_ = CaloDirection::NONE;
 }
 
 //preshower
 CaloPoint::CaloPoint(DetId::Detector detector, int subdetn, int layer, const XYZPoint& position)
     : XYZPoint(position), detector_(detector), subdetector_(subdetn), layer_(layer) {
   cellid_ = DetId();
+  side_ = CaloDirection::NONE;
 }


### PR DESCRIPTION
Fixes: https://github.com/cms-sw/cmssw/issues/35006

#### PR description:

This is initializing a enum field to NONE which seems reasonable given it wasn't given any value by the constructors arguments

#### PR validation:

Fixes the issue described in the above link - 35006

