### PR TITLE
Template PFTowers to run on packedCandidates

### DIFF
--- a/PhysicsTools/PatAlgos/python/producersHeavyIons/heavyIonJets_cff.py
+++ b/PhysicsTools/PatAlgos/python/producersHeavyIons/heavyIonJets_cff.py
@@ -52,7 +52,6 @@ from RecoBTag.ImpactParameter.trackCounting3D3rdComputer_cfi import *
 from PhysicsTools.PatAlgos.recoLayer0.jetCorrFactors_cfi import *
 
 recoPFJetsHIpostAODTask = cms.Task(
-    #PFTowers,
     PackedPFTowers,
     pfEmptyCollection,
     ak4PFJetsForFlow,

--- a/PhysicsTools/PatAlgos/python/producersHeavyIons/heavyIonJets_cff.py
+++ b/PhysicsTools/PatAlgos/python/producersHeavyIons/heavyIonJets_cff.py
@@ -36,7 +36,6 @@ genJetSubEvent.toReplaceWith(hiGenJetsTask,hiCleanedGenJetsTask_)
 
 from RecoHI.HiJetAlgos.PackedPFTowers_cfi import PackedPFTowers
 from RecoHI.HiJetAlgos.HiRecoPFJets_cff import pfEmptyCollection, ak4PFJetsForFlow, hiPuRho, hiFJRhoFlowModulation, akCs4PFJets
-hiPuRho.src = "PackedPFTowers"
 from RecoHI.HiTracking.highPurityGeneralTracks_cfi import highPurityGeneralTracks
 from RecoJets.JetAssociationProducers.ak5JTA_cff import *
 from RecoBTag.Configuration.RecoBTag_cff import impactParameterTagInfos, trackCountingHighEffBJetTags, trackCountingHighPurBJetTags, jetProbabilityBJetTags, jetBProbabilityBJetTags, secondaryVertexTagInfos, combinedSecondaryVertexV2BJetTags, simpleSecondaryVertexHighEffBJetTags, simpleSecondaryVertexHighPurBJetTags

--- a/PhysicsTools/PatAlgos/python/producersHeavyIons/heavyIonJets_cff.py
+++ b/PhysicsTools/PatAlgos/python/producersHeavyIons/heavyIonJets_cff.py
@@ -34,7 +34,9 @@ hiCleanedGenJetsTask_ = hiGenJetsTask.copyAndExclude([hiSignalGenParticles,ak4Hi
 hiCleanedGenJetsTask_.add(cleanedPartons,ak4HiGenJetsCleaned)
 genJetSubEvent.toReplaceWith(hiGenJetsTask,hiCleanedGenJetsTask_)
 
-from RecoHI.HiJetAlgos.HiRecoPFJets_cff import PFTowers, pfEmptyCollection, ak4PFJetsForFlow, hiPuRho, hiFJRhoFlowModulation, akCs4PFJets
+from RecoHI.HiJetAlgos.PackedPFTowers_cfi import PackedPFTowers
+from RecoHI.HiJetAlgos.HiRecoPFJets_cff import pfEmptyCollection, ak4PFJetsForFlow, hiPuRho, hiFJRhoFlowModulation, akCs4PFJets
+hiPuRho.src = "PackedPFTowers"
 from RecoHI.HiTracking.highPurityGeneralTracks_cfi import highPurityGeneralTracks
 from RecoJets.JetAssociationProducers.ak5JTA_cff import *
 from RecoBTag.Configuration.RecoBTag_cff import impactParameterTagInfos, trackCountingHighEffBJetTags, trackCountingHighPurBJetTags, jetProbabilityBJetTags, jetBProbabilityBJetTags, secondaryVertexTagInfos, combinedSecondaryVertexV2BJetTags, simpleSecondaryVertexHighEffBJetTags, simpleSecondaryVertexHighPurBJetTags
@@ -50,7 +52,8 @@ from RecoBTag.ImpactParameter.trackCounting3D3rdComputer_cfi import *
 from PhysicsTools.PatAlgos.recoLayer0.jetCorrFactors_cfi import *
 
 recoPFJetsHIpostAODTask = cms.Task(
-    PFTowers,
+    #PFTowers,
+    PackedPFTowers,
     pfEmptyCollection,
     ak4PFJetsForFlow,
     hiFJRhoFlowModulation,

--- a/RecoHI/HiJetAlgos/plugins/ParticleTowerProducer.cc
+++ b/RecoHI/HiJetAlgos/plugins/ParticleTowerProducer.cc
@@ -29,6 +29,7 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
@@ -44,6 +45,7 @@
 #include <map>
 #include <utility>
 
+template < class T > 
 class ParticleTowerProducer : public edm::stream::EDProducer<> {
 public:
   explicit ParticleTowerProducer(const edm::ParameterSet&);
@@ -57,7 +59,7 @@ private:
   double iphi2phi(int iphi, int ieta) const;
   // ----------member data ---------------------------
 
-  edm::EDGetTokenT<reco::PFCandidateCollection> src_;
+  edm::EDGetTokenT< typename edm::View<T> > src_;
   const bool useHF_;
 
   // tower edges from fast sim, used starting at index 30 for the HF
@@ -66,9 +68,10 @@ private:
 //
 // constructors and destructor
 //
-ParticleTowerProducer::ParticleTowerProducer(const edm::ParameterSet& iConfig)
-    : src_(consumes<reco::PFCandidateCollection>(iConfig.getParameter<edm::InputTag>("src"))),
-      useHF_(iConfig.getParameter<bool>("useHF")) {
+template <class T>
+ParticleTowerProducer<T>::ParticleTowerProducer(const edm::ParameterSet& iConfig)
+  : src_(consumes< typename edm::View<T> >(iConfig.getParameter<edm::InputTag>("src"))),
+    useHF_(iConfig.getParameter<bool>("useHF")) {
   produces<CaloTowerCollection>();
 }
 
@@ -77,7 +80,8 @@ ParticleTowerProducer::ParticleTowerProducer(const edm::ParameterSet& iConfig)
 //
 
 // ------------ method called to produce the data  ------------
-void ParticleTowerProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+template <class T>
+void ParticleTowerProducer<T>::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
 
   typedef std::pair<int, int> EtaPhi;
@@ -122,7 +126,8 @@ void ParticleTowerProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
 
 // Taken from FastSimulation/CalorimeterProperties/src/HCALProperties.cc
 // Note this returns an abs(ieta)
-int ParticleTowerProducer::eta2ieta(double eta) const {
+template <class T>
+int ParticleTowerProducer<T>::eta2ieta(double eta) const {
   // binary search in the array of towers eta edges
 
   int ieta = 1;
@@ -136,7 +141,8 @@ int ParticleTowerProducer::eta2ieta(double eta) const {
   return ieta;
 }
 
-int ParticleTowerProducer::phi2iphi(double phi, int ieta) const {
+template <class T>
+int ParticleTowerProducer<T>::phi2iphi(double phi, int ieta) const {
   phi = angle0to2pi::make0To2pi(phi);
   int nphi = 72;
   int n = 1;
@@ -152,7 +158,8 @@ int ParticleTowerProducer::phi2iphi(double phi, int ieta) const {
   return iphi;
 }
 
-double ParticleTowerProducer::iphi2phi(int iphi, int ieta) const {
+template <class T>
+double ParticleTowerProducer<T>::iphi2phi(int iphi, int ieta) const {
   double phi = 0;
   int nphi = 72;
 
@@ -171,7 +178,8 @@ double ParticleTowerProducer::iphi2phi(int iphi, int ieta) const {
   return phi;
 }
 
-double ParticleTowerProducer::ieta2eta(int ieta) const {
+template <class T>
+double ParticleTowerProducer<T>::ieta2eta(int ieta) const {
   int sign = 1;
   if (ieta < 0) {
     sign = -1;
@@ -182,13 +190,23 @@ double ParticleTowerProducer::ieta2eta(int ieta) const {
   return eta;
 }
 
-void ParticleTowerProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-  // particleTowerProducer
+template <class T>
+void ParticleTowerProducer<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("src", edm::InputTag("particleFlow"));
   desc.add<bool>("useHF", true);
-  descriptions.add("particleTowerProducer", desc);
+  if (typeid(T) == typeid(reco::PFCandidate)) {
+    desc.add<edm::InputTag>("src", edm::InputTag("particleFlow"));
+    descriptions.add("PFTowers", desc);
+  }
+  if (typeid(T) == typeid(pat::PackedCandidate)) {
+    desc.add<edm::InputTag>("src", edm::InputTag("packedPFCandidates"));
+    descriptions.add("PackedPFTowers", desc);
+  }
 }
 
+using PFTowers = ParticleTowerProducer<reco::PFCandidate>;
+using PackedPFTowers = ParticleTowerProducer<pat::PackedCandidate>;
+
 // define this as a plug-in
-DEFINE_FWK_MODULE(ParticleTowerProducer);
+DEFINE_FWK_MODULE(PFTowers);
+DEFINE_FWK_MODULE(PackedPFTowers);

--- a/RecoHI/HiJetAlgos/plugins/ParticleTowerProducer.cc
+++ b/RecoHI/HiJetAlgos/plugins/ParticleTowerProducer.cc
@@ -45,7 +45,7 @@
 #include <map>
 #include <utility>
 
-template < class T > 
+template <class T>
 class ParticleTowerProducer : public edm::stream::EDProducer<> {
 public:
   explicit ParticleTowerProducer(const edm::ParameterSet&);
@@ -59,7 +59,7 @@ private:
   double iphi2phi(int iphi, int ieta) const;
   // ----------member data ---------------------------
 
-  edm::EDGetTokenT< typename edm::View<T> > src_;
+  edm::EDGetTokenT<typename edm::View<T> > src_;
   const bool useHF_;
 
   // tower edges from fast sim, used starting at index 30 for the HF
@@ -70,8 +70,8 @@ private:
 //
 template <class T>
 ParticleTowerProducer<T>::ParticleTowerProducer(const edm::ParameterSet& iConfig)
-  : src_(consumes< typename edm::View<T> >(iConfig.getParameter<edm::InputTag>("src"))),
-    useHF_(iConfig.getParameter<bool>("useHF")) {
+    : src_(consumes<typename edm::View<T> >(iConfig.getParameter<edm::InputTag>("src"))),
+      useHF_(iConfig.getParameter<bool>("useHF")) {
   produces<CaloTowerCollection>();
 }
 

--- a/RecoHI/HiJetAlgos/python/HiRecoPFJets_cff.py
+++ b/RecoHI/HiJetAlgos/python/HiRecoPFJets_cff.py
@@ -119,3 +119,4 @@ hiRecoPFJets = cms.Sequence(hiRecoPFJetsTask)
 from Configuration.ProcessModifiers.run2_miniAOD_pp_on_AA_103X_cff import run2_miniAOD_pp_on_AA_103X
 run2_miniAOD_pp_on_AA_103X.toModify(akCs4PFJets,src = 'cleanedParticleFlow')
 run2_miniAOD_pp_on_AA_103X.toModify(PFTowers,src = 'cleanedParticleFlow')
+run2_miniAOD_pp_on_AA_103X.toModify(hiPuRho,src = "PackedPFTowers")

--- a/RecoHI/HiJetAlgos/python/HiRecoPFJets_cff.py
+++ b/RecoHI/HiJetAlgos/python/HiRecoPFJets_cff.py
@@ -5,8 +5,7 @@ from RecoJets.JetProducers.AnomalousCellParameters_cfi import *
 from RecoHI.HiJetAlgos.HiPFJetParameters_cff import *
 
 #pseudo towers for noise suppression background subtraction
-import RecoHI.HiJetAlgos.particleTowerProducer_cfi as _mod
-PFTowers = _mod.particleTowerProducer.clone(useHF = True)
+from RecoHI.HiJetAlgos.PFTowers_cfi import PFTowers
 
 #dummy sequence to speed-up reconstruction in pp_on_AA era
 pfEmptyCollection = cms.EDFilter('GenericPFCandidateSelector',


### PR DESCRIPTION
#### PR description:

PFTowers is templated to run with input pat::packedCandidate, instead of just reco::PFCandidate.
This allows us to rerun the full heavy-ion jet clustering sequence on miniAOD.
In the re-miniAOD workflows (158.01 and 140.5611 in the RelVal matrix) both the PFCandidates and packedPFCandidates are present. 
This PR switches the input to the packed candidates such that this input is tested.


#### PR validation:

Tested on 158.01

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport is foreseen


