### PR TITLE
Add producers/configs to refit muon tracks with standard TrackRefitter

### DIFF
--- a/RecoTracker/TrackProducer/plugins/TrackExtraRekeyer.cc
+++ b/RecoTracker/TrackProducer/plugins/TrackExtraRekeyer.cc
@@ -1,0 +1,64 @@
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/TrackReco/interface/TrackExtraFwd.h"
+
+class TrackExtraRekeyer : public edm::stream::EDProducer<>
+{
+public:
+  explicit TrackExtraRekeyer(const edm::ParameterSet &);
+  ~TrackExtraRekeyer() {}
+
+//   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+
+private:
+  
+  virtual void produce(edm::Event &, const edm::EventSetup &) override;
+  
+  edm::EDGetTokenT<reco::TrackCollection> inputTrack_;
+  edm::EDGetTokenT<edm::Association<reco::TrackExtraCollection>> inputAssoc_;
+  edm::EDPutTokenT<reco::TrackCollection> outputTrack_;
+
+};
+
+
+TrackExtraRekeyer::TrackExtraRekeyer(const edm::ParameterSet &iConfig)
+
+{
+  inputTrack_ = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("src"));
+  inputAssoc_ = consumes<edm::Association<reco::TrackExtraCollection>>(iConfig.getParameter<edm::InputTag>("association"));
+  
+  outputTrack_ = produces<reco::TrackCollection>();
+}
+
+// ------------ method called for each event  ------------
+void TrackExtraRekeyer::produce(edm::Event &iEvent, const edm::EventSetup &iSetup)
+{
+  using namespace edm;
+  
+  Handle<reco::TrackCollection> tracks;
+  iEvent.getByToken(inputTrack_, tracks);
+  
+  Handle<edm::Association<reco::TrackExtraCollection>> assoc;
+  iEvent.getByToken(inputAssoc_, assoc);
+
+  reco::TrackCollection tracksOut;
+  
+  for (auto const &track : *tracks) {
+    if (!assoc->contains(track.extra().id())) {
+      continue;
+    }
+    const reco::TrackExtraRef &trackextraref = (*assoc)[track.extra()];
+    if (trackextraref.isNonnull()) {
+      auto &trackout = tracksOut.emplace_back(track);
+      trackout.setExtra(trackextraref);
+    }
+  }
+  
+  iEvent.emplace(outputTrack_, std::move(tracksOut));
+  
+}
+
+DEFINE_FWK_MODULE(TrackExtraRekeyer);

--- a/RecoTracker/TrackProducer/plugins/TrackExtraRekeyer.cc
+++ b/RecoTracker/TrackProducer/plugins/TrackExtraRekeyer.cc
@@ -5,47 +5,43 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackReco/interface/TrackExtraFwd.h"
 
-class TrackExtraRekeyer : public edm::stream::EDProducer<>
-{
+class TrackExtraRekeyer : public edm::stream::EDProducer<> {
 public:
   explicit TrackExtraRekeyer(const edm::ParameterSet &);
   ~TrackExtraRekeyer() {}
 
-//   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+  //   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
 private:
-  
   virtual void produce(edm::Event &, const edm::EventSetup &) override;
-  
+
   edm::EDGetTokenT<reco::TrackCollection> inputTrack_;
   edm::EDGetTokenT<edm::Association<reco::TrackExtraCollection>> inputAssoc_;
   edm::EDPutTokenT<reco::TrackCollection> outputTrack_;
-
 };
-
 
 TrackExtraRekeyer::TrackExtraRekeyer(const edm::ParameterSet &iConfig)
 
 {
   inputTrack_ = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("src"));
-  inputAssoc_ = consumes<edm::Association<reco::TrackExtraCollection>>(iConfig.getParameter<edm::InputTag>("association"));
-  
+  inputAssoc_ =
+      consumes<edm::Association<reco::TrackExtraCollection>>(iConfig.getParameter<edm::InputTag>("association"));
+
   outputTrack_ = produces<reco::TrackCollection>();
 }
 
 // ------------ method called for each event  ------------
-void TrackExtraRekeyer::produce(edm::Event &iEvent, const edm::EventSetup &iSetup)
-{
+void TrackExtraRekeyer::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   using namespace edm;
-  
+
   Handle<reco::TrackCollection> tracks;
   iEvent.getByToken(inputTrack_, tracks);
-  
+
   Handle<edm::Association<reco::TrackExtraCollection>> assoc;
   iEvent.getByToken(inputAssoc_, assoc);
 
   reco::TrackCollection tracksOut;
-  
+
   for (auto const &track : *tracks) {
     if (!assoc->contains(track.extra().id())) {
       continue;
@@ -56,9 +52,8 @@ void TrackExtraRekeyer::produce(edm::Event &iEvent, const edm::EventSetup &iSetu
       trackout.setExtra(trackextraref);
     }
   }
-  
+
   iEvent.emplace(outputTrack_, std::move(tracksOut));
-  
 }
 
 DEFINE_FWK_MODULE(TrackExtraRekeyer);

--- a/RecoTracker/TrackProducer/plugins/TrackExtraRekeyer.cc
+++ b/RecoTracker/TrackProducer/plugins/TrackExtraRekeyer.cc
@@ -8,12 +8,12 @@
 class TrackExtraRekeyer : public edm::stream::EDProducer<> {
 public:
   explicit TrackExtraRekeyer(const edm::ParameterSet &);
-  ~TrackExtraRekeyer() {}
+  ~TrackExtraRekeyer() override {}
 
   //   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
 private:
-  virtual void produce(edm::Event &, const edm::EventSetup &) override;
+  void produce(edm::Event &, const edm::EventSetup &) override;
 
   edm::EDGetTokenT<reco::TrackCollection> inputTrack_;
   edm::EDGetTokenT<edm::Association<reco::TrackExtraCollection>> inputAssoc_;

--- a/RecoTracker/TrackProducer/plugins/TrackExtraRekeyer.cc
+++ b/RecoTracker/TrackProducer/plugins/TrackExtraRekeyer.cc
@@ -1,59 +1,61 @@
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackReco/interface/TrackExtraFwd.h"
 
-class TrackExtraRekeyer : public edm::stream::EDProducer<> {
+class TrackExtraRekeyer : public edm::global::EDProducer<> {
 public:
   explicit TrackExtraRekeyer(const edm::ParameterSet &);
-  ~TrackExtraRekeyer() override {}
+  ~TrackExtraRekeyer() override = default;
 
-  //   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
 private:
-  void produce(edm::Event &, const edm::EventSetup &) override;
+  void produce(edm::StreamID, edm::Event &, const edm::EventSetup &) const override;
 
-  edm::EDGetTokenT<reco::TrackCollection> inputTrack_;
-  edm::EDGetTokenT<edm::Association<reco::TrackExtraCollection>> inputAssoc_;
-  edm::EDPutTokenT<reco::TrackCollection> outputTrack_;
+  // memeber data
+  const edm::EDGetTokenT<reco::TrackCollection> inputTrack_;
+  const edm::EDGetTokenT<edm::Association<reco::TrackExtraCollection>> inputAssoc_;
+  const edm::EDPutTokenT<reco::TrackCollection> outputTrack_;
 };
 
 TrackExtraRekeyer::TrackExtraRekeyer(const edm::ParameterSet &iConfig)
-
-{
-  inputTrack_ = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("src"));
-  inputAssoc_ =
-      consumes<edm::Association<reco::TrackExtraCollection>>(iConfig.getParameter<edm::InputTag>("association"));
-
-  outputTrack_ = produces<reco::TrackCollection>();
-}
+    : inputTrack_(consumes(iConfig.getParameter<edm::InputTag>("src"))),
+      inputAssoc_(consumes(iConfig.getParameter<edm::InputTag>("association"))),
+      outputTrack_(produces<reco::TrackCollection>()) {}
 
 // ------------ method called for each event  ------------
-void TrackExtraRekeyer::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
+void TrackExtraRekeyer::produce(edm::StreamID, edm::Event &iEvent, const edm::EventSetup &iSetup) const {
   using namespace edm;
 
-  Handle<reco::TrackCollection> tracks;
-  iEvent.getByToken(inputTrack_, tracks);
-
-  Handle<edm::Association<reco::TrackExtraCollection>> assoc;
-  iEvent.getByToken(inputAssoc_, assoc);
+  auto const &tracks = iEvent.get(inputTrack_);
+  auto const &assoc = iEvent.get(inputAssoc_);
 
   reco::TrackCollection tracksOut;
 
-  for (auto const &track : *tracks) {
-    if (!assoc->contains(track.extra().id())) {
+  for (auto const &track : tracks) {
+    if (!assoc.contains(track.extra().id())) {
       continue;
     }
-    const reco::TrackExtraRef &trackextraref = (*assoc)[track.extra()];
+    const reco::TrackExtraRef &trackextraref = assoc[track.extra()];
     if (trackextraref.isNonnull()) {
       auto &trackout = tracksOut.emplace_back(track);
       trackout.setExtra(trackextraref);
     }
   }
-
   iEvent.emplace(outputTrack_, std::move(tracksOut));
+}
+
+void TrackExtraRekeyer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.setComment("Simple prooducer to re-key muon tracks for refit");
+  desc.add<edm::InputTag>("src", edm::InputTag("generalTracks"))->setComment("input track collections");
+  desc.add<edm::InputTag>("association", edm::InputTag("muonReducedTrackExtras"))
+      ->setComment("input track association collection");
+  descriptions.addWithDefaultLabel(desc);
 }
 
 DEFINE_FWK_MODULE(TrackExtraRekeyer);

--- a/RecoTracker/TrackProducer/plugins/TrackProducerFromPatMuons.cc
+++ b/RecoTracker/TrackProducer/plugins/TrackProducerFromPatMuons.cc
@@ -6,24 +6,20 @@
 #include "DataFormats/TrackReco/interface/TrackExtraFwd.h"
 #include "DataFormats/PatCandidates/interface/Muon.h"
 
-class TrackProducerFromPatMuons : public edm::stream::EDProducer<>
-{
+class TrackProducerFromPatMuons : public edm::stream::EDProducer<> {
 public:
   explicit TrackProducerFromPatMuons(const edm::ParameterSet &);
   ~TrackProducerFromPatMuons() {}
 
-//   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+  //   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
 private:
-  
   virtual void produce(edm::Event &, const edm::EventSetup &) override;
-  
+
   edm::EDGetTokenT<std::vector<pat::Muon>> inputMuons_;
   edm::EDPutTokenT<reco::TrackCollection> outputTrack_;
   bool innerTrackOnly_;
-
 };
-
 
 TrackProducerFromPatMuons::TrackProducerFromPatMuons(const edm::ParameterSet &iConfig)
 
@@ -34,24 +30,22 @@ TrackProducerFromPatMuons::TrackProducerFromPatMuons(const edm::ParameterSet &iC
 }
 
 // ------------ method called for each event  ------------
-void TrackProducerFromPatMuons::produce(edm::Event &iEvent, const edm::EventSetup &iSetup)
-{
+void TrackProducerFromPatMuons::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   using namespace edm;
-  
+
   Handle<std::vector<pat::Muon>> muons;
   iEvent.getByToken(inputMuons_, muons);
 
   reco::TrackCollection tracksOut;
-  
+
   for (auto const &muon : *muons) {
     const reco::TrackRef trackRef = innerTrackOnly_ ? muon.innerTrack() : muon.muonBestTrack();
     if (trackRef.isNonnull() && trackRef->extra().isAvailable()) {
       tracksOut.emplace_back(*trackRef);
     }
   }
-  
+
   iEvent.emplace(outputTrack_, std::move(tracksOut));
-  
 }
 
 DEFINE_FWK_MODULE(TrackProducerFromPatMuons);

--- a/RecoTracker/TrackProducer/plugins/TrackProducerFromPatMuons.cc
+++ b/RecoTracker/TrackProducer/plugins/TrackProducerFromPatMuons.cc
@@ -1,0 +1,57 @@
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/TrackReco/interface/TrackExtraFwd.h"
+#include "DataFormats/PatCandidates/interface/Muon.h"
+
+class TrackProducerFromPatMuons : public edm::stream::EDProducer<>
+{
+public:
+  explicit TrackProducerFromPatMuons(const edm::ParameterSet &);
+  ~TrackProducerFromPatMuons() {}
+
+//   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+
+private:
+  
+  virtual void produce(edm::Event &, const edm::EventSetup &) override;
+  
+  edm::EDGetTokenT<std::vector<pat::Muon>> inputMuons_;
+  edm::EDPutTokenT<reco::TrackCollection> outputTrack_;
+  bool innerTrackOnly_;
+
+};
+
+
+TrackProducerFromPatMuons::TrackProducerFromPatMuons(const edm::ParameterSet &iConfig)
+
+{
+  inputMuons_ = consumes<std::vector<pat::Muon>>(iConfig.getParameter<edm::InputTag>("src"));
+  outputTrack_ = produces<reco::TrackCollection>();
+  innerTrackOnly_ = iConfig.getParameter<bool>("innerTrackOnly");
+}
+
+// ------------ method called for each event  ------------
+void TrackProducerFromPatMuons::produce(edm::Event &iEvent, const edm::EventSetup &iSetup)
+{
+  using namespace edm;
+  
+  Handle<std::vector<pat::Muon>> muons;
+  iEvent.getByToken(inputMuons_, muons);
+
+  reco::TrackCollection tracksOut;
+  
+  for (auto const &muon : *muons) {
+    const reco::TrackRef trackRef = innerTrackOnly_ ? muon.innerTrack() : muon.muonBestTrack();
+    if (trackRef.isNonnull() && trackRef->extra().isAvailable()) {
+      tracksOut.emplace_back(*trackRef);
+    }
+  }
+  
+  iEvent.emplace(outputTrack_, std::move(tracksOut));
+  
+}
+
+DEFINE_FWK_MODULE(TrackProducerFromPatMuons);

--- a/RecoTracker/TrackProducer/plugins/TrackProducerFromPatMuons.cc
+++ b/RecoTracker/TrackProducer/plugins/TrackProducerFromPatMuons.cc
@@ -9,12 +9,12 @@
 class TrackProducerFromPatMuons : public edm::stream::EDProducer<> {
 public:
   explicit TrackProducerFromPatMuons(const edm::ParameterSet &);
-  ~TrackProducerFromPatMuons() {}
+  ~TrackProducerFromPatMuons() override {}
 
   //   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
 private:
-  virtual void produce(edm::Event &, const edm::EventSetup &) override;
+  void produce(edm::Event &, const edm::EventSetup &) override;
 
   edm::EDGetTokenT<std::vector<pat::Muon>> inputMuons_;
   edm::EDPutTokenT<reco::TrackCollection> outputTrack_;

--- a/RecoTracker/TrackProducer/plugins/TrackProducerFromPatMuons.cc
+++ b/RecoTracker/TrackProducer/plugins/TrackProducerFromPatMuons.cc
@@ -1,4 +1,5 @@
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "DataFormats/TrackReco/interface/Track.h"
@@ -6,46 +7,49 @@
 #include "DataFormats/TrackReco/interface/TrackExtraFwd.h"
 #include "DataFormats/PatCandidates/interface/Muon.h"
 
-class TrackProducerFromPatMuons : public edm::stream::EDProducer<> {
+class TrackProducerFromPatMuons : public edm::global::EDProducer<> {
 public:
   explicit TrackProducerFromPatMuons(const edm::ParameterSet &);
-  ~TrackProducerFromPatMuons() override {}
+  ~TrackProducerFromPatMuons() override = default;
 
-  //   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
 private:
-  void produce(edm::Event &, const edm::EventSetup &) override;
+  void produce(edm::StreamID, edm::Event &, const edm::EventSetup &) const override;
 
-  edm::EDGetTokenT<std::vector<pat::Muon>> inputMuons_;
-  edm::EDPutTokenT<reco::TrackCollection> outputTrack_;
-  bool innerTrackOnly_;
+  const edm::EDGetTokenT<std::vector<pat::Muon>> inputMuons_;
+  const edm::EDPutTokenT<reco::TrackCollection> outputTrack_;
+  const bool innerTrackOnly_;
 };
 
 TrackProducerFromPatMuons::TrackProducerFromPatMuons(const edm::ParameterSet &iConfig)
-
-{
-  inputMuons_ = consumes<std::vector<pat::Muon>>(iConfig.getParameter<edm::InputTag>("src"));
-  outputTrack_ = produces<reco::TrackCollection>();
-  innerTrackOnly_ = iConfig.getParameter<bool>("innerTrackOnly");
-}
+    : inputMuons_(consumes<std::vector<pat::Muon>>(iConfig.getParameter<edm::InputTag>("src"))),
+      outputTrack_(produces<reco::TrackCollection>()),
+      innerTrackOnly_(iConfig.getParameter<bool>("innerTrackOnly")) {}
 
 // ------------ method called for each event  ------------
-void TrackProducerFromPatMuons::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
+void TrackProducerFromPatMuons::produce(edm::StreamID, edm::Event &iEvent, const edm::EventSetup &iSetup) const {
   using namespace edm;
 
-  Handle<std::vector<pat::Muon>> muons;
-  iEvent.getByToken(inputMuons_, muons);
+  auto const &muons = iEvent.get(inputMuons_);
 
   reco::TrackCollection tracksOut;
 
-  for (auto const &muon : *muons) {
+  for (auto const &muon : muons) {
     const reco::TrackRef trackRef = innerTrackOnly_ ? muon.innerTrack() : muon.muonBestTrack();
     if (trackRef.isNonnull() && trackRef->extra().isAvailable()) {
       tracksOut.emplace_back(*trackRef);
     }
   }
-
   iEvent.emplace(outputTrack_, std::move(tracksOut));
+}
+
+void TrackProducerFromPatMuons::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.setComment("Simple prooducer to generate track from pat::muons ");
+  desc.add<edm::InputTag>("src", edm::InputTag("slimmedMuons"))->setComment("input track collections");
+  desc.add<bool>("innerTrackOnly", true)->setComment("use only inner track");
+  descriptions.addWithDefaultLabel(desc);
 }
 
 DEFINE_FWK_MODULE(TrackProducerFromPatMuons);

--- a/RecoTracker/TrackProducer/test/BuildFile.xml
+++ b/RecoTracker/TrackProducer/test/BuildFile.xml
@@ -29,3 +29,10 @@
   <use name="RecoTracker/TransientTrackingRecHit"/>
   <flags EDM_PLUGIN="1"/>
 </library>
+
+<environment>
+  <bin file="testMuonTrackRefitting.cpp">
+    <flags TEST_RUNNER_ARGS="/bin/bash RecoTracker/TrackProducer/test testMuonTrackRefitting.sh"/>
+    <use name="FWCore/Utilities"/>
+  </bin>
+</environment>

--- a/RecoTracker/TrackProducer/test/refitFromAOD.py
+++ b/RecoTracker/TrackProducer/test/refitFromAOD.py
@@ -1,0 +1,78 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
+
+process = cms.Process('RECO2',Run2_2016)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.Reconstruction_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+    
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+        '/store/mc/RunIISummer20UL16RECO/DYJetsToMuMu_M-50_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/AODSIM/106X_mcRun2_asymptotic_v13-v2/00000/1D4FBF4B-7B8D-A04F-A108-B1BEB60558FA.root',
+    ),
+    secondaryFileNames = cms.untracked.vstring()
+)
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('step1 nevts:1'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+# Output definition
+
+process.RECOSIMoutput = cms.OutputModule("PoolOutputModule",
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string(''),
+        filterName = cms.untracked.string('')
+    ),
+    fileName = cms.untracked.string('step1_RECO.root'),
+    outputCommands = process.RECOSIMEventContent.outputCommands,
+    splitLevel = cms.untracked.int32(0)
+)
+
+# Additional output definition
+process.RECOSIMoutput.outputCommands = cms.untracked.vstring("keep *_myRefittedTracks_*_*")
+
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
+
+process.trackExtraRekeyer = cms.EDProducer("TrackExtraRekeyer",
+                                         src = cms.InputTag("generalTracks"),
+                                         association = cms.InputTag("muonReducedTrackExtras"),
+                                         )
+
+import RecoTracker.TrackProducer.TrackRefitter_cfi
+process.myRefittedTracks = RecoTracker.TrackProducer.TrackRefitter_cfi.TrackRefitter.clone()
+process.myRefittedTracks.src= 'trackExtraRekeyer'
+process.myRefittedTracks.NavigationSchool = ''
+process.myRefittedTracks.Fitter = 'FlexibleKFFittingSmoother'
+                                         
+
+# Path and EndPath definitions
+process.reconstruction_step = cms.Path(process.trackExtraRekeyer*process.myRefittedTracks)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RECOSIMoutput_step = cms.EndPath(process.RECOSIMoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.reconstruction_step,process.endjob_step,process.RECOSIMoutput_step)
+
+

--- a/RecoTracker/TrackProducer/test/refitFromAOD.py
+++ b/RecoTracker/TrackProducer/test/refitFromAOD.py
@@ -5,11 +5,6 @@ from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
 process = cms.Process('RECO2',Run2_2016)
 
 options = VarParsing.VarParsing('analysis')
-options.register('inputFile',
-                 "/store/mc/RunIISummer20UL16RECO/DYJetsToMuMu_M-50_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/AODSIM/106X_mcRun2_asymptotic_v13-v2/00000/1D4FBF4B-7B8D-A04F-A108-B1BEB60558FA.root", # default value
-                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
-                 VarParsing.VarParsing.varType.string, # string, int, or float
-                 "input file name")
 options.register('globalTag',
                  "auto:run2_mc", # default value
                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
@@ -30,7 +25,7 @@ process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 process.source = cms.Source("PoolSource",
-                            fileNames = cms.untracked.vstring(options.inputFile),
+                            fileNames = cms.untracked.vstring(options.inputFiles),
                             secondaryFileNames = cms.untracked.vstring()
                             )
 

--- a/RecoTracker/TrackProducer/test/refitFromMINIAOD.py
+++ b/RecoTracker/TrackProducer/test/refitFromMINIAOD.py
@@ -1,0 +1,78 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
+
+process = cms.Process('RECO2',Run2_2016)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.Reconstruction_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+    
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+        '/store/mc/RunIISummer20UL16MiniAOD/DYJetsToMuMu_M-50_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/MINIAODSIM/106X_mcRun2_asymptotic_v13-v2/00000/01916D91-A314-D947-A420-388891D62FEA.root',
+    ),
+    secondaryFileNames = cms.untracked.vstring()
+)
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('step1 nevts:1'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+# Output definition
+
+process.RECOSIMoutput = cms.OutputModule("PoolOutputModule",
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string(''),
+        filterName = cms.untracked.string('')
+    ),
+    fileName = cms.untracked.string('step1_RECO.root'),
+    outputCommands = process.RECOSIMEventContent.outputCommands,
+    splitLevel = cms.untracked.int32(0)
+)
+
+# Additional output definition
+process.RECOSIMoutput.outputCommands = cms.untracked.vstring("keep *_myRefittedTracks_*_*")
+
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
+
+process.tracksFromMuons = cms.EDProducer("TrackProducerFromPatMuons",
+                                         src = cms.InputTag("slimmedMuons"),
+                                         innerTrackOnly = cms.bool(True),
+                                         )
+
+import RecoTracker.TrackProducer.TrackRefitter_cfi
+process.myRefittedTracks = RecoTracker.TrackProducer.TrackRefitter_cfi.TrackRefitter.clone()
+process.myRefittedTracks.src= 'tracksFromMuons'
+process.myRefittedTracks.NavigationSchool = ''
+process.myRefittedTracks.Fitter = 'FlexibleKFFittingSmoother'
+                                         
+
+# Path and EndPath definitions
+process.reconstruction_step = cms.Path(process.tracksFromMuons*process.myRefittedTracks)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RECOSIMoutput_step = cms.EndPath(process.RECOSIMoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.reconstruction_step,process.endjob_step,process.RECOSIMoutput_step)
+
+

--- a/RecoTracker/TrackProducer/test/refitFromMINIAOD.py
+++ b/RecoTracker/TrackProducer/test/refitFromMINIAOD.py
@@ -5,11 +5,6 @@ from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
 process = cms.Process('RECO2',Run2_2016)
 
 options = VarParsing.VarParsing('analysis')
-options.register('inputFile',
-                 '/store/mc/RunIISummer20UL16MiniAOD/DYJetsToMuMu_M-50_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/MINIAODSIM/106X_mcRun2_asymptotic_v13-v2/00000/01916D91-A314-D947-A420-388891D62FEA.root', # default value
-                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
-                 VarParsing.VarParsing.varType.string, # string, int, or float
-                 "input file name")
 options.register('globalTag',
                  "auto:run2_mc", # default value
                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
@@ -30,7 +25,7 @@ process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
     
 process.source = cms.Source("PoolSource",
-                            fileNames = cms.untracked.vstring(options.inputFile),
+                            fileNames = cms.untracked.vstring(options.inputFiles),
                             secondaryFileNames = cms.untracked.vstring()
                             )
 

--- a/RecoTracker/TrackProducer/test/testMuonTrackRefitting.cpp
+++ b/RecoTracker/TrackProducer/test/testMuonTrackRefitting.cpp
@@ -1,0 +1,2 @@
+#include "FWCore/Utilities/interface/TestHelper.h"
+RUNTEST()

--- a/RecoTracker/TrackProducer/test/testMuonTrackRefitting.sh
+++ b/RecoTracker/TrackProducer/test/testMuonTrackRefitting.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+function die { echo $1: status $2 ; exit $2; }
+
+echo "TESTING Refitting from Analysis Data-Tier codes ..."
+
+# test AOD
+echo "TESTING refitting from AOD ...\n\n"
+cmsRun ${LOCAL_TEST_DIR}/refitFromAOD.py maxEvents=100 inputFiles=/store/mc/RunIISummer20UL16RECO/DYJetsToMuMu_M-50_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/AODSIM/106X_mcRun2_asymptotic_v13-v2/00000/1D4FBF4B-7B8D-A04F-A108-B1BEB60558FA.root || die "Failure refitting from AOD" $?
+
+# test MINIAOD
+echo "TESTING refitting from MINIAOD ...\n\n"
+cmsRun ${LOCAL_TEST_DIR}/refitFromMINIAOD.py maxEvents=100 inputFiles=/store/mc/RunIISummer20UL16MiniAOD/DYJetsToMuMu_M-50_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/MINIAODSIM/106X_mcRun2_asymptotic_v13-v2/00000/01916D91-A314-D947-A420-388891D62FEA.root || die "Failure refitting from MINIAOD" $?


### PR DESCRIPTION
Originally in https://github.com/cms-sw/cmssw/pull/34640 from @bendavid 

#### PR description:

The necessary information to refit muon tracks from AOD or MINIAOD was added in #31217 but in order to save space there is no suitable collection of `reco::Tracks` directly stored which can be used by the standard TrackRefitter.

This PR adds small skim producers to produce the needed `reco::Track` collections either by re-keying the `TrackExtra` references from the relevant subset of generalTracks in the AOD case, or extracting the embedded tracks from the `slimmedMuon` collection in the MINIAOD case.

Example config files are also provided and exercised in unit tests.

#### PR validation:

Verified that the example configs run and produce refitted track collections with sensible pt distributions.
It also passes the added unit tests.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
