### PR TITLE
[Draft] esConsumes migration

### DIFF
--- a/Alignment/MuonAlignment/interface/MuonAlignment.h
+++ b/Alignment/MuonAlignment/interface/MuonAlignment.h
@@ -20,7 +20,7 @@
 
 class MuonAlignment {
 public:
-  MuonAlignment(const edm::EventSetup& iSetup);
+  MuonAlignment(const edm::EventSetup& iSetup, edm::ConsumesCollector iC);
 
   MuonAlignment(const edm::EventSetup& iSetup, const MuonAlignmentInputMethod& input);
 
@@ -45,7 +45,7 @@ public:
   void fillGapsInSurvey(double shiftErr, double angleErr);
   void copySurveyToAlignment();
 
-  void writeXML(const edm::ParameterSet& iConfig, const edm::EventSetup& iSetup);
+  void writeXML(const edm::ParameterSet& iConfig, const edm::EventSetup& iSetup, edm::ConsumesCollector);
 
   void saveDTSurveyToDB();
   void saveCSCSurveyToDB();
@@ -66,9 +66,9 @@ private:
   std::string theDTSurveyRecordName, theDTSurveyErrorRecordName;
   std::string theCSCSurveyRecordName, theCSCSurveyErrorRecordName;
 
-  edm::ESGetToken<DTGeometry, MuonGeometryRecord> esTokenDT_;
-  edm::ESGetToken<CSCGeometry, MuonGeometryRecord> esTokenCSC_;
-  edm::ESGetToken<GEMGeometry, MuonGeometryRecord> esTokenGEM_;
+  const edm::ESGetToken<DTGeometry, MuonGeometryRecord> esTokenDT_;
+  const edm::ESGetToken<CSCGeometry, MuonGeometryRecord> esTokenCSC_;
+  const edm::ESGetToken<GEMGeometry, MuonGeometryRecord> esTokenGEM_;
 
   align::Scalars displacements;
 

--- a/Alignment/MuonAlignment/interface/MuonAlignmentInputDB.h
+++ b/Alignment/MuonAlignment/interface/MuonAlignmentInputDB.h
@@ -19,18 +19,26 @@
 // $Id: MuonAlignmentInputDB.h,v 1.1 2008/03/15 20:26:46 pivarski Exp $
 //
 
-// system include files
-
-// user include files
 #include "Alignment/MuonAlignment/interface/MuonAlignmentInputMethod.h"
-
-// forward declarations
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "CondFormats/Alignment/interface/Alignments.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "CondFormats/AlignmentRecord/interface/DTAlignmentRcd.h"
+#include "CondFormats/AlignmentRecord/interface/DTAlignmentErrorRcd.h"
+#include "CondFormats/AlignmentRecord/interface/CSCAlignmentRcd.h"
+#include "CondFormats/AlignmentRecord/interface/CSCAlignmentErrorRcd.h"
+#include "CondFormats/AlignmentRecord/interface/GEMAlignmentRcd.h"
+#include "CondFormats/AlignmentRecord/interface/GEMAlignmentErrorRcd.h"
 
 class MuonAlignmentInputDB : public MuonAlignmentInputMethod {
 public:
-  MuonAlignmentInputDB();
-  MuonAlignmentInputDB(
-      std::string dtLabel, std::string cscLabel, std::string gemLabel, std::string idealLabel, bool getAPEs);
+  MuonAlignmentInputDB(edm::ConsumesCollector iC);
+  MuonAlignmentInputDB(std::string dtLabel,
+                       std::string cscLabel,
+                       std::string gemLabel,
+                       std::string idealLabel,
+                       bool getAPEs,
+                       edm::ConsumesCollector iC);
   ~MuonAlignmentInputDB() override;
 
   // ---------- const member functions ---------------------
@@ -47,9 +55,19 @@ public:
 
 private:
   // ---------- member data --------------------------------
+  const std::string m_dtLabel, m_cscLabel, m_gemLabel, idealGeometryLabel;
+  const bool m_getAPEs;
 
-  std::string m_dtLabel, m_cscLabel, m_gemLabel, idealGeometryLabel;
-  bool m_getAPEs;
+  const edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomToken_;
+  const edm::ESGetToken<CSCGeometry, MuonGeometryRecord> cscGeomToken_;
+  const edm::ESGetToken<GEMGeometry, MuonGeometryRecord> gemGeomToken_;
+  const edm::ESGetToken<Alignments, DTAlignmentRcd> dtAliToken_;
+  const edm::ESGetToken<Alignments, CSCAlignmentRcd> cscAliToken_;
+  const edm::ESGetToken<Alignments, GEMAlignmentRcd> gemAliToken_;
+  const edm::ESGetToken<AlignmentErrorsExtended, DTAlignmentErrorExtendedRcd> dtAliErrToken_;
+  const edm::ESGetToken<AlignmentErrorsExtended, CSCAlignmentErrorExtendedRcd> cscAliErrToken_;
+  const edm::ESGetToken<AlignmentErrorsExtended, GEMAlignmentErrorExtendedRcd> gemAliErrToken_;
+  const edm::ESGetToken<Alignments, GlobalPositionRcd> gprToken_;
 };
 
 #endif

--- a/Alignment/MuonAlignment/interface/MuonAlignmentInputMethod.h
+++ b/Alignment/MuonAlignment/interface/MuonAlignmentInputMethod.h
@@ -23,18 +23,17 @@
 #include <memory>
 
 #include "FWCore/Framework/interface/EventSetup.h"
-
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 // user include files
 #include "Alignment/MuonAlignment/interface/AlignableMuon.h"
-#include "Geometry/DTGeometry/interface/DTGeometry.h"
-#include "Geometry/CSCGeometry/interface/CSCGeometry.h"
-
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 // forward declarations
 
 class MuonAlignmentInputMethod {
 public:
   MuonAlignmentInputMethod();
-  MuonAlignmentInputMethod(std::string idealLabel);
+  MuonAlignmentInputMethod(edm::ConsumesCollector iC);
+  MuonAlignmentInputMethod(std::string idealLabel, edm::ConsumesCollector iC);
   virtual ~MuonAlignmentInputMethod();
 
   // ---------- const member functions ---------------------
@@ -51,7 +50,11 @@ public:
 
 private:
   // ---------- member data --------------------------------
-  std::string idealGeometryLabel;
+  const std::string idealGeometryLabel;
+
+  const edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomToken_;
+  const edm::ESGetToken<CSCGeometry, MuonGeometryRecord> cscGeomToken_;
+  const edm::ESGetToken<GEMGeometry, MuonGeometryRecord> gemGeomToken_;
 };
 
 #endif

--- a/Alignment/MuonAlignment/interface/MuonAlignmentInputSurveyDB.h
+++ b/Alignment/MuonAlignment/interface/MuonAlignmentInputSurveyDB.h
@@ -22,16 +22,25 @@
 // system include files
 
 // user include files
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "Alignment/MuonAlignment/interface/MuonAlignmentInputMethod.h"
+#include "Alignment/CommonAlignment/interface/SurveyDet.h"
 #include "CondFormats/Alignment/interface/Alignments.h"
 #include "CondFormats/Alignment/interface/SurveyErrors.h"
-
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "CondFormats/AlignmentRecord/interface/DTSurveyRcd.h"
+#include "CondFormats/AlignmentRecord/interface/DTSurveyErrorExtendedRcd.h"
+#include "CondFormats/AlignmentRecord/interface/CSCSurveyRcd.h"
+#include "CondFormats/AlignmentRecord/interface/CSCSurveyErrorExtendedRcd.h"
 // forward declarations
 
 class MuonAlignmentInputSurveyDB : public MuonAlignmentInputMethod {
 public:
-  MuonAlignmentInputSurveyDB();
-  MuonAlignmentInputSurveyDB(std::string dtLabel, std::string cscLabel, std::string idealLabel);
+  MuonAlignmentInputSurveyDB(edm::ConsumesCollector iC);
+  MuonAlignmentInputSurveyDB(std::string dtLabel,
+                             std::string cscLabel,
+                             std::string idealLabel,
+                             edm::ConsumesCollector iC);
   ~MuonAlignmentInputSurveyDB() override;
 
   // ---------- const member functions ---------------------
@@ -53,8 +62,15 @@ private:
                       const SurveyErrors* theSurveyErrors) const;
 
   // ---------- member data --------------------------------
+  const std::string m_dtLabel, m_cscLabel, idealGeometryLabel;
 
-  std::string m_dtLabel, m_cscLabel, idealGeometryLabel;
+  const edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomToken_;
+  const edm::ESGetToken<CSCGeometry, MuonGeometryRecord> cscGeomToken_;
+  const edm::ESGetToken<GEMGeometry, MuonGeometryRecord> gemGeomToken_;
+  const edm::ESGetToken<Alignments, DTSurveyRcd> dtSurveyToken_;
+  const edm::ESGetToken<SurveyErrors, DTSurveyErrorExtendedRcd> dtSurvErrorToken_;
+  const edm::ESGetToken<Alignments, CSCSurveyRcd> cscSurveyToken_;
+  const edm::ESGetToken<SurveyErrors, CSCSurveyErrorExtendedRcd> cscSurvErrorToken_;
 };
 
 #endif

