### PR TITLE
Add GPU workflow to runTheMatrix

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -69,13 +69,14 @@ class MatrixInjector(object):
         # Checking and setting up GPU attributes
         ####################################
         # Mendatory
-        self.RequiresGPU = opt.RequiresGPU
+        self.RequiresGPU='forbidden'
+        if opt.gpu: self.RequiresGPU=opt.gpu
         if self.RequiresGPU not in ('forbidden','optional','required'):
-            print('RequiresGPU must be forbidden, optional, required. Now, set to forbidden.')
+            print("'--gpu option' you provided are not 'forbidden', 'optional', 'required'. Now, set to forbidden.")
             self.RequiresGPU = 'forbidden'
-        if self.RequiresGPU == 'optional':
-            print('Optional GPU is turned off for RelVals. Now, changing it to forbidden')
-            self.RequiresGPU = 'forbidden'
+        #if self.RequiresGPU == 'optional':
+        #print("Optional GPU is turned off for RelVals. Now, changing it to forbidden")
+        #self.RequiresGPU = 'forbidden'
         self.GPUMemoryMB = opt.GPUMemoryMB
         self.CUDACapabilities = opt.CUDACapabilities.split(',')
         self.CUDARuntime = opt.CUDARuntime

--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -69,16 +69,9 @@ class MatrixInjector(object):
         # Checking and setting up GPU attributes
         ####################################
         # Mendatory
-        self.RequiresGPU='forbidden'
-        if opt.gpu: self.RequiresGPU=opt.gpu
-        if self.RequiresGPU not in ('forbidden','optional','required'):
-            print("'--gpu option' you provided are not 'forbidden', 'optional', 'required'. Now, set to forbidden.")
-            self.RequiresGPU = 'forbidden'
-        #if self.RequiresGPU == 'optional':
-        #print("Optional GPU is turned off for RelVals. Now, changing it to forbidden")
-        #self.RequiresGPU = 'forbidden'
+        self.RequiresGPU = opt.gpu
         self.GPUMemoryMB = opt.GPUMemoryMB
-        self.CUDACapabilities = opt.CUDACapabilities.split(',')
+        self.CUDACapabilities = opt.CUDACapabilities
         self.CUDARuntime = opt.CUDARuntime
         # optional
         self.GPUName = opt.GPUName
@@ -438,7 +431,7 @@ class MatrixInjector(object):
                                     if setPrimaryDs:
                                         chainDict['nowmTasklist'][-1]['PrimaryDataset']=setPrimaryDs
                                 nextHasDSInput=None
-                                if 'GPU' in step and self.RequiresGPU == 'required':
+                                if 'GPU' in step and self.RequiresGPU != 'forbidden':
                                     chainDict['nowmTasklist'][-1]['RequiresGPU'] = self.RequiresGPU
                                     chainDict['nowmTasklist'][-1]['GPUParams']=json.dumps(self.defaultGPUParams)
                             else:
@@ -453,7 +446,7 @@ class MatrixInjector(object):
                                     chainDict['nowmTasklist'][-1]['LumisPerJob']=splitForThisWf
                                 if step in wmsplit:
                                     chainDict['nowmTasklist'][-1]['LumisPerJob']=wmsplit[step]
-                                if 'GPU' in step and self.RequiresGPU == 'required':
+                                if 'GPU' in step and self.RequiresGPU != 'forbidden':
                                     chainDict['nowmTasklist'][-1]['RequiresGPU'] = self.RequiresGPU
                                     chainDict['nowmTasklist'][-1]['GPUParams']=json.dumps(self.defaultGPUParams)
 

--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -208,15 +208,9 @@ class MatrixInjector(object):
             "CUDACapabilities": self.CUDACapabilities,
             "CUDARuntime": self.CUDARuntime
             }
-        
-        self.dictGPUName={"GPUName": self.GPUName}
-        if self.GPUName: self.defaultGPUParams.update(self.dictGPUName)
-        
-        self.dictCUDADriverVersion={"CUDADriverVersion": self.CUDADriverVersion}
-        if self.CUDADriverVersion: self.defaultGPUParams.update(self.dictCUDADriverVersion)
-        
-        self.dictCUDARuntimeVersion={"CUDARuntimeVersion": self.CUDARuntimeVersion}
-        if self.CUDARuntimeVersion: elf.defaultGPUParams.update(self.dictCUDARuntimeVersion)
+        if self.GPUName: self.defaultGPUParams.update({"GPUName": self.GPUName})
+        if self.CUDADriverVersion: self.defaultGPUParams.update({"CUDADriverVersion": self.CUDADriverVersion})
+        if self.CUDARuntimeVersion: self.defaultGPUParams.update({"CUDARuntimeVersion": self.CUDARuntimeVersion})
 
         self.chainDicts={}
 

--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -206,11 +206,17 @@ class MatrixInjector(object):
         self.defaultGPUParams={
             "GPUMemoryMB": self.GPUMemoryMB,
             "CUDACapabilities": self.CUDACapabilities,
-            "CUDARuntime": self.CUDARuntime,
-            "GPUName": self.GPUName,
-            "CUDADriverVersion": self.CUDADriverVersion,
-            "CUDARuntimeVersion": self.CUDARuntimeVersion
+            "CUDARuntime": self.CUDARuntime
             }
+        
+        self.dictGPUName={"GPUName": self.GPUName}
+        if self.GPUName: self.defaultGPUParams.update(self.dictGPUName)
+        
+        self.dictCUDADriverVersion={"CUDADriverVersion": self.CUDADriverVersion}
+        if self.CUDADriverVersion: self.defaultGPUParams.update(self.dictCUDADriverVersion)
+        
+        self.dictCUDARuntimeVersion={"CUDARuntimeVersion": self.CUDARuntimeVersion}
+        if self.CUDARuntimeVersion: elf.defaultGPUParams.update(self.dictCUDARuntimeVersion)
 
         self.chainDicts={}
 

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -218,9 +218,7 @@ if __name__ == '__main__':
                         help='When submitting workflows to wmcontrol, force DQM outout to use pool and not DQMIO',
                         choices=['yes','no'],
                         dest='revertDqmio',
-                        default='no',
-                        const='no',
-                        nargs='?')
+                        default='no')
     
     parser.add_argument('--optionswm',
                         help='Specify a few things for wm injection',

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -104,278 +104,254 @@ if __name__ == '__main__':
         }
 
 
-    import optparse
+    import argparse
     usage = 'usage: runTheMatrix.py --show -s '
 
-    parser = optparse.OptionParser(usage)
+    parser = argparse.ArgumentParser(usage)
 
