### PR TITLE
PPS: fix of isPixelHit

### DIFF
--- a/CalibPPS/ESProducers/plugins/PPSPixelTopologyESSource.cc
+++ b/CalibPPS/ESProducers/plugins/PPSPixelTopologyESSource.cc
@@ -24,6 +24,7 @@
 
 #include "CondFormats/PPSObjects/interface/PPSPixelTopology.h"
 #include "CondFormats/DataRecord/interface/PPSPixelTopologyRcd.h"
+#include "FWCore/Utilities/interface/Exception.h"
 
 #include <memory>
 
@@ -81,6 +82,10 @@ PPSPixelTopologyESSource::PPSPixelTopologyESSource(const edm::ParameterSet& iCon
       dead_edge_width_(0.),
       active_edge_sigma_(0.),
       phys_active_edge_dist_(0.) {
+  // validate input
+  if (runType_ != "Run2" && runType_ != "Run3")
+    throw cms::Exception("PPS") << runType_ << " is not valid runType.";
+
   setPPSPixelTopology(iConfig);
   setWhatProduced(this);
   findingRecord<PPSPixelTopologyRcd>();

--- a/CalibPPS/ESProducers/plugins/PPSPixelTopologyESSource.cc
+++ b/CalibPPS/ESProducers/plugins/PPSPixelTopologyESSource.cc
@@ -82,11 +82,12 @@ PPSPixelTopologyESSource::PPSPixelTopologyESSource(const edm::ParameterSet& iCon
       dead_edge_width_(0.),
       active_edge_sigma_(0.),
       phys_active_edge_dist_(0.) {
+  setPPSPixelTopology(iConfig);
+
   // validate input
   if (runType_ != "Run2" && runType_ != "Run3")
     throw cms::Exception("PPS") << runType_ << " is not valid runType.";
 
-  setPPSPixelTopology(iConfig);
   setWhatProduced(this);
   findingRecord<PPSPixelTopologyRcd>();
 }

--- a/CondFormats/PPSObjects/src/PPSPixelTopology.cc
+++ b/CondFormats/PPSObjects/src/PPSPixelTopology.cc
@@ -28,16 +28,17 @@ unsigned short PPSPixelTopology::pixelIndex(PixelInfo pI) const {
 
 bool PPSPixelTopology::isPixelHit(float xLocalCoordinate, float yLocalCoordinate, bool is3x2 = true) const {
   // check hit fiducial boundaries
-  double xModuleSize = 2 * ((no_of_pixels_simX_ / 2. + 1) * pitch_simX_ + dead_edge_width_);
+  const double xModuleSize = 2 * ((no_of_pixels_simX_ / 2. + 1) * pitch_simX_ + dead_edge_width_);
   if (xLocalCoordinate < -xModuleSize / 2. || xLocalCoordinate > xModuleSize / 2.)
     return false;
 
-  double yModuleSize = (no_of_pixels_simY_ + 4.) * pitch_simY_ + 2. * dead_edge_width_;
-  double y2x2top = no_of_pixels_simY_ / 6. * pitch_simY_ + dead_edge_width_;
+  const double yModuleSize = (no_of_pixels_simY_ + 4.) * pitch_simY_ + 2. * dead_edge_width_;
+  const double y2x2top = no_of_pixels_simY_ / 6. * pitch_simY_ + dead_edge_width_;
   if (is3x2 && (yLocalCoordinate < -yModuleSize / 2. || yLocalCoordinate > yModuleSize / 2.))
     return false;
-
-  if (!is3x2 && (yLocalCoordinate < -yModuleSize / 2. || yLocalCoordinate > y2x2top))
+  if (!is3x2 && (runType_=="Run2") && (yLocalCoordinate < -yModuleSize / 2. || yLocalCoordinate > y2x2top))
+    return false;
+  if (!is3x2 && (runType_=="Run3") && (yLocalCoordinate < -yModuleSize / 2. || yLocalCoordinate > yModuleSize / 2.))
     return false;
 
   return true;

--- a/CondFormats/PPSObjects/src/PPSPixelTopology.cc
+++ b/CondFormats/PPSObjects/src/PPSPixelTopology.cc
@@ -36,9 +36,9 @@ bool PPSPixelTopology::isPixelHit(float xLocalCoordinate, float yLocalCoordinate
   const double y2x2top = no_of_pixels_simY_ / 6. * pitch_simY_ + dead_edge_width_;
   if (is3x2 && (yLocalCoordinate < -yModuleSize / 2. || yLocalCoordinate > yModuleSize / 2.))
     return false;
-  if (!is3x2 && (runType_=="Run2") && (yLocalCoordinate < -yModuleSize / 2. || yLocalCoordinate > y2x2top))
+  if (!is3x2 && (runType_ == "Run2") && (yLocalCoordinate < -yModuleSize / 2. || yLocalCoordinate > y2x2top))
     return false;
-  if (!is3x2 && (runType_=="Run3") && (yLocalCoordinate < -yModuleSize / 2. || yLocalCoordinate > yModuleSize / 2.))
+  if (!is3x2 && (runType_ == "Run3") && (yLocalCoordinate < -yModuleSize / 2. || yLocalCoordinate > yModuleSize / 2.))
     return false;
 
   return true;


### PR DESCRIPTION
#### PR description:

This PR contains a fix of the `PPSPixelTopology::isPixelHit` method (by @fabferro ), rectifying the logic relevant for Run3 (and 2x2 sensors). The problem affected (mostly) the direct simulation of PPS pixel RPs, where the simulated hit distribution was too narrow in the horizontal direction.

#### PR validation:

The following plots show a comparison before (blue) and after this PR (red dashed) for:
  * Run2 reco workflow: [reco_cmp.pdf](https://github.com/cms-sw/cmssw/files/7084752/reco_cmp.pdf) - no change as expected
  * direct simulation workflow: [dirsim_cmp.pdf](https://github.com/cms-sw/cmssw/files/7084756/dirsim_cmp.pdf) - no change for Run2, for Run3/2021 the x distribution extends to significantly larger values - as expected.

[hit_dist_cmp.pdf](https://github.com/cms-sw/cmssw/files/7084769/hit_dist_cmp.pdf) compares hit distributions at several RPs - left column (before), right (after). From the rhs column one can deduce the horizontal size of the sensors of about 16 mm which agrees with the design.


