### PR TITLE
Drop type specifications

### DIFF
--- a/DQM/SiPixelCommon/python/SiPixelOfflineDQM_client_cff.py
+++ b/DQM/SiPixelCommon/python/SiPixelOfflineDQM_client_cff.py
@@ -31,7 +31,7 @@ sipixelQTester = DQMQualityTester(
 
 #Heavy Ion QualityTester
 sipixelQTesterHI = sipixelQTester.clone(
-    qtList = cms.untracked.FileInPath('DQM/SiPixelMonitorClient/test/sipixel_tier0_qualitytest_heavyions.xml')
+    qtList = 'DQM/SiPixelMonitorClient/test/sipixel_tier0_qualitytest_heavyions.xml'
 )
 
 #DataCertification:

--- a/DQM/SiPixelCommon/python/SiPixelOfflineDQM_source_cff.py
+++ b/DQM/SiPixelCommon/python/SiPixelOfflineDQM_source_cff.py
@@ -97,16 +97,17 @@ SiPixelHitEfficiencySource.ringOn = False
 
 #HI track modules
 hiTracks = "hiGeneralTracks"
-hiRefittedForPixelDQM= refittedForPixelDQM.clone()
-hiRefittedForPixelDQM.src=hiTracks
+hiRefittedForPixelDQM= refittedForPixelDQM.clone(
+    src = hiTracks
+)
 
 SiPixelTrackResidualSource_HeavyIons = SiPixelTrackResidualSource.clone(
-    vtxsrc='hiSelectedVertex'
-    )
+    vtxsrc = 'hiSelectedVertex'
+)
 
 SiPixelHitEfficiencySource_HeavyIons = SiPixelHitEfficiencySource.clone(
-    vtxsrc='hiSelectedVertex'
-    )
+    vtxsrc = 'hiSelectedVertex'
+)
 
 
 #DQM service

--- a/DQM/SiPixelMonitorTrack/python/RefitterForPixelDQM.py
+++ b/DQM/SiPixelMonitorTrack/python/RefitterForPixelDQM.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 import RecoTracker.TrackProducer.TrackRefitter_cfi 
-refittedForPixelDQM = RecoTracker.TrackProducer.TrackRefitter_cfi.TrackRefitter.clone()
-refittedForPixelDQM.NavigationSchool = ''
-refittedForPixelDQM.Fitter = 'FlexibleKFFittingSmoother'
+refittedForPixelDQM = RecoTracker.TrackProducer.TrackRefitter_cfi.TrackRefitter.clone(
+    NavigationSchool = '',
+    Fitter = 'FlexibleKFFittingSmoother'
+)

--- a/DQM/SiPixelPhase1Common/python/HistogramManager_cfi.py
+++ b/DQM/SiPixelPhase1Common/python/HistogramManager_cfi.py
@@ -100,17 +100,21 @@ DefaultHisto = cms.PSet(
   #)
 )
 
-DefaultHistoDigiCluster=DefaultHisto.clone()
-DefaultHistoDigiCluster.topFolderName= cms.string("PixelPhase1/Phase1_MechanicalView")
+DefaultHistoDigiCluster=DefaultHisto.clone(
+    topFolderName = "PixelPhase1/Phase1_MechanicalView"
+)
 
-DefaultHistoSummary=DefaultHisto.clone()
-DefaultHistoSummary.topFolderName= cms.string("PixelPhase1/Summary")
+DefaultHistoSummary=DefaultHisto.clone(
+    topFolderName = "PixelPhase1/Summary"
+)
 
-DefaultHistoTrack=DefaultHisto.clone()
-DefaultHistoTrack.topFolderName= cms.string("PixelPhase1/Tracks")
+DefaultHistoTrack=DefaultHisto.clone(
+    topFolderName = "PixelPhase1/Tracks"
+)
 
-DefaultHistoReadout=DefaultHisto.clone()
-DefaultHistoReadout.topFolderName= cms.string("PixelPhase1/FED/Readout")
+DefaultHistoReadout=DefaultHisto.clone(
+    topFolderName = "PixelPhase1/FED/Readout"
+)
 
 # Commonly used specifications.
 StandardSpecifications1D = [

--- a/DQM/SiPixelPhase1Config/python/SiPixelPhase1OfflineDQM_source_cff.py
+++ b/DQM/SiPixelPhase1Config/python/SiPixelPhase1OfflineDQM_source_cff.py
@@ -49,26 +49,28 @@ siPixelPhase1OfflineDQM_source_cosmics = siPixelPhase1OfflineDQM_source.copyAndE
     SiPixelPhase1TrackEfficiencyAnalyzer 
 ])
 
-SiPixelPhase1TrackResidualsAnalyzer_cosmics = SiPixelPhase1TrackResidualsAnalyzer.clone()
-SiPixelPhase1TrackResidualsAnalyzer_cosmics.Tracks = "ctfWithMaterialTracksP5"
-SiPixelPhase1TrackResidualsAnalyzer_cosmics.trajectoryInput = "ctfWithMaterialTracksP5"
-SiPixelPhase1TrackResidualsAnalyzer_cosmics.VertexCut =cms.untracked.bool(False) # don't cuts based on the primary vertex position for cosmics
-
+SiPixelPhase1TrackResidualsAnalyzer_cosmics = SiPixelPhase1TrackResidualsAnalyzer.clone(
+    Tracks = "ctfWithMaterialTracksP5",
+    trajectoryInput = "ctfWithMaterialTracksP5",
+    VertexCut = False # don't cuts based on the primary vertex position for cosmics
+)
 
 siPixelPhase1OfflineDQM_source_cosmics.replace(SiPixelPhase1TrackResidualsAnalyzer,
                                                SiPixelPhase1TrackResidualsAnalyzer_cosmics)
 
-SiPixelPhase1RecHitsAnalyzer_cosmics = SiPixelPhase1RecHitsAnalyzer.clone()
-SiPixelPhase1RecHitsAnalyzer_cosmics.onlyValidHits = True # In Cosmics the efficiency plugin will not run, so we monitor only valid hits
-SiPixelPhase1RecHitsAnalyzer_cosmics.src = "ctfWithMaterialTracksP5"
-SiPixelPhase1RecHitsAnalyzer_cosmics.VertexCut = cms.untracked.bool(False)
+SiPixelPhase1RecHitsAnalyzer_cosmics = SiPixelPhase1RecHitsAnalyzer.clone(
+    onlyValidHits = True, # In Cosmics the efficiency plugin will not run, so we monitor only valid hits
+    src = "ctfWithMaterialTracksP5",
+    VertexCut = False
+)
 
 siPixelPhase1OfflineDQM_source_cosmics.replace(SiPixelPhase1RecHitsAnalyzer,
                                                SiPixelPhase1RecHitsAnalyzer_cosmics)
 
-SiPixelPhase1TrackClustersAnalyzer_cosmics = SiPixelPhase1TrackClustersAnalyzer.clone()
-SiPixelPhase1TrackClustersAnalyzer_cosmics.tracks = "ctfWithMaterialTracksP5"
-SiPixelPhase1TrackClustersAnalyzer_cosmics.VertexCut = cms.untracked.bool(False)
+SiPixelPhase1TrackClustersAnalyzer_cosmics = SiPixelPhase1TrackClustersAnalyzer.clone(
+    tracks = "ctfWithMaterialTracksP5",
+    VertexCut = False
+)
 
 siPixelPhase1OfflineDQM_source_cosmics.replace(SiPixelPhase1TrackClustersAnalyzer,
                                                SiPixelPhase1TrackClustersAnalyzer_cosmics)
