### PR TITLE
[UBSAN] Fix overloaded enum in TemplatedSecondaryVertexTagInfo

### DIFF
--- a/DataFormats/BTauReco/interface/TemplatedSecondaryVertexTagInfo.h
+++ b/DataFormats/BTauReco/interface/TemplatedSecondaryVertexTagInfo.h
@@ -30,15 +30,15 @@ namespace reco {
     }
 
     struct TrackData {
-      enum Status { trackSelected = 0, trackUsedForVertexFit, trackAssociatedToVertex };
-
-      inline bool usedForVertexFit() const { return (int)svStatus >= (int)trackUsedForVertexFit; }
-      inline bool associatedToVertex() const { return (int)svStatus >= (int)trackAssociatedToVertex; }
+      static const int trackSelected = 0;
+      static const int trackUsedForVertexFit = 1;
+      static const int trackAssociatedToVertex = 2;
+      inline bool usedForVertexFit() const { return svStatus >= trackUsedForVertexFit; }
+      inline bool associatedToVertex() const { return svStatus >= trackAssociatedToVertex; }
       inline bool associatedToVertex(unsigned int index) const {
-        return (int)svStatus == (int)trackAssociatedToVertex + (int)index;
+        return svStatus == trackAssociatedToVertex + (int)index;
       }
-
-      Status svStatus;
+      int svStatus;
     };
     typedef std::pair<unsigned int, TrackData> IndexedTrackData;
 

--- a/DataFormats/BTauReco/interface/TemplatedSecondaryVertexTagInfo.h
+++ b/DataFormats/BTauReco/interface/TemplatedSecondaryVertexTagInfo.h
@@ -30,9 +30,9 @@ namespace reco {
     }
 
     struct TrackData {
-      static const int trackSelected = 0;
-      static const int trackUsedForVertexFit = 1;
-      static const int trackAssociatedToVertex = 2;
+      static constexpr int trackSelected = 0;
+      static constexpr int trackUsedForVertexFit = 1;
+      static constexpr int trackAssociatedToVertex = 2;
       inline bool usedForVertexFit() const { return svStatus >= trackUsedForVertexFit; }
       inline bool associatedToVertex() const { return svStatus >= trackAssociatedToVertex; }
       inline bool associatedToVertex(unsigned int index) const {

--- a/DataFormats/BTauReco/src/classes_def.xml
+++ b/DataFormats/BTauReco/src/classes_def.xml
@@ -32,9 +32,8 @@
   <class name="reco::JTATagInfoRefVector"/>
   <class name="edm::Wrapper<reco::JTATagInfoCollection>"/>
 
-  <class name="reco::btag::TrackData" ClassVersion="14">
-   <version ClassVersion="14" checksum="427805128"/>
-   <version ClassVersion="13" checksum="3158345604"/>
+  <class name="reco::btag::TrackData" ClassVersion="13">
+   <version ClassVersion="13" checksum="427805128"/>
    <version ClassVersion="12" checksum="889773348"/>
    <version ClassVersion="11" checksum="427805128"/>
    <version ClassVersion="10" checksum="3899080432"/>

--- a/DataFormats/BTauReco/src/classes_def.xml
+++ b/DataFormats/BTauReco/src/classes_def.xml
@@ -32,7 +32,9 @@
   <class name="reco::JTATagInfoRefVector"/>
   <class name="edm::Wrapper<reco::JTATagInfoCollection>"/>
 
-  <class name="reco::btag::TrackData" ClassVersion="12">
+  <class name="reco::btag::TrackData" ClassVersion="14">
+   <version ClassVersion="14" checksum="427805128"/>
+   <version ClassVersion="13" checksum="3158345604"/>
    <version ClassVersion="12" checksum="889773348"/>
    <version ClassVersion="11" checksum="427805128"/>
    <version ClassVersion="10" checksum="3899080432"/>

--- a/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
@@ -947,8 +947,7 @@ void TemplatedSecondaryVertexProducer<TrackIPTagInfo, reco::Vertex>::markUsedTra
                                               << std::endl;
     } else {
       unsigned int index = pos - trackRefs.begin();
-      trackData[index].second.svStatus =
-          (btag::TrackData::Status)((unsigned int)btag::TrackData::trackAssociatedToVertex + idx);
+      trackData[index].second.svStatus = (btag::TrackData::trackAssociatedToVertex + idx);
     }
   }
 }
@@ -963,7 +962,7 @@ void TemplatedSecondaryVertexProducer<CandIPTagInfo, reco::VertexCompositePtrCan
     if (pos != trackRefs.end()) {
       unsigned int index = pos - trackRefs.begin();
       trackData[index].second.svStatus =
-          (btag::TrackData::Status)((unsigned int)btag::TrackData::trackAssociatedToVertex + idx);
+          (btag::TrackData::trackAssociatedToVertex + idx);
     }
   }
 }

--- a/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
@@ -961,8 +961,7 @@ void TemplatedSecondaryVertexProducer<CandIPTagInfo, reco::VertexCompositePtrCan
 
     if (pos != trackRefs.end()) {
       unsigned int index = pos - trackRefs.begin();
-      trackData[index].second.svStatus =
-          (btag::TrackData::trackAssociatedToVertex + idx);
+      trackData[index].second.svStatus = (btag::TrackData::trackAssociatedToVertex + idx);
     }
   }
 }


### PR DESCRIPTION
#### PR description:

Issue: https://github.com/cms-sw/cmssw/issues/35033

```
1302.17 step3
DataFormats/BTauReco/interface/TemplatedSecondaryVertexTagInfo.h:38:21: runtime error: load of value 4, which is not a valid value for type 'Status'
```
An enum object is currently manipulated to be outside its defined range in BTV code, which is considered undefined behavior with the UBSAN IB. This fix changes this enum structure to be integer based instead, which should get rid of the error, while not changing any behavior. 

#### PR validation:

As i had some issues reproducing the issues, i used a specific step2.root file [1] in workflow 1302.17 step3
```
cmsDriver.py step3  -s RAW2DIGI,L1Reco,RECO,RECOSIM,EI,PAT --conditions auto:phase1_2017_realistic -n 10 --datatier AODSIM,MINIAODSIM --eventcontent AODSIM,MINIAODSIM --era Run2_2017 --filein file:step2.root  --fileout file:step3.root  --nThreads 4 > step3_ProdTTbar_13UP17+ProdTTbar_13UP17+DIGIUP17PROD1+RECOPRODUP17.log  2>&1
```
With CMSSW_12_1_UBSAN_X_2021-09-03-2300 I get the reported error every time on event 10. After applying this fix, this error is gone.

[1]
https://cernbox.cern.ch/index.php/s/8vFa8hmOo9P94jf

