### PR TITLE
Update DD4HEP GT with latest developments

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1104,7 +1104,7 @@ upgradeWFs['DD4hep'].allowReuse = False
 class UpgradeWorkflow_DD4hepDB(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):
         if 'Run3' in stepDict[step][k]['--era']:
-            stepDict[stepName][k] = merge([{'--conditions': '120X_mcRun3_2021_realistic_dd4hep_v1', '--geometry': 'DB:Extended', '--procModifiers': 'dd4hep'}, stepDict[step][k]])
+            stepDict[stepName][k] = merge([{'--conditions': '121X_mcRun3_2021_realistic_dd4hep_v1', '--geometry': 'DB:Extended', '--procModifiers': 'dd4hep'}, stepDict[step][k]])
     def condition(self, fragment, stepList, key, hasHarvest):
         return '2021' in key
 upgradeWFs['DD4hepDB'] = UpgradeWorkflow_DD4hepDB(


### PR DESCRIPTION
#### PR description:

Following the comment https://github.com/cms-sw/cmssw/pull/35373#issuecomment-928051202
Bringing the DD4HEP GT up to date + adding the BeamSpot tags discussed in [1]. 
The diff wrt to the previous DD4HEP GT [2] contains
 *  the cleaning of unused tags (Pixel intermediate B-field templates, superseded magnetic field geometries, unused DT reco uncertainties) 
 * for Run3 MC the two records `BeamSpotOnlineHLTObjectsRcd` and `BeamSpotOnlineLegacyObjectsRcd` are supplied to Run 3 Simulation GlobalTags via the newly created tag: `BeamSpotOnlineObjects_Realistic25ns_13TeVCollisions_RoundOpticsLowSigmaZ_RunBased_v1_mc` (same on both records) with the same parameters as the regular BeamSpotObjectsRcd tag (`BeamSpotObjects_Realistic25ns_13TeVCollisions_RoundOpticsLowSigmaZ_RunBased_v1_mc`)

[1] https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4474.html

[2] https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021_realistic_dd4hep_v1/120X_mcRun3_2021_realistic_dd4hep_v1

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not a backport and no backport is needed

resolves https://github.com/cms-AlCaDB/AlCaTools/issues/38
