### PR TITLE
[GCC11] Fix compiler warnings for CalibPPS

### DIFF
--- a/CalibPPS/ESProducers/plugins/PPSAssociationCutsESSource.cc
+++ b/CalibPPS/ESProducers/plugins/PPSAssociationCutsESSource.cc
@@ -117,7 +117,8 @@ edm::ParameterSetDescription PPSAssociationCutsESSource::getIOVDefaultParameters
   desc.add<edm::EventRange>("validityRange", edm::EventRange())->setComment("interval of validity");
 
   for (auto &sector : {"45", "56"}) {
-    desc.add<edm::ParameterSetDescription>("association_cuts_" + std::string(sector), PPSAssociationCuts::getDefaultParameters())
+    desc.add<edm::ParameterSetDescription>("association_cuts_" + std::string(sector),
+                                           PPSAssociationCuts::getDefaultParameters())
         ->setComment("track-association cuts for sector " + std::string(sector));
   }
 

--- a/CalibPPS/ESProducers/plugins/PPSAssociationCutsESSource.cc
+++ b/CalibPPS/ESProducers/plugins/PPSAssociationCutsESSource.cc
@@ -116,9 +116,9 @@ edm::ParameterSetDescription PPSAssociationCutsESSource::getIOVDefaultParameters
   edm::ParameterSetDescription desc;
   desc.add<edm::EventRange>("validityRange", edm::EventRange())->setComment("interval of validity");
 
-  for (const std::string &sector : {"45", "56"}) {
-    desc.add<edm::ParameterSetDescription>("association_cuts_" + sector, PPSAssociationCuts::getDefaultParameters())
-        ->setComment("track-association cuts for sector " + sector);
+  for (auto &sector : {"45", "56"}) {
+    desc.add<edm::ParameterSetDescription>("association_cuts_" + std::string(sector), PPSAssociationCuts::getDefaultParameters())
+        ->setComment("track-association cuts for sector " + std::string(sector));
   }
 
   return desc;


### PR DESCRIPTION
This fixes the GCC11 compilation warnings from CalibPPS/ESProducers/plugins/PPSAssociationCutsESSource.cc 
```
  CalibPPS/ESProducers/plugins/PPSAssociationCutsESSource.cc:119:27: warning: loop variable 'sector' of type 'const string&' {aka 'const std::__cxx11::basic_string<char>&'} binds to a temporary constructed from type 'const char* const' [-Wrange-loop-construct]
   119 |   for (const std::string &sector : {"45", "56"}) {
```