### PR TITLE
Run3-sim91X Backport the xml files needed for a more correct Run3 geometry scenario definition

### DIFF
--- a/Geometry/CMSCommonData/data/materials/2021/v3/materials.xml
+++ b/Geometry/CMSCommonData/data/materials/2021/v3/materials.xml
@@ -1,0 +1,4405 @@
+<?xml version="1.0"?>
+<DDDefinition>
+
+ <MaterialSection label="materials.xml">
+  <ElementaryMaterial name="Aluminium" density="2.699*g/cm3" symbol=" " atomicWeight="26.982*g/mole" atomicNumber="13"/>
+  <ElementaryMaterial name="Antimony" density="6.691*g/cm3" symbol=" " atomicWeight="121.76*g/mole" atomicNumber="51"/>
+  <ElementaryMaterial name="Argon" density="1.662*mg/cm3" symbol=" " atomicWeight="39.948*g/mole" atomicNumber="18"/>
+  <ElementaryMaterial name="Arsenic" density="5.73*g/cm3" symbol=" " atomicWeight="74.922*g/mole" atomicNumber="33"/>
+  <ElementaryMaterial name="Barium" density="3.5*g/cm3" symbol=" " atomicWeight="137.33*g/mole" atomicNumber="56"/>
+  <ElementaryMaterial name="Beryllium" density="1.848*g/cm3" symbol=" " atomicWeight="9.0122*g/mole" atomicNumber="4"/>
+  <ElementaryMaterial name="Bismuth" density="9.747*g/cm3" symbol=" " atomicWeight="208.98*g/mole" atomicNumber="83"/>
+  <ElementaryMaterial name="Bor 10" density="2.37*g/cm3" symbol=" " atomicWeight="10*g/mole" atomicNumber="5"/>
+  <ElementaryMaterial name="Bor 11" density="2.37*g/cm3" symbol=" " atomicWeight="11*g/mole" atomicNumber="5"/>
+  <ElementaryMaterial name="Bromine" density="7.702*mg/cm3" symbol=" " atomicWeight="79.904*g/mole" atomicNumber="35"/>
+  <ElementaryMaterial name="Cadmium" density="8.65*g/cm3" symbol=" " atomicWeight="112.41*g/mole" atomicNumber="48"/>
+  <ElementaryMaterial name="Calcium" density="1.55*g/cm3" symbol=" " atomicWeight="40.078*g/mole" atomicNumber="20"/>
+  <ElementaryMaterial name="Carbon" density="2*g/cm3" symbol=" " atomicWeight="12.011*g/mole" atomicNumber="6"/>
+  <ElementaryMaterial name="Cerium" density="6.657*g/cm3" symbol=" " atomicWeight="140.12*g/mole" atomicNumber="58"/>
+  <ElementaryMaterial name="Cesium" density="1.873*g/cm3" symbol=" " atomicWeight="132.91*g/mole" atomicNumber="55"/>
+  <ElementaryMaterial name="Chlorine" density="2.995*mg/cm3" symbol=" " atomicWeight="35.45*g/mole" atomicNumber="17"/>
+  <ElementaryMaterial name="Chromium" density="7.18*g/cm3" symbol=" " atomicWeight="51.996*g/mole" atomicNumber="24"/>
+  <ElementaryMaterial name="Cobalt" density="8.9*g/cm3" symbol=" " atomicWeight="58.933*g/mole" atomicNumber="27"/>
+  <ElementaryMaterial name="Copper" density="8.96*g/cm3" symbol=" " atomicWeight="63.546*g/mole" atomicNumber="29"/>
+  <ElementaryMaterial name="Deuterium" density="0.17*mg/cm3" symbol=" " atomicWeight="2.01*g/mole" atomicNumber="1"/>
+  <ElementaryMaterial name="Fluorine" density="1.58*mg/cm3" symbol=" " atomicWeight="18.998*g/mole" atomicNumber="9"/>
+  <ElementaryMaterial name="Gallium" density="5.904*g/cm3" symbol=" " atomicWeight="69.723*g/mole" atomicNumber="31"/>
+  <ElementaryMaterial name="Germanium" density="5.323*g/cm3" symbol=" " atomicWeight="72.63*g/mole" atomicNumber="32"/>
+  <ElementaryMaterial name="Gold" density="19.32*g/cm3" symbol=" " atomicWeight="196.97*g/mole" atomicNumber="79"/>
+  <ElementaryMaterial name="Helium" density="0.166*mg/cm3" symbol=" " atomicWeight="4.0026*g/mole" atomicNumber="2"/>
+  <ElementaryMaterial name="Hydrogen" density="0.0837*mg/cm3" symbol=" " atomicWeight="1.00794*g/mole" atomicNumber="1"/>
+  <ElementaryMaterial name="Indium" density="7.31*g/cm3" symbol=" " atomicWeight="114.82*g/mole" atomicNumber="49"/>
+  <ElementaryMaterial name="Iodine" density="4.93*g/cm3" symbol=" " atomicWeight="126.9*g/mole" atomicNumber="53"/>
+  <ElementaryMaterial name="Iron" density="7.87*g/cm3" symbol=" " atomicWeight="55.845*g/mole" atomicNumber="26"/>
+  <ElementaryMaterial name="Krypton" density="3.48*mg/cm3" symbol=" " atomicWeight="83.798*g/mole" atomicNumber="36"/>
+  <ElementaryMaterial name="Lanthanum" density="6.154*g/cm3" symbol=" " atomicWeight="138.91*g/mole" atomicNumber="57"/>
+  <ElementaryMaterial name="Lead" density="11.35*g/cm3" symbol=" " atomicWeight="207.2*g/mole" atomicNumber="82"/>
+  <ElementaryMaterial name="Lithium" density="534*mg/cm3" symbol=" " atomicWeight="6.94*g/mole" atomicNumber="3"/>
+   <ElementaryMaterial name="Lutetium" density="9.84*g/cm3" symbol=" " atomicWeight="174.97*g/mole" atomicNumber="71"/>
+  <ElementaryMaterial name="Magnesium" density="1.74*g/cm3" symbol=" " atomicWeight="24.305*g/mole" atomicNumber="12"/>
+  <ElementaryMaterial name="Manganese" density="7.44*g/cm3" symbol=" " atomicWeight="54.938*g/mole" atomicNumber="25"/>
+  <ElementaryMaterial name="Molybdenum" density="10.22*g/cm3" symbol=" " atomicWeight="95.95*g/mole" atomicNumber="42"/>
+  <ElementaryMaterial name="Neodymium" density="6.9*g/cm3" symbol=" " atomicWeight="144.24*g/mole" atomicNumber="60"/>
+  <ElementaryMaterial name="Neon" density="0.8385*mg/cm3" symbol=" " atomicWeight="20.18*g/mole" atomicNumber="10"/>
+  <ElementaryMaterial name="Nickel" density="8.902*g/cm3" symbol=" " atomicWeight="58.693*g/mole" atomicNumber="28"/>
+  <ElementaryMaterial name="Niobium" density="8.57*g/cm3" symbol=" " atomicWeight="92.906*g/mole" atomicNumber="41"/>
+  <ElementaryMaterial name="Nitrogen" density="1.165*mg/cm3" symbol=" " atomicWeight="14.007*g/mole" atomicNumber="7"/>
+  <ElementaryMaterial name="Oxygen" density="1.3315*mg/cm3" symbol=" " atomicWeight="15.999*g/mole" atomicNumber="8"/>
+  <ElementaryMaterial name="Palladium" density="12.02*g/cm3" symbol=" " atomicWeight="106.42*g/mole" atomicNumber="46"/>
+  <ElementaryMaterial name="Phosphor" density="2.2*g/cm3" symbol=" " atomicWeight="30.974*g/mole" atomicNumber="15"/>
+  <ElementaryMaterial name="Potassium" density="862*mg/cm3" symbol=" " atomicWeight="39.098*g/mole" atomicNumber="19"/>
+  <ElementaryMaterial name="Praseodymium" density="6.71*g/cm3" symbol=" " atomicWeight="140.91*g/mole" atomicNumber="59"/>
+  <ElementaryMaterial name="Rhodium" density="12.41*g/cm3" symbol=" " atomicWeight="102.91*g/mole" atomicNumber="45"/>
+  <ElementaryMaterial name="Rubidium" density="1.532*g/cm3" symbol=" " atomicWeight="85.468*g/mole" atomicNumber="37"/>
+  <ElementaryMaterial name="Ruthenium" density="12.41*g/cm3" symbol=" " atomicWeight="101.07*g/mole" atomicNumber="44"/>
+  <ElementaryMaterial name="Scandium" density="2.989*g/cm3" symbol=" " atomicWeight="44.956*g/mole" atomicNumber="21"/>
+  <ElementaryMaterial name="Selenium" density="4.5*g/cm3" symbol=" " atomicWeight="78.971*g/mole" atomicNumber="34"/>
+  <ElementaryMaterial name="Silicon" density="2.33*g/cm3" symbol=" " atomicWeight="28.085*g/mole" atomicNumber="14"/>
+  <ElementaryMaterial name="Silver" density="10.5*g/cm3" symbol=" " atomicWeight="107.87*g/mole" atomicNumber="47"/>
+  <ElementaryMaterial name="Sodium" density="971*mg/cm3" symbol=" " atomicWeight="22.99*g/mole" atomicNumber="11"/>
+  <ElementaryMaterial name="Strontium" density="2.54*g/cm3" symbol=" " atomicWeight="87.62*g/mole" atomicNumber="38"/>
+  <ElementaryMaterial name="Sulfur" density="2*g/cm3" symbol=" " atomicWeight="32.06*g/mole" atomicNumber="16"/>
+  <ElementaryMaterial name="Tantalum" density="16.65*g/cm3" symbol=" " atomicWeight="180.95*g/mole" atomicNumber="73"/>
+  <ElementaryMaterial name="Technetium" density="11.5*g/cm3" symbol=" " atomicWeight="97*g/mole" atomicNumber="43"/>
+  <ElementaryMaterial name="Tellurium" density="6.24*g/cm3" symbol=" " atomicWeight="127.6*g/mole" atomicNumber="52"/>
+  <ElementaryMaterial name="Tin" density="7.31*g/cm3" symbol=" " atomicWeight="118.71*g/mole" atomicNumber="50"/>
+  <ElementaryMaterial name="Titanium" density="4.54*g/cm3" symbol=" " atomicWeight="47.867*g/mole" atomicNumber="22"/>
+  <ElementaryMaterial name="Tungsten" density="19.3*g/cm3" symbol=" " atomicWeight="183.84*g/mole" atomicNumber="74"/>
+  <ElementaryMaterial name="Uranium" density="18.95*g/cm3" symbol=" " atomicWeight="238.03*g/mole" atomicNumber="92"/>
+  <ElementaryMaterial name="Vacuum" density="1e-13*mg/cm3" symbol=" " atomicWeight="1*g/mole" atomicNumber="1"/>
+  <ElementaryMaterial name="Vanadium" density="6.11*g/cm3" symbol=" " atomicWeight="50.942*g/mole" atomicNumber="23"/>
+  <ElementaryMaterial name="Xenon" density="5.485*mg/cm3" symbol=" " atomicWeight="131.29*g/mole" atomicNumber="54"/>
+  <ElementaryMaterial name="Yttrium" density="4.469*g/cm3" symbol=" " atomicWeight="88.906*g/mole" atomicNumber="39"/>
+  <ElementaryMaterial name="Zinc" density="7.133*g/cm3" symbol=" " atomicWeight="65.38*g/mole" atomicNumber="30"/>
+  <ElementaryMaterial name="Zirconium" density="6.506*g/cm3" symbol=" " atomicWeight="91.224*g/mole" atomicNumber="40"/>
+  <CompositeMaterial name="80pct Argon plus 20pct CO_2" density="1.675*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.78405896">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.058934941">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1570061">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="AISI-1006-Steel" density="7.87*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0008">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0045">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0004">
+    <rMaterial name="materials:Phosphor"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0005">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.9938">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="AISI-1018-Steel" density="7.83*g/cm3 " symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0018">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0002">
+    <rMaterial name="materials:Phosphor"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0001">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0025">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.9854">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Steel_Upgrade" density="0.4915*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:AISI-1018-Steel"/>
+   </MaterialFraction>
+  </CompositeMaterial>  
+  <CompositeMaterial name="AISI-1045-Steel" density="7.87*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.005">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.009">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0004">
+    <rMaterial name="materials:Phosphor"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0005">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.9851">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Water" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.11190083">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.88809917">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="AQBB borated concre" density="2.135*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.032142361">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.47563465">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.20400656">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.051371319">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.20008524">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0048537181">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.02135636">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.010549802">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.001119">
+    <rMaterial name="materials:Water"/>
+   </MaterialFraction>   
+  </CompositeMaterial>
+  <CompositeMaterial name="Heavy Boron concrete" density="3.574*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.5203954">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.34702">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0080099">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0296094">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0684299">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.006620977">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.008010562">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.004774732">
+    <rMaterial name="materials:Titanium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.004804022">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.000555229">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.001653212">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.000118189">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>   
+  </CompositeMaterial>
+  <CompositeMaterial name="Air" density="1.214*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7494">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2369">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0129">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0008">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Al support" density="254*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Al-MMC" density="1.84*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Al-silicate plus Zi" density="3.3196*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.34196227">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11867705">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.43936068">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1">
+    <rMaterial name="materials:Zinc"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Al_2 O_3" density="3.91*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.52924272">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.47075728">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Aluminium 2219" density="2.84*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.9168">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.068">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.003">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0002">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.004">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.002">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.001">
+    <rMaterial name="materials:Titanium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015">
+    <rMaterial name="materials:Vanadium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.001">
+    <rMaterial name="materials:Zinc"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0025">
+    <rMaterial name="materials:Zirconium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Aluminium 2219 light" density="1.42*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.5">
+    <rMaterial name="materials:Aluminium 2219"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.5">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Aluminium 2219 very light" density="0.067558*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.065">
+    <rMaterial name="materials:Aluminium 2219"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.935">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Alumina" density="3.52*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.52924272">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.47075728">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Aluminium Pix_b" density="2.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Aluminium honeycomb" density="0.0511415*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.97670111">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017460186">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0055195064">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00030055565">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="1.863911e-05">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Aluminium silicate" density="3.156*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.37995808">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.13186339">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.48817853">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Aluminized Mylar" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.45014471">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.030220222">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.23984232">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.27979275">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ar 50pct plus CO_2 50pct" density="1.729*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.475815">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14306133">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.38112367">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ar 40pct plus Ethane 60pct " density="1.4692*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.46968659">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.42365618">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.10665723">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ar/Cu mixt. for Cors" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.032220584">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.93514796">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.018242877">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0021475706">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0056206649">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0048079473">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0010151454">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00079724857">
+    <rMaterial name="materials:Bromine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ar/Cu mixture for EM" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.30224783">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.4919464">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.17112881">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0020145463">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.012041684">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017214762">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.002658102">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00074786557">
+    <rMaterial name="materials:Bromine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ar/Cu mixture for HD" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.032220584">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.93514796">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.018242877">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0021475706">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0056206649">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0048079473">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0010151454">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00079724857">
+    <rMaterial name="materials:Bromine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ar/Pb mixture for EM" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.26749417">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.54605374">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.15145173">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0017829057">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.010657083">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.015235339">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0023524628">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.000661873">
+    <rMaterial name="materials:Bromine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0043106974">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="WCu" density="14.979*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.75">
+    <rMaterial name="materials:Tungsten"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ar/W Catcher section" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="9.6146597e-05">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.99990385">
+    <rMaterial name="materials:Tungsten"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ar/W Hadron section" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="9.6146597e-05">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.99990385">
+    <rMaterial name="materials:Tungsten"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ar/W mixt. for E.M." density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="9.6146597e-05">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.99990385">
+    <rMaterial name="materials:Tungsten"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Argon 50pct CF_4 CO_2" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.39336475">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11827135">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.29931485">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.18904904">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Argon CF_4 CO_2" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.22960113">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.16306585">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.29868266">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.30865037">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="BET2a concrete plus Poly" density="1.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.75468049">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.070780535">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0095602944">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.079376542">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.035227691">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.040083658">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0057520693">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00084050447">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0036982197">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="BET2b concrete plus Poly" density="1.35*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.86250534">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.080265403">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0031685162">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.026156529">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.011497209">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.013100008">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0017629095">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00028594245">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0012581468">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="B_2 O_3" density="2.34*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.057473742">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25288446">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.68964179">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ba O" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.89565575">
+    <rMaterial name="materials:Barium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.10434425">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Bakelite" density="1.3*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.074565894">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.77748634">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14794776">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Barite" density="3.2*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.003866475">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31286387">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0055278003">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0036870588">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.042359836">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017690768">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00036536456">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.49076686">
+    <rMaterial name="materials:Barium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11459208">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015333135">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0067465796">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Barium sulfate" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.5884092">
+    <rMaterial name="materials:Barium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.13739117">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.27419963">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Beryllia" density="2.63*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.36032657">
+    <rMaterial name="materials:Beryllium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.63967343">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Bi_4 Ge_3 O_12" density="7.1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.67102392">
+    <rMaterial name="materials:Bismuth"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1748602">
+    <rMaterial name="materials:Germanium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.15411587">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Borated Polyethyl." density="950*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.116">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.612">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.04">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.222">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Boron" density="2.34*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.18518519">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.81481481">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Boron-Barite" density="3.2*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0067292668">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.34051688">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.013925946">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0080541549">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.013576194">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.044652146">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0011660794">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00088239182">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="5.8572377e-05">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0023924499">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01052678">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.45198295">
+    <rMaterial name="materials:Barium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.10553619">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Boron_frits-Lumnite" density="3.1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.006189139">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33104107">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0054553968">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.016633648">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.029078398">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.020734192">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00052224672">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00060798896">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00045402481">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015404679">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0067780588">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.012029137">
+    <rMaterial name="materials:Titanium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.46123883">
+    <rMaterial name="materials:Barium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1076974">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C F_4" density="3.7037*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.13648398">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.86351602">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C O_2" density="1.8182*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.27292145">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.72707855">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C6F14" density="1.76*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.21318905">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.78681095">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="CF_4 CO_2 50:50" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.18196831">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.57564464">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.24238706">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="CO2Ar Freon" density="2.04*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.017209441">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25354028">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.030543441">
+    <rMaterial name="materials:Chlorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.016368527">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.68233831">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="CSC Electronics" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.00046948789">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00014841431">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="8.081657e-06">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="5.0118803e-07">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.32063924">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.39047805">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.28825623">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="CT Al cable" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.67273024">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31187538">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.015319366">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="7.5010078e-05">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="CT Cu cable" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.87214714">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12183881">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0059847409">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="2.9303816e-05">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C_New Air" density="1.205*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7494">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2369">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0129">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0008">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ca C O_3" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.40043563">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.47955758">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12000679">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ca O" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.71469586">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.28530414">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Cable_0" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.47272949">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.16266859">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.041785423">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.23271447">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="7.143868e-05">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.039129523">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.050901068">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Cable_MSGC_2" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.3625772">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12348903">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.036468221">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.30679798">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="3.0189302e-05">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.074162202">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.096475172">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Cable_MSGC_3" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.37934415">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12285748">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.035749337">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.29734771">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="2.9095785e-05">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.071569642">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.093102596">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Cable_Si_1" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.61618264">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.082694045">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.044364552">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2563757">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00037658981">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="6.4825308e-06">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Carbon fib.str." density="1.45*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.6470534">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.3529466">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Carbon fibre str." density="1.69*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.84491305">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.042542086">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11254487">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Carbon_fibre_str_Upgrade2" density="0.845*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.84491305">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.042542086">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11254487">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>  
+  <CompositeMaterial name="Carbon fibre st_b" density="1.69*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Carbon fibre str."/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Carbon_fibre_str_Upgrade" density="0.293*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Carbon fibre str."/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ce F_3" density="6.16*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.71085768">
+    <rMaterial name="materials:Cerium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.28914232">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ceramic" density="3.96525*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.52924272">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.47075728">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Coil average" density="5.10794*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.98933034">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.010669663">
+    <rMaterial name="materials:Helium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Colmanite Barite" density="3.2*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0033244208">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.32054568">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.019644903">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00631619">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.021681066">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.024762714">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00091831559">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0071874954">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00057930956">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="8.1400861e-05">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0019024847">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0083709328">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.47400649">
+    <rMaterial name="materials:Barium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1106786">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Connector" density="1.119*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.12175975">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.029972928">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.075860931">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.77184835">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00054859821">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="9.4434439e-06">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Coolant" density="1.52*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.012092387">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.063980691">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.24016253">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.68376439">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Thick_Copper" density="8.96*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Crack average" density="1.85*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.1922">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0242">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2836">
+    <rMaterial name="materials:Chlorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.5">
+    <rMaterial name="materials:Phosphor"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Cu/Quartz" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0081131524">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0092418886">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0011862487">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00011002641">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.98134868">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Cu/Sci spaghetti mix" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.012637483">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0017671321">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00040177288">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00010044322">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0022298395">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.98286333">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Cu/Scintillator/PolB" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.013621137">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0018577191">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.98179207">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00040133497">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00010033374">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0022274091">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="DTBX gas" density="1.695*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.049996061">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25927645">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.69072749">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Dead_Argon CF_4 CO_2" density="2.14154*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.22960113">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.16306585">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.29868266">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.30865037">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Doped Quartz" density="2.5*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.28638718">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.32623058">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.38738224">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Double-sided MSGC el" density="2.35*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.15487536">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0062815446">
+    <rMaterial name="materials:Tin"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.062222733">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.30743601">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12068891">
+    <rMaterial name="materials:Beryllium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.30724234">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.041253098">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Double-sided MSGCsub" density="2.207*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.20936607">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.36666251">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01999014">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.36881246">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.035168818">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Double-sided Si elec" density="2.392*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.25534309">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.013472574">
+    <rMaterial name="materials:Tin"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.058711815">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1751292">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.023514409">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.24970935">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.22411956">
+    <rMaterial name="materials:Beryllium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="DropsPolyethylene" density="450*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.85628451">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14371549">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="EAPD_Silicon" density="2.33*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Air" density="1.205*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7494">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2369">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0129">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0008">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Aluminium" density="2.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_CablPP1" density="1.6*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.51322876">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33317259">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12086275">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032735911">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_CablPP2" density="700*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.51322876">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33317259">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12086275">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032735911">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_CablPP3" density="400*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.51322876">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33317259">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12086275">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032735911">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_CablPP4" density="300*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.51322876">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33317259">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12086275">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032735911">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Cables" density="2.68*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.586">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.259">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.138">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="DD_E_Cables" density="5.36*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.586">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.259">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.138">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+   <CompositeMaterial name="E_Carbon Fibre" density="1.45*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.65">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.35">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Copper" density="8.96*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Epoxy" density="1.3*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.53539691">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.13179314">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33280996">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_G10" density="1.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.2198829">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.41718655">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.26819334">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.066018389">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.028718811">
+    <rMaterial name="materials:Chlorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Iron" density="7.87*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Lead" density="11.35*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_PbWO4" density="8.28*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.45532661">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.40403397">
+    <rMaterial name="materials:Tungsten"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14063942">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Polythene" density="950*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.85628451">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14371549">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Rohacell" density="71*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.84491305">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.042542086">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11254487">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Silicon" density="2.33*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Water" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.11190083">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.88809917">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ec_Cable_1" density="2.12*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.51322876">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33317259">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12086275">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032735911">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="EE_Aveolar" density="0.94*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.65">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.35">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Epoxy" density="1.3*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.53539691">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.13179314">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33280996">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ethane" density="1.356*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.79887887">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.20112113">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Fe_2 O_3" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.69944958">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.30055042">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Fibre_connector" density="1.05917*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.33154227">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.38182349">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.064261825">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.16677931">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.052722204">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0028709009">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Flushing gas" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0010671918">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00033736021">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="1.8370396e-05">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="1.1392493e-06">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.99857594">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Foam" density="100*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.85628451">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14371549">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Freon-12" density="4.93*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.099340816">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.58640112">
+    <rMaterial name="materials:Chlorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31425807">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="FrontEnd Electronics" density="1.03441*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.00065963049">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0002085221">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="1.1354728e-05">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="7.0416919e-07">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.45049813">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.54862165">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="G10" density="1.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.13232243">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032572448">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.48316123">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.35194389">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="G_conntr" density="2.007*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.36065118">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.38351407">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.051494019">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.20434074">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Gas" density="1.9573*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.49078595">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.50287777">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0063362788">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Glass" density="2.23*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.36611059">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.53173295">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.007820091">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0344084">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.059927964">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Graph.Epoxy Sup." density="138.3*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.80947966">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.073636829">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11688351">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Graphite Epoxy suprt" density="1.383*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.80947966">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.073636829">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11688351">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="HFE" density="1.52*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.012092387">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.063980691">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.24016253">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.68376439">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="HV Light Guides" density="1.32*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.46726616">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.53238309">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00034445206">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="5.9293189e-06">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="3.677097e-07">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="H_Air" density="1.205*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7494">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2369">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0129">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0008">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="H_Aluminium" density="2.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="H_Brass" density="8.53*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.3">
+    <rMaterial name="materials:Zinc"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="H_Iron" density="7.87*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="H_Polystyrene" density="1.032*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.91512109">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.084878906">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="H_Scintillator" density="1.032*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.91512109">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.084878906">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Hcal average" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.98854345">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="2.2305277e-06">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="7.0511343e-07">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="3.8395793e-08">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00034716943">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.011106403">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Hcal sci" density="1.032*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.92257895">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.07742105">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Hexel for CSC" density="165*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0002303291">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.046295939">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.35049864">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.47901437">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11791403">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0060466926">
+    <rMaterial name="materials:Chlorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="High Tension cables" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.45726783">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.44778783">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.070543148">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.024401185">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Honeycomb" density="280*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Hybrids" density="1.785*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.6459597">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.21237145">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.028514885">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11315397">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="ICB" density="2.309*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.26383847">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.097410682">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.023978583">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.35568471">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25908755">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Insulation" density="1.69*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.008091404">
+    <rMaterial name="materials:Helium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.043705226">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0029341267">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.023286651">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.10908214">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.81290046">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Isobutane" density="2.67*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.82658619">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.17341381">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="K_2 O" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.83015022">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.16984978">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Kapton" density="1.11*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.59985105">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.080541353">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31960759">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Kr/Cu mixture for HD" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.054145746">
+    <rMaterial name="materials:Krypton"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017829582">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0020989171">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0054933281">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0046990226">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00099214713">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0007791868">
+    <rMaterial name="materials:Bromine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.91396207">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Kr/Pb mixture for EM" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.38570939">
+    <rMaterial name="materials:Krypton"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.45792903">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12700974">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.001495172">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0089371927">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.012776589">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0019728114">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00055505683">
+    <rMaterial name="materials:Bromine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0036150168">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Kr/Pb mixture for HD" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.043537564">
+    <rMaterial name="materials:Krypton"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.93041049">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.014336428">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0016876993">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0044170805">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0037783947">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00079776662">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00062652927">
+    <rMaterial name="materials:Bromine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00040805081">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="LeadBPolymer" density="3.53*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.023">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0037037037">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.016296296">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.114">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.102">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.088">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.022">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.013">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.618">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="LeadLoadedPolymerCon" density="3.53*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.023512713">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.041643122">
+    <rMaterial name="materials:Lithium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11416406">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.10198306">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.087818747">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01869691">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0028328615">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.013031207">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.59631732">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Limonite" density="2.96*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0097839501">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.36018046">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.012566469">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.008172324">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.57297034">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.035392035">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00093441511">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Limonite Iron" density="4.16*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0077950891">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25025334">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.035888928">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.020743458">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.61983399">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.062339683">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0020806726">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0010648449">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Limonite magetite" density="3.41*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0046317534">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33176807">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.010582504">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.006612936">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.61641603">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.029106142">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00088255997">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Liquid Ar Detector" density="1.39*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Liquid Argon" density="1.39*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Liquid Kr Detector" density="2.39*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Krypton"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Liquid Krypton" density="2.39*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Krypton"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Lithium Polyethyl." density="950*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.113">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.596">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.075">
+    <rMaterial name="materials:Lithium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.216">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Boron Polyethyl." density="1.02*g/cm3 " symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.81347018">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1365297">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0092592584">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.040740732">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Boron PolyethylHD" density="1.40*g/cm3 " symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.81347018">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1365297">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0092592584">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.040740732">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="AntiLead" density="11.16*g/cm3 " symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.96">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.04">
+    <rMaterial name="materials:Antimony"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Low Tension cables" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.98029046">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.016876977">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0028325668">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Lucite" density="1.16*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.59985105">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.080541353">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31960759">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="ME_free_space" density="0.254467*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.003218">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.157312">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="5.5388547e-05">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.020068">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.249899">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.013999">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.555499">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="MSGC cooling pipe" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.30132877">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.053356059">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.42345953">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.22185565">
+    <rMaterial name="materials:Beryllium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="MSGC-Average" density="7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0016109746">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11608918">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.87746662">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.004833228">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="MS_Al_cable" density="1.95062*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.69471035">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2614148">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.043874854">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="MS_Cu_cable" density="9.4537*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.91351941">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.074051989">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.012428601">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="MS_cntr" density="2.049*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.27792206">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.36612478">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.21351888">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.028668949">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11376533">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_Aluminium" density="2.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_Argon 50pct CF_4 CO_2" density="2.1057*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.39336475">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11827135">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.29931485">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.18904904">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_Argon CF_4 CO_2" density="2.1416*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.22960113">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.16306585">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.29868266">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.30865037">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_B_Air" density="1.205*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7494">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2369">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0129">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0008">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_Cables" density="2.68*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.586">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.259">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.138">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="NEMA G10 plate" density="1.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.2198829">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.41718655">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.26819334">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.066018389">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.028718811">
+    <rMaterial name="materials:Chlorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_Copper" density="8.96*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_Thick_Steel-008" density="7.8*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.00089992039">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015987127">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0042943177">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00017903506">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00012830888">
+    <rMaterial name="materials:Phosphor"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="9.5139401e-05">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00029757275">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00069973892">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.99180725">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_DTBX Gas" density="1.695*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.049996061">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25927645">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.69072749">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_Electronics averag" density="1.3*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.074565894">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.77748634">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14794776">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_F_Air" density="1.205*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7494">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2369">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0129">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0008">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_NEMA FR4 plate" density="1.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.18077359">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.4056325">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.27804208">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.068442752">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.067109079">
+    <rMaterial name="materials:Bromine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_RPC_Bakelite" density="1.3*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.074565894">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.77748634">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14794776">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_RPC_Gas" density="1.87685*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.017572792">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2588934">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.031188319">
+    <rMaterial name="materials:Chlorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.016714124">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.67563137">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_Steel-008" density="7.8*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.00089992039">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015987127">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0042943177">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00017903506">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00012830888">
+    <rMaterial name="materials:Phosphor"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="9.5139401e-05">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00029757275">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00069973892">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.99180725">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_YokeSteel" density="7.87*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.001">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.001">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.004">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.9825">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_honeycomb" density=" 0.0511415*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.97670111">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017460186">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0055195064">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00030055565">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="1.863911e-05">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Cables" density="2.68*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.586">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.259">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.138">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Magetite" density="3.12*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0068217712">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.34582528">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.011586696">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0079728988">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.59461377">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032281783">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00089780071">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Magnet Conductor" density="3.157*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.097336411">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.014292995">
+    <rMaterial name="materials:Niobium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017134031">
+    <rMaterial name="materials:Titanium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0054482651">
+    <rMaterial name="materials:Helium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.75894659">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.10684171">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="MagnetiteBoron" density="3.637*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.007">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0026">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0104">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.35">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.013">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.02">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.02">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.027">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.55">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="MagnetiteConc" density="3.65*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0035">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0026">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0104">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.3512">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0131">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0201">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0201">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0271">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.5519">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Thick_MagnetiteConc" density="3.65*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0035">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0026">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0104">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.3512">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0131">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0201">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0201">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0271">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.5519">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Marble" density="2.35*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.46021905">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.53804265">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0017382968">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Methane" density="0.717*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.74868663">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25131337">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Mg O" density="3.58*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.60304188">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.39695812">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Mg-MMC" density="1.52*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Mn O" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.77446185">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.22553815">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Muon Al" density="2.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Muon average" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0012744281">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.001149531">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0002893993">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.99728664">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Mylar" density="1.39*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.62502108">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.041960452">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33301847">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="NEMA FR4 plate" density="1.025*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.18077359">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.4056325">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.27804208">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.068442752">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.067109079">
+    <rMaterial name="materials:Bromine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_NEMA G10 plate" density="1.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.2198829">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.41718655">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.26819334">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.066018389">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.028718811">
+    <rMaterial name="materials:Chlorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Na_2 O" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.74186418">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25813582">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ne30_DME70" density="1.7*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.15805943">
+    <rMaterial name="materials:Neon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.43902091">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.29239429">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11052537">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ni_2 O_3" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.70978275">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.29021725">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Nomex" density="32*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.027815941">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31653768">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00047881724">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.077581544">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.57758601">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Nomex for CSC" density="28.9*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.59985105">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.080541353">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31960759">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Noryl" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.85628451">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14371549">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="O_Hybrid" density="2.838*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.17862818">
+    <rMaterial name="materials:Silver"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0038859926">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.012801535">
+    <rMaterial name="materials:Tin"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11166264">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.13680825">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.096505544">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.238333">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.027828501">
+    <rMaterial name="materials:Zinc"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.17363266">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.019913693">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Optical fibre" density="1.05*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.91512109">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.084878906">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Outer_pipes" density="2.533*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.49604605">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.006094006">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032243322">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12103086">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.34458577">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="P_pipes" density="2.3285*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.32927494">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0007222183">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0019399576">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="8.087907e-05">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="5.7963526e-05">
+    <rMaterial name="materials:Phosphor"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="4.2979215e-05">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00013442846">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00031610699">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.44804883">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.044156804">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.17522489">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Pb W O_4" density="8.28*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.45532661">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.40403397">
+    <rMaterial name="materials:Tungsten"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14063942">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Pb/Sci spaghetti mix" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.018845478">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0017479474">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.97940657">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Peek" density="1.32*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.53539691">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.13179314">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33280996">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="PhotoCathode" density="1.87*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Cesium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Pigtails" density="3.145*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.65753522">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.20542786">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.027582577">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.10945434">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Pipe with Water" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.092022289">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.082576264">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.29261257">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.53278887">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Pipe with gas" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.18514234">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.13149061">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.24084727">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.24888489">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1936349">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Plexiglas" density="1.18*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.080541353">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.59985105">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31960759">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Polycarbonate" density="7*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.59985105">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.080541353">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31960759">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Polyethylene" density="950*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.85628451">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14371549">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="DD_Polyethylene" density="2*950*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.85628451">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14371549">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Polymer Concrete" density="450*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.23789097">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.43443755">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.26294502">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.064726463">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Polystyrene" density="1.032*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.91512109">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.084878906">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Polyvinylchloride" density="1.38*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.38437771">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.048384356">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.56723794">
+    <rMaterial name="materials:Chlorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Px_cool_pipe" density="2.72629*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.54838378">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0054611179">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.028894718">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1084613">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.30879909">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Quartz" density="2.64*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.46748103">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.53251897">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Quartz support" density="2.64*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.46748103">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.53251897">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="QuartzBundle" density="1.30515*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.41130114">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.46868914">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.056403482">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0052320714">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.057839878">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00052523876">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="9.0413398e-06">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="QuartzFibers" density="2.64*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.46748103">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.53251897">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="RPC Gas" density="1.87685*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.017572792">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2588934">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.031188319">
+    <rMaterial name="materials:Chlorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.016714124">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.67563137">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Rohacell" density="0.052*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.60">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.08">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.32">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="SITRA-Average" density="7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="SMD_metal" density="10.2*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.045444306">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.80484958">
+    <rMaterial name="materials:Silver"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14970612">
+    <rMaterial name="materials:Tin"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="S_2 O_3" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.57194838">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.42805162">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Scintillator" density="1.032*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.91512109">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.084878906">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Serpentine - Iron" density="3.765*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0089840293">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31549151">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11229814">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017986016">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0023751734">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.40725359">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.049064913">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.085014416">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015322121">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Serpentine 2" density="2.01*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.017056138">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.52511018">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.22286408">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.028434767">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.055055747">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.048338182">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.095947828">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0010639801">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0042627075">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0018663973">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Si O_2" density="2.64*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.46748103">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.53251897">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Si cooling pipe" density="1.921*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.56814774">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.19928206">
+    <rMaterial name="materials:Beryllium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.026024798">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2065454">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Silica" density="2.2*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.46748103">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.53251897">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Silicon Detector" density="2.33*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Siliecal" density="1.0859*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.87264263">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12735737">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Single-sided MSGC el" density="2.44*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.30413689">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0014717137">
+    <rMaterial name="materials:Tin"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.058467105">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.36931633">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.15011919">
+    <rMaterial name="materials:Beryllium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.10269944">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.013789342">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Single-sided MSGCsub" density="2.3258*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.33240081">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.43382861">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017726182">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.19998078">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.016063621">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Single-sided Si elec" density="2.392*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.31484492">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.014476209">
+    <rMaterial name="materials:Tin"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.050561611">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.114528">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.015377551">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2652606">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.22495111">
+    <rMaterial name="materials:Beryllium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="StainlessSteel" density="8.02*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.6996">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0004">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.19">
+    <rMaterial name="materials:Chromium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Stand.Concrete" density="2.35*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.006">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.03">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.5">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.03">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.014">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Thick_Stand.Concrete" density="2.35*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.006">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.03">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.5">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.03">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.014">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Standard Serpentine" density="2.302*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0096577278">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.52863475">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.32556232">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.054746312">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.022623255">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.028372381">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0012881659">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00095487516">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01557902">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.012581187">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Steel-008" density="7.8*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.00089992039">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015987127">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0042943177">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00017903506">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00012830888">
+    <rMaterial name="materials:Phosphor"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="9.5139401e-05">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00029757275">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00069973892">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.99180725">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Steel-light" density="520*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.6996">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0004">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.19">
+    <rMaterial name="materials:Chromium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Super Conductor" density="4.94*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.81579799">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.077846795">
+    <rMaterial name="materials:Niobium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.096238669">
+    <rMaterial name="materials:Titanium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.010116543">
+    <rMaterial name="materials:Helium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Brass" density="8.5*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.63">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.37">
+    <rMaterial name="materials:Zinc"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="BGA" density="8.82*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.62">
+    <rMaterial name="materials:Tin"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.36">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.02">
+    <rMaterial name="materials:Silver"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Air" density="1.214*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7494">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2369">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0129">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0008">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Argon CF_4 CO_2" density="2.1416*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.22960113">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.16306585">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.29868266">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.30865037">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Bronze" density="8.89*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.94059406">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.059405941">
+    <rMaterial name="materials:Tin"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Carbon fibre str." density="1.69*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.84491305">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.042542086">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11254487">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Foam" density="100*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.85628451">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14371549">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_MSGC-Average" density="230*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.8">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_OPC" density="1.05917*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.33154227">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.38182349">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.064261825">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.16677931">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.052722204">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0028709009">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_OP_cable" density="601.463*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0086851733">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.10083068">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.51167977">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.086185453">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.28766708">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0049518353">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Teflon" density="2.2*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.24018637">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.75981363">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ti_2 O_3" density="4.6*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.66612408">
+    <rMaterial name="materials:Titanium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33387592">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Tk_Cable_1" density="942.8*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.4364364">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.19550706">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.031331664">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.060965631">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.043156039">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.041667015">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.15813109">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032805106">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Tk_square_bundles" density="971*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.45591441">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.20422984">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032729696">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.063679098">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.045081214">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.043521896">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12057473">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.03426911">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Tk_support" density="5.25617*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="V_Air" density="1.205*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7494">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2369">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0129">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0008">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="V_Iron" density="7.87*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="V_Quartz" density="2.64*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.46748103">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.53251897">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Vcal C4H10" density="2.67*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.82658619">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.17341381">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Vcal CO2" density="1.98*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.27292145">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.72707855">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Vcal average" density="7.55*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0012701968">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015979957">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0042923919">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00017895477">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00012825134">
+    <rMaterial name="materials:Phosphor"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="9.5096736e-05">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0002974393">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00069942512">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.99136248">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="7.7766882e-05">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="W/Sci spaghetti mix" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0059212984">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00082799058">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00018825087">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="4.7062717e-05">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0010447923">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.99197061">
+    <rMaterial name="materials:Tungsten"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Wood" density="500*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.11684213">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.88315787">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="YokeSteel" density="7.87*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.001">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.001">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.004">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.9825">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="active_screen" density="11.197*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.025418913">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.085235146">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.50483588">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.38451007">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="c_Peek" density="1.8*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.45427914">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11182521">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.36306779">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.070827858">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="HV_Cu/QFib_mx." density="7.30515*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0247913">
+    <rMaterial name="materials:QuartzFibers"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00471238  ">
+    <rMaterial name="materials:Polystyrene"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.04296 ">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.927536">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Borosilicate_Glass" density="2.51*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.303594">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0452533">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0556199">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0449903">
+    <rMaterial name="materials:Zinc"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0222285">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0245335">
+    <rMaterial name="materials:Boron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0239803">
+    <rMaterial name="materials:Titanium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00459437">
+    <rMaterial name="materials:Antimony"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00001">
+    <rMaterial name="materials:Chromium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.475195">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Silicone_Gel" density="0.965*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.3866">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0973">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.3616">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1545">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Barium_Titanate" density="6.02*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.5889">
+    <rMaterial name="materials:Barium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2053">
+    <rMaterial name="materials:Titanium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2058">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_PolyGrains" density="589*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.85628451">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14371549">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="CuNi" density="8.94*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.3">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Acrylate" density="1170*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.55814">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.06977">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.37209">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Inconel600" density="8.47*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7200">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0285">
+    <rMaterial name="materials:Cobalt"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1500">
+    <rMaterial name="materials:Chromium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0800">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0100">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0050">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0050">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Kevlar" density="1.44*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.71180785">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11852895">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12699531">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.04266788">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <!-- Tracker Cooling Fluids INIT -->
+  <!-- 3M type is the old one used for Thermal Screen only -->
+  <CompositeMaterial name="C6F14_3M_-15C" density="1.80340*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:C6F14"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <!-- F2 type is the new one used for subdetectors and preshower -->
+  <CompositeMaterial name="C6F14_F2_-30C" density="1.87917*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:C6F14"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C6F14_F2_-20C" density="1.84675*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:C6F14"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C6F14_F2_-10C" density="1.82033*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:C6F14"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="CO2_Upgrade" density="0.2033*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Vcal CO2"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <!-- Tracker Cooling Fluids END -->
+  <!-- CASTOR materials -->
+  <CompositeMaterial name="Castor_QuartzFibers/Air_mx" density="2.1743080*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.9999233027749">
+    <rMaterial name="materials:QuartzFibers"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0000766972251">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Castor_Bundle6_QF/Air_mx" density="0.4808336*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.99800842127">
+    <rMaterial name="materials:QuartzFibers"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00199157873">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Castor_Bundle5_QF/Air_mx" density="0.5726188*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.99841066074">
+    <rMaterial name="materials:QuartzFibers"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00158933926">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Castor_Bundle4_QF/Air_mx" density="0.7092276*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.99881654262">
+    <rMaterial name="materials:QuartzFibers"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00118345738">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Castor_Bundle3_QF/Air_mx" density="1.1048788*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.99942577695">
+    <rMaterial name="materials:QuartzFibers"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00057422305">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Castor_Bundle2_QF/Air_mx" density="1.5612536*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.99974500842">
+    <rMaterial name="materials:QuartzFibers"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00025499158">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Castor_Bundle1_QF/Air_mx" density="2.2522530*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.99998212349">
+    <rMaterial name="materials:QuartzFibers"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00001787651">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Castor_LMixer_QF/Air_mx" density="2.2834241*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.99998943692">
+    <rMaterial name="materials:QuartzFibers"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00001056308">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Castor_Electronics averag" density="1.4881*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.000560">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.999440">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Castor_Paper" density="1.55*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.448">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.056">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.496">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Castor_Coolant" density="1.52*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.012092387">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.063980691">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.24016253">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.68376439">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="AlBeMet" density="2.071*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.380">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.615">
+    <rMaterial name="materials:Beryllium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0005">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0045">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_Rdout_Brd" density="1.79*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.98667">
+    <rMaterial name="materials:G10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01333">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_Kapton_Cu" density="1.24*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.9836">
+    <rMaterial name="materials:Kapton"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0164">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_GEM_Gas" density="1.8*mg/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.60">
+    <rMaterial name="materials:Argon"/>
+    </MaterialFraction>
+   <MaterialFraction fraction="0.083">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.145">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.172">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_GEM_Foil" density="1.74*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.6565">
+    <rMaterial name="materials:Kapton"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1013">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2422">
+    <rMaterial name="materials:M_GEM_Gas"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Diamond" density="3.52*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>   
+  <!--Materials added for BHM-->
+    <CompositeMaterial name="BorosilicateGlass" density="2.23*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.377220">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.028191">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.003321">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.539562">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.011644">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.040064">
+    <rMaterial name="materials:Boron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Bialkali" density="4.28*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.133">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.452">
+    <rMaterial name="materials:Cesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.415">
+    <rMaterial name="materials:Antimony"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="RTV" density="1.02*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0811">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.3790">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.3241">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2158">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="LYSO" density="7.11*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7145">
+    <rMaterial name="materials:Lutetium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0403">
+    <rMaterial name="materials:Yttrium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0637">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1815">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+ </MaterialSection>
+</DDDefinition>

