### PR TITLE
Run3-hcx319 Make use of ESGetToken in SimCalorimetry/HcalSimProducers

### DIFF
--- a/SimCalorimetry/HcalSimAlgos/interface/HcalSignalGenerator.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalSignalGenerator.h
@@ -2,7 +2,6 @@
 #define HcalSimAlgos_HcalSignalGenerator_h
 
 #include "SimCalorimetry/HcalSimAlgos/interface/HcalBaseSignalGenerator.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventPrincipal.h"
@@ -40,17 +39,17 @@ public:
 
   ~HcalSignalGenerator() override {}
 
-  void initializeEvent(const edm::Event* event, const edm::EventSetup* eventSetup) {
+  void initializeEvent(const edm::Event* event, const edm::EventSetup* eventSetup, const edm::ESGetToken<HcalDbService, HcalDbRecord>& tok) {
     theEvent = event;
-    eventSetup->get<HcalDbRecord>().get(theConditions);
-    theParameterMap->setDbService(theConditions.product());
+    theConditions = &(eventSetup->getData(tok));
+    theParameterMap->setDbService(theConditions);
   }
 
   /// some users use EventPrincipals, not Events.  We support both
-  void initializeEvent(const edm::EventPrincipal* eventPrincipal, const edm::EventSetup* eventSetup) {
+  void initializeEvent(const edm::EventPrincipal* eventPrincipal, const edm::EventSetup* eventSetup, const edm::ESGetToken<HcalDbService, HcalDbRecord>& tok) {
     theEventPrincipal = eventPrincipal;
-    eventSetup->get<HcalDbRecord>().get(theConditions);
-    theParameterMap->setDbService(theConditions.product());
+    theConditions = &(eventSetup->getData(tok));
+    theParameterMap->setDbService(theConditions);
   }
 
   virtual void fill(edm::ModuleCallingContext const* mcc) {
@@ -156,7 +155,7 @@ private:
   /// these fields are set in initializeEvent()
   const edm::Event* theEvent;
   const edm::EventPrincipal* theEventPrincipal;
-  edm::ESHandle<HcalDbService> theConditions;
+  const HcalDbService* theConditions;
   /// these come from the ParameterSet
   edm::InputTag theInputTag;
   edm::EDGetTokenT<COLLECTION> tok_;

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalSignalGenerator.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalSignalGenerator.h
@@ -39,14 +39,18 @@ public:
 
   ~HcalSignalGenerator() override {}
 
-  void initializeEvent(const edm::Event* event, const edm::EventSetup* eventSetup, const edm::ESGetToken<HcalDbService, HcalDbRecord>& tok) {
+  void initializeEvent(const edm::Event* event,
+                       const edm::EventSetup* eventSetup,
+                       const edm::ESGetToken<HcalDbService, HcalDbRecord>& tok) {
     theEvent = event;
     theConditions = &(eventSetup->getData(tok));
     theParameterMap->setDbService(theConditions);
   }
 
   /// some users use EventPrincipals, not Events.  We support both
-  void initializeEvent(const edm::EventPrincipal* eventPrincipal, const edm::EventSetup* eventSetup, const edm::ESGetToken<HcalDbService, HcalDbRecord>& tok) {
+  void initializeEvent(const edm::EventPrincipal* eventPrincipal,
+                       const edm::EventSetup* eventSetup,
+                       const edm::ESGetToken<HcalDbService, HcalDbRecord>& tok) {
     theEventPrincipal = eventPrincipal;
     theConditions = &(eventSetup->getData(tok));
     theParameterMap->setDbService(theConditions);

--- a/SimCalorimetry/HcalSimAlgos/src/HcalShapes.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalShapes.cc
@@ -1,6 +1,4 @@
 #include "SimCalorimetry/HcalSimAlgos/interface/HcalShapes.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/EventSetup.h"
 #include "SimCalorimetry/CaloSimAlgos/interface/CaloCachedShapeIntegrator.h"
 #include "CondFormats/HcalObjects/interface/HcalMCParam.h"
 #include "CondFormats/HcalObjects/interface/HcalMCParams.h"

--- a/SimCalorimetry/HcalSimAlgos/test/CaloSamplesAnalyzer.cc
+++ b/SimCalorimetry/HcalSimAlgos/test/CaloSamplesAnalyzer.cc
@@ -4,7 +4,6 @@
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -93,6 +92,9 @@ private:
   //tokens
   edm::EDGetTokenT<std::vector<PCaloHit>> tok_sim;
   edm::EDGetTokenT<std::vector<CaloSamples>> tok_calo;
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> tokGeom_;
+  edm::ESGetToken<HcalDDDRecConstants, HcalRecNumberingRecord> tokRecCns_;
+  edm::ESGetToken<HcalDbService,HcalDbRecord> tokDB_;
 };
 
 //
@@ -107,7 +109,10 @@ CaloSamplesAnalyzer::CaloSamplesAnalyzer(const edm::ParameterSet& iConfig)
       TestNumbering(iConfig.getParameter<bool>("TestNumbering")),
       tok_sim(consumes<std::vector<PCaloHit>>(
           edm::InputTag(iConfig.getParameter<std::string>("hitsProducer"), "HcalHits"))),
-      tok_calo(consumes<std::vector<CaloSamples>>(iConfig.getParameter<edm::InputTag>("CaloSamplesTag"))) {
+      tok_calo(consumes<std::vector<CaloSamples>>(iConfig.getParameter<edm::InputTag>("CaloSamplesTag"))),
+      tokGeom_(esConsumes<CaloGeometry, CaloGeometryRecord, edm::Transition::BeginRun>()),
+  tokRecCns_(esConsumes<HcalDDDRecConstants, HcalRecNumberingRecord, edm::Transition::BeginRun>()),
+  tokDB_(esConsumes<HcalDbService,HcalDbRecord>()) {
   usesResource("TFileService");
 }
 
@@ -143,15 +148,13 @@ void CaloSamplesAnalyzer::beginJob() {
 }
 
 void CaloSamplesAnalyzer::doBeginRun_(const edm::Run& iRun, const edm::EventSetup& iSetup) {
-  edm::ESHandle<CaloGeometry> geometry;
-  iSetup.get<CaloGeometryRecord>().get(geometry);
-  edm::ESHandle<HcalDDDRecConstants> pHRNDC;
-  iSetup.get<HcalRecNumberingRecord>().get(pHRNDC);
+  auto geometry = &iSetup.getData(tokGeom_);
+  auto pHRNDC = &iSetup.getData(tokRecCns_);
 
   // See if it's been updated
-  if (&*geometry != theGeometry) {
-    theGeometry = &*geometry;
-    theRecNumber = &*pHRNDC;
+  if (geometry != theGeometry) {
+    theGeometry = geometry;
+    theRecNumber = pHRNDC;
     theResponse->setGeometry(theGeometry);
   }
 }
@@ -161,9 +164,8 @@ void CaloSamplesAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetu
   treemap.clear();
 
   //conditions
-  edm::ESHandle<HcalDbService> conditions;
-  iSetup.get<HcalDbRecord>().get(conditions);
-  theParameterMap->setDbService(conditions.product());
+  auto conditions = &iSetup.getData(tokDB_);
+  theParameterMap->setDbService(conditions);
 
   // Event information
   const edm::EventAuxiliary& aux = iEvent.eventAuxiliary();

--- a/SimCalorimetry/HcalSimAlgos/test/CaloSamplesAnalyzer.cc
+++ b/SimCalorimetry/HcalSimAlgos/test/CaloSamplesAnalyzer.cc
@@ -94,7 +94,7 @@ private:
   edm::EDGetTokenT<std::vector<CaloSamples>> tok_calo;
   edm::ESGetToken<CaloGeometry, CaloGeometryRecord> tokGeom_;
   edm::ESGetToken<HcalDDDRecConstants, HcalRecNumberingRecord> tokRecCns_;
-  edm::ESGetToken<HcalDbService,HcalDbRecord> tokDB_;
+  edm::ESGetToken<HcalDbService, HcalDbRecord> tokDB_;
 };
 
 //
@@ -111,8 +111,8 @@ CaloSamplesAnalyzer::CaloSamplesAnalyzer(const edm::ParameterSet& iConfig)
           edm::InputTag(iConfig.getParameter<std::string>("hitsProducer"), "HcalHits"))),
       tok_calo(consumes<std::vector<CaloSamples>>(iConfig.getParameter<edm::InputTag>("CaloSamplesTag"))),
       tokGeom_(esConsumes<CaloGeometry, CaloGeometryRecord, edm::Transition::BeginRun>()),
-  tokRecCns_(esConsumes<HcalDDDRecConstants, HcalRecNumberingRecord, edm::Transition::BeginRun>()),
-  tokDB_(esConsumes<HcalDbService,HcalDbRecord>()) {
+      tokRecCns_(esConsumes<HcalDDDRecConstants, HcalRecNumberingRecord, edm::Transition::BeginRun>()),
+      tokDB_(esConsumes<HcalDbService, HcalDbRecord>()) {
   usesResource("TFileService");
 }
 

--- a/SimCalorimetry/HcalSimAlgos/test/HcalDigitizerTest.cc
+++ b/SimCalorimetry/HcalSimAlgos/test/HcalDigitizerTest.cc
@@ -31,7 +31,6 @@
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
 #include "Geometry/HcalTowerAlgo/interface/HcalHardcodeGeometryLoader.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -61,10 +60,15 @@ private:
   std::vector<DetId> hcalDetIds, hoDetIds, hfDetIds, hzdcDetIds, allDetIds;
   std::vector<HcalDetId> outerHcalDetIds;
 
+  const edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> tok_htopo_;
+  const edm::ESGetToken<HcalTimeSlew, HcalTimeSlewRecord> tok_slew_;
+
   const HcalTimeSlew* hcalTimeSlew_delay_;
 };
 
-HcalDigitizerTest::HcalDigitizerTest(const edm::ParameterSet& iConfig) {
+HcalDigitizerTest::HcalDigitizerTest(const edm::ParameterSet& iConfig) :
+  tok_htopo_(esConsumes<HcalTopology, HcalRecNumberingRecord>()),
+  tok_slew_(esConsumes<HcalTimeSlew, HcalTimeSlewRecord>(edm::ESInputTag("", "HBHE"))) {
   //DB helper preparation
   dbHardcode.setHB(HcalHardcodeParameters(iConfig.getParameter<edm::ParameterSet>("hb")));
   dbHardcode.setHE(HcalHardcodeParameters(iConfig.getParameter<edm::ParameterSet>("he")));
@@ -130,13 +134,8 @@ void HcalDigitizerTest::beginJob() {
 }
 
 void HcalDigitizerTest::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  edm::ESHandle<HcalTopology> htopo;
-  iSetup.get<HcalRecNumberingRecord>().get(htopo);
-  HcalTopology topology = (*htopo);
-
-  edm::ESHandle<HcalTimeSlew> delay;
-  iSetup.get<HcalTimeSlewRecord>().get("HBHE", delay);
-  hcalTimeSlew_delay_ = &*delay;
+  auto topology = iSetup.getData(tok_htopo_);
+  hcalTimeSlew_delay_ = &iSetup.getData(tok_slew_);
 
   std::string hitsName = "HcalHits";
   std::vector<std::string> caloDets;

--- a/SimCalorimetry/HcalSimAlgos/test/HcalDigitizerTest.cc
+++ b/SimCalorimetry/HcalSimAlgos/test/HcalDigitizerTest.cc
@@ -66,9 +66,9 @@ private:
   const HcalTimeSlew* hcalTimeSlew_delay_;
 };
 
-HcalDigitizerTest::HcalDigitizerTest(const edm::ParameterSet& iConfig) :
-  tok_htopo_(esConsumes<HcalTopology, HcalRecNumberingRecord>()),
-  tok_slew_(esConsumes<HcalTimeSlew, HcalTimeSlewRecord>(edm::ESInputTag("", "HBHE"))) {
+HcalDigitizerTest::HcalDigitizerTest(const edm::ParameterSet& iConfig)
+    : tok_htopo_(esConsumes<HcalTopology, HcalRecNumberingRecord>()),
+      tok_slew_(esConsumes<HcalTimeSlew, HcalTimeSlewRecord>(edm::ESInputTag("", "HBHE"))) {
   //DB helper preparation
   dbHardcode.setHB(HcalHardcodeParameters(iConfig.getParameter<edm::ParameterSet>("hb")));
   dbHardcode.setHE(HcalHardcodeParameters(iConfig.getParameter<edm::ParameterSet>("he")));

--- a/SimCalorimetry/HcalSimAlgos/test/HcalSignalGeneratorTest.cpp
+++ b/SimCalorimetry/HcalSimAlgos/test/HcalSignalGeneratorTest.cpp
@@ -1,11 +1,11 @@
 // user include files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "SimCalorimetry/HcalSimAlgos/interface/HcalSignalGenerator.h"
 
-class HcalSignalGeneratorTest : public edm::EDAnalyzer {
+class HcalSignalGeneratorTest : public edm::one::EDAnalyzer<> {
 public:
   explicit HcalSignalGeneratorTest(const edm::ParameterSet&);
   ~HcalSignalGeneratorTest() override {}
@@ -34,6 +34,7 @@ private:
   edm::EDGetTokenT<HcalQIE11DigitizerTraits::DigiCollection> tok_qie11_;
 
   edm::InputTag theHBHETag_, theHOTag_, theHFTag_, theZDCTag_, theQIE10Tag_, theQIE11Tag_;
+  const edm::ESGetToken<HcalDbService, HcalDbRecord> tokDB_;
 };
 
 HcalSignalGeneratorTest::HcalSignalGeneratorTest(const edm::ParameterSet& iConfig)
@@ -43,7 +44,8 @@ HcalSignalGeneratorTest::HcalSignalGeneratorTest(const edm::ParameterSet& iConfi
       theHFTag_(iConfig.getParameter<edm::InputTag>("HFdigiCollectionPile")),
       theZDCTag_(iConfig.getParameter<edm::InputTag>("ZDCdigiCollectionPile")),
       theQIE10Tag_(iConfig.getParameter<edm::InputTag>("QIE10digiCollectionPile")),
-      theQIE11Tag_(iConfig.getParameter<edm::InputTag>("QIE11digiCollectionPile")) {
+      theQIE11Tag_(iConfig.getParameter<edm::InputTag>("QIE11digiCollectionPile")),
+      tokDB_(esConsumes<HcalDbService, HcalDbRecord>()) {
   tok_hbhe_ = consumes<HBHEDigitizerTraits::DigiCollection>(theHBHETag_);
   tok_ho_ = consumes<HODigitizerTraits::DigiCollection>(theHOTag_);
   tok_hf_ = consumes<HFDigitizerTraits::DigiCollection>(theHFTag_);
@@ -67,12 +69,12 @@ HcalSignalGeneratorTest::HcalSignalGeneratorTest(const edm::ParameterSet& iConfi
 }
 
 void HcalSignalGeneratorTest::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  theHBHESignalGenerator.initializeEvent(&iEvent, &iSetup);
-  theHOSignalGenerator.initializeEvent(&iEvent, &iSetup);
-  theHFSignalGenerator.initializeEvent(&iEvent, &iSetup);
-  theZDCSignalGenerator.initializeEvent(&iEvent, &iSetup);
-  theQIE10SignalGenerator.initializeEvent(&iEvent, &iSetup);
-  theQIE11SignalGenerator.initializeEvent(&iEvent, &iSetup);
+  theHBHESignalGenerator.initializeEvent(&iEvent, &iSetup, tokDB_);
+  theHOSignalGenerator.initializeEvent(&iEvent, &iSetup, tokDB_);
+  theHFSignalGenerator.initializeEvent(&iEvent, &iSetup, tokDB_);
+  theZDCSignalGenerator.initializeEvent(&iEvent, &iSetup, tokDB_);
+  theQIE10SignalGenerator.initializeEvent(&iEvent, &iSetup, tokDB_);
+  theQIE11SignalGenerator.initializeEvent(&iEvent, &iSetup, tokDB_);
 
   theHBHESignalGenerator.fill(nullptr);
   theHOSignalGenerator.fill(nullptr);

--- a/SimCalorimetry/HcalSimProducers/plugins/PreMixingHcalWorker.cc
+++ b/SimCalorimetry/HcalSimProducers/plugins/PreMixingHcalWorker.cc
@@ -57,6 +57,8 @@ private:
   edm::EDGetTokenT<HcalQIE10DigitizerTraits::DigiCollection> tok_qie10_;
   edm::EDGetTokenT<HcalQIE11DigitizerTraits::DigiCollection> tok_qie11_;
 
+  const edm::ESGetToken<HcalDbService, HcalDbRecord> tokDB_;
+
   HcalDigiProducer myHcalDigitizer_;
   HBHESignalGenerator theHBHESignalGenerator;
   HOSignalGenerator theHOSignalGenerator;
@@ -76,6 +78,7 @@ PreMixingHcalWorker::PreMixingHcalWorker(const edm::ParameterSet &ps,
       ZDCPileInputTag_(ps.getParameter<edm::InputTag>("ZDCPileInputTag")),
       QIE10PileInputTag_(ps.getParameter<edm::InputTag>("QIE10PileInputTag")),
       QIE11PileInputTag_(ps.getParameter<edm::InputTag>("QIE11PileInputTag")),
+      tokDB_(iC.esConsumes()),
       myHcalDigitizer_(ps, iC) {
   tok_hbhe_ = iC.consumes<HBHEDigitizerTraits::DigiCollection>(HBHEPileInputTag_);
   tok_ho_ = iC.consumes<HODigitizerTraits::DigiCollection>(HOPileInputTag_);
@@ -135,12 +138,12 @@ void PreMixingHcalWorker::addPileups(const PileUpEventPrincipal &pep, const edm:
   LogDebug("PreMixingHcalWorker") << "\n===============> adding pileups from event  " << ep.id()
                                   << " for bunchcrossing " << pep.bunchCrossing();
 
-  theHBHESignalGenerator.initializeEvent(&ep, &ES);
-  theHOSignalGenerator.initializeEvent(&ep, &ES);
-  theHFSignalGenerator.initializeEvent(&ep, &ES);
-  theZDCSignalGenerator.initializeEvent(&ep, &ES);
-  theQIE10SignalGenerator.initializeEvent(&ep, &ES);
-  theQIE11SignalGenerator.initializeEvent(&ep, &ES);
+  theHBHESignalGenerator.initializeEvent(&ep, &ES, tokDB_);
+  theHOSignalGenerator.initializeEvent(&ep, &ES, tokDB_);
+  theHFSignalGenerator.initializeEvent(&ep, &ES, tokDB_);
+  theZDCSignalGenerator.initializeEvent(&ep, &ES, tokDB_);
+  theQIE10SignalGenerator.initializeEvent(&ep, &ES, tokDB_);
+  theQIE11SignalGenerator.initializeEvent(&ep, &ES, tokDB_);
 
   // put digis from pileup event into digitizer
 

--- a/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorkerProd.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorkerProd.cc
@@ -16,7 +16,9 @@
 using namespace std;
 namespace edm {
   // Constructor
-  DataMixingHcalDigiWorkerProd::DataMixingHcalDigiWorkerProd(const edm::ParameterSet &ps, edm::ConsumesCollector &&iC, const edm::ESGetToken<HcalDbService, HcalDbRecord>& tok)
+  DataMixingHcalDigiWorkerProd::DataMixingHcalDigiWorkerProd(const edm::ParameterSet &ps,
+                                                             edm::ConsumesCollector &&iC,
+                                                             const edm::ESGetToken<HcalDbService, HcalDbRecord> &tok)
       : HBHEPileInputTag_(ps.getParameter<edm::InputTag>("HBHEPileInputTag")),
         HOPileInputTag_(ps.getParameter<edm::InputTag>("HOPileInputTag")),
         HFPileInputTag_(ps.getParameter<edm::InputTag>("HFPileInputTag")),

--- a/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorkerProd.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorkerProd.cc
@@ -16,13 +16,14 @@
 using namespace std;
 namespace edm {
   // Constructor
-  DataMixingHcalDigiWorkerProd::DataMixingHcalDigiWorkerProd(const edm::ParameterSet &ps, edm::ConsumesCollector &&iC)
+  DataMixingHcalDigiWorkerProd::DataMixingHcalDigiWorkerProd(const edm::ParameterSet &ps, edm::ConsumesCollector &&iC, const edm::ESGetToken<HcalDbService, HcalDbRecord>& tok)
       : HBHEPileInputTag_(ps.getParameter<edm::InputTag>("HBHEPileInputTag")),
         HOPileInputTag_(ps.getParameter<edm::InputTag>("HOPileInputTag")),
         HFPileInputTag_(ps.getParameter<edm::InputTag>("HFPileInputTag")),
         ZDCPileInputTag_(ps.getParameter<edm::InputTag>("ZDCPileInputTag")),
         QIE10PileInputTag_(ps.getParameter<edm::InputTag>("QIE10PileInputTag")),
         QIE11PileInputTag_(ps.getParameter<edm::InputTag>("QIE11PileInputTag")),
+        tokDB_(tok),
         label_(ps.getParameter<std::string>("Label")) {
     //
     tok_hbhe_ = iC.consumes<HBHEDigitizerTraits::DigiCollection>(HBHEPileInputTag_);
@@ -91,12 +92,12 @@ namespace edm {
     LogDebug("DataMixingHcalDigiWorkerProd")
         << "\n===============> adding pileups from event  " << ep->id() << " for bunchcrossing " << bcr;
 
-    theHBHESignalGenerator.initializeEvent(ep, &ES);
-    theHOSignalGenerator.initializeEvent(ep, &ES);
-    theHFSignalGenerator.initializeEvent(ep, &ES);
-    theZDCSignalGenerator.initializeEvent(ep, &ES);
-    theQIE10SignalGenerator.initializeEvent(ep, &ES);
-    theQIE11SignalGenerator.initializeEvent(ep, &ES);
+    theHBHESignalGenerator.initializeEvent(ep, &ES, tokDB_);
+    theHOSignalGenerator.initializeEvent(ep, &ES, tokDB_);
+    theHFSignalGenerator.initializeEvent(ep, &ES, tokDB_);
+    theZDCSignalGenerator.initializeEvent(ep, &ES, tokDB_);
+    theQIE10SignalGenerator.initializeEvent(ep, &ES, tokDB_);
+    theQIE11SignalGenerator.initializeEvent(ep, &ES, tokDB_);
 
     // put digis from pileup event into digitizer
 

--- a/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorkerProd.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorkerProd.h
@@ -43,7 +43,9 @@ namespace edm {
   class DataMixingHcalDigiWorkerProd {
   public:
     /** standard constructor*/
-    explicit DataMixingHcalDigiWorkerProd(const edm::ParameterSet &ps, edm::ConsumesCollector &&iC, const edm::ESGetToken<HcalDbService, HcalDbRecord>&);
+    explicit DataMixingHcalDigiWorkerProd(const edm::ParameterSet &ps,
+                                          edm::ConsumesCollector &&iC,
+                                          const edm::ESGetToken<HcalDbService, HcalDbRecord> &);
 
     /**Default destructor*/
     virtual ~DataMixingHcalDigiWorkerProd();

--- a/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorkerProd.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorkerProd.h
@@ -43,7 +43,7 @@ namespace edm {
   class DataMixingHcalDigiWorkerProd {
   public:
     /** standard constructor*/
-    explicit DataMixingHcalDigiWorkerProd(const edm::ParameterSet &ps, edm::ConsumesCollector &&iC);
+    explicit DataMixingHcalDigiWorkerProd(const edm::ParameterSet &ps, edm::ConsumesCollector &&iC, const edm::ESGetToken<HcalDbService, HcalDbRecord>&);
 
     /**Default destructor*/
     virtual ~DataMixingHcalDigiWorkerProd();
@@ -85,6 +85,8 @@ namespace edm {
     edm::EDGetTokenT<ZDCDigitizerTraits::DigiCollection> tok_zdc_;
     edm::EDGetTokenT<HcalQIE10DigitizerTraits::DigiCollection> tok_qie10_;
     edm::EDGetTokenT<HcalQIE11DigitizerTraits::DigiCollection> tok_qie11_;
+
+    const edm::ESGetToken<HcalDbService, HcalDbRecord> tokDB_;
 
     HcalDigiProducer *myHcalDigitizer_;
     HBHESignalGenerator theHBHESignalGenerator;

--- a/SimGeneral/DataMixingModule/plugins/DataMixingModule.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingModule.cc
@@ -39,6 +39,7 @@ namespace edm {
         ZDCPileInputTag_(ps.getParameter<edm::InputTag>("ZDCPileInputTag")),
         QIE10PileInputTag_(ps.getParameter<edm::InputTag>("QIE10PileInputTag")),
         QIE11PileInputTag_(ps.getParameter<edm::InputTag>("QIE11PileInputTag")),
+        tokDB_(esConsumes<HcalDbService, HcalDbRecord>()),
         label_(ps.getParameter<std::string>("Label")) {
     // prepare for data access in DataMixingHcalDigiWorkerProd
     tok_hbhe_ = consumes<HBHEDigitizerTraits::DigiCollection>(HBHEPileInputTag_);
@@ -119,7 +120,7 @@ namespace edm {
       }
 
       if (MergeHcalDigisProd_)
-        HcalDigiWorkerProd_ = new DataMixingHcalDigiWorkerProd(ps, consumesCollector());
+        HcalDigiWorkerProd_ = new DataMixingHcalDigiWorkerProd(ps, consumesCollector(), tokDB_);
       else
         HcalDigiWorker_ = new DataMixingHcalDigiWorker(ps, consumesCollector());
 

--- a/SimGeneral/DataMixingModule/plugins/DataMixingModule.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingModule.h
@@ -164,6 +164,8 @@ namespace edm {
     edm::EDGetTokenT<HcalQIE10DigitizerTraits::DigiCollection> tok_qie10_;
     edm::EDGetTokenT<HcalQIE11DigitizerTraits::DigiCollection> tok_qie11_;
 
+    const edm::ESGetToken<HcalDbService, HcalDbRecord> tokDB_;
+
     bool MergeHcalDigis_;
     bool MergeHcalDigisProd_;
 


### PR DESCRIPTION
#### PR description:

Make use of ESGetToken in SimCalorimetry/HcalSimProducers

#### PR validation:

Use the runTheMatrix test workflows

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special