### PR TITLE
[12_0_X] Add new ECAL PF RecHit thresholds for 2021 Run 3 MC

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -68,11 +68,11 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
     'phase1_2021_design'           : '120X_mcRun3_2021_design_v4', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'        : '120X_mcRun3_2021_realistic_v5', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'        : '120X_mcRun3_2021_realistic_v6', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'          : '120X_mcRun3_2021cosmics_realistic_deco_v4',
+    'phase1_2021_cosmics'          : '120X_mcRun3_2021cosmics_realistic_deco_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi'     : '120X_mcRun3_2021_realistic_HI_v4',
+    'phase1_2021_realistic_hi'     : '120X_mcRun3_2021_realistic_HI_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
     'phase1_2023_realistic'        : '120X_mcRun3_2023_realistic_v5', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024


### PR DESCRIPTION
#### PR description:

This PR is a backport of PR #35233 that adds a new ECAL tag, EcalPFRecHitThresholds_34sigma_TL235, to the 2021 Run-3 MC GTs as per request from the ECAL group (https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4462.html), aiming the Run3Summer21 Campaign (in 120X).

The differences wrt the previous GTs are listed below.

**2021 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/120X_mcRun3_2021_realistic_v5/120X_mcRun3_2021_realistic_v6

**2021 cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/120X_mcRun3_2021cosmics_realistic_deco_v4/120X_mcRun3_2021cosmics_realistic_deco_v5

**2021 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/120X_mcRun3_2021_realistic_HI_v4/120X_mcRun3_2021_realistic_HI_v5

#### PR validation:
runTheMatrix.py -l 159.0,11634.0,7.23 --ibeos -j4

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

backport of #35233
