### PR TITLE
ECAL esConsumes migration of CaloOnlineTools/EcalTools

### DIFF
--- a/CaloOnlineTools/EcalTools/plugins/EcalCosmicsHists.cc
+++ b/CaloOnlineTools/EcalTools/plugins/EcalCosmicsHists.cc
@@ -15,28 +15,16 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "Geometry/CaloTopology/interface/CaloTopology.h"
 #include "Geometry/Records/interface/CaloTopologyRecord.h"
-#include "Geometry/EcalMapping/interface/EcalElectronicsMapping.h"
-#include "Geometry/EcalMapping/interface/EcalMappingRcd.h"
 
 #include "DataFormats/EgammaReco/interface/BasicCluster.h"
 #include "DataFormats/EgammaReco/interface/BasicClusterFwd.h"
-#include "DataFormats/EgammaReco/interface/SuperCluster.h"
-#include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
 #include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
 
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 
-#include "CondFormats/EcalObjects/interface/EcalADCToGeVConstant.h"
-#include "CondFormats/L1TObjects/interface/L1GtTriggerMenu.h"
-#include "CondFormats/DataRecord/interface/L1GtTriggerMenuRcd.h"
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutSetupFwd.h"
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutSetup.h"
-#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h"
-#include "CondFormats/DataRecord/interface/EcalADCToGeVConstantRcd.h"
-
-#include <vector>
-#include "TLine.h"
 
 using namespace cms;
 using namespace edm;
@@ -61,6 +49,22 @@ EcalCosmicsHists::EcalCosmicsHists(const edm::ParameterSet& iConfig)
       endcapClusterCollection_(iConfig.getParameter<edm::InputTag>("endcapClusterCollection")),
       l1GTReadoutRecTag_(iConfig.getUntrackedParameter<std::string>("L1GlobalReadoutRecord", "gtDigis")),
       l1GMTReadoutRecTag_(iConfig.getUntrackedParameter<std::string>("L1GlobalMuonReadoutRecord", "gtDigis")),
+      barrelClusterToken_(consumes<reco::SuperClusterCollection>(barrelClusterCollection_)),
+      endcapClusterToken_(consumes<reco::SuperClusterCollection>(endcapClusterCollection_)),
+      ebRecHitToken_(consumes<EcalRecHitCollection>(ecalRecHitCollectionEB_)),
+      eeRecHitToken_(consumes<EcalRecHitCollection>(ecalRecHitCollectionEE_)),
+      ecalRawDataToken_(consumes<EcalRawDataCollection>(ecalRawDataColl_)),
+      tracksToken_(consumes<reco::TrackCollection>(edm::InputTag("cosmicMuons"))),
+      tracksBarrelToken_(consumes<reco::TrackCollection>(edm::InputTag("cosmicMuonsBarrelOnly"))),
+      hbheRecHitToken_(consumes<HBHERecHitCollection>(edm::InputTag("hbhereco"))),
+      hfRecHitToken_(consumes<HFRecHitCollection>(edm::InputTag("hfreco"))),
+      hoRecHitToken_(consumes<HORecHitCollection>(edm::InputTag("horeco"))),
+      l1MuGMTToken_(consumes<L1MuGMTReadoutCollection>(l1GMTReadoutRecTag_)),
+      l1GTReadoutToken_(consumes<L1GlobalTriggerReadoutRecord>(l1GTReadoutRecTag_)),
+      gtRecordToken_(consumes<L1GlobalTriggerReadoutRecord>(edm::InputTag("gtDigis"))),
+      ecalADCToGeVConstantToken_(esConsumes()),
+      l1MenuToken_(esConsumes()),
+      ecalMappingToken_(esConsumes<edm::Transition::BeginRun>()),
       runNum_(-1),
       histRangeMax_(iConfig.getUntrackedParameter<double>("histogramMaxRange", 1.8)),
       histRangeMin_(iConfig.getUntrackedParameter<double>("histogramMinRange", 0.0)),
