### PR TITLE
Added more esConsumes to L1MuDTExtrapolationUnit

### DIFF
--- a/L1Trigger/DTTrackFinder/src/L1MuDTEUX.cc
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTEUX.cc
@@ -34,9 +34,7 @@
 #include "L1Trigger/DTTrackFinder/src/L1MuDTSEU.h"
 #include "L1Trigger/DTTrackFinder/interface/L1MuDTTrackSegPhi.h"
 #include "CondFormats/L1TObjects/interface/L1MuDTExtLut.h"
-#include "CondFormats/DataRecord/interface/L1MuDTExtLutRcd.h"
 #include "CondFormats/L1TObjects/interface/L1MuDTTFParameters.h"
-#include "CondFormats/DataRecord/interface/L1MuDTTFParametersRcd.h"
 
 using namespace std;
 
@@ -89,10 +87,7 @@ bool L1MuDTEUX::operator==(const L1MuDTEUX& eux) const {
 //
 // run EUX
 //
-void L1MuDTEUX::run(const edm::EventSetup& c) {
-  c.get<L1MuDTExtLutRcd>().get(theExtLUTs);
-  c.get<L1MuDTTFParametersRcd>().get(pars);
-
+void L1MuDTEUX::run(const L1MuDTExtLut& extLUTs, const L1MuDTTFParameters& pars) {
   const bool debug4 = m_sp.tf().config()->Debug(4);
   if (debug4)
     cout << "Run EUX " << m_id << endl;
@@ -138,19 +133,19 @@ void L1MuDTEUX::run(const edm::EventSetup& c) {
   // Extrapolation TS quality filter
   int qcut = 0;
   if (m_seu.ext() == EX12)
-    qcut = pars->get_soc_qcut_st1(m_sp.id().wheel(), m_sp.id().sector());
+    qcut = pars.get_soc_qcut_st1(m_sp.id().wheel(), m_sp.id().sector());
   if (m_seu.ext() == EX13)
-    qcut = pars->get_soc_qcut_st1(m_sp.id().wheel(), m_sp.id().sector());
+    qcut = pars.get_soc_qcut_st1(m_sp.id().wheel(), m_sp.id().sector());
   if (m_seu.ext() == EX14)
-    qcut = pars->get_soc_qcut_st1(m_sp.id().wheel(), m_sp.id().sector());
+    qcut = pars.get_soc_qcut_st1(m_sp.id().wheel(), m_sp.id().sector());
   if (m_seu.ext() == EX21)
-    qcut = pars->get_soc_qcut_st2(m_sp.id().wheel(), m_sp.id().sector());
+    qcut = pars.get_soc_qcut_st2(m_sp.id().wheel(), m_sp.id().sector());
   if (m_seu.ext() == EX23)
-    qcut = pars->get_soc_qcut_st2(m_sp.id().wheel(), m_sp.id().sector());
+    qcut = pars.get_soc_qcut_st2(m_sp.id().wheel(), m_sp.id().sector());
   if (m_seu.ext() == EX24)
-    qcut = pars->get_soc_qcut_st2(m_sp.id().wheel(), m_sp.id().sector());
+    qcut = pars.get_soc_qcut_st2(m_sp.id().wheel(), m_sp.id().sector());
   if (m_seu.ext() == EX34)
-    qcut = pars->get_soc_qcut_st4(m_sp.id().wheel(), m_sp.id().sector());
+    qcut = pars.get_soc_qcut_st4(m_sp.id().wheel(), m_sp.id().sector());
 
   if (m_start->quality() < qcut)
     return;
@@ -172,8 +167,8 @@ void L1MuDTEUX::run(const edm::EventSetup& c) {
   // and add offset (30 degrees ) for extrapolation to adjacent sector
   int offset = -2144 >> sh_phi;
   offset *= sec_mod(sector_ta - sector_st);
-  int low = theExtLUTs->getLow(lut_idx, phib_start);
-  int high = theExtLUTs->getHigh(lut_idx, phib_start);
+  int low = extLUTs.getLow(lut_idx, phib_start);
+  int high = extLUTs.getHigh(lut_idx, phib_start);
   if (low < 0)
     low += (1 << sh_phi) - 1;
   if (high < 0)
@@ -190,7 +185,7 @@ void L1MuDTEUX::run(const edm::EventSetup& c) {
     return;
 
   // is phi-difference within the extrapolation window?
-  bool openlut = pars->get_soc_openlut_extr(m_sp.id().wheel(), m_sp.id().sector());
+  bool openlut = pars.get_soc_openlut_extr(m_sp.id().wheel(), m_sp.id().sector());
   if ((diff >= low && diff <= high) || m_sp.tf().config()->getopenLUTs() || openlut) {
     m_result = true;
     int qual_st = m_start->quality();

--- a/L1Trigger/DTTrackFinder/src/L1MuDTEUX.h
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTEUX.h
@@ -39,6 +39,7 @@ class L1MuDTSectorProcessor;
 class L1MuDTSEU;
 class L1MuDTExtLut;
 class L1MuDTTFParameters;
+class L1MuDTExtLut;
 
 //              ---------------------
 //              -- Class Interface --
@@ -56,7 +57,7 @@ public:
   bool operator==(const L1MuDTEUX&) const;
 
   /// run Extrapolator
-  void run(const edm::EventSetup& c);
+  void run(const L1MuDTExtLut& extLUTs, const L1MuDTTFParameters& pars);
 
   /// reset Extrapolator
   void reset();
@@ -113,12 +114,9 @@ private:
   const L1MuDTTrackSegPhi* m_start;   // start track segment
   const L1MuDTTrackSegPhi* m_target;  // target track segment
 
-  edm::ESHandle<L1MuDTExtLut> theExtLUTs;  // extrapolation look-up tables
-  int const theExtFilter = 1;              // extrapolation quality filter
-  unsigned short const nbit_phi = 12;      // number of bits used for phi
-  unsigned short const nbit_phib = 10;     // number of bits used for phib
-
-  edm::ESHandle<L1MuDTTFParameters> pars;
+  int const theExtFilter = 1;           // extrapolation quality filter
+  unsigned short const nbit_phi = 12;   // number of bits used for phi
+  unsigned short const nbit_phib = 10;  // number of bits used for phib
 };
 
 #endif

--- a/L1Trigger/DTTrackFinder/src/L1MuDTExtrapolationUnit.cc
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTExtrapolationUnit.cc
@@ -41,6 +41,7 @@
 #include "L1Trigger/DTTrackFinder/interface/L1MuDTTrackSegPhi.h"
 #include "CondFormats/L1TObjects/interface/L1MuDTTFParameters.h"
 #include "CondFormats/DataRecord/interface/L1MuDTTFParametersRcd.h"
+#include "CondFormats/DataRecord/interface/L1MuDTExtLutRcd.h"
 
 using namespace std;
 
@@ -53,7 +54,7 @@ using namespace std;
 //----------------
 
 L1MuDTExtrapolationUnit::L1MuDTExtrapolationUnit(const L1MuDTSectorProcessor& sp, edm::ConsumesCollector iC)
-    : m_sp(sp), m_SEUs(), m_parsToken(iC.esConsumes()) {
+    : m_sp(sp), m_SEUs(), m_parsToken(iC.esConsumes()), m_extLUTsToken(iC.esConsumes()) {
   for (int ext_idx = 0; ext_idx < MAX_EXT; ext_idx++) {
     Extrapolation ext = static_cast<Extrapolation>(ext_idx);
 
@@ -93,7 +94,9 @@ L1MuDTExtrapolationUnit::~L1MuDTExtrapolationUnit() {
 // run Extrapolation Unit
 //
 void L1MuDTExtrapolationUnit::run(const edm::EventSetup& c) {
-  pars = c.getHandle(m_parsToken);
+  auto const& pars = c.getData(m_parsToken);
+
+  L1MuDTExtLut const& extLUTs = c.getData(m_extLUTsToken);
 
   SEUmap::const_iterator iter;
   for (iter = m_SEUs.begin(); iter != m_SEUs.end(); iter++) {
@@ -107,14 +110,14 @@ void L1MuDTExtrapolationUnit::run(const edm::EventSetup& c) {
 
     if (ts != nullptr && !ts->empty()) {
       ((*iter).second)->load(ts);
-      ((*iter).second)->run(c);
+      ((*iter).second)->run(extLUTs, pars);
     }
   }
 
   //
   // use EX21 to cross-check EX12
   //
-  bool run_21 = pars->get_soc_run_21(m_sp.id().wheel(), m_sp.id().sector());
+  bool run_21 = pars.get_soc_run_21(m_sp.id().wheel(), m_sp.id().sector());
   if (m_sp.tf().config()->getUseEX21() || run_21) {
     // search for EX12 + EX21 single extrapolation units
     for (unsigned int startAdr = 0; startAdr < 2; startAdr++) {
@@ -214,7 +217,7 @@ const bitset<12>& L1MuDTExtrapolationUnit::getEXTable(Extrapolation ext, unsigne
   //  assert( startAdr >= 0 && startAdr <= 3 );
 
   SEUId seuid = make_pair(ext, startAdr);
-  return m_SEUs[seuid]->exTable();
+  return m_SEUs.find(seuid)->second->exTable();
 }
 
 //
@@ -227,7 +230,7 @@ const bitset<12>& L1MuDTExtrapolationUnit::getQSTable(Extrapolation ext, unsigne
   //  assert( startAdr >= 0 && startAdr <= 3 );
 
   SEUId seuid = make_pair(ext, startAdr);
-  return m_SEUs[seuid]->qsTable();
+  return m_SEUs.find(seuid)->second->qsTable();
 }
 
 //

--- a/L1Trigger/DTTrackFinder/src/L1MuDTExtrapolationUnit.h
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTExtrapolationUnit.h
@@ -45,7 +45,8 @@ class L1MuDTSectorProcessor;
 class L1MuDTSEU;
 class L1MuDTTFParameters;
 class L1MuDTTFParametersRcd;
-
+class L1MuDTExtLut;
+class L1MuDTExtLutRcd;
 //              ---------------------
 //              -- Class Interface --
 //              ---------------------
@@ -94,10 +95,10 @@ public:
 private:
   const L1MuDTSectorProcessor& m_sp;  // reference to Sector Processor
 
-  mutable SEUmap m_SEUs;  // Single Extrapolation Units
+  SEUmap m_SEUs;  // Single Extrapolation Units
 
-  edm::ESGetToken<L1MuDTTFParameters, L1MuDTTFParametersRcd> m_parsToken;
-  edm::ESHandle<L1MuDTTFParameters> pars;
+  const edm::ESGetToken<L1MuDTTFParameters, L1MuDTTFParametersRcd> m_parsToken;
+  const edm::ESGetToken<L1MuDTExtLut, L1MuDTExtLutRcd> m_extLUTsToken;
 };
 
 #endif

--- a/L1Trigger/DTTrackFinder/src/L1MuDTSEU.cc
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTSEU.cc
@@ -82,7 +82,7 @@ L1MuDTSEU::~L1MuDTSEU() {
 //
 // run SEU
 //
-void L1MuDTSEU::run(const edm::EventSetup& c) {
+void L1MuDTSEU::run(const L1MuDTExtLut& extLUTs, const L1MuDTTFParameters& pars) {
   if (L1MuDTTFConfig::Debug(3))
     cout << "Run SEU " << m_ext << " " << m_startTS_Id << endl;
 
@@ -121,7 +121,7 @@ void L1MuDTSEU::run(const edm::EventSetup& c) {
     const L1MuDTTrackSegPhi* target_ts = m_sp.data()->getTSphi(target, reladr);
     if (target_ts && !target_ts->empty()) {
       m_EUXs[reladr]->load(m_startTS, target_ts);
-      m_EUXs[reladr]->run(c);
+      m_EUXs[reladr]->run(extLUTs, pars);
       if (m_EUXs[reladr]->result())
         m_EXtable.set(reladr);
     }

--- a/L1Trigger/DTTrackFinder/src/L1MuDTSEU.h
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTSEU.h
@@ -38,6 +38,8 @@ class L1MuDTSectorProcessor;
 class L1MuDTTrackSegPhi;
 class L1MuDTEUX;
 class L1MuDTERS;
+class L1MuDTExtLut;
+class L1MuDTTFParameters;
 
 //              ---------------------
 //              -- Class Interface --
@@ -52,7 +54,7 @@ public:
   ~L1MuDTSEU();
 
   /// run SEU
-  void run(const edm::EventSetup& c);
+  void run(const L1MuDTExtLut& extLUTs, const L1MuDTTFParameters& pars);
 
   /// reset SEU
   void reset();


### PR DESCRIPTION
- Helper classes no longer depend on EventSetup
- These were missed in the first pass through these classes

#### PR description:

Code compiles. The static analyzer doesn't report any more EventSetup gets from this code.