### PR TITLE
Move MSLayerKeeper* objects from thread-local into EventSetup

### DIFF
--- a/CalibTracker/Configuration/python/Tracker_DependentRecords_forGlobalTag_nofakes_cff.py
+++ b/CalibTracker/Configuration/python/Tracker_DependentRecords_forGlobalTag_nofakes_cff.py
@@ -45,3 +45,6 @@ siPixelQualityESProducer.ListOfRecordToMerge = cms.VPSet(
                   tag    = cms.string("")
                   )
         )
+
+# Multiple scattering parametrisation
+from RecoTracker.TkMSParametrization.multipleScatteringParametrisationMakerESProducer_cfi import *

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -137,6 +137,11 @@ def customiseFor35315(process):
 
     return process
 
+# MultipleScatteringParametrisationMakerESProducer
+def customiseFor35269(process):
+    process.load("RecoTracker.TkMSParametrization.multipleScatteringParametrisationMakerESProducer_cfi")
+    return process
+
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
     
@@ -144,5 +149,6 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
     # process = customiseFor12718(process)
 
     process = customiseFor35315(process)
+    process = customiseFor35269(process)
 
     return process

--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/PixelTripletLowPtGenerator.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/PixelTripletLowPtGenerator.h
@@ -19,9 +19,14 @@
 
 #include "RecoPixelVertexing/PixelLowPtUtilities/interface/TripletFilter.h"
 
-class TrackerGeometry;
-class TripletFilter;
+class IdealMagneticFieldRecord;
+class MultipleScatteringParametrisationMaker;
+class TrackerMultipleScatteringRecord;
 class SiPixelClusterShapeCache;
+class TrackerGeometry;
+class TransientTrackingRecHitBuilder;
+class TransientRecHitRecord;
+class TripletFilter;
 
 #include <vector>
 
@@ -48,6 +53,9 @@ public:
 private:
   edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> m_geomToken;
   edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> m_topoToken;
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> m_magfieldToken;
+  edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> m_ttrhBuilderToken;
+  edm::ESGetToken<MultipleScatteringParametrisationMaker, TrackerMultipleScatteringRecord> m_msmakerToken;
 
   void getTracker(const edm::EventSetup& es);
   GlobalPoint getGlobalPosition(const TrackingRecHit* recHit);
@@ -60,7 +68,6 @@ private:
   double rzTolerance;
   double maxAngleRatio;
 
-  std::string builderName;
   bool checkMultipleScattering;
   bool checkClusterShape;
 };

--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/ThirdHitPrediction.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/ThirdHitPrediction.h
@@ -22,7 +22,9 @@ class DetLayer;
 class OrderedHitPair;
 class TrackingRecHit;
 
+class MagneticField;
 class TransientTrackingRecHitBuilder;
+class MultipleScatteringParametrisationMaker;
 
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -38,10 +40,10 @@ public:
   ThirdHitPrediction(const TrackingRegion& region,
                      GlobalPoint inner,
                      GlobalPoint outer,
-                     const edm::EventSetup& es,
+                     const MagneticField& magfield,
+                     const TransientTrackingRecHitBuilder& ttrhBuilder,
                      double nSigMultipleScattering,
-                     double maxAngleRatio,
-                     std::string builderName);
+                     double maxAngleRatio);
   ~ThirdHitPrediction();
 
   void getRanges(const DetLayer* layer, float phi[], float rz[]);
@@ -50,7 +52,7 @@ public:
   bool isCompatibleWithMultipleScattering(GlobalPoint g3,
                                           const std::vector<const TrackingRecHit*>& h,
                                           std::vector<GlobalVector>& localDirs,
-                                          const edm::EventSetup& es);
+                                          const MultipleScatteringParametrisationMaker& msmaker);
 
 private:
   void initLayer(const DetLayer* layer);

--- a/RecoPixelVertexing/PixelLowPtUtilities/src/PixelTripletLowPtGenerator.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/PixelTripletLowPtGenerator.cc
@@ -6,11 +6,15 @@
 #include "RecoTracker/TkMSParametrization/interface/PixelRecoPointRZ.h"
 #include "RecoTracker/TkHitPairs/interface/HitPairGeneratorFromLayerPair.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/SiPixelCluster/interface/SiPixelClusterShapeCache.h"
+
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "RecoTracker/TkMSParametrization/interface/MultipleScatteringParametrisationMaker.h"
+#include "TrackingTools/Records/interface/TransientRecHitRecord.h"
+#include "RecoTracker/Record/interface/TrackerMultipleScatteringRecord.h"
 
 #undef Debug
 
