### PR TITLE
Migrate some code in RecoTracker/ConversionSeedGenerators to esConsumes

### DIFF
--- a/RecoTracker/ConversionSeedGenerators/plugins/PhotonConversionTrajectorySeedProducerFromSingleLegAlgo.cc
+++ b/RecoTracker/ConversionSeedGenerators/plugins/PhotonConversionTrajectorySeedProducerFromSingleLegAlgo.cc
@@ -16,7 +16,7 @@ PhotonConversionTrajectorySeedProducerFromSingleLegAlgo::PhotonConversionTraject
     const edm::ParameterSet& conf, edm::ConsumesCollector&& iC)
     : theHitsGenerator(new CombinedHitPairGeneratorForPhotonConversion(
           conf.getParameter<edm::ParameterSet>("OrderedHitsFactoryPSet"), iC)),
-      theSeedCreator(new SeedForPhotonConversion1Leg(conf.getParameter<edm::ParameterSet>("SeedCreatorPSet"))),
+      theSeedCreator(new SeedForPhotonConversion1Leg(conf.getParameter<edm::ParameterSet>("SeedCreatorPSet"), iC)),
       theRegionProducer(
           new GlobalTrackingRegionProducerFromBeamSpot(conf.getParameter<edm::ParameterSet>("RegionFactoryPSet"), iC)),
       theClusterCheck(conf.getParameter<edm::ParameterSet>("ClusterCheckPSet"), iC),

--- a/RecoTracker/ConversionSeedGenerators/plugins/PhotonConversionTrajectorySeedProducerFromSingleLegAlgo.cc
+++ b/RecoTracker/ConversionSeedGenerators/plugins/PhotonConversionTrajectorySeedProducerFromSingleLegAlgo.cc
@@ -4,7 +4,6 @@
 
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 
 //#define debugTSPFSLA
@@ -33,6 +32,7 @@ PhotonConversionTrajectorySeedProducerFromSingleLegAlgo::PhotonConversionTraject
   token_vertex = iC.consumes<reco::VertexCollection>(_primaryVtxInputTag);
   token_bs = iC.consumes<reco::BeamSpot>(_beamSpotInputTag);
   token_refitter = iC.consumes<reco::TrackCollection>(conf.getParameter<edm::InputTag>("TrackRefitter"));
+  token_magField = iC.esConsumes();
 }
 
 PhotonConversionTrajectorySeedProducerFromSingleLegAlgo::~PhotonConversionTrajectorySeedProducerFromSingleLegAlgo() {}
@@ -55,15 +55,13 @@ void PhotonConversionTrajectorySeedProducerFromSingleLegAlgo::find(const edm::Ev
     return;
   }
 
