### PR TITLE
Update tests in PythonAnalysis - executables no longer end with 3

### DIFF
--- a/PhysicsTools/PythonAnalysis/test/BuildFile.xml
+++ b/PhysicsTools/PythonAnalysis/test/BuildFile.xml
@@ -144,5 +144,5 @@
 <test name="import-lxml" command="python3 -c 'import lxml'"/>
 <test name="import-bs4" command="python3 -c 'import bs4'"/>
 <test name="run-flawfinder" command="flawfinder -h"/>
-<test name="run-ipython3" command="ipython3 -h"/>
-<test name="run-pylint3" command="pylint3 -h"/>
+<test name="run-ipython" command="ipython -h"/>
+<test name="run-pylint" command="pylint -h"/>


### PR DESCRIPTION
follows changes in https://github.com/cms-sw/cmsdist/pull/7330