### PR TITLE
Adding protections to PATTriggerProducer when the path has zero filters: 12_0

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATTriggerProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerProducer.cc
@@ -469,16 +469,22 @@ void PATTriggerProducer::produce(Event& iEvent, const EventSetup& iSetup) {
       for (size_t indexPath = 0; indexPath < sizePaths; ++indexPath) {
         const std::string& namePath = pathNames.at(indexPath);
         unsigned indexLastFilterPathModules(handleTriggerResults->index(indexPath) + 1);
-        while (indexLastFilterPathModules > 0) {
-          --indexLastFilterPathModules;
-          const std::string& labelLastFilterPathModules(hltConfig.moduleLabel(indexPath, indexLastFilterPathModules));
-          unsigned indexLastFilterFilters =
-              handleTriggerEvent->filterIndex(InputTag(labelLastFilterPathModules, "", nameProcess_));
-          if (indexLastFilterFilters < sizeFilters) {
-            if (hltConfig.moduleType(labelLastFilterPathModules) == "HLTBool")
-              continue;
-            break;
+        const unsigned sizeModulesPath(hltConfig.size(indexPath));
+        //protection for paths with zero filters (needed for reco, digi, etc paths)
+        if (sizeModulesPath != 0) {
+          while (indexLastFilterPathModules > 0) {
+            --indexLastFilterPathModules;
+            const std::string& labelLastFilterPathModules(hltConfig.moduleLabel(indexPath, indexLastFilterPathModules));
+            unsigned indexLastFilterFilters =
+                handleTriggerEvent->filterIndex(InputTag(labelLastFilterPathModules, "", nameProcess_));
+            if (indexLastFilterFilters < sizeFilters) {
+              if (hltConfig.moduleType(labelLastFilterPathModules) == "HLTBool")
+                continue;
+              break;
+            }
           }
+        } else {
+          indexLastFilterPathModules = 0;
         }
         TriggerPath triggerPath(namePath,
                                 indexPath,
@@ -489,8 +495,8 @@ void PATTriggerProducer::produce(Event& iEvent, const EventSetup& iSetup) {
                                 indexLastFilterPathModules,
                                 hltConfig.saveTagsModules(namePath).size());
         // add module names to path and states' map
-        const unsigned sizeModulesPath(hltConfig.size(indexPath));
-        assert(indexLastFilterPathModules < sizeModulesPath);
+
+        assert(indexLastFilterPathModules < sizeModulesPath || sizeModulesPath == 0);
         std::map<unsigned, std::string> indicesModules;
         for (size_t iM = 0; iM < sizeModulesPath; ++iM) {
           const std::string& nameModule(hltConfig.moduleLabel(indexPath, iM));


### PR DESCRIPTION
#### PR description:

This is the back port of https://github.com/cms-sw/cmssw/pull/35043 which is a bug fix to prevent a seg fault in a particular way of running pat trigger producer on a particularly produced sample.

It would be great if this was backported to 12_0 as it users may well be using it there as well.

#### PR validation:

validated as part of  https://github.com/cms-sw/cmssw/pull/35043


