### PR TITLE
[GCC11] Ignore used uninitialized warning in DTDigiSimLink

### DIFF
--- a/SimDataFormats/DigiSimLinks/src/DTDigiSimLink.cc
+++ b/SimDataFormats/DigiSimLinks/src/DTDigiSimLink.cc
@@ -22,11 +22,14 @@ DTDigiSimLink::DTDigiSimLink()
     : theWire(0), theDigiNumber(0), theTDCBase(32), theCounts(0), theSimTrackId(0), theEventId(0) {}
 
 DTDigiSimLink::ChannelType DTDigiSimLink::channel() const {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuninitialized"
   ChannelPacking result;
   result.wi = theWire;
   result.num = theDigiNumber;
   DTDigiSimLink::ChannelType* p_result = reinterpret_cast<DTDigiSimLink::ChannelType*>(&result);
   return *p_result;
+#pragma GCC diagnostic pop
 }
 
 int DTDigiSimLink::wire() const { return theWire; }


### PR DESCRIPTION
Looks like the GCC 11 warning
```
  SimDataFormats/DigiSimLinks/src/DTDigiSimLink.cc:29:11: warning: 'result' is used uninitialized [-Wuninitialized]
    29 |   return *p_result;
      |           ^~~~~~~~
SimDataFormats/DigiSimLinks/src/DTDigiSimLink.cc:25:18: note: 'result' declared here
   25 |   ChannelPacking result;
      |                  ^~~~~~
```
is false positive. ThisPR proposes to ignore the used uninitialized warning for this selected code.