### PR TITLE
Migrate module config in Validation{RecoVertex} to use default cfipython

### DIFF
--- a/Validation/RecoVertex/python/pvRecoSequence_cff.py
+++ b/Validation/RecoVertex/python/pvRecoSequence_cff.py
@@ -7,26 +7,22 @@ from Configuration.StandardSequences.Reconstruction_cff import *
 #from RecoVertex.PrimaryVertexProducer.OfflinePrimaryVertices_cfi import *
 
 # 2010-like PV reconstruction 
-
-offlinePrimaryVerticesGAP = cms.EDProducer("PrimaryVertexProducer",
-       verbose = cms.untracked.bool(False),
-       beamSpotLabel = cms.InputTag("offlineBeamSpot"),    
-       TrackLabel = cms.InputTag("generalTracks"),         # label of tracks to be used
-       TkFilterParameters = cms.PSet(
-                    algorithm=cms.string('filter'),
-                    maxNormalizedChi2 = cms.double(20.0),    #
-                    minSiliconLayersWithHits = cms.int32(5), # >= 5
-                    minPixelLayersWithHits = cms.int32(2),   # >= 2
-                    maxD0Significance = cms.double(100.0),     # keep most primary tracks
-                    minPt = cms.double(0.0),                 # better for softish events
-                    maxEta = cms.double(5.0),
-                    trackQuality = cms.string("any")
+import RecoVertex.PrimaryVertexProducer.primaryVertexProducer_cfi as _mod
+offlinePrimaryVerticesGAP = _mod.primaryVertexProducer.clone(
+       TrackLabel = "generalTracks",             # label of tracks to be used
+       TkFilterParameters = dict(
+                    maxNormalizedChi2 = 20.0,    #
+                    minSiliconLayersWithHits = 5,# >= 5
+                    minPixelLayersWithHits = 2,  # >= 2
+                    maxD0Significance = 100.0,   # keep most primary tracks
+                    minPt = 0.0,                 # better for softish events
+                    maxEta = 5.0
                 ),
        # clustering
-       TkClusParameters = cms.PSet(
-                   algorithm   = cms.string('gap'),
-                   TkGapClusParameters = cms.PSet(
-                         zSeparation = cms.double(0.2)
+       TkClusParameters = dict(
+                   algorithm   = 'gap',
+                   TkGapClusParameters = dict(
+                         zSeparation = 0.2
                    )
        ),
        vertexCollections = cms.VPSet(
@@ -36,45 +32,43 @@ offlinePrimaryVerticesGAP = cms.EDProducer("PrimaryVertexProducer",
                         minNdof=cms.double(0.0),
                         useBeamConstraint = cms.bool(False),
                         maxDistanceToBeam = cms.double(2.0)
-               )]
+                       )
+              ]
+       )
+)
+
+offlinePrimaryVerticesD0s5 = offlinePrimaryVerticesGAP.clone(
+    TkFilterParameters = dict( 
+           maxD0Significance = 5 
+    )
+)
+offlinePrimaryVerticesD0s51mm = offlinePrimaryVerticesGAP.clone(
+    TkFilterParameters = dict(
+           maxD0Significance = 5
+    ),
+    TkClusParameters = dict(
+           TkGapClusParameters = dict(
+                  zSeparation = 0.1
+           )
     )
 )
 
-
-
-offlinePrimaryVerticesD0s5 = offlinePrimaryVerticesGAP.clone()
-offlinePrimaryVerticesD0s5.TkFilterParameters.maxD0Significance = cms.double(5)
-
-offlinePrimaryVerticesD0s51mm = offlinePrimaryVerticesGAP.clone()
-offlinePrimaryVerticesD0s51mm.TkFilterParameters.maxD0Significance = cms.double(5)
-offlinePrimaryVerticesD0s51mm.TkClusParameters.TkGapClusParameters.zSeparation = cms.double(0.1) 
-
-
-offlinePrimaryVerticesDA100um = cms.EDProducer("PrimaryVertexProducer",
-
-    verbose = cms.untracked.bool(False),
-    TrackLabel = cms.InputTag("generalTracks"),
-    beamSpotLabel = cms.InputTag("offlineBeamSpot"),
-
-    TkFilterParameters = cms.PSet(
-        algorithm=cms.string('filter'),
-        maxNormalizedChi2 = cms.double(20.0),
-        minPixelLayersWithHits=cms.int32(2),
-        minSiliconLayersWithHits = cms.int32(5),
-        maxD0Significance = cms.double(5.0),
-        minPt = cms.double(0.0),
-        maxEta = cms.double(5.0),
-        trackQuality = cms.string("any")
+offlinePrimaryVerticesDA100um = _mod.primaryVertexProducer.clone(
+    TrackLabel = "generalTracks",
+    TkFilterParameters = dict(
+        maxNormalizedChi2 = 20.0,
+        maxD0Significance = 5.0,
+        maxEta = 5.0
     ),
 
-    TkClusParameters = cms.PSet(
-        algorithm   = cms.string("DA"),
-        TkDAClusParameters = cms.PSet(
-            coolingFactor = cms.double(0.6),  #  moderate annealing speed
-            Tmin = cms.double(4.0),            #  end of annealing
-            vertexSize = cms.double(0.01),    #  
-            d0CutOff = cms.double(3.),        # downweight high IP tracks
-            dzCutOff = cms.double(4.),         # outlier rejection after freeze-out (T<Tmin)
+    TkClusParameters = dict(
+        algorithm   = "DA",
+        TkDAClusParameters = dict(
+            coolingFactor = 0.6,  #  moderate annealing speed
+            Tmin = 4.0,           #  end of annealing
+            vertexSize = 0.01,    #  
+            d0CutOff = 3.,        # downweight high IP tracks
+            dzCutOff = 4.         # outlier rejection after freeze-out (T<Tmin)
         )
     ),
 
@@ -85,26 +79,35 @@ offlinePrimaryVerticesDA100um = cms.EDProducer("PrimaryVertexProducer",
                minNdof=cms.double(0.0),
                useBeamConstraint = cms.bool(False),
                maxDistanceToBeam = cms.double(1.0)
-               )
-      ]
+              )
+     ]
     )
-
-
-
 )
 
-offlinePrimaryVerticesDA100umV7 = offlinePrimaryVerticesDA100um.clone()
-offlinePrimaryVerticesDA100umV7.vertexCollections[0].maxDistanceToBeam = cms.double(2.0)
-offlinePrimaryVerticesDA100umV7.TkFilterParameters.maxNormalizedChi2 = cms.double(5.0)
-offlinePrimaryVerticesDA100umV7.TkClusParameters.TkDAClusParameters.coolingFactor = cms.double(0.8)
-offlinePrimaryVerticesDA100umV7.TkClusParameters.TkDAClusParameters.Tmin = cms.double(9.)
-
-offlinePrimaryVerticesDA100umV8 = offlinePrimaryVerticesDA100um.clone()
-offlinePrimaryVerticesDA100umV8.vertexCollections[0].maxDistanceToBeam = cms.double(1.0)
-offlinePrimaryVerticesDA100umV8.TkFilterParameters.maxNormalizedChi2 = cms.double(5.0)
-offlinePrimaryVerticesDA100umV8.TkClusParameters.TkDAClusParameters.coolingFactor = cms.double(0.6)
-offlinePrimaryVerticesDA100umV8.TkClusParameters.TkDAClusParameters.Tmin = cms.double(4.)
-
+offlinePrimaryVerticesDA100umV7 = offlinePrimaryVerticesDA100um.clone(
+    vertexCollections = {0: dict(maxDistanceToBeam = 2.0)},
+    TkFilterParameters = dict(
+           maxNormalizedChi2 = 5.0
+    ),
+    TkClusParameters = dict(
+           TkDAClusParameters = dict(
+                  coolingFactor = 0.8,
+                  Tmin = 9.
+           )
+    )
+)
+offlinePrimaryVerticesDA100umV8 = offlinePrimaryVerticesDA100um.clone(
+    vertexCollections = {0: dict(maxDistanceToBeam = 1.0)},
+    TkFilterParameters = dict(
+           maxNormalizedChi2 = 5.0
+    ),
+    TkClusParameters = dict(
+           TkDAClusParameters = dict(
+                  coolingFactor = 0.6,
+                  Tmin = 4.
+           )
+    )
+)
 
 seqPVReco = cms.Sequence(offlinePrimaryVerticesGAP + offlinePrimaryVerticesD0s5 + offlinePrimaryVerticesD0s51mm +
                          offlinePrimaryVerticesDA100um + offlinePrimaryVerticesDA100umV7 + offlinePrimaryVerticesDA100umV8 )


### PR DESCRIPTION
#### PR description: 
Optimization of the python configurations: Improve maintainability by cleaning up the duplicated and cloning from the default/reference configurations. 

In this PR, 1 file changed  
Validation/RecoVertex/python/pvRecoSequence_cff.py

The cfipython file used in this PR :  RecoVertex/PrimaryVertexProducer/primaryVertexProducer_cfi.py
(This cfipython used in PR #34818)

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_12_1_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).
