### PR TITLE
Improve HGCAL geometry handling in fireworks

### DIFF
--- a/DataFormats/HGCalReco/interface/Trackster.h
+++ b/DataFormats/HGCalReco/interface/Trackster.h
@@ -73,7 +73,6 @@ namespace ticl {
     inline void setRawPt(float value) { raw_pt_ = value; }
     inline void setRawEmPt(float value) { raw_em_pt_ = value; }
     inline void setBarycenter(Vector value) { barycenter_ = value; }
-    inline void setEigenValuesVectors();
     inline void fillPCAVariables(Eigen::Vector3d &eigenvalues,
                                  Eigen::Matrix3d &eigenvectors,
                                  Eigen::Vector3d &sigmas,

--- a/Fireworks/Calo/plugins/BuildFile.xml
+++ b/Fireworks/Calo/plugins/BuildFile.xml
@@ -10,6 +10,7 @@
   <use name="DataFormats/METReco"/>
   <use name="DataFormats/TauReco"/>
   <use name="DataFormats/TrackReco"/>
+  <use name="DataFormats/HGCalReco"/>
   <use name="Fireworks/Calo"/>
   <use name="Fireworks/Core"/>
   <use name="rootinteractive"/>

--- a/Fireworks/Calo/plugins/FWTracksterHitsProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWTracksterHitsProxyBuilder.cc
@@ -24,18 +24,18 @@ public:
   const FWTracksterHitsProxyBuilder &operator=(const FWTracksterHitsProxyBuilder &) = delete;  // stop default
 
 private:
-  edm::Handle<edm::ValueMap<std::pair<float, float>>> TimeValueMapHandle;
-  edm::Handle<std::vector<reco::CaloCluster>> layerClustersHandle;
-  double timeLowerBound, timeUpperBound;
-  long layer;
-  double saturation_energy;
-  bool heatmap;
-  bool z_plus;
-  bool z_minus;
-  bool enableTimeFilter;
-  bool enableSeedLines;
-  bool enablePositionLines;
-  bool enableEdges;
+  edm::Handle<edm::ValueMap<std::pair<float, float>>> TimeValueMapHandle_;
+  edm::Handle<std::vector<reco::CaloCluster>> layerClustersHandle_;
+  double timeLowerBound_, timeUpperBound_;
+  long layer_;
+  double saturation_energy_;
+  bool heatmap_;
+  bool z_plus_;
+  bool z_minus_;
+  bool enableTimeFilter_;
+  bool enableSeedLines_;
+  bool enablePositionLines_;
+  bool enableEdges_;
 
   void setItem(const FWEventItem *iItem) override;
 
@@ -60,12 +60,12 @@ void FWTracksterHitsProxyBuilder::setItem(const FWEventItem *iItem) {
 }
 
 void FWTracksterHitsProxyBuilder::build(const FWEventItem *iItem, TEveElementList *product, const FWViewContext *vc) {
-  iItem->getEvent()->getByLabel(edm::InputTag("hgcalLayerClusters", "timeLayerCluster"), TimeValueMapHandle);
-  iItem->getEvent()->getByLabel(edm::InputTag("hgcalLayerClusters"), layerClustersHandle);
-  if (TimeValueMapHandle.isValid()) {
-    timeLowerBound = item()->getConfig()->value<double>("TimeLowerBound(ns)");
-    timeUpperBound = item()->getConfig()->value<double>("TimeUpperBound(ns)");
-    if (timeLowerBound > timeUpperBound) {
+  iItem->getEvent()->getByLabel(edm::InputTag("hgcalLayerClusters", "timeLayerCluster"), TimeValueMapHandle_);
+  iItem->getEvent()->getByLabel(edm::InputTag("hgcalLayerClusters"), layerClustersHandle_);
+  if (TimeValueMapHandle_.isValid()) {
+    timeLowerBound_ = item()->getConfig()->value<double>("TimeLowerBound(ns)");
+    timeUpperBound_ = item()->getConfig()->value<double>("TimeUpperBound(ns)");
+    if (timeLowerBound_ > timeUpperBound_) {
       edm::LogWarning("InvalidParameters")
           << "lower time bound is larger than upper time bound. Maybe opposite is desired?";
     }
@@ -73,19 +73,19 @@ void FWTracksterHitsProxyBuilder::build(const FWEventItem *iItem, TEveElementLis
     edm::LogWarning("DataNotFound|InvalidData") << "couldn't locate 'timeLayerCluster' ValueMap in root file.";
   }
 
-  if (!layerClustersHandle.isValid()) {
+  if (!layerClustersHandle_.isValid()) {
     edm::LogWarning("DataNotFound|InvalidData") << "couldn't locate 'timeLayerCluster' ValueMap in root file.";
   }
 
-  layer = item()->getConfig()->value<long>("Layer");
-  saturation_energy = item()->getConfig()->value<double>("EnergyCutOff");
-  heatmap = item()->getConfig()->value<bool>("Heatmap");
-  z_plus = item()->getConfig()->value<bool>("Z+");
-  z_minus = item()->getConfig()->value<bool>("Z-");
-  enableTimeFilter = item()->getConfig()->value<bool>("EnableTimeFilter");
-  enableSeedLines = item()->getConfig()->value<bool>("EnableSeedLines");
-  enablePositionLines = item()->getConfig()->value<bool>("EnablePositionLines");
-  enableEdges = item()->getConfig()->value<bool>("EnableEdges");
+  layer_ = item()->getConfig()->value<long>("Layer");
+  saturation_energy_ = item()->getConfig()->value<double>("EnergyCutOff");
+  heatmap_ = item()->getConfig()->value<bool>("Heatmap");
+  z_plus_ = item()->getConfig()->value<bool>("Z+");
+  z_minus_ = item()->getConfig()->value<bool>("Z-");
+  enableTimeFilter_ = item()->getConfig()->value<bool>("EnableTimeFilter");
+  enableSeedLines_ = item()->getConfig()->value<bool>("EnableSeedLines");
+  enablePositionLines_ = item()->getConfig()->value<bool>("EnablePositionLines");
+  enableEdges_ = item()->getConfig()->value<bool>("EnableEdges");
 
   FWHeatmapProxyBuilderTemplate::build(iItem, product, vc);
 }
@@ -94,19 +94,19 @@ void FWTracksterHitsProxyBuilder::build(const ticl::Trackster &iData,
                                         unsigned int iIndex,
                                         TEveElement &oItemHolder,
                                         const FWViewContext *) {
-  if (enableTimeFilter && TimeValueMapHandle.isValid()) {
-    const float time = TimeValueMapHandle->get(iIndex).first;
-    if (time < timeLowerBound || time > timeUpperBound)
+  if (enableTimeFilter_ && TimeValueMapHandle_.isValid()) {
+    const float time = TimeValueMapHandle_->get(iIndex).first;
+    if (time < timeLowerBound_ || time > timeUpperBound_)
       return;
   }
 
   const ticl::Trackster &trackster = iData;
   const size_t N = trackster.vertices().size();
-  const std::vector<reco::CaloCluster> &layerClusters = *layerClustersHandle;
+  const std::vector<reco::CaloCluster> &layerClusters = *layerClustersHandle_;
 
   bool h_hex(false);
   TEveBoxSet *hex_boxset = new TEveBoxSet();
-  if (!heatmap)
+  if (!heatmap_)
     hex_boxset->UseSingleColor();
   hex_boxset->SetPickable(true);
   hex_boxset->Reset(TEveBoxSet::kBT_Hex, true, 64);
@@ -114,7 +114,7 @@ void FWTracksterHitsProxyBuilder::build(const ticl::Trackster &iData,
 
   bool h_box(false);
   TEveBoxSet *boxset = new TEveBoxSet();
-  if (!heatmap)
+  if (!heatmap_)
     boxset->UseSingleColor();
   boxset->SetPickable(true);
   boxset->Reset(TEveBoxSet::kBT_FreeBox, true, 64);
@@ -127,19 +127,12 @@ void FWTracksterHitsProxyBuilder::build(const ticl::Trackster &iData,
     for (std::vector<std::pair<DetId, float>>::iterator it = clusterDetIds.begin(), itEnd = clusterDetIds.end();
          it != itEnd;
          ++it) {
-      const uint8_t type = ((it->first >> 28) & 0xF);
 
       const float *corners = item()->getGeom()->getCorners(it->first);
       if (corners == nullptr)
         continue;
 
-      if (heatmap && hitmap->find(it->first) == hitmap->end())
-        continue;
-
-      const bool z = (it->first >> 25) & 0x1;
-
-      // discard everything thats not at the side that we are intersted in
-      if (((z_plus & z_minus) != 1) && (((z_plus | z_minus) == 0) || !(z == z_minus || z == !z_plus)))
+      if (heatmap_ && hitmap->find(it->first) == hitmap->end())
         continue;
 
       const float *parameters = item()->getGeom()->getParameters(it->first);
@@ -149,29 +142,28 @@ void FWTracksterHitsProxyBuilder::build(const ticl::Trackster &iData,
         continue;
 
       const int total_points = parameters[0];
-      const bool isScintillator = (total_points == 4);
+      const int layer = parameters[1];
+      const int zside = parameters[2];
+      const bool isSilicon = parameters[3];
+      const int siliconIndex = parameters[4];
+      const int lastLayerEE = parameters[5];
 
-      uint8_t ll = layer;
-      if (layer > 0) {
-        if (layer > 28) {
-          if (type == 8) {
-            continue;
-          }
-          ll -= 28;
-        } else {
-          if (type != 8) {
-            continue;
-          }
-        }
+      // discard everything that's not at the side that we are intersted in
+      auto const z_selection_is_on = z_plus_ ^ z_minus_;
+      auto const z_plus_selection_ok = z_plus_ && (zside ==1);
+      auto const z_minus_selection_ok = z_minus_ && (zside ==-1);
+      if (!z_minus_ && !z_plus_)
+        break;
+      if (z_selection_is_on && !(z_plus_selection_ok || z_minus_selection_ok))
+        break;
 
-        if (ll != ((it->first >> (isScintillator ? 17 : 20)) & 0x1F))
-          continue;
-      }
+      if (layer_ > 0 && layer != layer_)
+        break;
 
       // seed and cluster position
       if (layerCluster.seed().rawId() == it->first.rawId()) {
         const float crossScale = 1.0f + fmin(layerCluster.energy(), 5.0f);
-        if (enableSeedLines) {
+        if (enableSeedLines_) {
           TEveStraightLineSet *marker = new TEveStraightLineSet;
           marker->SetLineWidth(1);
 
@@ -188,7 +180,7 @@ void FWTracksterHitsProxyBuilder::build(const ticl::Trackster &iData,
           oItemHolder.AddElement(marker);
         }
 
-        if (enablePositionLines) {
+        if (enablePositionLines_) {
           TEveStraightLineSet *position_marker = new TEveStraightLineSet;
           position_marker->SetLineWidth(2);
           position_marker->SetLineColor(kOrange);
@@ -206,12 +198,12 @@ void FWTracksterHitsProxyBuilder::build(const ticl::Trackster &iData,
       const float energy =
           fmin((item()->getConfig()->value<bool>("Cluster(0)/RecHit(1)") ? hitmap->at(it->first)->energy()
                                                                          : layerCluster.energy()) /
-                   saturation_energy,
+                   saturation_energy_,
                1.0f);
       const uint8_t colorFactor = gradient_steps * energy;
 
       // Scintillator
-      if (isScintillator) {
+      if (!isSilicon) {
         const int total_vertices = 3 * total_points;
 
         std::vector<float> pnts(24);
@@ -225,7 +217,7 @@ void FWTracksterHitsProxyBuilder::build(const ticl::Trackster &iData,
           pnts[(i * 3 + 2) + total_vertices] = corners[i * 3 + 2] + shapes[3];
         }
         boxset->AddBox(&pnts[0]);
-        if (heatmap) {
+        if (heatmap_) {
           energy ? boxset->DigitColor(gradient[0][colorFactor], gradient[1][colorFactor], gradient[2][colorFactor])
                  : boxset->DigitColor(64, 64, 64);
         }
@@ -240,7 +232,7 @@ void FWTracksterHitsProxyBuilder::build(const ticl::Trackster &iData,
         float centerY = (corners[7] + corners[7 + offset]) / 2;
         float radius = fabs(corners[6] - corners[6 + offset]) / 2;
         hex_boxset->AddHex(TEveVector(centerX, centerY, corners[2]), radius, 90.0, shapes[3]);
-        if (heatmap) {
+        if (heatmap_) {
           energy ? hex_boxset->DigitColor(gradient[0][colorFactor], gradient[1][colorFactor], gradient[2][colorFactor])
                  : hex_boxset->DigitColor(64, 64, 64);
         }
@@ -250,25 +242,14 @@ void FWTracksterHitsProxyBuilder::build(const ticl::Trackster &iData,
     }
   }
 
-  if (enableEdges) {
+  if (enableEdges_) {
     auto &edges = trackster.edges();
 
     for (auto edge : edges) {
       auto doublet = std::make_pair(layerClusters[edge[0]], layerClusters[edge[1]]);
 
-      const bool isScintillatorIn = doublet.first.seed().det() == DetId::HGCalHSc;
-      const bool isScintillatorOut = doublet.second.seed().det() == DetId::HGCalHSc;
-      int layerIn = (isScintillatorIn) ? (HGCScintillatorDetId(doublet.first.seed()).layer())
-                                       : (HGCSiliconDetId(doublet.first.seed()).layer());
-      int layerOut = (isScintillatorOut) ? (HGCScintillatorDetId(doublet.second.seed()).layer())
-                                         : (HGCSiliconDetId(doublet.second.seed()).layer());
-
-      // Check if offset is needed
-      const int offset = 28;
-      const int offsetIn = offset * (doublet.first.seed().det() != DetId::HGCalEE);
-      const int offsetOut = offset * (doublet.second.seed().det() != DetId::HGCalEE);
-      layerIn += offsetIn;
-      layerOut += offsetOut;
+      int layerIn = item()->getGeom()->getParameters(doublet.first.seed())[1];
+      int layerOut = item()->getGeom()->getParameters(doublet.second.seed())[1];
 
       const bool isAdjacent = (layerOut - layerIn) == 1;
 
@@ -281,7 +262,7 @@ void FWTracksterHitsProxyBuilder::build(const ticl::Trackster &iData,
       }
 
       // draw 3D cross
-      if (layer == 0 || fabs(layerIn - layer) == 0 || fabs(layerOut - layer) == 0) {
+      if (layer_ == 0 || fabs(layerIn - layer_) == 0 || fabs(layerOut - layer_) == 0) {
         marker->AddLine(doublet.first.x(),
                         doublet.first.y(),
                         doublet.first.z(),
@@ -298,7 +279,7 @@ void FWTracksterHitsProxyBuilder::build(const ticl::Trackster &iData,
     hex_boxset->RefitPlex();
 
     hex_boxset->CSCTakeAnyParentAsMaster();
-    if (!heatmap) {
+    if (!heatmap_) {
       hex_boxset->CSCApplyMainColorToMatchingChildren();
       hex_boxset->CSCApplyMainTransparencyToMatchingChildren();
       hex_boxset->SetMainColor(item()->modelInfo(iIndex).displayProperties().color());
@@ -311,7 +292,7 @@ void FWTracksterHitsProxyBuilder::build(const ticl::Trackster &iData,
     boxset->RefitPlex();
 
     boxset->CSCTakeAnyParentAsMaster();
-    if (!heatmap) {
+    if (!heatmap_) {
       boxset->CSCApplyMainColorToMatchingChildren();
       boxset->CSCApplyMainTransparencyToMatchingChildren();
       boxset->SetMainColor(item()->modelInfo(iIndex).displayProperties().color());

--- a/Fireworks/Calo/plugins/FWTracksterHitsProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWTracksterHitsProxyBuilder.cc
@@ -144,8 +144,6 @@ void FWTracksterHitsProxyBuilder::build(const ticl::Trackster &iData,
       const int layer = parameters[1];
       const int zside = parameters[2];
       const bool isSilicon = parameters[3];
-      const int siliconIndex = parameters[4];
-      const int lastLayerEE = parameters[5];
 
       // discard everything that's not at the side that we are intersted in
       auto const z_selection_is_on = z_plus_ ^ z_minus_;

--- a/Fireworks/Calo/plugins/FWTracksterHitsProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWTracksterHitsProxyBuilder.cc
@@ -127,7 +127,6 @@ void FWTracksterHitsProxyBuilder::build(const ticl::Trackster &iData,
     for (std::vector<std::pair<DetId, float>>::iterator it = clusterDetIds.begin(), itEnd = clusterDetIds.end();
          it != itEnd;
          ++it) {
-
       const float *corners = item()->getGeom()->getCorners(it->first);
       if (corners == nullptr)
         continue;
@@ -150,8 +149,8 @@ void FWTracksterHitsProxyBuilder::build(const ticl::Trackster &iData,
 
       // discard everything that's not at the side that we are intersted in
       auto const z_selection_is_on = z_plus_ ^ z_minus_;
-      auto const z_plus_selection_ok = z_plus_ && (zside ==1);
-      auto const z_minus_selection_ok = z_minus_ && (zside ==-1);
+      auto const z_plus_selection_ok = z_plus_ && (zside == 1);
+      auto const z_minus_selection_ok = z_minus_ && (zside == -1);
       if (!z_minus_ && !z_plus_)
         break;
       if (z_selection_is_on && !(z_plus_selection_ok || z_minus_selection_ok))

--- a/Fireworks/Calo/plugins/FWTracksterLayersProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWTracksterLayersProxyBuilder.cc
@@ -29,17 +29,19 @@ public:
   const FWTracksterLayersProxyBuilder &operator=(const FWTracksterLayersProxyBuilder &) = delete;  // stop default
 
 private:
-  edm::Handle<edm::ValueMap<std::pair<float, float>>> TimeValueMapHandle;
-  edm::Handle<std::vector<reco::CaloCluster>> layerClustersHandle;
-  double timeLowerBound, timeUpperBound;
-  long layer;
-  bool z_plus;
-  bool z_minus;
-  bool enableTimeFilter;
-  bool enablePositionLines;
-  bool enableEdges;
-  double displayMode;
-  double proportionalityFactor;
+  edm::Handle<edm::ValueMap<std::pair<float, float>>> TimeValueMapHandle_;
+  edm::Handle<std::vector<reco::CaloCluster>> layerClustersHandle_;
+  double timeLowerBound_, timeUpperBound_;
+  long layer_;
+  double saturation_energy_;
+  bool heatmap_;
+  bool z_plus_;
+  bool z_minus_;
+  bool enableTimeFilter_;
+  bool enablePositionLines_;
+  bool enableEdges_;
+  double displayMode_;
+  double proportionalityFactor_;
 
   void setItem(const FWEventItem *iItem) override;
 
@@ -64,12 +66,12 @@ void FWTracksterLayersProxyBuilder::setItem(const FWEventItem *iItem) {
 }
 
 void FWTracksterLayersProxyBuilder::build(const FWEventItem *iItem, TEveElementList *product, const FWViewContext *vc) {
-  iItem->getEvent()->getByLabel(edm::InputTag("hgcalLayerClusters", "timeLayerCluster"), TimeValueMapHandle);
-  iItem->getEvent()->getByLabel(edm::InputTag("hgcalLayerClusters"), layerClustersHandle);
-  if (TimeValueMapHandle.isValid()) {
-    timeLowerBound = item()->getConfig()->value<double>("TimeLowerBound(ns)");
-    timeUpperBound = item()->getConfig()->value<double>("TimeUpperBound(ns)");
-    if (timeLowerBound > timeUpperBound) {
+  iItem->getEvent()->getByLabel(edm::InputTag("hgcalLayerClusters", "timeLayerCluster"), TimeValueMapHandle_);
+  iItem->getEvent()->getByLabel(edm::InputTag("hgcalLayerClusters"), layerClustersHandle_);
+  if (TimeValueMapHandle_.isValid()) {
+    timeLowerBound_ = item()->getConfig()->value<double>("TimeLowerBound(ns)");
+    timeUpperBound_ = item()->getConfig()->value<double>("TimeUpperBound(ns)");
+    if (timeLowerBound_ > timeUpperBound_) {
       edm::LogWarning("InvalidParameters")
           << "lower time bound is larger than upper time bound. Maybe opposite is desired?";
     }
@@ -77,18 +79,20 @@ void FWTracksterLayersProxyBuilder::build(const FWEventItem *iItem, TEveElementL
     edm::LogWarning("DataNotFound|InvalidData") << "couldn't locate 'timeLayerCluster' ValueMap in root file.";
   }
 
-  if (!layerClustersHandle.isValid()) {
+  if (!layerClustersHandle_.isValid()) {
     edm::LogWarning("DataNotFound|InvalidData") << "couldn't locate 'timeLayerCluster' ValueMap in root file.";
   }
 
-  layer = item()->getConfig()->value<long>("Layer");
-  z_plus = item()->getConfig()->value<bool>("Z+");
-  z_minus = item()->getConfig()->value<bool>("Z-");
-  enableTimeFilter = item()->getConfig()->value<bool>("EnableTimeFilter");
-  enablePositionLines = item()->getConfig()->value<bool>("EnablePositionLines");
-  enableEdges = item()->getConfig()->value<bool>("EnableEdges");
-  displayMode = item()->getConfig()->value<double>("DisplayMode");
-  proportionalityFactor = item()->getConfig()->value<double>("ProportionalityFactor");
+  layer_ = item()->getConfig()->value<long>("Layer");
+  saturation_energy_ = item()->getConfig()->value<double>("EnergyCutOff");
+  heatmap_ = item()->getConfig()->value<bool>("Heatmap");
+  z_plus_ = item()->getConfig()->value<bool>("Z+");
+  z_minus_ = item()->getConfig()->value<bool>("Z-");
+  enableTimeFilter_ = item()->getConfig()->value<bool>("EnableTimeFilter");
+  enablePositionLines_ = item()->getConfig()->value<bool>("EnablePositionLines");
+  enableEdges_ = item()->getConfig()->value<bool>("EnableEdges");
+  displayMode_ = item()->getConfig()->value<double>("DisplayMode");
+  proportionalityFactor_ = item()->getConfig()->value<double>("ProportionalityFactor");
 
   FWHeatmapProxyBuilderTemplate::build(iItem, product, vc);
 }
@@ -97,40 +101,53 @@ void FWTracksterLayersProxyBuilder::build(const ticl::Trackster &iData,
                                           unsigned int iIndex,
                                           TEveElement &oItemHolder,
                                           const FWViewContext *) {
-  if (enableTimeFilter && TimeValueMapHandle.isValid()) {
-    const float time = TimeValueMapHandle->get(iIndex).first;
-    if (time < timeLowerBound || time > timeUpperBound)
+  if (enableTimeFilter_ && TimeValueMapHandle_.isValid()) {
+    const float time = TimeValueMapHandle_->get(iIndex).first;
+    if (time < timeLowerBound_ || time > timeUpperBound_)
       return;
   }
 
   const ticl::Trackster &trackster = iData;
   const size_t N = trackster.vertices().size();
-  const std::vector<reco::CaloCluster> &layerClusters = *layerClustersHandle;
+  const std::vector<reco::CaloCluster> &layerClusters = *layerClustersHandle_;
 
   for (size_t i = 0; i < N; ++i) {
     const reco::CaloCluster layerCluster = layerClusters[trackster.vertices(i)];
     const math::XYZPoint &position = layerCluster.position();
     const size_t nHits = layerCluster.size();
-    const double energy = layerCluster.correctedEnergy();
+    const double energy = layerCluster.energy();
     float radius = 0;
+    auto detIdOnLayer = layerCluster.seed();
 
-    // discard everything thats not at the side that we are intersted in
-    const bool z = (layerCluster.seed() >> 25) & 0x1;
-    if (((z_plus & z_minus) != 1) && (((z_plus | z_minus) == 0) || !(z == z_minus || z == !z_plus)))
+    const auto * parameters = item()->getGeom()->getParameters(detIdOnLayer);
+    const int layer = parameters[1];
+    const int zside = parameters[2];
+    const bool isSilicon = parameters[3];
+    const int siliconIndex = parameters[4];
+    const int lastLayerEE = parameters[5];
+
+    auto const z_selection_is_on = z_plus_ ^ z_minus_;
+    auto const z_plus_selection_ok = z_plus_ && (zside ==1);
+    auto const z_minus_selection_ok = z_minus_ && (zside ==-1);
+    if (!z_minus_ && !z_plus_)
+        continue;
+    if (z_selection_is_on && !(z_plus_selection_ok || z_minus_selection_ok))
       continue;
 
-    if (displayMode == 0) {
+    if (layer_ > 0 && (layer != layer_))
+        continue;
+
+    if (displayMode_ == 0) {
       radius = sqrt(nHits);
-    } else if (displayMode == 1) {
+    } else if (displayMode_ == 1) {
       radius = nHits;
-    } else if (displayMode == 2) {
+    } else if (displayMode_ == 2) {
       radius = energy;
-    } else if (displayMode == 3) {
+    } else if (displayMode_ == 3) {
       radius = energy / nHits;
-    } else if (displayMode == 4) {
-      const bool isScintillator = layerCluster.seed().det() == DetId::HGCalHSc;
+    } else if (displayMode_ == 4) {
       float area = 0;
-      if (isScintillator) {
+      if (!isSilicon) {
         const bool isFine = (HGCScintillatorDetId(layerCluster.seed()).type() == 0);
         float dphi = (isFine) ? 1.0 * M_PI / 180. : 1.25 * M_PI / 180.;
         int ir = HGCScintillatorDetId(layerCluster.seed()).iradiusAbs();
@@ -147,18 +164,25 @@ void FWTracksterLayersProxyBuilder::build(const ticl::Trackster &iData,
     }
 
     auto eveCircle = new TEveGeoShape("Circle");
-    auto tube = new TGeoTube(0., proportionalityFactor * radius, 0.1);
+    auto tube = new TGeoTube(0., proportionalityFactor_ * radius, 0.1);
     eveCircle->SetShape(tube);
     eveCircle->InitMainTrans();
     eveCircle->RefMainTrans().Move3PF(position.x(), position.y(), position.z());
     setupAddElement(eveCircle, &oItemHolder);
+    // Apply heatmap color coding **after** the call to setupAddElement, that will internally setup the color.
+    if (heatmap_) {
+      const float normalized_energy =
+          fmin(energy/saturation_energy_, 1.0f);
+      const uint8_t colorFactor = gradient_steps * normalized_energy;
+      eveCircle->SetFillColor(TColor::GetColor(gradient[0][colorFactor], gradient[1][colorFactor], gradient[2][colorFactor]));
+    }
 
     // seed and cluster position
     const float crossScale = 1.0f + fmin(energy, 5.0f);
-    if (enablePositionLines) {
+    if (enablePositionLines_) {
       TEveStraightLineSet *position_marker = new TEveStraightLineSet;
       position_marker->SetLineWidth(2);
-      position_marker->SetLineColor(kOrange);
+      position_marker->SetLineColor(kWhite);
       auto const &pos = layerCluster.position();
       const float position_crossScale = crossScale * 0.5;
       position_marker->AddLine(
@@ -170,25 +194,14 @@ void FWTracksterLayersProxyBuilder::build(const ticl::Trackster &iData,
     }
   }
 
-  if (enableEdges) {
+  if (enableEdges_) {
     auto &edges = trackster.edges();
 
     for (auto edge : edges) {
       auto doublet = std::make_pair(layerClusters[edge[0]], layerClusters[edge[1]]);
 
-      const bool isScintillatorIn = doublet.first.seed().det() == DetId::HGCalHSc;
-      const bool isScintillatorOut = doublet.second.seed().det() == DetId::HGCalHSc;
-      int layerIn = (isScintillatorIn) ? (HGCScintillatorDetId(doublet.first.seed()).layer())
-                                       : (HGCSiliconDetId(doublet.first.seed()).layer());
-      int layerOut = (isScintillatorOut) ? (HGCScintillatorDetId(doublet.second.seed()).layer())
-                                         : (HGCSiliconDetId(doublet.second.seed()).layer());
-
-      // Check if offset is needed
-      const int offset = 28;
-      const int offsetIn = offset * (doublet.first.seed().det() != DetId::HGCalEE);
-      const int offsetOut = offset * (doublet.second.seed().det() != DetId::HGCalEE);
-      layerIn += offsetIn;
-      layerOut += offsetOut;
+      int layerIn = item()->getGeom()->getParameters(doublet.first.seed())[1];
+      int layerOut = item()->getGeom()->getParameters(doublet.second.seed())[1];
 
       const bool isAdjacent = (layerOut - layerIn) == 1;
 
@@ -201,7 +214,7 @@ void FWTracksterLayersProxyBuilder::build(const ticl::Trackster &iData,
       }
 
       // draw 3D cross
-      if (layer == 0 || fabs(layerIn - layer) == 0 || fabs(layerOut - layer) == 0) {
+      if (layer_ == 0 || fabs(layerIn - layer_) == 0 || fabs(layerOut - layer_) == 0) {
         marker->AddLine(doublet.first.x(),
                         doublet.first.y(),
                         doublet.first.z(),

--- a/Fireworks/Calo/plugins/FWTracksterLayersProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWTracksterLayersProxyBuilder.cc
@@ -123,8 +123,6 @@ void FWTracksterLayersProxyBuilder::build(const ticl::Trackster &iData,
     const int layer = parameters[1];
     const int zside = parameters[2];
     const bool isSilicon = parameters[3];
-    const int siliconIndex = parameters[4];
-    const int lastLayerEE = parameters[5];
 
     auto const z_selection_is_on = z_plus_ ^ z_minus_;
     auto const z_plus_selection_ok = z_plus_ && (zside == 1);

--- a/Fireworks/Calo/plugins/FWTracksterLayersProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWTracksterLayersProxyBuilder.cc
@@ -119,7 +119,7 @@ void FWTracksterLayersProxyBuilder::build(const ticl::Trackster &iData,
     float radius = 0;
     auto detIdOnLayer = layerCluster.seed();
 
-    const auto * parameters = item()->getGeom()->getParameters(detIdOnLayer);
+    const auto *parameters = item()->getGeom()->getParameters(detIdOnLayer);
     const int layer = parameters[1];
     const int zside = parameters[2];
     const bool isSilicon = parameters[3];
@@ -127,15 +127,15 @@ void FWTracksterLayersProxyBuilder::build(const ticl::Trackster &iData,
     const int lastLayerEE = parameters[5];
 
     auto const z_selection_is_on = z_plus_ ^ z_minus_;
-    auto const z_plus_selection_ok = z_plus_ && (zside ==1);
-    auto const z_minus_selection_ok = z_minus_ && (zside ==-1);
+    auto const z_plus_selection_ok = z_plus_ && (zside == 1);
+    auto const z_minus_selection_ok = z_minus_ && (zside == -1);
     if (!z_minus_ && !z_plus_)
-        continue;
+      continue;
     if (z_selection_is_on && !(z_plus_selection_ok || z_minus_selection_ok))
       continue;
 
     if (layer_ > 0 && (layer != layer_))
-        continue;
+      continue;
 
     if (displayMode_ == 0) {
       radius = sqrt(nHits);
@@ -171,10 +171,10 @@ void FWTracksterLayersProxyBuilder::build(const ticl::Trackster &iData,
     setupAddElement(eveCircle, &oItemHolder);
     // Apply heatmap color coding **after** the call to setupAddElement, that will internally setup the color.
     if (heatmap_) {
-      const float normalized_energy =
-          fmin(energy/saturation_energy_, 1.0f);
+      const float normalized_energy = fmin(energy / saturation_energy_, 1.0f);
       const uint8_t colorFactor = gradient_steps * normalized_energy;
-      eveCircle->SetFillColor(TColor::GetColor(gradient[0][colorFactor], gradient[1][colorFactor], gradient[2][colorFactor]));
+      eveCircle->SetFillColor(
+          TColor::GetColor(gradient[0][colorFactor], gradient[1][colorFactor], gradient[2][colorFactor]));
     }
 
     // seed and cluster position

--- a/Fireworks/Geometry/BuildFile.xml
+++ b/Fireworks/Geometry/BuildFile.xml
@@ -12,6 +12,7 @@
 <use name="Geometry/Records"/>
 <use name="DataFormats/GeometrySurface"/>
 <use name="DataFormats/MuonDetId"/>
+<use name="RecoLocalCalo/HGCalRecAlgos"/>
 <use name="Fireworks/Core"/>
 <use name="rootcore"/>
 <use name="rootgeom"/>

--- a/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
+++ b/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
@@ -531,11 +531,11 @@ void FWRecoGeometryESProducer::addCaloGeometry(FWRecoGeometry& fwRecoGeometry) {
       fwRecoGeometry.idToName[id].topology[3] = rhtools.isSilicon(it->rawId());
 
       // Silicon index
-      fwRecoGeometry.idToName[id].topology[4] = rhtools.isSilicon(it->rawId()) ? rhtools.getSiThickIndex(it->rawId()) : -1.;
+      fwRecoGeometry.idToName[id].topology[4] =
+          rhtools.isSilicon(it->rawId()) ? rhtools.getSiThickIndex(it->rawId()) : -1.;
 
       // Last EE layer
       fwRecoGeometry.idToName[id].topology[5] = rhtools.lastLayerEE();
-
     }
   }
 }

--- a/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
+++ b/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
@@ -13,6 +13,7 @@
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/HGCalGeometry/interface/HGCalGeometry.h"
 #include "Geometry/HGCalGeometry/interface/FastTimeGeometry.h"
+#include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
 #include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
 #include "Geometry/CSCGeometry/interface/CSCGeometry.h"
 #include "Geometry/DTGeometry/interface/DTGeometry.h"
@@ -492,6 +493,8 @@ void FWRecoGeometryESProducer::addCaloGeometry(FWRecoGeometry& fwRecoGeometry) {
       int subdet = (((DetId::HGCalEE == det) || (DetId::HGCalHSi == det) || (DetId::HGCalHSc == det)) ? ForwardEmpty
                                                                                                       : it->subdetId());
       const HGCalGeometry* geom = dynamic_cast<const HGCalGeometry*>(m_caloGeom->getSubdetectorGeometry(det, subdet));
+      hgcal::RecHitTools rhtools;
+      rhtools.setGeometry(*m_caloGeom);
       const auto cor = geom->getNewCorners(*it);
 
       // roll = yaw = pitch = 0
@@ -517,6 +520,22 @@ void FWRecoGeometryESProducer::addCaloGeometry(FWRecoGeometry& fwRecoGeometry) {
 
       // total points
       fwRecoGeometry.idToName[id].topology[0] = cor.size() - 1;
+
+      // Layer with Offset
+      fwRecoGeometry.idToName[id].topology[1] = rhtools.getLayerWithOffset(it->rawId());
+
+      // Zside, +/- 1
+      fwRecoGeometry.idToName[id].topology[2] = rhtools.zside(it->rawId());
+
+      // Is Silicon
+      fwRecoGeometry.idToName[id].topology[3] = rhtools.isSilicon(it->rawId());
+
+      // Silicon index
+      fwRecoGeometry.idToName[id].topology[4] = rhtools.isSilicon(it->rawId()) ? rhtools.getSiThickIndex(it->rawId()) : -1.;
+
+      // Last EE layer
+      fwRecoGeometry.idToName[id].topology[5] = rhtools.lastLayerEE();
+
     }
   }
 }


### PR DESCRIPTION
#### PR description:

* Trying to open the object panel in Fireworks while displaying
Tracksters, an error appears complaining about a missing symbol. That
was due to a declaration without any implementation of a trackster's
method. This removes that.

* Make use of the topology information, in the form of 9 floats for each
DetId, to pass HGCAL specific information to Fireworks. This will avoid
the weak and error-prone practice of unpacking the DetId bits while
rendering the objects via the dedicated proxies. Three floats are still
available. This will increase the coupling between the release, the
geometry dumping and the explored file. On the other hand, at present,
the unpacking is wrong for new geometries.

* Rename private variables with a final '_', in accordance to CMSSW coding
rules. Also, make use of the topology information now stored inside the
geometry description of Fireworks. This makes the code easier to read
and maintain. Finally, make Trackster-as-layer fully heatmap compatible.

#### PR validation:

usual `runTheMatrix.py -l limited -i all`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

