### PR TITLE
[120X] Include new geometry tags in Run-3 MC GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -66,17 +66,17 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak'     : '120X_upgrade2018cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'           : '120X_mcRun3_2021_design_v4', # GT containing design conditions for Phase1 2021
+    'phase1_2021_design'           : '120X_mcRun3_2021_design_v5', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'        : '120X_mcRun3_2021_realistic_v6', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'        : '120X_mcRun3_2021_realistic_v7', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'          : '120X_mcRun3_2021cosmics_realistic_deco_v5',
+    'phase1_2021_cosmics'          : '120X_mcRun3_2021cosmics_realistic_deco_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi'     : '120X_mcRun3_2021_realistic_HI_v5',
+    'phase1_2021_realistic_hi'     : '120X_mcRun3_2021_realistic_HI_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '120X_mcRun3_2023_realistic_v5', # GT containing realistic conditions for Phase1 2023
+    'phase1_2023_realistic'        : '120X_mcRun3_2023_realistic_v6', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '120X_mcRun3_2024_realistic_v5', # GT containing realistic conditions for Phase1 2024
+    'phase1_2024_realistic'        : '120X_mcRun3_2024_realistic_v6', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             : '113X_mcRun4_realistic_v7'
 }


### PR DESCRIPTION
#### PR description:

This PR is a backport of PR #35277 for inclusion of new DDD Geometry tags for Run3 MC, as requested in https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4460.html

In particular, two new tags are included: XMLFILE_Geometry_120YV2_Extended2021_mc and TKRECO_Geometry_120YV2.

The differences wrt the previous GTs are shown below:

**2021 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/120X_mcRun3_2021_design_v4/120X_mcRun3_2021_design_v5

**2021 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/120X_mcRun3_2021_realistic_v6/120X_mcRun3_2021_realistic_v7

**2021 cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/120X_mcRun3_2021cosmics_realistic_deco_v5/120X_mcRun3_2021cosmics_realistic_deco_v6

**2021 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/120X_mcRun3_2021_realistic_HI_v5/120X_mcRun3_2021_realistic_HI_v6

**2023 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/120X_mcRun3_2023_realistic_v5/120X_mcRun3_2023_realistic_v6

**2024 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/120X_mcRun3_2024_realistic_v5/120X_mcRun3_2024_realistic_v6


#### PR validation:

runTheMatrix.py -l 11925 --ibeos -j4

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

backport of PR #35277