### PR TITLE
[DQM] Prompt matrix redefinition 

### DIFF
--- a/DQMOffline/Configuration/python/autoDQM.py
+++ b/DQMOffline/Configuration/python/autoDQM.py
@@ -2,13 +2,17 @@ autoDQM = { 'DQMMessageLogger': ['DQMMessageLoggerSeq',
                               'PostDQMOffline',
                               'DQMMessageLoggerClientSeq'],
 
-            'common': ['@dcs+@DQMMessageLogger+@stripCommon+@pixel+@tracking+@L1TMon+@hlt+@beam+@castor+@physics+@tau+@ctpps',
+           'commonReduced': ['@dcs+@DQMMessageLogger+@hlt+@beam+@castor+@physics',
                         'PostDQMOffline',
-                        '@dcs+@DQMMessageLogger+@stripCommon+@pixel+@tracking+@L1TMon+@hlt+@beam+@fed+@tau+@ctpps+dqmFastTimerServiceClient'],
+                        '@dcs+@DQMMessageLogger+@hlt+@beam+@fed+dqmFastTimerServiceClient'],
 
-            'commonFakeHLT': ['@dcs+@DQMMessageLogger+@stripCommon+@pixel+@tracking+@L1TMon+@beam+@castor+@physics+@tau',
+	   'common': ['@dcs+@DQMMessageLogger+@stripCommon+@pixel+@tracking+@hlt+@beam+@castor+@physics',
                         'PostDQMOffline',
-                        '@dcs+@DQMMessageLoggerClient+@stripCommon+@pixel+@tracking+@L1TMon+@beam+@fed+@tau+dqmFastTimerServiceClient'],
+                        '@dcs+@DQMMessageLogger+@stripCommon+@pixel+@tracking+@hlt+@beam+@fed+dqmFastTimerServiceClient'],
+
+            'commonFakeHLT': ['@dcs+@DQMMessageLogger+@stripCommon+@pixel+@tracking+@beam+@castor+@physics',
+                        'PostDQMOffline',
+                        '@dcs+@DQMMessageLoggerClient+@stripCommon+@pixel+@tracking+@beam+@fed+dqmFastTimerServiceClient'],
 
             'commonSiStripZeroBias': ['@dcs+@DQMMessageLogger+@stripZeroBias+@pixelOnlyDQM+@trackingZeroBias+@L1TMon+@hlt+@beam+@castor+@physics',
                                       'PostDQMOffline',

--- a/DQMOffline/Configuration/python/autoDQM.py
+++ b/DQMOffline/Configuration/python/autoDQM.py
@@ -166,9 +166,9 @@ autoDQM = { 'DQMMessageLogger': ['DQMMessageLoggerSeq',
                         'PostDQMOffline',
                         '@commonSiStripZeroBias+@muon+@hcal+@jetmet+@ecal'],
 
-            'allForPrompt': ['@common+@muon+@hcal+@jetmet+@ecal+@egamma',
+            'allForPrompt': ['@common+@muon+@L1TMon+@hcal+@jetmet+@ecal+@egamma',
                              'PostDQMOffline',
-                             '@common+@muon+@hcal+@jetmet+@ecal+@egamma'],
+                             '@common+@muon+@L1TMon+@hcal+@jetmet+@ecal+@egamma'],
 
             'rerecoCommon': ['@common+@muon+@hcal+@jetmet+@ecal+@egamma+@L1TMuon+@L1TEgamma+@ctpps',
                              'PostDQMOffline',


### PR DESCRIPTION
#### PR description:

Based on agreements from PPD meetings:
- Created commonReduced which excludes TRK
- Removed CT-PPS, L1TMon and Tau from common

https://docs.google.com/presentation/d/1AF65xzq7T70Yt-0o_OV47YTFBv-kbvHZDlRmUSCZsAw/edit#slide=id.geedc047305_0_0

This PR goes in sync with: https://github.com/dmwm/T0/pull/4617

