### PR TITLE
Removed check on PDG code in GenParticleProducer

### DIFF
--- a/PhysicsTools/HepMCCandAlgos/plugins/GenParticleProducer.cc
+++ b/PhysicsTools/HepMCCandAlgos/plugins/GenParticleProducer.cc
@@ -147,7 +147,7 @@ static const double mmToCm = 0.1;
 static const double mmToNs = 1.0 / 299792458e-6;
 
 GenParticleProducer::GenParticleProducer(const ParameterSet& cfg)
-    : abortOnUnknownPDGCode_(cfg.getUntrackedParameter<bool>("abortOnUnknownPDGCode", true)),
+    : abortOnUnknownPDGCode_(false),
       saveBarCodes_(cfg.getUntrackedParameter<bool>("saveBarCodes", false)),
       doSubEvent_(cfg.getUntrackedParameter<bool>("doSubEvent", false)),
       useCF_(cfg.getUntrackedParameter<bool>("useCrossingFrame", false)) {


### PR DESCRIPTION
#### PR description:
This PR fix Run-1 problem described in #34586 . It is a simple fix - removed extra check of the pdg code (as in Run-2 and Run-3). This check overdoing control on pdg ID for event generator. a0 and f0 mesons (which provide exception) never path filters in HepMC -> Geant4 converter. In general, such exception should be in Geant4 side if a wrong particle appears.

The reason of the problem likely in GT for Run-1.

#### PR validation:
WF 4007.0


#### if this PR is a backport please specify the original PR and why you need to backport that PR: No

