### PR TITLE
Migration of  IORawDaata/CSCCommissioning/CSCFileDumper module to thread-safe edm:one::EDAnalyzer

### DIFF
--- a/IORawData/CSCCommissioning/src/CSCFileDumper.cc
+++ b/IORawData/CSCCommissioning/src/CSCFileDumper.cc
@@ -20,7 +20,7 @@
 #include <iostream>
 #include <sstream>
 
-CSCFileDumper::CSCFileDumper(const edm::ParameterSet &pset) {
+CSCFileDumper::CSCFileDumper(edm::ParameterSet const &pset) {
   i_token = consumes<FEDRawDataCollection>(pset.getParameter<edm::InputTag>("source"));
   // source_ = pset.getUntrackedParameter<std::string>("source","rawDataCollector");
   output = pset.getUntrackedParameter<std::string>("output");

--- a/IORawData/CSCCommissioning/src/CSCFileDumper.h
+++ b/IORawData/CSCCommissioning/src/CSCFileDumper.h
@@ -1,7 +1,7 @@
-#ifndef CSCFileDumper_h
-#define CSCFileDumper_h
+#ifndef IORawData_CSCCommissioning_CSCFileDumper_h
+#define IORawData_CSCCommissioning_CSCFileDumper_h
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -11,7 +11,7 @@
 
 #include <cstdio>
 
-class CSCFileDumper : public edm::EDAnalyzer {
+class CSCFileDumper : public edm::one::EDAnalyzer<> {
 public:
   std::map<int, FILE*> dump_files;
   std::set<unsigned long> eventsToDump;
@@ -20,10 +20,12 @@ public:
   std::string output, events;
   //	int fedID_first, fedID_last;
 
-  CSCFileDumper(const edm::ParameterSet& pset);
+  CSCFileDumper(edm::ParameterSet const& pset);
   ~CSCFileDumper(void) override;
 
+  void beginJob() override{};
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
+  void endJob() override{};
 
 private:
   std::vector<unsigned int> cscFEDids;

--- a/IORawData/CSCCommissioning/test/dumpTest.py
+++ b/IORawData/CSCCommissioning/test/dumpTest.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("TEST")
 
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
-process.MessageLogger.cout.placeholder = cms.untracked.bool(False)
+#process.MessageLogger.cout.placeholder = cms.untracked.bool(False)
 process.MessageLogger.cout.threshold = cms.untracked.string('INFO')
 process.MessageLogger.debugModules = cms.untracked.vstring('*')
 


### PR DESCRIPTION
#### PR description:
Migration of IORawDaata/CSCCommissioning/CSCFileDumper module from edm::EDAnalyzer to thread-safe edm:one::EDAnalyzer
CSCFileDumper - CSC-only tool to convert ED ROOT data files to CSC local DAQ format for further processing with CSC standalone tools

#### PR validation:
Compiles without errors
Sample data file was converted to CSC Local DAQ format

