### PR TITLE
[120X] Add GTs for Run-3 test beam data taking + edit DQM unit test run number and dataset

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -32,13 +32,13 @@ autoCond = {
     # GlobalTag for Run2 HI data
     'run2_data_promptlike_hi'      : '120X_dataRun2_PromptLike_HI_v1',
     # GlobalTag for Run3 HLT: it points to the online GT
-    'run3_hlt'                     : '120X_dataRun3_HLT_Candidate_2021_09_30_19_21_44',
+    'run3_hlt'                     : '120X_dataRun3_HLT_v3',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'              : '113X_dataRun2_HLT_relval_v2',
     # GlobalTag for Run3 data relvals (express GT)
-    'run3_data_express'            : '120X_dataRun3_Express_Candidate_2021_09_30_18_36_13',
+    'run3_data_express'            : '120X_dataRun3_Express_v2',
     # GlobalTag for Run3 data relvals
-    'run3_data_prompt'             : '113X_dataRun3_Prompt_v3',
+    'run3_data_prompt'             : '120X_dataRun3_Prompt_v2',
     # GlobalTag for Run3 offline data reprocessing
     'run3_data'                    : '113X_dataRun3_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -32,11 +32,11 @@ autoCond = {
     # GlobalTag for Run2 HI data
     'run2_data_promptlike_hi'      : '120X_dataRun2_PromptLike_HI_v1',
     # GlobalTag for Run3 HLT: it points to the online GT
-    'run3_hlt'                     : '113X_dataRun3_HLT_v3',
+    'run3_hlt'                     : '120X_dataRun3_HLT_Candidate_2021_09_30_19_21_44',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'              : '113X_dataRun2_HLT_relval_v2',
     # GlobalTag for Run3 data relvals (express GT)
-    'run3_data_express'            : '113X_dataRun3_Express_v4',
+    'run3_data_express'            : '120X_dataRun3_Express_Candidate_2021_09_30_18_36_13',
     # GlobalTag for Run3 data relvals
     'run3_data_prompt'             : '113X_dataRun3_Prompt_v3',
     # GlobalTag for Run3 offline data reprocessing

--- a/DQM/Integration/python/config/unittestinputsource_cfi.py
+++ b/DQM/Integration/python/config/unittestinputsource_cfi.py
@@ -32,7 +32,7 @@ options.register('runUniqueKey',
     "Unique run key from RCMS for Frontier")
 
 options.register('runNumber',
-                 334393,
+                 344518,
                  VarParsing.VarParsing.multiplicity.singleton,
                  VarParsing.VarParsing.varType.int,
                  "Run number. This run number has to be present in the dataset configured with the dataset option.")

--- a/DQM/Integration/python/config/unittestinputsource_cfi.py
+++ b/DQM/Integration/python/config/unittestinputsource_cfi.py
@@ -38,10 +38,10 @@ options.register('runNumber',
                  "Run number. This run number has to be present in the dataset configured with the dataset option.")
 
 options.register('dataset',
-                 '/ExpressCosmics/Commissioning2019-Express-v1/FEVT',
+                 '/ExpressCosmics/Commissioning2021-Express-v1/FEVT',
                  VarParsing.VarParsing.multiplicity.singleton,
                  VarParsing.VarParsing.varType.string,
-                 "Dataset name like '/ExpressCosmics/Commissioning2019-Express-v1/FEVT'")
+                 "Dataset name like '/ExpressCosmics/Commissioning2021-Express-v1/FEVT'")
 
 options.register('maxLumi',
                  2,


### PR DESCRIPTION
#### PR description:

Global Tag change:
 * it is needed for https://github.com/cms-sw/cmssw/pull/35551
 * this PR can be part of a commit in 35551 if preferred (this PR was submitted just to make things go faster)
 * Here are the differences with respect to the CRUZET GTs:
HLT:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_dataRun3_HLT_v3/120X_dataRun3_HLT_v3
Express:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_dataRun3_Express_v4/120X_dataRun3_Express_v2
Prompt:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_dataRun3_Prompt_v3/120X_dataRun3_Prompt_v2

HN: 
https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4488.html

Edit: 
 * now this PR contains changes in the DQM unit tests, to test a more recent CRUZET run 

#### PR validation:

Was tested at P5 for DQM

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is a backport, needed for DQM testing
