### PR TITLE
[HGCAL trigger] Migrate to esConsumes

### DIFF
--- a/L1Trigger/L1THGCal/interface/HGCalCoarseTriggerCellMapping.h
+++ b/L1Trigger/L1THGCal/interface/HGCalCoarseTriggerCellMapping.h
@@ -14,7 +14,7 @@ public:
   GlobalPoint getCoarseTriggerCellPosition(uint32_t ctcId) const;
   uint32_t getCoarseTriggerCellId(uint32_t detid) const;
   void checkSizeValidity(int ctcSize) const;
-  void eventSetup(const edm::EventSetup& es) { triggerTools_.eventSetup(es); }
+  void setGeometry(const HGCalTriggerGeometryBase* const geom) { triggerTools_.setGeometry(geom); }
 
   static constexpr int kCTCsizeCoarse_ = 16;
   static constexpr int kCTCsizeMid_ = 8;

--- a/L1Trigger/L1THGCal/interface/HGCalProcessorBaseT.h
+++ b/L1Trigger/L1THGCal/interface/HGCalProcessorBaseT.h
@@ -16,16 +16,19 @@ public:
 
   const std::string& name() const { return name_; }
 
-  void setGeometry(const HGCalTriggerGeometryBase* const geom) { geometry_ = geom; }
+  virtual void setGeometry(const HGCalTriggerGeometryBase* const geom) { geometry_ = geom; }
 
-  virtual void eventSetup(const edm::EventSetup& es){};
-
-  virtual void run(const InputCollection& inputColl, OutputCollection& outColl, const edm::EventSetup& es) = 0;
+  virtual void run(const InputCollection& inputColl, OutputCollection& outColl) = 0;
 
 protected:
-  const HGCalTriggerGeometryBase* geometry_;
+  const HGCalTriggerGeometryBase* geometry() const {
+    if (!geometry_)
+      throw cms::Exception("HGCTriggerSetupError") << "The geometry has not been set in processor " << name_;
+    return geometry_;
+  }
 
 private:
