### PR TITLE
ECAL esConsumes migration for remaining SimCalorimetry occurrences

### DIFF
--- a/SimCalorimetry/EcalElectronicsEmulation/interface/EcalFEtoDigi.h
+++ b/SimCalorimetry/EcalElectronicsEmulation/interface/EcalFEtoDigi.h
@@ -8,7 +8,6 @@
  * Created:  Thu Feb 22 11:32:53 CET 2007
  */
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -18,8 +17,11 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
+#include "CondFormats/DataRecord/interface/EcalTPGLutGroupRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTPGLutIdMapRcd.h"
+#include "CondFormats/EcalObjects/interface/EcalTPGLutGroup.h"
+#include "CondFormats/EcalObjects/interface/EcalTPGLutIdMap.h"
 #include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
-//#include "Geometry/EcalMapping/interface/EcalElectronicsMapping.h"
 
 #include <fstream>
 #include <iomanip>
@@ -50,15 +52,18 @@ private:
   int SMidToTCCid(const int) const;
   void getLUT(unsigned int *lut, const int towerId, const edm::EventSetup &) const;
 
+  const edm::ESGetToken<EcalTPGLutGroup, EcalTPGLutGroupRcd> tpgLutGroupToken_;
+  const edm::ESGetToken<EcalTPGLutIdMap, EcalTPGLutIdMapRcd> tpgLutIdMapToken_;
+
   TCCInputData inputdata_[N_SM];
 
-  std::string basename_;
-  bool useIdentityLUT_;
+  const std::string basename_;
+  const bool useIdentityLUT_;
   int sm_;
   bool singlefile;
 
-  int fileEventOffset_;
-  bool debug_;
+  const int fileEventOffset_;
+  const bool debug_;
   std::ofstream outfile;
 };
 

--- a/SimCalorimetry/EcalSelectiveReadoutProducers/interface/EcalSRCondTools.h
+++ b/SimCalorimetry/EcalSelectiveReadoutProducers/interface/EcalSRCondTools.h
@@ -10,7 +10,10 @@
 #include "FWCore/Utilities/interface/ESGetToken.h"
 #include "CondFormats/EcalObjects/interface/EcalSRSettings.h"
 #include "CondFormats/DataRecord/interface/EcalSRSettingsRcd.h"
+#include "CondFormats/EcalObjects/interface/EcalTPGPhysicsConst.h"
+#include "CondFormats/DataRecord/interface/EcalTPGPhysicsConstRcd.h"
 
+#include <string>
 /**
  */
 class EcalSRCondTools : public edm::one::EDAnalyzer<> {
@@ -68,10 +71,14 @@ private:
 
   //fields
 private:
-  edm::ParameterSet ps_;
-  edm::ESGetToken<EcalSRSettings, EcalSRSettingsRcd> hSrToken_;
+  const edm::ParameterSet ps_;
 
+  const std::string mode_;
+  bool iomode_write_;
   bool done_;
+
+  edm::ESGetToken<EcalSRSettings, EcalSRSettingsRcd> hSrToken_;
+  edm::ESGetToken<EcalTPGPhysicsConst, EcalTPGPhysicsConstRcd> tpgPhysicsConstToken_;
 };
 
 #endif  //SRCONDACCESS_H not defined

