### PR TITLE
Make --procModifier as list

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -2134,7 +2134,9 @@ class ConfigBuilder(object):
         if hasattr(self._options,"procModifiers") and self._options.procModifiers:
             import importlib
             thingsImported=[]
-            for pm in self._options.procModifiers.split(','):
+            for c in self._options.procModifiers:
+                thingsImported.extend(c.split(","))
+            for pm in thingsImported:
                 modifierStrings.append(pm)
                 modifierImports.append('from Configuration.ProcessModifiers.'+pm+'_cff import '+pm)
                 modifiers.append(getattr(importlib.import_module('Configuration.ProcessModifiers.'+pm+'_cff'),pm))

--- a/Configuration/Applications/python/Options.py
+++ b/Configuration/Applications/python/Options.py
@@ -363,7 +363,8 @@ expertSettings.add_option("--era",
 
 expertSettings.add_option("--procModifiers",
                           help="Specify any process Modifiers to include (in Configuration/ProcessModiers) - comma separated list",
-                          default=None,
+                          default=[],
+                          action="append",
                           dest="procModifiers")
 
 expertSettings.add_option("--evt_type",


### PR DESCRIPTION
#### PR description:
This is a PR as discussed in https://github.com/cms-sw/cmssw/issues/35520. 

It is to allow multiple occurrences of `--procModifiers` The use case is when dd4hep will be used as default, and we would like to use it together with any offsets workflows, e.g. gpu, mkfits which have another `--procModifier`.

However, 
https://github.com/cms-sw/cmssw/blob/master/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
needs to be updated also in the separated PR.

#### PR validation:
The following driver give the expected cfg file,
`cmsDriver.py step3 -s RAW2DIGI:RawToDigi_pixelOnly,RECO:reconstruction_pixelTrackingOnly,VALIDATION:@pixelTrackingOnlyValidation,DQM:@pixelTrackingOnlyDQM --conditions auto:phase1_2021_dd4hep --datatier GEN-SIM-RECO,DQMIO -n 10 --eventcontent RECOSIM,DQM --procModifiers dd4hep --procModifiers pixelNtupletFit,gpu --geometry DB:Extended --era Run3 --customise RecoPixelVertexing/Configuration/customizePixelTracksForTriplets.customizePixelTracksForTriplets --io Reco_Patatrack_PixelOnlyTripletsGPU_2021.io --python Reco_Patatrack_PixelOnlyTripletsGPU_2021.py --no_exec --filein file:step2.root --fileout file:step3.root --nThreads 8`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
Not a backport, and no need of backporting.
