### PR TITLE
removed lexical_cast boost dependency

### DIFF
--- a/L1Trigger/GlobalTriggerAnalyzer/src/L1GtTrigReport.cc
+++ b/L1Trigger/GlobalTriggerAnalyzer/src/L1GtTrigReport.cc
@@ -26,8 +26,6 @@
 #include <cmath>
 #include <string>
 
-#include "boost/lexical_cast.hpp"
-
 // user include files
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutSetupFwd.h"
 
@@ -473,7 +471,7 @@ void L1GtTrigReport::analyze(const edm::Event& iEvent, const edm::EventSetup& ev
 
       std::string ttName = itAlgo->first;
       int ttBitNumber = (itAlgo->second).algoBitNumber();
-      // std::string ttName = boost::lexical_cast<std::string>(iTechTrig);
+      // std::string ttName = std::to_string(iTechTrig);
       // int ttBitNumber = iTechTrig;
 
       // the result before applying the trigger masks is available

--- a/L1Trigger/GlobalTriggerAnalyzer/src/L1RetrieveL1Extra.cc
+++ b/L1Trigger/GlobalTriggerAnalyzer/src/L1RetrieveL1Extra.cc
@@ -25,8 +25,6 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "boost/lexical_cast.hpp"
-
 // constructor
 L1RetrieveL1Extra::L1RetrieveL1Extra(const edm::ParameterSet& paramSet, edm::ConsumesCollector&& iC)
     :  //

--- a/L1Trigger/L1TCommon/interface/Mask.h
+++ b/L1Trigger/L1TCommon/interface/Mask.h
@@ -2,9 +2,6 @@
 #define L1Trigger_L1TCommon_Mask_h
 #include <string>
 
-//boost libraries
-#include <boost/lexical_cast.hpp>
-
 namespace l1t {
 
   class Mask {

--- a/L1Trigger/L1TCommon/src/Mask.cc
+++ b/L1Trigger/L1TCommon/src/Mask.cc
@@ -4,13 +4,13 @@ namespace l1t {
 
   Mask::Mask(std::string id, std::string procRole) {
     id_ = id;
-    port_ = boost::lexical_cast<int>(id.substr(id.find_last_not_of("0123456789") + 1));
+    port_ = std::stoi(id.substr(id.find_last_not_of("0123456789") + 1));
     procRole_ = procRole;
   }
 
   void Mask::setPort(std::string id) {
     id_ = id;
-    port_ = boost::lexical_cast<int>(id.substr(id.find_last_not_of("0123456789") + 1));
+    port_ = std::stoi(id.substr(id.find_last_not_of("0123456789") + 1));
   }
 
 }  // namespace l1t


### PR DESCRIPTION
#### PR description:
Remove boost lexical cast dependency in L1Trigger with corresponding stl alternatives

#### PR validation:

Passed on scram -b runtests

#### if this PR is a backport:
@davidlange6 @vgvassilev
