### PR TITLE
`Alignment/OfflineValidation` improvements from CRUZET'21 data analysis

### DIFF
--- a/Alignment/OfflineValidation/plugins/BuildFile.xml
+++ b/Alignment/OfflineValidation/plugins/BuildFile.xml
@@ -12,6 +12,7 @@
 <use name="CondFormats/SiPixelObjects"/>
 <use name="CalibTracker/SiStripCommon"/>
 <use name="DQM/TrackerRemapper"/>
+<use name="DQM/SiPixelPhase1Common"/>
 <use name="DQMServices/Core"/>
 <use name="DataFormats/BeamSpot"/>
 <use name="DataFormats/DetId"/>

--- a/Alignment/OfflineValidation/plugins/DMRChecker.cc
+++ b/Alignment/OfflineValidation/plugins/DMRChecker.cc
@@ -149,11 +149,11 @@ namespace running {
 class DMRChecker : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   DMRChecker(const edm::ParameterSet &pset)
-      : geomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>()),
-        runInfoToken_(esConsumes<RunInfo, RunInfoRcd>()),
-        magFieldToken_(esConsumes<MagneticField, IdealMagneticFieldRecord>()),
-        topoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd>()),
-        latencyToken_(esConsumes<SiStripLatency, SiStripLatencyRcd>()),
+      : geomToken_(esConsumes()),
+        runInfoToken_(esConsumes()),
+        magFieldToken_(esConsumes()),
+        topoToken_(esConsumes()),
+        latencyToken_(esConsumes()),
         isCosmics_(pset.getParameter<bool>("isCosmics")) {
     usesResource(TFileService::kSharedResource);
 
@@ -195,7 +195,7 @@ public:
 
   static void fillDescriptions(edm::ConfigurationDescriptions &);
 
-  ~DMRChecker() override {}
+  ~DMRChecker() override = default;
 
   /*_______________________________________________________
   //
@@ -620,7 +620,7 @@ private:
               resDetailsTIB_[detid_db].rOrZDirection = resDetailsTIB_[detid_db].rDirection;  // barrel (split in r)
             }
 
-            hTIBResXPrime->Fill(uOrientation * resX * 10000);
+            hTIBResXPrime->Fill(uOrientation * resX * cmToUm);
             hTIBResXPull->Fill(pullX);
 
             // update residuals
@@ -630,7 +630,7 @@ private:
             uOrientation = deltaPhi(gUDirection.barePhi(), gPModule.barePhi()) >= 0. ? +1.F : -1.F;
             //vOrientation = gVDirection.z() - gPModule.z() >= 0 ? +1.F : -1.F; // not used for Strips
 
-            hTOBResXPrime->Fill(uOrientation * resX * 10000);
+            hTOBResXPrime->Fill(uOrientation * resX * cmToUm);
             hTOBResXPull->Fill(pullX);
 
             // if the detid has never occcurred yet, set the local orientations
@@ -647,7 +647,7 @@ private:
             uOrientation = deltaPhi(gUDirection.barePhi(), gPModule.barePhi()) >= 0. ? +1.F : -1.F;
             //vOrientation = gVDirection.perp() - gPModule.perp() >= 0. ? +1.F : -1.F; // not used for Strips
 
-            hTIDResXPrime->Fill(uOrientation * resX * 10000);
+            hTIDResXPrime->Fill(uOrientation * resX * cmToUm);
             hTIDResXPull->Fill(pullX);
 
             // update residuals
@@ -657,7 +657,7 @@ private:
             uOrientation = deltaPhi(gUDirection.barePhi(), gPModule.barePhi()) >= 0. ? +1.F : -1.F;
             //vOrientation = gVDirection.perp() - gPModule.perp() >= 0. ? +1.F : -1.F; // not used for Strips
 
-            hTECResXPrime->Fill(uOrientation * resX * 10000);
+            hTECResXPrime->Fill(uOrientation * resX * cmToUm);
             hTECResXPull->Fill(pullX);
 
             // update residuals

--- a/Alignment/OfflineValidation/plugins/GeneralPurposeTrackAnalyzer.cc
+++ b/Alignment/OfflineValidation/plugins/GeneralPurposeTrackAnalyzer.cc
@@ -32,13 +32,16 @@
 #include <boost/range/adaptor/indexed.hpp>
 
 // user include files
-
 #include "CommonTools/TrackerMap/interface/TrackerMap.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 #include "CondFormats/AlignmentRecord/interface/GlobalPositionRcd.h"
+#include "CondFormats/DataRecord/interface/SiPixelFedCablingMapRcd.h"
 #include "CondFormats/DataRecord/interface/SiStripCondDataRecords.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
 #include "CondFormats/SiStripObjects/interface/SiStripLatency.h"
+#include "DQM/SiPixelPhase1Common/interface/SiPixelCoordinates.h"
 #include "DQM/TrackerRemapper/interface/Phase1PixelMaps.h"
+#include "DQM/TrackerRemapper/interface/Phase1PixelROCMaps.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "DataFormats/DetId/interface/DetId.h"
@@ -60,11 +63,11 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "FWCore/Common/interface/TriggerNames.h"
-#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -85,9 +88,12 @@ const int kFPIX = PixelSubdetector::PixelEndcap;
 class GeneralPurposeTrackAnalyzer : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::SharedResources> {
 public:
   GeneralPurposeTrackAnalyzer(const edm::ParameterSet &pset)
-      : geomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>()),
-        magFieldToken_(esConsumes<MagneticField, IdealMagneticFieldRecord, edm::Transition::BeginRun>()),
-        latencyToken_(esConsumes<SiStripLatency, SiStripLatencyRcd, edm::Transition::BeginRun>()) {
+      : geomToken_(esConsumes()),
+        magFieldToken_(esConsumes<edm::Transition::BeginRun>()),
+        latencyToken_(esConsumes<edm::Transition::BeginRun>()),
+        geomTokenBR_(esConsumes<edm::Transition::BeginRun>()),
+        trackerTopologyTokenBR_(esConsumes<edm::Transition::BeginRun>()),
+        siPixelFedCablingMapTokenBR_(esConsumes<edm::Transition::BeginRun>()) {
     usesResource(TFileService::kSharedResource);
 
     TkTag_ = pset.getParameter<edm::InputTag>("TkTag");
@@ -116,9 +122,11 @@ public:
     pixelmap = std::make_unique<Phase1PixelMaps>("COLZ0 L");
     pixelmap->bookBarrelHistograms("entriesBarrel", "# hits", "# pixel hits");
     pixelmap->bookForwardHistograms("entriesForward", "# hits", "# pixel hits");
+
+    pixelrocsmap_ = std::make_unique<Phase1PixelROCMaps>("");
   }
 
-  ~GeneralPurposeTrackAnalyzer() override {}
+  ~GeneralPurposeTrackAnalyzer() override = default;
 
   static void fillDescriptions(edm::ConfigurationDescriptions &);
 
@@ -140,7 +148,13 @@ private:
   const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magFieldToken_;
   const edm::ESGetToken<SiStripLatency, SiStripLatencyRcd> latencyToken_;
 
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomTokenBR_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopologyTokenBR_;
+  const edm::ESGetToken<SiPixelFedCablingMap, SiPixelFedCablingMapRcd> siPixelFedCablingMapTokenBR_;
+
   edm::ESHandle<MagneticField> magneticField_;
+
+  SiPixelCoordinates coord_;
 
   edm::Service<TFileService> fs;
 
@@ -148,6 +162,7 @@ private:
   std::unique_ptr<TrackerMap> pmap;
 
   std::unique_ptr<Phase1PixelMaps> pixelmap;
+  std::unique_ptr<Phase1PixelROCMaps> pixelrocsmap_;
 
   TH1D *hchi2ndof;
   TH1D *hNtrk;
@@ -343,11 +358,13 @@ private:
 
     for (auto track = tC.cbegin(); track != tC.cend(); track++) {
       unsigned int nHit2D = 0;
+      std::bitset<16> rocsToMask;
       for (auto iHit = track->recHitsBegin(); iHit != track->recHitsEnd(); ++iHit) {
         if (this->isHit2D(**iHit)) {
           ++nHit2D;
         }
-
+        // rest the ROCs for the map
+        rocsToMask.reset();
         const DetId &detId = (*iHit)->geographicalId();
         const GeomDet *geomDet(theGeometry->idToDet(detId));
 
@@ -357,6 +374,18 @@ private:
           if (pixhit->isValid()) {
             unsigned int subid = detId.subdetId();
             int detid_db = detId.rawId();
+
+            // get the cluster
+            auto clustp = pixhit->cluster();
+
+            if (clustp.isNull())
+              continue;
+            auto const &cluster = *clustp;
+            int row = cluster.x() - 0.5, col = cluster.y() - 0.5;
+            int rocId = coord_.roc(detId, std::make_pair(row, col));
+
+            rocsToMask.set(rocId);
+            pixelrocsmap_->fillSelectedRocs(detid_db, rocsToMask, 1);
 
             if (!isPhase1_) {
               pmap->fill(detid_db, 1);
@@ -695,6 +724,14 @@ private:
 
     conditionsMap_[run.run()].first = mode;
     conditionsMap_[run.run()].second = B_;
+
+    // init the sipixel coordinates
+    const TrackerGeometry *trackerGeometry = &setup.getData(geomTokenBR_);
+    const TrackerTopology *trackerTopology = &setup.getData(trackerTopologyTokenBR_);
+    const SiPixelFedCablingMap *siPixelFedCablingMap = &setup.getData(siPixelFedCablingMapTokenBR_);
+
+    // Pixel Phase-1 helper class
+    coord_.init(trackerTopology, trackerGeometry, siPixelFedCablingMap);
   }
 
   //*************************************************************
@@ -1123,8 +1160,10 @@ private:
       fieldByRun_->GetXaxis()->SetBinLabel((the_r - theRuns_.front()) + 1, std::to_string(the_r).c_str());
     }
 
-    pmap->save(true, 0, 0, "PixelHitMap.pdf", 600, 800);
-    pmap->save(true, 0, 0, "PixelHitMap.png", 500, 750);
+    if (!isPhase1_) {
+      pmap->save(true, 0, 0, "PixelHitMap.pdf", 600, 800);
+      pmap->save(true, 0, 0, "PixelHitMap.png", 500, 750);
+    }
 
     tmap->save(true, 0, 0, "StripHitMap.pdf");
     tmap->save(true, 0, 0, "StripHitMap.png");
@@ -1139,6 +1178,10 @@ private:
     TCanvas cF("CanvForward", "CanvForward", 1600, 1000);
     pixelmap->drawForwardMaps("entriesForward", cF);
     cF.SaveAs("pixelForwardEntries.png");
+
+    TCanvas cRocs = TCanvas("cRocs", "cRocs", 1200, 1600);
+    pixelrocsmap_->drawMaps(cRocs, "Pixel on-track clusters occupancy");
+    cRocs.SaveAs("Phase1PixelROCMaps_fullROCs.png");
   }
 
   //*************************************************************

--- a/DQM/TrackerRemapper/interface/Phase1PixelMaps.h
+++ b/DQM/TrackerRemapper/interface/Phase1PixelMaps.h
@@ -80,7 +80,7 @@ public:
   // drawing methos
   void drawBarrelMaps(const std::string& currentHistoName, TCanvas& canvas, const char* drawOption = nullptr);
   void drawForwardMaps(const std::string& currentHistoName, TCanvas& canvas, const char* drawOption = nullptr);
-  void drawSummaryMaps(const std::string& currentHistoName, TCanvas& canvas);
+  void drawSummaryMaps(const std::string& currentHistoName, TCanvas& canvas, const char* drawOption = nullptr);
 
 private:
   Option_t* m_option;

--- a/DQM/TrackerRemapper/src/Phase1PixelMaps.cc
+++ b/DQM/TrackerRemapper/src/Phase1PixelMaps.cc
@@ -393,7 +393,7 @@ void Phase1PixelMaps::drawForwardMaps(const std::string& currentHistoName, TCanv
 }
 
 //============================================================================
-void Phase1PixelMaps::drawSummaryMaps(const std::string& currentHistoName, TCanvas& canvas) {
+void Phase1PixelMaps::drawSummaryMaps(const std::string& currentHistoName, TCanvas& canvas, const char* drawOption) {
   auto found = (std::find(m_knownNames.begin(), m_knownNames.end(), currentHistoName) != m_knownNames.end());
 
   if (!m_isBooked.second || !m_isBooked.first || !found) {
@@ -411,7 +411,8 @@ void Phase1PixelMaps::drawSummaryMaps(const std::string& currentHistoName, TCanv
     pxbTh2PolyBarrelSummary[currentHistoName]->SetMarkerSize(0.5);
   }
   pxbTh2PolyBarrelSummary[currentHistoName]->GetZaxis()->SetTitleOffset(1.4);
-  pxbTh2PolyBarrelSummary[currentHistoName]->Draw();
+  pxbTh2PolyBarrelSummary[currentHistoName]->Draw("AL");
+  pxbTh2PolyBarrelSummary[currentHistoName]->Draw(fmt::sprintf("%s%ssame", m_option, drawOption).c_str());
 
   canvas.cd(2);
   adjustCanvasMargins(canvas.cd(2), 0.07, 0.02, 0.01, isText ? 0.05 : 0.15);
@@ -420,7 +421,8 @@ void Phase1PixelMaps::drawSummaryMaps(const std::string& currentHistoName, TCanv
     pxfTh2PolyForwardSummary[currentHistoName]->SetMarkerSize(0.5);
   }
   pxfTh2PolyForwardSummary[currentHistoName]->GetZaxis()->SetTitleOffset(1.4);
-  pxfTh2PolyForwardSummary[currentHistoName]->Draw();
+  pxfTh2PolyForwardSummary[currentHistoName]->Draw("AL");
+  pxfTh2PolyForwardSummary[currentHistoName]->Draw(fmt::sprintf("%s%ssame", m_option, drawOption).c_str());
 }
 
 //============================================================================

--- a/DQM/TrackerRemapper/src/Phase1PixelROCMaps.cc
+++ b/DQM/TrackerRemapper/src/Phase1PixelROCMaps.cc
@@ -645,6 +645,7 @@ void Phase1PixelROCMaps::drawBarrelMaps(TCanvas& canvas, const std::string& text
   bottomPad->cd();
   bottomPad->Divide(2, 2);
   for (unsigned int lay = 1; lay <= n_layers; lay++) {
+    h_bpix_maps[lay - 1]->SetStats(false);
     PixelROCMapHelper::dress_plot(bottomPad, h_bpix_maps[lay - 1].get(), lay, 0, 1, found == std::string::npos);
   }
 }
@@ -676,6 +677,7 @@ void Phase1PixelROCMaps::drawForwardMaps(TCanvas& canvas, const std::string& tex
   bottomPad->cd();
   bottomPad->Divide(2, 1);
   for (unsigned int ring = 1; ring <= n_rings; ring++) {
+    h_fpix_maps[ring - 1]->SetStats(false);
     PixelROCMapHelper::dress_plot(bottomPad, h_fpix_maps[ring - 1].get(), 0, ring, 1, found == std::string::npos);
   }
 }
@@ -709,6 +711,7 @@ void Phase1PixelROCMaps::drawMaps(TCanvas& canvas, const std::string& text)
 
   // dress the plots
   for (unsigned int lay = 1; lay <= n_layers; lay++) {
+    h_bpix_maps[lay - 1]->SetStats(false);
     PixelROCMapHelper::dress_plot(bottomPad, h_bpix_maps[lay - 1].get(), lay, 0, 1, found == std::string::npos);
   }
 
@@ -717,6 +720,7 @@ void Phase1PixelROCMaps::drawMaps(TCanvas& canvas, const std::string& text)
   bottomPad->cd();
 
   for (unsigned int ring = 1; ring <= n_rings; ring++) {
+    h_fpix_maps[ring - 1]->SetStats(false);
     PixelROCMapHelper::dress_plot(
         bottomPad, h_fpix_maps[ring - 1].get(), 0, n_layers + ring, 1, found == std::string::npos);
   }

--- a/DQM/TrackerRemapper/src/Phase1PixelSummaryMap.cc
+++ b/DQM/TrackerRemapper/src/Phase1PixelSummaryMap.cc
@@ -88,7 +88,8 @@ void Phase1PixelSummaryMap::printTrackerMap(TCanvas& canvas) {
   canvas.SetBottomMargin(0.02);
   canvas.SetLeftMargin(0.02);
   canvas.SetRightMargin(0.14);
-  m_BaseTrackerMap->Draw("AC COLZ L");
+  m_BaseTrackerMap->Draw("AL");
+  m_BaseTrackerMap->Draw("AC COLZ0 L SAME");
 
   //### z arrow
   arrow = TArrow(0.05, 27.0, 0.05, -30.0, 0.02, "|>");


### PR DESCRIPTION
#### PR description:

Introduce some miscelleaneous improvements in the `EDAnalyzers` used to cross-check the Cosmics datasets for tracker alignment purposes, mostly  adding a Pixel on-track clusters occupancy map per ROC.  
I profit of this PR to introduce some other changes in the `DQM/TrackerRemapper` are added in order to be able display empty maps with marked singled out modules and ROCs. 

#### PR validation:

Private tests.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