@@ -78,30 +80,34 @@ siPixelPhase1OfflineDQM_source_cosmics.replace(SiPixelPhase1TrackClustersAnalyze
 
 siPixelPhase1OfflineDQM_source_hi = siPixelPhase1OfflineDQM_source.copy()
 
-SiPixelPhase1RecHitsAnalyzer_hi = SiPixelPhase1RecHitsAnalyzer.clone()
-SiPixelPhase1RecHitsAnalyzer_hi.src = "hiGeneralTracks"
+SiPixelPhase1RecHitsAnalyzer_hi = SiPixelPhase1RecHitsAnalyzer.clone(
+    src = "hiGeneralTracks"
+)
 
 siPixelPhase1OfflineDQM_source_hi.replace(SiPixelPhase1RecHitsAnalyzer,
                                           SiPixelPhase1RecHitsAnalyzer_hi)
 
-SiPixelPhase1TrackResidualsAnalyzer_hi = SiPixelPhase1TrackResidualsAnalyzer.clone()
-SiPixelPhase1TrackResidualsAnalyzer_hi.Tracks = "hiGeneralTracks"
-SiPixelPhase1TrackResidualsAnalyzer_hi.trajectoryInput = "hiRefittedForPixelDQM"
-SiPixelPhase1TrackResidualsAnalyzer_hi.vertices = "hiSelectedVertex"
+SiPixelPhase1TrackResidualsAnalyzer_hi = SiPixelPhase1TrackResidualsAnalyzer.clone(
+    Tracks = "hiGeneralTracks",
+    trajectoryInput = "hiRefittedForPixelDQM",
+    vertices = "hiSelectedVertex"
+)
 
 siPixelPhase1OfflineDQM_source_hi.replace(SiPixelPhase1TrackResidualsAnalyzer,
                                           SiPixelPhase1TrackResidualsAnalyzer_hi)
 
-SiPixelPhase1TrackClustersAnalyzer_hi = SiPixelPhase1TrackClustersAnalyzer.clone()
-SiPixelPhase1TrackClustersAnalyzer_hi.tracks = "hiGeneralTracks"
-SiPixelPhase1TrackClustersAnalyzer_hi.vertices = "hiSelectedVertex"
+SiPixelPhase1TrackClustersAnalyzer_hi = SiPixelPhase1TrackClustersAnalyzer.clone(
+    tracks = "hiGeneralTracks",
+    vertices = "hiSelectedVertex"
+)
 
 siPixelPhase1OfflineDQM_source_hi.replace(SiPixelPhase1TrackClustersAnalyzer,
                                                SiPixelPhase1TrackClustersAnalyzer_hi)
 
-SiPixelPhase1TrackEfficiencyAnalyzer_hi = SiPixelPhase1TrackEfficiencyAnalyzer.clone()
-SiPixelPhase1TrackEfficiencyAnalyzer_hi.tracks = "hiGeneralTracks"
-SiPixelPhase1TrackEfficiencyAnalyzer_hi.primaryvertices = "hiSelectedVertex"
+SiPixelPhase1TrackEfficiencyAnalyzer_hi = SiPixelPhase1TrackEfficiencyAnalyzer.clone(
+    tracks = "hiGeneralTracks",
+    primaryvertices = "hiSelectedVertex"
+)
 
 siPixelPhase1OfflineDQM_source_hi.replace(SiPixelPhase1TrackEfficiencyAnalyzer,
                                                SiPixelPhase1TrackEfficiencyAnalyzer_hi)

--- a/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_Timing_cff.py
+++ b/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_Timing_cff.py
@@ -129,17 +129,20 @@ siPixelPhase1OnlineDQM_harvesting = cms.Sequence(
 
 ## Additional settings for cosmic runs 
 
-SiPixelPhase1TrackClustersAnalyzer_cosmics = SiPixelPhase1TrackClustersAnalyzer.clone()
-SiPixelPhase1TrackClustersAnalyzer_cosmics.tracks  = cms.InputTag( "ctfWithMaterialTracksP5" )
-SiPixelPhase1TrackClustersAnalyzer_cosmics.VertexCut = cms.untracked.bool(False)
+SiPixelPhase1TrackClustersAnalyzer_cosmics = SiPixelPhase1TrackClustersAnalyzer.clone(
+    tracks = "ctfWithMaterialTracksP5", 
+    VertexCut = False
+)
 
-SiPixelPhase1TrackResidualsAnalyzer_cosmics = SiPixelPhase1TrackResidualsAnalyzer.clone()
-SiPixelPhase1TrackResidualsAnalyzer_cosmics.Tracks = cms.InputTag( "ctfWithMaterialTracksP5" )
-SiPixelPhase1TrackResidualsAnalyzer_cosmics.trajectoryInput = "ctfWithMaterialTracksP5"
-SiPixelPhase1TrackResidualsAnalyzer_cosmics.VertexCut = cms.untracked.bool(False)
+SiPixelPhase1TrackResidualsAnalyzer_cosmics = SiPixelPhase1TrackResidualsAnalyzer.clone(
+    Tracks = "ctfWithMaterialTracksP5",
+    trajectoryInput = "ctfWithMaterialTracksP5",
+    VertexCut = False
+)
 
-SiPixelPhase1TrackEfficiencyAnalyzer_cosmics=SiPixelPhase1TrackEfficiencyAnalyzer.clone()
-SiPixelPhase1TrackEfficiencyAnalyzer_cosmics.tracks=cms.InputTag( "ctfWithMaterialTracksP5" )
+SiPixelPhase1TrackEfficiencyAnalyzer_cosmics=SiPixelPhase1TrackEfficiencyAnalyzer.clone(
+    tracks = "ctfWithMaterialTracksP5"
+)
 
 siPixelPhase1OnlineDQM_source_cosmics = cms.Sequence(
    SiPixelPhase1DigisAnalyzer
@@ -150,20 +153,23 @@ siPixelPhase1OnlineDQM_source_cosmics = cms.Sequence(
 )
 
 ## Additional settings for pp_run (Phase 0 test)
-SiPixelPhase1TrackClustersAnalyzer_pprun = SiPixelPhase1TrackClustersAnalyzer.clone()
-SiPixelPhase1TrackClustersAnalyzer_pprun.tracks  = cms.InputTag( "initialStepTracksPreSplitting" )
-SiPixelPhase1TrackClustersAnalyzer_pprun.clusterShapeCache = cms.InputTag("siPixelClusterShapeCachePreSplitting")
-SiPixelPhase1TrackClustersAnalyzer_pprun.vertices = cms.InputTag('firstStepPrimaryVerticesPreSplitting')
-SiPixelPhase1TrackClustersAnalyzer_pprun.VertexCut = cms.untracked.bool(False)
+SiPixelPhase1TrackClustersAnalyzer_pprun = SiPixelPhase1TrackClustersAnalyzer.clone(
+    tracks  = "initialStepTracksPreSplitting",
+    clusterShapeCache = "siPixelClusterShapeCachePreSplitting",
+    vertices = 'firstStepPrimaryVerticesPreSplitting',
+    VertexCut = False
+)
 
-SiPixelPhase1TrackResidualsAnalyzer_pprun = SiPixelPhase1TrackResidualsAnalyzer.clone()
-SiPixelPhase1TrackResidualsAnalyzer_pprun.Tracks = cms.InputTag( "initialStepTracksPreSplitting" )
-SiPixelPhase1TrackResidualsAnalyzer_pprun.trajectoryInput = "initialStepTracksPreSplitting"
-SiPixelPhase1TrackResidualsAnalyzer_pprun.VertexCut = cms.untracked.bool(False)
+SiPixelPhase1TrackResidualsAnalyzer_pprun = SiPixelPhase1TrackResidualsAnalyzer.clone(
+    Tracks = "initialStepTracksPreSplitting",
+    trajectoryInput = "initialStepTracksPreSplitting",
+    VertexCut = False
+)
 
-SiPixelPhase1TrackEfficiencyAnalyzer_pprun=SiPixelPhase1TrackEfficiencyAnalyzer.clone()
-SiPixelPhase1TrackEfficiencyAnalyzer_pprun.tracks=cms.InputTag( "initialStepTracksPreSplitting" )
-SiPixelPhase1TrackEfficiencyAnalyzer_pprun.VertexCut = cms.untracked.bool(False)
+SiPixelPhase1TrackEfficiencyAnalyzer_pprun = SiPixelPhase1TrackEfficiencyAnalyzer.clone(
+    tracks = "initialStepTracksPreSplitting",
+    VertexCut = False
+)
 
 siPixelPhase1OnlineDQM_source_pprun = cms.Sequence(
    SiPixelPhase1DigisAnalyzer

--- a/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_cff.py
+++ b/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_cff.py
@@ -102,14 +102,16 @@ siPixelPhase1OnlineDQM_harvesting = cms.Sequence(
 
 ## Additional settings for cosmic runs                                                                                                                                                     
 
-SiPixelPhase1TrackClustersAnalyzer_cosmics = SiPixelPhase1TrackClustersAnalyzer.clone()
-SiPixelPhase1TrackClustersAnalyzer_cosmics.tracks  = cms.InputTag( "ctfWithMaterialTracksP5" )
-SiPixelPhase1TrackClustersAnalyzer_cosmics.VertexCut = cms.untracked.bool(False)
+SiPixelPhase1TrackClustersAnalyzer_cosmics = SiPixelPhase1TrackClustersAnalyzer.clone(
+    tracks = "ctfWithMaterialTracksP5",
+    VertexCut = False
+)
 
-SiPixelPhase1TrackResidualsAnalyzer_cosmics = SiPixelPhase1TrackResidualsAnalyzer.clone()
-SiPixelPhase1TrackResidualsAnalyzer_cosmics.Tracks = cms.InputTag( "ctfWithMaterialTracksP5" )
-SiPixelPhase1TrackResidualsAnalyzer_cosmics.trajectoryInput = "ctfWithMaterialTracksP5"
-SiPixelPhase1TrackResidualsAnalyzer_cosmics.VertexCut = cms.untracked.bool(False)
+SiPixelPhase1TrackResidualsAnalyzer_cosmics = SiPixelPhase1TrackResidualsAnalyzer.clone(
+    Tracks = "ctfWithMaterialTracksP5",
+    trajectoryInput = "ctfWithMaterialTracksP5",
+    VertexCut = False
+)
 
 siPixelPhase1OnlineDQM_source_cosmics = cms.Sequence(
    SiPixelPhase1DigisAnalyzer
@@ -121,16 +123,18 @@ siPixelPhase1OnlineDQM_source_cosmics = cms.Sequence(
 )
 
 ## Additional settings for pp_run                                                                                                                                         
-SiPixelPhase1TrackClustersAnalyzer_pprun = SiPixelPhase1TrackClustersAnalyzer.clone()
-SiPixelPhase1TrackClustersAnalyzer_pprun.tracks  = cms.InputTag( "initialStepTracksPreSplitting" )
-SiPixelPhase1TrackClustersAnalyzer_pprun.clusterShapeCache = cms.InputTag("siPixelClusterShapeCachePreSplitting")
-SiPixelPhase1TrackClustersAnalyzer_pprun.vertices = cms.InputTag('firstStepPrimaryVerticesPreSplitting')
-SiPixelPhase1TrackClustersAnalyzer_pprun.VertexCut = cms.untracked.bool(False)
+SiPixelPhase1TrackClustersAnalyzer_pprun = SiPixelPhase1TrackClustersAnalyzer.clone(
+    tracks = "initialStepTracksPreSplitting",
+    clusterShapeCache = "siPixelClusterShapeCachePreSplitting",
+    vertices = 'firstStepPrimaryVerticesPreSplitting',
+    VertexCut = False
+)
 
-SiPixelPhase1TrackResidualsAnalyzer_pprun = SiPixelPhase1TrackResidualsAnalyzer.clone()
-SiPixelPhase1TrackResidualsAnalyzer_pprun.Tracks = cms.InputTag( "initialStepTracksPreSplitting" )
-SiPixelPhase1TrackResidualsAnalyzer_pprun.trajectoryInput = "initialStepTracksPreSplitting"
-SiPixelPhase1TrackResidualsAnalyzer_pprun.VertexCut = cms.untracked.bool(False)
+SiPixelPhase1TrackResidualsAnalyzer_pprun = SiPixelPhase1TrackResidualsAnalyzer.clone(
+    Tracks = "initialStepTracksPreSplitting",
+    trajectoryInput = "initialStepTracksPreSplitting",
+    VertexCut = False
+)
 
 siPixelPhase1OnlineDQM_source_pprun = cms.Sequence(
    SiPixelPhase1DigisAnalyzer

--- a/DQM/SiPixelPhase1Track/python/SiPixelPhase1RecHits_cfi.py
+++ b/DQM/SiPixelPhase1Track/python/SiPixelPhase1RecHits_cfi.py
@@ -221,7 +221,8 @@ SiPixelPhase1RecHitsAnalyzer = DQMEDAnalyzer('SiPixelPhase1RecHits',
         histograms = SiPixelPhase1RecHitsConf,
         geometry = SiPixelPhase1Geometry,
         onlyValidHits = cms.bool(False),
-        triggerflags = trigger.SiPixelPhase1Triggers
+        triggerflags = trigger.SiPixelPhase1Triggers,
+        VertexCut = cms.untracked.bool(True)
 )
 
 SiPixelPhase1RecHitsHarvester = DQMEDHarvester("SiPixelPhase1Harvester",

--- a/DQM/SiPixelPhase1Track/python/SiPixelPhase1TrackClusters_cfi.py
+++ b/DQM/SiPixelPhase1Track/python/SiPixelPhase1TrackClusters_cfi.py
@@ -587,7 +587,8 @@ SiPixelPhase1TrackClustersAnalyzer = DQMEDAnalyzer('SiPixelPhase1TrackClusters',
         vertices = cms.InputTag("offlinePrimaryVertices"),
         histograms = SiPixelPhase1TrackClustersConf,
         geometry = SiPixelPhase1Geometry,
-        triggerflags = trigger.SiPixelPhase1Triggers
+        triggerflags = trigger.SiPixelPhase1Triggers,
+        VertexCut = cms.untracked.bool(True)
 )
 
 SiPixelPhase1TrackClustersHarvester = DQMEDHarvester("SiPixelPhase1Harvester",

--- a/DQM/SiPixelPhase1Track/python/SiPixelPhase1TrackEfficiency_cfi.py
+++ b/DQM/SiPixelPhase1Track/python/SiPixelPhase1TrackEfficiency_cfi.py
@@ -149,7 +149,8 @@ SiPixelPhase1TrackEfficiencyAnalyzer = DQMEDAnalyzer('SiPixelPhase1TrackEfficien
         tracker = cms.InputTag("MeasurementTrackerEvent"),
         histograms = SiPixelPhase1TrackEfficiencyConf,
         geometry = SiPixelPhase1Geometry,
-        triggerflags = trigger.SiPixelPhase1Triggers
+        triggerflags = trigger.SiPixelPhase1Triggers,
+        VertexCut = cms.untracked.bool(True)
 )
 
 SiPixelPhase1TrackEfficiencyHarvester = DQMEDHarvester("SiPixelPhase1Harvester",

--- a/DQM/SiPixelPhase1Track/python/SiPixelPhase1TrackResiduals_cfi.py
+++ b/DQM/SiPixelPhase1Track/python/SiPixelPhase1TrackResiduals_cfi.py
@@ -139,7 +139,8 @@ SiPixelPhase1TrackResidualsAnalyzer = DQMEDAnalyzer('SiPixelPhase1TrackResiduals
         vertices = cms.InputTag("offlinePrimaryVertices"),
         histograms = SiPixelPhase1TrackResidualsConf,
         geometry = SiPixelPhase1Geometry,
-        triggerflags = trigger.SiPixelPhase1Triggers
+        triggerflags = trigger.SiPixelPhase1Triggers,
+        VertexCut = cms.untracked.bool(True)
 )
 
 SiPixelPhase1TrackResidualsHarvester = DQMEDHarvester("SiPixelPhase1Harvester",

--- a/DQM/SiStripCommissioningSources/python/SiStripOfflineCRack_cfg.py
+++ b/DQM/SiStripCommissioningSources/python/SiStripOfflineCRack_cfg.py
@@ -131,9 +131,10 @@ process.TrackProducer.alias=('') # can we drop this?
 process.load('DQM.SiStripCommissioningSources.SiStripFineDelayHit_cfi')
 
 # Commissioning source file production
-process.CommissioningHistosWithTracking = process.CommissioningHistos.clone()
-process.CommissioningHistosWithTracking.InputModuleLabel = cms.string('siStripFineDelayHit')
-process.CommissioningHistosWithTracking.SignalToNoiseCut = cms.double(3.0)
+process.CommissioningHistosWithTracking = process.CommissioningHistos.clone(
+    InputModuleLabel = 'siStripFineDelayHit',
+    SignalToNoiseCut = cms.double(3.0)
+)
 
 # the path to run for analysis with tracking
 process.p2 = cms.Path(

--- a/DQM/SiStripCommissioningSources/python/SiStripOfflineP5_cfg.py
+++ b/DQM/SiStripCommissioningSources/python/SiStripOfflineP5_cfg.py
@@ -131,9 +131,10 @@ process.TrackProducer.alias=('') # can we drop this?
 process.load('DQM.SiStripCommissioningSources.SiStripFineDelayHit_cfi')
 
 # Commissioning source file production
-process.CommissioningHistosWithTracking = process.CommissioningHistos.clone()
-process.CommissioningHistosWithTracking.InputModuleLabel = cms.string('siStripFineDelayHit')
-process.CommissioningHistosWithTracking.SignalToNoiseCut = cms.double(3.0)
+process.CommissioningHistosWithTracking = process.CommissioningHistos.clone(
+    InputModuleLabel = 'siStripFineDelayHit',
+    SignalToNoiseCut = cms.double(3.0)
+)
 
 # the path to run for analysis with tracking
 process.p2 = cms.Path(

--- a/DQM/SiStripCommissioningSources/python/SiStripOnlineCRack_cfg.py
+++ b/DQM/SiStripCommissioningSources/python/SiStripOnlineCRack_cfg.py
@@ -129,9 +129,10 @@ process.TrackProducer.alias=('') # can we drop this?
 process.load('DQM.SiStripCommissioningSources.SiStripFineDelayHit_cfi')
 
 # Commissioning source file production
-process.CommissioningHistosWithTracking = process.CommissioningHistos.clone()
-process.CommissioningHistosWithTracking.InputModuleLabel = cms.string('siStripFineDelayHit')
-process.CommissioningHistosWithTracking.SignalToNoiseCut = cms.double(3.0)
+process.CommissioningHistosWithTracking = process.CommissioningHistos.clone(
+    InputModuleLabel = 'siStripFineDelayHit',
+    SignalToNoiseCut = cms.double(3.0)
+)
 
 # the path to run for analysis with tracking
 process.p2 = cms.Path(

--- a/DQM/SiStripCommissioningSources/python/SiStripOnlineP5NoOutput_cfg.py
+++ b/DQM/SiStripCommissioningSources/python/SiStripOnlineP5NoOutput_cfg.py
@@ -129,9 +129,10 @@ process.TrackProducer.alias=('') # can we drop this?
 process.load('DQM.SiStripCommissioningSources.SiStripFineDelayHit_cfi')
 
 # Commissioning source file production
-process.CommissioningHistosWithTracking = process.CommissioningHistos.clone()
-process.CommissioningHistosWithTracking.InputModuleLabel = cms.string('siStripFineDelayHit')
-process.CommissioningHistosWithTracking.SignalToNoiseCut = cms.double(3.0)
+process.CommissioningHistosWithTracking = process.CommissioningHistos.clone(
+    InputModuleLabel = 'siStripFineDelayHit',
+    SignalToNoiseCut = cms.double(3.0)
+)
 
 # the path to run for analysis with tracking
 process.p2 = cms.Path(

--- a/DQM/SiStripCommissioningSources/python/SiStripOnlineP5_cfg.py
+++ b/DQM/SiStripCommissioningSources/python/SiStripOnlineP5_cfg.py
@@ -129,9 +129,10 @@ process.TrackProducer.alias=('') # can we drop this?
 process.load('DQM.SiStripCommissioningSources.SiStripFineDelayHit_cfi')
 
 # Commissioning source file production
-process.CommissioningHistosWithTracking = process.CommissioningHistos.clone()
-process.CommissioningHistosWithTracking.InputModuleLabel = cms.string('siStripFineDelayHit')
-process.CommissioningHistosWithTracking.SignalToNoiseCut = cms.double(3.0)
+process.CommissioningHistosWithTracking = process.CommissioningHistos.clone(
+    InputModuleLabel = 'siStripFineDelayHit',
+    SignalToNoiseCut = cms.double(3.0)
+)
 
 # the path to run for analysis with tracking
 process.p2 = cms.Path(

--- a/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_Cosmic_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_Cosmic_cff.py
@@ -32,13 +32,11 @@ mergedSiStripQualityProducer = siStripQualityESProducer.clone(
         cms.PSet(record = cms.string('SiStripBadFiberRcd'), tag = cms.string('')),   # Bad Channel list from the selected IOV as done at PCL
         # BadChannel list from FED errors is included below
         cms.PSet(record = cms.string('RunInfoRcd'), tag = cms.string(''))            # List of FEDs exluded during data taking          
-        )
-    )
-
-mergedSiStripQualityProducer.ReduceGranularity = cms.bool(False)
-mergedSiStripQualityProducer.ThresholdForReducedGranularity = cms.double(0.3)
-mergedSiStripQualityProducer.appendToDataLabel = 'MergedBadComponent'
-
+        ),
+    ReduceGranularity = False,
+    ThresholdForReducedGranularity = 0.3,
+    appendToDataLabel = 'MergedBadComponent'
+)
 
 from DQM.SiStripMonitorClient.siStripBadComponentInfo_cfi import siStripBadComponentInfo
 siStripBadComponentInfo.StripQualityLabel = 'MergedBadComponent'

--- a/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_HeavyIons_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_HeavyIons_cff.py
@@ -43,12 +43,11 @@ mergedSiStripQualityProducer = siStripQualityESProducer.clone(
         cms.PSet(record = cms.string('SiStripBadFiberRcd'), tag = cms.string('')),   # Bad Channel list from the selected IOV as done at PCL
         # BadChannel list from FED errors is included below
         cms.PSet(record = cms.string('RunInfoRcd'), tag = cms.string(''))            # List of FEDs exluded during data taking          
-        )
-    )
-
-mergedSiStripQualityProducer.ReduceGranularity = cms.bool(False)
-mergedSiStripQualityProducer.ThresholdForReducedGranularity = cms.double(0.3)
-mergedSiStripQualityProducer.appendToDataLabel = 'MergedBadComponent'
+        ),
+    ReduceGranularity = False,
+    ThresholdForReducedGranularity = 0.3,
+    appendToDataLabel = 'MergedBadComponent'
+)
 
 from DQM.SiStripMonitorClient.siStripBadComponentInfo_cfi import siStripBadComponentInfo
 siStripBadComponentInfo.StripQualityLabel = 'MergedBadComponent'

--- a/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_cff.py
@@ -52,12 +52,11 @@ mergedSiStripQualityProducer = siStripQualityESProducer.clone(
         cms.PSet(record = cms.string('SiStripBadFiberRcd'), tag = cms.string('')),   # Bad Channel list from the selected IOV as done at PCL
         # BadChannel list from FED errors is included below
         cms.PSet(record = cms.string('RunInfoRcd'), tag = cms.string(''))            # List of FEDs exluded during data taking          
-        )
-    )
-
-mergedSiStripQualityProducer.ReduceGranularity = cms.bool(False)
-mergedSiStripQualityProducer.ThresholdForReducedGranularity = cms.double(0.3)
-mergedSiStripQualityProducer.appendToDataLabel = 'MergedBadComponent'
+        ),
+    ReduceGranularity = False,
+    ThresholdForReducedGranularity = 0.3,
+    appendToDataLabel = 'MergedBadComponent'
+)
 
 from DQM.SiStripMonitorClient.siStripBadComponentInfo_cfi import siStripBadComponentInfo
 siStripBadComponentInfo.StripQualityLabel = 'MergedBadComponent'

--- a/DQM/SiStripMonitorClient/python/SiStripDQMRecoConfigOfflineGlobalRunCAF_cfi.py
+++ b/DQM/SiStripMonitorClient/python/SiStripDQMRecoConfigOfflineGlobalRunCAF_cfi.py
@@ -8,19 +8,22 @@ from DQM.SiStripMonitorClient.RecoForDQM_Cosmic_cff import *
 from RecoTracker.TrackProducer.TrackRefitters_cff import *
 # cosmic track finder #
 import RecoTracker.TrackProducer.TrackRefitters_cff 
-cosmictrackfinderP5Refitter                   = RecoTracker.TrackProducer.TrackRefitters_cff.TrackRefitter.clone()
-cosmictrackfinderP5Refitter.src               = 'cosmictrackfinderP5'
-cosmictrackfinderP5Refitter.TrajectoryInEvent = True
+cosmictrackfinderP5Refitter = RecoTracker.TrackProducer.TrackRefitters_cff.TrackRefitter.clone(
+    src = 'cosmictrackfinderP5',
+    TrajectoryInEvent = True
+)
 # CTF #
 import RecoTracker.TrackProducer.TrackRefitters_cff
-ctfWithMaterialTracksP5Refitter                   = RecoTracker.TrackProducer.TrackRefitters_cff.TrackRefitter.clone()
-ctfWithMaterialTracksP5Refitter.src               = 'ctfWithMaterialTracksP5'
-ctfWithMaterialTracksP5Refitter.TrajectoryInEvent = True
+ctfWithMaterialTracksP5Refitter = RecoTracker.TrackProducer.TrackRefitters_cff.TrackRefitter.clone(
+    src = 'ctfWithMaterialTracksP5',
+    TrajectoryInEvent = True
+)
 # RS #
 import RecoTracker.TrackProducer.TrackRefitters_cff
-rsWithMaterialTracksP5Refitter                   = RecoTracker.TrackProducer.TrackRefitters_cff.TrackRefitter.clone()
-rsWithMaterialTracksP5Refitter.src               = 'rsWithMaterialTracksP5'
-rsWithMaterialTracksP5Refitter.TrajectoryInEvent = True
+rsWithMaterialTracksP5Refitter = RecoTracker.TrackProducer.TrackRefitters_cff.TrackRefitter.clone(
+    src = 'rsWithMaterialTracksP5',
+    TrajectoryInEvent = True
+)
 
 ## Scheduling ##
 # additional reco needed for running from RAW #

--- a/DQM/SiStripMonitorClient/python/SiStripDQMSourceConfigOfflineGlobalRunCAF_cfi.py
+++ b/DQM/SiStripMonitorClient/python/SiStripDQMSourceConfigOfflineGlobalRunCAF_cfi.py
@@ -15,68 +15,79 @@ DqmEventInfoSiStrip = cms.EDAnalyzer( "DQMEventInfo",
 
 # SiStripMonitoDigi
 import DQM.SiStripMonitorDigi.SiStripMonitorDigi_cfi
-SiStripMonitorDigiCAF                    = DQM.SiStripMonitorDigi.SiStripMonitorDigi_cfi.SiStripMonitorDigi.clone()
-SiStripMonitorDigiCAF.SelectAllDetectors = True
+SiStripMonitorDigiCAF = DQM.SiStripMonitorDigi.SiStripMonitorDigi_cfi.SiStripMonitorDigi.clone(
+    SelectAllDetectors = True
+)
 
 # SiStripMonitorCluster
 import DQM.SiStripMonitorCluster.SiStripMonitorCluster_cfi
-SiStripMonitorClusterCAF = DQM.SiStripMonitorCluster.SiStripMonitorCluster_cfi.SiStripMonitorCluster.clone()
-SiStripMonitorClusterCAF.SelectAllDetectors  = True
-SiStripMonitorClusterCAF.StripQualityLabel   = ''
+SiStripMonitorClusterCAF = DQM.SiStripMonitorCluster.SiStripMonitorCluster_cfi.SiStripMonitorCluster.clone(
+    SelectAllDetectors = True,
+    StripQualityLabel = ''
+)
 
 # SiStripMonitorTrack
 # clone for cosmic track finder
 import DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi
-SiStripMonitorTrackCAF_cosmicTk = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone()
-SiStripMonitorTrackCAF_cosmicTk.TrackProducer = 'cosmictrackfinderP5Refitter'
-SiStripMonitorTrackCAF_cosmicTk.Mod_On        = True
+SiStripMonitorTrackCAF_cosmicTk = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone(
+    TrackProducer = 'cosmictrackfinderP5Refitter',
+    Mod_On = True
+)
 # clone for CTF track finder
 import DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi
-SiStripMonitorTrackCAF_ckf = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone()
-SiStripMonitorTrackCAF_ckf.TrackProducer = 'ctfWithMaterialTracksP5Refitter'
-SiStripMonitorTrackCAF_ckf.Mod_On        = True
+SiStripMonitorTrackCAF_ckf = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone(
+    TrackProducer = 'ctfWithMaterialTracksP5Refitter',
+    Mod_On = True
+)
 # clone for RS track finder
 import DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi
-SiStripMonitorTrackCAF_rs = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone()
-SiStripMonitorTrackCAF_rs.TrackProducer = 'rsWithMaterialTracksP5Refitter'
-SiStripMonitorTrackCAF_rs.Mod_On        = True
+SiStripMonitorTrackCAF_rs = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone(
+    TrackProducer = 'rsWithMaterialTracksP5Refitter',
+    Mod_On = True
+)
 
 # TrackerMonitorTrack
 # clone for cosmic track finder
 import DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi
-MonitorTrackResidualsCAF_cosmicTk = DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi.MonitorTrackResiduals.clone()
-MonitorTrackResidualsCAF_cosmicTk.Tracks              = 'cosmictrackfinderP5'
-MonitorTrackResidualsCAF_cosmicTk.trajectoryInput     = 'cosmictrackfinderP5Refitter'
+MonitorTrackResidualsCAF_cosmicTk = DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi.MonitorTrackResiduals.clone(
+    Tracks = 'cosmictrackfinderP5',
+    trajectoryInput = 'cosmictrackfinderP5Refitter'
+)
 # clone for CTF track finder
 import DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi
-MonitorTrackResidualsCAF_ckf = DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi.MonitorTrackResiduals.clone()
-MonitorTrackResidualsCAF_ckf.Tracks              = 'ctfWithMaterialTracksP5'
-MonitorTrackResidualsCAF_ckf.trajectoryInput     = 'ctfWithMaterialTracksP5Refitter'
+MonitorTrackResidualsCAF_ckf = DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi.MonitorTrackResiduals.clone(
+    Tracks = 'ctfWithMaterialTracksP5',
+    trajectoryInput = 'ctfWithMaterialTracksP5Refitter'
+)
 # clone for RS track finder
 import DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi
-MonitorTrackResidualsCAF_rs = DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi.MonitorTrackResiduals.clone()
-MonitorTrackResidualsCAF_rs.Tracks              = 'rsWithMaterialTracksP5'
-MonitorTrackResidualsCAF_rs.trajectoryInput     = 'rsWithMaterialTracksP5Refitter'
+MonitorTrackResidualsCAF_rs = DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi.MonitorTrackResiduals.clone(
+    Tracks = 'rsWithMaterialTracksP5',
+    trajectoryInput = 'rsWithMaterialTracksP5Refitter'
+)
 
 # TrackingMonitor
 # clone for cosmic track finder
 import DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi
-TrackMonCAF_cosmicTk = DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi.TrackerCosmicTrackMon.clone()
-TrackMonCAF_cosmicTk.TrackProducer = 'cosmictrackfinderP5'
-TrackMonCAF_cosmicTk.AlgoName      = 'CosmicTk'
-TrackMonCAF_cosmicTk.FolderName    = 'SiStrip/Tracks'
+TrackMonCAF_cosmicTk = DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi.TrackerCosmicTrackMon.clone(
+    TrackProducer = 'cosmictrackfinderP5',
+    AlgoName = 'CosmicTk',
+    FolderName = 'SiStrip/Tracks'
+)
 # clone for CTF track finder
 import DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi
-TrackMonCAF_ckf = DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi.TrackerCosmicTrackMon.clone()
-TrackMonCAF_ckf.TrackProducer = 'ctfWithMaterialTracksP5'
-TrackMonCAF_ckf.AlgoName      = 'CKFTk'
-TrackMonCAF_ckf.FolderName    = 'SiStrip/Tracks'
+TrackMonCAF_ckf = DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi.TrackerCosmicTrackMon.clone(
+    TrackProducer = 'ctfWithMaterialTracksP5',
+    AlgoName = 'CKFTk',
+    FolderName = 'SiStrip/Tracks'
+)
 # clone for RS track finder
 import DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi
-TrackMonCAF_rs = DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi.TrackerCosmicTrackMon.clone()
-TrackMonCAF_rs.TrackProducer = 'rsWithMaterialTracksP5'
-TrackMonCAF_rs.AlgoName      = 'RSTk'
-TrackMonCAF_rs.FolderName    = 'SiStrip/Tracks'
+TrackMonCAF_rs = DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi.TrackerCosmicTrackMon.clone(
+    TrackProducer = 'rsWithMaterialTracksP5',
+    AlgoName = 'RSTk',
+    FolderName = 'SiStrip/Tracks'
+)
 
 # Scheduling
 SiStripDQMSourceGlobalRunCAF_fromRAW  = cms.Sequence( siStripFEDMonitor )

--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigHVOff_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigHVOff_cff.py
@@ -1,75 +1,110 @@
 # SiStripMonitorDigi ####
-import DQM.SiStripMonitorDigi.SiStripMonitorDigi_cfi
-SiStripMonitorDigiHVOff = DQM.SiStripMonitorDigi.SiStripMonitorDigi_cfi.SiStripMonitorDigi.clone()
-SiStripMonitorDigiHVOff.SelectAllDetectors  = True
-SiStripMonitorDigiHVOff.Mod_On              = False
-SiStripMonitorDigiHVOff.TkHistoMap_On       = False
-SiStripMonitorDigiHVOff.UseDCSFiltering     = False
-
-SiStripMonitorDigiHVOff.TProfTotalNumberOfDigis.subdetswitchon = True
-SiStripMonitorDigiHVOff.TProfDigiApvCycle.subdetswitchon   = False
-
-SiStripMonitorDigiHVOff.TH1ADCsCoolestStrip.moduleswitchon = False
-SiStripMonitorDigiHVOff.TH1ADCsCoolestStrip.layerswitchon   = False
-
-SiStripMonitorDigiHVOff.TH1ADCsHottestStrip.moduleswitchon = False
-SiStripMonitorDigiHVOff.TH1ADCsHottestStrip.layerswitchon  = False
-
-SiStripMonitorDigiHVOff.TH1DigiADCs.moduleswitchon         = False
-SiStripMonitorDigiHVOff.TH1DigiADCs.layerswitchon          = False
-
-SiStripMonitorDigiHVOff.TH1NumberOfDigis.moduleswitchon    = False
-SiStripMonitorDigiHVOff.TH1NumberOfDigis.layerswitchon     = False
-
-SiStripMonitorDigiHVOff.TH1StripOccupancy.moduleswitchon   = False
-SiStripMonitorDigiHVOff.TH1StripOccupancy.layerswitchon    = False
-
+from DQM.SiStripMonitorDigi.SiStripMonitorDigi_cfi import *
+SiStripMonitorDigiHVOff = SiStripMonitorDigi.clone(
+    SelectAllDetectors = True,
+    Mod_On = False,
+    TkHistoMap_On = False,
+    UseDCSFiltering = False,
+    TProfTotalNumberOfDigis = SiStripMonitorDigi.TProfTotalNumberOfDigis.clone(
+        subdetswitchon = True
+    ),
+    TProfDigiApvCycle = SiStripMonitorDigi.TProfDigiApvCycle.clone(
+        subdetswitchon = False
+    ),
+    TH1ADCsCoolestStrip = SiStripMonitorDigi.TH1ADCsCoolestStrip.clone(
+        moduleswitchon = False,
+        layerswitchon = False
+    ),
+    TH1ADCsHottestStrip = SiStripMonitorDigi.TH1ADCsHottestStrip.clone(
+        moduleswitchon = False,
+        layerswitchon = False
+    ),
+    TH1DigiADCs = SiStripMonitorDigi.TH1DigiADCs.clone(
+        moduleswitchon = False,
+        layerswitchon = False
+    ),
+    TH1NumberOfDigis = SiStripMonitorDigi.TH1NumberOfDigis.clone(
+        moduleswitchon = False,
+        layerswitchon = False
+    ),
+    TH1StripOccupancy = SiStripMonitorDigi.TH1StripOccupancy.clone(
+        moduleswitchon = False,
+        layerswitchon = False
+    )
+)
 
 # SiStripMonitorCluster ####
-import DQM.SiStripMonitorCluster.SiStripMonitorCluster_cfi
-SiStripMonitorClusterHVOff = DQM.SiStripMonitorCluster.SiStripMonitorCluster_cfi.SiStripMonitorCluster.clone()
-SiStripMonitorClusterHVOff.SelectAllDetectors  = True
-SiStripMonitorClusterHVOff.Mod_On              = False
-SiStripMonitorClusterHVOff.TkHistoMap_On       = False
-SiStripMonitorClusterHVOff.TProfTotalNumberOfClusters.subdetswitchon = True
-SiStripMonitorClusterHVOff.TProfClustersApvCycle.subdetswitchon = False
-SiStripMonitorClusterHVOff.UseDCSFiltering     = False
-
-SiStripMonitorClusterHVOff.TH1ClusterNoise.layerswitchon = False
-SiStripMonitorClusterHVOff.TH1ClusterNoise.moduleswitchon = False
-
-SiStripMonitorClusterHVOff.TH1NrOfClusterizedStrips.layerswitchon = False
-SiStripMonitorClusterHVOff.TH1NrOfClusterizedStrips.moduleswitchon = False
-
-SiStripMonitorClusterHVOff.TH1ClusterPos.layerswitchon = False
-SiStripMonitorClusterHVOff.TH1ClusterPos.moduleswitchon = False
-
-SiStripMonitorClusterHVOff.TH1ClusterDigiPos.layerswitchon = False
-SiStripMonitorClusterHVOff.TH1ClusterDigiPos.moduleswitchon = False
-
-SiStripMonitorClusterHVOff.TH1ModuleLocalOccupancy.layerswitchon = False
-SiStripMonitorClusterHVOff.TH1ModuleLocalOccupancy.moduleswitchon = False
-
-SiStripMonitorClusterHVOff.TH1nClusters.layerswitchon = False
-SiStripMonitorClusterHVOff.TH1nClusters.moduleswitchon = False
-
-SiStripMonitorClusterHVOff.TH1ClusterStoN.layerswitchon = False
-SiStripMonitorClusterHVOff.TH1ClusterStoN.moduleswitchon = False
-
-SiStripMonitorClusterHVOff.TH1ClusterStoNVsPos.layerswitchon = False
-SiStripMonitorClusterHVOff.TH1ClusterStoNVsPos.moduleswitchon = False
-
-SiStripMonitorClusterHVOff.TH1ClusterCharge.layerswitchon = False
-SiStripMonitorClusterHVOff.TH1ClusterCharge.moduleswitchon = False
-
-SiStripMonitorClusterHVOff.TH1ClusterWidth.layerswitchon = False
-SiStripMonitorClusterHVOff.TH1ClusterWidth.moduleswitchon = False
-
-SiStripMonitorClusterHVOff.TProfClustersVsDBxCycle.subdetswitchon = False
-SiStripMonitorClusterHVOff.TH2ApvCycleVsDBxGlobal.globalswitchon = False
-
-SiStripMonitorClusterHVOff.TH2CStripVsCpixel.globalswitchon=True
-SiStripMonitorClusterHVOff.TH1MultiplicityRegions.globalswitchon=True
-SiStripMonitorClusterHVOff.TH1MainDiagonalPosition.globalswitchon=True
-SiStripMonitorClusterHVOff.TH1StripNoise2ApvCycle.globalswitchon=True
-SiStripMonitorClusterHVOff.TH1StripNoise3ApvCycle.globalswitchon=True
+from DQM.SiStripMonitorCluster.SiStripMonitorCluster_cfi import *
+SiStripMonitorClusterHVOff = SiStripMonitorCluster.clone(
+    SelectAllDetectors = True,
+    Mod_On = False,
+    TkHistoMap_On = False,
+    TProfTotalNumberOfClusters = SiStripMonitorCluster.TProfTotalNumberOfClusters.clone(
+        subdetswitchon = True
+    ),
+    TProfClustersApvCycle = SiStripMonitorCluster.TProfClustersApvCycle.clone(
+        subdetswitchon = False
+    ),
+    UseDCSFiltering = False,
+    TH1ClusterNoise = SiStripMonitorCluster.TH1ClusterNoise.clone(
+        layerswitchon = False,
+        moduleswitchon = False
+    ),
+    TH1NrOfClusterizedStrips = SiStripMonitorCluster.TH1NrOfClusterizedStrips.clone(
+        layerswitchon = False,
+        moduleswitchon = False
+    ),
+    TH1ClusterPos = SiStripMonitorCluster.TH1ClusterPos.clone(
+        layerswitchon = False,
+        moduleswitchon = False
+    ),
+    TH1ClusterDigiPos = SiStripMonitorCluster.TH1ClusterDigiPos.clone(
+        layerswitchon = False,
+        moduleswitchon = False
+    ),
+    TH1ModuleLocalOccupancy = SiStripMonitorCluster.TH1ModuleLocalOccupancy.clone(
+        layerswitchon = False,
+        moduleswitchon = False
+    ),
+    TH1nClusters = SiStripMonitorCluster.TH1nClusters.clone(
+        layerswitchon = False,
+        moduleswitchon = False
+    ),
+    TH1ClusterStoN = SiStripMonitorCluster.TH1ClusterStoN.clone(
+        layerswitchon = False,
+        moduleswitchon = False
+    ),
+    TH1ClusterStoNVsPos = SiStripMonitorCluster.TH1ClusterStoNVsPos.clone(
+        layerswitchon = False,
+        moduleswitchon = False
+    ),
+    TH1ClusterCharge = SiStripMonitorCluster.TH1ClusterCharge.clone(
+        layerswitchon = False,
+        moduleswitchon = False
+    ),
+    TH1ClusterWidth = SiStripMonitorCluster.TH1ClusterWidth.clone(
+        layerswitchon = False,
+        moduleswitchon = False
+    ),
+    TProfClustersVsDBxCycle = SiStripMonitorCluster.TProfClustersVsDBxCycle.clone(
+        subdetswitchon = False
+    ),
+    TH2ApvCycleVsDBxGlobal = SiStripMonitorCluster.TH2ApvCycleVsDBxGlobal.clone(
+        globalswitchon = False
+    ),
+    TH2CStripVsCpixel = SiStripMonitorCluster.TH2CStripVsCpixel.clone(
+        globalswitchon = True
+    ),
+    TH1MultiplicityRegions = SiStripMonitorCluster.TH1MultiplicityRegions.clone(
+        globalswitchon = True
+    ),
+    TH1MainDiagonalPosition = SiStripMonitorCluster.TH1MainDiagonalPosition.clone(
+        globalswitchon = True
+    ),
+    TH1StripNoise2ApvCycle = SiStripMonitorCluster.TH1StripNoise2ApvCycle.clone(
+        globalswitchon = True
+    ),
+    TH1StripNoise3ApvCycle = SiStripMonitorCluster.TH1StripNoise3ApvCycle.clone(
+        globalswitchon = True
+    )
+)

--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigP5_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigP5_cff.py
@@ -37,92 +37,129 @@ SiStripMonitorDigi.TH1NumberOfDigis.moduleswitchon = False
 from DQM.SiStripMonitorDigi.SiStripBaselineValidator_cfi import *
 
 # SiStripMonitorCluster ####
-import DQM.SiStripMonitorCluster.SiStripMonitorCluster_cfi
-SiStripMonitorClusterReal = DQM.SiStripMonitorCluster.SiStripMonitorCluster_cfi.SiStripMonitorCluster.clone()
-SiStripMonitorClusterReal.SelectAllDetectors = True
-SiStripMonitorClusterReal.TProfTotalNumberOfClusters.subdetswitchon = True
-SiStripMonitorClusterReal.TProfClustersApvCycle.subdetswitchon = True
-SiStripMonitorClusterReal.TH2CStripVsCpixel.globalswitchon=True
-SiStripMonitorClusterReal.TH1MultiplicityRegions.globalswitchon=True
-SiStripMonitorClusterReal.TH1MainDiagonalPosition.globalswitchon=True
-SiStripMonitorClusterReal.TH1StripNoise2ApvCycle.globalswitchon=True
-SiStripMonitorClusterReal.TH1StripNoise3ApvCycle.globalswitchon=True
-SiStripMonitorClusterReal.ClusterHisto = True
+from DQM.SiStripMonitorCluster.SiStripMonitorCluster_cfi import *
+SiStripMonitorClusterReal = SiStripMonitorCluster.clone(
+    SelectAllDetectors = True,
+    TProfTotalNumberOfClusters = SiStripMonitorCluster.TProfTotalNumberOfClusters.clone(
+        subdetswitchon = True
+    ),
+    TProfClustersApvCycle = SiStripMonitorCluster.TProfClustersApvCycle.clone(
+        subdetswitchon = True
+    ),
+    TH2CStripVsCpixel = SiStripMonitorCluster.TH2CStripVsCpixel.clone(
+        globalswitchon = True
+    ),
+    TH1MultiplicityRegions = SiStripMonitorCluster.TH1MultiplicityRegions.clone(
+        globalswitchon = True
+    ),
+    TH1MainDiagonalPosition = SiStripMonitorCluster.TH1MainDiagonalPosition.clone(
+        globalswitchon = True
+    ),
+    TH1StripNoise2ApvCycle = SiStripMonitorCluster.TH1StripNoise2ApvCycle.clone(
+        globalswitchon = True
+    ),
+    TH1StripNoise3ApvCycle = SiStripMonitorCluster.TH1StripNoise3ApvCycle.clone(
+        globalswitchon = True
+    ),
+    ClusterHisto = True,
+    # removing some histograms
+    TH1NrOfClusterizedStrips = SiStripMonitorCluster.TH1NrOfClusterizedStrips.clone(
+        moduleswitchon = False
+    ),
+    TH1ClusterNoise = SiStripMonitorCluster.TH1ClusterNoise.clone(
+        moduleswitchon = False
+    ),
+    TH1ClusterStoN = SiStripMonitorCluster.TH1ClusterStoN.clone(
+        moduleswitchon = False
+    ),
+    TH1ClusterCharge = SiStripMonitorCluster.TH1ClusterCharge.clone(
+        moduleswitchon = False
+    ),
+    TH1ClusterWidth = SiStripMonitorCluster.TH1ClusterWidth.clone(
+        moduleswitchon = False
+    ),
+    TH1ModuleLocalOccupancy = SiStripMonitorCluster.TH1ModuleLocalOccupancy.clone(
+        moduleswitchon = False
+    ),
+    TH1nClusters = SiStripMonitorCluster.TH1nClusters.clone(
+        moduleswitchon = False
+    ),
+    TH1ClusterPos = SiStripMonitorCluster.TH1ClusterPos.clone(
+        moduleswitchon = False
+    )
+)
 
-# removing some histograms
-SiStripMonitorClusterReal.TH1NrOfClusterizedStrips.moduleswitchon = False
-SiStripMonitorClusterReal.TH1ClusterNoise.moduleswitchon = False
-SiStripMonitorClusterReal.TH1ClusterStoN.moduleswitchon = False
-SiStripMonitorClusterReal.TH1ClusterCharge.moduleswitchon = False
-SiStripMonitorClusterReal.TH1ClusterWidth.moduleswitchon = False
-SiStripMonitorClusterReal.TH1ModuleLocalOccupancy.moduleswitchon = False
-SiStripMonitorClusterReal.TH1nClusters.moduleswitchon = False
-SiStripMonitorClusterReal.TH1ClusterPos.moduleswitchon = False
-
-# SiStripMonitorTrack ####
 # Clone for Cosmic Track Finder
 import DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi
-SiStripMonitorTrack_cosmicTk = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone()
-SiStripMonitorTrack_cosmicTk.TrackProducer = 'cosmictrackfinderP5'
-SiStripMonitorTrack_cosmicTk.Mod_On        = False
+SiStripMonitorTrack_cosmicTk = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone(
+    TrackProducer = 'cosmictrackfinderP5',
+    Mod_On = False
+)
 
 # Clone for CKF Tracks
-SiStripMonitorTrack_ckf = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone()
-SiStripMonitorTrack_ckf.TrackProducer      = 'ctfWithMaterialTracksP5'
-SiStripMonitorTrack_ckf.Mod_On             = False
+SiStripMonitorTrack_ckf = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone(
+    TrackProducer = 'ctfWithMaterialTracksP5',
+    Mod_On = False
+)
 
 # Clone fir Road Search  Tracks
-#SiStripMonitorTrack_rs = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone()
-#SiStripMonitorTrack_rs.TrackProducer       = 'rsWithMaterialTracksP5'
-#SiStripMonitorTrack_rs.Mod_On              = True
+# SiStripMonitorTrack_rs = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone(
+#     TrackProducer = 'rsWithMaterialTracksP5',
+#     Mod_On = True
+# )
 
 # Clone for General Tracks (for Collision)
 SiStripMonitorTrack_gentk = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone(
-   TrackProducer    = 'generalTracks',
-   Mod_On           = False
+    TrackProducer = 'generalTracks',
+    Mod_On = False
 )
 
 # Clone for Heavy Ion Tracks (for HI Collisions)
-SiStripMonitorTrack_hi = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone()
-SiStripMonitorTrack_hi.TrackProducer    = 'hiGeneralTracks'
-SiStripMonitorTrack_hi.Mod_On           = True
+SiStripMonitorTrack_hi = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone(
+    TrackProducer = 'hiGeneralTracks',
+    Mod_On = True
+)
 
 # TrackerMonitorTrack ####
 # Clone for Cosmic Track Finder
-#import DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi
-#MonitorTrackResiduals_cosmicTk = DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi.MonitorTrackResiduals.clone()
-#MonitorTrackResiduals_cosmicTk.Tracks              = 'cosmictrackfinderP5'
-#MonitorTrackResiduals_cosmicTk.trajectoryInput     = 'cosmictrackfinderP5'
-#MonitorTrackResiduals_cosmicTk.Mod_On              = False
+# import DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi
+# MonitorTrackResiduals_cosmicTk = DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi.MonitorTrackResiduals.clone(
+#     Tracks = 'cosmictrackfinderP5',
+#     trajectoryInput = 'cosmictrackfinderP5',
+#     Mod_On = False
+# )
 
 # Clone for CKF Tracks
-#import DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi
-#MonitorTrackResiduals_ckf = DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi.MonitorTrackResiduals.clone()
-#MonitorTrackResiduals_ckf.Tracks                   = 'ctfWithMaterialTracksP5'
-#MonitorTrackResiduals_ckf.trajectoryInput          = 'ctfWithMaterialTracksP5'
-#MonitorTrackResiduals_ckf.Mod_On                   = False
+# import DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi
+# MonitorTrackResiduals_ckf = DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi.MonitorTrackResiduals.clone(
+#     Tracks = 'ctfWithMaterialTracksP5',
+#     trajectoryInput = 'ctfWithMaterialTracksP5',
+#     Mod_On = False
+# )
 
 # Clone for Road Search  Tracks
-#import DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi
-#MonitorTrackResiduals_rs = DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi.MonitorTrackResiduals.clone()
-#MonitorTrackResiduals_rs.Tracks                    = 'rsWithMaterialTracksP5'
-#MonitorTrackResiduals_rs.trajectoryInput           = 'rsWithMaterialTracksP5'
-#MonitorTrackResiduals_rs.Mod_On                    = False
+# import DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi
+# MonitorTrackResiduals_rs = DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi.MonitorTrackResiduals.clone(
+#     Tracks = 'rsWithMaterialTracksP5',
+#     trajectoryInput = 'rsWithMaterialTracksP5',
+#     Mod_On = False
+# )
 
 # Clone for General Track (for Collision data)
 import DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi
 MonitorTrackResiduals_gentk = DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi.MonitorTrackResiduals.clone(
-   Tracks                 = 'generalTracks',
-   trajectoryInput        = 'generalTracks',
-   Mod_On                 = False
+    Tracks = 'generalTracks',
+    trajectoryInput = 'generalTracks',
+    Mod_On = False
 )
 
 # Clone for Heavy Ion Tracks (for HI Collisions)
-#import DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi
-#MonitorTrackResiduals_hi = DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi.MonitorTrackResiduals.clone()
-#MonitorTrackResiduals_hi.Tracks                 = 'hiGeneralTracks'
-#MonitorTrackResiduals_hi.trajectoryInput        = 'hiGeneralTracks'
-#MonitorTrackResiduals_hi.Mod_On                 = False
+# import DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi
+# MonitorTrackResiduals_hi = DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi.MonitorTrackResiduals.clone(
+#     Tracks = 'hiGeneralTracks',
+#     trajectoryInput = 'hiGeneralTracks',
+#     Mod_On = False
+# )
 
 # Services needed for TkHistoMap
 from CalibTracker.SiStripCommon.TkDetMapESProducer_cfi import *

--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_Cosmic_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_Cosmic_cff.py
@@ -60,41 +60,47 @@ SiStripMonitorCluster.TH1NClusPx.xmax = cms.double(999.5)
 
 # SiStripMonitorTrack ####
 # Clone for Cosmic Tracks
-import DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi
-SiStripMonitorTrack_cosmicTk  = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone()
-SiStripMonitorTrack_cosmicTk.TrackProducer = 'cosmictrackfinderP5'
-SiStripMonitorTrack_cosmicTk.Mod_On        = False
+from DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi import *
+SiStripMonitorTrack_cosmicTk  = SiStripMonitorTrack.clone(
+    TrackProducer = 'cosmictrackfinderP5',
+    Mod_On = False
+)
 
 # Clone for CKF Tracks
-SiStripMonitorTrack_ckf = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone()
-SiStripMonitorTrack_ckf.TrackProducer      = 'ctfWithMaterialTracksP5'
-SiStripMonitorTrack_ckf.Mod_On             = False
-SiStripMonitorTrack_ckf.TH1nClustersOff.xmax = cms.double(1999.5)
+SiStripMonitorTrack_ckf = SiStripMonitorTrack.clone(
+    TrackProducer = 'ctfWithMaterialTracksP5',
+    Mod_On = False,
+    TH1nClustersOff = SiStripMonitorTrack.TH1nClustersOff.clone(
+        xmax = 1999.5
+    )
+)
 
 # Clone for Road Search  Tracks
-#import DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi
-#SiStripMonitorTrack_rs = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone()
-#SiStripMonitorTrack_rs.TrackProducer       = 'rsWithMaterialTracksP5'
-#SiStripMonitorTrack_rs.Mod_On              = False
+# SiStripMonitorTrack_rs = SiStripMonitorTrack.clone(
+#     TrackProducer = 'rsWithMaterialTracksP5',
+#     Mod_On = False
+# )
 
 # TrackerMonitorTrack ####
 # Clone for Cosmic Track Finder
-import DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi
-MonitorTrackResiduals_cosmicTk = DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi.MonitorTrackResiduals.clone()
-MonitorTrackResiduals_cosmicTk.trajectoryInput     = 'cosmictrackfinderP5'
-MonitorTrackResiduals_cosmicTk.Tracks              = 'cosmictrackfinderP5'
-MonitorTrackResiduals_cosmicTk.Mod_On              = False
+from DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi import *
+MonitorTrackResiduals_cosmicTk = MonitorTrackResiduals.clone(
+    trajectoryInput = 'cosmictrackfinderP5',
+    Tracks = 'cosmictrackfinderP5',
+    Mod_On = False
+)
 # Clone for CKF Tracks
-MonitorTrackResiduals_ckf = DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi.MonitorTrackResiduals.clone()
-MonitorTrackResiduals_ckf.trajectoryInput          = 'ctfWithMaterialTracksP5'
-MonitorTrackResiduals_ckf.Tracks                   = 'ctfWithMaterialTracksP5'
-MonitorTrackResiduals_ckf.Mod_On                   = False
+MonitorTrackResiduals_ckf = MonitorTrackResiduals.clone(
+    trajectoryInput = 'ctfWithMaterialTracksP5',
+    Tracks = 'ctfWithMaterialTracksP5',
+    Mod_On = False
+)
 # Clone for Road Search  Tracks
-#import DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi
-#MonitorTrackResiduals_rs = DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi.MonitorTrackResiduals.clone()
-#MonitorTrackResiduals_rs.trajectoryInput           = 'rsWithMaterialTracksP5'
-#MonitorTrackResiduals_rs.Tracks                    = 'rsWithMaterialTracksP5'
-#MonitorTrackResiduals_rs.Mod_On                    = False
+# MonitorTrackResiduals_rs = MonitorTrackResiduals.clone(
+#     trajectoryInput = 'rsWithMaterialTracksP5',
+#     Tracks = 'rsWithMaterialTracksP5',
+#     Mod_On = False
+# )
 
 # DQM Services
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer

--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_HeavyIons_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_HeavyIons_cff.py
@@ -32,18 +32,18 @@ SiStripMonitorCluster.StripDCSfilter = cms.PSet(
 
 # SiStripMonitorTrack ####
 import DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi
-SiStripMonitorTrack_hi  = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone()
-SiStripMonitorTrack_hi.TrackProducer = "hiGeneralTracks"
-SiStripMonitorTrack_hi.Mod_On        = False
+SiStripMonitorTrack_hi  = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone(
+    TrackProducer = "hiGeneralTracks",
+    Mod_On = False
+)
 
 # TrackerMonitorTrack ####
 import DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi
-MonitorTrackResiduals_hi = DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi.MonitorTrackResiduals.clone()
-MonitorTrackResiduals_hi.Tracks              = 'hiGeneralTracks'
-MonitorTrackResiduals_hi.trajectoryInput     = "hiGeneralTracks"
-MonitorTrackResiduals_hi.Mod_On              = False
-
-
+MonitorTrackResiduals_hi = DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi.MonitorTrackResiduals.clone(
+    Tracks = 'hiGeneralTracks',
+    trajectoryInput = "hiGeneralTracks",
+    Mod_On = False
+)
 
 SiStripDQMTier0_hi = cms.Sequence(APVPhases * consecutiveHEs *
                                   siStripFEDCheck * siStripFEDMonitor *

--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_cff.py
@@ -37,32 +37,35 @@ from DQM.SiStripMonitorClient.pset4GenericTriggerEventFlag_cfi import *
 
 # SiStripMonitorCluster ####
 from DQM.SiStripMonitorCluster.SiStripMonitorCluster_cfi import *
-SiStripMonitorClusterBPTX = SiStripMonitorCluster.clone()
-SiStripMonitorClusterBPTX.Mod_On = False
-SiStripMonitorClusterBPTX.TH1TotalNumberOfClusters.subdetswitchon   = True
-SiStripMonitorClusterBPTX.TProfClustersApvCycle.subdetswitchon      = True
-SiStripMonitorClusterBPTX.TProfTotalNumberOfClusters.subdetswitchon = True 
-SiStripMonitorClusterBPTX.TrendVs10LS = False
-SiStripMonitorClusterBPTX.TH2CStripVsCpixel.globalswitchon       = True
-SiStripMonitorClusterBPTX.TH1MultiplicityRegions.globalswitchon  = True
-SiStripMonitorClusterBPTX.TH1MainDiagonalPosition.globalswitchon = True
-SiStripMonitorClusterBPTX.TH1StripNoise2ApvCycle.globalswitchon  = True
-SiStripMonitorClusterBPTX.TH1StripNoise3ApvCycle.globalswitchon  = True
-SiStripMonitorClusterBPTX.ClusterHisto = True
-SiStripMonitorClusterBPTX.BPTXfilter = genericTriggerEventFlag4L1bd
-SiStripMonitorClusterBPTX.PixelDCSfilter = cms.PSet(
-    andOr         = cms.bool( False ),
-    dcsInputTag   = cms.InputTag( "scalersRawToDigi" ),
-    dcsPartitions = cms.vint32 ( 28, 29),
-    andOrDcs      = cms.bool( False ),
-    errorReplyDcs = cms.bool( True ),
-)
-SiStripMonitorClusterBPTX.StripDCSfilter = cms.PSet(
-    andOr         = cms.bool( False ),
-    dcsInputTag   = cms.InputTag( "scalersRawToDigi" ),
-    dcsPartitions = cms.vint32 ( 24, 25, 26, 27 ),
-    andOrDcs      = cms.bool( False ),
-    errorReplyDcs = cms.bool( True ),
+SiStripMonitorClusterBPTX = SiStripMonitorCluster.clone(
+    Mod_On = False,
+    TH1TotalNumberOfClusters = SiStripMonitorCluster.TH1TotalNumberOfClusters.clone(
+        subdetswitchon = True
+    ),
+    TProfClustersApvCycle = SiStripMonitorCluster.TProfClustersApvCycle.clone(
+        subdetswitchon = True
+    ),
+    TProfTotalNumberOfClusters = SiStripMonitorCluster.TProfTotalNumberOfClusters.clone(
+        subdetswitchon = True
+    ),
+    TrendVs10LS = False,
+    TH2CStripVsCpixel = SiStripMonitorCluster.TH2CStripVsCpixel.clone(
+        globalswitchon = True
+    ),
+    TH1MultiplicityRegions = SiStripMonitorCluster.TH1MultiplicityRegions.clone(
+        globalswitchon = True
+    ),
+    TH1MainDiagonalPosition = SiStripMonitorCluster.TH1MainDiagonalPosition.clone(
+        globalswitchon = True
+    ),
+    TH1StripNoise2ApvCycle = SiStripMonitorCluster.TH1StripNoise2ApvCycle.clone(
+        globalswitchon = True
+    ),
+    TH1StripNoise3ApvCycle = SiStripMonitorCluster.TH1StripNoise3ApvCycle.clone(
+        globalswitchon = True
+    ),
+    ClusterHisto = True,
+    BPTXfilter = genericTriggerEventFlag4L1bd
 )
 
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
@@ -79,37 +82,60 @@ stage2L1Trigger.toModify(SiStripMonitorClusterBPTX,
 from DQM.SiPixelMonitorTrack.RefitterForPixelDQM import *
 
 # Clone for SiStripMonitorTrack for all PDs but Minimum Bias and Jet ####
-import DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi 
-SiStripMonitorTrackCommon = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone()
-SiStripMonitorTrackCommon.TrackProducer = 'generalTracks'
-SiStripMonitorTrackCommon.Mod_On        = False
-SiStripMonitorTrackCommon.TH1ClusterCharge.ringView = cms.bool( True )
-SiStripMonitorTrackCommon.TH1ClusterStoNCorr.ringView = cms.bool( True )
-SiStripMonitorTrackCommon.TH1ClusterPos.layerView = cms.bool( False )
-SiStripMonitorTrackCommon.TH1ClusterPos.ringView = cms.bool( True )
+from DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi import *
+SiStripMonitorTrackCommon = SiStripMonitorTrack.clone(
+    TrackProducer = 'generalTracks',
+    Mod_On = False,
+    TH1ClusterCharge = SiStripMonitorTrack.TH1ClusterCharge.clone(
+        ringView = True
+    ),
+    TH1ClusterStoNCorr = SiStripMonitorTrack.TH1ClusterStoNCorr.clone(
+        ringView = True
+    ),
+    TH1ClusterPos = SiStripMonitorTrack.TH1ClusterPos.clone(
+        layerView = False,
+        ringView = True
+    )
+)
 
 # Clone for SiStripMonitorTrack for Minimum Bias ####
-import DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi
-SiStripMonitorTrackMB = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone()
-SiStripMonitorTrackMB.TrackProducer = 'generalTracks'
-SiStripMonitorTrackMB.Mod_On        = False
-SiStripMonitorTrackMB.genericTriggerEventPSet = genericTriggerEventFlag4HLTdb
-SiStripMonitorTrackMB.TH1ClusterCharge.ringView = cms.bool( True )
-SiStripMonitorTrackMB.TH1ClusterStoNCorr.ringView = cms.bool( True )
+from DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi import *
+SiStripMonitorTrackMB = SiStripMonitorTrack.clone(
+    TrackProducer = 'generalTracks',
+    Mod_On = False,
+    genericTriggerEventPSet = genericTriggerEventFlag4HLTdb,
+    TH1ClusterCharge = SiStripMonitorTrack.TH1ClusterCharge.clone(
+        ringView = True
+    ),
+    TH1ClusterStoNCorr = SiStripMonitorTrack.TH1ClusterStoNCorr.clone(
+        ringView = True
+    )
+)
 
 # Clone for SiStripMonitorTrack for Isolated Bunches ####
-import DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi
-SiStripMonitorTrackIB = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone()
-SiStripMonitorTrackIB.TrackProducer = 'generalTracks'
-SiStripMonitorTrackIB.Mod_On        = False
-SiStripMonitorTrackIB.genericTriggerEventPSet = genericTriggerEventFlag4HLTdbIB
-SiStripMonitorTrackIB.TH1ClusterCharge.ringView = cms.bool( True )
-SiStripMonitorTrackIB.TH1ClusterStoNCorr.ringView = cms.bool( True )
-SiStripMonitorTrackIB.TkHistoMap_On = cms.bool(False)
-SiStripMonitorTrackIB.TH1ClusterNoise.layerView = cms.bool(False) 
-SiStripMonitorTrackIB.TH1ClusterWidth.layerView = cms.bool(False) 
-SiStripMonitorTrackIB.TH1ClusterChargePerCM.ringView = cms.bool(False) 
-SiStripMonitorTrackIB.TopFolderName = cms.string("SiStrip/IsolatedBunches")
+from DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi import *
+SiStripMonitorTrackIB = SiStripMonitorTrack.clone(
+    TrackProducer = 'generalTracks',
+    Mod_On = False,
+    genericTriggerEventPSet = genericTriggerEventFlag4HLTdbIB,
+    TH1ClusterCharge = SiStripMonitorTrack.TH1ClusterCharge.clone(
+        ringView = True
+    ),
+    TH1ClusterStoNCorr = SiStripMonitorTrack.TH1ClusterStoNCorr.clone(
+        ringView = True
+    ),
+    TkHistoMap_On = False,
+    TH1ClusterNoise = SiStripMonitorTrack.TH1ClusterNoise.clone(
+        layerView = False
+    ),
+    TH1ClusterWidth = SiStripMonitorTrack.TH1ClusterWidth.clone(
+        layerView = False
+    ),
+    TH1ClusterChargePerCM = SiStripMonitorTrack.TH1ClusterChargePerCM.clone(
+        ringView = False
+    ),
+    TopFolderName = "SiStrip/IsolatedBunches"
+)
 
 ### TrackerMonitorTrack defined and used only for MinimumBias ####
 from DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi import *
@@ -167,6 +193,3 @@ SiStripDQMTier0MinBias = cms.Sequence(
     APVPhases*consecutiveHEs*siStripFEDCheck*siStripFEDMonitor*SiStripMonitorDigi*SiStripMonitorClusterBPTX
     *SiStripMonitorTrackMB*SiStripMonitorTrackIB*refittedForPixelDQM*MonitorTrackResiduals
     *dqmInfoSiStrip)
-
-
-

--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfig_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfig_cff.py
@@ -21,67 +21,72 @@ SiStripMonitorCluster.StripQualityLabel = ''
 from DQM.SiPixelMonitorTrack.RefitterForPixelDQM import *
 
 # On/Off Track Cluster Monitor ####
-# Clone for Sim data
-import DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi
-SiStripMonitorTrackSim = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone()
-SiStripMonitorTrackSim.TrackProducer = 'TrackRefitter'
-SiStripMonitorTrackSim.TrackLabel    = ''
-SiStripMonitorTrackSim.Cluster_src   = 'siStripClusters'
-SiStripMonitorTrackSim.Mod_On        = True
+# Clone for Sim dat
+from DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi import *
+SiStripMonitorTrackSim = SiStripMonitorTrack.clone(
+    TrackProducer = 'TrackRefitter',
+    TrackLabel = '',
+    Cluster_src = 'siStripClusters',
+    Mod_On = True
+)
 
-# Clone for Real Data
-import DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi
-SiStripMonitorTrackReal = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone()
-SiStripMonitorTrackReal.TrackProducer = 'ctfWithMaterialTracksP5'
-SiStripMonitorTrackReal.TrackLabel    = ''
-SiStripMonitorTrackReal.Cluster_src   = 'siStripClusters'
-SiStripMonitorTrackReal.Mod_On        = True
+# Clone for Real Dat
+from DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi import *
+SiStripMonitorTrackReal = SiStripMonitorTrack.clone(
+    TrackProducer = 'ctfWithMaterialTracksP5',
+    TrackLabel = '',
+    Cluster_src = 'siStripClusters',
+    Mod_On = True
+)
 
-# Clone for Real Data (Collision)
-import DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi
-SiStripMonitorTrackColl = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone()
-SiStripMonitorTrackColl.TrackProducer = 'refittedForPixelDQM'
-SiStripMonitorTrackColl.TrackLabel    = ''
-SiStripMonitorTrackColl.Cluster_src   = 'siStripClusters'
-SiStripMonitorTrackColl.Mod_On        = True
-
+# Clone for Real Data (Collision
+from DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi import *
+SiStripMonitorTrackColl = SiStripMonitorTrack.clone(
+    TrackProducer = 'refittedForPixelDQM',
+    TrackLabel = '',
+    Cluster_src = 'siStripClusters',
+    Mod_On = True
+)
 
 # Residual Monitor ####
 # Clone for Sim Data
-import DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi
-MonitorTrackResidualsSim = DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi.MonitorTrackResiduals.clone()
+from DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi import *
+MonitorTrackResidualsSim = MonitorTrackResiduals.clone()
 # Clone for Real Data
-MonitorTrackResidualsReal = DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi.MonitorTrackResiduals.clone()
-import DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi
-MonitorTrackResidualsReal.Tracks              = 'ctfWithMaterialTracksP5'
-MonitorTrackResidualsReal.trajectoryInput     = 'ctfWithMaterialTracksP5'
+MonitorTrackResidualsReal = MonitorTrackResiduals.clone(
+    Tracks = 'ctfWithMaterialTracksP5',
+    trajectoryInput = 'ctfWithMaterialTracksP5'
+)
 # Clone for Real Data
-MonitorTrackResidualsColl = DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi.MonitorTrackResiduals.clone()
-import DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi
-MonitorTrackResidualsColl.Tracks              = 'refittedForPixelDQM'
-MonitorTrackResidualsColl.trajectoryInput     = 'refittedForPixelDQM'
-
+MonitorTrackResidualsColl = MonitorTrackResiduals.clone(
+    Tracks = 'refittedForPixelDQM',
+    trajectoryInput = 'refittedForPixelDQM'
+)
 
 # Tracking Monitor ####
 # Clone for Sim Data
-import DQM.TrackingMonitor.TrackingMonitor_cfi
-TrackMonSim = DQM.TrackingMonitor.TrackingMonitor_cfi.TrackMon.clone()
-TrackMonSim.FolderName = 'Tracking/TrackParameters'
+from DQM.TrackingMonitor.TrackingMonitor_cfi import *
+TrackMonSim = TrackMon.clone(
+    FolderName = 'Tracking/TrackParameters'
+)
+
 # Clone for Real Data (Cosmic)
-import DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi
-TrackMonReal = DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi.TrackerCosmicTrackMon.clone()
-TrackMonReal.TrackProducer = 'ctfWithMaterialTracksP5'
-TrackMonReal.FolderName = 'Tracking/TrackParameters'
-TrackMonReal.AlgoName = 'CKFTk'
-TrackMonReal.doSeedParameterHistos = True
+from DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi import *
+TrackMonReal = TrackerCosmicTrackMon.clone(
+    TrackProducer = 'ctfWithMaterialTracksP5',
+    FolderName = 'Tracking/TrackParameters',
+    AlgoName = 'CKFTk',
+    doSeedParameterHistos = True
+)
 
 # Clone for Real Data (Collison)
-import DQM.TrackingMonitor.TrackingMonitor_cfi
-TrackMonColl = DQM.TrackingMonitor.TrackingMonitor_cfi.TrackMon.clone()
-TrackMonColl.TrackProducer = 'generalTracks'
-TrackMonColl.FolderName = 'Tracking/TrackParameters'
-TrackMonColl.AlgoName = 'CKFTk'
-TrackMonColl.doSeedParameterHistos = True
+from DQM.TrackingMonitor.TrackingMonitor_cfi import *
+TrackMonColl = TrackMon.clone(
+    TrackProducer = 'generalTracks',
+    FolderName = 'Tracking/TrackParameters',
+    AlgoName = 'CKFTk',
+    doSeedParameterHistos = True
+)
 
 # Sequences
 #removed modules using TkDetMap service

--- a/DQM/SiStripMonitorCluster/python/SiStripMonitorClusterAlca_cfi.py
+++ b/DQM/SiStripMonitorCluster/python/SiStripMonitorClusterAlca_cfi.py
@@ -1,245 +1,232 @@
 import FWCore.ParameterSet.Config as cms
 
-import DQM.SiStripMonitorCluster.SiStripMonitorCluster_cfi
+from DQM.SiStripMonitorCluster.SiStripMonitorCluster_cfi import *
 
 # SiStripMonitorCluster
-SiStripCalZeroBiasMonitorCluster = DQM.SiStripMonitorCluster.SiStripMonitorCluster_cfi.SiStripMonitorCluster.clone()
-
-SiStripCalZeroBiasMonitorCluster.ClusterProducerStrip = cms.InputTag("calZeroBiasClusters")
-SiStripCalZeroBiasMonitorCluster.ClusterProducerPix = cms.InputTag('siPixelClusters')
-
-SiStripCalZeroBiasMonitorCluster.ResetMEsEachRun = cms.bool(False)
-
-SiStripCalZeroBiasMonitorCluster.StripQualityLabel = cms.string('unbiased')
-
-SiStripCalZeroBiasMonitorCluster.SelectAllDetectors = cms.bool(True)
-SiStripCalZeroBiasMonitorCluster.ShowMechanicalStructureView = cms.bool(True)
-
-SiStripCalZeroBiasMonitorCluster.ClusterLabel = cms.string('')
-
-SiStripCalZeroBiasMonitorCluster.TkHistoMap_On = cms.bool(False)
-
-SiStripCalZeroBiasMonitorCluster.ClusterChTkHistoMap_On = cms.bool(False)
-
-SiStripCalZeroBiasMonitorCluster.TopFolderName = cms.string('AlcaReco/SiStrip')
-
-SiStripCalZeroBiasMonitorCluster.BPTXfilter     = cms.PSet()
-SiStripCalZeroBiasMonitorCluster.PixelDCSfilter = cms.PSet()
-SiStripCalZeroBiasMonitorCluster.StripDCSfilter = cms.PSet()
-
-SiStripCalZeroBiasMonitorCluster.CreateTrendMEs = cms.bool(False)
-SiStripCalZeroBiasMonitorCluster.TrendVs10LS = cms.bool(False)
-SiStripCalZeroBiasMonitorCluster.TH1ClusterNoise = cms.PSet(
-    Nbinx          = cms.int32(20),
-    xmin           = cms.double(-0.5),
-    xmax           = cms.double(9.5),
-    layerswitchon  = cms.bool(False),
-    moduleswitchon = cms.bool(False)
+SiStripCalZeroBiasMonitorCluster = SiStripMonitorCluster.clone(
+    ClusterProducerStrip = "calZeroBiasClusters",
+    ClusterProducerPix = 'siPixelClusters',
+    ResetMEsEachRun = False,
+    StripQualityLabel = 'unbiased',
+    SelectAllDetectors = True,
+    ShowMechanicalStructureView = True,
+    ClusterLabel = '',
+    TkHistoMap_On = False,
+    ClusterChTkHistoMap_On = False,
+    TopFolderName = 'AlcaReco/SiStrip',
+    BPTXfilter = SiStripMonitorCluster.BPTXfilter.clone(),
+    PixelDCSfilter = SiStripMonitorCluster.PixelDCSfilter.clone(),
+    StripDCSfilter = SiStripMonitorCluster.StripDCSfilter.clone(),
+    CreateTrendMEs = False,
+    TrendVs10LS = False,
+    TH1ClusterNoise = SiStripMonitorCluster.TH1ClusterNoise.clone(
+        Nbinx = 20,
+        xmin = -0.5,
+        xmax = 9.5,
+        layerswitchon  = False,
+        moduleswitchon = False
+    ),
+    TH1NrOfClusterizedStrips = SiStripMonitorCluster.TH1NrOfClusterizedStrips.clone(
+        Nbinx = 20,
+        xmin = -0.5,
+        xmax = 99.5,
+        layerswitchon  = False,
+        moduleswitchon = False
+    ),
+    TH1ClusterPos = SiStripMonitorCluster.TH1ClusterPos.clone(
+        Nbinx = 768,
+        xmin = -0.5,
+        xmax = 767.5,
+        layerswitchon  = True,
+        moduleswitchon = False
+    ),
+    TH1ClusterDigiPos = SiStripMonitorCluster.TH1ClusterDigiPos.clone(
+        Nbinx = 768,
+        xmin = -0.5,
+        xmax = 767.5,
+        layerswitchon  = False,
+        moduleswitchon = True
+    ),
+    TH1ModuleLocalOccupancy = SiStripMonitorCluster.TH1ModuleLocalOccupancy.clone(
+        Nbinx = 20,
+        xmin = -0.5,
+        xmax = 0.95,
+        layerswitchon  = False,
+        moduleswitchon = False
+    ),
+    TH1nClusters = SiStripMonitorCluster.TH1nClusters.clone(
+        Nbinx = 11,
+        xmin = -0.5,
+        xmax = 10.5,
+        layerswitchon  = False,
+        moduleswitchon = False
+    ),
+    TH1ClusterStoN = SiStripMonitorCluster.TH1ClusterStoN.clone(
+        Nbinx = 100,
+        xmin = -0.5,
+        xmax = 299.5,
+        layerswitchon  = False,
+        moduleswitchon = False
+    ),
+    TH1ClusterStoNVsPos = SiStripMonitorCluster.TH1ClusterStoNVsPos.clone(
+        Nbinx = 768,
+        xmin = -0.5,
+        xmax = 767.5,
+        Nbiny = 100,
+        ymin = -0.5,
+        ymax = 299.5,
+        layerswitchon  = False,
+        moduleswitchon = False
+    ),
+    TH1ClusterCharge = SiStripMonitorCluster.TH1ClusterCharge.clone(
+        Nbinx = 200,
+        xmin = -0.5,        
+        xmax = 799.5,
+        layerswitchon = False,
+        moduleswitchon = False,
+        subdetswitchon = True
+    ),
+    TH1ClusterWidth = SiStripMonitorCluster.TH1ClusterWidth.clone(
+        Nbinx = 30,
+        xmin = -0.5,
+        xmax = 29.5,
+        layerswitchon  = False,        
+        moduleswitchon = False,
+        subdetswitchon = True
+    ),
+    TProfNumberOfCluster = SiStripMonitorCluster.TProfNumberOfCluster.clone(
+        Nbinx = 100,
+        xmin = -0.5,
+        xmax = 499.5,
+        layerswitchon = False,        
+        moduleswitchon = False        
+    ),
+    TProfClusterWidth    = SiStripMonitorCluster.TProfClusterWidth.clone(
+        Nbinx = 100,
+        xmin = -0.5,
+        xmax = 499.5,
+        layerswitchon = False,        
+        moduleswitchon = False        
+    ),
+    ClusterConditions = SiStripMonitorCluster.ClusterConditions.clone(
+        minWidth = 0.0,
+        On = True,
+        maxStoN = 10000.0,
+        minStoN = 0.0,
+        maxWidth = 10000.0
+    ),
+    TProfTotalNumberOfClusters = SiStripMonitorCluster.TProfTotalNumberOfClusters.clone(
+        subdetswitchon = True
+    ),
+    TH1TotalNumberOfClusters = SiStripMonitorCluster.TH1TotalNumberOfClusters.clone(
+        Nbinx = 500,
+        xmin = -0.5,
+        xmax = 19999.5,
+        subdetswitchon = True
+    ),
+    TProfClustersApvCycle = SiStripMonitorCluster.TProfClustersApvCycle.clone(
+        Nbins = 70,
+        xmin = -0.5,
+        xmax = 69.5,
+        Nbinsy = 200,
+        ymin = 0.0,
+        ymax = 0.0,
+        subdetswitchon = True
+    ),
+    TH2ClustersApvCycle = SiStripMonitorCluster.TH2ClustersApvCycle.clone(
+        Nbinsx = 70,
+        xmin = -0.5,
+        xmax = 69.5,
+        Nbinsy = 400,
+        ymin = 0.0,
+        yfactor = 0.01,
+        subdetswitchon = True
+    ),
+    TProfClustersVsDBxCycle = SiStripMonitorCluster.TProfClustersVsDBxCycle.clone(
+        Nbins = 800,
+        xmin = 0.5,
+        xmax = 800.5,
+        ymin = 0.0,
+        ymax = 0.0,
+        subdetswitchon = False
+    ),
+    TProf2ApvCycleVsDBx = SiStripMonitorCluster.TProf2ApvCycleVsDBx.clone(
+        Nbinsx = 70,
+        xmin = -0.5,
+        xmax = 69.5,
+        Nbinsy = 800,
+        ymin = 0.5,
+        ymax = 800.5,
+        zmin = 0.0,
+        zmax = 0.0,
+        subdetswitchon = False
+    ),
+    TH2ApvCycleVsDBxGlobal = SiStripMonitorCluster.TH2ApvCycleVsDBxGlobal.clone(
+        Nbinsx = 70,
+        xmin = -0.5,
+        xmax = 69.5,
+        Nbinsy = 800,
+        ymin = 0.5,
+        ymax = 800.5,
+        globalswitchon = False
+    ),
+    TH2CStripVsCpixel = SiStripMonitorCluster.TH2CStripVsCpixel.clone(
+        Nbinsx = 150,
+        xmin = -0.5,
+        xmax = 74999.5,
+        Nbinsy = 50,
+        ymin = -0.5,
+        ymax = 14999.5,
+        globalswitchon = False
+    ),
+    MultiplicityRegions = SiStripMonitorCluster.MultiplicityRegions.clone(
+        k0 = 0.13,  # k from linear fit of the diagonal
+        q0 = 300,   # +/- variation of y axis intercept
+        dk0 = 40,   #+/- variation of k0 (in %) to contain the diagonal zone
+        MaxClus = 20000, #Divide Region 2 and Region 3
+        MinPix = 50  # minimum number of Pix clusters to flag events with zero Si clusters
+    ),
+    TH1MultiplicityRegions = SiStripMonitorCluster.TH1MultiplicityRegions.clone(
+        Nbinx = 5,
+        xmin = 0.5,
+        xmax = 5.5,
+        globalswitchon = False
+    ),        
+    TH1MainDiagonalPosition = SiStripMonitorCluster.TH1MainDiagonalPosition.clone(
+        Nbinsx = 100,
+        xmin = 0.,
+        xmax = 2.,
+        globalswitchon = False
+    ),   
+    # Nunmber of Cluster in Pixel
+    TH1NClusPx = SiStripMonitorCluster.TH1NClusPx.clone(
+        Nbinsx = 200,
+        xmax = 19999.5,                      
+        xmin = -0.5
+    ),
+    # Number of Cluster in Strip
+    TH1NClusStrip = SiStripMonitorCluster.TH1NClusStrip.clone(
+        Nbinsx = 500,
+        xmax = 99999.5,                      
+        xmin = -0.5
+    ),
+    TH1StripNoise2ApvCycle = SiStripMonitorCluster.TH1StripNoise2ApvCycle.clone(
+        Nbinsx = 70,
+        xmin = -0.5,
+        xmax = 69.5,
+        globalswitchon = False
+    ),
+    TH1StripNoise3ApvCycle = SiStripMonitorCluster.TH1StripNoise3ApvCycle.clone(
+        Nbinsx = 70,
+        xmin = -0.5,
+        xmax = 69.5,
+        globalswitchon = False
+    ),
+    Mod_On = True,
+    ClusterHisto = False,
+    HistoryProducer = "consecutiveHEs",
+    ApvPhaseProducer = "APVPhases",
+    UseDCSFiltering = True,
+    ShowControlView = False,
+    ShowReadoutView = False
 )
-SiStripCalZeroBiasMonitorCluster.TH1NrOfClusterizedStrips = cms.PSet(
-    Nbinx          = cms.int32(20),
-    xmin           = cms.double(-0.5),
-    xmax           = cms.double(99.5),
-    layerswitchon  = cms.bool(False),
-    moduleswitchon = cms.bool(False)
-)
-SiStripCalZeroBiasMonitorCluster.TH1ClusterPos = cms.PSet(
-    Nbinx          = cms.int32(768),
-    xmin           = cms.double(-0.5),
-    xmax           = cms.double(767.5),
-    layerswitchon  = cms.bool(True),
-    moduleswitchon = cms.bool(False)
-)
-SiStripCalZeroBiasMonitorCluster.TH1ClusterDigiPos = cms.PSet(
-    Nbinx          = cms.int32(768),
-    xmin           = cms.double(-0.5),
-    xmax           = cms.double(767.5),
-    layerswitchon  = cms.bool(False),
-    moduleswitchon = cms.bool(True)
-)                                
-SiStripCalZeroBiasMonitorCluster.TH1ModuleLocalOccupancy = cms.PSet(
-    Nbinx          = cms.int32(20),
-    xmin           = cms.double(-0.5),
-    xmax           = cms.double(0.95),
-    layerswitchon  = cms.bool(False),
-    moduleswitchon = cms.bool(False)
-)
-SiStripCalZeroBiasMonitorCluster.TH1nClusters = cms.PSet(
-    Nbinx          = cms.int32(11),
-    xmin           = cms.double(-0.5),
-    xmax           = cms.double(10.5),
-    layerswitchon  = cms.bool(False),
-    moduleswitchon = cms.bool(False)
-)
-SiStripCalZeroBiasMonitorCluster.TH1ClusterStoN = cms.PSet(
-    Nbinx          = cms.int32(100),
-    xmin           = cms.double(-0.5),
-    xmax           = cms.double(299.5),
-    layerswitchon  = cms.bool(False),
-    moduleswitchon = cms.bool(False)
-)
-SiStripCalZeroBiasMonitorCluster.TH1ClusterStoNVsPos = cms.PSet(
-    Nbinx          = cms.int32(768),
-    xmin           = cms.double(-0.5),
-    xmax           = cms.double(767.5),
-    Nbiny          = cms.int32(100),
-    ymin           = cms.double(-0.5),
-    ymax           = cms.double(299.5),
-    layerswitchon  = cms.bool(False),
-    moduleswitchon = cms.bool(False)
-)
-SiStripCalZeroBiasMonitorCluster.TH1ClusterCharge = cms.PSet(
-    Nbinx          = cms.int32(200),
-    xmin           = cms.double(-0.5),        
-    xmax           = cms.double(799.5),
-    layerswitchon  = cms.bool(False),
-    moduleswitchon = cms.bool(False),
-    subdetswitchon = cms.bool(True)
-)
-SiStripCalZeroBiasMonitorCluster.TH1ClusterWidth = cms.PSet(
-    Nbinx          = cms.int32(30),
-    xmin           = cms.double(-0.5),
-    xmax           = cms.double(29.5),
-    layerswitchon  = cms.bool(False),        
-    moduleswitchon = cms.bool(False),
-    subdetswitchon = cms.bool(True)
-)
-SiStripCalZeroBiasMonitorCluster.TProfNumberOfCluster = cms.PSet(
-    Nbinx            = cms.int32(100),
-    xmin             = cms.double(-0.5),
-    xmax             = cms.double(499.5),
-    layerswitchon    = cms.bool(False),        
-    moduleswitchon   = cms.bool(False)        
-)
-SiStripCalZeroBiasMonitorCluster.TProfClusterWidth    = cms.PSet(
-    Nbinx            = cms.int32(100),
-    xmin             = cms.double(-0.5),
-    xmax             = cms.double(499.5),
-    layerswitchon    = cms.bool(False),        
-    moduleswitchon   = cms.bool(False)        
-)                           
-SiStripCalZeroBiasMonitorCluster.ClusterConditions = cms.PSet(
-    minWidth   = cms.double(0.0),
-    On         = cms.bool(True),
-    maxStoN    = cms.double(10000.0),
-    minStoN    = cms.double(0.0),
-    maxWidth   = cms.double(10000.0)
-)
-SiStripCalZeroBiasMonitorCluster.TProfTotalNumberOfClusters = cms.PSet(
-    subdetswitchon = cms.bool(True)
-)
-SiStripCalZeroBiasMonitorCluster.TH1TotalNumberOfClusters = cms.PSet(
-    Nbinx          = cms.int32(500),
-    xmin           = cms.double(-0.5),
-    xmax           = cms.double(19999.5),
-    subdetswitchon = cms.bool(True)
-)
-SiStripCalZeroBiasMonitorCluster.TProfClustersApvCycle = cms.PSet(
-    Nbins = cms.int32(70),
-    xmin = cms.double(-0.5),
-    xmax = cms.double(69.5),
-    Nbinsy = cms.int32(200),
-    ymin = cms.double(0.0),
-    ymax = cms.double(0.0),
-    subdetswitchon = cms.bool(True)
-    )
-SiStripCalZeroBiasMonitorCluster.TH2ClustersApvCycle = cms.PSet(
-    Nbinsx = cms.int32(70),
-    xmin = cms.double(-0.5),
-    xmax = cms.double(69.5),
-    Nbinsy = cms.int32(400),
-    ymin = cms.double(0.0),
-    yfactor = cms.double(0.01),
-    subdetswitchon = cms.bool(True)
-)
-SiStripCalZeroBiasMonitorCluster.TProfClustersVsDBxCycle = cms.PSet(
-    Nbins = cms.int32(800),
-    xmin = cms.double(0.5),
-    xmax = cms.double(800.5),
-    ymin = cms.double(0.0),
-    ymax = cms.double(0.0),
-    subdetswitchon = cms.bool(False)
-    )
-SiStripCalZeroBiasMonitorCluster.TProf2ApvCycleVsDBx = cms.PSet(
-    Nbinsx = cms.int32(70),
-    xmin   = cms.double(-0.5),
-    xmax   = cms.double(69.5),
-    Nbinsy = cms.int32(800),
-    ymin   = cms.double(0.5),
-    ymax   = cms.double(800.5),
-    zmin   = cms.double(0.0),
-    zmax   = cms.double(0.0),
-    subdetswitchon = cms.bool(False)
-    )
-SiStripCalZeroBiasMonitorCluster.TH2ApvCycleVsDBxGlobal = cms.PSet(
-    Nbinsx = cms.int32(70),
-    xmin   = cms.double(-0.5),
-    xmax   = cms.double(69.5),
-    Nbinsy = cms.int32(800),
-    ymin   = cms.double(0.5),
-    ymax   = cms.double(800.5),
-    globalswitchon = cms.bool(False)
-    )
-SiStripCalZeroBiasMonitorCluster.TH2CStripVsCpixel = cms.PSet(
-    Nbinsx = cms.int32(150),
-    xmin   = cms.double(-0.5),
-    xmax   = cms.double(74999.5),
-    Nbinsy = cms.int32(50),
-    ymin   = cms.double(-0.5),
-    ymax   = cms.double(14999.5),
-    globalswitchon = cms.bool(False)
-    )
-SiStripCalZeroBiasMonitorCluster.MultiplicityRegions = cms.PSet(
-    k0 = cms.double(0.13),  # k from linear fit of the diagonal
-    q0 = cms.double(300),   # +/- variation of y axis intercept
-    dk0 = cms.double(40),   #+/- variation of k0 (in %) to contain the diagonal zone
-    MaxClus = cms.double(20000), #Divide Region 2 and Region 3
-    MinPix = cms.double(50)  # minimum number of Pix clusters to flag events with zero Si clusters
-    )
-SiStripCalZeroBiasMonitorCluster.TH1MultiplicityRegions = cms.PSet(
-    Nbinx          = cms.int32(5),
-    xmin           = cms.double(0.5),
-    xmax           = cms.double(5.5),
-    globalswitchon = cms.bool(False)
-    )                                 
-SiStripCalZeroBiasMonitorCluster.TH1MainDiagonalPosition= cms.PSet(
-    Nbinsx          = cms.int32(100),
-    xmin           = cms.double(0.),
-    xmax           = cms.double(2.),
-    globalswitchon = cms.bool(False)
-    )                            
-# Nunmber of Cluster in Pixel
-SiStripCalZeroBiasMonitorCluster.TH1NClusPx = cms.PSet(
-    Nbinsx = cms.int32(200),
-    xmax = cms.double(19999.5),                      
-    xmin = cms.double(-0.5)
-    )
-# Number of Cluster in Strip
-SiStripCalZeroBiasMonitorCluster.TH1NClusStrip = cms.PSet(
-    Nbinsx = cms.int32(500),
-    xmax = cms.double(99999.5),                      
-    xmin = cms.double(-0.5)
-    )
-SiStripCalZeroBiasMonitorCluster.TH1StripNoise2ApvCycle = cms.PSet(
-    Nbinsx = cms.int32(70),
-    xmin   = cms.double(-0.5),
-    xmax   = cms.double(69.5),
-    globalswitchon = cms.bool(False)
-    )
-SiStripCalZeroBiasMonitorCluster.TH1StripNoise3ApvCycle = cms.PSet(
-    Nbinsx = cms.int32(70),
-    xmin   = cms.double(-0.5),
-    xmax   = cms.double(69.5),
-    globalswitchon = cms.bool(False)
-    )
-SiStripCalZeroBiasMonitorCluster.Mod_On = cms.bool(True)
-SiStripCalZeroBiasMonitorCluster.ClusterHisto = cms.bool(False)                                                  
-
-SiStripCalZeroBiasMonitorCluster.HistoryProducer = cms.InputTag("consecutiveHEs")
-SiStripCalZeroBiasMonitorCluster.ApvPhaseProducer = cms.InputTag("APVPhases")
-
-SiStripCalZeroBiasMonitorCluster.UseDCSFiltering = cms.bool(True)
-                                              
-SiStripCalZeroBiasMonitorCluster.ShowControlView = cms.bool(False)
-SiStripCalZeroBiasMonitorCluster.ShowReadoutView = cms.bool(False)
-

--- a/DQM/SiStripMonitorCluster/python/SiStripMonitorCluster_cfi.py
+++ b/DQM/SiStripMonitorCluster/python/SiStripMonitorCluster_cfi.py
@@ -21,9 +21,21 @@ SiStripMonitorCluster = DQMEDAnalyzer('SiStripMonitorCluster',
 
     TopFolderName = cms.string('SiStrip'),
 
-    BPTXfilter     = cms.PSet(),
-    PixelDCSfilter = cms.PSet(),
-    StripDCSfilter = cms.PSet(),
+    BPTXfilter = cms.PSet(),
+    PixelDCSfilter = cms.PSet(
+        andOr = cms.bool(False),
+        dcsInputTag = cms.InputTag("scalersRawToDigi"),
+        dcsPartitions = cms.vint32(28, 29),
+        andOrDcs = cms.bool(False),
+        errorReplyDcs = cms.bool(True)
+    ),
+    StripDCSfilter = cms.PSet(
+        andOr = cms.bool(False),
+        dcsInputTag = cms.InputTag("scalersRawToDigi"),
+        dcsPartitions = cms.vint32(24, 25, 26, 27),
+        andOrDcs = cms.bool(False),
+        errorReplyDcs = cms.bool(True)
+    ),
 
     CreateTrendMEs = cms.bool(False),
     TrendVs10LS = cms.bool(False),

--- a/DQM/SiStripMonitorSummary/scripts/TemplateCfg21X_PedNoise_cfg.py
+++ b/DQM/SiStripMonitorSummary/scripts/TemplateCfg21X_PedNoise_cfg.py
@@ -55,40 +55,38 @@ process.DQMStore = cms.Service("DQMStore",
 )
 
 
-import CalibTracker.Configuration.Common.PoolDBESSource_cfi
-siStripCond = CalibTracker.Configuration.Common.PoolDBESSource_cfi.poolDBESSource.clone()
+from CalibTracker.Configuration.Common.PoolDBESSource_cfi import *
+siStripCond = poolDBESSource.clone(
+    toGet = (
+        poolDBESSource.toGet[0].clone(
+            record ='SiStripFedCablingRcd',
+            tag ='insert_FedCablingTag'
+        ), 
+        poolDBESSource.toGet[0].clone( 
+            record = 'SiStripNoisesRcd',
+            tag = 'insert_NoiseTag'
+        ), 
+        poolDBESSource.toGet[0].clone(
+            record = 'SiStripPedestalsRcd',
+            tag = 'insert_PedestalTag'
+        ),
+        poolDBESSource.toGet[0].clone(
+            record = 'SiStripApvGainRcd',
+            tag = 'SiStripGain_Ideal_21X'
+        ),
+        poolDBESSource.toGet[0].clone(
+            record = 'SiStripLorentzAngleRcd',
+            tag = 'SiStripLorentzAngle_Ideal_21X'
+        ),     
+        poolDBESSource.toGet[0].clone(
+            record = 'SiStripThresholdRcd',
+            tag = 'insert_ThresholdTag'
+        )
+    ),
+    connect = 'frontier://cmsfrontier.cern.ch:8000/FrontierProd/insertAccount'
+)
 
 sistripconn = cms.ESProducer("SiStripConnectivity")
-
-siStripCond.toGet = cms.VPSet(
-    cms.PSet(
-    record = cms.string('SiStripFedCablingRcd'),
-    tag = cms.string('insert_FedCablingTag')
-    ), 
-    cms.PSet( 
-        record = cms.string('SiStripNoisesRcd'),
-        tag = cms.string('insert_NoiseTag')
-    ), 
-    cms.PSet(
-        record = cms.string('SiStripPedestalsRcd'),
-        tag = cms.string('insert_PedestalTag')
-    ),
-    cms.PSet(
-        record = cms.string('SiStripApvGainRcd'),
-        tag = cms.string('SiStripGain_Ideal_21X')
-    ),
-    cms.PSet(
-        record = cms.string('SiStripLorentzAngleRcd'),
-        tag = cms.string('SiStripLorentzAngle_Ideal_21X')
-    ),     
-    cms.PSet(
-        record = cms.string('SiStripThresholdRcd'),
-        tag = cms.string('insert_ThresholdTag')
-    ))
-
-
-    
-siStripCond.connect = 'frontier://cmsfrontier.cern.ch:8000/FrontierProd/insertAccount'
 
 
     #-------------------------------------------------

--- a/DQM/SiStripMonitorSummary/scripts/TemplateCfg21X_Quality_cfg.py
+++ b/DQM/SiStripMonitorSummary/scripts/TemplateCfg21X_Quality_cfg.py
@@ -50,40 +50,38 @@ process.DQMStore = cms.Service("DQMStore",
     verbose = cms.untracked.int32(1)
 )
 
-import CalibTracker.Configuration.Common.PoolDBESSource_cfi
-siStripCond = CalibTracker.Configuration.Common.PoolDBESSource_cfi.poolDBESSource.clone()
+from CalibTracker.Configuration.Common.PoolDBESSource_cfi import *
+siStripCond = poolDBESSource.clone(
+    toGet = (
+        poolDBESSource.toGet[0].clone(
+            record = 'SiStripFedCablingRcd',
+            tag = 'insert_FedCablingTag'
+        ), 
+        poolDBESSource.toGet[0].clone( 
+            record = 'SiStripNoisesRcd',
+            tag = 'insert_NoiseTag'
+        ), 
+        poolDBESSource.toGet[0].clone(
+            record = 'SiStripPedestalsRcd',
+            tag = 'insert_PedestalTag'
+        ),
+        poolDBESSource.toGet[0].clone(
+            record = 'SiStripApvGainRcd',
+            tag = 'SiStripGain_Ideal_21X'
+        ),
+        poolDBESSource.toGet[0].clone(
+            record = 'SiStripLorentzAngleRcd',
+            tag = 'SiStripLorentzAngle_Ideal_21X'
+        ),     
+        poolDBESSource.toGet[0].clone(
+            record = 'SiStripThresholdRcd',
+            tag = 'insert_ThresholdTag'
+        )
+    ),
+    connect = 'frontier://cmsfrontier.cern.ch:8000/FrontierProd/insertAccount'
+)
 
 sistripconn = cms.ESProducer("SiStripConnectivity")
-
-siStripCond.toGet = cms.VPSet(
-    cms.PSet(
-    record = cms.string('SiStripFedCablingRcd'),
-    tag = cms.string('insert_FedCablingTag')
-    ), 
-    cms.PSet( 
-        record = cms.string('SiStripNoisesRcd'),
-        tag = cms.string('insert_NoiseTag')
-    ), 
-    cms.PSet(
-        record = cms.string('SiStripPedestalsRcd'),
-        tag = cms.string('insert_PedestalTag')
-    ),
-    cms.PSet(
-        record = cms.string('SiStripApvGainRcd'),
-        tag = cms.string('SiStripGain_Ideal_21X')
-    ),
-    cms.PSet(
-        record = cms.string('SiStripLorentzAngleRcd'),
-        tag = cms.string('SiStripLorentzAngle_Ideal_21X')
-    ),     
-    cms.PSet(
-        record = cms.string('SiStripThresholdRcd'),
-        tag = cms.string('insert_ThresholdTag')
-    ))
-
-
-    
-siStripCond.connect = 'frontier://cmsfrontier.cern.ch:8000/FrontierProd/insertAccount'
 
 process.a = cms.ESSource("PoolDBESSource",
     appendToDataLabel = cms.string('test'),

--- a/DQM/SiTrackerPhase2/python/Phase2TrackerMonitorDigi_cff.py
+++ b/DQM/SiTrackerPhase2/python/Phase2TrackerMonitorDigi_cff.py
@@ -1,88 +1,98 @@
 import FWCore.ParameterSet.Config as cms
 from DQM.SiTrackerPhase2.Phase2TrackerMonitorDigi_cfi import *
 
+pixDigiMon = digiMon.clone(
+    PixelPlotFillingFlag = True,
+    StandAloneClusteriserFlag = False,
+    TopFolderName = "TrackerPhase2ITDigi",
+    NumberOfDigisPerDetH = digiMon.NumberOfDigisPerDetH.clone(
+        Nbins = 500,
+        xmin = -0.5,
+        xmax = 999.5,
+        switch = True
+    ),
+    NumberOfClustersPerDetH = digiMon.NumberOfClustersPerDetH.clone(
+        Nbins = 200,
+        xmin = 0.0,
+        xmax = 2000.,
+        switch = True
+    ),
+    ChargeXYMapH = digiMon.ChargeXYMapH.clone(
+        Nxbins = 450,
+        xmin = 0.5,
+        xmax = 450.5,
+        Nybins = 1350,
+        ymin = 0.5,
+        ymax = 1350.5,
+        switch = False
+    ),
+    PositionOfDigisPH = digiMon.PositionOfDigisPH.clone(
+        Nxbins = 675,
+        xmin = 0.5,
+        xmax = 1350.5,
+        Nybins = 225,
+        ymin = 0.5,
+        ymax = 450.5,
+        switch = True
+    ),
+    XYPositionMapH = digiMon.XYPositionMapH.clone(
+        Nxbins = 340,
+        xmin = -170.,
+        xmax = 170.,
+        Nybins = 340,
+        ymin = -170.,
+        ymax = 170.,
+        switch = True
+    ),
+    RZPositionMapH = digiMon.RZPositionMapH.clone(
+        Nxbins = 600,
+        xmin = -3000.0,
+        xmax = 3000.,
+        Nybins = 280,
+        ymin = 0.,
+        ymax = 280.,
+        switch = True
+    ),
+    ClusterPositionPH = digiMon.ClusterPositionPH.clone(
+        Nxbins = 960,
+        xmin = 0.5,
+        xmax = 960.5,
+        Nybins = 32,
+        ymin = 0.5,
+        ymax = 32.5,
+        switch = True
+    )
+)
 
-pixDigiMon = digiMon.clone()
-pixDigiMon.PixelPlotFillingFlag = cms.bool(True)
-pixDigiMon.StandAloneClusteriserFlag = cms.bool(False)
-pixDigiMon.TopFolderName = cms.string("TrackerPhase2ITDigi")
-pixDigiMon.NumberOfDigisPerDetH = cms.PSet(
-    Nbins = cms.int32(500),
-    xmin = cms.double(-0.5),
-    xmax = cms.double(999.5),
-    switch = cms.bool(True))
-pixDigiMon.NumberOfClustersPerDetH = cms.PSet(
-    Nbins = cms.int32(200),
-    xmin = cms.double(0.0),
-    xmax = cms.double(2000.),
-    switch = cms.bool(True))
-pixDigiMon.ChargeXYMapH = cms.PSet(
-    Nxbins = cms.int32(450),
-    xmin   = cms.double(0.5),
-    xmax   = cms.double(450.5),
-    Nybins = cms.int32(1350),
-    ymin   = cms.double(0.5),
-    ymax   = cms.double(1350.5),
-    switch = cms.bool(False))
-pixDigiMon.PositionOfDigisPH = cms.PSet(
-    Nxbins = cms.int32(675),
-    xmin   = cms.double(0.5),
-    xmax   = cms.double(1350.5),
-    Nybins = cms.int32(225),
-    ymin   = cms.double(0.5),
-    ymax   = cms.double(450.5),
-    switch = cms.bool(True))
-pixDigiMon.XYPositionMapH = cms.PSet(
-    Nxbins = cms.int32(340),
-    xmin   = cms.double(-170.),
-    xmax   = cms.double(170.),
-    Nybins = cms.int32(340),
-    ymin   = cms.double(-170.),
-    ymax   = cms.double(170.),
-    switch = cms.bool(True))
-pixDigiMon.RZPositionMapH = cms.PSet(
-    Nxbins = cms.int32(600),
-    xmin   = cms.double(-3000.0),
-    xmax   = cms.double(3000.),
-    Nybins = cms.int32(280),
-    ymin   = cms.double(0.),
-    ymax   = cms.double(280.),
-    switch = cms.bool(True))
-pixDigiMon.ClusterPositionPH = cms.PSet(
-    Nxbins = cms.int32(960),
-    xmin   = cms.double(0.5),
-    xmax   = cms.double(960.5),
-    Nybins = cms.int32(32),
-    ymin   = cms.double(0.5),
-    ymax   = cms.double(32.5),
-    switch = cms.bool(True))
-
-
-otDigiMon = digiMon.clone()
-otDigiMon.PixelPlotFillingFlag = cms.bool(False)
-otDigiMon.StandAloneClusteriserFlag = cms.bool(False)
-otDigiMon.TopFolderName = cms.string("TrackerPhase2OTDigi")
-otDigiMon.XYPositionMapH = cms.PSet(
-    Nxbins = cms.int32(250),
-    xmin   = cms.double(-1250.),
-    xmax   = cms.double(1250.),
-    Nybins = cms.int32(250),
-    ymin   = cms.double(-1250.),
-    ymax   = cms.double(1250.),
-    switch = cms.bool(True))
-otDigiMon.RZPositionMapH = cms.PSet(
-    Nxbins = cms.int32(600),
-    xmin   = cms.double(-3000.),
-    xmax   = cms.double(3000.),
-    Nybins = cms.int32(250),
-    ymin   = cms.double(0.),
-    ymax   = cms.double(1250.),
-    switch = cms.bool(True))
-otDigiMon.PositionOfDigisSH = cms.PSet(
-    Nxbins = cms.int32(508),
-    xmin   = cms.double(0.5),
-    xmax   = cms.double(1016.5),
-    Nybins = cms.int32(2),
-    ymin   = cms.double(0.5),
-    ymax   = cms.double(2.5),
-    switch = cms.bool(True))
+otDigiMon = digiMon.clone(
+    PixelPlotFillingFlag = False,
+    StandAloneClusteriserFlag = False,
+    TopFolderName = "TrackerPhase2OTDigi",
+    XYPositionMapH = digiMon.XYPositionMapH.clone(
+        Nxbins = 250,
+        xmin = -1250.,
+        xmax = 1250.,
+        Nybins = 250,
+        ymin = -1250.,
+        ymax = 1250.,
+        switch = True
+    ),
+    RZPositionMapH = digiMon.RZPositionMapH.clone(
+        Nxbins = 600,
+        xmin = -3000.,
+        xmax = 3000.,
+        Nybins = 250,
+        ymin = 0.,
+        ymax = 1250.,
+        switch = True
+    ),
+    PositionOfDigisSH = digiMon.PositionOfDigisSH.clone(
+        Nxbins = 508,
+        xmin = 0.5,
+        xmax = 1016.5,
+        Nybins = 2,
+        ymin = 0.5,
+        ymax = 2.5,
+        switch = True
+    )
+)

--- a/DQM/TrackerMonitorTrack/python/MonitorTrackResiduals_cff.py
+++ b/DQM/TrackerMonitorTrack/python/MonitorTrackResiduals_cff.py
@@ -9,20 +9,21 @@ TrackRefitter.TrajectoryInEvent = True
 # ... but matching for strip stereo should be redone: 
 #ttrhbwor.Matcher = 'StandardMatcher'
 
-import DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi
-MonitorTrackResidualsTier0 = DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi.MonitorTrackResiduals.clone()
-MonitorTrackResidualsTier0.OutputMEsInRootFile = False
-MonitorTrackResidualsTier0.Mod_On = False
+from DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi import *
+MonitorTrackResidualsTier0 = MonitorTrackResiduals.clone(
+    OutputMEsInRootFile = False,
+    Mod_On = False
+)
 
-import DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi
-MonitorTrackResidualsDQM = DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi.MonitorTrackResiduals.clone()
-MonitorTrackResidualsDQM.OutputMEsInRootFile = False
-MonitorTrackResidualsDQM.Mod_On = True
+MonitorTrackResidualsDQM = MonitorTrackResiduals.clone(
+    OutputMEsInRootFile = False,
+    Mod_On = True
+)
 
-import DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi
-MonitorTrackResidualsStandAlone = DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi.MonitorTrackResiduals.clone()
-MonitorTrackResidualsStandAlone.OutputMEsInRootFile = True
-MonitorTrackResidualsStandAlone.Mod_On = False
+MonitorTrackResidualsStandAlone = MonitorTrackResiduals.clone(
+    OutputMEsInRootFile = True,
+    Mod_On = False
+)
 
 # Sequences
 DQMMonitorTrackResidualsTier0 = cms.Sequence(TrackRefitter*MonitorTrackResidualsTier0)

--- a/DQM/TrackerMonitorTrack/test/monitortrackresiduals_cfg.py
+++ b/DQM/TrackerMonitorTrack/test/monitortrackresiduals_cfg.py
@@ -44,21 +44,25 @@ process.load("Configuration.StandardSequences.MagneticField_cff")
 ## Load DBSetup (if needed)
 ##
 from Alignment.CommonAlignmentProducer.GlobalPosition_Frontier_DevDB_cff import *
-import CalibTracker.Configuration.Common.PoolDBESSource_cfi
-trackerAlignment = CalibTracker.Configuration.Common.PoolDBESSource_cfi.poolDBESSource.clone()
+from CalibTracker.Configuration.Common.PoolDBESSource_cfi import *
+trackerAlignment = poolDBESSource.clone(
+    connect = 'frontier://FrontierDev/CMS_COND_ALIGNMENT',
+    toGet = cms.VPSet(
+        cms.PSet(
+            record = cms.string('TrackerAlignmentRcd'),
+            tag = cms.string('Tracker10pbScenario210_mc')
+        ),
+        cms.PSet(
+            record = cms.string('TrackerAlignmentErrorRcd'),
+            tag = cms.string('Tracker10pbScenarioErrors210_mc')
+        )
+    )
+)
 from Geometry.TrackerGeometryBuilder.trackerGeometry_cfi import *
 
 es_prefer_trackerAlignment = cms.ESPrefer("PoolDBESSource","trackerAlignment")
 
-trackerAlignment.connect = 'frontier://FrontierDev/CMS_COND_ALIGNMENT'
-trackerAlignment.toGet = cms.VPSet(cms.PSet(
-    record = cms.string('TrackerAlignmentRcd'),
-    tag = cms.string('Tracker10pbScenario210_mc')
-), 
-    cms.PSet(
-        record = cms.string('TrackerAlignmentErrorRcd'),
-        tag = cms.string('Tracker10pbScenarioErrors210_mc')
-    ))
+
 # to apply misalignments
 TrackerDigiGeometryESModule.applyAlignment = True
 

--- a/DQM/TrackingMonitor/python/ClientTrackEfficiencySTACosmicMuons_cff.py
+++ b/DQM/TrackingMonitor/python/ClientTrackEfficiencySTACosmicMuons_cff.py
@@ -7,8 +7,7 @@ import FWCore.ParameterSet.Config as cms
 
 from DQM.TrackingMonitor.TrackEfficiencyClient_cfi import TrackEffClient
 
-ClientTrackEfficiencySTACosmicMuons = TrackEffClient.clone()
-ClientTrackEfficiencySTACosmicMuons.FolderName = 'Muons/cosmicMuons'
-ClientTrackEfficiencySTACosmicMuons.AlgoName = 'STA'
-    
-    
+ClientTrackEfficiencySTACosmicMuons = TrackEffClient.clone(
+    FolderName = 'Muons/cosmicMuons',
+    AlgoName = 'STA'
+)

--- a/DQM/TrackingMonitor/python/ClientTrackEfficiencyTkTracks_cff.py
+++ b/DQM/TrackingMonitor/python/ClientTrackEfficiencyTkTracks_cff.py
@@ -7,7 +7,8 @@ import FWCore.ParameterSet.Config as cms
 
 from DQM.TrackingMonitor.TrackEfficiencyClient_cfi import TrackEffClient
 
-ClientTrackEfficiencyTkTracks = TrackEffClient.clone()
-ClientTrackEfficiencyTkTracks.FolderName = 'Muons/TKTrack'
-ClientTrackEfficiencyTkTracks.AlgoName = 'CTF'
-ClientTrackEfficiencyTkTracks.trackEfficiency = False
+ClientTrackEfficiencyTkTracks = TrackEffClient.clone(
+    FolderName = 'Muons/TKTrack',
+    AlgoName = 'CTF',
+    trackEfficiency = False
+)

--- a/DQM/TrackingMonitor/python/LogMessageMonitor_cff.py
+++ b/DQM/TrackingMonitor/python/LogMessageMonitor_cff.py
@@ -1,121 +1,106 @@
 import FWCore.ParameterSet.Config as cms
 
-import DQM.TrackingMonitor.LogMessageMonitor_cfi
+from DQM.TrackingMonitor.LogMessageMonitor_cfi import *
 
-LocalRecoLogMessageMon = DQM.TrackingMonitor.LogMessageMonitor_cfi.LogMessageMon.clone()
-LocalRecoLogMessageMon.pluginsMonName = cms.string ( 'LocalReco' )
-LocalRecoLogMessageMon.modules        = cms.vstring( 'siPixelDigis', 'siStripDigis', 'siPixelClusters', 'siStripClusters' ) # siPixelDigis : SiPixelRawToDigi, siStripDigis : SiStripRawToDigi (SiStripRawToDigiUnpacker), siPixelClusters : SiPixelClusterProducer, siStripClusters : SiStripClusterizer
-LocalRecoLogMessageMon.categories     = cms.vstring( 'SiPixelRawToDigi', 'TooManyErrors', 'TooManyClusters' )
+LocalRecoLogMessageMon = LogMessageMon.clone(
+    pluginsMonName = 'LocalReco',
+    modules = ('siPixelDigis', 'siStripDigis', 'siPixelClusters', 'siStripClusters',), # siPixelDigis : SiPixelRawToDigi, siStripDigis : SiStripRawToDigi (SiStripRawToDigiUnpacker), siPixelClusters : SiPixelClusterProducer, siStripClusters : SiStripClusterizer
+    categories = ('SiPixelRawToDigi', 'TooManyErrors', 'TooManyClusters',)
+)
 
 # apparentely there are not LogError in RecoLocalTracker/SubCollectionProducers/src/TrackClusterRemover.cc
-ClusterizerLogMessageMon = DQM.TrackingMonitor.LogMessageMonitor_cfi.LogMessageMon.clone()
-ClusterizerLogMessageMon.pluginsMonName = cms.string ( 'TrackClusterRemover' )
-ClusterizerLogMessageMon.modules        = cms.vstring( 'detachedTripletStepClusters', 'lowPtTripletStepClusters', 'pixelPairStepClusters', 'mixedTripletStepClusters', 'pixelLessStepClusters', 'tobTecStepClusters' ) # TrackClusterRemover
-ClusterizerLogMessageMon.categories     = cms.vstring(  )
+ClusterizerLogMessageMon = LogMessageMon.clone(
+    pluginsMonName = 'TrackClusterRemover',
+    modules = ('detachedTripletStepClusters', 'lowPtTripletStepClusters', 'pixelPairStepClusters', 'mixedTripletStepClusters', 'pixelLessStepClusters', 'tobTecStepClusters',), # TrackClusterRemover
+    categories = ()
+)
 
 # initialStepSeeds,lowPtTripletStepSeeds, pixelPairStepSeeds, detachedTripletStepSeeds, : TooManyClusters (SeedGeneratorFromRegionHitsEDProducer),
 # photonConvTrajSeedFromSingleLeg : (PhotonConversionTrajectorySeedProducerFromSingleLeg)
-SeedingLogMessageMon = DQM.TrackingMonitor.LogMessageMonitor_cfi.LogMessageMon.clone()
-SeedingLogMessageMon.pluginsMonName = cms.string ( 'Seeding' ) 
-SeedingLogMessageMon.modules        = cms.vstring( 'initialStepSeedsPreSplitting', 'initialStepSeeds', 'detachedTripletStepSeeds', 'lowPtTripletStepSeeds', 'pixelPairStepSeeds', 'mixedTripletStepSeedsA', 'mixedTripletStepSeedsB', 'pixelLessStepSeeds', 'tobTecStepSeeds', 'jetCoreRegionalStepSeeds', 'muonSeededSeedsOutIn', 'muonSeededSeedsInOut', 'photonConvTrajSeedFromSingleLeg')
-SeedingLogMessageMon.categories     = cms.vstring( 'TooManyClusters', 'TooManyPairs', 'TooManyTriplets', 'TooManySeeds' )
+SeedingLogMessageMon = LogMessageMon.clone(
+    pluginsMonName = 'Seeding',
+    modules = ('initialStepSeedsPreSplitting', 'initialStepSeeds', 'detachedTripletStepSeeds', 'lowPtTripletStepSeeds', 'pixelPairStepSeeds', 'mixedTripletStepSeedsA', 'mixedTripletStepSeedsB', 'pixelLessStepSeeds', 'tobTecStepSeeds', 'jetCoreRegionalStepSeeds', 'muonSeededSeedsOutIn', 'muonSeededSeedsInOut', 'photonConvTrajSeedFromSingleLeg',),
+    categories = ('TooManyClusters', 'TooManyPairs', 'TooManyTriplets', 'TooManySeeds',)
+)
 
 # RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
-TrackCandidateLogMessageMon = DQM.TrackingMonitor.LogMessageMonitor_cfi.LogMessageMon.clone()
-TrackCandidateLogMessageMon.pluginsMonName = cms.string ( 'TrackCandidate' ) 
-TrackCandidateLogMessageMon.modules        = cms.vstring( 'initialStepTrackCandidatesPreSplitting', 'initialStepTrackCandidates', 'detachedTripletStepTrackCandidates', 'lowPtTripletStepTrackCandidates', 'pixelPairStepTrackCandidates', 'mixedTripletStepTrackCandidates', 'pixelLessStepTrackCandidates', 'tobTecStepTrackCandidates', 'jetCoreRegionalStepTrackCandidates', 'muonSeededTrackCandidatesInOut', 'muonSeededTrackCandidatesOutIn', 'convTrackCandidates' )
-TrackCandidateLogMessageMon.categories     = cms.vstring( 'TooManySeeds' )
+TrackCandidateLogMessageMon = LogMessageMon.clone(
+    pluginsMonName = 'TrackCandidate',
+    modules = ('initialStepTrackCandidatesPreSplitting', 'initialStepTrackCandidates', 'detachedTripletStepTrackCandidates', 'lowPtTripletStepTrackCandidates', 'pixelPairStepTrackCandidates', 'mixedTripletStepTrackCandidates', 'pixelLessStepTrackCandidates', 'tobTecStepTrackCandidates', 'jetCoreRegionalStepTrackCandidates', 'muonSeededTrackCandidatesInOut', 'muonSeededTrackCandidatesOutIn', 'convTrackCandidates',),
+    categories = ('TooManySeeds',)
+)
 
 # TrackProducer:FailedPropagation 
-TrackFinderLogMessageMon = DQM.TrackingMonitor.LogMessageMonitor_cfi.LogMessageMon.clone()
-TrackFinderLogMessageMon.pluginsMonName = cms.string ( 'TrackFinder' ) 
-TrackFinderLogMessageMon.modules        = cms.vstring( 'pixelTracks', 'initialStepTracks', 'lowPtTripletStepTracks', 'pixelPairStepTracks', 'detachedTripletStepTracks', 'mixedTripletStepTracks', 'pixelLessStepTracks', 'tobTecStepTracks', 'jetCoreRegionalStepTracks', 'muonSeededTracksOutIn', 'muonSeededTracksInOut', 'convStepTracks', 'generalTracks' )
-TrackFinderLogMessageMon.categories     = cms.vstring(
-    'FailedPropagation', 'RKPropagatorInS'
+TrackFinderLogMessageMon = LogMessageMon.clone(
+    pluginsMonName = 'TrackFinder',
+    modules = ('pixelTracks', 'initialStepTracks', 'lowPtTripletStepTracks', 'pixelPairStepTracks', 'detachedTripletStepTracks', 'mixedTripletStepTracks', 'pixelLessStepTracks', 'tobTecStepTracks', 'jetCoreRegionalStepTracks', 'muonSeededTracksOutIn', 'muonSeededTracksInOut', 'convStepTracks', 'generalTracks',),
+    categories = ('FailedPropagation', 'RKPropagatorInS',)
 )
 
-FullIterTrackingLogMessageMon = DQM.TrackingMonitor.LogMessageMonitor_cfi.LogMessageMon.clone()
-FullIterTrackingLogMessageMon.pluginsMonName = cms.string ( 'FullIterTracking' ) 
-FullIterTrackingLogMessageMon.modules     = cms.vstring(
-       'initialStepSeeds_iter0',
-       'initialStepTrackCandidates_iter0',
-       'initialStepTracks_iter0',
-       'lowPtTripletStepSeeds_iter1',
-       'lowPtTripletStepTrackCandidates_iter1',
-       'lowPtTripletStepTracks_iter1',
-       'pixelPairStepSeeds_iter2',
-       'pixelPairStepTrackCandidates_iter2',
-       'pixelPairStepTracks_iter2',
-       'detachedTripletStepSeeds_iter3',
-       'detachedTripletStepTrackCandidates_iter3',
-       'detachedTripletStepTracks_iter3',
-       'mixedTripletStepSeedsA_iter4',
-       'mixedTripletStepSeedsB_iter4',
-       'mixedTripletStepTrackCandidates_iter4',
-       'mixedTripletStepTracks_iter4',
-       'pixelLessStepSeeds_iter5',
-       'pixelLessStepTrackCandidates_iter5',
-       'pixelLessStepTracks_iter5',
-       'tobTecStepSeeds_iter6',
-       'tobTecStepTrackCandidates_iter6',
-       'tobTecStepTracks_iter6',
-       'photonConvTrajSeedFromSingleLeg',
-       'convTrackCandidates',
-       'convStepTracks',
-)
-FullIterTrackingLogMessageMon.categories     = cms.vstring(
-    'TooManyClusters',
-    'TooManyPairs',
-    'TooManyTriplets',
-    'TooManySeeds',
-)    
-
-IterTrackingLogMessageMon = DQM.TrackingMonitor.LogMessageMonitor_cfi.LogMessageMon.clone()
-IterTrackingLogMessageMon.pluginsMonName = cms.string ( 'IterTracking' ) 
-IterTrackingLogMessageMon.modules     = cms.vstring(
-       'initialStepSeeds_iter0',
-       'initialStepTrackCandidates_iter0',
-       'initialStepTracks_iter0',
-       'lowPtTripletStepSeeds_iter1',
-       'lowPtTripletStepTrackCandidates_iter1',
-       'lowPtTripletStepTracks_iter1',
-       'pixelPairStepSeeds_iter2',
-       'pixelPairStepTrackCandidates_iter2',
-       'pixelPairStepTracks_iter2',
-       'detachedTripletStepSeeds_iter3',
-       'detachedTripletStepTrackCandidates_iter3',
-       'detachedTripletStepTracks_iter3',
-       'mixedTripletStepSeedsA_iter4',
-       'mixedTripletStepSeedsB_iter4',
-       'mixedTripletStepTrackCandidates_iter4',
-       'mixedTripletStepTracks_iter4',
-       'pixelLessStepSeeds_iter5',
-       'pixelLessStepTrackCandidates_iter5',
-       'pixelLessStepTracks_iter5',
-       'tobTecStepSeeds_iter6',
-       'tobTecStepTrackCandidates_iter6',
-       'tobTecStepTracks_iter6',
-)
-IterTrackingLogMessageMon.categories     = cms.vstring(
-    'TooManyClusters',
-    'TooManyPairs',
-    'TooManyTriplets',
-    'TooManySeeds',
-)    
-
-
-ConversionLogMessageMon = DQM.TrackingMonitor.LogMessageMonitor_cfi.LogMessageMon.clone()
-ConversionLogMessageMon.pluginsMonName = cms.string ( 'Conversion' ) 
-ConversionLogMessageMon.modules     = cms.vstring(
-       'photonConvTrajSeedFromSingleLeg',
-       'convTrackCandidates',
-       'convStepTracks',
-)
-ConversionLogMessageMon.categories     = cms.vstring(
-    'TooManyClusters',
-    'TooManyPairs',
-    'TooManyTriplets',
-    'TooManySeeds',
+FullIterTrackingLogMessageMon = LogMessageMon.clone(
+    pluginsMonName = 'FullIterTracking',
+    modules = (
+        'initialStepSeeds_iter0',
+        'initialStepTrackCandidates_iter0',
+        'initialStepTracks_iter0',
+        'lowPtTripletStepSeeds_iter1',
+        'lowPtTripletStepTrackCandidates_iter1',
+        'lowPtTripletStepTracks_iter1',
+        'pixelPairStepSeeds_iter2',
+        'pixelPairStepTrackCandidates_iter2',
+        'pixelPairStepTracks_iter2',
+        'detachedTripletStepSeeds_iter3',
+        'detachedTripletStepTrackCandidates_iter3',
+        'detachedTripletStepTracks_iter3',
+        'mixedTripletStepSeedsA_iter4',
+        'mixedTripletStepSeedsB_iter4',
+        'mixedTripletStepTrackCandidates_iter4',
+        'mixedTripletStepTracks_iter4',
+        'pixelLessStepSeeds_iter5',
+        'pixelLessStepTrackCandidates_iter5',
+        'pixelLessStepTracks_iter5',
+        'tobTecStepSeeds_iter6',
+        'tobTecStepTrackCandidates_iter6',
+        'tobTecStepTracks_iter6',
+        'photonConvTrajSeedFromSingleLeg',
+        'convTrackCandidates',
+        'convStepTracks',
+    ),
+    categories = ('TooManyClusters', 'TooManyPairs', 'TooManyTriplets', 'TooManySeeds',)
 )
 
+IterTrackingLogMessageMon = LogMessageMon.clone(
+    pluginsMonName = 'IterTracking',
+    modules = (
+        'initialStepSeeds_iter0',
+        'initialStepTrackCandidates_iter0',
+        'initialStepTracks_iter0',
+        'lowPtTripletStepSeeds_iter1',
+        'lowPtTripletStepTrackCandidates_iter1',
+        'lowPtTripletStepTracks_iter1',
+        'pixelPairStepSeeds_iter2',
+        'pixelPairStepTrackCandidates_iter2',
+        'pixelPairStepTracks_iter2',
+        'detachedTripletStepSeeds_iter3',
+        'detachedTripletStepTrackCandidates_iter3',
+        'detachedTripletStepTracks_iter3',
+        'mixedTripletStepSeedsA_iter4',
+        'mixedTripletStepSeedsB_iter4',
+        'mixedTripletStepTrackCandidates_iter4',
+        'mixedTripletStepTracks_iter4',
+        'pixelLessStepSeeds_iter5',
+        'pixelLessStepTrackCandidates_iter5',
+        'pixelLessStepTracks_iter5',
+        'tobTecStepSeeds_iter6',
+        'tobTecStepTrackCandidates_iter6',
+        'tobTecStepTracks_iter6',
+    ),
+    categories = ('TooManyClusters', 'TooManyPairs', 'TooManyTriplets', 'TooManySeeds',)
+)
+
+ConversionLogMessageMon = LogMessageMon.clone(
+    pluginsMonName = 'Conversion',
+    modules = ('photonConvTrajSeedFromSingleLeg', 'convTrackCandidates', 'convStepTracks',),
+    categories = ('TooManyClusters', 'TooManyPairs', 'TooManyTriplets', 'TooManySeeds',)
+)
 

--- a/DQM/TrackingMonitor/python/MonitorTrackEfficiencySTACosmicMuons_cff.py
+++ b/DQM/TrackingMonitor/python/MonitorTrackEfficiencySTACosmicMuons_cff.py
@@ -7,10 +7,10 @@ import FWCore.ParameterSet.Config as cms
 
 from DQM.TrackingMonitor.TrackEfficiencyMonitor_cfi import TrackEffMon
 
-MonitorTrackEfficiencySTACosmicMuons = TrackEffMon.clone()
-MonitorTrackEfficiencySTACosmicMuons.TKTrackCollection = 'ctfWithMaterialTracksP5'
-MonitorTrackEfficiencySTACosmicMuons.STATrackCollection = 'cosmicMuons'
-MonitorTrackEfficiencySTACosmicMuons.FolderName = 'Muons/cosmicMuons'
-MonitorTrackEfficiencySTACosmicMuons.AlgoName = 'STA'
-    
-    
+MonitorTrackEfficiencySTACosmicMuons = TrackEffMon.clone(
+    TKTrackCollection = 'ctfWithMaterialTracksP5',
+    STATrackCollection = 'cosmicMuons',
+    FolderName = 'Muons/cosmicMuons',
+    AlgoName = 'STA'
+)
+

--- a/DQM/TrackingMonitor/python/MonitorTrackEfficiencyTkTracks_cff.py
+++ b/DQM/TrackingMonitor/python/MonitorTrackEfficiencyTkTracks_cff.py
@@ -7,9 +7,10 @@ import FWCore.ParameterSet.Config as cms
 
 from DQM.TrackingMonitor.TrackEfficiencyMonitor_cfi import TrackEffMon
 
-MonitorTrackEfficiencyTkTracks = TrackEffMon.clone()
-MonitorTrackEfficiencyTkTracks.TKTrackCollection = 'ctfWithMaterialTracksP5'
-MonitorTrackEfficiencyTkTracks.STATrackCollection = 'cosmicMuons'
-MonitorTrackEfficiencyTkTracks.FolderName = 'Muons/TKTrack'
-MonitorTrackEfficiencyTkTracks.AlgoName = 'CTF'
-MonitorTrackEfficiencyTkTracks.trackEfficiency = False
+MonitorTrackEfficiencyTkTracks = TrackEffMon.clone(
+    TKTrackCollection = 'ctfWithMaterialTracksP5',
+    STATrackCollection = 'cosmicMuons',
+    FolderName = 'Muons/TKTrack',
+    AlgoName = 'CTF',
+    trackEfficiency = False
+)

--- a/DQM/TrackingMonitor/python/MonitorTrackGLBCosmicMuons_cfi.py
+++ b/DQM/TrackingMonitor/python/MonitorTrackGLBCosmicMuons_cfi.py
@@ -1,13 +1,14 @@
 import FWCore.ParameterSet.Config as cms
 
-import DQM.TrackingMonitor.TrackingMonitor_cfi
-MonitorTrackGLBCosmicMuons = DQM.TrackingMonitor.TrackingMonitor_cfi.TrackMon.clone()
-MonitorTrackGLBCosmicMuons.TrackProducer = 'globalCosmicMuons'
-MonitorTrackGLBCosmicMuons.AlgoName = 'glb'
-MonitorTrackGLBCosmicMuons.FolderName = 'Muons/globalCosmicMuons'
-MonitorTrackGLBCosmicMuons.doBeamSpotPlots = False
-MonitorTrackGLBCosmicMuons.BSFolderName = 'Muons/globalCosmicMuons/BeamSpotParameters'
-MonitorTrackGLBCosmicMuons.doSeedParameterHistos = False
-MonitorTrackGLBCosmicMuons.doAllPlots = False
-MonitorTrackGLBCosmicMuons.doHitPropertiesPlots = True
-MonitorTrackGLBCosmicMuons.doGeneralPropertiesPlots = True
+from DQM.TrackingMonitor.TrackingMonitor_cfi import *
+MonitorTrackGLBCosmicMuons = TrackMon.clone(
+    TrackProducer = 'globalCosmicMuons',
+    AlgoName = 'glb',
+    FolderName = 'Muons/globalCosmicMuons',
+    doBeamSpotPlots = False,
+    BSFolderName = 'Muons/globalCosmicMuons/BeamSpotParameters',
+    doSeedParameterHistos = False,
+    doAllPlots = False,
+    doHitPropertiesPlots = True,
+    doGeneralPropertiesPlots = True,
+)

--- a/DQM/TrackingMonitor/python/MonitorTrackGLBMuons_cfi.py
+++ b/DQM/TrackingMonitor/python/MonitorTrackGLBMuons_cfi.py
@@ -1,22 +1,23 @@
 import FWCore.ParameterSet.Config as cms
 
-import DQM.TrackingMonitor.TrackingMonitor_cfi
-MonitorTrackGLBMuons = DQM.TrackingMonitor.TrackingMonitor_cfi.TrackMon.clone()
-MonitorTrackGLBMuons.TrackProducer = 'globalMuons'
-MonitorTrackGLBMuons.AlgoName = 'glb'
-MonitorTrackGLBMuons.FolderName = 'Muons/globalMuons'
-MonitorTrackGLBMuons.doBeamSpotPlots = False
-MonitorTrackGLBMuons.BSFolderName = 'Muons/globalCosmicMuons/BeamSpotParameters'
-MonitorTrackGLBMuons.doSeedParameterHistos = False
-MonitorTrackGLBMuons.doProfilesVsLS = True
-MonitorTrackGLBMuons.doAllPlots = False
-MonitorTrackGLBMuons.doGeneralPropertiesPlots = True
-MonitorTrackGLBMuons.doHitPropertiesPlots = True
-MonitorTrackGLBMuons.doTrackerSpecific = True
-MonitorTrackGLBMuons.doDCAPlots = True
-MonitorTrackGLBMuons.doDCAwrtPVPlots = True
-MonitorTrackGLBMuons.doDCAwrt000Plots = False
-MonitorTrackGLBMuons.doSIPPlots  = True
-MonitorTrackGLBMuons.doEffFromHitPatternVsPU = True
-MonitorTrackGLBMuons.doEffFromHitPatternVsBX = False
-MonitorTrackGLBMuons.doEffFromHitPatternVsLUMI = cms.bool(True)
+from DQM.TrackingMonitor.TrackingMonitor_cfi import *
+MonitorTrackGLBMuons = TrackMon.clone(
+    TrackProducer = 'globalMuons',
+    AlgoName = 'glb',
+    FolderName = 'Muons/globalMuons',
+    doBeamSpotPlots = False,
+    BSFolderName = 'Muons/globalCosmicMuons/BeamSpotParameters',
+    doSeedParameterHistos = False,
+    doProfilesVsLS = True,
+    doAllPlots = False,
+    doGeneralPropertiesPlots = True,
+    doHitPropertiesPlots = True,
+    doTrackerSpecific = True,
+    doDCAPlots = True,
+    doDCAwrtPVPlots = True,
+    doDCAwrt000Plots = False,
+    doSIPPlots  = True,
+    doEffFromHitPatternVsPU = True,
+    doEffFromHitPatternVsBX = False,
+    doEffFromHitPatternVsLUMI = True
+)

--- a/DQM/TrackingMonitor/python/MonitorTrackInnerTrackMuons_cff.py
+++ b/DQM/TrackingMonitor/python/MonitorTrackInnerTrackMuons_cff.py
@@ -15,49 +15,49 @@ muonsPt10 = cms.EDFilter("MuonSelector",
 )
 
 
-import SimMuon.MCTruth.MuonTrackProducer_cfi
-muonInnerTrack = SimMuon.MCTruth.MuonTrackProducer_cfi.muonTrackProducer.clone()
-#muonInnerTrack.muonsTag = cms.InputTag("muons")
-muonInnerTrack.muonsTag = cms.InputTag("muonsPt10")
-muonInnerTrack.selectionTags = ('All',)
-muonInnerTrack.trackType = "innerTrack"
+from SimMuon.MCTruth.MuonTrackProducer_cfi import *
+muonInnerTrack = muonTrackProducer.clone(
+    #muonsTag = "muons",
+    muonsTag = "muonsPt10",
+    selectionTags = ('All',),
+    trackType = "innerTrack"
+)
 
-import DQM.TrackingMonitor.TrackingMonitor_cfi
-MonitorTrackMuonsInnerTrack = DQM.TrackingMonitor.TrackingMonitor_cfi.TrackMon.clone()
-MonitorTrackMuonsInnerTrack.TrackProducer = 'muonInnerTrack'
-MonitorTrackMuonsInnerTrack.AlgoName = 'inner'
-MonitorTrackMuonsInnerTrack.FolderName = 'Muons/Tracking/innerTrack'
-MonitorTrackMuonsInnerTrack.doBeamSpotPlots = True
-MonitorTrackMuonsInnerTrack.BSFolderName = 'Muons/Tracking/innerTrack/BeamSpotParameters'
-MonitorTrackMuonsInnerTrack.doSeedParameterHistos = False
-MonitorTrackMuonsInnerTrack.doProfilesVsLS = False
-MonitorTrackMuonsInnerTrack.doAllPlots = False
-MonitorTrackMuonsInnerTrack.doGeneralPropertiesPlots = True
-MonitorTrackMuonsInnerTrack.doHitPropertiesPlots = True
-MonitorTrackMuonsInnerTrack.doTrackerSpecific = True
-MonitorTrackMuonsInnerTrack.doDCAPlots = True
-MonitorTrackMuonsInnerTrack.doDCAwrtPVPlots = True
-MonitorTrackMuonsInnerTrack.doDCAwrt000Plots = False
-MonitorTrackMuonsInnerTrack.doSIPPlots  = True
-MonitorTrackMuonsInnerTrack.doEffFromHitPatternVsPU = True
-MonitorTrackMuonsInnerTrack.doEffFromHitPatternVsBX = False
-MonitorTrackMuonsInnerTrack.TkSizeBin = 10
-MonitorTrackMuonsInnerTrack.TkSizeMax = 10.
-MonitorTrackMuonsInnerTrack.phiErrMax = 0.001
-MonitorTrackMuonsInnerTrack.etaErrMax = 0.001
-MonitorTrackMuonsInnerTrack.PVBin = 40
-MonitorTrackMuonsInnerTrack.PVMin = -0.5
-MonitorTrackMuonsInnerTrack.PVMax = 79.5 ## it might need to be adjust if CMS asks to have lumi levelling at lower values
-
-MonitorTrackMuonsInnerTrack.doRecHitVsPhiVsEtaPerTrack           = True
-MonitorTrackMuonsInnerTrack.doRecHitVsPtVsEtaPerTrack            = True
-#MonitorTrackMuonsInnerTrack.doGoodTrackRecHitVsPhiVsEtaPerTrack  = True
-MonitorTrackMuonsInnerTrack.doLayersVsPhiVsEtaPerTrack           = True
-#MonitorTrackMuonsInnerTrack.doGoodTrackLayersVsPhiVsEtaPerTrack  = True
-
-MonitorTrackMuonsInnerTrack.Eta2DBin   = 16
-MonitorTrackMuonsInnerTrack.Phi2DBin   = 16
-MonitorTrackMuonsInnerTrack.TrackPtBin = 50
+from DQM.TrackingMonitor.TrackingMonitor_cfi import *
+MonitorTrackMuonsInnerTrack = TrackMon.clone(
+    TrackProducer = 'muonInnerTrack',
+    AlgoName = 'inner',
+    FolderName = 'Muons/Tracking/innerTrack',
+    doBeamSpotPlots = True,
+    BSFolderName = 'Muons/Tracking/innerTrack/BeamSpotParameters',
+    doSeedParameterHistos = False,
+    doProfilesVsLS = False,
+    doAllPlots = False,
+    doGeneralPropertiesPlots = True,
+    doHitPropertiesPlots = True,
+    doTrackerSpecific = True,
+    doDCAPlots = True,
+    doDCAwrtPVPlots = True,
+    doDCAwrt000Plots = False,
+    doSIPPlots  = True,
+    doEffFromHitPatternVsPU = True,
+    doEffFromHitPatternVsBX = False,
+    TkSizeBin = 10,
+    TkSizeMax = 10.,
+    phiErrMax = 0.001,
+    etaErrMax = 0.001,
+    PVBin = 40,
+    PVMin = -0.5,
+    PVMax = 79.5, ## it might need to be adjust if CMS asks to have lumi levelling at lower values
+    doRecHitVsPhiVsEtaPerTrack = True,
+    doRecHitVsPtVsEtaPerTrack = True,
+    #doGoodTrackRecHitVsPhiVsEtaPerTrack = True,
+    doLayersVsPhiVsEtaPerTrack = True,
+    #doGoodTrackLayersVsPhiVsEtaPerTrack = True,
+    Eta2DBin = 16,
+    Phi2DBin = 16,
+    TrackPtBin = 50
+)
 
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker

--- a/DQM/TrackingMonitor/python/MonitorTrackSTACosmicMuonsHLT_cff.py
+++ b/DQM/TrackingMonitor/python/MonitorTrackSTACosmicMuonsHLT_cff.py
@@ -1,12 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 
-import DQM.TrackingMonitor.MonitorTrackSTAMuons_cfi
-MonitorTrackSTACosmicMuonsHLTDT = DQM.TrackingMonitor.MonitorTrackSTAMuons_cfi.MonitorTrackSTAMuons.clone()
-import DQM.TrackingMonitor.MonitorTrackSTAMuons_cfi
-MonitorTrackSTACosmicMuonsHLTCSC = DQM.TrackingMonitor.MonitorTrackSTAMuons_cfi.MonitorTrackSTAMuons.clone()
-MonitorTrackSTACosmicMuonsHLTDT.TrackProducer = 'dtCosmicSTA'
-MonitorTrackSTACosmicMuonsHLTDT.FolderName = 'Muons/cosmicMuonsHLTDT'
-MonitorTrackSTACosmicMuonsHLTCSC.TrackProducer = 'cscCosmicSTA'
-MonitorTrackSTACosmicMuonsHLTCSC.FolderName = 'Muons/cosmicMuonsHLTCSC'
+from DQM.TrackingMonitor.MonitorTrackSTAMuons_cfi import *
+MonitorTrackSTACosmicMuonsHLTDT = MonitorTrackSTAMuons.clone(
+    TrackProducer = 'dtCosmicSTA',
+    FolderName = 'Muons/cosmicMuonsHLTDT'
+)
 
-
+MonitorTrackSTACosmicMuonsHLTCSC = MonitorTrackSTAMuons.clone(
+    TrackProducer = 'cscCosmicSTA',
+    FolderName = 'Muons/cosmicMuonsHLTCSC'
+)

--- a/DQM/TrackingMonitor/python/MonitorTrackSTACosmicMuons_cff.py
+++ b/DQM/TrackingMonitor/python/MonitorTrackSTACosmicMuons_cff.py
@@ -1,30 +1,34 @@
 import FWCore.ParameterSet.Config as cms
 
 from DQM.TrackingMonitor.MonitorTrackSTACosmicMuons_cfi import *
-import DQM.TrackingMonitor.MonitorTrackSTAMuons_cfi
-MonitorTrackSTACosmicMuonsBarrel = DQM.TrackingMonitor.MonitorTrackSTAMuons_cfi.MonitorTrackSTAMuons.clone()
-import DQM.TrackingMonitor.MonitorTrackSTAMuons_cfi
-MonitorTrackSTACosmicMuonsEndCaps = DQM.TrackingMonitor.MonitorTrackSTAMuons_cfi.MonitorTrackSTAMuons.clone()
-import DQM.TrackingMonitor.MonitorTrackSTAMuons_cfi
-MonitorTrackSTACosmicMuons1LegBarrel = DQM.TrackingMonitor.MonitorTrackSTAMuons_cfi.MonitorTrackSTAMuons.clone()
-import DQM.TrackingMonitor.MonitorTrackSTAMuons_cfi
-MonitorTrackLHCStandAloneMuonsBarrelOnly = DQM.TrackingMonitor.MonitorTrackSTAMuons_cfi.MonitorTrackSTAMuons.clone()
-import DQM.TrackingMonitor.MonitorTrackSTAMuons_cfi
-MonitorTrackLHCStandAloneMuonsEndCapsOnly = DQM.TrackingMonitor.MonitorTrackSTAMuons_cfi.MonitorTrackSTAMuons.clone()
-import DQM.TrackingMonitor.MonitorTrackSTAMuons_cfi
-MonitorTrackSTACosmicMuonsNoDriftBarrel = DQM.TrackingMonitor.MonitorTrackSTAMuons_cfi.MonitorTrackSTAMuons.clone()
+from DQM.TrackingMonitor.MonitorTrackSTAMuons_cfi import *
+MonitorTrackSTACosmicMuonsBarrel = MonitorTrackSTAMuons.clone(
+    FolderName = 'Muons/cosmicMuonsBarrelOnly',
+    TrackProducer = 'cosmicMuonsBarrelOnly'
+)
+from DQM.TrackingMonitor.MonitorTrackSTAMuons_cfi import *
+MonitorTrackSTACosmicMuonsEndCaps = MonitorTrackSTAMuons.clone(
+    FolderName = 'Muons/cosmicMuonsEndCapsOnly',
+    TrackProducer = 'cosmicMuonsEndCapsOnly'
+)
+from DQM.TrackingMonitor.MonitorTrackSTAMuons_cfi import *
+MonitorTrackSTACosmicMuons1LegBarrel = MonitorTrackSTAMuons.clone(
+    FolderName = 'Muons/cosmicMuons1LegBarrelOnly',
+    TrackProducer = 'cosmicMuons1LegBarrelOnly'
+)
+from DQM.TrackingMonitor.MonitorTrackSTAMuons_cfi import *
+MonitorTrackLHCStandAloneMuonsBarrelOnly = MonitorTrackSTAMuons.clone(
+    FolderName = 'Muons/standAloneMuonsBarrelOnly',
+    TrackProducer = 'lhcStandAloneMuonsBarrelOnly'
+)
+from DQM.TrackingMonitor.MonitorTrackSTAMuons_cfi import *
+MonitorTrackLHCStandAloneMuonsEndCapsOnly = MonitorTrackSTAMuons.clone(
+    FolderName = 'Muons/standAloneMuonsEndCapsOnly',
+    TrackProducer = 'lhcStandAloneMuonsEndCapsOnly'
+)
+from DQM.TrackingMonitor.MonitorTrackSTAMuons_cfi import *
+MonitorTrackSTACosmicMuonsNoDriftBarrel = MonitorTrackSTAMuons.clone(
+    FolderName = 'Muons/cosmicMuonsNoDriftBarrelOnly',
+    TrackProducer = 'cosmicMuonsNoDriftBarrelOnly'
+)
 standAloneCosmicMuonsMonitors = cms.Sequence(MonitorTrackSTACosmicMuons*MonitorTrackSTACosmicMuonsBarrel*MonitorTrackSTACosmicMuons1LegBarrel*MonitorTrackSTACosmicMuonsEndCaps*MonitorTrackLHCStandAloneMuonsBarrelOnly*MonitorTrackLHCStandAloneMuonsEndCapsOnly*MonitorTrackSTACosmicMuonsNoDriftBarrel)
-MonitorTrackSTACosmicMuonsBarrel.FolderName = 'Muons/cosmicMuonsBarrelOnly'
-MonitorTrackSTACosmicMuonsBarrel.TrackProducer = 'cosmicMuonsBarrelOnly'
-MonitorTrackSTACosmicMuonsEndCaps.FolderName = 'Muons/cosmicMuonsEndCapsOnly'
-MonitorTrackSTACosmicMuonsEndCaps.TrackProducer = 'cosmicMuonsEndCapsOnly'
-MonitorTrackSTACosmicMuons1LegBarrel.FolderName = 'Muons/cosmicMuons1LegBarrelOnly'
-MonitorTrackSTACosmicMuons1LegBarrel.TrackProducer = 'cosmicMuons1LegBarrelOnly'
-MonitorTrackLHCStandAloneMuonsBarrelOnly.FolderName = 'Muons/standAloneMuonsBarrelOnly'
-MonitorTrackLHCStandAloneMuonsBarrelOnly.TrackProducer = 'lhcStandAloneMuonsBarrelOnly'
-MonitorTrackLHCStandAloneMuonsEndCapsOnly.FolderName = 'Muons/standAloneMuonsEndCapsOnly'
-MonitorTrackLHCStandAloneMuonsEndCapsOnly.TrackProducer = 'lhcStandAloneMuonsEndCapsOnly'
-MonitorTrackSTACosmicMuonsNoDriftBarrel.FolderName = 'Muons/cosmicMuonsNoDriftBarrelOnly'
-MonitorTrackSTACosmicMuonsNoDriftBarrel.TrackProducer = 'cosmicMuonsNoDriftBarrelOnly'
-
-

--- a/DQM/TrackingMonitor/python/MonitorTrackSTACosmicMuons_cfi.py
+++ b/DQM/TrackingMonitor/python/MonitorTrackSTACosmicMuons_cfi.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-import DQM.TrackingMonitor.MonitorTrackSTAMuons_cfi
-MonitorTrackSTACosmicMuons = DQM.TrackingMonitor.MonitorTrackSTAMuons_cfi.MonitorTrackSTAMuons.clone()
-MonitorTrackSTACosmicMuons.FolderName = 'Muons/cosmicMuons'
-MonitorTrackSTACosmicMuons.TrackProducer = 'cosmicMuons'
-
+from DQM.TrackingMonitor.MonitorTrackSTAMuons_cfi import *
+MonitorTrackSTACosmicMuons = MonitorTrackSTAMuons.clone(
+    FolderName = 'Muons/cosmicMuons',
+    TrackProducer = 'cosmicMuons'
+)
 

--- a/DQM/TrackingMonitor/python/MonitorTrackSTAMuons_cfi.py
+++ b/DQM/TrackingMonitor/python/MonitorTrackSTAMuons_cfi.py
@@ -1,358 +1,300 @@
 import FWCore.ParameterSet.Config as cms
 
 # MonitorTrackGlobal
-import DQM.TrackingMonitor.TrackingMonitor_cfi
-MonitorTrackSTAMuons = DQM.TrackingMonitor.TrackingMonitor_cfi.TrackMon.clone()
-
-# input tags
-MonitorTrackSTAMuons.TrackProducer = cms.InputTag("standAloneMuons","UpdatedAtVtx")
-MonitorTrackSTAMuons.SeedProducer  = cms.InputTag("combinedP5SeedsForCTF")
-MonitorTrackSTAMuons.TCProducer    = cms.InputTag("ckfTrackCandidatesP5")
-MonitorTrackSTAMuons.beamSpot      = cms.InputTag("offlineBeamSpot")
-MonitorTrackSTAMuons.ClusterLabels = cms.vstring('Tot')
-
-# output parameters
-MonitorTrackSTAMuons.AlgoName            = cms.string('sta')
-MonitorTrackSTAMuons.Quality             = cms.string('')
-MonitorTrackSTAMuons.FolderName          = cms.string('Muons/standAloneMuonsUpdatedAtVtx')
-MonitorTrackSTAMuons.BSFolderName        = cms.string('Muons/standAloneMuonsUpdatedAtVtx/BeamSpotParameters')
-
-# determines where to evaluate track parameters
-# options: 'default'      --> straight up track parametes
-#		   'ImpactPoint'  --> evalutate at impact point
-#		   'InnerSurface' --> evalutate at innermost measurement state
-#		   'OuterSurface' --> evalutate at outermost measurement state
-MonitorTrackSTAMuons.MeasurementState = cms.string('default')
-
-# which plots to do
-MonitorTrackSTAMuons.doTrackerSpecific          = cms.bool(False)
-MonitorTrackSTAMuons.doAllPlots                 = cms.bool(False)
-MonitorTrackSTAMuons.doBeamSpotPlots            = cms.bool(False)
-MonitorTrackSTAMuons.doSeedParameterHistos      = cms.bool(False)
-MonitorTrackSTAMuons.doTrackCandHistos          = cms.bool(False)
-MonitorTrackSTAMuons.doDCAPlots                 = cms.bool(False)
-MonitorTrackSTAMuons.doGeneralPropertiesPlots   = cms.bool(True)
-MonitorTrackSTAMuons.doHitPropertiesPlots       = cms.bool(True)
-MonitorTrackSTAMuons.doEffFromHitPatternVsPU    = cms.bool(False)
-MonitorTrackSTAMuons.doEffFromHitPatternVsBX    = cms.bool(False)
-#MonitorTrackSTAMuons.doGoodTrackPlots           = cms.bool(False)
-MonitorTrackSTAMuons.doMeasurementStatePlots    = cms.bool(True)
-MonitorTrackSTAMuons.doProfilesVsLS             = cms.bool(False)
-MonitorTrackSTAMuons.doRecHitVsPhiVsEtaPerTrack = cms.bool(False)
-#MonitorTrackSTAMuons.doGoodTrackRecHitVsPhiVsEtaPerTrack = cms.bool(False)
-
-#which seed plots to do
-MonitorTrackSTAMuons.doSeedNumberHisto    = cms.bool(False)
-MonitorTrackSTAMuons.doSeedVsClusterHisto = cms.bool(False)
-MonitorTrackSTAMuons.doSeedPTHisto        = cms.bool(False)
-MonitorTrackSTAMuons.doSeedETAHisto       = cms.bool(False)
-MonitorTrackSTAMuons.doSeedPHIHisto       = cms.bool(False)
-MonitorTrackSTAMuons.doSeedPHIVsETAHisto  = cms.bool(False)
-MonitorTrackSTAMuons.doSeedThetaHisto     = cms.bool(False)
-MonitorTrackSTAMuons.doSeedQHisto         = cms.bool(False)
-MonitorTrackSTAMuons.doSeedDxyHisto       = cms.bool(False)
-MonitorTrackSTAMuons.doSeedDzHisto        = cms.bool(False)
-MonitorTrackSTAMuons.doSeedNRecHitsHisto  = cms.bool(False)
-MonitorTrackSTAMuons.doSeedNVsPhiProf     = cms.bool(False)
-MonitorTrackSTAMuons.doSeedNVsEtaProf     = cms.bool(False)
-
-
-# paramters of the Track
-# ============================================================
-
-# chi2
-MonitorTrackSTAMuons.Chi2Bin = cms.int32(250)
-MonitorTrackSTAMuons.Chi2Max = cms.double(500.0)
-MonitorTrackSTAMuons.Chi2Min = cms.double(0.0)
-
-# chi2 dof
-MonitorTrackSTAMuons.Chi2NDFBin = cms.int32(200)
-MonitorTrackSTAMuons.Chi2NDFMax = cms.double(19.5)
-MonitorTrackSTAMuons.Chi2NDFMin = cms.double(-0.5)
-
-# chi^2 probability
-MonitorTrackSTAMuons.Chi2ProbBin = cms.int32(100)
-MonitorTrackSTAMuons.Chi2ProbMax = cms.double(1.0)
-MonitorTrackSTAMuons.Chi2ProbMin = cms.double(0.0)
-
-# Number of Tracks per Event
-MonitorTrackSTAMuons.TkSizeBin = cms.int32(11)
-MonitorTrackSTAMuons.TkSizeMax = cms.double(10.5)
-MonitorTrackSTAMuons.TkSizeMin = cms.double(-0.5)
-
-# Number of seeds per Event
-MonitorTrackSTAMuons.TkSeedSizeBin = cms.int32(20)
-MonitorTrackSTAMuons.TkSeedSizeMax = cms.double(19.5)
-MonitorTrackSTAMuons.TkSeedSizeMin = cms.double(-0.5)
-
-# Number of Track Cadidates per Event
-MonitorTrackSTAMuons.TCSizeBin = cms.int32(150)
-MonitorTrackSTAMuons.TCSizeMax = cms.double(149.5)
-MonitorTrackSTAMuons.TCSizeMin = cms.double(-0.5)
-
-# num rec hits
-MonitorTrackSTAMuons.TrackQBin = cms.int32(8)
-MonitorTrackSTAMuons.TrackQMax = cms.double(2.5)
-MonitorTrackSTAMuons.TrackQMin = cms.double(-2.5)
-
-# num rec hits in seed
-MonitorTrackSTAMuons.SeedHitBin = cms.int32(6)
-MonitorTrackSTAMuons.SeedHitMax = cms.double(5.5)
-MonitorTrackSTAMuons.SeedHitMin = cms.double(-0.5)
-
-# num rec hits per track candidate
-MonitorTrackSTAMuons.TCHitBin = cms.int32(40)
-MonitorTrackSTAMuons.TCHitMax = cms.double(39.5)
-MonitorTrackSTAMuons.TCHitMin = cms.double(-0.5)
-
-# num rec hits
-MonitorTrackSTAMuons.RecHitBin = cms.int32(120)
-MonitorTrackSTAMuons.RecHitMax = cms.double(120.0)
-MonitorTrackSTAMuons.RecHitMin = cms.double(0.0)
-
-# mean rec hits
-MonitorTrackSTAMuons.MeanHitBin = cms.int32(30)
-MonitorTrackSTAMuons.MeanHitMax = cms.double(29.5)
-MonitorTrackSTAMuons.MeanHitMin = cms.double(-0.5)
-
-# num TOB rec hits
-MonitorTrackSTAMuons.TOBHitBin = cms.int32(15)
-MonitorTrackSTAMuons.TOBHitMin = cms.double(-0.5)
-MonitorTrackSTAMuons.TOBHitMax = cms.double(14.5)
-
-# num TIB rec hits
-MonitorTrackSTAMuons.TIBHitBin = cms.int32(15)
-MonitorTrackSTAMuons.TIBHitMin = cms.double(-0.5)
-MonitorTrackSTAMuons.TIBHitMax = cms.double(14.5)
-
-# num TID rec hits
-MonitorTrackSTAMuons.TIDHitBin = cms.int32(15)
-MonitorTrackSTAMuons.TIDHitMin = cms.double(-0.5)
-MonitorTrackSTAMuons.TIDHitMax = cms.double(14.5)
-
-# num TEC rec hits
-MonitorTrackSTAMuons.TECHitBin = cms.int32(25)
-MonitorTrackSTAMuons.TECHitMin = cms.double(-0.5)
-MonitorTrackSTAMuons.TECHitMax = cms.double(24.5)
-
-# num PXB rec hits
-MonitorTrackSTAMuons.PXBHitBin = cms.int32(10)
-MonitorTrackSTAMuons.PXBHitMin = cms.double(-0.5)
-MonitorTrackSTAMuons.PXBHitMax = cms.double(9.5)
-
-# num PXF rec hits
-MonitorTrackSTAMuons.PXFHitBin = cms.int32(10)
-MonitorTrackSTAMuons.PXFHitMin = cms.double(-0.5)
-MonitorTrackSTAMuons.PXFHitMax = cms.double(9.5)
-
-# num rec hits lost
-MonitorTrackSTAMuons.RecLostBin = cms.int32(120)
-MonitorTrackSTAMuons.RecLostMax = cms.double(20)
-MonitorTrackSTAMuons.RecLostMin = cms.double(0.0)
-
-# num layers
-MonitorTrackSTAMuons.RecLayBin = cms.int32(120)
-MonitorTrackSTAMuons.RecLayMax = cms.double(120.0)
-MonitorTrackSTAMuons.RecLayMin = cms.double(0.0)
-
-# mean layers
-MonitorTrackSTAMuons.MeanLayBin = cms.int32(20)
-MonitorTrackSTAMuons.MeanLayMax = cms.double(19.5)
-MonitorTrackSTAMuons.MeanLayMin = cms.double(-0.5)
-
-# num TOB layers
-MonitorTrackSTAMuons.TOBLayBin = cms.int32(10)
-MonitorTrackSTAMuons.TOBLayMax = cms.double(9.5)
-MonitorTrackSTAMuons.TOBLayMin = cms.double(-0.5)
-
-# num TIB layers
-MonitorTrackSTAMuons.TIBLayBin = cms.int32(6)
-MonitorTrackSTAMuons.TIBLayMax = cms.double(5.5)
-MonitorTrackSTAMuons.TIBLayMin = cms.double(-0.5)
-
-# num TID layers
-MonitorTrackSTAMuons.TIDLayBin = cms.int32(6)
-MonitorTrackSTAMuons.TIDLayMax = cms.double(5.5)
-MonitorTrackSTAMuons.TIDLayMin = cms.double(-0.5)
-
-# num TEC layers
-MonitorTrackSTAMuons.TECLayBin = cms.int32(15)
-MonitorTrackSTAMuons.TECLayMax = cms.double(14.5)
-MonitorTrackSTAMuons.TECLayMin = cms.double(-0.5)
-
-# num PXB layers
-MonitorTrackSTAMuons.PXBLayBin = cms.int32(6)
-MonitorTrackSTAMuons.PXBLayMax = cms.double(5.5)
-MonitorTrackSTAMuons.PXBLayMin = cms.double(-0.5)
-
-# num PXF layers
-MonitorTrackSTAMuons.PXFLayBin = cms.int32(6)
-MonitorTrackSTAMuons.PXFLayMax = cms.double(5.5)
-MonitorTrackSTAMuons.PXFLayMin = cms.double(-0.5)
-
-# Track |p|
-MonitorTrackSTAMuons.TrackPBin = cms.int32(1000)
-MonitorTrackSTAMuons.TrackPMax = cms.double(1000)
-MonitorTrackSTAMuons.TrackPMin = cms.double(0)
-
-# Track pT
-MonitorTrackSTAMuons.TrackPtBin = cms.int32(1000)
-MonitorTrackSTAMuons.TrackPtMax = cms.double(1000)
-MonitorTrackSTAMuons.TrackPtMin = cms.double(0)
-
-# Track px
-MonitorTrackSTAMuons.TrackPxBin = cms.int32(1000)
-MonitorTrackSTAMuons.TrackPxMax = cms.double(500.0)
-MonitorTrackSTAMuons.TrackPxMin = cms.double(-500.0)
-
-# Track py
-MonitorTrackSTAMuons.TrackPyBin = cms.int32(1000)
-MonitorTrackSTAMuons.TrackPyMax = cms.double(500.0)
-MonitorTrackSTAMuons.TrackPyMin = cms.double(-500.0)
-
-# Track pz
-MonitorTrackSTAMuons.TrackPzMin = cms.double(-500.0)
-MonitorTrackSTAMuons.TrackPzMax = cms.double(500.0)
-MonitorTrackSTAMuons.TrackPzBin = cms.int32(1000)
-
-# track theta
-MonitorTrackSTAMuons.ThetaBin = cms.int32(100)
-MonitorTrackSTAMuons.ThetaMax = cms.double(3.2)
-MonitorTrackSTAMuons.ThetaMin = cms.double(0.0)
-
-# track eta
-MonitorTrackSTAMuons.EtaBin = cms.int32(100)
-MonitorTrackSTAMuons.EtaMax = cms.double(3.0)
-MonitorTrackSTAMuons.EtaMin = cms.double(-3.0)
-
-# track phi
-MonitorTrackSTAMuons.PhiBin = cms.int32(36)
-MonitorTrackSTAMuons.PhiMax = cms.double(3.2)
-MonitorTrackSTAMuons.PhiMin = cms.double(-3.2)
-
-# Track |p|	error
-MonitorTrackSTAMuons.pErrBin = cms.int32(100)
-MonitorTrackSTAMuons.pErrMax = cms.double(10.0)
-MonitorTrackSTAMuons.pErrMin = cms.double(0.0)
-
-# Track pT error
-MonitorTrackSTAMuons.ptErrBin = cms.int32(100)
-MonitorTrackSTAMuons.ptErrMax = cms.double(10.0)
-MonitorTrackSTAMuons.ptErrMin = cms.double(0.0)
-
-# Track px error
-MonitorTrackSTAMuons.pxErrBin = cms.int32(100)
-MonitorTrackSTAMuons.pxErrMax = cms.double(10.0)
-MonitorTrackSTAMuons.pxErrMin = cms.double(0.0)
-
-# Track py error
-MonitorTrackSTAMuons.pyErrBin = cms.int32(100)
-MonitorTrackSTAMuons.pyErrMax = cms.double(10.0)
-MonitorTrackSTAMuons.pyErrMin = cms.double(0.0)
-
-# Track pz error
-MonitorTrackSTAMuons.pzErrBin = cms.int32(100)
-MonitorTrackSTAMuons.pzErrMax = cms.double(10.0)
-MonitorTrackSTAMuons.pzErrMin = cms.double(0.0)
-
-# track eta error
-MonitorTrackSTAMuons.etaErrBin = cms.int32(100)
-MonitorTrackSTAMuons.etaErrMax = cms.double(0.5)
-MonitorTrackSTAMuons.etaErrMin = cms.double(0.0)
-
-# track phi Error
-MonitorTrackSTAMuons.phiErrBin = cms.int32(100)
-MonitorTrackSTAMuons.phiErrMax = cms.double(1.0)
-MonitorTrackSTAMuons.phiErrMin = cms.double(0.0)
-
-# PCA x position
-MonitorTrackSTAMuons.VXBin = cms.int32(20)
-MonitorTrackSTAMuons.VXMax = cms.double(20.0)
-MonitorTrackSTAMuons.VXMin = cms.double(-20.0)
-
-# PCA y position
-MonitorTrackSTAMuons.VYBin = cms.int32(20)
-MonitorTrackSTAMuons.VYMax = cms.double(20.0)
-MonitorTrackSTAMuons.VYMin = cms.double(-20.0)
-
-# PCA z position
-MonitorTrackSTAMuons.VZBin = cms.int32(50)
-MonitorTrackSTAMuons.VZMax = cms.double(100.0)
-MonitorTrackSTAMuons.VZMin = cms.double(-100.0)
-
-# PCA x position for 2D plot
-MonitorTrackSTAMuons.X0Bin = cms.int32(100)
-MonitorTrackSTAMuons.X0Max = cms.double(3.0)
-MonitorTrackSTAMuons.X0Min = cms.double(-3.0)
-
-# PCA y position for 2D plot
-MonitorTrackSTAMuons.Y0Bin = cms.int32(100)
-MonitorTrackSTAMuons.Y0Max = cms.double(3.0)
-MonitorTrackSTAMuons.Y0Min = cms.double(-3.0)
-
-# PCA z position for 2D plot
-MonitorTrackSTAMuons.Z0Bin = cms.int32(60)
-MonitorTrackSTAMuons.Z0Max = cms.double(30.0)
-MonitorTrackSTAMuons.Z0Min = cms.double(-30.0)
-
-# Track dxy (transverse impact parameter)
-MonitorTrackSTAMuons.DxyBin = cms.int32(100)
-MonitorTrackSTAMuons.DxyMax = cms.double(0.5)
-MonitorTrackSTAMuons.DxyMin = cms.double(-0.5)
-
-# Seed dxy (transverse impact parameter)
-MonitorTrackSTAMuons.SeedDxyBin = cms.int32(100)
-MonitorTrackSTAMuons.SeedDxyMax = cms.double(0.5)
-MonitorTrackSTAMuons.SeedDxyMin = cms.double(-0.5)
-
-# Seed dz (longitudinal impact parameter)
-MonitorTrackSTAMuons.SeedDzBin = cms.int32(200)
-MonitorTrackSTAMuons.SeedDzMax = cms.double(30.0)
-MonitorTrackSTAMuons.SeedDzMin = cms.double(-30.0)
-
-# Track Candidate dxy (transverse impact parameter)
-MonitorTrackSTAMuons.TCDxyBin = cms.int32(200)
-MonitorTrackSTAMuons.TCDxyMax = cms.double(100.0)
-MonitorTrackSTAMuons.TCDxyMin = cms.double(-100.0)
-
-# Track Candidate dz (transverse impact parameter)
-MonitorTrackSTAMuons.TCDzBin = cms.int32(200)
-MonitorTrackSTAMuons.TCDzMax = cms.double(400.0)
-MonitorTrackSTAMuons.TCDzMin = cms.double(-400.0)
-
-# NCluster Pixel
-MonitorTrackSTAMuons.NClusPxBin = cms.int32(50)
-MonitorTrackSTAMuons.NClusPxMax = cms.double(1999.5)
-MonitorTrackSTAMuons.NClusPxMin = cms.double(-0.5)
-
-# NCluster Strip
-MonitorTrackSTAMuons.NClusStrBin = cms.int32(150)
-MonitorTrackSTAMuons.NClusStrMax = cms.double(14999.5)
-MonitorTrackSTAMuons.NClusStrMin = cms.double(-0.5)
-
-# NCluster 2D
-MonitorTrackSTAMuons.NClus2DPxBin  = cms.int32(20)
-MonitorTrackSTAMuons.NClus2DPxMax  = cms.double(1999.5)
-MonitorTrackSTAMuons.NClus2DPxMin  = cms.double(-0.5)
-MonitorTrackSTAMuons.NClus2DStrBin = cms.int32(50)
-MonitorTrackSTAMuons.NClus2DStrMax = cms.double(14999.5)
-MonitorTrackSTAMuons.NClus2DStrMin = cms.double(-0.5)
-
-# NCluster Vs Tracks
-MonitorTrackSTAMuons.NClus2DTotBin = cms.int32(50)
-MonitorTrackSTAMuons.NClus2DTotMax = cms.double(14999.5)
-MonitorTrackSTAMuons.NClus2DTotMin = cms.double(-0.5)
-MonitorTrackSTAMuons.NTrk2D.NTrk2DBin     = cms.int32(20)
-MonitorTrackSTAMuons.NTrk2D.NTrk2DMax     = cms.double(199.5)
-MonitorTrackSTAMuons.NTrk2D.NTrk2DMin     = cms.double(-0.5)
-
-MonitorTrackSTAMuons.TTRHBuilder = cms.string('WithTrackAngle')
-
-# For plots vs LS
-MonitorTrackSTAMuons.LSBin = cms.int32(2000)
-MonitorTrackSTAMuons.LSMin = cms.double(0)
-MonitorTrackSTAMuons.LSMax = cms.double(2000.)
-
-# Luminosity based analysis
-MonitorTrackSTAMuons.doLumiAnalysis = cms.bool(False)
-
+from DQM.TrackingMonitor.TrackingMonitor_cfi import *
+MonitorTrackSTAMuons = TrackMon.clone(
+    # input tags
+    TrackProducer = ("standAloneMuons","UpdatedAtVtx"),
+    SeedProducer = "combinedP5SeedsForCTF",
+    TCProducer = "ckfTrackCandidatesP5",
+    beamSpot = "offlineBeamSpot",
+    ClusterLabels = ('Tot',),
+
+    # output parameters
+    AlgoName = 'sta',
+    Quality = '',
+    FolderName = 'Muons/standAloneMuonsUpdatedAtVtx',
+    BSFolderName = 'Muons/standAloneMuonsUpdatedAtVtx/BeamSpotParameters',
+
+    # determines where to evaluate track parameters
+    # options: 'default'      --> straight up track parametes
+    #		   'ImpactPoint'  --> evalutate at impact point
+    #		   'InnerSurface' --> evalutate at innermost measurement state
+    #		   'OuterSurface' --> evalutate at outermost measurement state
+    MeasurementState = 'default',
+
+    # which plots to do
+    doTrackerSpecific = False,
+    doAllPlots = False,
+    doBeamSpotPlots = False,
+    doSeedParameterHistos = False,
+    doTrackCandHistos = False,
+    doDCAPlots = False,
+    doGeneralPropertiesPlots = True,
+    doHitPropertiesPlots = True,
+    doEffFromHitPatternVsPU = False,
+    doEffFromHitPatternVsBX = False,
+    #doGoodTrackPlots = False,
+    doMeasurementStatePlots = True,
+    doProfilesVsLS = False,
+    doRecHitVsPhiVsEtaPerTrack = False,
+    #doGoodTrackRecHitVsPhiVsEtaPerTrack = False,
+
+    # which seed plots to do
+    doSeedNumberHisto= False,
+    doSeedVsClusterHisto = False,
+    doSeedPTHisto = False,
+    doSeedETAHisto = False,
+    doSeedPHIHisto = False,
+    doSeedPHIVsETAHisto = False,
+    doSeedThetaHisto = False,
+    doSeedQHisto = False,
+    doSeedDxyHisto = False,
+    doSeedDzHisto = False,
+    doSeedNRecHitsHisto = False,
+    doSeedNVsPhiProf = False,
+    doSeedNVsEtaProf = False,
+
+    # paramters of the Track
+    # ============================================================
+
+    # chi2
+    Chi2Bin = 250,
+    Chi2Max = 500.0,
+    Chi2Min = 0.0,
+    # chi2 dof
+    Chi2NDFBin = 200,
+    Chi2NDFMax = 19.5,
+    Chi2NDFMin = -0.5,
+    # chi^2 probability
+    Chi2ProbBin = 100,
+    Chi2ProbMax = 1.0,
+    Chi2ProbMin = 0.0,
+    # Number of Tracks per Event
+    TkSizeBin = 11,
+    TkSizeMax = 10.5,
+    TkSizeMin = -0.5,
+    # Number of seeds per Event
+    TkSeedSizeBin = 20,
+    TkSeedSizeMax = 19.5,
+    TkSeedSizeMin = -0.5,
+    # Number of Track Cadidates per Event
+    TCSizeBin = 150,
+    TCSizeMax = 149.5,
+    TCSizeMin = -0.5,
+    # num rec hits
+    TrackQBin = 8,
+    TrackQMax = 2.5,
+    TrackQMin = -2.5,
+    # num rec hits in seed
+    SeedHitBin = 6,
+    SeedHitMax = 5.5,
+    SeedHitMin = -0.5,
+    # num rec hits per track candidate
+    TCHitBin = 40,
+    TCHitMax = 39.5,
+    TCHitMin = -0.5,
+    # num rec hits
+    RecHitBin = 120,
+    RecHitMax = 120.0,
+    RecHitMin = 0.0,
+    # mean rec hits
+    MeanHitBin = 30,
+    MeanHitMax = 29.5,
+    MeanHitMin = -0.5,
+    # num TOB rec hits
+    TOBHitBin = cms.int32(15),
+    TOBHitMin = cms.double(-0.5),
+    TOBHitMax = cms.double(14.5),
+    # num TIB rec hits
+    TIBHitBin = cms.int32(15),
+    TIBHitMin = cms.double(-0.5),
+    TIBHitMax = cms.double(14.5),
+    # num TID rec hits
+    TIDHitBin = cms.int32(15),
+    TIDHitMin = cms.double(-0.5),
+    TIDHitMax = cms.double(14.5),
+    # num TEC rec hits
+    TECHitBin = cms.int32(25),
+    TECHitMin = cms.double(-0.5),
+    TECHitMax = cms.double(24.5),
+    # num PXB rec hits
+    PXBHitBin = cms.int32(10),
+    PXBHitMin = cms.double(-0.5),
+    PXBHitMax = cms.double(9.5),
+    # num PXF rec hits
+    PXFHitBin = cms.int32(10),
+    PXFHitMin = cms.double(-0.5),
+    PXFHitMax = cms.double(9.5),
+    # num rec hits lost
+    RecLostBin = 120,
+    RecLostMax = 20.,
+    RecLostMin = 0.0,
+    # num layers
+    RecLayBin = 120,
+    RecLayMax = 120.0,
+    RecLayMin = 0.0,
+    # mean layers
+    MeanLayBin = 20,
+    MeanLayMax = 19.5,
+    MeanLayMin = -0.5,
+    # num TOB layers
+    TOBLayBin = 10,
+    TOBLayMax = 9.5,
+    TOBLayMin = -0.5,
+    # num TIB layers
+    TIBLayBin = 6,
+    TIBLayMax = 5.5,
+    TIBLayMin = -0.5,
+    # num TID layers
+    TIDLayBin = 6,
+    TIDLayMax = 5.5,
+    TIDLayMin = -0.5,
+    # num TEC layers
+    TECLayBin = 15,
+    TECLayMax = 14.5,
+    TECLayMin = -0.5,
+    # num PXB layers
+    PXBLayBin = 6,
+    PXBLayMax = 5.5,
+    PXBLayMin = -0.5,
+    # num PXF layers
+    PXFLayBin = 6,
+    PXFLayMax = 5.5,
+    PXFLayMin = -0.5,
+    # Track |p|
+    TrackPBin = 1000,
+    TrackPMax = 1000.,
+    TrackPMin = 0.,
+    # Track pT
+    TrackPtBin = 1000,
+    TrackPtMax = 1000.,
+    TrackPtMin = 0.,
+    # Track px
+    TrackPxBin = 1000,
+    TrackPxMax = 500.0,
+    TrackPxMin = -500.0,
+    # Track py
+    TrackPyBin = 1000,
+    TrackPyMax = 500.0,
+    TrackPyMin = -500.0,
+    # Track pz
+    TrackPzMin = -500.0,
+    TrackPzMax = 500.0,
+    TrackPzBin = 1000,
+    # track theta
+    ThetaBin = 100,
+    ThetaMax = 3.2,
+    ThetaMin = 0.0,
+    # track eta
+    EtaBin = 100,
+    EtaMax = 3.0,
+    EtaMin = -3.0,
+    # track phi
+    PhiBin = 36,
+    PhiMax = 3.2,
+    PhiMin = -3.2,
+    # Track |p|	error
+    pErrBin = 100,
+    pErrMax = 10.0,
+    pErrMin = 0.0,
+    # Track pT error
+    ptErrBin = 100,
+    ptErrMax = 10.0,
+    ptErrMin = 0.0,
+    # Track px error
+    pxErrBin = 100,
+    pxErrMax = 10.0,
+    pxErrMin = 0.0,
+    # Track py error
+    pyErrBin = 100,
+    pyErrMax = 10.0,
+    pyErrMin = 0.0,
+    # Track pz error
+    pzErrBin = 100,
+    pzErrMax = 10.0,
+    pzErrMin = 0.0,
+    # track eta error
+    etaErrBin = 100,
+    etaErrMax = 0.5,
+    etaErrMin = 0.0,
+    # track phi Error
+    phiErrBin = 100,
+    phiErrMax = 1.0,
+    phiErrMin = 0.0,
+    # PCA x position
+    VXBin = 20,
+    VXMax = 20.0,
+    VXMin = -20.0,
+    # PCA y position
+    VYBin = 20,
+    VYMax = 20.0,
+    VYMin = -20.0,
+    # PCA z position
+    VZBin = 50,
+    VZMax = 100.0,
+    VZMin = -100.0,
+    # PCA x position for 2D plot
+    X0Bin = 100,
+    X0Max = 3.0,
+    X0Min = -3.0,
+    # PCA y position for 2D plot
+    Y0Bin = 100,
+    Y0Max = 3.0,
+    Y0Min = -3.0,
+    # PCA z position for 2D plot
+    Z0Bin = 60,
+    Z0Max = 30.0,
+    Z0Min = -30.0,
+    # Track dxy (transverse impact parameter)
+    DxyBin = 100,
+    DxyMax = 0.5,
+    DxyMin = -0.5,
+    # Seed dxy (transverse impact parameter)
+    SeedDxyBin = 100,
+    SeedDxyMax = 0.5,
+    SeedDxyMin = -0.5,
+    # Seed dz (longitudinal impact parameter)
+    SeedDzBin = 200,
+    SeedDzMax = 30.0,
+    SeedDzMin = -30.0,
+    # Track Candidate dxy (transverse impact parameter)
+    TCDxyBin = 200,
+    TCDxyMax = 100.0,
+    TCDxyMin = -100.0,
+    # Track Candidate dz (transverse impact parameter)
+    TCDzBin = 200,
+    TCDzMax = 400.0,
+    TCDzMin = -400.0,
+    # NCluster Pixel
+    NClusPxBin = 50,
+    NClusPxMax = 1999.5,
+    NClusPxMin = -0.5,
+    # NCluster Strip
+    NClusStrBin = 150,
+    NClusStrMax = 14999.5,
+    NClusStrMin = -0.5,
+    # NCluster 2D
+    NClus2DPxBin = cms.int32(20),
+    NClus2DPxMax = cms.double(1999.5),
+    NClus2DPxMin = cms.double(-0.5),
+    NClus2DStrBin = cms.int32(50),
+    NClus2DStrMax = cms.double(14999.5),
+    NClus2DStrMin = cms.double(-0.5),
+    # NCluster Vs Tracks
+    NClus2DTotBin = cms.int32(50),
+    NClus2DTotMax = cms.double(14999.5),
+    NClus2DTotMin = cms.double(-0.5),
+    NTrk2D = TrackMon.NTrk2D.clone(
+        NTrk2DBin = 20,
+        NTrk2DMax = 199.5,
+        NTrk2DMin = -0.5
+    ),
+    TTRHBuilder = 'WithTrackAngle',
+    # For plots vs LS
+    LSBin = 2000,
+    LSMin = 0.,
+    LSMax = 2000.,
+    # Luminosity based analysis
+    doLumiAnalysis = False
+)

--- a/DQM/TrackingMonitor/python/MonitorTrackTKCosmicMuons_cfi.py
+++ b/DQM/TrackingMonitor/python/MonitorTrackTKCosmicMuons_cfi.py
@@ -1,15 +1,15 @@
 import FWCore.ParameterSet.Config as cms
 
-import DQM.TrackingMonitor.TrackingMonitor_cfi
-MonitorTrackTKCosmicMuons = DQM.TrackingMonitor.TrackingMonitor_cfi.TrackMon.clone()
-MonitorTrackTKCosmicMuons.TrackProducer = 'ctfWithMaterialTracksP5'
-MonitorTrackTKCosmicMuons.AlgoName = 'ctf'
-MonitorTrackTKCosmicMuons.FolderName = 'Muons/TKTrack'
-MonitorTrackTKCosmicMuons.doBeamSpotPlots = False
-MonitorTrackTKCosmicMuons.BSFolderName = 'Muons/TKTrack/BeamSpotParameters'
-MonitorTrackTKCosmicMuons.doSeedParameterHistos = False
-MonitorTrackTKCosmicMuons.doAllPlots = False
-MonitorTrackTKCosmicMuons.doHitPropertiesPlots = True
-MonitorTrackTKCosmicMuons.doGeneralPropertiesPlots = True
-
+from DQM.TrackingMonitor.TrackingMonitor_cfi import *
+MonitorTrackTKCosmicMuons = TrackMon.clone(
+    TrackProducer = 'ctfWithMaterialTracksP5',
+    AlgoName = 'ctf',
+    FolderName = 'Muons/TKTrack',
+    doBeamSpotPlots = False,
+    BSFolderName = 'Muons/TKTrack/BeamSpotParameters',
+    doSeedParameterHistos = False,
+    doAllPlots = False,
+    doHitPropertiesPlots = True,
+    doGeneralPropertiesPlots = True
+)
 

--- a/DQM/TrackingMonitor/python/TrackFoldedOccupancyClient_cfi.py
+++ b/DQM/TrackingMonitor/python/TrackFoldedOccupancyClient_cfi.py
@@ -19,25 +19,25 @@ phase1Pixel.toModify(TrackerMapFoldedClient, EtaMin=-3., EtaMax=3.)
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(TrackerMapFoldedClient, EtaMin=-4.5, EtaMax=4.5)
 
-TrackerMapFoldedClient_highpurity_dzPV0p1=TrackerMapFoldedClient.clone(
-    TrackQuality=cms.string('highPurityTracks/dzPV0p1')
+TrackerMapFoldedClient_highpurity_dzPV0p1 = TrackerMapFoldedClient.clone(
+    TrackQuality = 'highPurityTracks/dzPV0p1'
 )
 
-TrackerMapFoldedClient_highpurity_pt0to1=TrackerMapFoldedClient.clone(
-    TrackQuality=cms.string('highPurityTracks/pt_0to1')
+TrackerMapFoldedClient_highpurity_pt0to1 = TrackerMapFoldedClient.clone(
+    TrackQuality = 'highPurityTracks/pt_0to1'
 )
 
-TrackerMapFoldedClient_highpurity_pt1=TrackerMapFoldedClient.clone(
-    TrackQuality=cms.string('highPurityTracks/pt_1')
+TrackerMapFoldedClient_highpurity_pt1 = TrackerMapFoldedClient.clone(
+    TrackQuality = 'highPurityTracks/pt_1'
 )
 
 foldedMapClientSeq=cms.Sequence(TrackerMapFoldedClient*TrackerMapFoldedClient_highpurity_dzPV0p1*TrackerMapFoldedClient_highpurity_pt0to1*TrackerMapFoldedClient_highpurity_pt1)
 
 #run3
-TrackerMapFoldedClient_hiConformalPixelTracks=TrackerMapFoldedClient.clone(
-    TrackQuality = cms.string('hiConformalPixelTracks')
+TrackerMapFoldedClient_hiConformalPixelTracks = TrackerMapFoldedClient.clone(
+    TrackQuality = 'hiConformalPixelTracks'
 )
 
-folded_with_conformalpixtkclient= cms.Sequence(TrackerMapFoldedClient_hiConformalPixelTracks+foldedMapClientSeq.copy())
+folded_with_conformalpixtkclient = cms.Sequence(TrackerMapFoldedClient_hiConformalPixelTracks+foldedMapClientSeq.copy())
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 pp_on_AA.toReplaceWith(foldedMapClientSeq, folded_with_conformalpixtkclient)

--- a/DQM/TrackingMonitor/python/TrackerCollisionTrackingMonitor_cfi.py
+++ b/DQM/TrackingMonitor/python/TrackerCollisionTrackingMonitor_cfi.py
@@ -1,88 +1,83 @@
 import FWCore.ParameterSet.Config as cms
 
-import DQM.TrackingMonitor.TrackingMonitor_cfi
-TrackerCollisionTrackMon = DQM.TrackingMonitor.TrackingMonitor_cfi.TrackMon.clone()
+from DQM.TrackingMonitor.TrackingMonitor_cfi import *
+TrackerCollisionTrackMon = TrackMon.clone(
+    # Update specific parameters
 
-# Update specific parameters
+    # input tags
+    TrackProducer = "generalTracks",
+    SeedProducer = "initialStepSeeds",
+    TCProducer = "initialStepTrackCandidates",
+    ClusterLabels = ('Tot','Strip','Pix',), # to decide which Seeds-Clusters correlation plots to have default is Total other options 'Strip', 'Pix'
+    beamSpot = "offlineBeamSpot",
+    primaryVertex = 'offlinePrimaryVertices',
+    primaryVertexInputTags = ('offlinePrimaryVertices',),    
+    selPrimaryVertexInputTags = ('goodOfflinePrimaryVertices',),
+    pvLabels = ('offline',),
 
-# input tags
-TrackerCollisionTrackMon.TrackProducer          = cms.InputTag("generalTracks")
-TrackerCollisionTrackMon.SeedProducer           = cms.InputTag("initialStepSeeds")
-TrackerCollisionTrackMon.TCProducer             = cms.InputTag("initialStepTrackCandidates")
-TrackerCollisionTrackMon.ClusterLabels          = cms.vstring('Tot','Strip','Pix') # to decide which Seeds-Clusters correlation plots to have default is Total other options 'Strip', 'Pix'
-TrackerCollisionTrackMon.beamSpot               = cms.InputTag("offlineBeamSpot")
-TrackerCollisionTrackMon.primaryVertex          = cms.InputTag('offlinePrimaryVertices')
-TrackerCollisionTrackMon.primaryVertexInputTags = cms.VInputTag(
-      cms.InputTag('offlinePrimaryVertices')
-)    
-TrackerCollisionTrackMon.selPrimaryVertexInputTags = cms.VInputTag(
-      cms.InputTag('goodOfflinePrimaryVertices')
-)    
-TrackerCollisionTrackMon.pvLabels               = cms.vstring(
-      'offline'
+    # output parameters
+    AlgoName = 'GenTk',
+    Quality = '',
+    FolderName = 'Tracking/GlobalParameters',
+    BSFolderName = 'Tracking/ParametersVsBeamSpot',
+
+    # determines where to evaluate track parameters
+    # 'ImpactPoint'  --> evalutate at impact point
+    MeasurementState = 'ImpactPoint',
+
+    # which plots to do
+    doAllPlots = False,
+    doGoodTrackPlots = cms.bool(True),
+    doTrackerSpecific = True,
+    doHitPropertiesPlots = True,
+    doGeneralPropertiesPlots = True,
+    doBeamSpotPlots = True,
+    doSeedParameterHistos = False,
+    doRecHitVsPhiVsEtaPerTrack = True,
+    doGoodTrackRecHitVsPhiVsEtaPerTrack = cms.bool(True),
+    doLayersVsPhiVsEtaPerTrack = True,
+    doGoodTrackLayersVsPhiVsEtaPerTrack = cms.bool(True),
+    doPUmonitoring = False,
+    doPlotsVsBXlumi = False,
+    doPlotsVsGoodPVtx = True,
+    doEffFromHitPatternVsPU = True,
+    doEffFromHitPatternVsBX = True,
+    doEffFromHitPatternVsLUMI = True,
+
+    # LS analysis
+    doLumiAnalysis = True,     
+    doProfilesVsLS = True,
+
+    doSeedNumberHisto = False,
+    doSeedETAHisto = False,
+    doSeedVsClusterHisto = False,
+
+    # Number of Tracks per Event
+    TkSizeBin = 600,
+    TkSizeMax = 2999.5,
+    TkSizeMin = -0.5,
+
+    # chi2 dof
+    Chi2NDFBin = 80,
+    Chi2NDFMax = 79.5,
+    Chi2NDFMin = -0.5,
+
+    # Number of seeds per Event
+    TkSeedSizeBin = 100,
+    TkSeedSizeMax = 499.5,
+    TkSeedSizeMin = -0.5,
+
+    # Number of Track Cadidates per Event
+    TCSizeBin = 100,
+    TCSizeMax = 499.5,
+    TCSizeMin = -0.5,
+
+    GoodPVtx = TrackMon.GoodPVtx.clone(
+        GoodPVtxBin = 60,
+        GoodPVtxMin = 0.,
+        GoodPVtxMax = 60.
+    )
 )
-
-# output parameters
-TrackerCollisionTrackMon.AlgoName              = cms.string('GenTk')
-TrackerCollisionTrackMon.Quality               = cms.string('')
-TrackerCollisionTrackMon.FolderName            = cms.string('Tracking/GlobalParameters')
-TrackerCollisionTrackMon.BSFolderName          = cms.string('Tracking/ParametersVsBeamSpot')
-
-# determines where to evaluate track parameters
-# 'ImpactPoint'  --> evalutate at impact point 
-TrackerCollisionTrackMon.MeasurementState      = cms.string('ImpactPoint')
-
-# which plots to do
-TrackerCollisionTrackMon.doAllPlots                          = cms.bool(False)
-TrackerCollisionTrackMon.doGoodTrackPlots                    = cms.bool(True)
-TrackerCollisionTrackMon.doTrackerSpecific                   = cms.bool(True)
-TrackerCollisionTrackMon.doHitPropertiesPlots                = cms.bool(True)
-TrackerCollisionTrackMon.doGeneralPropertiesPlots            = cms.bool(True)
-TrackerCollisionTrackMon.doBeamSpotPlots                     = cms.bool(True)
-TrackerCollisionTrackMon.doSeedParameterHistos               = cms.bool(False)
-TrackerCollisionTrackMon.doRecHitVsPhiVsEtaPerTrack          = cms.bool(True)
-TrackerCollisionTrackMon.doGoodTrackRecHitVsPhiVsEtaPerTrack = cms.bool(True)
-TrackerCollisionTrackMon.doLayersVsPhiVsEtaPerTrack          = cms.bool(True)
-TrackerCollisionTrackMon.doGoodTrackLayersVsPhiVsEtaPerTrack = cms.bool(True)
-TrackerCollisionTrackMon.doPUmonitoring                      = cms.bool(False)
-TrackerCollisionTrackMon.doPlotsVsBXlumi                     = cms.bool(False)
-TrackerCollisionTrackMon.doPlotsVsGoodPVtx                   = cms.bool(True)
-TrackerCollisionTrackMon.doEffFromHitPatternVsPU             = cms.bool(True)
-TrackerCollisionTrackMon.doEffFromHitPatternVsBX             = cms.bool(True)
-TrackerCollisionTrackMon.doEffFromHitPatternVsLUMI           = cms.bool(True)
-
-# LS analysis
-TrackerCollisionTrackMon.doLumiAnalysis       = cms.bool(True)     
-TrackerCollisionTrackMon.doProfilesVsLS       = cms.bool(True)
-
-TrackerCollisionTrackMon.doSeedNumberHisto    = cms.bool(False)
-TrackerCollisionTrackMon.doSeedETAHisto       = cms.bool(False)
-TrackerCollisionTrackMon.doSeedVsClusterHisto = cms.bool(False)
-
-# Number of Tracks per Event
-TrackerCollisionTrackMon.TkSizeBin             = cms.int32(600)
-TrackerCollisionTrackMon.TkSizeMax             = cms.double(2999.5)                        
-TrackerCollisionTrackMon.TkSizeMin             = cms.double(-0.5)
-
-# chi2 dof
-TrackerCollisionTrackMon.Chi2NDFBin            = cms.int32(80)
-TrackerCollisionTrackMon.Chi2NDFMax            = cms.double(79.5)
-TrackerCollisionTrackMon.Chi2NDFMin            = cms.double(-0.5)
-
-# Number of seeds per Event
-TrackerCollisionTrackMon.TkSeedSizeBin = cms.int32(100)
-TrackerCollisionTrackMon.TkSeedSizeMax = cms.double(499.5)                        
-TrackerCollisionTrackMon.TkSeedSizeMin = cms.double(-0.5)
-
-# Number of Track Cadidates per Event
-TrackerCollisionTrackMon.TCSizeBin = cms.int32(100)
-TrackerCollisionTrackMon.TCSizeMax = cms.double(499.5)
-TrackerCollisionTrackMon.TCSizeMin = cms.double(-0.5)
-
-TrackerCollisionTrackMon.GoodPVtx.GoodPVtxBin = cms.int32(60)
-TrackerCollisionTrackMon.GoodPVtx.GoodPVtxMin = cms.double( 0.)
-TrackerCollisionTrackMon.GoodPVtx.GoodPVtxMax = cms.double(60.)
-
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify(TrackerCollisionTrackMon, GoodPVtx=dict(GoodPVtxBin = 150, GoodPVtxMax = 150.))

--- a/DQM/TrackingMonitor/python/TrackerCosmicsTrackingMonitor_cfi.py
+++ b/DQM/TrackingMonitor/python/TrackerCosmicsTrackingMonitor_cfi.py
@@ -1,42 +1,42 @@
 import FWCore.ParameterSet.Config as cms
 
-import DQM.TrackingMonitor.TrackingMonitor_cfi
-TrackerCosmicTrackMon = DQM.TrackingMonitor.TrackingMonitor_cfi.TrackMon.clone()
+from DQM.TrackingMonitor.TrackingMonitor_cfi import *
+TrackerCosmicTrackMon = TrackMon.clone(
+    # Update specific parameters
+    SeedProducer = "combinedP5SeedsForCTF",
+    TCProducer = "ckfTrackCandidatesP5",
+    beamSpot = "offlineBeamSpot",     
 
-# Update specific parameters
-TrackerCosmicTrackMon.SeedProducer          = cms.InputTag("combinedP5SeedsForCTF")
-TrackerCosmicTrackMon.TCProducer            = cms.InputTag("ckfTrackCandidatesP5")
-TrackerCosmicTrackMon.beamSpot              = cms.InputTag("offlineBeamSpot")              
+    MeasurementState = 'default',
 
-TrackerCosmicTrackMon.MeasurementState      = cms.string('default')
+    doAllPlots = False,
+    doHitPropertiesPlots = True,
+    doGeneralPropertiesPlots = True,
+    doBeamSpotPlots = False,
+    doSeedParameterHistos = False,
 
-TrackerCosmicTrackMon.doAllPlots            = cms.bool(False)
-TrackerCosmicTrackMon.doHitPropertiesPlots     = cms.bool(True)
-TrackerCosmicTrackMon.doGeneralPropertiesPlots = cms.bool(True)
-TrackerCosmicTrackMon.doBeamSpotPlots       = cms.bool(False)
-TrackerCosmicTrackMon.doSeedParameterHistos = cms.bool(False)
+    Chi2Max = 500.0,
 
-TrackerCosmicTrackMon.Chi2Max               = cms.double(500.0)
+    TkSizeBin = 25,
+    TkSizeMax = 24.5,
 
-TrackerCosmicTrackMon.TkSizeBin             = cms.int32(25)
-TrackerCosmicTrackMon.TkSizeMax             = cms.double(24.5)
+    TkSeedSizeBin = 20,
+    TkSeedSizeMax = 19.5,
 
-TrackerCosmicTrackMon.TkSeedSizeBin         = cms.int32(20)
-TrackerCosmicTrackMon.TkSeedSizeMax         = cms.double(19.5)
+    RecLayBin = 35,
+    RecLayMax = 34.5,
 
-TrackerCosmicTrackMon.RecLayBin             = cms.int32(35)
-TrackerCosmicTrackMon.RecLayMax             = cms.double(34.5)
+    TrackPtMax = 30.0,
+    TrackPtMin = -0.5,
 
-TrackerCosmicTrackMon.TrackPtMax            = cms.double(30.0)
-TrackerCosmicTrackMon.TrackPtMin            = cms.double(-0.5)
+    TrackPxMax = 50.0,
+    TrackPxMin = -50.0,
 
-TrackerCosmicTrackMon.TrackPxMax            = cms.double(50.0)
-TrackerCosmicTrackMon.TrackPxMin            = cms.double(-50.0)
+    TrackPyMax = 50.0,
+    TrackPyMin = -50.0,
 
-TrackerCosmicTrackMon.TrackPyMax            = cms.double(50.0)
-TrackerCosmicTrackMon.TrackPyMin            = cms.double(-50.0)
+    TrackPzMax = 50.0,
+    TrackPzMin = -50.0,
 
-TrackerCosmicTrackMon.TrackPzMax            = cms.double(50.0)
-TrackerCosmicTrackMon.TrackPzMin            = cms.double(-50.0)
-
-TrackerCosmicTrackMon.doLumiAnalysis        = cms.bool(False)                       
+    doLumiAnalysis = False
+)

--- a/DQM/TrackingMonitor/python/TrackerHeavyIonTrackingMonitor_cfi.py
+++ b/DQM/TrackingMonitor/python/TrackerHeavyIonTrackingMonitor_cfi.py
@@ -1,41 +1,37 @@
 import FWCore.ParameterSet.Config as cms
 
-import DQM.TrackingMonitor.TrackingMonitor_cfi
-TrackerHeavyIonTrackMon = DQM.TrackingMonitor.TrackingMonitor_cfi.TrackMon.clone()
+from DQM.TrackingMonitor.TrackingMonitor_cfi import *
+TrackerHeavyIonTrackMon = TrackMon.clone(
+    # Update specific parameters
+    TrackProducer = "hiGeneralTracks",
+    SeedProducer = "hiPixelTrackSeeds",
+    TCProducer = "hiPrimTrackCandidates",
+    beamSpot = "offlineBeamSpot",
+    primaryVertex = 'hiSelectedVertex',
 
-# Update specific parameters
+    doHIPlots = True,
 
-TrackerHeavyIonTrackMon.TrackProducer         = cms.InputTag("hiGeneralTracks")
-TrackerHeavyIonTrackMon.SeedProducer          = cms.InputTag("hiPixelTrackSeeds")
-TrackerHeavyIonTrackMon.TCProducer            = cms.InputTag("hiPrimTrackCandidates")
-TrackerHeavyIonTrackMon.beamSpot              = cms.InputTag("offlineBeamSpot")
-TrackerHeavyIonTrackMon.primaryVertex         = cms.InputTag('hiSelectedVertex')
+    AlgoName = 'HeavyIonTk',
+    Quality = '',
+    FolderName = 'Tracking/GlobalParameters',
+    BSFolderName = 'Tracking/BeamSpotParameters',
 
+    MeasurementState = 'ImpactPoint',
 
-TrackerHeavyIonTrackMon.doHIPlots             = cms.bool(True)
+    doTrackerSpecific = True,
+    doAllPlots = True,
+    doBeamSpotPlots = True,
+    doSeedParameterHistos = True,
 
+    doLumiAnalysis = True,                       
 
-TrackerHeavyIonTrackMon.AlgoName              = cms.string('HeavyIonTk')
-TrackerHeavyIonTrackMon.Quality               = cms.string('')
-TrackerHeavyIonTrackMon.FolderName            = cms.string('Tracking/GlobalParameters')
-TrackerHeavyIonTrackMon.BSFolderName          = cms.string('Tracking/BeamSpotParameters')
+    # Number of Tracks per Event
+    TkSizeBin = 600,
+    TkSizeMax = 1799.5,                        
+    TkSizeMin = -0.5,
 
-TrackerHeavyIonTrackMon.MeasurementState      = cms.string('ImpactPoint')
-
-TrackerHeavyIonTrackMon.doTrackerSpecific     = cms.bool(True)
-TrackerHeavyIonTrackMon.doAllPlots            = cms.bool(True)
-TrackerHeavyIonTrackMon.doBeamSpotPlots       = cms.bool(True)
-TrackerHeavyIonTrackMon.doSeedParameterHistos = cms.bool(True)
-
-TrackerHeavyIonTrackMon.doLumiAnalysis        = cms.bool(True)                       
-
-# Number of Tracks per Event
-TrackerHeavyIonTrackMon.TkSizeBin             = cms.int32(600)
-TrackerHeavyIonTrackMon.TkSizeMax             = cms.double(1799.5)                        
-TrackerHeavyIonTrackMon.TkSizeMin             = cms.double(-0.5)
-
-# chi2 dof
-TrackerHeavyIonTrackMon.Chi2NDFBin            = cms.int32(160)
-TrackerHeavyIonTrackMon.Chi2NDFMax            = cms.double(79.5)
-TrackerHeavyIonTrackMon.Chi2NDFMin            = cms.double(-0.5)
-                
+    # chi2 dof
+    Chi2NDFBin = 160,
+    Chi2NDFMax = 79.5,
+    Chi2NDFMin = -0.5
+)

--- a/DQM/TrackingMonitor/python/TrackingMonitorAllTrackingSequences_cff.py
+++ b/DQM/TrackingMonitor/python/TrackingMonitorAllTrackingSequences_cff.py
@@ -18,88 +18,84 @@ TrackMon.doSeedParameterHistos  = cms.bool(False)
 # ---------------------------------------------------------------------------#
 
 # generalTracks
-TrackMonGenTk = TrackMon.clone()
-TrackMonGenTk.TrackProducer         = cms.InputTag("generalTracks")
-TrackMonGenTk.beamSpot              = cms.InputTag("offlineBeamSpot")
-TrackMonGenTk.FolderName            = cms.string('Tracking/GenTk/GlobalParameters')
-TrackMonGenTk.BSFolderName          = cms.string('Tracking/GenTk/BeamSpotParameters')
-TrackMonGenTk.AlgoName              = cms.string('GenTk')
-TrackMonGenTk.doSeedParameterHistos = cms.bool(False)
+TrackMonGenTk = TrackMon.clone(
+    TrackProducer = "generalTracks",
+    beamSpot = "offlineBeamSpot",
+    FolderName = 'Tracking/GenTk/GlobalParameters',
+    BSFolderName = 'Tracking/GenTk/BeamSpotParameters',
+    AlgoName = 'GenTk',
+    doSeedParameterHistos = False
+)
 
 
 
 # Step0 
-TrackMonStep0 = TrackMon.clone()
-TrackMonStep0.TrackProducer = cms.InputTag("zeroStepTracksWithQuality")
-TrackMonStep0.SeedProducer  = cms.InputTag("initialStepSeeds")
-TrackMonStep0.TCProducer    = cms.InputTag("initialStepTrackCandidates")
-TrackMonStep0.beamSpot      = cms.InputTag("offlineBeamSpot")
-TrackMonStep0.FolderName    = cms.string('Tracking/Step0/GlobalParameters')
-TrackMonStep0.BSFolderName  = cms.string('Tracking/Step0/BeamSpotParameters')
-TrackMonStep0.AlgoName      = cms.string('Step0')
-TrackMonStep0.doSeedParameterHistos = cms.bool(True)
-TrackMonStep0.doTrackCandHistos = cms.bool(True)
+TrackMonStep0 = TrackMon.clone(
+    TrackProducer = "zeroStepTracksWithQuality",
+    SeedProducer = "initialStepSeeds",
+    TCProducer = "initialStepTrackCandidates",
+    beamSpot = "offlineBeamSpot",
+    FolderName = 'Tracking/Step0/GlobalParameters',
+    BSFolderName = 'Tracking/Step0/BeamSpotParameters',
+    AlgoName = 'Step0',
+    doSeedParameterHistos = True,
+    doTrackCandHistos = True
+)
 
 # Step1 
-TrackMonStep1 = TrackMon.clone()
-TrackMonStep1.TrackProducer = cms.InputTag("preMergingFirstStepTracksWithQuality")
-TrackMonStep1.SeedProducer  = cms.InputTag("newSeedFromPairs")
-TrackMonStep1.TCProducer    = cms.InputTag("stepOneTrackCandidateMaker")
-TrackMonStep1.beamSpot      = cms.InputTag("offlineBeamSpot")
-TrackMonStep1.FolderName    = cms.string('Tracking/Step1/GlobalParameters')
-TrackMonStep1.BSFolderName  = cms.string('Tracking/Step1/BeamSpotParameters')
-TrackMonStep1.AlgoName      = cms.string('Step1')
-TrackMonStep1.doSeedParameterHistos = cms.bool(True)
-TrackMonStep1.doTrackCandHistos = cms.bool(True)
+TrackMonStep1 = TrackMon.clone(
+    TrackProducer = "preMergingFirstStepTracksWithQuality",
+    SeedProducer = "newSeedFromPairs",
+    TCProducer = "stepOneTrackCandidateMaker",
+    beamSpot = "offlineBeamSpot",
+    FolderName = 'Tracking/Step1/GlobalParameters',
+    BSFolderName = 'Tracking/Step1/BeamSpotParameters',
+    AlgoName = 'Step1',
+    doSeedParameterHistos = True,
+    doTrackCandHistos = True
+)
 
 # Step2 
-TrackMonStep2 = TrackMon.clone()
-TrackMonStep2.TrackProducer = cms.InputTag("secStep")
-TrackMonStep2.SeedProducer  = cms.InputTag("secTriplets")
-TrackMonStep2.TCProducer    = cms.InputTag("secTrackCandidates")
-TrackMonStep2.beamSpot      = cms.InputTag("offlineBeamSpot")
-TrackMonStep2.FolderName    = cms.string('Tracking/Step2/GlobalParameters')
-TrackMonStep2.BSFolderName  = cms.string('Tracking/Step2/BeamSpotParameters')
-TrackMonStep2.AlgoName      = cms.string('Step2')
-TrackMonStep2.doSeedParameterHistos = cms.bool(True)
-TrackMonStep2.doTrackCandHistos = cms.bool(True)
+TrackMonStep2 = TrackMon.clone(
+    TrackProducer = "secStep",
+    SeedProducer = "secTriplets",
+    TCProducer = "secTrackCandidates",
+    beamSpot = "offlineBeamSpot",
+    FolderName = 'Tracking/Step2/GlobalParameters',
+    BSFolderName = 'Tracking/Step2/BeamSpotParameters',
+    AlgoName = 'Step2',
+    doSeedParameterHistos = True,
+    doTrackCandHistos = True
+)
 
 # Step4 
-TrackMonStep4 = TrackMon.clone()
-TrackMonStep4.TrackProducer = cms.InputTag("pixellessStep")
-TrackMonStep4.SeedProducer  = cms.InputTag("fourthPLSeeds")
-TrackMonStep4.TCProducer    = cms.InputTag("fourthTrackCandidates")
-TrackMonStep4.beamSpot      = cms.InputTag("offlineBeamSpot")
-TrackMonStep4.FolderName    = cms.string('Tracking/Step4/GlobalParameters')
-TrackMonStep4.BSFolderName  = cms.string('Tracking/Step4/BeamSpotParameters')
-TrackMonStep4.AlgoName      = cms.string('Step4')
-TrackMonStep4.doSeedParameterHistos = cms.bool(True)
-TrackMonStep4.doTrackCandHistos = cms.bool(True)
+TrackMonStep4 = TrackMon.clone(
+    TrackProducer = "pixellessStep",
+    SeedProducer = "fourthPLSeeds",
+    TCProducer = "fourthTrackCandidates",
+    beamSpot = "offlineBeamSpot",
+    FolderName = 'Tracking/Step4/GlobalParameters',
+    BSFolderName = 'Tracking/Step4/BeamSpotParameters',
+    AlgoName = 'Step4',
+    doSeedParameterHistos = True,
+    doTrackCandHistos = True
+)
 
 # Step4 
-TrackMonStep5 = TrackMon.clone()
-TrackMonStep5.TrackProducer = cms.InputTag("tobtecStep")
-TrackMonStep5.SeedProducer  = cms.InputTag("fifthSeeds")
-TrackMonStep5.TCProducer    = cms.InputTag("fifthTrackCandidates")
-TrackMonStep5.beamSpot      = cms.InputTag("offlineBeamSpot")
-TrackMonStep5.FolderName    = cms.string('Tracking/Step5/GlobalParameters')
-TrackMonStep5.BSFolderName  = cms.string('Tracking/Step5/BeamSpotParameters')
-TrackMonStep5.AlgoName      = cms.string('Step5')
-TrackMonStep5.doSeedParameterHistos = cms.bool(True)
-TrackMonStep5.doTrackCandHistos = cms.bool(True)
+TrackMonStep5 = TrackMon.clone(
+    TrackProducer = "tobtecStep",
+    SeedProducer = "fifthSeeds",
+    TCProducer = "fifthTrackCandidates",
+    beamSpot = "offlineBeamSpot",
+    FolderName = 'Tracking/Step5/GlobalParameters',
+    BSFolderName = 'Tracking/Step5/BeamSpotParameters',
+    AlgoName = 'Step5',
+    doSeedParameterHistos = True,
+    doTrackCandHistos = True
+)
 
 # high Purity 
 # ---------------------------------------------------------------------------#
-
-
-
-
-
-
-
-
-
-
 
 
 

--- a/DQM/TrackingMonitor/python/TrackingMonitorSeedNumber_cff.py
+++ b/DQM/TrackingMonitor/python/TrackingMonitorSeedNumber_cff.py
@@ -3,120 +3,129 @@ import FWCore.ParameterSet.Config as cms
 #-------------------------------------------------
 # Tracking Monitor 
 #-------------------------------------------------
-import DQM.TrackingMonitor.TrackingMonitorSeed_cfi
+from DQM.TrackingMonitor.TrackingMonitorSeed_cfi import *
 
-TrackMonStep0 = DQM.TrackingMonitor.TrackingMonitorSeed_cfi.TrackMonSeed.clone()
-TrackMonStep0.TrackProducer = cms.InputTag("generalTracks")
-TrackMonStep0.SeedProducer  = cms.InputTag("initialStepSeeds")
-TrackMonStep0.TCProducer    = cms.InputTag("initialStepTrackCandidates")
-TrackMonStep0.AlgoName      = cms.string('initialStep')
-TrackMonStep0.TkSeedSizeBin = cms.int32(100) # could be 50 ?
-TrackMonStep0.TkSeedSizeMax = cms.double(5000)                         
-TrackMonStep0.TkSeedSizeMin = cms.double(0)
-TrackMonStep0.NClusPxBin    = cms.int32(100)
-TrackMonStep0.NClusPxMax    = cms.double(20000)
-TrackMonStep0.ClusterLabels = cms.vstring('Pix')
+TrackMonStep0 = TrackMonSeed.clone(
+    TrackProducer = "generalTracks",
+    SeedProducer = "initialStepSeeds",
+    TCProducer = "initialStepTrackCandidates",
+    AlgoName = 'initialStep',
+    TkSeedSizeBin = 100, # could be 50 ?
+    TkSeedSizeMax = 5000.,
+    TkSeedSizeMin = 0.,
+    NClusPxBin = 100,
+    NClusPxMax = 20000.,
+    ClusterLabels = ('Pix',)
+)
 
-TrackMonStep1 = DQM.TrackingMonitor.TrackingMonitorSeed_cfi.TrackMonSeed.clone()
-TrackMonStep1.TrackProducer = cms.InputTag("generalTracks")
-TrackMonStep1.SeedProducer  = cms.InputTag("lowPtTripletStepSeeds")
-TrackMonStep1.TCProducer    = cms.InputTag("lowPtTripletStepTrackCandidates")
-TrackMonStep1.AlgoName      = cms.string('lowPtTripletStep')
-TrackMonStep1.TkSeedSizeBin = cms.int32(100)
-TrackMonStep1.TkSeedSizeMax = cms.double(30000)                         
-TrackMonStep1.TkSeedSizeMin = cms.double(0)
-TrackMonStep1.NClusPxBin    = cms.int32(100)
-TrackMonStep1.NClusPxMax    = cms.double(20000)
-TrackMonStep1.ClusterLabels = cms.vstring('Pix')
+TrackMonStep1 = TrackMonSeed.clone(
+    TrackProducer = "generalTracks",
+    SeedProducer = "lowPtTripletStepSeeds",
+    TCProducer = "lowPtTripletStepTrackCandidates",
+    AlgoName = 'lowPtTripletStep',
+    TkSeedSizeBin = 100,
+    TkSeedSizeMax = 30000.,                         
+    TkSeedSizeMin = 0.,
+    NClusPxBin = 100,
+    NClusPxMax = 20000.,
+    ClusterLabels = ('Pix',)
+)
 
-TrackMonStep2 = DQM.TrackingMonitor.TrackingMonitorSeed_cfi.TrackMonSeed.clone()
-TrackMonStep2.TrackProducer = cms.InputTag("generalTracks")
-TrackMonStep2.SeedProducer  = cms.InputTag("pixelPairStepSeeds")
-TrackMonStep2.TCProducer    = cms.InputTag("pixelPairStepTrackCandidates")
-TrackMonStep2.AlgoName      = cms.string('pixelPairStep')
-TrackMonStep2.TkSeedSizeBin = cms.int32(400)
-TrackMonStep2.TkSeedSizeMax = cms.double(100000)                         
-TrackMonStep2.TkSeedSizeMin = cms.double(0)
-TrackMonStep2.TCSizeMax     = cms.double(199.5)
-TrackMonStep2.NClusPxBin    = cms.int32(100)
-TrackMonStep2.NClusPxMax    = cms.double(20000)
-TrackMonStep2.ClusterLabels = cms.vstring('Pix')
+TrackMonStep2 = TrackMonSeed.clone(
+    TrackProducer = "generalTracks",
+    SeedProducer = "pixelPairStepSeeds",
+    TCProducer = "pixelPairStepTrackCandidates",
+    AlgoName = 'pixelPairStep',
+    TkSeedSizeBin = 400,
+    TkSeedSizeMax = 100000.,                         
+    TkSeedSizeMin = 0.,
+    TCSizeMax = 199.5,
+    NClusPxBin = 100,
+    NClusPxMax = 20000.,
+    ClusterLabels = ('Pix',)
+)
 
-TrackMonStep3 = DQM.TrackingMonitor.TrackingMonitorSeed_cfi.TrackMonSeed.clone()
-TrackMonStep3.TrackProducer = cms.InputTag("generalTracks")
-TrackMonStep3.SeedProducer  = cms.InputTag("detachedTripletStepSeeds")
-TrackMonStep3.TCProducer    = cms.InputTag("detachedTripletStepTrackCandidates")
-TrackMonStep3.AlgoName      = cms.string('detachedTripletStep')
-TrackMonStep3.TkSeedSizeBin = cms.int32(100)
-TrackMonStep3.TkSeedSizeMax = cms.double(30000)                         
-TrackMonStep3.TkSeedSizeMin = cms.double(0)
-TrackMonStep3.NClusPxBin    = cms.int32(100)
-TrackMonStep3.NClusPxMax    = cms.double(20000)
-TrackMonStep3.ClusterLabels = cms.vstring('Pix')
+TrackMonStep3 = TrackMonSeed.clone(
+    TrackProducer = "generalTracks",
+    SeedProducer = "detachedTripletStepSeeds",
+    TCProducer = "detachedTripletStepTrackCandidates",
+    AlgoName = 'detachedTripletStep',
+    TkSeedSizeBin = 100,
+    TkSeedSizeMax = 30000.,                         
+    TkSeedSizeMin = 0.,
+    NClusPxBin = 100,
+    NClusPxMax = 20000.,
+    ClusterLabels = ('Pix',)
+)
 
-TrackMonStep4 = DQM.TrackingMonitor.TrackingMonitorSeed_cfi.TrackMonSeed.clone()
-TrackMonStep4.TrackProducer = cms.InputTag("generalTracks")
-TrackMonStep4.SeedProducer  = cms.InputTag("mixedTripletStepSeeds")
-TrackMonStep4.TCProducer    = cms.InputTag("mixedTripletStepTrackCandidates")
-TrackMonStep4.AlgoName      = cms.string('mixedTripletStep')
-TrackMonStep4.TkSeedSizeBin = cms.int32(400)
-TrackMonStep4.TkSeedSizeMax = cms.double(200000)                         
-TrackMonStep4.TkSeedSizeMin = cms.double(0)
-TrackMonStep4.TCSizeMax     = cms.double(199.5)
-TrackMonStep4.NClusStrBin   = cms.int32(500)
-TrackMonStep4.NClusStrMax   = cms.double(100000)
-TrackMonStep4.ClusterLabels = cms.vstring('Tot')
+TrackMonStep4 = TrackMonSeed.clone(
+    TrackProducer = "generalTracks",
+    SeedProducer = "mixedTripletStepSeeds",
+    TCProducer = "mixedTripletStepTrackCandidates",
+    AlgoName = 'mixedTripletStep',
+    TkSeedSizeBin = 400,
+    TkSeedSizeMax = 200000.,                         
+    TkSeedSizeMin = 0.,
+    TCSizeMax = 199.5,
+    NClusStrBin = 500,
+    NClusStrMax = 100000.,
+    ClusterLabels = ('Tot',)
+)
 
-TrackMonStep5 = DQM.TrackingMonitor.TrackingMonitorSeed_cfi.TrackMonSeed.clone()
-TrackMonStep5.TrackProducer = cms.InputTag("generalTracks")
-TrackMonStep5.SeedProducer  = cms.InputTag("pixelLessStepSeeds")
-TrackMonStep5.TCProducer    = cms.InputTag("pixelLessStepTrackCandidates")
-TrackMonStep5.AlgoName      = cms.string('pixelLessStep')
-TrackMonStep5.TkSeedSizeBin = cms.int32(400)
-TrackMonStep5.TkSeedSizeMax = cms.double(200000)                         
-TrackMonStep5.TkSeedSizeMin = cms.double(0)
-TrackMonStep5.NClusStrBin   = cms.int32(500)
-TrackMonStep5.NClusStrMax   = cms.double(100000)
-TrackMonStep5.ClusterLabels = cms.vstring('Strip')
+TrackMonStep5 = TrackMonSeed.clone(
+    TrackProducer = "generalTracks",
+    SeedProducer = "pixelLessStepSeeds",
+    TCProducer = "pixelLessStepTrackCandidates",
+    AlgoName = 'pixelLessStep',
+    TkSeedSizeBin = 400,
+    TkSeedSizeMax = 200000.,
+    TkSeedSizeMin = 0.,
+    NClusStrBin = 500,
+    NClusStrMax = 100000.,
+    ClusterLabels = ('Strip',)
+)
 
-TrackMonStep6 = DQM.TrackingMonitor.TrackingMonitorSeed_cfi.TrackMonSeed.clone()
-TrackMonStep6.TrackProducer = cms.InputTag("generalTracks")
-TrackMonStep6.SeedProducer  = cms.InputTag("tobTecStepSeeds")
-TrackMonStep6.TCProducer    = cms.InputTag("tobTecStepTrackCandidates")
-TrackMonStep6.AlgoName      = cms.string('tobTecStep')
-TrackMonStep6.TkSeedSizeBin = cms.int32(400)
-TrackMonStep6.TkSeedSizeMax = cms.double(100000)                         
-TrackMonStep6.TkSeedSizeMin = cms.double(0)
-TrackMonStep6.TCSizeMax     = cms.double(199.5)
-TrackMonStep6.NClusStrBin   = cms.int32(500)
-TrackMonStep6.NClusStrMax   = cms.double(100000)
-TrackMonStep6.ClusterLabels = cms.vstring('Strip')
+TrackMonStep6 = TrackMonSeed.clone(
+    TrackProducer = "generalTracks",
+    SeedProducer = "tobTecStepSeeds",
+    TCProducer = "tobTecStepTrackCandidates",
+    AlgoName = 'tobTecStep',
+    TkSeedSizeBin = 400,
+    TkSeedSizeMax = 100000.,                         
+    TkSeedSizeMin = 0.,
+    TCSizeMax = 199.5,
+    NClusStrBin = 500,
+    NClusStrMax = 100000.,
+    ClusterLabels = ('Strip',)
+)
 
-TrackMonStep9 = DQM.TrackingMonitor.TrackingMonitorSeed_cfi.TrackMonSeed.clone()
-TrackMonStep9.TrackProducer = cms.InputTag("generalTracks")
-TrackMonStep9.SeedProducer  = cms.InputTag("muonSeededSeedsInOut")
-TrackMonStep9.TCProducer    = cms.InputTag("muonSeededTrackCandidatesInOut")
-TrackMonStep9.AlgoName      = cms.string('muonSeededStepInOut')
-TrackMonStep9.TkSeedSizeBin = cms.int32(15)
-TrackMonStep9.TkSeedSizeMax = cms.double(14.5)                         
-TrackMonStep9.TkSeedSizeMin = cms.double(-0.5)
-TrackMonStep9.TCSizeMax     = cms.double(199.5)
-TrackMonStep9.NClusStrBin   = cms.int32(500)
-TrackMonStep9.NClusStrMax   = cms.double(100000)
-TrackMonStep9.ClusterLabels = cms.vstring('Strip')
+TrackMonStep9 = TrackMonSeed.clone(
+    TrackProducer = "generalTracks",
+    SeedProducer = "muonSeededSeedsInOut",
+    TCProducer = "muonSeededTrackCandidatesInOut",
+    AlgoName = 'muonSeededStepInOut',
+    TkSeedSizeBin = 15,
+    TkSeedSizeMax = 14.5,                         
+    TkSeedSizeMin = -0.5,
+    TCSizeMax = 199.5,
+    NClusStrBin = 500,
+    NClusStrMax = 100000.,
+    ClusterLabels = ('Strip',)
+)
 
-TrackMonStep10 = DQM.TrackingMonitor.TrackingMonitorSeed_cfi.TrackMonSeed.clone()
-TrackMonStep10.TrackProducer = cms.InputTag("generalTracks")
-TrackMonStep10.SeedProducer  = cms.InputTag("muonSeededSeedsOutIn")
-TrackMonStep10.TCProducer    = cms.InputTag("muonSeededTrackCandidatesOutIn")
-TrackMonStep10.AlgoName      = cms.string('muonSeededStepOutIn')
-TrackMonStep10.TkSeedSizeBin = cms.int32(15)
-TrackMonStep10.TkSeedSizeMax = cms.double(14.5)                         
-TrackMonStep10.TkSeedSizeMin = cms.double(-0.5)
-TrackMonStep10.TCSizeMax     = cms.double(199.5)
-TrackMonStep10.NClusStrBin   = cms.int32(500)
-TrackMonStep10.NClusStrMax   = cms.double(100000)
-TrackMonStep10.ClusterLabels = cms.vstring('Strip')
+TrackMonStep10 = TrackMonSeed.clone(
+    TrackProducer = "generalTracks",
+    SeedProducer = "muonSeededSeedsOutIn",
+    TCProducer = "muonSeededTrackCandidatesOutIn",
+    AlgoName = 'muonSeededStepOutIn',
+    TkSeedSizeBin = 15,
+    TkSeedSizeMax = 14.5,                         
+    TkSeedSizeMin = -0.5,
+    TCSizeMax = 199.5,
+    NClusStrBin = 500,
+    NClusStrMax = 100000.,
+    ClusterLabels = ('Strip',)
+)
 
 # out of the box
 trackMonIterativeTracking2012 = cms.Sequence(

--- a/DQM/TrackingMonitor/python/TrackingMonitorSeed_cfi.py
+++ b/DQM/TrackingMonitor/python/TrackingMonitorSeed_cfi.py
@@ -1,33 +1,33 @@
 import FWCore.ParameterSet.Config as cms
 
-import DQM.TrackingMonitor.TrackingMonitor_cfi
+from DQM.TrackingMonitor.TrackingMonitor_cfi import *
 
-TrackMonSeed = DQM.TrackingMonitor.TrackingMonitor_cfi.TrackMon.clone()
-
-TrackMonSeed.MeasurementState           = cms.string('ImpactPoint')
-TrackMonSeed.FolderName                 = cms.string('Tracking/TrackParameters')
-TrackMonSeed.BSFolderName               = cms.string('Tracking/TrackParameters/BeamSpotParameters')
-TrackMonSeed.AlgoName                   = cms.string('Seed')
-#TrackMonSeed.doGoodTrackPlots       = cms.bool(False)
-TrackMonSeed.doTrackerSpecific          = cms.bool(False)
-TrackMonSeed.doAllPlots                 = cms.bool(False)
-TrackMonSeed.doHitPropertiesPlots       = cms.bool(False)
-TrackMonSeed.doGeneralPropertiesPlots   = cms.bool(False)
-TrackMonSeed.doBeamSpotPlots            = cms.bool(False)
-TrackMonSeed.doSeedParameterHistos      = cms.bool(False)
-TrackMonSeed.doLumiAnalysis             = cms.bool(False)
-TrackMonSeed.doMeasurementStatePlots    = cms.bool(False)
-TrackMonSeed.doRecHitsPerTrackProfile   = cms.bool(False)
-TrackMonSeed.doRecHitVsPhiVsEtaPerTrack = cms.bool(False)
-#TrackMonSeed.doGoodTrackRecHitVsPhiVsEtaPerTrack = cms.bool(False)
-#
-# plot on Seed (total number, pt, seed # vs cluster)
-#
-TrackMonSeed.doSeedNumberHisto    = cms.bool(True)
-TrackMonSeed.doSeedLumiAnalysis   = cms.bool(True)
-TrackMonSeed.doSeedVsClusterHisto = cms.bool(True)
-TrackMonSeed.doSeedPTHisto        = cms.bool(True)
-TrackMonSeed.doSeedETAHisto       = cms.bool(True)
-TrackMonSeed.doSeedPHIHisto       = cms.bool(True)
-TrackMonSeed.doSeedPHIVsETAHisto  = cms.bool(True)
-TrackMonSeed.doStopSource         = cms.bool(True)
+TrackMonSeed = TrackMon.clone(
+    MeasurementState = 'ImpactPoint',
+    FolderName = 'Tracking/TrackParameters',
+    BSFolderName = 'Tracking/TrackParameters/BeamSpotParameters',
+    AlgoName = 'Seed',
+    #doGoodTrackPlots = False,
+    doTrackerSpecific = False,
+    doAllPlots = False,
+    doHitPropertiesPlots = False,
+    doGeneralPropertiesPlots = False,
+    doBeamSpotPlots = False,
+    doSeedParameterHistos = False,
+    doLumiAnalysis = False,
+    doMeasurementStatePlots = False,
+    doRecHitsPerTrackProfile = False,
+    doRecHitVsPhiVsEtaPerTrack = False,
+    #doGoodTrackRecHitVsPhiVsEtaPerTrack = False,
+    #
+    # plot on Seed (total number, pt, seed # vs cluster)
+    #
+    doSeedNumberHisto = True,
+    doSeedLumiAnalysis = True,
+    doSeedVsClusterHisto = True,
+    doSeedPTHisto = True,
+    doSeedETAHisto = True,
+    doSeedPHIHisto = True,
+    doSeedPHIVsETAHisto = True,
+    doStopSource = True
+)

--- a/DQM/TrackingMonitor/python/V0Monitor_cff.py
+++ b/DQM/TrackingMonitor/python/V0Monitor_cff.py
@@ -2,22 +2,28 @@ import FWCore.ParameterSet.Config as cms
 
 from DQM.TrackingMonitor.V0Monitor_cfi import *
 
-KshortMonitoring = v0Monitor.clone()
-KshortMonitoring.FolderName = cms.string("Tracking/V0Monitoring/Ks")
-KshortMonitoring.v0         = cms.InputTag('generalV0Candidates:Kshort')
-KshortMonitoring.histoPSet.massPSet = cms.PSet(
-   nbins = cms.int32 ( 100 ),
-   xmin  = cms.double( 0.400),
-   xmax  = cms.double( 0.600),
+KshortMonitoring = v0Monitor.clone(
+    FolderName = "Tracking/V0Monitoring/Ks",
+    v0 = 'generalV0Candidates:Kshort',
+    histoPSet = v0Monitor.histoPSet.clone(
+        massPSet = v0Monitor.histoPSet.massPSet.clone(
+            nbins = 100,
+            xmin = 0.400,
+            xmax = 0.600
+        )
+    )
 )
 
-LambdaMonitoring = v0Monitor.clone()
-LambdaMonitoring.FolderName = cms.string("Tracking/V0Monitoring/Lambda")
-LambdaMonitoring.v0         = cms.InputTag('generalV0Candidates:Lambda')
-LambdaMonitoring.histoPSet.massPSet = cms.PSet(
-   nbins = cms.int32 ( 100 ),
-   xmin  = cms.double( 1.050 ),
-   xmax  = cms.double( 1.250 )
+LambdaMonitoring = v0Monitor.clone(
+    FolderName = "Tracking/V0Monitoring/Lambda",
+    v0 = 'generalV0Candidates:Lambda',
+    histoPSet = v0Monitor.histoPSet.clone(
+        massPSet = v0Monitor.histoPSet.massPSet.clone(
+            nbins = 100,
+            xmin = 1.050,
+            xmax = 1.250
+        )
+    )
 )
 
 voMonitoringSequence = cms.Sequence(
@@ -28,12 +34,14 @@ voMonitoringSequence = cms.Sequence(
 from DQM.TrackingMonitorSource.pset4GenericTriggerEventFlag_cfi import *
 
 # tracker ON
-KshortMonitoringCommon = KshortMonitoring.clone()
-KshortMonitoringCommon.genericTriggerEventPSet = genericTriggerEventFlag4fullTracker
+KshortMonitoringCommon = KshortMonitoring.clone(
+    genericTriggerEventPSet = genericTriggerEventFlag4fullTracker
+)
 KshortMonitoringCommon.setLabel("KshortMonitoringCommon")
 
-LambdaMonitoringCommon = LambdaMonitoring.clone()
-LambdaMonitoringCommon.genericTriggerEventPSet = genericTriggerEventFlag4fullTracker
+LambdaMonitoringCommon = LambdaMonitoring.clone(
+    genericTriggerEventPSet = genericTriggerEventFlag4fullTracker
+)
 LambdaMonitoringCommon.setLabel("LambdaMonitoringCommon")
 
 voMonitoringCommonSequence = cms.Sequence(
@@ -43,47 +51,55 @@ voMonitoringCommonSequence = cms.Sequence(
 
 
 # tracker ON + ZeroBias selection
-KshortMonitoringMB = KshortMonitoring.clone()
-KshortMonitoringMB.FolderName = cms.string("Tracking/V0Monitoring/HIP_OOTpu_INpu/Ks")
-KshortMonitoringMB.genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTdb
+KshortMonitoringMB = KshortMonitoring.clone(
+    FolderName = "Tracking/V0Monitoring/HIP_OOTpu_INpu/Ks",
+    genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTdb
+)
 KshortMonitoringMB.setLabel("KshortMonitoringMB")
 
-LambdaMonitoringMB = LambdaMonitoring.clone()
-LambdaMonitoringMB.FolderName = cms.string("Tracking/V0Monitoring/HIP_OOTpu_INpu/Lambda")
-LambdaMonitoringMB.genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTdb
+LambdaMonitoringMB = LambdaMonitoring.clone(
+    FolderName = "Tracking/V0Monitoring/HIP_OOTpu_INpu/Lambda",
+    genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTdb
+)
 LambdaMonitoringMB.setLabel("LambdaMonitoringMB")
 
 # tracker ON + no HIP no OOT selection (HLT_ZeroBias_FirstCollisionAfterAbortGap)
-KshortMonitoringZBnoHIPnoOOT = KshortMonitoring.clone()
-KshortMonitoringZBnoHIPnoOOT.FolderName = cms.string("Tracking/V0Monitoring/noHIP_noOOTpu_INpu/Ks")
-KshortMonitoringZBnoHIPnoOOT.genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTnoHIPnoOOTdb
+KshortMonitoringZBnoHIPnoOOT = KshortMonitoring.clone(
+    FolderName = "Tracking/V0Monitoring/noHIP_noOOTpu_INpu/Ks",
+    genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTnoHIPnoOOTdb
+)
 KshortMonitoringZBnoHIPnoOOT.setLabel("KshortMonitoringZBnoHIPnoOOT")
 
-LambdaMonitoringZBnoHIPnoOOT = LambdaMonitoring.clone()
-LambdaMonitoringZBnoHIPnoOOT.FolderName = cms.string("Tracking/V0Monitoring/noHIP_noOOTpu_INpu/Lambda")
-LambdaMonitoringZBnoHIPnoOOT.genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTnoHIPnoOOTdb
+LambdaMonitoringZBnoHIPnoOOT = LambdaMonitoring.clone(
+    FolderName = "Tracking/V0Monitoring/noHIP_noOOTpu_INpu/Lambda",
+    genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTnoHIPnoOOTdb
+)
 LambdaMonitoringZBnoHIPnoOOT.setLabel("LambdaMonitoringZBnoHIPnoOOT")
 
 # tracker ON + HIP no OOT selection (HLT_ZeroBias_FirstCollisionInTrain)
-KshortMonitoringZBHIPnoOOT = KshortMonitoring.clone()
-KshortMonitoringZBHIPnoOOT.FolderName = cms.string("Tracking/V0Monitoring/HIP_noOOTpu_INpu/Ks")
-KshortMonitoringZBHIPnoOOT.genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTHIPnoOOTdb
+KshortMonitoringZBHIPnoOOT = KshortMonitoring.clone(
+    FolderName = "Tracking/V0Monitoring/HIP_noOOTpu_INpu/Ks",
+    genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTHIPnoOOTdb
+)
 KshortMonitoringZBHIPnoOOT.setLabel("KshortMonitoringZBHIPnoOOT")
 
-LambdaMonitoringZBHIPnoOOT = LambdaMonitoring.clone()
-LambdaMonitoringZBHIPnoOOT.FolderName = cms.string("Tracking/V0Monitoring/HIP_noOOTpu_INpu/Lambda")
-LambdaMonitoringZBHIPnoOOT.genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTHIPnoOOTdb
+LambdaMonitoringZBHIPnoOOT = LambdaMonitoring.clone(
+    FolderName = "Tracking/V0Monitoring/HIP_noOOTpu_INpu/Lambda",
+    genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTHIPnoOOTdb
+)
 LambdaMonitoringZBHIPnoOOT.setLabel("LambdaMonitoringZBHIPnoOOT")
 
 # tracker ON + HIP OOT selection (HLT_ZeroBias_FirstBXAfterTrain)
-KshortMonitoringZBHIPOOT = KshortMonitoring.clone()
-KshortMonitoringZBHIPOOT.FolderName = cms.string("Tracking/V0Monitoring/HIP_OOTpu_noINpu/Ks")
-KshortMonitoringZBHIPOOT.genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTHIPOOTdb
+KshortMonitoringZBHIPOOT = KshortMonitoring.clone(
+    FolderName = "Tracking/V0Monitoring/HIP_OOTpu_noINpu/Ks",
+    genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTHIPOOTdb
+)
 KshortMonitoringZBHIPOOT.setLabel("KshortMonitoringZBHIPOOT")
 
-LambdaMonitoringZBHIPOOT = LambdaMonitoring.clone()
-LambdaMonitoringZBHIPOOT.FolderName = cms.string("Tracking/V0Monitoring/HIP_OOTpu_noINpu/Lambda")
-LambdaMonitoringZBHIPOOT.genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTHIPOOTdb
+LambdaMonitoringZBHIPOOT = LambdaMonitoring.clone(
+    FolderName = "Tracking/V0Monitoring/HIP_OOTpu_noINpu/Lambda",
+    genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTHIPOOTdb
+)
 LambdaMonitoringZBHIPOOT.setLabel("LambdaMonitoringZBHIPOOT")
 
 voMonitoringMBSequence = cms.Sequence(
@@ -109,85 +125,98 @@ voMonitoringZBHIPOOTSequence = cms.Sequence(
 
 
 from CommonTools.RecoAlgos.vertexCompositeCandidateCollectionSelector_cfi import *
-KshortWlxy16 = vertexCompositeCandidateCollectionSelector.clone()
-KshortWlxy16.v0 = cms.InputTag('generalV0Candidates:Kshort')
+KshortWlxy16 = vertexCompositeCandidateCollectionSelector.clone(
+    v0 = 'generalV0Candidates:Kshort'
+)
 
-LambdaWlxy16 = vertexCompositeCandidateCollectionSelector.clone()
-LambdaWlxy16.v0 = cms.InputTag('generalV0Candidates:Lambda')
+LambdaWlxy16 = vertexCompositeCandidateCollectionSelector.clone(
+    v0 = 'generalV0Candidates:Lambda'
+)
 
-KshortWlxy16Monitoring = KshortMonitoring.clone()
-KshortWlxy16Monitoring.v0 = cms.InputTag('KshortWlxy16')
-KshortWlxy16Monitoring.FolderName = cms.string("Tracking/V0Monitoring/Ks/Lxy16")
+KshortWlxy16Monitoring = KshortMonitoring.clone(
+    v0 = 'KshortWlxy16',
+    FolderName = "Tracking/V0Monitoring/Ks/Lxy16"
+)
 
-LambdaWlxy16Monitoring = LambdaMonitoring.clone()
-LambdaWlxy16Monitoring.v0 = cms.InputTag('LambdaWlxy16')
-LambdaWlxy16Monitoring.FolderName = cms.string("Tracking/V0Monitoring/Lambda/Lxy16")
+LambdaWlxy16Monitoring = LambdaMonitoring.clone(
+    v0 = 'LambdaWlxy16',
+    FolderName = "Tracking/V0Monitoring/Lambda/Lxy16"
+)
 
 voWcutMonitoringSequence = cms.Sequence(
     KshortWlxy16*KshortWlxy16Monitoring
     + LambdaWlxy16*LambdaWlxy16Monitoring
 )
 
-KshortWlxy16MonitoringCommon = KshortMonitoringCommon.clone()
-KshortWlxy16MonitoringCommon.v0 = cms.InputTag('KshortWlxy16')
-KshortWlxy16MonitoringCommon.FolderName = cms.string("Tracking/V0Monitoring/Ks/Lxy16")
+KshortWlxy16MonitoringCommon = KshortMonitoringCommon.clone(
+    v0 = 'KshortWlxy16',
+    FolderName = "Tracking/V0Monitoring/Ks/Lxy16"
+)
 
-LambdaWlxy16MonitoringCommon = LambdaMonitoringCommon.clone()
-LambdaWlxy16MonitoringCommon.v0 = cms.InputTag('LambdaWlxy16')
-LambdaWlxy16MonitoringCommon.FolderName = cms.string("Tracking/V0Monitoring/Lambda/Lxy16")
+LambdaWlxy16MonitoringCommon = LambdaMonitoringCommon.clone(
+    v0 = 'LambdaWlxy16',
+    FolderName = "Tracking/V0Monitoring/Lambda/Lxy16"
+)
 
 voWcutMonitoringCommonSequence = cms.Sequence(
     KshortWlxy16*KshortWlxy16MonitoringCommon
     +LambdaWlxy16*LambdaWlxy16MonitoringCommon
 )
 
-KshortWlxy16MonitoringMB = KshortMonitoringMB.clone()
-KshortWlxy16MonitoringMB.v0 = cms.InputTag('KshortWlxy16')
-KshortWlxy16MonitoringMB.FolderName = cms.string("Tracking/V0Monitoring/HIP_OOTpu_INpu/Ks/Lxy16")
+KshortWlxy16MonitoringMB = KshortMonitoringMB.clone(
+    v0 = 'KshortWlxy16',
+    FolderName = "Tracking/V0Monitoring/HIP_OOTpu_INpu/Ks/Lxy16"
+)
 
-LambdaWlxy16MonitoringMB = LambdaMonitoringMB.clone()
-LambdaWlxy16MonitoringMB.v0 = cms.InputTag('LambdaWlxy16')
-LambdaWlxy16MonitoringMB.FolderName = cms.string("Tracking/V0Monitoring/HIP_OOTpu_INpu/Lambda/Lxy16")
+LambdaWlxy16MonitoringMB = LambdaMonitoringMB.clone(
+    v0 = 'LambdaWlxy16',
+    FolderName = "Tracking/V0Monitoring/HIP_OOTpu_INpu/Lambda/Lxy16"
+)
 
 voWcutMonitoringMBSequence = cms.Sequence(
     KshortWlxy16*KshortWlxy16MonitoringMB
     +LambdaWlxy16*LambdaWlxy16MonitoringMB
 )
 
-KshortWlxy16MonitoringZBnoHIPnoOOT = KshortMonitoringZBnoHIPnoOOT.clone()
-KshortWlxy16MonitoringZBnoHIPnoOOT.v0 = cms.InputTag('KshortWlxy16')
-KshortWlxy16MonitoringZBnoHIPnoOOT.FolderName = cms.string("Tracking/V0Monitoring/noHIP_noOOTpu_INpu/Ks/Lxy16")
+KshortWlxy16MonitoringZBnoHIPnoOOT = KshortMonitoringZBnoHIPnoOOT.clone(
+    v0 = 'KshortWlxy16',
+    FolderName = "Tracking/V0Monitoring/noHIP_noOOTpu_INpu/Ks/Lxy16"
+)
 
-LambdaWlxy16MonitoringZBnoHIPnoOOT = LambdaMonitoringZBnoHIPnoOOT.clone()
-LambdaWlxy16MonitoringZBnoHIPnoOOT.v0 = cms.InputTag('LambdaWlxy16')
-LambdaWlxy16MonitoringZBnoHIPnoOOT.FolderName = cms.string("Tracking/V0Monitoring/noHIP_noOOTpu_INpu/Lambda/Lxy16")
-
+LambdaWlxy16MonitoringZBnoHIPnoOOT = LambdaMonitoringZBnoHIPnoOOT.clone(
+    v0 = 'LambdaWlxy16',
+    FolderName = "Tracking/V0Monitoring/noHIP_noOOTpu_INpu/Lambda/Lxy16"
+)
 
 voWcutMonitoringZBnoHIPnoOOTSequence = cms.Sequence(
     KshortWlxy16*KshortWlxy16MonitoringZBnoHIPnoOOT
     +LambdaWlxy16*LambdaWlxy16MonitoringZBnoHIPnoOOT    
 )
 
-KshortWlxy16MonitoringZBHIPnoOOT = KshortMonitoringZBHIPnoOOT.clone()
-KshortWlxy16MonitoringZBHIPnoOOT.v0 = cms.InputTag('KshortWlxy16')
-KshortWlxy16MonitoringZBHIPnoOOT.FolderName = cms.string("Tracking/V0Monitoring/HIP_noOOTpu_INpu/Ks/Lxy16")
+KshortWlxy16MonitoringZBHIPnoOOT = KshortMonitoringZBHIPnoOOT.clone(
+    v0 = 'KshortWlxy16',
+    FolderName = "Tracking/V0Monitoring/HIP_noOOTpu_INpu/Ks/Lxy16"
+)
 
-LambdaWlxy16MonitoringZBHIPnoOOT = LambdaMonitoringZBHIPnoOOT.clone()
-LambdaWlxy16MonitoringZBHIPnoOOT.v0 = cms.InputTag('LambdaWlxy16')
-LambdaWlxy16MonitoringZBHIPnoOOT.FolderName = cms.string("Tracking/V0Monitoring/HIP_noOOTpu_INpu/Lambda/Lxy16")
+LambdaWlxy16MonitoringZBHIPnoOOT = LambdaMonitoringZBHIPnoOOT.clone(
+    v0 = 'LambdaWlxy16',
+    FolderName = "Tracking/V0Monitoring/HIP_noOOTpu_INpu/Lambda/Lxy16"
+)
 
 voWcutMonitoringZBHIPnoOOTSequence = cms.Sequence(
     KshortWlxy16*KshortWlxy16MonitoringZBHIPnoOOT
     +LambdaWlxy16*LambdaWlxy16MonitoringZBHIPnoOOT
 )
 
-KshortWlxy16MonitoringZBHIPOOT = KshortMonitoringZBHIPOOT.clone()
-KshortWlxy16MonitoringZBHIPOOT.v0 = cms.InputTag('KshortWlxy16')
-KshortWlxy16MonitoringZBHIPOOT.FolderName = cms.string("Tracking/V0Monitoring/HIP_OOTpu_noINpu/Ks/Lxy16")
+KshortWlxy16MonitoringZBHIPOOT = KshortMonitoringZBHIPOOT.clone(
+    v0 = 'KshortWlxy16',
+    FolderName = "Tracking/V0Monitoring/HIP_OOTpu_noINpu/Ks/Lxy16"
+)
 
-LambdaWlxy16MonitoringZBHIPOOT = LambdaMonitoringZBHIPOOT.clone()
-LambdaWlxy16MonitoringZBHIPOOT.v0 = cms.InputTag('LambdaWlxy16')
-LambdaWlxy16MonitoringZBHIPOOT.FolderName = cms.string("Tracking/V0Monitoring/HIP_OOTpu_noINpu/Lambda/Lxy16")
+LambdaWlxy16MonitoringZBHIPOOT = LambdaMonitoringZBHIPOOT.clone(
+    v0 = 'LambdaWlxy16',
+    FolderName = "Tracking/V0Monitoring/HIP_OOTpu_noINpu/Lambda/Lxy16"
+)
 
 voWcutMonitoringZBHIPOOTSequence = cms.Sequence(
     KshortWlxy16*KshortWlxy16MonitoringZBHIPOOT

--- a/DQM/TrackingMonitor/python/dEdxAnalyzer_cff.py
+++ b/DQM/TrackingMonitor/python/dEdxAnalyzer_cff.py
@@ -4,22 +4,26 @@ from DQM.TrackingMonitor.dEdxAnalyzer_cfi import *
 
 #ADD BY LOIC
 from RecoTracker.TrackProducer.TrackRefitter_cfi import *
-RefitterForDedxDQMDeDx = TrackRefitter.clone()
-RefitterForDedxDQMDeDx.src = cms.InputTag("generalTracks")
-RefitterForDedxDQMDeDx.TrajectoryInEvent = True
+RefitterForDedxDQMDeDx = TrackRefitter.clone(
+    src = "generalTracks",
+    TrajectoryInEvent = True
+)
 
 from RecoTracker.DeDx.dedxEstimators_cff import dedxHarmonic2
-dedxDQMHarm2SP = dedxHarmonic2.clone()
-#dedxDQMHarm2SP.tracks                     = cms.InputTag("RefitterForDedxDQMDeDx")
-dedxDQMHarm2SP.tracks                     = cms.InputTag("generalTracks")
-dedxDQMHarm2SP.UseStrip = cms.bool(True)
-dedxDQMHarm2SP.UsePixel = cms.bool(True)
+dedxDQMHarm2SP = dedxHarmonic2.clone(
+    #tracks = "RefitterForDedxDQMDeDx",
+    tracks = "generalTracks",
+    UseStrip = True,
+    UsePixel = True
+)
 
-dedxDQMHarm2SO = dedxDQMHarm2SP.clone()
-dedxDQMHarm2SO.UsePixel = cms.bool(False)
+dedxDQMHarm2SO = dedxDQMHarm2SP.clone(
+    UsePixel = False
+)
 
-dedxDQMHarm2PO = dedxDQMHarm2SP.clone()
-dedxDQMHarm2PO.UseStrip = cms.bool(False)
+dedxDQMHarm2PO = dedxDQMHarm2SP.clone(
+    UseStrip = False
+)
 
 #dEdxMonitor = cms.Sequence(
 #    RefitterForDedxDQMDeDx * dedxDQMHarm2SP * dedxDQMHarm2SO * dedxDQMHarm2PO

--- a/DQM/TrackingMonitorClient/python/TrackingClientConfig_Tier0_Cosmic_cff.py
+++ b/DQM/TrackingMonitorClient/python/TrackingClientConfig_Tier0_Cosmic_cff.py
@@ -62,15 +62,15 @@ TrackEffClient.AlgoName   = 'CKFTk'
 from DQM.TrackingMonitor.TrackFoldedOccupancyClient_cfi import TrackerMapFoldedClient 
 
 TrackerMapFoldedClient_CKFTk=TrackerMapFoldedClient.clone(
-    AlgoName = cms.string('CKFTk'),
-    MeasurementState = cms.string('default'),
-    TrackQuality = cms.string('')
+    AlgoName = 'CKFTk',
+    MeasurementState = 'default',
+    TrackQuality = ''
 )
 
 TrackerMapFoldedClient_CosmicTk=TrackerMapFoldedClient.clone(
-    AlgoName = cms.string('CosmicTk'),
-    MeasurementState = cms.string('default'),
-    TrackQuality = cms.string('')
+    AlgoName = 'CosmicTk',
+    MeasurementState = 'default',
+    TrackQuality = ''
 )
 
 # Sequence

--- a/DQM/TrackingMonitorClient/python/TrackingClientConfig_Tier0_cff.py
+++ b/DQM/TrackingMonitorClient/python/TrackingClientConfig_Tier0_cff.py
@@ -79,11 +79,12 @@ from DQM.TrackingMonitorClient.V0MonitoringClient_cff import *
 from DQM.TrackingMonitorClient.primaryVertexResolutionClient_cfi import *
 # Sequence
 
-#import DQM.TrackingMonitor.TrackEfficiencyMonitor_cfi
-#TrackEffMon_ckf = DQM.TrackingMonitor.TrackEfficiencyMonitor_cfi.TrackEffMon.clone()
-#TrackEffMon_ckf.TKTrackCollection                  = 'ctfWithMaterialTracksP5'
-#TrackEffMon_ckf.AlgoName                           = 'CKFTk'
-#TrackEffMon_ckf.FolderName                         = 'Tracking/TrackParameters/TrackEfficiency'
+# from DQM.TrackingMonitor.TrackEfficiencyMonitor_cfi import *
+# TrackEffMon_ckf = TrackEffMon.clone(
+#     TKTrackCollection = 'ctfWithMaterialTracksP5',
+#     AlgoName = 'CKFTk',
+#     FolderName = 'Tracking/TrackParameters/TrackEfficiency'
+# )
 
 from DQM.TrackingMonitor.TrackEfficiencyClient_cfi import *
 TrackEffClient.FolderName = 'Tracking/TrackParameters/TrackEfficiency'

--- a/DQM/TrackingMonitorClient/python/TrackingDQMClientHeavyIons_cfi.py
+++ b/DQM/TrackingMonitorClient/python/TrackingDQMClientHeavyIons_cfi.py
@@ -7,8 +7,8 @@ hiTrackingDqmClientHI = DQMEDHarvester("TrackingDQMClientHeavyIons",
 
 from DQM.TrackingMonitor.TrackFoldedOccupancyClient_cfi import TrackerMapFoldedClient
 
-TrackerMapFoldedClient_heavyionTk=TrackerMapFoldedClient.clone(
-    AlgoName = cms.string('HeavyIonTk'),
-    TrackQuality = cms.string('')
+TrackerMapFoldedClient_heavyionTk = TrackerMapFoldedClient.clone(
+    AlgoName = 'HeavyIonTk',
+    TrackQuality = ''
 )
 hiTrackingDqmClientHeavyIons=cms.Sequence(hiTrackingDqmClientHI*TrackerMapFoldedClient_heavyionTk)

--- a/DQM/TrackingMonitorClient/python/TrackingEffFromHitPatternClientConfigZeroBias_cff.py
+++ b/DQM/TrackingMonitorClient/python/TrackingEffFromHitPatternClientConfigZeroBias_cff.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-import DQM.TrackingMonitorClient.TrackingEffFromHitPatternClientConfig_cff
-trackingEffFromHitPatternZeroBias = DQM.TrackingMonitorClient.TrackingEffFromHitPatternClientConfig_cff.trackingEffFromHitPattern.clone(
-    subDirs = cms.untracked.vstring(
+from DQM.TrackingMonitorClient.TrackingEffFromHitPatternClientConfig_cff import *
+trackingEffFromHitPatternZeroBias = trackingEffFromHitPattern.clone(
+    subDirs = (
         "Tracking/TrackParameters/generalTracks/HitEffFromHitPattern*",
         "Tracking/TrackParameters/highPurityTracks/pt_1/HitEffFromHitPattern*",
         "Tracking/TrackParameters/highPurityTracks/dzPV0p1/HitEffFromHitPattern*",
@@ -10,6 +10,6 @@ trackingEffFromHitPatternZeroBias = DQM.TrackingMonitorClient.TrackingEffFromHit
         "Tracking/TrackParameters/highPurityTracks/pt_1/HIP_noOOT_INpu/HitEffFromHitPattern*",
         "Tracking/TrackParameters/highPurityTracks/pt_1/noHIP_noOOT_INpu/HitEffFromHitPattern*",
         "Muons/Tracking/innerTrack/HitEffFromHitPattern*",
-        "Muons/globalMuons/HitEffFromHitPattern*"
+        "Muons/globalMuons/HitEffFromHitPattern*",
     )
 )

--- a/DQM/TrackingMonitorClient/python/V0MonitoringClient_cff.py
+++ b/DQM/TrackingMonitorClient/python/V0MonitoringClient_cff.py
@@ -2,13 +2,23 @@ import FWCore.ParameterSet.Config as cms
 
 from DQM.TrackingMonitorClient.V0MonitoringClient_cfi import *
 
-KshortMonitorClient = v0MonitorClient.clone()
-KshortMonitorClient.inputme.folder  = cms.string('Tracking/V0Monitoring/Ks')
-KshortMonitorClient.outputme.folder = cms.string('Tracking/V0Monitoring/Ks')
+KshortMonitorClient = v0MonitorClient.clone(
+    inputme = v0MonitorClient.inputme.clone(
+        folder = 'Tracking/V0Monitoring/Ks'
+    ),
+    outputme = v0MonitorClient.outputme.clone(
+        folder = 'Tracking/V0Monitoring/Ks'
+    )
+)
 
-LambdaMonitoringClient = v0MonitorClient.clone()
-LambdaMonitoringClient.inputme.folder  = cms.string('Tracking/V0Monitoring/Lambda')
-LambdaMonitoringClient.outputme.folder = cms.string('Tracking/V0Monitoring/Lambda')
+LambdaMonitoringClient = v0MonitorClient.clone(
+    inputme = v0MonitorClient.inputme.clone(
+        folder = 'Tracking/V0Monitoring/Lambda'
+    ),
+    outputme = v0MonitorClient.outputme.clone(
+        folder = 'Tracking/V0Monitoring/Lambda'
+    )
+)
 
 voMonitoringClientSequence = cms.Sequence(
     KshortMonitorClient

--- a/DQM/TrackingMonitorClient/python/V0MonitoringClient_cfi.py
+++ b/DQM/TrackingMonitorClient/python/V0MonitoringClient_cfi.py
@@ -1,12 +1,13 @@
 from DQM.TrackingMonitorClient.DQMScaleToClient_cfi import *
 
-v0MonitorClient = dqmScaleToClient.clone()
-v0MonitorClient.outputme = cms.PSet(
-    folder = cms.string('Tracking/V0Monitoring'),
-    name = cms.string('v0_Lxy_normalized'),
-    factor = cms.double(1.)
-)
-v0MonitorClient.inputme = cms.PSet(
-    folder = cms.string('Tracking/V0Monitoring'),
-    name = cms.string('v0_Lxy')
+v0MonitorClient = dqmScaleToClient.clone(
+    outputme = dqmScaleToClient.outputme.clone(
+        folder = 'Tracking/V0Monitoring',
+        name = 'v0_Lxy_normalized',
+        factor = 1.
+    ),
+    inputme = dqmScaleToClient.inputme.clone(
+        folder = 'Tracking/V0Monitoring',
+        name = 'v0_Lxy'
+    )
 )

--- a/DQM/TrackingMonitorSource/python/LogMessageMonitor_cff.py
+++ b/DQM/TrackingMonitorSource/python/LogMessageMonitor_cff.py
@@ -1,12 +1,14 @@
 import FWCore.ParameterSet.Config as cms
 
 from DQM.TrackingMonitorSource.pset4GenericTriggerEventFlag_cfi import *
-import DQM.TrackingMonitor.LogMessageMonitor_cfi
+from DQM.TrackingMonitor.LogMessageMonitor_cfi import *
 
 # Clone for all PDs but MinBias ####
-LogMessageMonCommon = DQM.TrackingMonitor.LogMessageMonitor_cfi.LogMessageMon.clone()
-LogMessageMonCommon.genericTriggerEventPSet = genericTriggerEventFlag4fullTracker
+LogMessageMonCommon = LogMessageMon.clone(
+    genericTriggerEventPSet = genericTriggerEventFlag4fullTracker
+)
 
 # Clone for MinBias ###
-LogMessageMonMB = DQM.TrackingMonitor.LogMessageMonitor_cfi.LogMessageMon.clone()
-LogMessageMonMB.genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTdb
+LogMessageMonMB = LogMessageMon.clone(
+    genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTdb
+)

--- a/DQM/TrackingMonitorSource/python/TrackCollections2monitor_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackCollections2monitor_cff.py
@@ -65,8 +65,9 @@ trackSelector = cms.EDFilter('TrackSelector',
 )
 
 ### highpurity definition: https://cmssdt.cern.ch/SDT/lxr/source/RecoTracker/FinalTrackSelectors/python/selectHighPurity_cfi.py
-highPurityPtRange0to1 = trackSelector.clone()
-highPurityPtRange0to1.cut = cms.string("quality('highPurity') & pt >= 0 & pt < 1 ")
+highPurityPtRange0to1 = trackSelector.clone(
+    cut = "quality('highPurity') & pt >= 0 & pt < 1 "
+)
 
 sequenceName    ['highPurityPtRange0to1'] = highPurityPtRange0to1
 allTrackProducer['highPurityPtRange0to1'] = 'generalTracks'
@@ -97,8 +98,9 @@ doEffFromHitPatternVsBX             ['highPurityPtRange0to1'] = cms.bool(False)
 doEffFromHitPatternVsLumi           ['highPurityPtRange0to1'] = cms.bool(False)
 doStopSource                        ['highPurityPtRange0to1'] = cms.bool(True)
 
-highPurityPtRange1to10 = trackSelector.clone()
-highPurityPtRange1to10.cut = cms.string("quality('highPurity') & pt >= 1 & pt < 10 ")
+highPurityPtRange1to10 = trackSelector.clone(
+    cut = "quality('highPurity') & pt >= 1 & pt < 10 "
+)
 
 sequenceName    ['highPurityPtRange1to10'] = highPurityPtRange1to10 
 allTrackProducer['highPurityPtRange1to10'] = 'generalTracks'
@@ -128,8 +130,9 @@ doEffFromHitPatternVsBX             ['highPurityPtRange1to10'] = cms.bool(False)
 doEffFromHitPatternVsLumi           ['highPurityPtRange1to10'] = cms.bool(False)
 doStopSource                        ['highPurityPtRange1to10'] = cms.bool(True)
 
-highPurityPt10 = trackSelector.clone()
-highPurityPt10.cut = cms.string("quality('highPurity') & pt >= 10")
+highPurityPt10 = trackSelector.clone(
+    cut = "quality('highPurity') & pt >= 10"
+)
 
 sequenceName    ['highPurityPt10'] = highPurityPt10 
 allTrackProducer['highPurityPt10'] = 'generalTracks'
@@ -160,8 +163,9 @@ doEffFromHitPatternVsLumi           ['highPurityPt10'] = cms.bool(False)
 doStopSource                        ['highPurityPt10'] = cms.bool(True)
 
 ###### old monitored track collections
-highPurityPt1 = trackSelector.clone()
-highPurityPt1.cut = cms.string("quality('highPurity') & pt >= 1")
+highPurityPt1 = trackSelector.clone(
+    cut = "quality('highPurity') & pt >= 1"
+)
 
 sequenceName    ['highPurityPt1'] = highPurityPt1
 allTrackProducer['highPurityPt1'] = 'generalTracks'
@@ -193,8 +197,9 @@ doEffFromHitPatternVsLumi           ['highPurityPt1'] = cms.bool(True)
 doStopSource                        ['highPurityPt1'] = cms.bool(True)
 
 ###### forward-only monitored track collections
-highPurityPt1Eta2p5to3p0 = trackSelector.clone()
-highPurityPt1Eta2p5to3p0.cut = cms.string("quality('highPurity') & pt >= 1 & abs(eta) > 2.5")
+highPurityPt1Eta2p5to3p0 = trackSelector.clone(
+    cut = "quality('highPurity') & pt >= 1 & abs(eta) > 2.5"
+)
 
 sequenceName    ['highPurityPt1Eta2p5to3p0'] = highPurityPt1Eta2p5to3p0
 allTrackProducer['highPurityPt1Eta2p5to3p0'] = 'generalTracks'
@@ -232,46 +237,49 @@ doStopSource                        ['highPurityPt1Eta2p5to3p0'] = cms.bool(True
 ###### association is dz<1mm 
 from CommonTools.RecoAlgos.TrackWithVertexSelector_cfi import *
 
-trackAssociated2pvSelector = trackWithVertexSelector.clone()
-# the track collection
-trackAssociated2pvSelector.src = cms.InputTag('generalTracks')
-# kinematic cuts  (pT in GeV)
-trackAssociated2pvSelector.etaMin = cms.double(0.0)
-trackAssociated2pvSelector.etaMax = cms.double(5.0)
-trackAssociated2pvSelector.ptMin = cms.double(0.0)
-trackAssociated2pvSelector.ptMax = cms.double(100000.0)
-# impact parameter cut (in cm)
-trackAssociated2pvSelector.d0Max = cms.double(999.)
-trackAssociated2pvSelector.dzMax = cms.double(999.)
-# quality cuts (valid hits, normalized chi2)
-trackAssociated2pvSelector.normalizedChi2         = cms.double(999999.)
-trackAssociated2pvSelector.numberOfValidHits      = cms.uint32(0)
-trackAssociated2pvSelector.numberOfLostHits       = cms.uint32(999) ## at most 999 lost hits
-trackAssociated2pvSelector.numberOfValidPixelHits = cms.uint32(0) ## at least <n> hits in the pixels
-trackAssociated2pvSelector.ptErrorCut             = cms.double(9999999.) ## [pTError/pT]*max(1,normChi2) <= ptErrorCut
-trackAssociated2pvSelector.quality = cms.string("highPurity") # quality cut as defined in reco::TrackBase
-# compatibility with a vertex ?
-trackAssociated2pvSelector.useVtx       = cms.bool(True)
-trackAssociated2pvSelector.vertexTag    = cms.InputTag('trackingDQMgoodOfflinePrimaryVertices')
-trackAssociated2pvSelector.timesTag     = cms.InputTag('')
-trackAssociated2pvSelector.timeResosTag = cms.InputTag('')
-trackAssociated2pvSelector.nVertices    = cms.uint32(1) ## how many vertices to look at before dropping the track
-trackAssociated2pvSelector.vtxFallback  = cms.bool(True) ## falback to beam spot if there are no vertices
-# uses vtx=(0,0,0) with deltaZeta=15.9, deltaRho = 0.2
-trackAssociated2pvSelector.zetaVtx        = cms.double(999.)
-#trackAssociated2pvSelector.rhoVtx         = cms.double(0.2) ## tags used by b-tagging folks
-trackAssociated2pvSelector.rhoVtx         = cms.double(999.) ## tags used by b-tagging folks
-trackAssociated2pvSelector.nSigmaDtVertex = cms.double(0)
-# should _not_ be used for the TrackWithVertexRefSelector
-trackAssociated2pvSelector.copyExtras       = cms.untracked.bool(False) ## copies also extras and rechits on RECO
-trackAssociated2pvSelector.copyTrajectories = cms.untracked.bool(False) # don't set this to true on AOD!
+trackAssociated2pvSelector = trackWithVertexSelector.clone(
+    # the track collection
+    src = 'generalTracks',
+    # kinematic cuts  (pT in GeV)
+    etaMin = 0.0,
+    etaMax = 5.0,
+    ptMin = 0.0,
+    ptMax = 100000.0,
+    # impact parameter cut (in cm)
+    d0Max = 999.,
+    dzMax = 999.,
+    # quality cuts (valid hits, normalized chi2)
+    normalizedChi2 = 999999.,
+    numberOfValidHits = 0,
+    numberOfLostHits = 999, ## at most 999 lost hits
+    numberOfValidPixelHits = 0, ## at least <n> hits in the pixels
+    ptErrorCut = 9999999., ## [pTError/pT]*max(1,normChi2) <= ptErrorCut
+    quality = "highPurity", # quality cut as defined in reco::TrackBase
+    # compatibility with a vertex ?
+    useVtx = True,
+    vertexTag = 'trackingDQMgoodOfflinePrimaryVertices',
+    timesTag = '',
+    timeResosTag = '',
+    nVertices = 1, ## how many vertices to look at before dropping the track
+    vtxFallback = True, ## falback to beam spot if there are no vertices
+    # uses vtx=(0,0,0) with deltaZeta=15.9, deltaRho = 0.2
+    zetaVtx = 999.,
+    #rhoVtx = 0.2, ## tags used by b-tagging folks
+    rhoVtx = 999., ## tags used by b-tagging folks
+    nSigmaDtVertex = 0.,
+    # should _not_ be used for the TrackWithVertexRefSelector
+    copyExtras = False, ## copies also extras and rechits on RECO
+    copyTrajectories = False # don't set this to true on AOD!
+)
 
-highPurityPV0p1 = trackAssociated2pvSelector.clone()
-highPurityPV0p1.zetaVtx = cms.double(0.1) # wrt PV
-#highPurityPV0p1.dzMax   = cms.double(0.1) # wrt BS
+highPurityPV0p1 = trackAssociated2pvSelector.clone(
+    zetaVtx = 0.1, # wrt PV
+    #dzMax = 0.1 # wrt BS
+)
 
-PV0p1 = highPurityPV0p1.clone()
-PV0p1.quality = cms.string("") # quality cut as defined in reco::TrackBase
+PV0p1 = highPurityPV0p1.clone(
+    quality = "" # quality cut as defined in reco::TrackBase
+)
 
 #sequenceName    ['highPurityPV0p1'] = highPurityPV0p1
 sequenceName    ['highPurityPV0p1'] = highPurityPV0p1+PV0p1
@@ -304,9 +312,10 @@ doEffFromHitPatternVsLumi           ['highPurityPV0p1'] = cms.bool(True)
 doStopSource                        ['highPurityPV0p1'] = cms.bool(True)
 
 #pixel tracks
-hiConformalPixelTracksQA = trackSelector.clone()
-hiConformalPixelTracksQA.src = cms.InputTag('hiConformalPixelTracks')
-hiConformalPixelTracksQA.cut = cms.string("chi2/ndof/hitPattern.trackerLayersWithMeasurement < 200")
+hiConformalPixelTracksQA = trackSelector.clone(
+    src = 'hiConformalPixelTracks',
+    cut = "chi2/ndof/hitPattern.trackerLayersWithMeasurement < 200"
+)
 
 sequenceName    ['hiConformalPixelTracksQA'] = hiConformalPixelTracksQA
 allTrackProducer['hiConformalPixelTracksQA'] = 'generalTracks'

--- a/DQM/TrackingMonitorSource/python/TrackerCollisionTrackingMonitor_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackerCollisionTrackingMonitor_cff.py
@@ -3,33 +3,38 @@ import FWCore.ParameterSet.Config as cms
 from DQM.TrackingMonitorSource.pset4GenericTriggerEventFlag_cfi import *
 
 # Clone for TrackingMonitor for all PDs but MinBias ###
-import DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi
-TrackerCollisionTrackMonCommon = DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi.TrackerCollisionTrackMon.clone()
-TrackerCollisionTrackMonCommon.genericTriggerEventPSet = genericTriggerEventFlag4fullTracker
+from DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi import *
+TrackerCollisionTrackMonCommon = TrackerCollisionTrackMon.clone(
+    genericTriggerEventPSet = genericTriggerEventFlag4fullTracker
+)
 TrackerCollisionTrackMonCommon.setLabel("TrackerCollisionTrackMonCommon")
 
 # Clone for TrackingMonitor for ZeroBias ###
-import DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi
-TrackerCollisionTrackMonMB = DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi.TrackerCollisionTrackMon.clone()
-TrackerCollisionTrackMonMB.genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTdb
-TrackerCollisionTrackMonMB.doPrimaryVertexPlots    = cms.bool(True)
+from DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi import *
+TrackerCollisionTrackMonMB = TrackerCollisionTrackMon.clone(
+    genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTdb,
+    doPrimaryVertexPlots = True
+)
 TrackerCollisionTrackMonMB.setLabel("TrackerCollisionTrackMonMB")
 
 # Clone for TrackingMonitor for ZeroBias, no hip, no OOT pu (1st collision after abort gap) ###
-TrackerCollisionTrackMonZBnoHIPnoOOT = DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi.TrackerCollisionTrackMon.clone()
-TrackerCollisionTrackMonZBnoHIPnoOOT.genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTnoHIPnoOOTdb
-TrackerCollisionTrackMonZBnoHIPnoOOT.doPrimaryVertexPlots    = cms.bool(True)
+TrackerCollisionTrackMonZBnoHIPnoOOT = TrackerCollisionTrackMon.clone(
+    genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTnoHIPnoOOTdb,
+    doPrimaryVertexPlots = True
+)
 TrackerCollisionTrackMonZBnoHIPnoOOT.setLabel("TrackerCollisionTrackMonZBnoHIPnoOOT")
 
 # Clone for TrackingMonitor for ZeroBias, hip, no OOT pu (1st collision in train) ###
-TrackerCollisionTrackMonZBHIPnoOOT = DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi.TrackerCollisionTrackMon.clone()
-TrackerCollisionTrackMonZBHIPnoOOT.genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTHIPnoOOTdb
-TrackerCollisionTrackMonZBHIPnoOOT.doPrimaryVertexPlots    = cms.bool(True)
+TrackerCollisionTrackMonZBHIPnoOOT = TrackerCollisionTrackMon.clone(
+    genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTHIPnoOOTdb,
+    doPrimaryVertexPlots = True
+)
 TrackerCollisionTrackMonZBHIPnoOOT.setLabel("TrackerCollisionTrackMonZBHIPnoOOT")
 
 # Clone for TrackingMonitor for ZeroBias, hip, OOT pu (1st collision after train) ###
-TrackerCollisionTrackMonZBHIPOOT = DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi.TrackerCollisionTrackMon.clone()
-TrackerCollisionTrackMonZBHIPOOT.genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTHIPOOTdb
-TrackerCollisionTrackMonZBHIPOOT.doPrimaryVertexPlots    = cms.bool(True)
+TrackerCollisionTrackMonZBHIPOOT = TrackerCollisionTrackMon.clone(
+    genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTHIPOOTdb,
+    doPrimaryVertexPlots = True
+)
 TrackerCollisionTrackMonZBHIPOOT.setLabel("TrackerCollisionTrackMonZBHIPOOT")
 

--- a/DQM/TrackingMonitorSource/python/TrackingSourceConfigP5_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackingSourceConfigP5_cff.py
@@ -2,81 +2,91 @@ import FWCore.ParameterSet.Config as cms
 
 # TrackingMonitor ####
 # Clone for Cosmic Track Finder
-import DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi
-TrackMon_cosmicTk = DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi.TrackerCosmicTrackMon.clone()
-TrackMon_cosmicTk.TrackProducer = 'cosmictrackfinderP5'
-TrackMon_cosmicTk.AlgoName      = 'CosmicTk'
-TrackMon_cosmicTk.FolderName    = 'Tracking/TrackParameters'
-TrackMon_cosmicTk.doSeedParameterHistos = True
-TrackMon_cosmicTk.TkSizeBin = cms.int32(4)
-TrackMon_cosmicTk.TkSizeMax = cms.double( 3.5)
-TrackMon_cosmicTk.TkSizeMin = cms.double(-0.5)
+from DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi import *
+TrackMon_cosmicTk = TrackerCosmicTrackMon.clone(
+    TrackProducer = 'cosmictrackfinderP5',
+    AlgoName = 'CosmicTk',
+    FolderName = 'Tracking/TrackParameters',
+    doSeedParameterHistos = True,
+    TkSizeBin = 4,
+    TkSizeMax = 3.5,
+    TkSizeMin = -0.5
+)
 
 # Clone for CKF Tracks
-import DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi
-TrackMon_ckf = DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi.TrackerCosmicTrackMon.clone()
-TrackMon_ckf.TrackProducer      = 'ctfWithMaterialTracksP5'
-TrackMon_ckf.AlgoName           = 'CKFTk'
-TrackMon_ckf.FolderName         = 'Tracking/TrackParameters'
-TrackMon_ckf.doSeedParameterHistos = True
-TrackMon_ckf.TkSizeBin = cms.int32(4)
-TrackMon_ckf.TkSizeMax = cms.double( 3.5)
-TrackMon_ckf.TkSizeMin = cms.double(-0.5)
+from DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi import *
+TrackMon_ckf = TrackerCosmicTrackMon.clone(
+    TrackProducer = 'ctfWithMaterialTracksP5',
+    AlgoName = 'CKFTk',
+    FolderName = 'Tracking/TrackParameters',
+    doSeedParameterHistos = True,
+    TkSizeBin = 4,
+    TkSizeMax = 3.5,
+    TkSizeMin = -0.5
+)
 
 # Clone for Road Search  Tracks
-#import DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi
-#TrackMon_rs = DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi.TrackerCosmicTrackMon.clone()
-#TrackMon_rs.TrackProducer       = 'rsWithMaterialTracksP5'
-#TrackMon_rs.AlgoName            = 'RSTk'
-#TrackMon_rs.FolderName          = 'Tracking/TrackParameters'
-#TrackMon_rs.doSeedParameterHistos = True
+# from DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi import *
+# TrackMon_rs = TrackerCosmicTrackMon.clone(
+#     TrackProducer = 'rsWithMaterialTracksP5',
+#     AlgoName = 'RSTk',
+#     FolderName = 'Tracking/TrackParameters',
+#     doSeedParameterHistos = True
+# )
 
 # Clone for General Track (for Collision data)
-import DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi
-TrackMon_gentk = DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi.TrackerCollisionTrackMon.clone(
-     FolderName          = 'Tracking/TrackParameters',
-     BSFolderName        = 'Tracking/TrackParameters/BeamSpotParameters',
-# decrease number of histograms
-#    doTrackerSpecific = False
+from DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi import *
+TrackMon_gentk = TrackerCollisionTrackMon.clone(
+    FolderName = 'Tracking/TrackParameters',
+    BSFolderName = 'Tracking/TrackParameters/BeamSpotParameters'
+    # decrease number of histograms
+    # doTrackerSpecific = False
 )
+
 # Clone for Heavy Ion Tracks (for HI Collisions)
-import DQM.TrackingMonitor.TrackerHeavyIonTrackingMonitor_cfi
-TrackMon_hi = DQM.TrackingMonitor.TrackerHeavyIonTrackingMonitor_cfi.TrackerHeavyIonTrackMon.clone()
-TrackMon_hi.FolderName          = 'Tracking/TrackParameters'
-TrackMon_hi.BSFolderName        = 'Tracking/TrackParameters/BeamSpotParameters'
+from DQM.TrackingMonitor.TrackerHeavyIonTrackingMonitor_cfi import *
+TrackMon_hi = TrackerHeavyIonTrackMon.clone(
+    FolderName = 'Tracking/TrackParameters',
+    BSFolderName = 'Tracking/TrackParameters/BeamSpotParameters'
+)
 
 # Tracking Efficiency ####
 # Clone for Cosmic Tracks
-import DQM.TrackingMonitor.TrackEfficiencyMonitor_cfi
-TrackEffMon_cosmicTk = DQM.TrackingMonitor.TrackEfficiencyMonitor_cfi.TrackEffMon.clone()
-TrackEffMon_cosmicTk.TKTrackCollection             = 'cosmictrackfinderP5'
-TrackEffMon_cosmicTk.AlgoName                      = 'CosmicTk'
-TrackEffMon_cosmicTk.FolderName                    = 'Tracking/TrackParameters/TrackEfficiency'
+from DQM.TrackingMonitor.TrackEfficiencyMonitor_cfi import *
+TrackEffMon_cosmicTk = TrackEffMon.clone(
+    TKTrackCollection = 'cosmictrackfinderP5',
+    AlgoName = 'CosmicTk',
+    FolderName = 'Tracking/TrackParameters/TrackEfficiency'
+)
 
 # Clone for CKF Tracks
-import DQM.TrackingMonitor.TrackEfficiencyMonitor_cfi
-TrackEffMon_ckf = DQM.TrackingMonitor.TrackEfficiencyMonitor_cfi.TrackEffMon.clone()
-TrackEffMon_ckf.TKTrackCollection                  = 'ctfWithMaterialTracksP5'
-TrackEffMon_ckf.AlgoName                           = 'CKFTk'
-TrackEffMon_ckf.FolderName                         = 'Tracking/TrackParameters/TrackEfficiency'
+from DQM.TrackingMonitor.TrackEfficiencyMonitor_cfi import *
+TrackEffMon_ckf = TrackEffMon.clone(
+    TKTrackCollection = 'ctfWithMaterialTracksP5',
+    AlgoName = 'CKFTk',
+    FolderName = 'Tracking/TrackParameters/TrackEfficiency'
+)
 
 # Clone for RS Tracks
-#import DQM.TrackingMonitor.TrackEfficiencyMonitor_cfi
-#TrackEffMon_rs = DQM.TrackingMonitor.TrackEfficiencyMonitor_cfi.TrackEffMon.clone()
-#TrackEffMon_rs.TKTrackCollection                   = 'rsWithMaterialTracksP5'
-#TrackEffMon_rs.AlgoName                            = 'RSTk'
-#TrackEffMon_rs.FolderName                          = 'Tracking/TrackParameters/TrackEfficiency'
+# from DQM.TrackingMonitor.TrackEfficiencyMonitor_cfi import *
+# TrackEffMon_rs = TrackEffMon.clone(
+#     TKTrackCollection = 'rsWithMaterialTracksP5',
+#     AlgoName = 'RSTk',
+#     FolderName = 'Tracking/TrackParameters/TrackEfficiency'
+# )
 
 # Clone for Beam Halo  Tracks
-import DQM.TrackingMonitor.TrackEfficiencyMonitor_cfi
-TrackEffMon_bhmuon = DQM.TrackingMonitor.TrackEfficiencyMonitor_cfi.TrackEffMon.clone()
-TrackEffMon_bhmuon.TKTrackCollection               = 'ctfWithMaterialTracksBeamHaloMuon'
-TrackEffMon_bhmuon.AlgoName                        = 'BHMuonTk'
-TrackEffMon_bhmuon.FolderName                      = 'Tracking/TrackParameters/TrackEfficiency'
+from DQM.TrackingMonitor.TrackEfficiencyMonitor_cfi import *
+TrackEffMon_bhmuon = TrackEffMon.clone(
+    TKTrackCollection = 'ctfWithMaterialTracksBeamHaloMuon',
+    AlgoName = 'BHMuonTk',
+    FolderName = 'Tracking/TrackParameters/TrackEfficiency'
+)
 
 # Clone for Heavy Ion Tracks (for HI Collisions)
-import DQM.TrackingMonitor.TrackEfficiencyMonitor_cfi
-TrackEffMon_hi = DQM.TrackingMonitor.TrackEfficiencyMonitor_cfi.TrackEffMon.clone()
-TrackEffMon_hi.TKTrackCollection                   = 'hiGeneralTracks'
-TrackEffMon_hi.AlgoName                            = 'HeavyIonTk'
-TrackEffMon_hi.FolderName                          = 'Tracking/TrackParameters/TrackEfficiency'
+from DQM.TrackingMonitor.TrackEfficiencyMonitor_cfi import *
+TrackEffMon_hi = TrackEffMon.clone(
+    TKTrackCollection = 'hiGeneralTracks',
+    AlgoName = 'HeavyIonTk',
+    FolderName = 'Tracking/TrackParameters/TrackEfficiency'
+)

--- a/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_Cosmic_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_Cosmic_cff.py
@@ -2,65 +2,73 @@ import FWCore.ParameterSet.Config as cms
 
 # TrackingMonitor ####
 # Clone for Cosmic Track Finder
-import DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi
-TrackMon_cosmicTk = DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi.TrackerCosmicTrackMon.clone()
-TrackMon_cosmicTk.TrackProducer                    = 'cosmictrackfinderP5'
-TrackMon_cosmicTk.AlgoName                         = 'CosmicTk'
-TrackMon_cosmicTk.FolderName                       = 'Tracking/TrackParameters'
-TrackMon_cosmicTk.doSeedParameterHistos            = True
+from DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi import *
+TrackMon_cosmicTk = TrackerCosmicTrackMon.clone(
+    TrackProducer = 'cosmictrackfinderP5',
+    AlgoName = 'CosmicTk',
+    FolderName = 'Tracking/TrackParameters',
+    doSeedParameterHistos = True
+)
 
 # Clone for CKF Tracks
-import DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi
-TrackMon_ckf = DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi.TrackerCosmicTrackMon.clone()
-TrackMon_ckf.TrackProducer                         = 'ctfWithMaterialTracksP5'
-TrackMon_ckf.AlgoName                              = 'CKFTk'
-TrackMon_ckf.FolderName                            = 'Tracking/TrackParameters'
-TrackMon_ckf.doSeedParameterHistos                 = True
+from DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi import *
+TrackMon_ckf = TrackerCosmicTrackMon.clone(
+    TrackProducer = 'ctfWithMaterialTracksP5',
+    AlgoName = 'CKFTk',
+    FolderName = 'Tracking/TrackParameters',
+    doSeedParameterHistos = True
+)
 
 # Clone for Road Search  Tracks
-#import DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi
-#TrackMon_rs = DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi.TrackerCosmicTrackMon.clone()
-#TrackMon_rs.TrackProducer                          = 'rsWithMaterialTracksP5'
-#TrackMon_rs.AlgoName                               = 'RSTk'
-#TrackMon_rs.FolderName                             = 'Tracking/TrackParameters'
-#TrackMon_rs.doSeedParameterHistos                  = True
+from DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi import *
+TrackMon_rs = TrackerCosmicTrackMon.clone(
+    TrackProducer = 'rsWithMaterialTracksP5',
+    AlgoName = 'RSTk',
+    FolderName = 'Tracking/TrackParameters',
+    doSeedParameterHistos = True
+)
 
 # Clone for Beam Halo Muon Tracks
-import DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi
-TrackMon_bhmuon = DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi.TrackerCosmicTrackMon.clone()
-TrackMon_bhmuon.TrackProducer                      = 'ctfWithMaterialTracksBeamHaloMuon'
-TrackMon_bhmuon.AlgoName                           = 'BHMuonTk'
-TrackMon_bhmuon.FolderName                         = 'Tracking/TrackParameters'
-TrackMon_bhmuon.doSeedParameterHistos              = True
+# from DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi import *
+# TrackMon_bhmuon = TrackerCosmicTrackMon.clone(
+#     TrackProducer = 'ctfWithMaterialTracksBeamHaloMuon',
+#     AlgoName = 'BHMuonTk',
+#     FolderName = 'Tracking/TrackParameters',
+#     doSeedParameterHistos = True
+# )
 
 # Tracking Efficiency
 # Clone for Cosmic Tracks
-import DQM.TrackingMonitor.TrackEfficiencyMonitor_cfi
-TrackEffMon_cosmicTk = DQM.TrackingMonitor.TrackEfficiencyMonitor_cfi.TrackEffMon.clone()
-TrackEffMon_cosmicTk.TKTrackCollection             = 'cosmictrackfinderP5'
-TrackEffMon_cosmicTk.AlgoName                      = 'CosmicTk'
-TrackEffMon_cosmicTk.FolderName                    = 'Tracking/TrackParameters/TrackEfficiency'
+from DQM.TrackingMonitor.TrackEfficiencyMonitor_cfi import *
+TrackEffMon_cosmicTk = TrackEffMon.clone( 
+    TKTrackCollection = 'cosmictrackfinderP5',
+    AlgoName = 'CosmicTk',
+    FolderName = 'Tracking/TrackParameters/TrackEfficiency'
+)
 
 # Clone for CKF Tracks
-import DQM.TrackingMonitor.TrackEfficiencyMonitor_cfi
-TrackEffMon_ckf = DQM.TrackingMonitor.TrackEfficiencyMonitor_cfi.TrackEffMon.clone()
-TrackEffMon_ckf.TKTrackCollection                  = 'ctfWithMaterialTracksP5'
-TrackEffMon_ckf.AlgoName                           = 'CKFTk'
-TrackEffMon_ckf.FolderName                         = 'Tracking/TrackParameters/TrackEfficiency'
+from DQM.TrackingMonitor.TrackEfficiencyMonitor_cfi import *
+TrackEffMon_ckf = TrackEffMon.clone( 
+    TKTrackCollection = 'ctfWithMaterialTracksP5',
+    AlgoName = 'CKFTk',
+    FolderName = 'Tracking/TrackParameters/TrackEfficiency'
+)
 
 # Clone for RS Tracks
-#import DQM.TrackingMonitor.TrackEfficiencyMonitor_cfi
-#TrackEffMon_rs = DQM.TrackingMonitor.TrackEfficiencyMonitor_cfi.TrackEffMon.clone()
-#TrackEffMon_rs.TKTrackCollection                   = 'rsWithMaterialTracksP5'
-#TrackEffMon_rs.AlgoName                            = 'RSTk'
-#TrackEffMon_rs.FolderName                          = 'Tracking/TrackParameters/TrackEfficiency'
+# from DQM.TrackingMonitor.TrackEfficiencyMonitor_cfi import *
+# TrackEffMon_rs = TrackEffMon.clone( 
+#     TKTrackCollection = 'rsWithMaterialTracksP5',
+#     AlgoName = 'RSTk',
+#     FolderName = 'Tracking/TrackParameters/TrackEfficiency'
+# )
 
 # Clone for Beam Halo  Tracks
-import DQM.TrackingMonitor.TrackEfficiencyMonitor_cfi
-TrackEffMon_bhmuon = DQM.TrackingMonitor.TrackEfficiencyMonitor_cfi.TrackEffMon.clone()
-TrackEffMon_bhmuon.TKTrackCollection               = 'ctfWithMaterialTracksBeamHaloMuon'
-TrackEffMon_bhmuon.AlgoName                        = 'BHMuonTk'
-TrackEffMon_bhmuon.FolderName                      = 'Tracking/TrackParameters/TrackEfficiency'
+from DQM.TrackingMonitor.TrackEfficiencyMonitor_cfi import *
+TrackEffMon_bhmuon = TrackEffMon.clone( 
+    TKTrackCollection = 'ctfWithMaterialTracksBeamHaloMuon',
+    AlgoName = 'BHMuonTk',
+    FolderName = 'Tracking/TrackParameters/TrackEfficiency'
+)
 
 # Split Tracking
 from  DQM.TrackingMonitor.TrackSplittingMonitor_cfi import *
@@ -75,10 +83,11 @@ from DQM.TrackingMonitorSource.LogMessageMonitor_cff import *
 
 for module in selectedModules4cosmics :
     label = str(module)+'LogMessageMon'
-    locals()[label] = LogMessageMonCommon.clone()
-    locals()[label].pluginsMonName = pluginsMonName[module]
-    locals()[label].modules        = modulesLabel[module]
-    locals()[label].categories     = categories[module]
+    locals()[label] = LogMessageMonCommon.clone(
+        pluginsMonName = pluginsMonName[module],
+        modules = modulesLabel[module],
+        categories = categories[module]
+    )
     locals()[label].setLabel(label)
 
 # DQM Services

--- a/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_HeavyIons_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_HeavyIons_cff.py
@@ -1,10 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 
 # TrackingMonitor ####
-import DQM.TrackingMonitor.TrackerHeavyIonTrackingMonitor_cfi
-TrackMon_hi = DQM.TrackingMonitor.TrackerHeavyIonTrackingMonitor_cfi.TrackerHeavyIonTrackMon.clone()
-TrackMon_hi.FolderName          = 'Tracking/TrackParameters'
-TrackMon_hi.BSFolderName        = 'Tracking/TrackParameters/BeamSpotParameters'
-TrackMon_hi.TrackProducer = cms.InputTag("hiGeneralTracks")
+from DQM.TrackingMonitor.TrackerHeavyIonTrackingMonitor_cfi import *
+TrackMon_hi = TrackerHeavyIonTrackMon.clone(
+    FolderName = 'Tracking/TrackParameters',
+    BSFolderName = 'Tracking/TrackParameters/BeamSpotParameters',
+    TrackProducer = "hiGeneralTracks"
+)
 
 TrackMonDQMTier0_hi = cms.Sequence(TrackMon_hi)

--- a/DQM/TrackingMonitorSource/python/dEdxAnalyzer_cff.py
+++ b/DQM/TrackingMonitorSource/python/dEdxAnalyzer_cff.py
@@ -2,31 +2,43 @@ import FWCore.ParameterSet.Config as cms
 
 # dEdx monitor ####
 #from DQM.TrackingMonitor.dEdxAnalyzer_cff import *
-import DQM.TrackingMonitor.dEdxAnalyzer_cfi
+from DQM.TrackingMonitor.dEdxAnalyzer_cfi import *
 # Clone for all PDs but ZeroBias ####
-dEdxMonCommon = DQM.TrackingMonitor.dEdxAnalyzer_cfi.dEdxAnalyzer.clone()
+dEdxMonCommon = dEdxAnalyzer.clone()
 
-dEdxHitMonCommon = DQM.TrackingMonitor.dEdxAnalyzer_cfi.dEdxHitAnalyzer.clone()
+dEdxHitMonCommon = dEdxHitAnalyzer.clone()
 
 from DQM.TrackingMonitorSource.pset4GenericTriggerEventFlag_cfi import *
 # Clone for ZeroBias ####
-dEdxMonMB = DQM.TrackingMonitor.dEdxAnalyzer_cfi.dEdxAnalyzer.clone()
-dEdxMonMB.dEdxParameters.genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTdb
+dEdxMonMB = dEdxAnalyzer.clone(
+    dEdxParameters = dEdxAnalyzer.dEdxParameters.clone(
+        genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTdb
+    )
+)
 
-dEdxHitMonMB = DQM.TrackingMonitor.dEdxAnalyzer_cfi.dEdxHitAnalyzer.clone()
-dEdxHitMonMB.dEdxParameters.genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTdb
+dEdxHitMonMB = dEdxHitAnalyzer.clone(
+    dEdxParameters = dEdxHitAnalyzer.dEdxParameters.clone(
+        genericTriggerEventPSet = genericTriggerEventFlag4fullTrackerAndHLTdb
+    )
+)
 
 # Clone for SingleMu ####
-dEdxMonMU = DQM.TrackingMonitor.dEdxAnalyzer_cfi.dEdxAnalyzer.clone()
-dEdxMonMU.dEdxParameters.andOr         = cms.bool( False )
-dEdxMonMU.dEdxParameters.hltInputTag   = cms.InputTag( "TriggerResults::HLT" )
-dEdxMonMU.dEdxParameters.hltPaths      = cms.vstring("HLT_SingleMu40_Eta2p1_*")
-dEdxMonMU.dEdxParameters.errorReplyHlt = cms.bool( False )
-dEdxMonMU.dEdxParameters.andOrHlt      = cms.bool(True) 
+dEdxMonMU = dEdxAnalyzer.clone(
+    dEdxParameters = cms.PSet(
+        andOr = cms.bool(False),
+        hltInputTag = cms.InputTag("TriggerResults::HLT"),
+        hltPaths = cms.vstring("HLT_SingleMu40_Eta2p1_*"),
+        errorReplyHlt = cms.bool(False),
+        andOrHlt = cms.bool(True)
+    )
+)
 
-dEdxHitMonMU = DQM.TrackingMonitor.dEdxAnalyzer_cfi.dEdxHitAnalyzer.clone()
-dEdxHitMonMU.dEdxParameters.andOr         = cms.bool( False )
-dEdxHitMonMU.dEdxParameters.hltInputTag   = cms.InputTag( "TriggerResults::HLT" )
-dEdxHitMonMU.dEdxParameters.hltPaths      = cms.vstring("HLT_SingleMu40_Eta2p1_*")
-dEdxHitMonMU.dEdxParameters.errorReplyHlt = cms.bool( False )
-dEdxHitMonMU.dEdxParameters.andOrHlt      = cms.bool(True) 
+dEdxHitMonMU = dEdxHitAnalyzer.clone(
+    dEdxParameters = cms.PSet(
+        andOr = cms.bool(False),
+        hltInputTag = cms.InputTag("TriggerResults::HLT"),
+        hltPaths = cms.vstring("HLT_SingleMu40_Eta2p1_*"),
+        errorReplyHlt = cms.bool(False),
+        andOrHlt = cms.bool(True)
+    )
+)

--- a/DQM/TrackingMonitorSource/python/dedxHarmonic2monitor_cfi.py
+++ b/DQM/TrackingMonitorSource/python/dedxHarmonic2monitor_cfi.py
@@ -3,16 +3,19 @@ import FWCore.ParameterSet.Config as cms
 selectedDeDxHarm = {}
 
 from RecoTracker.DeDx.dedxEstimators_cff import dedxHarmonic2
-dedxDQMHarm2SP = dedxHarmonic2.clone()
-dedxDQMHarm2SP.tracks                     = cms.InputTag("generalTracks")
-dedxDQMHarm2SP.UseStrip = cms.bool(True)
-dedxDQMHarm2SP.UsePixel = cms.bool(True)
+dedxDQMHarm2SP = dedxHarmonic2.clone(
+    tracks = "generalTracks",
+    UseStrip = True,
+    UsePixel = True
+)
 
-dedxDQMHarm2SO = dedxDQMHarm2SP.clone()
-dedxDQMHarm2SO.UsePixel = cms.bool(False)
+dedxDQMHarm2SO = dedxDQMHarm2SP.clone(
+    UsePixel = False
+)
 
-dedxDQMHarm2PO = dedxDQMHarm2SP.clone()
-dedxDQMHarm2PO.UseStrip = cms.bool(False)
+dedxDQMHarm2PO = dedxDQMHarm2SP.clone(
+    UseStrip = False
+)
 
 dedxHarmonicSequence = cms.Sequence()
 dedxHarmonicSequence+=dedxDQMHarm2SP

--- a/DQM/TrackingMonitorSource/python/pixelTracksMonitoring_cff.py
+++ b/DQM/TrackingMonitorSource/python/pixelTracksMonitoring_cff.py
@@ -1,25 +1,24 @@
 import FWCore.ParameterSet.Config as cms
 
-import DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi
-pixelTracksMonitor = DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi.TrackerCollisionTrackMon.clone()
-pixelTracksMonitor.FolderName                = 'Tracking/PixelTrackParameters/pixelTracks'
-pixelTracksMonitor.TrackProducer             = 'pixelTracks'
-pixelTracksMonitor.allTrackProducer          = 'pixelTracks'
-pixelTracksMonitor.beamSpot                  = 'offlineBeamSpot'
-pixelTracksMonitor.primaryVertex             = 'pixelVertices'
-pixelTracksMonitor.pvNDOF                    = 1
-pixelTracksMonitor.doAllPlots                = False
-pixelTracksMonitor.doLumiAnalysis            = True
-pixelTracksMonitor.doProfilesVsLS            = True
-pixelTracksMonitor.doDCAPlots                = True
-pixelTracksMonitor.doProfilesVsLS            = True
-pixelTracksMonitor.doPlotsVsGoodPVtx         = True
-pixelTracksMonitor.doEffFromHitPatternVsPU   = False
-pixelTracksMonitor.doEffFromHitPatternVsBX   = False
-pixelTracksMonitor.doEffFromHitPatternVsLUMI = False
-pixelTracksMonitor.doPlotsVsGoodPVtx         = True
-pixelTracksMonitor.doPlotsVsLUMI             = True
-pixelTracksMonitor.doPlotsVsBX               = True
+from DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi import *
+pixelTracksMonitor = TrackerCollisionTrackMon.clone(
+    FolderName = 'Tracking/PixelTrackParameters/pixelTracks',
+    TrackProducer = 'pixelTracks',
+    allTrackProducer = 'pixelTracks',
+    beamSpot = 'offlineBeamSpot',
+    primaryVertex = 'pixelVertices',
+    pvNDOF = 1,
+    doAllPlots = False,
+    doLumiAnalysis = True,
+    doProfilesVsLS = True,
+    doDCAPlots = True,
+    doEffFromHitPatternVsPU = False,
+    doEffFromHitPatternVsBX = False,
+    doEffFromHitPatternVsLUMI = False,
+    doPlotsVsGoodPVtx = True,
+    doPlotsVsLUMI = True,
+    doPlotsVsBX = True
+)
 
 _trackSelector = cms.EDFilter('TrackSelector',
     src = cms.InputTag('pixelTracks'),
@@ -78,13 +77,13 @@ for kN,vN in ntuplet.items():
 
 from CommonTools.ParticleFlow.goodOfflinePrimaryVertices_cfi import goodOfflinePrimaryVertices as _goodOfflinePrimaryVertices
 goodPixelVertices = _goodOfflinePrimaryVertices.clone(
-    src = "pixelVertices",
+    src = "pixelVertices"
 )
 
 from DQM.TrackingMonitor.primaryVertexResolution_cfi import primaryVertexResolution as _primaryVertexResolution
 pixelVertexResolution = _primaryVertexResolution.clone(
     vertexSrc = "goodPixelVertices",
-    rootFolder = "OfflinePixelPV/Resolution",
+    rootFolder = "OfflinePixelPV/Resolution"
 )
 
 pixelTracksMonitoringTask = cms.Task(


### PR DESCRIPTION
#### PR description:

Drop type specs in DQM/SiPixelCommon, DQM/SiPixelMonitorTrack, DQM/SiPixelPhase1Common, DQM/SiPixelPhase1Config, DQM/SiPixelPhase1Track/, DQM/SiStripCommissioningSources, DQM/SiStripMonitorClient, DQM/SiStripMonitorCluster, DQM/SiStripMonitorSummary, DQM/SiTrackerPhase2, DQM/TrackerMonitorTrack, DQM/TrackingMonitor, DQM/TrackingMonitorClient and DQM/TrackingMonitorSource configuration files when the clone function mechanism is used.

Details here: [TypeSpecsToDrop_updated.pdf](https://github.com/cms-sw/cmssw/files/7242206/TypeSpecsToDrop_updated.pdf)

@sroychow and @arossi83 are aware and agree.

#### PR validation:

Passed the runTheMatrix.py -l limited -i all --ibeos tests.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

It is not a backport.