### PR TITLE
Update TrackReco HitPattern in light of GEM now including GE0

### DIFF
--- a/DataFormats/TrackReco/interface/HitPattern.h
+++ b/DataFormats/TrackReco/interface/HitPattern.h
@@ -33,7 +33,7 @@
 // | mu  = 0    |    DT  = 1    | 4*(stat-1)+superlayer     |                 | hit type = 0-3 |
 // | mu  = 0    |    CSC = 2    | 4*(stat-1)+(ring-1)       |                 | hit type = 0-3 |
 // | mu  = 0    |    RPC = 3    | 4*(stat-1)+2*layer+region |                 | hit type = 0-3 |
-// | mu  = 0    |    GEM = 4    | 2*(stat-1)+2*(layer-1)    |                 | hit type = 0-3 |
+// | mu  = 0    |    GEM = 4    | 1xxx=st0, 0yxx=st y-1 la x|                 | hit type = 0-3 |
 // | mu  = 0    |    ME0 = 5    | roll                      |                 | hit type = 0-3 |
 // | mtd = 2    |    BTL = 1    | moduleType = 1-3          |                 | hit type = 0-3 |
 // | mtd = 2    |    ETL = 2    | ring = 1-12               |                 | hit type = 0-3 |
@@ -769,8 +769,9 @@ namespace reco {
   inline uint16_t HitPattern::getGEMStation(uint16_t pattern)
 
   {
-    uint16_t sss = getSubSubStructure(pattern), stat = sss >> 1;
-    return stat + 1;
+    uint16_t sss = getSubSubStructure(pattern);
+    if (sss & 0b1000) return 0;
+    return (sss >> 2) + 1;
   }
 
   /// MTD
@@ -778,7 +779,12 @@ namespace reco {
 
   inline uint16_t HitPattern::getETLRing(uint16_t pattern) { return getSubSubStructure(pattern); }
 
-  inline uint16_t HitPattern::getGEMLayer(uint16_t pattern) { return (getSubSubStructure(pattern) & 1) + 1; }
+  inline uint16_t HitPattern::getGEMLayer(uint16_t pattern)
+  {
+    uint16_t sss = getSubSubStructure(pattern);
+    if (sss & 0b1000) return sss & 0b0111;
+    return sss & 0b11;
+  }
 
   inline bool HitPattern::validHitFilter(uint16_t pattern) { return getHitType(pattern) == HitPattern::VALID; }
 

--- a/DataFormats/TrackReco/interface/HitPattern.h
+++ b/DataFormats/TrackReco/interface/HitPattern.h
@@ -781,8 +781,8 @@ namespace reco {
   inline uint16_t HitPattern::getGEMLayer(uint16_t pattern) {
     uint16_t sss = getSubSubStructure(pattern);
     if (sss & 0b1000)
-      return sss & 0b0111;
-    return sss & 0b11;
+      return (sss & 0b0111) + 1;
+    return (sss & 0b11) + 1;
   }
 
   inline bool HitPattern::validHitFilter(uint16_t pattern) { return getHitType(pattern) == HitPattern::VALID; }

--- a/DataFormats/TrackReco/interface/HitPattern.h
+++ b/DataFormats/TrackReco/interface/HitPattern.h
@@ -746,7 +746,9 @@ namespace reco {
     return ((pattern >> HitTypeOffset) & HitTypeMask);
   }
 
-  inline uint16_t HitPattern::getMuonStation(uint16_t pattern) { return muonGEMHitFilter(pattern) ? getGEMStation(pattern) : (getSubSubStructure(pattern) >> 2) + 1; }
+  inline uint16_t HitPattern::getMuonStation(uint16_t pattern) {
+    return muonGEMHitFilter(pattern) ? getGEMStation(pattern) : (getSubSubStructure(pattern) >> 2) + 1;
+  }
 
   inline uint16_t HitPattern::getDTSuperLayer(uint16_t pattern) { return (getSubSubStructure(pattern) & 3); }
 

--- a/DataFormats/TrackReco/interface/HitPattern.h
+++ b/DataFormats/TrackReco/interface/HitPattern.h
@@ -214,7 +214,7 @@ namespace reco {
     /// GEM station: 1,2. Only valid for muon GEM patterns, of course.
     static uint16_t getGEMStation(uint16_t pattern);
 
-    /// GEM layer: 1,2. Only valid for muon GEM patterns, of course.
+    /// GEM layer: 1-6 for station 0, 1-2 for stations 1 and 2. Only valid for muon GEM patterns, of course.
     static uint16_t getGEMLayer(uint16_t pattern);
 
     /// BTL Module type: 1,2,3. Only valid for BTL patterns of course.
@@ -746,7 +746,7 @@ namespace reco {
     return ((pattern >> HitTypeOffset) & HitTypeMask);
   }
 
-  inline uint16_t HitPattern::getMuonStation(uint16_t pattern) { return (getSubSubStructure(pattern) >> 2) + 1; }
+  inline uint16_t HitPattern::getMuonStation(uint16_t pattern) { return muonGEMHitFilter(pattern) ? getGEMStation(pattern) : (getSubSubStructure(pattern) >> 2) + 1; }
 
   inline uint16_t HitPattern::getDTSuperLayer(uint16_t pattern) { return (getSubSubStructure(pattern) & 3); }
 

--- a/DataFormats/TrackReco/interface/HitPattern.h
+++ b/DataFormats/TrackReco/interface/HitPattern.h
@@ -766,11 +766,10 @@ namespace reco {
   inline uint16_t HitPattern::getRPCregion(uint16_t pattern) { return getSubSubStructure(pattern) & 1; }
 
   ////////////////////////////// GEM
-  inline uint16_t HitPattern::getGEMStation(uint16_t pattern)
-
-  {
+  inline uint16_t HitPattern::getGEMStation(uint16_t pattern) {
     uint16_t sss = getSubSubStructure(pattern);
-    if (sss & 0b1000) return 0;
+    if (sss & 0b1000)
+      return 0;
     return (sss >> 2) + 1;
   }
 
@@ -779,10 +778,10 @@ namespace reco {
 
   inline uint16_t HitPattern::getETLRing(uint16_t pattern) { return getSubSubStructure(pattern); }
 
-  inline uint16_t HitPattern::getGEMLayer(uint16_t pattern)
-  {
+  inline uint16_t HitPattern::getGEMLayer(uint16_t pattern) {
     uint16_t sss = getSubSubStructure(pattern);
-    if (sss & 0b1000) return sss & 0b0111;
+    if (sss & 0b1000)
+      return sss & 0b0111;
     return sss & 0b11;
   }
 

--- a/DataFormats/TrackReco/src/HitPattern.cc
+++ b/DataFormats/TrackReco/src/HitPattern.cc
@@ -827,7 +827,8 @@ void HitPattern::printHitPattern(HitCategory category, int position, std::ostrea
     } else if (muonRPCHitFilter(pattern)) {
       stream << "\trpc " << (getRPCregion(pattern) ? "endcaps" : "barrel") << ", layer " << getRPCLayer(pattern);
     } else if (muonGEMHitFilter(pattern)) {
-      stream << "\tgem " << " station " << getGEMStation(pattern) << ", layer" << getGEMLayer(pattern);
+      stream << "\tgem "
+             << " station " << getGEMStation(pattern) << ", layer" << getGEMLayer(pattern);
     } else if (muonME0HitFilter(pattern)) {
       stream << "\tme0 ";
     } else {

--- a/DataFormats/TrackReco/src/HitPattern.cc
+++ b/DataFormats/TrackReco/src/HitPattern.cc
@@ -827,7 +827,7 @@ void HitPattern::printHitPattern(HitCategory category, int position, std::ostrea
     } else if (muonRPCHitFilter(pattern)) {
       stream << "\trpc " << (getRPCregion(pattern) ? "endcaps" : "barrel") << ", layer " << getRPCLayer(pattern);
     } else if (muonGEMHitFilter(pattern)) {
-      stream << "\tgem " << (getGEMLayer(pattern) ? "layer1" : "layer2") << ", station " << getGEMStation(pattern);
+      stream << "\tgem " << " station " << getGEMStation(pattern) << ", layer" << getGEMLayer(pattern);
     } else if (muonME0HitFilter(pattern)) {
       stream << "\tme0 ";
     } else {

--- a/DataFormats/TrackReco/src/HitPattern.cc
+++ b/DataFormats/TrackReco/src/HitPattern.cc
@@ -104,10 +104,10 @@ namespace {
             uint16_t la = gemid.layer();
             if (st == 0) {
               layer |= 0b1000;
-              layer |= (la-1);
+              layer |= (la - 1);
             } else {
-              layer |= (st-1) << 2;
-              layer |= (la-1);
+              layer |= (st - 1) << 2;
+              layer |= (la - 1);
             }
           }
         } break;

--- a/DataFormats/TrackReco/src/HitPattern.cc
+++ b/DataFormats/TrackReco/src/HitPattern.cc
@@ -99,8 +99,17 @@ namespace {
         } break;
         case MuonSubdetId::GEM: {
           GEMDetId gemid(id.rawId());
-          layer = ((gemid.station() - 1) << 2);
-          layer |= abs(gemid.layer() - 1);
+          {
+            uint16_t st = gemid.station();
+            uint16_t la = gemid.layer();
+            if (st == 0) {
+              layer |= 0b1000;
+              layer |= (la-1);
+            } else {
+              layer |= (st-1) << 2;
+              layer |= (la-1);
+            }
+          }
         } break;
         case MuonSubdetId::ME0: {
           ME0DetId me0id(id.rawId());


### PR DESCRIPTION
#### PR description:
Updates TrackReco HitPattern to include GE0 in GEM, while keeping it backward compatible for GE1/1 and GE2/1 (i.e. those stations should have same bit pattern as before). Fixes a bug in the decoder which was previously reading the GEM station incorrectly. The HitPattern for GEM is not used so far, so no changes in the output is expected. Requested here: https://github.com/cms-sw/cmssw/issues/35033#issuecomment-914479447

@jshlee @slava77 

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

Ran a ten mu 2026 workflow and checked it ran to completion. Checked the output of printHitPattern after adding in a GEM hit, reads out correctly.

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
