### PR TITLE
ParameterizedSubtractor now calls base class implmentation

### DIFF
--- a/RecoHI/HiJetAlgos/src/ParametrizedSubtractor.cc
+++ b/RecoHI/HiJetAlgos/src/ParametrizedSubtractor.cc
@@ -62,38 +62,10 @@ void ParametrizedSubtractor::setupGeometryMap(edm::Event& iEvent, const edm::Eve
   if (bin_ < 0)
     bin_ = 0;
 
-  if (!geo_) {
-    edm::ESHandle<CaloGeometry> pG;
-    iSetup.get<CaloGeometryRecord>().get(pG);
-    geo_ = pG.product();
-    std::vector<DetId> alldid = geo_->getValidDetIds();
-
-    int ietaold = -10000;
-    ietamax_ = -10000;
-    ietamin_ = 10000;
-    for (std::vector<DetId>::const_iterator did = alldid.begin(); did != alldid.end(); did++) {
-      if ((*did).det() == DetId::Hcal) {
-        HcalDetId hid = HcalDetId(*did);
-        allgeomid_.push_back(*did);
-
-        if (hid.ieta() != ietaold) {
-          ietaold = hid.ieta();
-          geomtowers_[hid.ieta()] = 1;
-          if (hid.ieta() > ietamax_)
-            ietamax_ = hid.ieta();
-          if (hid.ieta() < ietamin_)
-            ietamin_ = hid.ieta();
-        } else {
-          geomtowers_[hid.ieta()]++;
-        }
-      }
-    }
-  }
-
+  PileUpSubtractor::setupGeometryMap(iEvent, iSetup);
   for (int i = ietamin_; i < ietamax_ + 1; i++) {
     emean_[i] = 0.;
     esigma_[i] = 0.;
-    ntowersWithJets_[i] = 0;
   }
 }
 


### PR DESCRIPTION
#### PR description:

The code previous was a cut-n-paste of the base class with some minor additions. Since the base class was updated to use esConsumes it is better to just call that implementation.

#### PR validation:

Code compiles.