### PR TITLE
remove runtime recursion from find_ntuplets in Patatrack

### DIFF
--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsImpl.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsImpl.h
@@ -358,7 +358,8 @@ __global__ void kernel_find_ntuplets(GPUCACell::Hits const *__restrict__ hhp,
     if (doit) {
       GPUCACell::TmpTuple stack;
       stack.reset();
-      thisCell.find_ntuplets<6>(hh, cells, *cellTracks, *foundNtuplets, *apc, quality, stack, minHitsPerNtuplet, pid < 3);
+      thisCell.find_ntuplets<6>(
+          hh, cells, *cellTracks, *foundNtuplets, *apc, quality, stack, minHitsPerNtuplet, pid < 3);
       assert(stack.empty());
       // printf("in %d found quadruplets: %d\n", cellIndex, apc->get());
     }

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsImpl.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsImpl.h
@@ -358,7 +358,7 @@ __global__ void kernel_find_ntuplets(GPUCACell::Hits const *__restrict__ hhp,
     if (doit) {
       GPUCACell::TmpTuple stack;
       stack.reset();
-      thisCell.find_ntuplets(hh, cells, *cellTracks, *foundNtuplets, *apc, quality, stack, minHitsPerNtuplet, pid < 3);
+      thisCell.find_ntuplets<6>(hh, cells, *cellTracks, *foundNtuplets, *apc, quality, stack, minHitsPerNtuplet, pid < 3);
       assert(stack.empty());
       // printf("in %d found quadruplets: %d\n", cellIndex, apc->get());
     }

--- a/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
@@ -270,7 +270,7 @@ public:
 
   // trying to free the track building process from hardcoded layers, leaving
   // the visit of the graph based on the neighborhood connections between cells.
-  template<int DEPTH>
+  template <int DEPTH>
   __device__ inline void find_ntuplets(Hits const& hh,
                                        GPUCACell* __restrict__ cells,
                                        CellTracksVector& cellTracks,
@@ -286,7 +286,6 @@ public:
     // the ntuplets is then saved if the number of hits it contains is greater
     // than a threshold
 
-    assert(DEPTH>0);
     tmpNtuplet.push_back_unsafe(theDoubletId_);
     assert(tmpNtuplet.size() <= 4);
 
@@ -295,7 +294,7 @@ public:
       if (cells[otherCell].theDoubletId_ < 0)
         continue;  // killed by earlyFishbone
       last = false;
-      cells[otherCell].find_ntuplets<DEPTH-1>(
+      cells[otherCell].find_ntuplets<DEPTH - 1>(
           hh, cells, cellTracks, foundNtuplets, apc, quality, tmpNtuplet, minHitsPerNtuplet, startAt0);
     }
     if (last) {  // if long enough save...
@@ -348,19 +347,18 @@ private:
   hindex_type theOuterHitId;
 };
 
-
- template<>
-  __device__ inline void GPUCACell::find_ntuplets<0>(Hits const& hh,
-                                       GPUCACell* __restrict__ cells,
-                                       CellTracksVector& cellTracks,
-                                       HitContainer& foundNtuplets,
-                                       cms::cuda::AtomicPairCounter& apc,
-                                       Quality* __restrict__ quality,
-                                       TmpTuple& tmpNtuplet,
-                                       const unsigned int minHitsPerNtuplet,
-                                       bool startAt0) const {
-    assert(false);
-
-  }
+template <>
+__device__ inline void GPUCACell::find_ntuplets<0>(Hits const& hh,
+                                                   GPUCACell* __restrict__ cells,
+                                                   CellTracksVector& cellTracks,
+                                                   HitContainer& foundNtuplets,
+                                                   cms::cuda::AtomicPairCounter& apc,
+                                                   Quality* __restrict__ quality,
+                                                   TmpTuple& tmpNtuplet,
+                                                   const unsigned int minHitsPerNtuplet,
+                                                   bool startAt0) const {
+  printf("ERROR: GPUCACell::find_ntuplets reached full depth!\n");
+  assert(false);  // on GPU is compiled away in NDEBUG mode
+}
 
 #endif  // RecoPixelVertexing_PixelTriplets_plugins_GPUCACell_h

--- a/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
@@ -270,6 +270,7 @@ public:
 
   // trying to free the track building process from hardcoded layers, leaving
   // the visit of the graph based on the neighborhood connections between cells.
+  template<int DEPTH>
   __device__ inline void find_ntuplets(Hits const& hh,
                                        GPUCACell* __restrict__ cells,
                                        CellTracksVector& cellTracks,
@@ -285,6 +286,7 @@ public:
     // the ntuplets is then saved if the number of hits it contains is greater
     // than a threshold
 
+    assert(DEPTH>0);
     tmpNtuplet.push_back_unsafe(theDoubletId_);
     assert(tmpNtuplet.size() <= 4);
 
@@ -293,7 +295,7 @@ public:
       if (cells[otherCell].theDoubletId_ < 0)
         continue;  // killed by earlyFishbone
       last = false;
-      cells[otherCell].find_ntuplets(
+      cells[otherCell].find_ntuplets<DEPTH-1>(
           hh, cells, cellTracks, foundNtuplets, apc, quality, tmpNtuplet, minHitsPerNtuplet, startAt0);
     }
     if (last) {  // if long enough save...
@@ -345,5 +347,20 @@ private:
   hindex_type theInnerHitId;
   hindex_type theOuterHitId;
 };
+
+
+ template<>
+  __device__ inline void GPUCACell::find_ntuplets<0>(Hits const& hh,
+                                       GPUCACell* __restrict__ cells,
+                                       CellTracksVector& cellTracks,
+                                       HitContainer& foundNtuplets,
+                                       cms::cuda::AtomicPairCounter& apc,
+                                       Quality* __restrict__ quality,
+                                       TmpTuple& tmpNtuplet,
+                                       const unsigned int minHitsPerNtuplet,
+                                       bool startAt0) const {
+    assert(false);
+
+  }
 
 #endif  // RecoPixelVertexing_PixelTriplets_plugins_GPUCACell_h


### PR DESCRIPTION
I replaced the runtime recursion with a compile time one.

compiles, runs, no regression.
is dramatically faster!
Running 4 times over 5000 events with 1 jobs, each with 8 threads, 8 streams and 1 GPUs:
before: 740.5 ±   1.4 ev/s
after: 913.9 ±  11.6 ev/s

nvprof:
before:
```
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   17.63%  2.22798s      5000  445.60us  6.5600us  1.3452ms  kernel_find_ntuplets(TrackingRecHit2DSOAView const *, GPUCACell*, unsigned int const *, cms::cuda::SimpleVector<cms::cuda::VecArray<unsigned short, int=48>>*, cms::cuda::OneToManyAssoc<unsigned int, int=32769, int=163840>*, cms::cuda::AtomicPairCounter*, pixelTrack::Quality*, unsigned int)
                    9.44%  1.19250s      5000  238.50us  14.752us  1.3508ms  gpuClustering::findClus(unsigned short const *, unsigned short const *, unsigned short const *, unsigned int const *, unsigned int*, unsigned int*, int*, int)
                    9.17%  1.15818s     10000  115.82us  1.9520us  481.25us  void kernel_BLFit<int=4>(cms::cuda::OneToManyAssoc<unsigned short, int=8, int=32768> const *, double, TrackSoAHeterogeneousT<int=32768>*, double*, float*, double*, unsigned int, unsigned int)
                    8.10%  1.02397s      5000  204.79us  22.912us  1.1259ms  kernel_connect(cms::cuda::AtomicPairCounter*, cms::cuda::AtomicPairCounter*, TrackingRecHit2DSOAView const *, GPUCACell*, unsigned int const *, cms::cuda::SimpleVector<cms::cuda::VecArray<unsigned int, int=36>>*, cms::cuda::VecArray<unsigned int, int=256> const *, float, float, float, float, float, float)
                    7.78%  983.37ms      5000  196.67us  10.464us  632.03us  gpuPixelDoublets::getDoubletsFromHisto(GPUCACell*, unsigned int*, cms::cuda::SimpleVector<cms::cuda::VecArray<unsigned int, int=36>>*, cms::cuda::SimpleVector<cms::cuda::VecArray<unsigned short, int=48>>*, TrackingRecHit2DSOAView const *, cms::cuda::VecArray<unsigned int, int=256>*, int, bool, bool, bool, bool, unsigned int)
                    6.89%  870.40ms      5000  174.08us  2.4000us  670.08us  void kernel_BLFit<int=3>(cms::cuda::OneToManyAssoc<unsigned short, int=8, int=32768> const *, double, TrackSoAHeterogeneousT<int=32768>*, double*, float*, double*, unsigned int, unsigned int)
                    6.48%  819.04ms      5000  163.81us  2.5600us  545.44us  gpuPixelDoublets::fishbone(TrackingRecHit2DSOAView const *, GPUCACell*, unsigned int const *, cms::cuda::VecArray<unsigned int, int=256> const *, unsigned int, bool)
                    4.29%  541.47ms      5000  108.29us  2.1120us  1.2090ms  kernel_rejectDuplicate(TrackingRecHit2DSOAView const *, cms::cuda::OneToManyAssoc<unsigned int, int=32769, int=163840> const *, TrackSoAHeterogeneousT<int=32768> const *, pixelTrack::Quality*, unsigned short, bool, cms::cuda::OneToManyAssoc<unsigned short, int=-1, int=131072> const *)
                    3.81%  481.74ms      5000  96.348us  5.4070us  351.74us  gpuVertexFinder::vertexFinderOneKernel(ZVertexSoA*, gpuVertexFinder::WorkSpace*, int, float, float, float)

```
after
```
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   10.64%  993.32ms      5000  198.66us  22.656us  1.1191ms  kernel_connect(cms::cuda::AtomicPairCounter*, cms::cuda::AtomicPairCounter*, TrackingRecHit2DSOAView const *, GPUCACell*, unsigned int const *, cms::cuda::SimpleVector<cms::cuda::VecArray<unsigned int, int=36>>*, cms::cuda::VecArray<unsigned int, int=256> const *, float, float, float, float, float, float)
                   10.62%  991.76ms     10000  99.176us  1.8890us  486.68us  void kernel_BLFit<int=4>(cms::cuda::OneToManyAssoc<unsigned short, int=8, int=32768> const *, double, TrackSoAHeterogeneousT<int=32768>*, double*, float*, double*, unsigned int, unsigned int)
                   10.26%  957.59ms      5000  191.52us  19.808us  1.0845ms  gpuClustering::findClus(unsigned short const *, unsigned short const *, unsigned short const *, unsigned int const *, unsigned int*, unsigned int*, int*, int)
                    9.13%  852.21ms      5000  170.44us  10.304us  690.33us  gpuPixelDoublets::getDoubletsFromHisto(GPUCACell*, unsigned int*, cms::cuda::SimpleVector<cms::cuda::VecArray<unsigned int, int=36>>*, cms::cuda::SimpleVector<cms::cuda::VecArray<unsigned short, int=48>>*, TrackingRecHit2DSOAView const *, cms::cuda::VecArray<unsigned int, int=256>*, int, bool, bool, bool, bool, unsigned int)
                    8.21%  766.72ms      5000  153.34us  2.8800us  515.87us  gpuPixelDoublets::fishbone(TrackingRecHit2DSOAView const *, GPUCACell*, unsigned int const *, cms::cuda::VecArray<unsigned int, int=256> const *, unsigned int, bool)
                    8.04%  750.35ms      5000  150.07us  3.0400us  929.82us  void kernel_BLFit<int=3>(cms::cuda::OneToManyAssoc<unsigned short, int=8, int=32768> const *, double, TrackSoAHeterogeneousT<int=32768>*, double*, float*, double*, unsigned int, unsigned int)
                    5.92%  553.06ms      5000  110.61us  6.6240us  414.30us  kernel_find_ntuplets(TrackingRecHit2DSOAView const *, GPUCACell*, unsigned int const *, cms::cuda::SimpleVector<cms::cuda::VecArray<unsigned short, int=48>>*, cms::cuda::OneToManyAssoc<unsigned int, int=32769, int=163840>*, cms::cuda::AtomicPairCounter*, pixelTrack::Quality*, unsigned int)
                    4.28%  399.38ms      5000  79.875us  5.4080us  256.99us  gpuVertexFinder::vertexFinderOneKernel(ZVertexSoA*, gpuVertexFinder::WorkSpace*, int, float, float, float)

```

technical.
