### PR TITLE
HBHEGPU: added taggedBadByDb by ChannelQuality in GPU [12_0_X] 

### DIFF
--- a/CondFormats/HcalObjects/interface/HcalChannelQualityGPU.h
+++ b/CondFormats/HcalObjects/interface/HcalChannelQualityGPU.h
@@ -1,0 +1,38 @@
+#ifndef CondFormats_HcalObjects_interface_HcalChannelQualityGPU_h
+#define CondFormats_HcalObjects_interface_HcalChannelQualityGPU_h
+
+#include "CondFormats/HcalObjects/interface/HcalChannelQuality.h"
+#include "FWCore/Utilities/interface/propagate_const_array.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
+
+#ifndef __CUDACC__
+#include "HeterogeneousCore/CUDAUtilities/interface/HostAllocator.h"
+#include "HeterogeneousCore/CUDACore/interface/ESProduct.h"
+#endif
+
+class HcalChannelQualityGPU {
+public:
+  struct Product {
+    edm::propagate_const_array<cms::cuda::device::unique_ptr<uint32_t[]>> status;
+  };
+
+#ifndef __CUDACC__
+  // rearrange reco params
+  HcalChannelQualityGPU(HcalChannelQuality const &);
+
+  // will trigger deallocation of Product thru ~Product
+  ~HcalChannelQualityGPU() = default;
+
+  // get device pointers
+  Product const &getProduct(cudaStream_t) const;
+
+private:
+  uint64_t totalChannels_;
+  std::vector<uint32_t, cms::cuda::HostAllocator<uint32_t>> status_;
+
+  cms::cuda::ESProduct<Product> product_;
+#endif  // __CUDACC__
+};
+
+
+#endif  // RecoLocalCalo_HcalRecAlgos_interface_HcalChannelQualityGPU_h

--- a/CondFormats/HcalObjects/src/HcalChannelQualityGPU.cc
+++ b/CondFormats/HcalObjects/src/HcalChannelQualityGPU.cc
@@ -1,0 +1,40 @@
+#include "CondFormats/HcalObjects/interface/HcalChannelQuality.h"
+#include "CondFormats/HcalObjects/interface/HcalChannelQualityGPU.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/copyAsync.h"
+
+// FIXME: add proper getters to conditions
+HcalChannelQualityGPU::HcalChannelQualityGPU(HcalChannelQuality const& quality)
+    : totalChannels_{quality.getAllContainers()[0].second.size() + quality.getAllContainers()[1].second.size()},
+      status_(totalChannels_) {
+  auto const containers = quality.getAllContainers();
+
+  // fill in eb
+  auto const& barrelValues = containers[0].second;
+  for (uint64_t i = 0; i < barrelValues.size(); ++i) {
+    status_[i] = barrelValues[i].getValue();
+  }
+
+  // fill in ee
+  auto const& endcapValues = containers[1].second;
+  auto const offset = barrelValues.size();
+  for (uint64_t i = 0; i < endcapValues.size(); ++i) {
+    status_[i + offset] = endcapValues[i].getValue();
+  }
+}
+
+HcalChannelQualityGPU::Product const& HcalChannelQualityGPU::getProduct(cudaStream_t stream) const {
+  auto const& product =
+      product_.dataForCurrentDeviceAsync(stream, [this](HcalChannelQualityGPU::Product& product, cudaStream_t stream) {
+        // allocate
+        product.status = cms::cuda::make_device_unique<uint32_t[]>(status_.size(), stream);
+
+        // transfer
+        cms::cuda::copyAsync(product.status, status_, stream);
+
+      });
+
+  return product;
+}
+
+TYPELOOKUP_DATA_REG(HcalChannelQualityGPU);

--- a/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
+++ b/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
@@ -542,6 +542,7 @@ def customiseHcalLocalReconstruction(process):
 
     process.load("EventFilter.HcalRawToDigi.hcalElectronicsMappingGPUESProducer_cfi")
 
