### PR TITLE
[DD4hep] [Backport] Enable tiny rotation of 3 volumes and increase precision of rotation matching

### DIFF
--- a/DetectorDescription/OfflineDBLoader/src/DDCoreToDDXMLOutput.cc
+++ b/DetectorDescription/OfflineDBLoader/src/DDCoreToDDXMLOutput.cc
@@ -39,6 +39,9 @@ static inline constexpr NumType convertGPerCcToMgPerCc(NumType gPerCc)  // g/cm^
   return (gPerCc * 1000.);
 }
 
+static constexpr double tol0 = 1.e-11;        // Tiny values to be considered equal to 0
+static constexpr double reflectTol = 1.0e-3;  // Tolerance for recognizing reflections; Geant4-compatible
+
 namespace cms::rotation_utils {
   /* For debugging 
   static double determinant(const dd4hep::Rotation3D &rot) {
@@ -51,7 +54,8 @@ namespace cms::rotation_utils {
   }
   */
 
-  static const std::string identityHash("1.0000000.0000000.0000000.0000001.0000000.0000000.0000000.0000001.000000");
+  static const std::string identityHash(
+      "1.00000000.00000000.00000000.00000001.00000000.00000000.00000000.00000001.0000000");
 
   static void addRotWithNewName(cms::DDNamespace& ns, std::string& name, const dd4hep::Rotation3D& rot) {
     const dd4hep::Rotation3D& rot2 = rot;
@@ -61,15 +65,15 @@ namespace cms::rotation_utils {
 
   static void addRotWithNewName(cms::DDNamespace& ns, std::string& name, const Double_t* rot) {
     using namespace cms_rounding;
-    dd4hep::Rotation3D rot2(roundIfNear0(rot[0]),
-                            roundIfNear0(rot[1]),
-                            roundIfNear0(rot[2]),
-                            roundIfNear0(rot[3]),
-                            roundIfNear0(rot[4]),
-                            roundIfNear0(rot[5]),
-                            roundIfNear0(rot[6]),
-                            roundIfNear0(rot[7]),
-                            roundIfNear0(rot[8]));
+    dd4hep::Rotation3D rot2(roundIfNear0(rot[0], tol0),
+                            roundIfNear0(rot[1], tol0),
+                            roundIfNear0(rot[2], tol0),
+                            roundIfNear0(rot[3], tol0),
+                            roundIfNear0(rot[4], tol0),
+                            roundIfNear0(rot[5], tol0),
+                            roundIfNear0(rot[6], tol0),
+                            roundIfNear0(rot[7], tol0),
+                            roundIfNear0(rot[8], tol0));
     addRotWithNewName(ns, name, rot2);
   }
 
@@ -115,8 +119,12 @@ void DDCoreToDDXMLOutput::solid(const dd4hep::Solid& solid, const cms::DDParsing
       xos << " y=\"" << trans[1] << "*mm\"";
       xos << " z=\"" << trans[2] << "*mm\"";
       xos << "/>" << std::endl;
-      std::string rotNameStr = cms::rotation_utils::rotName(rs.rightMatrix()->GetRotationMatrix(), context);
-      xos << "<rRotation name=\"" << rotNameStr << "\"/>" << std::endl;
+      auto rot = rs.rightMatrix()->GetRotationMatrix();
+      // The identity rotation can be omitted.
+      if (cms::rotation_utils::rotHash(rot) != cms::rotation_utils::identityHash) {
+        std::string rotNameStr = cms::rotation_utils::rotName(rot, context);
+        xos << "<rRotation name=\"" << rotNameStr << "\"/>" << std::endl;
+      }
       if (shape == cms::DDSolidShape::ddunion) {
         xos << "</UnionSolid>" << std::endl;
       } else if (shape == cms::DDSolidShape::ddsubtraction) {
@@ -618,8 +626,7 @@ void DDCoreToDDXMLOutput::material(const std::string& matName,
       << " density=\"" << std::scientific << std::setprecision(5) << convertGPerCcToMgPerCc(density) << "*mg/cm3\""
       << " method=\"mixture by weight\">" << std::endl;
 
-  auto compIter = matRefs.begin();
-  for (; compIter != matRefs.end(); ++compIter) {
+  for (auto compIter = matRefs.begin(); compIter != matRefs.end(); ++compIter) {
     xos << "<MaterialFraction fraction=\"" << std::fixed << std::setprecision(9) << compIter->fraction << "\">"
         << std::endl;
     xos << "<rMaterial name=\"" << compIter->name << "\"/>" << std::endl;
@@ -655,19 +662,21 @@ void DDCoreToDDXMLOutput::element(const TGeoMaterial* material, std::ostream& xo
 }
 
 void DDCoreToDDXMLOutput::rotation(const DDRotation& rotation, std::ostream& xos, const std::string& rotn) {
-  double tol = 1.0e-3;  // Geant4 compatible
   DD3Vector x, y, z;
   rotation.rotation().GetComponents(x, y, z);
   double a, b, c;
   x.GetCoordinates(a, b, c);
-  x.SetCoordinates(cms_rounding::roundIfNear0(a), cms_rounding::roundIfNear0(b), cms_rounding::roundIfNear0(c));
+  x.SetCoordinates(
+      cms_rounding::roundIfNear0(a, tol0), cms_rounding::roundIfNear0(b, tol0), cms_rounding::roundIfNear0(c, tol0));
   y.GetCoordinates(a, b, c);
-  y.SetCoordinates(cms_rounding::roundIfNear0(a), cms_rounding::roundIfNear0(b), cms_rounding::roundIfNear0(c));
+  y.SetCoordinates(
+      cms_rounding::roundIfNear0(a, tol0), cms_rounding::roundIfNear0(b, tol0), cms_rounding::roundIfNear0(c, tol0));
   z.GetCoordinates(a, b, c);
-  z.SetCoordinates(cms_rounding::roundIfNear0(a), cms_rounding::roundIfNear0(b), cms_rounding::roundIfNear0(c));
+  z.SetCoordinates(
+      cms_rounding::roundIfNear0(a, tol0), cms_rounding::roundIfNear0(b, tol0), cms_rounding::roundIfNear0(c, tol0));
   double check = (x.Cross(y)).Dot(z);  // in case of a LEFT-handed orthogonal system
                                        // this must be -1
-  bool reflection((1. - check) > tol);
+  bool reflection((1. - check) > reflectTol);
   std::string rotName = rotation.toString();
   if (rotName == ":") {
     if (!rotn.empty()) {
@@ -686,31 +695,33 @@ void DDCoreToDDXMLOutput::rotation(const DDRotation& rotation, std::ostream& xos
   }
   using namespace cms_rounding;
   xos << "name=\"" << rotName << "\""
-      << " phiX=\"" << roundIfNear0(convertRadToDeg(x.phi()), 4.e-4) << "*deg\""
-      << " thetaX=\"" << roundIfNear0(convertRadToDeg(x.theta()), 4.e-4) << "*deg\""
-      << " phiY=\"" << roundIfNear0(convertRadToDeg(y.phi()), 4.e-4) << "*deg\""
-      << " thetaY=\"" << roundIfNear0(convertRadToDeg(y.theta()), 4.e-4) << "*deg\""
-      << " phiZ=\"" << roundIfNear0(convertRadToDeg(z.phi()), 4.e-4) << "*deg\""
-      << " thetaZ=\"" << roundIfNear0(convertRadToDeg(z.theta()), 4.e-4) << "*deg\"/>" << std::endl;
+      << " phiX=\"" << roundIfNear0(convertRadToDeg(x.phi()), tol0) << "*deg\""
+      << " thetaX=\"" << roundIfNear0(convertRadToDeg(x.theta()), tol0) << "*deg\""
+      << " phiY=\"" << roundIfNear0(convertRadToDeg(y.phi()), tol0) << "*deg\""
+      << " thetaY=\"" << roundIfNear0(convertRadToDeg(y.theta()), tol0) << "*deg\""
+      << " phiZ=\"" << roundIfNear0(convertRadToDeg(z.phi()), tol0) << "*deg\""
+      << " thetaZ=\"" << roundIfNear0(convertRadToDeg(z.theta()), tol0) << "*deg\"/>" << std::endl;
 }
 
 void DDCoreToDDXMLOutput::rotation(const dd4hep::Rotation3D& rotation,
                                    std::ostream& xos,
                                    const cms::DDParsingContext& context,
                                    const std::string& rotn) {
-  double tol = 1.0e-3;  // Geant4 compatible
   ROOT::Math::XYZVector x, y, z;
   rotation.GetComponents(x, y, z);
   double a, b, c;
   x.GetCoordinates(a, b, c);
-  x.SetCoordinates(cms_rounding::roundIfNear0(a), cms_rounding::roundIfNear0(b), cms_rounding::roundIfNear0(c));
+  x.SetCoordinates(
+      cms_rounding::roundIfNear0(a, tol0), cms_rounding::roundIfNear0(b, tol0), cms_rounding::roundIfNear0(c, tol0));
   y.GetCoordinates(a, b, c);
-  y.SetCoordinates(cms_rounding::roundIfNear0(a), cms_rounding::roundIfNear0(b), cms_rounding::roundIfNear0(c));
+  y.SetCoordinates(
+      cms_rounding::roundIfNear0(a, tol0), cms_rounding::roundIfNear0(b, tol0), cms_rounding::roundIfNear0(c, tol0));
   z.GetCoordinates(a, b, c);
-  z.SetCoordinates(cms_rounding::roundIfNear0(a), cms_rounding::roundIfNear0(b), cms_rounding::roundIfNear0(c));
+  z.SetCoordinates(
+      cms_rounding::roundIfNear0(a, tol0), cms_rounding::roundIfNear0(b, tol0), cms_rounding::roundIfNear0(c, tol0));
   double check = (x.Cross(y)).Dot(z);  // in case of a LEFT-handed orthogonal system
                                        // this must be -1
-  bool reflection((1. - check) > tol);
+  bool reflection((1. - check) > reflectTol);
   if (!reflection) {
     xos << "<Rotation ";
   } else {
@@ -718,12 +729,12 @@ void DDCoreToDDXMLOutput::rotation(const dd4hep::Rotation3D& rotation,
   }
   using namespace cms_rounding;
   xos << "name=\"" << rotn << "\""
-      << " phiX=\"" << roundIfNear0(convertRadToDeg(x.phi()), 4.e-4) << "*deg\""
-      << " thetaX=\"" << roundIfNear0(convertRadToDeg(x.theta()), 4.e-4) << "*deg\""
-      << " phiY=\"" << roundIfNear0(convertRadToDeg(y.phi()), 4.e-4) << "*deg\""
-      << " thetaY=\"" << roundIfNear0(convertRadToDeg(y.theta()), 4.e-4) << "*deg\""
-      << " phiZ=\"" << roundIfNear0(convertRadToDeg(z.phi()), 4.e-4) << "*deg\""
-      << " thetaZ=\"" << roundIfNear0(convertRadToDeg(z.theta()), 4.e-4) << "*deg\"/>" << std::endl;
+      << " phiX=\"" << roundIfNear0(convertRadToDeg(x.phi()), tol0) << "*deg\""
+      << " thetaX=\"" << roundIfNear0(convertRadToDeg(x.theta()), tol0) << "*deg\""
+      << " phiY=\"" << roundIfNear0(convertRadToDeg(y.phi()), tol0) << "*deg\""
+      << " thetaY=\"" << roundIfNear0(convertRadToDeg(y.theta()), tol0) << "*deg\""
+      << " phiZ=\"" << roundIfNear0(convertRadToDeg(z.phi()), tol0) << "*deg\""
+      << " thetaZ=\"" << roundIfNear0(convertRadToDeg(z.theta()), tol0) << "*deg\"/>" << std::endl;
 }
 
 void DDCoreToDDXMLOutput::logicalPart(const DDLogicalPart& lp, std::ostream& xos) {


### PR DESCRIPTION
This 12_0 backport includes the 12_1 PR #35414 that enables the 7e-7 radian rotation of three sensitive ECal crystal volumes that were previously not rotated because ROOT was ignoring the tiny rotation. The tiny rotation should not have any noticeable effects, but it will cause a numerical change in the DD4hep XML geometry.

This backport also includes PR #35299 that increases the precision of rotation matching when creating the DD4hep big XML file for the DB. This change has no effect on workflows, since it only revises the tool that is run when a new DD4hep big XML file is needed for uploading into the DB.

#### PR validation:

A test DD4hep big XML file was created with this PR in 12_0, and it exactly matches the 12_1 version.