### PR TITLE
SiStripCalCosmicsNano ALCANANO: produce NANOEDMAOD

### DIFF
--- a/CalibTracker/SiStripCommon/python/customiseAlCaNano.py
+++ b/CalibTracker/SiStripCommon/python/customiseAlCaNano.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+
+def outputToFlat(process, outputName):
+    """ Replace PoolOutputModule by NanoAODOutputModule to get NanoAOD-like (flat tree) output without merging step """
+    orig = getattr(process, outputName)
+    setattr(process, outputName,
+            cms.OutputModule("NanoAODOutputModule", **{
+                pn: orig.getParameter(pn) for pn in orig.parameterNames_()
+                if pn != "eventAutoFlushCompressedSize"
+                })
+            )
+    return process
+
+def flatSiStripCalCosmicsNano(process):
+    return outputToFlat(process, "ALCARECOStreamSiStripCalCosmicsNano")

--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1151,9 +1151,9 @@ class ConfigBuilder(object):
         self.REDIGIDefaultSeq=self.DIGIDefaultSeq
 
     # for alca, skims, etc
-    def addExtraStream(self, name, stream, workflow='full', cppType="PoolOutputModule"):
+    def addExtraStream(self, name, stream, workflow='full'):
             # define output module and go from there
-        output = cms.OutputModule(cppType)
+        output = cms.OutputModule("PoolOutputModule")
         if stream.selectEvents.parameters_().__len__()!=0:
             output.SelectEvents = stream.selectEvents
         else:
@@ -1187,9 +1187,8 @@ class ConfigBuilder(object):
         if self._options.filtername:
             output.dataset.filterName= cms.untracked.string(self._options.filtername+"_"+stream.name)
 
-        if cppType == "PoolOutputModule":
-            #add an automatic flushing to limit memory consumption
-            output.eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
+        #add an automatic flushing to limit memory consumption
+        output.eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
 
         if workflow in ("producers,full"):
             if isinstance(stream.paths,tuple):
@@ -1288,12 +1287,10 @@ class ConfigBuilder(object):
                     print("Setting numberOfConcurrentLuminosityBlocks=1 because of AlCa sequence {}".format(shortName))
                     self._options.nConcurrentLumis = "1"
                     self._options.nConcurrentIOVs = "1"
-                isNano = (alcastream.dataTier == "NANOAOD")
-                output = self.addExtraStream(name, alcastream, workflow=workflow,
-                        cppType=("NanoAODOutputModule" if isNano else "PoolOutputModule"))
+                output = self.addExtraStream(name,alcastream, workflow = workflow)
                 self.executeAndRemember('process.ALCARECOEventContent.outputCommands.extend(process.OutALCARECO'+shortName+'_noDrop.outputCommands)')
                 self.AlCaPaths.append(shortName)
-                if 'DQM' in alcaList and not isNano:
+                if 'DQM' in alcaList:
                     if not self._options.inlineEventContent and hasattr(self.process,name):
                         self.executeAndRemember('process.' + name + '.outputCommands.append("keep *_MEtoEDMConverter_*_*")')
                     else:


### PR DESCRIPTION
#### PR description:

After the first attempt https://github.com/cms-sw/cmssw/pull/34985 failed at the merging step in the CMSSW_12_1_0_pre3 relvals ([hypernews](https://hypernews.cern.ch/HyperNews/CMS/get/relval/15942.html), [log](https://cms-unified.web.cern.ch/cms-unified/report/pdmvserv_RVCMSSW_12_1_0_pre3RunCosmics2021__RelVal_2021GR5_210921_144932_6110)) we learned (see also discussion with the Tier0 [CMSTZ-937](https://its.cern.ch/jira/browse/CMSTZ-937) and [dmwm](https://mattermost.web.cern.ch/cms-o-and-c/channels/dmwm) teams) that the workflow should produce NANOEDMAOD (nanoaod::FlatTable etc.), and the conversion to flat trees for NANOAOD is done in the merging step in the production system.
Hence this PR reverts the changes to ConfigBuilder from https://github.com/cms-sw/cmssw/pull/34985 (which changed the output module for ALCARECO skims with NANOAOD data tier), since this is not needed (to facilitate local testing I added a customise method, such that cmsDriver with `--customise=CalibTracker/SiStripCommon/customiseAlCaNano.flatSiStripCalCosmicsNano` directly produces the flat trees, as before).
This should at least stop the failing merge of the outputs in the relvals, although the conversion to flat trees when merging may need some more changes in the production system (I left `dataTier="NANOAOD"` in the [FilteredStream config](https://github.com/cms-sw/cmssw/blob/e99fe4b3b8919db12e17fb76ad7f12f34bbbb64a/Configuration/StandardSequences/python/AlCaRecoStreams_cff.py#L452-L459), anticipating that the same mechanism may be used as for physics skims, which seems to get the dataTier from the CMSSW config in [dmwm.DMCore.StdBase.determineOutputModules](https://github.com/dmwm/WMCore/blob/c05f7999c2c1345b61f29202d3d45e701e76f248/src/python/WMCore/WMSpec/StdSpecs/StdBase.py#L204-L234)).

#### PR validation:

Tested one of the runTheMatrix workflows that contain this (138.1), and converted to flat tree with the config from `Configuration/DataProcessing/test/RunMerge.py --input-files file:SiStripCalCosmicsNano.root --mergeNANO`

CC: @mmusich @FlorianBury @mdelcourt @robervalwalsh @tsusa @connorpa @tvami @malbouis @mariadalfonso @gouskos @davidlange6 @amaltaro