### PR TITLE
EMTF emulator and CSC TP producer changes for the new CCLUT implementation

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/README.md
+++ b/L1Trigger/CSCTriggerPrimitives/README.md
@@ -1,3 +1,8 @@
 # L1Trigger/CSCTriggerPrimitives Documentation
 
-Please refer to https://gitlab.cern.ch/tdr/notes/DN-21-019/blob/master/temp/DN-21-019_temp.pdf
+Please refer to this important documentation:
+* GEM, CSC, GEM-CSC, and HMT dataformat https://gitlab.cern.ch/tdr/notes/DN-20-016/blob/master/temp/DN-20-016_temp.pdf
+* GEM, CSC, GEM-CSC, and HMT trigger algorithm https://gitlab.cern.ch/tdr/notes/DN-21-019/blob/master/temp/DN-21-019_temp.pdf
+* CCLUT algorithm https://gitlab.cern.ch/tdr/notes/DN-19-059/blob/master/temp/DN-19-059_temp.pdf
+* Hadronic shower trigger algorithm: https://gitlab.cern.ch/tdr/notes/DN-20-033/blob/master/temp/DN-20-033_temp.pdf
+* Note describing the CSC firmware and CSC DAQ format https://github.com/csc-fw/otmb_fw_docs

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCBaseboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCBaseboard.h
@@ -53,6 +53,11 @@ protected:
   bool isME21_;
   bool isME31_;
   bool isME41_;
+  bool isME12_;
+  bool isME22_;
+  bool isME32_;
+  bool isME42_;
+  bool isME13_;
 
   // CSCDetId for this chamber
   CSCDetId cscId_;
@@ -104,5 +109,7 @@ protected:
   bool runME41Up_;
 
   bool runCCLUT_;
+  bool runCCLUT_TMB_;
+  bool runCCLUT_OTMB_;
 };
 #endif

