### PR TITLE
Enable GEM trigger clusters from EMTF in GEM L1T DQM

### DIFF
--- a/DQM/L1TMonitor/interface/L1TdeGEMTPG.h
+++ b/DQM/L1TMonitor/interface/L1TdeGEMTPG.h
@@ -33,6 +33,8 @@ private:
   std::vector<double> clusterMinBin_;
   std::vector<double> clusterMaxBin_;
 
+  bool useDataClustersOnlyInBX0_;
+
   // first key is the chamber number
   // second key is the variable
   std::map<uint32_t, std::map<std::string, MonitorElement*> > chamberHistos;

--- a/DQM/L1TMonitor/python/L1TdeGEMTPG_cfi.py
+++ b/DQM/L1TMonitor/python/L1TdeGEMTPG_cfi.py
@@ -8,8 +8,11 @@ l1tdeGEMTPGCommon = cms.PSet(
     dataEmul = cms.vstring("data","emul"),
     clusterVars = cms.vstring("size", "pad", "bx"),
     clusterNBin = cms.vuint32(20,384,10),
-    clusterMinBin = cms.vdouble(-0.5,-0.5,-4.5),
-    clusterMaxBin = cms.vdouble(19.5,383.5,5.5),
+    clusterMinBin = cms.vdouble(0,0,0),
+    clusterMaxBin = cms.vdouble(20,384,10),
+    ## GEM VFAT data is not captured in BX's other than BX0
+    ## For a good comparison, leave out those data clusters
+    useDataClustersOnlyInBX0 = cms.bool(True),
     B904Setup = cms.bool(False),
 )
 
@@ -17,6 +20,6 @@ from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 l1tdeGEMTPG = DQMEDAnalyzer(
     "L1TdeGEMTPG",
     l1tdeGEMTPGCommon,
-    data = cms.InputTag("valMuonGEMPadDigiClusters"),
+    data = cms.InputTag("emtfStage2Digis"),
     emul = cms.InputTag("valMuonGEMPadDigiClusters"),
 )

