### PR TITLE
Format for clustering CSC rechits with jet algorithms

### DIFF
--- a/DataFormats/CSCRecHit/BuildFile.xml
+++ b/DataFormats/CSCRecHit/BuildFile.xml
@@ -2,7 +2,6 @@
 <use   name="DataFormats/MuonDetId"/>
 <use   name="DataFormats/Candidate"/>
 <use   name="DataFormats/TrackingRecHit"/>
-
 <export>
   <lib name="1"/>
 </export>

--- a/DataFormats/CSCRecHit/BuildFile.xml
+++ b/DataFormats/CSCRecHit/BuildFile.xml
@@ -1,6 +1,8 @@
-<use name="DataFormats/Common"/>
-<use name="DataFormats/MuonDetId"/>
-<use name="DataFormats/TrackingRecHit"/>
+<use   name="DataFormats/Common"/>
+<use   name="DataFormats/MuonDetId"/>
+<use   name="DataFormats/Candidate"/>
+<use   name="DataFormats/TrackingRecHit"/>
+
 <export>
   <lib name="1"/>
 </export>

--- a/DataFormats/CSCRecHit/interface/CSCJetCandidate.h
+++ b/DataFormats/CSCRecHit/interface/CSCJetCandidate.h
@@ -1,5 +1,5 @@
-#ifndef DataFormats_CSCJetCandidate_H
-#define DataFormats_CSCJetCandidate_H
+#ifndef DataFormats_CSCJetCandidate_h
+#define DataFormats_CSCJetCandidate_h
 
 #include <vector>
 #include <memory>

--- a/DataFormats/CSCRecHit/interface/CSCJetCandidate.h
+++ b/DataFormats/CSCRecHit/interface/CSCJetCandidate.h
@@ -1,0 +1,43 @@
+#ifndef DataFormats_CSCJetCandidate_H
+#define DataFormats_CSCJetCandidate_H
+
+#include <vector>
+#include <memory>
+#include "DataFormats/Math/interface/Point3D.h"
+#include "DataFormats/Common/interface/SortedCollection.h"
+
+#include <DataFormats/CSCRecHit/interface/CSCRecHit2D.h>
+
+#include "DataFormats/Candidate/interface/LeafCandidate.h"
+
+namespace reco {
+
+  class CSCJetCandidate : public LeafCandidate {
+  public:
+    CSCJetCandidate(): phi_(0.),eta_(0.),x_(0.),y_(0.),z_(0.),tPeak_(-999.),tWire_(-999.) {}
+    
+    CSCJetCandidate(const double phi,const double eta,const double x, const double y,const double z, const double tPeak, const double tWire);
+
+    ~CSCJetCandidate() override;
+
+    double phi() const {return phi_;}
+    double eta() const {return eta_;}
+    double x() const {return x_;}
+    double y() const {return y_;}
+    double z() const {return z_;}
+    double tPeak() const {return tPeak_;}
+    double tWire() const {return tWire_;}
+
+   private:
+    double phi_;      
+    double eta_;      
+    double x_;      
+    double y_;
+    double z_;      
+    double tPeak_;      
+    double tWire_;      
+  }
+
+   typedef std::vector<CSCJetCandidate> CSCJetCandidateCollection;
+}
+#endif

