### PR TITLE
Add new features to BeamSpotOnlineObjects

### DIFF
--- a/CondFormats/BeamSpotObjects/interface/BeamSpotOnlineObjects.h
+++ b/CondFormats/BeamSpotObjects/interface/BeamSpotOnlineObjects.h
@@ -30,14 +30,18 @@ public:
     lastAnalyzedRun_ = 0;
     lastAnalyzedFill_ = 0;
     intParams_.resize(ISIZE, std::vector<int>(1, 0));
+    floatParams_.resize(FSIZE, std::vector<float>(1, 0.0));
+    stringParams_.resize(SSIZE, std::vector<std::string>(1, ""));
     timeParams_.resize(TSIZE, std::vector<unsigned long long>(1, 0ULL));
   }
 
   ~BeamSpotOnlineObjects() override {}
 
   /// Enums
-  enum IntParamIndex { NUM_TRACKS = 0, NUM_PVS = 1, ISIZE = 2 };
-  enum TimeParamIndex { CREATE_TIME = 0, TSIZE = 1 };
+  enum IntParamIndex { NUM_TRACKS = 0, NUM_PVS = 1, USED_EVENTS = 2, MAX_PVS = 3, ISIZE = 4 };
+  enum FloatParamIndex { MEAN_PV = 0, ERR_MEAN_PV = 1, RMS_PV = 2, ERR_RMS_PV = 3, FSIZE = 4 };
+  enum StringParamIndex { START_TIME = 0, END_TIME = 1, LUMI_RANGE = 2, SSIZE = 3 };
+  enum TimeParamIndex { CREATE_TIME = 0, START_TIMESTAMP = 1, END_TIMESTAMP = 2, TSIZE = 3 };
 
   /// Setters Methods
   // set lastAnalyzedLumi_, last analyzed lumisection
@@ -55,8 +59,41 @@ public:
   // set number of Primary Vertices used in the BeamSpot fit
   void SetNumPVs(int val);
 
+  // set number of Events used in the BeamSpot fit (for DIP)
+  void SetUsedEvents(int val);
+
+  // set max number of Primary Vertices used in the BeamSpot fit (for DIP)
+  void SetMaxPVs(int val);
+
+  // set mean number of PVs (for DIP)
+  void SetMeanPV(float val);
+
+  // set error on mean number of PVs (for DIP)
+  void SetMeanErrorPV(float val);
+
+  // set rms of number of PVs (for DIP)
+  void SetRmsPV(float val);
+
+  // set error on rm of number of PVs (for DIP)
+  void SetRmsErrorPV(float val);
+
+  // set start time of the firs LS as string (for DIP)
+  void SetStartTime(std::string val);
+
+  // set end time of the last LS as string (for DIP)
+  void SetEndTime(std::string val);
+
+  // set lumi range as string (for DIP)
+  void SetLumiRange(std::string val);
+
   // set creation time of the payload
   void SetCreationTime(cond::Time_t val);
+
+  // set timestamp of the first LS (for DIP)
+  void SetStartTimeStamp(cond::Time_t val);
+
+  // set timestamp of the last LS (for DIP)
+  void SetEndTimeStamp(cond::Time_t val);
 
   /// Getters Methods
   // get lastAnalyzedLumi_, last analyzed lumisection
@@ -74,8 +111,41 @@ public:
   // get number of Primary Vertices used in the BeamSpot fit
   int GetNumPVs() const;
 
+  // get number of Events used in the BeamSpot fit (for DIP)
+  int GetUsedEvents() const;
+
+  // get max number of Primary Vertices used in the BeamSpot fit (for DIP)
+  int GetMaxPVs() const;
+
+  // get mean number of PVs (for DIP)
+  float GetMeanPV() const;
+
+  // get error on mean number of PVs (for DIP)
+  float GetMeanErrorPV() const;
+
+  // get rms of number of PVs (for DIP)
+  float GetRmsPV() const;
+
+  // get error on rm of number of PVs (for DIP)
+  float GetRmsErrorPV() const;
+
+  // get start time of the firs LS as string (for DIP)
+  std::string GetStartTime() const;
+
+  // get end time of the last LS as string (for DIP)
+  std::string GetEndTime() const;
+
+  // get lumi range as string (for DIP)
+  std::string GetLumiRange() const;
+
   // get creation time of the payload
   cond::Time_t GetCreationTime() const;
