### PR TITLE
Addition of Bricked Pixel Algorithm in Phase2 Tracker Digitizer

### DIFF
--- a/DQM/Integration/python/clients/onlinebeammonitor_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/onlinebeammonitor_dqm_sourceclient-live_cfg.py
@@ -145,6 +145,18 @@ process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 #from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
 #process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
 
+# Please *do not* delete this toGet statement as it is needed to fetch BeamSpotOnline
+# information every lumisection (instead of every run as for the other records in the GT)
+process.GlobalTag.toGet = cms.VPSet(
+  cms.PSet(
+    record = cms.string("BeamSpotOnlineLegacyObjectsRcd"),
+    refreshTime = cms.uint64(1)
+  ),
+  cms.PSet(
+    record = cms.string("BeamSpotOnlineHLTObjectsRcd"),
+    refreshTime = cms.uint64(1)
+  )
+)
 
 process.dqmcommon = cms.Sequence(process.dqmEnv
                                * process.dqmSaver * process.dqmSaverPB)

--- a/DataFormats/GEMDigi/src/classes_def.xml
+++ b/DataFormats/GEMDigi/src/classes_def.xml
@@ -42,8 +42,8 @@
 <class name="MuonDigiCollection<GEMDetId,GEMCoPadDigi>"/>
 <class name="edm::Wrapper<MuonDigiCollection<GEMDetId,GEMCoPadDigi> >" splitLevel="0"/>
 
-<class name="GEMAMC13Status" ClassVersion="-1">
- <version ClassVersion="-1" checksum="3469985462"/>
+<class name="GEMAMC13Status" ClassVersion="3">
+ <version ClassVersion="3" checksum="3469985462"/>
 </class>
 <class name="std::vector<GEMAMC13Status>"/>
 <class name="std::map<uint16_t,std::vector<GEMAMC13Status> >"/>
@@ -51,8 +51,8 @@
 <class name="MuonDigiCollection<uint16_t,GEMAMC13Status>"/>
 <class name="edm::Wrapper<MuonDigiCollection<uint16_t,GEMAMC13Status> >" splitLevel="0"/>
 
-<class name="GEMAMCStatus" ClassVersion="-1">
- <version ClassVersion="-1" checksum="2120084327"/>
+<class name="GEMAMCStatus" ClassVersion="3">
+ <version ClassVersion="3" checksum="2120084327"/>
 </class>
 <class name="std::vector<GEMAMCStatus>"/>
 <class name="std::map<uint16_t,std::vector<GEMAMCStatus> >"/>
@@ -60,8 +60,8 @@
 <class name="MuonDigiCollection<uint16_t,GEMAMCStatus>"/>
 <class name="edm::Wrapper<MuonDigiCollection<uint16_t,GEMAMCStatus> >" splitLevel="0"/>
 
-<class name="GEMOHStatus" ClassVersion="-1">
- <version ClassVersion="-1" checksum="1715607020"/>
+<class name="GEMOHStatus" ClassVersion="3">
+ <version ClassVersion="3" checksum="1715607020"/>
 </class>
 <class name="std::vector<GEMOHStatus>"/>
 <class name="std::map<GEMDetId,std::vector<GEMOHStatus> >"/>
@@ -69,8 +69,8 @@
 <class name="MuonDigiCollection<GEMDetId,GEMOHStatus>"/>
 <class name="edm::Wrapper<MuonDigiCollection<GEMDetId,GEMOHStatus> >" splitLevel="0"/>
 
-<class name="GEMVFATStatus" ClassVersion="-1">
- <version ClassVersion="-1" checksum="2994917778"/>
+<class name="GEMVFATStatus" ClassVersion="3">
+ <version ClassVersion="3" checksum="2994917778"/>
 </class>
 <class name="std::vector<GEMVFATStatus>"/>
 <class name="std::map<GEMDetId,std::vector<GEMVFATStatus> >"/>

--- a/EventFilter/EcalRawToDigi/plugins/EcalRawToDigiGPU.cc
+++ b/EventFilter/EcalRawToDigi/plugins/EcalRawToDigiGPU.cc
@@ -103,6 +103,9 @@ void EcalRawToDigiGPU::acquire(edm::Event const& event,
 
   // output cpu
   outputCPU_ = {cms::cuda::make_host_unique<uint32_t[]>(2, ctx.stream())};
+  // initialize the number of channels
+  outputCPU_.nchannels[0] = 0;
+  outputCPU_.nchannels[1] = 0;
 
   // output gpu
   outputGPU_.allocate(config_, ctx.stream());

--- a/EventFilter/GEMRawToDigi/plugins/GEMPackingTester.cc
+++ b/EventFilter/GEMRawToDigi/plugins/GEMPackingTester.cc
@@ -92,9 +92,10 @@ void GEMPackingTester::analyze(const edm::Event& iEvent, const edm::EventSetup& 
           foundDigi = true;
       }
       if (!foundDigi) {
-        cout << "simMuonGEMDigi NOT found " << gemId << " " << digi->strip() << " " << digi->bx() << endl;
+        edm::LogInfo("GEMPackingTester") << "simMuonGEMDigi NOT found " << gemId << " " << digi->strip() << " "
+                                         << digi->bx();
         for (auto unpackeddigi = packed.first; unpackeddigi != packed.second; ++unpackeddigi) {
-          cout << "rec " << unpackeddigi->strip() << " " << unpackeddigi->bx() << endl;
+          edm::LogInfo("GEMPackingTester") << "rec " << unpackeddigi->strip() << " " << unpackeddigi->bx();
         }
       }
     }

--- a/HLTrigger/Configuration/python/HLT_Fake1_cff.py
+++ b/HLTrigger/Configuration/python/HLT_Fake1_cff.py
@@ -1,13 +1,13 @@
 # hltGetConfiguration --cff --data /dev/CMSSW_12_0_0/Fake1 --type Fake1
 
-# /dev/CMSSW_12_0_0/Fake1/V4 (CMSSW_12_0_0_pre4)
+# /dev/CMSSW_12_0_0/Fake1/V5 (CMSSW_12_0_0_pre5)
 
 import FWCore.ParameterSet.Config as cms
 
 fragment = cms.ProcessFragment( "HLT" )
 
 fragment.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_12_0_0/Fake1/V4')
+  tableName = cms.string('/dev/CMSSW_12_0_0/Fake1/V5')
 )
 
 fragment.streams = cms.PSet(  A = cms.vstring( 'InitialPD' ) )

--- a/HLTrigger/Configuration/python/HLT_Fake2_cff.py
+++ b/HLTrigger/Configuration/python/HLT_Fake2_cff.py
@@ -1,13 +1,13 @@
 # hltGetConfiguration --cff --data /dev/CMSSW_12_0_0/Fake2 --type Fake2
 
-# /dev/CMSSW_12_0_0/Fake2/V4 (CMSSW_12_0_0_pre4)
+# /dev/CMSSW_12_0_0/Fake2/V5 (CMSSW_12_0_0_pre5)
 
 import FWCore.ParameterSet.Config as cms
 
 fragment = cms.ProcessFragment( "HLT" )
 
 fragment.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_12_0_0/Fake2/V4')
+  tableName = cms.string('/dev/CMSSW_12_0_0/Fake2/V5')
 )
 
 fragment.streams = cms.PSet(  A = cms.vstring( 'InitialPD' ) )

--- a/HLTrigger/Configuration/python/HLT_Fake_cff.py
+++ b/HLTrigger/Configuration/python/HLT_Fake_cff.py
@@ -1,13 +1,13 @@
 # hltGetConfiguration --cff --data /dev/CMSSW_12_0_0/Fake --type Fake
 
-# /dev/CMSSW_12_0_0/Fake/V4 (CMSSW_12_0_0_pre4)
+# /dev/CMSSW_12_0_0/Fake/V5 (CMSSW_12_0_0_pre5)
 
 import FWCore.ParameterSet.Config as cms
 
 fragment = cms.ProcessFragment( "HLT" )
 
 fragment.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_12_0_0/Fake/V4')
+  tableName = cms.string('/dev/CMSSW_12_0_0/Fake/V5')
 )
 
 fragment.streams = cms.PSet(  A = cms.vstring( 'InitialPD' ) )

--- a/HLTrigger/Configuration/python/HLT_HIon_cff.py
+++ b/HLTrigger/Configuration/python/HLT_HIon_cff.py
@@ -1,13 +1,13 @@
 # hltGetConfiguration --cff --data /dev/CMSSW_12_0_0/HIon --type HIon
 
-# /dev/CMSSW_12_0_0/HIon/V3 (CMSSW_12_0_0_pre4)
+# /dev/CMSSW_12_0_0/HIon/V5 (CMSSW_12_0_0_pre5)
 
 import FWCore.ParameterSet.Config as cms
 
 fragment = cms.ProcessFragment( "HLT" )
 
 fragment.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_12_0_0/HIon/V3')
+  tableName = cms.string('/dev/CMSSW_12_0_0/HIon/V5')
 )
 
 fragment.transferSystem = cms.PSet( 

--- a/HLTrigger/Configuration/python/HLT_PIon_cff.py
+++ b/HLTrigger/Configuration/python/HLT_PIon_cff.py
@@ -1,13 +1,13 @@
 # hltGetConfiguration --cff --data /dev/CMSSW_12_0_0/PIon --type PIon
 
-# /dev/CMSSW_12_0_0/PIon/V3 (CMSSW_12_0_0_pre4)
+# /dev/CMSSW_12_0_0/PIon/V5 (CMSSW_12_0_0_pre5)
 
 import FWCore.ParameterSet.Config as cms
 
 fragment = cms.ProcessFragment( "HLT" )
 
 fragment.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_12_0_0/PIon/V3')
+  tableName = cms.string('/dev/CMSSW_12_0_0/PIon/V5')
 )
 
 fragment.transferSystem = cms.PSet( 

--- a/HLTrigger/Configuration/python/HLT_PRef_cff.py
+++ b/HLTrigger/Configuration/python/HLT_PRef_cff.py
@@ -1,13 +1,13 @@
 # hltGetConfiguration --cff --data /dev/CMSSW_12_0_0/PRef --type PRef
 
-# /dev/CMSSW_12_0_0/PRef/V3 (CMSSW_12_0_0_pre4)
+# /dev/CMSSW_12_0_0/PRef/V5 (CMSSW_12_0_0_pre5)
 
 import FWCore.ParameterSet.Config as cms
 
 fragment = cms.ProcessFragment( "HLT" )
 
 fragment.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_12_0_0/PRef/V3')
+  tableName = cms.string('/dev/CMSSW_12_0_0/PRef/V5')
 )
 
 fragment.transferSystem = cms.PSet( 
@@ -10983,8 +10983,8 @@ fragment.HLT_HcalCalibration_v5 = cms.Path( fragment.HLTBeginSequenceCalibration
 fragment.AlCa_EcalPhiSym_v9 = cms.Path( fragment.HLTBeginSequence + fragment.hltL1sZeroBiasIorAlwaysTrueIorIsolatedBunch + fragment.hltPreAlCaEcalPhiSym + fragment.HLTDoFullUnpackingEgammaEcalSequence + fragment.hltEcalPhiSymFilter + fragment.HLTEndSequence )
 fragment.HLT_ZeroBias_FirstCollisionAfterAbortGap_v5 = cms.Path( fragment.HLTBeginSequence + fragment.hltL1sL1ZeroBiasFirstCollisionAfterAbortGap + fragment.hltPreZeroBiasFirstCollisionAfterAbortGap + fragment.HLTEndSequence )
 fragment.AlCa_HIRPCMuonNormalisation_v1 = cms.Path( fragment.HLTBeginSequence + fragment.hltL1sSingleMu7to30 + fragment.hltPreAlCaHIRPCMuonNormalisation + fragment.hltHIRPCMuonNormaL1Filtered0 + fragment.HLTMuonLocalRecoSequence + fragment.HLTEndSequence )
-fragment.AlCa_LumiPixelsCounts_Random_v1 = cms.Path( fragment.HLTBeginSequenceRandom + fragment.hltPixelTrackerHVOn + fragment.hltPreAlCaLumiPixelsCountsRandom + fragment.hltSiPixelDigis + fragment.hltSiPixelClusters + fragment.hltAlcaPixelClusterCounts + fragment.HLTEndSequence )
-fragment.AlCa_LumiPixelsCounts_ZeroBias_v1 = cms.Path( fragment.HLTBeginSequence + fragment.hltPixelTrackerHVOn + fragment.hltL1sZeroBias + fragment.hltPreAlCaLumiPixelsCountsZeroBias + fragment.hltSiPixelDigis + fragment.hltSiPixelClusters + fragment.hltAlcaPixelClusterCounts + fragment.HLTEndSequence )
+fragment.AlCa_LumiPixelsCounts_Random_v1 = cms.Path( fragment.HLTBeginSequenceRandom + fragment.hltScalersRawToDigi + fragment.hltPixelTrackerHVOn + fragment.hltPreAlCaLumiPixelsCountsRandom + fragment.hltSiPixelDigis + fragment.hltSiPixelClusters + fragment.hltAlcaPixelClusterCounts + fragment.HLTEndSequence )
+fragment.AlCa_LumiPixelsCounts_ZeroBias_v1 = cms.Path( fragment.HLTBeginSequence + fragment.hltScalersRawToDigi + fragment.hltPixelTrackerHVOn + fragment.hltL1sZeroBias + fragment.hltPreAlCaLumiPixelsCountsZeroBias + fragment.hltSiPixelDigis + fragment.hltSiPixelClusters + fragment.hltAlcaPixelClusterCounts + fragment.HLTEndSequence )
 fragment.HLTriggerFinalPath = cms.Path( fragment.hltGtStage2Digis + fragment.hltScalersRawToDigi + fragment.hltFEDSelector + fragment.hltTriggerSummaryAOD + fragment.hltTriggerSummaryRAW + fragment.hltBoolFalse )
 fragment.HLTAnalyzerEndpath = cms.EndPath( fragment.hltGtStage2Digis + fragment.hltPreHLTAnalyzerEndpath + fragment.hltL1TGlobalSummary + fragment.hltTrigReport )
 

--- a/HLTrigger/Configuration/python/Tools/confdb.py
+++ b/HLTrigger/Configuration/python/Tools/confdb.py
@@ -791,6 +791,7 @@ if 'GlobalTag' in %%(dict)s:
       self.options['esmodules'].append( "-SiStripRecHitMatcherESProducer" )
       self.options['esmodules'].append( "-SiStripQualityESProducer" )
       self.options['esmodules'].append( "-StripCPEfromTrackAngleESProducer" )
+      self.options['esmodules'].append( "-TrackerAdditionalParametersPerDetESModule" )
       self.options['esmodules'].append( "-TrackerDigiGeometryESModule" )
       self.options['esmodules'].append( "-TrackerGeometricDetESModule" )
       self.options['esmodules'].append( "-VolumeBasedMagneticFieldESProducer" )

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -129,18 +129,11 @@ def customiseFor2018Input(process):
 
     return process
 
-def customiseFor34120(process):
-    """Ensure TrackerAdditionalParametersPerDetRcd ESProducer is run"""
-    process.load("Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi")
-    return process
 
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
     
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
-
-    if menuType in ["GRun","HIon","PIon","PRef"]:
-        process = customiseFor34120(process)
 
     return process

--- a/HLTrigger/Configuration/test/OnLine_HLT_Fake.py
+++ b/HLTrigger/Configuration/test/OnLine_HLT_Fake.py
@@ -1,13 +1,13 @@
 # hltGetConfiguration --full --data /dev/CMSSW_12_0_0/Fake --type Fake --unprescale --process HLTFake --globaltag auto:run1_hlt_Fake --input file:RelVal_Raw_Fake_DATA.root
 
-# /dev/CMSSW_12_0_0/Fake/V4 (CMSSW_12_0_0_pre4)
+# /dev/CMSSW_12_0_0/Fake/V5 (CMSSW_12_0_0_pre5)
 
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "HLTFake" )
 
 process.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_12_0_0/Fake/V4')
+  tableName = cms.string('/dev/CMSSW_12_0_0/Fake/V5')
 )
 
 process.streams = cms.PSet(  A = cms.vstring( 'InitialPD' ) )

