### PR TITLE
[10_6_X] Have embedded root files send close reports

### DIFF
--- a/IOPool/Input/src/RootEmbeddedFileSequence.cc
+++ b/IOPool/Input/src/RootEmbeddedFileSequence.cc
@@ -15,6 +15,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
+#include "Utilities/StorageFactory/interface/StatisticsSenderService.h"
 
 #include "CLHEP/Random/RandFlat.h"
 
@@ -113,6 +114,10 @@ namespace edm {
   void RootEmbeddedFileSequence::closeFile_() {
     // delete the RootFile object.
     if (rootFile()) {
+      edm::Service<edm::storage::StatisticsSenderService> service;
+      if (service.isAvailable()) {
+        service->filePreCloseEvent(lfn(), usedFallback());
+      }
       rootFile().reset();
     }
   }


### PR DESCRIPTION
When a file controlled by the RootEmbeddedFileSequence closes, it now informs the StatisticsSenderService.

#### PR description:

As requested in https://github.com/cms-sw/cmssw/issues/34873#issuecomment-914371662, this PR backports https://github.com/cms-sw/cmssw/pull/35074 to 10_6_X. Description of original PR
> When a file controlled by the RootEmbeddedFileSequence closes, it now informs the StatisticsSenderService.
Had to call the service directly as there was no good way to pass the ActivityRegistry into a class meant to be embedded inside a ED module.

#### PR validation:

Code compiles.