### PR TITLE
PPS Pixel data unpacking

### DIFF
--- a/EventFilter/CTPPSRawToDigi/interface/CTPPSPixelDataFormatter.h
+++ b/EventFilter/CTPPSRawToDigi/interface/CTPPSPixelDataFormatter.h
@@ -71,7 +71,7 @@ public:
 
   int nWords() const { return m_WordCounter; }
 
-  void interpretRawData(bool& errorsInEvent, int fedId, const FEDRawData& data, Collection& digis, Errors& errors);
+  void interpretRawData(bool& isRun3, bool& errorsInEvent, int fedId, const FEDRawData& data, Collection& digis, Errors& errors);
 
   int nDigis() const { return m_DigiCounter; }
 
@@ -83,7 +83,7 @@ public:
     short unsigned int fedch;
   };
 
-  void formatRawData(unsigned int lvl1_ID,
+  void formatRawData(bool& isRun3, unsigned int lvl1_ID,
                      RawData& fedRawData,
                      const Digis& digis,
                      std::vector<PPSPixelIndex> v_iDdet2fed);
@@ -98,8 +98,8 @@ private:
   bool m_IncludeErrors;
   RPixErrorChecker m_ErrorCheck;
 
-  int m_ADC_shift, m_PXID_shift, m_DCOL_shift, m_ROC_shift, m_LINK_shift;
-  Word32 m_LINK_mask, m_ROC_mask, m_DCOL_mask, m_PXID_mask, m_ADC_mask;
+  int m_ADC_shift, m_PXID_shift, m_DCOL_shift, m_ROC_shift, m_LINK_shift, m_COL_shift, m_ROW_shift;
+  Word32 m_LINK_mask, m_ROC_mask, m_DCOL_mask, m_PXID_mask, m_ADC_mask, m_COL_mask, m_ROW_mask;
 
   int checkError(const Word32& data) const;
 

--- a/EventFilter/CTPPSRawToDigi/interface/CTPPSPixelDataFormatter.h
+++ b/EventFilter/CTPPSRawToDigi/interface/CTPPSPixelDataFormatter.h
@@ -71,7 +71,8 @@ public:
 
   int nWords() const { return m_WordCounter; }
 
-  void interpretRawData(bool& isRun3, bool& errorsInEvent, int fedId, const FEDRawData& data, Collection& digis, Errors& errors);
+  void interpretRawData(
+      bool& isRun3, bool& errorsInEvent, int fedId, const FEDRawData& data, Collection& digis, Errors& errors);
 
   int nDigis() const { return m_DigiCounter; }
 
@@ -83,7 +84,8 @@ public:
     short unsigned int fedch;
   };
 
-  void formatRawData(bool& isRun3, unsigned int lvl1_ID,
+  void formatRawData(bool& isRun3,
+                     unsigned int lvl1_ID,
                      RawData& fedRawData,
                      const Digis& digis,
                      std::vector<PPSPixelIndex> v_iDdet2fed);

--- a/EventFilter/CTPPSRawToDigi/interface/CTPPSPixelDataFormatter.h
+++ b/EventFilter/CTPPSRawToDigi/interface/CTPPSPixelDataFormatter.h
@@ -72,7 +72,7 @@ public:
   int nWords() const { return m_WordCounter; }
 
   void interpretRawData(
-      bool& isRun3, bool& errorsInEvent, int fedId, const FEDRawData& data, Collection& digis, Errors& errors);
+      const bool& isRun3, bool& errorsInEvent, int fedId, const FEDRawData& data, Collection& digis, Errors& errors);
 
   int nDigis() const { return m_DigiCounter; }
 
@@ -84,7 +84,7 @@ public:
     short unsigned int fedch;
   };
 
