### PR TITLE
Improve fireworks geometry and proxies

### DIFF
--- a/Fireworks/Calo/plugins/FWTracksterHitsProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWTracksterHitsProxyBuilder.cc
@@ -116,20 +116,20 @@ void FWTracksterHitsProxyBuilder::build(const ticl::Trackster &iData,
   boxset->SetPickable(true);
   boxset->Reset(TEveBoxSet::kBT_FreeBox, true, 64);
 
-  TEveStraightLineSet * seed_marker = nullptr;
+  TEveStraightLineSet *seed_marker = nullptr;
   if (enableSeedLines_) {
     seed_marker = new TEveStraightLineSet("seeds");
     seed_marker->SetLineWidth(2);
-    seed_marker->SetLineColor(kOrange+10);
-    seed_marker->GetLinePlex().Reset(sizeof(TEveStraightLineSet::Line_t), 2*N);
+    seed_marker->SetLineColor(kOrange + 10);
+    seed_marker->GetLinePlex().Reset(sizeof(TEveStraightLineSet::Line_t), 2 * N);
   }
 
-  TEveStraightLineSet * position_marker = nullptr;
+  TEveStraightLineSet *position_marker = nullptr;
   if (enablePositionLines_) {
     position_marker = new TEveStraightLineSet("positions");
     position_marker->SetLineWidth(2);
     position_marker->SetLineColor(kOrange);
-    position_marker->GetLinePlex().Reset(sizeof(TEveStraightLineSet::Line_t), 2*N);
+    position_marker->GetLinePlex().Reset(sizeof(TEveStraightLineSet::Line_t), 2 * N);
   }
 
   for (size_t i = 0; i < N; ++i) {
@@ -173,15 +173,16 @@ void FWTracksterHitsProxyBuilder::build(const ticl::Trackster &iData,
       if (layerCluster.seed().rawId() == it->first.rawId()) {
         const float crossScale = 0.2f + fmin(layerCluster.energy(), 5.0f);
         if (enableSeedLines_) {
-
           // center of RecHit
           const float center[3] = {corners[total_points * 3 + 0],
                                    corners[total_points * 3 + 1],
                                    corners[total_points * 3 + 2] + shapes[3] * 0.5f};
 
           // draw 3D cross
-          seed_marker->AddLine(center[0] - crossScale, center[1], center[2], center[0] + crossScale, center[1], center[2]);
-          seed_marker->AddLine(center[0], center[1] - crossScale, center[2], center[0], center[1] + crossScale, center[2]);
+          seed_marker->AddLine(
+              center[0] - crossScale, center[1], center[2], center[0] + crossScale, center[1], center[2]);
+          seed_marker->AddLine(
+              center[0], center[1] - crossScale, center[2], center[0], center[1] + crossScale, center[2]);
         }
 
         if (enablePositionLines_) {
@@ -191,10 +192,8 @@ void FWTracksterHitsProxyBuilder::build(const ticl::Trackster &iData,
               pos.x() - position_crossScale, pos.y(), pos.z(), pos.x() + position_crossScale, pos.y(), pos.z());
           position_marker->AddLine(
               pos.x(), pos.y() - position_crossScale, pos.z(), pos.x(), pos.y() + position_crossScale, pos.z());
-
         }
       }
-
 
       const float energy =
           fmin((item()->getConfig()->value<bool>("Cluster(0)/RecHit(1)") ? hitmap->at(it->first)->energy()
@@ -203,7 +202,7 @@ void FWTracksterHitsProxyBuilder::build(const ticl::Trackster &iData,
                1.0f);
       const uint8_t colorFactor = gradient_steps * energy;
       auto transparency = item()->modelInfo(iIndex).displayProperties().transparency();
-      UChar_t alpha = (255*(100 - transparency))/100;
+      UChar_t alpha = (255 * (100 - transparency)) / 100;
 
       // Scintillator
       if (!isSilicon) {
@@ -221,8 +220,9 @@ void FWTracksterHitsProxyBuilder::build(const ticl::Trackster &iData,
         }
         boxset->AddBox(&pnts[0]);
         if (heatmap_) {
-          energy ? boxset->DigitColor(gradient[0][colorFactor], gradient[1][colorFactor], gradient[2][colorFactor], alpha)
-                 : boxset->DigitColor(64, 64, 64, alpha);
+          energy
+              ? boxset->DigitColor(gradient[0][colorFactor], gradient[1][colorFactor], gradient[2][colorFactor], alpha)
+              : boxset->DigitColor(64, 64, 64, alpha);
         }
       }
       // Silicon
@@ -234,7 +234,8 @@ void FWTracksterHitsProxyBuilder::build(const ticl::Trackster &iData,
         float radius = fabs(corners[6] - corners[6 + offset]) / 2;
         hex_boxset->AddHex(TEveVector(centerX, centerY, corners[2]), radius, 90.0, shapes[3]);
         if (heatmap_) {
-          energy ? hex_boxset->DigitColor(gradient[0][colorFactor], gradient[1][colorFactor], gradient[2][colorFactor], alpha)
+          energy ? hex_boxset->DigitColor(
+                       gradient[0][colorFactor], gradient[1][colorFactor], gradient[2][colorFactor], alpha)
                  : hex_boxset->DigitColor(64, 64, 64, alpha);
         } else {
           hex_boxset->CSCApplyMainColorToMatchingChildren();
@@ -244,7 +245,7 @@ void FWTracksterHitsProxyBuilder::build(const ticl::Trackster &iData,
         }
       }
     }  // End of loop over rechits of a single layercluster
-  } // End loop over the layerclusters of the trackster
+  }    // End loop over the layerclusters of the trackster
 
   hex_boxset->RefitPlex();
   boxset->RefitPlex();
@@ -282,24 +283,23 @@ void FWTracksterHitsProxyBuilder::build(const ticl::Trackster &iData,
       if (layer_ == 0 || std::abs(layerIn - layer_) == 0 || std::abs(layerOut - layer_) == 0) {
         if (isAdjacent)
           adjacent_marker->AddLine(doublet.first.x(),
-              doublet.first.y(),
-              doublet.first.z(),
-              doublet.second.x(),
-              doublet.second.y(),
-              doublet.second.z());
+                                   doublet.first.y(),
+                                   doublet.first.z(),
+                                   doublet.second.x(),
+                                   doublet.second.y(),
+                                   doublet.second.z());
         else
           non_adjacent_marker->AddLine(doublet.first.x(),
-              doublet.first.y(),
-              doublet.first.z(),
-              doublet.second.x(),
-              doublet.second.y(),
-              doublet.second.z());
+                                       doublet.first.y(),
+                                       doublet.first.z(),
+                                       doublet.second.x(),
+                                       doublet.second.y(),
+                                       doublet.second.z());
       }
-    } // End of loop over all edges of the trackster
+    }  // End of loop over all edges of the trackster
     oItemHolder.AddElement(adjacent_marker);
     oItemHolder.AddElement(non_adjacent_marker);
   }
