### PR TITLE
Have embedded root files send close reports

### DIFF
--- a/IOPool/Input/src/RootEmbeddedFileSequence.cc
+++ b/IOPool/Input/src/RootEmbeddedFileSequence.cc
@@ -16,6 +16,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "Utilities/StorageFactory/interface/StatisticsSenderService.h"
 
 #include "CLHEP/Random/RandFlat.h"
 
@@ -126,6 +127,10 @@ namespace edm {
   void RootEmbeddedFileSequence::closeFile_() {
     // delete the RootFile object.
     if (rootFile()) {
+      edm::Service<edm::storage::StatisticsSenderService> service;
+      if (service.isAvailable()) {
+        service->filePreCloseEvent(lfn(), usedFallback());
+      }
       rootFile().reset();
     }
   }


### PR DESCRIPTION
#### PR description:

When a file controlled by the RootEmbeddedFileSequence closes, it now informs the StatisticsSenderService.
Had to call the service directly as there was no good way to pass the ActivityRegistry into a class meant to be embedded inside a ED module.

#### PR validation:

Code compiles and framework unit tests pass. I had no way to check to see if the messages are actually being sent.

fixes #34873