--- a/DQM/L1TMonitor/python/L1TdeGEMTPG_cfi.py
+++ b/DQM/L1TMonitor/python/L1TdeGEMTPG_cfi.py
@@ -7,8 +7,8 @@ l1tdeGEMTPGCommon = cms.PSet(
     chambers = cms.vstring("GE11"),
     dataEmul = cms.vstring("data","emul"),
     clusterVars = cms.vstring("size", "pad", "bx"),
-    clusterNBin = cms.vuint32(20,384,10),
-    clusterMinBin = cms.vdouble(0,0,0),
+    clusterNBin = cms.vuint32(20,384,-5),
+    clusterMinBin = cms.vdouble(0,0,5),
     clusterMaxBin = cms.vdouble(20,384,10),
     ## GEM VFAT data is not captured in BX's other than BX0
     ## For a good comparison, leave out those data clusters

--- a/DQM/L1TMonitor/python/L1TdeGEMTPG_cfi.py
+++ b/DQM/L1TMonitor/python/L1TdeGEMTPG_cfi.py
@@ -7,9 +7,9 @@ l1tdeGEMTPGCommon = cms.PSet(
     chambers = cms.vstring("GE11"),
     dataEmul = cms.vstring("data","emul"),
     clusterVars = cms.vstring("size", "pad", "bx"),
-    clusterNBin = cms.vuint32(20,384,-5),
-    clusterMinBin = cms.vdouble(0,0,5),
-    clusterMaxBin = cms.vdouble(20,384,10),
+    clusterNBin = cms.vuint32(20,384,10),
+    clusterMinBin = cms.vdouble(0,0,-5),
+    clusterMaxBin = cms.vdouble(20,384,5),
     ## GEM VFAT data is not captured in BX's other than BX0
     ## For a good comparison, leave out those data clusters
     useDataClustersOnlyInBX0 = cms.bool(True),

--- a/DQM/L1TMonitor/src/L1TdeGEMTPG.cc
+++ b/DQM/L1TMonitor/src/L1TdeGEMTPG.cc
@@ -17,7 +17,8 @@ L1TdeGEMTPG::L1TdeGEMTPG(const edm::ParameterSet& ps)
       // binning
       clusterNBin_(ps.getParameter<std::vector<unsigned>>("clusterNBin")),
       clusterMinBin_(ps.getParameter<std::vector<double>>("clusterMinBin")),
-      clusterMaxBin_(ps.getParameter<std::vector<double>>("clusterMaxBin")) {}
+      clusterMaxBin_(ps.getParameter<std::vector<double>>("clusterMaxBin")),
+      useDataClustersOnlyInBX0_(ps.getParameter<bool>("useDataClustersOnlyInBX0")) {}
 
 L1TdeGEMTPG::~L1TdeGEMTPG() {}
 
@@ -57,6 +58,10 @@ void L1TdeGEMTPG::analyze(const edm::Event& e, const edm::EventSetup& c) {
     const int type = ((*it).first).station() - 1;
     for (auto cluster = range.first; cluster != range.second; cluster++) {
       if (cluster->isValid()) {
+        // ignore data clusters in BX's other than BX0
+        if (useDataClustersOnlyInBX0_ and cluster->bx() != 0)
+          continue;
+
         chamberHistos[type]["cluster_size_data"]->Fill(cluster->pads().size());
         chamberHistos[type]["cluster_pad_data"]->Fill(cluster->pads().front());
         chamberHistos[type]["cluster_bx_data"]->Fill(cluster->bx());

--- a/L1Trigger/L1TGEM/test/GEMTriggerPrimitivesAnalyzer.cc
+++ b/L1Trigger/L1TGEM/test/GEMTriggerPrimitivesAnalyzer.cc
@@ -65,12 +65,6 @@ private:
   bool dataVsEmulatorPlots_;
   void makeDataVsEmulatorPlots();
 
-  // plots of efficiencies in MC
-  bool mcEfficiencyPlots_;
-
-  // plots of resolution in MC
-  bool mcResolutionPlots_;
-
   /*
     When set to True, we assume that the data comes from
     the Building 904 GEM test-stand. This test-stand is a single
@@ -88,16 +82,12 @@ GEMTriggerPrimitivesAnalyzer::GEMTriggerPrimitivesAnalyzer(const edm::ParameterS
       chambers_(conf.getParameter<std::vector<std::string>>("chambers")),
       clusterVars_(conf.getParameter<std::vector<std::string>>("clusterVars")),
       dataVsEmulatorPlots_(conf.getParameter<bool>("dataVsEmulatorPlots")),
-      mcEfficiencyPlots_(conf.getParameter<bool>("mcEfficiencyPlots")),
-      mcResolutionPlots_(conf.getParameter<bool>("mcResolutionPlots")),
       B904Setup_(conf.getParameter<bool>("B904Setup")),
       B904RunNumber_(conf.getParameter<std::string>("B904RunNumber")) {
   usesResource("TFileService");
 }
 
-void GEMTriggerPrimitivesAnalyzer::analyze(const edm::Event &ev, const edm::EventSetup &setup) {
-  // efficiency and resolution analysis is done here
-}
+void GEMTriggerPrimitivesAnalyzer::analyze(const edm::Event &ev, const edm::EventSetup &setup) {}
 
 void GEMTriggerPrimitivesAnalyzer::endJob() {
   if (dataVsEmulatorPlots_)
@@ -199,7 +189,7 @@ void GEMTriggerPrimitivesAnalyzer::makePlot(TH1F *dataMon,
   dataMon->SetMarkerStyle(kPlus);
   dataMon->SetMarkerSize(3);
   // add 50% to make sure the legend does not overlap with the histograms
-  dataMon->SetMaximum(dataMon->GetBinContent(dataMon->GetMaximumBin()) * 1.5);
+  dataMon->SetMaximum(dataMon->GetBinContent(dataMon->GetMaximumBin()) * 1.6);
   dataMon->Draw("histp");
   dataMon->GetXaxis()->SetLabelSize(0.05);
   dataMon->GetYaxis()->SetLabelSize(0.05);
@@ -207,9 +197,9 @@ void GEMTriggerPrimitivesAnalyzer::makePlot(TH1F *dataMon,
   dataMon->GetYaxis()->SetTitleSize(0.05);
   emulMon->SetLineColor(kRed);
   emulMon->Draw("histsame");
-  auto legend = new TLegend(0.7, 0.7, 0.9, 0.9);
-  legend->AddEntry(dataMon, "Data", "p");
-  legend->AddEntry(emulMon, "Emulator", "l");
+  auto legend = new TLegend(0.6, 0.7, 0.9, 0.9);
+  legend->AddEntry(dataMon, TString("Data (" + std::to_string((int)dataMon->GetEntries()) + ")"), "p");
+  legend->AddEntry(emulMon, TString("Emulator (" + std::to_string((int)emulMon->GetEntries()) + ")"), "l");
   legend->Draw();
 
   c1->cd(2);

--- a/L1Trigger/L1TGEM/test/runGEMTriggerPrimitiveAnalyzer_cfg.py
+++ b/L1Trigger/L1TGEM/test/runGEMTriggerPrimitiveAnalyzer_cfg.py
@@ -5,8 +5,6 @@ from Configuration.Eras.Era_Run3_cff import Run3
 
 options = VarParsing('analysis')
 options.register ("dataVsEmulation", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
-options.register ("analyzeEffiency", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
-options.register ("analyzeResolution", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
 options.register ("dataVsEmulationFile", "empty", VarParsing.multiplicity.singleton, VarParsing.varType.string)
 """
 - For CMS runs, use the actual run number. Set B904Setup to False
@@ -29,12 +27,6 @@ process.source = cms.Source(
       fileNames = cms.untracked.vstring(options.inputFiles)
 )
 
-## if dataVsEmulation and analyzeEffiency or analyzeResolution are true,
-## pick dataVsEmulation
-if options.dataVsEmulation and (options.analyzeEffiency or options.analyzeResolution):
-    options.analyzeEffiency = False
-    options.analyzeResolution = False
-
 if options.dataVsEmulation:
     options.maxEvents = 1
     process.source = cms.Source("EmptySource")
@@ -54,8 +46,6 @@ process.gemTriggerPrimitivesAnalyzer = cms.EDAnalyzer(
     ## e.g. 334393
     runNumber = cms.uint32(options.runNumber),
     dataVsEmulatorPlots = cms.bool(options.dataVsEmulation),
-    mcEfficiencyPlots = cms.bool(options.analyzeEffiency),
-    mcResolutionPlots = cms.bool(options.analyzeResolution),
     B904RunNumber = cms.string(options.B904RunNumber)
 )
 


### PR DESCRIPTION
#### PR description:

Data vs emulation for GEM TPs in GEM L1T DQM. The purpose of this PR is not to figure out the differences, but rather update the L1T GEM DQM for Run-3. Basically, ```valMuonGEMPadDigiClusters``` is replaced with ```emtfStage2Digis``` since we now have GEM trigger data arriving at the EMTF. The data is not necessarily good, and I think  it shows in the data-vs-emulation plots. 

#### PR validation:

Tested on 10k events of RAW Run-3 data, run 344064. There are many differences, to be discussed at GEM-CSC meetings.

[GEM_dataVsEmul_CMS_Run_344064.pdf](https://github.com/cms-sw/cmssw/files/7342279/GEM_dataVsEmul_CMS_Run_344064.pdf)

Instructions to reproduce the slides on lxplus:
```
## unpack+re-emulate+dqm
cmsRun L1Trigger/CSCTriggerPrimitives/test/runCSCTriggerPrimitiveProducer_cfg.py l1GEM=True mc=False dqmGEM=True \
inputFiles=root:///eos/cms/store/data/Commissioning2021/Cosmics/RAW/v1/000/344/064/00000/dade01f7-bc85-491f-9c9c-7457af399849.root \
maxEvents=10000 dqm=True unpack=True unpackGEM=True l1=True useEmtfGEM=True

## dqm client
cmsRun L1Trigger/CSCTriggerPrimitives/test/runCSCL1TDQMClient_cfg.py useGEMs=True

## validation report
cmsRun L1Trigger/L1TGEM/test/runGEMTriggerPrimitiveAnalyzer_cfg.py dataVsEmulation=True runNumber=344064 \
dataVsEmulationFile=file:DQM_V0001_R000344064__Global__CMSSW_X_Y_Z__RECO.root
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A