### PR TITLE
Minor updates in CSC TP configurations for B904 tests

### DIFF
--- a/IORawData/CSCCommissioning/test/readFile_b904_Run3.py
+++ b/IORawData/CSCCommissioning/test/readFile_b904_Run3.py
@@ -63,7 +63,7 @@ if options.useB904ME11:
 # For B904 setup ME21 chamber, which corresponds to ME+2/1/03 VMECrate13 / DMBSlot2 RUI17 / FED838 in the production system mapping
 elif options.useB904ME21:
     FEDRUI = cms.PSet(
-        FED838 = cms.untracked.vstring('RUI16'),
+        FED838 = cms.untracked.vstring('RUI17'),
         RUI17 = cms.untracked.vstring(options.inputFiles[0])
     )
 # Please note that after passing mapping check this chamber still would be recognized as production chamber

--- a/IORawData/CSCCommissioning/test/readFile_b904_Run3.py
+++ b/IORawData/CSCCommissioning/test/readFile_b904_Run3.py
@@ -10,12 +10,20 @@ process.MessageLogger.debugModules = cms.untracked.vstring('*')
 process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
 
 options = VarParsing ('analysis')
-options.register ("firstRun", 341761, VarParsing.multiplicity.singleton, VarParsing.varType.int)
-options.register ("inputFilesGEM", "", VarParsing.multiplicity.singleton, VarParsing.varType.string)
-options.register ("readGEMData", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
-options.register ("useB904ME11", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
-options.register ("useB904ME21", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
-options.register ("useB904ME234s2", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
+options.register("firstRun", 341761, VarParsing.multiplicity.singleton, VarParsing.varType.int,
+                 "The first run for this data. Typically for Run-3 it needs to be set high enough, so that \
+                  cmsRun recognizes GEM detectors as valid. That is the case starting run 341761. Beyond making \
+                  sure that the GEM detectors are there, firstRun does not have a meaning.")
+options.register("inputFilesGEM", "", VarParsing.multiplicity.singleton, VarParsing.varType.string,
+                 "The GEM input file (if applicable). This needs to be filled for joint GEM-CSC runs with B904 ME1/1 test-stand.")
+options.register("readGEMData", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
+                 "Set to True when you want to process the GEM data as well as the CSC data.")
+options.register("useB904ME11", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
+                 "Set to True when using B904 ME1/1 data.")
+options.register("useB904ME21", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
+                 "Set to True when using B904 ME2/1 data (also works for ME3/1 and ME4/1).")
+options.register("useB904ME234s2", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
+                 "Set to True when using B904 ME1/1 data (also works for MEX/2 and ME1/3).")
 options.maxEvents = 10000
 options.parseArguments()
 

--- a/L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesAnalyzer.cc
+++ b/L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesAnalyzer.cc
@@ -68,12 +68,6 @@ private:
   bool dataVsEmulatorPlots_;
   void makeDataVsEmulatorPlots();
 
-  // plots of efficiencies in MC
-  bool mcEfficiencyPlots_;
-
-  // plots of resolution in MC
-  bool mcResolutionPlots_;
-
   /*
     When set to True, we assume that the data comes from
     the Building 904 CSC test-stand. This test-stand is a single
@@ -96,8 +90,6 @@ CSCTriggerPrimitivesAnalyzer::CSCTriggerPrimitivesAnalyzer(const edm::ParameterS
       clctVars_(conf.getParameter<std::vector<std::string>>("clctVars")),
       lctVars_(conf.getParameter<std::vector<std::string>>("lctVars")),
       dataVsEmulatorPlots_(conf.getParameter<bool>("dataVsEmulatorPlots")),
-      mcEfficiencyPlots_(conf.getParameter<bool>("mcEfficiencyPlots")),
-      mcResolutionPlots_(conf.getParameter<bool>("mcResolutionPlots")),
       useB904ME11_(conf.getParameter<bool>("useB904ME11")),
       useB904ME21_(conf.getParameter<bool>("useB904ME21")),
       useB904ME234s2_(conf.getParameter<bool>("useB904ME234s2")),
@@ -107,7 +99,6 @@ CSCTriggerPrimitivesAnalyzer::CSCTriggerPrimitivesAnalyzer(const edm::ParameterS
 }
 
 void CSCTriggerPrimitivesAnalyzer::analyze(const edm::Event &ev, const edm::EventSetup &setup) {
-  // efficiency and resolution analysis is done here
 }
 
 void CSCTriggerPrimitivesAnalyzer::endJob() {

--- a/L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesAnalyzer.cc
+++ b/L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesAnalyzer.cc
@@ -98,8 +98,7 @@ CSCTriggerPrimitivesAnalyzer::CSCTriggerPrimitivesAnalyzer(const edm::ParameterS
   useB904_ = useB904ME11_ or useB904ME21_ or useB904ME234s2_;
 }
 
-void CSCTriggerPrimitivesAnalyzer::analyze(const edm::Event &ev, const edm::EventSetup &setup) {
-}
+void CSCTriggerPrimitivesAnalyzer::analyze(const edm::Event &ev, const edm::EventSetup &setup) {}
 
 void CSCTriggerPrimitivesAnalyzer::endJob() {
   if (dataVsEmulatorPlots_)

--- a/L1Trigger/CSCTriggerPrimitives/test/runCSCL1TDQMClient_cfg.py
+++ b/L1Trigger/CSCTriggerPrimitives/test/runCSCL1TDQMClient_cfg.py
@@ -4,11 +4,16 @@ from Configuration.Eras.Era_Run3_cff import Run3
 from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
 
 options = VarParsing('analysis')
-options.register ("run3", True, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
-options.register ("mc", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
-options.register ("useB904ME11", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
-options.register ("useB904ME21", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
-options.register ("useB904ME234s2", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
+options.register("run3", True, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
+                 "Set to True when using Run-3 data.")
+options.register("mc", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
+                 "Set to True when running on MC.")
+options.register("useB904ME11", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
+                 "Set to True when using B904 ME1/1 data.")
+options.register("useB904ME21", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
+                 "Set to True when using B904 ME2/1 data (also works for ME3/1 and ME4/1).")
+options.register("useB904ME234s2", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
+                 "Set to True when using B904 ME1/1 data (also works for MEX/2 and ME1/3).")
 options.register ("useGEMs", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
 options.parseArguments()
 options.inputFiles = "file:step_DQM.root"

--- a/L1Trigger/CSCTriggerPrimitives/test/runCSCTriggerPrimitiveAnalyzer_cfg.py
+++ b/L1Trigger/CSCTriggerPrimitives/test/runCSCTriggerPrimitiveAnalyzer_cfg.py
@@ -5,19 +5,20 @@ from Configuration.Eras.Era_Run3_cff import Run3
 
 options = VarParsing('analysis')
 options.register ("dataVsEmulation", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
-options.register ("analyzeEffiency", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
-options.register ("analyzeResolution", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
 options.register ("dataVsEmulationFile", "empty", VarParsing.multiplicity.singleton, VarParsing.varType.string)
 """
 - For CMS runs, use the actual run number. Set useB904ME11, useB904ME21 or useB904ME234s2 to False
 - For B904 runs, set useB904ME11, useB904ME21 or useB904ME234s2 to True and set runNumber >= 341761.
   Set B904RunNumber to when the data was taken, e.g. 210519_162820.
 """
-options.register ("runNumber", 0, VarParsing.multiplicity.singleton, VarParsing.varType.int)
-options.register ("useB904ME11", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
-options.register ("useB904ME21", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
-options.register ("useB904ME234s2", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
-options.register ("B904RunNumber", "YYMMDD_HHMMSS", VarParsing.multiplicity.singleton, VarParsing.varType.string)
+options.register("runNumber", 0, VarParsing.multiplicity.singleton, VarParsing.varType.int)
+options.register("useB904ME11", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
+                 "Set to True when using B904 ME1/1 data.")
+options.register("useB904ME21", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
+                 "Set to True when using B904 ME2/1 data (also works for ME3/1 and ME4/1).")
+options.register("useB904ME234s2", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
+                 "Set to True when using B904 ME1/1 data (also works for MEX/2 and ME1/3).")
+options.register("B904RunNumber", "YYMMDD_HHMMSS", VarParsing.multiplicity.singleton, VarParsing.varType.string)
 options.parseArguments()
 
 B904Setup = options.useB904ME11 or options.useB904ME21 or options.useB904ME234s2

--- a/L1Trigger/CSCTriggerPrimitives/test/runCSCTriggerPrimitiveAnalyzer_cfg.py
+++ b/L1Trigger/CSCTriggerPrimitives/test/runCSCTriggerPrimitiveAnalyzer_cfg.py
@@ -36,12 +36,6 @@ process.source = cms.Source(
       fileNames = cms.untracked.vstring(options.inputFiles)
 )
 
-## if dataVsEmulation and analyzeEffiency or analyzeResolution are true,
-## pick dataVsEmulation
-if options.dataVsEmulation and (options.analyzeEffiency or options.analyzeResolution):
-    options.analyzeEffiency = False
-    options.analyzeResolution = False
-
 if options.dataVsEmulation:
     options.maxEvents = 1
     process.source = cms.Source("EmptySource")
@@ -61,8 +55,6 @@ process.cscTriggerPrimitivesAnalyzer = cms.EDAnalyzer(
     ## e.g. 334393
     runNumber = cms.uint32(options.runNumber),
     dataVsEmulatorPlots = cms.bool(options.dataVsEmulation),
-    mcEfficiencyPlots = cms.bool(options.analyzeEffiency),
-    mcResolutionPlots = cms.bool(options.analyzeResolution),
     B904RunNumber = cms.string(options.B904RunNumber)
 )
 

--- a/L1Trigger/CSCTriggerPrimitives/test/runCSCTriggerPrimitiveProducer_cfg.py
+++ b/L1Trigger/CSCTriggerPrimitives/test/runCSCTriggerPrimitiveProducer_cfg.py
@@ -4,23 +4,46 @@ from Configuration.Eras.Era_Run3_cff import Run3
 from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
 
 options = VarParsing('analysis')
-options.register ("unpack", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
-options.register ("unpackGEM", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
-options.register ("l1", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
-options.register ("l1GEM", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
-options.register ("mc", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
-options.register ("dqm", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
-options.register ("dqmGEM", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
-options.register ("useB904ME11", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
-options.register ("useB904ME21", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
-options.register ("useB904ME234s2", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
-options.register ("run3", True, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
-options.register ("runCCLUT", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
-options.register ("runME11ILT", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
-options.register ("saveEdmOutput", True, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
-options.register ("preTriggerAnalysis", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
-options.register ("dropNonMuonCollections", True, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
-options.register ("dqmOutputFile", "step_DQM.root", VarParsing.multiplicity.singleton, VarParsing.varType.string)
+options.register("unpack", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
+                 "Set to True when you want to unpack the CSC DAQ data.")
+options.register("unpackGEM", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
+                 "Set to True when you want to unpack the GEM DAQ data.")
+options.register("l1", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
+                 "Set to True when you want to re-emulate the CSC trigger primitives.")
+options.register("l1GEM", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
+                 "Set to True when you want to re-emulate the GEM trigger primitives.")
+options.register("mc", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
+                 "Set to True when running on MC.")
+options.register("dqm", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
+                 "Set to True when you want to run the CSC DQM")
+options.register("dqmGEM", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
+                 "Set to True when you want to run the GEM DQM")
+options.register("useB904ME11", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
+                 "Set to True when using B904 ME1/1 data.")
+options.register("useB904ME21", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
+                 "Set to True when using B904 ME2/1 data (also works for ME3/1 and ME4/1).")
+options.register("useB904ME234s2", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
+                 "Set to True when using B904 ME1/1 data (also works for MEX/2 and ME1/3).")
+options.register("run3", True, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
+                 "Set to True when using Run-3 data.")
+options.register("runCCLUT", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
+                 "Set to True when using the CCLUT algorithm (to be superseded soon).")
+options.register("runCCLUTOTMB", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
+                 "Set to True when using the CCLUT OTMB algorithm.")
+options.register("runCCLUTTMB", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
+                 "Set to True when using the CCLUT TMB algorithm.")
+options.register("runME11ILT", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
+                 "Set to True when running the GEM-CSC integrated local trigger algorithm in ME1/1.")
+options.register("runME21ILT", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
+                 "Set to True when running the GEM-CSC integrated local trigger algorithm in ME2/1.")
+options.register("saveEdmOutput", True, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
+                 "Set to True if you want to keep the EDM ROOT after unpacking and re-emulating.")
+options.register("preTriggerAnalysis", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
+                 "Set to True if you want to print out more details about CLCTs and LCTs in the offline CSC DQM module.")
+options.register("dropNonMuonCollections", True, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
+                 "Option to drop most non-muon collections generally considered unnecessary for GEM/CSC analysis")
+options.register("dqmOutputFile", "step_DQM.root", VarParsing.multiplicity.singleton, VarParsing.varType.string,
+                 "Name of the DQM output file. Default: step_DQM.root")
 options.parseArguments()
 
 process_era = Run3
@@ -95,13 +118,16 @@ if useB904Data:
 l1csc = process.cscTriggerPrimitiveDigis
 if options.l1:
       l1csc.commonParam.runCCLUT = options.runCCLUT
+      l1csc.commonParam.runCCLUT_OTMB = cms.bool(options.runCCLUTOTMB)
+      l1csc.commonParam.runCCLUT_TMB = cms.bool(options.runCCLUTTMB)
       l1csc.commonParam.runME11ILT = options.runME11ILT
+      l1csc.commonParam.runME21ILT = options.runME21ILT
       ## running on unpacked data, or after running the unpacker
       if (not options.mc or options.unpack):
             l1csc.CSCComparatorDigiProducer = "muonCSCDigis:MuonCSCComparatorDigi"
             l1csc.CSCWireDigiProducer = "muonCSCDigis:MuonCSCWireDigi"
             ## GEM-CSC trigger enabled
-            if options.runME11ILT:
+            if options.runME11ILT or options.runME21ILT:
                   l1csc.GEMPadDigiClusterProducer = "muonCSCDigis:MuonGEMPadDigiCluster"
 
 if options.l1GEM:


### PR DESCRIPTION
#### PR description:

@jfernan2  Recall that I recently closed https://github.com/cms-sw/cmssw/pull/34780 without merging it, because I did not want to introduce additional emulator changes while we're still investigating the performance of the Run-3 trigger primitives in the forward region for high-pT muons. Nevertheless PR https://github.com/cms-sw/cmssw/pull/34780 does have a few updates for our B904 test-stands. In particular we are testing the Run-3 firmware for ME2/1 this week (and the DMBSlot2 in currently wrong).

#### PR validation:

Code compiles. Only test configurations.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
