### PR TITLE
Modernize plugins in `DQM/BeamMonitor`

### DIFF
--- a/DQM/BeamMonitor/plugins/AlcaBeamMonitorClient.cc
+++ b/DQM/BeamMonitor/plugins/AlcaBeamMonitorClient.cc
@@ -59,7 +59,10 @@ AlcaBeamMonitorClient::AlcaBeamMonitorClient(const ParameterSet& ps)
 AlcaBeamMonitorClient::~AlcaBeamMonitorClient() = default;
 
 //----------------------------------------------------------------------------------------------------------------------
-void AlcaBeamMonitorClient::beginRun(const edm::Run& r, const EventSetup& context) {}
+void AlcaBeamMonitorClient::dqmBeginRun(const edm::Run& r, const EventSetup& context) {}
+
+//----------------------------------------------------------------------------------------------------------------------
+void AlcaBeamMonitorClient::bookHistograms(DQMStore::IBooker& i, const edm::Run& r, const edm::EventSetup& c) {}
 
 //----------------------------------------------------------------------------------------------------------------------
 void AlcaBeamMonitorClient::beginLuminosityBlock(const LuminosityBlock& iLumi, const EventSetup& iSetup) {}
@@ -81,7 +84,7 @@ void AlcaBeamMonitorClient::endLuminosityBlock(const LuminosityBlock& iLumi, con
 }
 
 //----------------------------------------------------------------------------------------------------------------------
-void AlcaBeamMonitorClient::endRun(const Run& iRun, const EventSetup& context) {
+void AlcaBeamMonitorClient::dqmEndRun(const Run& iRun, const EventSetup& context) {
   // use this in case any LS is missing.
   if (valuesMap_.empty()) {
     LogInfo("AlcaBeamMonitorClient") << "The histogram "

--- a/DQM/BeamMonitor/plugins/AlcaBeamMonitorClient.cc
+++ b/DQM/BeamMonitor/plugins/AlcaBeamMonitorClient.cc
@@ -56,15 +56,13 @@ AlcaBeamMonitorClient::AlcaBeamMonitorClient(const ParameterSet& ps)
   }
 }
 
-AlcaBeamMonitorClient::~AlcaBeamMonitorClient() {}
-
-//----------------------------------------------------------------------------------------------------------------------
-void AlcaBeamMonitorClient::beginJob() {}
+AlcaBeamMonitorClient::~AlcaBeamMonitorClient() = default;
 
 //----------------------------------------------------------------------------------------------------------------------
 void AlcaBeamMonitorClient::beginRun(const edm::Run& r, const EventSetup& context) {}
 
 //----------------------------------------------------------------------------------------------------------------------
+void AlcaBeamMonitorClient::beginLuminosityBlock(const LuminosityBlock& iLumi, const EventSetup& iSetup) {}
 
 //----------------------------------------------------------------------------------------------------------------------
 void AlcaBeamMonitorClient::analyze(const Event& iEvent, const EventSetup& iSetup) {}

--- a/DQM/BeamMonitor/plugins/AlcaBeamMonitorClient.h
+++ b/DQM/BeamMonitor/plugins/AlcaBeamMonitorClient.h
@@ -12,13 +12,13 @@
 #include <string>
 // CMS
 #include "DataFormats/Provenance/interface/LuminosityBlockID.h"
+#include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
-#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-class AlcaBeamMonitorClient : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::WatchLuminosityBlocks> {
+class AlcaBeamMonitorClient : public DQMOneEDAnalyzer<edm::one::WatchLuminosityBlocks> {
 public:
   typedef dqm::legacy::MonitorElement MonitorElement;
   typedef dqm::legacy::DQMStore DQMStore;
@@ -27,11 +27,12 @@ public:
   ~AlcaBeamMonitorClient() override;
 
 protected:
-  void beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) override;
+  void dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) override;
+  void bookHistograms(DQMStore::IBooker& i, const edm::Run& r, const edm::EventSetup& c) override;
   void beginLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup) override;
   void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
   void endLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup) override;
-  void endRun(const edm::Run& iRun, const edm::EventSetup& iSetup) override;
+  void dqmEndRun(const edm::Run& iRun, const edm::EventSetup& iSetup) override;
 
 private:
   //                x,y,z,sigmax(y,z)... [run,lumi]          Histo name

