### PR TITLE
[RFC] Add a mechanism to set the chosen case for SwitchProducer

### DIFF
--- a/FWCore/ParameterSet/python/Modules.py
+++ b/FWCore/ParameterSet/python/Modules.py
@@ -593,7 +593,7 @@ if __name__ == "__main__":
             self.assertEqual(cl.test2.type_(), "Bar")
             self.assertEqual(cl.test2.aa.value(), 11)
             self.assertEqual(cl.test2.bb.cc.value(), 12)
-            self.assertEqual(sp._getProducer().type_(), "Bar")
+            self.assertEqual(cl._getProducer().type_(), "Bar")
             # Modify clone
             cl.test1.a = 3
             self.assertEqual(cl.test1.a.value(), 3)


### PR DESCRIPTION
#### PR description:

This PR attempts to resolve to add a mechanism to "force a chosen case" for a SwitchProducer following the idea in https://github.com/cms-sw/cmssw/issues/31760#issuecomment-932279958. 

Opening now as a RFC, because I'm not fully satisfied with the naming I came up, and I'm not fully convinced of the approach (not that I would have really better ideas).

#### PR validation:

Framework unit tests run.