### PR TITLE
esConsumes migration of CalibMuon/DTCalibration

### DIFF
--- a/CalibMuon/DTCalibration/plugins/DTFakeT0ESProducer.cc
+++ b/CalibMuon/DTCalibration/plugins/DTFakeT0ESProducer.cc
@@ -61,7 +61,6 @@ std::unique_ptr<DTT0> DTFakeT0ESProducer::produce(const DTT0Rcd& iRecord) {
 }
 
 void DTFakeT0ESProducer::parseDDD(const DTT0Rcd& iRecord) {
-
   edm::ESTransientHandle<DDCompactView> cpv = iRecord.getTransientHandle(cpvTokenDDD_);
   const auto& mdc = iRecord.get(mdcToken_);
 

--- a/CalibMuon/DTCalibration/plugins/DTFakeT0ESProducer.cc
+++ b/CalibMuon/DTCalibration/plugins/DTFakeT0ESProducer.cc
@@ -27,13 +27,15 @@ using namespace std;
 
 DTFakeT0ESProducer::DTFakeT0ESProducer(const edm::ParameterSet& pset) {
   //framework
-  setWhatProduced(this, &DTFakeT0ESProducer::produce);
+  auto cc = setWhatProduced(this, &DTFakeT0ESProducer::produce);
   //  setWhatProduced(this,dependsOn(& DTGeometryESModule::parseDDD()));
   findingRecord<DTT0Rcd>();
 
   //read constant value for t0 from cfg
   t0Mean = pset.getParameter<double>("t0Mean");
   t0Sigma = pset.getParameter<double>("t0Sigma");
+  cpvTokenDDD_ = cc.consumesFrom<DDCompactView, IdealGeometryRecord>(edm::ESInputTag());
+  mdcToken_ = cc.consumes();
 }
 
 DTFakeT0ESProducer::~DTFakeT0ESProducer() {}
@@ -59,13 +61,11 @@ std::unique_ptr<DTT0> DTFakeT0ESProducer::produce(const DTT0Rcd& iRecord) {
 }
 
 void DTFakeT0ESProducer::parseDDD(const DTT0Rcd& iRecord) {
-  edm::ESTransientHandle<DDCompactView> cpv;
-  edm::ESHandle<MuonGeometryConstants> mdc;
 
-  iRecord.getRecord<IdealGeometryRecord>().get(cpv);
-  iRecord.getRecord<IdealGeometryRecord>().get(mdc);
+  edm::ESTransientHandle<DDCompactView> cpv = iRecord.getTransientHandle(cpvTokenDDD_);
+  const auto& mdc = iRecord.get(mdcToken_);
 
-  DTGeometryParserFromDDD parser(&(*cpv), *mdc, theLayerIdWiresMap);
+  DTGeometryParserFromDDD parser(&(*cpv), mdc, theLayerIdWiresMap);
 }
 
 void DTFakeT0ESProducer::setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,

--- a/CalibMuon/DTCalibration/plugins/DTFakeT0ESProducer.h
+++ b/CalibMuon/DTCalibration/plugins/DTFakeT0ESProducer.h
@@ -57,6 +57,5 @@ private:
 
   edm::ESGetToken<DDCompactView, IdealGeometryRecord> cpvTokenDDD_;
   edm::ESGetToken<MuonGeometryConstants, IdealGeometryRecord> mdcToken_;
-
 };
 #endif

--- a/CalibMuon/DTCalibration/plugins/DTFakeT0ESProducer.h
+++ b/CalibMuon/DTCalibration/plugins/DTFakeT0ESProducer.h
@@ -21,6 +21,12 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DetectorDescription/Core/interface/DDCompactView.h"
+#include "DetectorDescription/DDCMS/interface/DDCompactView.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "Geometry/MuonNumbering/interface/MuonGeometryConstants.h"
+
 //#include <pair>
 #include <map>
 
@@ -48,5 +54,9 @@ private:
   //t0 mean and sigma values read from cfg
   double t0Mean;
   double t0Sigma;
+
+  edm::ESGetToken<DDCompactView, IdealGeometryRecord> cpvTokenDDD_;
+  edm::ESGetToken<MuonGeometryConstants, IdealGeometryRecord> mdcToken_;
+
 };
 #endif

--- a/CalibMuon/DTCalibration/plugins/DTNoiseCalibration.cc
+++ b/CalibMuon/DTCalibration/plugins/DTNoiseCalibration.cc
@@ -51,7 +51,9 @@ DTNoiseCalibration::DTNoiseCalibration(const edm::ParameterSet& pset)
       dbLabel_(pset.getUntrackedParameter<string>("dbLabel", "")),
       //fastAnalysis_( pset.getParameter<bool>("fastAnalysis", true) ),
       wireIdWithHisto_(std::vector<DTWireId>()),
