### PR TITLE
[DBG] Fixed compilation errors

### DIFF
--- a/Calibration/HcalCalibAlgos/plugins/HcalHBHEMuonAnalyzer.cc
+++ b/Calibration/HcalCalibAlgos/plugins/HcalHBHEMuonAnalyzer.cc
@@ -810,9 +810,8 @@ void HcalHBHEMuonAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSet
   }
   if (accept) {
 #ifdef EDM_ML_DEBUG
-    for (unsigned int i = 0; i < hcal_ieta_.size(); ++i)
-      edm::LogVerbatim("HBHEMuon") << "[" << i << "] ieta/iphi for entry to "
-                                   << "HCAL has value of " << hcal_ieta_[i] << ":" << hcal_iphi_[i];
+    edm::LogVerbatim("HBHEMuon") << "ieta/iphi for entry to "
+                                 << "HCAL has value of " << hcal_ieta_ << ":" << hcal_iphi_;
 #endif
     for (unsigned int k = 0; k < muon_is_good.size(); ++k) {
       muon_is_good_ = muon_is_good[k];


### PR DESCRIPTION
This should fix the compilation errors of DBG IBs. `hcal_ieta_` and `hcal_iphi_` are of type `int` .