### PR TITLE
[UBSAN] Properly initialize data members , fixes UBSAN unit test

### DIFF
--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaRun.h
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaRun.h
@@ -530,7 +530,7 @@ public:
 
   //...................................................... methods that will (should) be private
 
-  void Init();
+  void Init(TEcnaObject*);
 
   void SetEcalSubDetector(const TString&);
 

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaRun.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaRun.cc
@@ -27,28 +27,7 @@ TEcnaRun::TEcnaRun(TEcnaObject* pObjectManager, const TString& SubDet) {
 
   // std::cout << "[Info Management] CLASS: TEcnaRun.           CREATE OBJECT: this = " << this << std::endl;
 
-  Init();
-  fObjectManager = (TEcnaObject*)pObjectManager;
-  Long_t i_this = (Long_t)this;
-  pObjectManager->RegisterPointer("TEcnaRun", i_this);
-
-  //............................ fCnaParCout
-  fCnaParCout = nullptr;
-  Long_t iCnaParCout = pObjectManager->GetPointerValue("TEcnaParCout");
-  if (iCnaParCout == 0) {
-    fCnaParCout = new TEcnaParCout(pObjectManager); /*fCnew++*/
-  } else {
-    fCnaParCout = (TEcnaParCout*)iCnaParCout;
-  }
-
-  //............................ fCnaParPaths
-  fCnaParPaths = nullptr;
-  Long_t iCnaParPaths = pObjectManager->GetPointerValue("TEcnaParPaths");
-  if (iCnaParPaths == 0) {
-    fCnaParPaths = new TEcnaParPaths(pObjectManager); /*fCnew++*/
-  } else {
-    fCnaParPaths = (TEcnaParPaths*)iCnaParPaths;
-  }
+  Init(pObjectManager);
 
   //fCfgResultsRootFilePath    = fCnaParPaths->ResultsRootFilePath();
   //fCfgHistoryRunListFilePath = fCnaParPaths->HistoryRunListFilePath();
@@ -76,31 +55,8 @@ TEcnaRun::TEcnaRun(TEcnaObject* pObjectManager, const TString& SubDet) {
 }
 
 TEcnaRun::TEcnaRun(TEcnaObject* pObjectManager, const TString& SubDet, const Int_t& NbOfSamples) {
-  //fCnaParPaths = 0; fCnaParPaths = new TEcnaParPaths();  //fCnew++;
-  //fCnaParCout = 0;  fCnaParCout  = new TEcnaParCout();   //fCnew++;
 
-  Init();
-  fObjectManager = (TEcnaObject*)pObjectManager;
-  Long_t i_this = (Long_t)this;
-  pObjectManager->RegisterPointer("TEcnaRun", i_this);
-
-  //............................ fCnaParCout
-  fCnaParCout = nullptr;
-  Long_t iCnaParCout = pObjectManager->GetPointerValue("TEcnaParCout");
-  if (iCnaParCout == 0) {
-    fCnaParCout = new TEcnaParCout(pObjectManager); /*fCnew++*/
-  } else {
-    fCnaParCout = (TEcnaParCout*)iCnaParCout;
-  }
-
-  //............................ fCnaParPaths
-  fCnaParPaths = nullptr;
-  Long_t iCnaParPaths = pObjectManager->GetPointerValue("TEcnaParPaths");
-  if (iCnaParPaths == 0) {
-    fCnaParPaths = new TEcnaParPaths(pObjectManager); /*fCnew++*/
-  } else {
-    fCnaParPaths = (TEcnaParPaths*)iCnaParPaths;
-  }
+  Init(pObjectManager);
 
   //fCfgResultsRootFilePath    = fCnaParPaths->ResultsRootFilePath();
   //fCfgHistoryRunListFilePath = fCnaParPaths->HistoryRunListFilePath();
@@ -131,7 +87,7 @@ TEcnaRun::TEcnaRun(TEcnaObject* pObjectManager, const TString& SubDet, const Int
 //.... return true or false according to the existence of the path. The path itself is in an attribute of fCnaParPaths.
 Bool_t TEcnaRun::GetPathForResults() { return fCnaParPaths->GetPathForResultsRootFiles(); }
 
-void TEcnaRun::Init() {
+void TEcnaRun::Init(TEcnaObject* pObjectManager) {
   //Initialisation
 
   fCnew = 0;
@@ -244,6 +200,25 @@ void TEcnaRun::Init() {
 
   fTagAvMeanCorss = nullptr;
   fTagAvSigCorss = nullptr;
+
+  fObjectManager = (TEcnaObject*)pObjectManager;
+  pObjectManager->RegisterPointer("TEcnaRun", (Long_t)this);
+
+  //............................ fCnaParCout
+  Long_t iCnaParCout = pObjectManager->GetPointerValue("TEcnaParCout");
+  if (iCnaParCout == 0) {
+    fCnaParCout = new TEcnaParCout(pObjectManager); /*fCnew++*/
+  } else {
+    fCnaParCout = (TEcnaParCout*)iCnaParCout;
+  }
+
+  //............................ fCnaParPaths
+  Long_t iCnaParPaths = pObjectManager->GetPointerValue("TEcnaParPaths");
+  if (iCnaParPaths == 0) {
+    fCnaParPaths = new TEcnaParPaths(pObjectManager); /*fCnew++*/
+  } else {
+    fCnaParPaths = (TEcnaParPaths*)iCnaParPaths;
+  }
 
   //................................................... Code Print  ( Init() )
   fCodePrintNoComment = fCnaParCout->GetCodePrint("NoComment");

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaRun.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaRun.cc
@@ -55,7 +55,6 @@ TEcnaRun::TEcnaRun(TEcnaObject* pObjectManager, const TString& SubDet) {
 }
 
 TEcnaRun::TEcnaRun(TEcnaObject* pObjectManager, const TString& SubDet, const Int_t& NbOfSamples) {
-
   Init(pObjectManager);
 
   //fCfgResultsRootFilePath    = fCnaParPaths->ResultsRootFilePath();

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaWrite.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaWrite.cc
@@ -51,6 +51,7 @@ TEcnaWrite::TEcnaWrite(TEcnaObject* pObjectManager, const TString& SubDet) {
   } else {
     fCnaParCout = (TEcnaParCout*)iCnaParCout;
   }
+  fCodePrintAllComments = fCnaParCout->GetCodePrint("AllComments");
 
   //............................ fCnaParPaths
   fCnaParPaths = nullptr;
@@ -118,6 +119,7 @@ TEcnaWrite::TEcnaWrite(const TString& SubDet,
   } else {
     fCnaParCout = (TEcnaParCout*)pCnaParCout;
   }
+  fCodePrintAllComments = fCnaParCout->GetCodePrint("AllComments");
 
   fEcal = nullptr;
   if (pEcal == nullptr) {
@@ -195,7 +197,6 @@ void TEcnaWrite::Init() {
   fjustap_2d_ss = nullptr;
   fjustap_1d_ss = nullptr;
 
-  fCodePrintAllComments = fCnaParCout->GetCodePrint("AllComments");
 }
 // end of Init()
 

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaWrite.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaWrite.cc
@@ -196,7 +196,6 @@ void TEcnaWrite::Init() {
 
   fjustap_2d_ss = nullptr;
   fjustap_1d_ss = nullptr;
-
 }
 // end of Init()
 


### PR DESCRIPTION
This change should fix the failing unit test in UBSAN IBs.
- TEcnaRun.cc : Common initialization code for `TEcnaRun` class is moved to `TEcnaRun::Init()`
- TEcnaWrite.cc: Fix initialization of fCodePrintAllComments

fixes #35463
