### PR TITLE
hltGetConfiguration changes for new confdb version and database: 12_0_X

### DIFF
--- a/HLTrigger/Configuration/python/Tools/confdbOfflineConverter.py
+++ b/HLTrigger/Configuration/python/Tools/confdbOfflineConverter.py
@@ -144,7 +144,7 @@ class OfflineConverter:
 def help():
     sys.stdout.write("""Usage: %s OPTIONS
 
-        --v1|--v2|--v3|--v3-beta|--v3-test  (specify the ConfDB version [default: v2])
+        --v1|--v2|--v3|--v3-beta|--v3-test  (specify the ConfDB version [default: v3])
 
         --run3|--run2|--dev|--online|--adg    (specify the target db [default: run3], online will only work inside p5 network)
 
@@ -211,7 +211,7 @@ def main():
 
     arg_count = Counter(args)
     db_count = arg_count['--v1'] + arg_count['--v2'] + arg_count['--v3'] + arg_count['--v3-beta'] + arg_count['--v3-test']
-    if db_count>1 in args:
+    if db_count>1:
         sys.stderr.write( 'ERROR: conflicting database version specifications: "--v1", "--v2", "--v3", "--v3-beta", and "--v3-test" are mutually exclusive options' )
         sys.exit(1)
 

--- a/HLTrigger/Configuration/python/Tools/confdbOfflineConverter.py
+++ b/HLTrigger/Configuration/python/Tools/confdbOfflineConverter.py
@@ -6,6 +6,7 @@ import urllib
 import shutil
 import subprocess
 import atexit
+from collections import Counter
 
 class OfflineConverter:
 
@@ -27,16 +28,25 @@ class OfflineConverter:
 
     databases = {}
     databases['v1'] = {}
-    databases['v1']['offline'] = ( '-t', 'oracle', '-h', 'cmsr1-s.cern.ch',        '-d', 'cms_cond.cern.ch',      '-u', 'cms_hltdev_reader', '-s', 'ConvertMe!' )
+    databases['v1']['offline'] = ( '-t', 'oracle', '-h', 'cmsr1-s.cern.ch',        '-d', 'cms_cond.cern.ch',      '-u', 'cms_hltdev_reader', '-s', 'convertMe!' )
     databases['v1']['hltdev']  = databases['v1']['offline']     # for backwards compatibility
-    databases['v1']['online']  = ( '-t', 'oracle', '-h', 'cmsonr1-s.cms',          '-d', 'cms_rcms.cern.ch',      '-u', 'cms_hlt_r',         '-s', 'ConvertMe!' )
-    databases['v1']['adg']     = ( '-t', 'oracle', '-h', 'cmsr1-s.cern.ch',        '-d', 'cms_cond.cern.ch',      '-u', 'cms_hlt_gui_r',     '-s', 'ConvertMe!' )
+    databases['v1']['online']  = ( '-t', 'oracle', '-h', 'cmsonr1-s.cms',          '-d', 'cms_rcms.cern.ch',      '-u', 'cms_hlt_r',         '-s', 'convertMe!' )
+    databases['v1']['adg']     = ( '-t', 'oracle', '-h', 'cmsr1-s.cern.ch',        '-d', 'cms_cond.cern.ch',      '-u', 'cms_hlt_gui_r',     '-s', 'convertMe!' )
     databases['v1']['orcoff']  = databases['v1']['adg']         # for backwards compatibility
-    databases['v2'] = {}
-    databases['v2']['offline'] = ( '-t', 'oracle', '-h', 'cmsr1-s.cern.ch',        '-d', 'cms_cond.cern.ch',      '-u', 'cms_hlt_gdr_r',     '-s', 'convertMe!' )
-    databases['v2']['online']  = ( '-t', 'oracle', '-h', 'cmsonr1-s.cms',          '-d', 'cms_rcms.cern.ch',      '-u', 'cms_hlt_gdr_r',     '-s', 'convertMe!' )
-    databases['v2']['adg']     = ( '-t', 'oracle', '-h', 'cmsonr1-adg1-s.cern.ch', '-d', 'cms_orcon_adg.cern.ch', '-u', 'cms_hlt_gdr_r',     '-s', 'convertMe!' )
-
+    databases['v3'] = {}
+    databases['v3']['run2'] = ( '-t', 'oracle', '-h', 'cmsr1-s.cern.ch,cmsr2-s.cern.ch,cmsr3-s.cern.ch',        '-d', 'cms_hlt.cern.ch',      '-u', 'cms_hlt_gdr_r',     '-s', 'convertMe!' )
+    databases['v3']['run3'] = ( '-t', 'oracle', '-h', 'cmsr1-s.cern.ch,cmsr2-s.cern.ch,cmsr3-s.cern.ch',        '-d', 'cms_hlt.cern.ch',      '-u', 'cms_hlt_v3_r',     '-s', 'convertMe!' )
+    databases['v3']['dev'] = ( '-t', 'oracle', '-h', 'cmsr1-s.cern.ch,cmsr2-s.cern.ch,cmsr3-s.cern.ch',        '-d', 'cms_hlt.cern.ch',      '-u', 'cms_hlt_gdrdev_r',     '-s', 'convertMe1!' )
+    databases['v3']['online']  = ( '-t', 'oracle', '-h', 'cmsonr1-s.cms',          '-d', 'cms_rcms.cern.ch',      '-u', 'cms_hlt_gdr_r',     '-s', 'convertMe!' )
+    databases['v3']['adg']     = ( '-t', 'oracle', '-h', 'cmsonr1-adg1-s.cern.ch', '-d', 'cms_orcon_adg.cern.ch', '-u', 'cms_hlt_gdr_r',     '-s', 'convertMe!' )
+    databases['v3-beta'] = dict(databases['v3'])
+    databases['v3-test'] = dict(databases['v3'])
+    databases['v2'] = dict(databases['v3'])
+    #old converter can only handle a single host so we modify the params accordingly
+    for dbkey in databases['v2']:
+        dbparams  = databases['v2'][dbkey]
+        if dbparams[3]=='cmsr1-s.cern.ch,cmsr2-s.cern.ch,cmsr3-s.cern.ch':
+            databases['v2'][dbkey] = dbparams[0:3]+('cmsr1-s.cern.ch',)+dbparams[4:]
 
     @staticmethod
     def CheckTempDirectory(dir):
@@ -49,12 +59,15 @@ class OfflineConverter:
         return dir
 
 
-    def __init__(self, version = 'v2', database = 'offline', url = None, verbose = False):
+    def __init__(self, version = 'v3', database = 'run3', url = None, verbose = False):
         self.verbose = verbose
         self.version = version
         self.baseDir = '/afs/cern.ch/user/c/confdb/www/%s/lib' % version
-        self.baseUrl = 'http://confdb.web.cern.ch/confdb/%s/lib' % version
-        self.jars    = ( 'ojdbc6.jar', 'cmssw-evf-confdb-converter.jar' )
+        self.baseUrl = 'https://confdb.web.cern.ch/confdb/%s/lib' % version
+        self.jars    = ( 'ojdbc8.jar', 'cmssw-evf-confdb-converter.jar' )
+        if version=='v2':
+            #legacy driver for run2 gui
+            self.jars = ( 'ojdbc6.jar', 'cmssw-evf-confdb-converter.jar' )
         self.workDir = ''
 
         # check the schema version
@@ -131,9 +144,9 @@ class OfflineConverter:
 def help():
     sys.stdout.write("""Usage: %s OPTIONS
 
-        --v1|--v2                   (specify the ConfDB version [default: v2])
+        --v1|--v2|--v3|--v3-beta|--v3-test  (specify the ConfDB version [default: v2])
 
-        --offline|--online|--adg    (specify the target db [default: offline])
+        --run3|--run2|--dev|--online|--adg    (specify the target db [default: run3], online will only work inside p5 network)
 
         Note that for v1
             --orcoff  is a synonim of --adg
@@ -180,8 +193,8 @@ def help():
 
 def main():
     args = sys.argv[1:]
-    version = 'v2'
-    db      = 'offline'
+    version = 'v3'
+    db      = 'run3'
     verbose = False
 
     if not args:
@@ -196,8 +209,10 @@ def main():
         verbose = True
         args.remove('--verbose')
 
-    if '--v1' in args and '--v2' in args:
-        sys.stderr.write( "ERROR: conflicting database version specifications \"--v1\" and \"--v2\"\n" )
+    arg_count = Counter(args)
+    db_count = arg_count['--v1'] + arg_count['--v2'] + arg_count['--v3'] + arg_count['--v3-beta'] + arg_count['--v3-test']
+    if db_count>1 in args:
+        sys.stderr.write( 'ERROR: conflicting database version specifications: "--v1", "--v2", "--v3", "--v3-beta", and "--v3-test" are mutually exclusive options' )
         sys.exit(1)
 
     if '--v1' in args:
@@ -207,12 +222,30 @@ def main():
 
     if '--v2' in args:
         version = 'v2'
-        db      = 'offline'
+        db      = 'run2'
         args.remove('--v2')
+
+    if '--v3' in args:
+        version = 'v3'
+        db      = 'run3'
+        args.remove('--v3')
+
+    if '--v3-beta' in args:
+        version = 'v3-beta'
+        db      = 'run3'
+        args.remove('--v3-beta')
+
+    if '--v3-test' in args:
+        version = 'v3-test'
+        db      = 'dev'
+        args.remove('--v3-test')
 
     _dbs = {}
     _dbs['v1'] = [ '--%s' % _db for _db in OfflineConverter.databases['v1'] ] + [ '--runNumber' ]
     _dbs['v2'] = [ '--%s' % _db for _db in OfflineConverter.databases['v2'] ] + [ '--runNumber' ]
+    _dbs['v3'] = [ '--%s' % _db for _db in OfflineConverter.databases['v3'] ] + [ '--runNumber'] 
+    _dbs['v3-beta'] = [ '--%s' % _db for _db in OfflineConverter.databases['v3-beta'] ] + [ '--runNumber' ]
+    _dbs['v3-test'] = [ '--%s' % _db for _db in OfflineConverter.databases['v3-test'] ] + [ '--runNumber' ]
     _dbargs = set(args) & set(sum(_dbs.values(), []))
 
     if _dbargs:

--- a/HLTrigger/Configuration/python/Tools/options.py
+++ b/HLTrigger/Configuration/python/Tools/options.py
@@ -156,5 +156,7 @@ class HLTProcessOptions(object):
       # '--timing' implies '--profiling'
       object.__setattr__(self, 'timing',    True)
       object.__setattr__(self, 'profiling', True)
+    elif name == 'setup' and value and value.find(":")!=-1:
+      raise Exception('you can not specify a converter/database in the setup option.\nIt takes the converter database specified by the primary config.\nPlease remove the text upto and including the ":" in\n  {} '.format(value))      
     else:
       object.__setattr__(self, name, value)

--- a/HLTrigger/Configuration/python/Tools/options.py
+++ b/HLTrigger/Configuration/python/Tools/options.py
@@ -46,9 +46,9 @@ class ConnectionL1TMenuXml(object):
 
 # type used to store a reference to an HLT configuration
 class ConnectionHLTMenu(object):
-  valid_versions  = 'v1', 'v2'
-  valid_databases = 'online', 'offline', 'adg'
-  compatibility   = { 'hltdev': ('v2', 'offline'), 'orcoff': ('v2', 'adg') }
+  valid_versions  = 'v1', 'v2', 'v3', 'v3-beta', 'v3-test'
+  valid_databases = 'online', 'run3', 'adg','dev','run2'
+  compatibility   = { 'hltdev': ('v3', 'run3'), 'orcoff': ('v3', 'adg') }
 
   def __init__(self, value):
     self.version    = None
@@ -60,9 +60,9 @@ class ConnectionHLTMenu(object):
       return
 
     if not ':' in value:
-      # default to 'v2/offline'
-      self.version    = 'v2'
-      self.database   = 'offline'
+      # default to 'v3/run3'
+      self.version    = 'v3'
+      self.database   = 'run3'
       self.name       = value
       return
 
@@ -73,7 +73,7 @@ class ConnectionHLTMenu(object):
     (db, name) = tokens
     # check if the menu should be automatically determined based on the run number
     if db == 'run':
-      self.version  = 'v2'
+      self.version  = 'v3'
       self.database = 'adg'
       self.run      = name
     # check for backward compatibility names
@@ -95,11 +95,11 @@ class ConnectionHLTMenu(object):
         self.database = db
         self.name     = name
       else:
-        # use the confdb v2 by default
+        # use the confdb v3 by default
         if db not in self.valid_databases:
           raise Exception('Invalid HLT database "%s", valid values are "%s"' % (db, '", "'.join(self.valid_databases)))
         self.database = db
-        self.version  = 'v2'
+        self.version  = 'v3'
         self.name     = name
 
 # options marked with a (*) only apply when creating a whole process configuration

--- a/HLTrigger/Configuration/scripts/hltGetConfiguration
+++ b/HLTrigger/Configuration/scripts/hltGetConfiguration
@@ -29,7 +29,7 @@ parser.add_argument('menu',
                     action  = 'store',
                     type    = options.ConnectionHLTMenu,
                     metavar = 'MENU',
-                    help    = 'HLT menu to dump from the database. Supported formats are:\n  - /path/to/configuration[/Vn]\n  - [[{v1|v2}/]{offline|online|adg}:]/path/to/configuration[/Vn]\n  - run:runnumber\nThe possible database schemas are "v1" and "v2" (default).\nThe possible databases are "offline" (default, used for offline development), "online" (used to extract online menus within Point 5) and "adg" (used to extract the online menus outside Point 5).\nIf no menu version is specified, the latest one is automatically used.\nIf "run:" is used instead, the HLT menu used for the given run number is looked up and used.' )
+		    help    = 'HLT menu to dump from the database. Supported formats are:\n  - /path/to/configuration[/Vn]\n  - [[{v1|v2|v3}/]{run3|run2|online|adg}:]/path/to/configuration[/Vn]\n  - run:runnumber\nThe possible converters are "v1", "v2, and "v3" (default).\nThe possible databases are "run3" (default, used for offline development), "run2" (used for accessing run2 offline development menus), "online" (used to extract online menus within Point 5) and "adg" (used to extract the online menus outside Point 5).\nIf no menu version is specified, the latest one is automatically used.\nIf "run:" is used instead, the HLT menu used for the given run number is looked up and used.\nNote other converters and databases exist as options but they are only for expert/special use.' )
 
 # options
 parser.add_argument('--process',
@@ -160,7 +160,7 @@ parser.add_argument('--setup',
                     type    = str,
                     default = defaults.setup,
                     metavar = 'STORE',
-                    help    = 'If set, download setup_cff from the specified configuration and load it.' )
+                    help    = 'If set, download setup_cff from the specified configuration and load it. Note, it is forced to be the same database and converter as specified by primary menu configuration, in fact it is an error to specify a converter/database here and the command will fail' )
 
 group = parser.add_mutually_exclusive_group()
 group.add_argument('--output',

--- a/HLTrigger/Configuration/scripts/hltIntegrationTests
+++ b/HLTrigger/Configuration/scripts/hltIntegrationTests
@@ -31,7 +31,9 @@ Usage:
   MENU is the HLT menu to test.
 
   -s | --setup SETUP          Use the Services and EventSetup modules from a different menu
-                              (usefull when testing a ConfDB area with only some new paths)
+                              (usefull when testing a ConfDB area with only some new paths).
+                              Note it is an error to specify the converter/db here, 
+                              it uses the same as set by the HLT menu
   -d | --dir      WORKDIR     Create all files and run all tests inside WORKDIR (defauls: ./hltintegration)
   -i | --input    INPUT       Use the specified RAW data file as input
   -n | --size     EVENTS      Run on EVENTS events (-1 for all, default is 100)
@@ -47,13 +49,14 @@ Usage:
 
   The supported formats for both menu specifications are:
     - /path/to/configuration[/Vn]
-    - [[{v1|v2}/]{offline|online|adg}:]/path/to/configuration[/Vn]
+    - [[{v1|v2|v3}/]{run3|run2|online|adg}:]/path/to/configuration[/Vn]
     - run:runnumber
-  The possible database schemas are \"v1\" and \"v2\" (default).
-  The possible databases are \"offline\" (default, used for offline development), \"online\" (used to
+  The possible converters are \"v1\", \"v2\", and \"v3\" (default).
+  The possible databases are \"run3\" (default, used for offline run3 development), \"run2\" (previously used for run2 development), \"online\" (used to
   extract online menus within Point 5) and \"adg\" (used to extract the online menus outside Point 5).
   If no menu version is specified, the latest one is automatically used.
   If \"run:\" is used instead, the HLT menu used for the given run number is looked up and used.
