### PR TITLE
[Backport] Add TrackerAdditionalParametersPerDet_cfi to prevent exception in Tracker test script

### DIFF
--- a/Geometry/TrackerGeometryBuilder/test/python/testTrackerModuleInfoDDD_cfg.py
+++ b/Geometry/TrackerGeometryBuilder/test/python/testTrackerModuleInfoDDD_cfg.py
@@ -16,6 +16,8 @@ process.TrackerGeometricDetESModule = cms.ESProducer( "TrackerGeometricDetESModu
 
 process.es_prefer_geomdet = cms.ESPrefer("TrackerGeometricDetESModule","")
 
+process.load("Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi")
+
 process.load("Alignment.CommonAlignmentProducer.FakeAlignmentSource_cfi")
 process.preferFakeAlign = cms.ESPrefer("FakeAlignmentSource") 
 


### PR DESCRIPTION
Backport of #35183 from 12_1. Adding a line to a config to prevent an exception occurring. See #35183 for more details.

The config in this PR is used to help validate geometry DB payloads, so it will be needed when the new DDD 12_0 geometry DB payloads are made.

The changed config in this PR was run for both Run 1 and Run 3 to check that it runs successfully with no exception.