### PR TITLE
Add logic in OnlineBeamSpotESProducer

### DIFF
--- a/RecoVertex/BeamSpotProducer/plugins/OnlineBeamSpotESProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/OnlineBeamSpotESProducer.cc
@@ -37,15 +37,14 @@ private:
   edm::ESGetToken<BeamSpotOnlineObjects, BeamSpotOnlineLegacyObjectsRcd> bsLegacyToken_;
 
   BeamSpotObjects fakeBS_;
-  int timeThreshold_;
-  double sigmaZThreshold_;
+  const int timeThreshold_;
+  const double sigmaZThreshold_;
 };
 
-OnlineBeamSpotESProducer::OnlineBeamSpotESProducer(const edm::ParameterSet& p) {
-  // get parameters
-  timeThreshold_ = p.getParameter<int>("timeThreshold");
-  sigmaZThreshold_ = p.getParameter<double>("sigmaZThreshold");
-
+OnlineBeamSpotESProducer::OnlineBeamSpotESProducer(const edm::ParameterSet& p)
+    // get parameters
+    : timeThreshold_(p.getParameter<int>("timeThreshold")),
+      sigmaZThreshold_(p.getParameter<double>("sigmaZThreshold")) {
   auto cc = setWhatProduced(this);
 
   fakeBS_.SetBeamWidthX(0.1);
@@ -60,8 +59,8 @@ OnlineBeamSpotESProducer::OnlineBeamSpotESProducer(const edm::ParameterSet& p) {
 
 void OnlineBeamSpotESProducer::fillDescriptions(edm::ConfigurationDescriptions& desc) {
   edm::ParameterSetDescription dsc;
-  dsc.add<int>("timeThreshold", 48);       // hours
-  dsc.add<double>("sigmaZThreshold", 2.);  // cm
+  dsc.add<int>("timeThreshold", 48)->setComment("hours");
+  dsc.add<double>("sigmaZThreshold", 2.)->setComment("cm");
   desc.addWithDefaultLabel(dsc);
 }
 

--- a/RecoVertex/BeamSpotProducer/python/BeamSpotOnline_cff.py
+++ b/RecoVertex/BeamSpotProducer/python/BeamSpotOnline_cff.py
@@ -3,10 +3,8 @@ import FWCore.ParameterSet.Config as cms
 from RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi import *
 
 #scalers = cms.EDProducer('ScalersRawToDigi')
-BeamSpotESProducer = cms.ESProducer("OnlineBeamSpotESProducer",
-                                    timeThreshold = cms.int32(48),
-                                    sigmaZThreshold = cms.double(2.0)
-                                   )
+import RecoVertex.BeamSpotProducer.onlineBeamSpotESProducer_cfi as _mod
+BeamSpotESProducer = _mod.onlineBeamSpotESProducer.clone()
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify(onlineBeamSpotProducer, useTransientRecord = True)

--- a/RecoVertex/BeamSpotProducer/python/BeamSpotOnline_cff.py
+++ b/RecoVertex/BeamSpotProducer/python/BeamSpotOnline_cff.py
@@ -3,7 +3,10 @@ import FWCore.ParameterSet.Config as cms
 from RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi import *
 
 #scalers = cms.EDProducer('ScalersRawToDigi')
-BeamSpotESProducer = cms.ESProducer("OnlineBeamSpotESProducer")
+BeamSpotESProducer = cms.ESProducer("OnlineBeamSpotESProducer",
+                                    timeThreshold = cms.int32(48),
+                                    sigmaZThreshold = cms.double(2.0)
+                                   )
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify(onlineBeamSpotProducer, useTransientRecord = True)

--- a/RecoVertex/BeamSpotProducer/test/test_onlineBeamSpotESProducer.py
+++ b/RecoVertex/BeamSpotProducer/test/test_onlineBeamSpotESProducer.py
@@ -44,8 +44,6 @@ process.MessageLogger = cms.Service("MessageLogger",
     )
 )
 
-process.scalersRawToDigi = cms.EDProducer('ScalersRawToDigi')
-
 process.load("RecoVertex.BeamSpotProducer.BeamSpotOnline_cff")
 #process.onlineBeamSpotProducer.useTransientRecord = cms.bool(False)
 
@@ -56,7 +54,6 @@ process.out = cms.OutputModule( "PoolOutputModule",
     )
                                 )
 
-process.dtRawDump = cms.Path(process.scalersRawToDigi + process.onlineBeamSpot )
-#process.dtRawDump = cms.Path( process.onlineBeamSpot )
+process.dtRawDump = cms.Path( process.onlineBeamSpot )
 
 process.e = cms.EndPath( process.out )

--- a/RecoVertex/BeamSpotProducer/test/test_scalars.py
+++ b/RecoVertex/BeamSpotProducer/test/test_scalars.py
@@ -5,8 +5,8 @@ process = cms.Process("DumpDTRaw",Run3)
 
 process.source = cms.Source("PoolSource",
                             fileNames = cms.untracked.vstring(
-    "file:/eos/cms/store/data/Commissioning2021/Cosmics/RAW/v1/000/342/218/00000/fdaf9009-dfd8-4774-9246-556088e65e9b.root",
-    "file:/eos/cms/store/data/Commissioning2021/Cosmics/RAW/v1/000/342/094/00000/7e88d2e8-6632-40f0-a1ca-4350adf60182.root"
+    "file:/eos/cms/store/data/Commissioning2021/Cosmics/RAW/v1/000/344/518/00000/00130ffc-3e69-4106-8151-c69dd735ee2e.root",
+    "file:/eos/cms/store/data/Commissioning2021/Cosmics/RAW/v1/000/344/518/00000/001d10b6-a19e-4889-ba07-88f8f6b17bc7.root"
     ),
                             skipEvents = cms.untracked.uint32(0) )
 
@@ -17,31 +17,23 @@ process.source = cms.Source("PoolSource",
 
 process.maxEvents = cms.untracked.PSet(
         input = cms.untracked.int32(-1)
-)        
-process.load("CondCore.DBCommon.CondDBSetup_cfi")
+)
+process.load("CondCore.CondDB.CondDB_cfi")
 
 from Configuration.AlCa.GlobalTag import GlobalTag as customiseGlobalTag
 process.GlobalTag = customiseGlobalTag(globaltag = "auto:run3_hlt_GRun")
- 
-process.BeamSpotDBSource = cms.ESSource("PoolDBESSource",
-                                        process.CondDBSetup,
-                                        toGet = cms.VPSet(
-                                            cms.PSet(
-                                                record = cms.string('BeamSpotOnlineLegacyObjectsRcd'),
-                                                tag = cms.string("BeamSpotOnlineTestLegacy"),
-                                                refreshTime = cms.uint64(1)
 
-                                            ),
-                                            cms.PSet(
-                                                record = cms.string('BeamSpotOnlineHLTObjectsRcd'),
-                                                tag = cms.string('BeamSpotOnlineTestHLT'),
-                                                refreshTime = cms.uint64(1)
-                                               )
-
-                                ),
-                                        #connect = cms.string('oracle://cms_orcon_prod/CMS_CONDITIONS')
-                                        connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS')
+process.GlobalTag.toGet = cms.VPSet(
+  cms.PSet(
+    record = cms.string("BeamSpotOnlineLegacyObjectsRcd"),
+    refreshTime = cms.uint64(1)
+  ),
+  cms.PSet(
+    record = cms.string("BeamSpotOnlineHLTObjectsRcd"),
+    refreshTime = cms.uint64(1)
+  )
 )
+
 process.MessageLogger = cms.Service("MessageLogger",
     cerr = cms.untracked.PSet(
         enable = cms.untracked.bool(False)


### PR DESCRIPTION
#### PR description:
This PR adds a real logic in `OnlineBeamSpotESProducer` to discriminate between the two different BeamSpot workflows.
The logic is based on two parameters `timeThreshold` (hours) and `sigmaZThreshold` (cm) which are both configurable.
The logic is the following:
1. If both BeamSpots are older than the `timeThreshold` (by default `48 hours`) retuns a fake BeamSpot
2. If one one of the two BeamSpots is newer than then `timeThreshold` returns it only if it the fit converged 
  (has `BeamType == 2`) and sigmaZ is larger than the threshold (by default `2 cm`)
3. If both BeamSpots are newer  than the `timeThreshold` returns the one that converges and has larger sigmaZ 

The checks on sigmaZ, on the creation time and on the convergence of the fit are also applied to the cases where the ESProducer was able to fetch from the DB only one of the two BeamSpot payloads.

The test `RecoVertex/BeamSpotProducer/test/test_scalars.py` was also updated to use a file available on eos and to comply with the changes made in #34348 (inclusion of the BS online tags in the GTs).

#### PR validation:
Tested locally using `RecoVertex/BeamSpotProducer/test/test_scalars.py`.

#### Backport
A backport to 12_0_X is provided in #35334

FYI @gennai @dzuolo