-  edm::ESHandle<MagneticField> handleMagField;
-  setup.get<IdealMagneticFieldRecord>().get(handleMagField);
-  magField = handleMagField.product();
-  if (UNLIKELY(magField->inTesla(GlobalPoint(0., 0., 0.)).z() < 0.01)) {
+  const auto& magField = setup.getData(token_magField);
+  if (UNLIKELY(magField.inTesla(GlobalPoint(0., 0., 0.)).z() < 0.01)) {
     seedCollection = nullptr;
     return;
   }
 
-  _IdealHelixParameters.setMagnField(magField);
+  _IdealHelixParameters.setMagnField(&magField);
 
   event.getByToken(token_vertex, vertexHandle);
   if (!vertexHandle.isValid() || vertexHandle->empty()) {

--- a/RecoTracker/ConversionSeedGenerators/plugins/PhotonConversionTrajectorySeedProducerFromSingleLegAlgo.h
+++ b/RecoTracker/ConversionSeedGenerators/plugins/PhotonConversionTrajectorySeedProducerFromSingleLegAlgo.h
@@ -68,6 +68,7 @@ private:
   edm::EDGetTokenT<reco::VertexCollection> token_vertex;
   edm::EDGetTokenT<reco::BeamSpot> token_bs;
   edm::EDGetTokenT<reco::TrackCollection> token_refitter;
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> token_magField;
 
   typedef std::vector<std::unique_ptr<TrackingRegion> > Regions;
   typedef Regions::const_iterator IR;

--- a/RecoTracker/ConversionSeedGenerators/plugins/SeedForPhotonConversion1Leg.h
+++ b/RecoTracker/ConversionSeedGenerators/plugins/SeedForPhotonConversion1Leg.h
@@ -6,9 +6,15 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "FWCore/Utilities/interface/Visibility.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "TrackingTools/GeomPropagators/interface/Propagator.h"
+#include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
+#include "TrackingTools/Records/interface/TransientRecHitRecord.h"
 
 #include "RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h"
 
@@ -21,10 +27,12 @@ class dso_hidden SeedForPhotonConversion1Leg {
 public:
   static const int cotTheta_Max = 99999;
 
-  SeedForPhotonConversion1Leg(const edm::ParameterSet& cfg)
-      : thePropagatorLabel(cfg.getParameter<std::string>("propagator")),
-        theBOFFMomentum(cfg.getParameter<double>("SeedMomentumForBOFF")),
-        TTRHBuilder(cfg.getParameter<std::string>("TTRHBuilder")) {}
+  SeedForPhotonConversion1Leg(const edm::ParameterSet& cfg, edm::ConsumesCollector iC)
+      : theBfieldToken(iC.esConsumes()),
+        theTrackerToken(iC.esConsumes()),
+        thePropagatorToken(iC.esConsumes(edm::ESInputTag("", cfg.getParameter<std::string>("propagator")))),
+        theTTRHBuilderToken(iC.esConsumes(edm::ESInputTag("", cfg.getParameter<std::string>("TTRHBuilder")))),
+        theBOFFMomentum(cfg.getParameter<double>("SeedMomentumForBOFF")) {}
 
   //dtor
   ~SeedForPhotonConversion1Leg() {}
@@ -62,9 +70,11 @@ protected:
                                         const TkClonerImpl& cloner) const;
 
 protected:
-  std::string thePropagatorLabel;
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> theBfieldToken;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> theTrackerToken;
+  edm::ESGetToken<Propagator, TrackingComponentsRecord> thePropagatorToken;
+  edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> theTTRHBuilderToken;
   double theBOFFMomentum;
-  std::string TTRHBuilder;
 
   std::stringstream* pss;
   PrintRecoObjects po;

--- a/RecoTracker/ConversionSeedGenerators/plugins/SeedForPhotonConversionFromQuadruplets.h
+++ b/RecoTracker/ConversionSeedGenerators/plugins/SeedForPhotonConversionFromQuadruplets.h
@@ -3,6 +3,7 @@
 
 #include "RecoTracker/TkTrackingRegions/interface/GlobalTrackingRegion.h"
 #include "RecoTracker/TkSeedingLayers/interface/SeedingHitSet.h"
+#include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
 
@@ -13,9 +14,10 @@
 
 class FreeTrajectoryState;
 class SeedComparitor;
-namespace edm {
-  class ConsumesCollector;
-}
+class IdealMagneticFieldRecord;
+class TransientRecHitRecord;
+class TrackerDigiGeometryRecord;
+class TrackingComponentsRecord;
 
 class SeedForPhotonConversionFromQuadruplets {
 public:
@@ -101,7 +103,10 @@ protected:
   double DeltaPhiManual(const math::XYZVector& v1, const math::XYZVector& v2);
 
 protected:
-  std::string thePropagatorLabel;
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> theBfieldToken;
+  edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> theTTRHBuilderToken;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> theTrackerToken;
+  edm::ESGetToken<Propagator, TrackingComponentsRecord> thePropagatorToken;
   double theBOFFMomentum;
   double kPI_;
 


### PR DESCRIPTION
#### PR description:

Part of #31061. These changes should be sufficient to cover `PhotonConversionTrajectorySeedProducerFromQuadruplets` and `PhotonConversionTrajectorySeedProducerFromSingleLeg` EDModules for the parts that are not covered by https://github.com/cms-sw/cmssw/pull/35393.

#### PR validation:

Code compiles.