### PR TITLE
modernize `CondTools/SiStrip`

### DIFF
--- a/CondTools/SiStrip/plugins/SiStripApvGainReader.cc
+++ b/CondTools/SiStrip/plugins/SiStripApvGainReader.cc
@@ -15,6 +15,8 @@ SiStripApvGainReader::SiStripApvGainReader(const edm::ParameterSet& iConfig)
       formatedOutput_(iConfig.getUntrackedParameter<std::string>("outputFile", "")),
       gainType_(iConfig.getUntrackedParameter<uint32_t>("gainType", 1)),
       gainToken_(esConsumes()) {
+  usesResource(TFileService::kSharedResource);
+
   if (fs_.isAvailable()) {
     tree_ = fs_->make<TTree>("Gains", "Gains");
 
@@ -24,8 +26,6 @@ SiStripApvGainReader::SiStripApvGainReader(const edm::ParameterSet& iConfig)
     tree_->Branch("Gain", &gain_, "Gain/D");
   }
 }
-
-SiStripApvGainReader::~SiStripApvGainReader() {}
 
 void SiStripApvGainReader::analyze(const edm::Event& e, const edm::EventSetup& iSetup) {
   const auto& stripApvGain = iSetup.getData(gainToken_);

--- a/CondTools/SiStrip/plugins/SiStripApvGainReader.h
+++ b/CondTools/SiStrip/plugins/SiStripApvGainReader.h
@@ -6,7 +6,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -24,10 +24,10 @@
 
 class SiStripGain;
 
-class SiStripApvGainReader : public edm::EDAnalyzer {
+class SiStripApvGainReader : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit SiStripApvGainReader(const edm::ParameterSet&);
-  ~SiStripApvGainReader() override;
+  ~SiStripApvGainReader() override = default;
 
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 

--- a/CondTools/SiStrip/plugins/SiStripBadStripReader.cc
+++ b/CondTools/SiStrip/plugins/SiStripBadStripReader.cc
@@ -1,5 +1,5 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -11,7 +11,7 @@
 #include <cstdio>
 #include <sys/time.h>
 
-class SiStripBadStripReader : public edm::EDAnalyzer {
+class SiStripBadStripReader : public edm::one::EDAnalyzer<> {
 public:
   explicit SiStripBadStripReader(const edm::ParameterSet& iConfig)
       : printdebug_(iConfig.getUntrackedParameter<uint32_t>("printDebug", 1)), badStripToken_(esConsumes()) {}
@@ -25,7 +25,7 @@ private:
   edm::ESGetToken<SiStripBadStrip, SiStripBadStripRcd> badStripToken_;
 };
 
-SiStripBadStripReader::~SiStripBadStripReader() {}
+SiStripBadStripReader::~SiStripBadStripReader() = default;
 
 void SiStripBadStripReader::analyze(const edm::Event& e, const edm::EventSetup& iSetup) {
   const auto& badStrip = iSetup.getData(badStripToken_);

--- a/CondTools/SiStrip/plugins/SiStripCablingTrackerMap.cc
+++ b/CondTools/SiStrip/plugins/SiStripCablingTrackerMap.cc
@@ -3,13 +3,10 @@
 
 #include <sstream>
 
-SiStripCablingTrackerMap::SiStripCablingTrackerMap(edm::ParameterSet const& conf)
-    : conf_(conf), detCablingToken_(esConsumes()) {}
-
-SiStripCablingTrackerMap::~SiStripCablingTrackerMap() {}
+SiStripCablingTrackerMap::SiStripCablingTrackerMap(edm::ParameterSet const& conf) : detCablingToken_(esConsumes()) {}
 
 void SiStripCablingTrackerMap::beginRun(const edm::Run& run, const edm::EventSetup& es) {
-  tkMap_detCab = new TrackerMap("DetCabling");
+  tkMap_detCab = std::make_unique<TrackerMap>("DetCabling");
 }
 
 //------------------------------------------------------------------------------------------

--- a/CondTools/SiStrip/plugins/SiStripCablingTrackerMap.h
+++ b/CondTools/SiStrip/plugins/SiStripCablingTrackerMap.h
@@ -2,7 +2,7 @@
 #define SiStripCablingTrackerMap_h
 
 #include "FWCore/Utilities/interface/Exception.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -13,22 +13,20 @@
 
 #include "CalibFormats/SiStripObjects/interface/SiStripDetCabling.h"
 
-class SiStripCablingTrackerMap : public edm::EDAnalyzer {
+class SiStripCablingTrackerMap : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   SiStripCablingTrackerMap(const edm::ParameterSet& conf);
-  ~SiStripCablingTrackerMap() override;
+  ~SiStripCablingTrackerMap() override = default;
 
   void beginRun(const edm::Run& run, const edm::EventSetup& es) override;
-
   void endJob() override;
-
+  void endRun(const edm::Run& run, const edm::EventSetup& es) override{};
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
 private:
-  edm::ParameterSet conf_;
   edm::ESGetToken<SiStripDetCabling, SiStripDetCablingRcd> detCablingToken_;
 
-  TrackerMap* tkMap_detCab;  //0 for onTrack, 1 for offTrack, 2 for All
+  std::unique_ptr<TrackerMap> tkMap_detCab;  //0 for onTrack, 1 for offTrack, 2 for All
 };
 
 #endif

--- a/CondTools/SiStrip/plugins/SiStripDetVOffFakeBuilder.h
+++ b/CondTools/SiStrip/plugins/SiStripDetVOffFakeBuilder.h
@@ -2,7 +2,7 @@
 #define SiStripDetVOff_H
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -13,7 +13,7 @@
 
 class TrackerGeometry;
 
-class SiStripDetVOffFakeBuilder : public edm::EDAnalyzer {
+class SiStripDetVOffFakeBuilder : public edm::one::EDAnalyzer<> {
 public:
   explicit SiStripDetVOffFakeBuilder(const edm::ParameterSet& iConfig);
 

--- a/CondTools/SiStrip/plugins/SiStripDetVOffReader.cc
+++ b/CondTools/SiStrip/plugins/SiStripDetVOffReader.cc
@@ -9,8 +9,6 @@
 SiStripDetVOffReader::SiStripDetVOffReader(const edm::ParameterSet& iConfig)
     : printdebug_(iConfig.getUntrackedParameter<bool>("printDebug", true)), detVOffToken_(esConsumes()) {}
 
-SiStripDetVOffReader::~SiStripDetVOffReader() {}
-
 void SiStripDetVOffReader::analyze(const edm::Event& e, const edm::EventSetup& iSetup) {
   const auto& detVOff = iSetup.getData(detVOffToken_);
   edm::LogInfo("SiStripDetVOffReader") << "[SiStripDetVOffReader::analyze] End Reading SiStripDetVOff" << std::endl;

--- a/CondTools/SiStrip/plugins/SiStripDetVOffReader.h
+++ b/CondTools/SiStrip/plugins/SiStripDetVOffReader.h
@@ -6,7 +6,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -24,10 +24,10 @@ class SiStripDetVOff;
 //
 // class decleration
 //
-class SiStripDetVOffReader : public edm::EDAnalyzer {
+class SiStripDetVOffReader : public edm::one::EDAnalyzer<> {
 public:
   explicit SiStripDetVOffReader(const edm::ParameterSet&);
-  ~SiStripDetVOffReader() override;
+  ~SiStripDetVOffReader() override = default;
 
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 

--- a/CondTools/SiStrip/plugins/SiStripFedCablingBuilder.h
+++ b/CondTools/SiStrip/plugins/SiStripFedCablingBuilder.h
@@ -4,7 +4,7 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "CondFormats/DataRecord/interface/SiStripFedCablingRcd.h"
 #include "CalibTracker/Records/interface/SiStripFecCablingRcd.h"
 #include "CalibTracker/Records/interface/SiStripDetCablingRcd.h"
@@ -15,15 +15,15 @@ class SiStripFecCabling;
 class SiStripDetCabling;
 class SiStripRegionCabling;
 
-class SiStripFedCablingBuilder : public edm::EDAnalyzer {
+class SiStripFedCablingBuilder : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   SiStripFedCablingBuilder(const edm::ParameterSet& iConfig);
 
-  ~SiStripFedCablingBuilder() override{};
+  ~SiStripFedCablingBuilder() = default;
 
   void beginRun(const edm::Run&, const edm::EventSetup&) override;
-
-  void analyze(const edm::Event&, const edm::EventSetup&) override { ; }
+  void analyze(const edm::Event&, const edm::EventSetup&) override {}
+  void endRun(const edm::Run&, const edm::EventSetup&) override{};
 
 private:
   bool printFecCabling_;

--- a/CondTools/SiStrip/plugins/SiStripFedCablingReader.h
+++ b/CondTools/SiStrip/plugins/SiStripFedCablingReader.h
@@ -1,7 +1,7 @@
 #ifndef CondTools_SiStrip_FedCablingReader_H
 #define CondTools_SiStrip_FedCablingReader_H
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -15,15 +15,14 @@ class SiStripFecCabling;
 class SiStripDetCabling;
 class SiStripRegionCabling;
 
-class SiStripFedCablingReader : public edm::EDAnalyzer {
+class SiStripFedCablingReader : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   SiStripFedCablingReader(const edm::ParameterSet&);
-
-  ~SiStripFedCablingReader() override { ; }
+  ~SiStripFedCablingReader() = default;
 
   void beginRun(const edm::Run&, const edm::EventSetup&) override;
-
-  void analyze(const edm::Event&, const edm::EventSetup&) override { ; }
+  void endRun(const edm::Run&, const edm::EventSetup&) override{};
+  void analyze(const edm::Event&, const edm::EventSetup&) override{};
 
 private:
   bool printFecCabling_;

--- a/CondTools/SiStrip/plugins/SiStripLorentzAngleReader.cc
+++ b/CondTools/SiStrip/plugins/SiStripLorentzAngleReader.cc
@@ -12,7 +12,6 @@ SiStripLorentzAngleReader::SiStripLorentzAngleReader(const edm::ParameterSet& iC
     : printdebug_(iConfig.getUntrackedParameter<uint32_t>("printDebug", 5)),
       label_(iConfig.getUntrackedParameter<std::string>("label", "")),
       laToken_(esConsumes(edm::ESInputTag{"", label_})) {}
-SiStripLorentzAngleReader::~SiStripLorentzAngleReader() {}
 
 void SiStripLorentzAngleReader::analyze(const edm::Event& e, const edm::EventSetup& iSetup) {
   const auto& lorentzAngles = iSetup.getData(laToken_);

--- a/CondTools/SiStrip/plugins/SiStripLorentzAngleReader.h
+++ b/CondTools/SiStrip/plugins/SiStripLorentzAngleReader.h
@@ -6,7 +6,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -21,10 +21,10 @@ class SiStripLorentzAngle;
 //
 // class decleration
 //
-class SiStripLorentzAngleReader : public edm::EDAnalyzer {
+class SiStripLorentzAngleReader : public edm::one::EDAnalyzer<> {
 public:
   explicit SiStripLorentzAngleReader(const edm::ParameterSet&);
-  ~SiStripLorentzAngleReader() override;
+  ~SiStripLorentzAngleReader() override = default;
 
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 

--- a/CondTools/SiStrip/plugins/SiStripNoisesReader.h
+++ b/CondTools/SiStrip/plugins/SiStripNoisesReader.h
@@ -6,7 +6,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -22,7 +22,7 @@
 #include <cstdio>
 #include <sys/time.h>
 
-class SiStripNoisesReader : public edm::EDAnalyzer {
+class SiStripNoisesReader : public edm::one::EDAnalyzer<> {
 public:
   explicit SiStripNoisesReader(const edm::ParameterSet&);
   ~SiStripNoisesReader() override;

--- a/CondTools/SiStrip/plugins/SiStripPedestalsReader.cc
+++ b/CondTools/SiStrip/plugins/SiStripPedestalsReader.cc
@@ -6,8 +6,6 @@ using namespace cms;
 SiStripPedestalsReader::SiStripPedestalsReader(const edm::ParameterSet& iConfig)
     : printdebug_(iConfig.getUntrackedParameter<uint32_t>("printDebug", 1)), pedestalsToken_(esConsumes()) {}
 
-SiStripPedestalsReader::~SiStripPedestalsReader() {}
-
 void SiStripPedestalsReader::analyze(const edm::Event& e, const edm::EventSetup& iSetup) {
   const auto& pedestals = iSetup.getData(pedestalsToken_);
   edm::LogInfo("SiStripPedestalsReader") << "[SiStripPedestalsReader::analyze] End Reading SiStripPedestals"

--- a/CondTools/SiStrip/plugins/SiStripPedestalsReader.h
+++ b/CondTools/SiStrip/plugins/SiStripPedestalsReader.h
@@ -6,7 +6,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -22,10 +22,10 @@
 #include <cstdio>
 #include <sys/time.h>
 
-class SiStripPedestalsReader : public edm::EDAnalyzer {
+class SiStripPedestalsReader : public edm::one::EDAnalyzer<> {
 public:
   explicit SiStripPedestalsReader(const edm::ParameterSet&);
-  ~SiStripPedestalsReader() override;
+  ~SiStripPedestalsReader() override = default;
 
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 

--- a/CondTools/SiStrip/plugins/SiStripSummaryReader.cc
+++ b/CondTools/SiStrip/plugins/SiStripSummaryReader.cc
@@ -11,8 +11,6 @@
 SiStripSummaryReader::SiStripSummaryReader(const edm::ParameterSet& iConfig)
     : printdebug_(iConfig.getUntrackedParameter<uint32_t>("printDebug", 1)), summaryToken_(esConsumes()) {}
 
-SiStripSummaryReader::~SiStripSummaryReader() {}
-
 void SiStripSummaryReader::analyze(const edm::Event& e, const edm::EventSetup& iSetup) {
   const auto& summary = iSetup.getData(summaryToken_);
   edm::LogInfo("SiStripSummaryReader") << "[SiStripSummaryReader::analyze] End Reading SiStripSummary" << std::endl;

--- a/CondTools/SiStrip/plugins/SiStripSummaryReader.h
+++ b/CondTools/SiStrip/plugins/SiStripSummaryReader.h
@@ -6,7 +6,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -17,10 +17,10 @@
 #include "CondFormats/DataRecord/interface/SiStripSummaryRcd.h"
 class SiStripSummary;
 
-class SiStripSummaryReader : public edm::EDAnalyzer {
+class SiStripSummaryReader : public edm::one::EDAnalyzer<> {
 public:
   explicit SiStripSummaryReader(const edm::ParameterSet&);
-  ~SiStripSummaryReader() override;
+  ~SiStripSummaryReader() override = default;
 
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 

--- a/CondTools/SiStrip/plugins/SiStripThresholdReader.cc
+++ b/CondTools/SiStrip/plugins/SiStripThresholdReader.cc
@@ -7,8 +7,6 @@ using namespace cms;
 SiStripThresholdReader::SiStripThresholdReader(const edm::ParameterSet& iConfig)
     : printdebug_(iConfig.getUntrackedParameter<uint32_t>("printDebug", 3)), thresholdToken_(esConsumes()) {}
 
-SiStripThresholdReader::~SiStripThresholdReader() {}
-
 void SiStripThresholdReader::analyze(const edm::Event& e, const edm::EventSetup& iSetup) {
   const auto& thresholds = iSetup.getData(thresholdToken_);
   edm::LogInfo("SiStripThresholdReader") << "[SiStripThresholdReader::analyze] End Reading SiStripThreshold"

--- a/CondTools/SiStrip/plugins/SiStripThresholdReader.h
+++ b/CondTools/SiStrip/plugins/SiStripThresholdReader.h
@@ -6,7 +6,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -22,10 +22,10 @@
 #include <cstdio>
 #include <sys/time.h>
 
-class SiStripThresholdReader : public edm::EDAnalyzer {
+class SiStripThresholdReader : public edm::one::EDAnalyzer<> {
 public:
   explicit SiStripThresholdReader(const edm::ParameterSet&);
-  ~SiStripThresholdReader() override;
+  ~SiStripThresholdReader() override = default;
 
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 


### PR DESCRIPTION
resolves https://github.com/cms-AlCaDB/AlCaTools/issues/35

#### PR description:

Migrate away from the deprecated `edm::EDAnalyzer` API in `CondTools/SiStrip` and other improvements.

#### PR validation:

It compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A