### PR TITLE
O2O test setup modified to work across boost version changes

### DIFF
--- a/CondCore/Utilities/interface/Payload2XMLModule.h
+++ b/CondCore/Utilities/interface/Payload2XMLModule.h
@@ -19,6 +19,17 @@ namespace py = pybind11;
       .def(py::init<>())                                                  \
       .def("write", &Payload2xml<CLASS_NAME>::write);
 
+#include <boost/version.hpp>
+namespace cond {
+  std::string boost_version_label(){
+      std::stringstream ss;
+      ss << BOOST_VERSION / 100000 <<".";
+      ss << BOOST_VERSION / 100 % 1000 << ".";
+      ss << BOOST_VERSION % 100;
+      return ss.str();
+  }
+}
+
 namespace {  // Avoid cluttering the global namespace.
 
   template <typename PayloadType>

--- a/CondCore/Utilities/interface/Payload2XMLModule.h
+++ b/CondCore/Utilities/interface/Payload2XMLModule.h
@@ -21,14 +21,14 @@ namespace py = pybind11;
 
 #include <boost/version.hpp>
 namespace cond {
-  std::string boost_version_label(){
-      std::stringstream ss;
-      ss << BOOST_VERSION / 100000 <<".";
-      ss << BOOST_VERSION / 100 % 1000 << ".";
-      ss << BOOST_VERSION % 100;
-      return ss.str();
+  inline std::string boost_version_label() {
+    std::stringstream ss;
+    ss << BOOST_VERSION / 100000 << ".";
+    ss << BOOST_VERSION / 100 % 1000 << ".";
+    ss << BOOST_VERSION % 100;
+    return ss.str();
   }
-}
+}  // namespace cond
 
 namespace {  // Avoid cluttering the global namespace.
 

--- a/CondCore/Utilities/plugins/Module_2XML.cc
+++ b/CondCore/Utilities/plugins/Module_2XML.cc
@@ -2,6 +2,7 @@
 #include "CondCore/Utilities/src/CondFormats.h"
 
 PAYLOAD_2XML_MODULE(pluginUtilities_payload2xml) {
+  m.def("boost_version_label", &cond::boost_version_label, "Get boost version for this release"); \
   PAYLOAD_2XML_CLASS(AlCaRecoTriggerBits);
   PAYLOAD_2XML_CLASS(AlignPCLThresholds);
   PAYLOAD_2XML_CLASS(AlignmentErrors);

--- a/CondCore/Utilities/plugins/Module_2XML.cc
+++ b/CondCore/Utilities/plugins/Module_2XML.cc
@@ -2,7 +2,7 @@
 #include "CondCore/Utilities/src/CondFormats.h"
 
 PAYLOAD_2XML_MODULE(pluginUtilities_payload2xml) {
-  m.def("boost_version_label", &cond::boost_version_label, "Get boost version for this release"); \
+  m.def("boost_version_label", &cond::boost_version_label, "Get boost version for this release");
   PAYLOAD_2XML_CLASS(AlCaRecoTriggerBits);
   PAYLOAD_2XML_CLASS(AlignPCLThresholds);
   PAYLOAD_2XML_CLASS(AlignmentErrors);

--- a/CondCore/Utilities/python/cond2xml.py
+++ b/CondCore/Utilities/python/cond2xml.py
@@ -52,6 +52,10 @@ def localLibName( payloadType ):
         ptype = payloadType.replace('::','_')
     return "%s_%spayload2xml" %(sanitize(ptype),prefix)
 
+def boost_version_for_this_release():
+    import pluginUtilities_payload2xml as mod2XML
+    return mod2XML.boost_version_label()
+
 class CondXmlProcessor(object):
 
     def __init__(self, condDBIn):

--- a/CondCore/Utilities/scripts/conddb
+++ b/CondCore/Utilities/scripts/conddb
@@ -745,7 +745,6 @@ def _get_maxtime_for_boost_version( session, timeType, boost_version):
     time = (maxSince,maxSince,maxSince)
     for r in q:
         r= _rawdict(r)
-        print('## bv %s - r[bv] %s'%(type(boost_version),type(r['boost_version'])))
         if boost_version < r['boost_version']:
             tlumi = r['run_number']<<32|0x1
             time = (r['run_number'],tlumi,r['run_start_time'])

--- a/CondCore/Utilities/scripts/conddb
+++ b/CondCore/Utilities/scripts/conddb
@@ -751,7 +751,7 @@ def _get_maxtime_for_boost_version( session, timeType, boost_version):
             break
     if timeType=='Run':
         return time[0]
-    elif timeType=='Run':
+    elif timeType=='Lumi':
         return time[1]
     elif timeType=='Time':
         return time[2]

--- a/CondCore/Utilities/scripts/conddb
+++ b/CondCore/Utilities/scripts/conddb
@@ -739,6 +739,25 @@ def _get_last_frozen_since( session, tagName, fcsr=None ):
     logging.debug('Last frozen since in destination tag is %s' %res)
     return res
 
+def _get_maxtime_for_boost_version( session, timeType, boost_version):
+    BoostRunMap = session.get_dbtype(conddb.BoostRunMap)
+    q = session.query(BoostRunMap).order_by(BoostRunMap.boost_version.asc())
+    time = (maxSince,maxSince,maxSince)
+    for r in q:
+        r= _rawdict(r)
+        print('## bv %s - r[bv] %s'%(type(boost_version),type(r['boost_version'])))
+        if boost_version < r['boost_version']:
+            tlumi = r['run_number']<<32|0x1
+            time = (r['run_number'],tlumi,r['run_start_time'])
+            break
+    if timeType=='Run':
+        return time[0]
+    elif timeType=='Run':
+        return time[1]
+    elif timeType=='Time':
+        return time[2]
+    return None
+
 class run_to_timestamp( object ):
     def __init__( self, session ):
         self.session = session
@@ -1833,8 +1852,11 @@ def _copy_tag(args, copyTime, session1, session2, first, second, fromIOV=None, t
 
         logging.debug('%s iov(s) to copy with %s payload(s)' %(len(iovs),len(hashes)))
     else:
+        maxTime = _get_maxtime_for_boost_version( session1, tag['time_type'], cond2xml.boost_version_for_this_release())
         query = query.order_by(IOV1.since.desc(), IOV1.insertion_time.desc())
         lastIov = None
+        targetIovSince = None
+        targetIovPayload = None
         for iov in query:
             iov = _rawdict(iov)
             since = iov['since'] 
@@ -1842,9 +1864,13 @@ def _copy_tag(args, copyTime, session1, session2, first, second, fromIOV=None, t
                 lastIov = since
             else:
                 if lastIov != since:
-                    iovs[since] = iov['payload_hash']
-                    hashes.add( iov['payload_hash'] )
-                    break
+                    if targetIovSince is None:
+                        targetIovSince = since
+                    if since < maxTime: 
+                        targetIovPayload = iov['payload_hash']
+                        break
+        iovs[targetIovSince]=targetIovPayload
+        hashes.add(targetIovPayload)
     logfun = logging.info 
     if len(iovs)==0:
         logfun = logging.warning


### PR DESCRIPTION
#### PR description:

The workflows of integration tests for most of the O2Os are currently executed on special sqlite exports of the concerned production Tags, where only the second-last iov is copied.  This choice, implemented with the command "conddb copy --o2oTest", allows to limit the execution time of the O2O workflow to a reasonable time. However, the present implementation fails when the second-last iov points to a payload produced with a boost release incompatible (=more recent) with the underlying release boost version. Typically, this happening in CMSSW branches that are left behind with respect to the last release used in production for the O2Os.
This problem is the cause of issue https://github.com/cms-sw/cmssw/issues/33989

To overcome the problem, the o2oTest option of the function conddb copy has been modified, to select the highest iov in the source tag, pointing to a payload with boost version compatible with the underlying CMSSW release.

The new implementation fixes the above issue.