--- a/Alignment/MuonAlignment/interface/MuonAlignmentInputXML.h
+++ b/Alignment/MuonAlignment/interface/MuonAlignmentInputXML.h
@@ -25,14 +25,15 @@
 #include "xercesc/util/XercesDefs.hpp"
 
 // user include files
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "Alignment/MuonAlignment/interface/MuonAlignmentInputMethod.h"
 #include "Alignment/CommonAlignment/interface/Alignable.h"
-
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 // forward declarations
 
 class MuonAlignmentInputXML : public MuonAlignmentInputMethod {
 public:
-  MuonAlignmentInputXML(const std::string &fileName, std::string idealLabel);
+  MuonAlignmentInputXML(const std::string &fileName, std::string idealLabel, edm::ConsumesCollector iC);
   ~MuonAlignmentInputXML() override;
 
   // ---------- const member functions ---------------------
@@ -96,7 +97,11 @@ private:
                            std::map<Alignable *, Alignable *> &alitoideal) const;
 
   // ---------- member data --------------------------------
-  std::string m_fileName, idealGeometryLabel;
+  const std::string m_fileName, idealGeometryLabel;
+
+  const edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomToken_;
+  const edm::ESGetToken<CSCGeometry, MuonGeometryRecord> cscGeomToken_;
+  const edm::ESGetToken<GEMGeometry, MuonGeometryRecord> gemGeomToken_;
 
   XMLCh *str_operation;
   XMLCh *str_collection;

--- a/Alignment/MuonAlignment/interface/MuonAlignmentOutputXML.h
+++ b/Alignment/MuonAlignment/interface/MuonAlignmentOutputXML.h
@@ -24,17 +24,18 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 // user include files
 #include "Alignment/MuonAlignment/interface/AlignableMuon.h"
 #include "CondFormats/Alignment/interface/AlignTransformErrorExtended.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 
 // forward declarations
 class AlignableObjectId;
 
 class MuonAlignmentOutputXML {
 public:
-  MuonAlignmentOutputXML(const edm::ParameterSet &iConfig);
+  MuonAlignmentOutputXML(const edm::ParameterSet &iConfig, edm::ConsumesCollector iC);
   virtual ~MuonAlignmentOutputXML();
 
   // ---------- const member functions ---------------------
@@ -65,7 +66,12 @@ private:
   bool m_suppressDTBarrel, m_suppressDTWheels, m_suppressDTStations, m_suppressDTChambers, m_suppressDTSuperLayers,
       m_suppressDTLayers;
   bool m_suppressCSCEndcaps, m_suppressCSCStations, m_suppressCSCRings, m_suppressCSCChambers, m_suppressCSCLayers;
-  std::string idealGeometryLabel;
+
+  const std::string idealGeometryLabel;
+
+  const edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomToken_;
+  const edm::ESGetToken<CSCGeometry, MuonGeometryRecord> cscGeomToken_;
+  const edm::ESGetToken<GEMGeometry, MuonGeometryRecord> gemGeomToken_;
 };
 
 #endif

