### PR TITLE
For async calls always store XrdCl::FileSystem with the response-handler.

### DIFF
--- a/Utilities/XrdAdaptor/src/XrdRequestManager.cc
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.cc
@@ -87,7 +87,7 @@ class SendMonitoringInfoHandler : public XrdCl::ResponseHandler {
 public:
   SendMonitoringInfoHandler(const SendMonitoringInfoHandler &) = delete;
   SendMonitoringInfoHandler &operator=(const SendMonitoringInfoHandler &) = delete;
-  SendMonitoringInfoHandler() = default;
+  SendMonitoringInfoHandler() = delete;
 
   SendMonitoringInfoHandler(const std::string &url) : m_fs(url) {}
 

--- a/Utilities/XrdAdaptor/src/XrdRequestManager.cc
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.cc
@@ -79,15 +79,20 @@ class SendMonitoringInfoHandler : public XrdCl::ResponseHandler {
     // Send Info has a response object; we must delete it.
     delete response;
     delete status;
+    delete this;
   }
+
+  XrdCl::FileSystem m_fs;
 
 public:
   SendMonitoringInfoHandler(const SendMonitoringInfoHandler &) = delete;
   SendMonitoringInfoHandler &operator=(const SendMonitoringInfoHandler &) = delete;
   SendMonitoringInfoHandler() = default;
-};
 
-CMS_THREAD_SAFE SendMonitoringInfoHandler nullHandler;
+  SendMonitoringInfoHandler(const std::string &url) : m_fs(url) {}
+
+  XrdCl::FileSystem& fs() { return m_fs; }
+};
 
 static void SendMonitoringInfo(XrdCl::File &file) {
   // Do not send this to a dCache data server as they return an error.
@@ -102,11 +107,11 @@ static void SendMonitoringInfo(XrdCl::File &file) {
   std::string lastUrl;
   file.GetProperty("LastURL", lastUrl);
   if (jobId && !lastUrl.empty()) {
-    XrdCl::URL url(lastUrl);
-    XrdCl::FileSystem fs(url);
-    if (!(fs.SendInfo(jobId, &nullHandler, 30).IsOK())) {
+    auto sm_handler = new SendMonitoringInfoHandler(lastUrl);
+    if (!(sm_handler->fs().SendInfo(jobId, sm_handler, 30).IsOK())) {
       edm::LogWarning("XrdAdaptorInternal")
           << "Failed to send the monitoring information, monitoring ID is " << jobId << ".";
+      delete sm_handler;
     }
     edm::LogInfo("XrdAdaptorInternal") << "Set monitoring ID to " << jobId << ".";
   }

--- a/Utilities/XrdAdaptor/src/XrdRequestManager.cc
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.cc
@@ -91,7 +91,7 @@ public:
 
   SendMonitoringInfoHandler(const std::string &url) : m_fs(url) {}
 
-  XrdCl::FileSystem& fs() { return m_fs; }
+  XrdCl::FileSystem &fs() { return m_fs; }
 };
 
 static void SendMonitoringInfo(XrdCl::File &file) {

--- a/Utilities/XrdAdaptor/src/XrdSource.cc
+++ b/Utilities/XrdAdaptor/src/XrdSource.cc
@@ -83,21 +83,24 @@ class QueryAttrHandler : public XrdCl::ResponseHandler {
   friend std::unique_ptr<QueryAttrHandler> std::make_unique<QueryAttrHandler>();
 
 public:
+  QueryAttrHandler() = delete;
   ~QueryAttrHandler() override = default;
   QueryAttrHandler(const QueryAttrHandler &) = delete;
   QueryAttrHandler &operator=(const QueryAttrHandler &) = delete;
 
-  static XrdCl::XRootDStatus query(XrdCl::FileSystem &fs,
+  QueryAttrHandler(const std::string &url) : m_fs(url) {}
+
+  static XrdCl::XRootDStatus query(const std::string &url,
                                    const std::string &attr,
                                    std::chrono::milliseconds timeout,
                                    std::string &result) {
-    auto handler = std::make_unique<QueryAttrHandler>();
+    auto handler = std::make_unique<QueryAttrHandler>(url);
     auto l_state = std::make_shared<QueryAttrState>();
     handler->m_state = l_state;
     XrdCl::Buffer arg(attr.size());
     arg.FromString(attr);
 
-    XrdCl::XRootDStatus st = fs.Query(XrdCl::QueryCode::Config, arg, handler.get());
+    XrdCl::XRootDStatus st = handler->m_fs.Query(XrdCl::QueryCode::Config, arg, handler.get());
     if (!st.IsOK()) {
       return st;
     }
@@ -121,8 +124,6 @@ public:
   }
 
 private:
-  QueryAttrHandler() {}
-
   void HandleResponse(XrdCl::XRootDStatus *status, XrdCl::AnyObject *response) override {
     // NOTE: we own the status and response pointers.
     std::unique_ptr<XrdCl::AnyObject> response_mgr;
@@ -176,6 +177,7 @@ private:
     std::unique_ptr<XrdCl::Buffer> m_response;
   };
   std::weak_ptr<QueryAttrState> m_state;
+  XrdCl::FileSystem m_fs;
 };
 
 Source::Source(timespec now, std::unique_ptr<XrdCl::File> fh, const std::string &exclude)
@@ -329,9 +331,8 @@ bool Source::getXrootdSiteFromURL(std::string url, std::string &site) {
   XrdCl::Buffer arg(attr.size());
   arg.FromString(attr);
 
-  XrdCl::FileSystem fs(url);
   std::string rsite;
-  XrdCl::XRootDStatus st = QueryAttrHandler::query(fs, "sitename", std::chrono::seconds(1), rsite);
+  XrdCl::XRootDStatus st = QueryAttrHandler::query(url, "sitename", std::chrono::seconds(1), rsite);
   if (!st.IsOK()) {
     XrdCl::URL xurl(url);
     getDomain(xurl.GetHostName(), site);


### PR DESCRIPTION
backport of #35455

This is a continuation of #34700.

XrdCl's internal response handlers (before user-supplied handler is called) access URL string that is part of the FileSystem object. As FileSystemObject was created on the stack, this gets destroyed while async request are still pending.

This PR moves FileSystem object into our response-handlers so it's lifetime is the same as that of the response. All response handlers auto-destruct as needed.