### PR TITLE
Misc changes in SiPixel CPE object code in `CondTools/SiPixel`

### DIFF
--- a/CondTools/SiPixel/plugins/SiPixel2DTemplateDBObjectUploader.cc
+++ b/CondTools/SiPixel/plugins/SiPixel2DTemplateDBObjectUploader.cc
@@ -165,8 +165,6 @@ void SiPixel2DTemplateDBObjectUploader::analyze(const edm::Event& iEvent, const 
       //Barrel Pixels first
       if ((phase == 1 && detid.subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel)) ||
           (phase == 2 && tGeo->geomDetSubDetector(detid.subdetId()) == GeomDetEnumerators::P2PXB)) {
-        edm::LogPrint("SiPixel2DTemplateDBObjectUploader") << "--- IN THE BARREL ---\n";
-
         //Get the layer, ladder, and module corresponding to this detID
         layer = tTopo->pxbLayer(detid.rawId());
         ladder = tTopo->pxbLadder(detid.rawId());
@@ -200,17 +198,12 @@ void SiPixel2DTemplateDBObjectUploader::analyze(const edm::Event& iEvent, const 
         if (thisID == 10000 || (!(*obj).putTemplateID(detid.rawId(), thisID)))
           edm::LogPrint("SiPixel2DTemplateDBObjectUploader")
               << " Could not fill barrel layer " << layer << ", module " << module << "\n";
-        // ----- debug:
         edm::LogPrint("SiPixel2DTemplateDBObjectUploader")
-            << "This is a barrel element with: layer " << layer << ", ladder " << ladder << " and module " << module
-            << ".\n";  //Uncomment to read out exact position of each element.
-                       // -----
+            << "This is a barrel element with: layer " << layer << ", ladder " << ladder << " and module " << module;
       }
       //Now endcaps
       else if ((phase == 1 && detid.subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap)) ||
                (phase == 2 && tGeo->geomDetSubDetector(detid.subdetId()) == GeomDetEnumerators::P2PXEC)) {
-        edm::LogPrint("SiPixel2DTemplateDBObjectUploader") << "--- IN AN ENDCAP ---\n";
-
         //Get the DetId's disk, blade, side, panel, and module
         disk = tTopo->pxfDisk(detid.rawId());    //1,2,3
         blade = tTopo->pxfBlade(detid.rawId());  //1-56 (Ring 1 is 1-22, Ring 2 is 23-56)
@@ -251,21 +244,18 @@ void SiPixel2DTemplateDBObjectUploader::analyze(const edm::Event& iEvent, const 
           edm::LogPrint("SiPixel2DTemplateDBObjectUploader")
               << " Could not fill endcap det unit" << side << ", disk " << disk << ", blade " << blade << ", and panel "
               << panel << ".\n";
-        // ----- debug:
         edm::LogPrint("SiPixel2DTemplateDBObjectUploader")
             << "This is an endcap element with: side " << side << ", disk " << disk << ", blade " << blade
-            << ", and panel " << panel << ".\n";  //Uncomment to read out exact position of each element.
-                                                  // -----
+            << ", and panel " << panel;
       } else {
         continue;
       }
 
       //Print out the assignment of this detID
       short mapnum;
-      edm::LogPrint("SiPixel2DTemplateDBObjectUploader") << "checking map:\n";
       mapnum = (*obj).getTemplateID(detid.rawId());
       edm::LogPrint("SiPixel2DTemplateDBObjectUploader")
-          << "The DetID: " << detid.rawId() << " is mapped to the template: " << mapnum << ".\n\n";
+          << "The DetID: " << detid.rawId() << " is mapped to the template: " << mapnum << "\n";
     }
   }
 

