### PR TITLE
Remove boost lexical_cast dependency in EventFilter

### DIFF
--- a/EventFilter/L1TRawToDigi/src/MP7FileReader.cc
+++ b/EventFilter/L1TRawToDigi/src/MP7FileReader.cc
@@ -5,7 +5,6 @@
 
 #include <boost/algorithm/string.hpp>
 #include <boost/regex.hpp>
-#include <boost/lexical_cast.hpp>
 
 #include <iostream>
 #include <string>
@@ -165,9 +164,9 @@ std::vector<uint32_t> MP7FileReader::searchLinks() {
       boost::split(tokens, tmp, boost::is_any_of(" \t"), boost::token_compress_on);
       // Convert it into uint32 s
       std::vector<uint32_t> links;
-      std::transform(
-          tokens.begin(), tokens.end(), std::back_inserter(links), boost::lexical_cast<uint32_t, const std::string&>);
-      return links;
+      std::transform(tokens.begin(), tokens.end(), std::back_inserter(links), [](const std::string& str) {
+        return std::stoul(str);
+      });
     } else {
       throw std::logic_error("Unexpected line found!");
     }
@@ -201,7 +200,7 @@ std::vector<std::vector<uint64_t> > MP7FileReader::readRows() {
 
     if (boost::regex_match(line, what, reFrame_)) {
       // check frame number
-      uint32_t n = boost::lexical_cast<uint32_t>(what[1].str());
+      uint32_t n = std::stoul(what[1].str());
 
       if (n != data.size()) {
         std::stringstream ss;

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -22,7 +22,6 @@
 #include <sys/time.h>
 #include <unistd.h>
 #include <cstdio>
-#include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string.hpp>
 
 //using boost::asio::ip::tcp;
@@ -84,10 +83,10 @@ namespace evf {
     char* fuLockPollIntervalPtr = std::getenv("FFF_LOCKPOLLINTERVAL");
     if (fuLockPollIntervalPtr) {
       try {
-        fuLockPollInterval_ = boost::lexical_cast<unsigned int>(std::string(fuLockPollIntervalPtr));
+        fuLockPollInterval_ = std::stoul(std::string(fuLockPollIntervalPtr));
         edm::LogInfo("EvFDaqDirector") << "Setting fu lock poll interval by environment string: " << fuLockPollInterval_
                                        << " us";
-      } catch (boost::bad_lexical_cast const&) {
+      } catch (const std::exception&) {
         edm::LogWarning("EvFDaqDirector") << "Bad lexical cast in parsing: " << std::string(fuLockPollIntervalPtr);
       }
     }
@@ -96,9 +95,9 @@ namespace evf {
     char* fileBrokerParamPtr = std::getenv("FFF_USEFILEBROKER");
     if (fileBrokerParamPtr) {
       try {
-        useFileBroker_ = (boost::lexical_cast<unsigned int>(std::string(fileBrokerParamPtr))) > 0;
+        useFileBroker_ = (std::stoul(std::string(fileBrokerParamPtr))) > 0;
         edm::LogInfo("EvFDaqDirector") << "Setting useFileBroker parameter by environment string: " << useFileBroker_;
-      } catch (boost::bad_lexical_cast const&) {
+      } catch (const std::exception&) {
         edm::LogWarning("EvFDaqDirector") << "Bad lexical cast in parsing: " << std::string(fileBrokerParamPtr);
       }
     }
@@ -126,9 +125,9 @@ namespace evf {
     char* startFromLSPtr = std::getenv("FFF_START_LUMISECTION");
     if (startFromLSPtr) {
       try {
-        startFromLS_ = boost::lexical_cast<unsigned int>(std::string(startFromLSPtr));
+        startFromLS_ = std::stoul(std::string(startFromLSPtr));
         edm::LogInfo("EvFDaqDirector") << "Setting start from LS by environment string: " << startFromLS_;
-      } catch (boost::bad_lexical_cast const&) {
+      } catch (const std::exception&) {
         edm::LogWarning("EvFDaqDirector") << "Bad lexical cast in parsing: " << std::string(startFromLSPtr);
       }
     }
@@ -137,10 +136,10 @@ namespace evf {
     char* fileBrokerUseLockParamPtr = std::getenv("FFF_FILEBROKERUSELOCALLOCK");
     if (fileBrokerUseLockParamPtr) {
       try {
-        fileBrokerUseLocalLock_ = (boost::lexical_cast<unsigned int>(std::string(fileBrokerUseLockParamPtr))) > 0;
+        fileBrokerUseLocalLock_ = (std::stoul(std::string(fileBrokerUseLockParamPtr))) > 0;
         edm::LogInfo("EvFDaqDirector") << "Setting fileBrokerUseLocalLock parameter by environment string: "
                                        << fileBrokerUseLocalLock_;
-      } catch (boost::bad_lexical_cast const&) {
+      } catch (const std::exception&) {
         edm::LogWarning("EvFDaqDirector") << "Bad lexical cast in parsing: " << std::string(fileBrokerUseLockParamPtr);
       }
     }
@@ -773,7 +772,7 @@ namespace evf {
       edm::LogError("EvFDaqDirector") << " error reading number of files from BU JSON -: " << BUEoLSFile;
       return -1;
     }
-    return boost::lexical_cast<int>(data);
+    return std::stoi(data);
   }
 
   bool EvFDaqDirector::bumpFile(unsigned int& ls,
@@ -1326,8 +1325,8 @@ namespace evf {
           if (i < dp.getData().size()) {
             std::string dataSize = dp.getData()[i];
             try {
-              fileSizeFromJson = boost::lexical_cast<long>(dataSize);
-            } catch (boost::bad_lexical_cast const&) {
+              fileSizeFromJson = std::stol(dataSize);
+            } catch (const std::exception&) {
               //non-fatal currently, processing can continue without this value
               edm::LogWarning("EvFDaqDirector") << "grabNextJsonFile - error parsing number of Bytes from BU JSON. "
                                                 << "Input value is -: " << dataSize;
@@ -1336,8 +1335,8 @@ namespace evf {
           }
         }
       }
-      return boost::lexical_cast<int>(data);
-    } catch (boost::bad_lexical_cast const& e) {
+      return std::stoi(data);
+    } catch (const std::exception& e) {
       edm::LogError("EvFDaqDirector") << "grabNextJsonFile - error parsing number of events from BU JSON. "
                                       << "Input value is -: " << data;
     } catch (std::runtime_error const& e) {
@@ -1423,7 +1422,7 @@ namespace evf {
           throw cms::Exception("EvFDaqDirector::grabNextJsonFileUnlock")
               << " error reading number of events from BU JSON -: No input value " << data;
       }
-      return boost::lexical_cast<int>(data);
+      return std::stoi(data);
     } catch (std::filesystem::filesystem_error const& ex) {
       // Input dir gone?
       unlockFULocal();
@@ -1432,7 +1431,7 @@ namespace evf {
       // Another process grabbed the file and NFS did not register this
       unlockFULocal();
       edm::LogError("EvFDaqDirector") << "grabNextFile runtime Exception -: " << e.what();
-    } catch (boost::bad_lexical_cast const&) {
+    } catch (const std::out_of_range&) {
       edm::LogError("EvFDaqDirector") << "grabNextFile error parsing number of events from BU JSON. "
                                       << "Input value is -: " << data;
     } catch (std::exception const& e) {

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -1336,8 +1336,11 @@ namespace evf {
         }
       }
       return std::stoi(data);
-    } catch (const std::exception& e) {
+    } catch (const std::out_of_range& e) {
       edm::LogError("EvFDaqDirector") << "grabNextJsonFile - error parsing number of events from BU JSON. "
+                                      << "Input value is -: " << data;
+    } catch (const std::invalid_argument& e) {
+      edm::LogError("EvFDaqDirector") << "grabNextJsonFile - argument error parsing events from BU JSON. "
                                       << "Input value is -: " << data;
     } catch (std::runtime_error const& e) {
       //Can be thrown by Json parser
@@ -1433,6 +1436,9 @@ namespace evf {
       edm::LogError("EvFDaqDirector") << "grabNextFile runtime Exception -: " << e.what();
     } catch (const std::out_of_range&) {
       edm::LogError("EvFDaqDirector") << "grabNextFile error parsing number of events from BU JSON. "
+                                      << "Input value is -: " << data;
+    } catch (const std::invalid_argument&) {
+      edm::LogError("EvFDaqDirector") << "grabNextFile argument error parsing events from BU JSON. "
                                       << "Input value is -: " << data;
     } catch (std::exception const& e) {
       // BU run directory disappeared?

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -46,8 +46,6 @@
 //JSON file reader
 #include "EventFilter/Utilities/interface/reader.h"
 
-#include <boost/lexical_cast.hpp>
-
 using namespace evf::FastMonState;
 
 FedRawDataInputSource::FedRawDataInputSource(edm::ParameterSet const& pset, edm::InputSourceDescription const& desc)
@@ -1556,10 +1554,10 @@ long FedRawDataInputSource::initFileList() {
       std::string runStr = fileStem.substr(3, end - 3);
       try {
         //get long to support test run numbers < 2^32
-        long rval = boost::lexical_cast<long>(runStr);
+        long rval = std::stol(runStr);
         edm::LogInfo("FedRawDataInputSource") << "Autodetected run number in fileListMode -: " << rval;
         return rval;
-      } catch (boost::bad_lexical_cast const&) {
+      } catch (const std::exception&) {
         edm::LogWarning("FedRawDataInputSource")
             << "Unable to autodetect run number in fileListMode from file -: " << fileName;
       }
@@ -1586,7 +1584,7 @@ evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getFile(unsigned int& ls,
       fileStem = fileStem.substr(0, fileStem.find('_'));
 
     if (!fileListLoopMode_)
-      ls = boost::lexical_cast<unsigned int>(fileStem);
+      ls = std::stoul(fileStem);
     else  //always starting from LS 1 in loop mode
       ls = 1 + loopModeIterationInc_;
 


### PR DESCRIPTION
#### PR description:

Remove boost lexical cast dependency in EventFilter with corresponding stl alternatives.

#### PR validation:

Passed runtests

#### if this PR is a backport:

<!-- Please replace this text with any link to  -->

@davidlange6 @vgvassilev
