### PR TITLE
add DQM splash run settings to master

### DIFF
--- a/DQM/Integration/python/clients/beamfake_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamfake_dqm_sourceclient-live_cfg.py
@@ -198,6 +198,11 @@ print("Configured frontierKey", options.runUniqueKey)
 
 #---------
 # Final path
+print("Final Source settings:", process.source)
+
 process.p = cms.Path(process.dqmcommon
                      * process.monitor
                     )
+
+
+

--- a/DQM/Integration/python/clients/beamhltfake_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhltfake_dqm_sourceclient-live_cfg.py
@@ -167,5 +167,10 @@ else:
 )
 print("Configured frontierKey", options.runUniqueKey)
 
+#---------
+# Final path
+print("Final Source settings:", process.source)
+
 process.p = cms.Path(process.dqmcommon
                     * process.monitor )
+

--- a/DQM/Integration/python/clients/castor_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/castor_dqm_sourceclient-live_cfg.py
@@ -143,4 +143,7 @@ if (process.runType.getRunType() == process.runType.hi_run):
 
 ### process customizations included here
 from DQM.Integration.config.online_customizations_cfi import *
+print("Final Source settings:", process.source)
 process = customise(process)
+
+

--- a/DQM/Integration/python/clients/csc_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/csc_dqm_sourceclient-live_cfg.py
@@ -222,4 +222,6 @@ if (process.runType.getRunType() == process.runType.hi_run):
 
 ### process customizations included here
 from DQM.Integration.config.online_customizations_cfi import *
+print("Final Source settings:", process.source)
 process = customise(process)
+

--- a/DQM/Integration/python/clients/ctpps_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ctpps_dqm_sourceclient-live_cfg.py
@@ -104,4 +104,5 @@ process.dqmProvInfo.runType = process.runType.getRunTypeName()
 
 # Process customizations included here
 from DQM.Integration.config.online_customizations_cfi import *
+print("Final Source settings:", process.source)
 process = customise(process)

--- a/DQM/Integration/python/clients/dt4ml_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/dt4ml_dqm_sourceclient-live_cfg.py
@@ -123,4 +123,5 @@ if (process.runType.getRunType() == process.runType.hi_run):
 
 ### process customizations included here
 from DQM.Integration.config.online_customizations_cfi import *
+print("Final Source settings:", process.source)
 process = customise(process)

--- a/DQM/Integration/python/clients/dt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/dt_dqm_sourceclient-live_cfg.py
@@ -104,4 +104,5 @@ if (process.runType.getRunType() == process.runType.hi_run):
 
 ### process customizations included here
 from DQM.Integration.config.online_customizations_cfi import *
+print("Final Source settings:", process.source)
 process = customise(process)

--- a/DQM/Integration/python/clients/ecal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ecal_dqm_sourceclient-live_cfg.py
@@ -171,4 +171,5 @@ elif runTypeName == 'hpu_run':
 
 ### process customizations included here
 from DQM.Integration.config.online_customizations_cfi import *
+print("Final Source settings:", process.source)
 process = customise(process)

