### PR TITLE
DAQ fix spurious luminosityBlockAuxiliary assertion in HLT (12_1_X)

### DIFF
--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -943,7 +943,7 @@ void FedRawDataInputSource::readSupervisor() {
                 //look at last LS file on disk to start from that lumisection (only within first 100 LS)
                 unsigned int lsToStart = daqDirector_->getLumisectionToStart();
 
-                for (unsigned int nextLS = lsToStart; nextLS <= ls; nextLS++) {
+                for (unsigned int nextLS = std::min(lsToStart, ls); nextLS <= ls; nextLS++) {
                   std::unique_ptr<InputFile> inf(new InputFile(evf::EvFDaqDirector::newLumi, nextLS));
                   fileQueue_.push(std::move(inf));
                 }


### PR DESCRIPTION
#### PR description:

Fix a crash caused by the missing luminosityBlockAuxiliary object, seen in rare instances at the start of run in production DAQ/HLT.

A race can happen because the local file lock is unlocked before lsToStart is determined.
Since this check involves stat calls for marker files locally, another competing process can in parallel create
the EoL marker file being checked (and cause lsToStart to be increased
above LS of the newly opened file).

In case lsToStart is larger than ls, source would skip opening a lumisection
before ending up processing events and this results in the lumi block
related assertion.

Bugfix ensures that lumisection is opened before file can be processed.


#### PR validation:

Tested in DAQ filterfarm test system (Openstack VMs). A special test mode was constructed to emulate conditions of crash and find a fix.

