### PR TITLE
Fix for O2O tests requiring to read runinfo payload

### DIFF
--- a/CondCore/Utilities/scripts/conddb
+++ b/CondCore/Utilities/scripts/conddb
@@ -1852,8 +1852,10 @@ def _copy_tag(args, copyTime, session1, session2, first, second, fromIOV=None, t
         logging.debug('%s iov(s) to copy with %s payload(s)' %(len(iovs),len(hashes)))
     else:
         maxTime = _get_maxtime_for_boost_version( session1, tag['time_type'], cond2xml.boost_version_for_this_release())
+        logging.info('Max time for boost version %s is %s'%(cond2xml.boost_version_for_this_release(),maxTime))
         query = query.order_by(IOV1.since.desc(), IOV1.insertion_time.desc())
         lastIov = None
+        prevIovSince = None
         targetIovSince = None
         targetIovPayload = None
         for iov in query:
@@ -1867,7 +1869,9 @@ def _copy_tag(args, copyTime, session1, session2, first, second, fromIOV=None, t
                         targetIovSince = since
                     if since < maxTime: 
                         targetIovPayload = iov['payload_hash']
+                        prevIovSince = since
                         break
+        iovs[prevIovSince]=targetIovPayload
         iovs[targetIovSince]=targetIovPayload
         hashes.add(targetIovPayload)
     logfun = logging.info 

--- a/CondTools/Ecal/test/EcalIntercalibConstants_O2O_test.sh
+++ b/CondTools/Ecal/test/EcalIntercalibConstants_O2O_test.sh
@@ -2,7 +2,7 @@
 conddb --yes copy EcalIntercalibConstants_V1_hlt --destdb EcalIntercalibConstants_V1_hlt_O2OTEST.db --o2oTest
 conddb --yes copy EcalIntercalibConstants_0T --destdb EcalIntercalibConstants_V1_hlt_O2OTEST.db
 conddb --yes copy EcalIntercalibConstants_3.8T_v2 --destdb EcalIntercalibConstants_V1_hlt_O2OTEST.db
-lastRun=`conddb list EcalIntercalibConstants_V1_hlt  | tail -2 | awk '{print $1}'`
+lastRun=`conddb --db EcalIntercalibConstants_V1_hlt_O2OTEST.db list EcalIntercalibConstants_V1_hlt  | tail -2 | head -1 | awk '{print $1}'`
 conddb --yes copy runinfo_start_31X_hlt --destdb EcalIntercalibConstants_V1_hlt_O2OTEST.db -f $lastRun -t $lastRun
 cmsRun ./src/CondTools/Ecal/python/EcalIntercalibConstantsPopConBTransitionAnalyzer_cfg.py runNumber=$lastRun destinationDatabase=sqlite_file:EcalIntercalibConstants_V1_hlt_O2OTEST.db destinationTag=EcalIntercalibConstants_V1_hlt tagForRunInfo=runinfo_start_31X_hlt tagForBOff=EcalIntercalibConstants_0T tagForBOn=EcalIntercalibConstants_3.8T_v2
 ret=$?


### PR DESCRIPTION
#### PR description:

The O2O test workflow is modified by adding in the target sqlite export one iov, with the original since value of the 'max iov pointing to a payload with boost version compatible with the underlying release'
For iovs of run time-type, this is allowing to have an upper run value where the corresponding RunInfo payload will be readable by the same release.

These changes correspond to commit 445f54284c6f066315d9ab70396d21fef7364296 in https://github.com/cms-sw/cmssw/pull/35442

Tested with all O2Os integration tests.