### PR TITLE
Added esConsumes to PhysicsTools/PatUtils

### DIFF
--- a/PhysicsTools/PatUtils/interface/LeptonVertexSignificance.h
+++ b/PhysicsTools/PatUtils/interface/LeptonVertexSignificance.h
@@ -32,17 +32,20 @@ namespace pat {
   public:
     LeptonVertexSignificance() = default;
     ~LeptonVertexSignificance() = default;
-    ;
 
     //NOTE: expects vertices from "offlinePrimaryVerticesFromCTFTracks"
     static edm::InputTag vertexCollectionTag();
 
     //NOTE: expects TransientTrackBuilder to be a copy of one from record TransientTrackRecord with label "TransientTrackBuilder"
-    float calculate(const Electron& anElectron, const reco::VertexCollection& vertex, TransientTrackBuilder& builder);
-    float calculate(const Muon& aMuon, const reco::VertexCollection& vertex, TransientTrackBuilder& builder);
+    float calculate(const Electron& anElectron,
+                    const reco::VertexCollection& vertices,
+                    const TransientTrackBuilder& builder);
+    float calculate(const Muon& aMuon, const reco::VertexCollection& vertices, const TransientTrackBuilder& builder);
 
   private:
-    float calculate(const reco::Track& track, const reco::VertexCollection& vertex, TransientTrackBuilder& builder);
+    float calculate(const reco::Track& track,
+                    const reco::VertexCollection& vertices,
+                    const TransientTrackBuilder& builder);
   };
 
 }  // namespace pat

--- a/PhysicsTools/PatUtils/interface/LeptonVertexSignificance.h
+++ b/PhysicsTools/PatUtils/interface/LeptonVertexSignificance.h
@@ -14,9 +14,9 @@
   \author   Steven Lowette
 */
 
-#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "FWCore/Utilities/interface/InputTag.h"
 
 class TransientTrackBuilder;
 
@@ -24,28 +24,25 @@ namespace reco {
   class Track;
 }
 
-namespace edm {
-  class Event;
-  class EventSetup;
-}  // namespace edm
-
 namespace pat {
   class Electron;
   class Muon;
 
   class LeptonVertexSignificance {
   public:
-    LeptonVertexSignificance();
-    LeptonVertexSignificance(const edm::EventSetup& iSetup, edm::ConsumesCollector&& iC);
-    ~LeptonVertexSignificance();
+    LeptonVertexSignificance() = default;
+    ~LeptonVertexSignificance() = default;
+    ;
 
-    float calculate(const Electron& anElectron, const edm::Event& iEvent);
-    float calculate(const Muon& aMuon, const edm::Event& iEvent);
+    //NOTE: expects vertices from "offlinePrimaryVerticesFromCTFTracks"
+    static edm::InputTag vertexCollectionTag();
+
+    //NOTE: expects TransientTrackBuilder to be a copy of one from record TransientTrackRecord with label "TransientTrackBuilder"
+    float calculate(const Electron& anElectron, const reco::VertexCollection& vertex, TransientTrackBuilder& builder);
+    float calculate(const Muon& aMuon, const reco::VertexCollection& vertex, TransientTrackBuilder& builder);
 
   private:
-    float calculate(const reco::Track& track, const edm::Event& iEvent);
-    TransientTrackBuilder* theTrackBuilder_;
-    edm::EDGetTokenT<reco::VertexCollection> vertexToken_;
+    float calculate(const reco::Track& track, const reco::VertexCollection& vertex, TransientTrackBuilder& builder);
   };
 
 }  // namespace pat

