### PR TITLE
uGT emulator code for hadronic shower triggers for Run-3

### DIFF
--- a/DataFormats/L1TGlobal/interface/GlobalObject.h
+++ b/DataFormats/L1TGlobal/interface/GlobalObject.h
@@ -15,6 +15,7 @@ namespace l1t {
   ///    ObjNull catch all errors
   enum GlobalObject {
     gtMu,
+    gtMuShower,
     gtEG,
     gtJet,
     gtTau,

--- a/DataFormats/L1TGlobal/src/GlobalObject.cc
+++ b/DataFormats/L1TGlobal/src/GlobalObject.cc
@@ -25,6 +25,7 @@ using namespace l1t;
 
 l1t::GlobalObject l1TGtObjectStringToEnum(const std::string& label) {
   static const l1t::L1TGtObjectStringToEnum l1TGtObjectStringToEnumMap[] = {{"Mu", gtMu},
+                                                                            {"MuShower", gtMuShower},
                                                                             {"EG", gtEG},
                                                                             {"Tau", gtTau},
                                                                             {"Jet", gtJet},
@@ -85,6 +86,10 @@ std::string l1t::l1TGtObjectEnumToString(const GlobalObject& gtObject) {
   switch (gtObject) {
     case gtMu: {
       gtObjectString = "Mu";
+    } break;
+
+    case gtMuShower: {
+      gtObjectString = "MuShower";
     } break;
 
     case gtEG: {

--- a/DataFormats/L1Trigger/interface/MuonShower.h
+++ b/DataFormats/L1Trigger/interface/MuonShower.h
@@ -34,16 +34,41 @@ namespace l1t {
 
     ~MuonShower() override;
 
-    void setOneNominalInTime(const bool bit) { isOneNominalInTime_ = bit; }
-    void setOneNominalOutOfTime(const bool bit) { isOneNominalOutOfTime_ = bit; }
-    void setTwoLooseInTime(const bool bit) { isTwoLooseInTime_ = bit; }
-    void setTwoLooseOutOfTime(const bool bit) { isTwoLooseOutOfTime_ = bit; }
+    // This makes sense as long as the one-nominal shower case is mapped
+    // onto 0b01 and the two-loose shower case is mapped onto 0b10.
+    // A third (unused option) is 0b11
+    void setOneNominalInTime(const bool bit) {
+      isOneNominalInTime_ = bit;
+      mus0_ = bit;
+    }
+    void setOneNominalOutOfTime(const bool bit) {
+      isOneNominalOutOfTime_ = bit;
+      musOutOfTime0_ = bit;
+    }
+    void setTwoLooseInTime(const bool bit) {
+      isTwoLooseInTime_ = bit;
+      mus1_ = bit;
+    }
+    void setTwoLooseOutOfTime(const bool bit) {
+      isTwoLooseOutOfTime_ = bit;
+      musOutOfTime1_ = bit;
+    }
+
+    void setMus0(const bool bit) { mus0_ = bit; }
+    void setMus1(const bool bit) { mus1_ = bit; }
+    void setMusOutOfTime0(const bool bit) { musOutOfTime0_ = bit; }
+    void setMusOutOfTime1(const bool bit) { musOutOfTime1_ = bit; }
 
     bool isValid() const;
     bool isOneNominalInTime() const { return isOneNominalInTime_; }
     bool isOneNominalOutOfTime() const { return isOneNominalOutOfTime_; }
     bool isTwoLooseInTime() const { return isTwoLooseInTime_; }
     bool isTwoLooseOutOfTime() const { return isTwoLooseOutOfTime_; }
+
+    bool mus0() const { return mus0_; }
+    bool mus1() const { return mus1_; }
+    bool musOutOfTime0() const { return musOutOfTime0_; }
+    bool musOutOfTime1() const { return musOutOfTime1_; }
 
     virtual bool operator==(const l1t::MuonShower& rhs) const;
     virtual inline bool operator!=(const l1t::MuonShower& rhs) const { return !(operator==(rhs)); };
@@ -55,6 +80,15 @@ namespace l1t {
     bool isOneNominalOutOfTime_;
     bool isTwoLooseInTime_;
     bool isTwoLooseOutOfTime_;
+
+    // The data members below represent the same data as the 4 members above.
+    // They are needed in order to interface with the uGT GlobalBoard class.
+    // 2 bits for the in-time showers
+    bool mus0_;
+    bool mus1_;
+    // 2 bits for the out-of-time showers
+    bool musOutOfTime0_;
+    bool musOutOfTime1_;
   };
 
 }  // namespace l1t

--- a/DataFormats/L1Trigger/src/MuonShower.cc
+++ b/DataFormats/L1Trigger/src/MuonShower.cc
@@ -5,7 +5,14 @@ l1t::MuonShower::MuonShower(bool oneNominalInTime, bool oneNominalOutOfTime, boo
       isOneNominalInTime_(oneNominalInTime),
       isOneNominalOutOfTime_(oneNominalOutOfTime),
       isTwoLooseInTime_(twoLooseInTime),
-      isTwoLooseOutOfTime_(twoLooseOutOfTime) {}
+      isTwoLooseOutOfTime_(twoLooseOutOfTime),
+      // This makes sense as long as the one-nominal shower case is mapped
+      // onto 0b01 and the two-loose shower case is mapped onto 0b10.
+      // A third (unused option) is 0b11
+      mus0_(isOneNominalInTime_),
+      mus1_(twoLooseInTime),
+      musOutOfTime0_(oneNominalOutOfTime),
+      musOutOfTime1_(twoLooseOutOfTime) {}
 
 l1t::MuonShower::~MuonShower() {}
 

--- a/DataFormats/L1Trigger/src/classes_def.xml
+++ b/DataFormats/L1Trigger/src/classes_def.xml
@@ -103,7 +103,8 @@
   <class name="l1t::MuonVectorRef"/>
   <class name="edm::Wrapper<l1t::MuonVectorRef>"/>
 
-  <class name="l1t::MuonShower" ClassVersion="10">
+  <class name="l1t::MuonShower" ClassVersion="11">
+   <version ClassVersion="11" checksum="1417249241"/>
    <version ClassVersion="10" checksum="3869296059"/>
   </class>
   <class name="edm::Ptr<l1t::MuonShower>"/>

--- a/L1Trigger/L1TGlobal/interface/GlobalBoard.h
+++ b/L1Trigger/L1TGlobal/interface/GlobalBoard.h
@@ -25,6 +25,7 @@
 // Trigger Objects
 #include "DataFormats/L1Trigger/interface/EGamma.h"
 #include "DataFormats/L1Trigger/interface/Muon.h"
+#include "DataFormats/L1Trigger/interface/MuonShower.h"
 #include "DataFormats/L1Trigger/interface/Tau.h"
 #include "DataFormats/L1Trigger/interface/Jet.h"
 #include "DataFormats/L1Trigger/interface/EtSum.h"
@@ -77,11 +78,17 @@ namespace l1t {
                                const bool receiveMu,
                                const int nrL1Mu);
 
+    void receiveMuonShowerObjectData(edm::Event&,
+                                     const edm::EDGetTokenT<BXVector<l1t::MuonShower>>&,
+                                     const bool receiveMuShower,
+                                     const int nrL1MuShower);
+
     void receiveExternalData(edm::Event&, const edm::EDGetTokenT<BXVector<GlobalExtBlk>>&, const bool receiveExt);
 
     /// initialize the class (mainly reserve)
     void init(const int numberPhysTriggers,
               const int nrL1Mu,
+              const int nrL1MuShower,
               const int nrL1EG,
               const int nrL1Tau,
               const int nrL1Jet,
@@ -97,6 +104,7 @@ namespace l1t {
                 std::unique_ptr<GlobalObjectMapRecord>& gtObjectMapRecord,  //GTO
                 const unsigned int numberPhysTriggers,
                 const int nrL1Mu,
+                const int nrL1MuShower,
                 const int nrL1EG,
                 const int nrL1Tau,
                 const int nrL1Jet);
@@ -122,6 +130,7 @@ namespace l1t {
     /// clear uGT
     void reset();
     void resetMu();
+    void resetMuonShower();
     void resetCalo();
     void resetExternal();
 
@@ -136,6 +145,9 @@ namespace l1t {
 
     /// return global muon trigger candidate
     inline const BXVector<const l1t::Muon*>* getCandL1Mu() const { return m_candL1Mu; }
+
+    /// return global muon trigger candidate
+    inline const BXVector<const l1t::MuonShower*>* getCandL1MuShower() const { return m_candL1MuShower; }
 
     /// pointer to EG data list
     inline const BXVector<const l1t::L1Candidate*>* getCandL1EG() const { return m_candL1EG; }
@@ -203,6 +215,7 @@ namespace l1t {
 
   private:
     BXVector<const l1t::Muon*>* m_candL1Mu;
+    BXVector<const l1t::MuonShower*>* m_candL1MuShower;
     BXVector<const l1t::L1Candidate*>* m_candL1EG;
     BXVector<const l1t::L1Candidate*>* m_candL1Tau;
     BXVector<const l1t::L1Candidate*>* m_candL1Jet;

--- a/L1Trigger/L1TGlobal/interface/GlobalDefinitions.h
+++ b/L1Trigger/L1TGlobal/interface/GlobalDefinitions.h
@@ -98,7 +98,8 @@ namespace l1t {
     CondCorrelation,
     CondExternal,
     CondCorrelationWithOverlapRemoval,
-    CondCorrelationThreeBody
+    CondCorrelationThreeBody,
+    CondMuonShower,
   };
 
   struct GtConditionCategoryStringToEnum {

--- a/L1Trigger/L1TGlobal/interface/MuonShowerCondition.h
+++ b/L1Trigger/L1TGlobal/interface/MuonShowerCondition.h
@@ -1,0 +1,81 @@
+#ifndef L1Trigger_L1TGlobal_MuonShowerCondition_h
+#define L1Trigger_L1TGlobal_MuonShowerCondition_h
+
+/**
+ * \class MuonShowerCondition
+ *
+ * Description: evaluation of a CondMuonShower condition.
+ */
+
+// system include files
+#include <iosfwd>
+#include <string>
+
+// user include files
+//   base classes
+#include "L1Trigger/L1TGlobal/interface/ConditionEvaluation.h"
+
+#include "DataFormats/L1Trigger/interface/MuonShower.h"
+
+// forward declarations
+class GlobalCondition;
+class MuonShowerTemplate;
+
+namespace l1t {
+
+  class GlobalBoard;
+
+  // class declaration
+  class MuonShowerCondition : public ConditionEvaluation {
+  public:
+    /// constructors
+    ///     default
+    MuonShowerCondition();
+
+    ///     from base template condition (from event setup usually)
+    MuonShowerCondition(const GlobalCondition*, const GlobalBoard*, const int nrL1MuShower);
+
+    // copy constructor
+    MuonShowerCondition(const MuonShowerCondition&);
+
+    // destructor
+    ~MuonShowerCondition() override;
+
+    // assign operator
+    MuonShowerCondition& operator=(const MuonShowerCondition&);
+
+    /// the core function to check if the condition matches
+    const bool evaluateCondition(const int bxEval) const override;
+
+    /// print condition
+    void print(std::ostream& myCout) const override;
+
+    ///   get / set the pointer to a Condition
+    inline const MuonShowerTemplate* gtMuonShowerTemplate() const { return m_gtMuonShowerTemplate; }
+
+    void setGtMuonShowerTemplate(const MuonShowerTemplate*);
+
+    ///   get / set the pointer to GTL
+    inline const GlobalBoard* gtGTL() const { return m_gtGTL; }
+
+    void setGtGTL(const GlobalBoard*);
+
+  private:
+    /// copy function for copy constructor and operator=
+    void copy(const MuonShowerCondition& cp);
+
+    /// load muon candidates
+    const l1t::MuonShower* getCandidate(const int bx, const int indexCand) const;
+
+    /// function to check a single object if it matches a condition
+    const bool checkObjectParameter(const int iCondition, const l1t::MuonShower& cand, const unsigned int index) const;
+
+    /// pointer to a MuonShowerTemplate
+    const MuonShowerTemplate* m_gtMuonShowerTemplate;
+
+    /// pointer to GTL, to be able to get the trigger objects
+    const GlobalBoard* m_gtGTL;
+  };
+
+}  // namespace l1t
+#endif

--- a/L1Trigger/L1TGlobal/interface/MuonShowerTemplate.h
+++ b/L1Trigger/L1TGlobal/interface/MuonShowerTemplate.h
@@ -1,0 +1,74 @@
+#ifndef L1Trigger_L1TGlobal_MuonShowerTemplate_h
+#define L1Trigger_L1TGlobal_MuonShowerTemplate_h
+
+/**
+ * \class MuonShowerTemplate
+ *
+ *
+ * Description: L1 Global Trigger muon shower template.
+ *
+ * \author: Sven Dildick (Rice University)
+ *
+ */
+
+// system include files
+#include <string>
+#include <iosfwd>
+
+// user include files
+
+//   base class
+#include "L1Trigger/L1TGlobal/interface/GlobalCondition.h"
+
+// forward declarations
+
+// class declaration
+class MuonShowerTemplate : public GlobalCondition {
+public:
+  // constructor
+  MuonShowerTemplate();
+
+  // constructor
+  MuonShowerTemplate(const std::string&);
+
+  // constructor
+  MuonShowerTemplate(const std::string&, const l1t::GtConditionType&);
+
+  // copy constructor
+  MuonShowerTemplate(const MuonShowerTemplate&);
+
+  // destructor
+  ~MuonShowerTemplate() override;
+
+  // assign operator
+  MuonShowerTemplate& operator=(const MuonShowerTemplate&);
+
+  // typedef for a single object template
+  struct ObjectParameter {
+    bool MuonShower0;
+    bool MuonShower1;
+    bool MuonShowerOutOfTime0;
+    bool MuonShowerOutOfTime1;
+  };
+
+public:
+  inline const std::vector<ObjectParameter>* objectParameter() const { return &m_objectParameter; }
+
+  /// set functions
+  void setConditionParameter(const std::vector<ObjectParameter>& objParameter);
+
+  /// print the condition
+  void print(std::ostream& myCout) const override;
+
+  /// output stream operator
+  friend std::ostream& operator<<(std::ostream&, const MuonShowerTemplate&);
+
+private:
+  /// copy function for copy constructor and operator=
+  void copy(const MuonShowerTemplate& cp);
+
+  /// variables containing the parameters
+  std::vector<ObjectParameter> m_objectParameter;
+};
+
+#endif

--- a/L1Trigger/L1TGlobal/interface/TriggerMenu.h
+++ b/L1Trigger/L1TGlobal/interface/TriggerMenu.h
@@ -32,6 +32,7 @@
 #include "L1Trigger/L1TGlobal/interface/GlobalScales.h"
 
 #include "L1Trigger/L1TGlobal/interface/MuonTemplate.h"
+#include "L1Trigger/L1TGlobal/interface/MuonShowerTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/CaloTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/EnergySumTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/ExternalTemplate.h"
@@ -53,6 +54,7 @@ public:
   TriggerMenu(const std::string&,
               const unsigned int numberConditionChips,
               const std::vector<std::vector<MuonTemplate> >&,
+              const std::vector<std::vector<MuonShowerTemplate> >&,
               const std::vector<std::vector<CaloTemplate> >&,
               const std::vector<std::vector<EnergySumTemplate> >&,
               const std::vector<std::vector<ExternalTemplate> >&,
@@ -108,6 +110,13 @@ public:
   inline const std::vector<std::vector<MuonTemplate> >& vecMuonTemplate() const { return m_vecMuonTemplate; }
 
   void setVecMuonTemplate(const std::vector<std::vector<MuonTemplate> >&);
+
+  //
+  inline const std::vector<std::vector<MuonShowerTemplate> >& vecMuonShowerTemplate() const {
+    return m_vecMuonShowerTemplate;
+  }
+
+  void setVecMuonShowerTemplate(const std::vector<std::vector<MuonShowerTemplate> >&);
 
   //
   inline const std::vector<std::vector<CaloTemplate> >& vecCaloTemplate() const { return m_vecCaloTemplate; }
@@ -218,6 +227,7 @@ private:
   /// vectors containing the conditions
   /// explicit, due to persistency...
   std::vector<std::vector<MuonTemplate> > m_vecMuonTemplate;
+  std::vector<std::vector<MuonShowerTemplate> > m_vecMuonShowerTemplate;
   std::vector<std::vector<CaloTemplate> > m_vecCaloTemplate;
   std::vector<std::vector<EnergySumTemplate> > m_vecEnergySumTemplate;
 

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.h
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.h
@@ -68,6 +68,7 @@ private:
 
   // number of objects of each type
   int m_nrL1Mu;
+  int m_nrL1MuShower;
   int m_nrL1EG;
   int m_nrL1Tau;
 
@@ -119,7 +120,9 @@ private:
 
   /// input tag for muon collection from GMT
   edm::InputTag m_muInputTag;
+  edm::InputTag m_muShowerInputTag;
   edm::EDGetTokenT<BXVector<l1t::Muon>> m_muInputToken;
+  edm::EDGetTokenT<BXVector<l1t::MuonShower>> m_muShowerInputToken;
 
   /// input tag for calorimeter collections from GCT
   edm::InputTag m_egInputTag;
@@ -185,6 +188,9 @@ private:
   edm::ESGetToken<L1TGlobalParameters, L1TGlobalParametersRcd> m_l1GtStableParToken;
   edm::ESGetToken<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd> m_l1GtMenuToken;
   edm::ESGetToken<L1TGlobalPrescalesVetosFract, L1TGlobalPrescalesVetosFractRcd> m_l1GtPrescaleVetosToken;
+
+  // switch to load muon showers in the global board
+  bool m_useMuonShowers;
 };
 
 #endif /*L1TGlobalProducer_h*/

--- a/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
+++ b/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
@@ -14,9 +14,9 @@
  *                - correlations with overlap object removal
  *                - displaced muons by R.Cavanaugh
  *
- * \new features: Elisa Fontanesi                                                      
- *                - extended for three-body correlation conditions                                         
- *                                                                
+ * \new features: Elisa Fontanesi
+ *                - extended for three-body correlation conditions
+ *
  * $Date$
  * $Revision$
  *
@@ -111,6 +111,11 @@ void l1t::TriggerMenuParser::setVecMuonTemplate(const std::vector<std::vector<Mu
   m_vecMuonTemplate = vecMuonTempl;
 }
 
+void l1t::TriggerMenuParser::setVecMuonShowerTemplate(
+    const std::vector<std::vector<MuonShowerTemplate> >& vecMuonShowerTempl) {
+  m_vecMuonShowerTemplate = vecMuonShowerTempl;
+}
+
 void l1t::TriggerMenuParser::setVecCaloTemplate(const std::vector<std::vector<CaloTemplate> >& vecCaloTempl) {
   m_vecCaloTemplate = vecCaloTempl;
 }
@@ -202,6 +207,7 @@ void l1t::TriggerMenuParser::parseCondFormats(const L1TUtmTriggerMenu* utmMenu) 
   m_conditionMap.resize(m_numberConditionChips);
 
   m_vecMuonTemplate.resize(m_numberConditionChips);
+  m_vecMuonShowerTemplate.resize(m_numberConditionChips);
   m_vecCaloTemplate.resize(m_numberConditionChips);
   m_vecEnergySumTemplate.resize(m_numberConditionChips);
   m_vecExternalTemplate.resize(m_numberConditionChips);
@@ -299,6 +305,12 @@ void l1t::TriggerMenuParser::parseCondFormats(const L1TUtmTriggerMenu* utmMenu) 
                    condition.getType() == esConditionType::TripleMuon ||
                    condition.getType() == esConditionType::QuadMuon) {
           parseMuon(condition, chipNr, false);
+
+        } else if (condition.getType() == esConditionType::MuonShower0 ||
+                   condition.getType() == esConditionType::MuonShower1 ||
+                   condition.getType() == esConditionType::MuonShowerOutOfTime0 ||
+                   condition.getType() == esConditionType::MuonShowerOutOfTime1) {
+          parseMuonShower(condition, chipNr, false);
 
           //parse Correlation Conditions
         } else if (condition.getType() == esConditionType::MuonMuonCorrelation ||
@@ -1516,6 +1528,89 @@ bool l1t::TriggerMenuParser::parseMuonCorr(const tmeventsetup::esObject* corrMu,
   (m_corMuonTemplate[chipNr]).push_back(muonCond);
 
   //
+  return true;
+}
+
+/**
+ * parseMuonShower Parse a muonShower condition and insert an entry to the conditions map
+ *
+ * @param node The corresponding node.
+ * @param name The name of the condition.
+ * @param chipNr The number of the chip this condition is located.
+ *
+ * @return "true" if succeeded, "false" if an error occurred.
+ *
+ */
+
+bool l1t::TriggerMenuParser::parseMuonShower(tmeventsetup::esCondition condMu,
+                                             unsigned int chipNr,
+                                             const bool corrFlag) {
+  using namespace tmeventsetup;
+
+  // get condition, particle name (must be muon) and type name
+  std::string condition = "muonShower";
+  std::string particle = "muonShower";  //l1t2string( condMu.objectType() );
+  std::string type = l1t2string(condMu.getType());
+  std::string name = l1t2string(condMu.getName());
+  // the number of muon shower objects is always 1
+  int nrObj = 1;
+
+  // condition type is always 1 particle, thus Type1s
+  GtConditionType cType = l1t::Type1s;
+
+  // edm::LogWarning("TriggerMenuParser") << "\n ****************************************** "
+  //                               << "\n      parseMuonShower  "
+  //                               << "\n condition = " << condition << "\n particle  = " << particle
+  //                               << "\n type      = " << type << "\n name      = " << name << std::endl;
+
+  // temporary storage of the parameters
+  std::vector<MuonShowerTemplate::ObjectParameter> objParameter(nrObj);
+
+  if (int(condMu.getObjects().size()) != nrObj) {
+    edm::LogError("TriggerMenuParser") << " condMu objects: nrObj = " << nrObj
+                                       << "condMu.getObjects().size() = " << condMu.getObjects().size() << std::endl;
+    return false;
+  }
+
+  // Get the muon shower object
+  esObject object = condMu.getObjects().at(0);
+  int relativeBx = object.getBxOffset();
+
+  if (condMu.getType() == esConditionType::MuonShower0) {
+    objParameter[0].MuonShower0 = true;
+  } else if (condMu.getType() == esConditionType::MuonShower1) {
+    objParameter[0].MuonShower1 = true;
+  } else if (condMu.getType() == esConditionType::MuonShowerOutOfTime0) {
+    objParameter[0].MuonShowerOutOfTime0 = true;
+  } else if (condMu.getType() == esConditionType::MuonShowerOutOfTime1) {
+    objParameter[0].MuonShowerOutOfTime1 = true;
+  }
+
+  // object types - all muons
+  std::vector<GlobalObject> objType(nrObj, gtMuShower);
+
+  // now create a new CondMuonition
+  MuonShowerTemplate muonShowerCond(name);
+  muonShowerCond.setCondType(cType);
+  muonShowerCond.setObjectType(objType);
+  muonShowerCond.setCondChipNr(chipNr);
+  muonShowerCond.setCondRelativeBx(relativeBx);
+
+  muonShowerCond.setConditionParameter(objParameter);
+
+  if (edm::isDebugEnabled()) {
+    std::ostringstream myCoutStream;
+    muonShowerCond.print(myCoutStream);
+  }
+
+  // insert condition into the map and into muon template vector
+  if (!insertConditionIntoMap(muonShowerCond, chipNr)) {
+    edm::LogError("TriggerMenuParser") << "    Error: duplicate condition (" << name << ")" << std::endl;
+    return false;
+  } else {
+    (m_vecMuonShowerTemplate[chipNr]).push_back(muonShowerCond);
+  }
+
   return true;
 }
 

--- a/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.h
+++ b/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.h
@@ -17,9 +17,9 @@
  *                - correlations with overlap object removal
  * \author R. Cavanaugh
  *                - displaced muons
- * \author Elisa Fontanesi                                                                               
- *                - extended for three-body correlation conditions                                                               
- *                                                                  
+ * \author Elisa Fontanesi
+ *                - extended for three-body correlation conditions
+ *
  *
  * $Date$
  * $Revision$
@@ -33,6 +33,7 @@
 #include "L1Trigger/L1TGlobal/interface/TriggerMenuFwd.h"
 
 #include "L1Trigger/L1TGlobal/interface/MuonTemplate.h"
+#include "L1Trigger/L1TGlobal/interface/MuonShowerTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/CaloTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/EnergySumTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/CorrelationTemplate.h"
@@ -123,6 +124,12 @@ namespace l1t {
     /// get / set the vectors containing the conditions
     inline const std::vector<std::vector<MuonTemplate> >& vecMuonTemplate() const { return m_vecMuonTemplate; }
     void setVecMuonTemplate(const std::vector<std::vector<MuonTemplate> >&);
+
+    //
+    inline const std::vector<std::vector<MuonShowerTemplate> >& vecMuonShowerTemplate() const {
+      return m_vecMuonShowerTemplate;
+    }
+    void setVecMuonShowerTemplate(const std::vector<std::vector<MuonShowerTemplate> >&);
 
     //
     inline const std::vector<std::vector<CaloTemplate> >& vecCaloTemplate() const { return m_vecCaloTemplate; }
@@ -266,6 +273,9 @@ namespace l1t {
 
     bool parseMuonCorr(const tmeventsetup::esObject* condMu, unsigned int chipNr = 0);
 
+    /// parse a muon shower condition
+    bool parseMuonShower(tmeventsetup::esCondition condMu, unsigned int chipNr = 0, const bool corrFlag = false);
+
     /// parse a calorimeter condition
     /*     bool parseCalo(XERCES_CPP_NAMESPACE::DOMNode* node, */
     /*             const std::string& name, unsigned int chipNr = 0, */
@@ -383,6 +393,7 @@ namespace l1t {
     /// vectors containing the conditions
     /// explicit, due to persistency...
     std::vector<std::vector<MuonTemplate> > m_vecMuonTemplate;
+    std::vector<std::vector<MuonShowerTemplate> > m_vecMuonShowerTemplate;
     std::vector<std::vector<CaloTemplate> > m_vecCaloTemplate;
     std::vector<std::vector<EnergySumTemplate> > m_vecEnergySumTemplate;
     std::vector<std::vector<ExternalTemplate> > m_vecExternalTemplate;

--- a/L1Trigger/L1TGlobal/python/simGtStage2Digis_cfi.py
+++ b/L1Trigger/L1TGlobal/python/simGtStage2Digis_cfi.py
@@ -4,32 +4,22 @@
 # All changes must be explicitly discussed with the L1T offline coordinator.
 #
 import FWCore.ParameterSet.Config as cms
-
-# cfi uGT emulator
-
-simGtStage2Digis = cms.EDProducer("L1TGlobalProducer",
-    MuonInputTag = cms.InputTag("simGmtStage2Digis"),
-    ExtInputTag = cms.InputTag("simGtExtFakeStage2Digis"),
-    EGammaInputTag = cms.InputTag("simCaloStage2Digis"),
-    TauInputTag = cms.InputTag("simCaloStage2Digis"),
-    JetInputTag = cms.InputTag("simCaloStage2Digis"),
-    EtSumInputTag = cms.InputTag("simCaloStage2Digis"),
-    AlgorithmTriggersUnmasked = cms.bool(True),    
-    AlgorithmTriggersUnprescaled = cms.bool(True),
-    GetPrescaleColumnFromData = cms.bool(False),
-    RequireMenuToMatchAlgoBlkInput = cms.bool(False),
-    AlgoBlkInputTag = cms.InputTag("gtStage2Digis")
-    # deprecated in Mike's version of producer:                              
-    #ProduceL1GtDaqRecord = cms.bool(True),
-    #GmtInputTag = cms.InputTag("gtInput"),
-    #extInputTag = cms.InputTag("gtInput"),
-    #caloInputTag = cms.InputTag("gtInput"),
-    #AlternativeNrBxBoardDaq = cms.uint32(0),
-    #WritePsbL1GtDaqRecord = cms.bool(True),
-    #TriggerMenuLuminosity = cms.string('startup'),
-    #PrescaleCSVFile = cms.string('prescale_L1TGlobal.csv'),
-    #PrescaleSet = cms.uint32(1),
-    #BstLengthBytes = cms.int32(-1),
-    #Verbosity = cms.untracked.int32(0)
+from L1Trigger.L1TGlobal.simGtStage2DigisDef_cfi import simGtStage2DigisDef
+simGtStage2Digis = simGtStage2DigisDef.clone(
+    MuonInputTag = "simGmtStage2Digis",
+    MuonShowerInputTag = "simGmtShowerDigis",
+    EGammaInputTag = "simCaloStage2Digis",
+    TauInputTag = "simCaloStage2Digis",
+    JetInputTag = "simCaloStage2Digis",
+    EtSumInputTag = "simCaloStage2Digis",
+    ExtInputTag = "simGtExtFakeStage2Digis",
+    AlgoBlkInputTag = "gtStage2Digis",
+    AlgorithmTriggersUnmasked = True,
+    AlgorithmTriggersUnprescaled = True,
+    GetPrescaleColumnFromData = False,
+    RequireMenuToMatchAlgoBlkInput = False,
 )
 
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(simGtStage2Digis,
+                     useMuonShowers = False)

--- a/L1Trigger/L1TGlobal/src/AlgorithmEvaluation.cc
+++ b/L1Trigger/L1TGlobal/src/AlgorithmEvaluation.cc
@@ -1,14 +1,14 @@
 /**
  * \class AlgorithmEvaluation
- * 
- * 
+ *
+ *
  * Description: Evaluation of a L1 Global Trigger algorithm.
- * 
+ *
  * Implementation:
  *    <TODO: enter implementation details>
- *   
- * \author: Vasile Mihai Ghete   - HEPHY Vienna 
- * 
+ *
+ * \author: Vasile Mihai Ghete   - HEPHY Vienna
+ *
  *
  */
 

--- a/L1Trigger/L1TGlobal/src/GlobalBoard.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalBoard.cc
@@ -27,6 +27,7 @@
 #include "L1Trigger/L1TGlobal/interface/GlobalAlgorithm.h"
 
 #include "L1Trigger/L1TGlobal/interface/MuonTemplate.h"
+#include "L1Trigger/L1TGlobal/interface/MuonShowerTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/CaloTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/EnergySumTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/ExternalTemplate.h"
@@ -42,6 +43,7 @@
 
 // Conditions for uGt
 #include "L1Trigger/L1TGlobal/interface/MuCondition.h"
+#include "L1Trigger/L1TGlobal/interface/MuonShowerCondition.h"
 #include "L1Trigger/L1TGlobal/interface/CaloCondition.h"
 #include "L1Trigger/L1TGlobal/interface/EnergySumCondition.h"
 #include "L1Trigger/L1TGlobal/interface/ExternalCondition.h"
@@ -60,6 +62,7 @@
 // constructor
 l1t::GlobalBoard::GlobalBoard()
     : m_candL1Mu(new BXVector<const l1t::Muon*>),
+      m_candL1MuShower(new BXVector<const l1t::MuonShower*>),
       m_candL1EG(new BXVector<const l1t::L1Candidate*>),
       m_candL1Tau(new BXVector<const l1t::L1Candidate*>),
       m_candL1Jet(new BXVector<const l1t::L1Candidate*>),
@@ -91,6 +94,7 @@ l1t::GlobalBoard::GlobalBoard()
 l1t::GlobalBoard::~GlobalBoard() {
   //reset();  //why would we need a reset?
   delete m_candL1Mu;
+  delete m_candL1MuShower;
   delete m_candL1EG;
   delete m_candL1Tau;
   delete m_candL1Jet;
@@ -107,6 +111,7 @@ void l1t::GlobalBoard::setBxLast(int bx) { m_bxLast_ = bx; }
 
 void l1t::GlobalBoard::init(const int numberPhysTriggers,
                             const int nrL1Mu,
+                            const int nrL1MuShower,
                             const int nrL1EG,
                             const int nrL1Tau,
                             const int nrL1Jet,
@@ -116,6 +121,7 @@ void l1t::GlobalBoard::init(const int numberPhysTriggers,
   setBxLast(bxLast);
 
   m_candL1Mu->setBXRange(m_bxFirst_, m_bxLast_);
+  m_candL1MuShower->setBXRange(m_bxFirst_, m_bxLast_);
   m_candL1EG->setBXRange(m_bxFirst_, m_bxLast_);
   m_candL1Tau->setBXRange(m_bxFirst_, m_bxLast_);
   m_candL1Jet->setBXRange(m_bxFirst_, m_bxLast_);
@@ -293,19 +299,19 @@ void l1t::GlobalBoard::receiveCaloObjectData(edm::Event& iEvent,
 			 //(*m_candETM).push_back(i,&(*etsum));
 			 LogDebug("L1TGlobal") << "ETM:  Pt " << etsum->hwPt() <<  " Phi " << etsum->hwPhi()  << std::endl;
 		       }
-		       break; 
+		       break;
 		     case l1t::EtSum::EtSumType::kMissingHt:
 		       {
 			 //(*m_candHTM).push_back(i,&(*etsum));
 			 LogDebug("L1TGlobal") << "HTM:  Pt " << etsum->hwPt() <<  " Phi " << etsum->hwPhi()  << std::endl;
 		       }
-		       break; 		     
+		       break;
 		     case l1t::EtSum::EtSumType::kTotalEt:
 		       {
 			 //(*m_candETT).push_back(i,&(*etsum));
 			 LogDebug("L1TGlobal") << "ETT:  Pt " << etsum->hwPt() << std::endl;
 		       }
-		       break; 		     
+		       break;
 		     case l1t::EtSum::EtSumType::kTotalHt:
 		       {
 			 //(*m_candHTT).push_back(i,&(*etsum));
@@ -384,6 +390,54 @@ void l1t::GlobalBoard::receiveMuonObjectData(edm::Event& iEvent,
   }  //end if ReveiveMuon data
 }
 
+// receive muon shower data from Global Muon Trigger
+void l1t::GlobalBoard::receiveMuonShowerObjectData(edm::Event& iEvent,
+                                                   const edm::EDGetTokenT<BXVector<l1t::MuonShower>>& muShowerInputToken,
+                                                   const bool receiveMuShower,
+                                                   const int nrL1MuShower) {
+  // get data from Global Muon Trigger
+  if (receiveMuShower) {
+    edm::Handle<BXVector<l1t::MuonShower>> muonData;
+    iEvent.getByToken(muShowerInputToken, muonData);
+
+    if (!muonData.isValid()) {
+      if (m_verbosity) {
+        edm::LogWarning("L1TGlobal") << "\nWarning: BXVector<l1t::MuonShower> with input tag "
+                                     << "\nrequested in configuration, but not found in the event.\n"
+                                     << std::endl;
+      }
+    } else {
+      //Loop over Muon Showers in this bx
+      int nObj = 0;
+      for (auto mu = muonData->begin(0); mu != muonData->end(0); ++mu) {
+        if (nObj < nrL1MuShower) {
+          /* Important here to split up the single object into 4 separate MuonShower
+             bits for the global board. This is because the UTM library considers those bits separate as well
+           */
+          l1t::MuonShower mus0;
+          l1t::MuonShower mus1;
+          l1t::MuonShower musOutOfTime0;
+          l1t::MuonShower musOutOfTime1;
+
+          mus0.setMus0(mu->mus0());
+          mus1.setMus1(mu->mus1());
+          musOutOfTime0.setMusOutOfTime0(mu->musOutOfTime0());
+          musOutOfTime1.setMusOutOfTime1(mu->musOutOfTime1());
+
+          (*m_candL1MuShower).push_back(0, &mus0);
+          (*m_candL1MuShower).push_back(0, &mus1);
+          (*m_candL1MuShower).push_back(0, &musOutOfTime0);
+          (*m_candL1MuShower).push_back(0, &musOutOfTime1);
+        } else {
+          edm::LogWarning("L1TGlobal") << " Too many Muon Showers (" << nObj
+                                       << ") for uGT Configuration maxMuShower =" << nrL1MuShower << std::endl;
+        }
+        nObj++;
+      }  //end loop over muon showers in bx
+    }    //end if over valid muon shower data
+  }      //end if ReveiveMuonShower data
+}
+
 // receive data from Global External Conditions
 void l1t::GlobalBoard::receiveExternalData(edm::Event& iEvent,
                                            const edm::EDGetTokenT<BXVector<GlobalExtBlk>>& extInputToken,
@@ -435,6 +489,7 @@ void l1t::GlobalBoard::runGTL(edm::Event& iEvent,
                               std::unique_ptr<GlobalObjectMapRecord>& gtObjectMapRecord,
                               const unsigned int numberPhysTriggers,
                               const int nrL1Mu,
+                              const int nrL1MuShower,
                               const int nrL1EG,
                               const int nrL1Tau,
                               const int nrL1Jet) {
@@ -504,6 +559,24 @@ void l1t::GlobalBoard::runGTL(edm::Event& iEvent,
             LogTrace("L1TGlobal") << myCout.str() << std::endl;
           }
           //delete muCondition;
+
+        } break;
+        case CondMuonShower: {
+          MuonShowerCondition* muShowerCondition = new MuonShowerCondition(itCond->second, this, nrL1MuShower);
+
+          muShowerCondition->setVerbosity(m_verbosity);
+
+          muShowerCondition->evaluateConditionStoreResult(iBxInEvent);
+
+          cMapResults[itCond->first] = muShowerCondition;
+
+          if (m_verbosity && m_isDebugEnabled) {
+            std::ostringstream myCout;
+            muShowerCondition->print(myCout);
+
+            edm::LogWarning("L1TGlobal") << "MuonShowerCondition " << myCout.str() << std::endl;
+          }
+          //delete muShowerCondition;
 
         } break;
         case CondCalo: {
@@ -1039,6 +1112,7 @@ void l1t::GlobalBoard::fillAlgRecord(int iBxInEvent,
 // clear GTL
 void l1t::GlobalBoard::reset() {
   resetMu();
+  resetMuonShower();
   resetCalo();
   resetExternal();
 
@@ -1052,6 +1126,12 @@ void l1t::GlobalBoard::reset() {
 void l1t::GlobalBoard::resetMu() {
   m_candL1Mu->clear();
   m_candL1Mu->setBXRange(m_bxFirst_, m_bxLast_);
+}
+
+// clear muon shower
+void l1t::GlobalBoard::resetMuonShower() {
+  m_candL1MuShower->clear();
+  m_candL1MuShower->setBXRange(m_bxFirst_, m_bxLast_);
 }
 
 // clear calo

--- a/L1Trigger/L1TGlobal/src/GlobalCondition.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalCondition.cc
@@ -180,6 +180,12 @@ void GlobalCondition::print(std::ostream& myCout) const {
     }
 
     break;
+    case l1t::CondMuonShower: {
+      myCout << "  Condition category: "
+             << "l1t::CondMuonShower" << std::endl;
+    }
+
+    break;
     case l1t::CondCalo: {
       myCout << "  Condition category: "
              << "l1t::CondCalo" << std::endl;
@@ -429,6 +435,11 @@ void GlobalCondition::print(std::ostream& myCout) const {
     switch (m_objectType[i]) {
       case l1t::gtMu: {
         myCout << " Mu ";
+      }
+
+      break;
+      case l1t::gtMuShower: {
+        myCout << " MuShower ";
       }
 
       break;

--- a/L1Trigger/L1TGlobal/src/MuonShowerCondition.cc
+++ b/L1Trigger/L1TGlobal/src/MuonShowerCondition.cc
@@ -1,0 +1,188 @@
+// this class header
+#include "L1Trigger/L1TGlobal/interface/MuonShowerCondition.h"
+
+// system include files
+#include <iostream>
+#include <iomanip>
+
+#include <string>
+#include <vector>
+#include <algorithm>
+
+// user include files
+//   base classes
+#include "L1Trigger/L1TGlobal/interface/MuonShowerTemplate.h"
+#include "L1Trigger/L1TGlobal/interface/ConditionEvaluation.h"
+
+#include "DataFormats/L1Trigger/interface/MuonShower.h"
+
+#include "L1Trigger/L1TGlobal/interface/GlobalBoard.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/MessageLogger/interface/MessageDrop.h"
+
+// constructors
+//     default
+l1t::MuonShowerCondition::MuonShowerCondition() : ConditionEvaluation() {
+  // empty
+}
+
+//     from base template condition (from event setup usually)
+l1t::MuonShowerCondition::MuonShowerCondition(const GlobalCondition* muonShowerTemplate,
+                                              const GlobalBoard* ptrGTL,
+                                              const int nrL1MuShower)
+    : ConditionEvaluation(),
+      m_gtMuonShowerTemplate(static_cast<const MuonShowerTemplate*>(muonShowerTemplate)),
+      m_gtGTL(ptrGTL) {
+  m_condMaxNumberObjects = nrL1MuShower;
+}
+
+// copy constructor
+void l1t::MuonShowerCondition::copy(const l1t::MuonShowerCondition& cp) {
+  m_gtMuonShowerTemplate = cp.gtMuonShowerTemplate();
+  m_gtGTL = cp.gtGTL();
+
+  m_condMaxNumberObjects = cp.condMaxNumberObjects();
+  m_condLastResult = cp.condLastResult();
+  m_combinationsInCond = cp.getCombinationsInCond();
+
+  m_verbosity = cp.m_verbosity;
+}
+
+l1t::MuonShowerCondition::MuonShowerCondition(const l1t::MuonShowerCondition& cp) : ConditionEvaluation() { copy(cp); }
+
+// destructor
+l1t::MuonShowerCondition::~MuonShowerCondition() {
+  // empty
+}
+
+// equal operator
+l1t::MuonShowerCondition& l1t::MuonShowerCondition::operator=(const l1t::MuonShowerCondition& cp) {
+  copy(cp);
+  return *this;
+}
+
+// methods
+void l1t::MuonShowerCondition::setGtMuonShowerTemplate(const MuonShowerTemplate* muonTempl) {
+  m_gtMuonShowerTemplate = muonTempl;
+}
+
+///   set the pointer to GTL
+void l1t::MuonShowerCondition::setGtGTL(const GlobalBoard* ptrGTL) { m_gtGTL = ptrGTL; }
+
+// try all object permutations and check spatial correlations, if required
+const bool l1t::MuonShowerCondition::evaluateCondition(const int bxEval) const {
+  // number of trigger objects in the condition
+  int nObjInCond = m_gtMuonShowerTemplate->nrObjects();
+
+  // the candidates
+  const BXVector<const l1t::MuonShower*>* candVec = m_gtGTL->getCandL1MuShower();
+
+  // Look at objects in bx = bx + relativeBx
+  int useBx = bxEval + m_gtMuonShowerTemplate->condRelativeBx();
+
+  // Fail condition if attempting to get Bx outside of range
+  if ((useBx < candVec->getFirstBX()) || (useBx > candVec->getLastBX())) {
+    return false;
+  }
+
+  // store the indices of the shower objects
+  // from the combination evaluated in the condition
+  SingleCombInCond objectsInComb;
+  objectsInComb.reserve(nObjInCond);
+
+  // clear the m_combinationsInCond vector
+  (combinationsInCond()).clear();
+
+  // clear the indices in the combination
+  objectsInComb.clear();
+
+  // If no candidates, no use looking any further.
+  int numberObjects = candVec->size(useBx);
+  if (numberObjects < 1) {
+    return false;
+  }
+
+  std::vector<int> index(numberObjects);
+
+  for (int i = 0; i < numberObjects; ++i) {
+    index[i] = i;
+  }
+
+  bool condResult = false;
+
+  // index is always zero, as they are global quantities (there is only one object)
+  int indexObj = 0;
+
+  objectsInComb.push_back(indexObj);
+  (combinationsInCond()).push_back(objectsInComb);
+
+  // if we get here all checks were successfull for this combination
+  // set the general result for evaluateCondition to "true"
+
+  condResult = true;
+  return condResult;
+}
+
+// load muon candidates
+const l1t::MuonShower* l1t::MuonShowerCondition::getCandidate(const int bx, const int indexCand) const {
+  return (m_gtGTL->getCandL1MuShower())->at(bx, indexCand);  //BLW Change for BXVector
+}
+
+/**
+ * checkObjectParameter - Compare a single particle with a numbered condition.
+ *
+ * @param iCondition The number of the condition.
+ * @param cand The candidate to compare.
+ *
+ * @return The result of the comparison (false if a condition does not exist).
+ */
+
+const bool l1t::MuonShowerCondition::checkObjectParameter(const int iCondition,
+                                                          const l1t::MuonShower& cand,
+                                                          const unsigned int index) const {
+  // number of objects in condition
+  int nObjInCond = m_gtMuonShowerTemplate->nrObjects();
+
+  if (iCondition >= nObjInCond || iCondition < 0) {
+    return false;
+  }
+
+  const MuonShowerTemplate::ObjectParameter objPar = (*(m_gtMuonShowerTemplate->objectParameter()))[iCondition];
+
+  LogDebug("L1TGlobal") << "\n MuonShowerTemplate::ObjectParameter : " << std::hex << "\n\t MuonShower0 = 0x "
+                        << objPar.MuonShower0 << "\n\t MuonShower1 = 0x " << objPar.MuonShower1
+                        << "\n\t MuonShowerOutOfTime0 = 0x " << objPar.MuonShowerOutOfTime0
+                        << "\n\t MuonShowerOutOfTime1 = 0x " << objPar.MuonShowerOutOfTime1 << std::endl;
+
+  LogDebug("L1TGlobal") << "\n l1t::MuonShower : "
+                        << "\n\t MuonShower0 = 0x " << cand.mus0() << "\n\t MuonShower1 = 0x " << cand.mus1()
+                        << "\n\t MuonShowerOutOfTime0 = 0x " << cand.musOutOfTime0()
+                        << "\n\t MuonShowerOutOfTime1 = 0x " << cand.musOutOfTime1() << std::dec << std::endl;
+
+  // check oneNominalInTime
+  if (cand.mus0() != objPar.MuonShower0) {
+    LogDebug("L1TGlobal") << "\t\t MuonShower failed MuonShower0 requirement" << std::endl;
+    return false;
+  }
+  if (cand.mus1() != objPar.MuonShower1) {
+    LogDebug("L1TGlobal") << "\t\t MuonShower failed MuonShower1 requirement" << std::endl;
+    return false;
+  }
+  if (cand.musOutOfTime0() != objPar.MuonShowerOutOfTime0) {
+    LogDebug("L1TGlobal") << "\t\t MuonShower failed MuonShowerOutOfTime0 requirement" << std::endl;
+    return false;
+  }
+  if (cand.musOutOfTime1() != objPar.MuonShowerOutOfTime1) {
+    LogDebug("L1TGlobal") << "\t\t MuonShower failed MuonShowerOutOfTime1 requirement" << std::endl;
+    return false;
+  }
+
+  return true;
+}
+
+void l1t::MuonShowerCondition::print(std::ostream& myCout) const {
+  m_gtMuonShowerTemplate->print(myCout);
+
+  ConditionEvaluation::print(myCout);
+}

--- a/L1Trigger/L1TGlobal/src/MuonShowerTemplate.cc
+++ b/L1Trigger/L1TGlobal/src/MuonShowerTemplate.cc
@@ -1,0 +1,81 @@
+// this class header
+#include "L1Trigger/L1TGlobal/interface/MuonShowerTemplate.h"
+
+// system include files
+#include <iostream>
+#include <iomanip>
+
+MuonShowerTemplate::MuonShowerTemplate() : GlobalCondition() { m_condCategory = l1t::CondMuonShower; }
+
+MuonShowerTemplate::MuonShowerTemplate(const std::string& cName) : GlobalCondition(cName) {
+  m_condCategory = l1t::CondMuonShower;
+}
+
+MuonShowerTemplate::MuonShowerTemplate(const std::string& cName, const l1t::GtConditionType& cType)
+    : GlobalCondition(cName, l1t::CondMuonShower, cType) {
+  int nObjects = nrObjects();
+
+  if (nObjects > 0) {
+    m_objectParameter.reserve(nObjects);
+
+    m_objectType.reserve(nObjects);
+    m_objectType.assign(nObjects, l1t::gtMuShower);
+  }
+}
+
+// copy constructor
+MuonShowerTemplate::MuonShowerTemplate(const MuonShowerTemplate& cp) : GlobalCondition(cp.m_condName) { copy(cp); }
+
+// destructor
+MuonShowerTemplate::~MuonShowerTemplate() {
+  // empty now
+}
+
+// assign operator
+MuonShowerTemplate& MuonShowerTemplate::operator=(const MuonShowerTemplate& cp) {
+  copy(cp);
+  return *this;
+}
+
+// setConditionParameter - set the parameters of the condition
+void MuonShowerTemplate::setConditionParameter(const std::vector<ObjectParameter>& objParameter) {
+  m_objectParameter = objParameter;
+}
+
+void MuonShowerTemplate::print(std::ostream& myCout) const {
+  myCout << "\n  MuonShowerTemplate print..." << std::endl;
+
+  GlobalCondition::print(myCout);
+
+  int nObjects = nrObjects();
+
+  for (int i = 0; i < nObjects; i++) {
+    myCout << std::endl;
+    myCout << "  Template for object " << i << " [ hex ]" << std::endl;
+    myCout << "    MuonShower0   = " << std::hex << m_objectParameter[i].MuonShower0 << std::endl;
+    myCout << "    MuonShower1   = " << std::hex << m_objectParameter[i].MuonShower1 << std::endl;
+    myCout << "    MuonShowerOutOfTime0   = " << std::hex << m_objectParameter[i].MuonShowerOutOfTime0 << std::endl;
+    myCout << "    MuonShowerOutOfTime1   = " << std::hex << m_objectParameter[i].MuonShowerOutOfTime1 << std::endl;
+  }
+
+  // reset to decimal output
+  myCout << std::dec << std::endl;
+}
+
+void MuonShowerTemplate::copy(const MuonShowerTemplate& cp) {
+  m_condName = cp.condName();
+  m_condCategory = cp.condCategory();
+  m_condType = cp.condType();
+  m_objectType = cp.objectType();
+  m_condGEq = cp.condGEq();
+  m_condChipNr = cp.condChipNr();
+  m_condRelativeBx = cp.condRelativeBx();
+
+  m_objectParameter = *(cp.objectParameter());
+}
+
+// output stream operator
+std::ostream& operator<<(std::ostream& os, const MuonShowerTemplate& result) {
+  result.print(os);
+  return os;
+}

--- a/L1Trigger/L1TGlobal/src/TriggerMenu.cc
+++ b/L1Trigger/L1TGlobal/src/TriggerMenu.cc
@@ -41,6 +41,7 @@ TriggerMenu::TriggerMenu(
     const std::string& triggerMenuNameVal,
     const unsigned int numberConditionChips,
     const std::vector<std::vector<MuonTemplate> >& vecMuonTemplateVal,
+    const std::vector<std::vector<MuonShowerTemplate> >& vecMuonShowerTemplateVal,
     const std::vector<std::vector<CaloTemplate> >& vecCaloTemplateVal,
     const std::vector<std::vector<EnergySumTemplate> >& vecEnergySumTemplateVal,
     const std::vector<std::vector<ExternalTemplate> >& vecExternalTemplateVal,
@@ -57,6 +58,7 @@ TriggerMenu::TriggerMenu(
       m_triggerMenuImplementation(0x0),
       m_scaleDbKey("NULL"),
       m_vecMuonTemplate(vecMuonTemplateVal),
+      m_vecMuonShowerTemplate(vecMuonShowerTemplateVal),
       m_vecCaloTemplate(vecCaloTemplateVal),
       m_vecEnergySumTemplate(vecEnergySumTemplateVal),
       m_vecExternalTemplate(vecExternalTemplateVal),
@@ -81,6 +83,7 @@ TriggerMenu::TriggerMenu(const TriggerMenu& rhs) {
 
   // copy physics conditions
   m_vecMuonTemplate = rhs.m_vecMuonTemplate;
+  m_vecMuonShowerTemplate = rhs.m_vecMuonShowerTemplate;
   m_vecCaloTemplate = rhs.m_vecCaloTemplate;
   m_vecEnergySumTemplate = rhs.m_vecEnergySumTemplate;
   m_vecExternalTemplate = rhs.m_vecExternalTemplate;
@@ -128,6 +131,7 @@ TriggerMenu& TriggerMenu::operator=(const TriggerMenu& rhs) {
     m_triggerMenuUUID = rhs.m_triggerMenuUUID;
 
     m_vecMuonTemplate = rhs.m_vecMuonTemplate;
+    m_vecMuonShowerTemplate = rhs.m_vecMuonShowerTemplate;
     m_vecCaloTemplate = rhs.m_vecCaloTemplate;
     m_vecEnergySumTemplate = rhs.m_vecEnergySumTemplate;
     m_vecExternalTemplate = rhs.m_vecExternalTemplate;
@@ -185,6 +189,26 @@ void TriggerMenu::buildGtConditionMap() {
     chipNr++;
 
     for (std::vector<MuonTemplate>::iterator itCond = itCondOnChip->begin(); itCond != itCondOnChip->end(); itCond++) {
+      (m_conditionMap.at(chipNr))[itCond->condName()] = &(*itCond);
+    }
+  }
+
+  //
+  size_t vecMuonShowerSize = m_vecMuonShowerTemplate.size();
+  if (condMapSize < vecMuonShowerSize) {
+    m_conditionMap.resize(vecMuonShowerSize);
+    condMapSize = m_conditionMap.size();
+  }
+
+  chipNr = -1;
+
+  for (std::vector<std::vector<MuonShowerTemplate> >::iterator itCondOnChip = m_vecMuonShowerTemplate.begin();
+       itCondOnChip != m_vecMuonShowerTemplate.end();
+       itCondOnChip++) {
+    chipNr++;
+
+    for (std::vector<MuonShowerTemplate>::iterator itCond = itCondOnChip->begin(); itCond != itCondOnChip->end();
+         itCond++) {
       (m_conditionMap.at(chipNr))[itCond->condName()] = &(*itCond);
     }
   }

--- a/L1Trigger/L1TGlobal/src/classes.h
+++ b/L1Trigger/L1TGlobal/src/classes.h
@@ -8,5 +8,6 @@ namespace L1Trigger_L1TGlobal {
     std::vector<CorrelationTemplate> dummy3;
     std::vector<CorrelationThreeBodyTemplate> dummy4;
     std::vector<CorrelationWithOverlapRemovalTemplate> dummy5;
+    std::vector<MuonShowerTemplate> dummy6;
   };
 }  // namespace L1Trigger_L1TGlobal

--- a/L1Trigger/L1TGlobal/src/classes_def.xml
+++ b/L1Trigger/L1TGlobal/src/classes_def.xml
@@ -31,17 +31,25 @@
     <field name="m_vecHfRingEtSumsTemplate" mapping="blob" />
     <field name="m_vecJetCountsTemplate" mapping="blob" />
     <field name="m_vecMuonTemplate" mapping="blob" />
+    <field name="m_vecMuonShowerTemplate" mapping="blob" />
   </class>
   <class name="MuonTemplate"/>
   <class name="MuonTemplate::ObjectParameter"/>
   <class name="std::vector<MuonTemplate::ObjectParameter>"/>
-  <class name="MuonTemplate::CorrelationParameter"/>
   <class name="std::vector<MuonTemplate>"/>
   <class name="std::vector<std::vector<MuonTemplate> >"/>
+  <class name="MuonTemplate::CorrelationParameter"/>
+
   <class name="CaloTemplate"/>
   <class name="CaloTemplate::ObjectParameter"/>
   <class name="std::vector<CaloTemplate::ObjectParameter>"/>
-  <class name="CaloTemplate::CorrelationParameter"/>
   <class name="std::vector<CaloTemplate>"/>
   <class name="std::vector<std::vector<CaloTemplate> >"/>
+  <class name="CaloTemplate::CorrelationParameter"/>
+
+  <class name="MuonShowerTemplate"/>
+  <class name="MuonShowerTemplate::ObjectParameter"/>
+  <class name="std::vector<MuonShowerTemplate::ObjectParameter>"/>
+  <class name="std::vector<MuonShowerTemplate>"/>
+  <class name="std::vector<std::vector<MuonShowerTemplate> >"/>
 </lcgdict>


### PR DESCRIPTION
#### PR description:

This PR is a first attempt to include the core code for the uGT emulator for hadronic shower triggers for Run-3. In previous PRs I introduced data formats for the CSC, EMTF and uGMT shower objects, and emulators for the CSC trigger, EMTF and uGMT.  A new object `MuonShower` object is introduced in the L1TGlobal emulator and data format packages. This object is treated separately from the regular `Muon` object. The core code is currently switched off, i.e. the parameter that enables reading muon shower trigger bits from the L1T menu XML file is set to `False`. As such, there should be no differences in any workflow. The code is based on UTM lib 0.9.X (https://gitlab.cern.ch/cms-l1t-utm/utm), which was recently integrated into CMSSW_12_0_X (https://github.com/cms-sw/cmsdist/pull/7337) and CMSSW_12_1_X (https://github.com/cms-sw/cmsdist/pull/7281). 

A few relevant presentations can be found here:
- https://indico.cern.ch/event/1032087/contributions/4334392/attachments/2239866/3798910/HadronicShowerTrigger_EXO_LL_L1DPG_6May2021.pdf
- https://indico.cern.ch/event/1032087/contributions/4334095/attachments/2241349/3800447/HLT_muon_shower_martin.pdf
- https://indico.cern.ch/event/1080450/contributions/4548741/attachments/2320995/3952292/MuonShower_Oct1_Martin.pdf

I'm currently waiting on a suitable dev branch to open up within cms-l1t-offline/cmssw for additional testing (rate in particular), but I wanted to go ahead and have the proposal run by L1T experts and other CMS software developers.

#### PR validation:

I tested the code on a private XML L1T menu, stripped from the regular trigger algorithms. However, as I wrote earlier, I need a branch in cms-l1t-offline/cmssw for more testing before the code can be enabled in the emulator.

Additional validation with ```scram b runtests``` and with WF 11634.0. 
```
11634.0_TTbar_14TeV+2021+TTbar_14TeV_TuneCP5_GenSim+Digi+Reco+HARVEST+ALCA Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Fri Oct  1 15:25:09 2021-date Fri Oct  1 14:50:10 2021; exit: 0 0 0 0 0
1 1 1 1 1 tests passed, 0 0 0 0 0 failed
```

I also wanted to run ```runTheMatrix.py -l limited -i all --ibeos```, but many WFs fail in step1 because of issues with globaltags? I'll try to run this again. 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

FYI @kakwok @Nik-Menendez @elfontan 