### PR TITLE
HCAL: uHTR group 0 LUT bits 12-15 set, used to set LLP trigger fine grain bits 

### DIFF
--- a/CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h
+++ b/CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h
@@ -43,6 +43,7 @@ public:
   void adc2Linear(const HFDataFrame& df, IntegerCaloSamples& ics) const override;
   void adc2Linear(const QIE10DataFrame& df, IntegerCaloSamples& ics) const override;
   void adc2Linear(const QIE11DataFrame& df, IntegerCaloSamples& ics) const override;
+  std::vector<unsigned short> group0FGbits(const QIE11DataFrame& df) const;
   void compress(const IntegerCaloSamples& ics,
                 const std::vector<bool>& featureBits,
                 HcalTriggerPrimitiveDigi& tp) const override;

--- a/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
+++ b/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
@@ -400,7 +400,8 @@ void HcaluLUTTPGCoder::update(const HcalDbService& conditions) {
 
     unsigned int mipMax = 0;
     unsigned int mipMin = 0;
-    unsigned int bit12_energy = 0; // defaults for energy requirement for bits 12-15 are high / low to avoid FG bit 0-4 being set when not intended
+    unsigned int bit12_energy =
+        0;  // defaults for energy requirement for bits 12-15 are high / low to avoid FG bit 0-4 being set when not intended
     unsigned int bit13_energy = 0;
     unsigned int bit14_energy = 999;
     unsigned int bit15_energy = 999;
@@ -411,10 +412,10 @@ void HcaluLUTTPGCoder::update(const HcalDbService& conditions) {
       const HcalTPChannelParameter* channelParameters = conditions.getHcalTPChannelParameter(cell);
       mipMax = channelParameters->getFGBitInfo() >> 16;
       mipMin = channelParameters->getFGBitInfo() & 0xFFFF;
-      bit12_energy = 16; // depths 1,2 max energy
-      bit13_energy = 80; // depths 3+ min energy
-      bit14_energy = 64; // prompt min energy
-      bit15_energy = 64; // delayed min energy
+      bit12_energy = 16;  // depths 1,2 max energy
+      bit13_energy = 80;  // depths 3+ min energy
+      bit14_energy = 64;  // prompt min energy
+      bit15_energy = 64;  // delayed min energy
     }
 
     int lutId = getLUTId(cell);
@@ -526,17 +527,18 @@ void HcaluLUTTPGCoder::update(const HcalDbService& conditions) {
                                                          containmentCorrection / nominalgain_ / granularity)),
                                             MASK);
 
