### PR TITLE
Initialize fields in ProcessCallGraph and HLTRegionalEcalResonanceFilter

### DIFF
--- a/HLTrigger/Timer/interface/ProcessCallGraph.h
+++ b/HLTrigger/Timer/interface/ProcessCallGraph.h
@@ -29,8 +29,7 @@ public:
   struct NodeType {
     edm::ModuleDescription module_;
     edm::EDMModuleType type_;
-    bool scheduled_;
-    NodeType() : scheduled_(false){};
+    bool scheduled_ = false;
   };
 
   // directed graph, with `NodeType` properties attached to each vertex

--- a/HLTrigger/Timer/interface/ProcessCallGraph.h
+++ b/HLTrigger/Timer/interface/ProcessCallGraph.h
@@ -30,6 +30,7 @@ public:
     edm::ModuleDescription module_;
     edm::EDMModuleType type_;
     bool scheduled_;
+    NodeType() : scheduled_(false){};
   };
 
   // directed graph, with `NodeType` properties attached to each vertex

--- a/HLTrigger/special/plugins/HLTRegionalEcalResonanceFilter.cc
+++ b/HLTrigger/special/plugins/HLTRegionalEcalResonanceFilter.cc
@@ -22,6 +22,8 @@ HLTRegionalEcalResonanceFilter::HLTRegionalEcalResonanceFilter(const edm::Parame
   endcapHitsToken_ = consumes<EERecHitCollection>(endcapHits_);
   endcapClustersToken_ = consumes<reco::BasicClusterCollection>(endcapClusters_);
 
+  store5x5RecHitEB_ = false;
+
   doSelBarrel_ = iConfig.getParameter<bool>("doSelBarrel");
 
   if (doSelBarrel_) {


### PR DESCRIPTION
#### PR description:

Fixes 2 of 3 issues on https://github.com/cms-sw/cmssw/issues/35008

This is initializing two boolean fields - one is the nested `NodeType` struct `scheduled_` field,
for which the default constructor is used to keep the fields untouched (instead of setting `scheduled_=false `)
The other is `store5x5RecHitEB_` which follows in a state where if `if (doSelBarrel_)` is false, `store5x5RecHitEB_` remains uninitialized and is later used here:
https://github.com/cms-sw/cmssw/blob/master/HLTrigger/special/plugins/HLTRegionalEcalResonanceFilter.cc#L613
which is causing the error.

#### PR validation:

After the change the sanitizer doesn't complain (the logs aren't showing the errors)

