### PR TITLE
Consumes migration of  Alignment/ReferenceTrajectories

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
@@ -93,6 +93,11 @@ MillePedeAlignmentAlgorithm::MillePedeAlignmentAlgorithm(const edm::ParameterSet
       theDir(theConfig.getUntrackedParameter<std::string>("fileDir")),
       theAlignmentParameterStore(nullptr),
       theAlignables(),
+      theTrajectoryFactory(
+          TrajectoryFactoryPlugin::get()->create(theConfig.getParameter<edm::ParameterSet>("TrajectoryFactory")
+                                                     .getParameter<std::string>("TrajectoryFactoryName"),
+                                                 theConfig.getParameter<edm::ParameterSet>("TrajectoryFactory"),
+                                                 iC)),
       theMinNumHits(cfg.getParameter<unsigned int>("minNumHits")),
       theMaximalCor2D(cfg.getParameter<double>("max2Dcorrelation")),
       firstIOV_(cfg.getUntrackedParameter<AlignmentAlgorithmBase::RunNumber>("firstIOV")),
@@ -273,9 +278,6 @@ void MillePedeAlignmentAlgorithm::initialize(const edm::EventSetup &setup,
       theMonitor = std::make_unique<MillePedeMonitor>(tTopo, (theDir + moniFile).c_str());
 
     // Get trajectory factory. In case nothing found, FrameWork will throw...
-    const edm::ParameterSet fctCfg(theConfig.getParameter<edm::ParameterSet>("TrajectoryFactory"));
-    const std::string fctName(fctCfg.getParameter<std::string>("TrajectoryFactoryName"));
-    theTrajectoryFactory = TrajectoryFactoryPlugin::get()->create(fctName, fctCfg);
   }
 
   if (this->isMode(myPedeSteerBit)) {

--- a/Alignment/ReferenceTrajectories/interface/TrajectoryFactoryBase.h
+++ b/Alignment/ReferenceTrajectories/interface/TrajectoryFactoryBase.h
@@ -28,27 +28,22 @@ public:
   typedef std::pair<TrajectoryStateOnSurface, TransientTrackingRecHit::ConstRecHitContainer> TrajectoryInput;
   typedef std::vector<TrajectoryStateOnSurface> ExternalPredictionCollection;
 
-  TrajectoryFactoryBase(const edm::ParameterSet& config, const edm::ConsumesCollector &iC);
-  TrajectoryFactoryBase(const edm::ParameterSet& config, unsigned int tracksPerTrajectory, const edm::ConsumesCollector &iC);
+  TrajectoryFactoryBase(const edm::ParameterSet& config, const edm::ConsumesCollector& iC);
+  TrajectoryFactoryBase(const edm::ParameterSet& config,
+                        unsigned int tracksPerTrajectory,
+                        const edm::ConsumesCollector& iC);
   virtual ~TrajectoryFactoryBase(void);
 
   virtual const ReferenceTrajectoryCollection trajectories(const edm::EventSetup& setup,
                                                            const ConstTrajTrackPairCollection& tracks,
-                                                           const reco::BeamSpot& beamSpot, edm::ConsumesCollector &iC) const = 0;
+                                                           const reco::BeamSpot& beamSpot,
+                                                           edm::ConsumesCollector& iC) const = 0;
 
   virtual const ReferenceTrajectoryCollection trajectories(const edm::EventSetup& setup,
                                                            const ConstTrajTrackPairCollection& tracks,
                                                            const ExternalPredictionCollection& external,
-                                                           const reco::BeamSpot& beamSpot, edm::ConsumesCollector &iC) const = 0;
-
-//  virtual const ReferenceTrajectoryCollection trajectories(const edm::EventSetup& setup,
-//                                                           const ConstTrajTrackPairCollection& tracks,
-//                                                           const reco::BeamSpot& beamSpot) const = 0;
-
-//  virtual const ReferenceTrajectoryCollection trajectories(const edm::EventSetup& setup,
-//                                                           const ConstTrajTrackPairCollection& tracks,
-//                                                           const ExternalPredictionCollection& external,
-//                                                           const reco::BeamSpot& beamSpot) const = 0;
+                                                           const reco::BeamSpot& beamSpot,
+                                                           edm::ConsumesCollector& iC) const = 0;
 
   virtual TrajectoryFactoryBase* clone(void) const = 0;
 

--- a/Alignment/ReferenceTrajectories/interface/TrajectoryFactoryBase.h
+++ b/Alignment/ReferenceTrajectories/interface/TrajectoryFactoryBase.h
@@ -36,14 +36,12 @@ public:
 
   virtual const ReferenceTrajectoryCollection trajectories(const edm::EventSetup& setup,
                                                            const ConstTrajTrackPairCollection& tracks,
-                                                           const reco::BeamSpot& beamSpot,
-                                                           edm::ConsumesCollector& iC) const = 0;
+                                                           const reco::BeamSpot& beamSpot) const = 0;
 
   virtual const ReferenceTrajectoryCollection trajectories(const edm::EventSetup& setup,
                                                            const ConstTrajTrackPairCollection& tracks,
                                                            const ExternalPredictionCollection& external,
-                                                           const reco::BeamSpot& beamSpot,
-                                                           edm::ConsumesCollector& iC) const = 0;
+                                                           const reco::BeamSpot& beamSpot) const = 0;
 
   virtual TrajectoryFactoryBase* clone(void) const = 0;
 

--- a/Alignment/ReferenceTrajectories/interface/TrajectoryFactoryBase.h
+++ b/Alignment/ReferenceTrajectories/interface/TrajectoryFactoryBase.h
@@ -34,12 +34,21 @@ public:
 
   virtual const ReferenceTrajectoryCollection trajectories(const edm::EventSetup& setup,
                                                            const ConstTrajTrackPairCollection& tracks,
-                                                           const reco::BeamSpot& beamSpot) const = 0;
+                                                           const reco::BeamSpot& beamSpot, edm::ConsumesCollector &iC) const = 0;
 
   virtual const ReferenceTrajectoryCollection trajectories(const edm::EventSetup& setup,
                                                            const ConstTrajTrackPairCollection& tracks,
                                                            const ExternalPredictionCollection& external,
-                                                           const reco::BeamSpot& beamSpot) const = 0;
+                                                           const reco::BeamSpot& beamSpot, edm::ConsumesCollector &iC) const = 0;
+
+//  virtual const ReferenceTrajectoryCollection trajectories(const edm::EventSetup& setup,
+//                                                           const ConstTrajTrackPairCollection& tracks,
+//                                                           const reco::BeamSpot& beamSpot) const = 0;
+
+//  virtual const ReferenceTrajectoryCollection trajectories(const edm::EventSetup& setup,
+//                                                           const ConstTrajTrackPairCollection& tracks,
+//                                                           const ExternalPredictionCollection& external,
+//                                                           const reco::BeamSpot& beamSpot) const = 0;
 
   virtual TrajectoryFactoryBase* clone(void) const = 0;
 

--- a/Alignment/ReferenceTrajectories/interface/TrajectoryFactoryBase.h
+++ b/Alignment/ReferenceTrajectories/interface/TrajectoryFactoryBase.h
@@ -10,6 +10,7 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 /// Base class for factories producing reference trajectories, i.e. instances of classes deriving from
 /// ReferenceTrajectoryBase, from a TrajTrackPairCollection.
 
@@ -27,8 +28,8 @@ public:
   typedef std::pair<TrajectoryStateOnSurface, TransientTrackingRecHit::ConstRecHitContainer> TrajectoryInput;
   typedef std::vector<TrajectoryStateOnSurface> ExternalPredictionCollection;
 
-  TrajectoryFactoryBase(const edm::ParameterSet& config);
-  TrajectoryFactoryBase(const edm::ParameterSet& config, unsigned int tracksPerTrajectory);
+  TrajectoryFactoryBase(const edm::ParameterSet& config, const edm::ConsumesCollector &iC);
+  TrajectoryFactoryBase(const edm::ParameterSet& config, unsigned int tracksPerTrajectory, const edm::ConsumesCollector &iC);
   virtual ~TrajectoryFactoryBase(void);
 
   virtual const ReferenceTrajectoryCollection trajectories(const edm::EventSetup& setup,

--- a/Alignment/ReferenceTrajectories/interface/TrajectoryFactoryPlugin.h
+++ b/Alignment/ReferenceTrajectories/interface/TrajectoryFactoryPlugin.h
@@ -8,6 +8,7 @@
 
 /// A PluginFactory that produces factories that inherit from TrajectoryFactoryBase.
 
-typedef edmplugin::PluginFactory<TrajectoryFactoryBase *(const edm::ParameterSet &, edm::ConsumesCollector &)> TrajectoryFactoryPlugin;
+typedef edmplugin::PluginFactory<TrajectoryFactoryBase *(const edm::ParameterSet &, edm::ConsumesCollector &)>
+    TrajectoryFactoryPlugin;
 
 #endif

--- a/Alignment/ReferenceTrajectories/interface/TrajectoryFactoryPlugin.h
+++ b/Alignment/ReferenceTrajectories/interface/TrajectoryFactoryPlugin.h
@@ -8,6 +8,6 @@
 
 /// A PluginFactory that produces factories that inherit from TrajectoryFactoryBase.
 
-typedef edmplugin::PluginFactory<TrajectoryFactoryBase *(const edm::ParameterSet &)> TrajectoryFactoryPlugin;
+typedef edmplugin::PluginFactory<TrajectoryFactoryBase *(const edm::ParameterSet &, edm::ConsumesCollector &)> TrajectoryFactoryPlugin;
 
 #endif

--- a/Alignment/ReferenceTrajectories/plugins/BzeroReferenceTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/BzeroReferenceTrajectoryFactory.cc
@@ -36,8 +36,7 @@ BzeroReferenceTrajectoryFactory::~BzeroReferenceTrajectoryFactory(void) {}
 const BzeroReferenceTrajectoryFactory::ReferenceTrajectoryCollection BzeroReferenceTrajectoryFactory::trajectories(
     const edm::EventSetup &setup,
     const ConstTrajTrackPairCollection &tracks,
-    const reco::BeamSpot &beamSpot,
-    edm::ConsumesCollector &iC) const {
+    const reco::BeamSpot &beamSpot) const {
   ReferenceTrajectoryCollection trajectories;
 
   const MagneticField *magneticField = &setup.getData(m_MagFieldToken);
@@ -69,8 +68,7 @@ const BzeroReferenceTrajectoryFactory::ReferenceTrajectoryCollection BzeroRefere
     const edm::EventSetup &setup,
     const ConstTrajTrackPairCollection &tracks,
     const ExternalPredictionCollection &external,
-    const reco::BeamSpot &beamSpot,
-    edm::ConsumesCollector &iC) const {
+    const reco::BeamSpot &beamSpot) const {
   ReferenceTrajectoryCollection trajectories;
 
   if (tracks.size() != external.size()) {

--- a/Alignment/ReferenceTrajectories/plugins/BzeroReferenceTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/BzeroReferenceTrajectoryFactory.cc
@@ -20,10 +20,13 @@
 /////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////
 
-BzeroReferenceTrajectoryFactory::BzeroReferenceTrajectoryFactory(const edm::ParameterSet &config)
-    : TrajectoryFactoryBase(config),
+BzeroReferenceTrajectoryFactory::BzeroReferenceTrajectoryFactory(const edm::ParameterSet &config, edm::ConsumesCollector &iC)
+    : 
+      TrajectoryFactoryBase(config, iC),
+m_MagFieldToken(iC.esConsumes()), 
       theMass(config.getParameter<double>("ParticleMass")),
-      theMomentumEstimate(config.getParameter<double>("MomentumEstimate")) {
+      theMomentumEstimate(config.getParameter<double>("MomentumEstimate"))
+{
   edm::LogInfo("Alignment") << "@SUB=BzeroReferenceTrajectoryFactory"
                             << "mass: " << theMass << "\nmomentum: " << theMomentumEstimate;
 }
@@ -35,8 +38,9 @@ const BzeroReferenceTrajectoryFactory::ReferenceTrajectoryCollection BzeroRefere
     const edm::EventSetup &setup, const ConstTrajTrackPairCollection &tracks, const reco::BeamSpot &beamSpot) const {
   ReferenceTrajectoryCollection trajectories;
 
-  edm::ESHandle<MagneticField> magneticField;
-  setup.get<IdealMagneticFieldRecord>().get(magneticField);
+//  edm::ESHandle<MagneticField> magneticField;
+//  setup.get<IdealMagneticFieldRecord>().get(magneticField);
+  const MagneticField* magneticField = &setup.getData(m_MagFieldToken); 
 
   ConstTrajTrackPairCollection::const_iterator itTracks = tracks.begin();
 
@@ -51,7 +55,7 @@ const BzeroReferenceTrajectoryFactory::ReferenceTrajectoryCollection BzeroRefere
       // set the flag for reversing the RecHits to false, since they are already in the correct order.
       config.hitsAreReverse = false;
       trajectories.push_back(ReferenceTrajectoryPtr(
-          new BzeroReferenceTrajectory(input.first, input.second, magneticField.product(), beamSpot, config)));
+          new BzeroReferenceTrajectory(input.first, input.second, magneticField, beamSpot, config)));
     }
 
     ++itTracks;
@@ -76,8 +80,7 @@ const BzeroReferenceTrajectoryFactory::ReferenceTrajectoryCollection BzeroRefere
     return trajectories;
   }
 