+    process.load("RecoLocalCalo.HcalRecProducers.hcalChannelQualityGPUESProducer_cfi")
     process.load("RecoLocalCalo.HcalRecProducers.hcalGainsGPUESProducer_cfi")
     process.load("RecoLocalCalo.HcalRecProducers.hcalGainWidthsGPUESProducer_cfi")
     process.load("RecoLocalCalo.HcalRecProducers.hcalLUTCorrsGPUESProducer_cfi")

--- a/RecoLocalCalo/HcalRecProducers/python/hbheRecHitProducerGPUTask_cff.py
+++ b/RecoLocalCalo/HcalRecProducers/python/hbheRecHitProducerGPUTask_cff.py
@@ -15,6 +15,7 @@ from RecoLocalCalo.HcalRecProducers.hcalConvertedEffectivePedestalWidthsGPUESPro
 hcalConvertedEffectivePedestalWidthsGPUESProducer.label0 = "withTopoEff"
 hcalConvertedEffectivePedestalWidthsGPUESProducer.label1 = "withTopoEff"
 
+from RecoLocalCalo.HcalRecProducers.hcalChannelQualityGPUESProducer_cfi import hcalChannelQualityGPUESProducer
 from RecoLocalCalo.HcalRecProducers.hcalQIECodersGPUESProducer_cfi import hcalQIECodersGPUESProducer
 from RecoLocalCalo.HcalRecProducers.hcalRecoParamsWithPulseShapesGPUESProducer_cfi import hcalRecoParamsWithPulseShapesGPUESProducer
 from RecoLocalCalo.HcalRecProducers.hcalRespCorrsGPUESProducer_cfi import hcalRespCorrsGPUESProducer
