### PR TITLE
Change Geometry_cff to GeometryDB_cff in AlCaDB related config files

### DIFF
--- a/Alignment/LaserAlignmentSimulation/test/LaserSimulation_cfg.py
+++ b/Alignment/LaserAlignmentSimulation/test/LaserSimulation_cfg.py
@@ -9,7 +9,7 @@ process = cms.Process("PROD")
 # include default services, like RandomNumberGenerator
 process.load("Configuration.StandardSequences.Services_cff")
 
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 
 process.load("Configuration.StandardSequences.MagneticField_cff")
 

--- a/Alignment/MuonAlignment/test/make_SVGtemplates_cfg.py
+++ b/Alignment/MuonAlignment/test/make_SVGtemplates_cfg.py
@@ -4,7 +4,7 @@ process = cms.Process("SVG")
 process.source = cms.Source("EmptySource")
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1))
 
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.MuonGeometrySVGTemplate = cms.EDAnalyzer("MuonGeometrySVGTemplate",
                                                  wheelTemplateName = cms.string("wheel_template.svg"))
 

--- a/Alignment/MuonAlignment/test/test_sanityCheck_cfg.py
+++ b/Alignment/MuonAlignment/test/test_sanityCheck_cfg.py
@@ -6,7 +6,7 @@ process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1))
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 process.GlobalTag.globaltag = "MC_36Y_V10::All"
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 
 from Alignment.MuonAlignment.MuonGeometrySanityCheck_cfi import *
 process.MuonGeometrySanityCheck = MuonGeometrySanityCheck.clone()