+  Note other converters and databases exist but they are for expert/special use only.
 
   It's possible to pass arbitrary command line options to hltGetConfiguration, using \"-x --option\".
   To pass multiple options, enclose them in quotes, or use \"-x\" more than once.

--- a/HLTrigger/Configuration/scripts/hltListPaths
+++ b/HLTrigger/Configuration/scripts/hltListPaths
@@ -53,7 +53,7 @@ parser.add_argument('menu',
                     action  = 'store', 
                     type    = options.ConnectionHLTMenu,
                     metavar = 'MENU', 
-                    help    = 'HLT menu to dump from the database. Supported formats are:\n  - /path/to/configuration[/Vn]\n  - [[{v1|v2}/]{offline|online|adg}:]/path/to/configuration[/Vn]\n  - run:runnumber\nThe possible database schemas are "v1" and "v2" (default).\nThe possible databases are "offline" (default, used for offline development), "online" (used to extract online menus within Point 5) and "adg" (used to extract the online menus outside Point 5).\nIf no menu version is specified, the latest one is automatically used.\nIf "run:" is used instead, the HLT menu used for the given run number is looked up and used.' )
+                    help    = 'HLT menu to dump from the database. Supported formats are:\n  - /path/to/configuration[/Vn]\n  - [[{v1|v2|v3}/]{run3|run2|online|adg}:]/path/to/configuration[/Vn]\n  - run:runnumber\nThe possible converters are "v1", "v2, and "v3" (default).\nThe possible databases are "run3" (default, used for offline development), "run2" (used for accessing run2 offline development menus), "online" (used to extract online menus within Point 5) and "adg" (used to extract the online menus outside Point 5).\nIf no menu version is specified, the latest one is automatically used.\nIf "run:" is used instead, the HLT menu used for the given run number is looked up and used.\nNote other converters and databases exist as options but they are only for expert/special use.' )
 
 # options
 group = parser.add_mutually_exclusive_group()

