### PR TITLE
Make Geant4 geometry exception to be just a warning

### DIFF
--- a/SimG4Core/Application/interface/ExceptionHandler.h
+++ b/SimG4Core/Application/interface/ExceptionHandler.h
@@ -18,7 +18,7 @@
 
 class ExceptionHandler : public G4VExceptionHandler {
 public:
-  explicit ExceptionHandler();
+  explicit ExceptionHandler(double th);
   ~ExceptionHandler() override;
 
   int operator==(const ExceptionHandler &right) const { return (this == &right); }
@@ -31,6 +31,9 @@ public:
 
   ExceptionHandler(const ExceptionHandler &) = delete;
   ExceptionHandler &operator=(const ExceptionHandler &right) = delete;
+
+private:
+  double m_eth;
 };
 
 #endif

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -85,6 +85,7 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
     StorePhysicsTables = cms.untracked.bool(False),
     RestorePhysicsTables = cms.untracked.bool(False),
     UseParametrisedEMPhysics = cms.untracked.bool(True),
+    ThresholdForGeometryExceptions = cms.double(0.01),   ## in GeV
     CheckGeometry = cms.untracked.bool(False),
     OnlySDs = cms.vstring('ZdcSensitiveDetector', 'TotemT2ScintSensitiveDetector', 'TotemSensitiveDetector', 'RomanPotSensitiveDetector', 'PLTSensitiveDetector', 'MuonSensitiveDetector', 'MtdSensitiveDetector', 'BCM1FSensitiveDetector', 'EcalSensitiveDetector', 'CTPPSSensitiveDetector', 'BSCSensitiveDetector', 'CTPPSDiamondSensitiveDetector', 'FP420SensitiveDetector', 'BHMSensitiveDetector', 'CastorSensitiveDetector', 'CaloTrkProcessing', 'HcalSensitiveDetector', 'TkAccumulatingSensitiveDetector'),
     G4CheckOverlap = cms.untracked.PSet(

--- a/SimG4Core/Application/src/ExceptionHandler.cc
+++ b/SimG4Core/Application/src/ExceptionHandler.cc
@@ -3,10 +3,13 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+#include "G4EventManager.hh"
+#include "G4TrackingManager.hh"
+#include "G4Track.hh"
 #include "globals.hh"
 #include <sstream>
 
-ExceptionHandler::ExceptionHandler() {}
+ExceptionHandler::ExceptionHandler(double th) : m_eth(th) {}
 
 ExceptionHandler::~ExceptionHandler() {}
 
@@ -19,14 +22,37 @@ bool ExceptionHandler::Notify(const char* exceptionOrigin,
   static const G4String ws_banner = "\n-------- WWWW ------- G4Exception-START -------- WWWW -------\n";
   static const G4String we_banner = "\n-------- WWWW -------- G4Exception-END --------- WWWW -------\n";
 
+  const G4Track* track = G4EventManager::GetEventManager()->GetTrackingManager()->GetTrack();
+  double ekin = m_eth;
+
   std::stringstream message;
   message << "*** G4Exception : " << exceptionCode << "\n"
           << "      issued by : " << exceptionOrigin << "\n"
           << description;
 
+  // part of exception happens outside tracking loop
+  if (nullptr != track) {
+    ekin = track->GetKineticEnergy();
+    message << "\n"
+            << "TrackID=" << track->GetTrackID() << " ParentID=" << track->GetParentID() << "  "
+            << track->GetParticleDefinition()->GetParticleName() << "; Ekin(MeV)=" << ekin / CLHEP::MeV
+            << "; time(ns)=" << track->GetGlobalTime() / CLHEP::ns << "; status=" << track->GetTrackStatus()
+            << "\n   position(mm): " << track->GetPosition() << "; direction: " << track->GetMomentumDirection();
+    const G4VPhysicalVolume* vol = track->GetVolume();
+    if (nullptr != vol) {
+      message << "\n   PhysicalVolume: " << vol->GetName() << "; material: " << track->GetMaterial()->GetName();
+    }
+    message << "\n   stepNumber=" << track->GetCurrentStepNumber()
+            << "; stepLength(mm)=" << track->GetStepLength() / CLHEP::mm << "; weight=" << track->GetWeight();
+    const G4VProcess* proc = track->GetCreatorProcess();
+    if (nullptr != proc) {
+      message << "; creatorProcess: " << proc->GetProcessName() << "; modeID=" << track->GetCreatorModelID();
+    }
+  }
+
   G4ExceptionSeverity localSeverity = severity;
   G4String code = G4String(*exceptionCode);
-  if (code == "GeomNav0003") {
+  if (ekin < m_eth && code == "GeomNav0003") {
     localSeverity = JustWarning;
   }
 

--- a/SimG4Core/Application/src/ExceptionHandler.cc
+++ b/SimG4Core/Application/src/ExceptionHandler.cc
@@ -25,8 +25,8 @@ bool ExceptionHandler::Notify(const char* exceptionOrigin,
           << description;
 
   G4ExceptionSeverity localSeverity = severity;
-  G4String code = G4String(*exceptionCode); 
-  if(code == "GeomNav0003") {
+  G4String code = G4String(*exceptionCode);
+  if (code == "GeomNav0003") {
     localSeverity = JustWarning;
   }
 

--- a/SimG4Core/Application/src/ExceptionHandler.cc
+++ b/SimG4Core/Application/src/ExceptionHandler.cc
@@ -46,9 +46,10 @@ bool ExceptionHandler::Notify(const char* exceptionOrigin,
             << "; stepLength(mm)=" << track->GetStepLength() / CLHEP::mm << "; weight=" << track->GetWeight();
     const G4VProcess* proc = track->GetCreatorProcess();
     if (nullptr != proc) {
-      message << "; creatorProcess: " << proc->GetProcessName() << "; modeID=" << track->GetCreatorModelID();
+      message << "; creatorProcess: " << proc->GetProcessName() << "; modelID=" << track->GetCreatorModelID();
     }
   }
+  message << "\n";
 
   G4ExceptionSeverity localSeverity = severity;
   G4String code = G4String(*exceptionCode);

--- a/SimG4Core/Application/src/ExceptionHandler.cc
+++ b/SimG4Core/Application/src/ExceptionHandler.cc
@@ -24,8 +24,14 @@ bool ExceptionHandler::Notify(const char* exceptionOrigin,
           << "      issued by : " << exceptionOrigin << "\n"
           << description;
 
+  G4ExceptionSeverity localSeverity = severity;
+  G4String code = G4String(*exceptionCode); 
+  if(code == "GeomNav0003") {
+    localSeverity = JustWarning;
+  }
+
   std::stringstream ss;
-  switch (severity) {
+  switch (localSeverity) {
     case FatalException:
     case FatalErrorInArgument:
     case RunMustBeAborted:

--- a/SimG4Core/Application/src/RunManagerMT.cc
+++ b/SimG4Core/Application/src/RunManagerMT.cc
@@ -1,4 +1,3 @@
-
 #include "SimG4Core/Application/interface/RunManagerMT.h"
 #include "SimG4Core/Application/interface/PrimaryTransformer.h"
 #include "SimG4Core/Application/interface/SimRunInterface.h"
@@ -86,8 +85,8 @@ RunManagerMT::RunManagerMT(edm::ParameterSet const& p)
 
   m_kernel = new G4MTRunManagerKernel();
   m_stateManager = G4StateManager::GetStateManager();
-  m_stateManager->SetExceptionHandler(new ExceptionHandler());
-
+  double th = p.getParameter<double>("ThresholdForGeometryExceptions") * CLHEP::GeV;
+  m_stateManager->SetExceptionHandler(new ExceptionHandler(th));
   m_check = p.getUntrackedParameter<bool>("CheckGeometry", false);
 }
 

--- a/SimG4Core/Application/src/RunManagerMTWorker.cc
+++ b/SimG4Core/Application/src/RunManagerMTWorker.cc
@@ -254,7 +254,8 @@ void RunManagerMTWorker::initializeG4(RunManagerMT* runManagerMaster, const edm:
   }
 
   // Define G4 exception handler
-  G4StateManager::GetStateManager()->SetExceptionHandler(new ExceptionHandler());
+  double th = m_p.getParameter<double>("ThresholdForGeometryExceptions") * CLHEP::GeV;
+  G4StateManager::GetStateManager()->SetExceptionHandler(new ExceptionHandler(th));
 
   // Set the geometry for the worker, share from master
   auto worldPV = runManagerMaster->world().GetWorldVolume();


### PR DESCRIPTION
#### PR description:
In mass production just running with 12_0_2 there are number of rare exceptions due to problem in Geant4 navigation at boundaries of some volumes. In this PR these exceptions are converted to warnings.  

Handling of Geant4 exception is changed: for each exception a dump of track parameters is added. This is needed, because not in all Geant4 exceptions G4Track information is given, or is given incomplete.

Introduce a new energy threshold. If a particle has kinetic energy blow the GeomNav0003 exceptions become JustWarning, track is killed, simulation continues.

#### PR validation:
private