--- a/CondTools/SiPixel/plugins/SiPixelGenErrorDBObjectUploader.cc
+++ b/CondTools/SiPixel/plugins/SiPixelGenErrorDBObjectUploader.cc
@@ -180,8 +180,6 @@ void SiPixelGenErrorDBObjectUploader::analyze(const edm::Event& iEvent, const ed
       //Barrel Pixels first
       if ((phase == 1 && detid.subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel)) ||
           (phase == 2 && tGeo->geomDetSubDetector(detid.subdetId()) == GeomDetEnumerators::P2PXB)) {
-        edm::LogPrint("SiPixelGenErrorDBObjectUploader") << "--- IN THE BARREL ---\n";
-
         //Get the layer, ladder, and module corresponding to this DetID
         layer = tTopo->pxbLayer(detid.rawId());
         ladder = tTopo->pxbLadder(detid.rawId());
@@ -215,17 +213,12 @@ void SiPixelGenErrorDBObjectUploader::analyze(const edm::Event& iEvent, const ed
         if (thisID == 10000 || (!(*obj).putGenErrorID(detid.rawId(), thisID)))
           edm::LogPrint("SiPixelGenErrorDBObjectUploader")
               << " Could not fill barrel layer " << layer << ", module " << module << "\n";
-        // ----- debug:
         edm::LogPrint("SiPixelGenErrorDBObjectUploader")
-            << "This is a barrel element with: layer " << layer << ", ladder " << ladder << " and module " << module
-            << ".\n";  //Uncomment to read out exact position of each element.
-                       // -----
+            << "This is a barrel element with: layer " << layer << ", ladder " << ladder << " and module " << module;
       }
       //Now endcaps
       else if ((phase == 1 && detid.subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap)) ||
                (phase == 2 && tGeo->geomDetSubDetector(detid.subdetId()) == GeomDetEnumerators::P2PXEC)) {
-        edm::LogPrint("SiPixelGenErrorDBObjectUploader") << "--- IN AN ENDCAP ---\n";
-
         //Get the DetID's disk, blade, side, panel, and module
         disk = tTopo->pxfDisk(detid.rawId());    //1,2,3
         blade = tTopo->pxfBlade(detid.rawId());  //1-56 (Ring 1 is 1-22, Ring 2 is 23-56)
@@ -265,20 +258,17 @@ void SiPixelGenErrorDBObjectUploader::analyze(const edm::Event& iEvent, const ed
           edm::LogPrint("SiPixelGenErrorDBObjectUploader")
               << " Could not fill endcap det unit" << side << ", disk " << disk << ", blade " << blade << ", panel "
               << panel << ".\n";
-        // ----- debug:
-        edm::LogPrint("SiPixelGenErrorDBObjectUploader")
-            << "This is an endcap element with: side " << side << ", disk " << disk << ", blade " << blade << ", panel "
-            << panel << ".\n";  //Uncomment to read out exact position of each element.
+        edm::LogPrint("SiPixelGenErrorDBObjectUploader") << "This is an endcap element with: side " << side << ", disk "
+                                                         << disk << ", blade " << blade << ", panel " << panel;
       } else {
         continue;
       }
 
       //Print out the assignment of this DetID
       short mapnum;
-      edm::LogPrint("SiPixelGenErrorDBObjectUploader") << "checking map:\n";
       mapnum = (*obj).getGenErrorID(detid.rawId());
       edm::LogPrint("SiPixelGenErrorDBObjectUploader")
-          << "The DetID: " << detid.rawId() << " is mapped to the template: " << mapnum << ".\n\n";
+          << "The DetID: " << detid.rawId() << " is mapped to the template: " << mapnum << "\n";
     }
   }
 

