### PR TITLE
Migrate `CondTools/RunInfo` to esConsumes

### DIFF
--- a/CondTools/RunInfo/interface/BTransitionAnalyzer.h
+++ b/CondTools/RunInfo/interface/BTransitionAnalyzer.h
@@ -17,7 +17,11 @@ namespace cond {
   class BTransitionAnalyzer : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
   public:
     BTransitionAnalyzer(const edm::ParameterSet& pset)
-        : m_currentThreshold(pset.getUntrackedParameter<double>("currentThreshold", 18000.)) {}
+        : m_currentThreshold(pset.getUntrackedParameter<double>("currentThreshold", 18000.)),
+          m_RunInfoToken(esConsumes<edm::Transition::EndRun>()),
+          m_ESToken(esConsumes<edm::Transition::EndRun>()),
+          m_ESTokenB0T(esConsumes<edm::Transition::EndRun>(edm::ESInputTag("", "0T"))),
+          m_ESTokenB38T(esConsumes<edm::Transition::EndRun>(edm::ESInputTag("", "38T"))) {}
 #ifdef __INTEL_COMPILER
     virtual ~BTransitionAnalyzer() = default;
 #endif
@@ -28,9 +32,8 @@ namespace cond {
     void beginRun(edm::Run const&, edm::EventSetup const&) final{};
     void analyze(edm::Event const&, edm::EventSetup const&) final{};
     void endRun(edm::Run const& run, edm::EventSetup const& eventSetup) final {
-      edm::ESHandle<RunInfo> runInfoHandle;
+      edm::ESHandle<RunInfo> runInfoHandle = eventSetup.getHandle(m_RunInfoToken);
       edm::ESHandle<T> payloadHandle, payloadRefHandle;
-      eventSetup.get<RunInfoRcd>().get(runInfoHandle);
       double avg_current = (double)runInfoHandle->m_avg_current;
       double current_default = -1;
       std::string bOnLabel = std::string("38T");
@@ -40,13 +43,16 @@ namespace cond {
                                       << " A for run: " << run.run()
                                       << " with the corresponding threshold: " << m_currentThreshold << " A."
                                       << std::endl;
-      if (avg_current != current_default && avg_current <= m_currentThreshold)
+      if (avg_current != current_default && avg_current <= m_currentThreshold) {
         bFieldLabel = bOffLabel;
+        payloadHandle = eventSetup.getHandle(m_ESTokenB0T);
+      } else {
+        payloadHandle = eventSetup.getHandle(m_ESTokenB38T);
+      }
       edm::LogInfo("BTransitionAnalyzer")
           << "The magnet was " << (bFieldLabel == bOnLabel ? "ON" : "OFF") << " during run " << run.run()
           << ".\nLoading the product for the corrisponding label " << bFieldLabel << std::endl;
-      eventSetup.get<R>().get(bFieldLabel, payloadHandle);
-      eventSetup.get<R>().get(payloadRefHandle);
+      payloadRefHandle = eventSetup.getHandle(m_ESToken);
       edm::Service<cond::service::PoolDBOutputService> mydbservice;
       if (mydbservice.isAvailable()) {
         if (!equalPayloads(payloadHandle, payloadRefHandle)) {
@@ -68,6 +74,10 @@ namespace cond {
 
   private:
     double m_currentThreshold;
+    const edm::ESGetToken<RunInfo, RunInfoRcd> m_RunInfoToken;
+    const edm::ESGetToken<T, R> m_ESToken;
+    const edm::ESGetToken<T, R> m_ESTokenB0T;
+    const edm::ESGetToken<T, R> m_ESTokenB38T;
   };
 }  //namespace cond
 #endif  //BTRANSITIONANALYZER_H

--- a/CondTools/RunInfo/plugins/FillInfoESAnalyzer.cc
+++ b/CondTools/RunInfo/plugins/FillInfoESAnalyzer.cc
@@ -1,8 +1,7 @@
 #include <string>
 #include <iostream>
 #include <map>
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -10,33 +9,39 @@
 #include "CondFormats/DataRecord/interface/FillInfoRcd.h"
 
 namespace edmtest {
-  class FillInfoESAnalyzer : public edm::EDAnalyzer {
+  class FillInfoESAnalyzer : public edm::one::EDAnalyzer<> {
+  private:
+    const edm::ESGetToken<FillInfo, FillInfoRcd> m_FillInfoToken;
+
   public:
-    explicit FillInfoESAnalyzer(edm::ParameterSet const& p) { std::cout << "FillInfoESAnalyzer" << std::endl; }
-    explicit FillInfoESAnalyzer(int i) { std::cout << "FillInfoESAnalyzer " << i << std::endl; }
-    ~FillInfoESAnalyzer() override { std::cout << "~FillInfoESAnalyzer " << std::endl; }
+    explicit FillInfoESAnalyzer(edm::ParameterSet const& p) : m_FillInfoToken(esConsumes()) {
+      edm::LogPrint("FillInfoESAnalyzer") << "FillInfoESAnalyzer" << std::endl;
+    }
+    explicit FillInfoESAnalyzer(int i) {
+      edm::LogPrint("FillInfoESAnalyzer") << "FillInfoESAnalyzer " << i << std::endl;
+    }
+    ~FillInfoESAnalyzer() override { edm::LogPrint("FillInfoESAnalyzer") << "~FillInfoESAnalyzer " << std::endl; }
     void analyze(const edm::Event& e, const edm::EventSetup& c) override;
   };
 
   void FillInfoESAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context) {
-    std::cout << "###FillInfoESAnalyzer::analyze" << std::endl;
-    std::cout << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
-    std::cout << " ---EVENT NUMBER " << e.id().event() << std::endl;
+    edm::LogPrint("FillInfoESAnalyzer") << "###FillInfoESAnalyzer::analyze" << std::endl;
+    edm::LogPrint("FillInfoESAnalyzer") << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
+    edm::LogPrint("FillInfoESAnalyzer") << " ---EVENT NUMBER " << e.id().event() << std::endl;
     edm::eventsetup::EventSetupRecordKey recordKey(
         edm::eventsetup::EventSetupRecordKey::TypeTag::findType("FillInfoRcd"));
     if (recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
       //record not found
-      std::cout << "Record \"FillInfoRcd"
-                << "\" does not exist " << std::endl;
+      edm::LogPrint("FillInfoESAnalyzer") << "Record \"FillInfoRcd"
+                                          << "\" does not exist " << std::endl;
     }
-    edm::ESHandle<FillInfo> sum;
-    std::cout << "got eshandle" << std::endl;
-    context.get<FillInfoRcd>().get(sum);
-    std::cout << "got context" << std::endl;
+    edm::LogPrint("FillInfoESAnalyzer") << "got eshandle" << std::endl;
+    edm::ESHandle<FillInfo> sum = context.getHandle(m_FillInfoToken);
+    edm::LogPrint("FillInfoESAnalyzer") << "got context" << std::endl;
     const FillInfo* summary = sum.product();
-    std::cout << "got FillInfo* " << std::endl;
-    std::cout << "print  result" << std::endl;
-    std::cout << *summary;
+    edm::LogPrint("FillInfoESAnalyzer") << "got FillInfo* " << std::endl;
+    edm::LogPrint("FillInfoESAnalyzer") << "print  result" << std::endl;
+    edm::LogPrint("FillInfoESAnalyzer") << *summary;
   }
   DEFINE_FWK_MODULE(FillInfoESAnalyzer);
 }  // namespace edmtest

--- a/CondTools/RunInfo/plugins/LHCInfoESAnalyzer.cc
+++ b/CondTools/RunInfo/plugins/LHCInfoESAnalyzer.cc
@@ -1,8 +1,7 @@
 #include <string>
 #include <iostream>
 #include <map>
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -10,33 +9,37 @@
 #include "CondFormats/DataRecord/interface/LHCInfoRcd.h"
 
 namespace edmtest {
-  class LHCInfoESAnalyzer : public edm::EDAnalyzer {
+  class LHCInfoESAnalyzer : public edm::one::EDAnalyzer<> {
+  private:
+    const edm::ESGetToken<LHCInfo, LHCInfoRcd> m_LHCInfoToken;
+
   public:
-    explicit LHCInfoESAnalyzer(edm::ParameterSet const& p) { std::cout << "LHCInfoESAnalyzer" << std::endl; }
-    explicit LHCInfoESAnalyzer(int i) { std::cout << "LHCInfoESAnalyzer " << i << std::endl; }
-    ~LHCInfoESAnalyzer() override { std::cout << "~LHCInfoESAnalyzer " << std::endl; }
+    explicit LHCInfoESAnalyzer(edm::ParameterSet const& p) : m_LHCInfoToken(esConsumes()) {
+      edm::LogPrint("LHCInfoESAnalyzer") << "LHCInfoESAnalyzer" << std::endl;
+    }
+    explicit LHCInfoESAnalyzer(int i) { edm::LogPrint("LHCInfoESAnalyzer") << "LHCInfoESAnalyzer " << i << std::endl; }
+    ~LHCInfoESAnalyzer() override { edm::LogPrint("LHCInfoESAnalyzer") << "~LHCInfoESAnalyzer " << std::endl; }
     void analyze(const edm::Event& e, const edm::EventSetup& c) override;
   };
 
   void LHCInfoESAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context) {
-    std::cout << "###LHCInfoESAnalyzer::analyze" << std::endl;
-    std::cout << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
-    std::cout << " ---EVENT NUMBER " << e.id().event() << std::endl;
+    edm::LogPrint("LHCInfoESAnalyzer") << "###LHCInfoESAnalyzer::analyze" << std::endl;
+    edm::LogPrint("LHCInfoESAnalyzer") << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
+    edm::LogPrint("LHCInfoESAnalyzer") << " ---EVENT NUMBER " << e.id().event() << std::endl;
     edm::eventsetup::EventSetupRecordKey recordKey(
         edm::eventsetup::EventSetupRecordKey::TypeTag::findType("LHCInfoRcd"));
     if (recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
       //record not found
-      std::cout << "Record \"LHCInfoRcd"
-                << "\" does not exist " << std::endl;
+      edm::LogPrint("LHCInfoESAnalyzer") << "Record \"LHCInfoRcd"
+                                         << "\" does not exist " << std::endl;
     }
-    edm::ESHandle<LHCInfo> sum;
-    std::cout << "got eshandle" << std::endl;
-    context.get<LHCInfoRcd>().get(sum);
-    std::cout << "got context" << std::endl;
+    edm::LogPrint("LHCInfoESAnalyzer") << "got eshandle" << std::endl;
+    edm::ESHandle<LHCInfo> sum = context.getHandle(m_LHCInfoToken);
+    edm::LogPrint("LHCInfoESAnalyzer") << "got context" << std::endl;
     const LHCInfo* summary = sum.product();
-    std::cout << "got LHCInfo* " << std::endl;
-    std::cout << "print  result" << std::endl;
-    std::cout << *summary;
+    edm::LogPrint("LHCInfoESAnalyzer") << "got LHCInfo* " << std::endl;
+    edm::LogPrint("LHCInfoESAnalyzer") << "print  result" << std::endl;
+    edm::LogPrint("LHCInfoESAnalyzer") << *summary;
   }
   DEFINE_FWK_MODULE(LHCInfoESAnalyzer);
 }  // namespace edmtest

--- a/CondTools/RunInfo/plugins/RunInfoESAnalyzer.cc
+++ b/CondTools/RunInfo/plugins/RunInfoESAnalyzer.cc
@@ -2,75 +2,54 @@
 #include <string>
 #include <iostream>
 #include <map>
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-
 #include "FWCore/Framework/interface/EventSetup.h"
-
 #include "CondFormats/RunInfo/interface/RunInfo.h"
-
 #include "CondFormats/DataRecord/interface/RunSummaryRcd.h"
 
 using namespace std;
 
 namespace edmtest {
-  class RunInfoESAnalyzer : public edm::EDAnalyzer {
-  public:
-    explicit RunInfoESAnalyzer(edm::ParameterSet const& p) { std::cout << "RunInfoESAnalyzer" << std::endl; }
-    explicit RunInfoESAnalyzer(int i) { std::cout << "RunInfoESAnalyzer " << i << std::endl; }
-    ~RunInfoESAnalyzer() override { std::cout << "~RunInfoESAnalyzer " << std::endl; }
-    //     virtual void beginJob();
-    //  virtual void beginRun(const edm::Run&, const edm::EventSetup& context);
-    void analyze(const edm::Event& e, const edm::EventSetup& c) override;
-
+  class RunInfoESAnalyzer : public edm::one::EDAnalyzer<> {
   private:
-  };
+    const edm::ESGetToken<RunInfo, RunInfoRcd> m_RunInfoToken;
 
-  /* void
-  RunInfoESAnalyzer::beginRun(const edm::Run&, const edm::EventSetup& context){
-    std::cout<<"###RunInfoESAnalyzer::beginRun"<<std::endl;
-    edm::ESHandle<RunInfo> RunInfo_lumiarray;
-    std::cout<<"got eshandle"<<std::endl;
-    context.get<RunInfoRcd>().get(RunInfo_lumiarray);
-    std::cout<<"got data"<<std::endl;
-  }
-  
-  void
-  RunInfoESAnalyzer::beginJob(){
-    std::cout<<"###RunInfoESAnalyzer::beginJob"<<std::endl;
-   
-  }
- 
-  */
+  public:
+    explicit RunInfoESAnalyzer(edm::ParameterSet const& p) : m_RunInfoToken(esConsumes()) {
+      edm::LogPrint("RunInfoESAnalyzer") << "RunInfoESAnalyzer" << std::endl;
+    }
+    explicit RunInfoESAnalyzer(int i) { edm::LogPrint("RunInfoESAnalyzer") << "RunInfoESAnalyzer " << i << std::endl; }
+    ~RunInfoESAnalyzer() override { edm::LogPrint("RunInfoESAnalyzer") << "~RunInfoESAnalyzer " << std::endl; }
+    void analyze(const edm::Event& e, const edm::EventSetup& c) override;
+  };
   void RunInfoESAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context) {
     using namespace edm::eventsetup;
-    std::cout << "###RunInfoESAnalyzer::analyze" << std::endl;
+    edm::LogPrint("RunInfoESAnalyzer") << "###RunInfoESAnalyzer::analyze" << std::endl;
 
     // Context is not used.
-    std::cout << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
-    std::cout << " ---EVENT NUMBER " << e.id().event() << std::endl;
+    edm::LogPrint("RunInfoESAnalyzer") << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
+    edm::LogPrint("RunInfoESAnalyzer") << " ---EVENT NUMBER " << e.id().event() << std::endl;
     edm::eventsetup::EventSetupRecordKey recordKey(
         edm::eventsetup::EventSetupRecordKey::TypeTag::findType("RunInfoRcd"));
     if (recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
       //record not found
-      std::cout << "Record \"RunInfoRcd"
-                << "\" does not exist " << std::endl;
+      edm::LogPrint("RunInfoESAnalyzer") << "Record \"RunInfoRcd"
+                                         << "\" does not exist " << std::endl;
     }
-    edm::ESHandle<RunInfo> sum;
-    std::cout << "got eshandle" << std::endl;
-    context.get<RunInfoRcd>().get(sum);
-    std::cout << "got context" << std::endl;
+    edm::LogPrint("RunInfoESAnalyzer") << "got eshandle" << std::endl;
+    edm::ESHandle<RunInfo> sum = context.getHandle(m_RunInfoToken);
+    edm::LogPrint("RunInfoESAnalyzer") << "got context" << std::endl;
     const RunInfo* summary = sum.product();
-    std::cout << "got RunInfo* " << std::endl;
-
-    std::cout << "print  result" << std::endl;
+    edm::LogPrint("RunInfoESAnalyzer") << "got RunInfo* " << std::endl;
+    edm::LogPrint("RunInfoESAnalyzer") << "print  result" << std::endl;
     summary->printAllValues();
-    /*  std::vector<std::string> subdet = summary->getSubdtIn();
-    std::cout<<"subdetector in the run "<< std::endl;
+    /*
+    std::vector<std::string> subdet = summary->getSubdtIn();
+    edm::LogPrint("RunInfoESAnalyzer")<<"subdetector in the run "<< std::endl;
     for (size_t i=0; i<subdet.size(); i++){
-        std::cout<<"--> " << subdet[i] << std::endl;
+      edm::LogPrint("RunInfoESAnalyzer")<<"--> " << subdet[i] << std::endl;
     }
     */
   }

--- a/CondTools/RunInfo/plugins/RunSummaryESAnalyzer.cc
+++ b/CondTools/RunInfo/plugins/RunSummaryESAnalyzer.cc
@@ -2,75 +2,59 @@
 #include <string>
 #include <iostream>
 #include <map>
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-
 #include "FWCore/Framework/interface/EventSetup.h"
-
 #include "CondFormats/RunInfo/interface/RunSummary.h"
-
 #include "CondFormats/DataRecord/interface/RunSummaryRcd.h"
 
 using namespace std;
 
 namespace edmtest {
-  class RunSummaryESAnalyzer : public edm::EDAnalyzer {
+  class RunSummaryESAnalyzer : public edm::one::EDAnalyzer<> {
+  private:
+    const edm::ESGetToken<RunSummary, RunSummaryRcd> m_RunSummaryToken;
+
   public:
-    explicit RunSummaryESAnalyzer(edm::ParameterSet const& p) { std::cout << "RunSummaryESAnalyzer" << std::endl; }
-    explicit RunSummaryESAnalyzer(int i) { std::cout << "RunSummaryESAnalyzer " << i << std::endl; }
-    ~RunSummaryESAnalyzer() override { std::cout << "~RunSummaryESAnalyzer " << std::endl; }
-    // virtual void beginJob();
-    // virtual void beginRun(const edm::Run&, const edm::EventSetup& context);
+    explicit RunSummaryESAnalyzer(edm::ParameterSet const& p) : m_RunSummaryToken(esConsumes()) {
+      edm::LogPrint("RunSummaryESAnalyzer") << "RunSummaryESAnalyzer" << std::endl;
+    }
+    explicit RunSummaryESAnalyzer(int i) {
+      edm::LogPrint("RunSummaryESAnalyzer") << "RunSummaryESAnalyzer " << i << std::endl;
+    }
+    ~RunSummaryESAnalyzer() override { edm::LogPrint("RunSummaryESAnalyzer") << "~RunSummaryESAnalyzer " << std::endl; }
     void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
   private:
   };
 
-  /* void
-  RunSummaryESAnalyzer::beginRun(const edm::Run&, const edm::EventSetup& context){
-    std::cout<<"###RunSummaryESAnalyzer::beginRun"<<std::endl;
-    edm::ESHandle<RunSummary> RunSummary_lumiarray;
-    std::cout<<"got eshandle"<<std::endl;
-    context.get<RunSummaryRcd>().get(RunSummary_lumiarray);
-    std::cout<<"got data"<<std::endl;
-  }
-  
-  void
-  RunSummaryESAnalyzer::beginJob(){
-    std::cout<<"###RunSummaryESAnalyzer::beginJob"<<std::endl;
-   
-  }
- 
-  */
   void RunSummaryESAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context) {
     using namespace edm::eventsetup;
-    std::cout << "###RunSummaryESAnalyzer::analyze" << std::endl;
+    edm::LogPrint("RunSummaryESAnalyzer") << "###RunSummaryESAnalyzer::analyze" << std::endl;
 
     // Context is not used.
-    std::cout << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
-    std::cout << " ---EVENT NUMBER " << e.id().event() << std::endl;
+    edm::LogPrint("RunSummaryESAnalyzer") << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
+    edm::LogPrint("RunSummaryESAnalyzer") << " ---EVENT NUMBER " << e.id().event() << std::endl;
     edm::eventsetup::EventSetupRecordKey recordKey(
         edm::eventsetup::EventSetupRecordKey::TypeTag::findType("RunSummaryRcd"));
     if (recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
       //record not found
-      std::cout << "Record \"RunSummaryRcd"
-                << "\" does not exist " << std::endl;
+      edm::LogPrint("RunSummaryESAnalyzer") << "Record \"RunSummaryRcd"
+                                            << "\" does not exist " << std::endl;
     }
-    edm::ESHandle<RunSummary> sum;
-    std::cout << "got eshandle" << std::endl;
-    context.get<RunSummaryRcd>().get(sum);
-    std::cout << "got context" << std::endl;
+    edm::LogPrint("RunSummaryESAnalyzer") << "got eshandle" << std::endl;
+    edm::ESHandle<RunSummary> sum = context.getHandle(m_RunSummaryToken);
+    edm::LogPrint("RunSummaryESAnalyzer") << "got context" << std::endl;
     const RunSummary* summary = sum.product();
-    std::cout << "got RunSummary* " << std::endl;
+    edm::LogPrint("RunSummaryESAnalyzer") << "got RunSummary* " << std::endl;
 
-    std::cout << "print  result" << std::endl;
+    edm::LogPrint("RunSummaryESAnalyzer") << "print  result" << std::endl;
     summary->printAllValues();
     std::vector<std::string> subdet = summary->getSubdtIn();
-    std::cout << "subdetector in the run " << std::endl;
+    edm::LogPrint("RunSummaryESAnalyzer") << "subdetector in the run " << std::endl;
     for (size_t i = 0; i < subdet.size(); i++) {
-      std::cout << "--> " << subdet[i] << std::endl;
+      edm::LogPrint("RunSummaryESAnalyzer") << "--> " << subdet[i] << std::endl;
     }
   }
   DEFINE_FWK_MODULE(RunSummaryESAnalyzer);

--- a/CondTools/RunInfo/plugins/XangleBetaStarFilter.cc
+++ b/CondTools/RunInfo/plugins/XangleBetaStarFilter.cc
@@ -6,17 +6,16 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Utilities/interface/Exception.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-
 #include "CondFormats/RunInfo/interface/LHCInfo.h"
 #include "CondFormats/DataRecord/interface/LHCInfoRcd.h"
 
 //----------------------------------------------------------------------------------------------------
 
-class XangleBetaStarFilter : public edm::EDFilter {
+class XangleBetaStarFilter : public edm::stream::EDFilter<> {
 public:
   explicit XangleBetaStarFilter(const edm::ParameterSet &);
 

--- a/CondTools/RunInfo/src/FillInfoPopConSourceHandler.cc
+++ b/CondTools/RunInfo/src/FillInfoPopConSourceHandler.cc
@@ -145,7 +145,8 @@ void FillInfoPopConSourceHandler::getNewObjects() {
   //execute the query
   coral::ICursor &fillDataCursor = fillDataQuery->execute();
   //initialize loop variables
-  unsigned short previousFillNumber = 1, currentFill = m_firstFill;
+  unsigned short previousFillNumber = 1;
+  unsigned short currentFill = m_firstFill;
   cond::Time_t previousFillEndTime = 0ULL, afterPreviousFillEndTime = 0ULL, beforeStableBeamStartTime = 0ULL;
   if (tagInfo().size > 0) {
     previousFillNumber = previousFill->fillNumber();

--- a/CondTools/RunInfo/src/RunInfoRead.cc
+++ b/CondTools/RunInfo/src/RunInfoRead.cc
@@ -23,22 +23,22 @@
 #include <cmath>
 
 namespace {
-  std::string dot(".");
-  std::string quote("\"");
-  std::string bNOTb(" NOT ");
-  std::string squoted(const std::string& s) { return quote + s + quote; }
+  const std::string dot(".");
+  const std::string quote("\"");
+  const std::string bNOTb(" NOT ");
+  const std::string squoted(const std::string& s) { return quote + s + quote; }
   //now strings for the tables and columns to be queried
-  std::string sParameterTable("RUNSESSION_PARAMETER");
-  std::string sDateTable("RUNSESSION_DATE");
-  std::string sStringTable("RUNSESSION_STRING");
-  std::string sIdParameterColumn("ID");
-  std::string sRunNumberParameterColumn("RUNNUMBER");
-  std::string sNameParameterColumn("NAME");
-  std::string sRunSessionParameterIdDataColumn("RUNSESSION_PARAMETER_ID");
-  std::string sValueDataColumn("VALUE");
-  std::string sDCSMagnetTable("CMSFWMAGNET");
-  std::string sDCSMagnetCurrentColumn("CURRENT");
-  std::string sDCSMagnetChangeDateColumn("CHANGE_DATE");
+  const std::string sParameterTable("RUNSESSION_PARAMETER");
+  const std::string sDateTable("RUNSESSION_DATE");
+  const std::string sStringTable("RUNSESSION_STRING");
+  const std::string sIdParameterColumn("ID");
+  const std::string sRunNumberParameterColumn("RUNNUMBER");
+  const std::string sNameParameterColumn("NAME");
+  const std::string sRunSessionParameterIdDataColumn("RUNSESSION_PARAMETER_ID");
+  const std::string sValueDataColumn("VALUE");
+  const std::string sDCSMagnetTable("CMSFWMAGNET");
+  const std::string sDCSMagnetCurrentColumn("CURRENT");
+  const std::string sDCSMagnetChangeDateColumn("CHANGE_DATE");
 }  // namespace
 
 RunInfoRead::RunInfoRead(const std::string& connectionString, const edm::ParameterSet& connectionPset)

--- a/CondTools/RunInfo/src/RunSummaryHandler.cc
+++ b/CondTools/RunInfo/src/RunSummaryHandler.cc
@@ -47,7 +47,6 @@ void RunSummaryHandler::getNewObjects() {
 
   size_t n_empty_run = 0;
   if (tagInfo().size > 0 && (tagInfo().lastInterval.since + 1) < snc) {
-    n_empty_run = snc - tagInfo().lastInterval.since - 1;
     edm::LogInfo("RunSummaryHandler") << "------- "
                                       << "entering fake run from " << tagInfo().lastInterval.since + 1 << "to "
                                       << snc - 1 << "- > getNewObjects" << std::endl;


### PR DESCRIPTION
#### PR description:

Part of #31061. Migrates modules of `CondTools/RunInfo` to use esConsumes.
Profited of the PR to modernize the code and address several static analyzer warnings.

#### PR validation:

It compiles. Also passed locally `EcalIntercalibConstants_O2O_test` which makes use of ` CondTools/RunInfo/interface/BTransitionAnalyzer.h`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

