### PR TITLE
Migrate TrackingRegions to esConsumes

### DIFF
--- a/FastSimulation/Muons/plugins/FastTSGFromL2Muon.cc
+++ b/FastSimulation/Muons/plugins/FastTSGFromL2Muon.cc
@@ -56,7 +56,7 @@ void FastTSGFromL2Muon::produce(edm::Event& ev, const edm::EventSetup& es) {
   std::unique_ptr<L3MuonTrajectorySeedCollection> result(new L3MuonTrajectorySeedCollection());
 
   // Region builder
-  theRegionBuilder->setEvent(ev);
+  theRegionBuilder->setEvent(ev, es);
 
   // Retrieve the Monte Carlo truth (SimTracks)
   edm::Handle<edm::SimTrackContainer> theSimTracks;

--- a/FastSimulation/Tracking/interface/SeedFinderSelector.h
+++ b/FastSimulation/Tracking/interface/SeedFinderSelector.h
@@ -21,6 +21,10 @@ class MultiHitGeneratorFromPairAndLayers;
 class HitTripletGeneratorFromPairAndLayers;
 class CAHitTripletGenerator;
 class CAHitQuadrupletGenerator;
+class IdealMagneticFieldRecord;
+class MagneticField;
+class MultipleScatteringParametrisationMaker;
+class TrackerMultipleScatteringRecord;
 
 class SeedFinderSelector {
 public:
@@ -45,7 +49,11 @@ private:
   const std::string measurementTrackerLabel_;
   const edm::ESGetToken<MeasurementTracker, CkfComponentsRecord> measurementTrackerESToken_;
   const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopologyESToken_;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> fieldESToken_;
+  const edm::ESGetToken<MultipleScatteringParametrisationMaker, TrackerMultipleScatteringRecord> msMakerESToken_;
   const TrackerTopology* trackerTopology_ = nullptr;
+  const MagneticField* field_ = nullptr;
+  const MultipleScatteringParametrisationMaker* msmaker_ = nullptr;
   std::unique_ptr<CAHitTripletGenerator> CAHitTriplGenerator_;
   std::unique_ptr<CAHitQuadrupletGenerator> CAHitQuadGenerator_;
   std::unique_ptr<SeedingLayerSetsBuilder> seedingLayers_;

--- a/FastSimulation/Tracking/src/SeedFinderSelector.cc
+++ b/FastSimulation/Tracking/src/SeedFinderSelector.cc
@@ -17,6 +17,8 @@
 #include "RecoPixelVertexing/PixelTriplets/interface/CAHitQuadrupletGenerator.h"
 #include "RecoPixelVertexing/PixelTriplets/interface/OrderedHitSeeds.h"
 #include "RecoTracker/TkHitPairs/interface/IntermediateHitDoublets.h"
+#include "RecoTracker/TkMSParametrization/interface/MultipleScatteringParametrisationMaker.h"
+#include "RecoTracker/Record/interface/TrackerMultipleScatteringRecord.h"
 // data formats
 #include "DataFormats/TrackerRecHit2D/interface/FastTrackerRecHit.h"
 
@@ -26,7 +28,9 @@ SeedFinderSelector::SeedFinderSelector(const edm::ParameterSet &cfg, edm::Consum
       measurementTracker_(nullptr),
       measurementTrackerLabel_(cfg.getParameter<std::string>("measurementTracker")),
       measurementTrackerESToken_(consumesCollector.esConsumes(edm::ESInputTag("", measurementTrackerLabel_))),
-      trackerTopologyESToken_(consumesCollector.esConsumes()) {
+      trackerTopologyESToken_(consumesCollector.esConsumes()),
+      fieldESToken_(consumesCollector.esConsumes()),
+      msMakerESToken_(consumesCollector.esConsumes()) {
   if (cfg.exists("pixelTripletGeneratorFactory")) {
     const edm::ParameterSet &tripletConfig = cfg.getParameter<edm::ParameterSet>("pixelTripletGeneratorFactory");
     pixelTripletGenerator_ = HitTripletGeneratorFromPairAndLayersFactory::get()->create(
@@ -80,6 +84,8 @@ void SeedFinderSelector::initEvent(const edm::Event &ev, const edm::EventSetup &
 
   measurementTracker_ = &es.getData(measurementTrackerESToken_);
   trackerTopology_ = &es.getData(trackerTopologyESToken_);
+  field_ = &es.getData(fieldESToken_);
+  msmaker_ = &es.getData(msMakerESToken_);
 
   if (multiHitGenerator_) {
     multiHitGenerator_->initES(es);
@@ -124,7 +130,7 @@ bool SeedFinderSelector::pass(const std::vector<const FastTrackerRecHit *> &hits
 
   HitDoublets result(fhm, shm);
   HitPairGeneratorFromLayerPair::doublets(
-      *trackingRegion_, *firstLayer, *secondLayer, fhm, shm, *eventSetup_, 0, result);
+      *trackingRegion_, *firstLayer, *secondLayer, fhm, shm, *field_, *msmaker_, 0, result);
 
   if (result.empty()) {
     return false;
@@ -208,13 +214,13 @@ bool SeedFinderSelector::pass(const std::vector<const FastTrackerRecHit *> &hits
           pairCandidate1[1], std::make_unique<RecHitsSortedInPhi>(sHits, trackingRegion_->origin(), sLayer));
       HitDoublets res1(firsthm, secondhm);
       HitPairGeneratorFromLayerPair::doublets(
-          *trackingRegion_, *fLayer, *sLayer, firsthm, secondhm, *eventSetup_, 0, res1);
+          *trackingRegion_, *fLayer, *sLayer, firsthm, secondhm, *field_, *msmaker_, 0, res1);
       filler.addDoublets(pairCandidate1, std::move(res1));
       const RecHitsSortedInPhi &thirdhm = *layerCache.add(
           pairCandidate2[1], std::make_unique<RecHitsSortedInPhi>(tHits, trackingRegion_->origin(), tLayer));
       HitDoublets res2(secondhm, thirdhm);
       HitPairGeneratorFromLayerPair::doublets(
-          *trackingRegion_, *sLayer, *tLayer, secondhm, thirdhm, *eventSetup_, 0, res2);
+          *trackingRegion_, *sLayer, *tLayer, secondhm, thirdhm, *field_, *msmaker_, 0, res2);
       filler.addDoublets(pairCandidate2, std::move(res2));
 
       std::vector<OrderedHitSeeds> tripletresult;
@@ -289,19 +295,19 @@ bool SeedFinderSelector::pass(const std::vector<const FastTrackerRecHit *> &hits
         pairCandidate1[1], std::make_unique<RecHitsSortedInPhi>(sHits, trackingRegion_->origin(), sLayer));
     HitDoublets res1(firsthm, secondhm);
     HitPairGeneratorFromLayerPair::doublets(
-        *trackingRegion_, *fLayer, *sLayer, firsthm, secondhm, *eventSetup_, 0, res1);
+        *trackingRegion_, *fLayer, *sLayer, firsthm, secondhm, *field_, *msmaker_, 0, res1);
     filler.addDoublets(pairCandidate1, std::move(res1));
     const RecHitsSortedInPhi &thirdhm = *layerCache.add(
         pairCandidate2[1], std::make_unique<RecHitsSortedInPhi>(tHits, trackingRegion_->origin(), tLayer));
     HitDoublets res2(secondhm, thirdhm);
     HitPairGeneratorFromLayerPair::doublets(
-        *trackingRegion_, *sLayer, *tLayer, secondhm, thirdhm, *eventSetup_, 0, res2);
+        *trackingRegion_, *sLayer, *tLayer, secondhm, thirdhm, *field_, *msmaker_, 0, res2);
     filler.addDoublets(pairCandidate2, std::move(res2));
     const RecHitsSortedInPhi &fourthhm = *layerCache.add(
         pairCandidate3[1], std::make_unique<RecHitsSortedInPhi>(frHits, trackingRegion_->origin(), frLayer));
     HitDoublets res3(thirdhm, fourthhm);
     HitPairGeneratorFromLayerPair::doublets(
-        *trackingRegion_, *tLayer, *frLayer, thirdhm, fourthhm, *eventSetup_, 0, res3);
+        *trackingRegion_, *tLayer, *frLayer, thirdhm, fourthhm, *field_, *msmaker_, 0, res3);
     filler.addDoublets(pairCandidate3, std::move(res3));
 
     std::vector<OrderedHitSeeds> quadrupletresult;

--- a/FastSimulation/Tracking/src/SeedFinderSelector.cc
+++ b/FastSimulation/Tracking/src/SeedFinderSelector.cc
@@ -150,8 +150,7 @@ bool SeedFinderSelector::pass(const std::vector<const FastTrackerRecHit *> &hits
       return !tripletresult.empty();
     } else if (multiHitGenerator_) {
       OrderedMultiHits tripletresult;
-      multiHitGenerator_->hitTriplets(
-          *trackingRegion_, tripletresult, *eventSetup_, result, &thmp, thirdLayerDetLayer, 1);
+      multiHitGenerator_->hitTriplets(*trackingRegion_, tripletresult, result, &thmp, thirdLayerDetLayer, 1);
       return !tripletresult.empty();
     }
     //new for Phase1

--- a/RecoHI/HiMuonAlgos/plugins/HIMuonTrackingRegionProducer.h
+++ b/RecoHI/HiMuonAlgos/plugins/HIMuonTrackingRegionProducer.h
@@ -53,7 +53,7 @@ public:
     std::vector<std::unique_ptr<TrackingRegion> > result;
 
     // initialize the region builder
-    theRegionBuilder->setEvent(ev);
+    theRegionBuilder->setEvent(ev, es);
 
     // get stand-alone muon collection
     edm::Handle<reco::TrackCollection> muonH;

--- a/RecoMuon/GlobalTrackingTools/interface/GlobalTrajectoryBuilderBase.h
+++ b/RecoMuon/GlobalTrackingTools/interface/GlobalTrajectoryBuilderBase.h
@@ -23,6 +23,10 @@
 #include "RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHit.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "RecoTracker/Record/interface/TrackerMultipleScatteringRecord.h"
+#include "RecoTracker/TkMSParametrization/interface/MultipleScatteringParametrisationMaker.h"
 #include "RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "TrackingTools/TrackRefitter/interface/TrackTransformer.h"
@@ -164,5 +168,9 @@ private:
   const TransientTrackingRecHitBuilder* theMuonRecHitBuilder;
   edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> theTopoToken;
   const TrackerTopology* theTopo;
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> theFieldToken;
+  const MagneticField* theField;
+  edm::ESGetToken<MultipleScatteringParametrisationMaker, TrackerMultipleScatteringRecord> theMSMakerToken;
+  const MultipleScatteringParametrisationMaker* theMSMaker;
 };
 #endif

--- a/RecoMuon/GlobalTrackingTools/interface/MuonTrackingRegionBuilder.h
+++ b/RecoMuon/GlobalTrackingTools/interface/MuonTrackingRegionBuilder.h
@@ -34,11 +34,10 @@
 
 class MuonServiceProxy;
 class MeasurementTrackerEvent;
-
-namespace edm {
-  class ParameterSet;
-  class Event;
-}  // namespace edm
+class MagneticField;
+class IdealMagneticFieldRecord;
+class MultipleScatteringParametrisationMaker;
+class TrackerMultipleScatteringRecord;
 
 class MuonTrackingRegionBuilder : public TrackingRegionProducer {
 public:
@@ -54,11 +53,15 @@ public:
 
   /// Define tracking region
   std::unique_ptr<RectangularEtaPhiTrackingRegion> region(const reco::TrackRef&) const;
-  std::unique_ptr<RectangularEtaPhiTrackingRegion> region(const reco::Track& t) const { return region(t, *theEvent); }
-  std::unique_ptr<RectangularEtaPhiTrackingRegion> region(const reco::Track&, const edm::Event&) const;
+  std::unique_ptr<RectangularEtaPhiTrackingRegion> region(const reco::Track& t) const {
+    return region(t, *theEvent, *theEventSetup);
+  }
+  std::unique_ptr<RectangularEtaPhiTrackingRegion> region(const reco::Track&,
+                                                          const edm::Event&,
+                                                          const edm::EventSetup&) const;
 
   /// Pass the Event to the algo at each event
-  virtual void setEvent(const edm::Event&);
+  void setEvent(const edm::Event&, const edm::EventSetup&);
 
   /// Add Fill Descriptions
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
@@ -69,6 +72,7 @@ private:
   void build(const edm::ParameterSet&, edm::ConsumesCollector&);
 
   const edm::Event* theEvent;
+  const edm::EventSetup* theEventSetup;
 
   bool useVertex;
   bool useFixedZ;
@@ -101,5 +105,7 @@ private:
   edm::EDGetTokenT<reco::BeamSpot> beamSpotToken;
   edm::EDGetTokenT<reco::VertexCollection> vertexCollectionToken;
   edm::EDGetTokenT<reco::TrackCollection> inputCollectionToken;
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> bfieldToken;
+  edm::ESGetToken<MultipleScatteringParametrisationMaker, TrackerMultipleScatteringRecord> msmakerToken;
 };
 #endif

--- a/RecoMuon/GlobalTrackingTools/src/GlobalTrajectoryBuilderBase.cc
+++ b/RecoMuon/GlobalTrackingTools/src/GlobalTrajectoryBuilderBase.cc
@@ -107,6 +107,8 @@ GlobalTrajectoryBuilderBase::GlobalTrajectoryBuilderBase(const edm::ParameterSet
       iC.esConsumes(edm::ESInputTag("", par.getParameter<std::string>("TrackerRecHitBuilder")));
   theMuonRecHitBuilderToken = iC.esConsumes(edm::ESInputTag("", par.getParameter<std::string>("MuonRecHitBuilder")));
   theTopoToken = iC.esConsumes();
+  theFieldToken = iC.esConsumes();
+  theMSMakerToken = iC.esConsumes();
 
   theRPCInTheFit = par.getParameter<bool>("RefitRPCHits");
 
@@ -137,7 +139,7 @@ void GlobalTrajectoryBuilderBase::setEvent(const edm::Event& event) {
   theEvent = &event;
 
   theTrackTransformer->setServices(theService->eventSetup());
-  theRegionBuilder->setEvent(event);
+  theRegionBuilder->setEvent(event, theService->eventSetup());
 
   theGlbRefitter->setEvent(event);
   theGlbRefitter->setServices(theService->eventSetup());
@@ -147,6 +149,9 @@ void GlobalTrajectoryBuilderBase::setEvent(const edm::Event& event) {
 
   //Retrieve tracker topology from geometry
   theTopo = &theService->eventSetup().getData(theTopoToken);
+
+  theField = &theService->eventSetup().getData(theFieldToken);
+  theMSMaker = &theService->eventSetup().getData(theMSMakerToken);
 }
 
 //
@@ -345,7 +350,9 @@ RectangularEtaPhiTrackingRegion GlobalTrajectoryBuilderBase::defineRegionOfInter
                                           region1->originRBound(),
                                           region1->originZBound(),
                                           etaMargin,
-                                          region1->phiMargin());
+                                          region1->phiMargin(),
+                                          *theField,
+                                          theMSMaker);
 
   return region2;
 }

--- a/RecoMuon/TrackerSeedGenerator/interface/L1MuonRegionProducer.h
+++ b/RecoMuon/TrackerSeedGenerator/interface/L1MuonRegionProducer.h
@@ -1,5 +1,7 @@
 #ifndef RecoMuon_TrackerSeedGenerator_L1MuonRegionProducer_H
 #define RecoMuon_TrackerSeedGenerator_L1MuonRegionProducer_H
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include <vector>
@@ -7,18 +9,17 @@
 
 class TrackingRegion;
 class L1MuGMTCand;
-namespace edm {
-  class Event;
-  class EventSetup;
-  class ParameterSet;
-}  // namespace edm
+class MagneticField;
+class IdealMagneticFieldRecord;
+class MultipleScatteringParametrisationMaker;
+class TrackerMultipleScatteringRecord;
 
 class L1MuonRegionProducer {
 public:
-  L1MuonRegionProducer(const edm::ParameterSet& cfg);
-  ~L1MuonRegionProducer() {}
+  L1MuonRegionProducer(const edm::ParameterSet& cfg, edm::ConsumesCollector iC);
+  ~L1MuonRegionProducer() = default;
   void setL1Constraint(const L1MuGMTCand& muon);
-  std::vector<std::unique_ptr<TrackingRegion> > regions() const;
+  std::vector<std::unique_ptr<TrackingRegion> > regions(const edm::EventSetup& iSetup) const;
 
 private:
   // region configuration
@@ -28,6 +29,9 @@ private:
   // L1 constraint
   double thePtL1, thePhiL1, theEtaL1;
   int theChargeL1;
+
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> theFieldToken;
+  edm::ESGetToken<MultipleScatteringParametrisationMaker, TrackerMultipleScatteringRecord> theMSMakerToken;
 };
 
 #endif

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGFromL1Muon.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGFromL1Muon.cc
@@ -51,7 +51,8 @@ TSGFromL1Muon::TSGFromL1Muon(const edm::ParameterSet& cfg) : theSFPTConfig(consu
 
   theSourceToken = iC.consumes<L1MuonParticleCollection>(theSourceTag);
 
-  theRegionProducer = std::make_unique<L1MuonRegionProducer>(cfg.getParameter<edm::ParameterSet>("RegionFactoryPSet"));
+  theRegionProducer =
+      std::make_unique<L1MuonRegionProducer>(cfg.getParameter<edm::ParameterSet>("RegionFactoryPSet"), iC);
   theFitter = std::make_unique<L1MuonPixelTrackFitter>(cfg.getParameter<edm::ParameterSet>("FitterPSet"));
 
   edm::ParameterSet cleanerPSet = cfg.getParameter<edm::ParameterSet>("CleanerPSet");
@@ -85,7 +86,7 @@ void TSGFromL1Muon::produce(edm::Event& ev, const edm::EventSetup& es) {
     theFitter->setL1Constraint(muon);
 
     typedef std::vector<std::unique_ptr<TrackingRegion> > Regions;
-    Regions regions = theRegionProducer->regions();
+    Regions regions = theRegionProducer->regions(es);
     for (Regions::const_iterator ir = regions.begin(); ir != regions.end(); ++ir) {
       L1MuonSeedsMerger::TracksAndHits tracks;
       const TrackingRegion& region = **ir;

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGFromL2Muon.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGFromL2Muon.cc
@@ -67,7 +67,7 @@ void TSGFromL2Muon::produce(edm::Event& ev, const edm::EventSetup& es) {
   theService->update(es);
   theTkSeedGenerator->setEvent(ev);
   if (theRegionBuilder)
-    theRegionBuilder->setEvent(ev);
+    theRegionBuilder->setEvent(ev, es);
   if (theSeedCleaner)
     theSeedCleaner->setEvent(ev);
 

--- a/RecoMuon/TrackerSeedGenerator/src/L1MuonRegionProducer.cc
+++ b/RecoMuon/TrackerSeedGenerator/src/L1MuonRegionProducer.cc
@@ -5,10 +5,15 @@
 #include "RecoTracker/TkTrackingRegions/interface/GlobalTrackingRegion.h"
 #include "DataFormats/L1GlobalMuonTrigger/interface/L1MuGMTCand.h"
 #include "RecoMuon/TrackerSeedGenerator/interface/L1MuonPixelTrackFitter.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "RecoTracker/Record/interface/TrackerMultipleScatteringRecord.h"
+#include "RecoTracker/TkMSParametrization/interface/MultipleScatteringParametrisationMaker.h"
 
 using namespace std;
 
-L1MuonRegionProducer::L1MuonRegionProducer(const edm::ParameterSet& cfg) {
+L1MuonRegionProducer::L1MuonRegionProducer(const edm::ParameterSet& cfg, edm::ConsumesCollector iC)
+    : theFieldToken(iC.esConsumes()), theMSMakerToken(iC.esConsumes()) {
   edm::ParameterSet regionPSet = cfg.getParameter<edm::ParameterSet>("RegionPSet");
 
   thePtMin = regionPSet.getParameter<double>("ptMin");
@@ -25,7 +30,9 @@ void L1MuonRegionProducer::setL1Constraint(const L1MuGMTCand& muon) {
   theChargeL1 = muon.charge();
 }
 
-std::vector<std::unique_ptr<TrackingRegion> > L1MuonRegionProducer::regions() const {
+std::vector<std::unique_ptr<TrackingRegion> > L1MuonRegionProducer::regions(const edm::EventSetup& iSetup) const {
+  const auto& field = iSetup.getData(theFieldToken);
+  const auto& msmaker = iSetup.getData(theMSMakerToken);
   double dx = cos(thePhiL1);
   double dy = sin(thePhiL1);
   double dz = sinh(theEtaL1);
@@ -36,8 +43,15 @@ std::vector<std::unique_ptr<TrackingRegion> > L1MuonRegionProducer::regions() co
   bending = fabs(bending);
   double errBending = L1MuonPixelTrackFitter::getBendingError(1. / thePtMin, theEtaL1);
 
-  result.push_back(std::make_unique<RectangularEtaPhiTrackingRegion>(
-      direction, theOrigin, thePtMin, theOriginRadius, theOriginHalfLength, 0.15, bending + 3 * errBending));
+  result.push_back(std::make_unique<RectangularEtaPhiTrackingRegion>(direction,
+                                                                     theOrigin,
+                                                                     thePtMin,
+                                                                     theOriginRadius,
+                                                                     theOriginHalfLength,
+                                                                     0.15,
+                                                                     bending + 3 * errBending,
+                                                                     field,
+                                                                     &msmaker));
 
   return result;
 }

--- a/RecoPixelVertexing/PixelLowPtUtilities/src/PixelTripletLowPtGenerator.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/PixelTripletLowPtGenerator.cc
@@ -91,7 +91,7 @@ void PixelTripletLowPtGenerator::hitTriplets(const TrackingRegion& region,
   // Set aliases
   const RecHitsSortedInPhi** thirdHitMap = new const RecHitsSortedInPhi*[size];
   for (int il = 0; il < size; il++)
-    thirdHitMap[il] = &(*theLayerCache)(thirdLayers[il], region, es);
+    thirdHitMap[il] = &(*theLayerCache)(thirdLayers[il], region);
 
   // Get tracker
   getTracker(es);

--- a/RecoPixelVertexing/PixelTriplets/plugins/CombinedHitTripletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CombinedHitTripletGenerator.cc
@@ -13,7 +13,7 @@ CombinedHitTripletGenerator::CombinedHitTripletGenerator(const edm::ParameterSet
   edm::ParameterSet generatorPSet = cfg.getParameter<edm::ParameterSet>("GeneratorPSet");
   std::string generatorName = generatorPSet.getParameter<std::string>("ComponentName");
   theGenerator = HitTripletGeneratorFromPairAndLayersFactory::get()->create(generatorName, generatorPSet, iC);
-  theGenerator->init(std::make_unique<HitPairGeneratorFromLayerPair>(0, 1, &theLayerCache), &theLayerCache);
+  theGenerator->init(std::make_unique<HitPairGeneratorFromLayerPair>(iC, 0, 1, &theLayerCache), &theLayerCache);
 }
 
 CombinedHitTripletGenerator::~CombinedHitTripletGenerator() {}

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
@@ -94,7 +94,7 @@ void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region,
   const RecHitsSortedInPhi* thirdHitMap[size];
   vector<const DetLayer*> thirdLayerDetLayer(size, nullptr);
   for (int il = 0; il < size; ++il) {
-    thirdHitMap[il] = &layerCache(thirdLayers[il], region, es);
+    thirdHitMap[il] = &layerCache(thirdLayers[il], region);
     thirdLayerDetLayer[il] = thirdLayers[il].detLayer();
   }
   hitTriplets(region, result, es, doublets, thirdHitMap, thirdLayerDetLayer, size, tripletLastLayerIndex);

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.cc
@@ -112,7 +112,7 @@ void PixelTripletLargeTipGenerator::hitTriplets(const TrackingRegion& region,
   const RecHitsSortedInPhi* thirdHitMap[size];
   vector<const DetLayer*> thirdLayerDetLayer(size, nullptr);
   for (int il = 0; il < size; ++il) {
-    thirdHitMap[il] = &layerCache(thirdLayers[il], region, es);
+    thirdHitMap[il] = &layerCache(thirdLayers[il], region);
     thirdLayerDetLayer[il] = thirdLayers[il].detLayer();
   }
   hitTriplets(region, result, es, doublets, thirdHitMap, thirdLayerDetLayer, size, tripletLastLayerIndex);

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletNoTipGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletNoTipGenerator.cc
@@ -72,7 +72,7 @@ void PixelTripletNoTipGenerator::hitTriplets(const TrackingRegion& region,
 
   const RecHitsSortedInPhi** thirdHitMap = new const RecHitsSortedInPhi*[size];
   for (int il = 0; il <= size - 1; il++) {
-    thirdHitMap[il] = &(*theLayerCache)(thirdLayers[il], region, es);
+    thirdHitMap[il] = &(*theLayerCache)(thirdLayers[il], region);
   }
 
   const auto& field = es.getData(fieldToken_);

--- a/RecoTauTag/HLTProducers/src/TrackingRegionsFromBeamSpotAndL2Tau.h
+++ b/RecoTauTag/HLTProducers/src/TrackingRegionsFromBeamSpotAndL2Tau.h
@@ -52,6 +52,10 @@ public:
       token_measurementTracker =
           iC.consumes<MeasurementTrackerEvent>(regionPSet.getParameter<edm::InputTag>("measurementTrackerName"));
     }
+    token_field = iC.esConsumes();
+    if (m_precise) {
+      token_msmaker = iC.esConsumes();
+    }
   }
 
   ~TrackingRegionsFromBeamSpotAndL2Tau() override {}
@@ -105,6 +109,12 @@ public:
       measurementTracker = hmte.product();
     }
 
+    const auto& field = es.getData(token_field);
+    const MultipleScatteringParametrisationMaker* msmaker = nullptr;
+    if (m_precise) {
+      msmaker = &es.getData(token_msmaker);
+    }
+
     // create maximum JetMaxN tracking regions in directions of
     // highest pt jets that are above threshold and are within allowed eta
     // (we expect that jet collection was sorted in decreasing pt order)
@@ -123,8 +133,10 @@ public:
                                                                          m_originHalfLength,
                                                                          m_deltaEta,
                                                                          m_deltaPhi,
-                                                                         m_whereToUseMeasurementTracker,
+                                                                         field,
+                                                                         msmaker,
                                                                          m_precise,
+                                                                         m_whereToUseMeasurementTracker,
                                                                          measurementTracker,
                                                                          m_searchOpt));
       ++n_regions;
@@ -147,6 +159,8 @@ private:
   RectangularEtaPhiTrackingRegion::UseMeasurementTracker m_whereToUseMeasurementTracker;
   bool m_searchOpt;
   edm::EDGetTokenT<reco::BeamSpot> token_beamSpot;
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> token_field;
+  edm::ESGetToken<MultipleScatteringParametrisationMaker, TrackerMultipleScatteringRecord> token_msmaker;
   bool m_precise;
 };
 

--- a/RecoTracker/ConversionSeedGenerators/plugins/CombinedHitPairGeneratorForPhotonConversion.cc
+++ b/RecoTracker/ConversionSeedGenerators/plugins/CombinedHitPairGeneratorForPhotonConversion.cc
@@ -18,7 +18,7 @@ CombinedHitPairGeneratorForPhotonConversion::CombinedHitPairGeneratorForPhotonCo
   theMaxElement = cfg.getParameter<unsigned int>("maxElement");
   maxHitPairsPerTrackAndGenerator = cfg.getParameter<unsigned int>("maxHitPairsPerTrackAndGenerator");
   theGenerator = std::make_unique<HitPairGeneratorFromLayerPairForPhotonConversion>(
-      0, 1, &theLayerCache, 0, maxHitPairsPerTrackAndGenerator);
+      iC, 0, 1, &theLayerCache, 0, maxHitPairsPerTrackAndGenerator);
 }
 
 const OrderedHitPairs& CombinedHitPairGeneratorForPhotonConversion::run(const ConversionRegion& convRegion,

--- a/RecoTracker/ConversionSeedGenerators/plugins/CombinedHitQuadrupletGeneratorForPhotonConversion.cc
+++ b/RecoTracker/ConversionSeedGenerators/plugins/CombinedHitQuadrupletGeneratorForPhotonConversion.cc
@@ -33,7 +33,7 @@ void CombinedHitQuadrupletGeneratorForPhotonConversion::hitPairs(const TrackingR
   assert(layers.numberOfLayersInSet() == 2);
 
   for (SeedingLayerSetsHits::LayerSetIndex i = 0; i < hlayers->size() && result.size() < maxHitQuadruplets; ++i) {
-    theGenerator->hitPairs(region, result, layers[i], ev, es);
+    theGenerator->hitPairs(region, result, layers[i]);
   }
   theLayerCache.clear();
 }

--- a/RecoTracker/ConversionSeedGenerators/plugins/HitPairGeneratorFromLayerPairForPhotonConversion.h
+++ b/RecoTracker/ConversionSeedGenerators/plugins/HitPairGeneratorFromLayerPairForPhotonConversion.h
@@ -3,12 +3,15 @@
 
 #include "RecoTracker/TkHitPairs/interface/HitPairGenerator.h"
 #include "RecoTracker/TkHitPairs/interface/LayerHitMapCache.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Utilities/interface/Visibility.h"
 
 #include "ConversionRegion.h"
 
 class DetLayer;
+class IdealMagneticFieldRecord;
+class MagneticField;
 class TrackingRegion;
 
 class dso_hidden HitPairGeneratorFromLayerPairForPhotonConversion {  // : public HitPairGenerator {
@@ -18,7 +21,8 @@ public:
   typedef SeedingLayerSetsHits::SeedingLayerSet Layers;
   typedef SeedingLayerSetsHits::SeedingLayer Layer;
 
-  HitPairGeneratorFromLayerPairForPhotonConversion(unsigned int inner,
+  HitPairGeneratorFromLayerPairForPhotonConversion(edm::ConsumesCollector iC,
+                                                   unsigned int inner,
                                                    unsigned int outer,
                                                    LayerCacheType* layerCache,
                                                    unsigned int nSize = 30000,
@@ -58,6 +62,7 @@ private:
   const unsigned int theOuterLayer;
   const unsigned int theInnerLayer;
   const unsigned int theMaxElement;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> theFieldToken;
 
   std::stringstream ss;
 };

--- a/RecoTracker/ConversionSeedGenerators/plugins/HitQuadrupletGeneratorFromLayerPairForPhotonConversion.cc
+++ b/RecoTracker/ConversionSeedGenerators/plugins/HitQuadrupletGeneratorFromLayerPairForPhotonConversion.cc
@@ -10,9 +10,6 @@
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegionBase.h"
 #include "RecoTracker/TkHitPairs/interface/OrderedHitPairs.h"
 
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-
 using namespace GeomDetEnumerators;
 using namespace std;
 #include "RecoTracker/TkMSParametrization/interface/PixelRecoUtilities.h"
@@ -40,9 +37,7 @@ HitQuadrupletGeneratorFromLayerPairForPhotonConversion::HitQuadrupletGeneratorFr
 
 void HitQuadrupletGeneratorFromLayerPairForPhotonConversion::hitPairs(const TrackingRegion &region,
                                                                       OrderedHitPairs &result,
-                                                                      const Layers &layers,
-                                                                      const edm::Event &event,
-                                                                      const edm::EventSetup &es) {
+                                                                      const Layers &layers) {
   ss->str("");
 
   typedef OrderedHitPair::InnerRecHit InnerHit;
@@ -58,11 +53,11 @@ void HitQuadrupletGeneratorFromLayerPairForPhotonConversion::hitPairs(const Trac
 #endif
 
   /*get hit sorted in phi for each layer: NB: doesn't apply any region cut*/
-  const RecHitsSortedInPhi &innerHitsMap = theLayerCache(innerLayerObj, region, es);
+  const RecHitsSortedInPhi &innerHitsMap = theLayerCache(innerLayerObj, region);
   if (innerHitsMap.empty())
     return;
 
-  const RecHitsSortedInPhi &outerHitsMap = theLayerCache(outerLayerObj, region, es);
+  const RecHitsSortedInPhi &outerHitsMap = theLayerCache(outerLayerObj, region);
   if (outerHitsMap.empty())
     return;
   /*----------------*/
@@ -84,7 +79,7 @@ void HitQuadrupletGeneratorFromLayerPairForPhotonConversion::hitPairs(const Trac
     GlobalPoint oPos = ohit->globalPosition();
 
     totCountP2++;
-    std::unique_ptr<const HitRZCompatibility> checkRZ = region.checkRZ(outerLayerObj.detLayer(), ohit, es);
+    std::unique_ptr<const HitRZCompatibility> checkRZ = region.checkRZ(outerLayerObj.detLayer(), ohit);
     for (nextoh = oh + 1; nextoh != outerHits.second; ++nextoh) {
       RecHitsSortedInPhi::Hit nohit = (*nextoh).hit();
       GlobalPoint noPos = nohit->globalPosition();
@@ -126,8 +121,8 @@ void HitQuadrupletGeneratorFromLayerPairForPhotonConversion::hitPairs(const Trac
       (*ss) << "\tiphimin, iphimax " << innerPhimin << " " << innerPhimax << std::endl;
 #endif
 
-      std::unique_ptr<const HitRZCompatibility> checkRZb = region.checkRZ(innerLayerObj.detLayer(), ohit, es);
-      std::unique_ptr<const HitRZCompatibility> checkRZc = region.checkRZ(innerLayerObj.detLayer(), nohit, es);
+      std::unique_ptr<const HitRZCompatibility> checkRZb = region.checkRZ(innerLayerObj.detLayer(), ohit);
+      std::unique_ptr<const HitRZCompatibility> checkRZc = region.checkRZ(innerLayerObj.detLayer(), nohit);
 
       /*Loop on inner hits*/
       vector<RecHitsSortedInPhi::Hit>::const_iterator ieh = innerHits.end();

--- a/RecoTracker/ConversionSeedGenerators/plugins/HitQuadrupletGeneratorFromLayerPairForPhotonConversion.h
+++ b/RecoTracker/ConversionSeedGenerators/plugins/HitQuadrupletGeneratorFromLayerPairForPhotonConversion.h
@@ -23,11 +23,7 @@ public:
 
   ~HitQuadrupletGeneratorFromLayerPairForPhotonConversion() {}
 
-  void hitPairs(const TrackingRegion &reg,
-                OrderedHitPairs &prs,
-                const Layers &layers,
-                const edm::Event &ev,
-                const edm::EventSetup &es);
+  void hitPairs(const TrackingRegion &reg, OrderedHitPairs &prs, const Layers &layers);
 
   bool failCheckRZCompatibility(const RecHitsSortedInPhi::Hit &hit,
                                 const DetLayer &layer,

--- a/RecoTracker/SpecialSeedGenerators/interface/CosmicRegionalSeedGenerator.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/CosmicRegionalSeedGenerator.h
@@ -56,20 +56,16 @@ public:
                                                         const edm::EventSetup& es) const override;
 
 private:
-  edm::ParameterSet conf_;
-  edm::ParameterSet regionPSet;
-
   float ptMin_;
   float rVertex_;
   float zVertex_;
   float deltaEta_;
   float deltaPhi_;
 
-  std::string thePropagatorName_;
   std::string regionBase_;
 
-  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerToken_;
   edm::ESGetToken<Propagator, TrackingComponentsRecord> propagatorToken_;
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magfieldToken_;
 
   edm::InputTag recoMuonsCollection_;
   edm::InputTag recoTrackMuonsCollection_;

--- a/RecoTracker/SpecialSeedGenerators/interface/CosmicTrackingRegion.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/CosmicTrackingRegion.h
@@ -10,7 +10,6 @@
 
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegionBase.h"
 #include "RecoTracker/TkTrackingRegions/interface/HitRZConstraint.h"
-#include "FWCore/Framework/interface/EventSetup.h"
 #include "RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 
@@ -81,11 +80,10 @@ public:
         theMeasurementTracker_(rh.theMeasurementTracker_),
         theMagneticField_(rh.theMagneticField_) {}
 
-  TrackingRegion::Hits hits(const edm::EventSetup& es, const SeedingLayerSetsHits::SeedingLayer& layer) const override;
+  TrackingRegion::Hits hits(const SeedingLayerSetsHits::SeedingLayer& layer) const override;
 
   std::unique_ptr<HitRZCompatibility> checkRZ(const DetLayer* layer,
                                               const Hit& outerHit,
-                                              const edm::EventSetup& iSetup,
                                               const DetLayer* outerlayer = nullptr,
                                               float lr = 0,
                                               float gz = 0,
@@ -104,7 +102,7 @@ public:
 
 private:
   template <typename T>
-  void hits_(const edm::EventSetup& es, const T& layer, TrackingRegion::Hits& result) const;
+  void hits_(const T& layer, TrackingRegion::Hits& result) const;
 
   const MeasurementTrackerEvent* theMeasurementTracker_;
   const MagneticField* theMagneticField_;

--- a/RecoTracker/SpecialSeedGenerators/interface/CosmicTrackingRegion.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/CosmicTrackingRegion.h
@@ -12,7 +12,7 @@
 #include "RecoTracker/TkTrackingRegions/interface/HitRZConstraint.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
 
 #include "DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h"
 #include "DataFormats/TrackingRecHit/interface/mayown_ptr.h"
@@ -56,11 +56,12 @@ public:
                        float zVertex,
                        float deltaEta,
                        float deltaPhi,
+                       const MagneticField& magField,
                        float dummy = 0.,
                        const MeasurementTrackerEvent* measurementTracker = nullptr)
       : TrackingRegionBase(dir, vertexPos, Range(-1 / ptMin, 1 / ptMin), rVertex, zVertex),
         theMeasurementTracker_(measurementTracker),
-        measurementTrackerName_("") {}
+        theMagneticField_(&magField) {}
 
   CosmicTrackingRegion(const GlobalVector& dir,
                        const GlobalPoint& vertexPos,
@@ -69,17 +70,16 @@ public:
                        float zVertex,
                        float deltaEta,
                        float deltaPhi,
-                       const edm::ParameterSet& extra,
+                       const MagneticField& magField,
                        const MeasurementTrackerEvent* measurementTracker = nullptr)
       : TrackingRegionBase(dir, vertexPos, Range(-1 / ptMin, 1 / ptMin), rVertex, zVertex),
-        theMeasurementTracker_(measurementTracker) {
-    measurementTrackerName_ = extra.getParameter<std::string>("measurementTrackerName");
-  }
+        theMeasurementTracker_(measurementTracker),
+        theMagneticField_(&magField) {}
 
   CosmicTrackingRegion(CosmicTrackingRegion const& rh)
       : TrackingRegionBase(rh),
         theMeasurementTracker_(rh.theMeasurementTracker_),
-        measurementTrackerName_(rh.measurementTrackerName_) {}
+        theMagneticField_(rh.theMagneticField_) {}
 
   TrackingRegion::Hits hits(const edm::EventSetup& es, const SeedingLayerSetsHits::SeedingLayer& layer) const override;
 
@@ -107,7 +107,7 @@ private:
   void hits_(const edm::EventSetup& es, const T& layer, TrackingRegion::Hits& result) const;
 
   const MeasurementTrackerEvent* theMeasurementTracker_;
-  std::string measurementTrackerName_;
+  const MagneticField* theMagneticField_;
 
   using cacheHitPointer = mayown_ptr<BaseTrackerRecHit>;
   using cacheHits = std::vector<cacheHitPointer>;

--- a/RecoTracker/SpecialSeedGenerators/interface/SimpleCosmicBONSeeder.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/SimpleCosmicBONSeeder.h
@@ -47,8 +47,8 @@ public:
   void produce(edm::Event &e, const edm::EventSetup &c) override;
 
   void init(const edm::EventSetup &c);
-  bool triplets(const edm::Event &e, const edm::EventSetup &c);
-  bool seeds(TrajectorySeedCollection &output, const edm::EventSetup &iSetup);
+  bool triplets(const edm::Event &e);
+  bool seeds(TrajectorySeedCollection &output);
   void done();
 
   bool goodTriplet(const GlobalPoint &inner,
@@ -58,12 +58,9 @@ public:
 
   std::pair<GlobalVector, int> pqFromHelixFit(const GlobalPoint &inner,
                                               const GlobalPoint &middle,
-                                              const GlobalPoint &outer,
-                                              const edm::EventSetup &iSetup) const;
+                                              const GlobalPoint &outer) const;
 
 private:
-  edm::ParameterSet conf_;
-
   const edm::EDGetTokenT<SeedingLayerSetsHits> seedingLayerToken_;
   const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magfieldToken_;
   const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerToken_;

--- a/RecoTracker/SpecialSeedGenerators/src/BeamHaloPairGenerator.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/BeamHaloPairGenerator.cc
@@ -23,8 +23,8 @@ const OrderedSeedingHits& BeamHaloPairGenerator::run(const TrackingRegion& regio
     throw cms::Exception("CtfSpecialSeedGenerator")
         << "You are using " << layers.numberOfLayersInSet() << " layers in set instead of 2 ";
   for (SeedingLayerSetsHits::SeedingLayerSet ls : layers) {
-    auto innerHits = region.hits(es, ls[0]);
-    auto outerHits = region.hits(es, ls[1]);
+    auto innerHits = region.hits(ls[0]);
+    auto outerHits = region.hits(ls[1]);
 
     for (auto iOuterHit = outerHits.begin(); iOuterHit != outerHits.end(); iOuterHit++) {
       for (auto iInnerHit = innerHits.begin(); iInnerHit != innerHits.end(); iInnerHit++) {

--- a/RecoTracker/SpecialSeedGenerators/src/CosmicTrackingRegion.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/CosmicTrackingRegion.cc
@@ -13,8 +13,6 @@
 
 #include "DataFormats/GeometrySurface/interface/BoundPlane.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
-
 namespace {
   template <class T>
   T sqr(T t) {
@@ -65,11 +63,6 @@ void CosmicTrackingRegion::hits_(const edm::EventSetup& es, const T& layer, Trac
   LogDebug("CosmicTrackingRegion") << "Looking at hits on subdet/layer " << layer.name();
   EtaPhiMeasurementEstimator est(0.3, 0.3);
 
-  //magnetic field
-  edm::ESHandle<MagneticField> field;
-  es.get<IdealMagneticFieldRecord>().get(field);
-  const MagneticField* magField = field.product();
-
   //region
   const GlobalPoint vtx = origin();
   GlobalVector dir = direction();
@@ -85,12 +78,12 @@ void CosmicTrackingRegion::hits_(const edm::EventSetup& es, const T& layer, Trac
   Surface::RotationType rot(sin(phi), -cos(phi), 0, 0, 0, -1, cos(phi), sin(phi), 0);
 
   Plane::PlanePointer surface = Plane::build(vtx, rot);
-  FreeTrajectoryState fts(GlobalTrajectoryParameters(vtx, dir, 1, magField));
+  FreeTrajectoryState fts(GlobalTrajectoryParameters(vtx, dir, 1, theMagneticField_));
   TrajectoryStateOnSurface tsos(fts, *surface);
   LogDebug("CosmicTrackingRegion") << "The state used to find measurement with the measurement tracker is:\n" << tsos;
 
   //propagator
-  AnalyticalPropagator prop(magField, alongMomentum);
+  AnalyticalPropagator prop(theMagneticField_, alongMomentum);
 
   //propagation verification (debug)
   //++++++++++++++++++++++++++++++++

--- a/RecoTracker/SpecialSeedGenerators/src/CosmicTrackingRegion.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/CosmicTrackingRegion.cc
@@ -46,15 +46,14 @@ void CosmicTrackingRegion::checkTracks(reco::TrackCollection const& tracks, std:
   }
 }
 
-TrackingRegion::Hits CosmicTrackingRegion::hits(const edm::EventSetup& es,
-                                                const SeedingLayerSetsHits::SeedingLayer& layer) const {
+TrackingRegion::Hits CosmicTrackingRegion::hits(const SeedingLayerSetsHits::SeedingLayer& layer) const {
   TrackingRegion::Hits result;
-  hits_(es, layer, result);
+  hits_(layer, result);
   return result;
 }
 
 template <typename T>
-void CosmicTrackingRegion::hits_(const edm::EventSetup& es, const T& layer, TrackingRegion::Hits& result) const {
+void CosmicTrackingRegion::hits_(const T& layer, TrackingRegion::Hits& result) const {
   //get and name collections
   //++++++++++++++++++++++++
 

--- a/RecoTracker/SpecialSeedGenerators/src/GenericPairGenerator.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/GenericPairGenerator.cc
@@ -24,8 +24,8 @@ const OrderedSeedingHits& GenericPairGenerator::run(const TrackingRegion& region
         << "You are using " << layers.numberOfLayersInSet() << " layers in set instead of 2 ";
 
   for (SeedingLayerSetsHits::SeedingLayerSet ls : layers) {
-    auto innerHits = region.hits(es, ls[0]);
-    auto outerHits = region.hits(es, ls[1]);
+    auto innerHits = region.hits(ls[0]);
+    auto outerHits = region.hits(ls[1]);
     for (auto iOuterHit = outerHits.begin(); iOuterHit != outerHits.end(); iOuterHit++) {
       for (auto iInnerHit = innerHits.begin(); iInnerHit != innerHits.end(); iInnerHit++) {
         hitPairs.push_back(OrderedHitPair(&(**iInnerHit), &(**iOuterHit)));

--- a/RecoTracker/SpecialSeedGenerators/src/GenericTripletGenerator.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/GenericTripletGenerator.cc
@@ -24,11 +24,11 @@ const OrderedSeedingHits& GenericTripletGenerator::run(const TrackingRegion& reg
         << "You are using " << layers.numberOfLayersInSet() << " layers in set instead of 3 ";
   std::map<float, OrderedHitTriplet> radius_triplet_map;
   for (SeedingLayerSetsHits::SeedingLayerSet ls : layers) {
-    auto innerHits = region.hits(es, ls[0]);
+    auto innerHits = region.hits(ls[0]);
     //std::cout << "innerHits.size()=" << innerHits.size() << std::endl;
-    auto middleHits = region.hits(es, ls[1]);
+    auto middleHits = region.hits(ls[1]);
     //std::cout << "middleHits.size()=" << middleHits.size() << std::endl;
-    auto outerHits = region.hits(es, ls[2]);
+    auto outerHits = region.hits(ls[2]);
     //std::cout << "outerHits.size()=" << outerHits.size() << std::endl;
     //std::cout << "trying " << innerHits.size()*middleHits.size()*outerHits.size() << " combinations "<<std::endl;
     for (auto iOuterHit = outerHits.begin(); iOuterHit != outerHits.end(); iOuterHit++) {

--- a/RecoTracker/SpecialSeedGenerators/src/SimpleCosmicBONSeeder.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/SimpleCosmicBONSeeder.cc
@@ -23,11 +23,10 @@ namespace {
 
 using namespace std;
 SimpleCosmicBONSeeder::SimpleCosmicBONSeeder(edm::ParameterSet const &conf)
-    : conf_(conf),
-      seedingLayerToken_(consumes<SeedingLayerSetsHits>(conf.getParameter<edm::InputTag>("TripletsSrc"))),
+    : seedingLayerToken_(consumes<SeedingLayerSetsHits>(conf.getParameter<edm::InputTag>("TripletsSrc"))),
       magfieldToken_(esConsumes()),
       trackerToken_(esConsumes()),
-      ttrhBuilderToken_(esConsumes(edm::ESInputTag("", conf_.getParameter<std::string>("TTRHBuilder")))),
+      ttrhBuilderToken_(esConsumes(edm::ESInputTag("", conf.getParameter<std::string>("TTRHBuilder")))),
       writeTriplets_(conf.getParameter<bool>("writeTriplets")),
       seedOnMiddle_(conf.existsAs<bool>("seedOnMiddle") ? conf.getParameter<bool>("seedOnMiddle") : false),
       rescaleError_(conf.existsAs<double>("rescaleError") ? conf.getParameter<double>("rescaleError") : 1.0),
@@ -37,7 +36,7 @@ SimpleCosmicBONSeeder::SimpleCosmicBONSeeder(edm::ParameterSet const &conf)
       check_(conf.getParameter<edm::ParameterSet>("ClusterCheckPSet"), consumesCollector()),
       maxTriplets_(conf.getParameter<int32_t>("maxTriplets")),
       maxSeeds_(conf.getParameter<int32_t>("maxSeeds")) {
-  edm::ParameterSet regionConf = conf_.getParameter<edm::ParameterSet>("RegionPSet");
+  edm::ParameterSet regionConf = conf.getParameter<edm::ParameterSet>("RegionPSet");
   float ptmin = regionConf.getParameter<double>("ptMin");
   float originradius = regionConf.getParameter<double>("originRadius");
   float halflength = regionConf.getParameter<double>("originHalfLength");
@@ -46,8 +45,8 @@ SimpleCosmicBONSeeder::SimpleCosmicBONSeeder(edm::ParameterSet const &conf)
   pMin_ = regionConf.getParameter<double>("pMin");
 
   //***top-bottom
-  positiveYOnly = conf_.getParameter<bool>("PositiveYOnly");
-  negativeYOnly = conf_.getParameter<bool>("NegativeYOnly");
+  positiveYOnly = conf.getParameter<bool>("PositiveYOnly");
+  negativeYOnly = conf.getParameter<bool>("NegativeYOnly");
   //***
 
   produces<TrajectorySeedCollection>();
@@ -98,9 +97,9 @@ void SimpleCosmicBONSeeder::produce(edm::Event &ev, const edm::EventSetup &es) {
       edm::LogError("TooManyClusters") << "Found too many clusters (" << clustsOrZero << "), bailing out.\n";
     } else {
       init(es);
-      bool tripletsOk = triplets(ev, es);
+      bool tripletsOk = triplets(ev);
       if (tripletsOk) {
-        bool seedsOk = seeds(*output, es);
+        bool seedsOk = seeds(*output);
         if (!seedsOk) {
         }
 
@@ -168,7 +167,7 @@ struct HigherInnerHit {
   }
 };
 
-bool SimpleCosmicBONSeeder::triplets(const edm::Event &e, const edm::EventSetup &es) {
+bool SimpleCosmicBONSeeder::triplets(const edm::Event &e) {
   hitTriplets.clear();
   hitTriplets.reserve(0);
   edm::Handle<SeedingLayerSetsHits> hlayers;
@@ -183,9 +182,9 @@ bool SimpleCosmicBONSeeder::triplets(const edm::Event &e, const edm::EventSetup 
   for (SeedingLayerSetsHits::LayerSetIndex layerIndex = 0; layerIndex < layers.size(); ++layerIndex) {
     SeedingLayerSetsHits::SeedingLayerSet ls = layers[layerIndex];
     /// ctfseeding SeedinHits and their iterators
-    auto innerHits = region_.hits(es, ls[0]);
-    auto middleHits = region_.hits(es, ls[1]);
-    auto outerHits = region_.hits(es, ls[2]);
+    auto innerHits = region_.hits(ls[0]);
+    auto middleHits = region_.hits(ls[1]);
+    auto outerHits = region_.hits(ls[2]);
 
     if (tripletsVerbosity_ > 0) {
       std::cout << "GenericTripletGenerator iLss = " << seedingLayersToString(ls) << " (" << layerIndex
@@ -291,7 +290,7 @@ bool SimpleCosmicBONSeeder::triplets(const edm::Event &e, const edm::EventSetup 
                         << " + " << outerpos << std::endl;
             }
             if (tripletsVerbosity_ > 3 && (helixVerbosity_ > 0)) {  // debug the momentum here too
-              pqFromHelixFit(innerpos, middlepos, outerpos, es);
+              pqFromHelixFit(innerpos, middlepos, outerpos);
             }
           }
         }
@@ -402,8 +401,7 @@ bool SimpleCosmicBONSeeder::goodTriplet(const GlobalPoint &inner,
 
 std::pair<GlobalVector, int> SimpleCosmicBONSeeder::pqFromHelixFit(const GlobalPoint &inner,
                                                                    const GlobalPoint &middle,
-                                                                   const GlobalPoint &outer,
-                                                                   const edm::EventSetup &iSetup) const {
+                                                                   const GlobalPoint &outer) const {
   if (helixVerbosity_ > 0) {
     std::cout << "DEBUG PZ =====" << std::endl;
     FastHelix helix(inner, middle, outer, magfield->nominalValue(), &*magfield);
@@ -453,7 +451,7 @@ std::pair<GlobalVector, int> SimpleCosmicBONSeeder::pqFromHelixFit(const GlobalP
   return mypq;
 }
 
-bool SimpleCosmicBONSeeder::seeds(TrajectorySeedCollection &output, const edm::EventSetup &iSetup) {
+bool SimpleCosmicBONSeeder::seeds(TrajectorySeedCollection &output) {
   typedef TrajectoryStateOnSurface TSOS;
 
   for (size_t it = 0; it < hitTriplets.size(); it++) {
@@ -483,7 +481,7 @@ bool SimpleCosmicBONSeeder::seeds(TrajectorySeedCollection &output, const edm::E
     }
 
     // First use FastHelix out of the box
-    std::pair<GlobalVector, int> pq = pqFromHelixFit(inner, middle, outer, iSetup);
+    std::pair<GlobalVector, int> pq = pqFromHelixFit(inner, middle, outer);
     GlobalVector gv = pq.first;
     float ch = pq.second;
     float Mom = sqrt(gv.x() * gv.x() + gv.y() * gv.y() + gv.z() * gv.z());

--- a/RecoTracker/TkHitPairs/interface/CombinedHitPairGenerator.h
+++ b/RecoTracker/TkHitPairs/interface/CombinedHitPairGenerator.h
@@ -37,8 +37,6 @@ public:
                 const edm::EventSetup& es) override;
 
 private:
-  CombinedHitPairGenerator(const CombinedHitPairGenerator& cb);
-
   edm::EDGetTokenT<SeedingLayerSetsHits> theSeedingLayerToken;
 
   LayerCacheType theLayerCache;

--- a/RecoTracker/TkHitPairs/interface/HitPairGeneratorFromLayerPair.h
+++ b/RecoTracker/TkHitPairs/interface/HitPairGeneratorFromLayerPair.h
@@ -1,11 +1,16 @@
 #ifndef HitPairGeneratorFromLayerPair_h
 #define HitPairGeneratorFromLayerPair_h
 
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "RecoTracker/TkHitPairs/interface/OrderedHitPairs.h"
 #include "RecoTracker/TkHitPairs/interface/LayerHitMapCache.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/SeedingLayerSetsHits.h"
 
 class DetLayer;
+class IdealMagneticFieldRecord;
+class MagneticField;
+class MultipleScatteringParametrisationMaker;
+class TrackerMultipleScatteringRecord;
 class TrackingRegion;
 
 class HitPairGeneratorFromLayerPair {
@@ -14,7 +19,8 @@ public:
   typedef SeedingLayerSetsHits::SeedingLayerSet Layers;
   typedef SeedingLayerSetsHits::SeedingLayer Layer;
 
-  HitPairGeneratorFromLayerPair(unsigned int inner,
+  HitPairGeneratorFromLayerPair(edm::ConsumesCollector iC,
+                                unsigned int inner,
                                 unsigned int outer,
                                 LayerCacheType* layerCache,
                                 unsigned int max = 0);
@@ -56,7 +62,8 @@ public:
                        const DetLayer& outerHitDetLayer,
                        const RecHitsSortedInPhi& innerHitsMap,
                        const RecHitsSortedInPhi& outerHitsMap,
-                       const edm::EventSetup& iSetup,
+                       const MagneticField& field,
+                       const MultipleScatteringParametrisationMaker& msmaker,
                        const unsigned int theMaxElement,
                        HitDoublets& result);
 
@@ -65,6 +72,8 @@ public:
 
 private:
   LayerCacheType* theLayerCache;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> theFieldToken;
+  const edm::ESGetToken<MultipleScatteringParametrisationMaker, TrackerMultipleScatteringRecord> theMSMakerToken;
   const unsigned int theOuterLayer;
   const unsigned int theInnerLayer;
   const unsigned int theMaxElement;

--- a/RecoTracker/TkHitPairs/interface/LayerHitMapCache.h
+++ b/RecoTracker/TkHitPairs/interface/LayerHitMapCache.h
@@ -77,15 +77,13 @@ public:
     return ptr;
   }
 
-  const RecHitsSortedInPhi& operator()(const SeedingLayerSetsHits::SeedingLayer& layer,
-                                       const TrackingRegion& region,
-                                       const edm::EventSetup& iSetup) {
+  const RecHitsSortedInPhi& operator()(const SeedingLayerSetsHits::SeedingLayer& layer, const TrackingRegion& region) {
     int key = layer.index();
     assert(key >= 0);
     const RecHitsSortedInPhi* lhm = theCache.get(key);
     if (lhm == nullptr) {
-      auto tmp = add(
-          layer, std::make_unique<RecHitsSortedInPhi>(region.hits(iSetup, layer), region.origin(), layer.detLayer()));
+      auto tmp =
+          add(layer, std::make_unique<RecHitsSortedInPhi>(region.hits(layer), region.origin(), layer.detLayer()));
       tmp->theOrigin = region.origin();
       lhm = tmp;
       LogDebug("LayerHitMapCache") << " I got" << lhm->all().second - lhm->all().first

--- a/RecoTracker/TkHitPairs/src/CombinedHitPairGenerator.cc
+++ b/RecoTracker/TkHitPairs/src/CombinedHitPairGenerator.cc
@@ -7,14 +7,7 @@
 CombinedHitPairGenerator::CombinedHitPairGenerator(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC)
     : theSeedingLayerToken(iC.consumes<SeedingLayerSetsHits>(cfg.getParameter<edm::InputTag>("SeedingLayers"))) {
   theMaxElement = cfg.getParameter<unsigned int>("maxElement");
-  theGenerator = std::make_unique<HitPairGeneratorFromLayerPair>(0, 1, &theLayerCache, theMaxElement);
-}
-
-CombinedHitPairGenerator::CombinedHitPairGenerator(const CombinedHitPairGenerator& cb)
-    : HitPairGenerator(cb),
-      theSeedingLayerToken(cb.theSeedingLayerToken),
-      theGenerator(std::make_unique<HitPairGeneratorFromLayerPair>(0, 1, &theLayerCache, cb.theMaxElement)) {
-  theMaxElement = cb.theMaxElement;
+  theGenerator = std::make_unique<HitPairGeneratorFromLayerPair>(iC, 0, 1, &theLayerCache, theMaxElement);
 }
 
 CombinedHitPairGenerator::~CombinedHitPairGenerator() {}

--- a/RecoTracker/TkHitPairs/src/HitPairGeneratorFromLayerPair.cc
+++ b/RecoTracker/TkHitPairs/src/HitPairGeneratorFromLayerPair.cc
@@ -92,11 +92,11 @@ HitDoublets HitPairGeneratorFromLayerPair::doublets(const TrackingRegion& region
                                                     const Layer& innerLayer,
                                                     const Layer& outerLayer,
                                                     LayerCacheType& layerCache) {
-  const RecHitsSortedInPhi& innerHitsMap = layerCache(innerLayer, region, iSetup);
+  const RecHitsSortedInPhi& innerHitsMap = layerCache(innerLayer, region);
   if (innerHitsMap.empty())
     return HitDoublets(innerHitsMap, innerHitsMap);
 
-  const RecHitsSortedInPhi& outerHitsMap = layerCache(outerLayer, region, iSetup);
+  const RecHitsSortedInPhi& outerHitsMap = layerCache(outerLayer, region);
   if (outerHitsMap.empty())
     return HitDoublets(innerHitsMap, outerHitsMap);
   HitDoublets result(innerHitsMap, outerHitsMap);
@@ -140,7 +140,6 @@ void HitPairGeneratorFromLayerPair::doublets(const TrackingRegion& region,
     std::unique_ptr<const HitRZCompatibility> checkRZ =
         region.checkRZ(&innerHitDetLayer,
                        ohit,
-                       iSetup,
                        &outerHitDetLayer,
                        outerHitsMap.rv(io),
                        outerHitsMap.z[io],

--- a/RecoTracker/TkHitPairs/src/HitPairGeneratorFromLayerPair.cc
+++ b/RecoTracker/TkHitPairs/src/HitPairGeneratorFromLayerPair.cc
@@ -31,13 +31,15 @@ namespace {
 #include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
 #include "RecoTracker/TkMSParametrization/interface/MultipleScatteringParametrisationMaker.h"
 #include "RecoTracker/Record/interface/TrackerMultipleScatteringRecord.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 
-HitPairGeneratorFromLayerPair::HitPairGeneratorFromLayerPair(unsigned int inner,
-                                                             unsigned int outer,
-                                                             LayerCacheType* layerCache,
-                                                             unsigned int max)
-    : theLayerCache(layerCache), theOuterLayer(outer), theInnerLayer(inner), theMaxElement(max) {}
+HitPairGeneratorFromLayerPair::HitPairGeneratorFromLayerPair(
+    edm::ConsumesCollector iC, unsigned int inner, unsigned int outer, LayerCacheType* layerCache, unsigned int max)
+    : theLayerCache(layerCache),
+      theFieldToken(iC.esConsumes()),
+      theMSMakerToken(iC.esConsumes()),
+      theOuterLayer(outer),
+      theInnerLayer(inner),
+      theMaxElement(max) {}
 
 HitPairGeneratorFromLayerPair::~HitPairGeneratorFromLayerPair() {}
 
@@ -99,10 +101,19 @@ HitDoublets HitPairGeneratorFromLayerPair::doublets(const TrackingRegion& region
   const RecHitsSortedInPhi& outerHitsMap = layerCache(outerLayer, region);
   if (outerHitsMap.empty())
     return HitDoublets(innerHitsMap, outerHitsMap);
+  const auto& field = iSetup.getData(theFieldToken);
+  const auto& msmaker = iSetup.getData(theMSMakerToken);
   HitDoublets result(innerHitsMap, outerHitsMap);
   result.reserve(std::max(innerHitsMap.size(), outerHitsMap.size()));
-  doublets(
-      region, *innerLayer.detLayer(), *outerLayer.detLayer(), innerHitsMap, outerHitsMap, iSetup, theMaxElement, result);
+  doublets(region,
+           *innerLayer.detLayer(),
+           *outerLayer.detLayer(),
+           innerHitsMap,
+           outerHitsMap,
+           field,
+           msmaker,
+           theMaxElement,
+           result);
 
   return result;
 }
@@ -112,16 +123,13 @@ void HitPairGeneratorFromLayerPair::doublets(const TrackingRegion& region,
                                              const DetLayer& outerHitDetLayer,
                                              const RecHitsSortedInPhi& innerHitsMap,
                                              const RecHitsSortedInPhi& outerHitsMap,
-                                             const edm::EventSetup& iSetup,
+                                             const MagneticField& field,
+                                             const MultipleScatteringParametrisationMaker& msmaker,
                                              const unsigned int theMaxElement,
                                              HitDoublets& result) {
   //  HitDoublets result(innerHitsMap,outerHitsMap); result.reserve(std::max(innerHitsMap.size(),outerHitsMap.size()));
   typedef RecHitsSortedInPhi::Hit Hit;
-  edm::ESHandle<MagneticField> hfield;
-  iSetup.get<IdealMagneticFieldRecord>().get(hfield);
-  edm::ESHandle<MultipleScatteringParametrisationMaker> hmaker;
-  iSetup.get<TrackerMultipleScatteringRecord>().get(hmaker);
-  InnerDeltaPhi deltaPhi(outerHitDetLayer, innerHitDetLayer, region, *hfield, *hmaker);
+  InnerDeltaPhi deltaPhi(outerHitDetLayer, innerHitDetLayer, region, field, msmaker);
 
   // std::cout << "layers " << theInnerLayer.detLayer()->seqNum()  << " " << outerLayer.detLayer()->seqNum() << std::endl;
 

--- a/RecoTracker/TkSeedGenerator/interface/MultiHitGeneratorFromPairAndLayers.h
+++ b/RecoTracker/TkSeedGenerator/interface/MultiHitGeneratorFromPairAndLayers.h
@@ -43,7 +43,6 @@ public:
 
   virtual void hitTriplets(const TrackingRegion& region,
                            OrderedMultiHits& result,
-                           const edm::EventSetup& es,
                            const HitDoublets& doublets,
                            const RecHitsSortedInPhi** thirdHitMap,
                            const std::vector<const DetLayer*>& thirdLayerDetLayer,

--- a/RecoTracker/TkSeedGenerator/plugins/CombinedMultiHitGenerator.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/CombinedMultiHitGenerator.cc
@@ -13,7 +13,7 @@ CombinedMultiHitGenerator::CombinedMultiHitGenerator(const edm::ParameterSet& cf
   edm::ParameterSet generatorPSet = cfg.getParameter<edm::ParameterSet>("GeneratorPSet");
   std::string generatorName = generatorPSet.getParameter<std::string>("ComponentName");
   theGenerator = MultiHitGeneratorFromPairAndLayersFactory::get()->create(generatorName, generatorPSet, iC);
-  theGenerator->init(std::make_unique<HitPairGeneratorFromLayerPair>(0, 1, &theLayerCache), &theLayerCache);
+  theGenerator->init(std::make_unique<HitPairGeneratorFromLayerPair>(iC, 0, 1, &theLayerCache), &theLayerCache);
 }
 
 CombinedMultiHitGenerator::~CombinedMultiHitGenerator() {}

--- a/RecoTracker/TkSeedGenerator/plugins/MultiHitFromChi2EDProducer.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/MultiHitFromChi2EDProducer.cc
@@ -118,8 +118,7 @@ void MultiHitFromChi2EDProducer::produce(edm::Event& iEvent, const edm::EventSet
       }
       const auto& thirdLayers = found->second;
 
-      generator_.hitSets(
-          region, multihits, iEvent, iSetup, layerPair.doublets(), thirdLayers, hitCache, refittedHitStorage);
+      generator_.hitSets(region, multihits, layerPair.doublets(), thirdLayers, hitCache, refittedHitStorage);
 
 #ifdef EDM_ML_DEBUG
       LogTrace("MultiHitFromChi2EDProducer")

--- a/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc
@@ -180,13 +180,11 @@ void MultiHitGeneratorFromChi2::hitSets(const TrackingRegion& region,
   }
 
   assert(theLayerCache);
-  hitSets(region, result, ev, es, doublets, thirdLayers, *theLayerCache, cache);
+  hitSets(region, result, doublets, thirdLayers, *theLayerCache, cache);
 }
 
 void MultiHitGeneratorFromChi2::hitSets(const TrackingRegion& region,
                                         OrderedMultiHits& result,
-                                        const edm::Event& ev,
-                                        const edm::EventSetup& es,
                                         const HitDoublets& doublets,
                                         const std::vector<SeedingLayerSetsHits::SeedingLayer>& thirdLayers,
                                         LayerCacheType& layerCache,
@@ -195,26 +193,24 @@ void MultiHitGeneratorFromChi2::hitSets(const TrackingRegion& region,
   const RecHitsSortedInPhi* thirdHitMap[size];
   vector<const DetLayer*> thirdLayerDetLayer(size, nullptr);
   for (int il = 0; il < size; ++il) {
-    thirdHitMap[il] = &layerCache(thirdLayers[il], region, es);
+    thirdHitMap[il] = &layerCache(thirdLayers[il], region);
 
     thirdLayerDetLayer[il] = thirdLayers[il].detLayer();
   }
-  hitSets(region, result, es, doublets, thirdHitMap, thirdLayerDetLayer, size, refittedHitStorage);
+  hitSets(region, result, doublets, thirdHitMap, thirdLayerDetLayer, size, refittedHitStorage);
 }
 
 void MultiHitGeneratorFromChi2::hitTriplets(const TrackingRegion& region,
                                             OrderedMultiHits& result,
-                                            const edm::EventSetup& es,
                                             const HitDoublets& doublets,
                                             const RecHitsSortedInPhi** thirdHitMap,
                                             const std::vector<const DetLayer*>& thirdLayerDetLayer,
                                             const int nThirdLayers) {
-  hitSets(region, result, es, doublets, thirdHitMap, thirdLayerDetLayer, nThirdLayers, cache);
+  hitSets(region, result, doublets, thirdHitMap, thirdLayerDetLayer, nThirdLayers, cache);
 }
 
 void MultiHitGeneratorFromChi2::hitSets(const TrackingRegion& region,
                                         OrderedMultiHits& result,
-                                        const edm::EventSetup& es,
                                         const HitDoublets& doublets,
                                         const RecHitsSortedInPhi** thirdHitMap,
                                         const std::vector<const DetLayer*>& thirdLayerDetLayer,

--- a/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.h
+++ b/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.h
@@ -57,8 +57,6 @@ public:
 
   void hitSets(const TrackingRegion& region,
                OrderedMultiHits& trs,
-               const edm::Event& ev,
-               const edm::EventSetup& es,
                const HitDoublets& doublets,
                const std::vector<SeedingLayerSetsHits::SeedingLayer>& thirdLayers,
                LayerCacheType& layerCache,
@@ -66,7 +64,6 @@ public:
 
   void hitTriplets(const TrackingRegion& region,
                    OrderedMultiHits& result,
-                   const edm::EventSetup& es,
                    const HitDoublets& doublets,
                    const RecHitsSortedInPhi** thirdHitMap,
                    const std::vector<const DetLayer*>& thirdLayerDetLayer,
@@ -74,7 +71,6 @@ public:
 
   void hitSets(const TrackingRegion& region,
                OrderedMultiHits& result,
-               const edm::EventSetup& es,
                const HitDoublets& doublets,
                const RecHitsSortedInPhi** thirdHitMap,
                const std::vector<const DetLayer*>& thirdLayerDetLayer,

--- a/RecoTracker/TkTrackingRegions/interface/GlobalTrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/GlobalTrackingRegion.h
@@ -8,6 +8,7 @@
  */
 
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
+#include "RecoTracker/TkMSParametrization/interface/MultipleScatteringParametrisationMaker.h"
 #include <vector>
 
 class GlobalTrackingRegion final : public TrackingRegion {
@@ -17,14 +18,18 @@ public:
    *  originHalfLength, positioned at "origin".
    *  This class DOES provide the possibility to displace the origin
    *  in the transverse plane. 
+   *
+   * if useMS == true, msmaker needs to be given
    */
   GlobalTrackingRegion(float ptMin,
                        const GlobalPoint& origin,
                        float originRadius,
                        float originHalfLength,
                        bool precise = false,
-                       bool useMS = false)
+                       bool useMS = false,
+                       const MultipleScatteringParametrisationMaker* msmaker = nullptr)
       : TrackingRegionBase(GlobalVector(0, 0, 0), origin, Range(-1 / ptMin, 1 / ptMin), originRadius, originHalfLength),
+        theMSMaker(msmaker),
         thePrecise(precise),
         theUseMS(useMS) {}
 
@@ -62,6 +67,7 @@ public:
   std::string print() const override;
 
 private:
+  const MultipleScatteringParametrisationMaker* theMSMaker = nullptr;
   bool thePrecise = false;
   bool theUseMS = false;
 };

--- a/RecoTracker/TkTrackingRegions/interface/GlobalTrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/GlobalTrackingRegion.h
@@ -46,11 +46,10 @@ public:
                            originHalfLength),
         thePrecise(precise) {}
 
-  TrackingRegion::Hits hits(const edm::EventSetup& es, const SeedingLayerSetsHits::SeedingLayer& layer) const override;
+  TrackingRegion::Hits hits(const SeedingLayerSetsHits::SeedingLayer& layer) const override;
 
   std::unique_ptr<HitRZCompatibility> checkRZ(const DetLayer* layer,
                                               const Hit& outerHit,
-                                              const edm::EventSetup& iSetup,
                                               const DetLayer* outerlayer = nullptr,
                                               float lr = 0,
                                               float gz = 0,

--- a/RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h
@@ -21,6 +21,8 @@ class OuterHitPhiPrediction;
 class BarrelDetLayer;
 class ForwardDetLayer;
 class MeasurementTrackerEvent;
+class MagneticField;
+class MultipleScatteringParametrisationMaker;
 
 class RectangularEtaPhiTrackingRegion final : public TrackingRegion {
 public:
@@ -51,8 +53,9 @@ public:
         theMeasurementTrackerUsage(rh.theMeasurementTrackerUsage),
         thePrecise(rh.thePrecise),
         theUseEtaPhi(rh.theUseEtaPhi),
-        theMeasurementTracker(rh.theMeasurementTracker) {}
-
+        theMeasurementTracker(rh.theMeasurementTracker),
+        theField(rh.theField),
+        theMSMaker(rh.theMSMaker) {}
   RectangularEtaPhiTrackingRegion& operator=(RectangularEtaPhiTrackingRegion const&) = delete;
   RectangularEtaPhiTrackingRegion(RectangularEtaPhiTrackingRegion&&) = default;
   RectangularEtaPhiTrackingRegion& operator=(RectangularEtaPhiTrackingRegion&&) = delete;
@@ -83,6 +86,7 @@ public:
   *  deltaPhi  - allowed deviation of the initial direction of particle
   *              in phi in respect to direction of the region 
   *  whereToUseMeasurementTracker: 1=everywhere, 0=outside pixles, -1=nowhere
+  * msmaker    - Needed if either precise or useMS is true
   */
   RectangularEtaPhiTrackingRegion(const GlobalVector& dir,
                                   const GlobalPoint& vertexPos,
@@ -91,8 +95,10 @@ public:
                                   float zVertex,
                                   float deltaEta,
                                   float deltaPhi,
-                                  UseMeasurementTracker whereToUseMeasurementTracker = UseMeasurementTracker::kNever,
+                                  const MagneticField& field,
+                                  const MultipleScatteringParametrisationMaker* msmaker,
                                   bool precise = true,
+                                  UseMeasurementTracker whereToUseMeasurementTracker = UseMeasurementTracker::kNever,
                                   const MeasurementTrackerEvent* measurementTracker = nullptr,
                                   bool etaPhiRegion = false)
       : RectangularEtaPhiTrackingRegion(dir,
@@ -102,8 +108,10 @@ public:
                                         zVertex,
                                         Margin(std::abs(deltaEta), std::abs(deltaEta)),
                                         Margin(std::abs(deltaPhi), std::abs(deltaPhi)),
-                                        whereToUseMeasurementTracker,
+                                        field,
+                                        msmaker,
                                         precise,
+                                        whereToUseMeasurementTracker,
                                         measurementTracker,
                                         etaPhiRegion) {}
 
@@ -120,8 +128,10 @@ public:
                                   float zVertex,
                                   Margin etaMargin,
                                   Margin phiMargin,
-                                  UseMeasurementTracker whereToUseMeasurementTracker = UseMeasurementTracker::kNever,
+                                  const MagneticField& field,
+                                  const MultipleScatteringParametrisationMaker* msmaker,
                                   bool precise = true,
+                                  UseMeasurementTracker whereToUseMeasurementTracker = UseMeasurementTracker::kNever,
                                   const MeasurementTrackerEvent* measurementTracker = nullptr,
                                   bool etaPhiRegion = false)
       : RectangularEtaPhiTrackingRegion(dir,
@@ -131,8 +141,10 @@ public:
                                         zVertex,
                                         etaMargin,
                                         phiMargin,
-                                        whereToUseMeasurementTracker,
+                                        field,
+                                        msmaker,
                                         precise,
+                                        whereToUseMeasurementTracker,
                                         measurementTracker,
                                         etaPhiRegion) {}
 
@@ -147,8 +159,10 @@ public:
                                   float zVertex,
                                   Margin etaMargin,
                                   Margin phiMargin,
-                                  UseMeasurementTracker whereToUseMeasurementTracker = UseMeasurementTracker::kNever,
+                                  const MagneticField& field,
+                                  const MultipleScatteringParametrisationMaker* msmaker,
                                   bool precise = true,
+                                  UseMeasurementTracker whereToUseMeasurementTracker = UseMeasurementTracker::kNever,
                                   const MeasurementTrackerEvent* measurementTracker = nullptr,
                                   bool etaPhiRegion = false,
                                   bool useMS = true)
@@ -158,7 +172,9 @@ public:
         thePrecise(precise),
         theUseMS(useMS),
         theUseEtaPhi(etaPhiRegion),
-        theMeasurementTracker(measurementTracker) {
+        theMeasurementTracker(measurementTracker),
+        theField(&field),
+        theMSMaker(msmaker) {
     initEtaRange(dir, etaMargin);
   }
 
@@ -223,6 +239,8 @@ private:
   bool theUseMS = false;
   bool theUseEtaPhi = false;
   const MeasurementTrackerEvent* theMeasurementTracker = nullptr;
+  const MagneticField* theField = nullptr;
+  const MultipleScatteringParametrisationMaker* theMSMaker = nullptr;
 
   using cacheHitPointer = mayown_ptr<BaseTrackerRecHit>;
   using cacheHits = std::vector<cacheHitPointer>;

--- a/RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h
@@ -12,7 +12,6 @@
 #include "RecoTracker/TkTrackingRegions/interface/TkTrackingRegionsMargin.h"
 //#include "CommonDet/TrajectoryParametrization/interface/GlobalTrajectoryParameters.h"
 #include "RecoTracker/TkTrackingRegions/interface/HitRZConstraint.h"
-#include "FWCore/Framework/interface/EventSetup.h"
 
 #include "DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h"
 #include "DataFormats/TrackingRecHit/interface/mayown_ptr.h"
@@ -189,7 +188,7 @@ public:
   /// is precise error calculation switched on
   bool isPrecise() const { return thePrecise; }
 
-  TrackingRegion::Hits hits(const edm::EventSetup& es, const SeedingLayerSetsHits::SeedingLayer& layer) const override;
+  TrackingRegion::Hits hits(const SeedingLayerSetsHits::SeedingLayer& layer) const override;
 
   /// Set the elements of the mask corresponding to the tracks that are compatable with the region.
   /// Does not reset the elements corresponding to the tracks that are not compatible.
@@ -197,13 +196,12 @@ public:
 
   std::unique_ptr<HitRZCompatibility> checkRZ(const DetLayer* layer,
                                               const Hit& outerHit,
-                                              const edm::EventSetup& iSetup,
                                               const DetLayer* outerlayer = nullptr,
                                               float lr = 0,
                                               float gz = 0,
                                               float dr = 0,
                                               float dz = 0) const override {
-    return checkRZOld(layer, outerHit, iSetup, outerlayer);
+    return checkRZOld(layer, outerHit, outerlayer);
   }
 
   std::unique_ptr<TrackingRegion> clone() const override {
@@ -216,13 +214,10 @@ public:
 private:
   std::unique_ptr<HitRZCompatibility> checkRZOld(const DetLayer* layer,
                                                  const Hit& outerHit,
-                                                 const edm::EventSetup& iSetup,
                                                  const DetLayer* outerlayer) const;
 
-  std::unique_ptr<MeasurementEstimator> estimator(const BarrelDetLayer* layer,
-                                                  const edm::EventSetup& iSetup) const dso_internal;
-  std::unique_ptr<MeasurementEstimator> estimator(const ForwardDetLayer* layer,
-                                                  const edm::EventSetup& iSetup) const dso_internal;
+  std::unique_ptr<MeasurementEstimator> estimator(const BarrelDetLayer* layer) const dso_internal;
+  std::unique_ptr<MeasurementEstimator> estimator(const ForwardDetLayer* layer) const dso_internal;
 
   OuterHitPhiPrediction phiWindow(const MagneticField& field) const dso_internal;
   HitRZConstraint rzConstraint() const dso_internal;

--- a/RecoTracker/TkTrackingRegions/interface/TrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/TrackingRegion.h
@@ -16,7 +16,6 @@
 #include "RecoTracker/TkTrackingRegions/interface/HitRCheck.h"
 #include "RecoTracker/TkTrackingRegions/interface/HitZCheck.h"
 
-#include "FWCore/Framework/interface/EventSetup.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/SeedingLayerSetsHits.h"
 
 #include "DataFormats/TrackReco/interface/Track.h"
@@ -89,7 +88,6 @@ public:
   /// and outer hit constraint
   virtual std::unique_ptr<HitRZCompatibility> checkRZ(const DetLayer* layer,
                                                       const Hit& outerHit,
-                                                      const edm::EventSetup& iSetup,
                                                       const DetLayer* outerlayer = nullptr,
                                                       float lr = 0,
                                                       float gz = 0,
@@ -97,7 +95,7 @@ public:
                                                       float dz = 0) const = 0;
 
   /// get hits from layer compatible with region constraints
-  virtual Hits hits(const edm::EventSetup& es, const SeedingLayerSetsHits::SeedingLayer& layer) const = 0;
+  virtual Hits hits(const SeedingLayerSetsHits::SeedingLayer& layer) const = 0;
 
   /// Set the elements of the mask corresponding to the tracks that are compatable with the region.
   /// Does not reset the elements corresponding to the tracks that are not compatible.

--- a/RecoTracker/TkTrackingRegions/plugins/AreaSeededTrackingRegionsBuilder.h
+++ b/RecoTracker/TkTrackingRegions/plugins/AreaSeededTrackingRegionsBuilder.h
@@ -12,6 +12,12 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+
+#include "RecoTracker/Record/interface/TrackerMultipleScatteringRecord.h"
+#include "RecoTracker/TkMSParametrization/interface/MultipleScatteringParametrisationMaker.h"
+
 #include "TrackingSeedCandidates.h"
 class AreaSeededTrackingRegionsBuilder {
 public:
@@ -72,7 +78,10 @@ public:
 
   class Builder {
   public:
-    explicit Builder(const AreaSeededTrackingRegionsBuilder* conf) : m_conf(conf) {}
+    explicit Builder(const AreaSeededTrackingRegionsBuilder* conf,
+                     const MagneticField* field,
+                     const MultipleScatteringParametrisationMaker* msmaker)
+        : m_conf(conf), m_field(field), m_msmaker(msmaker) {}
     ~Builder() = default;
 
     void setMeasurementTracker(const MeasurementTrackerEvent* mte) { m_measurementTracker = mte; }
@@ -88,6 +97,8 @@ public:
 
     const AreaSeededTrackingRegionsBuilder* m_conf = nullptr;
     const MeasurementTrackerEvent* m_measurementTracker = nullptr;
+    const MagneticField* m_field = nullptr;
+    const MultipleScatteringParametrisationMaker* m_msmaker = nullptr;
     TrackingSeedCandidates::Objects candidates;
   };
 
@@ -98,7 +109,7 @@ public:
 
   static void fillDescriptions(edm::ParameterSetDescription& desc);
 
-  Builder beginEvent(const edm::Event& e) const;
+  Builder beginEvent(const edm::Event& e, const edm::EventSetup& es) const;
 
 private:
   std::vector<Area> m_areas;
@@ -110,6 +121,8 @@ private:
   bool m_precise;
   edm::EDGetTokenT<MeasurementTrackerEvent> token_measurementTracker;
   RectangularEtaPhiTrackingRegion::UseMeasurementTracker m_whereToUseMeasurementTracker;
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> token_field;
+  edm::ESGetToken<MultipleScatteringParametrisationMaker, TrackerMultipleScatteringRecord> token_msmaker;
   bool m_searchOpt;
 };
 

--- a/RecoTracker/TkTrackingRegions/plugins/AreaSeededTrackingRegionsProducer.h
+++ b/RecoTracker/TkTrackingRegions/plugins/AreaSeededTrackingRegionsProducer.h
@@ -92,7 +92,7 @@ public:
 
   std::vector<std::unique_ptr<TrackingRegion> > regions(const edm::Event& e, const edm::EventSetup& es) const {
     auto origins = m_origins.origins(e);
-    auto builder = m_builder.beginEvent(e);
+    auto builder = m_builder.beginEvent(e, es);
     return builder.regions(origins, m_areas);
   }
 

--- a/RecoTracker/TkTrackingRegions/plugins/PixelInactiveAreaTrackingRegionsSeedingLayersProducer.cc
+++ b/RecoTracker/TkTrackingRegions/plugins/PixelInactiveAreaTrackingRegionsSeedingLayersProducer.cc
@@ -71,7 +71,7 @@ void PixelInactiveAreaTrackingRegionsSeedingLayersProducer::produce(edm::Event& 
   auto regions = std::make_unique<TrackingRegionsSeedingLayerSets>(seedingLayers);
 
   const auto origins = origins_.origins(iEvent);
-  const auto builder = trackingRegionsBuilder_.beginEvent(iEvent);
+  const auto builder = trackingRegionsBuilder_.beginEvent(iEvent, iSetup);
 
   const auto allAreas = inactiveAreaFinder_.inactiveAreas(iEvent, iSetup);
   for (const auto& origin : origins) {

--- a/RecoTracker/TkTrackingRegions/src/GlobalTrackingRegion.cc
+++ b/RecoTracker/TkTrackingRegions/src/GlobalTrackingRegion.cc
@@ -6,14 +6,10 @@
 #include "RecoTracker/TkTrackingRegions/interface/HitRCheck.h"
 #include "RecoTracker/TkTrackingRegions/interface/HitZCheck.h"
 
-#include "RecoTracker/Record/interface/TrackerMultipleScatteringRecord.h"
 #include "RecoTracker/TkMSParametrization/interface/PixelRecoUtilities.h"
-#include "RecoTracker/TkMSParametrization/interface/MultipleScatteringParametrisationMaker.h"
 #include "RecoTracker/TkMSParametrization/interface/MultipleScatteringParametrisation.h"
 #include "RecoTracker/TkMSParametrization/interface/PixelRecoPointRZ.h"
 #include "RecoTracker/TkMSParametrization/interface/PixelRecoLineRZ.h"
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 
 template <class T>
 T sqr(T t) {
@@ -91,9 +87,7 @@ std::unique_ptr<HitRZCompatibility> GlobalTrackingRegion::checkRZ(const DetLayer
   HitRZConstraint rzConstraint(leftLine, rightLine);
 
   if UNLIKELY (theUseMS) {
-    edm::ESHandle<MultipleScatteringParametrisationMaker> hmaker;
-    iSetup.get<TrackerMultipleScatteringRecord>().get(hmaker);
-    MultipleScatteringParametrisation iSigma = hmaker->parametrisation(layer);
+    MultipleScatteringParametrisation iSigma = theMSMaker->parametrisation(layer);
     PixelRecoPointRZ vtxMean(0., origin().z());
 
     float innerScatt = 3.f * (outerlayer ? iSigma(ptMin(), vtxMean, outerred, outerlayer->seqNum())

--- a/RecoTracker/TkTrackingRegions/src/GlobalTrackingRegion.cc
+++ b/RecoTracker/TkTrackingRegions/src/GlobalTrackingRegion.cc
@@ -24,14 +24,12 @@ std::string GlobalTrackingRegion::print() const {
   return str.str();
 }
 
-TrackingRegion::Hits GlobalTrackingRegion::hits(const edm::EventSetup& es,
-                                                const SeedingLayerSetsHits::SeedingLayer& layer) const {
+TrackingRegion::Hits GlobalTrackingRegion::hits(const SeedingLayerSetsHits::SeedingLayer& layer) const {
   return layer.hits();
 }
 
 std::unique_ptr<HitRZCompatibility> GlobalTrackingRegion::checkRZ(const DetLayer* layer,
                                                                   const Hit& outerHit,
-                                                                  const edm::EventSetup& iSetup,
                                                                   const DetLayer* outerlayer,
                                                                   float lr,
                                                                   float gz,

--- a/RecoTracker/TkTrackingRegions/src/OuterEstimator.h
+++ b/RecoTracker/TkTrackingRegions/src/OuterEstimator.h
@@ -22,8 +22,7 @@ class dso_internal OuterEstimator final : public MeasurementEstimator {
 public:
   using OuterHitCompat = OuterHitCompatibility<Algo>;
 
-  OuterEstimator(const OuterDetCompatibility& detCompatibility,
-                 const OuterHitCompat& hitCompatibility)
+  OuterEstimator(const OuterDetCompatibility& detCompatibility, const OuterHitCompat& hitCompatibility)
       : theDetCompatibility(detCompatibility), theHitCompatibility(hitCompatibility) {}
 
   ~OuterEstimator() override {}

--- a/RecoTracker/TkTrackingRegions/src/OuterEstimator.h
+++ b/RecoTracker/TkTrackingRegions/src/OuterEstimator.h
@@ -15,8 +15,6 @@
 #include "OuterDetCompatibility.h"
 #include "OuterHitCompatibility.h"
 
-#include "FWCore/Framework/interface/EventSetup.h"
-
 #include "FWCore/Utilities/interface/Visibility.h"
 
 template <typename Algo>
@@ -25,8 +23,7 @@ public:
   using OuterHitCompat = OuterHitCompatibility<Algo>;
 
   OuterEstimator(const OuterDetCompatibility& detCompatibility,
-                 const OuterHitCompat& hitCompatibility,
-                 const edm::EventSetup& iSetup)
+                 const OuterHitCompat& hitCompatibility)
       : theDetCompatibility(detCompatibility), theHitCompatibility(hitCompatibility) {}
 
   ~OuterEstimator() override {}

--- a/RecoTracker/TkTrackingRegions/src/RectangularEtaPhiTrackingRegion.cc
+++ b/RecoTracker/TkTrackingRegions/src/RectangularEtaPhiTrackingRegion.cc
@@ -99,7 +99,6 @@ void RectangularEtaPhiTrackingRegion::initEtaRange(const GlobalVector& dir, cons
 
 std::unique_ptr<HitRZCompatibility> RectangularEtaPhiTrackingRegion::checkRZOld(const DetLayer* layer,
                                                                                 const Hit& outerHit,
-                                                                                const edm::EventSetup& iSetup,
                                                                                 const DetLayer* outerlayer) const {
   bool isBarrel = (layer->location() == GeomDetEnumerators::barrel);
   GlobalPoint ohit = outerHit->globalPosition();
@@ -166,8 +165,7 @@ std::unique_ptr<HitRZCompatibility> RectangularEtaPhiTrackingRegion::checkRZOld(
   }
 }
 
-std::unique_ptr<MeasurementEstimator> RectangularEtaPhiTrackingRegion::estimator(const BarrelDetLayer* layer,
-                                                                                 const edm::EventSetup& iSetup) const {
+std::unique_ptr<MeasurementEstimator> RectangularEtaPhiTrackingRegion::estimator(const BarrelDetLayer* layer) const {
   using Algo = HitZCheck;
 
   // det dimensions
@@ -226,8 +224,7 @@ std::unique_ptr<MeasurementEstimator> RectangularEtaPhiTrackingRegion::estimator
                                                 OuterHitCompatibility<Algo>(phiPrediction, zPrediction));
 }
 
-std::unique_ptr<MeasurementEstimator> RectangularEtaPhiTrackingRegion::estimator(const ForwardDetLayer* layer,
-                                                                                 const edm::EventSetup& iSetup) const {
+std::unique_ptr<MeasurementEstimator> RectangularEtaPhiTrackingRegion::estimator(const ForwardDetLayer* layer) const {
   using Algo = HitRCheck;
   // det dimensions, ranges
   float halfThickness = 0.5f * layer->surface().bounds().thickness();
@@ -307,8 +304,7 @@ HitRZConstraint RectangularEtaPhiTrackingRegion::rzConstraint() const {
   return HitRZConstraint(pLeft, theLambdaRange.min(), pRight, theLambdaRange.max());
 }
 
-TrackingRegion::Hits RectangularEtaPhiTrackingRegion::hits(const edm::EventSetup& es,
-                                                           const SeedingLayerSetsHits::SeedingLayer& layer) const {
+TrackingRegion::Hits RectangularEtaPhiTrackingRegion::hits(const SeedingLayerSetsHits::SeedingLayer& layer) const {
   TrackingRegion::Hits result;
 
   //ESTIMATOR
@@ -331,12 +327,12 @@ TrackingRegion::Hits RectangularEtaPhiTrackingRegion::hits(const edm::EventSetup
          GeomDetEnumerators::isBarrel(detLayer->subDetector())) ||
         (!theUseEtaPhi && detLayer->location() == GeomDetEnumerators::barrel)) {
       const BarrelDetLayer& bl = dynamic_cast<const BarrelDetLayer&>(*detLayer);
-      est = estimator(&bl, es);
+      est = estimator(&bl);
     } else if ((GeomDetEnumerators::isTrackerPixel(detLayer->subDetector()) &&
                 GeomDetEnumerators::isEndcap(detLayer->subDetector())) ||
                (!theUseEtaPhi && detLayer->location() == GeomDetEnumerators::endcap)) {
       const ForwardDetLayer& fl = dynamic_cast<const ForwardDetLayer&>(*detLayer);
-      est = estimator(&fl, es);
+      est = estimator(&fl);
     }
 
     EtaPhiMeasurementEstimator etaPhiEstimator((theEtaRange.second - theEtaRange.first) * 0.5f,
@@ -383,7 +379,7 @@ TrackingRegion::Hits RectangularEtaPhiTrackingRegion::hits(const edm::EventSetup
     //
     if (detLayer->location() == GeomDetEnumerators::barrel) {
       const BarrelDetLayer& bl = dynamic_cast<const BarrelDetLayer&>(*detLayer);
-      auto est = estimator(&bl, es);
+      auto est = estimator(&bl);
       if (!est)
         return result;
       using Algo = HitZCheck;
@@ -397,7 +393,7 @@ TrackingRegion::Hits RectangularEtaPhiTrackingRegion::hits(const edm::EventSetup
 
     } else {
       const ForwardDetLayer& fl = dynamic_cast<const ForwardDetLayer&>(*detLayer);
-      auto est = estimator(&fl, es);
+      auto est = estimator(&fl);
       if (!est)
         return result;
       using Algo = HitRCheck;

--- a/RecoTracker/TkTrackingRegions/src/RectangularEtaPhiTrackingRegion.cc
+++ b/RecoTracker/TkTrackingRegions/src/RectangularEtaPhiTrackingRegion.cc
@@ -237,8 +237,7 @@ std::unique_ptr<MeasurementEstimator> RectangularEtaPhiTrackingRegion::estimator
   }
 
   return std::make_unique<OuterEstimator<Algo>>(OuterDetCompatibility(layer, phiRange, detRWindow, hitZWindow),
-                                                OuterHitCompatibility<Algo>(phiPrediction, zPrediction),
-                                                iSetup);
+                                                OuterHitCompatibility<Algo>(phiPrediction, zPrediction));
 }
 
 std::unique_ptr<MeasurementEstimator> RectangularEtaPhiTrackingRegion::estimator(const ForwardDetLayer* layer,
@@ -297,8 +296,7 @@ std::unique_ptr<MeasurementEstimator> RectangularEtaPhiTrackingRegion::estimator
   }
 
   return std::make_unique<OuterEstimator<Algo>>(OuterDetCompatibility(layer, phiRange, hitRWindow, detZWindow),
-                                                OuterHitCompatibility<Algo>(phiPrediction, rPrediction),
-                                                iSetup);
+                                                OuterHitCompatibility<Algo>(phiPrediction, rPrediction));
 }
 
 OuterHitPhiPrediction RectangularEtaPhiTrackingRegion::phiWindow(const MagneticField& field) const {


### PR DESCRIPTION
#### PR description:

This PR is part of #31061 and reworks TrackingRegion classes, classes that create TrackingRegions, and classes that use TrackingRegions to support esConsumes. in short the EventSetup accesses within TrackingRegion classes are moved to classes that create TrackingRegions.

This PR completes the rework started in https://github.com/cms-sw/cmssw/pull/35081 and continued in https://github.com/cms-sw/cmssw/pull/35269.

Resolves https://github.com/makortel/framework/issues/264.

#### PR validation:

Tested that limited matrix runs in in earlier IB on top of https://github.com/cms-sw/cmssw/pull/35269. After the rebase, tested that code compiles.