### PR TITLE
LowPtElectrons: fix for UL FastSim mini v2 and nano v9 workflows

### DIFF
--- a/RecoEgamma/EgammaElectronProducers/interface/LowPtGsfElectronFeatures.h
+++ b/RecoEgamma/EgammaElectronProducers/interface/LowPtGsfElectronFeatures.h
@@ -11,6 +11,10 @@
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h"
 #include <vector>
 
+namespace reco {
+  class Track;
+}
+
 namespace lowptgsfeleseed {
 
   std::vector<float> features(const reco::PreId& ecal,
@@ -24,7 +28,8 @@ namespace lowptgsfeleseed {
 namespace lowptgsfeleid {
 
   // feature list for new model (2019Sept15)
-  std::vector<float> features_V1(reco::GsfElectron const& ele, float rho, float unbiased, float field_z);
+  std::vector<float> features_V1(
+      reco::GsfElectron const& ele, float rho, float unbiased, float field_z, const reco::Track* trk = nullptr);
 
   // feature list for original models (2019Aug07 and earlier)
   std::vector<float> features_V0(reco::GsfElectron const& ele, float rho, float unbiased);

--- a/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronIDProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronIDProducer.cc
@@ -12,6 +12,7 @@
 #include "CommonTools/MVAUtils/interface/GBRForestTools.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/PatCandidates/interface/Electron.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 #include "DataFormats/EgammaReco/interface/SuperCluster.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
 #include "DataFormats/TrackReco/interface/Track.h"
@@ -34,14 +35,21 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions&);
 
 private:
-  double eval(const GBRForest& model, const reco::GsfElectron&, double rho, float unbiased, float field_z) const;
+  double eval(const GBRForest& model,
+              const reco::GsfElectron&,
+              double rho,
+              float unbiased,
+              float field_z,
+              const reco::Track* trk = nullptr) const;
 
-  template <typename EL, typename F>
-  void doWork(double rho, float bz, EL const& electrons, F&& idFunctor, edm::Event&) const;
+  template <typename EL, typename FID, typename FTRK>
+  void doWork(double rho, float bz, EL const& electrons, FID&& idFunctor, FTRK&& trkFunctor, edm::Event&) const;
+  const bool useGsfToTrack_;
   const bool usePAT_;
   edm::EDGetTokenT<reco::GsfElectronCollection> electrons_;
   edm::EDGetTokenT<pat::ElectronCollection> patElectrons_;
   const edm::EDGetTokenT<double> rho_;
+  edm::EDGetTokenT<edm::Association<reco::TrackCollection>> gsf2trk_;
   edm::EDGetTokenT<edm::ValueMap<float>> unbiased_;
   const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> fieldToken_;
 
@@ -60,10 +68,12 @@ private:
 ////////////////////////////////////////////////////////////////////////////////
 //
 LowPtGsfElectronIDProducer::LowPtGsfElectronIDProducer(const edm::ParameterSet& conf)
-    : usePAT_(conf.getParameter<bool>("usePAT")),
+    : useGsfToTrack_(conf.getParameter<bool>("useGsfToTrack")),
+      usePAT_(conf.getParameter<bool>("usePAT")),
       electrons_(),
       patElectrons_(),
       rho_(consumes<double>(conf.getParameter<edm::InputTag>("rho"))),
+      gsf2trk_(),
       unbiased_(),
       fieldToken_(esConsumes()),
       names_(conf.getParameter<std::vector<std::string>>("ModelNames")),
@@ -72,6 +82,9 @@ LowPtGsfElectronIDProducer::LowPtGsfElectronIDProducer(const edm::ParameterSet& 
       maxPtThreshold_(conf.getParameter<double>("MaxPtThreshold")),
       thresholds_(conf.getParameter<std::vector<double>>("ModelThresholds")),
       versionName_(conf.getParameter<std::string>("Version")) {
+  if (useGsfToTrack_) {
+    gsf2trk_ = consumes<edm::Association<reco::TrackCollection>>(conf.getParameter<edm::InputTag>("gsfToTrack"));
+  }
   if (usePAT_) {
     patElectrons_ = consumes<pat::ElectronCollection>(conf.getParameter<edm::InputTag>("electrons"));
   } else {
@@ -117,6 +130,12 @@ void LowPtGsfElectronIDProducer::produce(edm::StreamID, edm::Event& event, const
     throw cms::Exception("InvalidHandle", os.str());
   }
 
+  // Retrieve GsfToTrack Association from Event
+  edm::Handle<edm::Association<reco::TrackCollection>> gsf2trk;
+  if (useGsfToTrack_) {
+    event.getByToken(gsf2trk_, gsf2trk);
+  }
+
   double rho = *hRho;
   // Retrieve pat::Electrons or reco::GsfElectrons from Event
   edm::Handle<pat::ElectronCollection> patElectrons;
@@ -134,6 +153,29 @@ void LowPtGsfElectronIDProducer::produce(edm::StreamID, edm::Event& event, const
             return std::numeric_limits<float>::max();
           }
           return ele.electronID(kUnbiased);
+        },
+        [&](auto const& ele) {  // trkFunctor ...
+          if (useGsfToTrack_) {
+            const edm::Ptr<pat::PackedCandidate>* ptr1 =
+                ele.hasUserData("ele2packed") ? ele.template userData<edm::Ptr<pat::PackedCandidate>>("ele2packed")
+                                              : nullptr;
+            const edm::Ptr<pat::PackedCandidate>* ptr2 =
+                ele.hasUserData("ele2lost") ? ele.template userData<edm::Ptr<pat::PackedCandidate>>("ele2lost")
+                                            : nullptr;
+            if (ptr1 != nullptr && ptr1->isNonnull() && ptr1->isAvailable() && ptr1->get() != nullptr &&
+                ptr1->get()->bestTrack() != nullptr) {
+              return ptr1->get()->bestTrack();
+            } else if (ptr2 != nullptr && ptr2->isNonnull() && ptr2->isAvailable() && ptr2->get() != nullptr &&
+                       ptr2->get()->bestTrack() != nullptr) {
+              return ptr2->get()->bestTrack();
+            }
+          } else {
+            reco::TrackRef ref = ele.closestCtfTrackRef();
+            if (ref.isNonnull() && ref.isAvailable()) {
+              return ref.get();
+            }
+          }
+          return static_cast<const reco::Track*>(nullptr);
         },
         event);
   } else {
@@ -154,17 +196,37 @@ void LowPtGsfElectronIDProducer::produce(edm::StreamID, edm::Event& event, const
           }
           return unbiasedH[gsf];
         },
+        [&](auto const& ele) {  // trkFunctor ...
+          if (useGsfToTrack_) {
+            const auto& gsf = ele.core()->gsfTrack();
+            if (gsf.isNonnull() && gsf.isAvailable()) {
+              auto const& ref = (*gsf2trk)[gsf];
+              if (ref.isNonnull() && ref.isAvailable()) {
+                return ref.get();
+              }
+            }
+          } else {
+            reco::TrackRef ref = ele.closestCtfTrackRef();
+            if (ref.isNonnull() && ref.isAvailable()) {
+              return ref.get();
+            }
+          }
+          return static_cast<const reco::Track*>(nullptr);
+        },
         event);
   }
 }
 