-    parser.add_option('-b','--batchName',
-                      help='relval batch: suffix to be appended to Campaign name',
-                      dest='batchName',
-                      default=''
-                     )
+    parser.add_argument('-b','--batchName',
+                        help='relval batch: suffix to be appended to Campaign name',
+                        dest='batchName',
+                        default='')
 
-    parser.add_option('-m','--memoryOffset',
-                      help='memory of the wf for single core',
-                      dest='memoryOffset',
-                      default=3000
-                     )
+    parser.add_argument('-m','--memoryOffset',
+                        help='memory of the wf for single core',
+                        dest='memoryOffset',
+                        default=3000)
 
-    parser.add_option('--addMemPerCore',
-                      help='increase of memory per each n > 1 core:  memory(n_core) = memoryOffset + (n_core-1) * memPerCore',
-                      dest='memPerCore',
-                      default=1500
-                     )
+    parser.add_argument('--addMemPerCore',
+                        help='increase of memory per each n > 1 core:  memory(n_core) = memoryOffset + (n_core-1) * memPerCore',
+                        dest='memPerCore',
+                        default=1500)
     
-    parser.add_option('-j','--nproc',
-                      help='number of processes. 0 Will use 4 processes, not execute anything but create the wfs',
-                      dest='nProcs',
-                      default=4
-                     )
+    parser.add_argument('-j','--nproc',
+                        help='number of processes. 0 Will use 4 processes, not execute anything but create the wfs',
+                        dest='nProcs',
+                        default=4)
     
-    parser.add_option('-t','--nThreads',
-                      help='number of threads per process to use in cmsRun.',
-                      dest='nThreads',
-                      default=1
-                     )
+    parser.add_argument('-t','--nThreads',
+                        help='number of threads per process to use in cmsRun.',
+                        dest='nThreads',
+                        default=1)
     
-    parser.add_option('--nStreams',
-                      help='number of streams to use in cmsRun.',
-                      dest='nStreams',
-                      default=0
-                     )
+    parser.add_argument('--nStreams',
+                        help='number of streams to use in cmsRun.',
+                        dest='nStreams',
+                        default=0)
     
-    parser.add_option('--numberEventsInLuminosityBlock',
-                      help='number of events in a luminosity block',
-                      dest='numberEventsInLuminosityBlock',
-                      default=-1
-                     )
+    parser.add_argument('--numberEventsInLuminosityBlock',
+                        help='number of events in a luminosity block',
+                        dest='numberEventsInLuminosityBlock',
+                        default=-1)
 
-    parser.add_option('-n','--showMatrix',
-                      help='Only show the worflows. Use --ext to show more',
-                      dest='show',
-                      default=False,
-                      action='store_true'
-                      )
+    parser.add_argument('-n','--showMatrix',
+                        help='Only show the worflows. Use --ext to show more',
+                        dest='show',
+                        default=False,
+                        action='store_true')
     
-    parser.add_option('-e','--extended',
-                      help='Show details of workflows, used with --show',
-                      dest='extended',
-                      default=False,
-                      action='store_true'
-                      )
+    parser.add_argument('-e','--extended',
+                        help='Show details of workflows, used with --show',
+                        dest='extended',
+                        default=False,
+                        action='store_true')
     
-    parser.add_option('-s','--selected',
-                      help='Run a pre-defined selected matrix of wf. Deprecated, please use -l limited',
-                      dest='restricted',
-                      default=False,
-                      action='store_true'
-                      )
+    parser.add_argument('-s','--selected',
+                        help='Run a pre-defined selected matrix of wf. Deprecated, please use -l limited',
+                        dest='restricted',
+                        default=False,
+                        action='store_true')
     
-    parser.add_option('-l','--list',
-                     help='Comma separated list of workflow to be shown or ran. Possible keys are also '+str(predefinedSet.keys())+'. and wild card like muon, or mc',
-                     dest='testList',
-                     default=None
-                     )
+    parser.add_argument('-l','--list',
+                        help='Comma separated list of workflow to be shown or ran. Possible keys are also '+str(predefinedSet.keys())+'. and wild card like muon, or mc',
+                        dest='testList',
+                        default=None)
     
-    parser.add_option('-r','--raw',
-                      help='Temporary dump the .txt needed for prodAgent interface. To be discontinued soon. Argument must be the name of the set (standard, pileup,...)',
-                      dest='raw'
-                      )
+    parser.add_argument('-r','--raw',
+                        help='Temporary dump the .txt needed for prodAgent interface. To be discontinued soon. Argument must be the name of the set (standard, pileup,...)',
+                        dest='raw')
     
-    parser.add_option('-i','--useInput',
-                      help='Use recyling where available. Either all, or a comma separated list of wf number.',
-                      dest='useInput',
-                      default=None
-                      )
+    parser.add_argument('-i','--useInput',
+                        help='Use recyling where available. Either all, or a comma separated list of wf number.',
+                        dest='useInput',
+                        default=None)
     
-    parser.add_option('-w','--what',
-                      help='Specify the set to be used. Argument must be the name of a set (standard, pileup,...) or multiple sets separated by commas (--what standard,pileup )',
-                      dest='what',
-                      default='all'
-                      )
+    parser.add_argument('-w','--what',
+                        help='Specify the set to be used. Argument must be the name of a set (standard, pileup,...) or multiple sets separated by commas (--what standard,pileup )',
+                        dest='what',
+                        default='all')
     
-    parser.add_option('--step1',
-                      help='Used with --raw. Limit the production to step1',
-                      dest='step1Only',
-                      default=False
-                      )
+    parser.add_argument('--step1',
+                        help='Used with --raw. Limit the production to step1',
+                        dest='step1Only',
+                        default=False)
     
-    parser.add_option('--maxSteps',
-                      help='Only run maximum on maxSteps. Used when we are only interested in first n steps.',
-                      dest='maxSteps',
-                      default=9999,
-                      type="int"
-                      )
+    parser.add_argument('--maxSteps',
+                        help='Only run maximum on maxSteps. Used when we are only interested in first n steps.',
+                        dest='maxSteps',
+                        default=9999,
+                        type=int)
     
-    parser.add_option('--fromScratch',
-                      help='Comma separated list of wf to be run without recycling. all is not supported as default.',
-                      dest='fromScratch',
-                      default=None
-                       )
+    parser.add_argument('--fromScratch',
+                        help='Comma separated list of wf to be run without recycling. all is not supported as default.',
+                        dest='fromScratch',
+                        default=None)
     
-    parser.add_option('--refRelease',
-                      help='Allow to modify the recycling dataset version',
-                      dest='refRel',
-                      default=None
-                      )
+    parser.add_argument('--refRelease',
+                        help='Allow to modify the recycling dataset version',
+                        dest='refRel',
+                        default=None)
     
