### PR TITLE
Tracker phase2 bricked pixel localreco cmssw 12 1 x

### DIFF
--- a/CondFormats/SiPixelTransient/interface/SiPixelUtils.h
+++ b/CondFormats/SiPixelTransient/interface/SiPixelUtils.h
@@ -4,8 +4,8 @@
 namespace SiPixelUtils {
 
   float generic_position_formula(int size,                    //!< Size of this projection.
-                                 int Q_f,                     //!< Charge in the first pixel.
-                                 int Q_l,                     //!< Charge in the last pixel.
+                                 int q_f,                     //!< Charge in the first pixel.
+                                 int q_l,                     //!< Charge in the last pixel.
                                  float upper_edge_first_pix,  //!< As the name says.
                                  float lower_edge_last_pix,   //!< As the name says.
                                  float lorentz_shift,         //!< L-width
@@ -19,12 +19,12 @@ namespace SiPixelUtils {
                                  float size_cut               //!< Use edge when size == cuts
   );
 
-  float bricked_y_position_formula(
+  float generic_position_formula_y_bricked(
       int size,                    //!< Size of this projection.
-      int Q_f,                     //!< Charge in the first pixel.
-      int Q_l,                     //!< Charge in the last pixel.
-      int Q_f_b,                   //!< Charge in pixels that are "dented" compared to the lowest pixel of the cluster.
-      int Q_l_b,                   //!< Charge in pixels that are "dented" compared to the highest pixel of the cluster.
+      int q_f,                     //!< Charge in the first pixel.
+      int q_l,                     //!< Charge in the last pixel.
+      int q_f_b,                   //!< Charge in pixels that are "dented" compared to the lowest pixel of the cluster.
+      int q_l_b,                   //!< Charge in pixels that are "dented" compared to the highest pixel of the cluster.
       float upper_edge_first_pix,  //!< As the name says.
       float lower_edge_last_pix,   //!< As the name says.
       float lorentz_shift,         //!< L-width

--- a/CondFormats/SiPixelTransient/interface/SiPixelUtils.h
+++ b/CondFormats/SiPixelTransient/interface/SiPixelUtils.h
@@ -19,6 +19,24 @@ namespace SiPixelUtils {
                                  float size_cut               //!< Use edge when size == cuts
   );
 
-}
+  float bricked_y_position_formula(
+      int size,                    //!< Size of this projection.
+      int Q_f,                     //!< Charge in the first pixel.
+      int Q_l,                     //!< Charge in the last pixel.
+      int Q_f_b,                   //!< Charge in pixels that are "dented" compared to the lowest pixel of the cluster.
+      int Q_l_b,                   //!< Charge in pixels that are "dented" compared to the highest pixel of the cluster.
+      float upper_edge_first_pix,  //!< As the name says.
+      float lower_edge_last_pix,   //!< As the name says.
+      float lorentz_shift,         //!< L-width
+      float theThickness,          //detector thickness
+      float cot_angle,             //!< cot of alpha_ or beta_
+      float pitch,                 //!< thePitchX or thePitchY
+      bool first_is_big,           //!< true if the first is big
+      bool last_is_big,            //!< true if the last is big
+      float eff_charge_cut_low,    //!< Use edge if > W_eff (in pix) &&&
+      float eff_charge_cut_high,   //!< Use edge if < W_eff (in pix) &&&
+      float size_cut               //!< Use edge when size == cuts
+  );
+}  // namespace SiPixelUtils
 
 #endif

--- a/CondFormats/SiPixelTransient/src/SiPixelUtils.cc
+++ b/CondFormats/SiPixelTransient/src/SiPixelUtils.cc
@@ -28,7 +28,6 @@ namespace SiPixelUtils {
                                  float eff_charge_cut_high,   //!< Use edge if < w_eff  &&&
                                  float size_cut               //!< Use edge when size == cuts
   ) {
-
     float geom_center = 0.5f * (upper_edge_first_pix + lower_edge_last_pix);
 
     //--- The case of only one pixel in this projection is separate.  Note that
@@ -45,7 +44,6 @@ namespace SiPixelUtils {
     //--- Predicted charge width from geometry
     float w_pred = theThickness * cot_angle  // geometric correction (in cm)
                    - lorentz_shift;          // (in cm) &&& check fpix!
-
 
     //--- Total length of the two edge pixels (first+last)
     float sum_of_edge = 2.0f;
@@ -99,13 +97,11 @@ namespace SiPixelUtils {
       float eff_charge_cut_high,   //!< Use edge if < w_eff  &&&
       float size_cut               //!< Use edge when size == cuts
   ) {
-
     float geom_center = 0.5f * (upper_edge_first_pix + lower_edge_last_pix);
 
     //--- The case of only one pixel in this projection is separate.  Note that
     //--- here first_pix == last_pix, so the average of the two is still the
     //--- center of the pixel.
-
 
     //--- Width of the clusters minus the edge (first and last) pixels.
     //--- In the note, they are denoted x_F and x_L (and y_F and y_L)
@@ -114,7 +110,6 @@ namespace SiPixelUtils {
     //--- Predicted charge width from geometry
     float w_pred = theThickness * cot_angle  // geometric correction (in cm)
                    - lorentz_shift;          // (in cm) &&& check fpix!
-
 
     //--- Total length of the two edge pixels (first+last)
     float sum_of_edge = 2.0f;

--- a/CondFormats/SiPixelTransient/src/SiPixelUtils.cc
+++ b/CondFormats/SiPixelTransient/src/SiPixelUtils.cc
@@ -14,8 +14,8 @@ namespace SiPixelUtils {
   //!  are passed by the caller.
   //-----------------------------------------------------------------------------
   float generic_position_formula(int size,                    //!< Size of this projection.
-                                 int q_f,                     //!< Charge in the first pixel.
-                                 int q_l,                     //!< Charge in the last pixel.
+                                 int Q_f,                     //!< Charge in the first pixel.
+                                 int Q_l,                     //!< Charge in the last pixel.
                                  float upper_edge_first_pix,  //!< As the name says.
                                  float lower_edge_last_pix,   //!< As the name says.
                                  float lorentz_shift,         //!< L-shift at half thickness
@@ -24,8 +24,8 @@ namespace SiPixelUtils {
                                  float pitch,                 //!< thePitchX or thePitchY
                                  bool first_is_big,           //!< true if the first is big
                                  bool last_is_big,            //!< true if the last is big
-                                 float eff_charge_cut_low,    //!< Use edge if > w_eff  &&&
-                                 float eff_charge_cut_high,   //!< Use edge if < w_eff  &&&
+                                 float eff_charge_cut_low,    //!< Use edge if > W_eff  &&&
+                                 float eff_charge_cut_high,   //!< Use edge if < W_eff  &&&
                                  float size_cut               //!< Use edge when size == cuts
   ) {
     //cout<<" in PixelCPEGeneric:generic_position_formula - "<<endl; //dk
@@ -41,13 +41,13 @@ namespace SiPixelUtils {
 
     //--- Width of the clusters minus the edge (first and last) pixels.
     //--- In the note, they are denoted x_F and x_L (and y_F and y_L)
-    float w_inner = lower_edge_last_pix - upper_edge_first_pix;  // in cm
+    float W_inner = lower_edge_last_pix - upper_edge_first_pix;  // in cm
 
     //--- Predicted charge width from geometry
-    float w_pred = theThickness * cot_angle  // geometric correction (in cm)
+    float W_pred = theThickness * cot_angle  // geometric correction (in cm)
                    - lorentz_shift;          // (in cm) &&& check fpix!
 
-    //cout << " in PixelCPEGeneric:generic_position_formula - " << w_inner << " " << w_pred << endl;  // dk
+    //cout<<" in PixelCPEGeneric:generic_position_formula - "<<W_inner<<" "<<W_pred<<endl; //dk
 
     //--- Total length of the two edge pixels (first+last)
     float sum_of_edge = 2.0f;
@@ -57,31 +57,108 @@ namespace SiPixelUtils {
       sum_of_edge += 1.0f;
 
     //--- The `effective' charge width -- particle's path in first and last pixels only
-    float w_eff = std::abs(w_pred) - w_inner;
+    float W_eff = std::abs(W_pred) - W_inner;
 
     //--- If the observed charge width is inconsistent with the expectations
-    //--- based on the track, do *not* use w_pred-W_innner.  Instead, replace
+    //--- based on the track, do *not* use W_pred-W_innner.  Instead, replace
     //--- it with an *average* effective charge width, which is the average
     //--- length of the edge pixels.
     //
     //  bool usedEdgeAlgo = false;
-    if ((size >= size_cut) || ((w_eff / pitch < eff_charge_cut_low) | (w_eff / pitch > eff_charge_cut_high))) {
-      w_eff = pitch * 0.5f * sum_of_edge;  // ave. length of edge pixels (first+last) (cm)
+    if ((size >= size_cut) || ((W_eff / pitch < eff_charge_cut_low) | (W_eff / pitch > eff_charge_cut_high))) {
+      W_eff = pitch * 0.5f * sum_of_edge;  // ave. length of edge pixels (first+last) (cm)
                                            //  usedEdgeAlgo = true;
     }
 
     //--- Finally, compute the position in this projection
-    float qdiff = q_l - q_f;
-    float qsum = q_l + q_f;
+    float Qdiff = Q_l - Q_f;
+    float Qsum = Q_l + Q_f;
 
     //--- Temporary fix for clusters with both first and last pixel with charge = 0
-    if (qsum == 0)
-      qsum = 1.0f;
+    if (Qsum == 0)
+      Qsum = 1.0f;
 
-    //float hit_pos = geom_center + 0.5f*(qdiff/qsum) * w_eff + half_lorentz_shift;
-    float hit_pos = geom_center + 0.5f * (qdiff / qsum) * w_eff;
+    //float hit_pos = geom_center + 0.5f*(Qdiff/Qsum) * W_eff + half_lorentz_shift;
+    float hit_pos = geom_center + 0.5f * (Qdiff / Qsum) * W_eff;
 
     return hit_pos;
   }
 
+  float bricked_y_position_formula(
+      int size,                    //!< Size of this projection.
+      int Q_f,                     //!< Charge in the first pixel.
+      int Q_l,                     //!< Charge in the last pixel.
+      int Q_f_b,                   //!< Charge in pixels that are "dented" compared to the lowest pixel of the cluster.
+      int Q_l_b,                   //!< Charge in pixels that are "dented" compared to the highest pixel of the cluster.
+      float upper_edge_first_pix,  //!< As the name says.
+      float lower_edge_last_pix,   //!< As the name says.
+      float lorentz_shift,         //!< L-shift at half thickness
+      float theThickness,          //detector thickness
+      float cot_angle,             //!< cot of alpha_ or beta_
+      float pitch,                 //!< thePitchX or thePitchY
+      bool first_is_big,           //!< true if the first is big
+      bool last_is_big,            //!< true if the last is big
+      float eff_charge_cut_low,    //!< Use edge if > W_eff  &&&
+      float eff_charge_cut_high,   //!< Use edge if < W_eff  &&&
+      float size_cut               //!< Use edge when size == cuts
+  ) {
+    //cout<<" in PixelCPEGeneric:generic_position_formula - "<<endl; //dk
+
+    float geom_center = 0.5f * (upper_edge_first_pix + lower_edge_last_pix);
+
+    //--- The case of only one pixel in this projection is separate.  Note that
+    //--- here first_pix == last_pix, so the average of the two is still the
+    //--- center of the pixel.
+
+    //Make use of the bricked geometry, comment this out
+    //if (size == 1) {
+    //return geom_center;
+    //}
+
+    //--- Width of the clusters minus the edge (first and last) pixels.
+    //--- In the note, they are denoted x_F and x_L (and y_F and y_L)
+    float W_inner = lower_edge_last_pix - upper_edge_first_pix;  // in cm
+
+    //--- Predicted charge width from geometry
+    float W_pred = theThickness * cot_angle  // geometric correction (in cm)
+                   - lorentz_shift;          // (in cm) &&& check fpix!
+
+    //cout<<" in PixelCPEGeneric:generic_position_formula - "<<W_inner<<" "<<W_pred<<endl; //dk
+
+    //--- Total length of the two edge pixels (first+last)
+    float sum_of_edge = 2.0f;
+    if (first_is_big)
+      sum_of_edge += 1.0f;
+    if (last_is_big)
+      sum_of_edge += 1.0f;
+
+    //--- The `effective' charge width -- particle's path in first and last pixels only
+    float W_eff = std::abs(W_pred) - std::abs(W_inner);
+
+    //--- If the observed charge width is inconsistent with the expectations
+    //--- based on the track, do *not* use W_pred-W_innner.  Instead, replace
+    //--- it with an *average* effective charge width, which is the average
+    //--- length of the edge pixels.
+    //
+    //  bool usedEdgeAlgo = false;
+    if ((size >= size_cut) || ((W_eff / pitch < eff_charge_cut_low) | (W_eff / pitch > eff_charge_cut_high))) {
+      W_eff = pitch * 0.5f * sum_of_edge;  // ave. length of edge pixels (first+last) (cm)
+                                           //  usedEdgeAlgo = true;
+    }
+
+    //--- Finally, compute the position in this projection
+    float Qdiff = Q_l - Q_f;
+    float Qsum = Q_l + Q_f;
+    float Q_b_corr = Q_l_b + Q_f_b;
+
+    //--- Temporary fix for clusters with both first and last pixel with charge = 0
+    if (Qsum == 0)
+      Qsum = 1.0f;
+
+    //float hit_pos = geom_center + 0.5f*(Qdiff/Qsum) * W_eff + half_lorentz_shift;
+    float hit_pos =
+        geom_center + 0.5f * (Qdiff / Qsum) * W_eff + 0.5f * (Q_b_corr / Qsum) * W_eff;  //bricked correction
+
+    return hit_pos;
+  }
 }  // namespace SiPixelUtils

--- a/CondFormats/SiPixelTransient/src/SiPixelUtils.cc
+++ b/CondFormats/SiPixelTransient/src/SiPixelUtils.cc
@@ -97,7 +97,7 @@ namespace SiPixelUtils {
       float eff_charge_cut_high,   //!< Use edge if < w_eff  &&&
       float size_cut               //!< Use edge when size == cuts
   ) {
-    float geom_center = 0.5f * (upper_edge_first_pix + lower_edge_last_pix);
+    const auto geom_center = 0.5f * (upper_edge_first_pix + lower_edge_last_pix);
 
     //--- The case of only one pixel in this projection is separate.  Note that
     //--- here first_pix == last_pix, so the average of the two is still the
@@ -105,21 +105,21 @@ namespace SiPixelUtils {
 
     //--- Width of the clusters minus the edge (first and last) pixels.
     //--- In the note, they are denoted x_F and x_L (and y_F and y_L)
-    float w_inner = lower_edge_last_pix - upper_edge_first_pix;  // in cm
+    const auto w_inner = lower_edge_last_pix - upper_edge_first_pix;  // in cm
 
     //--- Predicted charge width from geometry
-    float w_pred = theThickness * cot_angle  // geometric correction (in cm)
+    const auto w_pred = theThickness * cot_angle  // geometric correction (in cm)
                    - lorentz_shift;          // (in cm) &&& check fpix!
 
     //--- Total length of the two edge pixels (first+last)
-    float sum_of_edge = 2.0f;
+    auto sum_of_edge = 2.0f;
     if (first_is_big)
       sum_of_edge += 1.0f;
     if (last_is_big)
       sum_of_edge += 1.0f;
 
     //--- The `effective' charge width -- particle's path in first and last pixels only
-    float w_eff = std::abs(w_pred) - std::abs(w_inner);
+    auto w_eff = std::abs(w_pred) - std::abs(w_inner);
 
     //--- If the observed charge width is inconsistent with the expectations
     //--- based on the track, do *not* use w_pred-w_innner.  Instead, replace
@@ -134,9 +134,9 @@ namespace SiPixelUtils {
     }
 
     //--- Finally, compute the position in this projection
-    float q_diff = q_l - q_f;
-    float q_sum = q_l + q_f;
-    float q_b_corr = q_l_b + q_f_b;
+    const auto q_diff = q_l - q_f;
+    auto q_sum = q_l + q_f;
+    const auto q_b_corr = q_l_b + q_f_b;
 
     //--- Temporary fix for clusters with both first and last pixel with charge = 0
     if (q_sum == 0)

--- a/CondFormats/SiPixelTransient/src/SiPixelUtils.cc
+++ b/CondFormats/SiPixelTransient/src/SiPixelUtils.cc
@@ -14,8 +14,8 @@ namespace SiPixelUtils {
   //!  are passed by the caller.
   //-----------------------------------------------------------------------------
   float generic_position_formula(int size,                    //!< Size of this projection.
-                                 int Q_f,                     //!< Charge in the first pixel.
-                                 int Q_l,                     //!< Charge in the last pixel.
+                                 int q_f,                     //!< Charge in the first pixel.
+                                 int q_l,                     //!< Charge in the last pixel.
                                  float upper_edge_first_pix,  //!< As the name says.
                                  float lower_edge_last_pix,   //!< As the name says.
                                  float lorentz_shift,         //!< L-shift at half thickness
@@ -24,8 +24,8 @@ namespace SiPixelUtils {
                                  float pitch,                 //!< thePitchX or thePitchY
                                  bool first_is_big,           //!< true if the first is big
                                  bool last_is_big,            //!< true if the last is big
-                                 float eff_charge_cut_low,    //!< Use edge if > W_eff  &&&
-                                 float eff_charge_cut_high,   //!< Use edge if < W_eff  &&&
+                                 float eff_charge_cut_low,    //!< Use edge if > w_eff  &&&
+                                 float eff_charge_cut_high,   //!< Use edge if < w_eff  &&&
                                  float size_cut               //!< Use edge when size == cuts
   ) {
     //cout<<" in PixelCPEGeneric:generic_position_formula - "<<endl; //dk
@@ -41,13 +41,13 @@ namespace SiPixelUtils {
 
     //--- Width of the clusters minus the edge (first and last) pixels.
     //--- In the note, they are denoted x_F and x_L (and y_F and y_L)
-    float W_inner = lower_edge_last_pix - upper_edge_first_pix;  // in cm
+    float w_inner = lower_edge_last_pix - upper_edge_first_pix;  // in cm
 
     //--- Predicted charge width from geometry
-    float W_pred = theThickness * cot_angle  // geometric correction (in cm)
+    float w_pred = theThickness * cot_angle  // geometric correction (in cm)
                    - lorentz_shift;          // (in cm) &&& check fpix!
 
-    //cout<<" in PixelCPEGeneric:generic_position_formula - "<<W_inner<<" "<<W_pred<<endl; //dk
+    //cout<<" in PixelCPEGeneric:generic_position_formula - "<<w_inner<<" "<<w_pred<<endl; //dk
 
     //--- Total length of the two edge pixels (first+last)
     float sum_of_edge = 2.0f;
@@ -57,39 +57,39 @@ namespace SiPixelUtils {
       sum_of_edge += 1.0f;
 
     //--- The `effective' charge width -- particle's path in first and last pixels only
-    float W_eff = std::abs(W_pred) - W_inner;
+    float w_eff = std::abs(w_pred) - w_inner;
 
     //--- If the observed charge width is inconsistent with the expectations
-    //--- based on the track, do *not* use W_pred-W_innner.  Instead, replace
+    //--- based on the track, do *not* use w_pred-w_innner.  Instead, replace
     //--- it with an *average* effective charge width, which is the average
     //--- length of the edge pixels.
     //
     //  bool usedEdgeAlgo = false;
-    if ((size >= size_cut) || ((W_eff / pitch < eff_charge_cut_low) | (W_eff / pitch > eff_charge_cut_high))) {
-      W_eff = pitch * 0.5f * sum_of_edge;  // ave. length of edge pixels (first+last) (cm)
+    if ((size >= size_cut) || ((w_eff / pitch < eff_charge_cut_low) | (w_eff / pitch > eff_charge_cut_high))) {
+      w_eff = pitch * 0.5f * sum_of_edge;  // ave. length of edge pixels (first+last) (cm)
                                            //  usedEdgeAlgo = true;
     }
 
     //--- Finally, compute the position in this projection
-    float Qdiff = Q_l - Q_f;
-    float Qsum = Q_l + Q_f;
+    float q_diff = q_l - q_f;
+    float q_sum = q_l + q_f;
 
     //--- Temporary fix for clusters with both first and last pixel with charge = 0
-    if (Qsum == 0)
-      Qsum = 1.0f;
+    if (q_sum == 0)
+      q_sum = 1.0f;
 
-    //float hit_pos = geom_center + 0.5f*(Qdiff/Qsum) * W_eff + half_lorentz_shift;
-    float hit_pos = geom_center + 0.5f * (Qdiff / Qsum) * W_eff;
+    //float hit_pos = geom_center + 0.5f*(q_diff/q_sum) * w_eff + half_lorentz_shift;
+    float hit_pos = geom_center + 0.5f * (q_diff / q_sum) * w_eff;
 
     return hit_pos;
   }
 
-  float bricked_y_position_formula(
+  float generic_position_formula_y_bricked(
       int size,                    //!< Size of this projection.
-      int Q_f,                     //!< Charge in the first pixel.
-      int Q_l,                     //!< Charge in the last pixel.
-      int Q_f_b,                   //!< Charge in pixels that are "dented" compared to the lowest pixel of the cluster.
-      int Q_l_b,                   //!< Charge in pixels that are "dented" compared to the highest pixel of the cluster.
+      int q_f,                     //!< Charge in the first pixel.
+      int q_l,                     //!< Charge in the last pixel.
+      int q_f_b,                   //!< Charge in pixels that are "dented" compared to the lowest pixel of the cluster.
+      int q_l_b,                   //!< Charge in pixels that are "dented" compared to the highest pixel of the cluster.
       float upper_edge_first_pix,  //!< As the name says.
       float lower_edge_last_pix,   //!< As the name says.
       float lorentz_shift,         //!< L-shift at half thickness
@@ -98,8 +98,8 @@ namespace SiPixelUtils {
       float pitch,                 //!< thePitchX or thePitchY
       bool first_is_big,           //!< true if the first is big
       bool last_is_big,            //!< true if the last is big
-      float eff_charge_cut_low,    //!< Use edge if > W_eff  &&&
-      float eff_charge_cut_high,   //!< Use edge if < W_eff  &&&
+      float eff_charge_cut_low,    //!< Use edge if > w_eff  &&&
+      float eff_charge_cut_high,   //!< Use edge if < w_eff  &&&
       float size_cut               //!< Use edge when size == cuts
   ) {
     //cout<<" in PixelCPEGeneric:generic_position_formula - "<<endl; //dk
@@ -117,13 +117,13 @@ namespace SiPixelUtils {
 
     //--- Width of the clusters minus the edge (first and last) pixels.
     //--- In the note, they are denoted x_F and x_L (and y_F and y_L)
-    float W_inner = lower_edge_last_pix - upper_edge_first_pix;  // in cm
+    float w_inner = lower_edge_last_pix - upper_edge_first_pix;  // in cm
 
     //--- Predicted charge width from geometry
-    float W_pred = theThickness * cot_angle  // geometric correction (in cm)
+    float w_pred = theThickness * cot_angle  // geometric correction (in cm)
                    - lorentz_shift;          // (in cm) &&& check fpix!
 
-    //cout<<" in PixelCPEGeneric:generic_position_formula - "<<W_inner<<" "<<W_pred<<endl; //dk
+    //cout<<" in PixelCPEGeneric:generic_position_formula - "<<w_inner<<" "<<w_pred<<endl; //dk
 
     //--- Total length of the two edge pixels (first+last)
     float sum_of_edge = 2.0f;
@@ -133,31 +133,31 @@ namespace SiPixelUtils {
       sum_of_edge += 1.0f;
 
     //--- The `effective' charge width -- particle's path in first and last pixels only
-    float W_eff = std::abs(W_pred) - std::abs(W_inner);
+    float w_eff = std::abs(w_pred) - std::abs(w_inner);
 
     //--- If the observed charge width is inconsistent with the expectations
-    //--- based on the track, do *not* use W_pred-W_innner.  Instead, replace
+    //--- based on the track, do *not* use w_pred-w_innner.  Instead, replace
     //--- it with an *average* effective charge width, which is the average
     //--- length of the edge pixels.
     //
     //  bool usedEdgeAlgo = false;
-    if ((size >= size_cut) || ((W_eff / pitch < eff_charge_cut_low) | (W_eff / pitch > eff_charge_cut_high))) {
-      W_eff = pitch * 0.5f * sum_of_edge;  // ave. length of edge pixels (first+last) (cm)
+    if ((size >= size_cut) || ((w_eff / pitch < eff_charge_cut_low) | (w_eff / pitch > eff_charge_cut_high))) {
+      w_eff = pitch * 0.5f * sum_of_edge;  // ave. length of edge pixels (first+last) (cm)
                                            //  usedEdgeAlgo = true;
     }
 
     //--- Finally, compute the position in this projection
-    float Qdiff = Q_l - Q_f;
-    float Qsum = Q_l + Q_f;
-    float Q_b_corr = Q_l_b + Q_f_b;
+    float q_diff = q_l - q_f;
+    float q_sum = q_l + q_f;
+    float q_b_corr = q_l_b + q_f_b;
 
     //--- Temporary fix for clusters with both first and last pixel with charge = 0
-    if (Qsum == 0)
-      Qsum = 1.0f;
+    if (q_sum == 0)
+      q_sum = 1.0f;
 
-    //float hit_pos = geom_center + 0.5f*(Qdiff/Qsum) * W_eff + half_lorentz_shift;
+    //float hit_pos = geom_center + 0.5f*(q_diff/q_sum) * w_eff + half_lorentz_shift;
     float hit_pos =
-        geom_center + 0.5f * (Qdiff / Qsum) * W_eff + 0.5f * (Q_b_corr / Qsum) * W_eff;  //bricked correction
+        geom_center + 0.5f * (q_diff / q_sum) * w_eff + 0.5f * (q_b_corr / q_sum) * w_eff;  //bricked correction
 
     return hit_pos;
   }

--- a/CondFormats/SiPixelTransient/src/SiPixelUtils.cc
+++ b/CondFormats/SiPixelTransient/src/SiPixelUtils.cc
@@ -109,7 +109,7 @@ namespace SiPixelUtils {
 
     //--- Predicted charge width from geometry
     const auto w_pred = theThickness * cot_angle  // geometric correction (in cm)
-                   - lorentz_shift;          // (in cm) &&& check fpix!
+                        - lorentz_shift;          // (in cm) &&& check fpix!
 
     //--- Total length of the two edge pixels (first+last)
     auto sum_of_edge = 2.0f;

--- a/CondFormats/SiPixelTransient/src/SiPixelUtils.cc
+++ b/CondFormats/SiPixelTransient/src/SiPixelUtils.cc
@@ -141,7 +141,8 @@ namespace SiPixelUtils {
     //--- length of the edge pixels.
     //
     //  bool usedEdgeAlgo = false;
-    if ((size >= size_cut) || ((w_eff / pitch < eff_charge_cut_low) | (w_eff / pitch > eff_charge_cut_high))) {
+    //Modified cut to make use of the w_eff in the bricked geometry
+    if (size >= size_cut) {
       w_eff = pitch * 0.5f * sum_of_edge;  // ave. length of edge pixels (first+last) (cm)
                                            //  usedEdgeAlgo = true;
     }

--- a/CondFormats/SiPixelTransient/src/SiPixelUtils.cc
+++ b/CondFormats/SiPixelTransient/src/SiPixelUtils.cc
@@ -28,7 +28,6 @@ namespace SiPixelUtils {
                                  float eff_charge_cut_high,   //!< Use edge if < w_eff  &&&
                                  float size_cut               //!< Use edge when size == cuts
   ) {
-    //cout<<" in PixelCPEGeneric:generic_position_formula - "<<endl; //dk
 
     float geom_center = 0.5f * (upper_edge_first_pix + lower_edge_last_pix);
 
@@ -47,7 +46,6 @@ namespace SiPixelUtils {
     float w_pred = theThickness * cot_angle  // geometric correction (in cm)
                    - lorentz_shift;          // (in cm) &&& check fpix!
 
-    //cout<<" in PixelCPEGeneric:generic_position_formula - "<<w_inner<<" "<<w_pred<<endl; //dk
 
     //--- Total length of the two edge pixels (first+last)
     float sum_of_edge = 2.0f;
@@ -78,7 +76,6 @@ namespace SiPixelUtils {
     if (q_sum == 0)
       q_sum = 1.0f;
 
-    //float hit_pos = geom_center + 0.5f*(q_diff/q_sum) * w_eff + half_lorentz_shift;
     float hit_pos = geom_center + 0.5f * (q_diff / q_sum) * w_eff;
 
     return hit_pos;
@@ -102,7 +99,6 @@ namespace SiPixelUtils {
       float eff_charge_cut_high,   //!< Use edge if < w_eff  &&&
       float size_cut               //!< Use edge when size == cuts
   ) {
-    //cout<<" in PixelCPEGeneric:generic_position_formula - "<<endl; //dk
 
     float geom_center = 0.5f * (upper_edge_first_pix + lower_edge_last_pix);
 
@@ -110,10 +106,6 @@ namespace SiPixelUtils {
     //--- here first_pix == last_pix, so the average of the two is still the
     //--- center of the pixel.
 
-    //Make use of the bricked geometry, comment this out
-    //if (size == 1) {
-    //return geom_center;
-    //}
 
     //--- Width of the clusters minus the edge (first and last) pixels.
     //--- In the note, they are denoted x_F and x_L (and y_F and y_L)
@@ -123,7 +115,6 @@ namespace SiPixelUtils {
     float w_pred = theThickness * cot_angle  // geometric correction (in cm)
                    - lorentz_shift;          // (in cm) &&& check fpix!
 
-    //cout<<" in PixelCPEGeneric:generic_position_formula - "<<w_inner<<" "<<w_pred<<endl; //dk
 
     //--- Total length of the two edge pixels (first+last)
     float sum_of_edge = 2.0f;
@@ -156,7 +147,6 @@ namespace SiPixelUtils {
     if (q_sum == 0)
       q_sum = 1.0f;
 
-    //float hit_pos = geom_center + 0.5f*(q_diff/q_sum) * w_eff + half_lorentz_shift;
     float hit_pos =
         geom_center + 0.5f * (q_diff / q_sum) * w_eff + 0.5f * (q_b_corr / q_sum) * w_eff;  //bricked correction
 

--- a/Configuration/Eras/python/Era_Phase2C11I13T27M9_cff.py
+++ b/Configuration/Eras/python/Era_Phase2C11I13T27M9_cff.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Phase2C11I13_cff import Phase2C11I13
+from Configuration.Eras.Modifier_phase2_3DPixels_cff import phase2_3DPixels              
+from Configuration.Eras.Modifier_phase2_brickedPixels_cff import phase2_brickedPixels
+from Configuration.Eras.Modifier_phase2_GE0_cff import phase2_GE0
+
+Phase2C11I13T27M9 = cms.ModifierChain(Phase2C11I13, phase2_3DPixels, phase2_brickedPixels, phase2_GE0)

--- a/Configuration/Eras/python/Era_Phase2C11I13T27M9_cff.py
+++ b/Configuration/Eras/python/Era_Phase2C11I13T27M9_cff.py
@@ -1,9 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Phase2C11I13_cff import Phase2C11I13
-from Configuration.Eras.Modifier_phase2_3DPixels_cff import phase2_3DPixels              
-from Configuration.Eras.Modifier_phase2_squarePixels_cff import phase2_squarePixels
 from Configuration.Eras.Modifier_phase2_brickedPixels_cff import phase2_brickedPixels
 from Configuration.Eras.Modifier_phase2_GE0_cff import phase2_GE0
 
-Phase2C11I13T27M9 = cms.ModifierChain(Phase2C11I13, phase2_3DPixels, phase2_squarePixels, phase2_brickedPixels, phase2_GE0)
+Phase2C11I13T27M9 = cms.ModifierChain(Phase2C11I13, phase2_brickedPixels, phase2_GE0)

--- a/Configuration/Eras/python/Era_Phase2C11I13T27M9_cff.py
+++ b/Configuration/Eras/python/Era_Phase2C11I13T27M9_cff.py
@@ -2,7 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Phase2C11I13_cff import Phase2C11I13
 from Configuration.Eras.Modifier_phase2_3DPixels_cff import phase2_3DPixels              
+from Configuration.Eras.Modifier_phase2_squarePixels_cff import phase2_squarePixels
 from Configuration.Eras.Modifier_phase2_brickedPixels_cff import phase2_brickedPixels
 from Configuration.Eras.Modifier_phase2_GE0_cff import phase2_GE0
 
-Phase2C11I13T27M9 = cms.ModifierChain(Phase2C11I13, phase2_3DPixels, phase2_brickedPixels, phase2_GE0)
+Phase2C11I13T27M9 = cms.ModifierChain(Phase2C11I13, phase2_3DPixels, phase2_squarePixels, phase2_brickedPixels, phase2_GE0)

--- a/Configuration/Eras/python/Modifier_phase2_brickedPixels_cff.py
+++ b/Configuration/Eras/python/Modifier_phase2_brickedPixels_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+phase2_brickedPixels = cms.Modifier()

--- a/Configuration/Geometry/python/dict2026Geometry.py
+++ b/Configuration/Geometry/python/dict2026Geometry.py
@@ -427,7 +427,7 @@ trackerDict = {
             'from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *',
             'trackerGeometry.applyAlignment = cms.bool(False)',
         ],
-        "era" : "phase2_tracker, phase2_3DPixels, trackingPhase2PU140",
+        "era" : "phase2_tracker, phase2_3DPixels, phase2_brickedPixels, trackingPhase2PU140",
     }
 }
 

--- a/Configuration/Geometry/python/dict2026Geometry.py
+++ b/Configuration/Geometry/python/dict2026Geometry.py
@@ -427,7 +427,7 @@ trackerDict = {
             'from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *',
             'trackerGeometry.applyAlignment = cms.bool(False)',
         ],
-        "era" : "phase2_tracker, phase2_3DPixels, phase2_brickedPixels, trackingPhase2PU140",
+        "era" : "phase2_tracker, phase2_brickedPixels, trackingPhase2PU140",
     }
 }
 

--- a/Configuration/ProcessModifiers/python/PixelCPEGenericForBricked_cff.py
+++ b/Configuration/ProcessModifiers/python/PixelCPEGenericForBricked_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+# This modifier is to run the Pixel Generic CPE algorithm specialized for bricked pixels in Phase-2 workflows
+PixelCPEGenericForBricked =  cms.Modifier()

--- a/Configuration/ProcessModifiers/python/PixelCPEGenericForBricked_cff.py
+++ b/Configuration/ProcessModifiers/python/PixelCPEGenericForBricked_cff.py
@@ -1,4 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-# This modifier is to run the Pixel Generic CPE algorithm specialized for bricked pixels in Phase-2 workflows
-PixelCPEGenericForBricked =  cms.Modifier()

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1267,8 +1267,9 @@ upgradeProperties[2026] = {
         'Geom' : 'Extended2026D87', # N.B.: Geometry with bricked pixels in the Inner Tracker (+others)
         'HLTmenu': '@fake2',
         'GT' : 'auto:phase2_realistic_T27',
+        'ProcessModifier': 'PixelCPEGenericForBricked',   # This swaps template reco CPE for generic reco CPE specialized for bricked
         'Era' : 'Phase2C11I13T27M9', # customized for bricked pixels and Muon M9
-        'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoLocal'],
+        'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoGlobal', 'HARVESTGlobal'],
     },
 }
 

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1264,11 +1264,11 @@ upgradeProperties[2026] = {
         'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoGlobal', 'HARVESTGlobal'],
     },
     '2026D87' : {
-        'Geom' : 'Extended2026D87', # N.B.: Geometry with 3D pixels in the Inner Tracker L1.
+        'Geom' : 'Extended2026D87', # N.B.: Geometry with bricked pixels in the Inner Tracker (+others)
         'HLTmenu': '@fake2',
         'GT' : 'auto:phase2_realistic_T27',
-        'Era' : 'Phase2C11I13T25M9', # customized for 3D pixels and Muon M9
-        'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger'],
+        'Era' : 'Phase2C11I13T27M9', # customized for bricked pixels and Muon M9
+        'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoLocal'],
     },
 }
 

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1354,7 +1354,6 @@ upgradeProperties[2026] = {
         'Geom' : 'Extended2026D87', # N.B.: Geometry with bricked pixels in the Inner Tracker (+others)
         'HLTmenu': '@fake2',
         'GT' : 'auto:phase2_realistic_T27',
-        'ProcessModifier': 'PixelCPEGenericForBricked',   # This swaps template reco CPE for generic reco CPE specialized for bricked
         'Era' : 'Phase2C11I13T27M9', # customized for bricked pixels and Muon M9
         'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoGlobal', 'HARVESTGlobal'],
     },

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -51,7 +51,8 @@ class Eras (object):
                  'Phase2C11I13T22M9',
                  'Phase2C11I13T23M9',
                  'Phase2C11I13T25M9',
-                 'Phase2C11I13T26M9'
+                 'Phase2C11I13T26M9',
+                 'Phase2C11I13T27M9'
         ]
 
         internalUseMods = ['run2_common', 'run2_25ns_specific',
@@ -68,7 +69,7 @@ class Eras (object):
                            'phase2_hgcal', 'phase2_timing', 'phase2_hfnose', 'phase2_hgcalV10', 'phase2_hgcalV11', 'phase2_hgcalV12',
                            'phase2_timing_layer', 'phase2_etlV4', 'phase2_hcal', 'phase2_ecal','phase2_ecal_devel',
                            'phase2_trigger',
-                           'phase2_squarePixels', 'phase2_3DPixels',
+                           'phase2_squarePixels', 'phase2_3DPixels', 'phase2_brickedPixels',
                            'trackingLowPU', 'trackingPhase1', 'ctpps', 'ctpps_2016', 'ctpps_2017', 'ctpps_2018', 'ctpps_2021', 'trackingPhase2PU140','highBetaStar_2018',
                            'tracker_apv_vfp30_2016', 'pf_badHcalMitigationOff', 'run2_miniAOD_80XLegacy','run2_miniAOD_94XFall17', 'run2_nanoAOD_92X',
                            'run2_nanoAOD_94XMiniAODv1', 'run2_nanoAOD_94XMiniAODv2', 'run2_nanoAOD_94X2016',

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
@@ -152,7 +152,6 @@ void PixelThresholdClusterizer::clusterizeDetUnitT(const T& input,
 
   assert(output.empty());
   //  Loop over all seeds.  TO DO: wouldn't using iterators be faster?
-  //  LogError("PixelThresholdClusterizer") <<  "Starting clusterizing";
   for (unsigned int i = 0; i < theSeeds.size(); i++) {
     // Gavril : The charge of seeds that were already inlcuded in clusters is set to 1 electron
     // so we don't want to call "make_cluster" for these cases
@@ -163,7 +162,6 @@ void PixelThresholdClusterizer::clusterizeDetUnitT(const T& input,
       //  Check if the cluster is above threshold
       // (TO DO: one is signed, other unsigned, gcc warns...)
       if (cluster.charge() >= clusterThreshold) {
-        // LogDebug("clusterizeDetUnit():") << "putting in this cluster" << i << cluster.charge() << cluster.pixelADC().size();
         // sort by row (x)
         output.push_back(std::move(cluster));
         std::push_heap(output.begin(), output.end(), [](SiPixelCluster const& cl1, SiPixelCluster const& cl2) {

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
@@ -102,9 +102,8 @@ bool PixelThresholdClusterizer::setup(const PixelGeomDetUnit* pixDet) {
   theNumOfCols = ncols;
 
   if (nrows > theBuffer.rows() || ncols > theBuffer.columns()) {  // change only when a larger is needed
-    //if( nrows != theNumOfRows || ncols != theNumOfCols ) {
-    //cout << " PixelThresholdClusterizer: pixel buffer redefined to "
-    // << nrows << " * " << ncols << endl;
+    if (nrows != theNumOfRows || ncols != theNumOfCols)
+      edm::LogWarning("setup()") << "pixel buffer redefined to" << nrows << " * " << ncols;
     //theNumOfRows = nrows;  // Set new sizes
     //theNumOfCols = ncols;
     // Resize the buffer
@@ -132,7 +131,8 @@ void PixelThresholdClusterizer::clusterizeDetUnitT(const T& input,
   typename T::const_iterator end = input.end();
 
   // Do not bother for empty detectors
-  //if (begin == end) cout << " PixelThresholdClusterizer::clusterizeDetUnit - No digis to clusterize";
+  if (begin == end)
+    edm::LogWarning("clusterizeDetUnit()") << "No digis to clusterize";
 
   //  Set up the clusterization on this DetId.
   if (!setup(pixDet))
@@ -152,7 +152,7 @@ void PixelThresholdClusterizer::clusterizeDetUnitT(const T& input,
 
   assert(output.empty());
   //  Loop over all seeds.  TO DO: wouldn't using iterators be faster?
-  //  edm::LogError("PixelThresholdClusterizer") <<  "Starting clusterizing" << endl;
+  //  LogError("PixelThresholdClusterizer") <<  "Starting clusterizing";
   for (unsigned int i = 0; i < theSeeds.size(); i++) {
     // Gavril : The charge of seeds that were already inlcuded in clusters is set to 1 electron
     // so we don't want to call "make_cluster" for these cases
@@ -163,7 +163,7 @@ void PixelThresholdClusterizer::clusterizeDetUnitT(const T& input,
       //  Check if the cluster is above threshold
       // (TO DO: one is signed, other unsigned, gcc warns...)
       if (cluster.charge() >= clusterThreshold) {
-        // std::cout << "putting in this cluster " << i << " " << cluster.charge() << " " << cluster.pixelADC().size() << endl;
+        // LogDebug("clusterizeDetUnit():") << "putting in this cluster" << i << cluster.charge() << cluster.pixelADC().size();
         // sort by row (x)
         output.push_back(std::move(cluster));
         std::push_heap(output.begin(), output.end(), [](SiPixelCluster const& cl1, SiPixelCluster const& cl2) {

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
@@ -148,7 +148,8 @@ void PixelThresholdClusterizer::clusterizeDetUnitT(const T& input,
 
   //  Copy PixelDigis to the buffer array; select the seed pixels
   //  on the way, and store them in theSeeds.
-  copy_to_buffer(begin, end);
+  if (end > begin)
+    copy_to_buffer(begin, end);
 
   assert(output.empty());
   //  Loop over all seeds.  TO DO: wouldn't using iterators be faster?

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.h
@@ -54,7 +54,7 @@
 
 #include <vector>
 
-class dso_hidden PixelThresholdClusterizer final : public PixelClusterizerBase {
+class dso_hidden PixelThresholdClusterizer : public PixelClusterizerBase {
 public:
   PixelThresholdClusterizer(edm::ParameterSet const& conf);
   ~PixelThresholdClusterizer() override;
@@ -77,7 +77,7 @@ public:
 
   static void fillPSetDescription(edm::ParameterSetDescription& desc);
 
-private:
+protected:
   template <typename T>
   void clusterizeDetUnitT(const T& input,
                           const PixelGeomDetUnit* pixDet,

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizerForBricked.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizerForBricked.cc
@@ -68,7 +68,8 @@ void PixelThresholdClusterizerForBricked::clusterizeDetUnitT(const T& input,
 
   //  Copy PixelDigis to the buffer array; select the seed pixels
   //  on the way, and store them in theSeeds.
-  copy_to_buffer(begin, end);
+  if (end > begin)
+    copy_to_buffer(begin, end);
 
   assert(output.empty());
   //  Loop over all seeds.  TO DO: wouldn't using iterators be faster?

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizerForBricked.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizerForBricked.cc
@@ -1,0 +1,243 @@
+//----------------------------------------------------------------------------
+//! \class PixelThresholdClusterizerForBricked
+//! \brief A specific threshold-based pixel clustering algorithm
+//!
+//! General logic of PixelThresholdClusterizerForBricked:
+//!
+//! The clusterization is performed on a matrix with size
+//! equal to the size of the pixel detector, each cell containing
+//! the ADC count of the corresponding pixel.
+//! The matrix is reset after each clusterization.
+//!
+//! The search starts from seed pixels, i.e. pixels with sufficiently
+//! large amplitudes, found at the time of filling of the matrix
+//! and stored in a SiPixelArrayBuffer.
+//!
+//! Translate the pixel charge to electrons, we are suppose to
+//! do the calibrations ADC->electrons here.
+//! Modify the thresholds to be in electrons, convert adc to electrons. d.k. 20/3/06
+//! Get rid of the noiseVector. d.k. 28/3/06
+//----------------------------------------------------------------------------
+
+// Our own includes
+#include "PixelThresholdClusterizerForBricked.h"
+#include "SiPixelArrayBuffer.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationOffline.h"
+// Geometry
+#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
+#include "Geometry/CommonTopologies/interface/PixelTopology.h"
+//#include "Geometry/CommonTopologies/RectangularPixelTopology.h"
+
+// STL
+#include <stack>
+#include <vector>
+#include <iostream>
+#include <atomic>
+using namespace std;
+
+//----------------------------------------------------------------------------
+//! Constructor:
+//!  Initilize the buffer to hold pixels from a detector module.
+//!  This is a vector of 44k ints, stays valid all the time.
+//----------------------------------------------------------------------------
+PixelThresholdClusterizerForBricked::PixelThresholdClusterizerForBricked(edm::ParameterSet const& conf)
+    : PixelThresholdClusterizer(conf) {}
+/////////////////////////////////////////////////////////////////////////////
+PixelThresholdClusterizerForBricked::~PixelThresholdClusterizerForBricked() {}
+
+//----------------------------------------------------------------------------
+//!  \brief Cluster pixels.
+//!  This method operates on a matrix of pixels
+//!  and finds the largest contiguous cluster around
+//!  each seed pixel.
+//!  Input and output data stored in DetSet
+//----------------------------------------------------------------------------
+template <typename T>
+void PixelThresholdClusterizerForBricked::clusterizeDetUnitT(const T& input,
+                                                             const PixelGeomDetUnit* pixDet,
+                                                             const TrackerTopology* tTopo,
+                                                             const std::vector<short>& badChannels,
+                                                             edmNew::DetSetVector<SiPixelCluster>::FastFiller& output) {
+  typename T::const_iterator begin = input.begin();
+  typename T::const_iterator end = input.end();
+
+  // Do not bother for empty detectors
+  //if (begin == end) cout << " PixelThresholdClusterizerForBricked::clusterizeDetUnit - No digis to clusterize";
+
+
+  // cout << " PixelThresholdClusterizerForBricked: " << endl;
+  //  Set up the clusterization on this DetId.
+  if (!setup(pixDet))
+    return;
+
+  theDetid = input.detId();
+
+  bool isBarrel = (DetId(theDetid).subdetId() == PixelSubdetector::PixelBarrel);
+  // Set separate cluster threshold for L1 (needed for phase1)
+  auto clusterThreshold = theClusterThreshold;
+  theLayer = (DetId(theDetid).subdetId() == 1) ? tTopo->pxbLayer(theDetid) : 0;
+  if (theLayer == 1)
+    clusterThreshold = theClusterThreshold_L1;
+
+  //  Copy PixelDigis to the buffer array; select the seed pixels
+  //  on the way, and store them in theSeeds.
+  copy_to_buffer(begin, end);
+
+  assert(output.empty());
+  //  Loop over all seeds.  TO DO: wouldn't using iterators be faster?
+  //  edm::LogError("PixelThresholdClusterizerForBricked") <<  "Starting clusterizing" << endl;
+  for (unsigned int i = 0; i < theSeeds.size(); i++) {
+    // Gavril : The charge of seeds that were already inlcuded in clusters is set to 1 electron
+    // so we don't want to call "make_cluster" for these cases
+    if (theBuffer(theSeeds[i]) >= theSeedThreshold) {  // Is this seed still valid?
+      //  Make a cluster around this seed
+
+      SiPixelCluster cluster;
+      if (!(&pixDet->specificTopology())->isBricked()) {
+        cluster = make_cluster(theSeeds[i], output);
+      } else {
+        cluster = make_cluster_bricked(theSeeds[i], output, isBarrel);
+      }
+
+      //  Check if the cluster is above threshold
+      // (TO DO: one is signed, other unsigned, gcc warns...)
+      if (cluster.charge() >= clusterThreshold) {
+        // std::cout << "putting in this cluster " << i << " " << cluster.charge() << " " << cluster.pixelADC().size() << endl;
+        // sort by row (x)
+        output.push_back(std::move(cluster));
+        std::push_heap(output.begin(), output.end(), [](SiPixelCluster const& cl1, SiPixelCluster const& cl2) {
+          return cl1.minPixelRow() < cl2.minPixelRow();
+        });
+      }
+    }
+  }
+  // sort by row (x)   maybe sorting the seed would suffice....
+  std::sort_heap(output.begin(), output.end(), [](SiPixelCluster const& cl1, SiPixelCluster const& cl2) {
+    return cl1.minPixelRow() < cl2.minPixelRow();
+  });
+
+  // Erase the seeds.
+  theSeeds.clear();
+
+  //  Need to clean unused pixels from the buffer array.
+  clear_buffer(begin, end);
+
+  theFakePixels.clear();
+}
+
+//----------------------------------------------------------------------------
+//!  \brief The actual clustering algorithm: group the neighboring pixels around the seed.
+//----------------------------------------------------------------------------
+SiPixelCluster PixelThresholdClusterizerForBricked::make_cluster_bricked(
+    const SiPixelCluster::PixelPos& pix, edmNew::DetSetVector<SiPixelCluster>::FastFiller& output, bool isbarrel) {
+  //First we acquire the seeds for the clusters
+  int seed_adc;
+  stack<SiPixelCluster::PixelPos, vector<SiPixelCluster::PixelPos> > dead_pixel_stack;
+
+  //The individual modules have been loaded into a buffer.
+  //After each pixel has been considered by the clusterizer, we set the adc count to 1
+  //to mark that we have already considered it.
+  //The only difference between dead/noisy pixels and standard ones is that for dead/noisy pixels,
+  //We consider the charge of the pixel to always be zero.
+
+  seed_adc = theBuffer(pix.row(), pix.col());
+
+  theBuffer.set_adc(pix, 1);
+
+  AccretionCluster acluster;
+  acluster.add(pix, seed_adc);
+
+  //Here we search all pixels adjacent to all pixels in the cluster.
+  bool dead_flag = false;
+  while (!acluster.empty()) {
+    //This is the standard algorithm to find and add a pixel
+    auto curInd = acluster.top();
+    acluster.pop();
+
+    for (auto r = std::max(0, int(acluster.x[curInd]) - 1); r < std::min(int(acluster.x[curInd]) + 2, theBuffer.rows());
+         ++r) {
+      int LowerAccLimity = 0;
+      int UpperAccLimity = 0;
+
+      if (r % 2 == int(acluster.x[curInd]) % 2) {
+        LowerAccLimity = std::max(0, int(acluster.y[curInd]) - 1);
+        UpperAccLimity = std::min(int(acluster.y[curInd]) + 2, theBuffer.columns());
+      }
+
+      else {
+        int parity_curr = int(acluster.x[curInd]) % 2;
+        int parity_hit = r % 2;
+
+        LowerAccLimity = std::max(0, int(acluster.y[curInd]) - parity_hit);
+        UpperAccLimity = std::min(int(acluster.y[curInd]) + parity_curr + 1, theBuffer.columns());
+      }
+
+      /*
+	for (auto c = std::max(0, int(acluster.y[curInd]) - 1);
+         c < std::min(int(acluster.y[curInd]) + 2, theBuffer.columns());
+         ++c)*/
+
+      for (auto c = LowerAccLimity; c < UpperAccLimity; ++c) {
+        if (theBuffer(r, c) >= thePixelThreshold) {
+          SiPixelCluster::PixelPos newpix(r, c);
+          if (!acluster.add(newpix, theBuffer(r, c)))
+            goto endClus;
+          //if (isbarrel) {std::cout<<"add "<<r<<" "<<c<<" "<<theBuffer(r,c)<<endl;}
+          theBuffer.set_adc(newpix, 1);
+          //std::cout<<"col "<<c<<" row "<<r<<std::endl;
+        }
+      }
+    }
+
+  }  // while accretion
+endClus:
+  SiPixelCluster cluster(acluster.isize, acluster.adc, acluster.x, acluster.y, acluster.xmin, acluster.ymin);
+  //Here we split the cluster, if the flag to do so is set and we have found a dead or noisy pixel.
+
+  if (dead_flag && doSplitClusters) {
+    // Set separate cluster threshold for L1 (needed for phase1)
+    auto clusterThreshold = theClusterThreshold;
+    if (theLayer == 1)
+      clusterThreshold = theClusterThreshold_L1;
+
+    //Set the first cluster equal to the existing cluster.
+    SiPixelCluster first_cluster = cluster;
+    bool have_second_cluster = false;
+    while (!dead_pixel_stack.empty()) {
+      //consider each found dead pixel
+      SiPixelCluster::PixelPos deadpix = dead_pixel_stack.top();
+      dead_pixel_stack.pop();
+      theBuffer.set_adc(deadpix, 1);
+
+      //Clusterize the split cluster using the dead pixel as a seed
+      SiPixelCluster second_cluster = make_cluster_bricked(deadpix, output, isbarrel);
+
+      //If both clusters would normally have been found by the clusterizer, put them into output
+      if (second_cluster.charge() >= clusterThreshold && first_cluster.charge() >= clusterThreshold) {
+        output.push_back(second_cluster);
+        have_second_cluster = true;
+      }
+
+      //We also want to keep the merged cluster in data and let the RecHit algorithm decide which set to keep
+      //This loop adds the second cluster to the first.
+      const std::vector<SiPixelCluster::Pixel>& branch_pixels = second_cluster.pixels();
+      for (unsigned int i = 0; i < branch_pixels.size(); i++) {
+        int temp_x = branch_pixels[i].x;
+        int temp_y = branch_pixels[i].y;
+        int temp_adc = branch_pixels[i].adc;
+        SiPixelCluster::PixelPos newpix(temp_x, temp_y);
+        cluster.add(newpix, temp_adc);
+      }
+    }
+
+    //Remember to also add the first cluster if we added the second one.
+    if (first_cluster.charge() >= clusterThreshold && have_second_cluster) {
+      output.push_back(first_cluster);
+      std::push_heap(output.begin(), output.end(), [](SiPixelCluster const& cl1, SiPixelCluster const& cl2) {
+        return cl1.minPixelRow() < cl2.minPixelRow();
+      });
+    }
+  }
+
+  return cluster;
+}

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizerForBricked.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizerForBricked.cc
@@ -72,7 +72,6 @@ void PixelThresholdClusterizerForBricked::clusterizeDetUnitT(const T& input,
 
   assert(output.empty());
   //  Loop over all seeds.  TO DO: wouldn't using iterators be faster?
-  //  LogError("PixelThresholdClusterizerForBricked") <<  "Starting clusterizing";
   for (unsigned int i = 0; i < theSeeds.size(); i++) {
     // Gavril : The charge of seeds that were already inlcuded in clusters is set to 1 electron
     // so we don't want to call "make_cluster" for these cases
@@ -88,7 +87,6 @@ void PixelThresholdClusterizerForBricked::clusterizeDetUnitT(const T& input,
       //  Check if the cluster is above threshold
       // (TO DO: one is signed, other unsigned, gcc warns...)
       if (cluster.charge() >= clusterThreshold) {
-        // LogDebug("clusterizeDetUnit():") << "putting in this cluster" << i << cluster.charge() << cluster.pixelADC().size();
         // sort by row (x)
         output.push_back(std::move(cluster));
         std::push_heap(output.begin(), output.end(), [](SiPixelCluster const& cl1, SiPixelCluster const& cl2) {

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizerForBricked.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizerForBricked.h
@@ -1,0 +1,80 @@
+#ifndef RecoLocalTracker_SiPixelClusterizer_PixelThresholdClusterizerForBricked_H
+#define RecoLocalTracker_SiPixelClusterizer_PixelThresholdClusterizerForBricked_H
+
+//-----------------------------------------------------------------------
+//! \class PixelThresholdClusterizerForBricked
+//! \brief An explicit threshold-based clustering algorithm.
+//!
+//! A threshold-based clustering algorithm which clusters SiPixelDigis
+//! into SiPixelClusters for each DetUnit.  The algorithm is straightforward
+//! and purely topological: the clustering process starts with seed pixels
+//! and continues by adding adjacent pixels above the pixel threshold.
+//! Once the cluster is made, it has to be above the cluster threshold as
+//! well.
+//!
+//! The clusterization is performed on a matrix with size
+//! equal to the size of the pixel detector, each cell containing
+//! the ADC count of the corresponding pixel.
+//! The matrix is reset after each clusterization.
+//!
+//! The search starts from seed pixels, i.e. pixels with sufficiently
+//! large amplitudes, found at the time of filling of the matrix
+//! and stored in a
+//!
+//! At this point the noise and dead channels are ignored, but soon they
+//! won't be.
+//!
+//! SiPixelCluster contains a barrycenter, but it should be noted that that
+//! information is largely useless.  One must use a PositionEstimator
+//! class to compute the RecHit position and its error for every given
+//! cluster.
+//!
+//! \author Largely copied from NewPixelClusterizer in ORCA written by
+//!     Danek Kotlinski (PSI).   Ported to CMSSW by Petar Maksimovic (JHU).
+//!     DetSetVector data container implemented by V.Chiochia (Uni Zurich)
+//!
+//! Sets the PixelArrayBuffer dimensions and pixel thresholds.
+//! Makes clusters and stores them in theCache if the option
+//! useCache has been set.
+//-----------------------------------------------------------------------
+
+// Base class, defines SiPixelDigi and SiPixelCluster.  The latter includes
+// Pixel, PixelPos and Shift as inner classes.
+//
+#include "PixelThresholdClusterizer.h"
+
+class dso_hidden PixelThresholdClusterizerForBricked final : public PixelThresholdClusterizer {
+public:
+  PixelThresholdClusterizerForBricked(edm::ParameterSet const& conf);
+  ~PixelThresholdClusterizerForBricked() override;
+
+  // Full I/O in DetSet
+  void clusterizeDetUnit(const edm::DetSet<PixelDigi>& input,
+                         const PixelGeomDetUnit* pixDet,
+                         const TrackerTopology* tTopo,
+                         const std::vector<short>& badChannels,
+                         edmNew::DetSetVector<SiPixelCluster>::FastFiller& output) override {
+    clusterizeDetUnitT(input, pixDet, tTopo, badChannels, output);
+  }
+  void clusterizeDetUnit(const edmNew::DetSet<SiPixelCluster>& input,
+                         const PixelGeomDetUnit* pixDet,
+                         const TrackerTopology* tTopo,
+                         const std::vector<short>& badChannels,
+                         edmNew::DetSetVector<SiPixelCluster>::FastFiller& output) override {
+    clusterizeDetUnitT(input, pixDet, tTopo, badChannels, output);
+  }
+
+private:
+  template <typename T>
+  void clusterizeDetUnitT(const T& input,
+                          const PixelGeomDetUnit* pixDet,
+                          const TrackerTopology* tTopo,
+                          const std::vector<short>& badChannels,
+                          edmNew::DetSetVector<SiPixelCluster>::FastFiller& output);
+
+  SiPixelCluster make_cluster_bricked(const SiPixelCluster::PixelPos& pix,
+                                      edmNew::DetSetVector<SiPixelCluster>::FastFiller& output,
+                                      bool isbarrel);
+};
+
+#endif

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.cc
@@ -14,6 +14,7 @@
 // Our own stuff
 #include "SiPixelClusterProducer.h"
 #include "PixelThresholdClusterizer.h"
+#include "PixelThresholdClusterizerForBricked.h"
 
 // Geometry
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
@@ -141,6 +142,9 @@ void SiPixelClusterProducer::produce(edm::Event& e, const edm::EventSetup& es) {
 void SiPixelClusterProducer::setupClusterizer(const edm::ParameterSet& conf) {
   if (clusterMode_ == "PixelThresholdReclusterizer" || clusterMode_ == "PixelThresholdClusterizer") {
     clusterizer_ = std::make_unique<PixelThresholdClusterizer>(conf);
+    clusterizer_->setSiPixelGainCalibrationService(theSiPixelGainCalibration_.get());
+  } else if (clusterMode_ == "PixelThresholdClusterizerForBricked") {
+    clusterizer_ = std::make_unique<PixelThresholdClusterizerForBricked>(conf);
     clusterizer_->setSiPixelGainCalibrationService(theSiPixelGainCalibration_.get());
   } else {
     throw cms::Exception("Configuration") << "[SiPixelClusterProducer]:"

--- a/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
+++ b/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
@@ -27,6 +27,11 @@ run3_common.toModify(siPixelClusters,
   VCaltoElectronOffset_L1 = 0  
 )
 
+# customize phase2 clusters for bricked pixels
+from Configuration.Eras.Modifier_phase2_brickedPixels_cff import phase2_brickedPixels
+phase2_brickedPixels.toModify(siPixelClusters, 
+                              ClusterMode = cms.string('PixelThresholdClusterizerForBricked')
+)
 
 # Need these until phase2 pixel templates are used
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
@@ -44,3 +49,4 @@ from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
 (premix_stage2 & phase2_tracker).toModify(siPixelClusters,
     src = "mixData:Pixel"
 )
+

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGenericForBricked.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGenericForBricked.h
@@ -42,7 +42,7 @@
 #include <vector>
 
 #if 0
-/** \class PixelCPEGenericForBrocked
+/** \class PixelCPEGenericForBricked
  * Perform the position and error evaluation of pixel hits using
  * the Det angle to estimate the track impact angle
  */

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGenericForBricked.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGenericForBricked.h
@@ -1,5 +1,5 @@
-#ifndef RecoLocalTracker_SiPixelRecHits_PixelCPEGeneric_H
-#define RecoLocalTracker_SiPixelRecHits_PixelCPEGeneric_H
+#ifndef RecoLocalTracker_SiPixelRecHits_PixelCPEGenericForBricked_H
+#define RecoLocalTracker_SiPixelRecHits_PixelCPEGenericForBricked_H
 
 // \class PixelCPEGeneric  -- a generalized CPE reco for the idealized detector
 //
@@ -30,7 +30,7 @@
 // simple, and is described in Morris's note (IN ???) on the generalizaton
 // of the pixel algorithm.
 
-#include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGenericBase.h"
+#include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGeneric.h"
 #include "CalibTracker/SiPixelESProducers/interface/SiPixelCPEGenericDBErrorParametrization.h"
 
 // The template header files
@@ -42,58 +42,37 @@
 #include <vector>
 
 #if 0
-/** \class PixelCPEGeneric
+/** \class PixelCPEGenericForBrocked
  * Perform the position and error evaluation of pixel hits using
  * the Det angle to estimate the track impact angle
  */
 #endif
 
 class MagneticField;
-class PixelCPEGeneric : public PixelCPEGenericBase {
+class PixelCPEGenericForBricked final : public PixelCPEGeneric {
 public:
-  PixelCPEGeneric(edm::ParameterSet const &conf,
-                  const MagneticField *,
-                  const TrackerGeometry &,
-                  const TrackerTopology &,
-                  const SiPixelLorentzAngle *,
-                  const SiPixelGenErrorDBObject *,
-                  const SiPixelLorentzAngle *);
+  PixelCPEGenericForBricked(edm::ParameterSet const& conf,
+                            const MagneticField*,
+                            const TrackerGeometry&,
+                            const TrackerTopology&,
+                            const SiPixelLorentzAngle*,
+                            const SiPixelGenErrorDBObject*,
+                            const SiPixelLorentzAngle*);
 
-  ~PixelCPEGeneric() override = default;
+  ~PixelCPEGenericForBricked() override{};
 
-  static void fillPSetDescription(edm::ParameterSetDescription &desc);
-
-protected:
-  LocalPoint localPosition(DetParam const &theDetParam, ClusterParam &theClusterParam) const override;
-  LocalError localError(DetParam const &theDetParam, ClusterParam &theClusterParam) const override;
-
-  //--------------------------------------------------------------------
-  //  Methods.
-  //------------------------------------------------------------------
-
-  //--- Errors squared in x and y.  &&& Need to be revisited.
-  float err2X(bool &, int &) const;
-  float err2Y(bool &, int &) const;
-
-  //--- Cuts made externally settable
-  float the_eff_charge_cut_lowX;
-  float the_eff_charge_cut_lowY;
-  float the_eff_charge_cut_highX;
-  float the_eff_charge_cut_highY;
-  float the_size_cutX;
-  float the_size_cutY;
-
-  bool inflate_errors;
-  bool inflate_all_errors_no_trk_angle;
-
-  bool DoCosmics_;
-  bool IrradiationBiasCorrection_;
-  bool isUpgrade_;
-  bool NoTemplateErrorsWhenNoTrkAngles_;
-
-  //--- DB Error Parametrization object, new light templates
-  std::vector<SiPixelGenErrorStore> thePixelGenError_;
-  //SiPixelCPEGenericDBErrorParametrization * genErrorsFromDB_;
+private:
+  LocalPoint localPosition(DetParam const& theDetParam, ClusterParam& theClusterParam) const override;
+  static void collect_edge_charges_bricked(ClusterParam& theClusterParam,  //!< input, the cluster
+                                           int& q_f_X,                     //!< output, Q first  in X
+                                           int& q_l_X,                     //!< output, Q last   in X
+                                           int& q_f_Y,                     //!< output, Q first  in Y
+                                           int& q_l_Y,                     //!< output, Q last   in Y
+                                           int& Q_f_b,
+                                           int& Q_l_b,               //Bricked correction
+                                           int& lowest_is_bricked,   //Bricked correction
+                                           int& highest_is_bricked,  //Bricked correction
+                                           bool truncate);
 };
 
 #endif

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
@@ -1,4 +1,5 @@
 #include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGeneric.h"
+#include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGenericForBricked.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
@@ -36,12 +37,13 @@ private:
   edm::ParameterSet pset_;
   bool useLAWidthFromDB_;
   bool UseErrorsFromTemplates_;
+  std::string CPEgenericMode_;  // user's choice of CPE generic
 };
 
 using namespace edm;
 
 PixelCPEGenericESProducer::PixelCPEGenericESProducer(const edm::ParameterSet& p) {
-  std::string myname = p.getParameter<std::string>("ComponentName");
+  CPEgenericMode_ = p.getParameter<std::string>("ComponentName");
   // Use LA-width from DB. If both (upper and this) are false LA-width is calcuated from LA-offset
   useLAWidthFromDB_ = p.getParameter<bool>("useLAWidthFromDB");
   // Use Alignment LA-offset
@@ -55,7 +57,7 @@ PixelCPEGenericESProducer::PixelCPEGenericESProducer(const edm::ParameterSet& p)
   UseErrorsFromTemplates_ = p.getParameter<bool>("UseErrorsFromTemplates");
 
   pset_ = p;
-  auto c = setWhatProduced(this, myname);
+  auto c = setWhatProduced(this, CPEgenericMode_);
   magfieldToken_ = c.consumes(magname);
   pDDToken_ = c.consumes();
   hTTToken_ = c.consumes();
@@ -84,13 +86,22 @@ std::unique_ptr<PixelClusterParameterEstimator> PixelCPEGenericESProducer::produ
     //} else {
     //std::cout<<" pass an empty GenError pointer"<<std::endl;
   }
-  return std::make_unique<PixelCPEGeneric>(pset_,
-                                           &iRecord.get(magfieldToken_),
-                                           iRecord.get(pDDToken_),
-                                           iRecord.get(hTTToken_),
-                                           &iRecord.get(lorentzAngleToken_),
-                                           genErrorDBObjectProduct,
-                                           lorentzAngleWidthProduct);
+
+  return (CPEgenericMode_ == "PixelCPEGenericForBricked")
+             ? std::make_unique<PixelCPEGenericForBricked>(pset_,
+                                                           &iRecord.get(magfieldToken_),
+                                                           iRecord.get(pDDToken_),
+                                                           iRecord.get(hTTToken_),
+                                                           &iRecord.get(lorentzAngleToken_),
+                                                           genErrorDBObjectProduct,
+                                                           lorentzAngleWidthProduct)
+             : std::make_unique<PixelCPEGeneric>(pset_,
+                                                 &iRecord.get(magfieldToken_),
+                                                 iRecord.get(pDDToken_),
+                                                 iRecord.get(hTTToken_),
+                                                 &iRecord.get(lorentzAngleToken_),
+                                                 genErrorDBObjectProduct,
+                                                 lorentzAngleWidthProduct);
 }
 
 void PixelCPEGenericESProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
@@ -56,9 +56,9 @@ from Configuration.Eras.Modifier_phase2_squarePixels_cff import phase2_squarePix
                                                                     )
 # customize phase2 CPE generic for bricked pixels
 from Configuration.Eras.Modifier_phase2_brickedPixels_cff import phase2_brickedPixels
-(phase2_tracker & phase2_brickedPixels ).toModify(PixelCPEGenericESProducer,
-                                                                                                 ComponentName = 'PixelCPEGenericForBricked', # PixelCPEGenericForBricked is derived fromPixelCPEGeneric with changes in some of the methods to deal with bricked pixel topology
-                                                                                                 UseErrorsFromTemplates = False,              # no GenErrors
-                                                                                                 LoadTemplatesFromDB = False,                 # do not load template
-                                                                                   )
+(phase2_tracker & phase2_brickedPixels ).toModify(PixelCPEGenericESProducer, 
+  ComponentName = 'PixelCPEGenericForBricked', # PixelCPEGenericForBricked is derived from PixelCPEGeneric with changes in some of the methods to deal with bricked pixel topology
+  UseErrorsFromTemplates = False,              # no GenErrors
+  LoadTemplatesFromDB = False,                 # do not load template
+                                                  )
 

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
@@ -56,8 +56,7 @@ from Configuration.Eras.Modifier_phase2_squarePixels_cff import phase2_squarePix
                                                                     )
 # customize phase2 CPE generic for bricked pixels
 from Configuration.Eras.Modifier_phase2_brickedPixels_cff import phase2_brickedPixels
-from Configuration.ProcessModifiers.PixelCPEGenericForBricked_cff import PixelCPEGenericForBricked
-(phase2_tracker & (phase2_3DPixels & phase2_brickedPixels & PixelCPEGenericForBricked)).toModify(PixelCPEGenericESProducer,
+(phase2_tracker & phase2_brickedPixels ).toModify(PixelCPEGenericESProducer,
                                                                                                  ComponentName = 'PixelCPEGenericForBricked', # PixelCPEGenericForBricked is derived fromPixelCPEGeneric with changes in some of the methods to deal with bricked pixel topology
                                                                                                  UseErrorsFromTemplates = False,              # no GenErrors
                                                                                                  LoadTemplatesFromDB = False,                 # do not load template

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
@@ -44,9 +44,8 @@ from Configuration.Eras.Modifier_phase2_3DPixels_cff import phase2_3DPixels
 from Configuration.ProcessModifiers.PixelCPEGeneric_cff import PixelCPEGeneric
 (phase2_tracker & (phase2_3DPixels & PixelCPEGeneric)).toModify(PixelCPEGenericESProducer,
                                                                 UseErrorsFromTemplates = False,    # no GenErrors
-                                                                LoadTemplatesFromDB = False,       # do not load templates
+                                                                LoadTemplatesFromDB = False        # do not load templates
                                                                 )
-
 # customize the Pixel CPE generic producer for phase2 square pixels
 # Do use Template errors for square pixels even in the first tracking step
 # This is needed because hardcoded errors in https://github.com/cms-sw/cmssw/blob/master/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc#L113
@@ -55,3 +54,12 @@ from Configuration.Eras.Modifier_phase2_squarePixels_cff import phase2_squarePix
 (phase2_tracker & (phase2_squarePixels | phase2_3DPixels)).toModify(PixelCPEGenericESProducer,
                                                                     NoTemplateErrorsWhenNoTrkAngles = False # use genErrors in the seeding step (when no track angles are available)
                                                                     )
+# customize phase2 CPE generic for bricked pixels
+from Configuration.Eras.Modifier_phase2_brickedPixels_cff import phase2_brickedPixels
+(phase2_tracker & (phase2_3DPixels & phase2_brickedPixels)).toModify(PixelCPEGenericESProducer,
+                                                                                       ComponentName = 'PixelCPEGenericForBricked' # PixelCPEGenericForBricked is derived fromPixelCPEGeneric with changes in some of the methods to deal with bricked pixel topology
+#                                                                                       UseErrorsFromTemplates = False,    # no GenErrors
+#                                                                                       LoadTemplatesFromDB = False,    # do not load templates
+#                                                                                       NoTemplateErrorsWhenNoTrkAngles = False, # use genErrors in the seeding step (when no track angles are available)
+                                                                                   )
+

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
@@ -56,10 +56,10 @@ from Configuration.Eras.Modifier_phase2_squarePixels_cff import phase2_squarePix
                                                                     )
 # customize phase2 CPE generic for bricked pixels
 from Configuration.Eras.Modifier_phase2_brickedPixels_cff import phase2_brickedPixels
-(phase2_tracker & (phase2_3DPixels & phase2_brickedPixels)).toModify(PixelCPEGenericESProducer,
-                                                                                       ComponentName = 'PixelCPEGenericForBricked' # PixelCPEGenericForBricked is derived fromPixelCPEGeneric with changes in some of the methods to deal with bricked pixel topology
-#                                                                                       UseErrorsFromTemplates = False,    # no GenErrors
-#                                                                                       LoadTemplatesFromDB = False,    # do not load templates
-#                                                                                       NoTemplateErrorsWhenNoTrkAngles = False, # use genErrors in the seeding step (when no track angles are available)
+from Configuration.ProcessModifiers.PixelCPEGenericForBricked_cff import PixelCPEGenericForBricked
+(phase2_tracker & (phase2_3DPixels & phase2_brickedPixels & PixelCPEGenericForBricked)).toModify(PixelCPEGenericESProducer,
+                                                                                                 ComponentName = 'PixelCPEGenericForBricked', # PixelCPEGenericForBricked is derived fromPixelCPEGeneric with changes in some of the methods to deal with bricked pixel topology
+                                                                                                 UseErrorsFromTemplates = False,              # no GenErrors
+                                                                                                 LoadTemplatesFromDB = False,                 # do not load template
                                                                                    )
 

--- a/RecoLocalTracker/SiPixelRecHits/python/SiPixelRecHits_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/SiPixelRecHits_cfi.py
@@ -9,6 +9,11 @@ siPixelRecHits = cms.EDProducer("SiPixelRecHitConverter",
     VerboseLevel = cms.untracked.int32(0)
 )
 
+from Configuration.Eras.Modifier_phase2_brickedPixels_cff import phase2_brickedPixels
+phase2_brickedPixels.toModify(siPixelRecHits,
+                              CPE = 'PixelCPEGenericForBricked'
+)
+
 # SwitchProducer wrapping the legacy pixel rechit producer
 siPixelRecHitsPreSplitting = SwitchProducerCUDA(
     cpu = siPixelRecHits.clone(
@@ -44,3 +49,4 @@ gpu.toReplaceWith(siPixelRecHitsPreSplittingTask, cms.Task(
     # SwitchProducer wrapping the legacy pixel rechit producer or the transfer of the pixel rechits to the host and the conversion from SoA
     siPixelRecHitsPreSplittingTask.copy()
 ))
+

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
@@ -21,7 +21,6 @@ using namespace std;
 
 namespace {
   constexpr float micronsToCm = 1.0e-4;
-  const bool MYDEBUG = false;
 }  // namespace
 
 //-----------------------------------------------------------------------------
@@ -77,8 +76,7 @@ PixelCPEGeneric::PixelCPEGeneric(edm::ParameterSet const& conf,
         throw cms::Exception("InvalidCalibrationLoaded")
             << "ERROR: GenErrors not filled correctly. Check the sqlite file. Using SiPixelTemplateDBObject version "
             << (*genErrorDBObject_).version();
-      if (MYDEBUG)
-        cout << "Loaded genErrorDBObject v" << (*genErrorDBObject_).version() << endl;
+      edm::LogInfo("PixelCPEGeneric") << "Loaded genErrorDBObject v" << (*genErrorDBObject_).version();
     } else {  // From file
       if (!SiPixelGenError::pushfile(-999, thePixelGenError_))
         throw cms::Exception("InvalidCalibrationLoaded")
@@ -86,18 +84,19 @@ PixelCPEGeneric::PixelCPEGeneric(edm::ParameterSet const& conf,
     }  // if load from DB
 
   } else {
-    if (MYDEBUG)
-      cout << " Use simple parametrised errors " << endl;
+#ifdef EDM_ML_DEBUG
+    cout << " Use simple parametrised errors " << endl;
+#endif
   }  // if ( useErrorsFromTemplates_ )
 
-  if (MYDEBUG) {
-    cout << "From PixelCPEGeneric::PixelCPEGeneric(...)" << endl;
-    cout << "(int)useErrorsFromTemplates_ = " << (int)useErrorsFromTemplates_ << endl;
-    cout << "truncatePixelCharge_         = " << (int)truncatePixelCharge_ << endl;
-    cout << "IrradiationBiasCorrection_   = " << (int)IrradiationBiasCorrection_ << endl;
-    cout << "(int)DoCosmics_              = " << (int)DoCosmics_ << endl;
-    cout << "(int)LoadTemplatesFromDB_    = " << (int)LoadTemplatesFromDB_ << endl;
-  }
+#ifdef EDM_ML_DEBUG
+  cout << "From PixelCPEGeneric::PixelCPEGeneric(...)" << endl;
+  cout << "(int)useErrorsFromTemplates_ = " << (int)useErrorsFromTemplates_ << endl;
+  cout << "truncatePixelCharge_         = " << (int)truncatePixelCharge_ << endl;
+  cout << "IrradiationBiasCorrection_   = " << (int)IrradiationBiasCorrection_ << endl;
+  cout << "(int)DoCosmics_              = " << (int)DoCosmics_ << endl;
+  cout << "(int)LoadTemplatesFromDB_    = " << (int)LoadTemplatesFromDB_ << endl;
+#endif
 }
 
 //-----------------------------------------------------------------------------
@@ -170,11 +169,9 @@ LocalPoint PixelCPEGeneric::localPosition(DetParam const& theDetParam, ClusterPa
     if (useLAWidthFromGenError) {
       chargeWidthX = (-micronsToCm * gtempl.lorxwidth());
       chargeWidthY = (-micronsToCm * gtempl.lorywidth());
-      if (MYDEBUG)
-        cout << " redefine la width (gen-error) " << chargeWidthX << " " << chargeWidthY << endl;
+      edm::LogInfo("PixelCPE localPosition():") << "redefine la width (gen-error)" << chargeWidthX << chargeWidthY;
     }
-    if (MYDEBUG)
-      cout << " GenError: " << gtemplID_ << endl;
+    edm::LogInfo("PixelCPE localPosition():") << "GenError:" << gtemplID_;
 
     // These numbers come in microns from the qbin(...) call. Transform them to cm.
     theClusterParam.deltax = theClusterParam.deltax * micronsToCm;
@@ -378,19 +375,19 @@ LocalError PixelCPEGeneric::localError(DetParam const& theDetParam, ClusterParam
       useErrorsFromTemplates_ && (!NoTemplateErrorsWhenNoTrkAngles_ || theClusterParam.with_track_angle);
 
   if (int(sizex) != (maxPixelRow - minPixelRow + 1))
-    LogDebug("PixelCPEGeneric") << " wrong x" << endl;
+    LogDebug("PixelCPEGeneric") << " wrong x";
   if (int(sizey) != (maxPixelCol - minPixelCol + 1))
-    LogDebug("PixelCPEGeneric") << " wrong y" << endl;
+    LogDebug("PixelCPEGeneric") << " wrong y";
 
-  LogDebug("PixelCPEGeneric") << " edge clus " << xerr << " " << yerr << endl;  //dk
+  LogDebug("PixelCPEGeneric") << " edge clus " << xerr << " " << yerr;  //dk
   if (bigInX || bigInY)
-    LogDebug("PixelCPEGeneric") << " big " << bigInX << " " << bigInY << endl;
+    LogDebug("PixelCPEGeneric") << " big " << bigInX << " " << bigInY;
   if (edgex || edgey)
-    LogDebug("PixelCPEGeneric") << " edge " << edgex << " " << edgey << endl;
-  LogDebug("PixelCPEGeneric") << " before if " << useErrorsFromTemplates_ << " " << theClusterParam.qBin_ << endl;
+    LogDebug("PixelCPEGeneric") << " edge " << edgex << " " << edgey;
+  LogDebug("PixelCPEGeneric") << " before if " << useErrorsFromTemplates_ << " " << theClusterParam.qBin_;
   if (theClusterParam.qBin_ == 0)
     LogDebug("PixelCPEGeneric") << " qbin 0! " << edgex << " " << edgey << " " << bigInX << " " << bigInY << " "
-                                << sizex << " " << sizey << endl;
+                                << sizex << " " << sizey;
 
   // from PixelCPEGenericBase
   setXYErrors(xerr, yerr, edgex, edgey, sizex, sizey, bigInX, bigInY, useTempErrors, theDetParam, theClusterParam);
@@ -426,9 +423,9 @@ LocalError PixelCPEGeneric::localError(DetParam const& theDetParam, ClusterParam
     throw cms::Exception("PixelCPEGeneric::localError") << "\nERROR: Negative pixel error yerr = " << yerr << "\n\n";
 #endif
 
-  LogDebug("PixelCPEGeneric") << " errors  " << xerr << " " << yerr << endl;  //dk
+  LogDebug("PixelCPEGeneric") << " errors  " << xerr << " " << yerr;  //dk
   if (theClusterParam.qBin_ == 0)
-    LogDebug("PixelCPEGeneric") << " qbin 0 " << xerr << " " << yerr << endl;
+    LogDebug("PixelCPEGeneric") << " qbin 0 " << xerr << " " << yerr;
 
   auto xerr_sq = xerr * xerr;
   auto yerr_sq = yerr * yerr;

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGenericForBricked.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGenericForBricked.cc
@@ -364,7 +364,8 @@ void PixelCPEGenericForBricked::collect_edge_charges_bricked(ClusterParam& theCl
   //bool lowest_is_bricked = 1; //Tells you if the lowest pixel of the cluster is on a bricked row or not.
   //bool highest_is_bricked = 0;
 
-  int q_t_b = 0;  //Sums up the charge of the non-bricked pixels at the top of the clusters in the event that the highest pixel of the cluster is on a bricked row.
+  //Sums up the charge of the non-bricked pixels at the top of the clusters in the event that the highest pixel of the cluster is on a bricked row.
+  int q_t_b = 0;
   int q_t_nb = 0;
   int q_b_b = 0;
   int q_b_nb = 0;

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGenericForBricked.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGenericForBricked.cc
@@ -1,0 +1,461 @@
+#include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGenericForBricked.h"
+
+#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
+#include "Geometry/TrackerGeometryBuilder/interface/RectangularPixelTopology.h"
+#include "DataFormats/DetId/interface/DetId.h"
+
+// Pixel templates contain the rec hit error parameterizaiton
+#include "CondFormats/SiPixelTransient/interface/SiPixelTemplate.h"
+
+// The generic formula
+#include "CondFormats/SiPixelTransient/interface/SiPixelUtils.h"
+
+// Services
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+
+#include "boost/multi_array.hpp"
+
+#include <iostream>
+using namespace std;
+
+namespace {
+  constexpr float micronsToCm = 1.0e-4;
+  const bool MYDEBUG = false;
+}  // namespace
+
+//-----------------------------------------------------------------------------
+//!  The constructor.
+//-----------------------------------------------------------------------------
+PixelCPEGenericForBricked::PixelCPEGenericForBricked(edm::ParameterSet const& conf,
+                                                     const MagneticField* mag,
+                                                     const TrackerGeometry& geom,
+                                                     const TrackerTopology& ttopo,
+                                                     const SiPixelLorentzAngle* lorentzAngle,
+                                                     const SiPixelGenErrorDBObject* genErrorDBObject,
+                                                     const SiPixelLorentzAngle* lorentzAngleWidth = nullptr)
+    : PixelCPEGeneric(conf, mag, geom, ttopo, lorentzAngle, genErrorDBObject, lorentzAngleWidth) {
+  if (theVerboseLevel > 0)
+    LogDebug("PixelCPEGenericForBricked") << " constructing a generic algorithm for ideal pixel detector.\n"
+                                          << " CPEGenericForBricked:: VerboseLevel = " << theVerboseLevel;
+  if (MYDEBUG) {
+    cout << "From PixelCPEGenericForBricked::PixelCPEGenericForBricked(...)" << endl;
+    cout << "(int)useErrorsFromTemplates_ = " << (int)useErrorsFromTemplates_ << endl;
+    cout << "truncatePixelCharge_         = " << (int)truncatePixelCharge_ << endl;
+    cout << "IrradiationBiasCorrection_   = " << (int)IrradiationBiasCorrection_ << endl;
+    cout << "(int)DoCosmics_              = " << (int)DoCosmics_ << endl;
+    cout << "(int)LoadTemplatesFromDB_    = " << (int)LoadTemplatesFromDB_ << endl;
+  }
+}
+
+//-----------------------------------------------------------------------------
+//! Hit position in the local frame (in cm).  Unlike other CPE's, this
+//! one converts everything from the measurement frame (in channel numbers)
+//! into the local frame (in centimeters).
+//-----------------------------------------------------------------------------
+LocalPoint PixelCPEGenericForBricked::localPosition(DetParam const& theDetParam,
+                                                    ClusterParam& theClusterParamBase) const {
+  ClusterParamGeneric& theClusterParam = static_cast<ClusterParamGeneric&>(theClusterParamBase);
+
+  //cout<<" in PixelCPEGenericForBricked:localPosition - "<<endl; //dk
+
+  float chargeWidthX = (theDetParam.lorentzShiftInCmX * theDetParam.widthLAFractionX);
+  float chargeWidthY = (theDetParam.lorentzShiftInCmY * theDetParam.widthLAFractionY);
+  float shiftX = 0.5f * theDetParam.lorentzShiftInCmX;
+  float shiftY = 0.5f * theDetParam.lorentzShiftInCmY;
+
+  //cout<<" main la width "<<chargeWidthX<<" "<<chargeWidthY<<endl;
+
+  if (useErrorsFromTemplates_) {
+    float qclus = theClusterParam.theCluster->charge();
+    float locBz = theDetParam.bz;
+    float locBx = theDetParam.bx;
+    //cout << "PixelCPEGenericForBricked::localPosition(...) : locBz = " << locBz << endl;
+
+    theClusterParam.pixmx = -999;     // max pixel charge for truncation of 2-D cluster
+    theClusterParam.sigmay = -999.9;  // CPE Generic y-error for multi-pixel cluster
+    theClusterParam.deltay = -999.9;  // CPE Generic y-bias for multi-pixel cluster
+    theClusterParam.sigmax = -999.9;  // CPE Generic x-error for multi-pixel cluster
+    theClusterParam.deltax = -999.9;  // CPE Generic x-bias for multi-pixel cluster
+    theClusterParam.sy1 = -999.9;     // CPE Generic y-error for single single-pixel
+    theClusterParam.dy1 = -999.9;     // CPE Generic y-bias for single single-pixel cluster
+    theClusterParam.sy2 = -999.9;     // CPE Generic y-error for single double-pixel cluster
+    theClusterParam.dy2 = -999.9;     // CPE Generic y-bias for single double-pixel cluster
+    theClusterParam.sx1 = -999.9;     // CPE Generic x-error for single single-pixel cluster
+    theClusterParam.dx1 = -999.9;     // CPE Generic x-bias for single single-pixel cluster
+    theClusterParam.sx2 = -999.9;     // CPE Generic x-error for single double-pixel cluster
+    theClusterParam.dx2 = -999.9;     // CPE Generic x-bias for single double-pixel cluster
+
+    SiPixelGenError gtempl(thePixelGenError_);
+    int gtemplID_ = theDetParam.detTemplateId;
+
+    //int gtemplID0 = genErrorDBObject_->getGenErrorID(theDetParam.theDet->geographicalId().rawId());
+    //if(gtemplID0!=gtemplID_) cout<<" different id "<< gtemplID_<<" "<<gtemplID0<<endl;
+
+    theClusterParam.qBin_ = gtempl.qbin(gtemplID_,
+                                        theClusterParam.cotalpha,
+                                        theClusterParam.cotbeta,
+                                        locBz,
+                                        locBx,
+                                        qclus,
+                                        IrradiationBiasCorrection_,
+                                        theClusterParam.pixmx,
+                                        theClusterParam.sigmay,
+                                        theClusterParam.deltay,
+                                        theClusterParam.sigmax,
+                                        theClusterParam.deltax,
+                                        theClusterParam.sy1,
+                                        theClusterParam.dy1,
+                                        theClusterParam.sy2,
+                                        theClusterParam.dy2,
+                                        theClusterParam.sx1,
+                                        theClusterParam.dx1,
+                                        theClusterParam.sx2,
+                                        theClusterParam.dx2);
+
+    // now use the charge widths stored in the new generic template headers (change to the
+    // incorrect sign convention of the base class)
+    bool useLAWidthFromGenError = false;
+    if (useLAWidthFromGenError) {
+      chargeWidthX = (-micronsToCm * gtempl.lorxwidth());
+      chargeWidthY = (-micronsToCm * gtempl.lorywidth());
+      if (MYDEBUG)
+        cout << " redefine la width (gen-error) " << chargeWidthX << " " << chargeWidthY << endl;
+    }
+    if (MYDEBUG)
+      cout << " GenError: " << gtemplID_ << endl;
+
+    // These numbers come in microns from the qbin(...) call. Transform them to cm.
+    theClusterParam.deltax = theClusterParam.deltax * micronsToCm;
+    theClusterParam.dx1 = theClusterParam.dx1 * micronsToCm;
+    theClusterParam.dx2 = theClusterParam.dx2 * micronsToCm;
+
+    theClusterParam.deltay = theClusterParam.deltay * micronsToCm;
+    theClusterParam.dy1 = theClusterParam.dy1 * micronsToCm;
+    theClusterParam.dy2 = theClusterParam.dy2 * micronsToCm;
+
+    theClusterParam.sigmax = theClusterParam.sigmax * micronsToCm;
+    theClusterParam.sx1 = theClusterParam.sx1 * micronsToCm;
+    theClusterParam.sx2 = theClusterParam.sx2 * micronsToCm;
+
+    theClusterParam.sigmay = theClusterParam.sigmay * micronsToCm;
+    theClusterParam.sy1 = theClusterParam.sy1 * micronsToCm;
+    theClusterParam.sy2 = theClusterParam.sy2 * micronsToCm;
+
+  }  // if ( useErrorsFromTemplates_ )
+  else {
+    theClusterParam.qBin_ = 0;
+  }
+
+  int q_f_X;  //!< Q of the first  pixel  in X
+  int q_l_X;  //!< Q of the last   pixel  in X
+  int q_f_Y;  //!< Q of the first  pixel  in Y
+  int q_l_Y;  //!< Q of the last   pixel  in Y
+  int q_f_b;  // Q first bricked: charge of the dented row at the bootom of a cluster
+  int q_l_b;  // Same but at the top of the cluster
+  int lowest_is_bricked = 1;
+  int highest_is_bricked = 0;
+
+  std::cout << theDetParam.theDet->geographicalId().rawId() << " " << theDetParam.theTopol->isBricked() << std::endl;
+
+  if (theDetParam.theTopol->isBricked()) {
+    collect_edge_charges_bricked(theClusterParam,
+                                 q_f_X,
+                                 q_l_X,
+                                 q_f_Y,
+                                 q_l_Y,
+                                 q_f_b,
+                                 q_l_b,
+                                 lowest_is_bricked,
+                                 highest_is_bricked,
+                                 useErrorsFromTemplates_ && truncatePixelCharge_);
+  } else {
+    collect_edge_charges(theClusterParam, q_f_X, q_l_X, q_f_Y, q_l_Y, useErrorsFromTemplates_ && truncatePixelCharge_);
+  }
+
+  //--- Find the inner widths along X and Y in one shot.  We
+  //--- compute the upper right corner of the inner pixels
+  //--- (== lower left corner of upper right pixel) and
+  //--- the lower left corner of the inner pixels
+  //--- (== upper right corner of lower left pixel), and then
+  //--- subtract these two points in the formula.
+
+  //--- Upper Right corner of Lower Left pixel -- in measurement frame
+  MeasurementPoint meas_URcorn_LLpix(theClusterParam.theCluster->minPixelRow() + 1.0,
+                                     theClusterParam.theCluster->minPixelCol() + 1.0);
+  //--- Lower Left corner of Upper Right pixel -- in measurement frame
+  MeasurementPoint meas_LLcorn_URpix(theClusterParam.theCluster->maxPixelRow(),
+                                     theClusterParam.theCluster->maxPixelCol());
+  if (theDetParam.theTopol->isBricked()) {
+    if (lowest_is_bricked)
+      meas_URcorn_LLpix = MeasurementPoint(theClusterParam.theCluster->minPixelRow() + 1.0,
+                                           theClusterParam.theCluster->minPixelCol() + 1.5);
+    if (highest_is_bricked)
+      meas_LLcorn_URpix =
+          MeasurementPoint(theClusterParam.theCluster->maxPixelRow(), theClusterParam.theCluster->maxPixelCol() + 0.5);
+  }
+
+  //--- These two now converted into the local
+  LocalPoint local_URcorn_LLpix;
+  LocalPoint local_LLcorn_URpix;
+
+  // PixelCPEGenericForBricked can be used with or without track angles
+  // If PixelCPEGenericForBricked is called with track angles, use them to correct for bows/kinks:
+  if (theClusterParam.with_track_angle) {
+    local_URcorn_LLpix = theDetParam.theTopol->localPosition(meas_URcorn_LLpix, theClusterParam.loc_trk_pred);
+    local_LLcorn_URpix = theDetParam.theTopol->localPosition(meas_LLcorn_URpix, theClusterParam.loc_trk_pred);
+  } else {
+    local_URcorn_LLpix = theDetParam.theTopol->localPosition(meas_URcorn_LLpix);
+    local_LLcorn_URpix = theDetParam.theTopol->localPosition(meas_LLcorn_URpix);
+  }
+
+#ifdef EDM_ML_DEBUG
+  if (theVerboseLevel > 0) {
+    cout << "\n\t >>> theClusterParam.theCluster->x = " << theClusterParam.theCluster->x()
+         << "\n\t >>> theClusterParam.theCluster->y = " << theClusterParam.theCluster->y()
+         << "\n\t >>> cluster: minRow = " << theClusterParam.theCluster->minPixelRow()
+         << "  minCol = " << theClusterParam.theCluster->minPixelCol()
+         << "\n\t >>> cluster: maxRow = " << theClusterParam.theCluster->maxPixelRow()
+         << "  maxCol = " << theClusterParam.theCluster->maxPixelCol()
+         << "\n\t >>> meas: inner lower left  = " << meas_URcorn_LLpix.x() << "," << meas_URcorn_LLpix.y()
+         << "\n\t >>> meas: inner upper right = " << meas_LLcorn_URpix.x() << "," << meas_LLcorn_URpix.y() << endl;
+  }
+#endif
+
+  //--- &&& Note that the cuts below should not be hardcoded (like in Orca and
+  //--- &&& CPEFromDetPosition/PixelCPEInitial), but rather be
+  //--- &&& externally settable (but tracked) parameters.
+
+  //--- Position, including the half lorentz shift
+
+#ifdef EDM_ML_DEBUG
+  if (theVerboseLevel > 0)
+    cout << "\t >>> Generic:: processing X" << endl;
+#endif
+
+  float xPos = SiPixelUtils::generic_position_formula(
+      theClusterParam.theCluster->sizeX(),
+      q_f_X,
+      q_l_X,
+      local_URcorn_LLpix.x(),
+      local_LLcorn_URpix.x(),
+      chargeWidthX,  // lorentz shift in cm
+      theDetParam.theThickness,
+      theClusterParam.cotalpha,
+      theDetParam.thePitchX,
+      theDetParam.theRecTopol->isItBigPixelInX(theClusterParam.theCluster->minPixelRow()),
+      theDetParam.theRecTopol->isItBigPixelInX(theClusterParam.theCluster->maxPixelRow()),
+      the_eff_charge_cut_lowX,
+      the_eff_charge_cut_highX,
+      the_size_cutX);  // cut for eff charge width &&&
+
+  // apply the lorentz offset correction
+  xPos = xPos + shiftX;
+
+#ifdef EDM_ML_DEBUG
+  if (theVerboseLevel > 0)
+    cout << "\t >>> Generic:: processing Y" << endl;
+#endif
+
+  // staggering pf the pixel cells allowed along local-Y direction only
+  float yPos;
+  if (theDetParam.theTopol->isBricked()) {
+    yPos = SiPixelUtils::bricked_y_position_formula(
+        theClusterParam.theCluster->sizeY(),
+        q_f_Y,
+        q_l_Y,
+        q_f_b,
+        q_l_b,
+        local_URcorn_LLpix.y(),
+        local_LLcorn_URpix.y(),
+        chargeWidthY,  // lorentz shift in cm
+        theDetParam.theThickness,
+        theClusterParam.cotbeta,
+        theDetParam.thePitchY,
+        theDetParam.theRecTopol->isItBigPixelInY(theClusterParam.theCluster->minPixelCol()),
+        theDetParam.theRecTopol->isItBigPixelInY(theClusterParam.theCluster->maxPixelCol()),
+        the_eff_charge_cut_lowY,
+        the_eff_charge_cut_highY,
+        the_size_cutY);  // cut for eff charge width &&&
+  } else {
+    yPos = SiPixelUtils::generic_position_formula(
+        theClusterParam.theCluster->sizeY(),
+        q_f_Y,
+        q_l_Y,
+        local_URcorn_LLpix.y(),
+        local_LLcorn_URpix.y(),
+        chargeWidthY,  // lorentz shift in cm
+        theDetParam.theThickness,
+        theClusterParam.cotbeta,
+        theDetParam.thePitchY,
+        theDetParam.theRecTopol->isItBigPixelInY(theClusterParam.theCluster->minPixelCol()),
+        theDetParam.theRecTopol->isItBigPixelInY(theClusterParam.theCluster->maxPixelCol()),
+        the_eff_charge_cut_lowY,
+        the_eff_charge_cut_highY,
+        the_size_cutY);  // cut for eff charge width &&&
+  }
+
+  // apply the lorentz offset correction
+  yPos = yPos + shiftY;
+
+  // Apply irradiation corrections
+  if (IrradiationBiasCorrection_) {
+    if (theClusterParam.theCluster->sizeX() == 1) {  // size=1
+      // ggiurgiu@jhu.edu, 02/03/09 : for size = 1, the Lorentz shift is already accounted by the irradiation correction
+      //float tmp1 =  (0.5 * theDetParam.lorentzShiftInCmX);
+      //cout << "Apply correction correction_dx1 = " << theClusterParam.dx1 << " to xPos = " << xPos;
+      xPos = xPos - (0.5f * theDetParam.lorentzShiftInCmX);
+      // Find if pixel is double (big).
+      bool bigInX = theDetParam.theRecTopol->isItBigPixelInX(theClusterParam.theCluster->maxPixelRow());
+      if (!bigInX)
+        xPos -= theClusterParam.dx1;
+      else
+        xPos -= theClusterParam.dx2;
+      //cout<<" to "<<xPos<<" "<<(tmp1+theClusterParam.dx1)<<endl;
+    } else {  // size>1
+      //cout << "Apply correction correction_deltax = " << theClusterParam.deltax << " to xPos = " << xPos;
+      xPos -= theClusterParam.deltax;
+      //cout<<" to "<<xPos<<endl;
+    }
+
+    if (theClusterParam.theCluster->sizeY() == 1) {
+      // ggiurgiu@jhu.edu, 02/03/09 : for size = 1, the Lorentz shift is already accounted by the irradiation correction
+      yPos = yPos - (0.5f * theDetParam.lorentzShiftInCmY);
+
+      // Find if pixel is double (big).
+      bool bigInY = theDetParam.theRecTopol->isItBigPixelInY(theClusterParam.theCluster->maxPixelCol());
+      if (!bigInY)
+        yPos -= theClusterParam.dy1;
+      else
+        yPos -= theClusterParam.dy2;
+
+    } else {
+      //cout << "Apply correction correction_deltay = " << theClusterParam.deltay << " to yPos = " << yPos << endl;
+      yPos -= theClusterParam.deltay;
+    }
+
+  }  // if ( IrradiationBiasCorrection_ )
+
+  //cout<<" in PixelCPEGenericForBricked:localPosition - pos = "<<xPos<<" "<<yPos<<endl; //dk
+
+  //--- Now put the two together
+  LocalPoint pos_in_local(xPos, yPos);
+  return pos_in_local;
+}
+
+void PixelCPEGenericForBricked::collect_edge_charges_bricked(ClusterParam& theClusterParamBase,  //!< input, the cluster
+                                                             int& Q_f_X,  //!< output, Q first  in X
+                                                             int& Q_l_X,  //!< output, Q last   in X
+                                                             int& Q_f_Y,  //!< output, Q first  in Y
+                                                             int& Q_l_Y,  //!< output, Q last   in Y
+                                                             int& Q_f_b,
+                                                             int& Q_l_b,               //Bricked correction
+                                                             int& lowest_is_bricked,   //Bricked correction
+                                                             int& highest_is_bricked,  //Bricked correction
+                                                             bool truncate) {
+  ClusterParamGeneric& theClusterParam = static_cast<ClusterParamGeneric&>(theClusterParamBase);
+
+  // FIXME: the latest version of collect_edge_charges() has a boolean arg based on ErrorsFromTemplates_ && TruncatePixelCharge_
+  // Initialize return variables.
+  Q_f_X = Q_l_X = 0.0;
+  Q_f_Y = Q_l_Y = 0.0;
+  Q_f_b = Q_l_b = 0.0;
+
+  // Obtain boundaries in index units
+  int xmin = theClusterParam.theCluster->minPixelRow();
+  int xmax = theClusterParam.theCluster->maxPixelRow();
+  int ymin = theClusterParam.theCluster->minPixelCol();
+  int ymax = theClusterParam.theCluster->maxPixelCol();
+
+  //bool lowest_is_bricked = 1; //Tells you if the lowest pixel of the cluster is on a bricked row or not.
+  //bool highest_is_bricked = 0;
+
+  int Q_t_b =
+      0;  //Sums up the charge of the non-bricked pixels at the top of the clusters in the event that the highest pixel of the cluster is on a bricked row.
+  int Q_t_nb = 0;
+  int Q_b_b = 0;
+  int Q_b_nb = 0;
+
+  //This is included in the main loop.
+  // Iterate over the pixels to find out if a bricked row is lowest/highest.
+  /*  int isize = theClusterParam.theCluster->size();
+  for (int i = 0; i != isize; ++i) {
+    auto const& pixel = theClusterParam.theCluster->pixel(i);
+
+    // Y projection
+    if (pixel.y == ymin && !(pixel.x%2) ) lowest_is_bricked = 0;
+    if (pixel.y == ymax && (pixel.x%2) ) highest_is_bricked = 1;
+  } */
+
+  // Iterate over the pixels.
+  int isize = theClusterParam.theCluster->size();
+  for (int i = 0; i != isize; ++i) {
+    //std::cout<<i<<"clust i"<<std::endl;
+    auto const& pixel = theClusterParam.theCluster->pixel(i);
+    // ggiurgiu@fnal.gov: add pixel charge truncation
+    int pix_adc = pixel.adc;
+    if (truncate)
+      pix_adc = std::min(pix_adc, theClusterParam.pixmx);
+    //std::cout<<pix_adc<<"adc i"<<std::endl;
+
+    //
+    // X projection
+    if (pixel.x == xmin)
+      Q_f_X += pix_adc;
+    if (pixel.x == xmax)
+      Q_l_X += pix_adc;
+    //
+    // Y projection
+    if (pixel.y == ymin) {
+      Q_f_Y += pix_adc;
+      if (pixel.x % 2)
+        Q_b_nb += pix_adc;
+      else
+        lowest_is_bricked = 0;
+    }
+
+    if (pixel.y == ymin + 1 && !(pixel.x % 2))
+      Q_b_b += pix_adc;
+
+    if (pixel.y == ymax) {
+      Q_l_Y += pix_adc;
+      if (!(pixel.x % 2))
+        Q_t_b += pix_adc;
+      else
+        highest_is_bricked = 1;
+    }
+
+    if (pixel.y == ymax - 1 && (pixel.x % 2))
+      Q_t_nb += pix_adc;
+  }
+
+  //std::cout<<lowest_is_bricked<<" it  "<<highest_is_bricked<<std::endl;
+
+  if (lowest_is_bricked)
+    Q_f_b = Q_b_b;
+  else
+    Q_f_b = Q_b_nb;
+
+  if (highest_is_bricked)
+    Q_l_b = -Q_t_b;
+  else
+    Q_l_b = -Q_t_nb;
+
+  //Need to add the edge pixels that were missed:
+  for (int i = 0; i != isize; ++i) {
+    auto const& pixel = theClusterParam.theCluster->pixel(i);
+    int pix_adc = pixel.adc;
+    if (truncate)
+      pix_adc = std::min(pix_adc, theClusterParam.pixmx);
+
+    if (lowest_is_bricked && pixel.y == ymin + 1 && !(pixel.x % 2))
+      Q_f_Y += pix_adc;
+
+    if (!highest_is_bricked && pixel.y == ymax - 1 && (pixel.x % 2))
+      Q_l_Y += pix_adc;
+
+    //std::cout<<Q_l_b<<" "<<Q_f_b<<" "<<Q_f_X<<" "<<Q_l_X<<" "<<Q_f_Y<<" "<<Q_l_Y<<" Qlb"<<std::endl;
+
+    return;
+  }
+}

--- a/RecoTracker/MeasurementDet/python/MeasurementTrackerESProducer_cfi.py
+++ b/RecoTracker/MeasurementDet/python/MeasurementTrackerESProducer_cfi.py
@@ -6,3 +6,7 @@ MeasurementTracker = _MeasurementTrackerESProducer_default.clone()
 
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
 trackingPhase2PU140.toModify(MeasurementTracker, Phase2StripCPE = 'Phase2StripCPE')
+
+from Configuration.Eras.Modifier_phase2_brickedPixels_cff import phase2_brickedPixels
+phase2_brickedPixels.toModify(MeasurementTracker, PixelCPE = cms.string('PixelCPEGenericForBricked'))
+

--- a/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
@@ -18,3 +18,7 @@ phase1Pixel.toModify(TTRHBuilderAngleAndTemplate, PixelCPE = 'PixelCPEClusterRep
 # Turn off template reco for phase 2 (when not supported)
 from Configuration.ProcessModifiers.PixelCPEGeneric_cff import PixelCPEGeneric
 PixelCPEGeneric.toModify(TTRHBuilderAngleAndTemplate, PixelCPE = 'PixelCPEGeneric')
+
+from Configuration.ProcessModifiers.PixelCPEGenericForBricked_cff import PixelCPEGenericForBricked
+PixelCPEGenericForBricked.toModify(TTRHBuilderAngleAndTemplate, PixelCPE = 'PixelCPEGenericForBricked')
+

--- a/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
@@ -19,6 +19,6 @@ phase1Pixel.toModify(TTRHBuilderAngleAndTemplate, PixelCPE = 'PixelCPEClusterRep
 from Configuration.ProcessModifiers.PixelCPEGeneric_cff import PixelCPEGeneric
 PixelCPEGeneric.toModify(TTRHBuilderAngleAndTemplate, PixelCPE = 'PixelCPEGeneric')
 
-from Configuration.ProcessModifiers.PixelCPEGenericForBricked_cff import PixelCPEGenericForBricked
-PixelCPEGenericForBricked.toModify(TTRHBuilderAngleAndTemplate, PixelCPE = 'PixelCPEGenericForBricked')
+from Configuration.Eras.Modifier_phase2_brickedPixels_cff import phase2_brickedPixels
+phase2_brickedPixels.toModify(TTRHBuilderAngleAndTemplate, PixelCPE = 'PixelCPEGenericForBricked')
 

--- a/RecoTracker/TransientTrackingRecHit/python/TransientTrackingRecHitBuilder_cfi.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TransientTrackingRecHitBuilder_cfi.py
@@ -11,3 +11,6 @@ ttrhbwr = cms.ESProducer("TkTransientTrackingRecHitBuilderESProducer",
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
 trackingPhase2PU140.toModify(ttrhbwr, Phase2StripCPE = cms.string('Phase2StripCPE'))
 
+from Configuration.Eras.Modifier_phase2_brickedPixels_cff import phase2_brickedPixels
+phase2_brickedPixels.toModify(ttrhbwr, PixelCPE = cms.string('PixelCPEGenericForBricked'))
+


### PR DESCRIPTION

![resZ_AbsEta](https://user-images.githubusercontent.com/57264803/135068982-8b2d993a-1902-445d-b92c-db888999a5c8.png)
#### PR description:

Update phase-2 Tracker local reconstruction framework to include clusterizer and CPE algorithms for the Inner Tracker (IT).
Configurations with bricked pixels were introduced in CMSSW with PR#34120 (geometry) and PR#35173 (digitizer).

Clusterizer and CPE are implemented as classes derived from the current PixelThresholdClusterizer and PixelCPEGeneric classes with specialized methods for bricked pixels.
The algorithms are activated for the phase-2 tracker geometry T27 containing bricked pixels in TEPX&TFPX, as well as the central 1 (3) module(s) of TBPX L2 (L3 and L4).

Tracking step added following the same approach used for T22 (

using CPE generic algo everywhere in the InnerTracker).

#### PR validation:


Specific validation done using FourMuExtendedPt_1_200 events: runTheMatrix workflow 36210.0 (T25 reference) and 39010.0 (T27 proposed). This generated cfg files which were modified: the Muon pT was chosen to be between 199 and 200 and samples of size 5000 were used for creating the attached plots (using phase2_reco_pixelntuple_cfg.py)
Verified that the PR passes the basic test procedure suggested in the CMSSW PR instructions

The following plots show that the hits are correctly reconstructed according to the bricked geometry. The residues in Y become better with an increasing size in X for both the barrel and the endcaps. The endcap plots have a _EC.png appendix. All other plots come from the analysis of the hits in the bricked region (layer 2, eta < 0.35 , layer 3, eta < 0.6, layer 4, eta < 0.44) apart fron the resZ and resRphi plots which run over the whole detector excluding layer 1.


![ClusterSizevsXmYm_EC](https://user-images.githubusercontent.com/57264803/135062855-f3da1066-85b0-4d84-b504-153fcaa33239.png)
![resX_spreadX1](https://user-images.githubusercontent.com/57264803/135062861-aaa971c5-a56e-4df8-8377-ae79eca51c72.png)
![resX_spreadX2](https://user-images.githubusercontent.com/57264803/135062863-c61861f3-46a0-4211-ba88-dd852e9afb53.png)
![resXvsXm_EC](https://user-images.githubusercontent.com/57264803/135062864-4d77e8d3-a0fd-4f30-ba78-84f96f5f06c0.png)
![resY_AbsEtaBin0](https://user-images.githubusercontent.com/57264803/135062866-7a3eb587-47e8-457c-853f-163188a5ff6c.png)
![resY_AbsEtaBin1](https://user-images.githubusercontent.com/57264803/135062868-9bf78c34-5fc8-405c-8b0c-87e10d2f3140.png)
![resY_AbsEtaBin2](https://user-images.githubusercontent.com/57264803/135062870-c9f9e991-1e36-4928-8e61-689628d9e897.png)
![resY_spreadX1](https://user-images.githubusercontent.com/57264803/135062872-bd226b79-0d9b-4b9f-aa03-1a4813d06cac.png)
![resY_spreadX1_EC](https://user-images.githubusercontent.com/57264803/135062874-a9a2727d-3839-4e32-ae24-a7d4e1cab71a.png)
![resY_spreadX2](https://user-images.githubusercontent.com/57264803/135062877-2056e41c-4c09-4f99-baa9-a5ef5541ed47.png)
![resY_spreadX2_EC](https://user-images.githubusercontent.com/57264803/135062878-20d02ebe-814d-4752-a4d9-78a3c417f89f.png)
![resY_spreadX3_EC](https://user-images.githubusercontent.com/57264803/135062879-1281fbfb-9344-4c8e-90d0-b7cb92644195.png)
![resY_spreadY1](https://user-images.githubusercontent.com/57264803/135062881-663ee4b9-56c1-415d-9ae1-cc530824014c.png)
![resY_spreadY2](https://user-images.githubusercontent.com/57264803/135062882-0fe5586d-49af-4c39-93e9-af7a4ac6ffac.png)
![resYvsYm](https://user-images.githubusercontent.com/57264803/135062883-d091c32b-80d7-4136-b69f-1cdfe12281a0.png)
![resYvsYm_EC](https://user-images.githubusercontent.com/57264803/135062884-25332731-c269-41aa-8190-8a43092fa7ed.png)
![RZhit](https://user-images.githubusercontent.com/57264803/135062886-22cdacdd-8ec0-4357-9049-5721bc65761f.png)

