### PR TITLE
Disabled duplicate GEM TP warnings in EMTF GEM unpacker [12_0_X]

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockGEM.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockGEM.cc
@@ -227,11 +227,12 @@ namespace l1t {
           }
         }  // End loop: for (auto const & iHit : *res_hit)
 
-        if (exact_duplicate)
-          edm::LogWarning("L1T|EMTF") << "EMTF unpacked duplicate GEM digis: BX " << Hit_.BX() << ", endcap "
-                                      << Hit_.Endcap() << ", station " << Hit_.Station() << ", neighbor "
-                                      << Hit_.Neighbor() << ", ring " << Hit_.Ring() << ", chamber " << Hit_.Chamber()
-                                      << ", roll " << Hit_.Roll() << ", pad " << Hit_.Pad() << std::endl;
+        // TODO: Re-enable once GEM TP data format is fixed
+        // if (exact_duplicate)
+        //   edm::LogWarning("L1T|EMTF") << "EMTF unpacked duplicate GEM digis: BX " << Hit_.BX() << ", endcap "
+        //                               << Hit_.Endcap() << ", station " << Hit_.Station() << ", neighbor "
+        //                               << Hit_.Neighbor() << ", ring " << Hit_.Ring() << ", chamber " << Hit_.Chamber()
+        //                               << ", roll " << Hit_.Roll() << ", pad " << Hit_.Pad() << std::endl;
 
         (res->at(iOut)).push_GEM(GEM_);
         if (!exact_duplicate)


### PR DESCRIPTION
Commented out the duplicate GEM TP warning in EMTF GEM block unpacker until the GEM-EMTF data format is fixed.

This was discussed in #34309 

This is the backport of #35042 