### PR TITLE
Add esConsumes to modules that inherit from TrackProducerBase

### DIFF
--- a/RecoEgamma/EgammaPhotonProducers/src/TrackProducerWithSCAssociation.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/TrackProducerWithSCAssociation.cc
@@ -64,10 +64,8 @@ DEFINE_FWK_MODULE(TrackProducerWithSCAssociation);
 
 TrackProducerWithSCAssociation::TrackProducerWithSCAssociation(const edm::ParameterSet& iConfig)
     : TrackProducerBase<reco::Track>(iConfig.getParameter<bool>("TrajectoryInEvent")), theAlgo(iConfig) {
-  setConf(iConfig);
-  setSrc(consumes<TrackCandidateCollection>(iConfig.getParameter<edm::InputTag>("src")),
-         consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpot")),
-         consumes<MeasurementTrackerEvent>(iConfig.getParameter<edm::InputTag>("MeasurementTrackerEvent")));
+  initTrackProducerBase(
+      iConfig, consumesCollector(), consumes<TrackCandidateCollection>(iConfig.getParameter<edm::InputTag>("src")));
   setAlias(iConfig.getParameter<std::string>("@module_label"));
 
   myname_ = iConfig.getParameter<std::string>("ComponentName");

--- a/RecoEgamma/EgammaPhotonProducers/src/TrackProducerWithSCAssociation.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/TrackProducerWithSCAssociation.cc
@@ -70,13 +70,6 @@ TrackProducerWithSCAssociation::TrackProducerWithSCAssociation(const edm::Parame
          consumes<MeasurementTrackerEvent>(iConfig.getParameter<edm::InputTag>("MeasurementTrackerEvent")));
   setAlias(iConfig.getParameter<std::string>("@module_label"));
 
-  if (iConfig.exists("clusterRemovalInfo")) {
-    edm::InputTag tag = iConfig.getParameter<edm::InputTag>("clusterRemovalInfo");
-    if (!(tag == edm::InputTag())) {
-      setClusterRemovalInfo(tag);
-    }
-  }
-
   myname_ = iConfig.getParameter<std::string>("ComponentName");
   conversionTrackCandidateProducer_ = iConfig.getParameter<std::string>("producer");
   trackCSuperClusterAssociationCollection_ = iConfig.getParameter<std::string>("trackCandidateSCAssociationCollection");

--- a/RecoEgamma/EgammaPhotonProducers/src/TrackProducerWithSCAssociation.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/TrackProducerWithSCAssociation.cc
@@ -42,6 +42,7 @@ private:
   edm::EDGetTokenT<reco::TrackCandidateCaloClusterPtrAssociation> assoc_token;
   edm::OrphanHandle<reco::TrackCollection> rTracks_;
   edm::EDGetTokenT<MeasurementTrackerEvent> measurementTrkToken_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> ttopoToken_;
   bool myTrajectoryInEvent_;
   bool validTrackCandidateSCAssociationInput_;
 
@@ -63,7 +64,9 @@ private:
 DEFINE_FWK_MODULE(TrackProducerWithSCAssociation);
 
 TrackProducerWithSCAssociation::TrackProducerWithSCAssociation(const edm::ParameterSet& iConfig)
-    : TrackProducerBase<reco::Track>(iConfig.getParameter<bool>("TrajectoryInEvent")), theAlgo(iConfig) {
+    : TrackProducerBase<reco::Track>(iConfig.getParameter<bool>("TrajectoryInEvent")),
+      theAlgo(iConfig),
+      ttopoToken_(esConsumes()) {
   initTrackProducerBase(
       iConfig, consumesCollector(), consumes<TrackCandidateCollection>(iConfig.getParameter<edm::InputTag>("src")));
   setAlias(iConfig.getParameter<std::string>("@module_label"));
@@ -116,9 +119,7 @@ void TrackProducerWithSCAssociation::produce(edm::Event& theEvent, const edm::Ev
   edm::ESHandle<MeasurementTracker> theMeasTk;
   getFromES(setup, theG, theMF, theFitter, thePropagator, theMeasTk, theBuilder);
 
-  edm::ESHandle<TrackerTopology> httopo;
-  setup.get<TrackerTopologyRcd>().get(httopo);
-  const TrackerTopology* ttopo = httopo.product();
+  const TrackerTopology* ttopo = &setup.getData(ttopoToken_);
 
   //
   //declare and get TrackColection to be retrieved from the event

--- a/RecoTracker/TrackProducer/interface/KfTrackProducerBase.h
+++ b/RecoTracker/TrackProducer/interface/KfTrackProducerBase.h
@@ -17,7 +17,7 @@ class KfTrackProducerBase : public TrackProducerBase<reco::Track> {
 public:
   /// Constructor
   explicit KfTrackProducerBase(bool trajectoryInEvent, bool split)
-      : TrackProducerBase<reco::Track>(trajectoryInEvent), useSplitting(split) {}
+      : TrackProducerBase<reco::Track>(trajectoryInEvent), rekeyClusterRefs_(false), useSplitting(split) {}
 
   /// Put produced collections in the event
   virtual void putInEvt(edm::Event&,
@@ -38,6 +38,16 @@ public:
                         int BeforeOrAfter = 0);
 
   //  void setSecondHitPattern(Trajectory* traj, reco::Track& track);
+protected:
+  /// Sets the information on cluster removal, and turns it on
+  void setClusterRemovalInfo(const edm::InputTag& clusterRemovalInfo) {
+    rekeyClusterRefs_ = true;
+    clusterRemovalInfo_ = clusterRemovalInfo;
+  }
+
+  bool rekeyClusterRefs_;
+  edm::InputTag clusterRemovalInfo_;
+
 private:
   bool useSplitting;
 };

--- a/RecoTracker/TrackProducer/interface/TrackProducerBase.h
+++ b/RecoTracker/TrackProducer/interface/TrackProducerBase.h
@@ -18,6 +18,7 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
+#include "TrackingTools/TrackFitters/interface/TrajectoryFitter.h"
 
 #include "DataFormats/TrackReco/interface/TrackExtra.h"
 #include "DataFormats/TrackCandidate/interface/TrackCandidateCollection.h"
@@ -34,6 +35,12 @@ class TrackerGeometry;
 class TrajectoryFitter;
 class TransientTrackingRecHitBuilder;
 class NavigationSchool;
+class TrackerDigiGeometryRecord;
+class IdealMagneticFieldRecord;
+class TransientRecHitRecord;
+class TrackingComponentsRecord;
+class NavigationSchoolRecord;
+class CkfComponentsRecord;
 
 template <class T>
 class TrackProducerBase : public AlgoProductTraits<T> {
@@ -95,7 +102,16 @@ protected:
   edm::EDGetTokenT<reco::BeamSpot> bsSrc_;
   edm::EDGetTokenT<MeasurementTrackerEvent> mteSrc_;
 
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackGeomSrc_;
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> mfSrc_;
+  edm::ESGetToken<TrajectoryFitter, TrajectoryFitter::Record> fitterSrc_;
+  edm::ESGetToken<Propagator, TrackingComponentsRecord> propagatorSrc_;
+  edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> builderSrc_;
+  edm::ESGetToken<MeasurementTracker, CkfComponentsRecord> measTkSrc_;
+  edm::ESGetToken<NavigationSchool, NavigationSchoolRecord> schoolSrc_;
+
   edm::ESHandle<NavigationSchool> theSchool;
+  bool useSchool_ = false;
 };
 
 #include "RecoTracker/TrackProducer/interface/TrackProducerBase.icc"

--- a/RecoTracker/TrackProducer/interface/TrackProducerBase.h
+++ b/RecoTracker/TrackProducer/interface/TrackProducerBase.h
@@ -45,7 +45,7 @@ public:
 
 public:
   /// Constructor
-  TrackProducerBase(bool trajectoryInEvent = false) : trajectoryInEvent_(trajectoryInEvent), rekeyClusterRefs_(false) {}
+  TrackProducerBase(bool trajectoryInEvent = false) : trajectoryInEvent_(trajectoryInEvent) {}
 
   /// Destructor
   virtual ~TrackProducerBase() noexcept(false);
@@ -85,12 +85,6 @@ public:
     alias_ = alias;
   }
 
-  /// Sets the information on cluster removal, and turns it on
-  void setClusterRemovalInfo(const edm::InputTag& clusterRemovalInfo) {
-    rekeyClusterRefs_ = true;
-    clusterRemovalInfo_ = clusterRemovalInfo;
-  }
-
   void setSecondHitPattern(Trajectory* traj,
                            T& track,
                            const Propagator* prop,
@@ -109,9 +103,6 @@ protected:
   edm::OrphanHandle<TrackCollection> rTracks_;
   edm::EDGetTokenT<reco::BeamSpot> bsSrc_;
   edm::EDGetTokenT<MeasurementTrackerEvent> mteSrc_;
-
-  bool rekeyClusterRefs_;
-  edm::InputTag clusterRemovalInfo_;
 
   edm::ESHandle<NavigationSchool> theSchool;
 };

--- a/RecoTracker/TrackProducer/interface/TrackProducerBase.h
+++ b/RecoTracker/TrackProducer/interface/TrackProducerBase.h
@@ -9,7 +9,7 @@
 
 #include "AlgoProductTraits.h"
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -67,17 +67,8 @@ public:
   /// Method where the procduction take place. To be implemented in concrete classes
   virtual void produce(edm::Event&, const edm::EventSetup&) = 0;
 
-  /// Set parameter set
-  void setConf(const edm::ParameterSet& conf) { conf_ = conf; }
-
-  /// set label of source collection
-  void setSrc(const edm::EDGetToken& src,
-              const edm::EDGetTokenT<reco::BeamSpot>& bsSrc,
-              const edm::EDGetTokenT<MeasurementTrackerEvent>& mteSrc) {
-    src_ = src;
-    bsSrc_ = bsSrc;
-    mteSrc_ = mteSrc;
-  }
+  /// Call this method in inheriting class' constructor
+  void initTrackProducerBase(const edm::ParameterSet& conf, edm::ConsumesCollector cc, const edm::EDGetToken& src);
 
   /// set the aliases of produced collections
   void setAlias(std::string alias) {

--- a/RecoTracker/TrackProducer/interface/TrackProducerBase.icc
+++ b/RecoTracker/TrackProducer/interface/TrackProducerBase.icc
@@ -46,6 +46,48 @@ void TrackProducerBase<T>::initTrackProducerBase(const edm::ParameterSet& conf,
   src_ = src;
   bsSrc_ = cc.consumes(conf.getParameter<edm::InputTag>("beamSpot"));
   mteSrc_ = cc.consumes(conf.getParameter<edm::InputTag>("MeasurementTrackerEvent"));
+
+  trackGeomSrc_ = cc.esConsumes();
+
+  // 2014/02/11 mia:
+  // we should get rid of the boolean parameter useSimpleMF,
+  // and use only a string magneticField [instead of SimpleMagneticField]
+  // or better an edm::ESInputTag (at the moment HLT does not handle ESInputTag)
+  bool useSimpleMF = false;
+  if (conf_.exists("useSimpleMF"))
+    useSimpleMF = conf_.getParameter<bool>("useSimpleMF");
+  std::string mfName = "";
+  if (useSimpleMF) {
+    mfName = conf_.getParameter<std::string>("SimpleMagneticField");
+  }
+  mfSrc_ = cc.esConsumes(edm::ESInputTag("", mfName));
+
+  std::string fitterName = conf_.getParameter<std::string>("Fitter");
+  fitterSrc_ = cc.esConsumes(edm::ESInputTag("", fitterName));
+
+  std::string propagatorName = conf_.getParameter<std::string>("Propagator");
+  propagatorSrc_ = cc.esConsumes(edm::ESInputTag("", propagatorName));
+
+  std::string builderName = conf_.getParameter<std::string>("TTRHBuilder");
+  builderSrc_ = cc.esConsumes(edm::ESInputTag("", builderName));
+
+  //
+  // get also the measurementTracker and the NavigationSchool
+  // (they are necessary to fill in the secondary hit patterns)
+  //
+
+  std::string theNavigationSchool = "";
+  if (conf_.exists("NavigationSchool"))
+    theNavigationSchool = conf_.getParameter<std::string>("NavigationSchool");
+  else
+    edm::LogWarning("TrackProducerBase")
+        << " NavigationSchool parameter not set. secondary hit pattern will not be filled.";
+  if (!theNavigationSchool.empty()) {
+    useSchool_ = true;
+    schoolSrc_ = cc.esConsumes(edm::ESInputTag("", theNavigationSchool));
+    std::string measTkName = conf_.getParameter<std::string>("MeasurementTracker");
+    measTkSrc_ = cc.esConsumes(edm::ESInputTag("", measTkName));
+  }
 }
 
 // ------------ method called to produce the data  ------------
@@ -63,68 +105,45 @@ void TrackProducerBase<T>::getFromES(const edm::EventSetup& setup,
   //
   LogDebug("TrackProducer") << "get geometry"
                             << "\n";
-  setup.get<TrackerDigiGeometryRecord>().get(theG);
+  theG = setup.getHandle(trackGeomSrc_);
   //
   //get magnetic field
   //
   LogDebug("TrackProducer") << "get magnetic field"
                             << "\n";
-  // 2014/02/11 mia:
-  // we should get rid of the boolean parameter useSimpleMF,
-  // and use only a string magneticField [instead of SimpleMagneticField]
-  // or better an edm::ESInputTag (at the moment HLT does not handle ESInputTag)
-  bool useSimpleMF = false;
-  if (conf_.exists("useSimpleMF"))
-    useSimpleMF = conf_.getParameter<bool>("useSimpleMF");
-  std::string mfName = "";
-  if (useSimpleMF) {
-    mfName = conf_.getParameter<std::string>("SimpleMagneticField");
-  }
-  setup.get<IdealMagneticFieldRecord>().get(mfName, theMF);
-  //  edm::ESInputTag mfESInputTag(mfName);
-  //  setup.get<IdealMagneticFieldRecord>().get(mfESInputTag, theMF);
+  theMF = setup.getHandle(mfSrc_);
 
   //
   // get the fitter from the ES
   //
   LogDebug("TrackProducer") << "get the fitter from the ES"
                             << "\n";
-  std::string fitterName = conf_.getParameter<std::string>("Fitter");
-  setup.get<TrajectoryFitter::Record>().get(fitterName, theFitter);
+  theFitter = setup.getHandle(fitterSrc_);
   //
   // get also the propagator
   //
   LogDebug("TrackProducer") << "get also the propagator"
                             << "\n";
-  std::string propagatorName = conf_.getParameter<std::string>("Propagator");
-  setup.get<TrackingComponentsRecord>().get(propagatorName, thePropagator);
+  thePropagator = setup.getHandle(propagatorSrc_);
 
   //
   // get the builder
   //
   LogDebug("TrackProducer") << "get also the TransientTrackingRecHitBuilder"
                             << "\n";
-  std::string builderName = conf_.getParameter<std::string>("TTRHBuilder");
-  setup.get<TransientRecHitRecord>().get(builderName, theBuilder);
+  theBuilder = setup.getHandle(builderSrc_);
 
   //
   // get also the measurementTracker and the NavigationSchool
   // (they are necessary to fill in the secondary hit patterns)
   //
 
-  LogDebug("TrackProducer") << "get a navigation school";
-  std::string theNavigationSchool = "";
-  if (conf_.exists("NavigationSchool"))
-    theNavigationSchool = conf_.getParameter<std::string>("NavigationSchool");
-  else
-    edm::LogWarning("TrackProducerBase")
-        << " NavigationSchool parameter not set. secondary hit pattern will not be filled.";
-  if (!theNavigationSchool.empty()) {
-    setup.get<NavigationSchoolRecord>().get(theNavigationSchool, theSchool);
+  if (useSchool_) {
+    LogDebug("TrackProducer") << "get a navigation school";
+    theSchool = setup.getHandle(schoolSrc_);
     LogDebug("TrackProducer") << "get also the measTk"
                               << "\n";
-    std::string measTkName = conf_.getParameter<std::string>("MeasurementTracker");
-    setup.get<CkfComponentsRecord>().get(measTkName, theMeasTk);
+    theMeasTk = setup.getHandle(measTkSrc_);
   } else {
     theSchool = edm::ESHandle<NavigationSchool>();    //put an invalid handle
     theMeasTk = edm::ESHandle<MeasurementTracker>();  //put an invalid handle

--- a/RecoTracker/TrackProducer/interface/TrackProducerBase.icc
+++ b/RecoTracker/TrackProducer/interface/TrackProducerBase.icc
@@ -37,6 +37,17 @@ template <class T>
 TrackProducerBase<T>::~TrackProducerBase() noexcept(false) {}
 
 // member functions
+
+template <class T>
+void TrackProducerBase<T>::initTrackProducerBase(const edm::ParameterSet& conf,
+                                                 edm::ConsumesCollector cc,
+                                                 const edm::EDGetToken& src) {
+  conf_ = conf;
+  src_ = src;
+  bsSrc_ = cc.consumes(conf.getParameter<edm::InputTag>("beamSpot"));
+  mteSrc_ = cc.consumes(conf.getParameter<edm::InputTag>("MeasurementTrackerEvent"));
+}
+
 // ------------ method called to produce the data  ------------
 
 template <class T>

--- a/RecoTracker/TrackProducer/plugins/DAFTrackProducer.cc
+++ b/RecoTracker/TrackProducer/plugins/DAFTrackProducer.cc
@@ -19,10 +19,8 @@
 
 DAFTrackProducer::DAFTrackProducer(const edm::ParameterSet& iConfig)
     : KfTrackProducerBase(iConfig.getParameter<bool>("TrajectoryInEvent"), false), theAlgo(iConfig) {
-  setConf(iConfig);
-  setSrc(consumes<TrackCandidateCollection>(iConfig.getParameter<edm::InputTag>("src")),
-         consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpot")),
-         consumes<MeasurementTrackerEvent>(iConfig.getParameter<edm::InputTag>("MeasurementTrackerEvent")));
+  initTrackProducerBase(
+      iConfig, consumesCollector(), consumes<TrackCandidateCollection>(iConfig.getParameter<edm::InputTag>("src")));
   srcTT_ = consumes<TrajTrackAssociationCollection>(iConfig.getParameter<edm::InputTag>("src"));
   setAlias(iConfig.getParameter<std::string>("@module_label"));
 

--- a/RecoTracker/TrackProducer/plugins/GsfTrackProducer.cc
+++ b/RecoTracker/TrackProducer/plugins/GsfTrackProducer.cc
@@ -27,10 +27,8 @@ GsfTrackProducer::GsfTrackProducer(const edm::ParameterSet& iConfig)
     : GsfTrackProducerBase(iConfig.getParameter<bool>("TrajectoryInEvent"),
                            iConfig.getParameter<bool>("useHitsSplitting")),
       theAlgo(iConfig) {
-  setConf(iConfig);
-  setSrc(consumes<TrackCandidateCollection>(iConfig.getParameter<edm::InputTag>("src")),
-         consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpot")),
-         consumes<MeasurementTrackerEvent>(iConfig.getParameter<edm::InputTag>("MeasurementTrackerEvent")));
+  initTrackProducerBase(
+      iConfig, consumesCollector(), consumes<TrackCandidateCollection>(iConfig.getParameter<edm::InputTag>("src")));
   setAlias(iConfig.getParameter<std::string>("@module_label"));
   //   string a = alias_;
   //   a.erase(a.size()-6,a.size());

--- a/RecoTracker/TrackProducer/plugins/GsfTrackProducer.cc
+++ b/RecoTracker/TrackProducer/plugins/GsfTrackProducer.cc
@@ -21,12 +21,15 @@ public:
 
 private:
   TrackProducerAlgorithm<reco::GsfTrack> theAlgo;
+
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> theTopoToken;
 };
 
 GsfTrackProducer::GsfTrackProducer(const edm::ParameterSet& iConfig)
     : GsfTrackProducerBase(iConfig.getParameter<bool>("TrajectoryInEvent"),
                            iConfig.getParameter<bool>("useHitsSplitting")),
-      theAlgo(iConfig) {
+      theAlgo(iConfig),
+      theTopoToken(esConsumes()) {
   initTrackProducerBase(
       iConfig, consumesCollector(), consumes<TrackCandidateCollection>(iConfig.getParameter<edm::InputTag>("src")));
   setAlias(iConfig.getParameter<std::string>("@module_label"));
@@ -63,8 +66,7 @@ void GsfTrackProducer::produce(edm::Event& theEvent, const edm::EventSetup& setu
   edm::ESHandle<TransientTrackingRecHitBuilder> theBuilder;
   getFromES(setup, theG, theMF, theFitter, thePropagator, theMeasTk, theBuilder);
 
-  edm::ESHandle<TrackerTopology> httopo;
-  setup.get<TrackerTopologyRcd>().get(httopo);
+  TrackerTopology const& ttopo = setup.getData(theTopoToken);
 
   //
   //declare and get TrackColection to be retrieved from the event
@@ -107,7 +109,7 @@ void GsfTrackProducer::produce(edm::Event& theEvent, const edm::EventSetup& setu
            algoResults,
            theBuilder.product(),
            bs,
-           httopo.product());
+           &ttopo);
   LogDebug("GsfTrackProducer") << "end"
                                << "\n";
 }

--- a/RecoTracker/TrackProducer/plugins/GsfTrackRefitter.cc
+++ b/RecoTracker/TrackProducer/plugins/GsfTrackRefitter.cc
@@ -19,10 +19,8 @@ GsfTrackRefitter::GsfTrackRefitter(const edm::ParameterSet& iConfig)
     : GsfTrackProducerBase(iConfig.getParameter<bool>("TrajectoryInEvent"),
                            iConfig.getParameter<bool>("useHitsSplitting")),
       theAlgo(iConfig) {
-  setConf(iConfig);
-  setSrc(consumes<edm::View<reco::GsfTrack>>(iConfig.getParameter<edm::InputTag>("src")),
-         consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpot")),
-         consumes<MeasurementTrackerEvent>(iConfig.getParameter<edm::InputTag>("MeasurementTrackerEvent")));
+  initTrackProducerBase(
+      iConfig, consumesCollector(), consumes<edm::View<reco::GsfTrack>>(iConfig.getParameter<edm::InputTag>("src")));
   setAlias(iConfig.getParameter<std::string>("@module_label"));
   std::string constraint_str = iConfig.getParameter<std::string>("constraint");
 

--- a/RecoTracker/TrackProducer/plugins/TrackProducer.cc
+++ b/RecoTracker/TrackProducer/plugins/TrackProducer.cc
@@ -19,10 +19,8 @@ TrackProducer::TrackProducer(const edm::ParameterSet& iConfig)
     : KfTrackProducerBase(iConfig.getParameter<bool>("TrajectoryInEvent"),
                           iConfig.getParameter<bool>("useHitsSplitting")),
       theAlgo(iConfig) {
-  setConf(iConfig);
-  setSrc(consumes<TrackCandidateCollection>(iConfig.getParameter<edm::InputTag>("src")),
-         consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpot")),
-         consumes<MeasurementTrackerEvent>(iConfig.getParameter<edm::InputTag>("MeasurementTrackerEvent")));
+  initTrackProducerBase(
+      iConfig, consumesCollector(), consumes<TrackCandidateCollection>(iConfig.getParameter<edm::InputTag>("src")));
   setAlias(iConfig.getParameter<std::string>("@module_label"));
 
   if (iConfig.exists("clusterRemovalInfo")) {

--- a/RecoTracker/TrackProducer/plugins/TrackProducer.cc
+++ b/RecoTracker/TrackProducer/plugins/TrackProducer.cc
@@ -18,7 +18,8 @@
 TrackProducer::TrackProducer(const edm::ParameterSet& iConfig)
     : KfTrackProducerBase(iConfig.getParameter<bool>("TrajectoryInEvent"),
                           iConfig.getParameter<bool>("useHitsSplitting")),
-      theAlgo(iConfig) {
+      theAlgo(iConfig),
+      theTTopoToken(esConsumes()) {
   initTrackProducerBase(
       iConfig, consumesCollector(), consumes<TrackCandidateCollection>(iConfig.getParameter<edm::InputTag>("src")));
   setAlias(iConfig.getParameter<std::string>("@module_label"));
@@ -61,8 +62,7 @@ void TrackProducer::produce(edm::Event& theEvent, const edm::EventSetup& setup) 
   edm::ESHandle<TransientTrackingRecHitBuilder> theBuilder;
   getFromES(setup, theG, theMF, theFitter, thePropagator, theMeasTk, theBuilder);
 
-  edm::ESHandle<TrackerTopology> httopo;
-  setup.get<TrackerTopologyRcd>().get(httopo);
+  TrackerTopology const& ttopo = setup.getData(theTTopoToken);
 
   //
   //declare and get TrackColection to be retrieved from the event
@@ -105,7 +105,7 @@ void TrackProducer::produce(edm::Event& theEvent, const edm::EventSetup& setup) 
            outputIndecesInputColl,
            algoResults,
            theBuilder.product(),
-           httopo.product());
+           &ttopo);
   LogDebug("TrackProducer") << "end"
                             << "\n";
 }

--- a/RecoTracker/TrackProducer/plugins/TrackProducer.h
+++ b/RecoTracker/TrackProducer/plugins/TrackProducer.h
@@ -34,6 +34,7 @@ public:
 
 private:
   TrackProducerAlgorithm<reco::Track> theAlgo;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> theTTopoToken;
 };
 
 #endif

--- a/RecoTracker/TrackProducer/plugins/TrackRefitter.cc
+++ b/RecoTracker/TrackProducer/plugins/TrackRefitter.cc
@@ -17,10 +17,8 @@ TrackRefitter::TrackRefitter(const edm::ParameterSet &iConfig)
     : KfTrackProducerBase(iConfig.getParameter<bool>("TrajectoryInEvent"),
                           iConfig.getParameter<bool>("useHitsSplitting")),
       theAlgo(iConfig) {
-  setConf(iConfig);
-  setSrc(consumes<edm::View<reco::Track>>(iConfig.getParameter<edm::InputTag>("src")),
-         consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpot")),
-         consumes<MeasurementTrackerEvent>(iConfig.getParameter<edm::InputTag>("MeasurementTrackerEvent")));
+  initTrackProducerBase(
+      iConfig, consumesCollector(), consumes<edm::View<reco::Track>>(iConfig.getParameter<edm::InputTag>("src")));
   setAlias(iConfig.getParameter<std::string>("@module_label"));
   std::string constraint_str = iConfig.getParameter<std::string>("constraint");
   edm::InputTag trkconstrcoll = iConfig.getParameter<edm::InputTag>("srcConstr");

--- a/RecoTracker/TrackProducer/plugins/TrackRefitter.cc
+++ b/RecoTracker/TrackProducer/plugins/TrackRefitter.cc
@@ -16,7 +16,8 @@
 TrackRefitter::TrackRefitter(const edm::ParameterSet &iConfig)
     : KfTrackProducerBase(iConfig.getParameter<bool>("TrajectoryInEvent"),
                           iConfig.getParameter<bool>("useHitsSplitting")),
-      theAlgo(iConfig) {
+      theAlgo(iConfig),
+      ttopoToken_(esConsumes()) {
   initTrackProducerBase(
       iConfig, consumesCollector(), consumes<edm::View<reco::Track>>(iConfig.getParameter<edm::InputTag>("src")));
   setAlias(iConfig.getParameter<std::string>("@module_label"));
@@ -73,8 +74,7 @@ void TrackRefitter::produce(edm::Event &theEvent, const edm::EventSetup &setup) 
   edm::ESHandle<TransientTrackingRecHitBuilder> theBuilder;
   getFromES(setup, theG, theMF, theFitter, thePropagator, theMeasTk, theBuilder);
 
-  edm::ESHandle<TrackerTopology> httopo;
-  setup.get<TrackerTopologyRcd>().get(httopo);
+  TrackerTopology const &ttopo = setup.getData(ttopoToken_);
 
   //
   //declare and get TrackCollection to be retrieved from the event
@@ -226,7 +226,7 @@ void TrackRefitter::produce(edm::Event &theEvent, const edm::EventSetup &setup) 
            outputIndecesInputColl,
            algoResults,
            theBuilder.product(),
-           httopo.product());
+           &ttopo);
   LogDebug("TrackRefitter") << "end"
                             << "\n";
 }

--- a/RecoTracker/TrackProducer/plugins/TrackRefitter.h
+++ b/RecoTracker/TrackProducer/plugins/TrackRefitter.h
@@ -24,6 +24,8 @@ private:
   enum Constraint { none, momentum, vertex, trackParameters };
   Constraint constraint_;
   edm::EDGetToken trkconstrcoll_;
+
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> ttopoToken_;
 };
 
 #endif


### PR DESCRIPTION
#### PR description:
- refactored TrackProducerBase to allow use of esConsumes.
- added some explicit esConsumes calls in modules.

#### PR validation:

Code compiles.