### PR TITLE
Change to the new method of using `writeOneIOV` in `PPSAssociationCuts`

### DIFF
--- a/CondTools/CTPPS/plugins/WritePPSAssociationCuts.cc
+++ b/CondTools/CTPPS/plugins/WritePPSAssociationCuts.cc
@@ -41,7 +41,7 @@ void WritePPSAssociationCuts::analyze(const edm::Event &iEvent, const edm::Event
   // store the data in a DB object
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
   if (poolDbService.isAvailable()) {
-    poolDbService->writeOne(&ppsAssociationCuts, poolDbService->currentTime(), "PPSAssociationCutsRcd");
+    poolDbService->writeOneIOV(&ppsAssociationCuts, poolDbService->currentTime(), "PPSAssociationCutsRcd");
   } else {
     throw cms::Exception("WritePPSAssociationCuts") << "PoolDBService required.";
   }

--- a/CondTools/CTPPS/test/BuildFile.xml
+++ b/CondTools/CTPPS/test/BuildFile.xml
@@ -1,0 +1,1 @@
+<test name="test_CondToolsCTPPS" command="test_CondToolsCTPPS.sh"/>

--- a/CondTools/CTPPS/test/test_CondToolsCTPPS.sh
+++ b/CondTools/CTPPS/test/test_CondToolsCTPPS.sh
@@ -1,0 +1,5 @@
+ #!/bin/bash -ex
+TEST_DIR=$CMSSW_BASE/src/CondTools/CTPPS/test
+echo "test dir: $TEST_DIR"
+
+cmsRun ${TEST_DIR}/write_PPSAssociationCuts_cfg.py


### PR DESCRIPTION
#### PR description:

Change to the new method of using `writeOneIOV` in `PPSAssociationCuts`
Resolves https://github.com/cms-sw/cmssw/issues/35667

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A