### PR TITLE
Fix Rare Undefined Behavior in PixelThresholdClusterizer

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
@@ -224,7 +224,7 @@ void PixelThresholdClusterizer::copy_to_buffer(DigiIterator begin, DigiIterator 
   }
 #endif
 
-  //If called with empty / invalid DetSet, warn the user
+  //If called with empty/invalid DetSet, warn the user
   if (end <= begin) {
     edm::LogWarning("PixelThresholdClusterizer") << " copy_to_buffer called with empty or invalid range" << std::endl;
     return;

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
@@ -148,7 +148,8 @@ void PixelThresholdClusterizer::clusterizeDetUnitT(const T& input,
 
   //  Copy PixelDigis to the buffer array; select the seed pixels
   //  on the way, and store them in theSeeds.
-  copy_to_buffer(begin, end);
+  if (end > begin)
+    copy_to_buffer(begin, end);
 
   assert(output.empty());
   //  Loop over all seeds.  TO DO: wouldn't using iterators be faster?
@@ -223,9 +224,11 @@ void PixelThresholdClusterizer::copy_to_buffer(DigiIterator begin, DigiIterator 
   }
 #endif
 
-  //avoid undefined behavior
-  if (end <= begin)
+  //If called with empty / invalid DetSet, warn the user
+  if (end <= begin) {
+    edm::LogWarning("PixelThresholdClusterizer") << " copy_to_buffer called with empty or invalid range" << std::endl;
     return;
+  }
 
   int electron[end - begin];  // pixel charge in electrons
   memset(electron, 0, (end - begin) * sizeof(int));

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
@@ -222,6 +222,11 @@ void PixelThresholdClusterizer::copy_to_buffer(DigiIterator begin, DigiIterator 
     // std::cout << (doMissCalibrate ? "VI from db" : "VI linear") << std::endl;
   }
 #endif
+
+  //avoid undefined behavior
+  if (end <= begin)
+    return;
+
   int electron[end - begin];  // pixel charge in electrons
   memset(electron, 0, (end - begin) * sizeof(int));
 


### PR DESCRIPTION
This is a small fix to address the undefined behavior reported in issue #35036. The change is just to check the range is sensible before initializing an array. 

No changes in output are expected. 

@mmusich @ferencek @tsusa @tvami @czangela 