--- a/Geometry/TrackerCommonData/data/PhaseI/v3/pixbarmaterial.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/v3/pixbarmaterial.xml
@@ -1,0 +1,826 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../../../DetectorDescription/Schema/DDLSchema.xsd">
+
+<MaterialSection label="pixbarmaterial.xml">
+    <CompositeMaterial name="CFK" density="1.575*g/cm3" symbol=" " method="mixture by weight">
+      <MaterialFraction fraction="1.00000000">
+        <rMaterial name="materials:Carbon"/>
+      </MaterialFraction>
+    </CompositeMaterial>
+
+    <CompositeMaterial name="Bpix_Pipe_Steel" density="8.02*g/cm3" symbol=" " method="mixture by weight">
+      <MaterialFraction fraction="0.0005">
+        <rMaterial name="materials:Carbon"/>
+      </MaterialFraction>
+      <MaterialFraction fraction="0.18">
+        <rMaterial name="materials:Chromium"/>
+      </MaterialFraction>
+      <MaterialFraction fraction="0.1">
+        <rMaterial name="materials:Nickel"/>
+      </MaterialFraction>
+      <MaterialFraction fraction="0.7195">
+        <rMaterial name="materials:Iron"/>
+      </MaterialFraction>
+    </CompositeMaterial>
+
+    <CompositeMaterial name="Bpix_CO2_-20C" density="1.0327*g/cm3" symbol=" " method="mixture by weight">
+      <MaterialFraction fraction="0.27292145">
+        <rMaterial name="materials:Carbon"/>
+      </MaterialFraction>
+      <MaterialFraction fraction="0.72707855">
+        <rMaterial name="materials:Oxygen"/>
+      </MaterialFraction>
+    </CompositeMaterial>  
+
+  <CompositeMaterial name="Polyurethane" density="0.0494*g/cm3" symbol=" " method="mixture by weight">   <!-- Airex -->
+     <MaterialFraction fraction="0.09">
+      <rMaterial name="materials:Nitrogen"/>
+     </MaterialFraction>
+     <MaterialFraction fraction="0.6559">
+      <rMaterial name="materials:Carbon"/>
+     </MaterialFraction>
+     <MaterialFraction fraction="0.0486">
+       <rMaterial name="materials:Hydrogen"/>
+     </MaterialFraction>
+    <MaterialFraction fraction="0.2056">
+       <rMaterial name="materials:Oxygen"/>
+     </MaterialFraction>
+   </CompositeMaterial>
+
+  <CompositeMaterial name="SupplyTubeEpoxy" density="1.05*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.5999">
+      <rMaterial name="materials:Carbon"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.0719">
+      <rMaterial name="materials:Hydrogen"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.2283">
+      <rMaterial name="materials:Oxygen"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.0999">
+      <rMaterial name="materials:Nitrogen"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+<!--  Upgrade-->
+    <CompositeMaterial name="SupplyTubeConn3_Upgrade" density="0.4868*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.560">
+      <rMaterial name="trackermaterial:micro_twisted_boundle"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.440">
+      <rMaterial name="pixbarmaterial:CFK"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+<!-- New materials -->
+  <CompositeMaterial name="SupplyTubeConn3" density="0.3556*g/cm3" symbol=" " method="mixture by weight">   <!--Supply tube material in Conn3 volume (no fpix contribution and 150/180 deg sectors)-->
+     <MaterialFraction fraction="0.027795">
+      <rMaterial name="pixbarmaterial:Bpix_Pipe_Steel"/>
+     </MaterialFraction>
+     <MaterialFraction fraction="0.015259">
+      <rMaterial name="pixbarmaterial:Bpix_CO2_-20C"/>
+     </MaterialFraction>
+     <MaterialFraction fraction="0.0944924">
+      <rMaterial name="pixbarmaterial:Polyurethane"/>
+     </MaterialFraction>
+	 <MaterialFraction fraction="0.256154">
+      <rMaterial name="pixbarmaterial:CFK"/>
+    </MaterialFraction>
+	 <MaterialFraction fraction="0.113846">
+      <rMaterial name="pixbarmaterial:SupplyTubeEpoxy"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.335428">
+      <rMaterial name="trackermaterial:T_Aluminium"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.085225">
+      <rMaterial name="trackermaterial:T_Copper"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.071801">
+      <rMaterial name="trackermaterial:T_Kapton"/>
+    </MaterialFraction>
+   </CompositeMaterial>
+   
+  <CompositeMaterial name="SupplyTubeConn3_3Disks" density="0.4646*g/cm3" symbol=" " method="mixture by weight"> <!-- fpix 3 disks service material added -->
+    <MaterialFraction fraction="1.00000000">
+      <rMaterial name="SupplyTubeConn3"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="SupplyTubeConn3_10Disks" density="0.7908*g/cm3" symbol=" " method="mixture by weight"> <!-- fpix 10 disks service material added -->
+    <MaterialFraction fraction="1.00000000">
+      <rMaterial name="SupplyTubeConn3"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="CoolPipesDaisyChain" density="6.00*g/cm3" symbol=" " method="mixture by weight">   <!-- Intralayer daisy chain pipes r_i=1.8mm R_o=2.0mm-->
+     <MaterialFraction fraction="0.6458">
+      <rMaterial name="pixbarmaterial:Bpix_Pipe_Steel"/>
+     </MaterialFraction>
+     <MaterialFraction fraction="0.3542">
+      <rMaterial name="pixbarmaterial:Bpix_CO2_-20C"/>
+     </MaterialFraction>
+   </CompositeMaterial>
+   
+  <CompositeMaterial name="Flange1_Airex" density="0.02697*g/cm3" symbol=" " method="mixture by weight">   <!-- Airex 0.546 empty factor-->
+     <MaterialFraction fraction="1.00">
+      <rMaterial name="pixbarmaterial:Polyurethane"/>
+     </MaterialFraction>
+   </CompositeMaterial>
+  <CompositeMaterial name="Flange2_Airex" density="0.02697*g/cm3" symbol=" " method="mixture by weight">   <!-- Airex 0.546 empty factor-->
+     <MaterialFraction fraction="1.00">
+      <rMaterial name="pixbarmaterial:Polyurethane"/>
+     </MaterialFraction>
+   </CompositeMaterial>
+  <CompositeMaterial name="Flange3_Airex" density="0.02697*g/cm3" symbol=" " method="mixture by weight">   <!-- Airex 0.546 empty factor-->
+     <MaterialFraction fraction="1.00">
+      <rMaterial name="pixbarmaterial:Polyurethane"/>
+     </MaterialFraction>
+   </CompositeMaterial>
+  <CompositeMaterial name="Flange4_InnerCFK" density="1.000*g/cm3" symbol=" " method="mixture by weight">   <!-- Airex 1.0 empty factor-->
+     <MaterialFraction fraction="1.00">
+      <rMaterial name="pixbarmaterial:CFK"/>
+     </MaterialFraction>
+   </CompositeMaterial>
+
+  <CompositeMaterial name="Flange1_CFK" density="0.86*g/cm3" symbol=" " method="mixture by weight"> <!--CFK 0.546 empty factor-->
+    <MaterialFraction fraction="1.00000000">
+      <rMaterial name="pixbarmaterial:CFK"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Flange2_CFK" density="0.86*g/cm3" symbol=" " method="mixture by weight"> <!--CFK 0.546 empty factor-->
+    <MaterialFraction fraction="1.00000000">
+      <rMaterial name="pixbarmaterial:CFK"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Flange3_CFK" density="0.86*g/cm3" symbol=" " method="mixture by weight"> <!--CFK 0.546 empty factor-->
+    <MaterialFraction fraction="1.00000000">
+      <rMaterial name="pixbarmaterial:CFK"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Flange4_CFK" density="1.575*g/cm3" symbol=" " method="mixture by weight"> <!--CFK 1 empty factor-->
+    <MaterialFraction fraction="1.00000000">
+      <rMaterial name="pixbarmaterial:CFK"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+  
+  <CompositeMaterial name="Polyoxymethylene" density="1.4*g/cm3" symbol=" " method="mixture by weight">
+     <MaterialFraction fraction="0.4">
+      <rMaterial name="materials:Carbon"/>
+     </MaterialFraction>
+     <MaterialFraction fraction="0.06667">
+       <rMaterial name="materials:Hydrogen"/>
+     </MaterialFraction>
+    <MaterialFraction fraction="0.5333">
+       <rMaterial name="materials:Oxygen"/>
+     </MaterialFraction>
+   </CompositeMaterial>
+
+  <CompositeMaterial name="BPix_Silicone" density="1.3*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.3787448">
+      <rMaterial name="materials:Silicon"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.21575329">
+      <rMaterial name="materials:Oxygen"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.3239468">
+      <rMaterial name="materials:Carbon"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.08155498">
+      <rMaterial name="materials:Hydrogen"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+   <CompositeMaterial name="LCP_Glass_Enforced" density="2.0*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.08">
+          <rMaterial name="materials:Silicon"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.52">
+          <rMaterial name="materials:Carbon"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.39">
+          <rMaterial name="materials:Oxygen"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.01">
+          <rMaterial name="materials:Hydrogen"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+
+   <CompositeMaterial name="Silicon_Nitride" density="3.4*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.6006">
+          <rMaterial name="materials:Silicon"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.3994">
+          <rMaterial name="materials:Nitrogen"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+
+  <CompositeMaterial name="Pix_Bar_Baseplate_Full" density="3.67256*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.75244">
+      <rMaterial name="pixbarmaterial:Silicon_Nitride"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.15186">
+      <rMaterial name="materials:Steel-008"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.04271">
+      <rMaterial name="trackermaterial:T_Silicone_Gel"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.05299">
+      <rMaterial name="materials:Epoxy"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="Pix_Bar_Baseplate_Full_Upgrade" density="0.367256*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.75244">
+      <rMaterial name="pixbarmaterial:Silicon_Nitride"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.15186">
+      <rMaterial name="materials:Steel-008"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.04271">
+      <rMaterial name="trackermaterial:T_Silicone_Gel"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.05299">
+      <rMaterial name="materials:Epoxy"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="Pix_Bar_Baseplate_Half" density="3.18369*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.86861">
+      <rMaterial name="pixbarmaterial:Silicon_Nitride"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.06085">
+      <rMaterial name="materials:Steel-008"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.04931">
+      <rMaterial name="trackermaterial:T_Silicone_Gel"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.02123">
+      <rMaterial name="materials:Epoxy"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="Pix_Bar_Hybrid_Full" density="4.41590*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.0063">
+      <rMaterial name="materials:Indium"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.09358">
+      <rMaterial name="materials:Lead"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.05034">
+      <rMaterial name="materials:Nickel"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.3217">
+      <rMaterial name="trackermaterial:T_Kapton"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.02405">
+      <rMaterial name="materials:Gold"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.04379">
+      <rMaterial name="materials:Epoxy"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.1596">
+      <rMaterial name="materials:Tin"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.23875">
+      <rMaterial name="trackermaterial:T_Copper"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.00379">
+      <rMaterial name="trackermaterial:T_Aluminium"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.00741">
+      <rMaterial name="materials:Alumina"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.0507">
+      <rMaterial name="trackermaterial:T_Barium_Titanate"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="Pix_Bar_Hybrid_Half" density="5.70663*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.00443">
+      <rMaterial name="materials:Indium"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.1322">
+      <rMaterial name="materials:Lead"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.03912">
+      <rMaterial name="materials:Nickel"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.24865">
+      <rMaterial name="trackermaterial:T_Kapton"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.0185">
+      <rMaterial name="materials:Gold"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.06187">
+      <rMaterial name="materials:Epoxy"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.22547">
+      <rMaterial name="materials:Tin"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.00267">
+      <rMaterial name="trackermaterial:T_Aluminium"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.185">
+      <rMaterial name="trackermaterial:T_Copper"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.01047">
+      <rMaterial name="materials:Alumina"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.07162">
+      <rMaterial name="trackermaterial:T_Barium_Titanate"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="Pix_Bar_Capacitor" density="2.22277*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="1">
+      <rMaterial name="trackermaterial:T_Barium_Titanate"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="T_Pix_Bar_Cool" density="1.95447*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.61432">
+      <rMaterial name="materials:C6F14_F2_-10C"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.38568">
+      <rMaterial name="trackermaterial:T_Aluminium"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+  
+  <CompositeMaterial name="Bpix_CO2_-20C_Half" density="2.0654*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="1.00000000">
+      <rMaterial name="pixbarmaterial:Bpix_CO2_-20C"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+  
+  <CompositeMaterial name="Bpix_Pipe_Steel_Half" density="16.04*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="1.00000000">
+      <rMaterial name="pixbarmaterial:Bpix_Pipe_Steel"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="Pix_Bar_Cable" density="1.67629*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.43796">
+      <rMaterial name="trackermaterial:T_Kapton"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.02339">
+      <rMaterial name="materials:Gold"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.19088">
+      <rMaterial name="trackermaterial:T_Aluminium"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.34777">
+      <rMaterial name="trackermaterial:T_Copper"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="Pix_Bar_Cable_Upgrade" density="0.55876*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="1.00000000">
+      <rMaterial name="Pix_Bar_Cable"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+    <CompositeMaterial name="Pix_Bar_CableSignal_Upgrade" density="0.925*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.249079">
+      <rMaterial name="trackermaterial:T_Kapton"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.476682">
+      <rMaterial name="trackermaterial:T_Aluminium"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.274239">
+      <rMaterial name="trackermaterial:T_Copper"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+     <CompositeMaterial name="Pix_Bar_CablePower_Upgrade" density="0.925*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.110505">
+      <rMaterial name="trackermaterial:T_Kapton"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.751012">
+      <rMaterial name="trackermaterial:T_Aluminium"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.138483">
+      <rMaterial name="trackermaterial:T_Copper"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="Pix_Bar_Cable_Layer1_Upgrade" density="5.72*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.46">
+      <rMaterial name="trackermaterial:T_Aluminium"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.54">
+      <rMaterial name="trackermaterial:T_Copper"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+  
+  <CompositeMaterial name="Pix_Bar_Cable_Layer234_Upgrade" density="4.31*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.46">
+      <rMaterial name="trackermaterial:T_Aluminium"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.54">
+      <rMaterial name="trackermaterial:T_Copper"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+  
+  <CompositeMaterial name="CFK_Layer1" density="1.575*1.196*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="1.000">
+      <rMaterial name="pixbarmaterial:CFK"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+  
+  <CompositeMaterial name="CFK_Layer2" density="1.575*1.108*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="1.000">
+      <rMaterial name="pixbarmaterial:CFK"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+  
+  <CompositeMaterial name="CFK_Layer3" density="1.575*1.122*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="1.000">
+      <rMaterial name="pixbarmaterial:CFK"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+  
+  <CompositeMaterial name="CFK_Layer4" density="1.575*1.234*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="1.000">
+      <rMaterial name="pixbarmaterial:CFK"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+  
+  <CompositeMaterial name="Flange_with_Manifold_Layer1" density="5.00093*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.1636">
+      <rMaterial name="trackermaterial:T_FR4"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.25809">
+      <rMaterial name="materials:C6F14_F2_-10C"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.23898">
+      <rMaterial name="materials:Steel-008"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.12917">
+      <rMaterial name="trackermaterial:T_CarbonFibreStr"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.19713">
+      <rMaterial name="trackermaterial:T_Aluminium"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.01304">
+      <rMaterial name="trackermaterial:T_Nomex"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="Flange_with_Manifold_Upgrade" density="1.38936*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.1216">
+      <rMaterial name="trackermaterial:T_Aluminium"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.1647">
+      <rMaterial name="materials:Steel-008"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.27897">
+      <rMaterial name="trackermaterial:T_CarbonFibreStr"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.35331">
+      <rMaterial name="trackermaterial:T_FR4"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.02816">
+      <rMaterial name="trackermaterial:T_Nomex"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.05321">
+      <rMaterial name="trackermaterial:T_Aluminium"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="Flange_with_Manifold_Layer2" density="5.34646*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.14778">
+      <rMaterial name="trackermaterial:T_FR4"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.28678">
+      <rMaterial name="materials:C6F14_F2_-10C"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.20276">
+      <rMaterial name="materials:Steel-008"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.15657">
+      <rMaterial name="trackermaterial:T_CarbonFibreStr"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.18269">
+      <rMaterial name="trackermaterial:T_Aluminium"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.02342">
+      <rMaterial name="trackermaterial:T_Nomex"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="FlangeInner_with_Manifold_Layer3" density="4.90600*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.10879">
+      <rMaterial name="trackermaterial:T_FR4"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.35422">
+      <rMaterial name="materials:C6F14_F2_-10C"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.36829">
+      <rMaterial name="materials:Steel-008"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.16871">
+      <rMaterial name="trackermaterial:T_Aluminium"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="FlangeOuter_Layer3" density="0.43142*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.11657">
+      <rMaterial name="trackermaterial:T_FR4"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.87067">
+      <rMaterial name="trackermaterial:T_CarbonFibreStr"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.00339">
+      <rMaterial name="trackermaterial:T_Aluminium"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.00938">
+      <rMaterial name="materials:Air"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="T_CarbonFibreStrBox" density="1.76355*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="1.0">
+      <rMaterial name="trackermaterial:T_CarbonFibreStr"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="FlangeOuter_Layer3_Upgrade" density="0.14381*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="1.00000000">
+      <rMaterial name="FlangeOuter_Layer3"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+ <CompositeMaterial name="cable_endring_to_tube" density="1.94299*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.10301">
+      <rMaterial name="trackermaterial:T_Kapton"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.15922">
+      <rMaterial name="pixfwdMaterials:FPix_Silicone"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.06696">
+      <rMaterial name="materials:Steel-008"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.04431">
+      <rMaterial name="pixfwdMaterials:FPix_Cylind_Noryl"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.02972">
+      <rMaterial name="materials:Epoxy"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.40314">
+      <rMaterial name="trackermaterial:T_Aluminium"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.19365">
+      <rMaterial name="trackermaterial:T_Copper"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="cable_endring_to_tube_Upgrade" density="0.64766*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="1.00000000">
+      <rMaterial name="cable_endring_to_tube"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="Layer1_2_EndringPrints" density="1.16836*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.01765">
+      <rMaterial name="materials:Lead"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.23843">
+      <rMaterial name="pixbarmaterial:LCP_Glass_Enforced"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.3061">
+      <rMaterial name="trackermaterial:T_FR4"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.00657">
+      <rMaterial name="materials:Steel-008"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.01658">
+      <rMaterial name="materials:Tin"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.41468">
+      <rMaterial name="trackermaterial:T_Copper"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="Layer1_2_EndringPrints_Upgrade" density="0.38945*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="1.00000000">
+      <rMaterial name="Layer1_2_EndringPrints"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="Layer3_EndringPrints" density="1.08648*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.01766">
+      <rMaterial name="materials:Lead"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.238">
+      <rMaterial name="pixbarmaterial:LCP_Glass_Enforced"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.30544">
+      <rMaterial name="trackermaterial:T_FR4"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.00789">
+      <rMaterial name="materials:Steel-008"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.01706">
+      <rMaterial name="materials:Tin"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.41396">
+      <rMaterial name="trackermaterial:T_Copper"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="Layer3_EndringPrints_Upgrade" density="0.36216*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="1.00000000">
+      <rMaterial name="Layer3_EndringPrints"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="silicone_pipes_plus_coolant" density="0.26030*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.53007">
+      <rMaterial name="materials:C6F14_F2_-10C"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.46993">
+      <rMaterial name="pixbarmaterial:BPix_Silicone"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+ <CompositeMaterial name="SectorA" density="0.4200*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.329">
+      <rMaterial name="trackermaterial:T_FR4"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.333">
+      <rMaterial name="trackermaterial:T_Aluminium"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.320">
+      <rMaterial name="trackermaterial:T_Copper"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.018">
+      <rMaterial name="materials:Steel-008"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+  
+ <CompositeMaterial name="SectorA_3Disks" density="0.55812*g/cm3" symbol=" " method="mixture by weight"> <!-- fpix 3 disks service material added -->
+    <MaterialFraction fraction="1.0">
+      <rMaterial name="pixbarmaterial:SectorA"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+ <CompositeMaterial name="SectorA_10Disks" density="0.95001*g/cm3" symbol=" " method="mixture by weight"> <!-- fpix 10 disks service material added -->
+    <MaterialFraction fraction="1.0">
+      <rMaterial name="pixbarmaterial:SectorA"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="SectorB" density="0.74961*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.19011">
+      <rMaterial name="materials:C6F14_F2_-10C"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.00494">
+      <rMaterial name="pixbarmaterial:Polyoxymethylene"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.1187">
+      <rMaterial name="trackermaterial:T_FR4"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.14233">
+      <rMaterial name="materials:Acrylate"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.0512">
+      <rMaterial name="materials:Steel-008"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.18915">
+      <rMaterial name="materials:Epoxy"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.06486">
+      <rMaterial name="trackermaterial:T_Copper"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.17137">
+      <rMaterial name="trackermaterial:T_Aluminium"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.05152">
+      <rMaterial name="materials:Polyvinylchloride"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.01581">
+      <rMaterial name="trackermaterial:T_Nomex"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="SectorC" density="0.7928*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.14778">
+      <rMaterial name="pixbarmaterial:Bpix_CO2_-20C"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.0139">
+      <rMaterial name="pixbarmaterial:Polyoxymethylene"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.22693">
+      <rMaterial name="trackermaterial:T_FR4"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.11069">
+      <rMaterial name="materials:Acrylate"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.03989">
+      <rMaterial name="materials:Steel-008"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.14938">
+      <rMaterial name="materials:Epoxy"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.01005">
+      <rMaterial name="pixfwdMaterials:FPix_TinLeadSolder"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.06396">
+      <rMaterial name="trackermaterial:T_Copper"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.20077">
+      <rMaterial name="trackermaterial:T_Aluminium"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.02082">
+      <rMaterial name="pixfwdMaterials:FPix_Cylind_Polyester"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.00319">
+      <rMaterial name="materials:Polyvinylchloride"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.01264">
+      <rMaterial name="trackermaterial:T_Nomex"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="SectorBC" density="1.133*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.265">
+      <rMaterial name="trackermaterial:T_FR4"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.115">
+      <rMaterial name="trackermaterial:T_Aluminium"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.052">
+      <rMaterial name="trackermaterial:T_Copper"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.006">
+      <rMaterial name="materials:Steel-008"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.562">
+      <rMaterial name="materials:Silicon"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+  
+ <CompositeMaterial name="SectorC_3Disks" density="1.22394*g/cm3" symbol=" " method="mixture by weight"> <!-- fpix 3 disks service material added -->
+    <MaterialFraction fraction="1.000000">
+      <rMaterial name="pixbarmaterial:SectorC"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+ <CompositeMaterial name="SectorC_10Disks" density="2.18549*g/cm3" symbol=" " method="mixture by weight"> <!-- fpix 10 disks service material added -->
+    <MaterialFraction fraction="1.000000">
+      <rMaterial name="pixbarmaterial:SectorC"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="SectorC_Upgrade" density="0.19652*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="1.00000000">
+      <rMaterial name="SectorC"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="PixelBarrelSupTubCables" density="0.6510*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.09162">
+      <rMaterial name="pixbarmaterial:Bpix_CO2_-20C"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.14907">
+      <rMaterial name="materials:Steel-008"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.28441">
+      <rMaterial name="materials:Polyethylene"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.4749">
+      <rMaterial name="trackermaterial:T_Copper"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+
+ <CompositeMaterial name="PixelBarrelSupTubCables2" density="0.4152*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.09162">
+      <rMaterial name="pixbarmaterial:Bpix_CO2_-20C"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.14907">
+      <rMaterial name="materials:Steel-008"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.28441">
+      <rMaterial name="materials:Polyethylene"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.4749">
+      <rMaterial name="trackermaterial:T_Copper"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+  
+  <CompositeMaterial name="PixelBarrelSupTubCables2_3Disks" density="0.96016*g/cm3" symbol=" " method="mixture by weight"> <!-- fpix 3 disks service material added -->
+    <MaterialFraction fraction="1.00000000">
+      <rMaterial name="PixelBarrelSupTubCables2"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="PixelBarrelSupTubCables2_10Disks" density="1.63436*g/cm3" symbol=" " method="mixture by weight"> <!-- fpix 10 disks service material added -->
+    <MaterialFraction fraction="1.00000000">
+      <rMaterial name="PixelBarrelSupTubCables2"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+
+</MaterialSection>
+
+</DDDefinition>
+

