### PR TITLE
Clean unused dependencies from BuildFiles

### DIFF
--- a/CalibMuon/DTDigiSync/BuildFile.xml
+++ b/CalibMuon/DTDigiSync/BuildFile.xml
@@ -1,5 +1,4 @@
 <use name="FWCore/PluginManager"/>
-<use name="Geometry/DTGeometry"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DQM/Physics/BuildFile.xml
+++ b/DQM/Physics/BuildFile.xml
@@ -24,5 +24,4 @@
 <use name="TrackingTools/TransientTrack"/>
 <use name="TrackingTools/Records"/>
 <use name="TrackingTools/PatternTools"/>
-<use name="CommonTools/RecoAlgos"/>
 <flags EDM_PLUGIN="1"/>

--- a/DataFormats/L1THGCal/BuildFile.xml
+++ b/DataFormats/L1THGCal/BuildFile.xml
@@ -4,7 +4,6 @@
 <use name="DataFormats/ForwardDetId"/>
 <use name="DataFormats/GeometryVector"/>
 <use name="FWCore/Utilities"/>
-<use name="DataFormats/HcalDetId"/>
 <use name="FWCore/MessageLogger"/>
 <use name="rootrflx"/>
 <use name="boost"/>

--- a/FastSimulation/Utilities/BuildFile.xml
+++ b/FastSimulation/Utilities/BuildFile.xml
@@ -1,6 +1,5 @@
 <use name="FWCore/ServiceRegistry"/>
 <use name="FWCore/Utilities"/>
-<use name="IOMC/RandomEngine"/>
 <use name="clhep"/>
 <use name="root"/>
 <use name="rootmath"/>

--- a/L1Trigger/L1THGCal/BuildFile.xml
+++ b/L1Trigger/L1THGCal/BuildFile.xml
@@ -1,9 +1,9 @@
+<use name="DataFormats/L1Trigger"/>
 <use name="FWCore/Framework"/>
 <use name="Geometry/HGCalGeometry"/>
 <use name="Geometry/CaloTopology"/>
 <use name="Geometry/Records"/>
 <use name="DataFormats/L1THGCal"/>
-<use name="Geometry/HcalTowerAlgo"/>
 <use name="SimDataFormats/CaloTest"/>
 <use name="PhysicsTools/TensorFlow" />
 <use name="json" />

--- a/L1Trigger/L1THGCal/test/BuildFile.xml
+++ b/L1Trigger/L1THGCal/test/BuildFile.xml
@@ -2,8 +2,6 @@
 <use name="L1Trigger/L1THGCal"/>
 <use name="Geometry/Records"/>
 <use name="CommonTools/UtilAlgos"/>
-<use name="DataFormats/L1Trigger"/>
-<use name="SimDataFormats/CaloTest"/>
 <library name="testL1TriggerL1THGCal" file="HGCalTriggerGeomTesterV9Imp2.cc,HGCalTriggerGeomTesterV9Imp3.cc">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/L1Trigger/L1TTrackMatch/plugins/BuildFile.xml
+++ b/L1Trigger/L1TTrackMatch/plugins/BuildFile.xml
@@ -7,7 +7,7 @@
 <use   name="SimTracker/TrackTriggerAssociation"/>
 <use   name="DataFormats/L1TrackTrigger"/>
 <use   name="FWCore/Utilities"/>
-<use   name="RecoJets/JetProducers"/>
+<use   name="fastjet"/>
 <use   name="root"/>
 <flags   EDM_PLUGIN="1"/>
 </library>

--- a/RecoLocalTracker/SiPixelDigiReProducers/plugins/BuildFile.xml
+++ b/RecoLocalTracker/SiPixelDigiReProducers/plugins/BuildFile.xml
@@ -1,7 +1,10 @@
 <use name="DataFormats/Common"/>
+<use name="DataFormats/DetId"/>
+<use name="FWCore/Framework"/>
+<use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
+<use name="FWCore/PluginManager"/>
 <use name="DataFormats/SiPixelDigi"/>
-<use name="CalibTracker/SiPixelESProducers"/>
 <library file="*.cc" name="RecoLocalTrackerSiPixelDigiReProducersPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/RecoMuon/GlobalMuonProducer/test/BuildFile.xml
