### PR TITLE
[UBSAN] initialize EcalEBTrigPrimTestAlgo::theMapping_ data member

### DIFF
--- a/SimCalorimetry/EcalEBTrigPrimAlgos/src/EcalEBTrigPrimTestAlgo.cc
+++ b/SimCalorimetry/EcalEBTrigPrimAlgos/src/EcalEBTrigPrimTestAlgo.cc
@@ -54,8 +54,7 @@ EcalEBTrigPrimTestAlgo::EcalEBTrigPrimTestAlgo(const EcalTrigTowerConstituentsMa
       tcpFormat_(tcpFormat),
       barrelOnly_(false),
       debug_(debug),
-      famos_(famos)
-{
+      famos_(famos) {
   maxNrSamples_ = 10;
   this->init();
 }

--- a/SimCalorimetry/EcalEBTrigPrimAlgos/src/EcalEBTrigPrimTestAlgo.cc
+++ b/SimCalorimetry/EcalEBTrigPrimAlgos/src/EcalEBTrigPrimTestAlgo.cc
@@ -55,7 +55,6 @@ EcalEBTrigPrimTestAlgo::EcalEBTrigPrimTestAlgo(const EcalTrigTowerConstituentsMa
       barrelOnly_(false),
       debug_(debug),
       famos_(famos)
-
 {
   maxNrSamples_ = 10;
   this->init();
@@ -78,6 +77,7 @@ EcalEBTrigPrimTestAlgo::EcalEBTrigPrimTestAlgo(int nSam, int binofmax, bool tcpF
 //----------------------------------------------------------------------
 void EcalEBTrigPrimTestAlgo::init() {
   // initialise data structures
+  theMapping_ = new EcalElectronicsMapping();
   initStructures(towerMapEB_);
   hitTowers_.resize(maxNrTowers_);
 
@@ -115,6 +115,7 @@ EcalEBTrigPrimTestAlgo::~EcalEBTrigPrimTestAlgo() {
   delete peak_finder_;
   delete fenixFormatterEB_;
   delete fenixTcpFormat_;
+  delete theMapping_;
 }
 
 void EcalEBTrigPrimTestAlgo::run(EBDigiCollection const *digi,


### PR DESCRIPTION
EcalEBTrigPrimTestAlgo::theMapping_ data member was never initialized which is causes UBSAN runtime errors mentioned https://github.com/cms-sw/cmssw/issues/35538. This PR proposes to initialize the data member. Local build of this change in UBSAN shows that it fixes the #35538 .
fixes #35538 