### PR TITLE
Fixed exceptional case handling in SherpaHadronizer

### DIFF
--- a/GeneratorInterface/SherpaInterface/src/SherpaHadronizer.cc
+++ b/GeneratorInterface/SherpaInterface/src/SherpaHadronizer.cc
@@ -199,6 +199,9 @@ SherpaHadronizer::SherpaHadronizer(const edm::ParameterSet &params)
   arguments.push_back(shRng);
   isInitialized = false;
   //initialization of Sherpa moved to initializeForInternalPartons
+#ifdef USING__MPI
+  MPI::Init();
+#endif
 }
 
 SherpaHadronizer::~SherpaHadronizer() {
@@ -215,9 +218,6 @@ bool SherpaHadronizer::initializeForInternalPartons() {
     char *argv[argc];
     for (int l = 0; l < argc; l++)
       argv[l] = (char *)arguments[l].c_str();
-#ifdef USING__MPI
-    MPI::Init();
-#endif
     Generator->InitializeTheRun(argc, argv);
     Generator->InitializeTheEventHandler();
     isInitialized = true;

--- a/GeneratorInterface/SherpaInterface/src/SherpaHadronizer.cc
+++ b/GeneratorInterface/SherpaInterface/src/SherpaHadronizer.cc
@@ -23,6 +23,8 @@
 
 #include "CLHEP/Random/RandomEngine.h"
 
+#include "FWCore/Utilities/interface/Exception.h"
+
 //This unnamed namespace is used (instead of static variables) to pass the
 //randomEngine passed to doSetRandomEngine to the External Random
 //Number Generator CMS_SHERPA_RNG of sherpa
@@ -95,8 +97,11 @@ void SherpaHadronizer::doSetRandomEngine(CLHEP::HepRandomEngine *v) {
       SetExternalEngine(v);
       // Throw exception if there is no reference to an external RNG and it is not the first call!
     } else {
-      throw edm::Exception(edm::errors::LogicError) << "The Sherpa interface got a randomEngine reference but there is "
-                                                       "no reference to the external RNG to hand it over to\n";
+      if (isInitialized and v != nullptr) {
+        throw edm::Exception(edm::errors::LogicError)
+            << "The Sherpa interface got a randomEngine reference but there is "
+               "no reference to the external RNG to hand it over to\n";
+      }
     }
   } else {
     cmsSherpaRng->setRandomEngine(v);
@@ -213,6 +218,7 @@ SherpaHadronizer::~SherpaHadronizer() {
 
 bool SherpaHadronizer::initializeForInternalPartons() {
   //initialize Sherpa but only once
+  throw cms::Exception("TEST");
   if (!isInitialized) {
     int argc = arguments.size();
     char *argv[argc];


### PR DESCRIPTION
#### PR description:

The MPI::Init function setups up a unix signal handler which interferes with the signal handled used in the cmsExternalGenerator program. Moving the call to the constructor allows the signal handler to be reset
before doing any data processing.

Even with this change, an unix signal happening in the constructor will cause a dealock of the ExternalGenerator system.

Also had to avoid a case where an exception could be thrown while we were unrolling from another exception. That would happen if doSetRandomEngine would throw an exception.

#### PR validation:

The code compiles and a simple job using the SherpaHadronizer with the ExternalGeneratorFilter ran fine.
Explicitly adding an exception to Sherpa allowed us to test the problem.