### PR TITLE
fix undefined behavior in `MultiTrackValidator`

### DIFF
--- a/Validation/RecoTrack/plugins/MultiTrackValidator.cc
+++ b/Validation/RecoTrack/plugins/MultiTrackValidator.cc
@@ -483,6 +483,9 @@ size_t MultiTrackValidator::tpDR(const TrackingParticleRefVector& tPCeff,
                                  DynArray<float>& dR_tPCeff,
                                  DynArray<float>& dR_tPCeff_jet,
                                  const edm::View<reco::Candidate>* cores) const {
+  if (tPCeff.empty()) {
+    return 0;
+  }
   float etaL[tPCeff.size()], phiL[tPCeff.size()];
   size_t n_selTP_dr = 0;
   for (size_t iTP : selected_tPCeff) {
@@ -532,6 +535,9 @@ void MultiTrackValidator::trackDR(const edm::View<reco::Track>& trackCollection,
                                   DynArray<float>& dR_trk,
                                   DynArray<float>& dR_trk_jet,
                                   const edm::View<reco::Candidate>* cores) const {
+  if (trackCollectionDr.empty()) {
+    return;
+  }
   int i = 0;
   float etaL[trackCollectionDr.size()];
   float phiL[trackCollectionDr.size()];


### PR DESCRIPTION
#### PR description:

Aim of this PR is to fix the undefined behavior reported at https://github.com/cms-sw/cmssw/issues/35037.
When the input track collection is empty, just return instead of creating arrays of size 0.

#### PR validation:

Run workflow 11603.0 with this branch on top of `CMSSW_12_1_UBSAN_X_2021-08-27-2300` and didn't observe runtime errors linked to  `MultiTrackValidator`.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A 

Cc:
@vberta @mtosi FYI
