### PR TITLE
Fixing collection for producing unprefirable bit in NANO (master)

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/L1TriggerResultsConverter.cc
+++ b/PhysicsTools/NanoAOD/plugins/L1TriggerResultsConverter.cc
@@ -135,8 +135,12 @@ void L1TriggerResultsConverter::produce(edm::Event& iEvent, const edm::EventSetu
     if (store_unprefireable_bit_) {
       edm::Handle<GlobalExtBlkBxCollection> handleExtResults;
       iEvent.getByToken(token_ext_, handleExtResults);
-      if (handleExtResults->size() != 0) {
-        unprefireable_bit = handleExtResults->at(0, 0).getExternalDecision(GlobalExtBlk::maxExternalConditions - 1);
+      if (handleExtResults.isValid()) {
+        if (handleExtResults->size() != 0) {
+          unprefireable_bit = handleExtResults->at(0, 0).getExternalDecision(GlobalExtBlk::maxExternalConditions - 1);
+        }
+      } else {
+        LogDebug("Unprefirable bit not found, always set to false");
       }
     }
   } else {

--- a/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
+++ b/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
@@ -254,7 +254,7 @@ l1bits=cms.EDProducer("L1TriggerResultsConverter",
                        src=cms.InputTag("gtStage2Digis"),
                        legacyL1=cms.bool(False),
                        storeUnprefireableBit=cms.bool(True),
-                       src_ext=cms.InputTag("gtStage2Digis"))
+                       src_ext=cms.InputTag("simGtExtUnprefireable"))
 
 triggerObjectTablesTask = cms.Task( unpackedPatTrigger,triggerObjectTable,l1bits)
 


### PR DESCRIPTION
#### PR description:

The L1 unprefirable bit ("L1_UnprefireableEvent") is currently always false in NANOAOD. This is found to be due to the wrong input collection being provided to the dedicated producer.

This PR corrects this.

#### PR validation:
 

Ran on a few unprefirable data events previously identified and checked that the boolean is now true. 
Checked that MC is not affected. 