+++ b/RecoMuon/GlobalMuonProducer/test/BuildFile.xml
@@ -1,10 +1,8 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/Utilities"/>
 <use name="FWCore/ParameterSet"/>
-<use name="FWCore/ServiceRegistry"/>
 <use name="RecoMuon/TrackingTools"/>
 <use name="TrackingTools/TransientTrack"/>
-<use name="FWCore/PluginManager"/>
 <use name="DataFormats/TrackReco"/>
 <use name="SimDataFormats/Track"/>
 <use name="CLHEP"/>

--- a/SimCalorimetry/HcalZeroSuppressionProducers/BuildFile.xml
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/BuildFile.xml
@@ -1,8 +1,5 @@
 <use name="CalibFormats/HcalObjects"/>
 <use name="DataFormats/HcalDigi"/>
-<use name="FWCore/Framework"/>
-<use name="FWCore/MessageLogger"/>
-<use name="FWCore/PluginManager"/>
 <use name="boost"/>
 <export>
   <lib name="1"/>

--- a/SimG4CMS/EcalTestBeam/BuildFile.xml
+++ b/SimG4CMS/EcalTestBeam/BuildFile.xml
@@ -1,16 +1,10 @@
-<use name="DataFormats/Common"/>
 <use name="DetectorDescription/Core"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
 <use name="Geometry/EcalCommonData"/>
 <use name="Geometry/EcalTestBeam"/>
-<use name="SimDataFormats/EcalTestBeam"/>
-<use name="SimDataFormats/GeneratorProducts"/>
-<use name="SimG4Core/Notification"/>
-<use name="SimG4Core/Watcher"/>
 <use name="SimG4CMS/Calo"/>
-<use name="TBDataFormats/EcalTBObjects"/>
 <use name="clhep"/>
 <use name="rootmath"/>
 <use name="geant4core"/>

--- a/SimG4CMS/EcalTestBeam/plugins/BuildFile.xml
+++ b/SimG4CMS/EcalTestBeam/plugins/BuildFile.xml
@@ -1,3 +1,9 @@
+<use name="DataFormats/Common"/>
 <use name="FWCore/Framework"/>
+<use name="SimDataFormats/EcalTestBeam"/>
+<use name="SimDataFormats/GeneratorProducts"/>
 <use name="SimG4CMS/EcalTestBeam"/>
+<use name="SimG4Core/Notification"/>
+<use name="SimG4Core/Watcher"/>
+<use name="TBDataFormats/EcalTBObjects"/>
 <flags EDM_PLUGIN="1"/>

--- a/SimG4CMS/FP420/BuildFile.xml
+++ b/SimG4CMS/FP420/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="SimG4Core/Watcher"/>
 <use name="SimG4Core/SensitiveDetector"/>
 <use name="SimG4Core/Notification"/>
 <use name="SimDataFormats/SimHitMaker"/>

--- a/SimG4CMS/FP420/plugins/BuildFile.xml
+++ b/SimG4CMS/FP420/plugins/BuildFile.xml
@@ -1,4 +1,5 @@
 <use name="SimG4CMS/FP420"/>
+<use name="SimG4Core/Watcher"/>
 <library file="*.cc" name="SimG4CMSFP420Plugins">
   <flags EDM_PLUGIN="1"/>
   <!--

--- a/SimG4CMS/Forward/BuildFile.xml
+++ b/SimG4CMS/Forward/BuildFile.xml
@@ -1,7 +1,6 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/MessageLogger"/>
-<use name="SimG4Core/Watcher"/>
 <use name="SimG4Core/SensitiveDetector"/>
 <use name="SimG4Core/Notification"/>
 <use name="SimG4Core/Physics"/>
@@ -10,7 +9,6 @@
 <use name="DataFormats/Math"/>
 <use name="SimDataFormats/SimHitMaker"/>
 <use name="SimDataFormats/CaloHit"/>
-<use name="SimDataFormats/Forward"/>
 <use name="Geometry/MTDCommonData"/>
 <use name="boost"/>
 <use name="clhep"/>

--- a/SimG4CMS/Forward/plugins/BuildFile.xml
+++ b/SimG4CMS/Forward/plugins/BuildFile.xml
@@ -4,6 +4,7 @@
 <use name="SimG4Core/Notification"/>
 <use name="SimG4CMS/Forward"/>
 <use name="SimDataFormats/CaloTest"/>
+<use name="SimDataFormats/Forward"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/MessageLogger"/>

--- a/SimG4CMS/ShowerLibraryProducer/BuildFile.xml
+++ b/SimG4CMS/ShowerLibraryProducer/BuildFile.xml
@@ -1,8 +1,6 @@
-<use name="SimG4Core/Watcher"/>
 <use name="SimG4Core/SensitiveDetector"/>
 <use name="SimG4Core/Notification"/>
 <use name="SimG4CMS/Calo"/>
-<use name="SimG4CMS/Forward"/>
 <use name="DataFormats/Math"/>
 <use name="SimDataFormats/CaloHit"/>
 <use name="FWCore/Framework"/>

--- a/SimG4CMS/ShowerLibraryProducer/plugins/BuildFile.xml
+++ b/SimG4CMS/ShowerLibraryProducer/plugins/BuildFile.xml
@@ -4,8 +4,10 @@
 <use name="FWCore/PluginManager"/>
 <use name="Geometry/HcalCommonData"/>
 <use name="Geometry/Records"/>
+<use name="SimG4CMS/Forward"/>
 <use name="SimG4CMS/ShowerLibraryProducer"/>
 <use name="SimG4Core/SensitiveDetector"/>
+<use name="SimG4Core/Watcher"/>
 <flags EDM_PLUGIN="1"/>
 <library name="SimG4CMSHcalForwardLibWriter" file="HcalForwardLibWriter.cc"></library>
 <library name="SimG4CMSShowerLibraryProducerPlugins" file="HFWedgeSensitiveDetectorBuilder.cc,FiberSensitiveDetectorBuilder.cc,HFChamberSensitiveDetectorBuilder.cc"></library>

--- a/SimGeneral/TrackingAnalysis/BuildFile.xml
+++ b/SimGeneral/TrackingAnalysis/BuildFile.xml
@@ -15,7 +15,6 @@
 <use name="DataFormats/L1TrackTrigger"/>
 <use name="DataFormats/TrackerCommon"/>
 <use name="FWCore/Utilities"/>
-<use name="Geometry/Records"/>
 <use name="SimDataFormats/CrossingFrame"/>
 <use name="SimDataFormats/EncodedEventId"/>
 <export>

--- a/SimGeneral/TrackingAnalysis/plugins/BuildFile.xml
+++ b/SimGeneral/TrackingAnalysis/plugins/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="SimGeneral/TrackingAnalysis"/>
 <use name="DataFormats/TrackerCommon"/>
 <use name="DataFormats/HepMCCandidate"/>
+<use name="Geometry/Records"/>
 <use name="SimDataFormats/TrackerDigiSimLink"/>
 <use name="SimGeneral/MixingModule"/>
 <use name="SimGeneral/PreMixingModule"/>

--- a/SimMuon/MCTruth/test/BuildFile.xml
+++ b/SimMuon/MCTruth/test/BuildFile.xml
@@ -3,7 +3,6 @@
   <use name="FWCore/ParameterSet"/>
   <use name="SimDataFormats/Track"/>
   <use name="DataFormats/TrackReco"/>
-  <use name="DataFormats/MuonReco"/>
   <use name="SimDataFormats/TrackingAnalysis"/>
   <use name="SimMuon/MCTruth"/>
   <flags EDM_PLUGIN="1"/>

--- a/SimTracker/TrackAssociation/BuildFile.xml
+++ b/SimTracker/TrackAssociation/BuildFile.xml
@@ -8,7 +8,6 @@
 <use name="TrackingTools/PatternTools"/>
 <use name="SimDataFormats/TrackingAnalysis"/>
 <use name="Geometry/Records"/>
-<use name="Geometry/TrackerGeometryBuilder"/>
 <use name="MagneticField/Records"/>
 <use name="clhep"/>
 <export>


### PR DESCRIPTION
#### PR description:

Another quick BuildFile cleaning PR in the style of many before (for example https://github.com/cms-sw/cmssw/pull/34809).

In many cases, the dependencies had to be moved to the appropriate BuildFile, for example from a plugins directory to the library directory or vice versa.

This PR cleans unnecessary includes from CMSSW BuildFiles that were recently added for 12_1_0_pre2.

#### PR validation:

CMSSW compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport intended.