### PR TITLE
Update of mkFit for 12_1_0_pre3

### DIFF
--- a/RecoTracker/MkFit/README.md
+++ b/RecoTracker/MkFit/README.md
@@ -41,6 +41,7 @@ $ runTheMatrix.py -l <workflow(s)> --apply 2 --command "--procModifiers tracking
 * *m_require_quality_filter:* is additional post-processing required for result tracks
 * *m_require_dupclean_tight:* is tight duplicate removal post-processing required for result tracks
 * *m_params:* IterationParams structure for this iteration
+* *m_backward_params:* IterationParams structure for backward search for this iteration
 * *m_layer_configs:* std::vector of per-layer parameters
 
 ### Iteration parameters [class IterationParams]

--- a/RecoTracker/MkFit/plugins/BuildFile.xml
+++ b/RecoTracker/MkFit/plugins/BuildFile.xml
@@ -1,6 +1,8 @@
 <library file="*.cc" name="RecoTrackerMkFitPlugins">
   <use name="CalibFormats/SiStripObjects"/>
   <use name="CalibTracker/Records"/>
+  <use name="CondFormats/DataRecord"/>
+  <use name="CondFormats/SiPixelObjects"/>
   <use name="DataFormats/Common"/>
   <use name="DataFormats/SiStripCluster"/>
   <use name="DataFormats/SiStripCommon"/>

--- a/RecoTracker/MkFit/plugins/MkFitEventOfHitsProducer.cc
+++ b/RecoTracker/MkFit/plugins/MkFitEventOfHitsProducer.cc
@@ -4,6 +4,9 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include "CondFormats/SiPixelObjects/interface/SiPixelQuality.h"
+#include "CondFormats/DataRecord/interface/SiPixelQualityRcd.h"
+
 #include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"
 #include "CalibTracker/Records/interface/SiStripQualityRcd.h"
 
@@ -44,9 +47,11 @@ private:
   const edm::EDGetTokenT<MkFitClusterIndexToHit> pixelClusterIndexToHitToken_;
   const edm::EDGetTokenT<MkFitClusterIndexToHit> stripClusterIndexToHitToken_;
   const edm::ESGetToken<MkFitGeometry, TrackerRecoGeometryRecord> mkFitGeomToken_;
-  edm::ESGetToken<SiStripQuality, SiStripQualityRcd> qualityToken_;
+  edm::ESGetToken<SiPixelQuality, SiPixelQualityRcd> pixelQualityToken_;
+  edm::ESGetToken<SiStripQuality, SiStripQualityRcd> stripQualityToken_;
   edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
   const edm::EDPutTokenT<MkFitEventOfHits> putToken_;
+  const bool usePixelQualityDB_;
   const bool useStripStripQualityDB_;
 };
 
