### PR TITLE
Fix empty histograms in CSC L1T DQM

### DIFF
--- a/DQM/L1TMonitor/src/L1TdeCSCTPG.cc
+++ b/DQM/L1TMonitor/src/L1TdeCSCTPG.cc
@@ -43,12 +43,6 @@ L1TdeCSCTPG::~L1TdeCSCTPG() {}
 void L1TdeCSCTPG::bookHistograms(DQMStore::IBooker& iBooker, const edm::Run&, const edm::EventSetup&) {
   iBooker.setCurrentFolder(monitorDir_);
 
-  // do not analyze Run-3 properties in Run-1 and Run-2 eras
-  if (!isRun3_) {
-    clctVars_.resize(4);
-    lctVars_.resize(5);
-  }
-
   // remove the non-ME1/1 chambers from the list when useB904ME11 is set to true
   if (useB904ME11_) {
     chambers_.resize(1);
@@ -65,11 +59,15 @@ void L1TdeCSCTPG::bookHistograms(DQMStore::IBooker& iBooker, const edm::Run&, co
     chambers_.resize(1);
     chambers_[0] = temp;
   }
-
-  // do not analyze the 1/4-strip bit, 1/8-strip bit
-  else {
+  // collision data in Run-3
+  else if (isRun3_) {
     clctVars_.resize(9);
     lctVars_.resize(9);
+  }
+  // do not analyze Run-3 properties in Run-1 and Run-2 eras
+  else {
+    clctVars_.resize(4);
+    lctVars_.resize(5);
   }
 
   // chamber type

--- a/DQM/L1TMonitorClient/src/L1TdeCSCTPGClient.cc
+++ b/DQM/L1TMonitorClient/src/L1TdeCSCTPGClient.cc
@@ -53,12 +53,6 @@ void L1TdeCSCTPGClient::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter 
 void L1TdeCSCTPGClient::book(DQMStore::IBooker &iBooker) {
   iBooker.setCurrentFolder(monitorDir_);
 
-  // do not analyze Run-3 properties in Run-1 and Run-2 eras
-  if (!isRun3_) {
-    clctVars_.resize(4);
-    lctVars_.resize(5);
-  }
-
   // remove the non-ME1/1 chambers from the list when useB904ME11 is set to true
   if (useB904ME11_) {
     chambers_.resize(1);
@@ -75,10 +69,15 @@ void L1TdeCSCTPGClient::book(DQMStore::IBooker &iBooker) {
     chambers_.resize(1);
     chambers_[0] = temp;
   }
-  // do not analyze the 1/4-strip bit, 1/8-strip bit
-  else {
+  // collision data in Run-3
+  else if (isRun3_) {
     clctVars_.resize(9);
     lctVars_.resize(9);
+  }
+  // do not analyze Run-3 properties in Run-1 and Run-2 eras
+  else {
+    clctVars_.resize(4);
+    lctVars_.resize(5);
   }
 
   // chamber type


### PR DESCRIPTION
#### PR description:

A few histograms were empty in CSC L1T DQM. 

#### PR validation:

Tested with WF 11634.0

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
