### PR TITLE
Adding pytest and anyio unit test

### DIFF
--- a/PhysicsTools/PythonAnalysis/test/BuildFile.xml
+++ b/PhysicsTools/PythonAnalysis/test/BuildFile.xml
@@ -106,6 +106,7 @@
 <test name="import-pycodestyle" command="python3 -c 'import pycodestyle'"/>
 <test name="import-pycurl" command="python3 -c 'import pycurl'"/>
 <test name="import-pyparsing" command="python3 -c 'import pyparsing'"/>
+<test name="import-pytest" command="python3 -m pytest --version"/>
 <test name="import-sqlite3" command="python3 -c 'import sqlite3'"/>
 <test name="import-pytz" command="python3 -c 'import pytz'"/>
 <test name="import-zmq" command="python3 -c 'import zmq'"/>

--- a/PhysicsTools/PythonAnalysis/test/BuildFile.xml
+++ b/PhysicsTools/PythonAnalysis/test/BuildFile.xml
@@ -33,6 +33,7 @@
   <test name="testCxOracle" command="python3 -c 'import cx_Oracle'"/>
 </iftool>
 
+<test name="import-anyio" command="python3 -c 'import anyio'"/>
 <test name="import-jinja2" command="python3 -c 'import jinja2'"/>
 <test name="import-keras" command="python3 -c 'import keras'"/>
 <test name="import-markupsafe" command="python3 -c 'import markupsafe'"/>
@@ -121,6 +122,7 @@
 <test name="import-send2trash" command="python3 -c 'import send2trash'"/>
 <test name="import-simplegeneric" command="python3 -c 'import simplegeneric'"/>
 <test name="import-singledispatch" command="python3 -c 'import singledispatch'"/>
+<test name="import-sniffio" command="python3 -c 'import sniffio'"/>
 <test name="import-sqlalchemy" command="python3 -c 'import sqlalchemy'"/>
 <test name="import-sympy" command="python3 -c 'import sympy'"/>
 <test name="import-tables" command="python3 -c 'import tables'"/>


### PR DESCRIPTION
`pytest` is broken in 12.1.0.pre3 due to missing `anyio` dependencies (see https://github.com/cms-sw/cmsdist/issues/7365). This PR proposes to add simple unit tests for `anyio`, `sniffio` and `pytest`  .

This should be merged with https://github.com/cms-sw/cmsdist/pull/7366
