### PR TITLE
fix `SiPixelCalCosmics` for Run3: logical mistake in DetStatus [12_0_X]

### DIFF
--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalCosmics_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalCosmics_cff.py
@@ -9,7 +9,7 @@ import DPGAnalysis.Skims.skim_detstatus_cfi
 ALCARECOSiPixelCalCosmicsDCSFilter = DPGAnalysis.Skims.skim_detstatus_cfi.dcsstatus.clone(
     DetectorType = cms.vstring('BPIX','FPIX'),
     ApplyFilter  = cms.bool(True),
-    AndOr        = cms.bool(True),
+    AndOr        = cms.bool(False),   # if True put partitions in AND, otherwise in OR
     DebugOn      = cms.untracked.bool(False)
 )
 
@@ -38,4 +38,6 @@ ALCARECOSiPixelCalCosmics =  Alignment.CommonAlignmentProducer.AlignmentTrackSel
 ALCARECOSiPixelCalCosmics.minHitsPerSubDet.inPIXEL = 1
 
 # Sequence #
-seqALCARECOSiPixelCalCosmics = cms.Sequence(ALCARECOSiPixelCalCosmicsDCSFilter+ALCARECOSiPixelCalCosmicsHLTFilter*ALCARECOSiPixelCalCosmics)
+seqALCARECOSiPixelCalCosmics = cms.Sequence(ALCARECOSiPixelCalCosmicsDCSFilter*
+                                            ALCARECOSiPixelCalCosmicsHLTFilter*
+                                            ALCARECOSiPixelCalCosmics)

--- a/DPGAnalysis/Skims/src/DetStatus.cc
+++ b/DPGAnalysis/Skims/src/DetStatus.cc
@@ -115,17 +115,16 @@ bool DetStatus::checkForDCSRecord(const DCSRecord& dcsRecord)
     edm::LogInfo("DetStatus") << "Using softFED#1022 for reading DCS bits" << std::endl;
   }
 
-  int count = 0;
   for (unsigned int detlist = 0; detlist < DcsStatus::nPartitions; detlist++) {
     if (verbose_)
       edm::LogInfo("DetStatus") << "testing " << DcsStatus::partitionName[detlist];
     if (requestedPartitions_.test(detlist)) {
-      count++;
       if (verbose_)
         edm::LogInfo("DetStatus") << " " << DcsStatus::partitionName[detlist] << "in the requested list" << std::endl;
       if (AndOr_) {
-        accepted =
-            (count == 1) ? dcsRecord.highVoltageReady(detlist) : (accepted && dcsRecord.highVoltageReady(detlist));
+        accepted = dcsRecord.highVoltageReady(detlist);
+        if (!accepted)
+          break;
       } else {
         accepted = (accepted || dcsRecord.highVoltageReady(detlist));
       }


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/35371

#### PR description:

It has been found out that the `SiPixelCalCosmics` ALCARECO produced exactly zero events for the full CRUZET [link to DAS](https://cmsweb.cern.ch/das/request?input=dataset%3D%2FCosmics%2FCommissioning2021-SiPixelCalCosmics-PromptReco-v1%2FALCARECO&instance=prod/global).
The issue has been traced to the logical mistake when migrating the `DPGAnalysis/Skims/src/DetStatus.cc` class to not use the `DCSStatus` from scalers, but from `DCSRecord` from the software FED `#1022` to extract `DCSRecord` (see PR cms-sw/cmssw#29198).
From Run3 we won't have scalers, so the new path in the code started to be exercised only during CRUZET'21. 
Since the final boolean `accept` was initialized to `false` the final result of the filter was always `false` leading to no events saved.

#### PR validation:

Tested succesfully the following `cmsDriver` command:

```
cmsDriver.py -s RAW2DIGI,RECO,ALCA:SiPixelCalCosmics --data --scenario cosmics --conditions 121X_dataRun3_Prompt_v1 --eventcontent=ALCARECO --datatier ALCARECO -n 100000 --no_exec --era Run3 --python_filename=SiPixelCalCosmics_2021_v1.py --nThreads=8 --dasquery='file dataset=/Cosmics/Commissioning2021-v1/RAW run=344421'
```

which was giving 0 events before and gives now:

```
File SiPixelCalCosmics.root Events 110
Branch Name | Average Uncompressed Size (Bytes/Event) | Average Compressed Size (Bytes/Event) 
recoMuons_muons__RECO. 5225.97 2831.74
recoTrackExtras_ALCARECOSiPixelCalCosmics__RECO. 595.264 465.6
recoTracks_ALCARECOSiPixelCalCosmics__RECO. 689.636 427.618
SiStripClusteredmNewDetSetVector_ALCARECOSiPixelCalCosmics__RECO. 787.964 403.218
SiPixelClusteredmNewDetSetVector_ALCARECOSiPixelCalCosmics__RECO. 492.236 365.427
TrackingRecHitsOwned_ALCARECOSiPixelCalCosmics__RECO. 2010.9 306.336
recoCaloMuons_muons__RECO. 354 238.782
EventAuxiliary 118.6 40.5727
edmTriggerResults_TriggerResults__HLT. 172.436 28.9091
EventProductProvenance 870.864 22.8182
EventSelections 78.6455 4.81818
BranchListIndexes 25.7364 3.01818
```
I profit of this PR to change the  `AndOr`  in the configuration to take the `OR` of the BPIx and FPix DCS bits, instead of the AND after consultation with the pixel offline group.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is combined backport of https://github.com/cms-sw/cmssw/pull/35371 and https://github.com/cms-sw/cmssw/pull/35378