### PR TITLE
Remove unused magnetic field geometry tags from all GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,83 +2,83 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'                  : '121X_mcRun1_design_v1',
+    'run1_design'                  : '121X_mcRun1_design_v2',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'                      : '121X_mcRun1_realistic_v1',
+    'run1_mc'                      : '121X_mcRun1_realistic_v2',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'                   : '121X_mcRun1_HeavyIon_v1',
+    'run1_mc_hi'                   : '121X_mcRun1_HeavyIon_v2',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'                 : '121X_mcRun2_startup_v1',
+    'run2_mc_50ns'                 : '121X_mcRun2_startup_v2',
     # GlobalTag for MC production (2015 L1 Trigger Stage1) with startup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
-    'run2_mc_l1stage1'             : '121X_mcRun2_asymptotic_l1stage1_v1',
+    'run2_mc_l1stage1'             : '121X_mcRun2_asymptotic_l1stage1_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'                  : '121X_mcRun2_design_v1',
+    'run2_design'                  : '121X_mcRun2_design_v2',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, prior to VFP change
-    'run2_mc_pre_vfp'              : '121X_mcRun2_asymptotic_preVFP_v1',
+    'run2_mc_pre_vfp'              : '121X_mcRun2_asymptotic_preVFP_v2',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, after VFP change
-    'run2_mc'                      : '121X_mcRun2_asymptotic_v1',
+    'run2_mc'                      : '121X_mcRun2_asymptotic_v2',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'              : '121X_mcRun2cosmics_asymptotic_deco_v1',
+    'run2_mc_cosmics'              : '121X_mcRun2cosmics_asymptotic_deco_v2',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'                   : '121X_mcRun2_HeavyIon_v1',
+    'run2_mc_hi'                   : '121X_mcRun2_HeavyIon_v2',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'                   : '121X_mcRun2_pA_v1',
+    'run2_mc_pa'                   : '121X_mcRun2_pA_v2',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'                    : '121X_dataRun2_v1',
+    'run2_data'                    : '121X_dataRun2_v2',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_HEfail'             : '121X_dataRun2_HEfail_v1',
+    'run2_data_HEfail'             : '121X_dataRun2_HEfail_v2',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'             : '121X_dataRun2_relval_v1',
+    'run2_data_relval'             : '121X_dataRun2_relval_v2',
     # GlobalTag for Run2 HI data
-    'run2_data_promptlike_hi'      : '121X_dataRun2_PromptLike_HI_v1',
+    'run2_data_promptlike_hi'      : '121X_dataRun2_PromptLike_HI_v2',
     # GlobalTag for Run3 HLT: it points to the online GT
-    'run3_hlt'                     : '121X_dataRun3_HLT_v1',
+    'run3_hlt'                     : '121X_dataRun3_HLT_v2',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'              : '121X_dataRun2_HLT_relval_v1',
+    'run2_hlt_relval'              : '121X_dataRun2_HLT_relval_v2',
     # GlobalTag for Run3 data relvals (express GT)
-    'run3_data_express'            : '121X_dataRun3_Express_v1',
+    'run3_data_express'            : '121X_dataRun3_Express_v2',
     # GlobalTag for Run3 data relvals
-    'run3_data_prompt'             : '121X_dataRun3_Prompt_v1',
+    'run3_data_prompt'             : '121X_dataRun3_Prompt_v2',
     # GlobalTag for Run3 offline data reprocessing
-    'run3_data'                    : '121X_dataRun3_v1',
+    'run3_data'                    : '121X_dataRun3_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'           : '121X_mc2017_design_v1',
+    'phase1_2017_design'           : '121X_mc2017_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'        : '121X_mc2017_realistic_v1',
+    'phase1_2017_realistic'        : '121X_mc2017_realistic_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector, for PP reference run
     'phase1_2017_realistic_ppref'  :  '120X_mc2017_realistic_forppRef5TeV_v2',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'          : '121X_mc2017cosmics_realistic_deco_v1',
+    'phase1_2017_cosmics'          : '121X_mc2017cosmics_realistic_deco_v2',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak'     : '121X_mc2017cosmics_realistic_peak_v1',
+    'phase1_2017_cosmics_peak'     : '121X_mc2017cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'           : '121X_upgrade2018_design_v1',
+    'phase1_2018_design'           : '121X_upgrade2018_design_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'        : '121X_upgrade2018_realistic_v1',
+    'phase1_2018_realistic'        : '121X_upgrade2018_realistic_v2',
     # GlobalTag for MC production with realistic run-dependent (RD) conditions for full Phase1 2018 detector
