### PR TITLE
Removed check on PDG code in GenParticleProducer

### DIFF
--- a/PhysicsTools/HepMCCandAlgos/plugins/GenParticleProducer.cc
+++ b/PhysicsTools/HepMCCandAlgos/plugins/GenParticleProducer.cc
@@ -147,7 +147,7 @@ static const double mmToCm = 0.1;
 static const double mmToNs = 1.0 / 299792458e-6;
 
 GenParticleProducer::GenParticleProducer(const ParameterSet& cfg)
-    : abortOnUnknownPDGCode_(cfg.getUntrackedParameter<bool>("abortOnUnknownPDGCode", true)),
+    : abortOnUnknownPDGCode_(false),
       saveBarCodes_(cfg.getUntrackedParameter<bool>("saveBarCodes", false)),
       doSubEvent_(cfg.getUntrackedParameter<bool>("doSubEvent", false)),
       useCF_(cfg.getUntrackedParameter<bool>("useCrossingFrame", false)) {


### PR DESCRIPTION
This a backport of #35262, which addresses the issue #34586.