-  edm::ESHandle<MagneticField> magneticField;
-  setup.get<IdealMagneticFieldRecord>().get(magneticField);
+  const MagneticField* magneticField = &setup.getData(m_MagFieldToken); 
 
   ConstTrajTrackPairCollection::const_iterator itTracks = tracks.begin();
   ExternalPredictionCollection::const_iterator itExternal = external.begin();
@@ -94,7 +97,7 @@ const BzeroReferenceTrajectoryFactory::ReferenceTrajectoryCollection BzeroRefere
         // set the flag for reversing the RecHits to false, since they are already in the correct order.
         config.hitsAreReverse = false;
         ReferenceTrajectoryPtr refTraj(
-            new BzeroReferenceTrajectory(*itExternal, input.second, magneticField.product(), beamSpot, config));
+            new BzeroReferenceTrajectory(*itExternal, input.second, magneticField, beamSpot, config));
 
         AlgebraicSymMatrix externalParamErrors(asHepMatrix<5>((*itExternal).localError().matrix()));
         refTraj->setParameterErrors(externalParamErrors.sub(2, 5));
@@ -108,7 +111,7 @@ const BzeroReferenceTrajectoryFactory::ReferenceTrajectoryCollection BzeroRefere
         // set the flag for reversing the RecHits to false, since they are already in the correct order.
         config.hitsAreReverse = false;
         trajectories.push_back(ReferenceTrajectoryPtr(
-            new BzeroReferenceTrajectory(input.first, input.second, magneticField.product(), beamSpot, config)));
+            new BzeroReferenceTrajectory(input.first, input.second, magneticField, beamSpot, config)));
       }
     }
 

--- a/Alignment/ReferenceTrajectories/plugins/BzeroReferenceTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/BzeroReferenceTrajectoryFactory.cc
@@ -34,9 +34,7 @@ BzeroReferenceTrajectoryFactory::~BzeroReferenceTrajectoryFactory(void) {}
 
 /////////////////////////////////////////////////////////////////////
 const BzeroReferenceTrajectoryFactory::ReferenceTrajectoryCollection BzeroReferenceTrajectoryFactory::trajectories(
-    const edm::EventSetup &setup,
-    const ConstTrajTrackPairCollection &tracks,
-    const reco::BeamSpot &beamSpot) const {
+    const edm::EventSetup &setup, const ConstTrajTrackPairCollection &tracks, const reco::BeamSpot &beamSpot) const {
   ReferenceTrajectoryCollection trajectories;
 
   const MagneticField *magneticField = &setup.getData(m_MagFieldToken);

--- a/Alignment/ReferenceTrajectories/plugins/BzeroReferenceTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/BzeroReferenceTrajectoryFactory.cc
@@ -20,13 +20,12 @@
 /////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////
 
-BzeroReferenceTrajectoryFactory::BzeroReferenceTrajectoryFactory(const edm::ParameterSet &config, edm::ConsumesCollector &iC)
-    : 
-      TrajectoryFactoryBase(config, iC),
-m_MagFieldToken(iC.esConsumes()), 
+BzeroReferenceTrajectoryFactory::BzeroReferenceTrajectoryFactory(const edm::ParameterSet &config,
+                                                                 edm::ConsumesCollector &iC)
+    : TrajectoryFactoryBase(config, iC),
+      m_MagFieldToken(iC.esConsumes()),
       theMass(config.getParameter<double>("ParticleMass")),
-      theMomentumEstimate(config.getParameter<double>("MomentumEstimate"))
-{
+      theMomentumEstimate(config.getParameter<double>("MomentumEstimate")) {
   edm::LogInfo("Alignment") << "@SUB=BzeroReferenceTrajectoryFactory"
                             << "mass: " << theMass << "\nmomentum: " << theMomentumEstimate;
 }
@@ -35,12 +34,13 @@ BzeroReferenceTrajectoryFactory::~BzeroReferenceTrajectoryFactory(void) {}
 
 /////////////////////////////////////////////////////////////////////
 const BzeroReferenceTrajectoryFactory::ReferenceTrajectoryCollection BzeroReferenceTrajectoryFactory::trajectories(
-    const edm::EventSetup &setup, const ConstTrajTrackPairCollection &tracks, const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const {
+    const edm::EventSetup &setup,
+    const ConstTrajTrackPairCollection &tracks,
+    const reco::BeamSpot &beamSpot,
+    edm::ConsumesCollector &iC) const {
   ReferenceTrajectoryCollection trajectories;
 
-//  edm::ESHandle<MagneticField> magneticField;
-//  setup.get<IdealMagneticFieldRecord>().get(magneticField);
-  const MagneticField* magneticField = &setup.getData(m_MagFieldToken); 
+  const MagneticField *magneticField = &setup.getData(m_MagFieldToken);
 
   ConstTrajTrackPairCollection::const_iterator itTracks = tracks.begin();
 
@@ -69,7 +69,8 @@ const BzeroReferenceTrajectoryFactory::ReferenceTrajectoryCollection BzeroRefere
     const edm::EventSetup &setup,
     const ConstTrajTrackPairCollection &tracks,
     const ExternalPredictionCollection &external,
-    const reco::BeamSpot &beamSpot,edm::ConsumesCollector &iC) const {
+    const reco::BeamSpot &beamSpot,
+    edm::ConsumesCollector &iC) const {
   ReferenceTrajectoryCollection trajectories;
 
   if (tracks.size() != external.size()) {
@@ -80,7 +81,7 @@ const BzeroReferenceTrajectoryFactory::ReferenceTrajectoryCollection BzeroRefere
     return trajectories;
   }
 
-  const MagneticField* magneticField = &setup.getData(m_MagFieldToken); 
+  const MagneticField *magneticField = &setup.getData(m_MagFieldToken);
 
   ConstTrajTrackPairCollection::const_iterator itTracks = tracks.begin();
   ExternalPredictionCollection::const_iterator itExternal = external.begin();

--- a/Alignment/ReferenceTrajectories/plugins/BzeroReferenceTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/BzeroReferenceTrajectoryFactory.cc
@@ -35,7 +35,7 @@ BzeroReferenceTrajectoryFactory::~BzeroReferenceTrajectoryFactory(void) {}
 
 /////////////////////////////////////////////////////////////////////
 const BzeroReferenceTrajectoryFactory::ReferenceTrajectoryCollection BzeroReferenceTrajectoryFactory::trajectories(
-    const edm::EventSetup &setup, const ConstTrajTrackPairCollection &tracks, const reco::BeamSpot &beamSpot) const {
+    const edm::EventSetup &setup, const ConstTrajTrackPairCollection &tracks, const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const {
   ReferenceTrajectoryCollection trajectories;
 
 //  edm::ESHandle<MagneticField> magneticField;
@@ -69,7 +69,7 @@ const BzeroReferenceTrajectoryFactory::ReferenceTrajectoryCollection BzeroRefere
     const edm::EventSetup &setup,
     const ConstTrajTrackPairCollection &tracks,
     const ExternalPredictionCollection &external,
-    const reco::BeamSpot &beamSpot) const {
+    const reco::BeamSpot &beamSpot,edm::ConsumesCollector &iC) const {
   ReferenceTrajectoryCollection trajectories;
 
   if (tracks.size() != external.size()) {

--- a/Alignment/ReferenceTrajectories/plugins/BzeroReferenceTrajectoryFactory.h
+++ b/Alignment/ReferenceTrajectories/plugins/BzeroReferenceTrajectoryFactory.h
@@ -19,16 +19,19 @@ public:
   /// Produce the reference trajectories.
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
                                                    const ConstTrajTrackPairCollection &tracks,
-                                                   const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const override;
+                                                   const reco::BeamSpot &beamSpot,
+                                                   edm::ConsumesCollector &iC) const override;
 
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
                                                    const ConstTrajTrackPairCollection &tracks,
                                                    const ExternalPredictionCollection &external,
-                                                   const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const override;
+                                                   const reco::BeamSpot &beamSpot,
+                                                   edm::ConsumesCollector &iC) const override;
 
   BzeroReferenceTrajectoryFactory *clone() const override { return new BzeroReferenceTrajectoryFactory(*this); }
 
   const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> m_MagFieldToken;
+
 private:
   double theMass;
   double theMomentumEstimate;

--- a/Alignment/ReferenceTrajectories/plugins/BzeroReferenceTrajectoryFactory.h
+++ b/Alignment/ReferenceTrajectories/plugins/BzeroReferenceTrajectoryFactory.h
@@ -19,12 +19,12 @@ public:
   /// Produce the reference trajectories.
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
                                                    const ConstTrajTrackPairCollection &tracks,
-                                                   const reco::BeamSpot &beamSpot) const override;
+                                                   const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const override;
 
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
                                                    const ConstTrajTrackPairCollection &tracks,
                                                    const ExternalPredictionCollection &external,
-                                                   const reco::BeamSpot &beamSpot) const override;
+                                                   const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const override;
 
   BzeroReferenceTrajectoryFactory *clone() const override { return new BzeroReferenceTrajectoryFactory(*this); }
 

--- a/Alignment/ReferenceTrajectories/plugins/BzeroReferenceTrajectoryFactory.h
+++ b/Alignment/ReferenceTrajectories/plugins/BzeroReferenceTrajectoryFactory.h
@@ -19,14 +19,12 @@ public:
   /// Produce the reference trajectories.
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
                                                    const ConstTrajTrackPairCollection &tracks,
-                                                   const reco::BeamSpot &beamSpot,
-                                                   edm::ConsumesCollector &iC) const override;
+                                                   const reco::BeamSpot &beamSpot) const override;
 
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
                                                    const ConstTrajTrackPairCollection &tracks,
                                                    const ExternalPredictionCollection &external,
-                                                   const reco::BeamSpot &beamSpot,
-                                                   edm::ConsumesCollector &iC) const override;
+                                                   const reco::BeamSpot &beamSpot) const override;
 
   BzeroReferenceTrajectoryFactory *clone() const override { return new BzeroReferenceTrajectoryFactory(*this); }
 

