### PR TITLE
Explicitly set numberOfConcurrentLuminosityBlocks to 1 in compare_external_generators_streams_cfg.py

### DIFF
--- a/GeneratorInterface/Pythia8Interface/test/compare_external_generators_streams_cfg.py
+++ b/GeneratorInterface/Pythia8Interface/test/compare_external_generators_streams_cfg.py
@@ -6,6 +6,7 @@ process.source =cms.Source("EmptySource")
 process.maxEvents.input = 10
 process.options.numberOfStreams = 2
 process.options.numberOfThreads = 2
+process.options.numberOfConcurrentLuminosityBlocks = 1 # because Pythia8GeneratorFilter requires synchronization at LuminosityBlock boundaries
 
 process.load("Configuration.StandardSequences.SimulationRandomNumberGeneratorSeeds_cff")
 process.RandomNumberGeneratorService.gen1 = process.RandomNumberGeneratorService.generator.clone()


### PR DESCRIPTION
#### PR description:

Testing #35326 showed that this configuration fails if the warning for lumi-syncrhonizing EDModules is changed to an exception. The EDModule that causes the synchronization is `Pythia8GeneratorFilter`. An alternative would be to use `Pythia8ConcurrentGeneratorFilter` instead, but the test looks like it does not attempt to test concurrent lumi capabilities. 

#### PR validation:

Tested on top of #35326 that the unit test succeeds.