--- a/CondTools/SiPixel/plugins/SiPixelTemplateDBObjectUploader.cc
+++ b/CondTools/SiPixel/plugins/SiPixelTemplateDBObjectUploader.cc
@@ -174,8 +174,6 @@ void SiPixelTemplateDBObjectUploader::analyze(const edm::Event& iEvent, const ed
       //Barrel Pixels first
       if ((phase == 1 && detid.subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel)) ||
           (phase == 2 && tGeo->geomDetSubDetector(detid.subdetId()) == GeomDetEnumerators::P2PXB)) {
-        edm::LogPrint("SiPixelTemplateDBObjectUploader") << "--- IN THE BARREL ---\n";
-
         //Get the layer, ladder, and module corresponding to this detID
         layer = tTopo->pxbLayer(detid.rawId());
         ladder = tTopo->pxbLadder(detid.rawId());
@@ -209,17 +207,12 @@ void SiPixelTemplateDBObjectUploader::analyze(const edm::Event& iEvent, const ed
         if (thisID == 10000 || (!obj.putTemplateID(detid.rawId(), thisID)))
           edm::LogPrint("SiPixelTemplateDBObjectUploader")
               << " Could not fill barrel layer " << layer << ", module " << module << "\n";
-        // ----- debug:
         edm::LogPrint("SiPixelTemplateDBObjectUploader")
-            << "This is a barrel element with: layer " << layer << ", ladder " << ladder << " and module " << module
-            << ".\n";  //Uncomment to read out exact position of each element.
-                       // -----
+            << "This is a barrel element with: layer " << layer << ", ladder " << ladder << " and module " << module;
       }
       //Now endcaps
       else if ((phase == 1 && detid.subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap)) ||
                (phase == 2 && tGeo->geomDetSubDetector(detid.subdetId()) == GeomDetEnumerators::P2PXEC)) {
-        edm::LogPrint("SiPixelTemplateDBObjectUploader") << "--- IN AN ENDCAP ---\n";
-
         //Get the DetId's disk, blade, side, panel, and module
         disk = tTopo->pxfDisk(detid.rawId());    //1,2,3
         blade = tTopo->pxfBlade(detid.rawId());  //1-56 (Ring 1 is 1-22, Ring 2 is 23-56)
@@ -259,20 +252,17 @@ void SiPixelTemplateDBObjectUploader::analyze(const edm::Event& iEvent, const ed
           edm::LogPrint("SiPixelTemplateDBObjectUploader")
               << " Could not fill endcap det unit" << side << ", disk " << disk << ", blade " << blade << ", and panel "
               << panel << ".\n";
-        // ----- debug:
-        edm::LogPrint("SiPixelTemplateDBObjectUploader")
-            << "This is an endcap element with: side " << side << ", disk " << disk << ", blade " << blade
-            << ", and panel " << panel << ".\n";  //Uncomment to read out exact position of each element.
+        edm::LogPrint("SiPixelTemplateDBObjectUploader") << "This is an endcap element with: side " << side << ", disk "
+                                                         << disk << ", blade " << blade << ", and panel " << panel;
       } else {
         continue;
       }
 
       //Print out the assignment of this detID
       short mapnum;
-      edm::LogPrint("SiPixelTemplateDBObjectUploader") << "checking map:\n";
       mapnum = obj.getTemplateID(detid.rawId());
       edm::LogPrint("SiPixelTemplateDBObjectUploader")
-          << "The DetID: " << detid.rawId() << " is mapped to the template: " << mapnum << ".\n\n";
+          << "The DetID: " << detid.rawId() << " is mapped to the template: " << mapnum << "\n";
     }
   }
 

--- a/CondTools/SiPixel/test/SiPixel2DTemplateDBObjectUploader_Phase2_cfg.py
+++ b/CondTools/SiPixel/test/SiPixel2DTemplateDBObjectUploader_Phase2_cfg.py
@@ -84,7 +84,7 @@ if len(magfieldstrsplit)>1 :
 	MagFieldString+=magfieldstrsplit[1]
 
 #open the map file
-mapfile = open(options.Map,'rU', newline='')
+mapfile = open(options.Map,'r', newline='')
 #read the csv file into a reader
 mapfilereader = csv.reader(mapfile,delimiter=options.Delimiter,quotechar=options.Quotechar)
 #separate into the different sections

--- a/CondTools/SiPixel/test/SiPixel2DTemplateDBObjectUploader_cfg.py
+++ b/CondTools/SiPixel/test/SiPixel2DTemplateDBObjectUploader_cfg.py
@@ -1,11 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 import FWCore.ParameterSet.VarParsing as opts
 import csv