-  void formatRawData(bool& isRun3,
+  void formatRawData(const bool& isRun3,
                      unsigned int lvl1_ID,
                      RawData& fedRawData,
                      const Digis& digis,

--- a/EventFilter/CTPPSRawToDigi/interface/CTPPSPixelRawToDigi.h
+++ b/EventFilter/CTPPSRawToDigi/interface/CTPPSPixelRawToDigi.h
@@ -44,5 +44,6 @@ private:
   std::string mappingLabel_;
 
   bool includeErrors_;
+  bool isRun3_;
 };
 #endif

--- a/EventFilter/CTPPSRawToDigi/plugins/CTPPSPixelDigiToRaw.cc
+++ b/EventFilter/CTPPSRawToDigi/plugins/CTPPSPixelDigiToRaw.cc
@@ -82,6 +82,7 @@ private:
   edm::ESGetToken<CTPPSPixelDAQMapping, CTPPSPixelDAQMappingRcd> tCTPPSPixelDAQMapping_;
   std::vector<CTPPSPixelDataFormatter::PPSPixelIndex> v_iDdet2fed_;
   CTPPSPixelFramePosition fPos_;
+  bool isRun3_;
 };
 
 //
@@ -106,6 +107,8 @@ CTPPSPixelDigiToRaw::CTPPSPixelDigiToRaw(const edm::ParameterSet& iConfig)
 
   // Define EDProduct type
   produces<FEDRawDataCollection>();
+
+  isRun3_ = iConfig.getParameter<bool>("isRun3");
 }
 
 CTPPSPixelDigiToRaw::~CTPPSPixelDigiToRaw() {}
