### PR TITLE
Removed unnecessary includes in PhysicsTools/PatAlgos

### DIFF
--- a/PhysicsTools/PatAlgos/interface/PATUserDataHelper.h
+++ b/PhysicsTools/PatAlgos/interface/PATUserDataHelper.h
@@ -25,7 +25,6 @@
   \version  $Id: PATUserDataHelper.h,v 1.8 2010/02/20 21:00:13 wmtan Exp $
 */
 
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/PhysicsTools/PatAlgos/interface/PATUserDataMerger.h
+++ b/PhysicsTools/PatAlgos/interface/PATUserDataMerger.h
@@ -20,7 +20,6 @@
   \version  $Id: PATUserDataMerger.h,v 1.10 2011/10/26 17:01:25 vadler Exp $
 */
 
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"


### PR DESCRIPTION
#### PR description:

These were causing false positive deprecation warnings

#### PR validation:

code compiles and in CMSDEPRECATED IB they no longer issue the warnings.