+
+  // get timestamp of the first LS (for DIP)
+  cond::Time_t GetStartTimeStamp() const;
+
+  // get timestamp of the last LS (for DIP)
+  cond::Time_t GetEndTimeStamp() const;
 
   /// Print BeamSpotOnline parameters
   void print(std::stringstream& ss) const;
@@ -87,7 +157,7 @@ private:
   std::vector<std::vector<int> > intParams_;
   std::vector<std::vector<float> > floatParams_;
   std::vector<std::vector<std::string> > stringParams_;
-  std::vector<std::vector<unsigned long long> > timeParams_;
+  std::vector<std::vector<unsigned long long> > timeParams_;  // unsigned long long is equal to cond::Time_t
 
   COND_SERIALIZABLE;
 };

--- a/CondFormats/BeamSpotObjects/src/BeamSpotOnlineObjects.cc
+++ b/CondFormats/BeamSpotObjects/src/BeamSpotOnlineObjects.cc
@@ -51,8 +51,46 @@ int BeamSpotOnlineObjects::GetNumTracks() const {
 
 int BeamSpotOnlineObjects::GetNumPVs() const { return BeamSpotOnlineObjectsImpl::getOneParam(intParams_, NUM_PVS); }
 
+int BeamSpotOnlineObjects::GetUsedEvents() const {
+  return BeamSpotOnlineObjectsImpl::getOneParam(intParams_, USED_EVENTS);
+}
+
+int BeamSpotOnlineObjects::GetMaxPVs() const { return BeamSpotOnlineObjectsImpl::getOneParam(intParams_, MAX_PVS); }
+
+float BeamSpotOnlineObjects::GetMeanPV() const { return BeamSpotOnlineObjectsImpl::getOneParam(floatParams_, MEAN_PV); }
+
+float BeamSpotOnlineObjects::GetMeanErrorPV() const {
+  return BeamSpotOnlineObjectsImpl::getOneParam(floatParams_, ERR_MEAN_PV);
+}
+
+float BeamSpotOnlineObjects::GetRmsPV() const { return BeamSpotOnlineObjectsImpl::getOneParam(floatParams_, RMS_PV); }
+
+float BeamSpotOnlineObjects::GetRmsErrorPV() const {
+  return BeamSpotOnlineObjectsImpl::getOneParam(floatParams_, ERR_RMS_PV);
+}
+
+std::string BeamSpotOnlineObjects::GetStartTime() const {
+  return BeamSpotOnlineObjectsImpl::getOneParam(stringParams_, START_TIME);
+}
+
+std::string BeamSpotOnlineObjects::GetEndTime() const {
+  return BeamSpotOnlineObjectsImpl::getOneParam(stringParams_, END_TIME);
+}
+
+std::string BeamSpotOnlineObjects::GetLumiRange() const {
+  return BeamSpotOnlineObjectsImpl::getOneParam(stringParams_, LUMI_RANGE);
+}
+
 cond::Time_t BeamSpotOnlineObjects::GetCreationTime() const {
   return BeamSpotOnlineObjectsImpl::getOneParam(timeParams_, CREATE_TIME);
+}
+
+cond::Time_t BeamSpotOnlineObjects::GetStartTimeStamp() const {
+  return BeamSpotOnlineObjectsImpl::getOneParam(timeParams_, START_TIMESTAMP);
+}
+
+cond::Time_t BeamSpotOnlineObjects::GetEndTimeStamp() const {
+  return BeamSpotOnlineObjectsImpl::getOneParam(timeParams_, END_TIMESTAMP);
 }
 
 // setters
@@ -62,8 +100,52 @@ void BeamSpotOnlineObjects::SetNumTracks(int nTracks) {
 
 void BeamSpotOnlineObjects::SetNumPVs(int nPVs) { BeamSpotOnlineObjectsImpl::setOneParam(intParams_, NUM_PVS, nPVs); }
 
+void BeamSpotOnlineObjects::SetUsedEvents(int usedEvents) {
+  BeamSpotOnlineObjectsImpl::setOneParam(intParams_, USED_EVENTS, usedEvents);
+}
+
+void BeamSpotOnlineObjects::SetMaxPVs(int maxPVs) {
+  BeamSpotOnlineObjectsImpl::setOneParam(intParams_, MAX_PVS, maxPVs);
+}
+
+void BeamSpotOnlineObjects::SetMeanPV(float meanPVs) {
+  BeamSpotOnlineObjectsImpl::setOneParam(floatParams_, MEAN_PV, meanPVs);
+}
+
+void BeamSpotOnlineObjects::SetMeanErrorPV(float errMeanPVs) {
+  BeamSpotOnlineObjectsImpl::setOneParam(floatParams_, ERR_MEAN_PV, errMeanPVs);
+}
+
+void BeamSpotOnlineObjects::SetRmsPV(float rmsPVs) {
+  BeamSpotOnlineObjectsImpl::setOneParam(floatParams_, RMS_PV, rmsPVs);
+}
+
+void BeamSpotOnlineObjects::SetRmsErrorPV(float errRmsPVs) {
+  BeamSpotOnlineObjectsImpl::setOneParam(floatParams_, ERR_RMS_PV, errRmsPVs);
+}
+
+void BeamSpotOnlineObjects::SetStartTime(std::string startTime) {
+  BeamSpotOnlineObjectsImpl::setOneParam(stringParams_, START_TIME, startTime);
+}
+
+void BeamSpotOnlineObjects::SetEndTime(std::string endTime) {
+  BeamSpotOnlineObjectsImpl::setOneParam(stringParams_, END_TIME, endTime);
+}
+
+void BeamSpotOnlineObjects::SetLumiRange(std::string lumiRange) {
+  BeamSpotOnlineObjectsImpl::setOneParam(stringParams_, LUMI_RANGE, lumiRange);
+}
+
 void BeamSpotOnlineObjects::SetCreationTime(cond::Time_t createTime) {
   BeamSpotOnlineObjectsImpl::setOneParam(timeParams_, CREATE_TIME, createTime);
+}
+
+void BeamSpotOnlineObjects::SetStartTimeStamp(cond::Time_t starTimeStamp) {
+  BeamSpotOnlineObjectsImpl::setOneParam(timeParams_, START_TIMESTAMP, starTimeStamp);
+}
+
+void BeamSpotOnlineObjects::SetEndTimeStamp(cond::Time_t endTimeStamp) {
+  BeamSpotOnlineObjectsImpl::setOneParam(timeParams_, END_TIMESTAMP, endTimeStamp);
 }
 
 // printers

--- a/DQM/BeamMonitor/plugins/BeamMonitor.cc
+++ b/DQM/BeamMonitor/plugins/BeamMonitor.cc
@@ -88,6 +88,13 @@ void BeamMonitor::formatFitTime(char* ts, const time_t& t) {
 
 static constexpr int buffTime = 23;
 
+std::string BeamMonitor::getGMTstring(const time_t& timeToConvert) {
+  char buff[32];
+  std::strftime(buff, sizeof(buff), "%Y.%m.%d %H:%M:%S GMT", gmtime(&timeToConvert));
+  std::string timeStr(buff);
+  return timeStr;
+}
+
 //
 // constructors and destructor
 //
@@ -1348,7 +1355,7 @@ void BeamMonitor::FitAndFill(const LuminosityBlock& lumiSeg, int& lastlumi, int&
 
       // Create the BeamSpotOnlineObjects object
       BeamSpotOnlineObjects* BSOnline = new BeamSpotOnlineObjects();
-      BSOnline->SetLastAnalyzedLumi(fitLS.second);
+      BSOnline->SetLastAnalyzedLumi(LSRange.second);
       BSOnline->SetLastAnalyzedRun(theBeamFitter->getRunNumber());
       BSOnline->SetLastAnalyzedFill(0);  // To be updated with correct LHC Fill number
       BSOnline->SetPosition(bs.x0(), bs.y0(), bs.z0());
@@ -1370,10 +1377,22 @@ void BeamMonitor::FitAndFill(const LuminosityBlock& lumiSeg, int& lastlumi, int&
       }
       BSOnline->SetNumTracks(theBeamFitter->getNTracks());
       BSOnline->SetNumPVs(theBeamFitter->getNPVs());
+      BSOnline->SetUsedEvents((int)DipPVInfo_[0]);
+      BSOnline->SetMeanPV(DipPVInfo_[1]);
+      BSOnline->SetMeanErrorPV(DipPVInfo_[2]);
+      BSOnline->SetRmsPV(DipPVInfo_[3]);
+      BSOnline->SetRmsErrorPV(DipPVInfo_[4]);
+      BSOnline->SetMaxPVs((int)DipPVInfo_[5]);
       auto creationTime =
           std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch())
               .count();
       BSOnline->SetCreationTime(creationTime);
+
+      std::pair<time_t, time_t> timeForDIP = theBeamFitter->getRefTime();
+      BSOnline->SetStartTimeStamp(timeForDIP.first);
+      BSOnline->SetStartTime(getGMTstring(timeForDIP.first));
+      BSOnline->SetEndTimeStamp(timeForDIP.second);
+      BSOnline->SetEndTime(getGMTstring(timeForDIP.second));
 
       edm::LogInfo("BeamMonitor") << "FitAndFill::[PayloadCreation] BeamSpotOnline object created: \n" << std::endl;
       edm::LogInfo("BeamMonitor") << *BSOnline << std::endl;
@@ -1385,8 +1404,8 @@ void BeamMonitor::FitAndFill(const LuminosityBlock& lumiSeg, int& lastlumi, int&
         onlineDbService_->logger().logInfo()
             << "BeamMonitor::FitAndFill - Do PV Fitting for LS = " << beginLumiOfPVFit_ << " to " << endLumiOfPVFit_;
         onlineDbService_->logger().logInfo()
-            << "BeamMonitor::FitAndFill - [BeamFitter] Do BeamSpot Fit for LS = " << fitLS.first << " to "
-            << fitLS.second;
+            << "BeamMonitor::FitAndFill - [BeamFitter] Do BeamSpot Fit for LS = " << LSRange.first << " to "
+            << LSRange.second;
         onlineDbService_->logger().logInfo()
             << "BeamMonitor::FitAndFill - [BeamMonitor] Do BeamSpot Fit for LS = " << beginLumiOfBSFit_ << " to "
             << endLumiOfBSFit_;
@@ -1395,6 +1414,17 @@ void BeamMonitor::FitAndFill(const LuminosityBlock& lumiSeg, int& lastlumi, int&
         onlineDbService_->logger().logInfo()
             << "BeamMonitor::FitAndFill - [PayloadCreation] BeamSpotOnline object created:";
         onlineDbService_->logger().logInfo() << "\n" << *BSOnline;
+        onlineDbService_->logger().logInfo() << "BeamMonitor - Additional parameters for DIP:";
+        onlineDbService_->logger().logInfo() << "Events used in the fit: " << BSOnline->GetUsedEvents();
+        onlineDbService_->logger().logInfo() << "Mean PV               : " << BSOnline->GetMeanPV();
+        onlineDbService_->logger().logInfo() << "Mean PV Error         : " << BSOnline->GetMeanErrorPV();
+        onlineDbService_->logger().logInfo() << "Rms PV                : " << BSOnline->GetRmsPV();
+        onlineDbService_->logger().logInfo() << "Rms PV Error          : " << BSOnline->GetRmsErrorPV();
+        onlineDbService_->logger().logInfo() << "Max PVs               : " << BSOnline->GetMaxPVs();
+        onlineDbService_->logger().logInfo() << "StartTime             : " << BSOnline->GetStartTime();
+        onlineDbService_->logger().logInfo() << "StartTimeStamp        : " << BSOnline->GetStartTimeStamp();
+        onlineDbService_->logger().logInfo() << "EndTime               : " << BSOnline->GetEndTime();
+        onlineDbService_->logger().logInfo() << "EndTimeStamp          : " << BSOnline->GetEndTimeStamp();
         onlineDbService_->logger().logInfo() << "BeamMonitor::FitAndFill - [PayloadCreation] onlineDbService available";
         onlineDbService_->logger().logInfo()
             << "BeamMonitor::FitAndFill - [PayloadCreation] SetCreationTime: " << creationTime
@@ -1405,7 +1435,7 @@ void BeamMonitor::FitAndFill(const LuminosityBlock& lumiSeg, int& lastlumi, int&
               << "BeamMonitor::FitAndFill - [PayloadCreation] writeForNextLumisection executed correctly";
         } catch (const std::exception& e) {
           onlineDbService_->logger().logError() << "BeamMonitor - Error writing record: " << recordName_
-                                                << " for Run: " << frun << " - Lumi: " << fitLS.second;
+                                                << " for Run: " << frun << " - Lumi: " << LSRange.second;
           onlineDbService_->logger().logError() << "Error is: " << e.what();
           onlineDbService_->logger().logError() << "RESULTS OF DEFAULT FIT WAS:";
           onlineDbService_->logger().logError() << "\n" << bs;

--- a/DQM/BeamMonitor/plugins/BeamMonitor.h
+++ b/DQM/BeamMonitor/plugins/BeamMonitor.h
@@ -55,6 +55,8 @@ private:
   void scrollTH1(TH1*, std::time_t);
   bool testScroll(std::time_t&, std::time_t&);
   void formatFitTime(char*, const std::time_t&);
+  std::string getGMTstring(const std::time_t&);
+
   const int dxBin_;
   const double dxMin_;
   const double dxMax_;

--- a/DQM/BeamMonitor/plugins/FakeBeamMonitor.cc
+++ b/DQM/BeamMonitor/plugins/FakeBeamMonitor.cc
@@ -89,6 +89,13 @@ void FakeBeamMonitor::formatFitTime(char* ts, const time_t& t) {
 
 static constexpr int buffTime = 23;
 
+std::string FakeBeamMonitor::getGMTstring(const time_t& timeToConvert) {
+  char buff[32];
+  std::strftime(buff, sizeof(buff), "%Y.%m.%d %H:%M:%S GMT", gmtime(&timeToConvert));
+  std::string timeStr(buff);
+  return timeStr;
+}
+
 //
 // constructors and destructor
 //
@@ -881,8 +888,8 @@ void FakeBeamMonitor::FitAndFill(const LuminosityBlock& lumiSeg, int& lastlumi, 
   sprintf(tmpTitlePV, "%s %i %s %i", "Num. of reco. vertices for LS: ", beginLumiOfPVFit_, " to ", endLumiOfPVFit_);
   h_nVtx_st->setAxisTitle(tmpTitlePV, 1);
 
-  //  std::vector<float> DipPVInfo_;
-  //  DipPVInfo_.clear();
+  std::vector<float> DipPVInfo_;
+  DipPVInfo_.clear();
   //
   //  if (countTotPV_ != 0) {
   //    DipPVInfo_.push_back((float)countEvtLastNLS_);
@@ -903,6 +910,12 @@ void FakeBeamMonitor::FitAndFill(const LuminosityBlock& lumiSeg, int& lastlumi, 
   //    }
   //  }
   //  theBeamFitter->SetPVInfo(DipPVInfo_);
+  DipPVInfo_.push_back(rndm_->Gaus(1000., 100.));  // Events used
+  DipPVInfo_.push_back(rndm_->Gaus(100., 10.));    // Mean PV
+  DipPVInfo_.push_back(rndm_->Gaus(10., 5.));      // Mean PV err
+  DipPVInfo_.push_back(rndm_->Gaus(10., 5.));      // Rms PV
+  DipPVInfo_.push_back(rndm_->Gaus(5., 3.));       // Rms PV err
+  DipPVInfo_.push_back(rndm_->Gaus(100., 10.));    // Max PVs
   countEvtLastNLS_ = 0;
 
   if (onlineMode_) {  // filling LS gap
@@ -1371,7 +1384,7 @@ void FakeBeamMonitor::FitAndFill(const LuminosityBlock& lumiSeg, int& lastlumi, 
 
   // Create the BeamSpotOnlineObjects object
   BeamSpotOnlineObjects* BSOnline = new BeamSpotOnlineObjects();
-  BSOnline->SetLastAnalyzedLumi(fitLS.second);
+  BSOnline->SetLastAnalyzedLumi(LSRange.second);
   BSOnline->SetLastAnalyzedRun(frun);
   BSOnline->SetLastAnalyzedFill(0);  // To be updated with correct LHC Fill number
   BSOnline->SetPosition(bs.x0(), bs.y0(), bs.z0());
@@ -1395,9 +1408,22 @@ void FakeBeamMonitor::FitAndFill(const LuminosityBlock& lumiSeg, int& lastlumi, 
   //      BSOnline->SetNumPVs(theBeamFitter->getNPVs());
   BSOnline->SetNumTracks(50);
   BSOnline->SetNumPVs(10);
+  BSOnline->SetUsedEvents((int)DipPVInfo_[0]);
+  BSOnline->SetMeanPV(DipPVInfo_[1]);
+  BSOnline->SetMeanErrorPV(DipPVInfo_[2]);
+  BSOnline->SetRmsPV(DipPVInfo_[3]);
+  BSOnline->SetRmsErrorPV(DipPVInfo_[4]);
+  BSOnline->SetMaxPVs((int)DipPVInfo_[5]);
   auto creationTime =
       std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
   BSOnline->SetCreationTime(creationTime);
+
+  // use fake timestamps from 1970.01.01 00:00:00 to 1970.01.01 00:00:01 GMT
+  std::pair<time_t, time_t> timeForDIP = std::make_pair(0, 1);
+  BSOnline->SetStartTimeStamp(timeForDIP.first);
+  BSOnline->SetStartTime(getGMTstring(timeForDIP.first));
+  BSOnline->SetEndTimeStamp(timeForDIP.second);
+  BSOnline->SetEndTime(getGMTstring(timeForDIP.second));
 
   edm::LogInfo("FakeBeamMonitor") << "FitAndFill::[PayloadCreation] BeamSpotOnline object created: \n" << std::endl;
   edm::LogInfo("FakeBeamMonitor") << *BSOnline << std::endl;
@@ -1410,7 +1436,7 @@ void FakeBeamMonitor::FitAndFill(const LuminosityBlock& lumiSeg, int& lastlumi, 
     onlineDbService_->logger().logInfo() << "FakeBeamMonitor::FitAndFill - Do PV Fitting for LS = " << beginLumiOfPVFit_
                                          << " to " << endLumiOfPVFit_;
     onlineDbService_->logger().logInfo() << "FakeBeamMonitor::FitAndFill - [BeamFitter] Do BeamSpot Fit for LS = "
-                                         << fitLS.first << " to " << fitLS.second;
+                                         << LSRange.first << " to " << LSRange.second;
     onlineDbService_->logger().logInfo() << "FakeBeamMonitor::FitAndFill - [FakeBeamMonitor] Do BeamSpot Fit for LS = "
                                          << beginLumiOfBSFit_ << " to " << endLumiOfBSFit_;
     onlineDbService_->logger().logInfo() << "FakeBeamMonitor - RESULTS OF DEFAULT FIT:";
@@ -1418,6 +1444,17 @@ void FakeBeamMonitor::FitAndFill(const LuminosityBlock& lumiSeg, int& lastlumi, 
     onlineDbService_->logger().logInfo()
         << "FakeBeamMonitor::FitAndFill - [PayloadCreation] BeamSpotOnline object created:";
     onlineDbService_->logger().logInfo() << "\n" << *BSOnline;
+    onlineDbService_->logger().logInfo() << "FakeBeamMonitor - Additional parameters for DIP:";
+    onlineDbService_->logger().logInfo() << "Events used in the fit: " << BSOnline->GetUsedEvents();
+    onlineDbService_->logger().logInfo() << "Mean PV               : " << BSOnline->GetMeanPV();
+    onlineDbService_->logger().logInfo() << "Mean PV Error         : " << BSOnline->GetMeanErrorPV();
+    onlineDbService_->logger().logInfo() << "Rms PV                : " << BSOnline->GetRmsPV();
+    onlineDbService_->logger().logInfo() << "Rms PV Error          : " << BSOnline->GetRmsErrorPV();
+    onlineDbService_->logger().logInfo() << "Max PVs               : " << BSOnline->GetMaxPVs();
+    onlineDbService_->logger().logInfo() << "StartTime             : " << BSOnline->GetStartTime();
+    onlineDbService_->logger().logInfo() << "StartTimeStamp        : " << BSOnline->GetStartTimeStamp();
+    onlineDbService_->logger().logInfo() << "EndTime               : " << BSOnline->GetEndTime();
+    onlineDbService_->logger().logInfo() << "EndTimeStamp          : " << BSOnline->GetEndTimeStamp();
     onlineDbService_->logger().logInfo() << "FakeBeamMonitor::FitAndFill - [PayloadCreation] onlineDbService available";
     onlineDbService_->logger().logInfo() << "FakeBeamMonitor::FitAndFill - [PayloadCreation] SetCreationTime: "
                                          << creationTime << " [epoch in microseconds]";
@@ -1427,7 +1464,7 @@ void FakeBeamMonitor::FitAndFill(const LuminosityBlock& lumiSeg, int& lastlumi, 
           << "FakeBeamMonitor::FitAndFill - [PayloadCreation] writeForNextLumisection executed correctly";
     } catch (const std::exception& e) {
       onlineDbService_->logger().logError() << "FakeBeamMonitor - Error writing record: " << recordName_
-                                            << " for Run: " << frun << " - Lumi: " << fitLS.second;
+                                            << " for Run: " << frun << " - Lumi: " << LSRange.second;
       onlineDbService_->logger().logError() << "Error is: " << e.what();
       onlineDbService_->logger().logError() << "RESULTS OF DEFAULT FIT WAS:";
       onlineDbService_->logger().logError() << "\n" << bs;

--- a/DQM/BeamMonitor/plugins/FakeBeamMonitor.h
+++ b/DQM/BeamMonitor/plugins/FakeBeamMonitor.h
@@ -56,6 +56,7 @@ private:
   void scrollTH1(TH1*, std::time_t);
   bool testScroll(std::time_t&, std::time_t&);
   void formatFitTime(char*, const std::time_t&);
+  std::string getGMTstring(const std::time_t&);
 
   const int dxBin_;
   const double dxMin_;


### PR DESCRIPTION
#### PR description:
In #35193 it was reported that the `BeamSpotOnline` objects do not contain certain features that were published in DIP during Run2. This PR adds these features by extending the vector members of `CondFormats/BeamSpotObjects/interface/BeamSpotOnlineObjects.h`, specifically:
 - Events used in the BeamSpot fit [int]
 - Mean of the PVs distribution and error on the mean [float]
 - RMS of the PVs distribution and error on the RMS [float]
 - Max number of PVs [int]
 - Start (and end) time of the first (and last) LS used in the fit [string]
 - Start (and end) time of the first (and last) LS used in the fit [epoch in seconds]

DQM clients `BeamMonitor` and `FakeBeamMonitor` have been updated to add to the payload the new parameters for DIP. The DB logs have also been updated with the parameters.
Same as for the BeamSpot values in the `FakeBeamMonitor` client, all the parameters for DIP produced by the fake client are filled with random numbers coming from a TRandom3.

#### PR validation:
Tested running:
```
cmsRun DQM/Integration/python/clients/beamhltfake_dqm_sourceclient-live_cfg.py unitTest=True runNumber=3252833
```
on `/store/express/Run2018E/ExpressPhysics/FEVT/Express-v1/000/325/283/00000/DF31860D-3EA3-2B42-A7CB-ACFE8C2810DF.root`

This produces a log which contains:
```
...
-----------------------------------------------------
              BeamSpotOnline Data
 Beam type    = 2
       X0     = 0.118887 +/- 0 [cm]
       Y0     = -0.0745552 +/- 0 [cm]
       Z0     = 0.0711385 +/- 0 [cm]
 Sigma Z0     = 3.65177 +/- 0 [cm]
 dxdz         = 0 +/- 0 [radians]
 dydz         = 0 +/- 0 [radians]
 Beam Width X = 0.000404199 +/- 0 [cm]
 Beam Width Y = 0.000861879 +/- 0 [cm]
 Emittance X  = 0 [cm]
 Emittance Y  = 0 [cm]
 Beta star    = 0 [cm]
 Last Lumi    = 2
 Last Run     = 325283
 Last Fill    = 0
-----------------------------------------------------
[2021-09-19 21:57:18.589888] INFO: FakeBeamMonitor - Additional parameters for DIP:
[2021-09-19 21:57:18.589900] INFO: Events used in the fit: 821
[2021-09-19 21:57:18.589911] INFO: Mean PV               : 106.167
[2021-09-19 21:57:18.589926] INFO: Mean PV Error         : 9.39724
[2021-09-19 21:57:18.589938] INFO: Rms PV                : 7.43257
[2021-09-19 21:57:18.589950] INFO: Rms PV Error          : 7.42233
[2021-09-19 21:57:18.589962] INFO: Max PVs               : 108
[2021-09-19 21:57:18.589972] INFO: StartTime             : 1970.01.01 00:00:00 GMT
[2021-09-19 21:57:18.589982] INFO: StartTimeStamp        : 0
[2021-09-19 21:57:18.589993] INFO: EndTime               : 1970.01.01 00:00:01 GMT
[2021-09-19 21:57:18.590004] INFO: EndTimeStamp          : 1
...
```
Which shows that the new values are correectly stored and read from the BeamSpotOnline object

#### Backport:
A backport to 12_0_X will be provided.

----
FYI @sikler @mmusich @gennai @dzuolo