### PR TITLE
[MultiTrackValidator] Fix #35225

### DIFF
--- a/Validation/RecoTrack/python/plotting/plotting.py
+++ b/Validation/RecoTrack/python/plotting/plotting.py
@@ -2496,7 +2496,7 @@ class PlotGroup(object):
         # Save the canvas to file and clear
         name = self._name
         if not os.path.exists(directory+'/'+name):
-            os.makedirs(directory+'/'+name)
+            os.makedirs(directory+'/'+name, exist_ok=True)
         if prefix is not None:
             name = prefix+name
         if postfix is not None:

--- a/Validation/RecoTrack/python/plotting/plotting.py
+++ b/Validation/RecoTrack/python/plotting/plotting.py
@@ -49,8 +49,7 @@ def _setStyle():
 def _getObject(tdirectory, name):
     obj = tdirectory.Get(name)
     if not obj:
-        if verbose:
-            print("Did not find {obj} from {dir}".format(obj=name, dir=tdirectory.GetPath()))
+        print("Did not find {obj} from {dir}".format(obj=name, dir=tdirectory.GetPath()))
         return None
     return obj
 
@@ -1073,7 +1072,7 @@ class AggregateBins:
         return result
 
 class AggregateHistos:
-    """Class to create a histogram by aggregaging integrals of another histoggrams."""
+    """Class to create a histogram by aggregating integrals of another histogram."""
     def __init__(self, name, mapping, normalizeTo=None):
         """Constructor.
 
@@ -1935,7 +1934,7 @@ class Plot:
         if self._fallback is not None:
             self._histograms = list(map(_modifyHisto, self._histograms, profileX))
         else:
-            self._histograms =list(map(lambda h: _modifyHisto(h, self._profileX), self._histograms))
+            self._histograms = list(map(lambda h: _modifyHisto(h, self._profileX), self._histograms))
         if requireAllHistograms and None in self._histograms:
             self._histograms = [None]*len(self._histograms)
 

--- a/Validation/RecoTrack/python/plotting/validation.py
+++ b/Validation/RecoTrack/python/plotting/validation.py
@@ -1297,10 +1297,6 @@ class SimpleValidation:
         for tableCreator in plotterFolder.getTableCreators():
             self._htmlReport.addTable(tableCreator.create(self._openFiles, self._labels, dqmSubFolder))
 
-
-        if len(fileList) == 0:
-            return fileList
-
         dups = _findDuplicates(fileList)
         if len(dups) > 0:
             print("Plotter produced multiple files with names", ", ".join(dups))

--- a/Validation/RecoTrack/python/plotting/validation.py
+++ b/Validation/RecoTrack/python/plotting/validation.py
@@ -978,6 +978,7 @@ class Validation:
             refValFile.Close()
 
         if len(fileList) == 0:
+            print("No object found in %s" % plotterFolder.getName())
             return []
 
         dups = _findDuplicates(fileList)
@@ -1044,6 +1045,7 @@ class Validation:
         fastValFile.Close()
 
         if len(fileList) == 0:
+            print("No object found in %s" % plotterFolder.getName())
             return []
 
         dups = _findDuplicates(fileList)
@@ -1111,6 +1113,7 @@ class Validation:
         pu140ValFile.Close()
 
         if len(fileList) == 0:
+            print("No object found in %s" % plotterFolder.getName())
             return []
 
         dups = _findDuplicates(fileList)
@@ -1294,6 +1297,9 @@ class SimpleValidation:
         plotterFolder.create(self._openFiles, self._labels, dqmSubFolder)
         fileList = plotterFolder.draw(directory=newdir, **self._plotterDrawArgs)
 
+        if len(fileList) == 0:
+            print("No object found in %s" % plotterFolder.getName())
+
         for tableCreator in plotterFolder.getTableCreators():
             self._htmlReport.addTable(tableCreator.create(self._openFiles, self._labels, dqmSubFolder))
 
@@ -1361,7 +1367,7 @@ class SeparateValidation:
 
         # check if plots are produced
         if len(fileList) == 0:
-            return fileList
+            print("No object found in %s" % plotterFolder.getName())
 
         # check if there are duplicated plot
         dups = _findDuplicates(fileList)


### PR DESCRIPTION
#### PR description:

This PR fixes a bug introduced with #34954: in case of an empty `PlotterFolder`, the return value of the `SimpleValidation._doPlots` function was different and caused the raise of an Exception.
The warning for a missing object in the `PlotterFolder` is now always printed (not only with the `verbose` option).

#### PR validation:

`makeHGCalValidationPlots.py` and `makeTrackValidationPlots.py`