### PR TITLE
ECAL esConsumes migration various packages

### DIFF
--- a/CondTools/Ecal/interface/ESDBCopy.h
+++ b/CondTools/Ecal/interface/ESDBCopy.h
@@ -1,8 +1,21 @@
-#ifndef ESDBCOPY_H
-#define ESDBCOPY_H
+#ifndef CondTools_Ecal_ESDBCopy_h
+#define CondTools_Ecal_ESDBCopy_h
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "CondCore/CondDB/interface/Exception.h"
+
+#include "CondFormats/ESObjects/interface/ESPedestals.h"
+#include "CondFormats/DataRecord/interface/ESPedestalsRcd.h"
+#include "CondFormats/ESObjects/interface/ESADCToGeVConstant.h"
+#include "CondFormats/DataRecord/interface/ESADCToGeVConstantRcd.h"
+#include "CondFormats/ESObjects/interface/ESChannelStatus.h"
+#include "CondFormats/DataRecord/interface/ESChannelStatusRcd.h"
+#include "CondFormats/ESObjects/interface/ESIntercalibConstants.h"
+#include "CondFormats/DataRecord/interface/ESIntercalibConstantsRcd.h"
+#include "CondFormats/ESObjects/interface/ESWeightStripGroups.h"
+#include "CondFormats/DataRecord/interface/ESWeightStripGroupsRcd.h"
+#include "CondFormats/ESObjects/interface/ESTBWeights.h"
+#include "CondFormats/DataRecord/interface/ESTBWeightsRcd.h"
 
 #include "FWCore/Framework/interface/IOVSyncValue.h"
 
@@ -15,7 +28,7 @@ namespace edm {
   class EventSetup;
 }  // namespace edm
 