@@ -149,7 +152,7 @@ void CTPPSPixelDigiToRaw::produce(edm::Event& iEvent, const edm::EventSetup& iSe
   std::sort(v_iDdet2fed_.begin(), v_iDdet2fed_.end(), CTPPSPixelDataFormatter::compare);
 
   // convert data to raw
-  formatter.formatRawData(iEvent.id().event(), rawdata, digis, v_iDdet2fed_);
+  formatter.formatRawData(isRun3_, iEvent.id().event(), rawdata, digis, v_iDdet2fed_);
 
   // pack raw data into collection
   for (auto it = fedIds_.begin(); it != fedIds_.end(); it++) {
@@ -171,6 +174,7 @@ void CTPPSPixelDigiToRaw::produce(edm::Event& iEvent, const edm::EventSetup& iSe
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void CTPPSPixelDigiToRaw::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
+  desc.add<bool>("isRun3", true);
   desc.add<edm::InputTag>("InputLabel", edm::InputTag("RPixDetDigitizer"));
   desc.add<std::string>("mappingLabel", "RPix");
   descriptions.add("ctppsPixelRawData", desc);

--- a/EventFilter/CTPPSRawToDigi/plugins/CTPPSPixelRawToDigi.cc
+++ b/EventFilter/CTPPSRawToDigi/plugins/CTPPSPixelRawToDigi.cc
@@ -30,6 +30,7 @@ CTPPSPixelRawToDigi::CTPPSPixelRawToDigi(const edm::ParameterSet& conf)
 
   produces<edm::DetSetVector<CTPPSPixelDigi>>();
 
+  isRun3_ = config_.getParameter<bool>("isRun3");
   includeErrors_ = config_.getParameter<bool>("includeErrors");
   mappingLabel_ = config_.getParameter<std::string>("mappingLabel");
 
@@ -44,6 +45,7 @@ CTPPSPixelRawToDigi::~CTPPSPixelRawToDigi() {
 
 void CTPPSPixelRawToDigi::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
+  desc.add<bool>("isRun3", true);
   desc.add<bool>("includeErrors", true);
   desc.add<edm::InputTag>("inputLabel", edm::InputTag("rawDataCollector"));
   desc.add<std::string>("mappingLabel", "RPix");
@@ -89,7 +91,7 @@ void CTPPSPixelRawToDigi::produce(edm::Event& ev, const edm::EventSetup& es) {
       /// get event data for this fed
       const FEDRawData& fedRawData = buffers->FEDData(fedId);
 
-      formatter.interpretRawData(errorsInEvent, fedId, fedRawData, *collection, errors);
+      formatter.interpretRawData(isRun3_, errorsInEvent, fedId, fedRawData, *collection, errors);
 
       if (includeErrors_) {
         for (auto const& is : errors) {

--- a/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
+++ b/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
@@ -113,6 +113,11 @@ totemTimingRawToDigi.rawDataTag = cms.InputTag("rawDataCollector")
 from EventFilter.CTPPSRawToDigi.ctppsPixelDigis_cfi import ctppsPixelDigis
 ctppsPixelDigis.inputLabel = cms.InputTag("rawDataCollector")
 
+from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
+from Configuration.Eras.Modifier_ctpps_2017_cff import ctpps_2017
+from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
+(ctpps_2016 | ctpps_2017 | ctpps_2018).toModify(ctppsPixelDigis, isRun3 = cms.bool(False) )
+
 # raw-to-digi task and sequence
 ctppsRawToDigiTask = cms.Task(
   totemTriggerRawToDigi,

--- a/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
+++ b/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
@@ -116,7 +116,7 @@ ctppsPixelDigis.inputLabel = cms.InputTag("rawDataCollector")
 from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
 from Configuration.Eras.Modifier_ctpps_2017_cff import ctpps_2017
 from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
-(ctpps_2016 | ctpps_2017 | ctpps_2018).toModify(ctppsPixelDigis, isRun3 = cms.bool(False) )
+(ctpps_2016 | ctpps_2017 | ctpps_2018).toModify(ctppsPixelDigis, isRun3 = False )
 
 # raw-to-digi task and sequence
 ctppsRawToDigiTask = cms.Task(

--- a/EventFilter/CTPPSRawToDigi/src/CTPPSPixelDataFormatter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/CTPPSPixelDataFormatter.cc
@@ -76,7 +76,7 @@ void CTPPSPixelDataFormatter::setErrorStatus(bool errorStatus) {
 }
 
 void CTPPSPixelDataFormatter::interpretRawData(
-    bool& isRun3, bool& errorsInEvent, int fedId, const FEDRawData& rawData, Collection& digis, Errors& errors) {
+    const bool& isRun3, bool& errorsInEvent, int fedId, const FEDRawData& rawData, Collection& digis, Errors& errors) {
   int nWords = rawData.size() / sizeof(Word64);
   if (nWords == 0)
     return;
@@ -216,8 +216,11 @@ void CTPPSPixelDataFormatter::interpretRawData(
   }
 }
 
-void CTPPSPixelDataFormatter::formatRawData(
-    bool& isRun3, unsigned int lvl1_ID, RawData& fedRawData, const Digis& digis, std::vector<PPSPixelIndex> iDdet2fed) {
+void CTPPSPixelDataFormatter::formatRawData(const bool& isRun3,
+                                            unsigned int lvl1_ID,
+                                            RawData& fedRawData,
+                                            const Digis& digis,
+                                            std::vector<PPSPixelIndex> iDdet2fed) {
   std::map<int, vector<Word32> > words;
   // translate digis into 32-bit raw words and store in map indexed by Fed
   m_allDetDigis = 0;

--- a/EventFilter/CTPPSRawToDigi/src/CTPPSPixelDataFormatter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/CTPPSPixelDataFormatter.cc
@@ -75,7 +75,8 @@ void CTPPSPixelDataFormatter::setErrorStatus(bool errorStatus) {
   m_ErrorCheck.setErrorStatus(m_IncludeErrors);
 }
 
-void CTPPSPixelDataFormatter::interpretRawData(bool& isRun3, bool& errorsInEvent, int fedId, const FEDRawData& rawData, Collection& digis, Errors& errors) {
+void CTPPSPixelDataFormatter::interpretRawData(
+    bool& isRun3, bool& errorsInEvent, int fedId, const FEDRawData& rawData, Collection& digis, Errors& errors) {
   int nWords = rawData.size() / sizeof(Word64);
   if (nWords == 0)
     return;
@@ -142,7 +143,6 @@ void CTPPSPixelDataFormatter::interpretRawData(bool& isRun3, bool& errorsInEvent
     mit = m_Mapping.find(fPos);
 
     if (mit == m_Mapping.end()) {
-
       if (nlink >= maxLinkIndex) {
         m_ErrorCheck.conversionError(fedId, iD, InvalidLinkId, ww, errors);
       } else if ((nroc - 1) >= maxRocIndex) {
@@ -179,7 +179,7 @@ void CTPPSPixelDataFormatter::interpretRawData(bool& isRun3, bool& errorsInEvent
     int col = (ww >> m_COL_shift) & m_COL_mask;
     int row = (ww >> m_ROW_shift) & m_ROW_mask;
 
-    if (!isRun3 && (dcol < min_Dcol || dcol > max_Dcol || pxid < min_Pixid || pxid > max_Pixid) ) {
+    if (!isRun3 && (dcol < min_Dcol || dcol > max_Dcol || pxid < min_Pixid || pxid > max_Pixid)) {
       edm::LogError("CTPPSPixelDataFormatter")
           << " unphysical dcol and/or pxid "
           << " nllink=" << nlink << " nroc=" << nroc << " adc=" << adc << " dcol=" << dcol << " pxid=" << pxid;
@@ -188,7 +188,7 @@ void CTPPSPixelDataFormatter::interpretRawData(bool& isRun3, bool& errorsInEvent
 
       continue;
     }
-    if (isRun3 && (col < min_COL || col > max_COL || row < min_ROW || row > max_ROW) ) {
+    if (isRun3 && (col < min_COL || col > max_COL || row < min_ROW || row > max_ROW)) {
       edm::LogError("CTPPSPixelDataFormatter")
           << " unphysical col and/or row "
           << " nllink=" << nlink << " nroc=" << nroc << " adc=" << adc << " col=" << col << " row=" << row;
@@ -201,14 +201,14 @@ void CTPPSPixelDataFormatter::interpretRawData(bool& isRun3, bool& errorsInEvent
     std::pair<int, int> rocPixel;
     std::pair<int, int> modPixel;
 
-    if(isRun3){
+    if (isRun3) {
       rocPixel = std::make_pair(row, col);
       modPixel = rocp.toGlobal(rocPixel);
-    }else{
+    } else {
       rocPixel = std::make_pair(dcol, pxid);
       modPixel = rocp.toGlobalfromDcol(rocPixel);
     }
-    
+
     CTPPSPixelDigi testdigi(modPixel.first, modPixel.second, adc);
 
     if (detDigis)
@@ -216,11 +216,8 @@ void CTPPSPixelDataFormatter::interpretRawData(bool& isRun3, bool& errorsInEvent
   }
 }
 
-void CTPPSPixelDataFormatter::formatRawData(bool& isRun3, unsigned int lvl1_ID,
-                                            RawData& fedRawData,
-                                            const Digis& digis,
-                                            std::vector<PPSPixelIndex> iDdet2fed) {
-
+void CTPPSPixelDataFormatter::formatRawData(
+    bool& isRun3, unsigned int lvl1_ID, RawData& fedRawData, const Digis& digis, std::vector<PPSPixelIndex> iDdet2fed) {
   std::map<int, vector<Word32> > words;
   // translate digis into 32-bit raw words and store in map indexed by Fed
   m_allDetDigis = 0;
@@ -250,17 +247,19 @@ void CTPPSPixelDataFormatter::formatRawData(bool& isRun3, unsigned int lvl1_ID,
         nroc = iDdet2fed.at(i).rocch + 1;
 
         pps::pixel::ElectronicIndex cabling = {nlink, nroc, dcol, pxid};
-	if(isRun3){
-	  cms_uint32_t word = (cabling.link << m_LINK_shift) | (cabling.roc << m_ROC_shift) |
-	    (rocPixelColumn << m_COL_shift) | (rocPixelRow << m_ROW_shift) | (it.adc() << m_ADC_shift);
+        if (isRun3) {
+          cms_uint32_t word = (cabling.link << m_LINK_shift) | (cabling.roc << m_ROC_shift) |
+                              (rocPixelColumn << m_COL_shift) | (rocPixelRow << m_ROW_shift) |
+                              (it.adc() << m_ADC_shift);
 
-	  words[iDdet2fed.at(i).fedid].push_back(word);
-	}else{
-	  cms_uint32_t word = (cabling.link << m_LINK_shift) | (cabling.roc << m_ROC_shift) |
-	    (cabling.dcol << m_DCOL_shift) | (cabling.pxid << m_PXID_shift) | (it.adc() << m_ADC_shift);
-	  
-	  words[iDdet2fed.at(i).fedid].push_back(word);
-	}
+          words[iDdet2fed.at(i).fedid].push_back(word);
+        } else {
+          cms_uint32_t word = (cabling.link << m_LINK_shift) | (cabling.roc << m_ROC_shift) |
+                              (cabling.dcol << m_DCOL_shift) | (cabling.pxid << m_PXID_shift) |
+                              (it.adc() << m_ADC_shift);
+
+          words[iDdet2fed.at(i).fedid].push_back(word);
+        }
         m_WordCounter++;
         m_hasDetDigis++;
 

--- a/EventFilter/CTPPSRawToDigi/test/test_pixels_only_cfg_eraRun3_562.py
+++ b/EventFilter/CTPPSRawToDigi/test/test_pixels_only_cfg_eraRun3_562.py
@@ -1,0 +1,82 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
+
+#process = cms.Process("CTPPSRawToDigiTestPixelsOnly",eras.Run2_2017)
+process = cms.Process("CTPPSRawToDigiTestPixelsOnly",eras.Run3)
+# minimum of logs
+process.MessageLogger = cms.Service("MessageLogger",
+    statistics = cms.untracked.vstring(),
+    destinations = cms.untracked.vstring('cerr'),
+    cerr = cms.untracked.PSet( threshold = cms.untracked.string('DEBUG') )
+)
+
+# raw data source
+process.source = cms.Source("PoolSource",
+  fileNames = cms.untracked.vstring(
+#    'file:/afs/cern.ch/user/f/fabferro/WORKSPACE/public/Unpacking/CMSSW_11_3_0/src/IORawData/SiPixelInputSources/test/PixelAlive_1463_548.root'
+      'file:/eos/cms/store/group/dpg_ctpps/comm_ctpps/PixelAlive_562_RAW.root'
+  ),
+labelRawDataLikeMC = cms.untracked.bool(False), # for testing H8 data
+duplicateCheckMode = cms.untracked.string("checkEachFile")
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+
+#process.load("CalibPPS.ESProducers.CTPPSPixelDAQMappingESSourceXML_cfi")
+
+#ctppsPixelDAQMappingESSourceXML = cms.ESSource("CTPPSPixelDAQMappingESSourceXML",
+#                                               verbosity = cms.untracked.uint32(2),
+#                                               subSystem= cms.untracked.string("RPix"),
+#                                               configuration = cms.VPSet(
+        # example configuration block:
+#        cms.PSet(
+#            validityRange = cms.EventRange("1:min - 999999999:max"),
+#            mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/rpix_tests_2021.xml"),
+#            maskFileNames = cms.vstring("CondFormats/PPSObjects/xml/rpix_channel_mask_220_far.xml")
+#            )
+#        )
+#                      
+#)
+
+# raw-to-digi conversion
+process.load("EventFilter.CTPPSRawToDigi.ctppsRawToDigi_cff")
+process.ctppsPixelDigis.inputLabel = cms.InputTag("source")
+
+ 
+
+                       
+
+#process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+#from Configuration.AlCa.GlobalTag import GlobalTag
+#process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2021_realistic', '')
+
+
+process.load("CondCore.CondDB.CondDB_cfi")
+# input database (in this case the local sqlite file)
+process.CondDB.connect = 'sqlite_file:/eos/cms/store/group/dpg_ctpps/comm_ctpps/CTPPSPixel_DAQMapping_AnalysisMask.db'
+
+process.PoolDBESSource = cms.ESSource("PoolDBESSource",
+    process.CondDB,
+    DumpStat=cms.untracked.bool(True),
+    toGet = cms.VPSet(cms.PSet(
+        record = cms.string('CTPPSPixelDAQMappingRcd'),
+        tag = cms.string("PixelDAQMapping")
+    )),
+)
+
+process.p = cms.Path(
+  process.ctppsPixelDigis
+#    process.ctppsRawToDigi
+)
+
+# output configuration
+process.output = cms.OutputModule("PoolOutputModule",
+  fileName = cms.untracked.string("file:./_digi_PixelAlive_562.root"),
+  outputCommands = cms.untracked.vstring(
+    'keep *'
+ )
+)
+
+process.outpath = cms.EndPath(process.output)


### PR DESCRIPTION
#### PR description:

This PR modifies the PPS pixel unpacking code in view of the changes for Run3. 
The changes concern 13 out of 64 bits of the data word that encode the pixel coordinates: the "double column-pixel id" convention is changed into a "column-row" one, due to the use of a slightly different readout chip (PROC600 instead of PsiDIG46).
The back compatibility with Run2 data is ensured by means of era modifiers: Run3 convention becomes the default one and Run2 one is triggered by means of ctpps_201* era modifiers.
The part of the code packing the simulated data is also changed accordingly.

#### PR validation:

The detectors are not yet installed. They will be installed beginning of November 21. Private validation on lab data, Run2 data and full simulation was done.  

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport expected.