+  const HGCalTriggerGeometryBase* geometry_;
   const std::string name_;
 };
 

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerCellCalibration.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerCellCalibration.h
@@ -9,7 +9,7 @@
 class HGCalTriggerCellCalibration {
 public:
   HGCalTriggerCellCalibration(const edm::ParameterSet& conf);
-  void eventSetup(const edm::EventSetup& es) { triggerTools_.eventSetup(es); }
+  void setGeometry(const HGCalTriggerGeometryBase* const geom) { triggerTools_.setGeometry(geom); }
   void calibrateInMipT(l1t::HGCalTriggerCell&) const;
   void calibrateMipTinGeV(l1t::HGCalTriggerCell&) const;
   void calibrateInGeV(l1t::HGCalTriggerCell&) const;

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerTools.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerTools.h
@@ -23,17 +23,12 @@
 #include "Geometry/HGCalGeometry/interface/HGCalGeometry.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
 
-namespace edm {
-  class Event;
-  class EventSetup;
-}  // namespace edm
-
 class HGCalTriggerTools {
 public:
   HGCalTriggerTools() : geom_(nullptr), eeLayers_(0), fhLayers_(0), bhLayers_(0), noseLayers_(0), totalLayers_(0) {}
   ~HGCalTriggerTools() {}
 
-  void eventSetup(const edm::EventSetup&);
+  void setGeometry(const HGCalTriggerGeometryBase* const);
   GlobalPoint getTCPosition(const DetId& id) const;
   unsigned layers(ForwardSubdetector type) const;
   unsigned layers(DetId::Detector type) const;

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerTools.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerTools.h
@@ -23,12 +23,17 @@
 #include "Geometry/HGCalGeometry/interface/HGCalGeometry.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
 
+namespace edm {
+  class EventSetup;
+}
+
 class HGCalTriggerTools {
 public:
   HGCalTriggerTools() : geom_(nullptr), eeLayers_(0), fhLayers_(0), bhLayers_(0), noseLayers_(0), totalLayers_(0) {}
   ~HGCalTriggerTools() {}
 
   void setGeometry(const HGCalTriggerGeometryBase* const);
+  void eventSetup(const edm::EventSetup&);  // Kept for backward compatibility: used in L1Trigger/L1CaloTrigger/test
   GlobalPoint getTCPosition(const DetId& id) const;
   unsigned layers(ForwardSubdetector type) const;
   unsigned layers(DetId::Detector type) const;

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerTowerGeometryHelper.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerTowerGeometryHelper.h
@@ -30,7 +30,7 @@ public:
 
   ~HGCalTriggerTowerGeometryHelper() {}
 
-  void eventSetup(const edm::EventSetup& es) { triggerTools_.eventSetup(es); }
+  void setGeometry(const HGCalTriggerGeometryBase* const geom) { triggerTools_.setGeometry(geom); }
 
   const std::vector<l1t::HGCalTowerCoord>& getTowerCoordinates() const;
 

--- a/L1Trigger/L1THGCal/interface/backend/HGCalClusteringDummyImpl.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalClusteringDummyImpl.h
@@ -14,7 +14,7 @@ class HGCalClusteringDummyImpl {
 public:
   HGCalClusteringDummyImpl(const edm::ParameterSet& conf);
 
-  void eventSetup(const edm::EventSetup& es) { triggerTools_.eventSetup(es); }
+  void setGeometry(const HGCalTriggerGeometryBase* const geom) { triggerTools_.setGeometry(geom); }
 
   void clusterizeDummy(const std::vector<edm::Ptr<l1t::HGCalTriggerCell>>& triggerCellsPtrs,
                        l1t::HGCalClusterBxCollection& clusters);

--- a/L1Trigger/L1THGCal/interface/backend/HGCalClusteringImpl.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalClusteringImpl.h
@@ -22,7 +22,7 @@ private:
 public:
   HGCalClusteringImpl(const edm::ParameterSet& conf);
 
-  void eventSetup(const edm::EventSetup& es) { triggerTools_.eventSetup(es); }
+  void setGeometry(const HGCalTriggerGeometryBase* const geom) { triggerTools_.setGeometry(geom); }
 
   /* dR-algorithms */
   bool isPertinent(const l1t::HGCalTriggerCell& tc, const l1t::HGCalCluster& clu, double distXY) const;

--- a/L1Trigger/L1THGCal/interface/backend/HGCalHistoClusteringImpl.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalHistoClusteringImpl.h
@@ -15,9 +15,9 @@ class HGCalHistoClusteringImpl {
 public:
   HGCalHistoClusteringImpl(const edm::ParameterSet& conf);
 
-  void eventSetup(const edm::EventSetup& es) {
-    triggerTools_.eventSetup(es);
-    shape_.eventSetup(es);
+  void setGeometry(const HGCalTriggerGeometryBase* const geom) {
+    triggerTools_.setGeometry(geom);
+    shape_.setGeometry(geom);
     if ((!dr_byLayer_coefficientA_.empty() && (dr_byLayer_coefficientA_.size() - 1) < triggerTools_.lastLayerBH()) ||
         (!dr_byLayer_coefficientB_.empty() && (dr_byLayer_coefficientB_.size() - 1) < triggerTools_.lastLayerBH())) {
       throw cms::Exception("Configuration")

--- a/L1Trigger/L1THGCal/interface/backend/HGCalHistoSeedingImpl.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalHistoSeedingImpl.h
@@ -108,7 +108,7 @@ private:
 public:
   HGCalHistoSeedingImpl(const edm::ParameterSet& conf);
 
-  void eventSetup(const edm::EventSetup& es) { triggerTools_.eventSetup(es); }
+  void setGeometry(const HGCalTriggerGeometryBase* const geom) { triggerTools_.setGeometry(geom); }
 
   float dR(const l1t::HGCalCluster& clu, const GlobalPoint& seed) const;
 

--- a/L1Trigger/L1THGCal/interface/backend/HGCalMulticlusteringImpl.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalMulticlusteringImpl.h
@@ -15,9 +15,9 @@ class HGCalMulticlusteringImpl {
 public:
   HGCalMulticlusteringImpl(const edm::ParameterSet& conf);
 
-  void eventSetup(const edm::EventSetup& es) {
-    triggerTools_.eventSetup(es);
-    shape_.eventSetup(es);
+  void setGeometry(const HGCalTriggerGeometryBase* const geom) {
+    triggerTools_.setGeometry(geom);
+    shape_.setGeometry(geom);
   }
 
   bool isPertinent(const l1t::HGCalCluster& clu, const l1t::HGCalMulticluster& mclu, double dR) const;

--- a/L1Trigger/L1THGCal/interface/backend/HGCalShowerShape.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalShowerShape.h
@@ -18,7 +18,7 @@ public:
 
   ~HGCalShowerShape() {}
 
-  void eventSetup(const edm::EventSetup& es) { triggerTools_.eventSetup(es); }
+  void setGeometry(const HGCalTriggerGeometryBase* const geom) { triggerTools_.setGeometry(geom); }
 
   int firstLayer(const l1t::HGCalMulticluster& c3d) const;
   int lastLayer(const l1t::HGCalMulticluster& c3d) const;

--- a/L1Trigger/L1THGCal/interface/backend/HGCalTowerMap2DImpl.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalTowerMap2DImpl.h
@@ -3,7 +3,6 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Framework/interface/EventSetup.h"
 
 #include "DataFormats/L1THGCal/interface/HGCalTriggerSums.h"
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
@@ -49,9 +48,9 @@ public:
     }
   }
 
-  void eventSetup(const edm::EventSetup& es) {
-    triggerTools_.eventSetup(es);
-    towerGeometryHelper_.eventSetup(es);
+  void setGeometry(const HGCalTriggerGeometryBase* const geom) {
+    triggerTools_.setGeometry(geom);
+    towerGeometryHelper_.setGeometry(geom);
   }
 
 private:

--- a/L1Trigger/L1THGCal/interface/backend/HGCalTriggerClusterInterpreterBase.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalTriggerClusterInterpreterBase.h
@@ -3,13 +3,14 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "DataFormats/L1THGCal/interface/HGCalMulticluster.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
 
 class HGCalTriggerClusterInterpreterBase {
 public:
   HGCalTriggerClusterInterpreterBase(){};
   virtual ~HGCalTriggerClusterInterpreterBase(){};
   virtual void initialize(const edm::ParameterSet& conf) = 0;
-  virtual void eventSetup(const edm::EventSetup& es) = 0;
+  virtual void setGeometry(const HGCalTriggerGeometryBase* const) = 0;
   virtual void interpret(l1t::HGCalMulticlusterBxCollection& multiclusters) const = 0;
 };
 

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorAutoEncoderImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorAutoEncoderImpl.h
@@ -20,7 +20,7 @@ public:
               std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput,
               std::vector<l1t::HGCalConcentratorData>& ae_EncodedOutput);
 
-  void eventSetup(const edm::EventSetup& es) { triggerTools_.eventSetup(es); }
+  void setGeometry(const HGCalTriggerGeometryBase* const geom) { triggerTools_.setGeometry(geom); }
 
 private:
   static constexpr int nTriggerCells_ = 48;

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorBestChoiceImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorBestChoiceImpl.h
@@ -16,7 +16,7 @@ public:
               std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput,
               std::vector<l1t::HGCalTriggerCell>& trigCellVecNotSelected);
 
-  void eventSetup(const edm::EventSetup& es) { triggerTools_.eventSetup(es); }
+  void setGeometry(const HGCalTriggerGeometryBase* const geom) { triggerTools_.setGeometry(geom); }
 
 private:
   std::vector<unsigned> nData_;

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorCoarsenerImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorCoarsenerImpl.h
@@ -13,10 +13,10 @@ public:
 
   void coarsen(const std::vector<l1t::HGCalTriggerCell>& trigCellVecInput,
                std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput);
-  void eventSetup(const edm::EventSetup& es) {
-    triggerTools_.eventSetup(es);
-    coarseTCmapping_.eventSetup(es);
-    calibration_.eventSetup(es);
+  void setGeometry(const HGCalTriggerGeometryBase* const geom) {
+    triggerTools_.setGeometry(geom);
+    coarseTCmapping_.setGeometry(geom);
+    calibration_.setGeometry(geom);
   }
 
 private:

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorProcessorSelection.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorProcessorSelection.h
@@ -27,8 +27,7 @@ public:
   void run(const edm::Handle<l1t::HGCalTriggerCellBxCollection>& triggerCellCollInput,
            std::tuple<l1t::HGCalTriggerCellBxCollection,
                       l1t::HGCalTriggerSumsBxCollection,
-                      l1t::HGCalConcentratorDataBxCollection>& triggerCollOutput,
-           const edm::EventSetup& es) override;
+                      l1t::HGCalConcentratorDataBxCollection>& triggerCollOutput) override;
 
 private:
   bool fixedDataSizePerHGCROC_;

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
@@ -16,14 +16,14 @@ public:
 
   void select(const std::vector<l1t::HGCalTriggerCell>& trigCellVecInput,
               std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput);
-  void eventSetup(const edm::EventSetup& es) {
-    triggerTools_.eventSetup(es);
-    coarseTCmapping_.eventSetup(es);
-    superTCmapping_.eventSetup(es);
-    calibrationEE_.eventSetup(es);
-    calibrationHEsi_.eventSetup(es);
-    calibrationHEsc_.eventSetup(es);
-    calibrationNose_.eventSetup(es);
+  void setGeometry(const HGCalTriggerGeometryBase* const geom) {
+    triggerTools_.setGeometry(geom);
+    coarseTCmapping_.setGeometry(geom);
+    superTCmapping_.setGeometry(geom);
+    calibrationEE_.setGeometry(geom);
+    calibrationHEsi_.setGeometry(geom);
+    calibrationHEsc_.setGeometry(geom);
+    calibrationNose_.setGeometry(geom);
   }
 
 private:

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorThresholdImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorThresholdImpl.h
@@ -14,7 +14,7 @@ public:
               std::vector<l1t::HGCalTriggerCell>& trigCellVecOutput,
               std::vector<l1t::HGCalTriggerCell>& trigCellVecNotSelected);
 
-  void eventSetup(const edm::EventSetup& es) { triggerTools_.eventSetup(es); }
+  void setGeometry(const HGCalTriggerGeometryBase* const geom) { triggerTools_.setGeometry(geom); }
 
 private:
   double threshold_silicon_;

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorTrigSumImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorTrigSumImpl.h
@@ -15,7 +15,7 @@ public:
              const std::vector<l1t::HGCalTriggerCell>& trigCellVecInput,
              std::vector<l1t::HGCalTriggerSums>& trigSumsVecOutput) const;
 
-  void eventSetup(const edm::EventSetup& es) { triggerTools_.eventSetup(es); }
+  void setGeometry(const HGCalTriggerGeometryBase* const geom) { triggerTools_.setGeometry(geom); }
 
 private:
   HGCalTriggerTools triggerTools_;

--- a/L1Trigger/L1THGCal/interface/veryfrontend/HGCalVFEProcessorSums.h
+++ b/L1Trigger/L1THGCal/interface/veryfrontend/HGCalVFEProcessorSums.h
@@ -13,9 +13,7 @@ class HGCalVFEProcessorSums : public HGCalVFEProcessorBase {
 public:
   HGCalVFEProcessorSums(const edm::ParameterSet& conf);
 
-  void run(const HGCalDigiCollection& digiColl,
-           l1t::HGCalTriggerCellBxCollection& triggerCellColl,
-           const edm::EventSetup& es) override;
+  void run(const HGCalDigiCollection& digiColl, l1t::HGCalTriggerCellBxCollection& triggerCellColl) override;
 
 private:
   std::unique_ptr<HGCalVFELinearizationImpl> vfeLinearizationSiImpl_;

--- a/L1Trigger/L1THGCal/interface/veryfrontend/HGCalVFESummationImpl.h
+++ b/L1Trigger/L1THGCal/interface/veryfrontend/HGCalVFESummationImpl.h
@@ -13,7 +13,7 @@ class HGCalVFESummationImpl {
 public:
   HGCalVFESummationImpl(const edm::ParameterSet& conf);
 
-  void eventSetup(const edm::EventSetup& es) { triggerTools_.eventSetup(es); }
+  void setGeometry(const HGCalTriggerGeometryBase* const geom) { triggerTools_.setGeometry(geom); }
   void triggerCellSums(const std::vector<std::pair<DetId, uint32_t> >&, std::unordered_map<uint32_t, uint32_t>&);
 
 private:

--- a/L1Trigger/L1THGCal/plugins/HGCalBackendLayer1Producer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalBackendLayer1Producer.cc
@@ -61,6 +61,6 @@ void HGCalBackendLayer1Producer::produce(edm::Event& e, const edm::EventSetup& e
   edm::Handle<l1t::HGCalTriggerCellBxCollection> trigCellBxColl;
 
   e.getByToken(input_cell_, trigCellBxColl);
-  backendProcess_->run(trigCellBxColl, *be_cluster_output, es);
+  backendProcess_->run(trigCellBxColl, *be_cluster_output);
   e.put(std::move(be_cluster_output), backendProcess_->name());
 }

--- a/L1Trigger/L1THGCal/plugins/HGCalBackendLayer2Producer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalBackendLayer2Producer.cc
@@ -64,7 +64,7 @@ void HGCalBackendLayer2Producer::produce(edm::Event& e, const edm::EventSetup& e
 
   e.getByToken(input_clusters_, trigCluster2DBxColl);
 
-  backendProcess_->run(trigCluster2DBxColl, be_output, es);
+  backendProcess_->run(trigCluster2DBxColl, be_output);
 
   e.put(std::make_unique<l1t::HGCalMulticlusterBxCollection>(std::move(be_output.first)), backendProcess_->name());
   e.put(std::make_unique<l1t::HGCalClusterBxCollection>(std::move(be_output.second)),

--- a/L1Trigger/L1THGCal/plugins/HGCalConcentratorProducer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalConcentratorProducer.cc
@@ -53,7 +53,6 @@ HGCalConcentratorProducer::HGCalConcentratorProducer(const edm::ParameterSet& co
 
 void HGCalConcentratorProducer::beginRun(const edm::Run& /*run*/, const edm::EventSetup& es) {
   triggerGeometry_ = es.getHandle(triggerGeomToken_);
-
   concentratorProcess_->setGeometry(triggerGeometry_.product());
 }
 
@@ -66,7 +65,7 @@ void HGCalConcentratorProducer::produce(edm::Event& e, const edm::EventSetup& es
   edm::Handle<l1t::HGCalTriggerCellBxCollection> trigCellBxColl;
 
   e.getByToken(input_cell_, trigCellBxColl);
-  concentratorProcess_->run(trigCellBxColl, cc_output, es);
+  concentratorProcess_->run(trigCellBxColl, cc_output);
   // Put in the event
   e.put(std::make_unique<l1t::HGCalTriggerCellBxCollection>(std::move(std::get<0>(cc_output))),
         concentratorProcess_->name());

--- a/L1Trigger/L1THGCal/plugins/HGCalTowerMapProducer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalTowerMapProducer.cc
@@ -59,7 +59,7 @@ void HGCalTowerMapProducer::produce(edm::Event& e, const edm::EventSetup& es) {
 
   e.getByToken(input_sums_, trigSumBxColl);
 
-  towersMapProcess_->run(trigSumBxColl, *towersMap_output, es);
+  towersMapProcess_->run(trigSumBxColl, *towersMap_output);
 
   e.put(std::move(towersMap_output), towersMapProcess_->name());
 }

--- a/L1Trigger/L1THGCal/plugins/HGCalTowerProducer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalTowerProducer.cc
@@ -48,7 +48,6 @@ HGCalTowerProducer::HGCalTowerProducer(const edm::ParameterSet& conf)
 }
 
 void HGCalTowerProducer::beginRun(const edm::Run& /*run*/, const edm::EventSetup& es) {
-  towersProcess_->eventSetup(es);
   triggerGeometry_ = es.getHandle(triggerGeomToken_);
   towersProcess_->setGeometry(triggerGeometry_.product());
 }
@@ -65,7 +64,7 @@ void HGCalTowerProducer::produce(edm::Event& e, const edm::EventSetup& es) {
   e.getByToken(input_towers_map_, towersMapBxColl);
   e.getByToken(input_trigger_cells_, clustersBxColl);
 
-  towersProcess_->run(inputsColl, *towers_output, es);
+  towersProcess_->run(inputsColl, *towers_output);
 
   e.put(std::move(towers_output), towersProcess_->name());
 }

--- a/L1Trigger/L1THGCal/plugins/HGCalVFEProducer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalVFEProducer.cc
@@ -68,17 +68,17 @@ void HGCalVFEProducer::produce(edm::Event& e, const edm::EventSetup& es) {
   // Processing DigiCollections and putting the results into the HGCalTriggerCellBxCollectio
   if (ee_digis_h.isValid()) {
     const HGCalDigiCollection& ee_digis = *ee_digis_h;
-    vfeProcess_->run(ee_digis, *vfe_trigcell_output, es);
+    vfeProcess_->run(ee_digis, *vfe_trigcell_output);
   }
 
   if (fh_digis_h.isValid()) {
     const HGCalDigiCollection& fh_digis = *fh_digis_h;
-    vfeProcess_->run(fh_digis, *vfe_trigcell_output, es);
+    vfeProcess_->run(fh_digis, *vfe_trigcell_output);
   }
 
   if (bh_digis_h.isValid()) {
     const HGCalDigiCollection& bh_digis = *bh_digis_h;
-    vfeProcess_->run(bh_digis, *vfe_trigcell_output, es);
+    vfeProcess_->run(bh_digis, *vfe_trigcell_output);
   }
 
   // Put in the event

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalBackendLayer1Processor2DClustering.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalBackendLayer1Processor2DClustering.cc
@@ -29,13 +29,11 @@ public:
   }
 
   void run(const edm::Handle<l1t::HGCalTriggerCellBxCollection>& collHandle,
-           l1t::HGCalClusterBxCollection& collCluster2D,
-           const edm::EventSetup& es) override {
-    es.get<CaloGeometryRecord>().get("", triggerGeometry_);
+           l1t::HGCalClusterBxCollection& collCluster2D) override {
     if (clustering_)
-      clustering_->eventSetup(es);
+      clustering_->setGeometry(geometry());
     if (clusteringDummy_)
-      clusteringDummy_->eventSetup(es);
+      clusteringDummy_->setGeometry(geometry());
 
     /* create a persistent vector of pointers to the trigger-cells */
     std::vector<edm::Ptr<l1t::HGCalTriggerCell>> triggerCellsPtrs;
@@ -56,10 +54,10 @@ public:
         clustering_->clusterizeDR(triggerCellsPtrs, collCluster2D);
         break;
       case NNC2d:
-        clustering_->clusterizeNN(triggerCellsPtrs, collCluster2D, *triggerGeometry_);
+        clustering_->clusterizeNN(triggerCellsPtrs, collCluster2D, *geometry());
         break;
       case dRNNC2d:
-        clustering_->clusterizeDRNN(triggerCellsPtrs, collCluster2D, *triggerGeometry_);
+        clustering_->clusterizeDRNN(triggerCellsPtrs, collCluster2D, *geometry());
         break;
       case dummyC2d:
         clusteringDummy_->clusterizeDummy(triggerCellsPtrs, collCluster2D);
@@ -72,8 +70,6 @@ public:
 
 private:
   enum ClusterType { dRC2d, NNC2d, dRNNC2d, dummyC2d };
-
-  edm::ESHandle<HGCalTriggerGeometryBase> triggerGeometry_;
 
   /* algorithms instances */
   std::unique_ptr<HGCalClusteringImpl> clustering_;

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalTowerMapProcessor.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalTowerMapProcessor.cc
@@ -15,10 +15,8 @@ public:
   }
 
   void run(const edm::Handle<l1t::HGCalTriggerSumsBxCollection>& collHandle,
-           l1t::HGCalTowerMapBxCollection& collTowerMap,
-           const edm::EventSetup& es) override {
-    es.get<CaloGeometryRecord>().get("", triggerGeometry_);
-    towermap2D_->eventSetup(es);
+           l1t::HGCalTowerMapBxCollection& collTowerMap) override {
+    towermap2D_->setGeometry(geometry());
 
     /* create a persistent vector of pointers to the trigger-sums */
     std::vector<edm::Ptr<l1t::HGCalTriggerSums>> triggerSumsPtrs;
@@ -32,8 +30,6 @@ public:
   }
 
 private:
-  edm::ESHandle<HGCalTriggerGeometryBase> triggerGeometry_;
-
   /* algorithms instances */
   std::unique_ptr<HGCalTowerMap2DImpl> towermap2D_;
 };

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalTowerProcessor.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalTowerProcessor.cc
@@ -17,14 +17,14 @@ public:
     towermap3D_ = std::make_unique<HGCalTowerMap3DImpl>();
   }
 
-  void eventSetup(const edm::EventSetup& es) override { towermap2D_->eventSetup(es); }
+  void setGeometry(const HGCalTriggerGeometryBase* const geom) override {
+    HGCalTowerProcessorBase::setGeometry(geom);
+    towermap2D_->setGeometry(geom);
+  }
 
   void run(const std::pair<edm::Handle<l1t::HGCalTowerMapBxCollection>, edm::Handle<l1t::HGCalClusterBxCollection>>&
                collHandle,
-           l1t::HGCalTowerBxCollection& collTowers,
-           const edm::EventSetup& es) override {
-    es.get<CaloGeometryRecord>().get("", triggerGeometry_);
-
+           l1t::HGCalTowerBxCollection& collTowers) override {
     auto& towerMapCollHandle = collHandle.first;
     auto& unclTCsCollHandle = collHandle.second;
 
@@ -65,7 +65,6 @@ public:
   }
 
 private:
-  edm::ESHandle<HGCalTriggerGeometryBase> triggerGeometry_;
   bool includeTrigCells_;
 
   /* algorithms instances */

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalTriggerClusterInterpretationEM.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalTriggerClusterInterpretationEM.cc
@@ -9,7 +9,7 @@ public:
   HGCalTriggerClusterInterpretationEM();
   ~HGCalTriggerClusterInterpretationEM() override{};
   void initialize(const edm::ParameterSet& conf) final;
-  void eventSetup(const edm::EventSetup& es) final;
+  void setGeometry(const HGCalTriggerGeometryBase* const) final;
   void interpret(l1t::HGCalMulticlusterBxCollection& multiclusters) const final;
 
 private:
@@ -42,7 +42,9 @@ void HGCalTriggerClusterInterpretationEM::initialize(const edm::ParameterSet& co
   }
 }
 
-void HGCalTriggerClusterInterpretationEM::eventSetup(const edm::EventSetup& es) { triggerTools_.eventSetup(es); }
+void HGCalTriggerClusterInterpretationEM::setGeometry(const HGCalTriggerGeometryBase* const geom) {
+  triggerTools_.setGeometry(geom);
+}
 
 void HGCalTriggerClusterInterpretationEM::interpret(l1t::HGCalMulticlusterBxCollection& multiclusters) const {
   for (unsigned int idx = 0; idx != multiclusters.size(); idx++) {

--- a/L1Trigger/L1THGCal/plugins/concentrator/HGCalConcentratorProcessorSelection.cc
+++ b/L1Trigger/L1THGCal/plugins/concentrator/HGCalConcentratorProcessorSelection.cc
@@ -55,21 +55,20 @@ HGCalConcentratorProcessorSelection::HGCalConcentratorProcessorSelection(const e
 void HGCalConcentratorProcessorSelection::run(const edm::Handle<l1t::HGCalTriggerCellBxCollection>& triggerCellCollInput,
                                               std::tuple<l1t::HGCalTriggerCellBxCollection,
                                                          l1t::HGCalTriggerSumsBxCollection,
-                                                         l1t::HGCalConcentratorDataBxCollection>& triggerCollOutput,
-                                              const edm::EventSetup& es) {
+                                                         l1t::HGCalConcentratorDataBxCollection>& triggerCollOutput) {
   if (thresholdImpl_)
-    thresholdImpl_->eventSetup(es);
+    thresholdImpl_->setGeometry(geometry());
   if (bestChoiceImpl_)
-    bestChoiceImpl_->eventSetup(es);
+    bestChoiceImpl_->setGeometry(geometry());
   if (superTriggerCellImpl_)
-    superTriggerCellImpl_->eventSetup(es);
+    superTriggerCellImpl_->setGeometry(geometry());
   if (autoEncoderImpl_)
-    autoEncoderImpl_->eventSetup(es);
+    autoEncoderImpl_->setGeometry(geometry());
   if (coarsenerImpl_)
-    coarsenerImpl_->eventSetup(es);
+    coarsenerImpl_->setGeometry(geometry());
   if (trigSumImpl_)
-    trigSumImpl_->eventSetup(es);
-  triggerTools_.eventSetup(es);
+    trigSumImpl_->setGeometry(geometry());
+  triggerTools_.setGeometry(geometry());
 
   auto& triggerCellCollOutput = std::get<0>(triggerCollOutput);
   auto& triggerSumCollOutput = std::get<1>(triggerCollOutput);
@@ -79,7 +78,7 @@ void HGCalConcentratorProcessorSelection::run(const edm::Handle<l1t::HGCalTrigge
 
   std::unordered_map<uint32_t, std::vector<l1t::HGCalTriggerCell>> tc_modules;
   for (const auto& trigCell : collInput) {
-    uint32_t module = geometry_->getModuleFromTriggerCell(trigCell.detId());
+    uint32_t module = geometry()->getModuleFromTriggerCell(trigCell.detId());
     tc_modules[module].push_back(trigCell);
   }
 
@@ -103,14 +102,14 @@ void HGCalConcentratorProcessorSelection::run(const edm::Handle<l1t::HGCalTrigge
           break;
         case bestChoiceSelect:
           if (triggerTools_.isEm(module_trigcell.first)) {
-            bestChoiceImpl_->select(geometry_->getLinksInModule(module_trigcell.first),
-                                    geometry_->getModuleSize(module_trigcell.first),
+            bestChoiceImpl_->select(geometry()->getLinksInModule(module_trigcell.first),
+                                    geometry()->getModuleSize(module_trigcell.first),
                                     module_trigcell.second,
                                     trigCellVecOutput,
                                     trigCellVecNotSelected);
           } else {
-            bestChoiceImpl_->select(geometry_->getLinksInModule(module_trigcell.first),
-                                    geometry_->getModuleSize(module_trigcell.first),
+            bestChoiceImpl_->select(geometry()->getLinksInModule(module_trigcell.first),
+                                    geometry()->getModuleSize(module_trigcell.first),
                                     trigCellVecCoarsened,
                                     trigCellVecOutput,
                                     trigCellVecNotSelected);
@@ -120,7 +119,7 @@ void HGCalConcentratorProcessorSelection::run(const edm::Handle<l1t::HGCalTrigge
           superTriggerCellImpl_->select(trigCellVecCoarsened, trigCellVecOutput);
           break;
         case autoEncoderSelect:
-          autoEncoderImpl_->select(geometry_->getLinksInModule(module_trigcell.first),
+          autoEncoderImpl_->select(geometry()->getLinksInModule(module_trigcell.first),
                                    trigCellVecCoarsened,
                                    trigCellVecOutput,
                                    ae_EncodedLayerOutput);
@@ -139,8 +138,8 @@ void HGCalConcentratorProcessorSelection::run(const edm::Handle<l1t::HGCalTrigge
           thresholdImpl_->select(module_trigcell.second, trigCellVecOutput, trigCellVecNotSelected);
           break;
         case bestChoiceSelect:
-          bestChoiceImpl_->select(geometry_->getLinksInModule(module_trigcell.first),
-                                  geometry_->getModuleSize(module_trigcell.first),
+          bestChoiceImpl_->select(geometry()->getLinksInModule(module_trigcell.first),
+                                  geometry()->getModuleSize(module_trigcell.first),
                                   module_trigcell.second,
                                   trigCellVecOutput,
                                   trigCellVecNotSelected);
@@ -149,7 +148,7 @@ void HGCalConcentratorProcessorSelection::run(const edm::Handle<l1t::HGCalTrigge
           superTriggerCellImpl_->select(module_trigcell.second, trigCellVecOutput);
           break;
         case autoEncoderSelect:
-          autoEncoderImpl_->select(geometry_->getLinksInModule(module_trigcell.first),
+          autoEncoderImpl_->select(geometry()->getLinksInModule(module_trigcell.first),
                                    module_trigcell.second,
                                    trigCellVecOutput,
                                    ae_EncodedLayerOutput);

--- a/L1Trigger/L1THGCal/plugins/veryfrontend/HGCalVFEProcessorSums.cc
+++ b/L1Trigger/L1THGCal/plugins/veryfrontend/HGCalVFEProcessorSums.cc
@@ -26,14 +26,13 @@ HGCalVFEProcessorSums::HGCalVFEProcessorSums(const edm::ParameterSet& conf) : HG
 }
 
 void HGCalVFEProcessorSums::run(const HGCalDigiCollection& digiColl,
-                                l1t::HGCalTriggerCellBxCollection& triggerCellColl,
-                                const edm::EventSetup& es) {
-  vfeSummationImpl_->eventSetup(es);
-  calibrationEE_->eventSetup(es);
-  calibrationHEsi_->eventSetup(es);
-  calibrationHEsc_->eventSetup(es);
-  calibrationNose_->eventSetup(es);
-  triggerTools_.eventSetup(es);
+                                l1t::HGCalTriggerCellBxCollection& triggerCellColl) {
+  vfeSummationImpl_->setGeometry(geometry());
+  calibrationEE_->setGeometry(geometry());
+  calibrationHEsi_->setGeometry(geometry());
+  calibrationHEsc_->setGeometry(geometry());
+  calibrationNose_->setGeometry(geometry());
+  triggerTools_.setGeometry(geometry());
 
   std::vector<HGCalDataFrame> dataframes;
   std::vector<std::pair<DetId, uint32_t>> linearized_dataframes;
@@ -44,13 +43,13 @@ void HGCalVFEProcessorSums::run(const HGCalDigiCollection& digiColl,
   for (const auto& digiData : digiColl) {
     if (DetId(digiData.id()).det() == DetId::Hcal && HcalDetId(digiData.id()).subdetId() != HcalEndcap)
       continue;
-    if (!geometry_->validCell(digiData.id()))
+    if (!geometry()->validCell(digiData.id()))
       continue;
-    uint32_t module = geometry_->getModuleFromCell(digiData.id());
+    uint32_t module = geometry()->getModuleFromCell(digiData.id());
 
     // no disconnected layer for HFNose
     if (DetId(digiData.id()).subdetId() != ForwardSubdetector::HFNose) {
-      if (geometry_->disconnectedModule(module))
+      if (geometry()->disconnectedModule(module))
         continue;
     }
 
@@ -89,7 +88,7 @@ void HGCalVFEProcessorSums::run(const HGCalDigiCollection& digiColl,
       l1t::HGCalTriggerCell triggerCell(reco::LeafCandidate::LorentzVector(), tc_compressed_value, 0, 0, 0, tc_id);
       triggerCell.setCompressedCharge(tc_compressed_code);
       triggerCell.setUncompressedCharge(tc_value);
-      GlobalPoint point = geometry_->getTriggerCellPosition(tc_id);
+      GlobalPoint point = geometry()->getTriggerCellPosition(tc_id);
 
       // 'value' is hardware, so p4 is meaningless, except for eta and phi
       math::PtEtaPhiMLorentzVector p4((double)tc_compressed_value / cosh(point.eta()), point.eta(), point.phi(), 0.);

--- a/L1Trigger/L1THGCal/src/HGCalTriggerTools.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerTools.cc
@@ -10,6 +10,10 @@
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "SimDataFormats/CaloTest/interface/HGCalTestNumbering.h"
 
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "FWCore/Framework/interface/EventSetup.h"
+
 namespace {
   template <typename DDD>
   inline void check_ddd(const DDD* ddd) {
@@ -25,6 +29,13 @@ namespace {
     }
   }
 }  // namespace
+
+// Kept for backward compatibility: used in L1Trigger/L1CaloTrigger/test
+void HGCalTriggerTools::eventSetup(const edm::EventSetup& es) {
+  edm::ESHandle<HGCalTriggerGeometryBase> triggerGeometry;
+  es.get<CaloGeometryRecord>().get(triggerGeometry);
+  setGeometry(triggerGeometry.product());
+}
 
 void HGCalTriggerTools::setGeometry(const HGCalTriggerGeometryBase* const geom) {
   geom_ = geom;

--- a/L1Trigger/L1THGCal/src/HGCalTriggerTools.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerTools.cc
@@ -10,10 +10,6 @@
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "SimDataFormats/CaloTest/interface/HGCalTestNumbering.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
-
-#include "FWCore/Framework/interface/EventSetup.h"
-
 namespace {
   template <typename DDD>
   inline void check_ddd(const DDD* ddd) {
@@ -30,11 +26,8 @@ namespace {
   }
 }  // namespace
 
-void HGCalTriggerTools::eventSetup(const edm::EventSetup& es) {
-  edm::ESHandle<HGCalTriggerGeometryBase> triggerGeometry_;
-  es.get<CaloGeometryRecord>().get(triggerGeometry_);
-  geom_ = triggerGeometry_.product();
-
+void HGCalTriggerTools::setGeometry(const HGCalTriggerGeometryBase* const geom) {
+  geom_ = geom;
   eeLayers_ = geom_->eeTopology().dddConstants().layers(true);
   fhLayers_ = geom_->fhTopology().dddConstants().layers(true);
   if (geom_->isWithNoseGeometry())

--- a/L1Trigger/L1THGCalUtilities/interface/HGCalTriggerNtupleBase.h
+++ b/L1Trigger/L1THGCalUtilities/interface/HGCalTriggerNtupleBase.h
@@ -6,20 +6,8 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-// #include "SimGeneral/HepPDTRecord/interface/PDTRecord.h"
-// #include "SimGeneral/HepPDTRecord/interface/ParticleDataTable.h"
-// #include "MagneticField/Engine/interface/MagneticField.h"
-// #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "TTree.h"
-
-// #include "MagneticField/Engine/interface/MagneticField.h"
-// #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
-// #include "TrackPropagation/RungeKutta/interface/defaultRKPropagator.h"
-// #include "TrackPropagation/RungeKutta/interface/RKPropagatorInS.h"
-// #include "FastSimulation/Event/interface/FSimEvent.h"
-// #include "SimGeneral/HepPDTRecord/interface/PDTRecord.h"
-//
-// #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 
 namespace HepPDT {
   class ParticleDataTable;
@@ -35,13 +23,31 @@ struct HGCalTriggerNtupleEventSetup {
 
 class HGCalTriggerNtupleBase {
 public:
-  HGCalTriggerNtupleBase(const edm::ParameterSet& conf){};
+  HGCalTriggerNtupleBase(const edm::ParameterSet& conf) : name_(conf.getParameter<std::string>("NtupleName")){};
   virtual ~HGCalTriggerNtupleBase(){};
+  const std::string& name() const { return name_; }
   virtual void initialize(TTree&, const edm::ParameterSet&, edm::ConsumesCollector&&) = 0;
-  virtual void fill(const edm::Event&, const HGCalTriggerNtupleEventSetup&) = 0;
+  virtual void fill(const edm::Event&, const HGCalTriggerNtupleEventSetup&) {
+    edm::LogWarning("NotImplemented") << "Calling ntuplizer fill(edm::Event, HGCalTriggerNtupleEventSetup), but it is "
+                                         "not implemented in the concrete class '"
+                                      << name() << "'. "
+                                      << "You might want to set 'accessEventSetup_' to true in order to call "
+                                         "fill(edm::Event, edm::EventSetup) instead.";
+  }
+  // Kept for backward compatibility: used in L1Trigger/L1CaloTrigger/test
+  virtual void fill(const edm::Event&, const edm::EventSetup&) {
+    edm::LogWarning("NotImplemented")
+        << "Calling ntuplizer fill(edm::Event, edm::EventSetup), but it is not implemented in the concrete class '"
+        << name() << "'. "
+        << "You might want to set 'accessEventSetup_' to false in order to call fill(edm::Event, "
+           "HGCalTriggerNtupleEventSetup) instead.";
+  }
+  bool accessEventSetup() const { return accessEventSetup_; }
 
 protected:
   virtual void clear() = 0;
+  bool accessEventSetup_ = true;
+  const std::string name_;
 };
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"

--- a/L1Trigger/L1THGCalUtilities/interface/HGCalTriggerNtupleBase.h
+++ b/L1Trigger/L1THGCalUtilities/interface/HGCalTriggerNtupleBase.h
@@ -3,16 +3,42 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+// #include "SimGeneral/HepPDTRecord/interface/PDTRecord.h"
+// #include "SimGeneral/HepPDTRecord/interface/ParticleDataTable.h"
+// #include "MagneticField/Engine/interface/MagneticField.h"
+// #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
 #include "TTree.h"
+
+// #include "MagneticField/Engine/interface/MagneticField.h"
+// #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+// #include "TrackPropagation/RungeKutta/interface/defaultRKPropagator.h"
+// #include "TrackPropagation/RungeKutta/interface/RKPropagatorInS.h"
+// #include "FastSimulation/Event/interface/FSimEvent.h"
+// #include "SimGeneral/HepPDTRecord/interface/PDTRecord.h"
+//
+// #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+
+namespace HepPDT {
+  class ParticleDataTable;
+}
+class MagneticField;
+class HGCalTriggerGeometryBase;
+
+struct HGCalTriggerNtupleEventSetup {
+  edm::ESHandle<HepPDT::ParticleDataTable> pdt;
+  edm::ESHandle<MagneticField> magfield;
+  edm::ESHandle<HGCalTriggerGeometryBase> geometry;
+};
 
 class HGCalTriggerNtupleBase {
 public:
   HGCalTriggerNtupleBase(const edm::ParameterSet& conf){};
   virtual ~HGCalTriggerNtupleBase(){};
   virtual void initialize(TTree&, const edm::ParameterSet&, edm::ConsumesCollector&&) = 0;
-  virtual void fill(const edm::Event&, const edm::EventSetup&) = 0;
+  virtual void fill(const edm::Event&, const HGCalTriggerNtupleEventSetup&) = 0;
 
 protected:
   virtual void clear() = 0;

--- a/L1Trigger/L1THGCalUtilities/plugins/CaloTruthCellsProducer.cc
+++ b/L1Trigger/L1THGCalUtilities/plugins/CaloTruthCellsProducer.cc
@@ -79,13 +79,13 @@ void CaloTruthCellsProducer::produce(edm::Event& event, edm::EventSetup const& s
   event.getByToken(triggerCellsToken_, triggerCellsHandle);
   auto const& triggerCells(*triggerCellsHandle);
 
-  dummyClustering_.eventSetup(setup);
-  showerShape_.eventSetup(setup);
-  triggerTools_.eventSetup(setup);
-
   edm::ESHandle<HGCalTriggerGeometryBase> geometryHandle;
   setup.get<CaloGeometryRecord>().get(geometryHandle);
   auto const& geometry(*geometryHandle);
+
+  dummyClustering_.setGeometry(geometryHandle.product());
+  showerShape_.setGeometry(geometryHandle.product());
+  triggerTools_.setGeometry(geometryHandle.product());
 
   std::unordered_map<uint32_t, CaloParticleRef> tcToCalo;
 

--- a/L1Trigger/L1THGCalUtilities/plugins/CaloTruthCellsProducer.cc
+++ b/L1Trigger/L1THGCalUtilities/plugins/CaloTruthCellsProducer.cc
@@ -31,6 +31,7 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
+  void beginRun(const edm::Run&, const edm::EventSetup&) override;
   void produce(edm::Event&, edm::EventSetup const&) override;
 
   std::unordered_map<uint32_t, double> makeHitMap(edm::Event const&,
@@ -45,6 +46,8 @@ private:
   edm::EDGetTokenT<std::vector<PCaloHit>> simHitsTokenEE_;
   edm::EDGetTokenT<std::vector<PCaloHit>> simHitsTokenHEfront_;
   edm::EDGetTokenT<std::vector<PCaloHit>> simHitsTokenHEback_;
+  edm::ESGetToken<HGCalTriggerGeometryBase, CaloGeometryRecord> triggerGeomToken_;
+  edm::ESHandle<HGCalTriggerGeometryBase> triggerGeomHandle_;
 
   HGCalClusteringDummyImpl dummyClustering_;
   HGCalShowerShape showerShape_;
@@ -60,6 +63,7 @@ CaloTruthCellsProducer::CaloTruthCellsProducer(edm::ParameterSet const& config)
       simHitsTokenEE_(consumes<std::vector<PCaloHit>>(config.getParameter<edm::InputTag>("simHitsEE"))),
       simHitsTokenHEfront_(consumes<std::vector<PCaloHit>>(config.getParameter<edm::InputTag>("simHitsHEfront"))),
       simHitsTokenHEback_(consumes<std::vector<PCaloHit>>(config.getParameter<edm::InputTag>("simHitsHEback"))),
+      triggerGeomToken_(esConsumes<HGCalTriggerGeometryBase, CaloGeometryRecord, edm::Transition::BeginRun>()),
       dummyClustering_(config.getParameterSet("dummyClustering")) {
   produces<CaloToCellsMap>();
   produces<l1t::HGCalClusterBxCollection>();
@@ -70,6 +74,10 @@ CaloTruthCellsProducer::CaloTruthCellsProducer(edm::ParameterSet const& config)
 
 CaloTruthCellsProducer::~CaloTruthCellsProducer() {}
 
+void CaloTruthCellsProducer::beginRun(const edm::Run& /*run*/, const edm::EventSetup& es) {
+  triggerGeomHandle_ = es.getHandle(triggerGeomToken_);
+}
+
 void CaloTruthCellsProducer::produce(edm::Event& event, edm::EventSetup const& setup) {
   edm::Handle<CaloParticleCollection> caloParticlesHandle;
   event.getByToken(caloParticlesToken_, caloParticlesHandle);
@@ -79,13 +87,11 @@ void CaloTruthCellsProducer::produce(edm::Event& event, edm::EventSetup const& s
   event.getByToken(triggerCellsToken_, triggerCellsHandle);
   auto const& triggerCells(*triggerCellsHandle);
 
-  edm::ESHandle<HGCalTriggerGeometryBase> geometryHandle;
-  setup.get<CaloGeometryRecord>().get(geometryHandle);
-  auto const& geometry(*geometryHandle);
+  auto const& geometry(*triggerGeomHandle_);
 
-  dummyClustering_.setGeometry(geometryHandle.product());
-  showerShape_.setGeometry(geometryHandle.product());
-  triggerTools_.setGeometry(geometryHandle.product());
+  dummyClustering_.setGeometry(triggerGeomHandle_.product());
+  showerShape_.setGeometry(triggerGeomHandle_.product());
+  triggerTools_.setGeometry(triggerGeomHandle_.product());
 
   std::unordered_map<uint32_t, CaloParticleRef> tcToCalo;
 

--- a/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleEvent.cc
+++ b/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleEvent.cc
@@ -5,7 +5,7 @@ public:
   HGCalTriggerNtupleEvent(const edm::ParameterSet&);
 
   void initialize(TTree&, const edm::ParameterSet&, edm::ConsumesCollector&&) final;
-  void fill(const edm::Event&, const edm::EventSetup&) final;
+  void fill(const edm::Event&, const HGCalTriggerNtupleEventSetup&) final;
 
 private:
   void clear() final;
@@ -26,7 +26,7 @@ void HGCalTriggerNtupleEvent::initialize(TTree& tree, const edm::ParameterSet&, 
   tree.Branch("lumi", &lumi_, "lumi/I");
 }
 
-void HGCalTriggerNtupleEvent::fill(const edm::Event& e, const edm::EventSetup& es) {
+void HGCalTriggerNtupleEvent::fill(const edm::Event& e, const HGCalTriggerNtupleEventSetup& es) {
   run_ = e.id().run();
   lumi_ = e.luminosityBlock();
   event_ = e.id().event();

--- a/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleEvent.cc
+++ b/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleEvent.cc
@@ -17,7 +17,9 @@ private:
 
 DEFINE_EDM_PLUGIN(HGCalTriggerNtupleFactory, HGCalTriggerNtupleEvent, "HGCalTriggerNtupleEvent");
 
-HGCalTriggerNtupleEvent::HGCalTriggerNtupleEvent(const edm::ParameterSet& conf) : HGCalTriggerNtupleBase(conf) {}
+HGCalTriggerNtupleEvent::HGCalTriggerNtupleEvent(const edm::ParameterSet& conf) : HGCalTriggerNtupleBase(conf) {
+  accessEventSetup_ = false;
+}
 
 void HGCalTriggerNtupleEvent::initialize(TTree& tree, const edm::ParameterSet&, edm::ConsumesCollector&&) {
   clear();

--- a/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleGen.cc
+++ b/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleGen.cc
@@ -189,7 +189,9 @@ private:
 
 DEFINE_EDM_PLUGIN(HGCalTriggerNtupleFactory, HGCalTriggerNtupleGen, "HGCalTriggerNtupleGen");
 
-HGCalTriggerNtupleGen::HGCalTriggerNtupleGen(const edm::ParameterSet &conf) : HGCalTriggerNtupleBase(conf) {}
+HGCalTriggerNtupleGen::HGCalTriggerNtupleGen(const edm::ParameterSet &conf) : HGCalTriggerNtupleBase(conf) {
+  accessEventSetup_ = false;
+}
 
 void HGCalTriggerNtupleGen::initialize(TTree &tree, const edm::ParameterSet &conf, edm::ConsumesCollector &&collector) {
   edm::ParameterSet particleFilter_(conf.getParameter<edm::ParameterSet>("particleFilter"));

--- a/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleGen.cc
+++ b/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleGen.cc
@@ -7,14 +7,11 @@
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
 
 #include "MagneticField/Engine/interface/MagneticField.h"
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "TrackPropagation/RungeKutta/interface/defaultRKPropagator.h"
 #include "TrackPropagation/RungeKutta/interface/RKPropagatorInS.h"
 #include "FastSimulation/Event/interface/FSimEvent.h"
-#include "SimGeneral/HepPDTRecord/interface/PDTRecord.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/ESWatcher.h"
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
 
@@ -120,7 +117,7 @@ public:
   HGCalTriggerNtupleGen(const edm::ParameterSet &);
 
   void initialize(TTree &, const edm::ParameterSet &, edm::ConsumesCollector &&) final;
-  void fill(const edm::Event &, const edm::EventSetup &) final;
+  void fill(const edm::Event &, const HGCalTriggerNtupleEventSetup &) final;
 
   enum ReachHGCal { notReach = 0, outsideEESurface = 1, onEESurface = 2 };
 
@@ -185,13 +182,9 @@ private:
 
   HGCalTriggerTools triggerTools_;
 
-  // edm::EDGetTokenT<std::vector<reco::GenParticle> > genParticles_;
   edm::EDGetToken simTracks_token_;
   edm::EDGetToken simVertices_token_;
   edm::EDGetToken hepmcev_token_;
-
-  edm::ESWatcher<PDTRecord> pdt_watcher_;
-  edm::ESWatcher<IdealMagneticFieldRecord> magfield_watcher_;
 };
 
 DEFINE_EDM_PLUGIN(HGCalTriggerNtupleFactory, HGCalTriggerNtupleGen, "HGCalTriggerNtupleGen");
@@ -251,26 +244,16 @@ void HGCalTriggerNtupleGen::initialize(TTree &tree, const edm::ParameterSet &con
   tree.Branch("genpart_posz", &genpart_posz_);
 }
 
-void HGCalTriggerNtupleGen::fill(const edm::Event &iEvent, const edm::EventSetup &es) {
+void HGCalTriggerNtupleGen::fill(const edm::Event &iEvent, const HGCalTriggerNtupleEventSetup &es) {
   clear();
 
   edm::Handle<std::vector<PileupSummaryInfo>> PupInfo_h;
   iEvent.getByToken(gen_PU_token_, PupInfo_h);
   const std::vector<PileupSummaryInfo> &PupInfo = *PupInfo_h;
 
-  if (pdt_watcher_.check(es)) {
-    edm::ESHandle<HepPDT::ParticleDataTable> pdt;
-    es.get<PDTRecord>().get(pdt);
-    mySimEvent_->initializePdt(&(*pdt));
-  }
-
-  if (magfield_watcher_.check(es)) {
-    edm::ESHandle<MagneticField> magfield;
-    es.get<IdealMagneticFieldRecord>().get(magfield);
-    aField_ = &(*magfield);
-  }
-
-  triggerTools_.eventSetup(es);
+  mySimEvent_->initializePdt(&(*es.pdt));
+  aField_ = &(*es.magfield);
+  triggerTools_.setGeometry(es.geometry.product());
 
   // This balck magic is needed to use the mySimEvent_
   edm::Handle<edm::HepMCProduct> hevH;

--- a/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleGenJet.cc
+++ b/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleGenJet.cc
@@ -9,7 +9,7 @@ public:
   HGCalTriggerNtupleGenJet(const edm::ParameterSet&);
 
   void initialize(TTree&, const edm::ParameterSet&, edm::ConsumesCollector&&) final;
-  void fill(const edm::Event&, const edm::EventSetup&) final;
+  void fill(const edm::Event&, const HGCalTriggerNtupleEventSetup&) final;
 
 private:
   void clear() final;
@@ -38,7 +38,7 @@ void HGCalTriggerNtupleGenJet::initialize(TTree& tree,
   tree.Branch("genjet_phi", &genjet_phi_);
 }
 
-void HGCalTriggerNtupleGenJet::fill(const edm::Event& e, const edm::EventSetup& es) {
+void HGCalTriggerNtupleGenJet::fill(const edm::Event& e, const HGCalTriggerNtupleEventSetup& es) {
   edm::Handle<reco::GenJetCollection> genjets_h;
   e.getByToken(genjet_token_, genjets_h);
   const reco::GenJetCollection& genjets = *genjets_h;

--- a/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleGenJet.cc
+++ b/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleGenJet.cc
@@ -25,7 +25,9 @@ private:
 
 DEFINE_EDM_PLUGIN(HGCalTriggerNtupleFactory, HGCalTriggerNtupleGenJet, "HGCalTriggerNtupleGenJet");
 
-HGCalTriggerNtupleGenJet::HGCalTriggerNtupleGenJet(const edm::ParameterSet& conf) : HGCalTriggerNtupleBase(conf) {}
+HGCalTriggerNtupleGenJet::HGCalTriggerNtupleGenJet(const edm::ParameterSet& conf) : HGCalTriggerNtupleBase(conf) {
+  accessEventSetup_ = false;
+}
 
 void HGCalTriggerNtupleGenJet::initialize(TTree& tree,
                                           const edm::ParameterSet& conf,

--- a/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleGenTau.cc
+++ b/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleGenTau.cc
@@ -58,7 +58,9 @@ private:
 
 DEFINE_EDM_PLUGIN(HGCalTriggerNtupleFactory, HGCalTriggerNtupleGenTau, "HGCalTriggerNtupleGenTau");
 
-HGCalTriggerNtupleGenTau::HGCalTriggerNtupleGenTau(const edm::ParameterSet& conf) : HGCalTriggerNtupleBase(conf) {}
+HGCalTriggerNtupleGenTau::HGCalTriggerNtupleGenTau(const edm::ParameterSet& conf) : HGCalTriggerNtupleBase(conf) {
+  accessEventSetup_ = false;
+}
 
 void HGCalTriggerNtupleGenTau::initialize(TTree& tree,
                                           const edm::ParameterSet& conf,

--- a/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleGenTau.cc
+++ b/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleGenTau.cc
@@ -11,7 +11,7 @@ public:
   HGCalTriggerNtupleGenTau(const edm::ParameterSet&);
 
   void initialize(TTree&, const edm::ParameterSet&, edm::ConsumesCollector&&) final;
-  void fill(const edm::Event&, const edm::EventSetup&) final;
+  void fill(const edm::Event&, const HGCalTriggerNtupleEventSetup&) final;
 
 private:
   void clear() final;
@@ -143,7 +143,7 @@ bool HGCalTriggerNtupleGenTau::isStableNeutralHadron(const reco::GenParticle& ca
           candidate.status() == 1);
 }
 
-void HGCalTriggerNtupleGenTau::fill(const edm::Event& e, const edm::EventSetup& es) {
+void HGCalTriggerNtupleGenTau::fill(const edm::Event& e, const HGCalTriggerNtupleEventSetup& es) {
   edm::Handle<reco::GenParticleCollection> gen_particles_h;
   e.getByToken(gen_token_, gen_particles_h);
   const reco::GenParticleCollection& gen_particles = *gen_particles_h;

--- a/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleHGCClusters.cc
+++ b/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleHGCClusters.cc
@@ -2,7 +2,6 @@
 #include <algorithm>
 #include "DataFormats/L1THGCal/interface/HGCalCluster.h"
 #include "DataFormats/L1THGCal/interface/HGCalMulticluster.h"
-#include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
 #include "L1Trigger/L1THGCalUtilities/interface/HGCalTriggerNtupleBase.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
@@ -12,7 +11,7 @@ public:
   HGCalTriggerNtupleHGCClusters(const edm::ParameterSet& conf);
   ~HGCalTriggerNtupleHGCClusters() override{};
   void initialize(TTree&, const edm::ParameterSet&, edm::ConsumesCollector&&) final;
-  void fill(const edm::Event& e, const edm::EventSetup& es) final;
+  void fill(const edm::Event& e, const HGCalTriggerNtupleEventSetup& es) final;
 
 private:
   void clear() final;
@@ -73,7 +72,7 @@ void HGCalTriggerNtupleHGCClusters::initialize(TTree& tree,
   tree.Branch(withPrefix("multicluster_pt"), &cl_multicluster_pt_);
 }
 
-void HGCalTriggerNtupleHGCClusters::fill(const edm::Event& e, const edm::EventSetup& es) {
+void HGCalTriggerNtupleHGCClusters::fill(const edm::Event& e, const HGCalTriggerNtupleEventSetup& es) {
   // retrieve clusters
   edm::Handle<l1t::HGCalClusterBxCollection> clusters_h;
   e.getByToken(clusters_token_, clusters_h);
@@ -82,11 +81,7 @@ void HGCalTriggerNtupleHGCClusters::fill(const edm::Event& e, const edm::EventSe
   e.getByToken(multiclusters_token_, multiclusters_h);
   const l1t::HGCalMulticlusterBxCollection& multiclusters = *multiclusters_h;
 
-  // retrieve geometry
-  edm::ESHandle<HGCalTriggerGeometryBase> geometry;
-  es.get<CaloGeometryRecord>().get(geometry);
-
-  triggerTools_.eventSetup(es);
+  triggerTools_.setGeometry(es.geometry.product());
 
   // Associate cells to clusters
   std::unordered_map<uint32_t, l1t::HGCalMulticlusterBxCollection::const_iterator> cluster2multicluster;

--- a/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleHGCClusters.cc
+++ b/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleHGCClusters.cc
@@ -39,7 +39,9 @@ DEFINE_EDM_PLUGIN(HGCalTriggerNtupleFactory, HGCalTriggerNtupleHGCClusters, "HGC
 
 HGCalTriggerNtupleHGCClusters::HGCalTriggerNtupleHGCClusters(const edm::ParameterSet& conf)
     : HGCalTriggerNtupleBase(conf),
-      filter_clusters_in_multiclusters_(conf.getParameter<bool>("FilterClustersInMulticlusters")) {}
+      filter_clusters_in_multiclusters_(conf.getParameter<bool>("FilterClustersInMulticlusters")) {
+  accessEventSetup_ = false;
+}
 
 void HGCalTriggerNtupleHGCClusters::initialize(TTree& tree,
                                                const edm::ParameterSet& conf,

--- a/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleHGCConcentratorData.cc
+++ b/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleHGCConcentratorData.cc
@@ -13,7 +13,7 @@ public:
   HGCalTriggerNtupleHGCConcentratorData(const edm::ParameterSet& conf);
   ~HGCalTriggerNtupleHGCConcentratorData() override{};
   void initialize(TTree&, const edm::ParameterSet&, edm::ConsumesCollector&&) final;
-  void fill(const edm::Event& e, const edm::EventSetup& es) final;
+  void fill(const edm::Event& e, const HGCalTriggerNtupleEventSetup& es) final;
 
 private:
   void clear() final;
@@ -21,7 +21,6 @@ private:
   HGCalTriggerTools triggerTools_;
 
   edm::EDGetToken concentrator_data_token_;
-  edm::ESHandle<HGCalTriggerGeometryBase> geometry_;
 
   int econ_n_;
   std::vector<uint32_t> econ_id_;
@@ -68,16 +67,13 @@ void HGCalTriggerNtupleHGCConcentratorData::initialize(TTree& tree,
   tree.Branch(withPrefix("data"), &econ_data_);
 }
 
-void HGCalTriggerNtupleHGCConcentratorData::fill(const edm::Event& e, const edm::EventSetup& es) {
+void HGCalTriggerNtupleHGCConcentratorData::fill(const edm::Event& e, const HGCalTriggerNtupleEventSetup& es) {
   // retrieve trigger cells
   edm::Handle<l1t::HGCalConcentratorDataBxCollection> concentrator_data_h;
   e.getByToken(concentrator_data_token_, concentrator_data_h);
   const l1t::HGCalConcentratorDataBxCollection& concentrator_data = *concentrator_data_h;
 
-  // retrieve geometry
-  es.get<CaloGeometryRecord>().get(geometry_);
-
-  triggerTools_.eventSetup(es);
+  triggerTools_.setGeometry(es.geometry.product());
 
   clear();
   for (auto econ_itr = concentrator_data.begin(0); econ_itr != concentrator_data.end(0); econ_itr++) {

--- a/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleHGCConcentratorData.cc
+++ b/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleHGCConcentratorData.cc
@@ -39,7 +39,9 @@ DEFINE_EDM_PLUGIN(HGCalTriggerNtupleFactory,
                   "HGCalTriggerNtupleHGCConcentratorData");
 
 HGCalTriggerNtupleHGCConcentratorData::HGCalTriggerNtupleHGCConcentratorData(const edm::ParameterSet& conf)
-    : HGCalTriggerNtupleBase(conf) {}
+    : HGCalTriggerNtupleBase(conf) {
+  accessEventSetup_ = false;
+}
 
 void HGCalTriggerNtupleHGCConcentratorData::initialize(TTree& tree,
                                                        const edm::ParameterSet& conf,

--- a/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleHGCDigis.cc
+++ b/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleHGCDigis.cc
@@ -68,6 +68,7 @@ private:
 DEFINE_EDM_PLUGIN(HGCalTriggerNtupleFactory, HGCalTriggerNtupleHGCDigis, "HGCalTriggerNtupleHGCDigis");
 
 HGCalTriggerNtupleHGCDigis::HGCalTriggerNtupleHGCDigis(const edm::ParameterSet& conf) : HGCalTriggerNtupleBase(conf) {
+  accessEventSetup_ = false;
   is_Simhit_comp_ = conf.getParameter<bool>("isSimhitComp");
   digiBXselect_ = conf.getParameter<std::vector<unsigned int>>("digiBXselect");
 

--- a/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleHGCMulticlusters.cc
+++ b/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleHGCMulticlusters.cc
@@ -62,7 +62,9 @@ DEFINE_EDM_PLUGIN(HGCalTriggerNtupleFactory, HGCalTriggerNtupleHGCMulticlusters,
 HGCalTriggerNtupleHGCMulticlusters::HGCalTriggerNtupleHGCMulticlusters(const edm::ParameterSet& conf)
     : HGCalTriggerNtupleBase(conf),
       fill_layer_info_(conf.getParameter<bool>("FillLayerInfo")),
-      fill_interpretation_info_(conf.getParameter<bool>("FillInterpretationInfo")) {}
+      fill_interpretation_info_(conf.getParameter<bool>("FillInterpretationInfo")) {
+  accessEventSetup_ = false;
+}
 
 void HGCalTriggerNtupleHGCMulticlusters::initialize(TTree& tree,
                                                     const edm::ParameterSet& conf,

--- a/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleHGCMulticlusters.cc
+++ b/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleHGCMulticlusters.cc
@@ -9,7 +9,7 @@ public:
   HGCalTriggerNtupleHGCMulticlusters(const edm::ParameterSet& conf);
   ~HGCalTriggerNtupleHGCMulticlusters() override{};
   void initialize(TTree&, const edm::ParameterSet&, edm::ConsumesCollector&&) final;
-  void fill(const edm::Event& e, const edm::EventSetup& es) final;
+  void fill(const edm::Event& e, const HGCalTriggerNtupleEventSetup& es) final;
 
 private:
   void clear() final;
@@ -119,15 +119,11 @@ void HGCalTriggerNtupleHGCMulticlusters::initialize(TTree& tree,
   }
 }
 
-void HGCalTriggerNtupleHGCMulticlusters::fill(const edm::Event& e, const edm::EventSetup& es) {
+void HGCalTriggerNtupleHGCMulticlusters::fill(const edm::Event& e, const HGCalTriggerNtupleEventSetup& es) {
   // retrieve clusters 3D
   edm::Handle<l1t::HGCalMulticlusterBxCollection> multiclusters_h;
   e.getByToken(multiclusters_token_, multiclusters_h);
   const l1t::HGCalMulticlusterBxCollection& multiclusters = *multiclusters_h;
-
-  // retrieve geometry
-  edm::ESHandle<HGCalTriggerGeometryBase> geometry;
-  es.get<CaloGeometryRecord>().get(geometry);
 
   clear();
   for (auto cl3d_itr = multiclusters.begin(0); cl3d_itr != multiclusters.end(0); cl3d_itr++) {
@@ -174,10 +170,10 @@ void HGCalTriggerNtupleHGCMulticlusters::fill(const edm::Event& e, const edm::Ev
 
     //Per layer cluster information
     if (fill_layer_info_) {
-      const unsigned nlayers = geometry->lastTriggerLayer();
+      const unsigned nlayers = es.geometry->lastTriggerLayer();
       std::vector<float> layer_pt(nlayers, 0.0);
       for (const auto& cl_ptr : cl3d_itr->constituents()) {
-        unsigned layer = geometry->triggerLayer(cl_ptr.second->detId());
+        unsigned layer = es.geometry->triggerLayer(cl_ptr.second->detId());
         layer_pt[layer] += cl_ptr.second->pt();
       }
       cl3d_layer_pt_.emplace_back(layer_pt);

--- a/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleHGCTriggerCells.cc
+++ b/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleHGCTriggerCells.cc
@@ -83,7 +83,9 @@ HGCalTriggerNtupleHGCTriggerCells::HGCalTriggerNtupleHGCTriggerCells(const edm::
       keV2fC_(conf.getParameter<double>("keV2fC")),
       fcPerMip_(conf.getParameter<std::vector<double>>("fcPerMip")),
       layerWeights_(conf.getParameter<std::vector<double>>("layerWeights")),
-      thicknessCorrections_(conf.getParameter<std::vector<double>>("thicknessCorrections")) {}
+      thicknessCorrections_(conf.getParameter<std::vector<double>>("thicknessCorrections")) {
+  accessEventSetup_ = false;
+}
 
 void HGCalTriggerNtupleHGCTriggerCells::initialize(TTree& tree,
                                                    const edm::ParameterSet& conf,

--- a/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleHGCTriggerCells.cc
+++ b/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleHGCTriggerCells.cc
@@ -11,7 +11,6 @@
 #include "SimDataFormats/CaloAnalysis/interface/CaloParticleFwd.h"
 #include "SimDataFormats/CaloAnalysis/interface/CaloParticle.h"
 #include "DataFormats/ForwardDetId/interface/HGCalTriggerDetId.h"
-#include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
 #include "L1Trigger/L1THGCalUtilities/interface/HGCalTriggerNtupleBase.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
@@ -21,7 +20,7 @@ public:
   HGCalTriggerNtupleHGCTriggerCells(const edm::ParameterSet& conf);
   ~HGCalTriggerNtupleHGCTriggerCells() override{};
   void initialize(TTree&, const edm::ParameterSet&, edm::ConsumesCollector&&) final;
-  void fill(const edm::Event& e, const edm::EventSetup& es) final;
+  void fill(const edm::Event& e, const HGCalTriggerNtupleEventSetup& es) final;
 
 private:
   double calibrate(double, int, unsigned);
@@ -43,7 +42,6 @@ private:
   std::vector<double> fcPerMip_;
   std::vector<double> layerWeights_;
   std::vector<double> thicknessCorrections_;
-  edm::ESHandle<HGCalTriggerGeometryBase> geometry_;
 
   int tc_n_;
   std::vector<uint32_t> tc_id_;
@@ -143,7 +141,7 @@ void HGCalTriggerNtupleHGCTriggerCells::initialize(TTree& tree,
     tree.Branch(withPrefix("genparticle_index"), &tc_genparticle_index_);
 }
 
-void HGCalTriggerNtupleHGCTriggerCells::fill(const edm::Event& e, const edm::EventSetup& es) {
+void HGCalTriggerNtupleHGCTriggerCells::fill(const edm::Event& e, const HGCalTriggerNtupleEventSetup& es) {
   // retrieve trigger cells
   edm::Handle<l1t::HGCalTriggerCellBxCollection> trigger_cells_h;
   e.getByToken(trigger_cells_token_, trigger_cells_h);
@@ -153,9 +151,6 @@ void HGCalTriggerNtupleHGCTriggerCells::fill(const edm::Event& e, const edm::Eve
   edm::Handle<l1t::HGCalMulticlusterBxCollection> multiclusters_h;
   e.getByToken(multiclusters_token_, multiclusters_h);
   const l1t::HGCalMulticlusterBxCollection& multiclusters = *multiclusters_h;
-
-  // retrieve geometry
-  es.get<CaloGeometryRecord>().get(geometry_);
 
   // sim hit association
   std::unordered_map<uint32_t, double> simhits_ee;
@@ -188,7 +183,7 @@ void HGCalTriggerNtupleHGCTriggerCells::fill(const edm::Event& e, const edm::Eve
     }
   }
 
-  triggerTools_.eventSetup(es);
+  triggerTools_.setGeometry(es.geometry.product());
 
   clear();
   for (auto tc_itr = trigger_cells.begin(0); tc_itr != trigger_cells.end(0); tc_itr++) {
@@ -248,7 +243,7 @@ void HGCalTriggerNtupleHGCTriggerCells::fill(const edm::Event& e, const edm::Eve
         double energy = 0;
         unsigned layer = triggerTools_.layerWithOffset(id);
         // search for simhit for all the cells inside the trigger cell
-        for (uint32_t c_id : geometry_->getCellsFromTriggerCell(id)) {
+        for (uint32_t c_id : triggerTools_.getTriggerGeometry()->getCellsFromTriggerCell(id)) {
           int thickness = triggerTools_.thicknessIndex(c_id);
           if (triggerTools_.isEm(id)) {
             auto itr = simhits_ee.find(c_id);
@@ -302,7 +297,7 @@ void HGCalTriggerNtupleHGCTriggerCells::simhits(const edm::Event& e,
 
   // EE
   for (const auto& simhit : ee_simhits) {
-    DetId id = triggerTools_.simToReco(simhit.id(), geometry_->eeTopology());
+    DetId id = triggerTools_.simToReco(simhit.id(), triggerTools_.getTriggerGeometry()->eeTopology());
     if (id.rawId() == 0)
       continue;
     auto itr_insert = simhits_ee.emplace(id, 0.);
@@ -310,7 +305,7 @@ void HGCalTriggerNtupleHGCTriggerCells::simhits(const edm::Event& e,
   }
   //  FH
   for (const auto& simhit : fh_simhits) {
-    DetId id = triggerTools_.simToReco(simhit.id(), geometry_->fhTopology());
+    DetId id = triggerTools_.simToReco(simhit.id(), triggerTools_.getTriggerGeometry()->fhTopology());
     if (id.rawId() == 0)
       continue;
     auto itr_insert = simhits_fh.emplace(id, 0.);
@@ -318,7 +313,7 @@ void HGCalTriggerNtupleHGCTriggerCells::simhits(const edm::Event& e,
   }
   //  BH
   for (const auto& simhit : bh_simhits) {
-    DetId id = triggerTools_.simToReco(simhit.id(), geometry_->hscTopology());
+    DetId id = triggerTools_.simToReco(simhit.id(), triggerTools_.getTriggerGeometry()->hscTopology());
     if (id.rawId() == 0)
       continue;
     auto itr_insert = simhits_bh.emplace(id, 0.);

--- a/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleHGCTriggerSums.cc
+++ b/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleHGCTriggerSums.cc
@@ -13,7 +13,7 @@ public:
   HGCalTriggerNtupleHGCTriggerSums(const edm::ParameterSet& conf);
   ~HGCalTriggerNtupleHGCTriggerSums() override{};
   void initialize(TTree&, const edm::ParameterSet&, edm::ConsumesCollector&&) final;
-  void fill(const edm::Event& e, const edm::EventSetup& es) final;
+  void fill(const edm::Event& e, const HGCalTriggerNtupleEventSetup& es) final;
 
 private:
   void clear() final;
@@ -79,13 +79,13 @@ void HGCalTriggerNtupleHGCTriggerSums::initialize(TTree& tree,
   tree.Branch(withPrefix("z"), &ts_z_);
 }
 
-void HGCalTriggerNtupleHGCTriggerSums::fill(const edm::Event& e, const edm::EventSetup& es) {
+void HGCalTriggerNtupleHGCTriggerSums::fill(const edm::Event& e, const HGCalTriggerNtupleEventSetup& es) {
   // retrieve trigger cells
   edm::Handle<l1t::HGCalTriggerSumsBxCollection> trigger_sums_h;
   e.getByToken(trigger_sums_token_, trigger_sums_h);
   const l1t::HGCalTriggerSumsBxCollection& trigger_sums = *trigger_sums_h;
 
-  triggerTools_.eventSetup(es);
+  triggerTools_.setGeometry(es.geometry.product());
 
   clear();
   for (auto ts_itr = trigger_sums.begin(0); ts_itr != trigger_sums.end(0); ts_itr++) {

--- a/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleHGCTriggerSums.cc
+++ b/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleHGCTriggerSums.cc
@@ -45,7 +45,9 @@ private:
 DEFINE_EDM_PLUGIN(HGCalTriggerNtupleFactory, HGCalTriggerNtupleHGCTriggerSums, "HGCalTriggerNtupleHGCTriggerSums");
 
 HGCalTriggerNtupleHGCTriggerSums::HGCalTriggerNtupleHGCTriggerSums(const edm::ParameterSet& conf)
-    : HGCalTriggerNtupleBase(conf) {}
+    : HGCalTriggerNtupleBase(conf) {
+  accessEventSetup_ = false;
+}
 
 void HGCalTriggerNtupleHGCTriggerSums::initialize(TTree& tree,
                                                   const edm::ParameterSet& conf,

--- a/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleManager.cc
+++ b/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleManager.cc
@@ -58,7 +58,11 @@ void HGCalTriggerNtupleManager::beginRun(const edm::Run& run, const edm::EventSe
 
 void HGCalTriggerNtupleManager::analyze(const edm::Event& e, const edm::EventSetup& es) {
   for (auto& hgc_ntuple : hgc_ntuples_) {
-    hgc_ntuple->fill(e, ntuple_es_);
+    if (hgc_ntuple->accessEventSetup()) {
+      hgc_ntuple->fill(e, es);
+    } else {
+      hgc_ntuple->fill(e, ntuple_es_);
+    }
   }
 
   tree_->Fill();

--- a/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleManager.cc
+++ b/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleManager.cc
@@ -8,6 +8,12 @@
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 #include "L1Trigger/L1THGCalUtilities/interface/HGCalTriggerNtupleBase.h"
 
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "SimGeneral/HepPDTRecord/interface/PDTRecord.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+
 class HGCalTriggerNtupleManager : public edm::EDAnalyzer {
 public:
   typedef std::unique_ptr<HGCalTriggerNtupleBase> ntuple_ptr;
@@ -15,18 +21,26 @@ public:
 public:
   explicit HGCalTriggerNtupleManager(const edm::ParameterSet& conf);
   ~HGCalTriggerNtupleManager() override{};
-  void beginRun(const edm::Run&, const edm::EventSetup&) override{};
+  void beginRun(const edm::Run&, const edm::EventSetup&) override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
 private:
   edm::Service<TFileService> file_service_;
   std::vector<ntuple_ptr> hgc_ntuples_;
   TTree* tree_;
+
+  HGCalTriggerNtupleEventSetup ntuple_es_;
+  edm::ESGetToken<HepPDT::ParticleDataTable, PDTRecord> pdtToken_;
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magfieldToken_;
+  edm::ESGetToken<HGCalTriggerGeometryBase, CaloGeometryRecord> triggerGeomToken_;
 };
 
 DEFINE_FWK_MODULE(HGCalTriggerNtupleManager);
 
-HGCalTriggerNtupleManager::HGCalTriggerNtupleManager(const edm::ParameterSet& conf) {
+HGCalTriggerNtupleManager::HGCalTriggerNtupleManager(const edm::ParameterSet& conf)
+    : pdtToken_(esConsumes<HepPDT::ParticleDataTable, PDTRecord, edm::Transition::BeginRun>()),
+      magfieldToken_(esConsumes<MagneticField, IdealMagneticFieldRecord, edm::Transition::BeginRun>()),
+      triggerGeomToken_(esConsumes<HGCalTriggerGeometryBase, CaloGeometryRecord, edm::Transition::BeginRun>()) {
   tree_ = file_service_->make<TTree>("HGCalTriggerNtuple", "HGCalTriggerNtuple");
   const std::vector<edm::ParameterSet>& ntuple_cfgs = conf.getParameterSetVector("Ntuples");
   for (const auto& ntuple_cfg : ntuple_cfgs) {
@@ -36,9 +50,16 @@ HGCalTriggerNtupleManager::HGCalTriggerNtupleManager(const edm::ParameterSet& co
   }
 }
 
+void HGCalTriggerNtupleManager::beginRun(const edm::Run& run, const edm::EventSetup& es) {
+  ntuple_es_.pdt = es.getHandle(pdtToken_);
+  ntuple_es_.magfield = es.getHandle(magfieldToken_);
+  ntuple_es_.geometry = es.getHandle(triggerGeomToken_);
+}
+
 void HGCalTriggerNtupleManager::analyze(const edm::Event& e, const edm::EventSetup& es) {
   for (auto& hgc_ntuple : hgc_ntuples_) {
-    hgc_ntuple->fill(e, es);
+    hgc_ntuple->fill(e, ntuple_es_);
   }
+
   tree_->Fill();
 }

--- a/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleTowers.cc
+++ b/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleTowers.cc
@@ -1,6 +1,4 @@
 #include "DataFormats/L1THGCal/interface/HGCalTower.h"
-#include "Geometry/Records/interface/CaloGeometryRecord.h"
-#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
 #include "L1Trigger/L1THGCalUtilities/interface/HGCalTriggerNtupleBase.h"
 
 class HGCalTriggerNtupleHGCTowers : public HGCalTriggerNtupleBase {
@@ -8,7 +6,7 @@ public:
   HGCalTriggerNtupleHGCTowers(const edm::ParameterSet& conf);
   ~HGCalTriggerNtupleHGCTowers() override{};
   void initialize(TTree&, const edm::ParameterSet&, edm::ConsumesCollector&&) final;
-  void fill(const edm::Event& e, const edm::EventSetup& es) final;
+  void fill(const edm::Event& e, const HGCalTriggerNtupleEventSetup& es) final;
 
 private:
   void clear() final;
@@ -55,15 +53,11 @@ void HGCalTriggerNtupleHGCTowers::initialize(TTree& tree,
   tree.Branch(withPrefix("iPhi"), &tower_iPhi_);
 }
 
-void HGCalTriggerNtupleHGCTowers::fill(const edm::Event& e, const edm::EventSetup& es) {
+void HGCalTriggerNtupleHGCTowers::fill(const edm::Event& e, const HGCalTriggerNtupleEventSetup& es) {
   // retrieve towers
   edm::Handle<l1t::HGCalTowerBxCollection> towers_h;
   e.getByToken(towers_token_, towers_h);
   const l1t::HGCalTowerBxCollection& towers = *towers_h;
-
-  // retrieve geometry
-  edm::ESHandle<HGCalTriggerGeometryBase> geometry;
-  es.get<CaloGeometryRecord>().get(geometry);
 
   clear();
   for (auto tower_itr = towers.begin(0); tower_itr != towers.end(0); tower_itr++) {

--- a/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleTowers.cc
+++ b/L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleTowers.cc
@@ -26,8 +26,9 @@ private:
 
 DEFINE_EDM_PLUGIN(HGCalTriggerNtupleFactory, HGCalTriggerNtupleHGCTowers, "HGCalTriggerNtupleHGCTowers");
 
-HGCalTriggerNtupleHGCTowers::HGCalTriggerNtupleHGCTowers(const edm::ParameterSet& conf)
-    : HGCalTriggerNtupleBase(conf) {}
+HGCalTriggerNtupleHGCTowers::HGCalTriggerNtupleHGCTowers(const edm::ParameterSet& conf) : HGCalTriggerNtupleBase(conf) {
+  accessEventSetup_ = false;
+}
 
 void HGCalTriggerNtupleHGCTowers::initialize(TTree& tree,
                                              const edm::ParameterSet& conf,


### PR DESCRIPTION
#### PR description:
- Part of #31061
- Migrate to use esConsumes for modules in   `L1Trigger/L1THGCal` and `L1Trigger/L1THGCalUtilities`

#### PR validation:
Private tests in `L1Trigger/L1THGCalUtilities/test`:
```
cmsRun testHGCalL1T_RelValV11_cfg.py
```

Tested D49, D60 and D68 workflows
```
runTheMatrix.py -w upgrade -l 23234.0 --maxSteps=2 
runTheMatrix.py -w upgrade -l 28234.0 --maxSteps=2 
runTheMatrix.py -w upgrade -l 31434.0 --maxSteps=2
```
