### PR TITLE
[12_0_X] Protection against missing discriminators for offline taus in L1 DQM

### DIFF
--- a/DQMOffline/L1Trigger/src/L1TTauOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TTauOffline.cc
@@ -704,6 +704,19 @@ void L1TTauOffline::getProbeTaus(const edm::Event& iEvent,
       TLorentzVector mytau;
       mytau.SetPtEtaPhiE(tauIt->pt(), tauIt->eta(), tauIt->phi(), tauIt->energy());
 
+      if ((*antimu)[tauCandidate].workingPoints.empty()) {
+        edm::LogWarning("L1TTauOffline") << "This offline tau has no antimu discriminator, skipping" << std::endl;
+        continue;
+      }
+      if ((*antiele)[tauCandidate].workingPoints.empty()) {
+        edm::LogWarning("L1TTauOffline") << "This offline tau has no antiele discriminator, skipping" << std::endl;
+        continue;
+      }
+      if ((*comb3T)[tauCandidate].workingPoints.empty()) {
+        edm::LogWarning("L1TTauOffline") << "This offline tau has no comb3T discriminator, skipping" << std::endl;
+        continue;
+      }
+
       if (fabs(tauIt->charge()) == 1 && fabs(tauIt->eta()) < 2.1 && tauIt->pt() > 20 &&
           (*antimu)[tauCandidate].workingPoints[AntiMuWPIndex_] &&
           (*antiele)[tauCandidate].workingPoints[AntiEleWPIndex_] && (*dmf)[tauCandidate] > 0.5 &&


### PR DESCRIPTION
#### PR description:

PR description in https://github.com/cms-sw/cmssw/pull/35305
All credit goes to @lathomas (thanks for fixing this so quickly)

Fixes https://github.com/cms-sw/cmssw/issues/35304

Very urgent as it crashes the T0 replay in 12_0_X

#### PR validation:

scramv1 b runtests

Following the recipe in the GitHub issue, the crash does not happen anymore

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of https://github.com/cms-sw/cmssw/pull/35305

cc @lathomas @cms-sw/alca-l2 @germanfgv
