### PR TITLE
Remove logic for setting nConcurrentLumis from cmsDriver in favor of similar logic now in cmsRun

### DIFF
--- a/Configuration/Applications/python/cmsDriverOptions.py
+++ b/Configuration/Applications/python/cmsDriverOptions.py
@@ -72,13 +72,6 @@ def OptionsFromItems(items):
 
     #now adjust the given parameters before passing it to the ConfigBuilder
 
-    # concurrency options
-    nStreams = options.nStreams if options.nStreams != '0' else options.nThreads
-    if options.nConcurrentLumis == '0':
-        options.nConcurrentLumis = '1' if nStreams == '1' else '2'
-    if options.nConcurrentIOVs == '0':
-        options.nConcurrentIOVs = options.nConcurrentLumis
-
     #trail a "/" to dirin and dirout
     if options.dirin!='' and (not options.dirin.endswith('/')):    options.dirin+='/'
     if options.dirout!='' and (not options.dirout.endswith('/')):  options.dirout+='/'


### PR DESCRIPTION
#### PR description:

This PR suggests to remove the logic to set `nConcurrentLumis` based on `nStreams` that was introduced in https://github.com/cms-sw/cmssw/pull/32406 in favor of similar logic introduced in cmsRun in https://github.com/cms-sw/cmssw/pull/34231.

Resolves https://github.com/makortel/framework/issues/260

#### PR validation:

Inspected the configurations for the matrix workflows `limited,5.2,140.0,521.0,7.0,300.0,140.0,5.5,511.0,281.0,8.1,534.0,281.0,132.0,280.0,120.0` and only the GEN steps specified in https://github.com/cms-sw/cmssw/pull/35182 and in ALCA step in 1001.0 (https://github.com/cms-sw/cmssw/pull/35073) set the `process.options.numberOfConcurrentLumis = 1`. All other steps use the default value of `0`, which the cmsRun then interprets as "set default value based on the number of streams".