@@ -21,6 +25,9 @@ PixelTripletLowPtGenerator::PixelTripletLowPtGenerator(const edm::ParameterSet& 
     : HitTripletGeneratorFromPairAndLayers(),  // no theMaxElement used in this class
       m_geomToken(iC.esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>()),
       m_topoToken(iC.esConsumes<TrackerTopology, TrackerTopologyRcd>()),
+      m_magfieldToken(iC.esConsumes()),
+      m_ttrhBuilderToken(iC.esConsumes(edm::ESInputTag("", cfg.getParameter<string>("TTRHBuilder")))),
+      m_msmakerToken(iC.esConsumes()),
       theTracker(nullptr),
       theClusterShapeCacheToken(
           iC.consumes<SiPixelClusterShapeCache>(cfg.getParameter<edm::InputTag>("clusterShapeCacheSrc"))) {
@@ -29,7 +36,6 @@ PixelTripletLowPtGenerator::PixelTripletLowPtGenerator(const edm::ParameterSet& 
   checkClusterShape = cfg.getParameter<bool>("checkClusterShape");
   rzTolerance = cfg.getParameter<double>("rzTolerance");
   maxAngleRatio = cfg.getParameter<double>("maxAngleRatio");
-  builderName = cfg.getParameter<string>("TTRHBuilder");
 }
 
 /*****************************************************************************/
@@ -65,6 +71,9 @@ void PixelTripletLowPtGenerator::hitTriplets(const TrackingRegion& region,
                                              const std::vector<SeedingLayerSetsHits::SeedingLayer>& thirdLayers) {
   //Retrieve tracker topology from geometry
   const TrackerTopology* tTopo = &es.getData(m_topoToken);
+  const auto& magfield = es.getData(m_magfieldToken);
+  const auto& ttrhBuilder = es.getData(m_ttrhBuilderToken);
+  const auto& msmaker = es.getData(m_msmakerToken);
 
   edm::Handle<SiPixelClusterShapeCache> clusterShapeCache;
   ev.getByToken(theClusterShapeCacheToken, clusterShapeCache);
@@ -105,7 +114,7 @@ void PixelTripletLowPtGenerator::hitTriplets(const TrackingRegion& region,
 
     // Initialize helix prediction
     ThirdHitPrediction thePrediction(
-        region, points[0], points[1], es, nSigMultipleScattering, maxAngleRatio, builderName);
+        region, points[0], points[1], magfield, ttrhBuilder, nSigMultipleScattering, maxAngleRatio);
 
     // Look at all layers
     for (int il = 0; il < size; il++) {
@@ -138,7 +147,7 @@ void PixelTripletLowPtGenerator::hitTriplets(const TrackingRegion& region,
 
         // Check if third hit is compatible with multiple scattering
         vector<GlobalVector> globalDirs;
-        if (thePrediction.isCompatibleWithMultipleScattering(points[2], recHits, globalDirs, es) == false) {
+        if (thePrediction.isCompatibleWithMultipleScattering(points[2], recHits, globalDirs, msmaker) == false) {
 #ifdef Debug
           cerr << "  not compatible: multiple scattering" << endl;
 #endif

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
@@ -1,14 +1,12 @@
 #include "RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.h"
 #include "RecoTracker/TkHitPairs/interface/HitPairGeneratorFromLayerPair.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 #include "ThirdHitPredictionFromInvParabola.h"
 #include "RecoPixelVertexing/PixelTriplets/interface/ThirdHitRZPrediction.h"
 #include "RecoTracker/TkMSParametrization/interface/PixelRecoUtilities.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "ThirdHitCorrection.h"
 #include "RecoTracker/TkHitPairs/interface/RecHitsSortedInPhi.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -23,8 +21,6 @@
 
 #include "DataFormats/Math/interface/normalizedPhi.h"
 
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
-
 #include <cstdio>
 #include <iostream>
 
@@ -35,6 +31,7 @@ using namespace std;
 
 PixelTripletHLTGenerator::PixelTripletHLTGenerator(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC)
     : HitTripletGeneratorFromPairAndLayers(cfg),
+      fieldToken_(iC.esConsumes()),
       useFixedPreFiltering(cfg.getParameter<bool>("useFixedPreFiltering")),
       extraHitRZtolerance(cfg.getParameter<double>("extraHitRZtolerance")),
       extraHitRPhitolerance(cfg.getParameter<double>("extraHitRPhitolerance")),
@@ -45,6 +42,9 @@ PixelTripletHLTGenerator::PixelTripletHLTGenerator(const edm::ParameterSet& cfg,
   std::string comparitorName = comparitorPSet.getParameter<std::string>("ComponentName");
   if (comparitorName != "none") {
     theComparitor = SeedComparitorFactory::get()->create(comparitorName, comparitorPSet, iC);
+  }
+  if (useMScat) {
+    msmakerToken_ = iC.esConsumes();
   }
 }
 
@@ -139,9 +139,11 @@ void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region,
   const float maxphi = M_PI + maxDelphi, minphi = -maxphi;  // increase to cater for any range
   const float safePhi = M_PI - maxDelphi;                   // sideband
 
-  edm::ESHandle<MagneticField> hfield;
-  es.get<IdealMagneticFieldRecord>().get(hfield);
-  const auto& field = *hfield;
+  const auto& field = es.getData(fieldToken_);
+  const MultipleScatteringParametrisationMaker* msmaker = nullptr;
+  if (useMScat) {
+    msmaker = &es.getData(msmakerToken_);
+  }
 
   // fill the prediction vector
   for (int il = 0; il < nThirdLayers; ++il) {
@@ -150,13 +152,14 @@ void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region,
     pred.initLayer(thirdLayerDetLayer[il]);
     pred.initTolerance(extraHitRZtolerance);
 
-    corrections[il].init(es,
-                         region.ptMin(),
+    corrections[il].init(region.ptMin(),
                          *doublets.detLayer(HitDoublets::inner),
                          *doublets.detLayer(HitDoublets::outer),
                          *thirdLayerDetLayer[il],
                          useMScat,
-                         useBend);
+                         msmaker,
+                         useBend,
+                         &field);
 
     layerTree.clear();
     float minv = 999999.0f, maxv = -minv;  // Initialise to extreme values in case no hits

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.h
@@ -10,7 +10,10 @@
 #include "CombinedHitTripletGenerator.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "RecoPixelVertexing/PixelTriplets/interface/HitTripletGeneratorFromPairAndLayers.h"
+#include "RecoTracker/Record/interface/TrackerMultipleScatteringRecord.h"
+#include "RecoTracker/TkMSParametrization/interface/MultipleScatteringParametrisationMaker.h"
 
 #include <utility>
 #include <vector>
@@ -64,6 +67,8 @@ public:
                    std::vector<int>* tripletLastLayerIndex);
 
 private:
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> fieldToken_;
+  edm::ESGetToken<MultipleScatteringParametrisationMaker, TrackerMultipleScatteringRecord> msmakerToken_;
   const bool useFixedPreFiltering;
   const float extraHitRZtolerance;
   const float extraHitRPhitolerance;

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.cc
@@ -1,5 +1,6 @@
 #include "RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.h"
 #include "RecoTracker/TkHitPairs/interface/HitPairGeneratorFromLayerPair.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "RecoPixelVertexing/PixelTriplets/interface/ThirdHitPredictionFromCircle.h"
 #include "RecoPixelVertexing/PixelTriplets/interface/ThirdHitRZPrediction.h"
@@ -14,8 +15,6 @@
 
 #include "MatchedHitRZCorrectionFromBending.h"
 #include "CommonTools/RecoAlgos/interface/KDTreeLinkerAlgo.h"
-
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
 #include <algorithm>
 #include <iostream>
@@ -53,7 +52,12 @@ PixelTripletLargeTipGenerator::PixelTripletLargeTipGenerator(const edm::Paramete
       useMScat(cfg.getParameter<bool>("useMultScattering")),
       useBend(cfg.getParameter<bool>("useBending")),
       dphi(useFixedPreFiltering ? cfg.getParameter<double>("phiPreFiltering") : 0),
-      trackerTopologyESToken_(iC.esConsumes()) {}
+      trackerTopologyESToken_(iC.esConsumes()),
+      fieldESToken_(iC.esConsumes()) {
+  if (useMScat) {
+    msmakerESToken_ = iC.esConsumes();
+  }
+}
 
 PixelTripletLargeTipGenerator::~PixelTripletLargeTipGenerator() {}
 
@@ -133,10 +137,11 @@ void PixelTripletLargeTipGenerator::hitTriplets(const TrackingRegion& region,
                                                 const int nThirdLayers,
                                                 std::vector<int>* tripletLastLayerIndex) {
   const TrackerTopology* tTopo = &es.getData(trackerTopologyESToken_);
-
-  edm::ESHandle<MagneticField> hfield;
-  es.get<IdealMagneticFieldRecord>().get(hfield);
-  const auto& field = *hfield;
+  const auto& field = es.getData(fieldESToken_);
+  const MultipleScatteringParametrisationMaker* msmaker = nullptr;
+  if (useMScat) {
+    msmaker = &es.getData(msmakerESToken_);
+  }
 
   auto outSeq = doublets.detLayer(HitDoublets::outer)->seqNum();
 
@@ -166,13 +171,14 @@ void PixelTripletLargeTipGenerator::hitTriplets(const TrackingRegion& region,
     predRZ.helix1.initTolerance(extraHitRZtolerance);
     predRZ.helix2.initTolerance(extraHitRZtolerance);
     predRZ.rzPositionFixup = MatchedHitRZCorrectionFromBending(layer, tTopo);
-    predRZ.correction.init(es,
-                           region.ptMin(),
+    predRZ.correction.init(region.ptMin(),
                            *doublets.detLayer(HitDoublets::inner),
                            *doublets.detLayer(HitDoublets::outer),
                            *thirdLayerDetLayer[il],
                            useMScat,
-                           false);
+                           msmaker,
+                           false,
+                           nullptr);
 
     layerTree.clear();
     float minv = 999999.0;

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.h
@@ -12,7 +12,10 @@
 #include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "RecoPixelVertexing/PixelTriplets/interface/HitTripletGeneratorFromPairAndLayers.h"
+#include "RecoTracker/Record/interface/TrackerMultipleScatteringRecord.h"
+#include "RecoTracker/TkMSParametrization/interface/MultipleScatteringParametrisationMaker.h"
 
 #include <utility>
 #include <vector>
@@ -72,5 +75,7 @@ private:
   const float dphi;
 
   const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopologyESToken_;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> fieldESToken_;
+  edm::ESGetToken<MultipleScatteringParametrisationMaker, TrackerMultipleScatteringRecord> msmakerESToken_;
 };
 #endif

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletNoTipGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletNoTipGenerator.cc
@@ -1,4 +1,5 @@
 #include "PixelTripletNoTipGenerator.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -16,8 +17,6 @@
 #include "TrackingTools/DetLayers/interface/DetLayer.h"
 #include "DataFormats/GeometrySurface/interface/SimpleDiskBounds.h"
 
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
-
 typedef PixelRecoRange<float> Range;
 template <class T>
 T sqr(T t) {
@@ -28,6 +27,8 @@ using namespace std;
 
 PixelTripletNoTipGenerator::PixelTripletNoTipGenerator(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC)
     : HitTripletGeneratorFromPairAndLayers(cfg),
+      fieldToken_(iC.esConsumes()),
+      msmakerToken_(iC.esConsumes()),
       extraHitRZtolerance(cfg.getParameter<double>("extraHitRZtolerance")),
       extraHitRPhitolerance(cfg.getParameter<double>("extraHitRPhitolerance")),
       extraHitPhiToleranceForPreFiltering(cfg.getParameter<double>("extraHitPhiToleranceForPreFiltering")),
@@ -74,12 +75,11 @@ void PixelTripletNoTipGenerator::hitTriplets(const TrackingRegion& region,
     thirdHitMap[il] = &(*theLayerCache)(thirdLayers[il], region, es);
   }
 
-  edm::ESHandle<MagneticField> hfield;
-  es.get<IdealMagneticFieldRecord>().get(hfield);
-  const auto& field = *hfield;
+  const auto& field = es.getData(fieldToken_);
+  const auto& msmaker = es.getData(msmakerToken_);
 
-  MultipleScatteringParametrisation sigma1RPhi(firstLayer, es);
-  MultipleScatteringParametrisation sigma2RPhi(secondLayer, es);
+  MultipleScatteringParametrisation sigma1RPhi = msmaker.parametrisation(firstLayer);
+  MultipleScatteringParametrisation sigma2RPhi = msmaker.parametrisation(secondLayer);
 
   typedef RecHitsSortedInPhi::Hit Hit;
   for (ip = pairs.begin(); ip != pairs.end(); ip++) {
@@ -106,7 +106,7 @@ void PixelTripletNoTipGenerator::hitTriplets(const TrackingRegion& region,
     for (int il = 0; il <= size - 1; il++) {
       const DetLayer* layer = thirdLayers[il].detLayer();
       bool barrelLayer = (layer->location() == GeomDetEnumerators::barrel);
-      MultipleScatteringParametrisation sigma3RPhi(layer, es);
+      MultipleScatteringParametrisation sigma3RPhi = msmaker.parametrisation(layer);
       double msRPhi3 = sigma3RPhi(pt_p1p2, line.cotLine(), point2);
 
       Range rRange;

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletNoTipGenerator.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletNoTipGenerator.h
@@ -1,13 +1,13 @@
 #ifndef PixelTripletNoTipGenerator_H
 #define PixelTripletNoTipGenerator_H
 
+#include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "RecoPixelVertexing/PixelTriplets/interface/HitTripletGeneratorFromPairAndLayers.h"
-#include "CombinedHitTripletGenerator.h"
+#include "RecoTracker/Record/interface/TrackerMultipleScatteringRecord.h"
+#include "RecoTracker/TkMSParametrization/interface/MultipleScatteringParametrisationMaker.h"
 
-namespace edm {
-  class Event;
-  class EventSetup;
-}  // namespace edm
+#include "CombinedHitTripletGenerator.h"
 
 #include <utility>
 #include <vector>
@@ -35,6 +35,8 @@ public:
                    const int nThirdLayers) override;
 
 private:
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> fieldToken_;
+  edm::ESGetToken<MultipleScatteringParametrisationMaker, TrackerMultipleScatteringRecord> msmakerToken_;
   float extraHitRZtolerance;
   float extraHitRPhitolerance;
   float extraHitPhiToleranceForPreFiltering;

--- a/RecoPixelVertexing/PixelTriplets/plugins/ThirdHitCorrection.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/ThirdHitCorrection.cc
@@ -2,7 +2,7 @@
 
 #include "TrackingTools/DetLayers/interface/BarrelDetLayer.h"
 #include "TrackingTools/DetLayers/interface/ForwardDetLayer.h"
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "RecoTracker/TkMSParametrization/interface/MultipleScatteringParametrisationMaker.h"
 
 using namespace pixelrecoutilities;
 
@@ -15,17 +15,16 @@ namespace {
 
 using pixelrecoutilities::LongitudinalBendingCorrection;
 
-void ThirdHitCorrection::init(const edm::EventSetup &es,
-                              float pt,
+void ThirdHitCorrection::init(float pt,
                               const DetLayer &layer3,
                               bool useMultipleScattering,
-                              bool useBendingCorrection) {
+                              const MultipleScatteringParametrisationMaker *msmaker,
+                              bool useBendingCorrection,
+                              const MagneticField *bfield) {
   theUseMultipleScattering = useMultipleScattering;
   theUseBendingCorrection = useBendingCorrection;
   if (useBendingCorrection) {
-    edm::ESHandle<MagneticField> hfield;
-    es.get<IdealMagneticFieldRecord>().get(hfield);
-    theBendingCorrection.init(pt, *hfield);
+    theBendingCorrection.init(pt, *bfield);
   }
 
   theMultScattCorrRPhi = 0;
@@ -35,17 +34,18 @@ void ThirdHitCorrection::init(const edm::EventSetup &es,
   thePt = pt;
 
   if (theUseMultipleScattering)
-    sigmaRPhi.init(&layer3, es);
+    sigmaRPhi = msmaker->parametrisation(&layer3);
 }
 
-void ThirdHitCorrection::init(const edm::EventSetup &es,
-                              float pt,
+void ThirdHitCorrection::init(float pt,
                               const DetLayer &layer1,
                               const DetLayer &layer2,
                               const DetLayer &layer3,
                               bool useMultipleScattering,
-                              bool useBendingCorrection) {
-  init(es, pt, layer3, useMultipleScattering, useBendingCorrection);
+                              const MultipleScatteringParametrisationMaker *msmaker,
+                              bool useBendingCorrection,
+                              const MagneticField *bfield) {
+  init(pt, layer3, useMultipleScattering, msmaker, useBendingCorrection, bfield);
 
   if (!theUseMultipleScattering)
     return;
@@ -78,7 +78,7 @@ void ThirdHitCorrection::init(const edm::EventSetup &es,
     }
   };
 
-  theMultScattCorrRPhi = 3.f * sigmaRPhi(pt, line.cotLine(), point2(), layer2.seqNum());
+  theMultScattCorrRPhi = 3.f * (*sigmaRPhi)(pt, line.cotLine(), point2(), layer2.seqNum());
 }
 
 void ThirdHitCorrection::init(const PixelRecoLineRZ &line, const PixelRecoPointRZ &constraint, int il) {
@@ -87,7 +87,7 @@ void ThirdHitCorrection::init(const PixelRecoLineRZ &line, const PixelRecoPointR
     return;
 
   // auto newCorr = theMultScattCorrRPhi;
-  theMultScattCorrRPhi = 3.f * sigmaRPhi(thePt, line.cotLine(), constraint, il);
+  theMultScattCorrRPhi = 3.f * (*sigmaRPhi)(thePt, line.cotLine(), constraint, il);
   // std::cout << "ThirdHitCorr " << (theBarrel ? "B " : "F " )<< theMultScattCorrRPhi << ' ' << newCorr << ' ' << newCorr/theMultScattCorrRPhi << std::endl;
   float overSinTheta = std::sqrt(1.f + sqr(line.cotLine()));
   if (theBarrel) {

--- a/RecoPixelVertexing/PixelTriplets/plugins/ThirdHitCorrection.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/ThirdHitCorrection.h
@@ -1,17 +1,18 @@
 #ifndef RecoPixelVertexing_PixelTriplets_ThirdHitCorrection_H
 #define RecoPixelVertexing_PixelTriplets_ThirdHitCorrection_H
 
-namespace edm {
-  class EventSetup;
-}
 #include "RecoTracker/TkMSParametrization/interface/LongitudinalBendingCorrection.h"
 #include "RecoTracker/TkMSParametrization/interface/MultipleScatteringParametrisation.h"
 
 class DetLayer;
+class MagneticField;
+class MultipleScatteringParametrisationMaker;
 
 #include "RecoTracker/TkMSParametrization/interface/PixelRecoRange.h"
 #include "RecoTracker/TkMSParametrization/interface/PixelRecoPointRZ.h"
 #include "RecoTracker/TkMSParametrization/interface/PixelRecoLineRZ.h"
+
+#include <optional>
 
 class ThirdHitCorrection {
 public:
@@ -19,29 +20,32 @@ public:
 
   ThirdHitCorrection() {}
 
-  void init(const edm::EventSetup &es,
-            float pt,
+  void init(float pt,
             const DetLayer &layer1,
             const DetLayer &layer2,
             const DetLayer &layer3,
             bool useMultipleScattering,
-            bool useBendingCorrection);
+            const MultipleScatteringParametrisationMaker *msmaker,
+            bool useBendingCorrection,
+            const MagneticField *bfield);
 
-  void init(const edm::EventSetup &es,
-            float pt,
+  void init(float pt,
             const DetLayer &layer3,
             bool useMultipleScattering,
-            bool useBendingCorrection);
+            const MultipleScatteringParametrisationMaker *msmaker,
+            bool useBendingCorrection,
+            const MagneticField *bfield);
 
-  ThirdHitCorrection(const edm::EventSetup &es,
-                     float pt,
+  ThirdHitCorrection(float pt,
                      const DetLayer *layer,
                      const PixelRecoLineRZ &line,
                      const PixelRecoPointRZ &constraint,
                      int ol,
                      bool useMultipleScattering,
-                     bool useBendingCorrection) {
-    init(es, pt, *layer, useMultipleScattering, useBendingCorrection);
+                     const MultipleScatteringParametrisationMaker *msmaker,
+                     bool useBendingCorrection,
+                     const MagneticField *bfield) {
+    init(pt, *layer, useMultipleScattering, msmaker, useBendingCorrection, bfield);
     init(line, constraint, ol);
   }
 
@@ -66,7 +70,7 @@ private:
   float thePt;
 
   pixelrecoutilities::LongitudinalBendingCorrection theBendingCorrection;
-  MultipleScatteringParametrisation sigmaRPhi;
+  std::optional<MultipleScatteringParametrisation> sigmaRPhi;
 };
 
 #endif

--- a/RecoTracker/Record/interface/TrackerMultipleScatteringRecord.h
+++ b/RecoTracker/Record/interface/TrackerMultipleScatteringRecord.h
@@ -1,0 +1,16 @@
+#ifndef RecoTracker_Record_TrackerMultipleScatteringRecord_h
+#define RecoTracker_Record_TrackerMultipleScatteringRecord_h
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+#include "FWCore/Framework/interface/DependentRecordImplementation.h"
+
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
+
+#include "FWCore/Utilities/interface/mplVector.h"
+
+class TrackerMultipleScatteringRecord : public edm::eventsetup::DependentRecordImplementation<
+                                            TrackerMultipleScatteringRecord,
+                                            edm::mpl::Vector<IdealMagneticFieldRecord, TrackerRecoGeometryRecord> > {};
+
+#endif

--- a/RecoTracker/Record/src/TrackerMultipleScatteringRecord.cc
+++ b/RecoTracker/Record/src/TrackerMultipleScatteringRecord.cc
@@ -1,0 +1,4 @@
+#include "RecoTracker/Record/interface/TrackerMultipleScatteringRecord.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(TrackerMultipleScatteringRecord);

--- a/RecoTracker/TkHitPairs/src/HitPairGeneratorFromLayerPair.cc
+++ b/RecoTracker/TkHitPairs/src/HitPairGeneratorFromLayerPair.cc
@@ -29,6 +29,8 @@ namespace {
 #include "TrackingTools/Records/interface/TransientRecHitRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
+#include "RecoTracker/TkMSParametrization/interface/MultipleScatteringParametrisationMaker.h"
+#include "RecoTracker/Record/interface/TrackerMultipleScatteringRecord.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
 HitPairGeneratorFromLayerPair::HitPairGeneratorFromLayerPair(unsigned int inner,
@@ -115,7 +117,11 @@ void HitPairGeneratorFromLayerPair::doublets(const TrackingRegion& region,
                                              HitDoublets& result) {
   //  HitDoublets result(innerHitsMap,outerHitsMap); result.reserve(std::max(innerHitsMap.size(),outerHitsMap.size()));
   typedef RecHitsSortedInPhi::Hit Hit;
-  InnerDeltaPhi deltaPhi(outerHitDetLayer, innerHitDetLayer, region, iSetup);
+  edm::ESHandle<MagneticField> hfield;
+  iSetup.get<IdealMagneticFieldRecord>().get(hfield);
+  edm::ESHandle<MultipleScatteringParametrisationMaker> hmaker;
+  iSetup.get<TrackerMultipleScatteringRecord>().get(hmaker);
+  InnerDeltaPhi deltaPhi(outerHitDetLayer, innerHitDetLayer, region, *hfield, *hmaker);
 
   // std::cout << "layers " << theInnerLayer.detLayer()->seqNum()  << " " << outerLayer.detLayer()->seqNum() << std::endl;
 

--- a/RecoTracker/TkHitPairs/src/InnerDeltaPhi.cc
+++ b/RecoTracker/TkHitPairs/src/InnerDeltaPhi.cc
@@ -84,7 +84,8 @@ namespace {
 InnerDeltaPhi::InnerDeltaPhi(const DetLayer& outlayer,
                              const DetLayer& layer,
                              const TrackingRegion& region,
-                             const edm::EventSetup& iSetup,
+                             const MagneticField& field,
+                             const MultipleScatteringParametrisationMaker& msmaker,
                              bool precise,
                              float extraTolerance)
     : innerIsBarrel(layer.isBarrel()),
@@ -100,14 +101,10 @@ InnerDeltaPhi::InnerDeltaPhi(const DetLayer& outlayer,
       theVtxZ(region.origin().z()),
       thePtMin(region.ptMin()),
       theVtx(region.origin().x(), region.origin().y()),
-      sigma(&layer, iSetup)
-
-{
+      sigma(msmaker.parametrisation(&layer)) {
   float zMinOrigin = theVtxZ - region.originZBound();
   float zMaxOrigin = theVtxZ + region.originZBound();
-  edm::ESHandle<MagneticField> hfield;
-  iSetup.get<IdealMagneticFieldRecord>().get(hfield);
-  theRCurvature = PixelRecoUtilities::bendingRadius(thePtMin, *hfield);
+  theRCurvature = PixelRecoUtilities::bendingRadius(thePtMin, field);
 
   if (innerIsBarrel)
     initBarrelLayer(layer);

--- a/RecoTracker/TkHitPairs/src/InnerDeltaPhi.h
+++ b/RecoTracker/TkHitPairs/src/InnerDeltaPhi.h
@@ -2,9 +2,8 @@
 #define InnerDeltaPhi_H
 
 /** predict phi bending in layer for the tracks constratind by outer hit r-z */
-#include "FWCore/Framework/interface/EventSetup.h"
-
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
+#include "RecoTracker/TkMSParametrization/interface/MultipleScatteringParametrisationMaker.h"
 #include "RecoTracker/TkMSParametrization/interface/MultipleScatteringParametrisation.h"
 
 #include "FWCore/Utilities/interface/Visibility.h"
@@ -23,7 +22,8 @@ public:
   InnerDeltaPhi(const DetLayer& outlayer,
                 const DetLayer& layer,
                 const TrackingRegion& region,
-                const edm::EventSetup& iSetup,
+                const MagneticField& field,
+                const MultipleScatteringParametrisationMaker& msmaker,
                 bool precise = true,
                 float extraTolerance = 0.f);
 

--- a/RecoTracker/TkMSParametrization/interface/MultipleScatteringParametrisation.h
+++ b/RecoTracker/TkMSParametrization/interface/MultipleScatteringParametrisation.h
@@ -15,20 +15,9 @@ class DetLayer;
 
 class MultipleScatteringParametrisation {
 public:
-  static void initKeepers(const edm::EventSetup &iSetup);
-
-  enum X0Source { useDetLayer = 0, useX0AtEta = 1, useX0DataAveraged = 2 };
   enum Consecutive { notAssumeConsecutive, useConsecutive };
 
-  MultipleScatteringParametrisation() {}
-
-  MultipleScatteringParametrisation(const DetLayer *layer,
-                                    const edm::EventSetup &iSetup,
-                                    X0Source x0source = useX0AtEta) {
-    init(layer, iSetup, x0source);
-  }
-
-  void init(const DetLayer *layer, const edm::EventSetup &iSetup, X0Source x0source = useX0AtEta);
+  MultipleScatteringParametrisation(const DetLayer *layer, const MSLayersKeeper *layerKeeper);
 
   /// MS sigma  at the layer for which parametrisation is initialised;
   /// particle assumed to come from nominal vertex, "fast" methods called

--- a/RecoTracker/TkMSParametrization/interface/MultipleScatteringParametrisationMaker.h
+++ b/RecoTracker/TkMSParametrization/interface/MultipleScatteringParametrisationMaker.h
@@ -1,0 +1,26 @@
+#ifndef RecoTracker_TkMSParametrization_MSLayersKeepers_h
+#define RecoTracker_TkMSParametrization_MSLayersKeepers_h
+
+#include "FWCore/Utilities/interface/propagate_const.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h"
+#include "RecoTracker/TkMSParametrization/interface/MultipleScatteringParametrisation.h"
+
+class DetLayer;
+
+class MultipleScatteringParametrisationMaker {
+public:
+  enum class X0Source { useDetLayer = 0, useX0AtEta = 1, useX0DataAveraged = 2 };
+
+  MultipleScatteringParametrisationMaker(GeometricSearchTracker const& tracker, MagneticField const& bfield);
+  ~MultipleScatteringParametrisationMaker();
+
+  MultipleScatteringParametrisation parametrisation(const DetLayer* layer,
+                                                    X0Source x0Source = X0Source::useX0AtEta) const;
+
+private:
+  struct Keepers;
+  edm::propagate_const<std::unique_ptr<Keepers>> impl_;
+};
+
+#endif

--- a/RecoTracker/TkMSParametrization/plugins/BuildFile.xml
+++ b/RecoTracker/TkMSParametrization/plugins/BuildFile.xml
@@ -1,0 +1,10 @@
+<use name="FWCore/Framework"/>
+<use name="FWCore/ParameterSet"/>
+<use name="MagneticField/Engine"/>
+<use name="MagneticField/Records"/>
+<use name="RecoTracker/Record"/>
+<use name="RecoTracker/TkDetLayers"/>
+<use name="RecoTracker/TkMSParametrization"/>
+<library file="*.cc" name="RecoTrackerTkMSParametrizationPlugins">
+  <flags EDM_PLUGIN="1"/>
+</library>

--- a/RecoTracker/TkMSParametrization/plugins/MultipleScatteringParametrisationMakerESProducer.cc
+++ b/RecoTracker/TkMSParametrization/plugins/MultipleScatteringParametrisationMakerESProducer.cc
@@ -1,0 +1,44 @@
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterDescription.h"
+#include "RecoTracker/TkMSParametrization/interface/MultipleScatteringParametrisationMaker.h"
+#include "RecoTracker/Record/interface/TrackerMultipleScatteringRecord.h"
+
+#include "RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h"
+#include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+
+class MultipleScatteringParametrisationMakerESProducer : public edm::ESProducer {
+public:
+  MultipleScatteringParametrisationMakerESProducer(edm::ParameterSet const& iConfig);
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  std::unique_ptr<MultipleScatteringParametrisationMaker> produce(const TrackerMultipleScatteringRecord& iRecord);
+
+private:
+  edm::ESGetToken<GeometricSearchTracker, TrackerRecoGeometryRecord> trackerToken_;
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> bfieldToken_;
+};
+
+MultipleScatteringParametrisationMakerESProducer::MultipleScatteringParametrisationMakerESProducer(
+    edm::ParameterSet const& iConfig) {
+  auto cc = setWhatProduced(this);
+  trackerToken_ = cc.consumes();
+  bfieldToken_ = cc.consumes();
+}
+
+void MultipleScatteringParametrisationMakerESProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  descriptions.addWithDefaultLabel(desc);
+}
+
+std::unique_ptr<MultipleScatteringParametrisationMaker> MultipleScatteringParametrisationMakerESProducer::produce(
+    const TrackerMultipleScatteringRecord& iRecord) {
+  return std::make_unique<MultipleScatteringParametrisationMaker>(iRecord.get(trackerToken_),
+                                                                  iRecord.get(bfieldToken_));
+}
+
+DEFINE_FWK_EVENTSETUP_MODULE(MultipleScatteringParametrisationMakerESProducer);

--- a/RecoTracker/TkMSParametrization/src/ES_MultipleScatteringParametrisationMaker.cc
+++ b/RecoTracker/TkMSParametrization/src/ES_MultipleScatteringParametrisationMaker.cc
@@ -1,0 +1,4 @@
+#include "RecoTracker/TkMSParametrization/interface/MultipleScatteringParametrisationMaker.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+TYPELOOKUP_DATA_REG(MultipleScatteringParametrisationMaker);

--- a/RecoTracker/TkMSParametrization/src/MSLayersKeeper.h
+++ b/RecoTracker/TkMSParametrization/src/MSLayersKeeper.h
@@ -13,7 +13,6 @@ public:
   virtual ~MSLayersKeeper() {}
   virtual MSLayer layer(const DetLayer* dl) const { return MSLayer(dl, DataX0(this)); }
   virtual const MSLayersAtAngle& layers(float cotTheta) const = 0;
-  virtual void init(const edm::EventSetup& iSetup) {}
 
 protected:
   typedef MSLayer::DataX0 DataX0;

--- a/RecoTracker/TkMSParametrization/src/MSLayersKeeperX0AtEta.cc
+++ b/RecoTracker/TkMSParametrization/src/MSLayersKeeperX0AtEta.cc
@@ -34,10 +34,7 @@ int MSLayersKeeperX0AtEta::idxBin(float eta) const {
 }
 
 //------------------------------------------------------------------------------
-void MSLayersKeeperX0AtEta::init(const edm::EventSetup& iSetup) {
-  if (isInitialised)
-    return;
-  isInitialised = true;
+MSLayersKeeperX0AtEta::MSLayersKeeperX0AtEta(const GeometricSearchTracker& tracker, const MagneticField& bfield) {
   const float BIG = 99999.;
 
   // set size from data file
@@ -47,13 +44,13 @@ void MSLayersKeeperX0AtEta::init(const edm::EventSetup& iSetup) {
   theDeltaEta = (theHalfNBins != 0) ? etaMax / theHalfNBins : BIG;
 
   theLayersData = vector<MSLayersAtAngle>(max(2 * theHalfNBins, 1));
-  MultipleScatteringGeometry layout(iSetup);
+  MultipleScatteringGeometry layout(tracker);
   for (int idxbin = 0; idxbin < 2 * theHalfNBins; idxbin++) {
     float etaValue = eta(idxbin);
     float cotTheta = sinh(etaValue);
 
-    vector<MSLayer> layers = layout.detLayers(etaValue, 0, iSetup);
-    vector<MSLayer> tmplay = layout.otherLayers(etaValue, iSetup);
+    vector<MSLayer> layers = layout.detLayers(etaValue, 0, bfield);
+    vector<MSLayer> tmplay = layout.otherLayers(etaValue);
     layers.insert(layers.end(), tmplay.begin(), tmplay.end());
     sort(layers.begin(), layers.end());
     setX0(layers, etaValue, msX0data);
@@ -76,7 +73,7 @@ void MSLayersKeeperX0AtEta::init(const edm::EventSetup& iSetup) {
     for (int isign = -1; isign <= 1; isign += 2) {
       float z = isign * 15.9;  //3 sigma from zero
       const MSLayersAtAngle& layersAtAngle = theLayersData[idxbin];
-      vector<MSLayer> candidates = layout.detLayers(etaValue, z, iSetup);
+      vector<MSLayer> candidates = layout.detLayers(etaValue, z, bfield);
       vector<MSLayer>::iterator it;
       for (it = candidates.begin(); it != candidates.end(); it++) {
         if (layersAtAngle.findLayer(*it))
@@ -144,3 +141,6 @@ void MSLayersKeeperX0AtEta::setX0(vector<MSLayer>& layers, float eta, const SumX
     sumX0atAngleLast = sumX0atAngle;
   }
 }
+
+//------------------------------------------------------------------------------
+MSLayersKeeperX0AtEta::~MSLayersKeeperX0AtEta() = default;

--- a/RecoTracker/TkMSParametrization/src/MSLayersKeeperX0AtEta.h
+++ b/RecoTracker/TkMSParametrization/src/MSLayersKeeperX0AtEta.h
@@ -1,17 +1,19 @@
 #ifndef MSLayersKeeperX0AtEta_H
 #define MSLayersKeeperX0AtEta_H
 
-#include "MSLayersKeeper.h"
-#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Utilities/interface/Visibility.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h"
+
+#include "MSLayersKeeper.h"
+
 class SumX0AtEtaDataProvider;
 class MSLayersKeeperX0Averaged;
 
 class dso_hidden MSLayersKeeperX0AtEta final : public MSLayersKeeper {
 public:
-  MSLayersKeeperX0AtEta() : isInitialised(false) {}
-  ~MSLayersKeeperX0AtEta() override {}
-  void init(const edm::EventSetup &iSetup) override;
+  MSLayersKeeperX0AtEta(const GeometricSearchTracker &tracker, const MagneticField &bfield);
+  ~MSLayersKeeperX0AtEta() override;
   const MSLayersAtAngle &layers(float cotTheta) const override;
 
 private:
@@ -20,7 +22,6 @@ private:
   static void setX0(std::vector<MSLayer> &, float eta, const SumX0AtEtaDataProvider &);
 
 private:
-  bool isInitialised;
   int theHalfNBins;
   float theDeltaEta;
   std::vector<MSLayersAtAngle> theLayersData;

--- a/RecoTracker/TkMSParametrization/src/MSLayersKeeperX0Averaged.cc
+++ b/RecoTracker/TkMSParametrization/src/MSLayersKeeperX0Averaged.cc
@@ -4,19 +4,15 @@
 
 using namespace std;
 
-void MSLayersKeeperX0Averaged::init(const edm::EventSetup &iSetup) {
-  if (isInitialised)
-    return;
-  isInitialised = true;
+MSLayersKeeperX0Averaged::MSLayersKeeperX0Averaged(const GeometricSearchTracker &tracker, const MagneticField &bfield) {
   //  cout << "HERE INITIALISATION! MSLayersKeeperX0Averaged"<<endl;
-  MSLayersKeeperX0AtEta layersX0Eta;
-  layersX0Eta.init(iSetup);
-  MultipleScatteringGeometry geom(iSetup);
-  vector<MSLayer> allLayers = geom.detLayers(iSetup);
+  MSLayersKeeperX0AtEta layersX0Eta(tracker, bfield);
+  MultipleScatteringGeometry geom(tracker);
+  vector<MSLayer> allLayers = geom.detLayers();
   vector<MSLayer>::iterator it;
   for (int i = -1; i <= 1; i++) {
     float eta = i * (-1.8);
-    vector<MSLayer> tmpLayers = geom.otherLayers(eta, iSetup);
+    vector<MSLayer> tmpLayers = geom.otherLayers(eta);
     vector<MSLayer>::const_iterator ic;
     for (ic = tmpLayers.begin(); ic != tmpLayers.end(); ic++) {
       it = find(allLayers.begin(), allLayers.end(), *ic);

--- a/RecoTracker/TkMSParametrization/src/MSLayersKeeperX0Averaged.h
+++ b/RecoTracker/TkMSParametrization/src/MSLayersKeeperX0Averaged.h
@@ -1,20 +1,20 @@
 #ifndef MSLayersKeeperX0Averaged_H
 #define MSLayersKeeperX0Averaged_H
 
-#include "MSLayersKeeper.h"
-#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Utilities/interface/Visibility.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h"
+
+#include "MSLayersKeeper.h"
 
 class dso_hidden MSLayersKeeperX0Averaged final : public MSLayersKeeper {
 public:
-  MSLayersKeeperX0Averaged() : isInitialised(false) {}
-  ~MSLayersKeeperX0Averaged() override {}
-  void init(const edm::EventSetup& iSetup) override;
+  MSLayersKeeperX0Averaged(const GeometricSearchTracker& tracker, const MagneticField& bfield);
+  ~MSLayersKeeperX0Averaged() override = default;
   MSLayer layer(const DetLayer* layer) const override { return *theLayersData.findLayer(MSLayer(layer)); }
   const MSLayersAtAngle& layers(float cotTheta) const override { return theLayersData; }
 
 private:
-  bool isInitialised;
   MSLayersAtAngle theLayersData;
 };
 #endif

--- a/RecoTracker/TkMSParametrization/src/MSLayersKeeperX0DetLayer.cc
+++ b/RecoTracker/TkMSParametrization/src/MSLayersKeeperX0DetLayer.cc
@@ -10,10 +10,7 @@
 
 using namespace std;
 
-void MSLayersKeeperX0DetLayer::init(const edm::EventSetup &iSetup) {
-  if (isInitialised)
-    return;
-  isInitialised = true;
+MSLayersKeeperX0DetLayer::MSLayersKeeperX0DetLayer() {
   //  vector<MSLayer> allLayers = MSLayersKeeperX0DetLayerGeom().detLayers();
   //MP
   vector<MSLayer> allLayers;

--- a/RecoTracker/TkMSParametrization/src/MSLayersKeeperX0DetLayer.h
+++ b/RecoTracker/TkMSParametrization/src/MSLayersKeeperX0DetLayer.h
@@ -8,14 +8,12 @@
 
 class dso_hidden MSLayersKeeperX0DetLayer final : public MSLayersKeeper {
 public:
-  MSLayersKeeperX0DetLayer() : isInitialised(false) {}
-  ~MSLayersKeeperX0DetLayer() override {}
-  void init(const edm::EventSetup& iSetup) override;
+  MSLayersKeeperX0DetLayer();
+  ~MSLayersKeeperX0DetLayer() override = default;
   MSLayer layer(const DetLayer* layer) const override { return *theLayersData.findLayer(MSLayer(layer)); }
   const MSLayersAtAngle& layers(float cotTheta) const override { return theLayersData; }
 
 private:
-  bool isInitialised;
   MSLayersAtAngle theLayersData;
 };
 #endif

--- a/RecoTracker/TkMSParametrization/src/MultipleScatteringGeometry.h
+++ b/RecoTracker/TkMSParametrization/src/MultipleScatteringGeometry.h
@@ -2,18 +2,19 @@
 #define MultipleScatteringGeometry_H
 
 #include <vector>
-#include "RecoTracker/TkMSParametrization/interface/MSLayer.h"
-#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Utilities/interface/Visibility.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h"
+#include "RecoTracker/TkMSParametrization/interface/MSLayer.h"
 
 class DetLayer;
 
 class dso_hidden MultipleScatteringGeometry {
 public:
-  MultipleScatteringGeometry(const edm::EventSetup &iSetup);
-  std::vector<MSLayer> detLayers(float eta, float z, const edm::EventSetup &iSetup) const;
-  std::vector<MSLayer> detLayers(const edm::EventSetup &iSetup) const;
-  std::vector<MSLayer> otherLayers(float eta, const edm::EventSetup &iSetup) const;
+  MultipleScatteringGeometry(const GeometricSearchTracker &tracker);
+  std::vector<MSLayer> detLayers(float eta, float z, const MagneticField &bfield) const;
+  std::vector<MSLayer> detLayers() const;
+  std::vector<MSLayer> otherLayers(float eta) const;
 
 protected:
   std::vector<const DetLayer *> theLayers;

--- a/RecoTracker/TkMSParametrization/src/MultipleScatteringParametrisation.cc
+++ b/RecoTracker/TkMSParametrization/src/MultipleScatteringParametrisation.cc
@@ -11,58 +11,19 @@ inline T sqr(T t) {
 }
 
 #include "MSLayersKeeper.h"
-#include "MSLayersKeeperX0AtEta.h"
-#include "MSLayersKeeperX0Averaged.h"
-#include "MSLayersKeeperX0DetLayer.h"
 #include "MSLayersAtAngle.h"
-
-//#include "RecoTracker/TkMSParametrization/interface/PixelRecoUtilities.h"
-
-#include <iostream>
 
 using namespace std;
 
 const float MultipleScatteringParametrisation::x0ToSigma = 0.0136f;
 
-namespace {
-  struct Keepers {
-    MSLayersKeeperX0DetLayer x0DetLayer;
-    MSLayersKeeperX0AtEta x0AtEta;
-    MSLayersKeeperX0Averaged x0Averaged;
-    MSLayersKeeper *keepers[3];  // {&x0DetLayer,&x0AtEta,&x0Averaged};
-    bool isInitialised;          // =false;
-    MSLayersKeeper const *operator()(int i) const { return keepers[i]; }
-    void init(const edm::EventSetup &iSetup) {
-      if (isInitialised)
-        return;
-      for (auto x : keepers)
-        x->init(iSetup);
-      isInitialised = true;
-    }
-    Keepers() : keepers{&x0DetLayer, &x0AtEta, &x0Averaged}, isInitialised(false) {}
-  };
-
-  thread_local Keepers keepers;
-  //NOTE: This is being used to globally cache information from the EventSetup
-  // this should not be done so we need this code changed.
-  //NOTE; the thread_local only works in this case because MultipleScateringParametrisation
-  // instances are only ever created on the stack and not the heap.
-
-}  // namespace
-
-void MultipleScatteringParametrisation::initKeepers(const edm::EventSetup &iSetup) { keepers.init(iSetup); }
-
-//using namespace PixelRecoUtilities;
 //----------------------------------------------------------------------
-void MultipleScatteringParametrisation::init(const DetLayer *layer, const edm::EventSetup &iSetup, X0Source x0Source) {
-  theLayerKeeper = keepers(x0Source);
-
-  // FIXME not thread safe: move elsewhere...
-  initKeepers(iSetup);
-
-  if (!layer)
-    return;
-  theLayer = theLayerKeeper->layer(layer);
+MultipleScatteringParametrisation::MultipleScatteringParametrisation(const DetLayer *layer,
+                                                                     const MSLayersKeeper *layerKeeper)
+    : theLayerKeeper(layerKeeper) {
+  if (layer) {
+    theLayer = theLayerKeeper->layer(layer);
+  }
 }
 
 //----------------------------------------------------------------------

--- a/RecoTracker/TkMSParametrization/src/MultipleScatteringParametrisationMaker.cc
+++ b/RecoTracker/TkMSParametrization/src/MultipleScatteringParametrisationMaker.cc
@@ -1,0 +1,28 @@
+#include "RecoTracker/TkMSParametrization/interface/MultipleScatteringParametrisationMaker.h"
+
+#include "MSLayersKeeper.h"
+#include "MSLayersKeeperX0AtEta.h"
+#include "MSLayersKeeperX0Averaged.h"
+#include "MSLayersKeeperX0DetLayer.h"
+#include "MSLayersAtAngle.h"
+
+struct MultipleScatteringParametrisationMaker::Keepers {
+  Keepers(GeometricSearchTracker const& tracker, MagneticField const& bfield)
+      : x0AtEta(tracker, bfield), x0Averaged(tracker, bfield), keepers{&x0DetLayer, &x0AtEta, &x0Averaged} {}
+
+  MSLayersKeeperX0DetLayer x0DetLayer;
+  MSLayersKeeperX0AtEta x0AtEta;
+  MSLayersKeeperX0Averaged x0Averaged;
+  MSLayersKeeper* keepers[3];  // {&x0DetLayer,&x0AtEta,&x0Averaged};
+};
+
+MultipleScatteringParametrisationMaker::MultipleScatteringParametrisationMaker(GeometricSearchTracker const& tracker,
+                                                                               MagneticField const& bfield)
+    : impl_(std::make_unique<Keepers>(tracker, bfield)) {}
+
+MultipleScatteringParametrisationMaker::~MultipleScatteringParametrisationMaker() = default;
+
+MultipleScatteringParametrisation MultipleScatteringParametrisationMaker::parametrisation(const DetLayer* layer,
+                                                                                          X0Source x0Source) const {
+  return MultipleScatteringParametrisation(layer, impl_->keepers[static_cast<int>(x0Source)]);
+}

--- a/RecoTracker/TkTrackingRegions/src/GlobalTrackingRegion.cc
+++ b/RecoTracker/TkTrackingRegions/src/GlobalTrackingRegion.cc
@@ -6,7 +6,9 @@
 #include "RecoTracker/TkTrackingRegions/interface/HitRCheck.h"
 #include "RecoTracker/TkTrackingRegions/interface/HitZCheck.h"
 
+#include "RecoTracker/Record/interface/TrackerMultipleScatteringRecord.h"
 #include "RecoTracker/TkMSParametrization/interface/PixelRecoUtilities.h"
+#include "RecoTracker/TkMSParametrization/interface/MultipleScatteringParametrisationMaker.h"
 #include "RecoTracker/TkMSParametrization/interface/MultipleScatteringParametrisation.h"
 #include "RecoTracker/TkMSParametrization/interface/PixelRecoPointRZ.h"
 #include "RecoTracker/TkMSParametrization/interface/PixelRecoLineRZ.h"
@@ -89,7 +91,9 @@ std::unique_ptr<HitRZCompatibility> GlobalTrackingRegion::checkRZ(const DetLayer
   HitRZConstraint rzConstraint(leftLine, rightLine);
 
   if UNLIKELY (theUseMS) {
-    MultipleScatteringParametrisation iSigma(layer, iSetup);
+    edm::ESHandle<MultipleScatteringParametrisationMaker> hmaker;
+    iSetup.get<TrackerMultipleScatteringRecord>().get(hmaker);
+    MultipleScatteringParametrisation iSigma = hmaker->parametrisation(layer);
     PixelRecoPointRZ vtxMean(0., origin().z());
 
     float innerScatt = 3.f * (outerlayer ? iSigma(ptMin(), vtxMean, outerred, outerlayer->seqNum())


### PR DESCRIPTION
#### PR description:

This PR is part of https://github.com/cms-sw/cmssw/issues/31061 and focuses on the `MultipleScatteringParametrisation` helper. That class relied an old hack to cache EventSetup data
https://github.com/cms-sw/cmssw/blob/919a7477d148ff35ff5d5174e117d27227c87284/RecoTracker/TkMSParametrization/src/MultipleScatteringParametrisation.cc#L45-L49
that this PR suggests to finally fix properly by moving the `MSLayersKeeperX0DetLayer`, `MSLayersKeeperX0AtEta`, and `MSLayersKeeperX0Averaged` from thread-locals into EventSetup itself. In the EventSetup they are abstracted into `MultipleScatteringParametrisationMaker` class that is then used to make `MultipleScatteringParametrisation` objects. The corresponding ESProducer is added into the `customizeHLTforCMSSW.py` and in various cff fragments within reconstruction configuration (I can't exclude missing some places).

This PR also completes the esConsumes migration for touched helper classes where that was feasible.

As in https://github.com/cms-sw/cmssw/pull/35081, despite of being part of #31061 this PR adds some new calls to the deprecated `EventSetupRecord::get()` function without `esConsumes()`. All these cases have some relation to `TrackingRegion` classes, and will be addressed in a subsequent PR (I have the work done already, but I though they would be easier to review separately).

Resolves https://github.com/makortel/framework/issues/251

#### PR validation:

Tested on earlier IB (on top of https://github.com/cms-sw/cmssw/pull/35081) that limited matrix runs. After rebase checked that the code compiles.