--- a/HLTrigger/Configuration/test/OnLine_HLT_Fake1.py
+++ b/HLTrigger/Configuration/test/OnLine_HLT_Fake1.py
@@ -1,13 +1,13 @@
 # hltGetConfiguration --full --data /dev/CMSSW_12_0_0/Fake1 --type Fake1 --unprescale --process HLTFake1 --globaltag auto:run2_hlt_Fake1 --input file:RelVal_Raw_Fake1_DATA.root
 
-# /dev/CMSSW_12_0_0/Fake1/V4 (CMSSW_12_0_0_pre4)
+# /dev/CMSSW_12_0_0/Fake1/V5 (CMSSW_12_0_0_pre5)
 
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "HLTFake1" )
 
 process.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_12_0_0/Fake1/V4')
+  tableName = cms.string('/dev/CMSSW_12_0_0/Fake1/V5')
 )
 
 process.streams = cms.PSet(  A = cms.vstring( 'InitialPD' ) )

--- a/HLTrigger/Configuration/test/OnLine_HLT_Fake2.py
+++ b/HLTrigger/Configuration/test/OnLine_HLT_Fake2.py
@@ -1,13 +1,13 @@
 # hltGetConfiguration --full --data /dev/CMSSW_12_0_0/Fake2 --type Fake2 --unprescale --process HLTFake2 --globaltag auto:run2_hlt_Fake2 --input file:RelVal_Raw_Fake2_DATA.root
 
-# /dev/CMSSW_12_0_0/Fake2/V4 (CMSSW_12_0_0_pre4)
+# /dev/CMSSW_12_0_0/Fake2/V5 (CMSSW_12_0_0_pre5)
 
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "HLTFake2" )
 
 process.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_12_0_0/Fake2/V4')
+  tableName = cms.string('/dev/CMSSW_12_0_0/Fake2/V5')
 )
 
 process.streams = cms.PSet(  A = cms.vstring( 'InitialPD' ) )

--- a/HLTrigger/Configuration/test/OnLine_HLT_HIon.py
+++ b/HLTrigger/Configuration/test/OnLine_HLT_HIon.py
@@ -1,13 +1,13 @@
 # hltGetConfiguration --full --data /dev/CMSSW_12_0_0/HIon --type HIon --unprescale --process HLTHIon --globaltag auto:run3_hlt_HIon --input file:RelVal_Raw_HIon_DATA.root
 
-# /dev/CMSSW_12_0_0/HIon/V3 (CMSSW_12_0_0_pre4)
+# /dev/CMSSW_12_0_0/HIon/V5 (CMSSW_12_0_0_pre5)
 
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "HLTHIon" )
 
 process.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_12_0_0/HIon/V3')
