### PR TITLE
Use esConsumes in PileUpSubtractor

### DIFF
--- a/RecoJets/JetProducers/interface/PileUpSubtractor.h
+++ b/RecoJets/JetProducers/interface/PileUpSubtractor.h
@@ -20,6 +20,8 @@
 #include "DataFormats/Candidate/interface/CandidateFwd.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 
+class CaloGeometryRecord;
+
 class PileUpSubtractor {
 public:
   typedef std::shared_ptr<fastjet::ClusterSequence> ClusterSequencePtr;
@@ -70,9 +72,10 @@ protected:
   int activeAreaRepeats;
   double ghostArea;
 
-  double nSigmaPU_;                     // number of sigma for pileup
-  double radiusPU_;                     // pileup radius
-  ActiveAreaSpecPtr fjActiveArea_;      // fastjet active area definition
+  double nSigmaPU_;                 // number of sigma for pileup
+  double radiusPU_;                 // pileup radius
+  ActiveAreaSpecPtr fjActiveArea_;  // fastjet active area definition
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geoToken_;
   CaloGeometry const* geo_;             // geometry
   int ietamax_;                         // maximum eta in geometry
   int ietamin_;                         // minimum eta in geometry

--- a/RecoJets/JetProducers/src/PileUpSubtractor.cc
+++ b/RecoJets/JetProducers/src/PileUpSubtractor.cc
@@ -19,6 +19,7 @@ using namespace std;
 
 PileUpSubtractor::PileUpSubtractor(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC) {
   geo_ = nullptr;
+  geoToken_ = iC.esConsumes();
   doAreaFastjet_ = iConfig.getParameter<bool>("doAreaFastjet");
   doRhoFastjet_ = iConfig.getParameter<bool>("doRhoFastjet");
   nSigmaPU_ = iConfig.getParameter<double>("nSigmaPU");
@@ -58,9 +59,7 @@ void PileUpSubtractor::setupGeometryMap(edm::Event& iEvent, const edm::EventSetu
   LogDebug("PileUpSubtractor") << "The subtractor setting up geometry...\n";
 
   if (geo_ == nullptr) {
-    edm::ESHandle<CaloGeometry> pG;
-    iSetup.get<CaloGeometryRecord>().get(pG);
-    geo_ = pG.product();
+    geo_ = &iSetup.getData(geoToken_);
     std::vector<DetId> alldid = geo_->getValidDetIds();
 
     int ietaold = -10000;


### PR DESCRIPTION
#### PR description:

This was missed in the VirtualJetProducer migration to esConsumes.

#### PR validation:

Code compiles.