### PR TITLE
Removed lexical_cast boost dependency in CondFormats

### DIFF
--- a/CondFormats/MFObjects/src/MagFieldConfig.cc
+++ b/CondFormats/MFObjects/src/MagFieldConfig.cc
@@ -12,7 +12,6 @@
 
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
-#include <boost/lexical_cast.hpp>
 
 using namespace std;
 using namespace magneticfield;
@@ -81,8 +80,8 @@ vector<unsigned> MagFieldConfig::expandList(const string& list) {
   for (vstring::const_iterator i = v1.begin(); i != v1.end(); ++i) {
     vstring v2;
     boost::split(v2, *i, boost::is_any_of("-"));
-    unsigned start = boost::lexical_cast<unsigned>(v2.front());
-    unsigned end = boost::lexical_cast<unsigned>(v2.back());
+    unsigned start = std::stoul(v2.front());
+    unsigned end = std::stoul(v2.back());
     if ((v2.size() > 2) || (start > end)) {
       throw cms::Exception("ConfigurationError")
           << "VolumeBasedMagneticFieldESProducerFromDB: malformed configuration" << list << endl;

--- a/CondFormats/Serialization/interface/eos/portable_archive_exception.hpp
+++ b/CondFormats/Serialization/interface/eos/portable_archive_exception.hpp
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include <boost/lexical_cast.hpp>
 #include <boost/archive/basic_archive.hpp>
 #include <boost/archive/archive_exception.hpp>
 
@@ -75,7 +74,7 @@ namespace eos {
     template <typename T>
     portable_archive_exception(const T& abnormal)
         : boost::archive::archive_exception(other_exception), msg("serialization of illegal floating point value: ") {
-      msg += boost::lexical_cast<std::string>(abnormal);
+      msg += std::to_string(abnormal);
     }
 
     //! override the base class function with our message

--- a/CondFormats/SiStripObjects/src/SiStripDetSummary.cc
+++ b/CondFormats/SiStripObjects/src/SiStripDetSummary.cc
@@ -34,7 +34,6 @@ void SiStripDetSummary::add(DetId detid, float value) {
       break;
   }
   detNum += layer * 10 + stereo;
-  // string name( detector + std::to_string(layer) + std::to_string(stereo) );
   valueMap_[detNum].mean += value;
   valueMap_[detNum].rms += value * value;
   valueMap_[detNum].count += 1;

--- a/CondFormats/SiStripObjects/src/SiStripDetSummary.cc
+++ b/CondFormats/SiStripObjects/src/SiStripDetSummary.cc
@@ -34,7 +34,7 @@ void SiStripDetSummary::add(DetId detid, float value) {
       break;
   }
   detNum += layer * 10 + stereo;
-  // string name( detector + boost::lexical_cast<string>(layer) + boost::lexical_cast<string>(stereo) );
+  // string name( detector + std::to_string(layer) + std::to_string(stereo) );
   valueMap_[detNum].mean += value;
   valueMap_[detNum].rms += value * value;
   valueMap_[detNum].count += 1;


### PR DESCRIPTION
#### PR description:

Remove boost lexical cast dependency in CondFormats with corresponding stl alternatives
#### PR validation:

passed runTheMatrix

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
@davidlange6 @vgvassilev
