### PR TITLE
[HGCAL] Adding comments in HGCAL associators

### DIFF
--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToCPAssociatorByEnergyScoreImpl.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToCPAssociatorByEnergyScoreImpl.cc
@@ -20,19 +20,20 @@ LCToCPAssociatorByEnergyScoreImpl::LCToCPAssociatorByEnergyScoreImpl(
 
 hgcal::association LCToCPAssociatorByEnergyScoreImpl::makeConnections(
     const edm::Handle<reco::CaloClusterCollection>& cCCH, const edm::Handle<CaloParticleCollection>& cPCH) const {
-  // 1. Extract collections and filter CaloParticles, if required
+  // Get collections
   const auto& clusters = *cCCH.product();
   const auto& caloParticles = *cPCH.product();
   auto nLayerClusters = clusters.size();
-  //Consider CaloParticles coming from the hard scatterer, excluding the PU contribution.
+
+  //Consider CaloParticles coming from the hard scatterer, excluding the PU contribution and save the indices.
   std::vector<size_t> cPIndices;
-  //Consider CaloParticles coming from the hard scatterer
-  //excluding the PU contribution and save the indices.
   removeCPFromPU(caloParticles, cPIndices, hardScatterOnly_);
   auto nCaloParticles = cPIndices.size();
 
-  // Initialize cPOnLayer. To be returned outside, since it contains the
-  // information to compute the CaloParticle-To-LayerCluster score.
+  // Initialize cPOnLayer. It contains the caloParticleOnLayer structure for all CaloParticles in each layer and 
+  // among other the information to compute the CaloParticle-To-LayerCluster score. It is one of the two objects that
+  // build the output of the makeConnections function. 
+  // cPOnLayer[cpId][layerId]
   hgcal::caloParticleToLayerCluster cPOnLayer;
   cPOnLayer.resize(nCaloParticles);
   for (unsigned int i = 0; i < nCaloParticles; ++i) {
@@ -46,6 +47,10 @@ hgcal::association LCToCPAssociatorByEnergyScoreImpl::makeConnections(
   }
 
   // Fill detIdToCaloParticleId_Map and update cPOnLayer
+  // The detIdToCaloParticleId_Map is used to connect a hit Detid (key) with all the CaloParticles that 
+  // contributed to that hit by storing the CaloParticle id and the fraction of the hit. Observe here 
+  // that all the different contributions of the same CaloParticle to a single hit (coming from their 
+  // internal SimClusters) are merged into a single entry with the fractions properly summed. 
   std::unordered_map<DetId, std::vector<hgcal::detIdInfoInCluster>> detIdToCaloParticleId_Map;
   for (const auto& cpId : cPIndices) {
     const SimClusterRefVector& simClusterRefVector = caloParticles[cpId].simClusters();
@@ -343,6 +348,7 @@ hgcal::association LCToCPAssociatorByEnergyScoreImpl::makeConnections(
     }
 
     // Compute the correct normalization
+    // It is the inverse of the denominator of the LCToCP score formula. Observe that this is the sum of the squares. 
     float invLayerClusterEnergyWeight = 0.f;
     for (auto const& haf : clusters[lcId].hitsAndFractions()) {
       invLayerClusterEnergyWeight +=
@@ -370,7 +376,7 @@ hgcal::association LCToCPAssociatorByEnergyScoreImpl::makeConnections(
         }
         cpPair.second +=
             (rhFraction - cpFraction) * (rhFraction - cpFraction) * hitEnergyWeight * invLayerClusterEnergyWeight;
-      }
+      } //End of loop over CaloParticles related the this LayerCluster. 
     }  // End of loop over Hits within a LayerCluster
 #ifdef EDM_ML_DEBUG
     if (cpsInLayerCluster[lcId].empty())
@@ -410,7 +416,7 @@ hgcal::association LCToCPAssociatorByEnergyScoreImpl::makeConnections(
           << CPNumberOfHits << "\t" << std::setw(18) << lcWithMaxEnergyInCP << "\t" << std::setw(15) << maxEnergyLCinCP
           << "\t" << std::setw(20) << CPEnergyFractionInLC << "\n";
 #endif
-      // Compute the correct normalization
+      // Compute the correct normalization. Observe that this is the sum of the squares. 
       float invCPEnergyWeight = 0.f;
       for (auto const& haf : cPOnLayer[cpId][layerId].hits_and_fractions) {
         invCPEnergyWeight += std::pow(haf.second * hitMap_->at(haf.first)->energy(), 2);
@@ -464,8 +470,9 @@ hgcal::association LCToCPAssociatorByEnergyScoreImpl::makeConnections(
             << (lcPair.second.first / CPenergy) << "\n";
       }
 #endif
-    }
-  }
+    } // End of loop over layers
+  } // End of loop over CaloParticles
+
   return {cpsInLayerCluster, cPOnLayer};
 }
 

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToCPAssociatorByEnergyScoreImpl.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToCPAssociatorByEnergyScoreImpl.cc
@@ -30,9 +30,9 @@ hgcal::association LCToCPAssociatorByEnergyScoreImpl::makeConnections(
   removeCPFromPU(caloParticles, cPIndices, hardScatterOnly_);
   auto nCaloParticles = cPIndices.size();
 
-  // Initialize cPOnLayer. It contains the caloParticleOnLayer structure for all CaloParticles in each layer and 
+  // Initialize cPOnLayer. It contains the caloParticleOnLayer structure for all CaloParticles in each layer and
   // among other the information to compute the CaloParticle-To-LayerCluster score. It is one of the two objects that
-  // build the output of the makeConnections function. 
+  // build the output of the makeConnections function.
   // cPOnLayer[cpId][layerId]
   hgcal::caloParticleToLayerCluster cPOnLayer;
   cPOnLayer.resize(nCaloParticles);
@@ -47,10 +47,10 @@ hgcal::association LCToCPAssociatorByEnergyScoreImpl::makeConnections(
   }
 
   // Fill detIdToCaloParticleId_Map and update cPOnLayer
-  // The detIdToCaloParticleId_Map is used to connect a hit Detid (key) with all the CaloParticles that 
-  // contributed to that hit by storing the CaloParticle id and the fraction of the hit. Observe here 
-  // that all the different contributions of the same CaloParticle to a single hit (coming from their 
-  // internal SimClusters) are merged into a single entry with the fractions properly summed. 
+  // The detIdToCaloParticleId_Map is used to connect a hit Detid (key) with all the CaloParticles that
+  // contributed to that hit by storing the CaloParticle id and the fraction of the hit. Observe here
+  // that all the different contributions of the same CaloParticle to a single hit (coming from their
+  // internal SimClusters) are merged into a single entry with the fractions properly summed.
   std::unordered_map<DetId, std::vector<hgcal::detIdInfoInCluster>> detIdToCaloParticleId_Map;
   for (const auto& cpId : cPIndices) {
     const SimClusterRefVector& simClusterRefVector = caloParticles[cpId].simClusters();
@@ -348,7 +348,7 @@ hgcal::association LCToCPAssociatorByEnergyScoreImpl::makeConnections(
     }
 
     // Compute the correct normalization
-    // It is the inverse of the denominator of the LCToCP score formula. Observe that this is the sum of the squares. 
+    // It is the inverse of the denominator of the LCToCP score formula. Observe that this is the sum of the squares.
     float invLayerClusterEnergyWeight = 0.f;
     for (auto const& haf : clusters[lcId].hitsAndFractions()) {
       invLayerClusterEnergyWeight +=
@@ -376,8 +376,8 @@ hgcal::association LCToCPAssociatorByEnergyScoreImpl::makeConnections(
         }
         cpPair.second +=
             (rhFraction - cpFraction) * (rhFraction - cpFraction) * hitEnergyWeight * invLayerClusterEnergyWeight;
-      } //End of loop over CaloParticles related the this LayerCluster. 
-    }  // End of loop over Hits within a LayerCluster
+      }  //End of loop over CaloParticles related the this LayerCluster.
+    }    // End of loop over Hits within a LayerCluster
 #ifdef EDM_ML_DEBUG
     if (cpsInLayerCluster[lcId].empty())
       LogDebug("LCToCPAssociatorByEnergyScoreImpl") << "layerCluster Id: \t" << lcId << "\tCP id:\t-1 "