@@ -57,10 +62,15 @@ MkFitEventOfHitsProducer::MkFitEventOfHitsProducer(edm::ParameterSet const& iCon
       stripClusterIndexToHitToken_{consumes(iConfig.getParameter<edm::InputTag>("stripHits"))},
       mkFitGeomToken_{esConsumes()},
       putToken_{produces<MkFitEventOfHits>()},
+      usePixelQualityDB_{iConfig.getParameter<bool>("usePixelQualityDB")},
       useStripStripQualityDB_{iConfig.getParameter<bool>("useStripStripQualityDB")} {
-  if (useStripStripQualityDB_) {
-    qualityToken_ = esConsumes();
+  if (useStripStripQualityDB_ || usePixelQualityDB_)
     geomToken_ = esConsumes();
+  if (usePixelQualityDB_) {
+    pixelQualityToken_ = esConsumes();
+  }
+  if (useStripStripQualityDB_) {
+    stripQualityToken_ = esConsumes();
   }
 }
 
@@ -69,6 +79,7 @@ void MkFitEventOfHitsProducer::fillDescriptions(edm::ConfigurationDescriptions& 
 
   desc.add("pixelHits", edm::InputTag{"mkFitSiPixelHits"});
   desc.add("stripHits", edm::InputTag{"mkFitSiStripHits"});
+  desc.add("usePixelQualityDB", true)->setComment("Use SiPixelQuality DB information");
   desc.add("useStripStripQualityDB", true)->setComment("Use SiStrip quality DB information");
 
   descriptions.addWithDefaultLabel(desc);
@@ -82,55 +93,73 @@ void MkFitEventOfHitsProducer::produce(edm::StreamID iID, edm::Event& iEvent, co
   auto eventOfHits = std::make_unique<mkfit::EventOfHits>(mkFitGeom.trackerInfo());
   mkfit::StdSeq::Cmssw_LoadHits_Begin(*eventOfHits, {&pixelHits.hits(), &stripHits.hits()});
 
-  if (useStripStripQualityDB_) {
+  if (usePixelQualityDB_ || useStripStripQualityDB_) {
     std::vector<mkfit::DeadVec> deadvectors(mkFitGeom.layerNumberConverter().nLayers());
-    const auto& siStripQuality = iSetup.getData(qualityToken_);
     const auto& trackerGeom = iSetup.getData(geomToken_);
-    const auto& badStrips = siStripQuality.getBadComponentList();
-    for (const auto& bs : badStrips) {
-      const DetId detid(bs.detid);
-      const auto& surf = trackerGeom.idToDet(detid)->surface();
-      bool isBarrel = (mkFitGeom.topology()->side(detid) == static_cast<unsigned>(TrackerDetSide::Barrel));
-      const auto ilay = mkFitGeom.mkFitLayerNumber(detid);
-      const auto q1 = isBarrel ? surf.zSpan().first : surf.rSpan().first;
-      const auto q2 = isBarrel ? surf.zSpan().second : surf.rSpan().second;
-      if (bs.BadModule)
-        deadvectors[ilay].push_back({surf.phiSpan().first, surf.phiSpan().second, q1, q2});
-      else {  //assume that BadApvs are filled in sync with BadFibers
-        auto const& topo = dynamic_cast<const StripTopology&>(trackerGeom.idToDet(detid)->topology());
-        int firstApv = -1;
-        int lastApv = -1;
 
-        auto addRangeAPV = [&topo, &surf, &q1, &q2](int first, int last, mkfit::DeadVec& dv) {
-          auto const firstPoint = surf.toGlobal(topo.localPosition(first * sistrip::STRIPS_PER_APV));
-          auto const lastPoint = surf.toGlobal(topo.localPosition((last + 1) * sistrip::STRIPS_PER_APV));
-          float phi1 = firstPoint.phi();
-          float phi2 = lastPoint.phi();
-          if (reco::deltaPhi(phi1, phi2) > 0)
-            std::swap(phi1, phi2);
-          LogTrace("SiStripBadComponents")
-              << "insert bad range " << first << " to " << last << " " << phi1 << " " << phi2;
-          dv.push_back({phi1, phi2, q1, q2});
-        };
+    if (usePixelQualityDB_) {
+      const auto& pixelQuality = iSetup.getData(pixelQualityToken_);
+      const auto& badPixels = pixelQuality.getBadComponentList();
+      for (const auto& bp : badPixels) {
+        const DetId detid(bp.DetID);
+        const auto& surf = trackerGeom.idToDet(detid)->surface();
+        bool isBarrel = (mkFitGeom.topology()->side(detid) == static_cast<unsigned>(TrackerDetSide::Barrel));
+        const auto ilay = mkFitGeom.mkFitLayerNumber(detid);
+        const auto q1 = isBarrel ? surf.zSpan().first : surf.rSpan().first;
+        const auto q2 = isBarrel ? surf.zSpan().second : surf.rSpan().second;
+        if (bp.errorType == 0)
+          deadvectors[ilay].push_back({surf.phiSpan().first, surf.phiSpan().second, q1, q2});
+      }
+    }
 
-        const int nApvs = topo.nstrips() / sistrip::STRIPS_PER_APV;
-        for (int apv = 0; apv < nApvs; ++apv) {
-          const bool isBad = bs.BadApvs & (1 << apv);
-          if (isBad) {
-            LogTrace("SiStripBadComponents") << "bad apv " << apv << " on " << bs.detid;
-            if (lastApv == -1) {
-              firstApv = apv;
-              lastApv = apv;
-            } else if (lastApv + 1 == apv)
-              lastApv++;
+    if (useStripStripQualityDB_) {
+      const auto& siStripQuality = iSetup.getData(stripQualityToken_);
+      const auto& badStrips = siStripQuality.getBadComponentList();
+      for (const auto& bs : badStrips) {
+        const DetId detid(bs.detid);
+        const auto& surf = trackerGeom.idToDet(detid)->surface();
+        bool isBarrel = (mkFitGeom.topology()->side(detid) == static_cast<unsigned>(TrackerDetSide::Barrel));
+        const auto ilay = mkFitGeom.mkFitLayerNumber(detid);
+        const auto q1 = isBarrel ? surf.zSpan().first : surf.rSpan().first;
+        const auto q2 = isBarrel ? surf.zSpan().second : surf.rSpan().second;
+        if (bs.BadModule)
+          deadvectors[ilay].push_back({surf.phiSpan().first, surf.phiSpan().second, q1, q2});
+        else {  //assume that BadApvs are filled in sync with BadFibers
+          auto const& topo = dynamic_cast<const StripTopology&>(trackerGeom.idToDet(detid)->topology());
+          int firstApv = -1;
+          int lastApv = -1;
 
-            if (apv + 1 == nApvs)
+          auto addRangeAPV = [&topo, &surf, &q1, &q2](int first, int last, mkfit::DeadVec& dv) {
+            auto const firstPoint = surf.toGlobal(topo.localPosition(first * sistrip::STRIPS_PER_APV));
+            auto const lastPoint = surf.toGlobal(topo.localPosition((last + 1) * sistrip::STRIPS_PER_APV));
+            float phi1 = firstPoint.phi();
+            float phi2 = lastPoint.phi();
+            if (reco::deltaPhi(phi1, phi2) > 0)
+              std::swap(phi1, phi2);
+            LogTrace("SiStripBadComponents")
+                << "insert bad range " << first << " to " << last << " " << phi1 << " " << phi2;
+            dv.push_back({phi1, phi2, q1, q2});
+          };
+
+          const int nApvs = topo.nstrips() / sistrip::STRIPS_PER_APV;
+          for (int apv = 0; apv < nApvs; ++apv) {
+            const bool isBad = bs.BadApvs & (1 << apv);
+            if (isBad) {
+              LogTrace("SiStripBadComponents") << "bad apv " << apv << " on " << bs.detid;
+              if (lastApv == -1) {
+                firstApv = apv;
+                lastApv = apv;
+              } else if (lastApv + 1 == apv)
+                lastApv++;
+
+              if (apv + 1 == nApvs)
+                addRangeAPV(firstApv, lastApv, deadvectors[ilay]);
+            } else if (firstApv != -1) {
               addRangeAPV(firstApv, lastApv, deadvectors[ilay]);
-          } else if (firstApv != -1) {
-            addRangeAPV(firstApv, lastApv, deadvectors[ilay]);
-            //and reset
-            firstApv = -1;
-            lastApv = -1;
+              //and reset
+              firstApv = -1;
+              lastApv = -1;
+            }
           }
         }
       }

--- a/RecoTracker/MkFit/plugins/createPhase1TrackerGeometry.cc
+++ b/RecoTracker/MkFit/plugins/createPhase1TrackerGeometry.cc
@@ -32,7 +32,7 @@ namespace {
       sp.append_plan(47, false);
       sp.fill_plan(48, 53);  // TID,  6 disks (3 mono + 3 stereo)
       sp.fill_plan(54, 71);  // TEC, 18 disks (3 mono + 3 stereo)
-      sp.finalize_plan();
+      sp.set_iterator_limits(2, 0);
     }
     {
       SteeringParams &sp = ic.m_steering_params[TrackerInfo::Reg_Transition_Neg];
@@ -47,7 +47,7 @@ namespace {
       sp.fill_plan(48, 53);  // TID,  6 disks  (3 mono + 3 stereo)
       sp.fill_plan(10, 17);  // TOB,  8 layers (6 mono + 2 stereo)
       sp.fill_plan(54, 71);  // TEC, 18 disks  (9 mono + 9 stereo)
-      sp.finalize_plan();
+      sp.set_iterator_limits(2, 0);
     }
     {
       SteeringParams &sp = ic.m_steering_params[TrackerInfo::Reg_Barrel];
@@ -57,7 +57,7 @@ namespace {
       sp.append_plan(3, false);
       sp.fill_plan(4, 9);    // TIB, 6 layers (4 mono + 2 stereo)
       sp.fill_plan(10, 17);  // TOB, 8 layers (6 mono + 2 stereo)
-      sp.finalize_plan();
+      sp.set_iterator_limits(2, 0);
     }
     {
       SteeringParams &sp = ic.m_steering_params[TrackerInfo::Reg_Transition_Pos];
@@ -72,7 +72,7 @@ namespace {
       sp.fill_plan(21, 26);  // TID,  6 disks  (3 mono + 3 stereo)
       sp.fill_plan(10, 17);  // TOB,  8 layers (6 mono + 2 stereo)
       sp.fill_plan(27, 44);  // TEC, 18 disks  (9 mono + 9 stereo)
-      sp.finalize_plan();
+      sp.set_iterator_limits(2, 0);
     }
     {
       SteeringParams &sp = ic.m_steering_params[TrackerInfo::Reg_Endcap_Pos];
@@ -84,8 +84,36 @@ namespace {
       sp.append_plan(20, false);
       sp.fill_plan(21, 26);  // TID,  6 disks  (3 mono + 3 stereo)
       sp.fill_plan(27, 44);  // TEC, 18 disks  (9 mono + 9 stereo)
-      sp.finalize_plan();
+      sp.set_iterator_limits(2, 0);
     }
+  }
+
+  void OverrideSteeringParams_Iter7(IterationConfig &ic) {
+    ic.m_backward_search = true;
+    ic.m_backward_params = ic.m_params;
+    ic.m_backward_params.maxHolesPerCand = 2;
+    ic.m_backward_params.maxConsecHoles = 2;
+    // Remove pixel layers from FwdSearch, add them to BkwSearch
+    auto &spv = ic.m_steering_params;
+    spv[TrackerInfo::Reg_Endcap_Neg].set_iterator_limits(8, 6, 19);
+    spv[TrackerInfo::Reg_Transition_Neg].set_iterator_limits(9, 7, 34);
+    spv[TrackerInfo::Reg_Barrel].set_iterator_limits(6, 4, 8);
+    spv[TrackerInfo::Reg_Transition_Pos].set_iterator_limits(9, 7, 34);
+    spv[TrackerInfo::Reg_Endcap_Pos].set_iterator_limits(8, 6, 19);
+  }
+
+  void OverrideSteeringParams_Iter8(IterationConfig &ic) {
+    ic.m_backward_search = true;
+    ic.m_backward_params = ic.m_params;
+    ic.m_backward_params.maxHolesPerCand = 2;
+    ic.m_backward_params.maxConsecHoles = 2;
+    // Remove pixel/tib/tid layers from FwdSearch, add them to BkwSearch/
+    auto &spv = ic.m_steering_params;
+    spv[TrackerInfo::Reg_Endcap_Neg].set_iterator_limits(12, 12, 24);
+    spv[TrackerInfo::Reg_Transition_Neg].set_iterator_limits(27, 19, 39);
+    spv[TrackerInfo::Reg_Barrel].set_iterator_limits(12, 10, 14);
+    spv[TrackerInfo::Reg_Transition_Pos].set_iterator_limits(27, 19, 39);
+    spv[TrackerInfo::Reg_Endcap_Pos].set_iterator_limits(12, 12, 24);
   }
 
   void partitionSeeds0(const TrackerInfo &trk_info,
@@ -221,9 +249,11 @@ namespace mkfit {
     ii[6].set_iteration_index_and_track_algorithm(6, (int)TrackBase::TrackAlgorithm::mixedTripletStep);
 
     ii[7].Clone(ii[0]);
+    OverrideSteeringParams_Iter7(ii[7]);
     ii[7].set_iteration_index_and_track_algorithm(7, (int)TrackBase::TrackAlgorithm::pixelLessStep);
 
     ii[8].Clone(ii[0]);
+    OverrideSteeringParams_Iter8(ii[8]);
     ii[8].set_iteration_index_and_track_algorithm(8, (int)TrackBase::TrackAlgorithm::tobTecStep);
 
     ii[9].Clone(ii[0]);


### PR DESCRIPTION
#### PR description:

This PR follows #34921 and updates mkFit in view of next pre-release.

In detail, this PR includes:
- usage of SiPixel quality DB information for mkFit;
- update of mkFit backward search for pixelLessStep and tobTecStep (currently NOT enabled in trackingMkFit procModifier).

It requires cms-sw/cmsdist#7287 and cms-data/RecoTracker-MkFit#4

Developments have been presented in detail at Tracking POG (https://indico.cern.ch/event/1071226/#3-mkfit-status-report). 


#### PR validation:

MTV results for tracking-only validation in TTbar RelVal (with mkFit enabled for 4 iterations as specified above, compared to full CKF [default]):
https://mmasciov.web.cern.ch/mmasciov/MkFitCMSSW/MTV_PRfor1210pre3/
More details and comparisons are included in report at Tracking POG (https://indico.cern.ch/event/1071226/#3-mkfit-status-report).


FYI @mtosi @vmariani @mmusich
(@slava77 @makortel)