### PR TITLE
Migrate Egamma-Electools to use esConsumes

### DIFF
--- a/EgammaAnalysis/ElectronTools/plugins/EGammaCutBasedEleIdAnalyzer.cc
+++ b/EgammaAnalysis/ElectronTools/plugins/EGammaCutBasedEleIdAnalyzer.cc
@@ -21,7 +21,7 @@ Implementation:
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Utilities/interface/transform.h"
@@ -45,7 +45,7 @@ Implementation:
 // class declaration
 //
 
-class EGammaCutBasedEleIdAnalyzer : public edm::EDAnalyzer {
+class EGammaCutBasedEleIdAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   typedef std::vector<edm::Handle<edm::ValueMap<reco::IsoDeposit> > > IsoDepositMaps;
   typedef std::vector<edm::Handle<edm::ValueMap<double> > > IsoDepositVals;
@@ -61,11 +61,12 @@ private:
   void analyze(const edm::Event &, const edm::EventSetup &) override;
   void endJob() override;
 
+  /*
   void beginRun(edm::Run const &, edm::EventSetup const &) override;
   void endRun(edm::Run const &, edm::EventSetup const &) override;
   void beginLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) override;
   void endLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) override;
-
+  */
   // ----------member data ---------------------------
 
   // input tags
@@ -254,7 +255,7 @@ void EGammaCutBasedEleIdAnalyzer::beginJob() {
 
 // ------------ method called once each job just after ending the event loop  ------------
 void EGammaCutBasedEleIdAnalyzer::endJob() {}
-
+/*
 // ------------ method called when starting to processes a run  ------------
 void EGammaCutBasedEleIdAnalyzer::beginRun(edm::Run const &, edm::EventSetup const &) {}
 
@@ -266,7 +267,7 @@ void EGammaCutBasedEleIdAnalyzer::beginLuminosityBlock(edm::LuminosityBlock cons
 
 // ------------ method called when ending the processing of a luminosity block  ------------
 void EGammaCutBasedEleIdAnalyzer::endLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) {}
-
+*/
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void EGammaCutBasedEleIdAnalyzer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   //The following says we do not know what parameters are allowed so do no validation

--- a/EgammaAnalysis/ElectronTools/plugins/ElectronIdMVAProducer.cc
+++ b/EgammaAnalysis/ElectronTools/plugins/ElectronIdMVAProducer.cc
@@ -37,6 +37,7 @@ private:
   edm::EDGetTokenT<EcalRecHitCollection> reducedEBRecHitCollectionToken_;
   edm::EDGetTokenT<EcalRecHitCollection> reducedEERecHitCollectionToken_;
   const EcalClusterLazyTools::ESGetTokens ecalClusterToolsESGetTokens_;
+  edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> ttrackbuilderToken_;
 
   double _Rho;
   std::string method_;
@@ -72,6 +73,8 @@ ElectronIdMVAProducer::ElectronIdMVAProducer(const edm::ParameterSet& iConfig)
   std::vector<std::string> fpMvaWeightFiles = iConfig.getParameter<std::vector<std::string> >("mvaWeightFile");
   Trig_ = iConfig.getParameter<bool>("Trig");
   NoIP_ = iConfig.getParameter<bool>("NoIP");
+
+  ttrackbuilderToken_ = esConsumes(edm::ESInputTag("", "TransientTrackBuilder"));
 
   produces<edm::ValueMap<float> >("");
 
@@ -134,10 +137,7 @@ bool ElectronIdMVAProducer::filter(edm::Event& iEvent, const edm::EventSetup& iS
                                  ecalClusterToolsESGetTokens_.get(iSetup),
                                  reducedEBRecHitCollectionToken_,
                                  reducedEERecHitCollectionToken_);
-
-  edm::ESHandle<TransientTrackBuilder> builder;
-  iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", builder);
-  TransientTrackBuilder thebuilder = *(builder.product());
+  auto const& thebuilder = iSetup.getData(ttrackbuilderToken_);
 
   edm::Handle<reco::GsfElectronCollection> egCollection;
   iEvent.getByToken(electronToken_, egCollection);

--- a/EgammaAnalysis/ElectronTools/plugins/ElectronIdMVAProducer.cc
+++ b/EgammaAnalysis/ElectronTools/plugins/ElectronIdMVAProducer.cc
@@ -3,7 +3,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -21,7 +21,7 @@
 // class declaration
 //
 
-class ElectronIdMVAProducer : public edm::EDFilter {
+class ElectronIdMVAProducer : public edm::stream::EDFilter<> {
 public:
   explicit ElectronIdMVAProducer(const edm::ParameterSet&);
   ~ElectronIdMVAProducer() override;

--- a/EgammaAnalysis/ElectronTools/plugins/ElectronIsolatorFromEffectiveArea.cc
+++ b/EgammaAnalysis/ElectronTools/plugins/ElectronIsolatorFromEffectiveArea.cc
@@ -1,5 +1,5 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -11,7 +11,7 @@
 
 #include "EgammaAnalysis/ElectronTools/interface/ElectronEffectiveArea.h"
 
-class ElectronIsolatorFromEffectiveArea : public edm::EDFilter {
+class ElectronIsolatorFromEffectiveArea : public edm::stream::EDFilter<> {
 public:
   typedef edm::ValueMap<double> CandDoubleMap;
   typedef ElectronEffectiveArea EEA;

--- a/EgammaAnalysis/ElectronTools/plugins/ElectronPATIdMVAProducer.cc
+++ b/EgammaAnalysis/ElectronTools/plugins/ElectronPATIdMVAProducer.cc
@@ -3,7 +3,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -21,7 +21,7 @@
 // class declaration
 //
 
-class ElectronPATIdMVAProducer : public edm::EDProducer {
+class ElectronPATIdMVAProducer : public edm::stream::EDProducer<> {
 public:
   explicit ElectronPATIdMVAProducer(const edm::ParameterSet&);
   ~ElectronPATIdMVAProducer() override;

--- a/EgammaAnalysis/ElectronTools/plugins/ElectronRegressionEnergyProducer.cc
+++ b/EgammaAnalysis/ElectronTools/plugins/ElectronRegressionEnergyProducer.cc
@@ -5,13 +5,13 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
 #include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "Geometry/Records/interface/CaloTopologyRecord.h"
@@ -27,7 +27,7 @@
 // class declaration
 //
 
-class ElectronRegressionEnergyProducer : public edm::EDFilter {
+class ElectronRegressionEnergyProducer : public edm::stream::EDFilter<> {
 public:
   explicit ElectronRegressionEnergyProducer(const edm::ParameterSet&);
   ~ElectronRegressionEnergyProducer() override;

--- a/EgammaAnalysis/ElectronTools/plugins/ElectronRegressionEnergyProducer.cc
+++ b/EgammaAnalysis/ElectronTools/plugins/ElectronRegressionEnergyProducer.cc
@@ -57,6 +57,9 @@ private:
 
   edm::EDGetTokenT<reco::VertexCollection> hVertexToken_;
   edm::EDGetTokenT<double> hRhoKt6PFJetsToken_;
+
+  edm::ESGetToken<CaloTopology, CaloTopologyRecord> ecalTopoToken_;
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeomToken_;
 };
 
 ElectronRegressionEnergyProducer::ElectronRegressionEnergyProducer(const edm::ParameterSet& iConfig) {
@@ -74,6 +77,9 @@ ElectronRegressionEnergyProducer::ElectronRegressionEnergyProducer(const edm::Pa
 
   hVertexToken_ = consumes<reco::VertexCollection>(edm::InputTag("offlinePrimaryVertices"));
   hRhoKt6PFJetsToken_ = consumes<double>(edm::InputTag("kt6PFJets", "rho"));
+
+  ecalTopoToken_ = esConsumes();
+  caloGeomToken_ = esConsumes();
 
   produces<edm::ValueMap<double> >(nameEnergyReg_);
   produces<edm::ValueMap<double> >(nameEnergyErrorReg_);
@@ -104,13 +110,8 @@ bool ElectronRegressionEnergyProducer::filter(edm::Event& iEvent, const edm::Eve
   assert(regressionEvaluator->isInitialized());
 
   if (!geomInitialized_) {
-    edm::ESHandle<CaloTopology> theCaloTopology;
-    iSetup.get<CaloTopologyRecord>().get(theCaloTopology);
-    ecalTopology_ = &(*theCaloTopology);
-
-    edm::ESHandle<CaloGeometry> theCaloGeometry;
-    iSetup.get<CaloGeometryRecord>().get(theCaloGeometry);
-    caloGeometry_ = &(*theCaloGeometry);
+    ecalTopology_ = &(iSetup.getData(ecalTopoToken_));
+    caloGeometry_ = &(iSetup.getData(caloGeomToken_));
     geomInitialized_ = true;
   }
 

--- a/EgammaAnalysis/ElectronTools/plugins/GBRForestGetterFromDB.cc
+++ b/EgammaAnalysis/ElectronTools/plugins/GBRForestGetterFromDB.cc
@@ -1,16 +1,14 @@
 #ifndef CalibratedElectronProducer_h
 #define CalibratedElectronProducer_h
 
-#include <iostream>
 #include <string>
-
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "CondFormats/DataRecord/interface/GBRWrapperRcd.h"
 #include "CondFormats/GBRForest/interface/GBRForest.h"
 #include <TFile.h>
@@ -25,23 +23,24 @@ private:
   std::string theGBRForestName;
   std::string theOutputFileName;
   std::string theOutputObjectName;
-  edm::ESHandle<GBRForest> theGBRForestHandle;
+  edm::ESGetToken<GBRForest, GBRWrapperRcd> theGBRForestToken_;
 };
 
 GBRForestGetterFromDB::GBRForestGetterFromDB(const edm::ParameterSet &conf)
     : theGBRForestName(conf.getParameter<std::string>("grbForestName")),
       theOutputFileName(conf.getUntrackedParameter<std::string>("outputFileName")),
       theOutputObjectName(conf.getUntrackedParameter<std::string>(
-          "outputObjectName", theGBRForestName.empty() ? "GBRForest" : theGBRForestName)) {}
+          "outputObjectName", theGBRForestName.empty() ? "GBRForest" : theGBRForestName)),
+      theGBRForestToken_(esConsumes()) {}
 
 GBRForestGetterFromDB::~GBRForestGetterFromDB() {}
 
 void GBRForestGetterFromDB::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
-  iSetup.get<GBRWrapperRcd>().get(theGBRForestName, theGBRForestHandle);
+  auto theGBRForestHandle = iSetup.getHandle(theGBRForestToken_);
   TFile *fOut = TFile::Open(theOutputFileName.c_str(), "RECREATE");
   fOut->WriteObject(theGBRForestHandle.product(), theOutputObjectName.c_str());
   fOut->Close();
-  std::cout << "Wrote output to " << theOutputFileName << std::endl;
+  edm::LogPrint("GBRForestGetterFromDB") << "Wrote output to " << theOutputFileName;
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/EgammaAnalysis/ElectronTools/plugins/PatElectronEAIsoCorrectionProducer.cc
+++ b/EgammaAnalysis/ElectronTools/plugins/PatElectronEAIsoCorrectionProducer.cc
@@ -1,4 +1,4 @@
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -6,7 +6,7 @@
 #include "DataFormats/PatCandidates/interface/Electron.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 
-class PatElectronEAIsoCorrectionProducer : public edm::EDProducer {
+class PatElectronEAIsoCorrectionProducer : public edm::stream::EDProducer<> {
 public:
   explicit PatElectronEAIsoCorrectionProducer(const edm::ParameterSet& iConfig);
   ~PatElectronEAIsoCorrectionProducer() override{};

--- a/EgammaAnalysis/ElectronTools/plugins/PhotonIsoProducer.cc
+++ b/EgammaAnalysis/ElectronTools/plugins/PhotonIsoProducer.cc
@@ -117,13 +117,10 @@ bool PhotonIsoProducer::filter(edm::Event& iEvent, const edm::EventSetup& iSetup
     isolator.fGetIsolation(&*aPho, &thePfColl, myVtxRef, vertexCollection);
 
     if (verbose_) {
-      edm::LogPrint("PhotonIsoProducer") << " run " << iEvent.id().run() 
-					 << " lumi " << iEvent.id().luminosityBlock() 
-					 << " event " << iEvent.id().event();
-      edm::LogPrint("PhotonIsoProducer") << " pt " << aPho->pt() 
-					 << " eta " << aPho->eta() 
-					 << " phi " << aPho->phi() 
-					 << " charge " << aPho->charge() << " : ";
+      edm::LogPrint("PhotonIsoProducer") << " run " << iEvent.id().run() << " lumi " << iEvent.id().luminosityBlock()
+                                         << " event " << iEvent.id().event();
+      edm::LogPrint("PhotonIsoProducer") << " pt " << aPho->pt() << " eta " << aPho->eta() << " phi " << aPho->phi()
+                                         << " charge " << aPho->charge() << " : ";
 
       edm::LogPrint("PhotonIsoProducer") << " ChargedIso " << isolator.getIsolationCharged();
       edm::LogPrint("PhotonIsoProducer") << " PhotonIso " << isolator.getIsolationPhoton();

--- a/EgammaAnalysis/ElectronTools/plugins/PhotonIsoProducer.cc
+++ b/EgammaAnalysis/ElectronTools/plugins/PhotonIsoProducer.cc
@@ -3,11 +3,11 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
@@ -22,7 +22,7 @@
 // class declaration
 //
 
-class PhotonIsoProducer : public edm::EDFilter {
+class PhotonIsoProducer : public edm::stream::EDFilter<> {
 public:
   explicit PhotonIsoProducer(const edm::ParameterSet&);
   ~PhotonIsoProducer() override;
@@ -117,15 +117,17 @@ bool PhotonIsoProducer::filter(edm::Event& iEvent, const edm::EventSetup& iSetup
     isolator.fGetIsolation(&*aPho, &thePfColl, myVtxRef, vertexCollection);
 
     if (verbose_) {
-      std::cout << " run " << iEvent.id().run() << " lumi " << iEvent.id().luminosityBlock() << " event "
-                << iEvent.id().event();
-      std::cout << " pt " << aPho->pt() << " eta " << aPho->eta() << " phi " << aPho->phi() << " charge "
-                << aPho->charge() << " : " << std::endl;
-      ;
+      edm::LogPrint("PhotonIsoProducer") << " run " << iEvent.id().run() 
+					 << " lumi " << iEvent.id().luminosityBlock() 
+					 << " event " << iEvent.id().event();
+      edm::LogPrint("PhotonIsoProducer") << " pt " << aPho->pt() 
+					 << " eta " << aPho->eta() 
+					 << " phi " << aPho->phi() 
+					 << " charge " << aPho->charge() << " : ";
 
-      std::cout << " ChargedIso " << isolator.getIsolationCharged() << std::endl;
-      std::cout << " PhotonIso " << isolator.getIsolationPhoton() << std::endl;
-      std::cout << " NeutralHadron Iso " << isolator.getIsolationNeutral() << std::endl;
+      edm::LogPrint("PhotonIsoProducer") << " ChargedIso " << isolator.getIsolationCharged();
+      edm::LogPrint("PhotonIsoProducer") << " PhotonIso " << isolator.getIsolationPhoton();
+      edm::LogPrint("PhotonIsoProducer") << " NeutralHadron Iso " << isolator.getIsolationNeutral();
     }
 
     chIsoValues.push_back(isolator.getIsolationCharged());

--- a/EgammaAnalysis/ElectronTools/plugins/RegressionEnergyPatElectronProducer.cc
+++ b/EgammaAnalysis/ElectronTools/plugins/RegressionEnergyPatElectronProducer.cc
@@ -43,7 +43,9 @@ RegressionEnergyPatElectronProducer::RegressionEnergyPatElectronProducer(const e
   }
 
   if (inputCollectionType_ == 0 && !produceValueMaps_) {
-    edm::LogPrint("RegressionEnergyPatElectronProducer") << " You are running on GsfElectrons and the producer is not configured to produce ValueMaps with the results. In that case, it does not nothing !! ";
+    edm::LogPrint("RegressionEnergyPatElectronProducer")
+        << " You are running on GsfElectrons and the producer is not configured to produce ValueMaps with the results. "
+           "In that case, it does not nothing !! ";
   }
 
   if (inputCollectionType_ == 0) {
@@ -52,7 +54,7 @@ RegressionEnergyPatElectronProducer::RegressionEnergyPatElectronProducer(const e
     produces<pat::ElectronCollection>();
   } else {
     throw cms::Exception("InconsistentParameters")
-        << " inputCollectionType should be either 0 (GsfElectrons) or 1 (pat::Electrons) " ;
+        << " inputCollectionType should be either 0 (GsfElectrons) or 1 (pat::Electrons) ";
   }
 
   //set regression type
@@ -79,7 +81,7 @@ RegressionEnergyPatElectronProducer::RegressionEnergyPatElectronProducer(const e
 
   geomInitialized_ = false;
 
-  edm::LogPrint("RegressionEnergyPatElectronProducer") << " Finished initialization " ;
+  edm::LogPrint("RegressionEnergyPatElectronProducer") << " Finished initialization ";
 }
 
 RegressionEnergyPatElectronProducer::~RegressionEnergyPatElectronProducer() { delete regressionEvaluator_; }
@@ -157,10 +159,13 @@ void RegressionEnergyPatElectronProducer::produce(edm::Event& event, const edm::
   for (unsigned iele = 0; iele < nElectrons_; ++iele) {
     const reco::GsfElectron* ele = (inputCollectionType_ == 0) ? &(*gsfCollectionH)[iele] : &(*patCollectionH)[iele];
     if (debug_) {
-      edm::LogPrint("RegressionEnergyPatElectronProducer") << "***********************************************************************\n";
-      edm::LogPrint("RegressionEnergyPatElectronProducer") << "Run Lumi Event: " << event.id().run() << " " << event.luminosityBlock() << " " << event.id().event()
-                << "\n";
-      edm::LogPrint("RegressionEnergyPatElectronProducer") << "Pat Electron : " << ele->pt() << " " << ele->eta() << " " << ele->phi() << "\n";
+      edm::LogPrint("RegressionEnergyPatElectronProducer")
+          << "***********************************************************************\n";
+      edm::LogPrint("RegressionEnergyPatElectronProducer")
+          << "Run Lumi Event: " << event.id().run() << " " << event.luminosityBlock() << " " << event.id().event()
+          << "\n";
+      edm::LogPrint("RegressionEnergyPatElectronProducer")
+          << "Pat Electron : " << ele->pt() << " " << ele->eta() << " " << ele->phi() << "\n";
     }
 
     pat::Electron* myPatElectron = (inputCollectionType_ == 0) ? nullptr : new pat::Electron((*patCollectionH)[iele]);
@@ -511,7 +516,8 @@ void RegressionEnergyPatElectronProducer::produce(edm::Event& event, const edm::
       energyValues.push_back(RegressionMomentum);
       energyErrorValues.push_back(RegressionMomentumError);
     } else {
-      edm::LogPrint("RegressionEnergyPatElectronProducer") << "Error: RegressionType = " << energyRegressionType_ << " is not supported.\n";
+      edm::LogPrint("RegressionEnergyPatElectronProducer")
+          << "Error: RegressionType = " << energyRegressionType_ << " is not supported.\n";
     }
 
     if (inputCollectionType_ == 1) {

--- a/EgammaAnalysis/ElectronTools/plugins/RegressionEnergyPatElectronProducer.cc
+++ b/EgammaAnalysis/ElectronTools/plugins/RegressionEnergyPatElectronProducer.cc
@@ -43,9 +43,7 @@ RegressionEnergyPatElectronProducer::RegressionEnergyPatElectronProducer(const e
   }
 
   if (inputCollectionType_ == 0 && !produceValueMaps_) {
-    std::cout << " You are running on GsfElectrons and the producer is not configured to produce ValueMaps with the "
-                 "results. In that case, it does not nothing !! "
-              << std::endl;
+    edm::LogPrint("RegressionEnergyPatElectronProducer") << " You are running on GsfElectrons and the producer is not configured to produce ValueMaps with the results. In that case, it does not nothing !! ";
   }
 
   if (inputCollectionType_ == 0) {
@@ -54,7 +52,7 @@ RegressionEnergyPatElectronProducer::RegressionEnergyPatElectronProducer(const e
     produces<pat::ElectronCollection>();
   } else {
     throw cms::Exception("InconsistentParameters")
-        << " inputCollectionType should be either 0 (GsfElectrons) or 1 (pat::Electrons) " << std::endl;
+        << " inputCollectionType should be either 0 (GsfElectrons) or 1 (pat::Electrons) " ;
   }
 
   //set regression type
@@ -81,7 +79,7 @@ RegressionEnergyPatElectronProducer::RegressionEnergyPatElectronProducer(const e
 
   geomInitialized_ = false;
 
-  std::cout << " Finished initialization " << std::endl;
+  edm::LogPrint("RegressionEnergyPatElectronProducer") << " Finished initialization " ;
 }
 
 RegressionEnergyPatElectronProducer::~RegressionEnergyPatElectronProducer() { delete regressionEvaluator_; }
@@ -159,10 +157,10 @@ void RegressionEnergyPatElectronProducer::produce(edm::Event& event, const edm::
   for (unsigned iele = 0; iele < nElectrons_; ++iele) {
     const reco::GsfElectron* ele = (inputCollectionType_ == 0) ? &(*gsfCollectionH)[iele] : &(*patCollectionH)[iele];
     if (debug_) {
-      std::cout << "***********************************************************************\n";
-      std::cout << "Run Lumi Event: " << event.id().run() << " " << event.luminosityBlock() << " " << event.id().event()
+      edm::LogPrint("RegressionEnergyPatElectronProducer") << "***********************************************************************\n";
+      edm::LogPrint("RegressionEnergyPatElectronProducer") << "Run Lumi Event: " << event.id().run() << " " << event.luminosityBlock() << " " << event.id().event()
                 << "\n";
-      std::cout << "Pat Electron : " << ele->pt() << " " << ele->eta() << " " << ele->phi() << "\n";
+      edm::LogPrint("RegressionEnergyPatElectronProducer") << "Pat Electron : " << ele->pt() << " " << ele->eta() << " " << ele->phi() << "\n";
     }
 
     pat::Electron* myPatElectron = (inputCollectionType_ == 0) ? nullptr : new pat::Electron((*patCollectionH)[iele]);
@@ -513,7 +511,7 @@ void RegressionEnergyPatElectronProducer::produce(edm::Event& event, const edm::
       energyValues.push_back(RegressionMomentum);
       energyErrorValues.push_back(RegressionMomentumError);
     } else {
-      std::cout << "Error: RegressionType = " << energyRegressionType_ << " is not supported.\n";
+      edm::LogPrint("RegressionEnergyPatElectronProducer") << "Error: RegressionType = " << energyRegressionType_ << " is not supported.\n";
     }
 
     if (inputCollectionType_ == 1) {

--- a/EgammaAnalysis/ElectronTools/plugins/RegressionEnergyPatElectronProducer.cc
+++ b/EgammaAnalysis/ElectronTools/plugins/RegressionEnergyPatElectronProducer.cc
@@ -25,6 +25,8 @@ RegressionEnergyPatElectronProducer::RegressionEnergyPatElectronProducer(const e
   regressionInputFile_ = cfg.getParameter<std::string>("regressionInputFile");
   recHitCollectionEBToken_ = mayConsume<EcalRecHitCollection>(cfg.getParameter<edm::InputTag>("recHitCollectionEB"));
   recHitCollectionEEToken_ = mayConsume<EcalRecHitCollection>(cfg.getParameter<edm::InputTag>("recHitCollectionEE"));
+  ecalTopoToken_ = esConsumes();
+  caloGeomToken_ = esConsumes();
   nameEnergyReg_ = cfg.getParameter<std::string>("nameEnergyReg");
   nameEnergyErrorReg_ = cfg.getParameter<std::string>("nameEnergyErrorReg");
   debug_ = cfg.getUntrackedParameter<bool>("debug");
@@ -87,13 +89,8 @@ RegressionEnergyPatElectronProducer::~RegressionEnergyPatElectronProducer() { de
 void RegressionEnergyPatElectronProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
   assert(regressionEvaluator_->isInitialized());
   if (!geomInitialized_) {
-    edm::ESHandle<CaloTopology> theCaloTopology;
-    setup.get<CaloTopologyRecord>().get(theCaloTopology);
-    ecalTopology_ = &(*theCaloTopology);
-
-    edm::ESHandle<CaloGeometry> theCaloGeometry;
-    setup.get<CaloGeometryRecord>().get(theCaloGeometry);
-    caloGeometry_ = &(*theCaloGeometry);
+    ecalTopology_ = &setup.getData(ecalTopoToken_);
+    caloGeometry_ = &setup.getData(caloGeomToken_);
     geomInitialized_ = true;
   }
 

--- a/EgammaAnalysis/ElectronTools/plugins/RegressionEnergyPatElectronProducer.h
+++ b/EgammaAnalysis/ElectronTools/plugins/RegressionEnergyPatElectronProducer.h
@@ -2,7 +2,7 @@
 #define RegressionEnergyPatElectronProducer_h
 
 #include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
@@ -10,7 +10,6 @@
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 
 #include "EgammaAnalysis/ElectronTools/interface/ElectronEnergyRegressionEvaluate.h"
-//#include "EGamma/EGammaAnalysisTools/interface/ElectronEnergyRegressionEvaluate.h"
 
 #include "DataFormats/PatCandidates/interface/Electron.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
@@ -18,7 +17,7 @@
 
 class CaloTopologyRecord;
 class CaloGeometryRecord;
-class RegressionEnergyPatElectronProducer : public edm::EDProducer {
+class RegressionEnergyPatElectronProducer : public edm::stream::EDProducer<> {
 public:
   explicit RegressionEnergyPatElectronProducer(const edm::ParameterSet &);
   ~RegressionEnergyPatElectronProducer() override;

--- a/EgammaAnalysis/ElectronTools/plugins/RegressionEnergyPatElectronProducer.h
+++ b/EgammaAnalysis/ElectronTools/plugins/RegressionEnergyPatElectronProducer.h
@@ -16,6 +16,8 @@
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 
+class CaloTopologyRecord;
+class CaloGeometryRecord;
 class RegressionEnergyPatElectronProducer : public edm::EDProducer {
 public:
   explicit RegressionEnergyPatElectronProducer(const edm::ParameterSet &);
@@ -31,6 +33,8 @@ private:
   edm::EDGetTokenT<EcalRecHitCollection> recHitCollectionEBToken_;
   edm::EDGetTokenT<EcalRecHitCollection> recHitCollectionEEToken_;
 
+  edm::ESGetToken<CaloTopology, CaloTopologyRecord> ecalTopoToken_;
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeomToken_;
   //
   bool useReducedRecHits_;
 


### PR DESCRIPTION
#### PR description:
Part of #31061. Migrates modules of ```EgammaAnalysis/ElectronTools``` to use esConsumes. 

#### PR validation:
Compiles and passes ```runTheMatrix.py -l limited -i all --ibeos```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
NA