### PR TITLE
Avoid race condition in PluginFactoryBase

### DIFF
--- a/FWCore/PluginManager/src/PluginFactoryBase.cc
+++ b/FWCore/PluginManager/src/PluginFactoryBase.cc
@@ -149,7 +149,12 @@ namespace edmplugin {
 
   void PluginFactoryBase::registerPMaker(void* iPMaker, const std::string& iName) {
     assert(nullptr != iPMaker);
-    m_plugins[iName].push_back(PluginMakerInfo(iPMaker, PluginManager::loadingFile()));
+    PMakers newMakers;
+    newMakers.emplace_back(iPMaker, PluginManager::loadingFile());
+    if (not m_plugins.emplace(iName, std::move(newMakers)).second) {
+      //the item was already added
+      m_plugins[iName].push_back(PluginMakerInfo(iPMaker, PluginManager::loadingFile()));
+    }
     newPlugin(iName);
   }
 


### PR DESCRIPTION

#### PR description:

Use atomic form of entry into the tbb::concurrent_unordered_map to avoid getting an empty entry.
This was pointed to by the UBSAN test showing where a reference was using a nullptr address.

#### PR validation:

Code compiles. All framework unit tests pass.