+from io import open
 
 options = opts.VarParsing ('standard')
 
 options.register('MagField',
-				 3.8,
+				 None,
 				 opts.VarParsing.multiplicity.singleton,
 				 opts.VarParsing.varType.float,
 				 'Magnetic field value in Tesla')
@@ -24,11 +25,6 @@ options.register('Append',
 				 opts.VarParsing.multiplicity.singleton,
 				 opts.VarParsing.varType.string,
 				 'Any additional string to add to the filename, i.e. "bugfix", etc.')
-options.register('Fullname',
-    			 None,
-    			 opts.VarParsing.multiplicity.singleton,
-    			 opts.VarParsing.varType.string,
-    			 'The entire filename in case the options above are insufficient, i.e. "SiPixel2DTemplateDBObject_phase1_EoR3_HV600_Tr2000", etc.')
 options.register('Map',
 				 '../data/template2D_phase1_2017_IOV1/IOV1_phase1_map.csv',
 				 opts.VarParsing.multiplicity.singleton,
@@ -72,47 +68,44 @@ options.register('useVectorIndices',
 options.parseArguments()
 
 if options.numerator==False and options.denominator==False :
-	print 'ERROR: Neither numerator nor denominator option was selected. Please rerun with numerator/denominator=True options.'
+	print('ERROR: Neither numerator nor denominator option was selected. Please rerun with numerator/denominator=True options.')
 	quit()
 if options.numerator==True and options.denominator==True :
-	print 'ERROR: Both numerator and denominator options are true. Please rerun with only one of numerator/denominator=True.'
+	print('ERROR: Both numerator and denominator options are true. Please rerun with only one of numerator/denominator=True.')
 	quit()
 
 MagFieldValue = 10.*options.MagField #code needs it in deciTesla
-print '\nMagField = %f deciTesla \n'%(MagFieldValue)
+print('\nMagField = %f deciTesla \n'%(MagFieldValue))
 version = options.Version
-print'\nVersion = %s \n'%(version)
+print('\nVersion = %s \n'%(version))
 magfieldstrsplit = str(options.MagField).split('.')
 MagFieldString = magfieldstrsplit[0]
 if len(magfieldstrsplit)>1 :
 	MagFieldString+=magfieldstrsplit[1]
 
 #open the map file
-mapfile = open(options.Map,'rUb')
+mapfile = open(options.Map,'r', newline='')
 #read the csv file into a reader
 mapfilereader = csv.reader(mapfile,delimiter=options.Delimiter,quotechar=options.Quotechar)
 #separate into the different sections
 barrel_rule_lines = []; endcap_rule_lines = []
 barrel_exception_lines = []; endcap_exception_lines = []
 sections = [barrel_rule_lines, endcap_rule_lines, barrel_exception_lines, endcap_exception_lines]
-i=0; line = mapfilereader.next()
+i=0; line = next(mapfilereader)
 for i in range(len(sections)) :
-	#print 'line = %s (length=%d)'%(line,len(line)) #DEBUG
-	while len(line)==0 or line[0].find('NUMERATOR TEMPLATE ID')==-1 : #skip to just before the section of info
-		line=mapfilereader.next()
-	#	print 'line = %s (length=%d)'%(line,len(line)) #DEBUG
+	while line[0].find('TEMPLATE ID')==-1 : #skip to just before the section of info
+		line=next(mapfilereader)
 	try :
-		line=mapfilereader.next()
+		line=next(mapfilereader)
 	except StopIteration :
-		print 'Done reading input file' #DEBUG
+		print('Done reading input file')
 		break
-	#print 'line2 = %s'%(line) #DEBUG
-	while len(line)>0 and line[1]!='' : #add the relevant lines to the section
+	while line[1]!='' : #add the lines that are the barrel rules
 		sections[i].append(line) 
 		try :
-			line=mapfilereader.next()
+			line=next(mapfilereader)
 		except StopIteration :
-			print 'Done reading input file'
+			print('Done reading input file')
 			break
 #print 'barrel rules = %s\nendcap rules = %s\nbarrel exceptions = %s\nendcap exceptions = %s'%(barrel_rule_lines,endcap_rule_lines,barrel_exception_lines,endcap_exception_lines) #DEBUG
 #Make the lists of location strings and template IDs
@@ -126,7 +119,7 @@ suffix = '.out'
 for s in range(len(sections)) :
 	for line in sections[s] :
 	#	print 'reading line: %s'%(line) #DEBUG
-		template_ID_s = line[0] if options.numerator==True else line[1]
+		template_ID_s = line[0]
 		while len(template_ID_s)<4 :
 			template_ID_s='0'+template_ID_s
 		newtemplatefilename = prefix+template_ID_s+suffix
@@ -134,7 +127,7 @@ for s in range(len(sections)) :
 		if not newtemplatefilename in template_filenames :
 			template_filenames.append(newtemplatefilename)
 		if s%2==0 :
-			lay, lad, mod = line[2], line[3], line[4]
+			lay, lad, mod = line[1], line[2], line[3]
 	#		print '	lay = %s, lad = %s, mod = %s'%(lay, lad, mod) #DEBUG
 			#barrel ID strings are "layer_ladder_module"
 			laysplit = lay.split('-'); firstlay=int(laysplit[0]); lastlay= int(laysplit[1])+1 if len(laysplit)>1 else firstlay+1
@@ -154,7 +147,7 @@ for s in range(len(sections)) :
 							location_index = barrel_locations.index(location_string)
 							barrel_template_IDs[location_index]=template_ID
 		else : 
-			disk, blade, side, panel = line[2], line[3], line[4], line[5]
+			disk, blade, side, panel = line[1], line[2], line[3], line[4]
 			#endcap ID strings are "disk_blade_side_panel"
 			disksplit = disk.split('-'); firstdisk=int(disksplit[0]); lastdisk = int(disksplit[1])+1 if len(disksplit)>1 else firstdisk+1
 			for i in range(firstdisk,lastdisk) :
@@ -177,9 +170,9 @@ for s in range(len(sections)) :
 #Debug print out assignments
 #print 'BARREL ASSIGNMENTS:' #DEBUG
 #for i in range(len(barrel_locations)) : #DEBUG
-#	tempid = barrel_template_IDs[i] #DEBUG
-#	lay, lad, mod = barrel_locations[i].split('_')[0], barrel_locations[i].split('_')[1], barrel_locations[i].split('_')[2] #DEBUG
-#	print '	layer %s, ladder %s, module %s will have template ID %d assigned to it'%(lay,lad,mod,tempid) #DEBUG
+	#tempid = barrel_template_IDs[i] #DEBUG
+	#lay, lad, mod = barrel_locations[i].split('_')[0], barrel_locations[i].split('_')[1], barrel_locations[i].split('_')[2] #DEBUG
+	#print '	layer %s, ladder %s, module %s will have template ID %d assigned to it'%(lay,lad,mod,tempid) #DEBUG
 #print 'ENDCAP ASSIGNMENTS:' #DEBUG
 #for i in range(len(endcap_locations)) : #DEBUG
 #	tempid = endcap_template_IDs[i] #DEBUG
@@ -188,7 +181,7 @@ for s in range(len(sections)) :
 
 from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("SiPixel2DTemplateDBUpload",eras.Run2_2017)
+process = cms.Process("SiPixel2DTemplateDBUpload",eras.Run2_2017)#C2)
 process.load("CondCore.CondDB.CondDB_cfi")
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.load('Configuration.Geometry.GeometryExtended2017Reco_cff')
@@ -197,71 +190,62 @@ process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, options.GlobalTag, '')
 
-
-template_base=''
-if options.Fullname!=None :
-	template_base=options.Fullname
-else :
-	template_base = 'SiPixel2DTemplateDBObject_phase1_'+MagFieldString+'T_'+options.Year+'_v'+version
+template_base = 'SiPixel2DTemplateDBObject_phase1_'+MagFieldString+'T'+'_v'+version
 if options.numerator==True :
 	template_base+='_num'
 elif options.denominator==True :
 	template_base+='_den'
-if options.Append!=None and options.Fullname==None :
+if options.Append!=None :
 	template_base+='_'+options.Append
 #output SQLite filename
 sqlitefilename = 'sqlite_file:'+template_base+'.db'
 
-print '\nUploading %s with record SiPixel2DTemplateDBObjectRcd in file %s\n' % (template_base,sqlitefilename)
+print('\nUploading %s with record SiPixel2DTemplateDBObjectRcd in file %s\n' % (template_base,sqlitefilename))
 
 process.source = cms.Source("EmptyIOVSource",
-				timetype = cms.string('runnumber'),
-				firstValue = cms.uint64(1),
-				lastValue = cms.uint64(1),
-				interval = cms.uint64(1)
-				)
+		timetype = cms.string('runnumber'),
+		firstValue = cms.uint64(1),
+		lastValue = cms.uint64(1),
+                interval = cms.uint64(1)
+		)
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1))
 if options.numerator==True :
 	process.PoolDBOutputService = cms.Service("PoolDBOutputService",
-				DBParameters = cms.PSet(messageLevel = cms.untracked.int32(0),
-				authenticationPath = cms.untracked.string('.')
-				),
-				timetype = cms.untracked.string('runnumber'),
-				connect = cms.string(sqlitefilename),
-				toPut = cms.VPSet(
-                                    cms.PSet(
-                                        record = cms.string('SiPixel2DTemplateDBObjectRcd'),
-                                        tag = cms.string(template_base)
-                                        )
-                                    )
-				)
+		DBParameters = cms.PSet(messageLevel = cms.untracked.int32(0),
+                    authenticationPath = cms.untracked.string('.')
+                    ),
+		timetype = cms.untracked.string('runnumber'),
+		connect = cms.string(sqlitefilename),
+		toPut = cms.VPSet(cms.PSet(record = cms.string('SiPixel2DTemplateDBObjectRcd'),
+		tag = cms.string(template_base)
+		)
+		)
+		)
 elif options.denominator==True :
 	process.PoolDBOutputService = cms.Service("PoolDBOutputService",
-				DBParameters = cms.PSet(messageLevel = cms.untracked.int32(0),
-				authenticationPath = cms.untracked.string('.')
-				),
-				timetype = cms.untracked.string('runnumber'),
-				connect = cms.string(sqlitefilename),
-				toPut = cms.VPSet(
-                                    cms.PSet(
-                                        record = cms.string('SiPixel2DTemplateDBObjectRcd'),
-                                        label=cms.string('unirradiated'),
-                                        tag = cms.string(template_base)
-                                        )
-                                    )
-				)
+	DBParameters = cms.PSet(messageLevel = cms.untracked.int32(0),
+                         authenticationPath = cms.untracked.string('.')
+                         ),
+			timetype = cms.untracked.string('runnumber'),
+			connect = cms.string(sqlitefilename),
+			toPut = cms.VPSet(cms.PSet(record = cms.string('SiPixel2DTemplateDBObjectRcd'),
+                            label=cms.string('unirradiated'),
+                            tag = cms.string(template_base)
+			)
+			)
+                    )
 process.uploader = cms.EDAnalyzer("SiPixel2DTemplateDBObjectUploader",
-				siPixelTemplateCalibrations = cms.vstring(template_filenames),
-				theTemplateBaseString = cms.string(template_base),
-				Version = cms.double(3.0),
-				MagField = cms.double(MagFieldValue),
-				detIds = cms.vuint32(1,2), #0 is for all, 1 is Barrel, 2 is EndCap
-				barrelLocations = cms.vstring(barrel_locations),
-				endcapLocations = cms.vstring(endcap_locations),
-				barrelTemplateIds = cms.vuint32(barrel_template_IDs),
-				endcapTemplateIds = cms.vuint32(endcap_template_IDs),
-				useVectorIndices  = cms.untracked.bool(options.useVectorIndices),
-				)
+	siPixelTemplateCalibrations = cms.vstring(template_filenames),
+	theTemplateBaseString = cms.string(template_base),
+	Version = cms.double(3.0),
+	MagField = cms.double(MagFieldValue),
+	detIds = cms.vuint32(1,2), #0 is for all, 1 is Barrel, 2 is EndCap
+	barrelLocations = cms.vstring(barrel_locations),
+	endcapLocations = cms.vstring(endcap_locations),
+	barrelTemplateIds = cms.vuint32(barrel_template_IDs),
+	endcapTemplateIds = cms.vuint32(endcap_template_IDs),
+	useVectorIndices  = cms.untracked.bool(options.useVectorIndices),
+	)
 process.myprint = cms.OutputModule("AsciiOutputModule")
 process.p = cms.Path(process.uploader)
 process.CondDB.connect = sqlitefilename