@@ -416,7 +416,7 @@ hgcal::association LCToCPAssociatorByEnergyScoreImpl::makeConnections(
           << CPNumberOfHits << "\t" << std::setw(18) << lcWithMaxEnergyInCP << "\t" << std::setw(15) << maxEnergyLCinCP
           << "\t" << std::setw(20) << CPEnergyFractionInLC << "\n";
 #endif
-      // Compute the correct normalization. Observe that this is the sum of the squares. 
+      // Compute the correct normalization. Observe that this is the sum of the squares.
       float invCPEnergyWeight = 0.f;
       for (auto const& haf : cPOnLayer[cpId][layerId].hits_and_fractions) {
         invCPEnergyWeight += std::pow(haf.second * hitMap_->at(haf.first)->energy(), 2);
@@ -470,8 +470,8 @@ hgcal::association LCToCPAssociatorByEnergyScoreImpl::makeConnections(
             << (lcPair.second.first / CPenergy) << "\n";
       }
 #endif
-    } // End of loop over layers
-  } // End of loop over CaloParticles
+    }  // End of loop over layers
+  }    // End of loop over CaloParticles
 
   return {cpsInLayerCluster, cPOnLayer};
 }

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToCPAssociatorByEnergyScoreImpl.h
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToCPAssociatorByEnergyScoreImpl.h
@@ -48,9 +48,9 @@ namespace hgcal {
     std::unordered_map<int, std::pair<float, float>> layerClusterIdToEnergyAndScore;
   };
 