-
 }
 
 REGISTER_FWPROXYBUILDER(FWTracksterHitsProxyBuilder, ticl::Trackster, "Trackster hits", FWViewType::kISpyBit);

--- a/Fireworks/Calo/plugins/FWTracksterLayersProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWTracksterLayersProxyBuilder.cc
@@ -110,6 +110,13 @@ void FWTracksterLayersProxyBuilder::build(const ticl::Trackster &iData,
   const ticl::Trackster &trackster = iData;
   const size_t N = trackster.vertices().size();
   const std::vector<reco::CaloCluster> &layerClusters = *layerClustersHandle_;
+  TEveStraightLineSet * position_marker = nullptr;
+
+  if (enablePositionLines_) {
+      position_marker = new TEveStraightLineSet;
+      position_marker->SetLineWidth(2);
+      position_marker->SetLineColor(kWhite);
+  }
 
   for (size_t i = 0; i < N; ++i) {
     const reco::CaloCluster layerCluster = layerClusters[trackster.vertices(i)];
@@ -161,7 +168,7 @@ void FWTracksterLayersProxyBuilder::build(const ticl::Trackster &iData,
       radius = sqrt(nHits * area) / M_PI;
     }
 
-    auto eveCircle = new TEveGeoShape("Circle");
+    auto * eveCircle = new TEveGeoShape("Circle");
     auto tube = new TGeoTube(0., proportionalityFactor_ * radius, 0.1);
     eveCircle->SetShape(tube);
     eveCircle->InitMainTrans();
@@ -173,14 +180,14 @@ void FWTracksterLayersProxyBuilder::build(const ticl::Trackster &iData,
       const uint8_t colorFactor = gradient_steps * normalized_energy;
       eveCircle->SetFillColor(
           TColor::GetColor(gradient[0][colorFactor], gradient[1][colorFactor], gradient[2][colorFactor]));
+    } else {
+      eveCircle->SetMainColor(item()->modelInfo(iIndex).displayProperties().color());
+      eveCircle->SetMainTransparency(item()->defaultDisplayProperties().transparency());
     }
 
     // seed and cluster position
     const float crossScale = 1.0f + fmin(energy, 5.0f);
     if (enablePositionLines_) {
-      TEveStraightLineSet *position_marker = new TEveStraightLineSet;
-      position_marker->SetLineWidth(2);
-      position_marker->SetLineColor(kWhite);
       auto const &pos = layerCluster.position();
       const float position_crossScale = crossScale * 0.5;
       position_marker->AddLine(
@@ -188,12 +195,22 @@ void FWTracksterLayersProxyBuilder::build(const ticl::Trackster &iData,
       position_marker->AddLine(
           pos.x(), pos.y() - position_crossScale, pos.z(), pos.x(), pos.y() + position_crossScale, pos.z());
 
-      oItemHolder.AddElement(position_marker);
     }
   }
 
+  if (enablePositionLines_)
+      oItemHolder.AddElement(position_marker);
+
   if (enableEdges_) {
     auto &edges = trackster.edges();
+
+    TEveStraightLineSet *adjacent_marker = new TEveStraightLineSet;
+    adjacent_marker->SetLineWidth(2);
+    adjacent_marker->SetLineColor(kYellow);
+
+    TEveStraightLineSet *non_adjacent_marker = new TEveStraightLineSet;
+    non_adjacent_marker->SetLineWidth(2);
+    non_adjacent_marker->SetLineColor(kRed);
 
     for (auto edge : edges) {
       auto doublet = std::make_pair(layerClusters[edge[0]], layerClusters[edge[1]]);
@@ -201,28 +218,28 @@ void FWTracksterLayersProxyBuilder::build(const ticl::Trackster &iData,
       int layerIn = item()->getGeom()->getParameters(doublet.first.seed())[1];
       int layerOut = item()->getGeom()->getParameters(doublet.second.seed())[1];
 
-      const bool isAdjacent = (layerOut - layerIn) == 1;
-
-      TEveStraightLineSet *marker = new TEveStraightLineSet;
-      marker->SetLineWidth(2);
-      if (isAdjacent) {
-        marker->SetLineColor(kYellow);
-      } else {
-        marker->SetLineColor(kRed);
-      }
+      const bool isAdjacent = std::abs(layerOut - layerIn) == 1;
 
       // draw 3D cross
       if (layer_ == 0 || fabs(layerIn - layer_) == 0 || fabs(layerOut - layer_) == 0) {
-        marker->AddLine(doublet.first.x(),
-                        doublet.first.y(),
-                        doublet.first.z(),
-                        doublet.second.x(),
-                        doublet.second.y(),
-                        doublet.second.z());
+        if (isAdjacent)
+          adjacent_marker->AddLine(doublet.first.x(),
+              doublet.first.y(),
+              doublet.first.z(),
+              doublet.second.x(),
+              doublet.second.y(),
+              doublet.second.z());
+        else
+          non_adjacent_marker->AddLine(doublet.first.x(),
+              doublet.first.y(),
+              doublet.first.z(),
+              doublet.second.x(),
+              doublet.second.y(),
+              doublet.second.z());
       }
-
-      oItemHolder.AddElement(marker);
     }
+    oItemHolder.AddElement(adjacent_marker);
+    oItemHolder.AddElement(non_adjacent_marker);
   }
 }
 

--- a/Fireworks/Calo/plugins/FWTracksterLayersProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWTracksterLayersProxyBuilder.cc
@@ -110,12 +110,12 @@ void FWTracksterLayersProxyBuilder::build(const ticl::Trackster &iData,
   const ticl::Trackster &trackster = iData;
   const size_t N = trackster.vertices().size();
   const std::vector<reco::CaloCluster> &layerClusters = *layerClustersHandle_;
-  TEveStraightLineSet * position_marker = nullptr;
+  TEveStraightLineSet *position_marker = nullptr;
 
   if (enablePositionLines_) {
-      position_marker = new TEveStraightLineSet;
-      position_marker->SetLineWidth(2);
-      position_marker->SetLineColor(kWhite);
+    position_marker = new TEveStraightLineSet;
+    position_marker->SetLineWidth(2);
+    position_marker->SetLineColor(kWhite);
   }
 
   for (size_t i = 0; i < N; ++i) {
@@ -168,7 +168,7 @@ void FWTracksterLayersProxyBuilder::build(const ticl::Trackster &iData,
       radius = sqrt(nHits * area) / M_PI;
     }
 
-    auto * eveCircle = new TEveGeoShape("Circle");
+    auto *eveCircle = new TEveGeoShape("Circle");
     auto tube = new TGeoTube(0., proportionalityFactor_ * radius, 0.1);
     eveCircle->SetShape(tube);
     eveCircle->InitMainTrans();
@@ -194,12 +194,11 @@ void FWTracksterLayersProxyBuilder::build(const ticl::Trackster &iData,
           pos.x() - position_crossScale, pos.y(), pos.z(), pos.x() + position_crossScale, pos.y(), pos.z());
       position_marker->AddLine(
           pos.x(), pos.y() - position_crossScale, pos.z(), pos.x(), pos.y() + position_crossScale, pos.z());
-
     }
   }
 
   if (enablePositionLines_)
-      oItemHolder.AddElement(position_marker);
+    oItemHolder.AddElement(position_marker);
 
   if (enableEdges_) {
     auto &edges = trackster.edges();
@@ -224,18 +223,18 @@ void FWTracksterLayersProxyBuilder::build(const ticl::Trackster &iData,
       if (layer_ == 0 || fabs(layerIn - layer_) == 0 || fabs(layerOut - layer_) == 0) {
         if (isAdjacent)
           adjacent_marker->AddLine(doublet.first.x(),
-              doublet.first.y(),
-              doublet.first.z(),
-              doublet.second.x(),
-              doublet.second.y(),
-              doublet.second.z());
+                                   doublet.first.y(),
+                                   doublet.first.z(),
+                                   doublet.second.x(),
+                                   doublet.second.y(),
+                                   doublet.second.z());
         else
           non_adjacent_marker->AddLine(doublet.first.x(),
-              doublet.first.y(),
-              doublet.first.z(),
-              doublet.second.x(),
-              doublet.second.y(),
-              doublet.second.z());
+                                       doublet.first.y(),
+                                       doublet.first.z(),
+                                       doublet.second.x(),
+                                       doublet.second.y(),
+                                       doublet.second.z());
       }
     }
     oItemHolder.AddElement(adjacent_marker);

--- a/Fireworks/Core/src/FW3DViewBase.cc
+++ b/Fireworks/Core/src/FW3DViewBase.cc
@@ -372,7 +372,7 @@ void FW3DViewBase::updateClipPlanes(bool resetCamera) {
     bmarker->SetMarkerSize(0.2);
     for (int i = 0; i < 8; ++i)
         bmarker->SetPoint(i, bbox[i].X(), bbox[i].Y(), bbox[i].Z());
-    eventScene()->AddElement(bmarker); 
+    eventScene()->AddElement(bmarker);
       */
 
       TGLCamera& cam = viewerGL()->CurrentCamera();
@@ -411,7 +411,7 @@ void FW3DViewBase::updateHGCalVisibility(bool) {
   if (HGCalHSi) {
     for (const auto& it : HGCalHSi->RefChildren()) {
       std::string title(it->GetElementTitle());
-      int layer = stoi(title.substr(title.length() - 2)) + 28;
+      int layer = stoi(title.substr(title.length() - 2));
       it->SetRnrState(layer >= r_lmin && layer <= r_lmax);
     }
   }
@@ -420,7 +420,7 @@ void FW3DViewBase::updateHGCalVisibility(bool) {
   if (HGCalHSc) {
     for (const auto& it : HGCalHSc->RefChildren()) {
       std::string title(it->GetElementTitle());
-      int layer = stoi(title.substr(title.length() - 2)) + 28;
+      int layer = stoi(title.substr(title.length() - 2));
       it->SetRnrState(layer >= r_lmin && layer <= r_lmax);
     }
   }

--- a/Fireworks/Core/src/FW3DViewGeometry.cc
+++ b/Fireworks/Core/src/FW3DViewGeometry.cc
@@ -379,18 +379,16 @@ void FW3DViewGeometry::showTrackerEndcap(bool showTrackerEndcap) {
 void FW3DViewGeometry::showHGCalEE(bool showHGCalEE) {
   if (showHGCalEE && !m_HGCalEEElements) {
     m_HGCalEEElements = new TEveElementList("HGCalEE");
-    for (const auto& id : m_geom->getMatchedIds(FWGeometry::HGCalEE)) {
+    auto const ids = m_geom->getMatchedIds(FWGeometry::HGCalEE);
+    for (const auto& id : ids) {
       TEveGeoShape* shape = m_geom->getHGCSiliconEveShape(id);
-      const unsigned int layer = (id >> 20) & 0x1F;
+      const unsigned int layer = m_geom->getParameters(id)[1];
+      const int siIndex = m_geom->getParameters(id)[4];
       shape->SetTitle(Form("HGCalEE %d", layer));
       {
-        float color[3];
-        color[0] = color[1] = color[2] = 0.3f + 0.7f * (1.0f - layer / 28.0f);
-        color[1] = 0.5f * (layer & 2U) + 0.5f * color[1];
-        const bool isFine = ((id >> 26) & 0x3) == 0;
-        color[0] *= isFine ? 1.0f : 1.0f;
-        color[1] *= isFine ? 1.0f : 0.4f;
-        color[2] *= isFine ? 0.0f : 0.0f;
+        float color[3] = {0., 0., 0.};
+        if (siIndex >= 0 && siIndex < 3)
+          color[siIndex] = 1.f;
         shape->SetMainColorRGB(color[0], color[1], color[2]);
         shape->SetPickable(false);
         m_colorComp[kFwHGCalEEColorIndex]->AddElement(shape);
@@ -408,18 +406,16 @@ void FW3DViewGeometry::showHGCalEE(bool showHGCalEE) {
 void FW3DViewGeometry::showHGCalHSi(bool showHGCalHSi) {
   if (showHGCalHSi && !m_HGCalHSiElements) {
     m_HGCalHSiElements = new TEveElementList("HGCalHSi");
-    for (const auto& id : m_geom->getMatchedIds(FWGeometry::HGCalHSi)) {
+    auto const ids = m_geom->getMatchedIds(FWGeometry::HGCalHSi);
+    for (const auto& id : ids) {
       TEveGeoShape* shape = m_geom->getHGCSiliconEveShape(id);
-      const unsigned int layer = (id >> 20) & 0x1F;
+      const unsigned int layer = m_geom->getParameters(id)[1];
+      const int siIndex = m_geom->getParameters(id)[4];
       shape->SetTitle(Form("HGCalHSi %d", layer));
       {
-        float color[3];
-        color[0] = color[1] = color[2] = 0.3f + 0.7f * (1.0f - layer / 28.0f);
-        color[0] = 0.5f * (layer & 2U) + 0.5f * color[0];
-        const bool isFine = ((id >> 26) & 0x3) == 0;
-        color[0] *= isFine ? 1.0f : 0.4f;
-        color[1] *= isFine ? 0.7f : 0.7f;
-        color[2] *= isFine ? 0.2f : 0.2f;
+        float color[3] = {0., 0., 0.};
+        if (siIndex >= 0 && siIndex < 3)
+          color[siIndex] = 1.f;
         shape->SetMainColorRGB(color[0], color[1], color[2]);
         shape->SetPickable(false);
         m_colorComp[kFwHGCalHSiColorIndex]->AddElement(shape);
@@ -440,7 +436,7 @@ void FW3DViewGeometry::showHGCalHSc(bool showHGCalHSc) {
     std::vector<unsigned int> ids = m_geom->getMatchedIds(FWGeometry::HGCalHSc);
     for (const auto& id : m_geom->getMatchedIds(FWGeometry::HGCalHSc)) {
       TEveGeoShape* shape = m_geom->getHGCScintillatorEveShape(id);
-      const unsigned int layer = (id >> 17) & 0x1F;
+      const unsigned int layer = m_geom->getParameters(id)[1];
       shape->SetTitle(Form("HGCalHSc %d", layer));
       addToCompound(shape, kFwHGCalHScColorIndex);
       m_HGCalHScElements->AddElement(shape);

--- a/Fireworks/Core/src/FWGeometry.cc
+++ b/Fireworks/Core/src/FWGeometry.cc
@@ -264,25 +264,19 @@ std::vector<unsigned int> FWGeometry::getMatchedIds(Detector det, SubDetector su
 
 std::vector<unsigned int> FWGeometry::getMatchedIds(Detector det) const {
   std::vector<unsigned int> ids;
-
+  std::set<unsigned int> cached_wafers;
   for (const auto& it : m_idToInfo) {
     if (((it.id >> kDetOffset) & 0xF) != det)
       continue;
-    // select only the 1st layer
-    // if(((it->id>>17)&0x1F) != 12) continue;
 
     // select only the first cell of each wafer
     if (det != HGCalHSc) {
-      bool flag(false);
-
-      for (const auto& id_it : ids) {
-        flag = (~0x3FF & it.id) == (~0x3FF & id_it);
-        if (flag)
-          break;
+      auto key = ~0x3FF & it.id;
+      if (cached_wafers.find(key) == cached_wafers.end()) {
+        cached_wafers.insert(key);
+        ids.push_back(it.id);
       }
-
-      if (flag)
-        continue;
+      continue;
     }
 
     ids.push_back(it.id);


### PR DESCRIPTION
#### PR description:
##### Improve HGCAL geometry rendering in Fireworks
* Remove double loop on detIds while selecting HGCAL components. This
  makes the HGCAL geometry rendering much much faster than before.
* Use the newly introduced parameters/topology information to gather
  information about a specific HGCAL detId. Avoid detId unpacking.
* Remove ad-hoc magic numbers while offsetting layers in the hadronic
  section.
* Color coding for the Silicon sensor is now bound to their thickness,
  with the following colour coding:
  * red is 120 um sensor
  * blue is 200 um sensor
  * green is 300 um sensor

##### Improve Trackster{Layer,Hits} Proxies
* Position lines (centres of LayerClusters) [and seed lines for the
  `Hits` Proxy] are now registered to a single `TEveStraightLineSet`.
  They are, as a consequence, a single entity in the GUI, and the
  selection will highlight them all for each trackster, individually.
* Edges are now partitioned in two `TEveStraightLineSet`: non-adjacent
  edges (spans more than one layer) and adjacent edges (between sibling
  layers). Non-adjacent edges are rendered in red, while adjacent edges
  in yellow.
* Add transparency support for the `Layer` proxy. Still not fully
  automated, but working.
* Keep colour memory between consecutive switches between `heat map` and
  full colour rendering.