--- a/CondTools/SiPixel/test/SiPixelGenErrorDBObjectUploader_Phase2_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelGenErrorDBObjectUploader_Phase2_cfg.py
@@ -72,7 +72,7 @@ if len(magfieldstrsplit)>1 :
 	MagFieldString+=magfieldstrsplit[1]
 
 #open the map file
-mapfile = open(options.Map,'rU', newline='')
+mapfile = open(options.Map,'r', newline='')
 #read the csv file into a reader
 mapfilereader = csv.reader(mapfile,delimiter=options.Delimiter,quotechar=options.Quotechar)
 #separate into the different sections

--- a/CondTools/SiPixel/test/SiPixelGenErrorDBObjectUploader_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelGenErrorDBObjectUploader_cfg.py
@@ -72,7 +72,7 @@ if len(magfieldstrsplit)>1 :
 	MagFieldString+=magfieldstrsplit[1]
 
 #open the map file
-mapfile = open(options.Map,'rU', newline='')
+mapfile = open(options.Map,'r', newline='')
 #read the csv file into a reader
 mapfilereader = csv.reader(mapfile,delimiter=options.Delimiter,quotechar=options.Quotechar)
 #separate into the different sections

--- a/CondTools/SiPixel/test/SiPixelTemplateDBObjectUploader_Phase2_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelTemplateDBObjectUploader_Phase2_cfg.py
@@ -72,7 +72,7 @@ if len(magfieldstrsplit)>1 :
 	MagFieldString+=magfieldstrsplit[1]
 
 #open the map file