-    parser.add_option('--wmcontrol',
-                      help='Create the workflows for injection to WMAgent. In the WORKING. -wmcontrol init will create the the workflows, -wmcontrol test will dryRun a test, -wmcontrol submit will submit to wmagent',
-                      choices=['init','test','submit','force'],
-                      dest='wmcontrol',
-                      default=None,
-                      )
+    parser.add_argument('--wmcontrol',
+                        help='Create the workflows for injection to WMAgent. In the WORKING. -wmcontrol init will create the the workflows, -wmcontrol test will dryRun a test, -wmcontrol submit will submit to wmagent',
+                        choices=['init','test','submit','force'],
+                        dest='wmcontrol',
+                        default='test',
+                        const='test',
+                        nargs='?')
     
-    parser.add_option('--revertDqmio',
-                      help='When submitting workflows to wmcontrol, force DQM outout to use pool and not DQMIO',
-                      choices=['yes','no'],
-                      dest='revertDqmio',
-                      default='no',
-                      )
+    parser.add_argument('--revertDqmio',
+                        help='When submitting workflows to wmcontrol, force DQM outout to use pool and not DQMIO',
+                        choices=['yes','no'],
+                        dest='revertDqmio',
+                        default='no',
+                        const='no',
+                        nargs='?')
     
-    parser.add_option('--optionswm',
-                      help='Specify a few things for wm injection',
-                      default='',
-                      dest='wmoptions')
+    parser.add_argument('--optionswm',
+                        help='Specify a few things for wm injection',
+                        default='',
+                        dest='wmoptions')
     
-    parser.add_option('--keep',
-                      help='allow to specify for which comma separated steps the output is needed',
-                      default=None)
+    parser.add_argument('--keep',
+                        help='allow to specify for which comma separated steps the output is needed',
+                        default=None)
     
-    parser.add_option('--label',
-                      help='allow to give a special label to the output dataset name',
-                      default='')
+    parser.add_argument('--label',
+                        help='allow to give a special label to the output dataset name',
+                        default='')
     
-    parser.add_option('--command',
-                      help='provide a way to add additional command to all of the cmsDriver commands in the matrix',
-                      dest='command',
-                      action='append',
-                      default=None
-                      )
+    parser.add_argument('--command',
+                        help='provide a way to add additional command to all of the cmsDriver commands in the matrix',
+                        dest='command',
+                        action='append',
+                        default=None)
     
-    parser.add_option('--apply',
-                      help='allow to use the --command only for 1 comma separeated',
-                      dest='apply',
-                      default=None)
+    parser.add_argument('--apply',
+                        help='allow to use the --command only for 1 comma separeated',
+                        dest='apply',
+                        default=None)
     
-    parser.add_option('--workflow',
-                      help='define a workflow to be created or altered from the matrix',
-                      action='append',
-                      dest='workflow',
-                      default=None
-                      )
+    parser.add_argument('--workflow',
+                        help='define a workflow to be created or altered from the matrix',
+                        action='append',
+                        dest='workflow',
+                        default=None)
     
-    parser.add_option('--dryRun',
-                      help='do not run the wf at all',
-                      action='store_true',
-                      dest='dryRun',
-                      default=False
-                      )
+    parser.add_argument('--dryRun',
+                        help='do not run the wf at all',
+                        action='store_true',
+                        dest='dryRun',
+                        default=False)
     
-    parser.add_option('--testbed',
-                      help='workflow injection to cmswebtest (you need dedicated rqmgr account)',
-                      dest='testbed',
-                      default=False,
-                      action='store_true'
-                      )
+    parser.add_argument('--testbed',
+                        help='workflow injection to cmswebtest (you need dedicated rqmgr account)',
+                        dest='testbed',
+                        default=False,
+                        action='store_true')
     
-    parser.add_option('--noCafVeto',
-                      help='Run from any source, ignoring the CAF label',
-                      dest='cafVeto',
-                      default=True,
-                      action='store_false'
-                      )
+    parser.add_argument('--noCafVeto',
+                        help='Run from any source, ignoring the CAF label',
+                        dest='cafVeto',
+                        default=True,
+                        action='store_false')
     
-    parser.add_option('--overWrite',
-                      help='Change the content of a step for another. List of pairs.',
-                      dest='overWrite',
-                      default=None
-                      )
+    parser.add_argument('--overWrite',
+                        help='Change the content of a step for another. List of pairs.',
+                        dest='overWrite',
+                        default=None)
     
-    parser.add_option('--noRun',
-                      help='Remove all run list selection from wfs',
-                      dest='noRun',
-                      default=False,
-                      action='store_true')
+    parser.add_argument('--noRun',
+                        help='Remove all run list selection from wfs',
+                        dest='noRun',
+                        default=False,
+                        action='store_true')
 
-    parser.add_option('--das-options',
-                      help='Options to be passed to dasgoclient.',
-                      dest='dasOptions',
-                      default="--limit 0",
-                      action='store')
+    parser.add_argument('--das-options',
+                        help='Options to be passed to dasgoclient.',
+                        dest='dasOptions',
+                        default="--limit 0",
+                        action='store')
 
-    parser.add_option('--job-reports',
-                      help='Dump framework job reports',
-                      dest='jobReports',
-                      default=False,
-                      action='store_true')
-
-    parser.add_option('--ibeos',
-                      help='Use IB EOS site configuration',
-                      dest='IBEos',
-                      default=False,
-                      action='store_true')
-
-    parser.add_option('--sites',
-                      help='Run DAS query to get data from a specific site (default is T2_CH_CERN). Set it to empty string to search all sites.',
-                      dest='dasSites',
-                      default='T2_CH_CERN',
-                      action='store')
+    parser.add_argument('--job-reports',
+                        help='Dump framework job reports',
+                        dest='jobReports',
+                        default=False,
+                        action='store_true')
     
-    parser.add_option('--interactive',
-                      help="Open the Matrix interactive shell",
-                      action='store_true',
-                      default=False)
+    parser.add_argument('--ibeos',
+                        help='Use IB EOS site configuration',
+                        dest='IBEos',
+                        default=False,
+                        action='store_true')
+    
+    parser.add_argument('--sites',
+                        help='Run DAS query to get data from a specific site (default is T2_CH_CERN). Set it to empty string to search all sites.',
+                        dest='dasSites',
+                        default='T2_CH_CERN',
+                        action='store')
+    
+    parser.add_argument('--interactive',
+                        help="Open the Matrix interactive shell",
+                        action='store_true',
+                        default=False)
+    
+    parser.add_argument('--dbs-url',
+                        help='Overwrite DbsUrl value in JSON submitted to ReqMgr2',
+                        dest='dbsUrl',
+                        default=None,
+                        action='store')
+    
+    parser.add_argument('--gpu','--requires-gpu',
+                        help='Enable GPU workflows. Possible options are "forbidden" (default), "required" (implied if no argument is given), or "optional".',
+                        dest='gpu',
+                        choices=['forbidden', 'optional', 'required'],
+                        nargs='?',
+                        const='required',
+                        default='forbidden',
+                        action='store')
 
