### PR TITLE
Added esConsumes to VirtualJetProducer classes

### DIFF
--- a/RecoJets/FFTJetProducers/plugins/FFTJetProducer.cc
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetProducer.cc
@@ -161,6 +161,11 @@ FFTJetProducer::FFTJetProducer(const edm::ParameterSet& ps)
   const std::string alias(ps.getUntrackedParameter<std::string>("alias", outputLabel));
   jet_type_switch(makeProduces, alias, outputLabel);
 
+  if (jetType == CALOJET) {
+    geometry_token_ = esConsumes();
+    topology_token_ = esConsumes();
+  }
+
   // Build the set of pattern recognition scales.
   // This is needed in order to read the clustering tree
   // from the event record.
@@ -568,11 +573,9 @@ void FFTJetProducer::writeJets(edm::Event& iEvent, const edm::EventSetup& iSetup
     // call the appropriate specific code.
     T jet;
     if constexpr (std::is_same_v<T, reco::CaloJet>) {
-      edm::ESHandle<CaloGeometry> geometry;
-      iSetup.get<CaloGeometryRecord>().get(geometry);
-      edm::ESHandle<HcalTopology> topology;
-      iSetup.get<HcalRecNumberingRecord>().get(topology);
-      writeSpecific(jet, jet4vec, vertexUsed(), constituents[ijet + 1], *geometry, *topology);
+      const CaloGeometry& geometry = iSetup.getData(geometry_token_);
+      const HcalTopology& topology = iSetup.getData(topology_token_);
+      writeSpecific(jet, jet4vec, vertexUsed(), constituents[ijet + 1], geometry, topology);
     } else {
       writeSpecific(jet, jet4vec, vertexUsed(), constituents[ijet + 1]);
     }

--- a/RecoJets/FFTJetProducers/plugins/FFTJetProducer.cc
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetProducer.cc
@@ -38,6 +38,8 @@
 #include "DataFormats/Candidate/interface/Candidate.h"
 
 #include "RecoJets/JetProducers/interface/JetSpecific.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 
 // Loader for the lookup tables
 #include "JetMETCorrections/FFTJetObjects/interface/FFTJetLookupTableSequenceLoader.h"
@@ -565,7 +567,15 @@ void FFTJetProducer::writeJets(edm::Event& iEvent, const edm::EventSetup& iSetup
     // vertex, constituents). These are overridden functions that will
     // call the appropriate specific code.
     T jet;
-    writeSpecific(jet, jet4vec, vertexUsed(), constituents[ijet + 1], iSetup);
+    if constexpr (std::is_same_v<T, reco::CaloJet>) {
+      edm::ESHandle<CaloGeometry> geometry;
+      iSetup.get<CaloGeometryRecord>().get(geometry);
+      edm::ESHandle<HcalTopology> topology;
+      iSetup.get<HcalRecNumberingRecord>().get(topology);
+      writeSpecific(jet, jet4vec, vertexUsed(), constituents[ijet + 1], *geometry, *topology);
+    } else {
+      writeSpecific(jet, jet4vec, vertexUsed(), constituents[ijet + 1]);
+    }
 
     // calcuate the jet area
     double ncells = myjet.ncells();

--- a/RecoJets/FFTJetProducers/plugins/FFTJetProducer.h
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetProducer.h
@@ -71,6 +71,11 @@ namespace fftjetcms {
   class DiscretizedEnergyFlow;
 }
 
+class CaloGeometry;
+class CaloGeometryRecord;
+class HcalTopology;
+class HcalRecNumberingRecord;
+
 //
 // class declaration
 //
@@ -398,6 +403,9 @@ private:
   edm::EDGetTokenT<std::vector<reco::FFTAnyJet<reco::GenJet> > > input_genjet_token_;
   edm::EDGetTokenT<reco::DiscretizedEnergyFlow> input_energyflow_token_;
   edm::EDGetTokenT<reco::FFTJetPileupSummary> input_pusummary_token_;
+
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometry_token_;
+  edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> topology_token_;
 };
 
 #endif  // RecoJets_FFTJetProducers_FFTJetProducer_h

--- a/RecoJets/JetProducers/interface/JetSpecific.h
+++ b/RecoJets/JetProducers/interface/JetSpecific.h
@@ -9,10 +9,10 @@
 #include "DataFormats/JetReco/interface/PFClusterJet.h"
 #include "DataFormats/JetReco/interface/BasicJet.h"
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
-#include "FWCore/Framework/interface/EventSetup.h"
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
 
 class CaloSubdetectorGeometry;
+class CaloGeometry;
 
 namespace reco {
 
@@ -29,7 +29,8 @@ namespace reco {
                      reco::Particle::LorentzVector const& p4,
                      reco::Particle::Point const& point,
                      std::vector<reco::CandidatePtr> const& constituents,
-                     edm::EventSetup const& c);
+                     CaloGeometry const& geometry,
+                     HcalTopology const& topology);
 
   /// Make PFlowJet specifics. Assumes PseudoJet is made from ParticleFlowCandidates
   bool makeSpecific(std::vector<reco::CandidatePtr> const& particles,
@@ -40,7 +41,6 @@ namespace reco {
                      reco::Particle::LorentzVector const& p4,
                      reco::Particle::Point const& point,
                      std::vector<reco::CandidatePtr> const& constituents,
-                     edm::EventSetup const& c,
                      edm::ValueMap<float> const* weights = nullptr);
 
   /// Make GenJet specifics. Assumes PseudoJet is made from HepMCCandidate
@@ -49,29 +49,25 @@ namespace reco {
   void writeSpecific(reco::GenJet& jet,
                      reco::Particle::LorentzVector const& p4,
                      reco::Particle::Point const& point,
-                     std::vector<reco::CandidatePtr> const& constituents,
-                     edm::EventSetup const& c);
+                     std::vector<reco::CandidatePtr> const& constituents);
 
   /// Make TrackJet. Assumes constituents point to tracks, through RecoChargedCandidates.
   void writeSpecific(reco::TrackJet& jet,
                      reco::Particle::LorentzVector const& p4,
                      reco::Particle::Point const& point,
-                     std::vector<reco::CandidatePtr> const& constituents,
-                     edm::EventSetup const& c);
+                     std::vector<reco::CandidatePtr> const& constituents);
 
   /// Make PFClusterJet. Assumes PseudoJet is made from PFCluster
   void writeSpecific(reco::PFClusterJet& jet,
                      reco::Particle::LorentzVector const& p4,
                      reco::Particle::Point const& point,
-                     std::vector<reco::CandidatePtr> const& constituents,
-                     edm::EventSetup const& c);
+                     std::vector<reco::CandidatePtr> const& constituents);
 
   /// Make BasicJet. Assumes nothing about the jet.
   void writeSpecific(reco::BasicJet& jet,
                      reco::Particle::LorentzVector const& p4,
                      reco::Particle::Point const& point,
-                     std::vector<reco::CandidatePtr> const& constituents,
-                     edm::EventSetup const& c);
+                     std::vector<reco::CandidatePtr> const& constituents);
 
   /// converts eta to the corresponding HCAL subdetector.
   HcalSubdetector hcalSubdetector(int iEta, const HcalTopology& topology);

