### PR TITLE
Avoid deprecated false positive warnings for ObjectSelector variant

### DIFF
--- a/CommonTools/CandAlgos/interface/SingleObjectShallowCloneSelector.h
+++ b/CommonTools/CandAlgos/interface/SingleObjectShallowCloneSelector.h
@@ -13,8 +13,8 @@ template <typename InputCollection,
           typename Selector,
           typename StoreContainer = typename helper::StoreContainerTrait<reco::CandidateCollection>::type,
           typename PostProcessor = helper::NullPostProcessor<reco::CandidateCollection>,
-          typename StoreManager = typename helper::StoreManagerTrait<reco::CandidateCollection>::type,
-          typename Base = typename helper::StoreManagerTrait<reco::CandidateCollection>::base,
+          typename StoreManager = typename helper::StoreManagerTrait<reco::CandidateCollection, edm::EDFilter>::type,
+          typename Base = typename helper::StoreManagerTrait<reco::CandidateCollection, edm::EDFilter>::base,
           typename RefAdder = typename helper::SelectionAdderTrait<InputCollection, StoreContainer>::type>
 class SingleObjectShallowCloneSelector
     : public ObjectShallowCloneSelector<

--- a/CommonTools/CandAlgos/plugins/AssociatedVariableMaxCutCandSelectorNew.cc
+++ b/CommonTools/CandAlgos/plugins/AssociatedVariableMaxCutCandSelectorNew.cc
@@ -16,7 +16,7 @@
  *
  */
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "CommonTools/UtilAlgos/interface/SingleObjectSelector.h"
+#include "CommonTools/UtilAlgos/interface/ObjectSelector.h"
 #include "CommonTools/UtilAlgos/interface/AssociatedVariableCollectionSelector.h"
 #include "CommonTools/UtilAlgos/interface/AndSelector.h"
 #include "CommonTools/UtilAlgos/interface/RefSelector.h"

