### PR TITLE
Added esConsumes to modules in SimMuon/MCTruth

### DIFF
--- a/SimMuon/MCTruth/interface/CSCHitAssociator.h
+++ b/SimMuon/MCTruth/interface/CSCHitAssociator.h
@@ -21,6 +21,8 @@
 #include "SimDataFormats/TrackerDigiSimLink/interface/StripDigiSimLink.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 
+class MuonGeometryRecord;
+
 class CSCHitAssociator {
 public:
   typedef edm::DetSetVector<StripDigiSimLink> DigiSimLinks;
@@ -28,18 +30,27 @@ public:
   typedef edm::DetSet<StripDigiSimLink> LayerLinks;
   typedef std::pair<uint32_t, EncodedEventId> SimHitIdpr;
 
-  CSCHitAssociator(const edm::Event &, const edm::EventSetup &, const edm::ParameterSet &);
-  CSCHitAssociator(const edm::ParameterSet &, edm::ConsumesCollector &&iC);
+  class Config {
+  public:
+    Config(const edm::ParameterSet &, edm::ConsumesCollector iC);
 
-  void initEvent(const edm::Event &, const edm::EventSetup &);
+  private:
+    friend class CSCHitAssociator;
+    const edm::InputTag linksTag_;
+    const edm::EDGetTokenT<DigiSimLinks> linksToken_;
+    const edm::ESGetToken<CSCGeometry, MuonGeometryRecord> geomToken_;
+  };
+
+  CSCHitAssociator(const edm::Event &, const edm::EventSetup &, const Config &);
 
   std::vector<SimHitIdpr> associateHitId(const TrackingRecHit &) const;
   std::vector<SimHitIdpr> associateCSCHitId(const CSCRecHit2D *) const;
 
 private:
-  const DigiSimLinks *theDigiSimLinks;
+  void initEvent(const edm::Event &, const edm::EventSetup &);
 
-  edm::InputTag linksTag;
+  const Config &theConfig;
+  const DigiSimLinks *theDigiSimLinks;
 
   const CSCGeometry *cscgeom;
 };

--- a/SimMuon/MCTruth/interface/DTHitAssociator.h
+++ b/SimMuon/MCTruth/interface/DTHitAssociator.h
@@ -28,12 +28,34 @@ public:
   typedef std::map<DTWireId, std::vector<DTDigi>> DigiMap;
   typedef std::map<DTWireId, std::vector<DTDigiSimLink>> LinksMap;
 
-  DTHitAssociator(const edm::Event &, const edm::EventSetup &, const edm::ParameterSet &, bool printRtS);
-  DTHitAssociator(const edm::ParameterSet &, edm::ConsumesCollector &&iC);
+  class Config {
+  public:
+    Config(const edm::ParameterSet &, edm::ConsumesCollector iC);
 
-  void initEvent(const edm::Event &, const edm::EventSetup &);
+  private:
+    friend class DTHitAssociator;
 
-  virtual ~DTHitAssociator() {}
+    edm::InputTag DTsimhitsTag;
+    edm::InputTag DTsimhitsXFTag;
+    edm::InputTag DTdigiTag;
+    edm::InputTag DTdigisimlinkTag;
+    edm::InputTag DTrechitTag;
+
+    edm::EDGetTokenT<edm::PSimHitContainer> DTsimhitsToken;
+    edm::EDGetTokenT<CrossingFrame<PSimHit>> DTsimhitsXFToken;
+    edm::EDGetTokenT<DTDigiCollection> DTdigiToken;
+    edm::EDGetTokenT<DTDigiSimLinkCollection> DTdigisimlinkToken;
+    edm::EDGetTokenT<DTRecHitCollection> DTrechitToken;
+
+    edm::ESGetToken<DTGeometry, MuonGeometryRecord> geomToken;
+
+    bool dumpDT;
+    bool crossingframe;
+    bool links_exist;
+    bool associatorByWire;
+  };
+
+  DTHitAssociator(const edm::Event &, const edm::EventSetup &, const Config &, bool printRtS);
 
   std::vector<SimHitIdpr> associateHitId(const TrackingRecHit &hit) const;
   std::vector<SimHitIdpr> associateDTHitId(const DTRecHit1D *dtrechit) const;
@@ -46,18 +68,10 @@ public:
   LinksMap mapOfLinks;
 
 private:
-  edm::InputTag DTsimhitsTag;
-  edm::InputTag DTsimhitsXFTag;
-  edm::InputTag DTdigiTag;
-  edm::InputTag DTdigisimlinkTag;
-  edm::InputTag DTrechitTag;
-
-  bool dumpDT;
-  bool crossingframe;
-  bool links_exist;
-  bool associatorByWire;
+  void initEvent(const edm::Event &, const edm::EventSetup &);
 
   bool SimHitOK(const edm::ESHandle<DTGeometry> &, const PSimHit &);
+  Config const &config_;
   bool printRtS;
 };
 

--- a/SimMuon/MCTruth/interface/DTHitAssociator.h
+++ b/SimMuon/MCTruth/interface/DTHitAssociator.h
@@ -15,9 +15,12 @@
 #include "SimDataFormats/DigiSimLinks/interface/DTDigiSimLinkCollection.h"
 #include "SimDataFormats/EncodedEventId/interface/EncodedEventId.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
+#include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
 
 #include <map>
 #include <vector>
+
+class MuonGeometryRecord;
 
 class DTHitAssociator {
 public:

--- a/SimMuon/MCTruth/interface/GEMHitAssociator.h
+++ b/SimMuon/MCTruth/interface/GEMHitAssociator.h
@@ -32,34 +32,39 @@
 
 class GEMHitAssociator {
 public:
+  class Config {
+  public:
+    Config(const edm::ParameterSet &, edm::ConsumesCollector ic);
+
+  private:
+    friend class GEMHitAssociator;
+
+    edm::InputTag GEMdigisimlinkTag;
+    edm::InputTag GEMsimhitsTag;
+    edm::InputTag GEMsimhitsXFTag;
+
+    edm::EDGetTokenT<CrossingFrame<PSimHit>> GEMsimhitsXFToken_;
+    edm::EDGetTokenT<edm::PSimHitContainer> GEMsimhitsToken_;
+    edm::EDGetTokenT<edm::DetSetVector<GEMDigiSimLink>> GEMdigisimlinkToken_;
+
+    bool crossingframe;
+    bool useGEMs_;
+  };
+
   typedef edm::DetSetVector<GEMDigiSimLink> DigiSimLinks;
   typedef edm::DetSet<GEMDigiSimLink> LayerLinks;
   typedef std::pair<uint32_t, EncodedEventId> SimHitIdpr;
 
   // Constructor with configurable parameters
-  GEMHitAssociator(const edm::ParameterSet &, edm::ConsumesCollector &&ic);
-  GEMHitAssociator(const edm::Event &e, const edm::ParameterSet &conf);
-
-  void initEvent(const edm::Event &);
-
-  // Destructor
-  ~GEMHitAssociator() {}
+  GEMHitAssociator(const edm::Event &e, const Config &config);
 
   std::vector<SimHitIdpr> associateRecHit(const GEMRecHit *gemrechit) const;
 
 private:
+  void initEvent(const edm::Event &);
+
+  const Config &theConfig;
   const DigiSimLinks *theDigiSimLinks;
-  edm::InputTag GEMdigisimlinkTag;
-
-  bool crossingframe;
-  bool useGEMs_;
-  edm::InputTag GEMsimhitsTag;
-  edm::InputTag GEMsimhitsXFTag;
-
-  edm::EDGetTokenT<CrossingFrame<PSimHit>> GEMsimhitsXFToken_;
-  edm::EDGetTokenT<edm::PSimHitContainer> GEMsimhitsToken_;
-  edm::EDGetTokenT<edm::DetSetVector<GEMDigiSimLink>> GEMdigisimlinkToken_;
-
   std::map<unsigned int, edm::PSimHitContainer> _SimHitMap;
 };
 

--- a/SimMuon/MCTruth/interface/GEMHitAssociator.h
+++ b/SimMuon/MCTruth/interface/GEMHitAssociator.h
@@ -38,9 +38,9 @@ public:
 
   // Constructor with configurable parameters
   GEMHitAssociator(const edm::ParameterSet &, edm::ConsumesCollector &&ic);
-  GEMHitAssociator(const edm::Event &e, const edm::EventSetup &eventSetup, const edm::ParameterSet &conf);
+  GEMHitAssociator(const edm::Event &e, const edm::ParameterSet &conf);
 
-  void initEvent(const edm::Event &, const edm::EventSetup &);
+  void initEvent(const edm::Event &);
 
   // Destructor
   ~GEMHitAssociator() {}

--- a/SimMuon/MCTruth/interface/MuonAssociatorByHits.h
+++ b/SimMuon/MCTruth/interface/MuonAssociatorByHits.h
@@ -17,6 +17,7 @@
 #include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
 #include "SimMuon/MCTruth/interface/GEMHitAssociator.h"
 #include "SimMuon/MCTruth/interface/RPCHitAssociator.h"
+#include "SimMuon/MCTruth/interface/CSCHitAssociator.h"
 
 #include <memory>
 
@@ -80,6 +81,7 @@ private:
   TrackerHitAssociator::Config trackerHitAssociatorConfig_;
   GEMHitAssociator::Config gemHitAssociatorConfig_;
   RPCHitAssociator::Config rpcHitAssociatorConfig_;
+  CSCHitAssociator::Config cscHitAssociatorConfig_;
 
   std::unique_ptr<muonAssociatorByHitsDiagnostics::InputDumper> diagnostics_;
 };

