### PR TITLE
Migrate CondTools-Ecal modules to use esconsumes

### DIFF
--- a/CondTools/Ecal/interface/EcalDBCopy.h
+++ b/CondTools/Ecal/interface/EcalDBCopy.h
@@ -5,7 +5,28 @@
 #include "CondCore/CondDB/interface/Exception.h"
 
 #include "FWCore/Framework/interface/IOVSyncValue.h"
-
+#include "CondFormats/EcalObjects/interface/EcalPedestals.h"
+#include "CondFormats/EcalObjects/interface/EcalTimeCalibConstants.h"
+#include "CondFormats/EcalObjects/interface/EcalChannelStatus.h"
+#include "CondFormats/EcalObjects/interface/EcalDQMChannelStatus.h"
+#include "CondFormats/EcalObjects/interface/EcalDQMTowerStatus.h"
+#include "CondFormats/EcalObjects/interface/EcalDCSTowerStatus.h"
+#include "CondFormats/EcalObjects/interface/EcalDAQTowerStatus.h"
+#include "CondFormats/EcalObjects/interface/EcalTPGCrystalStatus.h"
+#include "CondFormats/EcalObjects/interface/EcalLinearCorrections.h"
+#include "CondFormats/EcalObjects/interface/EcalIntercalibConstants.h"
+#include "CondFormats/EcalObjects/interface/EcalIntercalibErrors.h"
+#include "CondFormats/EcalObjects/interface/EcalGainRatios.h"
+#include "CondFormats/EcalObjects/interface/EcalWeightXtalGroups.h"
+#include "CondFormats/EcalObjects/interface/EcalIntercalibConstantsMC.h"
+#include "CondFormats/EcalObjects/interface/EcalLaserAlphas.h"
+#include "CondFormats/EcalObjects/interface/EcalLaserAPDPNRatiosRef.h"
+#include "CondFormats/EcalObjects/interface/EcalClusterCrackCorrParameters.h"
+#include "CondFormats/EcalObjects/interface/EcalPFRecHitThresholds.h"
+#include "CondFormats/EcalObjects/interface/EcalClusterEnergyUncertaintyParameters.h"
+#include "CondFormats/EcalObjects/interface/EcalClusterEnergyCorrectionParameters.h"
+#include "CondFormats/EcalObjects/interface/EcalClusterEnergyCorrectionObjectSpecificParameters.h"
+#include "CondFormats/EcalObjects/interface/EcalClusterLocalContCorrParameters.h"
 #include <string>
 #include <map>
 
@@ -15,6 +36,53 @@ namespace edm {
   class EventSetup;
 }  // namespace edm
 
+class EcalADCToGeVConstant;
+class EcalTPGTowerStatus;
+class EcalTBWeights;
+class EcalLaserAPDPNRatios;
+class Alignments;
+class EcalTimeOffsetConstant;
+class EcalSampleMask;
+class EcalSimPulseShape;
+class EcalTimeBiasCorrections;
+class EcalSamplesCorrelation;
+
+class EcalPedestalsRcd;
+class EcalADCToGeVConstantRcd;
+class EcalTimeCalibConstantsRcd;
+class EcalChannelStatusRcd;
+class EcalDQMChannelStatusRcd;
+class EcalDQMTowerStatusRcd;
+class EcalDCSTowerStatusRcd;
+class EcalTPGCrystalStatusRcd;
+class EcalDAQTowerStatusRcd;
+class EcalTPGTowerStatusRcd;
+class EcalTPGTowerStatusRcd;
+class EcalIntercalibConstantsRcd;
+class EcalLinearCorrectionsRcd;
+class EcalIntercalibConstantsMCRcd;
+class EcalIntercalibErrorsRcd;
+class EcalGainRatiosRcd;
+class EcalWeightXtalGroupsRcd;
+class EcalTBWeightsRcd;
+class EcalLaserAlphasRcd;
+class EcalLaserAPDPNRatiosRcd;
+class EcalLaserAPDPNRatiosRefRcd;
+class EcalClusterCrackCorrParametersRcd;
+class EcalPFRecHitThresholdsRcd;
+class EcalClusterEnergyUncertaintyParametersRcd;
+class EcalClusterEnergyCorrectionParametersRcd;
+class EcalClusterEnergyCorrectionObjectSpecificParametersRcd;
+class EcalClusterLocalContCorrParametersRcd;
+class EBAlignmentRcd;
+class EEAlignmentRcd;
+class ESAlignmentRcd;
+class EcalTimeOffsetConstantRcd;
+class EcalSampleMaskRcd;
+class EcalSimPulseShapeRcd;
+class EcalTimeBiasCorrectionsRcd;
+class EcalSamplesCorrelationRcd;
+
 class EcalDBCopy : public edm::EDAnalyzer {
 public:
   explicit EcalDBCopy(const edm::ParameterSet& iConfig);
@@ -23,12 +91,52 @@ public:
   void analyze(const edm::Event& evt, const edm::EventSetup& evtSetup) override;
 
 private:
-  bool shouldCopy(const edm::EventSetup& evtSetup, std::string container);
-  void copyToDB(const edm::EventSetup& evtSetup, std::string container);
+  bool shouldCopy(const edm::EventSetup& evtSetup, const std::string& container);
+  void copyToDB(const edm::EventSetup& evtSetup, const std::string& container);
 
   std::string m_timetype;
   std::map<std::string, unsigned long long> m_cacheIDs;
   std::map<std::string, std::string> m_records;
+  edm::ESGetToken<EcalPedestals, EcalPedestalsRcd> ecalPedestalToken_;
+  edm::ESGetToken<EcalADCToGeVConstant, EcalADCToGeVConstantRcd> ecalADCtoGeVToken_;
+  edm::ESGetToken<EcalTimeCalibConstants, EcalTimeCalibConstantsRcd> ecalTimeCalibToken_;
+  edm::ESGetToken<EcalChannelStatus, EcalChannelStatusRcd> ecalChannelStatusToken_;
+  edm::ESGetToken<EcalDQMChannelStatus, EcalDQMChannelStatusRcd> ecalDQMChannelStatusToken_;
+  edm::ESGetToken<EcalDQMTowerStatus, EcalDQMTowerStatusRcd> ecalDQMTowerStatusToken_;
+  edm::ESGetToken<EcalDCSTowerStatus, EcalDCSTowerStatusRcd> ecalDCSTowerStatusToken_;
+  edm::ESGetToken<EcalDAQTowerStatus, EcalDAQTowerStatusRcd> ecalDAQTowerStatusToken_;
+  edm::ESGetToken<EcalTPGCrystalStatus, EcalTPGCrystalStatusRcd> ecalTPGCrystalStatusToken_;
+  edm::ESGetToken<EcalTPGTowerStatus, EcalTPGTowerStatusRcd> ecalTPGTowerStatusToken_;
+  edm::ESGetToken<EcalIntercalibConstants, EcalIntercalibConstantsRcd> ecalIntercalibConstantsToken_;
+  edm::ESGetToken<EcalLinearCorrections, EcalLinearCorrectionsRcd> ecalLinearCorrectionsToken_;
+  edm::ESGetToken<EcalIntercalibConstantsMC, EcalIntercalibConstantsMCRcd> ecalIntercalibConstantsMCToken_;
+  edm::ESGetToken<EcalIntercalibErrors, EcalIntercalibErrorsRcd> ecalIntercalibErrorsToken_;
+  edm::ESGetToken<EcalGainRatios, EcalGainRatiosRcd> ecalGainRatiosToken_;
+  edm::ESGetToken<EcalWeightXtalGroups, EcalWeightXtalGroupsRcd> ecalWeightXtalGroupsToken_;
+  edm::ESGetToken<EcalTBWeights, EcalTBWeightsRcd> ecalTBWeightsToken_;
+  edm::ESGetToken<EcalLaserAlphas, EcalLaserAlphasRcd> ecalLaserAlphasToken_;
+  edm::ESGetToken<EcalLaserAPDPNRatios, EcalLaserAPDPNRatiosRcd> ecalLaserAPDPNRatiosToken_;
+  edm::ESGetToken<EcalLaserAPDPNRatiosRef, EcalLaserAPDPNRatiosRefRcd> ecalLaserAPDPNRatiosRefToken_;
+  edm::ESGetToken<EcalClusterCrackCorrParameters, EcalClusterCrackCorrParametersRcd>
+      ecalClusterCrackCorrParametersToken_;
+  edm::ESGetToken<EcalPFRecHitThresholds, EcalPFRecHitThresholdsRcd> ecalPFRecHitThresholdsToken_;
+  edm::ESGetToken<EcalClusterEnergyUncertaintyParameters, EcalClusterEnergyUncertaintyParametersRcd>
+      ecalClusterEnergyUncertaintyParametersToken_;
+  edm::ESGetToken<EcalClusterEnergyCorrectionParameters, EcalClusterEnergyCorrectionParametersRcd>
+      ecalClusterEnergyCorrectionParametersToken_;
+  edm::ESGetToken<EcalClusterEnergyCorrectionObjectSpecificParameters,
+                  EcalClusterEnergyCorrectionObjectSpecificParametersRcd>
+      ecalClusterEnergyCorrectionObjectSpecificParametersToken_;
+  edm::ESGetToken<EcalClusterLocalContCorrParameters, EcalClusterLocalContCorrParametersRcd>
+      ecalClusterLocalContCorrParametersToken_;
+  edm::ESGetToken<Alignments, EBAlignmentRcd> ebAlignmentToken_;
+  edm::ESGetToken<Alignments, EEAlignmentRcd> eeAlignmentToken_;
+  edm::ESGetToken<Alignments, ESAlignmentRcd> esAlignmentToken_;
+  edm::ESGetToken<EcalTimeOffsetConstant, EcalTimeOffsetConstantRcd> ecalTimeOffsetConstantToken_;
+  edm::ESGetToken<EcalSampleMask, EcalSampleMaskRcd> ecalSampleMaskToken_;
+  edm::ESGetToken<EcalSimPulseShape, EcalSimPulseShapeRcd> ecalSimPulseShapeToken_;
+  edm::ESGetToken<EcalTimeBiasCorrections, EcalTimeBiasCorrectionsRcd> ecalTimeBiasCorrectionsToken_;
+  edm::ESGetToken<EcalSamplesCorrelation, EcalSamplesCorrelationRcd> ecalSamplesCorrelationToken_;
 };
 
 #endif

