### PR TITLE
Set numberOfConcurrentLuminosityBlocks to 1 for GEN steps that have EDModules that are not going to support concurrent lumis

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1368,6 +1368,8 @@ class ConfigBuilder(object):
                 raise Exception("Neither gen fragment of input files provided: this is an inconsistent GEN step configuration")
 
         if not loadFailure:
+            from Configuration.Generator.concurrentLumisDisable import noConcurrentLumiGenerators
+
             generatorModule=sys.modules[loadFragment]
             genModules=generatorModule.__dict__
             #remove lhe producer module since this should have been
@@ -1385,6 +1387,10 @@ class ConfigBuilder(object):
                     theObject = getattr(generatorModule,name)
                     if isinstance(theObject, cmstypes._Module):
                         self._options.inlineObjets=name+','+self._options.inlineObjets
+                        if theObject.type_() in noConcurrentLumiGenerators:
+                            print("Setting numberOfConcurrentLuminosityBlocks=1 because of generator {}".format(theObject.type_()))
+                            self._options.nConcurrentLumis = "1"
+                            self._options.nConcurrentIOVs = "1"
                     elif isinstance(theObject, cms.Sequence) or isinstance(theObject, cmstypes.ESProducer):
                         self._options.inlineObjets+=','+name
 

--- a/Configuration/Generator/python/concurrentLumisDisable.py
+++ b/Configuration/Generator/python/concurrentLumisDisable.py
@@ -1,0 +1,17 @@
+# list of generator EDModules (C++ type) that do not support concurrentLuminosityBlocks
+noConcurrentLumiGenerators = [
+    "AMPTGeneratorFilter",
+    "BeamHaloProducer",
+    "CosMuoGenProducer",
+    "Herwig7GeneratorFilter",
+    "HydjetGeneratorFilter",
+    "PyquenGeneratorFilter",
+    "Pythia6GeneratorFilter",
+    "Pythia8EGun",
+    "Pythia8GeneratorFilter",
+    "Pythia8HadronizerFilter",
+    "Pythia8PtAndDxyGun",
+    "Pythia8PtGun",
+    "ReggeGribovPartonMCGeneratorFilter",
+    "SherpaGeneratorFilter",
+]


### PR DESCRIPTION
#### PR description:

As reported in #25090 several generator EDModules are not planned to be made support concurrent lumis (e.g. too difficult, so little overal CPU time spent so that it is not worth it, or with `ExternalGeneratorFilter` desire to continue testing generators also directly).

In order to silence the warning message on multithreaded jobs, and to later allow changing that warning to an exception (to better prevent any modules that do not support concurrent lumis to creep in workflow steps that are expected to support concurrent lumis), following the example of https://github.com/cms-sw/cmssw/pull/35073 this PR suggest the ConfigBuilder to set the number of concurrent lumis (and IOVs) explicitly to 1 if the job has `GEN` step with any of the generator EDModules that do not support concurrent lumis. In this PR I added a new file `Configuration/Generator/python/concurrentLumisDisable.py` to contain the list of the EDModules (so that it would be explicitly maintained by @cms-sw/generators-l2), in principle they could be listed elsewhere too.

This PR is very similar to 

#### PR validation:

Workflows `5.2,140.0,521.0,7.0,300.0,140.0,5.5,511.0,281.0,8.1,534.0,281.0,132.0,280.0,120.0` set their GEN step to use 1 concurrent lumi, and workflow `10024.0` continues to set 2 concurrent lumis (when run multithreaded).