-    parser.add_option('--dbs-url',
-                      help='Overwrite DbsUrl value in JSON submitted to ReqMgr2',
-                      dest='dbsUrl',
-                      default=None,
-                      action='store')
-
-    parser.add_option('--gpu',
-                      help='Use GPU workflow setup if available. It will force --requires-gpu required.',
-                      dest='gpuEnable',
-                      default=False,
-                      action='store_true')
-
-    parser.add_option('--requires-gpu',
-                      help='if GPU is required or not: forbidden (default, CPU-only), optional, required. For relvals, the GPU option will be turned off for optional.',
-                      dest='RequiresGPU',
-                      default='forbidden')
-
-    parser.add_option('--gpu-memory-mb',
-                      help='to specify GPU memory. Default = 8000 MB (for --requires-gpu = required).',
-                      dest='GPUMemoryMB',
-                      default=8000)
-
-    parser.add_option('--cuda-capabilities',
-                      help='to specify CUDA capabilities. Default = 6.0,6.1,6.2,7.0,7.2,7.5 (for RequiresGPU = required). Use comma to identify various CUDACapabilities',
-                      dest='CUDACapabilities',
-                      default='6.0,6.1,6.2,7.0,7.2,7.5')
-
-    parser.add_option('--cuda-runtime',
-                      help='to specify major and minor CUDA runtime used to build the application. Default = 11.2 (for RequiresGPU = required). FIX ME TO MATCH WITH CMSSW.',
-                      dest='CUDARuntime',
-                      default='11.2')
-
-    parser.add_option('--gpu-name',
-                      help='to specify GPU class. This is an optional parameter.',
-                      dest='GPUName',
-                      default='')
-
-    parser.add_option('--cuda-driver-version',
-                      help='to specify CUDA driver version. This is an optional parameter.',
-                      dest='CUDADriverVersion',
-                      default='')
-
-    parser.add_option('--cuda-runtime-version',
-                      help='to specify CUDA runtime version. This is an optional parameter.',
-                      dest='CUDARuntimeVersion',
-                      default='')
-
-    opt,args = parser.parse_args()
+    parser.add_argument('--gpu-memory-mb',
+                        help='to specify GPU memory. Default = 8000 MB (with --gpu).',
+                        dest='GPUMemoryMB',
+                        default=8000)
+    
+    parser.add_argument('--cuda-capabilities',
+                        help='to specify CUDA capabilities. Default = 6.0,6.1,6.2,7.0,7.2,7.5 (with --gpu). Use comma to identify various CUDACapabilities',
+                        dest='CUDACapabilities',
+                        default='6.0,6.1,6.2,7.0,7.2,7.5')
+    
+    parser.add_argument('--cuda-runtime',
+                        help='to specify major and minor CUDA runtime used to build the application. Default = 11.2 (with --gpu). FIX ME TO MATCH WITH CMSSW.',
+                        dest='CUDARuntime',
+                        default='11.2')
+    
+    parser.add_argument('--gpu-name',
+                        help='to specify GPU class. This is an optional parameter.',
+                        dest='GPUName',
+                        default='')
+    
+    parser.add_argument('--cuda-driver-version',
+                        help='to specify CUDA driver version. This is an optional parameter.',
+                        dest='CUDADriverVersion',
+                        default='')
+    
+    parser.add_argument('--cuda-runtime-version',
+                        help='to specify CUDA runtime version. This is an optional parameter.',
+                        dest='CUDARuntimeVersion',
+                        default='')
+    
+    opt = parser.parse_args()
     if opt.command: opt.command = ' '.join(opt.command)
     os.environ["CMSSW_DAS_QUERY_SITES"]=opt.dasSites
     if opt.IBEos:
@@ -444,7 +420,6 @@ if __name__ == '__main__':
     if opt.memoryOffset: opt.memoryOffset=int(opt.memoryOffset)
     if opt.memPerCore: opt.memPerCore=int(opt.memPerCore)
     if opt.GPUMemoryMB: opt.GPUMemoryMB=int(opt.GPUMemoryMB)
-    if opt.gpuEnable: opt.RequiresGPU="required"
 
     if opt.wmcontrol:
         performInjectionOptionTest(opt)

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -117,31 +117,37 @@ if __name__ == '__main__':
     parser.add_argument('-m','--memoryOffset',
                         help='memory of the wf for single core',
                         dest='memoryOffset',
+                        type=int,
                         default=3000)
 
     parser.add_argument('--addMemPerCore',
                         help='increase of memory per each n > 1 core:  memory(n_core) = memoryOffset + (n_core-1) * memPerCore',
                         dest='memPerCore',
+                        type=int,
                         default=1500)
     
     parser.add_argument('-j','--nproc',
                         help='number of processes. 0 Will use 4 processes, not execute anything but create the wfs',
                         dest='nProcs',
+                        type=int,
                         default=4)
     
     parser.add_argument('-t','--nThreads',
                         help='number of threads per process to use in cmsRun.',
                         dest='nThreads',
+                        type=int,
                         default=1)
     
     parser.add_argument('--nStreams',
                         help='number of streams to use in cmsRun.',
                         dest='nStreams',
+                        type=int,
                         default=0)
     
     parser.add_argument('--numberEventsInLuminosityBlock',
                         help='number of events in a luminosity block',
                         dest='numberEventsInLuminosityBlock',
+                        type=int,
                         default=-1)
 
     parser.add_argument('-n','--showMatrix',
@@ -323,33 +329,40 @@ if __name__ == '__main__':
                           default='forbidden',
                           action='store')
 
-    gpugroup.add_argument('--gpu-memory-mb',
-                          help='to specify GPU memory. Default = 8000 MB (with --gpu).',
+    gpugroup.add_argument('--gpu-memory',
+                          help='Specify the minimum amount of GPU memory required by the job, in MB (default: %(default)d MB)',
                           dest='GPUMemoryMB',
+                          type=int,
                           default=8000)
     
     gpugroup.add_argument('--cuda-capabilities',
-                          help='to specify CUDA capabilities. Default = 6.0,6.1,6.2,7.0,7.2,7.5 (with --gpu). Use comma to identify various CUDACapabilities',
+                          help='Specify a comma-separated list of CUDA "compute capabilities", or GPU hardware architectures, that the job can use (default: %(default)s).',
                           dest='CUDACapabilities',
-                          default='6.0,6.1,6.2,7.0,7.2,7.5')
+                          default='6.0,6.1,6.2,7.0,7.2,7.5,8.0,8.6')
     
