### PR TITLE
ECAL esConsumes migration of CalibCalorimetry packages

### DIFF
--- a/CalibCalorimetry/CaloMiscalibTools/interface/CaloMiscalibMapEcal.h
+++ b/CalibCalorimetry/CaloMiscalibTools/interface/CaloMiscalibMapEcal.h
@@ -5,7 +5,6 @@
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
 #include <iostream>

--- a/CalibCalorimetry/CaloMiscalibTools/interface/CaloMiscalibMapHcal.h
+++ b/CalibCalorimetry/CaloMiscalibTools/interface/CaloMiscalibMapHcal.h
@@ -4,7 +4,6 @@
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 #include "Geometry/CaloTopology/interface/HcalTopology.h"

--- a/CalibCalorimetry/CaloMiscalibTools/interface/CaloMiscalibTools.h
+++ b/CalibCalorimetry/CaloMiscalibTools/interface/CaloMiscalibTools.h
@@ -36,7 +36,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "CondFormats/EcalObjects/interface/EcalIntercalibConstants.h"
 #include "CondFormats/DataRecord/interface/EcalIntercalibConstantsRcd.h"

--- a/CalibCalorimetry/CaloMiscalibTools/interface/CaloMiscalibToolsMC.h
+++ b/CalibCalorimetry/CaloMiscalibTools/interface/CaloMiscalibToolsMC.h
@@ -36,7 +36,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "CondFormats/EcalObjects/interface/EcalIntercalibConstantsMC.h"
 #include "CondFormats/DataRecord/interface/EcalIntercalibConstantsMCRcd.h"

--- a/CalibCalorimetry/CaloMiscalibTools/interface/EcalRecHitRecalib.h
+++ b/CalibCalorimetry/CaloMiscalibTools/interface/EcalRecHitRecalib.h
@@ -50,8 +50,8 @@ private:
   const std::string ecalHitsProducer_;
   const std::string barrelHits_;
   const std::string endcapHits_;
-  const std::string RecalibBarrelHits_;
-  const std::string RecalibEndcapHits_;
+  const std::string recalibBarrelHits_;
+  const std::string recalibEndcapHits_;
   const double refactor_;
   const double refactor_mean_;
 

--- a/CalibCalorimetry/CaloMiscalibTools/interface/EcalRecHitRecalib.h
+++ b/CalibCalorimetry/CaloMiscalibTools/interface/EcalRecHitRecalib.h
@@ -23,18 +23,21 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
+#include "CondFormats/EcalObjects/interface/EcalIntercalibConstants.h"
+#include "CondFormats/DataRecord/interface/EcalIntercalibConstantsRcd.h"
 //
 // class decleration
 //
 