--- a/HLTrigger/Configuration/tables/makeCRAFT
+++ b/HLTrigger/Configuration/tables/makeCRAFT
@@ -8,4 +8,4 @@ TARGET="/users/sdonato/STORM/cosmics/FromMaster/CRAFT"  # where to store the onl
 TABLES="craft"
 
 source subtables.sh
-createSubtables "v2/offline" "$MASTER" "$TARGET" "$TABLES"
+createSubtables "v3/run3" "$MASTER" "$TARGET" "$TABLES"

--- a/HLTrigger/Configuration/tables/makeCRUZET
+++ b/HLTrigger/Configuration/tables/makeCRUZET
@@ -8,4 +8,4 @@ TARGET="/users/sdonato/STORM/cosmics/FromMaster/CRUZET" # where to store the onl
 TABLES="cruzet"
 
 source subtables.sh
-createSubtables "v2/offline" "$MASTER" "$TARGET" "$TABLES"
+createSubtables "v3/run3" "$MASTER" "$TARGET" "$TABLES"

--- a/HLTrigger/Configuration/tables/makeOnline0T
+++ b/HLTrigger/Configuration/tables/makeOnline0T
@@ -9,4 +9,4 @@ TARGET="/online/collisions/2015/25ns_0T/v1.1/HLT"   # where to store the online-
 TABLES="online_0T"
 
 source subtables.sh
