### PR TITLE
Fix undefined behavior in MuonIdProducer from empty pointer

### DIFF
--- a/RecoMuon/MuonIdentification/interface/MuonShowerDigiFiller.h
+++ b/RecoMuon/MuonIdentification/interface/MuonShowerDigiFiller.h
@@ -46,6 +46,7 @@
 
 class MuonShowerDigiFiller {
 public:
+  MuonShowerDigiFiller() {}
   MuonShowerDigiFiller(const edm::ParameterSet&, edm::ConsumesCollector&& iC);
 
   void getES(const edm::EventSetup& iSetup);

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -89,9 +89,8 @@ MuonIdProducer::MuonIdProducer(const edm::ParameterSet& iConfig)
   if (fillShowerDigis_ && fillMatching_) {
     edm::ParameterSet showerDigiParameters = iConfig.getParameter<edm::ParameterSet>("ShowerDigiFillerParameters");
     theShowerDigiFiller_ = std::make_unique<MuonShowerDigiFiller>(showerDigiParameters, consumesCollector());
-  }
-  else {
-    theShowerDigiFiller_ = std::make_unique<MuonShowerDigiFiller>(); // to be used to call fillDefault only
+  } else {
+    theShowerDigiFiller_ = std::make_unique<MuonShowerDigiFiller>();  // to be used to call fillDefault only
   }
 
   if (fillCaloCompatibility_) {

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -90,6 +90,9 @@ MuonIdProducer::MuonIdProducer(const edm::ParameterSet& iConfig)
     edm::ParameterSet showerDigiParameters = iConfig.getParameter<edm::ParameterSet>("ShowerDigiFillerParameters");
     theShowerDigiFiller_ = std::make_unique<MuonShowerDigiFiller>(showerDigiParameters, consumesCollector());
   }
+  else {
+    theShowerDigiFiller_ = std::make_unique<MuonShowerDigiFiller>(); // to be used to call fillDefault only
+  }
 
   if (fillCaloCompatibility_) {
     // Load MuonCaloCompatibility parameters
@@ -888,7 +891,7 @@ void MuonIdProducer::fillMuonId(edm::Event& iEvent,
 
     matchedChamber.id = chamber.id;
 
-    if (fillShowerDigis_) {
+    if (fillShowerDigis_ && fillMatching_) {
       theShowerDigiFiller_->fill(matchedChamber);
     } else {
       theShowerDigiFiller_->fillDefault(matchedChamber);


### PR DESCRIPTION
#### PR description:

Fix undefined behavior in `MuonIdProducer`, reported in issue [35036](https://github.com/cms-sw/cmssw/issues/35036). This is caused by the `theShowerDigiFiller_` pointer, which is used empty to call function `fillDefault(...)` whenever the `fillShowerDigis_` flag is false, e.g. in HLT.

I added a default constructor without parameters for `MuonShowerDigiFiller`, which is only used when `fillShowerDigis_` is false. Function `fillDefault(...)` doesn't use any data member of `MuonShowerDigiFiller` and can be called even with this minimal initialization.
In one [point](https://github.com/trocino/cmssw/blob/fix_UBSAN_issue35036_MUO-MuIdProd/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc#L894) I also had to fix the condition to use the fully initialized `MuonShowerDigiFiller`.

#### PR validation:

The code compiles without errors and passes the basic tests in `CMSSW_12_1_X_2021-09-15-1100`. I verified that the undefined behavior error disappears, running wf 11603.0 in `CMSSW_12_1_UBSAN_X_2021-09-13-1100`. 
