### PR TITLE
[UBSAN] Added missing deps in CalibTracker/SiStripCommon

### DIFF
--- a/CalibTracker/SiStripCommon/BuildFile.xml
+++ b/CalibTracker/SiStripCommon/BuildFile.xml
@@ -13,6 +13,7 @@
 <use name="CondFormats/DataRecord"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
 <use name="Geometry/Records"/>
+<use name="TrackingTools/PatternTools"/>
 <export>
   <lib name="1"/>
 </export>


### PR DESCRIPTION
UBSAN IBs failed to build with error
```
SiStripOnTrackClusterTableProducerBase.cc.o:(.data.rel+0x498): undefined reference to `typeinfo for BasicTrajectoryState'
```
This adds the missing deps on `TrackingTools/PatternTools` used here https://github.com/cms-sw/cmssw/blob/master/CalibTracker/SiStripCommon/interface/SiStripOnTrackClusterTableProducerBase.h#L8 added by https://github.com/cms-sw/cmssw/pull/34985