### PR TITLE
add onlineBeamSpotESProducer to BeamSpot_cfi: fix general Online BS swap case

### DIFF
--- a/RecoVertex/BeamSpotProducer/python/BeamSpot_cfi.py
+++ b/RecoVertex/BeamSpotProducer/python/BeamSpot_cfi.py
@@ -4,11 +4,14 @@ import RecoVertex.BeamSpotProducer.Modifiers as mods
 
 offlineBeamSpot = cms.EDProducer("BeamSpotProducer")
 
-import RecoVertex.BeamSpotProducer.onlineBeamSpotESProducer_cfi as _mod
-BeamSpotESProducer = _mod.onlineBeamSpotESProducer.clone(
-    timeThreshold = 999999 # for express allow >48h old payloads for replays. DO NOT CHANGE
-)
+def _loadOnlineBeamSpotESProduer(process):
+    import RecoVertex.BeamSpotProducer.onlineBeamSpotESProducer_cfi as _mod
+    process.BeamSpotESProducer = _mod.onlineBeamSpotESProducer.clone(
+        timeThreshold = 999999 # for express allow >48h old payloads for replays. DO NOT CHANGE
+    )
 
 import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
 _onlineBeamSpotProducer = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()
 mods.offlineToOnlineBeamSpotSwap.toReplaceWith(offlineBeamSpot, _onlineBeamSpotProducer)
+
+applyOnlineBSESProducer = mods.offlineToOnlineBeamSpotSwap.makeProcessModifier(_loadOnlineBeamSpotESProduer)

--- a/RecoVertex/BeamSpotProducer/python/BeamSpot_cfi.py
+++ b/RecoVertex/BeamSpotProducer/python/BeamSpot_cfi.py
@@ -4,6 +4,11 @@ import RecoVertex.BeamSpotProducer.Modifiers as mods
 
 offlineBeamSpot = cms.EDProducer("BeamSpotProducer")
 
+import RecoVertex.BeamSpotProducer.onlineBeamSpotESProducer_cfi as _mod
+BeamSpotESProducer = _mod.onlineBeamSpotESProducer.clone(
+    timeThreshold = 999999 # for express allow >48h old payloads for replays. DO NOT CHANGE
+)
+
 import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
 _onlineBeamSpotProducer = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()
 mods.offlineToOnlineBeamSpotSwap.toReplaceWith(offlineBeamSpot, _onlineBeamSpotProducer)


### PR DESCRIPTION
resolves https://github.com/cms-sw/cmssw/issues/35634

#### PR description:

In PR https://github.com/cms-sw/cmssw/pull/35373 the general case for the online <-> offline BS swap done via modifiers was missed, leading to issues in the visualization DQM clients. 
This PR supplies the `onlineBeamSpotESProducer` to `BeamSpot_cfi` as a general case fix-up.

#### PR validation:

Run `cmsRun DQM/Integration/python/clients/visualization-live_cfg.py unitTest=True`
that before was crashing with: 

```
...
Exception Message:
No "BeamSpotTransientObjectsRcd" record found in the EventSetup.n
 Please add an ESSource or ESProducer that delivers such a record.
----- End Fatal Exception -------------------------------------------------
```

while now crashes differently with:

```
----- Begin Fatal Exception 13-Oct-2021 10:41:57 CEST-----------------------
An exception of category 'NoProxyException' occurred while
   [0] Processing  Event run: 334393 lumi: 1 event: 16132 stream: 1
   [1] Running path 'FEVToutput_step'
   [2] Prefetching for module JsonWritingTimeoutPoolOutputModule/'FEVToutput'
   [3] Prefetching for module ReducedRecHitCollectionProducer/'reducedEcalRecHitsEB'
   [4] Prefetching for module EleIsoDetIdCollectionProducer/'interestingGedEleIsoDetIdEB'
   [5] Calling method for module GEDGsfElectronFinalizer/'gedGsfElectrons'
Exception Message:
No data of type "GBRForestD" with label "electron_eb_ecalOnly_1To300_0p2To2_mean" in record "GBRDWrapperRcd"
 Please add an ESSource or ESProducer to your job which can deliver this data.
----- End Fatal Exception -------------------------------------------------
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, but should be backported. 