### PR TITLE
Fix addOnTests.py option -t for python3

### DIFF
--- a/Utilities/ReleaseScripts/scripts/addOnTests.py
+++ b/Utilities/ReleaseScripts/scripts/addOnTests.py
@@ -145,11 +145,9 @@ class StandardTester(object):
 
         print('Running in %s thread(s)' % self.maxThreads)
 
+        if testList:
+            self.commands = {d:c for d,c in self.commands.items() if d in testList}
         for dirName, command in self.commands.items():
-
-            if testList and not dirName in testList:
-                del self.commands[dirName]
-                continue
 
             # make sure we don't run more than the allowed number of threads:
             while self.activeThreads() >= self.maxThreads:


### PR DESCRIPTION
#### PR description:

`addOnTests.py -t` complained that the `self.commands` dictionary was being modified during iteration via `self.commands.items()`. This PR suggests to fix the error by filtering the `self.commands` by `testList` beforehand.

#### PR validation:

`addOnTests.py -t <tests>` works again in a private test.