--- a/SimMuon/MCTruth/interface/MuonAssociatorByHits.h
+++ b/SimMuon/MCTruth/interface/MuonAssociatorByHits.h
@@ -18,6 +18,7 @@
 #include "SimMuon/MCTruth/interface/GEMHitAssociator.h"
 #include "SimMuon/MCTruth/interface/RPCHitAssociator.h"
 #include "SimMuon/MCTruth/interface/CSCHitAssociator.h"
+#include "SimMuon/MCTruth/interface/DTHitAssociator.h"
 
 #include <memory>
 
@@ -77,11 +78,11 @@ public:
 
 private:
   MuonAssociatorByHitsHelper helper_;
-  edm::ParameterSet const conf_;
   TrackerHitAssociator::Config trackerHitAssociatorConfig_;
   GEMHitAssociator::Config gemHitAssociatorConfig_;
   RPCHitAssociator::Config rpcHitAssociatorConfig_;
   CSCHitAssociator::Config cscHitAssociatorConfig_;
+  DTHitAssociator::Config dtHitAssociatorConfig_;
 
   std::unique_ptr<muonAssociatorByHitsDiagnostics::InputDumper> diagnostics_;
 };

--- a/SimMuon/MCTruth/interface/MuonAssociatorByHits.h
+++ b/SimMuon/MCTruth/interface/MuonAssociatorByHits.h
@@ -15,6 +15,7 @@
 
 #include "SimMuon/MCTruth/interface/MuonAssociatorByHitsHelper.h"
 #include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
+#include "SimMuon/MCTruth/interface/GEMHitAssociator.h"
 
 #include <memory>
 
@@ -76,6 +77,7 @@ private:
   MuonAssociatorByHitsHelper helper_;
   edm::ParameterSet const conf_;
   TrackerHitAssociator::Config trackerHitAssociatorConfig_;
+  GEMHitAssociator::Config gemHitAssociatorConfig_;
 
   std::unique_ptr<muonAssociatorByHitsDiagnostics::InputDumper> diagnostics_;
 };

--- a/SimMuon/MCTruth/interface/MuonAssociatorByHits.h
+++ b/SimMuon/MCTruth/interface/MuonAssociatorByHits.h
@@ -16,6 +16,7 @@
 #include "SimMuon/MCTruth/interface/MuonAssociatorByHitsHelper.h"
 #include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
 #include "SimMuon/MCTruth/interface/GEMHitAssociator.h"
+#include "SimMuon/MCTruth/interface/RPCHitAssociator.h"
 
 #include <memory>
 
@@ -78,6 +79,7 @@ private:
   edm::ParameterSet const conf_;
   TrackerHitAssociator::Config trackerHitAssociatorConfig_;
   GEMHitAssociator::Config gemHitAssociatorConfig_;
+  RPCHitAssociator::Config rpcHitAssociatorConfig_;
 
   std::unique_ptr<muonAssociatorByHitsDiagnostics::InputDumper> diagnostics_;
 };

--- a/SimMuon/MCTruth/interface/MuonAssociatorByHits.h
+++ b/SimMuon/MCTruth/interface/MuonAssociatorByHits.h
@@ -26,6 +26,8 @@ namespace muonAssociatorByHitsDiagnostics {
   class InputDumper;
 }
 
+class TrackerTopologyRcd;
+
 class MuonAssociatorByHits {
 public:
   MuonAssociatorByHits(const edm::ParameterSet &conf, edm::ConsumesCollector &&iC);
@@ -84,6 +86,7 @@ private:
   CSCHitAssociator::Config cscHitAssociatorConfig_;
   DTHitAssociator::Config dtHitAssociatorConfig_;
 
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> ttopoToken_;
   std::unique_ptr<muonAssociatorByHitsDiagnostics::InputDumper> diagnostics_;
 };
 

--- a/SimMuon/MCTruth/interface/MuonAssociatorByHitsHelper.h
+++ b/SimMuon/MCTruth/interface/MuonAssociatorByHitsHelper.h
@@ -36,6 +36,21 @@ public:
   MuonAssociatorByHitsHelper(const edm::ParameterSet &conf);
 
   struct Resources {
+    Resources(TrackerTopology const *tTopo,
+              TrackerHitAssociator const *trackerHitAssoc,
+              CSCHitAssociator const *cscHitAssoc,
+              DTHitAssociator const *dtHitAssoc,
+              RPCHitAssociator const *rpcHitAssoc,
+              GEMHitAssociator const *gemHitAssoc,
+              std::function<void(const TrackHitsCollection &, const TrackingParticleCollection &)> diagnostics)
+        : tTopo_(tTopo),
+          trackerHitAssoc_(trackerHitAssoc),
+          cscHitAssoc_(cscHitAssoc),
+          dtHitAssoc_(dtHitAssoc),
+          rpcHitAssoc_(rpcHitAssoc),
+          gemHitAssoc_(gemHitAssoc),
+          diagnostics_(diagnostics) {}
+
     TrackerTopology const *tTopo_;
     TrackerHitAssociator const *trackerHitAssoc_;
     CSCHitAssociator const *cscHitAssoc_;

--- a/SimMuon/MCTruth/interface/RPCHitAssociator.h
+++ b/SimMuon/MCTruth/interface/RPCHitAssociator.h
@@ -34,31 +34,37 @@ public:
   typedef edm::DetSetVector<RPCDigiSimLink> RPCDigiSimLinks;
   typedef std::pair<uint32_t, EncodedEventId> SimHitIdpr;
 
+  class Config {
+  public:
+    Config(const edm::ParameterSet &, edm::ConsumesCollector ic);
+
+  private:
+    friend class RPCHitAssociator;
+
+    edm::InputTag RPCdigisimlinkTag;
+
+    edm::InputTag RPCsimhitsTag;
+    edm::InputTag RPCsimhitsXFTag;
+
+    edm::EDGetTokenT<CrossingFrame<PSimHit>> RPCsimhitsXFToken_;
+    edm::EDGetTokenT<edm::PSimHitContainer> RPCsimhitsToken_;
+    edm::EDGetTokenT<edm::DetSetVector<RPCDigiSimLink>> RPCdigisimlinkToken_;
+
+    bool crossingframe;
+  };
+
   // Constructor with configurable parameters
-  RPCHitAssociator(const edm::ParameterSet &, edm::ConsumesCollector &&ic);
-  RPCHitAssociator(const edm::Event &e, const edm::ParameterSet &conf);
-
-  void initEvent(const edm::Event &);
-
-  // Destructor
-  ~RPCHitAssociator() {}
+  RPCHitAssociator(const edm::Event &e, const Config &conf);
 
   std::vector<SimHitIdpr> associateRecHit(const TrackingRecHit &hit) const;
   std::set<RPCDigiSimLink> findRPCDigiSimLink(uint32_t rpcDetId, int strip, int bx) const;
   //   const PSimHit* linkToSimHit(RPCDigiSimLink link);
 
 private:
+  void initEvent(const edm::Event &);
+
+  Config const &theConfig;
   edm::Handle<edm::DetSetVector<RPCDigiSimLink>> _thelinkDigis;
-  edm::InputTag RPCdigisimlinkTag;
-
-  bool crossingframe;
-  edm::InputTag RPCsimhitsTag;
-  edm::InputTag RPCsimhitsXFTag;
-
-  edm::EDGetTokenT<CrossingFrame<PSimHit>> RPCsimhitsXFToken_;
-  edm::EDGetTokenT<edm::PSimHitContainer> RPCsimhitsToken_;
-  edm::EDGetTokenT<edm::DetSetVector<RPCDigiSimLink>> RPCdigisimlinkToken_;
-
   std::map<unsigned int, edm::PSimHitContainer> _SimHitMap;
 };
 

--- a/SimMuon/MCTruth/interface/RPCHitAssociator.h
+++ b/SimMuon/MCTruth/interface/RPCHitAssociator.h
@@ -36,9 +36,9 @@ public:
 
   // Constructor with configurable parameters
   RPCHitAssociator(const edm::ParameterSet &, edm::ConsumesCollector &&ic);
-  RPCHitAssociator(const edm::Event &e, const edm::EventSetup &eventSetup, const edm::ParameterSet &conf);
+  RPCHitAssociator(const edm::Event &e, const edm::ParameterSet &conf);
 
