### PR TITLE
Explicitly set numberOfConcurrentLuminosityBlocks to 1 in testProduceCalibrationTree_cfg.py 

### DIFF
--- a/CalibTracker/SiStripCommon/test/testProduceCalibrationTree_cfg.py
+++ b/CalibTracker/SiStripCommon/test/testProduceCalibrationTree_cfg.py
@@ -204,4 +204,4 @@ if(options.unitTest):
 #Setup FWK for multithreaded
 process.options.numberOfThreads=cms.untracked.uint32(4)
 process.options.numberOfStreams=cms.untracked.uint32(0)
-#process.options.numberOfConcurrentLuminosityBlocks=cms.untracked.uint32(2)  ## not yet
+process.options.numberOfConcurrentLuminosityBlocks=cms.untracked.uint32(1)  ## not yet ready for 2, because of HitEff being legacy module


### PR DESCRIPTION
#### PR description:

Testing https://github.com/cms-sw/cmssw/pull/35326 showed that this configuration fails if the warning for lumi-syncrhonizing EDModules is changed to an exception. The EDModule that causes the synchronization is `HitEff` that is a legacy `edm::EDAnalyzer`. The real fix would be to change that to a one of the thread-efficient module types, so the change of this PR is more like a workaround until that is done (since the intention looks like the configuration should support concurrent lumis).

#### PR validation:

Tested on top of #35326 that the unit test succeeds.
