### PR TITLE
Partial esConsumes migration for TrajectorySeedProducer

### DIFF
--- a/FastSimulation/Tracking/interface/SeedFinderSelector.h
+++ b/FastSimulation/Tracking/interface/SeedFinderSelector.h
@@ -6,32 +6,29 @@
 #include <string>
 
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/SeedingLayerSetsHits.h"
+#include "RecoTracker/MeasurementDet/interface/MeasurementTracker.h"
+#include "RecoTracker/Record/interface/CkfComponentsRecord.h"
 #include "RecoTracker/TkSeedingLayers/interface/SeedingLayerSetsBuilder.h"
+#include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 
 class TrackingRegion;
 class FastTrackerRecHit;
 class MultiHitGeneratorFromPairAndLayers;
 class HitTripletGeneratorFromPairAndLayers;
-class MeasurementTracker;
 class CAHitTripletGenerator;
 class CAHitQuadrupletGenerator;
 
-namespace edm {
-  class Event;
-  class EventSetup;
-  class ParameterSet;
-  class ConsumesCollector;
-}  // namespace edm
-
 class SeedFinderSelector {
 public:
-  SeedFinderSelector(const edm::ParameterSet& cfg, edm::ConsumesCollector&& consumesCollector);
+  SeedFinderSelector(const edm::ParameterSet&, edm::ConsumesCollector&&);
 
   ~SeedFinderSelector();
 
-  void initEvent(const edm::Event& ev, const edm::EventSetup& es);
+  void initEvent(const edm::Event&, const edm::EventSetup&);
 
   void setTrackingRegion(const TrackingRegion* trackingRegion) { trackingRegion_ = trackingRegion; }
 
@@ -46,12 +43,14 @@ private:
   const edm::EventSetup* eventSetup_;
   const MeasurementTracker* measurementTracker_;
   const std::string measurementTrackerLabel_;
+  const edm::ESGetToken<MeasurementTracker, CkfComponentsRecord> measurementTrackerESToken_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopologyESToken_;
+  const TrackerTopology* trackerTopology_ = nullptr;
   std::unique_ptr<CAHitTripletGenerator> CAHitTriplGenerator_;
   std::unique_ptr<CAHitQuadrupletGenerator> CAHitQuadGenerator_;
   std::unique_ptr<SeedingLayerSetsBuilder> seedingLayers_;
   std::unique_ptr<SeedingLayerSetsHits> seedingLayer;
   std::vector<unsigned> layerPairs_;
-  edm::ESHandle<TrackerTopology> trackerTopology;
   std::vector<SeedingLayerSetsBuilder::SeedingLayerId> seedingLayerIds;
 };
 

--- a/FastSimulation/Tracking/src/SeedFinderSelector.cc
+++ b/FastSimulation/Tracking/src/SeedFinderSelector.cc
@@ -1,17 +1,16 @@
 #include "FastSimulation/Tracking/interface/SeedFinderSelector.h"
 
 // framework
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Event.h"
 
 // track reco
-#include "RecoTracker/MeasurementDet/interface/MeasurementTracker.h"
 #include "RecoTracker/TkHitPairs/interface/RecHitsSortedInPhi.h"
 #include "RecoTracker/TkHitPairs/interface/HitPairGeneratorFromLayerPair.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 #include "RecoTracker/TkSeedGenerator/interface/MultiHitGeneratorFromPairAndLayers.h"
 #include "RecoTracker/TkSeedGenerator/interface/MultiHitGeneratorFromPairAndLayersFactory.h"
-#include "RecoTracker/Record/interface/CkfComponentsRecord.h"
 #include "RecoPixelVertexing/PixelTriplets/interface/HitTripletGeneratorFromPairAndLayers.h"
 #include "RecoPixelVertexing/PixelTriplets/interface/HitTripletGeneratorFromPairAndLayersFactory.h"
 #include "RecoPixelVertexing/PixelTriplets/interface/CAHitTripletGenerator.h"