--- a/SimCalorimetry/EcalSelectiveReadoutProducers/src/EcalSRCondTools.cc
+++ b/SimCalorimetry/EcalSelectiveReadoutProducers/src/EcalSRCondTools.cc
@@ -53,10 +53,7 @@ constexpr int dccNum[12][12] = {
 using namespace std;
 
 EcalSRCondTools::EcalSRCondTools(const edm::ParameterSet& ps)
-    : ps_(ps),
-      mode_(ps.getParameter<string>("mode")),
-      iomode_write_(true),
-      done_(false) {
+    : ps_(ps), mode_(ps.getParameter<string>("mode")), iomode_write_(true), done_(false) {
   if (mode_ == "read") {
     iomode_write_ = false;
     hSrToken_ = esConsumes();

--- a/SimCalorimetry/EcalSelectiveReadoutProducers/src/EcalSRCondTools.cc
+++ b/SimCalorimetry/EcalSelectiveReadoutProducers/src/EcalSRCondTools.cc
@@ -12,11 +12,6 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 
-#include "CondFormats/EcalObjects/interface/EcalSRSettings.h"
-#include "CondFormats/EcalObjects/interface/EcalTPGPhysicsConst.h"
-#include "CondFormats/DataRecord/interface/EcalTPGPhysicsConstRcd.h"
-
-#include <string>
 #include <fstream>
 #include <iostream>
 #include <algorithm>
@@ -58,7 +53,16 @@ constexpr int dccNum[12][12] = {
 using namespace std;
 
 EcalSRCondTools::EcalSRCondTools(const edm::ParameterSet& ps)
-    : ps_(ps), hSrToken_(esConsumes<EcalSRSettings, EcalSRSettingsRcd>()), done_(false) {}
+    : ps_(ps),
+      mode_(ps.getParameter<string>("mode")),
+      iomode_write_(true),
+      done_(false) {
+  if (mode_ == "read") {
+    iomode_write_ = false;
+    hSrToken_ = esConsumes();
+    tpgPhysicsConstToken_ = esConsumes();
+  }
+}
 
 EcalSRCondTools::~EcalSRCondTools() {}
 
@@ -67,10 +71,7 @@ void EcalSRCondTools::analyze(const edm::Event& event, const edm::EventSetup& es
     return;
   EcalSRSettings* sr = new EcalSRSettings;
 
-  string mode = ps_.getParameter<string>("mode");
-
-  bool iomode_write = true;
-  if (mode == "online_config" || mode == "combine_config") {
+  if (mode_ == "online_config" || mode_ == "combine_config") {
     string fname = ps_.getParameter<string>("onlineSrpConfigFile");
     ifstream f(fname.c_str());
     if (!f.good()) {
@@ -79,20 +80,16 @@ void EcalSRCondTools::analyze(const edm::Event& event, const edm::EventSetup& es
     importSrpConfigFile(*sr, f, true);
   }
 
-  if (mode == "python_config" || mode == "combine_config") {
+  if (mode_ == "python_config" || mode_ == "combine_config") {
     importParameterSet(*sr, ps_);
   }
 
-  if (mode == "read") {
-    iomode_write = false;
-  }
-
-  if (!(mode == "python_config" || mode == "online_config" || mode == "combine_config" || (mode == "read"))) {
-    throw cms::Exception("Config") << "Invalid value," << mode << ",  for parameter mode. "
+  if (!(mode_ == "python_config" || mode_ == "online_config" || mode_ == "combine_config" || (mode_ == "read"))) {
+    throw cms::Exception("Config") << "Invalid value," << mode_ << ",  for parameter mode. "
                                    << "Valid values: online_config, python_config, combine_config, read";
   }
 
-  if (iomode_write) {
+  if (iomode_write_) {
     sr->bxGlobalOffset_ = ps_.getParameter<int>("bxGlobalOffset");
     sr->automaticSrpSelect_ = ps_.getParameter<int>("automaticSrpSelect");
     sr->automaticMasks_ = ps_.getParameter<int>("automaticMasks");
@@ -107,7 +104,7 @@ void EcalSRCondTools::analyze(const edm::Event& event, const edm::EventSetup& es
     db->writeOne(sr, firstSinceTime, "EcalSRSettingsRcd");
     done_ = true;
   } else {  //read mode
-    edm::ESHandle<EcalSRSettings> hSr = es.getHandle(hSrToken_);
+    const edm::ESHandle<EcalSRSettings> hSr = es.getHandle(hSrToken_);
     if (!hSr.isValid()) {
       cout << "EcalSRSettings record not found. Check the Cond DB Global tag.\n";
     } else {
@@ -117,8 +114,7 @@ void EcalSRCondTools::analyze(const edm::Event& event, const edm::EventSetup& es
     }
 
     //trigger tower thresholds (from FENIX configuration):
-    edm::ESHandle<EcalTPGPhysicsConst> hTp;
-    es.get<EcalTPGPhysicsConstRcd>().get(hTp);
+    const edm::ESHandle<EcalTPGPhysicsConst> hTp = es.getHandle(tpgPhysicsConstToken_);
     if (!hTp.isValid()) {
       cout << "EcalTPGPhysicsConst record not found. Check the Cond DB Global tag.\n";
     } else {

--- a/SimCalorimetry/EcalSimProducers/plugins/PreMixingEcalWorker.cc
+++ b/SimCalorimetry/EcalSimProducers/plugins/PreMixingEcalWorker.cc
@@ -41,10 +41,6 @@ private:
   std::string EEDigiCollectionDM_;  // secondary name to be given to collection of digis
   std::string ESDigiCollectionDM_;  // secondary name to be given to collection of digis
 
-  edm::EDGetTokenT<EBDigitizerTraits::DigiCollection> tok_eb_;
-  edm::EDGetTokenT<EEDigitizerTraits::DigiCollection> tok_ee_;
-  edm::EDGetTokenT<ESDigitizerTraits::DigiCollection> tok_es_;
-
   const double m_EBs25notCont;
   const double m_EEs25notCont;
   const double m_peToABarrel;
@@ -64,19 +60,16 @@ PreMixingEcalWorker::PreMixingEcalWorker(const edm::ParameterSet &ps,
     : EBPileInputTag_(ps.getParameter<edm::InputTag>("EBPileInputTag")),
       EEPileInputTag_(ps.getParameter<edm::InputTag>("EEPileInputTag")),
       ESPileInputTag_(ps.getParameter<edm::InputTag>("ESPileInputTag")),
-      tok_eb_(iC.consumes<EBDigitizerTraits::DigiCollection>(EBPileInputTag_)),
-      tok_ee_(iC.consumes<EEDigitizerTraits::DigiCollection>(EEPileInputTag_)),
-      tok_es_(iC.consumes<ESDigitizerTraits::DigiCollection>(ESPileInputTag_)),
       m_EBs25notCont(ps.getParameter<double>("EBs25notContainment")),
       m_EEs25notCont(ps.getParameter<double>("EEs25notContainment")),
       m_peToABarrel(ps.getParameter<double>("photoelectronsToAnalogBarrel")),
       m_peToAEndcap(ps.getParameter<double>("photoelectronsToAnalogEndcap")),
       m_timeDependent(ps.getParameter<bool>("timeDependent")),
       theEBSignalGenerator(
-          EBPileInputTag_, tok_eb_, m_EBs25notCont, m_EEs25notCont, m_peToABarrel, m_peToAEndcap, m_timeDependent),
+          iC, EBPileInputTag_, m_EBs25notCont, m_EEs25notCont, m_peToABarrel, m_peToAEndcap, m_timeDependent),
       theEESignalGenerator(
-          EEPileInputTag_, tok_ee_, m_EBs25notCont, m_EEs25notCont, m_peToABarrel, m_peToAEndcap, m_timeDependent),
-      theESSignalGenerator(ESPileInputTag_, tok_es_, m_EBs25notCont, m_EEs25notCont, m_peToABarrel, m_peToAEndcap),
+          iC, EEPileInputTag_, m_EBs25notCont, m_EEs25notCont, m_peToABarrel, m_peToAEndcap, m_timeDependent),
+      theESSignalGenerator(iC, ESPileInputTag_, m_EBs25notCont, m_EEs25notCont, m_peToABarrel, m_peToAEndcap),
       myEcalDigitizer_(ps, iC) {
   EBDigiCollectionDM_ = ps.getParameter<std::string>("EBDigiCollectionDM");
   EEDigiCollectionDM_ = ps.getParameter<std::string>("EEDigiCollectionDM");

--- a/SimCalorimetry/EcalZeroSuppressionProducers/interface/EcalZeroSuppressionProducer.h
+++ b/SimCalorimetry/EcalZeroSuppressionProducers/interface/EcalZeroSuppressionProducer.h
@@ -9,7 +9,6 @@
 #include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
 #include "DataFormats/Provenance/interface/Provenance.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -22,9 +21,6 @@
 
 class EcalZeroSuppressionProducer : public edm::stream::EDProducer<> {
 public:
-  // The following is not yet used, but will be the primary
-  // constructor when the parameter set system is available.
-  //
   explicit EcalZeroSuppressionProducer(const edm::ParameterSet &params);
   ~EcalZeroSuppressionProducer() override;
 
@@ -34,20 +30,21 @@ public:
   void initCalibrations(const edm::EventSetup &eventSetup);
 
 private:
-  double glbBarrelThreshold_;
-  double glbEndcapThreshold_;
+  const double glbBarrelThreshold_;
+  const double glbEndcapThreshold_;
 
-  std::string digiProducer_;        // name of module/plugin/producer making digis
-  std::string EBdigiCollection_;    // secondary name given to collection of digis
-  std::string EEdigiCollection_;    // secondary name given to collection of digis
-  std::string EBZSdigiCollection_;  // secondary name given to collection of digis
-  std::string EEZSdigiCollection_;  // secondary name given to collection of digis
+  const std::string digiProducer_;        // name of module/plugin/producer making digis
+  const std::string ebDigiCollection_;    // secondary name given to collection of digis
+  const std::string eeDigiCollection_;    // secondary name given to collection of digis
+  const std::string ebZSdigiCollection_;  // secondary name given to collection of digis
+  const std::string eeZSdigiCollection_;  // secondary name given to collection of digis
 
   EcalZeroSuppressor<EBDataFrame> theBarrelZeroSuppressor_;
   EcalZeroSuppressor<EEDataFrame> theEndcapZeroSuppressor_;
 
-  edm::EDGetTokenT<EBDigiCollection> EB_token;
-  edm::EDGetTokenT<EEDigiCollection> EE_token;
+  const edm::EDGetTokenT<EBDigiCollection> ebToken_;
+  const edm::EDGetTokenT<EEDigiCollection> eeToken_;
+  const edm::ESGetToken<EcalPedestals, EcalPedestalsRcd> pedestalToken_;
 };
 
 #endif

--- a/SimCalorimetry/EcalZeroSuppressionProducers/src/EcalZeroSuppressionProducer.cc
+++ b/SimCalorimetry/EcalZeroSuppressionProducers/src/EcalZeroSuppressionProducer.cc
@@ -1,24 +1,19 @@
 
 #include "SimCalorimetry/EcalZeroSuppressionProducers/interface/EcalZeroSuppressionProducer.h"
 
-EcalZeroSuppressionProducer::EcalZeroSuppressionProducer(const edm::ParameterSet &params) {
-  digiProducer_ = params.getParameter<std::string>("digiProducer");
-  EBdigiCollection_ = params.getParameter<std::string>("EBdigiCollection");
-  EEdigiCollection_ = params.getParameter<std::string>("EEdigiCollection");
-  EBZSdigiCollection_ = params.getParameter<std::string>("EBZSdigiCollection");
-  EEZSdigiCollection_ = params.getParameter<std::string>("EEZSdigiCollection");
-
-  // initialize the default values for the thresholds in number of noise sigmas
-
-  glbBarrelThreshold_ = params.getUntrackedParameter<double>("glbBarrelThreshold", 0.2);
-  glbEndcapThreshold_ = params.getUntrackedParameter<double>("glbEndcapThreshold", 0.4);
-
-  produces<EBDigiCollection>(EBZSdigiCollection_);
-  produces<EEDigiCollection>(EEZSdigiCollection_);
-
-  EB_token = consumes<EBDigiCollection>(edm::InputTag(digiProducer_));
-  EE_token = consumes<EEDigiCollection>(edm::InputTag(digiProducer_));
-  ;
+EcalZeroSuppressionProducer::EcalZeroSuppressionProducer(const edm::ParameterSet &params)
+    : glbBarrelThreshold_(params.getUntrackedParameter<double>("glbBarrelThreshold", 0.2)),
+      glbEndcapThreshold_(params.getUntrackedParameter<double>("glbEndcapThreshold", 0.4)),
+      digiProducer_(params.getParameter<std::string>("digiProducer")),
+      ebDigiCollection_(params.getParameter<std::string>("EBdigiCollection")),
+      eeDigiCollection_(params.getParameter<std::string>("EEdigiCollection")),
+      ebZSdigiCollection_(params.getParameter<std::string>("EBZSdigiCollection")),
+      eeZSdigiCollection_(params.getParameter<std::string>("EEZSdigiCollection")),
+      ebToken_(consumes<EBDigiCollection>(edm::InputTag(digiProducer_))),
+      eeToken_(consumes<EEDigiCollection>(edm::InputTag(digiProducer_))),
+      pedestalToken_(esConsumes()) {
+  produces<EBDigiCollection>(ebZSdigiCollection_);
+  produces<EEDigiCollection>(eeZSdigiCollection_);
 }
 
 EcalZeroSuppressionProducer::~EcalZeroSuppressionProducer() {}
@@ -34,26 +29,26 @@ void EcalZeroSuppressionProducer::produce(edm::Event &event, const edm::EventSet
   const EBDigiCollection *fullBarrelDigis = nullptr;
   const EEDigiCollection *fullEndcapDigis = nullptr;
 
-  event.getByToken(EB_token, pEBDigis);
+  event.getByToken(ebToken_, pEBDigis);
   if (pEBDigis.isValid()) {
     fullBarrelDigis = pEBDigis.product();  // get a ptr to the produc
     edm::LogInfo("ZeroSuppressionInfo") << "total # fullBarrelDigis: " << fullBarrelDigis->size();
   } else {
-    edm::LogError("ZeroSuppressionError") << "Error! can't get the product " << EBdigiCollection_.c_str();
+    edm::LogError("ZeroSuppressionError") << "Error! can't get the product " << ebDigiCollection_.c_str();
   }
 
-  event.getByToken(EE_token, pEEDigis);
+  event.getByToken(eeToken_, pEEDigis);
   if (pEEDigis.isValid()) {
     fullEndcapDigis = pEEDigis.product();  // get a ptr to the product
     edm::LogInfo("ZeroSuppressionInfo") << "total # fullEndcapDigis: " << fullEndcapDigis->size();
   } else {
-    edm::LogError("ZeroSuppressionError") << "Error! can't get the product " << EEdigiCollection_.c_str();
+    edm::LogError("ZeroSuppressionError") << "Error! can't get the product " << eeDigiCollection_.c_str();
   }
 
   // collection of zero suppressed digis to put in the event
 
-  std::unique_ptr<EBDigiCollection> gzsBarrelDigis(new EBDigiCollection());
-  std::unique_ptr<EEDigiCollection> gzsEndcapDigis(new EEDigiCollection());
+  auto gzsBarrelDigis = std::make_unique<EBDigiCollection>();
+  auto gzsEndcapDigis = std::make_unique<EEDigiCollection>();
 
   CaloDigiCollectionSorter sorter(5);
 
@@ -99,17 +94,14 @@ void EcalZeroSuppressionProducer::produce(edm::Event &event, const edm::EventSet
     //  }
   }
   // Step D: Put outputs into event
-  event.put(std::move(gzsBarrelDigis), EBZSdigiCollection_);
-  event.put(std::move(gzsEndcapDigis), EEZSdigiCollection_);
+  event.put(std::move(gzsBarrelDigis), ebZSdigiCollection_);
+  event.put(std::move(gzsEndcapDigis), eeZSdigiCollection_);
 }
 
 void EcalZeroSuppressionProducer::initCalibrations(const edm::EventSetup &eventSetup) {
   // Pedestals from event setup
+  const auto& thePedestals = eventSetup.getData(pedestalToken_);
 
-  edm::ESHandle<EcalPedestals> dbPed;
-  eventSetup.get<EcalPedestalsRcd>().get(dbPed);
-  const EcalPedestals *thePedestals = dbPed.product();
-
-  theBarrelZeroSuppressor_.setPedestals(thePedestals);
-  theEndcapZeroSuppressor_.setPedestals(thePedestals);
+  theBarrelZeroSuppressor_.setPedestals(&thePedestals);
+  theEndcapZeroSuppressor_.setPedestals(&thePedestals);
 }

--- a/SimCalorimetry/EcalZeroSuppressionProducers/src/EcalZeroSuppressionProducer.cc
+++ b/SimCalorimetry/EcalZeroSuppressionProducers/src/EcalZeroSuppressionProducer.cc
@@ -100,7 +100,7 @@ void EcalZeroSuppressionProducer::produce(edm::Event &event, const edm::EventSet
 
 void EcalZeroSuppressionProducer::initCalibrations(const edm::EventSetup &eventSetup) {
   // Pedestals from event setup
-  const auto& thePedestals = eventSetup.getData(pedestalToken_);
+  const auto &thePedestals = eventSetup.getData(pedestalToken_);
 
   theBarrelZeroSuppressor_.setPedestals(&thePedestals);
   theEndcapZeroSuppressor_.setPedestals(&thePedestals);


### PR DESCRIPTION
#### PR description:

The PR migrates remaining ECAL related code in the SimCalorimetry packages to esConsumes (#31061). The constructor of `EcalSignalGenerator` was changed to accept a `ConsumesCollector` that is now also used to get the token for the input data collection.

#### PR validation:

Code compiles. Passes 25202.0.