--- a/RecoJets/JetProducers/plugins/CompoundJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/CompoundJetProducer.cc
@@ -3,6 +3,8 @@
 #include "RecoJets/JetProducers/plugins/CompoundJetProducer.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "RecoJets/JetProducers/interface/JetSpecific.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 
 using namespace std;
 using namespace reco;
@@ -94,7 +96,16 @@ void CompoundJetProducer::writeCompoundJets(edm::Event& iEvent, edm::EventSetup 
 
       // Add the concrete subjet type to the subjet list to write to event record
       T jet;
-      reco::writeSpecific(jet, p4Subjet, point, subjetConstituents, iSetup);
+      if constexpr (std::is_same_v<T, reco::CaloJet>) {
+        edm::ESHandle<CaloGeometry> geometry;
+        iSetup.get<CaloGeometryRecord>().get(geometry);
+        edm::ESHandle<HcalTopology> topology;
+        iSetup.get<HcalRecNumberingRecord>().get(topology);
+
+        reco::writeSpecific(jet, p4Subjet, point, subjetConstituents, *geometry, *topology);
+      } else {
+        reco::writeSpecific(jet, p4Subjet, point, subjetConstituents);
+      }
       jet.setJetArea(itSubJet->subjetArea());
       subjetCollection->push_back(jet);
     }

