### PR TITLE
Pileup profile for UL 2017 5TeV

### DIFF
--- a/Configuration/StandardSequences/python/Mixing.py
+++ b/Configuration/StandardSequences/python/Mixing.py
@@ -118,6 +118,7 @@ addMixingScenario("2016_25ns_UltraLegacy_PoissonOOTPU",{'file': 'SimGeneral.Mixi
 addMixingScenario("mix_2016_PoissonOOTPU_HighPUTrains_Fill5412",{'file': 'SimGeneral.MixingModule.mix_2016_PoissonOOTPU_HighPUTrains_Fill5412_cfi'})
 addMixingScenario("2017_25ns_WinterMC_PUScenarioV1_PoissonOOTPU",{'file': 'SimGeneral.MixingModule.mix_2017_25ns_WinterMC_PUScenarioV1_PoissonOOTPU_cfi'})
 addMixingScenario("2017_25ns_UltraLegacy_PoissonOOTPU",{'file': 'SimGeneral.MixingModule.mix_2017_25ns_UltraLegacy_PoissonOOTPU_cfi'})
+addMixingScenario("2017_5TeV_UltraLegacy_PoissonOOTPU",{'file': 'SimGeneral.MixingModule.mix_2017_5TeV_UltraLegacy_PoissonOOTPU_cfi'})
 addMixingScenario("2018_25ns_ProjectedPileup_PoissonOOTPU",{'file': 'SimGeneral.MixingModule.mix_2018_25ns_ProjectedPileup_PoissonOOTPU_cfi'})
 addMixingScenario("2018_25ns_JuneProjectionFull18_PoissonOOTPU",{'file': 'SimGeneral.MixingModule.mix_2018_25ns_JuneProjectionFull18_PoissonOOTPU_cfi'})
 addMixingScenario("2018_25ns_UltraLegacy_PoissonOOTPU",{'file': 'SimGeneral.MixingModule.mix_2018_25ns_UltraLegacy_PoissonOOTPU_cfi'})

--- a/SimGeneral/MixingModule/python/mix_2017_5TeV_UltraLegacy_PoissonOOTPU_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_2017_5TeV_UltraLegacy_PoissonOOTPU_cfi.py
@@ -1,0 +1,17 @@
+import FWCore.ParameterSet.Config as cms
+from SimGeneral.MixingModule.mix_probFunction_25ns_PoissonOOTPU_cfi import *
+mix.input.nbPileupEvents.probFunctionVariable = cms.vint32(
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+    10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+    20, 21, 22, 23, 24, 25, 26, 27, 28
+    )
+
+mix.input.nbPileupEvents.probValue = cms.vdouble(
+    0.191452846727, 0.352881149019, 0.353135299622, 0.100289548466, 0.00224108424297,
+    7.19230424545e-08, 0.0, 0.0, 0.0, 0.0,
+    0.0, 0.0, 0.0, 0.0, 0.0,
+    0.0, 0.0, 0.0, 0.0, 0.0,
+    0.0, 0.0, 0.0, 0.0, 0.0,
+    0.0, 0.0, 0.0, 0.0
+    )
+


### PR DESCRIPTION
Pileup scenario for UL 2017 5 TeV production. Using a min bias cross section of 65 mb and the latest luminosity calibration from LUM-19-001, the luminosity-weighted distribution of bunch-by-bunch pileup is calculated. Some more information and plots [here.](https://indico.cern.ch/event/1077982/#10-pileup-scenario-for-5-tev-2) Needed for this [JIRA ticket](https://its.cern.ch/jira/browse/PDMVMCPROD-34).

Same as PR #35320 but for master.