--- a/DataFormats/CSCRecHit/interface/CSCJetCandidate.h
+++ b/DataFormats/CSCRecHit/interface/CSCJetCandidate.h
@@ -15,25 +15,42 @@ namespace reco {
   public:
 
     //default constructor
-    CSCJetCandidate(): x_(0.),y_(0.),z_(0.),tPeak_(-999.),tWire_(-999.) {}
+    CSCJetCandidate(): x_(0.),y_(0.),z_(0.),tPeak_(-999.),tWire_(-999.),quality_(0),chamber_(0), station_(0), nStrips_(0), hitWire_(0), wgroupsBX_(0), nWireGroups_(0){}
     
-    CSCJetCandidate(const double phi,const double eta,const double x, const double y,const double z, const double tPeak, const double tWire);
+    CSCJetCandidate(const double phi,const double eta,const float x, const float y,const float z, const float tPeak, const float tWire,
+                    const int quality,const int chamber,const int station,const int nStrips,const int hitWire,const int wgroupsBX,const int nWireGroups
+                );
 
     //destructor
     ~CSCJetCandidate() override;
 
-    double xPos() const {return x_;}
-    double yPos() const {return y_;}
-    double zPos() const {return z_;}
-    double tPeak() const {return tPeak_;}
-    double tWire() const {return tWire_;}
+    float xPos() const {return x_;}
+    float yPos() const {return y_;}
+    float zPos() const {return z_;}
+    float tPeak() const {return tPeak_;}
+    float tWire() const {return tWire_;}
+    int quality() const {return quality_;}
+    int chamber() const {return chamber_;}
+    int station() const {return station_;}
+    int nStrips() const {return nStrips_;}
+    int hitWire() const {return hitWire_;}
+    int wgroupsBX() const {return wgroupsBX_;}
+    int nWireGroups() const {return nWireGroups_;}
 
    private:
-    double x_;      
-    double y_;
-    double z_;      
-    double tPeak_;      
-    double tWire_;      
+    float x_;      
+    float y_;
+    float z_;      
+    float tPeak_;      
+    float tWire_;    
+    int   quality_; 
+    int   chamber_; 
+    int   station_; 
+    int   nStrips_;
+    int   hitWire_;
+    int   wgroupsBX_; 
+    int   nWireGroups_;
+ 
   };
 
    typedef std::vector<CSCJetCandidate> CSCJetCandidateCollection;

--- a/DataFormats/CSCRecHit/interface/CSCJetCandidate.h
+++ b/DataFormats/CSCRecHit/interface/CSCJetCandidate.h
@@ -7,36 +7,34 @@
 #include "DataFormats/Common/interface/SortedCollection.h"
 
 #include <DataFormats/CSCRecHit/interface/CSCRecHit2D.h>
-
 #include "DataFormats/Candidate/interface/LeafCandidate.h"
 
 namespace reco {
 
-  class CSCJetCandidate : public LeafCandidate {
+  class CSCJetCandidate : public LeafCandidate{
   public:
-    CSCJetCandidate(): phi_(0.),eta_(0.),x_(0.),y_(0.),z_(0.),tPeak_(-999.),tWire_(-999.) {}
+
+    //default constructor
+    CSCJetCandidate(): x_(0.),y_(0.),z_(0.),tPeak_(-999.),tWire_(-999.) {}
     
     CSCJetCandidate(const double phi,const double eta,const double x, const double y,const double z, const double tPeak, const double tWire);
 
+    //destructor
     ~CSCJetCandidate() override;
 
-    double phi() const {return phi_;}
-    double eta() const {return eta_;}
-    double x() const {return x_;}
-    double y() const {return y_;}
-    double z() const {return z_;}
+    double xPos() const {return x_;}
+    double yPos() const {return y_;}
+    double zPos() const {return z_;}
     double tPeak() const {return tPeak_;}
     double tWire() const {return tWire_;}
 
    private:
-    double phi_;      
-    double eta_;      
     double x_;      
     double y_;
     double z_;      
     double tPeak_;      
     double tWire_;      
-  }
+  };
 
    typedef std::vector<CSCJetCandidate> CSCJetCandidateCollection;
 }

