### PR TITLE
Migrate module config in EventFilter{RPCRawToDigi} to use default cfipython

### DIFF
--- a/EventFilter/RPCRawToDigi/python/RPCCPPFRawToDigi_cfi.py
+++ b/EventFilter/RPCRawToDigi/python/RPCCPPFRawToDigi_cfi.py
@@ -1,13 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+import EventFilter.RPCRawToDigi.RPCAMCRawToDigi_cfi as _mod
 
-rpcCPPFRawToDigi = cms.EDProducer('RPCAMCRawToDigi',
-    inputTag = cms.InputTag('rawDataCollector'),
-    calculateCRC = cms.bool(True),
-    fillCounters = cms.bool(True),
-    RPCAMCUnpacker = cms.string('RPCCPPFUnpacker'),
-    RPCAMCUnpackerSettings = cms.PSet(
-        fillAMCCounters = cms.bool(True),
-        bxMin = cms.int32(-2),
-        bxMax = cms.int32(2)
-    )
+rpcCPPFRawToDigi = _mod.RPCAMCRawToDigi.clone(
+    RPCAMCUnpacker = 'RPCCPPFUnpacker',
+    RPCAMCUnpackerSettings = dict()
 )


### PR DESCRIPTION
#### PR description: 
Optimization of the python configurations: Improve maintainability by cleaning up the duplicated and cloning from the default/reference configurations. 

In this PR, 2 files were changed.  
        modified:  EventFilter/RPCRawToDigi/python/RPCCPPFRawToDigi_cfi.py

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_12_1_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).