### PR TITLE
[UBSAN] Fix unit test by feeding it with correct input

### DIFF
--- a/EventFilter/L1TXRawToDigi/test/BuildFile.xml
+++ b/EventFilter/L1TXRawToDigi/test/BuildFile.xml
@@ -1,3 +1,4 @@
 <bin name="testUCTUnpacker" file="testUCTUnpacker.cpp">
+  <flags TEST_RUNNER_CMD="cat src/EventFilter/L1TXRawToDigi/test/event_test1.txt | testUCTUnpacker"/>
   <use name="EventFilter/L1TXRawToDigi"/>
 </bin>


### PR DESCRIPTION
Unit test `testUCTUnpacker` requires valid input to run. In UBSAN IBs it fails [a] as the stdin is closed and no data is feed to the test which resulted in creating `UCTAMCRawData` with undefined data. 

This PR proposes to use https://github.com/cms-sw/cmssw/blob/master/EventFilter/L1TXRawToDigi/test/event_test1.txt as input. Local test in UBSAN IBs shows no failure.


[a] https://cmssdt.cern.ch/SDT/cgi-bin/logreader/slc7_amd64_gcc10/CMSSW_12_1_UBSAN_X_2021-09-27-2300/unitTestLogs/EventFilter/L1TXRawToDigi#/
```
AMC Payload Header:
Data Length.. = 318408
BXID......... = 36
L1ID......... = 00000000
AMC No ...... = 0
Layer-1 Phi.. = 58432
Orbit No..... = 50225
AMC Payload Trailer:

 *** Break *** segmentation violation
Data Length.. = 


===========================================================
There was a crash.
This is the entire stack trace of all threads:
===========================================================
#0  0x00002af6b117a4fc in waitpid () from /lib64/libc.so.6
#1  0x00002af6b10f7f62 in do_system () from /lib64/libc.so.6
#2  0x00002af6b0098f9b in TUnixSystem::StackTrace() () from /cvmfs/cms-ib.cern.ch/nweek-02700/slc7_amd64_gcc10/cms/cmssw/CMSSW_12_1_UBSAN_X_2021-09-27-2300/external/slc7_amd64_gcc10/lib/libCore.so
#3  0x00002af6b0096555 in TUnixSystem::DispatchSignals(ESignals) () from /cvmfs/cms-ib.cern.ch/nweek-02700/slc7_amd64_gcc10/cms/cmssw/CMSSW_12_1_UBSAN_X_2021-09-27-2300/external/slc7_amd64_gcc10/lib/libCore.so
#4  <signal handler called>
#5  0x000000000041e602 in UCTAMCRawData::print() ()
#6  0x00000000004058a6 in main ()
===========================================================
```