--- a/CondTools/Ecal/interface/EcalDBCopy.h
+++ b/CondTools/Ecal/interface/EcalDBCopy.h
@@ -1,7 +1,7 @@
 #ifndef ECALDBCOPY_H
 #define ECALDBCOPY_H
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "CondCore/CondDB/interface/Exception.h"
 
 #include "FWCore/Framework/interface/IOVSyncValue.h"
@@ -83,7 +83,7 @@ class EcalSimPulseShapeRcd;
 class EcalTimeBiasCorrectionsRcd;
 class EcalSamplesCorrelationRcd;
 
-class EcalDBCopy : public edm::EDAnalyzer {
+class EcalDBCopy : public edm::one::EDAnalyzer<> {
 public:
   explicit EcalDBCopy(const edm::ParameterSet& iConfig);
   ~EcalDBCopy() override;

--- a/CondTools/Ecal/interface/EcalGetLaserData.h
+++ b/CondTools/Ecal/interface/EcalGetLaserData.h
@@ -1,7 +1,7 @@
 #ifndef ECALGETLASERDATA_H
 #define ECALGETLASERDATA_H
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "CondFormats/EcalObjects/interface/EcalLaserAPDPNRatiosRef.h"
 #include "CondFormats/EcalObjects/interface/EcalLaserAlphas.h"
 
@@ -21,7 +21,7 @@ class EcalLaserAPDPNRatiosRcd;
 class EcalLaserAPDPNRatiosRefRcd;
 class EcalLaserAlphasRcd;
 
-class EcalGetLaserData : public edm::EDAnalyzer {
+class EcalGetLaserData : public edm::one::EDAnalyzer<> {
 public:
   explicit EcalGetLaserData(const edm::ParameterSet& iConfig);
   ~EcalGetLaserData() override;

--- a/CondTools/Ecal/interface/EcalGetLaserData.h
+++ b/CondTools/Ecal/interface/EcalGetLaserData.h
@@ -2,27 +2,11 @@
 #define ECALGETLASERDATA_H
 
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "CondCore/CondDB/interface/Exception.h"
-
-#include "FWCore/Framework/interface/IOVSyncValue.h"
-
-#include "CondFormats/EcalObjects/interface/EcalLaserAPDPNRatios.h"
-#include "CondFormats/DataRecord/interface/EcalLaserAPDPNRatiosRcd.h"
 #include "CondFormats/EcalObjects/interface/EcalLaserAPDPNRatiosRef.h"
-#include "CondFormats/DataRecord/interface/EcalLaserAPDPNRatiosRefRcd.h"
 #include "CondFormats/EcalObjects/interface/EcalLaserAlphas.h"
-#include "CondFormats/DataRecord/interface/EcalLaserAlphasRcd.h"
-
-#include "OnlineDB/EcalCondDB/interface/all_monitoring_types.h"
-#include "OnlineDB/Oracle/interface/Oracle.h"
-#include "OnlineDB/EcalCondDB/interface/EcalCondDBInterface.h"
-
-#include "DataFormats/EcalDetId/interface/EBDetId.h"
-#include "DataFormats/EcalDetId/interface/EEDetId.h"
 
 #include <string>
 #include <map>
-#include <iostream>
 #include <vector>
 #include <ctime>
 
@@ -31,6 +15,11 @@ namespace edm {
   class Event;
   class EventSetup;
 }  // namespace edm
+
+class EcalLaserAPDPNRatios;
+class EcalLaserAPDPNRatiosRcd;
+class EcalLaserAPDPNRatiosRefRcd;
+class EcalLaserAlphasRcd;
 
 class EcalGetLaserData : public edm::EDAnalyzer {
 public:
@@ -48,6 +37,9 @@ private:
 
   void beginJob() override;
   void endJob() override;
+  edm::ESGetToken<EcalLaserAPDPNRatios, EcalLaserAPDPNRatiosRcd> ecalLaserAPDPNRatiosToken_;
+  edm::ESGetToken<EcalLaserAPDPNRatiosRef, EcalLaserAPDPNRatiosRefRcd> ecalLaserAPDPNRatiosRefToken_;
+  edm::ESGetToken<EcalLaserAlphas, EcalLaserAlphasRcd> ecalLaserAlphasToken_;
 };
 
 #endif

--- a/CondTools/Ecal/interface/EcalPFRecHitThresholdsMaker.h
+++ b/CondTools/Ecal/interface/EcalPFRecHitThresholdsMaker.h
@@ -1,7 +1,7 @@
 #ifndef ECALPFRECHITTHRESHOLDSMAKER_H
 #define ECALPFRECHITTHRESHOLDSMAKER_H
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "CondCore/CondDB/interface/Exception.h"
 
 #include "FWCore/Framework/interface/IOVSyncValue.h"
@@ -21,7 +21,7 @@ class EcalADCToGeVConstantRcd;
 class EcalIntercalibConstantsRcd;
 class EcalLaserDbService;
 class EcalLaserDbRecord;
-class EcalPFRecHitThresholdsMaker : public edm::EDAnalyzer {
+class EcalPFRecHitThresholdsMaker : public edm::one::EDAnalyzer<> {
 public:
   explicit EcalPFRecHitThresholdsMaker(const edm::ParameterSet& iConfig);
   ~EcalPFRecHitThresholdsMaker() override;

--- a/CondTools/Ecal/interface/EcalPFRecHitThresholdsMaker.h
+++ b/CondTools/Ecal/interface/EcalPFRecHitThresholdsMaker.h
@@ -5,9 +5,9 @@
 #include "CondCore/CondDB/interface/Exception.h"
 
 #include "FWCore/Framework/interface/IOVSyncValue.h"
-
+#include "CondFormats/EcalObjects/interface/EcalPedestals.h"
+#include "CondFormats/EcalObjects/interface/EcalIntercalibConstants.h"
 #include <string>
-#include <map>
 
 namespace edm {
   class ParameterSet;
@@ -15,6 +15,12 @@ namespace edm {
   class EventSetup;
 }  // namespace edm
 
+class EcalPedestalsRcd;
+class EcalADCToGeVConstant;
+class EcalADCToGeVConstantRcd;
+class EcalIntercalibConstantsRcd;
+class EcalLaserDbService;
+class EcalLaserDbRecord;
 class EcalPFRecHitThresholdsMaker : public edm::EDAnalyzer {
 public:
   explicit EcalPFRecHitThresholdsMaker(const edm::ParameterSet& iConfig);
@@ -25,6 +31,10 @@ public:
 private:
   std::string m_timetype;
   double m_nsigma;
+  edm::ESGetToken<EcalPedestals, EcalPedestalsRcd> ecalPedestalsToken_;
+  edm::ESGetToken<EcalADCToGeVConstant, EcalADCToGeVConstantRcd> ecalADCToGeVConstantToken_;
+  edm::ESGetToken<EcalIntercalibConstants, EcalIntercalibConstantsRcd> ecalIntercalibConstantsToken_;
+  edm::ESGetToken<EcalLaserDbService, EcalLaserDbRecord> ecalLaserDbServiceToken_;
 };
 
 #endif

--- a/CondTools/Ecal/plugins/TestEcalChannelStatusAnalyzer.cc
+++ b/CondTools/Ecal/plugins/TestEcalChannelStatusAnalyzer.cc
@@ -9,13 +9,12 @@ public:
   ExTestEcalChannelStatusAnalyzer(const edm::ParameterSet& pset)
       : popcon::PopConAnalyzer<popcon::EcalChannelStatusHandler>(pset),
         m_populator(pset),
-        m_source(pset.getParameter<edm::ParameterSet>("Source")) {}
+        m_source(pset.getParameter<edm::ParameterSet>("Source")),
+        ecalElectronicsMappingToken_(esConsumes()) {}
 
 private:
   void analyze(const edm::Event& ev, const edm::EventSetup& iSetup) override {
-    edm::ESHandle<EcalElectronicsMapping> eleMap;
-    iSetup.get<EcalMappingRcd>().get(eleMap);
-    ecalElectronicsMap = eleMap.product();
+    ecalElectronicsMap = &iSetup.getData(ecalElectronicsMappingToken_);
   }
 
   void endJob() override {
@@ -29,6 +28,7 @@ private:
   popcon::PopCon m_populator;
   SourceHandler m_source;
   const EcalElectronicsMapping* ecalElectronicsMap;
+  edm::ESGetToken<EcalElectronicsMapping, EcalMappingRcd> ecalElectronicsMappingToken_;
 };
 
 //define this as a plug-in

--- a/CondTools/Ecal/src/EcalDBCopy.cc
+++ b/CondTools/Ecal/src/EcalDBCopy.cc
@@ -1,67 +1,38 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
-
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-
 #include "CondTools/Ecal/interface/EcalDBCopy.h"
-#include "CondFormats/EcalObjects/interface/EcalPedestals.h"
 #include "CondFormats/DataRecord/interface/EcalPedestalsRcd.h"
 #include "CondFormats/EcalObjects/interface/EcalADCToGeVConstant.h"
 #include "CondFormats/DataRecord/interface/EcalADCToGeVConstantRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalTimeCalibConstants.h"
 #include "CondFormats/DataRecord/interface/EcalTimeCalibConstantsRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalChannelStatus.h"
 #include "CondFormats/DataRecord/interface/EcalChannelStatusRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalLinearCorrections.h"
 #include "CondFormats/DataRecord/interface/EcalLinearCorrectionsRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalIntercalibConstants.h"
 #include "CondFormats/DataRecord/interface/EcalIntercalibConstantsRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalIntercalibConstantsMC.h"
 #include "CondFormats/DataRecord/interface/EcalIntercalibConstantsMCRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalIntercalibErrors.h"
 #include "CondFormats/DataRecord/interface/EcalIntercalibErrorsRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalGainRatios.h"
 #include "CondFormats/DataRecord/interface/EcalGainRatiosRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalWeightXtalGroups.h"
 #include "CondFormats/DataRecord/interface/EcalWeightXtalGroupsRcd.h"
 #include "CondFormats/EcalObjects/interface/EcalTBWeights.h"
 #include "CondFormats/DataRecord/interface/EcalTBWeightsRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalLaserAlphas.h"
 #include "CondFormats/DataRecord/interface/EcalLaserAlphasRcd.h"
 #include "CondFormats/EcalObjects/interface/EcalLaserAPDPNRatios.h"
 #include "CondFormats/DataRecord/interface/EcalLaserAPDPNRatiosRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalLaserAPDPNRatiosRef.h"
 #include "CondFormats/DataRecord/interface/EcalLaserAPDPNRatiosRefRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalTPGCrystalStatus.h"
 #include "CondFormats/DataRecord/interface/EcalTPGCrystalStatusRcd.h"
 #include "CondFormats/EcalObjects/interface/EcalTPGTowerStatus.h"
 #include "CondFormats/DataRecord/interface/EcalTPGTowerStatusRcd.h"
-
-#include "CondFormats/EcalObjects/interface/EcalDCSTowerStatus.h"
 #include "CondFormats/DataRecord/interface/EcalDCSTowerStatusRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalDAQTowerStatus.h"
 #include "CondFormats/DataRecord/interface/EcalDAQTowerStatusRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalDQMTowerStatus.h"
 #include "CondFormats/DataRecord/interface/EcalDQMTowerStatusRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalDQMChannelStatus.h"
 #include "CondFormats/DataRecord/interface/EcalDQMChannelStatusRcd.h"
-
-#include "CondFormats/EcalObjects/interface/EcalClusterCrackCorrParameters.h"
 #include "CondFormats/DataRecord/interface/EcalClusterCrackCorrParametersRcd.h"
-
-#include "CondFormats/EcalObjects/interface/EcalPFRecHitThresholds.h"
 #include "CondFormats/DataRecord/interface/EcalPFRecHitThresholdsRcd.h"
-
-#include "CondFormats/EcalObjects/interface/EcalClusterEnergyCorrectionParameters.h"
 #include "CondFormats/DataRecord/interface/EcalClusterEnergyCorrectionParametersRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalClusterEnergyUncertaintyParameters.h"
 #include "CondFormats/DataRecord/interface/EcalClusterEnergyUncertaintyParametersRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalClusterEnergyCorrectionObjectSpecificParameters.h"
 #include "CondFormats/DataRecord/interface/EcalClusterEnergyCorrectionObjectSpecificParametersRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalClusterLocalContCorrParameters.h"
 #include "CondFormats/DataRecord/interface/EcalClusterLocalContCorrParametersRcd.h"
 
 #include "CondFormats/Alignment/interface/Alignments.h"
@@ -86,36 +57,66 @@
 #include <vector>
 
 EcalDBCopy::EcalDBCopy(const edm::ParameterSet& iConfig)
-    : m_timetype(iConfig.getParameter<std::string>("timetype")), m_cacheIDs(), m_records() {
+    : m_timetype(iConfig.getParameter<std::string>("timetype")),
+      m_cacheIDs(),
+      m_records(),
+      ecalPedestalToken_(esConsumes()),
+      ecalADCtoGeVToken_(esConsumes()),
+      ecalTimeCalibToken_(esConsumes()),
+      ecalChannelStatusToken_(esConsumes()),
+      ecalDQMChannelStatusToken_(esConsumes()),
+      ecalDQMTowerStatusToken_(esConsumes()),
+      ecalDCSTowerStatusToken_(esConsumes()),
+      ecalDAQTowerStatusToken_(esConsumes()),
+      ecalTPGCrystalStatusToken_(esConsumes()),
+      ecalTPGTowerStatusToken_(esConsumes()),
+      ecalIntercalibConstantsToken_(esConsumes()),
+      ecalLinearCorrectionsToken_(esConsumes()),
+      ecalIntercalibConstantsMCToken_(esConsumes()),
+      ecalIntercalibErrorsToken_(esConsumes()),
+      ecalGainRatiosToken_(esConsumes()),
+      ecalWeightXtalGroupsToken_(esConsumes()),
+      ecalTBWeightsToken_(esConsumes()),
+      ecalLaserAlphasToken_(esConsumes()),
+      ecalLaserAPDPNRatiosToken_(esConsumes()),
+      ecalLaserAPDPNRatiosRefToken_(esConsumes()),
+      ecalClusterCrackCorrParametersToken_(esConsumes()),
+      ecalPFRecHitThresholdsToken_(esConsumes()),
+      ecalClusterEnergyUncertaintyParametersToken_(esConsumes()),
+      ecalClusterEnergyCorrectionParametersToken_(esConsumes()),
+      ecalClusterEnergyCorrectionObjectSpecificParametersToken_(esConsumes()),
+      ecalClusterLocalContCorrParametersToken_(esConsumes()),
+      ebAlignmentToken_(esConsumes()),
+      eeAlignmentToken_(esConsumes()),
+      esAlignmentToken_(esConsumes()),
+      ecalTimeOffsetConstantToken_(esConsumes()),
+      ecalSampleMaskToken_(esConsumes()),
+      ecalSimPulseShapeToken_(esConsumes()),
+      ecalTimeBiasCorrectionsToken_(esConsumes()),
+      ecalSamplesCorrelationToken_(esConsumes()) {
   std::string container;
-  std::string tag;
   std::string record;
   typedef std::vector<edm::ParameterSet> Parameters;
   Parameters toCopy = iConfig.getParameter<Parameters>("toCopy");
-  for (Parameters::iterator i = toCopy.begin(); i != toCopy.end(); ++i) {
-    container = i->getParameter<std::string>("container");
-    record = i->getParameter<std::string>("record");
-    m_cacheIDs.insert(std::make_pair(container, 0));
-    m_records.insert(std::make_pair(container, record));
+  for (auto& iparam : toCopy) {
+    container = iparam.getParameter<std::string>("container");
+    record = iparam.getParameter<std::string>("record");
+    m_cacheIDs.emplace(container, 0);
+    m_records.emplace(container, record);
   }
 }
 
 EcalDBCopy::~EcalDBCopy() {}
 
 void EcalDBCopy::analyze(const edm::Event& evt, const edm::EventSetup& evtSetup) {
-  std::string container;
-  std::string record;
-  typedef std::map<std::string, std::string>::const_iterator recordIter;
-  for (recordIter i = m_records.begin(); i != m_records.end(); ++i) {
-    container = (*i).first;
-    record = (*i).second;
-    if (shouldCopy(evtSetup, container)) {
-      copyToDB(evtSetup, container);
+  for (const auto& irec : m_records) {
+    if (shouldCopy(evtSetup, irec.first)) {
+      copyToDB(evtSetup, irec.first);
     }
   }
 }
 
-bool EcalDBCopy::shouldCopy(const edm::EventSetup& evtSetup, std::string container) {
+bool EcalDBCopy::shouldCopy(const edm::EventSetup& evtSetup, const std::string& container) {
   unsigned long long cacheID = 0;
   if (container == "EcalPedestals") {
     cacheID = evtSetup.get<EcalPedestalsRcd>().cacheIdentifier();
@@ -199,7 +200,7 @@ bool EcalDBCopy::shouldCopy(const edm::EventSetup& evtSetup, std::string contain
   }
 }
 
-void EcalDBCopy::copyToDB(const edm::EventSetup& evtSetup, std::string container) {
+void EcalDBCopy::copyToDB(const edm::EventSetup& evtSetup, const std::string& container) {
   edm::Service<cond::service::PoolDBOutputService> dbOutput;
   if (!dbOutput.isAvailable()) {
     throw cms::Exception("PoolDBOutputService is not available");
@@ -208,209 +209,160 @@ void EcalDBCopy::copyToDB(const edm::EventSetup& evtSetup, std::string container
   std::string recordName = m_records[container];
 
   if (container == "EcalPedestals") {
-    edm::ESHandle<EcalPedestals> handle;
-    evtSetup.get<EcalPedestalsRcd>().get(handle);
-    const EcalPedestals* obj = handle.product();
-    std::cout << "ped pointer is: " << obj << std::endl;
+    const EcalPedestals* obj = &evtSetup.getData(ecalPedestalToken_);
+    edm::LogInfo("EcalDBCopy") << "ped pointer is: " << obj << std::endl;
     dbOutput->createNewIOV<const EcalPedestals>(
         new EcalPedestals(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalADCToGeVConstant") {
-    edm::ESHandle<EcalADCToGeVConstant> handle;
-    evtSetup.get<EcalADCToGeVConstantRcd>().get(handle);
-    const EcalADCToGeVConstant* obj = handle.product();
-    std::cout << "adc pointer is: " << obj << std::endl;
+    const EcalADCToGeVConstant* obj = &evtSetup.getData(ecalADCtoGeVToken_);
+    edm::LogInfo("EcalDBCopy") << "adc pointer is: " << obj << std::endl;
 
     dbOutput->createNewIOV<const EcalADCToGeVConstant>(
         new EcalADCToGeVConstant(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalTimeCalibConstants") {
-    edm::ESHandle<EcalTimeCalibConstants> handle;
-    evtSetup.get<EcalTimeCalibConstantsRcd>().get(handle);
-    const EcalTimeCalibConstants* obj = handle.product();
-    std::cout << "adc pointer is: " << obj << std::endl;
+    const EcalTimeCalibConstants* obj = &evtSetup.getData(ecalTimeCalibToken_);
+    edm::LogInfo("EcalDBCopy") << "adc pointer is: " << obj << std::endl;
 
     dbOutput->createNewIOV<const EcalTimeCalibConstants>(
         new EcalTimeCalibConstants(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalChannelStatus") {
-    edm::ESHandle<EcalChannelStatus> handle;
-    evtSetup.get<EcalChannelStatusRcd>().get(handle);
-    const EcalChannelStatus* obj = handle.product();
-    std::cout << "channel status pointer is: " << obj << std::endl;
+    const EcalChannelStatus* obj = &evtSetup.getData(ecalChannelStatusToken_);
+    edm::LogInfo("EcalDBCopy") << "channel status pointer is: " << obj << std::endl;
 
     dbOutput->createNewIOV<const EcalChannelStatus>(
         new EcalChannelStatus(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalDQMChannelStatus") {
-    edm::ESHandle<EcalDQMChannelStatus> handle;
-    evtSetup.get<EcalDQMChannelStatusRcd>().get(handle);
-    const EcalDQMChannelStatus* obj = handle.product();
-    std::cout << "DQM channel status pointer is: " << obj << std::endl;
+    const EcalDQMChannelStatus* obj = &evtSetup.getData(ecalDQMChannelStatusToken_);
+    edm::LogInfo("EcalDBCopy") << "DQM channel status pointer is: " << obj << std::endl;
     dbOutput->createNewIOV<const EcalDQMChannelStatus>(
         new EcalDQMChannelStatus(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalDQMTowerStatus") {
-    edm::ESHandle<EcalDQMTowerStatus> handle;
-    evtSetup.get<EcalDQMTowerStatusRcd>().get(handle);
-    const EcalDQMTowerStatus* obj = handle.product();
-    std::cout << "DQM Tower status pointer is: " << obj << std::endl;
+    const EcalDQMTowerStatus* obj = &evtSetup.getData(ecalDQMTowerStatusToken_);
+    edm::LogInfo("EcalDBCopy") << "DQM Tower status pointer is: " << obj << std::endl;
     dbOutput->createNewIOV<const EcalDQMTowerStatus>(
         new EcalDQMTowerStatus(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalDCSTowerStatus") {
-    edm::ESHandle<EcalDCSTowerStatus> handle;
-    evtSetup.get<EcalDCSTowerStatusRcd>().get(handle);
-    const EcalDCSTowerStatus* obj = handle.product();
-    std::cout << "channel status pointer is: " << obj << std::endl;
+    const EcalDCSTowerStatus* obj = &evtSetup.getData(ecalDCSTowerStatusToken_);
+    edm::LogInfo("EcalDBCopy") << "channel status pointer is: " << obj << std::endl;
 
     dbOutput->createNewIOV<const EcalDCSTowerStatus>(
         new EcalDCSTowerStatus(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalDAQTowerStatus") {
-    edm::ESHandle<EcalDAQTowerStatus> handle;
-    evtSetup.get<EcalDAQTowerStatusRcd>().get(handle);
-    const EcalDAQTowerStatus* obj = handle.product();
-    std::cout << "DAQ channel status pointer is: " << obj << std::endl;
+    const EcalDAQTowerStatus* obj = &evtSetup.getData(ecalDAQTowerStatusToken_);
+    edm::LogInfo("EcalDBCopy") << "DAQ channel status pointer is: " << obj << std::endl;
 
     dbOutput->createNewIOV<const EcalDAQTowerStatus>(
         new EcalDAQTowerStatus(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalTPGCrystalStatus") {
-    edm::ESHandle<EcalTPGCrystalStatus> handle;
-    evtSetup.get<EcalTPGCrystalStatusRcd>().get(handle);
-    const EcalTPGCrystalStatus* obj = handle.product();
-    std::cout << "TPG channel status pointer is: " << obj << std::endl;
+    const EcalTPGCrystalStatus* obj = &evtSetup.getData(ecalTPGCrystalStatusToken_);
+    edm::LogInfo("EcalDBCopy") << "TPG channel status pointer is: " << obj << std::endl;
 
     dbOutput->createNewIOV<const EcalTPGCrystalStatus>(
         new EcalTPGCrystalStatus(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalTPGTowerStatus") {
-    edm::ESHandle<EcalTPGTowerStatus> handle;
-    evtSetup.get<EcalTPGTowerStatusRcd>().get(handle);
-    const EcalTPGTowerStatus* obj = handle.product();
-    std::cout << "TPG tower status pointer is: " << obj << std::endl;
+    const EcalTPGTowerStatus* obj = &evtSetup.getData(ecalTPGTowerStatusToken_);
+    edm::LogInfo("EcalDBCopy") << "TPG tower status pointer is: " << obj << std::endl;
 
     dbOutput->createNewIOV<const EcalTPGTowerStatus>(
         new EcalTPGTowerStatus(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalIntercalibConstants") {
-    edm::ESHandle<EcalIntercalibConstants> handle;
-    evtSetup.get<EcalIntercalibConstantsRcd>().get(handle);
-    const EcalIntercalibConstants* obj = handle.product();
-    std::cout << "inter pointer is: " << obj << std::endl;
+    const EcalIntercalibConstants* obj = &evtSetup.getData(ecalIntercalibConstantsToken_);
+    edm::LogInfo("EcalDBCopy") << "inter pointer is: " << obj << std::endl;
     dbOutput->createNewIOV<const EcalIntercalibConstants>(
         new EcalIntercalibConstants(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalLinearCorrections") {
-    edm::ESHandle<EcalLinearCorrections> handle;
-    evtSetup.get<EcalLinearCorrectionsRcd>().get(handle);
-    const EcalLinearCorrections* obj = handle.product();
-    std::cout << "inter pointer is: " << obj << std::endl;
+    const EcalLinearCorrections* obj = &evtSetup.getData(ecalLinearCorrectionsToken_);
+    edm::LogInfo("EcalDBCopy") << "inter pointer is: " << obj << std::endl;
     dbOutput->createNewIOV<const EcalLinearCorrections>(
         new EcalLinearCorrections(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalIntercalibConstantsMC") {
-    edm::ESHandle<EcalIntercalibConstantsMC> handle;
-    evtSetup.get<EcalIntercalibConstantsMCRcd>().get(handle);
-    const EcalIntercalibConstantsMC* obj = handle.product();
-    std::cout << "intercalib MC pointer is: " << obj << std::endl;
+    const EcalIntercalibConstantsMC* obj = &evtSetup.getData(ecalIntercalibConstantsMCToken_);
+    edm::LogInfo("EcalDBCopy") << "intercalib MC pointer is: " << obj << std::endl;
     dbOutput->createNewIOV<const EcalIntercalibConstantsMC>(
         new EcalIntercalibConstantsMC(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalIntercalibErrors") {
-    edm::ESHandle<EcalIntercalibErrors> handle;
-    evtSetup.get<EcalIntercalibErrorsRcd>().get(handle);
-    const EcalIntercalibErrors* obj = handle.product();
-    std::cout << "inter pointer is: " << obj << std::endl;
+    const EcalIntercalibErrors* obj = &evtSetup.getData(ecalIntercalibErrorsToken_);
+    edm::LogInfo("EcalDBCopy") << "inter pointer is: " << obj << std::endl;
     dbOutput->createNewIOV<const EcalIntercalibErrors>(
         new EcalIntercalibErrors(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalGainRatios") {
-    edm::ESHandle<EcalGainRatios> handle;
-    evtSetup.get<EcalGainRatiosRcd>().get(handle);
-    const EcalGainRatios* obj = handle.product();
-    std::cout << "gain pointer is: " << obj << std::endl;
+    const EcalGainRatios* obj = &evtSetup.getData(ecalGainRatiosToken_);
+    edm::LogInfo("EcalDBCopy") << "gain pointer is: " << obj << std::endl;
     dbOutput->createNewIOV<const EcalGainRatios>(
         new EcalGainRatios(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalWeightXtalGroups") {
-    edm::ESHandle<EcalWeightXtalGroups> handle;
-    evtSetup.get<EcalWeightXtalGroupsRcd>().get(handle);
-    const EcalWeightXtalGroups* obj = handle.product();
-    std::cout << "weight pointer is: " << obj << std::endl;
+    const EcalWeightXtalGroups* obj = &evtSetup.getData(ecalWeightXtalGroupsToken_);
+    edm::LogInfo("EcalDBCopy") << "weight pointer is: " << obj << std::endl;
     dbOutput->createNewIOV<const EcalWeightXtalGroups>(
         new EcalWeightXtalGroups(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalTBWeights") {
-    edm::ESHandle<EcalTBWeights> handle;
-    evtSetup.get<EcalTBWeightsRcd>().get(handle);
-    const EcalTBWeights* obj = handle.product();
-    std::cout << "tbweight pointer is: " << obj << std::endl;
+    const EcalTBWeights* obj = &evtSetup.getData(ecalTBWeightsToken_);
+    edm::LogInfo("EcalDBCopy") << "tbweight pointer is: " << obj << std::endl;
     dbOutput->createNewIOV<const EcalTBWeights>(
         new EcalTBWeights(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalLaserAlphas") {
-    edm::ESHandle<EcalLaserAlphas> handle;
-    evtSetup.get<EcalLaserAlphasRcd>().get(handle);
-    const EcalLaserAlphas* obj = handle.product();
-    std::cout << "ecalLaserAlpha pointer is: " << obj << std::endl;
+    const EcalLaserAlphas* obj = &evtSetup.getData(ecalLaserAlphasToken_);
+    edm::LogInfo("EcalDBCopy") << "ecalLaserAlpha pointer is: " << obj << std::endl;
     dbOutput->createNewIOV<const EcalLaserAlphas>(
         new EcalLaserAlphas(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalLaserAPDPNRatios") {
-    edm::ESHandle<EcalLaserAPDPNRatios> handle;
-    evtSetup.get<EcalLaserAPDPNRatiosRcd>().get(handle);
-    const EcalLaserAPDPNRatios* obj = handle.product();
-    std::cout << "tbweight pointer is: " << obj << std::endl;
+    const EcalLaserAPDPNRatios* obj = &evtSetup.getData(ecalLaserAPDPNRatiosToken_);
+    edm::LogInfo("EcalDBCopy") << "tbweight pointer is: " << obj << std::endl;
     dbOutput->createNewIOV<const EcalLaserAPDPNRatios>(
         new EcalLaserAPDPNRatios(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalLaserAPDPNRatiosRef") {
-    edm::ESHandle<EcalLaserAPDPNRatiosRef> handle;
-    evtSetup.get<EcalLaserAPDPNRatiosRefRcd>().get(handle);
-    const EcalLaserAPDPNRatiosRef* obj = handle.product();
-    std::cout << "tbweight pointer is: " << obj << std::endl;
+    const EcalLaserAPDPNRatiosRef* obj = &evtSetup.getData(ecalLaserAPDPNRatiosRefToken_);
+    edm::LogInfo("EcalDBCopy") << "tbweight pointer is: " << obj << std::endl;
     dbOutput->createNewIOV<const EcalLaserAPDPNRatiosRef>(
         new EcalLaserAPDPNRatiosRef(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalClusterCrackCorrParameters") {
-    edm::ESHandle<EcalClusterCrackCorrParameters> handle;
-    evtSetup.get<EcalClusterCrackCorrParametersRcd>().get(handle);
-    const EcalClusterCrackCorrParameters* obj = handle.product();
-    std::cout << "cluster crack pointer is: " << obj << std::endl;
+    const EcalClusterCrackCorrParameters* obj = &evtSetup.getData(ecalClusterCrackCorrParametersToken_);
+    edm::LogInfo("EcalDBCopy") << "cluster crack pointer is: " << obj << std::endl;
     dbOutput->createNewIOV<const EcalClusterCrackCorrParameters>(
         new EcalClusterCrackCorrParameters(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalPFRecHitThresholds") {
-    edm::ESHandle<EcalPFRecHitThresholds> handle;
-    evtSetup.get<EcalPFRecHitThresholdsRcd>().get(handle);
-    const EcalPFRecHitThresholds* obj = handle.product();
-    std::cout << "Ecal PF rec hit thresholds pointer is: " << obj << std::endl;
+    const EcalPFRecHitThresholds* obj = &evtSetup.getData(ecalPFRecHitThresholdsToken_);
+    edm::LogInfo("EcalDBCopy") << "Ecal PF rec hit thresholds pointer is: " << obj << std::endl;
     dbOutput->createNewIOV<const EcalPFRecHitThresholds>(
         new EcalPFRecHitThresholds(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalClusterEnergyUncertaintyParameters") {
-    edm::ESHandle<EcalClusterEnergyUncertaintyParameters> handle;
-    evtSetup.get<EcalClusterEnergyUncertaintyParametersRcd>().get(handle);
-    const EcalClusterEnergyUncertaintyParameters* obj = handle.product();
-    std::cout << "tbweight pointer is: " << obj << std::endl;
+    const EcalClusterEnergyUncertaintyParameters* obj = &evtSetup.getData(ecalClusterEnergyUncertaintyParametersToken_);
+    edm::LogInfo("EcalDBCopy") << "tbweight pointer is: " << obj << std::endl;
     dbOutput->createNewIOV<const EcalClusterEnergyUncertaintyParameters>(
         new EcalClusterEnergyUncertaintyParameters(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalClusterEnergyCorrectionParameters") {
-    edm::ESHandle<EcalClusterEnergyCorrectionParameters> handle;
-    evtSetup.get<EcalClusterEnergyCorrectionParametersRcd>().get(handle);
-    const EcalClusterEnergyCorrectionParameters* obj = handle.product();
-    std::cout << "tbweight pointer is: " << obj << std::endl;
+    const EcalClusterEnergyCorrectionParameters* obj = &evtSetup.getData(ecalClusterEnergyCorrectionParametersToken_);
+    edm::LogInfo("EcalDBCopy") << "tbweight pointer is: " << obj << std::endl;
     dbOutput->createNewIOV<const EcalClusterEnergyCorrectionParameters>(
         new EcalClusterEnergyCorrectionParameters(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalClusterEnergyCorrectionObjectSpecificParameters") {
-    edm::ESHandle<EcalClusterEnergyCorrectionObjectSpecificParameters> handle;
-    evtSetup.get<EcalClusterEnergyCorrectionObjectSpecificParametersRcd>().get(handle);
-    const EcalClusterEnergyCorrectionObjectSpecificParameters* obj = handle.product();
-    std::cout << "tbweight pointer is: " << obj << std::endl;
+    const EcalClusterEnergyCorrectionObjectSpecificParameters* obj =
+        &evtSetup.getData(ecalClusterEnergyCorrectionObjectSpecificParametersToken_);
+    edm::LogInfo("EcalDBCopy") << "tbweight pointer is: " << obj << std::endl;
     dbOutput->createNewIOV<const EcalClusterEnergyCorrectionObjectSpecificParameters>(
         new EcalClusterEnergyCorrectionObjectSpecificParameters(*obj),
         dbOutput->beginOfTime(),
@@ -418,65 +370,49 @@ void EcalDBCopy::copyToDB(const edm::EventSetup& evtSetup, std::string container
         recordName);
 
   } else if (container == "EcalClusterLocalContCorrParameters") {
-    edm::ESHandle<EcalClusterLocalContCorrParameters> handle;
-    evtSetup.get<EcalClusterLocalContCorrParametersRcd>().get(handle);
-    const EcalClusterLocalContCorrParameters* obj = handle.product();
-    std::cout << "tbweight pointer is: " << obj << std::endl;
+    const EcalClusterLocalContCorrParameters* obj = &evtSetup.getData(ecalClusterLocalContCorrParametersToken_);
+    edm::LogInfo("EcalDBCopy") << "tbweight pointer is: " << obj << std::endl;
     dbOutput->createNewIOV<const EcalClusterLocalContCorrParameters>(
         new EcalClusterLocalContCorrParameters(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EBAlignment") {
-    edm::ESHandle<Alignments> handle;
-    evtSetup.get<EBAlignmentRcd>().get(handle);
-    const Alignments* obj = handle.product();
-    std::cout << "EB alignment pointer is: " << obj << std::endl;
+    const Alignments* obj = &evtSetup.getData(ebAlignmentToken_);
+    edm::LogInfo("EcalDBCopy") << "EB alignment pointer is: " << obj << std::endl;
     dbOutput->createNewIOV<const Alignments>(
         new Alignments(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EEAlignment") {
-    edm::ESHandle<Alignments> handle;
-    evtSetup.get<EEAlignmentRcd>().get(handle);
-    const Alignments* obj = handle.product();
-    std::cout << "EE alignment pointer is: " << obj << std::endl;
+    const Alignments* obj = &evtSetup.getData(eeAlignmentToken_);
+    edm::LogInfo("EcalDBCopy") << "EE alignment pointer is: " << obj << std::endl;
     dbOutput->createNewIOV<const Alignments>(
         new Alignments(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "ESAlignment") {
-    edm::ESHandle<Alignments> handle;
-    evtSetup.get<ESAlignmentRcd>().get(handle);
-    const Alignments* obj = handle.product();
-    std::cout << "ES alignment pointer is: " << obj << std::endl;
+    const Alignments* obj = &evtSetup.getData(esAlignmentToken_);
+    edm::LogInfo("EcalDBCopy") << "ES alignment pointer is: " << obj << std::endl;
     dbOutput->createNewIOV<const Alignments>(
         new Alignments(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalTimeOffsetConstant") {
-    edm::ESHandle<EcalTimeOffsetConstant> handle;
-    evtSetup.get<EcalTimeOffsetConstantRcd>().get(handle);
-    const EcalTimeOffsetConstant* obj = handle.product();
-    std::cout << "TimeOffset pointer is: " << obj << std::endl;
+    const EcalTimeOffsetConstant* obj = &evtSetup.getData(ecalTimeOffsetConstantToken_);
+    edm::LogInfo("EcalDBCopy") << "TimeOffset pointer is: " << obj << std::endl;
     dbOutput->createNewIOV<const EcalTimeOffsetConstant>(
         new EcalTimeOffsetConstant(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalSampleMask") {
-    edm::ESHandle<EcalSampleMask> handle;
-    evtSetup.get<EcalSampleMaskRcd>().get(handle);
-    const EcalSampleMask* obj = handle.product();
-    std::cout << "sample mask pointer is: " << obj << std::endl;
+    const EcalSampleMask* obj = &evtSetup.getData(ecalSampleMaskToken_);
+    edm::LogInfo("EcalDBCopy") << "sample mask pointer is: " << obj << std::endl;
     dbOutput->createNewIOV<const EcalSampleMask>(
         new EcalSampleMask(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalSimPulseShape") {
-    edm::ESHandle<EcalSimPulseShape> handle;
-    evtSetup.get<EcalSimPulseShapeRcd>().get(handle);
-    const EcalSimPulseShape* obj = handle.product();
+    const EcalSimPulseShape* obj = &evtSetup.getData(ecalSimPulseShapeToken_);
     dbOutput->createNewIOV<const EcalSimPulseShape>(
         new EcalSimPulseShape(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
 
   } else if (container == "EcalTimeBiasCorrections") {
-    edm::ESHandle<EcalTimeBiasCorrections> handle;
-    evtSetup.get<EcalTimeBiasCorrectionsRcd>().get(handle);
-    const EcalTimeBiasCorrections* obj = handle.product();
-    std::cout << "TimeBiasCorrections pointer is: " << obj << std::endl;
+    const EcalTimeBiasCorrections* obj = &evtSetup.getData(ecalTimeBiasCorrectionsToken_);
+    edm::LogInfo("EcalDBCopy") << "TimeBiasCorrections pointer is: " << obj << std::endl;
     EcalTimeBiasCorrections* bias_;
     bias_ = new EcalTimeBiasCorrections();
     std::vector<float> vect = obj->EBTimeCorrAmplitudeBins;
@@ -490,10 +426,8 @@ void EcalDBCopy::copyToDB(const edm::EventSetup& evtSetup, std::string container
     dbOutput->writeOne(bias_, dbOutput->beginOfTime(), "EcalTimeBiasCorrectionsRcd");
 
   } else if (container == "EcalSamplesCorrelation") {
-    edm::ESHandle<EcalSamplesCorrelation> handle;
-    evtSetup.get<EcalSamplesCorrelationRcd>().get(handle);
-    const EcalSamplesCorrelation* obj = handle.product();
-    std::cout << "SamplesCorrelation pointer is: " << obj << std::endl;
+    const EcalSamplesCorrelation* obj = &evtSetup.getData(ecalSamplesCorrelationToken_);
+    edm::LogInfo("EcalDBCopy") << "SamplesCorrelation pointer is: " << obj << std::endl;
     EcalSamplesCorrelation* correl_;
     correl_ = new EcalSamplesCorrelation();
     std::vector<double> vect = obj->EBG12SamplesCorrelation;
@@ -514,5 +448,5 @@ void EcalDBCopy::copyToDB(const edm::EventSetup& evtSetup, std::string container
     throw cms::Exception("Unknown container");
   }
 
-  std::cout << "EcalDBCopy wrote " << recordName << std::endl;
+  edm::LogInfo("EcalDBCopy") << "EcalDBCopy wrote " << recordName << std::endl;
 }

--- a/CondTools/Ecal/src/EcalPFRecHitThresholdsMaker.cc
+++ b/CondTools/Ecal/src/EcalPFRecHitThresholdsMaker.cc
@@ -1,102 +1,27 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
-
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-
 #include "FWCore/Framework/interface/Event.h"
-
 #include "CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbService.h"
 #include "CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbRecord.h"
-
 #include "CondTools/Ecal/interface/EcalPFRecHitThresholdsMaker.h"
-#include "CondFormats/EcalObjects/interface/EcalPedestals.h"
-#include "CondFormats/DataRecord/interface/EcalPedestalsRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalADCToGeVConstant.h"
-#include "CondFormats/DataRecord/interface/EcalADCToGeVConstantRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalTimeCalibConstants.h"
-#include "CondFormats/DataRecord/interface/EcalTimeCalibConstantsRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalChannelStatus.h"
-#include "CondFormats/DataRecord/interface/EcalChannelStatusRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalLinearCorrections.h"
-#include "CondFormats/DataRecord/interface/EcalLinearCorrectionsRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalIntercalibConstants.h"
-#include "CondFormats/DataRecord/interface/EcalIntercalibConstantsRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalIntercalibConstantsMC.h"
-#include "CondFormats/DataRecord/interface/EcalIntercalibConstantsMCRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalIntercalibErrors.h"
-#include "CondFormats/DataRecord/interface/EcalIntercalibErrorsRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalGainRatios.h"
-#include "CondFormats/DataRecord/interface/EcalGainRatiosRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalWeightXtalGroups.h"
-#include "CondFormats/DataRecord/interface/EcalWeightXtalGroupsRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalTBWeights.h"
-#include "CondFormats/DataRecord/interface/EcalTBWeightsRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalLaserAlphas.h"
-#include "CondFormats/DataRecord/interface/EcalLaserAlphasRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalLaserAPDPNRatios.h"
-#include "CondFormats/DataRecord/interface/EcalLaserAPDPNRatiosRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalLaserAPDPNRatiosRef.h"
-#include "CondFormats/DataRecord/interface/EcalLaserAPDPNRatiosRefRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalTPGCrystalStatus.h"
-#include "CondFormats/DataRecord/interface/EcalTPGCrystalStatusRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalTPGTowerStatus.h"
-#include "CondFormats/DataRecord/interface/EcalTPGTowerStatusRcd.h"
-
-#include "CondFormats/EcalObjects/interface/EcalDCSTowerStatus.h"
-#include "CondFormats/DataRecord/interface/EcalDCSTowerStatusRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalDAQTowerStatus.h"
-#include "CondFormats/DataRecord/interface/EcalDAQTowerStatusRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalDQMTowerStatus.h"
-#include "CondFormats/DataRecord/interface/EcalDQMTowerStatusRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalDQMChannelStatus.h"
-#include "CondFormats/DataRecord/interface/EcalDQMChannelStatusRcd.h"
-
-#include "CondFormats/EcalObjects/interface/EcalClusterCrackCorrParameters.h"
-#include "CondFormats/DataRecord/interface/EcalClusterCrackCorrParametersRcd.h"
-
 #include "CondFormats/EcalObjects/interface/EcalPFRecHitThresholds.h"
 #include "CondFormats/DataRecord/interface/EcalPFRecHitThresholdsRcd.h"
-
-#include "CondFormats/EcalObjects/interface/EcalClusterEnergyCorrectionParameters.h"
-#include "CondFormats/DataRecord/interface/EcalClusterEnergyCorrectionParametersRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalClusterEnergyUncertaintyParameters.h"
-#include "CondFormats/DataRecord/interface/EcalClusterEnergyUncertaintyParametersRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalClusterEnergyCorrectionObjectSpecificParameters.h"
-#include "CondFormats/DataRecord/interface/EcalClusterEnergyCorrectionObjectSpecificParametersRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalClusterLocalContCorrParameters.h"
-#include "CondFormats/DataRecord/interface/EcalClusterLocalContCorrParametersRcd.h"
-
-#include "CondFormats/Alignment/interface/Alignments.h"
-#include "CondFormats/AlignmentRecord/interface/EBAlignmentRcd.h"
-#include "CondFormats/AlignmentRecord/interface/EEAlignmentRcd.h"
-#include "CondFormats/AlignmentRecord/interface/ESAlignmentRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalTimeOffsetConstant.h"
-#include "CondFormats/DataRecord/interface/EcalTimeOffsetConstantRcd.h"
-
-#include "CondFormats/EcalObjects/interface/EcalSampleMask.h"
-#include "CondFormats/DataRecord/interface/EcalSampleMaskRcd.h"
-
-#include "CondFormats/EcalObjects/interface/EcalTimeBiasCorrections.h"
-#include "CondFormats/DataRecord/interface/EcalTimeBiasCorrectionsRcd.h"
-
-#include "CondFormats/EcalObjects/interface/EcalSamplesCorrelation.h"
-#include "CondFormats/DataRecord/interface/EcalSamplesCorrelationRcd.h"
-
-#include "DataFormats/Provenance/interface/Timestamp.h"
-
-#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
+#include "CondFormats/DataRecord/interface/EcalPedestalsRcd.h"
+#include "CondFormats/DataRecord/interface/EcalIntercalibConstantsRcd.h"
+#include "CondFormats/EcalObjects/interface/EcalADCToGeVConstant.h"
+#include "CondFormats/DataRecord/interface/EcalADCToGeVConstantRcd.h"
 
 #include <vector>
 
 EcalPFRecHitThresholdsMaker::EcalPFRecHitThresholdsMaker(const edm::ParameterSet& iConfig)
-    : m_timetype(iConfig.getParameter<std::string>("timetype")) {
-  std::string container;
-  std::string tag;
-  std::string record;
-
+    : m_timetype(iConfig.getParameter<std::string>("timetype")),
+      ecalPedestalsToken_(esConsumes()),
+      ecalADCToGeVConstantToken_(esConsumes()),
+      ecalIntercalibConstantsToken_(esConsumes()),
+      ecalLaserDbServiceToken_(esConsumes()) {
   m_nsigma = iConfig.getParameter<double>("NSigma");
 }
 
@@ -108,23 +33,16 @@ void EcalPFRecHitThresholdsMaker::analyze(const edm::Event& evt, const edm::Even
     throw cms::Exception("PoolDBOutputService is not available");
   }
 
-  edm::ESHandle<EcalPedestals> handle1;
-  evtSetup.get<EcalPedestalsRcd>().get(handle1);
-  const EcalPedestals* ped_db = handle1.product();
-  std::cout << "ped pointer is: " << ped_db << std::endl;
+  const EcalPedestals* ped_db = &evtSetup.getData(ecalPedestalsToken_);
+  edm::LogInfo("EcalPFRecHitThresholdsMaker") << "ped pointer is: " << ped_db << std::endl;
 
-  edm::ESHandle<EcalADCToGeVConstant> handle2;
-  evtSetup.get<EcalADCToGeVConstantRcd>().get(handle2);
-  const EcalADCToGeVConstant* adc_db = handle2.product();
-  std::cout << "adc pointer is: " << adc_db << std::endl;
+  const EcalADCToGeVConstant* adc_db = &evtSetup.getData(ecalADCToGeVConstantToken_);
+  edm::LogInfo("EcalPFRecHitThresholdsMaker") << "adc pointer is: " << adc_db << std::endl;
 
-  edm::ESHandle<EcalIntercalibConstants> handle3;
-  evtSetup.get<EcalIntercalibConstantsRcd>().get(handle3);
-  const EcalIntercalibConstants* ical_db = handle3.product();
-  std::cout << "inter pointer is: " << ical_db << std::endl;
+  const EcalIntercalibConstants* ical_db = &evtSetup.getData(ecalIntercalibConstantsToken_);
+  edm::LogInfo("EcalPFRecHitThresholdsMaker") << "inter pointer is: " << ical_db << std::endl;
 
-  edm::ESHandle<EcalLaserDbService> laser;
-  evtSetup.get<EcalLaserDbRecord>().get(laser);
+  const auto laser = evtSetup.getHandle(ecalLaserDbServiceToken_);
 
   EcalPFRecHitThresholds* pfthresh = new EcalPFRecHitThresholds();
 
@@ -155,7 +73,7 @@ void EcalPFRecHitThresholdsMaker::analyze(const edm::Event& evt, const edm::Even
         EcalPFRecHitThreshold thresh = aped.rms_x12 * calib * adc_EB * lasercalib * m_nsigma;
 
         if (iPhi == 100)
-          std::cout << "Thresh(GeV)=" << thresh << std::endl;
+          edm::LogInfo("EcalPFRecHitThresholdsMaker") << "Thresh(GeV)=" << thresh << std::endl;
 
         pfthresh->insert(std::make_pair(ebdetid.rawId(), thresh));
       }
@@ -198,7 +116,7 @@ void EcalPFRecHitThresholdsMaker::analyze(const edm::Event& evt, const edm::Even
         pfthresh->insert(std::make_pair(eedetid.rawId(), thresh));
 
         if (iX == 50)
-          std::cout << "Thresh(GeV)=" << thresh << std::endl;
+          edm::LogInfo("EcalPFRecHitThresholdsMaker") << "Thresh(GeV)=" << thresh << std::endl;
       }
     }
   }
@@ -206,5 +124,5 @@ void EcalPFRecHitThresholdsMaker::analyze(const edm::Event& evt, const edm::Even
   dbOutput->createNewIOV<const EcalPFRecHitThresholds>(
       pfthresh, dbOutput->beginOfTime(), dbOutput->endOfTime(), "EcalPFRecHitThresholdsRcd");
 
-  std::cout << "EcalPFRecHitThresholdsMaker wrote it " << std::endl;
+  edm::LogInfo("EcalPFRecHitThresholdsMaker") << "EcalPFRecHitThresholdsMaker wrote it " << std::endl;
 }


### PR DESCRIPTION
#### PR description:
Part of #31061. Migrates modules of ```CondTools/Ecal``` to use esConsumes. 

#### PR validation:
Code compiles and scram checker doesn't show the EventSetup get warnings.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
NA.