### PR TITLE
PPS: RP id update in DQM common

### DIFF
--- a/DQM/CTPPS/plugins/CTPPSCommonDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSCommonDQMSource.cc
@@ -156,22 +156,27 @@ void CTPPSCommonDQMSource::GlobalPlots::Init(DQMStore::IBooker &ibooker) {
     ya->SetBinLabel(18, "56, 220, NR-TP");
   }
 
-  h_trackCorr_hor = ibooker.book2D("track correlation hor", "ctpps_common_rp_hor", 6, -0.5, 5.5, 6, -0.5, 5.5);
+  h_trackCorr_hor = ibooker.book2D("track correlation hor", "ctpps_common_rp_hor", 8, -0.5, 7.5, 8, -0.5, 7.5);
   {
     TH2F *hist = h_trackCorr_hor->getTH2F();
     TAxis *xa = hist->GetXaxis(), *ya = hist->GetYaxis();
-    xa->SetBinLabel(1, "45, 210, far");
-    ya->SetBinLabel(1, "45, 210, far");
-    xa->SetBinLabel(2, "45, 220, far");
-    ya->SetBinLabel(2, "45, 220, far");
-    xa->SetBinLabel(3, "45, 220, cyl");
-    ya->SetBinLabel(3, "45, 220, cyl");
-    xa->SetBinLabel(4, "56, 210, far");
-    ya->SetBinLabel(4, "56, 210, far");
-    xa->SetBinLabel(5, "56, 220, far");
-    ya->SetBinLabel(5, "56, 220, far");
-    xa->SetBinLabel(6, "56, 220, cyl");
-    ya->SetBinLabel(6, "56, 220, cyl");
+    xa->SetBinLabel(1, "45, 210, FR");
+    ya->SetBinLabel(1, "45, 210, FR");
+    xa->SetBinLabel(2, "45, 220, NR");
+    ya->SetBinLabel(2, "45, 220, NR");
+    xa->SetBinLabel(3, "45, 220, C1");
+    ya->SetBinLabel(3, "45, 220, C1");
+    xa->SetBinLabel(4, "45, 220, FR");
+    ya->SetBinLabel(4, "45, 220, FR");
+
+    xa->SetBinLabel(5, "56, 210, FR");
+    ya->SetBinLabel(5, "56, 210, FR");
+    xa->SetBinLabel(6, "56, 220, NR");
+    ya->SetBinLabel(6, "56, 220, NR");
+    xa->SetBinLabel(7, "56, 220, C1");
+    ya->SetBinLabel(7, "56, 220, C1");
+    xa->SetBinLabel(8, "56, 220, FR");
+    ya->SetBinLabel(8, "56, 220, FR");
   }
 
   h_trackCorr_vert = ibooker.book2D("track correlation vert", "ctpps_common_rp_vert", 8, -0.5, 7.5, 8, -0.5, 7.5);
