### PR TITLE
[Backport] Add fake alignment to tracker geometry test

### DIFF
--- a/Geometry/TrackerGeometryBuilder/test/python/testTrackerHierarchy_cfg.py
+++ b/Geometry/TrackerGeometryBuilder/test/python/testTrackerHierarchy_cfg.py
@@ -15,6 +15,9 @@ process.prod = cms.EDAnalyzer("GeoHierarchy",
     fromDDD = cms.bool(True)
 )
 
+process.load("Alignment.CommonAlignmentProducer.FakeAlignmentSource_cfi")
+process.preferFakeAlign = cms.ESPrefer("FakeAlignmentSource") 
+
 process.p1 = cms.Path(process.prod)
 
 

--- a/Geometry/TrackerGeometryBuilder/test/python/testTracker_cfg.py
+++ b/Geometry/TrackerGeometryBuilder/test/python/testTracker_cfg.py
@@ -5,6 +5,9 @@ process.load("Configuration.Geometry.GeometryExtended2021Reco_cff")
 
 process.source = cms.Source("EmptySource")
 
+process.load("Alignment.CommonAlignmentProducer.FakeAlignmentSource_cfi")
+process.preferFakeAlign = cms.ESPrefer("FakeAlignmentSource") 
+
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
 )


### PR DESCRIPTION
#### PR description:
Backport of https://github.com/cms-sw/cmssw/pull/35119
This backport will be needed, to avoid crash on geometry unit test when geometry reco config is updated in https://github.com/cms-sw/cmssw/pull/35187