### PR TITLE
Migrate away from deprecated `edm::EDAnalyzer` API in `CalibTracker`and in modules inheriting from `ConditionDBWriter`

### DIFF
--- a/CalibTracker/SiPixelESProducers/test/SiPixelFakeGainForHLTReader.cc
+++ b/CalibTracker/SiPixelESProducers/test/SiPixelFakeGainForHLTReader.cc
@@ -67,6 +67,8 @@ namespace cms {
     fFile->Close();
   }
 
+  void SiPixelFakeGainForHLTReader::endRun(const edm::Run& run, const edm::EventSetup& iSetup) {}
+
   // ----------------------------------------------------------------------
   void SiPixelFakeGainForHLTReader::beginRun(const edm::Run& run, const edm::EventSetup& iSetup) {
     static int first(1);

--- a/CalibTracker/SiPixelESProducers/test/SiPixelFakeGainForHLTReader.h
+++ b/CalibTracker/SiPixelESProducers/test/SiPixelFakeGainForHLTReader.h
@@ -18,7 +18,7 @@
 //
 //
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
@@ -31,15 +31,15 @@
 #include "TH1F.h"
 
 namespace cms {
-  class SiPixelFakeGainForHLTReader : public edm::EDAnalyzer {
+  class SiPixelFakeGainForHLTReader : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
   public:
     explicit SiPixelFakeGainForHLTReader(const edm::ParameterSet& iConfig);
 
     ~SiPixelFakeGainForHLTReader(){};
-    virtual void beginJob() { ; }
-    virtual void beginRun(const edm::Run&, const edm::EventSetup&);
-    virtual void analyze(const edm::Event&, const edm::EventSetup&);
-    virtual void endJob();
+    virtual void beginRun(const edm::Run&, const edm::EventSetup&) override;
+    virtual void endRun(const edm::Run&, const edm::EventSetup&) override;
+    virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+    virtual void endJob() override;
 
   private:
     edm::ParameterSet conf_;

--- a/CalibTracker/SiPixelESProducers/test/SiPixelFakeGainOfflineReader.cc
+++ b/CalibTracker/SiPixelESProducers/test/SiPixelFakeGainOfflineReader.cc
@@ -70,8 +70,7 @@ namespace cms {
     fFile->Close();
   }
 
-  // ------------ method called once each job just before starting event loop  ------------
-  void SiPixelFakeGainOfflineReader::beginJob() {}
+  void SiPixelFakeGainOfflineReader::endRun(const edm::Run& run, const edm::EventSetup& iSetup) {}
 
   // ------------ method called once each job just before starting event loop  ------------
   void SiPixelFakeGainOfflineReader::beginRun(const edm::Run& run, const edm::EventSetup& iSetup) {

--- a/CalibTracker/SiPixelESProducers/test/SiPixelFakeGainOfflineReader.h
+++ b/CalibTracker/SiPixelESProducers/test/SiPixelFakeGainOfflineReader.h
@@ -18,7 +18,7 @@
 //
 //
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
@@ -31,15 +31,15 @@
 #include "TH1F.h"
 
 namespace cms {
-  class SiPixelFakeGainOfflineReader : public edm::EDAnalyzer {
+  class SiPixelFakeGainOfflineReader : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
   public:
     explicit SiPixelFakeGainOfflineReader(const edm::ParameterSet& iConfig);
 
     ~SiPixelFakeGainOfflineReader(){};
-    virtual void beginJob();
-    virtual void beginRun(const edm::Run&, const edm::EventSetup&);
-    virtual void analyze(const edm::Event&, const edm::EventSetup&);
-    virtual void endJob();
+    virtual void beginRun(const edm::Run&, const edm::EventSetup&) override;
+    virtual void endRun(const edm::Run&, const edm::EventSetup&) override;
+    virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+    virtual void endJob() override;
 
   private:
     edm::ParameterSet conf_;

--- a/CalibTracker/SiPixelESProducers/test/SiPixelFakeGainReader.cc
+++ b/CalibTracker/SiPixelESProducers/test/SiPixelFakeGainReader.cc
@@ -71,8 +71,7 @@ namespace cms {
     fFile->Close();
   }
 
-  // ------------ method called once each job just before starting event loop  ------------
-  void SiPixelFakeGainReader::beginJob() {}
+  void SiPixelFakeGainReader::endRun(const edm::Run& run, const edm::EventSetup& iSetup) {}
 
   // ------------ method called once each job just before starting event loop  ------------
   void SiPixelFakeGainReader::beginRun(const edm::Run& run, const edm::EventSetup& iSetup) {

--- a/CalibTracker/SiPixelESProducers/test/SiPixelFakeGainReader.h
+++ b/CalibTracker/SiPixelESProducers/test/SiPixelFakeGainReader.h
@@ -18,7 +18,7 @@
 //
 //
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
@@ -31,15 +31,15 @@
 #include "TH1F.h"
 
 namespace cms {
-  class SiPixelFakeGainReader : public edm::EDAnalyzer {
+  class SiPixelFakeGainReader : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
   public:
     explicit SiPixelFakeGainReader(const edm::ParameterSet& iConfig);
 
     ~SiPixelFakeGainReader(){};
-    virtual void beginJob();
-    virtual void beginRun(const edm::Run&, const edm::EventSetup&);
-    virtual void analyze(const edm::Event&, const edm::EventSetup&);
-    virtual void endJob();
+    virtual void beginRun(const edm::Run&, const edm::EventSetup&) override;
+    virtual void endRun(const edm::Run&, const edm::EventSetup&) override;
+    virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+    virtual void endJob() override;
 
   private:
     edm::ParameterSet conf_;

--- a/CalibTracker/SiPixelErrorEstimation/interface/SiPixelErrorEstimation.h
+++ b/CalibTracker/SiPixelErrorEstimation/interface/SiPixelErrorEstimation.h
@@ -1,4 +1,3 @@
-
 #ifndef CalibTracker_SiPixelerrorEstimation_SiPixelErrorEstimation_h
 #define CalibTracker_SiPixelerrorEstimation_SiPixelErrorEstimation_h
 
@@ -6,7 +5,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -60,7 +59,7 @@
 class TTree;
 class TFile;
 
-class SiPixelErrorEstimation : public edm::EDAnalyzer {
+class SiPixelErrorEstimation : public edm::one::EDAnalyzer<> {
 public:
   explicit SiPixelErrorEstimation(const edm::ParameterSet&);
   ~SiPixelErrorEstimation() override;

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAngle.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAngle.cc
@@ -67,7 +67,7 @@ SiPixelLorentzAngle::SiPixelLorentzAngle(edm::ParameterSet const& conf)
 }
 
 // Virtual destructor needed.
-SiPixelLorentzAngle::~SiPixelLorentzAngle() {}
+SiPixelLorentzAngle::~SiPixelLorentzAngle() = default;
 
 void SiPixelLorentzAngle::beginJob() {
   // 	cout << "started SiPixelLorentzAngle" << endl;

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAngle.h
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAngle.h
@@ -1,7 +1,7 @@
 #ifndef CalibTracker_SiPixelLorentzAngle_SiPixelLorentzAngle_h
 #define CalibTracker_SiPixelLorentzAngle_SiPixelLorentzAngle_h
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -80,12 +80,11 @@ struct Rechit {
 
 //SiPixelLorentzAngle is already the name of a data product
 namespace analyzer {
-  class SiPixelLorentzAngle : public edm::EDAnalyzer {
+  class SiPixelLorentzAngle : public edm::one::EDAnalyzer<> {
   public:
     explicit SiPixelLorentzAngle(const edm::ParameterSet &conf);
 
     ~SiPixelLorentzAngle() override;
-    //virtual void beginJob(const edm::EventSetup& c);
     void beginJob() override;
     void endJob() override;
     void analyze(const edm::Event &e, const edm::EventSetup &c) override;

--- a/CalibTracker/SiPixelTools/interface/SiPixelOfflineCalibAnalysisBase.h
+++ b/CalibTracker/SiPixelTools/interface/SiPixelOfflineCalibAnalysisBase.h
@@ -22,7 +22,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -57,7 +57,7 @@
 // class decleration
 //
 
-class SiPixelOfflineCalibAnalysisBase : public edm::EDAnalyzer {
+class SiPixelOfflineCalibAnalysisBase : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   typedef dqm::legacy::MonitorElement MonitorElement;
   typedef dqm::legacy::DQMStore DQMStore;
@@ -141,7 +141,7 @@ private:
   //the beginJob is used to load the calib database.  It then calls the pure
   //virtual calibrationSetup() function.  Derived classes should put beginJob functionality there.
   void beginRun(const edm::Run&, const edm::EventSetup&) override;
-  void beginRun(const edm::EventSetup& iSetup);
+  void endRun(const edm::Run&, const edm::EventSetup&) override;
   void beginJob() override;
 
   //calibrationSetup will be used by derived classes

--- a/CalibTracker/SiPixelTools/plugins/SiPixelCalibDigiFilter.cc
+++ b/CalibTracker/SiPixelTools/plugins/SiPixelCalibDigiFilter.cc
@@ -48,11 +48,7 @@ SiPixelCalibDigiFilter::SiPixelCalibDigiFilter(const edm::ParameterSet& iConfig)
   tPixelCalibDigi = consumes<edm::DetSetVector<SiPixelCalibDigi>>(edm::InputTag("SiPixelCalibDigiProducer"));
 }
 
-SiPixelCalibDigiFilter::~SiPixelCalibDigiFilter() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
-}
-
+SiPixelCalibDigiFilter::~SiPixelCalibDigiFilter() = default;
 //
 // member functions
 //
@@ -63,17 +59,12 @@ bool SiPixelCalibDigiFilter::filter(edm::Event& iEvent, const edm::EventSetup& i
   Handle<DetSetVector<SiPixelCalibDigi>> listOfDetIds;
   iEvent.getByToken(tPixelCalibDigi, listOfDetIds);
 
-  if (listOfDetIds->empty())
+  if (listOfDetIds->empty()) {
     return false;
-  else
+  } else {
     return true;
+  }
 }
-
-// ------------ method called once each job just before starting event loop  ------------
-void SiPixelCalibDigiFilter::beginJob() {}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void SiPixelCalibDigiFilter::endJob() {}
 
 // -- define this as a plug-in
 DEFINE_FWK_MODULE(SiPixelCalibDigiFilter);

--- a/CalibTracker/SiPixelTools/plugins/SiPixelCalibDigiFilter.h
+++ b/CalibTracker/SiPixelTools/plugins/SiPixelCalibDigiFilter.h
@@ -21,7 +21,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -34,15 +34,13 @@
 // class declaration
 //
 
-class SiPixelCalibDigiFilter : public edm::EDFilter {
+class SiPixelCalibDigiFilter : public edm::stream::EDFilter<> {
 public:
   explicit SiPixelCalibDigiFilter(const edm::ParameterSet&);
   ~SiPixelCalibDigiFilter() override;
 
 private:
-  void beginJob() override;
   bool filter(edm::Event&, const edm::EventSetup&) override;
-  void endJob() override;
 
   // ----------member data ---------------------------
   edm::EDGetTokenT<edm::DetSetVector<SiPixelCalibDigi>> tPixelCalibDigi;

--- a/CalibTracker/SiPixelTools/plugins/SiPixelDQMRocLevelAnalyzer.cc
+++ b/CalibTracker/SiPixelTools/plugins/SiPixelDQMRocLevelAnalyzer.cc
@@ -1,23 +1,13 @@
 #include "SiPixelDQMRocLevelAnalyzer.h"
 
-SiPixelDQMRocLevelAnalyzer::SiPixelDQMRocLevelAnalyzer(const edm::ParameterSet &iConfig) : conf_(iConfig) {}
+SiPixelDQMRocLevelAnalyzer::SiPixelDQMRocLevelAnalyzer(const edm::ParameterSet &iConfig) : conf_(iConfig) {
+  usesResource(TFileService::kSharedResource);
+}
 
-SiPixelDQMRocLevelAnalyzer::~SiPixelDQMRocLevelAnalyzer() {}
+SiPixelDQMRocLevelAnalyzer::~SiPixelDQMRocLevelAnalyzer() = default;
 
 // ------------ method called to for each event  ------------
-void SiPixelDQMRocLevelAnalyzer::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
-  using namespace edm;
-
-#ifdef THIS_IS_AN_EVENT_EXAMPLE
-  Handle<ExampleData> pIn;
-  iEvent.getByLabel("example", pIn);
-#endif
-
-#ifdef THIS_IS_AN_EVENTSETUP_EXAMPLE
-  ESHandle<SetupData> pSetup;
-  iSetup.get<SetupRecord>().get(pSetup);
-#endif
-}
+void SiPixelDQMRocLevelAnalyzer::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {}
 
 // ------------ method called once each job just before starting event loop  ------------
 void SiPixelDQMRocLevelAnalyzer::beginJob() {

--- a/CalibTracker/SiPixelTools/plugins/SiPixelDQMRocLevelAnalyzer.h
+++ b/CalibTracker/SiPixelTools/plugins/SiPixelDQMRocLevelAnalyzer.h
@@ -24,7 +24,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -41,7 +41,7 @@
 // class decleration
 //
 
-class SiPixelDQMRocLevelAnalyzer : public edm::EDAnalyzer {
+class SiPixelDQMRocLevelAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   typedef dqm::legacy::MonitorElement MonitorElement;
   typedef dqm::legacy::DQMStore DQMStore;

--- a/CalibTracker/SiPixelTools/plugins/SiPixelErrorsDigisToCalibDigis.cc
+++ b/CalibTracker/SiPixelTools/plugins/SiPixelErrorsDigisToCalibDigis.cc
@@ -111,9 +111,6 @@ void SiPixelErrorsDigisToCalibDigis::analyze(const edm::Event& iEvent, const edm
   }  // end of the for loop that goes through all plaquettes
 }
 
-// ------------ method called once each job just before starting event loop  ------------
-void SiPixelErrorsDigisToCalibDigis::beginJob() {}
-
 // ------------ method called once each job just after ending the event loop  ------------
 void SiPixelErrorsDigisToCalibDigis::endJob() {
   if (!outputFilename_.empty() && createOutputFile_) {

--- a/CalibTracker/SiPixelTools/plugins/SiPixelErrorsDigisToCalibDigis.h
+++ b/CalibTracker/SiPixelTools/plugins/SiPixelErrorsDigisToCalibDigis.h
@@ -14,7 +14,7 @@ Description: Create monitorElements for the Errors in created in the reduction o
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -41,7 +41,7 @@ Description: Create monitorElements for the Errors in created in the reduction o
 // class declaration
 //
 
-class SiPixelErrorsDigisToCalibDigis : public edm::EDAnalyzer {
+class SiPixelErrorsDigisToCalibDigis : public edm::one::EDAnalyzer<> {
 public:
   typedef dqm::legacy::MonitorElement MonitorElement;
   typedef dqm::legacy::DQMStore DQMStore;
@@ -71,7 +71,6 @@ protected:
   edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomToken_;
 
 private:
-  void beginJob() override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   void endJob() override;
 

--- a/CalibTracker/SiPixelTools/plugins/SiPixelFedFillerWordEventNumber.cc
+++ b/CalibTracker/SiPixelTools/plugins/SiPixelFedFillerWordEventNumber.cc
@@ -441,10 +441,5 @@ void SiPixelFedFillerWordEventNumber ::produce(edm::Event& iEvent, const edm::Ev
   vecFillerWordsEventNumber1.erase(vecFillerWordsEventNumber1.begin(), vecFillerWordsEventNumber1.end());
 }
 
-// ------------ method called once each job just before starting event loop  ------------
-void SiPixelFedFillerWordEventNumber ::beginJob() {}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void SiPixelFedFillerWordEventNumber ::endJob() {}
 //===== define this as a plug-in
 DEFINE_FWK_MODULE(SiPixelFedFillerWordEventNumber);

--- a/CalibTracker/SiPixelTools/plugins/SiPixelFedFillerWordEventNumber.h
+++ b/CalibTracker/SiPixelTools/plugins/SiPixelFedFillerWordEventNumber.h
@@ -6,7 +6,7 @@
 #include <vector>
 #include <iostream>
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -19,7 +19,7 @@
 #include "DataFormats/FEDRawData/interface/FEDTrailer.h"
 
 //===== class decleration
-class SiPixelFedFillerWordEventNumber : public edm::EDProducer {
+class SiPixelFedFillerWordEventNumber : public edm::stream::EDProducer<> {
 public:
   explicit SiPixelFedFillerWordEventNumber(const edm::ParameterSet &);
   ~SiPixelFedFillerWordEventNumber() override;
@@ -28,9 +28,7 @@ public:
   bool SaveFillerWordsbool;
 
 private:
-  void beginJob() override;
   void produce(edm::Event &, const edm::EventSetup &) override;
-  void endJob() override;
   edm::ParameterSet config_;
   int status;
   unsigned int EventNum;

--- a/CalibTracker/SiPixelTools/src/SiPixelOfflineCalibAnalysisBase.cc
+++ b/CalibTracker/SiPixelTools/src/SiPixelOfflineCalibAnalysisBase.cc
@@ -131,6 +131,9 @@ void SiPixelOfflineCalibAnalysisBase::beginRun(const edm::Run&, const edm::Event
   this->calibrationSetup(iSetup);
   theHistogramIdWorker_ = new SiPixelHistogramId(siPixelCalibDigiProducer_.label());
 }
+
+void SiPixelOfflineCalibAnalysisBase::endRun(const edm::Run&, const edm::EventSetup& iSetup) {}
+
 void SiPixelOfflineCalibAnalysisBase::beginJob() {}
 // ------------ method called once each job just before starting event loop  ------------
 

--- a/CalibTracker/SiStripESProducers/plugins/DBWriter/DummyCondDBWriter.h
+++ b/CalibTracker/SiStripESProducers/plugins/DBWriter/DummyCondDBWriter.h
@@ -2,7 +2,7 @@
 #define CalibTracker_SiStripESProducer_DummyCondDBWriter_h
 
 // user include files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -16,12 +16,12 @@
 #include <string>
 
 template <typename TObject, typename TObjectO, typename TRecord>
-class DummyCondDBWriter : public edm::EDAnalyzer {
+class DummyCondDBWriter : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   explicit DummyCondDBWriter(const edm::ParameterSet& iConfig);
   ~DummyCondDBWriter() override;
   void analyze(const edm::Event& e, const edm::EventSetup& es) override{};
-
+  void beginRun(const edm::Run& run, const edm::EventSetup& es) override{};
   void endRun(const edm::Run& run, const edm::EventSetup& es) override;
 
 private:

--- a/CalibTracker/SiStripESProducers/plugins/DBWriter/DummyCondObjPrinter.h
+++ b/CalibTracker/SiStripESProducers/plugins/DBWriter/DummyCondObjPrinter.h
@@ -2,7 +2,7 @@
 #define CalibTracker_SiStripESProducer_DummyCondObjPrinter_h
 
 // user include files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -14,7 +14,7 @@
 #include <string>
 
 template <typename TObject, typename TRecord>
-class DummyCondObjPrinter : public edm::EDAnalyzer {
+class DummyCondObjPrinter : public edm::one::EDAnalyzer<> {
 public:
   explicit DummyCondObjPrinter(const edm::ParameterSet& iConfig);
   ~DummyCondObjPrinter() override;

--- a/CalibTracker/SiStripESProducers/plugins/DBWriter/SiStripFedCablingManipulator.h
+++ b/CalibTracker/SiStripESProducers/plugins/DBWriter/SiStripFedCablingManipulator.h
@@ -2,7 +2,7 @@
 #define CalibTracker_SiStripESProducer_SiStripFedCablingManipulator_h
 
 // user include files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -15,12 +15,12 @@
 
 #include <string>
 
-class SiStripFedCablingManipulator : public edm::EDAnalyzer {
+class SiStripFedCablingManipulator : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   explicit SiStripFedCablingManipulator(const edm::ParameterSet& iConfig);
   ~SiStripFedCablingManipulator() override;
   void analyze(const edm::Event& e, const edm::EventSetup& es) override{};
-
+  void beginRun(const edm::Run& run, const edm::EventSetup& es) override{};
   void endRun(const edm::Run& run, const edm::EventSetup& es) override;
 
 private:

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripApvGainBuilderFromTag.h
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripApvGainBuilderFromTag.h
@@ -31,7 +31,7 @@ class TrackerGeometry;
  * several changes to the base classes used together with it.
  */
 
-class SiStripApvGainBuilderFromTag : public edm::EDAnalyzer {
+class SiStripApvGainBuilderFromTag : public edm::one::EDAnalyzer<> {
 public:
   explicit SiStripApvGainBuilderFromTag(const edm::ParameterSet& iConfig);
 

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripNoiseNormalizedWithApvGainBuilder.h
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripNoiseNormalizedWithApvGainBuilder.h
@@ -8,6 +8,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "CommonTools/ConditionDBWriter/interface/ConditionDBWriter.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
@@ -28,7 +29,7 @@ class TrackerGeometry;
  * rescale the noise (per strip).
  */
 
-class SiStripNoiseNormalizedWithApvGainBuilder : public edm::EDAnalyzer {
+class SiStripNoiseNormalizedWithApvGainBuilder : public edm::one::EDAnalyzer<> {
 public:
   explicit SiStripNoiseNormalizedWithApvGainBuilder(const edm::ParameterSet& iConfig);
 

--- a/CalibTracker/SiStripHitEfficiency/interface/HitEff.h
+++ b/CalibTracker/SiStripHitEfficiency/interface/HitEff.h
@@ -1,5 +1,5 @@
 #include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -48,7 +48,7 @@
 
 class TrackerTopology;
 
-class HitEff : public edm::EDAnalyzer {
+class HitEff : public edm::one::EDAnalyzer<> {
 public:
   explicit HitEff(const edm::ParameterSet& conf);
   double checkConsistency(const StripClusterParameterEstimator::LocalValues& parameters, double xx, double xerr);

--- a/CommonTools/ConditionDBWriter/interface/ConditionDBWriter.h
+++ b/CommonTools/ConditionDBWriter/interface/ConditionDBWriter.h
@@ -130,7 +130,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -146,7 +146,7 @@
 #include "DataFormats/Common/interface/Handle.h"
 
 template <class T>
-class ConditionDBWriter : public edm::EDAnalyzer {
+class ConditionDBWriter : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::WatchLuminosityBlocks> {
 public:
   explicit ConditionDBWriter(const edm::ParameterSet &iConfig)
       : minRunRange_(1 << 31),

--- a/CondFormats/PhysicsToolsObjects/test/SiStripDeDx2DBuilder.cc
+++ b/CondFormats/PhysicsToolsObjects/test/SiStripDeDx2DBuilder.cc
@@ -15,7 +15,7 @@
 //#include "CLHEP/Random/RandFlat.h"
 //#include "CLHEP/Random/RandGauss.h"
 
-class SiStripDeDx2DBuilder : public edm::EDAnalyzer {
+class SiStripDeDx2DBuilder : public edm::one::EDAnalyzer<> {
 public:
   explicit SiStripDeDx2DBuilder(const edm::ParameterSet& iConfig);
 

--- a/CondFormats/PhysicsToolsObjects/test/SiStripDeDx3DBuilder.cc
+++ b/CondFormats/PhysicsToolsObjects/test/SiStripDeDx3DBuilder.cc
@@ -15,7 +15,7 @@
 //#include "CLHEP/Random/RandFlat.h"
 //#include "CLHEP/Random/RandGauss.h"
 
-class SiStripDeDx3DBuilder : public edm::EDAnalyzer {
+class SiStripDeDx3DBuilder : public edm::one::EDAnalyzer<> {
 public:
   explicit SiStripDeDx3DBuilder(const edm::ParameterSet& iConfig);
 

--- a/CondFormats/PhysicsToolsObjects/test/SiStripDeDxMipBuilder.h
+++ b/CondFormats/PhysicsToolsObjects/test/SiStripDeDxMipBuilder.h
@@ -13,7 +13,7 @@
 //#include "CLHEP/Random/RandFlat.h"
 //#include "CLHEP/Random/RandGauss.h"
 
-class SiStripDeDxMipBuilder : public edm::EDAnalyzer {
+class SiStripDeDxMipBuilder : public edm::one::EDAnalyzer<> {
 public:
   explicit SiStripDeDxMipBuilder(const edm::ParameterSet& iConfig);
 

--- a/CondTools/SiStrip/plugins/SiStripApvGainBuilder.h
+++ b/CondTools/SiStrip/plugins/SiStripApvGainBuilder.h
@@ -13,7 +13,7 @@
 #include "CLHEP/Random/RandFlat.h"
 #include "CLHEP/Random/RandGauss.h"
 
-class SiStripApvGainBuilder : public edm::EDAnalyzer {
+class SiStripApvGainBuilder : public edm::one::EDAnalyzer<> {
 public:
   explicit SiStripApvGainBuilder(const edm::ParameterSet& iConfig);
 

--- a/CondTools/SiStrip/plugins/SiStripNoisesBuilder.h
+++ b/CondTools/SiStrip/plugins/SiStripNoisesBuilder.h
@@ -12,7 +12,7 @@
 #include "CLHEP/Random/RandFlat.h"
 #include "CLHEP/Random/RandGauss.h"
 
-class SiStripNoisesBuilder : public edm::EDAnalyzer {
+class SiStripNoisesBuilder : public edm::one::EDAnalyzer<> {
 public:
   explicit SiStripNoisesBuilder(const edm::ParameterSet& iConfig);
 

--- a/CondTools/SiStrip/plugins/SiStripPedestalsBuilder.h
+++ b/CondTools/SiStrip/plugins/SiStripPedestalsBuilder.h
@@ -13,7 +13,7 @@
 #include "CLHEP/Random/RandFlat.h"
 #include "CLHEP/Random/RandGauss.h"
 
-class SiStripPedestalsBuilder : public edm::EDAnalyzer {
+class SiStripPedestalsBuilder : public edm::one::EDAnalyzer<> {
 public:
   explicit SiStripPedestalsBuilder(const edm::ParameterSet& iConfig);
 

--- a/CondTools/SiStrip/plugins/SiStripSummaryBuilder.h
+++ b/CondTools/SiStrip/plugins/SiStripSummaryBuilder.h
@@ -13,7 +13,7 @@
 #include "CLHEP/Random/RandFlat.h"
 #include "CLHEP/Random/RandGauss.h"
 
-class SiStripSummaryBuilder : public edm::EDAnalyzer {
+class SiStripSummaryBuilder : public edm::one::EDAnalyzer<> {
 public:
   explicit SiStripSummaryBuilder(const edm::ParameterSet& iConfig);
 

--- a/CondTools/SiStrip/plugins/SiStripThresholdBuilder.h
+++ b/CondTools/SiStrip/plugins/SiStripThresholdBuilder.h
@@ -13,7 +13,7 @@
 #include "CLHEP/Random/RandFlat.h"
 #include "CLHEP/Random/RandGauss.h"
 
-class SiStripThresholdBuilder : public edm::EDAnalyzer {
+class SiStripThresholdBuilder : public edm::one::EDAnalyzer<> {
 public:
   explicit SiStripThresholdBuilder(const edm::ParameterSet& iConfig);
 


### PR DESCRIPTION
#### PR description:

Finalize migrate away from deprecated `edm::EDAnalyzer` API in `CalibTracker` and ` CommonTools/ConditionDBWriter`

#### PR validation:

It compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A


