### PR TITLE
Fix laser correction timing error in Ecal DQM

### DIFF
--- a/DQM/EcalMonitorTasks/interface/OccupancyTask.h
+++ b/DQM/EcalMonitorTasks/interface/OccupancyTask.h
@@ -29,7 +29,6 @@ namespace ecaldqm {
     void runOnDigis(DigiCollection const&, Collections);
     void runOnTPDigis(EcalTrigPrimDigiCollection const&);
     void runOnRecHits(EcalRecHitCollection const&, Collections);
-    void setEventTime(const edm::TimeValue_t& iTime);
     void setTokens(edm::ConsumesCollector&) override;
 
   private:

--- a/DQM/EcalMonitorTasks/src/OccupancyTask.cc
+++ b/DQM/EcalMonitorTasks/src/OccupancyTask.cc
@@ -1,5 +1,5 @@
 #include "DQM/EcalMonitorTasks/interface/OccupancyTask.h"
-
+#include "FWCore/Framework/interface/Event.h"
 #include "DQM/EcalCommon/interface/EcalDQMCommonUtils.h"
 #include "DataFormats/EcalRawData/interface/EcalDCCHeaderBlock.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -28,7 +28,6 @@ namespace ecaldqm {
   }
 
   void OccupancyTask::beginRun(edm::Run const&, edm::EventSetup const& _es) { FillLaser = true; }
-  void OccupancyTask::setEventTime(const edm::TimeValue_t& iTime) { m_iTime = iTime; }
   void OccupancyTask::beginEvent(edm::Event const& _evt,
                                  edm::EventSetup const& _es,
                                  bool const& ByLumiResetSwitch,
@@ -39,6 +38,7 @@ namespace ecaldqm {
       MEs_.at("RecHitThrAllByLumi").reset(GetElectronicsMap());
     }
     MESet& meLaserCorrProjEta(MEs_.at("LaserCorrProjEta"));
+    m_iTime = _evt.time().value();
     if (FillLaser) {
       float lasercalib = 1.;
       auto const& laser = &_es.getData(lasertoken_);


### PR DESCRIPTION
#### PR description:

This PR addresses the issue https://github.com/cms-sw/cmssw/issues/35014. The time stamp of the event was not set correctly which when sent as an argument to the laser correction function gave false values. This is now rectified.

#### PR validation:
The warning message was reproduced by running: 
For 2020 MWGR
```
cmsDriver.py step2 --conditions auto:run3_data_prompt --customise Configuration/DataProcessing/RecoTLR.customisePrompt,Configuration/DataProcessing/RecoTLR.customiseCosmicData --data --datatier RECO,DQMIO --era Run3 --eventcontent RECO,DQM --filein /store/express/Commissioning2020/ExpressCosmics/FEVT/Express-v1/000/338/714/00000/000D25B4-AE2B-ED4D-A539-F6EF7CDD527E.root --fileout "file:step2.root" --nThreads 8 --no_exec --number 1 --process reRECO --python_filename step_2_cfg.py --scenario cosmics --step RAW2DIGI,L1Reco,RECO,DQM

cmsRun  step_2_cfg.py
```

For 2021 CRUZET
```
cmsDriver.py step2 --conditions auto:run3_data_prompt --customise Configuration/DataProcessing/RecoTLR.customisePrompt,Configuration/DataProcessing/RecoTLR.customiseCosmicData --data --datatier RECO,DQMIO --era Run3 --eventcontent RECO,DQM --filein /store/express/Commissioning2021/ExpressCosmics/FEVT/Express-v1/000/344/518/00000/0147726b-df3d-467c-b802-17f26ff1ae92.root --fileout "file:step2.root" --nThreads 8 --no_exec --number 1 --process reRECO --python_filename step_2_cfg.py --scenario cosmics --step RAW2DIGI,L1Reco,RECO,DQM

cmsRun  step_2_cfg.py
```
After the changes were implemented the message no longer appears on running the same.


#### if this PR is a backport please specify the original PR and why you need to backport that PR:

