### PR TITLE
Fix for SiPixelRecHitFromCUDA crash during online GPU tests

### DIFF
--- a/CUDADataFormats/SiPixelCluster/interface/gpuClusteringConstants.h
+++ b/CUDADataFormats/SiPixelCluster/interface/gpuClusteringConstants.h
@@ -18,6 +18,7 @@ namespace gpuClustering {
   constexpr uint16_t maxNumModules = 2000;
   constexpr int32_t maxNumClustersPerModules = maxHitsInModule();
   constexpr uint16_t invalidModuleId = std::numeric_limits<uint16_t>::max() - 1;
+  constexpr int invalidClusterId = -9999;
   static_assert(invalidModuleId > maxNumModules);  // invalidModuleId must be > maxNumModules
 
 }  // namespace gpuClustering

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoA.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoA.cc
@@ -81,8 +81,14 @@ void SiPixelDigisClustersFromSoA::produce(edm::StreamID, edm::Event& iEvent, con
   edm::DetSet<PixelDigi>* detDigis = nullptr;
   uint32_t detId = 0;
   for (uint32_t i = 0; i < nDigis; i++) {
+    // check for uninitialized digis
+    // this is set in RawToDigi_kernel in SiPixelRawToClusterGPUKernel.cu
     if (digis.rawIdArr(i) == 0)
       continue;
+    // check for noisy/dead pixels (electrons set to 0)
+    if (digis.adc(i) == 0)
+      continue;
+
     detId = digis.rawIdArr(i);
     if (storeDigis_) {
       detDigis = &collection->find_or_insert(detId);
@@ -134,7 +140,11 @@ void SiPixelDigisClustersFromSoA::produce(edm::StreamID, edm::Event& iEvent, con
   };
 
   for (uint32_t i = 0; i < nDigis; i++) {
+    // check for uninitialized digis
     if (digis.rawIdArr(i) == 0)
+      continue;
+    // check for noisy/dead pixels (electrons set to 0)
+    if (digis.adc(i) == 0)
       continue;
     if (digis.clus(i) > 9000)
       continue;  // not in cluster; TODO add an assert for the size

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoA.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoA.cc
@@ -81,7 +81,7 @@ void SiPixelDigisClustersFromSoA::produce(edm::StreamID, edm::Event& iEvent, con
   edm::DetSet<PixelDigi>* detDigis = nullptr;
   uint32_t detId = 0;
   for (uint32_t i = 0; i < nDigis; i++) {
-    if (digis.pdigi(i) == 0)
+    if (digis.rawIdArr(i) == 0)
       continue;
     detId = digis.rawIdArr(i);
     if (storeDigis_) {
@@ -134,7 +134,7 @@ void SiPixelDigisClustersFromSoA::produce(edm::StreamID, edm::Event& iEvent, con
   };
 
   for (uint32_t i = 0; i < nDigis; i++) {
-    if (digis.pdigi(i) == 0)
+    if (digis.rawIdArr(i) == 0)
       continue;
     if (digis.clus(i) > 9000)
       continue;  // not in cluster; TODO add an assert for the size

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/gpuCalibPixel.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/gpuCalibPixel.h
@@ -54,9 +54,9 @@ namespace gpuCalibPixel {
       float gain = ret.second;
       // float pedestal = 0; float gain = 1.;
       if (isDeadColumn | isNoisyColumn) {
+        printf("bad pixel at %d in %d\n", i, id[i]);
         id[i] = invalidModuleId;
         adc[i] = 0;
-        printf("bad pixel at %d in %d\n", i, id[i]);
       } else {
         float vcal = adc[i] * gain - pedestal * gain;
         adc[i] = std::max(100, int(vcal * conversionFactor + offset));

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/gpuClustering.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/gpuClustering.h
@@ -276,7 +276,7 @@ namespace gpuClustering {
       // adjust the cluster id to be a positive value starting from 0
       for (int i = first; i < msize; i += blockDim.x) {
         if (id[i] == invalidModuleId) {  // skip invalid pixels
-          clusterId[i] = -9999;
+          clusterId[i] = invalidClusterId;
           continue;
         }
         clusterId[i] = -clusterId[i] - 1;


### PR DESCRIPTION
#### PR description:

These changes address the GPU error brought up in #34831 [comment](https://github.com/cms-sw/cmssw/issues/34831#issuecomment-896409931). [1]

The was error apparently was due to a `digi` at `row` 0 `col` 0, and the `adc` value not being (correctly) set in the packing, and then when checking in [SiPixelDigisClustersFromSoA.cc#137](https://cmssdt.cern.ch/dxr/CMSSW/source/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoA.cc#137) that one digi was skipped, so the associated cluster never got created, so later one ends up with one more rechit than actual clusters in that one module.

This is the actual digi being lost:
`Digi index 754; clusid 8; rawIdArr 344545284; adc 25661, pdigi: 00000000000000000000000000000000`

The condition `digis.pdigi(i) == 0`  was initially meant to check whether the digi was left uninitialized from the [RawToDigi_kernel](https://cmssdt.cern.ch/dxr/CMSSW/source/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu#361-363). But the problem is that a packed digi can be all zeros. For checking uninitialized digis, this condition is changed to `digis.rawIdArr(i) == 0`.

Other than that, to filter noisy/dead pixel digis the condition `digis.adc(i) == 0` was added well, [based on the treating of noisy/dead pixels in the calibDigis kernel](https://cmssdt.cern.ch/dxr/CMSSW/source/RecoLocalTracker/SiPixelClusterizer/plugins/gpuCalibPixel.h#57-59).

[1]
```
cmsRun: /data/cmsbld/jenkins/workspace/auto-builds/CMSSW_11_3_4-slc7_amd64_gcc900/build/CMSSW_11_3_4-build/tmp/BUILDROOT/58d469321d6ecb0427dd1e9f6c3703d5/opt/cmssw/slc7_amd64_gcc900/cms/cmssw/CMSSW_11_3_4/src/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitFromCUDA.cc:143: 
virtual void SiPixelRecHitFromCUDA::produce(edm::Event&, const edm::EventSetup&): 
Assertion `nhits <= dsv.size()' failed.


A fatal system signal has occurred: abort signal
The following is the call stack containing the origin of the signal.

...

Module: SiPixelRecHitFromCUDA:hltSiPixelRecHits@cuda (crashed)
```

#### PR validation:

Atm it was only checked that the recipe described in #34831 does not crash in 11_3_4.

#### if this PR is a backport please specify the original PR and why you need to backport that PR: