### PR TITLE
Remove CMS deprecation warnings in DetectorDescription/DDCMS

### DIFF
--- a/DetectorDescription/DDCMS/plugins/DDCMSDetector.cc
+++ b/DetectorDescription/DDCMS/plugins/DDCMSDetector.cc
@@ -29,13 +29,17 @@ public:
 
 private:
   const ESInputTag m_tag;
+  const ESGetToken<DDDetector, IdealGeometryRecord> m_detectorToken;
+  const ESGetToken<DDVectorRegistry, DDVectorRegistryRcd> m_registryToken;
 };
 
-DDCMSDetector::DDCMSDetector(const ParameterSet& iConfig) : m_tag(iConfig.getParameter<ESInputTag>("DDDetector")) {}
+DDCMSDetector::DDCMSDetector(const ParameterSet& iConfig)
+    : m_tag(iConfig.getParameter<ESInputTag>("DDDetector")),
+      m_detectorToken(esConsumes(m_tag)),
+      m_registryToken(esConsumes(m_tag)) {}
 
 void DDCMSDetector::analyze(const Event&, const EventSetup& iEventSetup) {
-  ESTransientHandle<DDDetector> det;
-  iEventSetup.get<IdealGeometryRecord>().get(m_tag, det);
+  ESTransientHandle<DDDetector> det = iEventSetup.getTransientHandle(m_detectorToken);
 
   LogVerbatim("Geometry") << "Iterate over the detectors:\n";
   LogVerbatim("Geometry").log([&](auto& log) {
@@ -46,8 +50,7 @@ void DDCMSDetector::analyze(const Event&, const EventSetup& iEventSetup) {
   });
   LogVerbatim("Geometry") << "..done!";
 
-  ESTransientHandle<DDVectorRegistry> registry;
-  iEventSetup.get<DDVectorRegistryRcd>().get(m_tag, registry);
+  ESTransientHandle<DDVectorRegistry> registry = iEventSetup.getTransientHandle(m_registryToken);
 
   LogVerbatim("Geometry") << "DD Vector Registry size: " << registry->vectors.size();
   LogVerbatim("Geometry").log([&](auto& log) {

--- a/DetectorDescription/DDCMS/plugins/test/DDTestCompactView.cc
+++ b/DetectorDescription/DDCMS/plugins/test/DDTestCompactView.cc
@@ -14,7 +14,8 @@ using namespace edm;
 
 class DDTestCompactView : public one::EDAnalyzer<> {
 public:
-  explicit DDTestCompactView(const ParameterSet& iConfig) : m_tag(iConfig.getParameter<ESInputTag>("DDDetector")) {}
+  explicit DDTestCompactView(const ParameterSet& iConfig)
+      : m_tag(iConfig.getParameter<ESInputTag>("DDDetector")), m_token(esConsumes(m_tag)) {}
 
   void beginJob() override {}
   void analyze(Event const& iEvent, EventSetup const&) override;
@@ -22,12 +23,12 @@ public:
 
 private:
   const ESInputTag m_tag;
+  const ESGetToken<DDCompactView, IdealGeometryRecord> m_token;
 };
 
 void DDTestCompactView::analyze(const Event&, const EventSetup& iEventSetup) {
   LogVerbatim("Geometry") << "DDTestCompactView::analyze: " << m_tag;
-  ESTransientHandle<DDCompactView> cpv;
-  iEventSetup.get<IdealGeometryRecord>().get(m_tag, cpv);
+  ESTransientHandle<DDCompactView> cpv = iEventSetup.getTransientHandle(m_token);
 
   std::cout << "Get trackerParameters:detIdShifts:\n";
   auto const& vec = cpv->getVector<int>("detIdShifts");

--- a/DetectorDescription/DDCMS/plugins/test/DDTestDumpFile.cc
+++ b/DetectorDescription/DDCMS/plugins/test/DDTestDumpFile.cc
@@ -32,17 +32,18 @@ private:
   const string m_tag;
   const string m_outputFileName;
   const ESInputTag m_label;
+  const ESGetToken<DDDetector, IdealGeometryRecord> m_token;
 };
 
 DDTestDumpFile::DDTestDumpFile(const ParameterSet& iConfig)
     : m_tag(iConfig.getUntrackedParameter<string>("tag", "unknown")),
       m_outputFileName(iConfig.getUntrackedParameter<string>("outputFileName", "cmsDD4HepGeom.root")),
-      m_label(iConfig.getParameter<ESInputTag>("DDDetector")) {}
+      m_label(iConfig.getParameter<ESInputTag>("DDDetector")),
+      m_token(esConsumes(m_label)) {}
 
 void DDTestDumpFile::analyze(const Event&, const EventSetup& iEventSetup) {
   LogVerbatim("Geometry") << "DDTestDumpFile::analyze: " << m_label;
-  ESTransientHandle<DDDetector> det;
-  iEventSetup.get<IdealGeometryRecord>().get(m_label, det);
+  ESTransientHandle<DDDetector> det = iEventSetup.getTransientHandle(m_token);
 
   TGeoManager& geom = det->manager();
 

--- a/DetectorDescription/DDCMS/plugins/test/DDTestDumpGeometry.cc
+++ b/DetectorDescription/DDCMS/plugins/test/DDTestDumpGeometry.cc
@@ -29,15 +29,15 @@ public:
 
 private:
   const ESInputTag m_tag;
+  const ESGetToken<DDDetector, IdealGeometryRecord> m_token;
 };
 
 DDTestDumpGeometry::DDTestDumpGeometry(const ParameterSet& iConfig)
-    : m_tag(iConfig.getParameter<ESInputTag>("DDDetector")) {}
+    : m_tag(iConfig.getParameter<ESInputTag>("DDDetector")), m_token(esConsumes(m_tag)) {}
 
 void DDTestDumpGeometry::analyze(const Event&, const EventSetup& iEventSetup) {
   LogVerbatim("Geometry") << "DDTestDumpGeometry::analyze: " << m_tag;
-  ESTransientHandle<DDDetector> det;
-  iEventSetup.get<IdealGeometryRecord>().get(m_tag, det);
+  ESTransientHandle<DDDetector> det = iEventSetup.getTransientHandle(m_token);
 
   TGeoManager const& geom = det->manager();
 

--- a/DetectorDescription/DDCMS/plugins/test/DDTestFilteredView.cc
+++ b/DetectorDescription/DDCMS/plugins/test/DDTestFilteredView.cc
@@ -15,7 +15,8 @@ using namespace edm;
 
 class DDTestFilteredView : public one::EDAnalyzer<> {
 public:
-  explicit DDTestFilteredView(const ParameterSet& iConfig) : m_tag(iConfig.getParameter<ESInputTag>("DDDetector")) {}
+  explicit DDTestFilteredView(const ParameterSet& iConfig)
+      : m_tag(iConfig.getParameter<ESInputTag>("DDDetector")), m_token(esConsumes(m_tag)) {}
 
   void beginJob() override {}
   void analyze(Event const& iEvent, EventSetup const&) override;
@@ -23,12 +24,12 @@ public:
 
 private:
   const ESInputTag m_tag;
+  const ESGetToken<DDCompactView, IdealGeometryRecord> m_token;
 };
 
 void DDTestFilteredView::analyze(const Event&, const EventSetup& iEventSetup) {
   LogVerbatim("Geometry") << "DDTestFilteredView::analyze: " << m_tag;
-  ESTransientHandle<DDCompactView> cpv;
-  iEventSetup.get<IdealGeometryRecord>().get(m_tag, cpv);
+  ESTransientHandle<DDCompactView> cpv = iEventSetup.getTransientHandle(m_token);
 
   DDFilteredView fv(cpv->detector(), cpv->detector()->worldVolume());
 

--- a/DetectorDescription/DDCMS/plugins/test/DDTestSpecPars.cc
+++ b/DetectorDescription/DDCMS/plugins/test/DDTestSpecPars.cc
@@ -1,4 +1,4 @@
-#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/ESTransientHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -12,24 +12,25 @@ using namespace std;
 using namespace cms;
 using namespace edm;
 
-class DDTestSpecPars : public one::EDAnalyzer<> {
+class DDTestSpecPars : public global::EDAnalyzer<> {
 public:
-  explicit DDTestSpecPars(const ParameterSet& iConfig) : m_tag(iConfig.getParameter<ESInputTag>("DDDetector")) {}
+  explicit DDTestSpecPars(const ParameterSet& iConfig)
+      : m_tag(iConfig.getParameter<ESInputTag>("DDDetector")), m_token(esConsumes(m_tag)) {}
 
   void beginJob() override {}
-  void analyze(Event const& iEvent, EventSetup const&) override;
+  void analyze(StreamID, Event const& iEvent, EventSetup const&) const override;
   void endJob() override {}
 
 private:
   const ESInputTag m_tag;
+  const ESGetToken<dd4hep::SpecParRegistry, DDSpecParRegistryRcd> m_token;
 };
 
-void DDTestSpecPars::analyze(const Event&, const EventSetup& iEventSetup) {
-  LogVerbatim("Geometry") << "DDTestSpecPars::analyze: " << m_tag;
-  ESTransientHandle<dd4hep::SpecParRegistry> registry;
-  iEventSetup.get<DDSpecParRegistryRcd>().get(m_tag, registry);
+void DDTestSpecPars::analyze(StreamID, const Event&, const EventSetup& iEventSetup) const {
+  ESTransientHandle<dd4hep::SpecParRegistry> registry = iEventSetup.getTransientHandle(m_token);
 
-  LogVerbatim("Geometry").log([&registry](auto& log) {
+  LogVerbatim("Geometry").log([&registry, this](auto& log) {
+    log << "DDTestSpecPars::analyze: " << m_tag;
     log << "DD SpecPar Registry size: " << registry->specpars.size();
     for (const auto& i : registry->specpars) {
       log << " " << i.first << " =>";

--- a/DetectorDescription/DDCMS/plugins/test/DDTestSpecParsFilter.cc
+++ b/DetectorDescription/DDCMS/plugins/test/DDTestSpecParsFilter.cc
@@ -17,6 +17,7 @@ class DDTestSpecParsFilter : public one::EDAnalyzer<> {
 public:
   explicit DDTestSpecParsFilter(const ParameterSet& iConfig)
       : m_tag(iConfig.getParameter<ESInputTag>("DDDetector")),
+        m_token(esConsumes(m_tag)),
         m_attribute(iConfig.getUntrackedParameter<string>("attribute", "")),
         m_value(iConfig.getUntrackedParameter<string>("value", "")) {}
 
@@ -26,14 +27,14 @@ public:
 
 private:
   const ESInputTag m_tag;
+  const ESGetToken<dd4hep::SpecParRegistry, DDSpecParRegistryRcd> m_token;
   const string m_attribute;
   const string m_value;
 };
 
 void DDTestSpecParsFilter::analyze(const Event&, const EventSetup& iEventSetup) {
   LogVerbatim("Geometry") << "DDTestSpecParsFilter::analyze: " << m_tag;
-  ESTransientHandle<dd4hep::SpecParRegistry> registry;
-  iEventSetup.get<DDSpecParRegistryRcd>().get(m_tag, registry);
+  ESTransientHandle<dd4hep::SpecParRegistry> registry = iEventSetup.getTransientHandle(m_token);
 
   LogVerbatim("Geometry") << "DDTestSpecParsFilter::analyze: " << m_tag << " for attribute " << m_attribute
                           << " and value " << m_value;

--- a/DetectorDescription/DDCMS/plugins/test/DDTestVectors.cc
+++ b/DetectorDescription/DDCMS/plugins/test/DDTestVectors.cc
@@ -1,4 +1,4 @@
-#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/ESTransientHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -12,24 +12,25 @@ using namespace std;
 using namespace cms;
 using namespace edm;
 
-class DDTestVectors : public one::EDAnalyzer<> {
+class DDTestVectors : public global::EDAnalyzer<> {
 public:
-  explicit DDTestVectors(const ParameterSet& iConfig) : m_tag(iConfig.getParameter<ESInputTag>("DDDetector")) {}
+  explicit DDTestVectors(const ParameterSet& iConfig)
+      : m_tag(iConfig.getParameter<ESInputTag>("DDDetector")), m_token(esConsumes(m_tag)) {}
 
   void beginJob() override {}
-  void analyze(Event const& iEvent, EventSetup const&) override;
+  void analyze(StreamID, Event const& iEvent, EventSetup const&) const override;
   void endJob() override {}
 
 private:
   const ESInputTag m_tag;
+  const ESGetToken<DDVectorRegistry, DDVectorRegistryRcd> m_token;
 };
 
-void DDTestVectors::analyze(const Event&, const EventSetup& iEventSetup) {
-  LogVerbatim("Geometry") << "DDTestVectors::analyze: " << m_tag;
-  ESTransientHandle<DDVectorRegistry> registry;
-  iEventSetup.get<DDVectorRegistryRcd>().get(m_tag, registry);
+void DDTestVectors::analyze(StreamID, const Event&, const EventSetup& iEventSetup) const {
+  ESTransientHandle<DDVectorRegistry> registry = iEventSetup.getTransientHandle(m_token);
 
-  LogVerbatim("Geometry").log([&registry](auto& log) {
+  LogVerbatim("Geometry").log([&registry, this](auto& log) {
+    log << "DDTestVectors::analyze: " << m_tag;
     log << "DD Vector Registry size: " << registry->vectors.size() << "\n";
     for (const auto& p : registry->vectors) {
       log << " " << p.first << " => ";


### PR DESCRIPTION
#### PR description:

- added esConsumes
- changes simple modules to global::

#### PR validation:

Code compiles