### PR TITLE
BugFix: HitFit MET resolution

### DIFF
--- a/TopQuarkAnalysis/TopHitFit/src/Resolution.cc
+++ b/TopQuarkAnalysis/TopHitFit/src/Resolution.cc
@@ -171,6 +171,7 @@ namespace hitfit {
   //   The uncertainty for a momentum P.
   //
   {
+    p = std::fabs(p);
     if (_inverse)
       p = 1 / p;
 


### PR DESCRIPTION
When the MET resolution to the Top fit is set, it gets evaluated for a specifc Kxy here [1] following the formula sigma = sqrt(p\*p\*c0\*c0+p\*c1\*c1+c2\*c2). There is no protection that p is positive, despite it being intended to be a magnitude.

This is relevant, since when the MET resolution is evaluated in the fit [2], it is done by inputting the x and y components of the kt vector to this sigma function. These components are signed, and can be negative.This means that the MET resolution assigned will be lower for systems with kt_x < 0 or/and kt_y < 0, when it should be symmetric around 0.

This fix ensures that the momentum input to the resolution function is always positive.

[1] https://github.com/cms-sw/cmssw/blob/master/TopQuarkAnalysis/TopHitFit/src/Resolution.cc#L163-L179

[2] https://github.com/cms-sw/cmssw/blob/master/TopQuarkAnalysis/TopHitFit/src/Constrained_Top.cc#L215-L216
