### PR TITLE
Update mkFit for 12_1_0_pre5

### DIFF
--- a/RecoTracker/MkFit/README.md
+++ b/RecoTracker/MkFit/README.md
@@ -38,8 +38,8 @@ $ runTheMatrix.py -l <workflow(s)> --apply 2 --command "--procModifiers tracking
 
 * *m_track_algorithm:* CMSSW track algorithm (used internally for reporting and consistency checks)
 * *m_requires_seed_hit_sorting:* do hits on seed tracks need to be sorted (required for seeds that include strip layers)
-* *m_require_quality_filter:* is additional post-processing required for result tracks
-* *m_require_dupclean_tight:* is tight duplicate removal post-processing required for result tracks
+* *m_requires_quality_filter:* is additional post-processing required for result tracks
+* *m_requires_dupclean_tight:* is tight duplicate removal post-processing required for result tracks
 * *m_params:* IterationParams structure for this iteration
 * *m_backward_params:* IterationParams structure for backward search for this iteration
 * *m_layer_configs:* std::vector of per-layer parameters

--- a/RecoTracker/MkFit/plugins/BuildFile.xml
+++ b/RecoTracker/MkFit/plugins/BuildFile.xml
@@ -3,6 +3,7 @@
   <use name="CalibTracker/Records"/>
   <use name="CondFormats/DataRecord"/>
   <use name="CondFormats/SiPixelObjects"/>
+  <use name="DataFormats/BeamSpot"/>
   <use name="DataFormats/Common"/>
   <use name="DataFormats/SiStripCluster"/>
   <use name="DataFormats/SiStripCommon"/>

--- a/RecoTracker/MkFit/plugins/MkFitEventOfHitsProducer.cc
+++ b/RecoTracker/MkFit/plugins/MkFitEventOfHitsProducer.cc
@@ -10,6 +10,7 @@
 #include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"
 #include "CalibTracker/Records/interface/SiStripQualityRcd.h"
 
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/SiStripCommon/interface/ConstantsForHardwareSystems.h"
 #include "DataFormats/TrackerCommon/interface/TrackerDetSide.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
@@ -42,6 +43,7 @@ private:
             mkfit::EventOfHits& eventOfHits,
             const MkFitGeometry& mkFitGeom) const;
 
+  const edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
   const edm::EDGetTokenT<MkFitHitWrapper> pixelHitsToken_;
   const edm::EDGetTokenT<MkFitHitWrapper> stripHitsToken_;
   const edm::EDGetTokenT<MkFitClusterIndexToHit> pixelClusterIndexToHitToken_;
@@ -56,7 +58,8 @@ private:
 };
 
 MkFitEventOfHitsProducer::MkFitEventOfHitsProducer(edm::ParameterSet const& iConfig)
-    : pixelHitsToken_{consumes(iConfig.getParameter<edm::InputTag>("pixelHits"))},
+    : beamSpotToken_{consumes(iConfig.getParameter<edm::InputTag>("beamSpot"))},
+      pixelHitsToken_{consumes(iConfig.getParameter<edm::InputTag>("pixelHits"))},
       stripHitsToken_{consumes(iConfig.getParameter<edm::InputTag>("stripHits"))},
       pixelClusterIndexToHitToken_{consumes(iConfig.getParameter<edm::InputTag>("pixelHits"))},
       stripClusterIndexToHitToken_{consumes(iConfig.getParameter<edm::InputTag>("stripHits"))},
@@ -77,6 +80,7 @@ MkFitEventOfHitsProducer::MkFitEventOfHitsProducer(edm::ParameterSet const& iCon
 void MkFitEventOfHitsProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
 
+  desc.add("beamSpot", edm::InputTag{"offlineBeamSpot"});
   desc.add("pixelHits", edm::InputTag{"mkFitSiPixelHits"});
   desc.add("stripHits", edm::InputTag{"mkFitSiStripHits"});
   desc.add("usePixelQualityDB", true)->setComment("Use SiPixelQuality DB information");
@@ -171,6 +175,16 @@ void MkFitEventOfHitsProducer::produce(edm::StreamID iID, edm::Event& iEvent, co
   fill(iEvent.get(stripClusterIndexToHitToken_).hits(), *eventOfHits, mkFitGeom);
 
   mkfit::StdSeq::Cmssw_LoadHits_End(*eventOfHits);
+
+  auto const bs = iEvent.get(beamSpotToken_);
+  eventOfHits->SetBeamSpot({.x = float(bs.x0()),
+                            .y = float(bs.y0()),
+                            .z = float(bs.z0()),
+                            .sigmaZ = float(bs.sigmaZ()),
+                            .beamWidthX = float(bs.BeamWidthX()),
+                            .beamWidthY = float(bs.BeamWidthY()),
+                            .dxdz = float(bs.dxdz()),
+                            .dydz = float(bs.dydz())});
 
   iEvent.emplace(putToken_, std::move(eventOfHits));
 }

--- a/RecoTracker/MkFit/plugins/MkFitEventOfHitsProducer.cc
+++ b/RecoTracker/MkFit/plugins/MkFitEventOfHitsProducer.cc
@@ -177,14 +177,8 @@ void MkFitEventOfHitsProducer::produce(edm::StreamID iID, edm::Event& iEvent, co
   mkfit::StdSeq::Cmssw_LoadHits_End(*eventOfHits);
 
   auto const bs = iEvent.get(beamSpotToken_);
-  eventOfHits->SetBeamSpot({.x = float(bs.x0()),
-                            .y = float(bs.y0()),
-                            .z = float(bs.z0()),
-                            .sigmaZ = float(bs.sigmaZ()),
-                            .beamWidthX = float(bs.BeamWidthX()),
-                            .beamWidthY = float(bs.BeamWidthY()),
-                            .dxdz = float(bs.dxdz()),
-                            .dydz = float(bs.dydz())});
+  eventOfHits->SetBeamSpot(
+      mkfit::BeamSpot(bs.x0(), bs.y0(), bs.z0(), bs.sigmaZ(), bs.BeamWidthX(), bs.BeamWidthY(), bs.dxdz(), bs.dydz()));
 
   iEvent.emplace(putToken_, std::move(eventOfHits));
 }

--- a/RecoTracker/MkFit/python/customizeHLTIter0ToMkFit.py
+++ b/RecoTracker/MkFit/python/customizeHLTIter0ToMkFit.py
@@ -36,6 +36,7 @@ def customizeHLTIter0ToMkFit(process):
         minGoodStripCharge = dict(refToPSet_ = 'HLTSiStripClusterChargeCutLoose'),
     )
     process.hltIter0PFlowCkfTrackCandidatesMkFitEventOfHits = mkFitEventOfHitsProducer_cfi.mkFitEventOfHitsProducer.clone(
+        beamSpot  = "hltOnlineBeamSpot",
         pixelHits = "hltIter0PFlowCkfTrackCandidatesMkFitSiPixelHits",
         stripHits = "hltIter0PFlowCkfTrackCandidatesMkFitSiStripHits",
     )


