### PR TITLE
[GCC11] fix warnings: Change to new method writeOneIOV

### DIFF
--- a/Alignment/TrackerAlignment/plugins/CreateTrackerAlignmentRcds.cc
+++ b/Alignment/TrackerAlignment/plugins/CreateTrackerAlignmentRcds.cc
@@ -386,9 +386,9 @@ void CreateIdealTkAlRecords::writeToDB() {
   }
 
   edm::LogInfo("Alignment") << "Writing ideal tracker-alignment records.";
-  poolDb->writeOne(&alignments_, since, "TrackerAlignmentRcd");
-  poolDb->writeOne(&alignmentErrors_, since, "TrackerAlignmentErrorExtendedRcd");
-  poolDb->writeOne(&alignmentSurfaceDeformations_, since, "TrackerSurfaceDeformationRcd");
+  poolDb->writeOneIOV(alignments_, since, "TrackerAlignmentRcd");
+  poolDb->writeOneIOV(alignmentErrors_, since, "TrackerAlignmentErrorExtendedRcd");
+  poolDb->writeOneIOV(alignmentSurfaceDeformations_, since, "TrackerSurfaceDeformationRcd");
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------

--- a/Alignment/TrackerAlignment/plugins/MCMisalignmentScaler.cc
+++ b/Alignment/TrackerAlignment/plugins/MCMisalignmentScaler.cc
@@ -226,7 +226,7 @@ void MCMisalignmentScaler::analyze(const edm::Event&, const edm::EventSetup& iSe
   }
   edm::LogInfo("Alignment") << "Writing rescaled tracker-alignment record.";
   const auto& since = cond::timeTypeSpecs[cond::runnumber].beginValue;
-  poolDb->writeOne(&rescaledAlignments, since, "TrackerAlignmentRcd");
+  poolDb->writeOneIOV(rescaledAlignments, since, "TrackerAlignmentRcd");
 }
 
 MCMisalignmentScaler::ScalerMap MCMisalignmentScaler::decodeSubDetectors(const edm::VParameterSet& psets) {

--- a/CondCore/DBOutputService/test/stubs/IOVPayloadEndOfJob.cc
+++ b/CondCore/DBOutputService/test/stubs/IOVPayloadEndOfJob.cc
@@ -37,7 +37,7 @@ void IOVPayloadEndOfJob::endJob() {
       //create
       cond::Time_t firstSinceTime = mydbservice->beginOfTime();
       std::cout << "firstSinceTime is begin of time " << firstSinceTime << std::endl;
-      mydbservice->writeOne(&myped, firstSinceTime, m_record);
+      mydbservice->writeOneIOV(myped, firstSinceTime, m_record);
     } else {
       //append
       cond::Time_t current = mydbservice->currentTime();
@@ -52,7 +52,7 @@ void IOVPayloadEndOfJob::endJob() {
         }
         cond::Time_t thisPayload_valid_since = current;
         std::cout << "appeding since time " << thisPayload_valid_since << std::endl;
-        mydbservice->writeOne(&myped, thisPayload_valid_since, m_record);
+        mydbservice->writeOneIOV(myped, thisPayload_valid_since, m_record);
         std::cout << "done" << std::endl;
         //std::cout<<myped->m_pedestals[1].m_mean<<std::endl;
       }

--- a/CondCore/DBOutputService/test/stubs/Timestamp.cc
+++ b/CondCore/DBOutputService/test/stubs/Timestamp.cc
@@ -33,7 +33,7 @@ void Timestamp::analyze(const edm::Event& evt, const edm::EventSetup& evtSetup) 
   std::cout << myped.m_pedestals[1].m_mean << std::endl;
   std::cout << "currentTime " << mydbservice->currentTime() << std::endl;
   if (mydbservice->currentTime() % 5 == 0) {
-    mydbservice->writeOne(&myped, mydbservice->currentTime(), m_record);
+    mydbservice->writeOneIOV(myped, mydbservice->currentTime(), m_record);
   }
 }
 void Timestamp::endJob() {}


### PR DESCRIPTION
GCC IBs has 12 warnings [a]. This PR ( just like https://github.com/cms-sw/cmssw/pull/35602 ) uses the new method `writeOneIOV` which fixes the compilation warnings

[a]
https://cmssdt.cern.ch/SDT/cgi-bin/showBuildLogs.py/slc7_amd64_gcc11/www/mon/12.1-mon-11/CMSSW_12_1_X_2021-10-11-1100
```
  CondFormats/Alignment/interface/Alignments.h:13:26: warning: 'void operator delete(void*, std::size_t)' called on pointer '<unknown>' with nonzero offset 160 [-Wfree-nonheap-object]
    13 |   virtual ~Alignments() {}

  CondFormats/Calibration/interface/Pedestals.h:17:25: warning: 'void operator delete(void*, std::size_t)' called on unallocated object 'myped' [-Wfree-nonheap-object]
    17 |   virtual ~Pedestals() {}
```