### PR TITLE
Add TrackerAdditionalParametersPerDet_cfi to prevent exception in Tracker test script

### DIFF
--- a/Geometry/TrackerGeometryBuilder/test/python/testTrackerModuleInfoDDD_cfg.py
+++ b/Geometry/TrackerGeometryBuilder/test/python/testTrackerModuleInfoDDD_cfg.py
@@ -16,6 +16,8 @@ process.TrackerGeometricDetESModule = cms.ESProducer( "TrackerGeometricDetESModu
 
 process.es_prefer_geomdet = cms.ESPrefer("TrackerGeometricDetESModule","")
 
+process.load("Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi")
+
 process.load("Alignment.CommonAlignmentProducer.FakeAlignmentSource_cfi")
 process.preferFakeAlign = cms.ESPrefer("FakeAlignmentSource") 
 


### PR DESCRIPTION
PR #34120 made the `TrackerAdditionalParametersPerDet` required for Run 2 and later Tracker configs. The `testTrackerModuleInfoDDD_cfg.py` config uses Run 1 by default, but it can also be used for later runs. Without the fix in this PR, this config encounters an exception if used for Run 2 or later.

#### PR validation:

The config runs successfully with this PR.

This PR should be backported to 12_0 because the config fixed in this PR is needed for validating geometry DB payloads, which will be needed for 12_0.