### PR TITLE
migrate `CondCore/PopCon` away from deprecated `EDAnalyzer` API

### DIFF
--- a/CondCore/PopCon/interface/PopConAnalyzer.h
+++ b/CondCore/PopCon/interface/PopConAnalyzer.h
@@ -9,12 +9,12 @@
 #include <vector>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 namespace popcon {
   template <typename S>
-  class PopConAnalyzer : public edm::EDAnalyzer {
+  class PopConAnalyzer : public edm::one::EDAnalyzer<> {
   public:
     typedef S SourceHandler;
 


### PR DESCRIPTION
resolves https://github.com/cms-AlCaDB/AlCaTools/issues/37

#### PR description:

Title says it all.

#### PR validation:

After checking dependencies with `git cms-checkdeps -a` it still compiles.
Running the unit tests for all the checked out packages there are multiple errors
```console
---> test EcalADCToGeV_update_test had ERRORS
---> test EcalDAQ_O2O_test had ERRORS
---> test EcalDCS_O2O_test had ERRORS
---> test EcalLaser_O2O_test had ERRORS
---> test EcalTPGBadStripStatus_O2O_test had ERRORS
---> test EcalTPGCrystalStatus_O2O_test had ERRORS
---> test EcalTPGFineGrainEBGroup_O2O_test had ERRORS
---> test EcalTPGFineGrainEBIdMap_O2O_test had ERRORS
---> test EcalTPGFineGrainStripEE_O2O_test had ERRORS
---> test EcalTPGFineGrainTowerEE_O2O_test had ERRORS
---> test EcalTPGLinearizationConst_O2O_test had ERRORS
---> test EcalTPGLutGroup_O2O_test had ERRORS
---> test EcalTPGLutIdMap_O2O_test had ERRORS
---> test EcalTPGPedestals_O2O_test had ERRORS
---> test EcalTPGPhysicsConst_O2O_test had ERRORS
---> test EcalTPGSlidingWindow_O2O_test had ERRORS
---> test EcalTPGSpike_O2O_test had ERRORS
---> test EcalTPGTowerStatus_O2O_test had ERRORS
---> test EcalTPGWeightGroup_O2O_test had ERRORS
---> test EcalTPGWeightIdMap_O2O_test had ERRORS
---> test RunInfoStart_O2O_test had ERRORS
```
all seemingly related to:

```bash
----- Begin Fatal Exception 29-Sep-2021 11:11:47 CEST-----------------------
An exception of category 'ConditionDatabase' occurred while
 ...
Exception Message:
Service "cms_omds_adg" can't be open with the current key. from cond::CredentialStore::setUpConnection
----- End Fatal Exception -------------------------------------------------
```
which looks like an intrinsic limitation of running the O2O test from the lambda user. 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
