### PR TITLE
Be consistent when replacing a Path/EndPath/Task in a Process that is also in a Schedule

### DIFF
--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -3295,13 +3295,13 @@ process.schedule = cms.Schedule(*[ process.path1, process.endpath1 ], tasks=[pro
             del p.g
             self.assertFalse(hasattr(p, 'f'))
             self.assertFalse(hasattr(p, 'g'))
-            self.assertTrue(p.t1.dumpPython() == 'cms.Task(process.h)\n')
-            self.assertTrue(p.s.dumpPython() == 'cms.Sequence(process.d)\n')
-            self.assertTrue(p.path1.dumpPython() == 'cms.Path(process.a+process.s, cms.Task(process.h))\n')
-            self.assertTrue(p.endpath1.dumpPython() == 'cms.EndPath(process.b)\n')
+            self.assertEqual(p.t1.dumpPython(), 'cms.Task(process.h)\n')
+            self.assertEqual(p.s.dumpPython(), 'cms.Sequence(process.d)\n')
+            self.assertEqual(p.path1.dumpPython(), 'cms.Path(process.a+process.s, cms.Task(process.h))\n')
+            self.assertEqual(p.endpath1.dumpPython(), 'cms.EndPath(process.b)\n')
             del p.s
-            self.assertTrue(p.path1.dumpPython() == 'cms.Path(process.a+(process.d), cms.Task(process.h))\n')
-            self.assertTrue(p.schedule_().dumpPython() == 'cms.Schedule(tasks=[cms.Task(process.h)])\n')
+            self.assertEqual(p.path1.dumpPython(), 'cms.Path(process.a+(process.d), cms.Task(process.h))\n')
+            self.assertEqual(p.schedule_().dumpPython(), 'cms.Schedule(tasks=[cms.Task(process.h)])\n')
         def testModifier(self):
             m1 = Modifier()
             p = Process("test",m1)

--- a/FWCore/ParameterSet/python/SequenceTypes.py
+++ b/FWCore/ParameterSet/python/SequenceTypes.py
@@ -754,6 +754,26 @@ class Schedule(_ValidatingParameterListBase,_ConfigureComponent,_Unlabelable):
         return aCopy
     def _place(self,label,process):
         process.setPartialSchedule_(self,label)
+    def _replaceIfHeldDirectly(self,original,replacement):
+        """Only replaces an 'original' with 'replacement' if 'original' is directly held.
+        If a contained Path or Task holds 'original' it will not be replaced."""
+        didReplace = False
+        if original in self._tasks:
+            self._tasks.remove(original)
+            if replacement is not None:
+                self._tasks.add(replacement)
+            didReplace = True
+        indices = []
+        for i, e in enumerate(self):
+            if original == e:
+                indices.append(i)
+        for i in reversed(indices):
+            self.pop(i)
+            if replacement is not None:
+                self.insert(i, replacement)
+            didReplace = True
+        return didReplace
+
     def moduleNames(self):
         result = set()
         visitor = NodeNameVisitor(result)


### PR DESCRIPTION
#### PR description:

Issue https://github.com/cms-sw/cmssw/issues/35624 point to a case where a `Path` in `Process` was replaced with `process.pathName = cms.Path(...)` that resulted in `None` in the `Schedule` object. The replacement logic works pretty well for Sequences/Tasks/Modules in Paths/Sequences/Tasks (e.g. thanks to https://github.com/cms-sw/cmssw/pull/27480). This PR proposes to make the replacement of Paths/EndPaths/Tasks consistent in Schedule too.

Resolves https://github.com/cms-sw/cmssw/issues/35624
Resolves https://github.com/makortel/framework/issues/304

#### PR validation:

Framework unit tests run.