### PR TITLE
[12_0_X] SiStripCalCosmicsNano ALCANANO: produce NANOEDMAOD

### DIFF
--- a/CalibTracker/SiStripCommon/python/customiseAlCaNano.py
+++ b/CalibTracker/SiStripCommon/python/customiseAlCaNano.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+
+def outputToFlat(process, outputName):
+    """ Replace PoolOutputModule by NanoAODOutputModule to get NanoAOD-like (flat tree) output without merging step """
+    orig = getattr(process, outputName)
+    setattr(process, outputName,
+            cms.OutputModule("NanoAODOutputModule", **{
+                pn: orig.getParameter(pn) for pn in orig.parameterNames_()
+                if pn != "eventAutoFlushCompressedSize"
+                })
+            )
+    return process
+
+def flatSiStripCalCosmicsNano(process):
+    return outputToFlat(process, "ALCARECOStreamSiStripCalCosmicsNano")

--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1151,9 +1151,9 @@ class ConfigBuilder(object):
         self.REDIGIDefaultSeq=self.DIGIDefaultSeq
 
     # for alca, skims, etc
-    def addExtraStream(self, name, stream, workflow='full', cppType="PoolOutputModule"):
+    def addExtraStream(self, name, stream, workflow='full'):
             # define output module and go from there
-        output = cms.OutputModule(cppType)
+        output = cms.OutputModule("PoolOutputModule")
         if stream.selectEvents.parameters_().__len__()!=0:
             output.SelectEvents = stream.selectEvents
         else:
@@ -1187,9 +1187,8 @@ class ConfigBuilder(object):
         if self._options.filtername:
             output.dataset.filterName= cms.untracked.string(self._options.filtername+"_"+stream.name)
 
-        if cppType == "PoolOutputModule":
-            #add an automatic flushing to limit memory consumption
-            output.eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
+        #add an automatic flushing to limit memory consumption
+        output.eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
 
         if workflow in ("producers,full"):
             if isinstance(stream.paths,tuple):
@@ -1284,12 +1283,10 @@ class ConfigBuilder(object):
             alcastream = getattr(alcaConfig,name)
             shortName = name.replace('ALCARECOStream','')
             if shortName in alcaList and isinstance(alcastream,cms.FilteredStream):
-                isNano = (alcastream.dataTier == "NANOAOD")
-                output = self.addExtraStream(name, alcastream, workflow=workflow,
-                        cppType=("NanoAODOutputModule" if isNano else "PoolOutputModule"))
+                output = self.addExtraStream(name,alcastream, workflow = workflow)
                 self.executeAndRemember('process.ALCARECOEventContent.outputCommands.extend(process.OutALCARECO'+shortName+'_noDrop.outputCommands)')
                 self.AlCaPaths.append(shortName)
-                if 'DQM' in alcaList and not isNano:
+                if 'DQM' in alcaList:
                     if not self._options.inlineEventContent and hasattr(self.process,name):
                         self.executeAndRemember('process.' + name + '.outputCommands.append("keep *_MEtoEDMConverter_*_*")')
                     else:


### PR DESCRIPTION
#### PR description:

Backport of https://github.com/cms-sw/cmssw/pull/35483 , for testing with 12_0_2 or 12_0_3 relvals, as discussed in https://github.com/cms-sw/cmssw/pull/35483#issuecomment-931344343

#### PR validation:

Tested one of the runTheMatrix workflows that contain this (138.1), and converted to flat tree with the config from Configuration/DataProcessing/test/RunMerge.py --input-files file:SiStripCalCosmicsNano.root --mergeNANO

CC: @tvami @mmusich 