### PR TITLE
Add a workaround for AlCa paths to the Patatrack customisation

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
+++ b/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
@@ -217,6 +217,32 @@ def customisePixelLocalReconstruction(process):
     process.HLTDoLocalPixelSequence = cms.Sequence(process.HLTDoLocalPixelTask)
 
 
+    # workaround for AlCa paths
+
+    if 'AlCa_LumiPixelsCounts_Random_v1' in process.__dict__:
+        # redefine the path to use the HLTDoLocalPixelSequence
+        process.AlCa_LumiPixelsCounts_Random_v1 = cms.Path(
+            process.HLTBeginSequenceRandom +
+            process.hltScalersRawToDigi +
+            process.hltPreAlCaLumiPixelsCountsRandom +
+            process.hltPixelTrackerHVOn +
+            process.HLTDoLocalPixelSequence +
+            process.hltAlcaPixelClusterCounts +
+            process.HLTEndSequence )
+
+    if 'AlCa_LumiPixelsCounts_ZeroBias_v1' in process.__dict__:
+        # redefine the path to use the HLTDoLocalPixelSequence
+        process.AlCa_LumiPixelsCounts_ZeroBias_v1 = cms.Path(
+            process.HLTBeginSequence +
+            process.hltScalersRawToDigi +
+            process.hltL1sZeroBias +
+            process.hltPreAlCaLumiPixelsCountsZeroBias +
+            process.hltPixelTrackerHVOn +
+            process.HLTDoLocalPixelSequence +
+            process.hltAlcaPixelClusterCounts +
+            process.HLTEndSequence )
+
+
     # done
     return process
 


### PR DESCRIPTION
#### PR description:

The AlCa LumiPixelsCounts paths use the pixel cluster modules directly, without any Sequence or Task.
After applying the Patatrack customisation, this leaves those modules both "scheduled" (on the AlCa paths) and "unscheduled" (on every other path), breaking the latter.

To work around this issue, the Patatrack customisation now redefines the AlCa LumiPixelsCounts using the `HLTDoLocalPixelSequence` and the `HLTDoLocalPixelTask`, making the pixel modules unscheduled.

#### PR validation:

Applying the Patatrack customisation to the latest HLT menu and running over 2018 data now works.
