### PR TITLE
Fix reading from unaligned address in TotemSampicFrame

### DIFF
--- a/EventFilter/CTPPSRawToDigi/interface/TotemSampicFrame.h
+++ b/EventFilter/CTPPSRawToDigi/interface/TotemSampicFrame.h
@@ -122,10 +122,28 @@ public:
     return tmp;
   }
 
+  template<class T>
+  T extractDataFromBytesMSB(const uint8_t* array, int start, int size) const{
+    T result=array[start];
+    for(int i=start+1;i<start+size;i++)
+      result=(result<<8)|array[i];
+    return result;
+
+  }
+  template<class T>
+  T extractDataFromBytesLSB(const uint8_t* array, int start, int size) const{
+    T result=array[start];
+    for(int i=start+size-1;i>=start;i--)
+      result=(result<<8)|array[i];
+    return result;
+
+  }
+
   inline uint64_t getFPGATimestamp() const {
     uint64_t tmp = 0;
     if (status_) {
-      tmp = *((const uint64_t*)(totemSampicInfoPtr_ + TotemSampicConstant::fpgaTime_Position)) & 0xFFFFFFFFFF;
+      tmp = extractDataFromBytesMSB<uint64_t>(totemSampicInfoPtr_,TotemSampicConstant::fpgaTime_Position,5);
+      //*((const uint64_t*)(totemSampicInfoPtr_ + TotemSampicConstant::fpgaTime_Position)) & 0xFFFFFFFFFF;
     }
     return tmp;
   }
