### PR TITLE
Migrate CondTools-Ecal modules to use esconsumes

### DIFF
--- a/CondTools/Geometry/plugins/CSCRecoIdealDBLoader.cc
+++ b/CondTools/Geometry/plugins/CSCRecoIdealDBLoader.cc
@@ -28,10 +28,16 @@ public:
 
 private:
   bool fromDD4Hep_;
+  edm::ESGetToken<cms::DDCompactView, IdealGeometryRecord> dd4HepCompactViewToken_;
+  edm::ESGetToken<DDCompactView, IdealGeometryRecord> compactViewToken_;
+  edm::ESGetToken<MuonGeometryConstants, IdealGeometryRecord> muonGeomConstantsToken_;
 };
 
 CSCRecoIdealDBLoader::CSCRecoIdealDBLoader(const edm::ParameterSet& iC) {
   fromDD4Hep_ = iC.getUntrackedParameter<bool>("fromDD4Hep", false);
+  dd4HepCompactViewToken_ = esConsumes<edm::Transition::BeginRun>();
+  compactViewToken_ = esConsumes<edm::Transition::BeginRun>();
+  muonGeomConstantsToken_ = esConsumes<edm::Transition::BeginRun>();
 }
 
 void CSCRecoIdealDBLoader::beginRun(const edm::Run&, edm::EventSetup const& es) {
@@ -45,19 +51,15 @@ void CSCRecoIdealDBLoader::beginRun(const edm::Run&, edm::EventSetup const& es) 
     return;
   }
 
-  edm::ESHandle<MuonGeometryConstants> pMNDC;
+  auto pMNDC = es.getHandle(muonGeomConstantsToken_);
   CSCGeometryParsFromDD cscgp;
 
   if (fromDD4Hep_) {
-    edm::ESTransientHandle<cms::DDCompactView> pDD;
-    es.get<IdealGeometryRecord>().get(pDD);
-    es.get<IdealGeometryRecord>().get(pMNDC);
+    auto pDD = es.getTransientHandle(dd4HepCompactViewToken_);
     const cms::DDCompactView& cpv = *pDD;
     cscgp.build(&cpv, *pMNDC, *rig, *rdp);
   } else {
-    edm::ESTransientHandle<DDCompactView> pDD;
-    es.get<IdealGeometryRecord>().get(pDD);
-    es.get<IdealGeometryRecord>().get(pMNDC);
+    auto pDD = es.getTransientHandle(compactViewToken_);
     const DDCompactView& cpv = *pDD;
     cscgp.build(&cpv, *pMNDC, *rig, *rdp);
   }

--- a/CondTools/Geometry/plugins/DTRecoIdealDBLoader.cc
+++ b/CondTools/Geometry/plugins/DTRecoIdealDBLoader.cc
@@ -29,10 +29,16 @@ public:
 
 private:
   bool fromDD4Hep_;
