### PR TITLE
Migrate module config in PhysicsTools to use default cfipython

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/genParticleAssociation_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/genParticleAssociation_cff.py
@@ -1,12 +1,13 @@
 import FWCore.ParameterSet.Config as cms
+import SimTracker.TrackAssociation.packedCandidatesGenAssociationDefault_cfi as _mod
 
-packedPFCandidateToGenAssociation = cms.EDProducer("PackedCandidateGenAssociationProducer",
-    trackToGenAssoc = cms.InputTag("prunedTrackMCMatch"),
+packedPFCandidateToGenAssociation = _mod.packedCandidatesGenAssociationDefault.clone(
+    trackToGenAssoc = "prunedTrackMCMatch",
 )
 
-lostTracksToGenAssociation = cms.EDProducer("PackedCandidateGenAssociationProducer",
-    trackToGenAssoc = cms.InputTag("prunedTrackMCMatch"),
-    trackToPackedCandidatesAssoc = cms.InputTag("lostTracks")
+lostTracksToGenAssociation = _mod.packedCandidatesGenAssociationDefault.clone(
+    trackToGenAssoc = "prunedTrackMCMatch",
+    trackToPackedCandidatesAssoc = "lostTracks"
 )
 
 packedCandidateToGenAssociationTask = cms.Task(packedPFCandidateToGenAssociation,lostTracksToGenAssociation)

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -7,7 +7,8 @@ from PhysicsTools.PatAlgos.tools.helpers import getPatAlgosToolsTask, addToProce
 from PhysicsTools.PatAlgos.tools.jetTools import switchJetCollection
 import CommonTools.CandAlgos.candPtrProjector_cfi as _mod
 from PhysicsTools.PatUtils.tools.pfforTrkMET_cff import *
-
+import JetMETCorrections.Type1MET.BadPFCandidateJetsEEnoiseProducer_cfi as _modbad
+import JetMETCorrections.Type1MET.UnclusteredBlobProducer_cfi as _modunc
 
 def isValidInputTag(input):
     input_str = input
@@ -1897,12 +1898,12 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
 
         task = getPatAlgosToolsTask(process)
 
-        pfCandidateJetsWithEEnoise = cms.EDProducer("BadPFCandidateJetsEEnoiseProducer",
+        pfCandidateJetsWithEEnoise = _modbad.BadPFCandidateJetsEEnoiseProducer.clone(
             jetsrc = jets,
-            userawPt = cms.bool(params["userawPt"]),
-            ptThreshold = cms.double(params["ptThreshold"]),
-            minEtaThreshold = cms.double(params["minEtaThreshold"]),
-            maxEtaThreshold = cms.double(params["maxEtaThreshold"]),
+            userawPt = params["userawPt"],
+            ptThreshold = params["ptThreshold"],
+            minEtaThreshold = params["minEtaThreshold"],
+            maxEtaThreshold = params["maxEtaThreshold"],
         )
         addToProcessAndTask("pfCandidateJetsWithEEnoise"+postfix, pfCandidateJetsWithEEnoise, process, task)
         patMetModuleSequence += getattr(process,"pfCandidateJetsWithEEnoise"+postfix)
@@ -1923,8 +1924,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         )
         addToProcessAndTask("badUnclustered"+postfix, badUnclustered, process, task)
         patMetModuleSequence += getattr(process,"badUnclustered"+postfix)
-        blobUnclustered = cms.EDProducer("UnclusteredBlobProducer",
-            candsrc = cms.InputTag("badUnclustered"+postfix),
+        blobUnclustered = _modunc.UnclusteredBlobProducer.clone(
+            candsrc = "badUnclustered"+postfix,
         )
         addToProcessAndTask("blobUnclustered"+postfix, blobUnclustered, process, task)
         patMetModuleSequence += getattr(process,"blobUnclustered"+postfix)


### PR DESCRIPTION
#### PR description: 
Optimization of the python configurations: Improve maintainability by cleaning up the duplicated and cloning from the default/reference configurations. 

In this PR, 2 files were changed.  
        modified:   PhysicsTools/PatAlgos/python/slimming/genParticleAssociation_cff.py
        modified:   PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py

The previous PR is #34955, #34973, #35101.

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_12_1_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).