### PR TITLE
Set collisionId in prunedGenParticles

### DIFF
--- a/PhysicsTools/HepMCCandAlgos/plugins/GenParticlePruner.cc
+++ b/PhysicsTools/HepMCCandAlgos/plugins/GenParticlePruner.cc
@@ -259,6 +259,7 @@ void GenParticlePruner::produce(Event &evt, const EventSetup &es) {
     GenParticle &newGen = out->back();
     //fill status flags
     newGen.statusFlags() = gen.statusFlags();
+    newGen.setCollisionId(gen.collisionId());
     // The "daIndxs" and "moIndxs" keep a list of the keys for the mother/daughter
     // parentage/descendency. In some cases, a circular referencing is encountered,
     // which would result in an infinite loop. The list is checked to


### PR DESCRIPTION
#### PR description:

The collisionID field is set for genParticles, but not for prunedGenParticles. 
This variable is needed for heavy-ion event overlay workflows. 

#### PR validation:

Tested with workflow 301.  collisionId appears filled in resulting output. 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Will need to backport this to 11_2_X. 