+  edm::ESGetToken<cms::DDCompactView, IdealGeometryRecord> dd4HepCompactViewToken_;
+  edm::ESGetToken<DDCompactView, IdealGeometryRecord> compactViewToken_;
+  edm::ESGetToken<MuonGeometryConstants, IdealGeometryRecord> muonGeomConstantsToken_;
 };
 
 DTRecoIdealDBLoader::DTRecoIdealDBLoader(const edm::ParameterSet& iC) {
   fromDD4Hep_ = iC.getUntrackedParameter<bool>("fromDD4Hep", false);
+  dd4HepCompactViewToken_ = esConsumes<edm::Transition::BeginRun>();
+  compactViewToken_ = esConsumes<edm::Transition::BeginRun>();
+  muonGeomConstantsToken_ = esConsumes<edm::Transition::BeginRun>();
 }
 
 void DTRecoIdealDBLoader::beginRun(const edm::Run&, edm::EventSetup const& es) {
@@ -43,19 +49,15 @@ void DTRecoIdealDBLoader::beginRun(const edm::Run&, edm::EventSetup const& es) {
     return;
   }
 
-  edm::ESHandle<MuonGeometryConstants> pMNDC;
+  auto pMNDC = es.getHandle(muonGeomConstantsToken_);
   DTGeometryParsFromDD dtgp;
 
   if (fromDD4Hep_) {
-    edm::ESTransientHandle<cms::DDCompactView> pDD;
-    es.get<IdealGeometryRecord>().get(pDD);
-    es.get<IdealGeometryRecord>().get(pMNDC);
+    auto pDD = es.getTransientHandle(dd4HepCompactViewToken_);
     const cms::DDCompactView& cpv = *pDD;
     dtgp.build(&cpv, *pMNDC, *rig);
   } else {
-    edm::ESTransientHandle<DDCompactView> pDD;
-    es.get<IdealGeometryRecord>().get(pDD);
-    es.get<IdealGeometryRecord>().get(pMNDC);
+    auto pDD = es.getTransientHandle(compactViewToken_);
     const DDCompactView& cpv = *pDD;
     dtgp.build(&cpv, *pMNDC, *rig);
   }

--- a/CondTools/Geometry/plugins/GEMRecoIdealDBLoader.cc
+++ b/CondTools/Geometry/plugins/GEMRecoIdealDBLoader.cc
@@ -30,10 +30,16 @@ public:
 
 private:
   bool fromDD4Hep_;
+  edm::ESGetToken<cms::DDCompactView, IdealGeometryRecord> dd4HepCompactViewToken_;
+  edm::ESGetToken<DDCompactView, IdealGeometryRecord> compactViewToken_;
+  edm::ESGetToken<MuonGeometryConstants, IdealGeometryRecord> muonGeomConstantsToken_;
 };
 
 GEMRecoIdealDBLoader::GEMRecoIdealDBLoader(const edm::ParameterSet& iC) {
   fromDD4Hep_ = iC.getUntrackedParameter<bool>("fromDD4Hep", false);  // set true for DD4HEP
+  dd4HepCompactViewToken_ = esConsumes<edm::Transition::BeginRun>();
+  compactViewToken_ = esConsumes<edm::Transition::BeginRun>();
+  muonGeomConstantsToken_ = esConsumes<edm::Transition::BeginRun>();
 }
 
 void GEMRecoIdealDBLoader::beginRun(const edm::Run&, edm::EventSetup const& es) {
@@ -46,22 +52,19 @@ void GEMRecoIdealDBLoader::beginRun(const edm::Run&, edm::EventSetup const& es) 
   }
 
   if (mydbservice->isNewTagRequest("GEMRecoGeometryRcd")) {
-    edm::ESHandle<MuonGeometryConstants> pMNDC;
+    auto pMNDC = es.getHandle(muonGeomConstantsToken_);
+
     GEMGeometryParsFromDD rpcpd;
     RecoIdealGeometry* rig = new RecoIdealGeometry;
 
     if (fromDD4Hep_) {
       edm::LogVerbatim("GEMRecoIdealDBLoader") << "(0) GEMRecoIdealDBLoader - DD4HEP ";
-      edm::ESTransientHandle<cms::DDCompactView> pDD;
-      es.get<IdealGeometryRecord>().get(pDD);
-      es.get<IdealGeometryRecord>().get(pMNDC);
+      auto pDD = es.getTransientHandle(dd4HepCompactViewToken_);
       const cms::DDCompactView& cpv = *pDD;
       rpcpd.build(&cpv, *pMNDC, *rig);
     } else {
       edm::LogVerbatim("GEMRecoIdealDBLoader") << "(0) GEMRecoIdealDBLoader - DDD ";
-      edm::ESTransientHandle<DDCompactView> pDD;
-      es.get<IdealGeometryRecord>().get(pDD);
-      es.get<IdealGeometryRecord>().get(pMNDC);
+      auto pDD = es.getTransientHandle(compactViewToken_);
       const DDCompactView& cpv = *pDD;
       rpcpd.build(&cpv, *pMNDC, *rig);
     }

--- a/CondTools/Geometry/plugins/HcalParametersDBBuilder.cc
+++ b/CondTools/Geometry/plugins/HcalParametersDBBuilder.cc
@@ -26,6 +26,8 @@ public:
 
 private:
   bool fromDD4Hep_;
+  edm::ESGetToken<cms::DDCompactView, IdealGeometryRecord> dd4HepCompactViewToken_;
+  edm::ESGetToken<DDCompactView, IdealGeometryRecord> compactViewToken_;
 };
 
 HcalParametersDBBuilder::HcalParametersDBBuilder(const edm::ParameterSet& ps)
