### PR TITLE
add `commissioning_run` as `runType` and use it in SiStrip online DQM client [12.0.X]

### DIFF
--- a/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
@@ -291,6 +291,17 @@ if (process.runType.getRunType() == process.runType.cosmic_run or process.runTyp
                          )
 
 
+### COMMISSIONING RUN SETTINGS
+if (process.runType.getRunType() == process.runType.commissioning_run):
+    #event selection for commissioning runs
+    if ((process.runType.getRunType() == process.runType.commissioning_run) and live):
+        process.source.SelectEvents = ['HLT_*']
+
+    process.SiStripFedMonitor = cms.Sequence(process.siStripFEDMonitor)
+    process.p = cms.Path(
+        process.siStripFEDCheck *
+        process.SiStripFedMonitor
+    )
 
 #else :
 ### pp COLLISION SETTING

--- a/DQM/Integration/python/clients/visualization-live-secondInstance_cfg.py
+++ b/DQM/Integration/python/clients/visualization-live-secondInstance_cfg.py
@@ -19,7 +19,7 @@ else:
 # this is needed to map the names of the run-types chosen by DQM to the scenarios, ideally we could converge to the same names
 #scenarios = {'pp_run': 'ppEra_Run2_2016','cosmic_run':'cosmicsEra_Run2_2016','hi_run':'HeavyIons'}
 #scenarios = {'pp_run': 'ppEra_Run2_2016','pp_run_stage1': 'ppEra_Run2_2016','cosmic_run':'cosmicsEra_Run2_2016','cosmic_run_stage1':'cosmicsEra_Run2_2016','hi_run':'HeavyIonsEra_Run2_HI'}
-scenarios = {'pp_run': 'ppEra_Run3','cosmic_run':'cosmicsEra_Run3','hi_run':'ppEra_Run2_2016_pA'}
+scenarios = {'pp_run': 'ppEra_Run3','cosmic_run':'cosmicsEra_Run3','hi_run':'ppEra_Run2_2016_pA', 'commissioning_run':'cosmicsEra_Run3'}
 
 if not runType.getRunTypeName() in scenarios.keys():
     msg = "Error getting the scenario out of the 'runkey', no mapping for: %s\n"%runType.getRunTypeName()

--- a/DQM/Integration/python/clients/visualization-live_cfg.py
+++ b/DQM/Integration/python/clients/visualization-live_cfg.py
@@ -19,7 +19,7 @@ else:
 # this is needed to map the names of the run-types chosen by DQM to the scenarios, ideally we could converge to the same names
 #scenarios = {'pp_run': 'ppEra_Run2_2016','cosmic_run':'cosmicsEra_Run2_2016','hi_run':'HeavyIons'}
 #scenarios = {'pp_run': 'ppEra_Run2_2016','pp_run_stage1': 'ppEra_Run2_2016','cosmic_run':'cosmicsEra_Run2_2016','cosmic_run_stage1':'cosmicsEra_Run2_2016','hi_run':'HeavyIonsEra_Run2_HI'}
-scenarios = {'pp_run': 'ppEra_Run3','cosmic_run':'cosmicsEra_Run3','hi_run':'ppEra_Run2_2016_pA'}
+scenarios = {'pp_run': 'ppEra_Run3','cosmic_run':'cosmicsEra_Run3','hi_run':'ppEra_Run2_2016_pA', 'commissioning_run':'cosmicsEra_Run3'}
 
 if not runType.getRunTypeName() in scenarios.keys():
     msg = "Error getting the scenario out of the 'runkey', no mapping for: %s\n"%runType.getRunTypeName()

--- a/DQM/Integration/python/config/dqmPythonTypes.py
+++ b/DQM/Integration/python/config/dqmPythonTypes.py
@@ -2,7 +2,7 @@
 from FWCore.ParameterSet.Types import PSet
 import FWCore.ParameterSet.Config as cms
 class RunType(PSet):
-  def __init__(self,types=['pp_run','pp_run_stage1','cosmic_run','cosmic_run_stage1','hi_run','hpu_run']):
+  def __init__(self,types=['pp_run','pp_run_stage1','cosmic_run','cosmic_run_stage1','hi_run','hpu_run','commissioning_run']):
     PSet.__init__(self)
     self.__runTypesDict = {}
     t=[(x,types.index(x)) for x in types ]


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/34832 and https://github.com/cms-sw/cmssw/pull/35691

#### PR description:

This PR adds a new DQM `runType` `commissioning_run` in order to define a new clause in the SiStrip online client to be used when there are no physics triggers.

#### PR validation:

At the moment none. to be further tested

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Original PR: https://github.com/cms-sw/cmssw/pull/34832, to be tested in 2021 Commissioning data-taking