-createSubtables "v2/offline" "$MASTER" "$TARGET" "$TABLES"
+createSubtables "v3/run3" "$MASTER" "$TARGET" "$TABLES"

--- a/HLTrigger/Configuration/tables/makeOnlineGRun
+++ b/HLTrigger/Configuration/tables/makeOnlineGRun
@@ -8,4 +8,4 @@ TARGET="/online/collisions/2018/2e34/v3.6/HLT" # where to store the online-compl
 TABLES="online_grun"
 
 source subtables.sh
-createSubtables "v2/offline" "$MASTER" "$TARGET" "$TABLES"
+createSubtables "v3/run3" "$MASTER" "$TARGET" "$TABLES"

--- a/HLTrigger/Configuration/tables/makeOnlineHIon
+++ b/HLTrigger/Configuration/tables/makeOnlineHIon
@@ -8,4 +8,4 @@ TARGET="/online/collisions/2018/HIon/v2.0/HLT"      # where to store the online-
 TABLES="online_hion"
 
 source subtables.sh
-createSubtables "v2/offline" "$MASTER" "$TARGET" "$TABLES"
+createSubtables "v3/run3" "$MASTER" "$TARGET" "$TABLES"

--- a/HLTrigger/Configuration/tables/makeOnlinePIon
+++ b/HLTrigger/Configuration/tables/makeOnlinePIon
@@ -8,4 +8,4 @@ TARGET="/online/collisions/2016/ProtonIon/v1.0/HLT"  # where to store the online
 TABLES="online_pion"
 
 source subtables.sh