--- a/DataFormats/CSCRecHit/interface/CSCJetCandidate.h
+++ b/DataFormats/CSCRecHit/interface/CSCJetCandidate.h
@@ -11,48 +11,69 @@
 
 namespace reco {
 
-  class CSCJetCandidate : public LeafCandidate{
+  class CSCJetCandidate : public LeafCandidate {
   public:
-
     //default constructor
-    CSCJetCandidate(): x_(0.),y_(0.),z_(0.),tPeak_(-999.),tWire_(-999.),quality_(0),chamber_(0), station_(0), nStrips_(0), hitWire_(0), wgroupsBX_(0), nWireGroups_(0){}
-    
-    CSCJetCandidate(const double phi,const double eta,const float x, const float y,const float z, const float tPeak, const float tWire,
-                    const int quality,const int chamber,const int station,const int nStrips,const int hitWire,const int wgroupsBX,const int nWireGroups
-                );
+    CSCJetCandidate()
+        : x_(0.),
+          y_(0.),
+          z_(0.),
+          tPeak_(-999.),
+          tWire_(-999.),
+          quality_(0),
+          chamber_(0),
+          station_(0),
+          nStrips_(0),
+          hitWire_(0),
+          wgroupsBX_(0),
+          nWireGroups_(0) {}
+
+    CSCJetCandidate(const double phi,
+                    const double eta,
+                    const float x,
+                    const float y,
+                    const float z,
+                    const float tPeak,
+                    const float tWire,
+                    const int quality,
+                    const int chamber,
+                    const int station,
+                    const int nStrips,
+                    const int hitWire,
+                    const int wgroupsBX,
+                    const int nWireGroups);
 
     //destructor
     ~CSCJetCandidate() override;
 
-    float xPos() const {return x_;}
-    float yPos() const {return y_;}
-    float zPos() const {return z_;}
-    float tPeak() const {return tPeak_;}
-    float tWire() const {return tWire_;}
-    int quality() const {return quality_;}
-    int chamber() const {return chamber_;}
-    int station() const {return station_;}
-    int nStrips() const {return nStrips_;}
-    int hitWire() const {return hitWire_;}
-    int wgroupsBX() const {return wgroupsBX_;}
-    int nWireGroups() const {return nWireGroups_;}
+    float xPos() const { return x_; }
+    float yPos() const { return y_; }
+    float zPos() const { return z_; }
+    float tPeak() const { return tPeak_; }
+    float tWire() const { return tWire_; }
+    int quality() const { return quality_; }
+    int chamber() const { return chamber_; }
+    int station() const { return station_; }
+    int nStrips() const { return nStrips_; }
+    int hitWire() const { return hitWire_; }
+    int wgroupsBX() const { return wgroupsBX_; }
+    int nWireGroups() const { return nWireGroups_; }
 
-   private:
-    float x_;      
+  private:
+    float x_;
     float y_;
-    float z_;      
-    float tPeak_;      
-    float tWire_;    
-    int   quality_; 
-    int   chamber_; 
-    int   station_; 
-    int   nStrips_;
-    int   hitWire_;
-    int   wgroupsBX_; 
-    int   nWireGroups_;
- 
+    float z_;
+    float tPeak_;
+    float tWire_;
+    int quality_;
+    int chamber_;
+    int station_;
+    int nStrips_;
+    int hitWire_;
+    int wgroupsBX_;
+    int nWireGroups_;
   };
 
-   typedef std::vector<CSCJetCandidate> CSCJetCandidateCollection;
-}
+  typedef std::vector<CSCJetCandidate> CSCJetCandidateCollection;
+}  // namespace reco
 #endif

--- a/DataFormats/CSCRecHit/src/CSCJetCandidate.cc
+++ b/DataFormats/CSCRecHit/src/CSCJetCandidate.cc
@@ -1,14 +1,19 @@
 #include "DataFormats/CSCRecHit/interface/CSCJetCandidate.h"
 
