### PR TITLE
Migrate module configuration in RecoVertex to use default cfipython v2

### DIFF
--- a/RecoVertex/BeamSpotProducer/python/BeamSpotOnline_cfi.py
+++ b/RecoVertex/BeamSpotProducer/python/BeamSpotOnline_cfi.py
@@ -1,12 +1,8 @@
 import FWCore.ParameterSet.Config as cms
-
-onlineBeamSpotProducer = cms.EDProducer('BeamSpotOnlineProducer',
-                                        src = cms.InputTag('scalersRawToDigi'),
-                                        changeToCMSCoordinates = cms.bool(False),
-                                        maxZ = cms.double(40),
-                                        maxRadius = cms.double(2),
-                                        setSigmaZ = cms.double(-1), #negative value disables it.
-                                        gtEvmLabel = cms.InputTag('gtEvmDigis'),
-                                        useTransientRecord = cms.bool(False)
+import RecoVertex.BeamSpotProducer.beamSpotOnlineProducer_cfi as _mod
+onlineBeamSpotProducer = _mod.beamSpotOnlineProducer.clone(
+                                        src = 'scalersRawToDigi',
+                                        setSigmaZ = -1, #negative value disables it.
+                                        gtEvmLabel = 'gtEvmDigis'
 )
 


### PR DESCRIPTION
#### PR description: 
Optimization of the python configurations: Improve maintainability by cleaning up the duplicated and cloning from the default/reference configurations. 

In this PR, 1 file changed.  
RecoVertex/BeamSpotProducer/python/BeamSpotOnline_cfi.py 
The previous PR is #35194

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_12_1_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).