### PR TITLE
[FMT] Fix warnings about deprecated use of `fmt::format_to()`

### DIFF
--- a/FWCore/MessageService/test/fmt_test.cppunit.cpp
+++ b/FWCore/MessageService/test/fmt_test.cppunit.cpp
@@ -55,10 +55,10 @@ void test_fmt_external::test_fmt()
   CPPUNIT_ASSERT(s_check == s);
   auto args = capture("{} {}", 42, "foo");
   std::apply(print_message, args);
-  fmt::memory_buffer buf;
-  format_to(buf, "{}", 42);  // replaces itoa(42, buffer, 10)
+  auto buf = fmt::memory_buffer();
+  format_to(std::back_inserter(buf), "{}", 42);  // replaces itoa(42, buffer, 10)
   fmt::print(to_string(buf));
-  format_to(buf, "{:x}", 42);  // replaces itoa(42, buffer, 16)
+  format_to(std::back_inserter(buf), "{:x}", 42);  // replaces itoa(42, buffer, 16)
   fmt::print(to_string(buf));
 }
 #include <Utilities/Testing/interface/CppUnit_testdriver.icpp>


### PR DESCRIPTION
This should fix the compiler warnings about the deprecated use of `fmt::format_to` [a] . 

@makortel , although this fixes the warning but according to https://github.com/fmtlib/fmt/issues/2420 it causes 5% performance losses. So better to check if this deprecated `fmt` api should be used or not. Currently it is only used in one unit test.

[a]
```
  FWCore/MessageService/test/fmt_test.cppunit.cpp:59:26: warning: 'fmt::v8::appender fmt::v8::format_to(fmt::v8::basic_memory_buffer<char, SIZE, Allocator>&, fmt::v8::format_string<T ...>, T&& ...) [with T = {int}; long unsigned int SIZE = 500; Allocator = std::allocator<char>; fmt::v8::format_string<T ...> = fmt::v8::basic_format_string<char, int>]' is deprecated [-Wdeprecated-declarations]
    59 |   format_to(buf, "{}", 42);  // replaces itoa(42, buffer, 10)
```