--- a/Alignment/MuonAlignment/plugins/MuonGeometryArrange.cc
+++ b/Alignment/MuonAlignment/plugins/MuonGeometryArrange.cc
@@ -47,7 +47,8 @@ MuonGeometryArrange::MuonGeometryArrange(const edm::ParameterSet& cfg)
       firstEvent_(true),
       idealInputLabel1("MuonGeometryArrangeLabel1"),
       idealInputLabel2("MuonGeometryArrangeLabel2"),
-      idealInputLabel2a("MuonGeometryArrangeLabel2a") {
+      idealInputLabel2a("MuonGeometryArrangeLabel2a"),
+      m_cc(consumesCollector()) {
   referenceMuon = nullptr;
   currentMuon = nullptr;
   // Input is XML
@@ -623,13 +624,13 @@ void MuonGeometryArrange::createROOTGeometry(const edm::EventSetup& iSetup) {}
 void MuonGeometryArrange::analyze(const edm::Event&, const edm::EventSetup& iSetup) {
   if (firstEvent_) {
     // My stuff
-    MuonAlignmentInputXML inputMethod1(_inputXMLCurrent, idealInputLabel1);
+    MuonAlignmentInputXML inputMethod1(_inputXMLCurrent, idealInputLabel1, m_cc);
     inputAlign1 = new MuonAlignment(iSetup, inputMethod1);
     inputAlign1->fillGapsInSurvey(0, 0);
-    MuonAlignmentInputXML inputMethod2(_inputXMLReference, idealInputLabel2);
+    MuonAlignmentInputXML inputMethod2(_inputXMLReference, idealInputLabel2, m_cc);
     inputAlign2 = new MuonAlignment(iSetup, inputMethod2);
     inputAlign2->fillGapsInSurvey(0, 0);
-    MuonAlignmentInputXML inputMethod2a(_inputXMLReference, idealInputLabel2a);
+    MuonAlignmentInputXML inputMethod2a(_inputXMLReference, idealInputLabel2a, m_cc);
     inputAlign2a = new MuonAlignment(iSetup, inputMethod2a);
     inputAlign2a->fillGapsInSurvey(0, 0);
 

--- a/Alignment/MuonAlignment/plugins/MuonGeometryArrange.h
+++ b/Alignment/MuonAlignment/plugins/MuonGeometryArrange.h
@@ -170,7 +170,9 @@ private:
 
   bool firstEvent_;
 
-  std::string idealInputLabel1, idealInputLabel2, idealInputLabel2a;
+  const std::string idealInputLabel1, idealInputLabel2, idealInputLabel2a;
+
+  edm::ConsumesCollector m_cc;
 };
 
 #endif

--- a/Alignment/MuonAlignment/plugins/MuonGeometrySVGTemplate.cc
+++ b/Alignment/MuonAlignment/plugins/MuonGeometrySVGTemplate.cc
@@ -52,6 +52,8 @@ private:
   void analyze(const edm::Event &, const edm::EventSetup &iConfig) override;
 
   std::string m_wheelTemplateName;
+
+  edm::ConsumesCollector m_cc;
   //       std::string m_disk1TemplateName;
   //       std::string m_disk23TemplateName;
   //       std::string m_diskp4TemplateName;
@@ -71,14 +73,14 @@ private:
 //
 
 MuonGeometrySVGTemplate::MuonGeometrySVGTemplate(const edm::ParameterSet &iConfig)
-    : m_wheelTemplateName(iConfig.getParameter<std::string>("wheelTemplateName")) {}
+    : m_wheelTemplateName(iConfig.getParameter<std::string>("wheelTemplateName")), m_cc(consumesCollector()) {}
 
 MuonGeometrySVGTemplate::~MuonGeometrySVGTemplate() {}
 
 // ------------ method called to for each event  ------------
 void MuonGeometrySVGTemplate::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   // loads ideal geometry
-  MuonAlignmentInputMethod inputMethod;
+  MuonAlignmentInputMethod inputMethod(m_cc);
   MuonAlignment muonAlignment(iSetup, inputMethod);
   AlignableNavigator *alignableNavigator = muonAlignment.getAlignableNavigator();
 

--- a/Alignment/MuonAlignment/plugins/MuonGeometrySanityCheck.cc
+++ b/Alignment/MuonAlignment/plugins/MuonGeometrySanityCheck.cc
@@ -94,6 +94,9 @@ private:
   std::string prefix;
   std::map<std::string, const MuonGeometrySanityCheckCustomFrame *> m_frames;
   std::vector<MuonGeometrySanityCheckPoint> m_points;
+
+  const edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomToken_;
+  const edm::ESGetToken<CSCGeometry, MuonGeometryRecord> cscGeomToken_;
 };
 
 //
@@ -108,7 +111,8 @@ private:
 // constructors and destructor
 //
 
-MuonGeometrySanityCheck::MuonGeometrySanityCheck(const edm::ParameterSet &iConfig) {
+MuonGeometrySanityCheck::MuonGeometrySanityCheck(const edm::ParameterSet &iConfig)
+    : dtGeomToken_(esConsumes<edm::Transition::BeginRun>()), cscGeomToken_(esConsumes<edm::Transition::BeginRun>()) {
   printout = iConfig.getParameter<std::string>("printout");
   if (printout != std::string("all") && printout != std::string("bad")) {
     throw cms::Exception("BadConfig") << "Printout must be \"all\" or \"bad\"." << std::endl;
@@ -581,10 +585,9 @@ std::string MuonGeometrySanityCheckPoint::detName() const {
 // ------------ method called to for each event  ------------
 void MuonGeometrySanityCheck::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   edm::ESHandle<DTGeometry> dtGeometry;
-  iSetup.get<MuonGeometryRecord>().get(dtGeometry);
-
   edm::ESHandle<CSCGeometry> cscGeometry;
-  iSetup.get<MuonGeometryRecord>().get(cscGeometry);
+  dtGeometry = iSetup.getHandle(dtGeomToken_);
+  cscGeometry = iSetup.getHandle(cscGeomToken_);
 
   int num_transformed = 0;
   int num_tested = 0;

--- a/Alignment/MuonAlignment/src/MuonAlignment.cc
+++ b/Alignment/MuonAlignment/src/MuonAlignment.cc
@@ -40,7 +40,8 @@ void MuonAlignment::init() {
   theAlignableNavigator = nullptr;
 }
 
-MuonAlignment::MuonAlignment(const edm::EventSetup& iSetup) {
+MuonAlignment::MuonAlignment(const edm::EventSetup& iSetup, edm::ConsumesCollector iC)
+    : esTokenDT_(iC.esConsumes()), esTokenCSC_(iC.esConsumes()), esTokenGEM_(iC.esConsumes()) {
   init();
 
   edm::ESHandle<DTGeometry> dtGeometry = iSetup.getHandle(esTokenDT_);
@@ -238,8 +239,10 @@ void MuonAlignment::copySurveyToAlignment() { recursiveCopySurveyToAlignment(the
 //____________________________________________________________________________________
 // Code needed to store alignments to DB
 
-void MuonAlignment::writeXML(const edm::ParameterSet& iConfig, const edm::EventSetup& iSetup) {
-  MuonAlignmentOutputXML(iConfig).write(theAlignableMuon, iSetup);
+void MuonAlignment::writeXML(const edm::ParameterSet& iConfig,
+                             const edm::EventSetup& iSetup,
+                             edm::ConsumesCollector iC) {
+  MuonAlignmentOutputXML(iConfig, iC).write(theAlignableMuon, iSetup);
 }
 
 void MuonAlignment::saveDTSurveyToDB(void) {

--- a/Alignment/MuonAlignment/src/MuonAlignmentInputMethod.cc
+++ b/Alignment/MuonAlignment/src/MuonAlignmentInputMethod.cc
@@ -14,13 +14,10 @@
 // system include files
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ESTransientHandle.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 // user include files
 #include "Alignment/MuonAlignment/interface/MuonAlignmentInputMethod.h"
-#include "Geometry/Records/interface/MuonNumberingRecord.h"
-
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "Geometry/Records/interface/MuonGeometryRecord.h"
 
 //
 // constants, enums and typedefs
@@ -33,8 +30,17 @@
 //
 // constructors and destructor
 //
-MuonAlignmentInputMethod::MuonAlignmentInputMethod() : idealGeometryLabel("idealForInputMethod") {}
-MuonAlignmentInputMethod::MuonAlignmentInputMethod(std::string idealLabel) : idealGeometryLabel(idealLabel) {}
+MuonAlignmentInputMethod::MuonAlignmentInputMethod() {}
+MuonAlignmentInputMethod::MuonAlignmentInputMethod(edm::ConsumesCollector iC)
+    : idealGeometryLabel("idealForInputMethod"),
+      dtGeomToken_(iC.esConsumes(edm::ESInputTag("", idealGeometryLabel))),
+      cscGeomToken_(iC.esConsumes(edm::ESInputTag("", idealGeometryLabel))),
+      gemGeomToken_(iC.esConsumes(edm::ESInputTag("", idealGeometryLabel))) {}
+MuonAlignmentInputMethod::MuonAlignmentInputMethod(std::string idealLabel, edm::ConsumesCollector iC)
+    : idealGeometryLabel(idealLabel),
+      dtGeomToken_(iC.esConsumes(edm::ESInputTag("", idealGeometryLabel))),
+      cscGeomToken_(iC.esConsumes(edm::ESInputTag("", idealGeometryLabel))),
+      gemGeomToken_(iC.esConsumes(edm::ESInputTag("", idealGeometryLabel))) {}
 
 // MuonAlignmentInputMethod::MuonAlignmentInputMethod(const MuonAlignmentInputMethod& rhs)
 // {
@@ -63,9 +69,9 @@ AlignableMuon* MuonAlignmentInputMethod::newAlignableMuon(const edm::EventSetup&
   edm::ESHandle<DTGeometry> dtGeometry;
   edm::ESHandle<CSCGeometry> cscGeometry;
   edm::ESHandle<GEMGeometry> gemGeometry;
-  iSetup.get<MuonGeometryRecord>().get(idealGeometryLabel, dtGeometry);
-  iSetup.get<MuonGeometryRecord>().get(idealGeometryLabel, cscGeometry);
-  iSetup.get<MuonGeometryRecord>().get(idealGeometryLabel, gemGeometry);
+  dtGeometry = iSetup.getHandle(dtGeomToken_);
+  cscGeometry = iSetup.getHandle(cscGeomToken_);
+  gemGeometry = iSetup.getHandle(gemGeomToken_);
   return new AlignableMuon(&(*dtGeometry), &(*cscGeometry), &(*gemGeometry));
 }
 

--- a/Alignment/MuonAlignment/src/MuonAlignmentInputSurveyDB.cc
+++ b/Alignment/MuonAlignment/src/MuonAlignmentInputSurveyDB.cc
@@ -16,12 +16,6 @@
 
 // user include files
 #include "Alignment/MuonAlignment/interface/MuonAlignmentInputSurveyDB.h"
-#include "CondFormats/AlignmentRecord/interface/DTSurveyRcd.h"
-#include "CondFormats/AlignmentRecord/interface/DTSurveyErrorExtendedRcd.h"
-#include "CondFormats/AlignmentRecord/interface/CSCSurveyRcd.h"
-#include "CondFormats/AlignmentRecord/interface/CSCSurveyErrorExtendedRcd.h"
-#include "Alignment/CommonAlignment/interface/SurveyDet.h"
-#include "Geometry/Records/interface/MuonGeometryRecord.h"
 
 //
 // constants, enums and typedefs
@@ -34,13 +28,32 @@
 //
 // constructors and destructor
 //
-MuonAlignmentInputSurveyDB::MuonAlignmentInputSurveyDB()
-    : m_dtLabel(""), m_cscLabel(""), idealGeometryLabel("idealForInputSurveyDB") {}
+MuonAlignmentInputSurveyDB::MuonAlignmentInputSurveyDB(edm::ConsumesCollector iC)
+    : m_dtLabel(""),
+      m_cscLabel(""),
+      idealGeometryLabel("idealForInputSurveyDB"),
+      dtGeomToken_(iC.esConsumes(edm::ESInputTag("", idealGeometryLabel))),
+      cscGeomToken_(iC.esConsumes(edm::ESInputTag("", idealGeometryLabel))),
+      gemGeomToken_(iC.esConsumes(edm::ESInputTag("", idealGeometryLabel))),
+      dtSurveyToken_(iC.esConsumes()),
+      dtSurvErrorToken_(iC.esConsumes()),
+      cscSurveyToken_(iC.esConsumes()),
+      cscSurvErrorToken_(iC.esConsumes()) {}
 
 MuonAlignmentInputSurveyDB::MuonAlignmentInputSurveyDB(std::string dtLabel,
                                                        std::string cscLabel,
-                                                       std::string idealLabel)
-    : m_dtLabel(dtLabel), m_cscLabel(cscLabel), idealGeometryLabel(idealLabel) {}
+                                                       std::string idealLabel,
+                                                       edm::ConsumesCollector iC)
+    : m_dtLabel(dtLabel),
+      m_cscLabel(cscLabel),
+      idealGeometryLabel(idealLabel),
+      dtGeomToken_(iC.esConsumes(edm::ESInputTag("", idealGeometryLabel))),
+      cscGeomToken_(iC.esConsumes(edm::ESInputTag("", idealGeometryLabel))),
+      gemGeomToken_(iC.esConsumes(edm::ESInputTag("", idealGeometryLabel))),
+      dtSurveyToken_(iC.esConsumes()),
+      dtSurvErrorToken_(iC.esConsumes()),
+      cscSurveyToken_(iC.esConsumes()),
+      cscSurvErrorToken_(iC.esConsumes()) {}
 
 // MuonAlignmentInputSurveyDB::MuonAlignmentInputSurveyDB(const MuonAlignmentInputSurveyDB& rhs)
 // {
@@ -69,18 +82,17 @@ AlignableMuon* MuonAlignmentInputSurveyDB::newAlignableMuon(const edm::EventSetu
   edm::ESHandle<DTGeometry> dtGeometry;
   edm::ESHandle<CSCGeometry> cscGeometry;
   edm::ESHandle<GEMGeometry> gemGeometry;
-  iSetup.get<MuonGeometryRecord>().get(idealGeometryLabel, dtGeometry);
-  iSetup.get<MuonGeometryRecord>().get(idealGeometryLabel, cscGeometry);
-  iSetup.get<MuonGeometryRecord>().get(idealGeometryLabel, gemGeometry);
-
   edm::ESHandle<Alignments> dtSurvey;
   edm::ESHandle<SurveyErrors> dtSurveyError;
   edm::ESHandle<Alignments> cscSurvey;
   edm::ESHandle<SurveyErrors> cscSurveyError;
-  iSetup.get<DTSurveyRcd>().get(m_dtLabel, dtSurvey);
-  iSetup.get<DTSurveyErrorExtendedRcd>().get(m_dtLabel, dtSurveyError);
-  iSetup.get<CSCSurveyRcd>().get(m_cscLabel, cscSurvey);
-  iSetup.get<CSCSurveyErrorExtendedRcd>().get(m_cscLabel, cscSurveyError);
+  dtGeometry = iSetup.getHandle(dtGeomToken_);
+  cscGeometry = iSetup.getHandle(cscGeomToken_);
+  gemGeometry = iSetup.getHandle(gemGeomToken_);
+  dtSurvey = iSetup.getHandle(dtSurveyToken_);
+  dtSurveyError = iSetup.getHandle(dtSurvErrorToken_);
+  cscSurvey = iSetup.getHandle(cscSurveyToken_);
+  cscSurveyError = iSetup.getHandle(cscSurvErrorToken_);
 
   AlignableMuon* output = new AlignableMuon(&(*dtGeometry), &(*cscGeometry), &(*gemGeometry));
 

--- a/Alignment/MuonAlignment/src/MuonAlignmentInputXML.cc
+++ b/Alignment/MuonAlignment/src/MuonAlignmentInputXML.cc
@@ -11,11 +11,8 @@
 //$Id: MuonAlignmentInputXML.cc,v 1.16 2011/03/22 09:49:50 innocent Exp $
 //
 
-// system include files
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "Utilities/Xerces/interface/Xerces.h"
-
-// Xerces include files
 #include "xercesc/parsers/XercesDOMParser.hpp"
 #include "xercesc/dom/DOM.hpp"
 #include "xercesc/sax/HandlerBase.hpp"
@@ -23,8 +20,6 @@
 #include "xercesc/util/PlatformUtils.hpp"
 #include "xercesc/util/XercesDefs.hpp"
 XERCES_CPP_NAMESPACE_USE
-
-// user include files
 #include "Alignment/MuonAlignment/interface/MuonAlignmentInputXML.h"
 #include "Alignment/CommonAlignment/interface/StructureType.h"
 #include "Alignment/CommonAlignment/interface/AlignableObjectId.h"
@@ -45,8 +40,14 @@ XERCES_CPP_NAMESPACE_USE
 //
 // constructors and destructor
 //
-MuonAlignmentInputXML::MuonAlignmentInputXML(const std::string &fileName, std::string idealLabel)
-    : m_fileName(fileName), idealGeometryLabel(idealLabel) {
+MuonAlignmentInputXML::MuonAlignmentInputXML(const std::string &fileName,
+                                             std::string idealLabel,
+                                             edm::ConsumesCollector iC)
+    : m_fileName(fileName),
+      idealGeometryLabel(idealLabel),
+      dtGeomToken_(iC.esConsumes(edm::ESInputTag("", idealGeometryLabel))),
+      cscGeomToken_(iC.esConsumes(edm::ESInputTag("", idealGeometryLabel))),
+      gemGeomToken_(iC.esConsumes(edm::ESInputTag("", idealGeometryLabel))) {
   cms::concurrency::xercesInitialize();
   str_operation = XMLString::transcode("operation");
   str_collection = XMLString::transcode("collection");
@@ -257,9 +258,9 @@ AlignableMuon *MuonAlignmentInputXML::newAlignableMuon(const edm::EventSetup &iS
   edm::ESHandle<DTGeometry> dtGeometry;
   edm::ESHandle<CSCGeometry> cscGeometry;
   edm::ESHandle<GEMGeometry> gemGeometry;
-  iSetup.get<MuonGeometryRecord>().get(idealGeometryLabel, dtGeometry);
-  iSetup.get<MuonGeometryRecord>().get(idealGeometryLabel, cscGeometry);
-  iSetup.get<MuonGeometryRecord>().get(idealGeometryLabel, gemGeometry);
+  dtGeometry = iSetup.getHandle(dtGeomToken_);
+  cscGeometry = iSetup.getHandle(cscGeomToken_);
+  gemGeometry = iSetup.getHandle(gemGeomToken_);
 
   AlignableMuon *alignableMuon = new AlignableMuon(&(*dtGeometry), &(*cscGeometry), &(*gemGeometry));
   std::map<unsigned int, Alignable *> alignableNavigator;  // real AlignableNavigators don't have const methods

--- a/Alignment/MuonAlignment/test/TestAlign.cpp
+++ b/Alignment/MuonAlignment/test/TestAlign.cpp
@@ -12,8 +12,7 @@
 
 // user include files
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "Alignment/MuonAlignment/interface/MuonAlignment.h"
@@ -28,7 +27,7 @@
 // class declaration
 //
 
-class TestAlign : public edm::EDAnalyzer {
+class TestAlign : public edm::one::EDAnalyzer<> {
 public:
   explicit TestAlign(const edm::ParameterSet&);
 
@@ -37,6 +36,7 @@ public:
   virtual void analyze(const edm::Event&, const edm::EventSetup&);
 
 private:
+  edm::ConsumesCollector m_cc;
   //typedef Surface::RotationType    RotationType;
   //typedef Surface::PositionType    PositionType;
 };
@@ -44,13 +44,15 @@ private:
 //
 // constructors and destructor
 //
-TestAlign::TestAlign(const edm::ParameterSet& iConfig) { edm::LogInfo("MuonAlignment") << "Starting!"; }
+TestAlign::TestAlign(const edm::ParameterSet& iConfig) : m_cc(consumesCollector()) {
+  edm::LogInfo("MuonAlignment") << "Starting!";
+}
 
 TestAlign::~TestAlign() { edm::LogInfo("MuonAlignment") << "Ending!"; }
 
 void TestAlign::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // Instantiate the helper class
-  MuonAlignment align(iSetup);
+  MuonAlignment align(iSetup, m_cc);
 
   // Get the AlignableMuon pointer
   AlignableMuon* theAlignableMuon = align.getAlignableMuon();

--- a/Alignment/MuonAlignment/test/muonGeometryDBConverter_cfg.py
+++ b/Alignment/MuonAlignment/test/muonGeometryDBConverter_cfg.py
@@ -34,121 +34,53 @@ process.load("Geometry.MuonNumbering.muonNumberingInitialization_cfi")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 process.load("Alignment.MuonAlignment.muonGeometryDBConverter_cfi")
 
-process.DTGeometryAlInputMethod = cms.ESProducer("DTGeometryESModule",
-    appendToDataLabel = cms.string('idealForInputMethod'),
-    applyAlignment = cms.bool(False),
-    alignmentsLabel = cms.string(''),
-    fromDDD = cms.bool(True)
-)
+import Geometry.DTGeometryBuilder.dtGeometryDB_cfi
+import Geometry.CSCGeometryBuilder.cscGeometryDB_cfi
+import Geometry.GEMGeometryBuilder.gemGeometryDB_cfi
+process.DTGeometryIdealForInputMethod = Geometry.DTGeometryBuilder.dtGeometryDB_cfi.DTGeometryESModule.clone()
+process.DTGeometryIdealForInputMethod.appendToDataLabel = 'idealForInputMethod'
+process.DTGeometryIdealForInputMethod.applyAlignment = cms.bool(False)
+process.CSCGeometryIdealForInputMethod = Geometry.CSCGeometryBuilder.cscGeometryDB_cfi.CSCGeometryESModule.clone()
+process.CSCGeometryIdealForInputMethod.appendToDataLabel = 'idealForInputMethod'
+process.CSCGeometryIdealForInputMethod.applyAlignment = cms.bool(False)
+process.GEMGeometryIdealForInputMethod = Geometry.GEMGeometryBuilder.gemGeometryDB_cfi.GEMGeometryESModule.clone()
+process.GEMGeometryIdealForInputMethod.appendToDataLabel = 'idealForInputMethod'
+process.GEMGeometryIdealForInputMethod.applyAlignment = cms.bool(False)
 
-process.CSCGeometryAlInputMethod = cms.ESProducer("CSCGeometryESModule",
-    appendToDataLabel = cms.string('idealForInputMethod'),
-    debugV = cms.untracked.bool(False),
-    useGangedStripsInME1a = cms.bool(False),
-    alignmentsLabel = cms.string(''),
-    useOnlyWiresInME1a = cms.bool(False),
-    useRealWireGeometry = cms.bool(True),
-    useCentreTIOffsets = cms.bool(False),
-    applyAlignment = cms.bool(False),
-    fromDDD = cms.bool(True),
-    fromDD4hep = cms.bool(False)
-)
+process.DTGeometryIdealForInputDB = Geometry.DTGeometryBuilder.dtGeometryDB_cfi.DTGeometryESModule.clone()
+process.DTGeometryIdealForInputDB.appendToDataLabel = 'idealForInputDB'
+process.DTGeometryIdealForInputDB.applyAlignment = cms.bool(False)
+process.CSCGeometryIdealForInputDB = Geometry.CSCGeometryBuilder.cscGeometryDB_cfi.CSCGeometryESModule.clone()
+process.CSCGeometryIdealForInputDB.appendToDataLabel = 'idealForInputDB'
+process.CSCGeometryIdealForInputDB.applyAlignment = cms.bool(False)
+process.GEMGeometryIdealForInputDB = Geometry.GEMGeometryBuilder.gemGeometryDB_cfi.GEMGeometryESModule.clone()
+process.GEMGeometryIdealForInputDB.appendToDataLabel = 'idealForInputDB'
+process.GEMGeometryIdealForInputDB.applyAlignment = cms.bool(False)
 
-process.GEMGeometryAlInputMethod = cms.ESProducer("GEMGeometryESModule",
-    appendToDataLabel = cms.string('idealForInputMethod'),
-    fromDDD = cms.bool(True),
-    fromDD4Hep = cms.bool(False),
-    alignmentsLabel = cms.string(''),
-    applyAlignment = cms.bool(False)
-)
+process.DTGeometryIdealForInputXML = Geometry.DTGeometryBuilder.dtGeometryDB_cfi.DTGeometryESModule.clone()
+process.DTGeometryIdealForInputXML.appendToDataLabel = 'idealForInputXML'
+process.DTGeometryIdealForInputXML.applyAlignment = cms.bool(False)
+process.CSCGeometryIdealForInputXML = Geometry.CSCGeometryBuilder.cscGeometryDB_cfi.CSCGeometryESModule.clone()
+process.CSCGeometryIdealForInputXML.appendToDataLabel = 'idealForInputXML'
+process.CSCGeometryIdealForInputXML.applyAlignment = cms.bool(False)
+process.GEMGeometryIdealForInputXML = Geometry.GEMGeometryBuilder.gemGeometryDB_cfi.GEMGeometryESModule.clone()
+process.GEMGeometryIdealForInputXML.appendToDataLabel = 'idealForInputXML'
+process.GEMGeometryIdealForInputXML.applyAlignment = cms.bool(False)
 
-process.DTGeometryAlInputDB = cms.ESProducer("DTGeometryESModule",
-    appendToDataLabel = cms.string('idealForInputDB'),
-    applyAlignment = cms.bool(False),
-    alignmentsLabel = cms.string(''),
-    fromDDD = cms.bool(True)
-)
+process.DTGeometryIdealForInputSurveyDB = Geometry.DTGeometryBuilder.dtGeometryDB_cfi.DTGeometryESModule.clone()
+process.DTGeometryIdealForInputSurveyDB.appendToDataLabel = 'idealForInputSurveyDB'
+process.DTGeometryIdealForInputSurveyDB.applyAlignment = cms.bool(False)
+process.CSCGeometryIdealForInputSurveyDB = Geometry.CSCGeometryBuilder.cscGeometryDB_cfi.CSCGeometryESModule.clone()
+process.CSCGeometryIdealForInputSurveyDB.appendToDataLabel = 'idealForInputSurveyDB'
+process.CSCGeometryIdealForInputSurveyDB.applyAlignment = cms.bool(False)
+process.GEMGeometryIdealForInputSurveyDB = Geometry.GEMGeometryBuilder.gemGeometryDB_cfi.GEMGeometryESModule.clone()
+process.GEMGeometryIdealForInputSurveyDB.appendToDataLabel = 'idealForInputSurveyDB'
+process.GEMGeometryIdealForInputSurveyDB.applyAlignment = cms.bool(False)
 
-process.CSCGeometryAlInputDB = cms.ESProducer("CSCGeometryESModule",
-    appendToDataLabel = cms.string('idealForInputDB'),
-    debugV = cms.untracked.bool(False),
-    useGangedStripsInME1a = cms.bool(False),
-    alignmentsLabel = cms.string(''),
-    useOnlyWiresInME1a = cms.bool(False),
-    useRealWireGeometry = cms.bool(True),
-    useCentreTIOffsets = cms.bool(False),
-    applyAlignment = cms.bool(False),
-    fromDDD = cms.bool(True),
-    fromDD4hep = cms.bool(False)
-)
-
-process.GEMGeometryAlInputDB = cms.ESProducer("GEMGeometryESModule",
-    appendToDataLabel = cms.string('idealForInputDB'),
-    fromDDD = cms.bool(True),
-    fromDD4Hep = cms.bool(False),
-    alignmentsLabel = cms.string(''),
-    applyAlignment = cms.bool(False)
-)
-
-process.DTGeometryAlOutputXML = cms.ESProducer("DTGeometryESModule",
-    appendToDataLabel = cms.string('idealForOutputXML'),
-    applyAlignment = cms.bool(False),
-    alignmentsLabel = cms.string(''),
-    fromDDD = cms.bool(True)
-)
-
-process.CSCGeometryAlOutputXML = cms.ESProducer("CSCGeometryESModule",
-    appendToDataLabel = cms.string('idealForOutputXML'),
-    debugV = cms.untracked.bool(False),
-    useGangedStripsInME1a = cms.bool(False),
-    alignmentsLabel = cms.string(''),
-    useOnlyWiresInME1a = cms.bool(False),
-    useRealWireGeometry = cms.bool(True),
-    useCentreTIOffsets = cms.bool(False),
-    applyAlignment = cms.bool(False),
-    fromDDD = cms.bool(True),
-    fromDD4hep = cms.bool(False)
-)
-
-process.GEMGeometryAlOutputXML = cms.ESProducer("GEMGeometryESModule",
-    appendToDataLabel = cms.string('idealForOutputXML'),
-    fromDDD = cms.bool(True),
-    fromDD4Hep = cms.bool(False),
-    alignmentsLabel = cms.string(''),
-    applyAlignment = cms.bool(False)
-)
-
-process.DTGeometryAlInputXML = cms.ESProducer("DTGeometryESModule",
-    appendToDataLabel = cms.string('idealForInputXML'),
-    applyAlignment = cms.bool(False),
-    alignmentsLabel = cms.string(''),
-    fromDDD = cms.bool(True)
-)
-
-process.CSCGeometryAlInputXML = cms.ESProducer("CSCGeometryESModule",
-    appendToDataLabel = cms.string('idealForInputXML'),
-    debugV = cms.untracked.bool(False),
-    useGangedStripsInME1a = cms.bool(False),
-    alignmentsLabel = cms.string(''),
-    useOnlyWiresInME1a = cms.bool(False),
-    useRealWireGeometry = cms.bool(True),
-    useCentreTIOffsets = cms.bool(False),
-    applyAlignment = cms.bool(False),
-    fromDDD = cms.bool(True),
-    fromDD4hep = cms.bool(False)
-)
-
-process.GEMGeometryAlInputXML = cms.ESProducer("GEMGeometryESModule",
-    appendToDataLabel = cms.string('idealForInputXML'),
-    fromDDD = cms.bool(True),
-    fromDD4Hep = cms.bool(False),
-    alignmentsLabel = cms.string(''),
-    applyAlignment = cms.bool(False)
-)
 ################################################################################
 # parameters to configure:
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, "auto:phase1_2017_design")
+process.GlobalTag = GlobalTag(process.GlobalTag, "auto:phase1_2021_design")
 process.muonGeometryDBConverter.input = options.input
 process.muonGeometryDBConverter.output = options.output
 

--- a/Alignment/SurveyAnalysis/plugins/DTSurveyConvert.cc
+++ b/Alignment/SurveyAnalysis/plugins/DTSurveyConvert.cc
@@ -6,7 +6,8 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "Alignment/SurveyAnalysis/plugins/DTSurveyConvert.h"
 
-DTSurveyConvert::DTSurveyConvert(const edm::ParameterSet &iConfig) : muonGeoToken_(esConsumes()) {
+DTSurveyConvert::DTSurveyConvert(const edm::ParameterSet &iConfig)
+    : muonGeoToken_(esConsumes()), m_cc(consumesCollector()) {
   //now do what ever initialization is needed
   nameWheel_m2 = iConfig.getUntrackedParameter<std::string>("nameWheel_m2");
   nameWheel_m1 = iConfig.getUntrackedParameter<std::string>("nameWheel_m1");
@@ -75,7 +76,7 @@ void DTSurveyConvert::analyze(const edm::Event &, const edm::EventSetup &iSetup)
 
   if (WriteToDB == true) {
     // Instantiate the helper class
-    MuonAlignment align(iSetup);
+    MuonAlignment align(iSetup, m_cc);
     std::ifstream inFile(outputFileName.c_str());
     while (!inFile.eof()) {
       float dx, dy, dz, sigma_dx, sigma_dy, sigma_dz;

--- a/Alignment/SurveyAnalysis/plugins/DTSurveyConvert.h
+++ b/Alignment/SurveyAnalysis/plugins/DTSurveyConvert.h
@@ -34,6 +34,8 @@ private:
 
   const edm::ESGetToken<DTGeometry, MuonGeometryRecord> muonGeoToken_;
 
+  edm::ConsumesCollector m_cc;
+
   std::vector<DTSurvey *> wheelList;
   std::string nameWheel_m2;
   std::string nameWheel_m1;


### PR DESCRIPTION
#### PR description:
esConsumes migration for the muon alignment modules.


#### PR validation:
PR has an issue.

I try to use ```consumesCollector()``` for Alignment/MuonAlignment/plugins/MuonGeometryDBConverter.cc (https://github.com/hyunyong/cmssw/blob/76328c9d2b24b0365d41fbff38ac6208e590e249/Alignment/MuonAlignment/plugins/MuonGeometryDBConverter.cc#L93)
However, es tokens are initialized at https://github.com/hyunyong/cmssw/blob/76328c9d2b24b0365d41fbff38ac6208e590e249/Alignment/MuonAlignment/plugins/MuonGeometryDBConverter.cc#L168

I guess this is the reason why I got this issue.

```
A module declared it consumes an EventSetup product after its constructor.
This must be done in the constructor
```
