### PR TITLE
Replace tags that have [cms_orcon_prod/...] in their name

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,27 +2,27 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'                  : '121X_mcRun1_design_v5',
+    'run1_design'                  : '121X_mcRun1_design_v6',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'                      : '121X_mcRun1_realistic_v5',
+    'run1_mc'                      : '121X_mcRun1_realistic_v6',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'                   : '121X_mcRun1_HeavyIon_v6',
+    'run1_mc_hi'                   : '121X_mcRun1_HeavyIon_v7',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'                 : '121X_mcRun2_startup_v5',
+    'run2_mc_50ns'                 : '121X_mcRun2_startup_v6',
     # GlobalTag for MC production (2015 L1 Trigger Stage1) with startup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
-    'run2_mc_l1stage1'             : '121X_mcRun2_asymptotic_l1stage1_v5',
+    'run2_mc_l1stage1'             : '121X_mcRun2_asymptotic_l1stage1_v6',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'                  : '121X_mcRun2_design_v5',
+    'run2_design'                  : '121X_mcRun2_design_v6',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, prior to VFP change
-    'run2_mc_pre_vfp'              : '121X_mcRun2_asymptotic_preVFP_v5',
+    'run2_mc_pre_vfp'              : '121X_mcRun2_asymptotic_preVFP_v6',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, after VFP change
-    'run2_mc'                      : '121X_mcRun2_asymptotic_v5',
+    'run2_mc'                      : '121X_mcRun2_asymptotic_v6',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'              : '121X_mcRun2cosmics_asymptotic_deco_v5',
+    'run2_mc_cosmics'              : '121X_mcRun2cosmics_asymptotic_deco_v6',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'                   : '121X_mcRun2_HeavyIon_v5',
+    'run2_mc_hi'                   : '121X_mcRun2_HeavyIon_v6',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'                   : '121X_mcRun2_pA_v5',
+    'run2_mc_pa'                   : '121X_mcRun2_pA_v6',
     # GlobalTag for Run2 data reprocessing
     'run2_data'                    : '121X_dataRun2_v5',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
