### PR TITLE
Include new geometry tags in Run-3 MC GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -66,17 +66,17 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak'     : '120X_upgrade2018cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'           : '121X_mcRun3_2021_design_v1', # GT containing design conditions for Phase1 2021
+    'phase1_2021_design'           : '121X_mcRun3_2021_design_v2', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'        : '121X_mcRun3_2021_realistic_v2', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'        : '121X_mcRun3_2021_realistic_v3', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'          : '121X_mcRun3_2021cosmics_realistic_deco_v2',
+    'phase1_2021_cosmics'          : '121X_mcRun3_2021cosmics_realistic_deco_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi'     : '121X_mcRun3_2021_realistic_HI_v2',
+    'phase1_2021_realistic_hi'     : '121X_mcRun3_2021_realistic_HI_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '121X_mcRun3_2023_realistic_v1', # GT containing realistic conditions for Phase1 2023
+    'phase1_2023_realistic'        : '121X_mcRun3_2023_realistic_v2', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '121X_mcRun3_2024_realistic_v1', # GT containing realistic conditions for Phase1 2024
+    'phase1_2024_realistic'        : '121X_mcRun3_2024_realistic_v2', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             : '113X_mcRun4_realistic_v7'
 }


### PR DESCRIPTION
#### PR description:

Inclusion of new DDD geometry tags in Run-3 MC GTs. Requested in 
https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4460.html

This is meant for `CMSSW_12_1_0_pre4` so should not merge before `CMSSW_12_1_0_pre3` is cut (expected to be today, Sept 14)

Differences in the GTs:
  * **2021 design: 121X_mcRun3_2021_design_v2**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021_design_v1/121X_mcRun3_2021_design_v2
  * **2021 realistic: 121X_mcRun3_2021_realistic_v3**
 https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021_realistic_v2/121X_mcRun3_2021_realistic_v3
  * **2021 cosmics: 121X_mcRun3_2021cosmics_realistic_deco_v3**
 https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021cosmics_realistic_deco_v2/121X_mcRun3_2021cosmics_realistic_deco_v3
  * **2021 heavy ion: 121X_mcRun3_2021_realistic_HI_v3**
 https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021_realistic_HI_v2/121X_mcRun3_2021_realistic_HI_v3
 * **2023 realistic: 121X_mcRun3_2023_realistic_v2**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2023_realistic_v1/121X_mcRun3_2023_realistic_v2
 * **2024 realistic: 121X_mcRun3_2024_realistic_v2**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2024_realistic_v1/121X_mcRun3_2024_realistic_v2

Differences are in the requested 2 geometry tags:
`XMLFILE_Geometry_120YV2_Extended2021_mc` and `TKRECO_Geometry_120YV2` 

These revisions are included:
 * PPS Run 3 sim and reco geometry was implemented.
 * PPS material names were made unique.
 * Duplicate material names were eliminated.
 * In the extended geometry description, numerical drift of rotation and translation values was reduced by rounding values <=|1e-11| to zero to match their original definitions.
 * In the Tracker Reco geometry record, calculated values of translations <=|1.e-10| were rounded to zero. Also, the third position of the so-called "navType" (_nt2) was updated from 4 to 6. This change occurred in XML during 11_2 development, but it never made it to the DB until now.


#### PR validation:

Geometry validation talk in the Simulation meeting: https://indico.cern.ch/event/1071938/#56-progress-report-on-dd4hep-m

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not a backport but a backport to 12_0_X is expected

cc @cvuosalo @srimanob 