### PR TITLE
Migrate module config in RecoTracker{IterativeTracking} to use default cfipython v3

### DIFF
--- a/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
@@ -31,7 +31,7 @@ trackingPhase1.toModify(mixedTripletStepClusters, oldClusterRemovalInfo='chargeC
 # SEEDING LAYERS
 from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *
 from RecoTracker.IterativeTracking.DetachedTripletStep_cff import detachedTripletStepSeedLayers
-from RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi as _seedmod
+import RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi as _seedmod
 mixedTripletStepSeedLayersA = _seedmod.seedingLayersEDProducer.clone(
      layerList = ['BPix2+FPix1_pos+FPix2_pos', 'BPix2+FPix1_neg+FPix2_neg'],
 #    layerList = ['BPix1+BPix2+BPix3', 

--- a/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
@@ -31,24 +31,24 @@ trackingPhase1.toModify(mixedTripletStepClusters, oldClusterRemovalInfo='chargeC
 # SEEDING LAYERS
 from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *
 from RecoTracker.IterativeTracking.DetachedTripletStep_cff import detachedTripletStepSeedLayers
-import RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi as _seedmod
-mixedTripletStepSeedLayersA = _seedmod.seedingLayersEDProducer.clone(
+import RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi as _mod
+mixedTripletStepSeedLayersA = _mod.seedingLayersEDProducer.clone(
      layerList = ['BPix2+FPix1_pos+FPix2_pos', 'BPix2+FPix1_neg+FPix2_neg'],
 #    layerList = ['BPix1+BPix2+BPix3', 
 #        'BPix1+BPix2+FPix1_pos', 'BPix1+BPix2+FPix1_neg', 
 #        'BPix1+FPix1_pos+FPix2_pos', 'BPix1+FPix1_neg+FPix2_neg', 
 #        'BPix2+FPix1_pos+FPix2_pos', 'BPix2+FPix1_neg+FPix2_neg'],
-    BPix = cms.PSet(
+    BPix = dict(
         TTRHBuilder = cms.string('WithTrackAngle'),
         HitProducer = cms.string('siPixelRecHits'),
         skipClusters = cms.InputTag('mixedTripletStepClusters')
     ),
-    FPix = cms.PSet(
+    FPix = dict(
         TTRHBuilder = cms.string('WithTrackAngle'),
         HitProducer = cms.string('siPixelRecHits'),
         skipClusters = cms.InputTag('mixedTripletStepClusters')
     ),
-    TEC = cms.PSet(
+    TEC = dict(
         matchedRecHits = cms.InputTag('siStripMatchedRecHits','matchedRecHit'),
         useRingSlector = cms.bool(True),
         TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
@@ -161,17 +161,15 @@ _fastSim_mixedTripletStepSeedsA = FastSimulation.Tracking.TrajectorySeedProducer
 )
 fastSim.toReplaceWith(mixedTripletStepSeedsA,_fastSim_mixedTripletStepSeedsA)
 
-import RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi as _mod
-
 # SEEDING LAYERS
 mixedTripletStepSeedLayersB = _mod.seedingLayersEDProducer.clone(
     layerList = ['BPix2+BPix3+TIB1'],
-    BPix = cms.PSet(
+    BPix = dict(
         TTRHBuilder = cms.string('WithTrackAngle'),
         HitProducer = cms.string('siPixelRecHits'),
         skipClusters = cms.InputTag('mixedTripletStepClusters')
     ),
-    TIB = cms.PSet(
+    TIB = dict(
         matchedRecHits = cms.InputTag('siStripMatchedRecHits','matchedRecHit'),
         TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutTight')),
         skipClusters = cms.InputTag('mixedTripletStepClusters')

--- a/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
@@ -31,12 +31,13 @@ trackingPhase1.toModify(mixedTripletStepClusters, oldClusterRemovalInfo='chargeC
 # SEEDING LAYERS
 from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *
 from RecoTracker.IterativeTracking.DetachedTripletStep_cff import detachedTripletStepSeedLayers
-mixedTripletStepSeedLayersA = cms.EDProducer('SeedingLayersEDProducer',
-     layerList = cms.vstring('BPix2+FPix1_pos+FPix2_pos', 'BPix2+FPix1_neg+FPix2_neg'),
-#    layerList = cms.vstring('BPix1+BPix2+BPix3', 
+from RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi as _seedmod
+mixedTripletStepSeedLayersA = _seedmod.seedingLayersEDProducer.clone(
+     layerList = ['BPix2+FPix1_pos+FPix2_pos', 'BPix2+FPix1_neg+FPix2_neg'],
+#    layerList = ['BPix1+BPix2+BPix3', 
 #        'BPix1+BPix2+FPix1_pos', 'BPix1+BPix2+FPix1_neg', 
 #        'BPix1+FPix1_pos+FPix2_pos', 'BPix1+FPix1_neg+FPix2_neg', 
-#        'BPix2+FPix1_pos+FPix2_pos', 'BPix2+FPix1_neg+FPix2_neg'),
+#        'BPix2+FPix1_pos+FPix2_pos', 'BPix2+FPix1_neg+FPix2_neg'],
     BPix = cms.PSet(
         TTRHBuilder = cms.string('WithTrackAngle'),
         HitProducer = cms.string('siPixelRecHits'),


### PR DESCRIPTION
#### PR description: 
Optimization of the python configurations: Improve maintainability by cleaning up the duplicated and cloning from the default/reference configurations. 

In this PR, 1 file changed.  
RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
The previous PR is #34007.

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_12_1_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).