### PR TITLE
[XrdAdaptor] Delay additional source acquisition when redirect limit error is returned.

### DIFF
--- a/Utilities/XrdAdaptor/src/XrdRequestManager.cc
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.cc
@@ -91,7 +91,7 @@ public:
 
   SendMonitoringInfoHandler(const std::string &url) : m_fs(url) {}
 
-  XrdCl::FileSystem& fs() { return m_fs; }
+  XrdCl::FileSystem &fs() { return m_fs; }
 };
 
 static void SendMonitoringInfo(XrdCl::File &file) {
@@ -121,6 +121,7 @@ RequestManager::RequestManager(const std::string &filename, XrdCl::OpenFlags::Fl
     : m_serverToAdvertise(nullptr),
       m_timeout(XRD_DEFAULT_TIMEOUT),
       m_nextInitialSourceToggle(false),
+      m_redirectLimitDelayScale(1),
       m_name(filename),
       m_flags(flags),
       m_perms(perms),
@@ -594,6 +595,7 @@ void XrdAdaptor::RequestManager::handleOpen(XrdCl::XRootDStatus &status, std::sh
   std::lock_guard<std::recursive_mutex> sentry(m_source_mutex);
   if (status.IsOK()) {
     edm::LogVerbatim("XrdAdaptorInternal") << "Successfully opened new source: " << source->PrettyID() << std::endl;
+    m_redirectLimitDelayScale = 1;
     for (const auto &s : m_activeSources) {
       if (source->ID() == s->ID()) {
         edm::LogVerbatim("XrdAdaptorInternal")
@@ -624,7 +626,12 @@ void XrdAdaptor::RequestManager::handleOpen(XrdCl::XRootDStatus &status, std::sh
     }
   } else {  // File-open failure - wait at least 120s before next attempt.
     edm::LogVerbatim("XrdAdaptorInternal") << "Got failure when trying to open a new source" << std::endl;
-    m_nextActiveSourceCheck.tv_sec += XRD_ADAPTOR_LONG_OPEN_DELAY - XRD_ADAPTOR_SHORT_OPEN_DELAY;
+    int delayScale = 1;
+    if (status.status == XrdCl::errRedirectLimit) {
+      m_redirectLimitDelayScale = std::min(2 * m_redirectLimitDelayScale, 100);
+      delayScale = m_redirectLimitDelayScale;
+    }
+    m_nextActiveSourceCheck.tv_sec += delayScale * XRD_ADAPTOR_LONG_OPEN_DELAY - XRD_ADAPTOR_SHORT_OPEN_DELAY;
   }
 }
 
@@ -1030,14 +1037,6 @@ void XrdAdaptor::RequestManager::OpenHandler::HandleResponseWithHosts(XrdCl::XRo
          << "' (errno=" << status->errNo << ", code=" << status->code << ")";
       ex.addContext("In XrdAdaptor::RequestManager::OpenHandler::HandleResponseWithHosts()");
       manager->addConnections(ex);
-
-      // Brian, should we do something like this:
-      // if (status.status == XrdCl::errRedirectLimit) {
-      //   // The following method does not exist (yet), would probaly need a multiplier for OPEN_DELAY.
-      //   // Note that with XCache cluster one will never get multiple sources.
-      //   manager->increaseMultiSourceInterval();
-      // }
-
       m_promise.set_exception(std::make_exception_ptr(ex));
     }
   }

--- a/Utilities/XrdAdaptor/src/XrdRequestManager.h
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.h
@@ -222,6 +222,7 @@ namespace XrdAdaptor {
     bool m_nextInitialSourceToggle;
     // The time when the next active source check should be performed.
     timespec m_nextActiveSourceCheck;
+    int m_redirectLimitDelayScale;
     bool searchMode;
 
     const std::string m_name;


### PR DESCRIPTION
When file open returns error status `XrdCl::errRedirectLimit` this means the limit of retries on a redirector has been reached and that any further requests on the same redirector will result in the same error.

This PR introduces a progressive scaling variable that increases the delay until the next attempt of additional source acquisition.

In redirector hierarchy the reject decision gets made on each site redirector, based on its configuration -- this is why scaling is progressive, a job might later still succeed in opening of another file replica from another site.

Together with the `triedrc=resel` change in previous PR this allows for tuning of how many:
a) reopen requests due to errors, and
b) reopen requests to get an additional source
are allowed at each point in a redirector hierarchy and avoids constant pinging of redirectors for the same file.

This is really important for XCache (where additional open requests potentially introduce unwanted file replicas in the cache) and might also be relevant for EOS and other installations where data is served from a single set of disks with several servers and opening of additional requests only burdens the storage system.