-	  unsigned int linearizedADC = lut[adc]; // used for bits 12, 13, 14, 15 for Group 0 LUT for LLP time and depth bits that rely on linearized energies
+          unsigned int linearizedADC =
+              lut[adc];  // used for bits 12, 13, 14, 15 for Group 0 LUT for LLP time and depth bits that rely on linearized energies
 
           if (qieType == QIE11) {
-	    if ((linearizedADC < bit12_energy and cell.depth() <= 2) or (cell.depth() >= 3))
-	      lut[adc] |= 1 << 12;
-	    if (linearizedADC >= bit13_energy and cell.depth() >= 3)
-	      lut[adc] |= 1 << 13;
-	    if (linearizedADC >= bit14_energy)
-	      lut[adc] |= 1 << 14;
-	    if (linearizedADC >= bit15_energy)
-	      lut[adc] |= 1 << 15;
+            if ((linearizedADC < bit12_energy and cell.depth() <= 2) or (cell.depth() >= 3))
+              lut[adc] |= 1 << 12;
+            if (linearizedADC >= bit13_energy and cell.depth() >= 3)
+              lut[adc] |= 1 << 13;
+            if (linearizedADC >= bit14_energy)
+              lut[adc] |= 1 << 14;
+            if (linearizedADC >= bit15_energy)
+              lut[adc] |= 1 << 15;
             if (adc >= mipMin and adc < mipMax)
               lut[adc] |= QIE11_LUT_MSB0;
             else if (adc >= mipMax)
@@ -602,8 +604,10 @@ std::vector<unsigned short> HcaluLUTTPGCoder::group0FGbits(const QIE11DataFrame&
   int lutId = getLUTId(HcalDetId(df.id()));
   const Lut& lut = inputLUT_.at(lutId);
   std::vector<unsigned short> group0LLPbits;
+  group0LLPbits.reserve(df.samples());
   for (int i = 0; i < df.samples(); i++) {
-    group0LLPbits.push_back((lut.at(df[i].adc()) >> 12) & 0xF); // four bits (12-15) of LUT used to set 6 finegrain bits from uHTR
+    group0LLPbits.push_back((lut.at(df[i].adc()) >> 12) &
+                            0xF);  // four bits (12-15) of LUT used to set 6 finegrain bits from uHTR
   }
   return group0LLPbits;
 }

--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFinegrainBit.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFinegrainBit.h
@@ -10,8 +10,8 @@ public:
   // see the const definitions below for the meaning of the bit towers.
   // Each bit is replicated for each depth level
   typedef std::array<std::bitset<6>, 2> Tower;
-  // Each pair contains energy and TDC of the cell in that depth of the trigger tower
-  typedef std::array<std::pair<int, int>, 7> TowerTDC;
+  // Each pair contains uHTR group 0 LUT bits 12-15, TDC, and ADC of the cell in that depth of the trigger tower
+  typedef std::array<std::pair<int, std::pair<int, int>>, 7> TowerTDC;
 
   HcalFinegrainBit(int version) : version_(version){};
 

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalFinegrainBit.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalFinegrainBit.cc
@@ -54,10 +54,10 @@ std::bitset<6> HcalFinegrainBit::compute(const HcalFinegrainBit::TowerTDC& tower
 
   for (size_t i = 0; i < 7; i++) {
     int bit12_15set = tower[i].first;
-    int bit12 = (bit12_15set & 0b0001); // low depth 1,2 energy
-    int bit13 = (bit12_15set & 0b0010) >> 1; // high depth 3+ energy
-    int bit14 = (bit12_15set & 0b0100) >> 2; // prompt energy passed
-    int bit15 = (bit12_15set & 0b1000) >> 3; // delayed energy passed
+    int bit12 = (bit12_15set & 0b0001);       // low depth 1,2 energy
+    int bit13 = (bit12_15set & 0b0010) >> 1;  // high depth 3+ energy
+    int bit14 = (bit12_15set & 0b0100) >> 2;  // prompt energy passed
+    int bit15 = (bit12_15set & 0b1000) >> 3;  // delayed energy passed
     int TDC = tower[i].second.first;
     int ADC = tower[i].second.second;
 
@@ -85,9 +85,11 @@ std::bitset<6> HcalFinegrainBit::compute(const HcalFinegrainBit::TowerTDC& tower
 
     // depth bit
     if (ADC > 0 && bit12 == 0)
-      EarlyEnergy += 1;  // early layers, depth 1 and 2. If bit12 = 0, too much energy in early layers. Require ADC > 0 to ensure valid hit in cell
+      EarlyEnergy +=
+          1;  // early layers, depth 1 and 2. If bit12 = 0, too much energy in early layers. Require ADC > 0 to ensure valid hit in cell
     if (ADC > 0 && bit13 == 1)
-      DeepEnergy += 1;  // deep layers, 3+. If bit13 = 1, energy in deep layers. Require ADC > 0 to ensure valid hit in cell
+      DeepEnergy +=
+          1;  // deep layers, 3+. If bit13 = 1, energy in deep layers. Require ADC > 0 to ensure valid hit in cell
   }
 
   // very delayed (100000), slightly delayed (010000), prompt (001000), 2 reserved bits (000110), depth flag (000001)

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalFinegrainBit.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalFinegrainBit.cc
@@ -49,44 +49,45 @@ std::bitset<6> HcalFinegrainBit::compute(const HcalFinegrainBit::TowerTDC& tower
   int Ndelayed = 0;
   int NveryDelayed = 0;
   int Nprompt = 0;
-  const int MinE = 64;
-
-  int DeepEnergy = 0;
   int EarlyEnergy = 0;
-  const int deepLayerMinE = 80;
-  const int earlyLayerMaxE = 16;
+  int DeepEnergy = 0;
 
   for (size_t i = 0; i < 7; i++) {
-    int ADC = tower[i].first;
-    int TDC = tower[i].second;
+    int bit12_15set = tower[i].first;
+    int bit12 = (bit12_15set & 0b0001); // low depth 1,2 energy
+    int bit13 = (bit12_15set & 0b0010) >> 1; // high depth 3+ energy
+    int bit14 = (bit12_15set & 0b0100) >> 2; // prompt energy passed
+    int bit15 = (bit12_15set & 0b1000) >> 3; // delayed energy passed
+    int TDC = tower[i].second.first;
+    int ADC = tower[i].second.second;
 
     // timing bits
     if (TDC < 50) {  // exclude error code for TDC in HE (unpacked)
       if (abs(tp_ieta) <=
           16) {  // in HB, TDC values are compressed. 01 = first delayed range, 10 = second delayed range
-        if (TDC == 1 && ADC >= MinE)
+        if (TDC == 1 && bit15 == 1)
           Ndelayed += 1;
-        if (TDC == 2 && ADC >= MinE)
+        if (TDC == 2 && bit15 == 1)
           NveryDelayed += 1;
-        if (TDC == 0 && ADC >= MinE)
+        if (TDC == 0 && bit14 == 1)
           Nprompt += 1;
       }
       if (abs(tp_ieta) > 16 &&
           i >= 1) {  // in HE, TDC values are uncompressed (0-49). Exclude depth 1 in HE due to backgrounds
-        if (TDC > tdc_HE[abs(tp_ieta) - 1][i] && TDC <= tdc_HE[abs(tp_ieta) - 1][i] + 2 && ADC >= MinE)
+        if (TDC > tdc_HE[abs(tp_ieta) - 1][i] && TDC <= tdc_HE[abs(tp_ieta) - 1][i] + 2 && bit15 == 1)
           Ndelayed += 1;
-        if (TDC > tdc_HE[abs(tp_ieta) - 1][i] + 2 && ADC >= MinE)
+        if (TDC > tdc_HE[abs(tp_ieta) - 1][i] + 2 && bit15 == 1)
           NveryDelayed += 1;
-        if (TDC <= tdc_HE[abs(tp_ieta) - 1][i] && TDC >= 0 && ADC >= MinE)
+        if (TDC <= tdc_HE[abs(tp_ieta) - 1][i] && TDC >= 0 && bit14 == 1)
           Nprompt += 1;
       }
     }
 
     // depth bit
-    if (i <= 1 && ADC >= earlyLayerMaxE)
-      EarlyEnergy += 1;  // early layers, depth 1 and 2
-    if (i >= 2 && ADC >= deepLayerMinE)
-      DeepEnergy += 1;  // deep layers, 3+
+    if (ADC > 0 && bit12 == 0)
+      EarlyEnergy += 1;  // early layers, depth 1 and 2. If bit12 = 0, too much energy in early layers. Require ADC > 0 to ensure valid hit in cell
+    if (ADC > 0 && bit13 == 1)
+      DeepEnergy += 1;  // deep layers, 3+. If bit13 = 1, energy in deep layers. Require ADC > 0 to ensure valid hit in cell
   }
 
   // very delayed (100000), slightly delayed (010000), prompt (001000), 2 reserved bits (000110), depth flag (000001)
@@ -95,18 +96,18 @@ std::bitset<6> HcalFinegrainBit::compute(const HcalFinegrainBit::TowerTDC& tower
   else
     result[0] = false;
   if (Nprompt > 0)
+    result[1] = true;  // 000010
+  else
+    result[1] = false;
+  if (Ndelayed > 0)
+    result[2] = true;  // 000100
+  else
+    result[2] = false;
+  if (NveryDelayed > 0)
     result[3] = true;  // 001000
   else
     result[3] = false;
-  if (Ndelayed > 0)
-    result[4] = true;  // 010000
-  else
-    result[4] = false;
-  if (NveryDelayed > 0)
-    result[5] = true;  // 100000
-  else
-    result[5] = false;
-  result[1] = result[2] = false;  // 000110 in HcalTriggerPrimitiveAlgo.cc, set to MIP bits from above
+  result[4] = result[5] = false;  // 110000 in HcalTriggerPrimitiveAlgo.cc, set to MIP bits from above
 
   return result;
 }

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -912,8 +912,8 @@ void HcalTriggerPrimitiveAlgo::addUpgradeTDCFG(const HcalTrigTowerDetId& id, con
   assert(ids.size() == 1 || ids.size() == 2);
   IntegerCaloSamples samples1(ids[0], int(frame.samples()));
   samples1.setPresamples(frame.presamples());
-  incoder_->adc2Linear(frame, samples1);  // use linearization LUT
-  std::vector<unsigned short> bits12_15 = incoder_->group0FGbits(frame); // get 4 energy bits (12-15) from group 0 LUT
+  incoder_->adc2Linear(frame, samples1);                                  // use linearization LUT
+  std::vector<unsigned short> bits12_15 = incoder_->group0FGbits(frame);  // get 4 energy bits (12-15) from group 0 LUT
 
   auto it = fgUpgradeTDCMap_.find(id);
   if (it == fgUpgradeTDCMap_.end()) {

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -499,8 +499,8 @@ void HcalTriggerPrimitiveAlgo::analyzeQIE11(IntegerCaloSamples& samples,
       output[ibin] = 0;
     }
     // peak-finding is not applied for FG bits
-    // compute(msb) returns two bits (MIP). compute(timingTDC,ids) returns 6 bits (1 depth, 2 reserved, 1 prompt, 1 delayed 01, 1 delayed 10)
-    finegrain[ibin] = fg_algo.compute(timingTDC[idx], ids[0]).to_ulong() | fg_algo.compute(msb[idx]).to_ulong() << 1;
+    // compute(msb) returns two bits (MIP). compute(timingTDC,ids) returns 6 bits (1 depth, 1 prompt, 1 delayed 01, 1 delayed 10, 2 reserved)
+    finegrain[ibin] = fg_algo.compute(timingTDC[idx], ids[0]).to_ulong() | fg_algo.compute(msb[idx]).to_ulong() << 4;
   }
   outcoder_->compress(output, finegrain, result);
 }
@@ -913,6 +913,7 @@ void HcalTriggerPrimitiveAlgo::addUpgradeTDCFG(const HcalTrigTowerDetId& id, con
   IntegerCaloSamples samples1(ids[0], int(frame.samples()));
   samples1.setPresamples(frame.presamples());
   incoder_->adc2Linear(frame, samples1);  // use linearization LUT
+  std::vector<unsigned short> bits12_15 = incoder_->group0FGbits(frame); // get 4 energy bits (12-15) from group 0 LUT
 
   auto it = fgUpgradeTDCMap_.find(id);
   if (it == fgUpgradeTDCMap_.end()) {
@@ -921,7 +922,7 @@ void HcalTriggerPrimitiveAlgo::addUpgradeTDCFG(const HcalTrigTowerDetId& id, con
     it = fgUpgradeTDCMap_.insert(std::make_pair(id, element)).first;
   }
   for (int i = 0; i < frame.samples(); i++) {
-    it->second[i][detId.depth() - 1] = std::make_pair(samples1[i], frame[i].tdc());
+    it->second[i][detId.depth() - 1] = std::make_pair(bits12_15[i], std::make_pair(frame[i].tdc(), samples1[i]));
   }
 }
 


### PR DESCRIPTION
#### PR description:

Bits 12-15 of the uHTR group 0 LUT are set, and are used in setting the 6 fine grain bits per trigger tower for the timing and depth based HCAL LLP L1 trigger. This change sets the LUT bits based on linearized ADC values and updates the LUT in HcaluLUTTPGCoder. The four bits are returned and used in HcalTriggerPrimitiveAlgo to pass to the HcalFinegrainBit compute function, where the LUT bits are used in conjunction with the TDC values in the fine grain bit algorithm. This both sets the group 0 LUT for online use, and bases the fine grain bit emulation on the LUTs used to set bits in hardware.  

In addition, the changes in HcalFinegrainBit.cc align the fine grain bit assignments with those in uHTR HB firmware version 2.5.0 and onward. Bit[0] is depth / amplitude based, bit[1] indicates a prompt cell, bit[2] indicates a slightly delayed cell, bit[3] indicates a very delayed cell, and bits[4] and [5] are reserved MIP bits. 

The uHTR LUT bit 12-15 settings and use in the fine grain bit algorithm are detailed in Section 3.5 in the uHTR specifications DocDB: https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12306&filename=LLPbits_uhtr_spec.pdf&version=22. 

These edits were presented at the Joint HCAL Trigger - DQM Meeting (Oct 8): https://indico.cern.ch/event/1084544/contributions/4559682/attachments/2324975/3959974/uHTRgroup0LUT_8Oct.pdf 

#### PR validation:

Passed runTheMatrix.py tests. Tested in CMSSW_12_1_X_2021-10-08-1100.