@@ -214,42 +219,46 @@ CTPPSCommonDQMSource::ArmPlots::ArmPlots(DQMStore::IBooker &ibooker, int _id, bo
   h_numRPWithTrack_bot =
       ibooker.book1D("number of bot RPs with tracks", title + ";number of bot RPs with tracks", 5, -0.5, 4.5);
 
-  h_trackCorr = ibooker.book2D("track correlation", title, 7, -0.5, 6.5, 7, -0.5, 6.5);
+  h_trackCorr = ibooker.book2D("track correlation", title, 8, -0.5, 7.5, 8, -0.5, 7.5);
   TH2F *h_trackCorr_h = h_trackCorr->getTH2F();
   TAxis *xa = h_trackCorr_h->GetXaxis(), *ya = h_trackCorr_h->GetYaxis();
-  xa->SetBinLabel(1, "210, far, hor");
-  ya->SetBinLabel(1, "210, far, hor");
-  xa->SetBinLabel(2, "210, far, top");
-  ya->SetBinLabel(2, "210, far, top");
-  xa->SetBinLabel(3, "210, far, bot");
-  ya->SetBinLabel(3, "210, far, bot");
-  xa->SetBinLabel(4, "220, cyl");
-  ya->SetBinLabel(4, "220, cyl");
-  xa->SetBinLabel(5, "220, far, hor");
-  ya->SetBinLabel(5, "220, far, hor");
-  xa->SetBinLabel(6, "220, far, top");
-  ya->SetBinLabel(6, "220, far, top");
-  xa->SetBinLabel(7, "220, far, bot");
-  ya->SetBinLabel(7, "220, far, bot");
+  xa->SetBinLabel(1, "210, FR-HR");
+  ya->SetBinLabel(1, "210, FR-HR");
+  xa->SetBinLabel(2, "210, FR-TP");
+  ya->SetBinLabel(2, "210, FR-TP");
+  xa->SetBinLabel(3, "210, FR-BT");
+  ya->SetBinLabel(3, "210, FR-BT");
+  xa->SetBinLabel(4, "220, NR-HR");
+  ya->SetBinLabel(4, "220, NR-HR");
+  xa->SetBinLabel(5, "220, C1");
+  ya->SetBinLabel(5, "220, C1");
+  xa->SetBinLabel(6, "220, FR-HR");
+  ya->SetBinLabel(6, "220, FR-HR");
+  xa->SetBinLabel(7, "220, FR-TP");
+  ya->SetBinLabel(7, "220, FR-TP");
+  xa->SetBinLabel(8, "220, FR-BT");
+  ya->SetBinLabel(8, "220, FR-BT");
 
-  h_trackCorr_overlap = ibooker.book2D("track correlation hor-vert overlaps", title, 7, -0.5, 6.5, 7, -0.5, 6.5);
+  h_trackCorr_overlap = ibooker.book2D("track correlation hor-vert overlaps", title, 8, -0.5, 7.5, 8, -0.5, 7.5);
   h_trackCorr_h = h_trackCorr_overlap->getTH2F();
   xa = h_trackCorr_h->GetXaxis();
   ya = h_trackCorr_h->GetYaxis();
-  xa->SetBinLabel(1, "210, far, hor");
-  ya->SetBinLabel(1, "210, far, hor");
-  xa->SetBinLabel(2, "210, far, top");
-  ya->SetBinLabel(2, "210, far, top");
-  xa->SetBinLabel(3, "210, far, bot");
-  ya->SetBinLabel(3, "210, far, bot");
-  xa->SetBinLabel(4, "220, cyl");
-  ya->SetBinLabel(4, "220, cyl");
-  xa->SetBinLabel(5, "220, far, hor");
-  ya->SetBinLabel(5, "220, far, hor");
-  xa->SetBinLabel(6, "220, far, top");
-  ya->SetBinLabel(6, "220, far, top");
-  xa->SetBinLabel(7, "220, far, bot");
-  ya->SetBinLabel(7, "220, far, bot");
+  xa->SetBinLabel(1, "210, FR-HR");
+  ya->SetBinLabel(1, "210, FR-HR");
+  xa->SetBinLabel(2, "210, FR-TP");
+  ya->SetBinLabel(2, "210, FR-TP");
+  xa->SetBinLabel(3, "210, FR-BT");
+  ya->SetBinLabel(3, "210, FR-BT");
+  xa->SetBinLabel(4, "220, NR-HR");
+  ya->SetBinLabel(4, "220, NR-HR");
+  xa->SetBinLabel(5, "220, C1");
+  ya->SetBinLabel(5, "220, C1");
+  xa->SetBinLabel(6, "220, FR-HR");
+  ya->SetBinLabel(6, "220, FR-HR");
+  xa->SetBinLabel(7, "220, FR-TP");
+  ya->SetBinLabel(7, "220, FR-TP");
+  xa->SetBinLabel(8, "220, FR-BT");
+  ya->SetBinLabel(8, "220, FR-BT");
 
   if (makeProtonRecoPlots) {
     h_proton_xi = ibooker.book1D("proton xi", title + ";xi", 100, 0., 0.3);
@@ -259,7 +268,7 @@ CTPPSCommonDQMSource::ArmPlots::ArmPlots(DQMStore::IBooker &ibooker, int _id, bo
     h_proton_time = ibooker.book1D("proton time", title + ";time   (ns)", 100, -1., 1.);
   }
 
-  for (const unsigned int rpDecId : {2, 3, 16, 23}) {
+  for (const unsigned int rpDecId : {3, 22, 16, 23}) {
     unsigned int st = rpDecId / 10, rp = rpDecId % 10, rpFullDecId = id * 100 + rpDecId;
     CTPPSDetId rpId(CTPPSDetId::sdTrackingStrip, id, st, rp);
     string stName, rpName;
@@ -267,7 +276,9 @@ CTPPSCommonDQMSource::ArmPlots::ArmPlots(DQMStore::IBooker &ibooker, int _id, bo
     rpId.rpName(rpName, CTPPSDetId::nShort);
     rpName = stName + "_" + rpName;
 
-    if (rp == 6) {
+    const bool timingRP = (rpDecId == 22 || rpDecId == 16);
+
+    if (timingRP) {
       timingRPPlots[rpFullDecId] = {
           ibooker.book1D(rpName + " - track x histogram", title + "/" + rpName + ";track x   (mm)", 200, 0., 40.),
           ibooker.book1D(
@@ -373,13 +384,15 @@ void CTPPSCommonDQMSource::analyzeTracks(edm::Event const &event, edm::EventSetu
       signed int idx = -1;
       if (stRPNum == 3)
         idx = 0;
-      if (stRPNum == 23)
+      if (stRPNum == 22)
         idx = 1;
       if (stRPNum == 16)
         idx = 2;
+      if (stRPNum == 23)
+        idx = 3;
 
       if (idx >= 0)
-        s_rp_idx_global_hor.insert(3 * arm + idx);
+        s_rp_idx_global_hor.insert(4 * arm + idx);
     }
 
     {
@@ -405,15 +418,18 @@ void CTPPSCommonDQMSource::analyzeTracks(edm::Event const &event, edm::EventSetu
         idx = 1;
       if (stRPNum == 5)
         idx = 2;
-      if (stRPNum == 16)
+      if (stRPNum == 22)
         idx = 3;
-      if (stRPNum == 23)
+      if (stRPNum == 16)
         idx = 4;
-      if (stRPNum == 24)
+      if (stRPNum == 23)
         idx = 5;
-      if (stRPNum == 25)
+      if (stRPNum == 24)
         idx = 6;
+      if (stRPNum == 25)
+        idx = 7;
 
+      // TODO: remove hor - not used
       const signed int hor = ((rpNum == 2) || (rpNum == 3) || (rpNum == 6)) ? 1 : 0;
 
       if (idx >= 0)
@@ -488,8 +504,10 @@ void CTPPSCommonDQMSource::analyzeTracks(edm::Event const &event, edm::EventSetu
 
     for (const auto &idx1 : ap.second) {
       for (const auto &idx2 : ap.second) {
+        // TODO: remove /10
         plots.h_trackCorr->Fill(idx1 / 10, idx2 / 10);
 
+        // TODO: remove /10
         if ((idx1 % 10) != (idx2 % 10))
           plots.h_trackCorr_overlap->Fill(idx1 / 10, idx2 / 10);
       }

--- a/DQM/CTPPS/plugins/CTPPSCommonDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSCommonDQMSource.cc
@@ -183,22 +183,22 @@ void CTPPSCommonDQMSource::GlobalPlots::Init(DQMStore::IBooker &ibooker) {
   {
     TH2F *hist = h_trackCorr_vert->getTH2F();
     TAxis *xa = hist->GetXaxis(), *ya = hist->GetYaxis();
-    xa->SetBinLabel(1, "45, 210, far, top");
-    ya->SetBinLabel(1, "45, 210, far, top");
-    xa->SetBinLabel(2, "45, 210, far, bot");
-    ya->SetBinLabel(2, "45, 210, far, bot");
-    xa->SetBinLabel(3, "45, 220, far, top");
-    ya->SetBinLabel(3, "45, 220, far, top");
-    xa->SetBinLabel(4, "45, 220, far, bot");
-    ya->SetBinLabel(4, "45, 220, far, bot");
-    xa->SetBinLabel(5, "56, 210, far, top");
-    ya->SetBinLabel(5, "56, 210, far, top");
-    xa->SetBinLabel(6, "56, 210, far, bot");
-    ya->SetBinLabel(6, "56, 210, far, bot");
-    xa->SetBinLabel(7, "56, 220, far, top");
-    ya->SetBinLabel(7, "56, 220, far, top");
-    xa->SetBinLabel(8, "56, 220, far, bot");
-    ya->SetBinLabel(8, "56, 220, far, bot");
+    xa->SetBinLabel(1, "45, 210, FR-TP");
+    ya->SetBinLabel(1, "45, 210, FR-TP");
+    xa->SetBinLabel(2, "45, 210, FR-BT");
+    ya->SetBinLabel(2, "45, 210, FR-BT");
+    xa->SetBinLabel(3, "45, 220, FR-TP");
+    ya->SetBinLabel(3, "45, 220, FR-TP");
+    xa->SetBinLabel(4, "45, 220, FR-BT");
+    ya->SetBinLabel(4, "45, 220, FR-BT");
+    xa->SetBinLabel(5, "56, 210, FR-TP");
+    ya->SetBinLabel(5, "56, 210, FR-TP");
+    xa->SetBinLabel(6, "56, 210, FR-BT");
+    ya->SetBinLabel(6, "56, 210, FR-BT");
+    xa->SetBinLabel(7, "56, 220, FR-TP");
+    ya->SetBinLabel(7, "56, 220, FR-TP");
+    xa->SetBinLabel(8, "56, 220, FR-BT");
+    ya->SetBinLabel(8, "56, 220, FR-BT");
   }
 }
 
@@ -429,7 +429,6 @@ void CTPPSCommonDQMSource::analyzeTracks(edm::Event const &event, edm::EventSetu
       if (stRPNum == 25)
         idx = 7;
 
-      // TODO: remove hor - not used
       const signed int hor = ((rpNum == 2) || (rpNum == 3) || (rpNum == 6)) ? 1 : 0;
 
       if (idx >= 0)
@@ -504,10 +503,8 @@ void CTPPSCommonDQMSource::analyzeTracks(edm::Event const &event, edm::EventSetu
 
     for (const auto &idx1 : ap.second) {
       for (const auto &idx2 : ap.second) {
-        // TODO: remove /10
         plots.h_trackCorr->Fill(idx1 / 10, idx2 / 10);
 
-        // TODO: remove /10
         if ((idx1 % 10) != (idx2 % 10))
           plots.h_trackCorr_overlap->Fill(idx1 / 10, idx2 / 10);
       }


### PR DESCRIPTION
#### PR description:

This PR updates `CTPPSCommonDQMSource` to use the RPs foreseen for Run 3, in particular:
  * it removes 210-near-hr (unused tracking RP)
  * it adds 220-near-hr (new timing RP)

This PR is independent of #35445 and #35454 - it modifies another module. This PR should conclude the changes in PPS DQM due to the new RP layout (most importantly the new timing RPs).

#### PR validation:

Below a screenshot of a DMQ file produced from 2018 data. In particular:
  * in the left column: RP 220-near-hr is present in the list and has the timing set of plots, conversely the 210-near-hr is missing
  * in the right part: the correlation histogram has the 220-near-hr on both axes.

![dqm](https://user-images.githubusercontent.com/17830858/135442559-40b97875-a378-4c5a-b79d-0628b407a264.png)



