### PR TITLE
Use esConsumes in  CosmicSeedGenerator

### DIFF
--- a/RecoPixelVertexing/PixelTriplets/interface/CosmicHitTripletGenerator.h
+++ b/RecoPixelVertexing/PixelTriplets/interface/CosmicHitTripletGenerator.h
@@ -5,7 +5,6 @@
 #include "RecoPixelVertexing/PixelTriplets/interface/OrderedHitTriplets.h"
 #include "RecoPixelVertexing/PixelTriplets/interface/CosmicHitTripletGeneratorFromLayerTriplet.h"
 #include "DataFormats/Common/interface/RangeMap.h"
-#include "FWCore/Framework/interface/EventSetup.h"
 
 class LayerWithHits;
 class DetLayer;
@@ -20,7 +19,7 @@ class CosmicHitTripletGenerator {
   typedef std::vector<std::unique_ptr<CosmicHitTripletGeneratorFromLayerTriplet> > Container;
 
 public:
-  CosmicHitTripletGenerator(CosmicLayerTriplets& layers, const edm::EventSetup& iSetup);
+  CosmicHitTripletGenerator(CosmicLayerTriplets& layers, const TrackerGeometry& trackGeom);
   CosmicHitTripletGenerator(CosmicLayerTriplets& layers);
 
   ~CosmicHitTripletGenerator();
@@ -30,9 +29,9 @@ public:
   void add(const LayerWithHits* inner,
            const LayerWithHits* middle,
            const LayerWithHits* outer,
-           const edm::EventSetup& iSetup);
+           const TrackerGeometry& trackGeom);
 
-  void hitTriplets(const TrackingRegion& reg, OrderedHitTriplets& prs, const edm::EventSetup& iSetup);
+  void hitTriplets(const TrackingRegion& reg, OrderedHitTriplets& prs);
 
 private:
   Container theGenerators;

--- a/RecoPixelVertexing/PixelTriplets/interface/CosmicHitTripletGeneratorFromLayerTriplet.h
+++ b/RecoPixelVertexing/PixelTriplets/interface/CosmicHitTripletGeneratorFromLayerTriplet.h
@@ -18,17 +18,16 @@ public:
   CosmicHitTripletGeneratorFromLayerTriplet(const LayerWithHits* inner,
                                             const LayerWithHits* middle,
                                             const LayerWithHits* outer,
-                                            const edm::EventSetup& iSetup);
+                                            const TrackerGeometry& trackGeom);
   ~CosmicHitTripletGeneratorFromLayerTriplet() {}
 
-  void hitTriplets(const TrackingRegion& ar, OrderedHitTriplets& ap, const edm::EventSetup& iSetup);
+  void hitTriplets(const TrackingRegion& ar, OrderedHitTriplets& ap);
 
   const LayerWithHits* innerLayer() const { return theInnerLayer; }
   const LayerWithHits* middleLayer() const { return theMiddleLayer; }
   const LayerWithHits* outerLayer() const { return theOuterLayer; }
 
 private:
-  const TransientTrackingRecHitBuilder* TTRHbuilder;
   const TrackerGeometry* trackerGeometry;
   const LayerWithHits* theOuterLayer;
   const LayerWithHits* theMiddleLayer;

--- a/RecoPixelVertexing/PixelTriplets/interface/CosmicLayerTriplets.h
+++ b/RecoPixelVertexing/PixelTriplets/interface/CosmicLayerTriplets.h
@@ -6,8 +6,6 @@
  */
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2DCollection.h"
 #include "DataFormats/Common/interface/RangeMap.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESWatcher.h"
 #include "TrackingTools/DetLayers/interface/BarrelDetLayer.h"
 #include "TrackingTools/DetLayers/interface/ForwardDetLayer.h"
 #include "RecoTracker/TkHitPairs/interface/LayerWithHits.h"
@@ -18,12 +16,18 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2DCollection.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
 
