### PR TITLE
[DD4hep] Add check for existing constant to prevent unneeded warning message

### DIFF
--- a/DetectorDescription/DDCMS/src/DDNamespace.cc
+++ b/DetectorDescription/DDCMS/src/DDNamespace.cc
@@ -3,6 +3,7 @@
 #include "DataFormats/Math/interface/Rounding.h"
 #include "DD4hep/Path.h"
 #include "DD4hep/Printout.h"
+#include "Evaluator/Evaluator.h"
 #include "XML/XML.h"
 
 #include <TClass.h>
@@ -136,6 +137,10 @@ void DDNamespace::addConstant(const string& name, const string& val, const strin
   addConstantNS(prepend(name), val, type);
 }
 
+namespace dd4hep {
+  dd4hep::tools::Evaluator& evaluator();
+}
+
 void DDNamespace::addConstantNS(const string& name, const string& val, const string& type) const {
   const string& v = val;
   const string& n = name;
@@ -145,7 +150,14 @@ void DDNamespace::addConstantNS(const string& name, const string& val, const str
                    n.c_str(),
                    v.c_str(),
                    type.c_str());
-  dd4hep::_toDictionary(n, v, type);
+  const dd4hep::tools::Evaluator& eval(dd4hep::evaluator());
+  bool constExists = eval.findVariable(n);
+  dd4hep::printout(
+      m_context->debug_constants ? dd4hep::ALWAYS : dd4hep::DEBUG, "DD4CMS", "findVariable result = %d", constExists);
+  if (constExists == false) {
+    // Only add it to the dictionary if it is not yet defined
+    dd4hep::_toDictionary(n, v, type);
+  }
   dd4hep::Constant c(n, v, type);
 
   m_context->description.addConstant(c);


### PR DESCRIPTION
When DD4hep simulation is run, these harmless warning messages appear:
```
Evaluator        WARN  +++ Overwriting variable: name=world_x value=101*m  Evaluator::Object : existing variable [setVariable error]
Evaluator        WARN  +++ Overwriting variable: name=world_y value=101*m  Evaluator::Object : existing variable [setVariable error]
Evaluator        WARN  +++ Overwriting variable: name=world_z value=450*m  Evaluator::Object : existing variable [setVariable error]
```
They are caused because two instances of a DD4hep `Detector` are created, one for the magnetic field and one for the CMS detector, and these three numeric variables are set for both. The DD4hep `Evaluator` is shared among all instances, so when the constants are defined a second time, these harmless warning messages are issued by DD4hep.

The fix is to check for the existence of a constant before adding it to the shared DD4hep dictionary. With this PR, constants that already exist are not added again, and the warning message is prevented. Note that the constants are still defined separately inside each `Detector` instance.

This PR resolves CMS issue #33712 and part of DD4hep issue https://github.com/AIDASoft/DD4hep/issues/844.


#### PR validation:

When DD4hep simulation is run with this PR, the warning messages do not appear, and simulation completes successfully.

No backport is necessary. Since the warning messages are harmless, it is OK to leave them in 12_0.