--- a/Geometry/VeryForwardData/data/CTPPS_2021/Stations/Simu/v3/CTPPS_210_Left_Station.xml
+++ b/Geometry/VeryForwardData/data/CTPPS_2021/Stations/Simu/v3/CTPPS_210_Left_Station.xml
@@ -1,0 +1,235 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition>
+    <ConstantsSection label="CTPPS_210_Left_Station.xml" eval="true">
+        <Constant name="RP_210_Left_Station_Length" value="[CTPPS_Stations_Assembly:CTPPS_220_Left_Station_Position_z]-[CTPPS_Stations_Assembly:CTPPS_210_Left_Station_Position_z]"/>
+        <!--Positions calculated from the wall closer to IP point-->
+        <Constant name="RP_210_Left_Prim_Vert_z" value="608*mm"/>
+        <Constant name="RP_210_Left_Prim_Hor_z" value="1058*mm"/>
+        <Constant name="RP_210_Left_Sec_Hor_z" value="9781*mm"/>
+        <Constant name="RP_210_Left_Sec_Vert_z" value="10231*mm"/>
+
+        <Constant name="RP_210_Left_Sec_Rot_Angle" value="8*deg"/>
+        <Constant name="RP_210_Left_Sec_Rot_Angle_neg8" value="-8*deg"/>
+        <Constant name="RP_210_Left_Sec_Rot_Angle_180" value="180*deg"/>
+        <Constant name="RP_210_Left_Sec_Rot_Angle_172" value="172*deg"/>
+ 
+        <Constant name="RP_210_Left_Hor_Vac_Length" value="[RP_Device:RP_Device_Envelope_Radius]+[RP_Device:RP_Device_Length_y]/2-[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int]"/>
+    </ConstantsSection>
+
+    <RotationSection label="CTPPS_210_Left_Station.xml">
+        <Rotation name="RP_210_Left_Sec_Rotation" 
+            phiX="[RP_210_Left_Sec_Rot_Angle]" thetaX="90*deg" 
+            phiY="(90*deg+[RP_210_Left_Sec_Rot_Angle])" thetaY="90*deg"
+            phiZ="0*deg" thetaZ="0*deg"/>
+        <Rotation name="RP_210_Left_90_y_Sec_Rotation_neg8" 
+            phiX="0*deg" thetaX="180*deg" 
+            phiY="82*deg" thetaY="90*deg"
+            phiZ="-8*deg" thetaZ="90*deg"/>
+        <Rotation name="RP_210_Left_90_x_Sec_Rotation" 
+            phiX="(0*deg+[RP_210_Left_Sec_Rot_Angle_neg8])" thetaX="90*deg" 
+            phiY="0*deg" thetaY="180*deg" 
+            phiZ="(90*deg+[RP_210_Left_Sec_Rot_Angle_neg8])" thetaZ="90*deg"/>
+        <Rotation name="RP_210_Left_Sec_Rotation_neg8" 
+            phiX="[RP_210_Left_Sec_Rot_Angle_neg8]" thetaX="90*deg" 
+            phiY="(90*deg+[RP_210_Left_Sec_Rot_Angle_neg8])" thetaY="90*deg"
+            phiZ="0*deg" thetaZ="0*deg"/>
+        <Rotation name="RP_210_Left_Sec_Rotation_180" 
+            phiX="[RP_210_Left_Sec_Rot_Angle_180]" thetaX="90*deg" 
+            phiY="(90*deg+[RP_210_Left_Sec_Rot_Angle_180])" thetaY="90*deg"
+            phiZ="0*deg" thetaZ="0*deg"/>
+        <Rotation name="RP_210_Left_Sec_Rotation_172" 
+            phiX="[RP_210_Left_Sec_Rot_Angle_172]" thetaX="90*deg" 
+            phiY="(90*deg+[RP_210_Left_Sec_Rot_Angle_172])" thetaY="90*deg"
+            phiZ="0*deg" thetaZ="0*deg"/>
+    </RotationSection>
+    
+    <SolidSection label="CTPPS_210_Left_Station.xml">  
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_Envelope_Radius]*1.1" dz="[RP_210_Left_Station_Length]/2" name="RP_210_Left_Station"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_210_Left_Prim_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2" name="RP_210_Left_Station_Tube_1"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_210_Left_Prim_Hor_z]-[RP_210_Left_Prim_Vert_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_210_Left_Station_Tube_2"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_210_Left_Sec_Hor_z]-[RP_210_Left_Prim_Hor_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_210_Left_Station_Tube_3"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_210_Left_Sec_Vert_z]-[RP_210_Left_Sec_Hor_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_210_Left_Station_Tube_4"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_210_Left_Station_Length]-[RP_210_Left_Sec_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2" name="RP_210_Left_Station_Tube_5"/>
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2" dz="[RP_210_Left_Station_Length]/2" name="RP_210_Left_Station_Vacuum_1"/>
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2" dz="[RP_Device:RP_Device_Envelope_Radius]" name="RP_210_Left_Station_Vert_Vacuum"/>
+        <UnionSolid name="RP_210_Left_Station_Vacuum_2">
+            <rSolid name="RP_210_Left_Station_Vacuum_1"/>
+            <rSolid name="RP_210_Left_Station_Vert_Vacuum"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Left_Station_Length]/2+[RP_210_Left_Prim_Vert_z]"/>
+        </UnionSolid>
+        <UnionSolid name="RP_210_Left_Station_Vacuum_3">
+            <rSolid name="RP_210_Left_Station_Vacuum_2"/>
+            <rSolid name="RP_210_Left_Station_Vert_Vacuum"/>
+            <rRotation name="RP_210_Left_90_x_Sec_Rotation"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Left_Station_Length]/2+[RP_210_Left_Sec_Vert_z]"/>
+        </UnionSolid>
+        <Polycone name="RP_210_Left_Station_Hor_Vacuum" startPhi="0*deg" deltaPhi="360*deg" >
+            <ZSection z="-[RP_Device:RP_Device_Length_y]/2+[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int]" rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2"/>
+            <ZSection z="-[RP_Device:RP_Device_Length_y]/2+[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int] + [RP_210_Left_Hor_Vac_Length]" rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2"/>
+        </Polycone> 
+        <UnionSolid name="RP_210_Left_Station_Vacuum_4">
+            <rSolid name="RP_210_Left_Station_Vacuum_3"/>
+            <rSolid name="RP_210_Left_Station_Hor_Vacuum"/>
+            <rRotation name="RP_Transformations:RP_y_90_rot"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Left_Station_Length]/2+[RP_210_Left_Prim_Hor_z]"/>
+        </UnionSolid>
+        <UnionSolid name="RP_210_Left_Station_Vacuum_5">
+            <rSolid name="RP_210_Left_Station_Vacuum_4"/>
+            <rSolid name="RP_210_Left_Station_Hor_Vacuum"/>
+            <rRotation name="RP_210_Left_90_y_Sec_Rotation_neg8"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Left_Station_Length]/2+[RP_210_Left_Sec_Hor_z]"/>
+        </UnionSolid>
+
+        <Polycone name="RP_210_Left_Station_Vacuum_1_Far" startPhi="0*deg" deltaPhi="360*deg" >
+            <ZSection z="0*mm" rMin="0*mm" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2"/>
+            <ZSection z="[RP_210_Left_Station_Length]/2" rMin="0*mm" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2"/>
+        </Polycone> 
+        <UnionSolid name="RP_210_Left_Station_Vacuum_2_Far">
+            <rSolid name="RP_210_Left_Station_Vacuum_1_Far"/>
+            <rSolid name="RP_210_Left_Station_Vert_Vacuum"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Left_Station_Length]/2+[RP_210_Left_Sec_Vert_z]"/>
+        </UnionSolid>
+        <UnionSolid name="RP_210_Left_Station_Vacuum_3_Far">
+            <rSolid name="RP_210_Left_Station_Vacuum_2_Far"/>
+            <rSolid name="RP_210_Left_Station_Hor_Vacuum"/>
+            <rRotation name="RP_Transformations:RP_y_90_rot"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Left_Station_Length]/2+[RP_210_Left_Sec_Hor_z]"/>
+        </UnionSolid>
+    </SolidSection>
+    
+    <LogicalPartSection label="CTPPS_210_Left_Station.xml">
+        <LogicalPart name="RP_210_Left_Station">
+            <rSolid name="RP_210_Left_Station"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Left_Station_Tube_1">
+            <rSolid name="RP_210_Left_Station_Tube_1"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Left_Station_Tube_2">
+            <rSolid name="RP_210_Left_Station_Tube_2"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Left_Station_Tube_3">
+            <rSolid name="RP_210_Left_Station_Tube_3"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Left_Station_Tube_4">
+            <rSolid name="RP_210_Left_Station_Tube_4"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Left_Station_Tube_5">
+            <rSolid name="RP_210_Left_Station_Tube_5"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Left_Station_Vacuum_5">
+            <rSolid name="RP_210_Left_Station_Vacuum_5"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Left_Station_Vacuum_3_Far">
+            <rSolid name="RP_210_Left_Station_Vacuum_3_Far"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    
+    <PosPartSection label="CTPPS_210_Left_Station.xml">
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Left_Station"/>
+            <rChild name="RP_Vertical_Device:RP_Device_Vert_Corp_3"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Left_Station_Length]/2+[RP_210_Left_Prim_Vert_z]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="RP_210_Left_Station"/>
+            <rChild name="RP_Vertical_Device:RP_Device_Vert_Corp_3"/>
+            <rRotation name="RP_210_Left_Sec_Rotation_neg8"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Left_Station_Length]/2+[RP_210_Left_Sec_Vert_z]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Left_Station"/>
+            <rChild name="RP_Horizontal_Device:RP_Device_Hor_Corp_3"/>
+            <rRotation name="RP_210_Left_Sec_Rotation_180"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Left_Station_Length]/2+[RP_210_Left_Prim_Hor_z]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="RP_210_Left_Station"/>
+            <rChild name="RP_Horizontal_Device:RP_Device_Hor_Corp_3"/>
+            <rRotation name="RP_210_Left_Sec_Rotation_172"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Left_Station_Length]/2+[RP_210_Left_Sec_Hor_z]"/>
+        </PosPart>
+        
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Left_Station"/>
+            <rChild name="RP_210_Left_Station_Tube_1"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Left_Station_Length]/2+([RP_210_Left_Prim_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Left_Station"/>
+            <rChild name="RP_210_Left_Station_Tube_2"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Left_Station_Length]/2+([RP_210_Left_Prim_Vert_z]+[RP_210_Left_Prim_Hor_z])/2"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Left_Station"/>
+            <rChild name="RP_210_Left_Station_Tube_3"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Left_Station_Length]/2+([RP_210_Left_Prim_Hor_z]+[RP_210_Left_Sec_Hor_z])/2"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Left_Station"/>
+            <rChild name="RP_210_Left_Station_Tube_4"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Left_Station_Length]/2+([RP_210_Left_Sec_Hor_z]+[RP_210_Left_Sec_Vert_z])/2"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Left_Station"/>
+            <rChild name="RP_210_Left_Station_Tube_5"/>
+            <Translation x="0*mm" y="0*mm" z="[RP_210_Left_Station_Length]/2-([RP_210_Left_Station_Length]-[RP_210_Left_Sec_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Left_Station"/>
+            <rChild name="RP_210_Left_Station_Vacuum_5"/>
+            <rRotation name="RP_210_Left_Sec_Rotation_180"/>
+            <!--<rRotation name="RP_210_Left_Sec_Rotation_180"/>-->
+        </PosPart>
+
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Left_Station_Vacuum_5"/>
+            <rChild name="RP_210_Left_Station_Vacuum_3_Far"/>
+            <rRotation name="RP_210_Left_Sec_Rotation_neg8"/>
+        </PosPart>
+        
+        <PosPart copyNumber="0">
+            <rParent name="RP_210_Left_Station_Vacuum_5"/>
+            <rChild name="RP_Box_000:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_z_180_rot"/>
+            <Translation x="0*mm" y="-[RP_Dist_Beam_Cent:RP_210_Left_Det_Dist_1]-[RP_Box:RP_Box_primary_vacuum_y]/2" z="[RP_210_Left_Prim_Vert_z]-[RP_210_Left_Station_Length]/2"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Left_Station_Vacuum_5"/>
+            <rChild name="RP_Box_001:RP_box_primary_vacuum"/>
+            <Translation x="0*mm" y="[RP_Dist_Beam_Cent:RP_210_Left_Det_Dist_0]+[RP_Box:RP_Box_primary_vacuum_y]/2" z="[RP_210_Left_Prim_Vert_z]-[RP_210_Left_Station_Length]/2"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="RP_210_Left_Station_Vacuum_5"/>
+            <rChild name="RP_Box_002:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_90_cw_z_rot"/>
+            <Translation x="-(-[RP_Dist_Beam_Cent:RP_210_Left_Det_Dist_2]-[RP_Box:RP_Box_primary_vacuum_y]/2)" y="0*mm" z="[RP_210_Left_Prim_Hor_z]-[RP_210_Left_Station_Length]/2"/>
+        </PosPart>
+        <PosPart copyNumber="10003">
+            <rParent name="RP_210_Left_Station_Vacuum_3_Far"/>
+            <rChild name="RP_Box_003:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_90_cw_z_rot"/>
+            <Translation x="-(-[RP_Dist_Beam_Cent:RP_210_Left_Det_Dist_3]-[RP_Box:RP_Box_primary_vacuum_y]/2)" y="0*mm" z="[RP_210_Left_Sec_Hor_z]-[RP_210_Left_Station_Length]/2"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="RP_210_Left_Station_Vacuum_3_Far"/>
+            <rChild name="RP_Box_004:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_z_180_rot"/>
+            <Translation x="0*mm" y="-[RP_Dist_Beam_Cent:RP_210_Left_Det_Dist_5]-[RP_Box:RP_Box_primary_vacuum_y]/2" z="[RP_210_Left_Sec_Vert_z]-[RP_210_Left_Station_Length]/2"/>
+        </PosPart>
+        <PosPart copyNumber="5">
+            <rParent name="RP_210_Left_Station_Vacuum_3_Far"/>
+            <rChild name="RP_Box_005:RP_box_primary_vacuum"/>
+            <Translation x="0*mm" y="[RP_Dist_Beam_Cent:RP_210_Left_Det_Dist_4]+[RP_Box:RP_Box_primary_vacuum_y]/2" z="[RP_210_Left_Sec_Vert_z]-[RP_210_Left_Station_Length]/2"/>
+        </PosPart>
+    </PosPartSection>
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/CTPPS_2021/Stations/Simu/v3/CTPPS_210_Right_Station.xml
+++ b/Geometry/VeryForwardData/data/CTPPS_2021/Stations/Simu/v3/CTPPS_210_Right_Station.xml
@@ -1,0 +1,236 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition>
+    <ConstantsSection label="CTPPS_210_Right_Station.xml" eval="true">
+        <Constant name="RP_210_Right_Station_Length" value="-([CTPPS_Stations_Assembly:CTPPS_220_Right_Station_Position_z]-[CTPPS_Stations_Assembly:CTPPS_210_Right_Station_Position_z])"/>
+        <!--Positions calculated from the wall closer to IP point-->
+        <Constant name="RP_210_Right_Prim_Vert_z" value="608*mm"/>
+        <Constant name="RP_210_Right_Prim_Hor_z" value="1058*mm"/>
+        <Constant name="RP_210_Right_Sec_Hor_z" value="9781*mm"/>
+        <Constant name="RP_210_Right_Sec_Vert_z" value="10231*mm"/>
+
+        <Constant name="RP_210_Right_Sec_Rot_Angle" value="8*deg"/>
+        <Constant name="RP_210_Right_Sec_Rot_Angle_neg8" value="-8*deg"/>
+        <Constant name="RP_210_Right_Sec_Rot_Angle_180" value="180*deg"/>
+        <Constant name="RP_210_Right_Sec_Rot_Angle_172" value="172*deg"/>
+
+        <Constant name="RP_210_Right_Hor_Vac_Length" value="[RP_Device:RP_Device_Envelope_Radius]+[RP_Device:RP_Device_Length_y]/2-[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int]"/>
+    </ConstantsSection>
+
+    <RotationSection label="CTPPS_210_Right_Station.xml">
+        <Rotation name="RP_210_Right_Sec_Rotation" 
+            phiX="[RP_210_Right_Sec_Rot_Angle]" thetaX="90*deg" 
+            phiY="(90*deg+[RP_210_Right_Sec_Rot_Angle])" thetaY="90*deg"
+            phiZ="0*deg" thetaZ="0*deg"/>
+        <Rotation name="RP_210_Right_90_y_Sec_Rotation_neg8" 
+            phiX="0*deg" thetaX="180*deg" 
+            phiY="(90*deg+[RP_210_Right_Sec_Rot_Angle_neg8])" thetaY="90*deg" 
+            phiZ="(0*deg+[RP_210_Right_Sec_Rot_Angle_neg8])" thetaZ="90*deg"/>
+        <Rotation name="RP_210_Right_90_x_Sec_Rotation_neg8" 
+            phiX="(0*deg+[RP_210_Right_Sec_Rot_Angle_neg8])" thetaX="90*deg" 
+            phiY="0*deg" thetaY="180*deg" 
+            phiZ="(90*deg+[RP_210_Right_Sec_Rot_Angle_neg8])" thetaZ="90*deg"/>
+        <Rotation name="RP_210_Right_Sec_Rotation_neg8" 
+            phiX="[RP_210_Right_Sec_Rot_Angle_neg8]" thetaX="90*deg" 
+            phiY="(90*deg+[RP_210_Right_Sec_Rot_Angle_neg8])" thetaY="90*deg"
+            phiZ="0*deg" thetaZ="0*deg"/>
+        <Rotation name="RP_210_Right_Sec_Rotation_180" 
+            phiX="[RP_210_Right_Sec_Rot_Angle_180]" thetaX="90*deg" 
+            phiY="(90*deg+[RP_210_Right_Sec_Rot_Angle_180])" thetaY="90*deg"
+            phiZ="0*deg" thetaZ="0*deg"/>
+        <Rotation name="RP_210_Right_Sec_Rotation_172" 
+            phiX="[RP_210_Right_Sec_Rot_Angle_172]" thetaX="90*deg" 
+            phiY="(90*deg+[RP_210_Right_Sec_Rot_Angle_172])" thetaY="90*deg"
+            phiZ="0*deg" thetaZ="0*deg"/>
+    </RotationSection>
+
+    <SolidSection label="CTPPS_210_Right_Station.xml">  
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_Envelope_Radius]*1.1" dz="[RP_210_Right_Station_Length]/2" name="RP_210_Right_Station"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_210_Right_Prim_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2" name="RP_210_Right_Station_Tube_1"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_210_Right_Prim_Hor_z]-[RP_210_Right_Prim_Vert_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_210_Right_Station_Tube_2"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_210_Right_Sec_Hor_z]-[RP_210_Right_Prim_Hor_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_210_Right_Station_Tube_3"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_210_Right_Sec_Vert_z]-[RP_210_Right_Sec_Hor_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_210_Right_Station_Tube_4"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_210_Right_Station_Length]-[RP_210_Right_Sec_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2" name="RP_210_Right_Station_Tube_5"/>
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2" dz="[RP_210_Right_Station_Length]/2" name="RP_210_Right_Station_Vacuum_1"/>
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2" dz="[RP_Device:RP_Device_Envelope_Radius]" name="RP_210_Right_Station_Vert_Vacuum"/>
+        <UnionSolid name="RP_210_Right_Station_Vacuum_2">
+            <rSolid name="RP_210_Right_Station_Vacuum_1"/>
+            <rSolid name="RP_210_Right_Station_Vert_Vacuum"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+[RP_210_Right_Prim_Vert_z])"/>
+        </UnionSolid>
+        <UnionSolid name="RP_210_Right_Station_Vacuum_3">
+            <rSolid name="RP_210_Right_Station_Vacuum_2"/>
+            <rSolid name="RP_210_Right_Station_Vert_Vacuum"/>
+            <rRotation name="RP_210_Right_90_x_Sec_Rotation_neg8"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+[RP_210_Right_Sec_Vert_z])"/>
+        </UnionSolid>
+        <Polycone name="RP_210_Right_Station_Hor_Vacuum" startPhi="0*deg" deltaPhi="360*deg" >
+            <ZSection z="-[RP_Device:RP_Device_Length_y]/2+[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int]" rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2"/>
+            <ZSection z="-[RP_Device:RP_Device_Length_y]/2+[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int] + [RP_210_Right_Hor_Vac_Length]" rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2"/>
+        </Polycone> 
+        <UnionSolid name="RP_210_Right_Station_Vacuum_4">
+            <rSolid name="RP_210_Right_Station_Vacuum_3"/>
+            <rSolid name="RP_210_Right_Station_Hor_Vacuum"/>
+            <rRotation name="RP_Transformations:RP_y_90_rot"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+[RP_210_Right_Prim_Hor_z])"/>
+        </UnionSolid>
+        <UnionSolid name="RP_210_Right_Station_Vacuum_5">
+            <rSolid name="RP_210_Right_Station_Vacuum_4"/>
+            <rSolid name="RP_210_Right_Station_Hor_Vacuum"/>
+            <rRotation name="RP_210_Right_90_y_Sec_Rotation_neg8"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+[RP_210_Right_Sec_Hor_z])"/>
+        </UnionSolid>
+
+        <Polycone name="RP_210_Right_Station_Vacuum_1_Far" startPhi="0*deg" deltaPhi="360*deg" >
+            <ZSection z="0*mm" rMin="0*mm" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2"/>
+            <ZSection z="-([RP_210_Right_Station_Length]/2)" rMin="0*mm" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2"/>
+        </Polycone> 
+        <UnionSolid name="RP_210_Right_Station_Vacuum_2_Far">
+            <rSolid name="RP_210_Right_Station_Vacuum_1_Far"/>
+            <rSolid name="RP_210_Right_Station_Vert_Vacuum"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+[RP_210_Right_Sec_Vert_z])"/>
+        </UnionSolid>
+        <UnionSolid name="RP_210_Right_Station_Vacuum_3_Far">
+            <rSolid name="RP_210_Right_Station_Vacuum_2_Far"/>
+            <rSolid name="RP_210_Right_Station_Hor_Vacuum"/>
+            <rRotation name="RP_Transformations:RP_y_90_rot"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+[RP_210_Right_Sec_Hor_z])"/>
+        </UnionSolid>
+    </SolidSection>
+
+    <LogicalPartSection label="CTPPS_210_Right_Station.xml">
+        <LogicalPart name="RP_210_Right_Station">
+            <rSolid name="RP_210_Right_Station"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Right_Station_Tube_1">
+            <rSolid name="RP_210_Right_Station_Tube_1"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Right_Station_Tube_2">
+            <rSolid name="RP_210_Right_Station_Tube_2"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Right_Station_Tube_3">
+            <rSolid name="RP_210_Right_Station_Tube_3"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Right_Station_Tube_4">
+            <rSolid name="RP_210_Right_Station_Tube_4"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Right_Station_Tube_5">
+            <rSolid name="RP_210_Right_Station_Tube_5"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Right_Station_Vacuum_5">
+            <rSolid name="RP_210_Right_Station_Vacuum_5"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Right_Station_Vacuum_3_Far">
+            <rSolid name="RP_210_Right_Station_Vacuum_3_Far"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+    </LogicalPartSection>
+
+    <PosPartSection label="CTPPS_210_Right_Station.xml">
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Right_Station"/>
+            <rChild name="RP_Vertical_Device:RP_Device_Vert_Corp_3"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+[RP_210_Right_Prim_Vert_z])"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="RP_210_Right_Station"/>
+            <rChild name="RP_Vertical_Device:RP_Device_Vert_Corp_3"/>
+            <rRotation name="RP_210_Right_Sec_Rotation_neg8"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+[RP_210_Right_Sec_Vert_z])"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Right_Station"/>
+            <rChild name="RP_Horizontal_Device:RP_Device_Hor_Corp_3"/>
+            <rRotation name="RP_210_Right_Sec_Rotation_180"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+[RP_210_Right_Prim_Hor_z])"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="RP_210_Right_Station"/>
+            <rChild name="RP_Horizontal_Device:RP_Device_Hor_Corp_3"/>
+            <rRotation name="RP_210_Right_Sec_Rotation_172"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+[RP_210_Right_Sec_Hor_z])"/>
+        </PosPart>
+
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Right_Station"/>
+            <rChild name="RP_210_Right_Station_Tube_1"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+([RP_210_Right_Prim_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Right_Station"/>
+            <rChild name="RP_210_Right_Station_Tube_2"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+([RP_210_Right_Prim_Vert_z]+[RP_210_Right_Prim_Hor_z])/2)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Right_Station"/>
+            <rChild name="RP_210_Right_Station_Tube_3"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+([RP_210_Right_Prim_Hor_z]+[RP_210_Right_Sec_Hor_z])/2)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Right_Station"/>
+            <rChild name="RP_210_Right_Station_Tube_4"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+([RP_210_Right_Sec_Hor_z]+[RP_210_Right_Sec_Vert_z])/2)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Right_Station"/>
+            <rChild name="RP_210_Right_Station_Tube_5"/>
+            <Translation x="0*mm" y="0*mm" z="-([RP_210_Right_Station_Length]/2-([RP_210_Right_Station_Length]-[RP_210_Right_Sec_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Right_Station"/>
+            <rChild name="RP_210_Right_Station_Vacuum_5"/>
+            <rRotation name="RP_210_Right_Sec_Rotation_180"/>
+        </PosPart>
+
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Right_Station_Vacuum_5"/>
+            <rChild name="RP_210_Right_Station_Vacuum_3_Far"/>
+            <rRotation name="RP_210_Right_Sec_Rotation_neg8"/>
+        </PosPart>
+
+        <PosPart copyNumber="100">
+            <rParent name="RP_210_Right_Station_Vacuum_5"/>
+            <rChild name="RP_Box_100:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_180_z_180_y_rot"/>
+            <Translation x="0*mm" y="-[RP_Dist_Beam_Cent:RP_210_Right_Det_Dist_1]-[RP_Box:RP_Box_primary_vacuum_y]/2" z="-([RP_210_Right_Prim_Vert_z]-[RP_210_Right_Station_Length]/2)"/>
+        </PosPart>
+        <PosPart copyNumber="101">
+            <rParent name="RP_210_Right_Station_Vacuum_5"/>
+            <rChild name="RP_Box_101:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_y_180_rot"/>
+            <Translation x="0*mm" y="[RP_Dist_Beam_Cent:RP_210_Right_Det_Dist_0]+[RP_Box:RP_Box_primary_vacuum_y]/2" z="-([RP_210_Right_Prim_Vert_z]-[RP_210_Right_Station_Length]/2)"/>
+        </PosPart>
+        <PosPart copyNumber="102">
+            <rParent name="RP_210_Right_Station_Vacuum_5"/>
+            <rChild name="RP_Box_102:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_90_z_cw_180_y_rot"/>
+            <Translation x="-(-[RP_Dist_Beam_Cent:RP_210_Right_Det_Dist_2]-[RP_Box:RP_Box_primary_vacuum_y]/2)" y="0*mm" z="-([RP_210_Right_Prim_Hor_z]-[RP_210_Right_Station_Length]/2)"/>
+        </PosPart>
+        <PosPart copyNumber="10103">
+            <rParent name="RP_210_Right_Station_Vacuum_3_Far"/>
+            <rChild name="RP_Box_103:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_90_z_cw_180_y_rot"/>
+            <Translation x="-(-[RP_Dist_Beam_Cent:RP_210_Right_Det_Dist_3]-[RP_Box:RP_Box_primary_vacuum_y]/2)" y="0*mm" z="-([RP_210_Right_Sec_Hor_z]-[RP_210_Right_Station_Length]/2)"/>
+        </PosPart>
+        <PosPart copyNumber="104">
+            <rParent name="RP_210_Right_Station_Vacuum_3_Far"/>
+            <rChild name="RP_Box_104:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_180_z_180_y_rot"/>
+            <Translation x="0*mm" y="-[RP_Dist_Beam_Cent:RP_210_Right_Det_Dist_5]-[RP_Box:RP_Box_primary_vacuum_y]/2" z="-([RP_210_Right_Sec_Vert_z]-[RP_210_Right_Station_Length]/2)"/>
+        </PosPart>
+        <PosPart copyNumber="105">
+            <rParent name="RP_210_Right_Station_Vacuum_3_Far"/>
+            <rChild name="RP_Box_105:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_y_180_rot"/>
+            <Translation x="0*mm" y="[RP_Dist_Beam_Cent:RP_210_Right_Det_Dist_4]+[RP_Box:RP_Box_primary_vacuum_y]/2" z="-([RP_210_Right_Sec_Vert_z]-[RP_210_Right_Station_Length]/2)"/>
+        </PosPart>
+    </PosPartSection>
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/CTPPS_2021/Stations/Simu/v3/CTPPS_220_Left_Station.xml
+++ b/Geometry/VeryForwardData/data/CTPPS_2021/Stations/Simu/v3/CTPPS_220_Left_Station.xml
@@ -1,0 +1,212 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition>
+    <ConstantsSection label="CTPPS_220_Left_Station.xml" eval="true">
+        <Constant name="RP_220_Left_Station_Length" value="6588*mm"/>
+        <!--Positions calculated from the wall closer to IP point-->
+        <Constant name="RP_220_Left_Prim_Vert_z" value="608*mm"/>
+        <Constant name="RP_220_Left_Prim_Hor_z" value="1058*mm"/>
+        <Constant name="RP_220_Left_Sec_Hor_z" value="5530*mm"/>
+        <Constant name="RP_220_Left_Sec_Vert_z" value="5980*mm"/>
+        <Constant name="RP_220_Left_Timing_z" value="1680*mm"/>
+        <Constant name="RP_220_Left_Rot_Angle_180" value="180*deg"/>
+        <Constant name="RP_220_Left_Hor_Vac_Length" value="[RP_Device:RP_Device_Envelope_Radius]+[RP_Device:RP_Device_Length_y]/2-[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int]"/>
+    </ConstantsSection>
+
+    <RotationSection label="CTPPS_220_Left_Station.xml">
+        <Rotation name="RP_220_Left_Sec_Rotation_180" 
+            phiX="[RP_220_Left_Rot_Angle_180]" thetaX="90*deg" 
+            phiY="(90*deg+[RP_220_Left_Rot_Angle_180])" thetaY="90*deg"
+            phiZ="0*deg" thetaZ="0*deg"/>
+        <Rotation name="PPS_Timing_rot" phiX="0*deg" thetaX="0*deg" phiY="90*deg" thetaY="90*deg" phiZ="0*deg" thetaZ="270*deg"/>
+    </RotationSection>
+
+    <SolidSection label="CTPPS_220_Left_Station.xml">  
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_Envelope_Radius]*1.1" dz="[RP_220_Left_Station_Length]/2" name="RP_220_Left_Station"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_220_Left_Prim_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2" name="RP_220_Left_Station_Tube_1"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_220_Left_Prim_Hor_z]-[RP_220_Left_Prim_Vert_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_220_Left_Station_Tube_2"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_220_Left_Timing_z]-[RP_220_Left_Prim_Hor_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_220_Left_Station_Tube_3a"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_220_Left_Sec_Hor_z]-[RP_220_Left_Timing_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_220_Left_Station_Tube_3b"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_220_Left_Sec_Vert_z]-[RP_220_Left_Sec_Hor_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_220_Left_Station_Tube_4"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_220_Left_Station_Length]-[RP_220_Left_Sec_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2" name="RP_220_Left_Station_Tube_5"/>
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2" dz="[RP_220_Left_Station_Length]/2" name="RP_220_Left_Station_Vacuum_1"/>
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2" dz="[RP_Device:RP_Device_Envelope_Radius]" name="RP_220_Left_Station_Vert_Vacuum"/>
+        <Tube name="CTPPS_Timing_Positive_Station_Hor_Vacuum" rMin="0*mm" rMax="[CTPPS_Timing_Station_Parameters:Timing_Hole_Diam]/2" dz="[CTPPS_Timing_Station_Parameters:Hor_Vac_Length]/2"/>
+        <UnionSolid name="RP_220_Left_Station_Vacuum_2">
+            <rSolid name="RP_220_Left_Station_Vacuum_1"/>
+            <rSolid name="RP_220_Left_Station_Vert_Vacuum"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_220_Left_Station_Length]/2+[RP_220_Left_Prim_Vert_z]"/>
+        </UnionSolid>
+        <UnionSolid name="RP_220_Left_Station_Vacuum_3">
+            <rSolid name="RP_220_Left_Station_Vacuum_2"/>
+            <rSolid name="RP_220_Left_Station_Vert_Vacuum"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_220_Left_Station_Length]/2+[RP_220_Left_Sec_Vert_z]"/>
+        </UnionSolid>
+        <!--<Tube name="CTPPS_Timing_Positive_Station" rMin="0*mm" rMax="[CTPPS_Timing_Station_Parameters:Device_Envelope_Radius]*1.1" dz="[CTPPS_Timing_Station_Parameters:Station_Length]/2"/>-->
+        <UnionSolid name="CTPPS_Timing_Positive_Station_Vacuum_3a">
+          <rSolid name="RP_220_Left_Station_Vacuum_3"/>
+          <rSolid name="CTPPS_Timing_Positive_Station_Hor_Vacuum"/>
+          <rRotation name="CTPPS_Diamond_Transformations:y_90_rot"/>
+<!--      <rRotation name="rotations:90YX"/>-->
+<!--      <rRotation name="CTPPS_Diamond_Transformations:y90D"/>-->
+          <Translation x="[CTPPS_Timing_Station_Parameters:Hor_Vac_Length]/2-[CTPPS_Timing_Station_Parameters:Device_Length_y]/2+[CTPPS_Timing_Station_Parameters:Hor_Closed_Wall_Thick_Int]" y="0*mm" z="-[RP_220_Left_Station_Length]/2+[RP_220_Left_Timing_z]"/>
+        </UnionSolid>
+
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2" dz="[RP_220_Left_Hor_Vac_Length]/2" name="RP_220_Left_Station_Hor_Vacuum"/>
+        <UnionSolid name="RP_220_Left_Station_Vacuum_4">
+            <rSolid name="CTPPS_Timing_Positive_Station_Vacuum_3a"/>
+            <rSolid name="RP_220_Left_Station_Hor_Vacuum"/>
+            <rRotation name="RP_Transformations:RP_y_90_rot"/>
+            <Translation x="-(-[RP_220_Left_Hor_Vac_Length]/2+[RP_Device:RP_Device_Length_y]/2-[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int])" y="0*mm" z="-[RP_220_Left_Station_Length]/2+[RP_220_Left_Prim_Hor_z]"/>
+        </UnionSolid>
+        <UnionSolid name="RP_220_Left_Station_Vacuum_5">
+            <rSolid name="RP_220_Left_Station_Vacuum_4"/>
+            <rSolid name="RP_220_Left_Station_Hor_Vacuum"/>
+            <rRotation name="RP_Transformations:RP_y_90_rot"/>
+            <Translation x="-(-[RP_220_Left_Hor_Vac_Length]/2+[RP_Device:RP_Device_Length_y]/2-[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int])" y="0*mm" z="-[RP_220_Left_Station_Length]/2+[RP_220_Left_Sec_Hor_z]"/>
+        </UnionSolid>
+    </SolidSection>
+    
+    <LogicalPartSection label="CTPPS_220_Left_Station.xml">
+        <LogicalPart name="RP_220_Left_Station">
+            <rSolid name="RP_220_Left_Station"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="RP_220_Left_Station_Tube_1">
+            <rSolid name="RP_220_Left_Station_Tube_1"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_220_Left_Station_Tube_2">
+            <rSolid name="RP_220_Left_Station_Tube_2"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_220_Left_Station_Tube_3a">
+            <rSolid name="RP_220_Left_Station_Tube_3a"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_220_Left_Station_Tube_3b">
+            <rSolid name="RP_220_Left_Station_Tube_3b"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_220_Left_Station_Tube_4">
+            <rSolid name="RP_220_Left_Station_Tube_4"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_220_Left_Station_Tube_5">
+            <rSolid name="RP_220_Left_Station_Tube_5"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_220_Left_Station_Vacuum_5">
+            <rSolid name="RP_220_Left_Station_Vacuum_5"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    
+    <PosPartSection label="CTPPS_220_Left_Station.xml">
+        <PosPart copyNumber="1">
+            <rParent name="RP_220_Left_Station"/>
+            <rChild name="RP_Vertical_Device:RP_Device_Vert_Corp_3"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_220_Left_Station_Length]/2+[RP_220_Left_Prim_Vert_z]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="RP_220_Left_Station"/>
+            <rChild name="RP_Vertical_Device:RP_Device_Vert_Corp_3"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_220_Left_Station_Length]/2+[RP_220_Left_Sec_Vert_z]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_220_Left_Station"/>
+            <rChild name="RP_Horizontal_Device:RP_Device_Hor_Corp_3"/>
+            <rRotation name="RP_220_Left_Sec_Rotation_180"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_220_Left_Station_Length]/2+[RP_220_Left_Prim_Hor_z]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="RP_220_Left_Station"/>
+            <rChild name="RP_Horizontal_Device:RP_Device_Hor_Corp_3"/>
+            <rRotation name="RP_220_Left_Sec_Rotation_180"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_220_Left_Station_Length]/2+[RP_220_Left_Sec_Hor_z]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="RP_220_Left_Station"/>
+            <rChild name="RP_Horizontal_Device:RP_Device_Hor_Corp_3"/>
+            <rRotation name="RP_220_Left_Sec_Rotation_180"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_220_Left_Station_Length]/2+[RP_220_Left_Timing_z]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_220_Left_Station"/>
+            <rChild name="RP_220_Left_Station_Tube_1"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_220_Left_Station_Length]/2+([RP_220_Left_Prim_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_220_Left_Station"/>
+            <rChild name="RP_220_Left_Station_Tube_2"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_220_Left_Station_Length]/2+([RP_220_Left_Prim_Vert_z]+[RP_220_Left_Prim_Hor_z])/2"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_220_Left_Station"/>
+            <rChild name="RP_220_Left_Station_Tube_3a"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_220_Left_Station_Length]/2+([RP_220_Left_Prim_Hor_z]+[RP_220_Left_Timing_z])/2"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_220_Left_Station"/>
+            <rChild name="RP_220_Left_Station_Tube_3b"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_220_Left_Station_Length]/2+([RP_220_Left_Timing_z]+[RP_220_Left_Sec_Hor_z])/2"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_220_Left_Station"/>
+            <rChild name="RP_220_Left_Station_Tube_4"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_220_Left_Station_Length]/2+([RP_220_Left_Sec_Hor_z]+[RP_220_Left_Sec_Vert_z])/2"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_220_Left_Station"/>
+            <rChild name="RP_220_Left_Station_Tube_5"/>
+            <Translation x="0*mm" y="0*mm" z="[RP_220_Left_Station_Length]/2-([RP_220_Left_Station_Length]-[RP_220_Left_Sec_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_220_Left_Station"/>
+            <rChild name="RP_220_Left_Station_Vacuum_5"/>
+            <rRotation name="RP_220_Left_Sec_Rotation_180"/>
+        </PosPart>
+        
+        <PosPart copyNumber="20">
+            <rParent name="RP_220_Left_Station_Vacuum_5"/>
+            <rChild name="RP_Box_020:RP_box_primary_vacuum"/>
+            <Translation x="0*mm" y="[RP_Dist_Beam_Cent:RP_220_Left_Det_Dist_0]+[RP_Box:RP_Box_primary_vacuum_y]/2" z="[RP_220_Left_Prim_Vert_z]-[RP_220_Left_Station_Length]/2"/>
+        </PosPart>
+        <PosPart copyNumber="21">
+            <rParent name="RP_220_Left_Station_Vacuum_5"/>
+            <rChild name="RP_Box_021:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_z_180_rot"/>
+            <Translation x="0*mm" y="-[RP_Dist_Beam_Cent:RP_220_Left_Det_Dist_1]-[RP_Box:RP_Box_primary_vacuum_y]/2" z="[RP_220_Left_Prim_Vert_z]-[RP_220_Left_Station_Length]/2"/>
+        </PosPart>
+        <PosPart copyNumber="22">
+            <rParent name="RP_220_Left_Station_Vacuum_5"/>
+            <rChild name="RP_Box_022:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_90_cw_z_rot"/>
+            <Translation x="-(-[RP_Dist_Beam_Cent:RP_220_Left_Det_Dist_2]-[RP_Box:RP_Box_primary_vacuum_y]/2)" y="0*mm" z="[RP_220_Left_Prim_Hor_z]-[RP_220_Left_Station_Length]/2"/>
+        </PosPart>
+        <PosPart copyNumber="10023">
+            <rParent name="RP_220_Left_Station_Vacuum_5"/>
+            <rChild name="RP_Box_023:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_90_cw_z_rot"/>
+            <Translation x="-(-[RP_Dist_Beam_Cent:RP_220_Left_Det_Dist_3]-[RP_Box:RP_Box_primary_vacuum_y]/2)" y="0*mm" z="[RP_220_Left_Sec_Hor_z]-[RP_220_Left_Station_Length]/2"/>
+        </PosPart>
+        <PosPart copyNumber="24">
+            <rParent name="RP_220_Left_Station_Vacuum_5"/>
+            <rChild name="RP_Box_024:RP_box_primary_vacuum"/>
+            <Translation x="0*mm" y="[RP_Dist_Beam_Cent:RP_220_Left_Det_Dist_4]+[RP_Box:RP_Box_primary_vacuum_y]/2" z="[RP_220_Left_Sec_Vert_z]-[RP_220_Left_Station_Length]/2"/>
+        </PosPart>
+        <PosPart copyNumber="25">
+            <rParent name="RP_220_Left_Station_Vacuum_5"/>
+            <rChild name="RP_Box_025:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_z_180_rot"/>
+            <Translation x="0*mm" y="-[RP_Dist_Beam_Cent:RP_220_Left_Det_Dist_5]-[RP_Box:RP_Box_primary_vacuum_y]/2" z="[RP_220_Left_Sec_Vert_z]-[RP_220_Left_Station_Length]/2"/>
+        </PosPart>
+        <PosPart copyNumber="16">
+            <rParent name="RP_220_Left_Station_Vacuum_5"/>
+            <rChild name="CTPPS_Timing_Horizontal_Pot:Primary_Vacuum"/>
+            <rRotation name="rotations:90YX"/>
+            <Translation x="-(-([RP_Dist_Beam_Cent:CTPPS_45_Det_Dist]+[CTPPS_Timing_Horizontal_Pot:plane_length]+[CTPPS_Timing_Horizontal_Pot:cut_depth]+[CTPPS_Timing_Horizontal_Pot:thin_window_thickness])/2)" y="0*cm" z="-[RP_220_Left_Station_Length]/2+[RP_220_Left_Timing_z]"/>
+        </PosPart>
+    </PosPartSection>
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/CTPPS_2021/Stations/Simu/v3/CTPPS_220_Right_Station.xml
+++ b/Geometry/VeryForwardData/data/CTPPS_2021/Stations/Simu/v3/CTPPS_220_Right_Station.xml
@@ -1,0 +1,213 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition>
+    <ConstantsSection label="CTPPS_220_Right_Station.xml" eval="true">
+        <Constant name="RP_220_Right_Station_Length" value="6588*mm"/>
+        <!--Positions calculated from the wall closer to IP point-->
+        <Constant name="RP_220_Right_Prim_Vert_z" value="608*mm"/>
+        <Constant name="RP_220_Right_Prim_Hor_z" value="1058*mm"/>
+        <Constant name="RP_220_Right_Sec_Hor_z" value="5530*mm"/>
+        <Constant name="RP_220_Right_Sec_Vert_z" value="5980*mm"/>
+        <Constant name="RP_220_Right_Timing_z" value="1680*mm"/>
+        <Constant name="RP_220_Right_Rot_Angle_180" value="180*deg"/>
+        <Constant name="RP_220_Right_Hor_Vac_Length" value="[RP_Device:RP_Device_Envelope_Radius]+[RP_Device:RP_Device_Length_y]/2-[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int]"/>
+    </ConstantsSection>
+
+    <RotationSection label="CTPPS_220_Right_Station.xml">
+        <Rotation name="RP_220_Right_Sec_Rotation_180" 
+            phiX="[RP_220_Right_Rot_Angle_180]" thetaX="90*deg" 
+            phiY="(90*deg+[RP_220_Right_Rot_Angle_180])" thetaY="90*deg"
+            phiZ="0*deg" thetaZ="0*deg"/>
+        <Rotation name="PPS_Timing_rot" phiX="0*deg" thetaX="0*deg" phiY="90*deg" thetaY="90*deg" phiZ="0*deg" thetaZ="270*deg"/>
+    </RotationSection>
+
+    <SolidSection label="CTPPS_220_Right_Station.xml">  
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_Envelope_Radius]*1.1" dz="[RP_220_Right_Station_Length]/2" name="RP_220_Right_Station"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_220_Right_Prim_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2" name="RP_220_Right_Station_Tube_1"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_220_Right_Prim_Hor_z]-[RP_220_Right_Prim_Vert_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_220_Right_Station_Tube_2"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_220_Right_Timing_z]-[RP_220_Right_Prim_Hor_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_220_Right_Station_Tube_3a"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_220_Right_Sec_Hor_z]-[RP_220_Right_Timing_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_220_Right_Station_Tube_3b"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_220_Right_Sec_Vert_z]-[RP_220_Right_Sec_Hor_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_220_Right_Station_Tube_4"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_220_Right_Station_Length]-[RP_220_Right_Sec_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2" name="RP_220_Right_Station_Tube_5"/>
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2" dz="[RP_220_Right_Station_Length]/2" name="RP_220_Right_Station_Vacuum_1"/>
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2" dz="[RP_Device:RP_Device_Envelope_Radius]" name="RP_220_Right_Station_Vert_Vacuum"/>
+        <Tube name="CTPPS_Timing_Negative_Station_Hor_Vacuum" rMin="0*mm" rMax="[CTPPS_Timing_Station_Parameters:Timing_Hole_Diam]/2" dz="[CTPPS_Timing_Station_Parameters:Hor_Vac_Length]/2"/>
+        <UnionSolid name="RP_220_Right_Station_Vacuum_2">
+            <rSolid name="RP_220_Right_Station_Vacuum_1"/>
+            <rSolid name="RP_220_Right_Station_Vert_Vacuum"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_220_Right_Station_Length]/2+[RP_220_Right_Prim_Vert_z])"/>
+        </UnionSolid>
+        <UnionSolid name="RP_220_Right_Station_Vacuum_3">
+            <rSolid name="RP_220_Right_Station_Vacuum_2"/>
+            <rSolid name="RP_220_Right_Station_Vert_Vacuum"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_220_Right_Station_Length]/2+[RP_220_Right_Sec_Vert_z])"/>
+        </UnionSolid>
+       <UnionSolid name="CTPPS_Timing_Negative_Station_Vacuum_3a">
+          <rSolid name="RP_220_Right_Station_Vacuum_3"/>
+          <rSolid name="CTPPS_Timing_Negative_Station_Hor_Vacuum"/>
+          <rRotation name="CTPPS_Diamond_Transformations:y_90_rot"/>
+<!--      <rRotation name="rotations:90YX"/>-->
+<!--      <rRotation name="CTPPS_Diamond_Transformations:y90D"/>-->
+          <Translation x="[CTPPS_Timing_Station_Parameters:Hor_Vac_Length]/2-[CTPPS_Timing_Station_Parameters:Device_Length_y]/2+[CTPPS_Timing_Station_Parameters:Hor_Closed_Wall_Thick_Int]" y="0*mm" z="-(-[RP_220_Right_Station_Length]/2+[RP_220_Right_Timing_z])"/>
+        </UnionSolid>
+        
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2" dz="[RP_220_Right_Hor_Vac_Length]/2" name="RP_220_Right_Station_Hor_Vacuum"/>
+        <UnionSolid name="RP_220_Right_Station_Vacuum_4">
+            <rSolid name="CTPPS_Timing_Negative_Station_Vacuum_3a"/>
+            <rSolid name="RP_220_Right_Station_Hor_Vacuum"/>
+            <rRotation name="RP_Transformations:RP_y_90_rot"/>
+            <Translation x="-(-[RP_220_Right_Hor_Vac_Length]/2+[RP_Device:RP_Device_Length_y]/2-[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int])" y="0*mm" z="-(-[RP_220_Right_Station_Length]/2+[RP_220_Right_Prim_Hor_z])"/>
+        </UnionSolid>
+        <UnionSolid name="RP_220_Right_Station_Vacuum_5">
+            <rSolid name="RP_220_Right_Station_Vacuum_4"/>
+            <rSolid name="RP_220_Right_Station_Hor_Vacuum"/>
+            <rRotation name="RP_Transformations:RP_y_90_rot"/>
+            <Translation x="-(-[RP_220_Right_Hor_Vac_Length]/2+[RP_Device:RP_Device_Length_y]/2-[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int])" y="0*mm" z="-(-[RP_220_Right_Station_Length]/2+[RP_220_Right_Sec_Hor_z])"/>
+        </UnionSolid>
+    </SolidSection>
+    
+    <LogicalPartSection label="CTPPS_220_Right_Station.xml">
+        <LogicalPart name="RP_220_Right_Station">
+            <rSolid name="RP_220_Right_Station"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="RP_220_Right_Station_Tube_1">
+            <rSolid name="RP_220_Right_Station_Tube_1"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_220_Right_Station_Tube_2">
+            <rSolid name="RP_220_Right_Station_Tube_2"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_220_Right_Station_Tube_3a">
+            <rSolid name="RP_220_Right_Station_Tube_3a"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_220_Right_Station_Tube_3b">
+            <rSolid name="RP_220_Right_Station_Tube_3b"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_220_Right_Station_Tube_4">
+            <rSolid name="RP_220_Right_Station_Tube_4"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_220_Right_Station_Tube_5">
+            <rSolid name="RP_220_Right_Station_Tube_5"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_220_Right_Station_Vacuum_5">
+            <rSolid name="RP_220_Right_Station_Vacuum_5"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    
+    <PosPartSection label="CTPPS_220_Right_Station.xml">
+        <PosPart copyNumber="1">
+            <rParent name="RP_220_Right_Station"/>
+            <rChild name="RP_Vertical_Device:RP_Device_Vert_Corp_3"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_220_Right_Station_Length]/2+[RP_220_Right_Prim_Vert_z])"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="RP_220_Right_Station"/>
+            <rChild name="RP_Vertical_Device:RP_Device_Vert_Corp_3"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_220_Right_Station_Length]/2+[RP_220_Right_Sec_Vert_z])"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_220_Right_Station"/>
+            <rChild name="RP_Horizontal_Device:RP_Device_Hor_Corp_3"/>
+            <rRotation name="RP_220_Right_Sec_Rotation_180"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_220_Right_Station_Length]/2+[RP_220_Right_Prim_Hor_z])"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="RP_220_Right_Station"/>
+            <rChild name="RP_Horizontal_Device:RP_Device_Hor_Corp_3"/>
+            <rRotation name="RP_220_Right_Sec_Rotation_180"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_220_Right_Station_Length]/2+[RP_220_Right_Sec_Hor_z])"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="RP_220_Right_Station"/>
+            <rChild name="RP_Horizontal_Device:RP_Device_Hor_Corp_3"/>
+            <rRotation name="RP_220_Right_Sec_Rotation_180"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_220_Right_Station_Length]/2+[RP_220_Right_Timing_z])"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_220_Right_Station"/>
+            <rChild name="RP_220_Right_Station_Tube_1"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_220_Right_Station_Length]/2+([RP_220_Right_Prim_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_220_Right_Station"/>
+            <rChild name="RP_220_Right_Station_Tube_2"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_220_Right_Station_Length]/2+([RP_220_Right_Prim_Vert_z]+[RP_220_Right_Prim_Hor_z])/2)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_220_Right_Station"/>
+            <rChild name="RP_220_Right_Station_Tube_3a"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_220_Right_Station_Length]/2+([RP_220_Right_Prim_Hor_z]+[RP_220_Right_Timing_z])/2)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_220_Right_Station"/>
+            <rChild name="RP_220_Right_Station_Tube_3b"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_220_Right_Station_Length]/2+([RP_220_Right_Timing_z]+[RP_220_Right_Sec_Hor_z])/2)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_220_Right_Station"/>
+            <rChild name="RP_220_Right_Station_Tube_4"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_220_Right_Station_Length]/2+([RP_220_Right_Sec_Hor_z]+[RP_220_Right_Sec_Vert_z])/2)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_220_Right_Station"/>
+            <rChild name="RP_220_Right_Station_Tube_5"/>
+            <Translation x="0*mm" y="0*mm" z="-([RP_220_Right_Station_Length]/2-([RP_220_Right_Station_Length]-[RP_220_Right_Sec_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_220_Right_Station"/>
+            <rChild name="RP_220_Right_Station_Vacuum_5"/>
+            <rRotation name="RP_220_Right_Sec_Rotation_180"/>
+        </PosPart>
+        
+        <PosPart copyNumber="120">
+            <rParent name="RP_220_Right_Station_Vacuum_5"/>
+            <rChild name="RP_Box_120:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_y_180_rot"/>
+            <Translation x="0*mm" y="[RP_Dist_Beam_Cent:RP_220_Right_Det_Dist_0]+[RP_Box:RP_Box_primary_vacuum_y]/2" z="-([RP_220_Right_Prim_Vert_z]-[RP_220_Right_Station_Length]/2)"/>
+        </PosPart>
+        <PosPart copyNumber="121">
+            <rParent name="RP_220_Right_Station_Vacuum_5"/>
+            <rChild name="RP_Box_121:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_180_z_180_y_rot"/>
+            <Translation x="0*mm" y="-[RP_Dist_Beam_Cent:RP_220_Right_Det_Dist_1]-[RP_Box:RP_Box_primary_vacuum_y]/2" z="-([RP_220_Right_Prim_Vert_z]-[RP_220_Right_Station_Length]/2)"/>
+        </PosPart>
+        <PosPart copyNumber="122">
+            <rParent name="RP_220_Right_Station_Vacuum_5"/>
+            <rChild name="RP_Box_122:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_90_z_cw_180_y_rot"/>
+            <Translation x="-(-[RP_Dist_Beam_Cent:RP_220_Right_Det_Dist_2]-[RP_Box:RP_Box_primary_vacuum_y]/2)" y="0*mm" z="-([RP_220_Right_Prim_Hor_z]-[RP_220_Right_Station_Length]/2)"/>
+        </PosPart>
+        <PosPart copyNumber="10123">
+            <rParent name="RP_220_Right_Station_Vacuum_5"/>
+            <rChild name="RP_Box_123:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_90_z_cw_180_y_rot"/>
+            <Translation x="-(-[RP_Dist_Beam_Cent:RP_220_Right_Det_Dist_3]-[RP_Box:RP_Box_primary_vacuum_y]/2)" y="0*mm" z="-([RP_220_Right_Sec_Hor_z]-[RP_220_Right_Station_Length]/2)"/>
+        </PosPart>
+        <PosPart copyNumber="124">
+            <rParent name="RP_220_Right_Station_Vacuum_5"/>
+            <rChild name="RP_Box_124:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_y_180_rot"/>
+            <Translation x="0*mm" y="[RP_Dist_Beam_Cent:RP_220_Right_Det_Dist_4]+[RP_Box:RP_Box_primary_vacuum_y]/2" z="-([RP_220_Right_Sec_Vert_z]-[RP_220_Right_Station_Length]/2)"/>
+        </PosPart>
+        <PosPart copyNumber="125">
+            <rParent name="RP_220_Right_Station_Vacuum_5"/>
+            <rChild name="RP_Box_125:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_180_z_180_y_rot"/>
+            <Translation x="0*mm" y="-[RP_Dist_Beam_Cent:RP_220_Right_Det_Dist_5]-[RP_Box:RP_Box_primary_vacuum_y]/2" z="-([RP_220_Right_Sec_Vert_z]-[RP_220_Right_Station_Length]/2)"/>
+        </PosPart>
+        <PosPart copyNumber="116">
+            <rParent name="RP_220_Right_Station_Vacuum_5"/>
+            <rChild name="CTPPS_Timing_Horizontal_Pot:Primary_Vacuum"/>
+            <rRotation name="rotations:90YX"/>
+            <Translation x="-(-([RP_Dist_Beam_Cent:CTPPS_56_Det_Dist]+[CTPPS_Timing_Horizontal_Pot:plane_length]+[CTPPS_Timing_Horizontal_Pot:cut_depth]+[CTPPS_Timing_Horizontal_Pot:thin_window_thickness])/2)" y="0*cm" z="-(-[RP_220_Right_Station_Length]/2+[RP_220_Right_Timing_z])"/>
+        </PosPart>
+    </PosPartSection>
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/CTPPS_2021/Stations/Simu/v3/CTPPS_Stations_Assembly.xml
+++ b/Geometry/VeryForwardData/data/CTPPS_2021/Stations/Simu/v3/CTPPS_Stations_Assembly.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<DDDefinition>
+    <ConstantsSection label="CTPPS_Stations_Assembly.xml" eval="true">
+        <!--positions of the stations from the IP5 to the first element of the station-->
+        <!--coordinate system is relative to CMS 1 (z>0) and 2 (z<0)-->
+        <Constant name="CTPPS_210_Left_Station_Position_z" value="202769*mm"/>
+        <Constant name="CTPPS_210_Right_Station_Position_z" value="-202769*mm"/>
+        <Constant name="CTPPS_220_Left_Station_Position_z" value="214020*mm"/>
+        <Constant name="CTPPS_220_Right_Station_Position_z" value="-214020*mm"/>
+        <!-- +-1500 mm for the two 220 m stations outside the IP-->
+    </ConstantsSection>
+    
+    <PosPartSection label="CTPPS_Stations_Assembly.xml">
+<!--todo if we remove this the alignment module hangs forever-->
+        <PosPart copyNumber="1">
+            <rParent name="cms:CMSE"/>
+            <rChild name="CTPPS_220_Right_Station:RP_220_Right_Station"/>
+            <Translation x="0*mm" y="0*mm" z="[CTPPS_220_Right_Station_Position_z]-[CTPPS_220_Right_Station:RP_220_Right_Station_Length]/2"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="cms:CMSE"/>
+            <rChild name="CTPPS_220_Left_Station:RP_220_Left_Station"/>
+            <Translation x="0*mm" y="0*mm" z="[CTPPS_220_Left_Station_Position_z]+[CTPPS_220_Left_Station:RP_220_Left_Station_Length]/2"/>
+        </PosPart>
+<!---->
+        <PosPart copyNumber="1">
+            <rParent name="cms:CMSE"/>
+            <rChild name="CTPPS_210_Right_Station:RP_210_Right_Station"/>
+            <Translation x="0*mm" y="0*mm" z="[CTPPS_210_Right_Station_Position_z]-[CTPPS_210_Right_Station:RP_210_Right_Station_Length]/2"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="cms:CMSE"/>
+            <rChild name="CTPPS_210_Left_Station:RP_210_Left_Station"/>
+            <Translation x="0*mm" y="0*mm" z="[CTPPS_210_Left_Station_Position_z]+[CTPPS_210_Left_Station:RP_210_Left_Station_Length]/2"/>
+        </PosPart>
+    </PosPartSection>
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/CTPPS_Diamond_2021/CTPPS_Diamond_Detector_Assembly/v1/CTPPS_Diamond_Detector_Assembly.xml
+++ b/Geometry/VeryForwardData/data/CTPPS_Diamond_2021/CTPPS_Diamond_Detector_Assembly/v1/CTPPS_Diamond_Detector_Assembly.xml
@@ -1,0 +1,69 @@
+<DDDefinition>
+
+  <ConstantsSection label="CTPPS_Diamond_Detector_Assembly.xml" eval="true">
+    <Constant name="Shift_dx" value="[CTPPS_Diamond_Parameters:Plane_dx]/2-([CTPPS_Timing_Horizontal_Pot:plane_length]-[CTPPS_Timing_Horizontal_Pot:bottom_wall_thickness])/2-[CTPPS_Timing_Horizontal_Pot:cut_depth]/2+[CTPPS_Timing_Horizontal_Pot:thin_window_thickness]*2"/>
+    <Constant name="box_dz" value="([CTPPS_Diamond_Parameters:Metalized_thick]*2+[CTPPS_Diamond_Parameters:Diamond_dz]+[CTPPS_Diamond_Parameters:PCB_thick])*4+[CTPPS_Diamond_Parameters:Plane_gap]*3"/>
+    <Constant name="Sensors_Displacement_Foil" value="0.5*mm"/>
+  </ConstantsSection>
+
+  <SolidSection label="CTPPS_Diamond_Detector_Assembly.xml">
+    <!-- Detector Main Box and Planes -->
+    <Box name="CTPPS_Diamond_Main_Box" dx="[CTPPS_Diamond_Parameters:PCB_dx]/2-[Sensors_Displacement_Foil]" dy="[CTPPS_Diamond_Parameters:Plane_dy]/2" dz="[box_dz]/2"/>
+    <Box name="CTPPS_Diamond_Main_Short" dx="[RP_Box:RP_Box_Height]/2-[Sensors_Displacement_Foil]" dy="[CTPPS_Diamond_Parameters:Plane_dy]/2" dz="[box_dz]/2"/> 
+    <Box name="PCB_main" dx="[CTPPS_Diamond_Parameters:PCB_dx]/2" dy="[CTPPS_Diamond_Parameters:PCB_dy]/2" dz="[CTPPS_Diamond_Parameters:PCB_thick]/2"/>
+    <Trd1 name="PCB_extra" dz="[CTPPS_Diamond_Parameters:PCB_extend_dx]/2" dy1="[CTPPS_Diamond_Parameters:PCB_extend_dy1]/2" dy2="[CTPPS_Diamond_Parameters:PCB_extend_dy2]/2" dx1="[CTPPS_Diamond_Parameters:PCB_thick]/2" dx2="[CTPPS_Diamond_Parameters:PCB_thick]/2"/>
+    <UnionSolid name="PCB">
+      <rSolid name="PCB_main"/>
+      <rSolid name="PCB_extra"/>
+      <rRotation name="rotations:90YX"/>
+      <Translation x="-[CTPPS_Diamond_Parameters:PCB_dx]/2-[CTPPS_Diamond_Parameters:PCB_extend_dx]/2" y="0*mm" z="0*mm"/>
+    </UnionSolid>
+  </SolidSection>
+
+  <LogicalPartSection label="CTPPS_Diamond_Detector_Assembly.xml">
+    <!-- ****** Detector Box and Downstream Plane ****** -->
+    <LogicalPart name="CTPPS_Diamond_Main_Box" category="envelope">
+      <rSolid name="CTPPS_Diamond_Main_Box"/>
+      <rMaterial name="materials:Vacuum"/>
+    </LogicalPart>
+    <LogicalPart name="CTPPS_Diamond_Main_Short" category="envelope">
+      <rSolid name="CTPPS_Diamond_Main_Short"/>
+      <rMaterial name="materials:Vacuum"/>
+    </LogicalPart>
+    <LogicalPart name="PCB" category="support">
+      <rSolid name="PCB"/>
+      <rMaterial name="RP_Materials:PPS_PCB"/> <!--should be equivalent to actual RO4350B-->
+    </LogicalPart>
+  </LogicalPartSection>
+
+  <PosPartSection label="CTPPS_Diamond_Detector_Assembly.xml">
+    <PosPart copyNumber="1">
+      <rParent name="CTPPS_Timing_Horizontal_Pot:Primary_Vacuum"/>
+      <rChild name="CTPPS_Diamond_Main_Box"/>
+      <Translation x="0*cm" y="0*cm" z="[Sensors_Displacement_Foil]"/>
+      <rRotation name="CTPPS_Diamond_Transformations:planes_box_rotation"/>
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="CTPPS_Diamond_Main_Box"/>
+      <rChild name="CTPPS_Diamond_Plane1:CTPPS_Diamond_Plane"/>
+      <Translation y="0*cm" x="[Shift_dx]" z="-([CTPPS_Diamond_Parameters:Plane_dz]+[CTPPS_Diamond_Parameters:Plane_gap])*3/2"/>
+    </PosPart>
+    <PosPart copyNumber="2">
+      <rParent name="CTPPS_Diamond_Main_Box"/>
+      <rChild name="CTPPS_Diamond_Plane2:CTPPS_Diamond_Plane"/>
+      <Translation y="0*cm" x="[Shift_dx]" z="-([CTPPS_Diamond_Parameters:Plane_dz]+[CTPPS_Diamond_Parameters:Plane_gap])/2"/>
+    </PosPart>
+    <PosPart copyNumber="3">
+      <rParent name="CTPPS_Diamond_Main_Box"/>
+      <rChild name="CTPPS_Diamond_Plane3:CTPPS_Diamond_Plane"/>
+      <Translation y="0*cm" x="[Shift_dx]" z="([CTPPS_Diamond_Parameters:Plane_dz]+[CTPPS_Diamond_Parameters:Plane_gap])/2"/>
+      <rRotation name="CTPPS_Diamond_Transformations:planes_x_rotation"/>
+    </PosPart>
+    <PosPart copyNumber="4">
+      <rParent name="CTPPS_Diamond_Main_Box"/>
+      <rChild name="CTPPS_Diamond_Plane4:CTPPS_Diamond_Plane"/>
+      <Translation y="0*cm" x="[Shift_dx]" z="([CTPPS_Diamond_Parameters:Plane_dz]+[CTPPS_Diamond_Parameters:Plane_gap])*3/2"/>
+    </PosPart>
+  </PosPartSection>
+
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Modules/v2/PPS_Pixel_Module_2x2_Run3.xml
+++ b/Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Modules/v2/PPS_Pixel_Module_2x2_Run3.xml
@@ -1,0 +1,230 @@
+<?xml version="1.0"?>
+<DDDefinition>
+
+<!--
+PPS Tracker module 2x2 for Run3
+
+Author: F.Ferro - INFN Genova
+
+-->
+
+<ConstantsSection label="PPS_Pixel_Module_2x2_Run3.xml" eval="true">
+
+<Constant name="ROChipL"            value="7.87*mm"/>    <!-- Readout chip length -->
+<Constant name="ROChipW"            value="10.557*mm"/>     <!-- Readout chip width -->
+<Constant name="ROChipT"            value="0.180*mm"/>    <!-- Readout chip thickness -->
+<Constant name="ROChipSpaceL"       value="0.23*mm"/>    <!-- Distance (along width) between adjacent chips -->
+<Constant name="ROChipSpaceW"       value="0.22*mm"/>    <!-- Distance (along length) between  adjacent chips -->
+
+<!-- https://istnazfisnucl-my.sharepoint.com/:b:/g/personal/fferro_infn_it/EZaGp04OlqRJm-IUy-UrkPcB6s8Q0eMGOGbIL6R-buTlsQ?e=b7t9oS -->
+<Constant name="AlSupportUshapeL" value="25.5*mm" />   <!-- height of the U shaped Aluminium support 1mm thick -->
+<Constant name="AlSupportUshapeW" value="50.0*mm" />   <!-- width of the U shaped Aluminium support 1mm thick -->
+<Constant name="AlSupportUshapeT" value="1.0*mm" />    <!-- thickness of the U shaped Aluminium support -->
+
+
+<Constant name="AlSupportThinWindowL" value="18.3*mm" />   <!-- height of the thin Aluminium support 0.5mm thick -->
+<Constant name="AlSupportThinWindowW" value="21.6*mm" />   <!-- width of the thin Aluminium support 0.5mm thick -->
+<Constant name="AlSupportThinWindowOffsetL" value="3.5*mm" />   <!-- overhang of the thin Aluminium support 0.5mm thick wrt to the U shape -->
+<Constant name="AlSupportThinWindowT" value="0.5*mm" />   <!-- width of the thin Aluminium support -->
+<Constant name="AlSupportUshapeTopCenterL" value="[AlSupportUshapeL]+[AlSupportThinWindowOffsetL]-[AlSupportThinWindowL]" />   <!-- height of the U shaped Aluminium support 1mm thick - Central Top part -->
+<Constant name="AlSupportUshapeSideW" value="[AlSupportUshapeW]/2.-[AlSupportThinWindowW]/2." />   <!-- Width of the U shaped Aluminium support 1mm thick - Left and Right wings -->
+
+<Constant name="FlexL" value="[AlSupportUshapeL]+[AlSupportThinWindowOffsetL]+0.17*mm" />  <!-- height of the Flex circuit (only the part in the envelop of the module) -->
+<Constant name="FlexW" value="16.65*mm" />    <!-- width of the Flex circuit - LIKE THE SENSOR? -->
+<Constant name="FlexT" value="0.445*mm" />   <!-- thickness of the Flex circuit -->
+
+<Constant name="WaferL" value="16.200*mm" />   <!-- height of the sensor -->
+<Constant name="WaferW" value="16.65*mm" />   <!-- width of the sensor -->
+<Constant name="WaferT" value="0.220*mm" />   <!-- thickness of the sensor -->
+
+<Constant name="EnvelopL" value="[FlexL]"/>
+<Constant name="EnvelopW" value="[AlSupportUshapeW]"/>    
+<Constant name="EnvelopT" value="[FlexT]+[WaferT]+[ROChipT]+2*[GlueT]"/>    
+<Constant name="EnvelopToBeSubtractedL" value="[AlSupportThinWindowOffsetL]"/>
+<Constant name="EnvelopToBeSubtractedW" value="[AlSupportUshapeW]/2. - [AlSupportThinWindowW]/2."/>    
+
+<Constant name="ThinWindowRailW" value="2.5*mm" />
+
+<Constant name="GlueT" value="0.050*mm" />   <!-- thickness of the glue -->
+<Constant name="GlueOnWaferL" value="16.200*mm" />   <!-- height of the glue on sensor -->
+<Constant name="GlueOnWaferW" value="16.65*mm" />   <!-- width of the glue on sensor -->
+<Constant name="GlueOnROCsL" value="2*[ROChipL]+[ROChipSpaceL]" />
+
+<!-- Al Support window WITH ONLY LATERAL RAILS -->
+<Constant name="GlueOnROCsL" value="2*[ROChipL]+[ROChipSpaceL]" />
+<Constant name="GlueOnROCsW" value="[ThinWindowRailW] - [AlSupportThinWindowW]/2. + [ROChipW] + [ROChipSpaceW]/2." />
+
+</ConstantsSection>
+
+
+
+<SolidSection label="PPS_Pixel_Module_2x2_Run3.xml">
+
+<Box name="EnvelopBeforeSubtraction"              dx="[EnvelopW]/2."   dy="[EnvelopL]/2."    dz="[EnvelopT]/2." /> 
+<Box name="EnvelopToBeSubtracted"              dx="[EnvelopToBeSubtractedW]/2."   dy="[EnvelopToBeSubtractedL]/2."    dz="[EnvelopT]/2." /> 
+
+<Box name="AlSupportUshapeTopCenter" dx="[AlSupportThinWindowW]/2." dy="[AlSupportUshapeTopCenterL]/2." dz="[AlSupportUshapeT]/2." />
+<Box name="AlSupportUshapeLeftSide" dx="[AlSupportUshapeSideW]/2." dy="[AlSupportUshapeL]/2." dz="[AlSupportUshapeT]/2." />
+<Box name="AlSupportUshapeRightSide" dx="[AlSupportUshapeSideW]/2." dy="[AlSupportUshapeL]/2." dz="[AlSupportUshapeT]/2." />
+<Box name="AlSupportThinWindow" dx="[AlSupportThinWindowW]/2." dy="[AlSupportThinWindowL]/2." dz="[AlSupportThinWindowT]/2." />
+<Box name="AlSupportThinWindowRail" dx="[ThinWindowRailW]/2." dy="[AlSupportThinWindowL]/2." dz="[AlSupportThinWindowT]/2." />
+
+
+<UnionSolid name="AlSupportUshapeCenterLeft">
+<rSolid name="AlSupportUshapeTopCenter"/>
+<rSolid name="AlSupportUshapeLeftSide"/>
+<Translation x="-[AlSupportThinWindowW]/2.-[AlSupportUshapeSideW]/2." y="[AlSupportUshapeTopCenterL]/2.-[AlSupportUshapeL]/2." z="0."/>
+</UnionSolid>
+<UnionSolid name="AlSupportUshape">
+<rSolid name="AlSupportUshapeCenterLeft"/>
+<rSolid name="AlSupportUshapeRightSide"/>
+<Translation x="[AlSupportThinWindowW]/2.+[AlSupportUshapeSideW]/2." y="[AlSupportUshapeTopCenterL]/2.-[AlSupportUshapeL]/2." z="0."/>
+</UnionSolid>
+
+<!-- Al Support window WITH ONLY LATERAL RAILS -->
+<UnionSolid name="AlSupportWithLeftRail">
+<rSolid name="AlSupportUshape"/>
+<rSolid name="AlSupportThinWindowRail"/> 
+<Translation x="-[AlSupportThinWindowW]/2.+[ThinWindowRailW]/2." y="-[AlSupportUshapeTopCenterL]/2.-[AlSupportThinWindowL]/2." z="-[AlSupportUshapeT]/2.+[AlSupportThinWindowT]/2."/>
+</UnionSolid>
+<UnionSolid name="AlSupport">
+<rSolid name="AlSupportWithLeftRail"/>
+<rSolid name="AlSupportThinWindowRail"/> 
+<Translation x="[AlSupportThinWindowW]/2.-[ThinWindowRailW]/2." y="-[AlSupportUshapeTopCenterL]/2.-[AlSupportThinWindowL]/2." z="-[AlSupportUshapeT]/2.+[AlSupportThinWindowT]/2."/>
+</UnionSolid>
+
+
+
+
+<Box name="RPixWafer2x2"              dx="[WaferW]/2."   dy="[WaferL]/2."    dz="[WaferT]/2." /> 
+<Box name="GlueOnWafer"              dx="[GlueOnWaferW]/2."   dy="[GlueOnWaferL]/2."    dz="[GlueT]/2." /> 
+<Box name="Flex"              dx="[FlexW]/2."   dy="[FlexL]/2."    dz="[FlexT]/2." /> 
+<Box name="GlueOnROCs"              dx="[GlueOnROCsW]/2."   dy="[GlueOnROCsL]/2."    dz="[GlueT]/2." /> 
+<Box name="ROChip"              dx="[ROChipW]/2."   dy="[ROChipL]/2."    dz="[ROChipT]/2." /> 
+
+<SubtractionSolid name="EnvelopTemp">
+  <rSolid name="EnvelopBeforeSubtraction" />
+  <rSolid name="EnvelopToBeSubtracted" />
+  <Translation x="-[AlSupportUshapeW]/2. + [EnvelopToBeSubtractedW]/2." y="-[EnvelopL]/2. + [AlSupportThinWindowOffsetL]/2." z="0.0*mm" />
+	     <!-- removing the bottom left corner of the box envelop -->
+</SubtractionSolid>
+<SubtractionSolid name="Envelop">
+  <rSolid name="EnvelopTemp" />
+  <rSolid name="EnvelopToBeSubtracted" />
+  <Translation x="[AlSupportUshapeW]/2. - [EnvelopToBeSubtractedW]/2." y="-[EnvelopL]/2. + [AlSupportThinWindowOffsetL]/2." z="0.0*mm" />
+	     <!-- removing the bottom right corner of the box envelop -->
+</SubtractionSolid>
+
+
+
+</SolidSection>
+
+
+<LogicalPartSection label="PPS_Pixel_Module_2x2_Run3.xml">
+
+ <LogicalPart name="Envelop" category="unspecified">
+  <rSolid name="Envelop"/>
+  <rMaterial name="materials:Vacuum" />
+ </LogicalPart>
+
+ <LogicalPart name="RPixWafer2x2" category="unspecified">
+  <rSolid name="RPixWafer2x2"/>
+  <rMaterial name="materials:Silicon"/>
+ </LogicalPart>
+
+
+<LogicalPart name="ROChip" category="unspecified">
+  <rSolid name="ROChip"/>
+  <rMaterial name="pixfwdMaterials:Pix_Fwd_ROChip"/>
+ </LogicalPart>
+
+<LogicalPart name="GlueOnROCs" category="unspecified">
+  <rSolid name="GlueOnROCs"/>
+  <rMaterial name="pixfwdMaterials:FPix_Thermflow"/>
+ </LogicalPart>
+
+<LogicalPart name="GlueOnWafer" category="unspecified">
+  <rSolid name="GlueOnWafer"/>
+  <rMaterial name="pixfwdMaterials:FPix_Thermflow"/>
+ </LogicalPart>
+
+<LogicalPart name="Flex" category="unspecified">
+  <rSolid name="Flex"/>
+  <rMaterial name="pixfwdMaterials:Pix_Fwd_HDI"/> 
+ </LogicalPart>
+
+<LogicalPart name="AlSupport" category="unspecified">
+  <rSolid name="AlSupport"/>
+  <rMaterial name="materials:Aluminium"/> 
+ </LogicalPart>
+
+</LogicalPartSection>
+
+
+<PosPartSection label="PPS_Pixel_Module_2x2_Run3.xml">
+
+<PosPart copyNumber="1">
+  <rParent name="PPS_Pixel_Module_2x2_Run3:Envelop"/>
+  <rChild name="PPS_Pixel_Module_2x2_Run3:Flex"/>
+  <Translation x="0" y="0"  z="[EnvelopT]/2.-[FlexT]/2." />
+ </PosPart>
+
+<PosPart copyNumber="1">
+  <rParent name="PPS_Pixel_Module_2x2_Run3:Envelop"/>
+  <rChild name="PPS_Pixel_Module_2x2_Run3:GlueOnWafer"/>
+  <Translation x="0" y="-[EnvelopL]/2.+[GlueOnWaferL]/2."  z="[EnvelopT]/2.-[FlexT]-[GlueT]/2." />
+ </PosPart>
+
+<PosPart copyNumber="1">
+  <rParent name="PPS_Pixel_Module_2x2_Run3:Envelop"/>
+  <rChild name="PPS_Pixel_Module_2x2_Run3:RPixWafer2x2"/>
+  <Translation x="0" y="-[EnvelopL]/2.+[WaferL]/2."  z="[EnvelopT]/2.-[FlexT]-[GlueT]-[WaferT]/2." />
+ </PosPart>
+
+<PosPart copyNumber="1">
+  <rParent name="PPS_Pixel_Module_2x2_Run3:Envelop"/>
+  <rChild name="PPS_Pixel_Module_2x2_Run3:ROChip"/>
+  <Translation x="-[ROChipW]/2.-[ROChipSpaceW]/2." y="-[EnvelopL]/2.+[ROChipL]/2.+0.17*mm"  z="[EnvelopT]/2.-[FlexT]-[GlueT]-[WaferT]-[ROChipT]/2." />
+ </PosPart>
+<PosPart copyNumber="2">
+  <rParent name="PPS_Pixel_Module_2x2_Run3:Envelop"/>
+  <rChild name="PPS_Pixel_Module_2x2_Run3:ROChip"/>
+  <Translation x="[ROChipW]/2.+[ROChipSpaceW]/2." y="-[EnvelopL]/2.+[ROChipL]/2.+0.17*mm"  z="[EnvelopT]/2.-[FlexT]-[GlueT]-[WaferT]-[ROChipT]/2." />
+ </PosPart>
+<PosPart copyNumber="3">
+  <rParent name="PPS_Pixel_Module_2x2_Run3:Envelop"/>
+  <rChild name="PPS_Pixel_Module_2x2_Run3:ROChip"/>
+  <Translation x="-[ROChipW]/2.-[ROChipSpaceW]/2." y="-[EnvelopL]/2.+3*[ROChipL]/2.+[ROChipSpaceL]+0.17*mm"  z="[EnvelopT]/2.-[FlexT]-[GlueT]-[WaferT]-[ROChipT]/2." />
+ </PosPart>
+<PosPart copyNumber="4">
+  <rParent name="PPS_Pixel_Module_2x2_Run3:Envelop"/>
+  <rChild name="PPS_Pixel_Module_2x2_Run3:ROChip"/>
+  <Translation x="+[ROChipW]/2.+[ROChipSpaceW]/2." y="-[EnvelopL]/2.+3*[ROChipL]/2.+[ROChipSpaceL]+0.17*mm"  z="[EnvelopT]/2.-[FlexT]-[GlueT]-[WaferT]-[ROChipT]/2." />
+ </PosPart>
+
+<!-- Al Support window WITH ONLY LATERAL RAILS -->
+<PosPart copyNumber="1">
+  <rParent name="PPS_Pixel_Module_2x2_Run3:Envelop"/>
+  <rChild name="PPS_Pixel_Module_2x2_Run3:GlueOnROCs"/>
+  <Translation x="-[ROChipW]-[ROChipSpaceW]/2.+[GlueOnROCsW]/2." y="-[EnvelopL]/2.+[GlueOnROCsL]/2. + 0.17*mm"  z="[EnvelopT]/2.-[FlexT]-[GlueT]-[WaferT]-[ROChipT]-[GlueT]/2." />
+ </PosPart>
+<PosPart copyNumber="2">
+  <rParent name="PPS_Pixel_Module_2x2_Run3:Envelop"/>
+  <rChild name="PPS_Pixel_Module_2x2_Run3:GlueOnROCs"/>
+  <Translation x="[ROChipW]+[ROChipSpaceW]/2.-[GlueOnROCsW]/2." y="-[EnvelopL]/2.+[GlueOnROCsL]/2. + 0.17*mm"  z="[EnvelopT]/2.-[FlexT]-[GlueT]-[WaferT]-[ROChipT]-[GlueT]/2." />
+ </PosPart>
+
+
+
+
+<PosPart copyNumber="1">
+  <rParent name="PPS_Pixel_Module_2x2_Run3:Envelop"/>
+  <rChild name="PPS_Pixel_Module_2x2_Run3:AlSupport"/>
+  <Translation x="0" y="[EnvelopL]/2.-[AlSupportUshapeTopCenterL]/2."  z="[EnvelopT]/2.-[FlexT]-[AlSupportUshapeT]/2." /> 
+ </PosPart>
+
+
+</PosPartSection>
+
+
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Modules/v2/PPS_Pixel_Sens.xml
+++ b/Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Modules/v2/PPS_Pixel_Sens.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<DDDefinition>
+	<SpecParSection label="PPS_Pixel_Sens.xml">
+		<SpecPar name="ROUHitsCTPPSPixel">
+			<PartSelector path="//.*:RPixWafer2x2"/>
+			<Parameter name="SensitiveDetector" value="CTPPSSensitiveDetector" eval="false"/>
+			<Parameter name="ReadOutName" value="CTPPSPixelHits" eval="false"/>
+		</SpecPar>
+	</SpecParSection>
+	<SpecParSection label="CTPPSPixelProdCuts.xml" eval="true">
+		<SpecPar name="CTPPSPixelAllPart">
+			<PartSelector path="//.*:Envelop"/>
+			<Parameter name="CMSCutsRegion" value="CTPPSPixelRegion" eval="false"/>
+			<Parameter name="ProdCutsForElectrons" value="1*mm"/>
+			<Parameter name="ProdCutsForPositrons" value="1*mm"/>
+			<Parameter name="ProdCutsForGamma" value="1*mm"/>
+		</SpecPar>
+		<SpecPar name="CTPPSPixelSensitivePart">
+			<PartSelector path="//.*:RPixWafer2x2"/>
+			<Parameter name="CMSCutsRegion" value="CTPPSPixelSensitiveRegion" eval="false"/>
+			<Parameter name="ProdCutsForElectrons" value="0.01*mm"/>
+			<Parameter name="ProdCutsForPositrons" value="0.01*mm"/>
+			<Parameter name="ProdCutsForGamma" value="0.01*mm"/>
+		</SpecPar>
+	</SpecParSection>
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Modules/v2/ppstrackerMaterials.xml
+++ b/Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Modules/v2/ppstrackerMaterials.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0"?>
+<DDDefinition>
+  
+
+<MaterialSection label="ppstrackerMaterials.xml">
+
+  <CompositeMaterial name="PPS_FPix_Thermflow" density="0.7625*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.3787448">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.21575329">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.3239468">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.08155498">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="PPS_FPix_TPG" density="2.47*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="PPS_FPix_CFSkin" density="3.43511*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="PPS_Pix_Fwd_Bump" density="0.41391*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="1.00">
+      <rMaterial name="ppstrackerMaterials:PPS_FPix_TinLeadSolder"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="PPS_Pix_Fwd_ROChip" density="2.15758*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="1">
+      <rMaterial name="materials:Silicon"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="PPS_Pix_Fwd_HDI" density="1.90587*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.3718">
+      <rMaterial name="ppstrackerMaterials:PPS_FPix_Kapton"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.13869">
+      <rMaterial name="ppstrackerMaterials:PPS_FPix_Epoxy"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.42221">
+      <rMaterial name="materials:Copper"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.00315">
+      <rMaterial name="materials:Barium_Titanate"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.00240">
+      <rMaterial name="ppstrackerMaterials:PPS_FPix_Alumina"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.04968">
+      <rMaterial name="ppstrackerMaterials:PPS_FPix_TinLeadSolder"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.01206">
+      <rMaterial name="materials:Indium"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+ 
+  <CompositeMaterial name="PPS_FPix_TinLeadSolder" density="8.8*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.49377422">
+      <rMaterial name="materials:Tin"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.50622577">
+      <rMaterial name="materials:Lead"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="PPS_FPix_Alumina" density="3.96*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.52924272">
+      <rMaterial name="materials:Aluminium"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.47075728">
+      <rMaterial name="materials:Oxygen"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="PPS_FPix_Epoxy" density="1.1*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.7367217">
+      <rMaterial name="materials:Carbon"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.0529922">
+      <rMaterial name="materials:Hydrogen"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.21028601">
+      <rMaterial name="materials:Oxygen"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+ <CompositeMaterial name="PPS_FPix_Kapton" density="1.4*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.6911352">
+      <rMaterial name="materials:Carbon"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.026363">
+      <rMaterial name="materials:Hydrogen"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.20923002">
+      <rMaterial name="materials:Oxygen"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.0732717">
+      <rMaterial name="materials:Nitrogen"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+</MaterialSection>
+
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/CTPPS_Timing_Horizontal_Pot/v2/CTPPS_Timing_Horizontal_Pot.xml
+++ b/Geometry/VeryForwardData/data/CTPPS_Timing_Horizontal_Pot/v2/CTPPS_Timing_Horizontal_Pot.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition>
+
+  <ConstantsSection label="CTPPS_Timing_Horizontal_Pot.xml" eval="true">
+    <Constant name="inner_diameter" value="141*mm"/>
+    <Constant name="plane_length" value="135*mm"/>
+    <Constant name="cut_width" value="16.57*mm"/>
+    <Constant name="cut_depth" value="1.7*mm"/>
+    <Constant name="thin_window_thickness" value="0.2*mm"/>
+    <Constant name="bottom_wall_thickness" value="[thin_window_thickness]+[cut_depth]"/>
+    <Constant name="external_wall_thickness" value="1*mm"/>
+  </ConstantsSection>
+
+  <SolidSection label="CTPPS_Timing_Horizontal_Pot.xml">
+    <Tubs name="Primary_Vacuum_nocut" rMin="0*mm" rMax="[inner_diameter]/2+[external_wall_thickness]" dz="[plane_length]/2" startPhi="0*deg" deltaPhi="360*deg"/>
+    <Tubs name="Bottom_Wall_nocut" rMin="0*mm" rMax="[inner_diameter]/2" dz="([bottom_wall_thickness])/2" startPhi="0*deg" deltaPhi="360*deg"/>
+    <Tubs name="External_Wall" rMin="[inner_diameter]/2" rMax="[inner_diameter]/2+[external_wall_thickness]" dz="[plane_length]/2" startPhi="0*deg" deltaPhi="360*deg"/>
+    <Trd1 name="Window_Cut" dz="[cut_depth]/2" dy2="[cut_width]/2+[cut_depth]" dy1="[cut_width]/2" dx1="[inner_diameter]/2" dx2="[inner_diameter]/2"/>
+    <UnionSolid name="Primary_Vacuum">
+      <rSolid name="Primary_Vacuum_nocut"/>
+      <rSolid name="Window_Cut"/>
+      <Translation x="0*mm" y="0*mm" z="-([plane_length]+[cut_depth])/2"/>
+    </UnionSolid>
+    <SubtractionSolid name="Bottom_Wall">
+      <rSolid name="Bottom_Wall_nocut"/>
+      <rSolid name="Window_Cut"/>
+      <Translation x="0*mm" y="0*mm" z="[bottom_wall_thickness]/2-[cut_depth]/2"/>
+    </SubtractionSolid>
+  </SolidSection>
+
+  <LogicalPartSection label="CTPPS_Timing_Horizontal_Pot.xml">
+    <LogicalPart name="Primary_Vacuum">
+      <rSolid name="Primary_Vacuum"/>
+      <rMaterial name="materials:Vacuum"/>
+    </LogicalPart>
+    <LogicalPart name="External_Wall">
+      <rSolid name="External_Wall"/>
+      <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+    </LogicalPart>
+    <LogicalPart name="Bottom_Wall">
+      <rSolid name="Bottom_Wall"/>
+      <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+    </LogicalPart>
+  </LogicalPartSection>
+
+  <PosPartSection label="CTPPS_Timing_Horizontal_Pot.xml">
+    <PosPart copyNumber="1">
+      <rParent name="Primary_Vacuum"/>
+      <rChild name="External_Wall"/>
+      <Translation x="0*cm" y="0*mm" z="0*mm"/>
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="Primary_Vacuum"/>
+      <rChild name="Bottom_Wall"/>
+      <Translation x="0*cm" y="0*mm" z="-[plane_length]/2+[bottom_wall_thickness]/2"/>
+    </PosPart>
+  </PosPartSection>
+
+</DDDefinition>
+

