### PR TITLE
Remove boost lexical_cast dependency in CalibTracker

### DIFF
--- a/CalibTracker/SiStripLorentzAngle/plugins/EnsembleCalibrationLA.cc
+++ b/CalibTracker/SiStripLorentzAngle/plugins/EnsembleCalibrationLA.cc
@@ -3,7 +3,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include <TChain.h>
 #include <TFile.h>
-#include <boost/lexical_cast.hpp>
 #include <fstream>
 #include <regex>
 
@@ -64,7 +63,7 @@ namespace sistrip {
         if (std::regex_match(ensemble.first, format)) {
           const bool TIB = "TIB" == std::regex_replace(ensemble.first, format, "\\1");
           const bool stereo = "s" == std::regex_replace(ensemble.first, format, "\\3");
-          const unsigned layer = boost::lexical_cast<unsigned>(std::regex_replace(ensemble.first, format, "\\2"));
+          const unsigned layer = std::stoul(std::regex_replace(ensemble.first, format, "\\2"));
           label = std::regex_replace(ensemble.first, format, "\\4");
           index = LA_Filler_Fitter::layer_index(TIB, stereo, layer);
 

--- a/CalibTracker/SiStripLorentzAngle/plugins/MeasureLA.cc
+++ b/CalibTracker/SiStripLorentzAngle/plugins/MeasureLA.cc
@@ -3,7 +3,6 @@
 #include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
 #include "CalibTracker/StandaloneTrackerTopology/interface/StandaloneTrackerTopology.h"
 
-#include <boost/lexical_cast.hpp>
 #include <TChain.h>
 #include <TFile.h>
 #include <regex>
@@ -184,7 +183,7 @@ namespace sistrip {
     std::regex format(".*(T[IO]B)_layer(\\d)([as]).*");
     const bool isTIB = "TIB" == std::regex_replace(layer, format, "\\1");
     const bool stereo = "s" == std::regex_replace(layer, format, "\\3");
-    const unsigned layerNum = boost::lexical_cast<unsigned>(std::regex_replace(layer, format, "\\2"));
+    const unsigned layerNum = std::stoul(std::regex_replace(layer, format, "\\2"));
     return std::make_pair(LA_Filler_Fitter::layer_index(isTIB, stereo, layerNum), method);
   }
 

--- a/CalibTracker/SiStripLorentzAngle/src/LA_Results.cc
+++ b/CalibTracker/SiStripLorentzAngle/src/LA_Results.cc
@@ -3,7 +3,6 @@
 
 #include <cmath>
 #include <regex>
-#include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string/erase.hpp>
 #include <TF1.h>
 #include <TGraphErrors.h>
@@ -60,8 +59,8 @@ LA_Filler_Fitter::Result LA_Filler_Fitter::result(Method m, const std::string na
 std::map<uint32_t, LA_Filler_Fitter::Result> LA_Filler_Fitter::module_results(const Book& book, const Method m) {
   std::map<uint32_t, Result> results;
   for (Book::const_iterator it = book.begin(".*_module\\d*" + method(m)); it != book.end(); ++it) {
-    const uint32_t detid = boost::lexical_cast<uint32_t>(
-        std::regex_replace(it->first, std::regex(".*_module(\\d*)_.*"), std::string("\\1")));
+    const uint32_t detid =
+        std::stoul(std::regex_replace(it->first, std::regex(".*_module(\\d*)_.*"), std::string("\\1")));
     results[detid] = result(m, it->first, book);
   }
   return results;


### PR DESCRIPTION
#### PR description:

Remove boost lexical cast dependency in CalibTracker with corresponding stl alternatives

#### PR validation:

Passed runtests

#### if this PR is a backport:

@davidlange6 @vgvassilev