### PR DESCRIPTION
### PR description:

This PR follows #35492 and updates mkFit in view of CMSSW_12_1_0_pre5.

In detail, this PR:
- adds the beamspot information to mkFit;
- fixes naming of parameters in mkFit README;
- (via cms-sw/cmsdist#7387 and cms-data/RecoTracker-MkFit#6) updates mkFit configuration for detachedTripletStep and pixelLessStep tracking iterations, with a gain in track reconstruction efficiency.

It requires cms-sw/cmsdist#7387 and cms-data/RecoTracker-MkFit#6


### PR validation:

In TTbar events with <PU>=50:

- mkFit (enabled in initialStepPreSplitting, initialStep, highPtTripletStep, detachedQuadStep), before and after this PR: http://uaf-10.t2.ucsd.edu/~mmasciov/MkFit_devs/PRvalidation_Oct13/MTV_PR35652_mkFit-4iter_vsMkFit-4iter/
--> Performance is unchanged (as expected).

- mkFit enabled in initialStepPreSplitting, initialStep, highPtTripletStep, detachedQuadStep, detachedTripletStep, pixelLessStep (6-iter) vs. default (4-iter: initialStepPreSplitting, initialStep, highPtTripletStep, detachedQuadStep): http://uaf-10.t2.ucsd.edu/~mmasciov/MkFit_devs/PRvalidation_Oct13/MTV_PR35652_mkFit-6iter_vsMkFit-4iter/
--> Efficiency for detachedTripletStep is improved (with further reduction in fake rate): http://uaf-10.t2.ucsd.edu/~mmasciov/MkFit_devs/PRvalidation_Oct13/MTV_PR35652_mkFit-6iter_vsMkFit-4iter/plots_building_detachedTripletStep/effandfakePtEtaPhi.pdf
--> Efficiency for pixelLessStep is improved: http://uaf-10.t2.ucsd.edu/~mmasciov/MkFit_devs/PRvalidation_Oct13/MTV_PR35652_mkFit-6iter_vsMkFit-4iter/plots_building_pixelLessStep/effandfakePtEtaPhi.pdf
--> Timing performance is ~ unchanged: http://uaf-10.t2.ucsd.edu/~mmasciov/MkFit_devs/PRvalidation_Oct13/MTV_PR35652_mkFit-6iter_vsMkFit-4iter/plots_timing.html

For history/completeness, comparisons wrt. standard CKF for all tracking iterations follow:

- mkFit vs. CKF performance when mkFit is enabled in initialStepPreSplitting, initialStep, highPtTripletStep, detachedQuadStep, before and after this PR: http://uaf-10.t2.ucsd.edu/~mmasciov/MkFit_devs/PRvalidation_Oct13/MTV_mkFit-4iter_vsCKF_Oct13/
--> Performance is unchanged (as expected).

- mkFit vs. CKF performance when mkFit is enabled in initialStepPreSplitting, initialStep, highPtTripletStep, detachedQuadStep, detachedTripletStep, pixelLessStep: http://uaf-10.t2.ucsd.edu/~mmasciov/MkFit_devs/PRvalidation_Oct13/MTV_mkFit-6iter_Oct13_vsCKF/
--> Efficiency for detachedTripletStep is improved (with further reduction in fake rate): http://uaf-10.t2.ucsd.edu/~mmasciov/MkFit_devs/PRvalidation_Oct13/MTV_mkFit-6iter_Oct13_vsCKF/plots_building_detachedTripletStep/effandfakePtEtaPhi.pdf
--> Efficiency for pixelLessStep is improved: http://uaf-10.t2.ucsd.edu/~mmasciov/MkFit_devs/PRvalidation_Oct13/MTV_mkFit-6iter_Oct13_vsCKF/plots_building_pixelLessStep/effandfakePtEtaPhi.pdf
--> Timing performance is ~ unchanged: http://uaf-10.t2.ucsd.edu/~mmasciov/MkFit_devs/PRvalidation_Oct13/MTV_mkFit-6iter_Oct13_vsCKF/plots_timing.html



