### PR TITLE
Explicitly set numberOfConcurrentLuminosityBlocks to 1 in unittest_FU.py

### DIFF
--- a/EventFilter/Utilities/test/unittest_FU.py
+++ b/EventFilter/Utilities/test/unittest_FU.py
@@ -54,7 +54,7 @@ process.maxEvents = cms.untracked.PSet(
 process.options = cms.untracked.PSet(
     numberOfThreads = cms.untracked.uint32(options.numThreads),
     numberOfStreams = cms.untracked.uint32(options.numFwkStreams),
-    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(2)
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(1) # ShmStreamConsumer requires synchronization at LuminosityBlock boundaries
 )
 process.MessageLogger = cms.Service("MessageLogger",
     cout = cms.untracked.PSet(threshold = cms.untracked.string( "ERROR" )),


### PR DESCRIPTION
#### PR description:

Testing #35326 showed that this configuration fails if the warning for lumi-syncrhonizing EDModules is changed to an exception. The EDModule that causes the synchronization is `ShmStreamConsumer` that is `RecoEventOutputModuleForFU<RecoEventWriterForFU>` that inherits from `edm::StreamerOutputModuleBase` that is
https://github.com/cms-sw/cmssw/blob/ac2754c6dc2d0894e92ebee07d1c7da04f797414/IOPool/Streamer/interface/StreamerOutputModuleBase.h#L20-L21
The intention of the test is clearly to support concurrent lumis, so this PR would be a workaround until the `StreamerOutputModuleBase` would be fixed (if it can be).

In principle using `edm::LuminosityBlockCache` to hold the per-lumi information could be used to avoid this synchronization.

#### PR validation:

Tested on top of #35326 that the unit test succeeds.