-#include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
+class GeometricSearchTracker;
+class TrackerTopology;
 
 #include <vector>
 class CosmicLayerTriplets {
 public:
-  CosmicLayerTriplets(){};
+  CosmicLayerTriplets(std::string geometry,
+                      const SiStripRecHit2DCollection &collrphi,
+                      const GeometricSearchTracker &track,
+                      const TrackerTopology &ttopo) {
+    init(collrphi, std::move(geometry), track, ttopo);
+  };
   ~CosmicLayerTriplets();
   //  explicit PixelSeedLayerPairs(const edm::EventSetup& iSetup);
   typedef std::pair<SeedLayerPairs::LayerPair, std::vector<const LayerWithHits *> > LayerPairAndLayers;
@@ -40,18 +44,14 @@ private:
   LayerWithHits *lh3;
   LayerWithHits *lh4;
 
-  edm::ESWatcher<TrackerRecoGeometryRecord> watchTrackerGeometry_;
-
   std::vector<BarrelDetLayer const *> bl;
   //MP
   std::vector<LayerWithHits *> allLayersWithHits;
 
-public:
-  void init(const SiStripRecHit2DCollection &collstereo,
-            const SiStripRecHit2DCollection &collrphi,
-            const SiStripMatchedRecHit2DCollection &collmatched,
+  void init(const SiStripRecHit2DCollection &collrphi,
             std::string geometry,
-            const edm::EventSetup &iSetup);
+            const GeometricSearchTracker &track,
+            const TrackerTopology &ttopo);
 
 private:
   std::string _geometry;

--- a/RecoPixelVertexing/PixelTriplets/src/CosmicHitTripletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/src/CosmicHitTripletGenerator.cc
@@ -6,7 +6,7 @@
 
 using namespace std;
 
-CosmicHitTripletGenerator::CosmicHitTripletGenerator(CosmicLayerTriplets& layers, const edm::EventSetup& iSetup) {
+CosmicHitTripletGenerator::CosmicHitTripletGenerator(CosmicLayerTriplets& layers, const TrackerGeometry& trackGeom) {
   //  vector<LayerTriplets::LayerTriplet> layerTriplets = layers();
   vector<CosmicLayerTriplets::LayerPairAndLayers> layerTriplets = layers.layers();
   vector<CosmicLayerTriplets::LayerPairAndLayers>::const_iterator it;
@@ -17,7 +17,7 @@ CosmicHitTripletGenerator::CosmicHitTripletGenerator(CosmicLayerTriplets& layers
       //       const LayerWithHits* second=(*it).first.second;
       //       const LayerWithHits* third=(*ilwh);
       //      add( (*it).first.first, (*it).first.second, (*it).second,iSetup);
-      add((*it).first.first, (*it).first.second, (*ilwh), iSetup);
+      add((*it).first.first, (*it).first.second, (*ilwh), trackGeom);
     }
   }
 }
@@ -27,15 +27,13 @@ CosmicHitTripletGenerator::~CosmicHitTripletGenerator() {}
 void CosmicHitTripletGenerator::add(const LayerWithHits* inner,
                                     const LayerWithHits* middle,
                                     const LayerWithHits* outer,
-                                    const edm::EventSetup& iSetup) {
-  theGenerators.push_back(std::make_unique<CosmicHitTripletGeneratorFromLayerTriplet>(inner, middle, outer, iSetup));
+                                    const TrackerGeometry& trackGeom) {
+  theGenerators.push_back(std::make_unique<CosmicHitTripletGeneratorFromLayerTriplet>(inner, middle, outer, trackGeom));
 }
 
-void CosmicHitTripletGenerator::hitTriplets(const TrackingRegion& region,
-                                            OrderedHitTriplets& pairs,
-                                            const edm::EventSetup& iSetup) {
+void CosmicHitTripletGenerator::hitTriplets(const TrackingRegion& region, OrderedHitTriplets& pairs) {
   Container::const_iterator i;
   for (i = theGenerators.begin(); i != theGenerators.end(); i++) {
-    (**i).hitTriplets(region, pairs, iSetup);
+    (**i).hitTriplets(region, pairs);
   }
 }

--- a/RecoPixelVertexing/PixelTriplets/src/CosmicHitTripletGeneratorFromLayerTriplet.cc
+++ b/RecoPixelVertexing/PixelTriplets/src/CosmicHitTripletGeneratorFromLayerTriplet.cc
@@ -2,12 +2,8 @@
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
 #include "TrackingTools/DetLayers/interface/DetLayer.h"
 #include "RecoPixelVertexing/PixelTriplets/interface/OrderedHitTriplets.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "TrackingTools/DetLayers/interface/BarrelDetLayer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h"
-#include "TrackingTools/Records/interface/TransientRecHitRecord.h"
 
 #include <cmath>
 
@@ -16,20 +12,13 @@ typedef TransientTrackingRecHit::ConstRecHitPointer TkHitPairsCachedHit;
 CosmicHitTripletGeneratorFromLayerTriplet::CosmicHitTripletGeneratorFromLayerTriplet(const LayerWithHits *inner,
                                                                                      const LayerWithHits *middle,
                                                                                      const LayerWithHits *outer,
-                                                                                     const edm::EventSetup &iSetup)
-    : TTRHbuilder(nullptr),
-      trackerGeometry(nullptr),
+                                                                                     const TrackerGeometry &trackGeom)
+    : trackerGeometry(&trackGeom),
       //theLayerCache(*layerCache),
       theOuterLayer(outer),
       theMiddleLayer(middle),
-      theInnerLayer(inner) {
-  edm::ESHandle<TrackerGeometry> tracker;
-  iSetup.get<TrackerDigiGeometryRecord>().get(tracker);
-  trackerGeometry = tracker.product();
-}
-void CosmicHitTripletGeneratorFromLayerTriplet::hitTriplets(const TrackingRegion &region,
-                                                            OrderedHitTriplets &result,
-                                                            const edm::EventSetup &iSetup) {
+      theInnerLayer(inner) {}
+void CosmicHitTripletGeneratorFromLayerTriplet::hitTriplets(const TrackingRegion &region, OrderedHitTriplets &result) {
   if (theInnerLayer->recHits().empty())
     return;
   if (theMiddleLayer->recHits().empty())
@@ -43,10 +32,6 @@ void CosmicHitTripletGeneratorFromLayerTriplet::hitTriplets(const TrackingRegion
   std::vector<const TrackingRecHit *>::const_iterator ohh;
   std::vector<const TrackingRecHit *>::const_iterator mhh;
   std::vector<const TrackingRecHit *>::const_iterator ihh;
-
-  std::string builderName = "WithTrackAngle";
-  edm::ESHandle<TransientTrackingRecHitBuilder> builder;
-  iSetup.get<TransientRecHitRecord>().get(builderName, builder);
 
   if (!seedfromoverlaps) {
     for (ohh = theOuterLayer->recHits().begin(); ohh != theOuterLayer->recHits().end(); ohh++) {

--- a/RecoPixelVertexing/PixelTriplets/src/CosmicLayerTriplets.cc
+++ b/RecoPixelVertexing/PixelTriplets/src/CosmicLayerTriplets.cc
@@ -53,21 +53,12 @@ CosmicLayerTriplets::~CosmicLayerTriplets() {
   }
 }
 
-void CosmicLayerTriplets::init(const SiStripRecHit2DCollection& collstereo,
-                               const SiStripRecHit2DCollection& collrphi,
-                               const SiStripMatchedRecHit2DCollection& collmatched,
+void CosmicLayerTriplets::init(const SiStripRecHit2DCollection& collrphi,
                                std::string geometry,
-                               const edm::EventSetup& iSetup) {
-  _geometry = geometry;
-  if (watchTrackerGeometry_.check(iSetup)) {
-    edm::ESHandle<GeometricSearchTracker> track;
-    iSetup.get<TrackerRecoGeometryRecord>().get(track);
-    bl = track->barrelLayers();
-  }
-  edm::ESHandle<TrackerTopology> httopo;
-  iSetup.get<TrackerTopologyRcd>().get(httopo);
-  const TrackerTopology& ttopo = *httopo;
-
+                               const GeometricSearchTracker& track,
+                               const TrackerTopology& ttopo) {
+  _geometry = std::move(geometry);
+  bl = track.barrelLayers();
   for (vector<LayerWithHits*>::const_iterator it = allLayersWithHits.begin(); it != allLayersWithHits.end(); it++) {
     delete *it;
   }

--- a/RecoTracker/SpecialSeedGenerators/interface/SeedGeneratorForCosmics.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/SeedGeneratorForCosmics.h
@@ -9,6 +9,7 @@
 #include "RecoTracker/TkTrackingRegions/interface/GlobalTrackingRegion.h"
 //#include "RecoTracker/SpecialSeedGenerators/interface/SeedGeneratorFromLayerPairs.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2DCollection.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2DCollection.h"
@@ -22,21 +23,28 @@
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
 #include "RecoPixelVertexing/PixelTriplets/interface/CosmicHitTripletGenerator.h"
 class PixelSeedLayerPairs;
+class GeometricSearchTracker;
+class TrackerRecoGeometryRecord;
 
 class SeedGeneratorForCosmics {
 public:
   typedef TrajectoryStateOnSurface TSOS;
-  SeedGeneratorForCosmics(const edm::ParameterSet &conf);
-  virtual ~SeedGeneratorForCosmics(){};
+  SeedGeneratorForCosmics(const edm::ParameterSet &conf, edm::ConsumesCollector);
+
+  void run(const SiStripRecHit2DCollection &collstereo,
+           const SiStripRecHit2DCollection &collrphi,
+           const SiStripMatchedRecHit2DCollection &collmatched,
+           const edm::EventSetup &c,
+           TrajectorySeedCollection &);
+
+private:
   void init(const SiStripRecHit2DCollection &collstereo,
             const SiStripRecHit2DCollection &collrphi,
             const SiStripMatchedRecHit2DCollection &collmatched,
             const edm::EventSetup &c);
 
-  void run(TrajectorySeedCollection &, const edm::EventSetup &c);
-  bool seeds(TrajectorySeedCollection &output, const edm::EventSetup &c, const TrackingRegion &region);
+  bool seeds(TrajectorySeedCollection &output, const TrackingRegion &region);
 
-private:
   int32_t maxSeeds_;
   GlobalTrackingRegion region;
   CosmicHitPairGenerator *thePairGenerator;
@@ -44,11 +52,14 @@ private:
   edm::ESHandle<MagneticField> magfield;
   edm::ESHandle<TrackerGeometry> tracker;
 
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> theMagfieldToken;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> theTrackerToken;
+  const edm::ESGetToken<GeometricSearchTracker, TrackerRecoGeometryRecord> theSearchTrackerToken;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> theTTopoToken;
+
   KFUpdator *theUpdator;
   PropagatorWithMaterial *thePropagatorAl;
   PropagatorWithMaterial *thePropagatorOp;
-  const TransientTrackingRecHitBuilder *TTTRHBuilder;
-  std::string builderName;
   std::string geometry;
   std::string hitsforseeds;
   float seedpt;

--- a/RecoTracker/SpecialSeedGenerators/src/CosmicSeedGenerator.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/CosmicSeedGenerator.cc
@@ -15,7 +15,7 @@
 
 using namespace std;
 CosmicSeedGenerator::CosmicSeedGenerator(edm::ParameterSet const& conf)
-    : cosmic_seed(conf),
+    : cosmic_seed(conf, consumesCollector()),
       check(conf, consumesCollector())
 
 {
@@ -45,10 +45,8 @@ void CosmicSeedGenerator::produce(edm::Event& ev, const edm::EventSetup& es) {
   //check on the number of clusters
   size_t clustsOrZero = check.tooManyClusters(ev);
   if (!clustsOrZero) {
-    cosmic_seed.init(*stereorecHits, *rphirecHits, *matchedrecHits, es);
-
     // invoke the seed finding algorithm
-    cosmic_seed.run(*output, es);
+    cosmic_seed.run(*stereorecHits, *rphirecHits, *matchedrecHits, es, *output);
   } else
     edm::LogError("TooManyClusters") << "Found too many clusters (" << clustsOrZero << "), bailing out.\n";
 

--- a/RecoTracker/SpecialSeedGenerators/src/SeedGeneratorForCRack.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/SeedGeneratorForCRack.cc
@@ -24,9 +24,9 @@ void SeedGeneratorForCRack::init(const SiStripRecHit2DCollection& collstereo,
   edm::ESHandle<TrackerTopology> httopo;
   iSetup.get<TrackerTopologyRcd>().get(httopo);
   CosmicLayerPairs cosmiclayers(geometry, collrphi, collmatched, *track, *httopo);
-  thePairGenerator = new CosmicHitPairGenerator(cosmiclayers, iSetup);
+  thePairGenerator = new CosmicHitPairGenerator(cosmiclayers, *tracker);
   HitPairs.clear();
-  thePairGenerator->hitPairs(region, HitPairs, iSetup);
+  thePairGenerator->hitPairs(region, HitPairs);
   LogDebug("CosmicSeedFinder") << "Initialized with " << HitPairs.size() << " hit pairs" << std::endl;
 }
 

--- a/RecoTracker/SpecialSeedGenerators/src/SeedGeneratorForCRack.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/SeedGeneratorForCRack.cc
@@ -2,6 +2,7 @@
 #include "RecoTracker/TkHitPairs/interface/CosmicLayerPairs.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "TrackingTools/Records/interface/TransientRecHitRecord.h"
+#include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
 void SeedGeneratorForCRack::init(const SiStripRecHit2DCollection& collstereo,
                                  const SiStripRecHit2DCollection& collrphi,
                                  const SiStripMatchedRecHit2DCollection& collmatched,
@@ -18,8 +19,11 @@ void SeedGeneratorForCRack::init(const SiStripRecHit2DCollection& collstereo,
 
   iSetup.get<TransientRecHitRecord>().get(builderName, theBuilder);
   TTTRHBuilder = theBuilder.product();
-  CosmicLayerPairs cosmiclayers(geometry);
-  cosmiclayers.init(collstereo, collrphi, collmatched, iSetup);
+  edm::ESHandle<GeometricSearchTracker> track;
+  iSetup.get<TrackerRecoGeometryRecord>().get(track);
+  edm::ESHandle<TrackerTopology> httopo;
+  iSetup.get<TrackerTopologyRcd>().get(httopo);
+  CosmicLayerPairs cosmiclayers(geometry, collrphi, collmatched, *track, *httopo);
   thePairGenerator = new CosmicHitPairGenerator(cosmiclayers, iSetup);
   HitPairs.clear();
   thePairGenerator->hitPairs(region, HitPairs, iSetup);

--- a/RecoTracker/SpecialSeedGenerators/src/SeedGeneratorForCosmics.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/SeedGeneratorForCosmics.cc
@@ -39,10 +39,10 @@ void SeedGeneratorForCosmics::init(const SiStripRecHit2DCollection& collstereo,
   }
 
   CosmicLayerTriplets cosmiclayers2(geometry, collrphi, *track, *httopo);
-  theTripletGenerator = new CosmicHitTripletGenerator(cosmiclayers2, iSetup);
+  theTripletGenerator = new CosmicHitTripletGenerator(cosmiclayers2, *tracker);
   HitTriplets.clear();
   if ((hitsforseeds == "triplets") || (hitsforseeds == "pairsandtriplets")) {
-    theTripletGenerator->hitTriplets(region, HitTriplets, iSetup);
+    theTripletGenerator->hitTriplets(region, HitTriplets);
   }
 }
 

--- a/RecoTracker/SpecialSeedGenerators/src/SeedGeneratorForCosmics.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/SeedGeneratorForCosmics.cc
@@ -24,9 +24,13 @@ void SeedGeneratorForCosmics::init(const SiStripRecHit2DCollection& collstereo,
   TTTRHBuilder = theBuilder.product();
   LogDebug("CosmicSeedFinder") << " Hits built with  " << hitsforseeds << " hits";
 
-  CosmicLayerPairs cosmiclayers(geometry);
+  edm::ESHandle<GeometricSearchTracker> track;
+  iSetup.get<TrackerRecoGeometryRecord>().get(track);
+  edm::ESHandle<TrackerTopology> httopo;
+  iSetup.get<TrackerTopologyRcd>().get(httopo);
+  
+  CosmicLayerPairs cosmiclayers(geometry, collrphi, collmatched, *track, *httopo);
 
-  cosmiclayers.init(collstereo, collrphi, collmatched, iSetup);
   thePairGenerator = new CosmicHitPairGenerator(cosmiclayers, iSetup);
   HitPairs.clear();
   if ((hitsforseeds == "pairs") || (hitsforseeds == "pairsandtriplets")) {

--- a/RecoTracker/SpecialSeedGenerators/src/SeedGeneratorForCosmics.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/SeedGeneratorForCosmics.cc
@@ -28,13 +28,13 @@ void SeedGeneratorForCosmics::init(const SiStripRecHit2DCollection& collstereo,
   iSetup.get<TrackerRecoGeometryRecord>().get(track);
   edm::ESHandle<TrackerTopology> httopo;
   iSetup.get<TrackerTopologyRcd>().get(httopo);
-  
+
   CosmicLayerPairs cosmiclayers(geometry, collrphi, collmatched, *track, *httopo);
 
-  thePairGenerator = new CosmicHitPairGenerator(cosmiclayers, iSetup);
+  thePairGenerator = new CosmicHitPairGenerator(cosmiclayers, *tracker);
   HitPairs.clear();
   if ((hitsforseeds == "pairs") || (hitsforseeds == "pairsandtriplets")) {
-    thePairGenerator->hitPairs(region, HitPairs, iSetup);
+    thePairGenerator->hitPairs(region, HitPairs);
   }
 
   CosmicLayerTriplets cosmiclayers2;

--- a/RecoTracker/SpecialSeedGenerators/src/SeedGeneratorForCosmics.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/SeedGeneratorForCosmics.cc
@@ -5,6 +5,7 @@
 #include "FWCore/Utilities/interface/isFinite.h"
 #include "TrackingTools/Records/interface/TransientRecHitRecord.h"
 #include "RecoTracker/TkSeedGenerator/interface/FastHelix.h"
+#include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
 void SeedGeneratorForCosmics::init(const SiStripRecHit2DCollection& collstereo,
                                    const SiStripRecHit2DCollection& collrphi,
                                    const SiStripMatchedRecHit2DCollection& collmatched,
@@ -37,8 +38,7 @@ void SeedGeneratorForCosmics::init(const SiStripRecHit2DCollection& collstereo,
     thePairGenerator->hitPairs(region, HitPairs);
   }
 
-  CosmicLayerTriplets cosmiclayers2;
-  cosmiclayers2.init(collstereo, collrphi, collmatched, geometry, iSetup);
+  CosmicLayerTriplets cosmiclayers2(geometry, collrphi, *track, *httopo);
   theTripletGenerator = new CosmicHitTripletGenerator(cosmiclayers2, iSetup);
   HitTriplets.clear();
   if ((hitsforseeds == "triplets") || (hitsforseeds == "pairsandtriplets")) {

--- a/RecoTracker/TkHitPairs/interface/CosmicHitPairGenerator.h
+++ b/RecoTracker/TkHitPairs/interface/CosmicHitPairGenerator.h
@@ -18,16 +18,16 @@ class CosmicHitPairGenerator {
   typedef std::vector<std::unique_ptr<CosmicHitPairGeneratorFromLayerPair> > Container;
 
 public:
-  CosmicHitPairGenerator(SeedLayerPairs& layers, const edm::EventSetup& iSetup);
+  CosmicHitPairGenerator(SeedLayerPairs& layers, const TrackerGeometry&);
   CosmicHitPairGenerator(SeedLayerPairs& layers);
 
   ~CosmicHitPairGenerator();
 
   /// add generators based on layers
   //  void  add(const DetLayer* inner, const DetLayer* outer);
-  void add(const LayerWithHits* inner, const LayerWithHits* outer, const edm::EventSetup& iSetup);
+  void add(const LayerWithHits* inner, const LayerWithHits* outer, const TrackerGeometry& trackGeom);
   /// form base class
-  void hitPairs(const TrackingRegion& reg, OrderedHitPairs& prs, const edm::EventSetup& iSetup);
+  void hitPairs(const TrackingRegion& reg, OrderedHitPairs& pr);
 
 private:
   Container theGenerators;

--- a/RecoTracker/TkHitPairs/interface/CosmicHitPairGeneratorFromLayerPair.h
+++ b/RecoTracker/TkHitPairs/interface/CosmicHitPairGeneratorFromLayerPair.h
@@ -11,47 +11,21 @@
 class DetLayer;
 class TrackingRegion;
 class LayerWithHits;
-class CompareHitPairsY {
-public:
-  CompareHitPairsY(const edm::EventSetup& iSetup) { iSetup.get<TrackerDigiGeometryRecord>().get(tracker); };
-  bool operator()(const OrderedHitPair& h1, const OrderedHitPair& h2) {
-    const TrackingRecHit* trh1i = h1.inner()->hit();
-    const TrackingRecHit* trh2i = h2.inner()->hit();
-    const TrackingRecHit* trh1o = h1.outer()->hit();
-    const TrackingRecHit* trh2o = h2.outer()->hit();
-    GlobalPoint in1p = tracker->idToDet(trh1i->geographicalId())->surface().toGlobal(trh1i->localPosition());
-    GlobalPoint in2p = tracker->idToDet(trh2i->geographicalId())->surface().toGlobal(trh2i->localPosition());
-    GlobalPoint ou1p = tracker->idToDet(trh1o->geographicalId())->surface().toGlobal(trh1o->localPosition());
-    GlobalPoint ou2p = tracker->idToDet(trh2o->geographicalId())->surface().toGlobal(trh2o->localPosition());
-    if (ou1p.y() * ou2p.y() < 0)
-      return ou1p.y() > ou2p.y();
-    else {
-      float dist1 = 100 * std::abs(ou1p.z() - in1p.z()) - std::abs(ou1p.y()) - 0.1 * std::abs(in1p.y());
-      float dist2 = 100 * std::abs(ou2p.z() - in2p.z()) - std::abs(ou2p.y()) - 0.1 * std::abs(in2p.y());
-      return dist1 < dist2;
-    }
-  }
 
-private:
-  edm::ESHandle<TrackerGeometry> tracker;
-};
 class CosmicHitPairGeneratorFromLayerPair {
 public:
-  CosmicHitPairGeneratorFromLayerPair(const LayerWithHits* inner,
-                                      const LayerWithHits* outer,
-                                      const edm::EventSetup& iSetup);
+  CosmicHitPairGeneratorFromLayerPair(const LayerWithHits* inner, const LayerWithHits* outer, const TrackerGeometry&);
   ~CosmicHitPairGeneratorFromLayerPair();
 
   //  virtual OrderedHitPairs hitPairs( const TrackingRegion& region,const edm::EventSetup& iSetup ) {
   //    return HitPairGenerator::hitPairs(region, iSetup);
   //  }
-  void hitPairs(const TrackingRegion& ar, OrderedHitPairs& ap, const edm::EventSetup& iSetup);
+  void hitPairs(const TrackingRegion& ar, OrderedHitPairs& ap);
 
   const LayerWithHits* innerLayer() const { return theInnerLayer; }
   const LayerWithHits* outerLayer() const { return theOuterLayer; }
 
 private:
-  const TransientTrackingRecHitBuilder* TTRHbuilder;
   const TrackerGeometry* trackerGeometry;
   const LayerWithHits* theOuterLayer;
   const LayerWithHits* theInnerLayer;

--- a/RecoTracker/TkHitPairs/interface/CosmicLayerPairs.h
+++ b/RecoTracker/TkHitPairs/interface/CosmicLayerPairs.h
@@ -15,22 +15,28 @@
 #include <vector>
 
 class TrackerTopology;
+class GeometricSearchTracker;
 
 class CosmicLayerPairs : public SeedLayerPairs {
 public:
-  CosmicLayerPairs(std::string geometry) : _geometry(geometry){};  //:isFirstCall(true){};
+  CosmicLayerPairs(std::string geometry,
+                   const SiStripRecHit2DCollection &collrphi,
+                   const SiStripMatchedRecHit2DCollection &collmatched,
+                   const GeometricSearchTracker &track,
+                   const TrackerTopology &ttopo)
+      : _geometry(geometry) {
+    init(collrphi, collmatched, track, ttopo);
+  };  //:isFirstCall(true){};
   ~CosmicLayerPairs() override;
-  //  explicit PixelSeedLayerPairs(const edm::EventSetup& iSetup);
 
-  //  virtual vector<LayerPair> operator()() const;
   std::vector<SeedLayerPairs::LayerPair> operator()() override;
-  void init(const SiStripRecHit2DCollection &collstereo,
-            const SiStripRecHit2DCollection &collrphi,
-            const SiStripMatchedRecHit2DCollection &collmatched,
-            //std::string geometry,
-            const edm::EventSetup &iSetup);
 
 private:
+  void init(const SiStripRecHit2DCollection &collrphi,
+            const SiStripMatchedRecHit2DCollection &collmatched,
+            const GeometricSearchTracker &,
+            const TrackerTopology &);
+
   //bool isFirstCall;
   std::string _geometry;
 

--- a/RecoTracker/TkHitPairs/interface/CosmicLayerPairs.h
+++ b/RecoTracker/TkHitPairs/interface/CosmicLayerPairs.h
@@ -26,7 +26,7 @@ public:
                    const TrackerTopology &ttopo)
       : _geometry(geometry) {
     init(collrphi, collmatched, track, ttopo);
-  };  //:isFirstCall(true){};
+  };
   ~CosmicLayerPairs() override;
 
   std::vector<SeedLayerPairs::LayerPair> operator()() override;
@@ -37,7 +37,6 @@ private:
             const GeometricSearchTracker &,
             const TrackerTopology &);
 
-  //bool isFirstCall;
   std::string _geometry;
 
   std::vector<BarrelDetLayer const *> bl;

--- a/RecoTracker/TkHitPairs/src/CosmicHitPairGenerator.cc
+++ b/RecoTracker/TkHitPairs/src/CosmicHitPairGenerator.cc
@@ -6,11 +6,11 @@
 
 using namespace std;
 
-CosmicHitPairGenerator::CosmicHitPairGenerator(SeedLayerPairs& layers, const edm::EventSetup& iSetup) {
+CosmicHitPairGenerator::CosmicHitPairGenerator(SeedLayerPairs& layers, const TrackerGeometry& trackGeom) {
   vector<SeedLayerPairs::LayerPair> layerPairs = layers();
   vector<SeedLayerPairs::LayerPair>::const_iterator it;
   for (it = layerPairs.begin(); it != layerPairs.end(); it++) {
-    add((*it).first, (*it).second, iSetup);
+    add((*it).first, (*it).second, trackGeom);
   }
 }
 
@@ -18,15 +18,13 @@ CosmicHitPairGenerator::~CosmicHitPairGenerator() {}
 
 void CosmicHitPairGenerator::add(const LayerWithHits* inner,
                                  const LayerWithHits* outer,
-                                 const edm::EventSetup& iSetup) {
-  theGenerators.push_back(std::make_unique<CosmicHitPairGeneratorFromLayerPair>(inner, outer, iSetup));
+                                 const TrackerGeometry& trackGeom) {
+  theGenerators.push_back(std::make_unique<CosmicHitPairGeneratorFromLayerPair>(inner, outer, trackGeom));
 }
 
-void CosmicHitPairGenerator::hitPairs(const TrackingRegion& region,
-                                      OrderedHitPairs& pairs,
-                                      const edm::EventSetup& iSetup) {
+void CosmicHitPairGenerator::hitPairs(const TrackingRegion& region, OrderedHitPairs& pairs) {
   Container::const_iterator i;
   for (i = theGenerators.begin(); i != theGenerators.end(); i++) {
-    (**i).hitPairs(region, pairs, iSetup);
+    (**i).hitPairs(region, pairs);
   }
 }

--- a/RecoTracker/TkHitPairs/src/CosmicHitPairGeneratorFromLayerPair.cc
+++ b/RecoTracker/TkHitPairs/src/CosmicHitPairGeneratorFromLayerPair.cc
@@ -12,19 +12,10 @@
 using namespace std;
 // typedef TransientTrackingRecHit::ConstRecHitPointer TkHitPairsCachedHit;
 
-CosmicHitPairGeneratorFromLayerPair::CosmicHitPairGeneratorFromLayerPair(
-    const LayerWithHits* inner,
-    const LayerWithHits* outer,
-    //							     LayerCacheType* layerCache,
-    const TrackerGeometry& geom)
-    : trackerGeometry(&geom),
-      //theLayerCache(*layerCache),
-      theOuterLayer(outer),
-      theInnerLayer(inner) {
-  //edm::ESHandle<TrackerGeometry> tracker;
-  //iSetup.get<TrackerDigiGeometryRecord>().get(tracker);
-  //trackerGeometry = tracker.product();
-}
+CosmicHitPairGeneratorFromLayerPair::CosmicHitPairGeneratorFromLayerPair(const LayerWithHits* inner,
+                                                                         const LayerWithHits* outer,
+                                                                         const TrackerGeometry& geom)
+    : trackerGeometry(&geom), theOuterLayer(outer), theInnerLayer(inner) {}
 CosmicHitPairGeneratorFromLayerPair::~CosmicHitPairGeneratorFromLayerPair() {}
 
 void CosmicHitPairGeneratorFromLayerPair::hitPairs(const TrackingRegion& region, OrderedHitPairs& result) {
@@ -103,6 +94,7 @@ void CosmicHitPairGeneratorFromLayerPair::hitPairs(const TrackingRegion& region,
   }
 
   /*
+  // uncomment if the sort operation below needs to be called
   class CompareHitPairsY {
   public:
     CompareHitPairsY(const TrackerGeometry& t): tracker{&t} {}
@@ -126,15 +118,16 @@ void CosmicHitPairGeneratorFromLayerPair::hitPairs(const TrackingRegion& region,
     
   private:
     const TrackerGeometry* tracker;
-    }; */
-  //   stable_sort(allthepairs.begin(),allthepairs.end(),CompareHitPairsY(*trackerGeometry));
-  //   //Seed from overlaps are saved only if
-  //   //no others have been saved
+  }; 
+  stable_sort(allthepairs.begin(),allthepairs.end(),CompareHitPairsY(*trackerGeometry));
+  //Seed from overlaps are saved only if
+  //no others have been saved
 
-  //   if (allthepairs.size()>0) {
-  //     if (seedfromoverlaps) {
-  //       if (result.size()==0) result.push_back(allthepairs[0]);
-  //     }
-  //     else result.push_back(allthepairs[0]);
-  //   }
+  if (allthepairs.size()>0) {
+    if (seedfromoverlaps) {
+      if (result.size()==0) result.push_back(allthepairs[0]);
+    }
+    else result.push_back(allthepairs[0]);
+  }
+*/
 }

--- a/RecoTracker/TkHitPairs/src/CosmicHitPairGeneratorFromLayerPair.cc
+++ b/RecoTracker/TkHitPairs/src/CosmicHitPairGeneratorFromLayerPair.cc
@@ -16,20 +16,18 @@ CosmicHitPairGeneratorFromLayerPair::CosmicHitPairGeneratorFromLayerPair(
     const LayerWithHits* inner,
     const LayerWithHits* outer,
     //							     LayerCacheType* layerCache,
-    const edm::EventSetup& iSetup)
-    : TTRHbuilder(nullptr),
-      trackerGeometry(nullptr),
+    const TrackerGeometry& geom)
+    : trackerGeometry(&geom),
       //theLayerCache(*layerCache),
       theOuterLayer(outer),
       theInnerLayer(inner) {
-  edm::ESHandle<TrackerGeometry> tracker;
-  iSetup.get<TrackerDigiGeometryRecord>().get(tracker);
-  trackerGeometry = tracker.product();
+  //edm::ESHandle<TrackerGeometry> tracker;
+  //iSetup.get<TrackerDigiGeometryRecord>().get(tracker);
+  //trackerGeometry = tracker.product();
 }
 CosmicHitPairGeneratorFromLayerPair::~CosmicHitPairGeneratorFromLayerPair() {}
-void CosmicHitPairGeneratorFromLayerPair::hitPairs(const TrackingRegion& region,
-                                                   OrderedHitPairs& result,
-                                                   const edm::EventSetup& iSetup) {
+
+void CosmicHitPairGeneratorFromLayerPair::hitPairs(const TrackingRegion& region, OrderedHitPairs& result) {
   //  static int NSee = 0; static int Ntry = 0; static int Nacc = 0;
 
   typedef OrderedHitPair::InnerRecHit InnerHit;
@@ -65,9 +63,6 @@ void CosmicHitPairGeneratorFromLayerPair::hitPairs(const TrackingRegion& region,
   }
 
   vector<OrderedHitPair> allthepairs;
-  std::string builderName = "WithTrackAngle";
-  edm::ESHandle<TransientTrackingRecHitBuilder> builder;
-  iSetup.get<TransientRecHitRecord>().get(builderName, builder);
 
   for (auto ohh = theOuterLayer->recHits().begin(); ohh != theOuterLayer->recHits().end(); ohh++) {
     for (auto ihh = theInnerLayer->recHits().begin(); ihh != theInnerLayer->recHits().end(); ihh++) {
@@ -107,7 +102,32 @@ void CosmicHitPairGeneratorFromLayerPair::hitPairs(const TrackingRegion& region,
     }
   }
 
-  //   stable_sort(allthepairs.begin(),allthepairs.end(),CompareHitPairsY(iSetup));
+  /*
+  class CompareHitPairsY {
+  public:
+    CompareHitPairsY(const TrackerGeometry& t): tracker{&t} {}
+    bool operator()(const OrderedHitPair& h1, const OrderedHitPair& h2) {
+      const TrackingRecHit* trh1i = h1.inner()->hit();
+      const TrackingRecHit* trh2i = h2.inner()->hit();
+      const TrackingRecHit* trh1o = h1.outer()->hit();
+      const TrackingRecHit* trh2o = h2.outer()->hit();
+      GlobalPoint in1p = tracker->idToDet(trh1i->geographicalId())->surface().toGlobal(trh1i->localPosition());
+      GlobalPoint in2p = tracker->idToDet(trh2i->geographicalId())->surface().toGlobal(trh2i->localPosition());
+      GlobalPoint ou1p = tracker->idToDet(trh1o->geographicalId())->surface().toGlobal(trh1o->localPosition());
+      GlobalPoint ou2p = tracker->idToDet(trh2o->geographicalId())->surface().toGlobal(trh2o->localPosition());
+      if (ou1p.y() * ou2p.y() < 0)
+        return ou1p.y() > ou2p.y();
+      else {
+        float dist1 = 100 * std::abs(ou1p.z() - in1p.z()) - std::abs(ou1p.y()) - 0.1 * std::abs(in1p.y());
+        float dist2 = 100 * std::abs(ou2p.z() - in2p.z()) - std::abs(ou2p.y()) - 0.1 * std::abs(in2p.y());
+        return dist1 < dist2;
+      }
+    }
+    
+  private:
+    const TrackerGeometry* tracker;
+    }; */
+  //   stable_sort(allthepairs.begin(),allthepairs.end(),CompareHitPairsY(*trackerGeometry));
   //   //Seed from overlaps are saved only if
   //   //no others have been saved
 

--- a/RecoTracker/TkHitPairs/src/CosmicLayerPairs.cc
+++ b/RecoTracker/TkHitPairs/src/CosmicLayerPairs.cc
@@ -11,7 +11,6 @@
 
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
-
 std::vector<SeedLayerPairs::LayerPair> CosmicLayerPairs::operator()() {
   std::vector<SeedLayerPairs::LayerPair> result;
 
@@ -236,29 +235,19 @@ std::vector<SeedLayerPairs::LayerPair> CosmicLayerPairs::operator()() {
 }
 CosmicLayerPairs::~CosmicLayerPairs() {}
 
-void CosmicLayerPairs::init(const SiStripRecHit2DCollection &collstereo,
-                            const SiStripRecHit2DCollection &collrphi,
+void CosmicLayerPairs::init(const SiStripRecHit2DCollection &collrphi,
                             const SiStripMatchedRecHit2DCollection &collmatched,
-                            //std::string geometry,
-                            const edm::EventSetup &iSetup) {
+                            const GeometricSearchTracker &track,
+                            const TrackerTopology &ttopo) {
   ////std::cout << "initializing geometry " << geometry << std::endl;
-  //_geometry=geometry;
-  //if(isFirstCall){
-  //std::cout << "in isFirtsCall" << std::endl;
-  edm::ESHandle<GeometricSearchTracker> track;
-  iSetup.get<TrackerRecoGeometryRecord>().get(track);
   //std::cout << "about to take barrel" << std::endl;
-  bl = track->barrelLayers();
+  bl = track.barrelLayers();
   //std::cout << "barrel taken" << std::endl;
-  fpos = track->posTecLayers();
+  fpos = track.posTecLayers();
   //std::cout << "pos forw taken" << std::endl;
-  fneg = track->negTecLayers();
+  fneg = track.negTecLayers();
   //std::cout << "neg forw taken" << std::endl;
   //isFirstCall=false;
-
-  edm::ESHandle<TrackerTopology> httopo;
-  iSetup.get<TrackerTopologyRcd>().get(httopo);
-  const TrackerTopology &ttopo = *httopo;
 
   if (_geometry ==
       "MTCC") {  //we have to distinguish the MTCC and CRACK case because they have special geometries with different neumbering of layers


### PR DESCRIPTION
#### PR description:

Modified helpers used by CosmicSeedGenerator to either no longer depend no the EventSetup or to use esConsumes.

#### PR validation:

Code compiles.