### PR TITLE
Migrate module config in SimTracker to use default cfipython

### DIFF
--- a/SimTracker/TrackAssociation/python/digiSimLinkPruner_cfi.py
+++ b/SimTracker/TrackAssociation/python/digiSimLinkPruner_cfi.py
@@ -1,14 +1,15 @@
 import FWCore.ParameterSet.Config as cms
+import SimTracker.TrackAssociation.digiSimLinkPrunerDefault_cfi as _mod
 
-prunedDigiSimLinks = cms.EDProducer("DigiSimLinkPruner",
-    stripSimLinkSrc = cms.InputTag("simSiStripDigis"),
-    trackingParticles = cms.InputTag('prunedTrackingParticles')
+prunedDigiSimLinks = _mod.digiSimLinkPrunerDefault.clone(
+    stripSimLinkSrc = "simSiStripDigis",
+    trackingParticles = "prunedTrackingParticles"
 )
 
-_prunedDigiSimLinks_phase2 = cms.EDProducer("DigiSimLinkPruner",
-    pixelSimLinkSrc = cms.InputTag("simSiPixelDigis", "Pixel"),
-    phase2OTSimLinkSrc = cms.InputTag("simSiPixelDigis","Tracker"),
-    trackingParticles = cms.InputTag('prunedTrackingParticles')
+_prunedDigiSimLinks_phase2 = _mod.digiSimLinkPrunerDefault.clone(
+    pixelSimLinkSrc = "simSiPixelDigis:Pixel",
+    phase2OTSimLinkSrc = "simSiPixelDigis:Tracker",
+    trackingParticles = "prunedTrackingParticles"
 )
 
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker

--- a/SimTracker/TrackAssociation/python/trackingParticlePrunerByGen_cfi.py
+++ b/SimTracker/TrackAssociation/python/trackingParticlePrunerByGen_cfi.py
@@ -1,10 +1,11 @@
 import FWCore.ParameterSet.Config as cms
+import SimTracker.TrackAssociation.tpSelectorByGenDefault_cfi as _mod
 
-prunedTrackingParticles = cms.EDProducer("TrackingParticleSelectorByGen",
-    select = cms.vstring(
+prunedTrackingParticles = _mod.tpSelectorByGenDefault.clone(
+    select = [
         "drop  *", # this is the default
         "keep++ (400 < abs(pdgId) < 600) || (4000 < abs(pdgId) < 6000)",   # keep decays for BPH studies
         "drop status != 1",                                                # keep only status == 1
         "drop charge == 0"
-    )
+    ]
 )


### PR DESCRIPTION
#### PR description: 
Optimization of the python configurations: Improve maintainability by cleaning up the duplicated and cloning from the default/reference configurations. 

In this PR, 2 files were changed.  
        modified:   SimTracker/TrackAssociation/python/digiSimLinkPruner_cfi.py
        modified:   SimTracker/TrackAssociation/python/trackingParticlePrunerByGen_cfi.py

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_12_1_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).