### PR TITLE
Add CSC TP efficiency producer in standard Validation sequence

### DIFF
--- a/Validation/Configuration/python/postValidation_cff.py
+++ b/Validation/Configuration/python/postValidation_cff.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from Validation.RecoMuon.PostProcessor_cff import *
 from Validation.RecoTrack.PostProcessorTracker_cfi import *
 from Validation.MuonIsolation.PostProcessor_cff import *
+from Validation.MuonCSCDigis.PostProcessor_cff import *
 from Validation.CaloTowers.CaloTowersPostProcessor_cff import *
 from Validation.HcalHits.SimHitsPostProcessor_cff import *
 from Validation.HcalDigis.HcalDigisPostProcessor_cff import *
@@ -43,6 +44,7 @@ postValidation = cms.Sequence(
     + METPostProcessor
     + L1GenPostProcessor
     + bdHadronTrackPostProcessor
+    + MuonCSCDigisPostProcessors
 )
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 
@@ -66,7 +68,6 @@ from Validation.MuonGEMHits.PostProcessor_cff import *
 from Validation.MuonGEMDigis.PostProcessor_cff import *
 from Validation.MuonGEMRecHits.PostProcessor_cff import *
 from Validation.MuonME0Validation.PostProcessor_cff import *
-from Validation.MuonCSCDigis.PostProcessor_cff import *
 from Validation.HGCalValidation.HGCalPostProcessor_cff import *
 from Validation.MtdValidation.MtdPostProcessor_cff import *
 

--- a/Validation/MuonCSCDigis/src/CSCStubEfficiencyValidation.cc
+++ b/Validation/MuonCSCDigis/src/CSCStubEfficiencyValidation.cc
@@ -48,6 +48,10 @@ void CSCStubEfficiencyValidation::bookHistograms(DQMStore::IBooker& iBooker) {
     etaCLCTDenom[j] = iBooker.book1D(t2, t2 + ";True Muon |#eta|; Entries", 50, etaMins_[j], etaMaxs_[j]);
     etaLCTDenom[j] = iBooker.book1D(t3, t3 + ";True Muon |#eta|; Entries", 50, etaMins_[j], etaMaxs_[j]);
 
+    etaALCTDenom[j]->getTH1()->SetMinimum(0);
+    etaCLCTDenom[j]->getTH1()->SetMinimum(0);
+    etaLCTDenom[j]->getTH1()->SetMinimum(0);
+
     t1 = "ALCTEtaNum_" + cn;
     t2 = "CLCTEtaNum_" + cn;
     t3 = "LCTEtaNum_" + cn;
@@ -55,6 +59,10 @@ void CSCStubEfficiencyValidation::bookHistograms(DQMStore::IBooker& iBooker) {
     etaALCTNum[j] = iBooker.book1D(t1, t1 + ";True Muon |#eta|; Entries", 50, etaMins_[j], etaMaxs_[j]);
     etaCLCTNum[j] = iBooker.book1D(t2, t2 + ";True Muon |#eta|; Entries", 50, etaMins_[j], etaMaxs_[j]);
     etaLCTNum[j] = iBooker.book1D(t3, t3 + ";True Muon |#eta|; Entries", 50, etaMins_[j], etaMaxs_[j]);
+
+    etaALCTNum[j]->getTH1()->SetMinimum(0);
+    etaCLCTNum[j]->getTH1()->SetMinimum(0);
+    etaLCTNum[j]->getTH1()->SetMinimum(0);
   }
 }
 


### PR DESCRIPTION
#### PR description:

We noticed that the efficiencies for the CSC TP efficiencies were not being added in the Validation step. There is an occupancy directory with denominators and numerators. There should be an efficiency directory with plots as well, but clearly it's not there. This PR fixes that. 

<img width="975" alt="Screen Shot 2021-09-02 at 12 49 09 PM" src="https://user-images.githubusercontent.com/4134786/131901558-33e313dc-88ba-4933-867d-5addf5f4136d.png">

Denominators and numerators

<img width="990" alt="Screen Shot 2021-09-02 at 12 51 46 PM" src="https://user-images.githubusercontent.com/4134786/131901671-73f488ea-43fb-49f2-bd5e-67ecc1a0b863.png">

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
