### PR TITLE
Include final DDD geometry in Run-3 GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -66,17 +66,17 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak'     : '121X_upgrade2018cosmics_realistic_peak_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'           : '121X_mcRun3_2021_design_v6',
+    'phase1_2021_design'           : '121X_mcRun3_2021_design_v7',
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'        : '121X_mcRun3_2021_realistic_v8',
+    'phase1_2021_realistic'        : '121X_mcRun3_2021_realistic_v9',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'          : '121X_mcRun3_2021cosmics_realistic_deco_v8',
+    'phase1_2021_cosmics'          : '121X_mcRun3_2021cosmics_realistic_deco_v9',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi'     : '121X_mcRun3_2021_realistic_HI_v8',
+    'phase1_2021_realistic_hi'     : '121X_mcRun3_2021_realistic_HI_v9',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '121X_mcRun3_2023_realistic_v7',
+    'phase1_2023_realistic'        : '121X_mcRun3_2023_realistic_v8',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '121X_mcRun3_2024_realistic_v7',
+    'phase1_2024_realistic'        : '121X_mcRun3_2024_realistic_v8',
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             : '121X_mcRun4_realistic_v4'
 }


### PR DESCRIPTION
#### PR description:

After PPS geometry revisions, the final Run 3 12_1 DDD geometry is ready. Changes in the geometry: 
 * include minor revisions to the PPS Pixel sensors and elimination of duplicate PPS material names (PRs #34927 and #35380).
* also, composite material definitions were corrected to remove repeated elements (PR #35210).

The new GTs and the diffs:
 * 121X_mcRun3_2021_design_v7
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021_design_v6/121X_mcRun3_2021_design_v7
 * 121X_mcRun3_2021_realistic_v9
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021_realistic_v8/121X_mcRun3_2021_realistic_v9
 * 121X_mcRun3_2021cosmics_realistic_deco_v9
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021cosmics_realistic_deco_v8/121X_mcRun3_2021cosmics_realistic_deco_v9
 * 121X_mcRun3_2021_realistic_HI_v9
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021_realistic_HI_v8/121X_mcRun3_2021_realistic_HI_v9
 * 121X_mcRun3_2023_realistic_v8
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2023_realistic_v7/121X_mcRun3_2023_realistic_v8
 * 121X_mcRun3_2024_realistic_v8
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2024_realistic_v7/121X_mcRun3_2024_realistic_v8

The diffs are only in the requested 
`XMLFILE_Geometry_121YV1_Extended2021_mc` tag

HN msg:
https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4475/2.html

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not a backport and no backport is expected

cc @cms-sw/geometry-l2 