--- a/CommonTools/RecoAlgos/interface/GsfElectronSelector.h
+++ b/CommonTools/RecoAlgos/interface/GsfElectronSelector.h
@@ -19,7 +19,7 @@
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrackExtra.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
-#include "CommonTools/UtilAlgos/interface/ObjectSelector.h"
+#include "CommonTools/UtilAlgos/interface/SingleObjectSelector.h"
 
 namespace helper {
   struct GsfElectronCollectionStoreManager {
@@ -108,7 +108,7 @@ namespace helper {
     std::unique_ptr<TrackingRecHitCollection> selHits_;
   };
 
-  class GsfElectronSelectorBase : public edm::EDFilter {
+  class GsfElectronSelectorBase : public edm::stream::EDFilter<> {
   public:
     GsfElectronSelectorBase(const edm::ParameterSet& cfg) {
       std::string alias(cfg.getParameter<std::string>("@module_label"));
@@ -122,11 +122,26 @@ namespace helper {
     }
   };
 
-  template <>
-  struct StoreManagerTrait<reco::GsfElectronCollection> {
+  struct GsfElectronCollectionStoreManagerTrait {
     typedef GsfElectronCollectionStoreManager type;
     typedef GsfElectronSelectorBase base;
   };
+
 }  // namespace helper
+
+template <typename Selector,
+          typename StoreManagerTrait = ::helper::GsfElectronCollectionStoreManagerTrait,
+          typename OutputCollection =
+              typename ::helper::SelectedOutputCollectionTrait<reco::GsfElectronCollection>::type,
+          typename StoreContainer = typename ::helper::StoreContainerTrait<reco::GsfElectronCollection>::type,
+          typename PostProcessor = ::helper::NullPostProcessor<reco::GsfElectronCollection> >
+using GsfElectronSingleObjectSelector = SingleObjectSelectorBase<reco::GsfElectronCollection,
+                                                                 Selector,
+                                                                 typename StoreManagerTrait::base,
+                                                                 OutputCollection,
+                                                                 StoreContainer,
+                                                                 PostProcessor,
+                                                                 typename StoreManagerTrait::type,
+                                                                 typename StoreManagerTrait::base>;
 
 #endif

--- a/CommonTools/RecoAlgos/plugins/EtaPtMinGsfElectronFullCloneSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/EtaPtMinGsfElectronFullCloneSelector.cc
@@ -15,7 +15,7 @@
 #include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
 #include "CommonTools/RecoAlgos/interface/GsfElectronSelector.h"
 
-typedef SingleObjectSelector<reco::GsfElectronCollection, AndSelector<EtaRangeSelector, PtMinSelector> >
+typedef GsfElectronSingleObjectSelector<AndSelector<EtaRangeSelector, PtMinSelector> >
     EtaPtMinGsfElectronFullCloneSelector;
 
 DEFINE_FWK_MODULE(EtaPtMinGsfElectronFullCloneSelector);

--- a/CommonTools/RecoAlgos/plugins/EtaPtMinPixelMatchGsfElectronFullCloneSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/EtaPtMinPixelMatchGsfElectronFullCloneSelector.cc
@@ -15,7 +15,7 @@
 #include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
 #include "CommonTools/RecoAlgos/interface/GsfElectronSelector.h"
 
-typedef SingleObjectSelector<reco::GsfElectronCollection, AndSelector<EtaRangeSelector, PtMinSelector> >
+typedef GsfElectronSingleObjectSelector<AndSelector<EtaRangeSelector, PtMinSelector> >
     EtaPtMinPixelMatchGsfElectronFullCloneSelector;
 
 DEFINE_FWK_MODULE(EtaPtMinPixelMatchGsfElectronFullCloneSelector);

--- a/CommonTools/UtilAlgos/interface/NullPostProcessor.h
+++ b/CommonTools/UtilAlgos/interface/NullPostProcessor.h
@@ -8,18 +8,18 @@
 #include "DataFormats/Common/interface/OrphanHandle.h"
 
 namespace edm {
-  class EDFilter;
   class Event;
   class ParameterSet;
 }  // namespace edm
 
 namespace helper {
 
-  template <typename OutputCollection, typename EdmFilter = edm::EDFilter>
+  template <typename OutputCollection>
   struct NullPostProcessor {
     NullPostProcessor(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC) : NullPostProcessor(iConfig) {}
     NullPostProcessor(const edm::ParameterSet& iConfig) {}
-    void init(EdmFilter&) {}
+    template <typename F>
+    void init(F&) {}
     void process(edm::OrphanHandle<OutputCollection>, edm::Event&) {}
   };
 

--- a/CommonTools/UtilAlgos/interface/ObjectSelector.h
+++ b/CommonTools/UtilAlgos/interface/ObjectSelector.h
@@ -13,76 +13,22 @@
  */
 
 #include "FWCore/Framework/interface/EDFilter.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Utilities/interface/InputTag.h"
-#include "CommonTools/UtilAlgos/interface/ParameterAdapter.h"
+#include "CommonTools/UtilAlgos/interface/ObjectSelectorBase.h"
 #include "CommonTools/UtilAlgos/interface/NonNullNumberSelector.h"
 #include "CommonTools/UtilAlgos/interface/StoreManagerTrait.h"
 #include "CommonTools/UtilAlgos/interface/SelectedOutputCollectionTrait.h"
 #include "CommonTools/UtilAlgos/interface/NullPostProcessor.h"
 #include "CommonTools/UtilAlgos/interface/EventSetupInitTrait.h"
-#include <utility>
-#include <vector>
-#include <memory>
-#include <algorithm>
 
 template <typename Selector,
           typename OutputCollection =
               typename ::helper::SelectedOutputCollectionTrait<typename Selector::collection>::type,
           typename SizeSelector = NonNullNumberSelector,
-          typename PostProcessor = ::helper::NullPostProcessor<OutputCollection, edm::EDFilter>,
+          typename PostProcessor = ::helper::NullPostProcessor<OutputCollection>,
           typename StoreManager = typename ::helper::StoreManagerTrait<OutputCollection, edm::EDFilter>::type,
           typename Base = typename ::helper::StoreManagerTrait<OutputCollection, edm::EDFilter>::base,
           typename Init = typename ::reco::modules::EventSetupInit<Selector>::type>
-class ObjectSelector : public Base {
-public:
-  /// constructor
-  // ObjectSelector()=default;
-  explicit ObjectSelector(const edm::ParameterSet& cfg)
-      : Base(cfg),
-        srcToken_(
-            this->template consumes<typename Selector::collection>(cfg.template getParameter<edm::InputTag>("src"))),
-        filter_(false),
-        selector_(cfg, this->consumesCollector()),
-        sizeSelector_(reco::modules::make<SizeSelector>(cfg)),
-        postProcessor_(cfg, this->consumesCollector()) {
-    const std::string filter("filter");
-    std::vector<std::string> bools = cfg.template getParameterNamesForType<bool>();
-    bool found = std::find(bools.begin(), bools.end(), filter) != bools.end();
-    if (found)
-      filter_ = cfg.template getParameter<bool>(filter);
-    postProcessor_.init(*this);
-  }
-  /// destructor
-  ~ObjectSelector() override {}
-
-private:
-  /// process one event
-  bool filter(edm::Event& evt, const edm::EventSetup& es) override {
-    Init::init(selector_, evt, es);
-    using namespace std;
-    edm::Handle<typename Selector::collection> source;
-    evt.getByToken(srcToken_, source);
-    StoreManager manager(source);
-    selector_.select(source, evt, es);
-    manager.cloneAndStore(selector_.begin(), selector_.end(), evt);
-    bool result = (!filter_ || sizeSelector_(manager.size()));
-    edm::OrphanHandle<OutputCollection> filtered = manager.put(evt);
-    postProcessor_.process(filtered, evt);
-    return result;
-  }
-  /// source collection label
-  edm::EDGetTokenT<typename Selector::collection> srcToken_;
-  /// filter event
-  bool filter_;
-  /// Object collection selector
-  Selector selector_;
-  /// selected object collection size selector
-  SizeSelector sizeSelector_;
-  /// post processor
-  PostProcessor postProcessor_;
-};
+using ObjectSelector =
+    ObjectSelectorBase<Selector, OutputCollection, SizeSelector, PostProcessor, StoreManager, Base, Init>;
 
 #endif

--- a/CommonTools/UtilAlgos/interface/ObjectSelectorBase.h
+++ b/CommonTools/UtilAlgos/interface/ObjectSelectorBase.h
@@ -1,0 +1,81 @@
+#ifndef RecoAlgos_ObjectSelectorBase_h
+#define RecoAlgos_ObjectSelectorBase_h
+/** \class ObjectSelectorBase
+ *
+ * selects a subset of a collection.
+ *
+ * \author Luca Lista, INFN
+ *
+ * \version $Revision: 1.3 $
+ *
+ * $Id: ObjectSelectorBase.h,v 1.3 2010/02/20 20:55:27 wmtan Exp $
+ *
+ */
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "CommonTools/UtilAlgos/interface/ParameterAdapter.h"
+#include <utility>
+#include <vector>
+#include <memory>
+#include <algorithm>
+
+template <typename Selector,
+          typename OutputCollection,
+          typename SizeSelector,
+          typename PostProcessor,
+          typename StoreManager,
+          typename Base,
+          typename Init>
+class ObjectSelectorBase : public Base {
+public:
+  /// constructor
+  // ObjectSelectorBase()=default;
+  explicit ObjectSelectorBase(const edm::ParameterSet& cfg)
+      : Base(cfg),
+        srcToken_(
+            this->template consumes<typename Selector::collection>(cfg.template getParameter<edm::InputTag>("src"))),
+        filter_(false),
+        selector_(cfg, this->consumesCollector()),
+        sizeSelector_(reco::modules::make<SizeSelector>(cfg)),
+        postProcessor_(cfg, this->consumesCollector()) {
+    const std::string filter("filter");
+    std::vector<std::string> bools = cfg.template getParameterNamesForType<bool>();
+    bool found = std::find(bools.begin(), bools.end(), filter) != bools.end();
+    if (found)
+      filter_ = cfg.template getParameter<bool>(filter);
+    postProcessor_.init(*this);
+  }
+  /// destructor
+  ~ObjectSelectorBase() override {}
+
+private:
+  /// process one event
+  bool filter(edm::Event& evt, const edm::EventSetup& es) override {
+    Init::init(selector_, evt, es);
+    using namespace std;
+    edm::Handle<typename Selector::collection> source;
+    evt.getByToken(srcToken_, source);
+    StoreManager manager(source);
+    selector_.select(source, evt, es);
+    manager.cloneAndStore(selector_.begin(), selector_.end(), evt);
+    bool result = (!filter_ || sizeSelector_(manager.size()));
+    edm::OrphanHandle<OutputCollection> filtered = manager.put(evt);
+    postProcessor_.process(filtered, evt);
+    return result;
+  }
+  /// source collection label
+  edm::EDGetTokenT<typename Selector::collection> srcToken_;
+  /// filter event
+  bool filter_;
+  /// Object collection selector
+  Selector selector_;
+  /// selected object collection size selector
+  SizeSelector sizeSelector_;
+  /// post processor
+  PostProcessor postProcessor_;
+};
+
+#endif

--- a/CommonTools/UtilAlgos/interface/ObjectSelectorStream.h
+++ b/CommonTools/UtilAlgos/interface/ObjectSelectorStream.h
@@ -20,22 +20,27 @@
 
 // system include files
 #include "FWCore/Framework/interface/stream/EDFilter.h"
-#include "CommonTools/UtilAlgos/interface/ObjectSelector.h"
+#include "CommonTools/UtilAlgos/interface/ObjectSelectorBase.h"
+#include "CommonTools/UtilAlgos/interface/NonNullNumberSelector.h"
+#include "CommonTools/UtilAlgos/interface/StoreManagerTrait.h"
+#include "CommonTools/UtilAlgos/interface/SelectedOutputCollectionTrait.h"
+#include "CommonTools/UtilAlgos/interface/NullPostProcessor.h"
+#include "CommonTools/UtilAlgos/interface/EventSetupInitTrait.h"
 
 template <typename Selector,
           typename OutputCollection =
               typename ::helper::SelectedOutputCollectionTrait<typename Selector::collection>::type,
           typename SizeSelector = NonNullNumberSelector,
-          typename PostProcessor = ::helper::NullPostProcessor<OutputCollection, edm::stream::EDFilter<>>,
+          typename PostProcessor = ::helper::NullPostProcessor<OutputCollection>,
           typename StoreManager = typename ::helper::StoreManagerTrait<OutputCollection, edm::stream::EDFilter<>>::type,
           typename Init = typename ::reco::modules::EventSetupInit<Selector>::type>
 using ObjectSelectorStream =
-    ObjectSelector<Selector,
-                   OutputCollection,
-                   SizeSelector,
-                   PostProcessor,
-                   StoreManager,
-                   typename ::helper::StoreManagerTrait<OutputCollection, edm::stream::EDFilter<>>::base,
-                   Init>;
+    ObjectSelectorBase<Selector,
+                       OutputCollection,
+                       SizeSelector,
+                       PostProcessor,
+                       StoreManager,
+                       typename ::helper::StoreManagerTrait<OutputCollection, edm::stream::EDFilter<>>::base,
+                       Init>;
 
 #endif

--- a/CommonTools/UtilAlgos/interface/ObjectSelectorStreamProducer.h
+++ b/CommonTools/UtilAlgos/interface/ObjectSelectorStreamProducer.h
@@ -7,7 +7,7 @@
 template <
     typename Selector,
     typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<typename Selector::collection>::type,
-    typename PostProcessor = ::helper::NullPostProcessor<OutputCollection, edm::stream::EDProducer<>>,
+    typename PostProcessor = ::helper::NullPostProcessor<OutputCollection>,
     typename StoreManager = typename ::helper::StoreManagerTrait<OutputCollection, edm::stream::EDProducer<>>::type,
     typename Init = typename ::reco::modules::EventSetupInit<Selector>::type>
 using ObjectSelectorStreamProducer =

--- a/CommonTools/UtilAlgos/interface/SingleObjectSelector.h
+++ b/CommonTools/UtilAlgos/interface/SingleObjectSelector.h
@@ -4,7 +4,12 @@
  *
  * \author Luca Lista, INFN
  */
-#include "CommonTools/UtilAlgos/interface/ObjectSelector.h"
+#include "CommonTools/UtilAlgos/interface/ObjectSelectorBase.h"
+#include "CommonTools/UtilAlgos/interface/NonNullNumberSelector.h"
+#include "CommonTools/UtilAlgos/interface/StoreManagerTrait.h"
+#include "CommonTools/UtilAlgos/interface/SelectedOutputCollectionTrait.h"
+#include "CommonTools/UtilAlgos/interface/NullPostProcessor.h"
+#include "CommonTools/UtilAlgos/interface/EventSetupInitTrait.h"
 #include "CommonTools/UtilAlgos/interface/StoreContainerTrait.h"
 #include "CommonTools/UtilAlgos/interface/SelectionAdderTrait.h"
 #include "CommonTools/UtilAlgos/interface/SingleElementCollectionSelector.h"
@@ -19,38 +24,37 @@ template <typename InputCollection,
           typename EdmFilter,
           typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<InputCollection>::type,
           typename StoreContainer = typename ::helper::StoreContainerTrait<OutputCollection>::type,
-          typename PostProcessor = ::helper::NullPostProcessor<OutputCollection, EdmFilter>,
+          typename PostProcessor = ::helper::NullPostProcessor<OutputCollection>,
           typename StoreManager = typename ::helper::StoreManagerTrait<OutputCollection, EdmFilter>::type,
           typename Base = typename ::helper::StoreManagerTrait<OutputCollection, EdmFilter>::base,
           typename RefAdder = typename ::helper::SelectionAdderTrait<InputCollection, StoreContainer>::type>
 class SingleObjectSelectorBase
-    : public ObjectSelector<
+    : public ObjectSelectorBase<
           SingleElementCollectionSelector<InputCollection, Selector, OutputCollection, StoreContainer, RefAdder>,
           OutputCollection,
           NonNullNumberSelector,
           PostProcessor,
           StoreManager,
-          Base> {
+          Base,
+          typename ::reco::modules::EventSetupInit<
+              SingleElementCollectionSelector<InputCollection, Selector, OutputCollection, StoreContainer, RefAdder>>::
+              type> {
+  using Init = typename ::reco::modules::EventSetupInit<
+      SingleElementCollectionSelector<InputCollection, Selector, OutputCollection, StoreContainer, RefAdder>>::type;
+
 public:
   // SingleObjectSelectorBase() = default;
   explicit SingleObjectSelectorBase(const edm::ParameterSet& cfg)
-      : ObjectSelector<
+      : ObjectSelectorBase<
             SingleElementCollectionSelector<InputCollection, Selector, OutputCollection, StoreContainer, RefAdder>,
             OutputCollection,
             NonNullNumberSelector,
             PostProcessor,
             StoreManager,
-            Base>(cfg) {}
+            Base,
+            Init>(cfg) {}
   ~SingleObjectSelectorBase() override {}
 };
-
-template <typename InputCollection,
-          typename Selector,
-          typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<InputCollection>::type,
-          typename StoreContainer = typename ::helper::StoreContainerTrait<OutputCollection>::type,
-          typename PostProcessor = ::helper::NullPostProcessor<OutputCollection, edm::EDFilter> >
-using SingleObjectSelectorLegacy =
-    SingleObjectSelectorBase<InputCollection, Selector, edm::EDFilter, OutputCollection, StoreContainer, PostProcessor>;
 
 #include "FWCore/Framework/interface/stream/EDFilter.h"
 
@@ -58,7 +62,7 @@ template <typename InputCollection,
           typename Selector,
           typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<InputCollection>::type,
           typename StoreContainer = typename ::helper::StoreContainerTrait<OutputCollection>::type,
-          typename PostProcessor = ::helper::NullPostProcessor<OutputCollection, edm::stream::EDFilter<> > >
+          typename PostProcessor = ::helper::NullPostProcessor<OutputCollection>>
 using SingleObjectSelectorStream = SingleObjectSelectorBase<InputCollection,
                                                             Selector,
                                                             edm::stream::EDFilter<>,
@@ -70,7 +74,7 @@ template <typename InputCollection,
           typename Selector,
           typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<InputCollection>::type,
           typename StoreContainer = typename ::helper::StoreContainerTrait<OutputCollection>::type,
-          typename PostProcessor = ::helper::NullPostProcessor<OutputCollection, edm::stream::EDFilter<> > >
+          typename PostProcessor = ::helper::NullPostProcessor<OutputCollection>>
 using SingleObjectSelector =
     SingleObjectSelectorStream<InputCollection, Selector, OutputCollection, StoreContainer, PostProcessor>;
 

--- a/CommonTools/UtilAlgos/interface/StoreManagerTrait.h
+++ b/CommonTools/UtilAlgos/interface/StoreManagerTrait.h
@@ -87,7 +87,7 @@ namespace helper {
     ObjectSelectorBase(const edm::ParameterSet &) { this->template produces<OutputCollection>(); }
   };
 
-  template <typename OutputCollection, typename EdmFilter = edm::EDFilter>
+  template <typename OutputCollection, typename EdmFilter>
   struct StoreManagerTrait {
     using type = CollectionStoreManager<OutputCollection>;
     using base = ObjectSelectorBase<OutputCollection, EdmFilter>;


### PR DESCRIPTION
#### PR description:

The deprecation warning about legacy module will trigger when the header file for one of those modules in included. Although ObjectSelector<> defaults to used edm::EDFilter, its variants do not. By doing some code reorganization, the variants no longer use ObjectSelector<>, instead they use ObjectSelectorBase<> which avoids default template parameters.

Now code that use the thread safe variants of ObjectSelector<> will not issue the deprecation warning.

#### PR validation:

Doing `git cms-checkdeps -a` and then compiling in the CMSDEPRECATED IB no longer generate warnings for the code using the variants. Code including explicitly or implicitly ObjectSelector.h still issue the warning.