-  // This object connects a LayerCluster, identified through its id (lcId), with a vector containing all the CaloParticles 
-  // (via their ids (cpIds)) that share at least one cell with the LayerCluster. For that pair (lcId,cpId) it 
-  // stores the score. Keep in mind that the association is not unique, since there could be several instances 
+  // This object connects a LayerCluster, identified through its id (lcId), with a vector of pairs containing all the CaloParticles 
+  // (via their ids (cpIds)) that share at least one cell with the LayerCluster. In that pair it 
+  // stores the score (lcId->(cpId,score)). Keep in mind that the association is not unique, since there could be several instances 
   // of the same CaloParticle from several related SimClusters that each contributed to the same LayerCluster. 
   typedef std::vector<std::vector<std::pair<unsigned int, float>>> layerClusterToCaloParticle;
   // This is used to save the caloParticleOnLayer structure for all CaloParticles in each layer. 

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToCPAssociatorByEnergyScoreImpl.h
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToCPAssociatorByEnergyScoreImpl.h
@@ -16,9 +16,9 @@ namespace edm {
 
 namespace hgcal {
   // This structure is used both for LayerClusters and CaloParticles storing their id and the fraction of a hit
-  // that belongs to the LayerCluster or CaloParticle. The meaning of the operator is extremely important since 
+  // that belongs to the LayerCluster or CaloParticle. The meaning of the operator is extremely important since
   // this struct will be used inside maps and other containers and when searching for one particular occurence
-  // only the clusterId member will be used in the check, skipping the fraction part. 
+  // only the clusterId member will be used in the check, skipping the fraction part.
   struct detIdInfoInCluster {
     bool operator==(const detIdInfoInCluster &o) const { return clusterId == o.clusterId; };
     long unsigned int clusterId;
@@ -30,17 +30,17 @@ namespace hgcal {
   };
 
   // This introduces a CaloParticle on layer concept. For a CaloParticle it stores:
-  // 1. Its id: caloParticleId. 
-  // 2. The energy that the CaloParticle deposited in a specific layer and it was reconstructed. 
-  // 3. The hits_and_fractions that contributed to that deposition. SimHits that aren't reconstructed 
-  //    and doesn't have any matched rechits are disregarded. Keep in mind that since a CaloParticle 
+  // 1. Its id: caloParticleId.
+  // 2. The energy that the CaloParticle deposited in a specific layer and it was reconstructed.
+  // 3. The hits_and_fractions that contributed to that deposition. SimHits that aren't reconstructed
+  //    and doesn't have any matched rechits are disregarded. Keep in mind that since a CaloParticle
   //    should most probably have more than one SimCluster, all different contributions from the same CaloParticle
-  //    to a single hit are merged into a single entry, with the fractions properly summed. 
-  // 4. A map to save the LayerClusters ids (id is the key) that reconstructed at least one SimHit of the CaloParticle under study 
-  //    together with the energy that the LayerCluster reconstructed from the CaloParticle and the score. The energy 
-  //    is not the energy of the LayerCluster, but the energy of the LayerCluster coming from the CaloParticle. 
-  //    So, there will be energy of the LayerCluster that is disregarded here, since there may be LayerCluster's 
-  //    cells that the CaloParticle didn't contribute. 
+  //    to a single hit are merged into a single entry, with the fractions properly summed.
+  // 4. A map to save the LayerClusters ids (id is the key) that reconstructed at least one SimHit of the CaloParticle under study
+  //    together with the energy that the LayerCluster reconstructed from the CaloParticle and the score. The energy
+  //    is not the energy of the LayerCluster, but the energy of the LayerCluster coming from the CaloParticle.
+  //    So, there will be energy of the LayerCluster that is disregarded here, since there may be LayerCluster's
+  //    cells that the CaloParticle didn't contribute.
   struct caloParticleOnLayer {
     unsigned int caloParticleId;
     float energy = 0;
@@ -48,17 +48,17 @@ namespace hgcal {
     std::unordered_map<int, std::pair<float, float>> layerClusterIdToEnergyAndScore;
   };
 
-  // This object connects a LayerCluster, identified through its id (lcId), with a vector of pairs containing all the CaloParticles 
-  // (via their ids (cpIds)) that share at least one cell with the LayerCluster. In that pair it 
-  // stores the score (lcId->(cpId,score)). Keep in mind that the association is not unique, since there could be several instances 
-  // of the same CaloParticle from several related SimClusters that each contributed to the same LayerCluster. 
+  // This object connects a LayerCluster, identified through its id (lcId), with a vector of pairs containing all the CaloParticles
+  // (via their ids (cpIds)) that share at least one cell with the LayerCluster. In that pair it
+  // stores the score (lcId->(cpId,score)). Keep in mind that the association is not unique, since there could be several instances
+  // of the same CaloParticle from several related SimClusters that each contributed to the same LayerCluster.
   typedef std::vector<std::vector<std::pair<unsigned int, float>>> layerClusterToCaloParticle;
-  // This is used to save the caloParticleOnLayer structure for all CaloParticles in each layer. 
-  // It is not exactly what is returned outside, but out of its entries, the output object is build.   
+  // This is used to save the caloParticleOnLayer structure for all CaloParticles in each layer.
+  // It is not exactly what is returned outside, but out of its entries, the output object is build.
   typedef std::vector<std::vector<hgcal::caloParticleOnLayer>> caloParticleToLayerCluster;
-  //This is the output of the makeConnections function that contain all the work with CP2LC and LC2CP 
-  //association. It will be read by the relevant associateSimToReco and associateRecoToSim functions to 
-  //provide the final product.  
+  //This is the output of the makeConnections function that contain all the work with CP2LC and LC2CP
+  //association. It will be read by the relevant associateSimToReco and associateRecoToSim functions to
+  //provide the final product.
   typedef std::tuple<layerClusterToCaloParticle, caloParticleToLayerCluster> association;
 }  // namespace hgcal
 

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToCPAssociatorByEnergyScoreImpl.h
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToCPAssociatorByEnergyScoreImpl.h
@@ -25,13 +25,6 @@ namespace hgcal {
     }
   };
 
-  struct detIdInfoInMultiCluster {
-    bool operator==(const detIdInfoInMultiCluster &o) const { return multiclusterId == o.multiclusterId; };
-    unsigned int multiclusterId;
-    long unsigned int clusterId;
-    float fraction;
-  };
-
   struct caloParticleOnLayer {
     unsigned int caloParticleId;
     float energy = 0;

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToCPAssociatorByEnergyScoreImpl.h
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToCPAssociatorByEnergyScoreImpl.h
@@ -15,6 +15,10 @@ namespace edm {
 }
 
 namespace hgcal {
+  // This structure is used both for LayerClusters and CaloParticles storing their id and the fraction of a hit
+  // that belongs to the LayerCluster or CaloParticle. The meaning of the operator is extremely important since 
+  // this struct will be used inside maps and other containers and when searching for one particular occurence
+  // only the clusterId member will be used in the check, skipping the fraction part. 
   struct detIdInfoInCluster {
     bool operator==(const detIdInfoInCluster &o) const { return clusterId == o.clusterId; };
     long unsigned int clusterId;
@@ -25,6 +29,18 @@ namespace hgcal {
     }
   };
 
+  // This introduces a CaloParticle on layer concept. For a CaloParticle it stores:
+  // 1. Its id: caloParticleId. 
+  // 2. The energy that the CaloParticle deposited in a specific layer and it was reconstructed. 
+  // 3. The hits_and_fractions that contributed to that deposition. SimHits that aren't reconstructed 
+  //    and doesn't have any matched rechits are disregarded. Keep in mind that since a CaloParticle 
+  //    should most probably have more than one SimCluster, all different contributions from the same CaloParticle
+  //    to a single hit are merged into a single entry, with the fractions properly summed. 
+  // 4. A map to save the LayerClusters ids (id is the key) that reconstructed at least one SimHit of the CaloParticle under study 
+  //    together with the energy that the LayerCluster reconstructed from the CaloParticle and the score. The energy 
+  //    is not the energy of the LayerCluster, but the energy of the LayerCluster coming from the CaloParticle. 
+  //    So, there will be energy of the LayerCluster that is disregarded here, since there may be LayerCluster's 
+  //    cells that the CaloParticle didn't contribute. 
   struct caloParticleOnLayer {
     unsigned int caloParticleId;
     float energy = 0;
@@ -32,8 +48,17 @@ namespace hgcal {
     std::unordered_map<int, std::pair<float, float>> layerClusterIdToEnergyAndScore;
   };
 
+  // This object connects a LayerCluster, identified through its id (lcId), with a vector containing all the CaloParticles 
+  // (via their ids (cpIds)) that share at least one cell with the LayerCluster. For that pair (lcId,cpId) it 
+  // stores the score. Keep in mind that the association is not unique, since there could be several instances 
+  // of the same CaloParticle from several related SimClusters that each contributed to the same LayerCluster. 
   typedef std::vector<std::vector<std::pair<unsigned int, float>>> layerClusterToCaloParticle;
+  // This is used to save the caloParticleOnLayer structure for all CaloParticles in each layer. 
+  // It is not exactly what is returned outside, but out of its entries, the output object is build.   
   typedef std::vector<std::vector<hgcal::caloParticleOnLayer>> caloParticleToLayerCluster;
+  //This is the output of the makeConnections function that contain all the work with CP2LC and LC2CP 
+  //association. It will be read by the relevant associateSimToReco and associateRecoToSim functions to 
+  //provide the final product.  
   typedef std::tuple<layerClusterToCaloParticle, caloParticleToLayerCluster> association;
 }  // namespace hgcal
 

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSCAssociatorByEnergyScoreImpl.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSCAssociatorByEnergyScoreImpl.cc
@@ -35,9 +35,9 @@ hgcal::association LCToSCAssociatorByEnergyScoreImpl::makeConnections(
   }
   nSimClusters = sCIndices.size();
 
-  // Initialize lcsInSimCluster. It contains the simClusterOnLayer structure for all simClusters in each layer and 
+  // Initialize lcsInSimCluster. It contains the simClusterOnLayer structure for all simClusters in each layer and
   // among other the information to compute the SimCluster-To-LayerCluster score. It is one of the two objects that
-  // build the output of the makeConnections function. 
+  // build the output of the makeConnections function.
   // lcsInSimCluster[scId][layerId]
   hgcal::simClusterToLayerCluster lcsInSimCluster;
   lcsInSimCluster.resize(nSimClusters);
@@ -51,10 +51,10 @@ hgcal::association LCToSCAssociatorByEnergyScoreImpl::makeConnections(
   }
 
   // Fill detIdToSimClusterId_Map and update lcsInSimCluster
-  // The detIdToSimClusterId_Map is used to connect a hit Detid (key) with all the SimClusters that 
-  // contributed to that hit by storing the SimCluster id and the fraction of the hit. Observe here 
-  // that in contrast to the CaloParticle case there is no merging and summing of the fractions, which 
-  // in the CaloParticle's case was necessary due to the multiple SimClusters of a single CaloParticle. 
+  // The detIdToSimClusterId_Map is used to connect a hit Detid (key) with all the SimClusters that
+  // contributed to that hit by storing the SimCluster id and the fraction of the hit. Observe here
+  // that in contrast to the CaloParticle case there is no merging and summing of the fractions, which
+  // in the CaloParticle's case was necessary due to the multiple SimClusters of a single CaloParticle.
   std::unordered_map<DetId, std::vector<hgcal::detIdInfoInCluster>> detIdToSimClusterId_Map;
   for (const auto& scId : sCIndices) {
     const auto& hits_and_fractions = simClusters[scId].hits_and_fractions();
@@ -110,10 +110,10 @@ hgcal::association LCToSCAssociatorByEnergyScoreImpl::makeConnections(
     LogDebug("LCToSCAssociatorByEnergyScoreImpl")
         << "For detId: " << (uint32_t)sc.first
         << " we have found the following connections with SimClusters:" << std::endl;
-    // At this point here if you activate the printing you will notice cases where in a 
+    // At this point here if you activate the printing you will notice cases where in a
     // specific detId there are more that one SimClusters contributing with fractions less than 1.
-    // This is important since it effects the score computation, since the fraction is also in the 
-    // denominator of the score formula. 
+    // This is important since it effects the score computation, since the fraction is also in the
+    // denominator of the score formula.
     for (auto const& sclu : sc.second) {
       LogDebug("LCToSCAssociatorByEnergyScoreImpl")
           << "  SimCluster Id: " << sclu.clusterId << " with fraction: " << sclu.fraction
@@ -123,12 +123,12 @@ hgcal::association LCToSCAssociatorByEnergyScoreImpl::makeConnections(
 #endif
 
   // Fill detIdToLayerClusterId_Map and scsInLayerCluster; update lcsInSimCluster
-  // The detIdToLayerClusterId_Map is used to connect a hit Detid (key) with all the LayerClusters that 
-  // contributed to that hit by storing the LayerCluster id and the fraction of the corresponding hit. 
+  // The detIdToLayerClusterId_Map is used to connect a hit Detid (key) with all the LayerClusters that
+  // contributed to that hit by storing the LayerCluster id and the fraction of the corresponding hit.
   std::unordered_map<DetId, std::vector<hgcal::detIdInfoInCluster>> detIdToLayerClusterId_Map;
-  // scsInLayerCluster together with lcsInSimCluster are the two objects that are used to build the 
-  // output of the makeConnections function. scsInLayerCluster connects a LayerCluster with 
-  // all the SimClusters that share at least one cell with the LayerCluster and for each pair (LC,SC) 
+  // scsInLayerCluster together with lcsInSimCluster are the two objects that are used to build the
+  // output of the makeConnections function. scsInLayerCluster connects a LayerCluster with
+  // all the SimClusters that share at least one cell with the LayerCluster and for each pair (LC,SC)
   // it stores the score.
   hgcal::layerClusterToSimCluster scsInLayerCluster;  //[lcId][scId]->(score)
   scsInLayerCluster.resize(nLayerClusters);
@@ -354,8 +354,8 @@ hgcal::association LCToSCAssociatorByEnergyScoreImpl::makeConnections(
       continue;
     }
 
-    // Compute the correct normalization. 
-    // It is the inverse of the denominator of the LCToSC score formula. Observe that this is the sum of the squares. 
+    // Compute the correct normalization.
+    // It is the inverse of the denominator of the LCToSC score formula. Observe that this is the sum of the squares.
     float invLayerClusterEnergyWeight = 0.f;
     for (auto const& haf : clusters[lcId].hitsAndFractions()) {
       invLayerClusterEnergyWeight +=
@@ -411,7 +411,7 @@ hgcal::association LCToSCAssociatorByEnergyScoreImpl::makeConnections(
       int lcWithMaxEnergyInSC = -1;
       //energy of the most energetic LC from all that were linked to SC
       float maxEnergyLCinSC = 0.f;
-      //Energy of the SC scId on layer layerId that was reconstructed. 
+      //Energy of the SC scId on layer layerId that was reconstructed.
       float SCenergy = lcsInSimCluster[scId][layerId].energy;
       //most energetic LC from all LCs linked to SC over SC energy.
       float SCEnergyFractionInLC = 0.f;
@@ -435,7 +435,7 @@ hgcal::association LCToSCAssociatorByEnergyScoreImpl::makeConnections(
           << "\t" << std::setw(18) << lcWithMaxEnergyInSC << "\t" << std::setw(15) << maxEnergyLCinSC << "\t"
           << std::setw(20) << SCEnergyFractionInLC << "\n";
 #endif
-      // Compute the correct normalization. Observe that this is the sum of the squares. 
+      // Compute the correct normalization. Observe that this is the sum of the squares.
       float invSCEnergyWeight = 0.f;
       for (auto const& haf : lcsInSimCluster[scId][layerId].hits_and_fractions) {
         invSCEnergyWeight += std::pow(haf.second * hitMap_->at(haf.first)->energy(), 2);
@@ -490,8 +490,8 @@ hgcal::association LCToSCAssociatorByEnergyScoreImpl::makeConnections(
             << (lcPair.second.first / SCenergy) << "\n";
       }
 #endif
-    } // End of loop over layers
-  } // End of loop over SimClusters
+    }  // End of loop over layers
+  }    // End of loop over SimClusters
 
   return {scsInLayerCluster, lcsInSimCluster};
 }

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSCAssociatorByEnergyScoreImpl.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSCAssociatorByEnergyScoreImpl.cc
@@ -35,9 +35,10 @@ hgcal::association LCToSCAssociatorByEnergyScoreImpl::makeConnections(
   }
   nSimClusters = sCIndices.size();
 
-  // Initialize lcsInSimCluster. To be returned outside, since it contains the
-  // information to compute the SimCluster-To-LayerCluster score.
-  // lcsInSimCluster[scId][layerId]:
+  // Initialize lcsInSimCluster. It contains the simClusterOnLayer structure for all simClusters in each layer and 
+  // among other the information to compute the SimCluster-To-LayerCluster score. It is one of the two objects that
+  // build the output of the makeConnections function. 
+  // lcsInSimCluster[scId][layerId]
   hgcal::simClusterToLayerCluster lcsInSimCluster;
   lcsInSimCluster.resize(nSimClusters);
   for (unsigned int i = 0; i < nSimClusters; ++i) {
@@ -50,6 +51,10 @@ hgcal::association LCToSCAssociatorByEnergyScoreImpl::makeConnections(
   }
 
   // Fill detIdToSimClusterId_Map and update lcsInSimCluster
+  // The detIdToSimClusterId_Map is used to connect a hit Detid (key) with all the SimClusters that 
+  // contributed to that hit by storing the SimCluster id and the fraction of the hit. Observe here 
+  // that in contrast to the CaloParticle case there is no merging and summing of the fractions, which 
+  // in the CaloParticle's case was necessary due to the multiple SimClusters of a single CaloParticle. 
   std::unordered_map<DetId, std::vector<hgcal::detIdInfoInCluster>> detIdToSimClusterId_Map;
   for (const auto& scId : sCIndices) {
     const auto& hits_and_fractions = simClusters[scId].hits_and_fractions();
@@ -76,6 +81,7 @@ hgcal::association LCToSCAssociatorByEnergyScoreImpl::makeConnections(
 #ifdef EDM_ML_DEBUG
   LogDebug("LCToSCAssociatorByEnergyScoreImpl")
       << "lcsInSimCluster INFO (Only SimCluster filled at the moment)" << std::endl;
+  LogDebug("LCToSCAssociatorByEnergyScoreImpl") << "    # of clusters :          " << nLayerClusters << std::endl;
   for (size_t sc = 0; sc < lcsInSimCluster.size(); ++sc) {
     LogDebug("LCToSCAssociatorByEnergyScoreImpl") << "For SimCluster Idx: " << sc << " we have: " << std::endl;
     for (size_t sclay = 0; sclay < lcsInSimCluster[sc].size(); ++sclay) {
@@ -84,7 +90,6 @@ hgcal::association LCToSCAssociatorByEnergyScoreImpl::makeConnections(
           << "    SimClusterIdx: " << lcsInSimCluster[sc][sclay].simClusterId << std::endl;
       LogDebug("LCToSCAssociatorByEnergyScoreImpl")
           << "    Energy:          " << lcsInSimCluster[sc][sclay].energy << std::endl;
-      LogDebug("LCToSCAssociatorByEnergyScoreImpl") << "    # of clusters :          " << nLayerClusters << std::endl;
       double tot_energy = 0.;
       for (auto const& haf : lcsInSimCluster[sc][sclay].hits_and_fractions) {
         LogDebug("LCToSCAssociatorByEnergyScoreImpl")
@@ -105,6 +110,10 @@ hgcal::association LCToSCAssociatorByEnergyScoreImpl::makeConnections(
     LogDebug("LCToSCAssociatorByEnergyScoreImpl")
         << "For detId: " << (uint32_t)sc.first
         << " we have found the following connections with SimClusters:" << std::endl;
+    // At this point here if you activate the printing you will notice cases where in a 
+    // specific detId there are more that one SimClusters contributing with fractions less than 1.
+    // This is important since it effects the score computation, since the fraction is also in the 
+    // denominator of the score formula. 
     for (auto const& sclu : sc.second) {
       LogDebug("LCToSCAssociatorByEnergyScoreImpl")
           << "  SimCluster Id: " << sclu.clusterId << " with fraction: " << sclu.fraction
@@ -114,12 +123,14 @@ hgcal::association LCToSCAssociatorByEnergyScoreImpl::makeConnections(
 #endif
 
   // Fill detIdToLayerClusterId_Map and scsInLayerCluster; update lcsInSimCluster
+  // The detIdToLayerClusterId_Map is used to connect a hit Detid (key) with all the LayerClusters that 
+  // contributed to that hit by storing the LayerCluster id and the fraction of the corresponding hit. 
   std::unordered_map<DetId, std::vector<hgcal::detIdInfoInCluster>> detIdToLayerClusterId_Map;
-  // this contains the ids of the simclusters contributing with at least one
-  // hit to the layer cluster and the reconstruction error. To be returned
-  // since this contains the information to compute the
-  // LayerCluster-To-SimCluster score.
-  hgcal::layerClusterToSimCluster scsInLayerCluster;  //[lcId][scId]->(energy,score)
+  // scsInLayerCluster together with lcsInSimCluster are the two objects that are used to build the 
+  // output of the makeConnections function. scsInLayerCluster connects a LayerCluster with 
+  // all the SimClusters that share at least one cell with the LayerCluster and for each pair (LC,SC) 
+  // it stores the score.
+  hgcal::layerClusterToSimCluster scsInLayerCluster;  //[lcId][scId]->(score)
   scsInLayerCluster.resize(nLayerClusters);
 
   for (unsigned int lcId = 0; lcId < nLayerClusters; ++lcId) {
@@ -343,7 +354,8 @@ hgcal::association LCToSCAssociatorByEnergyScoreImpl::makeConnections(
       continue;
     }
 
-    // Compute the correct normalization
+    // Compute the correct normalization. 
+    // It is the inverse of the denominator of the LCToSC score formula. Observe that this is the sum of the squares. 
     float invLayerClusterEnergyWeight = 0.f;
     for (auto const& haf : clusters[lcId].hitsAndFractions()) {
       invLayerClusterEnergyWeight +=
@@ -399,6 +411,7 @@ hgcal::association LCToSCAssociatorByEnergyScoreImpl::makeConnections(
       int lcWithMaxEnergyInSC = -1;
       //energy of the most energetic LC from all that were linked to SC
       float maxEnergyLCinSC = 0.f;
+      //Energy of the SC scId on layer layerId that was reconstructed. 
       float SCenergy = lcsInSimCluster[scId][layerId].energy;
       //most energetic LC from all LCs linked to SC over SC energy.
       float SCEnergyFractionInLC = 0.f;
@@ -422,7 +435,7 @@ hgcal::association LCToSCAssociatorByEnergyScoreImpl::makeConnections(
           << "\t" << std::setw(18) << lcWithMaxEnergyInSC << "\t" << std::setw(15) << maxEnergyLCinSC << "\t"
           << std::setw(20) << SCEnergyFractionInLC << "\n";
 #endif
-      // Compute the correct normalization
+      // Compute the correct normalization. Observe that this is the sum of the squares. 
       float invSCEnergyWeight = 0.f;
       for (auto const& haf : lcsInSimCluster[scId][layerId].hits_and_fractions) {
         invSCEnergyWeight += std::pow(haf.second * hitMap_->at(haf.first)->energy(), 2);
@@ -477,8 +490,9 @@ hgcal::association LCToSCAssociatorByEnergyScoreImpl::makeConnections(
             << (lcPair.second.first / SCenergy) << "\n";
       }
 #endif
-    }
-  }
+    } // End of loop over layers
+  } // End of loop over SimClusters
+
   return {scsInLayerCluster, lcsInSimCluster};
 }
 

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSCAssociatorByEnergyScoreImpl.h
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSCAssociatorByEnergyScoreImpl.h
@@ -16,9 +16,9 @@ namespace edm {
 
 namespace hgcal {
   // This structure is used both for LayerClusters and SimClusters storing their id and the fraction of a hit
-  // that belongs to the LayerCluster or SimCluster. The meaning of the operator is extremely important since 
+  // that belongs to the LayerCluster or SimCluster. The meaning of the operator is extremely important since
   // this struct will be used inside maps and other containers and when searching for one particular occurence
-  // only the clusterId member will be used in the check, skipping the fraction part. 
+  // only the clusterId member will be used in the check, skipping the fraction part.
   struct detIdInfoInCluster {
     bool operator==(const detIdInfoInCluster &o) const { return clusterId == o.clusterId; };
     long unsigned int clusterId;
@@ -30,15 +30,15 @@ namespace hgcal {
   };
 
   // This introduces a simCluster on layer concept. For a simCluster it stores:
-  // 1. Its id: simClusterId. 
-  // 2. The energy that the simCluster deposited in a specific layer and it was reconstructed. 
-  // 3. The hits_and_fractions that contributed to that deposition. SimHits that aren't reconstructed 
-  //    and doesn't have any matched rechits are disregarded. 
-  // 4. A map to save the LayerClusters ids (id is the key) that reconstructed at least one SimHit of the simCluster under study 
-  //    together with the energy that the Layercluster reconstructed from the SimClusters and the score. The energy 
-  //    is not the energy of the LayerCluster, but the energy of the LayerCluster coming from the SimCluster. 
-  //    So, there will be energy of the LayerCluster that is disregarded here, since there may be LayerCluster's 
-  //    cells that the SimCluster didn't contribute. 
+  // 1. Its id: simClusterId.
+  // 2. The energy that the simCluster deposited in a specific layer and it was reconstructed.
+  // 3. The hits_and_fractions that contributed to that deposition. SimHits that aren't reconstructed
+  //    and doesn't have any matched rechits are disregarded.
+  // 4. A map to save the LayerClusters ids (id is the key) that reconstructed at least one SimHit of the simCluster under study
+  //    together with the energy that the Layercluster reconstructed from the SimClusters and the score. The energy
+  //    is not the energy of the LayerCluster, but the energy of the LayerCluster coming from the SimCluster.
+  //    So, there will be energy of the LayerCluster that is disregarded here, since there may be LayerCluster's
+  //    cells that the SimCluster didn't contribute.
   struct simClusterOnLayer {
     unsigned int simClusterId;
     float energy = 0;
@@ -46,16 +46,16 @@ namespace hgcal {
     std::unordered_map<int, std::pair<float, float>> layerClusterIdToEnergyAndScore;
   };
 
-  // This object connects a LayerCluster, identified through its id (lcId), with a vector of pairs containing all the SimClusters 
-  // (via their ids (scIds)) that share at least one cell with the LayerCluster. In that pair it 
-  // stores the score (lcId->(scId,score)). 
+  // This object connects a LayerCluster, identified through its id (lcId), with a vector of pairs containing all the SimClusters
+  // (via their ids (scIds)) that share at least one cell with the LayerCluster. In that pair it
+  // stores the score (lcId->(scId,score)).
   typedef std::vector<std::vector<std::pair<unsigned int, float>>> layerClusterToSimCluster;
-  // This is used to save the simClusterOnLayer structure for all simClusters in each layer. 
-  // It is not exactly what is returned outside, but out of its entries, the output object is build. 
+  // This is used to save the simClusterOnLayer structure for all simClusters in each layer.
+  // It is not exactly what is returned outside, but out of its entries, the output object is build.
   typedef std::vector<std::vector<hgcal::simClusterOnLayer>> simClusterToLayerCluster;
-  //This is the output of the makeConnections function that contain all the work with SC2LC and LC2SC 
-  //association. It will be read by the relevant associateSimToReco and associateRecoToSim functions to 
-  //provide the final product.  
+  //This is the output of the makeConnections function that contain all the work with SC2LC and LC2SC
+  //association. It will be read by the relevant associateSimToReco and associateRecoToSim functions to
+  //provide the final product.
   typedef std::tuple<layerClusterToSimCluster, simClusterToLayerCluster> association;
 }  // namespace hgcal
 

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSCAssociatorByEnergyScoreImpl.h
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSCAssociatorByEnergyScoreImpl.h
@@ -15,6 +15,10 @@ namespace edm {
 }
 
 namespace hgcal {
+  // This structure is used both for LayerClusters and SimClusters storing the id and the fraction of a hit
+  // that belongs to the LayerCluster or SimCluster. The meaning of the operator is extremely important since 
+  // this struct will be used inside maps and other containers and when searching for one particular occurence
+  // only the clusterId member will be used in the check skipping the fraction part. 
   struct detIdInfoInCluster {
     bool operator==(const detIdInfoInCluster &o) const { return clusterId == o.clusterId; };
     long unsigned int clusterId;
@@ -25,13 +29,15 @@ namespace hgcal {
     }
   };
 
-  struct detIdInfoInMultiCluster {
-    bool operator==(const detIdInfoInMultiCluster &o) const { return multiclusterId == o.multiclusterId; };
-    unsigned int multiclusterId;
-    long unsigned int clusterId;
-    float fraction;
-  };
-
+  // For a simCluster it stores:
+  // 1. Its id: simClusterId. 
+  // 2. The energy that the simCluster deposited in a specific layer and it was reconstructed. 
+  // 3. The hits_and_fractions that contributed to that deposition. SimHits that aren't reconstructed 
+  //    and doesn't have any matched rechits are disgarded. 
+  // 4. A map to save the LayerClusters ids (id is the key) that reconstructed at least one SimHit of the simCluster under study 
+  //    together with the energy that the Layercluster reconstructed from the SimClusters and the score. The energy 
+  //    is not the energy of the LayerCluster, but the energy coming from the SimCluster. So, there will be energy of 
+  //    the LayerCluster that is disregarded here, since there may be LayerCluster's cells that the SimCluster didn't contributed. 
   struct simClusterOnLayer {
     unsigned int simClusterId;
     float energy = 0;
@@ -40,7 +46,12 @@ namespace hgcal {
   };
 
   typedef std::vector<std::vector<std::pair<unsigned int, float>>> layerClusterToSimCluster;
+  // This is used to save the simClusterOnLayer structure for all simClusters in each layer. 
+  // This is not exactly what is returned outside, but out of its entries, the output object is build. 
   typedef std::vector<std::vector<hgcal::simClusterOnLayer>> simClusterToLayerCluster;
+  //This is the output of the makeConnections function that contain all the work with SC2LC and LC2SC 
+  //association. It will be read by the relevant associateRecoToSim and associateSimToReco functions to 
+  //provide the final product.  
   typedef std::tuple<layerClusterToSimCluster, simClusterToLayerCluster> association;
 }  // namespace hgcal
 

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSCAssociatorByEnergyScoreImpl.h
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSCAssociatorByEnergyScoreImpl.h
@@ -15,10 +15,10 @@ namespace edm {
 }
 
 namespace hgcal {
-  // This structure is used both for LayerClusters and SimClusters storing the id and the fraction of a hit
+  // This structure is used both for LayerClusters and SimClusters storing their id and the fraction of a hit
   // that belongs to the LayerCluster or SimCluster. The meaning of the operator is extremely important since 
   // this struct will be used inside maps and other containers and when searching for one particular occurence
-  // only the clusterId member will be used in the check skipping the fraction part. 
+  // only the clusterId member will be used in the check, skipping the fraction part. 
   struct detIdInfoInCluster {
     bool operator==(const detIdInfoInCluster &o) const { return clusterId == o.clusterId; };
     long unsigned int clusterId;
@@ -36,8 +36,9 @@ namespace hgcal {
   //    and doesn't have any matched rechits are disregarded. 
   // 4. A map to save the LayerClusters ids (id is the key) that reconstructed at least one SimHit of the simCluster under study 
   //    together with the energy that the Layercluster reconstructed from the SimClusters and the score. The energy 
-  //    is not the energy of the LayerCluster, but the energy coming from the SimCluster. So, there will be energy of 
-  //    the LayerCluster that is disregarded here, since there may be LayerCluster's cells that the SimCluster didn't contributed. 
+  //    is not the energy of the LayerCluster, but the energy of the LayerCluster coming from the SimCluster. 
+  //    So, there will be energy of the LayerCluster that is disregarded here, since there may be LayerCluster's 
+  //    cells that the SimCluster didn't contribute. 
   struct simClusterOnLayer {
     unsigned int simClusterId;
     float energy = 0;

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSCAssociatorByEnergyScoreImpl.h
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSCAssociatorByEnergyScoreImpl.h
@@ -46,9 +46,9 @@ namespace hgcal {
     std::unordered_map<int, std::pair<float, float>> layerClusterIdToEnergyAndScore;
   };
 
-  // This object connects a LayerCluster, identified through its id (lcId), with a vector containing all the SimClusters 
-  // (via their ids (scIds)) that share at least one cell with the LayerCluster. For that pair (lcId,scId) it 
-  // stores the score. 
+  // This object connects a LayerCluster, identified through its id (lcId), with a vector of pairs containing all the SimClusters 
+  // (via their ids (scIds)) that share at least one cell with the LayerCluster. In that pair it 
+  // stores the score (lcId->(scId,score)). 
   typedef std::vector<std::vector<std::pair<unsigned int, float>>> layerClusterToSimCluster;
   // This is used to save the simClusterOnLayer structure for all simClusters in each layer. 
   // It is not exactly what is returned outside, but out of its entries, the output object is build. 

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSCAssociatorByEnergyScoreImpl.h
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSCAssociatorByEnergyScoreImpl.h
@@ -29,11 +29,11 @@ namespace hgcal {
     }
   };
 
-  // For a simCluster it stores:
+  // This introduces a simCluster on layer concept. For a simCluster it stores:
   // 1. Its id: simClusterId. 
   // 2. The energy that the simCluster deposited in a specific layer and it was reconstructed. 
   // 3. The hits_and_fractions that contributed to that deposition. SimHits that aren't reconstructed 
-  //    and doesn't have any matched rechits are disgarded. 
+  //    and doesn't have any matched rechits are disregarded. 
   // 4. A map to save the LayerClusters ids (id is the key) that reconstructed at least one SimHit of the simCluster under study 
   //    together with the energy that the Layercluster reconstructed from the SimClusters and the score. The energy 
   //    is not the energy of the LayerCluster, but the energy coming from the SimCluster. So, there will be energy of 
@@ -45,12 +45,15 @@ namespace hgcal {
     std::unordered_map<int, std::pair<float, float>> layerClusterIdToEnergyAndScore;
   };
 
+  // This object connects a LayerCluster, identified through its id (lcId), with a vector containing all the SimClusters 
+  // (via their ids (scIds)) that share at least one cell with the LayerCluster. For that pair (lcId,scId) it 
+  // stores the score. 
   typedef std::vector<std::vector<std::pair<unsigned int, float>>> layerClusterToSimCluster;
   // This is used to save the simClusterOnLayer structure for all simClusters in each layer. 
-  // This is not exactly what is returned outside, but out of its entries, the output object is build. 
+  // It is not exactly what is returned outside, but out of its entries, the output object is build. 
   typedef std::vector<std::vector<hgcal::simClusterOnLayer>> simClusterToLayerCluster;
   //This is the output of the makeConnections function that contain all the work with SC2LC and LC2SC 
-  //association. It will be read by the relevant associateRecoToSim and associateSimToReco functions to 
+  //association. It will be read by the relevant associateSimToReco and associateRecoToSim functions to 
   //provide the final product.  
   typedef std::tuple<layerClusterToSimCluster, simClusterToLayerCluster> association;
 }  // namespace hgcal

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSAssociatorByEnergyScoreImpl.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSAssociatorByEnergyScoreImpl.cc
@@ -34,9 +34,9 @@ hgcal::association TSToSimTSAssociatorByEnergyScoreImpl::makeConnections(
   }
   nSimTracksters = sTIndices.size();
 
-  // Initialize tssInSimTrackster. It contains the simTracksterOnLayer structure for all CaloParticles in each layer and 
+  // Initialize tssInSimTrackster. It contains the simTracksterOnLayer structure for all CaloParticles in each layer and
   // among other the information to compute the SimTrackster-To-Trackster score. It is one of the two objects that
-  // build the output of the makeConnections function. 
+  // build the output of the makeConnections function.
   // tssInSimTrackster[stId]
   hgcal::simTracksterToTrackster tssInSimTrackster;
   tssInSimTrackster.resize(nSimTracksters);
@@ -47,9 +47,9 @@ hgcal::association TSToSimTSAssociatorByEnergyScoreImpl::makeConnections(
   }
 
   // Fill lcToSimTracksterId_Map and update tssInSimTrackster
-  // The lcToSimTracksterId_Map is used to connect a LayerCluster, via its id (key), with all the SimTracksters that 
+  // The lcToSimTracksterId_Map is used to connect a LayerCluster, via its id (key), with all the SimTracksters that
   // contributed to that LayerCluster by storing the SimTrackster id and the fraction of the LayerCluster's energy
-  // in which the SimTrackster contributed. 
+  // in which the SimTrackster contributed.
   std::unordered_map<int, std::vector<hgcal::lcInfoInTrackster>> lcToSimTracksterId_Map;
   for (const auto& stId : sTIndices) {
     const auto& lcs = simTracksters[stId].vertices();

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSAssociatorByEnergyScoreImpl.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSAssociatorByEnergyScoreImpl.cc
@@ -108,7 +108,7 @@ hgcal::association TSToSimTSAssociatorByEnergyScoreImpl::makeConnections(
   // this contains the ids of the simTracksters contributing with at least one
   // hit to the Trackster. To be returned since this contains the information
   // to compute the Trackster-To-SimTrackster score.
-  hgcal::tracksterToSimTrackster stsInTrackster;  //[tsId][stId]->(energy,score)
+  hgcal::tracksterToSimTrackster stsInTrackster;  // tsId->(stId,score)
   stsInTrackster.resize(nTracksters);
 
   for (unsigned int tsId = 0; tsId < nTracksters; ++tsId) {

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSAssociatorByEnergyScoreImpl.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSAssociatorByEnergyScoreImpl.cc
@@ -34,9 +34,10 @@ hgcal::association TSToSimTSAssociatorByEnergyScoreImpl::makeConnections(
   }
   nSimTracksters = sTIndices.size();
 
-  // Initialize tssInSimTrackster. To be returned outside, since it contains the
-  // information to compute the SimTrackster-To-Trackster score.
-  // tssInSimTrackster[stId]:
+  // Initialize tssInSimTrackster. It contains the simTracksterOnLayer structure for all CaloParticles in each layer and 
+  // among other the information to compute the SimTrackster-To-Trackster score. It is one of the two objects that
+  // build the output of the makeConnections function. 
+  // tssInSimTrackster[stId]
   hgcal::simTracksterToTrackster tssInSimTrackster;
   tssInSimTrackster.resize(nSimTracksters);
   for (unsigned int i = 0; i < nSimTracksters; ++i) {
@@ -46,6 +47,9 @@ hgcal::association TSToSimTSAssociatorByEnergyScoreImpl::makeConnections(
   }
 
   // Fill lcToSimTracksterId_Map and update tssInSimTrackster
+  // The lcToSimTracksterId_Map is used to connect a LayerCluster, via its id (key), with all the SimTracksters that 
+  // contributed to that LayerCluster by storing the SimTrackster id and the fraction of the LayerCluster's energy
+  // in which the SimTrackster contributed. 
   std::unordered_map<int, std::vector<hgcal::lcInfoInTrackster>> lcToSimTracksterId_Map;
   for (const auto& stId : sTIndices) {
     const auto& lcs = simTracksters[stId].vertices();

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSAssociatorByEnergyScoreImpl.h
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSAssociatorByEnergyScoreImpl.h
@@ -15,12 +15,12 @@ namespace edm {
 }
 
 namespace hgcal {
-  // This structure is used for SimTracksters storing its id and the energy fraction of 
-  // a LayerCluster that is related to that SimTrackster. Be careful not to be confused by the fact that 
-  // similar structs are used in other HGCAL associators where the fraction is a hit's fraction. 
-  // The meaning of the operator is extremely important since this struct will be used inside maps and 
-  // other containers and when searching for one particular occurence only the clusterId member will be 
-  // used in the check, skipping the fraction part. 
+  // This structure is used for SimTracksters storing its id and the energy fraction of
+  // a LayerCluster that is related to that SimTrackster. Be careful not to be confused by the fact that
+  // similar structs are used in other HGCAL associators where the fraction is a hit's fraction.
+  // The meaning of the operator is extremely important since this struct will be used inside maps and
+  // other containers and when searching for one particular occurence only the clusterId member will be
+  // used in the check, skipping the fraction part.
   struct lcInfoInTrackster {
     bool operator==(const lcInfoInTrackster &o) const { return clusterId == o.clusterId; };
     long unsigned int clusterId;
@@ -31,20 +31,20 @@ namespace hgcal {
     }
   };
 
-  // In this structure, although it contains LayerClusters and per layer information through them, 
-  // most of the information is 3D information. For a simTrackster it stores: 
-  // 1. Its id: simTracksterId. 
-  // 2. The energy related to the SimTrackster. It is the sum of the LayerClusters energy in which a SimCluster 
-  //    contributed. Therefore, there will be energy from each LayerCluster that is disregarded. 
-  // 3. lcs_and_fractions: This is a vector of pairs. The pair is build from the LayerCluster id and the energy 
-  //    fraction of that LayerCluster which contributed to SimTrackster under study. So, be careful this is not the 
-  //    fraction of the hits. This is the fraction of the LayerCluster's energy in which the SimCluster contributed. 
-  //    This quantifies the statement above in 2 about the disregarded energy, by exactly storing the ratio of the 
-  //    reconstructed from SimCluster energy over the total LayerCluster energy. 
-  // 4. A map to save the tracksters id (id is the key) that have at least one LayerCluster in common with the 
-  //    SimTrackster under study together with the energy and score. Energy in this case is defined as the sum of all 
-  //    LayerClusters (shared between the SimTrackster and the trackster) energy (coming from SimCluster of the SimTrackster) 
-  //    times the LayerCluster's fraction in trackster.  
+  // In this structure, although it contains LayerClusters and per layer information through them,
+  // most of the information is 3D information. For a simTrackster it stores:
+  // 1. Its id: simTracksterId.
+  // 2. The energy related to the SimTrackster. It is the sum of the LayerClusters energy in which a SimCluster
+  //    contributed. Therefore, there will be energy from each LayerCluster that is disregarded.
+  // 3. lcs_and_fractions: This is a vector of pairs. The pair is build from the LayerCluster id and the energy
+  //    fraction of that LayerCluster which contributed to SimTrackster under study. So, be careful this is not the
+  //    fraction of the hits. This is the fraction of the LayerCluster's energy in which the SimCluster contributed.
+  //    This quantifies the statement above in 2 about the disregarded energy, by exactly storing the ratio of the
+  //    reconstructed from SimCluster energy over the total LayerCluster energy.
+  // 4. A map to save the tracksters id (id is the key) that have at least one LayerCluster in common with the
+  //    SimTrackster under study together with the energy and score. Energy in this case is defined as the sum of all
+  //    LayerClusters (shared between the SimTrackster and the trackster) energy (coming from SimCluster of the SimTrackster)
+  //    times the LayerCluster's fraction in trackster.
   struct simTracksterOnLayer {
     unsigned int simTracksterId;
     float energy = 0;
@@ -52,13 +52,13 @@ namespace hgcal {
     std::unordered_map<int, std::pair<float, float>> tracksterIdToEnergyAndScore;
   };
 
-  // This object connects a Trackster, identified through its id (tsId), with a vector of pairs containing all 
-  // the SimTracksters (via their ids (stIds)) that share at least one LayerCluster. In that pair 
-  // it stores the score (tsId->(stId,score)). Keep in mind that the association is not unique, since there could be 
-  // several instances of the same SimTrackster from several related SimClusters that each contributed to the same Trackster. 
-  typedef std::vector<std::vector<std::pair<unsigned int, float>>> tracksterToSimTrackster; 
-  // This is used to save the simTracksterOnLayer structure for all simTracksters. 
-  // It is not exactly what is returned outside, but out of its entries, the output object is build.   
+  // This object connects a Trackster, identified through its id (tsId), with a vector of pairs containing all
+  // the SimTracksters (via their ids (stIds)) that share at least one LayerCluster. In that pair
+  // it stores the score (tsId->(stId,score)). Keep in mind that the association is not unique, since there could be
+  // several instances of the same SimTrackster from several related SimClusters that each contributed to the same Trackster.
+  typedef std::vector<std::vector<std::pair<unsigned int, float>>> tracksterToSimTrackster;
+  // This is used to save the simTracksterOnLayer structure for all simTracksters.
+  // It is not exactly what is returned outside, but out of its entries, the output object is build.
   typedef std::vector<hgcal::simTracksterOnLayer> simTracksterToTrackster;
   typedef std::tuple<tracksterToSimTrackster, simTracksterToTrackster> association;
 }  // namespace hgcal

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSAssociatorByEnergyScoreImpl.h
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSAssociatorByEnergyScoreImpl.h
@@ -15,6 +15,12 @@ namespace edm {
 }
 
 namespace hgcal {
+  // This structure is used for SimTracksters storing its id and the energy fraction of 
+  // a LayerCluster that is related to that SimTrackster. Be careful not to be confused by the fact that 
+  // similar structs are used in other HGCAL associators where the fraction is a hit's fraction. 
+  // The meaning of the operator is extremely important since this struct will be used inside maps and 
+  // other containers and when searching for one particular occurence only the clusterId member will be 
+  // used in the check, skipping the fraction part. 
   struct lcInfoInTrackster {
     bool operator==(const lcInfoInTrackster &o) const { return clusterId == o.clusterId; };
     long unsigned int clusterId;
@@ -25,6 +31,20 @@ namespace hgcal {
     }
   };
 
+  // In this structure, although it contains LayerClusters and per layer information through them, 
+  // most of the information is 3D information. For a simTrackster it stores: 
+  // 1. Its id: simTracksterId. 
+  // 2. The energy related to the SimTrackster. It is the sum of the LayerClusters energy in which a SimCluster 
+  //    contributed. Therefore, there will be energy from each LayerCluster that is disregarded. 
+  // 3. lcs_and_fractions: This is a vector of pairs. The pair is build from the LayerCluster id and the energy 
+  //    fraction of that LayerCluster which contributed to SimTrackster under study. So, be careful this is not the 
+  //    fraction of the hits. This is the fraction of the LayerCluster's energy in which the SimCluster contributed. 
+  //    This quantifies the statement above in 2 about the disregarded energy, by exactly storing the ratio of the 
+  //    reconstructed from SimCluster energy over the total LayerCluster energy. 
+  // 4. A map to save the tracksters id (id is the key) that have at least one LayerCluster in common with the 
+  //    SimTrackster under study together with the energy and score. Energy in this case is defined as the sum of all 
+  //    LayerClusters (shared between the SimTrackster and the trackster) energy (coming from SimCluster of the SimTrackster) 
+  //    times the LayerCluster's fraction in trackster.  
   struct simTracksterOnLayer {
     unsigned int simTracksterId;
     float energy = 0;
@@ -32,7 +52,13 @@ namespace hgcal {
     std::unordered_map<int, std::pair<float, float>> tracksterIdToEnergyAndScore;
   };
 
-  typedef std::vector<std::vector<std::pair<unsigned int, float>>> tracksterToSimTrackster;
+  // This object connects a Trackster, identified through its id (tsId), with a vector of pairs containing all 
+  // the SimTracksters (via their ids (stIds)) that share at least one LayerCluster. In that pair 
+  // it stores the score (tsId->(stId,score)). Keep in mind that the association is not unique, since there could be 
+  // several instances of the same SimTrackster from several related SimClusters that each contributed to the same Trackster. 
+  typedef std::vector<std::vector<std::pair<unsigned int, float>>> tracksterToSimTrackster; 
+  // This is used to save the simTracksterOnLayer structure for all simTracksters. 
+  // It is not exactly what is returned outside, but out of its entries, the output object is build.   
   typedef std::vector<hgcal::simTracksterOnLayer> simTracksterToTrackster;
   typedef std::tuple<tracksterToSimTrackster, simTracksterToTrackster> association;
 }  // namespace hgcal


### PR DESCRIPTION
#### PR description:

This PR addresses the following issues: 
1. It includes some comments in HGCAL associators to make some complicated objects easier to understand. 
2. It removes the unused deprecated detIdInfoInMultiCluster struct. 

#### PR validation:

Tested locally with workflow `34624.0`. We expect no differences in any workflow.
  
#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not a backport. 

@rovere @felicepantaleo @lecriste @ebrondol 