### PR TITLE
Set numberOfConcurrentLuminosityBlocks to 1 for ALCA sequences that have EDModules that are not planned to support concurrent lumis

### DIFF
--- a/Configuration/AlCa/python/autoAlca.py
+++ b/Configuration/AlCa/python/autoAlca.py
@@ -124,3 +124,11 @@ autoAlca = { 'allForPrompt'         : buildList(['Charmonium', 'Commissioning', 
              'allForPromptCosmics'  : buildList(['Cosmics'], AlCaRecoMatrix),
              'allForExpressCosmics' : buildList(['ExpressCosmics'], AlCaRecoMatrix) }
 autoAlca.update(AlCaRecoMatrix)
+
+# list of AlCa sequences that have modules that do not support concurrent LuminosityBlocks
+AlCaNoConcurrentLumis = [
+    'PromptCalibProd',                 # AlcaBeamSpotProducer
+    'PromptCalibProdSiPixelAli',       # AlignmentProducerAsAnalyzer, MillePedeFileConverter
+    'PromptCalibProdBeamSpotHP',       # AlcaBeamSpotProducer
+    'PromptCalibProdBeamSpotHPLowPU',  # AlcaBeamSpotProducer
+]

--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1275,7 +1275,7 @@ class ConfigBuilder(object):
         # decide which ALCA paths to use
         alcaList = sequence.split("+")
         maxLevel=0
-        from Configuration.AlCa.autoAlca import autoAlca
+        from Configuration.AlCa.autoAlca import autoAlca, AlCaNoConcurrentLumis
         # support @X from autoAlca.py, and recursion support: i.e T0:@Mu+@EG+...
         self.expandMapping(alcaList,autoAlca)
         self.AlCaPaths=[]
@@ -1283,6 +1283,10 @@ class ConfigBuilder(object):
             alcastream = getattr(alcaConfig,name)
             shortName = name.replace('ALCARECOStream','')
             if shortName in alcaList and isinstance(alcastream,cms.FilteredStream):
+                if shortName in AlCaNoConcurrentLumis:
+                    print("Setting numberOfConcurrentLuminosityBlocks=1 because of AlCa sequence {}".format(shortName))
+                    self._options.nConcurrentLumis = "1"
+                    self._options.nConcurrentIOVs = "1"
                 output = self.addExtraStream(name,alcastream, workflow = workflow)
                 self.executeAndRemember('process.ALCARECOEventContent.outputCommands.extend(process.OutALCARECO'+shortName+'_noDrop.outputCommands)')
                 self.AlCaPaths.append(shortName)


### PR DESCRIPTION
#### PR description:

As reported in https://github.com/cms-sw/cmssw/issues/25090 the EDModules `AlcaBeamSpotProducer`, `AlignmentProducerAsAnalyzer`, `MillePedeFileConverter`, `AlcaBeamSpotProducer` do not support concurrent lumis, and in the PPD workshop in March it was said that in T0 the ALCA steps will process only one lumi at a time and therefore they would not benefit from concurrent lumis.

In order to silence the warning message on multithreaded jobs, and to later allow changing that warning to an exception (to better prevent any modules that do not support concurrent lumis to creep in workflow steps that are expected to support concurrent lumis), this PR suggest the `ConfigBuilder` to set the number of concurrent lumis (and IOVs) explicitly to 1 if the job has `ALCA` step with any of the AlCa sequences that (currently) contain modules that do not support concurrent lumis. In this PR the `Configuration/AlCa/python/autoAlca.py` was chosen as a place for the list of those sequences, in principle they could be listed elsewhere as well.

To best of my knowledge this approach should cover both `cmsDriver` and T0, since the latter uses `ConfigBuilder` e.g. in
https://github.com/cms-sw/cmssw/blob/209b3931b96401ccb7a13b20c1e0923319637399/Configuration/DataProcessing/python/Reco.py#L240

#### PR validation:

Workflows `134.0,1001.0,1001.2,1004.0,1030.0` set their `ALCA` or `ALCAOUTPUT` steps to use 