### PR TITLE
Add missing includes (companion commit for cms-sw/cmsdist#7309)

### DIFF
--- a/CondFormats/SiPixelObjects/src/SiPixelVCal.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelVCal.cc
@@ -1,6 +1,8 @@
 #include "CondFormats/SiPixelObjects/interface/SiPixelVCal.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+#include <algorithm>
+
 bool SiPixelVCal::putSlopeAndOffset(const uint32_t& pixid, float& slopeValue, float& offsetValue) {
   std::map<unsigned int, VCal>::const_iterator id = m_vcal.find(pixid);
   if (id != m_vcal.end()) {

--- a/Geometry/HcalCommonData/src/HcalDDDRecConstants.cc
+++ b/Geometry/HcalCommonData/src/HcalDDDRecConstants.cc
@@ -5,6 +5,7 @@
 #include "DataFormats/Math/interface/GeantUnits.h"
 #include "CLHEP/Units/GlobalPhysicalConstants.h"
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
+#include <algorithm>
 #include <cmath>
 
 //#define EDM_ML_DEBUG

--- a/L1Trigger/L1TMuonOverlap/src/GhostBuster.cc
+++ b/L1Trigger/L1TMuonOverlap/src/GhostBuster.cc
@@ -1,5 +1,6 @@
 #include "L1Trigger/L1TMuonOverlap/interface/GhostBuster.h"
 
+#include <algorithm>
 #include <sstream>
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"

--- a/L1Trigger/L1TMuonOverlap/src/GhostBusterPreferRefDt.cc
+++ b/L1Trigger/L1TMuonOverlap/src/GhostBusterPreferRefDt.cc
@@ -1,5 +1,6 @@
 #include "L1Trigger/L1TMuonOverlap/interface/GhostBusterPreferRefDt.h"
 
+#include <algorithm>
 #include <sstream>
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"


### PR DESCRIPTION
#### PR description:

Companion commit to cms-sw/cmsdist#7309, adds `#include <algorithm>` to several source files to fix build errors, e.g.
```
>> Compiling  /build/cmsbld/jenkins/workspace/ib-run-pr-tests/CMSSW_12_1_X_2021-09-14-1100/src/Geometry/HcalCommonData/src/HcalParametersFromDD.cc
>> Compiling  /build/cmsbld/jenkins/workspace/ib-run-pr-tests/CMSSW_12_1_X_2021-09-14-1100/src/Geometry/HcalCommonData/src/HcalSimParametersFromDD.cc
>> Compiling  /build/cmsbld/jenkins/workspace/ib-run-pr-tests/CMSSW_12_1_X_2021-09-14-1100/src/Geometry/HcalCommonData/src/HcalSimulationConstants.cc
>> Compiling  /build/cmsbld/jenkins/workspace/ib-run-pr-tests/CMSSW_12_1_X_2021-09-14-1100/src/Geometry/HcalCommonData/src/HcalTopologyMode.cc
/build/cmsbld/jenkins/workspace/ib-run-pr-tests/CMSSW_12_1_X_2021-09-14-1100/src/Geometry/HcalCommonData/src/HcalDDDRecConstants.cc: In member function 'std::vector HcalDDDRecConstants::getEtaBins(const int&) const':
/build/cmsbld/jenkins/workspace/ib-run-pr-tests/CMSSW_12_1_X_2021-09-14-1100/src/Geometry/HcalCommonData/src/HcalDDDRecConstants.cc:83:72: error: no matching function for call to 'find(std::vector::iterator, std::vector::iterator, int)'
   83 |           if (std::find(phiSp.begin(), phiSp.end(), (zside * phi.first)) == phiSp.end()) {
      |                                                                        ^
In file included from /cvmfs/cms-ib.cern.ch/nweek-02698/slc7_amd64_gcc900/external/gcc/9.3.0/include/c++/9.3.0/bits/locale_facets.h:48,
                 from /cvmfs/cms-ib.cern.ch/nweek-02698/slc7_amd64_gcc900/external/gcc/9.3.0/include/c++/9.3.0/bits/basic_ios.h:37,
                 from /cvmfs/cms-ib.cern.ch/nweek-02698/slc7_amd64_gcc900/external/gcc/9.3.0/include/c++/9.3.0/ios:44,
```
