### PR TITLE
clean up use of array parameters in L1T modules

### DIFF
--- a/L1Trigger/GlobalTrigger/plugins/L1GTPrescaler.cc
+++ b/L1Trigger/GlobalTrigger/plugins/L1GTPrescaler.cc
@@ -3,14 +3,6 @@
 #include <memory>
 #include <vector>
 
-template <class T, std::size_t N>
-std::array<T, N> make_array(std::vector<T> const &values) {
-  assert(N == values.size());
-  std::array<T, N> ret;
-  std::copy(values.begin(), values.end(), ret.begin());
-  return ret;
-}
-
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -36,8 +28,8 @@ private:
 
 L1GTPrescaler::L1GTPrescaler(edm::ParameterSet const &config)
     : m_l1ResultsToken(consumes<L1GlobalTriggerReadoutRecord>(config.getParameter<edm::InputTag>("l1Results"))),
-      m_algoPrescales(make_array<double, 128>(config.getParameter<std::vector<double>>("l1AlgoPrescales"))),
-      m_techPrescales(make_array<double, 64>(config.getParameter<std::vector<double>>("l1TechPrescales"))) {
+      m_algoPrescales(config.getParameter<std::array<double, 128>>("l1AlgoPrescales")),
+      m_techPrescales(config.getParameter<std::array<double, 64>>("l1TechPrescales")) {
   m_algoCounters.fill(0);
   m_techCounters.fill(0);
   produces<L1GlobalTriggerReadoutRecord>();

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalPrescaler.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalPrescaler.cc
@@ -8,21 +8,6 @@
 
 #include <fmt/printf.h>
 
-template <class T, std::size_t N>
-std::array<T, N> make_array(std::vector<T> const& values) {
-  assert(N == values.size());
-  std::array<T, N> ret;
-  std::copy(values.begin(), values.end(), ret.begin());
-  return ret;
-}
-
-template <class T>
-bool empty(T const& container) {
-  return container.empty();
-}
-
-bool empty(const char* container) { return container != nullptr; }
-
 using namespace std::literals;
 
 namespace {
@@ -63,12 +48,7 @@ namespace {
   }
 
   template <class T>
-#if __cplusplus > 201400
-  // extended constexpr support in C++14 and later
-  constexpr
-#endif
-      T
-      get_enum_value(Entry<T> const* entries, const char* tag) {
+  constexpr T get_enum_value(Entry<T> const* entries, const char* tag) {
     for (; entries->tag; ++entries)
       if (std::strcmp(entries->tag, tag) == 0)
         return entries->value;
@@ -76,12 +56,7 @@ namespace {
   }
 
   template <class T>
-#if __cplusplus > 201400
-  // extended constexpr support in C++14 and later
-  constexpr
-#endif
-      T
-      get_enum_value(Entry<T> const* entries, const char* tag, T default_value) {
+  constexpr T get_enum_value(Entry<T> const* entries, const char* tag, T default_value) {
     for (; entries->tag; ++entries)
       if (std::strcmp(entries->tag, tag) == 0)
         return entries->value;
@@ -105,22 +80,6 @@ namespace {
 #include "CondFormats/DataRecord/interface/L1TGlobalPrescalesVetosRcd.h"
 #include "CondFormats/L1TObjects/interface/L1TGlobalPrescalesVetos.h"
 #include "DataFormats/L1TGlobal/interface/GlobalAlgBlk.h"
-
-namespace {
-
-  template <typename T, std::size_t N, typename S>
-  std::array<T, N> getParameterArray(edm::ParameterSet const& config, S const& name) {
-    std::vector<T> values = config.getParameter<std::vector<T>>(name);
-    if (values.size() != N)
-      throw edm::Exception(edm::errors::Configuration)
-          << "Parameter \"" << name << "\" should have " << N << " elements.\n"
-          << "The number of elements in the configuration is incorrect.";
-    std::array<T, N> ret;
-    std::copy(values.begin(), values.end(), ret.begin());
-    return ret;
-  }
-
-}  // namespace
 
 class L1TGlobalPrescaler : public edm::one::EDFilter<> {
 public:
@@ -179,8 +138,8 @@ L1TGlobalPrescaler::L1TGlobalPrescaler(edm::ParameterSet const& config)
       m_l1tResultsToken(consumes<GlobalAlgBlkBxCollection>(config.getParameter<edm::InputTag>("l1tResults"))),
       m_l1tPrescales(m_mode == Mode::ApplyPrescaleValues or m_mode == Mode::ApplyPrescaleRatios or
                              m_mode == Mode::ForcePrescaleValues
-                         ? getParameterArray<double, GlobalAlgBlk::maxPhysicsTriggers>(config, "l1tPrescales")
-                         : std::array<double, GlobalAlgBlk::maxPhysicsTriggers>()),
+                         ? config.getParameter<std::array<double, GlobalAlgBlk::maxPhysicsTriggers>>("l1tPrescales")
+                         : std::array<double, GlobalAlgBlk::maxPhysicsTriggers>{}),
       m_l1tPrescaleColumn(m_mode == Mode::ApplyColumnValues or m_mode == Mode::ApplyColumnRatios or
                                   m_mode == Mode::ForceColumnValues
                               ? config.getParameter<uint32_t>("l1tPrescaleColumn")


### PR DESCRIPTION
#### PR description:

Replace user functions with ParameterSet::getParameter<std::array<...>>.
Remove the checks for C++14, and other unused code.

#### PR validation:

Technical, no changes expected.