+    # read the CUDA runtime version included in CMSSW
+    cudart_version = None
+    libcudart = os.path.realpath(os.path.expandvars('$CMSSW_RELEASE_BASE/external/$SCRAM_ARCH/lib/libcudart.so'))
+    if os.path.isfile(libcudart):
+        cudart_basename = os.path.basename(libcudart)
+        cudart_version = '.'.join(cudart_basename.split('.')[2:4])
     gpugroup.add_argument('--cuda-runtime',
-                          help='to specify major and minor CUDA runtime used to build the application. Default = 11.2 (with --gpu). FIX ME TO MATCH WITH CMSSW.',
+                          help='Specify major and minor version of the CUDA runtime used to build the application (default: %(default)s).',
                           dest='CUDARuntime',
-                          default='11.2')
+                          default=cudart_version)
     
     gpugroup.add_argument('--force-gpu-name',
-                          help='to specify GPU class. This is an optional parameter.',
+                          help='Request a specific GPU model, e.g. "Tesla T4" or "NVIDIA GeForce RTX 2080" (default: none). The default behaviour is to accept any supported GPU.',
                           dest='GPUName',
                           default='')
     
     gpugroup.add_argument('--force-cuda-driver-version',
-                          help='to specify CUDA driver version. This is an optional parameter.',
+                          help='Request a specific CUDA driver version, e.g. 470.57.02 (default: none). The default behaviour is to accept any supported CUDA driver version.',
                           dest='CUDADriverVersion',
                           default='')
     
     gpugroup.add_argument('--force-cuda-runtime-version',
-                          help='to specify CUDA runtime version. This is an optional parameter.',
+                          help='Request a specific CUDA runtime version, e.g. 11.4 (default: none). The default behaviour is to accept any supported CUDA runtime version.',
                           dest='CUDARuntimeVersion',
                           default='')
     
@@ -415,13 +428,7 @@ if __name__ == '__main__':
 
     if opt.useInput: opt.useInput = opt.useInput.split(',')
     if opt.fromScratch: opt.fromScratch = opt.fromScratch.split(',')
-    if opt.nProcs: opt.nProcs=int(opt.nProcs)
-    if opt.nThreads: opt.nThreads=int(opt.nThreads)
-    if opt.nStreams: opt.nStreams=int(opt.nStreams)
-    if opt.numberEventsInLuminosityBlock: opt.numberEventsInLuminosityBlock=int(opt.numberEventsInLuminosityBlock)
-    if opt.memoryOffset: opt.memoryOffset=int(opt.memoryOffset)
-    if opt.memPerCore: opt.memPerCore=int(opt.memPerCore)
-    if opt.GPUMemoryMB: opt.GPUMemoryMB=int(opt.GPUMemoryMB)
+    if opt.CUDACapabilities: opt.CUDACapabilities = opt.CUDACapabilities.split(',')
 
     if opt.wmcontrol:
         performInjectionOptionTest(opt)

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -335,42 +335,42 @@ if __name__ == '__main__':
                       action='store')
 
     parser.add_option('--gpu',
-                      help='Use GPU workflow setup if available',
+                      help='Use GPU workflow setup if available. It will force --requires-gpu required.',
                       dest='gpuEnable',
                       default=False,
                       action='store_true')
 