--- a/Alignment/TrackerAlignment/scripts/TkAlCaRecoPrescaling.ALCARECOTkAlCosmics0T.tpl
+++ b/Alignment/TrackerAlignment/scripts/TkAlCaRecoPrescaling.ALCARECOTkAlCosmics0T.tpl
@@ -34,7 +34,7 @@ process.source = cms.Source("PoolSource",
 from CondCore.DBCommon.CondDBSetup_cfi import *
 
 process.load('Configuration.EventContent.EventContent_cff')
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Geometry.CMSCommonData.cmsIdealGeometryXML_cfi")
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")

--- a/Alignment/TrackerAlignment/scripts/TkAlCaRecoPrescaling.ALCARECOTkAlMinBias.tpl
+++ b/Alignment/TrackerAlignment/scripts/TkAlCaRecoPrescaling.ALCARECOTkAlMinBias.tpl
@@ -33,7 +33,7 @@ process.source = cms.Source("PoolSource",
 from CondCore.DBCommon.CondDBSetup_cfi import *
 
 process.load('Configuration.EventContent.EventContent_cff')
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Geometry.CMSCommonData.cmsIdealGeometryXML_cfi")
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")

--- a/Alignment/TrackerAlignment/scripts/TkAlCaRecoSkimming.ALCARECOTkAlCosmics0T.tpl
+++ b/Alignment/TrackerAlignment/scripts/TkAlCaRecoSkimming.ALCARECOTkAlCosmics0T.tpl
@@ -35,7 +35,7 @@ process.source = cms.Source("PoolSource",
 from CondCore.DBCommon.CondDBSetup_cfi import *
 
 process.load('Configuration.EventContent.EventContent_cff')
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Geometry.CMSCommonData.cmsIdealGeometryXML_cfi")
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")

--- a/Alignment/TrackerAlignment/scripts/TkAlCaRecoSkimming.ALCARECOTkAlMinBias.tpl
+++ b/Alignment/TrackerAlignment/scripts/TkAlCaRecoSkimming.ALCARECOTkAlMinBias.tpl
@@ -34,7 +34,7 @@ process.source = cms.Source("PoolSource",
 from CondCore.DBCommon.CondDBSetup_cfi import *
 
 process.load('Configuration.EventContent.EventContent_cff')
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Geometry.CMSCommonData.cmsIdealGeometryXML_cfi")
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")

--- a/CalibMuon/CSCCalibration/test/testNewCalibConstants_global_cfg.py
+++ b/CalibMuon/CSCCalibration/test/testNewCalibConstants_global_cfg.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("TEST")
 
 # Standard stuff needed for the unpacking and local reco
-process.load("Configuration/StandardSequences/Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration/StandardSequences/MagneticField_cff")
 process.load("Configuration/StandardSequences/FrontierConditions_GlobalTag_cff")
 process.load("Configuration/StandardSequences/RawToDigi_Data_cff")

--- a/CalibMuon/CSCCalibration/test/testNewCalibConstants_sim_cfg.py
+++ b/CalibMuon/CSCCalibration/test/testNewCalibConstants_sim_cfg.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.load("Configuration/StandardSequences/Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration/StandardSequences/MagneticField_cff")
 process.load("Configuration/StandardSequences/FrontierConditions_GlobalTag_cff")
 # for Beam

--- a/CalibTracker/SiPixelConnectivity/test/SiPixelFedCablingMapWriter_cfg.py
+++ b/CalibTracker/SiPixelConnectivity/test/SiPixelFedCablingMapWriter_cfg.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("MapWriter")
 process.load("CondCore.DBCommon.CondDBCommon_cfi")
 
-#process.load("Configuration.StandardSequences.Geometry_cff")
+#process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.GeometryDB_cff")
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")

--- a/CalibTracker/SiPixelConnectivity/test/SiPixelFedCablingMapWriter_cfg.py
+++ b/CalibTracker/SiPixelConnectivity/test/SiPixelFedCablingMapWriter_cfg.py
@@ -3,7 +3,6 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("MapWriter")
 process.load("CondCore.DBCommon.CondDBCommon_cfi")
 
-#process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.GeometryDB_cff")
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")

--- a/CalibTracker/SiPixelLorentzAngle/test/SiPixelLorentzAngleCosmic_cfg.py
+++ b/CalibTracker/SiPixelLorentzAngle/test/SiPixelLorentzAngleCosmic_cfg.py
@@ -4,7 +4,7 @@ process = cms.Process("LA")
 
 process.load("Configuration.StandardSequences.Services_cff")
 
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 
 process.load("Configuration.StandardSequences.MagneticField_38T_cff")
 process.load("Configuration.StandardSequences.ReconstructionCosmics_cff")

--- a/CalibTracker/SiPixelLorentzAngle/test/SiPixelLorentzAngle_cfg.py
+++ b/CalibTracker/SiPixelLorentzAngle/test/SiPixelLorentzAngle_cfg.py
@@ -4,7 +4,7 @@ process = cms.Process("LA")
 
 process.load("Configuration.StandardSequences.Services_cff")
 
-#process.load("Configuration.StandardSequences.Geometry_cff")
+#process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load('Configuration/StandardSequences/GeometryExtended_cff')
 
 process.load('Configuration.StandardSequences.MagneticField_cff')

--- a/CalibTracker/SiStripChannelGain/test/SSTGain_PCL_Config_cfg.py
+++ b/CalibTracker/SiStripChannelGain/test/SSTGain_PCL_Config_cfg.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("APVGAIN")
 
-process.load('Configuration.StandardSequences.Geometry_cff')
+process.load('Configuration.StandardSequences.GeometryDB_cff')
 process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load("Geometry.CMSCommonData.cmsIdealGeometryXML_cfi")
 process.load("Geometry.TrackerGeometryBuilder.trackerGeometry_cfi")

--- a/Calibration/EcalAlCaRecoProducers/test/AlCaDoubleElectrons_cfg.py
+++ b/Calibration/EcalAlCaRecoProducers/test/AlCaDoubleElectrons_cfg.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("AlCaElectronsProduction")
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 process.GlobalTag.globaltag = cms.string('GR_R_52_V7::All')
 process.load("Configuration.StandardSequences.MagneticField_cff")

--- a/Calibration/HcalAlCaRecoProducers/test/di_cfg.py
+++ b/Calibration/HcalAlCaRecoProducers/test/di_cfg.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("DIJETS")
 
 
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_cff")
 
 process.maxEvents = cms.untracked.PSet(

--- a/Calibration/HcalAlCaRecoProducers/test/phi_sym_cfg.py
+++ b/Calibration/HcalAlCaRecoProducers/test/phi_sym_cfg.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("PHISYM")
 
 
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_cff")
 
 process.maxEvents = cms.untracked.PSet(

--- a/Calibration/HcalCalibAlgos/test/batchjob_analisotrk.csh
+++ b/Calibration/HcalCalibAlgos/test/batchjob_analisotrk.csh
@@ -24,7 +24,7 @@ process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 process.GlobalTag.globaltag = 'MC_31X_V5::All'
 
 process.load("Configuration.StandardSequences.Reconstruction_cff")
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_cff")
 
 process.load("Configuration.StandardSequences.VtxSmearedBetafuncEarlyCollision_cff")

--- a/Calibration/HcalCalibAlgos/test/batchjob_calib_valid.csh
+++ b/Calibration/HcalCalibAlgos/test/batchjob_calib_valid.csh
@@ -33,7 +33,7 @@ process.prefer("GlobalTag")
 
 process.load("Configuration.StandardSequences.VtxSmearedBetafuncEarlyCollision_cff")
 process.load("Configuration.StandardSequences.Generator_cff")
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_cff")
 process.load("Calibration.HcalAlCaRecoProducers.ALCARECOHcalCalIsoTrk_cff")
 process.load("Calibration.HcalAlCaRecoProducers.ALCARECOHcalCalIsoTrkNoHLT_cff")

--- a/Calibration/HcalCalibAlgos/test/batchjob_pf_corrs.csh
+++ b/Calibration/HcalCalibAlgos/test/batchjob_pf_corrs.csh
@@ -23,7 +23,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("HcalPFCorrsCulculation")
 process.load("Configuration.StandardSequences.MagneticField_cff")
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.Services_cff")
 process.load("Configuration.StandardSequences.Reconstruction_cff")
 

--- a/Calibration/TkAlCaRecoProducers/test/Alca_BeamFit_Workflow.py
+++ b/Calibration/TkAlCaRecoProducers/test/Alca_BeamFit_Workflow.py
@@ -52,7 +52,7 @@ process.hltLevel1GTSeed.L1SeedsLogicalExpression = cms.string('0 AND ( 40 OR 41 
 process.load("Configuration.StandardSequences.MagneticField_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 process.GlobalTag.globaltag = 'GR_R_38X_V9::All' #'GR_R_35X_V8::All'
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 
 
 ## reco PV

--- a/CondTools/SiPixel/test/SiPixelCondObjForHLTBuilder_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelCondObjForHLTBuilder_cfg.py
@@ -4,7 +4,7 @@ process = cms.Process("PEDESTALS")
 process.load("Configuration.StandardSequences.MagneticField_cff")
 
 #process.load("Geometry.TrackerSimData.trackerSimGeometryXML_cfi")
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Geometry.TrackerGeometryBuilder.trackerGeometry_cfi")
 process.load("Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")

--- a/CondTools/SiPixel/test/SiPixelCondObjForHLTReader_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelCondObjForHLTReader_cfg.py
@@ -4,7 +4,7 @@ process = cms.Process("PixelDBReader")
 process.load("FWCore.MessageService.MessageLogger_cfi")
 
 #process.load("Geometry.TrackerSimData.trackerSimGeometryXML_cfi")
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Geometry.TrackerGeometryBuilder.trackerGeometry_cfi")
 process.load("Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")

--- a/CondTools/SiPixel/test/SiPixelCondObjOfflineBuilder_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelCondObjOfflineBuilder_cfg.py
@@ -4,7 +4,7 @@ process = cms.Process("PEDESTALS")
 process.load("Configuration.StandardSequences.MagneticField_cff")
 
 #process.load("Geometry.TrackerSimData.trackerSimGeometryXML_cfi")
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Geometry.TrackerGeometryBuilder.trackerGeometry_cfi")
 process.load("Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")

--- a/CondTools/SiPixel/test/SiPixelCondObjOfflineReader_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelCondObjOfflineReader_cfg.py
@@ -4,7 +4,7 @@ process = cms.Process("PixelDBReader")
 process.load("FWCore.MessageService.MessageLogger_cfi")
 
 #process.load("Geometry.TrackerSimData.trackerSimGeometryXML_cfi")
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Geometry.TrackerGeometryBuilder.trackerGeometry_cfi")
 process.load("Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")

--- a/CondTools/SiPixel/test/SiPixelCondObjReader_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelCondObjReader_cfg.py
@@ -4,7 +4,7 @@ process = cms.Process("PixelDBReader")
 process.load("FWCore.MessageService.MessageLogger_cfi")
 
 #process.load("Geometry.TrackerSimData.trackerSimGeometryXML_cfi")
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Geometry.TrackerGeometryBuilder.trackerGeometry_cfi")
 process.load("Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")

--- a/CondTools/SiPixel/test/SiPixelGainCalibrationReadDQMFile_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelGainCalibrationReadDQMFile_cfg.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("test")
 process.load("CondTools.SiPixel.SiPixelGainCalibrationService_cfi")
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Geometry.TrackerGeometryBuilder.trackerGeometry_cfi")
 process.load("Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")

--- a/CondTools/SiPixel/test/SiPixelGainCalibrationRejectNoisyAndDead_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelGainCalibrationRejectNoisyAndDead_cfg.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("test")
 process.load("CondTools.SiPixel.SiPixelGainCalibrationService_cfi")
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Geometry.TrackerGeometryBuilder.trackerGeometry_cfi")
 process.load("Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")

--- a/CondTools/SiStrip/test/SiStripDetVOffFakeBuilder_cfg.py
+++ b/CondTools/SiStrip/test/SiStripDetVOffFakeBuilder_cfg.py
@@ -31,7 +31,7 @@ process.PoolDBOutputService = cms.Service("PoolDBOutputService",
     ))
 )
 
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.TrackerDigiGeometryESModule.applyAlignment = False
 
 process.prod = cms.EDAnalyzer("SiStripDetVOffFakeBuilder")

--- a/CondTools/SiStrip/test/SiStripFedCablingBuilder_cfg.py
+++ b/CondTools/SiStrip/test/SiStripFedCablingBuilder_cfg.py
@@ -35,7 +35,7 @@ process.PoolDBOutputService = cms.Service("PoolDBOutputService",
     ))
 )
 
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.TrackerDigiGeometryESModule.applyAlignment = False
 process.SiStripConnectivity = cms.ESProducer("SiStripConnectivity")
 process.SiStripRegionConnectivity = cms.ESProducer("SiStripRegionConnectivity",

--- a/CondTools/SiStrip/test/SiStripFedCablingReader_cfg.py
+++ b/CondTools/SiStrip/test/SiStripFedCablingReader_cfg.py
@@ -33,7 +33,7 @@ process.poolDBESSource = cms.ESSource("PoolDBESSource",
     ))
 )
 
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.TrackerDigiGeometryESModule.applyAlignment = False
 process.SiStripConnectivity = cms.ESProducer("SiStripConnectivity")
 process.SiStripRegionConnectivity = cms.ESProducer("SiStripRegionConnectivity",


### PR DESCRIPTION
#### PR description:

Taking care of the AlCa and DB part of https://github.com/cms-sw/cmssw/issues/31113
i.e. the fact that 
`process.load("Configuration.StandardSequences.Geometry_cff")`
was removed a while ago: https://github.com/cms-sw/cmssw/pull/8810
and thus should be replaced with 
`process.load("Configuration.StandardSequences.GeometryDB_cff")`

#### PR validation:

`scramv1 b runtests` though I guess this doesn't test any of these files, otherwise it would have been fixed already

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport and no backport is needed
