### PR TITLE
Fix Nano sequence for Premix-ProdLike .9921 relvals

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1109,6 +1109,8 @@ class UpgradeWorkflowPremixProdLike(UpgradeWorkflowPremix,UpgradeWorkflow_ProdLi
                         "--eventcontent": "PREMIXRAW"},
                        d])
             stepDict[stepName][k] = d
+        if 'Nano' in step:
+            stepDict[stepName][k] = merge([{'--filein':'file:step5.root','-s':'NANO','--datatier':'NANOAODSIM','--eventcontent':'NANOEDMAODSIM'}, stepDict[step][k]])
     def condition(self, fragment, stepList, key, hasHarvest):
         # use both conditions
         return UpgradeWorkflowPremix.condition(self, fragment, stepList, key, hasHarvest) and UpgradeWorkflow_ProdLike.condition(self, fragment, stepList, key, hasHarvest)


### PR DESCRIPTION
#### PR description:
Fix https://github.com/cms-sw/cmssw/issues/35596

#### PR validation:
The following runTheMatrix.py gives the proper config
`runTheMatrix.py --what upgrade -l 34834.9921 -t 8 --wm init`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
No need of backport.
