### PR TITLE
HCAL Simulation : reformatted HF Shower Library for Run3

### DIFF
--- a/Geometry/HcalSimData/python/HFParameters_cff.py
+++ b/Geometry/HcalSimData/python/HFParameters_cff.py
@@ -33,5 +33,5 @@ run2_common.toModify( HFShowerBlock, ProbMax = 0.5 )
 ## Change for the new HFShowerLibrary file to be used for Run 3
 ##
 from Configuration.Eras.Modifier_run3_HFSL_cff import run3_HFSL
-run3_HFSL.toModify( HFLibraryFileBlock, FileName = 'SimG4CMS/Calo/data/HFShowerLibrary_run3_v5.root', FileVersion = 1 )
+run3_HFSL.toModify( HFLibraryFileBlock, FileName = 'SimG4CMS/Calo/data/HFShowerLibrary_run3_v6.root', FileVersion = 2 )
 run3_HFSL.toModify( HFShowerBlock, EqualizeTimeShift = True )

--- a/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
+++ b/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
@@ -180,10 +180,10 @@ run3_common.toModify( hcalSimParameters,
                readoutFrameSize = cms.int32(10), 
                binOfMaximum     = cms.int32(6)
               ),
-    hf1 = dict( samplingFactor = 0.36,
+    hf1 = dict( samplingFactor = 0.37,
                 timePhase = 9.0 
                ),
-    hf2 = dict( samplingFactor = 0.36,
+    hf2 = dict( samplingFactor = 0.37,
                 timePhase = 8.0
                )
 ) 

--- a/SimG4CMS/Calo/src/HFShowerLibrary.cc
+++ b/SimG4CMS/Calo/src/HFShowerLibrary.cc
@@ -354,7 +354,8 @@ void HFShowerLibrary::getRecord(int type, int record) {
     if (newForm) {
       if (!v3version) {
         hadBranch->SetAddress(&photo);
-        hadBranch->GetEntry(nrc + totEvents);
+        int position = (fileVersion_ >= 2) ? nrc : (nrc + totEvents);
+        hadBranch->GetEntry(position);
       } else {
         std::vector<float> t;
         std::vector<float>* tp = &t;

--- a/SimG4CMS/ShowerLibraryProducer/interface/HcalForwardLibWriter.h
+++ b/SimG4CMS/ShowerLibraryProducer/interface/HcalForwardLibWriter.h
@@ -50,6 +50,8 @@ private:
   TTree* theTree;
   TFile* LibFile;
   TTree* LibTree;
+  TBranch* emBranch;
+  TBranch* hadBranch;
 
   edm::Service<TFileService> fs;
   std::string theDataFile;

--- a/SimG4CMS/ShowerLibraryProducer/plugins/HcalForwardLibWriter.cc
+++ b/SimG4CMS/ShowerLibraryProducer/plugins/HcalForwardLibWriter.cc
@@ -27,8 +27,8 @@ HcalForwardLibWriter::HcalForwardLibWriter(const edm::ParameterSet& iConfig) {
 
   //https://root.cern/root/html534/TTree.html
   // TBranch*Branch(const char* name, const char* classname, void** obj, Int_t bufsize = 32000, Int_t splitlevel = 99)
-  LibTree->Branch("emParticles", "HFShowerPhotons-emParticles", &emColl, bsize, splitlevel);
-  LibTree->Branch("hadParticles", "HFShowerPhotons-hadParticles", &hadColl, bsize, splitlevel);
+  emBranch = LibTree->Branch("emParticles", "HFShowerPhotons-emParticles", &emColl, bsize, splitlevel);
+  hadBranch = LibTree->Branch("hadParticles", "HFShowerPhotons-hadParticles", &hadColl, bsize, splitlevel);
 }
 
 HcalForwardLibWriter::~HcalForwardLibWriter() {}
@@ -40,6 +40,9 @@ void HcalForwardLibWriter::analyze(const edm::Event& iEvent, const edm::EventSet
   en.reserve(nbins);
   for (int i = 0; i < nbins; ++i)
     en.push_back(momBin[i]);
+
+  int nem = 0;
+  int nhad = 0;
 
   //shower photons
   int n = theFileHandle.size();
@@ -113,16 +116,15 @@ void HcalForwardLibWriter::analyze(const edm::Event& iEvent, const edm::EventSet
       }
       // end of cycle over photons in shower -------------------------------------------
 
-      //        if(iev>0) LibTree->SetBranchStatus("HFShowerLibInfo",0);
       if (particle == "electron") {
-        LibTree->SetBranchStatus("hadParticles", false);
-      } else {
-        LibTree->SetBranchStatus("emParticles", false);
-      }
-      LibTree->Fill();
-      if (particle == "electron") {
+        LibTree->SetEntries(nem + 1);
+        emBranch->Fill();
+        nem++;
         emColl.clear();
       } else {
+        LibTree->SetEntries(nhad + 1);
+        nhad++;
+        hadBranch->Fill();
         hadColl.clear();
       }
     }

--- a/SimG4CMS/ShowerLibraryProducer/test/README_SL_production_recipe.txt
+++ b/SimG4CMS/ShowerLibraryProducer/test/README_SL_production_recipe.txt
@@ -1,0 +1,40 @@
+(1) 
+Use configuration file runHFShowerTMP_cfg.py in directory
+/CMSSW_12_*_*/src/SimG4CMS/ShowerLibraryProducer/test/python.
+with EDProducer parameters as listed below (here - for electrons of 100 GeV):
+        PartID = cms.vint32(11),
+        MinEta = cms.double(4),
+        MaxEta = cms.double(4),
+        MinPhi = cms.double(-3.14159265359),
+        MaxPhi = cms.double(3.14159265359),
+        MinE   = cms.double(100),
+        MaxE   = cms.double(100)
+to perform a full simulation of showers in HF.
+Do it for all necessary energy points separately for pions and electrons.
+
+(2)
+Incident angle fixed to eta=4 and with random phi. 
+The grid of energies is specified in the file 
+/CMSSW_12_*_*/src/SimG4CMS/ShowerLibraryProducer/data/fileList.txt.
+Energies from the list should be used in the producer parameter list above (1).
+
+(3)
+Simulation is performed in special geometry with a staring point at 1000 mm from HF surface filled with air.
+To produce a sample with 10k showers for each energy, the number of simulated events should be somewhat bigger, 
+since some part of incident particles interacts in the air. 
+The latter showers are excluded from final sample and exactly 10k showers are selected and recorded. 
+So in production configuration file, number of event should be set this way: 
+    process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(11000)
+)
+
+(4)
+Once 16*2 samples of showers are produced, they should be moved to the directory 
+/CMSSW_12_*_*/src/SimG4CMS/ShowerLibraryProducer/python,
+where HF ShowerLibrary can be assembled from these input files using writelibraryfile_cfg.py [*]
+
+
+-----
+[*]
+Source file /CMSSW_*_*/src/SimG4CMS/ShowerLibraryProducer/plugins/HcalForwardLibWriter.cc 
+Configuration file is /CMSSW_12_*_*/src/SimG4CMS/ShowerLibraryProducer/python/writelibraryfile_cfg.py

--- a/SimG4CMS/ShowerLibraryProducer/test/README_SL_production_recipe.txt
+++ b/SimG4CMS/ShowerLibraryProducer/test/README_SL_production_recipe.txt
@@ -10,7 +10,7 @@ with EDProducer parameters as listed below (here - for electrons of 100 GeV):
         MinE   = cms.double(100),
         MaxE   = cms.double(100)
 to perform a full simulation of showers in HF.
-Do it for all necessary energy points separately for pions and electrons.
+Do it for all necessary energy points, separately for pions and electrons.
 
 (2)
 Incident angle fixed to eta=4 and with random phi. 
@@ -19,8 +19,8 @@ The grid of energies is specified in the file
 Energies from the list should be used in the producer parameter list above (1).
 
 (3)
-Simulation is performed in special geometry with a staring point at 1000 mm from HF surface filled with air.
-To produce a sample with 10k showers for each energy, the number of simulated events should be somewhat bigger, 
+Simulation is performed using special geometry with a starting point at 1000 mm from HF surface, the path filled with air.
+To produce a sample of 10k showers for each energy, the number of simulated events should be somewhat bigger, 
 since some part of incident particles interacts in the air. 
 The latter showers are excluded from final sample and exactly 10k showers are selected and recorded. 
 So in production configuration file, number of event should be set this way: 


### PR DESCRIPTION
#### PR description:

Much faster CPU-wise access to HF ShowerLibrary (SL) content, as suggested by Lev Kheyn:
https://indico.cern.ch/event/1071568/contributions/4510124/attachments/2303109/3917905/HF_SL_perf_lk_03_09_2021.pdf

The content _per se_ didn't change physics-wise, just has been rearranged/reassembled differently. 
Private tests show no change of GEANT history.

**NB**: needs  availability of HFShowerLibrary_run3_v6.root  for RelVal/Jenkins tests  
https://github.com/cms-sw/cmsdist/pull/7269  

PR includes:
(1)  SL assembling/production code modifications, allowing for performant splitLevel=0; 
(2)  SL-reading modification, back-compatible with previous SL versions ;
(3) small adjustment/reduction of HF reco energy scale  by ~3% (via Digitization config); 
(4) SL-production "README" recipe.

#### PR validation:

Single-pion gun ("CaloScan")  private 2021 test yields no change in 12_1_0_pre2 : 
(i)  with this branch (PR) _without_ aformentionent component (3)  
      wrt 
(ii) actual default
https://cms-cpt-software.web.cern.ch/cms-cpt-software/General/Validation/SVSuite/HCAL/calo_scan_single_pi/12_1_X/12_1_0_pre2_reformSL_run3_vs_12_1_0_pre2_run3_SinglePi/