-    parser.add_option('--RequiresGPU',
+    parser.add_option('--requires-gpu',
                       help='if GPU is required or not: forbidden (default, CPU-only), optional, required. For relvals, the GPU option will be turned off for optional.',
                       dest='RequiresGPU',
                       default='forbidden')
 
-    parser.add_option('--GPUMemoryMB',
-                      help='to specify GPU memory. Default = 8000 MB (for RequiresGPU = required).',
+    parser.add_option('--gpu-memory-mb',
+                      help='to specify GPU memory. Default = 8000 MB (for --requires-gpu = required).',
                       dest='GPUMemoryMB',
                       default=8000)
 
-    parser.add_option('--CUDACapabilities',
+    parser.add_option('--cuda-capabilities',
                       help='to specify CUDA capabilities. Default = 6.0,6.1,6.2,7.0,7.2,7.5 (for RequiresGPU = required). Use comma to identify various CUDACapabilities',
                       dest='CUDACapabilities',
                       default='6.0,6.1,6.2,7.0,7.2,7.5')
 
-    parser.add_option('--CUDARuntime',
+    parser.add_option('--cuda-runtime',
                       help='to specify major and minor CUDA runtime used to build the application. Default = 11.2 (for RequiresGPU = required). FIX ME TO MATCH WITH CMSSW.',
                       dest='CUDARuntime',
                       default='11.2')
 
-    parser.add_option('--GPUName',
+    parser.add_option('--gpu-name',
                       help='to specify GPU class. This is an optional parameter.',
                       dest='GPUName',
                       default='')
 
-    parser.add_option('--CUDADriverVersion',
+    parser.add_option('--cuda-driver-version',
                       help='to specify CUDA driver version. This is an optional parameter.',
                       dest='CUDADriverVersion',
                       default='')
 
-    parser.add_option('--CUDARuntimeVersion',
+    parser.add_option('--cuda-runtime-version',
                       help='to specify CUDA runtime version. This is an optional parameter.',
                       dest='CUDARuntimeVersion',
                       default='')

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -120,26 +120,31 @@ if __name__ == '__main__':
                       dest='memoryOffset',
                       default=3000
                      )
+
     parser.add_option('--addMemPerCore',
                       help='increase of memory per each n > 1 core:  memory(n_core) = memoryOffset + (n_core-1) * memPerCore',
                       dest='memPerCore',
                       default=1500
                      )
+    
     parser.add_option('-j','--nproc',
                       help='number of processes. 0 Will use 4 processes, not execute anything but create the wfs',
                       dest='nProcs',
                       default=4
                      )
+    
     parser.add_option('-t','--nThreads',
                       help='number of threads per process to use in cmsRun.',
                       dest='nThreads',
                       default=1
                      )
+    
     parser.add_option('--nStreams',
                       help='number of streams to use in cmsRun.',
                       dest='nStreams',
                       default=0
                      )
+    
     parser.add_option('--numberEventsInLuminosityBlock',
                       help='number of events in a luminosity block',
                       dest='numberEventsInLuminosityBlock',
@@ -152,119 +157,142 @@ if __name__ == '__main__':
                       default=False,
                       action='store_true'
                       )
+    
     parser.add_option('-e','--extended',
                       help='Show details of workflows, used with --show',
                       dest='extended',
                       default=False,
                       action='store_true'
                       )
+    
     parser.add_option('-s','--selected',
                       help='Run a pre-defined selected matrix of wf. Deprecated, please use -l limited',
                       dest='restricted',
                       default=False,
                       action='store_true'
                       )
+    
     parser.add_option('-l','--list',
-                     help='Coma separated list of workflow to be shown or ran. Possible keys are also '+str(predefinedSet.keys())+'. and wild card like muon, or mc',
+                     help='Comma separated list of workflow to be shown or ran. Possible keys are also '+str(predefinedSet.keys())+'. and wild card like muon, or mc',
                      dest='testList',
                      default=None
                      )
+    
     parser.add_option('-r','--raw',
                       help='Temporary dump the .txt needed for prodAgent interface. To be discontinued soon. Argument must be the name of the set (standard, pileup,...)',
                       dest='raw'
                       )
+    
     parser.add_option('-i','--useInput',
-                      help='Use recyling where available. Either all, or a coma separated list of wf number.',
+                      help='Use recyling where available. Either all, or a comma separated list of wf number.',
                       dest='useInput',
                       default=None
                       )
+    
     parser.add_option('-w','--what',
                       help='Specify the set to be used. Argument must be the name of a set (standard, pileup,...) or multiple sets separated by commas (--what standard,pileup )',
                       dest='what',
                       default='all'
                       )
+    
     parser.add_option('--step1',
                       help='Used with --raw. Limit the production to step1',
                       dest='step1Only',
                       default=False
                       )
+    
     parser.add_option('--maxSteps',
                       help='Only run maximum on maxSteps. Used when we are only interested in first n steps.',
                       dest='maxSteps',
                       default=9999,
                       type="int"
                       )
+    
     parser.add_option('--fromScratch',
-                      help='Coma separated list of wf to be run without recycling. all is not supported as default.',
+                      help='Comma separated list of wf to be run without recycling. all is not supported as default.',
                       dest='fromScratch',
                       default=None
                        )
+    
     parser.add_option('--refRelease',
                       help='Allow to modify the recycling dataset version',
                       dest='refRel',
                       default=None
                       )
+    
     parser.add_option('--wmcontrol',
                       help='Create the workflows for injection to WMAgent. In the WORKING. -wmcontrol init will create the the workflows, -wmcontrol test will dryRun a test, -wmcontrol submit will submit to wmagent',
                       choices=['init','test','submit','force'],
                       dest='wmcontrol',
                       default=None,
                       )
+    
     parser.add_option('--revertDqmio',
                       help='When submitting workflows to wmcontrol, force DQM outout to use pool and not DQMIO',
                       choices=['yes','no'],
                       dest='revertDqmio',
                       default='no',
                       )
+    
     parser.add_option('--optionswm',
                       help='Specify a few things for wm injection',
                       default='',
                       dest='wmoptions')
+    
     parser.add_option('--keep',
-                      help='allow to specify for which coma separated steps the output is needed',
+                      help='allow to specify for which comma separated steps the output is needed',
                       default=None)
+    
     parser.add_option('--label',
                       help='allow to give a special label to the output dataset name',
                       default='')
+    
     parser.add_option('--command',
                       help='provide a way to add additional command to all of the cmsDriver commands in the matrix',
                       dest='command',
                       action='append',
                       default=None
                       )
+    
     parser.add_option('--apply',
-                      help='allow to use the --command only for 1 coma separeated',
+                      help='allow to use the --command only for 1 comma separeated',
                       dest='apply',
                       default=None)
+    
     parser.add_option('--workflow',
                       help='define a workflow to be created or altered from the matrix',
                       action='append',
                       dest='workflow',
                       default=None
                       )
+    
     parser.add_option('--dryRun',
                       help='do not run the wf at all',
                       action='store_true',
                       dest='dryRun',
                       default=False
                       )
+    
     parser.add_option('--testbed',
                       help='workflow injection to cmswebtest (you need dedicated rqmgr account)',
                       dest='testbed',
                       default=False,
                       action='store_true'
                       )
+    
     parser.add_option('--noCafVeto',
                       help='Run from any source, ignoring the CAF label',
                       dest='cafVeto',
                       default=True,
                       action='store_false'
                       )
+    
     parser.add_option('--overWrite',
                       help='Change the content of a step for another. List of pairs.',
                       dest='overWrite',
                       default=None
                       )
+    
     parser.add_option('--noRun',
                       help='Remove all run list selection from wfs',
                       dest='noRun',
@@ -294,6 +322,7 @@ if __name__ == '__main__':
                       dest='dasSites',
                       default='T2_CH_CERN',
                       action='store')
+    
     parser.add_option('--interactive',
                       help="Open the Matrix interactive shell",
                       action='store_true',
@@ -304,6 +333,41 @@ if __name__ == '__main__':
                       dest='dbsUrl',
                       default=None,
                       action='store')
+
+    parser.add_option('--RequiresGPU',
+                      help='if GPU is reuired or not: forbidden (default, CPU-only), optional, required. For relvals, the GPU option will be turned off for optional.',
+                      dest='RequiresGPU',
+                      default='forbidden')
+
+    parser.add_option('--GPUMemoryMB',
+                      help='to specify GPU memory. Default = 8000 MB (for RequiresGPU = required).',
+                      dest='GPUMemoryMB',
+                      default='8000')
+
+    parser.add_option('--CUDACapabilities',
+                      help='to specify CUDA capabilities. Default = 7.5 (for RequiresGPU = required). Use comma to identify various CUDACapabilities',
+                      dest='CUDACapabilities',
+                      default='6.0,6.1,6.2,7.0,7.2,7.5')
+
+    parser.add_option('--CUDARuntime',
+                      help='to specify major and minor CUDA runtime used to build the application. Default = 11.2 (for RequiresGPU = required). FIX ME TO MATCH WITH CMSSW.',
+                      dest='CUDARuntime',
+                      default='11.2')
+
+    parser.add_option('--GPUName',
+                      help='to specify GPU class. This is an optional parameter.',
+                      dest='GPUName',
+                      default='')
+
+    parser.add_option('--CUDADriverVersion',
+                      help='to specify CUDA driver version. This is an optional parameter.',
+                      dest='CUDADriverVersion',
+                      default='')
+
+    parser.add_option('--CUDARuntimeVersion',
+                      help='to specify CUDA runtime version. This is an optional parameter.',
+                      dest='CUDARuntimeVersion',
+                      default='')
 
     opt,args = parser.parse_args()
     if opt.command: opt.command = ' '.join(opt.command)
@@ -372,9 +436,9 @@ if __name__ == '__main__':
     if opt.nProcs: opt.nProcs=int(opt.nProcs)
     if opt.nThreads: opt.nThreads=int(opt.nThreads)
     if opt.nStreams: opt.nStreams=int(opt.nStreams)
-    if (opt.numberEventsInLuminosityBlock): opt.numberEventsInLuminosityBlock=int(opt.numberEventsInLuminosityBlock)
-    if (opt.memoryOffset): opt.memoryOffset=int(opt.memoryOffset)
-    if (opt.memPerCore): opt.memPerCore=int(opt.memPerCore)
+    if opt.numberEventsInLuminosityBlock: opt.numberEventsInLuminosityBlock=int(opt.numberEventsInLuminosityBlock)
+    if opt.memoryOffset: opt.memoryOffset=int(opt.memoryOffset)
+    if opt.memPerCore: opt.memPerCore=int(opt.memPerCore)
 
     if opt.wmcontrol:
         performInjectionOptionTest(opt)

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -334,18 +334,24 @@ if __name__ == '__main__':
                       default=None,
                       action='store')
 
+    parser.add_option('--gpu',
+                      help='Use GPU workflow setup if available',
+                      dest='gpuEnable',
+                      default=False,
+                      action='store_true')
+
     parser.add_option('--RequiresGPU',
-                      help='if GPU is reuired or not: forbidden (default, CPU-only), optional, required. For relvals, the GPU option will be turned off for optional.',
+                      help='if GPU is required or not: forbidden (default, CPU-only), optional, required. For relvals, the GPU option will be turned off for optional.',
                       dest='RequiresGPU',
                       default='forbidden')
 
     parser.add_option('--GPUMemoryMB',
                       help='to specify GPU memory. Default = 8000 MB (for RequiresGPU = required).',
                       dest='GPUMemoryMB',
-                      default='8000')
+                      default=8000)
 
     parser.add_option('--CUDACapabilities',
-                      help='to specify CUDA capabilities. Default = 7.5 (for RequiresGPU = required). Use comma to identify various CUDACapabilities',
+                      help='to specify CUDA capabilities. Default = 6.0,6.1,6.2,7.0,7.2,7.5 (for RequiresGPU = required). Use comma to identify various CUDACapabilities',
                       dest='CUDACapabilities',
                       default='6.0,6.1,6.2,7.0,7.2,7.5')
 
@@ -410,8 +416,6 @@ if __name__ == '__main__':
     if opt.keep:
         opt.keep=map(stepOrIndex,opt.keep.split(','))
 
-
-
     if opt.testList:
         testList=[]
         for entry in opt.testList.split(','):
@@ -439,6 +443,8 @@ if __name__ == '__main__':
     if opt.numberEventsInLuminosityBlock: opt.numberEventsInLuminosityBlock=int(opt.numberEventsInLuminosityBlock)
     if opt.memoryOffset: opt.memoryOffset=int(opt.memoryOffset)
     if opt.memPerCore: opt.memPerCore=int(opt.memPerCore)
+    if opt.GPUMemoryMB: opt.GPUMemoryMB=int(opt.GPUMemoryMB)
+    if opt.gpuEnable: opt.RequiresGPU="required"
 
     if opt.wmcontrol:
         performInjectionOptionTest(opt)

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -300,7 +300,7 @@ if __name__ == '__main__':
                         action='store_true')
     
     parser.add_argument('--sites',
-                        help='Run DAS query to get data from a specific site (default is T2_CH_CERN). Set it to empty string to search all sites.',
+                        help='Run DAS query to get data from a specific site. Set it to empty string to search all sites.',
                         dest='dasSites',
                         default='T2_CH_CERN',
                         action='store')

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -312,44 +312,46 @@ if __name__ == '__main__':
                         default=None,
                         action='store')
     
-    parser.add_argument('--gpu','--requires-gpu',
-                        help='Enable GPU workflows. Possible options are "forbidden" (default), "required" (implied if no argument is given), or "optional".',
-                        dest='gpu',
-                        choices=['forbidden', 'optional', 'required'],
-                        nargs='?',
-                        const='required',
-                        default='forbidden',
-                        action='store')
+    gpugroup = parser.add_argument_group('GPU-related options','These options are only meaningful when --gpu is used, and is not set to forbidden.')
 
-    parser.add_argument('--gpu-memory-mb',
-                        help='to specify GPU memory. Default = 8000 MB (with --gpu).',
-                        dest='GPUMemoryMB',
-                        default=8000)
+    gpugroup.add_argument('--gpu','--requires-gpu',
+                          help='Enable GPU workflows. Possible options are "forbidden" (default), "required" (implied if no argument is given), or "optional".',
+                          dest='gpu',
+                          choices=['forbidden', 'optional', 'required'],
+                          nargs='?',
+                          const='required',
+                          default='forbidden',
+                          action='store')
+
+    gpugroup.add_argument('--gpu-memory-mb',
+                          help='to specify GPU memory. Default = 8000 MB (with --gpu).',
+                          dest='GPUMemoryMB',
+                          default=8000)
     
-    parser.add_argument('--cuda-capabilities',
-                        help='to specify CUDA capabilities. Default = 6.0,6.1,6.2,7.0,7.2,7.5 (with --gpu). Use comma to identify various CUDACapabilities',
-                        dest='CUDACapabilities',
-                        default='6.0,6.1,6.2,7.0,7.2,7.5')
+    gpugroup.add_argument('--cuda-capabilities',
+                          help='to specify CUDA capabilities. Default = 6.0,6.1,6.2,7.0,7.2,7.5 (with --gpu). Use comma to identify various CUDACapabilities',
+                          dest='CUDACapabilities',
+                          default='6.0,6.1,6.2,7.0,7.2,7.5')
     
-    parser.add_argument('--cuda-runtime',
-                        help='to specify major and minor CUDA runtime used to build the application. Default = 11.2 (with --gpu). FIX ME TO MATCH WITH CMSSW.',
-                        dest='CUDARuntime',
-                        default='11.2')
+    gpugroup.add_argument('--cuda-runtime',
+                          help='to specify major and minor CUDA runtime used to build the application. Default = 11.2 (with --gpu). FIX ME TO MATCH WITH CMSSW.',
+                          dest='CUDARuntime',
+                          default='11.2')
     
-    parser.add_argument('--gpu-name',
-                        help='to specify GPU class. This is an optional parameter.',
-                        dest='GPUName',
-                        default='')
+    gpugroup.add_argument('--force-gpu-name',
+                          help='to specify GPU class. This is an optional parameter.',
+                          dest='GPUName',
+                          default='')
     
-    parser.add_argument('--cuda-driver-version',
-                        help='to specify CUDA driver version. This is an optional parameter.',
-                        dest='CUDADriverVersion',
-                        default='')
+    gpugroup.add_argument('--force-cuda-driver-version',
+                          help='to specify CUDA driver version. This is an optional parameter.',
+                          dest='CUDADriverVersion',
+                          default='')
     
-    parser.add_argument('--cuda-runtime-version',
-                        help='to specify CUDA runtime version. This is an optional parameter.',
-                        dest='CUDARuntimeVersion',
-                        default='')
+    gpugroup.add_argument('--force-cuda-runtime-version',
+                          help='to specify CUDA runtime version. This is an optional parameter.',
+                          dest='CUDARuntimeVersion',
+                          default='')
     
     opt = parser.parse_args()
     if opt.command: opt.command = ' '.join(opt.command)

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -107,7 +107,7 @@ if __name__ == '__main__':
     import argparse
     usage = 'usage: runTheMatrix.py --show -s '
 
-    parser = argparse.ArgumentParser(usage)
+    parser = argparse.ArgumentParser(usage,formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
     parser.add_argument('-b','--batchName',
                         help='relval batch: suffix to be appended to Campaign name',
@@ -180,6 +180,7 @@ if __name__ == '__main__':
     parser.add_argument('-i','--useInput',
                         help='Use recyling where available. Either all, or a comma separated list of wf number.',
                         dest='useInput',
+                        type=lambda x: x.split(','),
                         default=None)
     
     parser.add_argument('-w','--what',
@@ -201,6 +202,7 @@ if __name__ == '__main__':
     parser.add_argument('--fromScratch',
                         help='Comma separated list of wf to be run without recycling. all is not supported as default.',
                         dest='fromScratch',
+                        type=lambda x: x.split(','),
                         default=None)
     
     parser.add_argument('--refRelease',
@@ -326,14 +328,15 @@ if __name__ == '__main__':
                           action='store')
 
     gpugroup.add_argument('--gpu-memory',
-                          help='Specify the minimum amount of GPU memory required by the job, in MB (default: %(default)d MB)',
+                          help='Specify the minimum amount of GPU memory required by the job, in MB.',
                           dest='GPUMemoryMB',
                           type=int,
                           default=8000)
     
     gpugroup.add_argument('--cuda-capabilities',
-                          help='Specify a comma-separated list of CUDA "compute capabilities", or GPU hardware architectures, that the job can use (default: %(default)s).',
+                          help='Specify a comma-separated list of CUDA "compute capabilities", or GPU hardware architectures, that the job can use.',
                           dest='CUDACapabilities',
+                          type=lambda x: x.split(','),
                           default='6.0,6.1,6.2,7.0,7.2,7.5,8.0,8.6')
     
     # read the CUDA runtime version included in CMSSW
@@ -343,22 +346,22 @@ if __name__ == '__main__':
         cudart_basename = os.path.basename(libcudart)
         cudart_version = '.'.join(cudart_basename.split('.')[2:4])
     gpugroup.add_argument('--cuda-runtime',
-                          help='Specify major and minor version of the CUDA runtime used to build the application (default: %(default)s).',
+                          help='Specify major and minor version of the CUDA runtime used to build the application.',
                           dest='CUDARuntime',
                           default=cudart_version)
     
     gpugroup.add_argument('--force-gpu-name',
-                          help='Request a specific GPU model, e.g. "Tesla T4" or "NVIDIA GeForce RTX 2080" (default: none). The default behaviour is to accept any supported GPU.',
+                          help='Request a specific GPU model, e.g. "Tesla T4" or "NVIDIA GeForce RTX 2080". The default behaviour is to accept any supported GPU.',
                           dest='GPUName',
                           default='')
     
     gpugroup.add_argument('--force-cuda-driver-version',
-                          help='Request a specific CUDA driver version, e.g. 470.57.02 (default: none). The default behaviour is to accept any supported CUDA driver version.',
+                          help='Request a specific CUDA driver version, e.g. 470.57.02. The default behaviour is to accept any supported CUDA driver version.',
                           dest='CUDADriverVersion',
                           default='')
     
     gpugroup.add_argument('--force-cuda-runtime-version',
-                          help='Request a specific CUDA runtime version, e.g. 11.4 (default: none). The default behaviour is to accept any supported CUDA runtime version.',
+                          help='Request a specific CUDA runtime version, e.g. 11.4. The default behaviour is to accept any supported CUDA runtime version.',
                           dest='CUDARuntimeVersion',
                           default='')
     
@@ -420,12 +423,7 @@ if __name__ == '__main__':
                     print(entry,'is not a possible selected entry')
 
         opt.testList = list(set(testList))
-
-
-    if opt.useInput: opt.useInput = opt.useInput.split(',')
-    if opt.fromScratch: opt.fromScratch = opt.fromScratch.split(',')
-    if opt.CUDACapabilities: opt.CUDACapabilities = opt.CUDACapabilities.split(',')
-
+    
     if opt.wmcontrol:
         performInjectionOptionTest(opt)
     if opt.overWrite:

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -212,9 +212,7 @@ if __name__ == '__main__':
                         help='Create the workflows for injection to WMAgent. In the WORKING. -wmcontrol init will create the the workflows, -wmcontrol test will dryRun a test, -wmcontrol submit will submit to wmagent',
                         choices=['init','test','submit','force'],
                         dest='wmcontrol',
-                        default='test',
-                        const='test',
-                        nargs='?')
+                        default=None)
     
     parser.add_argument('--revertDqmio',
                         help='When submitting workflows to wmcontrol, force DQM outout to use pool and not DQMIO',


### PR DESCRIPTION
#### PR description:
The original PR/discussion is https://github.com/cms-sw/cmssw/pull/33057 and https://github.com/dmwm/WMCore/issues/10388 from the WMCore side.
Information on GPU support from WMCore side: https://github.com/dmwm/WMCore/wiki/GPU-Support

This PR is to add GPU workflow to `runTheMatrix`. 
In addition, this PR migrates from `optparse` to `argparse`, with code clean up.

What to be done with this PR:
(Done)
- How can I get the `CUDARuntime` for each release, to be the default value? @makortel @fwyzard @smuzaffar (Done)
- Is `GPUParams` as expected from WMCore? I just use `jsons.dump(the dictionary)` as suggested. @amaltaro (Confirmed)

(Pending)
- In this PR, I assume that the defined stepname in [relval_step](https://github.com/cms-sw/cmssw/blob/master/Configuration/PyReleaseValidation/python/relval_steps.py) or [upgradeWorkflowComponents](https://github.com/cms-sw/cmssw/blob/master/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py) will contain GPU if that step uses GPU. OK?

Thanks.

FYI @dpiparo @davidlange6 @justinasr 

#### PR validation:
Using 
`runTheMatrix.py --what upgrade -l 11650.502 -t 8 --requires-gpu required --wm init` 
or
`runTheMatrix.py --what upgrade -l 11650.502 -t 8 --gpu --wm init` 
you will get
```
'GPUParams': '{"GPUMemoryMB": 8000, "CUDACapabilities": ["6.0", '
                        '"6.1", "6.2", "7.0", "7.2", "7.5"], "CUDARuntime": '
                        '"11.2"}',
'RequiresGPU': 'required',
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
This PR is not a backport.
