### PR TITLE
Fix out of bounds error in Ecal Validation

### DIFF
--- a/Validation/EcalDigis/plugins/EcalSelectiveReadoutValidation.cc
+++ b/Validation/EcalDigis/plugins/EcalSelectiveReadoutValidation.cc
@@ -446,7 +446,7 @@ void EcalSelectiveReadoutValidation::analyzeEE(const edm::Event& event, const ed
         eventError = true;
         ++nEeZsErrors_;
         pair<int, int> ru = dccCh(frame.id());
-        if (isRuComplete_[ru.first][ru.second - 1])
+        if (isRuComplete_[ru.first - 1][ru.second - 1])
           ++nEeZsErrorsType1_;
         if (nEeZsErrors_ < 3) {
           srApplicationErrorLog_ << event.id() << ", "
@@ -706,7 +706,7 @@ void EcalSelectiveReadoutValidation::analyzeEB(const edm::Event& event, const ed
         eventError = true;
         ++nEbZsErrors_;
         pair<int, int> ru = dccCh(frame.id());
-        if (isRuComplete_[ru.first][ru.second - 1])
+        if (isRuComplete_[ru.first - 1][ru.second - 1])
           ++nEbZsErrorsType1_;
         if (nEbZsErrors_ < 3) {
           srApplicationErrorLog_ << event.id() << ", "


### PR DESCRIPTION
#### PR description:
This PR addresses the runtime error described here: https://github.com/cms-sw/cmssw/issues/35037#issuecomment-940355813 in Ecal Validation

#### PR validation:
The PR was validated by running the workflow `281.0` on top of the release `CMSSW_12_1_UBSAN_X_2021-10-08-2300` and observed no runtime errors of type `index out of bounds`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
N/A
