### PR TITLE
[GCC11] Fix compilation warning for CommonTools

### DIFF
--- a/CommonTools/Utils/test/testDynArray.cpp
+++ b/CommonTools/Utils/test/testDynArray.cpp
@@ -16,7 +16,9 @@ struct A {
 int main(int s, char **) {
   using T = A;
 
-  unsigned n = 4 * s;
+  unsigned n = 4;
+  if (s > 1)
+    n = 4 * s;
 
   //  alignas(alignof(T)) unsigned char a_storage[sizeof(T)*n];
   //  DynArray<T> a(a_storage,n);


### PR DESCRIPTION
This should fix the GCC11 IB warnings
```
 CommonTools/Utils/test/testDynArray.cpp:54:3: warning: '*q_storage.2_54 + _82' may be used uninitialized [-Wmaybe-uninitialized]
    54 |   if (q[n - 1])
      |   ^~
```
I think compiler thinks that `n` could be `0` if `s<=0`