-class EcalRecHitRecalib : public edm::EDProducer {
+class EcalRecHitRecalib : public edm::stream::EDProducer<> {
 public:
   explicit EcalRecHitRecalib(const edm::ParameterSet &);
   ~EcalRecHitRecalib() override;
@@ -44,13 +47,19 @@ public:
 private:
   // ----------member data ---------------------------
 
-  std::string ecalHitsProducer_;
-  std::string barrelHits_;
-  std::string endcapHits_;
-  std::string RecalibBarrelHits_;
-  std::string RecalibEndcapHits_;
-  double refactor_;
-  double refactor_mean_;
+  const std::string ecalHitsProducer_;
+  const std::string barrelHits_;
+  const std::string endcapHits_;
+  const std::string RecalibBarrelHits_;
+  const std::string RecalibEndcapHits_;
+  const double refactor_;
+  const double refactor_mean_;
+
+  const edm::EDGetTokenT<EBRecHitCollection> ebRecHitToken_;
+  const edm::EDGetTokenT<EERecHitCollection> eeRecHitToken_;
+  const edm::ESGetToken<EcalIntercalibConstants, EcalIntercalibConstantsRcd> intercalibConstsToken_;
+  const edm::EDPutTokenT<EBRecHitCollection> barrelHitsToken_;
+  const edm::EDPutTokenT<EERecHitCollection> endcapHitsToken_;
 };
 
 #endif

--- a/CalibCalorimetry/CaloMiscalibTools/interface/HcalRecHitRecalib.h
+++ b/CalibCalorimetry/CaloMiscalibTools/interface/HcalRecHitRecalib.h
@@ -23,7 +23,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -32,8 +32,9 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CalibCalorimetry/CaloMiscalibTools/interface/CaloMiscalibMapHcal.h"
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
+#include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 
-class HcalRecHitRecalib : public edm::EDProducer {
+class HcalRecHitRecalib : public edm::stream::EDProducer<> {
 public:
   explicit HcalRecHitRecalib(const edm::ParameterSet &);
   ~HcalRecHitRecalib() override;
@@ -42,18 +43,19 @@ public:
   void produce(edm::Event &, const edm::EventSetup &) override;
 
 private:
-  edm::EDGetTokenT<HBHERecHitCollection> tok_hbhe_;
-  edm::EDGetTokenT<HORecHitCollection> tok_ho_;
-  edm::EDGetTokenT<HFRecHitCollection> tok_hf_;
-  std::string RecalibHBHEHits_;
-  std::string RecalibHFHits_;
-  std::string RecalibHOHits_;
+  const edm::EDGetTokenT<HBHERecHitCollection> tok_hbhe_;
+  const edm::EDGetTokenT<HORecHitCollection> tok_ho_;
+  const edm::EDGetTokenT<HFRecHitCollection> tok_hf_;
+  const edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> topologyToken_;
+  const std::string RecalibHBHEHits_;
+  const std::string RecalibHFHits_;
+  const std::string RecalibHOHits_;
 
   std::string hcalfile_;
-  std::string hcalfileinpath_;
+  const std::string hcalfileinpath_;
 
   CaloMiscalibMapHcal mapHcal_;
-  double refactor_;
-  double refactor_mean_;
+  const double refactor_;
+  const double refactor_mean_;
 };
 #endif

--- a/CalibCalorimetry/CaloMiscalibTools/interface/HcalRecHitRecalib.h
+++ b/CalibCalorimetry/CaloMiscalibTools/interface/HcalRecHitRecalib.h
@@ -47,9 +47,9 @@ private:
   const edm::EDGetTokenT<HORecHitCollection> tok_ho_;
   const edm::EDGetTokenT<HFRecHitCollection> tok_hf_;
   const edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> topologyToken_;
-  const std::string RecalibHBHEHits_;
-  const std::string RecalibHFHits_;
-  const std::string RecalibHOHits_;
+  const std::string recalibHBHEHits_;
+  const std::string recalibHFHits_;
+  const std::string recalibHOHits_;
 
   std::string hcalfile_;
   const std::string hcalfileinpath_;

--- a/CalibCalorimetry/CaloMiscalibTools/interface/WriteEcalMiscalibConstants.h
+++ b/CalibCalorimetry/CaloMiscalibTools/interface/WriteEcalMiscalibConstants.h
@@ -11,17 +11,20 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "CondFormats/EcalObjects/interface/EcalIntercalibConstants.h"
+#include "CondFormats/DataRecord/interface/EcalIntercalibConstantsRcd.h"
 //
 // class decleration
 //
 
-class WriteEcalMiscalibConstants : public edm::EDAnalyzer {
+class WriteEcalMiscalibConstants : public edm::one::EDAnalyzer<> {
 public:
   explicit WriteEcalMiscalibConstants(const edm::ParameterSet&);
   ~WriteEcalMiscalibConstants() override;
@@ -33,4 +36,6 @@ private:
 
   // ----------member data ---------------------------
   std::string newTagRequest_;
+
+  const edm::ESGetToken<EcalIntercalibConstants, EcalIntercalibConstantsRcd> intercalibConstsToken_;
 };

--- a/CalibCalorimetry/CaloMiscalibTools/interface/WriteEcalMiscalibConstantsMC.h
+++ b/CalibCalorimetry/CaloMiscalibTools/interface/WriteEcalMiscalibConstantsMC.h
@@ -11,17 +11,20 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "CondFormats/EcalObjects/interface/EcalIntercalibConstantsMC.h"
+#include "CondFormats/DataRecord/interface/EcalIntercalibConstantsMCRcd.h"
 //
 // class decleration
 //
 
-class WriteEcalMiscalibConstantsMC : public edm::EDAnalyzer {
+class WriteEcalMiscalibConstantsMC : public edm::one::EDAnalyzer<> {
 public:
   explicit WriteEcalMiscalibConstantsMC(const edm::ParameterSet&);
   ~WriteEcalMiscalibConstantsMC() override;
@@ -33,4 +36,6 @@ private:
 
   // ----------member data ---------------------------
   std::string newTagRequest_;
+
+  const edm::ESGetToken<EcalIntercalibConstantsMC, EcalIntercalibConstantsMCRcd> intercalibConstsToken_;
 };

--- a/CalibCalorimetry/CaloMiscalibTools/plugins/CaloMiscalibTools.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/plugins/CaloMiscalibTools.cc
@@ -25,6 +25,7 @@
 // user include files
 #include "CalibCalorimetry/CaloMiscalibTools/interface/CaloMiscalibTools.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "CalibCalorimetry/CaloMiscalibTools/interface/MiscalibReaderFromXMLEcalBarrel.h"
 #include "CalibCalorimetry/CaloMiscalibTools/interface/MiscalibReaderFromXMLEcalEndcap.h"
@@ -45,8 +46,8 @@ CaloMiscalibTools::CaloMiscalibTools(const edm::ParameterSet& iConfig) {
   barrelfile_ = barrelfiletmp.fullPath();
   endcapfile_ = endcapfiletmp.fullPath();
 
-  std::cout << "Barrel file is:" << barrelfile_ << std::endl;
-  std::cout << "endcap file is:" << endcapfile_ << std::endl;
+  edm::LogVerbatim("CaloMiscalibTools") << "Barrel file is:" << barrelfile_;
+  edm::LogVerbatim("CaloMiscalibTools") << "endcap file is:" << endcapfile_;
 
   // added by Zhen (changed since 1_2_0)
   setWhatProduced(this, &CaloMiscalibTools::produce);
@@ -75,9 +76,7 @@ CaloMiscalibTools::ReturnType CaloMiscalibTools::produce(const EcalIntercalibCon
     endcapreader_.parseXMLMiscalibFile(endcapfile_);
   map.print();
   // Added by Zhen, need a new object so to not be deleted at exit
-  //    std::cout<<"about to copy"<<std::endl;
   CaloMiscalibTools::ReturnType mydata = std::make_unique<EcalIntercalibConstants>(map.get());
-  //    std::cout<<"mydata "<<mydata<<std::endl;
   return mydata;
 }
 

--- a/CalibCalorimetry/CaloMiscalibTools/plugins/CaloMiscalibToolsMC.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/plugins/CaloMiscalibToolsMC.cc
@@ -25,6 +25,7 @@
 // user include files
 #include "CalibCalorimetry/CaloMiscalibTools/interface/CaloMiscalibToolsMC.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "CalibCalorimetry/CaloMiscalibTools/interface/MiscalibReaderFromXMLEcalBarrel.h"
 #include "CalibCalorimetry/CaloMiscalibTools/interface/MiscalibReaderFromXMLEcalEndcap.h"
@@ -45,8 +46,8 @@ CaloMiscalibToolsMC::CaloMiscalibToolsMC(const edm::ParameterSet& iConfig) {
   barrelfile_ = barrelfiletmp.fullPath();
   endcapfile_ = endcapfiletmp.fullPath();
 
-  std::cout << "Barrel file is:" << barrelfile_ << std::endl;
-  std::cout << "endcap file is:" << endcapfile_ << std::endl;
+  edm::LogVerbatim("CaloMiscalibToolsMC") << "Barrel file is:" << barrelfile_;
+  edm::LogVerbatim("CaloMiscalibToolsMC") << "endcap file is:" << endcapfile_;
 
   // added by Zhen (changed since 1_2_0)
   setWhatProduced(this, &CaloMiscalibToolsMC::produce);
@@ -75,9 +76,7 @@ CaloMiscalibToolsMC::ReturnType CaloMiscalibToolsMC::produce(const EcalIntercali
     endcapreader_.parseXMLMiscalibFile(endcapfile_);
   map.print();
   // Added by Zhen, need a new object so to not be deleted at exit
-  //    std::cout<<"about to copy"<<std::endl;
   CaloMiscalibToolsMC::ReturnType mydata = std::make_unique<EcalIntercalibConstantsMC>(map.get());
-  //    std::cout<<"mydata "<<mydata<<std::endl;
   return mydata;
 }
 

--- a/CalibCalorimetry/CaloMiscalibTools/plugins/EcalRecHitRecalib.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/plugins/EcalRecHitRecalib.cc
@@ -10,15 +10,15 @@ EcalRecHitRecalib::EcalRecHitRecalib(const edm::ParameterSet& iConfig)
     : ecalHitsProducer_(iConfig.getParameter<std::string>("ecalRecHitsProducer")),
       barrelHits_(iConfig.getParameter<std::string>("barrelHitCollection")),
       endcapHits_(iConfig.getParameter<std::string>("endcapHitCollection")),
-      RecalibBarrelHits_(iConfig.getParameter<std::string>("RecalibBarrelHitCollection")),
-      RecalibEndcapHits_(iConfig.getParameter<std::string>("RecalibEndcapHitCollection")),
+      recalibBarrelHits_(iConfig.getParameter<std::string>("RecalibBarrelHitCollection")),
+      recalibEndcapHits_(iConfig.getParameter<std::string>("RecalibEndcapHitCollection")),
       refactor_(iConfig.getUntrackedParameter<double>("Refactor", (double)1)),
       refactor_mean_(iConfig.getUntrackedParameter<double>("Refactor_mean", (double)1)),
       ebRecHitToken_(consumes<EBRecHitCollection>(edm::InputTag(ecalHitsProducer_, barrelHits_))),
       eeRecHitToken_(consumes<EERecHitCollection>(edm::InputTag(ecalHitsProducer_, endcapHits_))),
       intercalibConstsToken_(esConsumes()),
-      barrelHitsToken_(produces<EBRecHitCollection>(RecalibBarrelHits_)),
-      endcapHitsToken_(produces<EERecHitCollection>(RecalibEndcapHits_)) {}
+      barrelHitsToken_(produces<EBRecHitCollection>(recalibBarrelHits_)),
+      endcapHitsToken_(produces<EERecHitCollection>(recalibEndcapHits_)) {}
 
 EcalRecHitRecalib::~EcalRecHitRecalib() {}
 
@@ -64,7 +64,6 @@ void EcalRecHitRecalib::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
 
       if (icalit != ical.getMap().end()) {
         icalconst = (*icalit);
-        // edm::LogDebug("EcalRecHitRecalib") << "Found intercalib for xtal " << EBDetId(itb->id()) << " " << icalconst ;
 
       } else {
         edm::LogError("EcalRecHitRecalib") << "No intercalib const found for xtal " << EBDetId(itb->id())
@@ -90,7 +89,6 @@ void EcalRecHitRecalib::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
 
       if (icalit != ical.getMap().end()) {
         icalconst = (*icalit);
-        // edm:: LogDebug("EcalRecHitRecalib") << "Found intercalib for xtal " << EEDetId(ite->id()) << " " << icalconst ;
       } else {
         edm::LogError("EcalRecHitRecalib") << "No intercalib const found for xtal " << EEDetId(ite->id())
                                            << "! something wrong with EcalIntercalibConstants in your DB? ";

--- a/CalibCalorimetry/CaloMiscalibTools/plugins/EcalRecHitRecalib.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/plugins/EcalRecHitRecalib.cc
@@ -1,30 +1,24 @@
-
-#include "CondFormats/EcalObjects/interface/EcalIntercalibConstants.h"
-#include "CondFormats/DataRecord/interface/EcalIntercalibConstantsRcd.h"
-
 #include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
 #include "CalibCalorimetry/CaloMiscalibTools/interface/EcalRecHitRecalib.h"
-#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-EcalRecHitRecalib::EcalRecHitRecalib(const edm::ParameterSet& iConfig) {
-  ecalHitsProducer_ = iConfig.getParameter<std::string>("ecalRecHitsProducer");
-  barrelHits_ = iConfig.getParameter<std::string>("barrelHitCollection");
-  endcapHits_ = iConfig.getParameter<std::string>("endcapHitCollection");
-  RecalibBarrelHits_ = iConfig.getParameter<std::string>("RecalibBarrelHitCollection");
-  RecalibEndcapHits_ = iConfig.getParameter<std::string>("RecalibEndcapHitCollection");
-  refactor_ = iConfig.getUntrackedParameter<double>("Refactor", (double)1);
-  refactor_mean_ = iConfig.getUntrackedParameter<double>("Refactor_mean", (double)1);
-
-  //register your products
-  produces<EBRecHitCollection>(RecalibBarrelHits_);
-  produces<EERecHitCollection>(RecalibEndcapHits_);
-}
+EcalRecHitRecalib::EcalRecHitRecalib(const edm::ParameterSet& iConfig)
+    : ecalHitsProducer_(iConfig.getParameter<std::string>("ecalRecHitsProducer")),
+      barrelHits_(iConfig.getParameter<std::string>("barrelHitCollection")),
+      endcapHits_(iConfig.getParameter<std::string>("endcapHitCollection")),
+      RecalibBarrelHits_(iConfig.getParameter<std::string>("RecalibBarrelHitCollection")),
+      RecalibEndcapHits_(iConfig.getParameter<std::string>("RecalibEndcapHitCollection")),
+      refactor_(iConfig.getUntrackedParameter<double>("Refactor", (double)1)),
+      refactor_mean_(iConfig.getUntrackedParameter<double>("Refactor_mean", (double)1)),
+      ebRecHitToken_(consumes<EBRecHitCollection>(edm::InputTag(ecalHitsProducer_, barrelHits_))),
+      eeRecHitToken_(consumes<EERecHitCollection>(edm::InputTag(ecalHitsProducer_, endcapHits_))),
+      intercalibConstsToken_(esConsumes()),
+      barrelHitsToken_(produces<EBRecHitCollection>(RecalibBarrelHits_)),
+      endcapHitsToken_(produces<EERecHitCollection>(RecalibEndcapHits_)) {}
 
 EcalRecHitRecalib::~EcalRecHitRecalib() {}
 
@@ -39,14 +33,14 @@ void EcalRecHitRecalib::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
   const EBRecHitCollection* EBRecHits = nullptr;
   const EERecHitCollection* EERecHits = nullptr;
 
-  iEvent.getByLabel(ecalHitsProducer_, barrelHits_, barrelRecHitsHandle);
+  iEvent.getByToken(ebRecHitToken_, barrelRecHitsHandle);
   if (!barrelRecHitsHandle.isValid()) {
     LogDebug("") << "EcalREcHitMiscalib: Error! can't get product!" << std::endl;
   } else {
     EBRecHits = barrelRecHitsHandle.product();  // get a ptr to the product
   }
 
-  iEvent.getByLabel(ecalHitsProducer_, endcapHits_, endcapRecHitsHandle);
+  iEvent.getByToken(eeRecHitToken_, endcapRecHitsHandle);
   if (!endcapRecHitsHandle.isValid()) {
     LogDebug("") << "EcalREcHitMiscalib: Error! can't get product!" << std::endl;
   } else {
@@ -58,19 +52,17 @@ void EcalRecHitRecalib::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
   auto RecalibEERecHitCollection = std::make_unique<EERecHitCollection>();
 
   // Intercalib constants
-  edm::ESHandle<EcalIntercalibConstants> pIcal;
-  iSetup.get<EcalIntercalibConstantsRcd>().get(pIcal);
-  const EcalIntercalibConstants* ical = pIcal.product();
+  const EcalIntercalibConstants &ical = iSetup.getData(intercalibConstsToken_);
 
   if (EBRecHits) {
     //loop on all EcalRecHits (barrel)
     EBRecHitCollection::const_iterator itb;
     for (itb = EBRecHits->begin(); itb != EBRecHits->end(); ++itb) {
       // find intercalib constant for this xtal
-      EcalIntercalibConstantMap::const_iterator icalit = ical->getMap().find(itb->id().rawId());
+      EcalIntercalibConstantMap::const_iterator icalit = ical.getMap().find(itb->id().rawId());
       EcalIntercalibConstant icalconst = -1;
 
-      if (icalit != ical->getMap().end()) {
+      if (icalit != ical.getMap().end()) {
         icalconst = (*icalit);
         // edm::LogDebug("EcalRecHitRecalib") << "Found intercalib for xtal " << EBDetId(itb->id()) << " " << icalconst ;
 
@@ -93,10 +85,10 @@ void EcalRecHitRecalib::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
     EERecHitCollection::const_iterator ite;
     for (ite = EERecHits->begin(); ite != EERecHits->end(); ++ite) {
       // find intercalib constant for this xtal
-      EcalIntercalibConstantMap::const_iterator icalit = ical->getMap().find(ite->id().rawId());
+      EcalIntercalibConstantMap::const_iterator icalit = ical.getMap().find(ite->id().rawId());
       EcalIntercalibConstant icalconst = -1;
 
-      if (icalit != ical->getMap().end()) {
+      if (icalit != ical.getMap().end()) {
         icalconst = (*icalit);
         // edm:: LogDebug("EcalRecHitRecalib") << "Found intercalib for xtal " << EEDetId(ite->id()) << " " << icalconst ;
       } else {
@@ -115,6 +107,6 @@ void EcalRecHitRecalib::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
   }
 
   //Put Recalibrated rechit in the event
-  iEvent.put(std::move(RecalibEBRecHitCollection), RecalibBarrelHits_);
-  iEvent.put(std::move(RecalibEERecHitCollection), RecalibEndcapHits_);
+  iEvent.put(barrelHitsToken_, std::move(RecalibEBRecHitCollection));
+  iEvent.put(endcapHitsToken_, std::move(RecalibEERecHitCollection));
 }

--- a/CalibCalorimetry/CaloMiscalibTools/plugins/EcalRecHitRecalib.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/plugins/EcalRecHitRecalib.cc
@@ -52,7 +52,7 @@ void EcalRecHitRecalib::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
   auto RecalibEERecHitCollection = std::make_unique<EERecHitCollection>();
 
   // Intercalib constants
-  const EcalIntercalibConstants &ical = iSetup.getData(intercalibConstsToken_);
+  const EcalIntercalibConstants& ical = iSetup.getData(intercalibConstsToken_);
 
   if (EBRecHits) {
     //loop on all EcalRecHits (barrel)

--- a/CalibCalorimetry/CaloMiscalibTools/plugins/HcalRecHitRecalib.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/plugins/HcalRecHitRecalib.cc
@@ -12,23 +12,16 @@ HcalRecHitRecalib::HcalRecHitRecalib(const edm::ParameterSet& iConfig)
       tok_ho_(consumes<HORecHitCollection>(iConfig.getParameter<edm::InputTag>("hoInput"))),
       tok_hf_(consumes<HFRecHitCollection>(iConfig.getParameter<edm::InputTag>("hfInput"))),
       topologyToken_(esConsumes<edm::Transition::BeginRun>()),
-      RecalibHBHEHits_(iConfig.getParameter<std::string>("RecalibHBHEHitCollection")),
-      RecalibHFHits_(iConfig.getParameter<std::string>("RecalibHFHitCollection")),
-      RecalibHOHits_(iConfig.getParameter<std::string>("RecalibHOHitCollection")),
+      recalibHBHEHits_(iConfig.getParameter<std::string>("RecalibHBHEHitCollection")),
+      recalibHFHits_(iConfig.getParameter<std::string>("RecalibHFHitCollection")),
+      recalibHOHits_(iConfig.getParameter<std::string>("RecalibHOHitCollection")),
       hcalfileinpath_(iConfig.getUntrackedParameter<std::string>("fileNameHcal", "")),
       refactor_(iConfig.getUntrackedParameter<double>("Refactor", (double)1)),
       refactor_mean_(iConfig.getUntrackedParameter<double>("Refactor_mean", (double)1)) {
-  //   HBHEHitsProducer_ = iConfig.getParameter< std::string > ("HBHERecHitsProducer");
-  //   HOHitsProducer_ = iConfig.getParameter< std::string > ("HERecHitsProducer");
-  //   HFHitsProducer_ = iConfig.getParameter< std::string > ("HERecHitsProducer");
-  //   HBHEHits_ = iConfig.getParameter< std::string > ("HBHEHitCollection");
-  //   HFHits_ = iConfig.getParameter< std::string > ("HFHitCollection");
-  //   HOHits_ = iConfig.getParameter< std::string > ("HOHitCollection");
-
   //register your products
-  produces<HBHERecHitCollection>(RecalibHBHEHits_);
-  produces<HFRecHitCollection>(RecalibHFHits_);
-  produces<HORecHitCollection>(RecalibHOHits_);
+  produces<HBHERecHitCollection>(recalibHBHEHits_);
+  produces<HFRecHitCollection>(recalibHFHits_);
+  produces<HORecHitCollection>(recalibHOHits_);
 
   // here read them from xml (particular to HCAL)
   edm::FileInPath hcalfiletmp("CalibCalorimetry/CaloMiscalibTools/data/" + hcalfileinpath_);
@@ -82,46 +75,16 @@ void HcalRecHitRecalib::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
     HFRecHits = HFRecHitsHandle.product();  // get a ptr to the product
   }
 
-  //     iEvent.getByLabel(HBHEHitsProducer_,HBHEHits_,HBHERecHitsHandle);
-  //     HBHERecHits = HBHERecHitsHandle.product(); // get a ptr to the product
-
-  //     iEvent.getByLabel(HFHitsProducer_,HFHits_,HFRecHitsHandle);
-  //     HFRecHits = HFRecHitsHandle.product(); // get a ptr to the product
-
-  //     iEvent.getByLabel(HOHitsProducer_,HOHits_,HORecHitsHandle);
-  //     HORecHits = HORecHitsHandle.product(); // get a ptr to the product
-
   //Create empty output collections
   auto RecalibHBHERecHitCollection = std::make_unique<HBHERecHitCollection>();
   auto RecalibHFRecHitCollection = std::make_unique<HFRecHitCollection>();
   auto RecalibHORecHitCollection = std::make_unique<HORecHitCollection>();
 
-  // Intercalib constants
-  //  edm::ESHandle<EcalIntercalibConstants> pIcal;
-  //  iSetup.get<EcalIntercalibConstantsRcd>().get(pIcal);
-  //  const EcalIntercalibConstants* ical = pIcal.product();
-
   if (HBHERecHits) {
-    //loop on all EcalRecHits (barrel)
     HBHERecHitCollection::const_iterator itHBHE;
     for (itHBHE = HBHERecHits->begin(); itHBHE != HBHERecHits->end(); ++itHBHE) {
-      // find intercalib constant for this cell
-
-      //	EcalIntercalibConstants::EcalIntercalibConstantMap::const_iterator icalit=ical->getMap().find(itb->id().rawId());
-      //	EcalIntercalibConstants::EcalIntercalibConstant icalconst;
-
-      //	if( icalit!=ical->getMap().end() ){
-      //	  icalconst = icalit->second;
-      // edm::LogDebug("EcalRecHitMiscalib") << "Found intercalib for xtal " << EBDetId(itb->id()) << " " << icalconst ;
-
-      //	} else {
-      //	  edm::LogError("EcalRecHitMiscalib") << "No intercalib const found for xtal " << EBDetId(itb->id()) << "! something wrong with EcalIntercalibConstants in your DB? "
-      //              ;
-      //          }
-
-      float icalconst = (mapHcal_.get().find(itHBHE->id().rawId()))->second;
       // make the rechit with rescaled energy and put in the output collection
-
+      float icalconst = (mapHcal_.get().find(itHBHE->id().rawId()))->second;
       icalconst = refactor_mean_ +
                   (icalconst - refactor_mean_) * refactor_;  //apply additional scaling factor (works if gaussian)
       HBHERecHit aHit(itHBHE->id(), itHBHE->energy() * icalconst, itHBHE->time());
@@ -131,25 +94,9 @@ void HcalRecHitRecalib::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
   }
 
   if (HFRecHits) {
-    //loop on all EcalRecHits (barrel)
     HFRecHitCollection::const_iterator itHF;
     for (itHF = HFRecHits->begin(); itHF != HFRecHits->end(); ++itHF) {
-      // find intercalib constant for this cell
-
-      //	EcalIntercalibConstants::EcalIntercalibConstantMap::const_iterator icalit=ical->getMap().find(itb->id().rawId());
-      //	EcalIntercalibConstants::EcalIntercalibConstant icalconst;
-
-      //	if( icalit!=ical->getMap().end() ){
-      //	  icalconst = icalit->second;
-      // edm::LogDebug("EcalRecHitMiscalib") << "Found intercalib for xtal " << EBDetId(itb->id()) << " " << icalconst ;
-
-      //	} else {
-      //	  edm::LogError("EcalRecHitMiscalib") << "No intercalib const found for xtal " << EBDetId(itb->id()) << "! something wrong with EcalIntercalibConstants in your DB? "
-      //              ;
-      //          }
-
       // make the rechit with rescaled energy and put in the output collection
-
       float icalconst = (mapHcal_.get().find(itHF->id().rawId()))->second;
       icalconst = refactor_mean_ +
                   (icalconst - refactor_mean_) * refactor_;  //apply additional scaling factor (works if gaussian)
@@ -160,25 +107,9 @@ void HcalRecHitRecalib::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
   }
 
   if (HORecHits) {
-    //loop on all EcalRecHits (barrel)
     HORecHitCollection::const_iterator itHO;
     for (itHO = HORecHits->begin(); itHO != HORecHits->end(); ++itHO) {
-      // find intercalib constant for this cell
-
-      //	EcalIntercalibConstants::EcalIntercalibConstantMap::const_iterator icalit=ical->getMap().find(itb->id().rawId());
-      //	EcalIntercalibConstants::EcalIntercalibConstant icalconst;
-
-      //	if( icalit!=ical->getMap().end() ){
-      //	  icalconst = icalit->second;
-      // edm::LogDebug("EcalRecHitMiscalib") << "Found intercalib for xtal " << EBDetId(itb->id()) << " " << icalconst ;
-
-      //	} else {
-      //	  edm::LogError("EcalRecHitMiscalib") << "No intercalib const found for xtal " << EBDetId(itb->id()) << "! something wrong with EcalIntercalibConstants in your DB? "
-      //              ;
-      //          }
-
       // make the rechit with rescaled energy and put in the output collection
-
       float icalconst = (mapHcal_.get().find(itHO->id().rawId()))->second;
       icalconst = refactor_mean_ +
                   (icalconst - refactor_mean_) * refactor_;  //apply additional scaling factor (works if gaussian)
@@ -189,7 +120,7 @@ void HcalRecHitRecalib::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
   }
 
   //Put Recalibrated rechit in the event
-  iEvent.put(std::move(RecalibHBHERecHitCollection), RecalibHBHEHits_);
-  iEvent.put(std::move(RecalibHFRecHitCollection), RecalibHFHits_);
-  iEvent.put(std::move(RecalibHORecHitCollection), RecalibHOHits_);
+  iEvent.put(std::move(RecalibHBHERecHitCollection), recalibHBHEHits_);
+  iEvent.put(std::move(RecalibHFRecHitCollection), recalibHFHits_);
+  iEvent.put(std::move(RecalibHORecHitCollection), recalibHOHits_);
 }

--- a/CalibCalorimetry/CaloMiscalibTools/plugins/HcalRecHitRecalib.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/plugins/HcalRecHitRecalib.cc
@@ -17,8 +17,7 @@ HcalRecHitRecalib::HcalRecHitRecalib(const edm::ParameterSet& iConfig)
       RecalibHOHits_(iConfig.getParameter<std::string>("RecalibHOHitCollection")),
       hcalfileinpath_(iConfig.getUntrackedParameter<std::string>("fileNameHcal", "")),
       refactor_(iConfig.getUntrackedParameter<double>("Refactor", (double)1)),
-      refactor_mean_(iConfig.getUntrackedParameter<double>("Refactor_mean", (double)1))
-{
+      refactor_mean_(iConfig.getUntrackedParameter<double>("Refactor_mean", (double)1)) {
   //   HBHEHitsProducer_ = iConfig.getParameter< std::string > ("HBHERecHitsProducer");
   //   HOHitsProducer_ = iConfig.getParameter< std::string > ("HERecHitsProducer");
   //   HFHitsProducer_ = iConfig.getParameter< std::string > ("HERecHitsProducer");

--- a/CalibCalorimetry/CaloMiscalibTools/plugins/WriteEcalMiscalibConstants.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/plugins/WriteEcalMiscalibConstants.cc
@@ -16,23 +16,15 @@
 //
 //
 
-// system include files
-#include <iostream>
-
 // user include files
-
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 // DB includes
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 
 // user include files
-#include "CondFormats/EcalObjects/interface/EcalIntercalibConstants.h"
-#include "CondFormats/DataRecord/interface/EcalIntercalibConstantsRcd.h"
-//For Checks
-
 //this one
 #include "CalibCalorimetry/CaloMiscalibTools/interface/WriteEcalMiscalibConstants.h"
 
@@ -43,15 +35,11 @@
 //
 // constructors and destructor
 //
-WriteEcalMiscalibConstants::WriteEcalMiscalibConstants(const edm::ParameterSet& iConfig) {
-  //now do what ever initialization is needed
-  newTagRequest_ = iConfig.getParameter<std::string>("NewTagRequest");
-}
+WriteEcalMiscalibConstants::WriteEcalMiscalibConstants(const edm::ParameterSet& iConfig)
+    : newTagRequest_(iConfig.getParameter<std::string>("NewTagRequest")),
+      intercalibConstsToken_(esConsumes()) {}
 
-WriteEcalMiscalibConstants::~WriteEcalMiscalibConstants() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
-}
+WriteEcalMiscalibConstants::~WriteEcalMiscalibConstants() {}
 
 //
 // member functions
@@ -61,20 +49,17 @@ WriteEcalMiscalibConstants::~WriteEcalMiscalibConstants() {
 void WriteEcalMiscalibConstants::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
   // Intercalib constants
-  edm::ESHandle<EcalIntercalibConstants> pIcal;
-  iSetup.get<EcalIntercalibConstantsRcd>().get(pIcal);
-  const EcalIntercalibConstants* Mcal = pIcal.product();
+  const EcalIntercalibConstants* Mcal = &iSetup.getData(intercalibConstsToken_);
 
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
   if (poolDbService.isAvailable()) {
     if (poolDbService->isNewTagRequest(newTagRequest_)) {
-      std::cout << " Creating a  new one " << std::endl;
+      edm::LogVerbatim("WriteEcalMiscalibConstants") << "Creating a new IOV";
       poolDbService->createNewIOV<const EcalIntercalibConstants>(*Mcal, poolDbService->beginOfTime(), newTagRequest_);
-      std::cout << "Done" << std::endl;
+      edm::LogVerbatim("WriteEcalMiscalibConstants") << "Done";
     } else {
-      std::cout << "Old One " << std::endl;
-      poolDbService->appendSinceTime<const EcalIntercalibConstants>(
-          *Mcal, poolDbService->currentTime(), newTagRequest_);
+      edm::LogVerbatim("WriteEcalMiscalibConstants") << "Old IOV";
+      poolDbService->appendSinceTime<const EcalIntercalibConstants>(*Mcal, poolDbService->currentTime(), newTagRequest_);
     }
   }
 }
@@ -84,7 +69,6 @@ void WriteEcalMiscalibConstants::beginJob() {}
 
 // ------------ method called once each job just after ending the event loop  ------------
 void 
-
 WriteEcalMiscalibConstants::endJob() {
-  std::cout << "Here is the end" << std::endl;
+  edm::LogVerbatim("WriteEcalMiscalibConstants") << "Here is the end";
 }

--- a/CalibCalorimetry/CaloMiscalibTools/plugins/WriteEcalMiscalibConstants.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/plugins/WriteEcalMiscalibConstants.cc
@@ -58,7 +58,8 @@ void WriteEcalMiscalibConstants::analyze(const edm::Event& iEvent, const edm::Ev
       edm::LogVerbatim("WriteEcalMiscalibConstants") << "Done";
     } else {
       edm::LogVerbatim("WriteEcalMiscalibConstants") << "Old IOV";
-      poolDbService->appendSinceTime<const EcalIntercalibConstants>(*Mcal, poolDbService->currentTime(), newTagRequest_);
+      poolDbService->appendSinceTime<const EcalIntercalibConstants>(
+          *Mcal, poolDbService->currentTime(), newTagRequest_);
     }
   }
 }

--- a/CalibCalorimetry/CaloMiscalibTools/plugins/WriteEcalMiscalibConstants.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/plugins/WriteEcalMiscalibConstants.cc
@@ -36,8 +36,7 @@
 // constructors and destructor
 //
 WriteEcalMiscalibConstants::WriteEcalMiscalibConstants(const edm::ParameterSet& iConfig)
-    : newTagRequest_(iConfig.getParameter<std::string>("NewTagRequest")),
-      intercalibConstsToken_(esConsumes()) {}
+    : newTagRequest_(iConfig.getParameter<std::string>("NewTagRequest")), intercalibConstsToken_(esConsumes()) {}
 
 WriteEcalMiscalibConstants::~WriteEcalMiscalibConstants() {}
 
@@ -68,7 +67,4 @@ void WriteEcalMiscalibConstants::analyze(const edm::Event& iEvent, const edm::Ev
 void WriteEcalMiscalibConstants::beginJob() {}
 
 // ------------ method called once each job just after ending the event loop  ------------
-void 
-WriteEcalMiscalibConstants::endJob() {
-  edm::LogVerbatim("WriteEcalMiscalibConstants") << "Here is the end";
-}
+void WriteEcalMiscalibConstants::endJob() { edm::LogVerbatim("WriteEcalMiscalibConstants") << "Here is the end"; }

--- a/CalibCalorimetry/CaloMiscalibTools/plugins/WriteEcalMiscalibConstantsMC.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/plugins/WriteEcalMiscalibConstantsMC.cc
@@ -16,23 +16,15 @@
 //
 //
 
-// system include files
-#include <iostream>
-
 // user include files
-
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 // DB includes
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 
 // user include files
-#include "CondFormats/EcalObjects/interface/EcalIntercalibConstantsMC.h"
-#include "CondFormats/DataRecord/interface/EcalIntercalibConstantsMCRcd.h"
-//For Checks
-
 //this one
 #include "CalibCalorimetry/CaloMiscalibTools/interface/WriteEcalMiscalibConstantsMC.h"
 
@@ -43,15 +35,11 @@
 //
 // constructors and destructor
 //
-WriteEcalMiscalibConstantsMC::WriteEcalMiscalibConstantsMC(const edm::ParameterSet& iConfig) {
-  //now do what ever initialization is needed
-  newTagRequest_ = iConfig.getParameter<std::string>("NewTagRequest");
-}
+WriteEcalMiscalibConstantsMC::WriteEcalMiscalibConstantsMC(const edm::ParameterSet& iConfig)
+    : newTagRequest_(iConfig.getParameter<std::string>("NewTagRequest")),
+      intercalibConstsToken_(esConsumes()) {}
 
-WriteEcalMiscalibConstantsMC::~WriteEcalMiscalibConstantsMC() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
-}
+WriteEcalMiscalibConstantsMC::~WriteEcalMiscalibConstantsMC() {}
 
 //
 // member functions
@@ -61,18 +49,16 @@ WriteEcalMiscalibConstantsMC::~WriteEcalMiscalibConstantsMC() {
 void WriteEcalMiscalibConstantsMC::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
   // Intercalib constants
-  edm::ESHandle<EcalIntercalibConstantsMC> pIcal;
-  iSetup.get<EcalIntercalibConstantsMCRcd>().get(pIcal);
-  const EcalIntercalibConstantsMC* Mcal = pIcal.product();
+  const EcalIntercalibConstantsMC* Mcal = &iSetup.getData(intercalibConstsToken_);
 
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
   if (poolDbService.isAvailable()) {
     if (poolDbService->isNewTagRequest(newTagRequest_)) {
-      std::cout << " Creating a  new one " << std::endl;
+      edm::LogVerbatim("WriteEcalMiscalibConstantsMC") << "Creating a new IOV";
       poolDbService->createNewIOV<const EcalIntercalibConstantsMC>(*Mcal, poolDbService->beginOfTime(), newTagRequest_);
-      std::cout << "Done" << std::endl;
+      edm::LogVerbatim("WriteEcalMiscalibConstantsMC") << "Done";
     } else {
-      std::cout << "Old One " << std::endl;
+      edm::LogVerbatim("WriteEcalMiscalibConstantsMC") << "Old IOV";
       poolDbService->appendSinceTime<const EcalIntercalibConstantsMC>(
           *Mcal, poolDbService->currentTime(), newTagRequest_);
     }
@@ -84,7 +70,6 @@ void WriteEcalMiscalibConstantsMC::beginJob() {}
 
 // ------------ method called once each job just after ending the event loop  ------------
 void 
-
 WriteEcalMiscalibConstantsMC::endJob() {
-  std::cout << "Here is the end" << std::endl;
+  edm::LogVerbatim("WriteEcalMiscalibConstantsMC") << "Here is the end";
 }

--- a/CalibCalorimetry/CaloMiscalibTools/plugins/WriteEcalMiscalibConstantsMC.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/plugins/WriteEcalMiscalibConstantsMC.cc
@@ -36,8 +36,7 @@
 // constructors and destructor
 //
 WriteEcalMiscalibConstantsMC::WriteEcalMiscalibConstantsMC(const edm::ParameterSet& iConfig)
-    : newTagRequest_(iConfig.getParameter<std::string>("NewTagRequest")),
-      intercalibConstsToken_(esConsumes()) {}
+    : newTagRequest_(iConfig.getParameter<std::string>("NewTagRequest")), intercalibConstsToken_(esConsumes()) {}
 
 WriteEcalMiscalibConstantsMC::~WriteEcalMiscalibConstantsMC() {}
 
@@ -69,7 +68,4 @@ void WriteEcalMiscalibConstantsMC::analyze(const edm::Event& iEvent, const edm::
 void WriteEcalMiscalibConstantsMC::beginJob() {}
 
 // ------------ method called once each job just after ending the event loop  ------------
-void 
-WriteEcalMiscalibConstantsMC::endJob() {
-  edm::LogVerbatim("WriteEcalMiscalibConstantsMC") << "Here is the end";
-}
+void WriteEcalMiscalibConstantsMC::endJob() { edm::LogVerbatim("WriteEcalMiscalibConstantsMC") << "Here is the end"; }

--- a/CalibCalorimetry/CaloMiscalibTools/test/writeXMLinSqlite.py
+++ b/CalibCalorimetry/CaloMiscalibTools/test/writeXMLinSqlite.py
@@ -36,7 +36,7 @@ process.CaloMiscalibTools = cms.ESSource("CaloMiscalibTools",
 )
 
 process.prefer("CaloMiscalibTools")
-process.WriteInDB = cms.EDFilter("WriteEcalMiscalibConstants",
+process.WriteInDB = cms.EDAnalyzer("WriteEcalMiscalibConstants",
     NewTagRequest = cms.string('EcalIntercalibConstantsRcd')
 )
 

--- a/CalibCalorimetry/CaloMiscalibTools/test/writeXMLinSqliteMC.py
+++ b/CalibCalorimetry/CaloMiscalibTools/test/writeXMLinSqliteMC.py
@@ -31,12 +31,12 @@ process.PoolDBOutputService = cms.Service("PoolDBOutputService",
 )
 
 process.CaloMiscalibToolsMC = cms.ESSource("CaloMiscalibToolsMC",
-    fileNameBarrel = cms.untracked.string('inv_EcalIntercalibConstants_EB_startup.xml'),
-    fileNameEndcap = cms.untracked.string('inv_EcalIntercalibConstants_EE_startup.xml')
+    fileNameBarrel = cms.untracked.string('EcalIntercalibConstants_EB_startup.xml'),
+    fileNameEndcap = cms.untracked.string('EcalIntercalibConstants_EE_startup.xml')
 )
 
 process.prefer("CaloMiscalibToolsMC")
-process.WriteInDB = cms.EDFilter("WriteEcalMiscalibConstantsMC",
+process.WriteInDB = cms.EDAnalyzer("WriteEcalMiscalibConstantsMC",
     NewTagRequest = cms.string('EcalIntercalibConstantsMCRcd')
 )
 

--- a/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalABAnalyzer.cc
+++ b/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalABAnalyzer.cc
@@ -230,8 +230,8 @@ void EcalABAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& c) {
   const EcalRawDataCollection* DCCHeader = nullptr;
   e.getByToken(rawDataToken_, pDCCHeader);
   if (!pDCCHeader.isValid()) {
-    edm::LogError("nodata") << "Error! can't get the product retrieving DCC header" << eventHeaderCollection_.c_str() << " "
-              << eventHeaderProducer_.c_str();
+    edm::LogError("nodata") << "Error! can't get the product retrieving DCC header" << eventHeaderCollection_.c_str()
+                            << " " << eventHeaderProducer_.c_str();
   } else {
     DCCHeader = pDCCHeader.product();
   }

--- a/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalABAnalyzer.cc
+++ b/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalABAnalyzer.cc
@@ -16,27 +16,16 @@
 #include "CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalABAnalyzer.h"
 
 #include <sstream>
-#include <iostream>
 #include <fstream>
 #include <iomanip>
-#include <vector>
 
 #include <FWCore/MessageLogger/interface/MessageLogger.h>
-#include <FWCore/Utilities/interface/Exception.h>
-
-#include <FWCore/Framework/interface/ESHandle.h>
 #include <FWCore/Framework/interface/EventSetup.h>
-
-#include <Geometry/EcalMapping/interface/EcalElectronicsMapping.h>
-#include <Geometry/EcalMapping/interface/EcalMappingRcd.h>
-
 #include <FWCore/Framework/interface/Event.h>
 #include <FWCore/Framework/interface/MakerMacros.h>
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
-#include <DataFormats/EcalDigi/interface/EcalDigiCollections.h>
 #include <DataFormats/EcalDetId/interface/EcalElectronicsId.h>
 #include <DataFormats/EcalDetId/interface/EcalDetIdCollections.h>
-#include <DataFormats/EcalRawData/interface/EcalRawDataCollections.h>
 
 #include <CalibCalorimetry/EcalLaserAnalyzer/interface/TShapeAnalysis.h>
 #include <CalibCalorimetry/EcalLaserAnalyzer/interface/TMom.h>
@@ -52,7 +41,12 @@ using namespace std;
 EcalABAnalyzer::EcalABAnalyzer(const edm::ParameterSet& iConfig)
     //========================================================================
     : iEvent(0),
-
+      eventHeaderCollection_(iConfig.getParameter<std::string>("eventHeaderCollection")),
+      eventHeaderProducer_(iConfig.getParameter<std::string>("eventHeaderProducer")),
+      digiCollection_(iConfig.getParameter<std::string>("digiCollection")),
+      digiProducer_(iConfig.getParameter<std::string>("digiProducer")),
+      rawDataToken_(consumes<EcalRawDataCollection>(edm::InputTag(eventHeaderProducer_, eventHeaderCollection_))),
+      mappingToken_(esConsumes()),
       // framework parameters with default values
       _nsamples(iConfig.getUntrackedParameter<unsigned int>("nSamples", 10)),
       _presample(iConfig.getUntrackedParameter<unsigned int>("nPresamples", 2)),
@@ -73,8 +67,10 @@ EcalABAnalyzer::EcalABAnalyzer(const edm::ParameterSet& iConfig)
       _noise(iConfig.getUntrackedParameter<double>("noise", 2.0)),
       _chi2cut(iConfig.getUntrackedParameter<double>("chi2cut", 100.0)),
       _ecalPart(iConfig.getUntrackedParameter<std::string>("ecalPart", "EB")),
+      _fedid(iConfig.getUntrackedParameter<int>("fedId", -999)),
       _qualpercent(iConfig.getUntrackedParameter<double>("qualPercent", 0.2)),
       _debug(iConfig.getUntrackedParameter<int>("debug", 0)),
+      resdir_(iConfig.getUntrackedParameter<std::string>("resDir")),
       nCrys(NCRYSEB),
       runType(-1),
       runNum(0),
@@ -92,15 +88,11 @@ EcalABAnalyzer::EcalABAnalyzer(const edm::ParameterSet& iConfig)
 //========================================================================
 
 {
-  // Initialization from cfg file
-
-  resdir_ = iConfig.getUntrackedParameter<std::string>("resDir");
-
-  digiCollection_ = iConfig.getParameter<std::string>("digiCollection");
-  digiProducer_ = iConfig.getParameter<std::string>("digiProducer");
-
-  eventHeaderCollection_ = iConfig.getParameter<std::string>("eventHeaderCollection");
-  eventHeaderProducer_ = iConfig.getParameter<std::string>("eventHeaderProducer");
+  if (_ecalPart == "EB") {
+    ebDigiToken_ = consumes<EBDigiCollection>(edm::InputTag(digiProducer_, digiCollection_));
+  } else if (_ecalPart == "EE") {
+    eeDigiToken_ = consumes<EEDigiCollection>(edm::InputTag(digiProducer_, digiCollection_));
+  }
 
   // Geometrical constants initialization
 
@@ -236,12 +228,12 @@ void EcalABAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& c) {
   // retrieving DCC header
   edm::Handle<EcalRawDataCollection> pDCCHeader;
   const EcalRawDataCollection* DCCHeader = nullptr;
-  try {
-    e.getByLabel(eventHeaderProducer_, eventHeaderCollection_, pDCCHeader);
+  e.getByToken(rawDataToken_, pDCCHeader);
+  if (!pDCCHeader.isValid()) {
+    edm::LogError("nodata") << "Error! can't get the product retrieving DCC header" << eventHeaderCollection_.c_str() << " "
+              << eventHeaderProducer_.c_str();
+  } else {
     DCCHeader = pDCCHeader.product();
-  } catch (std::exception& ex) {
-    std::cerr << "Error! can't get the product retrieving DCC header" << eventHeaderCollection_.c_str() << " "
-              << eventHeaderProducer_.c_str() << std::endl;
   }
 
   //retrieving crystal data from Event
@@ -250,33 +242,26 @@ void EcalABAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& c) {
   edm::Handle<EEDigiCollection> pEEDigi;
   const EEDigiCollection* EEDigi = nullptr;
   if (_ecalPart == "EB") {
-    try {
-      e.getByLabel(digiProducer_, digiCollection_, pEBDigi);
+    e.getByToken(ebDigiToken_, pEBDigi);
+    if (!pEBDigi.isValid()) {
+      edm::LogError("nodata") << "Error! can't get the product retrieving EB crystal data " << digiCollection_.c_str();
+    } else {
       EBDigi = pEBDigi.product();
-    } catch (std::exception& ex) {
-      std::cerr << "Error! can't get the product retrieving EB crystal data " << digiCollection_.c_str() << std::endl;
     }
   } else if (_ecalPart == "EE") {
-    try {
-      e.getByLabel(digiProducer_, digiCollection_, pEEDigi);
+    e.getByToken(eeDigiToken_, pEEDigi);
+    if (!pEEDigi.isValid()) {
+      edm::LogError("nodata") << "Error! can't get the product retrieving EE crystal data " << digiCollection_.c_str();
+    } else {
       EEDigi = pEEDigi.product();
-    } catch (std::exception& ex) {
-      std::cerr << "Error! can't get the product retrieving EE crystal data " << digiCollection_.c_str() << std::endl;
     }
   } else {
-    std::cout << " Wrong ecalPart in cfg file " << std::endl;
+    edm::LogError("cfg_error") << " Wrong ecalPart in cfg file";
     return;
   }
 
   // retrieving electronics mapping
-  edm::ESHandle<EcalElectronicsMapping> ecalmapping;
-  const EcalElectronicsMapping* TheMapping = nullptr;
-  try {
-    c.get<EcalMappingRcd>().get(ecalmapping);
-    TheMapping = ecalmapping.product();
-  } catch (std::exception& ex) {
-    std::cerr << "Error! can't get the product EcalMappingRcd" << std::endl;
-  }
+  const auto& TheMapping = c.getData(mappingToken_);
 
   // =============================
   // Decode DCCHeader Information
@@ -363,7 +348,7 @@ void EcalABAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& c) {
 
       // Recover the TT id and the electronic crystal numbering from EcalElectronicsMapping
 
-      EcalElectronicsId elecid_crystal = TheMapping->getElectronicsId(id_crystal);
+      EcalElectronicsId elecid_crystal = TheMapping.getElectronicsId(id_crystal);
 
       int towerID = elecid_crystal.towerId();
       int strip = elecid_crystal.stripId();
@@ -445,7 +430,7 @@ void EcalABAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& c) {
       int iY = (eta - 1) / 5 + 1;
 
       side = MEEEGeom::side(iX, iY, iZ);
-      EcalElectronicsId elecid_crystal = TheMapping->getElectronicsId(id_crystal);
+      EcalElectronicsId elecid_crystal = TheMapping.getElectronicsId(id_crystal);
 
       int towerID = elecid_crystal.towerId();
       int channelID = elecid_crystal.channelId() - 1;
@@ -472,7 +457,7 @@ void EcalABAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& c) {
       //===========
 
       if ((*digiItr).size() > 10)
-        std::cout << "SAMPLES SIZE > 10!" << (*digiItr).size() << std::endl;
+        edm::LogVerbatim("EcalABAnalyzer") << "SAMPLES SIZE > 10!" << (*digiItr).size();
 
       // Loop on adc samples
 
@@ -522,8 +507,8 @@ void EcalABAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& c) {
 void EcalABAnalyzer::endJob() {
   //========================================================================
 
-  std::cout << "\n\t+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+" << std::endl;
-  std::cout << "\t+=+     Analyzing data: getting (alpha, beta)     +=+" << std::endl;
+  edm::LogVerbatim("EcalABAnalyzer") << "\n\t+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+";
+  edm::LogVerbatim("EcalABAnalyzer") << "\t+=+     Analyzing data: getting (alpha, beta)     +=+";
 
   // Adjust channel numbers for EE
   //===============================
@@ -551,8 +536,8 @@ void EcalABAnalyzer::endJob() {
   //======================
 
   if (_fitab) {
-    std::cout << "\n\t+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+" << std::endl;
-    std::cout << "\t+=+     Analyzing data: getting (alpha, beta)     +=+" << std::endl;
+    edm::LogVerbatim("EcalABAnalyzer") << "\n\t+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+";
+    edm::LogVerbatim("EcalABAnalyzer") << "\t+=+     Analyzing data: getting (alpha, beta)     +=+";
     TFile* fAB = nullptr;
     TTree* ABInit = nullptr;
     if (doesABTreeExist) {
@@ -595,12 +580,12 @@ void EcalABAnalyzer::endJob() {
       isTimingOK = false;
 
     if (!isGainOK)
-      std::cout << "\t+=+ ............................ WARNING! APD GAIN WAS NOT 1    +=+" << std::endl;
+      edm::LogVerbatim("EcalABAnalyzer") << "\t+=+ ............................ WARNING! APD GAIN WAS NOT 1    +=+";
     if (!isTimingOK)
-      std::cout << "\t+=+ ............................ WARNING! TIMING WAS BAD        +=+" << std::endl;
+      edm::LogVerbatim("EcalABAnalyzer") << "\t+=+ ............................ WARNING! TIMING WAS BAD        +=+";
 
-    std::cout << "\t+=+    .................................... done  +=+" << std::endl;
-    std::cout << "\t+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+" << std::endl;
+    edm::LogVerbatim("EcalABAnalyzer") << "\t+=+    .................................... done  +=+";
+    edm::LogVerbatim("EcalABAnalyzer") << "\t+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+";
   }
 }
 

--- a/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalABAnalyzer.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalABAnalyzer.h
@@ -1,5 +1,5 @@
-#ifndef EcalABAnalyzer_h_
-#define EcalABAnalyzer_h_
+#ifndef CalibCalorimetry_EcalLaserAnalyzer_EcalABAnalyzer_h
+#define CalibCalorimetry_EcalLaserAnalyzer_EcalABAnalyzer_h
 
 // $Id: EcalABAnalyzer.h
 
@@ -7,7 +7,12 @@
 #include <vector>
 #include <map>
 
-#include <FWCore/Framework/interface/EDAnalyzer.h>
+#include <FWCore/Framework/interface/one/EDAnalyzer.h>
+
+#include <DataFormats/EcalDigi/interface/EcalDigiCollections.h>
+#include <DataFormats/EcalRawData/interface/EcalRawDataCollections.h>
+#include <Geometry/EcalMapping/interface/EcalElectronicsMapping.h>
+#include <Geometry/EcalMapping/interface/EcalMappingRcd.h>
 
 class TShapeAnalysis;
 class TAPDPulse;
@@ -32,7 +37,7 @@ class TMom;
 // "EE" geometry
 #define NCRYSEE 830  // Number of crystals per EE supermodule
 
-class EcalABAnalyzer : public edm::EDAnalyzer {
+class EcalABAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   explicit EcalABAnalyzer(const edm::ParameterSet &iConfig);
   ~EcalABAnalyzer() override;
@@ -46,40 +51,46 @@ public:
 private:
   int iEvent;
 
+  const std::string eventHeaderCollection_;
+  const std::string eventHeaderProducer_;
+  const std::string digiCollection_;
+  const std::string digiProducer_;
+
+  const edm::EDGetTokenT<EcalRawDataCollection> rawDataToken_;
+  edm::EDGetTokenT<EBDigiCollection> ebDigiToken_;
+  edm::EDGetTokenT<EEDigiCollection> eeDigiToken_;
+  const edm::ESGetToken<EcalElectronicsMapping, EcalMappingRcd> mappingToken_;
+
   // Framework parameters
 
-  unsigned int _nsamples;
+  const unsigned int _nsamples;
   unsigned int _presample;
-  unsigned int _firstsample;
-  unsigned int _lastsample;
-  unsigned int _timingcutlow;
-  unsigned int _timingcuthigh;
-  unsigned int _timingquallow;
-  unsigned int _timingqualhigh;
-  double _ratiomincutlow;
-  double _ratiomincuthigh;
-  double _ratiomaxcutlow;
-  double _presamplecut;
-  unsigned int _niter;
-  double _alpha;
-  double _beta;
-  unsigned int _nevtmax;
-  double _noise;
-  double _chi2cut;
-  std::string _ecalPart;
-  int _fedid;
-  double _qualpercent;
-  int _debug;
+  const unsigned int _firstsample;
+  const unsigned int _lastsample;
+  const unsigned int _timingcutlow;
+  const unsigned int _timingcuthigh;
+  const unsigned int _timingquallow;
+  const unsigned int _timingqualhigh;
+  const double _ratiomincutlow;
+  const double _ratiomincuthigh;
+  const double _ratiomaxcutlow;
+  const double _presamplecut;
+  const unsigned int _niter;
+  const double _alpha;
+  const double _beta;
+  const unsigned int _nevtmax;
+  const double _noise;
+  const double _chi2cut;
+  const std::string _ecalPart;
+  const int _fedid;
+  const double _qualpercent;
+  const int _debug;
 
   TAPDPulse *APDPulse;
   TMom *Delta01;
   TMom *Delta12;
 
-  std::string resdir_;
-  std::string digiCollection_;
-  std::string digiProducer_;
-  std::string eventHeaderCollection_;
-  std::string eventHeaderProducer_;
+  const std::string resdir_;
 
   // Output file names
 

--- a/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalLaserAnalyzer.cc
+++ b/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalLaserAnalyzer.cc
@@ -16,28 +16,19 @@
 #include "CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalLaserAnalyzer.h"
 
 #include <sstream>
-#include <iostream>
 #include <fstream>
 #include <iomanip>
 
 #include <FWCore/MessageLogger/interface/MessageLogger.h>
 #include <FWCore/Utilities/interface/Exception.h>
 
-#include <FWCore/Framework/interface/ESHandle.h>
 #include <FWCore/Framework/interface/EventSetup.h>
-
-#include <Geometry/EcalMapping/interface/EcalElectronicsMapping.h>
-#include <Geometry/EcalMapping/interface/EcalMappingRcd.h>
 
 #include <FWCore/Framework/interface/Event.h>
 #include <FWCore/Framework/interface/MakerMacros.h>
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
-#include <DataFormats/EcalDigi/interface/EcalDigiCollections.h>
 #include <DataFormats/EcalDetId/interface/EcalElectronicsId.h>
 #include <DataFormats/EcalDetId/interface/EcalDetIdCollections.h>
-#include <DataFormats/EcalRawData/interface/EcalRawDataCollections.h>
-
-#include <vector>
 
 #include <CalibCalorimetry/EcalLaserAnalyzer/interface/TShapeAnalysis.h>
 #include <CalibCalorimetry/EcalLaserAnalyzer/interface/TPNFit.h>
@@ -56,9 +47,15 @@
 EcalLaserAnalyzer::EcalLaserAnalyzer(const edm::ParameterSet& iConfig)
     //========================================================================
     : iEvent(0),
-
+      eventHeaderCollection_(iConfig.getParameter<std::string>("eventHeaderCollection")),
+      eventHeaderProducer_(iConfig.getParameter<std::string>("eventHeaderProducer")),
+      digiCollection_(iConfig.getParameter<std::string>("digiCollection")),
+      digiProducer_(iConfig.getParameter<std::string>("digiProducer")),
+      digiPNCollection_(iConfig.getParameter<std::string>("digiPNCollection")),
+      rawDataToken_(consumes<EcalRawDataCollection>(edm::InputTag(eventHeaderProducer_, eventHeaderCollection_))),
+      pnDiodeDigiToken_(consumes<EcalPnDiodeDigiCollection>(edm::InputTag(digiProducer_))),
+      mappingToken_(esConsumes()),
       // Framework parameters with default values
-
       _nsamples(iConfig.getUntrackedParameter<unsigned int>("nSamples", 10)),
       _presample(iConfig.getUntrackedParameter<unsigned int>("nPresamples", 2)),
       _firstsample(iConfig.getUntrackedParameter<unsigned int>("firstSample", 1)),
@@ -88,6 +85,8 @@ EcalLaserAnalyzer::EcalLaserAnalyzer(const edm::ParameterSet& iConfig)
       _saveallevents(iConfig.getUntrackedParameter<bool>("saveAllEvents", false)),
       _qualpercent(iConfig.getUntrackedParameter<double>("qualPercent", 0.2)),
       _debug(iConfig.getUntrackedParameter<int>("debug", 0)),
+      resdir_(iConfig.getUntrackedParameter<std::string>("resDir")),
+      pncorfile_(iConfig.getUntrackedParameter<std::string>("pnCorFile")),
       nCrys(NCRYSEB),
       nPNPerMod(NPNPERMOD),
       nMod(NMODEE),
@@ -117,17 +116,11 @@ EcalLaserAnalyzer::EcalLaserAnalyzer(const edm::ParameterSet& iConfig)
 //========================================================================
 
 {
-  // Initialization from cfg file
-
-  resdir_ = iConfig.getUntrackedParameter<std::string>("resDir");
-  pncorfile_ = iConfig.getUntrackedParameter<std::string>("pnCorFile");
-
-  digiCollection_ = iConfig.getParameter<std::string>("digiCollection");
-  digiPNCollection_ = iConfig.getParameter<std::string>("digiPNCollection");
-  digiProducer_ = iConfig.getParameter<std::string>("digiProducer");
-
-  eventHeaderCollection_ = iConfig.getParameter<std::string>("eventHeaderCollection");
-  eventHeaderProducer_ = iConfig.getParameter<std::string>("eventHeaderProducer");
+  if (_ecalPart == "EB") {
+    ebDigiToken_ = consumes<EBDigiCollection>(edm::InputTag(digiProducer_, digiCollection_));
+  } else if (_ecalPart == "EE") {
+    eeDigiToken_ = consumes<EEDigiCollection>(edm::InputTag(digiProducer_, digiCollection_));
+  }
 
   // Geometrical constants initialization
 
@@ -318,64 +311,52 @@ void EcalLaserAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& c) {
   ++iEvent;
 
   // retrieving DCC header
-
   edm::Handle<EcalRawDataCollection> pDCCHeader;
   const EcalRawDataCollection* DCCHeader = nullptr;
-  try {
-    e.getByLabel(eventHeaderProducer_, eventHeaderCollection_, pDCCHeader);
+  e.getByToken(rawDataToken_, pDCCHeader);
+  if (!pDCCHeader.isValid()) {
+    edm::LogError("nodata") << "Error! can't get the product retrieving DCC header" << eventHeaderCollection_.c_str() << " "
+              << eventHeaderProducer_.c_str();
+  } else {
     DCCHeader = pDCCHeader.product();
-  } catch (std::exception& ex) {
-    std::cerr << "Error! can't get the product retrieving DCC header" << eventHeaderCollection_.c_str() << " "
-              << eventHeaderProducer_.c_str() << std::endl;
   }
 
   //retrieving crystal data from Event
-
   edm::Handle<EBDigiCollection> pEBDigi;
   const EBDigiCollection* EBDigi = nullptr;
   edm::Handle<EEDigiCollection> pEEDigi;
   const EEDigiCollection* EEDigi = nullptr;
-
   if (_ecalPart == "EB") {
-    try {
-      e.getByLabel(digiProducer_, digiCollection_, pEBDigi);
+    e.getByToken(ebDigiToken_, pEBDigi);
+    if (!pEBDigi.isValid()) {
+      edm::LogError("nodata") << "Error! can't get the product retrieving EB crystal data " << digiCollection_.c_str();
+    } else {
       EBDigi = pEBDigi.product();
-    } catch (std::exception& ex) {
-      std::cerr << "Error! can't get the product retrieving EB crystal data " << digiCollection_.c_str() << std::endl;
     }
   } else if (_ecalPart == "EE") {
-    try {
-      e.getByLabel(digiProducer_, digiCollection_, pEEDigi);
+    e.getByToken(eeDigiToken_, pEEDigi);
+    if (!pEEDigi.isValid()) {
+      edm::LogError("nodata") << "Error! can't get the product retrieving EE crystal data " << digiCollection_.c_str();
+    } else {
       EEDigi = pEEDigi.product();
-    } catch (std::exception& ex) {
-      std::cerr << "Error! can't get the product retrieving EE crystal data " << digiCollection_.c_str() << std::endl;
     }
   } else {
-    std::cout << " Wrong ecalPart in cfg file " << std::endl;
+    edm::LogError("cfg_error") << " Wrong ecalPart in cfg file ";
     return;
   }
 
   // retrieving crystal PN diodes from Event
-
   edm::Handle<EcalPnDiodeDigiCollection> pPNDigi;
   const EcalPnDiodeDigiCollection* PNDigi = nullptr;
-  try {
-    e.getByLabel(digiProducer_, pPNDigi);
+  e.getByToken(pnDiodeDigiToken_, pPNDigi);
+  if (!pPNDigi.isValid()) {
+    edm::LogError("nodata") << "Error! can't get the product " << digiPNCollection_.c_str();
+  } else {
     PNDigi = pPNDigi.product();
-  } catch (std::exception& ex) {
-    std::cerr << "Error! can't get the product " << digiPNCollection_.c_str() << std::endl;
   }
 
   // retrieving electronics mapping
-
-  edm::ESHandle<EcalElectronicsMapping> ecalmapping;
-  const EcalElectronicsMapping* TheMapping = nullptr;
-  try {
-    c.get<EcalMappingRcd>().get(ecalmapping);
-    TheMapping = ecalmapping.product();
-  } catch (std::exception& ex) {
-    std::cerr << "Error! can't get the product EcalMappingRcd" << std::endl;
-  }
+  const auto& TheMapping = c.getData(mappingToken_);
 
   // ============================
   // Decode DCCHeader Information
@@ -418,7 +399,7 @@ void EcalLaserAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& c) {
     std::vector<int>::iterator iter = find(colors.begin(), colors.end(), color);
     if (iter == colors.end()) {
       colors.push_back(color);
-      std::cout << " new color found " << color << " " << colors.size() << std::endl;
+      edm::LogVerbatim("EcalLaserAnalyzer") << " new color found " << color << " " << colors.size();
     }
   }
 
@@ -451,8 +432,7 @@ void EcalLaserAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& c) {
     EcalPnDiodeDetId pnDetId = EcalPnDiodeDetId((*pnItr).id());
 
     if (_debug == 1)
-      std::cout << "-- debug -- Inside PNDigi - pnID=" << pnDetId.iPnId() << ", dccID=" << pnDetId.iDCCId()
-                << std::endl;
+      edm::LogVerbatim("EcalLaserAnalyzer") << "-- debug -- Inside PNDigi - pnID=" << pnDetId.iPnId() << ", dccID=" << pnDetId.iDCCId();
 
     // Skip MEM DCC without relevant data
 
@@ -472,7 +452,7 @@ void EcalLaserAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& c) {
     }
 
     if (pnGain != 1)
-      std::cout << "PN gain different from 1" << std::endl;
+      edm::LogVerbatim("EcalLaserAnalyzer") << "PN gain different from 1";
 
     // Calculate amplitude from pulse
 
@@ -497,7 +477,7 @@ void EcalLaserAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& c) {
     allPNAmpl[pnDetId.iDCCId()].push_back(pnAmpl);
 
     if (_debug == 1)
-      std::cout << "-- debug -- Inside PNDigi - PNampl=" << pnAmpl << ", PNgain=" << pnGain << std::endl;
+      edm::LogVerbatim("EcalLaserAnalyzer") << "-- debug -- Inside PNDigi - PNampl=" << pnAmpl << ", PNgain=" << pnGain;
   }
 
   // ===========================
@@ -516,7 +496,7 @@ void EcalLaserAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& c) {
 
       EBDetId id_crystal(digiItr->id());
       EBDataFrame df(*digiItr);
-      EcalElectronicsId elecid_crystal = TheMapping->getElectronicsId(id_crystal);
+      EcalElectronicsId elecid_crystal = TheMapping.getElectronicsId(id_crystal);
 
       int etaG = id_crystal.ieta();  // global
       int phiG = id_crystal.iphi();  // global
@@ -545,8 +525,8 @@ void EcalLaserAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& c) {
       setGeomEB(etaG, phiG, module, tower, strip, xtal, apdRefTT, channel, lmr);
 
       if (_debug == 1)
-        std::cout << "-- debug -- Inside EBDigi - towerID:" << towerID << " channelID:" << channelID
-                  << " module:" << module << " modules:" << modules.size() << std::endl;
+        edm::LogVerbatim("EcalLaserAnalyzer") << "-- debug -- Inside EBDigi - towerID:" << towerID << " channelID:" << channelID
+                  << " module:" << module << " modules:" << modules.size();
 
       // APD Pulse
       //===========
@@ -619,7 +599,7 @@ void EcalLaserAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& c) {
 
       EEDetId id_crystal(digiItr->id());
       EEDataFrame df(*digiItr);
-      EcalElectronicsId elecid_crystal = TheMapping->getElectronicsId(id_crystal);
+      EcalElectronicsId elecid_crystal = TheMapping.getElectronicsId(id_crystal);
 
       int etaG = id_crystal.iy();
       int phiG = id_crystal.ix();
@@ -652,14 +632,14 @@ void EcalLaserAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& c) {
       setGeomEE(etaG, phiG, iX, iY, iZ, module, tower, ch, apdRefTT, channel, lmr);
 
       if (_debug == 1)
-        std::cout << "-- debug -- Inside EEDigi - towerID:" << towerID << " channelID:" << channelID
-                  << " module:" << module << " modules:" << modules.size() << std::endl;
+        edm::LogVerbatim("EcalLaserAnalyzer") << "-- debug -- Inside EEDigi - towerID:" << towerID << " channelID:" << channelID
+                  << " module:" << module << " modules:" << modules.size();
 
       // APD Pulse
       //===========
 
       if ((*digiItr).size() > 10)
-        std::cout << "SAMPLES SIZE > 10!" << (*digiItr).size() << std::endl;
+        edm::LogVerbatim("EcalLaserAnalyzer") << "SAMPLES SIZE > 10!" << (*digiItr).size();
 
       // Loop on adc samples
 
@@ -753,8 +733,8 @@ void EcalLaserAnalyzer::endJob() {
   //======================
 
   if (_fitab) {
-    std::cout << "\n\t+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+" << std::endl;
-    std::cout << "\t+=+     Analyzing data: getting (alpha, beta)     +=+" << std::endl;
+    edm::LogVerbatim("EcalLaserAnalyzer") << "\n\t+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+";
+    edm::LogVerbatim("EcalLaserAnalyzer") << "\t+=+     Analyzing data: getting (alpha, beta)     +=+";
     TFile* fAB = nullptr;
     TTree* ABInit = nullptr;
     if (doesABTreeExist) {
@@ -764,8 +744,8 @@ void EcalLaserAnalyzer::endJob() {
       ABInit = (TTree*)fAB->Get("ABCol0");
     }
     shapana->computeShape(alphafile, ABInit);
-    std::cout << "\t+=+    .................................... done  +=+" << std::endl;
-    std::cout << "\t+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+" << std::endl;
+    edm::LogVerbatim("EcalLaserAnalyzer") << "\t+=+    .................................... done  +=+";
+    edm::LogVerbatim("EcalLaserAnalyzer") << "\t+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+";
   }
 
   // Don't do anything if there is no events
@@ -776,7 +756,7 @@ void EcalLaserAnalyzer::endJob() {
     std::stringstream del;
     del << "rm " << ADCfile;
     system(del.str().c_str());
-    std::cout << " No Laser Events " << std::endl;
+    edm::LogVerbatim("EcalLaserAnalyzer") << " No Laser Events ";
     return;
   }
 
@@ -815,13 +795,13 @@ void EcalLaserAnalyzer::endJob() {
   // Analyze adc samples to get amplitudes
   //=======================================
 
-  std::cout << "\n\t+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+" << std::endl;
-  std::cout << "\t+=+     Analyzing laser data: getting APD, PN, APD/PN, PN/PN    +=+" << std::endl;
+  edm::LogVerbatim("EcalLaserAnalyzer") << "\n\t+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+";
+  edm::LogVerbatim("EcalLaserAnalyzer") << "\t+=+     Analyzing laser data: getting APD, PN, APD/PN, PN/PN    +=+";
 
   if (!isGainOK)
-    std::cout << "\t+=+ ............................ WARNING! APD GAIN WAS NOT 1    +=+" << std::endl;
+    edm::LogVerbatim("EcalLaserAnalyzer") << "\t+=+ ............................ WARNING! APD GAIN WAS NOT 1    +=+";
   if (!isTimingOK)
-    std::cout << "\t+=+ ............................ WARNING! TIMING WAS BAD        +=+" << std::endl;
+    edm::LogVerbatim("EcalLaserAnalyzer") << "\t+=+ ............................ WARNING! TIMING WAS BAD        +=+";
 
   APDFile = new TFile(APDfile.c_str(), "RECREATE");
 
@@ -993,7 +973,7 @@ void EcalLaserAnalyzer::endJob() {
       }
 
       if (_debug == 1)
-        std::cout << "-- debug test -- apdAmpl=" << apdAmpl << ", apdTime=" << apdTime << std::endl;
+        edm::LogVerbatim("EcalLaserAnalyzer") << "-- debug test -- apdAmpl=" << apdAmpl << ", apdTime=" << apdTime;
       double pnmean;
       if (pn0 < 10 && pn1 > 10) {
         pnmean = pn1;
@@ -1003,7 +983,7 @@ void EcalLaserAnalyzer::endJob() {
         pnmean = 0.5 * (pn0 + pn1);
 
       if (_debug == 1)
-        std::cout << "-- debug test -- pn0=" << pn0 << ", pn1=" << pn1 << std::endl;
+        edm::LogVerbatim("EcalLaserAnalyzer") << "-- debug test -- pn0=" << pn0 << ", pn1=" << pn1;
 
       // Fill PN stuff
       //===============
@@ -1224,7 +1204,7 @@ void EcalLaserAnalyzer::endJob() {
       //===================
 
       if (_debug == 1)
-        std::cout << "-- debug test -- Last Loop event:" << event << " apdAmpl:" << apdAmpl << std::endl;
+        edm::LogVerbatim("EcalLaserAnalyzer") << "-- debug test -- Last Loop event:" << event << " apdAmpl:" << apdAmpl;
       apdAmplA = 0.0;
       apdAmplB = 0.0;
 
@@ -1233,8 +1213,8 @@ void EcalLaserAnalyzer::endJob() {
       }
 
       if (_debug == 1)
-        std::cout << "-- debug test -- Last Loop apdAmplA:" << apdAmplA << " apdAmplB:" << apdAmplB
-                  << ", event:" << event << ", eventref:" << eventref << std::endl;
+        edm::LogVerbatim("EcalLaserAnalyzer") << "-- debug test -- Last Loop apdAmplA:" << apdAmplA << " apdAmplB:" << apdAmplB
+                  << ", event:" << event << ", eventref:" << eventref;
 
       // Fill APD stuff
       //===============
@@ -1350,8 +1330,8 @@ void EcalLaserAnalyzer::endJob() {
 
   resFile->Close();
 
-  std::cout << "\t+=+    .................................................. done  +=+" << std::endl;
-  std::cout << "\t+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+" << std::endl;
+  edm::LogVerbatim("EcalLaserAnalyzer") << "\t+=+    .................................................. done  +=+";
+  edm::LogVerbatim("EcalLaserAnalyzer") << "\t+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+";
 }
 
 void EcalLaserAnalyzer::setGeomEB(

--- a/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalLaserAnalyzer.cc
+++ b/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalLaserAnalyzer.cc
@@ -314,8 +314,8 @@ void EcalLaserAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& c) {
   const EcalRawDataCollection* DCCHeader = nullptr;
   e.getByToken(rawDataToken_, pDCCHeader);
   if (!pDCCHeader.isValid()) {
-    edm::LogError("nodata") << "Error! can't get the product retrieving DCC header" << eventHeaderCollection_.c_str() << " "
-              << eventHeaderProducer_.c_str();
+    edm::LogError("nodata") << "Error! can't get the product retrieving DCC header" << eventHeaderCollection_.c_str()
+                            << " " << eventHeaderProducer_.c_str();
   } else {
     DCCHeader = pDCCHeader.product();
   }
@@ -431,7 +431,8 @@ void EcalLaserAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& c) {
     EcalPnDiodeDetId pnDetId = EcalPnDiodeDetId((*pnItr).id());
 
     if (_debug == 1)
-      edm::LogVerbatim("EcalLaserAnalyzer") << "-- debug -- Inside PNDigi - pnID=" << pnDetId.iPnId() << ", dccID=" << pnDetId.iDCCId();
+      edm::LogVerbatim("EcalLaserAnalyzer")
+          << "-- debug -- Inside PNDigi - pnID=" << pnDetId.iPnId() << ", dccID=" << pnDetId.iDCCId();
 
     // Skip MEM DCC without relevant data
 
@@ -524,8 +525,9 @@ void EcalLaserAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& c) {
       setGeomEB(etaG, phiG, module, tower, strip, xtal, apdRefTT, channel, lmr);
 
       if (_debug == 1)
-        edm::LogVerbatim("EcalLaserAnalyzer") << "-- debug -- Inside EBDigi - towerID:" << towerID << " channelID:" << channelID
-                  << " module:" << module << " modules:" << modules.size();
+        edm::LogVerbatim("EcalLaserAnalyzer")
+            << "-- debug -- Inside EBDigi - towerID:" << towerID << " channelID:" << channelID << " module:" << module
+            << " modules:" << modules.size();
 
       // APD Pulse
       //===========
@@ -631,8 +633,9 @@ void EcalLaserAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& c) {
       setGeomEE(etaG, phiG, iX, iY, iZ, module, tower, ch, apdRefTT, channel, lmr);
 
       if (_debug == 1)
-        edm::LogVerbatim("EcalLaserAnalyzer") << "-- debug -- Inside EEDigi - towerID:" << towerID << " channelID:" << channelID
-                  << " module:" << module << " modules:" << modules.size();
+        edm::LogVerbatim("EcalLaserAnalyzer")
+            << "-- debug -- Inside EEDigi - towerID:" << towerID << " channelID:" << channelID << " module:" << module
+            << " modules:" << modules.size();
 
       // APD Pulse
       //===========
@@ -1212,8 +1215,9 @@ void EcalLaserAnalyzer::endJob() {
       }
 
       if (_debug == 1)
-        edm::LogVerbatim("EcalLaserAnalyzer") << "-- debug test -- Last Loop apdAmplA:" << apdAmplA << " apdAmplB:" << apdAmplB
-                  << ", event:" << event << ", eventref:" << eventref;
+        edm::LogVerbatim("EcalLaserAnalyzer")
+            << "-- debug test -- Last Loop apdAmplA:" << apdAmplA << " apdAmplB:" << apdAmplB << ", event:" << event
+            << ", eventref:" << eventref;
 
       // Fill APD stuff
       //===============

--- a/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalLaserAnalyzer.cc
+++ b/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalLaserAnalyzer.cc
@@ -20,7 +20,6 @@
 #include <iomanip>
 
 #include <FWCore/MessageLogger/interface/MessageLogger.h>
-#include <FWCore/Utilities/interface/Exception.h>
 
 #include <FWCore/Framework/interface/EventSetup.h>
 

--- a/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalLaserAnalyzer.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalLaserAnalyzer.h
@@ -5,7 +5,12 @@
 #include <vector>
 #include <map>
 
-#include <FWCore/Framework/interface/EDAnalyzer.h>
+#include <FWCore/Framework/interface/one/EDAnalyzer.h>
+
+#include <DataFormats/EcalDigi/interface/EcalDigiCollections.h>
+#include <DataFormats/EcalRawData/interface/EcalRawDataCollections.h>
+#include <Geometry/EcalMapping/interface/EcalElectronicsMapping.h>
+#include <Geometry/EcalMapping/interface/EcalMappingRcd.h>
 
 class TFile;
 class TTree;
@@ -44,7 +49,7 @@ class TMem;
 #define NSIDES 2    // Number of sides
 #define NREFCHAN 2  // Ref number for APDB
 
-class EcalLaserAnalyzer : public edm::EDAnalyzer {
+class EcalLaserAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   explicit EcalLaserAnalyzer(const edm::ParameterSet &iConfig);
   ~EcalLaserAnalyzer() override;
@@ -62,37 +67,49 @@ public:
 private:
   int iEvent;
 
+  const std::string eventHeaderCollection_;
+  const std::string eventHeaderProducer_;
+  const std::string digiCollection_;
+  const std::string digiProducer_;
+  const std::string digiPNCollection_;
+
+  const edm::EDGetTokenT<EcalRawDataCollection> rawDataToken_;
+  edm::EDGetTokenT<EBDigiCollection> ebDigiToken_;
+  edm::EDGetTokenT<EEDigiCollection> eeDigiToken_;
+  const edm::EDGetTokenT<EcalPnDiodeDigiCollection> pnDiodeDigiToken_;
+  const edm::ESGetToken<EcalElectronicsMapping, EcalMappingRcd> mappingToken_;
+
   // Framework parameters
 
-  unsigned int _nsamples;
+  const unsigned int _nsamples;
   unsigned int _presample;
-  unsigned int _firstsample;
-  unsigned int _lastsample;
-  unsigned int _nsamplesPN;
-  unsigned int _presamplePN;
-  unsigned int _firstsamplePN;
-  unsigned int _lastsamplePN;
-  unsigned int _timingcutlow;
-  unsigned int _timingcuthigh;
-  unsigned int _timingquallow;
-  unsigned int _timingqualhigh;
-  double _ratiomincutlow;
-  double _ratiomincuthigh;
-  double _ratiomaxcutlow;
-  double _presamplecut;
-  unsigned int _niter;
+  const unsigned int _firstsample;
+  const unsigned int _lastsample;
+  const unsigned int _nsamplesPN;
+  const unsigned int _presamplePN;
+  const unsigned int _firstsamplePN;
+  const unsigned int _lastsamplePN;
+  const unsigned int _timingcutlow;
+  const unsigned int _timingcuthigh;
+  const unsigned int _timingquallow;
+  const unsigned int _timingqualhigh;
+  const double _ratiomincutlow;
+  const double _ratiomincuthigh;
+  const double _ratiomaxcutlow;
+  const double _presamplecut;
+  const unsigned int _niter;
   bool _fitab;
-  double _alpha;
-  double _beta;
-  unsigned int _nevtmax;
-  double _noise;
-  double _chi2cut;
-  std::string _ecalPart;
-  bool _docorpn;
-  int _fedid;
-  bool _saveallevents;
-  double _qualpercent;
-  int _debug;
+  const double _alpha;
+  const double _beta;
+  const unsigned int _nevtmax;
+  const double _noise;
+  const double _chi2cut;
+  const std::string _ecalPart;
+  const bool _docorpn;
+  const int _fedid;
+  const bool _saveallevents;
+  const double _qualpercent;
+  const int _debug;
 
   TAPDPulse *APDPulse;
   TPNPulse *PNPulse;
@@ -102,13 +119,8 @@ private:
 
   bool doesABTreeExist;
 
-  std::string resdir_;
-  std::string pncorfile_;
-  std::string digiCollection_;
-  std::string digiPNCollection_;
-  std::string digiProducer_;
-  std::string eventHeaderCollection_;
-  std::string eventHeaderProducer_;
+  const std::string resdir_;
+  const std::string pncorfile_;
 
   // Output file names
 

--- a/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalLaserAnalyzer.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalLaserAnalyzer.h
@@ -1,3 +1,5 @@
+#ifndef CalibCalorimetry_EcalLaserAnalyzer_EcalLaserAnalyzer_h
+#define CalibCalorimetry_EcalLaserAnalyzer_EcalLaserAnalyzer_h
 // $Id: EcalLaserAnalyzer.h
 
 #include <memory>
@@ -244,3 +246,4 @@ private:
   bool isGainOK;
   bool isTimingOK;
 };
+#endif

--- a/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalLaserAnalyzer2.cc
+++ b/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalLaserAnalyzer2.cc
@@ -402,7 +402,8 @@ void EcalLaserAnalyzer2::analyze(const edm::Event& e, const edm::EventSetup& c) 
     EcalPnDiodeDetId pnDetId = EcalPnDiodeDetId((*pnItr).id());
 
     if (_debug == 1)
-      edm::LogVerbatim("EcalLaserAnalyzer2") << "-- debug test -- Inside PNDigi - pnID=" << pnDetId.iPnId() << ", dccID=" << pnDetId.iDCCId();
+      edm::LogVerbatim("EcalLaserAnalyzer2")
+          << "-- debug test -- Inside PNDigi - pnID=" << pnDetId.iPnId() << ", dccID=" << pnDetId.iDCCId();
 
     // Skip MEM DCC without relevant data
 
@@ -447,7 +448,8 @@ void EcalLaserAnalyzer2::analyze(const edm::Event& e, const edm::EventSetup& c) 
     allPNAmpl[pnDetId.iDCCId()].push_back(pnAmpl);
 
     if (_debug == 1)
-      edm::LogVerbatim("EcalLaserAnalyzer2") << "-- debug -- Inside PNDigi - PNampl=" << pnAmpl << ", PNgain=" << pnGain;
+      edm::LogVerbatim("EcalLaserAnalyzer2")
+          << "-- debug -- Inside PNDigi - PNampl=" << pnAmpl << ", PNgain=" << pnGain;
   }
 
   // ===========================
@@ -497,8 +499,9 @@ void EcalLaserAnalyzer2::analyze(const edm::Event& e, const edm::EventSetup& c) 
       setGeomEB(etaG, phiG, module, tower, strip, xtal, apdRefTT, channel, lmr);
 
       if (_debug == 1)
-        edm::LogVerbatim("EcalLaserAnalyzer2") << "-- debug -- Inside EBDigi - towerID:" << towerID << " channelID:" << channelID << " module:" << module
-             << " modules:" << modules.size();
+        edm::LogVerbatim("EcalLaserAnalyzer2")
+            << "-- debug -- Inside EBDigi - towerID:" << towerID << " channelID:" << channelID << " module:" << module
+            << " modules:" << modules.size();
 
       // APD Pulse
       //===========
@@ -596,8 +599,9 @@ void EcalLaserAnalyzer2::analyze(const edm::Event& e, const edm::EventSetup& c) 
       setGeomEE(etaG, phiG, iX, iY, iZ, module, tower, ch, apdRefTT, channel, lmr);
 
       if (_debug == 1)
-        edm::LogVerbatim("EcalLaserAnalyzer2") << "-- debug -- Inside EEDigi - towerID:" << towerID << " channelID:" << channelID << " module:" << module
-             << " modules:" << modules.size();
+        edm::LogVerbatim("EcalLaserAnalyzer2")
+            << "-- debug -- Inside EEDigi - towerID:" << towerID << " channelID:" << channelID << " module:" << module
+            << " modules:" << modules.size();
 
       // APD Pulse
       //===========
@@ -898,7 +902,8 @@ void EcalLaserAnalyzer2::endJob() {
       }
 
       if (_debug >= 1)
-        edm::LogVerbatim("EcalLaserAnalyzer2") << "-- debug test -- endJob -- apdAmpl:" << apdAmpl << " apdTime:" << apdTime;
+        edm::LogVerbatim("EcalLaserAnalyzer2")
+            << "-- debug test -- endJob -- apdAmpl:" << apdAmpl << " apdTime:" << apdTime;
       double pnmean;
       if (pn0 < 10 && pn1 > 10) {
         pnmean = pn1;
@@ -940,8 +945,8 @@ void EcalLaserAnalyzer2::endJob() {
 
         for (unsigned int ir = 0; ir < nRefChan; ir++) {
           if (_debug >= 1)
-            edm::LogVerbatim("EcalLaserAnalyzer2") << "-- debug test -- ir:" << ir << " tt:" << towerID << " refmap:" << apdRefMap[ir][iMod + 1]
-                 << " iCry:" << iCry;
+            edm::LogVerbatim("EcalLaserAnalyzer2") << "-- debug test -- ir:" << ir << " tt:" << towerID
+                                                   << " refmap:" << apdRefMap[ir][iMod + 1] << " iCry:" << iCry;
 
           if (apdRefMap[ir][iMod + 1] == iCry) {
             if (_debug >= 1)
@@ -955,8 +960,8 @@ void EcalLaserAnalyzer2::endJob() {
             if (_debug >= 1)
               edm::LogVerbatim("EcalLaserAnalyzer2") << "-- debug test -- apdAmplB=" << apdAmplB;
             if (_debug >= 1)
-              edm::LogVerbatim("EcalLaserAnalyzer2") << "-- debug test -- color=" << color << ", event:" << event << ", ir:" << ir
-                   << " tt-1:" << towerID - 1;
+              edm::LogVerbatim("EcalLaserAnalyzer2") << "-- debug test -- color=" << color << ", event:" << event
+                                                     << ", ir:" << ir << " tt-1:" << towerID - 1;
 
             RefAPDtrees[ir][iMod + 1]->Fill();
 
@@ -1159,8 +1164,9 @@ void EcalLaserAnalyzer2::endJob() {
       }
 
       if (_debug == 1)
-        edm::LogVerbatim("EcalLaserAnalyzer2") << "-- debug test -- LastLoop apdAmplA:" << apdAmplA << " apdAmplB:" << apdAmplB << ", event:" << event
-             << ", eventref:" << eventref;
+        edm::LogVerbatim("EcalLaserAnalyzer2")
+            << "-- debug test -- LastLoop apdAmplA:" << apdAmplA << " apdAmplB:" << apdAmplB << ", event:" << event
+            << ", eventref:" << eventref;
 
       // Fill APD stuff
       //===============
@@ -1212,8 +1218,8 @@ void EcalLaserAnalyzer2::endJob() {
         flag = 0;
 
       if (_debug >= 1)
-        edm::LogVerbatim("EcalLaserAnalyzer2") << "-- debug test -- endJob -- APD[0]" << APD[0] << " APDoPN[0] " << APDoPN[0] << " APDoAPDA[0] "
-             << APDoAPDA[0] << " flag " << flag;
+        edm::LogVerbatim("EcalLaserAnalyzer2") << "-- debug test -- endJob -- APD[0]" << APD[0] << " APDoPN[0] "
+                                               << APDoPN[0] << " APDoAPDA[0] " << APDoAPDA[0] << " flag " << flag;
       restrees[iColor]->Fill();
     }
   }
@@ -1247,8 +1253,9 @@ void EcalLaserAnalyzer2::endJob() {
         }
 
         if (_debug >= 1)
-          edm::LogVerbatim("EcalLaserAnalyzer2") << "-- debug test -- endJob -- filling pn results'tree: PN[0]:" << PN[0] << " iModule:" << iMod
-               << " iColor:" << iColor << " ch:" << ch;
+          edm::LogVerbatim("EcalLaserAnalyzer2")
+              << "-- debug test -- endJob -- filling pn results'tree: PN[0]:" << PN[0] << " iModule:" << iMod
+              << " iColor:" << iColor << " ch:" << ch;
 
         // Fill PN results trees
         //========================
@@ -1363,7 +1370,8 @@ bool EcalLaserAnalyzer2::getShapes() {
       unsigned int nBins2 = int(elecShape->GetNbinsX());
 
       if (nBins2 < nBins) {
-        edm::LogError("cfg_error") << "EcalLaserAnalyzer2::getShapes: wrong configuration of the shapes' number of bins";
+        edm::LogError("cfg_error")
+            << "EcalLaserAnalyzer2::getShapes: wrong configuration of the shapes' number of bins";
         isSPRFine = false;
       }
       assert(nSamplesShapes == nBins2);

--- a/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalLaserAnalyzer2.cc
+++ b/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalLaserAnalyzer2.cc
@@ -1,5 +1,6 @@
 /* 
  *  \class EcalLaserAnalyzer2
+ *
  *  primary author: Julie Malcles - CEA/Saclay
  *  author: Gautier Hamel De Monchenault - CEA/Saclay
  */
@@ -15,28 +16,18 @@
 #include "CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalLaserAnalyzer2.h"
 
 #include <sstream>
-#include <iostream>
-#include <iomanip>
 #include <fstream>
+#include <iomanip>
 
 #include <FWCore/MessageLogger/interface/MessageLogger.h>
-#include <FWCore/Utilities/interface/Exception.h>
 
-#include <FWCore/Framework/interface/ESHandle.h>
 #include <FWCore/Framework/interface/EventSetup.h>
-
-#include <Geometry/EcalMapping/interface/EcalElectronicsMapping.h>
-#include <Geometry/EcalMapping/interface/EcalMappingRcd.h>
 
 #include <FWCore/Framework/interface/Event.h>
 #include <FWCore/Framework/interface/MakerMacros.h>
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
-#include <DataFormats/EcalDigi/interface/EcalDigiCollections.h>
 #include <DataFormats/EcalDetId/interface/EcalElectronicsId.h>
 #include <DataFormats/EcalDetId/interface/EcalDetIdCollections.h>
-#include <DataFormats/EcalRawData/interface/EcalRawDataCollections.h>
-
-#include <vector>
 
 #include <CalibCalorimetry/EcalLaserAnalyzer/interface/TPNFit.h>
 #include <CalibCalorimetry/EcalLaserAnalyzer/interface/TMom.h>
@@ -56,8 +47,15 @@ using namespace std;
 EcalLaserAnalyzer2::EcalLaserAnalyzer2(const edm::ParameterSet& iConfig)
     //========================================================================
     : iEvent(0),
-
-      // framework parameters with default values
+      eventHeaderCollection_(iConfig.getParameter<std::string>("eventHeaderCollection")),
+      eventHeaderProducer_(iConfig.getParameter<std::string>("eventHeaderProducer")),
+      digiCollection_(iConfig.getParameter<std::string>("digiCollection")),
+      digiProducer_(iConfig.getParameter<std::string>("digiProducer")),
+      digiPNCollection_(iConfig.getParameter<std::string>("digiPNCollection")),
+      rawDataToken_(consumes<EcalRawDataCollection>(edm::InputTag(eventHeaderProducer_, eventHeaderCollection_))),
+      pnDiodeDigiToken_(consumes<EcalPnDiodeDigiCollection>(edm::InputTag(digiProducer_, digiPNCollection_))),
+      mappingToken_(esConsumes()),
+      // Framework parameters with default values
       _nsamples(iConfig.getUntrackedParameter<unsigned int>("nSamples", 10)),
       _presample(iConfig.getUntrackedParameter<unsigned int>("nPresamples", 2)),
       _firstsample(iConfig.getUntrackedParameter<unsigned int>("firstSample", 1)),
@@ -83,6 +81,9 @@ EcalLaserAnalyzer2::EcalLaserAnalyzer2(const edm::ParameterSet& iConfig)
       _saveallevents(iConfig.getUntrackedParameter<bool>("saveAllEvents", false)),
       _qualpercent(iConfig.getUntrackedParameter<double>("qualPercent", 0.2)),
       _debug(iConfig.getUntrackedParameter<int>("debug", 0)),
+      resdir_(iConfig.getUntrackedParameter<std::string>("resDir")),
+      elecfile_(iConfig.getUntrackedParameter<std::string>("elecFile")),
+      pncorfile_(iConfig.getUntrackedParameter<std::string>("pnCorFile")),
       nCrys(NCRYSEB),
       nPNPerMod(NPNPERMOD),
       nMod(NMODEB),
@@ -116,18 +117,11 @@ EcalLaserAnalyzer2::EcalLaserAnalyzer2(const edm::ParameterSet& iConfig)
 //========================================================================
 
 {
-  // Initialization from cfg file
-
-  resdir_ = iConfig.getUntrackedParameter<std::string>("resDir");
-  elecfile_ = iConfig.getUntrackedParameter<std::string>("elecFile");
-  pncorfile_ = iConfig.getUntrackedParameter<std::string>("pnCorFile");
-
-  digiCollection_ = iConfig.getParameter<std::string>("digiCollection");
-  digiPNCollection_ = iConfig.getParameter<std::string>("digiPNCollection");
-  digiProducer_ = iConfig.getParameter<std::string>("digiProducer");
-
-  eventHeaderCollection_ = iConfig.getParameter<std::string>("eventHeaderCollection");
-  eventHeaderProducer_ = iConfig.getParameter<std::string>("eventHeaderProducer");
+  if (_ecalPart == "EB") {
+    ebDigiToken_ = consumes<EBDigiCollection>(edm::InputTag(digiProducer_, digiCollection_));
+  } else if (_ecalPart == "EE") {
+    eeDigiToken_ = consumes<EEDigiCollection>(edm::InputTag(digiProducer_, digiCollection_));
+  }
 
   // Geometrical constants initialization
   if (_ecalPart == "EB") {
@@ -198,7 +192,7 @@ EcalLaserAnalyzer2::EcalLaserAnalyzer2(const edm::ParameterSet& iConfig)
 EcalLaserAnalyzer2::~EcalLaserAnalyzer2() {
   //========================================================================
 
-  // do anything here that needs to be done at desctruction time
+  // do anything here that needs to be done at destruction time
   // (e.g. close files, deallocate resources etc.)
 }
 
@@ -267,7 +261,7 @@ void EcalLaserAnalyzer2::beginJob() {
 
   IsMatacqOK = getShapes();
   if (!IsMatacqOK) {
-    cout << " ERROR! No matacq shape available: analysis aborted !" << endl;
+    edm::LogError("noshape") << " ERROR! No matacq shape available: analysis aborted !";
     return;
   }
 
@@ -285,11 +279,11 @@ void EcalLaserAnalyzer2::analyze(const edm::Event& e, const edm::EventSetup& c) 
   // retrieving DCC header
   edm::Handle<EcalRawDataCollection> pDCCHeader;
   const EcalRawDataCollection* DCCHeader = nullptr;
-  try {
-    e.getByLabel(eventHeaderProducer_, eventHeaderCollection_, pDCCHeader);
+  e.getByToken(rawDataToken_, pDCCHeader);
+  if (!pDCCHeader.isValid()) {
+    edm::LogError("nodata") << "Error! can't get the product retrieving DCC header" << eventHeaderCollection_.c_str();
+  } else {
     DCCHeader = pDCCHeader.product();
-  } catch (std::exception& ex) {
-    std::cerr << "Error! can't get the product  retrieving DCC header" << eventHeaderCollection_.c_str() << std::endl;
   }
 
   //retrieving crystal data from Event
@@ -297,46 +291,37 @@ void EcalLaserAnalyzer2::analyze(const edm::Event& e, const edm::EventSetup& c) 
   const EBDigiCollection* EBDigi = nullptr;
   edm::Handle<EEDigiCollection> pEEDigi;
   const EEDigiCollection* EEDigi = nullptr;
-
   if (_ecalPart == "EB") {
-    try {
-      e.getByLabel(digiProducer_, digiCollection_, pEBDigi);
+    e.getByToken(ebDigiToken_, pEBDigi);
+    if (!pEBDigi.isValid()) {
+      edm::LogError("nodata") << "Error! can't get the product retrieving EB crystal data " << digiCollection_.c_str();
+    } else {
       EBDigi = pEBDigi.product();
-    } catch (std::exception& ex) {
-      std::cerr << "Error! can't get the product retrieving EB crystal data " << digiCollection_.c_str() << std::endl;
     }
   } else if (_ecalPart == "EE") {
-    try {
-      e.getByLabel(digiProducer_, digiCollection_, pEEDigi);
+    e.getByToken(eeDigiToken_, pEEDigi);
+    if (!pEEDigi.isValid()) {
+      edm::LogError("nodata") << "Error! can't get the product retrieving EE crystal data " << digiCollection_.c_str();
+    } else {
       EEDigi = pEEDigi.product();
-    } catch (std::exception& ex) {
-      std::cerr << "Error! can't get the product retrieving EE crystal data " << digiCollection_.c_str() << std::endl;
     }
   } else {
-    cout << " Wrong ecalPart in cfg file " << endl;
+    edm::LogError("cfg_error") << " Wrong ecalPart in cfg file ";
     return;
   }
 
   // retrieving crystal PN diodes from Event
-
   edm::Handle<EcalPnDiodeDigiCollection> pPNDigi;
   const EcalPnDiodeDigiCollection* PNDigi = nullptr;
-  try {
-    e.getByLabel(digiProducer_, digiPNCollection_, pPNDigi);
+  e.getByToken(pnDiodeDigiToken_, pPNDigi);
+  if (!pPNDigi.isValid()) {
+    edm::LogError("nodata") << "Error! can't get the product " << digiPNCollection_.c_str();
+  } else {
     PNDigi = pPNDigi.product();
-  } catch (std::exception& ex) {
-    std::cerr << "Error! can't get the product " << digiPNCollection_.c_str() << std::endl;
   }
 
   // retrieving electronics mapping
-  edm::ESHandle<EcalElectronicsMapping> ecalmapping;
-  const EcalElectronicsMapping* TheMapping = nullptr;
-  try {
-    c.get<EcalMappingRcd>().get(ecalmapping);
-    TheMapping = ecalmapping.product();
-  } catch (std::exception& ex) {
-    std::cerr << "Error! can't get the product EcalMappingRcd" << std::endl;
-  }
+  const auto& TheMapping = c.getData(mappingToken_);
 
   // ====================================
   // Decode Basic DCCHeader Information
@@ -379,7 +364,7 @@ void EcalLaserAnalyzer2::analyze(const edm::Event& e, const edm::EventSetup& c) 
     vector<int>::iterator iter = find(colors.begin(), colors.end(), color);
     if (iter == colors.end()) {
       colors.push_back(color);
-      cout << " new color found " << color << " " << colors.size() << endl;
+      edm::LogVerbatim("EcalLaserAnalyzer2") << " new color found " << color << " " << colors.size();
     }
   }
 
@@ -417,7 +402,7 @@ void EcalLaserAnalyzer2::analyze(const edm::Event& e, const edm::EventSetup& c) 
     EcalPnDiodeDetId pnDetId = EcalPnDiodeDetId((*pnItr).id());
 
     if (_debug == 1)
-      cout << "-- debug test -- Inside PNDigi - pnID=" << pnDetId.iPnId() << ", dccID=" << pnDetId.iDCCId() << endl;
+      edm::LogVerbatim("EcalLaserAnalyzer2") << "-- debug test -- Inside PNDigi - pnID=" << pnDetId.iPnId() << ", dccID=" << pnDetId.iDCCId();
 
     // Skip MEM DCC without relevant data
 
@@ -437,7 +422,7 @@ void EcalLaserAnalyzer2::analyze(const edm::Event& e, const edm::EventSetup& c) 
     }
 
     if (pnGain != 1)
-      cout << "PN gain different from 1" << endl;
+      edm::LogVerbatim("EcalLaserAnalyzer2") << "PN gain different from 1";
 
     // Calculate amplitude from pulse
 
@@ -462,7 +447,7 @@ void EcalLaserAnalyzer2::analyze(const edm::Event& e, const edm::EventSetup& c) 
     allPNAmpl[pnDetId.iDCCId()].push_back(pnAmpl);
 
     if (_debug == 1)
-      cout << "-- debug -- Inside PNDigi - PNampl=" << pnAmpl << ", PNgain=" << pnGain << endl;
+      edm::LogVerbatim("EcalLaserAnalyzer2") << "-- debug -- Inside PNDigi - PNampl=" << pnAmpl << ", PNgain=" << pnGain;
   }
 
   // ===========================
@@ -483,7 +468,7 @@ void EcalLaserAnalyzer2::analyze(const edm::Event& e, const edm::EventSetup& c) 
 
       EBDetId id_crystal(digiItr->id());
       EBDataFrame df(*digiItr);
-      EcalElectronicsId elecid_crystal = TheMapping->getElectronicsId(id_crystal);
+      EcalElectronicsId elecid_crystal = TheMapping.getElectronicsId(id_crystal);
 
       int etaG = id_crystal.ieta();  // global
       int phiG = id_crystal.iphi();  // global
@@ -512,8 +497,8 @@ void EcalLaserAnalyzer2::analyze(const edm::Event& e, const edm::EventSetup& c) 
       setGeomEB(etaG, phiG, module, tower, strip, xtal, apdRefTT, channel, lmr);
 
       if (_debug == 1)
-        cout << "-- debug -- Inside EBDigi - towerID:" << towerID << " channelID:" << channelID << " module:" << module
-             << " modules:" << modules.size() << endl;
+        edm::LogVerbatim("EcalLaserAnalyzer2") << "-- debug -- Inside EBDigi - towerID:" << towerID << " channelID:" << channelID << " module:" << module
+             << " modules:" << modules.size();
 
       // APD Pulse
       //===========
@@ -567,6 +552,7 @@ void EcalLaserAnalyzer2::analyze(const edm::Event& e, const edm::EventSetup& c) 
         Delta12->addEntry(APDPulse->getDelta(1, 2));
       }
     }
+
   } else if (EEDigi) {
     // Loop on crystals
     //===================
@@ -577,7 +563,7 @@ void EcalLaserAnalyzer2::analyze(const edm::Event& e, const edm::EventSetup& c) 
 
       EEDetId id_crystal(digiItr->id());
       EEDataFrame df(*digiItr);
-      EcalElectronicsId elecid_crystal = TheMapping->getElectronicsId(id_crystal);
+      EcalElectronicsId elecid_crystal = TheMapping.getElectronicsId(id_crystal);
 
       int etaG = id_crystal.iy();
       int phiG = id_crystal.ix();
@@ -610,14 +596,14 @@ void EcalLaserAnalyzer2::analyze(const edm::Event& e, const edm::EventSetup& c) 
       setGeomEE(etaG, phiG, iX, iY, iZ, module, tower, ch, apdRefTT, channel, lmr);
 
       if (_debug == 1)
-        cout << "-- debug -- Inside EEDigi - towerID:" << towerID << " channelID:" << channelID << " module:" << module
-             << " modules:" << modules.size() << endl;
+        edm::LogVerbatim("EcalLaserAnalyzer2") << "-- debug -- Inside EEDigi - towerID:" << towerID << " channelID:" << channelID << " module:" << module
+             << " modules:" << modules.size();
 
       // APD Pulse
       //===========
 
       if ((*digiItr).size() > 10)
-        cout << "SAMPLES SIZE > 10!" << (*digiItr).size() << endl;
+        edm::LogVerbatim("EcalLaserAnalyzer2") << "SAMPLES SIZE > 10!" << (*digiItr).size();
 
       // Loop on adc samples
 
@@ -678,9 +664,9 @@ void EcalLaserAnalyzer2::endJob() {
   //========================================================================
 
   if (!IsMatacqOK) {
-    cout << "\n\t+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+" << endl;
-    cout << "\t+=+     WARNING! NO MATACQ        +=+" << endl;
-    cout << "\t+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+" << endl;
+    edm::LogVerbatim("EcalLaserAnalyzer2") << "\n\t+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+";
+    edm::LogVerbatim("EcalLaserAnalyzer2") << "\t+=+     WARNING! NO MATACQ        +=+";
+    edm::LogVerbatim("EcalLaserAnalyzer2") << "\t+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+";
     return;
   }
 
@@ -712,7 +698,7 @@ void EcalLaserAnalyzer2::endJob() {
     stringstream del;
     del << "rm " << ADCfile;
     system(del.str().c_str());
-    cout << " No Laser Events " << endl;
+    edm::LogVerbatim("EcalLaserAnalyzer2") << " No Laser Events ";
     return;
   }
 
@@ -751,13 +737,13 @@ void EcalLaserAnalyzer2::endJob() {
   // Analyze adc samples to get amplitudes
   //=======================================
 
-  cout << "\n\t+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+" << endl;
-  cout << "\t+=+     Analyzing laser data: getting APD, PN, APD/PN, PN/PN    +=+" << endl;
+  edm::LogVerbatim("EcalLaserAnalyzer2") << "\n\t+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+";
+  edm::LogVerbatim("EcalLaserAnalyzer2") << "\t+=+     Analyzing laser data: getting APD, PN, APD/PN, PN/PN    +=+";
 
   if (!isGainOK)
-    cout << "\t+=+ ............................ WARNING! APD GAIN WAS NOT 1    +=+" << endl;
+    edm::LogVerbatim("EcalLaserAnalyzer2") << "\t+=+ ............................ WARNING! APD GAIN WAS NOT 1    +=+";
   if (!isTimingOK)
-    cout << "\t+=+ ............................ WARNING! TIMING WAS BAD        +=+" << endl;
+    edm::LogVerbatim("EcalLaserAnalyzer2") << "\t+=+ ............................ WARNING! TIMING WAS BAD        +=+";
 
   APDFile = new TFile(APDfile.c_str(), "RECREATE");
 
@@ -838,6 +824,7 @@ void EcalLaserAnalyzer2::endJob() {
 
   for (unsigned int iM = 0; iM < nMod; iM++) {
     unsigned int iMod = modules[iM] - 1;
+
     for (unsigned int ich = 0; ich < nPNPerMod; ich++) {
       for (unsigned int icol = 0; icol < nCol; icol++) {
         PNFirstAnal[iMod][ich][icol] = new TPN(ich);
@@ -911,8 +898,7 @@ void EcalLaserAnalyzer2::endJob() {
       }
 
       if (_debug >= 1)
-        cout << "-- debug test -- endJob -- apdAmpl:" << apdAmpl << " apdTime:" << apdTime << endl;
-
+        edm::LogVerbatim("EcalLaserAnalyzer2") << "-- debug test -- endJob -- apdAmpl:" << apdAmpl << " apdTime:" << apdTime;
       double pnmean;
       if (pn0 < 10 && pn1 > 10) {
         pnmean = pn1;
@@ -922,7 +908,7 @@ void EcalLaserAnalyzer2::endJob() {
         pnmean = 0.5 * (pn0 + pn1);
 
       if (_debug >= 1)
-        cout << "-- debug test -- endJob -- pnMean:" << pnmean << endl;
+        edm::LogVerbatim("EcalLaserAnalyzer2") << "-- debug test -- endJob -- pnMean:" << pnmean;
 
       // Fill PN stuff
       //===============
@@ -939,7 +925,7 @@ void EcalLaserAnalyzer2::endJob() {
       if (apdAmpl != 0.0)
         APDFirstAnal[iCry][iCol]->addEntry(apdAmpl, pnmean, pn0, pn1, apdTime);
       if (_debug >= 1)
-        cout << "-- debug test -- endJob -- filling APDTree" << endl;
+        edm::LogVerbatim("EcalLaserAnalyzer2") << "-- debug test -- endJob -- filling APDTree";
 
       APDtrees[iCry]->Fill();
 
@@ -954,28 +940,28 @@ void EcalLaserAnalyzer2::endJob() {
 
         for (unsigned int ir = 0; ir < nRefChan; ir++) {
           if (_debug >= 1)
-            cout << "-- debug test -- ir:" << ir << " tt:" << towerID << " refmap:" << apdRefMap[ir][iMod + 1]
-                 << " iCry:" << iCry << endl;
+            edm::LogVerbatim("EcalLaserAnalyzer2") << "-- debug test -- ir:" << ir << " tt:" << towerID << " refmap:" << apdRefMap[ir][iMod + 1]
+                 << " iCry:" << iCry;
 
           if (apdRefMap[ir][iMod + 1] == iCry) {
             if (_debug >= 1)
-              cout << "-- debug test -- cut passed " << endl;
+              edm::LogVerbatim("EcalLaserAnalyzer2") << "-- debug test -- cut passed ";
             if (ir == 0)
               apdAmplA = apdAmpl;
             else if (ir == 1)
               apdAmplB = apdAmpl;
             if (_debug >= 1)
-              cout << "-- debug test -- apdAmplA=" << apdAmplA << endl;
+              edm::LogVerbatim("EcalLaserAnalyzer2") << "-- debug test -- apdAmplA=" << apdAmplA;
             if (_debug >= 1)
-              cout << "-- debug test -- apdAmplB=" << apdAmplB << endl;
+              edm::LogVerbatim("EcalLaserAnalyzer2") << "-- debug test -- apdAmplB=" << apdAmplB;
             if (_debug >= 1)
-              cout << "-- debug test -- color=" << color << ", event:" << event << ", ir:" << ir
-                   << " tt-1:" << towerID - 1 << endl;
+              edm::LogVerbatim("EcalLaserAnalyzer2") << "-- debug test -- color=" << color << ", event:" << event << ", ir:" << ir
+                   << " tt-1:" << towerID - 1;
 
             RefAPDtrees[ir][iMod + 1]->Fill();
 
             if (_debug >= 1)
-              cout << "-- debug test -- tree filled" << event << endl;
+              edm::LogVerbatim("EcalLaserAnalyzer2") << "-- debug test -- tree filled" << event;
           }
         }
       }
@@ -987,11 +973,10 @@ void EcalLaserAnalyzer2::endJob() {
   ADCFile->Close();
 
   if (_debug == 1)
-    cout << "-- debug test -- endJob -- after apdAmpl Loop" << endl;
+    edm::LogVerbatim("EcalLaserAnalyzer2") << "-- debug test -- endJob -- after apdAmpl Loop";
 
   // Remove temporary file
   //=======================
-
   stringstream del;
   del << "rm " << ADCfile;
   system(del.str().c_str());
@@ -1074,7 +1059,6 @@ void EcalLaserAnalyzer2::endJob() {
 
   // Build ref trees indexes
   //========================
-
   for (unsigned int imod = 0; imod < nMod; imod++) {
     int jmod = modules[imod];
     if (RefAPDtrees[0][jmod]->GetEntries() != 0 && RefAPDtrees[1][jmod]->GetEntries() != 0) {
@@ -1122,7 +1106,6 @@ void EcalLaserAnalyzer2::endJob() {
                                          APDFirstAnal[iCry][iCol]->getAPDoPN1().at(1));
       APDAnal[iCry][iCol]->setTimeCut(APDFirstAnal[iCry][iCol]->getTime().at(0),
                                       APDFirstAnal[iCry][iCol]->getTime().at(1));
-
       APDAnal[iCry][iCol]->set2DAPDoAPD0Cut(lowcut, highcut);
       APDAnal[iCry][iCol]->set2DAPDoAPD1Cut(lowcut, highcut);
     }
@@ -1144,7 +1127,7 @@ void EcalLaserAnalyzer2::endJob() {
         pnmean = 0.5 * (pn0 + pn1);
 
       // Get back color
-      //===============
+      //================
 
       unsigned int iCol = 0;
       for (unsigned int i = 0; i < nCol; i++) {
@@ -1167,7 +1150,7 @@ void EcalLaserAnalyzer2::endJob() {
       //===================
 
       if (_debug >= 1)
-        cout << "-- debug test -- LastLoop event:" << event << " apdAmpl:" << apdAmpl << endl;
+        edm::LogVerbatim("EcalLaserAnalyzer2") << "-- debug test -- LastLoop event:" << event << " apdAmpl:" << apdAmpl;
       apdAmplA = 0.0;
       apdAmplB = 0.0;
 
@@ -1176,8 +1159,8 @@ void EcalLaserAnalyzer2::endJob() {
       }
 
       if (_debug == 1)
-        cout << "-- debug test -- LastLoop apdAmplA:" << apdAmplA << " apdAmplB:" << apdAmplB << ", event:" << event
-             << ", eventref:" << eventref << endl;
+        edm::LogVerbatim("EcalLaserAnalyzer2") << "-- debug test -- LastLoop apdAmplA:" << apdAmplA << " apdAmplB:" << apdAmplB << ", event:" << event
+             << ", eventref:" << eventref;
 
       // Fill APD stuff
       //===============
@@ -1229,8 +1212,8 @@ void EcalLaserAnalyzer2::endJob() {
         flag = 0;
 
       if (_debug >= 1)
-        cout << "-- debug test -- endJob -- APD[0]" << APD[0] << " APDoPN[0] " << APDoPN[0] << " APDoAPDA[0] "
-             << APDoAPDA[0] << " flag " << flag << endl;
+        edm::LogVerbatim("EcalLaserAnalyzer2") << "-- debug test -- endJob -- APD[0]" << APD[0] << " APDoPN[0] " << APDoPN[0] << " APDoAPDA[0] "
+             << APDoAPDA[0] << " flag " << flag;
       restrees[iColor]->Fill();
     }
   }
@@ -1264,8 +1247,8 @@ void EcalLaserAnalyzer2::endJob() {
         }
 
         if (_debug >= 1)
-          cout << "-- debug test -- endJob -- filling pn results'tree: PN[0]:" << PN[0] << " iModule:" << iMod
-               << " iColor:" << iColor << " ch:" << ch << endl;
+          edm::LogVerbatim("EcalLaserAnalyzer2") << "-- debug test -- endJob -- filling pn results'tree: PN[0]:" << PN[0] << " iModule:" << iMod
+               << " iColor:" << iColor << " ch:" << ch;
 
         // Fill PN results trees
         //========================
@@ -1277,7 +1260,6 @@ void EcalLaserAnalyzer2::endJob() {
 
   // Remove temporary files
   //========================
-
   if (!_saveallevents) {
     APDFile->Close();
     stringstream del2;
@@ -1287,6 +1269,7 @@ void EcalLaserAnalyzer2::endJob() {
   } else {
     APDFile->cd();
     APDtrees[0]->Write();
+
     APDFile->Close();
     resFile->cd();
   }
@@ -1301,8 +1284,8 @@ void EcalLaserAnalyzer2::endJob() {
 
   resFile->Close();
 
-  cout << "\t+=+    .................................................. done  +=+" << endl;
-  cout << "\t+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+" << endl;
+  edm::LogVerbatim("EcalLaserAnalyzer2") << "\t+=+    .................................................. done  +=+";
+  edm::LogVerbatim("EcalLaserAnalyzer2") << "\t+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+";
 }
 
 //========================================================================
@@ -1333,7 +1316,7 @@ bool EcalLaserAnalyzer2::getShapes() {
         laserShape->Scale(1.0 / y);
     }
   } else {
-    cout << " ERROR! Matacq shape file not found !" << endl;
+    edm::LogError("file_not_found") << " ERROR! Matacq shape file not found !";
   }
   if (doesMatShapeExist)
     IsMatacqOK = true;
@@ -1365,7 +1348,7 @@ bool EcalLaserAnalyzer2::getShapes() {
     }
 
   } else {
-    cout << " ERROR! Elec shape file not found !" << endl;
+    edm::LogError("file_not_found") << " ERROR! Elec shape file not found !";
   }
 
   if (IsMatacqOK) {
@@ -1380,7 +1363,7 @@ bool EcalLaserAnalyzer2::getShapes() {
       unsigned int nBins2 = int(elecShape->GetNbinsX());
 
       if (nBins2 < nBins) {
-        cout << "EcalLaserAnalyzer2::getShapes: wrong configuration of the shapes' number of bins" << std::endl;
+        edm::LogError("cfg_error") << "EcalLaserAnalyzer2::getShapes: wrong configuration of the shapes' number of bins";
         isSPRFine = false;
       }
       assert(nSamplesShapes == nBins2);
@@ -1498,4 +1481,5 @@ void EcalLaserAnalyzer2::setGeomEE(
   idccID[channel] = dccID;
   iside[channel] = side;
 }
+
 DEFINE_FWK_MODULE(EcalLaserAnalyzer2);

--- a/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalLaserAnalyzer2.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalLaserAnalyzer2.h
@@ -1,3 +1,5 @@
+#ifndef CalibCalorimetry_EcalLaserAnalyzer_EcalLaserAnalyzer2_h
+#define CalibCalorimetry_EcalLaserAnalyzer_EcalLaserAnalyzer2_h
 // $Id: EcalLaserAnalyzer2.h
 
 #include <memory>
@@ -257,3 +259,4 @@ private:
   bool isGainOK;
   bool isTimingOK;
 };
+#endif

--- a/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalLaserAnalyzer2.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalLaserAnalyzer2.h
@@ -1,7 +1,16 @@
 // $Id: EcalLaserAnalyzer2.h
 
 #include <memory>
-#include <FWCore/Framework/interface/EDAnalyzer.h>
+
+#include <vector>
+#include <map>
+
+#include <FWCore/Framework/interface/one/EDAnalyzer.h>
+
+#include <DataFormats/EcalDigi/interface/EcalDigiCollections.h>
+#include <DataFormats/EcalRawData/interface/EcalRawDataCollections.h>
+#include <Geometry/EcalMapping/interface/EcalElectronicsMapping.h>
+#include <Geometry/EcalMapping/interface/EcalMappingRcd.h>
 
 class TFile;
 class TTree;
@@ -40,7 +49,7 @@ class TMem;
 #define NREFCHAN 2  // Ref number for APDB
 #define NSAMPSHAPES 250
 
-class EcalLaserAnalyzer2 : public edm::EDAnalyzer {
+class EcalLaserAnalyzer2 : public edm::one::EDAnalyzer<> {
 public:
   explicit EcalLaserAnalyzer2(const edm::ParameterSet &iConfig);
   ~EcalLaserAnalyzer2() override;
@@ -58,35 +67,45 @@ public:
 private:
   int iEvent;
 
+  const std::string eventHeaderCollection_;
+  const std::string eventHeaderProducer_;
+  const std::string digiCollection_;
+  const std::string digiProducer_;
+  const std::string digiPNCollection_;
+
+  const edm::EDGetTokenT<EcalRawDataCollection> rawDataToken_;
+  edm::EDGetTokenT<EBDigiCollection> ebDigiToken_;
+  edm::EDGetTokenT<EEDigiCollection> eeDigiToken_;
+  const edm::EDGetTokenT<EcalPnDiodeDigiCollection> pnDiodeDigiToken_;
+  const edm::ESGetToken<EcalElectronicsMapping, EcalMappingRcd> mappingToken_;
+
   // Framework parameters
 
-  unsigned int _nsamples;
+  const unsigned int _nsamples;
   unsigned int _presample;
-  unsigned int _firstsample;
-  unsigned int _lastsample;
-  unsigned int _samplemin;
-  unsigned int _samplemax;
-  unsigned int _nsamplesPN;
-  unsigned int _presamplePN;
-  unsigned int _firstsamplePN;
-  unsigned int _lastsamplePN;
-  unsigned int _timingcutlow;
-  unsigned int _timingcuthigh;
-  unsigned int _timingquallow;
-  unsigned int _timingqualhigh;
-  double _ratiomincutlow;
-  double _ratiomincuthigh;
-  double _ratiomaxcutlow;
-  double _presamplecut;
-  unsigned int _niter;
-  double _noise;
-  std::string _ecalPart;
-  bool _saveshapes;
-  bool _docorpn;
-  int _fedid;
-  bool _saveallevents;
-  double _qualpercent;
-  int _debug;
+  const unsigned int _firstsample;
+  const unsigned int _lastsample;
+  const unsigned int _nsamplesPN;
+  const unsigned int _presamplePN;
+  const unsigned int _firstsamplePN;
+  const unsigned int _lastsamplePN;
+  const unsigned int _timingcutlow;
+  const unsigned int _timingcuthigh;
+  const unsigned int _timingquallow;
+  const unsigned int _timingqualhigh;
+  const double _ratiomincutlow;
+  const double _ratiomincuthigh;
+  const double _ratiomaxcutlow;
+  const double _presamplecut;
+  const unsigned int _niter;
+  const double _noise;
+  const std::string _ecalPart;
+  const bool _saveshapes;
+  const bool _docorpn;
+  const int _fedid;
+  const bool _saveallevents;
+  const double _qualpercent;
+  const int _debug;
 
   TAPDPulse *APDPulse;
   TPNPulse *PNPulse;
@@ -94,14 +113,9 @@ private:
   TMom *Delta01;
   TMom *Delta12;
 
-  std::string resdir_;
-  std::string digiCollection_;
-  std::string elecfile_;
-  std::string pncorfile_;
-  std::string digiPNCollection_;
-  std::string digiProducer_;
-  std::string eventHeaderCollection_;
-  std::string eventHeaderProducer_;
+  const std::string resdir_;
+  const std::string elecfile_;
+  const std::string pncorfile_;
 
   // Output file names
 

--- a/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalPerEvtLaserAnalyzer.cc
+++ b/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalPerEvtLaserAnalyzer.cc
@@ -11,12 +11,10 @@
 #include "EcalPerEvtLaserAnalyzer.h"
 
 #include <sstream>
-#include <iostream>
 #include <iomanip>
 #include <ctime>
 
 #include <FWCore/MessageLogger/interface/MessageLogger.h>
-#include <FWCore/Utilities/interface/Exception.h>
 
 #include <CalibCalorimetry/EcalLaserAnalyzer/interface/MEEEGeom.h>
 #include <CalibCalorimetry/EcalLaserAnalyzer/interface/MEEBGeom.h>
@@ -25,17 +23,9 @@
 #include <FWCore/Framework/interface/MakerMacros.h>
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
 #include <FWCore/Framework/interface/EventSetup.h>
-#include <FWCore/Framework/interface/ESHandle.h>
 
-#include <Geometry/EcalMapping/interface/EcalElectronicsMapping.h>
-#include <Geometry/EcalMapping/interface/EcalMappingRcd.h>
-
-#include <DataFormats/EcalDigi/interface/EcalDigiCollections.h>
 #include <DataFormats/EcalDetId/interface/EcalElectronicsId.h>
 #include <DataFormats/EcalDetId/interface/EcalDetIdCollections.h>
-#include <DataFormats/EcalRawData/interface/EcalRawDataCollections.h>
-
-#include <vector>
 
 #include <CalibCalorimetry/EcalLaserAnalyzer/interface/TPNFit.h>
 #include <CalibCalorimetry/EcalLaserAnalyzer/interface/PulseFitWithFunction.h>
@@ -46,14 +36,19 @@ using namespace std;
 EcalPerEvtLaserAnalyzer::EcalPerEvtLaserAnalyzer(const edm::ParameterSet& iConfig)
     //========================================================================
     : iEvent(0),
-
+      eventHeaderCollection_(iConfig.getParameter<std::string>("eventHeaderCollection")),
+      eventHeaderProducer_(iConfig.getParameter<std::string>("eventHeaderProducer")),
+      digiCollection_(iConfig.getParameter<std::string>("digiCollection")),
+      digiProducer_(iConfig.getParameter<std::string>("digiProducer")),
+      digiPNCollection_(iConfig.getParameter<std::string>("digiPNCollection")),
+      rawDataToken_(consumes<EcalRawDataCollection>(edm::InputTag(eventHeaderProducer_, eventHeaderCollection_))),
+      pnDiodeDigiToken_(consumes<EcalPnDiodeDigiCollection>(edm::InputTag(digiProducer_, digiPNCollection_))),
+      mappingToken_(esConsumes()),
       // framework parameters with default values
       _nsamples(iConfig.getUntrackedParameter<unsigned int>("nSamples", 10)),
       _presample(iConfig.getUntrackedParameter<unsigned int>("nPresamples", 3)),
       _firstsample(iConfig.getUntrackedParameter<unsigned int>("firstSample", 1)),
       _lastsample(iConfig.getUntrackedParameter<unsigned int>("lastSample", 2)),
-      _samplemin(iConfig.getUntrackedParameter<unsigned int>("sampleMin", 3)),
-      _samplemax(iConfig.getUntrackedParameter<unsigned int>("sampleMax", 9)),
       _nsamplesPN(iConfig.getUntrackedParameter<unsigned int>("nSamplesPN", 50)),
       _presamplePN(iConfig.getUntrackedParameter<unsigned int>("nPresamplesPN", 6)),
       _firstsamplePN(iConfig.getUntrackedParameter<unsigned int>("firstSamplePN", 7)),
@@ -65,11 +60,10 @@ EcalPerEvtLaserAnalyzer::EcalPerEvtLaserAnalyzer(const edm::ParameterSet& iConfi
       _tower(iConfig.getUntrackedParameter<unsigned int>("tower", 1)),
       _channel(iConfig.getUntrackedParameter<unsigned int>("channel", 1)),
       _ecalPart(iConfig.getUntrackedParameter<std::string>("ecalPart", "EB")),
+      resdir_(iConfig.getUntrackedParameter<std::string>("resDir")),
+      refalphabeta_(iConfig.getUntrackedParameter<std::string>("refAlphaBeta")),
       nCrys(NCRYSEB),
-      nTT(NTTEB),
-      nSides(NSIDES),
       IsFileCreated(0),
-      nCh(0),
       runType(-1),
       runNum(0),
       dccID(-1),
@@ -83,26 +77,18 @@ EcalPerEvtLaserAnalyzer::EcalPerEvtLaserAnalyzer(const edm::ParameterSet& iConfi
 //========================================================================
 
 {
-  //now do what ever initialization is needed
-
-  resdir_ = iConfig.getUntrackedParameter<std::string>("resDir");
-  refalphabeta_ = iConfig.getUntrackedParameter<std::string>("refAlphaBeta");
-
-  digiCollection_ = iConfig.getParameter<std::string>("digiCollection");
-  digiPNCollection_ = iConfig.getParameter<std::string>("digiPNCollection");
-  digiProducer_ = iConfig.getParameter<std::string>("digiProducer");
-
-  eventHeaderCollection_ = iConfig.getParameter<std::string>("eventHeaderCollection");
-  eventHeaderProducer_ = iConfig.getParameter<std::string>("eventHeaderProducer");
+  if (_ecalPart == "EB") {
+    ebDigiToken_ = consumes<EBDigiCollection>(edm::InputTag(digiProducer_, digiCollection_));
+  } else if (_ecalPart == "EE") {
+    eeDigiToken_ = consumes<EEDigiCollection>(edm::InputTag(digiProducer_, digiCollection_));
+  }
 
   // Define geometrical constants
-
+  //
   if (_ecalPart == "EB") {
     nCrys = NCRYSEB;
-    nTT = NTTEB;
   } else {
     nCrys = NCRYSEE;
-    nTT = NTTEE;
   }
 }
 
@@ -157,7 +143,6 @@ void EcalPerEvtLaserAnalyzer::beginJob() {
   ADCtrees->SetBranchAddress("pn1", &pn1);
 
   IsFileCreated = 0;
-  nCh = nCrys;
 }
 
 //========================================================================
@@ -169,11 +154,11 @@ void EcalPerEvtLaserAnalyzer::analyze(const edm::Event& e, const edm::EventSetup
   // retrieving DCC header
   edm::Handle<EcalRawDataCollection> pDCCHeader;
   const EcalRawDataCollection* DCCHeader = nullptr;
-  try {
-    e.getByLabel(eventHeaderProducer_, eventHeaderCollection_, pDCCHeader);
+  e.getByToken(rawDataToken_, pDCCHeader);
+  if (!pDCCHeader.isValid()) {
+    edm::LogError("nodata") << "Error! can't get the product  retrieving DCC header" << eventHeaderCollection_.c_str();
+  } else {
     DCCHeader = pDCCHeader.product();
-  } catch (std::exception& ex) {
-    std::cerr << "Error! can't get the product  retrieving DCC header" << eventHeaderCollection_.c_str() << std::endl;
   }
 
   // retrieving crystal data from Event
@@ -181,42 +166,34 @@ void EcalPerEvtLaserAnalyzer::analyze(const edm::Event& e, const edm::EventSetup
   const EBDigiCollection* EBDigi = nullptr;
   edm::Handle<EEDigiCollection> pEEDigi;
   const EEDigiCollection* EEDigi = nullptr;
-
   if (_ecalPart == "EB") {
-    try {
-      e.getByLabel(digiProducer_, digiCollection_, pEBDigi);
+    e.getByToken(ebDigiToken_, pEBDigi);
+    if (!pEBDigi.isValid()) {
+      edm::LogError("nodata") << "Error! can't get the product retrieving EB crystal data " << digiCollection_.c_str();
+    } else {
       EBDigi = pEBDigi.product();
-    } catch (std::exception& ex) {
-      std::cerr << "Error! can't get the product retrieving EB crystal data " << digiCollection_.c_str() << std::endl;
     }
   } else {
-    try {
-      e.getByLabel(digiProducer_, digiCollection_, pEEDigi);
+    e.getByToken(eeDigiToken_, pEEDigi);
+    if (!pEEDigi.isValid()) {
+      edm::LogError("nodata") << "Error! can't get the product retrieving EE crystal data " << digiCollection_.c_str();
+    } else {
       EEDigi = pEEDigi.product();
-    } catch (std::exception& ex) {
-      std::cerr << "Error! can't get the product retrieving EE crystal data " << digiCollection_.c_str() << std::endl;
     }
   }
 
   // retrieving crystal PN diodes from Event
   edm::Handle<EcalPnDiodeDigiCollection> pPNDigi;
   const EcalPnDiodeDigiCollection* PNDigi = nullptr;
-  try {
-    e.getByLabel(digiProducer_, digiPNCollection_, pPNDigi);
+  e.getByToken(pnDiodeDigiToken_, pPNDigi);
+  if (!pPNDigi.isValid()) {
+    edm::LogError("nodata") << "Error! can't get the product " << digiPNCollection_.c_str();
+  } else {
     PNDigi = pPNDigi.product();
-  } catch (std::exception& ex) {
-    std::cerr << "Error! can't get the product " << digiPNCollection_.c_str() << std::endl;
   }
 
   // retrieving electronics mapping
-  edm::ESHandle<EcalElectronicsMapping> ecalmapping;
-  const EcalElectronicsMapping* TheMapping = nullptr;
-  try {
-    c.get<EcalMappingRcd>().get(ecalmapping);
-    TheMapping = ecalmapping.product();
-  } catch (std::exception& ex) {
-    std::cerr << "Error! can't get the product EcalMappingRcd" << std::endl;
-  }
+  const auto& TheMapping = c.getData(mappingToken_);
 
   // ====================================
   // Decode Basic DCCHeader Information
@@ -285,7 +262,7 @@ void EcalPerEvtLaserAnalyzer::analyze(const edm::Event& e, const edm::EventSetup
     vector<int>::iterator iter = find(colors.begin(), colors.end(), color);
     if (iter == colors.end()) {
       colors.push_back(color);
-      cout << " new color found " << color << " " << colors.size() << endl;
+      edm::LogVerbatim("EcalPerEvtLaserAnalyzer") << " new color found " << color << " " << colors.size();
     }
   }
 
@@ -391,7 +368,7 @@ void EcalPerEvtLaserAnalyzer::analyze(const edm::Event& e, const edm::EventSetup
 
       side = MEEBGeom::side(etaG, phiG);
 
-      EcalElectronicsId elecid_crystal = TheMapping->getElectronicsId(id_crystal);
+      EcalElectronicsId elecid_crystal = TheMapping.getElectronicsId(id_crystal);
 
       int towerID = elecid_crystal.towerId();
       // int channelID=elecid_crystal.channelId()-1;  // FIXME so far for endcap only
@@ -479,7 +456,7 @@ void EcalPerEvtLaserAnalyzer::analyze(const edm::Event& e, const edm::EventSetup
 
       // Recover the TT id and the electronic crystal numbering from EcalElectronicsMapping
 
-      EcalElectronicsId elecid_crystal = TheMapping->getElectronicsId(id_crystal);
+      EcalElectronicsId elecid_crystal = TheMapping.getElectronicsId(id_crystal);
 
       int towerID = elecid_crystal.towerId();
       int channelID = elecid_crystal.channelId() - 1;
@@ -563,10 +540,10 @@ void EcalPerEvtLaserAnalyzer::endJob() {
 
   ADCtrees->Write();
 
-  cout << "\n\t+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+" << endl;
-  cout << "\t+=+       Analyzing laser data: getting per event               +=+" << endl;
-  cout << "\t+=+            APD Amplitudes and ADC samples                   +=+" << endl;
-  cout << "\t+=+    for fed:" << _fedid << ", tower:" << _tower << ", and channel:" << _channel << endl;
+  edm::LogVerbatim("EcalPerEvtLaserAnalyzer") << "\n\t+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+";
+  edm::LogVerbatim("EcalPerEvtLaserAnalyzer") << "\t+=+       Analyzing laser data: getting per event               +=+";
+  edm::LogVerbatim("EcalPerEvtLaserAnalyzer") << "\t+=+            APD Amplitudes and ADC samples                   +=+";
+  edm::LogVerbatim("EcalPerEvtLaserAnalyzer") << "\t+=+    for fed:" << _fedid << ", tower:" << _tower << ", and channel:" << _channel;
 
   // Define temporary tree to save APD amplitudes
 
@@ -739,8 +716,8 @@ void EcalPerEvtLaserAnalyzer::endJob() {
   del << "rm " << ADCfile;
   system(del.str().c_str());
 
-  cout << "\t+=+    .................................................. done  +=+" << endl;
-  cout << "\t+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+" << endl;
+  edm::LogVerbatim("EcalPerEvtLaserAnalyzer") << "\t+=+    .................................................. done  +=+";
+  edm::LogVerbatim("EcalPerEvtLaserAnalyzer") << "\t+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+";
 }
 
 DEFINE_FWK_MODULE(EcalPerEvtLaserAnalyzer);

--- a/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalPerEvtLaserAnalyzer.cc
+++ b/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalPerEvtLaserAnalyzer.cc
@@ -540,10 +540,14 @@ void EcalPerEvtLaserAnalyzer::endJob() {
 
   ADCtrees->Write();
 
-  edm::LogVerbatim("EcalPerEvtLaserAnalyzer") << "\n\t+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+";
-  edm::LogVerbatim("EcalPerEvtLaserAnalyzer") << "\t+=+       Analyzing laser data: getting per event               +=+";
-  edm::LogVerbatim("EcalPerEvtLaserAnalyzer") << "\t+=+            APD Amplitudes and ADC samples                   +=+";
-  edm::LogVerbatim("EcalPerEvtLaserAnalyzer") << "\t+=+    for fed:" << _fedid << ", tower:" << _tower << ", and channel:" << _channel;
+  edm::LogVerbatim("EcalPerEvtLaserAnalyzer")
+      << "\n\t+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+";
+  edm::LogVerbatim("EcalPerEvtLaserAnalyzer")
+      << "\t+=+       Analyzing laser data: getting per event               +=+";
+  edm::LogVerbatim("EcalPerEvtLaserAnalyzer")
+      << "\t+=+            APD Amplitudes and ADC samples                   +=+";
+  edm::LogVerbatim("EcalPerEvtLaserAnalyzer")
+      << "\t+=+    for fed:" << _fedid << ", tower:" << _tower << ", and channel:" << _channel;
 
   // Define temporary tree to save APD amplitudes
 
@@ -716,8 +720,10 @@ void EcalPerEvtLaserAnalyzer::endJob() {
   del << "rm " << ADCfile;
   system(del.str().c_str());
 
-  edm::LogVerbatim("EcalPerEvtLaserAnalyzer") << "\t+=+    .................................................. done  +=+";
-  edm::LogVerbatim("EcalPerEvtLaserAnalyzer") << "\t+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+";
+  edm::LogVerbatim("EcalPerEvtLaserAnalyzer")
+      << "\t+=+    .................................................. done  +=+";
+  edm::LogVerbatim("EcalPerEvtLaserAnalyzer")
+      << "\t+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+";
 }
 
 DEFINE_FWK_MODULE(EcalPerEvtLaserAnalyzer);

--- a/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalPerEvtLaserAnalyzer.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalPerEvtLaserAnalyzer.h
@@ -1,10 +1,18 @@
 // $Id: EcalPerEvtLaserAnalyzer.h
 
 #include <memory>
-#include <FWCore/Framework/interface/EDAnalyzer.h>
 
-class TTree;
+#include <vector>
+
+#include <FWCore/Framework/interface/one/EDAnalyzer.h>
+
+#include <DataFormats/EcalDigi/interface/EcalDigiCollections.h>
+#include <DataFormats/EcalRawData/interface/EcalRawDataCollections.h>
+#include <Geometry/EcalMapping/interface/EcalElectronicsMapping.h>
+#include <Geometry/EcalMapping/interface/EcalMappingRcd.h>
+
 class TFile;
+class TTree;
 
 // Define geometrical constants
 // NOT the same for "EB" and "EE"
@@ -30,7 +38,7 @@ class TFile;
 #define NTTEE 33     // Number of EE Trigger Towers
 #define NPNEE 4      // Number of PN per EE supermodule
 
-class EcalPerEvtLaserAnalyzer : public edm::EDAnalyzer {
+class EcalPerEvtLaserAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   explicit EcalPerEvtLaserAnalyzer(const edm::ParameterSet &iConfig);
   ~EcalPerEvtLaserAnalyzer() override;
@@ -44,53 +52,50 @@ public:
 private:
   int iEvent;
 
+  const std::string eventHeaderCollection_;
+  const std::string eventHeaderProducer_;
+  const std::string digiCollection_;
+  const std::string digiProducer_;
+  const std::string digiPNCollection_;
+
+  const edm::EDGetTokenT<EcalRawDataCollection> rawDataToken_;
+  edm::EDGetTokenT<EBDigiCollection> ebDigiToken_;
+  edm::EDGetTokenT<EEDigiCollection> eeDigiToken_;
+  const edm::EDGetTokenT<EcalPnDiodeDigiCollection> pnDiodeDigiToken_;
+  const edm::ESGetToken<EcalElectronicsMapping, EcalMappingRcd> mappingToken_;
+
   // Framework parameters
 
-  unsigned int _nsamples;
-  unsigned int _presample;
-  unsigned int _firstsample;
-  unsigned int _lastsample;
-  unsigned int _samplemin;
-  unsigned int _samplemax;
-  unsigned int _nsamplesPN;
-  unsigned int _presamplePN;
-  unsigned int _firstsamplePN;
-  unsigned int _lastsamplePN;
-  unsigned int _timingcutlow;
-  unsigned int _timingcuthigh;
-  unsigned int _niter;
-  int _fedid;
-  unsigned int _tower;
-  unsigned int _channel;
-  std::string _ecalPart;
+  const unsigned int _nsamples;
+  const unsigned int _presample;
+  const unsigned int _firstsample;
+  const unsigned int _lastsample;
+  const unsigned int _nsamplesPN;
+  const unsigned int _presamplePN;
+  const unsigned int _firstsamplePN;
+  const unsigned int _lastsamplePN;
+  const unsigned int _timingcutlow;
+  const unsigned int _timingcuthigh;
+  const unsigned int _niter;
+  const int _fedid;
+  const unsigned int _tower;
+  const unsigned int _channel;
+  const std::string _ecalPart;
 
-  std::string resdir_;
-  std::string refalphabeta_;
-  std::string digiCollection_;
-  std::string digiPNCollection_;
-  std::string digiProducer_;
-  std::string eventHeaderCollection_;
-  std::string eventHeaderProducer_;
+  const std::string resdir_;
+  const std::string refalphabeta_;
 
   // Output file names
 
-  std::string alphafile;
   std::string ADCfile;
-  std::string APDfile;
   std::string resfile;
 
   //  Define geometrical constants
   //  Default values correspond to "EB" geometry (1700 crystals)
 
   unsigned int nCrys;
-  unsigned int nTT;
-  unsigned int nSides;
 
   int IsFileCreated;
-
-  // Define number of channels (68 or 1700) for alpha and beta calculation
-
-  unsigned int nCh;
 
   // Identify run type
 

--- a/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalPerEvtLaserAnalyzer.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalPerEvtLaserAnalyzer.h
@@ -1,3 +1,5 @@
+#ifndef CalibCalorimetry_EcalLaserAnalyzer_EcalPerEvtLaserAnalyzer_h
+#define CalibCalorimetry_EcalLaserAnalyzer_EcalPerEvtLaserAnalyzer_h
 // $Id: EcalPerEvtLaserAnalyzer.h
 
 #include <memory>
@@ -142,3 +144,4 @@ private:
   double apdTime;
   double pnAmpl;
 };
+#endif

--- a/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalTestPulseAnalyzer.cc
+++ b/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalTestPulseAnalyzer.cc
@@ -238,7 +238,8 @@ void EcalTestPulseAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& 
   }
 
   // retrieving electronics mapping
-  const auto& TheMapping = c.getData(mappingToken_);;
+  const auto& TheMapping = c.getData(mappingToken_);
+  ;
 
   // ====================================
   // Decode Basic DCCHeader Information

--- a/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalTestPulseAnalyzer.cc
+++ b/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalTestPulseAnalyzer.cc
@@ -8,29 +8,20 @@
 #include <TFile.h>
 #include <TTree.h>
 
-using namespace std;
 #include "EcalTestPulseAnalyzer.h"
 
 #include <sstream>
-#include <iostream>
 #include <iomanip>
 
 #include <FWCore/MessageLogger/interface/MessageLogger.h>
-#include <FWCore/Utilities/interface/Exception.h>
 
 #include <FWCore/Framework/interface/Event.h>
 #include <FWCore/Framework/interface/MakerMacros.h>
-#include <FWCore/Framework/interface/ESHandle.h>
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
 #include <FWCore/Framework/interface/EventSetup.h>
 
-#include <DataFormats/EcalDigi/interface/EcalDigiCollections.h>
-#include <DataFormats/EcalDetId/interface/EcalDetIdCollections.h>
-#include <DataFormats/EcalRawData/interface/EcalRawDataCollections.h>
-
-#include <Geometry/EcalMapping/interface/EcalElectronicsMapping.h>
-#include <Geometry/EcalMapping/interface/EcalMappingRcd.h>
 #include <DataFormats/EcalDetId/interface/EcalElectronicsId.h>
+#include <DataFormats/EcalDetId/interface/EcalDetIdCollections.h>
 
 #include <CalibCalorimetry/EcalLaserAnalyzer/interface/TPNFit.h>
 #include <CalibCalorimetry/EcalLaserAnalyzer/interface/TSFit.h>
@@ -45,9 +36,15 @@ using namespace std;
 EcalTestPulseAnalyzer::EcalTestPulseAnalyzer(const edm::ParameterSet& iConfig)
     //========================================================================
     : iEvent(0),
-
+      eventHeaderCollection_(iConfig.getParameter<std::string>("eventHeaderCollection")),
+      eventHeaderProducer_(iConfig.getParameter<std::string>("eventHeaderProducer")),
+      digiCollection_(iConfig.getParameter<std::string>("digiCollection")),
+      digiProducer_(iConfig.getParameter<std::string>("digiProducer")),
+      digiPNCollection_(iConfig.getParameter<std::string>("digiPNCollection")),
+      rawDataToken_(consumes<EcalRawDataCollection>(edm::InputTag(eventHeaderProducer_, eventHeaderCollection_))),
+      pnDiodeDigiToken_(consumes<EcalPnDiodeDigiCollection>(edm::InputTag(digiProducer_, digiPNCollection_))),
+      mappingToken_(esConsumes()),
       // framework parameters with default values
-
       _nsamples(iConfig.getUntrackedParameter<unsigned int>("nSamples", 10)),
       _presample(iConfig.getUntrackedParameter<unsigned int>("nPresamples", 3)),
       _firstsample(iConfig.getUntrackedParameter<unsigned int>("firstSample", 1)),
@@ -63,8 +60,8 @@ EcalTestPulseAnalyzer::EcalTestPulseAnalyzer(const edm::ParameterSet& iConfig)
       _timeofmax(iConfig.getUntrackedParameter<double>("timeOfMax", 4.5)),
       _ecalPart(iConfig.getUntrackedParameter<std::string>("ecalPart", "EB")),
       _fedid(iConfig.getUntrackedParameter<int>("fedID", -999)),
+      resdir_(iConfig.getUntrackedParameter<std::string>("resDir")),
       nCrys(NCRYSEB),
-      nTT(NTTEB),
       nMod(NMODEB),
       nGainPN(NGAINPN),
       nGainAPD(NGAINAPD),
@@ -89,25 +86,18 @@ EcalTestPulseAnalyzer::EcalTestPulseAnalyzer(const edm::ParameterSet& iConfig)
 //========================================================================
 
 {
-  //now do what ever initialization is needed
-
-  resdir_ = iConfig.getUntrackedParameter<std::string>("resDir");
-
-  digiCollection_ = iConfig.getParameter<std::string>("digiCollection");
-  digiPNCollection_ = iConfig.getParameter<std::string>("digiPNCollection");
-  digiProducer_ = iConfig.getParameter<std::string>("digiProducer");
-
-  eventHeaderCollection_ = iConfig.getParameter<std::string>("eventHeaderCollection");
-  eventHeaderProducer_ = iConfig.getParameter<std::string>("eventHeaderProducer");
+  if (_ecalPart == "EB") {
+    ebDigiToken_ = consumes<EBDigiCollection>(edm::InputTag(digiProducer_, digiCollection_));
+  } else if (_ecalPart == "EE") {
+    eeDigiToken_ = consumes<EEDigiCollection>(edm::InputTag(digiProducer_, digiCollection_));
+  }
 
   // Define geometrical constants
 
   if (_ecalPart == "EB") {
     nCrys = NCRYSEB;
-    nTT = NTTEB;
   } else {
     nCrys = NCRYSEE;
-    nTT = NTTEE;
   }
 
   iZ = 1;
@@ -209,56 +199,46 @@ void EcalTestPulseAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& 
   // Retrieve DCC header
   edm::Handle<EcalRawDataCollection> pDCCHeader;
   const EcalRawDataCollection* DCCHeader = nullptr;
-  try {
-    e.getByLabel(eventHeaderProducer_, eventHeaderCollection_, pDCCHeader);
+  e.getByToken(rawDataToken_, pDCCHeader);
+  if (!pDCCHeader.isValid()) {
+    edm::LogError("nodata") << "Error! can't get the product  retrieving DCC header" << eventHeaderCollection_.c_str();
+  } else {
     DCCHeader = pDCCHeader.product();
-  } catch (std::exception& ex) {
-    std::cerr << "Error! can't get the product  retrieving DCC header" << eventHeaderCollection_.c_str() << std::endl;
   }
 
-  // retrieving crystal EB data from Event
+  // retrieving crystal data from Event
   edm::Handle<EBDigiCollection> pEBDigi;
   const EBDigiCollection* EBDigi = nullptr;
-
-  // retrieving crystal EE data from Event
   edm::Handle<EEDigiCollection> pEEDigi;
   const EEDigiCollection* EEDigi = nullptr;
-
   if (_ecalPart == "EB") {
-    try {
-      e.getByLabel(digiProducer_, digiCollection_, pEBDigi);
+    e.getByToken(ebDigiToken_, pEBDigi);
+    if (!pEBDigi.isValid()) {
+      edm::LogError("nodata") << "Error! can't get the product retrieving EB crystal data " << digiCollection_.c_str();
+    } else {
       EBDigi = pEBDigi.product();
-    } catch (std::exception& ex) {
-      std::cerr << "Error! can't get the product retrieving EB crystal data " << digiCollection_.c_str() << std::endl;
     }
   } else {
-    try {
-      e.getByLabel(digiProducer_, digiCollection_, pEEDigi);
+    e.getByToken(eeDigiToken_, pEEDigi);
+    if (!pEEDigi.isValid()) {
+      edm::LogError("nodata") << "Error! can't get the product retrieving EE crystal data " << digiCollection_.c_str();
+    } else {
       EEDigi = pEEDigi.product();
-    } catch (std::exception& ex) {
-      std::cerr << "Error! can't get the product retrieving EE crystal data " << digiCollection_.c_str() << std::endl;
     }
   }
 
   // Retrieve crystal PN diodes from Event
   edm::Handle<EcalPnDiodeDigiCollection> pPNDigi;
   const EcalPnDiodeDigiCollection* PNDigi = nullptr;
-  try {
-    e.getByLabel(digiProducer_, digiPNCollection_, pPNDigi);
+  e.getByToken(pnDiodeDigiToken_, pPNDigi);
+  if (!pPNDigi.isValid()) {
+    edm::LogError("nodata") << "Error! can't get the product " << digiCollection_.c_str();
+  } else {
     PNDigi = pPNDigi.product();
-  } catch (std::exception& ex) {
-    std::cerr << "Error! can't get the product " << digiCollection_.c_str() << std::endl;
   }
 
   // retrieving electronics mapping
-  edm::ESHandle<EcalElectronicsMapping> ecalmapping;
-  const EcalElectronicsMapping* TheMapping = nullptr;
-  try {
-    c.get<EcalMappingRcd>().get(ecalmapping);
-    TheMapping = ecalmapping.product();
-  } catch (std::exception& ex) {
-    std::cerr << "Error! can't get the product EcalMappingRcd" << std::endl;
-  }
+  const auto& TheMapping = c.getData(mappingToken_);;
 
   // ====================================
   // Decode Basic DCCHeader Information
@@ -338,7 +318,7 @@ void EcalTestPulseAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& 
       pnG[samId] = (*pnItr).sample(samId).gainId();
 
       if (pnG[samId] != 1)
-        std::cout << "PN gain different from 1 for sample " << samId << std::endl;
+        edm::LogVerbatim("EcalTestPulseAnalyzer") << "PN gain different from 1 for sample " << samId;
       if (samId == 0)
         pngain = pnG[samId];
       if (samId > 0)
@@ -406,7 +386,7 @@ void EcalTestPulseAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& 
 
       side = MEEBGeom::side(etaG, phiG);
 
-      EcalElectronicsId elecid_crystal = TheMapping->getElectronicsId(id_crystal);
+      EcalElectronicsId elecid_crystal = TheMapping.getElectronicsId(id_crystal);
 
       towerID = elecid_crystal.towerId();
       int strip = elecid_crystal.stripId();
@@ -522,7 +502,7 @@ void EcalTestPulseAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& 
 
       // Recover the TT id and the electronic crystal numbering from EcalElectronicsMapping
 
-      EcalElectronicsId elecid_crystal = TheMapping->getElectronicsId(id_crystal);
+      EcalElectronicsId elecid_crystal = TheMapping.getElectronicsId(id_crystal);
 
       towerID = elecid_crystal.towerId();
       channelID = elecid_crystal.channelId() - 1;
@@ -652,16 +632,16 @@ void EcalTestPulseAnalyzer::endJob() {
     del << "rm " << rootfile;
     system(del.str().c_str());
 
-    std::cout << " No TP Events " << std::endl;
+    edm::LogVerbatim("EcalTestPulseAnalyzer") << " No TP Events ";
     return;
   }
 
-  std::cout << "\n\t+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+" << std::endl;
-  std::cout << "\t+=+     Analyzing test pulse data: getting APD, PN  +=+" << std::endl;
+  edm::LogVerbatim("EcalTestPulseAnalyzer") << "\n\t+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+";
+  edm::LogVerbatim("EcalTestPulseAnalyzer") << "\t+=+     Analyzing test pulse data: getting APD, PN  +=+";
 
   // Create output ntuples:
 
-  //std::cout<< "TP Test Name File "<< resfile.c_str() << std::endl;
+  //edm::LogVerbatim("EcalTestPulseAnalyzer")<< "TP Test Name File "<< resfile.c_str();
 
   resFile = new TFile(resfile.c_str(), "RECREATE");
 
@@ -810,8 +790,8 @@ void EcalTestPulseAnalyzer::endJob() {
   respntrees->Write();
   resFile->Close();
 
-  std::cout << "\t+=+    ...................................... done  +=+" << std::endl;
-  std::cout << "\t+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+" << std::endl;
+  edm::LogVerbatim("EcalTestPulseAnalyzer") << "\t+=+    ...................................... done  +=+";
+  edm::LogVerbatim("EcalTestPulseAnalyzer") << "\t+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+";
 }
 
 DEFINE_FWK_MODULE(EcalTestPulseAnalyzer);

--- a/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalTestPulseAnalyzer.h
+++ b/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalTestPulseAnalyzer.h
@@ -1,6 +1,17 @@
+#ifndef CalibCalorimetry_EcalLaserAnalyzer_EcalTestPulseAnalyzer_h
+#define CalibCalorimetry_EcalLaserAnalyzer_EcalTestPulseAnalyzer_h
 
 #include <memory>
-#include <FWCore/Framework/interface/EDAnalyzer.h>
+
+#include <vector>
+#include <map>
+
+#include <FWCore/Framework/interface/one/EDAnalyzer.h>
+
+#include <DataFormats/EcalDigi/interface/EcalDigiCollections.h>
+#include <DataFormats/EcalRawData/interface/EcalRawDataCollections.h>
+#include <Geometry/EcalMapping/interface/EcalElectronicsMapping.h>
+#include <Geometry/EcalMapping/interface/EcalMappingRcd.h>
 
 class TFile;
 class TTree;
@@ -17,22 +28,20 @@ class TTree;
 //   7     8
 //
 //
-// "EB" geometry
+
 // "EB" geometry
 #define NCRYSEB 1700  // Number of crystals per EB supermodule
-#define NTTEB 68      // Number of EB Trigger Towers
 #define NMODEB 9      // Number of EB submodules
 #define NPNPERMOD 2   // Number of PN per module
 
 // "EE" geometry
 #define NCRYSEE 830  // Number of crystals per EE supermodule
-#define NTTEE 68     // Number of EE Trigger Towers
 #define NMODEE 21    // Number of EE submodules
 
 #define NGAINPN 2   // Number of gains
 #define NGAINAPD 4  // Number of gains
 
-class EcalTestPulseAnalyzer : public edm::EDAnalyzer {
+class EcalTestPulseAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   explicit EcalTestPulseAnalyzer(const edm::ParameterSet &iConfig);
   ~EcalTestPulseAnalyzer() override;
@@ -44,30 +53,37 @@ public:
 private:
   int iEvent;
 
+  const std::string eventHeaderCollection_;
+  const std::string eventHeaderProducer_;
+  const std::string digiCollection_;
+  const std::string digiProducer_;
+  const std::string digiPNCollection_;
+
+  const edm::EDGetTokenT<EcalRawDataCollection> rawDataToken_;
+  edm::EDGetTokenT<EBDigiCollection> ebDigiToken_;
+  edm::EDGetTokenT<EEDigiCollection> eeDigiToken_;
+  const edm::EDGetTokenT<EcalPnDiodeDigiCollection> pnDiodeDigiToken_;
+  const edm::ESGetToken<EcalElectronicsMapping, EcalMappingRcd> mappingToken_;
+
   // Framework parameters
 
-  unsigned int _nsamples;
-  unsigned int _presample;
-  unsigned int _firstsample;
-  unsigned int _lastsample;
-  unsigned int _samplemin;
-  unsigned int _samplemax;
-  unsigned int _nsamplesPN;
-  unsigned int _presamplePN;
-  unsigned int _firstsamplePN;
-  unsigned int _lastsamplePN;
-  unsigned int _niter;
-  double _chi2max;
-  double _timeofmax;
-  std::string _ecalPart;
-  int _fedid;
+  const unsigned int _nsamples;
+  const unsigned int _presample;
+  const unsigned int _firstsample;
+  const unsigned int _lastsample;
+  const unsigned int _samplemin;
+  const unsigned int _samplemax;
+  const unsigned int _nsamplesPN;
+  const unsigned int _presamplePN;
+  const unsigned int _firstsamplePN;
+  const unsigned int _lastsamplePN;
+  const unsigned int _niter;
+  const double _chi2max;
+  const double _timeofmax;
+  const std::string _ecalPart;
+  const int _fedid;
 
-  std::string resdir_;
-  std::string digiCollection_;
-  std::string digiPNCollection_;
-  std::string digiProducer_;
-  std::string eventHeaderCollection_;
-  std::string eventHeaderProducer_;
+  const std::string resdir_;
 
   // Output file names
 
@@ -78,7 +94,6 @@ private:
   //  Default values correspond to "EB" geometry (1700 crystals)
 
   unsigned int nCrys;
-  unsigned int nTT;
   unsigned int nMod;
   unsigned int nGainPN;
   unsigned int nGainAPD;
@@ -148,3 +163,4 @@ private:
   unsigned int firstChanMod[NMODEB];
   unsigned int isFirstChanModFilled[NMODEB];
 };
+#endif

--- a/CalibCalorimetry/EcalPedestalOffsets/interface/EcalPedOffset.h
+++ b/CalibCalorimetry/EcalPedestalOffsets/interface/EcalPedOffset.h
@@ -1,5 +1,5 @@
-#ifndef EcalPedOffset_H
-#define EcalPedOffset_H
+#ifndef CalibCalorimetry_EcalPedestalOffsets_EcalPedOffset_H
+#define CalibCalorimetry_EcalPedestalOffsets_EcalPedOffset_H
 
 /**
  * \file EcalPedOffset.h
@@ -12,20 +12,20 @@
 #include <map>
 #include <string>
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include <DataFormats/EcalDigi/interface/EcalDigiCollections.h>
+#include <DataFormats/EcalRawData/interface/EcalRawDataCollections.h>
+#include <Geometry/EcalMapping/interface/EcalElectronicsMapping.h>
+#include <Geometry/EcalMapping/interface/EcalMappingRcd.h>
+
 #include "CalibCalorimetry/EcalPedestalOffsets/interface/TPedResult.h"
 #include "CalibCalorimetry/EcalPedestalOffsets/interface/TPedValues.h"
 
-class EBDigiCollection;
-class EEDigiCollection;
-
-class EcalElectronicsMapping;
-
-class EcalPedOffset : public edm::EDAnalyzer {
+class EcalPedOffset : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   //! Constructor
   EcalPedOffset(const edm::ParameterSet &ps);
@@ -38,6 +38,9 @@ public:
 
   //! BeginRun
   void beginRun(edm::Run const &, edm::EventSetup const &eventSetup) override;
+
+  //! EndRun
+  void endRun(edm::Run const &, edm::EventSetup const &) override;
 
   //! EndJob
   void endJob(void) override;
@@ -58,9 +61,14 @@ private:
   void readDACs(const edm::Handle<EBDigiCollection> &pDigis, const std::map<int, int> &DACvalues);
   void readDACs(const edm::Handle<EEDigiCollection> &pDigis, const std::map<int, int> &DACvalues);
 
-  edm::InputTag m_barrelDigiCollection;  //!< secondary name given to collection of digis
-  edm::InputTag m_endcapDigiCollection;  //!< secondary name given to collection of digis
-  edm::InputTag m_headerCollection;      //!< name of module/plugin/producer making headers
+  const edm::InputTag m_barrelDigiCollection;  //!< secondary name given to collection of digis
+  const edm::InputTag m_endcapDigiCollection;  //!< secondary name given to collection of digis
+  const edm::InputTag m_headerCollection;      //!< name of module/plugin/producer making headers
+
+  const edm::EDGetTokenT<EcalRawDataCollection> m_rawDataToken;
+  const edm::EDGetTokenT<EBDigiCollection> m_ebDigiToken;
+  const edm::EDGetTokenT<EEDigiCollection> m_eeDigiToken;
+  const edm::ESGetToken<EcalElectronicsMapping, EcalMappingRcd> m_mappingToken;
 
   std::string m_xmlFile;  //!< name of the xml file to be saved
 

--- a/CalibCalorimetry/EcalSRTools/interface/EcalDccWeightBuilder.h
+++ b/CalibCalorimetry/EcalSRTools/interface/EcalDccWeightBuilder.h
@@ -1,15 +1,16 @@
-/*
- */
+#ifndef CalibCalorimetry_EcalSRTools_EcalDccWeightBuilder_h
+#define CalibCalorimetry_EcalSRTools_EcalDccWeightBuilder_h
 
-#ifndef ECALDCCWEIGHTBUILDER_CC
-#define ECALDCCWEIGHTBUILDER_CC
-
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "SimCalorimetry/EcalSimAlgos/interface/EBShape.h"
 #include "SimCalorimetry/EcalSimAlgos/interface/EEShape.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
 #include "CondFormats/EcalObjects/interface/EcalIntercalibConstants.h"
+#include "CondFormats/DataRecord/interface/EcalIntercalibConstantsRcd.h"
+#include "Geometry/EcalMapping/interface/EcalElectronicsMapping.h"
+#include "Geometry/EcalMapping/interface/EcalMappingRcd.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
@@ -23,7 +24,7 @@ class EcalElectronicsMapping;
 
 /**
  */
-class EcalDccWeightBuilder : public edm::EDAnalyzer {
+class EcalDccWeightBuilder : public edm::one::EDAnalyzer<> {
 private:
   enum mode_t { WEIGHTS_FROM_CONFIG, COMPUTE_WEIGHTS };
 
@@ -121,6 +122,10 @@ private:
   std::string dbTag_;
   int dbVersion_;
   bool sqlMode_;
+
+  const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometryToken_;
+  const edm::ESGetToken<EcalElectronicsMapping, EcalMappingRcd> mappingToken_;
+  const edm::ESGetToken<EcalIntercalibConstants, EcalIntercalibConstantsRcd> intercalibConstToken_;
 
   edm::ESHandle<CaloGeometry> geom_;
 

--- a/CalibCalorimetry/EcalSRTools/interface/EcalDccWeightBuilder.h
+++ b/CalibCalorimetry/EcalSRTools/interface/EcalDccWeightBuilder.h
@@ -144,4 +144,4 @@ private:
   static const int nDccs = ecalDccFedIdMax - ecalDccFedIdMin + 1;
 };
 
-#endif  //ECALDCCWEIGHTBUILDER_CC not defined
+#endif  //CalibCalorimetry_EcalSRTools_EcalDccWeightBuilder_h not defined

--- a/CalibCalorimetry/EcalSRTools/src/EcalDccWeightBuilder.cc
+++ b/CalibCalorimetry/EcalSRTools/src/EcalDccWeightBuilder.cc
@@ -105,14 +105,7 @@ void EcalDccWeightBuilder::computeAllWeights(bool withIntercalib, const edm::Eve
 
   EcalSimParameterMap parameterMap;
   const vector<DetId>& ebDetIds = geom_->getValidDetIds(DetId::Ecal, EcalBarrel);
-
-  //   edm::LogVerbatim("EcalDccWeightBuilder") << __FILE__ << ":" << __LINE__ << ": "
-  //        <<  "Number of EB det IDs: " << ebDetIds.size() << "\n";
-
   const vector<DetId>& eeDetIds = geom_->getValidDetIds(DetId::Ecal, EcalEndcap);
-
-  //  edm::LogVerbatim("EcalDccWeightBuilder") << __FILE__ << ":" << __LINE__ << ": "
-  //        <<  "Number of EE det IDs: " << eeDetIds.size() << "\n";
 
   vector<DetId> detIds(ebDetIds.size() + eeDetIds.size());
   copy(ebDetIds.begin(), ebDetIds.end(), detIds.begin());
@@ -239,13 +232,6 @@ double EcalDccWeightBuilder::decodeWeight(int W) { return ((double)W) / weightSc
 
 template <class T>
 void EcalDccWeightBuilder::sort(const std::vector<T>& a, std::vector<int>& s, bool decreasingOrder) {
-  //   edm::LogVerbatim("EcalDccWeightBuilder") << __FILE__ << ":" << __LINE__ << ": "
-  //        << "sort input array:" ;
-  //   for(unsigned i=0; i<a.size(); ++i){
-  //     edm::LogVerbatim("EcalDccWeightBuilder") << "\t" << a[i];
-  //   }
-  //   edm::LogVerbatim("EcalDccWeightBuilder") << "\n";
-
   //performs a bubble sort: adjacent elements are successively swapped 2 by 2
   //until the list is finally sorted.
   bool changed = false;
@@ -265,13 +251,6 @@ void EcalDccWeightBuilder::sort(const std::vector<T>& a, std::vector<int>& s, bo
       }
     }
   } while (changed);
-
-  //   edm::LogVerbatim("EcalDccWeightBuilder") << __FILE__ << ":" << __LINE__ << ": "
-  //        << "sorted list of indices:" ;
-  //   for(unsigned i=0; i < s.size(); ++i){
-  //     edm::LogVerbatim("EcalDccWeightBuilder") << "\t" << s[i];
-  //   }
-  //   edm::LogVerbatim("EcalDccWeightBuilder") << "\n";
 }
 
 void EcalDccWeightBuilder::unbiasWeights(std::vector<double>& weights, std::vector<int>* encodedWeights) {
@@ -286,14 +265,6 @@ void EcalDccWeightBuilder::unbiasWeights(std::vector<double>& weights, std::vect
     dw[i] = decodeWeight(W[i]) - weights[i];
     wsum += W[i];
   }
-
-  //   edm::LogVerbatim("EcalDccWeightBuilder") << __FILE__ << ":" << __LINE__ << ": "
-  //        <<  "weights before bias correction: ";
-  //   for(unsigned i=0; i<weights.size(); ++i){
-  //     const double w = weights[i];
-  //     edm::LogVerbatim("EcalDccWeightBuilder") << "\t" << encodeWeight(w) << "(" << w << ", dw = " << dw[i] << ")";
-  //   }
-  //   edm::LogVerbatim("EcalDccWeightBuilder") << "\t sum: " << wsum << "\n";
 
   //sorts weight residuals in decreasing order:
   vector<int> iw(nw);
@@ -323,14 +294,6 @@ void EcalDccWeightBuilder::unbiasWeights(std::vector<double>& weights, std::vect
     if (i >= (int)nw)
       i = 0;
   }
-
-  //   edm::LogVerbatim("EcalDccWeightBuilder") << __FILE__ << ":" << __LINE__ << ": "
-  //        <<  "weights after bias correction: ";
-  //   for(unsigned i=0; i<weights.size(); ++i){
-  //     edm::LogVerbatim("EcalDccWeightBuilder") << "\t" << W[i] << "(" << decodeWeight(W[i]) << ", dw = "
-  // 	 << (decodeWeight(W[i])-weights[i]) << ")";
-  //   }
-  //   edm::LogVerbatim("EcalDccWeightBuilder") << "\n";
 
   //copy result
   if (encodedWeights != nullptr)
@@ -518,9 +481,6 @@ void EcalDccWeightBuilder::writeWeightToDB() {
       PasswordReader pr;
       pr.readPassword(fileName, dbUser_, dbPassword_);
     }
-
-    //     edm::LogVerbatim("EcalDccWeightBuilder") << __FILE__ << ":" << __LINE__ << ": "
-    //           <<  "Password: " << dbPassword_ << "\n";
 
     econn = new EcalCondDBInterface(dbSid_, dbUser_, dbPassword_);
     edm::LogVerbatim("EcalDccWeightBuilder") << "Done.";

--- a/CalibCalorimetry/EcalSRTools/src/EcalDccWeightBuilder.cc
+++ b/CalibCalorimetry/EcalSRTools/src/EcalDccWeightBuilder.cc
@@ -16,16 +16,10 @@
 #include <TFile.h>
 #include <TTree.h>
 
-#include "CondFormats/EcalObjects/interface/EcalIntercalibConstants.h"
-#include "CondFormats/DataRecord/interface/EcalIntercalibConstantsRcd.h"
+#include <FWCore/MessageLogger/interface/MessageLogger.h>
 #include "SimCalorimetry/EcalSimAlgos/interface/EcalSimParameterMap.h"
-#include "Geometry/Records/interface/CaloGeometryRecord.h"
-#include "Geometry/EcalMapping/interface/EcalElectronicsMapping.h"
-#include "Geometry/EcalMapping/interface/EcalMappingRcd.h"
 
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
-#include "DataFormats/EcalDetId/interface/EBDetId.h"
-#include "DataFormats/EcalDetId/interface/EEDetId.h"
 
 #ifdef DB_WRITE_SUPPORT
 #include "OnlineDB/EcalCondDB/interface/EcalCondDBInterface.h"
@@ -59,6 +53,9 @@ EcalDccWeightBuilder::EcalDccWeightBuilder(edm::ParameterSet const& ps)
       dbTag_(ps.getParameter<string>("dbTag")),
       dbVersion_(ps.getParameter<int>("dbVersion")),
       sqlMode_(ps.getParameter<bool>("sqlMode")),
+      geometryToken_(esConsumes()),
+      mappingToken_(esConsumes()),
+      intercalibConstToken_(esConsumes()),
       calibMap_(emptyCalibMap_),
       ebShape_(consumesCollector()),
       eeShape_(consumesCollector()) {
@@ -78,20 +75,17 @@ EcalDccWeightBuilder::EcalDccWeightBuilder(edm::ParameterSet const& ps)
 }
 
 void EcalDccWeightBuilder::analyze(const edm::Event& event, const edm::EventSetup& es) {
-  edm::ESHandle<EcalElectronicsMapping> handle;
-  es.get<EcalMappingRcd>().get(handle);
-  ecalElectronicsMap_ = handle.product();
+  const auto mappingHandle = es.getHandle(mappingToken_);
+  ecalElectronicsMap_ = mappingHandle.product();
 
   // Retrieval of intercalib constants
   if (dccWeightsWithIntercalib_) {
-    ESHandle<EcalIntercalibConstants> hIntercalib;
-    es.get<EcalIntercalibConstantsRcd>().get(hIntercalib);
-    const EcalIntercalibConstants* intercalib = hIntercalib.product();
-    calibMap_ = intercalib->getMap();
+    const auto& intercalibConst = es.getData(intercalibConstToken_);
+    calibMap_ = intercalibConst.getMap();
   }
 
   //gets geometry
-  es.get<CaloGeometryRecord>().get(geom_);
+  geom_ = es.getHandle(geometryToken_);
 
   //computes the weights:
   computeAllWeights(dccWeightsWithIntercalib_, es);
@@ -112,12 +106,12 @@ void EcalDccWeightBuilder::computeAllWeights(bool withIntercalib, const edm::Eve
   EcalSimParameterMap parameterMap;
   const vector<DetId>& ebDetIds = geom_->getValidDetIds(DetId::Ecal, EcalBarrel);
 
-  //   cout << __FILE__ << ":" << __LINE__ << ": "
+  //   edm::LogVerbatim("EcalDccWeightBuilder") << __FILE__ << ":" << __LINE__ << ": "
   //        <<  "Number of EB det IDs: " << ebDetIds.size() << "\n";
 
   const vector<DetId>& eeDetIds = geom_->getValidDetIds(DetId::Ecal, EcalEndcap);
 
-  //  cout << __FILE__ << ":" << __LINE__ << ": "
+  //  edm::LogVerbatim("EcalDccWeightBuilder") << __FILE__ << ":" << __LINE__ << ": "
   //        <<  "Number of EE det IDs: " << eeDetIds.size() << "\n";
 
   vector<DetId> detIds(ebDetIds.size() + eeDetIds.size());
@@ -140,12 +134,12 @@ void EcalDccWeightBuilder::computeAllWeights(bool withIntercalib, const edm::Eve
 
 #if 0
     //for debugging...
-    cout << __FILE__ << ":" << __LINE__ << ": ";
+    edm::LogVerbatim("EcalDccWeightBuilder") << __FILE__ << ":" << __LINE__ << ": ";
     if(it->subdetId()==EcalBarrel){
-      cout << "ieta = " << setw(4) << ((EBDetId)(*it)).ieta()
+      edm::LogVerbatim("EcalDccWeightBuilder") << "ieta = " << setw(4) << ((EBDetId)(*it)).ieta()
            << " iphi = " << setw(4) << ((EBDetId)(*it)).iphi() << " ";
     } else if(it->subdetId()==EcalEndcap){
-      cout << "ix = " << setw(3) << ((EEDetId)(*it)).ix()
+      edm::LogVerbatim("EcalDccWeightBuilder") << "ix = " << setw(3) << ((EEDetId)(*it)).ix()
            << " iy = " << setw(3) << ((EEDetId)(*it)).iy()
            << " iz = " << setw(1) << ((EEDetId)(*it)).iy() << " ";
     } else{
@@ -154,8 +148,8 @@ void EcalDccWeightBuilder::computeAllWeights(bool withIntercalib, const edm::Eve
         << "Got a detId which is neither tagged as ECAL Barrel "
         << "not ECAL endcap while looping on ECAL cell detIds\n";
     }
-    cout << " -> phase: "  << phase << "\n";
-    cout << " -> binOfMax: " << binOfMax << "\n";
+    edm::LogVerbatim("EcalDccWeightBuilder") << " -> phase: "  << phase << "\n";
+    edm::LogVerbatim("EcalDccWeightBuilder") << " -> binOfMax: " << binOfMax << "\n";
 #endif
 
     try {
@@ -187,17 +181,17 @@ void EcalDccWeightBuilder::computeAllWeights(bool withIntercalib, const edm::Eve
       unbiasWeights(w, &W);
       encodedWeights_[*it] = W;
     } catch (std::exception& e) {
-      cout << __FILE__ << ":" << __LINE__ << ": ";
+      edm::LogVerbatim("EcalDccWeightBuilder") << __FILE__ << ":" << __LINE__ << ": ";
       if (it->subdetId() == EcalBarrel) {
-        cout << "ieta = " << setw(4) << ((EBDetId)(*it)).ieta() << " iphi = " << setw(4) << ((EBDetId)(*it)).iphi()
+        edm::LogVerbatim("EcalDccWeightBuilder") << "ieta = " << setw(4) << ((EBDetId)(*it)).ieta() << " iphi = " << setw(4) << ((EBDetId)(*it)).iphi()
              << " ";
       } else if (it->subdetId() == EcalEndcap) {
-        cout << "ix = " << setw(3) << ((EEDetId)(*it)).ix() << " iy = " << setw(3) << ((EEDetId)(*it)).iy()
+        edm::LogVerbatim("EcalDccWeightBuilder") << "ix = " << setw(3) << ((EEDetId)(*it)).ix() << " iy = " << setw(3) << ((EEDetId)(*it)).iy()
              << " iz = " << setw(1) << ((EEDetId)(*it)).iy() << " ";
       } else {
-        cout << "DetId " << (uint32_t)(*it);
+        edm::LogVerbatim("EcalDccWeightBuilder") << "DetId " << (uint32_t)(*it);
       }
-      cout << "phase: " << phase << "\n";
+      edm::LogVerbatim("EcalDccWeightBuilder") << "phase: " << phase << "\n";
       throw;
     }
   }
@@ -244,12 +238,12 @@ double EcalDccWeightBuilder::decodeWeight(int W) { return ((double)W) / weightSc
 
 template <class T>
 void EcalDccWeightBuilder::sort(const std::vector<T>& a, std::vector<int>& s, bool decreasingOrder) {
-  //   cout << __FILE__ << ":" << __LINE__ << ": "
+  //   edm::LogVerbatim("EcalDccWeightBuilder") << __FILE__ << ":" << __LINE__ << ": "
   //        << "sort input array:" ;
   //   for(unsigned i=0; i<a.size(); ++i){
-  //     cout << "\t" << a[i];
+  //     edm::LogVerbatim("EcalDccWeightBuilder") << "\t" << a[i];
   //   }
-  //   cout << "\n";
+  //   edm::LogVerbatim("EcalDccWeightBuilder") << "\n";
 
   //performs a bubble sort: adjacent elements are successively swapped 2 by 2
   //until the list is finally sorted.
@@ -271,12 +265,12 @@ void EcalDccWeightBuilder::sort(const std::vector<T>& a, std::vector<int>& s, bo
     }
   } while (changed);
 
-  //   cout << __FILE__ << ":" << __LINE__ << ": "
+  //   edm::LogVerbatim("EcalDccWeightBuilder") << __FILE__ << ":" << __LINE__ << ": "
   //        << "sorted list of indices:" ;
   //   for(unsigned i=0; i < s.size(); ++i){
-  //     cout << "\t" << s[i];
+  //     edm::LogVerbatim("EcalDccWeightBuilder") << "\t" << s[i];
   //   }
-  //   cout << "\n";
+  //   edm::LogVerbatim("EcalDccWeightBuilder") << "\n";
 }
 
 void EcalDccWeightBuilder::unbiasWeights(std::vector<double>& weights, std::vector<int>* encodedWeights) {
@@ -292,13 +286,13 @@ void EcalDccWeightBuilder::unbiasWeights(std::vector<double>& weights, std::vect
     wsum += W[i];
   }
 
-  //   cout << __FILE__ << ":" << __LINE__ << ": "
+  //   edm::LogVerbatim("EcalDccWeightBuilder") << __FILE__ << ":" << __LINE__ << ": "
   //        <<  "weights before bias correction: ";
   //   for(unsigned i=0; i<weights.size(); ++i){
   //     const double w = weights[i];
-  //     cout << "\t" << encodeWeight(w) << "(" << w << ", dw = " << dw[i] << ")";
+  //     edm::LogVerbatim("EcalDccWeightBuilder") << "\t" << encodeWeight(w) << "(" << w << ", dw = " << dw[i] << ")";
   //   }
-  //   cout << "\t sum: " << wsum << "\n";
+  //   edm::LogVerbatim("EcalDccWeightBuilder") << "\t sum: " << wsum << "\n";
 
   //sorts weight residuals in decreasing order:
   vector<int> iw(nw);
@@ -329,13 +323,13 @@ void EcalDccWeightBuilder::unbiasWeights(std::vector<double>& weights, std::vect
       i = 0;
   }
 
-  //   cout << __FILE__ << ":" << __LINE__ << ": "
+  //   edm::LogVerbatim("EcalDccWeightBuilder") << __FILE__ << ":" << __LINE__ << ": "
   //        <<  "weights after bias correction: ";
   //   for(unsigned i=0; i<weights.size(); ++i){
-  //     cout << "\t" << W[i] << "(" << decodeWeight(W[i]) << ", dw = "
+  //     edm::LogVerbatim("EcalDccWeightBuilder") << "\t" << W[i] << "(" << decodeWeight(W[i]) << ", dw = "
   // 	 << (decodeWeight(W[i])-weights[i]) << ")";
   //   }
-  //   cout << "\n";
+  //   edm::LogVerbatim("EcalDccWeightBuilder") << "\n";
 
   //copy result
   if (encodedWeights != nullptr)
@@ -355,19 +349,19 @@ double EcalDccWeightBuilder::intercalib(const DetId& detId) {
     coef = (*itCalib);
   } else {
     coef = 1.;
-    std::cout << (uint32_t)detId << " not found in EcalIntercalibConstantMap" << std::endl;
+    edm::LogVerbatim("EcalDccWeightBuilder") << (uint32_t)detId << " not found in EcalIntercalibConstantMap";
   }
 #if 0
-  cout << __FILE__ << ":" << __LINE__ << ": ";
+  edm::LogVerbatim("EcalDccWeightBuilder") << __FILE__ << ":" << __LINE__ << ": ";
   if(detId.subdetId()==EcalBarrel){
-    cout <<  "ieta = " << ((EBDetId)detId).ieta()
+    edm::LogVerbatim("EcalDccWeightBuilder") <<  "ieta = " << ((EBDetId)detId).ieta()
 	 << " iphi = " << ((EBDetId)detId).iphi();
   } else{
-    cout << "ix = " << ((EEDetId)detId).ix()
+    edm::LogVerbatim("EcalDccWeightBuilder") << "ix = " << ((EEDetId)detId).ix()
 	 << " iy = " << ((EEDetId)detId).iy()
 	 << " iz = " << ((EEDetId)detId).zside();
   }
-  cout << " coef = " <<  coef << "\n";
+  edm::LogVerbatim("EcalDccWeightBuilder") << " coef = " <<  coef << "\n";
 #endif
   return coef;
 }
@@ -510,12 +504,12 @@ void EcalDccWeightBuilder::writeWeightToDB() {
 }
 #else   //DB_WRITE_SUPPORT defined
 void EcalDccWeightBuilder::writeWeightToDB() {
-  cout << "going to write to the online DB " << dbSid_ << " user " << dbUser_ << endl;
+  edm::LogVerbatim("EcalDccWeightBuilder") << "going to write to the online DB " << dbSid_ << " user " << dbUser_;
   ;
   EcalCondDBInterface* econn;
 
   try {
-    cout << "Making connection..." << flush;
+    edm::LogVerbatim("EcalDccWeightBuilder") << "Making connection..." << flush;
     const string& filePrefix = string("file:");
     if (dbPassword_.find(filePrefix) == 0) {  //password must be read for a file
       string fileName = dbPassword_.substr(filePrefix.size());
@@ -524,25 +518,25 @@ void EcalDccWeightBuilder::writeWeightToDB() {
       pr.readPassword(fileName, dbUser_, dbPassword_);
     }
 
-    //     cout << __FILE__ << ":" << __LINE__ << ": "
+    //     edm::LogVerbatim("EcalDccWeightBuilder") << __FILE__ << ":" << __LINE__ << ": "
     //           <<  "Password: " << dbPassword_ << "\n";
 
     econn = new EcalCondDBInterface(dbSid_, dbUser_, dbPassword_);
-    cout << "Done." << endl;
+    edm::LogVerbatim("EcalDccWeightBuilder") << "Done.";
   } catch (runtime_error& e) {
-    cerr << e.what() << endl;
+    edm::LogError("dbconnection") << e.what();
     exit(-1);
   }
 
   ODFEWeightsInfo weight_info;
   weight_info.setConfigTag(dbTag_);
   weight_info.setVersion(dbVersion_);
-  cout << "Inserting in DB..." << endl;
+  edm::LogVerbatim("EcalDccWeightBuilder") << "Inserting in DB...";
 
   econn->insertConfigSet(&weight_info);
 
   int weight_id = weight_info.getId();
-  cout << "WeightInfo inserted with ID " << weight_id << endl;
+  edm::LogVerbatim("EcalDccWeightBuilder") << "WeightInfo inserted with ID " << weight_id;
 
   vector<ODWeightsDat> datadel;
   datadel.reserve(encodedWeights_.size());
@@ -595,9 +589,9 @@ void EcalDccWeightBuilder::writeWeightToDB() {
     datadel.push_back(one_dat);
   }
   econn->insertConfigDataArraySet(datadel, &weight_info);
-  std::cout << " .. done insertion in DB " << endl;
+  edm::LogVerbatim("EcalDccWeightBuilder") << " .. done insertion in DB ";
   delete econn;
-  cout << "closed DB connection ... done" << endl;
+  edm::LogVerbatim("EcalDccWeightBuilder") << "closed DB connection ... done";
 }
 #endif  //DB_WRITE_SUPPORT not defined
 
@@ -617,22 +611,22 @@ void EcalDccWeightBuilder::dbId(const DetId& detId, int& fedId, int& smId, int& 
   xtalId = (elecId.stripId() - 1) * stripLength + elecId.xtalId();
 
 #if 0
-  cout << __FILE__ << ":" << __LINE__ << ": FED ID "
+  edm::LogVerbatim("EcalDccWeightBuilder") << __FILE__ << ":" << __LINE__ << ": FED ID "
        <<  fedId << "\n";
 
-  cout << __FILE__ << ":" << __LINE__ << ": SM logical ID "
+  edm::LogVerbatim("EcalDccWeightBuilder") << __FILE__ << ":" << __LINE__ << ": SM logical ID "
        <<  smId << "\n";
   
-  cout << __FILE__ << ":" << __LINE__ << ": RU ID (TT or SC): "
+  edm::LogVerbatim("EcalDccWeightBuilder") << __FILE__ << ":" << __LINE__ << ": RU ID (TT or SC): "
        <<  ruId << "\n";
   
-  cout << __FILE__ << ":" << __LINE__ << ": strip:"
+  edm::LogVerbatim("EcalDccWeightBuilder") << __FILE__ << ":" << __LINE__ << ": strip:"
        <<  elecId.stripId() << "\n";
   
-  cout << __FILE__ << ":" << __LINE__ << ": xtal in strip: "
+  edm::LogVerbatim("EcalDccWeightBuilder") << __FILE__ << ":" << __LINE__ << ": xtal in strip: "
        <<  elecId.xtalId() << "\n";
 
-  cout << __FILE__ << ":" << __LINE__ << ": xtalId in RU: "
+  edm::LogVerbatim("EcalDccWeightBuilder") << __FILE__ << ":" << __LINE__ << ": xtalId in RU: "
        <<  xtalId << "\n";
 #endif
 }

--- a/CalibCalorimetry/EcalSRTools/src/EcalDccWeightBuilder.cc
+++ b/CalibCalorimetry/EcalSRTools/src/EcalDccWeightBuilder.cc
@@ -183,11 +183,12 @@ void EcalDccWeightBuilder::computeAllWeights(bool withIntercalib, const edm::Eve
     } catch (std::exception& e) {
       edm::LogVerbatim("EcalDccWeightBuilder") << __FILE__ << ":" << __LINE__ << ": ";
       if (it->subdetId() == EcalBarrel) {
-        edm::LogVerbatim("EcalDccWeightBuilder") << "ieta = " << setw(4) << ((EBDetId)(*it)).ieta() << " iphi = " << setw(4) << ((EBDetId)(*it)).iphi()
-             << " ";
+        edm::LogVerbatim("EcalDccWeightBuilder") << "ieta = " << setw(4) << ((EBDetId)(*it)).ieta()
+                                                 << " iphi = " << setw(4) << ((EBDetId)(*it)).iphi() << " ";
       } else if (it->subdetId() == EcalEndcap) {
-        edm::LogVerbatim("EcalDccWeightBuilder") << "ix = " << setw(3) << ((EEDetId)(*it)).ix() << " iy = " << setw(3) << ((EEDetId)(*it)).iy()
-             << " iz = " << setw(1) << ((EEDetId)(*it)).iy() << " ";
+        edm::LogVerbatim("EcalDccWeightBuilder")
+            << "ix = " << setw(3) << ((EEDetId)(*it)).ix() << " iy = " << setw(3) << ((EEDetId)(*it)).iy()
+            << " iz = " << setw(1) << ((EEDetId)(*it)).iy() << " ";
       } else {
         edm::LogVerbatim("EcalDccWeightBuilder") << "DetId " << (uint32_t)(*it);
       }

--- a/CalibCalorimetry/EcalSRTools/test/produceDccWeights.py
+++ b/CalibCalorimetry/EcalSRTools/test/produceDccWeights.py
@@ -24,8 +24,9 @@ process.load("Geometry.HcalCommonData.hcalDDDRecConstants_cfi")
 #process.load("CalibCalorimetry.EcalTrivialCondModules.EcalTrivialCondRetriever_cfi")
 #process.EcalTrivialConditionRetriever.producedEcalIntercalibConstants = True
 # b) Getting conditions through frontier interface:
-process.load('Configuration/StandardSequences/FrontierConditions_GlobalTag_cff')
-process.GlobalTag.globaltag = "113X_dataRun3_HLT_v3"
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_data', '')
 # c) Getting conditions through oracle interface:
 #process.load("RecoLocalCalo.EcalRecProducers.getEcalConditions_orcoffint2r_cff")
 

--- a/CalibCalorimetry/EcalSRTools/test/produceDccWeights.py
+++ b/CalibCalorimetry/EcalSRTools/test/produceDccWeights.py
@@ -15,6 +15,9 @@ process.eegeom = cms.ESSource("EmptyESSource",
     firstValid = cms.vuint32(1)
 )
 
+process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cff")
+process.load("Geometry.HcalCommonData.hcalDDDRecConstants_cfi")
+
 # Conditions:
 #
 # a) Getting hardcoded conditions the same used for standard digitization:
@@ -22,7 +25,7 @@ process.eegeom = cms.ESSource("EmptyESSource",
 #process.EcalTrivialConditionRetriever.producedEcalIntercalibConstants = True
 # b) Getting conditions through frontier interface:
 process.load('Configuration/StandardSequences/FrontierConditions_GlobalTag_cff')
-process.GlobalTag.globaltag = "CRAFT09_R_V4::All"
+process.GlobalTag.globaltag = "113X_dataRun3_HLT_v3"
 # c) Getting conditions through oracle interface:
 #process.load("RecoLocalCalo.EcalRecProducers.getEcalConditions_orcoffint2r_cff")
 

--- a/CalibCalorimetry/EcalTPGTools/plugins/EcalTPGDBCopy.cc
+++ b/CalibCalorimetry/EcalTPGTools/plugins/EcalTPGDBCopy.cc
@@ -1,50 +1,10 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 
+#include <FWCore/MessageLogger/interface/MessageLogger.h>
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-
-#include "CondFormats/EcalObjects/interface/EcalTPGPedestals.h"
-#include "CondFormats/EcalObjects/interface/EcalTPGLinearizationConst.h"
-#include "CondFormats/EcalObjects/interface/EcalTPGSlidingWindow.h"
-#include "CondFormats/EcalObjects/interface/EcalTPGFineGrainEBIdMap.h"
-#include "CondFormats/EcalObjects/interface/EcalTPGFineGrainStripEE.h"
-#include "CondFormats/EcalObjects/interface/EcalTPGFineGrainTowerEE.h"
-#include "CondFormats/EcalObjects/interface/EcalTPGLutIdMap.h"
-#include "CondFormats/EcalObjects/interface/EcalTPGWeightIdMap.h"
-#include "CondFormats/EcalObjects/interface/EcalTPGWeightGroup.h"
-#include "CondFormats/EcalObjects/interface/EcalTPGOddWeightIdMap.h"
-#include "CondFormats/EcalObjects/interface/EcalTPGOddWeightGroup.h"
-#include "CondFormats/EcalObjects/interface/EcalTPGTPMode.h"
-#include "CondFormats/EcalObjects/interface/EcalTPGLutGroup.h"
-#include "CondFormats/EcalObjects/interface/EcalTPGFineGrainEBGroup.h"
-#include "CondFormats/EcalObjects/interface/EcalTPGPhysicsConst.h"
-#include "CondFormats/EcalObjects/interface/EcalTPGCrystalStatus.h"
-#include "CondFormats/EcalObjects/interface/EcalTPGSpike.h"
-#include "CondFormats/EcalObjects/interface/EcalTPGTowerStatus.h"
-#include "CondFormats/EcalObjects/interface/EcalTPGStripStatus.h"
-
-#include "CondFormats/DataRecord/interface/EcalTPGPedestalsRcd.h"
-#include "CondFormats/DataRecord/interface/EcalTPGLinearizationConstRcd.h"
-#include "CondFormats/DataRecord/interface/EcalTPGSlidingWindowRcd.h"
-#include "CondFormats/DataRecord/interface/EcalTPGFineGrainEBIdMapRcd.h"
-#include "CondFormats/DataRecord/interface/EcalTPGFineGrainStripEERcd.h"
-#include "CondFormats/DataRecord/interface/EcalTPGFineGrainTowerEERcd.h"
-#include "CondFormats/DataRecord/interface/EcalTPGLutIdMapRcd.h"
-#include "CondFormats/DataRecord/interface/EcalTPGWeightIdMapRcd.h"
-#include "CondFormats/DataRecord/interface/EcalTPGWeightGroupRcd.h"
-#include "CondFormats/DataRecord/interface/EcalTPGOddWeightIdMapRcd.h"
-#include "CondFormats/DataRecord/interface/EcalTPGOddWeightGroupRcd.h"
-#include "CondFormats/DataRecord/interface/EcalTPGTPModeRcd.h"
-#include "CondFormats/DataRecord/interface/EcalTPGLutGroupRcd.h"
-#include "CondFormats/DataRecord/interface/EcalTPGFineGrainEBGroupRcd.h"
-#include "CondFormats/DataRecord/interface/EcalTPGPhysicsConstRcd.h"
-#include "CondFormats/DataRecord/interface/EcalTPGCrystalStatusRcd.h"
-#include "CondFormats/DataRecord/interface/EcalTPGTowerStatusRcd.h"
-#include "CondFormats/DataRecord/interface/EcalTPGSpikeRcd.h"
-#include "CondFormats/DataRecord/interface/EcalTPGStripStatusRcd.h"
 
 #include "EcalTPGDBCopy.h"
 
@@ -52,6 +12,7 @@
 
 EcalTPGDBCopy::EcalTPGDBCopy(const edm::ParameterSet& iConfig)
     : m_timetype(iConfig.getParameter<std::string>("timetype")), m_cacheIDs(), m_records() {
+  auto cc = consumesCollector();
   std::string container;
   std::string tag;
   std::string record;
@@ -62,6 +23,7 @@ EcalTPGDBCopy::EcalTPGDBCopy(const edm::ParameterSet& iConfig)
     record = i->getParameter<std::string>("record");
     m_cacheIDs.insert(std::make_pair(container, 0));
     m_records.insert(std::make_pair(container, record));
+    setConsumes(cc, container);
   }
 }
 
@@ -80,7 +42,51 @@ void EcalTPGDBCopy::analyze(const edm::Event& evt, const edm::EventSetup& evtSet
   }
 }
 
-bool EcalTPGDBCopy::shouldCopy(const edm::EventSetup& evtSetup, std::string container) {
+void EcalTPGDBCopy::setConsumes(edm::ConsumesCollector& cc, const std::string& container) {
+  if (container == "EcalTPGPedestals") {
+    pedestalsToken_ = cc.esConsumes();
+  } else if (container == "EcalTPGLinearizationConst") {
+    linearizationConstToken_ = cc.esConsumes();
+  } else if (container == "EcalTPGSlidingWindow") {
+    slidingWindowToken_ = cc.esConsumes();
+  } else if (container == "EcalTPGFineGrainEBIdMap") {
+    fineGrainEBIdMapToken_ = cc.esConsumes();
+  } else if (container == "EcalTPGFineGrainStripEE") {
+    fineGrainStripEEToken_ = cc.esConsumes();
+  } else if (container == "EcalTPGFineGrainTowerEE") {
+    fineGrainTowerEEToken_ = cc.esConsumes();
+  } else if (container == "EcalTPGLutIdMap") {
+    lutIdMapToken_ = cc.esConsumes();
+  } else if (container == "EcalTPGWeightIdMap") {
+    weightIdMapToken_ = cc.esConsumes();
+  } else if (container == "EcalTPGWeightGroup") {
+    weightGroupToken_ = cc.esConsumes();
+  } else if (container == "EcalTPGOddWeightIdMap") {
+    oddWeightIdMapToken_ = cc.esConsumes();
+  } else if (container == "EcalTPGOddWeightGroup") {
+    oddWeightGroupToken_ = cc.esConsumes();
+  } else if (container == "EcalTPGTPMode") {
+    tpModeToken_ = cc.esConsumes();
+  } else if (container == "EcalTPGLutGroup") {
+    lutGroupToken_ = cc.esConsumes();
+  } else if (container == "EcalTPGFineGrainEBGroup") {
+    fineGrainEBGroupToken_ = cc.esConsumes();
+  } else if (container == "EcalTPGPhysicsConst") {
+    physicsConstToken_ = cc.esConsumes();
+  } else if (container == "EcalTPGCrystalStatus") {
+    crystalStatusToken_ = cc.esConsumes();
+  } else if (container == "EcalTPGTowerStatus") {
+    towerStatusToken_ = cc.esConsumes();
+  } else if (container == "EcalTPGSpike") {
+    spikeToken_ = cc.esConsumes();
+  } else if (container == "EcalTPGStripStatus") {
+    stripStatusToken_ = cc.esConsumes();
+  } else {
+    throw cms::Exception("Unknown container");
+  }
+}
+
+bool EcalTPGDBCopy::shouldCopy(const edm::EventSetup& evtSetup, const std::string& container) {
   unsigned long long cacheID = 0;
 
   if (container == "EcalTPGPedestals") {
@@ -133,7 +139,7 @@ bool EcalTPGDBCopy::shouldCopy(const edm::EventSetup& evtSetup, std::string cont
   }
 }
 
-void EcalTPGDBCopy::copyToDB(const edm::EventSetup& evtSetup, std::string container) {
+void EcalTPGDBCopy::copyToDB(const edm::EventSetup& evtSetup, const std::string& container) {
   edm::Service<cond::service::PoolDBOutputService> dbOutput;
   if (!dbOutput.isAvailable()) {
     throw cms::Exception("PoolDBOutputService is not available");
@@ -142,148 +148,123 @@ void EcalTPGDBCopy::copyToDB(const edm::EventSetup& evtSetup, std::string contai
   std::string recordName = m_records[container];
 
   if (container == "EcalTPGPedestals") {
-    edm::ESHandle<EcalTPGPedestals> handle;
-    evtSetup.get<EcalTPGPedestalsRcd>().get(handle);
+    const auto handle = evtSetup.getHandle(pedestalsToken_);
     const EcalTPGPedestals* obj = handle.product();
     dbOutput->createNewIOV<const EcalTPGPedestals>(
         new EcalTPGPedestals(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalTPGLinearizationConst") {
-    edm::ESHandle<EcalTPGLinearizationConst> handle;
-    evtSetup.get<EcalTPGLinearizationConstRcd>().get(handle);
+    const auto handle = evtSetup.getHandle(linearizationConstToken_);
     const EcalTPGLinearizationConst* obj = handle.product();
-
     dbOutput->createNewIOV<const EcalTPGLinearizationConst>(
         new EcalTPGLinearizationConst(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalTPGSlidingWindow") {
-    edm::ESHandle<EcalTPGSlidingWindow> handle;
-    evtSetup.get<EcalTPGSlidingWindowRcd>().get(handle);
+    const auto handle = evtSetup.getHandle(slidingWindowToken_);
     const EcalTPGSlidingWindow* obj = handle.product();
-
     dbOutput->createNewIOV<const EcalTPGSlidingWindow>(
         new EcalTPGSlidingWindow(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalTPGFineGrainEBIdMap") {
-    edm::ESHandle<EcalTPGFineGrainEBIdMap> handle;
-    evtSetup.get<EcalTPGFineGrainEBIdMapRcd>().get(handle);
+    const auto handle = evtSetup.getHandle(fineGrainEBIdMapToken_);
     const EcalTPGFineGrainEBIdMap* obj = handle.product();
     dbOutput->createNewIOV<const EcalTPGFineGrainEBIdMap>(
         new EcalTPGFineGrainEBIdMap(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalTPGFineGrainStripEE") {
-    edm::ESHandle<EcalTPGFineGrainStripEE> handle;
-    evtSetup.get<EcalTPGFineGrainStripEERcd>().get(handle);
+    const auto handle = evtSetup.getHandle(fineGrainStripEEToken_);
     const EcalTPGFineGrainStripEE* obj = handle.product();
     dbOutput->createNewIOV<const EcalTPGFineGrainStripEE>(
         new EcalTPGFineGrainStripEE(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalTPGFineGrainTowerEE") {
-    edm::ESHandle<EcalTPGFineGrainTowerEE> handle;
-    evtSetup.get<EcalTPGFineGrainTowerEERcd>().get(handle);
+    const auto handle = evtSetup.getHandle(fineGrainTowerEEToken_);
     const EcalTPGFineGrainTowerEE* obj = handle.product();
     dbOutput->createNewIOV<const EcalTPGFineGrainTowerEE>(
         new EcalTPGFineGrainTowerEE(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalTPGLutIdMap") {
-    edm::ESHandle<EcalTPGLutIdMap> handle;
-    evtSetup.get<EcalTPGLutIdMapRcd>().get(handle);
+    const auto handle = evtSetup.getHandle(lutIdMapToken_);
     const EcalTPGLutIdMap* obj = handle.product();
     dbOutput->createNewIOV<const EcalTPGLutIdMap>(
         new EcalTPGLutIdMap(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalTPGWeightIdMap") {
-    edm::ESHandle<EcalTPGWeightIdMap> handle;
-    evtSetup.get<EcalTPGWeightIdMapRcd>().get(handle);
+    const auto handle = evtSetup.getHandle(weightIdMapToken_);
     const EcalTPGWeightIdMap* obj = handle.product();
     dbOutput->createNewIOV<const EcalTPGWeightIdMap>(
         new EcalTPGWeightIdMap(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalTPGWeightGroup") {
-    edm::ESHandle<EcalTPGWeightGroup> handle;
-    evtSetup.get<EcalTPGWeightGroupRcd>().get(handle);
+    const auto handle = evtSetup.getHandle(weightGroupToken_);
     const EcalTPGWeightGroup* obj = handle.product();
     dbOutput->createNewIOV<const EcalTPGWeightGroup>(
         new EcalTPGWeightGroup(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalTPGOddWeightIdMap") {
-    edm::ESHandle<EcalTPGOddWeightIdMap> handle;
-    evtSetup.get<EcalTPGOddWeightIdMapRcd>().get(handle);
+    const auto handle = evtSetup.getHandle(oddWeightIdMapToken_);
     const EcalTPGOddWeightIdMap* obj = handle.product();
     dbOutput->createNewIOV<const EcalTPGOddWeightIdMap>(
         new EcalTPGOddWeightIdMap(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalTPGOddWeightGroup") {
-    edm::ESHandle<EcalTPGOddWeightGroup> handle;
-    evtSetup.get<EcalTPGOddWeightGroupRcd>().get(handle);
+    const auto handle = evtSetup.getHandle(oddWeightGroupToken_);
     const EcalTPGOddWeightGroup* obj = handle.product();
     dbOutput->createNewIOV<const EcalTPGOddWeightGroup>(
         new EcalTPGOddWeightGroup(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalTPGTPMode") {
-    edm::ESHandle<EcalTPGTPMode> handle;
-    evtSetup.get<EcalTPGTPModeRcd>().get(handle);
+    const auto handle = evtSetup.getHandle(tpModeToken_);
     const EcalTPGTPMode* obj = handle.product();
     dbOutput->createNewIOV<const EcalTPGTPMode>(
         new EcalTPGTPMode(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalTPGLutGroup") {
-    edm::ESHandle<EcalTPGLutGroup> handle;
-    evtSetup.get<EcalTPGLutGroupRcd>().get(handle);
+    const auto handle = evtSetup.getHandle(lutGroupToken_);
     const EcalTPGLutGroup* obj = handle.product();
     dbOutput->createNewIOV<const EcalTPGLutGroup>(
         new EcalTPGLutGroup(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalTPGFineGrainEBGroup") {
-    edm::ESHandle<EcalTPGFineGrainEBGroup> handle;
-    evtSetup.get<EcalTPGFineGrainEBGroupRcd>().get(handle);
-
+    const auto handle = evtSetup.getHandle(fineGrainEBGroupToken_);
     const EcalTPGFineGrainEBGroup* obj = handle.product();
-
     dbOutput->createNewIOV<const EcalTPGFineGrainEBGroup>(
         new EcalTPGFineGrainEBGroup(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalTPGPhysicsConst") {
-    edm::ESHandle<EcalTPGPhysicsConst> handle;
-    evtSetup.get<EcalTPGPhysicsConstRcd>().get(handle);
+    const auto handle = evtSetup.getHandle(physicsConstToken_);
     const EcalTPGPhysicsConst* obj = handle.product();
     dbOutput->createNewIOV<const EcalTPGPhysicsConst>(
         new EcalTPGPhysicsConst(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalTPGCrystalStatus") {
-    edm::ESHandle<EcalTPGCrystalStatus> handle;
-    evtSetup.get<EcalTPGCrystalStatusRcd>().get(handle);
+    const auto handle = evtSetup.getHandle(crystalStatusToken_);
     const EcalTPGCrystalStatus* obj = handle.product();
     dbOutput->createNewIOV<const EcalTPGCrystalStatus>(
         new EcalTPGCrystalStatus(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalTPGTowerStatus") {
-    edm::ESHandle<EcalTPGTowerStatus> handle;
-    evtSetup.get<EcalTPGTowerStatusRcd>().get(handle);
+    const auto handle = evtSetup.getHandle(towerStatusToken_);
     const EcalTPGTowerStatus* obj = handle.product();
     dbOutput->createNewIOV<const EcalTPGTowerStatus>(
         new EcalTPGTowerStatus(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalTPGSpike") {
-    edm::ESHandle<EcalTPGSpike> handle;
-    evtSetup.get<EcalTPGSpikeRcd>().get(handle);
+    const auto handle = evtSetup.getHandle(spikeToken_);
     const EcalTPGSpike* obj = handle.product();
 
     dbOutput->createNewIOV<const EcalTPGSpike>(
         new EcalTPGSpike(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalTPGStripStatus") {
-    edm::ESHandle<EcalTPGStripStatus> handle;
-    evtSetup.get<EcalTPGStripStatusRcd>().get(handle);
+    const auto handle = evtSetup.getHandle(stripStatusToken_);
     const EcalTPGStripStatus* obj = handle.product();
     dbOutput->createNewIOV<const EcalTPGStripStatus>(
         new EcalTPGStripStatus(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
-  }
-
-  else {
+  } else {
     throw cms::Exception("Unknown container");
   }
 
-  std::cout << "EcalTPGDBCopy wrote " << recordName << std::endl;
+  edm::LogInfo("EcalTPGDBCopy") << "EcalTPGDBCopy wrote " << recordName;
 }

--- a/CalibCalorimetry/EcalTPGTools/plugins/EcalTPGDBCopy.h
+++ b/CalibCalorimetry/EcalTPGTools/plugins/EcalTPGDBCopy.h
@@ -1,10 +1,51 @@
-#ifndef ECALTPGDBCOPY_H
-#define ECALTPGDBCOPY_H
+#ifndef CalibCalorimetry_EcalTPGTools_EcalTPGDBCopy_h
+#define CalibCalorimetry_EcalTPGTools_EcalTPGDBCopy_h
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "CondCore/CondDB/interface/Exception.h"
 
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/IOVSyncValue.h"
+
+#include "CondFormats/EcalObjects/interface/EcalTPGPedestals.h"
+#include "CondFormats/EcalObjects/interface/EcalTPGLinearizationConst.h"
+#include "CondFormats/EcalObjects/interface/EcalTPGSlidingWindow.h"
+#include "CondFormats/EcalObjects/interface/EcalTPGFineGrainEBIdMap.h"
+#include "CondFormats/EcalObjects/interface/EcalTPGFineGrainStripEE.h"
+#include "CondFormats/EcalObjects/interface/EcalTPGFineGrainTowerEE.h"
+#include "CondFormats/EcalObjects/interface/EcalTPGLutIdMap.h"
+#include "CondFormats/EcalObjects/interface/EcalTPGWeightIdMap.h"
+#include "CondFormats/EcalObjects/interface/EcalTPGWeightGroup.h"
+#include "CondFormats/EcalObjects/interface/EcalTPGOddWeightIdMap.h"
+#include "CondFormats/EcalObjects/interface/EcalTPGOddWeightGroup.h"
+#include "CondFormats/EcalObjects/interface/EcalTPGTPMode.h"
+#include "CondFormats/EcalObjects/interface/EcalTPGLutGroup.h"
+#include "CondFormats/EcalObjects/interface/EcalTPGFineGrainEBGroup.h"
+#include "CondFormats/EcalObjects/interface/EcalTPGPhysicsConst.h"
+#include "CondFormats/EcalObjects/interface/EcalTPGCrystalStatus.h"
+#include "CondFormats/EcalObjects/interface/EcalTPGSpike.h"
+#include "CondFormats/EcalObjects/interface/EcalTPGTowerStatus.h"
+#include "CondFormats/EcalObjects/interface/EcalTPGStripStatus.h"
+
+#include "CondFormats/DataRecord/interface/EcalTPGPedestalsRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTPGLinearizationConstRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTPGSlidingWindowRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTPGFineGrainEBIdMapRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTPGFineGrainStripEERcd.h"
+#include "CondFormats/DataRecord/interface/EcalTPGFineGrainTowerEERcd.h"
+#include "CondFormats/DataRecord/interface/EcalTPGLutIdMapRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTPGWeightIdMapRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTPGWeightGroupRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTPGOddWeightIdMapRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTPGOddWeightGroupRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTPGTPModeRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTPGLutGroupRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTPGFineGrainEBGroupRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTPGPhysicsConstRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTPGCrystalStatusRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTPGTowerStatusRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTPGSpikeRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTPGStripStatusRcd.h"
 
 #include <string>
 #include <map>
@@ -15,7 +56,7 @@ namespace edm {
   class EventSetup;
 }  // namespace edm
 
-class EcalTPGDBCopy : public edm::EDAnalyzer {
+class EcalTPGDBCopy : public edm::one::EDAnalyzer<> {
 public:
   explicit EcalTPGDBCopy(const edm::ParameterSet& iConfig);
   ~EcalTPGDBCopy() override;
@@ -23,12 +64,33 @@ public:
   void analyze(const edm::Event& evt, const edm::EventSetup& evtSetup) override;
 
 private:
-  bool shouldCopy(const edm::EventSetup& evtSetup, std::string container);
-  void copyToDB(const edm::EventSetup& evtSetup, std::string container);
+  void setConsumes(edm::ConsumesCollector& cc, const std::string& container);
+  bool shouldCopy(const edm::EventSetup& evtSetup, const std::string& container);
+  void copyToDB(const edm::EventSetup& evtSetup, const std::string& container);
 
   std::string m_timetype;
   std::map<std::string, unsigned long long> m_cacheIDs;
   std::map<std::string, std::string> m_records;
+
+  edm::ESGetToken<EcalTPGPedestals, EcalTPGPedestalsRcd> pedestalsToken_;
+  edm::ESGetToken<EcalTPGLinearizationConst, EcalTPGLinearizationConstRcd> linearizationConstToken_;
+  edm::ESGetToken<EcalTPGSlidingWindow, EcalTPGSlidingWindowRcd> slidingWindowToken_;
+  edm::ESGetToken<EcalTPGFineGrainEBIdMap, EcalTPGFineGrainEBIdMapRcd> fineGrainEBIdMapToken_;
+  edm::ESGetToken<EcalTPGFineGrainStripEE, EcalTPGFineGrainStripEERcd> fineGrainStripEEToken_;
+  edm::ESGetToken<EcalTPGFineGrainTowerEE, EcalTPGFineGrainTowerEERcd> fineGrainTowerEEToken_;
+  edm::ESGetToken<EcalTPGLutIdMap, EcalTPGLutIdMapRcd> lutIdMapToken_;
+  edm::ESGetToken<EcalTPGWeightIdMap, EcalTPGWeightIdMapRcd> weightIdMapToken_;
+  edm::ESGetToken<EcalTPGWeightGroup, EcalTPGWeightGroupRcd> weightGroupToken_;
+  edm::ESGetToken<EcalTPGOddWeightIdMap, EcalTPGOddWeightIdMapRcd> oddWeightIdMapToken_;
+  edm::ESGetToken<EcalTPGOddWeightGroup, EcalTPGOddWeightGroupRcd> oddWeightGroupToken_;
+  edm::ESGetToken<EcalTPGTPMode, EcalTPGTPModeRcd> tpModeToken_;
+  edm::ESGetToken<EcalTPGLutGroup, EcalTPGLutGroupRcd> lutGroupToken_;
+  edm::ESGetToken<EcalTPGFineGrainEBGroup, EcalTPGFineGrainEBGroupRcd> fineGrainEBGroupToken_;
+  edm::ESGetToken<EcalTPGPhysicsConst, EcalTPGPhysicsConstRcd> physicsConstToken_;
+  edm::ESGetToken<EcalTPGCrystalStatus, EcalTPGCrystalStatusRcd> crystalStatusToken_;
+  edm::ESGetToken<EcalTPGTowerStatus, EcalTPGTowerStatusRcd> towerStatusToken_;
+  edm::ESGetToken<EcalTPGSpike, EcalTPGSpikeRcd> spikeToken_;
+  edm::ESGetToken<EcalTPGStripStatus, EcalTPGStripStatusRcd> stripStatusToken_;
 };
 
 #endif

--- a/CalibCalorimetry/EcalTrivialCondModules/interface/EcalLaserCondTools.h
+++ b/CalibCalorimetry/EcalTrivialCondModules/interface/EcalLaserCondTools.h
@@ -1,16 +1,17 @@
-#ifndef EcaLaserCondTools_h
-#define EcaLaserCondTools_h
+#ifndef CalibCalorimetry_EcalTrivialCondModules_EcaLaserCondTools_h
+#define CalibCalorimetry_EcalTrivialCondModules_EcaLaserCondTools_h
 
 /*
  * $Id: EcalLaserCondTools.h,v 1.2 2010/06/14 10:45:16 pgras Exp $
  */
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 #include "CondFormats/EcalObjects/interface/EcalLaserAPDPNRatios.h"
+#include "CondFormats/DataRecord/interface/EcalLaserAPDPNRatiosRcd.h"
 
 #include "DataFormats/DetId/interface/DetId.h"
 
@@ -20,7 +21,7 @@
 #include <vector>
 /**
  */
-class EcalLaserCondTools : public edm::EDAnalyzer {
+class EcalLaserCondTools : public edm::one::EDAnalyzer<> {
   //static fields
 
   /** Number of extended laser monitoring regions
@@ -83,6 +84,7 @@ private:
 
   //fields
 private:
+  edm::ESGetToken<EcalLaserAPDPNRatios, EcalLaserAPDPNRatiosRcd> laserAPDPNRatiosToken_;
   FILE* fout_;
   FILE* eventList_;
   std::string eventListFileName_;

--- a/CalibCalorimetry/EcalTrivialCondModules/interface/EcalTrivialObjectAnalyzer.h
+++ b/CalibCalorimetry/EcalTrivialCondModules/interface/EcalTrivialObjectAnalyzer.h
@@ -82,11 +82,16 @@ private:
   const edm::ESGetToken<EcalTimeCalibErrors, EcalTimeCalibErrorsRcd> timeCalibErrorsToken_;
   const edm::ESGetToken<EcalTimeOffsetConstant, EcalTimeOffsetConstantRcd> timeOffsetConstantToken_;
   const edm::ESGetToken<EcalTBWeights, EcalTBWeightsRcd> tbWeightsToken_;
-  const edm::ESGetToken<EcalClusterLocalContCorrParameters, EcalClusterLocalContCorrParametersRcd> clusterLocalContCorrToken_;
+  const edm::ESGetToken<EcalClusterLocalContCorrParameters, EcalClusterLocalContCorrParametersRcd>
+      clusterLocalContCorrToken_;
   const edm::ESGetToken<EcalClusterCrackCorrParameters, EcalClusterCrackCorrParametersRcd> clusterCrackCorrToken_;
-  const edm::ESGetToken<EcalClusterEnergyCorrectionParameters, EcalClusterEnergyCorrectionParametersRcd> clusterEnergyCorrectionToken_;
-  const edm::ESGetToken<EcalClusterEnergyUncertaintyParameters, EcalClusterEnergyUncertaintyParametersRcd> clusterEnergyUncertaintyToken_;
-  const edm::ESGetToken<EcalClusterEnergyCorrectionObjectSpecificParameters, EcalClusterEnergyCorrectionObjectSpecificParametersRcd> clusterEnergyCorrectionObjectSpecificToken_;
+  const edm::ESGetToken<EcalClusterEnergyCorrectionParameters, EcalClusterEnergyCorrectionParametersRcd>
+      clusterEnergyCorrectionToken_;
+  const edm::ESGetToken<EcalClusterEnergyUncertaintyParameters, EcalClusterEnergyUncertaintyParametersRcd>
+      clusterEnergyUncertaintyToken_;
+  const edm::ESGetToken<EcalClusterEnergyCorrectionObjectSpecificParameters,
+                        EcalClusterEnergyCorrectionObjectSpecificParametersRcd>
+      clusterEnergyCorrectionObjectSpecificToken_;
   const edm::ESGetToken<EcalLaserAlphas, EcalLaserAlphasRcd> laserAlphasToken_;
   const edm::ESGetToken<EcalLaserAPDPNRatiosRef, EcalLaserAPDPNRatiosRefRcd> laserAPDPNRatiosRefToken_;
   const edm::ESGetToken<EcalLaserAPDPNRatios, EcalLaserAPDPNRatiosRcd> laserAPDPNRatiosToken_;

--- a/CalibCalorimetry/EcalTrivialCondModules/interface/EcalTrivialObjectAnalyzer.h
+++ b/CalibCalorimetry/EcalTrivialCondModules/interface/EcalTrivialObjectAnalyzer.h
@@ -1,18 +1,96 @@
+#ifndef CalibCalorimetry_EcalTrivialCondModules_EcalTrivialObjectAnalyzer_h
+#define CalibCalorimetry_EcalTrivialCondModules_EcalTrivialObjectAnalyzer_h
 //
 // Created: 2 Mar 2006
 //          Shahram Rahatlou, University of Rome & INFN
 //
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
-class EcalTrivialObjectAnalyzer : public edm::EDAnalyzer {
+#include "CondFormats/EcalObjects/interface/EcalPedestals.h"
+#include "CondFormats/DataRecord/interface/EcalPedestalsRcd.h"
+
+#include "CondFormats/EcalObjects/interface/EcalWeightXtalGroups.h"
+#include "CondFormats/DataRecord/interface/EcalWeightXtalGroupsRcd.h"
+
+#include "CondFormats/EcalObjects/interface/EcalTBWeights.h"
+#include "CondFormats/DataRecord/interface/EcalTBWeightsRcd.h"
+
+#include "CondFormats/EcalObjects/interface/EcalIntercalibConstants.h"
+#include "CondFormats/DataRecord/interface/EcalIntercalibConstantsRcd.h"
+
+#include "CondFormats/EcalObjects/interface/EcalIntercalibErrors.h"
+#include "CondFormats/DataRecord/interface/EcalIntercalibErrorsRcd.h"
+
+#include "CondFormats/EcalObjects/interface/EcalTimeCalibConstants.h"
+#include "CondFormats/DataRecord/interface/EcalTimeCalibConstantsRcd.h"
+
+#include "CondFormats/EcalObjects/interface/EcalTimeCalibErrors.h"
+#include "CondFormats/DataRecord/interface/EcalTimeCalibErrorsRcd.h"
+
+#include "CondFormats/EcalObjects/interface/EcalTimeOffsetConstant.h"
+#include "CondFormats/DataRecord/interface/EcalTimeOffsetConstantRcd.h"
+
+#include "CondFormats/EcalObjects/interface/EcalGainRatios.h"
+#include "CondFormats/DataRecord/interface/EcalGainRatiosRcd.h"
+
+#include "CondFormats/EcalObjects/interface/EcalADCToGeVConstant.h"
+#include "CondFormats/DataRecord/interface/EcalADCToGeVConstantRcd.h"
+
+#include "CondFormats/EcalObjects/interface/EcalLaserAlphas.h"
+#include "CondFormats/DataRecord/interface/EcalLaserAlphasRcd.h"
+
+#include "CondFormats/EcalObjects/interface/EcalLaserAPDPNRatiosRef.h"
+#include "CondFormats/DataRecord/interface/EcalLaserAPDPNRatiosRefRcd.h"
+
+#include "CondFormats/EcalObjects/interface/EcalLaserAPDPNRatios.h"
+#include "CondFormats/DataRecord/interface/EcalLaserAPDPNRatiosRcd.h"
+
+#include "CondFormats/EcalObjects/interface/EcalClusterLocalContCorrParameters.h"
+#include "CondFormats/DataRecord/interface/EcalClusterLocalContCorrParametersRcd.h"
+#include "CondFormats/EcalObjects/interface/EcalClusterCrackCorrParameters.h"
+#include "CondFormats/DataRecord/interface/EcalClusterCrackCorrParametersRcd.h"
+#include "CondFormats/EcalObjects/interface/EcalClusterEnergyCorrectionParameters.h"
+#include "CondFormats/DataRecord/interface/EcalClusterEnergyCorrectionParametersRcd.h"
+#include "CondFormats/EcalObjects/interface/EcalClusterEnergyUncertaintyParameters.h"
+#include "CondFormats/DataRecord/interface/EcalClusterEnergyUncertaintyParametersRcd.h"
+#include "CondFormats/EcalObjects/interface/EcalClusterEnergyCorrectionObjectSpecificParameters.h"
+#include "CondFormats/DataRecord/interface/EcalClusterEnergyCorrectionObjectSpecificParametersRcd.h"
+
+#include "CondFormats/EcalObjects/interface/EcalChannelStatus.h"
+#include "CondFormats/DataRecord/interface/EcalChannelStatusRcd.h"
+
+#include "CondFormats/EcalObjects/interface/EcalSampleMask.h"
+#include "CondFormats/DataRecord/interface/EcalSampleMaskRcd.h"
+
+class EcalTrivialObjectAnalyzer : public edm::one::EDAnalyzer<> {
 public:
-  explicit EcalTrivialObjectAnalyzer(edm::ParameterSet const& p) {}
-  explicit EcalTrivialObjectAnalyzer(int i) {}
+  explicit EcalTrivialObjectAnalyzer(edm::ParameterSet const& p);
   ~EcalTrivialObjectAnalyzer() override {}
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
 private:
+  const edm::ESGetToken<EcalPedestals, EcalPedestalsRcd> pedestalsToken_;
+  const edm::ESGetToken<EcalADCToGeVConstant, EcalADCToGeVConstantRcd> adcToGevConstantToken_;
+  const edm::ESGetToken<EcalWeightXtalGroups, EcalWeightXtalGroupsRcd> weightXtalGroupsToken_;
+  const edm::ESGetToken<EcalGainRatios, EcalGainRatiosRcd> gainRatiosToken_;
+  const edm::ESGetToken<EcalIntercalibConstants, EcalIntercalibConstantsRcd> intercalibConstantsToken_;
+  const edm::ESGetToken<EcalIntercalibErrors, EcalIntercalibErrorsRcd> intercalibErrorsToken_;
+  const edm::ESGetToken<EcalTimeCalibConstants, EcalTimeCalibConstantsRcd> timeCalibConstantsToken_;
+  const edm::ESGetToken<EcalTimeCalibErrors, EcalTimeCalibErrorsRcd> timeCalibErrorsToken_;
+  const edm::ESGetToken<EcalTimeOffsetConstant, EcalTimeOffsetConstantRcd> timeOffsetConstantToken_;
+  const edm::ESGetToken<EcalTBWeights, EcalTBWeightsRcd> tbWeightsToken_;
+  const edm::ESGetToken<EcalClusterLocalContCorrParameters, EcalClusterLocalContCorrParametersRcd> clusterLocalContCorrToken_;
+  const edm::ESGetToken<EcalClusterCrackCorrParameters, EcalClusterCrackCorrParametersRcd> clusterCrackCorrToken_;
+  const edm::ESGetToken<EcalClusterEnergyCorrectionParameters, EcalClusterEnergyCorrectionParametersRcd> clusterEnergyCorrectionToken_;
+  const edm::ESGetToken<EcalClusterEnergyUncertaintyParameters, EcalClusterEnergyUncertaintyParametersRcd> clusterEnergyUncertaintyToken_;
+  const edm::ESGetToken<EcalClusterEnergyCorrectionObjectSpecificParameters, EcalClusterEnergyCorrectionObjectSpecificParametersRcd> clusterEnergyCorrectionObjectSpecificToken_;
+  const edm::ESGetToken<EcalLaserAlphas, EcalLaserAlphasRcd> laserAlphasToken_;
+  const edm::ESGetToken<EcalLaserAPDPNRatiosRef, EcalLaserAPDPNRatiosRefRcd> laserAPDPNRatiosRefToken_;
+  const edm::ESGetToken<EcalLaserAPDPNRatios, EcalLaserAPDPNRatiosRcd> laserAPDPNRatiosToken_;
+  const edm::ESGetToken<EcalChannelStatus, EcalChannelStatusRcd> channelStatusToken_;
+  const edm::ESGetToken<EcalSampleMask, EcalSampleMaskRcd> sampleMaskToken_;
 };
+#endif

--- a/CalibCalorimetry/EcalTrivialCondModules/src/EcalLaserCondTools.cc
+++ b/CalibCalorimetry/EcalTrivialCondModules/src/EcalLaserCondTools.cc
@@ -7,12 +7,10 @@
 
 #include "CalibCalorimetry/EcalTrivialCondModules/interface/EcalLaserCondTools.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "CondFormats/DataRecord/interface/EcalLaserAPDPNRatiosRcd.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
 
@@ -36,6 +34,10 @@ EcalLaserCondTools::EcalLaserCondTools(const edm::ParameterSet& ps)
       toTime_(ps.getParameter<int>("toTime")),
       minP_(ps.getParameter<double>("transparencyMin")),
       maxP_(ps.getParameter<double>("transparencyMax")) {
+  if (mode_ == "db_to_ascii_file") {
+    laserAPDPNRatiosToken_ = esConsumes();
+  }
+
   ferr_ = fopen("corr_errors.txt", "w");
   fprintf(ferr_, "#t1\tdetid\tp1\tp2\tp3");
 
@@ -618,13 +620,10 @@ std::string EcalLaserCondTools::timeToString(time_t t) {
 }
 
 void EcalLaserCondTools::dbToAscii(const edm::EventSetup& es) {
-  edm::ESHandle<EcalLaserAPDPNRatios> hCorr;
-  es.get<EcalLaserAPDPNRatiosRcd>().get(hCorr);
+  const auto& laserAPDPNRatios = es.getData(laserAPDPNRatiosToken_);
 
-  const EcalLaserAPDPNRatios* corr = hCorr.product();
-
-  const EcalLaserAPDPNRatios::EcalLaserAPDPNRatiosMap& p = corr->getLaserMap();
-  const EcalLaserAPDPNRatios::EcalLaserTimeStampMap& t = corr->getTimeMap();
+  const EcalLaserAPDPNRatios::EcalLaserAPDPNRatiosMap& p = laserAPDPNRatios.getLaserMap();
+  const EcalLaserAPDPNRatios::EcalLaserTimeStampMap& t = laserAPDPNRatios.getTimeMap();
 
   if (t.size() != EcalLaserCondTools::nLmes)
     throw cms::Exception("LasCor") << "Unexpected number time parameter triplets\n";

--- a/CalibCalorimetry/EcalTrivialCondModules/src/EcalTrivialObjectAnalyzer.cc
+++ b/CalibCalorimetry/EcalTrivialCondModules/src/EcalTrivialObjectAnalyzer.cc
@@ -10,90 +10,51 @@
 #include <iomanip>
 #include <map>
 #include <vector>
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "DataFormats/EcalDetId/interface/EBDetId.h"
-
-#include "CondFormats/EcalObjects/interface/EcalPedestals.h"
-#include "CondFormats/DataRecord/interface/EcalPedestalsRcd.h"
-
 #include "CondFormats/EcalObjects/interface/EcalXtalGroupId.h"
-#include "CondFormats/EcalObjects/interface/EcalWeightXtalGroups.h"
-#include "CondFormats/DataRecord/interface/EcalWeightXtalGroupsRcd.h"
-
 #include "CondFormats/EcalObjects/interface/EcalWeightSet.h"
-#include "CondFormats/EcalObjects/interface/EcalTBWeights.h"
-#include "CondFormats/DataRecord/interface/EcalTBWeightsRcd.h"
-
-#include "CondFormats/EcalObjects/interface/EcalIntercalibConstants.h"
-#include "CondFormats/DataRecord/interface/EcalIntercalibConstantsRcd.h"
-
-#include "CondFormats/EcalObjects/interface/EcalIntercalibErrors.h"
-#include "CondFormats/DataRecord/interface/EcalIntercalibErrorsRcd.h"
-
-#include "CondFormats/EcalObjects/interface/EcalTimeCalibConstants.h"
-#include "CondFormats/DataRecord/interface/EcalTimeCalibConstantsRcd.h"
-
-#include "CondFormats/EcalObjects/interface/EcalTimeCalibErrors.h"
-#include "CondFormats/DataRecord/interface/EcalTimeCalibErrorsRcd.h"
-
-#include "CondFormats/EcalObjects/interface/EcalTimeOffsetConstant.h"
-#include "CondFormats/DataRecord/interface/EcalTimeOffsetConstantRcd.h"
-
+#include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "CondFormats/EcalObjects/interface/EcalMGPAGainRatio.h"
-#include "CondFormats/EcalObjects/interface/EcalGainRatios.h"
-#include "CondFormats/DataRecord/interface/EcalGainRatiosRcd.h"
-
-#include "CondFormats/EcalObjects/interface/EcalADCToGeVConstant.h"
-#include "CondFormats/DataRecord/interface/EcalADCToGeVConstantRcd.h"
-
-#include "CondFormats/EcalObjects/interface/EcalLaserAlphas.h"
-#include "CondFormats/DataRecord/interface/EcalLaserAlphasRcd.h"
-
-#include "CondFormats/EcalObjects/interface/EcalLaserAPDPNRatiosRef.h"
-#include "CondFormats/DataRecord/interface/EcalLaserAPDPNRatiosRefRcd.h"
-
-#include "CondFormats/EcalObjects/interface/EcalLaserAPDPNRatios.h"
-#include "CondFormats/DataRecord/interface/EcalLaserAPDPNRatiosRcd.h"
-
-#include "CondFormats/EcalObjects/interface/EcalClusterLocalContCorrParameters.h"
-#include "CondFormats/DataRecord/interface/EcalClusterLocalContCorrParametersRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalClusterCrackCorrParameters.h"
-#include "CondFormats/DataRecord/interface/EcalClusterCrackCorrParametersRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalClusterEnergyCorrectionParameters.h"
-#include "CondFormats/DataRecord/interface/EcalClusterEnergyCorrectionParametersRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalClusterEnergyUncertaintyParameters.h"
-#include "CondFormats/DataRecord/interface/EcalClusterEnergyUncertaintyParametersRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalClusterEnergyCorrectionObjectSpecificParameters.h"
-#include "CondFormats/DataRecord/interface/EcalClusterEnergyCorrectionObjectSpecificParametersRcd.h"
-
-#include "CondFormats/EcalObjects/interface/EcalChannelStatus.h"
-#include "CondFormats/DataRecord/interface/EcalChannelStatusRcd.h"
-
-#include "CondFormats/EcalObjects/interface/EcalSampleMask.h"
-#include "CondFormats/DataRecord/interface/EcalSampleMaskRcd.h"
 
 #include "CLHEP/Matrix/Matrix.h"
 
 using namespace std;
+
+EcalTrivialObjectAnalyzer::EcalTrivialObjectAnalyzer(edm::ParameterSet const& p)
+    : pedestalsToken_(esConsumes()),
+      adcToGevConstantToken_(esConsumes()),
+      weightXtalGroupsToken_(esConsumes()),
+      gainRatiosToken_(esConsumes()),
+      intercalibConstantsToken_(esConsumes()),
+      intercalibErrorsToken_(esConsumes()),
+      timeCalibConstantsToken_(esConsumes()),
+      timeCalibErrorsToken_(esConsumes()),
+      timeOffsetConstantToken_(esConsumes()),
+      tbWeightsToken_(esConsumes()),
+      clusterLocalContCorrToken_(esConsumes()),
+      clusterCrackCorrToken_(esConsumes()),
+      clusterEnergyCorrectionToken_(esConsumes()),
+      clusterEnergyUncertaintyToken_(esConsumes()),
+      clusterEnergyCorrectionObjectSpecificToken_(esConsumes()),
+      laserAlphasToken_(esConsumes()),
+      laserAPDPNRatiosRefToken_(esConsumes()),
+      laserAPDPNRatiosToken_(esConsumes()),
+      channelStatusToken_(esConsumes()),
+      sampleMaskToken_(esConsumes()) {
+}
 
 void EcalTrivialObjectAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context) {
   using namespace edm::eventsetup;
   // Context is not used.
   edm::LogInfo(">>> EcalTrivialObjectAnalyzer: processing run ") << e.id().run() << " event: " << e.id().event();
 
-  edm::ESHandle<EcalPedestals> pPeds;
-  context.get<EcalPedestalsRcd>().get(pPeds);
-
   // ADC -> GeV Scale
-  edm::ESHandle<EcalADCToGeVConstant> pAgc;
-  context.get<EcalADCToGeVConstantRcd>().get(pAgc);
-  const EcalADCToGeVConstant* agc = pAgc.product();
-  edm::LogInfo("Global ADC->GeV scale: EB ") << std::setprecision(6) << agc->getEBValue()
+  const auto& agc = context.getData(adcToGevConstantToken_);
+  edm::LogInfo("Global ADC->GeV scale: EB ") << std::setprecision(6) << agc.getEBValue()
                                              << " GeV/ADC count"
                                                 " EE "
-                                             << std::setprecision(6) << agc->getEEValue() << " GeV/ADC count";
+                                             << std::setprecision(6) << agc.getEEValue() << " GeV/ADC count";
 
   // use a channel to fetch values from DB
   double r1 = (double)std::rand() / (double(RAND_MAX) + double(1));
@@ -104,9 +65,9 @@ void EcalTrivialObjectAnalyzer::analyze(const edm::Event& e, const edm::EventSet
   EBDetId ebid(ieta, iphi);  //eta,phi
   edm::LogInfo("EcalTrivialObjectAnalyzer: using EBDetId: ") << ebid;
 
-  const EcalPedestals* myped = pPeds.product();
-  EcalPedestals::const_iterator it = myped->find(ebid.rawId());
-  if (it != myped->end()) {
+  const auto& myped = context.getData(pedestalsToken_);
+  EcalPedestals::const_iterator it = myped.find(ebid.rawId());
+  if (it != myped.end()) {
     edm::LogInfo("EcalPedestal: ") << "  mean_x1:  " << std::setprecision(8) << (*it).mean_x1
                                    << " rms_x1: " << (*it).rms_x1 << "  mean_x6:  " << (*it).mean_x6
                                    << " rms_x6: " << (*it).rms_x6 << "  mean_x12: " << (*it).mean_x12
@@ -116,13 +77,11 @@ void EcalTrivialObjectAnalyzer::analyze(const edm::Event& e, const edm::EventSet
   }
 
   // fetch map of groups of xtals
-  edm::ESHandle<EcalWeightXtalGroups> pGrp;
-  context.get<EcalWeightXtalGroupsRcd>().get(pGrp);
-  const EcalWeightXtalGroups* grp = pGrp.product();
+  const auto& grp = context.getData(weightXtalGroupsToken_);
 
-  EcalXtalGroupsMap::const_iterator git = grp->getMap().find(ebid.rawId());
+  EcalXtalGroupsMap::const_iterator git = grp.getMap().find(ebid.rawId());
   EcalXtalGroupId gid;
-  if (git != grp->getMap().end()) {
+  if (git != grp.getMap().end()) {
     edm::LogInfo("XtalGroupId.id() = ") << std::setprecision(3) << (*git).id();
     gid = (*git);
   } else {
@@ -130,13 +89,11 @@ void EcalTrivialObjectAnalyzer::analyze(const edm::Event& e, const edm::EventSet
   }
 
   // Gain Ratios
-  edm::ESHandle<EcalGainRatios> pRatio;
-  context.get<EcalGainRatiosRcd>().get(pRatio);
-  const EcalGainRatios* gr = pRatio.product();
+  const auto& gr = context.getData(gainRatiosToken_);
 
-  EcalGainRatioMap::const_iterator grit = gr->getMap().find(ebid.rawId());
+  EcalGainRatioMap::const_iterator grit = gr.getMap().find(ebid.rawId());
   EcalMGPAGainRatio mgpa;
-  if (grit != gr->getMap().end()) {
+  if (grit != gr.getMap().end()) {
     mgpa = (*grit);
 
     edm::LogInfo("EcalMGPAGainRatio: ") << "gain 12/6 :  " << std::setprecision(4) << mgpa.gain12Over6()
@@ -146,13 +103,11 @@ void EcalTrivialObjectAnalyzer::analyze(const edm::Event& e, const edm::EventSet
   }
 
   // Intercalib constants
-  edm::ESHandle<EcalIntercalibConstants> pIcal;
-  context.get<EcalIntercalibConstantsRcd>().get(pIcal);
-  const EcalIntercalibConstants* ical = pIcal.product();
+  const auto& ical = context.getData(intercalibConstantsToken_);
 
-  EcalIntercalibConstantMap::const_iterator icalit = ical->getMap().find(ebid.rawId());
+  EcalIntercalibConstantMap::const_iterator icalit = ical.getMap().find(ebid.rawId());
   EcalIntercalibConstant icalconst;
-  if (icalit != ical->getMap().end()) {
+  if (icalit != ical.getMap().end()) {
     icalconst = (*icalit);
 
     edm::LogInfo("EcalIntercalibConstant: ") << std::setprecision(6) << icalconst;
@@ -161,13 +116,11 @@ void EcalTrivialObjectAnalyzer::analyze(const edm::Event& e, const edm::EventSet
   }
 
   // Intercalib errors
-  edm::ESHandle<EcalIntercalibErrors> pIcalErr;
-  context.get<EcalIntercalibErrorsRcd>().get(pIcalErr);
-  const EcalIntercalibErrors* icalErr = pIcalErr.product();
+  const auto& icalErr = context.getData(intercalibErrorsToken_);
 
-  EcalIntercalibErrorMap::const_iterator icalitErr = icalErr->getMap().find(ebid.rawId());
+  EcalIntercalibErrorMap::const_iterator icalitErr = icalErr.getMap().find(ebid.rawId());
   EcalIntercalibError icalconstErr;
-  if (icalitErr != icalErr->getMap().end()) {
+  if (icalitErr != icalErr.getMap().end()) {
     icalconstErr = (*icalitErr);
 
     edm::LogInfo("EcalIntercalibError: ") << std::setprecision(6) << icalconstErr;
@@ -177,13 +130,11 @@ void EcalTrivialObjectAnalyzer::analyze(const edm::Event& e, const edm::EventSet
 
   {  // quick and dirty for cut and paste ;) it is a test program...
     // TimeCalib constants
-    edm::ESHandle<EcalTimeCalibConstants> pIcal;
-    context.get<EcalTimeCalibConstantsRcd>().get(pIcal);
-    const EcalTimeCalibConstants* ical = pIcal.product();
+    const auto& ical = context.getData(timeCalibConstantsToken_);
 
-    EcalTimeCalibConstantMap::const_iterator icalit = ical->getMap().find(ebid.rawId());
+    EcalTimeCalibConstantMap::const_iterator icalit = ical.getMap().find(ebid.rawId());
     EcalTimeCalibConstant icalconst;
-    if (icalit != ical->getMap().end()) {
+    if (icalit != ical.getMap().end()) {
       icalconst = (*icalit);
 
       edm::LogInfo("EcalTimeCalibConstant: ") << std::setprecision(6) << icalconst;
@@ -192,13 +143,11 @@ void EcalTrivialObjectAnalyzer::analyze(const edm::Event& e, const edm::EventSet
     }
 
     // TimeCalib errors
-    edm::ESHandle<EcalTimeCalibErrors> pIcalErr;
-    context.get<EcalTimeCalibErrorsRcd>().get(pIcalErr);
-    const EcalTimeCalibErrors* icalErr = pIcalErr.product();
+    const auto& icalErr = context.getData(timeCalibErrorsToken_);
 
-    EcalTimeCalibErrorMap::const_iterator icalitErr = icalErr->getMap().find(ebid.rawId());
+    EcalTimeCalibErrorMap::const_iterator icalitErr = icalErr.getMap().find(ebid.rawId());
     EcalTimeCalibError icalconstErr;
-    if (icalitErr != icalErr->getMap().end()) {
+    if (icalitErr != icalErr.getMap().end()) {
       icalconstErr = (*icalitErr);
 
       edm::LogInfo("EcalTimeCalibError: ") << std::setprecision(6) << icalconstErr;
@@ -211,27 +160,23 @@ void EcalTrivialObjectAnalyzer::analyze(const edm::Event& e, const edm::EventSet
   //std::cout <<"Fetching TimeOffsetConstant from DB " << std::endl;
 
   // Time Offset constants
-  edm::ESHandle<EcalTimeOffsetConstant> pTOff;
-  context.get<EcalTimeOffsetConstantRcd>().get(pTOff);
-  const EcalTimeOffsetConstant* TOff = pTOff.product();
+  const auto& TOff = context.getData(timeOffsetConstantToken_);
 
-  edm::LogInfo("EcalTimeOffsetConstant: ") << " EB " << TOff->getEBValue() << " EE " << TOff->getEEValue();
+  edm::LogInfo("EcalTimeOffsetConstant: ") << " EB " << TOff.getEBValue() << " EE " << TOff.getEEValue();
 
   // fetch TB weights
   edm::LogInfo("Fetching EcalTBWeights from DB ");
-  edm::ESHandle<EcalTBWeights> pWgts;
-  context.get<EcalTBWeightsRcd>().get(pWgts);
-  const EcalTBWeights* wgts = pWgts.product();
-  edm::LogInfo("EcalTBWeightMap.size(): ") << std::setprecision(3) << wgts->getMap().size();
+  const auto& wgts = context.getData(tbWeightsToken_);
+  edm::LogInfo("EcalTBWeightMap.size(): ") << std::setprecision(3) << wgts.getMap().size();
 
   // look up the correct weights for this  xtal
   //EcalXtalGroupId gid( (*git) );
   EcalTBWeights::EcalTDCId tdcid(1);
 
   edm::LogInfo("Lookup EcalWeightSet for groupid: ") << std::setprecision(3) << gid.id() << " and TDC id " << tdcid;
-  EcalTBWeights::EcalTBWeightMap::const_iterator wit = wgts->getMap().find(std::make_pair(gid, tdcid));
+  EcalTBWeights::EcalTBWeightMap::const_iterator wit = wgts.getMap().find(std::make_pair(gid, tdcid));
   EcalWeightSet wset;
-  if (wit != wgts->getMap().end()) {
+  if (wit != wgts.getMap().end()) {
     wset = wit->second;
     edm::LogInfo("check size of data members in EcalWeightSet");
     //wit->second.print(std::cout);
@@ -259,52 +204,41 @@ void EcalTrivialObjectAnalyzer::analyze(const edm::Event& e, const edm::EventSet
   }
 
   // cluster functions/corrections
-  edm::ESHandle<EcalClusterLocalContCorrParameters> pLocalCont;
-  context.get<EcalClusterLocalContCorrParametersRcd>().get(pLocalCont);
-  const EcalClusterLocalContCorrParameters* paramLocalCont = pLocalCont.product();
+  const auto& paramLocalCont = context.getData(clusterLocalContCorrToken_);
   edm::LogInfo("LocalContCorrParameters:");
-  for (EcalFunctionParameters::const_iterator it = paramLocalCont->params().begin();
-       it != paramLocalCont->params().end();
+  for (EcalFunctionParameters::const_iterator it = paramLocalCont.params().begin();
+       it != paramLocalCont.params().end();
        ++it) {
     // edm::LogInfo(" ") << *it;
   }
   // std::cout << "\n";
-  edm::ESHandle<EcalClusterCrackCorrParameters> pCrack;
-  context.get<EcalClusterCrackCorrParametersRcd>().get(pCrack);
-  const EcalClusterCrackCorrParameters* paramCrack = pCrack.product();
+  const auto& paramCrack = context.getData(clusterCrackCorrToken_);
   edm::LogInfo("CrackCorrParameters:");
-  for (EcalFunctionParameters::const_iterator it = paramCrack->params().begin(); it != paramCrack->params().end();
+  for (EcalFunctionParameters::const_iterator it = paramCrack.params().begin(); it != paramCrack.params().end();
        ++it) {
     //  edm::LogInfo(" ") << *it;
   }
   // std::cout << "\n";
-  edm::ESHandle<EcalClusterEnergyCorrectionParameters> pEnergyCorrection;
-  context.get<EcalClusterEnergyCorrectionParametersRcd>().get(pEnergyCorrection);
-  const EcalClusterEnergyCorrectionParameters* paramEnergyCorrection = pEnergyCorrection.product();
+const auto& paramEnergyCorrection = context.getData(clusterEnergyCorrectionToken_);
   edm::LogInfo("EnergyCorrectionParameters:");
-  for (EcalFunctionParameters::const_iterator it = paramEnergyCorrection->params().begin();
-       it != paramEnergyCorrection->params().end();
+  for (EcalFunctionParameters::const_iterator it = paramEnergyCorrection.params().begin();
+       it != paramEnergyCorrection.params().end();
        ++it) {
     // edm::LogInfo(" ") << *it;
   }
   // std::cout << "\n";
-  edm::ESHandle<EcalClusterEnergyUncertaintyParameters> pEnergyUncertainty;
-  context.get<EcalClusterEnergyUncertaintyParametersRcd>().get(pEnergyUncertainty);
-  const EcalClusterEnergyUncertaintyParameters* paramEnergyUncertainty = pEnergyUncertainty.product();
+  const auto& paramEnergyUncertainty = context.getData(clusterEnergyUncertaintyToken_);
   edm::LogInfo("EnergyCorrectionParameters:");
-  for (EcalFunctionParameters::const_iterator it = paramEnergyUncertainty->params().begin();
-       it != paramEnergyUncertainty->params().end();
+  for (EcalFunctionParameters::const_iterator it = paramEnergyUncertainty.params().begin();
+       it != paramEnergyUncertainty.params().end();
        ++it) {
     // edm::LogInfo(" ") << *it;
   }
   // std::cout << "\n";
-  edm::ESHandle<EcalClusterEnergyCorrectionObjectSpecificParameters> pEnergyCorrectionObjectSpecific;
-  context.get<EcalClusterEnergyCorrectionObjectSpecificParametersRcd>().get(pEnergyCorrectionObjectSpecific);
-  const EcalClusterEnergyCorrectionObjectSpecificParameters* paramEnergyCorrectionObjectSpecific =
-      pEnergyCorrectionObjectSpecific.product();
+  const auto& paramEnergyCorrectionObjectSpecific = context.getData(clusterEnergyCorrectionObjectSpecificToken_);
   edm::LogInfo("EnergyCorrectionObjectSpecificParameters:");
-  for (EcalFunctionParameters::const_iterator it = paramEnergyCorrectionObjectSpecific->params().begin();
-       it != paramEnergyCorrectionObjectSpecific->params().end();
+  for (EcalFunctionParameters::const_iterator it = paramEnergyCorrectionObjectSpecific.params().begin();
+       it != paramEnergyCorrectionObjectSpecific.params().end();
        ++it) {
     //  edm::LogInfo(" ") << *it;
   }
@@ -313,26 +247,22 @@ void EcalTrivialObjectAnalyzer::analyze(const edm::Event& e, const edm::EventSet
   // laser correction
 
   // laser alphas
-  edm::ESHandle<EcalLaserAlphas> pAlpha;
-  context.get<EcalLaserAlphasRcd>().get(pAlpha);
-  const EcalLaserAlphas* lalpha = pAlpha.product();
+  const auto& lalpha = context.getData(laserAlphasToken_);
 
   EcalLaserAlphaMap::const_iterator lalphait;
-  lalphait = lalpha->getMap().find(ebid.rawId());
-  if (lalphait != lalpha->getMap().end()) {
+  lalphait = lalpha.getMap().find(ebid.rawId());
+  if (lalphait != lalpha.getMap().end()) {
     edm::LogInfo("EcalLaserAlpha: ") << std::setprecision(6) << (*lalphait);
   } else {
     edm::LogInfo("No laser alpha found for this xtal! something wrong with EcalLaserAlphas in your DB? ");
   }
 
   // laser apdpnref
-  edm::ESHandle<EcalLaserAPDPNRatiosRef> pAPDPNRatiosRef;
-  context.get<EcalLaserAPDPNRatiosRefRcd>().get(pAPDPNRatiosRef);
-  const EcalLaserAPDPNRatiosRef* lref = pAPDPNRatiosRef.product();
+  const auto& lref = context.getData(laserAPDPNRatiosRefToken_);
 
   EcalLaserAPDPNRatiosRef::const_iterator lrefit;
-  lrefit = lref->getMap().find(ebid.rawId());
-  if (lrefit != lref->getMap().end()) {
+  lrefit = lref.getMap().find(ebid.rawId());
+  if (lrefit != lref.getMap().end()) {
     //  edm::LogInfo("EcalLaserAPDPNRatiosRef: ")
     //	       <<std::setprecision(6)
     //	       << (*lrefit)
@@ -342,15 +272,13 @@ void EcalTrivialObjectAnalyzer::analyze(const edm::Event& e, const edm::EventSet
   }
 
   // laser apdpn ratios
-  edm::ESHandle<EcalLaserAPDPNRatios> pAPDPNRatios;
-  context.get<EcalLaserAPDPNRatiosRcd>().get(pAPDPNRatios);
-  const EcalLaserAPDPNRatios* lratio = pAPDPNRatios.product();
+  const auto& lratio = context.getData(laserAPDPNRatiosToken_);
 
   EcalLaserAPDPNRatios::EcalLaserAPDPNRatiosMap::const_iterator lratioit;
-  lratioit = lratio->getLaserMap().find(ebid.rawId());
+  lratioit = lratio.getLaserMap().find(ebid.rawId());
   EcalLaserAPDPNRatios::EcalLaserAPDPNpair lratioconst;
 
-  if (lratioit != lratio->getLaserMap().end()) {
+  if (lratioit != lratio.getLaserMap().end()) {
     lratioconst = (*lratioit);
 
     //  edm::LogInfo("EcalLaserAPDPNRatios: ")
@@ -366,20 +294,18 @@ void EcalTrivialObjectAnalyzer::analyze(const edm::Event& e, const edm::EventSet
   EcalLaserAPDPNRatios::EcalLaserTimeStamp ltimestamp;
   // EcalLaserAPDPNRatios::EcalLaserTimeStampMap::const_iterator ltimeit;
   for (int i = 1; i <= 92; i++) {
-    ltimestamp = lratio->getTimeMap()[i];
+    ltimestamp = lratio.getTimeMap()[i];
     //  edm::LogInfo("i = ") << std::setprecision(6) << i
     //         << ltimestamp.t1.value() << " " << ltimestamp.t2.value() << " : " ;
   }
   // edm::LogInfo("Tests finished.");
 
   // channel status
-  edm::ESHandle<EcalChannelStatus> pChannelStatus;
-  context.get<EcalChannelStatusRcd>().get(pChannelStatus);
-  const EcalChannelStatus* ch_status = pChannelStatus.product();
+  const auto& ch_status = context.getData(channelStatusToken_);
 
   EcalChannelStatusMap::const_iterator chit;
-  chit = ch_status->getMap().find(ebid.rawId());
-  if (chit != ch_status->getMap().end()) {
+  chit = ch_status.getMap().find(ebid.rawId());
+  if (chit != ch_status.getMap().end()) {
     EcalChannelStatusCode ch_code = (*chit);
     edm::LogInfo("EcalChannelStatus: ") << std::setprecision(6) << ch_code.getStatusCode();
   } else {
@@ -389,11 +315,9 @@ void EcalTrivialObjectAnalyzer::analyze(const edm::Event& e, const edm::EventSet
   // laser transparency correction
 
   // Mask to ignore sample
-  edm::ESHandle<EcalSampleMask> pSMask;
-  context.get<EcalSampleMaskRcd>().get(pSMask);
-  const EcalSampleMask* smask = pSMask.product();
-  edm::LogInfo("Sample Mask EB ") << std::hex << smask->getEcalSampleMaskRecordEB() << " EE " << std::hex
-                                  << smask->getEcalSampleMaskRecordEE();
+  const auto& smask = context.getData(sampleMaskToken_);
+  edm::LogInfo("Sample Mask EB ") << std::hex << smask.getEcalSampleMaskRecordEB() << " EE " << std::hex
+                                  << smask.getEcalSampleMaskRecordEE();
 
   /*
     std::cout << "make CLHEP matrices from vector<vector<Ecalweight>>" << std::endl;

--- a/CalibCalorimetry/EcalTrivialCondModules/src/EcalTrivialObjectAnalyzer.cc
+++ b/CalibCalorimetry/EcalTrivialCondModules/src/EcalTrivialObjectAnalyzer.cc
@@ -41,8 +41,7 @@ EcalTrivialObjectAnalyzer::EcalTrivialObjectAnalyzer(edm::ParameterSet const& p)
       laserAPDPNRatiosRefToken_(esConsumes()),
       laserAPDPNRatiosToken_(esConsumes()),
       channelStatusToken_(esConsumes()),
-      sampleMaskToken_(esConsumes()) {
-}
+      sampleMaskToken_(esConsumes()) {}
 
 void EcalTrivialObjectAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context) {
   using namespace edm::eventsetup;
@@ -206,20 +205,18 @@ void EcalTrivialObjectAnalyzer::analyze(const edm::Event& e, const edm::EventSet
   // cluster functions/corrections
   const auto& paramLocalCont = context.getData(clusterLocalContCorrToken_);
   edm::LogInfo("LocalContCorrParameters:");
-  for (EcalFunctionParameters::const_iterator it = paramLocalCont.params().begin();
-       it != paramLocalCont.params().end();
+  for (EcalFunctionParameters::const_iterator it = paramLocalCont.params().begin(); it != paramLocalCont.params().end();
        ++it) {
     // edm::LogInfo(" ") << *it;
   }
   // std::cout << "\n";
   const auto& paramCrack = context.getData(clusterCrackCorrToken_);
   edm::LogInfo("CrackCorrParameters:");
-  for (EcalFunctionParameters::const_iterator it = paramCrack.params().begin(); it != paramCrack.params().end();
-       ++it) {
+  for (EcalFunctionParameters::const_iterator it = paramCrack.params().begin(); it != paramCrack.params().end(); ++it) {
     //  edm::LogInfo(" ") << *it;
   }
   // std::cout << "\n";
-const auto& paramEnergyCorrection = context.getData(clusterEnergyCorrectionToken_);
+  const auto& paramEnergyCorrection = context.getData(clusterEnergyCorrectionToken_);
   edm::LogInfo("EnergyCorrectionParameters:");
   for (EcalFunctionParameters::const_iterator it = paramEnergyCorrection.params().begin();
        it != paramEnergyCorrection.params().end();


### PR DESCRIPTION
#### PR description:

The PR migrates ECAL related code in the CalibCalorimetry packages to esConsumes (#31061). In addition `getByLabel()` calls were replaced by `getByToken()` and legacy module types were migrated to multithreaded module types.

Modified packages:
- CalibCalorimetry/CaloMiscalibTools
- CalibCalorimetry/EcalLaserAnalyzer
- CalibCalorimetry/EcalPedestalOffsets
- CalibCalorimetry/EcalSRTools
- CalibCalorimetry/EcalTPGTools
- CalibCalorimetry/EcalTrivialCondModules

#### PR validation:

Code compiles. Where test configurations were present those were run as well.
