### PR TITLE
Fix thread-safety problems with CSC simhit fitting in validation

### DIFF
--- a/Validation/MuonHits/BuildFile.xml
+++ b/Validation/MuonHits/BuildFile.xml
@@ -12,6 +12,7 @@
 <use name="SimDataFormats/Vertex"/>
 <use name="root"/>
 <use name="clhep"/>
+<use name="rootminuit"/>
 <export>
   <lib name="1"/>
 </export>

--- a/Validation/MuonHits/src/CSCSimHitMatcher.cc
+++ b/Validation/MuonHits/src/CSCSimHitMatcher.cc
@@ -241,11 +241,11 @@ void CSCSimHitMatcher::fitHitsInChamber(unsigned int detid, float& intercept, fl
     return;
 
   std::unique_ptr<TGraphErrors> gr(new TGraphErrors(x.size(), &x[0], &y[0], &xe[0], &ye[0]));
-  std::unique_ptr<TF1> fit(new TF1("fit", "pol1", -3, 4));
-  gr->Fit("fit", "EMQN");
+  TF1 fit("fit", "pol1", -3, 4);
+  gr->Fit(&fit, "EMQN");
 
-  intercept = fit->GetParameter(0);
-  slope = fit->GetParameter(1);
+  intercept = fit.GetParameter(0);
+  slope = fit.GetParameter(1);
 }
 
 float CSCSimHitMatcher::simHitsMeanStrip(const edm::PSimHitContainer& sim_hits) const {

--- a/Validation/MuonHits/src/CSCSimHitMatcher.cc
+++ b/Validation/MuonHits/src/CSCSimHitMatcher.cc
@@ -1,6 +1,7 @@
 #include "Validation/MuonHits/interface/CSCSimHitMatcher.h"
 #include "TGraphErrors.h"
 #include "TF1.h"
+#include "TMinuitMinimizer.h"
 
 using namespace std;
 
@@ -13,6 +14,10 @@ CSCSimHitMatcher::CSCSimHitMatcher(const edm::ParameterSet& ps, edm::ConsumesCol
 
   simHitInput_ = iC.consumes<edm::PSimHitContainer>(simHitPSet_.getParameter<edm::InputTag>("inputTag"));
   geomToken_ = iC.esConsumes<CSCGeometry, MuonGeometryRecord>();
+
+  //In order to make fitting ROOT histograms thread safe
+  // one must call this undocumented function
+  TMinuitMinimizer::UseStaticMinuit(false);
 }
 
 /// initialize the event
@@ -237,7 +242,7 @@ void CSCSimHitMatcher::fitHitsInChamber(unsigned int detid, float& intercept, fl
 
   std::unique_ptr<TGraphErrors> gr(new TGraphErrors(x.size(), &x[0], &y[0], &xe[0], &ye[0]));
   std::unique_ptr<TF1> fit(new TF1("fit", "pol1", -3, 4));
-  gr->Fit("fit", "EMQ");
+  gr->Fit("fit", "EMQN");
 
   intercept = fit->GetParameter(0);
   slope = fit->GetParameter(1);


### PR DESCRIPTION
#### PR description:

Fix thread-safety problems with CSC simhit fitting. In response to https://github.com/cms-sw/cmssw/pull/35329#issuecomment-932760674 by @Dr15Jones 

#### PR validation:

Compiles. Tested with (most tests seem to pass)
```
runTheMatrix.py -l limited
37 33 32 27 17 4 1 1 1 tests passed, 3 3 0 0 0 0 0 0 0 failed
```
#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A