### PR TITLE
Added esConsumes directly in MuonCkfTrajectoryBuilder

### DIFF
--- a/RecoMuon/L3TrackFinder/interface/MuonCkfTrajectoryBuilder.h
+++ b/RecoMuon/L3TrackFinder/interface/MuonCkfTrajectoryBuilder.h
@@ -4,6 +4,7 @@
 #include "RecoTracker/CkfPattern/interface/CkfTrajectoryBuilder.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
 
+class TrackingComponentsRecord;
 class MuonCkfTrajectoryBuilder : public CkfTrajectoryBuilder {
 public:
   MuonCkfTrajectoryBuilder(const edm::ParameterSet& conf, edm::ConsumesCollector& iC);
@@ -30,6 +31,7 @@ protected:
   const double theDeltaPhi;
   const std::string theProximityPropagatorName;
   const Propagator* theProximityPropagator;
+  const edm::ESGetToken<Propagator, TrackingComponentsRecord> thePropagatorToken;
   edm::ESWatcher<BaseCkfTrajectoryBuilder::Chi2MeasurementEstimatorRecord> theEstimatorWatcher;
   std::unique_ptr<Chi2MeasurementEstimatorBase> theEtaPhiEstimator;
 };

--- a/RecoMuon/L3TrackFinder/src/MuonCkfTrajectoryBuilder.cc
+++ b/RecoMuon/L3TrackFinder/src/MuonCkfTrajectoryBuilder.cc
@@ -21,6 +21,7 @@ MuonCkfTrajectoryBuilder::MuonCkfTrajectoryBuilder(const edm::ParameterSet& conf
       theDeltaPhi(conf.getParameter<double>("deltaPhi")),
       theProximityPropagatorName(conf.getParameter<std::string>("propagatorProximity")),
       theProximityPropagator(nullptr),
+      thePropagatorToken(iC.esConsumes(edm::ESInputTag("", theProximityPropagatorName))),
       theEtaPhiEstimator(nullptr) {
   //and something specific to me ?
   theUseSeedLayer = conf.getParameter<bool>("useSeedLayer");
@@ -32,9 +33,7 @@ MuonCkfTrajectoryBuilder::~MuonCkfTrajectoryBuilder() {}
 void MuonCkfTrajectoryBuilder::setEvent_(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   CkfTrajectoryBuilder::setEvent_(iEvent, iSetup);
 
-  edm::ESHandle<Propagator> propagatorProximityHandle;
-  iSetup.get<TrackingComponentsRecord>().get(theProximityPropagatorName, propagatorProximityHandle);
-  theProximityPropagator = propagatorProximityHandle.product();
+  theProximityPropagator = &iSetup.getData(thePropagatorToken);
 
   // theEstimator is set for this event in the base class
   if (theEstimatorWatcher.check(iSetup) && theDeltaEta > 0 && theDeltaPhi > 0)


### PR DESCRIPTION
#### PR description:

Part of the esConsumes migration.

#### PR validation:

Code compiles.