### PR TITLE
Improve PluginDescription with VPSets

### DIFF
--- a/FWCore/Integration/test/ProducerWithPSetDesc.cc
+++ b/FWCore/Integration/test/ProducerWithPSetDesc.cc
@@ -1042,6 +1042,24 @@ namespace edmtest {
     pluginDesc1.addNode(edm::PluginDescription<AnotherIntFactory>("type", true));
     iDesc.add<edm::ParameterSetDescription>("plugin1", pluginDesc1);
 
+    edm::ParameterSetDescription pluginDesc2;
+    pluginDesc2.addNode(edm::PluginDescription<AnotherIntFactory>("type", true));
+    std::vector<edm::ParameterSet> vDefaultsPlugins2;
+    iDesc.addVPSet("plugin2", pluginDesc2, vDefaultsPlugins2);
+
+    edm::ParameterSetDescription pluginDesc3;
+    pluginDesc3.addNode(edm::PluginDescription<AnotherIntFactory>("type", true));
+    std::vector<edm::ParameterSet> vDefaultsPlugins3;
+    edm::ParameterSet vpsetDefault0;
+    vpsetDefault0.addParameter<std::string>("type", "edmtestAnotherOneMaker");
+    vDefaultsPlugins3.push_back(vpsetDefault0);
+    edm::ParameterSet vpsetDefault1;
+    vpsetDefault1.addParameter<std::string>("type", "edmtestAnotherValueMaker");
+    vpsetDefault1.addParameter<int>("value", 11);
+    vDefaultsPlugins3.push_back(vpsetDefault1);
+
+    iDesc.addVPSet("plugin3", pluginDesc3, vDefaultsPlugins3);
+
     // ------------------------------------------
 
     descriptions.add("testProducerWithPsetDesc", iDesc);

--- a/FWCore/Integration/test/unit_test_outputs/testProducerWithPsetDesc_briefdoc.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testProducerWithPsetDesc_briefdoc.txt
@@ -186,6 +186,8 @@
     noDefaultPset4          PSet                           see Section 1.1.21
     plugin                  PSet                           see Section 1.1.22
     plugin1                 PSet                           see Section 1.1.23
+    plugin2                 VPSet                          see Section 1.1.24
+    plugin3                 VPSet                          see Section 1.1.25
     mightGet                untracked vstring     optional none
     Section 1.1.1 vuint5 default contents: (vector size = 6)
         [0]: 4294967295
@@ -698,6 +700,33 @@
         Section 1.1.23.1.2 edmtestAnotherValueMaker Plugin description:
         value int32   5
         type  string  none
+    Section 1.1.24 plugin2 VPSet description:
+        All elements will be validated using the PSet description in Section 1.1.24.1.
+        The default VPSet is empty.
+    Section 1.1.24.1 description of PSet used to validate elements of VPSet:
+        Section 1.1.24.1.1 PluginDescriptoredmtestAnotherIntFactory Plugins description:
+        Section 1.1.24.1.1.1 edmtestAnotherOneMaker Plugin description:
+        type string  none
+        Section 1.1.24.1.1.2 edmtestAnotherValueMaker Plugin description:
+        value int32   5
+        type  string  none
+    Section 1.1.25 plugin3 VPSet description:
+        All elements will be validated using the PSet description in Section 1.1.25.1.
+        The default VPSet has 2 elements.
+        [0]: see Section 1.1.25.2
+        [1]: see Section 1.1.25.3
+    Section 1.1.25.1 description of PSet used to validate elements of VPSet:
+        Section 1.1.25.1.1 PluginDescriptoredmtestAnotherIntFactory Plugins description:
+        Section 1.1.25.1.1.1 edmtestAnotherOneMaker Plugin description:
+        type string  none
+        Section 1.1.25.1.1.2 edmtestAnotherValueMaker Plugin description:
+        value int32   5
+        type  string  none
+    Section 1.1.25.2 PSet description of default VPSet element [0]
+        type string  'edmtestAnotherOneMaker'
+    Section 1.1.25.3 PSet description of default VPSet element [1]
+        type  string  'edmtestAnotherValueMaker'
+        value int32   11
   1.2 testLabel1
     Description allows anything. If the configured PSet contains illegal parameters,
     then validation will ignore them instead of throwing an exception.

--- a/FWCore/Integration/test/unit_test_outputs/testProducerWithPsetDesc_cfi.py
+++ b/FWCore/Integration/test/unit_test_outputs/testProducerWithPsetDesc_cfi.py
@@ -344,5 +344,16 @@ testProducerWithPsetDesc = cms.EDProducer('ProducerWithPSetDesc',
   
   ),
   plugin1 = cms.PSet(),
+  plugin2 = cms.VPSet(
+  ),
+  plugin3 = cms.VPSet(
+    cms.PSet(
+      type = cms.string('edmtestAnotherOneMaker')
+    ),
+    cms.PSet(
+      type = cms.string('edmtestAnotherValueMaker'),
+      value = cms.int32(11)
+    )
+  ),
   mightGet = cms.optional.untracked.vstring
 )

