### PR TITLE
Do not call the fishbone for events with pixel hits only in BPIX1

### DIFF
--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
@@ -23,7 +23,7 @@ void CAHitNtupletGeneratorKernelsGPU::launchKernels(HitsOnCPU const &hh, TkSoA *
   // zero tuples
   cms::cuda::launchZero(tuples_d, cudaStream);
 
-  auto nhits = hh.nHits();
+  int32_t nhits = hh.nHits();
 
 #ifdef NTUPLE_DEBUG
   std::cout << "start tuple building. N hits " << nhits << std::endl;
@@ -63,7 +63,8 @@ void CAHitNtupletGeneratorKernelsGPU::launchKernels(HitsOnCPU const &hh, TkSoA *
       params_.dcaCutOuterTriplet_);
   cudaCheck(cudaGetLastError());
 
-  if (nhits > 1 && params_.earlyFishbone_) {
+  // do not run the fishbone if there are hits only in BPIX1
+  if (nhits > isOuterHitOfCell_.offset && params_.earlyFishbone_) {
     auto nthTot = 128;
     auto stride = 16;
     auto blockSize = nthTot / stride;
@@ -115,7 +116,8 @@ void CAHitNtupletGeneratorKernelsGPU::launchKernels(HitsOnCPU const &hh, TkSoA *
       tuples_d, quality_d, device_tupleMultiplicity_.get());
   cudaCheck(cudaGetLastError());
 
-  if (nhits > 1 && params_.lateFishbone_) {
+  // do not run the fishbone if there are hits only in BPIX1
+  if (nhits > isOuterHitOfCell_.offset && params_.lateFishbone_) {
     auto nthTot = 128;
     auto stride = 16;
     auto blockSize = nthTot / stride;

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuFishbone.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuFishbone.h
@@ -16,28 +16,27 @@
 
 namespace gpuPixelDoublets {
 
-  //  __device__
-  //  __forceinline__
   __global__ void fishbone(GPUCACell::Hits const* __restrict__ hhp,
                            GPUCACell* cells,
                            uint32_t const* __restrict__ nCells,
                            GPUCACell::OuterHitOfCell const isOuterHitOfCellWrap,
-                           uint32_t nHits,
+                           int32_t nHits,
                            bool checkTrack) {
     constexpr auto maxCellsPerHit = GPUCACell::maxCellsPerHit;
 
     auto const& hh = *hhp;
 
     auto const isOuterHitOfCell = isOuterHitOfCellWrap.container;
-    auto offset = isOuterHitOfCellWrap.offset;
+    int32_t offset = isOuterHitOfCellWrap.offset;
 
-    // x run faster...
+    // x runs faster...
     auto firstY = threadIdx.y + blockIdx.y * blockDim.y;
     auto firstX = threadIdx.x;
 
     float x[maxCellsPerHit], y[maxCellsPerHit], z[maxCellsPerHit], n[maxCellsPerHit];
-    uint16_t d[maxCellsPerHit];  // uint8_t l[maxCellsPerHit];
     uint32_t cc[maxCellsPerHit];
+    uint16_t d[maxCellsPerHit];
+    // uint8_t l[maxCellsPerHit];
 
     for (int idy = firstY, nt = nHits - offset; idy < nt; idy += gridDim.y * blockDim.y) {
       auto const& vc = isOuterHitOfCell[idy];
@@ -85,10 +84,11 @@ namespace gpuPixelDoublets {
               cj.kill();
             }
           }
-        }  //cj
+        }  // cj
       }    // ci
     }      // hits
   }
+
 }  // namespace gpuPixelDoublets
 
 #endif  // RecoPixelVertexing_PixelTriplets_plugins_gpuFishbone_h


### PR DESCRIPTION
#### PR description:

Do not call the fishbone for events with pixel hits only in BPIX1.
This avoids a crash when the number of blocks would be zero.

#### PR validation:

Patatrack pixel track reconstruction can now run on events that previously led to a crash.
