### PR TITLE
Cleanup of DTRecoUncertainties/DTRecoUncertaintiesRcd

### DIFF
--- a/CalibMuon/DTCalibration/test/DBTools/DumpDBToFile.h
+++ b/CalibMuon/DTCalibration/test/DBTools/DumpDBToFile.h
@@ -21,7 +21,6 @@ class DTStatusFlag;
 class DTDeadFlag;
 class DTCalibrationMap;
 class DTReadOutMapping;
-class DTRecoUncertainties;
 class DTRecoConditions;
 
 class DumpDBToFile : public edm::EDAnalyzer {
@@ -47,7 +46,6 @@ private:
   const DTStatusFlag *statusMap;
   const DTDeadFlag *deadMap;
   const DTReadOutMapping *channelsMap;
-  const DTRecoUncertainties *uncertMap;
   const DTRecoConditions *rconds;
 
   DTCalibrationMap *theCalibFile;

--- a/CalibMuon/DTCalibration/test/DBTools/DumpFileToDB.cc
+++ b/CalibMuon/DTCalibration/test/DBTools/DumpFileToDB.cc
@@ -24,7 +24,6 @@
 #include "CondFormats/DTObjects/interface/DTStatusFlag.h"
 #include "CondFormats/DTObjects/interface/DTDeadFlag.h"
 #include "CondFormats/DTObjects/interface/DTReadOutMapping.h"
-#include "CondFormats/DTObjects/interface/DTRecoUncertainties.h"
 #include "CondFormats/DTObjects/interface/DTRecoConditions.h"
 #include "CondFormats/DataRecord/interface/DTRecoConditionsTtrigRcd.h"
 #include "CondFormats/DataRecord/interface/DTRecoConditionsVdriftRcd.h"
@@ -268,43 +267,27 @@ void DumpFileToDB::endJob() {
     //---------- Uncertainties
   } else if (dbToDump == "RecoUncertDB") {  // Write the Uncertainties
 
-    if (format == "Legacy") {
-      DTRecoUncertainties* uncert = new DTRecoUncertainties();
-      int version = 1;  // Uniform uncertainties per SL and step; parameters 0-3 are for steps 1-4.
-      uncert->setVersion(version);
-      // Loop over file entries
-      for (DTCalibrationMap::const_iterator keyAndCalibs = theCalibFile->keyAndConsts_begin();
-           keyAndCalibs != theCalibFile->keyAndConsts_end();
-           ++keyAndCalibs) {
-        vector<float> values = (*keyAndCalibs).second;
-        vector<float> uncerts(values.begin() + 11, values.end());
-        uncert->set((*keyAndCalibs).first, uncerts);
-      }
-      DTCalibDBUtils::writeToDB<DTRecoUncertainties>("DTRecoUncertaintiesRcd", uncert);
+    DTRecoConditions* conds = new DTRecoConditions();
+    conds->setFormulaExpr("par[step]");
+    int version = 1;  // Uniform uncertainties per SL and step; parameters 0-3 are for steps 1-4.
+    conds->setVersion(version);
 
-    } else if (format == "DTRecoConditions") {
-      DTRecoConditions* conds = new DTRecoConditions();
-      conds->setFormulaExpr("par[step]");
-      int version = 1;  // Uniform uncertainties per SL and step; parameters 0-3 are for steps 1-4.
-      conds->setVersion(version);
+    for (DTCalibrationMap::const_iterator keyAndCalibs = theCalibFile->keyAndConsts_begin();
+         keyAndCalibs != theCalibFile->keyAndConsts_end();
+         ++keyAndCalibs) {
+      vector<float> values = (*keyAndCalibs).second;
+      int fversion = int(values[10] / 1000);
+      int type = (int(values[10]) % 1000) / 100;
+      int nfields = int(values[10]) % 100;
+      if (type != 2)
+        throw cms::Exception("IncorrectSetup") << "Only type==2 supported for uncertainties DB";
+      if (values.size() != unsigned(nfields + 11))
+        throw cms::Exception("IncorrectSetup") << "Inconsistent number of fields";
+      if (fversion != version)
+        throw cms::Exception("IncorrectSetup") << "Inconsistent version of file";
 
-      for (DTCalibrationMap::const_iterator keyAndCalibs = theCalibFile->keyAndConsts_begin();
-           keyAndCalibs != theCalibFile->keyAndConsts_end();
-           ++keyAndCalibs) {
-        vector<float> values = (*keyAndCalibs).second;
-        int fversion = int(values[10] / 1000);
-        int type = (int(values[10]) % 1000) / 100;
-        int nfields = int(values[10]) % 100;
-        if (type != 2)
-          throw cms::Exception("IncorrectSetup") << "Only type==2 supported for uncertainties DB";
-        if (values.size() != unsigned(nfields + 11))
-          throw cms::Exception("IncorrectSetup") << "Inconsistent number of fields";
-        if (fversion != version)
-          throw cms::Exception("IncorrectSetup") << "Inconsistent version of file";
-
-        vector<double> params(values.begin() + 11, values.begin() + 11 + nfields);
-        conds->set((*keyAndCalibs).first, params);
-      }
+      vector<double> params(values.begin() + 11, values.begin() + 11 + nfields);
+      conds->set((*keyAndCalibs).first, params);
       DTCalibDBUtils::writeToDB<DTRecoConditions>("DTRecoConditionsUncertRcd", conds);
     }
   }

--- a/CalibMuon/DTCalibration/test/DumpDBToFile_cfg.py
+++ b/CalibMuon/DTCalibration/test/DumpDBToFile_cfg.py
@@ -94,8 +94,8 @@ elif DBFORMAT=="Legacy" :
     if TYPE=="TTrigDB" : RECORD = "DTTtrigRcd"
     if TYPE=="VDriftDB" : RECORD = "DTMtimeRcd"
     if TYPE=="UncertDB" :
-        RECORD = "DTRecoUncertaintiesRcd"
-        print('\nWARNING, Legacy RecoUncertDB is deprecated, as it is no longer used in reconstruction code')
+        RECORD = ""
+        print('\nERROR, Legacy RecoUncertDB is no longer supported')
 elif DBFORMAT=="DTRecoConditions" :
     if TYPE=="TTrigDB" : RECORD = "DTRecoConditionsTtrigRcd"
     if TYPE=="VDriftDB" : RECORD = "DTRecoConditionsVdriftRcd"

--- a/CalibMuon/DTCalibration/test/DumpFileToDB_cfg.py
+++ b/CalibMuon/DTCalibration/test/DumpFileToDB_cfg.py
@@ -74,8 +74,8 @@ if DBFORMAT=="Legacy" :
     if TYPE=="TTrigDB" : RECORD = "DTTtrigRcd"
     if TYPE=="VDriftDB" : RECORD = "DTMtimeRcd"
     if TYPE=="UncertDB" :
-        RECORD = "DTRecoUncertaintiesRcd"
-        print('\nWARNING, Legacy RecoUncertDB is deprecated, as it is no longer used in reconstruction code')
+        RECORD = ""
+        print('\nERROR, Legacy RecoUncertDB is no longer supported')
 elif DBFORMAT=="DTRecoConditions" :
     if TYPE=="TTrigDB" : RECORD = "DTRecoConditionsTtrigRcd"
     if TYPE=="VDriftDB" : RECORD = "DTRecoConditionsVdriftRcd"

--- a/Validation/DTRecHits/test/DTValidation_RelVal_fromRECO_local_cfg.py
+++ b/Validation/DTRecHits/test/DTValidation_RelVal_fromRECO_local_cfg.py
@@ -36,8 +36,8 @@ process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 ## Uncertainty DB
 if uncertDB != "" : 
     process.GlobalTag.toGet = cms.VPSet(
-        cms.PSet(record = cms.string("DTRecoUncertaintiesRcd"),
-                 tag = cms.string("DTRecoUncertainties_test"),
+        cms.PSet(record = cms.string("DTRecoConditionsUncertRcd"),
+                 tag = cms.string("UncertDB"),
                  connect = cms.untracked.string("sqlite_file:"+uncertDB))
         )
 


### PR DESCRIPTION
These DB formats have been superseeded since a few years. 
This PR removes a few occurrences in test code (while definitions still remain in place)

Please note that the two .cc files involved are some test utilities that are intended to be run manually by experts to inspect payloads; a few couts are present and I think they are legitimate in this context.