@@ -133,7 +151,8 @@ public:
   inline uint16_t getTimestampA() const {
     uint16_t tmp = 0;
     if (status_) {
-      tmp = *((const uint16_t*)(totemSampicInfoPtr_ + TotemSampicConstant::timestampA_Position));
+      tmp = extractDataFromBytesMSB<uint16_t>(totemSampicInfoPtr_,TotemSampicConstant::timestampA_Position,2);
+      //*((const uint16_t*)(totemSampicInfoPtr_ + TotemSampicConstant::timestampA_Position));
     }
     tmp = 0xFFF - tmp;
     return grayToBinary<uint16_t>(tmp);
@@ -142,7 +161,8 @@ public:
   inline uint16_t getTimestampB() const {
     uint16_t tmp = 0;
     if (status_) {
-      tmp = *((const uint16_t*)(totemSampicInfoPtr_ + TotemSampicConstant::timestampB_Position));
+      tmp = extractDataFromBytesMSB<uint16_t>(totemSampicInfoPtr_,TotemSampicConstant::timestampB_Position,2);
+      //*((const uint16_t*)(totemSampicInfoPtr_ + TotemSampicConstant::timestampB_Position));
     }
     return grayToBinary<uint16_t>(tmp);
   }
@@ -150,7 +170,8 @@ public:
   inline uint16_t getCellInfo() const {
     uint16_t tmp = 0;
     if (status_)
-      tmp = *((const uint16_t*)(totemSampicInfoPtr_ + TotemSampicConstant::cellInfo_Position));
+      tmp = extractDataFromBytesMSB<uint16_t>(totemSampicInfoPtr_,TotemSampicConstant::cellInfo_Position,2);
+      //*((const uint16_t*)(totemSampicInfoPtr_ + TotemSampicConstant::cellInfo_Position));
     return tmp & TotemSampicConstant::cellInfo_Mask;
   }
 
@@ -191,7 +212,8 @@ public:
   inline uint64_t getL1ATimestamp() const {
     uint64_t tmp = 0;
     if (status_) {
-      tmp = *((const uint64_t*)(totemSampicEventInfoPtr_ + TotemSampicConstant::l1ATimestamp_Position)) & 0xFFFFFFFFFF;
+      tmp = extractDataFromBytesMSB<uint64_t>(totemSampicEventInfoPtr_,TotemSampicConstant::l1ATimestamp_Position,5);
+      //*((const uint64_t*)(totemSampicEventInfoPtr_ + TotemSampicConstant::l1ATimestamp_Position)) & 0xFFFFFFFFFF;
     }
     return tmp;
   }
@@ -199,35 +221,40 @@ public:
   inline uint16_t getBunchNumber() const {
     uint16_t tmp = 0;
     if (status_)
-      tmp = *((const uint16_t*)(totemSampicEventInfoPtr_ + TotemSampicConstant::bunchNumber_Position));
+      tmp = extractDataFromBytesMSB<uint16_t>(totemSampicEventInfoPtr_,TotemSampicConstant::bunchNumber_Position,2);
+      //*((const uint16_t*)(totemSampicEventInfoPtr_ + TotemSampicConstant::bunchNumber_Position));
     return tmp;
   }
 
   inline uint32_t getOrbitNumber() const {
     uint32_t tmp = 0;
     if (status_)
-      tmp = *((const uint32_t*)(totemSampicEventInfoPtr_ + TotemSampicConstant::orbitNumber_Position));
+      tmp = extractDataFromBytesMSB<uint32_t>(totemSampicEventInfoPtr_,TotemSampicConstant::orbitNumber_Position,4);
+      //*((const uint32_t*)(totemSampicEventInfoPtr_ + TotemSampicConstant::orbitNumber_Position));
     return tmp;
   }
 
   inline uint32_t getEventNumber() const {
     uint32_t tmp = 0;
     if (status_)
-      tmp = *((const uint32_t*)(totemSampicEventInfoPtr_ + TotemSampicConstant::eventNumber_Position));
+      tmp = extractDataFromBytesMSB<uint32_t>(totemSampicEventInfoPtr_,TotemSampicConstant::eventNumber_Position,4);
+      //*((const uint32_t*)(totemSampicEventInfoPtr_ + TotemSampicConstant::eventNumber_Position));
     return tmp;
   }
 
   inline uint16_t getChannelMap() const {
     uint16_t tmp = 0;
     if (status_)
-      tmp = *((const uint16_t*)(totemSampicEventInfoPtr_ + TotemSampicConstant::channelMap_Position));
+      tmp = extractDataFromBytesMSB<uint16_t>(totemSampicEventInfoPtr_,TotemSampicConstant::channelMap_Position,2);
+      //*((const uint16_t*)(totemSampicEventInfoPtr_ + TotemSampicConstant::channelMap_Position));
     return tmp;
   }
 
   inline uint16_t getL1ALatency() const {
     uint16_t tmp = 0;
     if (status_)
-      tmp = *((const uint16_t*)(totemSampicEventInfoPtr_ + TotemSampicConstant::l1ALatency_Position));
+      tmp = extractDataFromBytesMSB<uint16_t>(totemSampicEventInfoPtr_,TotemSampicConstant::l1ALatency_Position,2);
+      //*((const uint16_t*)(totemSampicEventInfoPtr_ + TotemSampicConstant::l1ALatency_Position));
     return tmp;
   }
 

--- a/EventFilter/CTPPSRawToDigi/interface/TotemSampicFrame.h
+++ b/EventFilter/CTPPSRawToDigi/interface/TotemSampicFrame.h
@@ -132,7 +132,7 @@ public:
   }
   template<class T>
   T extractDataFromBytesLSB(const uint8_t* array, int start, int size) const{
-    T result=array[start];
+    T result=0;
     for(int i=start+size-1;i>=start;i--)
       result=(result<<8)|array[i];
     return result;

--- a/EventFilter/CTPPSRawToDigi/interface/TotemSampicFrame.h
+++ b/EventFilter/CTPPSRawToDigi/interface/TotemSampicFrame.h
@@ -122,56 +122,44 @@ public:
     return tmp;
   }
 
