### PR TITLE
Update L1TrackTrigger_cff.py

### DIFF
--- a/Configuration/StandardSequences/python/L1TrackTrigger_cff.py
+++ b/Configuration/StandardSequences/python/L1TrackTrigger_cff.py
@@ -13,5 +13,3 @@ _tttracks_l1tracktrigger = cms.Sequence(_tttracks_l1tracktrigger + L1PromptExten
 
 from Configuration.Eras.Modifier_phase2_trigger_cff import phase2_trigger
 phase2_trigger.toReplaceWith( L1TrackTrigger, _tttracks_l1tracktrigger )
-
-TTStubAlgorithm_official_Phase2TrackerDigi_.zMatchingPS = True


### PR DESCRIPTION
The deleted line is no longer necessary, since the default value of TTStubAlgorithm_official_Phase2TrackerDigi_.zMatchingPS = cms.bool(True) already in https://github.com/cms-sw/cmssw/blob/master/L1Trigger/TrackTrigger/python/TTStubAlgorithmRegister_cfi.py#L17 .