-  void initEvent(const edm::Event &, const edm::EventSetup &);
+  void initEvent(const edm::Event &);
 
   // Destructor
   ~RPCHitAssociator() {}

--- a/SimMuon/MCTruth/interface/TrackerMuonHitExtractor.h
+++ b/SimMuon/MCTruth/interface/TrackerMuonHitExtractor.h
@@ -21,7 +21,7 @@ public:
   explicit TrackerMuonHitExtractor(const edm::ParameterSet &);
   ~TrackerMuonHitExtractor();
 
-  void init(const edm::Event &, const edm::EventSetup &);
+  void init(const edm::Event &);
   std::vector<const TrackingRecHit *> getMuonHits(const reco::Muon &mu) const;
 
 private:

--- a/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorByHitsImpl.cc
+++ b/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorByHitsImpl.cc
@@ -29,20 +29,23 @@
 //
 MuonToTrackingParticleAssociatorByHitsImpl::MuonToTrackingParticleAssociatorByHitsImpl(
     TrackerMuonHitExtractor const &iHitExtractor,
-    std::unique_ptr<TrackerHitAssociator> iTracker,
-    std::unique_ptr<CSCHitAssociator> iCSC,
-    std::unique_ptr<DTHitAssociator> iDT,
-    std::unique_ptr<RPCHitAssociator> iRPC,
-    std::unique_ptr<GEMHitAssociator> iGEM,
-    MuonAssociatorByHitsHelper::Resources const &iResources,
+    TrackerHitAssociator::Config const &iTracker,
+    CSCHitAssociator::Config const &iCSC,
+    DTHitAssociator::Config const &iDT,
+    RPCHitAssociator::Config const &iRPC,
+    GEMHitAssociator::Config const &iGEM,
+    edm::Event const &iEvent,
+    edm::EventSetup const &iSetup,
+    const TrackerTopology *iTopo,
+    std::function<void(const TrackHitsCollection &, const TrackingParticleCollection &)> iDiagnostics,
     MuonAssociatorByHitsHelper const *iHelper)
     : m_hitExtractor(&iHitExtractor),
-      m_tracker(std::move(iTracker)),
-      m_csc(std::move(iCSC)),
-      m_dt(std::move(iDT)),
-      m_rpc(std::move(iRPC)),
-      m_gem(std::move(iGEM)),
-      m_resources(iResources),
+      m_tracker(iEvent, iTracker),
+      m_csc(iEvent, iSetup, iCSC),
+      m_dt(iEvent, iSetup, iDT, true),
+      m_rpc(iEvent, iRPC),
+      m_gem(iEvent, iGEM),
+      m_resources(iTopo, &m_tracker, &m_csc, &m_dt, &m_rpc, &m_gem, iDiagnostics),
       m_helper(iHelper) {}
 
 //

--- a/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorByHitsImpl.cc
+++ b/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorByHitsImpl.cc
@@ -29,9 +29,21 @@
 //
 MuonToTrackingParticleAssociatorByHitsImpl::MuonToTrackingParticleAssociatorByHitsImpl(
     TrackerMuonHitExtractor const &iHitExtractor,
+    std::unique_ptr<TrackerHitAssociator> iTracker,
+    std::unique_ptr<CSCHitAssociator> iCSC,
+    std::unique_ptr<DTHitAssociator> iDT,
+    std::unique_ptr<RPCHitAssociator> iRPC,
+    std::unique_ptr<GEMHitAssociator> iGEM,
     MuonAssociatorByHitsHelper::Resources const &iResources,
     MuonAssociatorByHitsHelper const *iHelper)
-    : m_hitExtractor(&iHitExtractor), m_resources(iResources), m_helper(iHelper) {}
+    : m_hitExtractor(&iHitExtractor),
+      m_tracker(std::move(iTracker)),
+      m_csc(std::move(iCSC)),
+      m_dt(std::move(iDT)),
+      m_rpc(std::move(iRPC)),
+      m_gem(std::move(iGEM)),
+      m_resources(iResources),
+      m_helper(iHelper) {}
 
 //
 // member functions

--- a/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorByHitsImpl.h
+++ b/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorByHitsImpl.h
@@ -21,6 +21,7 @@
 //
 
 // system include files
+#include <memory>
 
 // user include files
 #include "SimDataFormats/Associations/interface/MuonToTrackingParticleAssociatorBaseImpl.h"
@@ -32,6 +33,11 @@ class TrackerMuonHitExtractor;
 class MuonToTrackingParticleAssociatorByHitsImpl : public reco::MuonToTrackingParticleAssociatorBaseImpl {
 public:
   MuonToTrackingParticleAssociatorByHitsImpl(TrackerMuonHitExtractor const &iHitExtractor,
+                                             std::unique_ptr<TrackerHitAssociator> iTracker,
+                                             std::unique_ptr<CSCHitAssociator> iCSC,
+                                             std::unique_ptr<DTHitAssociator> iDT,
+                                             std::unique_ptr<RPCHitAssociator> iRPC,
+                                             std::unique_ptr<GEMHitAssociator> iGEM,
                                              MuonAssociatorByHitsHelper::Resources const &iResources,
                                              MuonAssociatorByHitsHelper const *iHelper);
 
@@ -61,6 +67,11 @@ public:
 private:
   // ---------- member data --------------------------------
   TrackerMuonHitExtractor const *m_hitExtractor;
+  std::unique_ptr<TrackerHitAssociator const> m_tracker;
+  std::unique_ptr<CSCHitAssociator const> m_csc;
+  std::unique_ptr<DTHitAssociator const> m_dt;
+  std::unique_ptr<RPCHitAssociator const> m_rpc;
+  std::unique_ptr<GEMHitAssociator const> m_gem;
   MuonAssociatorByHitsHelper::Resources m_resources;
   MuonAssociatorByHitsHelper const *m_helper;
 };

--- a/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorByHitsImpl.h
+++ b/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorByHitsImpl.h
@@ -21,7 +21,7 @@
 //
 
 // system include files
-#include <memory>
+#include <functional>
 
 // user include files
 #include "SimDataFormats/Associations/interface/MuonToTrackingParticleAssociatorBaseImpl.h"
@@ -32,14 +32,20 @@ class TrackerMuonHitExtractor;
 
 class MuonToTrackingParticleAssociatorByHitsImpl : public reco::MuonToTrackingParticleAssociatorBaseImpl {
 public:
-  MuonToTrackingParticleAssociatorByHitsImpl(TrackerMuonHitExtractor const &iHitExtractor,
-                                             std::unique_ptr<TrackerHitAssociator> iTracker,
-                                             std::unique_ptr<CSCHitAssociator> iCSC,
-                                             std::unique_ptr<DTHitAssociator> iDT,
-                                             std::unique_ptr<RPCHitAssociator> iRPC,
-                                             std::unique_ptr<GEMHitAssociator> iGEM,
-                                             MuonAssociatorByHitsHelper::Resources const &iResources,
-                                             MuonAssociatorByHitsHelper const *iHelper);
+  using TrackHitsCollection = MuonAssociatorByHitsHelper::TrackHitsCollection;
+
+  MuonToTrackingParticleAssociatorByHitsImpl(
+      TrackerMuonHitExtractor const &iHitExtractor,
+      TrackerHitAssociator::Config const &iTracker,
+      CSCHitAssociator::Config const &iCSC,
+      DTHitAssociator::Config const &iDT,
+      RPCHitAssociator::Config const &iRPC,
+      GEMHitAssociator::Config const &iGEM,
+      edm::Event const &iEvent,
+      edm::EventSetup const &iSetup,
+      const TrackerTopology *iTopo,
+      std::function<void(const TrackHitsCollection &, const TrackingParticleCollection &)>,
+      MuonAssociatorByHitsHelper const *iHelper);
 
   MuonToTrackingParticleAssociatorByHitsImpl(const MuonToTrackingParticleAssociatorByHitsImpl &) =
       delete;  // stop default
@@ -67,11 +73,11 @@ public:
 private:
   // ---------- member data --------------------------------
   TrackerMuonHitExtractor const *m_hitExtractor;
-  std::unique_ptr<TrackerHitAssociator const> m_tracker;
-  std::unique_ptr<CSCHitAssociator const> m_csc;
-  std::unique_ptr<DTHitAssociator const> m_dt;
-  std::unique_ptr<RPCHitAssociator const> m_rpc;
-  std::unique_ptr<GEMHitAssociator const> m_gem;
+  TrackerHitAssociator const m_tracker;
+  CSCHitAssociator const m_csc;
+  DTHitAssociator const m_dt;
+  RPCHitAssociator const m_rpc;
+  GEMHitAssociator const m_gem;
   MuonAssociatorByHitsHelper::Resources m_resources;
   MuonAssociatorByHitsHelper const *m_helper;
 };

