### PR TITLE
Removes boost erase_all dependency

### DIFF
--- a/DQMServices/StreamerIO/plugins/DQMStreamerReader.cc
+++ b/DQMServices/StreamerIO/plugins/DQMStreamerReader.cc
@@ -15,12 +15,8 @@
 #include <fstream>
 #include <memory>
 #include <queue>
-
-#include <boost/algorithm/string.hpp>
-#include <boost/format.hpp>
-#include <boost/range.hpp>
-#include <boost/regex.hpp>
-#include <boost/algorithm/string.hpp>
+#include <algorithm>
+#include <cctype>
 
 #include <IOPool/Streamer/interface/DumpTools.h>
 
@@ -347,7 +343,10 @@ namespace dqmservices {
     acceptAllEvt_ = false;
     for (Strings::const_iterator i(hltSel_.begin()), end(hltSel_.end()); i != end; ++i) {
       std::string hltPath(*i);
-      boost::erase_all(hltPath, " \t");
+      hltPath.erase(
+          std::remove_if(
+              hltPath.begin(), hltPath.end(), [](char c) { return std::isspace(static_cast<unsigned char>(c)); }),
+          hltPath.end());
       if (hltPath == "*")
         acceptAllEvt_ = true;
     }
@@ -361,7 +360,10 @@ namespace dqmservices {
     matchTriggerSel_ = false;
     for (Strings::const_iterator i(hltSel_.begin()), end(hltSel_.end()); i != end; ++i) {
       std::string hltPath(*i);
-      boost::erase_all(hltPath, " \t");
+      hltPath.erase(
+          std::remove_if(
+              hltPath.begin(), hltPath.end(), [](char c) { return std::isspace(static_cast<unsigned char>(c)); }),
+          hltPath.end()); 
       std::vector<Strings::const_iterator> matches = edm::regexMatch(tnames, hltPath);
       if (!matches.empty()) {
         matchTriggerSel_ = true;

--- a/DQMServices/StreamerIO/plugins/DQMStreamerReader.cc
+++ b/DQMServices/StreamerIO/plugins/DQMStreamerReader.cc
@@ -363,7 +363,7 @@ namespace dqmservices {
       hltPath.erase(
           std::remove_if(
               hltPath.begin(), hltPath.end(), [](char c) { return std::isspace(static_cast<unsigned char>(c)); }),
-          hltPath.end()); 
+          hltPath.end());
       std::vector<Strings::const_iterator> matches = edm::regexMatch(tnames, hltPath);
       if (!matches.empty()) {
         matchTriggerSel_ = true;

--- a/FWCore/Framework/src/EventSelector.cc
+++ b/FWCore/Framework/src/EventSelector.cc
@@ -39,9 +39,8 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ParameterSet/interface/Registry.h"
 
-#include "boost/algorithm/string.hpp"
-
 #include <algorithm>
+#include <cctype>
 #include <cassert>
 
 namespace edm {
@@ -89,7 +88,10 @@ namespace edm {
   Strings EventSelector::initPathSpecs(Strings const& pathSpecs) {
     Strings trimmedPathSpecs(pathSpecs);
     for (auto& pathspecifier : trimmedPathSpecs) {
-      boost::erase_all(pathspecifier, " \t");  // whitespace eliminated
+      pathspecifier.erase(std::remove_if(pathspecifier.begin(),
+                                         pathspecifier.end(),
+                                         [](char c) { return std::isspace(static_cast<unsigned char>(c)); }),
+                          pathspecifier.end());  // whitespace eliminated
     }
     // Return value optimization should avoid another copy;
     return trimmedPathSpecs;


### PR DESCRIPTION
#### PR description:
Removes white spaces and removes boost dependency. Attempt to clear the ambiguity discussed in issue #35522 
std::isspace removes white spaces of type:
' '		space (SPC)
'\t'		horizontal tab (TAB)
'\n'		newline (LF)
'\v'		vertical tab (VT)
'\f'		feed (FF)
'\r'		carriage return (CR)

#### PR validation:

Compiles

#### if this PR is a backport:

@davidlange6 @vgvassilev 