### PR TITLE
[GCC11] Fix warnings for EgammaHLTProducers

### DIFF
--- a/RecoEgamma/EgammaHLTProducers/plugins/HLTCaloObjInRegionsProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/HLTCaloObjInRegionsProducer.cc
@@ -213,7 +213,7 @@ std::unique_ptr<CaloObjCollType> HLTCaloObjInRegionsProducer<CaloObjType, CaloOb
   if (!inputColl->empty()) {
     const CaloSubdetectorGeometry* subDetGeom = caloGeomHandle.getSubdetectorGeometry(inputColl->begin()->id());
     if (!regions.empty()) {
-      for (const CaloObjType& obj : *inputColl) {
+      for (auto const& obj : *inputColl) {
         auto objGeom = subDetGeom->getGeometry(obj.id());
         if (objGeom == nullptr) {
           //wondering what to do here


### PR DESCRIPTION
This should fix the 5 warnings of GCC11 IBs
```
  RecoEgamma/EgammaHLTProducers/plugins/HLTCaloObjInRegionsProducer.cc:216:31: warning: loop variable 'obj' of type 'const ESDataFrame&' binds to a temporary constructed from type 'const edm::DataFrame' [-Wrange-loop-construct]
   216 |       for (const CaloObjType& obj : *inputColl) {
      |                               ^~~
```