-createSubtables "v2/offline" "$MASTER" "$TARGET" "$TABLES"
+createSubtables "v3/run3" "$MASTER" "$TARGET" "$TABLES"

--- a/HLTrigger/Configuration/tables/makeOnlinePRef
+++ b/HLTrigger/Configuration/tables/makeOnlinePRef
@@ -8,4 +8,4 @@ TARGET="/online/collisions/2017/pp5TeV/v1.0/HLT" # where to store the online-com
 TABLES="online_grun"
 
 source subtables.sh
-createSubtables "v2/offline" "$MASTER" "$TARGET" "$TABLES"
+createSubtables "v3/run3" "$MASTER" "$TARGET" "$TABLES"

--- a/HLTrigger/Configuration/tables/makeSubTables
+++ b/HLTrigger/Configuration/tables/makeSubTables
@@ -8,4 +8,4 @@ TARGET="/dev/CMSSW_12_0_0/TABLE"         # directory where to store the sub-tabl
 TABLES="GRun HIon PIon PRef"             # which sub-tables to create
 
 source subtables.sh
-createSubtables "v2/offline" "$MASTER" "$TARGET" "$TABLES"
+createSubtables "v3/run3" "$MASTER" "$TARGET" "$TABLES"

--- a/HLTrigger/Configuration/tables/makeTest
+++ b/HLTrigger/Configuration/tables/makeTest
@@ -9,4 +9,4 @@ TARGET="/users/sdonato/tmp"         # directory where to store the sub-tables
 TABLES="GRun"                 # which sub-tables to create
 
 source subtables.sh
