### PR TITLE
[120X] Include new ideal beamspot records in Run-3 MC design GT

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -66,7 +66,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak'     : '120X_upgrade2018cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'           : '120X_mcRun3_2021_design_v6', # GT containing design conditions for Phase1 2021
+    'phase1_2021_design'           : '120X_mcRun3_2021_design_v7', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
     'phase1_2021_realistic'        : '120X_mcRun3_2021_realistic_v9', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode


### PR DESCRIPTION
**New 2021 design MC beamspot GT**

Backport of the beamspot part of [1]
This PR is to include a new record introduced in [2] in the 2021 design MC as it was realized earlier that it was not created, see the comment [3]. The HN request can be found under [4]. 

The new GT and the diff wrt to the prev versioned GT are
 * 120X_mcRun3_2021_design_v7
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/120X_mcRun3_2021_design_v6/120X_mcRun3_2021_design_v7

They differ only in the requested tags:
 ```
  | BeamSpotOnlineHLTObjectsRcd | - | - | BeamSpotOnlineObjects_Ideal_Centered_SLHC_v3_mc
  | BeamSpotOnlineLegacyObjectsRcd | - | - | BeamSpotOnlineObjects_Ideal_Centered_SLHC_v3_mc
```

[1] https://github.com/cms-sw/cmssw/pull/35514
[2] https://github.com/cms-sw/cmssw/pull/35373
[3] https://github.com/cms-sw/cmssw/pull/35478#issuecomment-931182462
[4] https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4474/3.html

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
Partial backport of https://github.com/cms-sw/cmssw/pull/35514