### PR TITLE
[GCC11] Fix compilation warning for EcalMatacqDigi

### DIFF
--- a/DataFormats/EcalDigi/interface/EcalMatacqDigi.h
+++ b/DataFormats/EcalDigi/interface/EcalMatacqDigi.h
@@ -29,7 +29,7 @@ public:
 public:
   /** Default constructor.
    */
-  EcalMatacqDigi() : chId_(-1), ts_(0.), tTrigS_(999.), version_(-1) { init(); }
+  EcalMatacqDigi() : chId_(-1), freq(0), ts_(0.), tTrigS_(999.), version_(-1) { init(); }
 
   /** Constructor
    * @param samples adc time samples
@@ -43,7 +43,7 @@ public:
                  const double& ts,
                  const short& version = -1,
                  const double& tTrig = 999.)
-      : chId_(chId), data_(samples), ts_(ts), tTrigS_(tTrig), version_(version) {
+      : chId_(chId), data_(samples), freq(0), ts_(ts), tTrigS_(tTrig), version_(version) {
     init();
   };
 
@@ -270,6 +270,7 @@ public:
    * @param value new value
    */
   void laserPower(int value) { laserPower_ = value; }
+#endif
 
   void init() {
 #if (ECAL_MATACQ_DIGI_VERS >= 2)
@@ -285,10 +286,10 @@ public:
     emtcPhase_ = -1;
     attenuation_dB_ = -1;
     laserPower_ = -1;
+    tv_sec_ = 0;
+    tv_usec_ = 0;
 #endif
   }
-
-#endif
 
 private:
   /** Electronic channel id

--- a/DataFormats/EcalDigi/interface/EcalMatacqDigi.h
+++ b/DataFormats/EcalDigi/interface/EcalMatacqDigi.h
@@ -29,7 +29,7 @@ public:
 public:
   /** Default constructor.
    */
-  EcalMatacqDigi() : chId_(-1), freq(0), ts_(0.), tTrigS_(999.), version_(-1) { init(); }
+  EcalMatacqDigi() : chId_(-1), ts_(0.), tTrigS_(999.), version_(-1) { init(); }
 
   /** Constructor
    * @param samples adc time samples
@@ -43,7 +43,7 @@ public:
                  const double& ts,
                  const short& version = -1,
                  const double& tTrig = 999.)
-      : chId_(chId), data_(samples), freq(0), ts_(ts), tTrigS_(tTrig), version_(version) {
+      : chId_(chId), data_(samples), ts_(ts), tTrigS_(tTrig), version_(version) {
     init();
   };
 
@@ -299,10 +299,6 @@ private:
   /** ADC count of time samples
    */
   std::vector<Short_t> data_;
-
-  /** Frequency mode. 1->1GHz sampling, 2->2GHz sampling
-   */
-  int freq;
 
   /**Sampling period in seconds. In priniciple 1ns or 0.5ns
    */

--- a/DataFormats/EcalDigi/src/classes_def.xml
+++ b/DataFormats/EcalDigi/src/classes_def.xml
@@ -48,7 +48,8 @@
    <class name="EcalPnDiodeDigi" ClassVersion="10">
     <version ClassVersion="10" checksum="3691846555"/>
    </class>
-   <class name="EcalMatacqDigi" ClassVersion="11">
+   <class name="EcalMatacqDigi" ClassVersion="12">
+    <version ClassVersion="12" checksum="1211538371"/>
     <version ClassVersion="11" checksum="515819338"/>
     <version ClassVersion="10" checksum="804498184"/>
    </class>


### PR DESCRIPTION
This should fix the two compilation warnings of GCC11 IBs
```
  DataFormats/EcalDigi/interface/EcalMatacqDigi.h:16:7: warning: 'matacqDigi.EcalMatacqDigi::freq' may be used uninitialized [-Wmaybe-uninitialized]
    16 | class EcalMatacqDigi {
      |       ^~~~~~~~~~~~~~
  DataFormats/EcalDigi/interface/EcalMatacqDigi.h:16:7: warning: '*(const __vector(2) long long int*)((char*)&matacqDigi + offsetof(EcalMatacqDigi, EcalMatacqDigi::tv_sec_))' may be used uninitialized [-Wmaybe-uninitialized]
    16 | class EcalMatacqDigi {
      |       ^~~~~~~~~~~~~~
```
It also fixes the conditional code so that the `init()` ( https://github.com/cms-sw/cmssw/blob/master/DataFormats/EcalDigi/interface/EcalMatacqDigi.h#L32 ) method is also declared/defined for `#define ECAL_MATACQ_DIGI_VERS 1` (https://github.com/cms-sw/cmssw/blob/master/DataFormats/EcalDigi/interface/EcalMatacqDigi.h#L11)