### PR TITLE
[DEVEL] Delete unused FWCore/PyDevParameterSet/BuildFile.xml

### DIFF
--- a/FWCore/PyDevParameterSet/BuildFile.xml
+++ b/FWCore/PyDevParameterSet/BuildFile.xml
@@ -1,8 +1,0 @@
-<use name="DataFormats/Provenance"/>
-<use name="FWCore/ParameterSet"/>
-<use name="FWCore/Utilities"/>
-<use name="py3-pybind11"/>
-<use name="python"/>
-<export>
-  <lib name="1"/>
-</export>


### PR DESCRIPTION
Remove the unused FWCore/PyDevParameterSet/BuildFile.xml which was added during the py2-py3 migration