### PR TITLE
[Py3] Fix cmsDriver.py for --profile options

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -302,8 +302,8 @@ class ConfigBuilder(object):
             profilerFormat = "%s___%s___%%I.gz" % (
                 self._options.evt_type.replace("_cfi", ""),
                 hashlib.md5(
-                    str(self._options.step) + str(self._options.pileup) + str(self._options.conditions) +
-                    str(self._options.datatier) + str(self._options.profileTypeLabel)
+                    (str(self._options.step) + str(self._options.pileup) + str(self._options.conditions) +
+                    str(self._options.datatier) + str(self._options.profileTypeLabel)).encode('utf-8')
                 ).hexdigest()
             )
         if not profilerJobFormat and profilerFormat.endswith(".gz"):


### PR DESCRIPTION
12.0.X and 12.1.X igprof jobs are failing with error
```
>cmsDriver.py TTbar_14TeV_TuneCP5_cfi -s GEN,SIM -n 10 --conditions auto:phase2_realistic_T15 --beamspot HLLHC14TeV --datatier GEN-SIM --eventcontent RAWSIM --geometry Extended2026D49 --era Phase2C9 --relval 9000,100 -n 10 --profile pp --fileout file:step1.root
GEN,SIM,ENDJOB
We have determined that this is simulation (if not, rerun cmsDriver.py with --data)
Step: GEN Spec: 
Loading generator fragment from Configuration.Generator.TTbar_14TeV_TuneCP5_cfi
Step: SIM Spec: 
Step: ENDJOB Spec: 
Traceback (most recent call last):
  File "bin/slc7_amd64_gcc900/cmsDriver.py", line 56, in <module>
    run()
  File "bin/slc7_amd64_gcc900/cmsDriver.py", line 28, in run
    configBuilder.prepare()
  File "python/Configuration/Applications/ConfigBuilder.py", line 2178, in prepare
    self.addCommon()
  File "Configuration/Applications/ConfigBuilder.py", line 359, in addCommon
    (start, interval, eventFormat, jobFormat)=self.profileOptions()
  File "Configuration/Applications/ConfigBuilder.py", line 304, in profileOptions
    hashlib.md5(
TypeError: Unicode-objects must be encoded before hashing
```

I think this is due to python3 update. This PR should fix the issue. Local tests runs fine
```
>cmsDriver.py TTbar_14TeV_TuneCP5_cfi -s GEN,SIM -n 10 --conditions auto:phase2_realistic_T15 --beamspot HLLHC14TeV --datatier GEN-SIM --eventcontent RAWSIM --geometry Extended2026D49 --era Phase2C9 --relval 9000,100 -n 10 --profile pp --fileout file:step1.root
GEN,SIM,ENDJOB
We have determined that this is simulation (if not, rerun cmsDriver.py with --data)
Step: GEN Spec: 
Loading generator fragment from Configuration.Generator.TTbar_14TeV_TuneCP5_cfi
Step: SIM Spec: 
Step: ENDJOB Spec: 
Starting igprof -t cmsRun -pp cmsRun  TTbar_14TeV_TuneCP5_cfi_GEN_SIM.py

```