### PR TITLE
fix offline BS swap for express Run3 [12_0_X]

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -68,15 +68,15 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
     'phase1_2021_design'           : '120X_mcRun3_2021_design_v5', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'        : '120X_mcRun3_2021_realistic_v7', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'        : '120X_mcRun3_2021_realistic_v8', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'          : '120X_mcRun3_2021cosmics_realistic_deco_v6',
+    'phase1_2021_cosmics'          : '120X_mcRun3_2021cosmics_realistic_deco_v7',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi'     : '120X_mcRun3_2021_realistic_HI_v6',
+    'phase1_2021_realistic_hi'     : '120X_mcRun3_2021_realistic_HI_v7',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '120X_mcRun3_2023_realistic_v6', # GT containing realistic conditions for Phase1 2023
+    'phase1_2023_realistic'        : '120X_mcRun3_2023_realistic_v7', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '120X_mcRun3_2024_realistic_v6', # GT containing realistic conditions for Phase1 2024
+    'phase1_2024_realistic'        : '120X_mcRun3_2024_realistic_v7', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             : '113X_mcRun4_realistic_v7'
 }

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -5,6 +5,9 @@ import FWCore.ParameterSet.Config as cms
 # common utilities
 ##############################################################################
 def _swapOfflineBSwithOnline(process):
+    import RecoVertex.BeamSpotProducer.onlineBeamSpotESProducer_cfi as _mod
+    process.BeamSpotESProducer = _mod.onlineBeamSpotESProducer.clone()
+
     from RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi import onlineBeamSpotProducer
     process.offlineBeamSpot = onlineBeamSpotProducer.clone()
     return process

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -6,7 +6,9 @@ import FWCore.ParameterSet.Config as cms
 ##############################################################################
 def _swapOfflineBSwithOnline(process):
     import RecoVertex.BeamSpotProducer.onlineBeamSpotESProducer_cfi as _mod
-    process.BeamSpotESProducer = _mod.onlineBeamSpotESProducer.clone()
+    process.BeamSpotESProducer = _mod.onlineBeamSpotESProducer.clone(
+        timeThreshold = cms.int32(999999) # for express allow >48h old payloads for replays. DO NOT CHANGE
+    )
 
     from RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi import onlineBeamSpotProducer
     process.offlineBeamSpot = onlineBeamSpotProducer.clone()

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -7,7 +7,7 @@ import FWCore.ParameterSet.Config as cms
 def _swapOfflineBSwithOnline(process):
     import RecoVertex.BeamSpotProducer.onlineBeamSpotESProducer_cfi as _mod
     process.BeamSpotESProducer = _mod.onlineBeamSpotESProducer.clone(
-        timeThreshold = cms.int32(999999) # for express allow >48h old payloads for replays. DO NOT CHANGE
+        timeThreshold = 999999 # for express allow >48h old payloads for replays. DO NOT CHANGE
     )
 
     from RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi import onlineBeamSpotProducer

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1040,7 +1040,7 @@ upgradeWFs['DD4hep'].allowReuse = False
 class UpgradeWorkflow_DD4hepDB(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):
         if 'Run3' in stepDict[step][k]['--era']:
-            stepDict[stepName][k] = merge([{'--conditions': '120X_mcRun3_2021_realistic_dd4hep_v1', '--geometry': 'DB:Extended', '--procModifiers': 'dd4hep'}, stepDict[step][k]])
+            stepDict[stepName][k] = merge([{'--conditions': '120X_mcRun3_2021_realistic_dd4hep_v4', '--geometry': 'DB:Extended', '--procModifiers': 'dd4hep'}, stepDict[step][k]])
     def condition(self, fragment, stepList, key, hasHarvest):
         return '2021' in key
 upgradeWFs['DD4hepDB'] = UpgradeWorkflow_DD4hepDB(

--- a/DQM/BeamMonitor/python/AlcaBeamMonitorHeavyIons_cff.py
+++ b/DQM/BeamMonitor/python/AlcaBeamMonitorHeavyIons_cff.py
@@ -12,7 +12,9 @@ from Configuration.ProcessModifiers.dqmPerLSsaving_cff import dqmPerLSsaving
 dqmPerLSsaving.toModify(AlcaBeamMonitor, perLSsaving=True)
 
 import RecoVertex.BeamSpotProducer.onlineBeamSpotESProducer_cfi as _mod
-BeamSpotESProducer = _mod.onlineBeamSpotESProducer.clone()
+BeamSpotESProducer = _mod.onlineBeamSpotESProducer.clone(
+    timeThreshold = cms.int32(999999) # accept even old payloads for MC/Data ReReco. DO NOT CHANGE
+)
 
 import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
 scalerBeamSpot = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()

--- a/DQM/BeamMonitor/python/AlcaBeamMonitorHeavyIons_cff.py
+++ b/DQM/BeamMonitor/python/AlcaBeamMonitorHeavyIons_cff.py
@@ -11,6 +11,9 @@ AlcaBeamMonitor.PVFitter.VertexCollection  = 'hiSelectedVertex'
 from Configuration.ProcessModifiers.dqmPerLSsaving_cff import dqmPerLSsaving
 dqmPerLSsaving.toModify(AlcaBeamMonitor, perLSsaving=True)
 
+import RecoVertex.BeamSpotProducer.onlineBeamSpotESProducer_cfi as _mod
+BeamSpotESProducer = _mod.onlineBeamSpotESProducer.clone()
+
 import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
 scalerBeamSpot = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()
 alcaBeamMonitor = cms.Sequence( scalerBeamSpot*AlcaBeamMonitor )

--- a/DQM/BeamMonitor/python/AlcaBeamMonitorHeavyIons_cff.py
+++ b/DQM/BeamMonitor/python/AlcaBeamMonitorHeavyIons_cff.py
@@ -13,7 +13,7 @@ dqmPerLSsaving.toModify(AlcaBeamMonitor, perLSsaving=True)
 
 import RecoVertex.BeamSpotProducer.onlineBeamSpotESProducer_cfi as _mod
 BeamSpotESProducer = _mod.onlineBeamSpotESProducer.clone(
-    timeThreshold = cms.int32(999999) # accept even old payloads for MC/Data ReReco. DO NOT CHANGE
+    timeThreshold = 999999 # accept even old payloads for MC/Data ReReco. DO NOT CHANGE
 )
 
 import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi

--- a/DQM/BeamMonitor/python/AlcaBeamMonitor_cff.py
+++ b/DQM/BeamMonitor/python/AlcaBeamMonitor_cff.py
@@ -6,7 +6,9 @@ from Configuration.ProcessModifiers.dqmPerLSsaving_cff import dqmPerLSsaving
 dqmPerLSsaving.toModify(AlcaBeamMonitor, perLSsaving=True)
 
 import RecoVertex.BeamSpotProducer.onlineBeamSpotESProducer_cfi as _mod
-BeamSpotESProducer = _mod.onlineBeamSpotESProducer.clone()
+BeamSpotESProducer = _mod.onlineBeamSpotESProducer.clone(
+    timeThreshold = cms.int32(999999) # accept even old payloads for MC/Data ReReco. DO NOT CHANGE
+)
 
 import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
 scalerBeamSpot = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()

--- a/DQM/BeamMonitor/python/AlcaBeamMonitor_cff.py
+++ b/DQM/BeamMonitor/python/AlcaBeamMonitor_cff.py
@@ -7,7 +7,7 @@ dqmPerLSsaving.toModify(AlcaBeamMonitor, perLSsaving=True)
 
 import RecoVertex.BeamSpotProducer.onlineBeamSpotESProducer_cfi as _mod
 BeamSpotESProducer = _mod.onlineBeamSpotESProducer.clone(
-    timeThreshold = cms.int32(999999) # accept even old payloads for MC/Data ReReco. DO NOT CHANGE
+    timeThreshold = 999999 # accept even old payloads for MC/Data ReReco. DO NOT CHANGE
 )
 
 import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi

--- a/DQM/BeamMonitor/python/AlcaBeamMonitor_cff.py
+++ b/DQM/BeamMonitor/python/AlcaBeamMonitor_cff.py
@@ -5,6 +5,9 @@ from DQM.BeamMonitor.AlcaBeamMonitor_cfi import *
 from Configuration.ProcessModifiers.dqmPerLSsaving_cff import dqmPerLSsaving
 dqmPerLSsaving.toModify(AlcaBeamMonitor, perLSsaving=True)
 
+import RecoVertex.BeamSpotProducer.onlineBeamSpotESProducer_cfi as _mod
+BeamSpotESProducer = _mod.onlineBeamSpotESProducer.clone()
+
 import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
 scalerBeamSpot = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()
 

--- a/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
@@ -128,6 +128,9 @@ if (process.runType.getRunType() == process.runType.cosmic_run or process.runTyp
 else:
     process.load("Configuration.StandardSequences.Reconstruction_cff")
 
+import RecoVertex.BeamSpotProducer.onlineBeamSpotESProducer_cfi as _mod
+process.BeamSpotESProducer = _mod.onlineBeamSpotESProducer.clone()
+
 import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
 process.offlineBeamSpot = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()
 

--- a/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
@@ -116,6 +116,9 @@ if (process.runType.getRunType() == process.runType.cosmic_run or process.runTyp
 else:
     process.load("Configuration.StandardSequences.Reconstruction_cff")
 
+import RecoVertex.BeamSpotProducer.onlineBeamSpotESProducer_cfi as _mod
+process.BeamSpotESProducer = _mod.onlineBeamSpotESProducer.clone()
+
 import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
 process.offlineBeamSpot = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()
 

--- a/RecoVertex/BeamSpotProducer/python/BeamSpotOnline_cff.py
+++ b/RecoVertex/BeamSpotProducer/python/BeamSpotOnline_cff.py
@@ -1,13 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-from RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi import *
-
-#scalers = cms.EDProducer('ScalersRawToDigi')
 import RecoVertex.BeamSpotProducer.onlineBeamSpotESProducer_cfi as _mod
 BeamSpotESProducer = _mod.onlineBeamSpotESProducer.clone()
 
-from Configuration.Eras.Modifier_run3_common_cff import run3_common
-run3_common.toModify(onlineBeamSpotProducer, useTransientRecord = True)
-
+from RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi import *
 onlineBeamSpot = cms.Sequence( onlineBeamSpotProducer )
 

--- a/RecoVertex/BeamSpotProducer/python/BeamSpotOnline_cfi.py
+++ b/RecoVertex/BeamSpotProducer/python/BeamSpotOnline_cfi.py
@@ -10,3 +10,5 @@ onlineBeamSpotProducer = cms.EDProducer('BeamSpotOnlineProducer',
                                         useTransientRecord = cms.bool(False)
 )
 
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(onlineBeamSpotProducer, useTransientRecord = True)


### PR DESCRIPTION
backport of #35373

#### PR description:

Address discussion at https://github.com/cms-sw/cmssw/pull/35334#issuecomment-925116203.

#### PR validation:

Run successfully wf 138.2 with: ` runTheMatrix.py -l 138.2 -j 8 -t 4` and verified the configuration looks as it should:

```console
$edmConfigDump step2_RAW2DIGI_L1Reco_RECO_DQM.py > dump.py
$more dump.py | grep -A 5 OnlineBeamSpotESProducer
process.BeamSpotESProducer = cms.ESProducer("OnlineBeamSpotESProducer",
    appendToDataLabel = cms.string(''),
    sigmaZThreshold = cms.double(2),
    timeThreshold = cms.int32(48)
)

$more dump.py | grep useTransientRecord
    useTransientRecord = cms.bool(True)
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

backport of #35373