### PR TITLE
Disable G4GammaGeneralProcess

### DIFF
--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -176,7 +176,7 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
         G4MscSafetyFactor = cms.double(0.6), 
         G4MscLambdaLimit = cms.double(1.0), # mm 
         G4MscStepLimit = cms.string("UseSafety"), 
-        G4GeneralProcess = cms.bool(True),
+        G4GeneralProcess = cms.bool(False),
         ReadMuonData = cms.bool(False), 
         Verbosity = cms.untracked.int32(0),
         # 1 will print cuts as they get set from DD


### PR DESCRIPTION
#### PR description:
Gamma general process is disable in order to have the same configuration in 12_0 and 12_1. We can try to enable it only when Geant4 10.7p02 will be merged.

Simulation histories will be changed due to this PR.
