### PR TITLE
Fix assert in debug builds from GsfTrajectorySmoother

### DIFF
--- a/TrackingTools/TrackFitters/interface/DebugHelpers.h
+++ b/TrackingTools/TrackFitters/interface/DebugHelpers.h
@@ -12,6 +12,7 @@
 #include "DataFormats/MuonDetId/interface/ME0DetId.h"
 #include "DataFormats/MuonDetId/interface/MuonSubdetId.h"
 #include "TrackingTools/GsfTools/interface/GetComponents.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 namespace {
   inline void dump(TrackingRecHit const& hit, int hitcounter, const std::string& msgCat) {

--- a/TrackingTools/TrackFitters/interface/DebugHelpers.h
+++ b/TrackingTools/TrackFitters/interface/DebugHelpers.h
@@ -83,7 +83,7 @@ namespace {
     std::ostringstream ss;
     ss << " weights ";
     GetComponents comps(tsos);
-    auto const & tsosComponents = comps();
+    auto const& tsosComponents = comps();
 
     for (auto const& c : tsosComponents)
       ss << c.weight() << '/';

--- a/TrackingTools/TrackFitters/interface/DebugHelpers.h
+++ b/TrackingTools/TrackFitters/interface/DebugHelpers.h
@@ -11,6 +11,7 @@
 #include "DataFormats/MuonDetId/interface/GEMDetId.h"
 #include "DataFormats/MuonDetId/interface/ME0DetId.h"
 #include "DataFormats/MuonDetId/interface/MuonSubdetId.h"
+#include "TrackingTools/GsfTools/interface/GetComponents.h"
 
 namespace {
   inline void dump(TrackingRecHit const& hit, int hitcounter, const std::string& msgCat) {
@@ -81,15 +82,18 @@ namespace {
   inline void dump(TrajectoryStateOnSurface const& tsos, const char* header, const std::string& msgCat) {
     std::ostringstream ss;
     ss << " weights ";
-    for (auto const& c : tsos.components())
+    GetComponents comps(tsos);
+    auto const & tsosComponents = comps();
+
+    for (auto const& c : tsosComponents)
       ss << c.weight() << '/';
     ss << "\nmomentums ";
-    for (auto const& c : tsos.components())
+    for (auto const& c : tsosComponents)
       ss << c.globalMomentum().mag() << '/';
     ss << "\ndeltap/p ";
-    for (auto const& c : tsos.components())
+    for (auto const& c : tsosComponents)
       ss << std::sqrt(tsos.curvilinearError().matrix()(0, 0)) / c.globalMomentum().mag() << '/';
-    LogTrace(msgCat) << header << "! size " << tsos.components().size() << ss.str() << "\n"
+    LogTrace(msgCat) << header << "! size " << tsosComponents.size() << ss.str() << "\n"
                      << " with local position " << tsos.localPosition() << "\n"
                      << tsos;
   }


### PR DESCRIPTION
#### PR description:

This PR is trying to address the issue reported in https://github.com/cms-sw/cmssw/issues/34097, which is causing failures in DBG IB relvals due to GSF tracking code hitting an `assert(false)`. This is a technical PR, and no change in physics is expected.  

#### PR validation:

Ran the workflow `10824.0` from `CMSSW_12_1_DBG_X_2021-09-30-2300` to reproduce the issue. The issue could be reproduced, and this was the error message:
```
%MSG-e BasicSingleTrajectoryState:  GoodSeedProducer:trackerDrivenElectronSeeds  
Run: 1 Event: 1
asking for componenets to a SingleTrajectoryState
%MSG
cmsRun: /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/8e0ebc7a948785df3d5eabb18ad33031/opt/cmssw/slc7_amd64_gcc900/cms/cmssw/CMSSW_12_1_DBG_X_2021-09-30-2300/src/TrackingTools/TrajectoryState/src/BasicTrajectoryState.cc:248: virtual const Components& BasicSingleTrajectoryState::components() const: Assertion `false' failed.
```
Then merged this branch, compiled and reran the workflow `10824.0`. This time it looks like this issue was resolved. But a different problem was spotted: 
```
An exception of category 'PFECALSuperClusterAlgo::buildSuperCluster' occurred while
...
Exception Message:
Found a PS cluster matched to more than one EE cluster!
0x7f316c6cb608 == 0x7f316c6c4198
```
this is coming from here:
https://github.com/cms-sw/cmssw/blob/master/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc#L428-L432