### PR TITLE
Renamed new methods in PoolDBOutputService

### DIFF
--- a/CalibCalorimetry/CaloMiscalibTools/plugins/WriteEcalMiscalibConstants.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/plugins/WriteEcalMiscalibConstants.cc
@@ -58,8 +58,7 @@ void WriteEcalMiscalibConstants::analyze(const edm::Event& iEvent, const edm::Ev
       edm::LogVerbatim("WriteEcalMiscalibConstants") << "Done";
     } else {
       edm::LogVerbatim("WriteEcalMiscalibConstants") << "Old IOV";
-      poolDbService->appendOneIOV<const EcalIntercalibConstants>(
-          *Mcal, poolDbService->currentTime(), newTagRequest_);
+      poolDbService->appendOneIOV<const EcalIntercalibConstants>(*Mcal, poolDbService->currentTime(), newTagRequest_);
     }
   }
 }

--- a/CalibCalorimetry/CaloMiscalibTools/plugins/WriteEcalMiscalibConstants.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/plugins/WriteEcalMiscalibConstants.cc
@@ -54,11 +54,11 @@ void WriteEcalMiscalibConstants::analyze(const edm::Event& iEvent, const edm::Ev
   if (poolDbService.isAvailable()) {
     if (poolDbService->isNewTagRequest(newTagRequest_)) {
       edm::LogVerbatim("WriteEcalMiscalibConstants") << "Creating a new IOV";
-      poolDbService->createNewIOV<const EcalIntercalibConstants>(*Mcal, poolDbService->beginOfTime(), newTagRequest_);
+      poolDbService->createOneIOV<const EcalIntercalibConstants>(*Mcal, poolDbService->beginOfTime(), newTagRequest_);
       edm::LogVerbatim("WriteEcalMiscalibConstants") << "Done";
     } else {
       edm::LogVerbatim("WriteEcalMiscalibConstants") << "Old IOV";
-      poolDbService->appendSinceTime<const EcalIntercalibConstants>(
+      poolDbService->appendOneIOV<const EcalIntercalibConstants>(
           *Mcal, poolDbService->currentTime(), newTagRequest_);
     }
   }

--- a/CalibCalorimetry/CaloMiscalibTools/plugins/WriteEcalMiscalibConstantsMC.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/plugins/WriteEcalMiscalibConstantsMC.cc
@@ -54,11 +54,11 @@ void WriteEcalMiscalibConstantsMC::analyze(const edm::Event& iEvent, const edm::
   if (poolDbService.isAvailable()) {
     if (poolDbService->isNewTagRequest(newTagRequest_)) {
       edm::LogVerbatim("WriteEcalMiscalibConstantsMC") << "Creating a new IOV";
-      poolDbService->createNewIOV<const EcalIntercalibConstantsMC>(*Mcal, poolDbService->beginOfTime(), newTagRequest_);
+      poolDbService->createOneIOV<const EcalIntercalibConstantsMC>(*Mcal, poolDbService->beginOfTime(), newTagRequest_);
       edm::LogVerbatim("WriteEcalMiscalibConstantsMC") << "Done";
     } else {
       edm::LogVerbatim("WriteEcalMiscalibConstantsMC") << "Old IOV";
-      poolDbService->appendSinceTime<const EcalIntercalibConstantsMC>(
+      poolDbService->appendOneIOV<const EcalIntercalibConstantsMC>(
           *Mcal, poolDbService->currentTime(), newTagRequest_);
     }
   }

--- a/CalibCalorimetry/CaloMiscalibTools/plugins/WriteEcalMiscalibConstantsMC.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/plugins/WriteEcalMiscalibConstantsMC.cc
@@ -58,8 +58,7 @@ void WriteEcalMiscalibConstantsMC::analyze(const edm::Event& iEvent, const edm::
       edm::LogVerbatim("WriteEcalMiscalibConstantsMC") << "Done";
     } else {
       edm::LogVerbatim("WriteEcalMiscalibConstantsMC") << "Old IOV";
-      poolDbService->appendOneIOV<const EcalIntercalibConstantsMC>(
-          *Mcal, poolDbService->currentTime(), newTagRequest_);
+      poolDbService->appendOneIOV<const EcalIntercalibConstantsMC>(*Mcal, poolDbService->currentTime(), newTagRequest_);
     }
   }
 }

--- a/CalibTracker/SiPixelQuality/plugins/SiPixelStatusHarvester.cc
+++ b/CalibTracker/SiPixelQuality/plugins/SiPixelStatusHarvester.cc
@@ -194,7 +194,7 @@ void SiPixelStatusHarvester::dqmEndRun(const edm::Run& iRun, const edm::EventSet
     }
     if (debug_ == true) {  // only produced for debugging reason
       cond::Time_t thisIOV = (cond::Time_t)iRun.id().run();
-      poolDbService->writeOne<SiPixelQuality>(*siPixelQualityPermBad, thisIOV, recordName_ + "_permanentBad");
+      poolDbService->writeOneIOV<SiPixelQuality>(*siPixelQualityPermBad, thisIOV, recordName_ + "_permanentBad");
     }
 
     // IOV for final payloads. FEDerror25 and pcl
@@ -298,7 +298,7 @@ void SiPixelStatusHarvester::dqmEndRun(const edm::Run& iRun, const edm::EventSet
       fedError25IOV[it->first] = it->first;
 
       if (debug_ == true)  // only produced for debugging reason
-        poolDbService->writeOne<SiPixelQuality>(*siPixelQuality_FEDerror25, thisIOV, recordName_ + "_FEDerror25");
+        poolDbService->writeOneIOV<SiPixelQuality>(*siPixelQuality_FEDerror25, thisIOV, recordName_ + "_FEDerror25");
 
       delete siPixelQuality_FEDerror25;
     }
@@ -556,12 +556,12 @@ void SiPixelStatusHarvester::dqmEndRun(const edm::Run& iRun, const edm::EventSet
       edm::LuminosityBlockID lu(iRun.id().run(), endLumiBlock_ + 1);
       cond::Time_t thisIOV = (cond::Time_t)(lu.value());
       if (!SiPixelStatusHarvester::equal(lastPrompt, siPixelQualityPermBad))
-        poolDbService->writeOne<SiPixelQuality>(*siPixelQualityPermBad, thisIOV, recordName_ + "_prompt");
+        poolDbService->writeOneIOV<SiPixelQuality>(*siPixelQualityPermBad, thisIOV, recordName_ + "_prompt");
 
       // add empty bad components to last lumi+1 IF AND ONLY IF the last payload of other is not equal to empty
       SiPixelQuality* siPixelQualityDummy = new SiPixelQuality();
       if (!SiPixelStatusHarvester::equal(lastOther, siPixelQualityDummy))
-        poolDbService->writeOne<SiPixelQuality>(*siPixelQualityDummy, thisIOV, recordName_ + "_other");
+        poolDbService->writeOneIOV<SiPixelQuality>(*siPixelQualityDummy, thisIOV, recordName_ + "_other");
 
       delete siPixelQualityDummy;
     }
@@ -657,12 +657,12 @@ void SiPixelStatusHarvester::constructTag(std::map<int, SiPixelQuality*> siPixel
 
     SiPixelQuality* thisPayload = qIt->second;
     if (qIt == siPixelQualityTag.begin())
-      poolDbService->writeOne<SiPixelQuality>(*thisPayload, thisIOV, recordName_ + "_" + tagName);
+      poolDbService->writeOneIOV<SiPixelQuality>(*thisPayload, thisIOV, recordName_ + "_" + tagName);
     else {
       SiPixelQuality* prevPayload = (std::prev(qIt))->second;
       if (!SiPixelStatusHarvester::equal(thisPayload,
                                          prevPayload))  // only append newIOV if this payload differs wrt last
-        poolDbService->writeOne<SiPixelQuality>(*thisPayload, thisIOV, recordName_ + "_" + tagName);
+        poolDbService->writeOneIOV<SiPixelQuality>(*thisPayload, thisIOV, recordName_ + "_" + tagName);
     }
   }
 }

--- a/CalibTracker/SiStripESProducers/plugins/DBWriter/DummyCondDBWriter.h
+++ b/CalibTracker/SiStripESProducers/plugins/DBWriter/DummyCondDBWriter.h
@@ -68,7 +68,7 @@ void DummyCondDBWriter<TObject, TObjectO, TRecord>::endRun(const edm::Run& run, 
     else
       Time_ = iConfig_.getUntrackedParameter<uint32_t>("OpenIovAtTime", 1);
 
-    dbservice->writeOne(*obj, Time_, rcdName);
+    dbservice->writeOneIOV(*obj, Time_, rcdName);
   } else {
     edm::LogError("SiStripFedCablingBuilder") << "Service is unavailable" << std::endl;
   }

--- a/CalibTracker/SiStripESProducers/plugins/DBWriter/SiStripFedCablingManipulator.cc
+++ b/CalibTracker/SiStripESProducers/plugins/DBWriter/SiStripFedCablingManipulator.cc
@@ -41,12 +41,12 @@ void SiStripFedCablingManipulator::endRun(const edm::Run& run, const edm::EventS
       edm::LogInfo("SiStripFedCablingManipulator") << "first request for storing objects with Record "
                                                    << "SiStripFedCablingRcd"
                                                    << " at time " << Time_ << std::endl;
-      dbservice->createNewIOV<SiStripFedCabling>(*obj, Time_, "SiStripFedCablingRcd");
+      dbservice->createOneIOV<SiStripFedCabling>(*obj, Time_, "SiStripFedCablingRcd");
     } else {
       edm::LogInfo("SiStripFedCablingManipulator") << "appending a new object to existing tag "
                                                    << "SiStripFedCablingRcd"
                                                    << " in since mode " << std::endl;
-      dbservice->appendSinceTime<SiStripFedCabling>(*obj, Time_, "SiStripFedCablingRcd");
+      dbservice->appendOneIOV<SiStripFedCabling>(*obj, Time_, "SiStripFedCablingRcd");
     }
   } else {
     edm::LogError("SiStripFedCablingManipulator") << "Service is unavailable" << std::endl;

--- a/CommonTools/ConditionDBWriter/interface/ConditionDBWriter.h
+++ b/CommonTools/ConditionDBWriter/interface/ConditionDBWriter.h
@@ -332,7 +332,7 @@ private:
 
     edm::LogInfo("ConditionDBWriter") << "appending a new object to tag " << Record_ << " in since mode " << std::endl;
 
-    mydbservice->writeOne<T>(*objPointer, since, Record_);
+    mydbservice->writeOneIOV<T>(*objPointer, since, Record_);
   }
 
   void setTime() {

--- a/CondCore/DBOutputService/interface/OnlineDBOutputService.h
+++ b/CondCore/DBOutputService/interface/OnlineDBOutputService.h
@@ -37,11 +37,11 @@ namespace cond {
 
       //
       template <typename PayloadType>
-      bool writeForNextLumisection(const PayloadType& payload, const std::string& recordName) {
+      bool writeIOVForNextLumisection(const PayloadType& payload, const std::string& recordName) {
         cond::Time_t targetTime = getLastLumiProcessed() + m_latencyInLumisections;
         auto t0 = std::chrono::high_resolution_clock::now();
         logger().logInfo() << "Updating lumisection " << targetTime;
-        cond::Hash payloadId = PoolDBOutputService::writeOne<PayloadType>(payload, targetTime, recordName);
+        cond::Hash payloadId = PoolDBOutputService::writeOneIOV<PayloadType>(payload, targetTime, recordName);
         bool ret = true;
         if (payloadId.empty()) {
           return false;

--- a/CondCore/DBOutputService/interface/PoolDBOutputService.h
+++ b/CondCore/DBOutputService/interface/PoolDBOutputService.h
@@ -59,7 +59,7 @@ namespace cond {
       bool isNewTagRequest(const std::string& recordName);
 
       template <typename T>
-      Hash writeOne(const T& payload, Time_t time, const std::string& recordName) {
+      Hash writeOneIOV(const T& payload, Time_t time, const std::string& recordName) {
         std::lock_guard<std::recursive_mutex> lock(m_mutex);
         doStartTransaction();
         cond::persistency::TransactionScope scope(m_session.transaction());
@@ -85,7 +85,7 @@ namespace cond {
             }
           }
           thePayloadHash = m_session.storePayload(payload);
-          std::string payloadType = cond::demangledName(typeid(T));
+          std::string payloadType = cond::demangledName(typeid(payload));
           if (newTag) {
             createNewIOV(thePayloadHash, payloadType, time, myrecord);
           } else {
@@ -112,7 +112,7 @@ namespace cond {
           throwException("Provided payload pointer is invalid.", "PoolDBOutputService::writeOne");
         std::unique_ptr<const T> payload(payloadPtr);
         std::lock_guard<std::recursive_mutex> lock(m_mutex);
-        return writeOne<T>(*payload, time, recordName);
+        return writeOneIOV<T>(*payload, time, recordName);
       }
 
       template <typename T>
@@ -172,7 +172,7 @@ namespace cond {
       void closeIOV(Time_t lastTill, const std::string& recordName);
 
       template <typename T>
-      void createNewIOV(const T& payload, cond::Time_t firstSinceTime, const std::string& recordName) {
+      void createOneIOV(const T& payload, cond::Time_t firstSinceTime, const std::string& recordName) {
         std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
         Record& myrecord = this->lookUpRecord(recordName);
@@ -184,7 +184,7 @@ namespace cond {
         try {
           this->initDB();
           Hash payloadId = m_session.storePayload(payload);
-          createNewIOV(payloadId, cond::demangledName(typeid(T)), firstSinceTime, myrecord);
+          createNewIOV(payloadId, cond::demangledName(typeid(payload)), firstSinceTime, myrecord);
         } catch (const std::exception& er) {
           cond::throwException(std::string(er.what()), "PoolDBOutputService::createNewIov");
         }
@@ -197,11 +197,11 @@ namespace cond {
         if (!payloadPtr)
           throwException("Provided payload pointer is invalid.", "PoolDBOutputService::createNewIOV");
         std::unique_ptr<const T> payload(payloadPtr);
-        this->createNewIOV<T>(*payload, firstSinceTime, recordName);
+        this->createOneIOV<T>(*payload, firstSinceTime, recordName);
       }
 
       template <typename T>
-      void appendSinceTime(const T& payload, cond::Time_t sinceTime, const std::string& recordName) {
+      void appendOneIOV(const T& payload, cond::Time_t sinceTime, const std::string& recordName) {
         std::lock_guard<std::recursive_mutex> lock(m_mutex);
         Record& myrecord = this->lookUpRecord(recordName);
         if (myrecord.m_isNewTag) {
@@ -224,7 +224,7 @@ namespace cond {
         if (!payloadPtr)
           throwException("Provided payload pointer is invalid.", "PoolDBOutputService::appendSinceTime");
         std::unique_ptr<const T> payload(payloadPtr);
-        this->appendSinceTime<T>(*payload, sinceTime, recordName);
+        this->appendOneIOV<T>(*payload, sinceTime, recordName);
       }
 
       void createNewIOV(const std::string& firstPayloadId, cond::Time_t firstSinceTime, const std::string& recordName);

--- a/CondCore/DBOutputService/interface/PoolDBOutputService.h
+++ b/CondCore/DBOutputService/interface/PoolDBOutputService.h
@@ -111,7 +111,6 @@ namespace cond {
         if (!payloadPtr)
           throwException("Provided payload pointer is invalid.", "PoolDBOutputService::writeOne");
         std::unique_ptr<const T> payload(payloadPtr);
-        std::lock_guard<std::recursive_mutex> lock(m_mutex);
         return writeOneIOV<T>(*payload, time, recordName);
       }
 
@@ -174,7 +173,6 @@ namespace cond {
       template <typename T>
       void createOneIOV(const T& payload, cond::Time_t firstSinceTime, const std::string& recordName) {
         std::lock_guard<std::recursive_mutex> lock(m_mutex);
-
         Record& myrecord = this->lookUpRecord(recordName);
         if (!myrecord.m_isNewTag) {
           cond::throwException(myrecord.m_tag + " is not a new tag", "PoolDBOutputService::createNewIOV");

--- a/CondCore/DBOutputService/test/stubs/LumiBasedUpdateAnalyzer.cc
+++ b/CondCore/DBOutputService/test/stubs/LumiBasedUpdateAnalyzer.cc
@@ -50,7 +50,7 @@ void LumiBasedUpdateAnalyzer::beginLuminosityBlock(const edm::LuminosityBlock& l
   mydbservice->logger().logDebug() << "BeamType: " << mybeamspot.GetBeamType();
   m_ret = 0;
   try {
-    mydbservice->writeForNextLumisection(&mybeamspot, m_record);
+    mydbservice->writeIOVForNextLumisection(mybeamspot, m_record);
   } catch (const std::exception& e) {
     std::cout << "Error:" << e.what() << std::endl;
     mydbservice->logger().logError() << e.what();

--- a/CondFormats/MFObjects/test/MagFieldConfigDBWriter.cc
+++ b/CondFormats/MFObjects/test/MagFieldConfigDBWriter.cc
@@ -45,10 +45,10 @@ void MagFieldConfigDBWriter::endJob() {
     try {
       if (dbOutputSvc->isNewTagRequest(record)) {
         //create mode
-        dbOutputSvc->writeOne<MagFieldConfig>(*conf, dbOutputSvc->beginOfTime(), record);
+        dbOutputSvc->writeOneIOV<MagFieldConfig>(*conf, dbOutputSvc->beginOfTime(), record);
       } else {
         //append mode. Note: correct PoolDBESSource must be loaded
-        dbOutputSvc->writeOne<MagFieldConfig>(*conf, dbOutputSvc->currentTime(), record);
+        dbOutputSvc->writeOneIOV<MagFieldConfig>(*conf, dbOutputSvc->currentTime(), record);
       }
     } catch (const cond::Exception& er) {
       std::cout << er.what() << std::endl;

--- a/CondTools/SiPixel/plugins/SiPixelGainCalibrationReadDQMFile.cc
+++ b/CondTools/SiPixel/plugins/SiPixelGainCalibrationReadDQMFile.cc
@@ -450,20 +450,20 @@ void SiPixelGainCalibrationReadDQMFile::fillDatabase(const edm::EventSetup &iSet
       edm::LogPrint("SiPixelGainCalibrationReadDQMFile")
           << "now doing SiPixelGainCalibrationForHLTRcd payload..." << std::endl;
       if (mydbservice->isNewTagRequest(record_)) {
-        mydbservice->createNewIOV<SiPixelGainCalibrationForHLT>(
+        mydbservice->createOneIOV<SiPixelGainCalibrationForHLT>(
             *theGainCalibrationDbInputHLT, mydbservice->beginOfTime(), "SiPixelGainCalibrationForHLTRcd");
       } else {
-        mydbservice->appendSinceTime<SiPixelGainCalibrationForHLT>(
+        mydbservice->appendOneIOV<SiPixelGainCalibrationForHLT>(
             *theGainCalibrationDbInputHLT, mydbservice->currentTime(), "SiPixelGainCalibrationForHLTRcd");
       }
     } else if (record_ == "SiPixelGainCalibrationOfflineRcd") {
       edm::LogPrint("SiPixelGainCalibrationReadDQMFile")
           << "now doing SiPixelGainCalibrationOfflineRcd payload..." << std::endl;
       if (mydbservice->isNewTagRequest(record_)) {
-        mydbservice->createNewIOV<SiPixelGainCalibrationOffline>(
+        mydbservice->createOneIOV<SiPixelGainCalibrationOffline>(
             *theGainCalibrationDbInputOffline, mydbservice->beginOfTime(), "SiPixelGainCalibrationOfflineRcd");
       } else {
-        mydbservice->appendSinceTime<SiPixelGainCalibrationOffline>(
+        mydbservice->appendOneIOV<SiPixelGainCalibrationOffline>(
             *theGainCalibrationDbInputOffline, mydbservice->currentTime(), "SiPixelGainCalibrationOfflineRcd");
       }
     }

--- a/CondTools/SiPixel/plugins/SiPixelTemplateDBObjectUploader.cc
+++ b/CondTools/SiPixel/plugins/SiPixelTemplateDBObjectUploader.cc
@@ -281,9 +281,9 @@ void SiPixelTemplateDBObjectUploader::analyze(const edm::Event& iEvent, const ed
   if (!poolDbService.isAvailable())  // Die if not available
     throw cms::Exception("NotAvailable") << "PoolDBOutputService not available";
   if (poolDbService->isNewTagRequest("SiPixelTemplateDBObjectRcd"))
-    poolDbService->writeOne(&obj, poolDbService->beginOfTime(), "SiPixelTemplateDBObjectRcd");
+    poolDbService->writeOneIOV(obj, poolDbService->beginOfTime(), "SiPixelTemplateDBObjectRcd");
   else
-    poolDbService->writeOne(&obj, poolDbService->currentTime(), "SiPixelTemplateDBObjectRcd");
+    poolDbService->writeOneIOV(obj, poolDbService->currentTime(), "SiPixelTemplateDBObjectRcd");
 }
 
 void SiPixelTemplateDBObjectUploader::endJob() {}

--- a/CondTools/SiStrip/plugins/SiStripApvSimulationParametersBuilder.cc
+++ b/CondTools/SiStrip/plugins/SiStripApvSimulationParametersBuilder.cc
@@ -22,10 +22,10 @@ void SiStripApvSimulationParametersBuilder::analyze(const edm::Event&, const edm
   edm::Service<cond::service::PoolDBOutputService> mydbservice;
   if (mydbservice.isAvailable()) {
     if (mydbservice->isNewTagRequest("SiStripApvSimulationParametersRcd")) {
-      mydbservice->createNewIOV<SiStripApvSimulationParameters>(
+      mydbservice->createOneIOV<SiStripApvSimulationParameters>(
           *obj, mydbservice->beginOfTime(), "SiStripApvSimulationParametersRcd");
     } else {
-      mydbservice->appendSinceTime<SiStripApvSimulationParameters>(
+      mydbservice->appendOneIOV<SiStripApvSimulationParameters>(
           *obj, mydbservice->currentTime(), "SiStripApvSimulationParametersRcd");
     }
   } else {

--- a/CondTools/SiStrip/plugins/SiStripBadChannelBuilder.cc
+++ b/CondTools/SiStrip/plugins/SiStripBadChannelBuilder.cc
@@ -79,10 +79,9 @@ std::unique_ptr<SiStripBadStrip> SiStripBadChannelBuilder::getNewObject() {
 
   if (mydbservice.isAvailable()) {
     if (mydbservice->isNewTagRequest("SiStripBadStripRcd")) {
-      mydbservice->createNewIOV<SiStripBadStrip>(*obj, mydbservice->beginOfTime(), "SiStripBadStripRcd");
+      mydbservice->createOneIOV<SiStripBadStrip>(*obj, mydbservice->beginOfTime(), "SiStripBadStripRcd");
     } else {
-      //mydbservice->createNewIOV<SiStripBadStrip>(*obj, mydbservice->currentTime(),"SiStripBadStripRcd");
-      mydbservice->appendSinceTime<SiStripBadStrip>(*obj, mydbservice->currentTime(), "SiStripBadStripRcd");
+      mydbservice->appendOneIOV<SiStripBadStrip>(*obj, mydbservice->currentTime(), "SiStripBadStripRcd");
     }
   } else {
     edm::LogError("SiStripBadStripBuilder") << "Service is unavailable" << std::endl;

--- a/DQM/BeamMonitor/plugins/BeamMonitor.cc
+++ b/DQM/BeamMonitor/plugins/BeamMonitor.cc
@@ -1430,7 +1430,7 @@ void BeamMonitor::FitAndFill(const LuminosityBlock& lumiSeg, int& lastlumi, int&
             << "BeamMonitor::FitAndFill - [PayloadCreation] SetCreationTime: " << creationTime
             << " [epoch in microseconds]";
         try {
-          onlineDbService_->writeForNextLumisection(BSOnline, recordName_);
+          onlineDbService_->writeIOVForNextLumisection(BSOnline, recordName_);
           onlineDbService_->logger().logInfo()
               << "BeamMonitor::FitAndFill - [PayloadCreation] writeForNextLumisection executed correctly";
         } catch (const std::exception& e) {

--- a/DQM/BeamMonitor/plugins/FakeBeamMonitor.cc
+++ b/DQM/BeamMonitor/plugins/FakeBeamMonitor.cc
@@ -1459,7 +1459,7 @@ void FakeBeamMonitor::FitAndFill(const LuminosityBlock& lumiSeg, int& lastlumi, 
     onlineDbService_->logger().logInfo() << "FakeBeamMonitor::FitAndFill - [PayloadCreation] SetCreationTime: "
                                          << creationTime << " [epoch in microseconds]";
     try {
-      onlineDbService_->writeForNextLumisection(BSOnline, recordName_);
+      onlineDbService_->writeIOVForNextLumisection(BSOnline, recordName_);
       onlineDbService_->logger().logInfo()
           << "FakeBeamMonitor::FitAndFill - [PayloadCreation] writeForNextLumisection executed correctly";
     } catch (const std::exception& e) {

--- a/DQM/EcalMonitorDbModule/plugins/EcalDQMStatusWriter.cc
+++ b/DQM/EcalMonitorDbModule/plugins/EcalDQMStatusWriter.cc
@@ -36,8 +36,8 @@ void EcalDQMStatusWriter::analyze(edm::Event const &, edm::EventSetup const &_es
   if (firstRun_ == dbOutput.endOfTime())
     return;
 
-  dbOutput.writeOne(channelStatus_, firstRun_, "EcalDQMChannelStatusRcd");
-  dbOutput.writeOne(towerStatus_, firstRun_, "EcalDQMTowerStatusRcd");
+  dbOutput.writeOneIOV(channelStatus_, firstRun_, "EcalDQMChannelStatusRcd");
+  dbOutput.writeOneIOV(towerStatus_, firstRun_, "EcalDQMTowerStatusRcd");
 
   firstRun_ = dbOutput.endOfTime();  // avoid accidentally re-writing the conditions
 }

--- a/IOMC/EventVertexGenerators/src/BeamProfile2DB.cc
+++ b/IOMC/EventVertexGenerators/src/BeamProfile2DB.cc
@@ -103,7 +103,7 @@ void BeamProfile2DB::beginJob() {}
 // ------------ method called once each job just after ending the event loop  ------------
 void BeamProfile2DB::endJob() {
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
-  poolDbService->createNewIOV<SimBeamSpotObjects>(beamSpot_, poolDbService->beginOfTime(), "SimBeamSpotObjectsRcd");
+  poolDbService->createOneIOV<SimBeamSpotObjects>(beamSpot_, poolDbService->beginOfTime(), "SimBeamSpotObjectsRcd");
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------

--- a/RecoHI/HiJetAlgos/plugins/UETableProducer.cc
+++ b/RecoHI/HiJetAlgos/plugins/UETableProducer.cc
@@ -204,8 +204,7 @@ void UETableProducer::endJob() {
       if (pool->isNewTagRequest("JetCorrectionsRecord")) {
         pool->createOneIOV<JetCorrectorParametersCollection>(*jme_payload, pool->beginOfTime(), "JetCorrectionsRecord");
       } else {
-        pool->appendOneIOV<JetCorrectorParametersCollection>(
-            *jme_payload, pool->currentTime(), "JetCorrectionsRecord");
+        pool->appendOneIOV<JetCorrectorParametersCollection>(*jme_payload, pool->currentTime(), "JetCorrectionsRecord");
       }
     } else {
       ue_predictor_pf->values = ue_vec;

--- a/RecoHI/HiJetAlgos/plugins/UETableProducer.cc
+++ b/RecoHI/HiJetAlgos/plugins/UETableProducer.cc
@@ -202,18 +202,18 @@ void UETableProducer::endJob() {
       jme_payload->push_back(JetCorrectorParametersCollection::L1Offset, parameter);
 
       if (pool->isNewTagRequest("JetCorrectionsRecord")) {
-        pool->createNewIOV<JetCorrectorParametersCollection>(*jme_payload, pool->beginOfTime(), "JetCorrectionsRecord");
+        pool->createOneIOV<JetCorrectorParametersCollection>(*jme_payload, pool->beginOfTime(), "JetCorrectionsRecord");
       } else {
-        pool->appendSinceTime<JetCorrectorParametersCollection>(
+        pool->appendOneIOV<JetCorrectorParametersCollection>(
             *jme_payload, pool->currentTime(), "JetCorrectionsRecord");
       }
     } else {
       ue_predictor_pf->values = ue_vec;
 
       if (pool->isNewTagRequest("HeavyIonUERcd")) {
-        pool->createNewIOV<UETable>(*ue_predictor_pf, pool->beginOfTime(), "HeavyIonUERcd");
+        pool->createOneIOV<UETable>(*ue_predictor_pf, pool->beginOfTime(), "HeavyIonUERcd");
       } else {
-        pool->appendSinceTime<UETable>(*ue_predictor_pf, pool->currentTime(), "HeavyIonUERcd");
+        pool->appendOneIOV<UETable>(*ue_predictor_pf, pool->currentTime(), "HeavyIonUERcd");
       }
     }
   }


### PR DESCRIPTION
#### PR description:

The new methods - recently introduced - for writing, creating, appending IOVs supporting Payload objects by reference, have been renamed, to clearly distinguish them from the corresponding, existing methods taking pointers as input parameters.

The aim is avoid template instantiation with unintended types.
#### PR validation:

Unit and integration tests

