### PR TITLE
PPS: misaligned geometry built only optionally, off by default

### DIFF
--- a/Geometry/VeryForwardGeometryBuilder/plugins/CTPPSGeometryESModule.cc
+++ b/Geometry/VeryForwardGeometryBuilder/plugins/CTPPSGeometryESModule.cc
@@ -77,6 +77,7 @@ private:
                                          const char* name);
 
   const unsigned int verbosity_;
+  const bool buildMisalignedGeometry_;
   const bool isRun2_;
 
   edm::ESGetToken<DDCompactView, IdealGeometryRecord> ddToken_;
@@ -95,6 +96,7 @@ private:
 
 CTPPSGeometryESModule::CTPPSGeometryESModule(const edm::ParameterSet& iConfig)
     : verbosity_(iConfig.getUntrackedParameter<unsigned int>("verbosity")),
+      buildMisalignedGeometry_(iConfig.getParameter<bool>("buildMisalignedGeometry")),
       isRun2_(iConfig.getParameter<bool>("isRun2")),
       fromPreprocessedDB_(iConfig.getUntrackedParameter<bool>("fromPreprocessedDB", false)),
       fromDD4hep_(iConfig.getUntrackedParameter<bool>("fromDD4hep", false)) {
@@ -106,9 +108,11 @@ CTPPSGeometryESModule::CTPPSGeometryESModule(const edm::ParameterSet& iConfig)
     idealDBGDToken_ = c1.consumesFrom<DetGeomDesc, VeryForwardIdealGeometryRecord>(edm::ESInputTag());
     realAlignmentToken_ = c1.consumesFrom<CTPPSRPAlignmentCorrectionsData, RPRealAlignmentRecord>(edm::ESInputTag());
 
-    auto c2 = setWhatProduced(this, &CTPPSGeometryESModule::produceMisalignedGDFromPreprocessedDB);
-    misAlignmentToken_ =
-        c2.consumesFrom<CTPPSRPAlignmentCorrectionsData, RPMisalignedAlignmentRecord>(edm::ESInputTag());
+    if (buildMisalignedGeometry_) {
+      auto c2 = setWhatProduced(this, &CTPPSGeometryESModule::produceMisalignedGDFromPreprocessedDB);
+      misAlignmentToken_ =
+          c2.consumesFrom<CTPPSRPAlignmentCorrectionsData, RPMisalignedAlignmentRecord>(edm::ESInputTag());
+    }
   } else if (!fromDD4hep_) {
     auto c = setWhatProduced(this, &CTPPSGeometryESModule::produceIdealGD);
     ddToken_ = c.consumes<DDCompactView>(edm::ESInputTag("", iConfig.getParameter<std::string>("compactViewTag")));
@@ -117,9 +121,11 @@ CTPPSGeometryESModule::CTPPSGeometryESModule(const edm::ParameterSet& iConfig)
     idealGDToken_ = c1.consumesFrom<DetGeomDesc, IdealGeometryRecord>(edm::ESInputTag());
     realAlignmentToken_ = c1.consumesFrom<CTPPSRPAlignmentCorrectionsData, RPRealAlignmentRecord>(edm::ESInputTag());
 
-    auto c2 = setWhatProduced(this, &CTPPSGeometryESModule::produceMisalignedGD);
-    misAlignmentToken_ =
-        c2.consumesFrom<CTPPSRPAlignmentCorrectionsData, RPMisalignedAlignmentRecord>(edm::ESInputTag());
+    if (buildMisalignedGeometry_) {
+      auto c2 = setWhatProduced(this, &CTPPSGeometryESModule::produceMisalignedGD);
+      misAlignmentToken_ =
+          c2.consumesFrom<CTPPSRPAlignmentCorrectionsData, RPMisalignedAlignmentRecord>(edm::ESInputTag());
+    }
   } else {
     auto c = setWhatProduced(this, &CTPPSGeometryESModule::produceIdealGD);
     dd4hepToken_ =
@@ -129,21 +135,26 @@ CTPPSGeometryESModule::CTPPSGeometryESModule(const edm::ParameterSet& iConfig)
     idealGDToken_ = c1.consumesFrom<DetGeomDesc, IdealGeometryRecord>(edm::ESInputTag());
     realAlignmentToken_ = c1.consumesFrom<CTPPSRPAlignmentCorrectionsData, RPRealAlignmentRecord>(edm::ESInputTag());
 
-    auto c2 = setWhatProduced(this, &CTPPSGeometryESModule::produceMisalignedGD);
-    misAlignmentToken_ =
-        c2.consumesFrom<CTPPSRPAlignmentCorrectionsData, RPMisalignedAlignmentRecord>(edm::ESInputTag());
+    if (buildMisalignedGeometry_) {
+      auto c2 = setWhatProduced(this, &CTPPSGeometryESModule::produceMisalignedGD);
+      misAlignmentToken_ =
+          c2.consumesFrom<CTPPSRPAlignmentCorrectionsData, RPMisalignedAlignmentRecord>(edm::ESInputTag());
+    }
   }
 
   auto c_RTG = setWhatProduced(this, &CTPPSGeometryESModule::produceRealTG);
   dgdRealToken_ = c_RTG.consumes<DetGeomDesc>(edm::ESInputTag());
 
-  auto c_MTG = setWhatProduced(this, &CTPPSGeometryESModule::produceMisalignedTG);
-  dgdMisToken_ = c_MTG.consumes<DetGeomDesc>(edm::ESInputTag());
+  if (buildMisalignedGeometry_) {
+    auto c_MTG = setWhatProduced(this, &CTPPSGeometryESModule::produceMisalignedTG);
+    dgdMisToken_ = c_MTG.consumes<DetGeomDesc>(edm::ESInputTag());
+  }
 }
 
 void CTPPSGeometryESModule::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.addUntracked<unsigned int>("verbosity", 1);
+  desc.add<bool>("buildMisalignedGeometry", false)->setComment("switch if misaligned geometry shall be built");
   desc.add<bool>("isRun2", false)->setComment("Switch to legacy (2017-18) definition of diamond geometry");
   desc.add<std::string>("dbTag", std::string());
   desc.add<std::string>("compactViewTag", std::string());


### PR DESCRIPTION
#### PR description:

This PR adds a flag to `CTPPSGeometryESModule` whether the "misaligned" geometry shall be built. The flag is set to false by default. The motivation for this change includes:
  * the "misaligned" geometry is only used in special alignment studies,
  * the "misaligned" geometry causes problems in PPS HLT workflows (in progress), probably due to missing conditions data in the DB.

This PR is expected to be fully backward compatible, with no impact on the results from standard workflows. The (mis)alignment studies have so far been performed with the "direct" simulation of PPS, which uses `CTPPSCompositeESSource` instead of `CTPPSGeometryESModule`. The direct simulation is thus not affected by this PR.

No backports are foreseen.

#### PR validation:
The plots below compare histograms produced before this PR (blue) and with this PR (red dashed):
  * direct simulation WFs: [dirsim_cmp.pdf](https://github.com/cms-sw/cmssw/files/7234888/dirsim_cmp.pdf) -- no difference as expected.
  * Run2 reconstruction WFs: [reco_cmp.pdf](https://github.com/cms-sw/cmssw/files/7234889/reco_cmp.pdf) -- no difference as expected.
