### PR TITLE
add back DeepMET in NanoAOD

### DIFF
--- a/PhysicsTools/NanoAOD/python/met_cff.py
+++ b/PhysicsTools/NanoAOD/python/met_cff.py
@@ -158,8 +158,7 @@ metMCTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
 )
 
 
-metTablesTask = cms.Task( metTable, rawMetTable, caloMetTable, puppiMetTable, rawPuppiMetTable, tkMetTable, chsMetTable)
-deepMetTablesTask = cms.Task( deepMetResolutionTuneTable, deepMetResponseTuneTable )
+metTablesTask = cms.Task( metTable, rawMetTable, caloMetTable, puppiMetTable, rawPuppiMetTable, tkMetTable, chsMetTable, deepMetResolutionTuneTable, deepMetResponseTuneTable )
 _withFixEE2017_task = cms.Task(metTablesTask.copy(), metFixEE2017Table)
 for modifier in run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2:
     modifier.toReplaceWith(metTablesTask,_withFixEE2017_task) # only in old miniAOD, the new ones will come from the UL rereco

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -157,7 +157,7 @@ def nanoAOD_recalibrateMETs(process,isData):
     process.load('RecoMET.METPUSubtraction.deepMETProducer_cfi')
     process.deepMETsResolutionTune = process.deepMETProducer.clone()
     process.deepMETsResponseTune = process.deepMETProducer.clone()
-    process.deepMETsResponseTune.graph_path = ResponseTune_Graph.value()
+    process.deepMETsResponseTune.graph_path = nanoAOD_DeepMET_switch.ResponseTune_Graph.value()
 
     runMetCorAndUncFromMiniAOD(process,isData=isData)
     process.nanoSequenceCommon.insert(2,cms.Sequence(process.fullPatMetSequence))

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -143,41 +143,23 @@ def nanoAOD_addDeepInfo(process,addDeepBTag,addDeepFlavour):
     process.updatedJets.jetSource="selectedUpdatedPatJetsWithDeepInfo"
     return process
 
-def nanoAOD_addDeepMET(process, addDeepMETProducer, ResponseTune_Graph):
-    if addDeepMETProducer:
-        # produce DeepMET on the fly if it is not in MiniAOD
-        print("add DeepMET Producers")
-        process.load('RecoMET.METPUSubtraction.deepMETProducer_cfi')
-#        process.deepMETsResolutionTune = process.deepMETProducer.clone()
-        process.deepMETsResponseTune = process.deepMETProducer.clone()
-        #process.deepMETsResponseTune.graph_path = 'RecoMET/METPUSubtraction/data/deepmet/deepmet_resp_v1_2018.pb'
-        process.deepMETsResponseTune.graph_path = ResponseTune_Graph.value()
-    process.metTablesTask.add(process.deepMetTablesTask)
-    return process
 
 from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncFromMiniAOD
 def nanoAOD_recalibrateMETs(process,isData):
-
     # add DeepMETs
     nanoAOD_DeepMET_switch = cms.PSet(
-        nanoAOD_addDeepMET_switch = cms.untracked.bool(True), # decide if DeeMET should be included in Nano
-        nanoAOD_produceDeepMET_switch = cms.untracked.bool(False), # decide if DeepMET should be computed on the fly
         ResponseTune_Graph = cms.untracked.string('RecoMET/METPUSubtraction/data/deepmet/deepmet_resp_v1_2018.pb')
     )
-    for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016, run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2, run2_nanoAOD_102Xv1, run2_nanoAOD_106Xv1:
-        # compute DeepMETs in these eras (before 111X)
-        modifier.toModify(nanoAOD_DeepMET_switch, nanoAOD_produceDeepMET_switch =  cms.untracked.bool(True))
     for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016:
         modifier.toModify(nanoAOD_DeepMET_switch, ResponseTune_Graph=cms.untracked.string("RecoMET/METPUSubtraction/data/deepmet/deepmet_resp_v1_2016.pb"))
-    if nanoAOD_DeepMET_switch.nanoAOD_addDeepMET_switch:
-        process = nanoAOD_addDeepMET(process,
-                                     addDeepMETProducer=nanoAOD_DeepMET_switch.nanoAOD_produceDeepMET_switch,
-                                     ResponseTune_Graph=nanoAOD_DeepMET_switch.ResponseTune_Graph)
 
-    # if included in Nano, and not computed in the fly, then it should be extracted from minAOD
-    extractDeepMETs = nanoAOD_DeepMET_switch.nanoAOD_addDeepMET_switch and not nanoAOD_DeepMET_switch.nanoAOD_produceDeepMET_switch
+    print("add DeepMET Producers")
+    process.load('RecoMET.METPUSubtraction.deepMETProducer_cfi')
+    process.deepMETsResolutionTune = process.deepMETProducer.clone()
+    process.deepMETsResponseTune = process.deepMETProducer.clone()
+    process.deepMETsResponseTune.graph_path = ResponseTune_Graph.value()
 
-    runMetCorAndUncFromMiniAOD(process,isData=isData, extractDeepMETs=extractDeepMETs)
+    runMetCorAndUncFromMiniAOD(process,isData=isData)
     process.nanoSequenceCommon.insert(2,cms.Sequence(process.fullPatMetSequence))
 
 


### PR DESCRIPTION
#### PR description:
PR to add back DeepMET to NanoAOD.

In the Nano developments DeepMET is skipped in the PR https://github.com/cms-sw/cmssw/pull/34714 due to the conflicts and changes in `runMetCorAndUncFromMiniAOD`. This PR fixes the issues and will be able to read DeepMET from MiniAOD in the same way as chsMet, caloMet, etc. For the eras where DeepMET is computed in MiniAOD, it would be computed on the fly, inside the `nanoAOD_recalibrateMETs` function. 

#### PR validation:

tested with runTheMatrix.py and passed all tests.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
not a backport.

notifying @steggema @mseidel42 and @mariadalfonso 
