### PR TITLE
Adding fake alignment to make tracker geometry test work

### DIFF
--- a/Geometry/TrackerGeometryBuilder/test/python/testTrackerHierarchy_cfg.py
+++ b/Geometry/TrackerGeometryBuilder/test/python/testTrackerHierarchy_cfg.py
@@ -15,6 +15,9 @@ process.prod = cms.EDAnalyzer("GeoHierarchy",
     fromDDD = cms.bool(True)
 )
 
+process.load("Alignment.CommonAlignmentProducer.FakeAlignmentSource_cfi")
+process.preferFakeAlign = cms.ESPrefer("FakeAlignmentSource") 
+
 process.p1 = cms.Path(process.prod)
 
 

--- a/Geometry/TrackerGeometryBuilder/test/python/testTracker_cfg.py
+++ b/Geometry/TrackerGeometryBuilder/test/python/testTracker_cfg.py
@@ -5,6 +5,9 @@ process.load("Configuration.Geometry.GeometryExtended2021Reco_cff")
 
 process.source = cms.Source("EmptySource")
 
+process.load("Alignment.CommonAlignmentProducer.FakeAlignmentSource_cfi")
+process.preferFakeAlign = cms.ESPrefer("FakeAlignmentSource") 
+
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
 )


### PR DESCRIPTION
#### PR description:
To solve the issue reported in https://github.com/cms-sw/cmssw/issues/35118
When https://github.com/cms-sw/cmssw/pull/35092 was introduced, it will take alignment from the GT. However, for the unit test, we can pick the fake alignment instead.

#### PR validation:
Test with `testTrackerHierarchy_cfg.py` and `testTracker_cfg.py`, they now run fine.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
Not a backport. Will backport together with https://github.com/cms-sw/cmssw/pull/35092 to 12_0 if needs.