### PR TITLE
Fix for label of MuonGeometryRecord in DTDigitizer

### DIFF
--- a/SimMuon/DTDigitizer/src/DTDigitizer.cc
+++ b/SimMuon/DTDigitizer/src/DTDigitizer.cc
@@ -118,12 +118,12 @@ DTDigitizer::DTDigitizer(const ParameterSet &conf_)
   mix_ = conf_.getParameter<std::string>("mixLabel");
   collection_for_XF = conf_.getParameter<std::string>("InputCollection");
   cf_token = consumes<CrossingFrame<PSimHit>>(edm::InputTag(mix_, collection_for_XF));
-  muonGeom_token = esConsumes<DTGeometry, MuonGeometryRecord>(edm::ESInputTag("", geometryType));
   magnField_token = esConsumes<MagneticField, IdealMagneticFieldRecord>();
 
-  // String to choice between ideal (the deafult) and (mis)aligned geometry for
-  // the digitization step
+  // String to choose between ideal (the default) and (mis)aligned geometry
+  // for the digitization step
   geometryType = conf_.getParameter<std::string>("GeometryType");
+  muonGeom_token = esConsumes<DTGeometry, MuonGeometryRecord>(edm::ESInputTag("", geometryType));
 }
 
 // method called to produce the data


### PR DESCRIPTION
#### PR description:

As a non-expert, I stumbled upon a possible bug in the `DTDigitizer`, due to the incorrect order of a `esConsumes` call (see `muonGeom_token`) and the initialization of a string (i.e. `geometryType`) holding the label of the relevant record.

Opening a PR, so experts can review.

#### PR validation:

None.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport planned.