--- a/DQM/BeamMonitor/plugins/AlcaBeamMonitorClient.h
+++ b/DQM/BeamMonitor/plugins/AlcaBeamMonitorClient.h
@@ -11,16 +11,14 @@
 #include <vector>
 #include <string>
 // CMS
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "DQMServices/Core/interface/DQMStore.h"
 #include "DataFormats/Provenance/interface/LuminosityBlockID.h"
-//#include "DataFormats/VertexReco/interface/Vertex.h"
-//#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-class AlcaBeamMonitorClient : public edm::EDAnalyzer {
+class AlcaBeamMonitorClient : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::WatchLuminosityBlocks> {
 public:
   typedef dqm::legacy::MonitorElement MonitorElement;
   typedef dqm::legacy::DQMStore DQMStore;
@@ -29,8 +27,8 @@ public:
   ~AlcaBeamMonitorClient() override;
 
 protected:
-  void beginJob(void) override;
   void beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) override;
+  void beginLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup) override;
   void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
   void endLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup) override;
   void endRun(const edm::Run& iRun, const edm::EventSetup& iSetup) override;

--- a/DQM/BeamMonitor/plugins/BeamConditionsMonitor.cc
+++ b/DQM/BeamMonitor/plugins/BeamConditionsMonitor.cc
@@ -36,7 +36,7 @@ BeamConditionsMonitor::BeamConditionsMonitor(const ParameterSet& ps) : countEvt_
     monitorName_ = monitorName_ + "/";
 }
 
