### PR TITLE
Added esConsumes to L1MuBMSectorProcessor

### DIFF
--- a/L1Trigger/L1TMuonBarrel/src/L1MuBMAssignmentUnit.cc
+++ b/L1Trigger/L1TMuonBarrel/src/L1MuBMAssignmentUnit.cc
@@ -72,7 +72,7 @@ L1MuBMAssignmentUnit::~L1MuBMAssignmentUnit() {}
 //
 // run Assignment Unit
 //
-void L1MuBMAssignmentUnit::run(const edm::EventSetup& c) {
+void L1MuBMAssignmentUnit::run(const L1TMuonBarrelParams& bmtfParams) {
   // enable track candidate
   m_sp.track(m_id)->enable();
   m_sp.tracK(m_id)->enable();
@@ -99,10 +99,10 @@ void L1MuBMAssignmentUnit::run(const edm::EventSetup& c) {
   m_sp.tracK(m_id)->setBx(bx);
 
   // assign phi
-  PhiAU(c);
+  PhiAU(bmtfParams);
 
   // assign pt and charge
-  PtAU(c);
+  PtAU(bmtfParams);
 
   // assign quality
   QuaAU();
@@ -120,10 +120,7 @@ void L1MuBMAssignmentUnit::reset() {
 //
 // assign phi with 8 bit precision
 //
-void L1MuBMAssignmentUnit::PhiAU(const edm::EventSetup& c) {
-  const L1TMuonBarrelParamsRcd& bmtfParamsRcd = c.get<L1TMuonBarrelParamsRcd>();
-  bmtfParamsRcd.get(bmtfParamsHandle);
-  const L1TMuonBarrelParams& bmtfParams = *bmtfParamsHandle.product();
+void L1MuBMAssignmentUnit::PhiAU(const L1TMuonBarrelParams& bmtfParams) {
   thePhiLUTs = new L1MuBMLUTHandler(bmtfParams);  ///< phi-assignment look-up tables
   //thePhiLUTs->print();
   // calculate phi at station 2 using 8 bits (precision = 0.625 degrees)
@@ -198,11 +195,8 @@ void L1MuBMAssignmentUnit::PhiAU(const edm::EventSetup& c) {
 //
 // assign pt with 5 bit precision
 //
-void L1MuBMAssignmentUnit::PtAU(const edm::EventSetup& c) {
-  const L1TMuonBarrelParamsRcd& bmtfParamsRcd = c.get<L1TMuonBarrelParamsRcd>();
-  bmtfParamsRcd.get(bmtfParamsHandle);
-  const L1TMuonBarrelParams& bmtfParams1 = *bmtfParamsHandle.product();
-  const L1TMuonBarrelParamsAllPublic& bmtfParams = L1TMuonBarrelParamsAllPublic(bmtfParams1);
+void L1MuBMAssignmentUnit::PtAU(const L1TMuonBarrelParams& bmtfParams1) {
+  const L1TMuonBarrelParamsAllPublic bmtfParams(bmtfParams1);
   thePtaLUTs = new L1MuBMLUTHandler(bmtfParams);  ///< pt-assignment look-up tables
   //thePtaLUTs->print();
   // get pt-assignment method as function of track class and TS phib values

--- a/L1Trigger/L1TMuonBarrel/src/L1MuBMAssignmentUnit.h
+++ b/L1Trigger/L1TMuonBarrel/src/L1MuBMAssignmentUnit.h
@@ -57,16 +57,16 @@ public:
   ~L1MuBMAssignmentUnit();
 
   /// run Assignment Unit
-  void run(const edm::EventSetup& c);
+  void run(const L1TMuonBarrelParams& mbtfParams);
 
   /// reset Assignment Unit
   void reset();
 
   /// assign phi
-  void PhiAU(const edm::EventSetup& c);
+  void PhiAU(const L1TMuonBarrelParams&);
 
   /// assign pt and charge
-  void PtAU(const edm::EventSetup& c);
+  void PtAU(const L1TMuonBarrelParams&);
 
   /// assign quality
   void QuaAU();
@@ -109,7 +109,6 @@ private:
   std::vector<const L1MuBMTrackSegPhi*> m_TSphi;
   L1MuBMLUTHandler::PtAssMethod m_ptAssMethod;
 
-  edm::ESHandle<L1TMuonBarrelParams> bmtfParamsHandle;
   L1MuBMLUTHandler* thePtaLUTs;     ///< pt-assignment look-up tables
   L1MuBMLUTHandler* thePhiLUTs;     ///< phi-assignment look-up tables
   static unsigned short nbit_phi;   ///< # of bits used for pt-assignment

--- a/L1Trigger/L1TMuonBarrel/src/L1MuBMSectorProcessor.cc
+++ b/L1Trigger/L1TMuonBarrel/src/L1MuBMSectorProcessor.cc
@@ -62,6 +62,7 @@ L1MuBMSectorProcessor::L1MuBMSectorProcessor(const L1MuBMTrackFinder& tf,
       m_DataBuffer(new L1MuBMDataBuffer(*this)),
       m_EU(new L1MuBMExtrapolationUnit(*this, iC)),
       m_TA(new L1MuBMTrackAssembler(*this)),
+      m_bmtfParamsToken(iC.esConsumes()),
       m_AUs(),
       m_TrackCands(),
       m_TracKCands() {
@@ -139,11 +140,13 @@ void L1MuBMSectorProcessor::run(int bx, const edm::Event& e, const edm::EventSet
       m_TA->print();
   }
 
+  L1TMuonBarrelParams const& bmtfParams = c.getData(m_bmtfParamsToken);
+
   // assign pt, eta, phi and quality
   if (m_AUs[0] && !m_TA->isEmpty(0))
-    m_AUs[0]->run(c);
+    m_AUs[0]->run(bmtfParams);
   if (m_AUs[1] && !m_TA->isEmpty(1))
-    m_AUs[1]->run(c);
+    m_AUs[1]->run(bmtfParams);
 
   if (m_spid.wheel() == -1) {
     if (m_TrackCands[0] && !m_TrackCands[0]->empty() && m_TrackCands[0]->address(2) > 3 &&

--- a/L1Trigger/L1TMuonBarrel/src/L1MuBMSectorProcessor.h
+++ b/L1Trigger/L1TMuonBarrel/src/L1MuBMSectorProcessor.h
@@ -46,6 +46,8 @@ class L1MuBMTrackAssembler;
 class L1MuBMAssignmentUnit;
 class L1MuBMTrackFinder;
 class L1MuBMTrack;
+class L1TMuonBarrelParams;
+class L1TMuonBarrelParamsRcd;
 
 //              ---------------------
 //              -- Class Interface --
@@ -114,6 +116,7 @@ private:
   L1MuBMDataBuffer* m_DataBuffer;
   L1MuBMExtrapolationUnit* m_EU;
   L1MuBMTrackAssembler* m_TA;
+  const edm::ESGetToken<L1TMuonBarrelParams, L1TMuonBarrelParamsRcd> m_bmtfParamsToken;
   std::vector<L1MuBMAssignmentUnit*> m_AUs;
 
   std::vector<L1MuBMTrack*> m_TrackCands;


### PR DESCRIPTION
#### PR description:

- Removed EventSetup dependencies from L1MuBMAssignmentUnit
- Get data in L1MuBMSectorProcessor

This was missed in an eariler esConsumes migration.

#### PR validation:

Code compiles.