### PR TITLE
Modernize `Configuration/Skimming` and `DPGAnalysis/Skims`

### DIFF
--- a/Configuration/Skimming/interface/LeptonRecoSkim.h
+++ b/Configuration/Skimming/interface/LeptonRecoSkim.h
@@ -17,15 +17,13 @@
 #include <fstream>
 
 // user include files
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
-
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/one/EDFilter.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 
 //includes for reco objects
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
@@ -54,7 +52,7 @@
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "FWCore/Common/interface/TriggerNames.h"
 
-class LeptonRecoSkim : public edm::EDFilter {
+class LeptonRecoSkim : public edm::one::EDFilter<> {
 public:
   explicit LeptonRecoSkim(const edm::ParameterSet&);
   ~LeptonRecoSkim() override;
@@ -66,15 +64,20 @@ private:
 
   void handleObjects(const edm::Event&, const edm::EventSetup& iSetup);
 
+  // ----------member data ---------------------------
+  const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> m_CaloGeoToken;
+  const edm::ESGetToken<CaloTopology, CaloTopologyRecord> m_CaloTopoToken;
+
   edm::InputTag hltLabel;
   std::string filterName;
-  edm::InputTag m_electronSrc;
-  edm::InputTag m_pfelectronSrc;
-  edm::InputTag m_muonSrc;
-  edm::InputTag m_jetsSrc;
-  edm::InputTag m_pfjetsSrc;
-  edm::InputTag m_ebRecHitsSrc;
-  edm::InputTag m_eeRecHitsSrc;
+
+  edm::EDGetTokenT<reco::GsfElectronCollection> gsfElectronCollectionToken_;
+  edm::EDGetTokenT<reco::PFCandidateCollection> pfCandidateCollectionToken_;
+  edm::EDGetTokenT<reco::MuonCollection> muonCollectionToken_;
+  edm::EDGetTokenT<reco::CaloJetCollection> caloJetCollectionToken_;
+  edm::EDGetTokenT<reco::PFJetCollection> pfJetCollectionToken_;
+  edm::EDGetTokenT<EcalRecHitCollection> ebRecHitCollectionToken_;
+  edm::EDGetTokenT<EcalRecHitCollection> eeRecHitCollectionToken_;
 
   const reco::GsfElectronCollection* theElectronCollection;
   const reco::PFCandidateCollection* thePfCandidateCollection;
@@ -119,5 +122,4 @@ private:
 
   int NtotalElectrons;
   int NmvaElectrons;
-  // ----------member data ---------------------------
 };

--- a/Configuration/Skimming/src/LeptonSkimming.cc
+++ b/Configuration/Skimming/src/LeptonSkimming.cc
@@ -1,10 +1,10 @@
 
 // -*- C++ -*-
 //
-// Package:    SkimmingForB/LeptonSkimming
+// Package:    Configuration/Skimming
 // Class:      LeptonSkimming
 //
-/**\class LeptonSkimming LeptonSkimming.cc SkimmingForB/LeptonSkimming/plugins/LeptonSkimming.cc
+/**\class LeptonSkimming LeptonSkimming.cc Configuration/Skimming/src/LeptonSkimming.cc
 
  Description: [one line class summary]
 

--- a/DPGAnalysis/Skims/interface/BeamSplash.h
+++ b/DPGAnalysis/Skims/interface/BeamSplash.h
@@ -17,7 +17,7 @@
 // user include files
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -28,7 +28,7 @@
 // class declaration
 //
 
-class BeamSplash : public edm::EDFilter {
+class BeamSplash : public edm::stream::EDFilter<> {
 public:
   explicit BeamSplash(const edm::ParameterSet &);
   ~BeamSplash() override;

--- a/DPGAnalysis/Skims/interface/CSCSkim.h
+++ b/DPGAnalysis/Skims/interface/CSCSkim.h
@@ -20,7 +20,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/one/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -69,7 +69,7 @@
 #include "TString.h"
 #include "TTree.h"
 
-class CSCSkim : public edm::EDFilter {
+class CSCSkim : public edm::one::EDFilter<> {
 public:
   // Constructor
   explicit CSCSkim(const edm::ParameterSet &pset);
@@ -136,6 +136,9 @@ private:
   // file names
   std::string outputFileName;
   std::string histogramFileName;
+
+  // es token names
+  const edm::ESGetToken<CSCGeometry, MuonGeometryRecord> m_CSCGeomToken;
 
   // token names
   edm::EDGetTokenT<CSCWireDigiCollection> wds_token;

--- a/DPGAnalysis/Skims/interface/ECALActivity.h
+++ b/DPGAnalysis/Skims/interface/ECALActivity.h
@@ -17,7 +17,7 @@
 // user include files
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -28,7 +28,7 @@
 // class declaration
 //
 
-class ECALActivity : public edm::EDFilter {
+class ECALActivity : public edm::stream::EDFilter<> {
 public:
   explicit ECALActivity(const edm::ParameterSet &);
   ~ECALActivity() override;

--- a/DPGAnalysis/Skims/interface/EcalSkim.h
+++ b/DPGAnalysis/Skims/interface/EcalSkim.h
@@ -22,7 +22,7 @@
 // user include files
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -41,7 +41,7 @@
 
 class TFile;
 
-class EcalSkim : public edm::EDFilter {
+class EcalSkim : public edm::stream::EDFilter<> {
 public:
   explicit EcalSkim(const edm::ParameterSet &);
   ~EcalSkim() override;

--- a/DPGAnalysis/Skims/interface/EcalTangentFilter.h
+++ b/DPGAnalysis/Skims/interface/EcalTangentFilter.h
@@ -3,31 +3,29 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include <DataFormats/TrackReco/interface/Track.h>
-#include <DataFormats/TrackReco/interface/TrackBase.h>
-#include <DataFormats/MuonReco/interface/Muon.h>
-#include <DataFormats/MuonReco/interface/MuonFwd.h>
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackBase.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
 
 //
 // class declaration
 //
 
-class EcalTangentFilter : public edm::EDFilter {
+class EcalTangentFilter : public edm::stream::EDFilter<> {
 public:
   explicit EcalTangentFilter(const edm::ParameterSet&);
   ~EcalTangentFilter() override;
 
 private:
-  void beginJob() override;
   bool filter(edm::Event&, const edm::EventSetup&) override;
-  void endJob() override;
 
   // ----------member data ---------------------------
   int fNgood, fNtot, fEvt;

--- a/DPGAnalysis/Skims/interface/FilterOutScraping.h
+++ b/DPGAnalysis/Skims/interface/FilterOutScraping.h
@@ -17,7 +17,7 @@
 // user include files
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -30,7 +30,7 @@
 // class declaration
 //
 
-class FilterOutScraping : public edm::EDFilter {
+class FilterOutScraping : public edm::stream::EDFilter<> {
 public:
   explicit FilterOutScraping(const edm::ParameterSet &);
   ~FilterOutScraping() override;

--- a/DPGAnalysis/Skims/interface/FilterScrapingPixelProbability.h
+++ b/DPGAnalysis/Skims/interface/FilterScrapingPixelProbability.h
@@ -27,7 +27,7 @@
 // user include files
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -39,7 +39,7 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 
-class FilterScrapingPixelProbability : public edm::EDFilter {
+class FilterScrapingPixelProbability : public edm::stream::EDFilter<> {
 public:
   explicit FilterScrapingPixelProbability(const edm::ParameterSet &);
   ~FilterScrapingPixelProbability() override;

--- a/DPGAnalysis/Skims/interface/HLTInspect.h
+++ b/DPGAnalysis/Skims/interface/HLTInspect.h
@@ -17,7 +17,7 @@
 // user include files
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -28,7 +28,7 @@
 // class declaration
 //
 
-class HLTInspect : public edm::EDAnalyzer {
+class HLTInspect : public edm::one::EDAnalyzer<> {
 public:
   explicit HLTInspect(const edm::ParameterSet&);
   ~HLTInspect() override;

--- a/DPGAnalysis/Skims/interface/MatchedProbeMaker.h
+++ b/DPGAnalysis/Skims/interface/MatchedProbeMaker.h
@@ -16,7 +16,7 @@
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/Candidate/interface/CandMatchMap.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -27,7 +27,7 @@
 //
 
 template <typename T>
-class MatchedProbeMaker : public edm::EDProducer {
+class MatchedProbeMaker : public edm::one::EDProducer<> {
 public:
   typedef std::vector<T> collection;
 

--- a/DPGAnalysis/Skims/interface/MuonPtFilter.h
+++ b/DPGAnalysis/Skims/interface/MuonPtFilter.h
@@ -13,7 +13,7 @@
 
 /* Base Class Headers */
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -27,7 +27,7 @@ class Propagator;
 
 /* Class MuonPtFilter Interface */
 
-class MuonPtFilter : public edm::EDFilter {
+class MuonPtFilter : public edm::stream::EDFilter<> {
 public:
   /// Constructor
   MuonPtFilter(const edm::ParameterSet &);

--- a/DPGAnalysis/Skims/interface/PhysDecl.h
+++ b/DPGAnalysis/Skims/interface/PhysDecl.h
@@ -17,7 +17,7 @@
 // user include files
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/one/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -31,7 +31,7 @@
 // class declaration
 //
 
-class PhysDecl : public edm::EDFilter {
+class PhysDecl : public edm::one::EDFilter<> {
 public:
   explicit PhysDecl(const edm::ParameterSet &);
   ~PhysDecl() override;

--- a/DPGAnalysis/Skims/interface/SelectHFMinBias.h
+++ b/DPGAnalysis/Skims/interface/SelectHFMinBias.h
@@ -17,20 +17,17 @@
 // user include files
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "DataFormats/TrackReco/interface/Track.h"
-#include "DataFormats/TrackReco/interface/TrackFwd.h"
 
 //
 // class declaration
 //
 
-class SelectHFMinBias : public edm::EDFilter {
+class SelectHFMinBias : public edm::stream::EDFilter<> {
 public:
   explicit SelectHFMinBias(const edm::ParameterSet &);
   ~SelectHFMinBias() override;

--- a/DPGAnalysis/Skims/interface/TagProbeMassEDMFilter.h
+++ b/DPGAnalysis/Skims/interface/TagProbeMassEDMFilter.h
@@ -24,7 +24,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/one/EDFilter.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -35,7 +35,7 @@
 // class declaration
 //
 
-class TagProbeMassEDMFilter : public edm::EDFilter {
+class TagProbeMassEDMFilter : public edm::one::EDFilter<> {
 public:
   explicit TagProbeMassEDMFilter(const edm::ParameterSet&);
   ~TagProbeMassEDMFilter() override;

--- a/DPGAnalysis/Skims/interface/TagProbeMassProducer.h
+++ b/DPGAnalysis/Skims/interface/TagProbeMassProducer.h
@@ -24,22 +24,20 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Candidate/interface/CandidateFwd.h"
 
 // forward declarations
 
-class TagProbeMassProducer : public edm::EDProducer {
+class TagProbeMassProducer : public edm::stream::EDProducer<> {
 public:
   explicit TagProbeMassProducer(const edm::ParameterSet&);
   ~TagProbeMassProducer() override;
 
 private:
-  void beginJob() override;
   void produce(edm::Event&, const edm::EventSetup&) override;
-  void endJob() override;
 
   bool isPassingProbe(const unsigned int iprobe) const;
 

--- a/DPGAnalysis/Skims/src/CSCSkim.cc
+++ b/DPGAnalysis/Skims/src/CSCSkim.cc
@@ -48,7 +48,7 @@ using namespace edm;
 //===================
 //  CONSTRUCTOR
 //===================
-CSCSkim::CSCSkim(const edm::ParameterSet& pset) {
+CSCSkim::CSCSkim(const edm::ParameterSet& pset) : m_CSCGeomToken(esConsumes()) {
   // tokens from tags
 
   // Really should define the wire and digi tags in config, but for now, to avoid having to modify
@@ -222,8 +222,7 @@ bool CSCSkim::filter(edm::Event& event, const edm::EventSetup& eventSetup) {
   LogDebug("[CSCSkim] EventInfo") << "Run: " << iRun << "\tEvent: " << iEvent << "\tn Analyzed: " << nEventsAnalyzed;
 
   // Get the CSC Geometry :
-  ESHandle<CSCGeometry> cscGeom;
-  eventSetup.get<MuonGeometryRecord>().get(cscGeom);
+  ESHandle<CSCGeometry> cscGeom = eventSetup.getHandle(m_CSCGeomToken);
 
   // Get the DIGI collections
   edm::Handle<CSCWireDigiCollection> wires;

--- a/DPGAnalysis/Skims/src/EcalTangentFilter.cc
+++ b/DPGAnalysis/Skims/src/EcalTangentFilter.cc
@@ -49,11 +49,5 @@ bool EcalTangentFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup
   return goodEvent;
 }
 
-// ------------ method called once each job just before starting event loop  ------------
-void EcalTangentFilter::beginJob() {}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void EcalTangentFilter::endJob() {}
-
 //define this as a plug-in
 DEFINE_FWK_MODULE(EcalTangentFilter);

--- a/DPGAnalysis/Skims/src/HCALHighEnergyFilter.cc
+++ b/DPGAnalysis/Skims/src/HCALHighEnergyFilter.cc
@@ -22,7 +22,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -45,15 +45,13 @@
 using namespace edm;
 //using namespace l1extra;
 
-class HCALHighEnergyFilter : public edm::EDFilter {
+class HCALHighEnergyFilter : public edm::stream::EDFilter<> {
 public:
   explicit HCALHighEnergyFilter(const edm::ParameterSet&);
   ~HCALHighEnergyFilter() override;
 
 private:
-  void beginJob() override;
   bool filter(edm::Event&, const edm::EventSetup&) override;
-  void endJob() override;
   //  bool jetGood(L1JetParticleCollection::const_iterator &);
   bool jetGood(reco::CaloJetCollection::const_iterator&);
   // ----------member data ---------------------------
@@ -133,12 +131,6 @@ bool HCALHighEnergyFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSe
 
   return false;
 }
-
-// ------------ method called once each job just before starting event loop  ------------
-void HCALHighEnergyFilter::beginJob() {}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void HCALHighEnergyFilter::endJob() {}
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(HCALHighEnergyFilter);

--- a/DPGAnalysis/Skims/src/HcalHPDFilter.cc
+++ b/DPGAnalysis/Skims/src/HcalHPDFilter.cc
@@ -22,7 +22,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -35,26 +35,16 @@
 // class declaration
 //
 
-class HcalHPDFilter : public edm::EDFilter {
+class HcalHPDFilter : public edm::stream::EDFilter<> {
 public:
   explicit HcalHPDFilter(const edm::ParameterSet&);
   ~HcalHPDFilter() override;
 
 private:
-  void beginJob() override;
   bool filter(edm::Event&, const edm::EventSetup&) override;
-  void endJob() override;
 
   // ----------member data ---------------------------
 };
-
-//
-// constants, enums and typedefs
-//
-
-//
-// static data member definitions
-//
 
 //
 // constructors and destructor
@@ -83,12 +73,6 @@ bool HcalHPDFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   }
   return false;
 }
-
-// ------------ method called once each job just before starting event loop  ------------
-void HcalHPDFilter::beginJob() {}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void HcalHPDFilter::endJob() {}
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(HcalHPDFilter);

--- a/DPGAnalysis/Skims/src/NMaxPerLumi.cc
+++ b/DPGAnalysis/Skims/src/NMaxPerLumi.cc
@@ -22,7 +22,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -33,15 +33,13 @@
 // class declaration
 //
 
-class NMaxPerLumi : public edm::EDFilter {
+class NMaxPerLumi : public edm::stream::EDFilter<> {
 public:
   explicit NMaxPerLumi(const edm::ParameterSet&);
   ~NMaxPerLumi() override;
 
 private:
-  void beginJob() override;
   bool filter(edm::Event&, const edm::EventSetup&) override;
-  void endJob() override;
 
   // ----------member data ---------------------------
   std::map<unsigned int, std::map<unsigned int, unsigned int> > counters;
@@ -85,12 +83,6 @@ bool NMaxPerLumi::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     return true;
   }
 }
-
-// ------------ method called once each job just before starting event loop  ------------
-void NMaxPerLumi::beginJob() {}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void NMaxPerLumi::endJob() {}
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(NMaxPerLumi);

--- a/DPGAnalysis/Skims/src/PickEvents.cc
+++ b/DPGAnalysis/Skims/src/PickEvents.cc
@@ -32,7 +32,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/one/EDFilter.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -51,7 +51,7 @@ bool orderLuminosityBlockRange(edm::LuminosityBlockRange u, edm::LuminosityBlock
 // class declaration
 //
 
-class PickEvents : public edm::EDFilter {
+class PickEvents : public edm::one::EDFilter<> {
 public:
   explicit PickEvents(const edm::ParameterSet&);
   ~PickEvents() override;

--- a/DPGAnalysis/Skims/src/RPCNoise.cc
+++ b/DPGAnalysis/Skims/src/RPCNoise.cc
@@ -28,7 +28,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/one/EDFilter.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -84,7 +84,7 @@ using namespace edm;
 // class declaration
 //
 
-class RPCNoise : public edm::EDFilter {
+class RPCNoise : public edm::one::EDFilter<> {
 public:
   explicit RPCNoise(const edm::ParameterSet &);
   ~RPCNoise() override;

--- a/DPGAnalysis/Skims/src/RPCRecHitFilter.cc
+++ b/DPGAnalysis/Skims/src/RPCRecHitFilter.cc
@@ -4,11 +4,8 @@
 //
 
 #include "DPGAnalysis/Skims/src/RPCRecHitFilter.h"
-//#include "../interface/RecHitFilter.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-//#include "DataFormats/RPCDigi/interface/RPCDigi.h"
-//#include "DataFormats/RPCDigi/interface/RPCDigiCollection.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -17,7 +14,6 @@
 #include "DataFormats/RPCRecHit/interface/RPCRecHitCollection.h"
 
 #include <Geometry/DTGeometry/interface/DTGeometry.h>
-#include <Geometry/RPCGeometry/interface/RPCGeometry.h>
 #include "Geometry/RPCGeometry/interface/RPCGeomServ.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
@@ -39,14 +35,6 @@
 #include "DataFormats/L1GlobalMuonTrigger/interface/L1MuGMTCand.h"
 #include "CondFormats/L1TObjects/interface/L1GtParameters.h"
 #include "CondFormats/DataRecord/interface/L1GtParametersRcd.h"
-
-/*#include "DataFormats/L1Trigger/interface/L1MuonParticleFwd.h"
-#include "DataFormats/L1GlobalMuonTrigger/interface/L1MuRegionalCand.h"
-
-#include "DataFormats/L1GlobalMuonTrigger/interface/L1MuGMTReadoutCollection.h"
-
-#include "DataFormats/L1GlobalMuonTrigger/interface/L1MuGMTCand.h"
-*/
 
 using namespace reco;
 
@@ -75,12 +63,12 @@ using namespace edm;
 using namespace reco;
 using namespace std;
 
-RPCRecHitFilter::RPCRecHitFilter(const edm::ParameterSet& iConfig) {
-  LogTrace("RPCEffTrackExtrapolation") << "Dentro Costruttore" << std::endl;
+RPCRecHitFilter::RPCRecHitFilter(const edm::ParameterSet& iConfig)
+    : rpcGeomToken_(esConsumes()), trackingGeoToken_(esConsumes()) {
+  LogTrace("RPCEffTrackExtrapolation") << "inside constructor" << std::endl;
 
-  RPCDataLabel = iConfig.getUntrackedParameter<std::string>("rpcRecHitLabel");
-
-  //  RPCRecHits = iConfig.getParameter< edm::InputTag >("RPCRecHits");
+  RPCDataLabel_ = iConfig.getUntrackedParameter<std::string>("rpcRecHitLabel");
+  rpcRecHitToken_ = consumes<RPCRecHitCollection>(edm::InputTag(RPCDataLabel_));
 
   centralBX_ = iConfig.getUntrackedParameter<int>("CentralBunchCrossing", 0);
   BXWindow_ = iConfig.getUntrackedParameter<int>("BunchCrossingWindow", 9999);
@@ -99,14 +87,10 @@ RPCRecHitFilter::RPCRecHitFilter(const edm::ParameterSet& iConfig) {
 }
 
 bool RPCRecHitFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  edm::ESHandle<RPCGeometry> rpcGeo;
-  iSetup.get<MuonGeometryRecord>().get(rpcGeo);
+  edm::ESHandle<RPCGeometry> rpcGeo = iSetup.getHandle(rpcGeomToken_);
+  edm::ESHandle<GlobalTrackingGeometry> theTrackingGeometry = iSetup.getHandle(trackingGeoToken_);
 
-  edm::Handle<RPCRecHitCollection> rpcHits;
-  iEvent.getByLabel(RPCDataLabel, rpcHits);
-
-  ESHandle<GlobalTrackingGeometry> theTrackingGeometry;
-  iSetup.get<GlobalTrackingGeometryRecord>().get(theTrackingGeometry);
+  edm::Handle<RPCRecHitCollection> rpcHits = iEvent.getHandle(rpcRecHitToken_);
 
   std::map<int, int> numberOfRecHitsBarrel;
   std::map<int, int> numberOfDigisBarrel;

--- a/DPGAnalysis/Skims/src/RPCRecHitFilter.h
+++ b/DPGAnalysis/Skims/src/RPCRecHitFilter.h
@@ -42,7 +42,8 @@
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHit.h"
 
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "Geometry/RPCGeometry/interface/RPCGeometry.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 
 #include "TDirectory.h"
 #include "TFile.h"
@@ -58,7 +59,7 @@ typedef std::vector<TrajectoryMeasurement> MeasurementContainer;
 typedef std::pair<const GeomDet *, TrajectoryStateOnSurface> DetWithState;
 typedef std::vector<Trajectory> Trajectories;
 
-class RPCRecHitFilter : public edm::EDFilter {
+class RPCRecHitFilter : public edm::stream::EDFilter<> {
 public:
   explicit RPCRecHitFilter(const edm::ParameterSet &);
   ~RPCRecHitFilter() override {}
@@ -66,7 +67,14 @@ public:
 private:
   bool filter(edm::Event &, const edm::EventSetup &) override;
 
-  std::string RPCDataLabel;
+  // es token
+  const edm::ESGetToken<RPCGeometry, MuonGeometryRecord> rpcGeomToken_;
+  const edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> trackingGeoToken_;
+
+  // event token
+  edm::EDGetTokenT<RPCRecHitCollection> rpcRecHitToken_;
+
+  std::string RPCDataLabel_;
 
   int centralBX_, BXWindow_, minHits_, hitsInStations_;
 

--- a/DPGAnalysis/Skims/src/RecHitEnergyFilter.cc
+++ b/DPGAnalysis/Skims/src/RecHitEnergyFilter.cc
@@ -22,7 +22,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -32,15 +32,13 @@
 // class declaration
 //
 
-class RecHitEnergyFilter : public edm::EDFilter {
+class RecHitEnergyFilter : public edm::stream::EDFilter<> {
 public:
   explicit RecHitEnergyFilter(const edm::ParameterSet&);
   ~RecHitEnergyFilter() override;
 
 private:
-  void beginJob() override;
   bool filter(edm::Event&, const edm::EventSetup&) override;
-  void endJob() override;
 
   // RecHit input tags
   edm::InputTag ebRecHitsTag_;
@@ -102,12 +100,6 @@ bool RecHitEnergyFilter::filter(edm::Event& evt, const edm::EventSetup& iSetup) 
 
   return false;
 }
-
-// ------------ method called once each job just before starting event loop  ------------
-void RecHitEnergyFilter::beginJob() {}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void RecHitEnergyFilter::endJob() {}
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(RecHitEnergyFilter);

--- a/DPGAnalysis/Skims/src/SecondaryVertexFilter.cc
+++ b/DPGAnalysis/Skims/src/SecondaryVertexFilter.cc
@@ -22,7 +22,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -36,7 +36,7 @@
 // class declaration
 //
 
-class SecondaryVertexFilter : public edm::EDFilter {
+class SecondaryVertexFilter : public edm::stream::EDFilter<> {
 public:
   explicit SecondaryVertexFilter(const edm::ParameterSet&);
   ~SecondaryVertexFilter() override;

--- a/DPGAnalysis/Skims/src/SelectHFMinBias.cc
+++ b/DPGAnalysis/Skims/src/SelectHFMinBias.cc
@@ -15,11 +15,9 @@
 
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "DPGAnalysis/Skims/interface/SelectHFMinBias.h"

--- a/DPGAnalysis/Skims/src/SimpleJetFilter.cc
+++ b/DPGAnalysis/Skims/src/SimpleJetFilter.cc
@@ -22,7 +22,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -45,15 +45,13 @@
 // class declaration
 //
 
-class SimpleJetFilter : public edm::EDFilter {
+class SimpleJetFilter : public edm::stream::EDFilter<> {
 public:
   explicit SimpleJetFilter(const edm::ParameterSet&);
   ~SimpleJetFilter() override;
 
 private:
-  void beginJob() override;
   bool filter(edm::Event&, const edm::EventSetup&) override;
-  void endJob() override;
 
   // ----------member data ---------------------------
 
@@ -64,14 +62,6 @@ private:
   const double m_njetmin;
   JetIDSelectionFunctor m_jetIDfunc;
 };
-
-//
-// constants, enums and typedefs
-//
-
-//
-// static data member definitions
-//
 
 //
 // constructors and destructor
@@ -138,12 +128,6 @@ bool SimpleJetFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) 
 
   return selected;
 }
-
-// ------------ method called once each job just before starting event loop  ------------
-void SimpleJetFilter::beginJob() {}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void SimpleJetFilter::endJob() {}
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(SimpleJetFilter);

--- a/DPGAnalysis/Skims/src/TagProbeMassProducer.cc
+++ b/DPGAnalysis/Skims/src/TagProbeMassProducer.cc
@@ -119,12 +119,6 @@ void TagProbeMassProducer::produce(edm::Event& iEvent, const edm::EventSetup& iS
   iEvent.put(std::move(TPmass), "TPmass");
 }
 
-// ------------ method called once each job just before starting event loop  ------------
-void TagProbeMassProducer::beginJob() {}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void TagProbeMassProducer::endJob() {}
-
 bool TagProbeMassProducer::isPassingProbe(const unsigned int iProbe) const {
   if (iProbe > probes->size())
     return false;

--- a/DPGAnalysis/Skims/src/WZInterestingEventSelector.cc
+++ b/DPGAnalysis/Skims/src/WZInterestingEventSelector.cc
@@ -14,7 +14,7 @@
 #include <cstdlib>
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/one/EDFilter.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -41,7 +41,7 @@
 
 using namespace reco;
 
-class WZInterestingEventSelector : public edm::EDFilter {
+class WZInterestingEventSelector : public edm::one::EDFilter<> {
 public:
   struct event {
     long run;


### PR DESCRIPTION
#### PR description:

Part of #31061. Migrates modules of `Configuration/Skimming` and `DPGAnalysis/Skims` to use `esConsumes`.
Profited of the PR to modernize the code and address several static analyzer warnings.

#### PR validation:

It compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A