### PR TITLE
TDC simulation for HFQIE10 (12_1)

### DIFF
--- a/CalibFormats/CaloObjects/src/CaloSamples.cc
+++ b/CalibFormats/CaloObjects/src/CaloSamples.cc
@@ -49,18 +49,34 @@ CaloSamples &CaloSamples::operator+=(double value) {
 }
 
 CaloSamples &CaloSamples::operator+=(const CaloSamples &other) {
+  bool addHighFidelityPreMix = false;
   if (size_ != other.size_ || presamples_ != other.presamples_ || preciseSize_ != other.preciseSize_) {
-    edm::LogError("CaloHitResponse") << "Mismatched calo signals ";
+    if (presamples_ == other.presamples_ && preciseSize_ == other.size_) {
+      addHighFidelityPreMix = true;
+    }
+    else {
+      edm::LogError("CaloHitResponse") << "Mismatched calo signals ";
+    }
   }
-  int i;
-  for (i = 0; i < size_; ++i) {
-    data_[i] += other.data_[i];
+  if (addHighFidelityPreMix) {
+    int sampleBin(0);
+    for (int i = 0; i < preciseSize_; ++i) {
+      sampleBin = floor(i * deltaTprecise_ / 25);
+      data_[sampleBin] += other.data_[i];
+      preciseData_[i] += other.data_[i];
+    }
   }
-  if (preciseData_.empty() && !other.preciseData_.empty())
-    resetPrecise();
-  if (!other.preciseData_.empty()) {
-    for (i = 0; i < preciseSize_; ++i) {
-      preciseData_[i] += other.preciseData_[i];
+  else {
+    int i;
+    for (i = 0; i < size_; ++i) {
+      data_[i] += other.data_[i];
+    }
+    if (preciseData_.empty() && !other.preciseData_.empty())
+      resetPrecise();
+    if (!other.preciseData_.empty()) {
+      for (i = 0; i < preciseSize_; ++i) {
+        preciseData_[i] += other.preciseData_[i];
+      }
     }
   }
   return *this;

--- a/CalibFormats/CaloObjects/src/CaloSamples.cc
+++ b/CalibFormats/CaloObjects/src/CaloSamples.cc
@@ -53,8 +53,7 @@ CaloSamples &CaloSamples::operator+=(const CaloSamples &other) {
   if (size_ != other.size_ || presamples_ != other.presamples_ || preciseSize_ != other.preciseSize_) {
     if (presamples_ == other.presamples_ && preciseSize_ == other.size_) {
       addHighFidelityPreMix = true;
-    }
-    else {
+    } else {
       edm::LogError("CaloHitResponse") << "Mismatched calo signals ";
     }
   }
@@ -65,8 +64,7 @@ CaloSamples &CaloSamples::operator+=(const CaloSamples &other) {
       data_[sampleBin] += other.data_[i];
       preciseData_[i] += other.data_[i];
     }
-  }
-  else {
+  } else {
     int i;
     for (i = 0; i < size_; ++i) {
       data_[i] += other.data_[i];

--- a/SimCalorimetry/CaloSimAlgos/interface/CaloHitResponse.h
+++ b/SimCalorimetry/CaloSimAlgos/interface/CaloHitResponse.h
@@ -35,8 +35,8 @@ public:
   typedef std::map<DetId, CaloSamples> AnalogSignalMap;
   // get this from somewhere external
   enum { BUNCHSPACE = 25 };
-  double dt = 0.5;
-  int invdt = 2;
+  const double dt = 0.5;
+  const int invdt = 2;
 
   CaloHitResponse(const CaloVSimParameterMap *parameterMap, const CaloVShape *shape);
   CaloHitResponse(const CaloVSimParameterMap *parameterMap, const CaloShapes *shapes);

--- a/SimCalorimetry/CaloSimAlgos/interface/CaloHitResponse.h
+++ b/SimCalorimetry/CaloSimAlgos/interface/CaloHitResponse.h
@@ -35,6 +35,8 @@ public:
   typedef std::map<DetId, CaloSamples> AnalogSignalMap;
   // get this from somewhere external
   enum { BUNCHSPACE = 25 };
+  double dt = 0.5;
+  int invdt = 2;
 
   CaloHitResponse(const CaloVSimParameterMap *parameterMap, const CaloVShape *shape);
   CaloHitResponse(const CaloVSimParameterMap *parameterMap, const CaloShapes *shapes);

--- a/SimCalorimetry/CaloSimAlgos/interface/CaloHitResponse.h
+++ b/SimCalorimetry/CaloSimAlgos/interface/CaloHitResponse.h
@@ -38,8 +38,8 @@ public:
   const double dt = 0.5;
   const int invdt = 2;
 
-  CaloHitResponse(const CaloVSimParameterMap *parameterMap, const CaloVShape *shape);
-  CaloHitResponse(const CaloVSimParameterMap *parameterMap, const CaloShapes *shapes);
+  CaloHitResponse(const CaloVSimParameterMap *parameterMap, const CaloVShape *shape, bool PreMix1 = false, bool HighFidelity = false);
+  CaloHitResponse(const CaloVSimParameterMap *parameterMap, const CaloShapes *shapes, bool PreMix1 = false, bool HighFidelity = false);
 
   /// doesn't delete the pointers passed in
   virtual ~CaloHitResponse();
@@ -56,7 +56,7 @@ public:
   virtual void initializeHits() {}
 
   /// Finalize hits
-  virtual void finalizeHits(CLHEP::HepRandomEngine *) {}
+  virtual void finalizeHits(CLHEP::HepRandomEngine *);
 
   /// Complete cell digitization.
   virtual void run(const MixCollection<PCaloHit> &hits, CLHEP::HepRandomEngine *);
@@ -99,6 +99,8 @@ public:
   /// number of signals in the current cache
   int nSignals() const { return theAnalogSignalMap.size(); }
 
+  int getReadoutFrameSize(const DetId& id) const;
+
   /// creates an empty signal for this DetId
   CaloSamples makeBlankSignal(const DetId &detId) const;
 
@@ -136,6 +138,8 @@ protected:
 
   double thePhaseShift_;
   bool storePrecise;
+  bool PreMixDigis;
+  bool HighFidelityPreMix;
   bool ignoreTime;
 };
 

--- a/SimCalorimetry/CaloSimAlgos/interface/CaloHitResponse.h
+++ b/SimCalorimetry/CaloSimAlgos/interface/CaloHitResponse.h
@@ -35,8 +35,8 @@ public:
   typedef std::map<DetId, CaloSamples> AnalogSignalMap;
   // get this from somewhere external
   enum { BUNCHSPACE = 25 };
-  const double dt = 0.5;
-  const int invdt = 2;
+  static constexpr double dt = 0.5;
+  static constexpr int invdt = 2;
 
   CaloHitResponse(const CaloVSimParameterMap *parameterMap,
                   const CaloVShape *shape,
@@ -144,8 +144,8 @@ protected:
 
   double thePhaseShift_;
   bool storePrecise;
-  bool PreMixDigis;
-  bool HighFidelityPreMix;
+  bool preMixDigis;
+  bool highFidelityPreMix;
   bool ignoreTime;
 };
 

--- a/SimCalorimetry/CaloSimAlgos/interface/CaloHitResponse.h
+++ b/SimCalorimetry/CaloSimAlgos/interface/CaloHitResponse.h
@@ -38,8 +38,14 @@ public:
   const double dt = 0.5;
   const int invdt = 2;
 
-  CaloHitResponse(const CaloVSimParameterMap *parameterMap, const CaloVShape *shape, bool PreMix1 = false, bool HighFidelity = false);
-  CaloHitResponse(const CaloVSimParameterMap *parameterMap, const CaloShapes *shapes, bool PreMix1 = false, bool HighFidelity = false);
+  CaloHitResponse(const CaloVSimParameterMap *parameterMap,
+                  const CaloVShape *shape,
+                  bool PreMix1 = false,
+                  bool HighFidelity = false);
+  CaloHitResponse(const CaloVSimParameterMap *parameterMap,
+                  const CaloShapes *shapes,
+                  bool PreMix1 = false,
+                  bool HighFidelity = false);
 
   /// doesn't delete the pointers passed in
   virtual ~CaloHitResponse();
@@ -99,7 +105,7 @@ public:
   /// number of signals in the current cache
   int nSignals() const { return theAnalogSignalMap.size(); }
 
-  int getReadoutFrameSize(const DetId& id) const;
+  int getReadoutFrameSize(const DetId &id) const;
 
   /// creates an empty signal for this DetId
   CaloSamples makeBlankSignal(const DetId &detId) const;

--- a/SimCalorimetry/CaloSimAlgos/src/CaloHitResponse.cc
+++ b/SimCalorimetry/CaloSimAlgos/src/CaloHitResponse.cc
@@ -130,7 +130,7 @@ CaloSamples CaloHitResponse::makeAnalogSignal(const PCaloHit &hit, CLHEP::HepRan
     // use 0.5ns binning for precise sample
     for (int bin = 0; bin < result.size() * BUNCHSPACE * invdt; bin++) {
       sampleBin = bin / (BUNCHSPACE * invdt);
-      double pulseBit = (*shape)(binTime)*signal*dt;
+      double pulseBit = (*shape)(binTime)*signal * dt;
       result[sampleBin] += pulseBit;
       result.preciseAtMod(bin) += pulseBit;
       binTime += dt;
@@ -177,7 +177,7 @@ CaloSamples CaloHitResponse::makeBlankSignal(const DetId &detId) const {
   int preciseSize(storePrecise ? parameters.readoutFrameSize() * BUNCHSPACE * invdt : 0);
   CaloSamples result(detId, parameters.readoutFrameSize(), preciseSize);
   result.setPresamples(parameters.binOfMaximum() - 1);
-  if (storePrecise){
+  if (storePrecise) {
     result.setPreciseSize(preciseSize);
     result.setPrecise(result.presamples() * BUNCHSPACE * invdt, dt);
   }

--- a/SimCalorimetry/CaloSimAlgos/src/CaloHitResponse.cc
+++ b/SimCalorimetry/CaloSimAlgos/src/CaloHitResponse.cc
@@ -130,7 +130,7 @@ CaloSamples CaloHitResponse::makeAnalogSignal(const PCaloHit &hit, CLHEP::HepRan
     // use 0.5ns binning for precise sample
     for (int bin = 0; bin < result.size() * BUNCHSPACE * invdt; bin++) {
       sampleBin = bin / (BUNCHSPACE * invdt);
-      double pulseBit = (*shape)(binTime)*signal;
+      double pulseBit = (*shape)(binTime)*signal*dt;
       result[sampleBin] += pulseBit;
       result.preciseAtMod(bin) += pulseBit;
       binTime += dt;

--- a/SimCalorimetry/CaloSimAlgos/src/CaloHitResponse.cc
+++ b/SimCalorimetry/CaloSimAlgos/src/CaloHitResponse.cc
@@ -34,8 +34,8 @@ CaloHitResponse::CaloHitResponse(const CaloVSimParameterMap *parametersMap,
       theMaxBunch(10),
       thePhaseShift_(1.),
       storePrecise(HighFidelity),
-      PreMixDigis(PreMix1),
-      HighFidelityPreMix(HighFidelity),
+      preMixDigis(PreMix1),
+      highFidelityPreMix(HighFidelity),
       ignoreTime(false) {}
 
 CaloHitResponse::CaloHitResponse(const CaloVSimParameterMap *parametersMap,
@@ -54,8 +54,8 @@ CaloHitResponse::CaloHitResponse(const CaloVSimParameterMap *parametersMap,
       theMaxBunch(10),
       thePhaseShift_(1.),
       storePrecise(HighFidelity),
-      PreMixDigis(PreMix1),
-      HighFidelityPreMix(HighFidelity),
+      preMixDigis(PreMix1),
+      highFidelityPreMix(HighFidelity),
       ignoreTime(false) {}
 
 CaloHitResponse::~CaloHitResponse() {}
@@ -67,7 +67,7 @@ void CaloHitResponse::setBunchRange(int minBunch, int maxBunch) {
 
 void CaloHitResponse::finalizeHits(CLHEP::HepRandomEngine *) {
   // Convert any remaining HighFidelityPreMix DIGIs
-  if (!(PreMixDigis and HighFidelityPreMix)) {
+  if (!(preMixDigis and highFidelityPreMix)) {
     for (AnalogSignalMap::iterator itr = theAnalogSignalMap.begin(); itr != theAnalogSignalMap.end(); ++itr) {
       CaloSamples result(makeBlankSignal(itr->first));
       result += itr->second;
@@ -150,7 +150,7 @@ CaloSamples CaloHitResponse::makeAnalogSignal(const PCaloHit &hit, CLHEP::HepRan
     int sampleBin(0);
     // use 0.5ns binning for precise sample
     for (int bin = 0; bin < result.preciseSize(); bin++) {
-      sampleBin = (PreMixDigis and HighFidelityPreMix) ? bin : bin / (BUNCHSPACE * invdt);
+      sampleBin = (preMixDigis and highFidelityPreMix) ? bin : bin / (BUNCHSPACE * invdt);
       double pulseBit = (*shape)(binTime)*signal * dt;
       result[sampleBin] += pulseBit;
       result.preciseAtMod(bin) += pulseBit;
@@ -196,7 +196,7 @@ CaloSamples *CaloHitResponse::findSignal(const DetId &detId) {
 int CaloHitResponse::getReadoutFrameSize(const DetId &id) const {
   const CaloSimParameters &parameters = theParameterMap->simParameters(id);
   int readoutFrameSize = parameters.readoutFrameSize();
-  if (PreMixDigis and HighFidelityPreMix) {
+  if (preMixDigis and highFidelityPreMix) {
     //preserve fidelity of time info
     readoutFrameSize *= BUNCHSPACE * invdt;
   }

--- a/SimCalorimetry/CaloSimAlgos/src/CaloHitResponse.cc
+++ b/SimCalorimetry/CaloSimAlgos/src/CaloHitResponse.cc
@@ -18,7 +18,10 @@
 
 #include <iostream>
 
-CaloHitResponse::CaloHitResponse(const CaloVSimParameterMap *parametersMap, const CaloVShape *shape, bool PreMix1, bool HighFidelity)
+CaloHitResponse::CaloHitResponse(const CaloVSimParameterMap *parametersMap,
+                                 const CaloVShape *shape,
+                                 bool PreMix1,
+                                 bool HighFidelity)
     : theAnalogSignalMap(),
       theParameterMap(parametersMap),
       theShapes(nullptr),
@@ -35,7 +38,10 @@ CaloHitResponse::CaloHitResponse(const CaloVSimParameterMap *parametersMap, cons
       HighFidelityPreMix(HighFidelity),
       ignoreTime(false) {}
 
-CaloHitResponse::CaloHitResponse(const CaloVSimParameterMap *parametersMap, const CaloShapes *shapes, bool PreMix1, bool HighFidelity)
+CaloHitResponse::CaloHitResponse(const CaloVSimParameterMap *parametersMap,
+                                 const CaloShapes *shapes,
+                                 bool PreMix1,
+                                 bool HighFidelity)
     : theAnalogSignalMap(),
       theParameterMap(parametersMap),
       theShapes(shapes),
@@ -187,8 +193,8 @@ CaloSamples *CaloHitResponse::findSignal(const DetId &detId) {
   return result;
 }
 
-int CaloHitResponse::getReadoutFrameSize(const DetId& id) const {
-  const CaloSimParameters& parameters = theParameterMap->simParameters(id);
+int CaloHitResponse::getReadoutFrameSize(const DetId &id) const {
+  const CaloSimParameters &parameters = theParameterMap->simParameters(id);
   int readoutFrameSize = parameters.readoutFrameSize();
   if (PreMixDigis and HighFidelityPreMix) {
     //preserve fidelity of time info

--- a/SimCalorimetry/HcalSimAlgos/interface/HFSimParameters.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HFSimParameters.h
@@ -23,10 +23,12 @@ public:
   double fCtoGeV(const DetId& detId) const;
 
   double samplingFactor() const;
+  double threshold_currentTDC() const { return threshold_currentTDC_; }
 
 private:
   const HcalDbService* theDbService;
   double theSamplingFactor;
+  double threshold_currentTDC_;
 };
 
 #endif

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalTDC.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalTDC.h
@@ -6,6 +6,7 @@
 #include "DataFormats/HcalDetId/interface/HcalGenericDetId.h"
 #include "SimCalorimetry/HcalSimAlgos/interface/HcalTDCParameters.h"
 #include "DataFormats/HcalDigi/interface/QIE11DataFrame.h"
+#include "DataFormats/HcalDigi/interface/QIE10DataFrame.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 
 class HcalDbService;
@@ -22,6 +23,9 @@ public:
   /// adds timing information to the digi
   /// template <class Digi>
   void timing(const CaloSamples& lf, QIE11DataFrame& digi) const;
+  void timing(const CaloSamples& lf, QIE10DataFrame& digi) const;
+
+  std::vector<int> leadingEdgeTDC(const CaloSamples& lf) const;
 
   /// the Producer will probably update this every event
   void setDbService(const HcalDbService* service);

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalTDCParameters.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalTDCParameters.h
@@ -12,6 +12,7 @@ public:
   int alreadyTransitionCode() const { return 62; }
   int noTransitionCode() const { return 63; }
   int unlockedCode() const { return 61; }
+  int invalidCode() const { return 60; }
 
 private:
   int nbits_;

--- a/SimCalorimetry/HcalSimAlgos/src/HFSimParameters.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HFSimParameters.cc
@@ -18,7 +18,9 @@ HFSimParameters::HFSimParameters(double simHitToPhotoelectrons,
       theSamplingFactor(samplingFactor) {}
 
 HFSimParameters::HFSimParameters(const edm::ParameterSet& p)
-    : CaloSimParameters(p), theDbService(nullptr), theSamplingFactor(p.getParameter<double>("samplingFactor")) {}
+    : CaloSimParameters(p), theDbService(nullptr),
+      theSamplingFactor(p.getParameter<double>("samplingFactor")),
+      threshold_currentTDC_(p.getParameter<double>("threshold_currentTDC")) {}
 
 double HFSimParameters::photoelectronsToAnalog(const DetId& detId) const {
   // pe/fC = pe/GeV * GeV/fC  = (0.24 pe/GeV * 6 for photomult * 0.2146GeV/fC)

--- a/SimCalorimetry/HcalSimAlgos/src/HFSimParameters.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HFSimParameters.cc
@@ -18,7 +18,8 @@ HFSimParameters::HFSimParameters(double simHitToPhotoelectrons,
       theSamplingFactor(samplingFactor) {}
 
 HFSimParameters::HFSimParameters(const edm::ParameterSet& p)
-    : CaloSimParameters(p), theDbService(nullptr),
+    : CaloSimParameters(p),
+      theDbService(nullptr),
       theSamplingFactor(p.getParameter<double>("samplingFactor")),
       threshold_currentTDC_(p.getParameter<double>("threshold_currentTDC")) {}
 

--- a/SimCalorimetry/HcalSimAlgos/src/HcalElectronicsSim.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalElectronicsSim.cc
@@ -139,7 +139,7 @@ void HcalElectronicsSim::analogToDigital(
     CLHEP::HepRandomEngine* engine, CaloSamples& lf, QIE10DataFrame& result, double preMixFactor, unsigned preMixBits) {
   analogToDigitalImpl(engine, lf, result, preMixFactor, preMixBits);
   if (!PreMixDigis) {
-    const HcalSimParameters& pars = static_cast<const HcalSimParameters&>(theParameterMap->simParameters(lf.id()));
+    const HFSimParameters& pars = static_cast<const HFSimParameters&>(theParameterMap->simParameters(lf.id()));
     if (pars.threshold_currentTDC() > 0.) {
       HcalTDC theTDC((pars.threshold_currentTDC()));
       theTDC.timing(lf, result);

--- a/SimCalorimetry/HcalSimAlgos/src/HcalElectronicsSim.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalElectronicsSim.cc
@@ -138,6 +138,13 @@ void HcalElectronicsSim::analogToDigital(
 void HcalElectronicsSim::analogToDigital(
     CLHEP::HepRandomEngine* engine, CaloSamples& lf, QIE10DataFrame& result, double preMixFactor, unsigned preMixBits) {
   analogToDigitalImpl(engine, lf, result, preMixFactor, preMixBits);
+  if (!PreMixDigis) {
+    const HcalSimParameters& pars = static_cast<const HcalSimParameters&>(theParameterMap->simParameters(lf.id()));
+    if (pars.threshold_currentTDC() > 0.) {
+      HcalTDC theTDC((pars.threshold_currentTDC()));
+      theTDC.timing(lf, result);
+    }
+  }
 }
 
 void HcalElectronicsSim::analogToDigital(

--- a/SimCalorimetry/HcalSimAlgos/src/HcalTDC.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalTDC.cc
@@ -39,7 +39,6 @@ std::vector<int> HcalTDC::leadingEdgeTDC(const CaloSamples& lf) const {
   bool risingReady(true);
   int tdcBins = theTDCParameters.nbins();
   bool hasTDCValues = true;
-  std::cout << "preciseSize=" << lf.preciseSize() << " lfSize=" << lf.size() << std::endl;
   if (lf.preciseSize() == 0)
     hasTDCValues = false;
 

--- a/SimCalorimetry/HcalSimAlgos/src/HcalTDC.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalTDC.cc
@@ -14,7 +14,6 @@ void HcalTDC::timing(const CaloSamples& lf, QIE11DataFrame& digi) const {
   std::vector<int> packedTDCs = leadingEdgeTDC(lf);
 
   for (int ibin = 0; ibin < lf.size(); ++ibin) {
-
     digi.setSample(ibin, digi[ibin].adc(), packedTDCs[ibin], digi[ibin].soi());
 
   }  // loop over bunch crossing bins
@@ -24,7 +23,6 @@ void HcalTDC::timing(const CaloSamples& lf, QIE10DataFrame& digi) const {
   std::vector<int> packedTDCs = leadingEdgeTDC(lf);
 
   for (int ibin = 0; ibin < lf.size(); ++ibin) {
-
     QIE10DataFrame::Sample sam = digi[ibin];
     digi.setSample(ibin, sam.adc(), packedTDCs[ibin] /*LE TDC*/, 0. /*TE TDC*/, sam.capid(), sam.soi(), sam.ok());
 
@@ -96,7 +94,6 @@ std::vector<int> HcalTDC::leadingEdgeTDC(const CaloSamples& lf) const {
   }  // loop over bunch crossing bins
 
   return result;
-
 }
 
 void HcalTDC::setDbService(const HcalDbService* service) { theDbService = service; }

--- a/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
+++ b/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
@@ -181,10 +181,12 @@ run3_common.toModify( hcalSimParameters,
                binOfMaximum     = cms.int32(6)
               ),
     hf1 = dict( samplingFactor = 0.37,
-                timePhase = 9.0 
+                timePhase = 9.0,
+                threshold_currentTDC = cms.double(3.),
                ),
     hf2 = dict( samplingFactor = 0.37,
-                timePhase = 8.0
+                timePhase = 8.0,
+                threshold_currentTDC = cms.double(3.)
                )
 ) 
 

--- a/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
+++ b/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
@@ -136,11 +136,13 @@ from Configuration.Eras.Modifier_run2_HF_2017_cff import run2_HF_2017
 run2_HF_2017.toModify( hcalSimParameters,
     hf1 = dict(
                readoutFrameSize = cms.int32(3), 
-               binOfMaximum     = cms.int32(2)
+               binOfMaximum     = cms.int32(2),
+               threshold_currentTDC = cms.double(3.),
               ),
     hf2 = dict(
                readoutFrameSize = cms.int32(3), 
-               binOfMaximum     = cms.int32(2)
+               binOfMaximum     = cms.int32(2),
+               threshold_currentTDC = cms.double(3.),
               )
 )
 
@@ -181,12 +183,10 @@ run3_common.toModify( hcalSimParameters,
                binOfMaximum     = cms.int32(6)
               ),
     hf1 = dict( samplingFactor = 0.37,
-                timePhase = 9.0,
-                threshold_currentTDC = cms.double(3.),
+                timePhase = 9.0 
                ),
     hf2 = dict( samplingFactor = 0.37,
-                timePhase = 8.0,
-                threshold_currentTDC = cms.double(3.)
+                timePhase = 8.0
                )
 ) 
 

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
@@ -49,8 +49,8 @@ HcalDigitizer::HcalDigitizer(const edm::ParameterSet &ps, edm::ConsumesCollector
       theHOSiPMResponse(std::make_unique<HcalSiPMHitResponse>(
           &theParameterMap, &theShapes, ps.getParameter<bool>("HcalPreMixStage1"), false)),
       theHFResponse(std::make_unique<CaloHitResponse>(&theParameterMap, &theShapes)),
-      theHFQIE10Response(std::make_unique<CaloHitResponse>(&theParameterMap, &theShapes)),
-      theZDCResponse(std::make_unique<CaloHitResponse>(&theParameterMap, &theShapes)),
+      theHFQIE10Response(std::make_unique<CaloHitResponse>(&theParameterMap, &theShapes, ps.getParameter<bool>("HcalPreMixStage1"), true)),
+      theZDCResponse(std::make_unique<CaloHitResponse>(&theParameterMap, &theShapes, ps.getParameter<bool>("HcalPreMixStage1"), false)),
       theHBHEAmplifier(nullptr),
       theHFAmplifier(nullptr),
       theHOAmplifier(nullptr),
@@ -466,7 +466,7 @@ void HcalDigitizer::finalizeEvent(edm::Event &e, const edm::EventSetup &eventSet
   std::unique_ptr<HFDigiCollection> hfResult(new HFDigiCollection());
   std::unique_ptr<ZDCDigiCollection> zdcResult(new ZDCDigiCollection());
   std::unique_ptr<QIE10DigiCollection> hfQIE10Result(new QIE10DigiCollection(
-      !theHFQIE10DetIds.empty() ? theParameterMap.simParameters(theHFQIE10DetIds[0]).readoutFrameSize()
+      !theHFQIE10DetIds.empty() ? theHFQIE10Response.get()->getReadoutFrameSize(theHFQIE10DetIds[0])
                                 : QIE10DigiCollection::MAXSAMPLES));
   std::unique_ptr<QIE11DigiCollection> hbheQIE11Result(new QIE11DigiCollection(
       !theHBHEQIE11DetIds.empty() ? theHBHESiPMResponse.get()->getReadoutFrameSize(theHBHEQIE11DetIds[0]) :

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
@@ -49,8 +49,10 @@ HcalDigitizer::HcalDigitizer(const edm::ParameterSet &ps, edm::ConsumesCollector
       theHOSiPMResponse(std::make_unique<HcalSiPMHitResponse>(
           &theParameterMap, &theShapes, ps.getParameter<bool>("HcalPreMixStage1"), false)),
       theHFResponse(std::make_unique<CaloHitResponse>(&theParameterMap, &theShapes)),
-      theHFQIE10Response(std::make_unique<CaloHitResponse>(&theParameterMap, &theShapes, ps.getParameter<bool>("HcalPreMixStage1"), true)),
-      theZDCResponse(std::make_unique<CaloHitResponse>(&theParameterMap, &theShapes, ps.getParameter<bool>("HcalPreMixStage1"), false)),
+      theHFQIE10Response(std::make_unique<CaloHitResponse>(
+          &theParameterMap, &theShapes, ps.getParameter<bool>("HcalPreMixStage1"), true)),
+      theZDCResponse(std::make_unique<CaloHitResponse>(
+          &theParameterMap, &theShapes, ps.getParameter<bool>("HcalPreMixStage1"), false)),
       theHBHEAmplifier(nullptr),
       theHFAmplifier(nullptr),
       theHOAmplifier(nullptr),


### PR DESCRIPTION
#### PR description:

* This PR adds TDC timing simulation for the HF --> enables the use of data noise filters in MC
  * Replaces 11_3 PR https://github.com/cms-sw/cmssw/pull/33829
  * Now precise samples are stored in PreMixStage1 and converted back to usual DIGIs in PreMixStage2
* Original presentation in HCAL DPG: https://indico.cern.ch/event/1026044/contributions/4324030/attachments/2227968/3774461/qie10tdc_mseidel.pdf
    * Pulse shape deemed sufficient (no update)
    * Eta-dependence fixed by new HF shower library

#### PR validation:

Tested with workflows 11634.0 (Run3 ttbar), 11834.0 (Run3 ttbar+PU), 250202.181 (Run2 ttbar+premix PU), no "Mismatched calo signals" messages.

MC Run3 ttbar+PU:
![image](https://user-images.githubusercontent.com/1311783/133645296-5f80ca65-1710-4577-8b95-fc11d42d8de7.png)

MC Run2 ttbar+premix PU (time alignment for Run2 MC is a little off, keep frozen):
![image](https://user-images.githubusercontent.com/1311783/133645995-d2f236be-0909-4a2d-8482-9cc34d7347cd.png)

Run2 data:
<img width="807" alt="image" src="https://user-images.githubusercontent.com/1311783/133645481-5767109c-cc86-4cfe-a2a9-b7a626a980a3.png">

@abdoulline @kpedro88 @tvami 