### PR TITLE
Change current path in cmsExternalGenerator not cmsRun

### DIFF
--- a/GeneratorInterface/Core/bin/externalGenerator.cc
+++ b/GeneratorInterface/Core/bin/externalGenerator.cc
@@ -6,6 +6,7 @@
 #include <string>
 #include <thread>
 #include <memory>
+#include <filesystem>
 
 #include "FWCore/TestProcessor/interface/TestProcessor.h"
 
@@ -136,6 +137,13 @@ int main(int argc, char* argv[]) {
     std::cout << " no second argument given" << std::endl;
     return 1;
   }
+
+  using namespace std::string_literals;
+  using namespace std::filesystem;
+
+  auto newDir = path("thread"s + vm[kUniqueIDOpt].as<std::string>());
+  create_directory(newDir);
+  current_path(newDir);
 
   WorkerMonitorThread monitorThread;
 

--- a/GeneratorInterface/Core/plugins/ExternalGeneratorFilter.cc
+++ b/GeneratorInterface/Core/plugins/ExternalGeneratorFilter.cc
@@ -46,22 +46,15 @@ namespace externalgen {
 
       channel_.setupWorker([&]() {
         using namespace std::string_literals;
-        using namespace std::filesystem;
         edm::LogSystem("ExternalProcess") << id_ << " starting external process \n";
         std::string verboseCommand;
         if (verbose) {
           verboseCommand = "--verbose ";
         }
-        auto curDir = current_path();
-        auto newDir = path("thread"s + std::to_string(id_));
-        create_directory(newDir);
-        current_path(newDir);
         pipe_ =
             popen(("cmsExternalGenerator "s + verboseCommand + channel_.sharedMemoryName() + " " + channel_.uniqueID())
                       .c_str(),
                   "w");
-        current_path(curDir);
-
         if (nullptr == pipe_) {
           abort();
         }


### PR DESCRIPTION
#### PR description:

When doing concurrent beginStreams, changing of the current path was causing interference between threads.

This was found in the _DEVEL IB after concurrent beginStreams was added.

#### PR validation:

Code compiles. Unit test for the package passed.