### PR TITLE
decouple writing legacy and HLT payloads on same sqlite file in `CondTools/BeamSpot` tests 

### DIFF
--- a/CondTools/BeamSpot/test/BeamSpotOnlineRecordsReader_cfg.py
+++ b/CondTools/BeamSpot/test/BeamSpotOnlineRecordsReader_cfg.py
@@ -78,7 +78,7 @@ else:
     tag_name = options.inputTag
 
 from CondCore.CondDB.CondDB_cfi import *
-CondDBBeamSpotOnlineLegacy = CondDB.clone(connect = cms.string("sqlite_file:test.db")) # customize with input db file
+CondDBBeamSpotOnlineLegacy = CondDB.clone(connect = cms.string("sqlite_file:test_%s.db" % tag_name)) # customize with input db file
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
     CondDBBeamSpotOnlineLegacy,
     DumpStat=cms.untracked.bool(True),

--- a/CondTools/BeamSpot/test/BeamSpotOnlineRecordsWriter_cfg.py
+++ b/CondTools/BeamSpot/test/BeamSpotOnlineRecordsWriter_cfg.py
@@ -51,7 +51,7 @@ else:
 #################################
 # Produce a SQLITE FILE
 #################################
-CondDBBeamSpotObjects = CondDB.clone(connect = cms.string('sqlite_file:test.db')) # choose an output name
+CondDBBeamSpotObjects = CondDB.clone(connect = cms.string('sqlite_file:test_%s.db' % tag_name)) # choose an output name
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
                                           CondDBBeamSpotObjects,
                                           timetype = cms.untracked.string('lumiid'), #('lumiid'), #('runnumber')

--- a/CondTools/BeamSpot/test/testReadWriteOnlineBSFromDB.sh
+++ b/CondTools/BeamSpot/test/testReadWriteOnlineBSFromDB.sh
@@ -4,26 +4,30 @@ function die { echo $1: status $2 ; exit $2; }
 
 echo "TESTING BeamSpotOnline From DB Read / Write codes ..."
 
-## clean the input db file
-if test -f "test.db"; then
-    rm -fr test.db
+## clean the input db files
+if test -f "test_BSHLT_tag.db"; then
+    rm -fr test_BSHLT_tag.db
+fi
+
+if test -f "test_BSLegacy_tag.db"; then
+    rm -fr test_BSLegacy_tag.db
 fi
 
 ## copy the input file
 cp -pr $CMSSW_BASE/src/CondTools/BeamSpot/data/BeamFitResults_Run306171.txt .
 
 # test write
-echo "TESTING Writing BeamSpotOnlineLegacyObjectsRcd DB object ...\n\n"
+printf "TESTING Writing BeamSpotOnlineLegacyObjectsRcd DB object ...\n\n"
 cmsRun ${LOCAL_TEST_DIR}/BeamSpotOnlineRecordsWriter_cfg.py unitTest=True inputRecord=BeamSpotOnlineLegacyObjectsRcd || die "Failure writing payload for BeamSpotOnlineLegacyObjectsRcd" $? 
 
-echo "TESTING Writing BeamSpotOnlineHLTObjectsRcd DB object ...\n\n"
+printf "TESTING Writing BeamSpotOnlineHLTObjectsRcd DB object ...\n\n"
 cmsRun ${LOCAL_TEST_DIR}/BeamSpotOnlineRecordsWriter_cfg.py unitTest=True inputRecord=BeamSpotOnlineHLTObjectsRcd || die "Failure writing payload for BeamSpotOnlineHLTObjectsRcd" $? 
 # test read
 
-echo "TESTING Reading BeamSpotOnlineLegacyObjectsRcd DB object ...\n\n"
+printf "TESTING Reading BeamSpotOnlineLegacyObjectsRcd DB object ...\n\n"
 cmsRun ${LOCAL_TEST_DIR}/BeamSpotOnlineRecordsReader_cfg.py unitTest=True inputRecord=BeamSpotOnlineLegacyObjectsRcd || die "Failure reading payload for BeamSpotOnlineLegacyObjectsRcd" $? 
 
-echo "TESTING Reading BeamSpotOnlineHLTObjectsRcd DB object ...\n\n"
+printf "TESTING Reading BeamSpotOnlineHLTObjectsRcd DB object ...\n\n"
 cmsRun ${LOCAL_TEST_DIR}/BeamSpotOnlineRecordsReader_cfg.py unitTest=True inputRecord=BeamSpotOnlineHLTObjectsRcd || die "Failure reading payload for BeamSpotOnlineHLTObjectsRcd" $? 
 
 echo "TESTING reading BeamSpotObjectRcd DB object ...\n\n"


### PR DESCRIPTION
#### PR description:

Attempt to resolve https://github.com/cms-sw/cmssw/issues/35670 by decoupling writing legacy and HLT `BeamSpotOnline` payloads on same sqlite file.

#### PR validation:

Unit test (still) run. 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A 
