### PR TITLE
Use esConsumes in TSGFromL2Muon

### DIFF
--- a/FastSimulation/Muons/plugins/FastTSGFromL2Muon.cc
+++ b/FastSimulation/Muons/plugins/FastTSGFromL2Muon.cc
@@ -17,7 +17,7 @@
 
 #include <set>
 
-FastTSGFromL2Muon::FastTSGFromL2Muon(const edm::ParameterSet& cfg) : theConfig(cfg) {
+FastTSGFromL2Muon::FastTSGFromL2Muon(const edm::ParameterSet& cfg) {
   produces<L3MuonTrajectorySeedCollection>();
 
   edm::ParameterSet serviceParameters = cfg.getParameter<edm::ParameterSet>("ServiceParameters");
@@ -28,15 +28,14 @@ FastTSGFromL2Muon::FastTSGFromL2Muon(const edm::ParameterSet& cfg) : theConfig(c
   theSeedCollectionLabels = cfg.getParameter<std::vector<edm::InputTag> >("SeedCollectionLabels");
   theSimTrackCollectionLabel = cfg.getParameter<edm::InputTag>("SimTrackCollectionLabel");
   // useTFileService_ = cfg.getUntrackedParameter<bool>("UseTFileService",false);
+  edm::ParameterSet regionBuilderPSet = cfg.getParameter<edm::ParameterSet>("MuonTrackingRegionBuilder");
+  theRegionBuilder = std::make_unique<MuonTrackingRegionBuilder>(regionBuilderPSet, consumesCollector());
 }
 
 FastTSGFromL2Muon::~FastTSGFromL2Muon() {}
 
 void FastTSGFromL2Muon::beginRun(edm::Run const& run, edm::EventSetup const& es) {
   //region builder
-  edm::ParameterSet regionBuilderPSet = theConfig.getParameter<edm::ParameterSet>("MuonTrackingRegionBuilder");
-  edm::ConsumesCollector iC = consumesCollector();
-  theRegionBuilder = new MuonTrackingRegionBuilder(regionBuilderPSet, iC);
 
   /*
   if(useTFileService_) {

--- a/FastSimulation/Muons/plugins/FastTSGFromL2Muon.h
+++ b/FastSimulation/Muons/plugins/FastTSGFromL2Muon.h
@@ -37,7 +37,6 @@ private:
              const SimTrack& theSimTrack);
 
 private:
-  edm::ParameterSet theConfig;
   edm::InputTag theSimTrackCollectionLabel;
   edm::InputTag theL2CollectionLabel;
   std::vector<edm::InputTag> theSeedCollectionLabels;
@@ -46,7 +45,7 @@ private:
 
   MuonServiceProxy* theService;
   double thePtCut;
-  MuonTrackingRegionBuilder* theRegionBuilder;
+  std::unique_ptr<MuonTrackingRegionBuilder> theRegionBuilder;
 
   // TH1F* h_nSeedPerTrack;
   // TH1F* h_nGoodSeedPerTrack;

--- a/FastSimulation/Muons/plugins/FastTSGFromPropagation.h
+++ b/FastSimulation/Muons/plugins/FastTSGFromPropagation.h
@@ -44,6 +44,9 @@ struct TrajectoryStateTransform;
 class SimTrack;
 class TrackerGeometry;
 class TrackerTopology;
+class TransientRecHitRecord;
+class CkfComponentsRecord;
+class TrackerRecoGeometryRecord;
 
 class FastTSGFromPropagation : public TrackerSeedGenerator {
 public:
@@ -123,14 +126,9 @@ private:
     }
   };
 
-  unsigned long long theCacheId_MT;
   unsigned long long theCacheId_TG;
 
   std::string theCategory;
-
-  edm::ESHandle<GeometricSearchTracker> theTracker;
-
-  edm::ESHandle<MeasurementTracker> theMeasTracker;
 
   std::unique_ptr<const DirectTrackerNavigation> theNavigation;
 
@@ -175,6 +173,13 @@ private:
   edm::Handle<FastTrackerRecHitCombinationCollection> recHitCombinations;
   edm::Handle<MeasurementTrackerEvent> theMeasTrackerEvent;
   edm::ESHandle<TransientTrackingRecHitBuilder> theTTRHBuilder;
+
+  //from init
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> theGeometryToken;
+  edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> theTTRHBuilderToken;
+
+  //from setEvent
+  edm::ESGetToken<GeometricSearchTracker, TrackerRecoGeometryRecord> theTrackerToken;
 };
 
 #endif

--- a/RecoMuon/TrackerSeedGenerator/interface/TrackerSeedCleaner.h
+++ b/RecoMuon/TrackerSeedGenerator/interface/TrackerSeedCleaner.h
@@ -16,6 +16,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
 #include "RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h"
+#include "TrackingTools/Records/interface/TransientRecHitRecord.h"
 #include "RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h"
 #include "RecoMuon/TrackerSeedGenerator/interface/RedundantSeedCleaner.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
@@ -47,6 +48,7 @@ public:
     usePt_Cleaner = pset.getParameter<bool>("ptCleaner");
     cleanBySharedHits = pset.getParameter<bool>("cleanerFromSharedHits");
     beamspotToken_ = iC.consumes<reco::BeamSpot>(theBeamSpotTag);
+    theTTRHBuilderToken = iC.esConsumes(edm::ESInputTag("", builderName_));
   }
 
   ///intizialization
@@ -70,6 +72,7 @@ private:
 
   std::string builderName_;
   edm::ESHandle<TransientTrackingRecHitBuilder> theTTRHBuilder;
+  edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> theTTRHBuilderToken;
   bool useDirection_Cleaner, usePt_Cleaner, cleanBySharedHits;
 };
 

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForRoadSearch.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForRoadSearch.cc
@@ -23,7 +23,8 @@
 #include <TrackingTools/KalmanUpdators/interface/KFUpdator.h>
 #include "TrackingTools/GeomPropagators/interface/StateOnTrackerBound.h"
 
-TSGForRoadSearch::TSGForRoadSearch(const edm::ParameterSet &par, edm::ConsumesCollector &iC) {
+TSGForRoadSearch::TSGForRoadSearch(const edm::ParameterSet &par, edm::ConsumesCollector &iC)
+    : theGeometricSearchTrackerToken(iC.esConsumes()) {
   theOption = par.getParameter<unsigned int>("option");
   theCopyMuonRecHit = par.getParameter<bool>("copyMuonRecHit");
 
@@ -69,13 +70,7 @@ void TSGForRoadSearch::init(const MuonServiceProxy *service) { theProxyService =
 
 void TSGForRoadSearch::setEvent(const edm::Event &event) {
   //get the measurementtracker
-  if (theManySeeds) {
-    theProxyService->eventSetup().get<CkfComponentsRecord>().get(theMeasurementTracker);
-    if (!theMeasurementTracker.isValid()) /*abort*/ {
-      edm::LogError(theCategory) << "measurement tracker geometry not found ";
-    }
-  }
-  theProxyService->eventSetup().get<TrackerRecoGeometryRecord>().get(theGeometricSearchTracker);
+  theGeometricSearchTracker = theProxyService->eventSetup().getHandle(theGeometricSearchTrackerToken);
 
   edm::Handle<MeasurementTrackerEvent> data;
   event.getByToken(theMeasurementTrackerEventToken, data);

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForRoadSearch.h
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForRoadSearch.h
@@ -41,6 +41,7 @@ class TrackingRegion;
 class MuonServiceProxy;
 class TrajectoryStateUpdator;
 class TrackerTopology;
+class TrackerRecoGeometryRecord;
 
 class TSGForRoadSearch : public TrackerSeedGenerator {
 public:
@@ -88,8 +89,8 @@ private:
                           std::vector<TrajectorySeed> &result) const;
   edm::ParameterSet theConfig;
 
-  edm::ESHandle<MeasurementTracker> theMeasurementTracker;
   edm::ESHandle<GeometricSearchTracker> theGeometricSearchTracker;
+  edm::ESGetToken<GeometricSearchTracker, TrackerRecoGeometryRecord> theGeometricSearchTrackerToken;
 
   edm::InputTag theMeasurementTrackerEventTag;
   edm::EDGetTokenT<MeasurementTrackerEvent> theMeasurementTrackerEventToken;
@@ -102,9 +103,7 @@ private:
   bool theCopyMuonRecHit;
   bool theManySeeds;
   std::string thePropagatorName;
-  edm::ESHandle<Propagator> theProp;
   std::string thePropagatorCompatibleName;
-  edm::ESHandle<Propagator> thePropCompatible;
   Chi2MeasurementEstimator *theChi2Estimator;
   std::string theCategory;
 

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGFromL2Muon.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGFromL2Muon.cc
@@ -42,6 +42,8 @@ TSGFromL2Muon::TSGFromL2Muon(const edm::ParameterSet& cfg) {
   //L2 collection
   theL2CollectionLabel = cfg.getParameter<edm::InputTag>("MuonCollectionLabel");
   l2muonToken = consumes<reco::TrackCollection>(theL2CollectionLabel);
+
+  theTTopoToken = esConsumes();
 }
 
 TSGFromL2Muon::~TSGFromL2Muon() = default;
@@ -59,9 +61,7 @@ void TSGFromL2Muon::produce(edm::Event& ev, const edm::EventSetup& es) {
   auto result = std::make_unique<L3MuonTrajectorySeedCollection>();
 
   //Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHand;
-  es.get<TrackerTopologyRcd>().get(tTopoHand);
-  const TrackerTopology* tTopo = tTopoHand.product();
+  const TrackerTopology* tTopo = &es.getData(theTTopoToken);
 
   //intialize tools
   theService->update(es);

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGFromL2Muon.h
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGFromL2Muon.h
@@ -17,6 +17,7 @@ class MuonServiceProxy;
 class TrackerSeedGenerator;
 class MuonTrackingRegionBuilder;
 class TrackerSeedCleaner;
+class TrackerTopologyRcd;
 
 //
 // Generate tracker seeds from L2 muons
@@ -37,5 +38,6 @@ private:
   std::unique_ptr<TrackerSeedGenerator> theTkSeedGenerator;
   std::unique_ptr<TrackerSeedCleaner> theSeedCleaner;
   edm::EDGetTokenT<reco::TrackCollection> l2muonToken;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> theTTopoToken;
 };
 #endif

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGFromPropagation.h
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGFromPropagation.h
@@ -29,6 +29,7 @@ class GeometricSearchTracker;
 class DirectTrackerNavigation;
 struct TrajectoryStateTransform;
 class TrackerTopology;
+class TrackerRecoGeometryRecord;
 
 class TSGFromPropagation : public TrackerSeedGenerator {
 public:
@@ -105,15 +106,10 @@ private:
     }
   };
 
-  unsigned long long theCacheId_MT;
   unsigned long long theCacheId_TG;
 
   const std::string theCategory;
 
-  edm::ESHandle<GeometricSearchTracker> theTracker;
-
-  const std::string theMeasTrackerName;
-  edm::ESHandle<MeasurementTracker> theMeasTracker;
   edm::Handle<MeasurementTrackerEvent> theMeasTrackerEvent;
 
   std::unique_ptr<const DirectTrackerNavigation> theNavigation;
@@ -150,6 +146,7 @@ private:
   edm::Handle<reco::BeamSpot> beamSpot;
   const edm::EDGetTokenT<reco::BeamSpot> theBeamSpotToken;
   const edm::EDGetTokenT<MeasurementTrackerEvent> theMeasurementTrackerEventToken;
+  const edm::ESGetToken<GeometricSearchTracker, TrackerRecoGeometryRecord> theTrackerToken;
 };
 
 #endif

