### PR TITLE
[121X] include GTs for Pilot Beam Test

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -32,13 +32,13 @@ autoCond = {
     # GlobalTag for Run2 HI data
     'run2_data_promptlike_hi'      : '121X_dataRun2_PromptLike_HI_v5',
     # GlobalTag for Run3 HLT: it points to the online GT
-    'run3_hlt'                     : '121X_dataRun3_HLT_v5',
+    'run3_hlt'                     : '120X_dataRun3_HLT_v3',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'              : '121X_dataRun2_HLT_relval_v5',
     # GlobalTag for Run3 data relvals (express GT)
-    'run3_data_express'            : '121X_dataRun3_Express_v5',
+    'run3_data_express'            : '120X_dataRun3_Express_v2',
     # GlobalTag for Run3 data relvals
-    'run3_data_prompt'             : '121X_dataRun3_Prompt_v5',
+    'run3_data_prompt'             : '120X_dataRun3_Prompt_v2',
     # GlobalTag for Run3 offline data reprocessing
     'run3_data'                    : '121X_dataRun3_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)

--- a/DQM/Integration/python/config/unittestinputsource_cfi.py
+++ b/DQM/Integration/python/config/unittestinputsource_cfi.py
@@ -32,7 +32,7 @@ options.register('runUniqueKey',
     "Unique run key from RCMS for Frontier")
 
 options.register('runNumber',
-                 334393,
+                 344518,
                  VarParsing.VarParsing.multiplicity.singleton,
                  VarParsing.VarParsing.varType.int,
                  "Run number. This run number has to be present in the dataset configured with the dataset option.")
@@ -41,7 +41,7 @@ options.register('dataset',
                  '/ExpressCosmics/Commissioning2019-Express-v1/FEVT',
                  VarParsing.VarParsing.multiplicity.singleton,
                  VarParsing.VarParsing.varType.string,
-                 "Dataset name like '/ExpressCosmics/Commissioning2019-Express-v1/FEVT'")
+                 "Dataset name like '/ExpressCosmics/Commissioning2021-Express-v1/FEVT'")
 
 options.register('maxLumi',
                  2,

--- a/DQM/Integration/python/config/unittestinputsource_cfi.py
+++ b/DQM/Integration/python/config/unittestinputsource_cfi.py
@@ -38,7 +38,7 @@ options.register('runNumber',
                  "Run number. This run number has to be present in the dataset configured with the dataset option.")
 
 options.register('dataset',
-                 '/ExpressCosmics/Commissioning2019-Express-v1/FEVT',
+                 '/ExpressCosmics/Commissioning2021-Express-v1/FEVT',
                  VarParsing.VarParsing.multiplicity.singleton,
                  VarParsing.VarParsing.varType.string,
                  "Dataset name like '/ExpressCosmics/Commissioning2021-Express-v1/FEVT'")


### PR DESCRIPTION
#### PR description:

This PR is a forward port of PR #35561 that includes the online GTs for datataking and updates the DQM unit tests to use a 2021 CRUZET run. 

As it was suggested at the AlCaDB workshop (https://indico.cern.ch/event/1069946/contributions/4511740/attachments/2313276/3937722/Condition%20Database_%20Approaching%20Run3.pdf), we are planning to replace the most populated tags (> 50k) with a new tag in the Run 3 Prompt GT, due to better performance and manageability. In this PR, the newly introduced 120X Run 3 Prompt GT has a new such tag, EcalLaserAPDPNRatiosRcd, that is only valid starting from Run3 data. It was discussed and agreed upon also with the Ecal group.

In summary, the Run 3 Prompt GTs introduced in this PR are only valid for Run 3 data.

GT differences wrt CRUZET ones:
HLT:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_dataRun3_HLT_v3/120X_dataRun3_HLT_v3
Express:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_dataRun3_Express_v4/120X_dataRun3_Express_v2
Prompt:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_dataRun3_Prompt_v3/120X_dataRun3_Prompt_v2

The hypernews with the announcement of the Pilot Test Beam GTs is here: https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4488.html

#### PR validation:

Just as a sanity check as we do not expect to catch the errors that showed up in DQM online:

runTheMatrix.py -l 138.1,138.2 --ibeos -j8 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

It is a forward port of #35561.
