### PR TITLE
Fix undefined behaviour in Ecal Validation 

### DIFF
--- a/Validation/EcalDigis/plugins/EcalSelectiveReadoutValidation.cc
+++ b/Validation/EcalDigis/plugins/EcalSelectiveReadoutValidation.cc
@@ -291,6 +291,12 @@ void EcalSelectiveReadoutValidation::analyzeEE(const edm::Event& event, const ed
   nEeZsErrors_ = 0;
   nEeZsErrorsType1_ = 0;
 
+   /** Energy deposited in ECAL endcap crystals. Endcap index is 0 for EE- and
+   * 1 for EE+. X and Y index starts at x and y minimum in std CMS coordinate
+   * system.*/
+  std::unique_ptr<std::array<std::array<std::array<energiesEe_t, nEeY>, nEeX>, nEndcaps>> eeEnergies =
+      std::make_unique<std::array<std::array<std::array<energiesEe_t, nEeY>, nEeX>, nEndcaps>>();
+
   for (int iZ0 = 0; iZ0 < nEndcaps; ++iZ0) {
     for (int iX0 = 0; iX0 < nEeX; ++iX0) {
       for (int iY0 = 0; iY0 < nEeY; ++iY0) {
@@ -561,6 +567,13 @@ void EcalSelectiveReadoutValidation::analyzeEB(const edm::Event& event, const ed
   vector<pair<int, int>> xtalEtaPhi;
 
   xtalEtaPhi.reserve(nEbPhi * nEbEta);
+
+  /** Energy deposited in ECAL barrel crystals. Eta index starts from 0 at
+   * eta minimum and phi index starts at phi=0+ in CMS std coordinate system.
+   */
+  std::unique_ptr<std::array<std::array<energiesEb_t, nEbPhi>, nEbEta>> ebEnergies =
+      std::make_unique<std::array<std::array<energiesEb_t, nEbPhi>, nEbEta>>();
+
   for (int iEta0 = 0; iEta0 < nEbEta; ++iEta0) {
     for (int iPhi0 = 0; iPhi0 < nEbPhi; ++iPhi0) {
       (*ebEnergies)[iEta0][iPhi0].noZsRecE = -numeric_limits<double>::max();

--- a/Validation/EcalDigis/plugins/EcalSelectiveReadoutValidation.cc
+++ b/Validation/EcalDigis/plugins/EcalSelectiveReadoutValidation.cc
@@ -291,7 +291,7 @@ void EcalSelectiveReadoutValidation::analyzeEE(const edm::Event& event, const ed
   nEeZsErrors_ = 0;
   nEeZsErrorsType1_ = 0;
 
-   /** Energy deposited in ECAL endcap crystals. Endcap index is 0 for EE- and
+  /** Energy deposited in ECAL endcap crystals. Endcap index is 0 for EE- and
    * 1 for EE+. X and Y index starts at x and y minimum in std CMS coordinate
    * system.*/
   std::unique_ptr<std::array<std::array<std::array<energiesEe_t, nEeY>, nEeX>, nEndcaps>> eeEnergies =

--- a/Validation/EcalDigis/plugins/EcalSelectiveReadoutValidation.cc
+++ b/Validation/EcalDigis/plugins/EcalSelectiveReadoutValidation.cc
@@ -561,8 +561,6 @@ void EcalSelectiveReadoutValidation::analyzeEB(const edm::Event& event, const ed
   vector<pair<int, int>> xtalEtaPhi;
 
   xtalEtaPhi.reserve(nEbPhi * nEbEta);
-  std::unique_ptr<std::array<std::array<energiesEb_t, nEbPhi>, nEbEta>> ebEnergies =
-      std::make_unique<std::array<std::array<energiesEb_t, nEbPhi>, nEbEta>>();
   for (int iEta0 = 0; iEta0 < nEbEta; ++iEta0) {
     for (int iPhi0 = 0; iPhi0 < nEbPhi; ++iPhi0) {
       (*ebEnergies)[iEta0][iPhi0].noZsRecE = -numeric_limits<double>::max();

--- a/Validation/EcalDigis/plugins/EcalSelectiveReadoutValidation.cc
+++ b/Validation/EcalDigis/plugins/EcalSelectiveReadoutValidation.cc
@@ -125,7 +125,7 @@ EcalSelectiveReadoutValidation::EcalSelectiveReadoutValidation(const ParameterSe
       l1aOfTmax(0),
       triggerTowerMap_(nullptr),
       localReco_(ps.getParameter<bool>("LocalReco")),
-      weights_(ps.getParameter<vector<double> >("weights")),
+      weights_(ps.getParameter<vector<double>>("weights")),
       tpInGeV_(ps.getParameter<bool>("tpInGeV")),
       firstFIRSample_(ps.getParameter<int>("ecalDccZs1stSample")),
       useEventRate_(ps.getParameter<bool>("useEventRate")),
@@ -166,7 +166,7 @@ EcalSelectiveReadoutValidation::EcalSelectiveReadoutValidation(const ParameterSe
   logSrApplicationErrors_ = (!srApplicationErrorLogFileName_.empty());
 
   //FIR ZS weights
-  configFirWeights(ps.getParameter<vector<double> >("dccWeights"));
+  configFirWeights(ps.getParameter<vector<double>>("dccWeights"));
 
   // DQM ROOT output
   outputFile_ = ps.getUntrackedParameter<string>("outputFile", "");
@@ -182,7 +182,7 @@ EcalSelectiveReadoutValidation::EcalSelectiveReadoutValidation(const ParameterSe
 
   // get hold of back-end interface
 
-  vector<string> hists(ps.getUntrackedParameter<vector<string> >("histograms", vector<string>(1, "all")));
+  vector<string> hists(ps.getUntrackedParameter<vector<string>>("histograms", vector<string>(1, "all")));
 
   for (vector<string>::iterator it = hists.begin(); it != hists.end(); ++it)
     histList_.insert(*it);
@@ -294,11 +294,11 @@ void EcalSelectiveReadoutValidation::analyzeEE(const edm::Event& event, const ed
   for (int iZ0 = 0; iZ0 < nEndcaps; ++iZ0) {
     for (int iX0 = 0; iX0 < nEeX; ++iX0) {
       for (int iY0 = 0; iY0 < nEeY; ++iY0) {
-        eeEnergies[iZ0][iX0][iY0].noZsRecE = -numeric_limits<double>::max();
-        eeEnergies[iZ0][iX0][iY0].recE = -numeric_limits<double>::max();
-        eeEnergies[iZ0][iX0][iY0].simE = 0;  //must be set to zero.
-        eeEnergies[iZ0][iX0][iY0].simHit = 0;
-        eeEnergies[iZ0][iX0][iY0].gain12 = false;
+        (*eeEnergies)[iZ0][iX0][iY0].noZsRecE = -numeric_limits<double>::max();
+        (*eeEnergies)[iZ0][iX0][iY0].recE = -numeric_limits<double>::max();
+        (*eeEnergies)[iZ0][iX0][iY0].simE = 0;  //must be set to zero.
+        (*eeEnergies)[iZ0][iX0][iY0].simHit = 0;
+        (*eeEnergies)[iZ0][iX0][iY0].gain12 = false;
       }
     }
   }
@@ -324,19 +324,19 @@ void EcalSelectiveReadoutValidation::analyzeEE(const edm::Event& event, const ed
                                    << "[0," << nEeY - 1 << "]\n";
     }
     //    cout << "EE no ZS energy computation..." ;
-    eeEnergies[iZ0][iX0][iY0].noZsRecE = frame2Energy(frame);
+    (*eeEnergies)[iZ0][iX0][iY0].noZsRecE = frame2Energy(frame);
 
-    eeEnergies[iZ0][iX0][iY0].gain12 = true;
+    (*eeEnergies)[iZ0][iX0][iY0].gain12 = true;
     for (int i = 0; i < frame.size(); ++i) {
       const int gain12Code = 0x1;
       if (frame[i].gainId() != gain12Code)
-        eeEnergies[iZ0][iX0][iY0].gain12 = false;
+        (*eeEnergies)[iZ0][iX0][iY0].gain12 = false;
     }
 
     const GlobalPoint xtalPos = geometry_p->getGeometry(frame.id())->getPosition();
 
-    eeEnergies[iZ0][iX0][iY0].phi = rad2deg * ((double)xtalPos.phi());
-    eeEnergies[iZ0][iX0][iY0].eta = xtalPos.eta();
+    (*eeEnergies)[iZ0][iX0][iY0].phi = rad2deg * ((double)xtalPos.phi());
+    (*eeEnergies)[iZ0][iX0][iY0].eta = xtalPos.eta();
   }
 
   //EE rec hits:
@@ -356,7 +356,7 @@ void EcalSelectiveReadoutValidation::analyzeEE(const edm::Event& event, const ed
                                 << "[0," << nEeY - 1 << "]\n";
       }
       //    cout << "EE no ZS energy computation..." ;
-      eeEnergies[iZ0][iX0][iY0].recE = hit.energy();
+      (*eeEnergies)[iZ0][iX0][iY0].recE = hit.energy();
     }
   }
 
@@ -369,8 +369,8 @@ void EcalSelectiveReadoutValidation::analyzeEE(const edm::Event& event, const ed
     int iY = detId.iy();
     int iY0 = iXY2cIndex(iY);
     int iZ0 = detId.zside() > 0 ? 1 : 0;
-    eeEnergies[iZ0][iX0][iY0].simE += simHit.energy();
-    ++eeEnergies[iZ0][iX0][iY0].simHit;
+    (*eeEnergies)[iZ0][iX0][iY0].simE += simHit.energy();
+    ++(*eeEnergies)[iZ0][iX0][iY0].simHit;
   }
 
   bool EEcrystalShot[nEeX][nEeY][2];
@@ -409,14 +409,14 @@ void EcalSelectiveReadoutValidation::analyzeEE(const edm::Event& event, const ed
     }
 
     if (localReco_) {
-      eeEnergies[iZ0][iX0][iY0].recE = frame2Energy(frame);
+      (*eeEnergies)[iZ0][iX0][iY0].recE = frame2Energy(frame);
     }
 
-    eeEnergies[iZ0][iX0][iY0].gain12 = true;
+    (*eeEnergies)[iZ0][iX0][iY0].gain12 = true;
     for (int i = 0; i < frame.size(); ++i) {
       const int gain12Code = 0x1;
       if (frame[i].gainId() != gain12Code) {
-        eeEnergies[iZ0][iX0][iY0].gain12 = false;
+        (*eeEnergies)[iZ0][iX0][iY0].gain12 = false;
       }
     }
 
@@ -470,22 +470,22 @@ void EcalSelectiveReadoutValidation::analyzeEE(const edm::Event& event, const ed
   for (int iZ0 = 0; iZ0 < nEndcaps; ++iZ0) {
     for (int iX0 = 0; iX0 < nEeX; ++iX0) {
       for (int iY0 = 0; iY0 < nEeY; ++iY0) {
-        double recE = eeEnergies[iZ0][iX0][iY0].recE;
+        double recE = (*eeEnergies)[iZ0][iX0][iY0].recE;
         if (recE == -numeric_limits<double>::max())
           continue;  //not a crystal or ZS
-        fill(meEeRecE_, eeEnergies[iZ0][iX0][iY0].recE);
+        fill(meEeRecE_, (*eeEnergies)[iZ0][iX0][iY0].recE);
 
-        fill(meEeEMean_, ievt_ + 1, eeEnergies[iZ0][iX0][iY0].recE);
+        fill(meEeEMean_, ievt_ + 1, (*eeEnergies)[iZ0][iX0][iY0].recE);
 
         if (withEeSimHit_) {
-          if (!eeEnergies[iZ0][iX0][iY0].simHit) {  //noise only crystal channel
-            fill(meEeNoise_, eeEnergies[iZ0][iX0][iY0].noZsRecE);
+          if (!(*eeEnergies)[iZ0][iX0][iY0].simHit) {  //noise only crystal channel
+            fill(meEeNoise_, (*eeEnergies)[iZ0][iX0][iY0].noZsRecE);
           } else {
-            fill(meEeSimE_, eeEnergies[iZ0][iX0][iY0].simE);
-            fill(meEeRecEHitXtal_, eeEnergies[iZ0][iX0][iY0].recE);
+            fill(meEeSimE_, (*eeEnergies)[iZ0][iX0][iY0].simE);
+            fill(meEeRecEHitXtal_, (*eeEnergies)[iZ0][iX0][iY0].recE);
           }
-          fill(meEeRecVsSimE_, eeEnergies[iZ0][iX0][iY0].simE, eeEnergies[iZ0][iX0][iY0].recE);
-          fill(meEeNoZsRecVsSimE_, eeEnergies[iZ0][iX0][iY0].simE, eeEnergies[iZ0][iX0][iY0].noZsRecE);
+          fill(meEeRecVsSimE_, (*eeEnergies)[iZ0][iX0][iY0].simE, (*eeEnergies)[iZ0][iX0][iY0].recE);
+          fill(meEeNoZsRecVsSimE_, (*eeEnergies)[iZ0][iX0][iY0].simE, (*eeEnergies)[iZ0][iX0][iY0].noZsRecE);
         }
       }
     }
@@ -558,16 +558,18 @@ void EcalSelectiveReadoutValidation::analyzeEB(const edm::Event& event, const ed
   bool eventError = false;
   nEbZsErrors_ = 0;
   nEbZsErrorsType1_ = 0;
-  vector<pair<int, int> > xtalEtaPhi;
+  vector<pair<int, int>> xtalEtaPhi;
 
   xtalEtaPhi.reserve(nEbPhi * nEbEta);
+  std::unique_ptr<std::array<std::array<energiesEb_t, nEbPhi>, nEbEta>> ebEnergies =
+      std::make_unique<std::array<std::array<energiesEb_t, nEbPhi>, nEbEta>>();
   for (int iEta0 = 0; iEta0 < nEbEta; ++iEta0) {
     for (int iPhi0 = 0; iPhi0 < nEbPhi; ++iPhi0) {
-      ebEnergies[iEta0][iPhi0].noZsRecE = -numeric_limits<double>::max();
-      ebEnergies[iEta0][iPhi0].recE = -numeric_limits<double>::max();
-      ebEnergies[iEta0][iPhi0].simE = 0;  //must be zero.
-      ebEnergies[iEta0][iPhi0].simHit = 0;
-      ebEnergies[iEta0][iPhi0].gain12 = false;
+      (*ebEnergies)[iEta0][iPhi0].noZsRecE = -numeric_limits<double>::max();
+      (*ebEnergies)[iEta0][iPhi0].recE = -numeric_limits<double>::max();
+      (*ebEnergies)[iEta0][iPhi0].simE = 0;  //must be zero.
+      (*ebEnergies)[iEta0][iPhi0].simHit = 0;
+      (*ebEnergies)[iEta0][iPhi0].gain12 = false;
       xtalEtaPhi.push_back(pair<int, int>(iEta0, iPhi0));
     }
   }
@@ -597,18 +599,18 @@ void EcalSelectiveReadoutValidation::analyzeEB(const edm::Event& event, const ed
       throw cms::Exception(s.str());
     }
 
-    ebEnergies[iEta0][iPhi0].noZsRecE = frame2Energy(frame);
-    ebEnergies[iEta0][iPhi0].gain12 = true;
+    (*ebEnergies)[iEta0][iPhi0].noZsRecE = frame2Energy(frame);
+    (*ebEnergies)[iEta0][iPhi0].gain12 = true;
     for (int i = 0; i < frame.size(); ++i) {
       const int gain12Code = 0x1;
       if (frame[i].gainId() != gain12Code)
-        ebEnergies[iEta0][iPhi0].gain12 = false;
+        (*ebEnergies)[iEta0][iPhi0].gain12 = false;
     }
 
     const GlobalPoint xtalPos = geometry_p->getGeometry(frame.id())->getPosition();
 
-    ebEnergies[iEta0][iPhi0].phi = rad2deg * ((double)xtalPos.phi());
-    ebEnergies[iEta0][iPhi0].eta = xtalPos.eta();
+    (*ebEnergies)[iEta0][iPhi0].phi = rad2deg * ((double)xtalPos.phi());
+    (*ebEnergies)[iEta0][iPhi0].eta = xtalPos.eta();
   }  //next non-zs digi
 
   //EB sim hits
@@ -619,8 +621,8 @@ void EcalSelectiveReadoutValidation::analyzeEB(const edm::Event& event, const ed
     int iEta0 = iEta2cIndex(iEta);
     int iPhi = detId.iphi();
     int iPhi0 = iPhi2cIndex(iPhi);
-    ebEnergies[iEta0][iPhi0].simE += simHit.energy();
-    ++ebEnergies[iEta0][iPhi0].simHit;
+    (*ebEnergies)[iEta0][iPhi0].simE += simHit.energy();
+    ++(*ebEnergies)[iEta0][iPhi0].simHit;
   }
 
   bool crystalShot[nEbEta][nEbPhi];
@@ -660,14 +662,14 @@ void EcalSelectiveReadoutValidation::analyzeEB(const edm::Event& event, const ed
       abort();
     }
     if (localReco_) {
-      ebEnergies[iEta0][iPhi0].recE = frame2Energy(frame);
+      (*ebEnergies)[iEta0][iPhi0].recE = frame2Energy(frame);
     }
 
-    ebEnergies[iEta0][iPhi0].gain12 = true;
+    (*ebEnergies)[iEta0][iPhi0].gain12 = true;
     for (int i = 0; i < frame.size(); ++i) {
       const int gain12Code = 0x1;
       if (frame[i].gainId() != gain12Code) {
-        ebEnergies[iEta0][iPhi0].gain12 = false;
+        (*ebEnergies)[iEta0][iPhi0].gain12 = false;
       }
     }
 
@@ -733,18 +735,18 @@ void EcalSelectiveReadoutValidation::analyzeEB(const edm::Event& event, const ed
         LogError("EcalSrValid") << "iPhi0 (= " << iPhi0 << ") is out of range ("
                                 << "[0," << nEbPhi - 1 << "]\n";
       }
-      ebEnergies[iEta0][iPhi0].recE = hit.energy();
+      (*ebEnergies)[iEta0][iPhi0].recE = hit.energy();
     }
   }
 
   for (unsigned int i = 0; i < xtalEtaPhi.size(); ++i) {
     int iEta0 = xtalEtaPhi[i].first;
     int iPhi0 = xtalEtaPhi[i].second;
-    energiesEb_t& energies = ebEnergies[iEta0][iPhi0];
+    energiesEb_t& energies = (*ebEnergies)[iEta0][iPhi0];
 
     double recE = energies.recE;
     if (recE != -numeric_limits<double>::max()) {  //not zero suppressed
-      fill(meEbRecE_, ebEnergies[iEta0][iPhi0].recE);
+      fill(meEbRecE_, (*ebEnergies)[iEta0][iPhi0].recE);
       fill(meEbEMean_, ievt_ + 1, recE);
     }  //not zero suppressed
 

--- a/Validation/EcalDigis/plugins/EcalSelectiveReadoutValidation.h
+++ b/Validation/EcalDigis/plugins/EcalSelectiveReadoutValidation.h
@@ -518,8 +518,8 @@ private:
   CollHandle<EESrFlagCollection> eeSrFlags_;
   CollHandle<EBSrFlagCollection> ebComputedSrFlags_;
   CollHandle<EESrFlagCollection> eeComputedSrFlags_;
-  CollHandle<std::vector<PCaloHit> > ebSimHits_;
-  CollHandle<std::vector<PCaloHit> > eeSimHits_;
+  CollHandle<std::vector<PCaloHit>> ebSimHits_;
+  CollHandle<std::vector<PCaloHit>> eeSimHits_;
   CollHandle<EcalTrigPrimDigiCollection> tps_;
   CollHandle<RecHitCollection> ebRecHits_;
   CollHandle<RecHitCollection> eeRecHits_;
@@ -788,14 +788,16 @@ private:
 
   /** Energy deposited in ECAL barrel crystals. Eta index starts from 0 at
    * eta minimum and phi index starts at phi=0+ in CMS std coordinate system.
-   */ 
-   std::vector<std::vector<energiesEb_t>> ebEnergies= std::vector<std::vector<energiesEb_t>>(nEbEta, std::vector<energiesEb_t>(nEbPhi));
+   */
+  std::vector<std::vector<energiesEb_t>> ebEnergies =
+      std::vector<std::vector<energiesEb_t>>(nEbEta, std::vector<energiesEb_t>(nEbPhi));
 
   /** Energy deposited in ECAL endcap crystals. Endcap index is 0 for EE- and
    * 1 for EE+. X and Y index starts at x and y minimum in std CMS coordinate
    * system.
-   */ 
-  std::vector<std::vector<std::vector<energiesEe_t>>> eeEnergies= std::vector<std::vector<std::vector<energiesEe_t>>> (nEndcaps, std::vector<std::vector<energiesEe_t>> (nEeX, std::vector<energiesEe_t>(nEeY)));
+   */
+  std::vector<std::vector<std::vector<energiesEe_t>>> eeEnergies = std::vector<std::vector<std::vector<energiesEe_t>>>(
+      nEndcaps, std::vector<std::vector<energiesEe_t>>(nEeX, std::vector<energiesEe_t>(nEeY)));
 
   /** Permits to skip inner SC
    */

--- a/Validation/EcalDigis/plugins/EcalSelectiveReadoutValidation.h
+++ b/Validation/EcalDigis/plugins/EcalSelectiveReadoutValidation.h
@@ -788,14 +788,14 @@ private:
 
   /** Energy deposited in ECAL barrel crystals. Eta index starts from 0 at
    * eta minimum and phi index starts at phi=0+ in CMS std coordinate system.
-   */
-  energiesEb_t ebEnergies[nEbEta][nEbPhi];
+   */ 
+   std::vector<std::vector<energiesEb_t>> ebEnergies= std::vector<std::vector<energiesEb_t>>(nEbEta, std::vector<energiesEb_t>(nEbPhi));
 
   /** Energy deposited in ECAL endcap crystals. Endcap index is 0 for EE- and
    * 1 for EE+. X and Y index starts at x and y minimum in std CMS coordinate
    * system.
-   */
-  energiesEe_t eeEnergies[nEndcaps][nEeX][nEeY];
+   */ 
+  std::vector<std::vector<std::vector<energiesEe_t>>> eeEnergies= std::vector<std::vector<std::vector<energiesEe_t>>> (nEndcaps, std::vector<std::vector<energiesEe_t>> (nEeX, std::vector<energiesEe_t>(nEeY)));
 
   /** Permits to skip inner SC
    */

--- a/Validation/EcalDigis/plugins/EcalSelectiveReadoutValidation.h
+++ b/Validation/EcalDigis/plugins/EcalSelectiveReadoutValidation.h
@@ -789,15 +789,15 @@ private:
   /** Energy deposited in ECAL barrel crystals. Eta index starts from 0 at
    * eta minimum and phi index starts at phi=0+ in CMS std coordinate system.
    */
-  std::vector<std::vector<energiesEb_t>> ebEnergies =
-      std::vector<std::vector<energiesEb_t>>(nEbEta, std::vector<energiesEb_t>(nEbPhi));
+  std::unique_ptr<std::array<std::array<energiesEb_t, nEbPhi>, nEbEta>> ebEnergies =
+      std::make_unique<std::array<std::array<energiesEb_t, nEbPhi>, nEbEta>>();
 
   /** Energy deposited in ECAL endcap crystals. Endcap index is 0 for EE- and
    * 1 for EE+. X and Y index starts at x and y minimum in std CMS coordinate
    * system.
    */
-  std::vector<std::vector<std::vector<energiesEe_t>>> eeEnergies = std::vector<std::vector<std::vector<energiesEe_t>>>(
-      nEndcaps, std::vector<std::vector<energiesEe_t>>(nEeX, std::vector<energiesEe_t>(nEeY)));
+  std::unique_ptr<std::array<std::array<std::array<energiesEe_t, nEeY>, nEeX>, nEndcaps>> eeEnergies =
+      std::make_unique<std::array<std::array<std::array<energiesEe_t, nEeY>, nEeX>, nEndcaps>>();
 
   /** Permits to skip inner SC
    */

--- a/Validation/EcalDigis/plugins/EcalSelectiveReadoutValidation.h
+++ b/Validation/EcalDigis/plugins/EcalSelectiveReadoutValidation.h
@@ -786,19 +786,6 @@ private:
    */
   double ttEtSums[nTtEta][nTtPhi];
 
-  /** Energy deposited in ECAL barrel crystals. Eta index starts from 0 at
-   * eta minimum and phi index starts at phi=0+ in CMS std coordinate system.
-   */
-  std::unique_ptr<std::array<std::array<energiesEb_t, nEbPhi>, nEbEta>> ebEnergies =
-      std::make_unique<std::array<std::array<energiesEb_t, nEbPhi>, nEbEta>>();
-
-  /** Energy deposited in ECAL endcap crystals. Endcap index is 0 for EE- and
-   * 1 for EE+. X and Y index starts at x and y minimum in std CMS coordinate
-   * system.
-   */
-  std::unique_ptr<std::array<std::array<std::array<energiesEe_t, nEeY>, nEeX>, nEndcaps>> eeEnergies =
-      std::make_unique<std::array<std::array<std::array<energiesEe_t, nEeY>, nEeX>, nEndcaps>>();
-
   /** Permits to skip inner SC
    */
   bool SkipInnerSC_;

--- a/Validation/EcalHits/src/EcalSimHitsValidProducer.cc
+++ b/Validation/EcalHits/src/EcalSimHitsValidProducer.cc
@@ -435,7 +435,9 @@ void EcalSimHitsValidProducer::update(const G4Step *aStep) {
     float r = sqrt(x * x + y * y);
     float detr = r - 1290;
     int x0 = (int)floor(detr / 8.9);
-    eBX0[x0] += Edeposit;
+    if (x0 < 26) {
+      eBX0[x0] += Edeposit;
+    }
   }
 }
 


### PR DESCRIPTION
#### PR description:
This PR addresses the undefined behaviour of Ecal Validation codes reported in https://github.com/cms-sw/cmssw/issues/35037 and https://github.com/cms-sw/cmssw/issues/35004

#### PR validation:
The PR was validated by running the workflow `11603.0` on top of `CMSSW_12_1_UBSAN_X_2021-08-27-2300` and  observed no runtime errors linked to `EDProducerBase` or `EDConsumerBase`.

Also validated by running the workflow `101.0` on the same release and observed no runtime errors of type `index out of bound `.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
N/A
