### PR TITLE
Bug fix for Esinput tag creation in PCaloGeometryBuilder

### DIFF
--- a/CondTools/Geometry/plugins/PCaloGeometryBuilder.cc
+++ b/CondTools/Geometry/plugins/PCaloGeometryBuilder.cc
@@ -21,14 +21,15 @@ public:
         m_ecalP(pset.getUntrackedParameter<bool>("EcalP", true)),
         m_hgcal(pset.getUntrackedParameter<bool>("HGCal", false)) {
     const std::string toDB("_toDB");
-    ebGeomToken_ = esConsumes<edm::Transition::BeginRun>(edm::ESInputTag(EcalBarrelGeometry::producerTag() + toDB));
-    eeGeomToken_ = esConsumes<edm::Transition::BeginRun>(edm::ESInputTag(EcalEndcapGeometry::producerTag() + toDB));
-    esGeomToken_ = esConsumes<edm::Transition::BeginRun>(edm::ESInputTag(EcalPreshowerGeometry::producerTag() + toDB));
-    hgcalGeomToken_ = esConsumes<edm::Transition::BeginRun>(edm::ESInputTag(HGCalGeometry::producerTag() + toDB));
-    hcalGeomToken_ = esConsumes<edm::Transition::BeginRun>(edm::ESInputTag(HcalGeometry::producerTag() + toDB));
-    ctGeomToken_ = esConsumes<edm::Transition::BeginRun>(edm::ESInputTag(CaloTowerGeometry::producerTag() + toDB));
-    zdcGeomToken_ = esConsumes<edm::Transition::BeginRun>(edm::ESInputTag(ZdcGeometry::producerTag() + toDB));
-    castGeomToken_ = esConsumes<edm::Transition::BeginRun>(edm::ESInputTag(CastorGeometry::producerTag() + toDB));
+    ebGeomToken_ = esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", EcalBarrelGeometry::producerTag() + toDB));
+    eeGeomToken_ = esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", EcalEndcapGeometry::producerTag() + toDB));
+    esGeomToken_ =
+        esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", EcalPreshowerGeometry::producerTag() + toDB));
+    hgcalGeomToken_ = esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", HGCalGeometry::producerTag() + toDB));
+    hcalGeomToken_ = esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", HcalGeometry::producerTag() + toDB));
+    ctGeomToken_ = esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", CaloTowerGeometry::producerTag() + toDB));
+    zdcGeomToken_ = esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", ZdcGeometry::producerTag() + toDB));
+    castGeomToken_ = esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", CastorGeometry::producerTag() + toDB));
   }
 
   void beginRun(edm::Run const& iEvent, edm::EventSetup const&) override;


### PR DESCRIPTION
#### PR description:
This fixes incorrect syntax in creating an ESInputTag in ```CondTools/​Geometry/​plugins/​PCaloGeometryBuilder.cc``` as reported in [comment](https://github.com/cms-sw/cmssw/pull/35157#issuecomment-928021660)

#### PR validation:
Compiles and test config ```CondTools/Geometry/test/calogeometry2026writer.py``` runs.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
NA