### PR TITLE
Fix undefined behavior in the SiPixelDigitizer

### DIFF
--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelChargeReweightingAlgorithm.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelChargeReweightingAlgorithm.cc
@@ -230,8 +230,11 @@ bool SiPixelChargeReweightingAlgorithm::hitSignalReweight(const PSimHit& hit,
   for (int row = 0; row < TXSIZE; ++row) {
     for (int col = 0; col < TYSIZE; ++col) {
       //Fill charges into 21x13 Pixel Array with hitPixel in centre
-      pixrewgt[row][col] =
-          hitSignal[PixelDigi::pixelToChannel(hitPixel.first + row - THX, hitPixel.second + col - THY)];
+      if ((hitPixel.first + row - THX) >= 0 && (hitPixel.first + row - THX) < topol->nrows() &&
+          (hitPixel.second + col - THY) >= 0 && (hitPixel.second + col - THY) < topol->ncolumns()) {
+        pixrewgt[row][col] =
+            hitSignal[PixelDigi::pixelToChannel(hitPixel.first + row - THX, hitPixel.second + col - THY)];
+      }
     }
   }
 

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelChargeReweightingAlgorithm.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelChargeReweightingAlgorithm.cc
@@ -275,8 +275,7 @@ bool SiPixelChargeReweightingAlgorithm::hitSignalReweight(const PSimHit& hit,
 
   for (int row = rowmin; row < rowmax; ++row) {
     for (int col = colmin; col < colmax; ++col) {
-      float charge = 0;
-      charge = pixrewgt[row][col];
+      float charge = pixrewgt[row][col];
       if (charge > 0) {
         chargeAfter += charge;
         theSignal[PixelDigi::pixelToChannel(hitPixel.first + row - THX, hitPixel.second + col - THY)] +=

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelChargeReweightingAlgorithm.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelChargeReweightingAlgorithm.cc
@@ -227,14 +227,18 @@ bool SiPixelChargeReweightingAlgorithm::hitSignalReweight(const PSimHit& hit,
     ydouble[col] = topol->isItBigPixelInY(hitPixel.second + col - THY);
   }
 
-  for (int row = 0; row < TXSIZE; ++row) {
-    for (int col = 0; col < TYSIZE; ++col) {
+  // define loop boundaries that will prevent the row and col loops
+  // from going out of physical bounds of the pixel module
+  int rowmin = std::max(0, THX - hitPixel.first);
+  int rowmax = std::min(TXSIZE, topol->nrows() + THX - hitPixel.first);
+  int colmin = std::max(0, THY - hitPixel.second);
+  int colmax = std::min(TYSIZE, topol->ncolumns() + THY - hitPixel.second);
+
+  for (int row = rowmin; row < rowmax; ++row) {
+    for (int col = colmin; col < colmax; ++col) {
       //Fill charges into 21x13 Pixel Array with hitPixel in centre
-      if ((hitPixel.first + row - THX) >= 0 && (hitPixel.first + row - THX) < topol->nrows() &&
-          (hitPixel.second + col - THY) >= 0 && (hitPixel.second + col - THY) < topol->ncolumns()) {
-        pixrewgt[row][col] =
-            hitSignal[PixelDigi::pixelToChannel(hitPixel.first + row - THX, hitPixel.second + col - THY)];
-      }
+      pixrewgt[row][col] =
+          hitSignal[PixelDigi::pixelToChannel(hitPixel.first + row - THX, hitPixel.second + col - THY)];
     }
   }
 
@@ -269,12 +273,11 @@ bool SiPixelChargeReweightingAlgorithm::hitSignalReweight(const PSimHit& hit,
     printCluster(pixrewgt);
   }
 
-  for (int row = 0; row < TXSIZE; ++row) {
-    for (int col = 0; col < TYSIZE; ++col) {
+  for (int row = rowmin; row < rowmax; ++row) {
+    for (int col = colmin; col < colmax; ++col) {
       float charge = 0;
       charge = pixrewgt[row][col];
-      if ((hitPixel.first + row - THX) >= 0 && (hitPixel.first + row - THX) < topol->nrows() &&
-          (hitPixel.second + col - THY) >= 0 && (hitPixel.second + col - THY) < topol->ncolumns() && charge > 0) {
+      if (charge > 0) {
         chargeAfter += charge;
         theSignal[PixelDigi::pixelToChannel(hitPixel.first + row - THX, hitPixel.second + col - THY)] +=
             (boolmakeDigiSimLinks ? SiPixelDigitizerAlgorithm::Amplitude(charge, &hit, hitIndex, tofBin, charge)


### PR DESCRIPTION
#### PR description:

This PR addresses the issue with undefined behavior in PixelDigi::pixelToChannel(int row, int col) reported in https://github.com/cms-sw/cmssw/issues/35034 that originates from a call in https://github.com/cms-sw/cmssw/blob/master/SimTracker/SiPixelDigitizer/plugins/SiPixelChargeReweightingAlgorithm.cc The fix involves restricting the loop over the row and column coordinates to prevent it from going out of physical bounds.

  - no changes are expected in the output

#### PR validation:

Local tests as reported in https://github.com/cms-sw/cmssw/issues/35034#issuecomment-920137796