-template <typename EL, typename F>
+template <typename EL, typename FID, typename FTRK>
 void LowPtGsfElectronIDProducer::doWork(
-    double rho, float bz, EL const& electrons, F&& idFunctor, edm::Event& event) const {
+    double rho, float bz, EL const& electrons, FID&& idFunctor, FTRK&& trkFunctor, edm::Event& event) const {
   auto nElectrons = electrons->size();
   std::vector<float> ids;
   ids.reserve(nElectrons);
   std::transform(electrons->begin(), electrons->end(), std::back_inserter(ids), idFunctor);
+  std::vector<const reco::Track*> trks;
+  trks.reserve(nElectrons);
+  std::transform(electrons->begin(), electrons->end(), std::back_inserter(trks), trkFunctor);
 
   std::vector<float> output(nElectrons);  //resused for each model
   for (unsigned int index = 0; index < names_.size(); ++index) {
@@ -172,7 +234,7 @@ void LowPtGsfElectronIDProducer::doWork(
     for (unsigned int iele = 0; iele < nElectrons; iele++) {
       auto const& ele = (*electrons)[iele];
       if (ids[iele] != std::numeric_limits<float>::max()) {
-        output[iele] = eval(*models_[index], ele, rho, ids[iele], bz);
+        output[iele] = eval(*models_[index], ele, rho, ids[iele], bz, trks[iele]);
       } else {
         output[iele] = -999.;
       }
@@ -187,13 +249,17 @@ void LowPtGsfElectronIDProducer::doWork(
 
 //////////////////////////////////////////////////////////////////////////////////////////
 //
-double LowPtGsfElectronIDProducer::eval(
-    const GBRForest& model, const reco::GsfElectron& ele, double rho, float unbiased, float field_z) const {
+double LowPtGsfElectronIDProducer::eval(const GBRForest& model,
+                                        const reco::GsfElectron& ele,
+                                        double rho,
+                                        float unbiased,
+                                        float field_z,
+                                        const reco::Track* trk) const {
   std::vector<float> inputs;
   if (version_ == Version::V0) {
     inputs = lowptgsfeleid::features_V0(ele, rho, unbiased);
   } else if (version_ == Version::V1) {
-    inputs = lowptgsfeleid::features_V1(ele, rho, unbiased, field_z);
+    inputs = lowptgsfeleid::features_V1(ele, rho, unbiased, field_z, trk);
   }
   return model.GetResponse(inputs.data());
 }
@@ -202,8 +268,10 @@ double LowPtGsfElectronIDProducer::eval(
 //
 void LowPtGsfElectronIDProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
+  desc.add<bool>("useGsfToTrack", false);
   desc.add<bool>("usePAT", false);
   desc.add<edm::InputTag>("electrons", edm::InputTag("lowPtGsfElectrons"));
+  desc.addOptional<edm::InputTag>("gsfToTrack", edm::InputTag("lowPtGsfToTrackLinks"));
   desc.addOptional<edm::InputTag>("unbiased", edm::InputTag("lowPtGsfElectronSeedValueMaps:unbiased"));
   desc.add<edm::InputTag>("rho", edm::InputTag("fixedGridRhoFastjetAll"));
   desc.add<std::vector<std::string>>("ModelNames", {""});

--- a/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronIDProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronIDProducer.cc
@@ -156,17 +156,16 @@ void LowPtGsfElectronIDProducer::produce(edm::StreamID, edm::Event& event, const
         },
         [&](auto const& ele) {  // trkFunctor ...
           if (useGsfToTrack_) {
-            const edm::Ptr<pat::PackedCandidate>* ptr1 =
-                ele.hasUserData("ele2packed") ? ele.template userData<edm::Ptr<pat::PackedCandidate>>("ele2packed")
-                                              : nullptr;
-            const edm::Ptr<pat::PackedCandidate>* ptr2 =
-                ele.hasUserData("ele2lost") ? ele.template userData<edm::Ptr<pat::PackedCandidate>>("ele2lost")
-                                            : nullptr;
-            if (ptr1 != nullptr && ptr1->isNonnull() && ptr1->isAvailable() && ptr1->get() != nullptr &&
-                ptr1->get()->bestTrack() != nullptr) {
+            using PackedPtr = edm::Ptr<pat::PackedCandidate>;
+            const PackedPtr* ptr1 = ele.template userData<PackedPtr>("ele2packed");
+            const PackedPtr* ptr2 = ele.template userData<PackedPtr>("ele2lost");
+            auto hasBestTrack = [](const PackedPtr* ptr) {
+              return ptr != nullptr && ptr->isNonnull() && ptr->isAvailable() && ptr->get() != nullptr &&
+                     ptr->get()->bestTrack() != nullptr;
+            };
+            if (hasBestTrack(ptr1)) {
               return ptr1->get()->bestTrack();
-            } else if (ptr2 != nullptr && ptr2->isNonnull() && ptr2->isAvailable() && ptr2->get() != nullptr &&
-                       ptr2->get()->bestTrack() != nullptr) {
+            } else if (hasBestTrack(ptr2)) {
               return ptr2->get()->bestTrack();
             }
           } else {

--- a/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronCores_cff.py
+++ b/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronCores_cff.py
@@ -1,6 +1,3 @@
 import FWCore.ParameterSet.Config as cms
 
 from RecoEgamma.EgammaElectronProducers.lowPtGsfElectronCores_cfi import lowPtGsfElectronCores
-
-from Configuration.Eras.Modifier_fastSim_cff import fastSim
-fastSim.toModify(lowPtGsfElectronCores,ctfTracks = "generalTracksBeforeMixing")

--- a/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronID_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronID_cfi.py
@@ -8,3 +8,11 @@ bParking.toModify(
     lowPtGsfElectronID,
     ModelWeights = ["RecoEgamma/ElectronIdentification/data/LowPtElectrons/LowPtElectrons_ID_2021May17.root"],
 )
+
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
+from PhysicsTools.NanoAOD.nano_eras_cff import *
+(fastSim & (run2_miniAOD_UL | run2_nanoAOD_106Xv2)).toModify(
+    lowPtGsfElectronID,
+    useGsfToTrack = True,
+)

--- a/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronsPreRegression_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronsPreRegression_cfi.py
@@ -1,6 +1,3 @@
 from RecoEgamma.EgammaElectronProducers.gsfElectrons_cfi import ecalDrivenGsfElectrons
 
 lowPtGsfElectronsPreRegression = ecalDrivenGsfElectrons.clone(gsfElectronCoresTag = "lowPtGsfElectronCores")
-
-from Configuration.Eras.Modifier_fastSim_cff import fastSim
-fastSim.toModify(lowPtGsfElectronsPreRegression,ctfTracksTag = "generalTracksBeforeMixing")

--- a/RecoEgamma/EgammaElectronProducers/src/LowPtGsfElectronFeatures.cc
+++ b/RecoEgamma/EgammaElectronProducers/src/LowPtGsfElectronFeatures.cc
@@ -174,10 +174,6 @@ namespace lowptgsfeleid {
       eid_trk_p = tk->p();
       eid_trk_nhits = tk->found();
       eid_trk_chi2red = tk->normalizedChi2();
-      TVector3 trkTV3(0, 0, 0);
-      trkTV3.SetPtEtaPhi(tk->pt(), tk->eta(), tk->phi());
-      TVector3 eleTV3(0, 0, 0);
-      eleTV3.SetPtEtaPhi(ele.pt(), ele.eta(), ele.phi());
       trk_dr = reco::deltaR(*tk, ele);
     }
 

--- a/RecoEgamma/EgammaElectronProducers/src/LowPtGsfElectronFeatures.cc
+++ b/RecoEgamma/EgammaElectronProducers/src/LowPtGsfElectronFeatures.cc
@@ -132,7 +132,8 @@ namespace lowptgsfeleseed {
 
 namespace lowptgsfeleid {
 
-  std::vector<float> features_V1(reco::GsfElectron const& ele, float rho, float unbiased, float field_z) {
+  std::vector<float> features_V1(
+      reco::GsfElectron const& ele, float rho, float unbiased, float field_z, const reco::Track* trk) {
     float eid_rho = -999.;
     float eid_sc_eta = -999.;
     float eid_shape_full5x5_r9 = -999.;
@@ -168,17 +169,28 @@ namespace lowptgsfeleid {
     float sc_clus2_E_ov_p = -999.;
 
     // KF tracks
-    if (ele.core().isNonnull()) {
-      reco::TrackRef trk = ele.closestCtfTrackRef();
-      if (trk.isNonnull()) {
-        eid_trk_p = (float)trk->p();
-        eid_trk_nhits = (float)trk->found();
-        eid_trk_chi2red = (float)trk->normalizedChi2();
-        TVector3 trkTV3(0, 0, 0);
-        trkTV3.SetPtEtaPhi(trk->pt(), trk->eta(), trk->phi());
-        TVector3 eleTV3(0, 0, 0);
-        eleTV3.SetPtEtaPhi(ele.pt(), ele.eta(), ele.phi());
-        trk_dr = eleTV3.DeltaR(trkTV3);
+    if (trk != nullptr) {
+      eid_trk_p = (float)trk->p();
+      eid_trk_nhits = (float)trk->found();
+      eid_trk_chi2red = (float)trk->normalizedChi2();
+      TVector3 trkTV3(0, 0, 0);
+      trkTV3.SetPtEtaPhi(trk->pt(), trk->eta(), trk->phi());
+      TVector3 eleTV3(0, 0, 0);
+      eleTV3.SetPtEtaPhi(ele.pt(), ele.eta(), ele.phi());
+      trk_dr = eleTV3.DeltaR(trkTV3);
+    } else {
+      if (ele.core().isNonnull()) {
+        reco::TrackRef trk = ele.closestCtfTrackRef();
+        if (trk.isNonnull()) {
+          eid_trk_p = (float)trk->p();
+          eid_trk_nhits = (float)trk->found();
+          eid_trk_chi2red = (float)trk->normalizedChi2();
+          TVector3 trkTV3(0, 0, 0);
+          trkTV3.SetPtEtaPhi(trk->pt(), trk->eta(), trk->phi());
+          TVector3 eleTV3(0, 0, 0);
+          eleTV3.SetPtEtaPhi(ele.pt(), ele.eta(), ele.phi());
+          trk_dr = eleTV3.DeltaR(trkTV3);
+        }
       }
     }
 

--- a/RecoEgamma/EgammaElectronProducers/src/LowPtGsfElectronFeatures.cc
+++ b/RecoEgamma/EgammaElectronProducers/src/LowPtGsfElectronFeatures.cc
@@ -169,29 +169,16 @@ namespace lowptgsfeleid {
     float sc_clus2_E_ov_p = -999.;
 
     // KF tracks
-    if (trk != nullptr) {
-      eid_trk_p = (float)trk->p();
-      eid_trk_nhits = (float)trk->found();
-      eid_trk_chi2red = (float)trk->normalizedChi2();
+    if (trk != nullptr || (ele.core().isNonnull() && ele.closestCtfTrackRef().isNonnull())) {
+      const reco::Track* tk = trk ? trk : &*ele.closestCtfTrackRef();
+      eid_trk_p = tk->p();
+      eid_trk_nhits = tk->found();
+      eid_trk_chi2red = tk->normalizedChi2();
       TVector3 trkTV3(0, 0, 0);
-      trkTV3.SetPtEtaPhi(trk->pt(), trk->eta(), trk->phi());
+      trkTV3.SetPtEtaPhi(tk->pt(), tk->eta(), tk->phi());
       TVector3 eleTV3(0, 0, 0);
       eleTV3.SetPtEtaPhi(ele.pt(), ele.eta(), ele.phi());
-      trk_dr = eleTV3.DeltaR(trkTV3);
-    } else {
-      if (ele.core().isNonnull()) {
-        reco::TrackRef trk = ele.closestCtfTrackRef();
-        if (trk.isNonnull()) {
-          eid_trk_p = (float)trk->p();
-          eid_trk_nhits = (float)trk->found();
-          eid_trk_chi2red = (float)trk->normalizedChi2();
-          TVector3 trkTV3(0, 0, 0);
-          trkTV3.SetPtEtaPhi(trk->pt(), trk->eta(), trk->phi());
-          TVector3 eleTV3(0, 0, 0);
-          eleTV3.SetPtEtaPhi(ele.pt(), ele.eta(), ele.phi());
-          trk_dr = eleTV3.DeltaR(trkTV3);
-        }
-      }
+      trk_dr = reco::deltaR(*tk, ele);
     }
 
     // GSF tracks


### PR DESCRIPTION
#### PR description:

- UL mini v2 workflows for FastSim are broken due to an exception thrown by the `LowPtGsfElectronIDProducer` when attempting to access an `edm::Ref` to the missing `generalTracksBeforeMixing` collection in AOD. 
- All details can be found in this issue: https://github.com/cms-sw/cmssw/issues/34774.
- This PR provides an acceptable fix in the RECO chain by suppressing (i.e. removing) the FastSim switch to using tracks from the `generalTracksBeforeMixing` collection in the `GsfElectronCore` and `GsfElectron` objects.
- For re-miniaod (and re-nanoaod) workflows, this PR also provides an acceptable workaround that allows the ID producer to evaluate the BDT model without throwing an exception, while maintaining the expected physics performance. This is achieved by extracting features from the KF track used in the `ElectronSeed` step (obtained from the available `generalTracks` collection in AOD), instead of from the KF track embedded in the `GsfElectronCore` object (which is chosen based on number of shared hits with the `GsfTrack` and obtained from the missing `generalTracksBeforeMixing` collection in AOD). 
- All development was performed in the 10_6_X cycle (see the compare [here](https://github.com/cms-sw/cmssw/compare/CMSSW_10_6_X...bainbrid:LowPtElectrons_ULFastSimFix_106X)), tested with the example recipes provided in the issue [#34774](#34774), and then ported to master (this PR). This work will be back ported to 10_6_X in a future PR.
- Also tested is the behaviour for the nano v9 workflow, which is similarly affected.
- This work was presented to RECO/AT here: https://indico.cern.ch/event/1071803/. The final slide compares physics performance b/w the 10_6_X and 12_1_X cycles (essentially identical).
- Physics and computing performances are ~unaffected. 

#### PR validation:

This PR was validated using cmsDriver commands that performed the GEN->AOD and mini v2 steps, based on those provided [here](https://github.com/cms-sw/cmssw/issues/34774#issue-960576497), for tests with the 10_6_X cycle, and modified versions for tests with the 12_1_X release (this PR). 

@slava77 @jordan-martins @crovelli 