@@ -42,43 +42,43 @@ autoCond = {
     # GlobalTag for Run3 offline data reprocessing
     'run3_data'                    : '121X_dataRun3_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'           : '121X_mc2017_design_v5',
+    'phase1_2017_design'           : '121X_mc2017_design_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'        : '121X_mc2017_realistic_v5',
+    'phase1_2017_realistic'        : '121X_mc2017_realistic_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector, for PP reference run
     'phase1_2017_realistic_ppref'  :  '120X_mc2017_realistic_forppRef5TeV_v2',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'          : '121X_mc2017cosmics_realistic_deco_v5',
+    'phase1_2017_cosmics'          : '121X_mc2017cosmics_realistic_deco_v6',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak'     : '121X_mc2017cosmics_realistic_peak_v5',
+    'phase1_2017_cosmics_peak'     : '121X_mc2017cosmics_realistic_peak_v6',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'           : '121X_upgrade2018_design_v5',
+    'phase1_2018_design'           : '121X_upgrade2018_design_v6',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'        : '121X_upgrade2018_realistic_v5',
+    'phase1_2018_realistic'        : '121X_upgrade2018_realistic_v6',
     # GlobalTag for MC production with realistic run-dependent (RD) conditions for full Phase1 2018 detector
-    'phase1_2018_realistic_rd'     : '121X_upgrade2018_realistic_RD_v5',
+    'phase1_2018_realistic_rd'     : '121X_upgrade2018_realistic_RD_v6',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi'     : '121X_upgrade2018_realistic_HI_v5',
+    'phase1_2018_realistic_hi'     : '121X_upgrade2018_realistic_HI_v6',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' : '121X_upgrade2018_realistic_HEfail_v5',
+    'phase1_2018_realistic_HEfail' : '121X_upgrade2018_realistic_HEfail_v6',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'          : '121X_upgrade2018cosmics_realistic_deco_v7',
+    'phase1_2018_cosmics'          : '121X_upgrade2018cosmics_realistic_deco_v8',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak'     : '121X_upgrade2018cosmics_realistic_peak_v5',
+    'phase1_2018_cosmics_peak'     : '121X_upgrade2018cosmics_realistic_peak_v6',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'           : '121X_mcRun3_2021_design_v9',
+    'phase1_2021_design'           : '121X_mcRun3_2021_design_v10',
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'        : '121X_mcRun3_2021_realistic_v10',
+    'phase1_2021_realistic'        : '121X_mcRun3_2021_realistic_v11',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'          : '121X_mcRun3_2021cosmics_realistic_deco_v10',
+    'phase1_2021_cosmics'          : '121X_mcRun3_2021cosmics_realistic_deco_v11',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi'     : '121X_mcRun3_2021_realistic_HI_v10',
+    'phase1_2021_realistic_hi'     : '121X_mcRun3_2021_realistic_HI_v11',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '121X_mcRun3_2023_realistic_v9',
+    'phase1_2023_realistic'        : '121X_mcRun3_2023_realistic_v10',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '121X_mcRun3_2024_realistic_v9',
+    'phase1_2024_realistic'        : '121X_mcRun3_2024_realistic_v10',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             : '121X_mcRun4_realistic_v5'
+    'phase2_realistic'             : '121X_mcRun4_realistic_v6'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:

The following tags in the autoCond GTs that have the string  [cms_orcon_prod/...] in their name:
```
CSCBadChambers_empty_mc[cms_orcon_prod/CMS_COND_CSC_000]
L1RPCHwConfig_v1[cms_orcon_prod/CMS_COND_36X_RPC]
RPCStripNoises_v1_mc[cms_orcon_prod/CMS_COND_31X_RPC] SiPixelGenErrorDBObject_38T_v1_mc[cms_orcon_prod/CMS_COND_PIXEL_000]         
SiPixelLorentzAngle_forWidth_v1_mc[cms_orcon_prod/CMS_COND_31X_PIXEL]        
SiPixelLorentzAngle_fromAlignment_v1_mc[cms_orcon_prod/CMS_COND_31X_PIXEL]  
```

The tags without this string were queued to the respective Queues and the following GTs were created, also showing the diff wrt to the previous GT:
* 121X_mcRun1_design_v6
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun1_design_v5/121X_mcRun1_design_v6
* 121X_mcRun1_realistic_v6
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun1_realistic_v5/121X_mcRun1_realistic_v6
* 121X_mcRun1_HeavyIon_v7
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun1_HeavyIon_v6/121X_mcRun1_HeavyIon_v7
* 121X_mcRun2_startup_v6
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun2_startup_v5/121X_mcRun2_startup_v6
* 121X_mcRun2_asymptotic_l1stage1_v6
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun2_asymptotic_l1stage1_v5/121X_mcRun2_asymptotic_l1stage1_v6
* 121X_mcRun2_design_v6
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun2_design_v5/121X_mcRun2_design_v6
* 121X_mcRun2_asymptotic_preVFP_v6
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun2_asymptotic_preVFP_v5/121X_mcRun2_asymptotic_preVFP_v6
* 121X_mcRun2_asymptotic_v6
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun2_asymptotic_v5/121X_mcRun2_asymptotic_v6
* 121X_mcRun2cosmics_asymptotic_deco_v6
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun2cosmics_asymptotic_deco_v5/121X_mcRun2cosmics_asymptotic_deco_v6
* 121X_mcRun2_HeavyIon_v6
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun2_HeavyIon_v5/121X_mcRun2_HeavyIon_v6
* 121X_mcRun2_pA_v6
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun2_pA_v5/121X_mcRun2_pA_v6
* 121X_mc2017_design_v6
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mc2017_design_v5/121X_mc2017_design_v6
* 121X_mc2017_realistic_v6
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mc2017_realistic_v5/121X_mc2017_realistic_v6
* 121X_mc2017cosmics_realistic_deco_v6
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mc2017cosmics_realistic_deco_v5/121X_mc2017cosmics_realistic_deco_v6
* 121X_mc2017cosmics_realistic_peak_v6
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mc2017cosmics_realistic_peak_v5/121X_mc2017cosmics_realistic_peak_v6
* 121X_upgrade2018_design_v6
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_upgrade2018_design_v5/121X_upgrade2018_design_v6
* 121X_upgrade2018_realistic_v6
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_upgrade2018_realistic_v5/121X_upgrade2018_realistic_v6
* 121X_upgrade2018_realistic_RD_v6
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_upgrade2018_realistic_RD_v5/121X_upgrade2018_realistic_RD_v6
* 121X_upgrade2018_realistic_HI_v6
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_upgrade2018_realistic_HI_v5/121X_upgrade2018_realistic_HI_v6
* 121X_upgrade2018_realistic_HEfail_v6
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_upgrade2018_realistic_HEfail_v5/121X_upgrade2018_realistic_HEfail_v6
* 121X_upgrade2018cosmics_realistic_deco_v8
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_upgrade2018cosmics_realistic_deco_v7/121X_upgrade2018cosmics_realistic_deco_v8
* 121X_upgrade2018cosmics_realistic_peak_v6
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_upgrade2018cosmics_realistic_peak_v5/121X_upgrade2018cosmics_realistic_peak_v6
* 121X_mcRun3_2021_design_v10
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021_design_v9/121X_mcRun3_2021_design_v10
* 121X_mcRun3_2021_realistic_v11
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021_realistic_v10/121X_mcRun3_2021_realistic_v11
* 121X_mcRun3_2021cosmics_realistic_deco_v11
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021cosmics_realistic_deco_v10/121X_mcRun3_2021cosmics_realistic_deco_v11
* 121X_mcRun3_2021_realistic_HI_v11
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021_realistic_HI_v10/121X_mcRun3_2021_realistic_HI_v11
* 121X_mcRun3_2023_realistic_v10
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2023_realistic_v9/121X_mcRun3_2023_realistic_v10
* 121X_mcRun3_2024_realistic_v10
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2024_realistic_v9/121X_mcRun3_2024_realistic_v10
* 121X_mcRun4_realistic_v6
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun4_realistic_v5/121X_mcRun4_realistic_v6

This is the HN link:

https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4484.html

And this PR also resolves https://github.com/cms-AlCaDB/AlCaTools/issues/32 
#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not a backport and no backport is expected.
