### PR TITLE
Properly set L1 and L2 values in CSCL1TPLookupTableEP

### DIFF
--- a/CalibMuon/CSCCalibration/plugins/CSCL1TPLookupTableEP.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCL1TPLookupTableEP.cc
@@ -179,13 +179,13 @@ std::unique_ptr<CSCL1TPLookupTableME11ILT> CSCL1TPLookupTableEP::produceME11ILT(
 
   lut->set_CSC_slope_cosi_corr_L1_ME11_even(std::move(CSC_slope_cosi_corr_L1_ME11_even_));
   lut->set_CSC_slope_cosi_corr_L1_ME11_odd(std::move(CSC_slope_cosi_corr_L1_ME11_odd_));
-  lut->set_CSC_slope_cosi_corr_L1_ME11_even(std::move(CSC_slope_cosi_corr_L1_ME11_even_));
-  lut->set_CSC_slope_cosi_corr_L1_ME11_odd(std::move(CSC_slope_cosi_corr_L1_ME11_odd_));
+  lut->set_CSC_slope_cosi_corr_L2_ME11_even(std::move(CSC_slope_cosi_corr_L2_ME11_even_));
+  lut->set_CSC_slope_cosi_corr_L2_ME11_odd(std::move(CSC_slope_cosi_corr_L2_ME11_odd_));
 
   lut->set_CSC_slope_corr_L1_ME11_even(std::move(CSC_slope_corr_L1_ME11_even_));
   lut->set_CSC_slope_corr_L1_ME11_odd(std::move(CSC_slope_corr_L1_ME11_odd_));
-  lut->set_CSC_slope_corr_L1_ME11_even(std::move(CSC_slope_corr_L1_ME11_even_));
-  lut->set_CSC_slope_corr_L1_ME11_odd(std::move(CSC_slope_corr_L1_ME11_odd_));
+  lut->set_CSC_slope_corr_L2_ME11_even(std::move(CSC_slope_corr_L2_ME11_even_));
+  lut->set_CSC_slope_corr_L2_ME11_odd(std::move(CSC_slope_corr_L2_ME11_odd_));
 
   // GEM-CSC trigger: 1/8-strip difference to slope
   lut->set_es_diff_slope_L1_ME1a_even(std::move(es_diff_slope_L1_ME1a_even_));


### PR DESCRIPTION
#### PR description:

An apparent cut-n-paste error was resetting the L1 values to empty instead of setting the L2 values.

#### PR validation:

Code compiles. The problem was caught by the static analyzer noting that two variables were being used after calls to `std::move`.