### PR TITLE
PPS: use Run3 era in online DQM

### DIFF
--- a/DQM/Integration/python/clients/ctpps_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ctpps_dqm_sourceclient-live_cfg.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 import sys
-from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
-process = cms.Process('CTPPSDQM', Run2_2018)
+from Configuration.Eras.Era_Run3_cff import Run3
+process = cms.Process('CTPPSDQM', Run3)
 
 test = False
 unitTest = False


### PR DESCRIPTION
#### PR description:

The era modifier used in online DQM config of PPS is updated to `Run3`. This is a bug fix - currently `Run2_2018` is used.

#### PR validation:

The following command
`cmsRun DQM/Integration/python/clients/ctpps_dqm_sourceclient-live_cfg.py`
was executed on LXPLUS. The process runs without errors (but obviously it cannot find input data).

