### PR TITLE
Fixed deprecated warnings in some GeneratorInterface packages

### DIFF
--- a/GeneratorInterface/Core/interface/GeneratorFilter.h
+++ b/GeneratorInterface/Core/interface/GeneratorFilter.h
@@ -21,6 +21,7 @@
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/RandomEngineSentry.h"
 #include "FWCore/Utilities/interface/EDMException.h"
@@ -100,7 +101,7 @@ namespace edm {
     if (ps.exists("ExternalDecays")) {
       //decayer_ = new gen::ExternalDecayDriver(ps.getParameter<ParameterSet>("ExternalDecays"));
       ParameterSet ps1 = ps.getParameter<ParameterSet>("ExternalDecays");
-      decayer_ = new Decayer(ps1);
+      decayer_ = new Decayer(ps1, consumesCollector());
 
       std::vector<std::string> const& sharedResourcesDec = decayer_->sharedResources();
       for (auto const& resource : sharedResourcesDec) {

--- a/GeneratorInterface/Core/interface/HadronizerFilter.h
+++ b/GeneratorInterface/Core/interface/HadronizerFilter.h
@@ -21,6 +21,7 @@
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/RandomEngineSentry.h"
 #include "FWCore/Utilities/interface/BranchType.h"
@@ -131,7 +132,7 @@ namespace edm {
     if (ps.exists("ExternalDecays")) {
       //decayer_ = new gen::ExternalDecayDriver(ps.getParameter<ParameterSet>("ExternalDecays"));
       ParameterSet ps1 = ps.getParameter<ParameterSet>("ExternalDecays");
-      decayer_ = new Decayer(ps1);
+      decayer_ = new Decayer(ps1, consumesCollector());
 
       std::vector<std::string> const& sharedResourcesDec = decayer_->sharedResources();
       for (auto const& resource : sharedResourcesDec) {

--- a/GeneratorInterface/Core/interface/PythiaHepMCFilterGammaGamma.h
+++ b/GeneratorInterface/Core/interface/PythiaHepMCFilterGammaGamma.h
@@ -11,7 +11,6 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "GeneratorInterface/Core/interface/BaseHepMCFilter.h"
-#include "FWCore/Framework/interface/EDFilter.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/GeneratorInterface/Core/test/FailingGeneratorFilter.cc
+++ b/GeneratorInterface/Core/test/FailingGeneratorFilter.cc
@@ -108,7 +108,7 @@ namespace test {
 
   class DummyDec {
   public:
-    DummyDec(const edm::ParameterSet&) {}
+    DummyDec(const edm::ParameterSet&, edm::ConsumesCollector) {}
     std::vector<std::string> sharedResources() const { return {}; }
 
     HepMC::GenEvent* decay(HepMC::GenEvent const*) { return nullptr; }

--- a/GeneratorInterface/ExternalDecays/interface/ExternalDecayDriver.h
+++ b/GeneratorInterface/ExternalDecays/interface/ExternalDecayDriver.h
@@ -3,6 +3,7 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include <string>
 #include <vector>
@@ -28,7 +29,7 @@ namespace gen {
   class ExternalDecayDriver {
   public:
     // ctor & dtor
-    ExternalDecayDriver(const edm::ParameterSet&);
+    ExternalDecayDriver(const edm::ParameterSet&, edm::ConsumesCollector);
     ~ExternalDecayDriver();
 
     void init(const edm::EventSetup&);

--- a/GeneratorInterface/ExternalDecays/src/ExternalDecayDriver.cc
+++ b/GeneratorInterface/ExternalDecays/src/ExternalDecayDriver.cc
@@ -20,7 +20,8 @@
 using namespace gen;
 using namespace edm;
 
-ExternalDecayDriver::ExternalDecayDriver(const ParameterSet& pset) : fIsInitialized(false) {
+ExternalDecayDriver::ExternalDecayDriver(const ParameterSet& pset, edm::ConsumesCollector iCollector)
+    : fIsInitialized(false) {
   std::vector<std::string> extGenNames = pset.getParameter<std::vector<std::string> >("parameterSets");
 
   for (unsigned int ip = 0; ip < extGenNames.size(); ++ip) {
@@ -41,7 +42,7 @@ ExternalDecayDriver::ExternalDecayDriver(const ParameterSet& pset) : fIsInitiali
       exSharedResources.emplace_back(gen::FortranInstance::kFortranInstance);
     } else if (curSet == "Tauola" || curSet == "Tauolapp" || curSet == "Tauolapp114") {
       fTauolaInterface = std::unique_ptr<TauolaInterfaceBase>(
-          TauolaFactory::get()->create("Tauolapp114", pset.getUntrackedParameter<ParameterSet>(curSet)));
+          TauolaFactory::get()->create("Tauolapp114", pset.getUntrackedParameter<ParameterSet>(curSet), iCollector));
       fPhotosInterface = std::unique_ptr<PhotosInterfaceBase>(
           PhotosFactory::get()->create("Photos2155", pset.getUntrackedParameter<ParameterSet>(curSet)));
       fPhotosInterface->configureOnlyFor(15);

--- a/GeneratorInterface/Pythia6Interface/plugins/Pythia6EGun.cc
+++ b/GeneratorInterface/Pythia6Interface/plugins/Pythia6EGun.cc
@@ -5,7 +5,6 @@
 
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"

--- a/GeneratorInterface/Pythia6Interface/plugins/Pythia6Gun.cc
+++ b/GeneratorInterface/Pythia6Interface/plugins/Pythia6Gun.cc
@@ -9,8 +9,8 @@
 //#include "SimGeneral/HepPDTRecord/interface/ParticleDataTable.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Concurrency/interface/SharedResourceNames.h"
 
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
@@ -45,6 +45,7 @@ Pythia6Gun::Pythia6Gun(const ParameterSet& pset)
     throw edm::Exception(edm::errors::Configuration, "PythiaError") << " pythia did not accept MSTU(12)=12345";
   }
 
+  usesResource(edm::SharedResourceNames::kPythia6);
   produces<HepMCProduct>("unsmeared");
 }
 
@@ -83,6 +84,7 @@ void Pythia6Gun::beginLuminosityBlock(LuminosityBlock const& lumi, EventSetup co
   call_pyinit("NONE", "", "", 0.0);
 }
 
+void Pythia6Gun::endLuminosityBlock(LuminosityBlock const& lumi, EventSetup const&) {}
 void Pythia6Gun::endRun(Run const&, EventSetup const& es) {
   // here put in GenRunInfoProduct
 

--- a/GeneratorInterface/Pythia6Interface/plugins/Pythia6Gun.h
+++ b/GeneratorInterface/Pythia6Interface/plugins/Pythia6Gun.h
@@ -17,7 +17,7 @@
 #include "HepMC/GenEvent.h"
 
 // #include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 
 #include "GeneratorInterface/Pythia6Interface/interface/Pythia6Service.h"
 #include "GeneratorInterface/Pythia6Interface/interface/Pythia6Declarations.h"
@@ -37,12 +37,14 @@ namespace gen {
 
   // class Pythia6Service;
 
-  class Pythia6Gun : public edm::EDProducer {
+  class Pythia6Gun
+      : public edm::one::EDProducer<edm::one::WatchLuminosityBlocks, edm::one::WatchRuns, edm::one::SharedResources> {
   public:
     Pythia6Gun(const edm::ParameterSet&);
     ~Pythia6Gun() override;
     void beginJob() override;
     void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+    void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) final;
     void beginRun(edm::Run const&, edm::EventSetup const&) override;
     void endRun(edm::Run const&, edm::EventSetup const&) override;
     void produce(edm::Event&, const edm::EventSetup&) override;

--- a/GeneratorInterface/Pythia6Interface/plugins/Pythia6JetGun.cc
+++ b/GeneratorInterface/Pythia6Interface/plugins/Pythia6JetGun.cc
@@ -5,7 +5,6 @@
 
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"

--- a/GeneratorInterface/Pythia6Interface/plugins/Pythia6PartonEGun.cc
+++ b/GeneratorInterface/Pythia6Interface/plugins/Pythia6PartonEGun.cc
@@ -5,7 +5,6 @@
 
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"

--- a/GeneratorInterface/Pythia6Interface/plugins/Pythia6PartonPtGun.cc
+++ b/GeneratorInterface/Pythia6Interface/plugins/Pythia6PartonPtGun.cc
@@ -5,7 +5,6 @@
 
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"

--- a/GeneratorInterface/Pythia6Interface/plugins/Pythia6PtGun.cc
+++ b/GeneratorInterface/Pythia6Interface/plugins/Pythia6PtGun.cc
@@ -5,7 +5,6 @@
 
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"

--- a/GeneratorInterface/Pythia6Interface/plugins/Pythia6PtYDistGun.cc
+++ b/GeneratorInterface/Pythia6Interface/plugins/Pythia6PtYDistGun.cc
@@ -6,7 +6,6 @@
 
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"

--- a/GeneratorInterface/Pythia6Interface/test/BasicGenTester.cc
+++ b/GeneratorInterface/Pythia6Interface/test/BasicGenTester.cc
@@ -15,12 +15,12 @@
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 #include "TH1.h"
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "SimGeneral/HepPDTRecord/interface/ParticleDataTable.h"
 #include "HepPDT/ParticleDataTable.hh"
 
-class BasicGenTester : public edm::EDAnalyzer {
+class BasicGenTester : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::SharedResources> {
 public:
   //
   explicit BasicGenTester(const edm::ParameterSet&);
@@ -45,6 +45,7 @@ private:
   double fPtMin;
   double fPtMax;
   edm::ESHandle<HepPDT::ParticleDataTable> fPDGTable;
+  edm::ESGetToken<HepPDT::ParticleDataTable, edm::DefaultRecord> fPDGTableToken;
 };
 
 using namespace edm;
@@ -59,6 +60,9 @@ BasicGenTester::BasicGenTester(const ParameterSet& pset)
   fNPart = pset.getUntrackedParameter<int>("NPartForHisto", 500);
   fPtMin = pset.getUntrackedParameter<double>("PtMinForHisto", 0.);
   fPtMax = pset.getUntrackedParameter<double>("PtMaxForHisto", 25.);
+  usesResource(TFileService::kSharedResource);
+  fPDGTableToken = esConsumes<edm::Transition::BeginRun>();
+  consumes<HepMCProduct>(edm::InputTag("VtxSmeared"));
 }
 
 void BasicGenTester::beginJob() {
@@ -82,7 +86,7 @@ void BasicGenTester::beginJob() {
 }
 
 void BasicGenTester::beginRun(const edm::Run& r, const edm::EventSetup& es) {
-  es.getData(fPDGTable);
+  fPDGTable = es.getHandle(fPDGTableToken);
 
   return;
 }

--- a/GeneratorInterface/TauolaInterface/interface/TauSpinnerFilter.h
+++ b/GeneratorInterface/TauolaInterface/interface/TauSpinnerFilter.h
@@ -9,7 +9,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Run.h"
@@ -19,7 +19,7 @@
 
 #include "CLHEP/Random/RandomEngine.h"
 
-class TauSpinnerFilter : public edm::EDFilter {
+class TauSpinnerFilter : public edm::stream::EDFilter<> {
 public:
   TauSpinnerFilter(const edm::ParameterSet&);
   ~TauSpinnerFilter() override{};

--- a/GeneratorInterface/TauolaInterface/interface/TauolaFactory.h
+++ b/GeneratorInterface/TauolaInterface/interface/TauolaFactory.h
@@ -3,8 +3,10 @@
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "GeneratorInterface/TauolaInterface/interface/TauolaInterfaceBase.h"
 
-typedef edmplugin::PluginFactory<gen::TauolaInterfaceBase*(const edm::ParameterSet&)> TauolaFactory;
+typedef edmplugin::PluginFactory<gen::TauolaInterfaceBase*(const edm::ParameterSet&, edm::ConsumesCollector)>
+    TauolaFactory;
 
 #endif

--- a/GeneratorInterface/TauolaInterface/interface/TauolappInterface.h
+++ b/GeneratorInterface/TauolaInterface/interface/TauolappInterface.h
@@ -6,6 +6,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "GeneratorInterface/TauolaInterface/interface/TauolaInterfaceBase.h"
 #include "TLorentzVector.h"
 #include "TVector.h"
@@ -27,7 +28,7 @@ namespace gen {
   class TauolappInterface : public TauolaInterfaceBase {
   public:
     // ctor & dtor
-    TauolappInterface(const edm::ParameterSet&);
+    TauolappInterface(const edm::ParameterSet&, edm::ConsumesCollector);
     ~TauolappInterface() override;
 
     void enablePolarization() override {
@@ -72,6 +73,7 @@ namespace gen {
     std::vector<int> fPDGs;
     bool fPolarization;
     edm::ESHandle<HepPDT::ParticleDataTable> fPDGTable;
+    edm::ESGetToken<HepPDT::ParticleDataTable, edm::DefaultRecord> fPDGTableToken;
     edm::ParameterSet* fPSet;
     bool fIsInitialized;
 

--- a/GeneratorInterface/TauolaInterface/plugins/Tauolapp/TauolappInterface.cc
+++ b/GeneratorInterface/TauolaInterface/plugins/Tauolapp/TauolappInterface.cc
@@ -47,8 +47,9 @@ void gen::ranmar_(float* rvec, int* lenv) {
 void gen::rmarin_(int*, int*, int*) { return; }
 }
 
-TauolappInterface::TauolappInterface(const edm::ParameterSet& pset)
+TauolappInterface::TauolappInterface(const edm::ParameterSet& pset, edm::ConsumesCollector iCollector)
     : fPolarization(false),
+      fPDGTableToken(iCollector.esConsumes<edm::Transition::BeginLuminosityBlock>()),
       fPSet(nullptr),
       fIsInitialized(false),
       fMDTAU(-1),
@@ -58,9 +59,6 @@ TauolappInterface::TauolappInterface(const edm::ParameterSet& pset)
       dolhe(false),
       dolheBosonCorr(false),
       ntries(10) {
-  if (fPSet != nullptr)
-    throw cms::Exception("TauolappInterfaceError") << "Attempt to override Tauola an existing ParameterSet\n"
-                                                   << std::endl;
   fPSet = new ParameterSet(pset);
 }
 
@@ -78,7 +76,7 @@ void TauolappInterface::init(const edm::EventSetup& es) {
 
   fIsInitialized = true;
 
-  es.getData(fPDGTable);
+  fPDGTable = es.getHandle(fPDGTableToken);
 
   Tauolapp::Tauola::setDecayingParticle(15);
 


### PR DESCRIPTION
#### PR description:

The Pythia6GeneratorFilter needed to get esConsumes added in order to allow unit tests to pass once we enforce it.
- Converted modules away from legacy modules
- added esConsumes as needed
- Had to make ExternalDecayDriver ConsumesCollector aware because the Tauola interface was using the EventSetup.

#### PR validation:

Code compiles. None of these changes should cause any change to the behavior of the modules.