### PR TITLE
Fix 2021 Reco Geometry Config files

### DIFF
--- a/Configuration/Geometry/python/GeometryDD4hepExtended2021FlatMinus05PercentReco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2021FlatMinus05PercentReco_cff.py
@@ -12,7 +12,6 @@ from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi impor
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *
-trackerGeometry.applyAlignment = cms.bool(False)
 
 # calo
 from Geometry.CaloEventSetup.CaloTopology_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2021FlatMinus10PercentReco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2021FlatMinus10PercentReco_cff.py
@@ -12,7 +12,6 @@ from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi impor
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *
-trackerGeometry.applyAlignment = cms.bool(False)
 
 # calo
 from Geometry.CaloEventSetup.CaloTopology_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2021FlatPlus05PercentReco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2021FlatPlus05PercentReco_cff.py
@@ -12,7 +12,6 @@ from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi impor
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *
-trackerGeometry.applyAlignment = cms.bool(False)
 
 # calo
 from Geometry.CaloEventSetup.CaloTopology_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2021FlatPlus10PercentReco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2021FlatPlus10PercentReco_cff.py
@@ -12,7 +12,6 @@ from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi impor
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *
-trackerGeometry.applyAlignment = cms.bool(False)
 
 # calo
 from Geometry.CaloEventSetup.CaloTopology_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2021Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2021Reco_cff.py
@@ -12,7 +12,6 @@ from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi impor
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *
-trackerGeometry.applyAlignment = cms.bool(False)
 
 # calo
 from Geometry.CaloEventSetup.CaloTopology_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2021ZeroMaterialReco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2021ZeroMaterialReco_cff.py
@@ -12,7 +12,6 @@ from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi impor
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *
-trackerGeometry.applyAlignment = cms.bool(False)
 
 # calo
 from Geometry.CaloEventSetup.CaloTopology_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2021FlatMinus05PercentReco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2021FlatMinus05PercentReco_cff.py
@@ -12,7 +12,6 @@ from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi impor
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *
-trackerGeometry.applyAlignment = cms.bool(False)
 
 # calo
 from Geometry.CaloEventSetup.CaloTopology_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2021FlatMinus10PercentReco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2021FlatMinus10PercentReco_cff.py
@@ -12,7 +12,6 @@ from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi impor
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *
-trackerGeometry.applyAlignment = cms.bool(False)
 
 # calo
 from Geometry.CaloEventSetup.CaloTopology_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2021FlatPlus05PercentReco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2021FlatPlus05PercentReco_cff.py
@@ -12,7 +12,6 @@ from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi impor
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *
-trackerGeometry.applyAlignment = cms.bool(False)
 
 # calo
 from Geometry.CaloEventSetup.CaloTopology_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2021FlatPlus10PercentReco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2021FlatPlus10PercentReco_cff.py
@@ -12,7 +12,6 @@ from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi impor
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *
-trackerGeometry.applyAlignment = cms.bool(False)
 
 # calo
 from Geometry.CaloEventSetup.CaloTopology_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2021Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2021Reco_cff.py
@@ -12,7 +12,6 @@ from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi impor
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *
-trackerGeometry.applyAlignment = cms.bool(False)
 
 # calo
 from Geometry.CaloEventSetup.CaloTopology_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2021ZeroMaterialReco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2021ZeroMaterialReco_cff.py
@@ -12,7 +12,6 @@ from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi impor
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *
-trackerGeometry.applyAlignment = cms.bool(False)
 
 # calo
 from Geometry.CaloEventSetup.CaloTopology_cfi import *

--- a/Configuration/Geometry/python/dict2021Geometry.py
+++ b/Configuration/Geometry/python/dict2021Geometry.py
@@ -378,7 +378,6 @@ trackerDict = {
             'from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *',
             'from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *',
             'from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *',
-            'trackerGeometry.applyAlignment = cms.bool(False)',
         ],
     },
     "T2" : {
@@ -581,7 +580,6 @@ trackerDict = {
             'from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *',
             'from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *',
             'from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *',
-            'trackerGeometry.applyAlignment = cms.bool(False)',
         ],
     },
     "T3" : {
@@ -785,7 +783,6 @@ trackerDict = {
             'from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *',
             'from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *',
             'from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *',
-            'trackerGeometry.applyAlignment = cms.bool(False)',
         ],
     },
     "T4" : {
@@ -989,7 +986,6 @@ trackerDict = {
             'from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *',
             'from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *',
             'from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *',
-            'trackerGeometry.applyAlignment = cms.bool(False)',
         ],
     },
     "T5" : {
@@ -1194,7 +1190,6 @@ trackerDict = {
             'from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *',
             'from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *',
             'from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *',
-            'trackerGeometry.applyAlignment = cms.bool(False)',
         ],
     },
     "T6" : {
@@ -1399,7 +1394,6 @@ trackerDict = {
             'from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *',
             'from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *',
             'from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *',
-            'trackerGeometry.applyAlignment = cms.bool(False)',
         ],
     },
     "T7" : {
@@ -1604,7 +1598,6 @@ trackerDict = {
             'from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *',
             'from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *',
             'from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *',
-            'trackerGeometry.applyAlignment = cms.bool(False)',
         ],
     },
     "T8" : {
@@ -1809,7 +1802,6 @@ trackerDict = {
             'from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *',
             'from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *',
             'from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *',
-            'trackerGeometry.applyAlignment = cms.bool(False)',
         ],
     },
 }


### PR DESCRIPTION
#### PR description:
Summarise: https://indico.cern.ch/event/992973/#6-validation-results
As discrepancy shown in DD4hep validation in CMSSW_12_0_0_pre4, we see that there is a configuration that disables the tracker alignment for Run-3, implemented in https://github.com/cms-sw/cmssw/pull/28847. The following line is removed from this PR,
`trackerGeometry.applyAlignment = cms.bool(False)`

#### PR validation:
The private sample has been done. The result shows in slide 6 and 7 of
https://indico.cern.ch/event/992973/#6-validation-results
The agreement between DDD-DB / DD4hep-XML is seen.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
This is not a backport. It is unclear if we should backport for 12_0. To be discussed.
