### PR TITLE
Migrate CondtTools-L1trigger packages to use esConsumes

### DIFF
--- a/CondTools/L1Trigger/interface/L1ConfigOnlineProdBase.h
+++ b/CondTools/L1Trigger/interface/L1ConfigOnlineProdBase.h
@@ -89,8 +89,8 @@ L1ConfigOnlineProdBase<TRcd, TData>::L1ConfigOnlineProdBase(const edm::Parameter
   auto cc = setWhatProduced(this);
 
   //now do what ever other initialization is needed
-  l1TriggerKeyListToken_ = cc.esConsumes();
-  l1TriggerKeyToken_ = cc.esConsumes();
+  l1TriggerKeyListToken_ = cc.consumes();
+  l1TriggerKeyToken_ = cc.consumes();
 
   if (iConfig.exists("copyFromCondDB")) {
     m_copyFromCondDB = iConfig.getParameter<bool>("copyFromCondDB");
@@ -175,7 +175,7 @@ bool L1ConfigOnlineProdBase<TRcd, TData>::getObjectKey(const TRcd& record, std::
   // already in ORCON.
   const edm::ESHandle<L1TriggerKey> key;
   try {
-    key = iRecord.getHandle(l1TriggerKeyToken_);
+    key = record.getHandle(l1TriggerKeyToken_);
   } catch (l1t::DataAlreadyPresentException& ex) {
     objectKey = std::string();
     return false;

--- a/CondTools/L1Trigger/interface/L1ConfigOnlineProdBase.h
+++ b/CondTools/L1Trigger/interface/L1ConfigOnlineProdBase.h
@@ -124,9 +124,8 @@ std::unique_ptr<TData> L1ConfigOnlineProdBase<TRcd, TData>::produce(const TRcd& 
     if (m_copyFromCondDB) {
       // Get L1TriggerKeyList from EventSetup
       const L1TriggerKeyListRcd& keyListRcd = iRecord.template getRecord<L1TriggerKeyListRcd>();
-      ///edm::ESHandle<L1TriggerKeyList> keyList;
-      //keyListRcd.get(keyList);
-      auto keyList = iRecord.template getHandle(l1TriggerKeyListToken_);
+
+      const auto keyList = iRecord.getHandle(l1TriggerKeyListToken_);
 
       // Find payload token
       std::string recordName = edm::typelookup::className<TRcd>();
@@ -174,9 +173,9 @@ bool L1ConfigOnlineProdBase<TRcd, TData>::getObjectKey(const TRcd& record, std::
 
   // If L1TriggerKey is invalid, then all configuration objects are
   // already in ORCON.
-  edm::ESHandle<L1TriggerKey> key;
+  const edm::ESHandle<L1TriggerKey> key;
   try {
-    key = iRecord.template getHandle(l1TriggerKeyToken_);
+    key = iRecord.getHandle(l1TriggerKeyToken_);
   } catch (l1t::DataAlreadyPresentException& ex) {
     objectKey = std::string();
     return false;

--- a/CondTools/L1Trigger/interface/L1ConfigOnlineProdBase.h
+++ b/CondTools/L1Trigger/interface/L1ConfigOnlineProdBase.h
@@ -122,10 +122,7 @@ std::unique_ptr<TData> L1ConfigOnlineProdBase<TRcd, TData>::produce(const TRcd& 
   std::string key;
   if (getObjectKey(iRecord, key) || m_forceGeneration) {
     if (m_copyFromCondDB) {
-      // Get L1TriggerKeyList from EventSetup
-      const L1TriggerKeyListRcd& keyListRcd = iRecord.template getRecord<L1TriggerKeyListRcd>();
-
-      const auto keyList = iRecord.getHandle(l1TriggerKeyListToken_);
+      auto keyList = iRecord.getHandle(l1TriggerKeyListToken_);
 
       // Find payload token
       std::string recordName = edm::typelookup::className<TRcd>();
@@ -163,19 +160,16 @@ std::unique_ptr<TData> L1ConfigOnlineProdBase<TRcd, TData>::produce(const TRcd& 
 }
 
 template <class TRcd, class TData>
-bool L1ConfigOnlineProdBase<TRcd, TData>::getObjectKey(const TRcd& record, std::string& objectKey) {
-  // Get L1TriggerKey
-  const L1TriggerKeyRcd& keyRcd = record.template getRecord<L1TriggerKeyRcd>();
-
+bool L1ConfigOnlineProdBase<TRcd, TData>::getObjectKey(const TRcd& iRecord, std::string& objectKey) {
   // Explanation of funny syntax: since record is dependent, we are not
   // expecting getRecord to be a template so the compiler parses it
   // as a non-template. http://gcc.gnu.org/ml/gcc-bugs/2005-11/msg03685.html
 
   // If L1TriggerKey is invalid, then all configuration objects are
   // already in ORCON.
-  const edm::ESHandle<L1TriggerKey> key;
+  edm::ESHandle<L1TriggerKey> key;
   try {
-    key = record.getHandle(l1TriggerKeyToken_);
+    key = iRecord.getHandle(l1TriggerKeyToken_);
   } catch (l1t::DataAlreadyPresentException& ex) {
     objectKey = std::string();
     return false;

--- a/CondTools/L1Trigger/interface/L1ConfigOnlineProdBase.h
+++ b/CondTools/L1Trigger/interface/L1ConfigOnlineProdBase.h
@@ -62,6 +62,7 @@ private:
   // ----------member data ---------------------------
   edm::ESGetToken<L1TriggerKeyList, TRcd> l1TriggerKeyListToken_;
   edm::ESGetToken<L1TriggerKey, TRcd> l1TriggerKeyToken_;
+
 protected:
   l1t::OMDSReader m_omdsReader;
   bool m_forceGeneration;

--- a/CondTools/L1Trigger/interface/L1ObjectKeysOnlineProdBase.h
+++ b/CondTools/L1Trigger/interface/L1ObjectKeysOnlineProdBase.h
@@ -52,6 +52,7 @@ private:
   // ----------member data ---------------------------
 protected:
   l1t::OMDSReader m_omdsReader;
+  edm::ESGetToken<L1TriggerKey, L1TriggerKeyRcd> l1TriggerKeyToken_;
 };
 
 #endif

--- a/CondTools/L1Trigger/plugins/L1CondDBIOVWriter.cc
+++ b/CondTools/L1Trigger/plugins/L1CondDBIOVWriter.cc
@@ -60,6 +60,7 @@ L1CondDBIOVWriter::L1CondDBIOVWriter(const edm::ParameterSet& iConfig)
     std::string type = it->getParameter<std::string>("type");
     m_recordTypes.push_back(record + "@" + type);
   }
+  l1TriggerKeyToken_ = esConsumes();
 }
 
 L1CondDBIOVWriter::~L1CondDBIOVWriter() {
@@ -122,9 +123,7 @@ void L1CondDBIOVWriter::analyze(const edm::Event& iEvent, const edm::EventSetup&
       // ORCON.
 
       // Get L1TriggerKey from EventSetup
-      ESHandle<L1TriggerKey> esKey;
-      iSetup.get<L1TriggerKeyRcd>().get(esKey);
-
+      auto esKey = iSetup.getHandle(l1TriggerKeyToken_);
       recordTypeToKeyMap = esKey->recordToKeyMap();
     }
   } else {

--- a/CondTools/L1Trigger/plugins/L1CondDBIOVWriter.h
+++ b/CondTools/L1Trigger/plugins/L1CondDBIOVWriter.h
@@ -34,7 +34,8 @@
 #include "CondTools/L1Trigger/interface/DataWriter.h"
 
 // forward declarations
-
+class L1TriggerKey;
+class L1TriggerKeyRcd;
 class L1CondDBIOVWriter : public edm::EDAnalyzer {
 public:
   explicit L1CondDBIOVWriter(const edm::ParameterSet&);
@@ -65,6 +66,8 @@ private:
   bool m_logTransactions;
 
   bool m_forceUpdate;
+
+  edm::ESGetToken<L1TriggerKey, L1TriggerKeyRcd>  l1TriggerKeyToken_;
 };
 
 #endif

--- a/CondTools/L1Trigger/plugins/L1CondDBIOVWriter.h
+++ b/CondTools/L1Trigger/plugins/L1CondDBIOVWriter.h
@@ -67,7 +67,7 @@ private:
 
   bool m_forceUpdate;
 
-  edm::ESGetToken<L1TriggerKey, L1TriggerKeyRcd>  l1TriggerKeyToken_;
+  edm::ESGetToken<L1TriggerKey, L1TriggerKeyRcd> l1TriggerKeyToken_;
 };
 
 #endif

--- a/CondTools/L1Trigger/plugins/L1CondDBIOVWriter.h
+++ b/CondTools/L1Trigger/plugins/L1CondDBIOVWriter.h
@@ -24,7 +24,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -36,7 +36,7 @@
 // forward declarations
 class L1TriggerKey;
 class L1TriggerKeyRcd;
-class L1CondDBIOVWriter : public edm::EDAnalyzer {
+class L1CondDBIOVWriter : public edm::one::EDAnalyzer<> {
 public:
   explicit L1CondDBIOVWriter(const edm::ParameterSet&);
   ~L1CondDBIOVWriter() override;

--- a/CondTools/L1Trigger/plugins/L1CondDBPayloadWriter.cc
+++ b/CondTools/L1Trigger/plugins/L1CondDBPayloadWriter.cc
@@ -38,10 +38,6 @@
 //
 
 //
-// static data member definitions
-//
-
-//
 // constructors and destructor
 //
 L1CondDBPayloadWriter::L1CondDBPayloadWriter(const edm::ParameterSet& iConfig)
@@ -51,6 +47,7 @@ L1CondDBPayloadWriter::L1CondDBPayloadWriter(const edm::ParameterSet& iConfig)
       m_logTransactions(iConfig.getParameter<bool>("logTransactions")),
       m_newL1TriggerKeyList(iConfig.getParameter<bool>("newL1TriggerKeyList")) {
   //now do what ever initialization is needed
+  l1TriggerKeyToken_ = esConsumes();
 }
 
 L1CondDBPayloadWriter::~L1CondDBPayloadWriter() {
@@ -87,7 +84,7 @@ void L1CondDBPayloadWriter::analyze(const edm::Event& iEvent, const edm::EventSe
   bool triggerKeyOK = true;
   try {
     // Get L1TriggerKey
-    iSetup.get<L1TriggerKeyRcd>().get(key);
+    key = iSetup.getHandle(l1TriggerKeyToken_);
 
     if (!m_overwriteKeys) {
       triggerKeyOK = oldKeyList.token(key->tscKey()).empty();

--- a/CondTools/L1Trigger/plugins/L1CondDBPayloadWriter.h
+++ b/CondTools/L1Trigger/plugins/L1CondDBPayloadWriter.h
@@ -24,7 +24,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -37,7 +37,7 @@
 class L1TriggerKey;
 class L1TriggerKeyRcd;
 
-class L1CondDBPayloadWriter : public edm::EDAnalyzer {
+class L1CondDBPayloadWriter : public edm::one::EDAnalyzer<> {
 public:
   explicit L1CondDBPayloadWriter(const edm::ParameterSet&);
   ~L1CondDBPayloadWriter() override;

--- a/CondTools/L1Trigger/plugins/L1CondDBPayloadWriter.h
+++ b/CondTools/L1Trigger/plugins/L1CondDBPayloadWriter.h
@@ -34,6 +34,8 @@
 #include "CondTools/L1Trigger/interface/DataWriter.h"
 
 // forward declarations
+class L1TriggerKey;
+class L1TriggerKeyRcd;
 
 class L1CondDBPayloadWriter : public edm::EDAnalyzer {
 public:
@@ -62,6 +64,8 @@ private:
 
   // if true, do not retrieve L1TriggerKeyList from EventSetup
   bool m_newL1TriggerKeyList;
+
+  edm::ESGetToken<L1TriggerKey, L1TriggerKeyRcd> l1TriggerKeyToken_;
 };
 
 #endif

--- a/CondTools/L1Trigger/plugins/L1GtRunSettingsViewer.cc
+++ b/CondTools/L1Trigger/plugins/L1GtRunSettingsViewer.cc
@@ -23,7 +23,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -53,7 +53,7 @@
 // class decleration
 //
 
-class L1GtRunSettingsViewer : public edm::EDAnalyzer {
+class L1GtRunSettingsViewer : public edm::one::EDAnalyzer<> {
 public:
   explicit L1GtRunSettingsViewer(const edm::ParameterSet&);
   ~L1GtRunSettingsViewer() override;

--- a/CondTools/L1Trigger/plugins/L1O2OTestAnalyzer.cc
+++ b/CondTools/L1Trigger/plugins/L1O2OTestAnalyzer.cc
@@ -17,7 +17,6 @@
 //
 
 // system include files
-#include <iostream>
 #include <memory>
 #include <sstream>
 
@@ -60,6 +59,7 @@ private:
   bool m_printESRecords;
   bool m_printPayloadTokens;
   std::vector<std::string> m_recordsToPrint;
+  edm::ESGetToken<L1TriggerKey, L1TriggerKeyRcd> l1TriggerKeyToken_;
 };
 
 //
@@ -80,6 +80,7 @@ L1O2OTestAnalyzer::L1O2OTestAnalyzer(const edm::ParameterSet& iConfig)
       m_printPayloadTokens(iConfig.getParameter<bool>("printPayloadTokens")),
       m_recordsToPrint(iConfig.getParameter<std::vector<std::string> >("recordsToPrint")) {
   //now do what ever initialization is needed
+  l1TriggerKeyToken_ = esConsumes();
 }
 
 L1O2OTestAnalyzer::~L1O2OTestAnalyzer() {
@@ -104,65 +105,64 @@ void L1O2OTestAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup&
       edm::LogError("L1-O2O") << "Problem getting last L1TriggerKeyList";
     }
 
-    std::cout << "Found " << pList.tscKeyToTokenMap().size() << " TSC keys:" << std::endl;
+    edm::LogInfo("L1-O2O") << "Found " << pList.tscKeyToTokenMap().size() << " TSC keys:" << std::endl;
 
     L1TriggerKeyList::KeyToToken::const_iterator iTSCKey = pList.tscKeyToTokenMap().begin();
     L1TriggerKeyList::KeyToToken::const_iterator eTSCKey = pList.tscKeyToTokenMap().end();
     for (; iTSCKey != eTSCKey; ++iTSCKey) {
-      std::cout << iTSCKey->first;
+      edm::LogInfo("L1-O2O") << iTSCKey->first;
       if (m_printPayloadTokens) {
-        std::cout << " " << iTSCKey->second;
+        edm::LogInfo("L1-O2O") << " " << iTSCKey->second;
       }
-      std::cout << std::endl;
+      edm::LogInfo("L1-O2O") << std::endl;
     }
-    std::cout << std::endl;
+    edm::LogInfo("L1-O2O") << std::endl;
 
     L1TriggerKeyList::RecordToKeyToToken::const_iterator iRec = pList.recordTypeToKeyToTokenMap().begin();
     L1TriggerKeyList::RecordToKeyToToken::const_iterator eRec = pList.recordTypeToKeyToTokenMap().end();
     for (; iRec != eRec; ++iRec) {
       const L1TriggerKeyList::KeyToToken& keyTokenMap = iRec->second;
-      std::cout << "For record@type " << iRec->first << ", found " << keyTokenMap.size() << " keys:" << std::endl;
+      edm::LogInfo("L1-O2O") << "For record@type " << iRec->first << ", found " << keyTokenMap.size() << " keys:" << std::endl;
 
       L1TriggerKeyList::KeyToToken::const_iterator iKey = keyTokenMap.begin();
       L1TriggerKeyList::KeyToToken::const_iterator eKey = keyTokenMap.end();
       for (; iKey != eKey; ++iKey) {
-        std::cout << iKey->first;
+        edm::LogInfo("L1-O2O") << iKey->first;
         if (m_printPayloadTokens) {
-          std::cout << " " << iKey->second;
+          edm::LogInfo("L1-O2O") << " " << iKey->second;
         }
-        std::cout << std::endl;
+        edm::LogInfo("L1-O2O") << std::endl;
       }
-      std::cout << std::endl;
+      edm::LogInfo("L1-O2O") << std::endl;
     }
   }
 
   if (m_printL1TriggerKey) {
     try {
-      ESHandle<L1TriggerKey> pKey;
-      iSetup.get<L1TriggerKeyRcd>().get(pKey);
+      auto pKey = iSetup.getHandle(l1TriggerKeyToken_);
 
-      std::cout << std::endl;
-      std::cout << "Current TSC key = " << pKey->tscKey() << std::endl << std::endl;
+      edm::LogInfo("L1-O2O") << std::endl;
+      edm::LogInfo("L1-O2O") << "Current TSC key = " << pKey->tscKey() << std::endl << std::endl;
 
-      std::cout << "Current subsystem keys:" << std::endl;
-      std::cout << "CSCTF " << pKey->subsystemKey(L1TriggerKey::kCSCTF) << std::endl;
-      std::cout << "DTTF " << pKey->subsystemKey(L1TriggerKey::kDTTF) << std::endl;
-      std::cout << "RPC " << pKey->subsystemKey(L1TriggerKey::kRPC) << std::endl;
-      std::cout << "GMT " << pKey->subsystemKey(L1TriggerKey::kGMT) << std::endl;
-      std::cout << "RCT " << pKey->subsystemKey(L1TriggerKey::kRCT) << std::endl;
-      std::cout << "GCT " << pKey->subsystemKey(L1TriggerKey::kGCT) << std::endl;
-      std::cout << "GT " << pKey->subsystemKey(L1TriggerKey::kGT) << std::endl;
-      std::cout << "TSP0 " << pKey->subsystemKey(L1TriggerKey::kTSP0) << std::endl << std::endl;
+      edm::LogInfo("L1-O2O") << "Current subsystem keys:" << std::endl;
+      edm::LogInfo("L1-O2O") << "CSCTF " << pKey->subsystemKey(L1TriggerKey::kCSCTF) << std::endl;
+      edm::LogInfo("L1-O2O") << "DTTF " << pKey->subsystemKey(L1TriggerKey::kDTTF) << std::endl;
+      edm::LogInfo("L1-O2O") << "RPC " << pKey->subsystemKey(L1TriggerKey::kRPC) << std::endl;
+      edm::LogInfo("L1-O2O") << "GMT " << pKey->subsystemKey(L1TriggerKey::kGMT) << std::endl;
+      edm::LogInfo("L1-O2O") << "RCT " << pKey->subsystemKey(L1TriggerKey::kRCT) << std::endl;
+      edm::LogInfo("L1-O2O") << "GCT " << pKey->subsystemKey(L1TriggerKey::kGCT) << std::endl;
+      edm::LogInfo("L1-O2O") << "GT " << pKey->subsystemKey(L1TriggerKey::kGT) << std::endl;
+      edm::LogInfo("L1-O2O") << "TSP0 " << pKey->subsystemKey(L1TriggerKey::kTSP0) << std::endl << std::endl;
 
-      std::cout << "Object keys:" << std::endl;
+      edm::LogInfo("L1-O2O") << "Object keys:" << std::endl;
       const L1TriggerKey::RecordToKey& recKeyMap = pKey->recordToKeyMap();
       L1TriggerKey::RecordToKey::const_iterator iRec = recKeyMap.begin();
       L1TriggerKey::RecordToKey::const_iterator eRec = recKeyMap.end();
       for (; iRec != eRec; ++iRec) {
-        std::cout << iRec->first << " " << iRec->second << std::endl;
+        edm::LogInfo("L1-O2O") << iRec->first << " " << iRec->second << std::endl;
       }
     } catch (cms::Exception& ex) {
-      std::cout << "No L1TriggerKey found." << std::endl;
+      edm::LogError("L1-O2O") << "No L1TriggerKey found." << std::endl;
     }
   }
 
@@ -184,7 +184,7 @@ void L1O2OTestAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup&
 
     l1t::DataWriter writer;
 
-    std::cout << std::endl << "Run Settings keys:" << std::endl;
+    edm::LogInfo("L1-O2O") << std::endl << "Run Settings keys:" << std::endl;
 
     std::vector<std::string>::const_iterator iRec = m_recordsToPrint.begin();
     std::vector<std::string>::const_iterator iEnd = m_recordsToPrint.end();
@@ -198,11 +198,11 @@ void L1O2OTestAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup&
         key = pList.objectKey(*iRec, payloadToken);
       }
 
-      std::cout << *iRec << " " << key;
+      edm::LogInfo("L1-O2O") << *iRec << " " << key;
       if (m_printPayloadTokens) {
-        std::cout << " " << payloadToken;
+        edm::LogInfo("L1-O2O") << " " << payloadToken;
       }
-      std::cout << std::endl;
+      edm::LogInfo("L1-O2O") << std::endl;
 
       // Replace spaces in key with ?s.  Do reverse substitution when
       // making L1TriggerKey.
@@ -210,7 +210,7 @@ void L1O2OTestAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup&
       log += " " + *iRec + "Key=" + key;
     }
 
-    std::cout << std::endl << log << std::endl;
+    edm::LogInfo("L1-O2O") << std::endl << log << std::endl;
   }
 }
 

--- a/CondTools/L1Trigger/plugins/L1O2OTestAnalyzer.cc
+++ b/CondTools/L1Trigger/plugins/L1O2OTestAnalyzer.cc
@@ -22,7 +22,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -43,7 +43,7 @@
 // class decleration
 //
 
-class L1O2OTestAnalyzer : public edm::EDAnalyzer {
+class L1O2OTestAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   explicit L1O2OTestAnalyzer(const edm::ParameterSet&);
   ~L1O2OTestAnalyzer() override;

--- a/CondTools/L1Trigger/plugins/L1O2OTestAnalyzer.cc
+++ b/CondTools/L1Trigger/plugins/L1O2OTestAnalyzer.cc
@@ -122,7 +122,8 @@ void L1O2OTestAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup&
     L1TriggerKeyList::RecordToKeyToToken::const_iterator eRec = pList.recordTypeToKeyToTokenMap().end();
     for (; iRec != eRec; ++iRec) {
       const L1TriggerKeyList::KeyToToken& keyTokenMap = iRec->second;
-      edm::LogInfo("L1-O2O") << "For record@type " << iRec->first << ", found " << keyTokenMap.size() << " keys:" << std::endl;
+      edm::LogInfo("L1-O2O") << "For record@type " << iRec->first << ", found " << keyTokenMap.size()
+                             << " keys:" << std::endl;
 
       L1TriggerKeyList::KeyToToken::const_iterator iKey = keyTokenMap.begin();
       L1TriggerKeyList::KeyToToken::const_iterator eKey = keyTokenMap.end();

--- a/CondTools/L1Trigger/plugins/L1TriggerKeyOnlineProd.cc
+++ b/CondTools/L1Trigger/plugins/L1TriggerKeyOnlineProd.cc
@@ -48,10 +48,10 @@ L1TriggerKeyOnlineProd::L1TriggerKeyOnlineProd(const edm::ParameterSet& iConfig)
   //the following line is needed to tell the framework what
   // data is being produced
   auto cc = setWhatProduced(this);
-  
+
   //now do what ever other initialization is needed
   l1TriggerKeyToken_ = cc.consumes(edm::ESInputTag("", "SubsystemKeysOnly"));
-  for(auto mlabel : m_subsystemLabels) {
+  for (const auto& mlabel : m_subsystemLabels) {
     l1TriggerKeyTokenVec_.emplace_back(cc.consumes(edm::ESInputTag("", mlabel)));
   }
 }
@@ -70,7 +70,7 @@ L1TriggerKeyOnlineProd::ReturnType L1TriggerKeyOnlineProd::produce(const L1Trigg
   // Start with "SubsystemKeysOnly"
   edm::ESHandle<L1TriggerKey> subsystemKeys;
   try {
-    subsystemKeys = iRecord.getHandle(l1TriggerKeyToken_); 
+    subsystemKeys = iRecord.getHandle(l1TriggerKeyToken_);
   } catch (l1t::DataAlreadyPresentException& ex) {
     throw ex;
   }
@@ -78,7 +78,7 @@ L1TriggerKeyOnlineProd::ReturnType L1TriggerKeyOnlineProd::produce(const L1Trigg
   std::unique_ptr<L1TriggerKey> pL1TriggerKey = std::make_unique<L1TriggerKey>(*subsystemKeys);
 
   // Collate object keys
-  for (auto l1token : l1TriggerKeyTokenVec_) {
+  for (const auto& l1token : l1TriggerKeyTokenVec_) {
     edm::ESHandle<L1TriggerKey> objectKeys;
     try {
       objectKeys = iRecord.getHandle(l1token);

--- a/CondTools/L1Trigger/plugins/L1TriggerKeyOnlineProd.cc
+++ b/CondTools/L1Trigger/plugins/L1TriggerKeyOnlineProd.cc
@@ -47,9 +47,13 @@ L1TriggerKeyOnlineProd::L1TriggerKeyOnlineProd(const edm::ParameterSet& iConfig)
     : m_subsystemLabels(iConfig.getParameter<std::vector<std::string> >("subsystemLabels")) {
   //the following line is needed to tell the framework what
   // data is being produced
-  setWhatProduced(this);
-
+  auto cc = setWhatProduced(this);
+  
   //now do what ever other initialization is needed
+  l1TriggerKeyToken_ = cc.consumes(edm::ESInputTag("", "SubsystemKeysOnly"));
+  for(auto mlabel : m_subsystemLabels) {
+    l1TriggerKeyTokenVec_.emplace_back(cc.consumes(edm::ESInputTag("", mlabel)));
+  }
 }
 
 L1TriggerKeyOnlineProd::~L1TriggerKeyOnlineProd() {
@@ -66,7 +70,7 @@ L1TriggerKeyOnlineProd::ReturnType L1TriggerKeyOnlineProd::produce(const L1Trigg
   // Start with "SubsystemKeysOnly"
   edm::ESHandle<L1TriggerKey> subsystemKeys;
   try {
-    iRecord.get("SubsystemKeysOnly", subsystemKeys);
+    subsystemKeys = iRecord.getHandle(l1TriggerKeyToken_); 
   } catch (l1t::DataAlreadyPresentException& ex) {
     throw ex;
   }
@@ -74,12 +78,10 @@ L1TriggerKeyOnlineProd::ReturnType L1TriggerKeyOnlineProd::produce(const L1Trigg
   std::unique_ptr<L1TriggerKey> pL1TriggerKey = std::make_unique<L1TriggerKey>(*subsystemKeys);
 
   // Collate object keys
-  std::vector<std::string>::const_iterator itr = m_subsystemLabels.begin();
-  std::vector<std::string>::const_iterator end = m_subsystemLabels.end();
-  for (; itr != end; ++itr) {
+  for (auto l1token : l1TriggerKeyTokenVec_) {
     edm::ESHandle<L1TriggerKey> objectKeys;
     try {
-      iRecord.get(*itr, objectKeys);
+      objectKeys = iRecord.getHandle(l1token);
     } catch (l1t::DataAlreadyPresentException& ex) {
       throw ex;
     }

--- a/CondTools/L1Trigger/plugins/L1TriggerKeyOnlineProd.h
+++ b/CondTools/L1Trigger/plugins/L1TriggerKeyOnlineProd.h
@@ -48,8 +48,8 @@ public:
 private:
   // ----------member data ---------------------------
   std::vector<std::string> m_subsystemLabels;
-  edm::ESGetToken<L1TriggerKey, L1TriggerKeyRcd>  l1TriggerKeyToken_;
-  std::vector<edm::ESGetToken<L1TriggerKey, L1TriggerKeyRcd>>  l1TriggerKeyTokenVec_;
+  edm::ESGetToken<L1TriggerKey, L1TriggerKeyRcd> l1TriggerKeyToken_;
+  std::vector<edm::ESGetToken<L1TriggerKey, L1TriggerKeyRcd>> l1TriggerKeyTokenVec_;
 };
 
 #endif

--- a/CondTools/L1Trigger/plugins/L1TriggerKeyOnlineProd.h
+++ b/CondTools/L1Trigger/plugins/L1TriggerKeyOnlineProd.h
@@ -33,6 +33,8 @@
 #include "CondFormats/DataRecord/interface/L1TriggerKeyRcd.h"
 
 // forward declarations
+class L1TriggerKey;
+class L1TriggerKeyRcd;
 
 class L1TriggerKeyOnlineProd : public edm::ESProducer {
 public:
@@ -46,6 +48,8 @@ public:
 private:
   // ----------member data ---------------------------
   std::vector<std::string> m_subsystemLabels;
+  edm::ESGetToken<L1TriggerKey, L1TriggerKeyRcd>  l1TriggerKeyToken_;
+  std::vector<edm::ESGetToken<L1TriggerKey, L1TriggerKeyRcd>>  l1TriggerKeyTokenVec_;
 };
 
 #endif

--- a/CondTools/L1Trigger/src/L1ObjectKeysOnlineProdBase.cc
+++ b/CondTools/L1Trigger/src/L1ObjectKeysOnlineProdBase.cc
@@ -52,9 +52,10 @@ L1ObjectKeysOnlineProdBase::L1ObjectKeysOnlineProdBase(const edm::ParameterSet& 
 
   // The subsystemLabel is used by L1TriggerKeyOnlineProd to identify the
   // L1TriggerKeys to concatenate.
-  setWhatProduced(this, iConfig.getParameter<std::string>("subsystemLabel"));
+  auto cc = setWhatProduced(this, iConfig.getParameter<std::string>("subsystemLabel"));
 
   //now do what ever other initialization is needed
+  l1TriggerKeyToken_ = cc.consumes(edm::ESInputTag("", "SubsystemKeysOnly"));
 }
 
 L1ObjectKeysOnlineProdBase::~L1ObjectKeysOnlineProdBase() {
@@ -72,7 +73,7 @@ L1ObjectKeysOnlineProdBase::ReturnType L1ObjectKeysOnlineProdBase::produce(const
   // not present.
   edm::ESHandle<L1TriggerKey> subsystemKeys;
   try {
-    iRecord.get("SubsystemKeysOnly", subsystemKeys);
+    subsystemKeys = iRecord.getHandle(l1TriggerKeyToken_);
   } catch (l1t::DataAlreadyPresentException& ex) {
     throw ex;
   }

--- a/CondTools/L1TriggerExt/plugins/L1CondDBIOVWriterExt.cc
+++ b/CondTools/L1TriggerExt/plugins/L1CondDBIOVWriterExt.cc
@@ -25,6 +25,7 @@ L1CondDBIOVWriterExt::L1CondDBIOVWriterExt(const edm::ParameterSet& iConfig)
     std::string type = it->getParameter<std::string>("type");
     m_recordTypes.push_back(record + "@" + type);
   }
+  l1TriggerKeyExtToken_ = esConsumes();
 }
 
 L1CondDBIOVWriterExt::~L1CondDBIOVWriterExt() {
@@ -86,8 +87,7 @@ void L1CondDBIOVWriterExt::analyze(const edm::Event& iEvent, const edm::EventSet
       // ORCON.
 
       // Get L1TriggerKeyExt from EventSetup
-      ESHandle<L1TriggerKeyExt> esKey;
-      iSetup.get<L1TriggerKeyExtRcd>().get(esKey);
+      auto esKey = iSetup.getHandle(l1TriggerKeyExtToken_);
 
       recordTypeToKeyMap = esKey->recordToKeyMap();
     }

--- a/CondTools/L1TriggerExt/plugins/L1CondDBIOVWriterExt.h
+++ b/CondTools/L1TriggerExt/plugins/L1CondDBIOVWriterExt.h
@@ -4,7 +4,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -16,7 +16,7 @@
 class L1TriggerKeyExt;
 class L1TriggerKeyExtRcd;
 
-class L1CondDBIOVWriterExt : public edm::EDAnalyzer {
+class L1CondDBIOVWriterExt : public edm::one::EDAnalyzer<> {
 public:
   explicit L1CondDBIOVWriterExt(const edm::ParameterSet&);
   ~L1CondDBIOVWriterExt() override;

--- a/CondTools/L1TriggerExt/plugins/L1CondDBIOVWriterExt.h
+++ b/CondTools/L1TriggerExt/plugins/L1CondDBIOVWriterExt.h
@@ -13,6 +13,9 @@
 
 #include "CondTools/L1TriggerExt/interface/DataWriterExt.h"
 
+class L1TriggerKeyExt;
+class L1TriggerKeyExtRcd;
+
 class L1CondDBIOVWriterExt : public edm::EDAnalyzer {
 public:
   explicit L1CondDBIOVWriterExt(const edm::ParameterSet&);
@@ -45,6 +48,9 @@ private:
   bool m_logTransactions;
 
   bool m_forceUpdate;
+  
+  edm::ESGetToken<L1TriggerKeyExt, L1TriggerKeyExtRcd> l1TriggerKeyExtToken_;
 };
 
 #endif
+

--- a/CondTools/L1TriggerExt/plugins/L1CondDBIOVWriterExt.h
+++ b/CondTools/L1TriggerExt/plugins/L1CondDBIOVWriterExt.h
@@ -48,9 +48,8 @@ private:
   bool m_logTransactions;
 
   bool m_forceUpdate;
-  
+
   edm::ESGetToken<L1TriggerKeyExt, L1TriggerKeyExtRcd> l1TriggerKeyExtToken_;
 };
 
 #endif
-

--- a/CondTools/L1TriggerExt/plugins/L1CondDBPayloadWriterExt.h
+++ b/CondTools/L1TriggerExt/plugins/L1CondDBPayloadWriterExt.h
@@ -3,7 +3,7 @@
 #include <memory>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -17,7 +17,7 @@
 #include "CondFormats/L1TObjects/interface/L1TriggerKeyExt.h"
 #include "CondFormats/DataRecord/interface/L1TriggerKeyExtRcd.h"
 
-class L1CondDBPayloadWriterExt : public edm::EDAnalyzer {
+class L1CondDBPayloadWriterExt : public edm::one::EDAnalyzer<> {
 public:
   explicit L1CondDBPayloadWriterExt(const edm::ParameterSet&);
   ~L1CondDBPayloadWriterExt() override;

--- a/CondTools/L1TriggerExt/plugins/L1O2OTestAnalyzerExt.cc
+++ b/CondTools/L1TriggerExt/plugins/L1O2OTestAnalyzerExt.cc
@@ -2,7 +2,7 @@
 #include <sstream>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -25,7 +25,7 @@
 // class decleration
 //
 
-class L1O2OTestAnalyzerExt : public edm::EDAnalyzer {
+class L1O2OTestAnalyzerExt : public edm::one::EDAnalyzer<> {
 public:
   explicit L1O2OTestAnalyzerExt(const edm::ParameterSet&);
   ~L1O2OTestAnalyzerExt() override;

--- a/CondTools/L1TriggerExt/plugins/L1O2OTestAnalyzerExt.cc
+++ b/CondTools/L1TriggerExt/plugins/L1O2OTestAnalyzerExt.cc
@@ -72,35 +72,36 @@ void L1O2OTestAnalyzerExt::analyze(const edm::Event& iEvent, const edm::EventSet
       edm::LogError("L1-O2O") << "Problem getting last L1TriggerKeyListExt";
     }
 
-    edm::LogInfo("L1-O2O")  << "Found " << pList.tscKeyToTokenMap().size() << " TSC keys:" << std::endl;
+    edm::LogInfo("L1-O2O") << "Found " << pList.tscKeyToTokenMap().size() << " TSC keys:" << std::endl;
 
     L1TriggerKeyListExt::KeyToToken::const_iterator iTSCKey = pList.tscKeyToTokenMap().begin();
     L1TriggerKeyListExt::KeyToToken::const_iterator eTSCKey = pList.tscKeyToTokenMap().end();
     for (; iTSCKey != eTSCKey; ++iTSCKey) {
-      edm::LogInfo("L1-O2O")  << iTSCKey->first;
+      edm::LogInfo("L1-O2O") << iTSCKey->first;
       if (m_printPayloadTokens) {
-        edm::LogInfo("L1-O2O")  << " " << iTSCKey->second;
+        edm::LogInfo("L1-O2O") << " " << iTSCKey->second;
       }
-      edm::LogInfo("L1-O2O")  << std::endl;
+      edm::LogInfo("L1-O2O") << std::endl;
     }
-    edm::LogInfo("L1-O2O")  << std::endl;
+    edm::LogInfo("L1-O2O") << std::endl;
 
     L1TriggerKeyListExt::RecordToKeyToToken::const_iterator iRec = pList.recordTypeToKeyToTokenMap().begin();
     L1TriggerKeyListExt::RecordToKeyToToken::const_iterator eRec = pList.recordTypeToKeyToTokenMap().end();
     for (; iRec != eRec; ++iRec) {
       const L1TriggerKeyListExt::KeyToToken& keyTokenMap = iRec->second;
-      edm::LogInfo("L1-O2O")  << "For record@type " << iRec->first << ", found " << keyTokenMap.size() << " keys:" << std::endl;
+      edm::LogInfo("L1-O2O") << "For record@type " << iRec->first << ", found " << keyTokenMap.size()
+                             << " keys:" << std::endl;
 
       L1TriggerKeyListExt::KeyToToken::const_iterator iKey = keyTokenMap.begin();
       L1TriggerKeyListExt::KeyToToken::const_iterator eKey = keyTokenMap.end();
       for (; iKey != eKey; ++iKey) {
-        edm::LogInfo("L1-O2O")  << iKey->first;
+        edm::LogInfo("L1-O2O") << iKey->first;
         if (m_printPayloadTokens) {
-          edm::LogInfo("L1-O2O")  << " " << iKey->second;
+          edm::LogInfo("L1-O2O") << " " << iKey->second;
         }
-        edm::LogInfo("L1-O2O")  << std::endl;
+        edm::LogInfo("L1-O2O") << std::endl;
       }
-      edm::LogInfo("L1-O2O")  << std::endl;
+      edm::LogInfo("L1-O2O") << std::endl;
     }
   }
 
@@ -108,21 +109,21 @@ void L1O2OTestAnalyzerExt::analyze(const edm::Event& iEvent, const edm::EventSet
     try {
       ESHandle<L1TriggerKeyExt> pKey = iSetup.getHandle(l1TriggerKeyExtToken_);
 
-      edm::LogInfo("L1-O2O")  << std::endl;
-      edm::LogInfo("L1-O2O")  << "Current TSC key = " << pKey->tscKey() << std::endl << std::endl;
+      edm::LogInfo("L1-O2O") << std::endl;
+      edm::LogInfo("L1-O2O") << "Current TSC key = " << pKey->tscKey() << std::endl << std::endl;
 
-      edm::LogInfo("L1-O2O")  << "Current subsystem keys:" << std::endl;
-      edm::LogInfo("L1-O2O")  << "TSP0 " << pKey->subsystemKey(L1TriggerKeyExt::kuGT) << std::endl << std::endl;
+      edm::LogInfo("L1-O2O") << "Current subsystem keys:" << std::endl;
+      edm::LogInfo("L1-O2O") << "TSP0 " << pKey->subsystemKey(L1TriggerKeyExt::kuGT) << std::endl << std::endl;
 
-      edm::LogInfo("L1-O2O")  << "Object keys:" << std::endl;
+      edm::LogInfo("L1-O2O") << "Object keys:" << std::endl;
       const L1TriggerKeyExt::RecordToKey& recKeyMap = pKey->recordToKeyMap();
       L1TriggerKeyExt::RecordToKey::const_iterator iRec = recKeyMap.begin();
       L1TriggerKeyExt::RecordToKey::const_iterator eRec = recKeyMap.end();
       for (; iRec != eRec; ++iRec) {
-        edm::LogInfo("L1-O2O")  << iRec->first << " " << iRec->second << std::endl;
+        edm::LogInfo("L1-O2O") << iRec->first << " " << iRec->second << std::endl;
       }
     } catch (cms::Exception& ex) {
-      edm::LogInfo("L1-O2O")  << "No L1TriggerKeyExt found." << std::endl;
+      edm::LogInfo("L1-O2O") << "No L1TriggerKeyExt found." << std::endl;
     }
   }
 
@@ -141,7 +142,7 @@ void L1O2OTestAnalyzerExt::analyze(const edm::Event& iEvent, const edm::EventSet
 
     l1t::DataWriterExt writer;
 
-    edm::LogInfo("L1-O2O")  << std::endl << "Run Settings keys:" << std::endl;
+    edm::LogInfo("L1-O2O") << std::endl << "Run Settings keys:" << std::endl;
 
     std::vector<std::string>::const_iterator iRec = m_recordsToPrint.begin();
     std::vector<std::string>::const_iterator iEnd = m_recordsToPrint.end();
@@ -155,11 +156,11 @@ void L1O2OTestAnalyzerExt::analyze(const edm::Event& iEvent, const edm::EventSet
         key = pList.objectKey(*iRec, payloadToken);
       }
 
-      edm::LogInfo("L1-O2O")  << *iRec << " " << key;
+      edm::LogInfo("L1-O2O") << *iRec << " " << key;
       if (m_printPayloadTokens) {
-        edm::LogInfo("L1-O2O")  << " " << payloadToken;
+        edm::LogInfo("L1-O2O") << " " << payloadToken;
       }
-      edm::LogInfo("L1-O2O")  << std::endl;
+      edm::LogInfo("L1-O2O") << std::endl;
 
       // Replace spaces in key with ?s.  Do reverse substitution when
       // making L1TriggerKeyExt.

--- a/CondTools/L1TriggerExt/plugins/L1O2OTestAnalyzerExt.cc
+++ b/CondTools/L1TriggerExt/plugins/L1O2OTestAnalyzerExt.cc
@@ -72,7 +72,7 @@ void L1O2OTestAnalyzerExt::analyze(const edm::Event& iEvent, const edm::EventSet
       edm::LogError("L1-O2O") << "Problem getting last L1TriggerKeyListExt";
     }
 
-    edm::LogInfo("L1-O2O") << "Found " << pList.tscKeyToTokenMap().size() << " TSC keys:" << std::endl;
+    edm::LogInfo("L1-O2O") << "Found " << pList.tscKeyToTokenMap().size() << " TSC keys:";
 
     L1TriggerKeyListExt::KeyToToken::const_iterator iTSCKey = pList.tscKeyToTokenMap().begin();
     L1TriggerKeyListExt::KeyToToken::const_iterator eTSCKey = pList.tscKeyToTokenMap().end();
@@ -81,16 +81,13 @@ void L1O2OTestAnalyzerExt::analyze(const edm::Event& iEvent, const edm::EventSet
       if (m_printPayloadTokens) {
         edm::LogInfo("L1-O2O") << " " << iTSCKey->second;
       }
-      edm::LogInfo("L1-O2O") << std::endl;
     }
-    edm::LogInfo("L1-O2O") << std::endl;
 
     L1TriggerKeyListExt::RecordToKeyToToken::const_iterator iRec = pList.recordTypeToKeyToTokenMap().begin();
     L1TriggerKeyListExt::RecordToKeyToToken::const_iterator eRec = pList.recordTypeToKeyToTokenMap().end();
     for (; iRec != eRec; ++iRec) {
       const L1TriggerKeyListExt::KeyToToken& keyTokenMap = iRec->second;
-      edm::LogInfo("L1-O2O") << "For record@type " << iRec->first << ", found " << keyTokenMap.size()
-                             << " keys:" << std::endl;
+      edm::LogInfo("L1-O2O") << "For record@type " << iRec->first << ", found " << keyTokenMap.size() << " keys:";
 
       L1TriggerKeyListExt::KeyToToken::const_iterator iKey = keyTokenMap.begin();
       L1TriggerKeyListExt::KeyToToken::const_iterator eKey = keyTokenMap.end();
@@ -99,9 +96,7 @@ void L1O2OTestAnalyzerExt::analyze(const edm::Event& iEvent, const edm::EventSet
         if (m_printPayloadTokens) {
           edm::LogInfo("L1-O2O") << " " << iKey->second;
         }
-        edm::LogInfo("L1-O2O") << std::endl;
       }
-      edm::LogInfo("L1-O2O") << std::endl;
     }
   }
 
@@ -109,21 +104,20 @@ void L1O2OTestAnalyzerExt::analyze(const edm::Event& iEvent, const edm::EventSet
     try {
       ESHandle<L1TriggerKeyExt> pKey = iSetup.getHandle(l1TriggerKeyExtToken_);
 
-      edm::LogInfo("L1-O2O") << std::endl;
-      edm::LogInfo("L1-O2O") << "Current TSC key = " << pKey->tscKey() << std::endl << std::endl;
+      edm::LogInfo("L1-O2O") << "Current TSC key = " << pKey->tscKey();
 
-      edm::LogInfo("L1-O2O") << "Current subsystem keys:" << std::endl;
-      edm::LogInfo("L1-O2O") << "TSP0 " << pKey->subsystemKey(L1TriggerKeyExt::kuGT) << std::endl << std::endl;
+      edm::LogInfo("L1-O2O") << "Current subsystem keys:";
+      edm::LogInfo("L1-O2O") << "TSP0 " << pKey->subsystemKey(L1TriggerKeyExt::kuGT);
 
-      edm::LogInfo("L1-O2O") << "Object keys:" << std::endl;
+      edm::LogInfo("L1-O2O") << "Object keys:";
       const L1TriggerKeyExt::RecordToKey& recKeyMap = pKey->recordToKeyMap();
       L1TriggerKeyExt::RecordToKey::const_iterator iRec = recKeyMap.begin();
       L1TriggerKeyExt::RecordToKey::const_iterator eRec = recKeyMap.end();
       for (; iRec != eRec; ++iRec) {
-        edm::LogInfo("L1-O2O") << iRec->first << " " << iRec->second << std::endl;
+        edm::LogInfo("L1-O2O") << iRec->first << " " << iRec->second;
       }
     } catch (cms::Exception& ex) {
-      edm::LogInfo("L1-O2O") << "No L1TriggerKeyExt found." << std::endl;
+      edm::LogInfo("L1-O2O") << "No L1TriggerKeyExt found.";
     }
   }
 
@@ -142,7 +136,7 @@ void L1O2OTestAnalyzerExt::analyze(const edm::Event& iEvent, const edm::EventSet
 
     l1t::DataWriterExt writer;
 
-    edm::LogInfo("L1-O2O") << std::endl << "Run Settings keys:" << std::endl;
+    edm::LogInfo("L1-O2O") << "Run Settings keys:";
 
     std::vector<std::string>::const_iterator iRec = m_recordsToPrint.begin();
     std::vector<std::string>::const_iterator iEnd = m_recordsToPrint.end();
@@ -160,7 +154,6 @@ void L1O2OTestAnalyzerExt::analyze(const edm::Event& iEvent, const edm::EventSet
       if (m_printPayloadTokens) {
         edm::LogInfo("L1-O2O") << " " << payloadToken;
       }
-      edm::LogInfo("L1-O2O") << std::endl;
 
       // Replace spaces in key with ?s.  Do reverse substitution when
       // making L1TriggerKeyExt.
@@ -168,7 +161,7 @@ void L1O2OTestAnalyzerExt::analyze(const edm::Event& iEvent, const edm::EventSet
       log += " " + *iRec + "Key=" + key;
     }
 
-    edm::LogInfo("L1-O2O") << std::endl << log << std::endl;
+    edm::LogInfo("L1-O2O") << log;
   }
 }
 

--- a/CondTools/L1TriggerExt/plugins/L1O2OTestAnalyzerExt.cc
+++ b/CondTools/L1TriggerExt/plugins/L1O2OTestAnalyzerExt.cc
@@ -1,4 +1,3 @@
-#include <iostream>
 #include <memory>
 #include <sstream>
 
@@ -42,6 +41,7 @@ private:
   bool m_printESRecords;
   bool m_printPayloadTokens;
   std::vector<std::string> m_recordsToPrint;
+  edm::ESGetToken<L1TriggerKeyExt, L1TriggerKeyExtRcd> l1TriggerKeyExtToken_;
 };
 
 L1O2OTestAnalyzerExt::L1O2OTestAnalyzerExt(const edm::ParameterSet& iConfig)
@@ -51,6 +51,7 @@ L1O2OTestAnalyzerExt::L1O2OTestAnalyzerExt(const edm::ParameterSet& iConfig)
       m_printPayloadTokens(iConfig.getParameter<bool>("printPayloadTokens")),
       m_recordsToPrint(iConfig.getParameter<std::vector<std::string> >("recordsToPrint")) {
   //now do what ever initialization is needed
+  l1TriggerKeyExtToken_ = esConsumes();
 }
 
 L1O2OTestAnalyzerExt::~L1O2OTestAnalyzerExt() {
@@ -71,65 +72,61 @@ void L1O2OTestAnalyzerExt::analyze(const edm::Event& iEvent, const edm::EventSet
       edm::LogError("L1-O2O") << "Problem getting last L1TriggerKeyListExt";
     }
 
-    std::cout << "Found " << pList.tscKeyToTokenMap().size() << " TSC keys:" << std::endl;
+    edm::LogInfo("L1-O2O")  << "Found " << pList.tscKeyToTokenMap().size() << " TSC keys:" << std::endl;
 
     L1TriggerKeyListExt::KeyToToken::const_iterator iTSCKey = pList.tscKeyToTokenMap().begin();
     L1TriggerKeyListExt::KeyToToken::const_iterator eTSCKey = pList.tscKeyToTokenMap().end();
     for (; iTSCKey != eTSCKey; ++iTSCKey) {
-      std::cout << iTSCKey->first;
+      edm::LogInfo("L1-O2O")  << iTSCKey->first;
       if (m_printPayloadTokens) {
-        std::cout << " " << iTSCKey->second;
+        edm::LogInfo("L1-O2O")  << " " << iTSCKey->second;
       }
-      std::cout << std::endl;
+      edm::LogInfo("L1-O2O")  << std::endl;
     }
-    std::cout << std::endl;
+    edm::LogInfo("L1-O2O")  << std::endl;
 
     L1TriggerKeyListExt::RecordToKeyToToken::const_iterator iRec = pList.recordTypeToKeyToTokenMap().begin();
     L1TriggerKeyListExt::RecordToKeyToToken::const_iterator eRec = pList.recordTypeToKeyToTokenMap().end();
     for (; iRec != eRec; ++iRec) {
       const L1TriggerKeyListExt::KeyToToken& keyTokenMap = iRec->second;
-      std::cout << "For record@type " << iRec->first << ", found " << keyTokenMap.size() << " keys:" << std::endl;
+      edm::LogInfo("L1-O2O")  << "For record@type " << iRec->first << ", found " << keyTokenMap.size() << " keys:" << std::endl;
 
       L1TriggerKeyListExt::KeyToToken::const_iterator iKey = keyTokenMap.begin();
       L1TriggerKeyListExt::KeyToToken::const_iterator eKey = keyTokenMap.end();
       for (; iKey != eKey; ++iKey) {
-        std::cout << iKey->first;
+        edm::LogInfo("L1-O2O")  << iKey->first;
         if (m_printPayloadTokens) {
-          std::cout << " " << iKey->second;
+          edm::LogInfo("L1-O2O")  << " " << iKey->second;
         }
-        std::cout << std::endl;
+        edm::LogInfo("L1-O2O")  << std::endl;
       }
-      std::cout << std::endl;
+      edm::LogInfo("L1-O2O")  << std::endl;
     }
   }
 
   if (m_printL1TriggerKeyExt) {
     try {
-      ESHandle<L1TriggerKeyExt> pKey;
-      iSetup.get<L1TriggerKeyExtRcd>().get(pKey);
+      ESHandle<L1TriggerKeyExt> pKey = iSetup.getHandle(l1TriggerKeyExtToken_);
 
-      std::cout << std::endl;
-      std::cout << "Current TSC key = " << pKey->tscKey() << std::endl << std::endl;
+      edm::LogInfo("L1-O2O")  << std::endl;
+      edm::LogInfo("L1-O2O")  << "Current TSC key = " << pKey->tscKey() << std::endl << std::endl;
 
-      std::cout << "Current subsystem keys:" << std::endl;
-      std::cout << "TSP0 " << pKey->subsystemKey(L1TriggerKeyExt::kuGT) << std::endl << std::endl;
+      edm::LogInfo("L1-O2O")  << "Current subsystem keys:" << std::endl;
+      edm::LogInfo("L1-O2O")  << "TSP0 " << pKey->subsystemKey(L1TriggerKeyExt::kuGT) << std::endl << std::endl;
 
-      std::cout << "Object keys:" << std::endl;
+      edm::LogInfo("L1-O2O")  << "Object keys:" << std::endl;
       const L1TriggerKeyExt::RecordToKey& recKeyMap = pKey->recordToKeyMap();
       L1TriggerKeyExt::RecordToKey::const_iterator iRec = recKeyMap.begin();
       L1TriggerKeyExt::RecordToKey::const_iterator eRec = recKeyMap.end();
       for (; iRec != eRec; ++iRec) {
-        std::cout << iRec->first << " " << iRec->second << std::endl;
+        edm::LogInfo("L1-O2O")  << iRec->first << " " << iRec->second << std::endl;
       }
     } catch (cms::Exception& ex) {
-      std::cout << "No L1TriggerKeyExt found." << std::endl;
+      edm::LogInfo("L1-O2O")  << "No L1TriggerKeyExt found." << std::endl;
     }
   }
 
   if (m_printESRecords) {
-    //        ESHandle< L1TriggerKeyListExt > pList ;
-    //        iSetup.get< L1TriggerKeyListExtRcd >().get( pList ) ;
-
     L1TriggerKeyListExt pList;
     l1t::DataWriterExt dataWriter;
     if (!dataWriter.fillLastTriggerKeyList(pList)) {
@@ -144,7 +141,7 @@ void L1O2OTestAnalyzerExt::analyze(const edm::Event& iEvent, const edm::EventSet
 
     l1t::DataWriterExt writer;
 
-    std::cout << std::endl << "Run Settings keys:" << std::endl;
+    edm::LogInfo("L1-O2O")  << std::endl << "Run Settings keys:" << std::endl;
 
     std::vector<std::string>::const_iterator iRec = m_recordsToPrint.begin();
     std::vector<std::string>::const_iterator iEnd = m_recordsToPrint.end();
@@ -158,11 +155,11 @@ void L1O2OTestAnalyzerExt::analyze(const edm::Event& iEvent, const edm::EventSet
         key = pList.objectKey(*iRec, payloadToken);
       }
 
-      std::cout << *iRec << " " << key;
+      edm::LogInfo("L1-O2O")  << *iRec << " " << key;
       if (m_printPayloadTokens) {
-        std::cout << " " << payloadToken;
+        edm::LogInfo("L1-O2O")  << " " << payloadToken;
       }
-      std::cout << std::endl;
+      edm::LogInfo("L1-O2O")  << std::endl;
 
       // Replace spaces in key with ?s.  Do reverse substitution when
       // making L1TriggerKeyExt.
@@ -170,7 +167,7 @@ void L1O2OTestAnalyzerExt::analyze(const edm::Event& iEvent, const edm::EventSet
       log += " " + *iRec + "Key=" + key;
     }
 
-    std::cout << std::endl << log << std::endl;
+    edm::LogInfo("L1-O2O") << std::endl << log << std::endl;
   }
 }
 


### PR DESCRIPTION
#### PR description:
Part of #31061. Migrate ```CondTools/L1Trigger``` and  ```CondTools/L1TriggerExt``` modules to use esConsumes.   

#### PR validation:
Compiles.
#### if this PR is a backport please specify the original PR and why you need to backport that PR:
NA