### PR TITLE
Fix the HLT GPU customisation for running on the CPU

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
+++ b/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
@@ -159,7 +159,9 @@ def customisePixelLocalReconstruction(process):
     )
 
     # reconstruct the pixel clusters on the cpu
-    process.hltSiPixelClustersLegacy = process.hltSiPixelClusters.clone()
+    process.hltSiPixelClustersLegacy = process.hltSiPixelClusters.clone(
+        src = "hltSiPixelDigisLegacy"
+    )
 
     # SwitchProducer wrapping a subset of the legacy pixel cluster producer, or the conversion of the pixel digis (except errors) and clusters to the legacy format
     from RecoLocalTracker.SiPixelClusterizer.siPixelDigisClustersFromSoA_cfi import siPixelDigisClustersFromSoA as _siPixelDigisClustersFromSoA


### PR DESCRIPTION
#### PR description:

Fix the HLT configuration of the Pixel local reconstruction, when the customisation for running on the GPU is applied, but the resulting configuration is run on a CPU-only machine.

#### PR validation:

The configuration generated by
```
hltGetConfiguration \
    /dev/CMSSW_12_1_0/GRun/V1 \
    --eras Run3 \
    --globaltag auto:phase1_2021_realistic \
    --mc \
    --unprescale \
    --output minimal \
    --customise HLTrigger/Configuration/customizeHLTforPatatrack.customizeHLTforPatatrack \
    --input /store/relval/CMSSW_12_1_0_pre3/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_121X_mcRun3_2021_realistic_v2-v1/10000/0eb14c4a-e363-424a-9c0c-2688c7d32c74.root
```
now runs both on the GPU and on the CPU.
