### PR TITLE
introduce `auto:phase1_2021_dd4hep` and use it in RelVals

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -108,6 +108,10 @@ autoCond = autoCond0T(autoCond)
 from Configuration.AlCa.autoCondModifiers import autoCondHLTHI
 autoCond = autoCondHLTHI(autoCond)
 
+# special GT for 2021 DD4HEP geometry
+from Configuration.AlCa.autoCondModifiers import autoCondDD4HEP
+autoCond = autoCondDD4HEP(autoCond)
+
 ### OLD KEYS ### kept for backward compatibility
     # GlobalTag for MC production with perfectly aligned and calibrated detector
 autoCond['mc']               = ( autoCond['run1_design'] )

--- a/Configuration/AlCa/python/autoCondModifiers.py
+++ b/Configuration/AlCa/python/autoCondModifiers.py
@@ -30,3 +30,44 @@ def autoCondHLTHI(autoCond):
 
     autoCond.update(GlobalTagsHLTHI)
     return autoCond
+
+def autoCondDD4HEP(autoCond):
+
+    GlobalTagsDDHEP = {}
+    # substitute the DDD geometry tags with DD4HEP ones
+    CSCRECODIGI_Geometry_dd4hep    =  ','.join( ['CSCRECODIGI_Geometry_120DD4hepV1'            , "CSCRecoDigiParametersRcd", connectionString, "", "2021-09-28 12:00:00.000"] )
+    CSCRECO_Geometry_dd4hep        =  ','.join( ['CSCRECO_Geometry_120DD4hepV1'                , "CSCRecoGeometryRcd"      , connectionString, "", "2021-09-28 12:00:00.000"] )
+    DTRECO_Geometry_dd4hep         =  ','.join( ['DTRECO_Geometry_120DD4hepV1'                 , "DTRecoGeometryRcd"       , connectionString, "", "2021-09-28 12:00:00.000"] )
+    GEMRECO_Geometry_dd4hep        =  ','.join( ['GEMRECO_Geometry_120DD4hepV1'                , "GEMRecoGeometryRcd"      , connectionString, "", "2021-09-28 12:00:00.000"] )
+    XMLFILE_Geometry_dd4hep        =  ','.join( ['XMLFILE_Geometry_120DD4hepV3_Extended2021_mc', "GeometryFileRcd"         , connectionString, "Extended", "2021-09-28 12:00:00.000"] )
+    HCALParameters_Geometry_dd4hep =  ','.join( ['HCALParameters_Geometry_120DD4hepV1'         , "HcalParametersRcd"       , connectionString, "", "2021-09-28 12:00:00.000"] )
+    TKRECO_Geometry_dd4hep         =  ','.join( ['TKRECO_Geometry_120DD4hepV1'                 , "IdealGeometryRecord"     , connectionString, "", "2021-09-28 12:00:00.000"] )
+    CTRECO_Geometry_dd4hep         =  ','.join( ['CTRECO_Geometry_120DD4hepV1'                 , "PCaloTowerRcd"           , connectionString, "", "2021-09-28 12:00:00.000"] )
+    EBRECO_Geometry_dd4hep         =  ','.join( ['EBRECO_Geometry_120DD4hepV1'                 , "PEcalBarrelRcd"          , connectionString, "", "2021-09-28 12:00:00.000"] )
+    EERECO_Geometry_dd4hep         =  ','.join( ['EERECO_Geometry_120DD4hepV1'                 , "PEcalEndcapRcd"          , connectionString, "", "2021-09-28 12:00:00.000"] )
+    EPRECO_Geometry_dd4hep         =  ','.join( ['EPRECO_Geometry_120DD4hepV1'                 , "PEcalPreshowerRcd"       , connectionString, "", "2021-09-28 12:00:00.000"] )
+    HCALRECO_Geometry_dd4hep       =  ','.join( ['HCALRECO_Geometry_120DD4hepV1'               , "PHcalRcd"                , connectionString, "", "2021-09-28 12:00:00.000"] )
+    TKParameters_Geometry_dd4hep   =  ','.join( ['TKParameters_Geometry_120DD4hepV1'           , "PTrackerParametersRcd"   , connectionString, "", "2021-09-28 12:00:00.000"] )
+    ZDCRECO_Geometry_dd4hep        =  ','.join( ['ZDCRECO_Geometry_120DD4hepV1'                , "PZdcRcd"                 , connectionString, "", "2021-09-28 12:00:00.000"] )
+    RPCRECO_Geometry_dd4hep        =  ','.join( ['RPCRECO_Geometry_120DD4hepV1'                , "RPCRecoGeometryRcd"      , connectionString, "", "2021-09-28 12:00:00.000"] )
+
+    for key,val in autoCond.items():
+        if key == 'phase1_2021_realistic':    # modification of the DD4HEP relval GT
+            GlobalTagsDDHEP['phase1_2021_dd4hep'] = (autoCond[key],
+                                                     CSCRECODIGI_Geometry_dd4hep,
+                                                     CSCRECO_Geometry_dd4hep,
+                                                     DTRECO_Geometry_dd4hep,
+                                                     GEMRECO_Geometry_dd4hep,
+                                                     XMLFILE_Geometry_dd4hep,
+                                                     HCALParameters_Geometry_dd4hep,
+                                                     TKRECO_Geometry_dd4hep,
+                                                     CTRECO_Geometry_dd4hep,
+                                                     EBRECO_Geometry_dd4hep,
+                                                     EERECO_Geometry_dd4hep,
+                                                     EPRECO_Geometry_dd4hep,
+                                                     HCALRECO_Geometry_dd4hep,
+                                                     TKParameters_Geometry_dd4hep,
+                                                     ZDCRECO_Geometry_dd4hep,
+                                                     RPCRECO_Geometry_dd4hep)
+    autoCond.update(GlobalTagsDDHEP)
+    return autoCond

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1104,7 +1104,7 @@ upgradeWFs['DD4hep'].allowReuse = False
 class UpgradeWorkflow_DD4hepDB(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):
         if 'Run3' in stepDict[step][k]['--era']:
-            stepDict[stepName][k] = merge([{'--conditions': '121X_mcRun3_2021_realistic_dd4hep_v3', '--geometry': 'DB:Extended', '--procModifiers': 'dd4hep'}, stepDict[step][k]])
+            stepDict[stepName][k] = merge([{'--conditions': 'auto:phase1_2021_dd4hep', '--geometry': 'DB:Extended', '--procModifiers': 'dd4hep'}, stepDict[step][k]])
     def condition(self, fragment, stepList, key, hasHarvest):
         return '2021' in key
 upgradeWFs['DD4hepDB'] = UpgradeWorkflow_DD4hepDB(


### PR DESCRIPTION
#### PR description:

Implement proposal described in https://github.com/cms-sw/cmssw/pull/35436#discussion_r717309213 by creating a symbolic GlobalTag assembled on-the-fly (`auto:phase1_2021_dd4hep`) and putting it on par with the current `auto:phase1_2021_realistic` excepted the dd4hep geometry tags.
This guarantees the new key will stay up-to-date with the main 2021 realistic GT in automatic way.

#### PR validation:

Run successfully `runTheMatrix.py -l 11634.912 -t 4 -j 8`.
### NB: Changes are expected since the current diff between the main 2021 Global Tag and the one used in RelVals is:
```console
$ conddb diff 121X_mcRun3_2021_realistic_v8 121X_mcRun3_2021_realistic_dd4hep_v3 
[2021-09-29 09:34:19,113] INFO: Connecting to pro [frontier://PromptProd/cms_conditions]
Record                     Label     pro::121X_mcRun3_2021_realistic_v8 Tag   pro::121X_mcRun3_2021_realistic_dd4hep_v3 Tag   
-------------------------  --------  ---------------------------------------  ---------------------------------------------   
CSCRecoDigiParametersRcd   -         CSCRECODIGI_Geometry_112YV2              CSCRECODIGI_Geometry_120DD4hepV1                
CSCRecoGeometryRcd         -         CSCRECO_Geometry_112YV2                  CSCRECO_Geometry_120DD4hepV1                    
DTRecoGeometryRcd          -         DTRECO_Geometry_112YV2                   DTRECO_Geometry_120DD4hepV1                     
EcalPFRecHitThresholdsRcd  -         EcalPFRecHitThresholds_34sigma_TL235     EcalPFRecHitThresholds_UL_2018_2e3sig           
GEMRecoGeometryRcd         -         GEMRECO_Geometry_113YV4                  GEMRECO_Geometry_120DD4hepV1                    
GeometryFileRcd            Extended  XMLFILE_Geometry_120YV2_Extended2021_mc  XMLFILE_Geometry_120DD4hepV3_Extended2021_mc    
HcalParametersRcd          -         HCALParameters_Geometry_112YV2           HCALParameters_Geometry_120DD4hepV1             
HcalRespCorrsRcd           -         HcalRespCorrs_2021_v3.0_mc               HcalRespCorrs_2021_v2.0_mc                      
IdealGeometryRecord        -         TKRECO_Geometry_120YV2                   TKRECO_Geometry_120DD4hepV1                     
PCaloTowerRcd              -         CTRECO_Geometry_112YV2                   CTRECO_Geometry_120DD4hepV1                     
PEcalBarrelRcd             -         EBRECO_Geometry_112YV2                   EBRECO_Geometry_120DD4hepV1                     
PEcalEndcapRcd             -         EERECO_Geometry_112YV2                   EERECO_Geometry_120DD4hepV1                     
PEcalPreshowerRcd          -         EPRECO_Geometry_112YV2                   EPRECO_Geometry_120DD4hepV1                     
PHcalRcd                   -         HCALRECO_Geometry_112YV2                 HCALRECO_Geometry_120DD4hepV1                   
PTrackerParametersRcd      -         TKParameters_Geometry_112YV2             TKParameters_Geometry_120DD4hepV1               
PZdcRcd                    -         ZDCRECO_Geometry_112YV2                  ZDCRECO_Geometry_120DD4hepV1                    
RPCRecoGeometryRcd         -         RPCRECO_Geometry_112YV2                  RPCRECO_Geometry_120DD4hepV1         
```
and these two differences:
```console
EcalPFRecHitThresholdsRcd  -         EcalPFRecHitThresholds_34sigma_TL235     EcalPFRecHitThresholds_UL_2018_2e3sig        
HcalRespCorrsRcd           -         HcalRespCorrs_2021_v3.0_mc               HcalRespCorrs_2021_v2.0_mc                      
```
are re-absorbed here.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
cc:
@cvuosalo 
