### PR TITLE
Fix the TriggerResultsFilter default configuration to skip the current process [12.0.x]

### DIFF
--- a/HLTrigger/HLTfilters/plugins/TriggerResultsFilter.cc
+++ b/HLTrigger/HLTfilters/plugins/TriggerResultsFilter.cc
@@ -42,11 +42,14 @@ TriggerResultsFilter::~TriggerResultsFilter() { delete m_expression; }
 void TriggerResultsFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   // # use HLTPathStatus results
-  desc.add<bool>("usePathStatus", false);
-  // # HLT results   - set to empty to ignore HLT
-  desc.add<edm::InputTag>("hltResults", edm::InputTag("TriggerResults"));
+  desc.add<bool>("usePathStatus", false)
+      ->setComment("Read the HLT results from the TriggerResults (false) or from the current job's PathStatus (true).");
+  // # HLT results - set to empty to ignore HLT
+  desc.add<edm::InputTag>("hltResults", edm::InputTag("TriggerResults", "", "@skipCurrentProcess"))
+      ->setComment("HLT TriggerResults. Leave empty to ignore the HLT results. Ignored when usePathStatus is true.");
   // # L1 uGT results - set to empty to ignore L1T
-  desc.add<edm::InputTag>("l1tResults", edm::InputTag("hltGtStage2Digis"));
+  desc.add<edm::InputTag>("l1tResults", edm::InputTag("hltGtStage2Digis"))
+      ->setComment("uGT digi collection. Leave empty to ignore the L1T results.");
   // # use initial L1 decision, before masks and prescales
   desc.add<bool>("l1tIgnoreMaskAndPrescale", false);
   // # OBSOLETE - these parameters are ignored, they are left only not to break old configurations

--- a/HLTrigger/HLTfilters/test/triggerResultsFilter.py
+++ b/HLTrigger/HLTfilters/test/triggerResultsFilter.py
@@ -179,6 +179,6 @@ process.path_false_pattern       = cms.Path( process.filter_false_pattern )
 
 # define an EndPath to analyze all other path results
 process.hltTrigReport = cms.EDAnalyzer( 'HLTrigReport',
-    HLTriggerResults = cms.InputTag( 'TriggerResults','','TEST' )
+    HLTriggerResults = cms.InputTag( 'TriggerResults', '', 'TEST' )
 )
 process.HLTAnalyzerEndpath = cms.EndPath( process.hltTrigReport )

--- a/HLTrigger/HLTfilters/test/triggerResultsFilter_producer.py
+++ b/HLTrigger/HLTfilters/test/triggerResultsFilter_producer.py
@@ -44,8 +44,8 @@ process.success = cms.EDFilter('HLTBool', result = cms.bool(True))
 process.Path_1  = cms.Path(process.scale_1)
 process.Path_2  = cms.Path(process.scale_2)
 process.Path_3  = cms.Path(process.scale_3)
-process.True    = cms.Path(process.success)
-process.False   = cms.Path(process.fail)
+process.AlwaysTrue    = cms.Path(process.success)
+process.AlwaysFalse   = cms.Path(process.fail)
 process.L1_Path = cms.Path(process.success)
 
 # define and EndPath to analyze all other path results


### PR DESCRIPTION
#### PR description:

The default configuration of `TriggerResultsFilter` tries to read the `TriggerResults` without specifying any process label, which is understood as wanting to read from the current process.
This leads to test for the `TriggerResultsFilter` failing because of a conflict in the schedule.

This PR updates the default configuration to ignore the current process.

#### PR validation:

`HLTrigger/HLTfilters/test/triggerResultsFilter.py` now works:

```bash
cmsRun HLTrigger/HLTfilters/test/triggerResultsFilter_producer.py
...
cmsRun HLTrigger/HLTfilters/test/triggerResultsFilter.py
...
TrigReport ---------- Path   Summary ------------
TrigReport  Trig Bit#   Executed     Passed     Failed      Error Name
TrigReport     1    0       1000        500        500          0 path_1
TrigReport     1    1       1000        333        667          0 path_2
TrigReport     1    2       1000        200        800          0 path_3
TrigReport     1    3       1000         33        967          0 path_all_explicit
TrigReport     1    4       1000        733        267          0 path_any_or
TrigReport     1    5       1000       1000          0          0 path_any_star
TrigReport     1    6       1000         33        967          0 path_1_pre
TrigReport     1    7       1000         33        967          0 path_2_pre
TrigReport     1    8       1000         99        901          0 path_any_pre
TrigReport     1    9       1000       1000          0          0 path_any_doublestar
TrigReport     1   10       1000        733        267          0 path_any_question
TrigReport     1   11       1000          0       1000          0 path_wrong_name
TrigReport     1   12       1000          0       1000          0 path_wrong_pattern
TrigReport     1   13       1000       1000          0          0 path_not_wrong_pattern
TrigReport     1   14       1000          0       1000          0 path_empty_pattern
TrigReport     1   15       1000          0       1000          0 path_l1path_pattern
TrigReport     1   16       1000          0       1000          0 path_l1singlemuopen_pattern
TrigReport     1   17       1000       1000          0          0 path_true_pattern
TrigReport     1   18       1000          0       1000          0 path_false_pattern
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of #35131 .