--- a/FWCore/Integration/test/unit_test_outputs/testProducerWithPsetDesc_doc.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testProducerWithPsetDesc_doc.txt
@@ -537,6 +537,14 @@ generated for each configuration with a module label.
                         type: PSet 
                         see Section 1.1.23
 
+    plugin2
+                        type: VPSet 
+                        see Section 1.1.24
+
+    plugin3
+                        type: VPSet 
+                        see Section 1.1.25
+
     mightGet
                         type: untracked vstring optional
                         default: none
@@ -2031,6 +2039,72 @@ generated for each configuration with a module label.
         type
                         type: string 
                         default: none
+
+    Section 1.1.24 plugin2 VPSet description:
+        All elements will be validated using the PSet description in Section 1.1.24.1.
+        The default VPSet is empty.
+
+    Section 1.1.24.1 description of PSet used to validate elements of VPSet:
+
+        Section 1.1.24.1.1 PluginDescriptoredmtestAnotherIntFactory Plugins description:
+
+        Section 1.1.24.1.1.1 edmtestAnotherOneMaker Plugin description:
+
+        type
+                        type: string 
+                        default: none
+
+        Section 1.1.24.1.1.2 edmtestAnotherValueMaker Plugin description:
+
+        value
+                        type: int32 
+                        default: 5
+
+        type
+                        type: string 
+                        default: none
+
+    Section 1.1.25 plugin3 VPSet description:
+        All elements will be validated using the PSet description in Section 1.1.25.1.
+        The default VPSet has 2 elements.
+        [0]: see Section 1.1.25.2
+        [1]: see Section 1.1.25.3
+
+    Section 1.1.25.1 description of PSet used to validate elements of VPSet:
+
+        Section 1.1.25.1.1 PluginDescriptoredmtestAnotherIntFactory Plugins description:
+
+        Section 1.1.25.1.1.1 edmtestAnotherOneMaker Plugin description:
+
+        type
+                        type: string 
+                        default: none
+
+        Section 1.1.25.1.1.2 edmtestAnotherValueMaker Plugin description:
+
+        value
+                        type: int32 
+                        default: 5
+
+        type
+                        type: string 
+                        default: none
+
+    Section 1.1.25.2 PSet description of default VPSet element [0]
+
+        type
+                        type: string 
+                        default: 'edmtestAnotherOneMaker'
+
+    Section 1.1.25.3 PSet description of default VPSet element [1]
+
+        type
+                        type: string 
+                        default: 'edmtestAnotherValueMaker'
+
+        value
+                        type: int32 
+                        default: 11
 
   1.2 module label: testLabel1
   A comment for a ParameterSetDescription

--- a/FWCore/ParameterSet/interface/PluginDescription.h
+++ b/FWCore/ParameterSet/interface/PluginDescription.h
@@ -124,7 +124,7 @@ namespace edm {
 
     void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, bool optional) const final {
       loadPlugin(findType(pset));
-      cache_->validate(pset);
+      parameterSetDescription_->validate(pset);
       //all names are good
       auto n = pset.getParameterNames();
       validatedLabels.insert(n.begin(), n.end());
@@ -141,7 +141,7 @@ namespace edm {
 
         loadPlugin(defaultType_);
 
-        cache_->writeCfi(os, startWithComma, indentation);
+        parameterSetDescription_->writeCfi(os, startWithComma, indentation);
         wroteSomething = true;
       }
     }
@@ -216,11 +216,7 @@ namespace edm {
       return iPSet.getUntrackedParameter<std::string>(typeLabel_, defaultType_);
     }
 