--- a/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_000.xml
+++ b/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_000.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition>
+    
+    <SolidSection label="RP_Box_000.xml">
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_primary_vacuum_y]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_box_primary_vacuum"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_bottom_foil_base"/>
+        <Box dx="[RP_Box:RP_Box_Window_Bottom_Width]/2" dy="[RP_Box:RP_Box_Foil_Thickness]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Front_Thin_Wall_Thickness]" name="RP_bot_foil_front_cut"/>
+        <SubtractionSolid name="RP_bottom_foil_1">
+            <rSolid name="RP_bottom_foil_base"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+        </SubtractionSolid>
+         <SubtractionSolid name="RP_bottom_foil">
+             <rSolid name="RP_bottom_foil_1"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+         </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" name="RP_bot_hole_x"/>
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]+0.01*mm" name="RP_bot_hole_z"/>
+        <Tubs rMin="0*mm" rMax="2*mm" dz="[RP_Box:RP_Box_Bottom_Wall_Thickness]" startPhi="0*deg" deltaPhi="360*deg" name="RP_bot_hole_corner"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_bottom_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_primary_vacuum_y]/2-[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_box_secondary_vacuum"/>
+        <SubtractionSolid name="RP_bottom_wall_2a">
+            <rSolid name="RP_bottom_wall_1"/>
+            <rSolid name="RP_bot_hole_x"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_2">
+            <rSolid name="RP_bottom_wall_2a"/>
+            <rSolid name="RP_bot_hole_z"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_3">
+            <rSolid name="RP_bottom_wall_2"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_4">
+            <rSolid name="RP_bottom_wall_3"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_5">
+            <rSolid name="RP_bottom_wall_4"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_5"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RP_front_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_Window_Size]/2" dy="[RP_Box:RP_Box_Window_Size]/2-[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Rect"/>
+        <Tube rMin="0*mm" rMax="[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Curv"/>
+        <SubtractionSolid name="RP_front_wall_2">
+            <rSolid name="RP_front_wall_1"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_45_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_3">
+            <rSolid name="RP_front_wall_2"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_135_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_4">
+            <rSolid name="RP_front_wall_3"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]+([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_5">
+            <rSolid name="RP_front_wall_4"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="-([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_5"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <Box dx="[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2" name="RP_Left_Right_Wall"/>
+    </SolidSection>
+    
+    <LogicalPartSection label="RP_Box_000.xml">
+        <LogicalPart name="RP_box_primary_vacuum">
+            <rSolid name="RP_box_primary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        <LogicalPart name="RP_box_secondary_vacuum">
+            <rSolid name="RP_box_secondary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_foil">
+            <rSolid name="RP_bottom_foil"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_Left_Right_Wall">
+            <rSolid name="RP_Left_Right_Wall"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+    </LogicalPartSection>
+    
+    <PosPartSection label="RP_Box_000.xml">
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_bottom_foil"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_box_secondary_vacuum"/>
+            <Translation x="0*mm" y="[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_secondary_vacuum"/>
+            <rChild name="RP_bottom_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Secondary_Vacuum_Height]/2+[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <rRotation name="RP_Transformations:RP_y_180_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="-[RP_Box:RP_Box_primary_vacuum_z]/2+[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="-[RP_Box:RP_Box_primary_vacuum_x]/2+[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+    </PosPartSection>
+   
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_001.xml
+++ b/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_001.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition>
+    
+    <SolidSection label="RP_Box_001.xml">
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_primary_vacuum_y]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_box_primary_vacuum"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_bottom_foil_base"/>
+        <Box dx="[RP_Box:RP_Box_Window_Bottom_Width]/2" dy="[RP_Box:RP_Box_Foil_Thickness]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Front_Thin_Wall_Thickness]" name="RP_bot_foil_front_cut"/>
+        <SubtractionSolid name="RP_bottom_foil_1">
+            <rSolid name="RP_bottom_foil_base"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+        </SubtractionSolid>
+         <SubtractionSolid name="RP_bottom_foil">
+             <rSolid name="RP_bottom_foil_1"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+         </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" name="RP_bot_hole_x"/>
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]+0.01*mm" name="RP_bot_hole_z"/>
+        <Tubs rMin="0*mm" rMax="2*mm" dz="[RP_Box:RP_Box_Bottom_Wall_Thickness]" startPhi="0*deg" deltaPhi="360*deg" name="RP_bot_hole_corner"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_bottom_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_primary_vacuum_y]/2-[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_box_secondary_vacuum"/>
+        <SubtractionSolid name="RP_bottom_wall_2a">
+            <rSolid name="RP_bottom_wall_1"/>
+            <rSolid name="RP_bot_hole_x"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_2">
+            <rSolid name="RP_bottom_wall_2a"/>
+            <rSolid name="RP_bot_hole_z"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_3">
+            <rSolid name="RP_bottom_wall_2"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_4">
+            <rSolid name="RP_bottom_wall_3"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_5">
+            <rSolid name="RP_bottom_wall_4"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_5"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RP_front_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_Window_Size]/2" dy="[RP_Box:RP_Box_Window_Size]/2-[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Rect"/>
+        <Tube rMin="0*mm" rMax="[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Curv"/>
+        <SubtractionSolid name="RP_front_wall_2">
+            <rSolid name="RP_front_wall_1"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_45_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_3">
+            <rSolid name="RP_front_wall_2"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_135_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_4">
+            <rSolid name="RP_front_wall_3"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]+([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_5">
+            <rSolid name="RP_front_wall_4"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="-([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_5"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <Box dx="[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2" name="RP_Left_Right_Wall"/>
+    </SolidSection>
+    
+    <LogicalPartSection label="RP_Box_001.xml">
+        <LogicalPart name="RP_box_primary_vacuum">
+            <rSolid name="RP_box_primary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        <LogicalPart name="RP_box_secondary_vacuum">
+            <rSolid name="RP_box_secondary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_foil">
+            <rSolid name="RP_bottom_foil"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_Left_Right_Wall">
+            <rSolid name="RP_Left_Right_Wall"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+    </LogicalPartSection>
+    
+    <PosPartSection label="RP_Box_001.xml">
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_bottom_foil"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_box_secondary_vacuum"/>
+            <Translation x="0*mm" y="[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_secondary_vacuum"/>
+            <rChild name="RP_bottom_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Secondary_Vacuum_Height]/2+[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <rRotation name="RP_Transformations:RP_y_180_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="-[RP_Box:RP_Box_primary_vacuum_z]/2+[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="-[RP_Box:RP_Box_primary_vacuum_x]/2+[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+    </PosPartSection>
+   
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_002.xml
+++ b/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_002.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition>
+    
+    <SolidSection label="RP_Box_002.xml">
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_primary_vacuum_y]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_box_primary_vacuum"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_bottom_foil_base"/>
+        <Box dx="[RP_Box:RP_Box_Window_Bottom_Width]/2" dy="[RP_Box:RP_Box_Foil_Thickness]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Front_Thin_Wall_Thickness]" name="RP_bot_foil_front_cut"/>
+        <SubtractionSolid name="RP_bottom_foil_1">
+            <rSolid name="RP_bottom_foil_base"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+        </SubtractionSolid>
+         <SubtractionSolid name="RP_bottom_foil">
+             <rSolid name="RP_bottom_foil_1"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+         </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" name="RP_bot_hole_x"/>
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]+0.01*mm" name="RP_bot_hole_z"/>
+        <Tubs rMin="0*mm" rMax="2*mm" dz="[RP_Box:RP_Box_Bottom_Wall_Thickness]" startPhi="0*deg" deltaPhi="360*deg" name="RP_bot_hole_corner"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_bottom_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_primary_vacuum_y]/2-[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_box_secondary_vacuum"/>
+        <SubtractionSolid name="RP_bottom_wall_2a">
+            <rSolid name="RP_bottom_wall_1"/>
+            <rSolid name="RP_bot_hole_x"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_2">
+            <rSolid name="RP_bottom_wall_2a"/>
+            <rSolid name="RP_bot_hole_z"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_3">
+            <rSolid name="RP_bottom_wall_2"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_4">
+            <rSolid name="RP_bottom_wall_3"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_5">
+            <rSolid name="RP_bottom_wall_4"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_5"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RP_front_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_Window_Size]/2" dy="[RP_Box:RP_Box_Window_Size]/2-[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Rect"/>
+        <Tube rMin="0*mm" rMax="[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Curv"/>
+        <SubtractionSolid name="RP_front_wall_2">
+            <rSolid name="RP_front_wall_1"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_45_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_3">
+            <rSolid name="RP_front_wall_2"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_135_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_4">
+            <rSolid name="RP_front_wall_3"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]+([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_5">
+            <rSolid name="RP_front_wall_4"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="-([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_5"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <Box dx="[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2" name="RP_Left_Right_Wall"/>
+    </SolidSection>
+    
+    <LogicalPartSection label="RP_Box_002.xml">
+        <LogicalPart name="RP_box_primary_vacuum">
+            <rSolid name="RP_box_primary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        <LogicalPart name="RP_box_secondary_vacuum">
+            <rSolid name="RP_box_secondary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_foil">
+            <rSolid name="RP_bottom_foil"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_Left_Right_Wall">
+            <rSolid name="RP_Left_Right_Wall"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+    </LogicalPartSection>
+    
+    <PosPartSection label="RP_Box_002.xml">
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_bottom_foil"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_box_secondary_vacuum"/>
+            <Translation x="0*mm" y="[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_secondary_vacuum"/>
+            <rChild name="RP_bottom_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Secondary_Vacuum_Height]/2+[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <rRotation name="RP_Transformations:RP_y_180_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="-[RP_Box:RP_Box_primary_vacuum_z]/2+[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="-[RP_Box:RP_Box_primary_vacuum_x]/2+[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+    </PosPartSection>
+   
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_003.xml
+++ b/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_003.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition>
+    
+    <SolidSection label="RP_Box_003.xml">
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_primary_vacuum_y]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_box_primary_vacuum"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_bottom_foil_base"/>
+        <Box dx="[RP_Box:RP_Box_Window_Bottom_Width]/2" dy="[RP_Box:RP_Box_Foil_Thickness]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Front_Thin_Wall_Thickness]" name="RP_bot_foil_front_cut"/>
+        <SubtractionSolid name="RP_bottom_foil_1">
+            <rSolid name="RP_bottom_foil_base"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+        </SubtractionSolid>
+         <SubtractionSolid name="RP_bottom_foil">
+             <rSolid name="RP_bottom_foil_1"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+         </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" name="RP_bot_hole_x"/>
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]+0.01*mm" name="RP_bot_hole_z"/>
+        <Tubs rMin="0*mm" rMax="2*mm" dz="[RP_Box:RP_Box_Bottom_Wall_Thickness]" startPhi="0*deg" deltaPhi="360*deg" name="RP_bot_hole_corner"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_bottom_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_primary_vacuum_y]/2-[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_box_secondary_vacuum"/>
+        <SubtractionSolid name="RP_bottom_wall_2a">
+            <rSolid name="RP_bottom_wall_1"/>
+            <rSolid name="RP_bot_hole_x"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_2">
+            <rSolid name="RP_bottom_wall_2a"/>
+            <rSolid name="RP_bot_hole_z"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_3">
+            <rSolid name="RP_bottom_wall_2"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_4">
+            <rSolid name="RP_bottom_wall_3"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_5">
+            <rSolid name="RP_bottom_wall_4"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_5"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RP_front_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_Window_Size]/2" dy="[RP_Box:RP_Box_Window_Size]/2-[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Rect"/>
+        <Tube rMin="0*mm" rMax="[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Curv"/>
+        <SubtractionSolid name="RP_front_wall_2">
+            <rSolid name="RP_front_wall_1"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_45_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_3">
+            <rSolid name="RP_front_wall_2"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_135_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_4">
+            <rSolid name="RP_front_wall_3"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]+([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_5">
+            <rSolid name="RP_front_wall_4"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="-([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_5"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <Box dx="[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2" name="RP_Left_Right_Wall"/>
+    </SolidSection>
+    
+    <LogicalPartSection label="RP_Box_003.xml">
+        <LogicalPart name="RP_box_primary_vacuum">
+            <rSolid name="RP_box_primary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        <LogicalPart name="RP_box_secondary_vacuum">
+            <rSolid name="RP_box_secondary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_foil">
+            <rSolid name="RP_bottom_foil"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_Left_Right_Wall">
+            <rSolid name="RP_Left_Right_Wall"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+    </LogicalPartSection>
+    
+    <PosPartSection label="RP_Box_003.xml">
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_bottom_foil"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_box_secondary_vacuum"/>
+            <Translation x="0*mm" y="[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_secondary_vacuum"/>
+            <rChild name="RP_bottom_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Secondary_Vacuum_Height]/2+[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <rRotation name="RP_Transformations:RP_y_180_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="-[RP_Box:RP_Box_primary_vacuum_z]/2+[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="-[RP_Box:RP_Box_primary_vacuum_x]/2+[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+    </PosPartSection>
+   
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_004.xml
+++ b/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_004.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition>
+    
+    <SolidSection label="RP_Box_004.xml">
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_primary_vacuum_y]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_box_primary_vacuum"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_bottom_foil_base"/>
+        <Box dx="[RP_Box:RP_Box_Window_Bottom_Width]/2" dy="[RP_Box:RP_Box_Foil_Thickness]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Front_Thin_Wall_Thickness]" name="RP_bot_foil_front_cut"/>
+        <SubtractionSolid name="RP_bottom_foil_1">
+            <rSolid name="RP_bottom_foil_base"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+        </SubtractionSolid>
+         <SubtractionSolid name="RP_bottom_foil">
+             <rSolid name="RP_bottom_foil_1"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+         </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" name="RP_bot_hole_x"/>
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]+0.01*mm" name="RP_bot_hole_z"/>
+        <Tubs rMin="0*mm" rMax="2*mm" dz="[RP_Box:RP_Box_Bottom_Wall_Thickness]" startPhi="0*deg" deltaPhi="360*deg" name="RP_bot_hole_corner"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_bottom_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_primary_vacuum_y]/2-[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_box_secondary_vacuum"/>
+        <SubtractionSolid name="RP_bottom_wall_2a">
+            <rSolid name="RP_bottom_wall_1"/>
+            <rSolid name="RP_bot_hole_x"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_2">
+            <rSolid name="RP_bottom_wall_2a"/>
+            <rSolid name="RP_bot_hole_z"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_3">
+            <rSolid name="RP_bottom_wall_2"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_4">
+            <rSolid name="RP_bottom_wall_3"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_5">
+            <rSolid name="RP_bottom_wall_4"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_5"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RP_front_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_Window_Size]/2" dy="[RP_Box:RP_Box_Window_Size]/2-[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Rect"/>
+        <Tube rMin="0*mm" rMax="[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Curv"/>
+        <SubtractionSolid name="RP_front_wall_2">
+            <rSolid name="RP_front_wall_1"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_45_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_3">
+            <rSolid name="RP_front_wall_2"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_135_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_4">
+            <rSolid name="RP_front_wall_3"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]+([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_5">
+            <rSolid name="RP_front_wall_4"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="-([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_5"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <Box dx="[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2" name="RP_Left_Right_Wall"/>
+    </SolidSection>
+    
+    <LogicalPartSection label="RP_Box_004.xml">
+        <LogicalPart name="RP_box_primary_vacuum">
+            <rSolid name="RP_box_primary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        <LogicalPart name="RP_box_secondary_vacuum">
+            <rSolid name="RP_box_secondary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_foil">
+            <rSolid name="RP_bottom_foil"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_Left_Right_Wall">
+            <rSolid name="RP_Left_Right_Wall"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+    </LogicalPartSection>
+    
+    <PosPartSection label="RP_Box_004.xml">
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_bottom_foil"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_box_secondary_vacuum"/>
+            <Translation x="0*mm" y="[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_secondary_vacuum"/>
+            <rChild name="RP_bottom_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Secondary_Vacuum_Height]/2+[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <rRotation name="RP_Transformations:RP_y_180_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="-[RP_Box:RP_Box_primary_vacuum_z]/2+[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="-[RP_Box:RP_Box_primary_vacuum_x]/2+[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+    </PosPartSection>
+   
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_005.xml
+++ b/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_005.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition>
+    
+    <SolidSection label="RP_Box_005.xml">
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_primary_vacuum_y]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_box_primary_vacuum"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_bottom_foil_base"/>
+        <Box dx="[RP_Box:RP_Box_Window_Bottom_Width]/2" dy="[RP_Box:RP_Box_Foil_Thickness]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Front_Thin_Wall_Thickness]" name="RP_bot_foil_front_cut"/>
+        <SubtractionSolid name="RP_bottom_foil_1">
+            <rSolid name="RP_bottom_foil_base"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+        </SubtractionSolid>
+         <SubtractionSolid name="RP_bottom_foil">
+             <rSolid name="RP_bottom_foil_1"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+         </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" name="RP_bot_hole_x"/>
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]+0.01*mm" name="RP_bot_hole_z"/>
+        <Tubs rMin="0*mm" rMax="2*mm" dz="[RP_Box:RP_Box_Bottom_Wall_Thickness]" startPhi="0*deg" deltaPhi="360*deg" name="RP_bot_hole_corner"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_bottom_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_primary_vacuum_y]/2-[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_box_secondary_vacuum"/>
+        <SubtractionSolid name="RP_bottom_wall_2a">
+            <rSolid name="RP_bottom_wall_1"/>
+            <rSolid name="RP_bot_hole_x"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_2">
+            <rSolid name="RP_bottom_wall_2a"/>
+            <rSolid name="RP_bot_hole_z"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_3">
+            <rSolid name="RP_bottom_wall_2"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_4">
+            <rSolid name="RP_bottom_wall_3"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_5">
+            <rSolid name="RP_bottom_wall_4"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_5"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RP_front_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_Window_Size]/2" dy="[RP_Box:RP_Box_Window_Size]/2-[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Rect"/>
+        <Tube rMin="0*mm" rMax="[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Curv"/>
+        <SubtractionSolid name="RP_front_wall_2">
+            <rSolid name="RP_front_wall_1"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_45_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_3">
+            <rSolid name="RP_front_wall_2"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_135_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_4">
+            <rSolid name="RP_front_wall_3"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]+([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_5">
+            <rSolid name="RP_front_wall_4"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="-([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_5"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <Box dx="[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2" name="RP_Left_Right_Wall"/>
+    </SolidSection>
+    
+    <LogicalPartSection label="RP_Box_005.xml">
+        <LogicalPart name="RP_box_primary_vacuum">
+            <rSolid name="RP_box_primary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        <LogicalPart name="RP_box_secondary_vacuum">
+            <rSolid name="RP_box_secondary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_foil">
+            <rSolid name="RP_bottom_foil"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_Left_Right_Wall">
+            <rSolid name="RP_Left_Right_Wall"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+    </LogicalPartSection>
+    
+    <PosPartSection label="RP_Box_005.xml">
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_bottom_foil"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_box_secondary_vacuum"/>
+            <Translation x="0*mm" y="[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_secondary_vacuum"/>
+            <rChild name="RP_bottom_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Secondary_Vacuum_Height]/2+[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <rRotation name="RP_Transformations:RP_y_180_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="-[RP_Box:RP_Box_primary_vacuum_z]/2+[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="-[RP_Box:RP_Box_primary_vacuum_x]/2+[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+    </PosPartSection>
+   
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_020.xml
+++ b/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_020.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition>
+    
+    <SolidSection label="RP_Box_020.xml">
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_primary_vacuum_y]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_box_primary_vacuum"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_bottom_foil_base"/>
+        <Box dx="[RP_Box:RP_Box_Window_Bottom_Width]/2" dy="[RP_Box:RP_Box_Foil_Thickness]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Front_Thin_Wall_Thickness]" name="RP_bot_foil_front_cut"/>
+        <SubtractionSolid name="RP_bottom_foil_1">
+            <rSolid name="RP_bottom_foil_base"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+        </SubtractionSolid>
+         <SubtractionSolid name="RP_bottom_foil">
+             <rSolid name="RP_bottom_foil_1"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+         </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" name="RP_bot_hole_x"/>
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]+0.01*mm" name="RP_bot_hole_z"/>
+        <Tubs rMin="0*mm" rMax="2*mm" dz="[RP_Box:RP_Box_Bottom_Wall_Thickness]" startPhi="0*deg" deltaPhi="360*deg" name="RP_bot_hole_corner"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_bottom_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_primary_vacuum_y]/2-[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_box_secondary_vacuum"/>
+        <SubtractionSolid name="RP_bottom_wall_2a">
+            <rSolid name="RP_bottom_wall_1"/>
+            <rSolid name="RP_bot_hole_x"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_2">
+            <rSolid name="RP_bottom_wall_2a"/>
+            <rSolid name="RP_bot_hole_z"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_3">
+            <rSolid name="RP_bottom_wall_2"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_4">
+            <rSolid name="RP_bottom_wall_3"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_5">
+            <rSolid name="RP_bottom_wall_4"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_5"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RP_front_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_Window_Size]/2" dy="[RP_Box:RP_Box_Window_Size]/2-[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Rect"/>
+        <Tube rMin="0*mm" rMax="[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Curv"/>
+        <SubtractionSolid name="RP_front_wall_2">
+            <rSolid name="RP_front_wall_1"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_45_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_3">
+            <rSolid name="RP_front_wall_2"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_135_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_4">
+            <rSolid name="RP_front_wall_3"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]+([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_5">
+            <rSolid name="RP_front_wall_4"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="-([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_5"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <Box dx="[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2" name="RP_Left_Right_Wall"/>
+    </SolidSection>
+    
+    <LogicalPartSection label="RP_Box_020.xml">
+        <LogicalPart name="RP_box_primary_vacuum">
+            <rSolid name="RP_box_primary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        <LogicalPart name="RP_box_secondary_vacuum">
+            <rSolid name="RP_box_secondary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_foil">
+            <rSolid name="RP_bottom_foil"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_Left_Right_Wall">
+            <rSolid name="RP_Left_Right_Wall"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+    </LogicalPartSection>
+    
+    <PosPartSection label="RP_Box_020.xml">
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_bottom_foil"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_box_secondary_vacuum"/>
+            <Translation x="0*mm" y="[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_secondary_vacuum"/>
+            <rChild name="RP_bottom_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Secondary_Vacuum_Height]/2+[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <rRotation name="RP_Transformations:RP_y_180_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="-[RP_Box:RP_Box_primary_vacuum_z]/2+[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="-[RP_Box:RP_Box_primary_vacuum_x]/2+[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+    </PosPartSection>
+   
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_021.xml
+++ b/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_021.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition>
+    
+    <SolidSection label="RP_Box_021.xml">
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_primary_vacuum_y]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_box_primary_vacuum"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_bottom_foil_base"/>
+        <Box dx="[RP_Box:RP_Box_Window_Bottom_Width]/2" dy="[RP_Box:RP_Box_Foil_Thickness]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Front_Thin_Wall_Thickness]" name="RP_bot_foil_front_cut"/>
+        <SubtractionSolid name="RP_bottom_foil_1">
+            <rSolid name="RP_bottom_foil_base"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+        </SubtractionSolid>
+         <SubtractionSolid name="RP_bottom_foil">
+             <rSolid name="RP_bottom_foil_1"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+         </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" name="RP_bot_hole_x"/>
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]+0.01*mm" name="RP_bot_hole_z"/>
+        <Tubs rMin="0*mm" rMax="2*mm" dz="[RP_Box:RP_Box_Bottom_Wall_Thickness]" startPhi="0*deg" deltaPhi="360*deg" name="RP_bot_hole_corner"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_bottom_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_primary_vacuum_y]/2-[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_box_secondary_vacuum"/>
+        <SubtractionSolid name="RP_bottom_wall_2a">
+            <rSolid name="RP_bottom_wall_1"/>
+            <rSolid name="RP_bot_hole_x"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_2">
+            <rSolid name="RP_bottom_wall_2a"/>
+            <rSolid name="RP_bot_hole_z"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_3">
+            <rSolid name="RP_bottom_wall_2"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_4">
+            <rSolid name="RP_bottom_wall_3"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_5">
+            <rSolid name="RP_bottom_wall_4"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_5"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RP_front_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_Window_Size]/2" dy="[RP_Box:RP_Box_Window_Size]/2-[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Rect"/>
+        <Tube rMin="0*mm" rMax="[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Curv"/>
+        <SubtractionSolid name="RP_front_wall_2">
+            <rSolid name="RP_front_wall_1"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_45_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_3">
+            <rSolid name="RP_front_wall_2"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_135_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_4">
+            <rSolid name="RP_front_wall_3"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]+([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_5">
+            <rSolid name="RP_front_wall_4"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="-([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_5"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <Box dx="[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2" name="RP_Left_Right_Wall"/>
+    </SolidSection>
+    
+    <LogicalPartSection label="RP_Box_021.xml">
+        <LogicalPart name="RP_box_primary_vacuum">
+            <rSolid name="RP_box_primary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        <LogicalPart name="RP_box_secondary_vacuum">
+            <rSolid name="RP_box_secondary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_foil">
+            <rSolid name="RP_bottom_foil"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_Left_Right_Wall">
+            <rSolid name="RP_Left_Right_Wall"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+    </LogicalPartSection>
+    
+    <PosPartSection label="RP_Box_021.xml">
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_bottom_foil"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_box_secondary_vacuum"/>
+            <Translation x="0*mm" y="[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_secondary_vacuum"/>
+            <rChild name="RP_bottom_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Secondary_Vacuum_Height]/2+[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <rRotation name="RP_Transformations:RP_y_180_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="-[RP_Box:RP_Box_primary_vacuum_z]/2+[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="-[RP_Box:RP_Box_primary_vacuum_x]/2+[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+    </PosPartSection>
+   
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_022.xml
+++ b/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_022.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition>
+    
+    <SolidSection label="RP_Box_022.xml">
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_primary_vacuum_y]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_box_primary_vacuum"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_bottom_foil_base"/>
+        <Box dx="[RP_Box:RP_Box_Window_Bottom_Width]/2" dy="[RP_Box:RP_Box_Foil_Thickness]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Front_Thin_Wall_Thickness]" name="RP_bot_foil_front_cut"/>
+        <SubtractionSolid name="RP_bottom_foil_1">
+            <rSolid name="RP_bottom_foil_base"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+        </SubtractionSolid>
+         <SubtractionSolid name="RP_bottom_foil">
+             <rSolid name="RP_bottom_foil_1"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+         </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" name="RP_bot_hole_x"/>
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]+0.01*mm" name="RP_bot_hole_z"/>
+        <Tubs rMin="0*mm" rMax="2*mm" dz="[RP_Box:RP_Box_Bottom_Wall_Thickness]" startPhi="0*deg" deltaPhi="360*deg" name="RP_bot_hole_corner"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_bottom_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_primary_vacuum_y]/2-[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_box_secondary_vacuum"/>
+        <SubtractionSolid name="RP_bottom_wall_2a">
+            <rSolid name="RP_bottom_wall_1"/>
+            <rSolid name="RP_bot_hole_x"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_2">
+            <rSolid name="RP_bottom_wall_2a"/>
+            <rSolid name="RP_bot_hole_z"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_3">
+            <rSolid name="RP_bottom_wall_2"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_4">
+            <rSolid name="RP_bottom_wall_3"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_5">
+            <rSolid name="RP_bottom_wall_4"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_5"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RP_front_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_Window_Size]/2" dy="[RP_Box:RP_Box_Window_Size]/2-[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Rect"/>
+        <Tube rMin="0*mm" rMax="[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Curv"/>
+        <SubtractionSolid name="RP_front_wall_2">
+            <rSolid name="RP_front_wall_1"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_45_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_3">
+            <rSolid name="RP_front_wall_2"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_135_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_4">
+            <rSolid name="RP_front_wall_3"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]+([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_5">
+            <rSolid name="RP_front_wall_4"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="-([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_5"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <Box dx="[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2" name="RP_Left_Right_Wall"/>
+    </SolidSection>
+    
+    <LogicalPartSection label="RP_Box_022.xml">
+        <LogicalPart name="RP_box_primary_vacuum">
+            <rSolid name="RP_box_primary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        <LogicalPart name="RP_box_secondary_vacuum">
+            <rSolid name="RP_box_secondary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_foil">
+            <rSolid name="RP_bottom_foil"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_Left_Right_Wall">
+            <rSolid name="RP_Left_Right_Wall"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+    </LogicalPartSection>
+    
+    <PosPartSection label="RP_Box_022.xml">
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_bottom_foil"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_box_secondary_vacuum"/>
+            <Translation x="0*mm" y="[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_secondary_vacuum"/>
+            <rChild name="RP_bottom_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Secondary_Vacuum_Height]/2+[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <rRotation name="RP_Transformations:RP_y_180_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="-[RP_Box:RP_Box_primary_vacuum_z]/2+[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="-[RP_Box:RP_Box_primary_vacuum_x]/2+[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+    </PosPartSection>
+   
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_023.xml
+++ b/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_023.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition>
+    
+    <SolidSection label="RP_Box_023.xml">
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_primary_vacuum_y]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_box_primary_vacuum"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_bottom_foil_base"/>
+        <Box dx="[RP_Box:RP_Box_Window_Bottom_Width]/2" dy="[RP_Box:RP_Box_Foil_Thickness]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Front_Thin_Wall_Thickness]" name="RP_bot_foil_front_cut"/>
+        <SubtractionSolid name="RP_bottom_foil_1">
+            <rSolid name="RP_bottom_foil_base"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+        </SubtractionSolid>
+         <SubtractionSolid name="RP_bottom_foil">
+             <rSolid name="RP_bottom_foil_1"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+         </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" name="RP_bot_hole_x"/>
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]+0.01*mm" name="RP_bot_hole_z"/>
+        <Tubs rMin="0*mm" rMax="2*mm" dz="[RP_Box:RP_Box_Bottom_Wall_Thickness]" startPhi="0*deg" deltaPhi="360*deg" name="RP_bot_hole_corner"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_bottom_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_primary_vacuum_y]/2-[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_box_secondary_vacuum"/>
+        <SubtractionSolid name="RP_bottom_wall_2a">
+            <rSolid name="RP_bottom_wall_1"/>
+            <rSolid name="RP_bot_hole_x"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_2">
+            <rSolid name="RP_bottom_wall_2a"/>
+            <rSolid name="RP_bot_hole_z"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_3">
+            <rSolid name="RP_bottom_wall_2"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_4">
+            <rSolid name="RP_bottom_wall_3"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_5">
+            <rSolid name="RP_bottom_wall_4"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_5"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RP_front_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_Window_Size]/2" dy="[RP_Box:RP_Box_Window_Size]/2-[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Rect"/>
+        <Tube rMin="0*mm" rMax="[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Curv"/>
+        <SubtractionSolid name="RP_front_wall_2">
+            <rSolid name="RP_front_wall_1"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_45_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_3">
+            <rSolid name="RP_front_wall_2"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_135_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_4">
+            <rSolid name="RP_front_wall_3"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]+([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_5">
+            <rSolid name="RP_front_wall_4"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="-([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_5"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <Box dx="[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2" name="RP_Left_Right_Wall"/>
+    </SolidSection>
+    
+    <LogicalPartSection label="RP_Box_023.xml">
+        <LogicalPart name="RP_box_primary_vacuum">
+            <rSolid name="RP_box_primary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        <LogicalPart name="RP_box_secondary_vacuum">
+            <rSolid name="RP_box_secondary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_foil">
+            <rSolid name="RP_bottom_foil"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_Left_Right_Wall">
+            <rSolid name="RP_Left_Right_Wall"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+    </LogicalPartSection>
+    
+    <PosPartSection label="RP_Box_023.xml">
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_bottom_foil"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_box_secondary_vacuum"/>
+            <Translation x="0*mm" y="[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_secondary_vacuum"/>
+            <rChild name="RP_bottom_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Secondary_Vacuum_Height]/2+[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <rRotation name="RP_Transformations:RP_y_180_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="-[RP_Box:RP_Box_primary_vacuum_z]/2+[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="-[RP_Box:RP_Box_primary_vacuum_x]/2+[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+    </PosPartSection>
+   
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_024.xml
+++ b/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_024.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition>
+    
+    <SolidSection label="RP_Box_024.xml">
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_primary_vacuum_y]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_box_primary_vacuum"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_bottom_foil_base"/>
+        <Box dx="[RP_Box:RP_Box_Window_Bottom_Width]/2" dy="[RP_Box:RP_Box_Foil_Thickness]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Front_Thin_Wall_Thickness]" name="RP_bot_foil_front_cut"/>
+        <SubtractionSolid name="RP_bottom_foil_1">
+            <rSolid name="RP_bottom_foil_base"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+        </SubtractionSolid>
+         <SubtractionSolid name="RP_bottom_foil">
+             <rSolid name="RP_bottom_foil_1"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+         </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" name="RP_bot_hole_x"/>
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]+0.01*mm" name="RP_bot_hole_z"/>
+        <Tubs rMin="0*mm" rMax="2*mm" dz="[RP_Box:RP_Box_Bottom_Wall_Thickness]" startPhi="0*deg" deltaPhi="360*deg" name="RP_bot_hole_corner"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_bottom_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_primary_vacuum_y]/2-[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_box_secondary_vacuum"/>
+        <SubtractionSolid name="RP_bottom_wall_2a">
+            <rSolid name="RP_bottom_wall_1"/>
+            <rSolid name="RP_bot_hole_x"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_2">
+            <rSolid name="RP_bottom_wall_2a"/>
+            <rSolid name="RP_bot_hole_z"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_3">
+            <rSolid name="RP_bottom_wall_2"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_4">
+            <rSolid name="RP_bottom_wall_3"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_5">
+            <rSolid name="RP_bottom_wall_4"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_5"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RP_front_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_Window_Size]/2" dy="[RP_Box:RP_Box_Window_Size]/2-[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Rect"/>
+        <Tube rMin="0*mm" rMax="[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Curv"/>
+        <SubtractionSolid name="RP_front_wall_2">
+            <rSolid name="RP_front_wall_1"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_45_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_3">
+            <rSolid name="RP_front_wall_2"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_135_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_4">
+            <rSolid name="RP_front_wall_3"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]+([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_5">
+            <rSolid name="RP_front_wall_4"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="-([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_5"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <Box dx="[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2" name="RP_Left_Right_Wall"/>
+    </SolidSection>
+    
+    <LogicalPartSection label="RP_Box_024.xml">
+        <LogicalPart name="RP_box_primary_vacuum">
+            <rSolid name="RP_box_primary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        <LogicalPart name="RP_box_secondary_vacuum">
+            <rSolid name="RP_box_secondary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_foil">
+            <rSolid name="RP_bottom_foil"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_Left_Right_Wall">
+            <rSolid name="RP_Left_Right_Wall"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+    </LogicalPartSection>
+    
+    <PosPartSection label="RP_Box_024.xml">
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_bottom_foil"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_box_secondary_vacuum"/>
+            <Translation x="0*mm" y="[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_secondary_vacuum"/>
+            <rChild name="RP_bottom_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Secondary_Vacuum_Height]/2+[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <rRotation name="RP_Transformations:RP_y_180_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="-[RP_Box:RP_Box_primary_vacuum_z]/2+[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="-[RP_Box:RP_Box_primary_vacuum_x]/2+[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+    </PosPartSection>
+   
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_025.xml
+++ b/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_025.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition>
+    
+    <SolidSection label="RP_Box_025.xml">
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_primary_vacuum_y]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_box_primary_vacuum"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_bottom_foil_base"/>
+        <Box dx="[RP_Box:RP_Box_Window_Bottom_Width]/2" dy="[RP_Box:RP_Box_Foil_Thickness]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Front_Thin_Wall_Thickness]" name="RP_bot_foil_front_cut"/>
+        <SubtractionSolid name="RP_bottom_foil_1">
+            <rSolid name="RP_bottom_foil_base"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+        </SubtractionSolid>
+         <SubtractionSolid name="RP_bottom_foil">
+             <rSolid name="RP_bottom_foil_1"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+         </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" name="RP_bot_hole_x"/>
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]+0.01*mm" name="RP_bot_hole_z"/>
+        <Tubs rMin="0*mm" rMax="2*mm" dz="[RP_Box:RP_Box_Bottom_Wall_Thickness]" startPhi="0*deg" deltaPhi="360*deg" name="RP_bot_hole_corner"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_bottom_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_primary_vacuum_y]/2-[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_box_secondary_vacuum"/>
+        <SubtractionSolid name="RP_bottom_wall_2a">
+            <rSolid name="RP_bottom_wall_1"/>
+            <rSolid name="RP_bot_hole_x"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_2">
+            <rSolid name="RP_bottom_wall_2a"/>
+            <rSolid name="RP_bot_hole_z"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_3">
+            <rSolid name="RP_bottom_wall_2"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_4">
+            <rSolid name="RP_bottom_wall_3"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_5">
+            <rSolid name="RP_bottom_wall_4"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_5"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RP_front_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_Window_Size]/2" dy="[RP_Box:RP_Box_Window_Size]/2-[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Rect"/>
+        <Tube rMin="0*mm" rMax="[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Curv"/>
+        <SubtractionSolid name="RP_front_wall_2">
+            <rSolid name="RP_front_wall_1"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_45_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_3">
+            <rSolid name="RP_front_wall_2"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_135_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_4">
+            <rSolid name="RP_front_wall_3"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]+([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_5">
+            <rSolid name="RP_front_wall_4"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="-([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_5"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <Box dx="[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2" name="RP_Left_Right_Wall"/>
+    </SolidSection>
+    
+    <LogicalPartSection label="RP_Box_025.xml">
+        <LogicalPart name="RP_box_primary_vacuum">
+            <rSolid name="RP_box_primary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        <LogicalPart name="RP_box_secondary_vacuum">
+            <rSolid name="RP_box_secondary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_foil">
+            <rSolid name="RP_bottom_foil"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_Left_Right_Wall">
+            <rSolid name="RP_Left_Right_Wall"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+    </LogicalPartSection>
+    
+    <PosPartSection label="RP_Box_025.xml">
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_bottom_foil"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_box_secondary_vacuum"/>
+            <Translation x="0*mm" y="[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_secondary_vacuum"/>
+            <rChild name="RP_bottom_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Secondary_Vacuum_Height]/2+[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <rRotation name="RP_Transformations:RP_y_180_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="-[RP_Box:RP_Box_primary_vacuum_z]/2+[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="-[RP_Box:RP_Box_primary_vacuum_x]/2+[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+    </PosPartSection>
+   
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_100.xml
+++ b/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_100.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition>
+    
+    <SolidSection label="RP_Box_100.xml">
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_primary_vacuum_y]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_box_primary_vacuum"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_bottom_foil_base"/>
+        <Box dx="[RP_Box:RP_Box_Window_Bottom_Width]/2" dy="[RP_Box:RP_Box_Foil_Thickness]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Front_Thin_Wall_Thickness]" name="RP_bot_foil_front_cut"/>
+        <SubtractionSolid name="RP_bottom_foil_1">
+            <rSolid name="RP_bottom_foil_base"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+        </SubtractionSolid>
+         <SubtractionSolid name="RP_bottom_foil">
+             <rSolid name="RP_bottom_foil_1"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+         </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" name="RP_bot_hole_x"/>
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]+0.01*mm" name="RP_bot_hole_z"/>
+        <Tubs rMin="0*mm" rMax="2*mm" dz="[RP_Box:RP_Box_Bottom_Wall_Thickness]" startPhi="0*deg" deltaPhi="360*deg" name="RP_bot_hole_corner"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_bottom_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_primary_vacuum_y]/2-[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_box_secondary_vacuum"/>
+        <SubtractionSolid name="RP_bottom_wall_2a">
+            <rSolid name="RP_bottom_wall_1"/>
+            <rSolid name="RP_bot_hole_x"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_2">
+            <rSolid name="RP_bottom_wall_2a"/>
+            <rSolid name="RP_bot_hole_z"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_3">
+            <rSolid name="RP_bottom_wall_2"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_4">
+            <rSolid name="RP_bottom_wall_3"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_5">
+            <rSolid name="RP_bottom_wall_4"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_5"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RP_front_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_Window_Size]/2" dy="[RP_Box:RP_Box_Window_Size]/2-[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Rect"/>
+        <Tube rMin="0*mm" rMax="[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Curv"/>
+        <SubtractionSolid name="RP_front_wall_2">
+            <rSolid name="RP_front_wall_1"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_45_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_3">
+            <rSolid name="RP_front_wall_2"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_135_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_4">
+            <rSolid name="RP_front_wall_3"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]+([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_5">
+            <rSolid name="RP_front_wall_4"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="-([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_5"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <Box dx="[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2" name="RP_Left_Right_Wall"/>
+    </SolidSection>
+    
+    <LogicalPartSection label="RP_Box_100.xml">
+        <LogicalPart name="RP_box_primary_vacuum">
+            <rSolid name="RP_box_primary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        <LogicalPart name="RP_box_secondary_vacuum">
+            <rSolid name="RP_box_secondary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_foil">
+            <rSolid name="RP_bottom_foil"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_Left_Right_Wall">
+            <rSolid name="RP_Left_Right_Wall"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+    </LogicalPartSection>
+    
+    <PosPartSection label="RP_Box_100.xml">
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_bottom_foil"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_box_secondary_vacuum"/>
+            <Translation x="0*mm" y="[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_secondary_vacuum"/>
+            <rChild name="RP_bottom_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Secondary_Vacuum_Height]/2+[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <rRotation name="RP_Transformations:RP_y_180_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="-[RP_Box:RP_Box_primary_vacuum_z]/2+[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="-[RP_Box:RP_Box_primary_vacuum_x]/2+[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+    </PosPartSection>
+   
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_101.xml
+++ b/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_101.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition>
+    
+    <SolidSection label="RP_Box_101.xml">
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_primary_vacuum_y]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_box_primary_vacuum"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_bottom_foil_base"/>
+        <Box dx="[RP_Box:RP_Box_Window_Bottom_Width]/2" dy="[RP_Box:RP_Box_Foil_Thickness]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Front_Thin_Wall_Thickness]" name="RP_bot_foil_front_cut"/>
+        <SubtractionSolid name="RP_bottom_foil_1">
+            <rSolid name="RP_bottom_foil_base"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+        </SubtractionSolid>
+         <SubtractionSolid name="RP_bottom_foil">
+             <rSolid name="RP_bottom_foil_1"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+         </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" name="RP_bot_hole_x"/>
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]+0.01*mm" name="RP_bot_hole_z"/>
+        <Tubs rMin="0*mm" rMax="2*mm" dz="[RP_Box:RP_Box_Bottom_Wall_Thickness]" startPhi="0*deg" deltaPhi="360*deg" name="RP_bot_hole_corner"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_bottom_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_primary_vacuum_y]/2-[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_box_secondary_vacuum"/>
+        <SubtractionSolid name="RP_bottom_wall_2a">
+            <rSolid name="RP_bottom_wall_1"/>
+            <rSolid name="RP_bot_hole_x"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_2">
+            <rSolid name="RP_bottom_wall_2a"/>
+            <rSolid name="RP_bot_hole_z"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_3">
+            <rSolid name="RP_bottom_wall_2"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_4">
+            <rSolid name="RP_bottom_wall_3"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_5">
+            <rSolid name="RP_bottom_wall_4"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_5"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RP_front_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_Window_Size]/2" dy="[RP_Box:RP_Box_Window_Size]/2-[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Rect"/>
+        <Tube rMin="0*mm" rMax="[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Curv"/>
+        <SubtractionSolid name="RP_front_wall_2">
+            <rSolid name="RP_front_wall_1"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_45_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_3">
+            <rSolid name="RP_front_wall_2"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_135_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_4">
+            <rSolid name="RP_front_wall_3"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]+([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_5">
+            <rSolid name="RP_front_wall_4"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="-([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_5"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <Box dx="[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2" name="RP_Left_Right_Wall"/>
+    </SolidSection>
+    
+    <LogicalPartSection label="RP_Box_101.xml">
+        <LogicalPart name="RP_box_primary_vacuum">
+            <rSolid name="RP_box_primary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        <LogicalPart name="RP_box_secondary_vacuum">
+            <rSolid name="RP_box_secondary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_foil">
+            <rSolid name="RP_bottom_foil"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_Left_Right_Wall">
+            <rSolid name="RP_Left_Right_Wall"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+    </LogicalPartSection>
+    
+    <PosPartSection label="RP_Box_101.xml">
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_bottom_foil"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_box_secondary_vacuum"/>
+            <Translation x="0*mm" y="[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_secondary_vacuum"/>
+            <rChild name="RP_bottom_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Secondary_Vacuum_Height]/2+[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <rRotation name="RP_Transformations:RP_y_180_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="-[RP_Box:RP_Box_primary_vacuum_z]/2+[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="-[RP_Box:RP_Box_primary_vacuum_x]/2+[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+    </PosPartSection>
+   
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_102.xml
+++ b/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_102.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition>
+    
+    <SolidSection label="RP_Box_102.xml">
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_primary_vacuum_y]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_box_primary_vacuum"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_bottom_foil_base"/>
+        <Box dx="[RP_Box:RP_Box_Window_Bottom_Width]/2" dy="[RP_Box:RP_Box_Foil_Thickness]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Front_Thin_Wall_Thickness]" name="RP_bot_foil_front_cut"/>
+        <SubtractionSolid name="RP_bottom_foil_1">
+            <rSolid name="RP_bottom_foil_base"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+        </SubtractionSolid>
+         <SubtractionSolid name="RP_bottom_foil">
+             <rSolid name="RP_bottom_foil_1"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+         </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" name="RP_bot_hole_x"/>
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]+0.01*mm" name="RP_bot_hole_z"/>
+        <Tubs rMin="0*mm" rMax="2*mm" dz="[RP_Box:RP_Box_Bottom_Wall_Thickness]" startPhi="0*deg" deltaPhi="360*deg" name="RP_bot_hole_corner"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_bottom_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_primary_vacuum_y]/2-[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_box_secondary_vacuum"/>
+        <SubtractionSolid name="RP_bottom_wall_2a">
+            <rSolid name="RP_bottom_wall_1"/>
+            <rSolid name="RP_bot_hole_x"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_2">
+            <rSolid name="RP_bottom_wall_2a"/>
+            <rSolid name="RP_bot_hole_z"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_3">
+            <rSolid name="RP_bottom_wall_2"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_4">
+            <rSolid name="RP_bottom_wall_3"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_5">
+            <rSolid name="RP_bottom_wall_4"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_5"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RP_front_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_Window_Size]/2" dy="[RP_Box:RP_Box_Window_Size]/2-[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Rect"/>
+        <Tube rMin="0*mm" rMax="[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Curv"/>
+        <SubtractionSolid name="RP_front_wall_2">
+            <rSolid name="RP_front_wall_1"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_45_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_3">
+            <rSolid name="RP_front_wall_2"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_135_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_4">
+            <rSolid name="RP_front_wall_3"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]+([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_5">
+            <rSolid name="RP_front_wall_4"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="-([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_5"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <Box dx="[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2" name="RP_Left_Right_Wall"/>
+    </SolidSection>
+    
+    <LogicalPartSection label="RP_Box_102.xml">
+        <LogicalPart name="RP_box_primary_vacuum">
+            <rSolid name="RP_box_primary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        <LogicalPart name="RP_box_secondary_vacuum">
+            <rSolid name="RP_box_secondary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_foil">
+            <rSolid name="RP_bottom_foil"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_Left_Right_Wall">
+            <rSolid name="RP_Left_Right_Wall"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+    </LogicalPartSection>
+    
+    <PosPartSection label="RP_Box_102.xml">
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_bottom_foil"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_box_secondary_vacuum"/>
+            <Translation x="0*mm" y="[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_secondary_vacuum"/>
+            <rChild name="RP_bottom_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Secondary_Vacuum_Height]/2+[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <rRotation name="RP_Transformations:RP_y_180_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="-[RP_Box:RP_Box_primary_vacuum_z]/2+[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="-[RP_Box:RP_Box_primary_vacuum_x]/2+[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+    </PosPartSection>
+   
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_103.xml
+++ b/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_103.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition>
+    
+    <SolidSection label="RP_Box_103.xml">
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_primary_vacuum_y]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_box_primary_vacuum"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_bottom_foil_base"/>
+        <Box dx="[RP_Box:RP_Box_Window_Bottom_Width]/2" dy="[RP_Box:RP_Box_Foil_Thickness]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Front_Thin_Wall_Thickness]" name="RP_bot_foil_front_cut"/>
+        <SubtractionSolid name="RP_bottom_foil_1">
+            <rSolid name="RP_bottom_foil_base"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+        </SubtractionSolid>
+         <SubtractionSolid name="RP_bottom_foil">
+             <rSolid name="RP_bottom_foil_1"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+         </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" name="RP_bot_hole_x"/>
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]+0.01*mm" name="RP_bot_hole_z"/>
+        <Tubs rMin="0*mm" rMax="2*mm" dz="[RP_Box:RP_Box_Bottom_Wall_Thickness]" startPhi="0*deg" deltaPhi="360*deg" name="RP_bot_hole_corner"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_bottom_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_primary_vacuum_y]/2-[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_box_secondary_vacuum"/>
+        <SubtractionSolid name="RP_bottom_wall_2a">
+            <rSolid name="RP_bottom_wall_1"/>
+            <rSolid name="RP_bot_hole_x"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_2">
+            <rSolid name="RP_bottom_wall_2a"/>
+            <rSolid name="RP_bot_hole_z"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_3">
+            <rSolid name="RP_bottom_wall_2"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_4">
+            <rSolid name="RP_bottom_wall_3"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_5">
+            <rSolid name="RP_bottom_wall_4"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_5"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RP_front_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_Window_Size]/2" dy="[RP_Box:RP_Box_Window_Size]/2-[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Rect"/>
+        <Tube rMin="0*mm" rMax="[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Curv"/>
+        <SubtractionSolid name="RP_front_wall_2">
+            <rSolid name="RP_front_wall_1"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_45_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_3">
+            <rSolid name="RP_front_wall_2"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_135_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_4">
+            <rSolid name="RP_front_wall_3"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]+([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_5">
+            <rSolid name="RP_front_wall_4"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="-([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_5"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <Box dx="[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2" name="RP_Left_Right_Wall"/>
+    </SolidSection>
+    
+    <LogicalPartSection label="RP_Box_103.xml">
+        <LogicalPart name="RP_box_primary_vacuum">
+            <rSolid name="RP_box_primary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        <LogicalPart name="RP_box_secondary_vacuum">
+            <rSolid name="RP_box_secondary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_foil">
+            <rSolid name="RP_bottom_foil"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_Left_Right_Wall">
+            <rSolid name="RP_Left_Right_Wall"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+    </LogicalPartSection>
+    
+    <PosPartSection label="RP_Box_103.xml">
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_bottom_foil"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_box_secondary_vacuum"/>
+            <Translation x="0*mm" y="[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_secondary_vacuum"/>
+            <rChild name="RP_bottom_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Secondary_Vacuum_Height]/2+[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <rRotation name="RP_Transformations:RP_y_180_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="-[RP_Box:RP_Box_primary_vacuum_z]/2+[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="-[RP_Box:RP_Box_primary_vacuum_x]/2+[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+    </PosPartSection>
+   
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_104.xml
+++ b/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_104.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition>
+    
+    <SolidSection label="RP_Box_104.xml">
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_primary_vacuum_y]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_box_primary_vacuum"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_bottom_foil_base"/>
+        <Box dx="[RP_Box:RP_Box_Window_Bottom_Width]/2" dy="[RP_Box:RP_Box_Foil_Thickness]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Front_Thin_Wall_Thickness]" name="RP_bot_foil_front_cut"/>
+        <SubtractionSolid name="RP_bottom_foil_1">
+            <rSolid name="RP_bottom_foil_base"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+        </SubtractionSolid>
+         <SubtractionSolid name="RP_bottom_foil">
+             <rSolid name="RP_bottom_foil_1"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+         </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" name="RP_bot_hole_x"/>
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]+0.01*mm" name="RP_bot_hole_z"/>
+        <Tubs rMin="0*mm" rMax="2*mm" dz="[RP_Box:RP_Box_Bottom_Wall_Thickness]" startPhi="0*deg" deltaPhi="360*deg" name="RP_bot_hole_corner"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_bottom_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_primary_vacuum_y]/2-[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_box_secondary_vacuum"/>
+        <SubtractionSolid name="RP_bottom_wall_2a">
+            <rSolid name="RP_bottom_wall_1"/>
+            <rSolid name="RP_bot_hole_x"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_2">
+            <rSolid name="RP_bottom_wall_2a"/>
+            <rSolid name="RP_bot_hole_z"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_3">
+            <rSolid name="RP_bottom_wall_2"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_4">
+            <rSolid name="RP_bottom_wall_3"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_5">
+            <rSolid name="RP_bottom_wall_4"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_5"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RP_front_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_Window_Size]/2" dy="[RP_Box:RP_Box_Window_Size]/2-[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Rect"/>
+        <Tube rMin="0*mm" rMax="[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Curv"/>
+        <SubtractionSolid name="RP_front_wall_2">
+            <rSolid name="RP_front_wall_1"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_45_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_3">
+            <rSolid name="RP_front_wall_2"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_135_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_4">
+            <rSolid name="RP_front_wall_3"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]+([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_5">
+            <rSolid name="RP_front_wall_4"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="-([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_5"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <Box dx="[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2" name="RP_Left_Right_Wall"/>
+    </SolidSection>
+    
+    <LogicalPartSection label="RP_Box_104.xml">
+        <LogicalPart name="RP_box_primary_vacuum">
+            <rSolid name="RP_box_primary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        <LogicalPart name="RP_box_secondary_vacuum">
+            <rSolid name="RP_box_secondary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_foil">
+            <rSolid name="RP_bottom_foil"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_Left_Right_Wall">
+            <rSolid name="RP_Left_Right_Wall"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+    </LogicalPartSection>
+    
+    <PosPartSection label="RP_Box_104.xml">
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_bottom_foil"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_box_secondary_vacuum"/>
+            <Translation x="0*mm" y="[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_secondary_vacuum"/>
+            <rChild name="RP_bottom_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Secondary_Vacuum_Height]/2+[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <rRotation name="RP_Transformations:RP_y_180_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="-[RP_Box:RP_Box_primary_vacuum_z]/2+[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="-[RP_Box:RP_Box_primary_vacuum_x]/2+[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+    </PosPartSection>
+   
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_105.xml
+++ b/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_105.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition>
+    
+    <SolidSection label="RP_Box_105.xml">
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_primary_vacuum_y]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_box_primary_vacuum"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_bottom_foil_base"/>
+        <Box dx="[RP_Box:RP_Box_Window_Bottom_Width]/2" dy="[RP_Box:RP_Box_Foil_Thickness]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Front_Thin_Wall_Thickness]" name="RP_bot_foil_front_cut"/>
+        <SubtractionSolid name="RP_bottom_foil_1">
+            <rSolid name="RP_bottom_foil_base"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+        </SubtractionSolid>
+         <SubtractionSolid name="RP_bottom_foil">
+             <rSolid name="RP_bottom_foil_1"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+         </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" name="RP_bot_hole_x"/>
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]+0.01*mm" name="RP_bot_hole_z"/>
+        <Tubs rMin="0*mm" rMax="2*mm" dz="[RP_Box:RP_Box_Bottom_Wall_Thickness]" startPhi="0*deg" deltaPhi="360*deg" name="RP_bot_hole_corner"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_bottom_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_primary_vacuum_y]/2-[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_box_secondary_vacuum"/>
+        <SubtractionSolid name="RP_bottom_wall_2a">
+            <rSolid name="RP_bottom_wall_1"/>
+            <rSolid name="RP_bot_hole_x"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_2">
+            <rSolid name="RP_bottom_wall_2a"/>
+            <rSolid name="RP_bot_hole_z"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_3">
+            <rSolid name="RP_bottom_wall_2"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_4">
+            <rSolid name="RP_bottom_wall_3"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_5">
+            <rSolid name="RP_bottom_wall_4"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_5"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RP_front_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_Window_Size]/2" dy="[RP_Box:RP_Box_Window_Size]/2-[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Rect"/>
+        <Tube rMin="0*mm" rMax="[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Curv"/>
+        <SubtractionSolid name="RP_front_wall_2">
+            <rSolid name="RP_front_wall_1"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_45_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_3">
+            <rSolid name="RP_front_wall_2"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_135_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_4">
+            <rSolid name="RP_front_wall_3"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]+([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_5">
+            <rSolid name="RP_front_wall_4"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="-([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_5"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <Box dx="[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2" name="RP_Left_Right_Wall"/>
+    </SolidSection>
+    
+    <LogicalPartSection label="RP_Box_105.xml">
+        <LogicalPart name="RP_box_primary_vacuum">
+            <rSolid name="RP_box_primary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        <LogicalPart name="RP_box_secondary_vacuum">
+            <rSolid name="RP_box_secondary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_foil">
+            <rSolid name="RP_bottom_foil"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_Left_Right_Wall">
+            <rSolid name="RP_Left_Right_Wall"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+    </LogicalPartSection>
+    
+    <PosPartSection label="RP_Box_105.xml">
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_bottom_foil"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_box_secondary_vacuum"/>
+            <Translation x="0*mm" y="[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_secondary_vacuum"/>
+            <rChild name="RP_bottom_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Secondary_Vacuum_Height]/2+[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <rRotation name="RP_Transformations:RP_y_180_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="-[RP_Box:RP_Box_primary_vacuum_z]/2+[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="-[RP_Box:RP_Box_primary_vacuum_x]/2+[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+    </PosPartSection>
+   
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_120.xml
+++ b/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_120.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition>
+    
+    <SolidSection label="RP_Box_120.xml">
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_primary_vacuum_y]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_box_primary_vacuum"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_bottom_foil_base"/>
+        <Box dx="[RP_Box:RP_Box_Window_Bottom_Width]/2" dy="[RP_Box:RP_Box_Foil_Thickness]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Front_Thin_Wall_Thickness]" name="RP_bot_foil_front_cut"/>
+        <SubtractionSolid name="RP_bottom_foil_1">
+            <rSolid name="RP_bottom_foil_base"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+        </SubtractionSolid>
+         <SubtractionSolid name="RP_bottom_foil">
+             <rSolid name="RP_bottom_foil_1"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+         </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" name="RP_bot_hole_x"/>
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]+0.01*mm" name="RP_bot_hole_z"/>
+        <Tubs rMin="0*mm" rMax="2*mm" dz="[RP_Box:RP_Box_Bottom_Wall_Thickness]" startPhi="0*deg" deltaPhi="360*deg" name="RP_bot_hole_corner"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_bottom_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_primary_vacuum_y]/2-[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_box_secondary_vacuum"/>
+        <SubtractionSolid name="RP_bottom_wall_2a">
+            <rSolid name="RP_bottom_wall_1"/>
+            <rSolid name="RP_bot_hole_x"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_2">
+            <rSolid name="RP_bottom_wall_2a"/>
+            <rSolid name="RP_bot_hole_z"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_3">
+            <rSolid name="RP_bottom_wall_2"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_4">
+            <rSolid name="RP_bottom_wall_3"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_5">
+            <rSolid name="RP_bottom_wall_4"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_5"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RP_front_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_Window_Size]/2" dy="[RP_Box:RP_Box_Window_Size]/2-[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Rect"/>
+        <Tube rMin="0*mm" rMax="[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Curv"/>
+        <SubtractionSolid name="RP_front_wall_2">
+            <rSolid name="RP_front_wall_1"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_45_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_3">
+            <rSolid name="RP_front_wall_2"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_135_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_4">
+            <rSolid name="RP_front_wall_3"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]+([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_5">
+            <rSolid name="RP_front_wall_4"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="-([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_5"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <Box dx="[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2" name="RP_Left_Right_Wall"/>
+    </SolidSection>
+    
+    <LogicalPartSection label="RP_Box_120.xml">
+        <LogicalPart name="RP_box_primary_vacuum">
+            <rSolid name="RP_box_primary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        <LogicalPart name="RP_box_secondary_vacuum">
+            <rSolid name="RP_box_secondary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_foil">
+            <rSolid name="RP_bottom_foil"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_Left_Right_Wall">
+            <rSolid name="RP_Left_Right_Wall"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+    </LogicalPartSection>
+    
+    <PosPartSection label="RP_Box_120.xml">
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_bottom_foil"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_box_secondary_vacuum"/>
+            <Translation x="0*mm" y="[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_secondary_vacuum"/>
+            <rChild name="RP_bottom_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Secondary_Vacuum_Height]/2+[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <rRotation name="RP_Transformations:RP_y_180_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="-[RP_Box:RP_Box_primary_vacuum_z]/2+[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="-[RP_Box:RP_Box_primary_vacuum_x]/2+[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+    </PosPartSection>
+   
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_121.xml
+++ b/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_121.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition>
+    
+    <SolidSection label="RP_Box_121.xml">
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_primary_vacuum_y]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_box_primary_vacuum"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_bottom_foil_base"/>
+        <Box dx="[RP_Box:RP_Box_Window_Bottom_Width]/2" dy="[RP_Box:RP_Box_Foil_Thickness]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Front_Thin_Wall_Thickness]" name="RP_bot_foil_front_cut"/>
+        <SubtractionSolid name="RP_bottom_foil_1">
+            <rSolid name="RP_bottom_foil_base"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+        </SubtractionSolid>
+         <SubtractionSolid name="RP_bottom_foil">
+             <rSolid name="RP_bottom_foil_1"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+         </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" name="RP_bot_hole_x"/>
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]+0.01*mm" name="RP_bot_hole_z"/>
+        <Tubs rMin="0*mm" rMax="2*mm" dz="[RP_Box:RP_Box_Bottom_Wall_Thickness]" startPhi="0*deg" deltaPhi="360*deg" name="RP_bot_hole_corner"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_bottom_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_primary_vacuum_y]/2-[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_box_secondary_vacuum"/>
+        <SubtractionSolid name="RP_bottom_wall_2a">
+            <rSolid name="RP_bottom_wall_1"/>
+            <rSolid name="RP_bot_hole_x"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_2">
+            <rSolid name="RP_bottom_wall_2a"/>
+            <rSolid name="RP_bot_hole_z"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_3">
+            <rSolid name="RP_bottom_wall_2"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_4">
+            <rSolid name="RP_bottom_wall_3"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_5">
+            <rSolid name="RP_bottom_wall_4"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_5"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RP_front_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_Window_Size]/2" dy="[RP_Box:RP_Box_Window_Size]/2-[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Rect"/>
+        <Tube rMin="0*mm" rMax="[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Curv"/>
+        <SubtractionSolid name="RP_front_wall_2">
+            <rSolid name="RP_front_wall_1"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_45_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_3">
+            <rSolid name="RP_front_wall_2"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_135_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_4">
+            <rSolid name="RP_front_wall_3"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]+([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_5">
+            <rSolid name="RP_front_wall_4"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="-([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_5"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <Box dx="[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2" name="RP_Left_Right_Wall"/>
+    </SolidSection>
+    
+    <LogicalPartSection label="RP_Box_121.xml">
+        <LogicalPart name="RP_box_primary_vacuum">
+            <rSolid name="RP_box_primary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        <LogicalPart name="RP_box_secondary_vacuum">
+            <rSolid name="RP_box_secondary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_foil">
+            <rSolid name="RP_bottom_foil"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_Left_Right_Wall">
+            <rSolid name="RP_Left_Right_Wall"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+    </LogicalPartSection>
+    
+    <PosPartSection label="RP_Box_121.xml">
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_bottom_foil"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_box_secondary_vacuum"/>
+            <Translation x="0*mm" y="[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_secondary_vacuum"/>
+            <rChild name="RP_bottom_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Secondary_Vacuum_Height]/2+[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <rRotation name="RP_Transformations:RP_y_180_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="-[RP_Box:RP_Box_primary_vacuum_z]/2+[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="-[RP_Box:RP_Box_primary_vacuum_x]/2+[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+    </PosPartSection>
+   
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_122.xml
+++ b/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_122.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition>
+    
+    <SolidSection label="RP_Box_122.xml">
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_primary_vacuum_y]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_box_primary_vacuum"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_bottom_foil_base"/>
+        <Box dx="[RP_Box:RP_Box_Window_Bottom_Width]/2" dy="[RP_Box:RP_Box_Foil_Thickness]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Front_Thin_Wall_Thickness]" name="RP_bot_foil_front_cut"/>
+        <SubtractionSolid name="RP_bottom_foil_1">
+            <rSolid name="RP_bottom_foil_base"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+        </SubtractionSolid>
+         <SubtractionSolid name="RP_bottom_foil">
+             <rSolid name="RP_bottom_foil_1"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+         </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" name="RP_bot_hole_x"/>
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]+0.01*mm" name="RP_bot_hole_z"/>
+        <Tubs rMin="0*mm" rMax="2*mm" dz="[RP_Box:RP_Box_Bottom_Wall_Thickness]" startPhi="0*deg" deltaPhi="360*deg" name="RP_bot_hole_corner"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_bottom_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_primary_vacuum_y]/2-[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_box_secondary_vacuum"/>
+        <SubtractionSolid name="RP_bottom_wall_2a">
+            <rSolid name="RP_bottom_wall_1"/>
+            <rSolid name="RP_bot_hole_x"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_2">
+            <rSolid name="RP_bottom_wall_2a"/>
+            <rSolid name="RP_bot_hole_z"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_3">
+            <rSolid name="RP_bottom_wall_2"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_4">
+            <rSolid name="RP_bottom_wall_3"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_5">
+            <rSolid name="RP_bottom_wall_4"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_5"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RP_front_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_Window_Size]/2" dy="[RP_Box:RP_Box_Window_Size]/2-[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Rect"/>
+        <Tube rMin="0*mm" rMax="[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Curv"/>
+        <SubtractionSolid name="RP_front_wall_2">
+            <rSolid name="RP_front_wall_1"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_45_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_3">
+            <rSolid name="RP_front_wall_2"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_135_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_4">
+            <rSolid name="RP_front_wall_3"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]+([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_5">
+            <rSolid name="RP_front_wall_4"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="-([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_5"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <Box dx="[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2" name="RP_Left_Right_Wall"/>
+    </SolidSection>
+    
+    <LogicalPartSection label="RP_Box_122.xml">
+        <LogicalPart name="RP_box_primary_vacuum">
+            <rSolid name="RP_box_primary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        <LogicalPart name="RP_box_secondary_vacuum">
+            <rSolid name="RP_box_secondary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_foil">
+            <rSolid name="RP_bottom_foil"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_Left_Right_Wall">
+            <rSolid name="RP_Left_Right_Wall"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+    </LogicalPartSection>
+    
+    <PosPartSection label="RP_Box_122.xml">
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_bottom_foil"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_box_secondary_vacuum"/>
+            <Translation x="0*mm" y="[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_secondary_vacuum"/>
+            <rChild name="RP_bottom_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Secondary_Vacuum_Height]/2+[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <rRotation name="RP_Transformations:RP_y_180_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="-[RP_Box:RP_Box_primary_vacuum_z]/2+[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="-[RP_Box:RP_Box_primary_vacuum_x]/2+[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+    </PosPartSection>
+   
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_123.xml
+++ b/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_123.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition>
+    
+    <SolidSection label="RP_Box_123.xml">
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_primary_vacuum_y]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_box_primary_vacuum"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_bottom_foil_base"/>
+        <Box dx="[RP_Box:RP_Box_Window_Bottom_Width]/2" dy="[RP_Box:RP_Box_Foil_Thickness]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Front_Thin_Wall_Thickness]" name="RP_bot_foil_front_cut"/>
+        <SubtractionSolid name="RP_bottom_foil_1">
+            <rSolid name="RP_bottom_foil_base"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+        </SubtractionSolid>
+         <SubtractionSolid name="RP_bottom_foil">
+             <rSolid name="RP_bottom_foil_1"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+         </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" name="RP_bot_hole_x"/>
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]+0.01*mm" name="RP_bot_hole_z"/>
+        <Tubs rMin="0*mm" rMax="2*mm" dz="[RP_Box:RP_Box_Bottom_Wall_Thickness]" startPhi="0*deg" deltaPhi="360*deg" name="RP_bot_hole_corner"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_bottom_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_primary_vacuum_y]/2-[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_box_secondary_vacuum"/>
+        <SubtractionSolid name="RP_bottom_wall_2a">
+            <rSolid name="RP_bottom_wall_1"/>
+            <rSolid name="RP_bot_hole_x"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_2">
+            <rSolid name="RP_bottom_wall_2a"/>
+            <rSolid name="RP_bot_hole_z"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_3">
+            <rSolid name="RP_bottom_wall_2"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_4">
+            <rSolid name="RP_bottom_wall_3"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_5">
+            <rSolid name="RP_bottom_wall_4"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_5"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RP_front_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_Window_Size]/2" dy="[RP_Box:RP_Box_Window_Size]/2-[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Rect"/>
+        <Tube rMin="0*mm" rMax="[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Curv"/>
+        <SubtractionSolid name="RP_front_wall_2">
+            <rSolid name="RP_front_wall_1"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_45_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_3">
+            <rSolid name="RP_front_wall_2"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_135_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_4">
+            <rSolid name="RP_front_wall_3"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]+([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_5">
+            <rSolid name="RP_front_wall_4"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="-([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_5"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <Box dx="[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2" name="RP_Left_Right_Wall"/>
+    </SolidSection>
+    
+    <LogicalPartSection label="RP_Box_123.xml">
+        <LogicalPart name="RP_box_primary_vacuum">
+            <rSolid name="RP_box_primary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        <LogicalPart name="RP_box_secondary_vacuum">
+            <rSolid name="RP_box_secondary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_foil">
+            <rSolid name="RP_bottom_foil"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_Left_Right_Wall">
+            <rSolid name="RP_Left_Right_Wall"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+    </LogicalPartSection>
+    
+    <PosPartSection label="RP_Box_123.xml">
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_bottom_foil"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_box_secondary_vacuum"/>
+            <Translation x="0*mm" y="[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_secondary_vacuum"/>
+            <rChild name="RP_bottom_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Secondary_Vacuum_Height]/2+[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <rRotation name="RP_Transformations:RP_y_180_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="-[RP_Box:RP_Box_primary_vacuum_z]/2+[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="-[RP_Box:RP_Box_primary_vacuum_x]/2+[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+    </PosPartSection>
+   
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_124.xml
+++ b/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_124.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition>
+    
+    <SolidSection label="RP_Box_124.xml">
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_primary_vacuum_y]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_box_primary_vacuum"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_bottom_foil_base"/>
+        <Box dx="[RP_Box:RP_Box_Window_Bottom_Width]/2" dy="[RP_Box:RP_Box_Foil_Thickness]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Front_Thin_Wall_Thickness]" name="RP_bot_foil_front_cut"/>
+        <SubtractionSolid name="RP_bottom_foil_1">
+            <rSolid name="RP_bottom_foil_base"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+        </SubtractionSolid>
+         <SubtractionSolid name="RP_bottom_foil">
+             <rSolid name="RP_bottom_foil_1"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+         </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" name="RP_bot_hole_x"/>
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]+0.01*mm" name="RP_bot_hole_z"/>
+        <Tubs rMin="0*mm" rMax="2*mm" dz="[RP_Box:RP_Box_Bottom_Wall_Thickness]" startPhi="0*deg" deltaPhi="360*deg" name="RP_bot_hole_corner"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_bottom_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_primary_vacuum_y]/2-[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_box_secondary_vacuum"/>
+        <SubtractionSolid name="RP_bottom_wall_2a">
+            <rSolid name="RP_bottom_wall_1"/>
+            <rSolid name="RP_bot_hole_x"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_2">
+            <rSolid name="RP_bottom_wall_2a"/>
+            <rSolid name="RP_bot_hole_z"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_3">
+            <rSolid name="RP_bottom_wall_2"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_4">
+            <rSolid name="RP_bottom_wall_3"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_5">
+            <rSolid name="RP_bottom_wall_4"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_5"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RP_front_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_Window_Size]/2" dy="[RP_Box:RP_Box_Window_Size]/2-[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Rect"/>
+        <Tube rMin="0*mm" rMax="[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Curv"/>
+        <SubtractionSolid name="RP_front_wall_2">
+            <rSolid name="RP_front_wall_1"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_45_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_3">
+            <rSolid name="RP_front_wall_2"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_135_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_4">
+            <rSolid name="RP_front_wall_3"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]+([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_5">
+            <rSolid name="RP_front_wall_4"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="-([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_5"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <Box dx="[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2" name="RP_Left_Right_Wall"/>
+    </SolidSection>
+    
+    <LogicalPartSection label="RP_Box_124.xml">
+        <LogicalPart name="RP_box_primary_vacuum">
+            <rSolid name="RP_box_primary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        <LogicalPart name="RP_box_secondary_vacuum">
+            <rSolid name="RP_box_secondary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_foil">
+            <rSolid name="RP_bottom_foil"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_Left_Right_Wall">
+            <rSolid name="RP_Left_Right_Wall"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+    </LogicalPartSection>
+    
+    <PosPartSection label="RP_Box_124.xml">
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_bottom_foil"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_box_secondary_vacuum"/>
+            <Translation x="0*mm" y="[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_secondary_vacuum"/>
+            <rChild name="RP_bottom_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Secondary_Vacuum_Height]/2+[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <rRotation name="RP_Transformations:RP_y_180_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="-[RP_Box:RP_Box_primary_vacuum_z]/2+[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="-[RP_Box:RP_Box_primary_vacuum_x]/2+[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+    </PosPartSection>
+   
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_125.xml
+++ b/Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_125.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition>
+    
+    <SolidSection label="RP_Box_125.xml">
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_primary_vacuum_y]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_box_primary_vacuum"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2" dy="[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2"
+            name="RP_bottom_foil_base"/>
+        <Box dx="[RP_Box:RP_Box_Window_Bottom_Width]/2" dy="[RP_Box:RP_Box_Foil_Thickness]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Front_Thin_Wall_Thickness]" name="RP_bot_foil_front_cut"/>
+        <SubtractionSolid name="RP_bottom_foil_1">
+            <rSolid name="RP_bottom_foil_base"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+        </SubtractionSolid>
+         <SubtractionSolid name="RP_bottom_foil">
+             <rSolid name="RP_bottom_foil_1"/>
+            <rSolid name="RP_bot_foil_front_cut"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_Box:RP_Box_primary_vacuum_z]/2"/>
+         </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" name="RP_bot_hole_x"/>
+        <Box dx="[RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius]+0.01*mm" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]+0.01*mm" name="RP_bot_hole_z"/>
+        <Tubs rMin="0*mm" rMax="2*mm" dz="[RP_Box:RP_Box_Bottom_Wall_Thickness]" startPhi="0*deg" deltaPhi="360*deg" name="RP_bot_hole_corner"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_bottom_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_primary_vacuum_y]/2-[RP_Box:RP_Box_Foil_Thickness]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]" name="RP_box_secondary_vacuum"/>
+        <SubtractionSolid name="RP_bottom_wall_2a">
+            <rSolid name="RP_bottom_wall_1"/>
+            <rSolid name="RP_bot_hole_x"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_2">
+            <rSolid name="RP_bottom_wall_2a"/>
+            <rSolid name="RP_bot_hole_z"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_3">
+            <rSolid name="RP_bottom_wall_2"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_4">
+            <rSolid name="RP_bottom_wall_3"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="-([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_5">
+            <rSolid name="RP_bottom_wall_4"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_5"/>
+            <rSolid name="RP_bot_hole_corner"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="-([RP_Box:RP_Box_Bottom_Hole_x]/2-[RP_Box:RP_Box_Bottom_Hole_radius])" y="0*mm" z="([RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]-[RP_Box:RP_Box_Bottom_Hole_radius])"/>
+        </SubtractionSolid>
+        
+        <Box dx="[RP_Box:RP_Box_primary_vacuum_x]/2 - [RP_Box:RP_Box_Right_Left_Wall_Thickness]" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RP_front_wall_1"/>
+        <Box dx="[RP_Box:RP_Box_Window_Size]/2" dy="[RP_Box:RP_Box_Window_Size]/2-[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Rect"/>
+        <Tube rMin="0*mm" rMax="[RP_Box:RP_Box_Window_Radius]" dz="[RP_Box:RP_Box_Front_Wall_Thickness]/2" name="RB_Box_Window_Curv"/>
+        <SubtractionSolid name="RP_front_wall_2">
+            <rSolid name="RP_front_wall_1"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_45_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_3">
+            <rSolid name="RP_front_wall_2"/>
+            <rSolid name="RB_Box_Window_Rect"/>
+            <rRotation name="RP_Transformations:RP_135_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_4">
+            <rSolid name="RP_front_wall_3"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]+([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_5">
+            <rSolid name="RP_front_wall_4"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="-([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_5"/>
+            <rSolid name="RB_Box_Window_Curv"/>
+            <Translation x="([RP_Box:RP_Box_Window_Size]-2*[RP_Box:RP_Box_Window_Radius])/sqrt(2)" y="-[RP_Box:RP_Box_Height]/2+[RP_Box:RP_Box_Window_Center_From_Bottom]" z="[RP_Box:RP_Box_Front_Thin_Wall_Thickness]"/>
+        </SubtractionSolid>
+        <Box dx="[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" dy="[RP_Box:RP_Box_Height]/2" dz="[RP_Box:RP_Box_primary_vacuum_z]/2" name="RP_Left_Right_Wall"/>
+    </SolidSection>
+    
+    <LogicalPartSection label="RP_Box_125.xml">
+        <LogicalPart name="RP_box_primary_vacuum">
+            <rSolid name="RP_box_primary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        <LogicalPart name="RP_box_secondary_vacuum">
+            <rSolid name="RP_box_secondary_vacuum"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_foil">
+            <rSolid name="RP_bottom_foil"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_bottom_wall_6">
+            <rSolid name="RP_bottom_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_front_wall_6">
+            <rSolid name="RP_front_wall_6"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+        <LogicalPart name="RP_Left_Right_Wall">
+            <rSolid name="RP_Left_Right_Wall"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        
+    </LogicalPartSection>
+    
+    <PosPartSection label="RP_Box_125.xml">
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_bottom_foil"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_box_secondary_vacuum"/>
+            <Translation x="0*mm" y="[RP_Box:RP_Box_Foil_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_secondary_vacuum"/>
+            <rChild name="RP_bottom_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_Secondary_Vacuum_Height]/2+[RP_Box:RP_Box_Bottom_Wall_Thickness]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="[RP_Box:RP_Box_primary_vacuum_z]/2-[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_front_wall_6"/>
+            <rRotation name="RP_Transformations:RP_y_180_rot"/>
+            <Translation x="0*mm" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="-[RP_Box:RP_Box_primary_vacuum_z]/2+[RP_Box:RP_Box_Front_Wall_Thickness]/2"/>
+        </PosPart>
+        <PosPart copyNumber="0">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="-[RP_Box:RP_Box_primary_vacuum_x]/2+[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_box_primary_vacuum"/>
+            <rChild name="RP_Left_Right_Wall"/>
+            <Translation x="[RP_Box:RP_Box_primary_vacuum_x]/2-[RP_Box:RP_Box_Right_Left_Wall_Thickness]/2" y="-[RP_Box:RP_Box_primary_vacuum_y]/2+[RP_Box:RP_Box_Foil_Thickness]+[RP_Box:RP_Box_Height]/2" z="0*mm"/>
+        </PosPart>
+    </PosPartSection>
+   
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/RP_Device/v1/RP_Device.xml
+++ b/Geometry/VeryForwardData/data/RP_Device/v1/RP_Device.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition>
+    <ConstantsSection label="RP_Device.xml" eval="true">
+        <Constant name="RP_Device_RP_Hole_Diam" value="150*mm"/>
+        <Constant name="RP_Device_Beam_Hole_Diam" value="80*mm"/>
+        <Constant name="RP_Device_Wall_Thickness" value="2*mm"/>
+        <Constant name="RP_Device_Length_z" value="180*mm"/>
+        <Constant name="RP_Device_Length_y" value="112*mm"/>
+        <Constant name="RP_Device_Det_Bellow_Length" value="93.7*mm"/>
+        <Constant name="RP_Device_Envelope_Radius" value="450*mm"/>
+    </ConstantsSection>
+    <!--SolidSection label="RP_Device.xml">  
+        <Tube rMin="0*mm" rMax="[RP_Device_Beam_Hole_Diam]/2+[RP_Device_Wall_Thickness]" dz="[RP_Device_Length_z]/2" name="RP_Device_Beam_Pipe"/>
+        <Tube rMin="0*mm" rMax="[RP_Device_RP_Hole_Diam]/2+[RP_Device_Wall_Thickness]" dz="[RP_Device_Length_y]/2" name="RP_Device_RP_Hole"/>
+        <Tube rMin="0*mm" rMax="[RP_Device_Beam_Hole_Diam]/2" dz="[RP_Device_Length_z]" name="RP_Device_Beam_Pipe_Interior"/>
+        <Tube rMin="0*mm" rMax="[RP_Device_RP_Hole_Diam]/2" dz="[RP_Device_Length_y]" name="RP_Device_RP_Hole_Interior"/>
+        <UnionSolid name="RP_Device_Corp_1">
+            <rSolid name="RP_Device_Beam_Pipe"/>
+            <rSolid name="RP_Device_RP_Hole"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+        </UnionSolid>
+        <SubtractionSolid name="RP_Device_Corp_2">
+            <rSolid name="RP_Device_Corp_1"/>
+            <rSolid name="RP_Device_Beam_Pipe_Interior"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_Device_Corp_3">
+            <rSolid name="RP_Device_Corp_2"/>
+            <rSolid name="RP_Device_RP_Hole_Interior"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+        </SubtractionSolid>
+    </SolidSection>
+    
+    <LogicalPartSection label="RP_Device.xml">
+        <LogicalPart name="RP_Device_Corp_3">
+            <rSolid name="RP_Device_Corp_3"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    
+    <PosPartSection label="RP_Device.xml">
+    </PosPartSection-->
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/RP_Horizontal_Device/2021/Simu/v2/RP_Horizontal_Device.xml
+++ b/Geometry/VeryForwardData/data/RP_Horizontal_Device/2021/Simu/v2/RP_Horizontal_Device.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition>
+    <ConstantsSection label="RP_Horizontal_Device.xml" eval="true">
+        <Constant name="RP_Device_Hor_Closed_Wall_Thick_Ext" value="2*mm"/>
+        <Constant name="RP_Device_Hor_Closed_Wall_Thick_Int" value="2*mm"/>
+        <Constant name="RP_Device_Hor_RP_Section_Tot_Length" value="[RP_Device:RP_Device_Length_y]+[RP_Device:RP_Device_Det_Bellow_Length]+[RP_Device_Hor_Closed_Wall_Thick_Ext]"/>
+    </ConstantsSection>
+    
+    <SolidSection label="RP_Horizontal_Device.xml">  
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="[RP_Device:RP_Device_Length_z]/2" name="RP_Device_Hor_Beam_Pipe"/>
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="[RP_Device_Hor_RP_Section_Tot_Length]/2" name="RP_Device_Hor_RP_Hole"/>
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2" dz="[RP_Device:RP_Device_Length_z]" name="RP_Device_Hor_Beam_Pipe_Interior"/>
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2" dz="[RP_Device_Hor_RP_Section_Tot_Length]" name="RP_Device_Hor_RP_Hole_Interior"/>
+        <UnionSolid name="RP_Device_Hor_Corp_1">
+            <rSolid name="RP_Device_Hor_Beam_Pipe"/>
+            <rSolid name="RP_Device_Hor_RP_Hole"/>
+            <rRotation name="RP_Transformations:RP_y_90_rot"/>
+            <Translation x="[RP_Device:RP_Device_Det_Bellow_Length]/2-[RP_Device_Hor_Closed_Wall_Thick_Ext]/2" y="0*mm" z="0*mm"/>
+        </UnionSolid>
+        <SubtractionSolid name="RP_Device_Hor_Corp_2">
+            <rSolid name="RP_Device_Hor_Corp_1"/>
+            <rSolid name="RP_Device_Hor_Beam_Pipe_Interior"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_Device_Hor_Corp_3">
+            <rSolid name="RP_Device_Hor_Corp_2"/>
+            <rSolid name="RP_Device_Hor_RP_Hole_Interior"/>
+            <rRotation name="RP_Transformations:RP_y_90_rot"/>
+            <Translation x="[RP_Device_Hor_RP_Section_Tot_Length]-[RP_Device:RP_Device_Length_y]/2+[RP_Device_Hor_Closed_Wall_Thick_Int]" y="0*mm" z="0*mm"/>
+        </SubtractionSolid>
+    </SolidSection>
+    
+    <LogicalPartSection label="RP_Horizontal_Device.xml">
+        <LogicalPart name="RP_Device_Hor_Corp_3">
+            <rSolid name="RP_Device_Hor_Corp_3"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/RP_Hybrid/v2/RP_Hybrid.xml
+++ b/Geometry/VeryForwardData/data/RP_Hybrid/v2/RP_Hybrid.xml
@@ -1,0 +1,240 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition>
+    <ConstantsSection label="RP_Hybrid.xml" eval="true">
+<!--
+    Detector
+       a
+    ________
+    |      |
+    |      |b
+    |      |
+    |      |
+    ========
+
+       Top
+       /\
+     a/  \b
+     /    \
+Left/      \Right
+    \      /
+    c\    /d
+      ====
+
+Sizes and fiducial positions are taken from Eric's drawings, rev. TOTEM v2-A3.
+-->
+        <Constant name="RP_Det_Edge_Length" value="22.276*mm"/>
+        <Constant name="RP_Det_Size_a" value="36.07*mm"/>
+        <Constant name="RP_Det_Size_b" value="36.07*mm"/>
+        <Constant name="RP_Det_Fid_Top_a" value="0.301*mm"/>
+        <Constant name="RP_Det_Fid_Top_b" value="1.0275*mm"/>
+        <Constant name="RP_Det_Fid_Left_a" value="0.301*mm"/>
+        <Constant name="RP_Det_Fid_Left_c" value="0.2985*mm"/>
+        <Constant name="RP_Det_Fid_Right_b" value="1.0275*mm"/>
+        <Constant name="RP_Det_Fid_Right_d" value="1.0255*mm"/>
+        <Constant name="xT" value="[RP_Det_Size_a]/2-[RP_Det_Fid_Top_b]"/>
+        <Constant name="yT" value="[RP_Det_Size_b]/2-[RP_Det_Fid_Top_a]"/>
+        <Constant name="xL" value="-[RP_Det_Size_a]/2+[RP_Det_Fid_Left_c]"/>
+        <Constant name="yL" value="[RP_Det_Size_b]/2-[RP_Det_Fid_Left_a]"/>
+        <Constant name="xR" value="[RP_Det_Size_a]/2-[RP_Det_Fid_Right_b]"/>
+        <Constant name="yR" value="-[RP_Det_Size_b]/2+[RP_Det_Fid_Right_d]"/>
+<!--
+displacement of the intersection of fiducial-guided lines wrt the geometric centre
+calculated as a solution of the linear system consisting of the equation of the
+line going through left and right fiducials and the distance to the middle
+between left and right fiducials, i.e.:
+(y-yL)(xR-xL)-(yR-yL)(x-xL)=0
+sqrt((xR-x)^2+(yR-y)^2)=0.5*sqrt((xR-xL)^2+(yR-yL)^2)
+-->
+        <Constant name="RP_Det_dx_0" value="([RP_Det_Fid_Left_c]-[RP_Det_Fid_Right_b])/2"/>
+<!-- RP_Det_dx = -0.3645 -->
+        <Constant name="RP_Det_dy_0" value="([RP_Det_Fid_Right_d]-[RP_Det_Fid_Left_a])/2"/>
+<!-- RP_Det_dy = 0.362 -->
+        <Constant name="RP_Det_dx" value="([RP_Det_dx_0]-[RP_Det_dy_0])/sqrt(2)"/>
+<!-- -0.514 -->
+        <Constant name="RP_Det_dy" value="([RP_Det_dx_0]+[RP_Det_dy_0])/sqrt(2)"/>
+<!-- -0.016 -->
+        <Constant name="RP_Det_Thickness" value="0.3*mm"/>
+        <Constant name="RP_Det_Edge_to_Center" value="abs([RP_Det_dx_0]+[RP_Det_dy_0]-[RP_Det_Size_a]+[RP_Det_Edge_Length]/sqrt(2))/sqrt(2)"/>
+<!-- RP_Det_Edge_to_Center = 14.369 -->
+        
+        <Constant name="RP_Ref_Hole_Radius" value="5/2*mm"/>
+        <Constant name="RP_Front_Frame_Hole_Bottom_diagonal" value="80*mm"/>
+        <Constant name="RP_Front_Frame_Hole_Bottom_size" value="[RP_Front_Frame_Hole_Bottom_diagonal]*sqrt(2)*0.5"/>
+        <Constant name="RP_Front_Frame_Leg_x" value="5*mm"/>
+        <Constant name="RP_Front_Frame_Leg_y" value="3.2*mm"/>
+        <Constant name="RP_Front_Frame_Leg_Thin_y" value="1.6*mm"/>
+        <Constant name="RP_Front_Frame_Leg_Thin_z" value="0.45*mm"/>
+        <Constant name="RP_Front_Frame_Leg_Base_y" value="[RP_Front_Frame_Leg_y]-[RP_Front_Frame_Leg_Thin_y]"/>
+        <Constant name="RP_Front_Frame_X" value="118*mm"/> <!-- without positioning struts (2mm left, 3mm right) -->
+        <Constant name="RP_Front_Frame_Y_full" value="80.2*mm"/> <!-- with positioning "legs" -->
+        <Constant name="RP_Front_Frame_Y" value="[RP_Front_Frame_Y_full]-[RP_Front_Frame_Leg_y]"/> <!-- without positioning "legs" -->
+        <Constant name="RP_Front_Frame_Z" value="1*mm"/>
+        <Constant name="RP_Front_Frame_Ref_x" value="11.5*mm"/>
+        <Constant name="RP_Front_Frame_Ref_y" value="44.2*mm"/>
+        <Constant name="RP_Front_Frame_Ref_Hole_Dist" value="101*mm"/>
+        <Constant name="RP_Front_Frame_Ref_Hole_dy" value="-[RP_Front_Frame_Y]/2-[RP_Front_Frame_Leg_y]+[RP_Front_Frame_Ref_y]"/>
+        <Constant name="RP_Barrette_Thick_x" value="13*mm"/>
+        <Constant name="RP_Barrette_Thin_x" value="23*mm-[RP_Barrette_Thick_x]"/>
+        <Constant name="RP_Barrette_y" value="78*mm"/>
+        <Constant name="RP_Barrette_Thick_z" value="4.5*mm"/>
+        <Constant name="RP_Barrette_Thin_z" value="0.8*mm"/>
+        <Constant name="RP_Barrette_Ref_y" value="42*mm"/>
+        <Constant name="RP_Barrette_Ref_Hole_dx" value="-[RP_Barrette_Thick_x]/2+8.5*mm"/>
+        <Constant name="RP_Barrette_Ref_Hole_dy" value="-[RP_Barrette_y]/2+[RP_Barrette_Ref_y]"/>
+        <Constant name="RP_PCB_x" value="90*mm"/>
+        <Constant name="RP_PCB_y" value="78*mm"/>
+        <Constant name="RP_PCB_z" value="1.25*mm"/>
+        <Constant name="RP_PCB_Hole_Size" value="30*mm"/>
+        <Constant name="RP_PCB_Hole_dy" value="10.42*mm"/>
+        
+    </ConstantsSection>
+    
+    <SolidSection label="RP_Hybrid.xml">
+        <Box dx="[RP_Front_Frame_X]/2" dy="[RP_Front_Frame_Y]/2" dz="[RP_Front_Frame_Z]/2" name="RP_Front_Frame_1"/>
+        <Box dx="[RP_Front_Frame_Hole_Bottom_size]/2" dy="[RP_Front_Frame_Hole_Bottom_size]/2" dz="[RP_Front_Frame_Z]" name="RP_Hole_1"/>
+        <Box dx="[RP_Front_Frame_Leg_x]/2" dy="[RP_Front_Frame_Leg_Base_y]/2" dz="[RP_Front_Frame_Z]/2" name="RP_Front_Frame_Leg_Base"/>
+        <Trd1 dx1="2/2*mm" dx2="5/2*mm" dy1="[RP_Front_Frame_Leg_Thin_z]/2" dy2="[RP_Front_Frame_Leg_Thin_z]/2" dz="[RP_Front_Frame_Leg_Thin_y]/2" name="RP_Front_Frame_Leg_Strut"/>
+        <Tubs rMin="0*mm" rMax="[RP_Ref_Hole_Radius]" dz="[RP_Front_Frame_Z]" startPhi="0*deg" deltaPhi="360*deg" name="RP_Front_Frame_Ref_Hole"/>
+        <UnionSolid name="RP_Front_Frame_Leg">
+            <rSolid name="RP_Front_Frame_Leg_Base"/>
+            <rSolid name="RP_Front_Frame_Leg_Strut"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="0*mm" y="-[RP_Front_Frame_Leg_Base_y]/2-[RP_Front_Frame_Leg_Thin_y]/2" z="-[RP_Front_Frame_Z]/2+[RP_Front_Frame_Leg_Thin_z]/2"/>
+        </UnionSolid>
+        <SubtractionSolid name="RP_Front_Frame_2">
+            <rSolid name="RP_Front_Frame_1"/>
+            <rSolid name="RP_Hole_1"/>
+            <rRotation name="RP_Transformations:RP_45_z_rot"/>
+            <Translation x="0*mm" y="-[RP_Front_Frame_Y]/2" z="0*mm" />
+        </SubtractionSolid>
+        <UnionSolid name="RP_Front_Frame_3a">
+            <rSolid name="RP_Front_Frame_2"/>
+            <rSolid name="RP_Front_Frame_Leg"/>
+            <Translation x="-[RP_Front_Frame_Hole_Bottom_diagonal]/2-[RP_Front_Frame_Leg_x]/2" y="-[RP_Front_Frame_Y]/2-[RP_Front_Frame_Leg_Base_y]/2" z="0*mm"/>
+        </UnionSolid>
+        <UnionSolid name="RP_Front_Frame_3b">
+            <rSolid name="RP_Front_Frame_3a"/>
+            <rSolid name="RP_Front_Frame_Leg"/>
+            <Translation x="[RP_Front_Frame_Hole_Bottom_diagonal]/2+[RP_Front_Frame_Leg_x]/2" y="-[RP_Front_Frame_Y]/2-[RP_Front_Frame_Leg_Base_y]/2" z="0*mm"/>
+        </UnionSolid>
+        <SubtractionSolid name="RP_Front_Frame_3h_Right">
+            <rSolid name="RP_Front_Frame_3b"/>
+            <rSolid name="RP_Front_Frame_Ref_Hole"/>
+            <Translation x="[RP_Front_Frame_Ref_Hole_Dist]/2" y="[RP_Front_Frame_Ref_Hole_dy]" z="0*mm"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_Front_Frame_3h">
+            <rSolid name="RP_Front_Frame_3h_Right"/>
+            <rSolid name="RP_Front_Frame_Ref_Hole"/>
+            <Translation x="-[RP_Front_Frame_Ref_Hole_Dist]/2" y="[RP_Front_Frame_Ref_Hole_dy]" z="0*mm"/>
+        </SubtractionSolid>
+        <Trd1 dx1="3/2*mm" dx2="3*(1+2*tan((90-10)*deg))/2*mm" dy1="[RP_Front_Frame_Z]/2" dy2="[RP_Front_Frame_Z]/2" dz="3/2*mm" name="RP_Front_Frame_Right_Strut_base"/>
+        <!-- the box below is intentionally two times thicker to avoid visualisation errors due to lack of precision -->
+        <Box dx="3*tan((90-10)*deg)/2*mm" dy="[RP_Front_Frame_Z]" dz="3/2*mm" name="RP_Front_Frame_Right_Strut_cut"/>
+        <SubtractionSolid name="RP_Front_Frame_Right_Strut">
+            <rSolid name="RP_Front_Frame_Right_Strut_base"/>
+            <rSolid name="RP_Front_Frame_Right_Strut_cut"/>
+            <Translation x="3*(1+tan((90-10)*deg))/2*mm" y="0*mm" z="0*mm"/>
+        </SubtractionSolid>
+        <UnionSolid name="RP_Front_Frame_3">
+            <rSolid name="RP_Front_Frame_3h"/>
+            <rSolid name="RP_Front_Frame_Right_Strut"/>
+            <rRotation name="RP_Transformations:RP_y_270_z_90_rot"/>
+            <Translation x="[RP_Front_Frame_X]/2+3/2*mm" y="[RP_Front_Frame_Ref_Hole_dy]+3/2*mm" z="0*mm"/>
+        </UnionSolid>
+        <UnionSolid name="RP_Back_Frame_3">
+            <rSolid name="RP_Front_Frame_3h"/>
+            <rSolid name="RP_Front_Frame_Right_Strut"/>
+            <rRotation name="RP_Transformations:RP_y_90_z_90_rot"/>
+            <Translation x="-([RP_Front_Frame_X]/2+3/2*mm)" y="[RP_Front_Frame_Ref_Hole_dy]+3/2*mm" z="0*mm"/>
+        </UnionSolid>
+
+        <Box dx="[RP_Barrette_Thick_x]/2" dy="[RP_Barrette_y]/2" dz="[RP_Barrette_Thick_z]/2" name="RP_Barrette_Thick_Base"/>
+        <Box dx="[RP_Barrette_Thin_x]/2"  dy="[RP_Barrette_y]/2" dz="[RP_Barrette_Thin_z]/2" name="RP_Barrette_Thin_Base"/>
+        <Tubs rMin="0*mm" rMax="[RP_Ref_Hole_Radius]" dz="[RP_Barrette_Thick_z]" startPhi="0*deg" deltaPhi="360*deg" name="RP_Barrette_Ref_Hole"/>
+        <Box dx="9/2*mm" dy="6/2*mm" dz="[RP_Barrette_Thick_z]/2" name="RP_Barrette_Bottom_Cut"/>
+        <UnionSolid name="RP_Barrette_Base_Left">
+            <rSolid name="RP_Barrette_Thick_Base"/>
+            <rSolid name="RP_Barrette_Thin_Base"/>
+            <Translation x="[RP_Barrette_Thick_x]/2+[RP_Barrette_Thin_x]/2" y="0*mm" z="[RP_Barrette_Thick_z]/2-[RP_Barrette_Thin_z]/2"/>
+        </UnionSolid>
+        <SubtractionSolid name="RP_Barrette_Left_1">
+            <rSolid name="RP_Barrette_Base_Left"/>
+            <rSolid name="RP_Barrette_Ref_Hole"/>
+            <Translation x="[RP_Barrette_Ref_Hole_dx]" y="[RP_Barrette_Ref_Hole_dy]" z="0*mm"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_Barrette_Left">
+            <rSolid name="RP_Barrette_Left_1"/>
+            <rSolid name="RP_Barrette_Bottom_Cut"/>
+            <Translation x="-[RP_Barrette_Thick_x]/2+9/2*mm" y="-[RP_Barrette_y]/2+6/2*mm" z="0*mm"/>
+        </SubtractionSolid>
+
+        <UnionSolid name="RP_Barrette_Base_Right">
+            <rSolid name="RP_Barrette_Thick_Base"/>
+            <rSolid name="RP_Barrette_Thin_Base"/>
+            <Translation x="-([RP_Barrette_Thick_x]/2+[RP_Barrette_Thin_x]/2)" y="0*mm" z="[RP_Barrette_Thick_z]/2-[RP_Barrette_Thin_z]/2"/>
+        </UnionSolid>
+        <SubtractionSolid name="RP_Barrette_Right_1">
+            <rSolid name="RP_Barrette_Base_Right"/>
+            <rSolid name="RP_Barrette_Ref_Hole"/>
+            <Translation x="-[RP_Barrette_Ref_Hole_dx]" y="[RP_Barrette_Ref_Hole_dy]" z="0*mm"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_Barrette_Right">
+            <rSolid name="RP_Barrette_Right_1"/>
+            <rSolid name="RP_Barrette_Bottom_Cut"/>
+            <Translation x="[RP_Barrette_Thick_x]/2-9/2*mm" y="[RP_Barrette_y]/2-6/2*mm" z="0*mm"/>
+        </SubtractionSolid>
+
+        <Box dx="[RP_PCB_x]/2" dy="[RP_PCB_y]/2" dz="[RP_PCB_z]/2" name="RP_PCB_1"/>
+        <Box dx="[RP_PCB_Hole_Size]/2" dy="[RP_PCB_Hole_Size]/2" dz="[RP_PCB_z]" name="RP_PCB_Hole"/>
+        <SubtractionSolid name="RP_PCB">
+            <rSolid name="RP_PCB_1"/>
+            <rSolid name="RP_PCB_Hole"/>
+            <rRotation name="RP_Transformations:RP_45_z_rot"/>
+            <Translation x="0*mm" y="-[RP_PCB_y]/2+[RP_PCB_Hole_dy]" z="0*mm"/>
+        </SubtractionSolid>
+        <Box dx="[RP_Det_Size_a]/2" dy="[RP_Det_Size_b]/2" dz="[RP_Det_Thickness]/2" name="RP_Silicon_Detector_1"/>
+        <Box dx="[RP_Det_Edge_Length]/2" dy="[RP_Det_Edge_Length]/2" dz="[RP_Det_Thickness]" name="RP_Silicon_Det_Edge_Cut"/>
+        <SubtractionSolid name="RP_Silicon_Detector">
+            <rSolid name="RP_Silicon_Detector_1"/>
+            <rSolid name="RP_Silicon_Det_Edge_Cut"/>
+            <rRotation name="RP_Transformations:RP_45_z_rot"/>
+            <Translation x="-[RP_Det_Size_a]/2" y="-[RP_Det_Size_b]/2" z="0*mm"/>
+        </SubtractionSolid>
+    </SolidSection>
+    
+    <LogicalPartSection label="RP_Hybrid.xml">
+        <LogicalPart name="RP_Front_Frame_3">
+            <rSolid name="RP_Front_Frame_3"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_Back_Frame_3">
+            <rSolid name="RP_Back_Frame_3"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_Barrette_Left">
+            <rSolid name="RP_Barrette_Left"/>
+            <rMaterial name="RP_Materials:PPS_CE7"/>
+        </LogicalPart>
+        <LogicalPart name="RP_Barrette_Right">
+            <rSolid name="RP_Barrette_Right"/>
+            <rMaterial name="RP_Materials:PPS_CE7"/>
+        </LogicalPart>
+        <LogicalPart name="RP_PCB">
+            <rSolid name="RP_PCB"/>
+            <rMaterial name="RP_Materials:PPS_PCB"/>
+        </LogicalPart>
+        <LogicalPart name="RP_Silicon_Detector">
+            <rSolid name="RP_Silicon_Detector"/>
+            <rMaterial name="materials:Silicon"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    
+    <!--PosPartSection label="RP_Hybrid.xml">
+        <PosPart copyNumber="0">
+            <rParent name="RP_Box:RP_box_primary_vacuum"/>
+            <rChild name="RP_Silicon_Detector"/>
+            <rRotation name="RP_Transformations:RP_45_z_180_y_rot"/>
+        </PosPart>
+    </PosPartSection-->
+    
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/RP_Materials/v4/RP_Materials.xml
+++ b/Geometry/VeryForwardData/data/RP_Materials/v4/RP_Materials.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0"?>
+<DDDefinition>
+
+ <MaterialSection label="RP_Materials.xml">
+  <CompositeMaterial name="PPS_AISI-316L-Steel" density="8*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0003">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.02">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00045">
+    <rMaterial name="materials:Phosphor"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0003">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.18">
+    <rMaterial name="materials:Chromium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.025">
+    <rMaterial name="materials:Molybdenum"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.64395">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  
+  <CompositeMaterial name="PPS_Epoxy" density="1.32*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.53539691">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.13179314">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33280996">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="PPS_PCB" density="1.957*g/cm3" symbol=" " method="mixture by weight">
+  <MaterialFraction fraction="0.2562774130">
+   <rMaterial name="materials:Silicon"/>
+  </MaterialFraction>
+  <MaterialFraction fraction="0.4720560530">
+   <rMaterial name="materials:Oxygen"/>
+  </MaterialFraction>
+  <MaterialFraction fraction="0.0054740637">
+   <rMaterial name="materials:Bor 10"/>
+  </MaterialFraction>
+  <MaterialFraction fraction="0.0240858800">
+   <rMaterial name="materials:Bor 11"/>
+  </MaterialFraction>
+  <MaterialFraction fraction="0.0419495748">
+   <rMaterial name="materials:Sodium"/>
+  </MaterialFraction>
+  <MaterialFraction fraction="0.1606190730">
+   <rMaterial name="materials:Carbon"/>
+  </MaterialFraction>
+  <MaterialFraction fraction="0.0395379420">
+   <rMaterial name="materials:Hydrogen"/>
+  </MaterialFraction>
+ </CompositeMaterial>
+ 
+  <CompositeMaterial name="PPS_CE7" density="2.44*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.3">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+ </MaterialSection>
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/RP_Vertical_Device/2021/Simu/v2/RP_Vertical_Device.xml
+++ b/Geometry/VeryForwardData/data/RP_Vertical_Device/2021/Simu/v2/RP_Vertical_Device.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition>
+    <ConstantsSection label="RP_Vertical_Device.xml" eval="true">
+    </ConstantsSection>
+    
+    <SolidSection label="RP_Vertical_Device.xml">  
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="[RP_Device:RP_Device_Length_z]/2" name="RP_Device_Vert_Beam_Pipe"/>
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="[RP_Device:RP_Device_Length_y]/2+[RP_Device:RP_Device_Det_Bellow_Length]" name="RP_Device_Vert_RP_Hole"/>
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2" dz="[RP_Device:RP_Device_Length_z]" name="RP_Device_Vert_Beam_Pipe_Interior"/>
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2" dz="[RP_Device:RP_Device_Length_y]+2*[RP_Device:RP_Device_Det_Bellow_Length]" name="RP_Device_Vert_RP_Hole_Interior"/>
+        <UnionSolid name="RP_Device_Vert_Corp_1">
+            <rSolid name="RP_Device_Vert_Beam_Pipe"/>
+            <rSolid name="RP_Device_Vert_RP_Hole"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+        </UnionSolid>
+        <SubtractionSolid name="RP_Device_Vert_Corp_2">
+            <rSolid name="RP_Device_Vert_Corp_1"/>
+            <rSolid name="RP_Device_Vert_Beam_Pipe_Interior"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="RP_Device_Vert_Corp_3">
+            <rSolid name="RP_Device_Vert_Corp_2"/>
+            <rSolid name="RP_Device_Vert_RP_Hole_Interior"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+        </SubtractionSolid>
+    </SolidSection>
+    
+    <LogicalPartSection label="RP_Vertical_Device.xml">
+        <LogicalPart name="RP_Device_Vert_Corp_3">
+            <rSolid name="RP_Device_Vert_Corp_3"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    
+</DDDefinition>


### PR DESCRIPTION
#### PR description:

Backport the xml files needed for a more correct Run3 geometry scenario definition. This is the split version of #35108 retaining only the xml parts

#### PR validation:

Use the runTheMatrix test workflows in #35108

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Done in many PR's for 12_1_X and these files are from 12_1_X