### PR TITLE
[EGM HLT] Produce sigma_IPhi_IPhi, needed for regression 

### DIFF
--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTClusterShapeProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTClusterShapeProducer.cc
@@ -63,7 +63,6 @@ EgammaHLTClusterShapeProducer::EgammaHLTClusterShapeProducer(const edm::Paramete
   produces<reco::RecoEcalCandidateIsolationMap>("sigmaIPhiIPhi");
   produces<reco::RecoEcalCandidateIsolationMap>("sigmaIPhiIPhi5x5");
   produces<reco::RecoEcalCandidateIsolationMap>("sigmaIPhiIPhi5x5NoiseCleaned");
-
 }
 
 EgammaHLTClusterShapeProducer::~EgammaHLTClusterShapeProducer() {}
@@ -134,7 +133,7 @@ void EgammaHLTClusterShapeProducer::produce(edm::StreamID sid,
         sigmaee = sigmaee - 0.02 * (EtaSC - 2.3);
     }
 
-    //this is full5x5 showershape 
+    //this is full5x5 showershape
     double sigmaee5x5 = sqrt(lazyTools5x5.localCovariances(*(recoecalcandref->superCluster()->seed()))[0]);
     double sigmaee5x5NoiseCleaned = sqrt(lazyTools5x5.localCovariances(*(recoecalcandref->superCluster()->seed()),
                                                                        EgammaLocalCovParamDefaults::kRelEnCut,
@@ -156,7 +155,6 @@ void EgammaHLTClusterShapeProducer::produce(edm::StreamID sid,
     clshMap2.insert(recoecalcandref, sigmapp);
     clsh5x5Map2.insert(recoecalcandref, sigmapp5x5);
     clsh5x5NoiseCleanedMap2.insert(recoecalcandref, sigmapp5x5NoiseCleaned);
-
   }
 
   iEvent.put(std::make_unique<reco::RecoEcalCandidateIsolationMap>(clshMap));
@@ -168,7 +166,6 @@ void EgammaHLTClusterShapeProducer::produce(edm::StreamID sid,
   iEvent.put(std::make_unique<reco::RecoEcalCandidateIsolationMap>(clsh5x5Map2), "sigmaIPhiIPhi5x5");
   iEvent.put(std::make_unique<reco::RecoEcalCandidateIsolationMap>(clsh5x5NoiseCleanedMap2),
              "sigmaIPhiIPhi5x5NoiseCleaned");
-
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTClusterShapeProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTClusterShapeProducer.cc
@@ -134,16 +134,16 @@ void EgammaHLTClusterShapeProducer::produce(edm::StreamID sid,
     }
 
     //this is full5x5 showershape
-    auto const ecalCandLocalCov = lazyTools5x5.localCovariances(*(recoecalcandref->superCluster()->seed())); 
-    auto const sigmaee5x5 = sqrt(ecalCandLocalCov[0]); 
+    auto const ecalCandLocalCov = lazyTools5x5.localCovariances(*(recoecalcandref->superCluster()->seed()));
+    auto const sigmaee5x5 = sqrt(ecalCandLocalCov[0]);
     auto const sigmapp5x5 = sqrt(ecalCandLocalCov[2]);
 
-    auto const ecalCandLocalCovNoiseCleaned = lazyTools5x5.localCovariances(*(recoecalcandref->superCluster()->seed()), 
-									    EgammaLocalCovParamDefaults::kRelEnCut, 
-									    &thresholds, 
-									    multThresEB_, 
-									    multThresEE_); 
-    auto const sigmaee5x5NoiseCleaned = sqrt(ecalCandLocalCovNoiseCleaned[0]); 
+    auto const ecalCandLocalCovNoiseCleaned = lazyTools5x5.localCovariances(*(recoecalcandref->superCluster()->seed()),
+                                                                            EgammaLocalCovParamDefaults::kRelEnCut,
+                                                                            &thresholds,
+                                                                            multThresEB_,
+                                                                            multThresEE_);
+    auto const sigmaee5x5NoiseCleaned = sqrt(ecalCandLocalCovNoiseCleaned[0]);
     auto const sigmapp5x5NoiseCleaned = sqrt(ecalCandLocalCovNoiseCleaned[2]);
 
     clshMap.insert(recoecalcandref, sigmaee);

--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTClusterShapeProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTClusterShapeProducer.cc
@@ -134,19 +134,17 @@ void EgammaHLTClusterShapeProducer::produce(edm::StreamID sid,
     }
 
     //this is full5x5 showershape
-    double sigmaee5x5 = sqrt(lazyTools5x5.localCovariances(*(recoecalcandref->superCluster()->seed()))[0]);
-    double sigmaee5x5NoiseCleaned = sqrt(lazyTools5x5.localCovariances(*(recoecalcandref->superCluster()->seed()),
-                                                                       EgammaLocalCovParamDefaults::kRelEnCut,
-                                                                       &thresholds,
-                                                                       multThresEB_,
-                                                                       multThresEE_)[0]);
+    auto const ecalCandLocalCov = lazyTools5x5.localCovariances(*(recoecalcandref->superCluster()->seed())); 
+    auto const sigmaee5x5 = sqrt(ecalCandLocalCov[0]); 
+    auto const sigmapp5x5 = sqrt(ecalCandLocalCov[2]);
 
-    double sigmapp5x5 = sqrt(lazyTools5x5.localCovariances(*(recoecalcandref->superCluster()->seed()))[2]);
-    double sigmapp5x5NoiseCleaned = sqrt(lazyTools5x5.localCovariances(*(recoecalcandref->superCluster()->seed()),
-                                                                       EgammaLocalCovParamDefaults::kRelEnCut,
-                                                                       &thresholds,
-                                                                       multThresEB_,
-                                                                       multThresEE_)[2]);
+    auto const ecalCandLocalCovNoiseCleaned = lazyTools5x5.localCovariances(*(recoecalcandref->superCluster()->seed()), 
+									    EgammaLocalCovParamDefaults::kRelEnCut, 
+									    &thresholds, 
+									    multThresEB_, 
+									    multThresEE_); 
+    auto const sigmaee5x5NoiseCleaned = sqrt(ecalCandLocalCovNoiseCleaned[0]); 
+    auto const sigmapp5x5NoiseCleaned = sqrt(ecalCandLocalCovNoiseCleaned[2]);
 
     clshMap.insert(recoecalcandref, sigmaee);
     clsh5x5Map.insert(recoecalcandref, sigmaee5x5);


### PR DESCRIPTION
#### PR description:
In EGM HLT producer for cluster shape variables, adding sigmaIPhiIPhi, which is needed in HLT supercluster regression setup. 

#### PR validation:
Ran EGM HLT on DY sample, after merging this branch and checked sigmaIPhiIPhi distributions.
<img width="450" alt="Screen Shot 2021-09-30 at 14 01 02" src="https://user-images.githubusercontent.com/5052706/135452426-9bfa5be4-cdb7-456d-b4c1-25884383f6e9.png">

This PR is not a backport.
Backport is not needed.