### PR TITLE
GPUCACell::find_ntuplets abort on recursion overflow

### DIFF
--- a/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
@@ -359,7 +359,11 @@ __device__ inline void GPUCACell::find_ntuplets<0>(Hits const& hh,
                                                    const unsigned int minHitsPerNtuplet,
                                                    bool startAt0) const {
   printf("ERROR: GPUCACell::find_ntuplets reached full depth!\n");
-  assert(false);  // on GPU is compiled away in NDEBUG mode
+#ifdef __CUDA_ARCH__
+  __trap();
+#else
+  abort();
+#endif
 }
 
 #endif  // RecoPixelVertexing_PixelTriplets_plugins_GPUCACell_h


### PR DESCRIPTION
#### PR description:

Use the `__trap()` builtin to abort the execution from within a GPU kernel if the  `GPUCACell::find_ntuplets` recusrions overflows.

This should not be possible in Phase-1 code, and is not yet been used in Phase-2 code, but is added for extra robustness.

#### PR validation:

Running with the standard configuration does not show any regressions, not even on performance:

measurement     |   #35473     |  #35473 with `__trap()`  
----------------|-------------------|-------------------
I/O throughput  |        ~ 2 kev/s  |        ~ 2 kev/s  
quadruplets     |   1289 ±  3 ev/s  |   1292 ±  4 ev/s  
triplets        |    724 ±  3 ev/s  |    720 ±  2 ev/s  

.

Forcing the overflow to happen by artificially reducing the maximum recursion fails as expected:
```
Begin processing the 1st record. Run 1, Event 1602, LumiSection 17 on stream 0 at 05-Oct-2021 15:15:12.381 CEST
ERROR: GPUCACell::find_ntuplets reached full depth!
... (repeated 819 times)
ERROR: GPUCACell::find_ntuplets reached full depth!
terminate called after throwing an instance of 'std::runtime_error'
  what():  
/data/user/fwyzard/CMSSW_12_1_0_pre3/src/HeterogeneousCore/CUDAUtilities/src/CachingDeviceAllocator.h, line 617:
cudaCheck(error = cudaEventRecord(search_key.ready_event, search_key.associated_stream));
cudaErrorLaunchFailure: unspecified launch failure
```
followed by the usual stack trace.
