### PR TITLE
Change to the new method `writeOneIOV` in `PPSTimingCalibrationPCLHarvester`

### DIFF
--- a/CalibPPS/TimingCalibration/plugins/PPSTimingCalibrationPCLHarvester.cc
+++ b/CalibPPS/TimingCalibration/plugins/PPSTimingCalibrationPCLHarvester.cc
@@ -142,7 +142,7 @@ void PPSTimingCalibrationPCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQM
 
   // write the object
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
-  poolDbService->writeOne(&calib, poolDbService->currentTime(), "PPSTimingCalibrationRcd");
+  poolDbService->writeOneIOV(calib, poolDbService->currentTime(), "PPSTimingCalibrationRcd");
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
#### PR description:

Simple PR to fix https://github.com/cms-sw/cmssw/issues/35601 by changing to the new method `writeOneIOV` in `PPSTimingCalibrationPCLHarvester`


#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
