### PR TITLE
Beamspot DIP server (normal DQM client)

### DIFF
--- a/DQM/BeamMonitor/plugins/BeamSpotDipServer.cc
+++ b/DQM/BeamMonitor/plugins/BeamSpotDipServer.cc
@@ -19,32 +19,31 @@
 
 using namespace std;
 
-/*****************************************************************************/ 
+/*****************************************************************************/
 class ErrHandler : public DipPublicationErrorHandler {
- public:
+public:
   virtual ~ErrHandler() = default;
- private:
+
+private:
   void handleException(DipPublication* publication, DipException& e) override {
-    edm::LogError("BeamSpotDipServer")
-      << "exception (create): " << e.what();
+    edm::LogError("BeamSpotDipServer") << "exception (create): " << e.what();
   }
 };
 
-/*****************************************************************************/ 
-BeamSpotDipServer::BeamSpotDipServer(const edm::ParameterSet& ps)
-{
+/*****************************************************************************/
+BeamSpotDipServer::BeamSpotDipServer(const edm::ParameterSet& ps) {
   //
   verbose = ps.getUntrackedParameter<bool>("verbose");
   testing = ps.getUntrackedParameter<bool>("testing");
 
-  subjectCMS = ps.getUntrackedParameter<string>("subjectCMS"); 
-  subjectLHC = ps.getUntrackedParameter<string>("subjectLHC"); 
-  subjectPV  = ps.getUntrackedParameter<string>("subjectPV" ); 
+  subjectCMS = ps.getUntrackedParameter<string>("subjectCMS");
+  subjectLHC = ps.getUntrackedParameter<string>("subjectLHC");
+  subjectPV = ps.getUntrackedParameter<string>("subjectPV");
 
   readFromNFS = ps.getUntrackedParameter<bool>("readFromNFS");
   // only if readFromNFS = true
-  sourceFile  = ps.getUntrackedParameter<string>("sourceFile" ); // beamspot
-  sourceFile1 = ps.getUntrackedParameter<string>("sourceFile1"); // tk status
+  sourceFile = ps.getUntrackedParameter<string>("sourceFile");    // beamspot
+  sourceFile1 = ps.getUntrackedParameter<string>("sourceFile1");  // tk status
 
   timeoutLS = ps.getUntrackedParameter<vector<int>>("timeoutLS");
 
@@ -56,204 +55,172 @@ BeamSpotDipServer::BeamSpotDipServer(const edm::ParameterSet& ps)
 
   //
   dip = Dip::create("CmsBeamSpotServer");
-  edm::LogInfo("BeamSpotDipServer")
-    << "reading from " << (readFromNFS ? "file (NFS)" : "database");
+  edm::LogInfo("BeamSpotDipServer") << "reading from " << (readFromNFS ? "file (NFS)" : "database");
 }
 
-/*****************************************************************************/ 
-void BeamSpotDipServer::bookHistograms(
-  DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&)
-{
+/*****************************************************************************/
+void BeamSpotDipServer::bookHistograms(DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&) {
   // do nothing
 }
 
-/*****************************************************************************/ 
-void BeamSpotDipServer::dqmBeginRun(
-  const edm::Run& r, const edm::EventSetup&)
-{
+/*****************************************************************************/
+void BeamSpotDipServer::dqmBeginRun(const edm::Run& r, const edm::EventSetup&) {
   edm::LogInfo("BeamSpotDipServer") << "begin run " << r.run();
 
-  try
-  {
+  try {
     ErrHandler errHandler;
 
     edm::LogInfo("BeamSpotDipServer") << "server started at " + getDateTime();
 
     edm::LogInfo("BeamSpotDipServer") << "creating publication " + subjectCMS;
-    publicationCMS = dip->createDipPublication(subjectCMS.c_str(),&errHandler);
-        messageCMS = dip->createDipData();
+    publicationCMS = dip->createDipPublication(subjectCMS.c_str(), &errHandler);
+    messageCMS = dip->createDipData();
 
     edm::LogInfo("BeamSpotDipServer") << "creating publication " + subjectLHC;
-    publicationLHC = dip->createDipPublication(subjectLHC.c_str(),&errHandler);
-        messageLHC = dip->createDipData();
+    publicationLHC = dip->createDipPublication(subjectLHC.c_str(), &errHandler);
+    messageLHC = dip->createDipData();
 
     edm::LogInfo("BeamSpotDipServer") << "creating publication " + subjectPV;
-    publicationPV  = dip->createDipPublication(subjectPV.c_str(), &errHandler);
-        messagePV  = dip->createDipData();
+    publicationPV = dip->createDipPublication(subjectPV.c_str(), &errHandler);
+    messagePV = dip->createDipData();
 
-    trueRcd(); // starts with all 0
-    publishRcd("UNINITIALIZED","",true,false);
-  }
-  catch (exception & e)
-  {
+    trueRcd();  // starts with all 0
+    publishRcd("UNINITIALIZED", "", true, false);
+  } catch (exception& e) {
     edm::LogError("BeamSpotDipServer") << "exception (start up): " << e.what();
   }
 
-  quality = qualities[0]; // start with Uncertain
+  quality = qualities[0];  // start with Uncertain
 }
 
-/*****************************************************************************/ 
-void BeamSpotDipServer::dqmBeginLuminosityBlock(
-  const edm::LuminosityBlock&, const edm::EventSetup&)
-{
+/*****************************************************************************/
+void BeamSpotDipServer::dqmBeginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) {
   // do nothing
 }
 
-/*****************************************************************************/ 
-void BeamSpotDipServer::analyze(
-  const edm::Event& iEvent, const edm::EventSetup&)
-{
-  if(!readFromNFS)
-  {
+/*****************************************************************************/
+void BeamSpotDipServer::analyze(const edm::Event& iEvent, const edm::EventSetup&) {
+  if (!readFromNFS) {
     // get runnumber
     runnum = iEvent.run();
 
     // get tracker status if in a new lumisection
     int nthlumi = iEvent.luminosityBlock();
 
-    if (nthlumi > lastlumi) { // check every LS
+    if (nthlumi > lastlumi) {  // check every LS
       lastlumi = nthlumi;
 
       edm::Handle<DCSRecord> dcsRecord;
       iEvent.getByToken(dcsRecordToken_, dcsRecord);
-    
-      wholeTrackerOn = 
-        (*dcsRecord).highVoltageReady(DCSRecord::BPIX)   &&
-        (*dcsRecord).highVoltageReady(DCSRecord::FPIX)   &&
-        (*dcsRecord).highVoltageReady(DCSRecord::TIBTID) &&
-        (*dcsRecord).highVoltageReady(DCSRecord::TOB)    &&
-        (*dcsRecord).highVoltageReady(DCSRecord::TECp)   &&
-        (*dcsRecord).highVoltageReady(DCSRecord::TECm);
 
-      if(verbose)
-        edm::LogInfo("BeamSpotDipServer")
-          << "whole tracker on? " << (wholeTrackerOn ? "yes" : "no");
+      wholeTrackerOn =
+          (*dcsRecord).highVoltageReady(DCSRecord::BPIX) && (*dcsRecord).highVoltageReady(DCSRecord::FPIX) &&
+          (*dcsRecord).highVoltageReady(DCSRecord::TIBTID) && (*dcsRecord).highVoltageReady(DCSRecord::TOB) &&
+          (*dcsRecord).highVoltageReady(DCSRecord::TECp) && (*dcsRecord).highVoltageReady(DCSRecord::TECm);
+
+      if (verbose)
+        edm::LogInfo("BeamSpotDipServer") << "whole tracker on? " << (wholeTrackerOn ? "yes" : "no");
     }
   }
 }
 
-/*****************************************************************************/ 
-void BeamSpotDipServer::dqmEndLuminosityBlock(
-  const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& iSetup)
-{
-  edm::LogInfo("BeamSpotDipServer")
-    << "--------------------- end of LS " << lumiSeg.luminosityBlock();
+/*****************************************************************************/
+void BeamSpotDipServer::dqmEndLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& iSetup) {
+  edm::LogInfo("BeamSpotDipServer") << "--------------------- end of LS " << lumiSeg.luminosityBlock();
 
-  try
-  { 
-  if(readFromNFS)
-  {
-  ifstream logFile(sourceFile);
+  try {
+    if (readFromNFS) {
+      ifstream logFile(sourceFile);
 
-  if (!logFile.good()) {
-    edm::LogWarning("BeamSpotDipServer")
-      << "Source File: " + sourceFile + " doesn't exist!";
-    problem();
-  } else {
-    lastModTime = getLastTime(sourceFile);
+      if (!logFile.good()) {
+        edm::LogWarning("BeamSpotDipServer") << "Source File: " + sourceFile + " doesn't exist!";
+        problem();
+      } else {
+        lastModTime = getLastTime(sourceFile);
 
-    if (lastFitTime == 0)
-      lastFitTime = lastModTime;
+        if (lastFitTime == 0)
+          lastFitTime = lastModTime;
 
-    if(getFileSize(sourceFile) == 0) { 
-      // source file has zero length
-      if (lastModTime > lastFitTime) {
-        string tmp = tkStatus();
-        edm::LogInfo("BeamSpotDipServer")
-          << "New run starts. Run number: " << runnum;
-        if (verbose)
-          edm::LogInfo("BeamSpotDipServer")
-            << "Initial lastModTime = " + getDateTime(lastModTime);
-      }
-      lastFitTime = lastModTime;
-    }
-
-    if (lastModTime > lastFitTime) {
-      // source file modified
-      if (verbose) {
-        edm::LogInfo("BeamSpotDipServer")
-          << "time of last fit    = " + getDateTime(lastFitTime);
-        edm::LogInfo("BeamSpotDipServer")
-          << "time of current fit = " + getDateTime(lastModTime);
-      }
-      lastFitTime = lastModTime;
-
-      // source file length > 0
-      if(getFileSize(sourceFile) > 0) {
-        if (verbose)
-          edm::LogInfo("BeamSpotDipServer")
-            << "reading record from " + sourceFile;
-
-        if (readRcd(logFile)) {
-          if (verbose)
-            edm::LogInfo("BeamSpotDipServer") << "got new record from file";
-
-          trueRcd();
-          alive.reset();
-          alive.flip(7);
-        } else {
-          if (verbose)
-            edm::LogInfo("BeamSpotDipServer") << "problem with new record";
-          fakeRcd();
+        if (getFileSize(sourceFile) == 0) {
+          // source file has zero length
+          if (lastModTime > lastFitTime) {
+            string tmp = tkStatus();
+            edm::LogInfo("BeamSpotDipServer") << "New run starts. Run number: " << runnum;
+            if (verbose)
+              edm::LogInfo("BeamSpotDipServer") << "Initial lastModTime = " + getDateTime(lastModTime);
+          }
+          lastFitTime = lastModTime;
         }
 
-        lsCount = 0;
+        if (lastModTime > lastFitTime) {
+          // source file modified
+          if (verbose) {
+            edm::LogInfo("BeamSpotDipServer") << "time of last fit    = " + getDateTime(lastFitTime);
+            edm::LogInfo("BeamSpotDipServer") << "time of current fit = " + getDateTime(lastModTime);
+          }
+          lastFitTime = lastModTime;
+
+          // source file length > 0
+          if (getFileSize(sourceFile) > 0) {
+            if (verbose)
+              edm::LogInfo("BeamSpotDipServer") << "reading record from " + sourceFile;
+
+            if (readRcd(logFile)) {
+              if (verbose)
+                edm::LogInfo("BeamSpotDipServer") << "got new record from file";
+
+              trueRcd();
+              alive.reset();
+              alive.flip(7);
+            } else {
+              if (verbose)
+                edm::LogInfo("BeamSpotDipServer") << "problem with new record";
+              fakeRcd();
+            }
+
+            lsCount = 0;
+          }
+        } else {
+          // source file not touched
+          problem();
+        }
       }
-    } else {
-      // source file not touched
-      problem();
-    }
-  }
 
-  logFile.close();
-  } else {
-    edm::ESHandle<BeamSpotOnlineObjects>
-      bsLegacyHandle = iSetup.getHandle(bsLegacyToken_);
-    auto const & bs = *bsLegacyHandle; 
- 
-    // from database
-    if(readRcd(bs)) {
-      if (verbose)
-        edm::LogInfo("BeamSpotDipServer") << "got new record from database";
-      trueRcd();
-      alive.reset();
-      alive.flip(7);
+      logFile.close();
     } else {
-      if (verbose)
-        edm::LogInfo("BeamSpotDipServer") << "problem with new record";
-      fakeRcd();
+      edm::ESHandle<BeamSpotOnlineObjects> bsLegacyHandle = iSetup.getHandle(bsLegacyToken_);
+      auto const& bs = *bsLegacyHandle;
+
+      // from database
+      if (readRcd(bs)) {
+        if (verbose)
+          edm::LogInfo("BeamSpotDipServer") << "got new record from database";
+        trueRcd();
+        alive.reset();
+        alive.flip(7);
+      } else {
+        if (verbose)
+          edm::LogInfo("BeamSpotDipServer") << "problem with new record";
+        fakeRcd();
+      }
+
+      lsCount = 0;
     }
 
-    lsCount = 0;
-  }
-
-  // quality of the publish results
-  if (testing)
-     publishRcd(qualities[0],"Testing",true,true); // Uncertain
-  else if (quality == qualities[1]) // Bad
-    publishRcd(quality,"No fit or fit fails",true,true);
-  else
-    publishRcd(quality,"",true,true); // Good
-  } catch (exception & e) {
-    edm::LogWarning("BeamSpotDipServer")
-      << "io exception (end of lumi): " << e.what();
+    // quality of the publish results
+    if (testing)
+      publishRcd(qualities[0], "Testing", true, true);  // Uncertain
+    else if (quality == qualities[1])                   // Bad
+      publishRcd(quality, "No fit or fit fails", true, true);
+    else
+      publishRcd(quality, "", true, true);  // Good
+  } catch (exception& e) {
+    edm::LogWarning("BeamSpotDipServer") << "io exception (end of lumi): " << e.what();
   };
 }
 
-/*****************************************************************************/ 
-void BeamSpotDipServer::dqmEndRun(
-  const edm::Run&, const edm::EventSetup&)
-{
+/*****************************************************************************/
+void BeamSpotDipServer::dqmEndRun(const edm::Run&, const edm::EventSetup&) {
   // destroy publications and data
   edm::LogInfo("BeamSpotDipServer") << "destroying publication " + subjectCMS;
   dip->destroyDipPublication(publicationCMS);
@@ -264,34 +231,30 @@ void BeamSpotDipServer::dqmEndRun(
   delete messageLHC;
 
   edm::LogInfo("BeamSpotDipServer") << "destroying publication " + subjectPV;
-  dip->destroyDipPublication(publicationPV );
-  delete messagePV ;
+  dip->destroyDipPublication(publicationPV);
+  delete messagePV;
 }
 
-/*****************************************************************************/ 
-long BeamSpotDipServer::getFileSize(string filename)
-{
+/*****************************************************************************/
+long BeamSpotDipServer::getFileSize(string filename) {
   struct stat stat_buf;
   int rc = stat(filename.c_str(), &stat_buf);
   return (rc == 0 ? stat_buf.st_size : -1);
 }
 
-/*****************************************************************************/ 
-time_t BeamSpotDipServer::getLastTime(string filename)
-{
+/*****************************************************************************/
+time_t BeamSpotDipServer::getLastTime(string filename) {
   struct stat stat_buf;
   int rc = stat(filename.c_str(), &stat_buf);
   return (rc == 0 ? stat_buf.st_mtime : -1);
 }
 
 /*****************************************************************************/
-vector<string> BeamSpotDipServer::parse(string line, const string & delimiter)
-{
+vector<string> BeamSpotDipServer::parse(string line, const string& delimiter) {
   vector<string> list;
 
   size_t pos = 0;
-  while((pos = line.find(delimiter)) != string::npos)
-  {
+  while ((pos = line.find(delimiter)) != string::npos) {
     string token = line.substr(0, pos);
 
     list.push_back(token);
@@ -299,18 +262,16 @@ vector<string> BeamSpotDipServer::parse(string line, const string & delimiter)
     line.erase(0, pos + delimiter.length());
   }
 
-  list.push_back(line); // remainder
+  list.push_back(line);  // remainder
 
   return list;
 }
 
-/*****************************************************************************/ 
-string BeamSpotDipServer::tkStatus()
-{
+/*****************************************************************************/
+string BeamSpotDipServer::tkStatus() {
   string outstr;
 
-  if(readFromNFS)
-  { // get from file on /nfs
+  if (readFromNFS) {  // get from file on /nfs
     ifstream logfile(sourceFile1);
 
     if (!logfile.good() || getFileSize(sourceFile1) == 0) {
@@ -323,81 +284,82 @@ string BeamSpotDipServer::tkStatus()
       try {
         string record;
 
-        while (getline(logfile,record)) {
-          nthLnInRcd ++;
+        while (getline(logfile, record)) {
+          nthLnInRcd++;
           vector<string> tmp = parse(record, " ");
 
-          switch(nthLnInRcd) {
-            case 7  :
+          switch (nthLnInRcd) {
+            case 7:
               if (tmp[1].find("Yes") == string::npos)
                 outstr = "CMS Tracker OFF.";
               else
                 outstr = "CMS not taking data or no beam.";
               break;
-            case 8  : runnum = stoi(tmp[1]); break;
-            default : break;
+            case 8:
+              runnum = stoi(tmp[1]);
+              break;
+            default:
+              break;
           }
         }
-      } catch (exception & e) {
-        edm::LogWarning("BeamSpotDipServer")
-          << "exception (tkStatus): " << e.what();
+      } catch (exception& e) {
+        edm::LogWarning("BeamSpotDipServer") << "exception (tkStatus): " << e.what();
       }
     }
 
     logfile.close();
-  }
-  else
-  { 
+  } else {
     // get from DCS
-    if(wholeTrackerOn) outstr = "CMS not taking data or no beam.";
-                  else outstr = "CMS Tracker OFF.";
+    if (wholeTrackerOn)
+      outstr = "CMS not taking data or no beam.";
+    else
+      outstr = "CMS Tracker OFF.";
   }
 
   return outstr;
 }
 
-/*****************************************************************************/ 
-void BeamSpotDipServer::problem()
-{
-  if(verbose)
+/*****************************************************************************/
+void BeamSpotDipServer::problem() {
+  if (verbose)
     edm::LogInfo("BeamSpotDipServer") << "no update | alive = " << alive;
 
   lsCount++;
 
-  if ((lsCount % timeoutLS[0] == 0)
-   && (lsCount % timeoutLS[1] != 0)) // first time out
+  if ((lsCount % timeoutLS[0] == 0) && (lsCount % timeoutLS[1] != 0))  // first time out
   {
-    if (!alive.test(1)) alive.flip(1);
-    if (!alive.test(2))
-    {
-      if (!alive.test(7)) fakeRcd();
-                     else trueRcd();
+    if (!alive.test(1))
+      alive.flip(1);
+    if (!alive.test(2)) {
+      if (!alive.test(7))
+        fakeRcd();
+      else
+        trueRcd();
 
       stringstream warnMsg;
       warnMsg << "No new data for " << lsCount << " LS";
-      publishRcd("Uncertain",warnMsg.str(),false,false);
+      publishRcd("Uncertain", warnMsg.str(), false, false);
     } else {
       fakeRcd();
 
       stringstream warnMsg;
-      warnMsg << "No new data for " << lsCount << " LS: "
-               << tkStatus();
-      publishRcd("Bad",warnMsg.str(),false,false);
+      warnMsg << "No new data for " << lsCount << " LS: " << tkStatus();
+      publishRcd("Bad", warnMsg.str(), false, false);
     }
-  }
-  else if (lsCount % timeoutLS[1] == 0) // second time out
+  } else if (lsCount % timeoutLS[1] == 0)  // second time out
   {
-    if (!alive.test(2)) alive.flip(2);
+    if (!alive.test(2))
+      alive.flip(2);
     fakeRcd();
 
     stringstream warnMsg;
     warnMsg << "No new data for " << lsCount << " LS: " << tkStatus();
-    publishRcd("Bad",warnMsg.str(),false,false);
+    publishRcd("Bad", warnMsg.str(), false, false);
   }
 }
 
-/*****************************************************************************/ 
-bool BeamSpotDipServer::readRcd(const BeamSpotOnlineObjects & bs)
+/*****************************************************************************/
+bool BeamSpotDipServer::readRcd(const BeamSpotOnlineObjects& bs)
 // read from database
 {
   runnum = bs.GetLastAnalyzedRun();
@@ -405,25 +367,23 @@ bool BeamSpotDipServer::readRcd(const BeamSpotOnlineObjects & bs)
   // get from BeamSpotOnlineObject
 
   try {
-    startTime      = bs.GetStartTime();
+    startTime = bs.GetStartTime();
     startTimeStamp = bs.GetStartTimeStamp();
-      endTime      = bs.GetEndTime();
-      endTimeStamp = bs.GetEndTimeStamp();
-  } catch (exception & e) {
-    edm::LogWarning("BeamSpotDipServer")
-      << "time variables are not available (readRcd): " << e.what();
+    endTime = bs.GetEndTime();
+    endTimeStamp = bs.GetEndTimeStamp();
+  } catch (exception& e) {
+    edm::LogWarning("BeamSpotDipServer") << "time variables are not available (readRcd): " << e.what();
 
-    startTime      = bs.GetCreationTime();
+    startTime = bs.GetCreationTime();
     startTimeStamp = bs.GetCreationTime();
-      endTime      = bs.GetCreationTime();
-      endTimeStamp = bs.GetCreationTime();
+    endTime = bs.GetCreationTime();
+    endTimeStamp = bs.GetCreationTime();
   }
 
   try {
     lumiRange = bs.GetLumiRange();
-  } catch (exception & e) {
-    edm::LogWarning("BeamSpotDipServer")
-      << "lumirange variable not avaialble (readRcd): " << e.what();
+  } catch (exception& e) {
+    edm::LogWarning("BeamSpotDipServer") << "lumirange variable not avaialble (readRcd): " << e.what();
 
     lumiRange = to_string(bs.GetLastAnalyzedLumi());
   }
@@ -432,259 +392,299 @@ bool BeamSpotDipServer::readRcd(const BeamSpotOnlineObjects & bs)
 
   type = bs.GetBeamType();
 
-  if(verbose)
-    edm::LogInfo("BeamSpotDipServer")
-         << "run: "    << runnum
-         << ", LS: "   << currentLS 
-         << ", time: " << startTime << " " << startTimeStamp
-         << ", type: " << type;
+  if (verbose)
+    edm::LogInfo("BeamSpotDipServer") << "run: " << runnum << ", LS: " << currentLS << ", time: " << startTime << " "
+                                      << startTimeStamp << ", type: " << type;
 
-  if (testing)          quality = qualities[0]; // Uncertain
-  else if (type >= 2)   quality = qualities[2]; // Good
-                   else quality = qualities[1]; // Bad
+  if (testing)
+    quality = qualities[0];  // Uncertain
+  else if (type >= 2)
+    quality = qualities[2];  // Good
+  else
+    quality = qualities[1];  // Bad
 
   x = bs.GetX();
   y = bs.GetY();
   z = bs.GetZ();
 
   sigma_z = bs.GetSigmaZ();
-  dxdz    = bs.Getdxdz(); 
-  dydz    = bs.Getdydz();
+  dxdz = bs.Getdxdz();
+  dydz = bs.Getdydz();
   width_x = bs.GetBeamWidthX();
   width_y = bs.GetBeamWidthX();
 
-  err_x       = bs.GetXError();
-  err_y       = bs.GetYError();
-  err_z       = bs.GetZError();
+  err_x = bs.GetXError();
+  err_y = bs.GetYError();
+  err_z = bs.GetZError();
   err_sigma_z = bs.GetSigmaZError();
-  err_dxdz    = bs.GetdxdzError();
-  err_dydz    = bs.GetdydzError();
+  err_dxdz = bs.GetdxdzError();
+  err_dydz = bs.GetdydzError();
   err_width_x = bs.GetBeamWidthXError();
   err_width_y = bs.GetBeamWidthYError();
 
   try {
-       events = bs.GetUsedEvents();
-       meanPV = bs.GetMeanPV();
-   err_meanPV = bs.GetMeanErrorPV();
-        rmsPV = bs.GetRmsPV();
+    events = bs.GetUsedEvents();
+    meanPV = bs.GetMeanPV();
+    err_meanPV = bs.GetMeanErrorPV();
+    rmsPV = bs.GetRmsPV();
     err_rmsPV = bs.GetRmsErrorPV();
-        maxPV = bs.GetMaxPVs();
-  } catch (exception & e) {
-    edm::LogWarning("BeamSpotDipServer")
-      << "PV variables are not available (readRcd): " << e.what();
+    maxPV = bs.GetMaxPVs();
+  } catch (exception& e) {
+    edm::LogWarning("BeamSpotDipServer") << "PV variables are not available (readRcd): " << e.what();
 
-       events = 0.;
-       meanPV = 0.;
-   err_meanPV = 0.;
-        rmsPV = 0.;
+    events = 0.;
+    meanPV = 0.;
+    err_meanPV = 0.;
+    rmsPV = 0.;
     err_rmsPV = 0.;
-        maxPV = 0.;
+    maxPV = 0.;
   }
 
   nPV = bs.GetNumPVs();
 
-  if(verbose)
-    edm::LogInfo("BeamSpotDipServer")
-               << "pos: (" << x << "," << y << "," << z << ")"
-               << " nPV: " << nPV;
+  if (verbose)
+    edm::LogInfo("BeamSpotDipServer") << "pos: (" << x << "," << y << "," << z << ")"
+                                      << " nPV: " << nPV;
 
   return true;
 }
 
-/*****************************************************************************/ 
-bool BeamSpotDipServer::readRcd(ifstream & file) // readFromNFS
+/*****************************************************************************/
+bool BeamSpotDipServer::readRcd(ifstream& file)  // readFromNFS
 {
   int nthLnInRcd = 0;
   bool rcdQlty = false;
 
-  try
-  {
-  string record;
-  while (getline(file,record)) {
+  try {
+    string record;
+    while (getline(file, record)) {
+      nthLnInRcd++;
 
-  nthLnInRcd ++;
+      vector<string> tmp = parse(record, " ");
 
-  vector<string> tmp = parse(record, " ");
+      switch (nthLnInRcd) {
+        case 1:
+          if (record.rfind("Run", 0) != 0) {
+            edm::LogError("BeamSpotDipServer") << "Reading of results text file interrupted. " + getDateTime();
+            return false;
+          }
+          runnum = stoi(tmp[1]);
+          break;
+        case 2:
+          startTime = tmp[1] + " " + tmp[2] + " " + tmp[3];
+          startTimeStamp = stol(tmp[4]);
+          break;
+        case 3:
+          endTime = tmp[1] + " " + tmp[2] + " " + tmp[3];
+          endTimeStamp = stol(tmp[4]);
+          break;
+        case 4:
+          lumiRange = record.substr(10);
+          if (verbose)
+            edm::LogInfo("BeamSpotDipServer") << "lumisection range: " + lumiRange;
+          currentLS = stoi(tmp[3]);
+          break;
+        case 5:
+          type = stoi(tmp[1]);
+          if (testing)
+            quality = qualities[0];  // Uncertain
+          else if (type >= 2)
+            quality = qualities[2];  // Good
+          else
+            quality = qualities[1];  // Bad
+          break;
 
-  switch(nthLnInRcd) {
-    case 1:
-      if(record.rfind("Run", 0) != 0) {
-        edm::LogError("BeamSpotDipServer")
-          << "Reading of results text file interrupted. " + getDateTime();
-        return false;
+        case 6:
+          x = stof(tmp[1]);
+          break;
+        case 7:
+          y = stof(tmp[1]);
+          break;
+        case 8:
+          z = stof(tmp[1]);
+          break;
+
+        case 9:
+          sigma_z = stof(tmp[1]);
+          break;
+        case 10:
+          dxdz = stof(tmp[1]);
+          break;
+        case 11:
+          dydz = stof(tmp[1]);
+          break;
+        case 12:
+          width_x = stof(tmp[1]);
+          break;
+        case 13:
+          width_y = stof(tmp[1]);
+          break;
+
+        case 14:
+          err_x = sqrt(stof(tmp[1]));
+          break;
+        case 15:
+          err_y = sqrt(stof(tmp[2]));
+          break;
+        case 16:
+          err_z = sqrt(stof(tmp[3]));
+          break;
+        case 17:
+          err_sigma_z = sqrt(stof(tmp[4]));
+          break;
+        case 18:
+          err_dxdz = sqrt(stof(tmp[5]));
+          break;
+        case 19:
+          err_dydz = sqrt(stof(tmp[6]));
+          break;
+        case 20:
+          err_width_x = sqrt(stof(tmp[7]));
+          err_width_y = err_width_x;
+          break;
+        case 21:
+          break;
+        case 22:
+          break;
+        case 23:
+          break;
+        case 24:
+          events = stoi(tmp[1]);
+          break;
+
+        case 25:
+          meanPV = stof(tmp[1]);
+          break;
+        case 26:
+          err_meanPV = stof(tmp[1]);
+          break;
+        case 27:
+          rmsPV = stof(tmp[1]);
+          break;
+        case 28:
+          err_rmsPV = stof(tmp[1]);
+          break;
+        case 29:
+          maxPV = stoi(tmp[1]);
+          break;
+        case 30:
+          nPV = stoi(tmp[1]);
+          rcdQlty = true;
+          break;
+
+        default:
+          break;
       }
-      runnum = stoi(tmp[1]);
-      break;
-    case 2:
-      startTime = tmp[1]+" "+tmp[2]+" "+tmp[3]; startTimeStamp = stol(tmp[4]);
-      break;
-    case 3:
-      endTime   = tmp[1]+" "+tmp[2]+" "+tmp[3]; endTimeStamp   = stol(tmp[4]);
-      break;
-    case 4:
-      lumiRange = record.substr(10);
-      if(verbose)
-        edm::LogInfo("BeamSpotDipServer") << "lumisection range: " + lumiRange;
-      currentLS = stoi(tmp[3]);
-      break;
-    case 5:
-      type = stoi(tmp[1]);
-      if (testing)          quality = qualities[0]; // Uncertain
-      else if (type >= 2)   quality = qualities[2]; // Good
-                       else quality = qualities[1]; // Bad
-      break;
+    }
 
-    case 6: x = stof(tmp[1]); break;
-    case 7: y = stof(tmp[1]); break;
-    case 8: z = stof(tmp[1]); break;
-
-    case 9: sigma_z  = stof(tmp[1]); break;
-    case 10: dxdz    = stof(tmp[1]); break;
-    case 11: dydz    = stof(tmp[1]); break;
-    case 12: width_x = stof(tmp[1]); break;
-    case 13: width_y = stof(tmp[1]); break;
-
-    case 14: err_x       = sqrt(stof(tmp[1])); break;
-    case 15: err_y       = sqrt(stof(tmp[2])); break;
-    case 16: err_z       = sqrt(stof(tmp[3])); break;
-    case 17: err_sigma_z = sqrt(stof(tmp[4])); break;
-    case 18: err_dxdz    = sqrt(stof(tmp[5])); break;
-    case 19: err_dydz    = sqrt(stof(tmp[6])); break;
-    case 20: err_width_x = sqrt(stof(tmp[7]));
-            err_width_y = err_width_x; break;
-    case 21: break;
-    case 22: break;
-    case 23: break;
-    case 24: events = stoi(tmp[1]); break;
-
-    case 25:     meanPV = stof(tmp[1]); break;
-    case 26: err_meanPV = stof(tmp[1]); break;
-    case 27:      rmsPV = stof(tmp[1]); break;
-    case 28:  err_rmsPV = stof(tmp[1]); break;
-    case 29:      maxPV = stoi(tmp[1]); break;
-    case 30:        nPV = stoi(tmp[1]); rcdQlty = true; break;
-
-    default: break;
-  }
-  }
-
-  file.close();
-  } catch (exception & e) {
-    edm::LogWarning("BeamSpotDipServer")
-      << "io exception (readRcd): " << e.what();
+    file.close();
+  } catch (exception& e) {
+    edm::LogWarning("BeamSpotDipServer") << "io exception (readRcd): " << e.what();
   }
 
   return rcdQlty;
 }
 
-/*****************************************************************************/ 
-void BeamSpotDipServer::CMS2LHCRF_POS(float x, float y, float z)
-{
-  if (x != 0) { // Rotation + Translation + Inversion + Scaling
+/*****************************************************************************/
+void BeamSpotDipServer::CMS2LHCRF_POS(float x, float y, float z) {
+  if (x != 0) {  // Rotation + Translation + Inversion + Scaling
     double tmpx = x;
     // x*rotY[0]*rotZ[0] + y*rotY[0]*rotZ[1] - z*rotY[1] + trans[0];
     Centroid[0] = tmpx;
-    Centroid[0] *= -1.0*cm2um;
-  }
-  else
+    Centroid[0] *= -1.0 * cm2um;
+  } else
     Centroid[0] = x;
 
-  if (y != 0) { // Rotation + Translation + Scaling
+  if (y != 0) {  // Rotation + Translation + Scaling
     double tmpy = y;
     // x*(rotX[1]*rotY[1]*rotZ[0] - rotX[0]*rotZ[1]) +
     // y*(rotX[0]*rotZ[0] + rotX[1]*rotY[1]*rotZ[1]) +
     // z*rotX[1]*rotY[0] + trans[1];
     Centroid[1] = tmpy;
     Centroid[1] *= cm2um;
-  }
-  else
+  } else
     Centroid[1] = y;
 
-  if (z != 0) { // Rotation + Translation + Inversion + Scaling
+  if (z != 0) {  // Rotation + Translation + Inversion + Scaling
     double tmpz = z;
     // x*(rotX[0]*rotY[1]*rotZ[0] + rotX[1]*rotZ[1]) +
     // y*(rotX[0]*rotY[1]*rotZ[1] - rotX[1]*rotZ[0]) +
     // z*rotX[0]*rotY[0] + trans[2];
     Centroid[2] = tmpz;
-    Centroid[2] *= -1.0*cm2mm;
-  }
-  else
+    Centroid[2] *= -1.0 * cm2mm;
+  } else
     Centroid[2] = z;
 }
 
-/*****************************************************************************/ 
-void BeamSpotDipServer::trueRcd()
-{
-  try
-  {
+/*****************************************************************************/
+void BeamSpotDipServer::trueRcd() {
+  try {
     // CMS to LHC RF
-    CMS2LHCRF_POS(x,y,z);
+    CMS2LHCRF_POS(x, y, z);
 
-    Tilt[0] = dxdz*rad2urad;
-    Tilt[1] = (dydz != 0 ? (dydz*-1*rad2urad) : 0);
+    Tilt[0] = dxdz * rad2urad;
+    Tilt[1] = (dydz != 0 ? (dydz * -1 * rad2urad) : 0);
 
-    Size[0] = width_x*cm2um;
-    Size[1] = width_y*cm2um;
-    Size[2] = sigma_z*cm2mm;
+    Size[0] = width_x * cm2um;
+    Size[1] = width_y * cm2um;
+    Size[2] = sigma_z * cm2mm;
 
     // CMS
-    messageCMS->insert(runnum,"runnum");
-    messageCMS->insert(startTime,"startTime");
-    messageCMS->insert(endTime,"endTime");
-    messageCMS->insert(startTimeStamp,"startTimeStamp");
-    messageCMS->insert(endTimeStamp,"endTimeStamp");
-    messageCMS->insert(lumiRange,"lumiRange");
-    messageCMS->insert(quality,"quality");
-    messageCMS->insert(type,"type"); // Unknown=-1, Fake=0, Tracker=2(Good)
-    messageCMS->insert(x,"x");
-    messageCMS->insert(y,"y");
-    messageCMS->insert(z,"z");
-    messageCMS->insert(dxdz,"dxdz");
-    messageCMS->insert(dydz,"dydz");
-    messageCMS->insert(width_x,"width_x");
-    messageCMS->insert(width_y,"width_y");
-    messageCMS->insert(sigma_z,"sigma_z");
+    messageCMS->insert(runnum, "runnum");
+    messageCMS->insert(startTime, "startTime");
+    messageCMS->insert(endTime, "endTime");
+    messageCMS->insert(startTimeStamp, "startTimeStamp");
+    messageCMS->insert(endTimeStamp, "endTimeStamp");
+    messageCMS->insert(lumiRange, "lumiRange");
+    messageCMS->insert(quality, "quality");
+    messageCMS->insert(type, "type");  // Unknown=-1, Fake=0, Tracker=2(Good)
+    messageCMS->insert(x, "x");
+    messageCMS->insert(y, "y");
+    messageCMS->insert(z, "z");
+    messageCMS->insert(dxdz, "dxdz");
+    messageCMS->insert(dydz, "dydz");
+    messageCMS->insert(width_x, "width_x");
+    messageCMS->insert(width_y, "width_y");
+    messageCMS->insert(sigma_z, "sigma_z");
 
     if (publishStatErrors) {
-      messageCMS->insert(err_x,"err_x");
-      messageCMS->insert(err_y,"err_y");
-      messageCMS->insert(err_z,"err_z");
-      messageCMS->insert(err_dxdz,"err_dxdz");
-      messageCMS->insert(err_dydz,"err_dydz");
-      messageCMS->insert(err_width_x,"err_width_x");
-      messageCMS->insert(err_width_y,"err_width_y");
-      messageCMS->insert(err_sigma_z,"err_sigma_z");
+      messageCMS->insert(err_x, "err_x");
+      messageCMS->insert(err_y, "err_y");
+      messageCMS->insert(err_z, "err_z");
+      messageCMS->insert(err_dxdz, "err_dxdz");
+      messageCMS->insert(err_dydz, "err_dydz");
+      messageCMS->insert(err_width_x, "err_width_x");
+      messageCMS->insert(err_width_y, "err_width_y");
+      messageCMS->insert(err_sigma_z, "err_sigma_z");
     }
 
     // LHC
-    messageLHC->insert(Size,3,"Size");
-    messageLHC->insert(Centroid,3,"Centroid");
-    messageLHC->insert(Tilt,2,"Tilt");
+    messageLHC->insert(Size, 3, "Size");
+    messageLHC->insert(Centroid, 3, "Centroid");
+    messageLHC->insert(Tilt, 2, "Tilt");
 
     // PV
-    messagePV->insert(runnum,"runnum");
-    messagePV->insert(startTime,"startTime");
-    messagePV->insert(endTime,"endTime");
-    messagePV->insert(startTimeStamp,"startTimeStamp");
-    messagePV->insert(endTimeStamp,"endTimeStamp");
-    messagePV->insert(lumiRange,"lumiRange");
-    messagePV->insert(events,"events");
-    messagePV->insert(meanPV,"meanPV");
-    messagePV->insert(err_meanPV,"err_meanPV");
-    messagePV->insert(rmsPV,"rmsPV");
-    messagePV->insert(err_rmsPV,"err_rmsPV");
-    messagePV->insert(maxPV,"maxPV");
-    messagePV->insert(nPV,"nPV");
-  } catch (exception & e){
+    messagePV->insert(runnum, "runnum");
+    messagePV->insert(startTime, "startTime");
+    messagePV->insert(endTime, "endTime");
+    messagePV->insert(startTimeStamp, "startTimeStamp");
+    messagePV->insert(endTimeStamp, "endTimeStamp");
+    messagePV->insert(lumiRange, "lumiRange");
+    messagePV->insert(events, "events");
+    messagePV->insert(meanPV, "meanPV");
+    messagePV->insert(err_meanPV, "err_meanPV");
+    messagePV->insert(rmsPV, "rmsPV");
+    messagePV->insert(err_rmsPV, "err_rmsPV");
+    messagePV->insert(maxPV, "maxPV");
+    messagePV->insert(nPV, "nPV");
+  } catch (exception& e) {
     edm::LogWarning("BeamSpotDipServer") << "exception (trueRcd): " << e.what();
   }
 }
 
-/*****************************************************************************/ 
-void BeamSpotDipServer::fakeRcd()
-{
-  try
-  {
+/*****************************************************************************/
+void BeamSpotDipServer::fakeRcd() {
+  try {
     Centroid[0] = 0;
     Centroid[1] = 0;
     Centroid[2] = 0;
@@ -696,77 +696,69 @@ void BeamSpotDipServer::fakeRcd()
     Tilt[0] = 0;
     Tilt[1] = 0;
 
-    messageLHC->insert(Size,3,"Size");
-    messageLHC->insert(Centroid,3,"Centroid");
-    messageLHC->insert(Tilt,2,"Tilt");
-  } catch (exception & e){
+    messageLHC->insert(Size, 3, "Size");
+    messageLHC->insert(Centroid, 3, "Centroid");
+    messageLHC->insert(Tilt, 2, "Tilt");
+  } catch (exception& e) {
     edm::LogWarning("BeamSpotDipServer") << "exception (fakeRcd): " << e.what();
   }
 }
 
-/*****************************************************************************/ 
-void BeamSpotDipServer::publishRcd(string qlty, string err,
-                                   bool pubCMS, bool fitTime)
-{
-  try
-  {
+/*****************************************************************************/
+void BeamSpotDipServer::publishRcd(string qlty, string err, bool pubCMS, bool fitTime) {
+  try {
     bool updateCMS = pubCMS && (currentLS % intLS == 0);
 
-    if(verbose)
-    {
-      edm::LogInfo("BeamSpotDipServer")
-        << "sending (" << qlty << " | " << err << ")";
+    if (verbose) {
+      edm::LogInfo("BeamSpotDipServer") << "sending (" << qlty << " | " << err << ")";
 
       if (alive.test(7)) {
-        if (updateCMS) edm::LogInfo("BeamSpotDipServer") << " to CCC and CMS";
+        if (updateCMS)
+          edm::LogInfo("BeamSpotDipServer") << " to CCC and CMS";
         else if (!alive.test(1) && !alive.test(2))
-                       edm::LogInfo("BeamSpotDipServer") << " to CCC only";
+          edm::LogInfo("BeamSpotDipServer") << " to CCC only";
       }
     }
 
     DipTimestamp zeit;
     if (fitTime) {
       long epoch;
-      epoch = endTimeStamp*1000; // convert to ms
+      epoch = endTimeStamp * 1000;  // convert to ms
       zeit = DipTimestamp(epoch);
-    }
-    else zeit = DipTimestamp();
+    } else
+      zeit = DipTimestamp();
 
-    // send 
-    if(updateCMS)
+    // send
+    if (updateCMS)
       publicationCMS->send(messageCMS, zeit);
 
     publicationLHC->send(messageLHC, zeit);
     publicationPV->send(messagePV, zeit);
 
     // set qualities
-    if (qlty == qualities[0]) { // Uncertain
+    if (qlty == qualities[0]) {  // Uncertain
       if (updateCMS)
         publicationCMS->setQualityUncertain(err.c_str());
 
       publicationLHC->setQualityUncertain(err.c_str());
-    }
-    else if (qlty == qualities[1]) { // Bad
+    } else if (qlty == qualities[1]) {  // Bad
       if (updateCMS)
         publicationCMS->setQualityBad(err.c_str());
 
       publicationLHC->setQualityBad(err.c_str());
-    }
-    else if (qlty == "UNINITIALIZED") {
+    } else if (qlty == "UNINITIALIZED") {
       if (updateCMS)
         publicationCMS->setQualityBad("UNINITIALIZED");
 
       publicationLHC->setQualityBad("UNINITIALIZED");
     }
-  } catch (exception & e) {
-    edm::LogWarning("BeamSpotDipServer")
-      << "exception (publishRcd): " << e.what();
+  } catch (exception& e) {
+    edm::LogWarning("BeamSpotDipServer") << "exception (publishRcd): " << e.what();
   }
 }
 
-/*****************************************************************************/ 
-string BeamSpotDipServer::getDateTime(time_t t)
-{
+/*****************************************************************************/
+string BeamSpotDipServer::getDateTime(time_t t) {
   char mbstr[100];
   strftime(mbstr, sizeof(mbstr), "%Y.%m.%d %H:%M:%S %z", std::localtime(&t));
 
@@ -774,12 +766,10 @@ string BeamSpotDipServer::getDateTime(time_t t)
 }
 
 //
-string BeamSpotDipServer::getDateTime()
-{
+string BeamSpotDipServer::getDateTime() {
   time_t t = time(nullptr);
 
   return getDateTime(t);
 }
 
 DEFINE_FWK_MODULE(BeamSpotDipServer);
-

--- a/DQM/BeamMonitor/plugins/BeamSpotDipServer.cc
+++ b/DQM/BeamMonitor/plugins/BeamSpotDipServer.cc
@@ -24,7 +24,7 @@ class ErrHandler : public DipPublicationErrorHandler {
  public:
   virtual ~ErrHandler() = default;
  private:
-  void handleException(DipPublication* publication, DipException& e) {
+  void handleException(DipPublication* publication, DipException& e) override {
     edm::LogError("BeamSpotDipServer")
       << "exception (create): " << e.what();
   }
@@ -51,8 +51,6 @@ BeamSpotDipServer::BeamSpotDipServer(const edm::ParameterSet& ps)
   //
   bsLegacyToken_ = esConsumes<edm::Transition::EndLuminosityBlock>();
 
-//  dcsStatus_ = consumes<DcsStatusCollection>(
-//    ps.getUntrackedParameter<string>("DCSStatus", "scalersRawToDigi")); 
   dcsRecordInputTag_ = ps.getParameter<edm::InputTag>("dcsRecordInputTag");
   dcsRecordToken_ = consumes<DCSRecord>(dcsRecordInputTag_);
 
@@ -126,21 +124,8 @@ void BeamSpotDipServer::analyze(
     if (nthlumi > lastlumi) { // check every LS
       lastlumi = nthlumi;
 
-//      edm::Handle<DcsStatusCollection> dcsStatus;
-//      iEvent.getByToken(dcsStatus_, dcsStatus);
-
       edm::Handle<DCSRecord> dcsRecord;
       iEvent.getByToken(dcsRecordToken_, dcsRecord);
-
-//      wholeTrackerOn = true;
-//      for (auto const& status : *dcsStatus) {
-//        if (!status.ready(DcsStatus::BPIX))   wholeTrackerOn = false;
-//        if (!status.ready(DcsStatus::FPIX))   wholeTrackerOn = false;
-//        if (!status.ready(DcsStatus::TIBTID)) wholeTrackerOn = false;
-//        if (!status.ready(DcsStatus::TOB))    wholeTrackerOn = false;
-//        if (!status.ready(DcsStatus::TECp))   wholeTrackerOn = false;
-//        if (!status.ready(DcsStatus::TECm))   wholeTrackerOn = false;
-//      }
     
       wholeTrackerOn = 
         (*dcsRecord).highVoltageReady(DCSRecord::BPIX)   &&

--- a/DQM/BeamMonitor/plugins/BeamSpotDipServer.cc
+++ b/DQM/BeamMonitor/plugins/BeamSpotDipServer.cc
@@ -1,0 +1,800 @@
+#include "DQM/BeamMonitor/plugins/BeamSpotDipServer.h"
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+
+#include <fstream>
+#include <vector>
+#include <ctime>
+#include <sys/stat.h>
+
+#include "Dip.h"
+#include "DipFactory.h"
+#include "DipPublication.h"
+#include "DipTimestamp.h"
+
+using namespace std;
+
+/*****************************************************************************/ 
+class ErrHandler : public DipPublicationErrorHandler {
+ public:
+  virtual ~ErrHandler() = default;
+ private:
+  void handleException(DipPublication* publication, DipException& e) {
+    edm::LogError("BeamSpotDipServer")
+      << "exception (create): " << e.what();
+  }
+};
+
+/*****************************************************************************/ 
+BeamSpotDipServer::BeamSpotDipServer(const edm::ParameterSet& ps)
+{
+  //
+  verbose = ps.getUntrackedParameter<bool>("verbose");
+  testing = ps.getUntrackedParameter<bool>("testing");
+
+  subjectCMS = ps.getUntrackedParameter<string>("subjectCMS"); 
+  subjectLHC = ps.getUntrackedParameter<string>("subjectLHC"); 
+  subjectPV  = ps.getUntrackedParameter<string>("subjectPV" ); 
+
+  readFromNFS = ps.getUntrackedParameter<bool>("readFromNFS");
+  // only if readFromNFS = true
+  sourceFile  = ps.getUntrackedParameter<string>("sourceFile" ); // beamspot
+  sourceFile1 = ps.getUntrackedParameter<string>("sourceFile1"); // tk status
+
+  timeoutLS = ps.getUntrackedParameter<vector<int>>("timeoutLS");
+
+  //
+  bsLegacyToken_ = esConsumes<edm::Transition::EndLuminosityBlock>();
+
+//  dcsStatus_ = consumes<DcsStatusCollection>(
+//    ps.getUntrackedParameter<string>("DCSStatus", "scalersRawToDigi")); 
+  dcsRecordInputTag_ = ps.getParameter<edm::InputTag>("dcsRecordInputTag");
+  dcsRecordToken_ = consumes<DCSRecord>(dcsRecordInputTag_);
+
+  //
+  dip = Dip::create("CmsBeamSpotServer");
+  edm::LogInfo("BeamSpotDipServer")
+    << "reading from " << (readFromNFS ? "file (NFS)" : "database");
+}
+
+/*****************************************************************************/ 
+void BeamSpotDipServer::bookHistograms(
+  DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&)
+{
+  // do nothing
+}
+
+/*****************************************************************************/ 
+void BeamSpotDipServer::dqmBeginRun(
+  const edm::Run& r, const edm::EventSetup&)
+{
+  edm::LogInfo("BeamSpotDipServer") << "begin run " << r.run();
+
+  try
+  {
+    ErrHandler errHandler;
+
+    edm::LogInfo("BeamSpotDipServer") << "server started at " + getDateTime();
+
+    edm::LogInfo("BeamSpotDipServer") << "creating publication " + subjectCMS;
+    publicationCMS = dip->createDipPublication(subjectCMS.c_str(),&errHandler);
+        messageCMS = dip->createDipData();
+
+    edm::LogInfo("BeamSpotDipServer") << "creating publication " + subjectLHC;
+    publicationLHC = dip->createDipPublication(subjectLHC.c_str(),&errHandler);
+        messageLHC = dip->createDipData();
+
+    edm::LogInfo("BeamSpotDipServer") << "creating publication " + subjectPV;
+    publicationPV  = dip->createDipPublication(subjectPV.c_str(), &errHandler);
+        messagePV  = dip->createDipData();
+
+    trueRcd(); // starts with all 0
+    publishRcd("UNINITIALIZED","",true,false);
+  }
+  catch (exception & e)
+  {
+    edm::LogError("BeamSpotDipServer") << "exception (start up): " << e.what();
+  }
+
+  quality = qualities[0]; // start with Uncertain
+}
+
+/*****************************************************************************/ 
+void BeamSpotDipServer::dqmBeginLuminosityBlock(
+  const edm::LuminosityBlock&, const edm::EventSetup&)
+{
+  // do nothing
+}
+
+/*****************************************************************************/ 
+void BeamSpotDipServer::analyze(
+  const edm::Event& iEvent, const edm::EventSetup&)
+{
+  if(!readFromNFS)
+  {
+    // get runnumber
+    runnum = iEvent.run();
+
+    // get tracker status if in a new lumisection
+    int nthlumi = iEvent.luminosityBlock();
+
+    if (nthlumi > lastlumi) { // check every LS
+      lastlumi = nthlumi;
+
+//      edm::Handle<DcsStatusCollection> dcsStatus;
+//      iEvent.getByToken(dcsStatus_, dcsStatus);
+
+      edm::Handle<DCSRecord> dcsRecord;
+      iEvent.getByToken(dcsRecordToken_, dcsRecord);
+
+//      wholeTrackerOn = true;
+//      for (auto const& status : *dcsStatus) {
+//        if (!status.ready(DcsStatus::BPIX))   wholeTrackerOn = false;
+//        if (!status.ready(DcsStatus::FPIX))   wholeTrackerOn = false;
+//        if (!status.ready(DcsStatus::TIBTID)) wholeTrackerOn = false;
+//        if (!status.ready(DcsStatus::TOB))    wholeTrackerOn = false;
+//        if (!status.ready(DcsStatus::TECp))   wholeTrackerOn = false;
+//        if (!status.ready(DcsStatus::TECm))   wholeTrackerOn = false;
+//      }
+    
+      wholeTrackerOn = 
+        (*dcsRecord).highVoltageReady(DCSRecord::BPIX)   &&
+        (*dcsRecord).highVoltageReady(DCSRecord::FPIX)   &&
+        (*dcsRecord).highVoltageReady(DCSRecord::TIBTID) &&
+        (*dcsRecord).highVoltageReady(DCSRecord::TOB)    &&
+        (*dcsRecord).highVoltageReady(DCSRecord::TECp)   &&
+        (*dcsRecord).highVoltageReady(DCSRecord::TECm);
+
+      if(verbose)
+        edm::LogInfo("BeamSpotDipServer")
+          << "whole tracker on? " << (wholeTrackerOn ? "yes" : "no");
+    }
+  }
+}
+
+/*****************************************************************************/ 
+void BeamSpotDipServer::dqmEndLuminosityBlock(
+  const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& iSetup)
+{
+  edm::LogInfo("BeamSpotDipServer")
+    << "--------------------- end of LS " << lumiSeg.luminosityBlock();
+
+  try
+  { 
+  if(readFromNFS)
+  {
+  ifstream logFile(sourceFile);
+
+  if (!logFile.good()) {
+    edm::LogWarning("BeamSpotDipServer")
+      << "Source File: " + sourceFile + " doesn't exist!";
+    problem();
+  } else {
+    lastModTime = getLastTime(sourceFile);
+
+    if (lastFitTime == 0)
+      lastFitTime = lastModTime;
+
+    if(getFileSize(sourceFile) == 0) { 
+      // source file has zero length
+      if (lastModTime > lastFitTime) {
+        string tmp = tkStatus();
+        edm::LogInfo("BeamSpotDipServer")
+          << "New run starts. Run number: " << runnum;
+        if (verbose)
+          edm::LogInfo("BeamSpotDipServer")
+            << "Initial lastModTime = " + getDateTime(lastModTime);
+      }
+      lastFitTime = lastModTime;
+    }
+
+    if (lastModTime > lastFitTime) {
+      // source file modified
+      if (verbose) {
+        edm::LogInfo("BeamSpotDipServer")
+          << "time of last fit    = " + getDateTime(lastFitTime);
+        edm::LogInfo("BeamSpotDipServer")
+          << "time of current fit = " + getDateTime(lastModTime);
+      }
+      lastFitTime = lastModTime;
+
+      // source file length > 0
+      if(getFileSize(sourceFile) > 0) {
+        if (verbose)
+          edm::LogInfo("BeamSpotDipServer")
+            << "reading record from " + sourceFile;
+
+        if (readRcd(logFile)) {
+          if (verbose)
+            edm::LogInfo("BeamSpotDipServer") << "got new record from file";
+
+          trueRcd();
+          alive.reset();
+          alive.flip(7);
+        } else {
+          if (verbose)
+            edm::LogInfo("BeamSpotDipServer") << "problem with new record";
+          fakeRcd();
+        }
+
+        lsCount = 0;
+      }
+    } else {
+      // source file not touched
+      problem();
+    }
+  }
+
+  logFile.close();
+  } else {
+    edm::ESHandle<BeamSpotOnlineObjects>
+      bsLegacyHandle = iSetup.getHandle(bsLegacyToken_);
+    auto const & bs = *bsLegacyHandle; 
+ 
+    // from database
+    if(readRcd(bs)) {
+      if (verbose)
+        edm::LogInfo("BeamSpotDipServer") << "got new record from database";
+      trueRcd();
+      alive.reset();
+      alive.flip(7);
+    } else {
+      if (verbose)
+        edm::LogInfo("BeamSpotDipServer") << "problem with new record";
+      fakeRcd();
+    }
+
+    lsCount = 0;
+  }
+
+  // quality of the publish results
+  if (testing)
+     publishRcd(qualities[0],"Testing",true,true); // Uncertain
+  else if (quality == qualities[1]) // Bad
+    publishRcd(quality,"No fit or fit fails",true,true);
+  else
+    publishRcd(quality,"",true,true); // Good
+  } catch (exception & e) {
+    edm::LogWarning("BeamSpotDipServer")
+      << "io exception (end of lumi): " << e.what();
+  };
+}
+
+/*****************************************************************************/ 
+void BeamSpotDipServer::dqmEndRun(
+  const edm::Run&, const edm::EventSetup&)
+{
+  // destroy publications and data
+  edm::LogInfo("BeamSpotDipServer") << "destroying publication " + subjectCMS;
+  dip->destroyDipPublication(publicationCMS);
+  delete messageCMS;
+
+  edm::LogInfo("BeamSpotDipServer") << "destroying publication " + subjectLHC;
+  dip->destroyDipPublication(publicationLHC);
+  delete messageLHC;
+
+  edm::LogInfo("BeamSpotDipServer") << "destroying publication " + subjectPV;
+  dip->destroyDipPublication(publicationPV );
+  delete messagePV ;
+}
+
+/*****************************************************************************/ 
+long BeamSpotDipServer::getFileSize(string filename)
+{
+  struct stat stat_buf;
+  int rc = stat(filename.c_str(), &stat_buf);
+  return (rc == 0 ? stat_buf.st_size : -1);
+}
+
+/*****************************************************************************/ 
+time_t BeamSpotDipServer::getLastTime(string filename)
+{
+  struct stat stat_buf;
+  int rc = stat(filename.c_str(), &stat_buf);
+  return (rc == 0 ? stat_buf.st_mtime : -1);
+}
+
+/*****************************************************************************/
+vector<string> BeamSpotDipServer::parse(string line, const string & delimiter)
+{
+  vector<string> list;
+
+  size_t pos = 0;
+  while((pos = line.find(delimiter)) != string::npos)
+  {
+    string token = line.substr(0, pos);
+
+    list.push_back(token);
+
+    line.erase(0, pos + delimiter.length());
+  }
+
+  list.push_back(line); // remainder
+
+  return list;
+}
+
+/*****************************************************************************/ 
+string BeamSpotDipServer::tkStatus()
+{
+  string outstr;
+
+  if(readFromNFS)
+  { // get from file on /nfs
+    ifstream logfile(sourceFile1);
+
+    if (!logfile.good() || getFileSize(sourceFile1) == 0) {
+      // file does not exist or has zero size
+      outstr = "No CMS Tracker status available. No DAQ/DQM.";
+    } else {
+      int nthLnInRcd = 0;
+      string record;
+
+      try {
+        string record;
+
+        while (getline(logfile,record)) {
+          nthLnInRcd ++;
+          vector<string> tmp = parse(record, " ");
+
+          switch(nthLnInRcd) {
+            case 7  :
+              if (tmp[1].find("Yes") == string::npos)
+                outstr = "CMS Tracker OFF.";
+              else
+                outstr = "CMS not taking data or no beam.";
+              break;
+            case 8  : runnum = stoi(tmp[1]); break;
+            default : break;
+          }
+        }
+      } catch (exception & e) {
+        edm::LogWarning("BeamSpotDipServer")
+          << "exception (tkStatus): " << e.what();
+      }
+    }
+
+    logfile.close();
+  }
+  else
+  { 
+    // get from DCS
+    if(wholeTrackerOn) outstr = "CMS not taking data or no beam.";
+                  else outstr = "CMS Tracker OFF.";
+  }
+
+  return outstr;
+}
+
+/*****************************************************************************/ 
+void BeamSpotDipServer::problem()
+{
+  if(verbose)
+    edm::LogInfo("BeamSpotDipServer") << "no update | alive = " << alive;
+
+  lsCount++;
+
+  if ((lsCount % timeoutLS[0] == 0)
+   && (lsCount % timeoutLS[1] != 0)) // first time out
+  {
+    if (!alive.test(1)) alive.flip(1);
+    if (!alive.test(2))
+    {
+      if (!alive.test(7)) fakeRcd();
+                     else trueRcd();
+
+      stringstream warnMsg;
+      warnMsg << "No new data for " << lsCount << " LS";
+      publishRcd("Uncertain",warnMsg.str(),false,false);
+    } else {
+      fakeRcd();
+
+      stringstream warnMsg;
+      warnMsg << "No new data for " << lsCount << " LS: "
+               << tkStatus();
+      publishRcd("Bad",warnMsg.str(),false,false);
+    }
+  }
+  else if (lsCount % timeoutLS[1] == 0) // second time out
+  {
+    if (!alive.test(2)) alive.flip(2);
+    fakeRcd();
+
+    stringstream warnMsg;
+    warnMsg << "No new data for " << lsCount << " LS: " << tkStatus();
+    publishRcd("Bad",warnMsg.str(),false,false);
+  }
+}
+
+/*****************************************************************************/ 
+bool BeamSpotDipServer::readRcd(const BeamSpotOnlineObjects & bs)
+// read from database
+{
+  runnum = bs.GetLastAnalyzedRun();
+
+  // get from BeamSpotOnlineObject
+
+  try {
+    startTime      = bs.GetStartTime();
+    startTimeStamp = bs.GetStartTimeStamp();
+      endTime      = bs.GetEndTime();
+      endTimeStamp = bs.GetEndTimeStamp();
+  } catch (exception & e) {
+    edm::LogWarning("BeamSpotDipServer")
+      << "time variables are not available (readRcd): " << e.what();
+
+    startTime      = bs.GetCreationTime();
+    startTimeStamp = bs.GetCreationTime();
+      endTime      = bs.GetCreationTime();
+      endTimeStamp = bs.GetCreationTime();
+  }
+
+  try {
+    lumiRange = bs.GetLumiRange();
+  } catch (exception & e) {
+    edm::LogWarning("BeamSpotDipServer")
+      << "lumirange variable not avaialble (readRcd): " << e.what();
+
+    lumiRange = to_string(bs.GetLastAnalyzedLumi());
+  }
+
+  currentLS = bs.GetLastAnalyzedLumi();
+
+  type = bs.GetBeamType();
+
+  if(verbose)
+    edm::LogInfo("BeamSpotDipServer")
+         << "run: "    << runnum
+         << ", LS: "   << currentLS 
+         << ", time: " << startTime << " " << startTimeStamp
+         << ", type: " << type;
+
+  if (testing)          quality = qualities[0]; // Uncertain
+  else if (type >= 2)   quality = qualities[2]; // Good
+                   else quality = qualities[1]; // Bad
+
+  x = bs.GetX();
+  y = bs.GetY();
+  z = bs.GetZ();
+
+  sigma_z = bs.GetSigmaZ();
+  dxdz    = bs.Getdxdz(); 
+  dydz    = bs.Getdydz();
+  width_x = bs.GetBeamWidthX();
+  width_y = bs.GetBeamWidthX();
+
+  err_x       = bs.GetXError();
+  err_y       = bs.GetYError();
+  err_z       = bs.GetZError();
+  err_sigma_z = bs.GetSigmaZError();
+  err_dxdz    = bs.GetdxdzError();
+  err_dydz    = bs.GetdydzError();
+  err_width_x = bs.GetBeamWidthXError();
+  err_width_y = bs.GetBeamWidthYError();
+
+  try {
+       events = bs.GetUsedEvents();
+       meanPV = bs.GetMeanPV();
+   err_meanPV = bs.GetMeanErrorPV();
+        rmsPV = bs.GetRmsPV();
+    err_rmsPV = bs.GetRmsErrorPV();
+        maxPV = bs.GetMaxPVs();
+  } catch (exception & e) {
+    edm::LogWarning("BeamSpotDipServer")
+      << "PV variables are not available (readRcd): " << e.what();
+
+       events = 0.;
+       meanPV = 0.;
+   err_meanPV = 0.;
+        rmsPV = 0.;
+    err_rmsPV = 0.;
+        maxPV = 0.;
+  }
+
+  nPV = bs.GetNumPVs();
+
+  if(verbose)
+    edm::LogInfo("BeamSpotDipServer")
+               << "pos: (" << x << "," << y << "," << z << ")"
+               << " nPV: " << nPV;
+
+  return true;
+}
+
+/*****************************************************************************/ 
+bool BeamSpotDipServer::readRcd(ifstream & file) // readFromNFS
+{
+  int nthLnInRcd = 0;
+  bool rcdQlty = false;
+
+  try
+  {
+  string record;
+  while (getline(file,record)) {
+
+  nthLnInRcd ++;
+
+  vector<string> tmp = parse(record, " ");
+
+  switch(nthLnInRcd) {
+    case 1:
+      if(record.rfind("Run", 0) != 0) {
+        edm::LogError("BeamSpotDipServer")
+          << "Reading of results text file interrupted. " + getDateTime();
+        return false;
+      }
+      runnum = stoi(tmp[1]);
+      break;
+    case 2:
+      startTime = tmp[1]+" "+tmp[2]+" "+tmp[3]; startTimeStamp = stol(tmp[4]);
+      break;
+    case 3:
+      endTime   = tmp[1]+" "+tmp[2]+" "+tmp[3]; endTimeStamp   = stol(tmp[4]);
+      break;
+    case 4:
+      lumiRange = record.substr(10);
+      if(verbose)
+        edm::LogInfo("BeamSpotDipServer") << "lumisection range: " + lumiRange;
+      currentLS = stoi(tmp[3]);
+      break;
+    case 5:
+      type = stoi(tmp[1]);
+      if (testing)          quality = qualities[0]; // Uncertain
+      else if (type >= 2)   quality = qualities[2]; // Good
+                       else quality = qualities[1]; // Bad
+      break;
+
+    case 6: x = stof(tmp[1]); break;
+    case 7: y = stof(tmp[1]); break;
+    case 8: z = stof(tmp[1]); break;
+
+    case 9: sigma_z  = stof(tmp[1]); break;
+    case 10: dxdz    = stof(tmp[1]); break;
+    case 11: dydz    = stof(tmp[1]); break;
+    case 12: width_x = stof(tmp[1]); break;
+    case 13: width_y = stof(tmp[1]); break;
+
+    case 14: err_x       = sqrt(stof(tmp[1])); break;
+    case 15: err_y       = sqrt(stof(tmp[2])); break;
+    case 16: err_z       = sqrt(stof(tmp[3])); break;
+    case 17: err_sigma_z = sqrt(stof(tmp[4])); break;
+    case 18: err_dxdz    = sqrt(stof(tmp[5])); break;
+    case 19: err_dydz    = sqrt(stof(tmp[6])); break;
+    case 20: err_width_x = sqrt(stof(tmp[7]));
+            err_width_y = err_width_x; break;
+    case 21: break;
+    case 22: break;
+    case 23: break;
+    case 24: events = stoi(tmp[1]); break;
+
+    case 25:     meanPV = stof(tmp[1]); break;
+    case 26: err_meanPV = stof(tmp[1]); break;
+    case 27:      rmsPV = stof(tmp[1]); break;
+    case 28:  err_rmsPV = stof(tmp[1]); break;
+    case 29:      maxPV = stoi(tmp[1]); break;
+    case 30:        nPV = stoi(tmp[1]); rcdQlty = true; break;
+
+    default: break;
+  }
+  }
+
+  file.close();
+  } catch (exception & e) {
+    edm::LogWarning("BeamSpotDipServer")
+      << "io exception (readRcd): " << e.what();
+  }
+
+  return rcdQlty;
+}
+
+/*****************************************************************************/ 
+void BeamSpotDipServer::CMS2LHCRF_POS(float x, float y, float z)
+{
+  if (x != 0) { // Rotation + Translation + Inversion + Scaling
+    double tmpx = x;
+    // x*rotY[0]*rotZ[0] + y*rotY[0]*rotZ[1] - z*rotY[1] + trans[0];
+    Centroid[0] = tmpx;
+    Centroid[0] *= -1.0*cm2um;
+  }
+  else
+    Centroid[0] = x;
+
+  if (y != 0) { // Rotation + Translation + Scaling
+    double tmpy = y;
+    // x*(rotX[1]*rotY[1]*rotZ[0] - rotX[0]*rotZ[1]) +
+    // y*(rotX[0]*rotZ[0] + rotX[1]*rotY[1]*rotZ[1]) +
+    // z*rotX[1]*rotY[0] + trans[1];
+    Centroid[1] = tmpy;
+    Centroid[1] *= cm2um;
+  }
+  else
+    Centroid[1] = y;
+
+  if (z != 0) { // Rotation + Translation + Inversion + Scaling
+    double tmpz = z;
+    // x*(rotX[0]*rotY[1]*rotZ[0] + rotX[1]*rotZ[1]) +
+    // y*(rotX[0]*rotY[1]*rotZ[1] - rotX[1]*rotZ[0]) +
+    // z*rotX[0]*rotY[0] + trans[2];
+    Centroid[2] = tmpz;
+    Centroid[2] *= -1.0*cm2mm;
+  }
+  else
+    Centroid[2] = z;
+}
+
+/*****************************************************************************/ 
+void BeamSpotDipServer::trueRcd()
+{
+  try
+  {
+    // CMS to LHC RF
+    CMS2LHCRF_POS(x,y,z);
+
+    Tilt[0] = dxdz*rad2urad;
+    Tilt[1] = (dydz != 0 ? (dydz*-1*rad2urad) : 0);
+
+    Size[0] = width_x*cm2um;
+    Size[1] = width_y*cm2um;
+    Size[2] = sigma_z*cm2mm;
+
+    // CMS
+    messageCMS->insert(runnum,"runnum");
+    messageCMS->insert(startTime,"startTime");
+    messageCMS->insert(endTime,"endTime");
+    messageCMS->insert(startTimeStamp,"startTimeStamp");
+    messageCMS->insert(endTimeStamp,"endTimeStamp");
+    messageCMS->insert(lumiRange,"lumiRange");
+    messageCMS->insert(quality,"quality");
+    messageCMS->insert(type,"type"); // Unknown=-1, Fake=0, Tracker=2(Good)
+    messageCMS->insert(x,"x");
+    messageCMS->insert(y,"y");
+    messageCMS->insert(z,"z");
+    messageCMS->insert(dxdz,"dxdz");
+    messageCMS->insert(dydz,"dydz");
+    messageCMS->insert(width_x,"width_x");
+    messageCMS->insert(width_y,"width_y");
+    messageCMS->insert(sigma_z,"sigma_z");
+
+    if (publishStatErrors) {
+      messageCMS->insert(err_x,"err_x");
+      messageCMS->insert(err_y,"err_y");
+      messageCMS->insert(err_z,"err_z");
+      messageCMS->insert(err_dxdz,"err_dxdz");
+      messageCMS->insert(err_dydz,"err_dydz");
+      messageCMS->insert(err_width_x,"err_width_x");
+      messageCMS->insert(err_width_y,"err_width_y");
+      messageCMS->insert(err_sigma_z,"err_sigma_z");
+    }
+
+    // LHC
+    messageLHC->insert(Size,3,"Size");
+    messageLHC->insert(Centroid,3,"Centroid");
+    messageLHC->insert(Tilt,2,"Tilt");
+
+    // PV
+    messagePV->insert(runnum,"runnum");
+    messagePV->insert(startTime,"startTime");
+    messagePV->insert(endTime,"endTime");
+    messagePV->insert(startTimeStamp,"startTimeStamp");
+    messagePV->insert(endTimeStamp,"endTimeStamp");
+    messagePV->insert(lumiRange,"lumiRange");
+    messagePV->insert(events,"events");
+    messagePV->insert(meanPV,"meanPV");
+    messagePV->insert(err_meanPV,"err_meanPV");
+    messagePV->insert(rmsPV,"rmsPV");
+    messagePV->insert(err_rmsPV,"err_rmsPV");
+    messagePV->insert(maxPV,"maxPV");
+    messagePV->insert(nPV,"nPV");
+  } catch (exception & e){
+    edm::LogWarning("BeamSpotDipServer") << "exception (trueRcd): " << e.what();
+  }
+}
+
+/*****************************************************************************/ 
+void BeamSpotDipServer::fakeRcd()
+{
+  try
+  {
+    Centroid[0] = 0;
+    Centroid[1] = 0;
+    Centroid[2] = 0;
+
+    Size[0] = 0;
+    Size[1] = 0;
+    Size[2] = 0;
+
+    Tilt[0] = 0;
+    Tilt[1] = 0;
+
+    messageLHC->insert(Size,3,"Size");
+    messageLHC->insert(Centroid,3,"Centroid");
+    messageLHC->insert(Tilt,2,"Tilt");
+  } catch (exception & e){
+    edm::LogWarning("BeamSpotDipServer") << "exception (fakeRcd): " << e.what();
+  }
+}
+
+/*****************************************************************************/ 
+void BeamSpotDipServer::publishRcd(string qlty, string err,
+                                   bool pubCMS, bool fitTime)
+{
+  try
+  {
+    bool updateCMS = pubCMS && (currentLS % intLS == 0);
+
+    if(verbose)
+    {
+      edm::LogInfo("BeamSpotDipServer")
+        << "sending (" << qlty << " | " << err << ")";
+
+      if (alive.test(7)) {
+        if (updateCMS) edm::LogInfo("BeamSpotDipServer") << " to CCC and CMS";
+        else if (!alive.test(1) && !alive.test(2))
+                       edm::LogInfo("BeamSpotDipServer") << " to CCC only";
+      }
+    }
+
+    DipTimestamp zeit;
+    if (fitTime) {
+      long epoch;
+      epoch = endTimeStamp*1000; // convert to ms
+      zeit = DipTimestamp(epoch);
+    }
+    else zeit = DipTimestamp();
+
+    // send 
+    if(updateCMS)
+      publicationCMS->send(messageCMS, zeit);
+
+    publicationLHC->send(messageLHC, zeit);
+    publicationPV->send(messagePV, zeit);
+
+    // set qualities
+    if (qlty == qualities[0]) { // Uncertain
+      if (updateCMS)
+        publicationCMS->setQualityUncertain(err.c_str());
+
+      publicationLHC->setQualityUncertain(err.c_str());
+    }
+    else if (qlty == qualities[1]) { // Bad
+      if (updateCMS)
+        publicationCMS->setQualityBad(err.c_str());
+
+      publicationLHC->setQualityBad(err.c_str());
+    }
+    else if (qlty == "UNINITIALIZED") {
+      if (updateCMS)
+        publicationCMS->setQualityBad("UNINITIALIZED");
+
+      publicationLHC->setQualityBad("UNINITIALIZED");
+    }
+  } catch (exception & e) {
+    edm::LogWarning("BeamSpotDipServer")
+      << "exception (publishRcd): " << e.what();
+  }
+}
+
+/*****************************************************************************/ 
+string BeamSpotDipServer::getDateTime(time_t t)
+{
+  char mbstr[100];
+  strftime(mbstr, sizeof(mbstr), "%Y.%m.%d %H:%M:%S %z", std::localtime(&t));
+
+  return mbstr;
+}
+
+//
+string BeamSpotDipServer::getDateTime()
+{
+  time_t t = time(nullptr);
+
+  return getDateTime(t);
+}
+
+DEFINE_FWK_MODULE(BeamSpotDipServer);
+

--- a/DQM/BeamMonitor/plugins/BeamSpotDipServer.h
+++ b/DQM/BeamMonitor/plugins/BeamSpotDipServer.h
@@ -26,12 +26,11 @@ class DipPublication;
 
 class LuminosityBlock;
 
-class BeamSpotDipServer : public DQMOneLumiEDAnalyzer<>
-{
- public:
+class BeamSpotDipServer : public DQMOneLumiEDAnalyzer<> {
+public:
   explicit BeamSpotDipServer(const edm::ParameterSet&);
 
- protected:
+protected:
   void bookHistograms(DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&) override;
   void dqmBeginRun(const edm::Run& r, const edm::EventSetup&) override;
   void analyze(const edm::Event& e, const edm::EventSetup&) override;
@@ -39,34 +38,33 @@ class BeamSpotDipServer : public DQMOneLumiEDAnalyzer<>
   void dqmEndLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup&) override;
   void dqmEndRun(const edm::Run&, const edm::EventSetup& iSetup) override;
 
- private:
-  long   getFileSize(std::string filename);
+private:
+  long getFileSize(std::string filename);
   time_t getLastTime(std::string filename);
 
-  std::vector<std::string> parse(std::string line, const std::string & delimiter);
+  std::vector<std::string> parse(std::string line, const std::string& delimiter);
   std::string tkStatus();
 
-  bool readRcd(const BeamSpotOnlineObjects & bs); // read from database
-  bool readRcd(std::ifstream & file);             // read from NFS
+  bool readRcd(const BeamSpotOnlineObjects& bs);  // read from database
+  bool readRcd(std::ifstream& file);              // read from NFS
 
   void problem();
   void CMS2LHCRF_POS(float x, float y, float z);
 
   void trueRcd();
   void fakeRcd();
-  void publishRcd(std::string qlty, std::string err,
-                  bool pubCMS, bool fitTime);
+  void publishRcd(std::string qlty, std::string err, bool pubCMS, bool fitTime);
 
   std::string getDateTime();
   std::string getDateTime(long epoch);
 
   // constants
-  const char * qualities[3] = {"Uncertain","Bad","Good"};
+  const char* qualities[3] = {"Uncertain", "Bad", "Good"};
   const bool publishStatErrors = true;
   const int rad2urad = 1000000;
   const int cm2um = 10000;
   const int cm2mm = 10;
-  const int intLS = 1; // for CMS scaler
+  const int intLS = 1;  // for CMS scaler
 
   // variables
   long lastFitTime = 0;
@@ -76,13 +74,13 @@ class BeamSpotDipServer : public DQMOneLumiEDAnalyzer<>
   int currentLS = 0;
 
   // DIP objects
-  DipFactory * dip;
-  DipData * messageCMS;
-  DipData * messageLHC;
-  DipData * messagePV;
-  DipPublication * publicationCMS;
-  DipPublication * publicationLHC;
-  DipPublication * publicationPV;
+  DipFactory* dip;
+  DipData* messageCMS;
+  DipData* messageLHC;
+  DipData* messagePV;
+  DipPublication* publicationCMS;
+  DipPublication* publicationLHC;
+  DipPublication* publicationPV;
 
   // initial values of beamspot object
   int runnum;
@@ -132,8 +130,7 @@ class BeamSpotDipServer : public DQMOneLumiEDAnalyzer<>
   bool wholeTrackerOn = false;
 
   // online beamspot
-  edm::ESGetToken<BeamSpotOnlineObjects, BeamSpotOnlineLegacyObjectsRcd>
-    bsLegacyToken_; 
+  edm::ESGetToken<BeamSpotOnlineObjects, BeamSpotOnlineLegacyObjectsRcd> bsLegacyToken_;
 
   // inputs
   bool verbose;

--- a/DQM/BeamMonitor/plugins/BeamSpotDipServer.h
+++ b/DQM/BeamMonitor/plugins/BeamSpotDipServer.h
@@ -1,0 +1,157 @@
+#ifndef DQM_BeamMonitor__BeamSpotDipServer_h
+#define DQM_BeamMonitor__BeamSpotDipServer_h
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+
+#include "FWCore/Utilities/interface/ESGetToken.h"
+
+#include "DataFormats/Scalers/interface/BeamSpotOnline.h"
+//#include "DataFormats/Scalers/interface/DcsStatus.h"
+#include "DataFormats/OnlineMetaData/interface/DCSRecord.h"
+
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
+
+#include "CondFormats/BeamSpotObjects/interface/BeamSpotOnlineObjects.h"
+#include "CondFormats/DataRecord/interface/BeamSpotOnlineLegacyObjectsRcd.h"
+
+#include <string>
+#include <bits/stdc++.h>
+
+class DipFactory;
+class DipData;
+class DipPublication;
+
+class LuminosityBlock;
+
+class BeamSpotDipServer : public DQMOneLumiEDAnalyzer<>
+{
+ public:
+  explicit BeamSpotDipServer(const edm::ParameterSet&);
+
+ protected:
+  void bookHistograms(DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&) override;
+  void dqmBeginRun(const edm::Run& r, const edm::EventSetup&) override;
+  void analyze(const edm::Event& e, const edm::EventSetup&) override;
+  void dqmBeginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup&) override;
+  void dqmEndLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup&) override;
+  void dqmEndRun(const edm::Run&, const edm::EventSetup& iSetup) override;
+
+ private:
+  long   getFileSize(std::string filename);
+  time_t getLastTime(std::string filename);
+
+  std::vector<std::string> parse(std::string line, const std::string & delimiter);
+  std::string tkStatus();
+
+  bool readRcd(const BeamSpotOnlineObjects & bs); // read from database
+  bool readRcd(std::ifstream & file);             // read from NFS
+
+  void problem();
+  void CMS2LHCRF_POS(float x, float y, float z);
+
+  void trueRcd();
+  void fakeRcd();
+  void publishRcd(std::string qlty, std::string err,
+                  bool pubCMS, bool fitTime);
+
+  std::string getDateTime();
+  std::string getDateTime(long epoch);
+
+  // constants
+  const char * qualities[3] = {"Uncertain","Bad","Good"};
+  const bool publishStatErrors = true;
+  const int rad2urad = 1000000;
+  const int cm2um = 10000;
+  const int cm2mm = 10;
+  const int intLS = 1; // for CMS scaler
+
+  // variables
+  long lastFitTime = 0;
+  long lastModTime = 0;
+  std::bitset<8> alive;
+//  int idleTime = 0;
+  int lsCount = 0;
+  int currentLS = 0;
+
+  // DIP objects
+  DipFactory * dip;
+  DipData * messageCMS;
+  DipData * messageLHC;
+  DipData * messagePV;
+  DipPublication * publicationCMS;
+  DipPublication * publicationLHC;
+  DipPublication * publicationPV;
+
+  // initial values of beamspot object
+  int runnum;
+  std::string startTime = getDateTime();
+  std::string endTime = getDateTime();
+  time_t startTimeStamp = 0;
+  time_t endTimeStamp = 0;
+  std::string lumiRange = "0 - 0";
+  std::string quality = "Uncertain";
+  int type = -1;
+  float x = 0;
+  float y = 0;
+  float z = 0;
+  float dxdz = 0;
+  float dydz = 0;
+  float err_x = 0;
+  float err_y = 0;
+  float err_z = 0;
+  float err_dxdz = 0;
+  float err_dydz = 0;
+  float width_x = 0;
+  float width_y = 0;
+  float sigma_z = 0;
+  float err_width_x = 0;
+  float err_width_y = 0;
+  float err_sigma_z = 0;
+
+  // added for PV information
+  int events = 0;
+  float meanPV = 0;
+  float err_meanPV = 0;
+  float rmsPV = 0;
+  float err_rmsPV = 0;
+  int maxPV = 0;
+  int nPV = 0;
+
+  //
+  float Size[3];
+  float Centroid[3];
+  float Tilt[2];
+
+  // tracker status
+//  edm::EDGetTokenT<DcsStatusCollection> dcsStatus_;
+  edm::InputTag dcsRecordInputTag_;
+  edm::EDGetTokenT<DCSRecord> dcsRecordToken_;
+
+  int lastlumi = -1;
+  bool wholeTrackerOn = false;
+
+  // online beamspot
+  edm::ESGetToken<BeamSpotOnlineObjects, BeamSpotOnlineLegacyObjectsRcd>
+    bsLegacyToken_; 
+
+  // inputs
+  bool verbose;
+  bool testing;
+
+  std::string subjectCMS;
+  std::string subjectLHC;
+  std::string subjectPV;
+
+  bool readFromNFS;
+
+  std::string sourceFile;
+  std::string sourceFile1;
+
+  std::vector<int> timeoutLS;
+};
+
+#endif

--- a/DQM/BeamMonitor/plugins/BeamSpotDipServer.h
+++ b/DQM/BeamMonitor/plugins/BeamSpotDipServer.h
@@ -9,7 +9,6 @@
 #include "FWCore/Utilities/interface/ESGetToken.h"
 
 #include "DataFormats/Scalers/interface/BeamSpotOnline.h"
-//#include "DataFormats/Scalers/interface/DcsStatus.h"
 #include "DataFormats/OnlineMetaData/interface/DCSRecord.h"
 
 #include "DQMServices/Core/interface/DQMStore.h"
@@ -73,7 +72,6 @@ class BeamSpotDipServer : public DQMOneLumiEDAnalyzer<>
   long lastFitTime = 0;
   long lastModTime = 0;
   std::bitset<8> alive;
-//  int idleTime = 0;
   int lsCount = 0;
   int currentLS = 0;
 
@@ -127,7 +125,6 @@ class BeamSpotDipServer : public DQMOneLumiEDAnalyzer<>
   float Tilt[2];
 
   // tracker status
-//  edm::EDGetTokenT<DcsStatusCollection> dcsStatus_;
   edm::InputTag dcsRecordInputTag_;
   edm::EDGetTokenT<DCSRecord> dcsRecordToken_;
 

--- a/DQM/BeamMonitor/plugins/BuildFile.xml
+++ b/DQM/BeamMonitor/plugins/BuildFile.xml
@@ -9,9 +9,6 @@
 <use name="DataFormats/VertexReco"/>
 <use name="DataFormats/TrackerRecHit2D"/>
 <use name="CondCore/DBOutputService"/>
-<use name="DataFormats/OnlineMetaData"/>
-<use name="dip"/>
-<use name="log4cplus"/>
 <library file="BeamMonitor.cc" name="BeamMonitor">
   <flags EDM_PLUGIN="1"/>
 </library>
@@ -58,5 +55,8 @@
 </library>
 
 <library file="BeamSpotDipServer.cc" name="BeamSpotDipServer">
+  <use name="DataFormats/OnlineMetaData"/>
+  <use name="dip"/>
+  <use name="log4cplus"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/DQM/BeamMonitor/plugins/BuildFile.xml
+++ b/DQM/BeamMonitor/plugins/BuildFile.xml
@@ -54,9 +54,11 @@
   <flags EDM_PLUGIN="1"/>
 </library>
 
+<ifarchitecture name="_amd64_">
 <library file="BeamSpotDipServer.cc" name="BeamSpotDipServer">
   <use name="DataFormats/OnlineMetaData"/>
   <use name="dip"/>
   <use name="log4cplus"/>
   <flags EDM_PLUGIN="1"/>
 </library>
+</ifarchitecture>

--- a/DQM/BeamMonitor/plugins/BuildFile.xml
+++ b/DQM/BeamMonitor/plugins/BuildFile.xml
@@ -9,6 +9,9 @@
 <use name="DataFormats/VertexReco"/>
 <use name="DataFormats/TrackerRecHit2D"/>
 <use name="CondCore/DBOutputService"/>
+<use name="DataFormats/OnlineMetaData"/>
+<use name="dip"/>
+<use name="log4cplus"/>
 <library file="BeamMonitor.cc" name="BeamMonitor">
   <flags EDM_PLUGIN="1"/>
 </library>
@@ -51,5 +54,9 @@
 </library>
 
 <library file="FakeBeamMonitor.cc" name="FakeBeamMonitor">
+  <flags EDM_PLUGIN="1"/>
+</library>
+
+<library file="BeamSpotDipServer.cc" name="BeamSpotDipServer">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/DQM/BeamMonitor/python/BeamSpotDipServer_cff.py
+++ b/DQM/BeamMonitor/python/BeamSpotDipServer_cff.py
@@ -1,0 +1,25 @@
+import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+
+beamSpotDipServer = DQMEDAnalyzer("BeamSpotDipServer",
+  monitorName = cms.untracked.string("BeamSpotDipServer"),
+  #
+  verbose = cms.untracked.bool(False),
+  testing = cms.untracked.bool(False),
+  #
+  subjectCMS = cms.untracked.string("dip/CMS/Tracker/BeamSpot"),
+  subjectLHC = cms.untracked.string("dip/CMS/LHC/LuminousRegion"),
+  subjectPV  = cms.untracked.string("dip/CMS/Tracker/PrimaryVertices"),
+  #
+  readFromNFS = cms.untracked.bool(True),
+  # DCSStatus   = cms.untracked.string("scalersRawToDigi"),
+  dcsRecordInputTag = cms.InputTag ( "onlineMetaDataDigis" ),
+  #
+  sourceFile  = cms.untracked.string(
+    "/nfshome0/dqmpro/BeamMonitorDQM/BeamFitResults.txt"),
+  sourceFile1 = cms.untracked.string(
+    "/nfshome0/dqmpro/BeamMonitorDQM/BeamFitResults_TkStatus.txt"),
+  #
+  timeoutLS = cms.untracked.vint32(1,2)
+)
+

--- a/DQM/BeamMonitor/python/BeamSpotDipServer_cff.py
+++ b/DQM/BeamMonitor/python/BeamSpotDipServer_cff.py
@@ -12,7 +12,7 @@ beamSpotDipServer = DQMEDAnalyzer("BeamSpotDipServer",
   subjectPV  = cms.untracked.string("dip/CMS/Tracker/PrimaryVertices"),
   #
   readFromNFS = cms.untracked.bool(True),
-  # DCSStatus   = cms.untracked.string("scalersRawToDigi"),
+  #
   dcsRecordInputTag = cms.InputTag ( "onlineMetaDataDigis" ),
   #
   sourceFile  = cms.untracked.string(

--- a/DQM/BeamMonitor/test/beamspotdip_dqm_sourceclient-file_cfg.py
+++ b/DQM/BeamMonitor/test/beamspotdip_dqm_sourceclient-file_cfg.py
@@ -1,0 +1,58 @@
+from __future__ import print_function
+import FWCore.ParameterSet.Config as cms
+
+#
+process = cms.Process("BeamSpotDipServer")
+process.load("DQMServices.Core.DQM_cfg")
+
+# message logger
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cerr = cms.untracked.PSet(
+    threshold = cms.untracked.string('INFO'),
+    default = cms.untracked.PSet(
+       limit = cms.untracked.int32(1000)
+    ),
+    BeamSpotDipServer = cms.untracked.PSet(
+        limit = cms.untracked.int32(1000)
+    )
+)
+
+# source
+process.source = cms.Source("PoolSource",
+  fileNames=cms.untracked.vstring(
+    'file:/tmp/sikler/b.root' # lxplus7101
+  )
+)
+
+process.maxEvents = cms.untracked.PSet(
+  input = cms.untracked.int32(100)
+)
+
+# beamspot from database
+process.load("CondCore.CondDB.CondDB_cfi") 
+
+process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
+
+process.GlobalTag.toGet = cms.VPSet(
+  cms.PSet(
+    record = cms.string("BeamSpotOnlineLegacyObjectsRcd"),
+    refreshTime = cms.uint64(1)
+  ),
+)
+
+# module
+process.load("DQM.BeamMonitor.BeamSpotDipServer_cff")
+
+process.beamSpotDipServer.verbose = True
+process.beamSpotDipServer.testing = True
+
+process.beamSpotDipServer.readFromNFS = True
+process.beamSpotDipServer.sourceFile  = "../../../../../BeamFitResults.txt"
+process.beamSpotDipServer.sourceFile1 = "../../../../../TkStatus.txt"
+
+# process customizations
+from DQM.Integration.config.online_customizations_cfi import *
+process = customise(process)
+
+# path
+process.p = cms.Path( process.beamSpotDipServer )

--- a/DQM/BeamMonitor/test/log4cplus.properties
+++ b/DQM/BeamMonitor/test/log4cplus.properties
@@ -1,0 +1,14 @@
+# Set root logger level to WARN and its only appender to A1.
+log4cplus.rootLogger=WARN, A1
+
+# A1 is set to be a ConsoleAppender.
+log4cplus.appender.A1=log4cplus::ConsoleAppender
+log4cplus.appender.A1.ImmediateFlush=true
+log4cplus.appender.A1.logToStdErr=false
+
+# A1 uses PatternLayout.
+log4cplus.appender.A1.layout=log4cplus::PatternLayout
+log4cplus.appender.A1.layout.ConversionPattern=%d{%m/%d/%y %H:%M:%S} [%t] %-5p %c{2} %%%x%% - %m%n
+
+#log4cplus.logger.dip.system=INFO
+#log4cplus.logger.dip.publication=WARN

--- a/DQM/Integration/python/clients/beamspotdip_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamspotdip_dqm_sourceclient-live_cfg.py
@@ -1,0 +1,34 @@
+from __future__ import print_function
+import FWCore.ParameterSet.Config as cms
+
+#
+process = cms.Process("BeamSpotDipServer")
+process.load("DQMServices.Core.DQM_cfg")
+
+# input
+# for live online DQM in P5
+process.load("DQM.Integration.config.inputsource_cfi")
+# for testing in lxplus
+# process.load("DQM.Integration.config.fileinputsource_cfi")
+
+# beamspot from database
+process.load("CondCore.CondDB.CondDB_cfi")
+
+process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
+
+process.GlobalTag.toGet = cms.VPSet(
+  cms.PSet(
+    record = cms.string("BeamSpotOnlineLegacyObjectsRcd"),
+    refreshTime = cms.uint64(1)
+  ),
+)
+
+# module
+process.load("DQM.BeamMonitor.BeamSpotDipServer_cff")
+
+# process customizations included here
+from DQM.Integration.config.online_customizations_cfi import *
+process = customise(process)
+
+# path
+process.p = cms.Path( process.beamSpotDipServer )


### PR DESCRIPTION
#### PR description:
Forwardport of #35428.
Integrates the former java DIP BeamSpot server as a DQM client:
- By default raeds the value from the txt files
- An option to read the Legacy BeamSpotonline from the DB is added. but not used by default

More details in #35428 and https://github.com/cms-sw/cmssw/pull/35193#issuecomment-926621275
I profit of this PR to remove a couple of commented out lines.

#### PR validation:
Compiles on lxplus + see #35428

#### Backport
This is the forward port of #35428.

FYI @sikler