### PR TITLE
ECAL esConsumes migration of Calibration packages

### DIFF
--- a/Calibration/EcalAlCaRecoProducers/plugins/SelectedElectronFEDListProducer.cc
+++ b/Calibration/EcalAlCaRecoProducers/plugins/SelectedElectronFEDListProducer.cc
@@ -57,8 +57,7 @@ SelectedElectronFEDListProducer<TEle, TCand>::SelectedElectronFEDListProducer(co
       caloGeometryToken_(esConsumes()),
       siPixelFedCablingMapToken_(esConsumes()),
       trackerGeometryToken_(esConsumes()),
-      siStripRegionCablingToken_(esConsumes())
-{
+      siStripRegionCablingToken_(esConsumes()) {
   // input electron collection Tag
   if (iConfig.existsAs<std::vector<edm::InputTag>>("electronTags")) {
     electronTags_ = iConfig.getParameter<std::vector<edm::InputTag>>("electronTags");

--- a/Calibration/EcalAlCaRecoProducers/plugins/SelectedElectronFEDListProducer.cc
+++ b/Calibration/EcalAlCaRecoProducers/plugins/SelectedElectronFEDListProducer.cc
@@ -296,31 +296,30 @@ void SelectedElectronFEDListProducer<TEle, TCand>::beginJob() {
 template <typename TEle, typename TCand>
 void SelectedElectronFEDListProducer<TEle, TCand>::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // get the hcal electronics map
-  const auto pSetup = iSetup.getHandle(hcalDbToken_);
-  HcalReadoutMap_ = pSetup->getHcalMapping();
+  const auto& pSetup = iSetup.getData(hcalDbToken_);
+  HcalReadoutMap_ = pSetup.getHcalMapping();
 
   // get the ecal electronics map
-  const auto ecalmapping = iSetup.getHandle(ecalMappingToken_);
-  EcalMapping_ = ecalmapping.product();
+  EcalMapping_ = &iSetup.getData(ecalMappingToken_);
 
   // get the calo geometry
-  const auto caloGeometry = iSetup.getHandle(caloGeometryToken_);
-  GeometryCalo_ = caloGeometry.product();
+  const auto& caloGeometry = iSetup.getData(caloGeometryToken_);
+  GeometryCalo_ = &caloGeometry;
 
   //ES geometry
-  GeometryES_ = caloGeometry->getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
+  GeometryES_ = caloGeometry.getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
 
   // pixel tracker cabling map
   const auto pixelCablingMap = iSetup.getTransientHandle(siPixelFedCablingMapToken_);
   PixelCabling_.reset();
   PixelCabling_ = pixelCablingMap->cablingTree();
 
-  const auto trackerGeometry = iSetup.getHandle(trackerGeometryToken_);
+  const auto& trackerGeometry = iSetup.getData(trackerGeometryToken_);
 
   if (pixelModuleVector_.empty()) {
     // build the tracker pixel module map
-    std::vector<const GeomDet*>::const_iterator itTracker = trackerGeometry->dets().begin();
-    for (; itTracker != trackerGeometry->dets().end(); ++itTracker) {
+    std::vector<const GeomDet*>::const_iterator itTracker = trackerGeometry.dets().begin();
+    for (; itTracker != trackerGeometry.dets().end(); ++itTracker) {
       int subdet = (*itTracker)->geographicalId().subdetId();
       if (!(subdet == PixelSubdetector::PixelBarrel || subdet == PixelSubdetector::PixelEndcap))
         continue;
@@ -339,8 +338,7 @@ void SelectedElectronFEDListProducer<TEle, TCand>::produce(edm::Event& iEvent, c
     std::sort(pixelModuleVector_.begin(), pixelModuleVector_.end());
   }
 
-  const auto SiStripCablingHandle = iSetup.getHandle(siStripRegionCablingToken_);
-  StripRegionCabling_ = SiStripCablingHandle.product();
+  StripRegionCabling_ = &iSetup.getData(siStripRegionCablingToken_);
 
   SiStripRegionCabling::Cabling SiStripCabling;
   SiStripCabling = StripRegionCabling_->getRegionCabling();

--- a/Calibration/EcalAlCaRecoProducers/plugins/SelectedElectronFEDListProducer.h
+++ b/Calibration/EcalAlCaRecoProducers/plugins/SelectedElectronFEDListProducer.h
@@ -1,17 +1,33 @@
-#ifndef SelectedElectronFEDListProducer_h
-#define SelectedElectronFEDListProducer_h
+#ifndef Calibration_EcalAlCaRecoProducers_SelectedElectronFEDListProducer_h
+#define Calibration_EcalAlCaRecoProducers_SelectedElectronFEDListProducer_h
 
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 // egamma objects
 #include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
 
+#include "Geometry/EcalMapping/interface/EcalElectronicsMapping.h"
+// Geometry
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/EcalMapping/interface/EcalMappingRcd.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+// strip geometry
+#include "CalibFormats/SiStripObjects/interface/SiStripRegionCabling.h"
+#include "CalibTracker/Records/interface/SiStripDetCablingRcd.h"
+#include "CalibTracker/Records/interface/SiStripRegionCablingRcd.h"
+// Strip and pixel
+#include "CondFormats/DataRecord/interface/SiPixelFedCablingMapRcd.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
+// Hcal objects
+#include "CalibFormats/HcalObjects/interface/HcalDbService.h"
+#include "CalibFormats/HcalObjects/interface/HcalDbRecord.h"
+
 // Math
 #include "DataFormats/Math/interface/normalizedPhi.h"
 
 #include "FWCore/Framework/interface/stream/EDProducer.h"
-// #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 // Message logger
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
@@ -19,14 +35,10 @@ class InputTag;
 
 class FEDRawDataCollection;
 
-class SiPixelFedCablingMap;
 class SiPixelFedCablingTree;
 class SiStripFedCabling;
-class SiStripRegionCabling;
 
-class CaloGeometry;
 class CaloSubdetectorGeometry;
-class EcalElectronicsMapping;
 class HcalElectronicsMap;
 
 // Hcal rec hit: this is a Fwd file defining typedefs
@@ -130,6 +142,14 @@ private:
   edm::EDGetTokenT<HBHERecHitCollection> hbheRecHitToken_;
   std::vector<edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> > recoEcalCandidateToken_;
   std::vector<edm::EDGetTokenT<TEleColl> > electronToken_;
+
+  // Token for the input collection
+  const edm::ESGetToken<HcalDbService, HcalDbRecord> hcalDbToken_;
+  const edm::ESGetToken<EcalElectronicsMapping, EcalMappingRcd> ecalMappingToken_;
+  const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeometryToken_;
+  const edm::ESGetToken<SiPixelFedCablingMap, SiPixelFedCablingMapRcd> siPixelFedCablingMapToken_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeometryToken_;
+  const edm::ESGetToken<SiStripRegionCabling, SiStripRegionCablingRcd> siStripRegionCablingToken_;
 
   // used inside the producer
   math::XYZVector beamSpotPosition_;

--- a/Calibration/EcalCalibAlgos/interface/ECALpedestalPCLHarvester.h
+++ b/Calibration/EcalCalibAlgos/interface/ECALpedestalPCLHarvester.h
@@ -29,6 +29,8 @@
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
 #include "CondFormats/EcalObjects/interface/EcalPedestals.h"
 #include "CondFormats/EcalObjects/interface/EcalChannelStatus.h"
+#include "CondFormats/DataRecord/interface/EcalPedestalsRcd.h"
+#include "CondFormats/DataRecord/interface/EcalChannelStatusRcd.h"
 
 class ECALpedestalPCLHarvester : public DQMEDHarvester {
 public:
@@ -41,24 +43,30 @@ private:
 
   void dqmPlots(const EcalPedestals& newpeds, DQMStore::IBooker& ibooker);
 
-  const EcalPedestals* currentPedestals_;
-  const EcalPedestals* g6g1Pedestals_;
-  const EcalChannelStatus* channelStatus_;
+  bool checkVariation(const EcalPedestalsMap& oldPedestals, const EcalPedestalsMap& newPedestals);
   bool checkStatusCode(const DetId& id);
   bool isGood(const DetId& id);
 
-  bool checkVariation(const EcalPedestalsMap& oldPedestals, const EcalPedestalsMap& newPedestals);
   std::vector<int> chStatusToExclude_;
-  int minEntries_;
+  const int minEntries_;
 
   int entriesEB_[EBDetId::kSizeForDenseIndexing];
   int entriesEE_[EEDetId::kSizeForDenseIndexing];
-  bool checkAnomalies_;           // whether or not to avoid creating sqlite file in case of many changed pedestals
-  double nSigma_;                 // threshold in sigmas to define a pedestal as changed
-  double thresholdAnomalies_;     // threshold (fraction of changed pedestals) to avoid creation of sqlite file
-  std::string dqmDir_;            // DQM directory where histograms are stored
-  std::string labelG6G1_;         // DB label from which pedestals for G6 and G1 are to be copied
-  float threshDiffEB_;            // if the new pedestals differs more than this from old, keep old
-  float threshDiffEE_;            // same as above for EE. Stray channel protection
-  float threshChannelsAnalyzed_;  // threshold for minimum percentage of channels analized to produce DQM plots
+  const bool checkAnomalies_;           // whether or not to avoid creating sqlite file in case of many changed pedestals
+  const double nSigma_;                 // threshold in sigmas to define a pedestal as changed
+  const double thresholdAnomalies_;     // threshold (fraction of changed pedestals) to avoid creation of sqlite file
+  const std::string dqmDir_;            // DQM directory where histograms are stored
+  const std::string labelG6G1_;         // DB label from which pedestals for G6 and G1 are to be copied
+  const float threshDiffEB_;            // if the new pedestals differs more than this from old, keep old
+  const float threshDiffEE_;            // same as above for EE. Stray channel protection
+  const float threshChannelsAnalyzed_;  // threshold for minimum percentage of channels analized to produce DQM plots
+
+  // ES token
+  const edm::ESGetToken<EcalChannelStatus, EcalChannelStatusRcd> channelsStatusToken_;
+  const edm::ESGetToken<EcalPedestals, EcalPedestalsRcd> pedestalsToken_;
+  const edm::ESGetToken<EcalPedestals, EcalPedestalsRcd> g6g1PedestalsToken_;
+
+  const EcalPedestals* currentPedestals_;
+  const EcalPedestals* g6g1Pedestals_;
+  const EcalChannelStatus* channelStatus_;
 };

--- a/Calibration/EcalCalibAlgos/interface/ECALpedestalPCLHarvester.h
+++ b/Calibration/EcalCalibAlgos/interface/ECALpedestalPCLHarvester.h
@@ -52,13 +52,13 @@ private:
 
   int entriesEB_[EBDetId::kSizeForDenseIndexing];
   int entriesEE_[EEDetId::kSizeForDenseIndexing];
-  const bool checkAnomalies_;           // whether or not to avoid creating sqlite file in case of many changed pedestals
-  const double nSigma_;                 // threshold in sigmas to define a pedestal as changed
-  const double thresholdAnomalies_;     // threshold (fraction of changed pedestals) to avoid creation of sqlite file
-  const std::string dqmDir_;            // DQM directory where histograms are stored
-  const std::string labelG6G1_;         // DB label from which pedestals for G6 and G1 are to be copied
-  const float threshDiffEB_;            // if the new pedestals differs more than this from old, keep old
-  const float threshDiffEE_;            // same as above for EE. Stray channel protection
+  const bool checkAnomalies_;        // whether or not to avoid creating sqlite file in case of many changed pedestals
+  const double nSigma_;              // threshold in sigmas to define a pedestal as changed
+  const double thresholdAnomalies_;  // threshold (fraction of changed pedestals) to avoid creation of sqlite file
+  const std::string dqmDir_;         // DQM directory where histograms are stored
+  const std::string labelG6G1_;      // DB label from which pedestals for G6 and G1 are to be copied
+  const float threshDiffEB_;         // if the new pedestals differs more than this from old, keep old
+  const float threshDiffEE_;         // same as above for EE. Stray channel protection
   const float threshChannelsAnalyzed_;  // threshold for minimum percentage of channels analized to produce DQM plots
 
   // ES token

--- a/Calibration/EcalCalibAlgos/interface/ECALpedestalPCLworker.h
+++ b/Calibration/EcalCalibAlgos/interface/ECALpedestalPCLworker.h
@@ -23,6 +23,8 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "CondFormats/EcalObjects/interface/EcalPedestals.h"
+#include "CondFormats/DataRecord/interface/EcalPedestalsRcd.h"
 #include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
 #include "DataFormats/TCDS/interface/BSTRecord.h"
 #include "DataFormats/TCDS/interface/TCDSRecord.h"
@@ -43,6 +45,7 @@ private:
   edm::EDGetTokenT<EBDigiCollection> digiTokenEB_;
   edm::EDGetTokenT<EEDigiCollection> digiTokenEE_;
   edm::EDGetTokenT<TCDSRecord> tcdsToken_;
+  const edm::ESGetToken<EcalPedestals, EcalPedestalsRcd> pedestalToken_;
 
   std::vector<MonitorElement *> meEB_;
   std::vector<MonitorElement *> meEE_;

--- a/Calibration/EcalCalibAlgos/interface/EcalEleCalibLooper.h
+++ b/Calibration/EcalCalibAlgos/interface/EcalEleCalibLooper.h
@@ -61,68 +61,65 @@ private:
   int etaShifter(const int) const;
 
 private:
-  //! ES token
-  const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> m_geometryToken;
-
   //! EcalBarrel Input Collection name
-  edm::InputTag m_barrelAlCa;
+  const edm::InputTag m_barrelAlCa;
   //! EcalEndcap Input Collection name
-  edm::InputTag m_endcapAlCa;
+  const edm::InputTag m_endcapAlCa;
+  //! To take the electrons
+  edm::InputTag m_ElectronLabel;
 
   //! reconstruction window size
-  int m_recoWindowSidex;
-  int m_recoWindowSidey;
+  const int m_recoWindowSidex;
+  const int m_recoWindowSidey;
 
   //! eta size of the sub-matrix
-  int m_etaWidth;  //PG sub matrix size and borders
+  const int m_etaWidth;  //PG sub matrix size and borders
   //! eta size of the additive border to the sub-matrix
   //    int m_etaBorder ; //FIXME
   //! phi size of the sub-matrix
-  int m_phiWidthEB;
+  const int m_phiWidthEB;
   //! phi size of the additive border to the sub-matrix
   //    int m_phiBorderEB //FIXME;
 
   //! eta start of the region of interest
-  int m_etaStart;  //PG ECAL region to be calibrated
+  const int m_etaStart;  //PG ECAL region to be calibrated
   //! eta end of the region of interest
-  int m_etaEnd;
+  const int m_etaEnd;
   //! phi start of the region of interest
-  int m_phiStartEB;
+  const int m_phiStartEB;
   //! phi end of the region of interest
-  int m_phiEndEB;
+  const int m_phiEndEB;
   //!DS For the EE
-  int m_radStart;
-  int m_radEnd;
-  int m_radWidth;
+  const int m_radStart;
+  const int m_radEnd;
+  const int m_radWidth;
   //FIXME    int m_radBorder ;
-  int m_phiStartEE;
-  int m_phiEndEE;
-  int m_phiWidthEE;
+  const int m_phiStartEE;
+  const int m_phiEndEE;
+  const int m_phiWidthEE;
 
   //! maximum number of events per crystal
-  int m_maxSelectedNumPerXtal;
+  const int m_maxSelectedNumPerXtal;
 
   //! single blocks calibrators
   std::vector<VEcalCalibBlock *> m_EcalCalibBlocks;
   //! minimum energy per crystal cut
-  double m_minEnergyPerCrystal;
+  const double m_minEnergyPerCrystal;
   //! maximum energy per crystal cut
-  double m_maxEnergyPerCrystal;
+  const double m_maxEnergyPerCrystal;
   //! minimum coefficient accepted (RAW)
-  double m_minCoeff;
+  const double m_minCoeff;
   //! maximum coefficient accepted (RAW)
-  double m_maxCoeff;
+  const double m_maxCoeff;
   //! to exclude the blocksolver
-  int m_usingBlockSolver;
+  const int m_usingBlockSolver;
 
   //!the maps of  recalib coeffs
   EcalIntercalibConstantMap m_barrelMap;
   EcalIntercalibConstantMap m_endcapMap;
 
   //! DS sets the number of loops to do
-  unsigned int m_loops;
-  //! To take the electrons
-  edm::InputTag m_ElectronLabel;
+  const unsigned int m_loops;
   //The map Filler
   VFillMap *m_MapFiller;
 
@@ -141,6 +138,13 @@ private:
   std::map<int, int> m_xtalNumOfHits;
 
   bool isfirstcall_;
+
+  //! ED token
+  const edm::EDGetTokenT<EBRecHitCollection> m_ebRecHitToken;
+  const edm::EDGetTokenT<EERecHitCollection> m_eeRecHitToken;
+  const edm::EDGetTokenT<reco::GsfElectronCollection> m_gsfElectronToken;
+  //! ES token
+  const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> m_geometryToken;
 };
 #endif
 #endif

--- a/Calibration/EcalCalibAlgos/interface/EcalEleCalibLooper.h
+++ b/Calibration/EcalCalibAlgos/interface/EcalEleCalibLooper.h
@@ -25,6 +25,8 @@
 #include "DataFormats/EgammaCandidates/interface/Electron.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
 
 #include "CLHEP/Matrix/GenMatrix.h"
 #include "CLHEP/Matrix/Matrix.h"
@@ -59,6 +61,9 @@ private:
   int etaShifter(const int) const;
 
 private:
+  //! ES token
+  const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> m_geometryToken;
+
   //! EcalBarrel Input Collection name
   edm::InputTag m_barrelAlCa;
   //! EcalEndcap Input Collection name

--- a/Calibration/EcalCalibAlgos/interface/ElectronCalibrationUniv.h
+++ b/Calibration/EcalCalibAlgos/interface/ElectronCalibrationUniv.h
@@ -24,7 +24,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -40,6 +40,9 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
+#include "DataFormats/EgammaCandidates/interface/Electron.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
 #include "Calibration/Tools/interface/HouseholderDecomposition.h"
 #include "Calibration/Tools/interface/MinL3Algorithm.h"
 #include "Calibration/Tools/interface/CalibrationCluster.h"
@@ -53,7 +56,8 @@
 // class decleration
 //
 
-class ElectronCalibrationUniv : public edm::EDAnalyzer {
+class ElectronCalibrationUniv : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
+
 public:
   explicit ElectronCalibrationUniv(const edm::ParameterSet &);
   ~ElectronCalibrationUniv() override;
@@ -61,6 +65,7 @@ public:
   void analyze(const edm::Event &, const edm::EventSetup &) override;
   void beginJob() override;
   void beginRun(edm::Run const &, edm::EventSetup const &) override;
+  void endRun(edm::Run const &, edm::EventSetup const &) override;
   void endJob() override;
 
 private:
@@ -69,35 +74,32 @@ private:
 
   // ----------member data ---------------------------
 
-  std::string rootfile_;
-  edm::InputTag EBrecHitLabel_;
-  edm::InputTag EErecHitLabel_;
-  edm::InputTag electronLabel_;
-  edm::InputTag trackLabel_;
-  std::string calibAlgo_;
-  std::string miscalibfile_;
-  std::string miscalibfileEndCap_;
-  int keventweight_;
-  double ElePt_;
-  int maxeta_;
-  int mineta_;
-  int maxphi_;
-  int minphi_;
-  double cut1_;
-  double cut2_;
-  double cut3_;
-  double cutEPCalo1_;
-  double cutEPCalo2_;
-  double cutEPin1_;
-  double cutEPin2_;
-  double cutCalo1_;
-  double cutCalo2_;
-  double cutESeed_;
-  int ClusterSize_;
-  int elecclass_;
-  int theMaxLoops;
-
-  bool FirstIteration;
+  const edm::InputTag ebRecHitLabel_;
+  const edm::InputTag eeRecHitLabel_;
+  const edm::InputTag electronLabel_;
+  const std::string rootfile_;
+  const std::string calibAlgo_;
+  const std::string miscalibfile_;
+  const std::string miscalibfileEndCap_;
+  const int keventweight_;
+  const double elePt_;
+  const int maxeta_;
+  const int mineta_;
+  const int maxphi_;
+  const int minphi_;
+  const double cut1_;
+  const double cut2_;
+  const double cut3_;
+  const int numevent_;
+  const double cutEPCalo1_;
+  const double cutEPCalo2_;
+  const double cutEPin1_;
+  const double cutEPin2_;
+  const double cutCalo1_;
+  const double cutCalo2_;
+  const double cutESeed_;
+  const int clusterSize_;
+  const int elecclass_;
 
   int read_events;
 
@@ -116,7 +118,11 @@ private:
   MinL3Algorithm *MyL3Algo1;
   MinL3AlgoUniv<DetId> *UnivL3;
 
-  edm::ESHandle<CaloTopology> theCaloTopology;
+  const edm::EDGetTokenT<EBRecHitCollection> ebRecHitToken_;
+  const edm::EDGetTokenT<EERecHitCollection> eeRecHitToken_;
+  const edm::EDGetTokenT<reco::GsfElectronCollection> gsfElectronToken_;
+  const edm::ESGetToken<CaloTopology, CaloTopologyRecord> topologyToken_;
+  edm::ESHandle<CaloTopology> theCaloTopology_;
 
   std::vector<float> solution;
   std::vector<float> solutionNoCuts;
@@ -126,7 +132,6 @@ private:
   std::map<DetId, float> Univsolution;
 
   // int eventcrystal[25][25];
-  int numevent_;
 
   TFile *f;
 

--- a/Calibration/EcalCalibAlgos/interface/ElectronCalibrationUniv.h
+++ b/Calibration/EcalCalibAlgos/interface/ElectronCalibrationUniv.h
@@ -26,7 +26,6 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 // Geometry
@@ -121,7 +120,7 @@ private:
   const edm::EDGetTokenT<EERecHitCollection> eeRecHitToken_;
   const edm::EDGetTokenT<reco::GsfElectronCollection> gsfElectronToken_;
   const edm::ESGetToken<CaloTopology, CaloTopologyRecord> topologyToken_;
-  edm::ESHandle<CaloTopology> theCaloTopology_;
+  const CaloTopology* theCaloTopology_;
 
   std::vector<float> solution;
   std::vector<float> solutionNoCuts;

--- a/Calibration/EcalCalibAlgos/interface/ElectronCalibrationUniv.h
+++ b/Calibration/EcalCalibAlgos/interface/ElectronCalibrationUniv.h
@@ -120,7 +120,7 @@ private:
   const edm::EDGetTokenT<EERecHitCollection> eeRecHitToken_;
   const edm::EDGetTokenT<reco::GsfElectronCollection> gsfElectronToken_;
   const edm::ESGetToken<CaloTopology, CaloTopologyRecord> topologyToken_;
-  const CaloTopology* theCaloTopology_;
+  const CaloTopology *theCaloTopology_;
 
   std::vector<float> solution;
   std::vector<float> solutionNoCuts;

--- a/Calibration/EcalCalibAlgos/interface/ElectronCalibrationUniv.h
+++ b/Calibration/EcalCalibAlgos/interface/ElectronCalibrationUniv.h
@@ -57,7 +57,6 @@
 //
 
 class ElectronCalibrationUniv : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
-
 public:
   explicit ElectronCalibrationUniv(const edm::ParameterSet &);
   ~ElectronCalibrationUniv() override;

--- a/Calibration/EcalCalibAlgos/interface/InvRingCalib.h
+++ b/Calibration/EcalCalibAlgos/interface/InvRingCalib.h
@@ -13,13 +13,17 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/CaloRecHit/interface/CaloRecHit.h"
+#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "CondFormats/EcalObjects/interface/EcalIntercalibConstants.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
 
 #include <string>
 #include <vector>
-//#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
-#include "DataFormats/CaloRecHit/interface/CaloRecHit.h"
 
 #include "Calibration/EcalCalibAlgos/interface/VFillMap.h"
 
@@ -60,37 +64,37 @@ private:
 
 private:
   //! EcalBarrel Input Collection name
-  edm::InputTag m_barrelAlCa;
+  const edm::InputTag m_barrelAlCa;
   //! EcalEndcap Input Collection name
-  edm::InputTag m_endcapAlCa;
+  const edm::InputTag m_endcapAlCa;
   //! To take the electrons
-  edm::InputTag m_ElectronLabel;
+  const edm::InputTag m_ElectronLabel;
   //! reconstruction window size
-  int m_recoWindowSidex;
-  int m_recoWindowSidey;
+  const int m_recoWindowSidex;
+  const int m_recoWindowSidey;
   //! minimum energy per crystal cut
-  double m_minEnergyPerCrystal;
+  const double m_minEnergyPerCrystal;
   //! maximum energy per crystal cut
-  double m_maxEnergyPerCrystal;
+  const double m_maxEnergyPerCrystal;
   //! eta start of the zone of interest
-  int m_etaStart;
+  const int m_etaStart;
   //! eta end of the zone of interest
-  int m_etaEnd;
+  const int m_etaEnd;
   //! eta size of the regions
-  int m_etaWidth;
+  const int m_etaWidth;
   //    std::map<int,float> m_eta;
   //! maximum number of events per Ring
-  int m_maxSelectedNumPerRing;
+  const int m_maxSelectedNumPerRing;
   //! number of events already read per Ring
   std::map<int, int> m_RingNumOfHits;
   //! single blocks calibrators
   std::vector<VEcalCalibBlock *> m_IMACalibBlocks;
   //! minimum coefficient accepted (RAW)
-  double m_minCoeff;
+  const double m_minCoeff;
   //! maximum coefficient accepted (RAW)
-  double m_maxCoeff;
+  const double m_maxCoeff;
   //! to exclude the blocksolver
-  int m_usingBlockSolver;
+  const int m_usingBlockSolver;
   //!position of the cell, borders, coords etc...
   std::map<int, GlobalPoint> m_cellPos;
   std::map<int, int> m_cellPhi;
@@ -101,8 +105,8 @@ private:
   //! LP sets the number of loops to do
   unsigned int m_loops;
   //! LP define the EE region to calibrate
-  int m_startRing;
-  int m_endRing;
+  const int m_startRing;
+  const int m_endRing;
   //!association map between Raw detIds and Rings
   std::map<int, int> m_xtalRing;
   //!association map between  raw detIds and Region
@@ -114,14 +118,21 @@ private:
   std::vector<DetId> m_barrelCells;
   std::vector<DetId> m_endcapCells;
   //!coeffs filenames
-  std::string m_EBcoeffFile;
-  std::string m_EEcoeffFile;
+  const std::string m_EBcoeffFile;
+  const std::string m_EEcoeffFile;
   //!endcap zone to be calibrated
-  int m_EEZone;
+  const int m_EEZone;
   //!EB regions vs. eta index
   std::map<int, int> m_Reg;
   std::string m_mapFillerType;
   bool isfirstcall_;
+
+  //! ED token
+  const edm::EDGetTokenT<EBRecHitCollection> m_ebRecHitToken;
+  const edm::EDGetTokenT<EERecHitCollection> m_eeRecHitToken;
+  const edm::EDGetTokenT<reco::GsfElectronCollection> m_gsfElectronToken;
+  //! ES token
+  const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> m_geometryToken;
 };
 #endif
 #endif

--- a/Calibration/EcalCalibAlgos/interface/PhiSymmetryCalibration.h
+++ b/Calibration/EcalCalibAlgos/interface/PhiSymmetryCalibration.h
@@ -127,7 +127,6 @@ private:
   const edm::EDGetTokenT<EERecHitCollection> eeRecHitToken_;
   const edm::ESGetToken<EcalChannelStatus, EcalChannelStatusRcd> channelStatusToken_;
   const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometryToken_;
-  edm::ESGetToken<EcalIntercalibConstants, EcalIntercalibConstantsRcd> intercalibConstantsToken_;
 
   // energy cut in the barrel
   const double eCut_barl_;

--- a/Calibration/EcalCalibAlgos/interface/PhiSymmetryCalibration.h
+++ b/Calibration/EcalCalibAlgos/interface/PhiSymmetryCalibration.h
@@ -36,7 +36,8 @@
 
 class TH1F;
 
-class PhiSymmetryCalibration : public edm::one::EDAnalyzer<edm::one::SharedResources, edm::one::WatchRuns, edm::one::WatchLuminosityBlocks> {
+class PhiSymmetryCalibration
+    : public edm::one::EDAnalyzer<edm::one::SharedResources, edm::one::WatchRuns, edm::one::WatchLuminosityBlocks> {
 public:
   /// Constructor
   PhiSymmetryCalibration(const edm::ParameterSet& iConfig);

--- a/Calibration/EcalCalibAlgos/interface/PhiSymmetryCalibration.h
+++ b/Calibration/EcalCalibAlgos/interface/PhiSymmetryCalibration.h
@@ -19,19 +19,24 @@
 #include "Calibration/EcalCalibAlgos/interface/EcalGeomPhiSymHelper.h"
 
 // Framework
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ProducerBase.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 
 #include "CondFormats/EcalObjects/interface/EcalIntercalibConstants.h"
+#include "CondFormats/DataRecord/interface/EcalIntercalibConstantsRcd.h"
+#include "CondFormats/EcalObjects/interface/EcalChannelStatus.h"
+#include "CondFormats/DataRecord/interface/EcalChannelStatusRcd.h"
+#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/DetId/interface/DetId.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
 
 class TH1F;
 
-class PhiSymmetryCalibration : public edm::EDAnalyzer {
+class PhiSymmetryCalibration : public edm::one::EDAnalyzer<edm::one::SharedResources, edm::one::WatchRuns, edm::one::WatchLuminosityBlocks> {
 public:
   /// Constructor
   PhiSymmetryCalibration(const edm::ParameterSet& iConfig);
@@ -41,7 +46,9 @@ public:
 
   /// Called at beginning of job
   void beginJob() override;
+  void beginRun(edm::Run const&, const edm::EventSetup&) override;
   void endRun(edm::Run const&, const edm::EventSetup&) override;
+  void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
   void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
   /// Called at end of job
@@ -111,27 +118,33 @@ private:
 
   // steering parameters
 
-  std::string ecalHitsProducer_;
-  std::string barrelHits_;
-  std::string endcapHits_;
+  const std::string ecalHitsProducer_;
+  const std::string barrelHits_;
+  const std::string endcapHits_;
+
+  const edm::EDGetTokenT<EBRecHitCollection> ebRecHitToken_;
+  const edm::EDGetTokenT<EERecHitCollection> eeRecHitToken_;
+  const edm::ESGetToken<EcalChannelStatus, EcalChannelStatusRcd> channelStatusToken_;
+  const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometryToken_;
+  edm::ESGetToken<EcalIntercalibConstants, EcalIntercalibConstantsRcd> intercalibConstantsToken_;
 
   // energy cut in the barrel
-  double eCut_barl_;
+  const double eCut_barl_;
 
   // parametrized energy cut EE : e_cut = ap + eta_ring*b
-  double ap_;
-  double b_;
+  const double ap_;
+  const double b_;
 
-  int eventSet_;
+  const int eventSet_;
   /// threshold in channel status beyond which channel is marked bad
-  int statusThreshold_;
+  const int statusThreshold_;
 
   static const int kMaxEndciPhi = 360;
 
   float phi_endc[kMaxEndciPhi][kEndcEtaRings];
 
-  bool reiteration_;
-  std::string oldcalibfile_;  //searched for in Calibration/EcalCalibAlgos/data
+  const bool reiteration_;
+  const std::string oldcalibfile_;  //searched for in Calibration/EcalCalibAlgos/data
 
   /// the old calibration constants (when reiterating, the last ones derived)
   EcalIntercalibConstants oldCalibs_;

--- a/Calibration/EcalCalibAlgos/interface/Pi0FixedMassWindowCalibration.h
+++ b/Calibration/EcalCalibAlgos/interface/Pi0FixedMassWindowCalibration.h
@@ -11,16 +11,15 @@
 // Framework
 #include "FWCore/Framework/interface/LooperFactory.h"
 #include "FWCore/Framework/interface/ESProducerLooper.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 
 #include "CondFormats/EcalObjects/interface/EcalIntercalibConstants.h"
+#include "CondFormats/DataRecord/interface/EcalIntercalibConstantsRcd.h"
 #include "DataFormats/DetId/interface/DetId.h"
 
 #include "DataFormats/EcalRecHit/interface/EcalRecHit.h"
@@ -34,13 +33,10 @@
 #include "DataFormats/EcalDetId/interface/ESDetId.h"
 #include "DataFormats/DetId/interface/DetId.h"
 
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "RecoEcal/EgammaClusterAlgos/interface/IslandClusterAlgo.h"
 #include "RecoEcal/EgammaCoreTools/interface/PositionCalc.h"
 #include "RecoEcal/EgammaCoreTools/interface/ClusterShapeAlgo.h"
@@ -87,9 +83,9 @@ private:
 
   int nevent;
 
-  unsigned int theMaxLoops;
-  std::string ecalHitsProducer_;
-  std::string barrelHits_;
+  const unsigned int theMaxLoops;
+  const std::string ecalHitsProducer_;
+  const std::string barrelHits_;
 
   IslandClusterAlgo::VerbosityLevel verbosity;
 
@@ -139,6 +135,10 @@ private:
 
   const EcalRecHitCollection* ecalRecHitBarrelCollection;
   const EcalRecHitCollection* recalibEcalRecHitCollection;
+
+  const edm::EDGetTokenT<EcalRecHitCollection> recHitToken_;
+  const edm::ESGetToken<EcalIntercalibConstants, EcalIntercalibConstantsRcd> intercalibConstantsToken_;
+  const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometryToken_;
 
   // root tree
   TFile* theFile;

--- a/Calibration/EcalCalibAlgos/interface/ZeeCalibration.h
+++ b/Calibration/EcalCalibAlgos/interface/ZeeCalibration.h
@@ -21,17 +21,16 @@
 #include <memory>
 #include <vector>
 #include <map>
+#include <string>
 
 // user include files
 #include "FWCore/Framework/interface/LooperFactory.h"
 #include "FWCore/Framework/interface/ESProducerLooper.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "Calibration/Tools/interface/ZIterativeAlgorithmWithFit.h"
 #include "Calibration/Tools/interface/CalibElectron.h"
@@ -42,8 +41,12 @@
 #include "CondFormats/EcalObjects/interface/EcalIntercalibConstants.h"
 #include "CondFormats/DataRecord/interface/EcalIntercalibConstantsRcd.h"
 
+#include "DataFormats/Common/interface/TriggerResults.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/DetId/interface/DetId.h"
+
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
 
 #include "TTree.h"
 #include "TFile.h"
@@ -53,17 +56,11 @@
 #include "TH2.h"
 
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/EgammaCandidates/interface/ElectronFwd.h"
 #include "DataFormats/EgammaCandidates/interface/Electron.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
-
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-#include <vector>
-#include <string>
 
 // class declaration
 //
@@ -145,23 +142,33 @@ private:
 
   std::string outputFileName_;
 
-  std::string rechitProducer_;
-  std::string rechitCollection_;
-  std::string erechitProducer_;
-  std::string erechitCollection_;
-  std::string scProducer_;
-  std::string scCollection_;
+  const edm::InputTag hlTriggerResults_;
 
-  std::string scIslandProducer_;
-  std::string scIslandCollection_;
+  const std::string mcProducer_;
+  const std::string rechitProducer_;
+  const std::string rechitCollection_;
+  const std::string erechitProducer_;
+  const std::string erechitCollection_;
+  const std::string scProducer_;
+  const std::string scCollection_;
 
-  std::string mcProducer_;
+  const std::string scIslandProducer_;
+  const std::string scIslandCollection_;
+
+  const std::string electronProducer_;
+  const std::string electronCollection_;
+
   std::string calibMode_;
 
-  std::string electronProducer_;
-  std::string electronCollection_;
+  const edm::EDGetTokenT<edm::TriggerResults> trigResultsToken_;
+  const edm::EDGetTokenT<edm::HepMCProduct> hepMCToken_;
+  const edm::EDGetTokenT<EBRecHitCollection> ebRecHitToken_;
+  const edm::EDGetTokenT<EERecHitCollection> eeRecHitToken_;
+  const edm::EDGetTokenT<reco::SuperClusterCollection> scToken_;
+  const edm::EDGetTokenT<reco::SuperClusterCollection> islandSCToken_;
+  const edm::EDGetTokenT<reco::GsfElectronCollection> gsfElectronToken_;
 
-  std::string RecalibBarrelHits_;
+  const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometryToken_;
 
   unsigned int etaBins_;
   unsigned int etBins_;
@@ -337,8 +344,6 @@ private:
 
   int CRACK_ELECTRONS_IN_BARREL;
   int CRACK_ELECTRONS_IN_ENDCAP;
-
-  edm::InputTag hlTriggerResults_;
 
   unsigned int nEvents_;  // number of events processed
 

--- a/Calibration/EcalCalibAlgos/src/ECALpedestalPCLHarvester.cc
+++ b/Calibration/EcalCalibAlgos/src/ECALpedestalPCLHarvester.cc
@@ -155,14 +155,9 @@ void ECALpedestalPCLHarvester::fillDescriptions(edm::ConfigurationDescriptions& 
 }
 
 void ECALpedestalPCLHarvester::endRun(edm::Run const& run, edm::EventSetup const& isetup) {
-  const auto chStatus = isetup.getHandle(channelsStatusToken_);
-  channelStatus_ = chStatus.product();
-
-  const auto peds = isetup.getHandle(pedestalsToken_);
-  currentPedestals_ = peds.product();
-
-  const auto g6g1peds = isetup.getHandle(g6g1PedestalsToken_);
-  g6g1Pedestals_ = g6g1peds.product();
+  channelStatus_ = &isetup.getData(channelsStatusToken_);
+  currentPedestals_ = &isetup.getData(pedestalsToken_);
+  g6g1Pedestals_ = &isetup.getData(g6g1PedestalsToken_);
 }
 
 bool ECALpedestalPCLHarvester::checkStatusCode(const DetId& id) {

--- a/Calibration/EcalCalibAlgos/src/ECALpedestalPCLHarvester.cc
+++ b/Calibration/EcalCalibAlgos/src/ECALpedestalPCLHarvester.cc
@@ -5,29 +5,29 @@
 // user include files
 #include "Calibration/EcalCalibAlgos/interface/ECALpedestalPCLHarvester.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "CondFormats/EcalObjects/interface/EcalChannelStatus.h"
 #include "CondFormats/EcalObjects/interface/EcalChannelStatusCode.h"
-#include "CondFormats/DataRecord/interface/EcalPedestalsRcd.h"
-#include "CondFormats/DataRecord/interface/EcalChannelStatusRcd.h"
 #include "CommonTools/Utils/interface/StringToEnumValue.h"
-#include <iostream>
 #include <string>
 
 ECALpedestalPCLHarvester::ECALpedestalPCLHarvester(const edm::ParameterSet& ps)
-    : currentPedestals_(nullptr), channelStatus_(nullptr) {
+    : minEntries_(ps.getParameter<int>("MinEntries")),
+      checkAnomalies_(ps.getParameter<bool>("checkAnomalies")),
+      nSigma_(ps.getParameter<double>("nSigma")),
+      thresholdAnomalies_(ps.getParameter<double>("thresholdAnomalies")),
+      dqmDir_(ps.getParameter<std::string>("dqmDir")),
+      labelG6G1_(ps.getParameter<std::string>("labelG6G1")),
+      threshDiffEB_(ps.getParameter<double>("threshDiffEB")),
+      threshDiffEE_(ps.getParameter<double>("threshDiffEE")),
+      threshChannelsAnalyzed_(ps.getParameter<double>("threshChannelsAnalyzed")),
+      channelsStatusToken_(esConsumes<edm::Transition::EndRun>()),
+      pedestalsToken_(esConsumes<edm::Transition::EndRun>()),
+      g6g1PedestalsToken_(esConsumes<edm::Transition::EndRun>(edm::ESInputTag("", labelG6G1_))),
+      currentPedestals_(nullptr),
+      g6g1Pedestals_(nullptr),
+      channelStatus_(nullptr) {
   chStatusToExclude_ = StringToEnumValue<EcalChannelStatusCode::Code>(
       ps.getParameter<std::vector<std::string> >("ChannelStatusToExclude"));
-  minEntries_ = ps.getParameter<int>("MinEntries");
-  checkAnomalies_ = ps.getParameter<bool>("checkAnomalies");
-  nSigma_ = ps.getParameter<double>("nSigma");
-  thresholdAnomalies_ = ps.getParameter<double>("thresholdAnomalies");
-  dqmDir_ = ps.getParameter<std::string>("dqmDir");
-  labelG6G1_ = ps.getParameter<std::string>("labelG6G1");
-  threshDiffEB_ = ps.getParameter<double>("threshDiffEB");
-  threshDiffEE_ = ps.getParameter<double>("threshDiffEE");
-  threshChannelsAnalyzed_ = ps.getParameter<double>("threshChannelsAnalyzed");
 }
 
 void ECALpedestalPCLHarvester::dqmEndJob(DQMStore::IBooker& ibooker_, DQMStore::IGetter& igetter_) {
@@ -155,16 +155,13 @@ void ECALpedestalPCLHarvester::fillDescriptions(edm::ConfigurationDescriptions& 
 }
 
 void ECALpedestalPCLHarvester::endRun(edm::Run const& run, edm::EventSetup const& isetup) {
-  edm::ESHandle<EcalChannelStatus> chStatus;
-  isetup.get<EcalChannelStatusRcd>().get(chStatus);
+  const auto chStatus = isetup.getHandle(channelsStatusToken_);
   channelStatus_ = chStatus.product();
 
-  edm::ESHandle<EcalPedestals> peds;
-  isetup.get<EcalPedestalsRcd>().get(peds);
+  const auto peds = isetup.getHandle(pedestalsToken_);
   currentPedestals_ = peds.product();
 
-  edm::ESHandle<EcalPedestals> g6g1peds;
-  isetup.get<EcalPedestalsRcd>().get(labelG6G1_, g6g1peds);
+  const auto g6g1peds = isetup.getHandle(g6g1PedestalsToken_);
   g6g1Pedestals_ = g6g1peds.product();
 }
 

--- a/Calibration/EcalCalibAlgos/src/ECALpedestalPCLworker.cc
+++ b/Calibration/EcalCalibAlgos/src/ECALpedestalPCLworker.cc
@@ -101,7 +101,7 @@ void ECALpedestalPCLworker::bookHistograms(DQMStore::IBooker& ibooker, edm::Run 
   ibooker.cd();
   ibooker.setCurrentFolder(dqmDir_);
 
-  const auto peds = es.getData(pedestalToken_);
+  const auto& peds = es.getData(pedestalToken_);
 
   for (uint32_t i = 0; i < EBDetId::kSizeForDenseIndexing; ++i) {
     ibooker.setCurrentFolder(dqmDir_ + "/EB/" + std::to_string(int(i / 100)));

--- a/Calibration/EcalCalibAlgos/src/ECALpedestalPCLworker.cc
+++ b/Calibration/EcalCalibAlgos/src/ECALpedestalPCLworker.cc
@@ -5,8 +5,8 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include <sstream>
 
-ECALpedestalPCLworker::ECALpedestalPCLworker(const edm::ParameterSet& iConfig) : pedestalToken_(esConsumes<edm::Transition::BeginRun>())
-{
+ECALpedestalPCLworker::ECALpedestalPCLworker(const edm::ParameterSet& iConfig)
+    : pedestalToken_(esConsumes<edm::Transition::BeginRun>()) {
   edm::InputTag digiTagEB = iConfig.getParameter<edm::InputTag>("BarrelDigis");
   edm::InputTag digiTagEE = iConfig.getParameter<edm::InputTag>("EndcapDigis");
 

--- a/Calibration/EcalCalibAlgos/src/ECALpedestalPCLworker.cc
+++ b/Calibration/EcalCalibAlgos/src/ECALpedestalPCLworker.cc
@@ -2,15 +2,10 @@
 #include "Calibration/EcalCalibAlgos/interface/ECALpedestalPCLworker.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "CondFormats/EcalObjects/interface/EcalPedestals.h"
-#include "CondFormats/DataRecord/interface/EcalPedestalsRcd.h"
-#include <iostream>
 #include <sstream>
 
-ECALpedestalPCLworker::ECALpedestalPCLworker(const edm::ParameterSet& iConfig)
-
+ECALpedestalPCLworker::ECALpedestalPCLworker(const edm::ParameterSet& iConfig) : pedestalToken_(esConsumes<edm::Transition::BeginRun>())
 {
   edm::InputTag digiTagEB = iConfig.getParameter<edm::InputTag>("BarrelDigis");
   edm::InputTag digiTagEE = iConfig.getParameter<edm::InputTag>("EndcapDigis");
@@ -106,8 +101,7 @@ void ECALpedestalPCLworker::bookHistograms(DQMStore::IBooker& ibooker, edm::Run 
   ibooker.cd();
   ibooker.setCurrentFolder(dqmDir_);
 
-  edm::ESHandle<EcalPedestals> peds;
-  es.get<EcalPedestalsRcd>().get(peds);
+  const auto peds = es.getHandle(pedestalToken_);
 
   for (uint32_t i = 0; i < EBDetId::kSizeForDenseIndexing; ++i) {
     ibooker.setCurrentFolder(dqmDir_ + "/EB/" + std::to_string(int(i / 100)));

--- a/Calibration/EcalCalibAlgos/src/ECALpedestalPCLworker.cc
+++ b/Calibration/EcalCalibAlgos/src/ECALpedestalPCLworker.cc
@@ -101,7 +101,7 @@ void ECALpedestalPCLworker::bookHistograms(DQMStore::IBooker& ibooker, edm::Run 
   ibooker.cd();
   ibooker.setCurrentFolder(dqmDir_);
 
-  const auto peds = es.getHandle(pedestalToken_);
+  const auto peds = es.getData(pedestalToken_);
 
   for (uint32_t i = 0; i < EBDetId::kSizeForDenseIndexing; ++i) {
     ibooker.setCurrentFolder(dqmDir_ + "/EB/" + std::to_string(int(i / 100)));
@@ -111,7 +111,7 @@ void ECALpedestalPCLworker::bookHistograms(DQMStore::IBooker& ibooker, edm::Run 
     int centralBin = fixedBookingCenterBin_;
 
     if (dynamicBooking_) {
-      centralBin = int((peds->find(id))->mean_x12);
+      centralBin = int((peds.find(id))->mean_x12);
     }
 
     int min = centralBin - nBins_ / 2;
@@ -129,7 +129,7 @@ void ECALpedestalPCLworker::bookHistograms(DQMStore::IBooker& ibooker, edm::Run 
     int centralBin = fixedBookingCenterBin_;
 
     if (dynamicBooking_) {
-      centralBin = int((peds->find(id))->mean_x12);
+      centralBin = int((peds.find(id))->mean_x12);
     }
 
     int min = centralBin - nBins_ / 2;

--- a/Calibration/EcalCalibAlgos/src/EcalEleCalibLooper.cc
+++ b/Calibration/EcalCalibAlgos/src/EcalEleCalibLooper.cc
@@ -1,6 +1,5 @@
 #include <memory>
 #include <cmath>
-#include <iostream>
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -9,9 +8,7 @@
 #include "Calibration/EcalCalibAlgos/interface/EcalEleCalibLooper.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/EgammaReco/interface/ClusterShape.h"
-#include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
-#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "CondFormats/DataRecord/interface/EcalIntercalibConstantsRcd.h"
 #include "Calibration/Tools/interface/calibXMLwriter.h"
@@ -31,7 +28,8 @@
 
 //!LP ctor
 EcalEleCalibLooper::EcalEleCalibLooper(const edm::ParameterSet& iConfig)
-    : m_barrelAlCa(iConfig.getParameter<edm::InputTag>("alcaBarrelHitCollection")),
+    : m_geometryToken(esConsumes()),
+      m_barrelAlCa(iConfig.getParameter<edm::InputTag>("alcaBarrelHitCollection")),
       m_endcapAlCa(iConfig.getParameter<edm::InputTag>("alcaEndcapHitCollection")),
       m_recoWindowSidex(iConfig.getParameter<int>("recoWindowSidex")),
       m_recoWindowSidey(iConfig.getParameter<int>("recoWindowSidey")),
@@ -168,9 +166,7 @@ edm::EDLooper::Status EcalEleCalibLooper::duringLoop(const edm::Event& iEvent, c
   // with the beginJob without arguments migration
 
   if (isfirstcall_) {
-    edm::ESHandle<CaloGeometry> geoHandle;
-    iSetup.get<CaloGeometryRecord>().get(geoHandle);
-    const CaloGeometry& geometry = *geoHandle;
+    const auto& geometry = iSetup.getData(m_geometryToken);
     m_barrelCells = geometry.getValidDetIds(DetId::Ecal, EcalBarrel);
     m_endcapCells = geometry.getValidDetIds(DetId::Ecal, EcalEndcap);
     for (std::vector<DetId>::const_iterator barrelIt = m_barrelCells.begin(); barrelIt != m_barrelCells.end();

--- a/Calibration/EcalCalibAlgos/src/ElectronCalibrationUniv.cc
+++ b/Calibration/EcalCalibAlgos/src/ElectronCalibrationUniv.cc
@@ -236,7 +236,7 @@ void ElectronCalibrationUniv::beginRun(edm::Run const&, edm::EventSetup const& i
   //========================================================================
 
   //To Deal with Geometry:
-  theCaloTopology_ = iSetup.getHandle(topologyToken_);
+  theCaloTopology_ = &iSetup.getData(topologyToken_);
 }
 
 //========================================================================

--- a/Calibration/EcalCalibAlgos/src/ElectronCalibrationUniv.cc
+++ b/Calibration/EcalCalibAlgos/src/ElectronCalibrationUniv.cc
@@ -47,8 +47,7 @@ ElectronCalibrationUniv::ElectronCalibrationUniv(const edm::ParameterSet& iConfi
       ebRecHitToken_(consumes<EBRecHitCollection>(ebRecHitLabel_)),
       eeRecHitToken_(consumes<EERecHitCollection>(eeRecHitLabel_)),
       gsfElectronToken_(consumes<reco::GsfElectronCollection>(electronLabel_)),
-      topologyToken_(esConsumes<edm::Transition::BeginRun>()) {
-}
+      topologyToken_(esConsumes<edm::Transition::BeginRun>()) {}
 
 ElectronCalibrationUniv::~ElectronCalibrationUniv() {}
 

--- a/Calibration/EcalCalibAlgos/src/ElectronCalibrationUniv.cc
+++ b/Calibration/EcalCalibAlgos/src/ElectronCalibrationUniv.cc
@@ -1,25 +1,14 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "DataFormats/DetId/interface/DetId.h"
-#include "CondFormats/EcalObjects/interface/EcalIntercalibConstants.h"
-#include "CondFormats/DataRecord/interface/EcalIntercalibConstantsRcd.h"
 #include "Calibration/Tools/interface/calibXMLwriter.h"
 #include "Calibration/Tools/interface/CalibrationCluster.h"
 #include "Calibration/Tools/interface/HouseholderDecomposition.h"
 #include "Calibration/Tools/interface/MinL3Algorithm.h"
 #include "Calibration/EcalCalibAlgos/interface/ElectronCalibrationUniv.h"
-#include "DataFormats/EgammaCandidates/interface/Electron.h"
-#include "DataFormats/EgammaReco/interface/SuperCluster.h"
-#include "DataFormats/TrackReco/interface/Track.h"
-#include "DataFormats/TrackReco/interface/TrackFwd.h"
-#include "DataFormats/TrackReco/interface/TrackExtraFwd.h"
 #include "FWCore/Utilities/interface/isFinite.h"
-#include "TFile.h"
-#include "TH1.h"
-#include "TH2.h"
 #include "TF1.h"
 #include "TRandom.h"
 
@@ -28,39 +17,37 @@
 #include <stdexcept>
 #include <vector>
 
-#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
-#include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
-
-ElectronCalibrationUniv::ElectronCalibrationUniv(const edm::ParameterSet& iConfig) {
-  rootfile_ = iConfig.getParameter<std::string>("rootfile");
-  EBrecHitLabel_ = iConfig.getParameter<edm::InputTag>("ebRecHitsLabel");
-  EErecHitLabel_ = iConfig.getParameter<edm::InputTag>("eeRecHitsLabel");
-  electronLabel_ = iConfig.getParameter<edm::InputTag>("electronLabel");
-  trackLabel_ = iConfig.getParameter<edm::InputTag>("trackLabel");
-  calibAlgo_ = iConfig.getParameter<std::string>("CALIBRATION_ALGO");
-  keventweight_ = iConfig.getParameter<int>("keventweight");
-  ClusterSize_ = iConfig.getParameter<int>("Clustersize");
-  ElePt_ = iConfig.getParameter<double>("ElePt");
-  maxeta_ = iConfig.getParameter<int>("maxeta");
-  mineta_ = iConfig.getParameter<int>("mineta");
-  maxphi_ = iConfig.getParameter<int>("maxphi");
-  minphi_ = iConfig.getParameter<int>("minphi");
-  cut1_ = iConfig.getParameter<double>("cut1");
-  cut2_ = iConfig.getParameter<double>("cut2");
-  cut3_ = iConfig.getParameter<double>("cut3");
-  elecclass_ = iConfig.getParameter<int>("elecclass");
-  numevent_ = iConfig.getParameter<int>("numevent");
-  miscalibfile_ = iConfig.getParameter<std::string>("miscalibfile");
-  miscalibfileEndCap_ = iConfig.getParameter<std::string>("miscalibfileEndCap");
-
-  cutEPCalo1_ = iConfig.getParameter<double>("cutEPCaloMin");
-  cutEPCalo2_ = iConfig.getParameter<double>("cutEPCaloMax");
-  cutEPin1_ = iConfig.getParameter<double>("cutEPinMin");
-  cutEPin2_ = iConfig.getParameter<double>("cutEPinMax");
-  cutCalo1_ = iConfig.getParameter<double>("cutCaloMin");
-  cutCalo2_ = iConfig.getParameter<double>("cutCaloMax");
-
-  cutESeed_ = iConfig.getParameter<double>("cutESeed");
+ElectronCalibrationUniv::ElectronCalibrationUniv(const edm::ParameterSet& iConfig)
+    : ebRecHitLabel_(iConfig.getParameter<edm::InputTag>("ebRecHitsLabel")),
+      eeRecHitLabel_(iConfig.getParameter<edm::InputTag>("eeRecHitsLabel")),
+      electronLabel_(iConfig.getParameter<edm::InputTag>("electronLabel")),
+      rootfile_(iConfig.getParameter<std::string>("rootfile")),
+      calibAlgo_(iConfig.getParameter<std::string>("CALIBRATION_ALGO")),
+      miscalibfile_(iConfig.getParameter<std::string>("miscalibfile")),
+      miscalibfileEndCap_(iConfig.getParameter<std::string>("miscalibfileEndCap")),
+      keventweight_(iConfig.getParameter<int>("keventweight")),
+      elePt_(iConfig.getParameter<double>("ElePt")),
+      maxeta_(iConfig.getParameter<int>("maxeta")),
+      mineta_(iConfig.getParameter<int>("mineta")),
+      maxphi_(iConfig.getParameter<int>("maxphi")),
+      minphi_(iConfig.getParameter<int>("minphi")),
+      cut1_(iConfig.getParameter<double>("cut1")),
+      cut2_(iConfig.getParameter<double>("cut2")),
+      cut3_(iConfig.getParameter<double>("cut3")),
+      numevent_(iConfig.getParameter<int>("numevent")),
+      cutEPCalo1_(iConfig.getParameter<double>("cutEPCaloMin")),
+      cutEPCalo2_(iConfig.getParameter<double>("cutEPCaloMax")),
+      cutEPin1_(iConfig.getParameter<double>("cutEPinMin")),
+      cutEPin2_(iConfig.getParameter<double>("cutEPinMax")),
+      cutCalo1_(iConfig.getParameter<double>("cutCaloMin")),
+      cutCalo2_(iConfig.getParameter<double>("cutCaloMax")),
+      cutESeed_(iConfig.getParameter<double>("cutESeed")),
+      clusterSize_(iConfig.getParameter<int>("Clustersize")),
+      elecclass_(iConfig.getParameter<int>("elecclass")),
+      ebRecHitToken_(consumes<EBRecHitCollection>(ebRecHitLabel_)),
+      eeRecHitToken_(consumes<EERecHitCollection>(eeRecHitLabel_)),
+      gsfElectronToken_(consumes<reco::GsfElectronCollection>(electronLabel_)),
+      topologyToken_(esConsumes<edm::Transition::BeginRun>()) {
 }
 
 ElectronCalibrationUniv::~ElectronCalibrationUniv() {}
@@ -223,7 +210,7 @@ void ElectronCalibrationUniv::beginJob() {
   GeneralMapEndCapPlusBeforePt =
       new TH2F("GeneralMapEndCapPlusBeforePt", "Map without any cuts", 100, 0, 100, 100, 0, 100);
 
-  calibClusterSize = ClusterSize_;
+  calibClusterSize = clusterSize_;
   etaMin = int(mineta_);
   etaMax = int(maxeta_);
   phiMin = int(minphi_);
@@ -250,8 +237,12 @@ void ElectronCalibrationUniv::beginRun(edm::Run const&, edm::EventSetup const& i
   //========================================================================
 
   //To Deal with Geometry:
-  iSetup.get<CaloTopologyRecord>().get(theCaloTopology);
+  theCaloTopology_ = iSetup.getHandle(topologyToken_);
 }
+
+//========================================================================
+void ElectronCalibrationUniv::endRun(edm::Run const&, edm::EventSetup const& iSetup) {}
+//========================================================================
 
 //========================================================================
 
@@ -622,7 +613,7 @@ void ElectronCalibrationUniv::analyze(const edm::Event& iEvent, const edm::Event
 
   // Get EBRecHits
   edm::Handle<EBRecHitCollection> EBphits;
-  iEvent.getByLabel(EBrecHitLabel_, EBphits);
+  iEvent.getByToken(ebRecHitToken_, EBphits);
   if (!EBphits.isValid()) {
     std::cerr << "Error! can't get the product EBRecHitCollection: " << std::endl;
   }
@@ -631,7 +622,7 @@ void ElectronCalibrationUniv::analyze(const edm::Event& iEvent, const edm::Event
   // Get EERecHits
   edm::Handle<EERecHitCollection> EEphits;
 
-  iEvent.getByLabel(EErecHitLabel_, EEphits);
+  iEvent.getByToken(eeRecHitToken_, EEphits);
   if (!EEphits.isValid()) {
     std::cerr << "Error! can't get the product EERecHitCollection: " << std::endl;
   }
@@ -639,7 +630,7 @@ void ElectronCalibrationUniv::analyze(const edm::Event& iEvent, const edm::Event
 
   // Get pixelElectrons
   edm::Handle<reco::GsfElectronCollection> pElectrons;
-  iEvent.getByLabel(electronLabel_, pElectrons);
+  iEvent.getByToken(gsfElectronToken_, pElectrons);
   if (!pElectrons.isValid()) {
     std::cerr << "Error! can't get the product ElectronCollection: " << std::endl;
   }
@@ -737,9 +728,9 @@ void ElectronCalibrationUniv::analyze(const edm::Event& iEvent, const edm::Event
   float energy3x3 = 0.;
   float energy5x5 = 0.;
   //Should be moved to cfg file!
-  int ClusterSize = ClusterSize_;
+  int ClusterSize = clusterSize_;
 
-  const CaloSubdetectorTopology* topology = theCaloTopology->getSubdetectorTopology(DetId::Ecal, maxHitId.subdetId());
+  const CaloSubdetectorTopology* topology = theCaloTopology_->getSubdetectorTopology(DetId::Ecal, maxHitId.subdetId());
   std::vector<DetId> NxNaroundMax = topology->getWindow(maxHitId, ClusterSize, ClusterSize);
   //ToCompute 3x3
   std::vector<DetId> S9aroundMax = topology->getWindow(maxHitId, 3, 3);
@@ -822,7 +813,7 @@ void ElectronCalibrationUniv::analyze(const edm::Event& iEvent, const edm::Event
   }
 
   EventsAfterCuts->Fill(11);
-  if (highestElePt < ElePt_)
+  if (highestElePt < elePt_)
     return;
 
   if (maxHitId.subdetId() == EcalBarrel) {

--- a/Calibration/EcalCalibAlgos/src/PhiSymmetryCalibration.cc
+++ b/Calibration/EcalCalibAlgos/src/PhiSymmetryCalibration.cc
@@ -56,10 +56,6 @@ PhiSymmetryCalibration::PhiSymmetryCalibration(const edm::ParameterSet& iConfig)
       oldcalibfile_(iConfig.getUntrackedParameter<std::string>("oldcalibfile", "EcalintercalibConstants.xml")) {
   isfirstpass_ = true;
 
-  if (!reiteration_) {
-    intercalibConstantsToken_ = esConsumes();
-  }
-
   et_spectrum_b_histos.resize(kBarlRings);
   e_spectrum_b_histos.resize(kBarlRings);
   et_spectrum_e_histos.resize(kEndcEtaRings);
@@ -499,12 +495,6 @@ void PhiSymmetryCalibration::setUp(const edm::EventSetup& setup) {
     int ret = EcalIntercalibConstantsXMLTranslator::readXML(fip.fullPath(), h, oldCalibs_);
     if (ret)
       edm::LogError("PhiSym") << "Error reading XML files" << endl;
-    ;
-
-  } else {
-    // in fact if not reiterating, oldCalibs_ will never be used
-    const auto pIcal = setup.getHandle(intercalibConstantsToken_);
-    oldCalibs_ = *pIcal;
   }
 }
 

--- a/Calibration/EcalCalibAlgos/src/PhiSymmetryCalibration.cc
+++ b/Calibration/EcalCalibAlgos/src/PhiSymmetryCalibration.cc
@@ -5,26 +5,19 @@
 
 // Framework
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
-#include "CondFormats/DataRecord/interface/EcalIntercalibConstantsRcd.h"
 #include "CondFormats/EcalObjects/interface/EcalIntercalibErrors.h"
 #include "CondTools/Ecal/interface/EcalIntercalibConstantsXMLTranslator.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 
 // Geometry
-#include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
-#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 
 //Channel status
-#include "CondFormats/EcalObjects/interface/EcalChannelStatus.h"
-#include "CondFormats/DataRecord/interface/EcalChannelStatusRcd.h"
 #include "CondFormats/EcalObjects/interface/EcalChannelStatusCode.h"
 
 #include "FWCore/Framework/interface/Run.h"
@@ -47,11 +40,13 @@ const float PhiSymmetryCalibration::kMiscalRangeEE = .10;
 // Class constructor
 
 PhiSymmetryCalibration::PhiSymmetryCalibration(const edm::ParameterSet& iConfig)
-    :
-
-      ecalHitsProducer_(iConfig.getParameter<std::string>("ecalRecHitsProducer")),
+    : ecalHitsProducer_(iConfig.getParameter<std::string>("ecalRecHitsProducer")),
       barrelHits_(iConfig.getParameter<std::string>("barrelHitCollection")),
       endcapHits_(iConfig.getParameter<std::string>("endcapHitCollection")),
+      ebRecHitToken_(consumes<EBRecHitCollection>(edm::InputTag(ecalHitsProducer_, barrelHits_))),
+      eeRecHitToken_(consumes<EERecHitCollection>(edm::InputTag(ecalHitsProducer_, endcapHits_))),
+      channelStatusToken_(esConsumes()),
+      geometryToken_(esConsumes()),
       eCut_barl_(iConfig.getParameter<double>("eCut_barrel")),
       ap_(iConfig.getParameter<double>("ap")),
       b_(iConfig.getParameter<double>("b")),
@@ -60,6 +55,10 @@ PhiSymmetryCalibration::PhiSymmetryCalibration(const edm::ParameterSet& iConfig)
       reiteration_(iConfig.getUntrackedParameter<bool>("reiteration", false)),
       oldcalibfile_(iConfig.getUntrackedParameter<std::string>("oldcalibfile", "EcalintercalibConstants.xml")) {
   isfirstpass_ = true;
+
+  if (!reiteration_) {
+    intercalibConstantsToken_ = esConsumes();
+  }
 
   et_spectrum_b_histos.resize(kBarlRings);
   e_spectrum_b_histos.resize(kBarlRings);
@@ -71,6 +70,9 @@ PhiSymmetryCalibration::PhiSymmetryCalibration(const edm::ParameterSet& iConfig)
   nevents_ = 0;
   eventsinrun_ = 0;
   eventsinlb_ = 0;
+
+  // because ROOT draws something
+  usesResource();
 }
 
 //_____________________________________________________________________________
@@ -239,21 +241,20 @@ void PhiSymmetryCalibration::analyze(const edm::Event& event, const edm::EventSe
   Handle<EBRecHitCollection> barrelRecHitsHandle;
   Handle<EERecHitCollection> endcapRecHitsHandle;
 
-  event.getByLabel(ecalHitsProducer_, barrelHits_, barrelRecHitsHandle);
+  event.getByToken(ebRecHitToken_, barrelRecHitsHandle);
   if (!barrelRecHitsHandle.isValid()) {
     LogError("") << "[PhiSymmetryCalibration] Error! Can't get product!" << std::endl;
   }
 
-  event.getByLabel(ecalHitsProducer_, endcapHits_, endcapRecHitsHandle);
+  event.getByToken(ebRecHitToken_, endcapRecHitsHandle);
   if (!endcapRecHitsHandle.isValid()) {
     LogError("") << "[PhiSymmetryCalibration] Error! Can't get product!" << std::endl;
   }
 
   // get the ecal geometry
-  edm::ESHandle<CaloGeometry> geoHandle;
-  setup.get<CaloGeometryRecord>().get(geoHandle);
-  const CaloSubdetectorGeometry* barrelGeometry = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
-  const CaloSubdetectorGeometry* endcapGeometry = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
+  const auto& geometry = setup.getData(geometryToken_);
+  const auto* barrelGeometry = geometry.getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
+  const auto* endcapGeometry = geometry.getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
 
   bool pass = false;
   // select interesting EcalRecHits (barrel)
@@ -377,6 +378,8 @@ void PhiSymmetryCalibration::analyze(const edm::Event& event, const edm::EventSe
   }
 }
 
+void PhiSymmetryCalibration::beginRun(edm::Run const&, const edm::EventSetup&) {}
+
 void PhiSymmetryCalibration::endRun(edm::Run const& run, const edm::EventSetup&) {
   std::cout << "PHIREPRT : run " << run.run() << " start " << (run.beginTime().value() >> 32) << " end "
             << (run.endTime().value() >> 32) << " dur "
@@ -478,13 +481,11 @@ void PhiSymmetryCalibration::getKfactors() {
 //_____________________________________________________________________________
 
 void PhiSymmetryCalibration::setUp(const edm::EventSetup& setup) {
-  edm::ESHandle<EcalChannelStatus> chStatus;
-  setup.get<EcalChannelStatusRcd>().get(chStatus);
+  const auto& chStatus = setup.getData(channelStatusToken_);
 
-  edm::ESHandle<CaloGeometry> geoHandle;
-  setup.get<CaloGeometryRecord>().get(geoHandle);
+  const auto& geometry = setup.getData(geometryToken_);
 
-  e_.setup(&(*geoHandle), &(*chStatus), statusThreshold_);
+  e_.setup(&geometry, &chStatus, statusThreshold_);
 
   if (reiteration_) {
     EcalCondHeader h;
@@ -502,11 +503,12 @@ void PhiSymmetryCalibration::setUp(const edm::EventSetup& setup) {
 
   } else {
     // in fact if not reiterating, oldCalibs_ will never be used
-    edm::ESHandle<EcalIntercalibConstants> pIcal;
-    setup.get<EcalIntercalibConstantsRcd>().get(pIcal);
+    const auto pIcal = setup.getHandle(intercalibConstantsToken_);
     oldCalibs_ = *pIcal;
   }
 }
+
+void PhiSymmetryCalibration::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {}
 
 void PhiSymmetryCalibration::endLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const&) {
   if ((lb.endTime().value() >> 32) - (lb.beginTime().value() >> 32) < 60)

--- a/Calibration/EcalCalibAlgos/src/PhiSymmetryCalibration_step2.cc
+++ b/Calibration/EcalCalibAlgos/src/PhiSymmetryCalibration_step2.cc
@@ -4,9 +4,6 @@
 #include "CondFormats/EcalObjects/interface/EcalIntercalibConstants.h"
 #include "CondTools/Ecal/interface/EcalIntercalibConstantsXMLTranslator.h"
 #include "CondFormats/DataRecord/interface/EcalIntercalibConstantsRcd.h"
-#include "CondFormats/DataRecord/interface/EcalChannelStatusRcd.h"
-#include "Geometry/Records/interface/CaloGeometryRecord.h"
-#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 
 #include "TH2F.h"
 
@@ -20,13 +17,15 @@ using namespace std;
 
 PhiSymmetryCalibration_step2::~PhiSymmetryCalibration_step2() {}
 
-PhiSymmetryCalibration_step2::PhiSymmetryCalibration_step2(const edm::ParameterSet& iConfig) {
-  statusThreshold_ = iConfig.getUntrackedParameter<int>("statusThreshold", 0);
-  have_initial_miscalib_ = iConfig.getUntrackedParameter<bool>("haveInitialMiscalib", false);
-  initialmiscalibfile_ = iConfig.getUntrackedParameter<std::string>("initialmiscalibfile", "InitialMiscalib.xml");
-  oldcalibfile_ = iConfig.getUntrackedParameter<std::string>("oldcalibfile", "EcalIntercalibConstants.xml");
-  reiteration_ = iConfig.getUntrackedParameter<bool>("reiteration", false);
-  firstpass_ = true;
+PhiSymmetryCalibration_step2::PhiSymmetryCalibration_step2(const edm::ParameterSet& iConfig)
+    : channelStatusToken_(esConsumes()),
+      geometryToken_(esConsumes()),
+      firstpass_(true),
+      statusThreshold_(iConfig.getUntrackedParameter<int>("statusThreshold", 0)),
+      reiteration_(iConfig.getUntrackedParameter<bool>("reiteration", false)),
+      oldcalibfile_(iConfig.getUntrackedParameter<std::string>("oldcalibfile", "EcalIntercalibConstants.xml")),
+      have_initial_miscalib_(iConfig.getUntrackedParameter<bool>("haveInitialMiscalib", false)),
+      initialmiscalibfile_(iConfig.getUntrackedParameter<std::string>("initialmiscalibfile", "InitialMiscalib.xml")) {
 }
 
 void PhiSymmetryCalibration_step2::analyze(const edm::Event& ev, const edm::EventSetup& se) {
@@ -37,16 +36,14 @@ void PhiSymmetryCalibration_step2::analyze(const edm::Event& ev, const edm::Even
 }
 
 void PhiSymmetryCalibration_step2::setUp(const edm::EventSetup& se) {
-  edm::ESHandle<EcalChannelStatus> chStatus;
-  se.get<EcalChannelStatusRcd>().get(chStatus);
+  const auto& chStatus = se.getData(channelStatusToken_);
 
-  edm::ESHandle<CaloGeometry> geoHandle;
-  se.get<CaloGeometryRecord>().get(geoHandle);
+  const auto& geometry = se.getData(geometryToken_);
 
-  barrelCells = geoHandle->getValidDetIds(DetId::Ecal, EcalBarrel);
-  endcapCells = geoHandle->getValidDetIds(DetId::Ecal, EcalEndcap);
+  barrelCells = geometry.getValidDetIds(DetId::Ecal, EcalBarrel);
+  endcapCells = geometry.getValidDetIds(DetId::Ecal, EcalEndcap);
 
-  e_.setup(&(*geoHandle), &(*chStatus), statusThreshold_);
+  e_.setup(&geometry, &chStatus, statusThreshold_);
 
   /// if a miscalibration was applied, load it, if not put it to 1
   if (have_initial_miscalib_) {

--- a/Calibration/EcalCalibAlgos/src/PhiSymmetryCalibration_step2.cc
+++ b/Calibration/EcalCalibAlgos/src/PhiSymmetryCalibration_step2.cc
@@ -25,8 +25,7 @@ PhiSymmetryCalibration_step2::PhiSymmetryCalibration_step2(const edm::ParameterS
       reiteration_(iConfig.getUntrackedParameter<bool>("reiteration", false)),
       oldcalibfile_(iConfig.getUntrackedParameter<std::string>("oldcalibfile", "EcalIntercalibConstants.xml")),
       have_initial_miscalib_(iConfig.getUntrackedParameter<bool>("haveInitialMiscalib", false)),
-      initialmiscalibfile_(iConfig.getUntrackedParameter<std::string>("initialmiscalibfile", "InitialMiscalib.xml")) {
-}
+      initialmiscalibfile_(iConfig.getUntrackedParameter<std::string>("initialmiscalibfile", "InitialMiscalib.xml")) {}
 
 void PhiSymmetryCalibration_step2::analyze(const edm::Event& ev, const edm::EventSetup& se) {
   if (firstpass_) {

--- a/Calibration/EcalCalibAlgos/src/PhiSymmetryCalibration_step2.h
+++ b/Calibration/EcalCalibAlgos/src/PhiSymmetryCalibration_step2.h
@@ -1,15 +1,20 @@
+#ifndef Calibration_EcalCalibAlgos_PhiSymmetryCalibration_step2_h
+#define Calibration_EcalCalibAlgos_PhiSymmetryCalibration_step2_h
+
 #include "Calibration/EcalCalibAlgos/interface/EcalGeomPhiSymHelper.h"
+#include "CondFormats/DataRecord/interface/EcalChannelStatusRcd.h"
 #include "CondFormats/EcalObjects/interface/EcalIntercalibConstants.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ProducerBase.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 
 class TH1F;
 class TH2F;
 
-class PhiSymmetryCalibration_step2 : public edm::EDAnalyzer {
+class PhiSymmetryCalibration_step2 : public edm::one::EDAnalyzer<> {
 public:
   PhiSymmetryCalibration_step2(const edm::ParameterSet& iConfig);
   ~PhiSymmetryCalibration_step2() override;
@@ -29,6 +34,9 @@ public:
   void readEtSums();
 
 private:
+  const edm::ESGetToken<EcalChannelStatus, EcalChannelStatusRcd> channelStatusToken_;
+  const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometryToken_;
+
   // Transverse energy sum arrays
   double etsum_barl_[kBarlRings][kBarlWedges][kSides];
   double etsum_endc_[kEndcWedgesX][kEndcWedgesX][kSides];
@@ -62,10 +70,10 @@ private:
   std::vector<DetId> endcapCells;
 
   bool firstpass_;
-  int statusThreshold_;
+  const int statusThreshold_;
 
-  bool reiteration_;
-  std::string oldcalibfile_;
+  const bool reiteration_;
+  const std::string oldcalibfile_;
 
   /// the old calibration constants (when reiterating, the last ones derived)
   EcalIntercalibConstants oldCalibs_;
@@ -77,8 +85,8 @@ private:
   EcalIntercalibConstants miscalib_;
 
   ///
-  bool have_initial_miscalib_;
-  std::string initialmiscalibfile_;
+  const bool have_initial_miscalib_;
+  const std::string initialmiscalibfile_;
 
   /// res miscalib histos
   std::vector<TH1F*> miscal_resid_barl_histos;
@@ -87,3 +95,4 @@ private:
   std::vector<TH1F*> miscal_resid_endc_histos;
   std::vector<TH2F*> correl_endc_histos;
 };
+#endif

--- a/Calibration/EcalCalibAlgos/src/PhiSymmetryCalibration_step2_SM.cc
+++ b/Calibration/EcalCalibAlgos/src/PhiSymmetryCalibration_step2_SM.cc
@@ -4,9 +4,6 @@
 #include "CondFormats/EcalObjects/interface/EcalIntercalibConstants.h"
 #include "CondTools/Ecal/interface/EcalIntercalibConstantsXMLTranslator.h"
 #include "CondFormats/DataRecord/interface/EcalIntercalibConstantsRcd.h"
-#include "CondFormats/DataRecord/interface/EcalChannelStatusRcd.h"
-#include "Geometry/Records/interface/CaloGeometryRecord.h"
-#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 
 #include "TH2F.h"
 
@@ -20,13 +17,15 @@ using namespace std;
 
 PhiSymmetryCalibration_step2_SM::~PhiSymmetryCalibration_step2_SM() {}
 
-PhiSymmetryCalibration_step2_SM::PhiSymmetryCalibration_step2_SM(const edm::ParameterSet& iConfig) {
-  statusThreshold_ = iConfig.getUntrackedParameter<int>("statusThreshold", 0);
-  have_initial_miscalib_ = iConfig.getUntrackedParameter<bool>("haveInitialMiscalib", false);
-  initialmiscalibfile_ = iConfig.getUntrackedParameter<std::string>("initialmiscalibfile", "InitialMiscalib.xml");
-  oldcalibfile_ = iConfig.getUntrackedParameter<std::string>("oldcalibfile", "EcalIntercalibConstants.xml");
-  reiteration_ = iConfig.getUntrackedParameter<bool>("reiteration", false);
-  firstpass_ = true;
+PhiSymmetryCalibration_step2_SM::PhiSymmetryCalibration_step2_SM(const edm::ParameterSet& iConfig)
+    : channelStatusToken_(esConsumes()),
+      geometryToken_(esConsumes()),
+      firstpass_(true),
+      statusThreshold_(iConfig.getUntrackedParameter<int>("statusThreshold", 0)),
+      reiteration_(iConfig.getUntrackedParameter<bool>("reiteration", false)),
+      oldcalibfile_(iConfig.getUntrackedParameter<std::string>("oldcalibfile", "EcalIntercalibConstants.xml")),
+      have_initial_miscalib_(iConfig.getUntrackedParameter<bool>("haveInitialMiscalib", false)),
+      initialmiscalibfile_(iConfig.getUntrackedParameter<std::string>("initialmiscalibfile", "InitialMiscalib.xml")) {
 }
 
 void PhiSymmetryCalibration_step2_SM::analyze(const edm::Event& ev, const edm::EventSetup& se) {
@@ -37,16 +36,14 @@ void PhiSymmetryCalibration_step2_SM::analyze(const edm::Event& ev, const edm::E
 }
 
 void PhiSymmetryCalibration_step2_SM::setUp(const edm::EventSetup& se) {
-  edm::ESHandle<EcalChannelStatus> chStatus;
-  se.get<EcalChannelStatusRcd>().get(chStatus);
+  const auto& chStatus = se.getData(channelStatusToken_);
 
-  edm::ESHandle<CaloGeometry> geoHandle;
-  se.get<CaloGeometryRecord>().get(geoHandle);
+  const auto& geometry = se.getData(geometryToken_);
 
-  barrelCells = geoHandle->getValidDetIds(DetId::Ecal, EcalBarrel);
-  endcapCells = geoHandle->getValidDetIds(DetId::Ecal, EcalEndcap);
+  barrelCells = geometry.getValidDetIds(DetId::Ecal, EcalBarrel);
+  endcapCells = geometry.getValidDetIds(DetId::Ecal, EcalEndcap);
 
-  e_.setup(&(*geoHandle), &(*chStatus), statusThreshold_);
+  e_.setup(&geometry, &chStatus, statusThreshold_);
 
   for (int sign = 0; sign < kSides; sign++) {
     for (int ieta = 0; ieta < kBarlRings; ieta++) {

--- a/Calibration/EcalCalibAlgos/src/PhiSymmetryCalibration_step2_SM.cc
+++ b/Calibration/EcalCalibAlgos/src/PhiSymmetryCalibration_step2_SM.cc
@@ -25,8 +25,7 @@ PhiSymmetryCalibration_step2_SM::PhiSymmetryCalibration_step2_SM(const edm::Para
       reiteration_(iConfig.getUntrackedParameter<bool>("reiteration", false)),
       oldcalibfile_(iConfig.getUntrackedParameter<std::string>("oldcalibfile", "EcalIntercalibConstants.xml")),
       have_initial_miscalib_(iConfig.getUntrackedParameter<bool>("haveInitialMiscalib", false)),
-      initialmiscalibfile_(iConfig.getUntrackedParameter<std::string>("initialmiscalibfile", "InitialMiscalib.xml")) {
-}
+      initialmiscalibfile_(iConfig.getUntrackedParameter<std::string>("initialmiscalibfile", "InitialMiscalib.xml")) {}
 
 void PhiSymmetryCalibration_step2_SM::analyze(const edm::Event& ev, const edm::EventSetup& se) {
   if (firstpass_) {

--- a/Calibration/EcalCalibAlgos/src/PhiSymmetryCalibration_step2_SM.h
+++ b/Calibration/EcalCalibAlgos/src/PhiSymmetryCalibration_step2_SM.h
@@ -1,15 +1,20 @@
+#ifndef Calibration_EcalCalibAlgos_PhiSymmetryCalibration_step2_SM_h
+#define Calibration_EcalCalibAlgos_PhiSymmetryCalibration_step2_SM_h
+
 #include "Calibration/EcalCalibAlgos/interface/EcalGeomPhiSymHelper.h"
+#include "CondFormats/DataRecord/interface/EcalChannelStatusRcd.h"
 #include "CondFormats/EcalObjects/interface/EcalIntercalibConstants.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ProducerBase.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 
 class TH1F;
 class TH2F;
 
-class PhiSymmetryCalibration_step2_SM : public edm::EDAnalyzer {
+class PhiSymmetryCalibration_step2_SM : public edm::one::EDAnalyzer<> {
 public:
   PhiSymmetryCalibration_step2_SM(const edm::ParameterSet& iConfig);
   ~PhiSymmetryCalibration_step2_SM() override;
@@ -29,6 +34,9 @@ public:
   void readEtSums();
 
 private:
+  const edm::ESGetToken<EcalChannelStatus, EcalChannelStatusRcd> channelStatusToken_;
+  const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometryToken_;
+
   // Transverse energy sum arrays
   double etsum_barl_[kBarlRings][kBarlWedges][kSides];
 
@@ -71,10 +79,10 @@ private:
   std::vector<DetId> endcapCells;
 
   bool firstpass_;
-  int statusThreshold_;
+  const int statusThreshold_;
 
-  bool reiteration_;
-  std::string oldcalibfile_;
+  const bool reiteration_;
+  const std::string oldcalibfile_;
 
   /// the old calibration constants (when reiterating, the last ones derived)
   EcalIntercalibConstants oldCalibs_;
@@ -86,8 +94,8 @@ private:
   EcalIntercalibConstants miscalib_;
 
   ///
-  bool have_initial_miscalib_;
-  std::string initialmiscalibfile_;
+  const bool have_initial_miscalib_;
+  const std::string initialmiscalibfile_;
 
   /// res miscalib histos
   std::vector<TH1F*> miscal_resid_barl_histos;
@@ -96,3 +104,4 @@ private:
   std::vector<TH1F*> miscal_resid_endc_histos;
   std::vector<TH2F*> correl_endc_histos;
 };
+#endif

--- a/Calibration/EcalCalibAlgos/src/Pi0FixedMassWindowCalibration.cc
+++ b/Calibration/EcalCalibAlgos/src/Pi0FixedMassWindowCalibration.cc
@@ -6,17 +6,14 @@
 
 // Conditions database
 
-#include "CondFormats/DataRecord/interface/EcalIntercalibConstantsRcd.h"
 #include "Calibration/Tools/interface/Pi0CalibXMLwriter.h"
 
 // Reconstruction Classes
 #include "DataFormats/EgammaReco/interface/BasicCluster.h"
 #include "DataFormats/EgammaReco/interface/BasicClusterFwd.h"
 // Geometry
-#include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
-#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CaloTopology/interface/EcalEndcapTopology.h"
 #include "Geometry/CaloTopology/interface/EcalBarrelTopology.h"
 
@@ -35,7 +32,10 @@ using namespace std;
 Pi0FixedMassWindowCalibration::Pi0FixedMassWindowCalibration(const edm::ParameterSet& iConfig)
     : theMaxLoops(iConfig.getUntrackedParameter<unsigned int>("maxLoops", 0)),
       ecalHitsProducer_(iConfig.getParameter<std::string>("ecalRecHitsProducer")),
-      barrelHits_(iConfig.getParameter<std::string>("barrelHitCollection")) {
+      barrelHits_(iConfig.getParameter<std::string>("barrelHitCollection")),
+      recHitToken_(consumes<EcalRecHitCollection>(edm::InputTag(ecalHitsProducer_, barrelHits_))),
+      intercalibConstantsToken_(esConsumes()),
+      geometryToken_(esConsumes()) {
   std::cout << "[Pi0FixedMassWindowCalibration] Constructor " << std::endl;
   // The verbosity level
   std::string verbosityString = iConfig.getParameter<std::string>("VerbosityLevel");
@@ -272,6 +272,9 @@ edm::EDLooper::Status Pi0FixedMassWindowCalibration::duringLoop(const edm::Event
   // this chunk used to belong to beginJob(isetup). Moved here
   // with the beginJob without arguments migration
 
+  // get the ecal geometry:
+  const auto& geometry = setup.getData(geometryToken_);
+
   if (isfirstcall_) {
     // initialize arrays
 
@@ -288,23 +291,9 @@ edm::EDLooper::Status Pi0FixedMassWindowCalibration::duringLoop(const edm::Event
 
     // get initial constants out of DB
 
-    edm::ESHandle<EcalIntercalibConstants> pIcal;
-    EcalIntercalibConstantMap imap;
-
-    try {
-      setup.get<EcalIntercalibConstantsRcd>().get(pIcal);
-      std::cout << "Taken EcalIntercalibConstants" << std::endl;
-      imap = pIcal.product()->getMap();
-      std::cout << "imap.size() = " << imap.size() << std::endl;
-    } catch (std::exception& ex) {
-      std::cerr << "Error! can't get EcalIntercalibConstants " << std::endl;
-    }
-
-    // get the ecal geometry:
-    edm::ESHandle<CaloGeometry> geoHandle;
-    setup.get<CaloGeometryRecord>().get(geoHandle);
-    const CaloGeometry& geometry = *geoHandle;
-    //const CaloSubdetectorGeometry *barrelGeometry = geometry.getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
+    const auto& pIcal = setup.getData(intercalibConstantsToken_);
+    const auto imap = pIcal.getMap();
+    std::cout << "imap.size() = " << imap.size() << std::endl;
 
     // loop over all barrel crystals
     barrelCells = geometry.getValidDetIds(DetId::Ecal, EcalBarrel);
@@ -340,7 +329,7 @@ edm::EDLooper::Status Pi0FixedMassWindowCalibration::duringLoop(const edm::Event
 
   int nRecHitsEB = 0;
   Handle<EcalRecHitCollection> pEcalRecHitBarrelCollection;
-  event.getByLabel(ecalHitsProducer_, barrelHits_, pEcalRecHitBarrelCollection);
+  event.getByToken(recHitToken_, pEcalRecHitBarrelCollection);
   const EcalRecHitCollection* ecalRecHitBarrelCollection = pEcalRecHitBarrelCollection.product();
   cout << " ECAL Barrel RecHits # " << ecalRecHitBarrelCollection->size() << endl;
   for (EcalRecHitCollection::const_iterator aRecHitEB = ecalRecHitBarrelCollection->begin();
@@ -380,18 +369,14 @@ edm::EDLooper::Status Pi0FixedMassWindowCalibration::duringLoop(const edm::Event
     irecalib++;
   }
 
-  // get the geometry and topology from the event setup:
-  edm::ESHandle<CaloGeometry> geoHandle;
-  setup.get<CaloGeometryRecord>().get(geoHandle);
-
   const CaloSubdetectorGeometry* geometry_p;
 
   std::string clustershapetag;
-  geometry_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
-  EcalBarrelTopology topology{*geoHandle};
+  geometry_p = geometry.getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
+  EcalBarrelTopology topology{geometry};
 
   const CaloSubdetectorGeometry* geometryES_p;
-  geometryES_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
+  geometryES_p = geometry.getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
 
   /*
   reco::BasicClusterCollection clusters;

--- a/Calibration/EcalCalibAlgos/src/Pi0FixedMassWindowCalibration.cc
+++ b/Calibration/EcalCalibAlgos/src/Pi0FixedMassWindowCalibration.cc
@@ -292,7 +292,7 @@ edm::EDLooper::Status Pi0FixedMassWindowCalibration::duringLoop(const edm::Event
     // get initial constants out of DB
 
     const auto& pIcal = setup.getData(intercalibConstantsToken_);
-    const auto imap = pIcal.getMap();
+    const auto& imap = pIcal.getMap();
     std::cout << "imap.size() = " << imap.size() << std::endl;
 
     // loop over all barrel crystals


### PR DESCRIPTION
#### PR description:

This PR migrates ECAL related code in the Calibration packages to esConsumes (#31061). In addition `getByLabel()` calls were replaced by `getByToken()` and legacy module types were migrated to multithreaded module types.

#### PR validation:

Code compiles.
