### PR TITLE
LowPtElectrons: fix for UL FastSim mini v2 and nano v9 workflows (back port)

### DIFF
--- a/RecoEgamma/EgammaElectronProducers/interface/LowPtGsfElectronFeatures.h
+++ b/RecoEgamma/EgammaElectronProducers/interface/LowPtGsfElectronFeatures.h
@@ -11,10 +11,15 @@
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h"
 #include <vector>
 
+namespace reco {
+  class Track;
+}
+
 namespace lowptgsfeleid {
 
   // feature list for new model (2019Sept15)
-  std::vector<float> features_V1(reco::GsfElectron const& ele, float rho, float unbiased, float field_z);
+  std::vector<float> features_V1(
+      reco::GsfElectron const& ele, float rho, float unbiased, float field_z, const reco::Track* trk = nullptr);
 
   // feature list for original models (2019Aug07 and earlier)
   std::vector<float> features_V0(reco::GsfElectron const& ele, float rho, float unbiased);

--- a/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronIDProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronIDProducer.cc
@@ -12,6 +12,7 @@
 #include "CommonTools/MVAUtils/interface/GBRForestTools.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
 #include "DataFormats/PatCandidates/interface/Electron.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 #include "DataFormats/EgammaReco/interface/SuperCluster.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
 #include "DataFormats/TrackReco/interface/Track.h"
@@ -35,12 +36,19 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions&);
 
 private:
-  double eval(const std::string& name, const edm::Ptr<reco::GsfElectron>&, double rho, float unbiased, float field_z) const;
+  double eval(const std::string& name,
+              const edm::Ptr<reco::GsfElectron>&,
+              double rho,
+              float unbiased,
+              float field_z,
+              const reco::Track* trk = nullptr) const;
 
+  const bool useGsfToTrack_;
   const bool usePAT_;
   edm::EDGetTokenT<reco::GsfElectronCollection> electrons_;
   edm::EDGetTokenT<pat::ElectronCollection> patElectrons_;
   const edm::EDGetTokenT<double> rho_;
+  edm::EDGetTokenT<edm::Association<reco::TrackCollection> > gsf2trk_;
   edm::EDGetTokenT<edm::ValueMap<float> > unbiased_;
   const std::vector<std::string> names_;
   const bool passThrough_;
@@ -54,10 +62,12 @@ private:
 ////////////////////////////////////////////////////////////////////////////////
 //
 LowPtGsfElectronIDProducer::LowPtGsfElectronIDProducer(const edm::ParameterSet& conf)
-    : usePAT_(conf.getParameter<bool>("usePAT")),
+    : useGsfToTrack_(conf.getParameter<bool>("useGsfToTrack")),
+      usePAT_(conf.getParameter<bool>("usePAT")),
       electrons_(),
       patElectrons_(),
       rho_(consumes<double>(conf.getParameter<edm::InputTag>("rho"))),
+      gsf2trk_(),
       unbiased_(),
       names_(conf.getParameter<std::vector<std::string> >("ModelNames")),
       passThrough_(conf.getParameter<bool>("PassThrough")),