-class ESDBCopy : public edm::EDAnalyzer {
+class ESDBCopy : public edm::one::EDAnalyzer<> {
 public:
   explicit ESDBCopy(const edm::ParameterSet& iConfig);
   ~ESDBCopy() override;
@@ -23,12 +36,19 @@ public:
   void analyze(const edm::Event& evt, const edm::EventSetup& evtSetup) override;
 
 private:
-  bool shouldCopy(const edm::EventSetup& evtSetup, std::string container);
-  void copyToDB(const edm::EventSetup& evtSetup, std::string container);
+  bool shouldCopy(const edm::EventSetup& evtSetup, const std::string& container);
+  void copyToDB(const edm::EventSetup& evtSetup, const std::string& container);
 
   std::string m_timetype;
   std::map<std::string, unsigned long long> m_cacheIDs;
   std::map<std::string, std::string> m_records;
+
+  const edm::ESGetToken<ESPedestals, ESPedestalsRcd> esPedestalsToken_;
+  const edm::ESGetToken<ESADCToGeVConstant, ESADCToGeVConstantRcd> esADCToGeVConstantToken_;
+  const edm::ESGetToken<ESChannelStatus, ESChannelStatusRcd> esChannelStatusToken_;
+  const edm::ESGetToken<ESIntercalibConstants, ESIntercalibConstantsRcd> esIntercalibConstantsToken_;
+  const edm::ESGetToken<ESWeightStripGroups, ESWeightStripGroupsRcd> esWeightStripGroupsToken_;
+  const edm::ESGetToken<ESTBWeights, ESTBWeightsRcd> esTBWeightsToken_;
 };
 
 #endif

--- a/RecoEcal/EgammaCoreTools/interface/EcalClusterPUCleaningTools.h
+++ b/RecoEcal/EgammaCoreTools/interface/EcalClusterPUCleaningTools.h
@@ -12,28 +12,34 @@
  */
 
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "DataFormats/EgammaReco/interface/SuperCluster.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
-
-#include "FWCore/Framework/interface/ESHandle.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
 
 class CaloGeometry;
 
 class EcalClusterPUCleaningTools {
 public:
-  EcalClusterPUCleaningTools(const edm::Event &ev,
-                             const edm::EventSetup &es,
+  EcalClusterPUCleaningTools(edm::ConsumesCollector &cc,
                              const edm::InputTag &redEBRecHits,
                              const edm::InputTag &redEERecHits);
   ~EcalClusterPUCleaningTools();
-  reco::SuperCluster CleanedSuperCluster(float xi, const reco::SuperCluster &cluster, const edm::Event &ev);
+  reco::SuperCluster CleanedSuperCluster(float xi,
+                                         const reco::SuperCluster &cluster,
+                                         const edm::Event &ev,
+                                         const edm::EventSetup &es);
 
 private:
-  void getGeometry(const edm::EventSetup &es);
-  void getEBRecHits(const edm::Event &ev, const edm::InputTag &redEBRecHits);
-  void getEERecHits(const edm::Event &ev, const edm::InputTag &redEERecHits);
+  void getEBRecHits(const edm::Event &ev);
+  void getEERecHits(const edm::Event &ev);
 
-  const CaloGeometry *geometry_;
+  const edm::EDGetTokenT<EcalRecHitCollection> pEBRecHitsToken_;
+  const edm::EDGetTokenT<EcalRecHitCollection> pEERecHitsToken_;
+  const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometryToken_;
+
   const EcalRecHitCollection *ebRecHits_;
   const EcalRecHitCollection *eeRecHits_;
 };

--- a/RecoHI/HiEgammaAlgos/interface/EcalClusterIsoCalculator.h
+++ b/RecoHI/HiEgammaAlgos/interface/EcalClusterIsoCalculator.h
@@ -3,16 +3,12 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
 #include "DataFormats/EgammaReco/interface/BasicClusterFwd.h"
 #include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
-
-#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
-#include "Geometry/Records/interface/IdealGeometryRecord.h"
 
 class EcalClusterIsoCalculator {
 public:
@@ -29,7 +25,6 @@ public:
 private:
   const reco::BasicClusterCollection *fEBclusters_;
   const reco::BasicClusterCollection *fEEclusters_;
-  const CaloGeometry *geometry_;
 };
 
 #endif

--- a/RecoHI/HiEgammaAlgos/src/EcalClusterIsoCalculator.cc
+++ b/RecoHI/HiEgammaAlgos/src/EcalClusterIsoCalculator.cc
@@ -4,12 +4,10 @@
 #include "RecoHI/HiEgammaAlgos/interface/EcalClusterIsoCalculator.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "Geometry/Records/interface/CaloGeometryRecord.h"
-#include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
-
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/EgammaReco/interface/BasicCluster.h"
 #include "DataFormats/EgammaReco/interface/SuperCluster.h"
+#include "DataFormats/Math/interface/deltaR.h"
 #include "DataFormats/Math/interface/Vector3D.h"
 
 using namespace edm;
@@ -29,13 +27,6 @@ EcalClusterIsoCalculator::EcalClusterIsoCalculator(const edm::Event &iEvent,
     fEEclusters_ = pEEclusters.product();
   else
     fEEclusters_ = nullptr;
-
-  ESHandle<CaloGeometry> geometryHandle;
-  iSetup.get<CaloGeometryRecord>().get(geometryHandle);
-  if (geometryHandle.isValid())
-    geometry_ = geometryHandle.product();
-  else
-    geometry_ = nullptr;
 }
 
 double EcalClusterIsoCalculator::getEcalClusterIso(const reco::SuperClusterRef cluster,
@@ -73,7 +64,6 @@ double EcalClusterIsoCalculator::getEcalClusterIso(const reco::SuperClusterRef c
 
   for (BasicClusterCollection::const_iterator iclu = fEEclusters_->begin(); iclu != fEEclusters_->end(); ++iclu) {
     const BasicCluster *clu = &(*iclu);
-    const GlobalPoint clusPoint(clu->x(), clu->y(), clu->z());
     math::XYZVector ClusPoint(clu->x(), clu->y(), clu->z());
     double eta = ClusPoint.eta();
 

--- a/RecoTBCalo/EcalSimpleTBAnalysis/interface/EcalSimple2007H4TBAnalyzer.h
+++ b/RecoTBCalo/EcalSimpleTBAnalysis/interface/EcalSimple2007H4TBAnalyzer.h
@@ -16,48 +16,59 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
+#include "DataFormats/EcalRecHit/interface/EcalUncalibratedRecHit.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
+#include "TBDataFormats/EcalTBObjects/interface/EcalTBHodoscopeRecInfo.h"
+#include "TBDataFormats/EcalTBObjects/interface/EcalTBTDCRecInfo.h"
+#include "TBDataFormats/EcalTBObjects/interface/EcalTBEventHeader.h"
 
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
 
 #include <string>
-//#include "TTree.h"
 #include "TH1.h"
 #include "TGraph.h"
 #include "TH2.h"
 #include <fstream>
 #include <map>
-//#include<stl_pair>
 
-class EcalSimple2007H4TBAnalyzer : public edm::EDAnalyzer {
+class EcalSimple2007H4TBAnalyzer : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   explicit EcalSimple2007H4TBAnalyzer(const edm::ParameterSet&);
   ~EcalSimple2007H4TBAnalyzer() override;
 
   void analyze(edm::Event const&, edm::EventSetup const&) override;
   void beginRun(edm::Run const&, edm::EventSetup const&) override;
+  void endRun(edm::Run const&, edm::EventSetup const&) override;
   void endJob() override;
 
 private:
-  std::string rootfile_;
-  std::string digiCollection_;
-  std::string digiProducer_;
-  std::string hitCollection_;
-  std::string hitProducer_;
-  std::string hodoRecInfoCollection_;
-  std::string hodoRecInfoProducer_;
-  std::string tdcRecInfoCollection_;
-  std::string tdcRecInfoProducer_;
-  std::string eventHeaderCollection_;
-  std::string eventHeaderProducer_;
+  const std::string rootfile_;
+  const std::string digiCollection_;
+  const std::string digiProducer_;
+  const std::string hitCollection_;
+  const std::string hitProducer_;
+  const std::string hodoRecInfoCollection_;
+  const std::string hodoRecInfoProducer_;
+  const std::string tdcRecInfoCollection_;
+  const std::string tdcRecInfoProducer_;
+  const std::string eventHeaderCollection_;
+  const std::string eventHeaderProducer_;
+
+  const edm::EDGetTokenT<EEDigiCollection> eeDigiToken_;
+  const edm::EDGetTokenT<EEUncalibratedRecHitCollection> eeUncalibratedRecHitToken_;
+  const edm::EDGetTokenT<EcalTBHodoscopeRecInfo> tbHodoscopeRecInfoToken_;
+  const edm::EDGetTokenT<EcalTBTDCRecInfo> tbTDCRecInfoToken_;
+  const edm::EDGetTokenT<EcalTBEventHeader> tbEventHeaderToken_;
+  const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometryToken_;
 
   // Amplitude vs TDC offset
   TH2F* h_ampltdc;

--- a/RecoTBCalo/EcalTBRecProducers/interface/EcalTBWeightUncalibRecHitProducer.h
+++ b/RecoTBCalo/EcalTBRecProducers/interface/EcalTBWeightUncalibRecHitProducer.h
@@ -1,22 +1,31 @@
 #ifndef RecoTBCalo_EcalTBRecProducers_EcalTBWeightUncalibRecHitProducer_HH
 #define RecoTBCalo_EcalTBRecProducers_EcalTBWeightUncalibRecHitProducer_HH
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitRecWeightsAlgo.h"
+#include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
 #include "DataFormats/EcalDigi/interface/EBDataFrame.h"
 #include "DataFormats/EcalDigi/interface/EEDataFrame.h"
 #include "TBDataFormats/EcalTBObjects/interface/EcalTBTDCRecInfo.h"
+#include "CondFormats/EcalObjects/interface/EcalPedestals.h"
+#include "CondFormats/DataRecord/interface/EcalPedestalsRcd.h"
+#include "CondFormats/EcalObjects/interface/EcalWeightXtalGroups.h"
+#include "CondFormats/DataRecord/interface/EcalWeightXtalGroupsRcd.h"
 #include "CondFormats/EcalObjects/interface/EcalWeight.h"
+#include "CondFormats/EcalObjects/interface/EcalTBWeights.h"
+#include "CondFormats/DataRecord/interface/EcalTBWeightsRcd.h"
+#include "CondFormats/EcalObjects/interface/EcalGainRatios.h"
+#include "CondFormats/DataRecord/interface/EcalGainRatiosRcd.h"
 #include "SimCalorimetry/EcalSimAlgos/interface/EBShape.h"
 #include "SimCalorimetry/EcalSimAlgos/interface/EEShape.h"
 
 // forward declaration
-class EcalTBWeightUncalibRecHitProducer : public edm::EDProducer {
+class EcalTBWeightUncalibRecHitProducer : public edm::stream::EDProducer<> {
 public:
   typedef std::vector<double> EcalRecoAmplitudes;
   explicit EcalTBWeightUncalibRecHitProducer(const edm::ParameterSet& ps);
@@ -24,15 +33,23 @@ public:
   void produce(edm::Event& evt, const edm::EventSetup& es) override;
 
 private:
-  edm::InputTag EBdigiCollection_;      // secondary name given to collection of digis
-  edm::InputTag EEdigiCollection_;      // secondary name given to collection of digis
-  edm::InputTag tdcRecInfoCollection_;  // secondary name given to collection of digis
+  const edm::InputTag ebDigiCollection_;
+  const edm::InputTag eeDigiCollection_;
+  const edm::InputTag tdcRecInfoCollection_;
 
-  std::string EBhitCollection_;  // secondary name to be given to collection of hit
-  std::string EEhitCollection_;  // secondary name to be given to collection of hit
+  const std::string ebHitCollection_;  // secondary name to be given to collection of hit
+  const std::string eeHitCollection_;  // secondary name to be given to collection of hit
 
-  EcalUncalibRecHitRecWeightsAlgo<EBDataFrame> EBalgo_;
-  EcalUncalibRecHitRecWeightsAlgo<EEDataFrame> EEalgo_;
+  const edm::EDGetTokenT<EBDigiCollection> ebDigiToken_;
+  const edm::EDGetTokenT<EEDigiCollection> eeDigiToken_;
+  const edm::EDGetTokenT<EcalTBTDCRecInfo> tbTDCRecInfoToken_;
+  const edm::ESGetToken<EcalWeightXtalGroups, EcalWeightXtalGroupsRcd> weightXtalGroupsToken_;
+  const edm::ESGetToken<EcalGainRatios, EcalGainRatiosRcd> gainRatiosToken_;
+  const edm::ESGetToken<EcalTBWeights, EcalTBWeightsRcd> tbWeightsToken_;
+  const edm::ESGetToken<EcalPedestals, EcalPedestalsRcd> pedestalsToken_;
+
+  EcalUncalibRecHitRecWeightsAlgo<EBDataFrame> ebAlgo_;
+  EcalUncalibRecHitRecWeightsAlgo<EEDataFrame> eeAlgo_;
 
   const EEShape testbeamEEShape;
   const EBShape testbeamEBShape;
@@ -40,14 +57,9 @@ private:
   /*     HepMatrix makeMatrixFromVectors(const std::vector< std::vector<EcalWeight> >& vecvec); */
   /*     HepMatrix makeDummySymMatrix(int size); */
 
-  int nbTimeBin_;
+  const int nbTimeBin_;
 
   //use 2004 convention for the TDC
-  bool use2004OffsetConvention_;
-
-  /*     int nMaxPrintout_; // max # of printouts */
-  /*     int counter_; // internal verbosity counter */
-
-  //    bool counterExceeded() const { return ( (counter_>nMaxPrintout_) || (counter_<0) ) ; }
+  const bool use2004OffsetConvention_;
 };
 #endif

--- a/RecoTBCalo/EcalTBRecProducers/src/EcalTBWeightUncalibRecHitProducer.cc
+++ b/RecoTBCalo/EcalTBRecProducers/src/EcalTBWeightUncalibRecHitProducer.cc
@@ -9,36 +9,22 @@
   *
   */
 #include "RecoTBCalo/EcalTBRecProducers/interface/EcalTBWeightUncalibRecHitProducer.h"
-#include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
 #include "DataFormats/EcalDigi/interface/EcalMGPASample.h"
 #include "DataFormats/Common/interface/Handle.h"
 
-#include <iostream>
-#include <iomanip>
 #include <cmath>
 
-#include "FWCore/Framework/interface/ESHandle.h"
-
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-#include "CondFormats/EcalObjects/interface/EcalPedestals.h"
-#include "CondFormats/DataRecord/interface/EcalPedestalsRcd.h"
 
 #include "DataFormats/EcalRecHit/interface/EcalUncalibratedRecHit.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 
 #include "CondFormats/EcalObjects/interface/EcalXtalGroupId.h"
-#include "CondFormats/EcalObjects/interface/EcalWeightXtalGroups.h"
-#include "CondFormats/DataRecord/interface/EcalWeightXtalGroupsRcd.h"
 
 #include "CondFormats/EcalObjects/interface/EcalWeight.h"
 #include "CondFormats/EcalObjects/interface/EcalWeightSet.h"
-#include "CondFormats/EcalObjects/interface/EcalTBWeights.h"
-#include "CondFormats/DataRecord/interface/EcalTBWeightsRcd.h"
 
 #include "CondFormats/EcalObjects/interface/EcalMGPAGainRatio.h"
-#include "CondFormats/EcalObjects/interface/EcalGainRatios.h"
-#include "CondFormats/DataRecord/interface/EcalGainRatiosRcd.h"
 
 #include "CLHEP/Matrix/Matrix.h"
 #include "CLHEP/Matrix/SymMatrix.h"
@@ -46,18 +32,24 @@
 
 #define DEBUG
 EcalTBWeightUncalibRecHitProducer::EcalTBWeightUncalibRecHitProducer(const edm::ParameterSet& ps)
-    : testbeamEEShape(),  // Shapes have been updated in 2018 such as to be able to fetch shape from the DB if EBShape(consumesCollector())//EEShape(consumesCollector()) are used
-      testbeamEBShape()  // use default constructor if you would rather prefer to use Phase I hardcoded shapes (18.05.2018 K. Theofilatos)
-{
-  EBdigiCollection_ = ps.getParameter<edm::InputTag>("EBdigiCollection");
-  EEdigiCollection_ = ps.getParameter<edm::InputTag>("EEdigiCollection");
-  tdcRecInfoCollection_ = ps.getParameter<edm::InputTag>("tdcRecInfoCollection");
-  EBhitCollection_ = ps.getParameter<std::string>("EBhitCollection");
-  EEhitCollection_ = ps.getParameter<std::string>("EEhitCollection");
-  nbTimeBin_ = ps.getParameter<int>("nbTimeBin");
-  use2004OffsetConvention_ = ps.getUntrackedParameter<bool>("use2004OffsetConvention", false);
-  produces<EBUncalibratedRecHitCollection>(EBhitCollection_);
-  produces<EEUncalibratedRecHitCollection>(EEhitCollection_);
+    : ebDigiCollection_(ps.getParameter<edm::InputTag>("EBdigiCollection")),
+      eeDigiCollection_(ps.getParameter<edm::InputTag>("EEdigiCollection")),
+      tdcRecInfoCollection_(ps.getParameter<edm::InputTag>("tdcRecInfoCollection")),
+      ebHitCollection_(ps.getParameter<std::string>("EBhitCollection")),
+      eeHitCollection_(ps.getParameter<std::string>("EEhitCollection")),
+      ebDigiToken_(consumes<EBDigiCollection>(ebDigiCollection_)),
+      eeDigiToken_(consumes<EEDigiCollection>(eeDigiCollection_)),
+      tbTDCRecInfoToken_(consumes<EcalTBTDCRecInfo>(tdcRecInfoCollection_)),
+      weightXtalGroupsToken_(esConsumes()),
+      gainRatiosToken_(esConsumes()),
+      tbWeightsToken_(esConsumes()),
+      pedestalsToken_(esConsumes()),
+      testbeamEEShape(), // Shapes have been updated in 2018 such as to be able to fetch shape from the DB if EBShape(consumesCollector())//EEShape(consumesCollector()) are used
+      testbeamEBShape(), // use default constructor if you would rather prefer to use Phase I hardcoded shapes (18.05.2018 K. Theofilatos)
+      nbTimeBin_(ps.getParameter<int>("nbTimeBin")),
+      use2004OffsetConvention_(ps.getUntrackedParameter<bool>("use2004OffsetConvention", false)) {
+  produces<EBUncalibratedRecHitCollection>(ebHitCollection_);
+  produces<EEUncalibratedRecHitCollection>(eeHitCollection_);
 }
 
 EcalTBWeightUncalibRecHitProducer::~EcalTBWeightUncalibRecHitProducer() {}
@@ -67,11 +59,10 @@ void EcalTBWeightUncalibRecHitProducer::produce(edm::Event& evt, const edm::Even
 
   Handle<EBDigiCollection> pEBDigis;
   const EBDigiCollection* EBdigis = nullptr;
-  if (!EBdigiCollection_.label().empty() || !EBdigiCollection_.instance().empty()) {
-    //     evt.getByLabel( digiProducer_, EBdigiCollection_, pEBDigis);
-    evt.getByLabel(EBdigiCollection_, pEBDigis);
+  if (!ebDigiCollection_.label().empty() || !ebDigiCollection_.instance().empty()) {
+    evt.getByToken(ebDigiToken_, pEBDigis);
     if (!pEBDigis.isValid()) {
-      edm::LogError("EcalUncalibRecHitError") << "Error! can't get the product " << EBdigiCollection_;
+      edm::LogError("EcalUncalibRecHitError") << "Error! can't get the product " << ebDigiCollection_;
     } else {
       EBdigis = pEBDigis.product();  // get a ptr to the produc
 #ifdef DEBUG
@@ -82,17 +73,14 @@ void EcalTBWeightUncalibRecHitProducer::produce(edm::Event& evt, const edm::Even
 
   Handle<EEDigiCollection> pEEDigis;
   const EEDigiCollection* EEdigis = nullptr;
-
-  if (!EEdigiCollection_.label().empty() || !EEdigiCollection_.instance().empty()) {
-    //     evt.getByLabel( digiProducer_, EEdigiCollection_, pEEDigis);
-    evt.getByLabel(EEdigiCollection_, pEEDigis);
+  if (!eeDigiCollection_.label().empty() || !eeDigiCollection_.instance().empty()) {
+    evt.getByToken(eeDigiToken_, pEEDigis);
     if (!pEEDigis.isValid()) {
-      edm::LogError("EcalUncalibRecHitError") << "Error! can't get the product " << EEdigiCollection_;
+      edm::LogError("EcalUncalibRecHitError") << "Error! can't get the product " << eeDigiCollection_;
     } else {
       EEdigis = pEEDigis.product();  // get a ptr to the produc
 #ifdef DEBUG
       LogDebug("EcalUncalibRecHitInfo") << "total # EEdigis: " << EEdigis->size();
-      //	 std::cout << "total # EEdigis: " << EEdigis->size() << std::endl;
 #endif
     }
   }
@@ -102,55 +90,36 @@ void EcalTBWeightUncalibRecHitProducer::produce(edm::Event& evt, const edm::Even
 
   Handle<EcalTBTDCRecInfo> pRecTDC;
   const EcalTBTDCRecInfo* recTDC = nullptr;
-
-  //     evt.getByLabel( digiProducer_, EBdigiCollection_, pEBDigis);
-  evt.getByLabel(tdcRecInfoCollection_, pRecTDC);
+  evt.getByToken(tbTDCRecInfoToken_, pRecTDC);
   if (pRecTDC.isValid()) {
     recTDC = pRecTDC.product();  // get a ptr to the product
   }
 
   // fetch map of groups of xtals
-  edm::ESHandle<EcalWeightXtalGroups> pGrp;
-  es.get<EcalWeightXtalGroupsRcd>().get(pGrp);
-  const EcalWeightXtalGroups* grp = pGrp.product();
-  if (!grp)
-    return;
+  const auto& grp = es.getData(weightXtalGroupsToken_);
 
-  const EcalXtalGroupsMap& grpMap = grp->getMap();
+  const EcalXtalGroupsMap& grpMap = grp.getMap();
 
   // Gain Ratios
-  edm::ESHandle<EcalGainRatios> pRatio;
-  es.get<EcalGainRatiosRcd>().get(pRatio);
-  const EcalGainRatioMap& gainMap = pRatio.product()->getMap();  // map of gain ratios
+  const EcalGainRatioMap& gainMap = es.getData(gainRatiosToken_).getMap();  // map of gain ratios
 
   // fetch TB weights
 #ifdef DEBUG
   LogDebug("EcalUncalibRecHitDebug") << "Fetching EcalTBWeights from DB ";
-  //   std::cout  <<"Fetching EcalTBWeights from DB " ;
 #endif
-  edm::ESHandle<EcalTBWeights> pWgts;
-  es.get<EcalTBWeightsRcd>().get(pWgts);
-  const EcalTBWeights* wgts = pWgts.product();
-
-  if (!wgts)
-    return;
+  const auto& wgts = es.getData(tbWeightsToken_);
 
 #ifdef DEBUG
-  LogDebug("EcalUncalibRecHitDebug") << "EcalTBWeightMap.size(): " << std::setprecision(3) << wgts->getMap().size();
-  //   std::cout << "EcalTBWeightMap.size(): " << std::setprecision(3) << wgts->getMap().size() ;
+  LogDebug("EcalUncalibRecHitDebug") << "EcalTBWeightMap.size(): " << std::setprecision(3) << wgts.getMap().size();
 #endif
 
   // fetch the pedestals from the cond DB via EventSetup
 #ifdef DEBUG
   LogDebug("EcalUncalibRecHitDebug") << "fetching pedestals....";
-  //   std::cout << "fetching pedestals....";
 #endif
-  edm::ESHandle<EcalPedestals> pedHandle;
-  es.get<EcalPedestalsRcd>().get(pedHandle);
-  const EcalPedestalsMap& pedMap = pedHandle.product()->getMap();  // map of pedestals
+  const EcalPedestalsMap& pedMap = es.getData(pedestalsToken_).getMap();  // map of pedestals
 #ifdef DEBUG
   LogDebug("EcalUncalibRecHitDebug") << "done.";
-  //   std::cout << "done." ;
 #endif
   // collection of reco'ed ampltudes to put in the event
 
@@ -177,8 +146,6 @@ void EcalTBWeightUncalibRecHitProducer::produce(edm::Event& evt, const edm::Even
   if (EBdigis) {
     for (unsigned int idig = 0; idig < EBdigis->size(); ++idig) {
       EBDataFrame itdg = (*EBdigis)[idig];
-
-      //     counter_++; // verbosity counter
 
       // find pedestals for this channel
 #ifdef DEBUG
@@ -268,8 +235,8 @@ void EcalTBWeightUncalibRecHitProducer::produce(edm::Event& evt, const edm::Even
       }  //check TDC
 
       // now lookup the correct weights in the map
-      wit = wgts->getMap().find(std::make_pair(gid, tdcid));
-      if (wit == wgts->getMap().end()) {  // no weights found for this group ID
+      wit = wgts.getMap().find(std::make_pair(gid, tdcid));
+      if (wit == wgts.getMap().end()) {  // no weights found for this group ID
         edm::LogError("EcalUncalibRecHitError")
             << "No weights found for EcalGroupId: " << gid.id() << " and  EcalTDCId: " << tdcid
             << "\n  skipping digi with id: " << EBDetId(itdg.id());
@@ -299,8 +266,7 @@ void EcalTBWeightUncalibRecHitProducer::produce(edm::Event& evt, const edm::Even
       // chi2mat[0]=&mat3;
       // chi2mat[1]=&mat4;
 
-      EcalUncalibratedRecHit aHit = EBalgo_.makeRecHit(itdg, pedVec, pedRMSVec, gainRatios, weights, testbeamEBShape);
-      //EBalgo_.makeRecHit(itdg, pedVec, gainRatios, weights, chi2mat);
+      EcalUncalibratedRecHit aHit = ebAlgo_.makeRecHit(itdg, pedVec, pedRMSVec, gainRatios, weights, testbeamEBShape);
       EBuncalibRechits->push_back(aHit);
 #ifdef DEBUG
       if (aHit.amplitude() > 0.) {
@@ -311,18 +277,15 @@ void EcalTBWeightUncalibRecHitProducer::produce(edm::Event& evt, const edm::Even
     }
   }
   // put the collection of reconstructed hits in the event
-  evt.put(std::move(EBuncalibRechits), EBhitCollection_);
+  evt.put(std::move(EBuncalibRechits), ebHitCollection_);
 
   if (EEdigis) {
     for (unsigned int idig = 0; idig < EEdigis->size(); ++idig) {
       EEDataFrame itdg = (*EEdigis)[idig];
 
-      //     counter_++; // verbosity counter
-
       // find pedestals for this channel
 #ifdef DEBUG
       LogDebug("EcalUncalibRecHitDebug") << "looking up pedestal for crystal: " << EEDetId(itdg.id());
-      //	 std::cout << "looking up pedestal for crystal: " << EEDetId(itdg.id()) ;
 #endif
       pedIter = pedMap.find(itdg.id().rawId());
       if (pedIter == pedMap.end()) {
@@ -344,7 +307,6 @@ void EcalTBWeightUncalibRecHitProducer::produce(edm::Event& evt, const edm::Even
       // find gain ratios
 #ifdef DEBUG
       LogDebug("EcalUncalibRecHitDebug") << "looking up gainRatios for crystal: " << EEDetId(itdg.id());
-      //	 std::cout << "looking up gainRatios for crystal: " << EEDetId(itdg.id()) ;
 #endif
       gainIter = gainMap.find(itdg.id().rawId());
       if (gainIter == gainMap.end()) {
@@ -409,8 +371,8 @@ void EcalTBWeightUncalibRecHitProducer::produce(edm::Event& evt, const edm::Even
       }  //check TDC
 
       // now lookup the correct weights in the map
-      wit = wgts->getMap().find(std::make_pair(gid, tdcid));
-      if (wit == wgts->getMap().end()) {  // no weights found for this group ID
+      wit = wgts.getMap().find(std::make_pair(gid, tdcid));
+      if (wit == wgts.getMap().end()) {  // no weights found for this group ID
         edm::LogError("EcalUncalibRecHitError")
             << "No weights found for EcalGroupId: " << gid.id() << " and  EcalTDCId: " << tdcid
             << "\n  skipping digi with id: " << EEDetId(itdg.id());
@@ -422,7 +384,6 @@ void EcalTBWeightUncalibRecHitProducer::produce(edm::Event& evt, const edm::Even
 
 #ifdef DEBUG
       LogDebug("EcalUncalibRecHitDebug") << "accessing matrices of weights...";
-      //	 std::cout << "accessing matrices of weights...";
 #endif
       const EcalWeightSet::EcalWeightMatrix& mat1 = wset.getWeightsBeforeGainSwitch();
       const EcalWeightSet::EcalWeightMatrix& mat2 = wset.getWeightsAfterGainSwitch();
@@ -441,24 +402,18 @@ void EcalTBWeightUncalibRecHitProducer::produce(edm::Event& evt, const edm::Even
       //chi2mat[0]=&mat3;
       //chi2mat[1]=&mat4;
 
-      EcalUncalibratedRecHit aHit = EEalgo_.makeRecHit(itdg, pedVec, pedRMSVec, gainRatios, weights, testbeamEEShape);
-      //EEalgo_.makeRecHit(itdg, pedVec, gainRatios, weights, chi2mat);
+      EcalUncalibratedRecHit aHit = eeAlgo_.makeRecHit(itdg, pedVec, pedRMSVec, gainRatios, weights, testbeamEEShape);
       EEuncalibRechits->push_back(aHit);
 #ifdef DEBUG
       if (aHit.amplitude() > 0.) {
         LogDebug("EcalUncalibRecHitDebug") << "processed EEDataFrame with id: " << EEDetId(itdg.id()) << "\n"
-                                           << "uncalib rechit amplitude: " << aHit.amplitude()
-
-            // 	   std::cout << "processed EEDataFrame with id: "
-            //                   << EEDetId(itdg.id()) << "\n"
-            //                   << "uncalib rechit amplitude: " << aHit.amplitude() << std::endl;
-            ;
+                                           << "uncalib rechit amplitude: " << aHit.amplitude();
       }
 #endif
     }
   }
   // put the collection of reconstructed hits in the event
-  evt.put(std::move(EEuncalibRechits), EEhitCollection_);
+  evt.put(std::move(EEuncalibRechits), eeHitCollection_);
 }
 
 // HepMatrix

--- a/RecoTBCalo/EcalTBRecProducers/src/EcalTBWeightUncalibRecHitProducer.cc
+++ b/RecoTBCalo/EcalTBRecProducers/src/EcalTBWeightUncalibRecHitProducer.cc
@@ -44,8 +44,8 @@ EcalTBWeightUncalibRecHitProducer::EcalTBWeightUncalibRecHitProducer(const edm::
       gainRatiosToken_(esConsumes()),
       tbWeightsToken_(esConsumes()),
       pedestalsToken_(esConsumes()),
-      testbeamEEShape(), // Shapes have been updated in 2018 such as to be able to fetch shape from the DB if EBShape(consumesCollector())//EEShape(consumesCollector()) are used
-      testbeamEBShape(), // use default constructor if you would rather prefer to use Phase I hardcoded shapes (18.05.2018 K. Theofilatos)
+      testbeamEEShape(),  // Shapes have been updated in 2018 such as to be able to fetch shape from the DB if EBShape(consumesCollector())//EEShape(consumesCollector()) are used
+      testbeamEBShape(),  // use default constructor if you would rather prefer to use Phase I hardcoded shapes (18.05.2018 K. Theofilatos)
       nbTimeBin_(ps.getParameter<int>("nbTimeBin")),
       use2004OffsetConvention_(ps.getUntrackedParameter<bool>("use2004OffsetConvention", false)) {
   produces<EBUncalibratedRecHitCollection>(ebHitCollection_);


### PR DESCRIPTION
#### PR description:

This PR migrates ECAL related code in the various reco and db packages to esConsumes (#31061). In addition `getByLabel()` calls were replaced by `getByToken()`and legacy module types were migrated to multithreaded module types.

#### PR validation:

Code compiles.