--- a/RecoMuon/TrackerSeedGenerator/src/TrackerSeedCleaner.cc
+++ b/RecoMuon/TrackerSeedGenerator/src/TrackerSeedCleaner.cc
@@ -31,8 +31,6 @@
 #include "RecoTracker/TkMSParametrization/interface/PixelRecoRange.h"
 
 #include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
-#include "RecoMuon/TrackerSeedGenerator/interface/TrackerSeedGenerator.h"
-#include "RecoMuon/TrackerSeedGenerator/interface/TrackerSeedGeneratorFactory.h"
 
 using namespace std;
 using namespace edm;

--- a/RecoMuon/TrackerSeedGenerator/src/TrackerSeedCleaner.cc
+++ b/RecoMuon/TrackerSeedGenerator/src/TrackerSeedCleaner.cc
@@ -24,7 +24,6 @@
 
 #include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
 #include "TrackingTools/PatternTools/interface/TSCBLBuilderNoMaterial.h"
-#include "TrackingTools/Records/interface/TransientRecHitRecord.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
 #include "RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h"
 #include "RecoTracker/TkTrackingRegions/interface/TkTrackingRegionsMargin.h"
@@ -59,7 +58,7 @@ void TrackerSeedCleaner::clean(const reco::TrackRef& muR,
   if (cleanBySharedHits)
     theRedundantCleaner->define(seeds);
 
-  theProxyService->eventSetup().get<TransientRecHitRecord>().get(builderName_, theTTRHBuilder);
+  theTTRHBuilder = theProxyService->eventSetup().getHandle(theTTRHBuilderToken);
 
   LogDebug("TrackerSeedCleaner") << seeds.size() << " trajectory seeds to the events before cleaning" << endl;
 


### PR DESCRIPTION
#### PR description:

- Add esConsumes directly in TSGFromL2Muon
- Helper classes used by TSGFromL2Muon expanded to use esConsumes

#### PR validation:

Code compiles.