### PR TITLE
[120X] Revert GTs to use older geometry tags to be consistent w ongoing MC campaign 

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -66,17 +66,17 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak'     : '120X_upgrade2018cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'           : '120X_mcRun3_2021_design_v5', # GT containing design conditions for Phase1 2021
+    'phase1_2021_design'           : '120X_mcRun3_2021_design_v6', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'        : '120X_mcRun3_2021_realistic_v8', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'        : '120X_mcRun3_2021_realistic_v9', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'          : '120X_mcRun3_2021cosmics_realistic_deco_v7',
+    'phase1_2021_cosmics'          : '120X_mcRun3_2021cosmics_realistic_deco_v8',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi'     : '120X_mcRun3_2021_realistic_HI_v7',
+    'phase1_2021_realistic_hi'     : '120X_mcRun3_2021_realistic_HI_v8',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '120X_mcRun3_2023_realistic_v7', # GT containing realistic conditions for Phase1 2023
+    'phase1_2023_realistic'        : '120X_mcRun3_2023_realistic_v8', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '120X_mcRun3_2024_realistic_v7', # GT containing realistic conditions for Phase1 2024
+    'phase1_2024_realistic'        : '120X_mcRun3_2024_realistic_v8', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             : '113X_mcRun4_realistic_v7'
 }


### PR DESCRIPTION
#### PR description:

It was requested [1] that the autoCond in 12_0_X stays as close to the production GTs as possible, and the MC production for PF calibration using 12_0_0 is using GTs  that don't have the geometry fixes from [2] (neither do the GTs in 12_0_1), thus we are "reverting" to the geometry tags used in these sample, namely to  
```
Record | Label |  Tag 	
GeometryFileRcd | Extended | XMLFILE_Geometry_120YV1_Extended2021_mc	
IdealGeometryRecord | - |  TKRECO_Geometry_112YV2
```

The new GTs are the following, and I'm comparing with the GTs at the time of the MC campaign 

 * 120X_mcRun3_2021_design_v6
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/120X_mcRun3_2021_design_v4/120X_mcRun3_2021_design_v6 
 * 120X_mcRun3_2021_realistic_v9
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/120X_mcRun3_2021_realistic_v6/120X_mcRun3_2021_realistic_v9
 * 120X_mcRun3_2021cosmics_realistic_deco_v8
 https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/120X_mcRun3_2021cosmics_realistic_deco_v5/120X_mcRun3_2021cosmics_realistic_deco_v8
 * 120X_mcRun3_2021_realistic_HI_v8
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/120X_mcRun3_2021_realistic_HI_v5/120X_mcRun3_2021_realistic_HI_v8
 * 120X_mcRun3_2023_realistic_v8
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/120X_mcRun3_2023_realistic_v5/120X_mcRun3_2023_realistic_v8  * 120X_mcRun3_2024_realistic_v8
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/120X_mcRun3_2024_realistic_v5/120X_mcRun3_2024_realistic_v8

Differences are the newly introduced BeamSpot tags needed for [3], except the design GT where the BeamSpot was not changed, i.e. we dont see any differences.

HN announcement in [4]

[1] https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4475/1/1/1/1/1.html
[2] https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4460.html
[3] https://github.com/cms-sw/cmssw/pull/35397
[4] https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4478.html

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
This is meant for 12_0_X only

cc @srimanob @cms-sw/geometry-l2 @rappoccio 