### PR TITLE
Fix string when HiMixNoPU is used in relvals

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -468,11 +468,14 @@ class MatrixInjector(object):
                             if 'pileup' in chainDict['nowmTasklist'][-1]['nowmIO']:
                                 chainDict['nowmTasklist'][-1]['MCPileup']=chainDict['nowmTasklist'][-1]['nowmIO']['pileup']
                             if '--pileup ' in s[2][index]:      # catch --pileup (scenarion) and not --pileup_ (dataset to be mixed) => works also making PRE-MIXed dataset
+                                pileupString = s[2][index].split()[s[2][index].split().index('--pileup')+1]
                                 processStrPrefix='PU_'          # take care of pu overlay done with GEN-SIM mixing
-                                if (  s[2][index].split()[  s[2][index].split().index('--pileup')+1 ]  ).find('25ns')  > 0 :
+                                if pileupString.find('25ns')  > 0 :
                                     processStrPrefix='PU25ns_'
-                                elif   (  s[2][index].split()[  s[2][index].split().index('--pileup')+1 ]  ).find('50ns')  > 0 :
+                                elif pileupString.find('50ns')  > 0 :
                                     processStrPrefix='PU50ns_'
+                                elif 'nopu' in pileupString.lower():
+                                    processStrPrefix=''
                             if 'premix_stage2' in s[2][index] and '--pileup_input' in s[2][index]: # take care of pu overlay done with DIGI mixing of premixed events
                                 if s[2][index].split()[ s[2][index].split().index('--pileup_input')+1  ].find('25ns')  > 0 :
                                     processStrPrefix='PUpmx25ns_'


### PR DESCRIPTION
#### PR description:
When HiMixNoPU workflow is used (e.g. 159.3), `--pileup HiMixNoPU` is used with cmsDriver. In this case, we don't expect `PU_` in the processing string. This PR introduces the protection on that.

#### PR validation:
Test with ` runTheMatrix.py --what standard -l 159.3 --wm init`

Before
```
 'Task2': {'AcquisitionEra': 'CMSSW_12_1_X_2021-09-23-2300',
           'ConfigCacheID': 1043,
           'EventStreams': 0,
           'GPUParams': None,
           'GlobalTag': '121X_mcRun3_2021_realistic_HI_v5',
           'InputFromOutputModule': 'RAWSIMoutput',
           'InputTask': 'ZMM_14_HI_2021',
           'KeepOutput': True,
           'LumisPerJob': 10,
           'Memory': 3000,
           'Multicore': 1,
           'ProcessingString': 'PU_121X_mcRun3_2021_realistic_HI_v5',
           'RequiresGPU': None,
           'SplittingAlgo': 'LumiBased',
           'TaskName': 'DIGIHI2021PPRECO'},
```

After
```
'Task2': {'AcquisitionEra': 'CMSSW_12_1_X_2021-09-23-2300',
           'ConfigCacheID': 1043,
           'EventStreams': 0,
           'GPUParams': None,
           'GlobalTag': '121X_mcRun3_2021_realistic_HI_v5',
           'InputFromOutputModule': 'RAWSIMoutput',
           'InputTask': 'ZMM_14_HI_2021',
           'KeepOutput': True,
           'LumisPerJob': 10,
           'Memory': 3000,
           'Multicore': 1,
           'ProcessingString': '121X_mcRun3_2021_realistic_HI_v5',
           'RequiresGPU': None,
           'SplittingAlgo': 'LumiBased',
           'TaskName': 'DIGIHI2021PPRECO'},
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
Not a backport, and no need of backport.

FYI @justinasr 