### PR TITLE
Add new ECAL PF RecHit thresholds for 2021 Run 3 MC

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -66,11 +66,11 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
     'phase1_2021_design'           : '121X_mcRun3_2021_design_v1', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'        : '121X_mcRun3_2021_realistic_Candidate_2021_09_10_15_39_01', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'        : '121X_mcRun3_2021_realistic_v2', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'          : '121X_mcRun3_2021cosmics_realistic_deco_Candidate_2021_09_10_15_41_04',
+    'phase1_2021_cosmics'          : '121X_mcRun3_2021cosmics_realistic_deco_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi'     : '121X_mcRun3_2021_realistic_HI_Candidate_2021_09_10_15_36_57',
+    'phase1_2021_realistic_hi'     : '121X_mcRun3_2021_realistic_HI_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
     'phase1_2023_realistic'        : '121X_mcRun3_2023_realistic_v1', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -66,11 +66,11 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
     'phase1_2021_design'           : '121X_mcRun3_2021_design_v1', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'        : '121X_mcRun3_2021_realistic_v1', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'        : '121X_mcRun3_2021_realistic_Candidate_2021_09_10_15_39_01', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'          : '121X_mcRun3_2021cosmics_realistic_deco_v1',
+    'phase1_2021_cosmics'          : '121X_mcRun3_2021cosmics_realistic_deco_Candidate_2021_09_10_15_41_04',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi'     : '121X_mcRun3_2021_realistic_HI_v1',
+    'phase1_2021_realistic_hi'     : '121X_mcRun3_2021_realistic_HI_Candidate_2021_09_10_15_36_57',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
     'phase1_2023_realistic'        : '121X_mcRun3_2023_realistic_v1', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024


### PR DESCRIPTION
#### PR description:

This PR is to add a new ECAL tag, EcalPFRecHitThresholds_34sigma_TL235, to the 2021 Run-3 MC GTs as per request from the ECAL group (https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4462.html), aiming the Run 3 MC Campaign (in 120X).

The differences wrt the previous GTs are listed below.

**2021 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021_realistic_v1/121X_mcRun3_2021_realistic_v2

**2021 cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021cosmics_realistic_deco_v1/121X_mcRun3_2021cosmics_realistic_deco_v2

**2021 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021_realistic_HI_v1/121X_mcRun3_2021_realistic_HI_v2  

#### PR validation:

runTheMatrix.py -l 159.0,11634.0,7.23 --ibeos -j4

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR will be backported to 120X.