--- a/L1Trigger/CSCTriggerPrimitives/python/params/auxiliaryParams.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/params/auxiliaryParams.py
@@ -33,7 +33,7 @@ commonParam = cms.PSet(
     # CCLUT for TMB is NOT planned for startup Run-3
     runCCLUT_TMB = cms.bool(False),
     # CCLUT for OTMB is planned for startup Run-3
-    runCCLUT_OTMB = cms.bool(True),
+    runCCLUT_OTMB = cms.bool(False),
 
     ## Phase-2 version is not needed for Run-3
     enableAlctPhase2 = cms.bool(False)

--- a/L1Trigger/CSCTriggerPrimitives/python/params/auxiliaryParams.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/params/auxiliaryParams.py
@@ -30,7 +30,10 @@ commonParam = cms.PSet(
 
     # comparator-code algorithm to improve
     # CLCT position and bending resolution
-    runCCLUT = cms.bool(False),
+    # CCLUT for TMB is NOT planned for startup Run-3
+    runCCLUT_TMB = cms.bool(False),
+    # CCLUT for OTMB is planned for startup Run-3
+    runCCLUT_OTMB = cms.bool(True),
 
     ## Phase-2 version is not needed for Run-3
     enableAlctPhase2 = cms.bool(False)

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCBaseboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCBaseboard.cc
@@ -16,7 +16,14 @@ CSCBaseboard::CSCBaseboard(unsigned endcap,
   isME21_ = (theStation == 2 && theRing == 1);
   isME31_ = (theStation == 3 && theRing == 1);
   isME41_ = (theStation == 4 && theRing == 1);
+  isME12_ = (theStation == 1 && theRing == 2);
+  isME22_ = (theStation == 2 && theRing == 2);
+  isME32_ = (theStation == 3 && theRing == 2);
+  isME42_ = (theStation == 4 && theRing == 2);
+  isME13_ = (theStation == 1 && theRing == 3);
 
+  const bool hasTMB(isME12_ or isME22_ or isME32_ or isME42_ or isME13_);
+  const bool hasOTMB(isME11_ or isME21_ or isME31_ or isME41_);
   cscId_ = CSCDetId(theEndcap, theStation, theRing, theChamber, 0);
 
   commonParams_ = conf.getParameter<edm::ParameterSet>("commonParam");
@@ -41,7 +48,10 @@ CSCBaseboard::CSCBaseboard(unsigned endcap,
   runME11ILT_ = commonParams_.getParameter<bool>("runME11ILT");
   runME21ILT_ = commonParams_.getParameter<bool>("runME21ILT");
 
-  runCCLUT_ = commonParams_.getParameter<bool>("runCCLUT");
+  runCCLUT_TMB_ = commonParams_.getParameter<bool>("runCCLUT_TMB");
+  runCCLUT_OTMB_ = commonParams_.getParameter<bool>("runCCLUT_OTMB");
+  // check if CCLUT should be on in this chamber
+  runCCLUT_ = (hasTMB and runCCLUT_TMB_) or (hasOTMB and runCCLUT_OTMB_);
 
   // general case
   tmbParams_ = conf.getParameter<edm::ParameterSet>("tmbPhase1");

--- a/L1Trigger/CSCTriggerPrimitives/src/GEMClusterProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/GEMClusterProcessor.cc
@@ -36,6 +36,11 @@ void GEMClusterProcessor::run(const GEMPadDigiClusterCollection* in_clusters) {
   // Step 1: clear the GEMInternalCluster vector
   clear();
 
+  if (in_clusters == nullptr) {
+    edm::LogWarning("GEMClusterProcessor") << "Attempt to run without valid in_clusters pointer.";
+    return;
+  }
+
   // Step 2: put coincidence clusters in GEMInternalCluster vector
   addCoincidenceClusters(in_clusters);
 

--- a/L1Trigger/L1TMuonEndCap/interface/PrimitiveConversion.h
+++ b/L1Trigger/L1TMuonEndCap/interface/PrimitiveConversion.h
@@ -24,7 +24,8 @@ public:
                  bool useNewZones,
                  bool fixME11Edges,
                  bool bugME11Dupes,
-                 bool useRun3CCLUT);
+                 bool useRun3CCLUT_OTMB,
+                 bool useRun3CCLUT_TMB);
 
   void process(const std::map<int, TriggerPrimitiveCollection>& selected_prim_map, EMTFHitCollection& conv_hits) const;
 
@@ -105,7 +106,8 @@ private:
   bool duplicateTheta_, fixZonePhi_, useNewZones_, fixME11Edges_;
   bool bugME11Dupes_;
   // Run 3 CCLUT algorithm
-  bool useRun3CCLUT_;
+  bool useRun3CCLUT_OTMB_;
+  bool useRun3CCLUT_TMB_;
 };
 
 #endif

--- a/L1Trigger/L1TMuonEndCap/interface/VersionControl.h
+++ b/L1Trigger/L1TMuonEndCap/interface/VersionControl.h
@@ -36,7 +36,7 @@ private:
   // For primitive conversion
   std::vector<int> zoneBoundaries_;
   int zoneOverlap_;
-  bool includeNeighbor_, duplicateTheta_, fixZonePhi_, useNewZones_, fixME11Edges_, useRun3CCLUT_;
+  bool includeNeighbor_, duplicateTheta_, fixZonePhi_, useNewZones_, fixME11Edges_, useRun3CCLUT_OTMB_, useRun3CCLUT_TMB_;
 
   // For pattern recognition
   std::vector<std::string> pattDefinitions_, symPattDefinitions_;

--- a/L1Trigger/L1TMuonEndCap/interface/VersionControl.h
+++ b/L1Trigger/L1TMuonEndCap/interface/VersionControl.h
@@ -36,7 +36,8 @@ private:
   // For primitive conversion
   std::vector<int> zoneBoundaries_;
   int zoneOverlap_;
-  bool includeNeighbor_, duplicateTheta_, fixZonePhi_, useNewZones_, fixME11Edges_, useRun3CCLUT_OTMB_, useRun3CCLUT_TMB_;
+  bool includeNeighbor_, duplicateTheta_, fixZonePhi_, useNewZones_, fixME11Edges_, useRun3CCLUT_OTMB_,
+      useRun3CCLUT_TMB_;
 
   // For pattern recognition
   std::vector<std::string> pattDefinitions_, symPattDefinitions_;

--- a/L1Trigger/L1TMuonEndCap/python/simEmtfDigis_cfi.py
+++ b/L1Trigger/L1TMuonEndCap/python/simEmtfDigis_cfi.py
@@ -20,7 +20,8 @@ simEmtfDigisMC = cms.EDProducer("L1TMuonEndCapTrackProducer",
     Era = cms.string('Run2_2018'),
 
     # New Run 3 CSC TPs using CCLUT algorithm
-    UseRun3CCLUT    = cms.bool(False),
+    UseRun3CCLUT_OTMB = cms.bool(False),
+    UseRun3CCLUT_TMB  = cms.bool(False),
 
     # Input collections
     # Three options for CSCInput
@@ -163,5 +164,4 @@ stage2L1Trigger_2018.toModify(simEmtfDigis, RPCEnable = cms.bool(True), Era = cm
 
 ## Era: Run3_2021
 from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
-stage2L1Trigger_2021.toModify(simEmtfDigis, RPCEnable = cms.bool(True), UseRun3CCLUT = cms.bool(False), Era = cms.string('Run3_2021'))
-
+stage2L1Trigger_2021.toModify(simEmtfDigis, RPCEnable = cms.bool(True), UseRun3CCLUT_OTMB = cms.bool(False), Era = cms.string('Run3_2021'))

--- a/L1Trigger/L1TMuonEndCap/src/PrimitiveConversion.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PrimitiveConversion.cc
@@ -182,13 +182,11 @@ void PrimitiveConversion::convert_csc(int pc_sector,
   //conv_hit.set_strip_hi      ( tp_data.strip_hi );
   conv_hit.set_wire(tp_data.keywire);
   conv_hit.set_quality(tp_data.quality);
+  conv_hit.set_pattern(pattern);
   conv_hit.set_bend(tp_data.bend);
   conv_hit.set_time(0.);  // No fine resolution timing
   conv_hit.set_alct_quality(tp_data.alct_quality);
   conv_hit.set_clct_quality(tp_data.clct_quality);
-
-  conv_hit.set_pattern(pattern);
-
   // Run-3
   conv_hit.set_strip_quart(tp_data.strip_quart);
   conv_hit.set_strip_eighth(tp_data.strip_eighth);

--- a/L1Trigger/L1TMuonEndCap/src/PrimitiveConversion.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PrimitiveConversion.cc
@@ -21,7 +21,8 @@ void PrimitiveConversion::configure(const GeometryTranslator* tp_geom,
                                     bool useNewZones,
                                     bool fixME11Edges,
                                     bool bugME11Dupes,
-                                    bool useRun3CCLUT) {
+                                    bool useRun3CCLUT_OTMB,
+                                    bool useRun3CCLUT_TMB) {
   emtf_assert(tp_geom != nullptr);
   emtf_assert(pc_lut != nullptr);
 
@@ -47,7 +48,8 @@ void PrimitiveConversion::configure(const GeometryTranslator* tp_geom,
   bugME11Dupes_ = bugME11Dupes;
 
   // Run 3 CCLUT algorithm
-  useRun3CCLUT_ = useRun3CCLUT;
+  useRun3CCLUT_OTMB_ = useRun3CCLUT_OTMB;
+  useRun3CCLUT_TMB_ = useRun3CCLUT_TMB;
 }
 
 void PrimitiveConversion::process(const std::map<int, TriggerPrimitiveCollection>& selected_prim_map,
@@ -157,11 +159,35 @@ void PrimitiveConversion::convert_csc(int pc_sector,
   //conv_hit.set_strip_hi      ( tp_data.strip_hi );
   conv_hit.set_wire(tp_data.keywire);
   conv_hit.set_quality(tp_data.quality);
-  conv_hit.set_pattern(tp_data.pattern);
   conv_hit.set_bend(tp_data.bend);
   conv_hit.set_time(0.);  // No fine resolution timing
   conv_hit.set_alct_quality(tp_data.alct_quality);
   conv_hit.set_clct_quality(tp_data.clct_quality);
+
+  const auto& detid(conv_hit.CreateCSCDetId());
+  const bool isMEX1(detid.isME11() or detid.isME21() or detid.isME31() or detid.isME41());
+  const bool isMEX2(detid.isME12() or detid.isME22() or detid.isME32() or detid.isME42());
+  const bool isME13(detid.isME13());
+
+  // check if CCLUT is on for this CSC TP
+  const bool useRun3CCLUT((useRun3CCLUT_OTMB_ and isMEX1) or (useRun3CCLUT_TMB_ and (isMEX2 or isME13)));
+  if (useRun3CCLUT) {
+    // convert slope to Run-2 pattern for CSC TPs coming from MEX/1 chambers
+    // where the CCLUT algorithm is enabled
+    const unsigned slopeList[32] = {10, 10, 10, 8, 8, 8, 6, 6, 6, 4, 4, 4, 2, 2, 2, 2,
+                                    10, 10, 10, 9, 9, 9, 7, 7, 7, 5, 5, 5, 3, 3, 3, 3};
+
+    // this LUT follows the same convention as in CSCPatternBank.cc
+    unsigned slope_and_sign(tp_data.slope);
+    if (tp_data.bend == 0) {
+      slope_and_sign += 16;
+    }
+    unsigned run2_converted_PID = slopeList[slope_and_sign];
+    conv_hit.set_pattern(run2_converted_PID);
+  } else {
+    conv_hit.set_pattern(tp_data.pattern);
+  }
+
   // Run-3
   conv_hit.set_strip_quart(tp_data.strip_quart);
   conv_hit.set_strip_eighth(tp_data.strip_eighth);
@@ -295,16 +321,24 @@ void PrimitiveConversion::convert_csc_details(EMTFHit& conv_hit) const {
   if (bugStrip0BeforeFW48200 == false && fw_strip == 0 && clct_pat_corr_sign == -1)
     clct_pat_corr = 0;
 
+  // check if the CCLUT algorithm is on in this chamber
+  const auto& detid(conv_hit.CreateCSCDetId());
+  const bool isMEX1(detid.isME11() or detid.isME21() or detid.isME31() or detid.isME41());
+  const bool isMEX2(detid.isME12() or detid.isME22() or detid.isME32() or detid.isME42());
+  const bool isME13(detid.isME13());
+
+  const bool useRun3CCLUT((useRun3CCLUT_OTMB_ and isMEX1) or (useRun3CCLUT_TMB_ and (isMEX2 or isME13)));
+
   if (is_10degree) {
     eighth_strip = fw_strip << 2;  // full precision, uses only 2 bits of pattern correction
-    if (useRun3CCLUT_) {
+    if (useRun3CCLUT) {
       eighth_strip += (conv_hit.Strip_quart_bit() << 1 | conv_hit.Strip_eighth_bit() << 0);  // Run 3 CCLUT variables
     } else {
       eighth_strip += clct_pat_corr_sign * (clct_pat_corr >> 1);
     }
   } else {
     eighth_strip = fw_strip << 3;  // multiply by 2, uses all 3 bits of pattern correction
-    if (useRun3CCLUT_) {
+    if (useRun3CCLUT) {
       eighth_strip += (conv_hit.Strip_quart_bit() << 2 | conv_hit.Strip_eighth_bit() << 1);  // Run 3 CCLUT variables
     } else {
       eighth_strip += clct_pat_corr_sign * (clct_pat_corr >> 0);

--- a/L1Trigger/L1TMuonEndCap/src/PrimitiveConversion.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PrimitiveConversion.cc
@@ -128,7 +128,7 @@ void PrimitiveConversion::convert_csc(int pc_sector,
       emtf_assert(tp_subsector == 2);
     }
   }
-  
+
   // Calculate Pattern
   unsigned pattern = tp_data.pattern;
   const auto& detid(conv_hit.CreateCSCDetId());
@@ -188,7 +188,7 @@ void PrimitiveConversion::convert_csc(int pc_sector,
   conv_hit.set_clct_quality(tp_data.clct_quality);
 
   conv_hit.set_pattern(pattern);
-  
+
   // Run-3
   conv_hit.set_strip_quart(tp_data.strip_quart);
   conv_hit.set_strip_eighth(tp_data.strip_eighth);

--- a/L1Trigger/L1TMuonEndCap/src/SectorProcessor.cc
+++ b/L1Trigger/L1TMuonEndCap/src/SectorProcessor.cc
@@ -106,7 +106,8 @@ void SectorProcessor::process_single_bx(int bx,
                       cfg.useNewZones_,
                       cfg.fixME11Edges_,
                       cfg.bugME11Dupes_,
-                      cfg.useRun3CCLUT_);
+                      cfg.useRun3CCLUT_OTMB_,
+                      cfg.useRun3CCLUT_TMB_);
 
   PatternRecognition patt_recog;
   patt_recog.configure(verbose_,

--- a/L1Trigger/L1TMuonEndCap/src/VersionControl.cc
+++ b/L1Trigger/L1TMuonEndCap/src/VersionControl.cc
@@ -6,7 +6,8 @@ VersionControl::VersionControl(const edm::ParameterSet& iConfig) : config_(iConf
   useO2O_ = iConfig.getParameter<bool>("FWConfig");
   era_ = iConfig.getParameter<std::string>("Era");
   // Run 3 CCLUT
-  useRun3CCLUT_ = iConfig.getParameter<bool>("UseRun3CCLUT");
+  useRun3CCLUT_OTMB_ = iConfig.getParameter<bool>("UseRun3CCLUT_OTMB");
+  useRun3CCLUT_TMB_ = iConfig.getParameter<bool>("UseRun3CCLUT_TMB");
 
   useDT_ = iConfig.getParameter<bool>("DTEnable");
   useCSC_ = iConfig.getParameter<bool>("CSCEnable");


### PR DESCRIPTION
#### PR description:

Due to hardware limitations, the CCLUT algorithm will not be used in TMBs at the beginning of Run 3. This PR modifies the current CCLUT implementation in CSC TP producer and EMTF emulator to split the cases for TMBs and OTMBs. 

After these changes, the CCLUT algorithm can be enabled for CSC stations/rings with OTMBs or TMBs with the specific flags `runCCLUT_OTMB` and `runCCLUT_TMB` respectively. Currently, both of the flags are set to `False`, so we expect no change in trigger performance. 

#### PR validation:

Validated with `runTheMatrix.py -l limited -i all --ibeos` and no changes are observed.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A


FYI @dildick 

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
