### PR TITLE
[HGCAL] Updates for dEdx weights calculation 

### DIFF
--- a/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialProducer.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialProducer.cc
@@ -94,6 +94,7 @@ TrackingMaterialProducer::TrackingMaterialProducer(const edm::ParameterSet& iPSe
   //Check if HGCal volumes are selected
   isHGCal = false;
   if (std::find(m_selectedNames.begin(), m_selectedNames.end(), "HGCal") != m_selectedNames.end()) {
+  //if (std::find(m_selectedNames.begin(), m_selectedNames.end(), "CALOECTSRear") != m_selectedNames.end()) {
     isHGCal = true;
   }
   //Check if HFNose volumes are selected
@@ -150,19 +151,24 @@ void TrackingMaterialProducer::update(const BeginOfTrack* event) {
   }
 
   //For the HGCal case:
-  //In the beginning of each track, the track will first hit SS and it will
-  //save the upper z volume boundary. So, the low boundary of the first SS
-  //volume is never saved. So, here we give the low boundary hardcoded.
-  //This can be found by running
-  //Geometry/HGCalCommonData/test/testHGCalParameters_cfg.py
-  //on the geometry under study and looking for zFront print out.
+  //In the beginning of each track, the track will first hit an HGCAL volume and it will
+  //save the upper z volume boundary. So, the low boundary of the first
+  //volume is never saved. Here we give the low boundary of the first volume.
+  //This can be found by asking first to run not on 'HGCal' volume below but
+  //on 'CALOECTSRear', which at the moment of this writing it contains
+  //HGCalService, HGCal and thermal screen. You should run Fireworks to
+  //check if these naming conventions and volumes are valid in the future.
+  //Then, check the VolumesZPosition.txt file to see where CEService ends and
+  //put that number in hgcalzfront. Keep in mind to run on the desired volume above here:
+  //https://github.com/cms-sw/cmssw/blob/master/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialProducer.cc#L95
+  //and to replace the volume name of the material first hit at the file creation line below
   if (isHGCal && track->GetTrackStatus() != fStopAndKill && fabs(track->GetMomentum().eta()) > outerHGCalEta &&
       fabs(track->GetMomentum().eta()) < innerHGCalEta) {
     if (track->GetMomentum().eta() > 0.) {
-      outVolumeZpositionTxt << "StainlessSteel " << m_hgcalzfront << " " << 0 << " " << 0 << " " << 0 << " " << 0
+      outVolumeZpositionTxt << "Air " << m_hgcalzfront << " " << 0 << " " << 0 << " " << 0 << " " << 0
                             << std::endl;
     } else if (track->GetMomentum().eta() <= 0.) {
-      outVolumeZpositionTxt << "StainlessSteel " << -m_hgcalzfront << " " << 0 << " " << 0 << " " << 0 << " " << 0
+      outVolumeZpositionTxt << "Air " << -m_hgcalzfront << " " << 0 << " " << 0 << " " << 0 << " " << 0
                             << std::endl;
     }
   }

--- a/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialProducer.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialProducer.cc
@@ -93,8 +93,8 @@ TrackingMaterialProducer::TrackingMaterialProducer(const edm::ParameterSet& iPSe
 
   //Check if HGCal volumes are selected
   isHGCal = false;
-  if (std::find(m_selectedNames.begin(), m_selectedNames.end(), "HGCal") != m_selectedNames.end()) {
   //if (std::find(m_selectedNames.begin(), m_selectedNames.end(), "CALOECTSRear") != m_selectedNames.end()) {
+  if (std::find(m_selectedNames.begin(), m_selectedNames.end(), "HGCal") != m_selectedNames.end()) {
     isHGCal = true;
   }
   //Check if HFNose volumes are selected
@@ -165,11 +165,9 @@ void TrackingMaterialProducer::update(const BeginOfTrack* event) {
   if (isHGCal && track->GetTrackStatus() != fStopAndKill && fabs(track->GetMomentum().eta()) > outerHGCalEta &&
       fabs(track->GetMomentum().eta()) < innerHGCalEta) {
     if (track->GetMomentum().eta() > 0.) {
-      outVolumeZpositionTxt << "Air " << m_hgcalzfront << " " << 0 << " " << 0 << " " << 0 << " " << 0
-                            << std::endl;
+      outVolumeZpositionTxt << "Air " << m_hgcalzfront << " " << 0 << " " << 0 << " " << 0 << " " << 0 << std::endl;
     } else if (track->GetMomentum().eta() <= 0.) {
-      outVolumeZpositionTxt << "Air " << -m_hgcalzfront << " " << 0 << " " << 0 << " " << 0 << " " << 0
-                            << std::endl;
+      outVolumeZpositionTxt << "Air " << -m_hgcalzfront << " " << 0 << " " << 0 << " " << 0 << " " << 0 << std::endl;
     }
   }
 

--- a/SimTracker/TrackerMaterialAnalysis/python/trackingMaterialProducerHGCal_cfi.py
+++ b/SimTracker/TrackerMaterialAnalysis/python/trackingMaterialProducerHGCal_cfi.py
@@ -16,15 +16,20 @@ trackingMaterialProducer.Watchers = cms.VPSet(cms.PSet(
         PrimaryTracksOnly = cms.bool(True),
         #The file to direct the HGCal volumes z position
         txtOutFile = cms.untracked.string('VolumesZPosition.txt'),
-        #In the beginning of each track, the track will first hit SS and it will 
-        #save the upper z volume boundary. So, the low boundary of the first SS 
-        #volume is never saved. Here we give the low boundary. 
-        #This can be found by running
-        #Geometry/HGCalCommonData/test/testHGCalParameters_cfg.py
-        #on the geometry under study and looking for zFront print out. 
-        #Plus or minus endcap is being dealt with inside the code. 
-        hgcalzfront = cms.double(3190.5),
-        SelectedVolumes = cms.vstring('HGCal')
+        #In the beginning of each track, the track will first hit an HGCAL volume and it will
+        #save the upper z volume boundary. So, the low boundary of the first
+        #volume is never saved. Here we give the low boundary of the first volume.
+        #This can be found by asking first to run not on 'HGCal' volume below but
+        #on 'CALOECTSRear', which at the moment of this writing it contains
+        #HGCalService, HGCal and thermal screen. You should run Fireworks to
+        #check if these naming conventions and volumes are valid in the future.
+        #Then, check the VolumesZPosition.txt file to see where CEService ends and
+        #put that number in hgcalzfront below. Keep in mind to run on the desired volume here:
+        #https://github.com/cms-sw/cmssw/blob/master/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialProducer.cc#L95
+        #and to replace the volume name of the material first hit at the file creation line:
+        #https://github.com/cms-sw/cmssw/blob/master/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialProducer.cc#L159-L168
+        hgcalzfront = cms.double(3210.5),
+        SelectedVolumes = cms.vstring('HGCal')#CALOECTSRear HGCal
     ),
     type = cms.string('TrackingMaterialProducer')
 ))

--- a/SimTracker/TrackerMaterialAnalysis/test/trackingMaterialProducer10GeVNeutrino_ForHGCalPhaseII.py
+++ b/SimTracker/TrackerMaterialAnalysis/test/trackingMaterialProducer10GeVNeutrino_ForHGCalPhaseII.py
@@ -12,7 +12,7 @@ readGeometryFromDB = False
 # only a temporary hack, since the material description has
 # been updated in release via XML and the DB is behind.
 if not readGeometryFromDB:
-  process.load('Configuration.Geometry.GeometryExtended2026D83Reco_cff')
+  process.load('Configuration.Geometry.GeometryExtended2026D86Reco_cff')
 else:
 # GlobalTag and geometry via GT
   process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')


### PR DESCRIPTION
#### PR description:

In order to calculate the dEdx weights needed for the calibration of recostructed hits, we need an input file with certain info on the HGCAL volumes. Here we alter the procedure of finding the first volume z position. 

#### PR validation:

This is tested against the V16 (D86) HGCAL geometry scenario. 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not a backport. 

@rovere @felicepantaleo @lecriste @ebrondol 