### PR TITLE
Protection against missing discriminators for offline taus in L1 DQM

### DIFF
--- a/DQMOffline/L1Trigger/src/L1TTauOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TTauOffline.cc
@@ -704,6 +704,19 @@ void L1TTauOffline::getProbeTaus(const edm::Event& iEvent,
       TLorentzVector mytau;
       mytau.SetPtEtaPhiE(tauIt->pt(), tauIt->eta(), tauIt->phi(), tauIt->energy());
 
+      if ((*antimu)[tauCandidate].workingPoints.empty()) {
+        LogWarning("This offline tau has no antimu discriminator, skipping");
+        continue;
+      }
+      if ((*antiele)[tauCandidate].workingPoints.empty()) {
+        LogWarning("This offline tau has no antiele discriminator, skipping");
+        continue;
+      }
+      if ((*comb3T)[tauCandidate].workingPoints.empty()) {
+        LogWarning("This offline tau has no comb3T discriminator, skipping");
+        continue;
+      }
+
       if (fabs(tauIt->charge()) == 1 && fabs(tauIt->eta()) < 2.1 && tauIt->pt() > 20 &&
           (*antimu)[tauCandidate].workingPoints[AntiMuWPIndex_] &&
           (*antiele)[tauCandidate].workingPoints[AntiEleWPIndex_] && (*dmf)[tauCandidate] > 0.5 &&

--- a/DQMOffline/L1Trigger/src/L1TTauOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TTauOffline.cc
@@ -705,15 +705,15 @@ void L1TTauOffline::getProbeTaus(const edm::Event& iEvent,
       mytau.SetPtEtaPhiE(tauIt->pt(), tauIt->eta(), tauIt->phi(), tauIt->energy());
 
       if ((*antimu)[tauCandidate].workingPoints.empty()) {
-        LogWarning("This offline tau has no antimu discriminator, skipping");
+        edm::LogWarning("L1TTauOffline") << "This offline tau has no antimu discriminator, skipping" << std::endl;
         continue;
       }
       if ((*antiele)[tauCandidate].workingPoints.empty()) {
-        LogWarning("This offline tau has no antiele discriminator, skipping");
+        edm::LogWarning("L1TTauOffline") << "This offline tau has no antiele discriminator, skipping" << std::endl;
         continue;
       }
       if ((*comb3T)[tauCandidate].workingPoints.empty()) {
-        LogWarning("This offline tau has no comb3T discriminator, skipping");
+        edm::LogWarning("L1TTauOffline") << "This offline tau has no comb3T discriminator, skipping" << std::endl;
         continue;
       }
 


### PR DESCRIPTION
#### PR description:
This (hopefully) is a short term bug fix of the issue described in https://github.com/cms-sw/cmssw/issues/35304 
In very rare cases, the anti electron discriminators seem to be missing for offline tau, leading to a crash in the L1 DQM code. 
A protection is added to skip such offline taus. 

#### PR validation:

Checked that the crash in https://github.com/cms-sw/cmssw/issues/35304 is gone after this fix. 

@tvami 