-    'phase1_2018_realistic_rd'     : '121X_upgrade2018_realistic_RD_v1',
+    'phase1_2018_realistic_rd'     : '121X_upgrade2018_realistic_RD_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi'     : '121X_upgrade2018_realistic_HI_v1',
+    'phase1_2018_realistic_hi'     : '121X_upgrade2018_realistic_HI_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' : '121X_upgrade2018_realistic_HEfail_v1',
+    'phase1_2018_realistic_HEfail' : '121X_upgrade2018_realistic_HEfail_v2',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'          : '121X_upgrade2018cosmics_realistic_deco_v3',
+    'phase1_2018_cosmics'          : '121X_upgrade2018cosmics_realistic_deco_v4',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak'     : '121X_upgrade2018cosmics_realistic_peak_v1',
+    'phase1_2018_cosmics_peak'     : '121X_upgrade2018cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'           : '121X_mcRun3_2021_design_v3',
+    'phase1_2021_design'           : '121X_mcRun3_2021_design_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'        : '121X_mcRun3_2021_realistic_v4', 
+    'phase1_2021_realistic'        : '121X_mcRun3_2021_realistic_v5', 
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'          : '121X_mcRun3_2021cosmics_realistic_deco_v4',
+    'phase1_2021_cosmics'          : '121X_mcRun3_2021cosmics_realistic_deco_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi'     : '121X_mcRun3_2021_realistic_HI_v4',
+    'phase1_2021_realistic_hi'     : '121X_mcRun3_2021_realistic_HI_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '121X_mcRun3_2023_realistic_v3', 
+    'phase1_2023_realistic'        : '121X_mcRun3_2023_realistic_v4', 
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '121X_mcRun3_2024_realistic_v3', 
+    'phase1_2024_realistic'        : '121X_mcRun3_2024_realistic_v4', 
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             : '121X_mcRun4_realistic_v1'
+    'phase2_realistic'             : '121X_mcRun4_realistic_v2'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:

This PR removes the unused 
```
MFGeometryFileRcd | 130503 | MFGeometry_130503
MFGeometryFileRcd | 120812 | MFGeometry_120812
```
tags from all GTs. These tags have been superseded a long time ago by 
```
MFGeometryFileRcd | 90322 | MFGeometry_90322
MFGeometryFileRcd | 160812 | MFGeometry_160812
```
but have never been removed from the GTs. See the request in [1] and the diffs in [2], they only show these 2 tags.

[1] 
https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4450.html

[2] 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun1_design_v1/121X_mcRun1_design_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun1_realistic_v1/121X_mcRun1_realistic_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun1_HeavyIon_v1/121X_mcRun1_HeavyIon_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun2_startup_v1/121X_mcRun2_startup_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun2_asymptotic_l1stage1_v1/121X_mcRun2_asymptotic_l1stage1_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun2_design_v1/121X_mcRun2_design_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun2_asymptotic_preVFP_v1/121X_mcRun2_asymptotic_preVFP_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun2_asymptotic_v1/121X_mcRun2_asymptotic_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun2cosmics_asymptotic_deco_v1/121X_mcRun2cosmics_asymptotic_deco_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun2_HeavyIon_v1/121X_mcRun2_HeavyIon_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun2_pA_v1/121X_mcRun2_pA_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_dataRun2_v1/121X_dataRun2_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_dataRun2_HEfail_v1/121X_dataRun2_HEfail_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_dataRun2_relval_v1/121X_dataRun2_relval_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_dataRun2_PromptLike_HI_v1/121X_dataRun2_PromptLike_HI_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_dataRun3_HLT_v1/121X_dataRun3_HLT_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_dataRun2_HLT_relval_v1/121X_dataRun2_HLT_relval_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_dataRun3_Express_v1/121X_dataRun3_Express_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_dataRun3_Prompt_v1/121X_dataRun3_Prompt_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_dataRun3_v1/121X_dataRun3_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mc2017_design_v1/121X_mc2017_design_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mc2017_realistic_v1/121X_mc2017_realistic_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/120X_mc2017_realistic_forppRef5TeV_v2/120X_mc2017_realistic_forppRef5TeV_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mc2017cosmics_realistic_deco_v1/121X_mc2017cosmics_realistic_deco_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mc2017cosmics_realistic_peak_v1/121X_mc2017cosmics_realistic_peak_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_upgrade2018_design_v1/121X_upgrade2018_design_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_upgrade2018_realistic_v1/121X_upgrade2018_realistic_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_upgrade2018_realistic_RD_v1/121X_upgrade2018_realistic_RD_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_upgrade2018_realistic_HI_v1/121X_upgrade2018_realistic_HI_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_upgrade2018_realistic_HEfail_v1/121X_upgrade2018_realistic_HEfail_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_upgrade2018cosmics_realistic_deco_v3/121X_upgrade2018cosmics_realistic_deco_v4
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_upgrade2018cosmics_realistic_peak_v1/121X_upgrade2018cosmics_realistic_peak_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021_design_v3/121X_mcRun3_2021_design_v4
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021_realistic_v4/121X_mcRun3_2021_realistic_v5
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021cosmics_realistic_deco_v4/121X_mcRun3_2021cosmics_realistic_deco_v5
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021_realistic_HI_v4/121X_mcRun3_2021_realistic_HI_v5
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2023_realistic_v3/121X_mcRun3_2023_realistic_v4
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2024_realistic_v3/121X_mcRun3_2024_realistic_v4
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun4_realistic_v1/121X_mcRun4_realistic_v2



#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not a backport and no backport is needed


resolves https://github.com/cms-AlCaDB/AlCaTools/issues/20