### PR TITLE
Increase SiPixel L1 cluster threshold from 2000 to 4000e, synchronize channel threshold between HTL and offline

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -135,7 +135,7 @@ def customisePixelGainForRun2Input(process):
 
     return process
 
-def customizePixelL1ClusterThreshold(process):
+def customisePixelL1ClusterThresholdForRun2Input(process):
     # revert the pixel Layer 1 cluster threshold to be compatible with Run2:
     for producer in producers_by_type(process, "SiPixelClusterProducer"):
         if hasattr(producer,"ClusterThreshold_L1"):
@@ -146,7 +146,7 @@ def customizePixelL1ClusterThreshold(process):
 def customiseFor2018Input(process):
     """Customise the HLT to run on Run 2 data/MC"""
     process = customisePixelGainForRun2Input(process)
-    process = customizePixelL1ClusterThreshold(process)
+    process = customisePixelL1ClusterThresholdForRun2Input(process)
     process = customiseHCALFor2018Input(process)
 
     return process

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -135,10 +135,18 @@ def customisePixelGainForRun2Input(process):
 
     return process
 
+def customizePixelL1ClusterThreshold(process):
+    # revert the pixel Layer 1 cluster threshold to be compatible with Run2:
+    for producer in producers_by_type(process, "SiPixelClusterProducer"):
+        if hasattr(producer,"ClusterThreshold_L1"):
+            producer.ClusterThreshold_L1 = 2000
+
+    return process
 
 def customiseFor2018Input(process):
     """Customise the HLT to run on Run 2 data/MC"""
     process = customisePixelGainForRun2Input(process)
+    process = customizePixelL1ClusterThreshold(process)
     process = customiseHCALFor2018Input(process)
 
     return process
@@ -157,6 +165,13 @@ def customiseFor35269(process):
     process.load("RecoTracker.TkMSParametrization.multipleScatteringParametrisationMakerESProducer_cfi")
     return process
 
+# Increase L1 cluster threshold from 2000 to 4000e making it the same as all other layers
+def customiseFor35518(process):
+    for producer in producers_by_type(process, "SiPixelClusterProducer"):
+        if hasattr(producer,"ClusterThreshold_L1"):
+            producer.ClusterThreshold_L1 = 4000
+    return process
+
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
     
@@ -170,5 +185,6 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
     process = customiseFor35309(process)
     process = customiseFor35315(process)
     process = customiseFor35269(process)
+    process = customiseFor35518(process)
 
     return process

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -170,6 +170,8 @@ def customiseFor35518(process):
     for producer in producers_by_type(process, "SiPixelClusterProducer"):
         if hasattr(producer,"ClusterThreshold_L1"):
             producer.ClusterThreshold_L1 = 4000
+        if hasattr(producer,"ChannelThreshold"):
+            producer.ChannelThreshold = 10
     return process
 
 # CMSSW version specific customizations

--- a/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
+++ b/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
@@ -24,7 +24,8 @@ run3_common.toModify(siPixelClusters,
   VCaltoElectronGain      = 1,  # all gains=1, pedestals=0
   VCaltoElectronGain_L1   = 1,   
   VCaltoElectronOffset    = 0,   
-  VCaltoElectronOffset_L1 = 0  
+  VCaltoElectronOffset_L1 = 0,  
+  ClusterThreshold_L1     = 4000
 )
 
 

--- a/RecoLocalTracker/SiPixelClusterizer/python/siPixelClustersPreSplitting_cff.py
+++ b/RecoLocalTracker/SiPixelClusterizer/python/siPixelClustersPreSplitting_cff.py
@@ -19,13 +19,16 @@ from RecoLocalTracker.SiPixelClusterizer.siPixelRawToClusterCUDA_cfi import siPi
 siPixelClustersPreSplittingCUDA = _siPixelRawToClusterCUDA.clone()
 
 run3_common.toModify(siPixelClustersPreSplittingCUDA,
-    # use the pixel channel calibrations scheme for Run 3
-    isRun2 = False
-)
+                     # use the pixel channel calibrations scheme for Run 3
+                     isRun2 = False,
+                     clusterThreshold_layer1 = 4000)
 
 # convert the pixel digis (except errors) and clusters to the legacy format
 from RecoLocalTracker.SiPixelClusterizer.siPixelDigisClustersFromSoA_cfi import siPixelDigisClustersFromSoA as _siPixelDigisClustersFromSoA
 siPixelDigisClustersPreSplitting = _siPixelDigisClustersFromSoA.clone()
+
+run3_common.toModify(siPixelDigisClustersPreSplitting,
+                     clusterThreshold_layer1 = 4000)
 
 gpu.toReplaceWith(siPixelClustersPreSplittingTask, cms.Task(
     # conditions used *only* by the modules running on GPU


### PR DESCRIPTION
#### PR description:

Increase the SiPixel L1 cluster threshold from 2000 to 4000e making it the same as all other layers.
With the new L1 detector the lower thresholds should not be needed anymore as there is a clear separation between real clusters and junk (see the attached plot). The change will affect the cluster charge distribution for L1, the lower edge will shift from 2000
to 4000e.

![Cluster_charge](https://user-images.githubusercontent.com/4885289/136060774-786b1fe4-bb8b-45f8-a22c-677a7ce85dcb.jpg)

In addition, the PR sets the `SiPixelClusterProducer` `ChannelThreshold` at the HLT to 10 to make it in sync with the offline reconstruction.

This is a resubmission of https://github.com/cms-sw/cmssw/pull/35506 with the additional Run 3 modifiers for the GPU code and the related HLT modifiers.

#### PR validation:

Run RECO on raw data from the cosmic run 344420.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport needed.

@dkotlins @mmusich 
