### PR TITLE
[GCC11] Fix compiler warnings for RecoPPS

### DIFF
--- a/RecoPPS/ProtonReconstruction/plugins/CTPPSProtonProducer.cc
+++ b/RecoPPS/ProtonReconstruction/plugins/CTPPSProtonProducer.cc
@@ -168,9 +168,9 @@ CTPPSProtonProducer::CTPPSProtonProducer(const edm::ParameterSet &iConfig)
       opticalFunctionsToken_(esConsumes<LHCInterpolatedOpticalFunctionsSetCollection, CTPPSInterpolatedOpticsRcd>(
           edm::ESInputTag("", opticsLabel_))),
       geometryToken_(esConsumes<CTPPSGeometry, VeryForwardRealGeometryRecord>()) {
-  for (const std::string &sector : {"45", "56"}) {
-    const unsigned int arm = (sector == "45") ? 0 : 1;
-    association_cuts_[arm].load(iConfig.getParameterSet("association_cuts_" + sector));
+  for (auto &sector : {"45", "56"}) {
+    const unsigned int arm = strcmp(sector, "45") == 0 ? 0 : 1;
+    association_cuts_[arm].load(iConfig.getParameterSet("association_cuts_" + std::string(sector)));
   }
 
   if (doSingleRPReconstruction_)
@@ -212,9 +212,10 @@ void CTPPSProtonProducer::fillDescriptions(edm::ConfigurationDescriptions &descr
   desc.add<double>("localAngleYMin", -0.04)->setComment("minimal accepted value of local vertical angle (rad)");
   desc.add<double>("localAngleYMax", +0.04)->setComment("maximal accepted value of local vertical angle (rad)");
 
-  for (const std::string &sector : {"45", "56"}) {
-    desc.add<edm::ParameterSetDescription>("association_cuts_" + sector, AssociationCuts::getDefaultParameters())
-        ->setComment("track-association cuts for sector " + sector);
+  for (auto &sector : {"45", "56"}) {
+    desc.add<edm::ParameterSetDescription>("association_cuts_" + std::string(sector),
+                                           AssociationCuts::getDefaultParameters())
+        ->setComment("track-association cuts for sector " + std::string(sector));
   }
 
   std::vector<edm::ParameterSet> config;


### PR DESCRIPTION
Thsi fixes the GCC11 compilation warnings for `RecoPPS/ProtonReconstruction/plugins/CTPPSProtonProducer.cc` 

```
  RecoPPS/ProtonReconstruction/plugins/CTPPSProtonProducer.cc:171:27: warning: loop variable 'sector' of type 'const string&' {aka 'const std::__cxx11::basic_string<char>&'} binds to a temporary constructed from type 'const char* const' [-Wrange-loop-construct]
   171 |   for (const std::string &sector : {"45", "56"}) {
      |                           ^~~~~~
RecoPPS/ProtonReconstruction/plugins/CTPPSProtonProducer.cc:215:27: warning: loop variable 'sector' of type 'const string&' {aka 'const std::__cxx11::basic_string<char>&'} binds to a temporary constructed from type 'const char* const' [-Wrange-loop-construct]
   215 |   for (const std::string &sector : {"45", "56"}) {
      |                           ^~~~~~

```