### PR TITLE
fix messages in `NoRecordException`

### DIFF
--- a/FWCore/Framework/src/NoRecordException.cc
+++ b/FWCore/Framework/src/NoRecordException.cc
@@ -26,10 +26,10 @@ bool edm::eventsetup::recordDoesExist(EventSetupImpl const& iES, EventSetupRecor
 void edm::eventsetup::no_record_exception_message_builder(cms::Exception& oException,
                                                           const char* iName,
                                                           bool iKnownRecord) {
-  oException << "No \"" << iName << "\" record found in the EventSetup.n";
+  oException << "No \"" << iName << "\" record found in the EventSetup.\n";
   if (iKnownRecord) {
     oException << "\n The Record is delivered by an ESSource or ESProducer but there is no valid IOV for the "
-                  "synchronizatio value.\n"
+                  "synchronization value.\n"
                   " Please check \n"
                   "   a) if the synchronization value is reasonable and report to the hypernews if it is not.\n"
                   "   b) else check that all ESSources have been properly configured. \n";


### PR DESCRIPTION
#### PR description:

A rather silly PR, just fixing a couple of typos in  `NoRecordException` that I've been seeing every time a mistake in the conditions is made. 

#### PR validation:

It compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A 