@@ -34,6 +36,8 @@ HcalParametersDBBuilder::HcalParametersDBBuilder(const edm::ParameterSet& ps)
   edm::LogVerbatim("HCalGeom") << "HcalParametersDBBuilder::HcalParametersDBBuilder called with dd4hep: "
                                << fromDD4Hep_;
 #endif
+  dd4HepCompactViewToken_ = esConsumes<edm::Transition::BeginRun>();
+  compactViewToken_ = esConsumes<edm::Transition::BeginRun>();
 }
 
 void HcalParametersDBBuilder::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -56,15 +60,13 @@ void HcalParametersDBBuilder::beginRun(const edm::Run&, edm::EventSetup const& e
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("HCalGeom") << "HcalParametersDBBuilder::Try to access cms::DDCompactView";
 #endif
-    edm::ESTransientHandle<cms::DDCompactView> cpv;
-    es.get<IdealGeometryRecord>().get(cpv);
+    auto cpv = es.getTransientHandle(dd4HepCompactViewToken_);
     builder.build((*cpv), *php);
   } else {
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("HCalGeom") << "HcalParametersDBBuilder::Try to access DDCompactView";
 #endif
-    edm::ESTransientHandle<DDCompactView> cpv;
-    es.get<IdealGeometryRecord>().get(cpv);
+    auto cpv = es.getTransientHandle(compactViewToken_);
     builder.build(&(*cpv), *php);
   }
 

--- a/CondTools/Geometry/plugins/ME0RecoIdealDBLoader.cc
+++ b/CondTools/Geometry/plugins/ME0RecoIdealDBLoader.cc
@@ -28,10 +28,16 @@ public:
 
 private:
   bool fromDD4Hep_;
