### PR TITLE
[EGM] Eta-Extended-Electrons (EEE)

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -17,6 +17,24 @@ from HLTrigger.Configuration.common import *
 #                     pset.minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('HLTSiStripClusterChargeCutNone'))
 #     return process
 
+# Eta Extended Electrons 
+def customiseForPRNUM(process):
+    for pset in process._Process__psets.values():
+        if hasattr(pset,'ComponentType'):
+            if (pset.ComponentType == 'CkfBaseTrajectoryFilter'):
+                if not hasattr(pset, 'highEtaSwitch'):
+                    pset.highEtaSwitch = cms.double(5.0)
+                if not hasattr(pset, 'minHitsAtHighEta'):
+                    pset.minHitsAtHighEta = cms.int32(5)
+
+    for esp in esproducers_by_type(process, 'KFFittingSmootherESProducer'):
+        if not hasattr(esp, 'HighEtaSwitch'):
+            esp.HighEtaSwitch = cms.double(5.0)
+        if not hasattr(esp, 'MinNumberOfHitsHighEta'):
+            esp.MinNumberOfHitsHighEta = cms.int32(5)
+
+    return process
+
 def customiseHCALFor2018Input(process):
     """Customise the HLT to run on Run 2 data/MC using the old readout for the HCAL barel"""
 
@@ -144,5 +162,6 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
     # process = customiseFor12718(process)
 
     process = customiseFor35315(process)
+    process = customiseForPRNUM(process)
 
     return process

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -27,12 +27,6 @@ def customiseFor35309(process):
                 if not hasattr(pset, 'minHitsAtHighEta'):
                     pset.minHitsAtHighEta = cms.int32(5)
 
-    for esp in esproducers_by_type(process, 'KFFittingSmootherESProducer'):
-        if not hasattr(esp, 'HighEtaSwitch'):
-            esp.HighEtaSwitch = cms.double(5.0)
-        if not hasattr(esp, 'MinNumberOfHitsHighEta'):
-            esp.MinNumberOfHitsHighEta = cms.int32(5)
-
     return process
 
 def customiseHCALFor2018Input(process):

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -18,7 +18,7 @@ from HLTrigger.Configuration.common import *
 #     return process
 
 # Eta Extended Electrons 
-def customiseForPRNUM(process):
+def customiseFor35309(process):
     for pset in process._Process__psets.values():
         if hasattr(pset,'ComponentType'):
             if (pset.ComponentType == 'CkfBaseTrajectoryFilter'):
@@ -161,7 +161,7 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
 
+    process = customiseFor35309(process)
     process = customiseFor35315(process)
-    process = customiseForPRNUM(process)
 
     return process

--- a/RecoParticleFlow/PFProducer/interface/PFEGammaFilters.h
+++ b/RecoParticleFlow/PFProducer/interface/PFEGammaFilters.h
@@ -52,6 +52,7 @@ private:
   const int ele_missinghits_;
   const float ele_ecalDrivenHademPreselCut_;
   const float ele_maxElePtForOnlyMVAPresel_;
+  const bool allowEEEinPF_;
   float ele_maxNtracks_;
   float ele_maxHcalE_;
   float ele_maxTrackPOverEele_;

--- a/RecoParticleFlow/PFProducer/interface/PFEGammaFilters.h
+++ b/RecoParticleFlow/PFProducer/interface/PFEGammaFilters.h
@@ -32,6 +32,7 @@ public:
 
 private:
   bool passGsfElePreSelWithOnlyConeHadem(const reco::GsfElectron &) const;
+  bool thisEleIsNotAllowedInPF(const reco::GsfElectron&, bool) const;
 
   // Photon selections
   const float ph_Et_;

--- a/RecoParticleFlow/PFProducer/interface/PFEGammaFilters.h
+++ b/RecoParticleFlow/PFProducer/interface/PFEGammaFilters.h
@@ -32,7 +32,7 @@ public:
 
 private:
   bool passGsfElePreSelWithOnlyConeHadem(const reco::GsfElectron &) const;
-  bool thisEleIsNotAllowedInPF(const reco::GsfElectron&, bool) const;
+  bool thisEleIsNotAllowedInPF(const reco::GsfElectron &, bool) const;
 
   // Photon selections
   const float ph_Et_;