@@ -50,6 +51,7 @@ hbheRecHitProducerGPUTask = cms.Task(
     hcalConvertedEffectivePedestalsGPUESProducer,
     hcalConvertedPedestalWidthsGPUESProducer,
     hcalConvertedEffectivePedestalWidthsGPUESProducer,
+    hcalChannelQualityGPUESProducer,
     hcalQIECodersGPUESProducer,
     hcalRecoParamsWithPulseShapesGPUESProducer,
     hcalRespCorrsGPUESProducer,

--- a/RecoLocalCalo/HcalRecProducers/src/DeclsForKernels.h
+++ b/RecoLocalCalo/HcalRecProducers/src/DeclsForKernels.h
@@ -4,6 +4,7 @@
 #include <functional>
 #include <optional>
 
+#include "CondFormats/HcalObjects/interface/HcalChannelStatus.h"
 #include "CUDADataFormats/HcalDigi/interface/DigiCollection.h"
 #include "CUDADataFormats/HcalRecHitSoA/interface/RecHitCollection.h"
 #include "CalibCalorimetry/HcalAlgos/interface/HcalTimeSlew.h"
@@ -18,6 +19,7 @@
 #include "CondFormats/DataRecord/interface/HcalSiPMCharacteristicsRcd.h"
 #include "CondFormats/DataRecord/interface/HcalSiPMParametersRcd.h"
 #include "CondFormats/DataRecord/interface/HcalTimeCorrsRcd.h"
+#include "CondFormats/DataRecord/interface/HcalChannelQualityRcd.h"
 #include "CondFormats/HcalObjects/interface/HcalConvertedEffectivePedestalWidthsGPU.h"
 #include "CondFormats/HcalObjects/interface/HcalConvertedEffectivePedestalsGPU.h"
 #include "CondFormats/HcalObjects/interface/HcalGainWidthsGPU.h"
@@ -30,6 +32,7 @@
 #include "CondFormats/HcalObjects/interface/HcalSiPMCharacteristicsGPU.h"
 #include "CondFormats/HcalObjects/interface/HcalSiPMParametersGPU.h"
 #include "CondFormats/HcalObjects/interface/HcalTimeCorrsGPU.h"
+#include "CondFormats/HcalObjects/interface/HcalChannelQualityGPU.h"
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
 #include "Geometry/HcalCommonData/interface/HcalDDDRecConstants.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
@@ -49,6 +52,7 @@ namespace hcal {
       HcalConvertedEffectivePedestalWidthsGPU::Product const& effectivePedestalWidths;
       HcalConvertedPedestalsGPU::Product const& pedestals;
       HcalQIECodersGPU::Product const& qieCoders;
+      HcalChannelQualityGPU::Product const& channelQuality;
       HcalRecoParamsWithPulseShapesGPU::Product const& recoParams;
       HcalRespCorrsGPU::Product const& respCorrs;
       HcalTimeCorrsGPU::Product const& timeCorrs;

--- a/RecoLocalCalo/HcalRecProducers/src/HBHERecHitProducerGPU.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HBHERecHitProducerGPU.cc
@@ -175,6 +175,10 @@ void HBHERecHitProducerGPU::acquire(edm::Event const& event,
   edm::ESHandle<HcalDDDRecConstants> recConstantsHandle;
   setup.get<HcalRecNumberingRecord>().get(recConstantsHandle);
 
+  edm::ESHandle<HcalChannelQualityGPU> qualHandle;
+  setup.get<HcalChannelQualityRcd>().get(qualHandle);
+  auto const& chQualProduct = qualHandle->getProduct(ctx.stream());
+
   edm::ESHandle<HcalSiPMParametersGPU> sipmParametersHandle;
   setup.get<HcalSiPMParametersRcd>().get(sipmParametersHandle);
   auto const& sipmParametersProduct = sipmParametersHandle->getProduct(ctx.stream());
@@ -195,6 +199,7 @@ void HBHERecHitProducerGPU::acquire(edm::Event const& event,
                                                       effectivePedestalWidthsProduct,
                                                       pedestalsProduct,
                                                       qieCodersProduct,
+                                                      chQualProduct,
                                                       recoParamsProduct,
                                                       respCorrsProduct,
                                                       timeCorrsProduct,

--- a/RecoLocalCalo/HcalRecProducers/src/HcalESProducersGPUDefs.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalESProducersGPUDefs.cc
@@ -33,6 +33,9 @@
 #include "CondFormats/HcalObjects/interface/HcalRecoParamsGPU.h"
 #include "CondFormats/HcalObjects/interface/HcalRespCorrs.h"
 #include "CondFormats/HcalObjects/interface/HcalRespCorrsGPU.h"
+#include "CondFormats/HcalObjects/interface/HcalChannelQuality.h"
+#include "CondFormats/HcalObjects/interface/HcalChannelQualityGPU.h"
+#include "CondFormats/DataRecord/interface/HcalChannelQualityRcd.h"
 #include "CondFormats/HcalObjects/interface/HcalSiPMCharacteristics.h"
 #include "CondFormats/HcalObjects/interface/HcalSiPMCharacteristicsGPU.h"
 #include "CondFormats/HcalObjects/interface/HcalSiPMParameters.h"
@@ -64,6 +67,8 @@ using HcalPedestalWidthsGPUESProducer =
 using HcalGainWidthsGPUESProducer = ConvertingESProducerT<HcalGainWidthsRcd, HcalGainWidthsGPU, HcalGainWidths>;
 
 using HcalQIECodersGPUESProducer = ConvertingESProducerT<HcalQIEDataRcd, HcalQIECodersGPU, HcalQIEData>;
+
+using HcalChannelQualityGPUESProducer = ConvertingESProducerT<HcalChannelQualityRcd, HcalChannelQualityGPU, HcalChannelQuality>;
 
 using HcalQIETypesGPUESProducer = ConvertingESProducerT<HcalQIETypesRcd, HcalQIETypesGPU, HcalQIETypes>;
 
@@ -111,6 +116,7 @@ DEFINE_FWK_EVENTSETUP_MODULE(HcalTimeCorrsGPUESProducer);
 DEFINE_FWK_EVENTSETUP_MODULE(HcalPedestalWidthsGPUESProducer);
 DEFINE_FWK_EVENTSETUP_MODULE(HcalGainWidthsGPUESProducer);
 DEFINE_FWK_EVENTSETUP_MODULE(HcalQIECodersGPUESProducer);
+DEFINE_FWK_EVENTSETUP_MODULE(HcalChannelQualityGPUESProducer);
 DEFINE_FWK_EVENTSETUP_MODULE(HcalQIETypesGPUESProducer);
 DEFINE_FWK_EVENTSETUP_MODULE(HcalSiPMParametersGPUESProducer);
 DEFINE_FWK_EVENTSETUP_MODULE(HcalSiPMCharacteristicsGPUESProducer);

--- a/RecoLocalCalo/HcalRecProducers/src/MahiGPU.cu
+++ b/RecoLocalCalo/HcalRecProducers/src/MahiGPU.cu
@@ -89,6 +89,7 @@ namespace hcal {
                                                       float* method0Time,
                                                       uint32_t* outputdid,
                                                       uint32_t const nchannels,
+						      uint32_t const* qualityStatus,
                                                       uint32_t const* recoParam1Values,
                                                       uint32_t const* recoParam2Values,
                                                       float const* qieCoderOffsets,
@@ -389,6 +390,17 @@ namespace hcal {
         printf("tsTOT = %f tstrig = %f ts4Thresh = %f\n", shrEnergyM0TotalAccum[lch], energym0_per_ts_gain0, ts4Thresh);
 #endif
 
+	// Channel quality check
+	//    https://github.com/cms-sw/cmssw/blob/master/RecoLocalCalo/HcalRecAlgos/plugins/HcalChannelPropertiesEP.cc#L107-L109
+	//    https://github.com/cms-sw/cmssw/blob/6d2f66057131baacc2fcbdd203588c41c885b42c/CondCore/HcalPlugins/plugins/HcalChannelQuality_PayloadInspector.cc#L30
+	//      const bool taggedBadByDb = severity.dropChannel(digistatus->getValue());
+	//  do not run MAHI if taggedBadByDb = true
+
+	auto const digiStatus_ = qualityStatus[hashedId];
+	const bool taggedBadByDb = (digiStatus_/32770);
+
+	if(taggedBadByDb) outputChi2[gch] = -9999.f;
+
         // check as in cpu version if mahi is not needed
         // FIXME: KNOWN ISSUE: observed a problem when rawCharge and pedestal
         // are basically equal and generate -0.00000...
@@ -418,7 +430,7 @@ namespace hcal {
 
 #ifdef HCAL_MAHI_GPUDEBUG
       printf(
-          "charrge(%d) = %f pedestal(%d) = %f dfc(%d) = %f pedestalWidth(%d) = %f noiseADC(%d) = %f noisPhoto(%d) = "
+          "charge(%d) = %f pedestal(%d) = %f dfc(%d) = %f pedestalWidth(%d) = %f noiseADC(%d) = %f noisPhoto(%d) = "
           "%f\n",
           sample,
           rawCharge,
@@ -1100,6 +1112,7 @@ namespace hcal {
           outputGPU.recHits.timeM0.get(),
           outputGPU.recHits.did.get(),
           totalChannels,
+	  conditions.channelQuality.status,
           conditions.recoParams.param1,
           conditions.recoParams.param2,
           conditions.qieCoders.offsets,


### PR DESCRIPTION
This PR add a functionality to the Mahi on GPU that take into account the HcalChannelQuality to resynch with what is done on CPU

On CPU the rechit is dropped, while for the GPU energy is set to 0.
Tested on Run3 MC, and disable the ieta=18, depth1. (Those channel are present only at DIGI, but the fiber is not connected to the scintillator, so energy is not meaningful.)

Help in solving some differences observed between the Run3 HLT menu

backport of #35357

@fwyzard @abdoulline @silviodonato 
