### PR TITLE
Include realistic `CSCBadChambers` in Run-3 MC GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -68,15 +68,15 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
     'phase1_2021_design'           : '121X_mcRun3_2021_design_v10',
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'        : '121X_mcRun3_2021_realistic_v11',
+    'phase1_2021_realistic'        : '121X_mcRun3_2021_realistic_v12',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'          : '121X_mcRun3_2021cosmics_realistic_deco_v11',
+    'phase1_2021_cosmics'          : '121X_mcRun3_2021cosmics_realistic_deco_v12',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi'     : '121X_mcRun3_2021_realistic_HI_v11',
+    'phase1_2021_realistic_hi'     : '121X_mcRun3_2021_realistic_HI_v12',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '121X_mcRun3_2023_realistic_v10',
+    'phase1_2023_realistic'        : '121X_mcRun3_2023_realistic_v11',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '121X_mcRun3_2024_realistic_v10',
+    'phase1_2024_realistic'        : '121X_mcRun3_2024_realistic_v11',
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             : '121X_mcRun4_realistic_v6'
 }


### PR DESCRIPTION
#### PR description:

PR to update the Run-3 MC GT with a more realistic bad chamber list for the CSC detector as requested in 
https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4492.html

This includes one bad chamber (ME+2/2/31) and replaces the `CSCBadChambers_empty_mc` with the new `CSCBadChambers_Realistic_211012_mc` tag

I've created the following GTs and I show now the diff wrt to the prev GT:
 * 121X_mcRun3_2021_realistic_v12
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021_realistic_v11/121X_mcRun3_2021_realistic_v12
* 121X_mcRun3_2021cosmics_realistic_deco_v12
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021cosmics_realistic_deco_v11/121X_mcRun3_2021cosmics_realistic_deco_v12
 * 121X_mcRun3_2021_realistic_HI_v12
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021_realistic_HI_v11/121X_mcRun3_2021_realistic_HI_v12
 * 121X_mcRun3_2023_realistic_v11
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2023_realistic_v10/121X_mcRun3_2023_realistic_v11
 * 121X_mcRun3_2024_realistic_v11
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2024_realistic_v10/121X_mcRun3_2024_realistic_v11

As expected the diffs are in the `CSCBadChambers_Realistic_211012_mc` tag only.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A