-createSubtables "v2/offline" "$MASTER" "$TARGET" "$TABLES"
+createSubtables "v3/run3" "$MASTER" "$TARGET" "$TABLES"

--- a/HLTrigger/Configuration/tables/subtables.sh
+++ b/HLTrigger/Configuration/tables/subtables.sh
@@ -51,7 +51,7 @@ function checkJars() {
 function makeCreateConfig() {
   local baseDir="/afs/cern.ch/user/c/confdb/www/${Vx}/lib"
   local baseUrl="http://confdb.web.cern.ch/confdb/${Vx}/lib"
-  local JARS="ojdbc6.jar cmssw-evf-confdb-gui.jar"
+  local JARS="ojdbc8.jar cmssw-evf-confdb-gui.jar"
   workDir="$baseDir"
 
   # try to read the .jar files from AFS, or download them

--- a/HLTrigger/Configuration/tables/subtables.sh
+++ b/HLTrigger/Configuration/tables/subtables.sh
@@ -103,6 +103,13 @@ function loadConfiguration() {
       DBUSER="cms_hlt_gdr_w"
       PWHASH="0196d34dd35b04c0f3597dc89fbbe6e2"
       ;;
+     "v3/run3")
+      # v3 run3
+      DBHOST="cmsr1-s.cern.ch"
+      DBNAME="cms_hlt.cern.ch"
+      DBUSER="cms_hlt_v3_w"
+      PWHASH="0196d34dd35b04c0f3597dc89fbbe6e2"
+      ;;
     *)
       # see https://github.com/fwyzard/hlt-confdb/blob/confdbv2/test/runCreateConfig
       echo "Error, unnown database \"$1\", exiting."


### PR DESCRIPTION
#### PR description:

This PR adapts the HLT tools to handle the new confdb version (v3) and the new run3 confdb database.

This includes being able to access the new converter and database as well as adapting the post python processing of the config to give the expected output.

#### PR validation:

Menus are being downloaded from confdb as expected. Tested v3 /v2 converter and run3/run2/adg databases.


#### if this PR is a backport please specify the original PR and why you need to backport that PR:

backport of https://github.com/cms-sw/cmssw/pull/35584

Needed for users to download menus in 12_0_0 with the new database/converter