--- a/RecoJets/JetProducers/plugins/CompoundJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/CompoundJetProducer.cc
@@ -59,6 +59,13 @@ void CompoundJetProducer::writeCompoundJets(edm::Event& iEvent, edm::EventSetup 
   // this is the hardjet areas
   std::vector<double> area_hardJets;
 
+  [[maybe_unused]] const CaloGeometry* pGeometry = nullptr;
+  [[maybe_unused]] const HcalTopology* pTopology = nullptr;
+  if constexpr (std::is_same_v<T, reco::CaloJet>) {
+    pGeometry = &getGeometry(iSetup);
+    pTopology = &getTopology(iSetup);
+  }
+
   // Loop over the hard jets
   std::vector<CompoundPseudoJet>::const_iterator it = fjCompoundJets_.begin(), iEnd = fjCompoundJets_.end(),
                                                  iBegin = fjCompoundJets_.begin();
@@ -97,12 +104,7 @@ void CompoundJetProducer::writeCompoundJets(edm::Event& iEvent, edm::EventSetup 
       // Add the concrete subjet type to the subjet list to write to event record
       T jet;
       if constexpr (std::is_same_v<T, reco::CaloJet>) {
-        edm::ESHandle<CaloGeometry> geometry;
-        iSetup.get<CaloGeometryRecord>().get(geometry);
-        edm::ESHandle<HcalTopology> topology;
-        iSetup.get<HcalRecNumberingRecord>().get(topology);
-
-        reco::writeSpecific(jet, p4Subjet, point, subjetConstituents, *geometry, *topology);
+        reco::writeSpecific(jet, p4Subjet, point, subjetConstituents, *pGeometry, *pTopology);
       } else {
         reco::writeSpecific(jet, p4Subjet, point, subjetConstituents);
       }

--- a/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
@@ -306,8 +306,7 @@ void FastjetJetProducer::produceTrackJets(edm::Event& iEvent, const edm::EventSe
           jet,
           reco::Particle::LorentzVector(fjJets_[ijet].px(), fjJets_[ijet].py(), fjJets_[ijet].pz(), fjJets_[ijet].E()),
           vertex_,
-          constituents,
-          iSetup);
+          constituents);
       jet.setJetArea(0);
       jet.setPileup(0);
       jet.setPrimaryVertex(edm::Ref<reco::VertexCollection>(pvCollection, (int)(itVtx - pvCollection->begin())));

--- a/RecoJets/JetProducers/plugins/SubEventGenJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/SubEventGenJetProducer.cc
@@ -147,7 +147,7 @@ void SubEventGenJetProducer::runAlgorithm(edm::Event& iEvent, edm::EventSetup co
     double jetArea = 0.0;
     double pu = 0.;
 
-    writeSpecific(jet, Particle::LorentzVector(px, py, pz, E), vertex_, constituents, iSetup);
+    writeSpecific(jet, Particle::LorentzVector(px, py, pz, E), vertex_, constituents);
 
     jet.setJetArea(jetArea);
     jet.setPileup(pu);

--- a/RecoJets/JetProducers/plugins/SubjetFilterJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/SubjetFilterJetProducer.cc
@@ -126,6 +126,13 @@ void SubjetFilterJetProducer::writeCompoundJets(edm::Event& iEvent, const edm::E
   vector<CompoundPseudoJet>::const_iterator itEnd(fjCompoundJets_.end());
   vector<CompoundPseudoJet>::const_iterator it(itBegin);
 
+  [[maybe_unused]] const CaloGeometry* pGeometry = nullptr;
+  [[maybe_unused]] const HcalTopology* pTopology = nullptr;
+  if constexpr (std::is_same_v<T, reco::CaloJet>) {
+    pGeometry = &getGeometry(iSetup);
+    pTopology = &getTopology(iSetup);
+  }
+
   for (; it != itEnd; ++it) {
     int jetIndex = it - itBegin;
     fastjet::PseudoJet fatJet = it->hardJet();
@@ -153,12 +160,7 @@ void SubjetFilterJetProducer::writeCompoundJets(edm::Event& iEvent, const edm::E
 
       T subJet;
       if constexpr (std::is_same_v<T, reco::CaloJet>) {
-        edm::ESHandle<CaloGeometry> geometry;
-        iSetup.get<CaloGeometryRecord>().get(geometry);
-        edm::ESHandle<HcalTopology> topology;
-        iSetup.get<HcalRecNumberingRecord>().get(topology);
-
-        reco::writeSpecific(subJet, p4SubJet, point, subJetConstituents, *geometry, *topology);
+        reco::writeSpecific(subJet, p4SubJet, point, subJetConstituents, *pGeometry, *pTopology);
       } else {
         reco::writeSpecific(subJet, p4SubJet, point, subJetConstituents);
       }

--- a/RecoJets/JetProducers/plugins/SubjetFilterJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/SubjetFilterJetProducer.cc
@@ -28,6 +28,8 @@
 #include "RecoJets/JetProducers/interface/JetSpecific.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 using namespace std;
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -150,7 +152,16 @@ void SubjetFilterJetProducer::writeCompoundJets(edm::Event& iEvent, const edm::E
           subJetConstituents.push_back(inputs_[*itIndex]);
 
       T subJet;
-      reco::writeSpecific(subJet, p4SubJet, point, subJetConstituents, iSetup);
+      if constexpr (std::is_same_v<T, reco::CaloJet>) {
+        edm::ESHandle<CaloGeometry> geometry;
+        iSetup.get<CaloGeometryRecord>().get(geometry);
+        edm::ESHandle<HcalTopology> topology;
+        iSetup.get<HcalRecNumberingRecord>().get(topology);
+
+        reco::writeSpecific(subJet, p4SubJet, point, subJetConstituents, *geometry, *topology);
+      } else {
+        reco::writeSpecific(subJet, p4SubJet, point, subJetConstituents);
+      }
       subJet.setJetArea(itSub->subjetArea());
 
       if (subJetIndex < 2) {

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.h
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.h
@@ -32,6 +32,9 @@
 #include <memory>
 #include <vector>
 
+class CaloGeometryRecord;
+class HcalRecNumberingRecord;
+
 class dso_hidden VirtualJetProducer : public edm::stream::EDProducer<> {
 protected:
   //
@@ -140,6 +143,10 @@ protected:
   // to an output of CandidatePtr's.
   virtual std::vector<reco::CandidatePtr> getConstituents(const std::vector<fastjet::PseudoJet>& fjConstituents);
 
+  //These are only valid if we are dealing with CaloJets
+  CaloGeometry const& getGeometry(edm::EventSetup const&) const;
+  HcalTopology const& getTopology(edm::EventSetup const&) const;
+
   //
   // member data
   //
@@ -210,6 +217,10 @@ protected:
   edm::ValueMap<float> weights_;  // weights per particle (e.g. from PUPPI)
 
 private:
+  //These are only initialized if we are dealing with CaloJets
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometry_token_;
+  edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> topology_token_;
+
   std::unique_ptr<AnomalousTower> anomalousTowerDef_;  // anomalous tower definition
 
   // tokens for the data access

--- a/RecoJets/JetProducers/src/JetSpecific.cc
+++ b/RecoJets/JetProducers/src/JetSpecific.cc
@@ -35,13 +35,7 @@ void reco::writeSpecific(reco::CaloJet& jet,
                          std::vector<reco::CandidatePtr> const& constituents,
                          CaloGeometry const& geometry,
                          HcalTopology const& topology) {
-  // Get geometry
-  //edm::ESHandle<CaloGeometry> geometry;
-  //c.get<CaloGeometryRecord>().get(geometry);
   const CaloSubdetectorGeometry* towerGeometry = geometry.getSubdetectorGeometry(DetId::Calo, CaloTowerDetId::SubdetId);
-
-  //edm::ESHandle<HcalTopology> topology;
-  //c.get<HcalRecNumberingRecord>().get(topology);
 
   // Make the specific
   reco::CaloJet::Specific specific;

--- a/RecoJets/JetProducers/src/JetSpecific.cc
+++ b/RecoJets/JetProducers/src/JetSpecific.cc
@@ -17,9 +17,7 @@
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
-#include "Geometry/Records/interface/CaloGeometryRecord.h"
 
 #include <cmath>
 
@@ -35,19 +33,19 @@ void reco::writeSpecific(reco::CaloJet& jet,
                          reco::Particle::LorentzVector const& p4,
                          reco::Particle::Point const& point,
                          std::vector<reco::CandidatePtr> const& constituents,
-                         edm::EventSetup const& c) {
+                         CaloGeometry const& geometry,
+                         HcalTopology const& topology) {
   // Get geometry
-  edm::ESHandle<CaloGeometry> geometry;
-  c.get<CaloGeometryRecord>().get(geometry);
-  const CaloSubdetectorGeometry* towerGeometry =
-      geometry->getSubdetectorGeometry(DetId::Calo, CaloTowerDetId::SubdetId);
+  //edm::ESHandle<CaloGeometry> geometry;
+  //c.get<CaloGeometryRecord>().get(geometry);
+  const CaloSubdetectorGeometry* towerGeometry = geometry.getSubdetectorGeometry(DetId::Calo, CaloTowerDetId::SubdetId);
 
-  edm::ESHandle<HcalTopology> topology;
-  c.get<HcalRecNumberingRecord>().get(topology);
+  //edm::ESHandle<HcalTopology> topology;
+  //c.get<HcalRecNumberingRecord>().get(topology);
 
   // Make the specific
   reco::CaloJet::Specific specific;
-  makeSpecific(constituents, towerGeometry, &specific, *topology);
+  makeSpecific(constituents, towerGeometry, &specific, topology);
   // Set the calo jet
   jet = reco::CaloJet(p4, point, specific, constituents);
 }
@@ -56,8 +54,7 @@ void reco::writeSpecific(reco::CaloJet& jet,
 void reco::writeSpecific(reco::BasicJet& jet,
                          reco::Particle::LorentzVector const& p4,
                          reco::Particle::Point const& point,
-                         std::vector<reco::CandidatePtr> const& constituents,
-                         edm::EventSetup const& c) {
+                         std::vector<reco::CandidatePtr> const& constituents) {
   jet = reco::BasicJet(p4, point, constituents);
 }
 
@@ -65,8 +62,7 @@ void reco::writeSpecific(reco::BasicJet& jet,
 void reco::writeSpecific(reco::GenJet& jet,
                          reco::Particle::LorentzVector const& p4,
                          reco::Particle::Point const& point,
-                         std::vector<reco::CandidatePtr> const& constituents,
-                         edm::EventSetup const& c) {
+                         std::vector<reco::CandidatePtr> const& constituents) {
   // Make the specific
   reco::GenJet::Specific specific;
   makeSpecific(constituents, &specific);
@@ -79,7 +75,6 @@ void reco::writeSpecific(reco::PFJet& jet,
                          reco::Particle::LorentzVector const& p4,
                          reco::Particle::Point const& point,
                          std::vector<reco::CandidatePtr> const& constituents,
-                         edm::EventSetup const& c,
                          edm::ValueMap<float> const* weights) {
   // Make the specific
   reco::PFJet::Specific specific;
@@ -100,8 +95,7 @@ void reco::writeSpecific(reco::PFJet& jet,
 void reco::writeSpecific(reco::TrackJet& jet,
                          reco::Particle::LorentzVector const& p4,
                          reco::Particle::Point const& point,
-                         std::vector<reco::CandidatePtr> const& constituents,
-                         edm::EventSetup const& c) {
+                         std::vector<reco::CandidatePtr> const& constituents) {
   jet = reco::TrackJet(p4, point, constituents);
 }
 
@@ -109,8 +103,7 @@ void reco::writeSpecific(reco::TrackJet& jet,
 void reco::writeSpecific(reco::PFClusterJet& jet,
                          reco::Particle::LorentzVector const& p4,
                          reco::Particle::Point const& point,
-                         std::vector<reco::CandidatePtr> const& constituents,
-                         edm::EventSetup const& c) {
+                         std::vector<reco::CandidatePtr> const& constituents) {
   jet = reco::PFClusterJet(p4, point, constituents);
 }
 

--- a/TopQuarkAnalysis/TopEventProducers/src/PseudoTopProducer.cc
+++ b/TopQuarkAnalysis/TopEventProducers/src/PseudoTopProducer.cc
@@ -150,7 +150,7 @@ void PseudoTopProducer::produce(edm::Event& event, const edm::EventSetup& eventS
 
     const LorentzVector jetP4(fjJet.px(), fjJet.py(), fjJet.pz(), fjJet.E());
     reco::GenJet lepJet;
-    reco::writeSpecific(lepJet, jetP4, genVertex_, constituents, eventSetup);
+    reco::writeSpecific(lepJet, jetP4, genVertex_, constituents);
 
     lepJet.setPdgId(lepCand->pdgId());
     lepJet.setCharge(lepCand->charge());
@@ -226,7 +226,7 @@ void PseudoTopProducer::produce(edm::Event& event, const edm::EventSetup& eventS
 
     const LorentzVector jetP4(fjJet.px(), fjJet.py(), fjJet.pz(), fjJet.E());
     reco::GenJet genJet;
-    reco::writeSpecific(genJet, jetP4, genVertex_, constituents, eventSetup);
+    reco::writeSpecific(genJet, jetP4, genVertex_, constituents);
 
     const double jetArea = fjJet.has_area() ? fjJet.area() : 0;
     genJet.setJetArea(jetArea);


### PR DESCRIPTION
#### PR description:

- changed reco::writeSpecific jet helper functions to no longer take an EventSetup
- have VirtualJetProducer base class do esConsumes and added protected function to get the ES data products.

#### PR validation:

Code compiles.