### PR TITLE
[bugfix] Adding protection for empty trajectory

### DIFF
--- a/TrackingTools/TrajectoryFiltering/interface/MinHitsTrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/MinHitsTrajectoryFilter.h
@@ -50,17 +50,17 @@ protected:
     int seedPenalty = (2 == traj.seedNHits()) ? theSeedPairPenalty : 0;  // increase by one if seed-doublet...
     bool passed = false;
 
-    if (!traj.empty()) { 
+    if (!traj.empty()) {
       double pt = traj.lastMeasurement().updatedState().freeTrajectoryState()->momentum().perp();
       double pz = traj.lastMeasurement().updatedState().freeTrajectoryState()->momentum().z();
       double sinhTrajEta2 = (pz * pz) / (pt * pt);
       double myEtaSwitch = sinh(theHighEtaSwitch);
       if (sinhTrajEta2 < (myEtaSwitch * myEtaSwitch)) {
-	if (traj.foundHits() >= theMinHits + seedPenalty)
-	  passed = true;
+        if (traj.foundHits() >= theMinHits + seedPenalty)
+          passed = true;
       } else {  //absTrajEta>theHighEtaSwitch, so apply relaxed cuts
-	if (traj.foundHits() >= theMinHitsAtHighEta + seedPenalty)
-	  passed = true;
+        if (traj.foundHits() >= theMinHitsAtHighEta + seedPenalty)
+          passed = true;
       }
     }
     return passed;

--- a/TrackingTools/TrajectoryFiltering/interface/MinHitsTrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/MinHitsTrajectoryFilter.h
@@ -13,7 +13,7 @@
 class MinHitsTrajectoryFilter final : public TrajectoryFilter {
 public:
   explicit MinHitsTrajectoryFilter(int minHits = 5,
-                                   double highEtaSwitch = 5.0,
+                                   double highEtaSwitch = sinh(5.0),
                                    int minHitsAtHighEta = 5,
                                    int seedPairPenalty = 0)
       : theMinHits(minHits),
@@ -23,7 +23,7 @@ public:
 
   MinHitsTrajectoryFilter(const edm::ParameterSet& pset, edm::ConsumesCollector& iC)
       : theMinHits(pset.getParameter<int>("minimumNumberOfHits")),
-        theHighEtaSwitch(pset.getParameter<double>("highEtaSwitch")),
+        theHighEtaSwitch(sinh(pset.getParameter<double>("highEtaSwitch"))),
         theMinHitsAtHighEta(pset.getParameter<int>("minHitsAtHighEta")),
         theSeedPairPenalty(pset.getParameter<int>("seedPairPenalty")) {}
 
@@ -51,11 +51,10 @@ protected:
     bool passed = false;
 
     if (!traj.empty()) {
-      auto pt = traj.lastMeasurement().updatedState().freeTrajectoryState()->momentum().perp();
+      auto pt2 = traj.lastMeasurement().updatedState().freeTrajectoryState()->momentum().perp2();
       auto pz = traj.lastMeasurement().updatedState().freeTrajectoryState()->momentum().z();
-      auto sinhTrajEta2 = (pz * pz) / (pt * pt);
-      auto myEtaSwitch = sinh(theHighEtaSwitch);
-      if (sinhTrajEta2 < (myEtaSwitch * myEtaSwitch)) {
+      auto sinhTrajEta2 = (pz * pz) / pt2;
+      if (sinhTrajEta2 < (theHighEtaSwitch * theHighEtaSwitch)) {
         if (traj.foundHits() >= theMinHits + seedPenalty)
           passed = true;
       } else {  //absTrajEta>theHighEtaSwitch, so apply relaxed cuts

--- a/TrackingTools/TrajectoryFiltering/interface/MinHitsTrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/MinHitsTrajectoryFilter.h
@@ -49,16 +49,19 @@ protected:
   bool QF(const T& traj) const {
     int seedPenalty = (2 == traj.seedNHits()) ? theSeedPairPenalty : 0;  // increase by one if seed-doublet...
     bool passed = false;
-    double pt = traj.lastMeasurement().updatedState().freeTrajectoryState()->momentum().perp();
-    double pz = traj.lastMeasurement().updatedState().freeTrajectoryState()->momentum().z();
-    double sinhTrajEta2 = (pz * pz) / (pt * pt);
-    double myEtaSwitch = sinh(theHighEtaSwitch);
-    if (sinhTrajEta2 < (myEtaSwitch * myEtaSwitch)) {
-      if (traj.foundHits() >= theMinHits + seedPenalty)
-        passed = true;
-    } else {  //absTrajEta>theHighEtaSwitch, so apply relaxed cuts
-      if (traj.foundHits() >= theMinHitsAtHighEta + seedPenalty)
-        passed = true;
+
+    if (!traj.empty()) { 
+      double pt = traj.lastMeasurement().updatedState().freeTrajectoryState()->momentum().perp();
+      double pz = traj.lastMeasurement().updatedState().freeTrajectoryState()->momentum().z();
+      double sinhTrajEta2 = (pz * pz) / (pt * pt);
+      double myEtaSwitch = sinh(theHighEtaSwitch);
+      if (sinhTrajEta2 < (myEtaSwitch * myEtaSwitch)) {
+	if (traj.foundHits() >= theMinHits + seedPenalty)
+	  passed = true;
+      } else {  //absTrajEta>theHighEtaSwitch, so apply relaxed cuts
+	if (traj.foundHits() >= theMinHitsAtHighEta + seedPenalty)
+	  passed = true;
+      }
     }
     return passed;
   }

--- a/TrackingTools/TrajectoryFiltering/interface/MinHitsTrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/MinHitsTrajectoryFilter.h
@@ -51,10 +51,10 @@ protected:
     bool passed = false;
 
     if (!traj.empty()) {
-      double pt = traj.lastMeasurement().updatedState().freeTrajectoryState()->momentum().perp();
-      double pz = traj.lastMeasurement().updatedState().freeTrajectoryState()->momentum().z();
-      double sinhTrajEta2 = (pz * pz) / (pt * pt);
-      double myEtaSwitch = sinh(theHighEtaSwitch);
+      auto pt = traj.lastMeasurement().updatedState().freeTrajectoryState()->momentum().perp();
+      auto pz = traj.lastMeasurement().updatedState().freeTrajectoryState()->momentum().z();
+      auto sinhTrajEta2 = (pz * pz) / (pt * pt);
+      auto myEtaSwitch = sinh(theHighEtaSwitch);
       if (sinhTrajEta2 < (myEtaSwitch * myEtaSwitch)) {
         if (traj.foundHits() >= theMinHits + seedPenalty)
           passed = true;


### PR DESCRIPTION
#### PR description:
This is a follow up of my earlier PR on eta extended electrons, which recently got merged  https://github.com/cms-sw/cmssw/pull/35309

It created some issues as reported here https://github.com/cms-sw/cmssw/issues/35488

The issues happened because of missing protection against empty trajectory before accessing trajectory's `lastMeasurement()`. This is being addressed in this PR.

#### PR validation:
Failing WFs reported in github issue https://github.com/cms-sw/cmssw/issues/35488 seem to run fine now, after the fix.

This PR is not a backport.
Backport not necessary.