+  edm::ESGetToken<cms::DDCompactView, IdealGeometryRecord> dd4HepCompactViewToken_;
+  edm::ESGetToken<DDCompactView, IdealGeometryRecord> compactViewToken_;
+  edm::ESGetToken<MuonGeometryConstants, IdealGeometryRecord> muonGeomConstantsToken_;
 };
 
 ME0RecoIdealDBLoader::ME0RecoIdealDBLoader(const edm::ParameterSet& iC) {
   fromDD4Hep_ = iC.getUntrackedParameter<bool>("fromDD4Hep", false);  // set true for DD4HEP
+  dd4HepCompactViewToken_ = esConsumes<edm::Transition::BeginRun>();
+  compactViewToken_ = esConsumes<edm::Transition::BeginRun>();
+  muonGeomConstantsToken_ = esConsumes<edm::Transition::BeginRun>();
 }
 
 void ME0RecoIdealDBLoader::beginRun(const edm::Run&, edm::EventSetup const& es) {
@@ -44,21 +50,17 @@ void ME0RecoIdealDBLoader::beginRun(const edm::Run&, edm::EventSetup const& es) 
   }
 
   if (mydbservice->isNewTagRequest("ME0RecoGeometryRcd")) {
-    edm::ESHandle<MuonGeometryConstants> pMNDC;
+    auto pMNDC = es.getHandle(muonGeomConstantsToken_);
     ME0GeometryParsFromDD me0pd;
     RecoIdealGeometry* rig = new RecoIdealGeometry;
     if (fromDD4Hep_) {
       edm::LogVerbatim("ME0RecoIdealDBLoader") << "(0) ME0RecoIdealDBLoader - DD4HEP ";
-      edm::ESTransientHandle<cms::DDCompactView> pDD;
-      es.get<IdealGeometryRecord>().get(pDD);
-      es.get<IdealGeometryRecord>().get(pMNDC);
+      auto pDD = es.getTransientHandle(dd4HepCompactViewToken_);
       const cms::DDCompactView& cpv = *pDD;
       me0pd.build(&cpv, *pMNDC, *rig);
     } else {
       edm::LogVerbatim("ME0RecoIdealDBLoader") << "(0) ME0RecoIdealDBLoader - DDD ";
-      edm::ESTransientHandle<DDCompactView> pDD;
-      es.get<IdealGeometryRecord>().get(pDD);
-      es.get<IdealGeometryRecord>().get(pMNDC);
+      auto pDD = es.getTransientHandle(compactViewToken_);
       const DDCompactView& cpv = *pDD;
       me0pd.build(&cpv, *pMNDC, *rig);
     }

--- a/CondTools/Geometry/plugins/PCaloGeometryBuilder.cc
+++ b/CondTools/Geometry/plugins/PCaloGeometryBuilder.cc
@@ -19,7 +19,17 @@ public:
   PCaloGeometryBuilder(const edm::ParameterSet& pset)
       : m_ecalE(pset.getUntrackedParameter<bool>("EcalE", true)),
         m_ecalP(pset.getUntrackedParameter<bool>("EcalP", true)),
-        m_hgcal(pset.getUntrackedParameter<bool>("HGCal", false)) {}
+        m_hgcal(pset.getUntrackedParameter<bool>("HGCal", false)) {
+    const std::string toDB("_toDB");
+    ebGeomToken_ = esConsumes<edm::Transition::BeginRun>(edm::ESInputTag(EcalBarrelGeometry::producerTag() + toDB));
+    eeGeomToken_ = esConsumes<edm::Transition::BeginRun>(edm::ESInputTag(EcalEndcapGeometry::producerTag() + toDB));
+    esGeomToken_ = esConsumes<edm::Transition::BeginRun>(edm::ESInputTag(EcalPreshowerGeometry::producerTag() + toDB));
+    hgcalGeomToken_ = esConsumes<edm::Transition::BeginRun>(edm::ESInputTag(HGCalGeometry::producerTag() + toDB));
+    hcalGeomToken_ = esConsumes<edm::Transition::BeginRun>(edm::ESInputTag(HcalGeometry::producerTag() + toDB));
+    ctGeomToken_ = esConsumes<edm::Transition::BeginRun>(edm::ESInputTag(CaloTowerGeometry::producerTag() + toDB));
+    zdcGeomToken_ = esConsumes<edm::Transition::BeginRun>(edm::ESInputTag(ZdcGeometry::producerTag() + toDB));
+    castGeomToken_ = esConsumes<edm::Transition::BeginRun>(edm::ESInputTag(CastorGeometry::producerTag() + toDB));
+  }
 
   void beginRun(edm::Run const& iEvent, edm::EventSetup const&) override;
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override {}
@@ -29,48 +39,46 @@ private:
   bool m_ecalE;
   bool m_ecalP;
   bool m_hgcal;
+  edm::ESGetToken<CaloSubdetectorGeometry, EcalBarrelGeometry::AlignedRecord> ebGeomToken_;
+  edm::ESGetToken<CaloSubdetectorGeometry, EcalEndcapGeometry::AlignedRecord> eeGeomToken_;
+  edm::ESGetToken<CaloSubdetectorGeometry, EcalPreshowerGeometry::AlignedRecord> esGeomToken_;
+  edm::ESGetToken<CaloSubdetectorGeometry, HGCalGeometry::AlignedRecord> hgcalGeomToken_;
+  edm::ESGetToken<CaloSubdetectorGeometry, HcalGeometry::AlignedRecord> hcalGeomToken_;
+  edm::ESGetToken<CaloSubdetectorGeometry, CaloTowerGeometry::AlignedRecord> ctGeomToken_;
+  edm::ESGetToken<CaloSubdetectorGeometry, ZdcGeometry::AlignedRecord> zdcGeomToken_;
+  edm::ESGetToken<CaloSubdetectorGeometry, CastorGeometry::AlignedRecord> castGeomToken_;
 };
 
 void PCaloGeometryBuilder::beginRun(const edm::Run&, edm::EventSetup const& es) {
-  const std::string toDB("_toDB");
-
-  std::cout << "Writing out " << EcalBarrelGeometry::producerTag() << std::endl;
-  edm::ESHandle<CaloSubdetectorGeometry> pGeb;
-  es.get<EcalBarrelGeometry::AlignedRecord>().get(EcalBarrelGeometry::producerTag() + toDB, pGeb);
-
+  edm::LogInfo("PCaloGeometryBuilder") << "Writing out " << EcalBarrelGeometry::producerTag() << std::endl;
+  auto pGeb = es.getHandle(ebGeomToken_);
   if (m_ecalE) {
-    std::cout << "Writing out " << EcalEndcapGeometry::producerTag() << std::endl;
-    edm::ESHandle<CaloSubdetectorGeometry> pGee;
-    es.get<EcalEndcapGeometry::AlignedRecord>().get(EcalEndcapGeometry::producerTag() + toDB, pGee);
+    edm::LogInfo("PCaloGeometryBuilder") << "Writing out " << EcalEndcapGeometry::producerTag() << std::endl;
+    auto pGeb = es.getHandle(eeGeomToken_);
   }
 
   if (m_ecalP) {
-    std::cout << "Writing out " << EcalPreshowerGeometry::producerTag() << std::endl;
-    edm::ESHandle<CaloSubdetectorGeometry> pGes;
-    es.get<EcalPreshowerGeometry::AlignedRecord>().get(EcalPreshowerGeometry::producerTag() + toDB, pGes);
+    edm::LogInfo("PCaloGeometryBuilder") << "Writing out " << EcalPreshowerGeometry::producerTag() << std::endl;
+    auto pGes = es.getHandle(esGeomToken_);
   }
 
   if (m_hgcal) {
-    std::cout << "Writing out " << HGCalGeometry::producerTag() << std::endl;
-    edm::ESHandle<CaloSubdetectorGeometry> pGee;
-    es.get<HGCalGeometry::AlignedRecord>().get(HGCalGeometry::producerTag() + toDB, pGee);
+    edm::LogInfo("PCaloGeometryBuilder") << "Writing out " << HGCalGeometry::producerTag() << std::endl;
+    auto pGhgcal = es.getHandle(hgcalGeomToken_);
+    ;
   }
 
-  std::cout << "Writing out " << HcalGeometry::producerTag() << std::endl;
-  edm::ESHandle<CaloSubdetectorGeometry> pGhcal;
-  es.get<HcalGeometry::AlignedRecord>().get(HcalGeometry::producerTag() + toDB, pGhcal);
+  edm::LogInfo("PCaloGeometryBuilder") << "Writing out " << HcalGeometry::producerTag() << std::endl;
+  auto pGhcal = es.getHandle(hcalGeomToken_);
 
-  std::cout << "Writing out " << CaloTowerGeometry::producerTag() << std::endl;
-  edm::ESHandle<CaloSubdetectorGeometry> pGct;
-  es.get<CaloTowerGeometry::AlignedRecord>().get(CaloTowerGeometry::producerTag() + toDB, pGct);
+  edm::LogInfo("PCaloGeometryBuilder") << "Writing out " << CaloTowerGeometry::producerTag() << std::endl;
+  auto pGct = es.getHandle(ctGeomToken_);
 
-  std::cout << "Writing out " << ZdcGeometry::producerTag() << std::endl;
-  edm::ESHandle<CaloSubdetectorGeometry> pGzdc;
-  es.get<ZdcGeometry::AlignedRecord>().get(ZdcGeometry::producerTag() + toDB, pGzdc);
+  edm::LogInfo("PCaloGeometryBuilder") << "Writing out " << ZdcGeometry::producerTag() << std::endl;
+  auto pGzdc = es.getHandle(zdcGeomToken_);
 
-  std::cout << "Writing out " << CastorGeometry::producerTag() << std::endl;
-  edm::ESHandle<CaloSubdetectorGeometry> pGcast;
-  es.get<CastorGeometry::AlignedRecord>().get(CastorGeometry::producerTag() + toDB, pGcast);
+  edm::LogInfo("PCaloGeometryBuilder") << "Writing out " << CastorGeometry::producerTag() << std::endl;
+  auto pGcast = es.getHandle(castGeomToken_);
 }
 
 DEFINE_FWK_MODULE(PCaloGeometryBuilder);

