### PR TITLE
[HGCAL] Updates on validation scripts 

### DIFF
--- a/Validation/Geometry/python/plot_hgcal_utils.py
+++ b/Validation/Geometry/python/plot_hgcal_utils.py
@@ -34,16 +34,19 @@ plots.setdefault('x_over_l_vs_eta', Plot_params(10, '#eta', '(x/X_{0})/(x/#lambd
 plots.setdefault('x_over_l_vs_phi', Plot_params(20, '#varphi [rad]', '(x/X_{0})/(x/#lambda_{I})', 0., 0., 0., 0., '', 0, -1, -1, 0, 0))
 
 # Conversion name from the label (key) to the components in CMSSW/Geometry
-_LABELS2COMPS = {'BeamPipe': 'BEAM',
+_LABELS2COMPS = {'BeamPipe': 'BEAM', #There are other BEAM volumes but there are behind the region of our interest. 
                  'Tracker': 'Tracker', 
-                 'EndcapTimingLayer + Thermal Screen': 'CALOECTSFront',
-                 'Neutron Moderator + Thermal Screen' : 'CALOECTSMiddle',
+                 #CALOECTSFront contains both CALOECTSModerator and EndcapTimingLayer plus 
+                 #thermal screen but I want to split those. 
+                 #In V16(D86) there is no CALOECTSMiddle.
+                 'EndcapTimingLayer': 'EndcapTimingLayer',
+                 'Neutron Moderator + Thermal Screen' : 'CALOECTSModerator',
                  'HGCal + HGCal Service + Thermal Screen' : 'CALOECTSRear',
                  'Solenoid Magnet' : 'MGNT',
                  'Muon Wheels and Cables' : 'MB',
                  'ECAL': 'ECAL',
                  'HCal': 'HCal',
-                 'FromVertexToBackOfHGCal' : ['BEAM','Tracker','ECAL','HCal','CALOECTSFront','CALOECTSMiddle','CALOECTSRear','MGNT','MB'],
+                 'FromVertexToBackOfHGCal' : ['BEAM','Tracker','ECAL','HCal','EndcapTimingLayer','CALOECTSModerator','CALOECTSRear','MGNT','MB'],
                  'HGCal': 'HGCal',
                  'HGCalEE': 'HGCalEE',
                  'HGCalHE': ['HGCalHEsil', 'HGCalHEmix']
@@ -60,7 +63,7 @@ COMPOUNDS = OrderedDict()
 COMPOUNDS["HGCal"] = ["HGCal"]
 COMPOUNDS["HGCalEE"] = ["HGCalEE"]
 COMPOUNDS["HGCalHE"] = ["HGCalHEsil", "HGCalHEmix"]
-COMPOUNDS["FromVertexToBackOfHGCal"] = ["BeamPipe","Tracker","ECAL","HCal","EndcapTimingLayer + Thermal Screen","Neutron Moderator + Thermal Screen","HGCal + HGCal Service + Thermal Screen","Solenoid Magnet","Muon Wheels and Cables"]
+COMPOUNDS["FromVertexToBackOfHGCal"] = ["BeamPipe","Tracker","ECAL","HCal","EndcapTimingLayer","Neutron Moderator + Thermal Screen","HGCal + HGCal Service + Thermal Screen","Solenoid Magnet","Muon Wheels and Cables"]
 
 # The DETECTORS must be the single component of the HGCal for which
 # the user can ask for the corresponding material description.
@@ -74,7 +77,7 @@ DETECTORS["BeamPipe"] = kGray+2
 DETECTORS["Tracker"]  = 9 #kAzure-5
 DETECTORS["ECAL"] = 2 #kOrange+10
 DETECTORS["HCal"] = 6  #kMagenta-2
-DETECTORS["EndcapTimingLayer + Thermal Screen"] = 7#kAzure-9 
+DETECTORS["EndcapTimingLayer"] = 7#kAzure-9 
 DETECTORS["Neutron Moderator + Thermal Screen"] = 46#kOrange+5
 DETECTORS["HGCal + HGCal Service + Thermal Screen"] = 5#kOrange-2
 DETECTORS["Solenoid Magnet"] = 4#kGray+5

--- a/Validation/Geometry/test/runP_FromVertexUpToInFrontOfMuonStations_cfg.py
+++ b/Validation/Geometry/test/runP_FromVertexUpToInFrontOfMuonStations_cfg.py
@@ -1,31 +1,19 @@
-from __future__ import print_function
-# In order to produce what you need (or in a loop)
-#time cmsRun runP_FromVertexUpToInFrontOfMuonStations_cfg.py geom=Extended2023D41 label=BeamPipe
-#time cmsRun runP_FromVertexUpToInFrontOfMuonStations_cfg.py geom=Extended2023D41 label=Tracker
-#time cmsRun runP_FromVertexUpToInFrontOfMuonStations_cfg.py geom=Extended2023D41 label=ECAL
-#time cmsRun runP_FromVertexUpToInFrontOfMuonStations_cfg.py geom=Extended2023D41 label=HCal
-##EndcapTimingLayer + Thermal Screen (Barrel Timing Layer is included in the Tracker)
-#time cmsRun runP_FromVertexUpToInFrontOfMuonStations_cfg.py geom=Extended2023D41 label='EndcapTimingLayer + Thermal Screen'
-##Neutron Moderator + Thermal Screen
-#time cmsRun runP_FromVertexUpToInFrontOfMuonStations_cfg.py geom=Extended2023D41 label='Neutron Moderator + Thermal Screen'
-##HGCal + HGCal Service + Thermal Screen
-#time cmsRun runP_FromVertexUpToInFrontOfMuonStations_cfg.py geom=Extended2023D41 label='HGCal + HGCal Service + Thermal Screen'
-##Solenoid Magnet
-#time cmsRun runP_FromVertexUpToInFrontOfMuonStations_cfg.py geom=Extended2023D41 label='Solenoid Magnet'
-##Muon Wheels and Cables
-#time cmsRun runP_FromVertexUpToInFrontOfMuonStations_cfg.py geom=Extended2023D41 label='Muon Wheels and Cables'
-##Finally, all together 
-#time cmsRun runP_FromVertexUpToInFrontOfMuonStations_cfg.py geom=Extended2023D41 label=FromVertexToBackOfHGCal
+#Check the material bugdet sections of the HGCAL DPG website for the recipe. Namely,
+#HGCAL only: https://hgcal.web.cern.ch/MaterialBudget/MaterialBudget/
+#From vertex: https://hgcal.web.cern.ch/MaterialBudget/MaterialBudgetFromVertexUpToInfrontOfMuonStations/
 
 import FWCore.ParameterSet.Config as cms
 from FWCore.ParameterSet.VarParsing import VarParsing
 import sys, re
 
-process = cms.Process("PROD")
+from FWCore.PythonFramework.CmsRun import CmsRun
+from Configuration.Eras.Era_Phase2_cff import Phase2
+
+process = cms.Process("PROD", Phase2)
 
 process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 
-# The default geometry is Extended2026D77Reco. If a different geoemtry
+# The default geometry is Extended2023D86Reco. If a different geoemtry
 # is needed, the appropriate flag has to be passed at command line,
 # e.g.: cmsRun runP_FromVertexUpToInFrontOfMuonStations_cfg.py geom="XYZ"
 
@@ -40,7 +28,7 @@ _ALLOWED_LABELS = _LABELS2COMPS.keys()
 
 options = VarParsing('analysis')
 options.register('geom',             #name
-                 'Extended2026D77Reco',      #default value
+                 'Extended2023D86',      #default value
                  VarParsing.multiplicity.singleton,   # kind of options
                  VarParsing.varType.string,           # type of option
                  "Select the geometry to be studied"  # help message
@@ -67,7 +55,7 @@ if options.label not in _ALLOWED_LABELS:
 _components = _LABELS2COMPS[options.label]
 
 # Load geometry either from the Database of from files
-process.load("Configuration.Geometry.Geometry%s_cff" % options.geom)
+process.load("Configuration.Geometry.Geometry%sReco_cff" % options.geom)
 
 #
 #Magnetic Field
@@ -112,10 +100,10 @@ process.g4SimHits.Watchers = cms.VPSet(cms.PSet(
         #        TextFile = cms.string("matbdg_HGCal.txt")
         TextFile = cms.string('None'), 
         #Setting ranges for histos
-        #Make z 2mm per bin. Be careful this could lead to memory crashes if too low. 
+        #Make z 4mm per bin. Be careful this could lead to memory crashes if too low. 
         minZ = cms.double(-7000.),
         maxZ = cms.double(7000.),
-        nintZ = cms.int32(7000), 
+        nintZ = cms.int32(3500), 
         # Make r 1cm per bin
         rMin = cms.double(-50.), 
         rMax = cms.double(8000.),
@@ -135,3 +123,9 @@ process.g4SimHits.Watchers = cms.VPSet(cms.PSet(
 
      )
 ))
+
+
+cmsRun = CmsRun(process)
+cmsRun.run()
+
+

--- a/Validation/HGCalValidation/python/html.py
+++ b/Validation/HGCalValidation/python/html.py
@@ -47,7 +47,7 @@ _sampleName = {
     "RelValH125GGgluonfusion" : "Higgs to gamma gamma",
     "RelValNuGun" : "Neutrino gun",
     "RelValZpTT_1500" : "Z prime with 1500 GeV nominal mass",
-    "RelValTenTau_15_500" : "Ten Taus with energy from 15 GeV to 500 GeV"
+    "RelValTenTau_15_500_Eta3p1" : "Ten Taus with energy from 15 GeV to 500 GeV"
 }
 
 _sampleFileName = {

--- a/Validation/HGCalValidation/scripts/hgcalPerformanceValidation.py
+++ b/Validation/HGCalValidation/scripts/hgcalPerformanceValidation.py
@@ -244,7 +244,7 @@ phase2samples_noPU = [
     Sample("RelValZMM", midfix="14", scenario="2026D49", appendGlobalTag=appendglobaltag ),
     #Sample("RelValZMM", midfix="14", scenario="2026D49", dqmVersion="0002", appendGlobalTag=appendglobaltag ),
     Sample("RelValZEE", midfix="14", scenario="2026D49", appendGlobalTag=appendglobaltag ),
-    #Sample("RelValTenTau_15_500_Eta3p1", scenario="2026D49", appendGlobalTag=appendglobaltag  ),
+    Sample("RelValTenTau_15_500_Eta3p1", scenario="2026D49", appendGlobalTag=appendglobaltag  ),
     #Sample("RelValTenTau_15_500", scenario="2026D49", appendGlobalTag=appendglobaltag  ),
     Sample("RelValTTbar", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag ),
     Sample("RelValQCD_Pt15To7000_Flat", midfix="14", scenario="2026D49", appendGlobalTag=appendglobaltag ),

--- a/Validation/HGCalValidation/scripts/hgcalPerformanceValidation.py
+++ b/Validation/HGCalValidation/scripts/hgcalPerformanceValidation.py
@@ -83,7 +83,12 @@ def putype(t):
 #------------------------------------------------------------------------------------------
 #thereleases = { "CMSSW 11_1_X" : ["CMSSW_11_1_0_pre4_GEANT4","CMSSW_11_1_0_pre3","CMSSW_11_1_0_pre2"] }
 thereleases = OrderedDict()
-thereleases = { "CMSSW 12_0_X" : [
+thereleases = { "CMSSW 12_1_X" : [
+    "CMSSW_12_1_0_pre2_vs_CMSSW_12_0_0_pre6",
+    "CMSSW_12_1_0_pre2_D77_vs_CMSSW_12_1_0_pre2_D76"
+                 ],
+                "CMSSW 12_0_X" : [
+    "CMSSW_12_0_0_pre6_vs_CMSSW_12_0_0_pre4",
     "CMSSW_12_0_0_pre4_vs_CMSSW_12_0_0_pre3",
     "CMSSW_12_0_0_pre3_vs_CMSSW_12_0_0_pre2",
     "CMSSW_12_0_0_pre2_vs_CMSSW_12_0_0_pre1",
@@ -136,18 +141,20 @@ geometryTests = OrderedDict()
 geometryTests = { "Material budget" : [
                 #"Extended2026D49_vs_Extended2026D71",
                 "Extended2026D49_vs_Extended2026D76",
-                "Extended2026D76_vs_Extended2026D83"
+                "Extended2026D76_vs_Extended2026D83",
+                "Extended2026D83_vs_Extended2026D86"
                 ]
 }
 
-GeoScenario = "Extended2026D76_vs_Extended2026D83"
+GeoScenario = "Extended2026D83_vs_Extended2026D86"
 
-RefRelease='CMSSW_12_0_0_pre3'
+RefRelease='CMSSW_12_0_0_pre6'
 
-NewRelease='CMSSW_12_0_0_pre4'
+NewRelease='CMSSW_12_1_0_pre2'
 
 NotNormalRelease = "normal"
 NotNormalRefRelease = "normal"
+#NotNormalRefRelease = "raw"
 
 if ( os.path.isdir('%s/%s' %(opt.WWWAREA, NewRelease))) : 
     print("The campaign you are trying to validate has already an existing validation folder in the official www area.")
@@ -162,6 +169,7 @@ if "raw" in NotNormalRelease:
 else: 
     #   appendglobaltag = "_2026D49noPU"
     appendglobaltag = "_2026D76noPU"
+    #   appendglobaltag = "_2026D77noPU"
 
 #Until the final list of RelVals settles down the following sample list is under constant review
 '''
@@ -234,9 +242,10 @@ phase2samples_noPU = [
     #Sample("RelValZpTT_1500", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag ),
     Sample("RelValZTT", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag ),
     Sample("RelValZMM", midfix="14", scenario="2026D49", appendGlobalTag=appendglobaltag ),
+    #Sample("RelValZMM", midfix="14", scenario="2026D49", dqmVersion="0002", appendGlobalTag=appendglobaltag ),
     Sample("RelValZEE", midfix="14", scenario="2026D49", appendGlobalTag=appendglobaltag ),
     #Sample("RelValTenTau_15_500_Eta3p1", scenario="2026D49", appendGlobalTag=appendglobaltag  ),
-    Sample("RelValTenTau_15_500", scenario="2026D49", appendGlobalTag=appendglobaltag  ),
+    #Sample("RelValTenTau_15_500", scenario="2026D49", appendGlobalTag=appendglobaltag  ),
     Sample("RelValTTbar", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag ),
     Sample("RelValQCD_Pt15To7000_Flat", midfix="14", scenario="2026D49", appendGlobalTag=appendglobaltag ),
     #Sample("RelValQCD_Pt15To7000_Flat", midfix="14TeV", scenario="2026D49", appendGlobalTag=appendglobaltag ),
@@ -405,6 +414,9 @@ if (opt.OBJ == 'layerClusters' or opt.OBJ == 'hitCalibration' or opt.OBJ == 'hit
             cmd = 'python3 Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename)+ ' --collection %s' %(opt.HTMLVALNAME)
         elif "raw" in NotNormalRelease and "normal" in NotNormalRefRelease:
             cmd = 'python3 Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("mcRun4_realistic_v3_2026D76noPU-v1","mcRun4_realistic_v3_2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+            #cmd = 'python3 Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("mcRun4_realistic_v3_2026D49noPU_raw1100_rsb-v1","mcRun4_realistic_v3_2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+        elif "normal" in NotNormalRelease and "raw" in NotNormalRefRelease:
+            cmd = 'python3 Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("mcRun4_realistic_v7_2026D77noPU-v1","mcRun4_realistic_v7_2026D76noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
             #cmd = 'python3 Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("mcRun4_realistic_v3_2026D49noPU_raw1100_rsb-v1","mcRun4_realistic_v3_2026D49noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
         elif "raw" in NotNormalRelease and "raw" in NotNormalRefRelease:
             #cmd = 'python3 Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
@@ -910,6 +922,8 @@ if (opt.GEOMETRY) :
         #We need the directory for the geometry related results 
         if (not os.path.isdir('%s/%s/%s' %(opt.WWWAREA,GeoScenario,obj))):
             processCmd('mkdir -p %s/%s/%s' %(opt.WWWAREA,GeoScenario,obj) )
+            processCmd('mkdir -p %s/%s' %(GeoScenario,obj) )
+
         index_file.write('  <br/>\n' )
         index_file.write('  <ul>\n' )
         index_file.write('   <li><a href="%s/index.html">%s</a></li>\n' %(obj, _geoPageNameMap[obj] ) )


### PR DESCRIPTION
#### PR description:

With the opportunity of the HGCAL V16 material budget study and the ongoing `12_1_0_pre2_Phase2_D76` RelVal campaign,  we update the following: 

1. The latest menu for the webpage including RelVal campaigns and updated geometry section. 
2. The `html.py` script with a tweak in the name of a RelVal sample. 
3. The main validation script `hgcalPerformanceValidation.py` with a directory creation to make our life easier in the material budget study. 
4. The config script used for the material budget study including all detectors from vertex up to in front of muon stations. 
5. The `plot_hgcal_utils.py` script, since with the removal of the CALOECTSMiddle Volume, the CALOECTSFront contains now the EndcapTimingLayer, the Neutron Moderator and the Thermal Screen, which we wish to split. 

#### PR validation:

We have used these scripts to perform the `12_1_0_pre2_Phase2_D76` campaign validation and the HGCAL V16 material budget study. 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not a backport. 

@rovere @felicepantaleo @lecriste @ebrondol 