-    void loadPlugin(std::string const& iName) const {
-      if (not cache_) {
-        cache_ = loadDescription(iName);
-      }
-    }
+    void loadPlugin(std::string const& iName) const { parameterSetDescription_ = loadDescription(iName); }
 
     std::shared_ptr<ParameterSetDescription> loadDescription(std::string const& iName) const {
       using CreatedType = PluginDescriptionAdaptorBase<typename T::CreatedType>;
@@ -247,7 +243,7 @@ namespace edm {
 
     // ---------- member data --------------------------------
     //Validation of plugins is only done on one thread at a time
-    CMS_SA_ALLOW mutable std::shared_ptr<ParameterSetDescription> cache_;
+    CMS_SA_ALLOW mutable std::shared_ptr<ParameterSetDescription> parameterSetDescription_;
     std::string typeLabel_;
     std::string defaultType_;
     bool typeLabelIsTracked_;

--- a/FWCore/ParameterSet/interface/PluginDescription.h
+++ b/FWCore/ParameterSet/interface/PluginDescription.h
@@ -123,8 +123,7 @@ namespace edm {
                                     std::set<ParameterTypes>& wildcardTypes) const final {}
 
     void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, bool optional) const final {
-      loadPlugin(findType(pset));
-      parameterSetDescription_->validate(pset);
+      loadDescription(findType(pset)).validate(pset);
       //all names are good
       auto n = pset.getParameterNames();
       validatedLabels.insert(n.begin(), n.end());
@@ -138,10 +137,7 @@ namespace edm {
           conf.allowNoCache();
           edmplugin::PluginManager::configure(conf);
         }
-
-        loadPlugin(defaultType_);
-
-        parameterSetDescription_->writeCfi(os, startWithComma, indentation);
+        loadDescription(defaultType_).writeCfi(os, startWithComma, indentation);
         wroteSomething = true;
       }
     }
@@ -187,7 +183,7 @@ namespace edm {
         new_dfh.init();
         new_dfh.setSection(newSection);
 
-        loadDescription(info.name_)->print(os, new_dfh);
+        loadDescription(info.name_).print(os, new_dfh);
 
         previousName = info.name_;
       }
@@ -216,34 +212,30 @@ namespace edm {
       return iPSet.getUntrackedParameter<std::string>(typeLabel_, defaultType_);
     }
 
-    void loadPlugin(std::string const& iName) const { parameterSetDescription_ = loadDescription(iName); }
-
-    std::shared_ptr<ParameterSetDescription> loadDescription(std::string const& iName) const {
+    ParameterSetDescription loadDescription(std::string const& iName) const {
       using CreatedType = PluginDescriptionAdaptorBase<typename T::CreatedType>;
       std::unique_ptr<CreatedType> a(edmplugin::PluginFactory<CreatedType*()>::get()->create(iName));
 
-      std::shared_ptr<ParameterSetDescription> desc = std::make_shared<ParameterSetDescription>(a->description());
+      ParameterSetDescription desc = a->description();
 
       //There is no way to check to see if a node already wants a label
       if (typeLabelIsTracked_) {
         if (defaultType_.empty()) {
-          desc->add<std::string>(typeLabel_);
+          desc.add<std::string>(typeLabel_);
         } else {
-          desc->add<std::string>(typeLabel_, defaultType_);
+          desc.add<std::string>(typeLabel_, defaultType_);
         }
       } else {
         if (defaultType_.empty()) {
-          desc->addUntracked<std::string>(typeLabel_);
+          desc.addUntracked<std::string>(typeLabel_);
         } else {
-          desc->addUntracked<std::string>(typeLabel_, defaultType_);
+          desc.addUntracked<std::string>(typeLabel_, defaultType_);
         }
       }
       return desc;
     }
 
     // ---------- member data --------------------------------
-    //Validation of plugins is only done on one thread at a time
-    CMS_SA_ALLOW mutable std::shared_ptr<ParameterSetDescription> parameterSetDescription_;
     std::string typeLabel_;
     std::string defaultType_;
     bool typeLabelIsTracked_;


### PR DESCRIPTION

#### PR description:

This allows the ParameterSetDescriptions to be different for each element of a VPSet in the special case where the elements hold a PluginDescription. Previously all elements would need to have the same plugin type.

#### PR validation:

Extended an existing unit test to cover this case. It seems to only really be different in the ParameterSetDescription part of things in a minor way.