--- a/CondTools/Geometry/plugins/PHGCalParametersDBBuilder.cc
+++ b/CondTools/Geometry/plugins/PHGCalParametersDBBuilder.cc
@@ -31,6 +31,8 @@ private:
 
   std::string name_, name2_, namew_, namec_, namet_;
   bool fromDD4Hep_;
+  edm::ESGetToken<cms::DDCompactView, IdealGeometryRecord> dd4HepCompactViewToken_;
+  edm::ESGetToken<DDCompactView, IdealGeometryRecord> compactViewToken_;
 };
 
 PHGCalParametersDBBuilder::PHGCalParametersDBBuilder(const edm::ParameterSet& iC) {
@@ -40,6 +42,9 @@ PHGCalParametersDBBuilder::PHGCalParametersDBBuilder(const edm::ParameterSet& iC
   namec_ = iC.getParameter<std::string>("nameC");
   namet_ = iC.getParameter<std::string>("nameT");
   fromDD4Hep_ = iC.getParameter<bool>("fromDD4Hep");
+  dd4HepCompactViewToken_ = esConsumes<edm::Transition::BeginRun>();
+  compactViewToken_ = esConsumes<edm::Transition::BeginRun>();
+
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HGCalGeom") << "HGCalParametersESModule for " << name_ << ":" << name2_ << ":" << namew_ << ":"
                                 << namec_ << ":" << namet_ << " and fromDD4Hep flag " << fromDD4Hep_;
@@ -71,15 +76,13 @@ void PHGCalParametersDBBuilder::beginRun(const edm::Run&, edm::EventSetup const&
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("HGCalGeom") << "PHGCalParametersDBBuilder::Try to access cm::DDCompactView";
 #endif
-    edm::ESTransientHandle<cms::DDCompactView> cpv;
-    es.get<IdealGeometryRecord>().get(cpv);
+    auto cpv = es.getTransientHandle(dd4HepCompactViewToken_);
     builder.build(cpv.product(), *ptp, name_, namew_, namec_, namet_, name2_);
   } else {
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("HGCalGeom") << "PHGCalParametersDBBuilder::Try to access DDCompactView";
 #endif
-    edm::ESTransientHandle<DDCompactView> cpv;
-    es.get<IdealGeometryRecord>().get(cpv);
+    auto cpv = es.getTransientHandle(compactViewToken_);
     builder.build(cpv.product(), *ptp, name_, namew_, namec_, namet_);
   }
   swapParameters(ptp, phgp);

--- a/CondTools/Geometry/plugins/PTrackerParametersDBBuilder.cc
+++ b/CondTools/Geometry/plugins/PTrackerParametersDBBuilder.cc
@@ -20,10 +20,14 @@ public:
 
 private:
   bool fromDD4hep_;
+  edm::ESGetToken<cms::DDCompactView, IdealGeometryRecord> dd4HepCompactViewToken_;
+  edm::ESGetToken<DDCompactView, IdealGeometryRecord> compactViewToken_;
 };
 
 PTrackerParametersDBBuilder::PTrackerParametersDBBuilder(const edm::ParameterSet& iConfig) {
   fromDD4hep_ = iConfig.getParameter<bool>("fromDD4hep");
+  dd4HepCompactViewToken_ = esConsumes<edm::Transition::BeginRun>();
+  compactViewToken_ = esConsumes<edm::Transition::BeginRun>();
 }
 
 void PTrackerParametersDBBuilder::beginRun(const edm::Run&, edm::EventSetup const& es) {
@@ -37,12 +41,10 @@ void PTrackerParametersDBBuilder::beginRun(const edm::Run&, edm::EventSetup cons
   TrackerParametersFromDD builder;
 
   if (!fromDD4hep_) {
-    edm::ESTransientHandle<DDCompactView> cpv;
-    es.get<IdealGeometryRecord>().get(cpv);
+    auto cpv = es.getTransientHandle(compactViewToken_);
     builder.build(&(*cpv), *ptp);
   } else {
-    edm::ESTransientHandle<cms::DDCompactView> cpv;
-    es.get<IdealGeometryRecord>().get(cpv);
+    auto cpv = es.getTransientHandle(dd4HepCompactViewToken_);
     builder.build(&(*cpv), *ptp);
   }
 

--- a/CondTools/Geometry/plugins/RPCRecoIdealDBLoader.cc
+++ b/CondTools/Geometry/plugins/RPCRecoIdealDBLoader.cc
@@ -28,10 +28,16 @@ public:
 
 private:
   bool fromDD4Hep_;
+  edm::ESGetToken<cms::DDCompactView, IdealGeometryRecord> dd4HepCompactViewToken_;
+  edm::ESGetToken<DDCompactView, IdealGeometryRecord> compactViewToken_;
+  edm::ESGetToken<MuonGeometryConstants, IdealGeometryRecord> muonGeomConstantsToken_;
 };
 
 RPCRecoIdealDBLoader::RPCRecoIdealDBLoader(const edm::ParameterSet& iC) {
   fromDD4Hep_ = iC.getUntrackedParameter<bool>("fromDD4Hep", false);
+  dd4HepCompactViewToken_ = esConsumes<edm::Transition::BeginRun>();
+  compactViewToken_ = esConsumes<edm::Transition::BeginRun>();
+  muonGeomConstantsToken_ = esConsumes<edm::Transition::BeginRun>();
 }
 
 void RPCRecoIdealDBLoader::beginRun(const edm::Run&, edm::EventSetup const& es) {
@@ -42,19 +48,15 @@ void RPCRecoIdealDBLoader::beginRun(const edm::Run&, edm::EventSetup const& es) 
     return;
   }
 
-  edm::ESHandle<MuonGeometryConstants> pMNDC;
+  auto pMNDC = es.getHandle(muonGeomConstantsToken_);
   RPCGeometryParsFromDD rpcpd;
 
   if (fromDD4Hep_) {
-    edm::ESTransientHandle<cms::DDCompactView> pDD;
-    es.get<IdealGeometryRecord>().get(pDD);
-    es.get<IdealGeometryRecord>().get(pMNDC);
+    auto pDD = es.getTransientHandle(dd4HepCompactViewToken_);
     const cms::DDCompactView& cpv = *pDD;
     rpcpd.build(&cpv, *pMNDC, *rig);
   } else {
-    edm::ESTransientHandle<DDCompactView> pDD;
-    es.get<IdealGeometryRecord>().get(pDD);
-    es.get<IdealGeometryRecord>().get(pMNDC);
+    auto pDD = es.getTransientHandle(compactViewToken_);
     const DDCompactView& cpv = *pDD;
     rpcpd.build(&cpv, *pMNDC, *rig);
   }

--- a/CondTools/Geometry/plugins/XMLGeometryReader.cc
+++ b/CondTools/Geometry/plugins/XMLGeometryReader.cc
@@ -25,18 +25,19 @@ public:
 private:
   std::string m_fname;
   std::string m_label;
+  edm::ESGetToken<FileBlob, GeometryFileRcd> fileBlobToken_;
 };
 
 XMLGeometryReader::XMLGeometryReader(const edm::ParameterSet& iConfig) {
   m_fname = iConfig.getUntrackedParameter<std::string>("XMLFileName", "test.xml");
   m_label = iConfig.getUntrackedParameter<std::string>("geomLabel", "Extended");
+  fileBlobToken_ = esConsumes<edm::Transition::BeginRun>();
 }
 
 void XMLGeometryReader::beginRun(edm::Run const& run, edm::EventSetup const& iSetup) {
   edm::LogInfo("XMLGeometryReader") << "XMLGeometryReader::beginRun";
 
-  edm::ESHandle<FileBlob> geometry;
-  iSetup.get<GeometryFileRcd>().get(m_label, geometry);
+  auto geometry = iSetup.getHandle(fileBlobToken_);
   std::unique_ptr<std::vector<unsigned char> > blob((*geometry).getUncompressedBlob());
 
   std::string outfile1(m_fname);


### PR DESCRIPTION
#### PR description:
Part of #31061. Migrate ```CondTools/Geometry``` modules to use esConsumes.

#### PR validation:
code compiles and scram build checker doesn't show the EventSetup get warnings.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
NA
