### PR TITLE
Enable mkFit by default in 4+2 tracking iterations (initialStepPreSpl…

### DIFF
--- a/Configuration/Eras/python/ModifierChain_trackingMkFitProd_cff.py
+++ b/Configuration/Eras/python/ModifierChain_trackingMkFitProd_cff.py
@@ -6,6 +6,8 @@ from Configuration.ProcessModifiers.trackingMkFitInitialStepPreSplitting_cff imp
 from Configuration.ProcessModifiers.trackingMkFitInitialStep_cff import *
 from Configuration.ProcessModifiers.trackingMkFitHighPtTripletStep_cff import *
 from Configuration.ProcessModifiers.trackingMkFitDetachedQuadStep_cff import *
+from Configuration.ProcessModifiers.trackingMkFitDetachedTripletStep_cff import *
+from Configuration.ProcessModifiers.trackingMkFitPixelLessStep_cff import *
 
 trackingMkFitProd =  cms.ModifierChain(
     trackingMkFitCommon,
@@ -13,4 +15,6 @@ trackingMkFitProd =  cms.ModifierChain(
     trackingMkFitInitialStep,
     trackingMkFitHighPtTripletStep,
     trackingMkFitDetachedQuadStep,
+    trackingMkFitDetachedTripletStep,
+    trackingMkFitPixelLessStep,
 )


### PR DESCRIPTION
### PR description:

Following PR #35457, this PR enables mkFit for tracking in 4 (initialStepPreSplitting, initialStep, highPtTripletStep, detachedQuadStep) + 2 (detachedTripletStep, pixelLessStep) tracking iterations for the entire era of Phase-1 pixel detector (i.e. from 2017 to end of Run 3), except for HI eras (Run2_2017_pp_on_XeXe, Run2_2017_ppRef, Run2_2018_pp_on_AA, Run2_2018_pp_on_AA_noHCALmitigation, Run3_pp_on_PbPb) and 2017 special tracking eras (Run2_2017_trackingLowPU, Run2_2017_trackingRun2), following the plan presented in https://indico.cern.ch/event/1082441/#1-news

Note: the first 4 iterations were already enabled in PR #35457; this PR enables 2 additional iterations.

### PR validation:

The performance of tracking after this PR, together with PR #35652 and PR #35686 (updated as suggested [here](https://github.com/cms-sw/cmssw/pull/35686/files#r730469513)) follows:
http://uaf-10.t2.ucsd.edu/~mmasciov/MkFit_devs/PRvalidation_Oct13/MTV_PR35660_mkFit-6iter_DNNfinalWP_afterPR35652/
Looking at out-of-the-box high-purity tracks (http://uaf-10.t2.ucsd.edu/~mmasciov/MkFit_devs/PRvalidation_Oct13/MTV_PR35660_mkFit-6iter_DNNfinalWP_afterPR35652/plots_highPurity/effandfakePtEtaPhi.pdf), efficiency is (much) improved (at low track pT), with overall lower fake+duplicate rate.


