### PR TITLE
[backport] Set equivalence of first/last bx labels used by different subsystems in ECAL DQM

### DIFF
--- a/DQM/EcalMonitorTasks/src/RawDataTask.cc
+++ b/DQM/EcalMonitorTasks/src/RawDataTask.cc
@@ -22,7 +22,15 @@ namespace ecaldqm {
 
   void RawDataTask::beginEvent(edm::Event const& _evt, edm::EventSetup const&, bool const& ByLumiResetSwitch, bool&) {
     orbit_ = _evt.orbitNumber() & 0xffffffff;
+
     bx_ = _evt.bunchCrossing() & 0xfff;
+    // There's no agreement in CMS on how to label the last/first BX
+    // TCDS calls it always 3564, but some subsystems call it 0.
+    // From testing: bx_ is labeled 0, dccBX and FEBxs[iFE] labeled 3564
+    // Setting bx_ to 0 to match the other two
+    if (bx_ == 3564)
+      bx_ = 0;
+
     triggerType_ = _evt.experimentType() & 0xf;
     l1A_ = 0;
     feL1Offset_ = _evt.isRealData() ? 1 : 0;

--- a/DQM/EcalMonitorTasks/src/RawDataTask.cc
+++ b/DQM/EcalMonitorTasks/src/RawDataTask.cc
@@ -8,6 +8,7 @@
 #include "DQM/EcalCommon/interface/FEFlags.h"
 
 #include "DataFormats/EcalDetId/interface/EcalElectronicsId.h"
+#include "DataFormats/Luminosity/interface/LumiConstants.h"
 
 namespace ecaldqm {
 
@@ -28,7 +29,7 @@ namespace ecaldqm {
     // TCDS calls it always 3564, but some subsystems call it 0.
     // From testing: bx_ is labeled 0, dccBX and FEBxs[iFE] labeled 3564
     // Setting bx_ to 0 to match the other two
-    if (bx_ == 3564)
+    if (bx_ == LumiConstants::numBX) // 3564
       bx_ = 0;
 
     triggerType_ = _evt.experimentType() & 0xf;


### PR DESCRIPTION
#### PR description:

A bug was discovered by ECAL DAQ in which the labeling conventions for the first/last bunch crossing are different depending on the subsystem: http://cmsonline.cern.ch/cms-elog/1123223

 TCDS always labels this bx as 3564, while other subsystems label it as 0. This was leading to a DQM integrity error plot being mistakenly filled.

We have set these values so the bx labels are treated as the same in this scope and avoid incorrectly filling DQM integrity error plots.

#### PR validation:

The ECAL DQM code was run on an offending dataset and the fake integrity errors disappeared. We also confirmed the results with ECAL DAQ.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is a backport of https://github.com/cms-sw/cmssw/pull/35661 to include it in Online DQM at P5.