### PR TITLE
Set collisionId in prunedGenParticles (11_2_X)

### DIFF
--- a/PhysicsTools/HepMCCandAlgos/plugins/GenParticlePruner.cc
+++ b/PhysicsTools/HepMCCandAlgos/plugins/GenParticlePruner.cc
@@ -255,6 +255,7 @@ void GenParticlePruner::produce(Event &evt, const EventSetup &es) {
     GenParticle &newGen = out->back();
     //fill status flags
     newGen.statusFlags() = gen.statusFlags();
+    newGen.setCollisionId(gen.collisionId());
     // The "daIndxs" and "moIndxs" keep a list of the keys for the mother/daughter
     // parentage/descendency. In some cases, a circular referencing is encountered,
     // which would result in an infinite loop. The list is checked to


### PR DESCRIPTION
#### PR description:

Backport of #35432 

11_2_X was used for the reminiAOD of 2018 PbPb data and MC.
Some of the MC datasets will have to be reminiAOD'd with this fix.

Incidentally, I did not see an 11_2_X IB available. 
Presumably there is very little development in this release, but hopefully we can build a new one at some point, although it's not very urgent. 