### PR TITLE
increase l1 cluster threshold from 2000 to 4000e

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterThresholds.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterThresholds.h
@@ -9,6 +9,6 @@ struct SiPixelClusterThresholds {
   const int32_t otherLayers;
 };
 
-constexpr SiPixelClusterThresholds kSiPixelClusterThresholdsDefaultPhase1{.layer1 = 2000, .otherLayers = 4000};
+constexpr SiPixelClusterThresholds kSiPixelClusterThresholdsDefaultPhase1{.layer1 = 4000, .otherLayers = 4000};
 
 #endif  // RecoLocalTracker_SiPixelClusterizer_plugins_SiPixelClusterThresholds_h

--- a/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
+++ b/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
@@ -24,7 +24,8 @@ run3_common.toModify(siPixelClusters,
   VCaltoElectronGain      = 1,  # all gains=1, pedestals=0
   VCaltoElectronGain_L1   = 1,   
   VCaltoElectronOffset    = 0,   
-  VCaltoElectronOffset_L1 = 0  
+  VCaltoElectronOffset_L1 = 0,  
+  ClusterThreshold_L1     = 4000
 )
 
 


### PR DESCRIPTION
#### PR description:

Increase L1 cluster threshold from 2000 to 4000e making it the same as all other layers.
With the new L1 detector the lower thresholds should not be needed anymore.
The change will affect the cluster charge distribution for L1, the lower edge will shift from 2000
to 4000e.

#### PR validation:

Run RECO on raw data from the cosmic run 344420.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport needed.

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