@@ -115,17 +119,11 @@ void EcalCosmicsHists::analyze(edm::Event const& iEvent, edm::EventSetup const& 
   //LogDebug("EcalCosmicsHists")<< "Timestamp: " << iEvent.id().run() << " " << iEvent.id().event() << " " << iEvent.time().value();
 
   // check DB payload
-  edm::ESHandle<EcalADCToGeVConstant> pAgc;
-  iSetup.get<EcalADCToGeVConstantRcd>().get(pAgc);
-  const EcalADCToGeVConstant* agc = pAgc.product();
+  const auto& agc = iSetup.getData(ecalADCToGeVConstantToken_);
   if (naiveEvtNum_ <= 1) {
-    LogWarning("EcalCosmicsHists") << "Global EB ADC->GeV scale: " << agc->getEBValue() << " GeV/ADC count";
-    LogWarning("EcalCosmicsHists") << "Global EE ADC->GeV scale: " << agc->getEEValue() << " GeV/ADC count";
+    LogWarning("EcalCosmicsHists") << "Global EB ADC->GeV scale: " << agc.getEBValue() << " GeV/ADC count";
+    LogWarning("EcalCosmicsHists") << "Global EE ADC->GeV scale: " << agc.getEEValue() << " GeV/ADC count";
   }
-  //float adcEBconst = agc->getEBValue();
-  //float adcEEconst = agc->getEEValue();
-
-  //
 
   //===================TIMESTAMP INFORMTION=================================
   // Code added to get the time in seconds
@@ -136,14 +134,14 @@ void EcalCosmicsHists::analyze(edm::Event const& iEvent, edm::EventSetup const& 
   //std::cout << "Event Time " << eventTime << " High " <<timeStampHigh<< " low"<<timeStampLow <<" value " <<iEvent.time().value() << std::endl;
   //========================================================================
 
-  iEvent.getByLabel(barrelClusterCollection_, bscHandle);
+  iEvent.getByToken(barrelClusterToken_, bscHandle);
   if (!(bscHandle.isValid())) {
     LogWarning("EcalCosmicsHists") << barrelClusterCollection_ << " not available";
     return;
   }
   LogDebug("EcalCosmicsHists") << "event " << ievt;
 
-  iEvent.getByLabel(endcapClusterCollection_, escHandle);
+  iEvent.getByToken(endcapClusterToken_, escHandle);
   if (!(escHandle.isValid())) {
     LogWarning("EcalCosmicsHists") << endcapClusterCollection_ << " not available";
     hasEndcapClusters = false;
@@ -151,20 +149,20 @@ void EcalCosmicsHists::analyze(edm::Event const& iEvent, edm::EventSetup const& 
   }
 
   Handle<EcalRecHitCollection> hits;
-  iEvent.getByLabel(ecalRecHitCollectionEB_, hits);
+  iEvent.getByToken(ebRecHitToken_, hits);
   if (!(hits.isValid())) {
     LogWarning("EcalCosmicsHists") << ecalRecHitCollectionEB_ << " not available";
     return;
   }
   Handle<EcalRecHitCollection> hitsEE;
-  iEvent.getByLabel(ecalRecHitCollectionEE_, hitsEE);
+  iEvent.getByToken(eeRecHitToken_, hitsEE);
   if (!(hitsEE.isValid())) {
     LogWarning("EcalCosmicsHists") << ecalRecHitCollectionEE_ << " not available";
     return;
   }
 
   Handle<EcalRawDataCollection> DCCHeaders;
-  iEvent.getByLabel(ecalRawDataColl_, DCCHeaders);
+  iEvent.getByToken(ecalRawDataToken_, DCCHeaders);
   if (!DCCHeaders.isValid())
     LogWarning("EcalCosmicsHists") << "DCC headers not available";
 
@@ -1007,7 +1005,7 @@ void EcalCosmicsHists::analyze(edm::Event const& iEvent, edm::EventSetup const& 
 
   // get reco tracks
   edm::Handle<reco::TrackCollection> recoTracks;
-  iEvent.getByLabel("cosmicMuons", recoTracks);
+  iEvent.getByToken(tracksToken_, recoTracks);
 
   if (recoTracks.isValid()) {
     //    LogWarning("EcalCosmicsHists") << "... Valid TrackAssociator recoTracks !!! " << recoTracks.product()->size();
@@ -1176,7 +1174,7 @@ void EcalCosmicsHists::analyze(edm::Event const& iEvent, edm::EventSetup const& 
 
   // Study on Tracks for High Energy events
   edm::Handle<reco::TrackCollection> recoTracksBarrel;
-  iEvent.getByLabel("cosmicMuonsBarrelOnly", recoTracksBarrel);
+  iEvent.getByToken(tracksBarrelToken_, recoTracksBarrel);
   if (!recoTracksBarrel.isValid()) {
     //edm::LogWarning("EcalCosmicsHists") << "RecoTracksBarrel not valid!! " ;
   } else {
@@ -1259,13 +1257,13 @@ void EcalCosmicsHists::analyze(edm::Event const& iEvent, edm::EventSetup const& 
 
   //hcal rechits
   edm::Handle<HBHERecHitCollection> hbhe;
-  iEvent.getByLabel("hbhereco", hbhe);
+  iEvent.getByToken(hbheRecHitToken_, hbhe);
 
   edm::Handle<HFRecHitCollection> hfrh;
-  iEvent.getByLabel("hfreco", hfrh);
+  iEvent.getByToken(hfRecHitToken_, hfrh);
 
   edm::Handle<HORecHitCollection> horh;
-  iEvent.getByLabel("horeco", horh);
+  iEvent.getByToken(hoRecHitToken_, horh);
 
   if (hbhe.isValid()) {
     //    LogInfo("EcalCosmicHists") << "event " << ievt << " HBHE RecHits collection size " << hbhe->size();
@@ -1313,7 +1311,7 @@ std::vector<bool> EcalCosmicsHists::determineTriggers(const edm::Event& iEvent, 
 
   // get the GMTReadoutCollection
   Handle<L1MuGMTReadoutCollection> gmtrc_handle;
-  iEvent.getByLabel(l1GMTReadoutRecTag_, gmtrc_handle);
+  iEvent.getByToken(l1MuGMTToken_, gmtrc_handle);
   L1MuGMTReadoutCollection const* gmtrc = gmtrc_handle.product();
   if (!(gmtrc_handle.isValid())) {
     LogWarning("EcalCosmicsHists") << "l1MuGMTReadoutCollection"
@@ -1322,31 +1320,29 @@ std::vector<bool> EcalCosmicsHists::determineTriggers(const edm::Event& iEvent, 
   }
   // get hold of L1GlobalReadoutRecord
   Handle<L1GlobalTriggerReadoutRecord> L1GTRR;
-  iEvent.getByLabel(l1GTReadoutRecTag_, L1GTRR);
+  iEvent.getByToken(l1GTReadoutToken_, L1GTRR);
 
   //Ecal
-  edm::ESHandle<L1GtTriggerMenu> menuRcd;
-  eventSetup.get<L1GtTriggerMenuRcd>().get(menuRcd);
-  const L1GtTriggerMenu* menu = menuRcd.product();
+  const auto& menu = eventSetup.getData(l1MenuToken_);
   edm::Handle<L1GlobalTriggerReadoutRecord> gtRecord;
-  iEvent.getByLabel(edm::InputTag("gtDigis"), gtRecord);
+  iEvent.getByToken(gtRecordToken_, gtRecord);
   // Get dWord after masking disabled bits
   const DecisionWord dWord = gtRecord->decisionWord();
 
-  bool l1SingleEG1 = menu->gtAlgorithmResult("L1_SingleEG1", dWord);
-  bool l1SingleEG5 = menu->gtAlgorithmResult("L1_SingleEG5", dWord);
-  bool l1SingleEG8 = menu->gtAlgorithmResult("L1_SingleEG8", dWord);
-  bool l1SingleEG10 = menu->gtAlgorithmResult("L1_SingleEG10", dWord);
-  bool l1SingleEG12 = menu->gtAlgorithmResult("L1_SingleEG12", dWord);
-  bool l1SingleEG15 = menu->gtAlgorithmResult("L1_SingleEG15", dWord);
-  bool l1SingleEG20 = menu->gtAlgorithmResult("L1_SingleEG20", dWord);
-  bool l1SingleEG25 = menu->gtAlgorithmResult("L1_SingleEG25", dWord);
-  bool l1DoubleNoIsoEGBTBtight = menu->gtAlgorithmResult("L1_DoubleNoIsoEG_BTB_tight", dWord);
-  bool l1DoubleNoIsoEGBTBloose = menu->gtAlgorithmResult("L1_DoubleNoIsoEG_BTB_loose ", dWord);
-  bool l1DoubleNoIsoEGTopBottom = menu->gtAlgorithmResult("L1_DoubleNoIsoEGTopBottom", dWord);
-  bool l1DoubleNoIsoEGTopBottomCen = menu->gtAlgorithmResult("L1_DoubleNoIsoEGTopBottomCen", dWord);
-  bool l1DoubleNoIsoEGTopBottomCen2 = menu->gtAlgorithmResult("L1_DoubleNoIsoEGTopBottomCen2", dWord);
-  bool l1DoubleNoIsoEGTopBottomCenVert = menu->gtAlgorithmResult("L1_DoubleNoIsoEGTopBottomCenVert", dWord);
+  bool l1SingleEG1 = menu.gtAlgorithmResult("L1_SingleEG1", dWord);
+  bool l1SingleEG5 = menu.gtAlgorithmResult("L1_SingleEG5", dWord);
+  bool l1SingleEG8 = menu.gtAlgorithmResult("L1_SingleEG8", dWord);
+  bool l1SingleEG10 = menu.gtAlgorithmResult("L1_SingleEG10", dWord);
+  bool l1SingleEG12 = menu.gtAlgorithmResult("L1_SingleEG12", dWord);
+  bool l1SingleEG15 = menu.gtAlgorithmResult("L1_SingleEG15", dWord);
+  bool l1SingleEG20 = menu.gtAlgorithmResult("L1_SingleEG20", dWord);
+  bool l1SingleEG25 = menu.gtAlgorithmResult("L1_SingleEG25", dWord);
+  bool l1DoubleNoIsoEGBTBtight = menu.gtAlgorithmResult("L1_DoubleNoIsoEG_BTB_tight", dWord);
+  bool l1DoubleNoIsoEGBTBloose = menu.gtAlgorithmResult("L1_DoubleNoIsoEG_BTB_loose ", dWord);
+  bool l1DoubleNoIsoEGTopBottom = menu.gtAlgorithmResult("L1_DoubleNoIsoEGTopBottom", dWord);
+  bool l1DoubleNoIsoEGTopBottomCen = menu.gtAlgorithmResult("L1_DoubleNoIsoEGTopBottomCen", dWord);
+  bool l1DoubleNoIsoEGTopBottomCen2 = menu.gtAlgorithmResult("L1_DoubleNoIsoEGTopBottomCen2", dWord);
+  bool l1DoubleNoIsoEGTopBottomCenVert = menu.gtAlgorithmResult("L1_DoubleNoIsoEGTopBottomCenVert", dWord);
 
   l1Triggers[4] = l1SingleEG1 || l1SingleEG5 || l1SingleEG8 || l1SingleEG10 || l1SingleEG12 || l1SingleEG15 ||
                   l1SingleEG20 || l1SingleEG25 || l1DoubleNoIsoEGBTBtight || l1DoubleNoIsoEGBTBloose ||
@@ -1568,9 +1564,7 @@ void EcalCosmicsHists::initHists(int FED) {
 
 // ------------ method called once each job just before starting event loop  ------------
 void EcalCosmicsHists::beginRun(edm::Run const&, edm::EventSetup const& eventSetup) {
-  edm::ESHandle<EcalElectronicsMapping> handle;
-  eventSetup.get<EcalMappingRcd>().get(handle);
-  ecalElectronicsMap_ = handle.product();
+  ecalElectronicsMap_ = &eventSetup.getData(ecalMappingToken_);
 
   //Here I will init some of the specific histograms
   int numBins = 200;  //(int)round(histRangeMax_-histRangeMin_)+1;
@@ -2754,6 +2748,8 @@ void EcalCosmicsHists::beginRun(edm::Run const&, edm::EventSetup const& eventSet
   EEP_FedsNumXtalsInClusterHist_ =
       new TH1F("NumActiveXtalsInClusterAllHist", "Number of active Xtals in Cluster EEP;NumXtals", 100, 0, 100);
 }
+
+void EcalCosmicsHists::endRun(edm::Run const&, edm::EventSetup const& eventSetup) {}
 
 // ------------ method called once each job just after ending the event loop  ------------
 void EcalCosmicsHists::endJob() {

--- a/CaloOnlineTools/EcalTools/plugins/EcalCosmicsHists.cc
+++ b/CaloOnlineTools/EcalTools/plugins/EcalCosmicsHists.cc
@@ -660,7 +660,7 @@ void EcalCosmicsHists::analyze(edm::Event const& iEvent, edm::EventSetup const& 
       //				     << " ) " << std::endl;
 
       if (!EEDetId::validDetId(ix, iy, iz)) {
-        LogWarning("EcalCosmicsHists") << "INVALID EE DetId !!!" << endl;
+        LogWarning("EcalCosmicsHists") << "INVALID EE DetId !!!";
         return;
       }
 
@@ -1008,7 +1008,6 @@ void EcalCosmicsHists::analyze(edm::Event const& iEvent, edm::EventSetup const& 
   iEvent.getByToken(tracksToken_, recoTracks);
 
   if (recoTracks.isValid()) {
-    //    LogWarning("EcalCosmicsHists") << "... Valid TrackAssociator recoTracks !!! " << recoTracks.product()->size();
     std::map<int, std::vector<DetId> > trackDetIdMap;
     int tracks = 0;
     for (reco::TrackCollection::const_iterator recoTrack = recoTracks->begin(); recoTrack != recoTracks->end();
@@ -1169,16 +1168,15 @@ void EcalCosmicsHists::analyze(edm::Event const& iEvent, edm::EventSetup const& 
       numberofCosmicsWTrackHist_->Fill(numSeeds);
     }
   } else {
-    //    LogWarning("EcalCosmicsHists") << "!!! No TrackAssociator recoTracks !!!";
+    LogWarning("EcalCosmicsHists") << "!!! No TrackAssociator recoTracks !!!";
   }
 
   // Study on Tracks for High Energy events
   edm::Handle<reco::TrackCollection> recoTracksBarrel;
   iEvent.getByToken(tracksBarrelToken_, recoTracksBarrel);
   if (!recoTracksBarrel.isValid()) {
-    //edm::LogWarning("EcalCosmicsHists") << "RecoTracksBarrel not valid!! " ;
+    edm::LogWarning("EcalCosmicsHists") << "RecoTracksBarrel not valid!! ";
   } else {
-    //edm::LogWarning("EcalCosmicsHists") << "Number of barrel reco tracks found in the event: " << recoTracksBarrel->size() ;
     HighEnergy_numRecoTrackBarrel->Fill(recoTracksBarrel->size());
     for (reco::TrackCollection::const_iterator recoTrack = recoTracksBarrel->begin();
          recoTrack != recoTracksBarrel->end();
@@ -1266,7 +1264,6 @@ void EcalCosmicsHists::analyze(edm::Event const& iEvent, edm::EventSetup const& 
   iEvent.getByToken(hoRecHitToken_, horh);
 
   if (hbhe.isValid()) {
-    //    LogInfo("EcalCosmicHists") << "event " << ievt << " HBHE RecHits collection size " << hbhe->size();
     const HBHERecHitCollection hbheHit = *(hbhe.product());
     for (HBHERecHitCollection::const_iterator hhit = hbheHit.begin(); hhit != hbheHit.end(); hhit++) {
       //      if (hhit->energy() > 0.6){
@@ -1274,21 +1271,19 @@ void EcalCosmicsHists::analyze(edm::Event const& iEvent, edm::EventSetup const& 
       //      }
     }
   } else {
-    //    LogWarning("EcalCosmicHists") << " HBHE RecHits **NOT** VALID!! " << endl;
+    LogWarning("EcalCosmicHists") << " HBHE RecHits **NOT** VALID!! ";
   }
 
   if (hfrh.isValid()) {
-    //    LogInfo("EcalCosmicHists") << "event " << ievt << " HF RecHits collection size " << hfrh->size();
     const HFRecHitCollection hfHit = *(hfrh.product());
     for (HFRecHitCollection::const_iterator hhit = hfHit.begin(); hhit != hfHit.end(); hhit++) {
       hcalEnergy_HF_->Fill(hhit->energy());
     }
   } else {
-    //    LogWarning("EcalCosmicHists") << " HF RecHits **NOT** VALID!! " << endl;
+    LogWarning("EcalCosmicHists") << " HF RecHits **NOT** VALID!! ";
   }
 
   if (horh.isValid()) {
-    //    LogInfo("EcalCosmicHists") << "event " << ievt << " HO RecHits collection size " << horh->size();
     const HORecHitCollection hoHit = *(horh.product());
     for (HORecHitCollection::const_iterator hhit = hoHit.begin(); hhit != hoHit.end(); hhit++) {
       //     if (hhit->energy() > 0.6){
@@ -1296,7 +1291,7 @@ void EcalCosmicsHists::analyze(edm::Event const& iEvent, edm::EventSetup const& 
       //     }
     }
   } else {
-    //    LogWarning("EcalCosmicHists") << " HO RecHits **NOT** VALID!! " << endl;
+    LogWarning("EcalCosmicHists") << " HO RecHits **NOT** VALID!! ";
   }
 
   // *** end of HCAL code *** //

--- a/CaloOnlineTools/EcalTools/plugins/EcalCosmicsHists.h
+++ b/CaloOnlineTools/EcalTools/plugins/EcalCosmicsHists.h
@@ -20,19 +20,24 @@
 #include <memory>
 #include <vector>
 #include <map>
-#include <set>
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "CondFormats/DataRecord/interface/EcalADCToGeVConstantRcd.h"
+#include "CondFormats/EcalObjects/interface/EcalADCToGeVConstant.h"
+#include "CondFormats/L1TObjects/interface/L1GtTriggerMenu.h"
+#include "CondFormats/DataRecord/interface/L1GtTriggerMenuRcd.h"
 
 #include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
 #include "DataFormats/EcalRecHit/interface/EcalUncalibratedRecHit.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
+#include "DataFormats/EgammaReco/interface/SuperCluster.h"
+#include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/EcalRawData/interface/EcalRawDataCollections.h"
 #include "DataFormats/L1GlobalMuonTrigger/interface/L1MuRegionalCand.h"
@@ -41,6 +46,7 @@
 #include "DataFormats/L1GlobalTrigger/interface/L1GtPsbWord.h"
 
 #include "Geometry/EcalMapping/interface/EcalElectronicsMapping.h"
+#include "Geometry/EcalMapping/interface/EcalMappingRcd.h"
 
 #include "CaloOnlineTools/EcalTools/interface/EcalFedMap.h"
 
@@ -65,13 +71,14 @@
 // class declaration
 //
 
-class EcalCosmicsHists : public edm::EDAnalyzer {
+class EcalCosmicsHists : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   explicit EcalCosmicsHists(const edm::ParameterSet&);
   ~EcalCosmicsHists() override;
 
 private:
   void beginRun(edm::Run const&, edm::EventSetup const&) override;
+  void endRun(edm::Run const&, edm::EventSetup const&) override;
   void analyze(edm::Event const&, edm::EventSetup const&) override;
   void endJob() override;
   std::string intToString(int num);
@@ -88,21 +95,39 @@ private:
   edm::InputTag l1GTReadoutRecTag_;
   edm::InputTag l1GMTReadoutRecTag_;
 
+  const edm::EDGetTokenT<reco::SuperClusterCollection> barrelClusterToken_;
+  const edm::EDGetTokenT<reco::SuperClusterCollection> endcapClusterToken_;
+  const edm::EDGetTokenT<EcalRecHitCollection> ebRecHitToken_;
+  const edm::EDGetTokenT<EcalRecHitCollection> eeRecHitToken_;
+  const edm::EDGetTokenT<EcalRawDataCollection> ecalRawDataToken_;
+  const edm::EDGetTokenT<reco::TrackCollection> tracksToken_;
+  const edm::EDGetTokenT<reco::TrackCollection> tracksBarrelToken_;
+  const edm::EDGetTokenT<HBHERecHitCollection> hbheRecHitToken_;
+  const edm::EDGetTokenT<HFRecHitCollection> hfRecHitToken_;
+  const edm::EDGetTokenT<HORecHitCollection> hoRecHitToken_;
+  const edm::EDGetTokenT<L1MuGMTReadoutCollection> l1MuGMTToken_;
+  const edm::EDGetTokenT<L1GlobalTriggerReadoutRecord> l1GTReadoutToken_;
+  const edm::EDGetTokenT<L1GlobalTriggerReadoutRecord> gtRecordToken_;
+
+  const edm::ESGetToken<EcalADCToGeVConstant, EcalADCToGeVConstantRcd> ecalADCToGeVConstantToken_;
+  const edm::ESGetToken<L1GtTriggerMenu, L1GtTriggerMenuRcd> l1MenuToken_;
+  const edm::ESGetToken<EcalElectronicsMapping, EcalMappingRcd> ecalMappingToken_;
+
   int runNum_;
-  double histRangeMax_, histRangeMin_;
-  double minTimingAmpEB_;
-  double minTimingAmpEE_;
-  double minRecHitAmpEB_;
-  double minRecHitAmpEE_;
-  double minHighEnergy_;
+  const double histRangeMax_, histRangeMin_;
+  const double minTimingAmpEB_;
+  const double minTimingAmpEE_;
+  const double minRecHitAmpEB_;
+  const double minRecHitAmpEE_;
+  const double minHighEnergy_;
 
   double* ttEtaBins;
   double* modEtaBins;
   std::string fileName_;
-  bool runInFileName_;
+  const bool runInFileName_;
 
-  double startTime_, runTimeLength_;
-  int numTimingBins_;
+  const double startTime_, runTimeLength_;
+  const int numTimingBins_;
 
   std::map<int, TH1F*> FEDsAndHists_;
   std::map<int, TH1F*> FEDsAndE2Hists_;

--- a/CaloOnlineTools/EcalTools/plugins/EcalDigiDisplay.h
+++ b/CaloOnlineTools/EcalTools/plugins/EcalDigiDisplay.h
@@ -5,19 +5,19 @@
 #include <vector>
 #include <string>
 
-#include <FWCore/Framework/interface/EDAnalyzer.h>
+#include <FWCore/Framework/interface/one/EDAnalyzer.h>
 #include <FWCore/Framework/interface/Event.h>
 #include <FWCore/Framework/interface/EventSetup.h>
-#include <FWCore/Framework/interface/ESHandle.h>
 #include <FWCore/Framework/interface/MakerMacros.h>
 #include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
+#include "DataFormats/EcalRawData/interface/EcalRawDataCollections.h"
 #include "CaloOnlineTools/EcalTools/interface/EcalFedMap.h"
 #include "Geometry/EcalMapping/interface/EcalMappingRcd.h"
 #include "Geometry/EcalMapping/interface/EcalElectronicsMapping.h"
 
 // class declaration
 
-class EcalDigiDisplay : public edm::EDAnalyzer {
+class EcalDigiDisplay : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   //Constractor
   EcalDigiDisplay(const edm::ParameterSet& ps);
@@ -27,6 +27,7 @@ public:
 private:
   void analyze(edm::Event const& e, edm::EventSetup const& c) override;
   void beginRun(edm::Run const&, edm::EventSetup const& c) override;
+  void endRun(edm::Run const&, edm::EventSetup const& c) override;
   void endJob() override;
 
 protected:
@@ -36,9 +37,15 @@ protected:
 
   EcalFedMap* fedMap;
 
-  std::string ebDigiCollection_;
-  std::string eeDigiCollection_;
-  std::string digiProducer_;
+  const std::string ebDigiCollection_;
+  const std::string eeDigiCollection_;
+  const std::string digiProducer_;
+
+  const edm::EDGetTokenT<EcalRawDataCollection> rawDataToken_;
+  const edm::EDGetTokenT<EBDigiCollection> ebDigiToken_;
+  const edm::EDGetTokenT<EEDigiCollection> eeDigiToken_;
+  const edm::EDGetTokenT<EcalPnDiodeDigiCollection> pnDiodeDigiToken_;
+  const edm::ESGetToken<EcalElectronicsMapping, EcalMappingRcd> ecalMappingToken_;
 
   std::vector<int> requestedFeds_;
   std::vector<std::string> requestedEbs_;

--- a/CaloOnlineTools/EcalTools/plugins/EcalDisplaysByEvent.h
+++ b/CaloOnlineTools/EcalTools/plugins/EcalDisplaysByEvent.h
@@ -21,15 +21,15 @@
 #include <vector>
 #include <map>
 #include <set>
+#include <string>
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 #include "Geometry/EcalMapping/interface/EcalMappingRcd.h"
@@ -59,13 +59,14 @@
 // class declaration
 //
 
-class EcalDisplaysByEvent : public edm::EDAnalyzer {
+class EcalDisplaysByEvent : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   explicit EcalDisplaysByEvent(const edm::ParameterSet&);
   ~EcalDisplaysByEvent() override;
 
 private:
   void beginRun(edm::Run const&, edm::EventSetup const&) override;
+  void endRun(edm::Run const&, edm::EventSetup const&) override;
   void analyze(edm::Event const&, edm::EventSetup const&) override;
   void endJob() override;
   std::string intToString(int num);
@@ -78,7 +79,7 @@ private:
   TH2F* init2DEcalHist(std::string histTypeName, int subDet);
   TH3F* init3DEcalHist(std::string histTypeName, int dubDet);
   TCanvas* init2DEcalCanvas(std::string canvasName);
-  void selectHits(edm::Handle<EcalRecHitCollection> hits, int ievt, edm::ESHandle<CaloTopology> caloTopo);
+  void selectHits(edm::Handle<EcalRecHitCollection> hits, int ievt);
   TGraph* selectDigi(DetId det, int ievt);
   int getEEIndex(EcalElectronicsId elecId);
   void makeHistos(edm::Handle<EBDigiCollection> ebDigis);
@@ -93,27 +94,36 @@ private:
 
   // ----------member data ---------------------------
 
-  edm::InputTag EBRecHitCollection_;
-  edm::InputTag EERecHitCollection_;
-  edm::InputTag EBDigis_;
-  edm::InputTag EEDigis_;
-  edm::InputTag headerProducer_;
+  const edm::InputTag EBRecHitCollection_;
+  const edm::InputTag EERecHitCollection_;
+  const edm::InputTag EBDigis_;
+  const edm::InputTag EEDigis_;
+  const edm::InputTag headerProducer_;
 
   edm::Handle<EBDigiCollection> EBdigisHandle;
   edm::Handle<EEDigiCollection> EEdigisHandle;
 
+  const edm::EDGetTokenT<EcalRawDataCollection> rawDataToken_;
+  const edm::EDGetTokenT<EcalRecHitCollection> ebRecHitToken_;
+  const edm::EDGetTokenT<EcalRecHitCollection> eeRecHitToken_;
+  const edm::EDGetTokenT<EBDigiCollection> ebDigiToken_;
+  const edm::EDGetTokenT<EEDigiCollection> eeDigiToken_;
+
+  const edm::ESGetToken<EcalElectronicsMapping, EcalMappingRcd> ecalMappingToken_;
+  const edm::ESGetToken<CaloTopology, CaloTopologyRecord> topologyToken_;
+
   int runNum_;
-  int side_;
-  double threshold_;
-  double minTimingAmp_;
-  bool makeDigiGraphs_;
-  bool makeTimingHistos_;
-  bool makeEnergyHistos_;
-  bool makeOccupancyHistos_;
-  double histRangeMin_;
-  double histRangeMax_;
-  double minTimingEnergyEB_;
-  double minTimingEnergyEE_;
+  const int side_;
+  const double threshold_;
+  const double minTimingAmp_;
+  const bool makeDigiGraphs_;
+  const bool makeTimingHistos_;
+  const bool makeEnergyHistos_;
+  const bool makeOccupancyHistos_;
+  const double histRangeMin_;
+  const double histRangeMax_;
+  const double minTimingEnergyEB_;
+  const double minTimingEnergyEE_;
 
   std::set<EBDetId> listEBChannels;
   std::set<EEDetId> listEEChannels;
@@ -224,6 +234,7 @@ private:
   TTree* histoCanvasNames_;
   EcalFedMap* fedMap_;
   const EcalElectronicsMapping* ecalElectronicsMap_;
+  const CaloTopology* caloTopo_;
 
   int naiveEvtNum_;
 };

--- a/CaloOnlineTools/EcalTools/plugins/EcalMipGraphs.cc
+++ b/CaloOnlineTools/EcalTools/plugins/EcalMipGraphs.cc
@@ -20,8 +20,6 @@
 #include "RecoCaloTools/Navigation/interface/CaloNavigator.h"
 #include "TCanvas.h"
 #include <utility>
-#include <string>
-#include <vector>
 
 using namespace edm;
 using namespace std;
@@ -45,6 +43,13 @@ EcalMipGraphs::EcalMipGraphs(const edm::ParameterSet& iConfig)
       EBDigis_(iConfig.getParameter<edm::InputTag>("EBDigiCollection")),
       EEDigis_(iConfig.getParameter<edm::InputTag>("EEDigiCollection")),
       headerProducer_(iConfig.getParameter<edm::InputTag>("headerProducer")),
+      rawDataToken_(consumes<EcalRawDataCollection>(headerProducer_)),
+      ebRecHitToken_(consumes<EcalRecHitCollection>(EBRecHitCollection_)),
+      eeRecHitToken_(consumes<EcalRecHitCollection>(EERecHitCollection_)),
+      ebDigiToken_(consumes<EBDigiCollection>(EBDigis_)),
+      eeDigiToken_(consumes<EEDigiCollection>(EEDigis_)),
+      ecalMappingToken_(esConsumes<edm::Transition::BeginRun>()),
+      topologyToken_(esConsumes()),
       runNum_(-1),
       side_(iConfig.getUntrackedParameter<int>("side", 3)),
       threshold_(iConfig.getUntrackedParameter<double>("amplitudeThreshold", 12.0)),
@@ -94,7 +99,7 @@ void EcalMipGraphs::analyze(edm::Event const& iEvent, edm::EventSetup const& iSe
   // get the headers
   // (one header for each supermodule)
   edm::Handle<EcalRawDataCollection> DCCHeaders;
-  iEvent.getByLabel(headerProducer_, DCCHeaders);
+  iEvent.getByToken(rawDataToken_, DCCHeaders);
 
   for (EcalRawDataCollection::const_iterator headerItr = DCCHeaders->begin(); headerItr != DCCHeaders->end();
        ++headerItr) {
@@ -114,21 +119,21 @@ void EcalMipGraphs::analyze(edm::Event const& iEvent, edm::EventSetup const& iSe
   //We only want the 3x3's for this event...
   listEBChannels.clear();
   listEEChannels.clear();
+  caloTopo_ = &iSetup.getData(topologyToken_);
+
   Handle<EcalRecHitCollection> EBhits;
   Handle<EcalRecHitCollection> EEhits;
-  ESHandle<CaloTopology> caloTopo;
-  iSetup.get<CaloTopologyRecord>().get(caloTopo);
-  iEvent.getByLabel(EBRecHitCollection_, EBhits);
-  iEvent.getByLabel(EERecHitCollection_, EEhits);
+  iEvent.getByToken(ebRecHitToken_, EBhits);
+  iEvent.getByToken(eeRecHitToken_, EEhits);
   // Now, retrieve the crystal digi from the event
-  iEvent.getByLabel(EBDigis_, EBdigisHandle);
-  iEvent.getByLabel(EEDigis_, EEdigisHandle);
+  iEvent.getByToken(ebDigiToken_, EBdigisHandle);
+  iEvent.getByToken(eeDigiToken_, EEdigisHandle);
   //debug
   //LogWarning("EcalMipGraphs") << "event " << ievt << " EBhits collection size " << EBhits->size();
   //LogWarning("EcalMipGraphs") << "event " << ievt << " EEhits collection size " << EEhits->size();
 
-  selectHits(EBhits, ievt, caloTopo);
-  selectHits(EEhits, ievt, caloTopo);
+  selectHits(EBhits, ievt);
+  selectHits(EEhits, ievt);
 }
 
 TGraph* EcalMipGraphs::selectDigi(DetId thisDet, int ievt) {
@@ -232,7 +237,7 @@ TGraph* EcalMipGraphs::selectDigi(DetId thisDet, int ievt) {
   return oneGraph;
 }
 
-void EcalMipGraphs::selectHits(Handle<EcalRecHitCollection> hits, int ievt, ESHandle<CaloTopology> caloTopo) {
+void EcalMipGraphs::selectHits(Handle<EcalRecHitCollection> hits, int ievt) {
   for (EcalRecHitCollection::const_iterator hitItr = hits->begin(); hitItr != hits->end(); ++hitItr) {
     EcalRecHit hit = (*hitItr);
     DetId det = hit.id();
@@ -281,7 +286,7 @@ void EcalMipGraphs::selectHits(Handle<EcalRecHitCollection> hits, int ievt, ESHa
       TGraph* myGraph;
       int canvasNum = 1;
 
-      CaloNavigator<DetId> cursor = CaloNavigator<DetId>(det, caloTopo->getSubdetectorTopology(det));
+      CaloNavigator<DetId> cursor = CaloNavigator<DetId>(det, caloTopo_->getSubdetectorTopology(det));
       //Now put each graph in one by one
       for (int j = side_ / 2; j >= -side_ / 2; --j) {
         for (int i = -side_ / 2; i <= side_ / 2; ++i) {
@@ -328,10 +333,10 @@ void EcalMipGraphs::initHists(int FED) {
 
 // ------------ method called once each job just before starting event loop  ------------
 void EcalMipGraphs::beginRun(edm::Run const&, edm::EventSetup const& c) {
-  edm::ESHandle<EcalElectronicsMapping> handle;
-  c.get<EcalMappingRcd>().get(handle);
-  ecalElectronicsMap_ = handle.product();
+  ecalElectronicsMap_ = &c.getData(ecalMappingToken_);
 }
+
+void EcalMipGraphs::endRun(edm::Run const&, edm::EventSetup const& c) {}
 
 // ------------ method called once each job just after ending the event loop  ------------
 void EcalMipGraphs::endJob() {

--- a/CaloOnlineTools/EcalTools/plugins/EcalMipGraphs.cc
+++ b/CaloOnlineTools/EcalTools/plugins/EcalMipGraphs.cc
@@ -128,9 +128,6 @@ void EcalMipGraphs::analyze(edm::Event const& iEvent, edm::EventSetup const& iSe
   // Now, retrieve the crystal digi from the event
   iEvent.getByToken(ebDigiToken_, EBdigisHandle);
   iEvent.getByToken(eeDigiToken_, EEdigisHandle);
-  //debug
-  //LogWarning("EcalMipGraphs") << "event " << ievt << " EBhits collection size " << EBhits->size();
-  //LogWarning("EcalMipGraphs") << "event " << ievt << " EEhits collection size " << EEhits->size();
 
   selectHits(EBhits, ievt);
   selectHits(EEhits, ievt);

--- a/CaloOnlineTools/EcalTools/plugins/EcalMipGraphs.h
+++ b/CaloOnlineTools/EcalTools/plugins/EcalMipGraphs.h
@@ -21,15 +21,15 @@
 #include <vector>
 #include <map>
 #include <set>
+#include <string>
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 #include "Geometry/EcalMapping/interface/EcalMappingRcd.h"
@@ -56,38 +56,48 @@
 // class declaration
 //
 
-class EcalMipGraphs : public edm::EDAnalyzer {
+class EcalMipGraphs : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   explicit EcalMipGraphs(const edm::ParameterSet&);
   ~EcalMipGraphs() override;
 
 private:
   void beginRun(edm::Run const&, edm::EventSetup const&) override;
+  void endRun(edm::Run const&, edm::EventSetup const&) override;
   void analyze(edm::Event const&, edm::EventSetup const&) override;
   void endJob() override;
   std::string intToString(int num);
   std::string floatToString(float num);
   void writeGraphs();
   void initHists(int);
-  void selectHits(edm::Handle<EcalRecHitCollection> hits, int ievt, edm::ESHandle<CaloTopology> caloTopo);
+  void selectHits(edm::Handle<EcalRecHitCollection> hits, int ievt);
   TGraph* selectDigi(DetId det, int ievt);
   int getEEIndex(EcalElectronicsId elecId);
 
   // ----------member data ---------------------------
 
-  edm::InputTag EBRecHitCollection_;
-  edm::InputTag EERecHitCollection_;
-  edm::InputTag EBDigis_;
-  edm::InputTag EEDigis_;
-  edm::InputTag headerProducer_;
+  const edm::InputTag EBRecHitCollection_;
+  const edm::InputTag EERecHitCollection_;
+  const edm::InputTag EBDigis_;
+  const edm::InputTag EEDigis_;
+  const edm::InputTag headerProducer_;
 
   edm::Handle<EBDigiCollection> EBdigisHandle;
   edm::Handle<EEDigiCollection> EEdigisHandle;
 
+  const edm::EDGetTokenT<EcalRawDataCollection> rawDataToken_;
+  const edm::EDGetTokenT<EcalRecHitCollection> ebRecHitToken_;
+  const edm::EDGetTokenT<EcalRecHitCollection> eeRecHitToken_;
+  const edm::EDGetTokenT<EBDigiCollection> ebDigiToken_;
+  const edm::EDGetTokenT<EEDigiCollection> eeDigiToken_;
+
+  const edm::ESGetToken<EcalElectronicsMapping, EcalMappingRcd> ecalMappingToken_;
+  const edm::ESGetToken<CaloTopology, CaloTopologyRecord> topologyToken_;
+
   int runNum_;
-  int side_;
-  double threshold_;
-  double minTimingAmp_;
+  const int side_;
+  const double threshold_;
+  const double minTimingAmp_;
 
   std::set<EBDetId> listEBChannels;
   std::set<EEDetId> listEEChannels;
@@ -114,6 +124,7 @@ private:
   TTree* canvasNames_;
   EcalFedMap* fedMap_;
   const EcalElectronicsMapping* ecalElectronicsMap_;
+  const CaloTopology* caloTopo_;
 
   int naiveEvtNum_;
 };

--- a/CaloOnlineTools/EcalTools/plugins/EcalPedHists.h
+++ b/CaloOnlineTools/EcalTools/plugins/EcalPedHists.h
@@ -1,3 +1,5 @@
+#ifndef CaloOnlineTools_EcalTools_EcalPedHists_h
+#define CaloOnlineTools_EcalTools_EcalPedHists_h
 /**
  * Module which outputs a root file of ADC counts (all three gains)
  *   of user-selected channels (defaults to channel 1) for 
@@ -8,11 +10,10 @@
  *
  */
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
 #include "DataFormats/EcalDetId/interface/EcalDetIdCollections.h"
 #include "DataFormats/EcalDigi/interface/EcalTriggerPrimitiveDigi.h"
@@ -31,7 +32,7 @@
 
 typedef std::map<std::string, TH1F*> stringHistMap;
 
-class EcalPedHists : public edm::EDAnalyzer {
+class EcalPedHists : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   EcalPedHists(const edm::ParameterSet& ps);
   ~EcalPedHists() override;
@@ -39,6 +40,7 @@ public:
 protected:
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
   void beginRun(edm::Run const&, edm::EventSetup const& c) override;
+  void endRun(edm::Run const&, edm::EventSetup const& c) override;
   void endJob(void) override;
 
 private:
@@ -52,9 +54,9 @@ private:
   bool allFEDsSelected_;
   bool histsFilled_;
   std::string fileName_;
-  edm::InputTag barrelDigiCollection_;
-  edm::InputTag endcapDigiCollection_;
-  edm::InputTag headerProducer_;
+  const edm::InputTag barrelDigiCollection_;
+  const edm::InputTag endcapDigiCollection_;
+  const edm::InputTag headerProducer_;
   std::vector<int> listChannels_;
   std::vector<int> listSamples_;
   std::vector<int> listFEDs_;
@@ -63,5 +65,13 @@ private:
   std::set<int> theRealFedSet_;
   EcalFedMap* fedMap_;
   TFile* root_file_;
+
+  const edm::EDGetTokenT<EcalRawDataCollection> rawDataToken_;
+  const edm::EDGetTokenT<EBDigiCollection> ebDigiToken_;
+  const edm::EDGetTokenT<EEDigiCollection> eeDigiToken_;
+  const edm::ESGetToken<EcalElectronicsMapping, EcalMappingRcd> ecalMappingToken_;
+
   const EcalElectronicsMapping* ecalElectronicsMap_;
 };
+
+#endif

--- a/CaloOnlineTools/EcalTools/plugins/EcalTPGAnalyzer.cc
+++ b/CaloOnlineTools/EcalTools/plugins/EcalTPGAnalyzer.cc
@@ -42,7 +42,6 @@ EcalTPGAnalyzer::EcalTPGAnalyzer(const edm::ParameterSet& iConfig)
       allowTP_(iConfig.getParameter<bool>("ReadTriggerPrimitives")),
       useEE_(iConfig.getParameter<bool>("UseEndCap")),
       print_(iConfig.getParameter<bool>("Print")) {
-
   // file
   file_ = new TFile("ECALTPGtree.root", "RECREATE");
   file_->cd();

--- a/CaloOnlineTools/EcalTools/plugins/EcalTPGAnalyzer.cc
+++ b/CaloOnlineTools/EcalTools/plugins/EcalTPGAnalyzer.cc
@@ -12,32 +12,9 @@
 #include <utility>
 
 // user include files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
-#include "DataFormats/EcalDigi/interface/EcalTriggerPrimitiveDigi.h"
-
-#include "Geometry/CaloTopology/interface/EcalTrigTowerConstituentsMap.h"
-#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
-#include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
-#include "Geometry/Records/interface/CaloGeometryRecord.h"
-
-#include "CondFormats/L1TObjects/interface/L1GtTriggerMenu.h"
-#include "CondFormats/DataRecord/interface/L1GtTriggerMenuRcd.h"
-#include "CondFormats/L1TObjects/interface/L1GtTriggerMask.h"
-#include "CondFormats/DataRecord/interface/L1GtTriggerMaskAlgoTrigRcd.h"
-#include "CondFormats/DataRecord/interface/L1GtTriggerMaskTechTrigRcd.h"
-#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutSetupFwd.h"
-#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutSetup.h"
-#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h"
-#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerRecord.h"
 
 #include "EcalTPGAnalyzer.h"
 
@@ -47,16 +24,24 @@
 using namespace edm;
 class CaloSubdetectorGeometry;
 
-EcalTPGAnalyzer::EcalTPGAnalyzer(const edm::ParameterSet& iConfig) {
-  tpCollection_ = iConfig.getParameter<edm::InputTag>("TPCollection");
-  tpEmulatorCollection_ = iConfig.getParameter<edm::InputTag>("TPEmulatorCollection");
-  digiCollectionEB_ = iConfig.getParameter<edm::InputTag>("DigiCollectionEB");
-  digiCollectionEE_ = iConfig.getParameter<edm::InputTag>("DigiCollectionEE");
-  gtRecordCollectionTag_ = iConfig.getParameter<std::string>("GTRecordCollection");
-
-  allowTP_ = iConfig.getParameter<bool>("ReadTriggerPrimitives");
-  useEE_ = iConfig.getParameter<bool>("UseEndCap");
-  print_ = iConfig.getParameter<bool>("Print");
+EcalTPGAnalyzer::EcalTPGAnalyzer(const edm::ParameterSet& iConfig)
+    : tpCollection_(iConfig.getParameter<edm::InputTag>("TPCollection")),
+      tpEmulatorCollection_(iConfig.getParameter<edm::InputTag>("TPEmulatorCollection")),
+      digiCollectionEB_(iConfig.getParameter<edm::InputTag>("DigiCollectionEB")),
+      digiCollectionEE_(iConfig.getParameter<edm::InputTag>("DigiCollectionEE")),
+      gtRecordCollectionTag_(iConfig.getParameter<std::string>("GTRecordCollection")),
+      l1GtReadoutRecordToken_(consumes<L1GlobalTriggerReadoutRecord>(edm::InputTag(gtRecordCollectionTag_))),
+      tpToken_(consumes<EcalTrigPrimDigiCollection>(tpCollection_)),
+      tpEmulToken_(consumes<EcalTrigPrimDigiCollection>(tpEmulatorCollection_)),
+      ebDigiToken_(consumes<EBDigiCollection>(digiCollectionEB_)),
+      eeDigiToken_(consumes<EEDigiCollection>(digiCollectionEE_)),
+      eTTMapToken_(esConsumes<edm::Transition::BeginRun>()),
+      ebGeometryToken_(esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", "EcalBarrel"))),
+      eeGeometryToken_(esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", "EcalEndcap"))),
+      l1GtMaskToken_(esConsumes()),
+      allowTP_(iConfig.getParameter<bool>("ReadTriggerPrimitives")),
+      useEE_(iConfig.getParameter<bool>("UseEndCap")),
+      print_(iConfig.getParameter<bool>("Print")) {
 
   // file
   file_ = new TFile("ECALTPGtree.root", "RECREATE");
@@ -93,17 +78,12 @@ EcalTPGAnalyzer::~EcalTPGAnalyzer() {
 
 void EcalTPGAnalyzer::beginRun(edm::Run const&, edm::EventSetup const& evtSetup) {
   // geometry
-  ESHandle<CaloGeometry> theGeometry;
-  ESHandle<CaloSubdetectorGeometry> theEndcapGeometry_handle, theBarrelGeometry_handle;
-
-  evtSetup.get<CaloGeometryRecord>().get(theGeometry);
-  evtSetup.get<EcalEndcapGeometryRecord>().get("EcalEndcap", theEndcapGeometry_handle);
-  evtSetup.get<EcalBarrelGeometryRecord>().get("EcalBarrel", theBarrelGeometry_handle);
-
-  evtSetup.get<IdealGeometryRecord>().get(eTTmap_);
-  theEndcapGeometry_ = &(*theEndcapGeometry_handle);
-  theBarrelGeometry_ = &(*theBarrelGeometry_handle);
+  eTTmap_ = &evtSetup.getData(eTTMapToken_);
+  theBarrelGeometry_ = &evtSetup.getData(ebGeometryToken_);
+  theEndcapGeometry_ = &evtSetup.getData(eeGeometryToken_);
 }
+
+void EcalTPGAnalyzer::endRun(edm::Run const&, edm::EventSetup const& evtSetup) {}
 
 void EcalTPGAnalyzer::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) {
   using namespace edm;
@@ -129,12 +109,11 @@ void EcalTPGAnalyzer::analyze(edm::Event const& iEvent, edm::EventSetup const& i
   ///////////////////////////
 
   edm::Handle<L1GlobalTriggerReadoutRecord> gtRecord;
-  iEvent.getByLabel(edm::InputTag(gtRecordCollectionTag_), gtRecord);
+  iEvent.getByToken(l1GtReadoutRecordToken_, gtRecord);
   DecisionWord dWord = gtRecord->decisionWord();  // this will get the decision word *before* masking disabled bits
 
-  edm::ESHandle<L1GtTriggerMask> l1GtTmAlgo;
-  iSetup.get<L1GtTriggerMaskAlgoTrigRcd>().get(l1GtTmAlgo);
-  std::vector<unsigned int> triggerMaskAlgoTrig = l1GtTmAlgo.product()->gtTriggerMask();
+  const auto& l1GtTmAlgo = iSetup.getData(l1GtMaskToken_);
+  std::vector<unsigned int> triggerMaskAlgoTrig = l1GtTmAlgo.gtTriggerMask();
 
   // apply masks on algo
   int iDaq = 0;
@@ -156,7 +135,7 @@ void EcalTPGAnalyzer::analyze(edm::Event const& iEvent, edm::EventSetup const& i
   ///////////////////////////
 
   edm::Handle<EcalTrigPrimDigiCollection> tp;
-  iEvent.getByLabel(tpCollection_, tp);
+  iEvent.getByToken(tpToken_, tp);
   if (print_)
     std::cout << "TP collection size=" << tp.product()->size() << std::endl;
 
@@ -175,7 +154,7 @@ void EcalTPGAnalyzer::analyze(edm::Event const& iEvent, edm::EventSetup const& i
   ///////////////////////////
 
   edm::Handle<EcalTrigPrimDigiCollection> tpEmul;
-  iEvent.getByLabel(tpEmulatorCollection_, tpEmul);
+  iEvent.getByToken(tpEmulToken_, tpEmul);
   if (print_)
     std::cout << "TPEmulator collection size=" << tpEmul.product()->size() << std::endl;
 
@@ -194,7 +173,7 @@ void EcalTPGAnalyzer::analyze(edm::Event const& iEvent, edm::EventSetup const& i
 
   // Get EB xtal digi inputs
   edm::Handle<EBDigiCollection> digiEB;
-  iEvent.getByLabel(digiCollectionEB_, digiEB);
+  iEvent.getByToken(ebDigiToken_, digiEB);
 
   for (unsigned int i = 0; i < digiEB.product()->size(); i++) {
     const EBDataFrame& df = (*(digiEB.product()))[i];
@@ -208,11 +187,11 @@ void EcalTPGAnalyzer::analyze(edm::Event const& iEvent, edm::EventSetup const& i
   if (useEE_) {
     // Get EE xtal digi inputs
     edm::Handle<EEDigiCollection> digiEE;
-    iEvent.getByLabel(digiCollectionEE_, digiEE);
+    iEvent.getByToken(eeDigiToken_, digiEE);
     for (unsigned int i = 0; i < digiEE.product()->size(); i++) {
       const EEDataFrame& df = (*(digiEE.product()))[i];
       const EEDetId& id = df.id();
-      const EcalTrigTowerDetId towid = (*eTTmap_).towerOf(id);
+      const EcalTrigTowerDetId towid = eTTmap_->towerOf(id);
       itTT = mapTower.find(towid);
       if (itTT != mapTower.end())
         (itTT->second).nbXtal_++;

--- a/CaloOnlineTools/EcalTools/plugins/EcalTPGAnalyzer.h
+++ b/CaloOnlineTools/EcalTools/plugins/EcalTPGAnalyzer.h
@@ -1,3 +1,5 @@
+#ifndef CaloOnlineTools_EcalTools_EcalTPGAnalyzer_h
+#define CaloOnlineTools_EcalTools_EcalTPGAnalyzer_h
 // -*- C++ -*-
 //
 // Class:      EcalTPGAnalyzer
@@ -5,13 +7,18 @@
 //
 // Original Author:  Pascal Paganini
 //
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "CondFormats/L1TObjects/interface/L1GtTriggerMask.h"
+#include "CondFormats/DataRecord/interface/L1GtTriggerMaskAlgoTrigRcd.h"
+#include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
+#include "DataFormats/EcalDigi/interface/EcalTriggerPrimitiveDigi.h"
+#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h"
 #include "Geometry/CaloTopology/interface/EcalTrigTowerConstituentsMap.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include <vector>
 #include <string>
 #include <TFile.h>
@@ -32,12 +39,13 @@ public:
   }
 };
 
-class EcalTPGAnalyzer : public edm::EDAnalyzer {
+class EcalTPGAnalyzer : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   explicit EcalTPGAnalyzer(const edm::ParameterSet &);
   ~EcalTPGAnalyzer() override;
   void analyze(edm::Event const &, edm::EventSetup const &) override;
   void beginRun(edm::Run const &, edm::EventSetup const &) override;
+  void endRun(edm::Run const &, edm::EventSetup const &) override;
 
 private:
   struct EcalTPGVariables {
@@ -68,17 +76,30 @@ private:
   TTree *tree_;
   EcalTPGVariables treeVariables_;
 
-  edm::InputTag tpCollection_;
-  edm::InputTag tpEmulatorCollection_;
-  edm::InputTag digiCollectionEB_;
-  edm::InputTag digiCollectionEE_;
-  std::string gtRecordCollectionTag_;
+  const edm::InputTag tpCollection_;
+  const edm::InputTag tpEmulatorCollection_;
+  const edm::InputTag digiCollectionEB_;
+  const edm::InputTag digiCollectionEE_;
+  const std::string gtRecordCollectionTag_;
 
-  bool allowTP_;
-  bool useEE_;
-  bool print_;
+  const edm::EDGetTokenT<L1GlobalTriggerReadoutRecord> l1GtReadoutRecordToken_;
+  const edm::EDGetTokenT<EcalTrigPrimDigiCollection> tpToken_;
+  const edm::EDGetTokenT<EcalTrigPrimDigiCollection> tpEmulToken_;
+  const edm::EDGetTokenT<EBDigiCollection> ebDigiToken_;
+  const edm::EDGetTokenT<EEDigiCollection> eeDigiToken_;
 
-  const CaloSubdetectorGeometry *theEndcapGeometry_;
+  const edm::ESGetToken<EcalTrigTowerConstituentsMap, IdealGeometryRecord> eTTMapToken_;
+  const edm::ESGetToken<CaloSubdetectorGeometry, EcalBarrelGeometryRecord> ebGeometryToken_;
+  const edm::ESGetToken<CaloSubdetectorGeometry, EcalEndcapGeometryRecord> eeGeometryToken_;
+  const edm::ESGetToken<L1GtTriggerMask, L1GtTriggerMaskAlgoTrigRcd> l1GtMaskToken_;
+
+  const bool allowTP_;
+  const bool useEE_;
+  const bool print_;
+
   const CaloSubdetectorGeometry *theBarrelGeometry_;
-  edm::ESHandle<EcalTrigTowerConstituentsMap> eTTmap_;
+  const CaloSubdetectorGeometry *theEndcapGeometry_;
+  const EcalTrigTowerConstituentsMap *eTTmap_;
 };
+
+#endif

--- a/CaloOnlineTools/EcalTools/plugins/EcalURecHitHists.h
+++ b/CaloOnlineTools/EcalTools/plugins/EcalURecHitHists.h
@@ -1,3 +1,5 @@
+#ifndef CaloOnlineTools_EcalTools_EcalURecHitHists_h
+#define CaloOnlineTools_EcalTools_EcalURecHitHists_h
 // -*- C++ -*-
 //
 // Package:   EcalURecHitHists
@@ -24,20 +26,19 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
-#include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
 #include "DataFormats/EcalRecHit/interface/EcalUncalibratedRecHit.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/EcalRawData/interface/EcalRawDataCollections.h"
 
 #include "Geometry/EcalMapping/interface/EcalElectronicsMapping.h"
+#include "Geometry/EcalMapping/interface/EcalMappingRcd.h"
 
 #include "CaloOnlineTools/EcalTools/interface/EcalFedMap.h"
 
@@ -45,19 +46,19 @@
 #include "TH1F.h"
 #include "TGraph.h"
 #include "TNtuple.h"
-#include "Geometry/EcalMapping/interface/EcalMappingRcd.h"
 
 //
 // class declaration
 //
 
-class EcalURecHitHists : public edm::EDAnalyzer {
+class EcalURecHitHists : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   explicit EcalURecHitHists(const edm::ParameterSet&);
   ~EcalURecHitHists() override;
 
 private:
   void beginRun(edm::Run const&, edm::EventSetup const&) override;
+  void endRun(edm::Run const&, edm::EventSetup const&) override;
   void analyze(edm::Event const&, edm::EventSetup const&) override;
   void endJob() override;
   std::string intToString(int num);
@@ -65,10 +66,15 @@ private:
 
   // ----------member data ---------------------------
 
-  edm::InputTag EBUncalibratedRecHitCollection_;
-  edm::InputTag EEUncalibratedRecHitCollection_;
+  const edm::InputTag ebUncalibratedRecHitCollection_;
+  const edm::InputTag eeUncalibratedRecHitCollection_;
+
+  const edm::EDGetTokenT<EcalUncalibratedRecHitCollection> ebUncalibRecHitsToken_;
+  const edm::EDGetTokenT<EcalUncalibratedRecHitCollection> eeUncalibRecHitsToken_;
+  const edm::ESGetToken<EcalElectronicsMapping, EcalMappingRcd> ecalMappingToken_;
+
   int runNum_;
-  double histRangeMax_, histRangeMin_;
+  const double histRangeMax_, histRangeMin_;
   std::string fileName_;
 
   std::vector<int> maskedChannels_;
@@ -84,3 +90,5 @@ private:
   EcalFedMap* fedMap_;
   const EcalElectronicsMapping* ecalElectronicsMap_;
 };
+
+#endif


### PR DESCRIPTION
#### PR description:

This PR migrates ECAL related code in the CaloOnlineTools/EcalTools packages to esConsumes (#31061 ). In addition `getByLabel()` calls were replaced by `getByToken()` and legacy module types were migrated to multithreaded module types.

#### PR validation:

Code compiles.