### PR TITLE
[Online DQM] re-introduce unit tests for visualization

### DIFF
--- a/DQM/Integration/test/BuildFile.xml
+++ b/DQM/Integration/test/BuildFile.xml
@@ -29,6 +29,5 @@
 <!-- <test name="TestDQMOnlineClient-ecalcalib_dqm_sourceclient" command="runtest.sh ecalcalib_dqm_sourceclient-live_cfg.py" /> -->
 <!-- streamDQMCalibration is required -->
 <!-- <test name="TestDQMOnlineClient-hcalcalib_dqm_sourceclient" command="runtest.sh hcalcalib_dqm_sourceclient-live_cfg.py" /> -->
-<!-- No data of type "GBRForestD" with label "electron_eb_ecalOnly_1To300_0p2To2_mean" in record "GBRDWrapperRcd" -->
-<!-- <test name="TestDQMOnlineClient-visualization" command="runtest.sh visualization-live_cfg.py" />  -->
-<!-- <test name="TestDQMOnlineClient-visualization_secondInstance" command="runtest.sh visualization-live-secondInstance_cfg.py" /> -->
+<test name="TestDQMOnlineClient-visualization" command="runtest.sh visualization-live_cfg.py" />
+<test name="TestDQMOnlineClient-visualization_secondInstance" command="runtest.sh visualization-live-secondInstance_cfg.py" />


### PR DESCRIPTION
#### PR description:

Apparently #35593 has fixed a long-standing issue, leading to not being able to run the visualization unit tests.

#### PR validation:

Run `cmsRun DQM/Integration/python/clients/visualization-live_cfg.py unitTest=True` in a recent IB (rebased to HEAD of CMSSW_12_1_X) adding commit 9870cee9372e5aa8fadbc42e88994c97c0ac92d7 (proposed in https://github.com/cms-sw/cmssw/pull/35639) and it run successfully. 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