-      lumiMax_(3000) {
+      lumiMax_(3000), 
+      dtGeomToken_(esConsumes()),
+      ttrigToken_(esConsumes(edm::ESInputTag("", pset.getParameter<string>("dbLabel")))) {
   // Get the debug parameter for verbose output
   //debug = ps.getUntrackedParameter<bool>("debug");
   /*// The analysis type
@@ -96,12 +98,10 @@ void DTNoiseCalibration::beginJob() {
 
 void DTNoiseCalibration::beginRun(const edm::Run& run, const edm::EventSetup& setup) {
   // Get the DT Geometry
-  setup.get<MuonGeometryRecord>().get(dtGeom_);
-
+  dtGeom_ = setup.getHandle(dtGeomToken_);
   // tTrig
   if (readDB_)
-    setup.get<DTTtrigRcd>().get(dbLabel_, tTrigMap_);
-
+    tTrigMap_ = &setup.getData(ttrigToken_);
   runBeginTime_ = time_t(run.beginTime().value() >> 32);
   runEndTime_ = time_t(run.endTime().value() >> 32);
   /*

--- a/CalibMuon/DTCalibration/plugins/DTNoiseCalibration.cc
+++ b/CalibMuon/DTCalibration/plugins/DTNoiseCalibration.cc
@@ -51,7 +51,7 @@ DTNoiseCalibration::DTNoiseCalibration(const edm::ParameterSet& pset)
       dbLabel_(pset.getUntrackedParameter<string>("dbLabel", "")),
       //fastAnalysis_( pset.getParameter<bool>("fastAnalysis", true) ),
       wireIdWithHisto_(std::vector<DTWireId>()),
-      lumiMax_(3000), 
+      lumiMax_(3000),
       dtGeomToken_(esConsumes()),
       ttrigToken_(esConsumes(edm::ESInputTag("", pset.getParameter<string>("dbLabel")))) {
   // Get the debug parameter for verbose output

--- a/CalibMuon/DTCalibration/plugins/DTNoiseCalibration.h
+++ b/CalibMuon/DTCalibration/plugins/DTNoiseCalibration.h
@@ -12,6 +12,8 @@
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "CondFormats/DataRecord/interface/DTTtrigRcd.h"
 
 #include <string>
 #include <vector>
@@ -74,8 +76,11 @@ private:
 
   // Get the DT Geometry
   edm::ESHandle<DTGeometry> dtGeom_;
+  const edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomToken_;
+
   // tTrig map
   edm::ESHandle<DTTtrig> tTrigMap_;
+  const edm::ESGetToken<DTTtrig, DTTtrigRcd> ttrigToken_;
 
   TFile* rootFile_;
   // TDC digi distribution

--- a/CalibMuon/DTCalibration/plugins/DTNoiseComputation.cc
+++ b/CalibMuon/DTCalibration/plugins/DTNoiseComputation.cc
@@ -38,7 +38,8 @@
 using namespace edm;
 using namespace std;
 
-DTNoiseComputation::DTNoiseComputation(const edm::ParameterSet &ps) {
+DTNoiseComputation::DTNoiseComputation(const edm::ParameterSet &ps) :
+  dtGeomToken_(esConsumes()) {
   cout << "[DTNoiseComputation]: Constructor" << endl;
 
   // Get the debug parameter for verbose output
@@ -61,7 +62,7 @@ DTNoiseComputation::DTNoiseComputation(const edm::ParameterSet &ps) {
 
 void DTNoiseComputation::beginRun(const edm::Run &, const EventSetup &setup) {
   // Get the DT Geometry
-  setup.get<MuonGeometryRecord>().get(dtGeom);
+  dtGeom = setup.getHandle(dtGeomToken_);
 
   static int count = 0;
 

--- a/CalibMuon/DTCalibration/plugins/DTNoiseComputation.cc
+++ b/CalibMuon/DTCalibration/plugins/DTNoiseComputation.cc
@@ -38,8 +38,7 @@
 using namespace edm;
 using namespace std;
 
-DTNoiseComputation::DTNoiseComputation(const edm::ParameterSet &ps) :
-  dtGeomToken_(esConsumes()) {
+DTNoiseComputation::DTNoiseComputation(const edm::ParameterSet &ps) : dtGeomToken_(esConsumes()) {
   cout << "[DTNoiseComputation]: Constructor" << endl;
 
   // Get the debug parameter for verbose output

--- a/CalibMuon/DTCalibration/plugins/DTNoiseComputation.h
+++ b/CalibMuon/DTCalibration/plugins/DTNoiseComputation.h
@@ -14,6 +14,7 @@
 #include "DataFormats/MuonDetId/interface/DTWireId.h"
 #include "DataFormats/MuonDetId/interface/DTChamberId.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 
 #include <string>
 #include <map>
@@ -57,6 +58,7 @@ private:
 
   // Get the DT Geometry
   edm::ESHandle<DTGeometry> dtGeom;
+  const edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomToken_;
 
   // The file which contain the occupancy plot and the digi event plot
   TFile* theFile;

--- a/CalibMuon/DTCalibration/plugins/DTResidualCalibration.cc
+++ b/CalibMuon/DTCalibration/plugins/DTResidualCalibration.cc
@@ -64,8 +64,8 @@ void DTResidualCalibration::beginJob() { TH1::SetDefaultSumw2(true); }
 void DTResidualCalibration::beginRun(const edm::Run& run, const edm::EventSetup& setup) {
   // get the geometry
   edm::ESHandle<DTGeometry> dtGeomH;
-   dtGeomH = setup.getHandle(dtGeomToken_);
-   dtGeom_ = dtGeomH.product();
+  dtGeomH = setup.getHandle(dtGeomToken_);
+  dtGeom_ = dtGeomH.product();
 
   // Loop over all the chambers
   if (histoMapTH1F_.empty()) {

--- a/CalibMuon/DTCalibration/plugins/DTResidualCalibration.cc
+++ b/CalibMuon/DTCalibration/plugins/DTResidualCalibration.cc
@@ -35,7 +35,8 @@ DTResidualCalibration::DTResidualCalibration(const edm::ParameterSet& pset)
     : histRange_(pset.getParameter<double>("histogramRange")),
       segment4DLabel_(pset.getParameter<edm::InputTag>("segment4DLabel")),
       rootBaseDir_(pset.getUntrackedParameter<std::string>("rootBaseDir", "DT/Residuals")),
-      detailedAnalysis_(pset.getUntrackedParameter<bool>("detailedAnalysis", false)) {
+      detailedAnalysis_(pset.getUntrackedParameter<bool>("detailedAnalysis", false)),
+      dtGeomToken_(esConsumes()) {
   edm::ConsumesCollector collector(consumesCollector());
   select_ = new DTSegmentSelector(pset, collector);
 
@@ -63,8 +64,8 @@ void DTResidualCalibration::beginJob() { TH1::SetDefaultSumw2(true); }
 void DTResidualCalibration::beginRun(const edm::Run& run, const edm::EventSetup& setup) {
   // get the geometry
   edm::ESHandle<DTGeometry> dtGeomH;
-  setup.get<MuonGeometryRecord>().get(dtGeomH);
-  dtGeom_ = dtGeomH.product();
+   dtGeomH = setup.getHandle(dtGeomToken_);
+   dtGeom_ = dtGeomH.product();
 
   // Loop over all the chambers
   if (histoMapTH1F_.empty()) {

--- a/CalibMuon/DTCalibration/plugins/DTResidualCalibration.h
+++ b/CalibMuon/DTCalibration/plugins/DTResidualCalibration.h
@@ -13,6 +13,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 
 #include "CalibMuon/DTCalibration/interface/DTSegmentSelector.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 
 #include <string>
 #include <vector>
@@ -59,6 +60,8 @@ private:
   TFile* rootFile_;
   // Geometry
   const DTGeometry* dtGeom_;
+  const edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomToken_;
+
   // Histograms per super-layer
   std::map<DTSuperLayerId, TH1F*> histoMapTH1F_;
   std::map<DTSuperLayerId, TH2F*> histoMapTH2F_;

--- a/CalibMuon/DTCalibration/plugins/DTT0Calibration.cc
+++ b/CalibMuon/DTCalibration/plugins/DTT0Calibration.cc
@@ -43,8 +43,7 @@ DTT0Calibration::DTT0Calibration(const edm::ParameterSet& pset)
       rejectDigiFromPeak(pset.getParameter<unsigned int>("rejectDigiFromPeak")),
       hLayerPeaks("hLayerPeaks", "", 3000, 0, 3000),
       spectrum(20),
-      dtGeomToken_(esConsumes())
-{
+      dtGeomToken_(esConsumes()) {
   // Get the debug parameter for verbose output
   if (debug)
     cout << "[DTT0Calibration]Constructor called!" << endl;

--- a/CalibMuon/DTCalibration/plugins/DTT0Calibration.cc
+++ b/CalibMuon/DTCalibration/plugins/DTT0Calibration.cc
@@ -42,8 +42,8 @@ DTT0Calibration::DTT0Calibration(const edm::ParameterSet& pset)
       tpPeakWidthPerLayer(pset.getParameter<double>("tpPeakWidthPerLayer")),
       rejectDigiFromPeak(pset.getParameter<unsigned int>("rejectDigiFromPeak")),
       hLayerPeaks("hLayerPeaks", "", 3000, 0, 3000),
-      spectrum(20)
-
+      spectrum(20),
+      dtGeomToken_(esConsumes())
 {
   // Get the debug parameter for verbose output
   if (debug)
@@ -99,7 +99,7 @@ void DTT0Calibration::analyze(const edm::Event& event, const edm::EventSetup& ev
 
   // Get the DT Geometry
   if (nevents == 1)
-    eventSetup.get<MuonGeometryRecord>().get(dtGeom);
+    dtGeom = eventSetup.getHandle(dtGeomToken_);
 
   // Iterate through all digi collections ordered by LayerId
   for (const auto& digis_per_layer : *digis) {

--- a/CalibMuon/DTCalibration/plugins/DTT0Calibration.h
+++ b/CalibMuon/DTCalibration/plugins/DTT0Calibration.h
@@ -17,6 +17,7 @@
 #include "DataFormats/MuonDetId/interface/DTWireId.h"
 #include "DataFormats/DTDigi/interface/DTDigiCollection.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 
 #include <string>
 #include <vector>
@@ -122,5 +123,6 @@ private:
 
   //DTGeometry used to loop on the SL in the endJob
   edm::ESHandle<DTGeometry> dtGeom;
+  const edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomToken_;
 };
 #endif

--- a/CalibMuon/DTCalibration/plugins/DTT0CalibrationRMS.cc
+++ b/CalibMuon/DTCalibration/plugins/DTT0CalibrationRMS.cc
@@ -24,7 +24,8 @@ using namespace edm;
 // using namespace cond;
 
 // Constructor
-DTT0CalibrationRMS::DTT0CalibrationRMS(const edm::ParameterSet& pset) {
+DTT0CalibrationRMS::DTT0CalibrationRMS(const edm::ParameterSet& pset) : 
+  dtGeomToken_(esConsumes()) {
   // Get the debug parameter for verbose output
   debug = pset.getUntrackedParameter<bool>("debug");
   if (debug)
@@ -102,7 +103,7 @@ void DTT0CalibrationRMS::analyze(const edm::Event& event, const edm::EventSetup&
   event.getByLabel(digiLabel, digis);
 
   // Get the DT Geometry
-  eventSetup.get<MuonGeometryRecord>().get(dtGeom);
+  dtGeom = eventSetup.getHandle(dtGeomToken_);
 
   // Iterate through all digi collections ordered by LayerId
   DTDigiCollection::DigiRangeIterator dtLayerIt;

--- a/CalibMuon/DTCalibration/plugins/DTT0CalibrationRMS.cc
+++ b/CalibMuon/DTCalibration/plugins/DTT0CalibrationRMS.cc
@@ -24,8 +24,7 @@ using namespace edm;
 // using namespace cond;
 
 // Constructor
-DTT0CalibrationRMS::DTT0CalibrationRMS(const edm::ParameterSet& pset) : 
-  dtGeomToken_(esConsumes()) {
+DTT0CalibrationRMS::DTT0CalibrationRMS(const edm::ParameterSet& pset) : dtGeomToken_(esConsumes()) {
   // Get the debug parameter for verbose output
   debug = pset.getUntrackedParameter<bool>("debug");
   if (debug)

--- a/CalibMuon/DTCalibration/plugins/DTT0CalibrationRMS.h
+++ b/CalibMuon/DTCalibration/plugins/DTT0CalibrationRMS.h
@@ -13,6 +13,7 @@
 #include "Geometry/DTGeometry/interface/DTGeometry.h"
 #include "DataFormats/MuonDetId/interface/DTWireId.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 
 #include <string>
 #include <vector>
@@ -105,5 +106,6 @@ private:
 
   //DTGeometry used to loop on the SL in the endJob
   edm::ESHandle<DTGeometry> dtGeom;
+  const edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomToken_;
 };
 #endif

--- a/CalibMuon/DTCalibration/plugins/DTT0ChamberReferenceCorrection.cc
+++ b/CalibMuon/DTCalibration/plugins/DTT0ChamberReferenceCorrection.cc
@@ -8,6 +8,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "DataFormats/MuonDetId/interface/DTWireId.h"
 #include "CondFormats/DTObjects/interface/DTT0.h"
@@ -21,8 +22,9 @@ using namespace edm;
 
 namespace dtCalibration {
 
-  DTT0ChamberReferenceCorrection::DTT0ChamberReferenceCorrection(const ParameterSet& pset)
-      : calibChamber_(pset.getParameter<string>("calibChamber")) {
+  DTT0ChamberReferenceCorrection::DTT0ChamberReferenceCorrection(const ParameterSet& pset,edm::ConsumesCollector cc)
+    : calibChamber_(pset.getParameter<string>("calibChamber")),
+      t0Token_(cc.esConsumes()) {
     //DTChamberId chosenChamberId;
     if (!calibChamber_.empty() && calibChamber_ != "None" && calibChamber_ != "All") {
       stringstream linestr;
@@ -40,8 +42,8 @@ namespace dtCalibration {
   void DTT0ChamberReferenceCorrection::setES(const EventSetup& setup) {
     // Get t0 record from DB
     ESHandle<DTT0> t0H;
-    setup.get<DTT0Rcd>().get(t0H);
-    t0Map_ = &*t0H;
+    t0H = setup.getHandle(t0Token_);
+    t0Map_ = &setup.getData(t0Token_);
     LogVerbatim("Calibration") << "[DTT0ChamberReferenceCorrection] T0 version: " << t0H->version();
   }
 

--- a/CalibMuon/DTCalibration/plugins/DTT0ChamberReferenceCorrection.cc
+++ b/CalibMuon/DTCalibration/plugins/DTT0ChamberReferenceCorrection.cc
@@ -22,9 +22,8 @@ using namespace edm;
 
 namespace dtCalibration {
 
-  DTT0ChamberReferenceCorrection::DTT0ChamberReferenceCorrection(const ParameterSet& pset,edm::ConsumesCollector cc)
-    : calibChamber_(pset.getParameter<string>("calibChamber")),
-      t0Token_(cc.esConsumes()) {
+  DTT0ChamberReferenceCorrection::DTT0ChamberReferenceCorrection(const ParameterSet& pset, edm::ConsumesCollector cc)
+      : calibChamber_(pset.getParameter<string>("calibChamber")), t0Token_(cc.esConsumes()) {
     //DTChamberId chosenChamberId;
     if (!calibChamber_.empty() && calibChamber_ != "None" && calibChamber_ != "All") {
       stringstream linestr;

--- a/CalibMuon/DTCalibration/plugins/DTT0ChamberReferenceCorrection.h
+++ b/CalibMuon/DTCalibration/plugins/DTT0ChamberReferenceCorrection.h
@@ -11,6 +11,10 @@
 
 #include "CalibMuon/DTCalibration/interface/DTT0BaseCorrection.h"
 #include "DataFormats/MuonDetId/interface/DTChamberId.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "CondFormats/DataRecord/interface/DTT0Rcd.h"
+#include "CondFormats/DTObjects/interface/DTT0.h"
 
 #include <string>
 
@@ -25,7 +29,7 @@ namespace dtCalibration {
   class DTT0ChamberReferenceCorrection : public DTT0BaseCorrection {
   public:
     // Constructor
-    DTT0ChamberReferenceCorrection(const edm::ParameterSet&);
+    DTT0ChamberReferenceCorrection(const edm::ParameterSet&, edm::ConsumesCollector);
 
     // Destructor
     ~DTT0ChamberReferenceCorrection() override;
@@ -40,6 +44,7 @@ namespace dtCalibration {
 
     DTChamberId chosenChamberId_;
     const DTT0* t0Map_;
+    edm::ESGetToken<DTT0, DTT0Rcd> t0Token_;  
   };
 
 }  // namespace dtCalibration

--- a/CalibMuon/DTCalibration/plugins/DTT0ChamberReferenceCorrection.h
+++ b/CalibMuon/DTCalibration/plugins/DTT0ChamberReferenceCorrection.h
@@ -44,7 +44,7 @@ namespace dtCalibration {
 
     DTChamberId chosenChamberId_;
     const DTT0* t0Map_;
-    edm::ESGetToken<DTT0, DTT0Rcd> t0Token_;  
+    edm::ESGetToken<DTT0, DTT0Rcd> t0Token_;
   };
 
 }  // namespace dtCalibration

--- a/CalibMuon/DTCalibration/plugins/DTT0Correction.cc
+++ b/CalibMuon/DTCalibration/plugins/DTT0Correction.cc
@@ -30,8 +30,8 @@ using namespace std;
 DTT0Correction::DTT0Correction(const ParameterSet& pset)
     : correctionAlgo_{DTT0CorrectionFactory::get()->create(pset.getParameter<string>("correctionAlgo"),
                                                            pset.getParameter<ParameterSet>("correctionAlgoConfig"))},
-  dtGeomToken_(esConsumes()), 
-  t0Token_(esConsumes()) {
+      dtGeomToken_(esConsumes()),
+      t0Token_(esConsumes()) {
   LogVerbatim("Calibration") << "[DTT0Correction] Constructor called" << endl;
 }
 

--- a/CalibMuon/DTCalibration/plugins/DTT0Correction.cc
+++ b/CalibMuon/DTCalibration/plugins/DTT0Correction.cc
@@ -29,7 +29,9 @@ using namespace std;
 
 DTT0Correction::DTT0Correction(const ParameterSet& pset)
     : correctionAlgo_{DTT0CorrectionFactory::get()->create(pset.getParameter<string>("correctionAlgo"),
-                                                           pset.getParameter<ParameterSet>("correctionAlgoConfig"))} {
+                                                           pset.getParameter<ParameterSet>("correctionAlgoConfig"))},
+  dtGeomToken_(esConsumes()), 
+  t0Token_(esConsumes()) {
   LogVerbatim("Calibration") << "[DTT0Correction] Constructor called" << endl;
 }
 
@@ -38,12 +40,12 @@ DTT0Correction::~DTT0Correction() { LogVerbatim("Calibration") << "[DTT0Correcti
 void DTT0Correction::beginRun(const edm::Run& run, const edm::EventSetup& setup) {
   // Get t0 record from DB
   ESHandle<DTT0> t0H;
-  setup.get<DTT0Rcd>().get(t0H);
-  t0Map_ = &*t0H;
+  t0H = setup.getHandle(t0Token_);
+  t0Map_ = &setup.getData(t0Token_);
   LogVerbatim("Calibration") << "[DTT0Correction]: T0 version: " << t0H->version() << endl;
 
   // Get geometry from Event Setup
-  setup.get<MuonGeometryRecord>().get(muonGeom_);
+  muonGeom_ = setup.getHandle(dtGeomToken_);
 
   // Pass EventSetup to correction Algo
   correctionAlgo_->setES(setup);

--- a/CalibMuon/DTCalibration/plugins/DTT0Correction.h
+++ b/CalibMuon/DTCalibration/plugins/DTT0Correction.h
@@ -8,6 +8,9 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "CondFormats/DTObjects/interface/DTT0.h"
+#include "CondFormats/DataRecord/interface/DTT0Rcd.h"
 
 #include <string>
 
@@ -34,9 +37,13 @@ public:
 
 protected:
 private:
-  const DTT0* t0Map_;
-  edm::ESHandle<DTGeometry> muonGeom_;
-
   std::unique_ptr<dtCalibration::DTT0BaseCorrection> correctionAlgo_;
+
+  edm::ESHandle<DTGeometry> muonGeom_;
+  const edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomToken_;
+
+  const DTT0* t0Map_;
+  edm::ESGetToken<DTT0, DTT0Rcd> t0Token_;
+
 };
 #endif

--- a/CalibMuon/DTCalibration/plugins/DTT0Correction.h
+++ b/CalibMuon/DTCalibration/plugins/DTT0Correction.h
@@ -44,6 +44,5 @@ private:
 
   const DTT0* t0Map_;
   edm::ESGetToken<DTT0, DTT0Rcd> t0Token_;
-
 };
 #endif

--- a/CalibMuon/DTCalibration/plugins/DTT0FEBPathCorrection.cc
+++ b/CalibMuon/DTCalibration/plugins/DTT0FEBPathCorrection.cc
@@ -26,8 +26,7 @@ using namespace edm;
 namespace dtCalibration {
 
   DTT0FEBPathCorrection::DTT0FEBPathCorrection(const ParameterSet& pset, edm::ConsumesCollector cc)
-    : calibChamber_(pset.getParameter<string>("calibChamber")),
-      t0Token_(cc.esConsumes()) {
+      : calibChamber_(pset.getParameter<string>("calibChamber")), t0Token_(cc.esConsumes()) {
     //DTChamberId chosenChamberId;
     if (!calibChamber_.empty() && calibChamber_ != "None" && calibChamber_ != "All") {
       stringstream linestr;

--- a/CalibMuon/DTCalibration/plugins/DTT0FEBPathCorrection.cc
+++ b/CalibMuon/DTCalibration/plugins/DTT0FEBPathCorrection.cc
@@ -16,7 +16,6 @@
 #include "CondFormats/DTObjects/interface/DTT0.h"
 #include "CondFormats/DataRecord/interface/DTT0Rcd.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 
 #include <string>
 #include <sstream>

--- a/CalibMuon/DTCalibration/plugins/DTT0FEBPathCorrection.cc
+++ b/CalibMuon/DTCalibration/plugins/DTT0FEBPathCorrection.cc
@@ -15,6 +15,8 @@
 #include "DataFormats/MuonDetId/interface/DTWireId.h"
 #include "CondFormats/DTObjects/interface/DTT0.h"
 #include "CondFormats/DataRecord/interface/DTT0Rcd.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
 
 #include <string>
 #include <sstream>
@@ -24,8 +26,9 @@ using namespace edm;
 
 namespace dtCalibration {
 
-  DTT0FEBPathCorrection::DTT0FEBPathCorrection(const ParameterSet& pset)
-      : calibChamber_(pset.getParameter<string>("calibChamber")) {
+  DTT0FEBPathCorrection::DTT0FEBPathCorrection(const ParameterSet& pset, edm::ConsumesCollector cc)
+    : calibChamber_(pset.getParameter<string>("calibChamber")),
+      t0Token_(cc.esConsumes()) {
     //DTChamberId chosenChamberId;
     if (!calibChamber_.empty() && calibChamber_ != "None" && calibChamber_ != "All") {
       stringstream linestr;
@@ -43,8 +46,8 @@ namespace dtCalibration {
   void DTT0FEBPathCorrection::setES(const EventSetup& setup) {
     // Get t0 record from DB
     ESHandle<DTT0> t0H;
-    setup.get<DTT0Rcd>().get(t0H);
-    t0Map_ = &*t0H;
+    t0H = setup.getHandle(t0Token_);
+    t0Map_ = &setup.getData(t0Token_);
     LogVerbatim("Calibration") << "[DTT0FEBPathCorrection] T0 version: " << t0H->version();
   }
 

--- a/CalibMuon/DTCalibration/plugins/DTT0FEBPathCorrection.h
+++ b/CalibMuon/DTCalibration/plugins/DTT0FEBPathCorrection.h
@@ -11,6 +11,10 @@
 
 #include "CalibMuon/DTCalibration/interface/DTT0BaseCorrection.h"
 #include "DataFormats/MuonDetId/interface/DTChamberId.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "CondFormats/DataRecord/interface/DTT0Rcd.h"
+#include "CondFormats/DTObjects/interface/DTT0.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include <string>
 
@@ -25,7 +29,7 @@ namespace dtCalibration {
   class DTT0FEBPathCorrection : public DTT0BaseCorrection {
   public:
     // Constructor
-    DTT0FEBPathCorrection(const edm::ParameterSet&);
+    DTT0FEBPathCorrection(const edm::ParameterSet&, edm::ConsumesCollector);
 
     // Destructor
     ~DTT0FEBPathCorrection() override;
@@ -42,6 +46,7 @@ namespace dtCalibration {
 
     DTChamberId chosenChamberId_;
     const DTT0* t0Map_;
+    edm::ESGetToken<DTT0, DTT0Rcd> t0Token_;
   };
 
 }  // namespace dtCalibration

--- a/CalibMuon/DTCalibration/plugins/DTTPDeadWriter.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTPDeadWriter.cc
@@ -33,11 +33,10 @@ using namespace std;
 using namespace edm;
 
 // Constructor
-DTTPDeadWriter::DTTPDeadWriter(const ParameterSet& pset) : 
-  dtGeomToken_(esConsumes()) {
+DTTPDeadWriter::DTTPDeadWriter(const ParameterSet& pset) : dtGeomToken_(esConsumes()) {
   // get selected debug option
   debug = pset.getUntrackedParameter<bool>("debug", false);
-  t0Token_ = esConsumes(edm::ESInputTag("", pset.getParameter<string>("debug"))); 
+  t0Token_ = esConsumes(edm::ESInputTag("", pset.getParameter<string>("debug")));
 
   // Create the object to be written to DB
   tpDeadList = new DTDeadFlag();

--- a/CalibMuon/DTCalibration/plugins/DTTPDeadWriter.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTPDeadWriter.cc
@@ -33,9 +33,11 @@ using namespace std;
 using namespace edm;
 
 // Constructor
-DTTPDeadWriter::DTTPDeadWriter(const ParameterSet& pset) {
+DTTPDeadWriter::DTTPDeadWriter(const ParameterSet& pset) : 
+  dtGeomToken_(esConsumes()) {
   // get selected debug option
   debug = pset.getUntrackedParameter<bool>("debug", false);
+  t0Token_ = esConsumes(edm::ESInputTag("", pset.getParameter<string>("debug"))); 
 
   // Create the object to be written to DB
   tpDeadList = new DTDeadFlag();
@@ -52,12 +54,10 @@ DTTPDeadWriter::~DTTPDeadWriter() {
 
 void DTTPDeadWriter::beginRun(const edm::Run&, const EventSetup& setup) {
   // Get the t0 map
-  ESHandle<DTT0> t0;
-  setup.get<DTT0Rcd>().get(t0);
-  tZeroMap = &*t0;
+  tZeroMap = &setup.getData(t0Token_);
 
   // Get the muon Geometry
-  setup.get<MuonGeometryRecord>().get(muonGeom);
+  muonGeom = setup.getHandle(dtGeomToken_);
 }
 
 // Do the job

--- a/CalibMuon/DTCalibration/plugins/DTTPDeadWriter.h
+++ b/CalibMuon/DTCalibration/plugins/DTTPDeadWriter.h
@@ -10,6 +10,9 @@
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "Geometry/DTGeometry/interface/DTGeometry.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "CondFormats/DTObjects/interface/DTT0.h"
+#include "CondFormats/DataRecord/interface/DTT0Rcd.h"
 
 #include <string>
 
@@ -48,11 +51,13 @@ private:
 
   //The map of t0 to be read from event
   const DTT0* tZeroMap;
+  edm::ESGetToken<DTT0, DTT0Rcd> t0Token_;
 
   // The object to be written to DB
   DTDeadFlag* tpDeadList;
 
   //The DTGeometry
   edm::ESHandle<DTGeometry> muonGeom;
+  const edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomToken_;
 };
 #endif

--- a/CalibMuon/DTCalibration/plugins/DTTTrigCorrectionFirst.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigCorrectionFirst.cc
@@ -25,7 +25,9 @@
 using namespace edm;
 using namespace std;
 
-DTTTrigCorrectionFirst::DTTTrigCorrectionFirst(const ParameterSet& pset) {
+DTTTrigCorrectionFirst::DTTTrigCorrectionFirst(const ParameterSet& pset): 
+  dtGeomToken_(esConsumes()), 
+  ttrigToken_(esConsumes(edm::ESInputTag("", pset.getParameter<string>("dbLabel")))) {
   debug = pset.getUntrackedParameter<bool>("debug", false);
   ttrigMin = pset.getUntrackedParameter<double>("ttrigMin", 0);
   ttrigMax = pset.getUntrackedParameter<double>("ttrigMax", 5000);
@@ -38,11 +40,10 @@ DTTTrigCorrectionFirst::~DTTTrigCorrectionFirst() {}
 
 void DTTTrigCorrectionFirst::beginRun(const edm::Run& run, const edm::EventSetup& setup) {
   ESHandle<DTTtrig> tTrig;
-  setup.get<DTTtrigRcd>().get(dbLabel, tTrig);
-  tTrigMap = &*tTrig;
+  tTrig = setup.getHandle(ttrigToken_);
+  tTrigMap = &setup.getData(ttrigToken_);
   cout << "[DTTTrigCorrection]: TTrig version: " << tTrig->version() << endl;
-
-  setup.get<MuonGeometryRecord>().get(muonGeom);
+  muonGeom = setup.getHandle(dtGeomToken_);
 }
 
 void DTTTrigCorrectionFirst::endJob() {

--- a/CalibMuon/DTCalibration/plugins/DTTTrigCorrectionFirst.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigCorrectionFirst.cc
@@ -25,9 +25,8 @@
 using namespace edm;
 using namespace std;
 
-DTTTrigCorrectionFirst::DTTTrigCorrectionFirst(const ParameterSet& pset): 
-  dtGeomToken_(esConsumes()), 
-  ttrigToken_(esConsumes(edm::ESInputTag("", pset.getParameter<string>("dbLabel")))) {
+DTTTrigCorrectionFirst::DTTTrigCorrectionFirst(const ParameterSet& pset)
+    : dtGeomToken_(esConsumes()), ttrigToken_(esConsumes(edm::ESInputTag("", pset.getParameter<string>("dbLabel")))) {
   debug = pset.getUntrackedParameter<bool>("debug", false);
   ttrigMin = pset.getUntrackedParameter<double>("ttrigMin", 0);
   ttrigMax = pset.getUntrackedParameter<double>("ttrigMax", 5000);

--- a/CalibMuon/DTCalibration/plugins/DTTTrigCorrectionFirst.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigCorrectionFirst.h
@@ -11,6 +11,8 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "CondFormats/DataRecord/interface/DTTtrigRcd.h"
 
 #include <string>
 
@@ -35,8 +37,11 @@ public:
 
 protected:
 private:
-  const DTTtrig* tTrigMap;
   edm::ESHandle<DTGeometry> muonGeom;
+  const edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomToken_;
+
+  const DTTtrig* tTrigMap;
+  const edm::ESGetToken<DTTtrig, DTTtrigRcd> ttrigToken_;
 
   std::string dbLabel;
 

--- a/CalibMuon/DTCalibration/plugins/DTTTrigOffsetCalibration.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigOffsetCalibration.cc
@@ -38,7 +38,7 @@ DTTTrigOffsetCalibration::DTTTrigOffsetCalibration(const ParameterSet& pset)
     : theRecHits4DLabel_(pset.getParameter<InputTag>("recHits4DLabel")),
       doTTrigCorrection_(pset.getUntrackedParameter<bool>("doT0SegCorrection", false)),
       theCalibChamber_(pset.getUntrackedParameter<string>("calibChamber", "All")),
-      dbLabel_(pset.getUntrackedParameter<string>("dbLabel", "")), 
+      dbLabel_(pset.getUntrackedParameter<string>("dbLabel", "")),
       ttrigToken_(esConsumes(edm::ESInputTag("", pset.getParameter<string>("dbLabel")))),
       dtGeomToken_(esConsumes()) {
   LogVerbatim("Calibration") << "[DTTTrigOffsetCalibration] Constructor called!";

--- a/CalibMuon/DTCalibration/plugins/DTTTrigOffsetCalibration.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigOffsetCalibration.cc
@@ -38,7 +38,9 @@ DTTTrigOffsetCalibration::DTTTrigOffsetCalibration(const ParameterSet& pset)
     : theRecHits4DLabel_(pset.getParameter<InputTag>("recHits4DLabel")),
       doTTrigCorrection_(pset.getUntrackedParameter<bool>("doT0SegCorrection", false)),
       theCalibChamber_(pset.getUntrackedParameter<string>("calibChamber", "All")),
-      dbLabel_(pset.getUntrackedParameter<string>("dbLabel", "")) {
+      dbLabel_(pset.getUntrackedParameter<string>("dbLabel", "")), 
+      ttrigToken_(esConsumes(edm::ESInputTag("", pset.getParameter<string>("dbLabel")))),
+      dtGeomToken_(esConsumes()) {
   LogVerbatim("Calibration") << "[DTTTrigOffsetCalibration] Constructor called!";
 
   edm::ConsumesCollector collector(consumesCollector());
@@ -53,8 +55,8 @@ DTTTrigOffsetCalibration::DTTTrigOffsetCalibration(const ParameterSet& pset)
 void DTTTrigOffsetCalibration::beginRun(const edm::Run& run, const edm::EventSetup& setup) {
   if (doTTrigCorrection_) {
     ESHandle<DTTtrig> tTrig;
-    setup.get<DTTtrigRcd>().get(dbLabel_, tTrig);
-    tTrigMap_ = &*tTrig;
+    tTrig = setup.getHandle(ttrigToken_);
+    tTrigMap_ = &setup.getData(ttrigToken_);
     LogVerbatim("Calibration") << "[DTTTrigOffsetCalibration]: TTrig version: " << tTrig->version() << endl;
   }
 }
@@ -79,7 +81,7 @@ void DTTTrigOffsetCalibration::analyze(const Event& event, const EventSetup& eve
 
   // Get the DT Geometry
   ESHandle<DTGeometry> dtGeom;
-  eventSetup.get<MuonGeometryRecord>().get(dtGeom);
+  dtGeom = eventSetup.getHandle(dtGeomToken_);
 
   // Get the rechit collection from the event
   Handle<DTRecSegment4DCollection> all4DSegments;

--- a/CalibMuon/DTCalibration/plugins/DTTTrigOffsetCalibration.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigOffsetCalibration.h
@@ -10,6 +10,9 @@
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "CalibMuon/DTCalibration/interface/DTSegmentSelector.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "CondFormats/DataRecord/interface/DTTtrigRcd.h"
+#include "Geometry/DTGeometry/interface/DTGeometry.h"
 
 #include <map>
 
@@ -49,5 +52,8 @@ private:
   TFile* rootFile_;
   const DTTtrig* tTrigMap_;
   ChamberHistosMap theT0SegHistoMap_;
+
+  const edm::ESGetToken<DTTtrig, DTTtrigRcd> ttrigToken_;
+  const edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomToken_;
 };
 #endif

--- a/CalibMuon/DTCalibration/plugins/DTTTrigWriter.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigWriter.cc
@@ -33,7 +33,8 @@ using namespace std;
 using namespace edm;
 
 // Constructor
-DTTTrigWriter::DTTTrigWriter(const ParameterSet& pset) {
+DTTTrigWriter::DTTTrigWriter(const ParameterSet& pset) : 
+  dtGeomToken_(esConsumes()) {
   // get selected debug option
   debug = pset.getUntrackedParameter<bool>("debug", false);
 
@@ -72,8 +73,7 @@ void DTTTrigWriter::analyze(const Event& event, const EventSetup& eventSetup) {
     cout << "[DTTTrigWriter]Analyzer called!" << endl;
 
   // Get the DT Geometry
-  ESHandle<DTGeometry> dtGeom;
-  eventSetup.get<MuonGeometryRecord>().get(dtGeom);
+  dtGeom = eventSetup.getHandle(dtGeomToken_);
 
   // Get all the sls from the setup
   const vector<const DTSuperLayer*> superLayers = dtGeom->superLayers();

--- a/CalibMuon/DTCalibration/plugins/DTTTrigWriter.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigWriter.cc
@@ -33,8 +33,7 @@ using namespace std;
 using namespace edm;
 
 // Constructor
-DTTTrigWriter::DTTTrigWriter(const ParameterSet& pset) : 
-  dtGeomToken_(esConsumes()) {
+DTTTrigWriter::DTTTrigWriter(const ParameterSet& pset) : dtGeomToken_(esConsumes()) {
   // get selected debug option
   debug = pset.getUntrackedParameter<bool>("debug", false);
 

--- a/CalibMuon/DTCalibration/plugins/DTTTrigWriter.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigWriter.h
@@ -67,6 +67,5 @@ private:
   //geom
   edm::ESHandle<DTGeometry> dtGeom;
   const edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomToken_;
-
 };
 #endif

--- a/CalibMuon/DTCalibration/plugins/DTTTrigWriter.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigWriter.h
@@ -8,7 +8,10 @@
  */
 
 #include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 // #include "DataFormats/MuonDetId/interface/DTSuperLayerId.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "Geometry/DTGeometry/interface/DTGeometry.h"
 
 #include <string>
 
@@ -60,5 +63,10 @@ private:
 
   // The object to be written to DB
   DTTtrig* tTrig;
+
+  //geom
+  edm::ESHandle<DTGeometry> dtGeom;
+  const edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomToken_;
+
 };
 #endif

--- a/CalibMuon/DTCalibration/plugins/DTVDriftSegmentCalibration.cc
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftSegmentCalibration.cc
@@ -33,7 +33,8 @@ using namespace edm;
 DTVDriftSegmentCalibration::DTVDriftSegmentCalibration(const ParameterSet& pset)
     : theRecHits4DLabel_(pset.getParameter<InputTag>("recHits4DLabel")),
       //writeVDriftDB_(pset.getUntrackedParameter<bool>("writeVDriftDB", false)),
-      theCalibChamber_(pset.getUntrackedParameter<string>("calibChamber", "All")) {
+      theCalibChamber_(pset.getUntrackedParameter<string>("calibChamber", "All")),
+      dtGeomToken_(esConsumes()) {
   LogVerbatim("Calibration") << "[DTVDriftSegmentCalibration] Constructor called!";
 
   edm::ConsumesCollector collector(consumesCollector());
@@ -59,7 +60,7 @@ void DTVDriftSegmentCalibration::analyze(const Event& event, const EventSetup& e
 
   // Get the DT Geometry
   ESHandle<DTGeometry> dtGeom;
-  eventSetup.get<MuonGeometryRecord>().get(dtGeom);
+  dtGeom = eventSetup.getHandle(dtGeomToken_);
 
   // Get the rechit collection from the event
   Handle<DTRecSegment4DCollection> all4DSegments;

--- a/CalibMuon/DTCalibration/plugins/DTVDriftSegmentCalibration.h
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftSegmentCalibration.h
@@ -11,6 +11,8 @@
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "CalibMuon/DTCalibration/interface/DTSegmentSelector.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "Geometry/DTGeometry/interface/DTGeometry.h"
 
 #include <map>
 
@@ -45,5 +47,7 @@ private:
   TFile* rootFile_;
   ChamberHistosMapTH1F theVDriftHistoMapTH1F_;
   ChamberHistosMapTH2F theVDriftHistoMapTH2F_;
+
+  const edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomToken_;
 };
 #endif

--- a/CalibMuon/DTCalibration/plugins/DTVDriftWriter.cc
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftWriter.cc
@@ -32,8 +32,11 @@
 using namespace std;
 using namespace edm;
 
-DTVDriftWriter::DTVDriftWriter(const ParameterSet& pset)
-    : granularity_(pset.getUntrackedParameter<string>("calibGranularity", "bySL")),
+DTVDriftWriter::DTVDriftWriter(const ParameterSet& pset) :  
+      mTimeMapToken_(esConsumes()),
+      vDriftMapToken_(esConsumes()),
+      dtGeomToken_(esConsumes()),
+      granularity_(pset.getUntrackedParameter<string>("calibGranularity", "bySL")),
       mTimeMap_(nullptr),
       vDriftMap_(nullptr),
       vDriftAlgo_{DTVDriftPluginFactory::get()->create(pset.getParameter<string>("vDriftAlgo"),
@@ -53,13 +56,9 @@ DTVDriftWriter::~DTVDriftWriter() { LogVerbatim("Calibration") << "[DTVDriftWrit
 void DTVDriftWriter::beginRun(const edm::Run& run, const edm::EventSetup& setup) {
   // Get the map of vdrift from the Setup
   if (readLegacyVDriftDB) {
-    ESHandle<DTMtime> mTime;
-    setup.get<DTMtimeRcd>().get(mTime);
-    mTimeMap_ = &*mTime;
+    mTimeMap_ = &setup.getData(mTimeMapToken_);
   } else {
-    ESHandle<DTRecoConditions> hVdrift;
-    setup.get<DTRecoConditionsVdriftRcd>().get(hVdrift);
-    vDriftMap_ = &*hVdrift;
+    vDriftMap_ = &setup.getData(vDriftMapToken_);
     // Consistency check: no parametrization is implemented for the time being
     int version = vDriftMap_->version();
     if (version != 1) {
@@ -68,7 +67,8 @@ void DTVDriftWriter::beginRun(const edm::Run& run, const edm::EventSetup& setup)
   }
 
   // Get geometry from Event Setup
-  setup.get<MuonGeometryRecord>().get(dtGeom_);
+  dtGeom_ = setup.getHandle(dtGeomToken_);
+
   // Pass EventSetup to concrete implementation
   vDriftAlgo_->setES(setup);
 }

--- a/CalibMuon/DTCalibration/plugins/DTVDriftWriter.cc
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftWriter.cc
@@ -32,8 +32,8 @@
 using namespace std;
 using namespace edm;
 
-DTVDriftWriter::DTVDriftWriter(const ParameterSet& pset) :  
-      mTimeMapToken_(esConsumes()),
+DTVDriftWriter::DTVDriftWriter(const ParameterSet& pset)
+    : mTimeMapToken_(esConsumes()),
       vDriftMapToken_(esConsumes()),
       dtGeomToken_(esConsumes()),
       granularity_(pset.getUntrackedParameter<string>("calibGranularity", "bySL")),

--- a/CalibMuon/DTCalibration/plugins/DTVDriftWriter.h
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftWriter.h
@@ -39,7 +39,7 @@ private:
   const edm::ESGetToken<DTMtime, DTMtimeRcd> mTimeMapToken_;
   const edm::ESGetToken<DTRecoConditions, DTRecoConditionsVdriftRcd> vDriftMapToken_;
   const edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomToken_;
-  std::string granularity_;  // enforced by SL
+  std::string granularity_;            // enforced by SL
   const DTMtime* mTimeMap_;            // legacy DB object
   const DTRecoConditions* vDriftMap_;  // DB object in new format
   bool readLegacyVDriftDB;             // which format to use to read old values

--- a/CalibMuon/DTCalibration/plugins/DTVDriftWriter.h
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftWriter.h
@@ -12,6 +12,9 @@
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "CondFormats/DataRecord/interface/DTMtimeRcd.h"
+#include "CondFormats/DataRecord/interface/DTRecoConditionsVdriftRcd.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 
 #include <string>
 
@@ -33,8 +36,10 @@ public:
   void endJob() override;
 
 private:
+  const edm::ESGetToken<DTMtime, DTMtimeRcd> mTimeMapToken_;
+  const edm::ESGetToken<DTRecoConditions, DTRecoConditionsVdriftRcd> vDriftMapToken_;
+  const edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomToken_;
   std::string granularity_;  // enforced by SL
-
   const DTMtime* mTimeMap_;            // legacy DB object
   const DTRecoConditions* vDriftMap_;  // DB object in new format
   bool readLegacyVDriftDB;             // which format to use to read old values


### PR DESCRIPTION
#### PR description:

This PR aims to partially migrate `CalibMuon/DTCalibration` package to use esConsumes. Technical PR, no change in physics is expected.

#### PR validation:

code compiles. 
`runTheMatrix.py -l 1330` ran fine

This PR is not a backport.
Backport not needed.