### PR TITLE
`TrackToTrackComparisonHists`: use correct handle to check if vertex collection is present

### DIFF
--- a/DQM/TrackingMonitorSource/src/TrackToTrackComparisonHists.cc
+++ b/DQM/TrackingMonitorSource/src/TrackToTrackComparisonHists.cc
@@ -120,7 +120,7 @@ void TrackToTrackComparisonHists::analyze(const edm::Event& iEvent, const edm::E
 
   edm::Handle<reco::VertexCollection> monitoredPVHandle;
   iEvent.getByToken(monitoredPVToken_, monitoredPVHandle);
-  if (!monitoredTracksHandle.isValid()) {
+  if (!monitoredPVHandle.isValid()) {
     edm::LogError("TrackToTrackComparisonHists") << "monitoredPVHandle not found, skipping event";
     return;
   }


### PR DESCRIPTION
#### PR description:

Fix for https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/2261/2/1/2.html

#### PR validation:

Tested with `PSet`s provided from Tier-0  https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/2261/2/1/2/2/1/1/1.html and patched with the new Global Tag:
```
process.GlobalTag.globaltag = '113X_dataRun3_Express_Candidate_2021_09_20_22_29_07'
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, but a backport will be needed.  