-
-reco::CSCJetCandidate:CSCJetCandidate(double phi, double eta, double x,double y, double z,double t);
-             LeafCandidate(0,LorentzVector(math::PtEtaPhiMLorentzVector(1.0,eta(),phi(),0)),Point(x,y,z)) {
-
-    phi_ = phi;
-    eta_ = eta;
-    x_   = x;
+/*
+ * Create LeafCandidate with (eta,phi) only as CSC rechits has no energy/momentum measurement
+ * Energy is set to 1.0 as a place holder, mass is set at 0.
+ * Vertex associated with the CSC rechit is set to the origin.
+ *
+ */
+reco::CSCJetCandidate::CSCJetCandidate(double phi, double eta, double x,double y, double z,double tPeak, double tWire):
+             LeafCandidate(0,LorentzVector(math::PtEtaPhiMLorentzVector(1.0,eta,phi,0)),Point(0,0,0)) {
+    
+    x_ = x;
     y_ = y;
     z_ = z;
+    tPeak_ = tPeak;
+    tWire_ = tWire;
 }
 
 reco::CSCJetCandidate::~CSCJetCandidate() {

--- a/DataFormats/CSCRecHit/src/CSCJetCandidate.cc
+++ b/DataFormats/CSCRecHit/src/CSCJetCandidate.cc
@@ -1,0 +1,16 @@
+#include "DataFormats/CSCRecHit/interface/CSCJetCandidate.h"
+
+
+reco::CSCJetCandidate:CSCJetCandidate(double phi, double eta, double x,double y, double z,double t);
+             LeafCandidate(0,LorentzVector(math::PtEtaPhiMLorentzVector(1.0,eta(),phi(),0)),Point(x,y,z)) {
+
+    phi_ = phi;
+    eta_ = eta;
+    x_   = x;
+    y_ = y;
+    z_ = z;
+}
+
+reco::CSCJetCandidate::~CSCJetCandidate() {
+
+}

--- a/DataFormats/CSCRecHit/src/CSCJetCandidate.cc
+++ b/DataFormats/CSCRecHit/src/CSCJetCandidate.cc
@@ -2,11 +2,12 @@
 
 /*
  * Create LeafCandidate with (eta,phi) only as CSC rechits has no energy/momentum measurement
- * Energy is set to 1.0 as a place holder, mass is set at 0.
+ * Pt is set to 1.0 as a place holder, mass is set at 0.
  * Vertex associated with the CSC rechit is set to the origin.
  *
  */
-reco::CSCJetCandidate::CSCJetCandidate(double phi, double eta, double x,double y, double z,double tPeak, double tWire):
+reco::CSCJetCandidate::CSCJetCandidate(double phi, double eta, float x,float y, float z,float tPeak, float tWire,
+                                       int quality, int chamber, int station, int nStrips, int hitWire, int wgroupsBX, int nWireGroups):
              LeafCandidate(0,LorentzVector(math::PtEtaPhiMLorentzVector(1.0,eta,phi,0)),Point(0,0,0)) {
     
     x_ = x;
@@ -14,6 +15,14 @@ reco::CSCJetCandidate::CSCJetCandidate(double phi, double eta, double x,double y
     z_ = z;
     tPeak_ = tPeak;
     tWire_ = tWire;
+    quality_      =    quality;     
+    chamber_      =    chamber; 
+    station_      =    station; 
+    nStrips_      =    nStrips;
+    hitWire_      =    hitWire;
+    wgroupsBX_    =    wgroupsBX; 
+    nWireGroups_  =    nWireGroups;
+
 }
 
 reco::CSCJetCandidate::~CSCJetCandidate() {

--- a/DataFormats/CSCRecHit/src/CSCJetCandidate.cc
+++ b/DataFormats/CSCRecHit/src/CSCJetCandidate.cc
@@ -6,25 +6,33 @@
  * Vertex associated with the CSC rechit is set to the origin.
  *
  */
-reco::CSCJetCandidate::CSCJetCandidate(double phi, double eta, float x,float y, float z,float tPeak, float tWire,
-                                       int quality, int chamber, int station, int nStrips, int hitWire, int wgroupsBX, int nWireGroups):
-             LeafCandidate(0,LorentzVector(math::PtEtaPhiMLorentzVector(1.0,eta,phi,0)),Point(0,0,0)) {
-    
-    x_ = x;
-    y_ = y;
-    z_ = z;
-    tPeak_ = tPeak;
-    tWire_ = tWire;
-    quality_      =    quality;     
-    chamber_      =    chamber; 
-    station_      =    station; 
-    nStrips_      =    nStrips;
-    hitWire_      =    hitWire;
-    wgroupsBX_    =    wgroupsBX; 
-    nWireGroups_  =    nWireGroups;
-
+reco::CSCJetCandidate::CSCJetCandidate(double phi,
+                                       double eta,
+                                       float x,
+                                       float y,
+                                       float z,
+                                       float tPeak,
+                                       float tWire,
+                                       int quality,
+                                       int chamber,
+                                       int station,
+                                       int nStrips,
+                                       int hitWire,
+                                       int wgroupsBX,
+                                       int nWireGroups)
+    : LeafCandidate(0, LorentzVector(math::PtEtaPhiMLorentzVector(1.0, eta, phi, 0)), Point(0, 0, 0)) {
+  x_ = x;
+  y_ = y;
+  z_ = z;
+  tPeak_ = tPeak;
+  tWire_ = tWire;
+  quality_ = quality;
+  chamber_ = chamber;
+  station_ = station;
+  nStrips_ = nStrips;
+  hitWire_ = hitWire;
+  wgroupsBX_ = wgroupsBX;
+  nWireGroups_ = nWireGroups;
 }
 
-reco::CSCJetCandidate::~CSCJetCandidate() {
-
-}
+reco::CSCJetCandidate::~CSCJetCandidate() {}

--- a/DataFormats/CSCRecHit/src/classes.h
+++ b/DataFormats/CSCRecHit/src/classes.h
@@ -1,6 +1,8 @@
 #include <DataFormats/CSCRecHit/interface/CSCRecHit2D.h>
 #include <DataFormats/CSCRecHit/interface/CSCRecHit2DCollection.h>
 
+#include <DataFormats/CSCRecHit/interface/CSCJetCandidate.h>
+
 #include <DataFormats/CSCRecHit/interface/CSCSegment.h>
 #include <DataFormats/CSCRecHit/interface/CSCSegmentCollection.h>
 

--- a/DataFormats/CSCRecHit/src/classes_def.xml
+++ b/DataFormats/CSCRecHit/src/classes_def.xml
@@ -17,7 +17,8 @@
   <class name="edm::ClonePolicy<CSCRecHit2D>"/> <!-- Root6 -->
   <class name="edm::RangeMap<CSCDetId,edm::OwnVector<CSCRecHit2D,edm::ClonePolicy<CSCRecHit2D> >,edm::ClonePolicy<CSCRecHit2D> >"/>
   <class name="edm::Wrapper<edm::RangeMap<CSCDetId,edm::OwnVector<CSCRecHit2D,edm::ClonePolicy<CSCRecHit2D> >,edm::ClonePolicy<CSCRecHit2D> > >"/>
-
+  <class name="CSCJetCandidate"/>
+  <class name="std::vector<CSCJetCandidate>"/>
   <class name="std::vector<CSCSegment>"/>
   <class name="std::vector<CSCSegment*>"/>
   <class name="CSCSegment" ClassVersion="11">

--- a/DataFormats/CSCRecHit/src/classes_def.xml
+++ b/DataFormats/CSCRecHit/src/classes_def.xml
@@ -17,8 +17,9 @@
   <class name="edm::ClonePolicy<CSCRecHit2D>"/> <!-- Root6 -->
   <class name="edm::RangeMap<CSCDetId,edm::OwnVector<CSCRecHit2D,edm::ClonePolicy<CSCRecHit2D> >,edm::ClonePolicy<CSCRecHit2D> >"/>
   <class name="edm::Wrapper<edm::RangeMap<CSCDetId,edm::OwnVector<CSCRecHit2D,edm::ClonePolicy<CSCRecHit2D> >,edm::ClonePolicy<CSCRecHit2D> > >"/>
-  <class name="reco::CSCJetCandidate" ClassVersion="3">
+  <class name="reco::CSCJetCandidate" ClassVersion="4">
     <version ClassVersion="3" checksum="1185432696"/>
+    <version ClassVersion="4" checksum="882507185"/>
   </class>
   <class name="std::vector<reco::CSCJetCandidate>"/>
   <class name="edm::Wrapper<std::vector<reco::CSCJetCandidate>>"/>

--- a/DataFormats/CSCRecHit/src/classes_def.xml
+++ b/DataFormats/CSCRecHit/src/classes_def.xml
@@ -17,9 +17,11 @@
   <class name="edm::ClonePolicy<CSCRecHit2D>"/> <!-- Root6 -->
   <class name="edm::RangeMap<CSCDetId,edm::OwnVector<CSCRecHit2D,edm::ClonePolicy<CSCRecHit2D> >,edm::ClonePolicy<CSCRecHit2D> >"/>
   <class name="edm::Wrapper<edm::RangeMap<CSCDetId,edm::OwnVector<CSCRecHit2D,edm::ClonePolicy<CSCRecHit2D> >,edm::ClonePolicy<CSCRecHit2D> > >"/>
-  <class name="CSCJetCandidate"/>
-  <class name="std::vector<CSCJetCandidate>"/>
-  <class name="std::vector<CSCSegment>"/>
+  <class name="reco::CSCJetCandidate" ClassVersion="3">
+    <version ClassVersion="3" checksum="1185432696"/>
+  </class>
+  <class name="std::vector<reco::CSCJetCandidate>"/>
+  <class name="edm::Wrapper<std::vector<reco::CSCJetCandidate>>"/>
   <class name="std::vector<CSCSegment*>"/>
   <class name="CSCSegment" ClassVersion="11">
    <version ClassVersion="11" checksum="160361831"/>

--- a/RecoLocalMuon/CSCRecHitD/src/CSCJetCandidateProducer.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCJetCandidateProducer.cc
@@ -13,16 +13,14 @@
 #include <DataFormats/CSCRecHit/interface/CSCRecHit2DCollection.h>
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 
-CSCJetCandidateProducer::CSCJetCandidateProducer(const edm::ParameterSet& ps)
-{
+CSCJetCandidateProducer::CSCJetCandidateProducer(const edm::ParameterSet& ps) {
   cscRechitInputToken_ = consumes<CSCRecHit2DCollection>(edm::InputTag("csc2DRecHits")),
 
   // register what this produces
-  produces<CSCJetCandidateCollection>();
+      produces<CSCJetCandidateCollection>();
 }
 
-CSCJetCandidateProducer::~CSCJetCandidateProducer() {
-}
+CSCJetCandidateProducer::~CSCJetCandidateProducer() {}
 
 void CSCJetCandidateProducer::produce(edm::Event& ev, const edm::EventSetup& setup) {
   LogTrace("CSCRecHit") << "[CSCJetCandidateProducer] starting event ";
@@ -31,7 +29,7 @@ void CSCJetCandidateProducer::produce(edm::Event& ev, const edm::EventSetup& set
   edm::Handle<CSCRecHit2DCollection> cscRechits;
 
   setup.get<MuonGeometryRecord>().get(cscG);
-  ev.getByToken(cscRechitInputToken_,cscRechits);
+  ev.getByToken(cscRechitInputToken_, cscRechits);
 
   // Create empty collection of rechits
   auto oc = std::make_unique<CSCJetCandidateCollection>();
@@ -39,37 +37,36 @@ void CSCJetCandidateProducer::produce(edm::Event& ev, const edm::EventSetup& set
   // Put collection in event
   LogTrace("CSCRecHit") << "[CSCJetCandidateProducer] putting collection of " << oc->size() << " rechits into event.";
 
-  for (const CSCRecHit2D cscRechit : *cscRechits) {
-    LocalPoint  cscRecHitLocalPosition       = cscRechit.localPosition();
+  for (const CSCRecHit2D& cscRechit : *cscRechits) {
+    LocalPoint cscRecHitLocalPosition = cscRechit.localPosition();
     CSCDetId cscdetid = cscRechit.cscDetId();
     int endcap = CSCDetId::endcap(cscdetid) == 1 ? 1 : -1;
     const CSCChamber* cscchamber = cscG->chamber(cscdetid);
     if (cscchamber) {
-        GlobalPoint globalPosition = cscchamber->toGlobal(cscRecHitLocalPosition);
+      GlobalPoint globalPosition = cscchamber->toGlobal(cscRecHitLocalPosition);
 
-        float x = globalPosition.x();
-        float y = globalPosition.y();
-        float z = globalPosition.z();
-        double phi = globalPosition.phi();
-        double eta = globalPosition.eta();
-        float tpeak    = cscRechit.tpeak();
-        float wireTime = cscRechit.wireTime();
-        int  quality = cscRechit.quality();
-        int  chamber =  endcap * (CSCDetId::station(cscdetid)*10 + CSCDetId::ring(cscdetid));
-        int station  = endcap *CSCDetId::station(cscdetid);
-        int nStrips  = cscRechit.nStrips();
-        int hitWire  = cscRechit.hitWire();
-        int wgroupsBX = cscRechit.wgroupsBX();
-        int nWireGroups = cscRechit.nWireGroups();
+      float x = globalPosition.x();
+      float y = globalPosition.y();
+      float z = globalPosition.z();
+      double phi = globalPosition.phi();
+      double eta = globalPosition.eta();
+      float tpeak = cscRechit.tpeak();
+      float wireTime = cscRechit.wireTime();
+      int quality = cscRechit.quality();
+      int chamber = endcap * (CSCDetId::station(cscdetid) * 10 + CSCDetId::ring(cscdetid));
+      int station = endcap * CSCDetId::station(cscdetid);
+      int nStrips = cscRechit.nStrips();
+      int hitWire = cscRechit.hitWire();
+      int wgroupsBX = cscRechit.wgroupsBX();
+      int nWireGroups = cscRechit.nWireGroups();
 
-
-        reco::CSCJetCandidate rh(phi, eta, x ,y,z,tpeak,wireTime,quality,chamber, station, nStrips, hitWire,wgroupsBX,nWireGroups);
-        oc->push_back(rh);
+      reco::CSCJetCandidate rh(
+          phi, eta, x, y, z, tpeak, wireTime, quality, chamber, station, nStrips, hitWire, wgroupsBX, nWireGroups);
+      oc->push_back(rh);
     }
   }
   ev.put(std::move(oc));
 }
-
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(CSCJetCandidateProducer);

--- a/RecoLocalMuon/CSCRecHitD/src/CSCJetCandidateProducer.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCJetCandidateProducer.cc
@@ -1,0 +1,65 @@
+#include <RecoLocalMuon/CSCRecHitD/src/CSCJetCandidateProducer.h>
+
+#include <FWCore/Framework/interface/Frameworkfwd.h>
+#include <FWCore/Framework/interface/EDProducer.h>
+#include <FWCore/Framework/interface/Event.h>
+#include <FWCore/Framework/interface/MakerMacros.h>
+#include <DataFormats/Common/interface/Handle.h>
+#include <FWCore/Framework/interface/ESHandle.h>
+#include <FWCore/ParameterSet/interface/ParameterSet.h>
+#include <FWCore/Utilities/interface/Exception.h>
+#include <FWCore/MessageLogger/interface/MessageLogger.h>
+
+#include <DataFormats/CSCRecHit/interface/CSCRecHit2DCollection.h>
+
+CSCJetCandidateProducer::CSCJetCandidateProducer(const edm::ParameterSet& ps)
+{
+  cscRechitInputToken_ = consumes<CSCRecHit2DCollection>(edm::InputTag("csc2DRecHits")),
+
+  // register what this produces
+  produces<CSCJetCandidateCollection>();
+}
+
+CSCJetCandidateProducer::~CSCJetCandidateProducer() {
+}
+
+void CSCJetCandidateProducer::produce(edm::Event& ev, const edm::EventSetup& setup) {
+  LogTrace("CSCRecHit") << "[CSCJetCandidateProducer] starting event ";
+
+  edm::Handle<CSCRecHit2DCollection> cscRechits;
+
+  ev.getByToken(cscRechitInputToken_,cscRechits);
+
+  // Create empty collection of rechits
+  auto oc = std::make_unique<CSCJetCandidateCollection>();
+
+  // Put collection in event
+  LogTrace("CSCRecHit") << "[CSCJetCandidateProducer] putting collection of " << oc->size() << " rechits into event.";
+
+  for (const CSCRecHit2D cscRechit : *cscRechits) {
+    LocalPoint  cscRecHitLocalPosition       = cscRechit.localPosition();
+    CSCDetId cscdetid = cscRechit.cscDetId();
+    cscRechitsDetId[ncscRechits] = CSCDetId::rawIdMaker(CSCDetId::endcap(cscdetid), CSCDetId::station(cscdetid), CSCDetId::ring(cscdetid), CSCDetId::chamber(cscdetid), CSCDetId::layer(cscdetid));
+    int endcap = CSCDetId::endcap(cscdetid) == 1 ? 1 : -1;
+    const CSCChamber* cscchamber = cscG->chamber(cscdetid);
+    if (cscchamber) {
+        GlobalPoint globalPosition = cscchamber->toGlobal(cscRecHitLocalPosition);
+
+        double x = globalPosition.x();
+        double y = globalPosition.y();
+        double z = globalPosition.z();
+        double phi = globalPosition.phi();
+        double eta = globalPosition.eta();
+        double tpeak    = cscRechit.tpeak();
+        double wireTime = cscRechit.wireTime();
+
+        CSCJetCandidate rh = (phi, eta, x ,y,z,tpeak,wireTime);
+        oc.push_back(rh)
+    }
+  }
+  ev.put(std::move(oc));
+}
+
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(CSCJetCandidateProducer);

--- a/RecoLocalMuon/CSCRecHitD/src/CSCJetCandidateProducer.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCJetCandidateProducer.cc
@@ -47,15 +47,23 @@ void CSCJetCandidateProducer::produce(edm::Event& ev, const edm::EventSetup& set
     if (cscchamber) {
         GlobalPoint globalPosition = cscchamber->toGlobal(cscRecHitLocalPosition);
 
-        double x = globalPosition.x();
-        double y = globalPosition.y();
-        double z = globalPosition.z();
+        float x = globalPosition.x();
+        float y = globalPosition.y();
+        float z = globalPosition.z();
         double phi = globalPosition.phi();
         double eta = globalPosition.eta();
-        double tpeak    = cscRechit.tpeak();
-        double wireTime = cscRechit.wireTime();
+        float tpeak    = cscRechit.tpeak();
+        float wireTime = cscRechit.wireTime();
+        int  quality = cscRechit.quality();
+        int  chamber =  endcap * (CSCDetId::station(cscdetid)*10 + CSCDetId::ring(cscdetid));
+        int station  = endcap *CSCDetId::station(cscdetid);
+        int nStrips  = cscRechit.nStrips();
+        int hitWire  = cscRechit.hitWire();
+        int wgroupsBX = cscRechit.wgroupsBX();
+        int nWireGroups = cscRechit.nWireGroups();
 
-        reco::CSCJetCandidate rh(phi, eta, x ,y,z,tpeak,wireTime);
+
+        reco::CSCJetCandidate rh(phi, eta, x ,y,z,tpeak,wireTime,quality,chamber, station, nStrips, hitWire,wgroupsBX,nWireGroups);
         oc->push_back(rh);
     }
   }

--- a/RecoLocalMuon/CSCRecHitD/src/CSCJetCandidateProducer.h
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCJetCandidateProducer.h
@@ -1,0 +1,39 @@
+#ifndef CSCRecHitD_CSCJetCandidateProducer_h
+#define CSCRecHitD_CSCJetCandidateProducer_h
+
+/** \class CSCJetCandidateProducer 
+ *
+ * Produces a collection of CSCJetCandidate's (2D CSC RecHits as JetCandidates)
+ * \author Martin Kwok
+ *
+ */
+
+#include <FWCore/Framework/interface/ConsumesCollector.h>
+#include <FWCore/Framework/interface/Frameworkfwd.h>
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include <FWCore/Framework/interface/Event.h>
+#include <FWCore/ParameterSet/interface/ParameterSet.h>
+#include <FWCore/Utilities/interface/InputTag.h>
+#include <FWCore/Utilities/interface/ESGetToken.h>
+
+#include "DataFormats/CSCRecHit/interface/CSCSegmentCollection.h"
+#include "DataFormats/CSCRecHit/interface/CSCJetCandidate.h"
+#include "Geometry/CSCGeometry/interface/CSCGeometry.h"
+#include "DataFormats/MuonDetId/interface/CSCDetId.h"
+
+
+
+class CSCJetCandidateProducer : public edm::stream::EDProducer<> {
+public:
+  explicit CSCJetCandidateProducer(const edm::ParameterSet& ps);
+  ~CSCJetCandidateProducer() override;
+
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
+
+private:
+
+  edm::EDGetTokenT<CSCRecHit2DCollection> cscRechitInputToken_;
+};
+
+#endif

--- a/RecoLocalMuon/CSCRecHitD/src/CSCJetCandidateProducer.h
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCJetCandidateProducer.h
@@ -21,8 +21,6 @@
 #include "Geometry/CSCGeometry/interface/CSCGeometry.h"
 #include "DataFormats/MuonDetId/interface/CSCDetId.h"
 
-
-
 class CSCJetCandidateProducer : public edm::stream::EDProducer<> {
 public:
   explicit CSCJetCandidateProducer(const edm::ParameterSet& ps);
@@ -30,9 +28,7 @@ public:
 
   void produce(edm::Event&, const edm::EventSetup&) override;
 
-
 private:
-
   edm::EDGetTokenT<CSCRecHit2DCollection> cscRechitInputToken_;
   typedef std::vector<reco::CSCJetCandidate> CSCJetCandidateCollection;
 };

--- a/RecoLocalMuon/CSCRecHitD/src/CSCJetCandidateProducer.h
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCJetCandidateProducer.h
@@ -34,6 +34,7 @@ public:
 private:
 
   edm::EDGetTokenT<CSCRecHit2DCollection> cscRechitInputToken_;
+  typedef std::vector<reco::CSCJetCandidate> CSCJetCandidateCollection;
 };
 
 #endif


### PR DESCRIPTION
#### PR description:


This PR adds a new class `CSCJetCandidate` that builds from `CSCRecHit2D` and conform to `Reco::Candidate` format. 
The new collection can be used for running jet algorithms on CSC rechits. 
This is an essential ingredient for an HLT path for LLP in Run 3. 

[Presentation at Reco meeting, Oct 1](https://indico.cern.ch/event/1080450/contributions/4548741/attachments/2320995/3952292/MuonShower_Oct1_Martin.pdf
)
<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:
```
runTheMatrix.py -l limited -i all --ibeos
31 0 0 0 0 0 0 0 0 tests passed, 8 31 0 0 0 0 0 0 0 failed
```

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->


