### PR TITLE
[106X Backport] BugFix: HitFit MET resolution

### DIFF
--- a/TopQuarkAnalysis/TopHitFit/src/Resolution.cc
+++ b/TopQuarkAnalysis/TopHitFit/src/Resolution.cc
@@ -215,6 +215,7 @@ double Resolution::sigma (double p) const
 //   The uncertainty for a momentum P.
 //
 {
+  p = std::fabs(p);
   if (_inverse)
     p = 1 / p;
 


### PR DESCRIPTION
Backport for UL analyses of the HitFit MET resolution bugfix. https://github.com/cms-sw/cmssw/pull/35504 
