### PR TITLE
Removed lexical_cast boost dependency in DQM

### DIFF
--- a/DQM/HcalCommon/interface/HcalCommonHeaders.h
+++ b/DQM/HcalCommon/interface/HcalCommonHeaders.h
@@ -56,7 +56,6 @@
 
 #include "DQM/HcalCommon/interface/Constants.h"
 
-#include "boost/lexical_cast.hpp"
 #include <algorithm>
 #include <sstream>
 #include <typeinfo>

--- a/DQM/L1TMonitor/interface/L1ExtraDQM.h
+++ b/DQM/L1TMonitor/interface/L1ExtraDQM.h
@@ -65,7 +65,6 @@
 
 #include "DQMServices/Core/interface/DQMStore.h"
 
-#include "boost/lexical_cast.hpp"
 #include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 
 // forward declarations

--- a/DQM/SiStripCommissioningSources/src/PedsFullNoiseTask.cc
+++ b/DQM/SiStripCommissioningSources/src/PedsFullNoiseTask.cc
@@ -9,8 +9,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "boost/lexical_cast.hpp"
-
 // -----------------------------------------------------------------------------
 //
 PedsFullNoiseTask::PedsFullNoiseTask(DQMStore* dqm, const FedChannelConnection& conn, const edm::ParameterSet& pset)

--- a/DQMOffline/CalibTracker/plugins/SiStripBadComponentsDQMServiceReader.cc
+++ b/DQMOffline/CalibTracker/plugins/SiStripBadComponentsDQMServiceReader.cc
@@ -8,8 +8,6 @@
 #include <cstdio>
 #include <sys/time.h>
 
-#include <boost/lexical_cast.hpp>
-
 using namespace std;
 
 SiStripBadComponentsDQMServiceReader::SiStripBadComponentsDQMServiceReader(const edm::ParameterSet& iConfig)
@@ -47,7 +45,7 @@ void SiStripBadComponentsDQMServiceReader::analyze(const edm::Event& e, const ed
       unsigned int value = (*(range.first + it));
       ss << detIdToString(detid[id], tTopo) << "\t" << detid[id] << "\t";
 
-      uint32_t flag = boost::lexical_cast<uint32_t>(siStripBadStrip.decode(value).flag);
+      uint32_t flag = static_cast<uint32_t>(siStripBadStrip.decode(value).flag);
 
       printError(ss, ((flag & FedErrorMask) == FedErrorMask), "Fed error, ");
       printError(ss, ((flag & DigiErrorMask) == DigiErrorMask), "Digi error, ");
@@ -120,7 +118,7 @@ string SiStripBadComponentsDQMServiceReader::detIdToString(DetId detid, const Tr
     name += "+";
   }
   //   if( side != -1 ) {
-  //     name += boost::lexical_cast<string>(side);
+  //     name += std::to_string(side);
   //   }
 
   return name;


### PR DESCRIPTION
#### PR description:

Remove boost lexical cast dependency in DQM and DQMOffline with corresponding stl alternatives. Removed unnecesary headers

#### PR validation:

Passed runtests

#### if this PR is a backport:

@davidlange6 @vgvassilev
