### PR TITLE
fix issue with SiPixelBadModule_ may be used uninitialized in TSAN builds

### DIFF
--- a/CondTools/SiPixel/plugins/SiPixelBadModuleReader.cc
+++ b/CondTools/SiPixel/plugins/SiPixelBadModuleReader.cc
@@ -32,11 +32,15 @@ SiPixelBadModuleReader::SiPixelBadModuleReader(const edm::ParameterSet& iConfig)
 SiPixelBadModuleReader::~SiPixelBadModuleReader() = default;
 
 void SiPixelBadModuleReader::analyze(const edm::Event& e, const edm::EventSetup& iSetup) {
-  const SiPixelQuality* SiPixelBadModule_;
-  if (whichRcd == "SiPixelQualityRcd")
+  const SiPixelQuality* SiPixelBadModule_ = nullptr;
+  if (whichRcd == "SiPixelQualityRcd") {
     SiPixelBadModule_ = &iSetup.getData(badModuleToken);
-  if (whichRcd == "SiPixelQualityFromDbRcd")
+  } else if (whichRcd == "SiPixelQualityFromDbRcd") {
     SiPixelBadModule_ = &iSetup.getData(badModuleFromDBToken);
+  } else {
+    throw cms::Exception("LogicalError") << "SiPixelBadModuleReader::analyze, unsupported RcdName value " << whichRcd
+                                         << ".\n Please check the configuration." << std::endl;
+  }
 
   edm::ESHandle<SiPixelFedCablingMap> map = iSetup.getHandle(siPixelFedCablingToken);
   edm::LogInfo("SiPixelBadModuleReader") << "[SiPixelBadModuleReader::analyze] End Reading SiPixelBadModule"


### PR DESCRIPTION
resolves https://github.com/cms-sw/cmssw/issues/35606

#### PR description:

Title says it all.

#### PR validation:

Compiled in `CMSSW_12_1_TSAN_X_2021-10-08-1100` and didn't observe warnings.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