--- a/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorEDProducer.cc
+++ b/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorEDProducer.cc
@@ -189,6 +189,7 @@ private:
   TrackerMuonHitExtractor hitExtractor_;
   GEMHitAssociator::Config gemHitAssociatorConfig_;
   RPCHitAssociator::Config rpcHitAssociatorConfig_;
+  CSCHitAssociator::Config cscHitAssociatorConfig_;
 
   const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
   std::unique_ptr<InputDumper> diagnostics_;
@@ -212,13 +213,13 @@ MuonToTrackingParticleAssociatorEDProducer::MuonToTrackingParticleAssociatorEDPr
       hitExtractor_(iConfig, consumesCollector()),
       gemHitAssociatorConfig_(iConfig, consumesCollector()),
       rpcHitAssociatorConfig_(iConfig, consumesCollector()),
+      cscHitAssociatorConfig_(iConfig, consumesCollector()),
       tTopoToken_(esConsumes()) {
   // register your products
   produces<reco::MuonToTrackingParticleAssociator>();
 
   // hack for consumes
   DTHitAssociator dttruth(iConfig, consumesCollector());
-  CSCHitAssociator cscruth(iConfig, consumesCollector());
 
   edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
       << "\n constructing MuonToTrackingParticleAssociatorEDProducer"
@@ -257,7 +258,7 @@ void MuonToTrackingParticleAssociatorEDProducer::produce(edm::Event &iEvent, con
   // Tracker hit association
   TrackerHitAssociator trackertruth(iEvent, trackerHitAssociatorConfig_);
   // CSC hit association
-  CSCHitAssociator csctruth(iEvent, iSetup, config_);
+  CSCHitAssociator csctruth(iEvent, iSetup, cscHitAssociatorConfig_);
   // DT hit association
   printRtS = false;
   DTHitAssociator dttruth(iEvent, iSetup, config_, printRtS);

--- a/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorEDProducer.cc
+++ b/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorEDProducer.cc
@@ -190,6 +190,7 @@ private:
   GEMHitAssociator::Config gemHitAssociatorConfig_;
   RPCHitAssociator::Config rpcHitAssociatorConfig_;
   CSCHitAssociator::Config cscHitAssociatorConfig_;
+  DTHitAssociator::Config dtHitAssociatorConfig_;
 
   const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
   std::unique_ptr<InputDumper> diagnostics_;
@@ -214,12 +215,10 @@ MuonToTrackingParticleAssociatorEDProducer::MuonToTrackingParticleAssociatorEDPr
       gemHitAssociatorConfig_(iConfig, consumesCollector()),
       rpcHitAssociatorConfig_(iConfig, consumesCollector()),
       cscHitAssociatorConfig_(iConfig, consumesCollector()),
+      dtHitAssociatorConfig_(iConfig, consumesCollector()),
       tTopoToken_(esConsumes()) {
   // register your products
   produces<reco::MuonToTrackingParticleAssociator>();
-
-  // hack for consumes
-  DTHitAssociator dttruth(iConfig, consumesCollector());
 
   edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
       << "\n constructing MuonToTrackingParticleAssociatorEDProducer"
@@ -261,7 +260,7 @@ void MuonToTrackingParticleAssociatorEDProducer::produce(edm::Event &iEvent, con
   CSCHitAssociator csctruth(iEvent, iSetup, cscHitAssociatorConfig_);
   // DT hit association
   printRtS = false;
-  DTHitAssociator dttruth(iEvent, iSetup, config_, printRtS);
+  DTHitAssociator dttruth(iEvent, iSetup, dtHitAssociatorConfig_, printRtS);
   // RPC hit association
   RPCHitAssociator rpctruth(iEvent, rpcHitAssociatorConfig_);
   // GEM hit association

--- a/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorEDProducer.cc
+++ b/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorEDProducer.cc
@@ -187,10 +187,10 @@ private:
   MuonAssociatorByHitsHelper helper_;
   TrackerHitAssociator::Config trackerHitAssociatorConfig_;
   TrackerMuonHitExtractor hitExtractor_;
+  GEMHitAssociator::Config gemHitAssociatorConfig_;
 
   const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
   std::unique_ptr<InputDumper> diagnostics_;
-
 };
 
 //
@@ -209,13 +209,13 @@ MuonToTrackingParticleAssociatorEDProducer::MuonToTrackingParticleAssociatorEDPr
       helper_(iConfig),
       trackerHitAssociatorConfig_(iConfig, consumesCollector()),
       hitExtractor_(iConfig, consumesCollector()),
+      gemHitAssociatorConfig_(iConfig, consumesCollector()),
       tTopoToken_(esConsumes()) {
   // register your products
   produces<reco::MuonToTrackingParticleAssociator>();
 
   // hack for consumes
   RPCHitAssociator rpctruth(iConfig, consumesCollector());
-  GEMHitAssociator gemtruth(iConfig, consumesCollector());
   DTHitAssociator dttruth(iConfig, consumesCollector());
   CSCHitAssociator cscruth(iConfig, consumesCollector());
 
@@ -263,7 +263,7 @@ void MuonToTrackingParticleAssociatorEDProducer::produce(edm::Event &iEvent, con
   // RPC hit association
   RPCHitAssociator rpctruth(iEvent, config_);
   // GEM hit association
-  GEMHitAssociator gemtruth(iEvent, config_);
+  GEMHitAssociator gemtruth(iEvent, gemHitAssociatorConfig_);
 
   MuonAssociatorByHitsHelper::Resources resources = {
       tTopo, &trackertruth, &csctruth, &dttruth, &rpctruth, &gemtruth, {}};

--- a/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorEDProducer.cc
+++ b/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorEDProducer.cc
@@ -246,7 +246,7 @@ MuonToTrackingParticleAssociatorEDProducer::~MuonToTrackingParticleAssociatorEDP
 void MuonToTrackingParticleAssociatorEDProducer::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   using namespace edm;
 
-  hitExtractor_.init(iEvent, iSetup);
+  hitExtractor_.init(iEvent);
 
   // Retrieve tracker topology from geometry
   const TrackerTopology *tTopo = &iSetup.getData(tTopoToken_);
@@ -266,9 +266,9 @@ void MuonToTrackingParticleAssociatorEDProducer::produce(edm::Event &iEvent, con
   printRtS = false;
   dttruth_ = std::make_unique<DTHitAssociator>(iEvent, iSetup, config_, printRtS);
   // RPC hit association
-  rpctruth_ = std::make_unique<RPCHitAssociator>(iEvent, iSetup, config_);
+  rpctruth_ = std::make_unique<RPCHitAssociator>(iEvent, config_);
   // GEM hit association
-  gemtruth_ = std::make_unique<GEMHitAssociator>(iEvent, iSetup, config_);
+  gemtruth_ = std::make_unique<GEMHitAssociator>(iEvent, config_);
 
   MuonAssociatorByHitsHelper::Resources resources = {
       tTopo, trackertruth_.get(), csctruth_.get(), dttruth_.get(), rpctruth_.get(), gemtruth_.get(), {}};

--- a/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorEDProducer.cc
+++ b/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorEDProducer.cc
@@ -188,6 +188,8 @@ private:
   TrackerHitAssociator::Config trackerHitAssociatorConfig_;
   TrackerMuonHitExtractor hitExtractor_;
 
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
+
   std::unique_ptr<RPCHitAssociator> rpctruth_;
   std::unique_ptr<GEMHitAssociator> gemtruth_;
   std::unique_ptr<DTHitAssociator> dttruth_;
@@ -211,7 +213,8 @@ MuonToTrackingParticleAssociatorEDProducer::MuonToTrackingParticleAssociatorEDPr
     : config_(iConfig),
       helper_(iConfig),
       trackerHitAssociatorConfig_(iConfig, consumesCollector()),
-      hitExtractor_(iConfig, consumesCollector()) {
+      hitExtractor_(iConfig, consumesCollector()),
+      tTopoToken_(esConsumes()) {
   // register your products
   produces<reco::MuonToTrackingParticleAssociator>();
 
@@ -246,9 +249,7 @@ void MuonToTrackingParticleAssociatorEDProducer::produce(edm::Event &iEvent, con
   hitExtractor_.init(iEvent, iSetup);
 
   // Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHand;
-  iSetup.get<TrackerTopologyRcd>().get(tTopoHand);
-  const TrackerTopology *tTopo = tTopoHand.product();
+  const TrackerTopology *tTopo = &iSetup.getData(tTopoToken_);
 
   bool printRtS = true;
 

--- a/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorEDProducer.cc
+++ b/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorEDProducer.cc
@@ -188,6 +188,7 @@ private:
   TrackerHitAssociator::Config trackerHitAssociatorConfig_;
   TrackerMuonHitExtractor hitExtractor_;
   GEMHitAssociator::Config gemHitAssociatorConfig_;
+  RPCHitAssociator::Config rpcHitAssociatorConfig_;
 
   const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
   std::unique_ptr<InputDumper> diagnostics_;
@@ -210,12 +211,12 @@ MuonToTrackingParticleAssociatorEDProducer::MuonToTrackingParticleAssociatorEDPr
       trackerHitAssociatorConfig_(iConfig, consumesCollector()),
       hitExtractor_(iConfig, consumesCollector()),
       gemHitAssociatorConfig_(iConfig, consumesCollector()),
+      rpcHitAssociatorConfig_(iConfig, consumesCollector()),
       tTopoToken_(esConsumes()) {
   // register your products
   produces<reco::MuonToTrackingParticleAssociator>();
 
   // hack for consumes
-  RPCHitAssociator rpctruth(iConfig, consumesCollector());
   DTHitAssociator dttruth(iConfig, consumesCollector());
   CSCHitAssociator cscruth(iConfig, consumesCollector());
 
@@ -261,7 +262,7 @@ void MuonToTrackingParticleAssociatorEDProducer::produce(edm::Event &iEvent, con
   printRtS = false;
   DTHitAssociator dttruth(iEvent, iSetup, config_, printRtS);
   // RPC hit association
-  RPCHitAssociator rpctruth(iEvent, config_);
+  RPCHitAssociator rpctruth(iEvent, rpcHitAssociatorConfig_);
   // GEM hit association
   GEMHitAssociator gemtruth(iEvent, gemHitAssociatorConfig_);
 

--- a/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorEDProducer.cc
+++ b/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorEDProducer.cc
@@ -189,13 +189,8 @@ private:
   TrackerMuonHitExtractor hitExtractor_;
 
   const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
-
-  std::unique_ptr<RPCHitAssociator> rpctruth_;
-  std::unique_ptr<GEMHitAssociator> gemtruth_;
-  std::unique_ptr<DTHitAssociator> dttruth_;
-  std::unique_ptr<CSCHitAssociator> csctruth_;
-  std::unique_ptr<TrackerHitAssociator> trackertruth_;
   std::unique_ptr<InputDumper> diagnostics_;
+
 };
 
 //
@@ -259,19 +254,19 @@ void MuonToTrackingParticleAssociatorEDProducer::produce(edm::Event &iEvent, con
   // the resources own the memory.
 
   // Tracker hit association
-  trackertruth_ = std::make_unique<TrackerHitAssociator>(iEvent, trackerHitAssociatorConfig_);
+  TrackerHitAssociator trackertruth(iEvent, trackerHitAssociatorConfig_);
   // CSC hit association
-  csctruth_ = std::make_unique<CSCHitAssociator>(iEvent, iSetup, config_);
+  CSCHitAssociator csctruth(iEvent, iSetup, config_);
   // DT hit association
   printRtS = false;
-  dttruth_ = std::make_unique<DTHitAssociator>(iEvent, iSetup, config_, printRtS);
+  DTHitAssociator dttruth(iEvent, iSetup, config_, printRtS);
   // RPC hit association
-  rpctruth_ = std::make_unique<RPCHitAssociator>(iEvent, config_);
+  RPCHitAssociator rpctruth(iEvent, config_);
   // GEM hit association
-  gemtruth_ = std::make_unique<GEMHitAssociator>(iEvent, config_);
+  GEMHitAssociator gemtruth(iEvent, config_);
 
   MuonAssociatorByHitsHelper::Resources resources = {
-      tTopo, trackertruth_.get(), csctruth_.get(), dttruth_.get(), rpctruth_.get(), gemtruth_.get(), {}};
+      tTopo, &trackertruth, &csctruth, &dttruth, &rpctruth, &gemtruth, {}};
 
   if (diagnostics_) {
     diagnostics_->read(iEvent);

--- a/SimMuon/MCTruth/plugins/SeedToTrackProducer.cc
+++ b/SimMuon/MCTruth/plugins/SeedToTrackProducer.cc
@@ -26,7 +26,8 @@
 //
 // constructors and destructor
 //
-SeedToTrackProducer::SeedToTrackProducer(const edm::ParameterSet &iConfig) {
+SeedToTrackProducer::SeedToTrackProducer(const edm::ParameterSet &iConfig)
+    : theMGFieldToken(esConsumes()), theTrackingGeometryToken(esConsumes()), theTopoToken(esConsumes()) {
   L2seedsTagT_ = consumes<TrajectorySeedCollection>(iConfig.getParameter<edm::InputTag>("L2seedsCollection"));
   L2seedsTagS_ = consumes<edm::View<TrajectorySeed>>(iConfig.getParameter<edm::InputTag>("L2seedsCollection"));
 
@@ -58,12 +59,10 @@ void SeedToTrackProducer::produce(edm::Event &iEvent, const edm::EventSetup &iSe
   edm::Ref<reco::TrackExtraCollection>::key_type idx = 0;
 
   // magnetic fied and detector geometry
-  iSetup.get<IdealMagneticFieldRecord>().get(theMGField);
-  iSetup.get<GlobalTrackingGeometryRecord>().get(theTrackingGeometry);
+  theMGField = iSetup.getHandle(theMGFieldToken);
+  theTrackingGeometry = iSetup.getHandle(theTrackingGeometryToken);
 
-  edm::ESHandle<TrackerTopology> httopo;
-  iSetup.get<TrackerTopologyRcd>().get(httopo);
-  const TrackerTopology &ttopo = *httopo;
+  const TrackerTopology &ttopo = iSetup.getData(theTopoToken);
 
   // now read the L2 seeds collection :
   edm::Handle<TrajectorySeedCollection> L2seedsCollection;

--- a/SimMuon/MCTruth/plugins/SeedToTrackProducer.h
+++ b/SimMuon/MCTruth/plugins/SeedToTrackProducer.h
@@ -22,7 +22,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "MagneticField/Engine/interface/MagneticField.h"
@@ -47,16 +47,15 @@
 
 typedef math::Error<5>::type CovarianceMatrix;
 
-class SeedToTrackProducer : public edm::one::EDProducer<> {
+class SeedToTrackProducer : public edm::global::EDProducer<> {
 public:
   explicit SeedToTrackProducer(const edm::ParameterSet &);
-  ~SeedToTrackProducer() override;
 
 private:
-  void beginJob() override;
-  void produce(edm::Event &, const edm::EventSetup &) override;
-  void endJob() override;
-  virtual TrajectoryStateOnSurface seedTransientState(const TrajectorySeed &);
+  void produce(edm::StreamID, edm::Event &, const edm::EventSetup &) const final;
+  TrajectoryStateOnSurface seedTransientState(const TrajectorySeed &,
+                                              const MagneticField &,
+                                              const GlobalTrackingGeometry &) const;
   // ----------member data ---------------------------
 
   edm::EDGetTokenT<TrajectorySeedCollection> L2seedsTagT_;
@@ -65,7 +64,4 @@ private:
   const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> theMGFieldToken;
   const edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> theTrackingGeometryToken;
   const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> theTopoToken;
-
-  edm::ESHandle<MagneticField> theMGField;
-  edm::ESHandle<GlobalTrackingGeometry> theTrackingGeometry;
 };

--- a/SimMuon/MCTruth/plugins/SeedToTrackProducer.h
+++ b/SimMuon/MCTruth/plugins/SeedToTrackProducer.h
@@ -62,6 +62,10 @@ private:
   edm::EDGetTokenT<TrajectorySeedCollection> L2seedsTagT_;
   edm::EDGetTokenT<edm::View<TrajectorySeed>> L2seedsTagS_;
 
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> theMGFieldToken;
+  const edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> theTrackingGeometryToken;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> theTopoToken;
+
   edm::ESHandle<MagneticField> theMGField;
   edm::ESHandle<GlobalTrackingGeometry> theTrackingGeometry;
 };

--- a/SimMuon/MCTruth/src/GEMHitAssociator.cc
+++ b/SimMuon/MCTruth/src/GEMHitAssociator.cc
@@ -20,19 +20,17 @@ GEMHitAssociator::GEMHitAssociator(const edm::ParameterSet &conf, edm::ConsumesC
   GEMdigisimlinkToken_ = iC.consumes<edm::DetSetVector<GEMDigiSimLink>>(GEMdigisimlinkTag);
 }
 
-GEMHitAssociator::GEMHitAssociator(const edm::Event &e,
-                                   const edm::EventSetup &eventSetup,
-                                   const edm::ParameterSet &conf)
+GEMHitAssociator::GEMHitAssociator(const edm::Event &e, const edm::ParameterSet &conf)
     : GEMdigisimlinkTag(conf.getParameter<edm::InputTag>("GEMdigisimlinkTag")),
       // CrossingFrame used or not ?
       crossingframe(conf.getParameter<bool>("crossingframe")),
       useGEMs_(conf.getParameter<bool>("useGEMs")),
       GEMsimhitsTag(conf.getParameter<edm::InputTag>("GEMsimhitsTag")),
       GEMsimhitsXFTag(conf.getParameter<edm::InputTag>("GEMsimhitsXFTag")) {
-  initEvent(e, eventSetup);
+  initEvent(e);
 }
 
-void GEMHitAssociator::initEvent(const edm::Event &e, const edm::EventSetup &eventSetup) {
+void GEMHitAssociator::initEvent(const edm::Event &e) {
   if (useGEMs_) {
     if (crossingframe) {
       edm::Handle<CrossingFrame<PSimHit>> cf;

--- a/SimMuon/MCTruth/src/GEMHitAssociator.cc
+++ b/SimMuon/MCTruth/src/GEMHitAssociator.cc
@@ -4,13 +4,13 @@
 using namespace std;
 
 // Constructor
-GEMHitAssociator::GEMHitAssociator(const edm::ParameterSet &conf, edm::ConsumesCollector &&iC)
+GEMHitAssociator::Config::Config(const edm::ParameterSet &conf, edm::ConsumesCollector iC)
     : GEMdigisimlinkTag(conf.getParameter<edm::InputTag>("GEMdigisimlinkTag")),
       // CrossingFrame used or not ?
-      crossingframe(conf.getParameter<bool>("crossingframe")),
-      useGEMs_(conf.getParameter<bool>("useGEMs")),
       GEMsimhitsTag(conf.getParameter<edm::InputTag>("GEMsimhitsTag")),
-      GEMsimhitsXFTag(conf.getParameter<edm::InputTag>("GEMsimhitsXFTag")) {
+      GEMsimhitsXFTag(conf.getParameter<edm::InputTag>("GEMsimhitsXFTag")),
+      crossingframe(conf.getParameter<bool>("crossingframe")),
+      useGEMs_(conf.getParameter<bool>("useGEMs")) {
   if (crossingframe) {
     GEMsimhitsXFToken_ = iC.consumes<CrossingFrame<PSimHit>>(GEMsimhitsXFTag);
   } else if (!GEMsimhitsTag.label().empty()) {
@@ -20,24 +20,15 @@ GEMHitAssociator::GEMHitAssociator(const edm::ParameterSet &conf, edm::ConsumesC
   GEMdigisimlinkToken_ = iC.consumes<edm::DetSetVector<GEMDigiSimLink>>(GEMdigisimlinkTag);
 }
 
-GEMHitAssociator::GEMHitAssociator(const edm::Event &e, const edm::ParameterSet &conf)
-    : GEMdigisimlinkTag(conf.getParameter<edm::InputTag>("GEMdigisimlinkTag")),
-      // CrossingFrame used or not ?
-      crossingframe(conf.getParameter<bool>("crossingframe")),
-      useGEMs_(conf.getParameter<bool>("useGEMs")),
-      GEMsimhitsTag(conf.getParameter<edm::InputTag>("GEMsimhitsTag")),
-      GEMsimhitsXFTag(conf.getParameter<edm::InputTag>("GEMsimhitsXFTag")) {
-  initEvent(e);
-}
+GEMHitAssociator::GEMHitAssociator(const edm::Event &e, const Config &config) : theConfig(config) { initEvent(e); }
 
 void GEMHitAssociator::initEvent(const edm::Event &e) {
-  if (useGEMs_) {
-    if (crossingframe) {
-      edm::Handle<CrossingFrame<PSimHit>> cf;
-      LogTrace("GEMHitAssociator") << "getting CrossingFrame<PSimHit> collection - " << GEMsimhitsXFTag;
-      e.getByLabel(GEMsimhitsXFTag, cf);
+  if (theConfig.useGEMs_) {
+    if (theConfig.crossingframe) {
+      LogTrace("GEMHitAssociator") << "getting CrossingFrame<PSimHit> collection - " << theConfig.GEMsimhitsXFTag;
+      CrossingFrame<PSimHit> const &cf = e.get(theConfig.GEMsimhitsXFToken_);
 
-      std::unique_ptr<MixCollection<PSimHit>> GEMsimhits(new MixCollection<PSimHit>(cf.product()));
+      std::unique_ptr<MixCollection<PSimHit>> GEMsimhits(new MixCollection<PSimHit>(&cf));
       LogTrace("GEMHitAssociator") << "... size = " << GEMsimhits->size();
 
       //   MixCollection<PSimHit> & simHits = *hits;
@@ -46,22 +37,19 @@ void GEMHitAssociator::initEvent(const edm::Event &e) {
         _SimHitMap[hitItr->detUnitId()].push_back(*hitItr);
       }
 
-    } else if (!GEMsimhitsTag.label().empty()) {
-      edm::Handle<edm::PSimHitContainer> GEMsimhits;
-      LogTrace("GEMHitAssociator") << "getting PSimHit collection - " << GEMsimhitsTag;
-      e.getByLabel(GEMsimhitsTag, GEMsimhits);
-      LogTrace("GEMHitAssociator") << "... size = " << GEMsimhits->size();
+    } else if (!theConfig.GEMsimhitsTag.label().empty()) {
+      LogTrace("GEMHitAssociator") << "getting PSimHit collection - " << theConfig.GEMsimhitsTag;
+      edm::PSimHitContainer const &GEMsimhits = e.get(theConfig.GEMsimhitsToken_);
+      LogTrace("GEMHitAssociator") << "... size = " << GEMsimhits.size();
 
       // arrange the hits by detUnit
-      for (edm::PSimHitContainer::const_iterator hitItr = GEMsimhits->begin(); hitItr != GEMsimhits->end(); ++hitItr) {
+      for (edm::PSimHitContainer::const_iterator hitItr = GEMsimhits.begin(); hitItr != GEMsimhits.end(); ++hitItr) {
         _SimHitMap[hitItr->detUnitId()].push_back(*hitItr);
       }
     }
 
-    edm::Handle<DigiSimLinks> digiSimLinks;
-    LogTrace("GEMHitAssociator") << "getting GEM Strip DigiSimLink collection - " << GEMdigisimlinkTag;
-    e.getByLabel(GEMdigisimlinkTag, digiSimLinks);
-    theDigiSimLinks = digiSimLinks.product();
+    LogTrace("GEMHitAssociator") << "getting GEM Strip DigiSimLink collection - " << theConfig.GEMdigisimlinkTag;
+    theDigiSimLinks = &e.get(theConfig.GEMdigisimlinkToken_);
   }
 }
 // end of constructor
@@ -69,7 +57,7 @@ void GEMHitAssociator::initEvent(const edm::Event &e) {
 std::vector<GEMHitAssociator::SimHitIdpr> GEMHitAssociator::associateRecHit(const GEMRecHit *gemrechit) const {
   std::vector<SimHitIdpr> matched;
 
-  if (useGEMs_) {
+  if (theConfig.useGEMs_) {
     if (gemrechit) {
       GEMDetId gemDetId = gemrechit->gemId();
       int fstrip = gemrechit->firstClusterStrip();

--- a/SimMuon/MCTruth/src/MuonAssociatorByHits.cc
+++ b/SimMuon/MCTruth/src/MuonAssociatorByHits.cc
@@ -137,9 +137,12 @@ namespace muonAssociatorByHitsDiagnostics {
 }  // namespace muonAssociatorByHitsDiagnostics
 
 MuonAssociatorByHits::MuonAssociatorByHits(const edm::ParameterSet &conf, edm::ConsumesCollector &&iC)
-    : helper_(conf), conf_(conf), trackerHitAssociatorConfig_(conf, std::move(iC)), gemHitAssociatorConfig_(conf, iC) {
+    : helper_(conf),
+      conf_(conf),
+      trackerHitAssociatorConfig_(conf, std::move(iC)),
+      gemHitAssociatorConfig_(conf, iC),
+      rpcHitAssociatorConfig_(conf, iC) {
   // hack for consumes
-  RPCHitAssociator rpctruth(conf, std::move(iC));
   DTHitAssociator dttruth(conf, std::move(iC));
   CSCHitAssociator muonTruth(conf, std::move(iC));
   if (conf.getUntrackedParameter<bool>("dumpInputCollections")) {
@@ -174,7 +177,7 @@ RecoToSimCollection MuonAssociatorByHits::associateRecoToSim(
   bool printRtS(true);
   DTHitAssociator dttruth(*e, *setup, conf_, printRtS);
   // RPC hit association
-  RPCHitAssociator rpctruth(*e, conf_);
+  RPCHitAssociator rpctruth(*e, rpcHitAssociatorConfig_);
   // GEM hit association
   GEMHitAssociator gemtruth(*e, gemHitAssociatorConfig_);
 
@@ -222,7 +225,7 @@ SimToRecoCollection MuonAssociatorByHits::associateSimToReco(
   bool printRtS = false;
   DTHitAssociator dttruth(*e, *setup, conf_, printRtS);
   // RPC hit association
-  RPCHitAssociator rpctruth(*e, conf_);
+  RPCHitAssociator rpctruth(*e, rpcHitAssociatorConfig_);
   // GEM hit association
   GEMHitAssociator gemtruth(*e, gemHitAssociatorConfig_);
 

--- a/SimMuon/MCTruth/src/MuonAssociatorByHits.cc
+++ b/SimMuon/MCTruth/src/MuonAssociatorByHits.cc
@@ -175,9 +175,9 @@ RecoToSimCollection MuonAssociatorByHits::associateRecoToSim(
   bool printRtS(true);
   DTHitAssociator dttruth(*e, *setup, conf_, printRtS);
   // RPC hit association
-  RPCHitAssociator rpctruth(*e, *setup, conf_);
+  RPCHitAssociator rpctruth(*e, conf_);
   // GEM hit association
-  GEMHitAssociator gemtruth(*e, *setup, conf_);
+  GEMHitAssociator gemtruth(*e, conf_);
 
   MuonAssociatorByHitsHelper::Resources resources = {
       tTopo, &trackertruth, &csctruth, &dttruth, &rpctruth, &gemtruth, {}};
@@ -223,9 +223,9 @@ SimToRecoCollection MuonAssociatorByHits::associateSimToReco(
   bool printRtS = false;
   DTHitAssociator dttruth(*e, *setup, conf_, printRtS);
   // RPC hit association
-  RPCHitAssociator rpctruth(*e, *setup, conf_);
+  RPCHitAssociator rpctruth(*e, conf_);
   // GEM hit association
-  GEMHitAssociator gemtruth(*e, *setup, conf_);
+  GEMHitAssociator gemtruth(*e, conf_);
 
   MuonAssociatorByHitsHelper::Resources resources = {
       tTopo, &trackertruth, &csctruth, &dttruth, &rpctruth, &gemtruth, {}};

--- a/SimMuon/MCTruth/src/MuonAssociatorByHits.cc
+++ b/SimMuon/MCTruth/src/MuonAssociatorByHits.cc
@@ -137,10 +137,9 @@ namespace muonAssociatorByHitsDiagnostics {
 }  // namespace muonAssociatorByHitsDiagnostics
 
 MuonAssociatorByHits::MuonAssociatorByHits(const edm::ParameterSet &conf, edm::ConsumesCollector &&iC)
-    : helper_(conf), conf_(conf), trackerHitAssociatorConfig_(conf, std::move(iC)) {
+    : helper_(conf), conf_(conf), trackerHitAssociatorConfig_(conf, std::move(iC)), gemHitAssociatorConfig_(conf, iC) {
   // hack for consumes
   RPCHitAssociator rpctruth(conf, std::move(iC));
-  GEMHitAssociator gemtruth(conf, std::move(iC));
   DTHitAssociator dttruth(conf, std::move(iC));
   CSCHitAssociator muonTruth(conf, std::move(iC));
   if (conf.getUntrackedParameter<bool>("dumpInputCollections")) {
@@ -177,7 +176,7 @@ RecoToSimCollection MuonAssociatorByHits::associateRecoToSim(
   // RPC hit association
   RPCHitAssociator rpctruth(*e, conf_);
   // GEM hit association
-  GEMHitAssociator gemtruth(*e, conf_);
+  GEMHitAssociator gemtruth(*e, gemHitAssociatorConfig_);
 
   MuonAssociatorByHitsHelper::Resources resources = {
       tTopo, &trackertruth, &csctruth, &dttruth, &rpctruth, &gemtruth, {}};
@@ -225,7 +224,7 @@ SimToRecoCollection MuonAssociatorByHits::associateSimToReco(
   // RPC hit association
   RPCHitAssociator rpctruth(*e, conf_);
   // GEM hit association
-  GEMHitAssociator gemtruth(*e, conf_);
+  GEMHitAssociator gemtruth(*e, gemHitAssociatorConfig_);
 
   MuonAssociatorByHitsHelper::Resources resources = {
       tTopo, &trackertruth, &csctruth, &dttruth, &rpctruth, &gemtruth, {}};

--- a/SimMuon/MCTruth/src/MuonAssociatorByHits.cc
+++ b/SimMuon/MCTruth/src/MuonAssociatorByHits.cc
@@ -141,10 +141,10 @@ MuonAssociatorByHits::MuonAssociatorByHits(const edm::ParameterSet &conf, edm::C
       conf_(conf),
       trackerHitAssociatorConfig_(conf, std::move(iC)),
       gemHitAssociatorConfig_(conf, iC),
-      rpcHitAssociatorConfig_(conf, iC) {
+      rpcHitAssociatorConfig_(conf, iC),
+      cscHitAssociatorConfig_(conf, iC) {
   // hack for consumes
   DTHitAssociator dttruth(conf, std::move(iC));
-  CSCHitAssociator muonTruth(conf, std::move(iC));
   if (conf.getUntrackedParameter<bool>("dumpInputCollections")) {
     diagnostics_ = std::make_unique<InputDumper>(conf, std::move(iC));
   }
@@ -172,7 +172,7 @@ RecoToSimCollection MuonAssociatorByHits::associateRecoToSim(
   // Tracker hit association
   TrackerHitAssociator trackertruth(*e, trackerHitAssociatorConfig_);
   // CSC hit association
-  CSCHitAssociator csctruth(*e, *setup, conf_);
+  CSCHitAssociator csctruth(*e, *setup, cscHitAssociatorConfig_);
   // DT hit association
   bool printRtS(true);
   DTHitAssociator dttruth(*e, *setup, conf_, printRtS);
@@ -220,7 +220,7 @@ SimToRecoCollection MuonAssociatorByHits::associateSimToReco(
   // Tracker hit association
   TrackerHitAssociator trackertruth(*e, trackerHitAssociatorConfig_);
   // CSC hit association
-  CSCHitAssociator csctruth(*e, *setup, conf_);
+  CSCHitAssociator csctruth(*e, *setup, cscHitAssociatorConfig_);
   // DT hit association
   bool printRtS = false;
   DTHitAssociator dttruth(*e, *setup, conf_, printRtS);

--- a/SimMuon/MCTruth/src/MuonAssociatorByHits.cc
+++ b/SimMuon/MCTruth/src/MuonAssociatorByHits.cc
@@ -138,13 +138,12 @@ namespace muonAssociatorByHitsDiagnostics {
 
 MuonAssociatorByHits::MuonAssociatorByHits(const edm::ParameterSet &conf, edm::ConsumesCollector &&iC)
     : helper_(conf),
-      conf_(conf),
       trackerHitAssociatorConfig_(conf, std::move(iC)),
       gemHitAssociatorConfig_(conf, iC),
       rpcHitAssociatorConfig_(conf, iC),
-      cscHitAssociatorConfig_(conf, iC) {
+      cscHitAssociatorConfig_(conf, iC),
+      dtHitAssociatorConfig_(conf, iC) {
   // hack for consumes
-  DTHitAssociator dttruth(conf, std::move(iC));
   if (conf.getUntrackedParameter<bool>("dumpInputCollections")) {
     diagnostics_ = std::make_unique<InputDumper>(conf, std::move(iC));
   }
@@ -175,7 +174,7 @@ RecoToSimCollection MuonAssociatorByHits::associateRecoToSim(
   CSCHitAssociator csctruth(*e, *setup, cscHitAssociatorConfig_);
   // DT hit association
   bool printRtS(true);
-  DTHitAssociator dttruth(*e, *setup, conf_, printRtS);
+  DTHitAssociator dttruth(*e, *setup, dtHitAssociatorConfig_, printRtS);
   // RPC hit association
   RPCHitAssociator rpctruth(*e, rpcHitAssociatorConfig_);
   // GEM hit association
@@ -223,7 +222,7 @@ SimToRecoCollection MuonAssociatorByHits::associateSimToReco(
   CSCHitAssociator csctruth(*e, *setup, cscHitAssociatorConfig_);
   // DT hit association
   bool printRtS = false;
-  DTHitAssociator dttruth(*e, *setup, conf_, printRtS);
+  DTHitAssociator dttruth(*e, *setup, dtHitAssociatorConfig_, printRtS);
   // RPC hit association
   RPCHitAssociator rpctruth(*e, rpcHitAssociatorConfig_);
   // GEM hit association

--- a/SimMuon/MCTruth/src/MuonAssociatorByHits.cc
+++ b/SimMuon/MCTruth/src/MuonAssociatorByHits.cc
@@ -142,7 +142,8 @@ MuonAssociatorByHits::MuonAssociatorByHits(const edm::ParameterSet &conf, edm::C
       gemHitAssociatorConfig_(conf, iC),
       rpcHitAssociatorConfig_(conf, iC),
       cscHitAssociatorConfig_(conf, iC),
-      dtHitAssociatorConfig_(conf, iC) {
+      dtHitAssociatorConfig_(conf, iC),
+      ttopoToken_(iC.esConsumes()) {
   // hack for consumes
   if (conf.getUntrackedParameter<bool>("dumpInputCollections")) {
     diagnostics_ = std::make_unique<InputDumper>(conf, std::move(iC));
@@ -164,9 +165,7 @@ RecoToSimCollection MuonAssociatorByHits::associateRecoToSim(
   }
 
   // Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHand;
-  setup->get<TrackerTopologyRcd>().get(tTopoHand);
-  const TrackerTopology *tTopo = tTopoHand.product();
+  const TrackerTopology *tTopo = &setup->getData(ttopoToken_);
 
   // Tracker hit association
   TrackerHitAssociator trackertruth(*e, trackerHitAssociatorConfig_);
@@ -212,9 +211,7 @@ SimToRecoCollection MuonAssociatorByHits::associateSimToReco(
   }
 
   // Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHand;
-  setup->get<TrackerTopologyRcd>().get(tTopoHand);
-  const TrackerTopology *tTopo = tTopoHand.product();
+  const TrackerTopology *tTopo = &setup->getData(ttopoToken_);
 
   // Tracker hit association
   TrackerHitAssociator trackertruth(*e, trackerHitAssociatorConfig_);

--- a/SimMuon/MCTruth/src/RPCHitAssociator.cc
+++ b/SimMuon/MCTruth/src/RPCHitAssociator.cc
@@ -4,12 +4,12 @@
 using namespace std;
 
 // Constructor
-RPCHitAssociator::RPCHitAssociator(const edm::ParameterSet &conf, edm::ConsumesCollector &&iC)
+RPCHitAssociator::Config::Config(const edm::ParameterSet &conf, edm::ConsumesCollector iC)
     : RPCdigisimlinkTag(conf.getParameter<edm::InputTag>("RPCdigisimlinkTag")),
       // CrossingFrame used or not ?
-      crossingframe(conf.getParameter<bool>("crossingframe")),
       RPCsimhitsTag(conf.getParameter<edm::InputTag>("RPCsimhitsTag")),
-      RPCsimhitsXFTag(conf.getParameter<edm::InputTag>("RPCsimhitsXFTag")) {
+      RPCsimhitsXFTag(conf.getParameter<edm::InputTag>("RPCsimhitsXFTag")),
+      crossingframe(conf.getParameter<bool>("crossingframe")) {
   if (crossingframe) {
     RPCsimhitsXFToken_ = iC.consumes<CrossingFrame<PSimHit>>(RPCsimhitsXFTag);
   } else if (!RPCsimhitsTag.label().empty()) {
@@ -19,24 +19,16 @@ RPCHitAssociator::RPCHitAssociator(const edm::ParameterSet &conf, edm::ConsumesC
   RPCdigisimlinkToken_ = iC.consumes<edm::DetSetVector<RPCDigiSimLink>>(RPCdigisimlinkTag);
 }
 
-RPCHitAssociator::RPCHitAssociator(const edm::Event &e, const edm::ParameterSet &conf)
-    : RPCdigisimlinkTag(conf.getParameter<edm::InputTag>("RPCdigisimlinkTag")),
-      // CrossingFrame used or not ?
-      crossingframe(conf.getParameter<bool>("crossingframe")),
-      RPCsimhitsTag(conf.getParameter<edm::InputTag>("RPCsimhitsTag")),
-      RPCsimhitsXFTag(conf.getParameter<edm::InputTag>("RPCsimhitsXFTag")) {
-  initEvent(e);
-}
+RPCHitAssociator::RPCHitAssociator(const edm::Event &e, const Config &conf) : theConfig(conf) { initEvent(e); }
 
 void RPCHitAssociator::initEvent(const edm::Event &e)
 
 {
-  if (crossingframe) {
-    edm::Handle<CrossingFrame<PSimHit>> cf;
-    LogTrace("RPCHitAssociator") << "getting CrossingFrame<PSimHit> collection - " << RPCsimhitsXFTag;
-    e.getByLabel(RPCsimhitsXFTag, cf);
+  if (theConfig.crossingframe) {
+    LogTrace("RPCHitAssociator") << "getting CrossingFrame<PSimHit> collection - " << theConfig.RPCsimhitsXFTag;
+    CrossingFrame<PSimHit> const &cf = e.get(theConfig.RPCsimhitsXFToken_);
 
-    std::unique_ptr<MixCollection<PSimHit>> RPCsimhits(new MixCollection<PSimHit>(cf.product()));
+    std::unique_ptr<MixCollection<PSimHit>> RPCsimhits(new MixCollection<PSimHit>(&cf));
     LogTrace("RPCHitAssociator") << "... size = " << RPCsimhits->size();
 
     //   MixCollection<PSimHit> & simHits = *hits;
@@ -45,22 +37,19 @@ void RPCHitAssociator::initEvent(const edm::Event &e)
       _SimHitMap[hitItr->detUnitId()].push_back(*hitItr);
     }
 
-  } else if (!RPCsimhitsTag.label().empty()) {
-    edm::Handle<edm::PSimHitContainer> RPCsimhits;
-    LogTrace("RPCHitAssociator") << "getting PSimHit collection - " << RPCsimhitsTag;
-    e.getByLabel(RPCsimhitsTag, RPCsimhits);
-    LogTrace("RPCHitAssociator") << "... size = " << RPCsimhits->size();
+  } else if (!theConfig.RPCsimhitsTag.label().empty()) {
+    LogTrace("RPCHitAssociator") << "getting PSimHit collection - " << theConfig.RPCsimhitsTag;
+    edm::PSimHitContainer const &RPCsimhits = e.get(theConfig.RPCsimhitsToken_);
+    LogTrace("RPCHitAssociator") << "... size = " << RPCsimhits.size();
 
     // arrange the hits by detUnit
-    for (edm::PSimHitContainer::const_iterator hitItr = RPCsimhits->begin(); hitItr != RPCsimhits->end(); ++hitItr) {
+    for (edm::PSimHitContainer::const_iterator hitItr = RPCsimhits.begin(); hitItr != RPCsimhits.end(); ++hitItr) {
       _SimHitMap[hitItr->detUnitId()].push_back(*hitItr);
     }
   }
 
-  edm::Handle<edm::DetSetVector<RPCDigiSimLink>> thelinkDigis;
-  LogTrace("RPCHitAssociator") << "getting RPCDigiSimLink collection - " << RPCdigisimlinkTag;
-  e.getByLabel(RPCdigisimlinkTag, thelinkDigis);
-  _thelinkDigis = thelinkDigis;
+  LogTrace("RPCHitAssociator") << "getting RPCDigiSimLink collection - " << theConfig.RPCdigisimlinkTag;
+  _thelinkDigis = e.getHandle(theConfig.RPCdigisimlinkToken_);
 }
 // end of constructor
 

--- a/SimMuon/MCTruth/src/RPCHitAssociator.cc
+++ b/SimMuon/MCTruth/src/RPCHitAssociator.cc
@@ -19,18 +19,16 @@ RPCHitAssociator::RPCHitAssociator(const edm::ParameterSet &conf, edm::ConsumesC
   RPCdigisimlinkToken_ = iC.consumes<edm::DetSetVector<RPCDigiSimLink>>(RPCdigisimlinkTag);
 }
 
-RPCHitAssociator::RPCHitAssociator(const edm::Event &e,
-                                   const edm::EventSetup &eventSetup,
-                                   const edm::ParameterSet &conf)
+RPCHitAssociator::RPCHitAssociator(const edm::Event &e, const edm::ParameterSet &conf)
     : RPCdigisimlinkTag(conf.getParameter<edm::InputTag>("RPCdigisimlinkTag")),
       // CrossingFrame used or not ?
       crossingframe(conf.getParameter<bool>("crossingframe")),
       RPCsimhitsTag(conf.getParameter<edm::InputTag>("RPCsimhitsTag")),
       RPCsimhitsXFTag(conf.getParameter<edm::InputTag>("RPCsimhitsXFTag")) {
-  initEvent(e, eventSetup);
+  initEvent(e);
 }
 
-void RPCHitAssociator::initEvent(const edm::Event &e, const edm::EventSetup &eventSetup)
+void RPCHitAssociator::initEvent(const edm::Event &e)
 
 {
   if (crossingframe) {

--- a/SimMuon/MCTruth/src/TrackerMuonHitExtractor.cc
+++ b/SimMuon/MCTruth/src/TrackerMuonHitExtractor.cc
@@ -27,7 +27,7 @@ TrackerMuonHitExtractor::TrackerMuonHitExtractor(const edm::ParameterSet &parset
 
 TrackerMuonHitExtractor::~TrackerMuonHitExtractor() {}
 
-void TrackerMuonHitExtractor::init(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
+void TrackerMuonHitExtractor::init(const edm::Event &iEvent) {
   iEvent.getByLabel(inputDTRecSegment4DCollection_, dtSegmentCollectionH_);
   iEvent.getByLabel(inputCSCSegmentCollection_, cscSegmentCollectionH_);
 


### PR DESCRIPTION
#### PR description:

- refactored some of the hit associators to make it easier to deal with esConsumes
- added esConsumes to the modules
- some random code improvements
#### PR validation:

The code compiles.