-mapfile = open(options.Map,'rU', newline='')
+mapfile = open(options.Map,'r', newline='')
 #read the csv file into a reader
 mapfilereader = csv.reader(mapfile,delimiter=options.Delimiter,quotechar=options.Quotechar)
 #separate into the different sections

--- a/CondTools/SiPixel/test/SiPixelTemplateDBObjectUploader_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelTemplateDBObjectUploader_cfg.py
@@ -72,7 +72,7 @@ if len(magfieldstrsplit)>1 :
 	MagFieldString+=magfieldstrsplit[1]
 
 #open the map file
-mapfile = open(options.Map,'rU', newline='')
+mapfile = open(options.Map,'r', newline='')
 #read the csv file into a reader
 mapfilereader = csv.reader(mapfile,delimiter=options.Delimiter,quotechar=options.Quotechar)
 #separate into the different sections


### PR DESCRIPTION
#### PR description:

 * Fix  "'U' mode is deprecated" message when reading in files. The default now contains the 'U' mode.
 * Other py3 related changes for SiPixel2DTemplateDBObjectUploader_cfg.py with some other cleaning
 * Also make the printouts a bit more concise as the unit tests were really dominated by the CPE printouts
 * I'll deal with the "Assigned value is undefined" SA warning a bit later, this is just for a char array not being initialized

#### PR validation:

 `scramv1 b runtests` runs fine

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
