### PR TITLE
Allow to preset timeout for connection on coral-supported Databases

### DIFF
--- a/CondCore/CondDB/interface/ConnectionPool.h
+++ b/CondCore/CondDB/interface/ConnectionPool.h
@@ -43,6 +43,7 @@ namespace cond {
       void setAuthenticationSystem(int authSysCode);
       void setFrontierSecurity(const std::string& signature);
       void setLogging(bool flag);
+      void setConnectionTimeout(int seconds);
       bool isLoggingEnabled() const;
       void setParameters(const edm::ParameterSet& connectionPset);
       void configure();
@@ -65,6 +66,7 @@ namespace cond {
       int m_authSys = 0;
       std::string m_authenticationService = std::string("");
       coral::MsgLevel m_messageLevel = coral::Error;
+      int m_connectionTimeout = 0;
       CoralMsgReporter* m_msgReporter = nullptr;
       bool m_loggingEnabled = false;
       //The frontier security option is turned on for all sessions

--- a/CondCore/CondDB/python/CondDB_cfi.py
+++ b/CondCore/CondDB/python/CondDB_cfi.py
@@ -6,6 +6,7 @@ CondDB = cms.PSet(
         authenticationSystem = cms.untracked.int32(0),
         security = cms.untracked.string(''),
         messageLevel = cms.untracked.int32(0),
+        connectionTimeout = cms.untracked.int32(0),
     ),
     connect = cms.string(''), 
 )

--- a/CondCore/CondDB/src/ConnectionPool.cc
+++ b/CondCore/CondDB/src/ConnectionPool.cc
@@ -67,6 +67,7 @@ namespace cond {
           level = coral::Error;
       }
       setMessageVerbosity(level);
+      setConnectionTimeout(connectionPset.getUntrackedParameter<int>("connectionTimeout", m_connectionTimeout));
       setLogging(connectionPset.getUntrackedParameter<bool>("logging", m_loggingEnabled));
     }
 
@@ -75,6 +76,7 @@ namespace cond {
     void ConnectionPool::configure(coral::IConnectionServiceConfiguration& coralConfig) {
       coralConfig.disablePoolAutomaticCleanUp();
       coralConfig.disableConnectionSharing();
+      coralConfig.setConnectionTimeOut(m_connectionTimeout);
       // message streaming
       coral::MessageStream::setMsgVerbosity(m_messageLevel);
       m_msgReporter->setOutputLevel(m_messageLevel);
@@ -184,6 +186,8 @@ namespace cond {
     }
 
     void ConnectionPool::setMessageVerbosity(coral::MsgLevel level) { m_messageLevel = level; }
+
+    void ConnectionPool::setConnectionTimeout(int seconds) { m_connectionTimeout = seconds; }
 
     void ConnectionPool::setLogDestination(Logger& logger) { m_msgReporter->subscribe(logger); }
 


### PR DESCRIPTION
#### PR description:

We are adding the access to the coral connectionTimeout parameter, to allow to preset values in the read-only workflows based on ESSource. Default value is 0=> no pool of idle connection.

The effect has been tested on Hilton for the HLT workflow. No visible performace change observe, but clear decrease of File descriptor opened ( the previous default value was 300 seconds )

Unit and integration test of CondCore packages are ok.