### PR TITLE
GEM in DCS HV bits

### DIFF
--- a/DQMServices/Components/plugins/DQMProvInfo.cc
+++ b/DQMServices/Components/plugins/DQMProvInfo.cc
@@ -174,6 +174,8 @@ void DQMProvInfo::bookHistogramsEventInfo(DQMStore::IBooker& iBooker) {
   reportSummaryMap_->setBinLabel(VBIN_TE_M, "TECm", 2);
   reportSummaryMap_->setBinLabel(VBIN_CASTOR, "CASTOR", 2);
   reportSummaryMap_->setBinLabel(VBIN_ZDC, "ZDC", 2);
+  reportSummaryMap_->setBinLabel(VBIN_GEM_P, "GEM+", 2);
+  reportSummaryMap_->setBinLabel(VBIN_GEM_M, "GEM-", 2);
   reportSummaryMap_->setBinLabel(VBIN_PHYSICS_DECLARED, "PhysDecl", 2);
   reportSummaryMap_->setBinLabel(VBIN_MOMENTUM, "13 TeV", 2);
   reportSummaryMap_->setBinLabel(VBIN_STABLE_BEAM, "Stable B", 2);
@@ -361,6 +363,8 @@ void DQMProvInfo::fillDcsBitsFromDCSRecord(const DCSRecord& dcsRecord, bool* dcs
   dcsBits[VBIN_TE_M] = dcsRecord.highVoltageReady(DCSRecord::Partition::TECm);
   dcsBits[VBIN_CASTOR] = dcsRecord.highVoltageReady(DCSRecord::Partition::CASTOR);
   dcsBits[VBIN_ZDC] = dcsRecord.highVoltageReady(DCSRecord::Partition::ZDC);
+  dcsBits[VBIN_GEM_P] = dcsRecord.highVoltageReady(DCSRecord::Partition::GEMp);
+  dcsBits[VBIN_GEM_M] = dcsRecord.highVoltageReady(DCSRecord::Partition::GEMm);
 }
 
 void DQMProvInfo::fillDcsBitsFromDcsStatusCollection(const edm::Handle<DcsStatusCollection>& dcsStatusCollection,
@@ -402,6 +406,8 @@ void DQMProvInfo::fillDcsBitsFromDcsStatusCollection(const edm::Handle<DcsStatus
     dcsBits[VBIN_TE_M] &= dcsStatusItr.ready(DcsStatus::TECm);
     dcsBits[VBIN_CASTOR] &= dcsStatusItr.ready(DcsStatus::CASTOR);
     dcsBits[VBIN_ZDC] &= dcsStatusItr.ready(DcsStatus::ZDC);
+    //dcsBits[VBIN_GEM_P] &= dcsStatusItr.ready(DcsStatus::GEMp);  // GEMp and GEMm are not implemented
+    //dcsBits[VBIN_GEM_M] &= dcsStatusItr.ready(DcsStatus::GEMm);
 
     // Some info-level logging
     edm::LogInfo("DQMProvInfo") << "DCS status: 0x" << std::hex << dcsStatusItr.ready() << std::dec << std::endl;
@@ -420,7 +426,7 @@ bool DQMProvInfo::isPhysicsDeclared(bool* dcsBits) {
          (dcsBits[VBIN_BPIX] && dcsBits[VBIN_FPIX] && dcsBits[VBIN_TIBTID] && dcsBits[VBIN_TOB] &&
           dcsBits[VBIN_TEC_P] && dcsBits[VBIN_TE_M]) &&
          (dcsBits[VBIN_CSC_P] || dcsBits[VBIN_CSC_M] || dcsBits[VBIN_DT_0] || dcsBits[VBIN_DT_P] ||
-          dcsBits[VBIN_DT_M] || dcsBits[VBIN_RPC]);
+          dcsBits[VBIN_DT_M] || dcsBits[VBIN_RPC] || dcsBits[VBIN_GEM_P] || dcsBits[VBIN_GEM_M]);
 }
 
 void DQMProvInfo::blankAllLumiSections() {

--- a/DQMServices/Components/plugins/DQMProvInfo.cc
+++ b/DQMServices/Components/plugins/DQMProvInfo.cc
@@ -174,8 +174,8 @@ void DQMProvInfo::bookHistogramsEventInfo(DQMStore::IBooker& iBooker) {
   reportSummaryMap_->setBinLabel(VBIN_TE_M, "TECm", 2);
   reportSummaryMap_->setBinLabel(VBIN_CASTOR, "CASTOR", 2);
   reportSummaryMap_->setBinLabel(VBIN_ZDC, "ZDC", 2);
-  reportSummaryMap_->setBinLabel(VBIN_GEM_P, "GEM+", 2);
-  reportSummaryMap_->setBinLabel(VBIN_GEM_M, "GEM-", 2);
+  reportSummaryMap_->setBinLabel(VBIN_GEM_P, "GEMp", 2);
+  reportSummaryMap_->setBinLabel(VBIN_GEM_M, "GEMm", 2);
   reportSummaryMap_->setBinLabel(VBIN_PHYSICS_DECLARED, "PhysDecl", 2);
   reportSummaryMap_->setBinLabel(VBIN_MOMENTUM, "13 TeV", 2);
   reportSummaryMap_->setBinLabel(VBIN_STABLE_BEAM, "Stable B", 2);

--- a/DQMServices/Components/plugins/DQMProvInfo.h
+++ b/DQMServices/Components/plugins/DQMProvInfo.h
@@ -78,18 +78,20 @@ private:
   const static int VBIN_TE_M = 23;
   const static int VBIN_CASTOR = 24;
   const static int VBIN_ZDC = 25;
+  const static int VBIN_GEM_P = 26;
+  const static int VBIN_GEM_M = 27;
 
   // Highest DCS bin, used for the length of the corresponding array.
   // We will have the indexes to this array the same as the vbins numbers.
   // (I.e. value at index 0 will not be used.)
-  const static int MAX_DCS_VBINS = 25;
+  const static int MAX_DCS_VBINS = 27;
 
-  const static int VBIN_PHYSICS_DECLARED = 26;
-  const static int VBIN_MOMENTUM = 27;
-  const static int VBIN_STABLE_BEAM = 28;
-  const static int VBIN_VALID = 29;
+  const static int VBIN_PHYSICS_DECLARED = 28;
+  const static int VBIN_MOMENTUM = 29;
+  const static int VBIN_STABLE_BEAM = 30;
+  const static int VBIN_VALID = 31;
 
-  const static int MAX_VBINS = 29;
+  const static int MAX_VBINS = 31;
 
   // Beam momentum at flat top, used to determine if collisions are
   // occurring with the beams at the energy allowed for physics production.

--- a/DataFormats/OnlineMetaData/src/DCSRecord.cc
+++ b/DataFormats/OnlineMetaData/src/DCSRecord.cc
@@ -6,7 +6,7 @@
 
 const DCSRecord::ParitionNames DCSRecord::partitionNames_ = {
     {"EBp",  "EBm",    "EEp", "EEm",    "HBHEa", "HBHEb", "HBHEc", "HF",   "HO",   "RPC", "DT0", "DTp",  "DTm", "CSCp",
-     "CSCm", "CASTOR", "ZDC", "TIBTID", "TOB",   "TECp",  "TECm",  "BPIX", "FPIX", "ESp", "ESm", "GEMm", "GEMp"}};
+     "CSCm", "CASTOR", "ZDC", "TIBTID", "TOB",   "TECp",  "TECm",  "BPIX", "FPIX", "ESp", "ESm", "GEMp", "GEMm"}};
 
 DCSRecord::DCSRecord() : timestamp_(edm::Timestamp::invalidTimestamp()), magnetCurrent_(-1) {}
 


### PR DESCRIPTION
#### PR description:
This PR adds rows for GEM systems in the DCS HV onlineDQM plot. Only inputs from softFED(1022) are equipped, while the input from FED735 is not realized since there are no GEM bits in SCAL system.

#### PR validation:
Test are done and one can check again by `runTheMatrix` workflows

@jshlee @watson-ij 