### PR TITLE
Migrating away from deprecated `edm::EDAnalyzer` API in `CalibTracker/SiStripLorentzAngle`

### DIFF
--- a/CalibTracker/SiStripLorentzAngle/interface/SiStripLAProfileBooker.h
+++ b/CalibTracker/SiStripLorentzAngle/interface/SiStripLAProfileBooker.h
@@ -3,7 +3,7 @@
 
 #include <map>
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
@@ -30,7 +30,7 @@
 
 class TrackerTopology;
 
-class SiStripLAProfileBooker : public edm::EDAnalyzer {
+class SiStripLAProfileBooker : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   typedef dqm::legacy::MonitorElement MonitorElement;
   typedef dqm::legacy::DQMStore DQMStore;
@@ -39,6 +39,8 @@ public:
   ~SiStripLAProfileBooker() override;
 
   void beginRun(edm::Run const&, const edm::EventSetup& c) override;
+
+  void endRun(edm::Run const&, const edm::EventSetup& c) override;
 
   void endJob() override;
 

--- a/CalibTracker/SiStripLorentzAngle/plugins/EnsembleCalibrationLA.cc
+++ b/CalibTracker/SiStripLorentzAngle/plugins/EnsembleCalibrationLA.cc
@@ -20,6 +20,8 @@ namespace sistrip {
         vMethods(conf.getParameter<std::vector<int> >("Methods")),
         tTopoToken_(esConsumes<edm::Transition::EndRun>()) {}
 
+  EnsembleCalibrationLA::~EnsembleCalibrationLA(){};
+
   void EnsembleCalibrationLA::endJob() {
     Book book("la_ensemble");
     TChain* const chain = new TChain("la_ensemble");
@@ -40,6 +42,8 @@ namespace sistrip {
     write_samples_plots(book);
     write_calibrations();
   }
+
+  void EnsembleCalibrationLA::beginRun(const edm::Run&, const edm::EventSetup& eSetup) {}
 
   void EnsembleCalibrationLA::endRun(const edm::Run&, const edm::EventSetup& eSetup) {
     tTopo_ = &eSetup.getData(tTopoToken_);

--- a/CalibTracker/SiStripLorentzAngle/plugins/EnsembleCalibrationLA.h
+++ b/CalibTracker/SiStripLorentzAngle/plugins/EnsembleCalibrationLA.h
@@ -2,17 +2,20 @@
 #define CalibTracker_SiStripLorentzAngle_EnsembleCalibrationLA_h
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "CalibTracker/SiStripLorentzAngle/interface/LA_Filler_Fitter.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
 namespace sistrip {
-  class EnsembleCalibrationLA : public edm::EDAnalyzer {
+  class EnsembleCalibrationLA : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
   public:
     explicit EnsembleCalibrationLA(const edm::ParameterSet&);
     void analyze(const edm::Event&, const edm::EventSetup&) override {}
+    void beginRun(const edm::Run&, const edm::EventSetup&) override;
     void endRun(const edm::Run&, const edm::EventSetup&) override;
     void endJob() override;
+
+    ~EnsembleCalibrationLA() override;
 
   private:
     void write_ensembles_text(const Book&);

--- a/CalibTracker/SiStripLorentzAngle/plugins/SiStripLAProfileBooker.cc
+++ b/CalibTracker/SiStripLorentzAngle/plugins/SiStripLAProfileBooker.cc
@@ -237,6 +237,8 @@ void SiStripLAProfileBooker::beginRun(const edm::Run&, const edm::EventSetup& c)
   TrackCounter = 1;
 }
 
+void SiStripLAProfileBooker::endRun(const edm::Run&, const edm::EventSetup& c) {}
+
 SiStripLAProfileBooker::~SiStripLAProfileBooker() {
   detparmap::iterator detpariter;
   for (detpariter = detmap.begin(); detpariter != detmap.end(); ++detpariter)


### PR DESCRIPTION
resolves https://github.com/cms-AlCaDB/AlCaTools/issues/29

#### PR description:

Migrating away from the deprecated `edm::EDAnalyzer` API in `CalibTracker/SiStripLorentzAngle`. Addressing the issue reported in https://github.com/cms-AlCaDB/AlCaTools/issues/29

#### PR validation:

It compiles

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A