### PR TITLE
Extend L1T CSC DQM with option for ME234/2 chambers and ME2/1 chamber at B904

### DIFF
--- a/DQM/L1TMonitor/interface/L1TdeCSCTPG.h
+++ b/DQM/L1TMonitor/interface/L1TdeCSCTPG.h
@@ -61,9 +61,12 @@ private:
   /*
     When set to True, we assume that the data comes from
     the Building 904 CSC test-stand. This test-stand is a single
-    ME1/1 chamber.
+    ME1/1 chamber or ME4/2 chamber.
   */
-  bool B904Setup_;
+  bool useB904_;
+  bool useB904ME11_;
+  bool useB904ME21_;
+  bool useB904ME234s2_;
 
   bool isRun3_;
 

--- a/DQM/L1TMonitor/python/L1TdeCSCTPG_cfi.py
+++ b/DQM/L1TMonitor/python/L1TdeCSCTPG_cfi.py
@@ -28,7 +28,9 @@ l1tdeCSCTPGCommon = cms.PSet(
     lctNBin = cms.vuint32(16, 116, 224, 16, 2, 448, 896, 5, 16, 2, 2),
     lctMinBin = cms.vdouble(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
     lctMaxBin = cms.vdouble(16, 116, 224, 16, 2, 448, 896, 5, 16, 2, 2),
-    B904Setup = cms.bool(False),
+    useB904ME11 = cms.bool(False),
+    useB904ME21 = cms.bool(False),
+    useB904ME234s2 = cms.bool(False),
     isRun3 = cms.bool(False),
     preTriggerAnalysis = cms.bool(False)
 )

--- a/DQM/L1TMonitor/src/L1TdeCSCTPG.cc
+++ b/DQM/L1TMonitor/src/L1TdeCSCTPG.cc
@@ -30,9 +30,13 @@ L1TdeCSCTPG::L1TdeCSCTPG(const edm::ParameterSet& ps)
       alctMaxBin_(ps.getParameter<std::vector<double>>("alctMaxBin")),
       clctMaxBin_(ps.getParameter<std::vector<double>>("clctMaxBin")),
       lctMaxBin_(ps.getParameter<std::vector<double>>("lctMaxBin")),
-      B904Setup_(ps.getParameter<bool>("B904Setup")),
+      useB904ME11_(ps.getParameter<bool>("useB904ME11")),
+      useB904ME21_(ps.getParameter<bool>("useB904ME21")),
+      useB904ME234s2_(ps.getParameter<bool>("useB904ME234s2")),
       isRun3_(ps.getParameter<bool>("isRun3")),
-      preTriggerAnalysis_(ps.getParameter<bool>("preTriggerAnalysis")) {}
+      preTriggerAnalysis_(ps.getParameter<bool>("preTriggerAnalysis")) {
+  useB904_ = useB904ME11_ or useB904ME21_ or useB904ME234s2_;
+}
 
 L1TdeCSCTPG::~L1TdeCSCTPG() {}
 
@@ -45,10 +49,23 @@ void L1TdeCSCTPG::bookHistograms(DQMStore::IBooker& iBooker, const edm::Run&, co
     lctVars_.resize(5);
   }
 
-  // remove the non-ME1/1 chambers from the list when B904Setup is set to true
-  if (B904Setup_) {
+  // remove the non-ME1/1 chambers from the list when useB904ME11 is set to true
+  if (useB904ME11_) {
     chambers_.resize(1);
   }
+  // similar for ME2/1
+  else if (useB904ME21_) {
+    auto temp = chambers_[3];
+    chambers_.resize(1);
+    chambers_[0] = temp;
+  }
+  // similar for ME4/2
+  else if (useB904ME234s2_) {
+    auto temp = chambers_.back();
+    chambers_.resize(1);
+    chambers_[0] = temp;
+  }
+
   // do not analyze the 1/4-strip bit, 1/8-strip bit
   else {
     clctVars_.resize(9);
@@ -109,15 +126,23 @@ void L1TdeCSCTPG::analyze(const edm::Event& e, const edm::EventSetup& c) {
   e.getByToken(dataLCT_token_, dataLCTs);
   e.getByToken(emulLCT_token_, emulLCTs);
   // only do pre-trigger analysis when B904 setup is used
-  if (B904Setup_)
+  if (useB904_)
     e.getByToken(emulpreCLCT_token_, emulpreCLCTs);
 
   for (auto it = dataALCTs->begin(); it != dataALCTs->end(); it++) {
     auto range = dataALCTs->get((*it).first);
-    const int type = ((*it).first).iChamberType() - 2;
+    const CSCDetId& detid((*it).first);
+    int type = ((*it).first).iChamberType() - 2;
     // ignore non-ME1/1 chambers when using B904 test-stand data
-    if (B904Setup_ and !((*it).first).isME11())
+    if (useB904ME11_ and !(detid.isME11()))
       continue;
+    if (useB904ME21_ and !(detid.isME21()))
+      continue;
+    if (useB904ME234s2_ and !(detid.isME22() or detid.isME32() or detid.isME42()))
+      continue;
+    // to prevent crashes because you are booking histos for single b904 chamber
+    if (useB904ME234s2_ or useB904ME21_)
+      type = 0;
     for (auto alct = range.first; alct != range.second; alct++) {
       if (alct->isValid()) {
         chamberHistos[type]["alct_quality_data"]->Fill(alct->getQuality());
@@ -129,10 +154,18 @@ void L1TdeCSCTPG::analyze(const edm::Event& e, const edm::EventSetup& c) {
 
   for (auto it = emulALCTs->begin(); it != emulALCTs->end(); it++) {
     auto range = emulALCTs->get((*it).first);
-    const int type = ((*it).first).iChamberType() - 2;
+    const CSCDetId& detid((*it).first);
+    int type = ((*it).first).iChamberType() - 2;
     // ignore non-ME1/1 chambers when using B904 test-stand data
-    if (B904Setup_ and !((*it).first).isME11())
+    if (useB904ME11_ and !(detid.isME11()))
       continue;
+    if (useB904ME21_ and !(detid.isME21()))
+      continue;
+    if (useB904ME234s2_ and !(detid.isME22() or detid.isME32() or detid.isME42()))
+      continue;
+    // to prevent crashes because you are booking histos for single b904 chamber
+    if (useB904ME234s2_ or useB904ME21_)
+      type = 0;
     for (auto alct = range.first; alct != range.second; alct++) {
       if (alct->isValid()) {
         chamberHistos[type]["alct_quality_emul"]->Fill(alct->getQuality());
@@ -148,10 +181,18 @@ void L1TdeCSCTPG::analyze(const edm::Event& e, const edm::EventSetup& c) {
 
   for (auto it = dataCLCTs->begin(); it != dataCLCTs->end(); it++) {
     auto range = dataCLCTs->get((*it).first);
-    const int type = ((*it).first).iChamberType() - 2;
+    const CSCDetId& detid((*it).first);
+    int type = ((*it).first).iChamberType() - 2;
     // ignore non-ME1/1 chambers when using B904 test-stand data
-    if (B904Setup_ and !((*it).first).isME11())
+    if (useB904ME11_ and !(detid.isME11()))
       continue;
+    if (useB904ME21_ and !(detid.isME21()))
+      continue;
+    if (useB904ME234s2_ and !(detid.isME22() or detid.isME32() or detid.isME42()))
+      continue;
+    // to prevent crashes because you are booking histos for single b904 chamber
+    if (useB904ME234s2_ or useB904ME21_)
+      type = 0;
     for (auto clct = range.first; clct != range.second; clct++) {
       if (clct->isValid()) {
         if (preTriggerAnalysis_) {
@@ -167,7 +208,7 @@ void L1TdeCSCTPG::analyze(const edm::Event& e, const edm::EventSetup& c) {
           chamberHistos[type]["clct_eighthstrip_data"]->Fill(clct->getKeyStrip(8));
           chamberHistos[type]["clct_slope_data"]->Fill(clct->getSlope());
           chamberHistos[type]["clct_compcode_data"]->Fill(clct->getCompCode());
-          if (B904Setup_) {
+          if (useB904_) {
             chamberHistos[type]["clct_quartstripbit_data"]->Fill(clct->getQuartStripBit());
             chamberHistos[type]["clct_eighthstripbit_data"]->Fill(clct->getEighthStripBit());
           }
@@ -178,10 +219,18 @@ void L1TdeCSCTPG::analyze(const edm::Event& e, const edm::EventSetup& c) {
 
   for (auto it = emulCLCTs->begin(); it != emulCLCTs->end(); it++) {
     auto range = emulCLCTs->get((*it).first);
-    const int type = ((*it).first).iChamberType() - 2;
+    const CSCDetId& detid((*it).first);
+    int type = ((*it).first).iChamberType() - 2;
     // ignore non-ME1/1 chambers when using B904 test-stand data
-    if (B904Setup_ and !((*it).first).isME11())
+    if (useB904ME11_ and !(detid.isME11()))
       continue;
+    if (useB904ME21_ and !(detid.isME21()))
+      continue;
+    if (useB904ME234s2_ and !(detid.isME22() or detid.isME32() or detid.isME42()))
+      continue;
+    // to prevent crashes because you are booking histos for single b904 chamber
+    if (useB904ME234s2_ or useB904ME21_)
+      type = 0;
     // remove the duplicate CLCTs
     // these are CLCTs that have the same properties as CLCTs found
     // before by the emulator, except for the BX, which is off by +1
@@ -205,7 +254,7 @@ void L1TdeCSCTPG::analyze(const edm::Event& e, const edm::EventSetup& c) {
           chamberHistos[type]["clct_eighthstrip_emul"]->Fill(clct.getKeyStrip(8));
           chamberHistos[type]["clct_slope_emul"]->Fill(clct.getSlope());
           chamberHistos[type]["clct_compcode_emul"]->Fill(clct.getCompCode());
-          if (B904Setup_) {
+          if (useB904_) {
             chamberHistos[type]["clct_quartstripbit_emul"]->Fill(clct.getQuartStripBit());
             chamberHistos[type]["clct_eighthstripbit_emul"]->Fill(clct.getEighthStripBit());
           }
@@ -234,10 +283,18 @@ void L1TdeCSCTPG::analyze(const edm::Event& e, const edm::EventSetup& c) {
 
   for (auto it = dataLCTs->begin(); it != dataLCTs->end(); it++) {
     auto range = dataLCTs->get((*it).first);
-    const int type = ((*it).first).iChamberType() - 2;
+    const CSCDetId& detid((*it).first);
+    int type = ((*it).first).iChamberType() - 2;
     // ignore non-ME1/1 chambers when using B904 test-stand data
-    if (B904Setup_ and !((*it).first).isME11())
+    if (useB904ME11_ and !(detid.isME11()))
       continue;
+    if (useB904ME21_ and !(detid.isME21()))
+      continue;
+    if (useB904ME234s2_ and !(detid.isME22() or detid.isME32() or detid.isME42()))
+      continue;
+    // to prevent crashes because you are booking histos for single b904 chamber
+    if (useB904ME234s2_ or useB904ME21_)
+      type = 0;
     for (auto lct = range.first; lct != range.second; lct++) {
       if (lct->isValid()) {
         chamberHistos[type]["lct_pattern_data"]->Fill(lct->getPattern());
@@ -250,7 +307,7 @@ void L1TdeCSCTPG::analyze(const edm::Event& e, const edm::EventSetup& c) {
           chamberHistos[type]["lct_slope_data"]->Fill(lct->getSlope());
           chamberHistos[type]["lct_quartstrip_data"]->Fill(lct->getStrip(4));
           chamberHistos[type]["lct_eighthstrip_data"]->Fill(lct->getStrip(8));
-          if (B904Setup_) {
+          if (useB904_) {
             chamberHistos[type]["lct_quartstripbit_data"]->Fill(lct->getQuartStripBit());
             chamberHistos[type]["lct_eighthstripbit_data"]->Fill(lct->getEighthStripBit());
           }
@@ -261,11 +318,18 @@ void L1TdeCSCTPG::analyze(const edm::Event& e, const edm::EventSetup& c) {
 
   for (auto it = emulLCTs->begin(); it != emulLCTs->end(); it++) {
     auto range = emulLCTs->get((*it).first);
-    const int type = ((*it).first).iChamberType() - 2;
+    const CSCDetId& detid((*it).first);
+    int type = ((*it).first).iChamberType() - 2;
     // ignore non-ME1/1 chambers when using B904 test-stand data
-    if (B904Setup_ and !((*it).first).isME11())
+    if (useB904ME11_ and !(detid.isME11()))
       continue;
-
+    if (useB904ME21_ and !(detid.isME21()))
+      continue;
+    if (useB904ME234s2_ and !(detid.isME22() or detid.isME32() or detid.isME42()))
+      continue;
+    // to prevent crashes because you are booking histos for single b904 chamber
+    if (useB904ME234s2_ or useB904ME21_)
+      type = 0;
     // remove the duplicate LCTs
     // these are LCTs that have the same properties as LCTs found
     // before by the emulator, except for the BX, which is off by +1
@@ -287,7 +351,7 @@ void L1TdeCSCTPG::analyze(const edm::Event& e, const edm::EventSetup& c) {
           chamberHistos[type]["lct_slope_emul"]->Fill(lct.getSlope());
           chamberHistos[type]["lct_quartstrip_emul"]->Fill(lct.getStrip(4));
           chamberHistos[type]["lct_eighthstrip_emul"]->Fill(lct.getStrip(8));
-          if (B904Setup_) {
+          if (useB904_) {
             chamberHistos[type]["lct_quartstripbit_emul"]->Fill(lct.getQuartStripBit());
             chamberHistos[type]["lct_eighthstripbit_emul"]->Fill(lct.getEighthStripBit());
           }

--- a/DQM/L1TMonitorClient/interface/L1TdeCSCTPGClient.h
+++ b/DQM/L1TMonitorClient/interface/L1TdeCSCTPGClient.h
@@ -53,7 +53,10 @@ private:
     the Building 904 CSC test-stand. This test-stand is a single
     ME1/1 chamber.
   */
-  bool B904Setup_;
+  bool useB904_;
+  bool useB904ME11_;
+  bool useB904ME21_;
+  bool useB904ME234s2_;
 
   bool isRun3_;
 

--- a/DQM/L1TMonitorClient/src/L1TdeCSCTPGClient.cc
+++ b/DQM/L1TMonitorClient/src/L1TdeCSCTPGClient.cc
@@ -27,8 +27,12 @@ L1TdeCSCTPGClient::L1TdeCSCTPGClient(const edm::ParameterSet &ps)
       alctMaxBin_(ps.getParameter<std::vector<double>>("alctMaxBin")),
       clctMaxBin_(ps.getParameter<std::vector<double>>("clctMaxBin")),
       lctMaxBin_(ps.getParameter<std::vector<double>>("lctMaxBin")),
-      B904Setup_(ps.getParameter<bool>("B904Setup")),
-      isRun3_(ps.getParameter<bool>("isRun3")) {}
+      useB904ME11_(ps.getParameter<bool>("useB904ME11")),
+      useB904ME21_(ps.getParameter<bool>("useB904ME21")),
+      useB904ME234s2_(ps.getParameter<bool>("useB904ME234s2")),
+      isRun3_(ps.getParameter<bool>("isRun3")) {
+  useB904_ = useB904ME11_ or useB904ME21_ or useB904ME234s2_;
+}
 
 L1TdeCSCTPGClient::~L1TdeCSCTPGClient() {}
 
@@ -55,9 +59,21 @@ void L1TdeCSCTPGClient::book(DQMStore::IBooker &iBooker) {
     lctVars_.resize(5);
   }
 
-  // remove the non-ME1/1 chambers from the list when B904Setup is set to true
-  if (B904Setup_) {
+  // remove the non-ME1/1 chambers from the list when useB904ME11 is set to true
+  if (useB904ME11_) {
     chambers_.resize(1);
+  }
+  // similar for ME2/1
+  else if (useB904ME21_) {
+    auto temp = chambers_[3];
+    chambers_.resize(1);
+    chambers_[0] = temp;
+  }
+  // similar for ME4/2
+  else if (useB904ME234s2_) {
+    auto temp = chambers_.back();
+    chambers_.resize(1);
+    chambers_[0] = temp;
   }
   // do not analyze the 1/4-strip bit, 1/8-strip bit
   else {

--- a/IORawData/CSCCommissioning/src/CSCFileReader.h
+++ b/IORawData/CSCCommissioning/src/CSCFileReader.h
@@ -1,7 +1,7 @@
 #ifndef CSCFileReader_h
 #define CSCFileReader_h
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "DataFormats/Provenance/interface/EventID.h"
@@ -15,7 +15,7 @@
 #include "FileReaderDDU.h"
 #include "FileReaderDCC.h"
 
-class CSCFileReader : public edm::EDProducer {
+class CSCFileReader : public edm::stream::EDProducer<> {
 private:
   std::vector<std::string> fileNames[40];
   std::vector<std::string>::const_iterator currentFile[40];

--- a/IORawData/CSCCommissioning/test/readFile_b904_Run3.py
+++ b/IORawData/CSCCommissioning/test/readFile_b904_Run3.py
@@ -13,6 +13,9 @@ options = VarParsing ('analysis')
 options.register ("firstRun", 341761, VarParsing.multiplicity.singleton, VarParsing.varType.int)
 options.register ("inputFilesGEM", "", VarParsing.multiplicity.singleton, VarParsing.varType.string)
 options.register ("readGEMData", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
+options.register ("useB904ME11", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
+options.register ("useB904ME21", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
+options.register ("useB904ME234s2", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
 options.maxEvents = 10000
 options.parseArguments()
 
@@ -50,18 +53,39 @@ process.rawDataCollectorGEM = cms.EDAlias(
     )
 )
 
-# Note by Sven Dildick: I had to change the CSC producer module name to process.rawDataCollectorCSC so
-# that the name would not conflict with the GEM source.
-
 # For B904 setup ME11 chamber, which corresponds to ME+1/1/02 in the production system mapping
 # changing to FED837 and RUI16 could let to pass data without disabling mapping consistency check unpacking flags
+if options.useB904ME11:
+    FEDRUI = cms.PSet(
+        FED846 = cms.untracked.vstring('RUI01'),
+        RUI01 = cms.untracked.vstring(options.inputFiles[0])
+    )
+# Please note that after passing mapping check this chamber still would be recognized as production chamber
+# ME+2/2/03, which is OK, because this is the same chamber type as ME42 hardware-wise.
+elif options.useB904ME21:
+    FEDRUI = cms.PSet(
+        FED839 = cms.untracked.vstring('RUI18'),
+        RUI18 = cms.untracked.vstring(options.inputFiles[0])
+    )
+# For B904 setup ME21 chamber, which corresponds to ME+2/1/03 VMECrate13 / DMBSlot2 RUI17 / FED838 in the production system mapping
+elif options.useB904ME234s2:
+    FEDRUI = cms.PSet(
+        FED838 = cms.untracked.vstring('RUI16'),
+        RUI17 = cms.untracked.vstring(options.inputFiles[0])
+    )
+## default case
+else:
+    FEDRUI = cms.PSet(
+        FED837 = cms.untracked.vstring('RUI16'),
+        RUI16 = cms.untracked.vstring('/afs/cern.ch/user/b/barvic/public/cscgem_tests/csc_00000001_EmuRUI01_Local_000_210519_162820_UTC.raw')
+    )
+
+# Note by Sven Dildick: I had to change the CSC producer module name to process.rawDataCollectorCSC so
+# that the name would not conflict with the GEM source.
 process.rawDataCollectorCSC = cms.EDProducer(
     'CSCFileReader',
+    FEDRUI,
     firstEvent  = cms.untracked.int32(0),
-    FED846 = cms.untracked.vstring('RUI01'),
-    RUI01 = cms.untracked.vstring(options.inputFiles[0])
-    #      FED837 = cms.untracked.vstring('RUI16'),
-    #      RUI16 = cms.untracked.vstring('/afs/cern.ch/user/b/barvic/public/cscgem_tests/csc_00000001_EmuRUI01_Local_000_210519_162820_UTC.raw')
 )
 
 process.FEVT = cms.OutputModule(

--- a/IORawData/CSCCommissioning/test/readFile_b904_Run3.py
+++ b/IORawData/CSCCommissioning/test/readFile_b904_Run3.py
@@ -60,18 +60,18 @@ if options.useB904ME11:
         FED846 = cms.untracked.vstring('RUI01'),
         RUI01 = cms.untracked.vstring(options.inputFiles[0])
     )
-# Please note that after passing mapping check this chamber still would be recognized as production chamber
-# ME+2/2/03, which is OK, because this is the same chamber type as ME42 hardware-wise.
-elif options.useB904ME21:
-    FEDRUI = cms.PSet(
-        FED839 = cms.untracked.vstring('RUI18'),
-        RUI18 = cms.untracked.vstring(options.inputFiles[0])
-    )
 # For B904 setup ME21 chamber, which corresponds to ME+2/1/03 VMECrate13 / DMBSlot2 RUI17 / FED838 in the production system mapping
-elif options.useB904ME234s2:
+elif options.useB904ME21:
     FEDRUI = cms.PSet(
         FED838 = cms.untracked.vstring('RUI16'),
         RUI17 = cms.untracked.vstring(options.inputFiles[0])
+    )
+# Please note that after passing mapping check this chamber still would be recognized as production chamber
+# ME+2/2/03, which is OK, because this is the same chamber type as ME42 hardware-wise.
+elif options.useB904ME234s2:
+    FEDRUI = cms.PSet(
+        FED839 = cms.untracked.vstring('RUI18'),
+        RUI18 = cms.untracked.vstring(options.inputFiles[0])
     )
 ## default case
 else:

--- a/L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesAnalyzer.cc
+++ b/L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesAnalyzer.cc
@@ -79,7 +79,10 @@ private:
     the Building 904 CSC test-stand. This test-stand is a single
     ME1/1 chamber.
   */
-  bool B904Setup_;
+  bool useB904_;
+  bool useB904ME11_;
+  bool useB904ME21_;
+  bool useB904ME234s2_;
   // label only relevant for B904 local runs
   std::string B904RunNumber_;
 };
@@ -95,9 +98,12 @@ CSCTriggerPrimitivesAnalyzer::CSCTriggerPrimitivesAnalyzer(const edm::ParameterS
       dataVsEmulatorPlots_(conf.getParameter<bool>("dataVsEmulatorPlots")),
       mcEfficiencyPlots_(conf.getParameter<bool>("mcEfficiencyPlots")),
       mcResolutionPlots_(conf.getParameter<bool>("mcResolutionPlots")),
-      B904Setup_(conf.getParameter<bool>("B904Setup")),
+      useB904ME11_(conf.getParameter<bool>("useB904ME11")),
+      useB904ME21_(conf.getParameter<bool>("useB904ME21")),
+      useB904ME234s2_(conf.getParameter<bool>("useB904ME234s2")),
       B904RunNumber_(conf.getParameter<std::string>("B904RunNumber")) {
   usesResource("TFileService");
+  useB904_ = useB904ME11_ or useB904ME21_ or useB904ME234s2_;
 }
 
 void CSCTriggerPrimitivesAnalyzer::analyze(const edm::Event &ev, const edm::EventSetup &setup) {
@@ -134,7 +140,7 @@ void CSCTriggerPrimitivesAnalyzer::makeDataVsEmulatorPlots() {
   }
 
   TString runTitle = "CMS_Run_" + std::to_string(runNumber_);
-  if (B904Setup_)
+  if (useB904_)
     runTitle = "B904_Cosmic_Run_" + TString(B904RunNumber_);
 
   TPostScript *ps = new TPostScript("CSC_dataVsEmul_" + runTitle + ".ps", 111);
@@ -226,7 +232,7 @@ void CSCTriggerPrimitivesAnalyzer::makePlot(TH1F *dataMon,
   ps->NewPage();
 
   TString runTitle = "(CMS Run " + std::to_string(runNumber_) + ")";
-  if (B904Setup_)
+  if (useB904_)
     runTitle = "(B904 Cosmic Run " + TString(B904RunNumber_) + ")";
   const TString title(chamber + " " + lcts + " " + var + " " + runTitle);
   c1->cd(1);

--- a/L1Trigger/CSCTriggerPrimitives/test/runCSCL1TDQMClient_cfg.py
+++ b/L1Trigger/CSCTriggerPrimitives/test/runCSCL1TDQMClient_cfg.py
@@ -6,7 +6,9 @@ from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
 options = VarParsing('analysis')
 options.register ("run3", True, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
 options.register ("mc", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
-options.register ("useB904Data", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
+options.register ("useB904ME11", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
+options.register ("useB904ME21", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
+options.register ("useB904ME234s2", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
 options.register ("useGEMs", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
 options.parseArguments()
 options.inputFiles = "file:step_DQM.root"
@@ -52,7 +54,9 @@ else:
       if options.run3:
             process.GlobalTag = GlobalTag(process.GlobalTag, '112X_dataRun3_Prompt_v5', '')
 
-process.l1tdeCSCTPGClient.B904Setup = options.useB904Data
+process.l1tdeCSCTPGClient.useB904ME11 = options.useB904ME11
+process.l1tdeCSCTPGClient.useB904ME21 = options.useB904ME21
+process.l1tdeCSCTPGClient.useB904ME234s2 = options.useB904ME234s2
 
 ## schedule and path definition
 process.dqmsequence = cms.Sequence(process.l1tdeCSCTPGClient)

--- a/L1Trigger/CSCTriggerPrimitives/test/runCSCTriggerPrimitiveAnalyzer_cfg.py
+++ b/L1Trigger/CSCTriggerPrimitives/test/runCSCTriggerPrimitiveAnalyzer_cfg.py
@@ -9,19 +9,22 @@ options.register ("analyzeEffiency", False, VarParsing.multiplicity.singleton, V
 options.register ("analyzeResolution", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
 options.register ("dataVsEmulationFile", "empty", VarParsing.multiplicity.singleton, VarParsing.varType.string)
 """
-- For CMS runs, use the actual run number. Set B904Setup to False
-- For B904 runs, set B904Setup to True and set runNumber >= 341761.
+- For CMS runs, use the actual run number. Set useB904ME11, useB904ME21 or useB904ME234s2 to False
+- For B904 runs, set useB904ME11, useB904ME21 or useB904ME234s2 to True and set runNumber >= 341761.
   Set B904RunNumber to when the data was taken, e.g. 210519_162820.
 """
 options.register ("runNumber", 0, VarParsing.multiplicity.singleton, VarParsing.varType.int)
-options.register ("B904Setup", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
+options.register ("useB904ME11", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
+options.register ("useB904ME21", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
+options.register ("useB904ME234s2", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
 options.register ("B904RunNumber", "YYMMDD_HHMMSS", VarParsing.multiplicity.singleton, VarParsing.varType.string)
 options.parseArguments()
 
-if options.B904Setup and options.B904RunNumber == "YYMMDD_HHMMSS":
+B904Setup = options.useB904ME11 or options.useB904ME21 or options.useB904ME234s2
+if B904Setup and options.B904RunNumber == "YYMMDD_HHMMSS":
     sys.exit("B904 setup was selected. Please provide a valid Run Number")
 
-if (not options.B904Setup) and int(options.runNumber) == 0:
+if (not B904Setup) and int(options.runNumber) == 0:
     sys.exit("Please provide a valid CMS Run Number")
 
 process = cms.Process("ANALYSIS", Run3)
@@ -63,6 +66,8 @@ process.cscTriggerPrimitivesAnalyzer = cms.EDAnalyzer(
 )
 
 # this needs to be set here, otherwise we duplicate the B904Setup parameter
-process.cscTriggerPrimitivesAnalyzer.B904Setup = options.B904Setup
+process.cscTriggerPrimitivesAnalyzer.useB904ME11 = options.useB904ME11
+process.cscTriggerPrimitivesAnalyzer.useB904ME21 = options.useB904ME21
+process.cscTriggerPrimitivesAnalyzer.useB904ME234s2 = options.useB904ME234s2
 
 process.p = cms.Path(process.cscTriggerPrimitivesAnalyzer)

--- a/L1Trigger/CSCTriggerPrimitives/test/runCSCTriggerPrimitiveProducer_cfg.py
+++ b/L1Trigger/CSCTriggerPrimitives/test/runCSCTriggerPrimitiveProducer_cfg.py
@@ -11,7 +11,9 @@ options.register ("l1GEM", False, VarParsing.multiplicity.singleton, VarParsing.
 options.register ("mc", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
 options.register ("dqm", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
 options.register ("dqmGEM", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
-options.register ("useB904Data", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
+options.register ("useB904ME11", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
+options.register ("useB904ME21", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
+options.register ("useB904ME234s2", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
 options.register ("run3", True, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
 options.register ("runCCLUT", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
 options.register ("runME11ILT", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
@@ -77,7 +79,8 @@ if not options.mc or options.unpack:
       process.cscTriggerPrimitiveDigis.CSCWireDigiProducer = "muonCSCDigis:MuonCSCWireDigi"
 
 ## unpacker
-if options.useB904Data:
+useB904Data = options.useB904ME11 or options.useB904ME21 or options.useB904ME234s2
+if useB904Data:
       ## CSC
       process.muonCSCDigis.DisableMappingCheck = True
       process.muonCSCDigis.B904Setup = True
@@ -105,7 +108,9 @@ if options.l1GEM:
 
 ## DQM monitor
 if options.dqm:
-      process.l1tdeCSCTPG.B904Setup = options.useB904Data
+      process.l1tdeCSCTPG.useB904ME11 = options.useB904ME11
+      process.l1tdeCSCTPG.useB904ME21 = options.useB904ME21
+      process.l1tdeCSCTPG.useB904ME234s2 = options.useB904ME234s2
       process.l1tdeCSCTPG.emulALCT = "cscTriggerPrimitiveDigis"
       process.l1tdeCSCTPG.emulCLCT = "cscTriggerPrimitiveDigis"
       process.l1tdeCSCTPG.emulLCT = "cscTriggerPrimitiveDigis:MPCSORTED"


### PR DESCRIPTION
#### PR description:

We are currently testing Run-3 trigger motherboard firmware for ME1/3 and MEX/2 chambers with Virtex-2 FPGAs, and for MEX/1 chambers with Virtex-6 FPGAs. We have an ME4/2 and ME2/1 chamber with full trigger+DAQ at B904 for this purpose. This PR extends the L1T CSC DQM with option for ME234/2 and MEX/1 chambers at B904 (follow-up of https://github.com/cms-sw/cmssw/pull/33876). The results also hold for ME1/2 and ME1/3 because they share the same electronics setup (but do have different size and geometry).

Thanks to @barvic for helping with debugging, and to Karoly Banicz for taking the data.

#### PR validation:

Tested on the ME4/2 B904 chamber with a few thousand cosmic events.

[CSC_dataVsEmul_B904_Cosmic_Run_210810_160642 (1).pdf](https://github.com/cms-sw/cmssw/files/7087706/CSC_dataVsEmul_B904_Cosmic_Run_210810_160642.1.pdf)

There should be no changes in the tests because the algorithm did not change, just the analysis code.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

FYI @tahuang1991 