### PR TITLE
Fix undefined behavior in TSGFromL2 from empty pointer

### DIFF
--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGFromL2Muon.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGFromL2Muon.cc
@@ -90,6 +90,8 @@ void TSGFromL2Muon::produce(edm::Event& ev, const edm::EventSetup& es) {
     std::unique_ptr<RectangularEtaPhiTrackingRegion> region;
     if (theRegionBuilder) {
       region = theRegionBuilder->region(muRef);
+    } else {
+      region = std::make_unique<RectangularEtaPhiTrackingRegion>();
     }
 
     //Make seeds container

--- a/RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h
@@ -42,6 +42,8 @@ public:
 
   static UseMeasurementTracker stringToUseMeasurementTracker(const std::string& name);
 
+  RectangularEtaPhiTrackingRegion() {}
+
   RectangularEtaPhiTrackingRegion(RectangularEtaPhiTrackingRegion const& rh)
       : TrackingRegion(rh),
         theEtaRange(rh.theEtaRange),

--- a/RecoTracker/TkTrackingRegions/interface/TrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/TrackingRegion.h
@@ -47,6 +47,8 @@ public:
   typedef SeedingLayerSetsHits::Hits Hits;
 
 public:
+  TrackingRegion() {}
+
   TrackingRegion(const GlobalVector& direction,
                  const GlobalPoint& originPos,
                  const Range& invPtRange,


### PR DESCRIPTION
#### PR description:

Fix undefined behavior in `TSGFromL2Muon`, reported in issue [35036](https://github.com/cms-sw/cmssw/issues/35036#issuecomment-907224738). The issue is caused by the `region` pointer, which is only initialized if there is a valid `theRegionBuilder` in the event. The region pointer is then accessed empty in lines 102/104 and 106/108 when given as an input to `trackerSeeds()` and  `clean()` functions.

To solve this issue, I added a default constructor without parameters for `RectangularEtaPhiTrackingRegion` and `TrackingRegion` classes. This makes possible to have a minimal initialization for the `region` pointer. The default initialization of `region` is done if `theRegionBuilder` states to `false` by adding an `else` statement in line 93. Then, when the code tries to access it in lines 102/104 and 106/108 `region` is not an empty pointer anymore.

#### PR validation:

I verified that the undefined behavior error disappears by running the workflow 11650.0 in `CMSSW_12_1_UBSAN_X_2021-09-13-1100` release.

The code have a clean build without errors and pass the basic tests (`runTheMatrix.py -l limited -i all --ibeos`) when running with `CMSSW_12_1_X_2021-09-23-2300`. I have also checked out the dependencies and the code format.