--- a/DQM/Integration/python/clients/ecalcalib_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ecalcalib_dqm_sourceclient-live_cfg.py
@@ -213,4 +213,5 @@ process.schedule = cms.Schedule(process.ecalLaserLedPath,process.ecalTestPulsePa
 
 ### process customizations included here
 from DQM.Integration.config.online_customizations_cfi import *
+print("Final Source settings:", process.source)
 process = customise(process)

--- a/DQM/Integration/python/clients/es_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/es_dqm_sourceclient-live_cfg.py
@@ -96,4 +96,5 @@ if (process.runType.getRunType() == process.runType.hi_run):
 
 ### process customizations included here
 from DQM.Integration.config.online_customizations_cfi import *
+print("Final Source settings:", process.source)
 process = customise(process)

--- a/DQM/Integration/python/clients/fed_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/fed_dqm_sourceclient-live_cfg.py
@@ -156,4 +156,5 @@ process.schedule = cms.Schedule(
 
 # Finaly: DQM process customizations
 from DQM.Integration.config.online_customizations_cfi import *
+print("Final Source settings:", process.source)
 process = customise(process)

--- a/DQM/Integration/python/clients/gem_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/gem_dqm_sourceclient-live_cfg.py
@@ -58,4 +58,5 @@ process.schedule = cms.Schedule(
 process.dqmProvInfo.runType = process.runType.getRunTypeName()
 
 from DQM.Integration.config.online_customizations_cfi import *
+print("Final Source settings:", process.source)
 process = customise(process)

--- a/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
@@ -46,7 +46,7 @@ elif useFileInput:
 	from DQM.Integration.config.fileinputsource_cfi import options
 else:
 	process.load('DQM.Integration.config.inputsource_cfi')
-	from DQM.Integration.config.inputsource_cfi import options
+	from DQM.Integration.config.inputsource_cfi import options, BeamSplashRun
 process.load('DQM.Integration.config.environment_cfi')
 
 #-------------------------------------
@@ -60,7 +60,7 @@ process.dqmSaverPB.runNumber = options.runNumber
 process = customise(process)
 process.DQMStore.verbose = 0
 if not unitTest and not useFileInput :
-  if not process.BeamSplashRun :
+  if not BeamSplashRun :
 	  process.source.minEventsPerLumi = 100
 
 #-------------------------------------

--- a/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
@@ -46,7 +46,7 @@ elif useFileInput:
 	from DQM.Integration.config.fileinputsource_cfi import options
 else:
 	process.load('DQM.Integration.config.inputsource_cfi')
-	from DQM.Integration.config.inputsource_cfi import options, BeamSplashRun
+	from DQM.Integration.config.inputsource_cfi import options
 process.load('DQM.Integration.config.environment_cfi')
 
 #-------------------------------------
@@ -60,7 +60,7 @@ process.dqmSaverPB.runNumber = options.runNumber
 process = customise(process)
 process.DQMStore.verbose = 0
 if not unitTest and not useFileInput :
-  if not BeamSplashRun :
+  if not options.BeamSplashRun :
     process.source.minEventsPerLumi = 100
 
 #-------------------------------------

--- a/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
@@ -59,8 +59,9 @@ process.dqmSaverPB.tag = subsystem
 process.dqmSaverPB.runNumber = options.runNumber
 process = customise(process)
 process.DQMStore.verbose = 0
-if not useFileInput and not unitTest:
-	process.source.minEventsPerLumi = 100
+if not unitTest and not useFileInput :
+  if not process.BeamSplashRun :
+	  process.source.minEventsPerLumi = 100
 
 #-------------------------------------
 #	CMSSW/Hcal non-DQM Related Module import
@@ -256,4 +257,5 @@ process.options.wantSummary = True
 
 # tracer
 #process.Tracer = cms.Service("Tracer")
+print("Final Source settings:", process.source)
 process = customise(process)

--- a/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
@@ -61,7 +61,7 @@ process = customise(process)
 process.DQMStore.verbose = 0
 if not unitTest and not useFileInput :
   if not BeamSplashRun :
-	  process.source.minEventsPerLumi = 100
+    process.source.minEventsPerLumi = 100
 
 #-------------------------------------
 #	CMSSW/Hcal non-DQM Related Module import

--- a/DQM/Integration/python/clients/hcalcalib_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcalcalib_dqm_sourceclient-live_cfg.py
@@ -37,7 +37,7 @@ if useFileInput:
 	from DQM.Integration.config.fileinputsource_cfi import options
 else:
 	process.load('DQM.Integration.config.inputsource_cfi')
-	from DQM.Integration.config.inputsource_cfi import options
+	from DQM.Integration.config.inputsource_cfi import options, BeamSplashRun
 process.load('DQM.Integration.config.environment_cfi')
 
 #-------------------------------------
@@ -52,10 +52,8 @@ process.dqmSaverPB.tag = subsystem
 process.dqmSaverPB.runNumber = options.runNumber
 process = customise(process)
 if not useFileInput:
-  if hasattr(process, "BeamSplashRun") :
-    if not process.BeamSplashRun : 
-      process.source.minEventsPerLumi=100
-  else : process.source.minEventsPerLumi=100
+  if not BeamSplashRun : 
+    process.source.minEventsPerLumi=100
 
 
 #-------------------------------------

--- a/DQM/Integration/python/clients/hcalcalib_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcalcalib_dqm_sourceclient-live_cfg.py
@@ -52,7 +52,10 @@ process.dqmSaverPB.tag = subsystem
 process.dqmSaverPB.runNumber = options.runNumber
 process = customise(process)
 if not useFileInput:
-	process.source.minEventsPerLumi=100
+  if hasattr(process, "BeamSplashRun") :
+    if not process.BeamSplashRun : 
+      process.source.minEventsPerLumi=100
+	else : process.source.minEventsPerLumi=100
 
 
 #-------------------------------------
@@ -236,6 +239,7 @@ process.p = cms.Path(
 #-------------------------------------
 #	Scheduling
 #-------------------------------------
+print("Final Source settings:", process.source)
 process.options = cms.untracked.PSet(
 		Rethrow = cms.untracked.vstring(
 #			"ProductNotFound",

--- a/DQM/Integration/python/clients/hcalcalib_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcalcalib_dqm_sourceclient-live_cfg.py
@@ -37,7 +37,7 @@ if useFileInput:
 	from DQM.Integration.config.fileinputsource_cfi import options
 else:
 	process.load('DQM.Integration.config.inputsource_cfi')
-	from DQM.Integration.config.inputsource_cfi import options, BeamSplashRun
+	from DQM.Integration.config.inputsource_cfi import options
 process.load('DQM.Integration.config.environment_cfi')
 
 #-------------------------------------
@@ -52,7 +52,7 @@ process.dqmSaverPB.tag = subsystem
 process.dqmSaverPB.runNumber = options.runNumber
 process = customise(process)
 if not useFileInput:
-  if not BeamSplashRun : 
+  if not options.BeamSplashRun : 
     process.source.minEventsPerLumi=100
 
 

--- a/DQM/Integration/python/clients/hcalcalib_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcalcalib_dqm_sourceclient-live_cfg.py
@@ -55,7 +55,7 @@ if not useFileInput:
   if hasattr(process, "BeamSplashRun") :
     if not process.BeamSplashRun : 
       process.source.minEventsPerLumi=100
-	else : process.source.minEventsPerLumi=100
+  else : process.source.minEventsPerLumi=100
 
 
 #-------------------------------------

--- a/DQM/Integration/python/clients/hcalreco_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcalreco_dqm_sourceclient-live_cfg.py
@@ -55,7 +55,7 @@ elif useFileInput:
 	from DQM.Integration.config.fileinputsource_cfi import options
 else:
 	process.load('DQM.Integration.config.inputsource_cfi')
-	from DQM.Integration.config.inputsource_cfi import options
+	from DQM.Integration.config.inputsource_cfi import options, BeamSplashRun
 process.load('DQM.Integration.config.environment_cfi')
 
 #-------------------------------------
@@ -69,7 +69,7 @@ process.dqmSaverPB.runNumber = options.runNumber
 process = customise(process)
 process.DQMStore.verbose = 0
 if not unitTest and not useFileInput:
-  if not process.BeamSplashRun :
+  if not BeamSplashRun :
     process.source.minEventsPerLumi = 5
 
 #	Note, runType is obtained after importing DQM-related modules

--- a/DQM/Integration/python/clients/hcalreco_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcalreco_dqm_sourceclient-live_cfg.py
@@ -55,7 +55,7 @@ elif useFileInput:
 	from DQM.Integration.config.fileinputsource_cfi import options
 else:
 	process.load('DQM.Integration.config.inputsource_cfi')
-	from DQM.Integration.config.inputsource_cfi import options, BeamSplashRun
+	from DQM.Integration.config.inputsource_cfi import options
 process.load('DQM.Integration.config.environment_cfi')
 
 #-------------------------------------
@@ -69,7 +69,7 @@ process.dqmSaverPB.runNumber = options.runNumber
 process = customise(process)
 process.DQMStore.verbose = 0
 if not unitTest and not useFileInput:
-  if not BeamSplashRun :
+  if not options.BeamSplashRun :
     process.source.minEventsPerLumi = 5
 
 #	Note, runType is obtained after importing DQM-related modules

--- a/DQM/Integration/python/clients/hcalreco_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcalreco_dqm_sourceclient-live_cfg.py
@@ -68,8 +68,9 @@ process.dqmSaverPB.tag = "HcalReco"
 process.dqmSaverPB.runNumber = options.runNumber
 process = customise(process)
 process.DQMStore.verbose = 0
-if not useFileInput and not unitTest:
-	process.source.minEventsPerLumi = 5
+if not unitTest and not useFileInput:
+  if not process.BeamSplashRun :
+    process.source.minEventsPerLumi = 5
 
 #	Note, runType is obtained after importing DQM-related modules
 #	=> DQM-dependent
@@ -196,4 +197,7 @@ process.options = cms.untracked.PSet(
 			"TooFewProducts"
 		)
 )
+
 process.options.wantSummary = True
+print("Final Source settings:", process.source)
+

--- a/DQM/Integration/python/clients/hlt_dqm_clientPB-live_cfg.py
+++ b/DQM/Integration/python/clients/hlt_dqm_clientPB-live_cfg.py
@@ -85,5 +85,5 @@ process.psColumnVsLumi = process.dqmCorrelationClient.clone(
 process.load('DQM.HLTEvF.psMonitorClient_cfi')
 process.psChecker = process.psMonitorClient.clone()
 
-
+print("Final Source settings:", process.source)
 process.p = cms.EndPath( process.fastTimerServiceClient + process.throughputServiceClient + process.psColumnVsLumi + process.psChecker + process.dqmEnv + process.dqmSaver + process.dqmSaverPB )

--- a/DQM/Integration/python/clients/hlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hlt_dqm_sourceclient-live_cfg.py
@@ -1,4 +1,4 @@
-sourceimport FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.Config as cms
 
 import sys
 from Configuration.ProcessModifiers.run2_HECollapse_2018_cff import run2_HECollapse_2018

--- a/DQM/Integration/python/clients/hlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hlt_dqm_sourceclient-live_cfg.py
@@ -1,4 +1,4 @@
-import FWCore.ParameterSet.Config as cms
+sourceimport FWCore.ParameterSet.Config as cms
 
 import sys
 from Configuration.ProcessModifiers.run2_HECollapse_2018_cff import run2_HECollapse_2018
@@ -136,3 +136,4 @@ process.pp = cms.Path(process.dqmEnv+process.dqmSaver+process.dqmSaverPB)
 ### process customizations included here
 from DQM.Integration.config.online_customizations_cfi import *
 process = customise(process)
+print("Final Source settings:", process.source)

--- a/DQM/Integration/python/clients/info_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/info_dqm_sourceclient-live_cfg.py
@@ -79,3 +79,4 @@ else:
 # Process customizations included here
 from DQM.Integration.config.online_customizations_cfi import *
 process = customise(process)
+print("Final Source settings:", process.source)

--- a/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
@@ -184,4 +184,4 @@ process.schedule = cms.Schedule(
 
 from DQM.Integration.config.online_customizations_cfi import *
 process = customise(process)
-
+print("Final Source settings:", process.source)

--- a/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
@@ -180,3 +180,4 @@ process.schedule = cms.Schedule(
 
 from DQM.Integration.config.online_customizations_cfi import *
 process = customise(process)
+print("Final Source settings:", process.source)

--- a/DQM/Integration/python/clients/mutracking_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/mutracking_dqm_sourceclient-live_cfg.py
@@ -188,5 +188,5 @@ process.allPaths = cms.Path(process.hltHighLevel *
 from DQM.Integration.config.online_customizations_cfi import *
 
 process = customise(process)
-
+process.options.wantSummary = cms.untracked.bool(True)
 

--- a/DQM/Integration/python/clients/mutracking_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/mutracking_dqm_sourceclient-live_cfg.py
@@ -189,4 +189,5 @@ from DQM.Integration.config.online_customizations_cfi import *
 
 process = customise(process)
 process.options.wantSummary = cms.untracked.bool(True)
+print("Final Source settings:", process.source)
 

--- a/DQM/Integration/python/clients/onlinebeammonitor_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/onlinebeammonitor_dqm_sourceclient-live_cfg.py
@@ -171,4 +171,4 @@ process = customise(process)
 
 process.p = cms.Path( process.dqmcommon
                         * process.monitor )
-
+print("Final Source settings:", process.source)

--- a/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
@@ -252,3 +252,4 @@ process = customise(process)
 #--------------------------------------------------
 
 print("Running with run type = ", process.runType.getRunType())
+print("Final Source settings:", process.source)

--- a/DQM/Integration/python/clients/pixellumi_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixellumi_dqm_sourceclient-live_cfg.py
@@ -142,3 +142,4 @@ process.p = cms.Path(process.Reco*process.DQMmodules)
 ### process customizations included here
 from DQM.Integration.config.online_customizations_cfi import *
 process = customise(process)
+print("Final Source settings:", process.source)

--- a/DQM/Integration/python/clients/rpc_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/rpc_dqm_sourceclient-live_cfg.py
@@ -190,3 +190,6 @@ if (process.runType.getRunType() == process.runType.hi_run):
 ### process customizations included here
 from DQM.Integration.config.online_customizations_cfi import *
 process = customise(process)
+print("Final Source settings:", process.source)
+
+

--- a/DQM/Integration/python/clients/scal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/scal_dqm_sourceclient-live_cfg.py
@@ -107,3 +107,4 @@ if (process.runType.getRunType() == process.runType.hi_run):
 ### process customizations included here
 from DQM.Integration.config.online_customizations_cfi import *
 process = customise(process)
+print("Final Source settings:", process.source)

--- a/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
@@ -659,3 +659,4 @@ if (process.runType.getRunType() == process.runType.hi_run):
 ### process customizations included here
 from DQM.Integration.config.online_customizations_cfi import *
 process = customise(process)
+print("Final Source settings:", process.source)

--- a/DQM/Integration/python/clients/visualization-live-secondInstance_cfg.py
+++ b/DQM/Integration/python/clients/visualization-live-secondInstance_cfg.py
@@ -14,7 +14,7 @@ if 'unitTest=True' in sys.argv:
 if unitTest:
     from DQM.Integration.config.unittestinputsource_cfi import options, runType, source
 else:
-    from DQM.Integration.config.inputsource_cfi import options, runType, source
+    from DQM.Integration.config.inputsource_cfi import options, runType, source, set_BeamSplashRun_settings
 
 # this is needed to map the names of the run-types chosen by DQM to the scenarios, ideally we could converge to the same names
 #scenarios = {'pp_run': 'ppEra_Run2_2016','cosmic_run':'cosmicsEra_Run2_2016','hi_run':'HeavyIons'}
@@ -26,6 +26,9 @@ if not runType.getRunTypeName() in scenarios.keys():
     raise RuntimeError(msg)
 
 scenarioName = scenarios[runType.getRunTypeName()]
+
+if not unitTest and process.BeamSplashRun :
+  scenarioName = 'ppEra_Run3'
 
 print("Using scenario:",scenarioName)
 
@@ -68,6 +71,8 @@ if not unitTest:
     process.source.minEventsPerLumi              = 0
     process.source.nextLumiTimeoutMillis         = 10000
     process.source.streamLabel                   = 'streamDQMEventDisplay'
+    if process.BeamSplashRun :
+      set_BeamSplashRun_settings( process.source )
 
     m = re.search(r"\((\w+)\)", str(source.runNumber))
     runno = str(m.group(1))
@@ -118,3 +123,4 @@ if dump:
     psetFile.close()
     cmsRun = "cmsRun -e RunVisualizationProcessingCfg.py"
     print("Now do:\n%s" % cmsRun)
+print("Final Source settings:", process.source)

--- a/DQM/Integration/python/clients/visualization-live-secondInstance_cfg.py
+++ b/DQM/Integration/python/clients/visualization-live-secondInstance_cfg.py
@@ -14,7 +14,7 @@ if 'unitTest=True' in sys.argv:
 if unitTest:
     from DQM.Integration.config.unittestinputsource_cfi import options, runType, source
 else:
-    from DQM.Integration.config.inputsource_cfi import options, runType, source, set_BeamSplashRun_settings
+    from DQM.Integration.config.inputsource_cfi import options, runType, source, BeamSplashRun, set_BeamSplashRun_settings
 
 # this is needed to map the names of the run-types chosen by DQM to the scenarios, ideally we could converge to the same names
 #scenarios = {'pp_run': 'ppEra_Run2_2016','cosmic_run':'cosmicsEra_Run2_2016','hi_run':'HeavyIons'}
@@ -27,8 +27,9 @@ if not runType.getRunTypeName() in scenarios.keys():
 
 scenarioName = scenarios[runType.getRunTypeName()]
 
-if not unitTest and process.BeamSplashRun :
-  scenarioName = 'ppEra_Run3'
+if not unitTest :
+  if BeamSplashRun :
+    scenarioName = 'ppEra_Run3'
 
 print("Using scenario:",scenarioName)
 

--- a/DQM/Integration/python/clients/visualization-live-secondInstance_cfg.py
+++ b/DQM/Integration/python/clients/visualization-live-secondInstance_cfg.py
@@ -14,7 +14,7 @@ if 'unitTest=True' in sys.argv:
 if unitTest:
     from DQM.Integration.config.unittestinputsource_cfi import options, runType, source
 else:
-    from DQM.Integration.config.inputsource_cfi import options, runType, source, BeamSplashRun, set_BeamSplashRun_settings
+    from DQM.Integration.config.inputsource_cfi import options, runType, source, set_BeamSplashRun_settings
 
 # this is needed to map the names of the run-types chosen by DQM to the scenarios, ideally we could converge to the same names
 #scenarios = {'pp_run': 'ppEra_Run2_2016','cosmic_run':'cosmicsEra_Run2_2016','hi_run':'HeavyIons'}
@@ -28,7 +28,7 @@ if not runType.getRunTypeName() in scenarios.keys():
 scenarioName = scenarios[runType.getRunTypeName()]
 
 if not unitTest :
-  if BeamSplashRun :
+  if options.BeamSplashRun :
     # scenarioName = 'ppEra_Run3' FIXME
     pass
 
@@ -73,7 +73,7 @@ if not unitTest:
     process.source.minEventsPerLumi              = 0
     process.source.nextLumiTimeoutMillis         = 10000
     process.source.streamLabel                   = 'streamDQMEventDisplay'
-    if BeamSplashRun :
+    if options.BeamSplashRun :
       set_BeamSplashRun_settings( process.source )
 
     m = re.search(r"\((\w+)\)", str(source.runNumber))

--- a/DQM/Integration/python/clients/visualization-live-secondInstance_cfg.py
+++ b/DQM/Integration/python/clients/visualization-live-secondInstance_cfg.py
@@ -29,7 +29,8 @@ scenarioName = scenarios[runType.getRunTypeName()]
 
 if not unitTest :
   if BeamSplashRun :
-    scenarioName = 'ppEra_Run3'
+    # scenarioName = 'ppEra_Run3' FIXME
+    pass
 
 print("Using scenario:",scenarioName)
 
@@ -72,7 +73,7 @@ if not unitTest:
     process.source.minEventsPerLumi              = 0
     process.source.nextLumiTimeoutMillis         = 10000
     process.source.streamLabel                   = 'streamDQMEventDisplay'
-    if process.BeamSplashRun :
+    if BeamSplashRun :
       set_BeamSplashRun_settings( process.source )
 
     m = re.search(r"\((\w+)\)", str(source.runNumber))

--- a/DQM/Integration/python/clients/visualization-live_cfg.py
+++ b/DQM/Integration/python/clients/visualization-live_cfg.py
@@ -14,7 +14,7 @@ if 'unitTest=True' in sys.argv:
 if unitTest:
     from DQM.Integration.config.unittestinputsource_cfi import options, runType, source
 else:
-    from DQM.Integration.config.inputsource_cfi import options, runType, source, BeamSplashRun, set_BeamSplashRun_settings
+    from DQM.Integration.config.inputsource_cfi import options, runType, source, set_BeamSplashRun_settings
 
 # this is needed to map the names of the run-types chosen by DQM to the scenarios, ideally we could converge to the same names
 #scenarios = {'pp_run': 'ppEra_Run2_2016','cosmic_run':'cosmicsEra_Run2_2016','hi_run':'HeavyIons'}
@@ -28,7 +28,7 @@ if not runType.getRunTypeName() in scenarios.keys():
 scenarioName = scenarios[runType.getRunTypeName()]
 
 if not unitTest :
-  if BeamSplashRun :
+  if options.BeamSplashRun :
     # scenarioName = 'ppEra_Run3' #FIXME
     pass
 
@@ -71,7 +71,7 @@ if not unitTest:
     process.source.minEventsPerLumi              = 0
     process.source.nextLumiTimeoutMillis         = 10000
     process.source.streamLabel                   = 'streamDQM'
-    if BeamSplashRun :
+    if options.BeamSplashRun :
       set_BeamSplashRun_settings( process.source )
 
     m = re.search(r"\((\w+)\)", str(source.runNumber))

--- a/DQM/Integration/python/clients/visualization-live_cfg.py
+++ b/DQM/Integration/python/clients/visualization-live_cfg.py
@@ -29,7 +29,8 @@ scenarioName = scenarios[runType.getRunTypeName()]
 
 if not unitTest :
   if BeamSplashRun :
-    scenarioName = 'ppEra_Run3'
+    # scenarioName = 'ppEra_Run3' #FIXME
+    pass
 
 print("Using scenario:",scenarioName)
 
@@ -70,7 +71,7 @@ if not unitTest:
     process.source.minEventsPerLumi              = 0
     process.source.nextLumiTimeoutMillis         = 10000
     process.source.streamLabel                   = 'streamDQM'
-    if process.BeamSplashRun :
+    if BeamSplashRun :
       set_BeamSplashRun_settings( process.source )
 
     m = re.search(r"\((\w+)\)", str(source.runNumber))

--- a/DQM/Integration/python/clients/visualization-live_cfg.py
+++ b/DQM/Integration/python/clients/visualization-live_cfg.py
@@ -14,7 +14,7 @@ if 'unitTest=True' in sys.argv:
 if unitTest:
     from DQM.Integration.config.unittestinputsource_cfi import options, runType, source
 else:
-    from DQM.Integration.config.inputsource_cfi import options, runType, source, set_BeamSplashRun_settings
+    from DQM.Integration.config.inputsource_cfi import options, runType, source, BeamSplashRun, set_BeamSplashRun_settings
 
 # this is needed to map the names of the run-types chosen by DQM to the scenarios, ideally we could converge to the same names
 #scenarios = {'pp_run': 'ppEra_Run2_2016','cosmic_run':'cosmicsEra_Run2_2016','hi_run':'HeavyIons'}
@@ -27,8 +27,9 @@ if not runType.getRunTypeName() in scenarios.keys():
 
 scenarioName = scenarios[runType.getRunTypeName()]
 
-if not unitTest and process.BeamSplashRun :
-  scenarioName = 'ppEra_Run3'
+if not unitTest :
+  if BeamSplashRun :
+    scenarioName = 'ppEra_Run3'
 
 print("Using scenario:",scenarioName)
 

--- a/DQM/Integration/python/clients/visualization-live_cfg.py
+++ b/DQM/Integration/python/clients/visualization-live_cfg.py
@@ -14,7 +14,7 @@ if 'unitTest=True' in sys.argv:
 if unitTest:
     from DQM.Integration.config.unittestinputsource_cfi import options, runType, source
 else:
-    from DQM.Integration.config.inputsource_cfi import options, runType, source
+    from DQM.Integration.config.inputsource_cfi import options, runType, source, set_BeamSplashRun_settings
 
 # this is needed to map the names of the run-types chosen by DQM to the scenarios, ideally we could converge to the same names
 #scenarios = {'pp_run': 'ppEra_Run2_2016','cosmic_run':'cosmicsEra_Run2_2016','hi_run':'HeavyIons'}
@@ -26,6 +26,9 @@ if not runType.getRunTypeName() in scenarios.keys():
     raise RuntimeError(msg)
 
 scenarioName = scenarios[runType.getRunTypeName()]
+
+if not unitTest and process.BeamSplashRun :
+  scenarioName = 'ppEra_Run3'
 
 print("Using scenario:",scenarioName)
 
@@ -66,6 +69,8 @@ if not unitTest:
     process.source.minEventsPerLumi              = 0
     process.source.nextLumiTimeoutMillis         = 10000
     process.source.streamLabel                   = 'streamDQM'
+    if process.BeamSplashRun :
+      set_BeamSplashRun_settings( process.source )
 
     m = re.search(r"\((\w+)\)", str(source.runNumber))
     runno = str(m.group(1))
@@ -113,3 +118,4 @@ if dump:
     psetFile.close()
     cmsRun = "cmsRun -e RunVisualizationProcessingCfg.py"
     print("Now do:\n%s" % cmsRun)
+print("Final Source settings:", process.source)

--- a/DQM/Integration/python/config/inputsource_cfi.py
+++ b/DQM/Integration/python/config/inputsource_cfi.py
@@ -110,4 +110,19 @@ else:
 #    secondaryFileNames = cms.untracked.vstring()
 #)
 
-print("Source:", source)
+# https://twiki.cern.ch/twiki/bin/viewauth/CMS/CMSBeamSplash2017
+def set_BeamSplashRun_settings( source ):
+  source.minEventsPerLumi      = 1000000
+  source.nextLumiTimeoutMillis = 15000
+
+BeamSplashRun = False
+if BeamSplashRun : set_BeamSplashRun_settings( source )
+
+
+print("Initial Source settings:", source)
+
+
+
+
+
+

--- a/DQM/Integration/python/config/inputsource_cfi.py
+++ b/DQM/Integration/python/config/inputsource_cfi.py
@@ -45,6 +45,12 @@ options.register('noDB',
                  VarParsing.VarParsing.varType.bool,
                  "Don't upload the BeamSpot conditions to the DB")
 
+options.register('BeamSplashRun',
+                 False, # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.bool,
+                 "Set client source settings for beam SPLASH run")
+
 # Parameters for runType
 
 options.register ('runkey',
@@ -115,9 +121,7 @@ def set_BeamSplashRun_settings( source ):
   source.minEventsPerLumi      = 1000000
   source.nextLumiTimeoutMillis = 15000
 
-BeamSplashRun = False
-if BeamSplashRun : set_BeamSplashRun_settings( source )
-
+if options.BeamSplashRun : set_BeamSplashRun_settings( source )
 
 print("Initial Source settings:", source)
 

--- a/DQM/Integration/python/config/pbsource_cfi.py
+++ b/DQM/Integration/python/config/pbsource_cfi.py
@@ -91,4 +91,4 @@ def set_BeamSplashRun_settings( source ):
 BeamSplashRun = False
 if BeamSplashRun : set_BeamSplashRun_settings( source )
 
-print("Source:", source)
+print("Initial Source settings:", source)

--- a/DQM/Integration/python/config/pbsource_cfi.py
+++ b/DQM/Integration/python/config/pbsource_cfi.py
@@ -83,4 +83,12 @@ source = cms.Source("DQMProtobufReader",
     endOfRunKills  = cms.untracked.bool(endOfRunKills),
 )
 
+# https://twiki.cern.ch/twiki/bin/viewauth/CMS/CMSBeamSplash2017
+def set_BeamSplashRun_settings( source ):
+  source.minEventsPerLumi      = 1000000
+  source.nextLumiTimeoutMillis = 15000
+
+BeamSplashRun = False
+if BeamSplashRun : set_BeamSplashRun_settings( source )
+
 print("Source:", source)

--- a/DQM/Integration/python/config/pbsource_cfi.py
+++ b/DQM/Integration/python/config/pbsource_cfi.py
@@ -32,6 +32,12 @@ options.register('skipFirstLumis',
                  VarParsing.VarParsing.varType.bool,
                  "Skip (and ignore the minEventsPerLumi parameter) for the files which have been available at the begining of the processing. ")
 
+options.register('BeamSplashRun',
+                 False, # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.bool,
+                 "Set client source settings for beam SPLASH run")
+
 # Parameters for runType
 
 options.register ('runkey',
@@ -88,7 +94,8 @@ def set_BeamSplashRun_settings( source ):
   # source.minEventsPerLumi      = 1000000
   source.nextLumiTimeoutMillis = 15000
 
-BeamSplashRun = False
-if BeamSplashRun : set_BeamSplashRun_settings( source )
+if options.BeamSplashRun : set_BeamSplashRun_settings( source )
 
 print("Initial Source settings:", source)
+
+

--- a/DQM/Integration/python/config/pbsource_cfi.py
+++ b/DQM/Integration/python/config/pbsource_cfi.py
@@ -85,7 +85,7 @@ source = cms.Source("DQMProtobufReader",
 
 # https://twiki.cern.ch/twiki/bin/viewauth/CMS/CMSBeamSplash2017
 def set_BeamSplashRun_settings( source ):
-  source.minEventsPerLumi      = 1000000
+  # source.minEventsPerLumi      = 1000000
   source.nextLumiTimeoutMillis = 15000
 
 BeamSplashRun = False


### PR DESCRIPTION
#### PR description:

Add predefined DQM splash run settings to simplify switch from default run settings to splash run settings, following [0, 1].
Add Final Source settings printout.

[0] https://indico.cern.ch/event/928899/contributions/3905163/attachments/2056166/3447902/dqm-online.pdf
[1] https://twiki.cern.ch/twiki/bin/view/CMS/CMSBeamSplash2017

#### PR validation:

Forwardport of https://github.com/cms-sw/cmssw/pull/35226