@@ -25,7 +24,9 @@ SeedFinderSelector::SeedFinderSelector(const edm::ParameterSet &cfg, edm::Consum
     : trackingRegion_(nullptr),
       eventSetup_(nullptr),
       measurementTracker_(nullptr),
-      measurementTrackerLabel_(cfg.getParameter<std::string>("measurementTracker")) {
+      measurementTrackerLabel_(cfg.getParameter<std::string>("measurementTracker")),
+      measurementTrackerESToken_(consumesCollector.esConsumes(edm::ESInputTag("", measurementTrackerLabel_))),
+      trackerTopologyESToken_(consumesCollector.esConsumes()) {
   if (cfg.exists("pixelTripletGeneratorFactory")) {
     const edm::ParameterSet &tripletConfig = cfg.getParameter<edm::ParameterSet>("pixelTripletGeneratorFactory");
     pixelTripletGenerator_ = HitTripletGeneratorFromPairAndLayersFactory::get()->create(
@@ -35,7 +36,7 @@ SeedFinderSelector::SeedFinderSelector(const edm::ParameterSet &cfg, edm::Consum
   if (cfg.exists("MultiHitGeneratorFactory")) {
     const edm::ParameterSet &tripletConfig = cfg.getParameter<edm::ParameterSet>("MultiHitGeneratorFactory");
     multiHitGenerator_ = MultiHitGeneratorFromPairAndLayersFactory::get()->create(
-        tripletConfig.getParameter<std::string>("ComponentName"), tripletConfig);
+        tripletConfig.getParameter<std::string>("ComponentName"), tripletConfig, consumesCollector);
   }
 
   if (cfg.exists("CAHitTripletGeneratorFactory")) {
@@ -77,10 +78,8 @@ SeedFinderSelector::~SeedFinderSelector() { ; }
 void SeedFinderSelector::initEvent(const edm::Event &ev, const edm::EventSetup &es) {
   eventSetup_ = &es;
 
-  edm::ESHandle<MeasurementTracker> measurementTrackerHandle;
-  es.get<CkfComponentsRecord>().get(measurementTrackerLabel_, measurementTrackerHandle);
-  es.get<TrackerTopologyRcd>().get(trackerTopology);
-  measurementTracker_ = &(*measurementTrackerHandle);
+  measurementTracker_ = &es.getData(measurementTrackerESToken_);
+  trackerTopology_ = &es.getData(trackerTopologyESToken_);
 
   if (multiHitGenerator_) {
     multiHitGenerator_->initES(es);
@@ -320,7 +319,6 @@ bool SeedFinderSelector::pass(const std::vector<const FastTrackerRecHit *> &hits
 
 //new for Phase1
 SeedingLayerSetsBuilder::SeedingLayerId SeedFinderSelector::Layer_tuple(const FastTrackerRecHit *hit) const {
-  const TrackerTopology *const tTopo = trackerTopology.product();
   GeomDetEnumerators::SubDetector subdet = GeomDetEnumerators::invalidDet;
   TrackerDetSide side = TrackerDetSide::Barrel;
   int idLayer = 0;
@@ -328,11 +326,11 @@ SeedingLayerSetsBuilder::SeedingLayerId SeedFinderSelector::Layer_tuple(const Fa
   if ((hit->det()->geographicalId()).subdetId() == PixelSubdetector::PixelBarrel) {
     subdet = GeomDetEnumerators::PixelBarrel;
     side = TrackerDetSide::Barrel;
-    idLayer = tTopo->pxbLayer(hit->det()->geographicalId());
+    idLayer = trackerTopology_->pxbLayer(hit->det()->geographicalId());
   } else if ((hit->det()->geographicalId()).subdetId() == PixelSubdetector::PixelEndcap) {
     subdet = GeomDetEnumerators::PixelEndcap;
-    idLayer = tTopo->pxfDisk(hit->det()->geographicalId());
-    if (tTopo->pxfSide(hit->det()->geographicalId()) == 1) {
+    idLayer = trackerTopology_->pxfDisk(hit->det()->geographicalId());
+    if (trackerTopology_->pxfSide(hit->det()->geographicalId()) == 1) {
       side = TrackerDetSide::NegEndcap;
     } else {
       side = TrackerDetSide::PosEndcap;

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGFromOrderedHits.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGFromOrderedHits.cc
@@ -1,5 +1,7 @@
 #include "TSGFromOrderedHits.h"
 
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
 #include "RecoTracker/TkTrackingRegions/interface/OrderedHitsGeneratorFactory.h"
 #include "RecoTracker/TkTrackingRegions/interface/OrderedHitsGenerator.h"
@@ -19,7 +21,7 @@ TSGFromOrderedHits::TSGFromOrderedHits(const edm::ParameterSet &pset, edm::Consu
   theGenerator = std::make_unique<SeedGeneratorFromRegionHits>(
       OrderedHitsGeneratorFactory::get()->create(hitsfactoryName, hitsfactoryPSet, iC),
       nullptr,
-      SeedCreatorFactory::get()->create(seedCreatorType, seedCreatorPSet));
+      SeedCreatorFactory::get()->create(seedCreatorType, seedCreatorPSet, edm::ConsumesCollector(iC)));
 }
 
 TSGFromOrderedHits::~TSGFromOrderedHits() = default;

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGFromOrderedHits.h
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGFromOrderedHits.h
@@ -2,9 +2,8 @@
 #define RecoMuon_TrackerSeedGenerator_TSGFromOrderedHits_H
 
 #include "RecoMuon/TrackerSeedGenerator/interface/TrackerSeedGenerator.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
 #include "DataFormats/Provenance/interface/RunID.h"
-#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 class SeedGeneratorFromRegionHits;
 class TrackingRegion;

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGSmart.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGSmart.cc
@@ -1,5 +1,6 @@
 #include "RecoMuon/TrackerSeedGenerator/plugins/TSGSmart.h"
 
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
 #include "RecoTracker/TkTrackingRegions/interface/OrderedHitsGeneratorFactory.h"
 #include "RecoTracker/TkTrackingRegions/interface/OrderedHitsGenerator.h"
@@ -20,7 +21,7 @@ TSGSmart::TSGSmart(const edm::ParameterSet &pset, edm::ConsumesCollector &iC) {
   thePairGenerator = std::make_unique<SeedGeneratorFromRegionHits>(
       OrderedHitsGeneratorFactory::get()->create(pairhitsfactoryName, pairhitsfactoryPSet, iC),
       nullptr,
-      SeedCreatorFactory::get()->create("SeedFromConsecutiveHitsCreator", creatorPSet));
+      SeedCreatorFactory::get()->create("SeedFromConsecutiveHitsCreator", creatorPSet, edm::ConsumesCollector(iC)));
 
   edm::ParameterSet TripletPSet = pset.getParameter<edm::ParameterSet>("PixelTripletGeneratorSet");
   edm::ParameterSet triplethitsfactoryPSet = TripletPSet.getParameter<edm::ParameterSet>("OrderedHitsFactoryPSet");
@@ -29,7 +30,7 @@ TSGSmart::TSGSmart(const edm::ParameterSet &pset, edm::ConsumesCollector &iC) {
   theTripletGenerator = std::make_unique<SeedGeneratorFromRegionHits>(
       OrderedHitsGeneratorFactory::get()->create(triplethitsfactoryName, triplethitsfactoryPSet, iC),
       nullptr,
-      SeedCreatorFactory::get()->create("SeedFromConsecutiveHitsCreator", creatorPSet));
+      SeedCreatorFactory::get()->create("SeedFromConsecutiveHitsCreator", creatorPSet, edm::ConsumesCollector(iC)));
 
   edm::ParameterSet MixedPSet = pset.getParameter<edm::ParameterSet>("MixedGeneratorSet");
   edm::ParameterSet mixedhitsfactoryPSet = MixedPSet.getParameter<edm::ParameterSet>("OrderedHitsFactoryPSet");
@@ -38,7 +39,7 @@ TSGSmart::TSGSmart(const edm::ParameterSet &pset, edm::ConsumesCollector &iC) {
   theMixedGenerator = std::make_unique<SeedGeneratorFromRegionHits>(
       OrderedHitsGeneratorFactory::get()->create(mixedhitsfactoryName, mixedhitsfactoryPSet, iC),
       nullptr,
-      SeedCreatorFactory::get()->create("SeedFromConsecutiveHitsCreator", creatorPSet));
+      SeedCreatorFactory::get()->create("SeedFromConsecutiveHitsCreator", creatorPSet, edm::ConsumesCollector(iC)));
 }
 
 TSGSmart::~TSGSmart() = default;

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGSmart.h
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGSmart.h
@@ -2,6 +2,7 @@
 #define RecoMuon_TrackerSeedGenerator_TSGSmart_H
 
 #include "RecoMuon/TrackerSeedGenerator/interface/TrackerSeedGenerator.h"
+#include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 class SeedGeneratorFromRegionHits;

--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/LowPtClusterShapeSeedComparitor.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/LowPtClusterShapeSeedComparitor.h
@@ -2,18 +2,15 @@
 #define _LowPtClusterShapeSeedComparitor_h_
 
 #include "RecoTracker/TkSeedingLayers/interface/SeedComparitor.h"
-#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/SiPixelCluster/interface/SiPixelClusterShapeCache.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeHitFilter.h"
-
-class TrackerTopology;
-
-namespace edm {
-  class ParameterSet;
-  class EventSetup;
-}  // namespace edm
+#include "RecoTracker/Record/interface/CkfComponentsRecord.h"
 
 class LowPtClusterShapeSeedComparitor : public SeedComparitor {
 public:
@@ -31,12 +28,13 @@ public:
   }
 
 private:
-  /// something
-  edm::ESHandle<ClusterShapeHitFilter> theShapeFilter;
-  edm::ESHandle<TrackerTopology> theTTopo;
   edm::EDGetTokenT<SiPixelClusterShapeCache> thePixelClusterShapeCacheToken;
   edm::Handle<SiPixelClusterShapeCache> thePixelClusterShapeCache;
   std::string theShapeFilterLabel_;
+  const edm::ESGetToken<ClusterShapeHitFilter, CkfComponentsRecord> clusterShapeHitFilterESToken_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopologyESToken_;
+  const ClusterShapeHitFilter *clusterShapeHitFilter_ = nullptr;
+  const TrackerTopology *trackerTopology_ = nullptr;
 };
 
 #endif

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.cc
@@ -1,15 +1,14 @@
 #include "RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.h"
 #include "RecoTracker/TkHitPairs/interface/HitPairGeneratorFromLayerPair.h"
-#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 #include "RecoPixelVertexing/PixelTriplets/interface/ThirdHitPredictionFromCircle.h"
 #include "RecoPixelVertexing/PixelTriplets/interface/ThirdHitRZPrediction.h"
 #include "RecoTracker/TkMSParametrization/interface/PixelRecoUtilities.h"
-#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "RecoPixelVertexing/PixelTriplets/plugins/ThirdHitCorrection.h"
 #include "RecoTracker/TkHitPairs/interface/RecHitsSortedInPhi.h"
 
@@ -51,7 +50,8 @@ PixelTripletLargeTipGenerator::PixelTripletLargeTipGenerator(const edm::Paramete
       extraHitRPhitolerance(cfg.getParameter<double>("extraHitRPhitolerance")),
       useMScat(cfg.getParameter<bool>("useMultScattering")),
       useBend(cfg.getParameter<bool>("useBending")),
-      dphi(useFixedPreFiltering ? cfg.getParameter<double>("phiPreFiltering") : 0) {}
+      dphi(useFixedPreFiltering ? cfg.getParameter<double>("phiPreFiltering") : 0),
+      trackerTopologyESToken_(iC.esConsumes()) {}
 
 PixelTripletLargeTipGenerator::~PixelTripletLargeTipGenerator() {}
 
@@ -130,13 +130,7 @@ void PixelTripletLargeTipGenerator::hitTriplets(const TrackingRegion& region,
                                                 const std::vector<const DetLayer*>& thirdLayerDetLayer,
                                                 const int nThirdLayers,
                                                 std::vector<int>* tripletLastLayerIndex) {
-  edm::ESHandle<TrackerGeometry> tracker;
-  es.get<TrackerDigiGeometryRecord>().get(tracker);
-
-  //Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHand;
-  es.get<TrackerTopologyRcd>().get(tTopoHand);
-  const TrackerTopology* tTopo = tTopoHand.product();
+  const TrackerTopology* tTopo = &es.getData(trackerTopologyESToken_);
 
   auto outSeq = doublets.detLayer(HitDoublets::outer)->seqNum();
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.h
@@ -8,8 +8,10 @@
  */
 
 #include "CombinedHitTripletGenerator.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "RecoPixelVertexing/PixelTriplets/interface/HitTripletGeneratorFromPairAndLayers.h"
 
 #include <utility>
@@ -68,5 +70,7 @@ private:
   const bool useMScat;
   const bool useBend;
   const float dphi;
+
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopologyESToken_;
 };
 #endif

--- a/RecoTracker/SpecialSeedGenerators/interface/CosmicSeedCreator.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/CosmicSeedCreator.h
@@ -3,13 +3,14 @@
 
 #include "RecoTracker/TkSeedGenerator/interface/SeedCreator.h"
 #include "RecoTracker/TkSeedingLayers/interface/SeedComparitor.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 
 class CosmicSeedCreator final : public SeedCreator {
 public:
-  CosmicSeedCreator(const edm::ParameterSet &extra) { maxseeds_ = extra.getParameter<int>("maxseeds"); }
+  CosmicSeedCreator(const edm::ParameterSet &extra, edm::ConsumesCollector &&);
 
   ~CosmicSeedCreator() override {}
 
@@ -23,7 +24,9 @@ public:
 private:
   const TrackingRegion *region = nullptr;
   const SeedComparitor *filter = nullptr;
-  edm::ESHandle<MagneticField> bfield;
+  const MagneticField *bfield = nullptr;
+
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magneticFieldESToken_;
 
   unsigned int maxseeds_;
 };

--- a/RecoTracker/TkSeedGenerator/interface/MultiHitGeneratorFromPairAndLayersFactory.h
+++ b/RecoTracker/TkSeedGenerator/interface/MultiHitGeneratorFromPairAndLayersFactory.h
@@ -2,13 +2,15 @@
 #define MultiHitGeneratorFromPairAndLayersFactory_H
 
 #include "RecoTracker/TkSeedGenerator/interface/MultiHitGeneratorFromPairAndLayers.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 
 namespace edm {
   class ParameterSet;
 }
 
-typedef edmplugin::PluginFactory<MultiHitGeneratorFromPairAndLayers *(const edm::ParameterSet &)>
+typedef edmplugin::PluginFactory<MultiHitGeneratorFromPairAndLayers *(const edm::ParameterSet &,
+                                                                      edm::ConsumesCollector &)>
     MultiHitGeneratorFromPairAndLayersFactory;
 
 #endif

--- a/RecoTracker/TkSeedGenerator/interface/SeedCreator.h
+++ b/RecoTracker/TkSeedGenerator/interface/SeedCreator.h
@@ -8,7 +8,6 @@ class SeedingHitSet;
 class SeedComparitor;
 
 namespace edm {
-  class Event;
   class EventSetup;
 }  // namespace edm
 

--- a/RecoTracker/TkSeedGenerator/interface/SeedCreatorFactory.h
+++ b/RecoTracker/TkSeedGenerator/interface/SeedCreatorFactory.h
@@ -3,11 +3,11 @@
 
 #include "RecoTracker/TkSeedGenerator/interface/SeedCreator.h"
 #include "FWCore/PluginManager/interface/PluginFactory.h"
-
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 namespace edm {
   class ParameterSet;
 }
 
-typedef edmplugin::PluginFactory<SeedCreator *(const edm::ParameterSet &)> SeedCreatorFactory;
+typedef edmplugin::PluginFactory<SeedCreator *(const edm::ParameterSet &, edm::ConsumesCollector &&)> SeedCreatorFactory;
 
 #endif

--- a/RecoTracker/TkSeedGenerator/interface/SeedCreatorFromRegionHitsEDProducerT.h
+++ b/RecoTracker/TkSeedGenerator/interface/SeedCreatorFromRegionHitsEDProducerT.h
@@ -37,7 +37,7 @@ template <typename T_SeedCreator>
 SeedCreatorFromRegionHitsEDProducerT<T_SeedCreator>::SeedCreatorFromRegionHitsEDProducerT(
     const edm::ParameterSet& iConfig)
     : seedingHitSetsToken_(consumes<RegionsSeedingHitSets>(iConfig.getParameter<edm::InputTag>("seedingHitSets"))),
-      seedCreator_(iConfig) {
+      seedCreator_(iConfig, consumesCollector()) {
   edm::ConsumesCollector iC = consumesCollector();
   edm::ParameterSet comparitorPSet = iConfig.getParameter<edm::ParameterSet>("SeedComparitorPSet");
   std::string comparitorName = comparitorPSet.getParameter<std::string>("ComponentName");

--- a/RecoTracker/TkSeedGenerator/plugins/CombinedMultiHitGenerator.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/CombinedMultiHitGenerator.cc
@@ -12,7 +12,7 @@ CombinedMultiHitGenerator::CombinedMultiHitGenerator(const edm::ParameterSet& cf
     : theSeedingLayerToken(iC.consumes<SeedingLayerSetsHits>(cfg.getParameter<edm::InputTag>("SeedingLayers"))) {
   edm::ParameterSet generatorPSet = cfg.getParameter<edm::ParameterSet>("GeneratorPSet");
   std::string generatorName = generatorPSet.getParameter<std::string>("ComponentName");
-  theGenerator = MultiHitGeneratorFromPairAndLayersFactory::get()->create(generatorName, generatorPSet);
+  theGenerator = MultiHitGeneratorFromPairAndLayersFactory::get()->create(generatorName, generatorPSet, iC);
   theGenerator->init(std::make_unique<HitPairGeneratorFromLayerPair>(0, 1, &theLayerCache), &theLayerCache);
 }
 

--- a/RecoTracker/TkSeedGenerator/plugins/MultiHitFromChi2EDProducer.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/MultiHitFromChi2EDProducer.cc
@@ -33,7 +33,7 @@ private:
 
 MultiHitFromChi2EDProducer::MultiHitFromChi2EDProducer(const edm::ParameterSet& iConfig)
     : doubletToken_(consumes<IntermediateHitDoublets>(iConfig.getParameter<edm::InputTag>("doublets"))),
-      generator_(iConfig) {
+      generator_(iConfig, consumesCollector()) {
   produces<RegionsSeedingHitSets>();
   produces<edm::OwnVector<BaseTrackerRecHit> >();
 }

--- a/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.h
+++ b/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.h
@@ -10,15 +10,22 @@
 
 #include "RecoTracker/TkSeedGenerator/interface/MultiHitGenerator.h"
 #include "CombinedMultiHitGenerator.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "RecoTracker/TkSeedGenerator/interface/MultiHitGeneratorFromPairAndLayers.h"
 #include "RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeHitFilter.h"
+#include "RecoTracker/Record/interface/CkfComponentsRecord.h"
 #include "RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h"
+#include "TrackingTools/Records/interface/TransientRecHitRecord.h"
+#include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
 
 #include "DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h"
 #include "DataFormats/TrackingRecHit/interface/mayown_ptr.h"
 
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "MagneticField/UniformEngine/interface/UniformMagneticField.h"
 
 #include <utility>
@@ -30,7 +37,9 @@ class dso_hidden MultiHitGeneratorFromChi2 final : public MultiHitGeneratorFromP
   typedef CombinedMultiHitGenerator::LayerCacheType LayerCacheType;
 
 public:
-  MultiHitGeneratorFromChi2(const edm::ParameterSet& cfg);
+  MultiHitGeneratorFromChi2(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC)
+      : MultiHitGeneratorFromChi2(cfg, iC) {}
+  MultiHitGeneratorFromChi2(const edm::ParameterSet& cfg, edm::ConsumesCollector&);
 
   ~MultiHitGeneratorFromChi2() override;
 
@@ -119,5 +128,9 @@ private:
   std::string mfName_;
 
   std::vector<int> detIdsToDebug;
+
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magneticFieldESToken_;
+  edm::ESGetToken<ClusterShapeHitFilter, CkfComponentsRecord> clusterShapeHitFilterESToken_;
+  edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> transientTrackingRecHitBuilderESToken_;
 };
 #endif

--- a/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsCreator.h
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsCreator.h
@@ -5,34 +5,27 @@
 #include "RecoTracker/TkSeedGenerator/interface/SeedCreator.h"
 #include "RecoTracker/TkSeedingLayers/interface/SeedingHitSet.h"
 #include "RecoTracker/TkSeedingLayers/interface/SeedComparitor.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
-#include "TrackingTools/GeomPropagators/interface/Propagator.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "TrackingTools/GeomPropagators/interface/Propagator.h"
+#include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
 
 #include "RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h"
+#include "TrackingTools/Records/interface/TransientRecHitRecord.h"
 
 #include "DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h"
 #include "DataFormats/TrackingRecHit/interface/mayown_ptr.h"
 
-namespace edm {
-  class ParameterSetDescription;
-}
 class FreeTrajectoryState;
 
 class dso_hidden SeedFromConsecutiveHitsCreator : public SeedCreator {
 public:
-  SeedFromConsecutiveHitsCreator(const edm::ParameterSet &cfg)
-      : thePropagatorLabel(cfg.getParameter<std::string>("propagator")),
-        theBOFFMomentum(cfg.getParameter<double>("SeedMomentumForBOFF")),
-        theOriginTransverseErrorMultiplier(cfg.getParameter<double>("OriginTransverseErrorMultiplier")),
-        theMinOneOverPtError(cfg.getParameter<double>("MinOneOverPtError")),
-        TTRHBuilder(cfg.getParameter<std::string>("TTRHBuilder")),
-        mfName_(cfg.getParameter<std::string>("magneticField")),
-        forceKinematicWithRegionDirection_(cfg.getParameter<bool>("forceKinematicWithRegionDirection")) {}
+  SeedFromConsecutiveHitsCreator(const edm::ParameterSet &, edm::ConsumesCollector &&);
 
-  //dtor
   ~SeedFromConsecutiveHitsCreator() override;
 
   static void fillDescriptions(edm::ParameterSetDescription &desc);
@@ -67,9 +60,9 @@ protected:
 
   const TrackingRegion *region = nullptr;
   const SeedComparitor *filter = nullptr;
-  edm::ESHandle<TrackerGeometry> tracker;
-  edm::ESHandle<Propagator> propagatorHandle;
-  edm::ESHandle<MagneticField> bfield;
+  TrackerGeometry const *trackerGeometry_;
+  Propagator const *propagator_;
+  MagneticField const *magneticField_;
   float nomField;
   bool isBOFF = false;
   std::string TTRHBuilder;
@@ -77,5 +70,10 @@ protected:
   bool forceKinematicWithRegionDirection_;
 
   TkClonerImpl cloner;
+
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeometryESToken_;
+  const edm::ESGetToken<Propagator, TrackingComponentsRecord> propagatorESToken_;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magneticFieldESToken_;
+  const edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> transientTrackingRecHitBuilderESToken_;
 };
 #endif

--- a/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsStraightLineCreator.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsStraightLineCreator.cc
@@ -14,7 +14,7 @@ bool SeedFromConsecutiveHitsStraightLineCreator::initialKinematic(GlobalTrajecto
   double rescale = 1000. / initMomentum.perp();
   initMomentum *= rescale;  // set to approximately infinite momentum
   TrackCharge q = 1;        // irrelevant, since infinite momentum
-  kine = GlobalTrajectoryParameters(vertexPos, initMomentum, q, &*bfield);
+  kine = GlobalTrajectoryParameters(vertexPos, initMomentum, q, magneticField_);
 
   return true;
 }

--- a/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsStraightLineCreator.h
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsStraightLineCreator.h
@@ -2,13 +2,15 @@
 #define RecoTracker_TkSeedGenerator_SeedFromConsecutiveHitsStraightLineCreator_H
 #include "FWCore/Utilities/interface/Visibility.h"
 
+#include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
 #include "SeedFromConsecutiveHitsCreator.h"
 #include "RecoTracker/TkSeedingLayers/interface/SeedingHitSet.h"
 class FreeTrajectoryState;
 
 class dso_hidden SeedFromConsecutiveHitsStraightLineCreator final : public SeedFromConsecutiveHitsCreator {
 public:
-  SeedFromConsecutiveHitsStraightLineCreator(const edm::ParameterSet& cfg) : SeedFromConsecutiveHitsCreator(cfg) {}
+  SeedFromConsecutiveHitsStraightLineCreator(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC)
+      : SeedFromConsecutiveHitsCreator(cfg, std::move(iC)) {}
 
   ~SeedFromConsecutiveHitsStraightLineCreator() override {}
 

--- a/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsTripletOnlyCreator.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsTripletOnlyCreator.cc
@@ -24,30 +24,30 @@ bool SeedFromConsecutiveHitsTripletOnlyCreator::initialKinematic(GlobalTrajector
                     tth2->globalPosition(),
                     tth1->globalPosition(),
                     nomField,
-                    &*bfield,
+                    magneticField_,
                     tth1->globalPosition());
     kine = helix.stateAtVertex();
     if UNLIKELY (isBOFF && (theBOFFMomentum > 0)) {
       kine = GlobalTrajectoryParameters(
-          kine.position(), kine.momentum().unit() * theBOFFMomentum, kine.charge(), &*bfield);
+          kine.position(), kine.momentum().unit() * theBOFFMomentum, kine.charge(), magneticField_);
     }
     return (filter ? filter->compatible(hits, kine, helix) : true);
   }
 
   const GlobalPoint& vertexPos = region->origin();
 
-  FastHelix helix(tth2->globalPosition(), tth1->globalPosition(), vertexPos, nomField, &*bfield);
+  FastHelix helix(tth2->globalPosition(), tth1->globalPosition(), vertexPos, nomField, magneticField_);
   if (helix.isValid()) {
     kine = helix.stateAtVertex();
   } else {
     GlobalVector initMomentum(tth2->globalPosition() - vertexPos);
     initMomentum *= (100. / initMomentum.perp());
-    kine = GlobalTrajectoryParameters(vertexPos, initMomentum, 1, &*bfield);
+    kine = GlobalTrajectoryParameters(vertexPos, initMomentum, 1, magneticField_);
   }
 
   if UNLIKELY (isBOFF && (theBOFFMomentum > 0)) {
-    kine =
-        GlobalTrajectoryParameters(kine.position(), kine.momentum().unit() * theBOFFMomentum, kine.charge(), &*bfield);
+    kine = GlobalTrajectoryParameters(
+        kine.position(), kine.momentum().unit() * theBOFFMomentum, kine.charge(), magneticField_);
   }
   return (filter ? filter->compatible(hits, kine, helix) : true);
 }

--- a/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsTripletOnlyCreator.h
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsTripletOnlyCreator.h
@@ -2,11 +2,13 @@
 #define RecoTracker_TkSeedGenerator_SeedFromConsecutiveHitsTripletOnlyCreator_H
 #include "FWCore/Utilities/interface/Visibility.h"
 
+#include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
 #include "SeedFromConsecutiveHitsCreator.h"
 
 class dso_hidden SeedFromConsecutiveHitsTripletOnlyCreator final : public SeedFromConsecutiveHitsCreator {
 public:
-  SeedFromConsecutiveHitsTripletOnlyCreator(const edm::ParameterSet& cfg) : SeedFromConsecutiveHitsCreator(cfg) {}
+  SeedFromConsecutiveHitsTripletOnlyCreator(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC)
+      : SeedFromConsecutiveHitsCreator(cfg, std::move(iC)) {}
 
   static void fillDescriptions(edm::ParameterSetDescription& desc) {
     SeedFromConsecutiveHitsCreator::fillDescriptions(desc);

--- a/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.cc
@@ -16,8 +16,6 @@
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
@@ -69,7 +67,6 @@ SeedGeneratorFromProtoTracksEDProducer::SeedGeneratorFromProtoTracksEDProducer(c
       originRadius(cfg.getParameter<double>("originRadius")),
       useProtoTrackKinematics(cfg.getParameter<bool>("useProtoTrackKinematics")),
       useEventsWithNoVertex(cfg.getParameter<bool>("useEventsWithNoVertex")),
-      builderName(cfg.getParameter<std::string>("TTRHBuilder")),
       usePV_(cfg.getParameter<bool>("usePV")),
       includeFourthHit_(cfg.getParameter<bool>("includeFourthHit")),
       theInputCollectionTag(consumes<reco::TrackCollection>(cfg.getParameter<InputTag>("InputCollection"))),
@@ -129,8 +126,6 @@ void SeedGeneratorFromProtoTracksEDProducer::produce(edm::Event& ev, const edm::
       if (seedFromProtoTrack.isValid())
         (*result).push_back(seedFromProtoTrack.trajectorySeed());
     } else {
-      edm::ESHandle<TransientTrackingRecHitBuilder> ttrhbESH;
-      es.get<TransientRecHitRecord>().get(builderName, ttrhbESH);
       std::vector<Hit> hits;
       for (unsigned int iHit = 0, nHits = proto.recHitsSize(); iHit < nHits; ++iHit) {
         TrackingRecHitRef refHit = proto.recHit(iHit);

--- a/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.h
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.h
@@ -3,9 +3,11 @@
 #include "FWCore/Utilities/interface/Visibility.h"
 
 #include "FWCore/Framework/interface/stream/EDProducer.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "SeedFromConsecutiveHitsCreator.h"
+
+#include <string>
 
 namespace edm {
   class Event;
@@ -20,7 +22,6 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  const edm::ParameterSet theConfig;
   const double originHalfLength;
   const double originRadius;
   const bool useProtoTrackKinematics;
@@ -30,5 +31,6 @@ private:
   const bool includeFourthHit_;
   const edm::EDGetTokenT<reco::TrackCollection> theInputCollectionTag;
   const edm::EDGetTokenT<reco::VertexCollection> theInputVertexCollectionTag;
+  SeedFromConsecutiveHitsCreator seedCreator_;
 };
 #endif

--- a/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.h
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.h
@@ -3,16 +3,12 @@
 #include "FWCore/Utilities/interface/Visibility.h"
 
 #include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "SeedFromConsecutiveHitsCreator.h"
 
 #include <string>
-
-namespace edm {
-  class Event;
-  class EventSetup;
-}  // namespace edm
 
 class dso_hidden SeedGeneratorFromProtoTracksEDProducer : public edm::stream::EDProducer<> {
 public:
@@ -26,7 +22,6 @@ private:
   const double originRadius;
   const bool useProtoTrackKinematics;
   const bool useEventsWithNoVertex;
-  const std::string builderName;
   const bool usePV_;
   const bool includeFourthHit_;
   const edm::EDGetTokenT<reco::TrackCollection> theInputCollectionTag;

--- a/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromRegionHitsEDProducer.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromRegionHitsEDProducer.cc
@@ -51,7 +51,7 @@ SeedGeneratorFromRegionHitsEDProducer::SeedGeneratorFromRegionHitsEDProducer(con
   theGenerator = std::make_unique<SeedGeneratorFromRegionHits>(
       OrderedHitsGeneratorFactory::get()->create(hitsfactoryName, hitsfactoryPSet, iC),
       std::move(aComparitor),
-      SeedCreatorFactory::get()->create(creatorName, creatorPSet));
+      SeedCreatorFactory::get()->create(creatorName, creatorPSet, consumesCollector()));
 
   produces<TrajectorySeedCollection>();
 }


### PR DESCRIPTION
#### PR description:

Partial esConsumes migration for TrajectorySeedProducer. Excludes migration related to MultipleScatteringParametrisation and PixelRecoUtilities because Matti is working on that separately.

#### PR validation:

Relies on existing tests.