--- a/PhysicsTools/PatUtils/plugins/PackedCandidatesTrackLiteModifier.cc
+++ b/PhysicsTools/PatUtils/plugins/PackedCandidatesTrackLiteModifier.cc
@@ -1,4 +1,3 @@
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/PhysicsTools/PatUtils/src/LeptonVertexSignificance.cc
+++ b/PhysicsTools/PatUtils/src/LeptonVertexSignificance.cc
@@ -16,22 +16,24 @@ edm::InputTag LeptonVertexSignificance::vertexCollectionTag() {
 
 // calculate the TrackIsoPt for the lepton object
 float LeptonVertexSignificance::calculate(const Electron& theElectron,
-                                          const reco::VertexCollection& vertex,
-                                          TransientTrackBuilder& builder) {
-  return this->calculate(*theElectron.gsfTrack(), vertex, builder);
+                                          const reco::VertexCollection& vertices,
+                                          const TransientTrackBuilder& builder) {
+  return this->calculate(*theElectron.gsfTrack(), vertices, builder);
 }
 
 float LeptonVertexSignificance::calculate(const Muon& theMuon,
-                                          const reco::VertexCollection& vertex,
-                                          TransientTrackBuilder& builder) {
-  return this->calculate(*theMuon.track(), vertex, builder);
+                                          const reco::VertexCollection& vertices,
+                                          const TransientTrackBuilder& builder) {
+  return this->calculate(*theMuon.track(), vertices, builder);
 }
 
 // calculate the TrackIsoPt for the lepton's track
 float LeptonVertexSignificance::calculate(const reco::Track& theTrack,
-                                          const reco::VertexCollection& vertex,
-                                          TransientTrackBuilder& builder) {
-  reco::Vertex const& theVertex = vertex.front();
+                                          const reco::VertexCollection& vertices,
+                                          const TransientTrackBuilder& builder) {
+  if (vertices.empty())
+    return 0;
+  reco::Vertex const& theVertex = vertices.front();
   // calculate the track-vertex association significance
   reco::TransientTrack theTrTrack = builder.build(&theTrack);
   GlobalPoint theVertexPoint(theVertex.position().x(), theVertex.position().y(), theVertex.position().z());

--- a/PhysicsTools/PatUtils/src/LeptonVertexSignificance.cc
+++ b/PhysicsTools/PatUtils/src/LeptonVertexSignificance.cc
@@ -1,52 +1,39 @@
 #include "PhysicsTools/PatUtils/interface/LeptonVertexSignificance.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "DataFormats/Common/interface/Handle.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
-#include "TrackingTools/Records/interface/TransientTrackRecord.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 #include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/PatCandidates/interface/Electron.h"
 #include "DataFormats/PatCandidates/interface/Muon.h"
 
 using namespace pat;
 
-// constructor
-LeptonVertexSignificance::LeptonVertexSignificance(const edm::EventSetup& iSetup, edm::ConsumesCollector&& iC)
-    : vertexToken_(iC.consumes<reco::VertexCollection>(edm::InputTag("offlinePrimaryVerticesFromCTFTracks"))) {
-  // instantiate the transient-track builder
-  edm::ESHandle<TransientTrackBuilder> builder;
-  iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", builder);
-  theTrackBuilder_ = new TransientTrackBuilder(*builder.product());
+edm::InputTag LeptonVertexSignificance::vertexCollectionTag() {
+  return edm::InputTag("offlinePrimaryVerticesFromCTFTracks");
 }
-
-// destructor
-LeptonVertexSignificance::~LeptonVertexSignificance() { delete theTrackBuilder_; }
 
 // calculate the TrackIsoPt for the lepton object
-float LeptonVertexSignificance::calculate(const Electron& theElectron, const edm::Event& iEvent) {
-  return this->calculate(*theElectron.gsfTrack(), iEvent);
+float LeptonVertexSignificance::calculate(const Electron& theElectron,
+                                          const reco::VertexCollection& vertex,
+                                          TransientTrackBuilder& builder) {
+  return this->calculate(*theElectron.gsfTrack(), vertex, builder);
 }
 
-float LeptonVertexSignificance::calculate(const Muon& theMuon, const edm::Event& iEvent) {
-  return this->calculate(*theMuon.track(), iEvent);
+float LeptonVertexSignificance::calculate(const Muon& theMuon,
+                                          const reco::VertexCollection& vertex,
+                                          TransientTrackBuilder& builder) {
+  return this->calculate(*theMuon.track(), vertex, builder);
 }
 
 // calculate the TrackIsoPt for the lepton's track
-float LeptonVertexSignificance::calculate(const reco::Track& theTrack, const edm::Event& iEvent) {
-  // FIXME: think more about how to handle events without vertices
-  // lepton LR calculation should have nothing to do with event selection
-  edm::Handle<reco::VertexCollection> vertexHandle;
-  iEvent.getByToken(vertexToken_, vertexHandle);
-  if (vertexHandle.product()->empty())
-    return 0;
-  reco::Vertex theVertex = vertexHandle.product()->front();
+float LeptonVertexSignificance::calculate(const reco::Track& theTrack,
+                                          const reco::VertexCollection& vertex,
+                                          TransientTrackBuilder& builder) {
+  reco::Vertex const& theVertex = vertex.front();
   // calculate the track-vertex association significance
-  reco::TransientTrack theTrTrack = theTrackBuilder_->build(&theTrack);
+  reco::TransientTrack theTrTrack = builder.build(&theTrack);
   GlobalPoint theVertexPoint(theVertex.position().x(), theVertex.position().y(), theVertex.position().z());
   FreeTrajectoryState theLeptonNearVertex = theTrTrack.trajectoryStateClosestToPoint(theVertexPoint).theState();
   return fabs(theVertex.position().z() - theLeptonNearVertex.position().z()) /


### PR DESCRIPTION
#### PR description:

- added esConsumes calls to modules
- switched to using std::unique_ptr
- removed edm::Event and edm::EventSetup dependencies from LeptonVertexSignificance

#### PR validation:

Code compiles.