### PR TITLE
simplify logic for `AndOr` in `DetStatus`

### DIFF
--- a/DPGAnalysis/Skims/src/DetStatus.cc
+++ b/DPGAnalysis/Skims/src/DetStatus.cc
@@ -115,17 +115,16 @@ bool DetStatus::checkForDCSRecord(const DCSRecord& dcsRecord)
     edm::LogInfo("DetStatus") << "Using softFED#1022 for reading DCS bits" << std::endl;
   }
 
-  int count = 0;
   for (unsigned int detlist = 0; detlist < DcsStatus::nPartitions; detlist++) {
     if (verbose_)
       edm::LogInfo("DetStatus") << "testing " << DcsStatus::partitionName[detlist];
     if (requestedPartitions_.test(detlist)) {
-      count++;
       if (verbose_)
         edm::LogInfo("DetStatus") << " " << DcsStatus::partitionName[detlist] << "in the requested list" << std::endl;
       if (AndOr_) {
-        accepted =
-            (count == 1) ? dcsRecord.highVoltageReady(detlist) : (accepted && dcsRecord.highVoltageReady(detlist));
+        accepted = dcsRecord.highVoltageReady(detlist);
+        if (!accepted)
+          break;
       } else {
         accepted = (accepted || dcsRecord.highVoltageReady(detlist));
       }


### PR DESCRIPTION
#### PR description:

Follow-up on https://github.com/cms-sw/cmssw/pull/35371#discussion_r714338877 by @ferencek 

#### PR validation:

It compiles, checked again with:

```
cmsDriver.py -s RAW2DIGI,RECO,ALCA:SiPixelCalCosmics --data --scenario cosmics --conditions 121X_dataRun3_Prompt_v1 --eventcontent=ALCARECO --datatier ALCARECO -n 100000 --no_exec --era Run3 --python_filename=SiPixelCalCosmics_2021_v1.py --nThreads=8 --dasquery='file dataset=/Cosmics/Commissioning2021-v1/RAW run=344421'
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport but will be backported.
