### PR TITLE
Fix CMS deprecated warnings in JetMetCorrections/Modules

### DIFF
--- a/JetMETCorrections/Modules/interface/JetResolution.h
+++ b/JetMETCorrections/Modules/interface/JetResolution.h
@@ -14,6 +14,7 @@ namespace edm {
 }
 class JetResolutionObject;
 class JetResolutionRcd;
+class JetResolutionScaleFactorRcd;
 #endif
 
 namespace JME {
@@ -50,7 +51,7 @@ namespace JME {
     }
 
 #ifndef STANDALONE
-    using Token = edm::ESGetToken<JetResolutionObject, JetResolutionRcd>;
+    using Token = edm::ESGetToken<JetResolutionObject, JetResolutionScaleFactorRcd>;
     static const JetResolutionScaleFactor get(const edm::EventSetup&, const Token&);
 #endif
 

--- a/JetMETCorrections/Modules/interface/JetResolution.h
+++ b/JetMETCorrections/Modules/interface/JetResolution.h
@@ -8,9 +8,12 @@
 #include <CondFormats/JetMETObjects/interface/JetResolutionObject.h>
 
 #ifndef STANDALONE
+#include "FWCore/Utilities/interface/ESGetToken.h"
 namespace edm {
   class EventSetup;
 }
+class JetResolutionObject;
+class JetResolutionRcd;
 #endif
 
 namespace JME {
@@ -23,7 +26,8 @@ namespace JME {
     }
 
 #ifndef STANDALONE
-    static const JetResolution get(const edm::EventSetup&, const std::string&);
+    using Token = edm::ESGetToken<JetResolutionObject, JetResolutionRcd>;
+    static const JetResolution get(const edm::EventSetup&, const Token&);
 #endif
 
     float getResolution(const JetParameters& parameters) const;
@@ -46,7 +50,8 @@ namespace JME {
     }
 
 #ifndef STANDALONE
-    static const JetResolutionScaleFactor get(const edm::EventSetup&, const std::string&);
+    using Token = edm::ESGetToken<JetResolutionObject, JetResolutionRcd>;
+    static const JetResolutionScaleFactor get(const edm::EventSetup&, const Token&);
 #endif
 
     float getScaleFactor(const JetParameters& parameters,

--- a/JetMETCorrections/Modules/plugins/FactorizedJetCorrectorDemo.cc
+++ b/JetMETCorrections/Modules/plugins/FactorizedJetCorrectorDemo.cc
@@ -6,7 +6,7 @@
 #include "TLorentzVector.h"
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -26,7 +26,7 @@
 // class declaration
 //
 
-class FactorizedJetCorrectorDemo : public edm::EDAnalyzer {
+class FactorizedJetCorrectorDemo : public edm::one::EDAnalyzer<> {
 public:
   explicit FactorizedJetCorrectorDemo(const edm::ParameterSet&);
   ~FactorizedJetCorrectorDemo() override;
@@ -38,6 +38,7 @@ private:
   void endJob() override;
 
   std::string mJetCorService, mPayloadName, mUncertaintyTag, mUncertaintyFile;
+  edm::ESGetToken<JetCorrectorParametersCollection, JetCorrectionsRecord> mPayloadToken;
   std::vector<std::string> mLevels;
   bool mDebug, mUseCondDB;
   int mNHistoPoints, mNGraphPoints;
@@ -59,6 +60,7 @@ private:
 FactorizedJetCorrectorDemo::FactorizedJetCorrectorDemo(const edm::ParameterSet& iConfig) {
   mLevels = iConfig.getParameter<std::vector<std::string> >("levels");
   mPayloadName = iConfig.getParameter<std::string>("PayloadName");
+  mPayloadToken = esConsumes(edm::ESInputTag("", mPayloadName));
   mUncertaintyTag = iConfig.getParameter<std::string>("UncertaintyTag");
   mUncertaintyFile = iConfig.getParameter<std::string>("UncertaintyFile");
   mNHistoPoints = iConfig.getParameter<int>("NHistoPoints");
@@ -79,8 +81,7 @@ void FactorizedJetCorrectorDemo::analyze(const edm::Event& iEvent, const edm::Ev
     std::cout << "Hello from FactorizedJetCorrectorDemo" << std::endl;
   // retreive parameters from the DB this still need a proper configurable
   // payloadName like: JetCorrectorParametersCollection_Spring10_AK5Calo.
-  edm::ESHandle<JetCorrectorParametersCollection> parameters;
-  iSetup.get<JetCorrectionsRecord>().get(mPayloadName, parameters);
+  edm::ESHandle<JetCorrectorParametersCollection> parameters = iSetup.getHandle(mPayloadToken);
 
   std::vector<JetCorrectorParameters> params;
   for (std::vector<std::string>::const_iterator level = mLevels.begin(); level != mLevels.end(); ++level) {

--- a/JetMETCorrections/Modules/plugins/JetCorrectorDBWriter.cc
+++ b/JetMETCorrections/Modules/plugins/JetCorrectorDBWriter.cc
@@ -6,7 +6,7 @@
 #include <fstream>
 #include <iostream>
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -15,7 +15,7 @@
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 #include "CondFormats/JetMETObjects/interface/JetCorrectorParameters.h"
 
-class JetCorrectorDBWriter : public edm::EDAnalyzer {
+class JetCorrectorDBWriter : public edm::one::EDAnalyzer<> {
 public:
   JetCorrectorDBWriter(const edm::ParameterSet&);
   void beginJob() override;

--- a/JetMETCorrections/Modules/plugins/JetCorrectorOnTheFly.cc
+++ b/JetMETCorrections/Modules/plugins/JetCorrectorOnTheFly.cc
@@ -1,5 +1,5 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -25,7 +25,7 @@ using namespace std;
 // class declaration
 //
 template <class Jet>
-class JetCorrectorOnTheFly : public edm::EDAnalyzer {
+class JetCorrectorOnTheFly : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit JetCorrectorOnTheFly(const edm::ParameterSet&);
   ~JetCorrectorOnTheFly() override;
@@ -55,6 +55,8 @@ JetCorrectorOnTheFly<Jet>::JetCorrectorOnTheFly(const edm::ParameterSet& iConfig
   mVertexToken = consumes<reco::VertexCollection>(edm::InputTag("offlinePrimaryVertices"));
   mMinRawJetPt = iConfig.getParameter<double>("MinRawJetPt");
   mDebug = iConfig.getParameter<bool>("Debug");
+
+  usesResource(TFileService::kSharedResource);
 }
 //---------------------------------------------------------------------------
 template <class Jet>

--- a/JetMETCorrections/Modules/plugins/JetResolutionDBReader.cc
+++ b/JetMETCorrections/Modules/plugins/JetResolutionDBReader.cc
@@ -9,7 +9,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -25,7 +25,7 @@
 // class declaration
 //
 
-class JetResolutionDBReader : public edm::EDAnalyzer {
+class JetResolutionDBReader : public edm::one::EDAnalyzer<> {
 public:
   explicit JetResolutionDBReader(const edm::ParameterSet&);
   ~JetResolutionDBReader() override;
@@ -37,12 +37,13 @@ private:
 
   std::string m_era;
   std::string m_label;
+  edm::ESGetToken<JME::JetResolutionObject, JetResolutionRcd> m_token;
 
   bool m_save_file;
   bool m_print;
 };
 
-class JetResolutionScaleFactorDBReader : public edm::EDAnalyzer {
+class JetResolutionScaleFactorDBReader : public edm::one::EDAnalyzer<> {
 public:
   explicit JetResolutionScaleFactorDBReader(const edm::ParameterSet&);
 
@@ -51,6 +52,7 @@ private:
 
   std::string m_era;
   std::string m_label;
+  edm::ESGetToken<JME::JetResolutionObject, JetResolutionScaleFactorRcd> m_token;
 
   bool m_save_file;
   bool m_print;
@@ -59,6 +61,7 @@ private:
 JetResolutionDBReader::JetResolutionDBReader(const edm::ParameterSet& iConfig) {
   m_era = iConfig.getUntrackedParameter<std::string>("era");
   m_label = iConfig.getUntrackedParameter<std::string>("label");
+  m_token = esConsumes(edm::ESInputTag("", m_label));
   m_print = iConfig.getUntrackedParameter<bool>("dump", true);
   m_save_file = iConfig.getUntrackedParameter<bool>("saveFile", false);
 }
@@ -66,10 +69,9 @@ JetResolutionDBReader::JetResolutionDBReader(const edm::ParameterSet& iConfig) {
 JetResolutionDBReader::~JetResolutionDBReader() {}
 
 void JetResolutionDBReader::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  edm::ESHandle<JME::JetResolutionObject> jerObjectHandle;
   std::cout << "Inspecting JER payload for label: " << m_label << std::endl;
 
-  iSetup.get<JetResolutionRcd>().get(m_label, jerObjectHandle);
+  auto jerObjectHandle = iSetup.getTransientHandle(m_token);
 
   if (m_print) {
     jerObjectHandle->dump();
@@ -89,15 +91,15 @@ void JetResolutionDBReader::endJob() {}
 JetResolutionScaleFactorDBReader::JetResolutionScaleFactorDBReader(const edm::ParameterSet& iConfig) {
   m_era = iConfig.getUntrackedParameter<std::string>("era");
   m_label = iConfig.getUntrackedParameter<std::string>("label");
+  m_token = esConsumes(edm::ESInputTag("", m_label));
   m_print = iConfig.getUntrackedParameter<bool>("dump", true);
   m_save_file = iConfig.getUntrackedParameter<bool>("saveFile", false);
 }
 
 void JetResolutionScaleFactorDBReader::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  edm::ESHandle<JME::JetResolutionObject> jerObjectHandle;
   std::cout << "Inspecting JER SF payload for label: " << m_label << std::endl;
 
-  iSetup.get<JetResolutionScaleFactorRcd>().get(m_label, jerObjectHandle);
+  auto jerObjectHandle = iSetup.getTransientHandle(m_token);
 
   if (m_print) {
     jerObjectHandle->dump();

--- a/JetMETCorrections/Modules/plugins/JetResolutionDBWriter.cc
+++ b/JetMETCorrections/Modules/plugins/JetResolutionDBWriter.cc
@@ -5,7 +5,7 @@
 #include <fstream>
 #include <iostream>
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -14,7 +14,7 @@
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 #include "CondFormats/JetMETObjects/interface/JetResolutionObject.h"
 
-class JetResolutionDBWriter : public edm::EDAnalyzer {
+class JetResolutionDBWriter : public edm::one::EDAnalyzer<> {
 public:
   JetResolutionDBWriter(const edm::ParameterSet&);
   void beginJob() override;

--- a/JetMETCorrections/Modules/plugins/METCorrectorDBReader.cc
+++ b/JetMETCorrections/Modules/plugins/METCorrectorDBReader.cc
@@ -45,6 +45,7 @@ namespace {
     void endJob() override;
 
     std::string mPayloadName, mGlobalTag;
+    edm::ESGetToken<MEtXYcorrectParametersCollection, MEtXYcorrectRecord> mPayloadToken;
     bool mCreateTextFile, mPrintScreen;
   };
 
@@ -52,6 +53,7 @@ namespace {
 
 METCorrectorDBReader::METCorrectorDBReader(const edm::ParameterSet& iConfig) {
   mPayloadName = iConfig.getUntrackedParameter<std::string>("payloadName");
+  mPayloadToken = esConsumes(edm::ESInputTag("", mPayloadName));
   mGlobalTag = iConfig.getUntrackedParameter<std::string>("globalTag");
   mPrintScreen = iConfig.getUntrackedParameter<bool>("printScreen");
   mCreateTextFile = iConfig.getUntrackedParameter<bool>("createTextFile");
@@ -60,9 +62,8 @@ METCorrectorDBReader::METCorrectorDBReader(const edm::ParameterSet& iConfig) {
 METCorrectorDBReader::~METCorrectorDBReader() {}
 
 void METCorrectorDBReader::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  edm::ESHandle<MEtXYcorrectParametersCollection> MEtXYcorParaColl;
+  edm::ESHandle<MEtXYcorrectParametersCollection> MEtXYcorParaColl = iSetup.getHandle(mPayloadToken);
   edm::LogInfo("METCorrectorDBReader") << "Inspecting MET payload with label: " << mPayloadName;
-  iSetup.get<MEtXYcorrectRecord>().get(mPayloadName, MEtXYcorParaColl);
 
   // get the sections from Collection (pair of section and METCorr.Par class)
   std::vector<MEtXYcorrectParametersCollection::key_type> keys;

--- a/JetMETCorrections/Modules/plugins/QGLikelihoodDBReader.cc
+++ b/JetMETCorrections/Modules/plugins/QGLikelihoodDBReader.cc
@@ -1,6 +1,6 @@
 #include <memory>
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -10,7 +10,7 @@
 #include "JetMETCorrections/Objects/interface/JetCorrectionsRecord.h"
 #include "CondFormats/DataRecord/interface/QGLikelihoodRcd.h"
 
-class QGLikelihoodDBReader : public edm::EDAnalyzer {
+class QGLikelihoodDBReader : public edm::one::EDAnalyzer<> {
 public:
   explicit QGLikelihoodDBReader(const edm::ParameterSet&);
   ~QGLikelihoodDBReader() override{};
@@ -21,20 +21,20 @@ private:
   void endJob() override{};
 
   std::string mPayloadName;
+  edm::ESGetToken<QGLikelihoodObject, QGLikelihoodRcd> mPayloadToken;
   bool mCreateTextFile, mPrintScreen;
 };
 
 QGLikelihoodDBReader::QGLikelihoodDBReader(const edm::ParameterSet& iConfig) {
   mPayloadName = iConfig.getUntrackedParameter<std::string>("payloadName");
+  mPayloadToken = esConsumes(edm::ESInputTag("", mPayloadName));
   mPrintScreen = iConfig.getUntrackedParameter<bool>("printScreen");
   mCreateTextFile = iConfig.getUntrackedParameter<bool>("createTextFile");
 }
 
 void QGLikelihoodDBReader::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   edm::LogInfo("UserOutput") << "Inspecting QGLikelihood payload with label:" << mPayloadName << std::endl;
-  edm::ESHandle<QGLikelihoodObject> QGLParamsColl;
-  QGLikelihoodRcd const& rcdhandle = iSetup.get<QGLikelihoodRcd>();
-  rcdhandle.get(mPayloadName, QGLParamsColl);
+  edm::ESHandle<QGLikelihoodObject> QGLParamsColl = iSetup.getHandle(mPayloadToken);
 
   edm::LogInfo("UserOutput") << "Ranges in which the QGTagger could be applied:"
                              << "  pt: " << QGLParamsColl->qgValidRange.PtMin << " --> "

--- a/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
+++ b/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
@@ -3,7 +3,7 @@
 
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 #include "CondFormats/JetMETObjects/interface/QGLikelihoodObject.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -22,7 +22,7 @@
 #include <string>
 #include <vector>
 
-class QGLikelihoodDBWriter : public edm::EDAnalyzer {
+class QGLikelihoodDBWriter : public edm::one::EDAnalyzer<> {
 public:
   QGLikelihoodDBWriter(const edm::ParameterSet&);
   void beginJob() override;

--- a/JetMETCorrections/Modules/plugins/QGLikelihoodSystematicsDBReader.cc
+++ b/JetMETCorrections/Modules/plugins/QGLikelihoodSystematicsDBReader.cc
@@ -1,6 +1,6 @@
 #include <memory>
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -10,7 +10,7 @@
 #include "JetMETCorrections/Objects/interface/JetCorrectionsRecord.h"
 #include "CondFormats/DataRecord/interface/QGLikelihoodSystematicsRcd.h"
 
-class QGLikelihoodSystematicsDBReader : public edm::EDAnalyzer {
+class QGLikelihoodSystematicsDBReader : public edm::one::EDAnalyzer<> {
 public:
   explicit QGLikelihoodSystematicsDBReader(const edm::ParameterSet&);
   ~QGLikelihoodSystematicsDBReader() override{};
@@ -21,20 +21,20 @@ private:
   void endJob() override{};
 
   std::string mPayloadName;
+  edm::ESGetToken<QGLikelihoodSystematicsObject, QGLikelihoodSystematicsRcd> mPayloadToken;
   bool mCreateTextFile, mPrintScreen;
 };
 
 QGLikelihoodSystematicsDBReader::QGLikelihoodSystematicsDBReader(const edm::ParameterSet& iConfig) {
   mPayloadName = iConfig.getUntrackedParameter<std::string>("payloadName");
+  mPayloadToken = esConsumes(edm::ESInputTag("", mPayloadName));
   mPrintScreen = iConfig.getUntrackedParameter<bool>("printScreen");
   mCreateTextFile = iConfig.getUntrackedParameter<bool>("createTextFile");
 }
 
 void QGLikelihoodSystematicsDBReader::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   edm::LogInfo("UserOutput") << "Inspecting QGLikelihood payload with label:" << mPayloadName << std::endl;
-  edm::ESHandle<QGLikelihoodSystematicsObject> QGLSysPar;
-  QGLikelihoodSystematicsRcd const& rcdhandle = iSetup.get<QGLikelihoodSystematicsRcd>();
-  rcdhandle.get(mPayloadName, QGLSysPar);
+  edm::ESHandle<QGLikelihoodSystematicsObject> QGLSysPar = iSetup.getHandle(mPayloadToken);
 
   std::vector<QGLikelihoodSystematicsObject::Entry> const& data = QGLSysPar->data;
   edm::LogInfo("UserOutput") << "There are " << data.size()

--- a/JetMETCorrections/Modules/plugins/QGLikelihoodSystematicsDBWriter.cc
+++ b/JetMETCorrections/Modules/plugins/QGLikelihoodSystematicsDBWriter.cc
@@ -6,7 +6,7 @@
 #include <string>
 #include <fstream>
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -15,7 +15,7 @@
 #include "CondFormats/JetMETObjects/interface/QGLikelihoodObject.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 
-class QGLikelihoodSystematicsDBWriter : public edm::EDAnalyzer {
+class QGLikelihoodSystematicsDBWriter : public edm::one::EDAnalyzer<> {
 public:
   QGLikelihoodSystematicsDBWriter(const edm::ParameterSet&);
   void beginJob() override;

--- a/JetMETCorrections/Modules/src/JetResolution.cc
+++ b/JetMETCorrections/Modules/src/JetResolution.cc
@@ -20,11 +20,8 @@ namespace JME {
   }
 
 #ifndef STANDALONE
-  const JetResolution JetResolution::get(const edm::EventSetup& setup, const std::string& label) {
-    edm::ESHandle<JetResolutionObject> handle;
-    setup.get<JetResolutionRcd>().get(label, handle);
-
-    return *handle;
+  const JetResolution JetResolution::get(const edm::EventSetup& setup, const Token& token) {
+    return setup.getData(token);
   }
 #endif
 
@@ -45,11 +42,8 @@ namespace JME {
   }
 
 #ifndef STANDALONE
-  const JetResolutionScaleFactor JetResolutionScaleFactor::get(const edm::EventSetup& setup, const std::string& label) {
-    edm::ESHandle<JetResolutionObject> handle;
-    setup.get<JetResolutionScaleFactorRcd>().get(label, handle);
-
-    return *handle;
+  const JetResolutionScaleFactor JetResolutionScaleFactor::get(const edm::EventSetup& setup, const Token& token) {
+    return setup.getData(token);
   }
 #endif
 

--- a/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
+++ b/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
@@ -118,6 +118,8 @@ public:
       } else {
         m_jets_algo = cfg.getParameter<std::string>("algo");
         m_jets_algo_pt = cfg.getParameter<std::string>("algopt");
+        m_jets_algo_token = esConsumes(edm::ESInputTag("", m_jets_algo));
+        m_jets_algo_pt_token = esConsumes(edm::ESInputTag("", m_jets_algo_pt));
       }
 
       std::uint32_t seed = cfg.getParameter<std::uint32_t>("seed");
@@ -198,8 +200,8 @@ public:
         resolution = *m_resolution_from_file;
         resolution_sf = *m_scale_factor_from_file;
       } else {
-        resolution = JME::JetResolution::get(setup, m_jets_algo_pt);
-        resolution_sf = JME::JetResolutionScaleFactor::get(setup, m_jets_algo);
+        resolution = JME::JetResolution::get(setup, m_jets_algo_pt_token);
+        resolution_sf = JME::JetResolutionScaleFactor::get(setup, m_jets_algo_token);
       }
 
       if (m_useDeterministicSeed) {
@@ -310,6 +312,8 @@ private:
   bool m_enabled;
   std::string m_jets_algo_pt;
   std::string m_jets_algo;
+  JME::JetResolution::Token m_jets_algo_pt_token;
+  JME::JetResolutionScaleFactor::Token m_jets_algo_token;
   Variation m_systematic_variation;
   std::string m_uncertaintySource;
   bool m_useDeterministicSeed;

--- a/RecoMET/METProducers/interface/METSignificanceProducer.h
+++ b/RecoMET/METProducers/interface/METSignificanceProducer.h
@@ -60,6 +60,9 @@ namespace cms {
     std::string jetSFType_;
     std::string jetResPtType_;
     std::string jetResPhiType_;
+    JME::JetResolutionScaleFactor::Token jetSFTypeToken_;
+    JME::JetResolution::Token jetResPtTypeToken_;
+    JME::JetResolution::Token jetResPhiTypeToken_;
     edm::EDGetTokenT<edm::ValueMap<float>> weightsToken_;
 
     metsig::METSignificance* metSigAlgo_;

--- a/RecoMET/METProducers/src/METSignificanceProducer.cc
+++ b/RecoMET/METProducers/src/METSignificanceProducer.cc
@@ -26,6 +26,9 @@ namespace cms {
     jetSFType_ = iConfig.getParameter<std::string>("srcJetSF");
     jetResPtType_ = iConfig.getParameter<std::string>("srcJetResPt");
     jetResPhiType_ = iConfig.getParameter<std::string>("srcJetResPhi");
+    jetSFTypeToken_ = esConsumes(edm::ESInputTag("", jetSFType_));
+    jetResPtTypeToken_ = esConsumes(edm::ESInputTag("", jetResPtType_));
+    jetResPhiTypeToken_ = esConsumes(edm::ESInputTag("", jetResPhiType_));
     rhoToken_ = consumes<double>(iConfig.getParameter<edm::InputTag>("srcRho"));
 
     edm::InputTag srcWeights = iConfig.getParameter<edm::InputTag>("srcWeights");
@@ -80,9 +83,9 @@ namespace cms {
     if (!weightsToken_.isUninitialized())
       event.getByToken(weightsToken_, weights);
 
-    JME::JetResolution resPtObj = JME::JetResolution::get(setup, jetResPtType_);
-    JME::JetResolution resPhiObj = JME::JetResolution::get(setup, jetResPhiType_);
-    JME::JetResolutionScaleFactor resSFObj = JME::JetResolutionScaleFactor::get(setup, jetSFType_);
+    JME::JetResolution resPtObj = JME::JetResolution::get(setup, jetResPtTypeToken_);
+    JME::JetResolution resPhiObj = JME::JetResolution::get(setup, jetResPhiTypeToken_);
+    JME::JetResolutionScaleFactor resSFObj = JME::JetResolutionScaleFactor::get(setup, jetSFTypeToken_);
 
     //
     // compute the significance


### PR DESCRIPTION
#### PR description:

- moved modules away from inheriting from legacy types
- added esConsumes to modules and helpers
  - For JME::JetResolution* classes, changes to modules outside of the package was required
- did some memory management improvements
 
#### PR validation:

Code compiles.