### PR TITLE
Fix buffer underflow with HitPattern::getMuonStation()

### DIFF
--- a/DataFormats/TrackReco/src/HitPattern.cc
+++ b/DataFormats/TrackReco/src/HitPattern.cc
@@ -882,16 +882,16 @@ uint16_t HitPattern::isStereo(DetId i, const TrackerTopology& ttopo) {
 }
 
 int HitPattern::muonStations(int subdet, int hitType) const {
-  int stations[4] = {0, 0, 0, 0};
+  int stations[5] = {0, 0, 0, 0, 0};
   for (int i = beginTrackHits; i < endTrackHits; ++i) {
     uint16_t pattern = getHitPatternByAbsoluteIndex(i);
     if (muonHitFilter(pattern) && (subdet == 0 || int(getSubStructure(pattern)) == subdet) &&
         (hitType == -1 || int(getHitType(pattern)) == hitType)) {
-      stations[getMuonStation(pattern) - 1] = 1;
+      stations[getMuonStation(pattern)] = 1;
     }
   }
 
-  return stations[0] + stations[1] + stations[2] + stations[3];
+  return stations[0] + stations[1] + stations[2] + stations[3] + stations[4];
 }
 
 int HitPattern::innermostMuonStationWithHits(int hitType) const {


### PR DESCRIPTION
#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

Fix underflow caused by GEM station 0 not being taken into account in HitPattern::getMuonStation()

Reported in issue #35283.

#### PR validation:

Trivial fix, I grepped through the file to see if there are other places that a similar thing could happen (similar constructions seem only to occur in the DT stations), but couldn't see any immediately. If there's a recipe to run the ASAN that I could try to check further, please let me know.

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
