### PR TITLE
[GCC11] Fix compilation warning for FW/ToyIntProducers

### DIFF
--- a/FWCore/Framework/test/stubs/ToyIntProducers.cc
+++ b/FWCore/Framework/test/stubs/ToyIntProducers.cc
@@ -457,7 +457,7 @@ namespace edmtest {
     }
 
     // EventSetup is not used.
-    for (auto const tv : tokenValues_) {
+    for (auto const& tv : tokenValues_) {
       e.emplace(tv.token, tv.value);
     }
   }


### PR DESCRIPTION
This should fix the GCC11 IB warnings
```
 FWCore/Framework/test/stubs/ToyIntProducers.cc:460:21: warning: loop variable 'tv' creates a copy from type 'const edmtest::ManyIntProducer::TokenValue' [-Wrange-loop-construct]
   460 |     for (auto const tv : tokenValues_) {
      |                     ^~
```