+  tableName = cms.string('/dev/CMSSW_12_0_0/HIon/V5')
 )
 
 process.transferSystem = cms.PSet( 
@@ -4523,6 +4523,9 @@ process.SteppingHelixPropagatorAny = cms.ESProducer( "SteppingHelixPropagatorESP
   ApplyRadX0Correction = cms.bool( True ),
   useMagVolumes = cms.bool( True ),
   returnTangentPlane = cms.bool( True )
+)
+process.TrackerAdditionalParametersPerDetESModule = cms.ESProducer( "TrackerAdditionalParametersPerDetESModule",
+  appendToDataLabel = cms.string( "" )
 )
 process.TrackerDigiGeometryESModule = cms.ESProducer( "TrackerDigiGeometryESModule",
   appendToDataLabel = cms.string( "" ),

--- a/HLTrigger/Configuration/test/OnLine_HLT_PIon.py
+++ b/HLTrigger/Configuration/test/OnLine_HLT_PIon.py
@@ -1,13 +1,13 @@
 # hltGetConfiguration --full --data /dev/CMSSW_12_0_0/PIon --type PIon --unprescale --process HLTPIon --globaltag auto:run3_hlt_PIon --input file:RelVal_Raw_PIon_DATA.root
 
-# /dev/CMSSW_12_0_0/PIon/V3 (CMSSW_12_0_0_pre4)
+# /dev/CMSSW_12_0_0/PIon/V5 (CMSSW_12_0_0_pre5)
 
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "HLTPIon" )
 
 process.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_12_0_0/PIon/V3')
+  tableName = cms.string('/dev/CMSSW_12_0_0/PIon/V5')
 )
 
 process.transferSystem = cms.PSet( 
@@ -3994,6 +3994,9 @@ process.SteppingHelixPropagatorAny = cms.ESProducer( "SteppingHelixPropagatorESP
   ApplyRadX0Correction = cms.bool( True ),
   useMagVolumes = cms.bool( True ),
   returnTangentPlane = cms.bool( True )
+)
+process.TrackerAdditionalParametersPerDetESModule = cms.ESProducer( "TrackerAdditionalParametersPerDetESModule",
+  appendToDataLabel = cms.string( "" )
 )
 process.TrackerDigiGeometryESModule = cms.ESProducer( "TrackerDigiGeometryESModule",
   appendToDataLabel = cms.string( "" ),

--- a/HLTrigger/Configuration/test/OnLine_HLT_PRef.py
+++ b/HLTrigger/Configuration/test/OnLine_HLT_PRef.py
@@ -1,13 +1,13 @@
 # hltGetConfiguration --full --data /dev/CMSSW_12_0_0/PRef --type PRef --unprescale --process HLTPRef --globaltag auto:run3_hlt_PRef --input file:RelVal_Raw_PRef_DATA.root
 
-# /dev/CMSSW_12_0_0/PRef/V3 (CMSSW_12_0_0_pre4)
+# /dev/CMSSW_12_0_0/PRef/V5 (CMSSW_12_0_0_pre5)
 
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "HLTPRef" )
 
 process.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_12_0_0/PRef/V3')
+  tableName = cms.string('/dev/CMSSW_12_0_0/PRef/V5')
 )
 
 process.transferSystem = cms.PSet( 
@@ -4073,6 +4073,9 @@ process.SteppingHelixPropagatorAny = cms.ESProducer( "SteppingHelixPropagatorESP
   ApplyRadX0Correction = cms.bool( True ),
   useMagVolumes = cms.bool( True ),
   returnTangentPlane = cms.bool( True )
+)
+process.TrackerAdditionalParametersPerDetESModule = cms.ESProducer( "TrackerAdditionalParametersPerDetESModule",
+  appendToDataLabel = cms.string( "" )
 )
 process.TrackerDigiGeometryESModule = cms.ESProducer( "TrackerDigiGeometryESModule",
   appendToDataLabel = cms.string( "" ),
@@ -11800,8 +11803,8 @@ process.HLT_HcalCalibration_v5 = cms.Path( process.HLTBeginSequenceCalibration +
 process.AlCa_EcalPhiSym_v9 = cms.Path( process.HLTBeginSequence + process.hltL1sZeroBiasIorAlwaysTrueIorIsolatedBunch + process.hltPreAlCaEcalPhiSym + process.HLTDoFullUnpackingEgammaEcalSequence + process.hltEcalPhiSymFilter + process.HLTEndSequence )
 process.HLT_ZeroBias_FirstCollisionAfterAbortGap_v5 = cms.Path( process.HLTBeginSequence + process.hltL1sL1ZeroBiasFirstCollisionAfterAbortGap + process.hltPreZeroBiasFirstCollisionAfterAbortGap + process.HLTEndSequence )
 process.AlCa_HIRPCMuonNormalisation_v1 = cms.Path( process.HLTBeginSequence + process.hltL1sSingleMu7to30 + process.hltPreAlCaHIRPCMuonNormalisation + process.hltHIRPCMuonNormaL1Filtered0 + process.HLTMuonLocalRecoSequence + process.HLTEndSequence )
-process.AlCa_LumiPixelsCounts_Random_v1 = cms.Path( process.HLTBeginSequenceRandom + process.hltPixelTrackerHVOn + process.hltPreAlCaLumiPixelsCountsRandom + process.hltSiPixelDigis + process.hltSiPixelClusters + process.hltAlcaPixelClusterCounts + process.HLTEndSequence )
-process.AlCa_LumiPixelsCounts_ZeroBias_v1 = cms.Path( process.HLTBeginSequence + process.hltPixelTrackerHVOn + process.hltL1sZeroBias + process.hltPreAlCaLumiPixelsCountsZeroBias + process.hltSiPixelDigis + process.hltSiPixelClusters + process.hltAlcaPixelClusterCounts + process.HLTEndSequence )
+process.AlCa_LumiPixelsCounts_Random_v1 = cms.Path( process.HLTBeginSequenceRandom + process.hltScalersRawToDigi + process.hltPixelTrackerHVOn + process.hltPreAlCaLumiPixelsCountsRandom + process.hltSiPixelDigis + process.hltSiPixelClusters + process.hltAlcaPixelClusterCounts + process.HLTEndSequence )
+process.AlCa_LumiPixelsCounts_ZeroBias_v1 = cms.Path( process.HLTBeginSequence + process.hltScalersRawToDigi + process.hltPixelTrackerHVOn + process.hltL1sZeroBias + process.hltPreAlCaLumiPixelsCountsZeroBias + process.hltSiPixelDigis + process.hltSiPixelClusters + process.hltAlcaPixelClusterCounts + process.HLTEndSequence )
 process.HLTriggerFinalPath = cms.Path( process.hltGtStage2Digis + process.hltScalersRawToDigi + process.hltFEDSelector + process.hltTriggerSummaryAOD + process.hltTriggerSummaryRAW + process.hltBoolFalse )
 process.HLTAnalyzerEndpath = cms.EndPath( process.hltGtStage2Digis + process.hltPreHLTAnalyzerEndpath + process.hltL1TGlobalSummary + process.hltTrigReport )
 process.PhysicsCommissioningOutput = cms.EndPath( process.hltGtStage2Digis + process.hltPrePhysicsCommissioningOutput + process.hltOutputPhysicsCommissioning )

--- a/HeterogeneousCore/CUDACore/interface/ESProduct.h
+++ b/HeterogeneousCore/CUDACore/interface/ESProduct.h
@@ -75,6 +75,9 @@ namespace cms {
             transferAsync(data.m_data, cudaStream);
             assert(data.m_fillingStream == nullptr);
             data.m_fillingStream = cudaStream;
+            // Record in the cudaStream an event to mark the readiness of the
+            // EventSetup data on the GPU, so other streams can check for it
+            cudaCheck(cudaEventRecord(data.m_event.get(), cudaStream));
             // Now the filling has been enqueued to the cudaStream, so we
             // can return the GPU data immediately, since all subsequent
             // work must be either enqueued to the cudaStream, or the cudaStream

--- a/PhysicsTools/NanoAOD/python/lowPtElectrons_cff.py
+++ b/PhysicsTools/NanoAOD/python/lowPtElectrons_cff.py
@@ -172,21 +172,23 @@ lowPtElectronMCTable = cms.EDProducer(
 )
 
 ################################################################################
-# Sequences
+# Tasks
 ################################################################################
 
-lowPtElectronSequence = cms.Sequence(modifiedLowPtElectrons
-                                     +updatedLowPtElectrons
-                                     +lowPtPATElectronID
-                                     +isoForLowPtEle
-                                     +updatedLowPtElectronsWithUserData
-                                     +finalLowPtElectrons)
-lowPtElectronTables = cms.Sequence(lowPtElectronTable)
-lowPtElectronMC = cms.Sequence(
-    matchingLowPtElecPhoton
-    +lowPtElectronsMCMatchForTable
-    +lowPtElectronsMCMatchForTableAlt
-    +lowPtElectronMCTable)
+lowPtElectronTask = cms.Task(modifiedLowPtElectrons,
+                             updatedLowPtElectrons,
+                             lowPtPATElectronID,
+                             isoForLowPtEle,
+                             updatedLowPtElectronsWithUserData,
+                             finalLowPtElectrons)
+
+lowPtElectronTablesTask = cms.Task(lowPtElectronTable)
+
+lowPtElectronMCTask = cms.Task(
+    matchingLowPtElecPhoton,
+    lowPtElectronsMCMatchForTable,
+    lowPtElectronsMCMatchForTableAlt,
+    lowPtElectronMCTable)
 
 ################################################################################
 # Modifiers
@@ -198,6 +200,6 @@ _modifiers = ( run2_miniAOD_80XLegacy |
                run2_nanoAOD_94X2016 |
                run2_nanoAOD_102Xv1 |
                run2_nanoAOD_106Xv1 )
-(_modifiers).toReplaceWith(lowPtElectronSequence,cms.Sequence())
-(_modifiers).toReplaceWith(lowPtElectronTables,cms.Sequence())
-(_modifiers).toReplaceWith(lowPtElectronMC,cms.Sequence())
+(_modifiers).toReplaceWith(lowPtElectronTask,cms.Task())
+(_modifiers).toReplaceWith(lowPtElectronTablesTask,cms.Task())
+(_modifiers).toReplaceWith(lowPtElectronMCTask,cms.Task())

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -62,10 +62,10 @@ lhcInfoTable = cms.EDProducer("LHCInfoProducer",
 )
 
 nanoSequenceCommon = cms.Sequence(
-        nanoMetadata + jetSequence + cms.Sequence(extraFlagsProducersTask, muonTask, tauTask, boostedTauTask) + electronSequence + lowPtElectronSequence + photonSequence +
-        cms.Sequence(vertexTablesTask,isoTrackTask) + jetLepSequence + # must be after all the leptons
+        nanoMetadata + jetSequence + cms.Sequence(extraFlagsProducersTask, muonTask, tauTask, boostedTauTask, electronTask, lowPtElectronTask, photonTask,
+        vertexTablesTask,isoTrackTask) + jetLepSequence + # must be after all the leptons
         linkedObjects  +
-        jetTables + cms.Sequence(muonTablesTask,tauTablesTask,boostedTauTablesTask) + electronTables + lowPtElectronTables + photonTables + cms.Sequence(globalTablesTask) + metTables + simpleCleanerTable + cms.Sequence(extraFlagsTableTask,isoTrackTablesTask)
+        jetTables + cms.Sequence(muonTablesTask,tauTablesTask,boostedTauTablesTask) + cms.Sequence(electronTablesTask, lowPtElectronTablesTask, photonTablesTask, globalTablesTask) + metTables + simpleCleanerTable + cms.Sequence(extraFlagsTableTask,isoTrackTablesTask)
         )
 
 nanoSequenceOnlyFullSim = cms.Sequence(triggerObjectTablesTask)
@@ -74,8 +74,8 @@ nanoSequenceOnlyData = cms.Sequence(cms.Sequence(protonTablesTask) + lhcInfoTabl
 nanoSequence = cms.Sequence(nanoSequenceCommon + nanoSequenceOnlyData + nanoSequenceOnlyFullSim)
 
 nanoSequenceFS = cms.Sequence(
-    cms.Sequence(genParticleTask,particleLevelTask) + nanoSequenceCommon + jetMC + cms.Sequence(muonMCTask) + electronMC + lowPtElectronMC + photonMC + 
-    cms.Sequence(tauMCTask,boostedTauMCTask) + metMC +
+    cms.Sequence(genParticleTask,particleLevelTask) + nanoSequenceCommon + jetMC + cms.Sequence(muonMCTask, electronMCTask, lowPtElectronMCTask, photonMCTask,
+    tauMCTask,boostedTauMCTask) + metMC +
     cms.Sequence(ttbarCatMCProducersTask,globalTablesMCTask,cms.Task(btagWeightTable),genWeightsTableTask,genVertexTablesTask,genParticleTablesTask,particleLevelTablesTask,ttbarCategoryTableTask) )
 
 # GenVertex only stored in newer MiniAOD
@@ -150,6 +150,7 @@ def nanoAOD_addDeepMET(process, addDeepMETProducer, ResponseTune_Graph):
 from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncFromMiniAOD
 from PhysicsTools.PatAlgos.slimming.puppiForMET_cff import makePuppiesFromMiniAOD
 def nanoAOD_recalibrateMETs(process,isData):
+
     # add DeepMETs
     nanoAOD_DeepMET_switch = cms.PSet(
         nanoAOD_addDeepMET_switch = cms.untracked.bool(True), # decide if DeeMET should be included in Nano
@@ -184,6 +185,9 @@ def nanoAOD_recalibrateMETs(process,isData):
     for table in process.jetTable, process.corrT1METJetTable:
         table.variables.muonSubtrFactor = Var("1-userFloat('muonSubtrRawPt')/(pt()*jecFactor('Uncorrected'))",float,doc="1-(muon-subtracted raw pt)/(raw pt)",precision=6)
     process.metTables += process.corrT1METJetTable
+
+
+#
 #    makePuppiesFromMiniAOD(process,True) # call this before in the global customizer otherwise it would reset photon IDs in VID
     nanoAOD_PuppiV15_switch = cms.PSet(
             recoMetFromPFCs = cms.untracked.bool(False),
@@ -220,18 +224,25 @@ def nanoAOD_recalibrateMETs(process,isData):
 
 from PhysicsTools.SelectorUtils.tools.vid_id_tools import *
 def nanoAOD_activateVID(process):
-    switchOnVIDElectronIdProducer(process,DataFormat.MiniAOD)
+
+    switchOnVIDElectronIdProducer(process,DataFormat.MiniAOD,electronTask)
     for modname in electron_id_modules_WorkingPoints_nanoAOD.modules:
         setupAllVIDIdsInModule(process,modname,setupVIDElectronSelection)
-    process.electronSequence.insert(process.electronSequence.index(process.bitmapVIDForEle),process.egmGsfElectronIDSequence)
+
+    electronTask_ = process.egmGsfElectronIDTask.copy()
+    electronTask_.add(electronTask.copy())
+    process.electronTask = electronTask_.copy()
     for modifier in run2_miniAOD_80XLegacy,run2_nanoAOD_94XMiniAODv1,run2_nanoAOD_94XMiniAODv2,run2_nanoAOD_94X2016,run2_nanoAOD_102Xv1,run2_nanoAOD_106Xv1:
         modifier.toModify(process.electronMVAValueMapProducer, src = "slimmedElectronsUpdated")
         modifier.toModify(process.egmGsfElectronIDs, physicsObjectSrc = "slimmedElectronsUpdated")
 
-    switchOnVIDPhotonIdProducer(process,DataFormat.MiniAOD) # do not call this to avoid resetting photon IDs in VID, if called before inside makePuppiesFromMiniAOD
+    switchOnVIDPhotonIdProducer(process,DataFormat.MiniAOD,photonTask) # do not call this to avoid resetting photon IDs in VID, if called before inside makePuppiesFromMiniAOD
     for modname in photon_id_modules_WorkingPoints_nanoAOD.modules:
         setupAllVIDIdsInModule(process,modname,setupVIDPhotonSelection)
-    process.photonSequence.insert(process.photonSequence.index(bitmapVIDForPho),process.egmPhotonIDSequence)
+
+    photonTask_ = process.egmPhotonIDTask.copy()
+    photonTask_.add(photonTask.copy())
+    process.photonTak = photonTask_.copy()
     for modifier in run2_miniAOD_80XLegacy,run2_nanoAOD_94XMiniAODv1,run2_nanoAOD_94XMiniAODv2,run2_nanoAOD_94X2016,run2_nanoAOD_102Xv1:
         modifier.toModify(process.photonMVAValueMapProducer, src = "slimmedPhotonsTo106X")
         modifier.toModify(process.egmPhotonIDs, physicsObjectSrc = "slimmedPhotonsTo106X")

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -65,7 +65,7 @@ nanoSequenceCommon = cms.Sequence(
         nanoMetadata + jetSequence + cms.Sequence(extraFlagsProducersTask, muonTask, tauTask, boostedTauTask, electronTask, lowPtElectronTask, photonTask,
         vertexTablesTask,isoTrackTask) + jetLepSequence + # must be after all the leptons
         linkedObjects  +
-        jetTables + cms.Sequence(muonTablesTask,tauTablesTask,boostedTauTablesTask) + cms.Sequence(electronTablesTask, lowPtElectronTablesTask, photonTablesTask, globalTablesTask) + metTables + simpleCleanerTable + cms.Sequence(extraFlagsTableTask,isoTrackTablesTask)
+        jetTables + cms.Sequence(muonTablesTask, tauTablesTask, boostedTauTablesTask, electronTablesTask, lowPtElectronTablesTask, photonTablesTask, globalTablesTask) + metTables + simpleCleanerTable + cms.Sequence(extraFlagsTableTask,isoTrackTablesTask)
         )
 
 nanoSequenceOnlyFullSim = cms.Sequence(triggerObjectTablesTask)
@@ -242,7 +242,7 @@ def nanoAOD_activateVID(process):
 
     photonTask_ = process.egmPhotonIDTask.copy()
     photonTask_.add(photonTask.copy())
-    process.photonTak = photonTask_.copy()
+    process.photonTask = photonTask_.copy()
     for modifier in run2_miniAOD_80XLegacy,run2_nanoAOD_94XMiniAODv1,run2_nanoAOD_94XMiniAODv2,run2_nanoAOD_94X2016,run2_nanoAOD_102Xv1:
         modifier.toModify(process.photonMVAValueMapProducer, src = "slimmedPhotonsTo106X")
         modifier.toModify(process.egmPhotonIDs, physicsObjectSrc = "slimmedPhotonsTo106X")

--- a/PhysicsTools/NanoAOD/python/photons_cff.py
+++ b/PhysicsTools/NanoAOD/python/photons_cff.py
@@ -113,6 +113,7 @@ run2_miniAOD_80XLegacy.toModify(calibratedPatPhotonsNano,
                                 correctionFile = cms.string("EgammaAnalysis/ElectronTools/data/ScalesSmearings/Legacy2016_07Aug2017_FineEtaR9_v3_ele_unc")
 )
 
+
 slimmedPhotonsWithUserData = cms.EDProducer("PATPhotonUserDataEmbedder",
     src = cms.InputTag("slimmedPhotons"),
     userFloats = cms.PSet(
@@ -139,12 +140,12 @@ slimmedPhotonsWithUserData = cms.EDProducer("PATPhotonUserDataEmbedder",
     ),
     userInts = cms.PSet(
         VIDNestedWPBitmap = cms.InputTag("bitmapVIDForPho"),
-        VIDNestedWPBitmap_Spring16V2p2 = cms.InputTag("bitmapVIDForPhoSpring16V2p2"),
         seedGain = cms.InputTag("seedGainPho"),
     )
 )
 
-for modifier in run2_egamma_2016, run2_egamma_2017, run2_egamma_2018, run2_miniAOD_80XLegacy, run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2, run2_nanoAOD_102Xv1:
+
+for modifier in run2_egamma_2016, run2_egamma_2017, run2_egamma_2018:
     modifier.toModify(slimmedPhotonsWithUserData.userFloats,
                       ecalEnergyErrPostCorrNew = cms.InputTag("calibratedPatPhotonsNano","ecalEnergyErrPostCorr"),
                       ecalEnergyPreCorrNew     = cms.InputTag("calibratedPatPhotonsNano","ecalEnergyPreCorr"),
@@ -206,22 +207,6 @@ photonTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
         mvaID_Fall17V1p1 = Var("userFloat('mvaID_Fall17V1p1')",float,doc="MVA ID score, Fall17V1p1",precision=10),
         mvaID_WP90 = Var("userInt('mvaID_WP90')",bool,doc="MVA ID WP90, Fall17V2"),
         mvaID_WP80 = Var("userInt('mvaID_WP80')",bool,doc="MVA ID WP80, Fall17V2"),
-        cutBased_Spring16V2p2 = Var(
-            "userInt('cutID_Spring16_loose')+userInt('cutID_Spring16_medium')+userInt('cutID_Spring16_tight')",
-            int,
-            doc="cut-based ID bitmap, Spring16V2p2, (0:fail, 1:loose, 2:medium, 3:tight)"
-        ),
-        mvaID_Spring16nonTrigV1 = Var(
-            "userFloat('mvaID_Spring16nonTrigV1')",
-            float,
-            doc="MVA ID score, Spring16nonTrigV1",
-            precision=10
-        ),
-        vidNestedWPBitmap_Spring16V2p2 = Var(
-            "userInt('VIDNestedWPBitmap_Spring16V2p2')",
-            int,
-            doc="Spring16V2p2 " + make_bitmapVID_docstring(photon_id_modules_WorkingPoints_nanoAOD_Spring16V2p2)
-        ),
         pfRelIso03_chg = Var("userFloat('PFIsoChg')/pt",float,doc="PF relative isolation dR=0.3, charged component (with rho*EA PU corrections)"),
         pfRelIso03_all = Var("userFloat('PFIsoAll')/pt",float,doc="PF relative isolation dR=0.3, total (with rho*EA PU corrections)"),
         hoe = Var("hadronicOverEm()",float,doc="H over E",precision=8),
@@ -233,7 +218,7 @@ photonTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
 
 
 #these eras need to make the energy correction, hence the "New"
-for modifier in run2_egamma_2016,run2_egamma_2017,run2_egamma_2018,run2_nanoAOD_94XMiniAODv1, run2_miniAOD_80XLegacy, run2_nanoAOD_102Xv1,run2_nanoAOD_94XMiniAODv2:
+for modifier in run2_egamma_2016, run2_egamma_2017, run2_egamma_2018 :
     modifier.toModify(photonTable.variables,
         pt = Var("pt*userFloat('ecalEnergyPostCorrNew')/userFloat('ecalEnergyPreCorrNew')", float, precision=-1, doc="p_{T}"),
         energyErr = Var("userFloat('ecalEnergyErrPostCorrNew')",float,doc="energy error of the cluster from regression",precision=6),
@@ -249,13 +234,30 @@ for modifier in run2_nanoAOD_94X2016,:
                       
     )
 
-# only add the Spring16 IDs for 2016 nano
-(~(run2_nanoAOD_94X2016 | run2_miniAOD_80XLegacy)).toModify(photonTable.variables,
-    cutBased_Spring16V2p2 = None,
-    mvaID_Spring16nonTrigV1 = None,
-    vidNestedWPBitmap_Spring16V2p2 = None,
-)
+for modifier in run2_nanoAOD_94X2016, run2_miniAOD_80XLegacy:
+    modifier.toModify(slimmedPhotonsWithUserData.userInts,
+        VIDNestedWPBitmap_Spring16V2p2 = cms.InputTag("bitmapVIDForPhoSpring16V2p2"),
+    )
 
+for modifier in run2_nanoAOD_94X2016, run2_miniAOD_80XLegacy:
+   modifier.toModify(photonTable.variables,
+        cutBased_Spring16V2p2 = Var(
+            "userInt('cutID_Spring16_loose')+userInt('cutID_Spring16_medium')+userInt('cutID_Spring16_tight')",
+            int,
+            doc="cut-based ID bitmap, Spring16V2p2, (0:fail, 1:loose, 2:medium, 3:tight)"
+        ),
+        vidNestedWPBitmap_Spring16V2p2 = Var(
+            "userInt('VIDNestedWPBitmap_Spring16V2p2')",
+            int,
+            doc="Spring16V2p2 " + make_bitmapVID_docstring(photon_id_modules_WorkingPoints_nanoAOD_Spring16V2p2)
+        ),
+        mvaID_Spring16nonTrigV1 = Var(
+            "userFloat('mvaID_Spring16nonTrigV1')",
+            float,
+            doc="MVA ID score, Spring16nonTrigV1",
+            precision=10
+        ),
+    )
 
 photonsMCMatchForTable = cms.EDProducer("MCMatcher",  # cut on deltaR, deltaPt/Pt; pick best by deltaR
     src         = photonTable.src,                 # final reco collection
@@ -297,7 +299,7 @@ for modifier in run2_miniAOD_80XLegacy,run2_nanoAOD_94XMiniAODv1,run2_nanoAOD_94
 
 
 ##adding 4 most imp scale & smearing variables to table
-for modifier in run2_nanoAOD_106Xv1,run2_nanoAOD_106Xv2,run2_egamma_2016,run2_egamma_2017,run2_egamma_2018,run2_miniAOD_80XLegacy, run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2,run2_nanoAOD_102Xv1:
+for modifier in run2_egamma_2016, run2_egamma_2017, run2_egamma_2018:
     modifier.toModify(photonTable.variables,
                       dEscaleUp=Var("userFloat('ecalEnergyPostCorrNew') - userFloat('energyScaleUpNew')", float, doc="ecal energy scale shifted 1 sigma up (adding gain/stat/syst in quadrature)", precision=8),
                       dEscaleDown=Var("userFloat('ecalEnergyPostCorrNew') - userFloat('energyScaleDownNew')", float, doc="ecal energy scale shifted 1 sigma down (adding gain/stat/syst in quadrature)", precision=8),
@@ -313,60 +315,20 @@ for modifier in run2_nanoAOD_94X2016,:
                       dEsigmaDown=Var("userFloat('ecalEnergyPostCorr') - userFloat('energySigmaDown')", float,  doc="ecal energy smearing value shifted 1 sigma up", precision=8),
     )
 
-photonSequence = cms.Sequence(
-        bitmapVIDForPho + \
-        bitmapVIDForPhoSpring16V2p2 + \
-        isoForPho + \
-        seedGainPho + \
-        slimmedPhotonsWithUserData + \
-        finalPhotons
-)
-
-photonTables = cms.Sequence ( photonTable)
-photonMC = cms.Sequence(photonsMCMatchForTable + photonMCTable)
+photonTask = cms.Task(bitmapVIDForPho, isoForPho, seedGainPho, calibratedPatPhotonsNano, slimmedPhotonsWithUserData, finalPhotons)
+photonTablesTask = cms.Task(photonTable)
+photonMCTask = cms.Task(photonsMCMatchForTable, photonMCTable)
 
 from RecoEgamma.EgammaIsolationAlgos.egmPhotonIsolationMiniAOD_cff import egmPhotonIsolation
 from RecoEgamma.PhotonIdentification.photonIDValueMapProducer_cff import photonIDValueMapProducer
 
-_withUpdatePho_sequence = photonSequence.copy() ###copy first for non-ULs else it just takes the UL sequence
+_withUpdatePho_Task = cms.Task(egmPhotonIsolation,photonIDValueMapProducer,slimmedPhotonsTo106X)
+_withUpdatePho_Task.add(photonTask.copy())
 
-
-###UL to be done first
-_withUL16preVFPScale_sequence = photonSequence.copy()
-_withUL16preVFPScale_sequence.replace(slimmedPhotonsWithUserData, calibratedPatPhotonsNano  + slimmedPhotonsWithUserData)
-(run2_egamma_2016 & tracker_apv_vfp30_2016).toReplaceWith(photonSequence, _withUL16preVFPScale_sequence)
-
-_withUL16postVFPScale_sequence = photonSequence.copy()
-_withUL16postVFPScale_sequence.replace(slimmedPhotonsWithUserData, calibratedPatPhotonsNano  + slimmedPhotonsWithUserData)
-(run2_egamma_2016 & ~tracker_apv_vfp30_2016).toReplaceWith(photonSequence, _withUL16postVFPScale_sequence)
-
-_withUL17Scale_sequence = photonSequence.copy()
-_withUL17Scale_sequence.replace(slimmedPhotonsWithUserData, calibratedPatPhotonsNano  + slimmedPhotonsWithUserData)
-run2_egamma_2017.toReplaceWith(photonSequence, _withUL17Scale_sequence)
-
-_withUL18Scale_sequence = photonSequence.copy()
-_withUL18Scale_sequence.replace(slimmedPhotonsWithUserData, calibratedPatPhotonsNano  + slimmedPhotonsWithUserData)
-run2_egamma_2018.toReplaceWith(photonSequence, _withUL18Scale_sequence)
-
-
-_updatePhoTo106X_sequence =cms.Sequence(egmPhotonIsolation + photonIDValueMapProducer + slimmedPhotonsTo106X)
-_withUpdatePho_sequence.insert(0,_updatePhoTo106X_sequence)
 for modifier in run2_nanoAOD_94XMiniAODv2,run2_nanoAOD_94X2016 ,run2_nanoAOD_102Xv1,run2_nanoAOD_94XMiniAODv1:
-    modifier.toReplaceWith(photonSequence, _withUpdatePho_sequence)
+    modifier.toReplaceWith(photonTask, _withUpdatePho_Task)
 
-
-_with80XScale_sequence = _withUpdatePho_sequence.copy()
-_with80XScale_sequence.replace(slimmedPhotonsWithUserData, calibratedPatPhotonsNano  + slimmedPhotonsWithUserData)
-run2_miniAOD_80XLegacy.toReplaceWith(photonSequence, _with80XScale_sequence)
-
-_with94Xv1Scale_sequence = _withUpdatePho_sequence.copy()
-_with94Xv1Scale_sequence.replace(slimmedPhotonsWithUserData, calibratedPatPhotonsNano + slimmedPhotonsWithUserData)
-run2_nanoAOD_94XMiniAODv1.toReplaceWith(photonSequence, _with94Xv1Scale_sequence)
-
-_with94Xv2Scale_sequence = _withUpdatePho_sequence.copy()
-_with94Xv2Scale_sequence.replace(slimmedPhotonsWithUserData, calibratedPatPhotonsNano + slimmedPhotonsWithUserData)
-run2_nanoAOD_94XMiniAODv2.toReplaceWith(photonSequence, _with94Xv2Scale_sequence)
-
-_with102Xv1Scale_sequence = photonSequence.copy()
-_with102Xv1Scale_sequence.replace(slimmedPhotonsWithUserData, calibratedPatPhotonsNano + slimmedPhotonsWithUserData)
-run2_nanoAOD_102Xv1.toReplaceWith(photonSequence, _with102Xv1Scale_sequence)
+for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016:
+    _withSpring16V2p2_Task = cms.Task(bitmapVIDForPhoSpring16V2p2)
+    _withSpring16V2p2_Task.add(_withUpdatePho_Task.copy())
+    modifier.toReplaceWith(photonTask, _withSpring16V2p2_Task)

--- a/PhysicsTools/NanoAOD/python/photons_cff.py
+++ b/PhysicsTools/NanoAOD/python/photons_cff.py
@@ -145,7 +145,7 @@ slimmedPhotonsWithUserData = cms.EDProducer("PATPhotonUserDataEmbedder",
 )
 
 
-for modifier in run2_egamma_2016, run2_egamma_2017, run2_egamma_2018, run2_miniAOD_80XLegacy, run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2, run2_nanoAOD_102Xv1:
+for modifier in run2_egamma_2016, run2_egamma_2017, run2_egamma_2018:
     modifier.toModify(slimmedPhotonsWithUserData.userFloats,
                       ecalEnergyErrPostCorrNew = cms.InputTag("calibratedPatPhotonsNano","ecalEnergyErrPostCorr"),
                       ecalEnergyPreCorrNew     = cms.InputTag("calibratedPatPhotonsNano","ecalEnergyPreCorr"),
@@ -218,7 +218,7 @@ photonTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
 
 
 #these eras need to make the energy correction, hence the "New"
-for modifier in run2_egamma_2016,run2_egamma_2017,run2_egamma_2018,run2_nanoAOD_94XMiniAODv1, run2_miniAOD_80XLegacy, run2_nanoAOD_102Xv1,run2_nanoAOD_94XMiniAODv2:
+for modifier in run2_egamma_2016, run2_egamma_2017, run2_egamma_2018 :
     modifier.toModify(photonTable.variables,
         pt = Var("pt*userFloat('ecalEnergyPostCorrNew')/userFloat('ecalEnergyPreCorrNew')", float, precision=-1, doc="p_{T}"),
         energyErr = Var("userFloat('ecalEnergyErrPostCorrNew')",float,doc="energy error of the cluster from regression",precision=6),
@@ -299,7 +299,7 @@ for modifier in run2_miniAOD_80XLegacy,run2_nanoAOD_94XMiniAODv1,run2_nanoAOD_94
 
 
 ##adding 4 most imp scale & smearing variables to table
-for modifier in run2_nanoAOD_106Xv1,run2_nanoAOD_106Xv2,run2_egamma_2016,run2_egamma_2017,run2_egamma_2018,run2_miniAOD_80XLegacy, run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2,run2_nanoAOD_102Xv1:
+for modifier in run2_egamma_2016, run2_egamma_2017, run2_egamma_2018:
     modifier.toModify(photonTable.variables,
                       dEscaleUp=Var("userFloat('ecalEnergyPostCorrNew') - userFloat('energyScaleUpNew')", float, doc="ecal energy scale shifted 1 sigma up (adding gain/stat/syst in quadrature)", precision=8),
                       dEscaleDown=Var("userFloat('ecalEnergyPostCorrNew') - userFloat('energyScaleDownNew')", float, doc="ecal energy scale shifted 1 sigma down (adding gain/stat/syst in quadrature)", precision=8),

--- a/PhysicsTools/NanoAOD/python/photons_cff.py
+++ b/PhysicsTools/NanoAOD/python/photons_cff.py
@@ -113,6 +113,7 @@ run2_miniAOD_80XLegacy.toModify(calibratedPatPhotonsNano,
                                 correctionFile = cms.string("EgammaAnalysis/ElectronTools/data/ScalesSmearings/Legacy2016_07Aug2017_FineEtaR9_v3_ele_unc")
 )
 
+
 slimmedPhotonsWithUserData = cms.EDProducer("PATPhotonUserDataEmbedder",
     src = cms.InputTag("slimmedPhotons"),
     userFloats = cms.PSet(
@@ -139,10 +140,10 @@ slimmedPhotonsWithUserData = cms.EDProducer("PATPhotonUserDataEmbedder",
     ),
     userInts = cms.PSet(
         VIDNestedWPBitmap = cms.InputTag("bitmapVIDForPho"),
-        VIDNestedWPBitmap_Spring16V2p2 = cms.InputTag("bitmapVIDForPhoSpring16V2p2"),
         seedGain = cms.InputTag("seedGainPho"),
     )
 )
+
 
 for modifier in run2_egamma_2016, run2_egamma_2017, run2_egamma_2018, run2_miniAOD_80XLegacy, run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2, run2_nanoAOD_102Xv1:
     modifier.toModify(slimmedPhotonsWithUserData.userFloats,
@@ -206,22 +207,6 @@ photonTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
         mvaID_Fall17V1p1 = Var("userFloat('mvaID_Fall17V1p1')",float,doc="MVA ID score, Fall17V1p1",precision=10),
         mvaID_WP90 = Var("userInt('mvaID_WP90')",bool,doc="MVA ID WP90, Fall17V2"),
         mvaID_WP80 = Var("userInt('mvaID_WP80')",bool,doc="MVA ID WP80, Fall17V2"),
-        cutBased_Spring16V2p2 = Var(
-            "userInt('cutID_Spring16_loose')+userInt('cutID_Spring16_medium')+userInt('cutID_Spring16_tight')",
-            int,
-            doc="cut-based ID bitmap, Spring16V2p2, (0:fail, 1:loose, 2:medium, 3:tight)"
-        ),
-        mvaID_Spring16nonTrigV1 = Var(
-            "userFloat('mvaID_Spring16nonTrigV1')",
-            float,
-            doc="MVA ID score, Spring16nonTrigV1",
-            precision=10
-        ),
-        vidNestedWPBitmap_Spring16V2p2 = Var(
-            "userInt('VIDNestedWPBitmap_Spring16V2p2')",
-            int,
-            doc="Spring16V2p2 " + make_bitmapVID_docstring(photon_id_modules_WorkingPoints_nanoAOD_Spring16V2p2)
-        ),
         pfRelIso03_chg = Var("userFloat('PFIsoChg')/pt",float,doc="PF relative isolation dR=0.3, charged component (with rho*EA PU corrections)"),
         pfRelIso03_all = Var("userFloat('PFIsoAll')/pt",float,doc="PF relative isolation dR=0.3, total (with rho*EA PU corrections)"),
         hoe = Var("hadronicOverEm()",float,doc="H over E",precision=8),
@@ -249,13 +234,30 @@ for modifier in run2_nanoAOD_94X2016,:
                       
     )
 
-# only add the Spring16 IDs for 2016 nano
-(~(run2_nanoAOD_94X2016 | run2_miniAOD_80XLegacy)).toModify(photonTable.variables,
-    cutBased_Spring16V2p2 = None,
-    mvaID_Spring16nonTrigV1 = None,
-    vidNestedWPBitmap_Spring16V2p2 = None,
-)
+for modifier in run2_nanoAOD_94X2016, run2_miniAOD_80XLegacy:
+    modifier.toModify(slimmedPhotonsWithUserData.userInts,
+        VIDNestedWPBitmap_Spring16V2p2 = cms.InputTag("bitmapVIDForPhoSpring16V2p2"),
+    )
 
+for modifier in run2_nanoAOD_94X2016, run2_miniAOD_80XLegacy:
+   modifier.toModify(photonTable.variables,
+        cutBased_Spring16V2p2 = Var(
+            "userInt('cutID_Spring16_loose')+userInt('cutID_Spring16_medium')+userInt('cutID_Spring16_tight')",
+            int,
+            doc="cut-based ID bitmap, Spring16V2p2, (0:fail, 1:loose, 2:medium, 3:tight)"
+        ),
+        vidNestedWPBitmap_Spring16V2p2 = Var(
+            "userInt('VIDNestedWPBitmap_Spring16V2p2')",
+            int,
+            doc="Spring16V2p2 " + make_bitmapVID_docstring(photon_id_modules_WorkingPoints_nanoAOD_Spring16V2p2)
+        ),
+        mvaID_Spring16nonTrigV1 = Var(
+            "userFloat('mvaID_Spring16nonTrigV1')",
+            float,
+            doc="MVA ID score, Spring16nonTrigV1",
+            precision=10
+        ),
+    )
 
 photonsMCMatchForTable = cms.EDProducer("MCMatcher",  # cut on deltaR, deltaPt/Pt; pick best by deltaR
     src         = photonTable.src,                 # final reco collection
@@ -313,60 +315,20 @@ for modifier in run2_nanoAOD_94X2016,:
                       dEsigmaDown=Var("userFloat('ecalEnergyPostCorr') - userFloat('energySigmaDown')", float,  doc="ecal energy smearing value shifted 1 sigma up", precision=8),
     )
 
-photonSequence = cms.Sequence(
-        bitmapVIDForPho + \
-        bitmapVIDForPhoSpring16V2p2 + \
-        isoForPho + \
-        seedGainPho + \
-        slimmedPhotonsWithUserData + \
-        finalPhotons
-)
-
-photonTables = cms.Sequence ( photonTable)
-photonMC = cms.Sequence(photonsMCMatchForTable + photonMCTable)
+photonTask = cms.Task(bitmapVIDForPho, isoForPho, seedGainPho, calibratedPatPhotonsNano, slimmedPhotonsWithUserData, finalPhotons)
+photonTablesTask = cms.Task(photonTable)
+photonMCTask = cms.Task(photonsMCMatchForTable, photonMCTable)
 
 from RecoEgamma.EgammaIsolationAlgos.egmPhotonIsolationMiniAOD_cff import egmPhotonIsolation
 from RecoEgamma.PhotonIdentification.photonIDValueMapProducer_cff import photonIDValueMapProducer
 
-_withUpdatePho_sequence = photonSequence.copy() ###copy first for non-ULs else it just takes the UL sequence
+_withUpdatePho_Task = cms.Task(egmPhotonIsolation,photonIDValueMapProducer,slimmedPhotonsTo106X)
+_withUpdatePho_Task.add(photonTask.copy())
 
-
-###UL to be done first
-_withUL16preVFPScale_sequence = photonSequence.copy()
-_withUL16preVFPScale_sequence.replace(slimmedPhotonsWithUserData, calibratedPatPhotonsNano  + slimmedPhotonsWithUserData)
-(run2_egamma_2016 & tracker_apv_vfp30_2016).toReplaceWith(photonSequence, _withUL16preVFPScale_sequence)
-
-_withUL16postVFPScale_sequence = photonSequence.copy()
-_withUL16postVFPScale_sequence.replace(slimmedPhotonsWithUserData, calibratedPatPhotonsNano  + slimmedPhotonsWithUserData)
-(run2_egamma_2016 & ~tracker_apv_vfp30_2016).toReplaceWith(photonSequence, _withUL16postVFPScale_sequence)
-
-_withUL17Scale_sequence = photonSequence.copy()
-_withUL17Scale_sequence.replace(slimmedPhotonsWithUserData, calibratedPatPhotonsNano  + slimmedPhotonsWithUserData)
-run2_egamma_2017.toReplaceWith(photonSequence, _withUL17Scale_sequence)
-
-_withUL18Scale_sequence = photonSequence.copy()
-_withUL18Scale_sequence.replace(slimmedPhotonsWithUserData, calibratedPatPhotonsNano  + slimmedPhotonsWithUserData)
-run2_egamma_2018.toReplaceWith(photonSequence, _withUL18Scale_sequence)
-
-
-_updatePhoTo106X_sequence =cms.Sequence(egmPhotonIsolation + photonIDValueMapProducer + slimmedPhotonsTo106X)
-_withUpdatePho_sequence.insert(0,_updatePhoTo106X_sequence)
 for modifier in run2_nanoAOD_94XMiniAODv2,run2_nanoAOD_94X2016 ,run2_nanoAOD_102Xv1,run2_nanoAOD_94XMiniAODv1:
-    modifier.toReplaceWith(photonSequence, _withUpdatePho_sequence)
+    modifier.toReplaceWith(photonTask, _withUpdatePho_Task)
 
-
-_with80XScale_sequence = _withUpdatePho_sequence.copy()
-_with80XScale_sequence.replace(slimmedPhotonsWithUserData, calibratedPatPhotonsNano  + slimmedPhotonsWithUserData)
-run2_miniAOD_80XLegacy.toReplaceWith(photonSequence, _with80XScale_sequence)
-
-_with94Xv1Scale_sequence = _withUpdatePho_sequence.copy()
-_with94Xv1Scale_sequence.replace(slimmedPhotonsWithUserData, calibratedPatPhotonsNano + slimmedPhotonsWithUserData)
-run2_nanoAOD_94XMiniAODv1.toReplaceWith(photonSequence, _with94Xv1Scale_sequence)
-
-_with94Xv2Scale_sequence = _withUpdatePho_sequence.copy()
-_with94Xv2Scale_sequence.replace(slimmedPhotonsWithUserData, calibratedPatPhotonsNano + slimmedPhotonsWithUserData)
-run2_nanoAOD_94XMiniAODv2.toReplaceWith(photonSequence, _with94Xv2Scale_sequence)
-
-_with102Xv1Scale_sequence = photonSequence.copy()
-_with102Xv1Scale_sequence.replace(slimmedPhotonsWithUserData, calibratedPatPhotonsNano + slimmedPhotonsWithUserData)
-run2_nanoAOD_102Xv1.toReplaceWith(photonSequence, _with102Xv1Scale_sequence)
+for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016:
+    _withSpring16V2p2_Task = cms.Task(bitmapVIDForPhoSpring16V2p2)
+    _withSpring16V2p2_Task.add(_withUpdatePho_Task.copy())
+    modifier.toReplaceWith(photonTask, _withSpring16V2p2_Task)

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitProducerGPU.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitProducerGPU.cc
@@ -213,7 +213,9 @@ void EcalUncalibRecHitProducerGPU::acquire(edm::Event const& event,
 
   if ((neb_ > configParameters_.maxNumberHitsEB) || (nee_ > configParameters_.maxNumberHitsEE)) {
     edm::LogError("EcalUncalibRecHitProducerGPU")
-        << "max number of channels exceeded. See options 'maxNumberHitsEB and maxNumberHitsEE' ";
+        << "Max number of channels exceeded in barrel or endcap. Number of barrel channels: " << neb_
+        << " with maxNumberHitsEB=" << configParameters_.maxNumberHitsEB << ", number of endcap channels: " << nee_
+        << " with maxNumberHitsEE=" << configParameters_.maxNumberHitsEE;
   }
 
   // conditions

--- a/RecoLocalCalo/HcalRecProducers/src/HcalCPURecHitsProducer.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalCPURecHitsProducer.cc
@@ -76,6 +76,11 @@ void HcalCPURecHitsProducer::acquire(edm::Event const& event,
   std::cout << "num rec Hits = " << recHits.size << std::endl;
 #endif
 
+  // do not try to copy the rechits if they are empty
+  if (recHits.size == 0) {
+    return;
+  }
+
   auto lambdaToTransfer = [&ctx](auto& dest, auto* src) {
     using vector_type = typename std::remove_reference<decltype(dest)>::type;
     using src_data_type = typename std::remove_pointer<decltype(src)>::type;

--- a/RecoLocalCalo/HcalRecProducers/src/MahiGPU.cu
+++ b/RecoLocalCalo/HcalRecProducers/src/MahiGPU.cu
@@ -1048,14 +1048,14 @@ namespace hcal {
                     cudaStream_t cudaStream) {
       auto const totalChannels = inputGPU.f01HEDigis.size + inputGPU.f5HBDigis.size + inputGPU.f3HBDigis.size;
 
-      // protections when the detector is out
-      if (totalChannels == 0)
-        return;
+      // FIXME: the number of channels in output might change given that some channesl might be filtered out
 
-      // FIXME: may be move this assignment to emphasize this more clearly
-      // FIXME: number of channels for output might change given that
-      //   some channesl might be filtered out
+      // do not run when there are no rechits (e.g. if HCAL is not being read),
+      // but do set the size of the output collection to 0
       outputGPU.recHits.size = totalChannels;
+      if (totalChannels == 0) {
+        return;
+      }
 
       // TODO: this can be lifted by implementing a separate kernel
       // similar to the default one, but properly handling the diff in #sample

--- a/SimG4CMS/Calo/src/HCalSD.cc
+++ b/SimG4CMS/Calo/src/HCalSD.cc
@@ -137,6 +137,8 @@ HCalSD::HCalSD(const std::string& name,
   if (forTBHC) {
     useHF = false;
     matNames.emplace_back("Scintillator");
+  } else {
+    matNames = hcalSimConstants_->hcalsimpar()->hcalMaterialNames_;
   }
 
   HcalNumberingScheme* scheme;
@@ -508,11 +510,13 @@ double HCalSD::getEnergyDeposit(const G4Step* aStep) {
       }
     }
   }
+  double wt0(1.0);
   if (useBirk) {
     const G4Material* mat = aStep->GetPreStepPoint()->GetMaterial();
     if (isItScintillator(mat))
-      weight_ *= getAttenuation(aStep, birk1, birk2, birk3);
+      wt0 = getAttenuation(aStep, birk1, birk2, birk3);
   }
+  weight_ *= wt0;
   double wt1 = getResponseWt(theTrack);
   double wt2 = theTrack->GetWeight();
   double edep = weight_ * wt1 * destep;
@@ -521,7 +525,7 @@ double HCalSD::getEnergyDeposit(const G4Step* aStep) {
   }
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HcalSim") << "HCalSD: edep= " << edep << " Det: " << det + 2 << " depth= " << depth_
-                              << " weight= " << weight_ << " wt1= " << wt1 << " wt2= " << wt2;
+                              << " weight= " << weight_ << " wt0= " << wt0 << " wt1= " << wt1 << " wt2= " << wt2;
 #endif
   return edep;
 }

--- a/SimG4CMS/Calo/test/python/minbias_cfg.py
+++ b/SimG4CMS/Calo/test/python/minbias_cfg.py
@@ -13,6 +13,7 @@ process.load("Configuration.EventContent.EventContent_cff")
 process.load('Configuration.StandardSequences.Generator_cff')
 process.load('Configuration.StandardSequences.SimIdeal_cff')
 process.load("SimG4CMS.Calo.CaloSimHitStudy_cfi")
+process.load("SimG4CMS.Calo.hcalSimHitDump_cfi")
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.autoCond import autoCond
@@ -21,6 +22,7 @@ process.GlobalTag.globaltag = autoCond['run2_mc']
 if 'MessageLogger' in process.__dict__:
     process.MessageLogger.G4cerr=dict()
     process.MessageLogger.HitStudy=dict()
+    process.MessageLogger.HcalSim=dict()
 
 process.source = cms.Source("EmptySource")
 
@@ -55,13 +57,14 @@ process.output = cms.OutputModule("PoolOutputModule",
 
 process.generation_step = cms.Path(process.pgen)
 process.simulation_step = cms.Path(process.psim)
-process.analysis_step   = cms.Path(process.CaloSimHitStudy)
+process.analysis_step   = cms.Path(process.CaloSimHitStudy+process.hcalSimHitDump)
 process.out_step = cms.EndPath(process.output)
 
 process.generator.pythiaHepMCVerbosity = False
 process.generator.pythiaPylistVerbosity = 0
 process.g4SimHits.Physics.type = 'SimG4Core/Physics/FTFP_BERT_EMM'
 process.CaloSimHitStudy.TestNumbering = True
+process.hcalSimHitDump.MaxEvent = 5
 
 # process.g4SimHits.ECalSD.IgnoreTrackID      = True
 # process.g4SimHits.HCalSD.IgnoreTrackID      = True

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.cc
@@ -248,17 +248,17 @@ namespace cms {
         algotype = AlgorithmType::InnerPixel;
         break;
       case TrackerGeometry::ModuleType::Ph2PXB:
-        if (topol->isBricked()) 
-	  algotype = AlgorithmType::InnerPixelBricked;
-        else 
-	  algotype = AlgorithmType::InnerPixel;
-	break;
+        if (topol->isBricked())
+          algotype = AlgorithmType::InnerPixelBricked;
+        else
+          algotype = AlgorithmType::InnerPixel;
+        break;
       case TrackerGeometry::ModuleType::Ph2PXF:
-        if (topol->isBricked()) 
-	  algotype = AlgorithmType::InnerPixelBricked;
-        else 
-	  algotype = AlgorithmType::InnerPixel;
-	break;
+        if (topol->isBricked())
+          algotype = AlgorithmType::InnerPixelBricked;
+        else
+          algotype = AlgorithmType::InnerPixel;
+        break;
       case TrackerGeometry::ModuleType::Ph2PXB3D:
         algotype = AlgorithmType::InnerPixel3D;
         break;
@@ -293,11 +293,10 @@ namespace cms {
         continue;
 
       // Decide if we want analog readout for Outer Tracker.
-      if (!ot_analog && 
-	  algotype != AlgorithmType::InnerPixel && 
-	  algotype != AlgorithmType::InnerPixel3D &&
-	  algotype != AlgorithmType::InnerPixelBricked) continue;
-      
+      if (!ot_analog && algotype != AlgorithmType::InnerPixel && algotype != AlgorithmType::InnerPixel3D &&
+          algotype != AlgorithmType::InnerPixelBricked)
+        continue;
+
       std::map<int, DigitizerUtility::DigiSimInfo> digi_map;
       fiter->second->digitize(dynamic_cast<const Phase2TrackerGeomDetUnit*>(det_u), digi_map, tTopo_);
 
@@ -356,12 +355,11 @@ namespace cms {
     for (auto const& det_u : pDD_->detUnits()) {
       uint32_t rawId = det_u->geographicalId().rawId();
       auto algotype = getAlgoType(rawId);
-      
+
       auto fiter = algomap_.find(algotype);
-      if (fiter == algomap_.end() || 
-	  algotype == AlgorithmType::InnerPixel || 
-	  algotype == AlgorithmType::InnerPixel3D || 
-	  algotype == AlgorithmType::InnerPixelBricked) continue;
+      if (fiter == algomap_.end() || algotype == AlgorithmType::InnerPixel || algotype == AlgorithmType::InnerPixel3D ||
+          algotype == AlgorithmType::InnerPixelBricked)
+        continue;
 
       std::map<int, DigitizerUtility::DigiSimInfo> digi_map;
       fiter->second->digitize(dynamic_cast<const Phase2TrackerGeomDetUnit*>(det_u), digi_map, tTopo_);

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.h
@@ -73,7 +73,7 @@ namespace cms {
     using vstring = std::vector<std::string>;
 
     // constants of different algorithm types
-    enum class AlgorithmType { InnerPixel, InnerPixel3D, PixelinPS, StripinPS, TwoStrip, Unknown };
+    enum class AlgorithmType { InnerPixel,  InnerPixelBricked, InnerPixel3D, PixelinPS, StripinPS, TwoStrip, Unknown };
     AlgorithmType getAlgoType(uint32_t idet);
 
     void accumulatePixelHits(edm::Handle<std::vector<PSimHit> >, size_t globalSimHitIndex, const uint32_t tofBin);

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.h
@@ -73,7 +73,7 @@ namespace cms {
     using vstring = std::vector<std::string>;
 
     // constants of different algorithm types
-    enum class AlgorithmType { InnerPixel,  InnerPixelBricked, InnerPixel3D, PixelinPS, StripinPS, TwoStrip, Unknown };
+    enum class AlgorithmType { InnerPixel, InnerPixelBricked, InnerPixel3D, PixelinPS, StripinPS, TwoStrip, Unknown };
     AlgorithmType getAlgoType(uint32_t idet);
 
     void accumulatePixelHits(edm::Handle<std::vector<PSimHit> >, size_t globalSimHitIndex, const uint32_t tofBin);

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.cc
@@ -37,24 +37,13 @@
 using namespace edm;
 using namespace sipixelobjects;
 
-namespace {
+namespace Ph2TkDigiAlgo  {
   // Mass in MeV
   constexpr double m_pion = 139.571;
   constexpr double m_kaon = 493.677;
   constexpr double m_electron = 0.511;
   constexpr double m_muon = 105.658;
   constexpr double m_proton = 938.272;
-  float calcQ(float x);
-}  // namespace
-namespace {
-  float calcQ(float x) {
-    constexpr float p1 = 12.5f;
-    constexpr float p2 = 0.2733f;
-    constexpr float p3 = 0.147f;
-
-    auto xx = std::min(0.5f * x * x, p1);
-    return 0.5f * (1.f - std::copysign(std::sqrt(1.f - unsafe_expf<4>(-xx * (1.f + p2 / (1.f + p3 * xx)))), x));
-  }
 }  // namespace
 Phase2TrackerDigitizerAlgorithm::Phase2TrackerDigitizerAlgorithm(const edm::ParameterSet& conf_common,
                                                                  const edm::ParameterSet& conf_specific,
@@ -279,17 +268,17 @@ std::vector<DigitizerUtility::EnergyDepositUnit> Phase2TrackerDigitizerAlgorithm
 //==============================================================================
 std::vector<float> Phase2TrackerDigitizerAlgorithm::fluctuateEloss(
     int pid, float particleMomentum, float eloss, float length, int NumberOfSegs) const {
-  double particleMass = ::m_pion;  // Mass in MeV, assume pion
+  double particleMass = Ph2TkDigiAlgo::m_pion;  // Mass in MeV, assume pion
   pid = std::abs(pid);
   if (pid != 211) {  // Mass in MeV
     if (pid == 11)
-      particleMass = ::m_electron;
+      particleMass = Ph2TkDigiAlgo::m_electron;
     else if (pid == 13)
-      particleMass = ::m_muon;
+      particleMass = Ph2TkDigiAlgo::m_muon;
     else if (pid == 321)
-      particleMass = ::m_kaon;
+      particleMass = Ph2TkDigiAlgo::m_kaon;
     else if (pid == 2212)
-      particleMass = ::m_proton;
+      particleMass = Ph2TkDigiAlgo::m_proton;
   }
   // What is the track segment length.
   float segmentLength = length / NumberOfSegs;
@@ -513,7 +502,7 @@ void Phase2TrackerDigitizerAlgorithm::induce_signal(
       } else {
         mp = MeasurementPoint(ix, 0.0);
         xLB = topol->localPosition(mp).x();
-        LowerBound = 1 - ::calcQ((xLB - CloudCenterX) / SigmaX);
+        LowerBound = 1 - calcQ((xLB - CloudCenterX) / SigmaX);
       }
 
       float xUB, UpperBound;
@@ -522,7 +511,7 @@ void Phase2TrackerDigitizerAlgorithm::induce_signal(
       } else {
         mp = MeasurementPoint(ix + 1, 0.0);
         xUB = topol->localPosition(mp).x();
-        UpperBound = 1. - ::calcQ((xUB - CloudCenterX) / SigmaX);
+        UpperBound = 1. - calcQ((xUB - CloudCenterX) / SigmaX);
       }
       float TotalIntegrationRange = UpperBound - LowerBound;  // get strip
       x.emplace(ix, TotalIntegrationRange);                   // save strip integral
@@ -537,7 +526,7 @@ void Phase2TrackerDigitizerAlgorithm::induce_signal(
       } else {
         mp = MeasurementPoint(0.0, iy);
         yLB = topol->localPosition(mp).y();
-        LowerBound = 1. - ::calcQ((yLB - CloudCenterY) / SigmaY);
+        LowerBound = 1. - calcQ((yLB - CloudCenterY) / SigmaY);
       }
 
       float yUB, UpperBound;
@@ -546,7 +535,7 @@ void Phase2TrackerDigitizerAlgorithm::induce_signal(
       } else {
         mp = MeasurementPoint(0.0, iy + 1);
         yUB = topol->localPosition(mp).y();
-        UpperBound = 1. - ::calcQ((yUB - CloudCenterY) / SigmaY);
+        UpperBound = 1. - calcQ((yUB - CloudCenterY) / SigmaY);
       }
 
       float TotalIntegrationRange = UpperBound - LowerBound;
@@ -1041,3 +1030,12 @@ int Phase2TrackerDigitizerAlgorithm::convertSignalToAdc(uint32_t detID, float si
   }
   return signal_in_adc;
 }
+float Phase2TrackerDigitizerAlgorithm::calcQ(float x) {
+  constexpr float p1 = 12.5f;
+  constexpr float p2 = 0.2733f;
+  constexpr float p3 = 0.147f;
+  
+  auto xx = std::min(0.5f * x * x, p1);
+  return 0.5f * (1.f - std::copysign(std::sqrt(1.f - unsafe_expf<4>(-xx * (1.f + p2 / (1.f + p3 * xx)))), x));
+}
+  

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.cc
@@ -37,14 +37,14 @@
 using namespace edm;
 using namespace sipixelobjects;
 
-namespace Ph2TkDigiAlgo  {
+namespace Ph2TkDigiAlgo {
   // Mass in MeV
   constexpr double m_pion = 139.571;
   constexpr double m_kaon = 493.677;
   constexpr double m_electron = 0.511;
   constexpr double m_muon = 105.658;
   constexpr double m_proton = 938.272;
-}  // namespace
+}  // namespace Ph2TkDigiAlgo
 Phase2TrackerDigitizerAlgorithm::Phase2TrackerDigitizerAlgorithm(const edm::ParameterSet& conf_common,
                                                                  const edm::ParameterSet& conf_specific,
                                                                  edm::ConsumesCollector iC)
@@ -1034,8 +1034,7 @@ float Phase2TrackerDigitizerAlgorithm::calcQ(float x) {
   constexpr float p1 = 12.5f;
   constexpr float p2 = 0.2733f;
   constexpr float p3 = 0.147f;
-  
+
   auto xx = std::min(0.5f * x * x, p1);
   return 0.5f * (1.f - std::copysign(std::sqrt(1.f - unsafe_expf<4>(-xx * (1.f + p2 / (1.f + p3 * xx)))), x));
 }
-  

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.h
@@ -1,3 +1,5 @@
+
+
 #ifndef __SimTracker_SiPhase2Digitizer_Phase2TrackerDigitizerAlgorithm_h
 #define __SimTracker_SiPhase2Digitizer_Phase2TrackerDigitizerAlgorithm_h
 
@@ -218,6 +220,7 @@ protected:
       const Phase2TrackerGeomDetUnit* pixdet);  // remove dead modules uisng the list in the DB
 
   const SubdetEfficiencies subdetEfficiencies_;
+  float calcQ(float x);
 
   // For random numbers
   std::unique_ptr<CLHEP::RandGaussQ> gaussDistribution_;

--- a/SimTracker/SiPhase2Digitizer/plugins/PixelBrickedDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/PixelBrickedDigitizerAlgorithm.cc
@@ -1,0 +1,232 @@
+#include <iostream>
+#include <cmath>
+
+#include "SimTracker/SiPhase2Digitizer/plugins/PixelBrickedDigitizerAlgorithm.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
+
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationOfflineSimService.h"
+
+#include "CondFormats/SiPixelObjects/interface/GlobalPixel.h"
+#include "CondFormats/DataRecord/interface/SiPixelQualityRcd.h"
+#include "CondFormats/DataRecord/interface/SiPixelFedCablingMapRcd.h"
+#include "CondFormats/DataRecord/interface/SiPixelLorentzAngleSimRcd.h"
+
+// Geometry
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
+#include "Geometry/CommonTopologies/interface/PixelTopology.h"
+
+using namespace edm;
+using namespace sipixelobjects;
+
+PixelBrickedDigitizerAlgorithm::PixelBrickedDigitizerAlgorithm(const edm::ParameterSet& conf, edm::ConsumesCollector iC)
+  : PixelDigitizerAlgorithm(conf,iC)
+    /*    odd_row_interchannelCoupling_next_row_(conf.getParameter<ParameterSet>("PixelBrickedDigitizerAlgorithm")
+                                                 .getParameter<double>("Odd_row_interchannelCoupling_next_row"))
+         even_row_interchannelCoupling_next_row_(conf.getParameter<ParameterSet>("PixelBrickedDigitizerAlgorithm")
+                                                  .getParameter<double>("Even_row_interchannelCoupling_next_row")),
+      odd_column_interchannelCoupling_next_column_(
+          conf.getParameter<ParameterSet>("PixelBrickedDigitizerAlgorithm")
+              .getParameter<double>("Odd_column_interchannelCoupling_next_column")),
+      even_column_interchannelCoupling_next_column_(
+          conf.getParameter<ParameterSet>("PixelBrickedDigitizerAlgorithm")
+	  .getParameter<double>("Even_column_interchannelCoupling_next_column"))*/
+{
+  
+  even_row_interchannelCoupling_next_row_ = conf.getParameter<ParameterSet>("PixelBrickedDigitizerAlgorithm")
+    .getParameter<double>("Even_row_interchannelCoupling_next_row");
+  pixelFlag_ = true;
+  LogDebug("PixelBrickedDigitizerAlgorithm") << "Algorithm constructed "
+                                      << "Configuration parameters:"
+                                      << "Threshold/Gain = "
+                                      << "threshold in electron Endcap = " << theThresholdInE_Endcap_
+                                      << "threshold in electron Barrel = " << theThresholdInE_Barrel_ << " "
+                                      << theElectronPerADC_ << " " << theAdcFullScale_
+                                      << " The delta cut-off is set to " << tMax_ << " pix-inefficiency "
+					     << addPixelInefficiency_ ;
+}
+PixelBrickedDigitizerAlgorithm::~PixelBrickedDigitizerAlgorithm() { LogDebug("PixelBrickedDigitizerAlgorithm") << "Algorithm deleted"; }
+void PixelBrickedDigitizerAlgorithm::induce_signal(
+    const PSimHit& hit,
+    const size_t hitIndex,
+    const uint32_t tofBin,
+    const Phase2TrackerGeomDetUnit* pixdet,
+    const std::vector<DigitizerUtility::SignalPoint>& collection_points) {
+  // X  - Rows, Left-Right, 160, (1.6cm)   for barrel
+  // Y  - Columns, Down-Up, 416, (6.4cm)
+  const Phase2TrackerTopology* topol = &pixdet->specificTopology();
+  uint32_t detID = pixdet->geographicalId().rawId();
+  signal_map_type& theSignal = _signal[detID];
+  
+
+  // local map to store pixels hit by 1 Hit.
+  using hit_map_type = std::map<int, float, std::less<int> >;
+  hit_map_type hit_signal;
+
+  // Assign signals to readout channels and store sorted by channel number
+  // Iterate over collection points on the collection plane
+  for (auto const& v : collection_points) {
+    float CloudCenterX = v.position().x();  // Charge position in x
+    float CloudCenterY = v.position().y();  //                 in y
+    float SigmaX = v.sigma_x();             // Charge spread in x
+    float SigmaY = v.sigma_y();             //               in y
+    float Charge = v.amplitude();           // Charge amplitude
+
+
+    // Find the maximum cloud spread in 2D plane , assume 3*sigma
+    float CloudRight = CloudCenterX + clusterWidth_ * SigmaX;
+    float CloudLeft = CloudCenterX - clusterWidth_ * SigmaX;
+    float CloudUp = CloudCenterY + clusterWidth_ * SigmaY;
+    float CloudDown = CloudCenterY - clusterWidth_ * SigmaY;
+
+    // Define 2D cloud limit points
+    LocalPoint PointRightUp = LocalPoint(CloudRight, CloudUp);
+    LocalPoint PointLeftDown = LocalPoint(CloudLeft, CloudDown);
+
+    // This points can be located outside the sensor area.
+    // The conversion to measurement point does not check for that
+    // so the returned pixel index might be wrong (outside range).
+    // We rely on the limits check below to fix this.
+    // But remember whatever we do here THE CHARGE OUTSIDE THE ACTIVE
+    // PIXEL ARE IS LOST, it should not be collected.
+
+    // Convert the 2D points to pixel indices
+    MeasurementPoint mp = topol->measurementPosition(PointRightUp);
+    //MeasurementPoint mp_bricked = topol->measurementPosition(PointRightUp);
+    int IPixRightUpX = static_cast<int>(std::floor(mp.x()));  // cast reqd.
+    //int IPixRightUpY = static_cast<int>(std::floor(mp.y()));
+
+    int numColumns = topol->ncolumns();  // det module number of cols&rows
+    int numRows = topol->nrows();
+    IPixRightUpX = numRows > IPixRightUpX ? IPixRightUpX : numRows - 1;
+
+    //Specific to bricked geometry 
+    int IPixRightUpY = static_cast<int>(mp.y() - 0.5*(IPixRightUpX%2) );
+
+    mp = topol->measurementPosition(PointLeftDown);
+    
+    int IPixLeftDownX = static_cast<int>(std::floor(mp.x()));
+
+    IPixLeftDownX = 0 < IPixLeftDownX ? IPixLeftDownX : 0;
+
+    //Specific to bricked geometry 
+    int IPixLeftDownY = static_cast<int>(mp.y() - 0.5*(IPixLeftDownX%2));//changed in case negative value	
+
+    IPixRightUpY =  numColumns > IPixRightUpY    ? IPixRightUpY : numColumns - 1;
+    IPixLeftDownY = 0 < IPixLeftDownY ? IPixLeftDownY : 0;
+
+    // First integrate charge strips in x
+    hit_map_type x;
+    for (int ix = IPixLeftDownX; ix <= IPixRightUpX; ++ix) {  // loop over x index
+      float xLB, LowerBound;
+      // Why is set to 0 if ix=0, does it meen that we accept charge
+      // outside the sensor?
+      if (ix == 0 || SigmaX == 0.) {  // skip for surface segemnts
+        LowerBound = 0.;
+      } else {
+        mp = MeasurementPoint(ix, 0.0);
+        xLB = topol->localPosition(mp).x();
+        LowerBound = 1 - calcQ((xLB - CloudCenterX) / SigmaX);
+      }
+      
+      float xUB, UpperBound;
+      if (ix == numRows - 1 || SigmaX == 0.) {
+        UpperBound = 1.;
+      } else {
+        mp = MeasurementPoint(ix + 1, 0.0);
+        xUB = topol->localPosition(mp).x();
+        UpperBound = 1. - calcQ((xUB - CloudCenterX) / SigmaX);
+      }
+      float TotalIntegrationRange = UpperBound - LowerBound;  // get strip
+      x.emplace(ix, TotalIntegrationRange);                   // save strip integral
+    }
+
+    // Now integrate strips in y. Two maps will be filled: y and y_bricked which will both be used for the induced signal.
+    int IPixLeftDownY_bricked = IPixLeftDownY;
+    int IPixRightUpY_bricked = IPixRightUpY;
+    
+    //Specific to bricked geometry
+    IPixRightUpY = std::min( IPixRightUpY + int((IPixRightUpX%2)), numColumns-1);
+    
+    //This map will be twice as large as the non-bricked hit map in y to harbor both the integrated charge from the bricked and non-bricked columns.
+    hit_map_type y;
+    for (int iy = IPixLeftDownY; iy <= IPixRightUpY; ++iy) {  // loop over y index
+      float yLB, LowerBound;
+      if (iy == 0 || SigmaY == 0.) {
+        LowerBound = 0.;
+      } else {
+        mp = MeasurementPoint(0.0, iy);
+        yLB = topol->localPosition(mp).y();
+        LowerBound = 1. - calcQ((yLB - CloudCenterY) / SigmaY);
+      }
+      
+      float yUB, UpperBound;
+      if (iy >= numColumns - 1 || SigmaY == 0.) {
+        UpperBound = 1.;
+      } else {
+	mp = MeasurementPoint(0.0, iy + 1);
+        yUB = topol->localPosition(mp).y();
+        UpperBound = 1. - calcQ((yUB - CloudCenterY) / SigmaY);
+      }
+      
+      float TotalIntegrationRange = UpperBound - LowerBound;
+	
+      //Even indices correspond to the non-bricked columns
+      y.emplace(2*iy, TotalIntegrationRange);  // save strip integral
+    }
+    
+    IPixLeftDownY_bricked = std::max( IPixLeftDownY_bricked - int((!(IPixLeftDownX%2))), 0);
+    for (int iy = IPixLeftDownY_bricked; iy <= IPixRightUpY_bricked; ++iy) {  // loop over y index
+      float yLB, LowerBound;
+      if (iy == 0 || SigmaY == 0.) {
+        LowerBound = 0.;
+      } else {
+	mp = MeasurementPoint(0.0, iy + 0.5);
+        yLB = topol->localPosition(mp).y();
+        LowerBound = 1. - calcQ((yLB - CloudCenterY) / SigmaY);
+      }
+      
+      float yUB, UpperBound;
+      if (iy >= numColumns  || SigmaY == 0.) { // This was changed for bricked pixels
+        UpperBound = 1.;
+      } else {
+	mp = MeasurementPoint(0.0, iy + 1.5 );
+        yUB = topol->localPosition(mp).y();
+        UpperBound = 1. - calcQ((yUB - CloudCenterY) / SigmaY);
+      }
+
+      float TotalIntegrationRange = UpperBound - LowerBound;
+      //Odd indices correspond to bricked columns
+      y.emplace(2*iy + 1, TotalIntegrationRange);  // save strip integral
+    }//loop over y index
+    
+    // Get the 2D charge integrals by folding x and y strips
+    for (int ix = IPixLeftDownX; ix <= IPixRightUpX; ++ix) {    // loop over x index
+      for (int iy = std::max(0,IPixLeftDownY - int((ix%2)))   ; iy <= IPixRightUpY ; ++iy) {  // loop over y index
+	int iy_considered = iy*2 + ix%2;
+	float ChargeFraction = Charge * x[ix] * y[iy_considered];
+	
+	int chanFired = -1;
+	if (ChargeFraction > 0.) {
+	  chanFired =
+	    pixelFlag_ ? PixelDigi::pixelToChannel(ix, iy ) : Phase2TrackerDigi::pixelToChannel(ix, iy);  // Get index
+	  // Load the ampl
+	  hit_signal[chanFired] += ChargeFraction;
+	}
+      }  
+    }//x loop
+  }//collection loop
+  // Fill the global map with all hit pixels from this event
+  float corr_time = hit.tof() - pixdet->surface().toGlobal(hit.localPosition()).mag() * c_inv;
+  for (auto const& hit_s : hit_signal) {
+    int chan = hit_s.first;
+    theSignal[chan] +=
+      (makeDigiSimLinks_ ? DigitizerUtility::Amplitude(hit_s.second, &hit, hit_s.second, corr_time, hitIndex, tofBin)
+       : DigitizerUtility::Amplitude(hit_s.second, nullptr, hit_s.second));
+  }
+}
+

--- a/SimTracker/SiPhase2Digitizer/plugins/PixelBrickedDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/PixelBrickedDigitizerAlgorithm.cc
@@ -24,8 +24,8 @@ using namespace edm;
 using namespace sipixelobjects;
 
 PixelBrickedDigitizerAlgorithm::PixelBrickedDigitizerAlgorithm(const edm::ParameterSet& conf, edm::ConsumesCollector iC)
-  : PixelDigitizerAlgorithm(conf,iC)
-    /*    odd_row_interchannelCoupling_next_row_(conf.getParameter<ParameterSet>("PixelBrickedDigitizerAlgorithm")
+    : PixelDigitizerAlgorithm(conf, iC)
+/*    odd_row_interchannelCoupling_next_row_(conf.getParameter<ParameterSet>("PixelBrickedDigitizerAlgorithm")
                                                  .getParameter<double>("Odd_row_interchannelCoupling_next_row"))
          even_row_interchannelCoupling_next_row_(conf.getParameter<ParameterSet>("PixelBrickedDigitizerAlgorithm")
                                                   .getParameter<double>("Even_row_interchannelCoupling_next_row")),
@@ -36,32 +36,30 @@ PixelBrickedDigitizerAlgorithm::PixelBrickedDigitizerAlgorithm(const edm::Parame
           conf.getParameter<ParameterSet>("PixelBrickedDigitizerAlgorithm")
 	  .getParameter<double>("Even_column_interchannelCoupling_next_column"))*/
 {
-  
   even_row_interchannelCoupling_next_row_ = conf.getParameter<ParameterSet>("PixelBrickedDigitizerAlgorithm")
-    .getParameter<double>("Even_row_interchannelCoupling_next_row");
+                                                .getParameter<double>("Even_row_interchannelCoupling_next_row");
   pixelFlag_ = true;
-  LogDebug("PixelBrickedDigitizerAlgorithm") << "Algorithm constructed "
-                                      << "Configuration parameters:"
-                                      << "Threshold/Gain = "
-                                      << "threshold in electron Endcap = " << theThresholdInE_Endcap_
-                                      << "threshold in electron Barrel = " << theThresholdInE_Barrel_ << " "
-                                      << theElectronPerADC_ << " " << theAdcFullScale_
-                                      << " The delta cut-off is set to " << tMax_ << " pix-inefficiency "
-					     << addPixelInefficiency_ ;
+  LogDebug("PixelBrickedDigitizerAlgorithm")
+      << "Algorithm constructed "
+      << "Configuration parameters:"
+      << "Threshold/Gain = "
+      << "threshold in electron Endcap = " << theThresholdInE_Endcap_
+      << "threshold in electron Barrel = " << theThresholdInE_Barrel_ << " " << theElectronPerADC_ << " "
+      << theAdcFullScale_ << " The delta cut-off is set to " << tMax_ << " pix-inefficiency " << addPixelInefficiency_;
 }
-PixelBrickedDigitizerAlgorithm::~PixelBrickedDigitizerAlgorithm() { LogDebug("PixelBrickedDigitizerAlgorithm") << "Algorithm deleted"; }
-void PixelBrickedDigitizerAlgorithm::induce_signal(
-    const PSimHit& hit,
-    const size_t hitIndex,
-    const uint32_t tofBin,
-    const Phase2TrackerGeomDetUnit* pixdet,
-    const std::vector<DigitizerUtility::SignalPoint>& collection_points) {
+PixelBrickedDigitizerAlgorithm::~PixelBrickedDigitizerAlgorithm() {
+  LogDebug("PixelBrickedDigitizerAlgorithm") << "Algorithm deleted";
+}
+void PixelBrickedDigitizerAlgorithm::induce_signal(const PSimHit& hit,
+                                                   const size_t hitIndex,
+                                                   const uint32_t tofBin,
+                                                   const Phase2TrackerGeomDetUnit* pixdet,
+                                                   const std::vector<DigitizerUtility::SignalPoint>& collection_points) {
   // X  - Rows, Left-Right, 160, (1.6cm)   for barrel
   // Y  - Columns, Down-Up, 416, (6.4cm)
   const Phase2TrackerTopology* topol = &pixdet->specificTopology();
   uint32_t detID = pixdet->geographicalId().rawId();
   signal_map_type& theSignal = _signal[detID];
-  
 
   // local map to store pixels hit by 1 Hit.
   using hit_map_type = std::map<int, float, std::less<int> >;
@@ -75,7 +73,6 @@ void PixelBrickedDigitizerAlgorithm::induce_signal(
     float SigmaX = v.sigma_x();             // Charge spread in x
     float SigmaY = v.sigma_y();             //               in y
     float Charge = v.amplitude();           // Charge amplitude
-
 
     // Find the maximum cloud spread in 2D plane , assume 3*sigma
     float CloudRight = CloudCenterX + clusterWidth_ * SigmaX;
@@ -104,19 +101,19 @@ void PixelBrickedDigitizerAlgorithm::induce_signal(
     int numRows = topol->nrows();
     IPixRightUpX = numRows > IPixRightUpX ? IPixRightUpX : numRows - 1;
 
-    //Specific to bricked geometry 
-    int IPixRightUpY = static_cast<int>(mp.y() - 0.5*(IPixRightUpX%2) );
+    //Specific to bricked geometry
+    int IPixRightUpY = static_cast<int>(mp.y() - 0.5 * (IPixRightUpX % 2));
 
     mp = topol->measurementPosition(PointLeftDown);
-    
+
     int IPixLeftDownX = static_cast<int>(std::floor(mp.x()));
 
     IPixLeftDownX = 0 < IPixLeftDownX ? IPixLeftDownX : 0;
 
-    //Specific to bricked geometry 
-    int IPixLeftDownY = static_cast<int>(mp.y() - 0.5*(IPixLeftDownX%2));//changed in case negative value	
+    //Specific to bricked geometry
+    int IPixLeftDownY = static_cast<int>(mp.y() - 0.5 * (IPixLeftDownX % 2));  //changed in case negative value
 
-    IPixRightUpY =  numColumns > IPixRightUpY    ? IPixRightUpY : numColumns - 1;
+    IPixRightUpY = numColumns > IPixRightUpY ? IPixRightUpY : numColumns - 1;
     IPixLeftDownY = 0 < IPixLeftDownY ? IPixLeftDownY : 0;
 
     // First integrate charge strips in x
@@ -132,7 +129,7 @@ void PixelBrickedDigitizerAlgorithm::induce_signal(
         xLB = topol->localPosition(mp).x();
         LowerBound = 1 - calcQ((xLB - CloudCenterX) / SigmaX);
       }
-      
+
       float xUB, UpperBound;
       if (ix == numRows - 1 || SigmaX == 0.) {
         UpperBound = 1.;
@@ -148,10 +145,10 @@ void PixelBrickedDigitizerAlgorithm::induce_signal(
     // Now integrate strips in y. Two maps will be filled: y and y_bricked which will both be used for the induced signal.
     int IPixLeftDownY_bricked = IPixLeftDownY;
     int IPixRightUpY_bricked = IPixRightUpY;
-    
+
     //Specific to bricked geometry
-    IPixRightUpY = std::min( IPixRightUpY + int((IPixRightUpX%2)), numColumns-1);
-    
+    IPixRightUpY = std::min(IPixRightUpY + int((IPixRightUpX % 2)), numColumns - 1);
+
     //This map will be twice as large as the non-bricked hit map in y to harbor both the integrated charge from the bricked and non-bricked columns.
     hit_map_type y;
     for (int iy = IPixLeftDownY; iy <= IPixRightUpY; ++iy) {  // loop over y index
@@ -163,70 +160,69 @@ void PixelBrickedDigitizerAlgorithm::induce_signal(
         yLB = topol->localPosition(mp).y();
         LowerBound = 1. - calcQ((yLB - CloudCenterY) / SigmaY);
       }
-      
+
       float yUB, UpperBound;
       if (iy >= numColumns - 1 || SigmaY == 0.) {
         UpperBound = 1.;
       } else {
-	mp = MeasurementPoint(0.0, iy + 1);
+        mp = MeasurementPoint(0.0, iy + 1);
         yUB = topol->localPosition(mp).y();
         UpperBound = 1. - calcQ((yUB - CloudCenterY) / SigmaY);
       }
-      
+
       float TotalIntegrationRange = UpperBound - LowerBound;
-	
+
       //Even indices correspond to the non-bricked columns
-      y.emplace(2*iy, TotalIntegrationRange);  // save strip integral
+      y.emplace(2 * iy, TotalIntegrationRange);  // save strip integral
     }
-    
-    IPixLeftDownY_bricked = std::max( IPixLeftDownY_bricked - int((!(IPixLeftDownX%2))), 0);
+
+    IPixLeftDownY_bricked = std::max(IPixLeftDownY_bricked - int((!(IPixLeftDownX % 2))), 0);
     for (int iy = IPixLeftDownY_bricked; iy <= IPixRightUpY_bricked; ++iy) {  // loop over y index
       float yLB, LowerBound;
       if (iy == 0 || SigmaY == 0.) {
         LowerBound = 0.;
       } else {
-	mp = MeasurementPoint(0.0, iy + 0.5);
+        mp = MeasurementPoint(0.0, iy + 0.5);
         yLB = topol->localPosition(mp).y();
         LowerBound = 1. - calcQ((yLB - CloudCenterY) / SigmaY);
       }
-      
+
       float yUB, UpperBound;
-      if (iy >= numColumns  || SigmaY == 0.) { // This was changed for bricked pixels
+      if (iy >= numColumns || SigmaY == 0.) {  // This was changed for bricked pixels
         UpperBound = 1.;
       } else {
-	mp = MeasurementPoint(0.0, iy + 1.5 );
+        mp = MeasurementPoint(0.0, iy + 1.5);
         yUB = topol->localPosition(mp).y();
         UpperBound = 1. - calcQ((yUB - CloudCenterY) / SigmaY);
       }
 
       float TotalIntegrationRange = UpperBound - LowerBound;
       //Odd indices correspond to bricked columns
-      y.emplace(2*iy + 1, TotalIntegrationRange);  // save strip integral
-    }//loop over y index
-    
+      y.emplace(2 * iy + 1, TotalIntegrationRange);  // save strip integral
+    }                                                //loop over y index
+
     // Get the 2D charge integrals by folding x and y strips
-    for (int ix = IPixLeftDownX; ix <= IPixRightUpX; ++ix) {    // loop over x index
-      for (int iy = std::max(0,IPixLeftDownY - int((ix%2)))   ; iy <= IPixRightUpY ; ++iy) {  // loop over y index
-	int iy_considered = iy*2 + ix%2;
-	float ChargeFraction = Charge * x[ix] * y[iy_considered];
-	
-	int chanFired = -1;
-	if (ChargeFraction > 0.) {
-	  chanFired =
-	    pixelFlag_ ? PixelDigi::pixelToChannel(ix, iy ) : Phase2TrackerDigi::pixelToChannel(ix, iy);  // Get index
-	  // Load the ampl
-	  hit_signal[chanFired] += ChargeFraction;
-	}
-      }  
-    }//x loop
-  }//collection loop
+    for (int ix = IPixLeftDownX; ix <= IPixRightUpX; ++ix) {                                 // loop over x index
+      for (int iy = std::max(0, IPixLeftDownY - int((ix % 2))); iy <= IPixRightUpY; ++iy) {  // loop over y index
+        int iy_considered = iy * 2 + ix % 2;
+        float ChargeFraction = Charge * x[ix] * y[iy_considered];
+
+        int chanFired = -1;
+        if (ChargeFraction > 0.) {
+          chanFired =
+              pixelFlag_ ? PixelDigi::pixelToChannel(ix, iy) : Phase2TrackerDigi::pixelToChannel(ix, iy);  // Get index
+          // Load the ampl
+          hit_signal[chanFired] += ChargeFraction;
+        }
+      }
+    }  //x loop
+  }    //collection loop
   // Fill the global map with all hit pixels from this event
   float corr_time = hit.tof() - pixdet->surface().toGlobal(hit.localPosition()).mag() * c_inv;
   for (auto const& hit_s : hit_signal) {
     int chan = hit_s.first;
     theSignal[chan] +=
-      (makeDigiSimLinks_ ? DigitizerUtility::Amplitude(hit_s.second, &hit, hit_s.second, corr_time, hitIndex, tofBin)
-       : DigitizerUtility::Amplitude(hit_s.second, nullptr, hit_s.second));
+        (makeDigiSimLinks_ ? DigitizerUtility::Amplitude(hit_s.second, &hit, hit_s.second, corr_time, hitIndex, tofBin)
+                           : DigitizerUtility::Amplitude(hit_s.second, nullptr, hit_s.second));
   }
 }
-

--- a/SimTracker/SiPhase2Digitizer/plugins/PixelBrickedDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/PixelBrickedDigitizerAlgorithm.h
@@ -1,0 +1,29 @@
+
+#ifndef _SimTracker_SiPhase2Digitizer_PixelBrickedDigitizerAlgorithm_h
+#define _SimTracker_SiPhase2Digitizer_PixelBrickedDigitizerAlgorithm_h
+
+#include "CondFormats/SiPixelObjects/interface/GlobalPixel.h"
+#include "CondFormats/DataRecord/interface/SiPixelQualityRcd.h"
+#include "CondFormats/DataRecord/interface/SiPixelFedCablingMapRcd.h"
+#include "CondFormats/DataRecord/interface/SiPixelLorentzAngleSimRcd.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "SimTracker/SiPhase2Digitizer/plugins/PixelDigitizerAlgorithm.h"
+
+class PixelBrickedDigitizerAlgorithm : public PixelDigitizerAlgorithm {
+private:
+
+public:
+  PixelBrickedDigitizerAlgorithm(const edm::ParameterSet& conf, edm::ConsumesCollector  iC);
+  ~PixelBrickedDigitizerAlgorithm() override;
+
+  
+  // Specific for bricked pixel
+  void induce_signal(const PSimHit& hit,
+                     const size_t hitIndex,
+                     const unsigned int tofBin,
+                     const Phase2TrackerGeomDetUnit* pixdet,
+                     const std::vector<DigitizerUtility::SignalPoint>& collection_points);
+
+};
+#endif

--- a/SimTracker/SiPhase2Digitizer/plugins/PixelBrickedDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/PixelBrickedDigitizerAlgorithm.h
@@ -12,18 +12,15 @@
 
 class PixelBrickedDigitizerAlgorithm : public PixelDigitizerAlgorithm {
 private:
-
 public:
-  PixelBrickedDigitizerAlgorithm(const edm::ParameterSet& conf, edm::ConsumesCollector  iC);
+  PixelBrickedDigitizerAlgorithm(const edm::ParameterSet& conf, edm::ConsumesCollector iC);
   ~PixelBrickedDigitizerAlgorithm() override;
 
-  
   // Specific for bricked pixel
   void induce_signal(const PSimHit& hit,
                      const size_t hitIndex,
                      const unsigned int tofBin,
                      const Phase2TrackerGeomDetUnit* pixdet,
-                     const std::vector<DigitizerUtility::SignalPoint>& collection_points);
-
+                     const std::vector<DigitizerUtility::SignalPoint>& collection_points) override;
 };
 #endif

--- a/SimTracker/SiPhase2Digitizer/plugins/PixelDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/PixelDigitizerAlgorithm.h
@@ -52,10 +52,10 @@ public:
   void add_cross_talk(const Phase2TrackerGeomDetUnit* pixdet) override;
 
   // Addition four xtalk-related parameters to PixelDigitizerAlgorithm specific parameters initialized in Phase2TrackerDigitizerAlgorithm
-  const double odd_row_interchannelCoupling_next_row_;
-  const double even_row_interchannelCoupling_next_row_;
-  const double odd_column_interchannelCoupling_next_column_;
-  const double even_column_interchannelCoupling_next_column_;
+  double odd_row_interchannelCoupling_next_row_;
+  double even_row_interchannelCoupling_next_row_;
+  double odd_column_interchannelCoupling_next_column_;
+  double even_column_interchannelCoupling_next_column_;
 
   // Timewalk parameters
   bool apply_timewalk_;

--- a/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
+++ b/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
@@ -90,7 +90,8 @@ phase2TrackerDigitizer = cms.PSet(
         OhmicColumnRadius = cms.double(4.0),
         NPColumnGap = cms.double(46.0)
     ),
-
+#Pixel-Bricked Digitizer Algorithm
+    PixelBrickedDigitizerAlgorithm   = PixelDigitizerAlgorithmCommon.clone(),
 #Pixel in PS Module
     PSPDigitizerAlgorithm = cms.PSet(
       ElectronPerAdc = cms.double(135.0),

--- a/Validation/RecoTrack/python/plotting/plotting.py
+++ b/Validation/RecoTrack/python/plotting/plotting.py
@@ -446,12 +446,12 @@ def _getYminMaxAroundMedian(obj, coverage, coverageRange=None):
     if nvals < 2:
         # Take median and +- 1 values
         if len(yvals) % 2 == 0:
-            half = len(yvals)/2
+            half = len(yvals) // 2
             return ( yvals[half-1], yvals[half] )
         else:
-            middle = len(yvals)/2
+            middle = len(yvals) // 2
             return ( yvals[middle-1], yvals[middle+1] )
-    ind_min = (len(yvals)-nvals)/2
+    ind_min = (len(yvals)-nvals) // 2
     ind_max = len(yvals)-1 - ind_min
 
     return (yvals[ind_min], yvals[ind_max])


### PR DESCRIPTION
#### PR description:
Updating Phase2 Tracker Digitizer framework to include Bricked Pixel algorithm for the Inner Tracker (IT). The algorithm gets
activated for the phase 2 tracker geometry (T27) containing bricked pixels in TEPX&TFPX, as well as the central 1 (3) rod(s) of TBPX L2 (L3 and 4). The detailed description of the geometry and corresponding changes got included in the [PR#34120 ](https://github.com/cms-sw/cmssw/pull/34120/). This update do not have any impact on the Outer Tracker digis (verified with Phase2 DQM plots). Attaching a few slides for the IT distributions. 
[BrickedPR.pdf](https://github.com/cms-sw/cmssw/files/7113554/BrickedPR.pdf)

#### PR validation:
Validation done using SingleMuFlatPt2To100 events (runTheMatrix workflow 39104.0). No change observed in Digi DQM distributions for OT, as expected. 

Verified that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
@emiglior 