### PR TITLE
Migrating away from deprecated edm::EDAnalyzer API in CalibTracker/SiPixelESProducers

### DIFF
--- a/CalibTracker/SiPixelESProducers/interface/SiPixelDetInfoFileWriter.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelDetInfoFileWriter.h
@@ -18,14 +18,14 @@
 //
 //
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include <string>
 #include <iostream>
 #include <fstream>
 
-class SiPixelDetInfoFileWriter : public edm::EDAnalyzer {
+class SiPixelDetInfoFileWriter : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   explicit SiPixelDetInfoFileWriter(const edm::ParameterSet &);
   ~SiPixelDetInfoFileWriter() override;
@@ -34,6 +34,7 @@ private:
   void beginJob() override;
   void beginRun(const edm::Run &, const edm::EventSetup &) override;
   void analyze(const edm::Event &, const edm::EventSetup &) override;
+  void endRun(const edm::Run &, const edm::EventSetup &) override{};
 
 private:
   edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomTokenBeginRun_;


### PR DESCRIPTION
#### PR description:

Migrating away from the deprecated `edm::EDAnalyzer` API in `CalibTracker/SiPixelESProducers/interface/SiPixelDetInfoFileWriter.h`. Addressing the issue reported in https://github.com/cms-AlCaDB/AlCaTools/issues/33

#### PR validation:

No special validation done other than checking that the code compiles. None of the production code is touched, no changes expected in the output.

@tvami 