--- a/Alignment/ReferenceTrajectories/plugins/BzeroReferenceTrajectoryFactory.h
+++ b/Alignment/ReferenceTrajectories/plugins/BzeroReferenceTrajectoryFactory.h
@@ -1,4 +1,5 @@
 #include "Alignment/ReferenceTrajectories/interface/TrajectoryFactoryBase.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
 namespace edm {
   class ParameterSet;
@@ -13,9 +14,8 @@ namespace reco {
 
 class BzeroReferenceTrajectoryFactory : public TrajectoryFactoryBase {
 public:
-  BzeroReferenceTrajectoryFactory(const edm::ParameterSet &config);
+  BzeroReferenceTrajectoryFactory(const edm::ParameterSet &config, edm::ConsumesCollector &iC);
   ~BzeroReferenceTrajectoryFactory() override;
-
   /// Produce the reference trajectories.
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
                                                    const ConstTrajTrackPairCollection &tracks,
@@ -28,6 +28,7 @@ public:
 
   BzeroReferenceTrajectoryFactory *clone() const override { return new BzeroReferenceTrajectoryFactory(*this); }
 
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> m_MagFieldToken;
 private:
   double theMass;
   double theMomentumEstimate;

--- a/Alignment/ReferenceTrajectories/plugins/CombinedTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/CombinedTrajectoryFactory.cc
@@ -23,7 +23,7 @@
 
 class CombinedTrajectoryFactory : public TrajectoryFactoryBase {
 public:
-  CombinedTrajectoryFactory(const edm::ParameterSet &config);
+  CombinedTrajectoryFactory(const edm::ParameterSet &config, edm::ConsumesCollector &iC);
   ~CombinedTrajectoryFactory() override;
 
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
@@ -56,8 +56,8 @@ private:
 
 using namespace std;
 
-CombinedTrajectoryFactory::CombinedTrajectoryFactory(const edm::ParameterSet &config)
-    : TrajectoryFactoryBase(config), theUseAllFactories(config.getParameter<bool>("useAllFactories")) {
+CombinedTrajectoryFactory::CombinedTrajectoryFactory(const edm::ParameterSet &config, edm::ConsumesCollector &iC)
+    : TrajectoryFactoryBase(config, iC), theUseAllFactories(config.getParameter<bool>("useAllFactories")) {
   vector<string> factoryNames = config.getParameter<vector<string>>("TrajectoryFactoryNames");
   for (auto const &factoryName : factoryNames) {
     // auto_ptr to avoid missing a delete due to throw...
@@ -68,7 +68,7 @@ CombinedTrajectoryFactory::CombinedTrajectoryFactory(const edm::ParameterSet &co
                                         << "separated strings, but is '" << factoryName << "'";
     }
     const edm::ParameterSet factoryCfg = config.getParameter<edm::ParameterSet>(namePset->At(1)->GetName());
-    theFactories.emplace_back(TrajectoryFactoryPlugin::get()->create(namePset->At(0)->GetName(), factoryCfg));
+    theFactories.emplace_back(TrajectoryFactoryPlugin::get()->create(namePset->At(0)->GetName(), factoryCfg, iC));
   }
 }
 

--- a/Alignment/ReferenceTrajectories/plugins/CombinedTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/CombinedTrajectoryFactory.cc
@@ -28,12 +28,14 @@ public:
 
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
                                                    const ConstTrajTrackPairCollection &tracks,
-                                                   const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const override;
+                                                   const reco::BeamSpot &beamSpot,
+                                                   edm::ConsumesCollector &iC) const override;
 
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
                                                    const ConstTrajTrackPairCollection &tracks,
                                                    const ExternalPredictionCollection &external,
-                                                   const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const override;
+                                                   const reco::BeamSpot &beamSpot,
+                                                   edm::ConsumesCollector &iC) const override;
 
   CombinedTrajectoryFactory *clone() const override { return new CombinedTrajectoryFactory(*this); }
 
@@ -75,7 +77,10 @@ CombinedTrajectoryFactory::CombinedTrajectoryFactory(const edm::ParameterSet &co
 CombinedTrajectoryFactory::~CombinedTrajectoryFactory(void) {}
 
 const CombinedTrajectoryFactory::ReferenceTrajectoryCollection CombinedTrajectoryFactory::trajectories(
-    const edm::EventSetup &setup, const ConstTrajTrackPairCollection &tracks, const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const {
+    const edm::EventSetup &setup,
+    const ConstTrajTrackPairCollection &tracks,
+    const reco::BeamSpot &beamSpot,
+    edm::ConsumesCollector &iC) const {
   ReferenceTrajectoryCollection trajectories;
   ReferenceTrajectoryCollection tmpTrajectories;  // outside loop for efficiency
 
@@ -94,7 +99,8 @@ const CombinedTrajectoryFactory::ReferenceTrajectoryCollection CombinedTrajector
     const edm::EventSetup &setup,
     const ConstTrajTrackPairCollection &tracks,
     const ExternalPredictionCollection &external,
-    const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const {
+    const reco::BeamSpot &beamSpot,
+    edm::ConsumesCollector &iC) const {
   ReferenceTrajectoryCollection trajectories;
   ReferenceTrajectoryCollection tmpTrajectories;  // outside loop for efficiency
 

--- a/Alignment/ReferenceTrajectories/plugins/CombinedTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/CombinedTrajectoryFactory.cc
@@ -28,14 +28,12 @@ public:
 
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
                                                    const ConstTrajTrackPairCollection &tracks,
-                                                   const reco::BeamSpot &beamSpot,
-                                                   edm::ConsumesCollector &iC) const override;
+                                                   const reco::BeamSpot &beamSpot) const override;
 
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
                                                    const ConstTrajTrackPairCollection &tracks,
                                                    const ExternalPredictionCollection &external,
-                                                   const reco::BeamSpot &beamSpot,
-                                                   edm::ConsumesCollector &iC) const override;
+                                                   const reco::BeamSpot &beamSpot) const override;
 
   CombinedTrajectoryFactory *clone() const override { return new CombinedTrajectoryFactory(*this); }
 
@@ -79,13 +77,12 @@ CombinedTrajectoryFactory::~CombinedTrajectoryFactory(void) {}
 const CombinedTrajectoryFactory::ReferenceTrajectoryCollection CombinedTrajectoryFactory::trajectories(
     const edm::EventSetup &setup,
     const ConstTrajTrackPairCollection &tracks,
-    const reco::BeamSpot &beamSpot,
-    edm::ConsumesCollector &iC) const {
+    const reco::BeamSpot &beamSpot) const {
   ReferenceTrajectoryCollection trajectories;
   ReferenceTrajectoryCollection tmpTrajectories;  // outside loop for efficiency
 
   for (auto const &factory : theFactories) {
-    tmpTrajectories = factory->trajectories(setup, tracks, beamSpot, iC);
+    tmpTrajectories = factory->trajectories(setup, tracks, beamSpot);
     trajectories.insert(trajectories.end(), tmpTrajectories.begin(), tmpTrajectories.end());
 
     if (!theUseAllFactories && !trajectories.empty())
@@ -99,13 +96,12 @@ const CombinedTrajectoryFactory::ReferenceTrajectoryCollection CombinedTrajector
     const edm::EventSetup &setup,
     const ConstTrajTrackPairCollection &tracks,
     const ExternalPredictionCollection &external,
-    const reco::BeamSpot &beamSpot,
-    edm::ConsumesCollector &iC) const {
+    const reco::BeamSpot &beamSpot) const {
   ReferenceTrajectoryCollection trajectories;
   ReferenceTrajectoryCollection tmpTrajectories;  // outside loop for efficiency
 
   for (auto const &factory : theFactories) {
-    tmpTrajectories = factory->trajectories(setup, tracks, external, beamSpot, iC);
+    tmpTrajectories = factory->trajectories(setup, tracks, external, beamSpot);
     trajectories.insert(trajectories.end(), tmpTrajectories.begin(), tmpTrajectories.end());
 
     if (!theUseAllFactories && !trajectories.empty())

--- a/Alignment/ReferenceTrajectories/plugins/CombinedTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/CombinedTrajectoryFactory.cc
@@ -75,9 +75,7 @@ CombinedTrajectoryFactory::CombinedTrajectoryFactory(const edm::ParameterSet &co
 CombinedTrajectoryFactory::~CombinedTrajectoryFactory(void) {}
 
 const CombinedTrajectoryFactory::ReferenceTrajectoryCollection CombinedTrajectoryFactory::trajectories(
-    const edm::EventSetup &setup,
-    const ConstTrajTrackPairCollection &tracks,
-    const reco::BeamSpot &beamSpot) const {
+    const edm::EventSetup &setup, const ConstTrajTrackPairCollection &tracks, const reco::BeamSpot &beamSpot) const {
   ReferenceTrajectoryCollection trajectories;
   ReferenceTrajectoryCollection tmpTrajectories;  // outside loop for efficiency
 

--- a/Alignment/ReferenceTrajectories/plugins/CombinedTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/CombinedTrajectoryFactory.cc
@@ -28,12 +28,12 @@ public:
 
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
                                                    const ConstTrajTrackPairCollection &tracks,
-                                                   const reco::BeamSpot &beamSpot) const override;
+                                                   const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const override;
 
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
                                                    const ConstTrajTrackPairCollection &tracks,
                                                    const ExternalPredictionCollection &external,
-                                                   const reco::BeamSpot &beamSpot) const override;
+                                                   const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const override;
 
   CombinedTrajectoryFactory *clone() const override { return new CombinedTrajectoryFactory(*this); }
 
@@ -75,12 +75,12 @@ CombinedTrajectoryFactory::CombinedTrajectoryFactory(const edm::ParameterSet &co
 CombinedTrajectoryFactory::~CombinedTrajectoryFactory(void) {}
 
 const CombinedTrajectoryFactory::ReferenceTrajectoryCollection CombinedTrajectoryFactory::trajectories(
-    const edm::EventSetup &setup, const ConstTrajTrackPairCollection &tracks, const reco::BeamSpot &beamSpot) const {
+    const edm::EventSetup &setup, const ConstTrajTrackPairCollection &tracks, const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const {
   ReferenceTrajectoryCollection trajectories;
   ReferenceTrajectoryCollection tmpTrajectories;  // outside loop for efficiency
 
   for (auto const &factory : theFactories) {
-    tmpTrajectories = factory->trajectories(setup, tracks, beamSpot);
+    tmpTrajectories = factory->trajectories(setup, tracks, beamSpot, iC);
     trajectories.insert(trajectories.end(), tmpTrajectories.begin(), tmpTrajectories.end());
 
     if (!theUseAllFactories && !trajectories.empty())
@@ -94,12 +94,12 @@ const CombinedTrajectoryFactory::ReferenceTrajectoryCollection CombinedTrajector
     const edm::EventSetup &setup,
     const ConstTrajTrackPairCollection &tracks,
     const ExternalPredictionCollection &external,
-    const reco::BeamSpot &beamSpot) const {
+    const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const {
   ReferenceTrajectoryCollection trajectories;
   ReferenceTrajectoryCollection tmpTrajectories;  // outside loop for efficiency
 
   for (auto const &factory : theFactories) {
-    tmpTrajectories = factory->trajectories(setup, tracks, external, beamSpot);
+    tmpTrajectories = factory->trajectories(setup, tracks, external, beamSpot, iC);
     trajectories.insert(trajectories.end(), tmpTrajectories.begin(), tmpTrajectories.end());
 
     if (!theUseAllFactories && !trajectories.empty())

--- a/Alignment/ReferenceTrajectories/plugins/DualBzeroTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/DualBzeroTrajectoryFactory.cc
@@ -23,14 +23,12 @@ public:
   /// Produce the reference trajectories.
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
                                                    const ConstTrajTrackPairCollection &tracks,
-                                                   const reco::BeamSpot &beamSpot,
-                                                   edm::ConsumesCollector &iC) const override;
+                                                   const reco::BeamSpot &beamSpot) const override;
 
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
                                                    const ConstTrajTrackPairCollection &tracks,
                                                    const ExternalPredictionCollection &external,
-                                                   const reco::BeamSpot &beamSpot,
-                                                   edm::ConsumesCollector &iC) const override;
+                                                   const reco::BeamSpot &beamSpot) const override;
 
   DualBzeroTrajectoryFactory *clone() const override { return new DualBzeroTrajectoryFactory(*this); }
 
@@ -66,8 +64,7 @@ DualBzeroTrajectoryFactory::~DualBzeroTrajectoryFactory(void) {}
 const DualBzeroTrajectoryFactory::ReferenceTrajectoryCollection DualBzeroTrajectoryFactory::trajectories(
     const edm::EventSetup &setup,
     const ConstTrajTrackPairCollection &tracks,
-    const reco::BeamSpot &beamSpot,
-    edm::ConsumesCollector &iC) const {
+    const reco::BeamSpot &beamSpot) const {
   ReferenceTrajectoryCollection trajectories;
 
   const MagneticField *magneticField = &setup.getData(m_MagFieldToken);
@@ -97,8 +94,7 @@ const DualBzeroTrajectoryFactory::ReferenceTrajectoryCollection DualBzeroTraject
     const edm::EventSetup &setup,
     const ConstTrajTrackPairCollection &tracks,
     const ExternalPredictionCollection &external,
-    const reco::BeamSpot &beamSpot,
-    edm::ConsumesCollector &iC) const {
+    const reco::BeamSpot &beamSpot) const {
   ReferenceTrajectoryCollection trajectories;
 
   if (tracks.size() != external.size()) {

--- a/Alignment/ReferenceTrajectories/plugins/DualBzeroTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/DualBzeroTrajectoryFactory.cc
@@ -62,9 +62,7 @@ DualBzeroTrajectoryFactory::DualBzeroTrajectoryFactory(const edm::ParameterSet &
 DualBzeroTrajectoryFactory::~DualBzeroTrajectoryFactory(void) {}
 
 const DualBzeroTrajectoryFactory::ReferenceTrajectoryCollection DualBzeroTrajectoryFactory::trajectories(
-    const edm::EventSetup &setup,
-    const ConstTrajTrackPairCollection &tracks,
-    const reco::BeamSpot &beamSpot) const {
+    const edm::EventSetup &setup, const ConstTrajTrackPairCollection &tracks, const reco::BeamSpot &beamSpot) const {
   ReferenceTrajectoryCollection trajectories;
 
   const MagneticField *magneticField = &setup.getData(m_MagFieldToken);

--- a/Alignment/ReferenceTrajectories/plugins/DualBzeroTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/DualBzeroTrajectoryFactory.cc
@@ -16,8 +16,9 @@
 
 class DualBzeroTrajectoryFactory : public TrajectoryFactoryBase {
 public:
-  DualBzeroTrajectoryFactory(const edm::ParameterSet &config);
+  DualBzeroTrajectoryFactory(const edm::ParameterSet &config, edm::ConsumesCollector &iC);
   ~DualBzeroTrajectoryFactory() override;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> m_MagFieldToken;
 
   /// Produce the reference trajectories.
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
@@ -52,8 +53,9 @@ protected:
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
-DualBzeroTrajectoryFactory::DualBzeroTrajectoryFactory(const edm::ParameterSet &config)
-    : TrajectoryFactoryBase(config) {
+DualBzeroTrajectoryFactory::DualBzeroTrajectoryFactory(const edm::ParameterSet &config, edm::ConsumesCollector &iC)
+    : TrajectoryFactoryBase(config, iC),m_MagFieldToken(iC.esConsumes())
+ {
   theMass = config.getParameter<double>("ParticleMass");
   theMomentumEstimate = config.getParameter<double>("MomentumEstimate");
 }
@@ -64,8 +66,7 @@ const DualBzeroTrajectoryFactory::ReferenceTrajectoryCollection DualBzeroTraject
     const edm::EventSetup &setup, const ConstTrajTrackPairCollection &tracks, const reco::BeamSpot &beamSpot) const {
   ReferenceTrajectoryCollection trajectories;
 
-  edm::ESHandle<MagneticField> magneticField;
-  setup.get<IdealMagneticFieldRecord>().get(magneticField);
+  const MagneticField* magneticField = &setup.getData(m_MagFieldToken);
 
   ConstTrajTrackPairCollection::const_iterator itTracks = tracks.begin();
 
@@ -78,7 +79,7 @@ const DualBzeroTrajectoryFactory::ReferenceTrajectoryCollection DualBzeroTraject
       config.includeAPEs = includeAPEs_;
       config.allowZeroMaterial = allowZeroMaterial_;
       ReferenceTrajectoryPtr ptr(new DualBzeroReferenceTrajectory(
-          input.refTsos, input.fwdRecHits, input.bwdRecHits, magneticField.product(), beamSpot, config));
+          input.refTsos, input.fwdRecHits, input.bwdRecHits, magneticField, beamSpot, config));
       trajectories.push_back(ptr);
     }
 
@@ -103,8 +104,7 @@ const DualBzeroTrajectoryFactory::ReferenceTrajectoryCollection DualBzeroTraject
     return trajectories;
   }
 
-  edm::ESHandle<MagneticField> magneticField;
-  setup.get<IdealMagneticFieldRecord>().get(magneticField);
+  const MagneticField* magneticField = &setup.getData(m_MagFieldToken);
 
   ConstTrajTrackPairCollection::const_iterator itTracks = tracks.begin();
   ExternalPredictionCollection::const_iterator itExternal = external.begin();
@@ -115,7 +115,7 @@ const DualBzeroTrajectoryFactory::ReferenceTrajectoryCollection DualBzeroTraject
     if (input.refTsos.isValid()) {
       if ((*itExternal).isValid()) {
         TrajectoryStateOnSurface propExternal =
-            propagateExternal(*itExternal, input.refTsos.surface(), magneticField.product());
+            propagateExternal(*itExternal, input.refTsos.surface(), magneticField);
 
         if (!propExternal.isValid())
           continue;
@@ -125,7 +125,7 @@ const DualBzeroTrajectoryFactory::ReferenceTrajectoryCollection DualBzeroTraject
         config.includeAPEs = includeAPEs_;
         config.allowZeroMaterial = allowZeroMaterial_;
         ReferenceTrajectoryPtr ptr(new DualBzeroReferenceTrajectory(
-            propExternal, input.fwdRecHits, input.bwdRecHits, magneticField.product(), beamSpot, config));
+            propExternal, input.fwdRecHits, input.bwdRecHits, magneticField, beamSpot, config));
 
         AlgebraicSymMatrix externalParamErrors(asHepMatrix<5>(propExternal.localError().matrix()));
         ptr->setParameterErrors(externalParamErrors.sub(2, 5));
@@ -136,7 +136,7 @@ const DualBzeroTrajectoryFactory::ReferenceTrajectoryCollection DualBzeroTraject
         config.includeAPEs = includeAPEs_;
         config.allowZeroMaterial = allowZeroMaterial_;
         ReferenceTrajectoryPtr ptr(new DualBzeroReferenceTrajectory(
-            input.refTsos, input.fwdRecHits, input.bwdRecHits, magneticField.product(), beamSpot, config));
+            input.refTsos, input.fwdRecHits, input.bwdRecHits, magneticField, beamSpot, config));
 
         trajectories.push_back(ptr);
       }

--- a/Alignment/ReferenceTrajectories/plugins/DualBzeroTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/DualBzeroTrajectoryFactory.cc
@@ -23,12 +23,14 @@ public:
   /// Produce the reference trajectories.
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
                                                    const ConstTrajTrackPairCollection &tracks,
-                                                   const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const override;
+                                                   const reco::BeamSpot &beamSpot,
+                                                   edm::ConsumesCollector &iC) const override;
 
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
                                                    const ConstTrajTrackPairCollection &tracks,
                                                    const ExternalPredictionCollection &external,
-                                                   const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const override;
+                                                   const reco::BeamSpot &beamSpot,
+                                                   edm::ConsumesCollector &iC) const override;
 
   DualBzeroTrajectoryFactory *clone() const override { return new DualBzeroTrajectoryFactory(*this); }
 
@@ -54,8 +56,7 @@ protected:
 ////////////////////////////////////////////////////////////////////////////////
 
 DualBzeroTrajectoryFactory::DualBzeroTrajectoryFactory(const edm::ParameterSet &config, edm::ConsumesCollector &iC)
-    : TrajectoryFactoryBase(config, iC),m_MagFieldToken(iC.esConsumes())
- {
+    : TrajectoryFactoryBase(config, iC), m_MagFieldToken(iC.esConsumes()) {
   theMass = config.getParameter<double>("ParticleMass");
   theMomentumEstimate = config.getParameter<double>("MomentumEstimate");
 }
@@ -63,10 +64,13 @@ DualBzeroTrajectoryFactory::DualBzeroTrajectoryFactory(const edm::ParameterSet &
 DualBzeroTrajectoryFactory::~DualBzeroTrajectoryFactory(void) {}
 
 const DualBzeroTrajectoryFactory::ReferenceTrajectoryCollection DualBzeroTrajectoryFactory::trajectories(
-    const edm::EventSetup &setup, const ConstTrajTrackPairCollection &tracks, const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const {
+    const edm::EventSetup &setup,
+    const ConstTrajTrackPairCollection &tracks,
+    const reco::BeamSpot &beamSpot,
+    edm::ConsumesCollector &iC) const {
   ReferenceTrajectoryCollection trajectories;
 
-  const MagneticField* magneticField = &setup.getData(m_MagFieldToken);
+  const MagneticField *magneticField = &setup.getData(m_MagFieldToken);
 
   ConstTrajTrackPairCollection::const_iterator itTracks = tracks.begin();
 
@@ -93,7 +97,8 @@ const DualBzeroTrajectoryFactory::ReferenceTrajectoryCollection DualBzeroTraject
     const edm::EventSetup &setup,
     const ConstTrajTrackPairCollection &tracks,
     const ExternalPredictionCollection &external,
-    const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const {
+    const reco::BeamSpot &beamSpot,
+    edm::ConsumesCollector &iC) const {
   ReferenceTrajectoryCollection trajectories;
 
   if (tracks.size() != external.size()) {
@@ -104,7 +109,7 @@ const DualBzeroTrajectoryFactory::ReferenceTrajectoryCollection DualBzeroTraject
     return trajectories;
   }
 
-  const MagneticField* magneticField = &setup.getData(m_MagFieldToken);
+  const MagneticField *magneticField = &setup.getData(m_MagFieldToken);
 
   ConstTrajTrackPairCollection::const_iterator itTracks = tracks.begin();
   ExternalPredictionCollection::const_iterator itExternal = external.begin();
@@ -114,8 +119,7 @@ const DualBzeroTrajectoryFactory::ReferenceTrajectoryCollection DualBzeroTraject
     // Check input: If all hits were rejected, the TSOS is initialized as invalid.
     if (input.refTsos.isValid()) {
       if ((*itExternal).isValid()) {
-        TrajectoryStateOnSurface propExternal =
-            propagateExternal(*itExternal, input.refTsos.surface(), magneticField);
+        TrajectoryStateOnSurface propExternal = propagateExternal(*itExternal, input.refTsos.surface(), magneticField);
 
         if (!propExternal.isValid())
           continue;

--- a/Alignment/ReferenceTrajectories/plugins/DualBzeroTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/DualBzeroTrajectoryFactory.cc
@@ -23,12 +23,12 @@ public:
   /// Produce the reference trajectories.
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
                                                    const ConstTrajTrackPairCollection &tracks,
-                                                   const reco::BeamSpot &beamSpot) const override;
+                                                   const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const override;
 
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
                                                    const ConstTrajTrackPairCollection &tracks,
                                                    const ExternalPredictionCollection &external,
-                                                   const reco::BeamSpot &beamSpot) const override;
+                                                   const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const override;
 
   DualBzeroTrajectoryFactory *clone() const override { return new DualBzeroTrajectoryFactory(*this); }
 
@@ -63,7 +63,7 @@ DualBzeroTrajectoryFactory::DualBzeroTrajectoryFactory(const edm::ParameterSet &
 DualBzeroTrajectoryFactory::~DualBzeroTrajectoryFactory(void) {}
 
 const DualBzeroTrajectoryFactory::ReferenceTrajectoryCollection DualBzeroTrajectoryFactory::trajectories(
-    const edm::EventSetup &setup, const ConstTrajTrackPairCollection &tracks, const reco::BeamSpot &beamSpot) const {
+    const edm::EventSetup &setup, const ConstTrajTrackPairCollection &tracks, const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const {
   ReferenceTrajectoryCollection trajectories;
 
   const MagneticField* magneticField = &setup.getData(m_MagFieldToken);
@@ -93,7 +93,7 @@ const DualBzeroTrajectoryFactory::ReferenceTrajectoryCollection DualBzeroTraject
     const edm::EventSetup &setup,
     const ConstTrajTrackPairCollection &tracks,
     const ExternalPredictionCollection &external,
-    const reco::BeamSpot &beamSpot) const {
+    const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const {
   ReferenceTrajectoryCollection trajectories;
 
   if (tracks.size() != external.size()) {

--- a/Alignment/ReferenceTrajectories/plugins/DualTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/DualTrajectoryFactory.cc
@@ -23,12 +23,14 @@ public:
   /// Produce the reference trajectories.
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
                                                    const ConstTrajTrackPairCollection &tracks,
-                                                   const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const override;
+                                                   const reco::BeamSpot &beamSpot,
+                                                   edm::ConsumesCollector &iC) const override;
 
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
                                                    const ConstTrajTrackPairCollection &tracks,
                                                    const ExternalPredictionCollection &external,
-                                                   const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const override;
+                                                   const reco::BeamSpot &beamSpot,
+                                                   edm::ConsumesCollector &iC) const override;
 
   DualTrajectoryFactory *clone() const override { return new DualTrajectoryFactory(*this); }
 
@@ -53,7 +55,9 @@ protected:
 ////////////////////////////////////////////////////////////////////////////////
 
 DualTrajectoryFactory::DualTrajectoryFactory(const edm::ParameterSet &config, edm::ConsumesCollector &iC)
-    : TrajectoryFactoryBase(config, iC),m_MagFieldToken(iC.esConsumes()),theMass(config.getParameter<double>("ParticleMass")) {
+    : TrajectoryFactoryBase(config, iC),
+      m_MagFieldToken(iC.esConsumes()),
+      theMass(config.getParameter<double>("ParticleMass")) {
   edm::LogInfo("Alignment") << "@SUB=DualTrajectoryFactory"
                             << "mass: " << theMass;
 }
@@ -61,10 +65,13 @@ DualTrajectoryFactory::DualTrajectoryFactory(const edm::ParameterSet &config, ed
 DualTrajectoryFactory::~DualTrajectoryFactory(void) {}
 
 const DualTrajectoryFactory::ReferenceTrajectoryCollection DualTrajectoryFactory::trajectories(
-    const edm::EventSetup &setup, const ConstTrajTrackPairCollection &tracks, const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const {
+    const edm::EventSetup &setup,
+    const ConstTrajTrackPairCollection &tracks,
+    const reco::BeamSpot &beamSpot,
+    edm::ConsumesCollector &iC) const {
   ReferenceTrajectoryCollection trajectories;
 
-  const MagneticField* magneticField = &setup.getData(m_MagFieldToken);
+  const MagneticField *magneticField = &setup.getData(m_MagFieldToken);
 
   if (magneticField->inTesla(GlobalPoint(0., 0., 0.)).mag2() < 1.e-6) {
     edm::LogWarning("Alignment") << "@SUB=DualTrajectoryFactory::trajectories"
@@ -98,7 +105,8 @@ const DualTrajectoryFactory::ReferenceTrajectoryCollection DualTrajectoryFactory
     const edm::EventSetup &setup,
     const ConstTrajTrackPairCollection &tracks,
     const ExternalPredictionCollection &external,
-    const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const {
+    const reco::BeamSpot &beamSpot,
+    edm::ConsumesCollector &iC) const {
   ReferenceTrajectoryCollection trajectories;
 
   if (tracks.size() != external.size()) {
@@ -108,7 +116,7 @@ const DualTrajectoryFactory::ReferenceTrajectoryCollection DualTrajectoryFactory
         << "\tnumber of tracks = " << tracks.size() << "\tnumber of external predictions = " << external.size();
     return trajectories;
   }
-  const MagneticField* magneticField = &setup.getData(m_MagFieldToken);
+  const MagneticField *magneticField = &setup.getData(m_MagFieldToken);
 
   if (magneticField->inTesla(GlobalPoint(0., 0., 0.)).mag2() < 1.e-6) {
     edm::LogWarning("Alignment") << "@SUB=DualTrajectoryFactory::trajectories"
@@ -125,8 +133,7 @@ const DualTrajectoryFactory::ReferenceTrajectoryCollection DualTrajectoryFactory
     // Check input: If all hits were rejected, the TSOS is initialized as invalid.
     if (input.refTsos.isValid()) {
       if ((*itExternal).isValid()) {
-        TrajectoryStateOnSurface propExternal =
-            propagateExternal(*itExternal, input.refTsos.surface(), magneticField);
+        TrajectoryStateOnSurface propExternal = propagateExternal(*itExternal, input.refTsos.surface(), magneticField);
 
         if (!propExternal.isValid())
           continue;

--- a/Alignment/ReferenceTrajectories/plugins/DualTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/DualTrajectoryFactory.cc
@@ -23,12 +23,12 @@ public:
   /// Produce the reference trajectories.
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
                                                    const ConstTrajTrackPairCollection &tracks,
-                                                   const reco::BeamSpot &beamSpot) const override;
+                                                   const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const override;
 
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
                                                    const ConstTrajTrackPairCollection &tracks,
                                                    const ExternalPredictionCollection &external,
-                                                   const reco::BeamSpot &beamSpot) const override;
+                                                   const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const override;
 
   DualTrajectoryFactory *clone() const override { return new DualTrajectoryFactory(*this); }
 
@@ -61,7 +61,7 @@ DualTrajectoryFactory::DualTrajectoryFactory(const edm::ParameterSet &config, ed
 DualTrajectoryFactory::~DualTrajectoryFactory(void) {}
 
 const DualTrajectoryFactory::ReferenceTrajectoryCollection DualTrajectoryFactory::trajectories(
-    const edm::EventSetup &setup, const ConstTrajTrackPairCollection &tracks, const reco::BeamSpot &beamSpot) const {
+    const edm::EventSetup &setup, const ConstTrajTrackPairCollection &tracks, const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const {
   ReferenceTrajectoryCollection trajectories;
 
   const MagneticField* magneticField = &setup.getData(m_MagFieldToken);
@@ -98,7 +98,7 @@ const DualTrajectoryFactory::ReferenceTrajectoryCollection DualTrajectoryFactory
     const edm::EventSetup &setup,
     const ConstTrajTrackPairCollection &tracks,
     const ExternalPredictionCollection &external,
-    const reco::BeamSpot &beamSpot) const {
+    const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const {
   ReferenceTrajectoryCollection trajectories;
 
   if (tracks.size() != external.size()) {

--- a/Alignment/ReferenceTrajectories/plugins/DualTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/DualTrajectoryFactory.cc
@@ -63,9 +63,7 @@ DualTrajectoryFactory::DualTrajectoryFactory(const edm::ParameterSet &config, ed
 DualTrajectoryFactory::~DualTrajectoryFactory(void) {}
 
 const DualTrajectoryFactory::ReferenceTrajectoryCollection DualTrajectoryFactory::trajectories(
-    const edm::EventSetup &setup,
-    const ConstTrajTrackPairCollection &tracks,
-    const reco::BeamSpot &beamSpot) const {
+    const edm::EventSetup &setup, const ConstTrajTrackPairCollection &tracks, const reco::BeamSpot &beamSpot) const {
   ReferenceTrajectoryCollection trajectories;
 
   const MagneticField *magneticField = &setup.getData(m_MagFieldToken);

--- a/Alignment/ReferenceTrajectories/plugins/DualTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/DualTrajectoryFactory.cc
@@ -23,14 +23,12 @@ public:
   /// Produce the reference trajectories.
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
                                                    const ConstTrajTrackPairCollection &tracks,
-                                                   const reco::BeamSpot &beamSpot,
-                                                   edm::ConsumesCollector &iC) const override;
+                                                   const reco::BeamSpot &beamSpot) const override;
 
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
                                                    const ConstTrajTrackPairCollection &tracks,
                                                    const ExternalPredictionCollection &external,
-                                                   const reco::BeamSpot &beamSpot,
-                                                   edm::ConsumesCollector &iC) const override;
+                                                   const reco::BeamSpot &beamSpot) const override;
 
   DualTrajectoryFactory *clone() const override { return new DualTrajectoryFactory(*this); }
 
@@ -67,8 +65,7 @@ DualTrajectoryFactory::~DualTrajectoryFactory(void) {}
 const DualTrajectoryFactory::ReferenceTrajectoryCollection DualTrajectoryFactory::trajectories(
     const edm::EventSetup &setup,
     const ConstTrajTrackPairCollection &tracks,
-    const reco::BeamSpot &beamSpot,
-    edm::ConsumesCollector &iC) const {
+    const reco::BeamSpot &beamSpot) const {
   ReferenceTrajectoryCollection trajectories;
 
   const MagneticField *magneticField = &setup.getData(m_MagFieldToken);
@@ -105,8 +102,7 @@ const DualTrajectoryFactory::ReferenceTrajectoryCollection DualTrajectoryFactory
     const edm::EventSetup &setup,
     const ConstTrajTrackPairCollection &tracks,
     const ExternalPredictionCollection &external,
-    const reco::BeamSpot &beamSpot,
-    edm::ConsumesCollector &iC) const {
+    const reco::BeamSpot &beamSpot) const {
   ReferenceTrajectoryCollection trajectories;
 
   if (tracks.size() != external.size()) {

--- a/Alignment/ReferenceTrajectories/plugins/DualTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/DualTrajectoryFactory.cc
@@ -16,8 +16,9 @@
 
 class DualTrajectoryFactory : public TrajectoryFactoryBase {
 public:
-  DualTrajectoryFactory(const edm::ParameterSet &config);
+  DualTrajectoryFactory(const edm::ParameterSet &config, edm::ConsumesCollector &iC);
   ~DualTrajectoryFactory() override;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> m_MagFieldToken;
 
   /// Produce the reference trajectories.
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
@@ -51,8 +52,8 @@ protected:
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
-DualTrajectoryFactory::DualTrajectoryFactory(const edm::ParameterSet &config)
-    : TrajectoryFactoryBase(config), theMass(config.getParameter<double>("ParticleMass")) {
+DualTrajectoryFactory::DualTrajectoryFactory(const edm::ParameterSet &config, edm::ConsumesCollector &iC)
+    : TrajectoryFactoryBase(config, iC),m_MagFieldToken(iC.esConsumes()),theMass(config.getParameter<double>("ParticleMass")) {
   edm::LogInfo("Alignment") << "@SUB=DualTrajectoryFactory"
                             << "mass: " << theMass;
 }
@@ -63,8 +64,8 @@ const DualTrajectoryFactory::ReferenceTrajectoryCollection DualTrajectoryFactory
     const edm::EventSetup &setup, const ConstTrajTrackPairCollection &tracks, const reco::BeamSpot &beamSpot) const {
   ReferenceTrajectoryCollection trajectories;
 
-  edm::ESHandle<MagneticField> magneticField;
-  setup.get<IdealMagneticFieldRecord>().get(magneticField);
+  const MagneticField* magneticField = &setup.getData(m_MagFieldToken);
+
   if (magneticField->inTesla(GlobalPoint(0., 0., 0.)).mag2() < 1.e-6) {
     edm::LogWarning("Alignment") << "@SUB=DualTrajectoryFactory::trajectories"
                                  << "B-field in z is " << magneticField->inTesla(GlobalPoint(0., 0., 0.)).z()
@@ -83,7 +84,7 @@ const DualTrajectoryFactory::ReferenceTrajectoryCollection DualTrajectoryFactory
       config.includeAPEs = includeAPEs_;
       config.allowZeroMaterial = allowZeroMaterial_;
       ReferenceTrajectoryPtr ptr(new DualReferenceTrajectory(
-          input.refTsos, input.fwdRecHits, input.bwdRecHits, magneticField.product(), beamSpot, config));
+          input.refTsos, input.fwdRecHits, input.bwdRecHits, magneticField, beamSpot, config));
       trajectories.push_back(ptr);
     }
 
@@ -107,9 +108,8 @@ const DualTrajectoryFactory::ReferenceTrajectoryCollection DualTrajectoryFactory
         << "\tnumber of tracks = " << tracks.size() << "\tnumber of external predictions = " << external.size();
     return trajectories;
   }
+  const MagneticField* magneticField = &setup.getData(m_MagFieldToken);
 
-  edm::ESHandle<MagneticField> magneticField;
-  setup.get<IdealMagneticFieldRecord>().get(magneticField);
   if (magneticField->inTesla(GlobalPoint(0., 0., 0.)).mag2() < 1.e-6) {
     edm::LogWarning("Alignment") << "@SUB=DualTrajectoryFactory::trajectories"
                                  << "B-field in z is " << magneticField->inTesla(GlobalPoint(0., 0., 0.)).z()
@@ -126,7 +126,7 @@ const DualTrajectoryFactory::ReferenceTrajectoryCollection DualTrajectoryFactory
     if (input.refTsos.isValid()) {
       if ((*itExternal).isValid()) {
         TrajectoryStateOnSurface propExternal =
-            propagateExternal(*itExternal, input.refTsos.surface(), magneticField.product());
+            propagateExternal(*itExternal, input.refTsos.surface(), magneticField);
 
         if (!propExternal.isValid())
           continue;
@@ -136,7 +136,7 @@ const DualTrajectoryFactory::ReferenceTrajectoryCollection DualTrajectoryFactory
         config.includeAPEs = includeAPEs_;
         config.allowZeroMaterial = allowZeroMaterial_;
         ReferenceTrajectoryPtr ptr(new DualReferenceTrajectory(
-            propExternal, input.fwdRecHits, input.bwdRecHits, magneticField.product(), beamSpot, config));
+            propExternal, input.fwdRecHits, input.bwdRecHits, magneticField, beamSpot, config));
 
         AlgebraicSymMatrix externalParamErrors(asHepMatrix<5>(propExternal.localError().matrix()));
         ptr->setParameterErrors(externalParamErrors);
@@ -147,7 +147,7 @@ const DualTrajectoryFactory::ReferenceTrajectoryCollection DualTrajectoryFactory
         config.includeAPEs = includeAPEs_;
         config.allowZeroMaterial = allowZeroMaterial_;
         ReferenceTrajectoryPtr ptr(new DualReferenceTrajectory(
-            input.refTsos, input.fwdRecHits, input.bwdRecHits, magneticField.product(), beamSpot, config));
+            input.refTsos, input.fwdRecHits, input.bwdRecHits, magneticField, beamSpot, config));
         trajectories.push_back(ptr);
       }
     }

--- a/Alignment/ReferenceTrajectories/plugins/ReferenceTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/ReferenceTrajectoryFactory.cc
@@ -57,16 +57,12 @@ ReferenceTrajectoryFactory::ReferenceTrajectoryFactory(const edm::ParameterSet &
       theMass(config.getParameter<double>("ParticleMass")),
       theUseBzeroIfFieldOff(config.getParameter<bool>("UseBzeroIfFieldOff")),
       theBzeroFactory(nullptr){
-    //edm::ParameterSet pset,
-//    pset(config),
-    // next two lines not needed, but may help to better understand log file:
-//    pset.eraseSimpleParameter("TrajectoryFactoryName"),
-//    pset.addParameter("TrajectoryFactoryName", std::string("BzeroReferenceTrajectoryFactory")),
-//    pset.addParameter("MomentumEstimate", myPset.getParameter<double>("MomentumEstimateFieldOff")),
-//    theBzeroFactory = new BzeroReferenceTrajectoryFactory(pset, iC){
   edm::LogInfo("Alignment") << "@SUB=ReferenceTrajectoryFactory"
                             << "mass: " << theMass
                             << "\nusing Bzero if |B| = 0: " << (theUseBzeroIfFieldOff ? "yes" : "no");
+    // We take the config of this factory, copy it, replace its name and add 
+    // the momentum parameter as expected by BzeroReferenceTrajectoryFactory and create it: 
+    //
     edm::ParameterSet pset;
     pset.copyForModify(config);
     // next two lines not needed, but may help to better understand log file:
@@ -186,15 +182,6 @@ const TrajectoryFactoryBase *ReferenceTrajectoryFactory::bzeroFactory() const {
     const edm::ParameterSet &myPset = this->configuration();
     edm::LogInfo("Alignment") << "@SUB=ReferenceTrajectoryFactory::bzeroFactory"
                               << "Using BzeroReferenceTrajectoryFactory for some (all?) events.";
-    // We take the config of this factory, copy it, replace its name and add
-    // the momentum parameter as expected by BzeroReferenceTrajectoryFactory and create it:
-    //edm::ParameterSet pset;
-    //pset.copyForModify(myPset);
-    // next two lines not needed, but may help to better understand log file:
-    //pset.eraseSimpleParameter("TrajectoryFactoryName");
-    //pset.addParameter("TrajectoryFactoryName", std::string("BzeroReferenceTrajectoryFactory"));
-    //pset.addParameter("MomentumEstimate", myPset.getParameter<double>("MomentumEstimateFieldOff"));
-    //theBzeroFactory = new BzeroReferenceTrajectoryFactory(pset, iC);
   }
   return theBzeroFactory;
 }

--- a/Alignment/ReferenceTrajectories/plugins/ReferenceTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/ReferenceTrajectoryFactory.cc
@@ -44,7 +44,6 @@ protected:
   bool theUseBzeroIfFieldOff;
   //edm::ParameterSet pset;
   mutable const TrajectoryFactoryBase *theBzeroFactory;
-
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -56,23 +55,20 @@ ReferenceTrajectoryFactory::ReferenceTrajectoryFactory(const edm::ParameterSet &
       m_MagFieldToken(iC.esConsumes()),
       theMass(config.getParameter<double>("ParticleMass")),
       theUseBzeroIfFieldOff(config.getParameter<bool>("UseBzeroIfFieldOff")),
-      theBzeroFactory(nullptr){
+      theBzeroFactory(nullptr) {
   edm::LogInfo("Alignment") << "@SUB=ReferenceTrajectoryFactory"
                             << "mass: " << theMass
                             << "\nusing Bzero if |B| = 0: " << (theUseBzeroIfFieldOff ? "yes" : "no");
-    // We take the config of this factory, copy it, replace its name and add 
-    // the momentum parameter as expected by BzeroReferenceTrajectoryFactory and create it: 
-    //
-    edm::ParameterSet pset;
-    pset.copyForModify(config);
-    // next two lines not needed, but may help to better understand log file:
-    pset.eraseSimpleParameter("TrajectoryFactoryName");
-    pset.addParameter("TrajectoryFactoryName", std::string("BzeroReferenceTrajectoryFactory"));
-    pset.addParameter("MomentumEstimate", config.getParameter<double>("MomentumEstimateFieldOff"));
-    theBzeroFactory = new BzeroReferenceTrajectoryFactory(pset, iC);
-
-
-
+  // We take the config of this factory, copy it, replace its name and add
+  // the momentum parameter as expected by BzeroReferenceTrajectoryFactory and create it:
+  //
+  edm::ParameterSet pset;
+  pset.copyForModify(config);
+  // next two lines not needed, but may help to better understand log file:
+  pset.eraseSimpleParameter("TrajectoryFactoryName");
+  pset.addParameter("TrajectoryFactoryName", std::string("BzeroReferenceTrajectoryFactory"));
+  pset.addParameter("MomentumEstimate", config.getParameter<double>("MomentumEstimateFieldOff"));
+  theBzeroFactory = new BzeroReferenceTrajectoryFactory(pset, iC);
 }
 
 ReferenceTrajectoryFactory::ReferenceTrajectoryFactory(const ReferenceTrajectoryFactory &other)
@@ -85,9 +81,7 @@ ReferenceTrajectoryFactory::ReferenceTrajectoryFactory(const ReferenceTrajectory
 ReferenceTrajectoryFactory::~ReferenceTrajectoryFactory(void) { delete theBzeroFactory; }
 
 const ReferenceTrajectoryFactory::ReferenceTrajectoryCollection ReferenceTrajectoryFactory::trajectories(
-    const edm::EventSetup &setup,
-    const ConstTrajTrackPairCollection &tracks,
-    const reco::BeamSpot &beamSpot) const {
+    const edm::EventSetup &setup, const ConstTrajTrackPairCollection &tracks, const reco::BeamSpot &beamSpot) const {
   const MagneticField *magneticField = &setup.getData(m_MagFieldToken);
 
   if (theUseBzeroIfFieldOff && magneticField->inTesla(GlobalPoint(0., 0., 0.)).mag2() < 1.e-6) {

--- a/Alignment/ReferenceTrajectories/plugins/ReferenceTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/ReferenceTrajectoryFactory.cc
@@ -27,19 +27,20 @@ public:
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
                                                    const ConstTrajTrackPairCollection &tracks,
                                                    const reco::BeamSpot &beamSpot,
-						   edm::ConsumesCollector &iC) const override;
+                                                   edm::ConsumesCollector &iC) const override;
 
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
                                                    const ConstTrajTrackPairCollection &tracks,
                                                    const ExternalPredictionCollection &external,
-                                                   const reco::BeamSpot &beamSpot,edm::ConsumesCollector &iC) const override;
+                                                   const reco::BeamSpot &beamSpot,
+                                                   edm::ConsumesCollector &iC) const override;
 
   ReferenceTrajectoryFactory *clone() const override { return new ReferenceTrajectoryFactory(*this); }
 
 protected:
   ReferenceTrajectoryFactory(const ReferenceTrajectoryFactory &other);
   const TrajectoryFactoryBase *bzeroFactory() const;
-  const TrajectoryFactoryBase *bzeroFactory( edm::ConsumesCollector &iC) const;
+  const TrajectoryFactoryBase *bzeroFactory(edm::ConsumesCollector &iC) const;
 
   double theMass;
   bool theUseBzeroIfFieldOff;
@@ -51,7 +52,7 @@ protected:
 ////////////////////////////////////////////////////////////////////////////////
 
 ReferenceTrajectoryFactory::ReferenceTrajectoryFactory(const edm::ParameterSet &config, edm::ConsumesCollector &iC)
-    : TrajectoryFactoryBase(config,iC),
+    : TrajectoryFactoryBase(config, iC),
       m_MagFieldToken(iC.esConsumes()),
       theMass(config.getParameter<double>("ParticleMass")),
       theUseBzeroIfFieldOff(config.getParameter<bool>("UseBzeroIfFieldOff")),
@@ -71,8 +72,11 @@ ReferenceTrajectoryFactory::ReferenceTrajectoryFactory(const ReferenceTrajectory
 ReferenceTrajectoryFactory::~ReferenceTrajectoryFactory(void) { delete theBzeroFactory; }
 
 const ReferenceTrajectoryFactory::ReferenceTrajectoryCollection ReferenceTrajectoryFactory::trajectories(
-    const edm::EventSetup &setup, const ConstTrajTrackPairCollection &tracks, const reco::BeamSpot &beamSpot,edm::ConsumesCollector &iC) const {
-  const MagneticField* magneticField = &setup.getData(m_MagFieldToken);
+    const edm::EventSetup &setup,
+    const ConstTrajTrackPairCollection &tracks,
+    const reco::BeamSpot &beamSpot,
+    edm::ConsumesCollector &iC) const {
+  const MagneticField *magneticField = &setup.getData(m_MagFieldToken);
 
   if (theUseBzeroIfFieldOff && magneticField->inTesla(GlobalPoint(0., 0., 0.)).mag2() < 1.e-6) {
     return this->bzeroFactory(iC)->trajectories(setup, tracks, beamSpot, iC);
@@ -93,8 +97,8 @@ const ReferenceTrajectoryFactory::ReferenceTrajectoryCollection ReferenceTraject
       config.allowZeroMaterial = allowZeroMaterial_;
       // set the flag for reversing the RecHits to false, since they are already in the correct order.
       config.hitsAreReverse = false;
-      trajectories.push_back(ReferenceTrajectoryPtr(
-          new ReferenceTrajectory(input.first, input.second, magneticField, beamSpot, config)));
+      trajectories.push_back(
+          ReferenceTrajectoryPtr(new ReferenceTrajectory(input.first, input.second, magneticField, beamSpot, config)));
     }
 
     ++itTracks;
@@ -108,7 +112,7 @@ const ReferenceTrajectoryFactory::ReferenceTrajectoryCollection ReferenceTraject
     const ConstTrajTrackPairCollection &tracks,
     const ExternalPredictionCollection &external,
     const reco::BeamSpot &beamSpot,
-   edm::ConsumesCollector &iC) const {
+    edm::ConsumesCollector &iC) const {
   ReferenceTrajectoryCollection trajectories;
 
   if (tracks.size() != external.size()) {
@@ -118,7 +122,7 @@ const ReferenceTrajectoryFactory::ReferenceTrajectoryCollection ReferenceTraject
         << "\tnumber of tracks = " << tracks.size() << "\tnumber of external predictions = " << external.size();
     return trajectories;
   }
-  const MagneticField* magneticField = &setup.getData(m_MagFieldToken);
+  const MagneticField *magneticField = &setup.getData(m_MagFieldToken);
 
   if (theUseBzeroIfFieldOff && magneticField->inTesla(GlobalPoint(0., 0., 0.)).mag2() < 1.e-6) {
     return this->bzeroFactory(iC)->trajectories(setup, tracks, external, beamSpot, iC);
@@ -162,7 +166,7 @@ const ReferenceTrajectoryFactory::ReferenceTrajectoryCollection ReferenceTraject
   return trajectories;
 }
 
-const TrajectoryFactoryBase *ReferenceTrajectoryFactory::bzeroFactory(  edm::ConsumesCollector &iC) const {
+const TrajectoryFactoryBase *ReferenceTrajectoryFactory::bzeroFactory(edm::ConsumesCollector &iC) const {
   if (!theBzeroFactory) {
     const edm::ParameterSet &myPset = this->configuration();
     edm::LogInfo("Alignment") << "@SUB=ReferenceTrajectoryFactory::bzeroFactory"

--- a/Alignment/ReferenceTrajectories/plugins/ReferenceTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/ReferenceTrajectoryFactory.cc
@@ -26,18 +26,18 @@ public:
   /// Produce the reference trajectories.
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
                                                    const ConstTrajTrackPairCollection &tracks,
-                                                   const reco::BeamSpot &beamSpot) const override;
+                                                   const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const override;
 
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
                                                    const ConstTrajTrackPairCollection &tracks,
                                                    const ExternalPredictionCollection &external,
-                                                   const reco::BeamSpot &beamSpot) const override;
+                                                   const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const override;
 
   ReferenceTrajectoryFactory *clone() const override { return new ReferenceTrajectoryFactory(*this); }
 
 protected:
   ReferenceTrajectoryFactory(const ReferenceTrajectoryFactory &other);
-  const TrajectoryFactoryBase *bzeroFactory() const;
+  const TrajectoryFactoryBase *bzeroFactory(edm::ConsumesCollector &iC) const;
 
   double theMass;
   bool theUseBzeroIfFieldOff;
@@ -69,11 +69,11 @@ ReferenceTrajectoryFactory::ReferenceTrajectoryFactory(const ReferenceTrajectory
 ReferenceTrajectoryFactory::~ReferenceTrajectoryFactory(void) { delete theBzeroFactory; }
 
 const ReferenceTrajectoryFactory::ReferenceTrajectoryCollection ReferenceTrajectoryFactory::trajectories(
-    const edm::EventSetup &setup, const ConstTrajTrackPairCollection &tracks, const reco::BeamSpot &beamSpot) const {
+    const edm::EventSetup &setup, const ConstTrajTrackPairCollection &tracks, const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const {
   const MagneticField* magneticField = &setup.getData(m_MagFieldToken);
 
   if (theUseBzeroIfFieldOff && magneticField->inTesla(GlobalPoint(0., 0., 0.)).mag2() < 1.e-6) {
-    return this->bzeroFactory()->trajectories(setup, tracks, beamSpot);
+    return this->bzeroFactory(iC)->trajectories(setup, tracks, beamSpot);
   }
 
   ReferenceTrajectoryCollection trajectories;
@@ -105,7 +105,8 @@ const ReferenceTrajectoryFactory::ReferenceTrajectoryCollection ReferenceTraject
     const edm::EventSetup &setup,
     const ConstTrajTrackPairCollection &tracks,
     const ExternalPredictionCollection &external,
-    const reco::BeamSpot &beamSpot) const {
+    const reco::BeamSpot &beamSpot,
+edm::ConsumesCollector &iC) const {
   ReferenceTrajectoryCollection trajectories;
 
   if (tracks.size() != external.size()) {
@@ -118,7 +119,7 @@ const ReferenceTrajectoryFactory::ReferenceTrajectoryCollection ReferenceTraject
   const MagneticField* magneticField = &setup.getData(m_MagFieldToken);
 
   if (theUseBzeroIfFieldOff && magneticField->inTesla(GlobalPoint(0., 0., 0.)).mag2() < 1.e-6) {
-    return this->bzeroFactory()->trajectories(setup, tracks, external, beamSpot);
+    return this->bzeroFactory(iC)->trajectories(setup, tracks, external, beamSpot);
   }
 
   ConstTrajTrackPairCollection::const_iterator itTracks = tracks.begin();
@@ -159,14 +160,13 @@ const ReferenceTrajectoryFactory::ReferenceTrajectoryCollection ReferenceTraject
   return trajectories;
 }
 
-const TrajectoryFactoryBase *ReferenceTrajectoryFactory::bzeroFactory() const {
+const TrajectoryFactoryBase *ReferenceTrajectoryFactory::bzeroFactory(edm::ConsumesCollector &iC) const {
   if (!theBzeroFactory) {
     const edm::ParameterSet &myPset = this->configuration();
     edm::LogInfo("Alignment") << "@SUB=ReferenceTrajectoryFactory::bzeroFactory"
                               << "Using BzeroReferenceTrajectoryFactory for some (all?) events.";
     // We take the config of this factory, copy it, replace its name and add
     // the momentum parameter as expected by BzeroReferenceTrajectoryFactory and create it:
-    edm::ConsumesCollector iC;
     edm::ParameterSet pset;
     pset.copyForModify(myPset);
     // next two lines not needed, but may help to better understand log file:

--- a/Alignment/ReferenceTrajectories/plugins/ReferenceTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/ReferenceTrajectoryFactory.cc
@@ -19,8 +19,9 @@
 
 class ReferenceTrajectoryFactory : public TrajectoryFactoryBase {
 public:
-  ReferenceTrajectoryFactory(const edm::ParameterSet &config);
+  ReferenceTrajectoryFactory(const edm::ParameterSet &config, edm::ConsumesCollector &iC);
   ~ReferenceTrajectoryFactory() override;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> m_MagFieldToken;
 
   /// Produce the reference trajectories.
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
@@ -47,8 +48,9 @@ protected:
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
-ReferenceTrajectoryFactory::ReferenceTrajectoryFactory(const edm::ParameterSet &config)
-    : TrajectoryFactoryBase(config),
+ReferenceTrajectoryFactory::ReferenceTrajectoryFactory(const edm::ParameterSet &config, edm::ConsumesCollector &iC)
+    : TrajectoryFactoryBase(config,iC),
+      m_MagFieldToken(iC.esConsumes()),
       theMass(config.getParameter<double>("ParticleMass")),
       theUseBzeroIfFieldOff(config.getParameter<bool>("UseBzeroIfFieldOff")),
       theBzeroFactory(nullptr) {
@@ -68,8 +70,8 @@ ReferenceTrajectoryFactory::~ReferenceTrajectoryFactory(void) { delete theBzeroF
 
 const ReferenceTrajectoryFactory::ReferenceTrajectoryCollection ReferenceTrajectoryFactory::trajectories(
     const edm::EventSetup &setup, const ConstTrajTrackPairCollection &tracks, const reco::BeamSpot &beamSpot) const {
-  edm::ESHandle<MagneticField> magneticField;
-  setup.get<IdealMagneticFieldRecord>().get(magneticField);
+  const MagneticField* magneticField = &setup.getData(m_MagFieldToken);
+
   if (theUseBzeroIfFieldOff && magneticField->inTesla(GlobalPoint(0., 0., 0.)).mag2() < 1.e-6) {
     return this->bzeroFactory()->trajectories(setup, tracks, beamSpot);
   }
@@ -90,7 +92,7 @@ const ReferenceTrajectoryFactory::ReferenceTrajectoryCollection ReferenceTraject
       // set the flag for reversing the RecHits to false, since they are already in the correct order.
       config.hitsAreReverse = false;
       trajectories.push_back(ReferenceTrajectoryPtr(
-          new ReferenceTrajectory(input.first, input.second, magneticField.product(), beamSpot, config)));
+          new ReferenceTrajectory(input.first, input.second, magneticField, beamSpot, config)));
     }
 
     ++itTracks;
@@ -113,9 +115,8 @@ const ReferenceTrajectoryFactory::ReferenceTrajectoryCollection ReferenceTraject
         << "\tnumber of tracks = " << tracks.size() << "\tnumber of external predictions = " << external.size();
     return trajectories;
   }
+  const MagneticField* magneticField = &setup.getData(m_MagFieldToken);
 
-  edm::ESHandle<MagneticField> magneticField;
-  setup.get<IdealMagneticFieldRecord>().get(magneticField);
   if (theUseBzeroIfFieldOff && magneticField->inTesla(GlobalPoint(0., 0., 0.)).mag2() < 1.e-6) {
     return this->bzeroFactory()->trajectories(setup, tracks, external, beamSpot);
   }
@@ -135,7 +136,7 @@ const ReferenceTrajectoryFactory::ReferenceTrajectoryCollection ReferenceTraject
         // set the flag for reversing the RecHits to false, since they are already in the correct order.
         config.hitsAreReverse = false;
         ReferenceTrajectoryPtr refTraj(
-            new ReferenceTrajectory(*itExternal, input.second, magneticField.product(), beamSpot, config));
+            new ReferenceTrajectory(*itExternal, input.second, magneticField, beamSpot, config));
 
         AlgebraicSymMatrix externalParamErrors(asHepMatrix<5>((*itExternal).localError().matrix()));
         refTraj->setParameterErrors(externalParamErrors);
@@ -147,7 +148,7 @@ const ReferenceTrajectoryFactory::ReferenceTrajectoryCollection ReferenceTraject
         config.allowZeroMaterial = allowZeroMaterial_;
         config.hitsAreReverse = false;
         trajectories.push_back(ReferenceTrajectoryPtr(
-            new ReferenceTrajectory(input.first, input.second, magneticField.product(), beamSpot, config)));
+            new ReferenceTrajectory(input.first, input.second, magneticField, beamSpot, config)));
       }
     }
 
@@ -165,13 +166,14 @@ const TrajectoryFactoryBase *ReferenceTrajectoryFactory::bzeroFactory() const {
                               << "Using BzeroReferenceTrajectoryFactory for some (all?) events.";
     // We take the config of this factory, copy it, replace its name and add
     // the momentum parameter as expected by BzeroReferenceTrajectoryFactory and create it:
+    edm::ConsumesCollector iC;
     edm::ParameterSet pset;
     pset.copyForModify(myPset);
     // next two lines not needed, but may help to better understand log file:
     pset.eraseSimpleParameter("TrajectoryFactoryName");
     pset.addParameter("TrajectoryFactoryName", std::string("BzeroReferenceTrajectoryFactory"));
     pset.addParameter("MomentumEstimate", myPset.getParameter<double>("MomentumEstimateFieldOff"));
-    theBzeroFactory = new BzeroReferenceTrajectoryFactory(pset);
+    theBzeroFactory = new BzeroReferenceTrajectoryFactory(pset, iC);
   }
   return theBzeroFactory;
 }

--- a/Alignment/ReferenceTrajectories/plugins/ReferenceTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/ReferenceTrajectoryFactory.cc
@@ -26,18 +26,20 @@ public:
   /// Produce the reference trajectories.
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
                                                    const ConstTrajTrackPairCollection &tracks,
-                                                   const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const override;
+                                                   const reco::BeamSpot &beamSpot,
+						   edm::ConsumesCollector &iC) const override;
 
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
                                                    const ConstTrajTrackPairCollection &tracks,
                                                    const ExternalPredictionCollection &external,
-                                                   const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const override;
+                                                   const reco::BeamSpot &beamSpot,edm::ConsumesCollector &iC) const override;
 
   ReferenceTrajectoryFactory *clone() const override { return new ReferenceTrajectoryFactory(*this); }
 
 protected:
   ReferenceTrajectoryFactory(const ReferenceTrajectoryFactory &other);
-  const TrajectoryFactoryBase *bzeroFactory(edm::ConsumesCollector &iC) const;
+  const TrajectoryFactoryBase *bzeroFactory() const;
+  const TrajectoryFactoryBase *bzeroFactory( edm::ConsumesCollector &iC) const;
 
   double theMass;
   bool theUseBzeroIfFieldOff;
@@ -69,11 +71,11 @@ ReferenceTrajectoryFactory::ReferenceTrajectoryFactory(const ReferenceTrajectory
 ReferenceTrajectoryFactory::~ReferenceTrajectoryFactory(void) { delete theBzeroFactory; }
 
 const ReferenceTrajectoryFactory::ReferenceTrajectoryCollection ReferenceTrajectoryFactory::trajectories(
-    const edm::EventSetup &setup, const ConstTrajTrackPairCollection &tracks, const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const {
+    const edm::EventSetup &setup, const ConstTrajTrackPairCollection &tracks, const reco::BeamSpot &beamSpot,edm::ConsumesCollector &iC) const {
   const MagneticField* magneticField = &setup.getData(m_MagFieldToken);
 
   if (theUseBzeroIfFieldOff && magneticField->inTesla(GlobalPoint(0., 0., 0.)).mag2() < 1.e-6) {
-    return this->bzeroFactory(iC)->trajectories(setup, tracks, beamSpot);
+    return this->bzeroFactory(iC)->trajectories(setup, tracks, beamSpot, iC);
   }
 
   ReferenceTrajectoryCollection trajectories;
@@ -106,7 +108,7 @@ const ReferenceTrajectoryFactory::ReferenceTrajectoryCollection ReferenceTraject
     const ConstTrajTrackPairCollection &tracks,
     const ExternalPredictionCollection &external,
     const reco::BeamSpot &beamSpot,
-edm::ConsumesCollector &iC) const {
+   edm::ConsumesCollector &iC) const {
   ReferenceTrajectoryCollection trajectories;
 
   if (tracks.size() != external.size()) {
@@ -119,7 +121,7 @@ edm::ConsumesCollector &iC) const {
   const MagneticField* magneticField = &setup.getData(m_MagFieldToken);
 
   if (theUseBzeroIfFieldOff && magneticField->inTesla(GlobalPoint(0., 0., 0.)).mag2() < 1.e-6) {
-    return this->bzeroFactory(iC)->trajectories(setup, tracks, external, beamSpot);
+    return this->bzeroFactory(iC)->trajectories(setup, tracks, external, beamSpot, iC);
   }
 
   ConstTrajTrackPairCollection::const_iterator itTracks = tracks.begin();
@@ -160,7 +162,7 @@ edm::ConsumesCollector &iC) const {
   return trajectories;
 }
 
-const TrajectoryFactoryBase *ReferenceTrajectoryFactory::bzeroFactory(edm::ConsumesCollector &iC) const {
+const TrajectoryFactoryBase *ReferenceTrajectoryFactory::bzeroFactory(  edm::ConsumesCollector &iC) const {
   if (!theBzeroFactory) {
     const edm::ParameterSet &myPset = this->configuration();
     edm::LogInfo("Alignment") << "@SUB=ReferenceTrajectoryFactory::bzeroFactory"

--- a/Alignment/ReferenceTrajectories/plugins/ReferenceTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/ReferenceTrajectoryFactory.cc
@@ -173,7 +173,6 @@ const ReferenceTrajectoryFactory::ReferenceTrajectoryCollection ReferenceTraject
 
 const TrajectoryFactoryBase *ReferenceTrajectoryFactory::bzeroFactory() const {
   if (!theBzeroFactory) {
-    const edm::ParameterSet &myPset = this->configuration();
     edm::LogInfo("Alignment") << "@SUB=ReferenceTrajectoryFactory::bzeroFactory"
                               << "Using BzeroReferenceTrajectoryFactory for some (all?) events.";
   }

--- a/Alignment/ReferenceTrajectories/plugins/TwoBodyDecayTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/TwoBodyDecayTrajectoryFactory.cc
@@ -93,9 +93,7 @@ TwoBodyDecayTrajectoryFactory::TwoBodyDecayTrajectoryFactory(const edm::Paramete
 TwoBodyDecayTrajectoryFactory::~TwoBodyDecayTrajectoryFactory() {}
 
 const TrajectoryFactoryBase::ReferenceTrajectoryCollection TwoBodyDecayTrajectoryFactory::trajectories(
-    const edm::EventSetup &setup,
-    const ConstTrajTrackPairCollection &tracks,
-    const reco::BeamSpot &beamSpot) const {
+    const edm::EventSetup &setup, const ConstTrajTrackPairCollection &tracks, const reco::BeamSpot &beamSpot) const {
   ReferenceTrajectoryCollection trajectories;
 
   const MagneticField *magneticField = &setup.getData(m_MagFieldToken);

--- a/Alignment/ReferenceTrajectories/plugins/TwoBodyDecayTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/TwoBodyDecayTrajectoryFactory.cc
@@ -39,14 +39,12 @@ public:
   /// Produce the trajectories.
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
                                                    const ConstTrajTrackPairCollection &tracks,
-                                                   const reco::BeamSpot &beamSpot,
-                                                   edm::ConsumesCollector &iC) const override;
+                                                   const reco::BeamSpot &beamSpot) const override;
 
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
                                                    const ConstTrajTrackPairCollection &tracks,
                                                    const ExternalPredictionCollection &external,
-                                                   const reco::BeamSpot &beamSpot,
-                                                   edm::ConsumesCollector &iC) const override;
+                                                   const reco::BeamSpot &beamSpot) const override;
 
   TwoBodyDecayTrajectoryFactory *clone() const override { return new TwoBodyDecayTrajectoryFactory(*this); }
 
@@ -97,8 +95,7 @@ TwoBodyDecayTrajectoryFactory::~TwoBodyDecayTrajectoryFactory() {}
 const TrajectoryFactoryBase::ReferenceTrajectoryCollection TwoBodyDecayTrajectoryFactory::trajectories(
     const edm::EventSetup &setup,
     const ConstTrajTrackPairCollection &tracks,
-    const reco::BeamSpot &beamSpot,
-    edm::ConsumesCollector &iC) const {
+    const reco::BeamSpot &beamSpot) const {
   ReferenceTrajectoryCollection trajectories;
 
   const MagneticField *magneticField = &setup.getData(m_MagFieldToken);
@@ -135,8 +132,7 @@ const TrajectoryFactoryBase::ReferenceTrajectoryCollection TwoBodyDecayTrajector
     const edm::EventSetup &setup,
     const ConstTrajTrackPairCollection &tracks,
     const ExternalPredictionCollection &external,
-    const reco::BeamSpot &beamSpot,
-    edm::ConsumesCollector &iC) const {
+    const reco::BeamSpot &beamSpot) const {
   ReferenceTrajectoryCollection trajectories;
 
   const MagneticField *magneticField = &setup.getData(m_MagFieldToken);
@@ -169,7 +165,7 @@ const TrajectoryFactoryBase::ReferenceTrajectoryCollection TwoBodyDecayTrajector
       return constructTrajectories(tracks, tbd, magneticField, beamSpot, true);
     } else {
       // Return without external estimate
-      trajectories = this->trajectories(setup, tracks, beamSpot, iC);
+      trajectories = this->trajectories(setup, tracks, beamSpot);
     }
   } else {
     edm::LogInfo("ReferenceTrajectories") << "@SUB=TwoBodyDecayTrajectoryFactory::trajectories"

--- a/Alignment/ReferenceTrajectories/plugins/TwoBodyDecayTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/TwoBodyDecayTrajectoryFactory.cc
@@ -39,12 +39,14 @@ public:
   /// Produce the trajectories.
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
                                                    const ConstTrajTrackPairCollection &tracks,
-                                                   const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const override;
+                                                   const reco::BeamSpot &beamSpot,
+                                                   edm::ConsumesCollector &iC) const override;
 
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
                                                    const ConstTrajTrackPairCollection &tracks,
                                                    const ExternalPredictionCollection &external,
-                                                   const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const override;
+                                                   const reco::BeamSpot &beamSpot,
+                                                   edm::ConsumesCollector &iC) const override;
 
   TwoBodyDecayTrajectoryFactory *clone() const override { return new TwoBodyDecayTrajectoryFactory(*this); }
 
@@ -73,8 +75,12 @@ protected:
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
-TwoBodyDecayTrajectoryFactory::TwoBodyDecayTrajectoryFactory(const edm::ParameterSet &config, edm::ConsumesCollector &iC)
-    : TrajectoryFactoryBase(config, 2, iC),m_MagFieldToken(iC.esConsumes()),       m_globTackingToken(iC.esConsumes()) , theFitter(config){
+TwoBodyDecayTrajectoryFactory::TwoBodyDecayTrajectoryFactory(const edm::ParameterSet &config,
+                                                             edm::ConsumesCollector &iC)
+    : TrajectoryFactoryBase(config, 2, iC),
+      m_MagFieldToken(iC.esConsumes()),
+      m_globTackingToken(iC.esConsumes()),
+      theFitter(config) {
   const edm::ParameterSet ppc = config.getParameter<edm::ParameterSet>("ParticleProperties");
   thePrimaryMass = ppc.getParameter<double>("PrimaryMass");
   thePrimaryWidth = ppc.getParameter<double>("PrimaryWidth");
@@ -89,14 +95,14 @@ TwoBodyDecayTrajectoryFactory::TwoBodyDecayTrajectoryFactory(const edm::Paramete
 TwoBodyDecayTrajectoryFactory::~TwoBodyDecayTrajectoryFactory() {}
 
 const TrajectoryFactoryBase::ReferenceTrajectoryCollection TwoBodyDecayTrajectoryFactory::trajectories(
-    const edm::EventSetup &setup, const ConstTrajTrackPairCollection &tracks, const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const {
+    const edm::EventSetup &setup,
+    const ConstTrajTrackPairCollection &tracks,
+    const reco::BeamSpot &beamSpot,
+    edm::ConsumesCollector &iC) const {
   ReferenceTrajectoryCollection trajectories;
 
-  const MagneticField* magneticField = &setup.getData(m_MagFieldToken);
-  
- //edm::ESHandle<GlobalTrackingGeometry> trackingGeometry;
- // setup.get<GlobalTrackingGeometryRecord>().get(trackingGeometry);
-   const GlobalTrackingGeometry* trackingGeometry= &setup.getData(m_globTackingToken);
+  const MagneticField *magneticField = &setup.getData(m_MagFieldToken);
+  const GlobalTrackingGeometry *trackingGeometry = &setup.getData(m_globTackingToken);
   if (tracks.size() == 2) {
     // produce transient tracks from persistent tracks
     std::vector<reco::TransientTrack> transientTracks(2);
@@ -129,12 +135,13 @@ const TrajectoryFactoryBase::ReferenceTrajectoryCollection TwoBodyDecayTrajector
     const edm::EventSetup &setup,
     const ConstTrajTrackPairCollection &tracks,
     const ExternalPredictionCollection &external,
-    const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const {
+    const reco::BeamSpot &beamSpot,
+    edm::ConsumesCollector &iC) const {
   ReferenceTrajectoryCollection trajectories;
 
-  const MagneticField* magneticField = &setup.getData(m_MagFieldToken);
+  const MagneticField *magneticField = &setup.getData(m_MagFieldToken);
 
-   const GlobalTrackingGeometry* trackingGeometry= &setup.getData(m_globTackingToken);
+  const GlobalTrackingGeometry *trackingGeometry = &setup.getData(m_globTackingToken);
 
   if (tracks.size() == 2 && external.size() == 2) {
     if (external[0].isValid() && external[1].isValid())  // Include external estimates

--- a/Alignment/ReferenceTrajectories/plugins/TwoBodyDecayTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/TwoBodyDecayTrajectoryFactory.cc
@@ -31,8 +31,10 @@ public:
   typedef TwoBodyDecayTrajectoryState::TsosContainer TsosContainer;
   typedef TwoBodyDecayTrajectory::ConstRecHitCollection ConstRecHitCollection;
 
-  TwoBodyDecayTrajectoryFactory(const edm::ParameterSet &config);
+  TwoBodyDecayTrajectoryFactory(const edm::ParameterSet &config, edm::ConsumesCollector &iC);
   ~TwoBodyDecayTrajectoryFactory() override;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> m_MagFieldToken;
+  const edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> m_globTackingToken;
 
   /// Produce the trajectories.
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
@@ -71,8 +73,8 @@ protected:
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
-TwoBodyDecayTrajectoryFactory::TwoBodyDecayTrajectoryFactory(const edm::ParameterSet &config)
-    : TrajectoryFactoryBase(config, 2), theFitter(config) {
+TwoBodyDecayTrajectoryFactory::TwoBodyDecayTrajectoryFactory(const edm::ParameterSet &config, edm::ConsumesCollector &iC)
+    : TrajectoryFactoryBase(config, 2, iC),m_MagFieldToken(iC.esConsumes()),       m_globTackingToken(iC.esConsumes()) , theFitter(config){
   const edm::ParameterSet ppc = config.getParameter<edm::ParameterSet>("ParticleProperties");
   thePrimaryMass = ppc.getParameter<double>("PrimaryMass");
   thePrimaryWidth = ppc.getParameter<double>("PrimaryWidth");
@@ -90,20 +92,19 @@ const TrajectoryFactoryBase::ReferenceTrajectoryCollection TwoBodyDecayTrajector
     const edm::EventSetup &setup, const ConstTrajTrackPairCollection &tracks, const reco::BeamSpot &beamSpot) const {
   ReferenceTrajectoryCollection trajectories;
 
-  edm::ESHandle<MagneticField> magneticField;
-  setup.get<IdealMagneticFieldRecord>().get(magneticField);
-
-  edm::ESHandle<GlobalTrackingGeometry> trackingGeometry;
-  setup.get<GlobalTrackingGeometryRecord>().get(trackingGeometry);
-
+  const MagneticField* magneticField = &setup.getData(m_MagFieldToken);
+  
+ //edm::ESHandle<GlobalTrackingGeometry> trackingGeometry;
+ // setup.get<GlobalTrackingGeometryRecord>().get(trackingGeometry);
+   const GlobalTrackingGeometry* trackingGeometry= &setup.getData(m_globTackingToken);
   if (tracks.size() == 2) {
     // produce transient tracks from persistent tracks
     std::vector<reco::TransientTrack> transientTracks(2);
 
-    transientTracks[0] = reco::TransientTrack(*tracks[0].second, magneticField.product());
+    transientTracks[0] = reco::TransientTrack(*tracks[0].second, magneticField);
     transientTracks[0].setTrackingGeometry(trackingGeometry);
 
-    transientTracks[1] = reco::TransientTrack(*tracks[1].second, magneticField.product());
+    transientTracks[1] = reco::TransientTrack(*tracks[1].second, magneticField);
     transientTracks[1].setTrackingGeometry(trackingGeometry);
 
     // estimate the decay parameters
@@ -115,7 +116,7 @@ const TrajectoryFactoryBase::ReferenceTrajectoryCollection TwoBodyDecayTrajector
       return trajectories;
     }
 
-    return constructTrajectories(tracks, tbd, magneticField.product(), beamSpot, false);
+    return constructTrajectories(tracks, tbd, magneticField, beamSpot, false);
   } else {
     edm::LogInfo("ReferenceTrajectories") << "@SUB=TwoBodyDecayTrajectoryFactory::trajectories"
                                           << "Need 2 tracks, got " << tracks.size() << ".\n";
@@ -131,11 +132,9 @@ const TrajectoryFactoryBase::ReferenceTrajectoryCollection TwoBodyDecayTrajector
     const reco::BeamSpot &beamSpot) const {
   ReferenceTrajectoryCollection trajectories;
 
-  edm::ESHandle<MagneticField> magneticField;
-  setup.get<IdealMagneticFieldRecord>().get(magneticField);
+  const MagneticField* magneticField = &setup.getData(m_MagFieldToken);
 
-  edm::ESHandle<GlobalTrackingGeometry> trackingGeometry;
-  setup.get<GlobalTrackingGeometryRecord>().get(trackingGeometry);
+   const GlobalTrackingGeometry* trackingGeometry= &setup.getData(m_globTackingToken);
 
   if (tracks.size() == 2 && external.size() == 2) {
     if (external[0].isValid() && external[1].isValid())  // Include external estimates
@@ -143,10 +142,10 @@ const TrajectoryFactoryBase::ReferenceTrajectoryCollection TwoBodyDecayTrajector
       // produce transient tracks from persistent tracks
       std::vector<reco::TransientTrack> transientTracks(2);
 
-      transientTracks[0] = reco::TransientTrack(*tracks[0].second, magneticField.product());
+      transientTracks[0] = reco::TransientTrack(*tracks[0].second, magneticField);
       transientTracks[0].setTrackingGeometry(trackingGeometry);
 
-      transientTracks[1] = reco::TransientTrack(*tracks[1].second, magneticField.product());
+      transientTracks[1] = reco::TransientTrack(*tracks[1].second, magneticField);
       transientTracks[1].setTrackingGeometry(trackingGeometry);
 
       // estimate the decay parameters. the transient tracks are not really associated to the
@@ -160,7 +159,7 @@ const TrajectoryFactoryBase::ReferenceTrajectoryCollection TwoBodyDecayTrajector
         return trajectories;
       }
 
-      return constructTrajectories(tracks, tbd, magneticField.product(), beamSpot, true);
+      return constructTrajectories(tracks, tbd, magneticField, beamSpot, true);
     } else {
       // Return without external estimate
       trajectories = this->trajectories(setup, tracks, beamSpot);

--- a/Alignment/ReferenceTrajectories/plugins/TwoBodyDecayTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/TwoBodyDecayTrajectoryFactory.cc
@@ -39,12 +39,12 @@ public:
   /// Produce the trajectories.
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
                                                    const ConstTrajTrackPairCollection &tracks,
-                                                   const reco::BeamSpot &beamSpot) const override;
+                                                   const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const override;
 
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
                                                    const ConstTrajTrackPairCollection &tracks,
                                                    const ExternalPredictionCollection &external,
-                                                   const reco::BeamSpot &beamSpot) const override;
+                                                   const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const override;
 
   TwoBodyDecayTrajectoryFactory *clone() const override { return new TwoBodyDecayTrajectoryFactory(*this); }
 
@@ -89,7 +89,7 @@ TwoBodyDecayTrajectoryFactory::TwoBodyDecayTrajectoryFactory(const edm::Paramete
 TwoBodyDecayTrajectoryFactory::~TwoBodyDecayTrajectoryFactory() {}
 
 const TrajectoryFactoryBase::ReferenceTrajectoryCollection TwoBodyDecayTrajectoryFactory::trajectories(
-    const edm::EventSetup &setup, const ConstTrajTrackPairCollection &tracks, const reco::BeamSpot &beamSpot) const {
+    const edm::EventSetup &setup, const ConstTrajTrackPairCollection &tracks, const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const {
   ReferenceTrajectoryCollection trajectories;
 
   const MagneticField* magneticField = &setup.getData(m_MagFieldToken);
@@ -129,7 +129,7 @@ const TrajectoryFactoryBase::ReferenceTrajectoryCollection TwoBodyDecayTrajector
     const edm::EventSetup &setup,
     const ConstTrajTrackPairCollection &tracks,
     const ExternalPredictionCollection &external,
-    const reco::BeamSpot &beamSpot) const {
+    const reco::BeamSpot &beamSpot, edm::ConsumesCollector &iC) const {
   ReferenceTrajectoryCollection trajectories;
 
   const MagneticField* magneticField = &setup.getData(m_MagFieldToken);
@@ -162,7 +162,7 @@ const TrajectoryFactoryBase::ReferenceTrajectoryCollection TwoBodyDecayTrajector
       return constructTrajectories(tracks, tbd, magneticField, beamSpot, true);
     } else {
       // Return without external estimate
-      trajectories = this->trajectories(setup, tracks, beamSpot);
+      trajectories = this->trajectories(setup, tracks, beamSpot, iC);
     }
   } else {
     edm::LogInfo("ReferenceTrajectories") << "@SUB=TwoBodyDecayTrajectoryFactory::trajectories"

--- a/Alignment/ReferenceTrajectories/src/TrajectoryFactoryBase.cc
+++ b/Alignment/ReferenceTrajectories/src/TrajectoryFactoryBase.cc
@@ -6,9 +6,9 @@
 
 #include "Alignment/ReferenceTrajectories/interface/TrajectoryFactoryBase.h"
 
-TrajectoryFactoryBase::TrajectoryFactoryBase(const edm::ParameterSet& config) : TrajectoryFactoryBase(config, 1) {}
+TrajectoryFactoryBase::TrajectoryFactoryBase(const edm::ParameterSet& config, const edm::ConsumesCollector &iC) : TrajectoryFactoryBase(config, 1, iC) {}
 
-TrajectoryFactoryBase::TrajectoryFactoryBase(const edm::ParameterSet& config, unsigned int tracksPerTrajectory)
+TrajectoryFactoryBase::TrajectoryFactoryBase(const edm::ParameterSet& config, unsigned int tracksPerTrajectory, const edm::ConsumesCollector &iC)
     : cfg_(config),
       tracksPerTrajectory_(tracksPerTrajectory),
       materialEffects_(materialEffects(config.getParameter<std::string>("MaterialEffects"))),

--- a/Alignment/ReferenceTrajectories/src/TrajectoryFactoryBase.cc
+++ b/Alignment/ReferenceTrajectories/src/TrajectoryFactoryBase.cc
@@ -6,9 +6,12 @@
 
 #include "Alignment/ReferenceTrajectories/interface/TrajectoryFactoryBase.h"
 
-TrajectoryFactoryBase::TrajectoryFactoryBase(const edm::ParameterSet& config, const edm::ConsumesCollector &iC) : TrajectoryFactoryBase(config, 1, iC) {}
+TrajectoryFactoryBase::TrajectoryFactoryBase(const edm::ParameterSet& config, const edm::ConsumesCollector& iC)
+    : TrajectoryFactoryBase(config, 1, iC) {}
 
-TrajectoryFactoryBase::TrajectoryFactoryBase(const edm::ParameterSet& config, unsigned int tracksPerTrajectory, const edm::ConsumesCollector &iC)
+TrajectoryFactoryBase::TrajectoryFactoryBase(const edm::ParameterSet& config,
+                                             unsigned int tracksPerTrajectory,
+                                             const edm::ConsumesCollector& iC)
     : cfg_(config),
       tracksPerTrajectory_(tracksPerTrajectory),
       materialEffects_(materialEffects(config.getParameter<std::string>("MaterialEffects"))),


### PR DESCRIPTION
#### PR description:

This PR is about the consumes migration of Alignment/ReferenceTrajectories and its dependencies. 

#### PR validation:

Ran successfully wf 1001.0 

1001.0_RunMinBias2011A+RunMinBias2011A+TIER0EXP+ALCAEXP+ALCAHARVDSIPIXELCALRUN1+ALCAHARVD1+ALCAHARVD2+ALCAHARVD3+ALCAHARVD4+ALCAHARVD5 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED Step5-PASSED Step6-PASSED Step7-PASSED Step8-PASSED  - time date Tue Sep 28 10:38:23 2021-date Tue Sep 28 10:27:48 2021; exit: 0 0 0 0 0 0 0 0 0
1 1 1 1 1 1 1 1 1 tests passed, 0 0 0 0 0 0 0 0 0 failed

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not a backport and no backport is needed.