-BeamConditionsMonitor::~BeamConditionsMonitor() {}
+BeamConditionsMonitor::~BeamConditionsMonitor() = default;
 
 //--------------------------------------------------------
 void BeamConditionsMonitor::beginJob() {
@@ -56,9 +56,6 @@ void BeamConditionsMonitor::beginJob() {
 }
 
 //--------------------------------------------------------
-void BeamConditionsMonitor::beginRun(const edm::Run& r, const EventSetup& context) {}
-
-//--------------------------------------------------------
 void BeamConditionsMonitor::beginLuminosityBlock(const LuminosityBlock& lumiSeg, const EventSetup& context) {
   countLumi_++;
 }
@@ -75,9 +72,5 @@ void BeamConditionsMonitor::endLuminosityBlock(const LuminosityBlock& lumiSeg, c
   h_x0_lumi->ShiftFillLast(condBeamSpot.GetX(), condBeamSpot.GetXError(), 1);
   h_y0_lumi->ShiftFillLast(condBeamSpot.GetY(), condBeamSpot.GetYError(), 1);
 }
-//--------------------------------------------------------
-void BeamConditionsMonitor::endRun(const Run& r, const EventSetup& context) {}
-//--------------------------------------------------------
-void BeamConditionsMonitor::endJob() {}
 
 DEFINE_FWK_MODULE(BeamConditionsMonitor);

--- a/DQM/BeamMonitor/plugins/BeamConditionsMonitor.cc
+++ b/DQM/BeamMonitor/plugins/BeamConditionsMonitor.cc
@@ -56,9 +56,12 @@ void BeamConditionsMonitor::beginJob() {
 }
 
 //--------------------------------------------------------
-void BeamConditionsMonitor::beginLuminosityBlock(const LuminosityBlock& lumiSeg, const EventSetup& context) {
+void BeamConditionsMonitor::dqmBeginLuminosityBlock(const LuminosityBlock& lumiSeg, const EventSetup& context) {
   countLumi_++;
 }
+
+//----------------------------------------------------------------------------------------------------------------------
+void BeamConditionsMonitor::bookHistograms(DQMStore::IBooker& i, const edm::Run& r, const edm::EventSetup& c) {}
 
 // ----------------------------------------------------------
 void BeamConditionsMonitor::analyze(const Event& iEvent, const EventSetup& iSetup) {
@@ -67,7 +70,7 @@ void BeamConditionsMonitor::analyze(const Event& iEvent, const EventSetup& iSetu
 }
 
 //--------------------------------------------------------
-void BeamConditionsMonitor::endLuminosityBlock(const LuminosityBlock& lumiSeg, const EventSetup& iSetup) {
+void BeamConditionsMonitor::dqmEndLuminosityBlock(const LuminosityBlock& lumiSeg, const EventSetup& iSetup) {
   LogInfo("BeamConditions") << "[BeamConditionsMonitor]:" << condBeamSpot << endl;
   h_x0_lumi->ShiftFillLast(condBeamSpot.GetX(), condBeamSpot.GetXError(), 1);
   h_y0_lumi->ShiftFillLast(condBeamSpot.GetY(), condBeamSpot.GetYError(), 1);

--- a/DQM/BeamMonitor/plugins/BeamConditionsMonitor.h
+++ b/DQM/BeamMonitor/plugins/BeamConditionsMonitor.h
@@ -11,7 +11,7 @@
 #include <string>
 // CMS
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DQMServices/Core/interface/DQMStore.h"
@@ -23,7 +23,7 @@
 // class declaration
 //
 class BeamSpotObjectsRcd;
-class BeamConditionsMonitor : public edm::EDAnalyzer {
+class BeamConditionsMonitor : public edm::one::EDAnalyzer<edm::one::WatchLuminosityBlocks> {
 public:
   BeamConditionsMonitor(const edm::ParameterSet&);
   ~BeamConditionsMonitor() override;
@@ -35,9 +35,6 @@ protected:
   // BeginJob
   void beginJob() override;
 
-  // BeginRun
-  void beginRun(const edm::Run& r, const edm::EventSetup& c) override;
-
   // Fake Analyze
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
@@ -45,12 +42,6 @@ protected:
 
   // DQM Client Diagnostic
   void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& c) override;
-
-  // EndRun
-  void endRun(const edm::Run& r, const edm::EventSetup& c) override;
-
-  // Endjob
-  void endJob() override;
 
 private:
   edm::ParameterSet parameters_;

--- a/DQM/BeamMonitor/plugins/BeamConditionsMonitor.h
+++ b/DQM/BeamMonitor/plugins/BeamConditionsMonitor.h
@@ -10,20 +10,20 @@
 // C++
 #include <string>
 // CMS
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/one/EDAnalyzer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "CondFormats/BeamSpotObjects/interface/BeamSpotObjects.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
-#include "DataFormats/BeamSpot/interface/BeamSpot.h"
-#include "CondFormats/BeamSpotObjects/interface/BeamSpotObjects.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 //
 // class declaration
 //
 class BeamSpotObjectsRcd;
-class BeamConditionsMonitor : public edm::one::EDAnalyzer<edm::one::WatchLuminosityBlocks> {
+class BeamConditionsMonitor : public DQMOneLumiEDAnalyzer<> {
 public:
   BeamConditionsMonitor(const edm::ParameterSet&);
   ~BeamConditionsMonitor() override;
@@ -35,13 +35,15 @@ protected:
   // BeginJob
   void beginJob() override;
 
+  void bookHistograms(DQMStore::IBooker& i, const edm::Run& r, const edm::EventSetup& c) override;
+
   // Fake Analyze
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
-  void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& context) override;
+  void dqmBeginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& context) override;
 
   // DQM Client Diagnostic
-  void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& c) override;
+  void dqmEndLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& c) override;
 
 private:
   edm::ParameterSet parameters_;

--- a/DQM/BeamMonitor/plugins/BeamMonitor.cc
+++ b/DQM/BeamMonitor/plugins/BeamMonitor.cc
@@ -903,7 +903,6 @@ void BeamMonitor::FitAndFill(const LuminosityBlock& lumiSeg, int& lastlumi, int&
     DipPVInfo_.push_back(h_nVtx_st->getRMSError());
     DipPVInfo_.push_back((float)MaxPVs);
     DipPVInfo_.push_back((float)countTotPV_);
-    MaxPVs = 0;
   } else {
     for (size_t i = 0; i < 7; i++) {
       if (i > 0) {
@@ -914,7 +913,6 @@ void BeamMonitor::FitAndFill(const LuminosityBlock& lumiSeg, int& lastlumi, int&
     }
   }
   theBeamFitter->SetPVInfo(DipPVInfo_);
-  countEvtLastNLS_ = 0;
 
   if (onlineMode_) {  // filling LS gap
     // FIXME: need to add protection for the case if the gap is at the resetting LS!

--- a/DQM/BeamMonitor/plugins/BeamMonitorBx.cc
+++ b/DQM/BeamMonitor/plugins/BeamMonitorBx.cc
@@ -116,8 +116,11 @@ void BeamMonitorBx::beginJob() {
   dbe_->setCurrentFolder(monitorName_ + "FitBx/All_nPVs");
 }
 
+//----------------------------------------------------------------------------------------------------------------------
+void BeamMonitorBx::bookHistograms(DQMStore::IBooker& i, const edm::Run& r, const edm::EventSetup& c) {}
+
 //--------------------------------------------------------
-void BeamMonitorBx::beginRun(const edm::Run& r, const EventSetup& context) {
+void BeamMonitorBx::dqmBeginRun(const edm::Run& r, const EventSetup& context) {
   ftimestamp = r.beginTime().value();
   tmpTime = ftimestamp >> 32;
   startTime = refTime = tmpTime;
@@ -563,6 +566,6 @@ void BeamMonitorBx::weight(double& mean, double& meanError, const double& val, c
 }
 
 //--------------------------------------------------------
-void BeamMonitorBx::endRun(const Run& r, const EventSetup& context) {}
+void BeamMonitorBx::dqmEndRun(const Run& r, const EventSetup& context) {}
 
 DEFINE_FWK_MODULE(BeamMonitorBx);

--- a/DQM/BeamMonitor/plugins/BeamMonitorBx.h
+++ b/DQM/BeamMonitor/plugins/BeamMonitorBx.h
@@ -10,8 +10,8 @@
 // C++
 #include <string>
 // CMS
+#include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
-#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -22,7 +22,7 @@
 // class declaration
 //
 
-class BeamMonitorBx : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::WatchLuminosityBlocks> {
+class BeamMonitorBx : public DQMOneEDAnalyzer<edm::one::WatchLuminosityBlocks> {
 public:
   typedef dqm::legacy::MonitorElement MonitorElement;
   typedef dqm::legacy::DQMStore DQMStore;
@@ -36,9 +36,10 @@ public:
 protected:
   // BeginJob
   void beginJob() override;
+  void bookHistograms(DQMStore::IBooker& i, const edm::Run& r, const edm::EventSetup& c) override;
 
   // BeginRun
-  void beginRun(const edm::Run& r, const edm::EventSetup& c) override;
+  void dqmBeginRun(const edm::Run& r, const edm::EventSetup& c) override;
 
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
@@ -46,7 +47,7 @@ protected:
 
   void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& c) override;
   // EndRun
-  void endRun(const edm::Run& r, const edm::EventSetup& c) override;
+  void dqmEndRun(const edm::Run& r, const edm::EventSetup& c) override;
 
 private:
   void FitAndFill(const edm::LuminosityBlock& lumiSeg, int&, int&, int&);

--- a/DQM/BeamMonitor/plugins/BeamMonitorBx.h
+++ b/DQM/BeamMonitor/plugins/BeamMonitorBx.h
@@ -10,11 +10,11 @@
 // C++
 #include <string>
 // CMS
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DQMServices/Core/interface/DQMStore.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "RecoVertex/BeamSpotProducer/interface/BeamFitter.h"
 #include <fstream>
 
@@ -22,7 +22,7 @@
 // class declaration
 //
 
-class BeamMonitorBx : public edm::EDAnalyzer {
+class BeamMonitorBx : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::WatchLuminosityBlocks> {
 public:
   typedef dqm::legacy::MonitorElement MonitorElement;
   typedef dqm::legacy::DQMStore DQMStore;
@@ -90,10 +90,6 @@ private:
   std::map<TString, MonitorElement*> hs;   // Tables
   std::map<TString, MonitorElement*> hst;  // Trending Histos
 
-  //Test
-  //  MonitorElement * h_x0;
-
-  //
   std::time_t tmpTime;
   std::time_t refTime;
   std::time_t startTime;

--- a/DQM/BeamMonitor/plugins/FakeBeamMonitor.cc
+++ b/DQM/BeamMonitor/plugins/FakeBeamMonitor.cc
@@ -916,7 +916,6 @@ void FakeBeamMonitor::FitAndFill(const LuminosityBlock& lumiSeg, int& lastlumi, 
   DipPVInfo_.push_back(rndm_->Gaus(10., 5.));      // Rms PV
   DipPVInfo_.push_back(rndm_->Gaus(5., 3.));       // Rms PV err
   DipPVInfo_.push_back(rndm_->Gaus(100., 10.));    // Max PVs
-  countEvtLastNLS_ = 0;
 
   if (onlineMode_) {  // filling LS gap
     // FIXME: need to add protection for the case if the gap is at the resetting LS!

--- a/DQM/BeamMonitor/plugins/PixelVTXMonitor.cc
+++ b/DQM/BeamMonitor/plugins/PixelVTXMonitor.cc
@@ -33,7 +33,7 @@ PixelVTXMonitor::PixelVTXMonitor(const edm::ParameterSet& ps) : parameters_(ps) 
   minVtxDoF_ = parameters_.getParameter<double>("MinVtxDoF");
 }
 
-PixelVTXMonitor::~PixelVTXMonitor() {}
+PixelVTXMonitor::~PixelVTXMonitor() = default;
 
 void PixelVTXMonitor::bookHistograms() {
   std::vector<std::string> hltPathsOfInterest =
@@ -164,12 +164,6 @@ void PixelVTXMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& i
 
 void PixelVTXMonitor::endRun(edm::Run const& iRun, edm::EventSetup const& iSetup) {}
 
-void PixelVTXMonitor::endJob() {}
 // Define this as a plug-in
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(PixelVTXMonitor);
-
-// Local Variables:
-// show-trailing-whitespace: t
-// truncate-lines: t
-// End:

--- a/DQM/BeamMonitor/plugins/PixelVTXMonitor.cc
+++ b/DQM/BeamMonitor/plugins/PixelVTXMonitor.cc
@@ -35,7 +35,7 @@ PixelVTXMonitor::PixelVTXMonitor(const edm::ParameterSet& ps) : parameters_(ps) 
 
 PixelVTXMonitor::~PixelVTXMonitor() = default;
 
-void PixelVTXMonitor::bookHistograms() {
+void PixelVTXMonitor::bookHistograms(DQMStore::IBooker& i, const edm::Run& r, const edm::EventSetup& c) {
   std::vector<std::string> hltPathsOfInterest =
       parameters_.getParameter<std::vector<std::string> >("HLTPathsOfInterest");
   if (hltPathsOfInterest.empty())
@@ -95,7 +95,7 @@ void PixelVTXMonitor::bookHistograms() {
 
 void PixelVTXMonitor::beginJob() { dbe_ = edm::Service<DQMStore>().operator->(); }
 
-void PixelVTXMonitor::beginRun(edm::Run const& iRun, edm::EventSetup const& iSetup) {
+void PixelVTXMonitor::dqmBeginRun(edm::Run const& iRun, edm::EventSetup const& iSetup) {
   bool changed = true;
   if (hltConfig_.init(iRun, iSetup, hltInputTag_.process(), changed)) {
     // if init returns TRUE, initialisation has succeeded!
@@ -108,8 +108,8 @@ void PixelVTXMonitor::beginRun(edm::Run const& iRun, edm::EventSetup const& iSet
                                      << " failed";
     // In this case, all access methods will return empty values!
   }
-  bookHistograms();
 }
+
 void PixelVTXMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) {
   if (histoMap_.empty())
     return;
@@ -162,7 +162,7 @@ void PixelVTXMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& i
   }
 }
 
-void PixelVTXMonitor::endRun(edm::Run const& iRun, edm::EventSetup const& iSetup) {}
+void PixelVTXMonitor::dqmEndRun(edm::Run const& iRun, edm::EventSetup const& iSetup) {}
 
 // Define this as a plug-in
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/DQM/BeamMonitor/plugins/PixelVTXMonitor.h
+++ b/DQM/BeamMonitor/plugins/PixelVTXMonitor.h
@@ -14,7 +14,7 @@
 #include <vector>
 #include <map>
 
-#include <FWCore/Framework/interface/EDAnalyzer.h>
+#include <FWCore/Framework/interface/one/EDAnalyzer.h>
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
@@ -27,7 +27,7 @@
 // class declaration
 //
 
-class PixelVTXMonitor : public edm::EDAnalyzer {
+class PixelVTXMonitor : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   typedef dqm::legacy::MonitorElement MonitorElement;
   typedef dqm::legacy::DQMStore DQMStore;
@@ -39,7 +39,6 @@ protected:
   void beginRun(edm::Run const& iRun, edm::EventSetup const& iSetup) override;
   void analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) override;
   void endRun(edm::Run const& iRun, edm::EventSetup const& iSetup) override;
-  void endJob() override;
 
 private:
   void bookHistograms();
@@ -68,8 +67,3 @@ private:
 };
 
 #endif  // PIXELVTXMONITOR_H
-
-// Local Variables:
-// show-trailing-whitespace: t
-// truncate-lines: t
-// End:

--- a/DQM/BeamMonitor/plugins/PixelVTXMonitor.h
+++ b/DQM/BeamMonitor/plugins/PixelVTXMonitor.h
@@ -14,20 +14,20 @@
 #include <vector>
 #include <map>
 
-#include <FWCore/Framework/interface/one/EDAnalyzer.h>
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "DQMServices/Core/interface/DQMStore.h"
-#include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
-#include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
-#include "DataFormats/VertexReco/interface/VertexFwd.h"
-#include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
+#include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
 
 //
 // class declaration
 //
 
-class PixelVTXMonitor : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
+class PixelVTXMonitor : public DQMOneEDAnalyzer<> {
 public:
   typedef dqm::legacy::MonitorElement MonitorElement;
   typedef dqm::legacy::DQMStore DQMStore;
@@ -36,13 +36,12 @@ public:
 
 protected:
   void beginJob() override;
-  void beginRun(edm::Run const& iRun, edm::EventSetup const& iSetup) override;
+  void dqmBeginRun(edm::Run const& iRun, edm::EventSetup const& iSetup) override;
+  void bookHistograms(DQMStore::IBooker& i, const edm::Run& r, const edm::EventSetup& c) override;
   void analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) override;
-  void endRun(edm::Run const& iRun, edm::EventSetup const& iSetup) override;
+  void dqmEndRun(edm::Run const& iRun, edm::EventSetup const& iSetup) override;
 
 private:
-  void bookHistograms();
-
   edm::ParameterSet parameters_;
 
   std::string moduleName_;

--- a/DQM/BeamMonitor/python/AlcaBeamMonitorClient_cfi.py
+++ b/DQM/BeamMonitor/python/AlcaBeamMonitorClient_cfi.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 
-AlcaBeamMonitorClient = cms.EDAnalyzer("AlcaBeamMonitorClient",
+AlcaBeamMonitorClient = DQMEDAnalyzer("AlcaBeamMonitorClient",
                               	 MonitorName = cms.untracked.string('AlcaBeamMonitor'),
                                )

--- a/DQM/BeamMonitor/python/BeamConditionsMonitor_cff.py
+++ b/DQM/BeamMonitor/python/BeamConditionsMonitor_cff.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 
-dqmBeamCondMonitor = cms.EDAnalyzer("BeamConditionsMonitor",
+dqmBeamCondMonitor = DQMEDAnalyzer("BeamConditionsMonitor",
                               monitorName = cms.untracked.string('BeamMonitor'),
                               beamSpot = cms.untracked.InputTag('offlineBeamSpot'), ## hltOfflineBeamSpot for HLTMON
                               Debug = cms.untracked.bool(False)

--- a/DQM/BeamMonitor/python/BeamMonitorBx_cff.py
+++ b/DQM/BeamMonitor/python/BeamMonitorBx_cff.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 
-dqmBeamMonitorBx = cms.EDAnalyzer("BeamMonitorBx",
+dqmBeamMonitorBx = DQMEDAnalyzer("BeamMonitorBx",
                               monitorName = cms.untracked.string('BeamMonitor'),
                               beamSpot = cms.untracked.InputTag('offlineBeamSpot'), ## hltOfflineBeamSpot for HLTMON
                               primaryVertex = cms.untracked.InputTag('offlinePrimaryVertices'),

--- a/DQM/BeamMonitor/python/PixelVTXMonitor_cfi.py
+++ b/DQM/BeamMonitor/python/PixelVTXMonitor_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 
-pixelVTXMonitor = cms.EDAnalyzer("PixelVTXMonitor",
+pixelVTXMonitor = DQMEDAnalyzer("PixelVTXMonitor",
     ModuleName          = cms.string('BeamPixel'),
     FolderName          = cms.string('PixelVertex'),
     PixelClusterInputTag = cms.InputTag('siPixelClusters'),                                 


### PR DESCRIPTION
#### PR description:
This PR migrates from `edm::EDAnalyzer` to  `edm::one::EDAnalyzer<>` the last plugins in the `DQM/BeamMonitor` package
that were reported by the Static Analyzer in [the latest IB report for 12_1_X](https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_12_1_X_2021-09-30-1100/slc7_amd64_gcc900/llvm-analysis/index.html).
I also fixed some dead assignment in the same package that were again reported by the SA.

Not being the original author of these plugins, and since most of them are untouched since a couple of years, I would
like to have comments on whether the migration was done propely or not.

[EDIT] after the comments received the plugins have been actually migrated to use `DQM*EDAnalyzer`s.

#### PR validation:
Code compiles

#### Backport:
Not a backport, no backport needed.
