### PR TITLE
PPS bug fix of Run2 pixel topology

### DIFF
--- a/CalibPPS/ESProducers/python/ppsTopology_cff.py
+++ b/CalibPPS/ESProducers/python/ppsTopology_cff.py
@@ -6,4 +6,4 @@ from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
 from Configuration.Eras.Modifier_ctpps_2017_cff import ctpps_2017
 from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
 
-(ctpps_2016 | ctpps_2017 | ctpps_2018).toModify(ppsPixelTopologyESSource, RunType = cms.string('Run2'), simYWidth = cms.double(24.4) )
+(ctpps_2016 | ctpps_2017 | ctpps_2018).toModify(ppsPixelTopologyESSource, RunType = cms.string('Run2'), simYWidth = cms.double(24.4), noOfPixelSimY = cms.int32(156),  noOfPixels = cms.int32(24960))


### PR DESCRIPTION
#### PR description:
This PR fix a couple of missing parameters in the Run2 configuration of PPS Pixel topology 

#### PR validation:

Direct simulation tests and reconstruction ones are ok.