-  template<class T>
-  T extractDataFromBytesMSB(const uint8_t* array, int start, int size) const{
-    T result=array[start];
-    for(int i=start+1;i<start+size;i++)
-      result=(result<<8)|array[i];
+  template <class T>
+  T extractDataFromBytesMSB(const uint8_t* array, int start, int size) const {
+    T result = array[start];
+    for (int i = start + 1; i < start + size; i++)
+      result = (result << 8) | array[i];
     return result;
-
-  }
-  template<class T>
-  T extractDataFromBytesLSB(const uint8_t* array, int start, int size) const{
-    T result=0;
-    for(int i=start+size-1;i>=start;i--)
-      result=(result<<8)|array[i];
-    return result;
-
   }
 
   inline uint64_t getFPGATimestamp() const {
     uint64_t tmp = 0;
-    if (status_) {
-      tmp = extractDataFromBytesMSB<uint64_t>(totemSampicInfoPtr_,TotemSampicConstant::fpgaTime_Position,5);
-      //*((const uint64_t*)(totemSampicInfoPtr_ + TotemSampicConstant::fpgaTime_Position)) & 0xFFFFFFFFFF;
-    }
+    if (status_)
+      tmp =
+          extractDataFromBytesMSB<uint64_t>(totemSampicInfoPtr_, TotemSampicConstant::fpgaTime_Position, fpgaTime_Size);
     return tmp;
   }
 
   inline uint16_t getTimestampA() const {
     uint16_t tmp = 0;
-    if (status_) {
-      tmp = extractDataFromBytesMSB<uint16_t>(totemSampicInfoPtr_,TotemSampicConstant::timestampA_Position,2);
-      //*((const uint16_t*)(totemSampicInfoPtr_ + TotemSampicConstant::timestampA_Position));
-    }
+    if (status_)
+      tmp = extractDataFromBytesMSB<uint16_t>(
+          totemSampicInfoPtr_, TotemSampicConstant::timestampA_Position, timestampA_Size);
     tmp = 0xFFF - tmp;
     return grayToBinary<uint16_t>(tmp);
   }
 
   inline uint16_t getTimestampB() const {
     uint16_t tmp = 0;
-    if (status_) {
-      tmp = extractDataFromBytesMSB<uint16_t>(totemSampicInfoPtr_,TotemSampicConstant::timestampB_Position,2);
-      //*((const uint16_t*)(totemSampicInfoPtr_ + TotemSampicConstant::timestampB_Position));
-    }
+    if (status_)
+      tmp = extractDataFromBytesMSB<uint16_t>(
+          totemSampicInfoPtr_, TotemSampicConstant::timestampB_Position, timestampB_Size);
     return grayToBinary<uint16_t>(tmp);
   }
 
   inline uint16_t getCellInfo() const {
     uint16_t tmp = 0;
     if (status_)
-      tmp = extractDataFromBytesMSB<uint16_t>(totemSampicInfoPtr_,TotemSampicConstant::cellInfo_Position,2);
-      //*((const uint16_t*)(totemSampicInfoPtr_ + TotemSampicConstant::cellInfo_Position));
+      tmp =
+          extractDataFromBytesMSB<uint16_t>(totemSampicInfoPtr_, TotemSampicConstant::cellInfo_Position, cellInfo_Size);
     return tmp & TotemSampicConstant::cellInfo_Mask;
   }
 
@@ -211,50 +199,49 @@ public:
 
   inline uint64_t getL1ATimestamp() const {
     uint64_t tmp = 0;
-    if (status_) {
-      tmp = extractDataFromBytesMSB<uint64_t>(totemSampicEventInfoPtr_,TotemSampicConstant::l1ATimestamp_Position,5);
-      //*((const uint64_t*)(totemSampicEventInfoPtr_ + TotemSampicConstant::l1ATimestamp_Position)) & 0xFFFFFFFFFF;
-    }
+    if (status_)
+      tmp = extractDataFromBytesMSB<uint64_t>(
+          totemSampicEventInfoPtr_, TotemSampicConstant::l1ATimestamp_Position, l1ATimestamp_Size);
     return tmp;
   }
 
   inline uint16_t getBunchNumber() const {
     uint16_t tmp = 0;
     if (status_)
-      tmp = extractDataFromBytesMSB<uint16_t>(totemSampicEventInfoPtr_,TotemSampicConstant::bunchNumber_Position,2);
-      //*((const uint16_t*)(totemSampicEventInfoPtr_ + TotemSampicConstant::bunchNumber_Position));
+      tmp = extractDataFromBytesMSB<uint16_t>(
+          totemSampicEventInfoPtr_, TotemSampicConstant::bunchNumber_Position, bunchNumber_Size);
     return tmp;
   }
 
   inline uint32_t getOrbitNumber() const {
     uint32_t tmp = 0;
     if (status_)
-      tmp = extractDataFromBytesMSB<uint32_t>(totemSampicEventInfoPtr_,TotemSampicConstant::orbitNumber_Position,4);
-      //*((const uint32_t*)(totemSampicEventInfoPtr_ + TotemSampicConstant::orbitNumber_Position));
+      tmp = extractDataFromBytesMSB<uint32_t>(
+          totemSampicEventInfoPtr_, TotemSampicConstant::orbitNumber_Position, orbitNumber_Size);
     return tmp;
   }
 
   inline uint32_t getEventNumber() const {
     uint32_t tmp = 0;
     if (status_)
-      tmp = extractDataFromBytesMSB<uint32_t>(totemSampicEventInfoPtr_,TotemSampicConstant::eventNumber_Position,4);
-      //*((const uint32_t*)(totemSampicEventInfoPtr_ + TotemSampicConstant::eventNumber_Position));
+      tmp = extractDataFromBytesMSB<uint32_t>(
+          totemSampicEventInfoPtr_, TotemSampicConstant::eventNumber_Position, eventNumber_Size);
     return tmp;
   }
 
   inline uint16_t getChannelMap() const {
     uint16_t tmp = 0;
     if (status_)
-      tmp = extractDataFromBytesMSB<uint16_t>(totemSampicEventInfoPtr_,TotemSampicConstant::channelMap_Position,2);
-      //*((const uint16_t*)(totemSampicEventInfoPtr_ + TotemSampicConstant::channelMap_Position));
+      tmp = extractDataFromBytesMSB<uint16_t>(
+          totemSampicEventInfoPtr_, TotemSampicConstant::channelMap_Position, channelMap_Size);
     return tmp;
   }
 
   inline uint16_t getL1ALatency() const {
     uint16_t tmp = 0;
     if (status_)
-      tmp = extractDataFromBytesMSB<uint16_t>(totemSampicEventInfoPtr_,TotemSampicConstant::l1ALatency_Position,2);
-      //*((const uint16_t*)(totemSampicEventInfoPtr_ + TotemSampicConstant::l1ALatency_Position));
+      tmp = extractDataFromBytesMSB<uint16_t>(
+          totemSampicEventInfoPtr_, TotemSampicConstant::l1ALatency_Position, l1ALatency_Size);
     return tmp;
   }
 
@@ -289,6 +276,17 @@ public:
   inline bool valid() const { return status_ != 0; }
 
 protected:
+  const int fpgaTime_Size = 5;
+  const int timestampA_Size = 2;
+  const int timestampB_Size = 2;
+  const int cellInfo_Size = 2;
+  const int l1ATimestamp_Size = 5;
+  const int bunchNumber_Size = 2;
+  const int orbitNumber_Size = 4;
+  const int eventNumber_Size = 4;
+  const int channelMap_Size = 2;
+  const int l1ALatency_Size = 2;
+
   const uint8_t* totemSampicInfoPtr_;
   const uint8_t* totemSampicDataPtr_;
   const uint8_t* totemSampicEventInfoPtr_;

--- a/EventFilter/CTPPSRawToDigi/interface/TotemSampicFrame.h
+++ b/EventFilter/CTPPSRawToDigi/interface/TotemSampicFrame.h
@@ -27,28 +27,28 @@ enum TotemSampicConstant {
   controlBits3_Position = 4,
   controlBits4_Position = 5,
   controlBits5_Position = 6,
-  fpgaTime_Position = 7,         // fpgaTime_Size = 5,
-  timestampA_Position = 12,      // timestampA_Size = 2,
+  fpgaTime_Position = 7,     // fpgaTime_Size = 5,
+  timestampA_Position = 12,  // timestampA_Size = 2,
   fpgaTime_Size = timestampA_Position - fpgaTime_Position,
-  timestampB_Position = 14,      // timestampB_Size = 2,
+  timestampB_Position = 14,  // timestampB_Size = 2,
   timestampA_Size = timestampB_Position - timestampA_Position,
-  cellInfo_Position = 16,        // cellInfo_Size = 2,
+  cellInfo_Position = 16,  // cellInfo_Size = 2,
   timestampB_Size = cellInfo_Position - timestampB_Position,
   planeChannelId_Position = 18,  // planeChannelId_Size = 1,
   cellInfo_Size = planeChannelId_Position - cellInfo_Position,
-  reserved_Position = 19,        // reserved_Size = 5,
+  reserved_Position = 19,  // reserved_Size = 5,
 
-  boardId_Position = 0,           // boardId_Size = 1,
-  l1ATimestamp_Position = 1,      // l1ATimestamp_Size = 5,
-  bunchNumber_Position = 6,       // bunchNumber_Size = 2,
+  boardId_Position = 0,       // boardId_Size = 1,
+  l1ATimestamp_Position = 1,  // l1ATimestamp_Size = 5,
+  bunchNumber_Position = 6,   // bunchNumber_Size = 2,
   l1ATimestamp_Size = bunchNumber_Position - l1ATimestamp_Position,
-  orbitNumber_Position = 8,       // orbitNumber_Size = 4,
+  orbitNumber_Position = 8,  // orbitNumber_Size = 4,
   bunchNumber_Size = orbitNumber_Position - bunchNumber_Position,
-  eventNumber_Position = 12,      // eventNumber_Size = 4,
+  eventNumber_Position = 12,  // eventNumber_Size = 4,
   orbitNumber_Size = eventNumber_Position - orbitNumber_Position,
-  channelMap_Position = 16,       // channelMap_Size = 2,
+  channelMap_Position = 16,  // channelMap_Size = 2,
   eventNumber_Size = channelMap_Position - eventNumber_Position,
-  l1ALatency_Position = 18,       // l1ALatency_Size = 2,
+  l1ALatency_Position = 18,  // l1ALatency_Size = 2,
   channelMap_Size = l1ALatency_Position - channelMap_Position,
   numberOfSamples_Position = 20,  // numberOfSamples_Size = 1,
   l1ALatency_Size = numberOfSamples_Position - l1ALatency_Position,
@@ -132,20 +132,19 @@ public:
     return tmp;
   }
 
-  template<class T>
-  T extractDataFromBytesLSB(const uint8_t* array, int start, int size) const{
-    T result=0;
-    for(int i=start+size-1;i>=start;i--)
-      result=(result<<8)|array[i];
+  template <class T>
+  T extractDataFromBytesLSB(const uint8_t* array, int start, int size) const {
+    T result = 0;
+    for (int i = start + size - 1; i >= start; i--)
+      result = (result << 8) | array[i];
     return result;
-
   }
 
   inline uint64_t getFPGATimestamp() const {
     uint64_t tmp = 0;
     if (status_)
-      tmp = extractDataFromBytesLSB<uint64_t>(
-          totemSampicInfoPtr_, TotemSampicConstant::fpgaTime_Position, fpgaTime_Size);
+      tmp =
+          extractDataFromBytesLSB<uint64_t>(totemSampicInfoPtr_, TotemSampicConstant::fpgaTime_Position, fpgaTime_Size);
     return tmp;
   }
 

--- a/EventFilter/CTPPSRawToDigi/interface/TotemSampicFrame.h
+++ b/EventFilter/CTPPSRawToDigi/interface/TotemSampicFrame.h
@@ -29,19 +29,29 @@ enum TotemSampicConstant {
   controlBits5_Position = 6,
   fpgaTime_Position = 7,         // fpgaTime_Size = 5,
   timestampA_Position = 12,      // timestampA_Size = 2,
+  fpgaTime_Size = timestampA_Position - fpgaTime_Position,
   timestampB_Position = 14,      // timestampB_Size = 2,
+  timestampA_Size = timestampB_Position - timestampA_Position,
   cellInfo_Position = 16,        // cellInfo_Size = 2,
+  timestampB_Size = cellInfo_Position - timestampB_Position,
   planeChannelId_Position = 18,  // planeChannelId_Size = 1,
+  cellInfo_Size = planeChannelId_Position - cellInfo_Position,
   reserved_Position = 19,        // reserved_Size = 5,
 
   boardId_Position = 0,           // boardId_Size = 1,
   l1ATimestamp_Position = 1,      // l1ATimestamp_Size = 5,
   bunchNumber_Position = 6,       // bunchNumber_Size = 2,
+  l1ATimestamp_Size = bunchNumber_Position - l1ATimestamp_Position,
   orbitNumber_Position = 8,       // orbitNumber_Size = 4,
+  bunchNumber_Size = orbitNumber_Position - bunchNumber_Position,
   eventNumber_Position = 12,      // eventNumber_Size = 4,
+  orbitNumber_Size = eventNumber_Position - orbitNumber_Position,
   channelMap_Position = 16,       // channelMap_Size = 2,
+  eventNumber_Size = channelMap_Position - eventNumber_Position,
   l1ALatency_Position = 18,       // l1ALatency_Size = 2,
+  channelMap_Size = l1ALatency_Position - channelMap_Position,
   numberOfSamples_Position = 20,  // numberOfSamples_Size = 1,
+  l1ALatency_Size = numberOfSamples_Position - l1ALatency_Position,
   offsetOfSamples_Position = 21,  // offsetOfSamples_Size = 1,
   fwVersion_Position = 22,        // fwVersion_Size = 1,
   pllInfo_Position = 23,          // pllInfo_Size = 1,
@@ -122,26 +132,27 @@ public:
     return tmp;
   }
 
-  template <class T>
-  T extractDataFromBytesMSB(const uint8_t* array, int start, int size) const {
-    T result = array[start];
-    for (int i = start + 1; i < start + size; i++)
-      result = (result << 8) | array[i];
+  template<class T>
+  T extractDataFromBytesLSB(const uint8_t* array, int start, int size) const{
+    T result=0;
+    for(int i=start+size-1;i>=start;i--)
+      result=(result<<8)|array[i];
     return result;
+
   }
 
   inline uint64_t getFPGATimestamp() const {
     uint64_t tmp = 0;
     if (status_)
-      tmp =
-          extractDataFromBytesMSB<uint64_t>(totemSampicInfoPtr_, TotemSampicConstant::fpgaTime_Position, fpgaTime_Size);
+      tmp = extractDataFromBytesLSB<uint64_t>(
+          totemSampicInfoPtr_, TotemSampicConstant::fpgaTime_Position, fpgaTime_Size);
     return tmp;
   }
 
   inline uint16_t getTimestampA() const {
     uint16_t tmp = 0;
     if (status_)
-      tmp = extractDataFromBytesMSB<uint16_t>(
+      tmp = extractDataFromBytesLSB<uint16_t>(
           totemSampicInfoPtr_, TotemSampicConstant::timestampA_Position, timestampA_Size);
     tmp = 0xFFF - tmp;
     return grayToBinary<uint16_t>(tmp);
@@ -150,7 +161,7 @@ public:
   inline uint16_t getTimestampB() const {
     uint16_t tmp = 0;
     if (status_)
-      tmp = extractDataFromBytesMSB<uint16_t>(
+      tmp = extractDataFromBytesLSB<uint16_t>(
           totemSampicInfoPtr_, TotemSampicConstant::timestampB_Position, timestampB_Size);
     return grayToBinary<uint16_t>(tmp);
   }
@@ -159,7 +170,7 @@ public:
     uint16_t tmp = 0;
     if (status_)
       tmp =
-          extractDataFromBytesMSB<uint16_t>(totemSampicInfoPtr_, TotemSampicConstant::cellInfo_Position, cellInfo_Size);
+          extractDataFromBytesLSB<uint16_t>(totemSampicInfoPtr_, TotemSampicConstant::cellInfo_Position, cellInfo_Size);
     return tmp & TotemSampicConstant::cellInfo_Mask;
   }
 
@@ -200,7 +211,7 @@ public:
   inline uint64_t getL1ATimestamp() const {
     uint64_t tmp = 0;
     if (status_)
-      tmp = extractDataFromBytesMSB<uint64_t>(
+      tmp = extractDataFromBytesLSB<uint64_t>(
           totemSampicEventInfoPtr_, TotemSampicConstant::l1ATimestamp_Position, l1ATimestamp_Size);
     return tmp;
   }
@@ -208,7 +219,7 @@ public:
   inline uint16_t getBunchNumber() const {
     uint16_t tmp = 0;
     if (status_)
-      tmp = extractDataFromBytesMSB<uint16_t>(
+      tmp = extractDataFromBytesLSB<uint16_t>(
           totemSampicEventInfoPtr_, TotemSampicConstant::bunchNumber_Position, bunchNumber_Size);
     return tmp;
   }
@@ -216,7 +227,7 @@ public:
   inline uint32_t getOrbitNumber() const {
     uint32_t tmp = 0;
     if (status_)
-      tmp = extractDataFromBytesMSB<uint32_t>(
+      tmp = extractDataFromBytesLSB<uint32_t>(
           totemSampicEventInfoPtr_, TotemSampicConstant::orbitNumber_Position, orbitNumber_Size);
     return tmp;
   }
@@ -224,7 +235,7 @@ public:
   inline uint32_t getEventNumber() const {
     uint32_t tmp = 0;
     if (status_)
-      tmp = extractDataFromBytesMSB<uint32_t>(
+      tmp = extractDataFromBytesLSB<uint32_t>(
           totemSampicEventInfoPtr_, TotemSampicConstant::eventNumber_Position, eventNumber_Size);
     return tmp;
   }
@@ -232,7 +243,7 @@ public:
   inline uint16_t getChannelMap() const {
     uint16_t tmp = 0;
     if (status_)
-      tmp = extractDataFromBytesMSB<uint16_t>(
+      tmp = extractDataFromBytesLSB<uint16_t>(
           totemSampicEventInfoPtr_, TotemSampicConstant::channelMap_Position, channelMap_Size);
     return tmp;
   }
@@ -240,7 +251,7 @@ public:
   inline uint16_t getL1ALatency() const {
     uint16_t tmp = 0;
     if (status_)
-      tmp = extractDataFromBytesMSB<uint16_t>(
+      tmp = extractDataFromBytesLSB<uint16_t>(
           totemSampicEventInfoPtr_, TotemSampicConstant::l1ALatency_Position, l1ALatency_Size);
     return tmp;
   }
@@ -276,17 +287,6 @@ public:
   inline bool valid() const { return status_ != 0; }
 
 protected:
-  const int fpgaTime_Size = 5;
-  const int timestampA_Size = 2;
-  const int timestampB_Size = 2;
-  const int cellInfo_Size = 2;
-  const int l1ATimestamp_Size = 5;
-  const int bunchNumber_Size = 2;
-  const int orbitNumber_Size = 4;
-  const int eventNumber_Size = 4;
-  const int channelMap_Size = 2;
-  const int l1ALatency_Size = 2;
-
   const uint8_t* totemSampicInfoPtr_;
   const uint8_t* totemSampicDataPtr_;
   const uint8_t* totemSampicEventInfoPtr_;


### PR DESCRIPTION
#### PR description:
Goal of this PR is to fix the unaligned address operations in TotemSampicFrame(please refer to #35012). It is replacing pointer casts with sequence of bitwise operations which don't violate byte alignment of the data array.

#### PR validation:
Changes were validated against relval 136.8562, new values were compared with the previous implementation. There was no difference in the produced numbers.

@jan-kaspar 