### PR TITLE
Add ability to conditionally apply [[deprecated]]

### DIFF
--- a/FWCore/Framework/interface/EDAnalyzer.h
+++ b/FWCore/Framework/interface/EDAnalyzer.h
@@ -8,6 +8,7 @@
 #include "FWCore/Framework/interface/SharedResourcesAcquirer.h"
 #include "FWCore/Concurrency/interface/SerialTaskQueue.h"
 #include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
+#include "FWCore/Utilities/interface/deprecated_macro.h"
 
 #include <string>
 
@@ -25,7 +26,7 @@ namespace edm {
     class ModuleHolderT;
   }
 
-  class EDAnalyzer : public EDConsumerBase {
+  class CMS_DEPRECATED EDAnalyzer : public EDConsumerBase {
   public:
     template <typename T>
     friend class maker::ModuleHolderT;

--- a/FWCore/Framework/interface/EDFilter.h
+++ b/FWCore/Framework/interface/EDFilter.h
@@ -19,6 +19,7 @@ These products should be informational products about the filter decision.
 #include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
+#include "FWCore/Utilities/interface/deprecated_macro.h"
 
 #include <string>
 #include <vector>
@@ -35,7 +36,7 @@ namespace edm {
   class ActivityRegistry;
   class ThinnedAssociationsHelper;
 
-  class EDFilter : public ProducerBase, public EDConsumerBase {
+  class CMS_DEPRECATED EDFilter : public ProducerBase, public EDConsumerBase {
   public:
     template <typename T>
     friend class maker::ModuleHolderT;

--- a/FWCore/Framework/interface/EDProducer.h
+++ b/FWCore/Framework/interface/EDProducer.h
@@ -16,6 +16,7 @@ EDProducts into an Event.
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 #include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
+#include "FWCore/Utilities/interface/deprecated_macro.h"
 
 #include <string>
 #include <vector>
@@ -32,7 +33,7 @@ namespace edm {
     class ModuleHolderT;
   }
 
-  class EDProducer : public ProducerBase, public EDConsumerBase {
+  class CMS_DEPRECATED EDProducer : public ProducerBase, public EDConsumerBase {
   public:
     template <typename T>
     friend class maker::ModuleHolderT;

--- a/FWCore/Framework/interface/EventSetup.h
+++ b/FWCore/Framework/interface/EventSetup.h
@@ -38,6 +38,7 @@
 #include "FWCore/Framework/interface/data_default_record_trait.h"
 #include "FWCore/Utilities/interface/Transition.h"
 #include "FWCore/Utilities/interface/ESIndices.h"
+#include "FWCore/Utilities/interface/deprecated_macro.h"
 
 // forward declarations
 
@@ -124,18 +125,19 @@ namespace edm {
 
     /** can directly access data if data_default_record_trait<> is defined for this data type **/
     template <typename T>
-    bool getData(T& iHolder) const {
-      return getData(std::string{}, iHolder);
+    CMS_DEPRECATED bool getData(T& iHolder) const {
+      auto const& rec = this->get<eventsetup::default_record_t<T>>();
+      return rec.get(std::string{}, iHolder);
     }
 
     template <typename T>
-    bool getData(const std::string& iLabel, T& iHolder) const {
+    CMS_DEPRECATED bool getData(const std::string& iLabel, T& iHolder) const {
       auto const& rec = this->get<eventsetup::default_record_t<T>>();
       return rec.get(iLabel, iHolder);
     }
 
     template <typename T>
-    bool getData(const ESInputTag& iTag, T& iHolder) const {
+    CMS_DEPRECATED bool getData(const ESInputTag& iTag, T& iHolder) const {
       auto const& rec = this->get<eventsetup::default_record_t<T>>();
       return rec.get(iTag, iHolder);
     }

--- a/FWCore/Framework/interface/EventSetupRecord.h
+++ b/FWCore/Framework/interface/EventSetupRecord.h
@@ -49,6 +49,7 @@
 #include "FWCore/Utilities/interface/ESInputTag.h"
 #include "FWCore/Utilities/interface/ESIndices.h"
 #include "FWCore/Utilities/interface/Likely.h"
+#include "FWCore/Utilities/interface/deprecated_macro.h"
 
 // system include files
 #include <exception>
@@ -108,37 +109,22 @@ namespace edm {
       }
 
       template <typename HolderT>
-      bool get(HolderT& iHolder) const {
-        return get("", iHolder);
+      CMS_DEPRECATED bool get(HolderT& iHolder) const {
+        return deprecated_get("", iHolder);
       }
 
       template <typename HolderT>
-      bool get(char const* iName, HolderT& iHolder) const {
-        if UNLIKELY (requireTokens_) {
-          throwCalledGetWithoutToken(heterocontainer::className<typename HolderT::value_type>(), iName);
-        }
-        typename HolderT::value_type const* value = nullptr;
-        ComponentDescription const* desc = nullptr;
-        std::shared_ptr<ESHandleExceptionFactory> whyFailedFactory;
-        impl_->getImplementation(
-            value, iName, desc, iHolder.transientAccessOnly, whyFailedFactory, *context_, eventSetupImpl_);
-
-        if (value) {
-          iHolder = HolderT(value, desc);
-          return true;
-        } else {
-          iHolder = HolderT(std::move(whyFailedFactory));
-          return false;
-        }
+      CMS_DEPRECATED bool get(char const* iName, HolderT& iHolder) const {
+        return deprecated_get(iName, iHolder);
       }
 
       template <typename HolderT>
-      bool get(std::string const& iName, HolderT& iHolder) const {
-        return get(iName.c_str(), iHolder);
+      CMS_DEPRECATED bool get(std::string const& iName, HolderT& iHolder) const {
+        return deprecated_get(iName.c_str(), iHolder);
       }
 
       template <typename HolderT>
-      bool get(ESInputTag const& iTag, HolderT& iHolder) const {
+      CMS_DEPRECATED bool get(ESInputTag const& iTag, HolderT& iHolder) const {
         if UNLIKELY (requireTokens_) {
           throwCalledGetWithoutToken(heterocontainer::className<typename HolderT::value_type>(), iTag.data().c_str());
         }
@@ -258,6 +244,26 @@ namespace edm {
       bool requireTokens() const { return requireTokens_; }
 
     private:
+      template <typename HolderT>
+      bool deprecated_get(char const* iName, HolderT& iHolder) const {
+        if UNLIKELY (requireTokens_) {
+          throwCalledGetWithoutToken(heterocontainer::className<typename HolderT::value_type>(), iName);
+        }
+        typename HolderT::value_type const* value = nullptr;
+        ComponentDescription const* desc = nullptr;
+        std::shared_ptr<ESHandleExceptionFactory> whyFailedFactory;
+        impl_->getImplementation(
+            value, iName, desc, iHolder.transientAccessOnly, whyFailedFactory, *context_, eventSetupImpl_);
+
+        if (value) {
+          iHolder = HolderT(value, desc);
+          return true;
+        } else {
+          iHolder = HolderT(std::move(whyFailedFactory));
+          return false;
+        }
+      }
+
       template <template <typename> typename H, typename T, typename R>
       H<T> invalidTokenHandle(ESGetToken<T, R> const& iToken) const {
         auto const key = this->key();

--- a/FWCore/Utilities/interface/deprecated_macro.h
+++ b/FWCore/Utilities/interface/deprecated_macro.h
@@ -1,0 +1,8 @@
+#ifndef FWCore_Utilites_deprecated_macro_h
+#define FWCore_Utilites_deprecated_macro_h
+#if !defined USE_CMS_DEPRECATED
+#define CMS_DEPRECATED
+#else
+#define CMS_DEPRECATED [[deprecated]]
+#endif
+#endif


### PR DESCRIPTION
#### PR description:

- added conditional `CMS_DEPRECATED` macro which is only turned on if `USE_CMS_DEPRECATED` is set
- made non esConsumes related EventSetup get calls CMS_DEPRECATED. Some minor code changes were applied to reduce redundant warning messages (e.g. a deprecated function internally calling another deprecated function).
- made use of legacy module types CMS_DEPRECATED

#### PR validation:

Code was compiles with and without USE_CMS_DEPRECATED set. When deprecations are turned on, expected warnings were generated. 