### PR TITLE
Address undefined behavior as reported by UBSAN in CSC and GEM L1T producers

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -1078,13 +1078,13 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::readoutCLCTs() const {
   // debugging messages when early_tbin or late_tbin has a suspicious value
   if (early_tbin < 0) {
     edm::LogWarning("CSCCathodeLCTProcessor|SuspiciousParameters")
-      << "Early time bin (early_tbin) smaller than minimum allowed, which is 0. set early_tbin to 0.";
+        << "Early time bin (early_tbin) smaller than minimum allowed, which is 0. set early_tbin to 0.";
     early_tbin = 0;
   }
   if (late_tbin > max_late_tbin) {
     edm::LogWarning("CSCCathodeLCTProcessor|SuspiciousParameters")
-      << "Late time bin (late_tbin) larger than maximum allowed, which is " << max_late_tbin
-      << ". set early_tbin to max allowed";
+        << "Late time bin (late_tbin) larger than maximum allowed, which is " << max_late_tbin
+        << ". set early_tbin to max allowed";
     late_tbin = CSCConstants::MAX_CLCT_TBINS - 1;
   }
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -1076,20 +1076,16 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::readoutCLCTs() const {
   const int max_late_tbin = CSCConstants::MAX_CLCT_TBINS - 1;
 
   // debugging messages when early_tbin or late_tbin has a suspicious value
-  bool debugTimeBins = true;
-  if (debugTimeBins) {
-    if (early_tbin < 0) {
-      edm::LogWarning("CSCCathodeLCTProcessor|SuspiciousParameters")
-          << "Early time bin (early_tbin) smaller than minimum allowed, which is 0. set early_tbin to 0.";
-      early_tbin = 0;
-    }
-    if (late_tbin > max_late_tbin) {
-      edm::LogWarning("CSCCathodeLCTProcessor|SuspiciousParameters")
-          << "Late time bin (late_tbin) larger than maximum allowed, which is " << max_late_tbin
-          << ". set early_tbin to max allowed";
-      late_tbin = CSCConstants::MAX_CLCT_TBINS - 1;
-    }
-    debugTimeBins = false;
+  if (early_tbin < 0) {
+    edm::LogWarning("CSCCathodeLCTProcessor|SuspiciousParameters")
+      << "Early time bin (early_tbin) smaller than minimum allowed, which is 0. set early_tbin to 0.";
+    early_tbin = 0;
+  }
+  if (late_tbin > max_late_tbin) {
+    edm::LogWarning("CSCCathodeLCTProcessor|SuspiciousParameters")
+      << "Late time bin (late_tbin) larger than maximum allowed, which is " << max_late_tbin
+      << ". set early_tbin to max allowed";
+    late_tbin = CSCConstants::MAX_CLCT_TBINS - 1;
   }
 
   // get the valid LCTs. No BX selection is done here

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -613,14 +613,14 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(
           if (quality[hstrip] > best_quality[0]) {
             best_halfstrip[0] = hstrip;
             best_quality[0] = quality[hstrip];
-          }
-          // temporary alias
-          const int best_hs(best_halfstrip[0]);
-          const int best_pat(best_pid[best_hs]);
-          // construct a CLCT if the trigger condition has been met
-          if (best_hs >= 0 && nhits[best_hs] >= nplanes_hit_pattern) {
-            // overwrite the current best CLCT
-            tempBestCLCT = constructCLCT(first_bx, best_hs, hits_in_patterns[best_hs][best_pat]);
+            // temporary alias
+            const int best_hs(best_halfstrip[0]);
+            const int best_pat(best_pid[best_hs]);
+            // construct a CLCT if the trigger condition has been met
+            if (best_hs >= 0 && nhits[best_hs] >= nplanes_hit_pattern) {
+              // overwrite the current best CLCT
+              tempBestCLCT = constructCLCT(first_bx, best_hs, hits_in_patterns[best_hs][best_pat]);
+            }
           }
         }
       }
@@ -640,14 +640,14 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(
           if (quality[hstrip] > best_quality[1]) {
             best_halfstrip[1] = hstrip;
             best_quality[1] = quality[hstrip];
-          }
-          // temporary alias
-          const int best_hs(best_halfstrip[1]);
-          const int best_pat(best_pid[best_hs]);
-          // construct a CLCT if the trigger condition has been met
-          if (best_hs >= 0 && nhits[best_hs] >= nplanes_hit_pattern) {
-            // overwrite the current second best CLCT
-            tempSecondCLCT = constructCLCT(first_bx, best_hs, hits_in_patterns[best_hs][best_pat]);
+            // temporary alias
+            const int best_hs(best_halfstrip[1]);
+            const int best_pat(best_pid[best_hs]);
+            // construct a CLCT if the trigger condition has been met
+            if (best_hs >= 0 && nhits[best_hs] >= nplanes_hit_pattern) {
+              // overwrite the current second best CLCT
+              tempSecondCLCT = constructCLCT(first_bx, best_hs, hits_in_patterns[best_hs][best_pat]);
+            }
           }
         }
         // add the CLCTs to the collection

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -280,20 +280,16 @@ std::vector<CSCCorrelatedLCTDigi> CSCMotherboard::readoutLCTs() const {
   const int max_late_tbin = CSCConstants::MAX_LCT_TBINS - 1;
 
   // debugging messages when early_tbin or late_tbin has a suspicious value
-  bool debugTimeBins = true;
-  if (debugTimeBins) {
-    if (early_tbin < 0) {
-      edm::LogWarning("CSCMotherboard|SuspiciousParameters")
-          << "Early time bin (early_tbin) smaller than minimum allowed, which is 0. set early_tbin to 0.";
-      early_tbin = 0;
-    }
-    if (late_tbin > max_late_tbin) {
-      edm::LogWarning("CSCMotherboard|SuspiciousParameters")
-          << "Late time bin (late_tbin) larger than maximum allowed, which is " << max_late_tbin
-          << ". set early_tbin to max allowed";
-      late_tbin = CSCConstants::MAX_LCT_TBINS - 1;
-    }
-    debugTimeBins = false;
+  if (early_tbin < 0) {
+    edm::LogWarning("CSCMotherboard|SuspiciousParameters")
+      << "Early time bin (early_tbin) smaller than minimum allowed, which is 0. set early_tbin to 0.";
+    early_tbin = 0;
+  }
+  if (late_tbin > max_late_tbin) {
+    edm::LogWarning("CSCMotherboard|SuspiciousParameters")
+      << "Late time bin (late_tbin) larger than maximum allowed, which is " << max_late_tbin
+      << ". set early_tbin to max allowed";
+    late_tbin = CSCConstants::MAX_LCT_TBINS - 1;
   }
 
   // Start from the vector of all found correlated LCTs and select

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -282,13 +282,13 @@ std::vector<CSCCorrelatedLCTDigi> CSCMotherboard::readoutLCTs() const {
   // debugging messages when early_tbin or late_tbin has a suspicious value
   if (early_tbin < 0) {
     edm::LogWarning("CSCMotherboard|SuspiciousParameters")
-      << "Early time bin (early_tbin) smaller than minimum allowed, which is 0. set early_tbin to 0.";
+        << "Early time bin (early_tbin) smaller than minimum allowed, which is 0. set early_tbin to 0.";
     early_tbin = 0;
   }
   if (late_tbin > max_late_tbin) {
     edm::LogWarning("CSCMotherboard|SuspiciousParameters")
-      << "Late time bin (late_tbin) larger than maximum allowed, which is " << max_late_tbin
-      << ". set early_tbin to max allowed";
+        << "Late time bin (late_tbin) larger than maximum allowed, which is " << max_late_tbin
+        << ". set early_tbin to max allowed";
     late_tbin = CSCConstants::MAX_LCT_TBINS - 1;
   }
 

--- a/L1Trigger/CSCTriggerPrimitives/src/GEMClusterProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/GEMClusterProcessor.cc
@@ -8,6 +8,8 @@ GEMClusterProcessor::GEMClusterProcessor(int region, unsigned station, unsigned 
     : region_(region), station_(station), chamber_(chamber) {
   isEven_ = chamber_ % 2 == 0;
 
+  hasGE21Geometry16Partitions_ = false;
+
   if (station_ == 1) {
     const edm::ParameterSet copad(conf.getParameter<edm::ParameterSet>("copadParamGE11"));
     maxDeltaPad_ = copad.getParameter<unsigned int>("maxDeltaPad");

--- a/L1Trigger/L1TGEM/plugins/GEMPadDigiProducer.cc
+++ b/L1Trigger/L1TGEM/plugins/GEMPadDigiProducer.cc
@@ -49,7 +49,7 @@ private:
   const GEMGeometry* geometry_;
 };
 
-GEMPadDigiProducer::GEMPadDigiProducer(const edm::ParameterSet& ps) : geometry_(nullptr) {
+GEMPadDigiProducer::GEMPadDigiProducer(const edm::ParameterSet& ps) : use16GE21_(false), geometry_(nullptr) {
   digis_ = ps.getParameter<edm::InputTag>("InputCollection");
 
   digi_token_ = consumes<GEMDigiCollection>(digis_);

--- a/L1Trigger/L1TGEM/plugins/GEMPadDigiReader.cc
+++ b/L1Trigger/L1TGEM/plugins/GEMPadDigiReader.cc
@@ -4,7 +4,7 @@
  *  \authors: Vadim Khotilovich
  */
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/stream/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -23,7 +23,7 @@
 
 using namespace std;
 
-class GEMPadDigiReader : public edm::EDAnalyzer {
+class GEMPadDigiReader : public edm::stream::EDAnalyzer<> {
 public:
   explicit GEMPadDigiReader(const edm::ParameterSet& pset);
 


### PR DESCRIPTION
#### PR description:

In response to https://github.com/cms-sw/cmssw/issues/35010

#### PR validation:

Ran WF 136.751 that was reporting the issue.

Also tested it on 10k cosmic muons from a July run with the B904 ME1/1 test-stand. Results look very good (and unchanged).
[CSC_dataVsEmul_B904_Cosmic_Run_210701_135109_10k.pdf](https://github.com/cms-sw/cmssw/files/7108030/CSC_dataVsEmul_B904_Cosmic_Run_210701_135109_10k.pdf)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
