### PR TITLE
test pylint instead of pylint3

### DIFF
--- a/PhysicsTools/PythonAnalysis/test/BuildFile.xml
+++ b/PhysicsTools/PythonAnalysis/test/BuildFile.xml
@@ -145,4 +145,4 @@
 <test name="import-bs4" command="python3 -c 'import bs4'"/>
 <test name="run-flawfinder" command="flawfinder -h"/>
 <test name="run-ipython3" command="ipython3 -h"/>
-<test name="run-pylint3" command="pylint3 -h"/>
+<test name="run-pylint" command="pylint -h"/>


### PR DESCRIPTION
Test for `pylint` instead of `pylint3`. This should be merge along with https://github.com/cms-sw/cmsdist/pull/7330 which removes renaming of python tools to `name3`