--- a/RecoParticleFlow/PFProducer/python/particleFlow_cff.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlow_cff.py
@@ -10,6 +10,10 @@ from RecoParticleFlow.PFProducer.particleFlowTmpPtrs_cfi import *
 
 particleFlowTmp = particleFlow.clone()
 
+## temporary for 12_1; EtaExtendedEles do not enter PF because ID/regression of EEEs are not ready yet
+## In 12_2, we expect to have EEE's ID/regression, then this switch can flip to True
+particleFlowTmp.PFEGammaFiltersParameters.allowEEEinPF = cms.bool(False)
+
 from Configuration.Eras.Modifier_pf_badHcalMitigationOff_cff import pf_badHcalMitigationOff
 pf_badHcalMitigationOff.toModify(particleFlowTmp.PFEGammaFiltersParameters,
                                  electron_protectionsForBadHcal = dict(enableProtections = False),

--- a/RecoParticleFlow/PFProducer/src/PFEGammaFilters.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaFilters.cc
@@ -168,11 +168,11 @@ bool PFEGammaFilters::passElectronSelection(const reco::GsfElectron& electron,
   //TEMPORARY hack for 12_1.
   //Do not allow new EtaExtendedEle to enter PF, until ID, regression of EtaExtendedEle are in place.
   //In 12_2, we expect to have EtaExtendedEle's ID/regression, then this switch can flip to True
-  //this is to be taken care of by EGM POG  
+  //this is to be taken care of by EGM POG
   //https://github.com/cms-sw/cmssw/issues/35374
-  if ( thisEleIsNotAllowedInPF(electron,allowEEEinPF_) )  
+  if (thisEleIsNotAllowedInPF(electron, allowEEEinPF_))
     passEleSelection = false;
-  
+
   return passEleSelection && passGsfElePreSelWithOnlyConeHadem(electron);
 }
 
@@ -335,9 +335,9 @@ bool PFEGammaFilters::isElectronSafeForJetMET(const reco::GsfElectron& electron,
   //TEMPORARY hack for 12_1.
   //Do not allow new EtaExtendedEle to be SafeForJetMET, until ID, regression of EtaExtendedEle are in place.
   //In 12_2, we expect to have EtaExtendedEle's ID/regression, then this switch can flip to True
-  //this is to be taken care of by EGM POG 
-  //https://github.com/cms-sw/cmssw/issues/35374 
-  if ( thisEleIsNotAllowedInPF(electron,allowEEEinPF_) )  
+  //this is to be taken care of by EGM POG
+  //https://github.com/cms-sw/cmssw/issues/35374
+  if (thisEleIsNotAllowedInPF(electron, allowEEEinPF_))
     isSafeForJetMET = false;
 
   return isSafeForJetMET;
@@ -418,7 +418,7 @@ bool PFEGammaFilters::passGsfElePreSelWithOnlyConeHadem(const reco::GsfElectron&
 }
 
 bool PFEGammaFilters::thisEleIsNotAllowedInPF(const reco::GsfElectron& electron, bool allowEtaExtEleinPF) const {
-  bool returnVal=false;
+  bool returnVal = false;
   if (!allowEtaExtEleinPF) {
     const auto nHitGsf = electron.gsfTrack()->numberOfValidHits();
     const auto absEleEta = std::abs(electron.eta());

--- a/RecoParticleFlow/PFProducer/src/PFEGammaFilters.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaFilters.cc
@@ -36,7 +36,8 @@ PFEGammaFilters::PFEGammaFilters(const edm::ParameterSet& cfg)
       ele_noniso_mva_(cfg.getParameter<double>("electron_noniso_mvaCut")),
       ele_missinghits_(cfg.getParameter<unsigned int>("electron_missinghits")),
       ele_ecalDrivenHademPreselCut_(cfg.getParameter<double>("electron_ecalDrivenHademPreselCut")),
-      ele_maxElePtForOnlyMVAPresel_(cfg.getParameter<double>("electron_maxElePtForOnlyMVAPresel")) {
+      ele_maxElePtForOnlyMVAPresel_(cfg.getParameter<double>("electron_maxElePtForOnlyMVAPresel")),
+      allowEEEinPF_(cfg.getParameter<bool>("allowEEEinPF")) {
   auto const& eleProtectionsForBadHcal = cfg.getParameter<edm::ParameterSet>("electron_protectionsForBadHcal");
   auto const& eleProtectionsForJetMET = cfg.getParameter<edm::ParameterSet>("electron_protectionsForJetMET");
   auto const& phoProtectionsForBadHcal = cfg.getParameter<edm::ParameterSet>("photon_protectionsForBadHcal");
@@ -161,6 +162,16 @@ bool PFEGammaFilters::passElectronSelection(const reco::GsfElectron& electron,
           (std::abs(electron.deltaPhiSuperClusterTrackAtVtx()) < badHcal_dPhi_[EE])) {
         passEleSelection = true;
       }
+    }
+  }
+
+  //TEMPORARY hack. 
+  //Do not allow new EtaExtendedEle to enter PF, until ID, regression of EEEs are in place.
+  if  (!allowEEEinPF_) {
+    int nHitGsf= electron.gsfTrack()->numberOfValidHits();
+    double absEleEta = fabs(electron.eta());
+    if ( (absEleEta>2.5) && (nHitGsf<5) ) {
+      passEleSelection=false;
     }
   }
 
@@ -323,6 +334,16 @@ bool PFEGammaFilters::isElectronSafeForJetMET(const reco::GsfElectron& electron,
     isSafeForJetMET = false;
   }
 
+  //TEMPORARY hack. 
+  //Do not allow new EtaExtendedEle to be SafeForJetMET, until ID, regression of EEEs are in place.  
+  if  (!allowEEEinPF_) {
+    int nHitGsf= electron.gsfTrack()->numberOfValidHits();
+    double absEleEta = fabs(electron.eta());
+    if ( (absEleEta>2.5) && (nHitGsf<5) ) {
+      isSafeForJetMET=false;
+    }
+  }
+
   return isSafeForJetMET;
 }
 bool PFEGammaFilters::isPhotonSafeForJetMET(const reco::Photon& photon, const reco::PFCandidate& pfcand) const {
@@ -411,6 +432,7 @@ void PFEGammaFilters::fillPSetDescription(edm::ParameterSetDescription& iDesc) {
   iDesc.add<unsigned int>("electron_missinghits", 1);
   iDesc.add<double>("electron_ecalDrivenHademPreselCut", 0.15);
   iDesc.add<double>("electron_maxElePtForOnlyMVAPresel", 50.0);
+  iDesc.add<bool>("allowEEEinPF",false);
   {
     edm::ParameterSetDescription psd;
     psd.add<double>("maxNtracks", 3.0)->setComment("Max tracks pointing at Ele cluster");

--- a/RecoParticleFlow/PFProducer/src/PFEGammaFilters.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaFilters.cc
@@ -165,13 +165,13 @@ bool PFEGammaFilters::passElectronSelection(const reco::GsfElectron& electron,
     }
   }
 
-  //TEMPORARY hack. 
+  //TEMPORARY hack.
   //Do not allow new EtaExtendedEle to enter PF, until ID, regression of EEEs are in place.
-  if  (!allowEEEinPF_) {
-    int nHitGsf= electron.gsfTrack()->numberOfValidHits();
+  if (!allowEEEinPF_) {
+    int nHitGsf = electron.gsfTrack()->numberOfValidHits();
     double absEleEta = fabs(electron.eta());
-    if ( (absEleEta>2.5) && (nHitGsf<5) ) {
-      passEleSelection=false;
+    if ((absEleEta > 2.5) && (nHitGsf < 5)) {
+      passEleSelection = false;
     }
   }
 
@@ -334,13 +334,13 @@ bool PFEGammaFilters::isElectronSafeForJetMET(const reco::GsfElectron& electron,
     isSafeForJetMET = false;
   }
 
-  //TEMPORARY hack. 
-  //Do not allow new EtaExtendedEle to be SafeForJetMET, until ID, regression of EEEs are in place.  
-  if  (!allowEEEinPF_) {
-    int nHitGsf= electron.gsfTrack()->numberOfValidHits();
+  //TEMPORARY hack.
+  //Do not allow new EtaExtendedEle to be SafeForJetMET, until ID, regression of EEEs are in place.
+  if (!allowEEEinPF_) {
+    int nHitGsf = electron.gsfTrack()->numberOfValidHits();
     double absEleEta = fabs(electron.eta());
-    if ( (absEleEta>2.5) && (nHitGsf<5) ) {
-      isSafeForJetMET=false;
+    if ((absEleEta > 2.5) && (nHitGsf < 5)) {
+      isSafeForJetMET = false;
     }
   }
 
@@ -432,7 +432,7 @@ void PFEGammaFilters::fillPSetDescription(edm::ParameterSetDescription& iDesc) {
   iDesc.add<unsigned int>("electron_missinghits", 1);
   iDesc.add<double>("electron_ecalDrivenHademPreselCut", 0.15);
   iDesc.add<double>("electron_maxElePtForOnlyMVAPresel", 50.0);
-  iDesc.add<bool>("allowEEEinPF",false);
+  iDesc.add<bool>("allowEEEinPF", false);
   {
     edm::ParameterSetDescription psd;
     psd.add<double>("maxNtracks", 3.0)->setComment("Max tracks pointing at Ele cluster");

--- a/TrackingTools/GsfTracking/python/CkfElectronCandidateMaker_cff.py
+++ b/TrackingTools/GsfTracking/python/CkfElectronCandidateMaker_cff.py
@@ -21,6 +21,8 @@ TrajectoryFilterForElectrons = TrackingTools.TrajectoryFiltering.TrajectoryFilte
     maxConsecLostHits = 1,
     nSigmaMinPt = 5.0,
     minimumNumberOfHits = 5,
+    highEtaSwitch = 2.5,
+    minHitsAtHighEta = 3,
     maxCCCLostHits = 9999,
     minGoodStripCharge = dict(refToPSet_ = 'SiStripClusterChargeCutNone')
 )

--- a/TrackingTools/GsfTracking/python/GsfElectronFittingSmoother_cfi.py
+++ b/TrackingTools/GsfTracking/python/GsfElectronFittingSmoother_cfi.py
@@ -4,5 +4,7 @@ import TrackingTools.TrackFitters.KFFittingSmoother_cfi
 GsfElectronFittingSmoother = TrackingTools.TrackFitters.KFFittingSmoother_cfi.KFFittingSmoother.clone(
     ComponentName = 'GsfElectronFittingSmoother',
     Fitter        = 'GsfTrajectoryFitter',
-    Smoother      = 'GsfTrajectorySmoother'
+    Smoother      = 'GsfTrajectorySmoother',
+    MinNumberOfHitsHighEta = 3,
+    HighEtaSwitch = 2.5
 )

--- a/TrackingTools/TrackFitters/plugins/KFFittingSmootherESProducer.cc
+++ b/TrackingTools/TrackFitters/plugins/KFFittingSmootherESProducer.cc
@@ -74,22 +74,25 @@ namespace {
       desc.add<double>("LogPixelProbabilityCut", 0);
     }
 
-    int getNhitCutValue(const Trajectory& t, double theHighEtaSwitch, int theMinNumberOfHitsHighEta, int theMinNumberOfHits) const {
+    int getNhitCutValue(const Trajectory& t,
+                        double theHighEtaSwitch,
+                        int theMinNumberOfHitsHighEta,
+                        int theMinNumberOfHits) const {
       double sinhTrajEta2 = std::numeric_limits<double>::max();
-      if ( !t.empty() && t.isValid() ) {
-	/* in principle we can access eta() and check it w.r.t theHighEtaSwitch.
+      if (!t.empty() && t.isValid()) {
+        /* in principle we can access eta() and check it w.r.t theHighEtaSwitch.
 	   but eta() is expensive, so we are making use of the following relation
 	   sinh(eta) = pz/pt (will square on both side to get rid of sign)
 	 */
-	double pt = t.lastMeasurement().updatedState().freeTrajectoryState()->momentum().perp() ;
-	double pz = t.lastMeasurement().updatedState().freeTrajectoryState()->momentum().z() ;
-	sinhTrajEta2 = (pz*pz)/(pt*pt);
+        double pt = t.lastMeasurement().updatedState().freeTrajectoryState()->momentum().perp();
+        double pz = t.lastMeasurement().updatedState().freeTrajectoryState()->momentum().z();
+        sinhTrajEta2 = (pz * pz) / (pt * pt);
       }
       double myEtaSwitch = sinh(theHighEtaSwitch);
-      const auto thisHitCut = sinhTrajEta2 > (myEtaSwitch*myEtaSwitch) ? theMinNumberOfHitsHighEta : theMinNumberOfHits;
+      const auto thisHitCut =
+          sinhTrajEta2 > (myEtaSwitch * myEtaSwitch) ? theMinNumberOfHitsHighEta : theMinNumberOfHits;
       return thisHitCut;
     }
-    
 
     Trajectory fitOne(const Trajectory& t, fitType type) const override;
     Trajectory fitOne(const TrajectorySeed& aSeed,
@@ -224,7 +227,8 @@ namespace {
 #endif
 
       bool hasNaN = false;
-      const auto thisHitCut = getNhitCutValue(smoothed, theHighEtaSwitch, theMinNumberOfHitsHighEta, theMinNumberOfHits);
+      const auto thisHitCut =
+          getNhitCutValue(smoothed, theHighEtaSwitch, theMinNumberOfHitsHighEta, theMinNumberOfHits);
 
       if (!smoothed.isValid() || (hasNaN = !checkForNans(smoothed)) || (smoothed.foundHits() < thisHitCut)) {
         if (hasNaN)

--- a/TrackingTools/TrackFitters/plugins/KFFittingSmootherESProducer.cc
+++ b/TrackingTools/TrackFitters/plugins/KFFittingSmootherESProducer.cc
@@ -28,7 +28,7 @@ namespace {
           theNoOutliersBeginEnd(conf.getParameter<bool>("NoOutliersBeginEnd")),
           theMinDof(conf.getParameter<int>("MinDof")),
           theMinNumberOfHits(conf.getParameter<int>("MinNumberOfHits")),
-	  theMinNumberOfHitsHighEta(conf.getParameter<int>("MinNumberOfHitsHighEta")),
+          theMinNumberOfHitsHighEta(conf.getParameter<int>("MinNumberOfHitsHighEta")),
           theHighEtaSwitch(conf.getParameter<double>("HighEtaSwitch")),
           rejectTracksFlag(conf.getParameter<bool>("RejectTracks")),
           breakTrajWith2ConsecutiveMissing(conf.getParameter<bool>("BreakTrajWith2ConsecutiveMissing")),
@@ -100,11 +100,16 @@ namespace {
 
     Trajectory smoothingStep(Trajectory&& fitted) const {
       double absTrajEta = 99.0;
-      if ( !fitted.empty() ) {
-	absTrajEta=fabs(fitted.lastMeasurement().updatedState().freeTrajectoryState()->momentum().eta()); //needed for eta-extended electrons
+      if (!fitted.empty()) {
+        absTrajEta = fabs(fitted.lastMeasurement()
+                              .updatedState()
+                              .freeTrajectoryState()
+                              ->momentum()
+                              .eta());  //needed for eta-extended electrons
       }
-      int thisHitCut=theMinNumberOfHits;
-      if (absTrajEta>theHighEtaSwitch) thisHitCut=theMinNumberOfHitsHighEta;
+      int thisHitCut = theMinNumberOfHits;
+      if (absTrajEta > theHighEtaSwitch)
+        thisHitCut = theMinNumberOfHitsHighEta;
       if (theEstimateCut > 0) {
         // remove "outlier" at the end of Traj
         while (
@@ -211,12 +216,17 @@ namespace {
 #endif
 
       bool hasNaN = false;
-      double absTrajEta=99.0;
+      double absTrajEta = 99.0;
       if (smoothed.isValid()) {
-	absTrajEta=fabs(smoothed.lastMeasurement().updatedState().freeTrajectoryState()->momentum().eta()); //needed for eta-extended electrons 
+        absTrajEta = fabs(smoothed.lastMeasurement()
+                              .updatedState()
+                              .freeTrajectoryState()
+                              ->momentum()
+                              .eta());  //needed for eta-extended electrons
       }
-      int thisHitCut=theMinNumberOfHits;
-      if (absTrajEta>theHighEtaSwitch) thisHitCut=theMinNumberOfHitsHighEta;
+      int thisHitCut = theMinNumberOfHits;
+      if (absTrajEta > theHighEtaSwitch)
+        thisHitCut = theMinNumberOfHitsHighEta;
       if (!smoothed.isValid() || (hasNaN = !checkForNans(smoothed)) || (smoothed.foundHits() < thisHitCut)) {
         if (hasNaN)
           edm::LogWarning("TrackNaN") << "Track has NaN or the cov is not pos-definite";

--- a/TrackingTools/TrajectoryFiltering/interface/MinHitsTrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/MinHitsTrajectoryFilter.h
@@ -49,11 +49,11 @@ protected:
   bool QF(const T& traj) const {
     int seedPenalty = (2 == traj.seedNHits()) ? theSeedPairPenalty : 0;  // increase by one if seed-doublet...
     bool passed = false;
-    double pt = traj.lastMeasurement().updatedState().freeTrajectoryState()->momentum().perp() ;
-    double pz = traj.lastMeasurement().updatedState().freeTrajectoryState()->momentum().z() ;
-    double sinhTrajEta2 = (pz*pz)/(pt*pt);
+    double pt = traj.lastMeasurement().updatedState().freeTrajectoryState()->momentum().perp();
+    double pz = traj.lastMeasurement().updatedState().freeTrajectoryState()->momentum().z();
+    double sinhTrajEta2 = (pz * pz) / (pt * pt);
     double myEtaSwitch = sinh(theHighEtaSwitch);
-    if (sinhTrajEta2 < (myEtaSwitch*myEtaSwitch) ) {
+    if (sinhTrajEta2 < (myEtaSwitch * myEtaSwitch)) {
       if (traj.foundHits() >= theMinHits + seedPenalty)
         passed = true;
     } else {  //absTrajEta>theHighEtaSwitch, so apply relaxed cuts

--- a/TrackingTools/TrajectoryFiltering/interface/MinHitsTrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/MinHitsTrajectoryFilter.h
@@ -12,11 +12,13 @@
 
 class MinHitsTrajectoryFilter final : public TrajectoryFilter {
 public:
-  explicit MinHitsTrajectoryFilter(int minHits = 5, int seedPairPenalty = 0)
-      : theMinHits(minHits), theSeedPairPenalty(seedPairPenalty) {}
+  explicit MinHitsTrajectoryFilter(int minHits = 5, double highEtaSwitch = 5.0, int minHitsAtHighEta = 5, int seedPairPenalty = 0)
+    : theMinHits(minHits), theHighEtaSwitch(highEtaSwitch), theMinHitsAtHighEta(minHitsAtHighEta), theSeedPairPenalty(seedPairPenalty) {}
 
   MinHitsTrajectoryFilter(const edm::ParameterSet& pset, edm::ConsumesCollector& iC)
       : theMinHits(pset.getParameter<int>("minimumNumberOfHits")),
+        theHighEtaSwitch(pset.getParameter<double>("highEtaSwitch")),
+        theMinHitsAtHighEta(pset.getParameter<int>("minHitsAtHighEta")),
         theSeedPairPenalty(pset.getParameter<int>("seedPairPenalty")) {}
 
   bool qualityFilter(const Trajectory& traj) const override { return QF<Trajectory>(traj); }
@@ -30,6 +32,8 @@ public:
   inline edm::ParameterSetDescription getFilledConfigurationDescription() {
     edm::ParameterSetDescription desc;
     desc.add<int>("minimumNumberOfHits", 5);
+    desc.add<double>("highEtaSwitch", 5.0);
+    desc.add<int>("minHitsAtHighEta", 5);
     desc.add<int>("seedPairPenalty", 0);
     return desc;
   }
@@ -38,10 +42,20 @@ protected:
   template <class T>
   bool QF(const T& traj) const {
     int seedPenalty = (2 == traj.seedNHits()) ? theSeedPairPenalty : 0;  // increase by one if seed-doublet...
-    return (traj.foundHits() >= theMinHits + seedPenalty);
+    bool passed=false;
+    double absTrajEta=fabs(traj.lastMeasurement().updatedState().freeTrajectoryState()->momentum().eta());
+    if (absTrajEta<theHighEtaSwitch) {
+      if (traj.foundHits() >= theMinHits + seedPenalty) passed=true;
+    }
+    else { //absTrajEta>theHighEtaSwitch, so apply relaxed cuts
+      if (traj.foundHits() >= theMinHitsAtHighEta + seedPenalty) passed=true;
+    }
+    return passed;
   }
 
   int theMinHits;
+  double theHighEtaSwitch; 
+  int theMinHitsAtHighEta;
   int theSeedPairPenalty;
 };
 

--- a/TrackingTools/TrajectoryFiltering/interface/MinHitsTrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/MinHitsTrajectoryFilter.h
@@ -12,8 +12,14 @@
 
 class MinHitsTrajectoryFilter final : public TrajectoryFilter {
 public:
-  explicit MinHitsTrajectoryFilter(int minHits = 5, double highEtaSwitch = 5.0, int minHitsAtHighEta = 5, int seedPairPenalty = 0)
-    : theMinHits(minHits), theHighEtaSwitch(highEtaSwitch), theMinHitsAtHighEta(minHitsAtHighEta), theSeedPairPenalty(seedPairPenalty) {}
+  explicit MinHitsTrajectoryFilter(int minHits = 5,
+                                   double highEtaSwitch = 5.0,
+                                   int minHitsAtHighEta = 5,
+                                   int seedPairPenalty = 0)
+      : theMinHits(minHits),
+        theHighEtaSwitch(highEtaSwitch),
+        theMinHitsAtHighEta(minHitsAtHighEta),
+        theSeedPairPenalty(seedPairPenalty) {}
 
   MinHitsTrajectoryFilter(const edm::ParameterSet& pset, edm::ConsumesCollector& iC)
       : theMinHits(pset.getParameter<int>("minimumNumberOfHits")),
@@ -42,19 +48,20 @@ protected:
   template <class T>
   bool QF(const T& traj) const {
     int seedPenalty = (2 == traj.seedNHits()) ? theSeedPairPenalty : 0;  // increase by one if seed-doublet...
-    bool passed=false;
-    double absTrajEta=fabs(traj.lastMeasurement().updatedState().freeTrajectoryState()->momentum().eta());
-    if (absTrajEta<theHighEtaSwitch) {
-      if (traj.foundHits() >= theMinHits + seedPenalty) passed=true;
-    }
-    else { //absTrajEta>theHighEtaSwitch, so apply relaxed cuts
-      if (traj.foundHits() >= theMinHitsAtHighEta + seedPenalty) passed=true;
+    bool passed = false;
+    double absTrajEta = fabs(traj.lastMeasurement().updatedState().freeTrajectoryState()->momentum().eta());
+    if (absTrajEta < theHighEtaSwitch) {
+      if (traj.foundHits() >= theMinHits + seedPenalty)
+        passed = true;
+    } else {  //absTrajEta>theHighEtaSwitch, so apply relaxed cuts
+      if (traj.foundHits() >= theMinHitsAtHighEta + seedPenalty)
+        passed = true;
     }
     return passed;
   }
 
   int theMinHits;
-  double theHighEtaSwitch; 
+  double theHighEtaSwitch;
   int theMinHitsAtHighEta;
   int theSeedPairPenalty;
 };

--- a/TrackingTools/TrajectoryFiltering/interface/MinHitsTrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/MinHitsTrajectoryFilter.h
@@ -49,8 +49,11 @@ protected:
   bool QF(const T& traj) const {
     int seedPenalty = (2 == traj.seedNHits()) ? theSeedPairPenalty : 0;  // increase by one if seed-doublet...
     bool passed = false;
-    double absTrajEta = fabs(traj.lastMeasurement().updatedState().freeTrajectoryState()->momentum().eta());
-    if (absTrajEta < theHighEtaSwitch) {
+    double pt = traj.lastMeasurement().updatedState().freeTrajectoryState()->momentum().perp() ;
+    double pz = traj.lastMeasurement().updatedState().freeTrajectoryState()->momentum().z() ;
+    double sinhTrajEta2 = (pz*pz)/(pt*pt);
+    double myEtaSwitch = sinh(theHighEtaSwitch);
+    if (sinhTrajEta2 < (myEtaSwitch*myEtaSwitch) ) {
       if (traj.foundHits() >= theMinHits + seedPenalty)
         passed = true;
     } else {  //absTrajEta>theHighEtaSwitch, so apply relaxed cuts

--- a/TrackingTools/TrajectoryFiltering/python/TrajectoryFilter_cff.py
+++ b/TrackingTools/TrajectoryFiltering/python/TrajectoryFilter_cff.py
@@ -8,6 +8,8 @@ CkfBaseTrajectoryFilter_block = cms.PSet(
 #--- Cuts applied to completed trajectory
 # At least this many hits (counting matched hits as 1)
     minimumNumberOfHits = cms.int32(5),
+    highEtaSwitch = cms.double(5.0),
+    minHitsAtHighEta = cms.int32(5),
 # add this if seed is a Pair  (opposed to a triplet)
     seedPairPenalty = cms.int32(0),
 # What is this ?
@@ -68,7 +70,9 @@ MaxHitsTrajectoryFilter_block = cms.PSet(
 )
 MinHitsTrajectoryFilter_block = cms.PSet(
     ComponentType = cms.string('MinHitsTrajectoryFilter'),
-    minimumNumberOfHits = cms.int32(5)
+    minimumNumberOfHits = cms.int32(5),
+    highEtaSwitch = cms.double(5.0),
+    minHitsAtHighEta = cms.int32(5)
 )
 MinPtTrajectoryFilter_block = cms.PSet(
     ComponentType = cms.string('MinPtTrajectoryFilter'),


### PR DESCRIPTION
#### PR description:

This PR aims to improve electron reconstruction efficiency in high eta region, 2.5<|eta|<3.0. 

Motivation: EEEs can be important for many analyses, one example is measurement of weak mixing angle using forward-backward asymmetry of DY events.
 
Currently, electron reconstruction efficiency sharply falls off after around |eta|=2.5. This is because GSF tracking tends to fail in high eta, as the outer tracker coverage ends and we are left with only the inner tracker layers. Two parameters were identified, whose cut-values need to be relaxed, to improve GSF tracking efficiency in high eta region; they are the following:
```
(1) process.TrajectoryFilterForElectrons.minimumNumberOfHits = cms.int32(3)  ### default was 5
(2) process.GsfElectronFittingSmoother.MinNumberOfHits = cms.int32(3)  #### default was 5 
```
However, this change was made only for high eta electrons, keeping the parameters' cut values same in low eta. 

Note that while we expect EEEs to enter 12_1 and MC samples to be produced with it, the PF Electron ID and energy regression for EEEs would likely be suboptimal. So a temporary switch is added to prevent EEEs to enter particle flow. When 12_1 samples will be available, we will retrain PF electron ID and energy regression including EEEs, and we will put in the updates in 12_2 while removing this switch and allowing EEEs to the particle flow. This is done as an intermediate, safe approach.

#### PR validation:
Some checks were made using 1000 double-electron gun events. 
This plot shows electron eta distribution(from AOD); default CMSSW in blue and after merging this branch in green. More electrons are reconstructed in high eta, but there is no change in other regions.
<img width="500" alt="Screen Shot 2021-09-16 at 19 19 56" src="https://user-images.githubusercontent.com/5052706/133657017-71110abc-4b26-4629-b6e4-0910b577d51f.png">

This is general track eta distribution(from AOD), showing no change, as intended.
<img width="500" alt="Screen Shot 2021-09-16 at 19 30 01" src="https://user-images.githubusercontent.com/5052706/133658106-45f7c932-754a-4fd6-a2db-10bfbff217c9.png">

`runTheMatrix.py -l  12434.0 ` ran fine (ttbar 2023)

This PR is not a backport.
Backport not needed.

This work is done together with Shilpi and Yash; in collaboration with PF group (Josh, Kenichi, Kenneth et. al) and with help from tracking experts (Mia et. al). Thanks to Marino(HLT-STORM) for helping with HLT customisation. 
