### PR TITLE
Fix filling and multiplicity ranges

### DIFF
--- a/DQMOffline/Muon/interface/CSCOfflineMonitor.h
+++ b/DQMOffline/Muon/interface/CSCOfflineMonitor.h
@@ -156,16 +156,19 @@ private:
 
   // Wire digis
   MonitorElement *hWirenGroupsTotal;
+  MonitorElement *hWirenGroupsTotalHi;
   std::vector<MonitorElement *> hWireTBin;
   std::vector<MonitorElement *> hWireNumber;
 
   // Strip Digis
   MonitorElement *hStripNFired;
+  MonitorElement *hStripNFiredHi;
   std::vector<MonitorElement *> hStripNumber;
   std::vector<MonitorElement *> hStripPed;
 
   // Rechits
   MonitorElement *hRHnrechits;
+  MonitorElement *hRHnrechitsHi;
   std::vector<MonitorElement *> hRHGlobal;
   std::vector<MonitorElement *> hRHSumQ;
   std::vector<MonitorElement *> hRHTiming;


### PR DESCRIPTION
Two simple set of changes to CSC DQM sub package that examines digis, rechits, and segments:
i) Fix two mis-filled simple efficiency histograms - bins didn't match x-axis labels (CSC chamber ring labels)
ii) Split overall strip and wire digi, and rechit multiplicity plots into two, one with 'standard' range and with 'extended' range for high multiplicities seen in phase2 PU200 simulations. I've adjusted the 'standard' ranges and binning so that the overall number of bins is slightly reduced so there is no increase in resource usage.

PR validation:

Validated on several runs with 250 events of run3 TTbar workflow using
runTheMatrix.py -l 11634.0 --command="-n 250"

scram b code-format shows no suggestions for change.