@@ -65,6 +75,9 @@ LowPtGsfElectronIDProducer::LowPtGsfElectronIDProducer(const edm::ParameterSet& 
       maxPtThreshold_(conf.getParameter<double>("MaxPtThreshold")),
       thresholds_(conf.getParameter<std::vector<double> >("ModelThresholds")),
       version_(conf.getParameter<std::string>("Version")) {
+  if (useGsfToTrack_) {
+    gsf2trk_ = consumes<edm::Association<reco::TrackCollection> >(conf.getParameter<edm::InputTag>("gsfToTrack"));
+  }
   if (usePAT_) {
     patElectrons_ = consumes<pat::ElectronCollection>(conf.getParameter<edm::InputTag>("electrons"));
   } else {
@@ -107,6 +120,12 @@ void LowPtGsfElectronIDProducer::produce(edm::StreamID, edm::Event& event, const
     throw cms::Exception("InvalidHandle", os.str());
   }
 
+  // Retrieve GsfToTrack Association from Event
+  edm::Handle<edm::Association<reco::TrackCollection> > gsf2trk;
+  if (useGsfToTrack_) {
+    event.getByToken(gsf2trk_, gsf2trk);
+  }
+
   // Retrieve pat::Electrons or reco::GsfElectrons from Event
   edm::Handle<pat::ElectronCollection> patElectrons;
   edm::Handle<reco::GsfElectronCollection> electrons;
@@ -135,8 +154,29 @@ void LowPtGsfElectronIDProducer::produce(edm::StreamID, edm::Event& event, const
       if (!ele->isElectronIDAvailable("unbiased")) {
         continue;
       }
+
+      // Extract Track
+      const reco::Track* trk = nullptr;
+      if (useGsfToTrack_) {
+        const edm::Ptr<pat::PackedCandidate>* cand =
+            ele->hasUserData("ele2packed")
+                ? ele->userData<edm::Ptr<pat::PackedCandidate> >("ele2packed")
+                : ele->hasUserData("ele2lost") ? ele->userData<edm::Ptr<pat::PackedCandidate> >("ele2lost") : nullptr;
+        if (cand != nullptr && cand->isNonnull()) {
+          trk = (*cand)->bestTrack();
+        }
+      } else {
+        reco::TrackRef ref = ele->closestCtfTrackRef();
+        if (ref.isNonnull() && ref.isAvailable()) {
+          trk = ref.get();
+        }
+      }
+      if (trk == nullptr) {
+        continue;
+      }
+
       for (unsigned int iname = 0; iname < names_.size(); ++iname) {
-        output[iname][iele] = eval(names_[iname], ele, *rho, ele->electronID("unbiased"), zfield.z());
+        output[iname][iele] = eval(names_[iname], ele, *rho, ele->electronID("unbiased"), zfield.z(), trk);
       }
     }
   } else {
@@ -149,9 +189,24 @@ void LowPtGsfElectronIDProducer::produce(edm::StreamID, edm::Event& event, const
       if (gsf.isNull()) {
         continue;
       }
+
+      // Extract Track
+      const reco::Track* trk = nullptr;
+      if (useGsfToTrack_) {
+        trk = (*gsf2trk)[gsf].get();
+      } else {
+        reco::TrackRef ref = ele->closestCtfTrackRef();
+        if (ref.isNonnull() && ref.isAvailable()) {
+          trk = ref.get();
+        }
+      }
+      if (trk == nullptr) {
+        continue;
+      }
+
       float unbiased = (*unbiasedH)[gsf];
       for (unsigned int iname = 0; iname < names_.size(); ++iname) {
-        output[iname][iele] = eval(names_[iname], ele, *rho, unbiased, zfield.z());
+        output[iname][iele] = eval(names_[iname], ele, *rho, unbiased, zfield.z(), trk);
       }
     }
   }
@@ -172,8 +227,12 @@ void LowPtGsfElectronIDProducer::produce(edm::StreamID, edm::Event& event, const
 
 //////////////////////////////////////////////////////////////////////////////////////////
 //
-double LowPtGsfElectronIDProducer::eval(
-  const std::string& name, const edm::Ptr<reco::GsfElectron>& ele, double rho, float unbiased, float field_z) const {
+double LowPtGsfElectronIDProducer::eval(const std::string& name,
+                                        const edm::Ptr<reco::GsfElectron>& ele,
+                                        double rho,
+                                        float unbiased,
+                                        float field_z,
+                                        const reco::Track* trk) const {
   auto iter = std::find(names_.begin(), names_.end(), name);
   if (iter != names_.end()) {
     int index = std::distance(names_.begin(), iter);
@@ -185,7 +244,7 @@ double LowPtGsfElectronIDProducer::eval(
     } else if (version_ == "V0") {
       inputs = lowptgsfeleid::features_V0(*ele, rho, unbiased);
     } else if (version_ == "V1") {
-      inputs = lowptgsfeleid::features_V1(*ele, rho, unbiased, field_z);
+      inputs = lowptgsfeleid::features_V1(*ele, rho, unbiased, field_z, trk);
     }
     return models_.at(index)->GetResponse(inputs.data());
   } else {
@@ -198,8 +257,10 @@ double LowPtGsfElectronIDProducer::eval(
 //
 void LowPtGsfElectronIDProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
+  desc.add<bool>("useGsfToTrack", false);
   desc.add<bool>("usePAT", false);
   desc.add<edm::InputTag>("electrons", edm::InputTag("lowPtGsfElectrons"));
+  desc.addOptional<edm::InputTag>("gsfToTrack", edm::InputTag("lowPtGsfToTrackLinks"));
   desc.addOptional<edm::InputTag>("unbiased", edm::InputTag("lowPtGsfElectronSeedValueMaps:unbiased"));
   desc.add<edm::InputTag>("rho", edm::InputTag("fixedGridRhoFastjetAllTmp"));
   desc.add<std::vector<std::string> >("ModelNames", std::vector<std::string>());

--- a/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronIDProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronIDProducer.cc
@@ -195,7 +195,12 @@ void LowPtGsfElectronIDProducer::produce(edm::StreamID, edm::Event& event, const
       // Extract Track
       const reco::Track* trk = nullptr;
       if (useGsfToTrack_) {
-        trk = (*gsf2trk)[gsf].get();
+        if (gsf.isAvailable()) {
+          auto const& ref = (*gsf2trk)[gsf];
+          if (ref.isNonnull() && ref.isAvailable()) {
+            trk = ref.get();
+          }
+        }
       } else {
         reco::TrackRef ref = ele->closestCtfTrackRef();
         if (ref.isNonnull() && ref.isAvailable()) {

--- a/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronIDProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronIDProducer.cc
@@ -158,16 +158,18 @@ void LowPtGsfElectronIDProducer::produce(edm::StreamID, edm::Event& event, const
       // Extract Track
       const reco::Track* trk = nullptr;
       if (useGsfToTrack_) {
-        const edm::Ptr<pat::PackedCandidate>* ptr1 =
-	  ele->hasUserData("ele2packed") ? ele->userData<edm::Ptr<pat::PackedCandidate> >("ele2packed") : nullptr;
-        const edm::Ptr<pat::PackedCandidate>* ptr2 =
-	  ele->hasUserData("ele2lost") ? ele->userData<edm::Ptr<pat::PackedCandidate> >("ele2lost") : nullptr;
-        const pat::PackedCandidate* cand1 = ptr1 && ptr1->isNonnull() ? ptr1->get() : nullptr;
-        const pat::PackedCandidate* cand2 = ptr2 && ptr2->isNonnull() ? ptr2->get() : nullptr;
-	const pat::PackedCandidate* cand = cand1 ? cand1 : cand2;
-        if (cand != nullptr) {
-          trk = cand->bestTrack();
-        }
+	using PackedPtr = edm::Ptr<pat::PackedCandidate>;
+	const PackedPtr* ptr1 = ele->userData<PackedPtr>("ele2packed");
+	const PackedPtr* ptr2 = ele->userData<PackedPtr>("ele2lost");
+	auto hasBestTrack = [](const PackedPtr* ptr) {
+	  return ptr != nullptr && ptr->isNonnull() && ptr->isAvailable() && ptr->get() != nullptr &&
+	  ptr->get()->bestTrack() != nullptr;
+	};
+	if (hasBestTrack(ptr1)) {
+	  trk = ptr1->get()->bestTrack();
+	} else if (hasBestTrack(ptr2)) {
+	  trk = ptr2->get()->bestTrack();
+	}
       } else {
         reco::TrackRef ref = ele->closestCtfTrackRef();
         if (ref.isNonnull() && ref.isAvailable()) {

--- a/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronIDProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronIDProducer.cc
@@ -158,12 +158,15 @@ void LowPtGsfElectronIDProducer::produce(edm::StreamID, edm::Event& event, const
       // Extract Track
       const reco::Track* trk = nullptr;
       if (useGsfToTrack_) {
-        const edm::Ptr<pat::PackedCandidate>* cand =
-            ele->hasUserData("ele2packed")
-                ? ele->userData<edm::Ptr<pat::PackedCandidate> >("ele2packed")
-                : ele->hasUserData("ele2lost") ? ele->userData<edm::Ptr<pat::PackedCandidate> >("ele2lost") : nullptr;
-        if (cand != nullptr && cand->isNonnull()) {
-          trk = (*cand)->bestTrack();
+        const edm::Ptr<pat::PackedCandidate>* ptr1 =
+	  ele->hasUserData("ele2packed") ? ele->userData<edm::Ptr<pat::PackedCandidate> >("ele2packed") : nullptr;
+        const edm::Ptr<pat::PackedCandidate>* ptr2 =
+	  ele->hasUserData("ele2lost") ? ele->userData<edm::Ptr<pat::PackedCandidate> >("ele2lost") : nullptr;
+        const pat::PackedCandidate* cand1 = ptr1 && ptr1->isNonnull() ? ptr1->get() : nullptr;
+        const pat::PackedCandidate* cand2 = ptr2 && ptr2->isNonnull() ? ptr2->get() : nullptr;
+	const pat::PackedCandidate* cand = cand1 ? cand1 : cand2;
+        if (cand != nullptr) {
+          trk = cand->bestTrack();
         }
       } else {
         reco::TrackRef ref = ele->closestCtfTrackRef();

--- a/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronIDProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronIDProducer.cc
@@ -176,9 +176,6 @@ void LowPtGsfElectronIDProducer::produce(edm::StreamID, edm::Event& event, const
           trk = ref.get();
         }
       }
-      if (trk == nullptr) {
-        continue;
-      }
 
       for (unsigned int iname = 0; iname < names_.size(); ++iname) {
         output[iname][iele] = eval(names_[iname], ele, *rho, ele->electronID("unbiased"), zfield.z(), trk);
@@ -204,9 +201,6 @@ void LowPtGsfElectronIDProducer::produce(edm::StreamID, edm::Event& event, const
         if (ref.isNonnull() && ref.isAvailable()) {
           trk = ref.get();
         }
-      }
-      if (trk == nullptr) {
-        continue;
       }
 
       float unbiased = (*unbiasedH)[gsf];

--- a/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronIDProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronIDProducer.cc
@@ -158,18 +158,18 @@ void LowPtGsfElectronIDProducer::produce(edm::StreamID, edm::Event& event, const
       // Extract Track
       const reco::Track* trk = nullptr;
       if (useGsfToTrack_) {
-	using PackedPtr = edm::Ptr<pat::PackedCandidate>;
-	const PackedPtr* ptr1 = ele->userData<PackedPtr>("ele2packed");
-	const PackedPtr* ptr2 = ele->userData<PackedPtr>("ele2lost");
-	auto hasBestTrack = [](const PackedPtr* ptr) {
-	  return ptr != nullptr && ptr->isNonnull() && ptr->isAvailable() && ptr->get() != nullptr &&
-	  ptr->get()->bestTrack() != nullptr;
-	};
-	if (hasBestTrack(ptr1)) {
-	  trk = ptr1->get()->bestTrack();
-	} else if (hasBestTrack(ptr2)) {
-	  trk = ptr2->get()->bestTrack();
-	}
+        using PackedPtr = edm::Ptr<pat::PackedCandidate>;
+        const PackedPtr* ptr1 = ele->userData<PackedPtr>("ele2packed");
+        const PackedPtr* ptr2 = ele->userData<PackedPtr>("ele2lost");
+        auto hasBestTrack = [](const PackedPtr* ptr) {
+          return ptr != nullptr && ptr->isNonnull() && ptr->isAvailable() && ptr->get() != nullptr &&
+                 ptr->get()->bestTrack() != nullptr;
+        };
+        if (hasBestTrack(ptr1)) {
+          trk = ptr1->get()->bestTrack();
+        } else if (hasBestTrack(ptr2)) {
+          trk = ptr2->get()->bestTrack();
+        }
       } else {
         reco::TrackRef ref = ele->closestCtfTrackRef();
         if (ref.isNonnull() && ref.isAvailable()) {

--- a/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronID_cff.py
+++ b/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronID_cff.py
@@ -28,3 +28,9 @@ run2_miniAOD_devel.toModify(
     lowPtGsfElectronID,
     ModelWeights = ["RecoEgamma/ElectronIdentification/data/LowPtElectrons/LowPtElectrons_ID_2021May17.root"],
 )
+
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+fastSim.toModify(
+    lowPtGsfElectronID,
+    useGsfToTrack = True,
+)

--- a/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronID_cff.py
+++ b/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronID_cff.py
@@ -30,7 +30,9 @@ run2_miniAOD_devel.toModify(
 )
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-fastSim.toModify(
+from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
+from PhysicsTools.NanoAOD.nano_eras_cff import *
+(fastSim & (run2_miniAOD_UL | run2_nanoAOD_106Xv2)).toModify(
     lowPtGsfElectronID,
     useGsfToTrack = True,
 )

--- a/RecoEgamma/EgammaElectronProducers/src/LowPtGsfElectronFeatures.cc
+++ b/RecoEgamma/EgammaElectronProducers/src/LowPtGsfElectronFeatures.cc
@@ -11,7 +11,8 @@
 
 namespace lowptgsfeleid {
 
-  std::vector<float> features_V1(reco::GsfElectron const& ele, float rho, float unbiased, float field_z) {
+  std::vector<float> features_V1(
+      reco::GsfElectron const& ele, float rho, float unbiased, float field_z, const reco::Track* trk) {
     float eid_rho = -999.;
     float eid_sc_eta = -999.;
     float eid_shape_full5x5_r9 = -999.;
@@ -47,17 +48,28 @@ namespace lowptgsfeleid {
     float sc_clus2_E_ov_p = -999.;
 
     // KF tracks
-    if (ele.core().isNonnull()) {
-      reco::TrackRef trk = ele.closestCtfTrackRef();
-      if (trk.isNonnull()) {
-        eid_trk_p = (float)trk->p();
-        eid_trk_nhits = (float)trk->found();
-        eid_trk_chi2red = (float)trk->normalizedChi2();
-        TVector3 trkTV3(0, 0, 0);
-        trkTV3.SetPtEtaPhi(trk->pt(), trk->eta(), trk->phi());
-        TVector3 eleTV3(0, 0, 0);
-        eleTV3.SetPtEtaPhi(ele.pt(), ele.eta(), ele.phi());
-        trk_dr = eleTV3.DeltaR(trkTV3);
+    if (trk != nullptr) {
+      eid_trk_p = (float)trk->p();
+      eid_trk_nhits = (float)trk->found();
+      eid_trk_chi2red = (float)trk->normalizedChi2();
+      TVector3 trkTV3(0, 0, 0);
+      trkTV3.SetPtEtaPhi(trk->pt(), trk->eta(), trk->phi());
+      TVector3 eleTV3(0, 0, 0);
+      eleTV3.SetPtEtaPhi(ele.pt(), ele.eta(), ele.phi());
+      trk_dr = eleTV3.DeltaR(trkTV3);
+    } else {
+      if (ele.core().isNonnull()) {
+        reco::TrackRef trk = ele.closestCtfTrackRef();
+        if (trk.isNonnull()) {
+          eid_trk_p = (float)trk->p();
+          eid_trk_nhits = (float)trk->found();
+          eid_trk_chi2red = (float)trk->normalizedChi2();
+          TVector3 trkTV3(0, 0, 0);
+          trkTV3.SetPtEtaPhi(trk->pt(), trk->eta(), trk->phi());
+          TVector3 eleTV3(0, 0, 0);
+          eleTV3.SetPtEtaPhi(ele.pt(), ele.eta(), ele.phi());
+          trk_dr = eleTV3.DeltaR(trkTV3);
+        }
       }
     }
 

--- a/RecoEgamma/EgammaElectronProducers/src/LowPtGsfElectronFeatures.cc
+++ b/RecoEgamma/EgammaElectronProducers/src/LowPtGsfElectronFeatures.cc
@@ -48,29 +48,16 @@ namespace lowptgsfeleid {
     float sc_clus2_E_ov_p = -999.;
 
     // KF tracks
-    if (trk != nullptr) {
-      eid_trk_p = (float)trk->p();
-      eid_trk_nhits = (float)trk->found();
-      eid_trk_chi2red = (float)trk->normalizedChi2();
+    if (trk != nullptr || (ele.core().isNonnull() && ele.closestCtfTrackRef().isNonnull())) {
+      const reco::Track* tk = trk ? trk : &*ele.closestCtfTrackRef();
+      eid_trk_p = tk->p();
+      eid_trk_nhits = tk->found();
+      eid_trk_chi2red = tk->normalizedChi2();
       TVector3 trkTV3(0, 0, 0);
-      trkTV3.SetPtEtaPhi(trk->pt(), trk->eta(), trk->phi());
+      trkTV3.SetPtEtaPhi(tk->pt(), tk->eta(), tk->phi());
       TVector3 eleTV3(0, 0, 0);
       eleTV3.SetPtEtaPhi(ele.pt(), ele.eta(), ele.phi());
-      trk_dr = eleTV3.DeltaR(trkTV3);
-    } else {
-      if (ele.core().isNonnull()) {
-        reco::TrackRef trk = ele.closestCtfTrackRef();
-        if (trk.isNonnull()) {
-          eid_trk_p = (float)trk->p();
-          eid_trk_nhits = (float)trk->found();
-          eid_trk_chi2red = (float)trk->normalizedChi2();
-          TVector3 trkTV3(0, 0, 0);
-          trkTV3.SetPtEtaPhi(trk->pt(), trk->eta(), trk->phi());
-          TVector3 eleTV3(0, 0, 0);
-          eleTV3.SetPtEtaPhi(ele.pt(), ele.eta(), ele.phi());
-          trk_dr = eleTV3.DeltaR(trkTV3);
-        }
-      }
+      trk_dr = reco::deltaR(*tk, ele);
     }
 
     // GSF tracks


### PR DESCRIPTION
#### PR description:

- UL mini v2 workflows for FastSim are broken due to an exception thrown by the `LowPtGsfElectronIDProducer` when attempting to access an `edm::Ref` to the missing `generalTracksBeforeMixing` collection in AOD. 
- All details can be found in this issue: https://github.com/cms-sw/cmssw/issues/34774.
- For re-miniaod (and re-nanoaod) workflows, this PR also provides an acceptable workaround that allows the ID producer to evaluate the BDT model without throwing an exception, while maintaining the expected physics performance. This is achieved by extracting features from the KF track used in the `ElectronSeed` step (obtained from the available `generalTracks` collection in AOD), instead of from the KF track embedded in the `GsfElectronCore` object (which is chosen based on number of shared hits with the `GsfTrack` and obtained from the missing `generalTracksBeforeMixing` collection in AOD). 
- All development was performed in the 10_6_X cycle (see the compare [here](https://github.com/cms-sw/cmssw/compare/CMSSW_10_6_X...bainbrid:LowPtElectrons_ULFastSimFix_106X)), tested with the example recipes provided in the issue [#34774](#34774), and then ported to master (this PR).
- Also tested is the behaviour for the nano v9 workflow, which is similarly affected.
- This work was presented to RECO/AT here: https://indico.cern.ch/event/1071803/. The final slide compares physics performance b/w the 10_6_X and 12_1_X cycles (essentially identical).
- Physics and computing performances are ~unaffected. 

#### PR validation:

This PR was validated using cmsDriver commands that performed the GEN->AOD and mini v2 steps, based on those provided [here](https://github.com/cms-sw/cmssw/issues/34774#issue-960576497), for tests with the 10_6_X cycle, and modified versions for tests with the 12_1_X release (this PR). 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is a back port of #35181.

@slava77 @jordan-martins @crovelli 
