### PR TITLE
Using new Run3ScoutingHitPattern class for hitPattern in Run-3 scouting

### DIFF
--- a/DataFormats/Scouting/interface/Run3ScoutingHitPattern.h
+++ b/DataFormats/Scouting/interface/Run3ScoutingHitPattern.h
@@ -1,0 +1,1132 @@
+#ifndef DataFormats_Run3ScoutingHitPattern_h
+#define DataFormats_Run3ScoutingHitPattern_h
+
+// Copy of DataFormats/TrackReco/interface/HitPattern.h, v13
+//
+// Hit pattern is the summary information of the hits associated to track in
+// AOD.  When RecHits are no longer available, the compact hit pattern should
+// allow basic track selection based on the hits in various subdetectors.
+// The hits of a track are saved in unit16_t hitPattern[MaxHits].
+//
+//                                            uint16_t
+// +------------+---------------+---------------------------+-----------------+----------------+
+// |  tk/mu/mtd | sub-structure |     sub-sub-structure     |     stereo      |    hit type    |
+// +------------+---------------+---------------------------+-----------------+----------------+
+// |    11-10   | 9   8    7    |  6     5     4     3      |        2        |    1        0  |  bit
+// +------------+---------------+---------------------------+-----------------+----------------|
+// | tk  = 1    |    PXB = 1    | layer = 1-3               |                 | hit type = 0-3 |
+// | tk  = 1    |    PXF = 2    | disk  = 1-2               |                 | hit type = 0-3 |
+// | tk  = 1    |    TIB = 3    | layer = 1-4               | 0=rphi,1=stereo | hit type = 0-3 |
+// | tk  = 1    |    TID = 4    | wheel = 1-3               | 0=rphi,1=stereo | hit type = 0-3 |
+// | tk  = 1    |    TOB = 5    | layer = 1-6               | 0=rphi,1=stereo | hit type = 0-3 |
+// | tk  = 1    |    TEC = 6    | wheel = 1-9               | 0=rphi,1=stereo | hit type = 0-3 |
+// | mu  = 0    |    DT  = 1    | 4*(stat-1)+superlayer     |                 | hit type = 0-3 |
+// | mu  = 0    |    CSC = 2    | 4*(stat-1)+(ring-1)       |                 | hit type = 0-3 |
+// | mu  = 0    |    RPC = 3    | 4*(stat-1)+2*layer+region |                 | hit type = 0-3 |
+// | mu  = 0    |    GEM = 4    | 1xxx=st0, 0yxx=st y-1 la x|                 | hit type = 0-3 |
+// | mu  = 0    |    ME0 = 5    | roll                      |                 | hit type = 0-3 |
+// | mtd = 2    |    BTL = 1    | moduleType = 1-3          |                 | hit type = 0-3 |
+// | mtd = 2    |    ETL = 2    | ring = 1-12               |                 | hit type = 0-3 |
+// +------------+---------------+---------------------------+-----------------+----------------+
+//
+//  hit type, see DataFormats/TrackingRecHit/interface/TrackingRecHit.h
+//      VALID    = valid hit                                     = 0
+//      MISSING  = detector is good, but no rec hit found        = 1
+//      INACTIVE = detector is off, so there was no hope         = 2
+//      BAD      = there were many bad strips within the ellipse = 3
+//
+// It had been shown by Zongru using a 100 GeV muon sample with 5000 events
+// uniform in eta and phi, the average (maximum) number of tracker hits is
+// 13 (17) and the average (maximum) number of muon detector hits is about
+// 26 (50). If the number of hits of a track is larger than 80 then the extra
+// hits are ignored by hit pattern. The static hit pattern array might be
+// improved to a dynamic one in the future.
+//
+// Because of tracking with/without overlaps and with/without hit-splitting,
+// the final number of hits per track is pretty "variable". Compared with the
+// number of valid hits, the number of crossed layers with measurement should
+// be more robust to discriminate between good and fake track.
+//
+// Since 4-bit for sub-sub-structure is not enough to specify a muon layer,
+// the layer case counting methods are implemented for tracker only. This is
+// different from the hit counting methods which are implemented for both
+// tracker and muon detector.
+//
+// Given a tracker layer, specified by sub-structure and layer, the method
+// getTrackerLayerCase(substr, layer) groups all of the hits in the hit pattern
+// array for the layer together and returns one of the four cases
+//
+//     crossed
+//        layer case 0: VALID + (MISSING, OFF, BAD) ==> with measurement
+//        layer case 1: MISSING + (OFF, BAD) ==> without measurement
+//        layer case 2: OFF, BAD ==> totally off or bad, cannot say much
+//     not crossed
+//        layer case NULL_RETURN: track outside acceptance or in gap ==> null
+//
+// Given a tracker layer, specified by sub-structure and layer, the method
+// getTrackerMonoStereo(substr, layer) groups all of the valid hits in the hit
+// pattern array for the layer together and returns
+//
+//              0: neither a valid mono nor a valid stereo hit
+//           MONO: valid mono hit
+//         STEREO: valid stereo hit
+//  MONO | STEREO: both
+//
+//
+// Given a track, here is an example usage of hit pattern
+//
+//     // hit pattern of the track
+//    const reco::HitPattern &p = track->hitPattern();
+//
+//     // loop over the hits of the track.
+//    for (int i = 0; i < p.numberOfAllHits(HitPattern::TRACK_HITS); i++) {
+//        uint32_t hit = p.getHitPattern(HitPattern::TRACK_HITS, i);
+//
+//        // if the hit is valid and in pixel barrel, print out the layer
+//        if (p.validHitFilter(hit) && p.pixelBarrelHitFilter(hit)){
+//            cout << "valid hit found in pixel barrel layer "
+//                 << p.getLayer(hit)
+//                 << endl;
+//        }
+//
+//        // expert level: printout the hit in 11-bit binary format
+//        cout << "hit in 11-bit binary format = ";
+//        for (int j = 10; j >= 0; j--){
+//            int bit = (hit >> j) & 0x1;
+//            cout << bit;
+//        }
+//        cout << endl;
+//    }
+//
+//    //count the number of valid pixel barrel *** hits ***
+//    cout << "number of of valid pixel barrel hits is "
+//         << p.numberOfValidPixelBarrelHits()
+//         << endl;
+//
+//    //count the number of pixel barrel *** layers *** with measurement
+//    cout << "number of of pixel barrel layers with measurement is "
+//         << p.pixelBarrelLayersWithMeasurement()
+//         << endl;
+//
+
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
+#include "DataFormats/MuonDetId/interface/MuonSubdetId.h"
+#include "DataFormats/ForwardDetId/interface/MTDDetId.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
+#include "DataFormats/TrackReco/interface/HitPattern.h"
+#include "FWCore/Utilities/interface/Likely.h"
+
+#include <utility>
+#include <algorithm>
+#include <iostream>
+#include <ostream>
+#include <memory>
+
+class TrackerTopology;
+
+using namespace reco;
+
+namespace reco {
+  class HitPattern;
+}
+
+class Run3ScoutingHitPattern {
+public:
+  enum { MONO = 1, STEREO = 2 };
+
+  enum HIT_DETECTOR_TYPE { MUON_HIT = 0, TRACKER_HIT = 1, MTD_HIT = 2 };
+
+  enum HIT_TYPE { VALID = 0, MISSING = 1, INACTIVE = 2, BAD = 3 };
+
+  enum HitCategory { TRACK_HITS = 0, MISSING_INNER_HITS = 1, MISSING_OUTER_HITS = 2 };
+  const static unsigned short ARRAY_LENGTH = 57;
+  const static unsigned short HIT_LENGTH = 12;
+  const static unsigned short MaxHits = (8 * sizeof(uint16_t) * ARRAY_LENGTH) / HIT_LENGTH;
+
+  static const uint32_t NULL_RETURN = 999999;
+  static const uint16_t EMPTY_PATTERN = 0x0;
+
+  static bool trackerHitFilter(uint16_t pattern);
+  static bool muonHitFilter(uint16_t pattern);
+  static bool timingHitFilter(uint16_t pattern);
+
+  static bool validHitFilter(uint16_t pattern);
+  static bool missingHitFilter(uint16_t pattern);
+  static bool inactiveHitFilter(uint16_t pattern);
+  static bool badHitFilter(uint16_t pattern);
+
+  static bool pixelHitFilter(uint16_t pattern);
+  static bool pixelBarrelHitFilter(uint16_t pattern);
+  static bool pixelEndcapHitFilter(uint16_t pattern);
+  static bool stripHitFilter(uint16_t pattern);
+  static bool stripTIBHitFilter(uint16_t pattern);
+  static bool stripTIDHitFilter(uint16_t pattern);
+  static bool stripTOBHitFilter(uint16_t pattern);
+  static bool stripTECHitFilter(uint16_t pattern);
+
+  static bool muonDTHitFilter(uint16_t pattern);
+  static bool muonCSCHitFilter(uint16_t pattern);
+  static bool muonRPCHitFilter(uint16_t pattern);
+  static bool muonGEMHitFilter(uint16_t pattern);
+  static bool muonME0HitFilter(uint16_t pattern);
+
+  static bool timingBTLHitFilter(uint16_t pattern);
+  static bool timingETLHitFilter(uint16_t pattern);
+
+  static uint32_t getHitType(uint16_t pattern);
+
+  // mono (0) or stereo (1)
+  static uint32_t getSide(uint16_t pattern);
+  static uint32_t getLayer(uint16_t pattern);
+  static uint32_t getSubSubStructure(uint16_t pattern);
+  static uint32_t getSubStructure(uint16_t pattern);
+  static uint32_t getSubDetector(uint16_t pattern);
+
+  /// Muon station (1-4). Only valid for muon patterns, of course. only for patterns from muon, of course
+  static uint16_t getMuonStation(uint16_t pattern);
+
+  /// DT superlayer (1-3). Where the "hit" was a DT segment, superlayer is 0. Only valid for muon DT patterns, of course.
+  static uint16_t getDTSuperLayer(uint16_t pattern);  // only for DT patterns
+
+  /// CSC ring (1-4). Only valid for muon CSC patterns, of course.
+  static uint16_t getCSCRing(uint16_t pattern);
+
+  /// RPC layer: for station 1 and 2, layer = 1(inner) or 2(outer); for station 3, 4 layer is always 0. Only valid for muon RPC patterns, of course.
+  static uint16_t getRPCLayer(uint16_t pattern);
+
+  /// RPC region: 0 = barrel, 1 = endcap. Only valid for muon RPC patterns, of course.
+  static uint16_t getRPCregion(uint16_t pattern);
+
+  /// GEM station: 1,2. Only valid for muon GEM patterns, of course.
+  static uint16_t getGEMStation(uint16_t pattern);
+
+  /// GEM layer: 1-6 for station 0, 1-2 for stations 1 and 2. Only valid for muon GEM patterns, of course.
+  static uint16_t getGEMLayer(uint16_t pattern);
+
+  /// BTL Module type: 1,2,3. Only valid for BTL patterns of course.
+  static uint16_t getBTLModType(uint16_t pattern);
+
+  /// ETL Ring: 1-12. Only valid for ETL patterns of course.
+  static uint16_t getETLRing(uint16_t pattern);
+
+  Run3ScoutingHitPattern();
+
+  Run3ScoutingHitPattern(const Run3ScoutingHitPattern &other);
+
+  Run3ScoutingHitPattern &operator=(const Run3ScoutingHitPattern &other);
+
+  template <typename I>
+  bool appendHits(const I &begin, const I &end, const TrackerTopology &ttopo);
+  bool appendHit(const TrackingRecHit &hit, const TrackerTopology &ttopo);
+  bool appendHit(const TrackingRecHitRef &ref, const TrackerTopology &ttopo);
+  bool appendHit(const DetId &id, TrackingRecHit::Type hitType, const TrackerTopology &ttopo);
+  bool appendHit(const uint16_t pattern, TrackingRecHit::Type hitType);
+
+  /**
+     * This is meant to be used only in cases where the an
+     * already-packed hit information is re-interpreted in terms of
+     * HitPattern (i.e. MiniAOD PackedCandidate, and the IO rule for
+     * reading old versions of HitPattern)
+     */
+  bool appendTrackerHit(uint16_t subdet, uint16_t layer, uint16_t stereo, TrackingRecHit::Type hitType);
+
+  /**
+     * This is meant to be used only in cases where the an
+     * already-packed hit information is re-interpreted in terms of
+     * HitPattern (i.e. the IO rule for reading old versions of
+     * HitPattern)
+     */
+  bool appendMuonHit(const DetId &id, TrackingRecHit::Type hitType);
+
+  // get the pattern of the position-th hit
+  uint16_t getHitPattern(HitCategory category, int position) const;
+
+  void clear();
+
+  // print the pattern of the position-th hit
+  void printHitPattern(HitCategory category, int position, std::ostream &stream) const;
+  void print(HitCategory category, std::ostream &stream = std::cout) const;
+
+  // has valid hit in PXB/PXF layer x
+  bool hasValidHitInPixelLayer(enum PixelSubdetector::SubDetector, uint16_t layer) const;
+
+  int numberOfAllHits(HitCategory category) const;  // not-null
+  int numberOfValidHits() const;                    // not-null, valid
+
+  int numberOfAllTrackerHits(HitCategory category) const;  // not-null, tracker
+  int numberOfValidTrackerHits() const;                    // not-null, valid, tracker
+  int numberOfValidPixelHits() const;                      // not-null, valid, pixel
+  int numberOfValidPixelBarrelHits() const;                // not-null, valid, pixel PXB
+  int numberOfValidPixelEndcapHits() const;                // not-null, valid, pixel PXF
+  int numberOfValidStripHits() const;                      // not-null, valid, strip
+  int numberOfValidStripTIBHits() const;                   // not-null, valid, strip TIB
+  int numberOfValidStripTIDHits() const;                   // not-null, valid, strip TID
+  int numberOfValidStripTOBHits() const;                   // not-null, valid, strip TOB
+  int numberOfValidStripTECHits() const;                   // not-null, valid, strip TEC
+
+  int numberOfLostHits(HitCategory category) const;             // not-null, not valid
+  int numberOfLostTrackerHits(HitCategory category) const;      // not-null, not valid, tracker
+  int numberOfLostPixelHits(HitCategory category) const;        // not-null, not valid, pixel
+  int numberOfLostPixelBarrelHits(HitCategory category) const;  // not-null, not valid, pixel PXB
+  int numberOfLostPixelEndcapHits(HitCategory category) const;  // not-null, not valid, pixel PXF
+  int numberOfLostStripHits(HitCategory category) const;        // not-null, not valid, strip
+  int numberOfLostStripTIBHits(HitCategory category) const;     // not-null, not valid, strip TIB
+  int numberOfLostStripTIDHits(HitCategory category) const;     // not-null, not valid, strip TID
+  int numberOfLostStripTOBHits(HitCategory category) const;     // not-null, not valid, strip TOB
+  int numberOfLostStripTECHits(HitCategory category) const;     // not-null, not valid, strip TEC
+
+  int numberOfTimingHits() const;          // not-null timing
+  int numberOfValidTimingHits() const;     // not-null, valid, timing
+  int numberOfValidTimingBTLHits() const;  // not-null, valid, timing BTL
+  int numberOfValidTimingETLHits() const;  // not-null, valid, timing ETL
+
+  int numberOfLostTimingHits() const;     // not-null, not valid, timing
+  int numberOfLostTimingBTLHits() const;  // not-null, not valid, timing BTL
+  int numberOfLostTimingETLHits() const;  // not-null, not valid, timing ETL
+
+  int numberOfMuonHits() const;          // not-null, muon
+  int numberOfValidMuonHits() const;     // not-null, valid, muon
+  int numberOfValidMuonDTHits() const;   // not-null, valid, muon DT
+  int numberOfValidMuonCSCHits() const;  // not-null, valid, muon CSC
+  int numberOfValidMuonRPCHits() const;  // not-null, valid, muon RPC
+  int numberOfValidMuonGEMHits() const;  // not-null, valid, muon GEM
+  int numberOfValidMuonME0Hits() const;  // not-null, valid, muon ME0
+
+  int numberOfLostMuonHits() const;     // not-null, not valid, muon
+  int numberOfLostMuonDTHits() const;   // not-null, not valid, muon DT
+  int numberOfLostMuonCSCHits() const;  // not-null, not valid, muon CSC
+  int numberOfLostMuonRPCHits() const;  // not-null, not valid, muon RPC
+  int numberOfLostMuonGEMHits() const;  // not-null, not valid, muon GEM
+  int numberOfLostMuonME0Hits() const;  // not-null, not valid, muon ME0
+
+  int numberOfBadHits() const;         // not-null, bad (only used in Muon Ch.)
+  int numberOfBadMuonHits() const;     // not-null, bad, muon
+  int numberOfBadMuonDTHits() const;   // not-null, bad, muon DT
+  int numberOfBadMuonCSCHits() const;  // not-null, bad, muon CSC
+  int numberOfBadMuonRPCHits() const;  // not-null, bad, muon RPC
+  int numberOfBadMuonGEMHits() const;  // not-null, bad, muon GEM
+  int numberOfBadMuonME0Hits() const;  // not-null, bad, muon ME0
+
+  int numberOfInactiveHits() const;         // not-null, inactive
+  int numberOfInactiveTrackerHits() const;  // not-null, inactive, tracker
+  int numberOfInactiveTimingHits() const;   // not-null, inactive, timing
+
+  // count strip layers that have non-null, valid mono and stereo hits
+  int numberOfValidStripLayersWithMonoAndStereo(uint16_t stripdet, uint16_t layer) const;
+  int numberOfValidStripLayersWithMonoAndStereo() const;
+  int numberOfValidTOBLayersWithMonoAndStereo(uint32_t layer = 0) const;
+  int numberOfValidTIBLayersWithMonoAndStereo(uint32_t layer = 0) const;
+  int numberOfValidTIDLayersWithMonoAndStereo(uint32_t layer = 0) const;
+  int numberOfValidTECLayersWithMonoAndStereo(uint32_t layer = 0) const;
+
+  uint32_t getTrackerLayerCase(HitCategory category, uint16_t substr, uint16_t layer) const;
+  uint16_t getTrackerMonoStereo(HitCategory category, uint16_t substr, uint16_t layer) const;
+
+  int trackerLayersWithMeasurementOld() const;   // case 0: tracker
+  int trackerLayersWithMeasurement() const;      // case 0: tracker
+  int pixelLayersWithMeasurementOld() const;     // case 0: pixel
+  int pixelLayersWithMeasurement() const;        // case 0: pixel
+  int stripLayersWithMeasurement() const;        // case 0: strip
+  int pixelBarrelLayersWithMeasurement() const;  // case 0: pixel PXB
+  int pixelEndcapLayersWithMeasurement() const;  // case 0: pixel PXF
+  int stripTIBLayersWithMeasurement() const;     // case 0: strip TIB
+  int stripTIDLayersWithMeasurement() const;     // case 0: strip TID
+  int stripTOBLayersWithMeasurement() const;     // case 0: strip TOB
+  int stripTECLayersWithMeasurement() const;     // case 0: strip TEC
+
+  int trackerLayersWithoutMeasurement(HitCategory category) const;      // case 1: tracker
+  int trackerLayersWithoutMeasurementOld(HitCategory category) const;   // case 1: tracker
+  int pixelLayersWithoutMeasurement(HitCategory category) const;        // case 1: pixel
+  int stripLayersWithoutMeasurement(HitCategory category) const;        // case 1: strip
+  int pixelBarrelLayersWithoutMeasurement(HitCategory category) const;  // case 1: pixel PXB
+  int pixelEndcapLayersWithoutMeasurement(HitCategory category) const;  // case 1: pixel PXF
+  int stripTIBLayersWithoutMeasurement(HitCategory category) const;     // case 1: strip TIB
+  int stripTIDLayersWithoutMeasurement(HitCategory category) const;     // case 1: strip TID
+  int stripTOBLayersWithoutMeasurement(HitCategory category) const;     // case 1: strip TOB
+  int stripTECLayersWithoutMeasurement(HitCategory category) const;     // case 1: strip TEC
+
+  int trackerLayersTotallyOffOrBad(HitCategory category = TRACK_HITS) const;      // case 2: tracker
+  int pixelLayersTotallyOffOrBad(HitCategory category = TRACK_HITS) const;        // case 2: pixel
+  int stripLayersTotallyOffOrBad(HitCategory category = TRACK_HITS) const;        // case 2: strip
+  int pixelBarrelLayersTotallyOffOrBad(HitCategory category = TRACK_HITS) const;  // case 2: pixel PXB
+  int pixelEndcapLayersTotallyOffOrBad(HitCategory category = TRACK_HITS) const;  // case 2: pixel PXF
+  int stripTIBLayersTotallyOffOrBad(HitCategory category = TRACK_HITS) const;     // case 2: strip TIB
+  int stripTIDLayersTotallyOffOrBad(HitCategory category = TRACK_HITS) const;     // case 2: strip TID
+  int stripTOBLayersTotallyOffOrBad(HitCategory category = TRACK_HITS) const;     // case 2: strip TOB
+  int stripTECLayersTotallyOffOrBad(HitCategory category = TRACK_HITS) const;     // case 2: strip TEC
+
+  int trackerLayersNull() const;      // case NULL_RETURN: tracker
+  int pixelLayersNull() const;        // case NULL_RETURN: pixel
+  int stripLayersNull() const;        // case NULL_RETURN: strip
+  int pixelBarrelLayersNull() const;  // case NULL_RETURN: pixel PXB
+  int pixelEndcapLayersNull() const;  // case NULL_RETURN: pixel PXF
+  int stripTIBLayersNull() const;     // case NULL_RETURN: strip TIB
+  int stripTIDLayersNull() const;     // case NULL_RETURN: strip TID
+  int stripTOBLayersNull() const;     // case NULL_RETURN: strip TOB
+  int stripTECLayersNull() const;     // case NULL_RETURN: strip TEC
+
+  /// subdet = 0(all), 1(DT), 2(CSC), 3(RPC) 4(GEM); hitType=-1(all), 0=valid, 3=bad
+  int muonStations(int subdet, int hitType) const;
+
+  int muonStationsWithValidHits() const;
+  int muonStationsWithBadHits() const;
+  int muonStationsWithAnyHits() const;
+
+  int dtStationsWithValidHits() const;
+  int dtStationsWithBadHits() const;
+  int dtStationsWithAnyHits() const;
+
+  int cscStationsWithValidHits() const;
+  int cscStationsWithBadHits() const;
+  int cscStationsWithAnyHits() const;
+
+  int rpcStationsWithValidHits() const;
+  int rpcStationsWithBadHits() const;
+  int rpcStationsWithAnyHits() const;
+
+  int gemStationsWithValidHits() const;
+  int gemStationsWithBadHits() const;
+  int gemStationsWithAnyHits() const;
+
+  int me0StationsWithValidHits() const;
+  int me0StationsWithBadHits() const;
+  int me0StationsWithAnyHits() const;
+
+  /// hitType=-1(all), 0=valid, 3=bad; 0 = no stations at all
+  int innermostMuonStationWithHits(int hitType) const;
+  int innermostMuonStationWithValidHits() const;
+  int innermostMuonStationWithBadHits() const;
+  int innermostMuonStationWithAnyHits() const;
+
+  /// hitType=-1(all), 0=valid, 3=bad; 0 = no stations at all
+  int outermostMuonStationWithHits(int hitType) const;
+  int outermostMuonStationWithValidHits() const;
+  int outermostMuonStationWithBadHits() const;
+  int outermostMuonStationWithAnyHits() const;
+
+  int numberOfDTStationsWithRPhiView() const;
+  int numberOfDTStationsWithRZView() const;
+  int numberOfDTStationsWithBothViews() const;
+
+  void fillRun3ScoutingHitPatternWithHitPattern(const reco::HitPattern trackRecoHitPattern);
+
+private:
+  // 3 bits for hit type
+  const static unsigned short HitTypeOffset = 0;
+  const static unsigned short HitTypeMask = 0x3;
+
+  // 1 bit to identify the side in double-sided detectors
+  const static unsigned short SideOffset = 2;
+  const static unsigned short SideMask = 0x1;
+
+  // 4 bits to identify the layer/disk/wheel within the substructure
+  const static unsigned short LayerOffset = 3;
+  const static unsigned short LayerMask = 0xF;
+
+  // 3 bits to identify the tracker/muon detector substructure
+  const static unsigned short SubstrOffset = 7;
+  const static unsigned short SubstrMask = 0x7;
+
+  // 2 bits to distinguish tracker, muon, mtd subsystems
+  const static unsigned short SubDetectorOffset = 10;
+  const static unsigned short SubDetectorMask = 0x3;
+
+  const static unsigned short minTrackerWord = 1 << SubDetectorOffset;
+  const static unsigned short maxTrackerWord = (2 << SubDetectorOffset) - 1;
+  const static unsigned short minPixelWord = minTrackerWord | (1 << SubstrOffset);
+  const static unsigned short minStripWord = minTrackerWord | (3 << SubstrOffset);
+
+  // detector side for tracker modules (mono/stereo)
+  static uint16_t isStereo(DetId i, const TrackerTopology &ttopo);
+  static bool stripSubdetectorHitFilter(uint16_t pattern, StripSubdetector::SubDetector substructure);
+
+  static uint16_t encode(const TrackingRecHit &hit, const TrackerTopology &ttopo);
+  static uint16_t encode(const DetId &id, TrackingRecHit::Type hitType, const TrackerTopology &ttopo);
+  static uint16_t encode(uint16_t det, uint16_t subdet, uint16_t layer, uint16_t side, TrackingRecHit::Type hitType);
+
+  // generic count methods
+  typedef bool filterType(uint16_t);
+
+  template <typename F>
+  void call(HitCategory category, filterType typeFilter, F f) const;
+
+  int countHits(HitCategory category, filterType filter) const;
+  int countTypedHits(HitCategory category, filterType typeFilter, filterType filter) const;
+
+  bool insertTrackHit(const uint16_t pattern);
+  bool insertExpectedInnerHit(const uint16_t pattern);
+  bool insertExpectedOuterHit(const uint16_t pattern);
+  void insertHit(const uint16_t pattern);
+
+  uint16_t getHitPatternByAbsoluteIndex(int position) const;
+
+  std::pair<uint8_t, uint8_t> getCategoryIndexRange(HitCategory category) const;
+
+  uint16_t hitPattern[ARRAY_LENGTH];
+  uint8_t hitCount;
+
+  uint8_t beginTrackHits;
+  uint8_t endTrackHits;
+  uint8_t beginInner;
+  uint8_t endInner;
+  uint8_t beginOuter;
+  uint8_t endOuter;
+
+  template <int N>
+  friend struct Run3ScoutingPatternSet;
+};
+
+inline std::pair<uint8_t, uint8_t> Run3ScoutingHitPattern::getCategoryIndexRange(HitCategory category) const {
+  switch (category) {
+    case TRACK_HITS:
+      return std::pair<uint8_t, uint8_t>(beginTrackHits, endTrackHits);
+      break;
+    case MISSING_INNER_HITS:
+      return std::pair<uint8_t, uint8_t>(beginInner, endInner);
+      break;
+    case MISSING_OUTER_HITS:
+      return std::pair<uint8_t, uint8_t>(beginOuter, endOuter);
+      break;
+  }
+  return std::pair<uint8_t, uint8_t>(-1, -1);
+}
+
+template <typename I>
+bool Run3ScoutingHitPattern::appendHits(const I &begin, const I &end, const TrackerTopology &ttopo) {
+  for (I hit = begin; hit != end; hit++) {
+    if UNLIKELY ((!appendHit(*hit, ttopo))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+inline uint16_t Run3ScoutingHitPattern::getHitPattern(HitCategory category, int position) const {
+  std::pair<uint8_t, uint8_t> range = getCategoryIndexRange(category);
+  if UNLIKELY ((position < 0 || (position + range.first) >= range.second)) {
+    return Run3ScoutingHitPattern::EMPTY_PATTERN;
+  }
+
+  return getHitPatternByAbsoluteIndex(range.first + position);
+}
+
+inline int Run3ScoutingHitPattern::countHits(HitCategory category, filterType filter) const {
+  int count = 0;
+  std::pair<uint8_t, uint8_t> range = getCategoryIndexRange(category);
+  for (int i = range.first; i < range.second; ++i) {
+    if (filter(getHitPatternByAbsoluteIndex(i))) {
+      ++count;
+    }
+  }
+  return count;
+}
+
+template <typename F>
+void Run3ScoutingHitPattern::call(HitCategory category, filterType typeFilter, F f) const {
+  std::pair<uint8_t, uint8_t> range = getCategoryIndexRange(category);
+  for (int i = range.first; i < range.second; i++) {
+    uint16_t pattern = getHitPatternByAbsoluteIndex(i);
+    // f() return false to ask to stop looping
+    if (typeFilter(pattern) && !f(pattern)) {
+      break;
+    }
+  }
+}
+
+inline int Run3ScoutingHitPattern::countTypedHits(HitCategory category,
+                                                  filterType typeFilter,
+                                                  filterType filter) const {
+  int count = 0;
+  std::pair<uint8_t, uint8_t> range = getCategoryIndexRange(category);
+  for (int i = range.first; i < range.second; ++i) {
+    uint16_t pattern = getHitPatternByAbsoluteIndex(i);
+    if (typeFilter(pattern) && filter(pattern)) {
+      ++count;
+    }
+  }
+  return count;
+}
+
+inline bool Run3ScoutingHitPattern::pixelHitFilter(uint16_t pattern) {
+  if UNLIKELY (!trackerHitFilter(pattern)) {
+    return false;
+  }
+
+  uint32_t substructure = getSubStructure(pattern);
+  return (substructure == PixelSubdetector::PixelBarrel || substructure == PixelSubdetector::PixelEndcap);
+}
+
+inline bool Run3ScoutingHitPattern::pixelBarrelHitFilter(uint16_t pattern) {
+  if UNLIKELY (!trackerHitFilter(pattern)) {
+    return false;
+  }
+
+  uint32_t substructure = getSubStructure(pattern);
+  return (substructure == PixelSubdetector::PixelBarrel);
+}
+
+inline bool Run3ScoutingHitPattern::pixelEndcapHitFilter(uint16_t pattern) {
+  if UNLIKELY (!trackerHitFilter(pattern)) {
+    return false;
+  }
+
+  uint32_t substructure = getSubStructure(pattern);
+  return (substructure == PixelSubdetector::PixelEndcap);
+}
+
+inline bool Run3ScoutingHitPattern::stripHitFilter(uint16_t pattern) {
+  return pattern > minStripWord && pattern <= maxTrackerWord;
+}
+
+inline bool Run3ScoutingHitPattern::stripSubdetectorHitFilter(uint16_t pattern,
+                                                              StripSubdetector::SubDetector substructure) {
+  if UNLIKELY (!trackerHitFilter(pattern)) {
+    return false;
+  }
+
+  return substructure == getSubStructure(pattern);
+}
+
+inline bool Run3ScoutingHitPattern::stripTIBHitFilter(uint16_t pattern) {
+  return stripSubdetectorHitFilter(pattern, StripSubdetector::TIB);
+}
+
+inline bool Run3ScoutingHitPattern::stripTIDHitFilter(uint16_t pattern) {
+  return stripSubdetectorHitFilter(pattern, StripSubdetector::TID);
+}
+
+inline bool Run3ScoutingHitPattern::stripTOBHitFilter(uint16_t pattern) {
+  return stripSubdetectorHitFilter(pattern, StripSubdetector::TOB);
+}
+
+inline bool Run3ScoutingHitPattern::stripTECHitFilter(uint16_t pattern) {
+  return stripSubdetectorHitFilter(pattern, StripSubdetector::TEC);
+}
+
+inline bool Run3ScoutingHitPattern::muonDTHitFilter(uint16_t pattern) {
+  if UNLIKELY (!muonHitFilter(pattern)) {
+    return false;
+  }
+
+  uint32_t substructure = getSubStructure(pattern);
+  return (substructure == (uint32_t)MuonSubdetId::DT);
+}
+
+inline bool Run3ScoutingHitPattern::muonCSCHitFilter(uint16_t pattern) {
+  if UNLIKELY (!muonHitFilter(pattern)) {
+    return false;
+  }
+
+  uint32_t substructure = getSubStructure(pattern);
+  return (substructure == (uint32_t)MuonSubdetId::CSC);
+}
+
+inline bool Run3ScoutingHitPattern::muonRPCHitFilter(uint16_t pattern) {
+  if UNLIKELY (!muonHitFilter(pattern)) {
+    return false;
+  }
+
+  uint32_t substructure = getSubStructure(pattern);
+  return (substructure == (uint32_t)MuonSubdetId::RPC);
+}
+
+inline bool Run3ScoutingHitPattern::muonGEMHitFilter(uint16_t pattern) {
+  if UNLIKELY (!muonHitFilter(pattern)) {
+    return false;
+  }
+
+  uint32_t substructure = getSubStructure(pattern);
+  return (substructure == (uint32_t)MuonSubdetId::GEM);
+}
+
+inline bool Run3ScoutingHitPattern::muonME0HitFilter(uint16_t pattern) {
+  if UNLIKELY (!muonHitFilter(pattern))
+    return false;
+  uint16_t substructure = getSubStructure(pattern);
+  return (substructure == (uint16_t)MuonSubdetId::ME0);
+}
+
+inline bool Run3ScoutingHitPattern::trackerHitFilter(uint16_t pattern) {
+  return pattern > minTrackerWord && pattern <= maxTrackerWord;
+}
+
+inline bool Run3ScoutingHitPattern::muonHitFilter(uint16_t pattern) {
+  if UNLIKELY (pattern == Run3ScoutingHitPattern::EMPTY_PATTERN) {
+    return false;
+  }
+
+  return (((pattern >> SubDetectorOffset) & SubDetectorMask) == 0);
+}
+
+inline bool Run3ScoutingHitPattern::timingBTLHitFilter(uint16_t pattern) {
+  if UNLIKELY (!timingHitFilter(pattern))
+    return false;
+  uint16_t substructure = getSubStructure(pattern);
+  return (substructure == (uint16_t)MTDDetId::BTL);
+}
+
+inline bool Run3ScoutingHitPattern::timingETLHitFilter(uint16_t pattern) {
+  if UNLIKELY (!timingHitFilter(pattern))
+    return false;
+  uint16_t substructure = getSubStructure(pattern);
+  return (substructure == (uint16_t)MTDDetId::ETL);
+}
+
+inline bool Run3ScoutingHitPattern::timingHitFilter(uint16_t pattern) {
+  if UNLIKELY (pattern == Run3ScoutingHitPattern::EMPTY_PATTERN) {
+    return false;
+  }
+
+  return (((pattern >> SubDetectorOffset) & SubDetectorMask) == 2);
+}
+
+inline uint32_t Run3ScoutingHitPattern::getSubStructure(uint16_t pattern) {
+  if UNLIKELY (pattern == Run3ScoutingHitPattern::EMPTY_PATTERN) {
+    return NULL_RETURN;
+  }
+
+  return ((pattern >> SubstrOffset) & SubstrMask);
+}
+
+inline uint32_t Run3ScoutingHitPattern::getLayer(uint16_t pattern) {
+  return Run3ScoutingHitPattern::getSubSubStructure(pattern);
+}
+
+inline uint32_t Run3ScoutingHitPattern::getSubSubStructure(uint16_t pattern) {
+  if UNLIKELY (pattern == Run3ScoutingHitPattern::EMPTY_PATTERN) {
+    return NULL_RETURN;
+  }
+
+  return ((pattern >> LayerOffset) & LayerMask);
+}
+
+inline uint32_t Run3ScoutingHitPattern::getSubDetector(uint16_t pattern) {
+  if UNLIKELY (pattern == Run3ScoutingHitPattern::EMPTY_PATTERN) {
+    return NULL_RETURN;
+  }
+
+  return ((pattern >> SubDetectorOffset) & SubDetectorMask);
+}
+
+inline uint32_t Run3ScoutingHitPattern::getSide(uint16_t pattern) {
+  if UNLIKELY (pattern == Run3ScoutingHitPattern::EMPTY_PATTERN) {
+    return NULL_RETURN;
+  }
+
+  return (pattern >> SideOffset) & SideMask;
+}
+
+inline uint32_t Run3ScoutingHitPattern::getHitType(uint16_t pattern) {
+  if UNLIKELY (pattern == Run3ScoutingHitPattern::EMPTY_PATTERN) {
+    return NULL_RETURN;
+  }
+
+  return ((pattern >> HitTypeOffset) & HitTypeMask);
+}
+
+inline uint16_t Run3ScoutingHitPattern::getMuonStation(uint16_t pattern) {
+  return muonGEMHitFilter(pattern) ? getGEMStation(pattern) : (getSubSubStructure(pattern) >> 2) + 1;
+}
+
+inline uint16_t Run3ScoutingHitPattern::getDTSuperLayer(uint16_t pattern) { return (getSubSubStructure(pattern) & 3); }
+
+inline uint16_t Run3ScoutingHitPattern::getCSCRing(uint16_t pattern) { return (getSubSubStructure(pattern) & 3) + 1; }
+
+inline uint16_t Run3ScoutingHitPattern::getRPCLayer(uint16_t pattern) {
+  uint16_t subSubStructure = getSubSubStructure(pattern);
+  uint16_t stat = subSubStructure >> 2;
+
+  if LIKELY (stat <= 1) {
+    return ((subSubStructure >> 1) & 1) + 1;
+  }
+
+  return 0;
+}
+
+inline uint16_t Run3ScoutingHitPattern::getRPCregion(uint16_t pattern) { return getSubSubStructure(pattern) & 1; }
+
+////////////////////////////// GEM
+inline uint16_t Run3ScoutingHitPattern::getGEMStation(uint16_t pattern) {
+  uint16_t sss = getSubSubStructure(pattern);
+  if (sss & 0b1000)
+    return 0;
+  return (sss >> 2) + 1;
+}
+
+/// MTD
+inline uint16_t Run3ScoutingHitPattern::getBTLModType(uint16_t pattern) { return getSubSubStructure(pattern); }
+
+inline uint16_t Run3ScoutingHitPattern::getETLRing(uint16_t pattern) { return getSubSubStructure(pattern); }
+
+inline uint16_t Run3ScoutingHitPattern::getGEMLayer(uint16_t pattern) {
+  uint16_t sss = getSubSubStructure(pattern);
+  if (sss & 0b1000)
+    return (sss & 0b0111) + 1;
+  return (sss & 0b11) + 1;
+}
+
+inline bool Run3ScoutingHitPattern::validHitFilter(uint16_t pattern) {
+  return getHitType(pattern) == Run3ScoutingHitPattern::VALID;
+}
+
+inline bool Run3ScoutingHitPattern::missingHitFilter(uint16_t pattern) {
+  return getHitType(pattern) == Run3ScoutingHitPattern::MISSING;
+}
+
+inline bool Run3ScoutingHitPattern::inactiveHitFilter(uint16_t pattern) {
+  return getHitType(pattern) == Run3ScoutingHitPattern::INACTIVE;
+}
+
+inline bool Run3ScoutingHitPattern::badHitFilter(uint16_t pattern) {
+  return getHitType(pattern) == Run3ScoutingHitPattern::BAD;
+}
+
+inline int Run3ScoutingHitPattern::numberOfAllHits(HitCategory category) const {
+  std::pair<uint8_t, uint8_t> range = getCategoryIndexRange(category);
+  return range.second - range.first;
+}
+
+inline int Run3ScoutingHitPattern::numberOfAllTrackerHits(HitCategory category) const {
+  return countHits(category, trackerHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfMuonHits() const { return countHits(TRACK_HITS, muonHitFilter); }
+
+inline int Run3ScoutingHitPattern::numberOfTimingHits() const { return countHits(TRACK_HITS, timingHitFilter); }
+
+inline int Run3ScoutingHitPattern::numberOfValidHits() const { return countHits(TRACK_HITS, validHitFilter); }
+
+inline int Run3ScoutingHitPattern::numberOfValidTrackerHits() const {
+  return countTypedHits(TRACK_HITS, validHitFilter, trackerHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfValidMuonHits() const {
+  return countTypedHits(TRACK_HITS, validHitFilter, muonHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfValidTimingHits() const {
+  return countTypedHits(TRACK_HITS, validHitFilter, timingHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfValidPixelHits() const {
+  return countTypedHits(TRACK_HITS, validHitFilter, pixelHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfValidPixelBarrelHits() const {
+  return countTypedHits(TRACK_HITS, validHitFilter, pixelBarrelHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfValidPixelEndcapHits() const {
+  return countTypedHits(TRACK_HITS, validHitFilter, pixelEndcapHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfValidStripHits() const {
+  return countTypedHits(TRACK_HITS, validHitFilter, stripHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfValidStripTIBHits() const {
+  return countTypedHits(TRACK_HITS, validHitFilter, stripTIBHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfValidStripTIDHits() const {
+  return countTypedHits(TRACK_HITS, validHitFilter, stripTIDHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfValidStripTOBHits() const {
+  return countTypedHits(TRACK_HITS, validHitFilter, stripTOBHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfValidStripTECHits() const {
+  return countTypedHits(TRACK_HITS, validHitFilter, stripTECHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfValidMuonDTHits() const {
+  return countTypedHits(TRACK_HITS, validHitFilter, muonDTHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfValidMuonCSCHits() const {
+  return countTypedHits(TRACK_HITS, validHitFilter, muonCSCHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfValidMuonRPCHits() const {
+  return countTypedHits(TRACK_HITS, validHitFilter, muonRPCHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfValidMuonGEMHits() const {
+  return countTypedHits(TRACK_HITS, validHitFilter, muonGEMHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfValidMuonME0Hits() const {
+  return countTypedHits(TRACK_HITS, validHitFilter, muonME0HitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfValidTimingBTLHits() const {
+  return countTypedHits(TRACK_HITS, validHitFilter, timingBTLHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfValidTimingETLHits() const {
+  return countTypedHits(TRACK_HITS, validHitFilter, timingETLHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfLostHits(HitCategory category) const {
+  return countHits(category, missingHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfLostTrackerHits(HitCategory category) const {
+  return countTypedHits(category, missingHitFilter, trackerHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfLostMuonHits() const {
+  return countTypedHits(TRACK_HITS, missingHitFilter, muonHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfLostTimingHits() const {
+  return countTypedHits(TRACK_HITS, missingHitFilter, timingHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfLostTimingBTLHits() const {
+  return countTypedHits(TRACK_HITS, missingHitFilter, timingBTLHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfLostTimingETLHits() const {
+  return countTypedHits(TRACK_HITS, missingHitFilter, timingETLHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfLostPixelHits(HitCategory category) const {
+  return countTypedHits(category, missingHitFilter, pixelHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfLostPixelBarrelHits(HitCategory category) const {
+  return countTypedHits(category, missingHitFilter, pixelBarrelHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfLostPixelEndcapHits(HitCategory category) const {
+  return countTypedHits(category, missingHitFilter, pixelEndcapHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfLostStripHits(HitCategory category) const {
+  return countTypedHits(category, missingHitFilter, stripHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfLostStripTIBHits(HitCategory category) const {
+  return countTypedHits(category, missingHitFilter, stripTIBHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfLostStripTIDHits(HitCategory category) const {
+  return countTypedHits(category, missingHitFilter, stripTIDHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfLostStripTOBHits(HitCategory category) const {
+  return countTypedHits(category, missingHitFilter, stripTOBHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfLostStripTECHits(HitCategory category) const {
+  return countTypedHits(category, missingHitFilter, stripTECHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfLostMuonDTHits() const {
+  return countTypedHits(TRACK_HITS, missingHitFilter, muonDTHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfLostMuonCSCHits() const {
+  return countTypedHits(TRACK_HITS, missingHitFilter, muonCSCHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfLostMuonRPCHits() const {
+  return countTypedHits(TRACK_HITS, missingHitFilter, muonRPCHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfLostMuonGEMHits() const {
+  return countTypedHits(TRACK_HITS, missingHitFilter, muonGEMHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfLostMuonME0Hits() const {
+  return countTypedHits(TRACK_HITS, missingHitFilter, muonME0HitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfBadHits() const { return countHits(TRACK_HITS, badHitFilter); }
+
+inline int Run3ScoutingHitPattern::numberOfBadMuonHits() const {
+  return countTypedHits(TRACK_HITS, inactiveHitFilter, muonHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfBadMuonDTHits() const {
+  return countTypedHits(TRACK_HITS, inactiveHitFilter, muonDTHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfBadMuonCSCHits() const {
+  return countTypedHits(TRACK_HITS, inactiveHitFilter, muonCSCHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfBadMuonRPCHits() const {
+  return countTypedHits(TRACK_HITS, inactiveHitFilter, muonRPCHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfBadMuonGEMHits() const {
+  return countTypedHits(TRACK_HITS, inactiveHitFilter, muonGEMHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfBadMuonME0Hits() const {
+  return countTypedHits(TRACK_HITS, inactiveHitFilter, muonME0HitFilter);
+}
+
+inline int Run3ScoutingHitPattern::numberOfInactiveHits() const { return countHits(TRACK_HITS, inactiveHitFilter); }
+
+inline int Run3ScoutingHitPattern::numberOfInactiveTrackerHits() const {
+  return countTypedHits(TRACK_HITS, inactiveHitFilter, trackerHitFilter);
+}
+
+inline int Run3ScoutingHitPattern::trackerLayersWithMeasurementOld() const {
+  return pixelLayersWithMeasurement() + stripLayersWithMeasurement();
+}
+
+inline int Run3ScoutingHitPattern::pixelLayersWithMeasurementOld() const {
+  return pixelBarrelLayersWithMeasurement() + pixelEndcapLayersWithMeasurement();
+}
+
+inline int Run3ScoutingHitPattern::stripLayersWithMeasurement() const {
+  return stripTIBLayersWithMeasurement() + stripTIDLayersWithMeasurement() + stripTOBLayersWithMeasurement() +
+         stripTECLayersWithMeasurement();
+}
+
+inline int Run3ScoutingHitPattern::trackerLayersWithoutMeasurementOld(HitCategory category) const {
+  return pixelLayersWithoutMeasurement(category) + stripLayersWithoutMeasurement(category);
+}
+
+inline int Run3ScoutingHitPattern::pixelLayersWithoutMeasurement(HitCategory category) const {
+  return pixelBarrelLayersWithoutMeasurement(category) + pixelEndcapLayersWithoutMeasurement(category);
+}
+
+inline int Run3ScoutingHitPattern::stripLayersWithoutMeasurement(HitCategory category) const {
+  return stripTIBLayersWithoutMeasurement(category) + stripTIDLayersWithoutMeasurement(category) +
+         stripTOBLayersWithoutMeasurement(category) + stripTECLayersWithoutMeasurement(category);
+}
+
+inline int Run3ScoutingHitPattern::trackerLayersTotallyOffOrBad(HitCategory category) const {
+  return pixelLayersTotallyOffOrBad(category) + stripLayersTotallyOffOrBad(category);
+}
+
+inline int Run3ScoutingHitPattern::pixelLayersTotallyOffOrBad(HitCategory category) const {
+  return pixelBarrelLayersTotallyOffOrBad(category) + pixelEndcapLayersTotallyOffOrBad(category);
+}
+
+inline int Run3ScoutingHitPattern::stripLayersTotallyOffOrBad(HitCategory category) const {
+  return stripTIBLayersTotallyOffOrBad(category) + stripTIDLayersTotallyOffOrBad(category) +
+         stripTOBLayersTotallyOffOrBad(category) + stripTECLayersTotallyOffOrBad(category);
+}
+
+inline int Run3ScoutingHitPattern::trackerLayersNull() const { return pixelLayersNull() + stripLayersNull(); }
+
+inline int Run3ScoutingHitPattern::pixelLayersNull() const { return pixelBarrelLayersNull() + pixelEndcapLayersNull(); }
+
+inline int Run3ScoutingHitPattern::stripLayersNull() const {
+  return stripTIBLayersNull() + stripTIDLayersNull() + stripTOBLayersNull() + stripTECLayersNull();
+}
+
+inline int Run3ScoutingHitPattern::muonStationsWithValidHits() const { return muonStations(0, 0); }
+
+inline int Run3ScoutingHitPattern::muonStationsWithBadHits() const { return muonStations(0, 3); }
+
+inline int Run3ScoutingHitPattern::muonStationsWithAnyHits() const { return muonStations(0, -1); }
+
+inline int Run3ScoutingHitPattern::dtStationsWithValidHits() const { return muonStations(1, 0); }
+
+inline int Run3ScoutingHitPattern::dtStationsWithBadHits() const { return muonStations(1, 3); }
+
+inline int Run3ScoutingHitPattern::dtStationsWithAnyHits() const { return muonStations(1, -1); }
+
+inline int Run3ScoutingHitPattern::cscStationsWithValidHits() const { return muonStations(2, 0); }
+
+inline int Run3ScoutingHitPattern::cscStationsWithBadHits() const { return muonStations(2, 3); }
+
+inline int Run3ScoutingHitPattern::cscStationsWithAnyHits() const { return muonStations(2, -1); }
+
+inline int Run3ScoutingHitPattern::rpcStationsWithValidHits() const { return muonStations(3, 0); }
+
+inline int Run3ScoutingHitPattern::rpcStationsWithBadHits() const { return muonStations(3, 3); }
+
+inline int Run3ScoutingHitPattern::rpcStationsWithAnyHits() const { return muonStations(3, -1); }
+
+inline int Run3ScoutingHitPattern::gemStationsWithValidHits() const { return muonStations(4, 0); }
+
+inline int Run3ScoutingHitPattern::gemStationsWithBadHits() const { return muonStations(4, 3); }
+
+inline int Run3ScoutingHitPattern::gemStationsWithAnyHits() const { return muonStations(4, -1); }
+
+inline int Run3ScoutingHitPattern::me0StationsWithValidHits() const { return muonStations(5, 0); }
+
+inline int Run3ScoutingHitPattern::me0StationsWithBadHits() const { return muonStations(5, 3); }
+
+inline int Run3ScoutingHitPattern::me0StationsWithAnyHits() const { return muonStations(5, -1); }
+
+inline int Run3ScoutingHitPattern::innermostMuonStationWithValidHits() const { return innermostMuonStationWithHits(0); }
+
+inline int Run3ScoutingHitPattern::innermostMuonStationWithBadHits() const { return innermostMuonStationWithHits(3); }
+
+inline int Run3ScoutingHitPattern::innermostMuonStationWithAnyHits() const { return innermostMuonStationWithHits(-1); }
+
+inline int Run3ScoutingHitPattern::outermostMuonStationWithValidHits() const { return outermostMuonStationWithHits(0); }
+
+inline int Run3ScoutingHitPattern::outermostMuonStationWithBadHits() const { return outermostMuonStationWithHits(3); }
+
+inline int Run3ScoutingHitPattern::outermostMuonStationWithAnyHits() const { return outermostMuonStationWithHits(-1); }
+
+template <int N = Run3ScoutingHitPattern::MaxHits>
+struct Run3ScoutingPatternSet {
+  static constexpr int MaxHits = N;
+  unsigned char hit[N];
+  unsigned char nhit;
+
+  unsigned char const *begin() const { return hit; }
+
+  unsigned char const *end() const { return hit + nhit; }
+
+  unsigned char *begin() { return hit; }
+
+  unsigned char *end() { return hit + nhit; }
+
+  int size() const { return nhit; }
+
+  unsigned char operator[](int i) const { return hit[i]; }
+
+  Run3ScoutingPatternSet() : nhit(0) {}
+
+  Run3ScoutingPatternSet(Run3ScoutingHitPattern::HitCategory category, Run3ScoutingHitPattern const &hp) {
+    fill(category, hp);
+  }
+
+  void fill(Run3ScoutingHitPattern::HitCategory category, Run3ScoutingHitPattern const &hp) {
+    int lhit = 0;
+    auto unpack = [&lhit, this](uint16_t pattern) -> bool {
+      unsigned char p = 255 & (pattern >> 3);
+      hit[lhit++] = p;
+
+      // bouble sort
+      if (lhit > 1) {
+        for (auto h = hit + lhit - 1; h != hit; --h) {
+          if ((*(h - 1)) <= p) {
+            break;
+          }
+          (*h) = *(h - 1);
+          *(h - 1) = p;
+        }
+      }
+      return lhit < MaxHits;
+    };
+
+    hp.call(category, Run3ScoutingHitPattern::validHitFilter, unpack);
+    nhit = lhit;
+  }
+};
+
+template <int N>
+inline Run3ScoutingPatternSet<N> commonHits(Run3ScoutingPatternSet<N> const &p1, Run3ScoutingPatternSet<N> const &p2) {
+  Run3ScoutingPatternSet<N> comm;
+  comm.nhit = std::set_intersection(p1.begin(), p1.end(), p2.begin(), p2.end(), comm.begin()) - comm.begin();
+  return comm;
+}
+
+#endif

--- a/DataFormats/Scouting/interface/Run3ScoutingMuon.h
+++ b/DataFormats/Scouting/interface/Run3ScoutingMuon.h
@@ -6,6 +6,7 @@
 
 // Class for holding muon information, for use in data scouting
 // IMPORTANT: the content of this class should be changed only in backwards compatible ways!
+
 class Run3ScoutingMuon {
 public:
   //constructor with values for all data fields
@@ -63,7 +64,7 @@ public:
                    float trk_vx,
                    float trk_vy,
                    float trk_vz,
-                   reco::HitPattern trk_hitPattern,
+                   Run3ScoutingHitPattern trk_run3ScoutingHitPattern,
                    std::vector<int> vtxIndx)
       : pt_(pt),
         eta_(eta),
@@ -119,7 +120,7 @@ public:
         trk_vx_(trk_vx),
         trk_vy_(trk_vy),
         trk_vz_(trk_vz),
-        trk_hitPattern_(trk_hitPattern),
+        trk_run3ScoutingHitPattern_(trk_run3ScoutingHitPattern),
         vtxIndx_(std::move(vtxIndx)) {}
   //default constructor
   Run3ScoutingMuon()
@@ -237,8 +238,10 @@ public:
   float trk_vx() const { return trk_vx_; }
   float trk_vy() const { return trk_vy_; }
   float trk_vz() const { return trk_vz_; }
-  reco::HitPattern const& trk_hitPattern() const { return trk_hitPattern_; }
+  Run3ScoutingHitPattern const& trk_hitPattern() const { return trk_run3ScoutingHitPattern_; }
   std::vector<int> const& vtxIndx() const { return vtxIndx_; }
+
+  friend class Run3ScoutingHitPattern;
 
 private:
   float pt_;
@@ -295,7 +298,7 @@ private:
   float trk_vx_;
   float trk_vy_;
   float trk_vz_;
-  reco::HitPattern trk_hitPattern_;
+  Run3ScoutingHitPattern trk_run3ScoutingHitPattern_;
   std::vector<int> vtxIndx_;
 };
 

--- a/DataFormats/Scouting/src/Run3ScoutingHitPattern.cc
+++ b/DataFormats/Scouting/src/Run3ScoutingHitPattern.cc
@@ -1,0 +1,1019 @@
+#include "DataFormats/Scouting/interface/Run3ScoutingHitPattern.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
+#include "DataFormats/MuonDetId/interface/DTLayerId.h"
+#include "DataFormats/MuonDetId/interface/CSCDetId.h"
+#include "DataFormats/MuonDetId/interface/RPCDetId.h"
+#include "DataFormats/MuonDetId/interface/GEMDetId.h"
+#include "DataFormats/MuonDetId/interface/ME0DetId.h"
+#include "DataFormats/ForwardDetId/interface/BTLDetId.h"
+#include "DataFormats/ForwardDetId/interface/ETLDetId.h"
+
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+
+#include "FWCore/Utilities/interface/Likely.h"
+
+#include <bitset>
+
+using namespace reco;
+
+Run3ScoutingHitPattern::Run3ScoutingHitPattern()
+    : hitCount(0), beginTrackHits(0), endTrackHits(0), beginInner(0), endInner(0), beginOuter(0), endOuter(0) {
+  memset(hitPattern, Run3ScoutingHitPattern::EMPTY_PATTERN, sizeof(uint16_t) * Run3ScoutingHitPattern::ARRAY_LENGTH);
+}
+
+Run3ScoutingHitPattern::Run3ScoutingHitPattern(const Run3ScoutingHitPattern& other)
+    : hitCount(other.hitCount),
+      beginTrackHits(other.beginTrackHits),
+      endTrackHits(other.endTrackHits),
+      beginInner(other.beginInner),
+      endInner(other.endInner),
+      beginOuter(other.beginOuter),
+      endOuter(other.endOuter) {
+  memcpy(this->hitPattern, other.hitPattern, sizeof(uint16_t) * Run3ScoutingHitPattern::ARRAY_LENGTH);
+}
+
+Run3ScoutingHitPattern& Run3ScoutingHitPattern::operator=(const Run3ScoutingHitPattern& other) {
+  if (this == &other) {
+    return *this;
+  }
+
+  this->hitCount = other.hitCount;
+
+  this->beginTrackHits = other.beginTrackHits;
+  this->endTrackHits = other.endTrackHits;
+
+  this->beginInner = other.beginInner;
+  this->endInner = other.endInner;
+
+  this->beginOuter = other.beginOuter;
+  this->endOuter = other.endOuter;
+
+  memcpy(this->hitPattern, other.hitPattern, sizeof(uint16_t) * Run3ScoutingHitPattern::ARRAY_LENGTH);
+
+  return *this;
+}
+
+void Run3ScoutingHitPattern::clear(void) {
+  this->hitCount = 0;
+  this->beginTrackHits = 0;
+  this->endTrackHits = 0;
+  this->beginInner = 0;
+  this->endInner = 0;
+  this->beginOuter = 0;
+  this->endOuter = 0;
+
+  memset(this->hitPattern, EMPTY_PATTERN, sizeof(uint16_t) * Run3ScoutingHitPattern::ARRAY_LENGTH);
+}
+
+bool Run3ScoutingHitPattern::appendHit(const TrackingRecHitRef& ref, const TrackerTopology& ttopo) {
+  return appendHit(*ref, ttopo);
+}
+
+uint16_t Run3ScoutingHitPattern::encode(const TrackingRecHit& hit, const TrackerTopology& ttopo) {
+  return encode(hit.geographicalId(), hit.getType(), ttopo);
+}
+
+namespace {
+  uint16_t encodeMuonLayer(const DetId& id) {
+    uint16_t detid = id.det();
+    uint16_t subdet = id.subdetId();
+
+    uint16_t layer = 0x0;
+    if (detid == DetId::Muon) {
+      switch (subdet) {
+        case MuonSubdetId::DT:
+          layer = ((DTLayerId(id.rawId()).station() - 1) << 2);
+          layer |= DTLayerId(id.rawId()).superLayer();
+          break;
+        case MuonSubdetId::CSC:
+          layer = ((CSCDetId(id.rawId()).station() - 1) << 2);
+          layer |= (CSCDetId(id.rawId()).ring() - 1);
+          break;
+        case MuonSubdetId::RPC: {
+          RPCDetId rpcid(id.rawId());
+          layer = ((rpcid.station() - 1) << 2);
+          layer |= (rpcid.station() <= 2) ? ((rpcid.layer() - 1) << 1) : 0x0;
+          layer |= abs(rpcid.region());
+        } break;
+        case MuonSubdetId::GEM: {
+          GEMDetId gemid(id.rawId());
+          {
+            uint16_t st = gemid.station();
+            uint16_t la = gemid.layer();
+            if (st == 0) {
+              layer |= 0b1000;
+              layer |= (la - 1);
+            } else {
+              layer |= (st - 1) << 2;
+              layer |= (la - 1);
+            }
+          }
+        } break;
+        case MuonSubdetId::ME0: {
+          ME0DetId me0id(id.rawId());
+          //layer = ((me0id.roll()-1)<<1) + abs(me0id.layer()-1);
+          //layer = ((me0id.roll()-1)<<1) + abs(me0id.layer());
+          //Only layer information that is meaningful is in the roll/etapartition
+          layer = (me0id.roll());
+        } break;
+      }
+    }
+    return layer;
+  }
+  uint16_t encodeTimingLayer(const DetId& id) {
+    uint16_t detid = id.det();
+    uint16_t subdet = id.subdetId();
+    uint16_t layer = 0x0;
+    if (detid == DetId::Forward && subdet == FastTime) {
+      MTDDetId mtdid(id);
+      switch (mtdid.mtdSubDetector()) {
+        case MTDDetId::BTL:
+          layer = BTLDetId(id).modType();
+          break;
+        case MTDDetId::ETL:
+          layer = ETLDetId(id).mtdRR();
+          break;
+        default:
+          throw cms::Exception("Run3ScoutingHitPattern") << "Invalid MTD Subdetector " << mtdid.mtdSubDetector() << "!";
+      }
+    } else {
+      throw cms::Exception("Run3ScoutingHitPattern")
+          << "Invalid DetId for FastTime det= " << detid << " subdet= " << subdet << "!";
+    }
+    return layer;
+  }
+}  // namespace
+
+uint16_t Run3ScoutingHitPattern::encode(const DetId& id, TrackingRecHit::Type hitType, const TrackerTopology& ttopo) {
+  uint16_t detid = id.det();
+  uint16_t subdet = id.subdetId();
+
+  // adding layer/disk/wheel bits
+  uint16_t layer = 0x0;
+  if (detid == DetId::Tracker) {
+    layer = ttopo.layer(id);
+  } else if (detid == DetId::Muon) {
+    layer = encodeMuonLayer(id);
+  } else if (detid == DetId::Forward && subdet == FastTime) {
+    layer = encodeTimingLayer(id);
+  }
+
+  // adding mono/stereo bit
+  uint16_t side = 0x0;
+  if (detid == DetId::Tracker) {
+    side = isStereo(id, ttopo);
+  } else if (detid == DetId::Muon || (detid == DetId::Forward && subdet == FastTime)) {
+    side = 0x0;
+  }
+
+  // juggle the detid around to deal with the fact the bitwidth is larger
+  // DetId::Muon is 2 and DetId::Forward is 6, must map to 0 and 2 respectively
+  if (detid == DetId::Tracker) {
+    detid = TRACKER_HIT;
+  } else if (detid == DetId::Muon) {
+    detid = MUON_HIT;  // DetId::Muon is 2 and needs to be reordered to match old encoding where it got masked
+  } else if (detid == DetId::Forward && subdet == FastTime) {
+    detid = MTD_HIT;  // since DetId::Forward is some other number, reorder it here
+  }
+
+  return encode(detid, subdet, layer, side, hitType);
+}
+
+uint16_t Run3ScoutingHitPattern::encode(
+    uint16_t det, uint16_t subdet, uint16_t layer, uint16_t side, TrackingRecHit::Type hitType) {
+  uint16_t pattern = Run3ScoutingHitPattern::EMPTY_PATTERN;
+
+  // adding tracker/muon/mtd detector bits
+  pattern |= (det & SubDetectorMask) << SubDetectorOffset;
+
+  // adding substructure (PXB, PXF, TIB, TID, TOB, TEC, or DT, CSC, RPC,GEM, or BTL, ETL) bits
+  pattern |= (subdet & SubstrMask) << SubstrOffset;
+
+  // adding layer/disk/wheel/ring/modType bits
+  pattern |= (layer & LayerMask) << LayerOffset;
+
+  // adding mono/stereo bit
+  pattern |= (side & SideMask) << SideOffset;
+
+  TrackingRecHit::Type patternHitType =
+      (hitType == TrackingRecHit::missing_inner || hitType == TrackingRecHit::missing_outer)
+          ? TrackingRecHit::missing
+          : ((hitType == TrackingRecHit::inactive_inner || hitType == TrackingRecHit::inactive_outer)
+                 ? TrackingRecHit::inactive
+                 : hitType);
+
+  pattern |= (patternHitType & HitTypeMask) << HitTypeOffset;
+
+  return pattern;
+}
+
+bool Run3ScoutingHitPattern::appendHit(const TrackingRecHit& hit, const TrackerTopology& ttopo) {
+  return appendHit(hit.geographicalId(), hit.getType(), ttopo);
+}
+
+bool Run3ScoutingHitPattern::appendHit(const DetId& id, TrackingRecHit::Type hitType, const TrackerTopology& ttopo) {
+  //if Run3ScoutingHitPattern is full, journey ends no matter what.
+  if UNLIKELY ((hitCount == Run3ScoutingHitPattern::MaxHits)) {
+    return false;
+  }
+
+  uint16_t pattern = Run3ScoutingHitPattern::encode(id, hitType, ttopo);
+
+  return appendHit(pattern, hitType);
+}
+
+bool Run3ScoutingHitPattern::appendHit(const uint16_t pattern, TrackingRecHit::Type hitType) {
+  //if Run3ScoutingHitPattern is full, journey ends no matter what.
+  if UNLIKELY ((hitCount == Run3ScoutingHitPattern::MaxHits)) {
+    return false;
+  }
+
+  switch (hitType) {
+    case TrackingRecHit::valid:
+    case TrackingRecHit::missing:
+    case TrackingRecHit::inactive:
+    case TrackingRecHit::bad:
+      // hitCount != endT => we are not inserting T type of hits but of T'
+      // 0 != beginT || 0 != endT => we already have hits of T type
+      // so we already have hits of T in the vector and we don't want to
+      // mess them with T' hits.
+      if UNLIKELY (((hitCount != endTrackHits) && (0 != beginTrackHits || 0 != endTrackHits))) {
+        cms::Exception("Run3ScoutingHitPattern")
+            << "TRACK_HITS"
+            << " were stored on this object before hits of some other category were inserted "
+            << "but hits of the same category should be inserted in a row. "
+            << "Please rework the code so it inserts all "
+            << "TRACK_HITS"
+            << " in a row.";
+        return false;
+      }
+      return insertTrackHit(pattern);
+      break;
+    case TrackingRecHit::inactive_inner:
+    case TrackingRecHit::missing_inner:
+      if UNLIKELY (((hitCount != endInner) && (0 != beginInner || 0 != endInner))) {
+        cms::Exception("Run3ScoutingHitPattern")
+            << "MISSING_INNER_HITS"
+            << " were stored on this object before hits of some other category were inserted "
+            << "but hits of the same category should be inserted in a row. "
+            << "Please rework the code so it inserts all "
+            << "MISSING_INNER_HITS"
+            << " in a row.";
+        return false;
+      }
+      return insertExpectedInnerHit(pattern);
+      break;
+    case TrackingRecHit::inactive_outer:
+    case TrackingRecHit::missing_outer:
+      if UNLIKELY (((hitCount != endOuter) && (0 != beginOuter || 0 != endOuter))) {
+        cms::Exception("Run3ScoutingHitPattern")
+            << "MISSING_OUTER_HITS"
+            << " were stored on this object before hits of some other category were inserted "
+            << "but hits of the same category should be inserted in a row. "
+            << "Please rework the code so it inserts all "
+            << "MISSING_OUTER_HITS"
+            << " in a row.";
+        return false;
+      }
+      return insertExpectedOuterHit(pattern);
+      break;
+  }
+
+  return false;
+}
+
+bool Run3ScoutingHitPattern::appendTrackerHit(uint16_t subdet,
+                                              uint16_t layer,
+                                              uint16_t stereo,
+                                              TrackingRecHit::Type hitType) {
+  return appendHit(encode(TRACKER_HIT, subdet, layer, stereo, hitType), hitType);
+}
+
+bool Run3ScoutingHitPattern::appendMuonHit(const DetId& id, TrackingRecHit::Type hitType) {
+  //if Run3ScoutingHitPattern is full, journey ends no matter what.
+  if UNLIKELY ((hitCount == Run3ScoutingHitPattern::MaxHits)) {
+    return false;
+  }
+
+  if UNLIKELY (id.det() != DetId::Muon) {
+    throw cms::Exception("Run3ScoutingHitPattern") << "Got DetId from det " << id.det()
+                                                   << " that is not Muon in appendMuonHit(), which should only be used "
+                                                      "for muon hits in the Run3ScoutingHitPattern IO rule";
+  }
+
+  uint16_t subdet = id.subdetId();
+  return appendHit(encode(MUON_HIT, subdet, encodeMuonLayer(id), 0, hitType), hitType);
+}
+
+uint16_t Run3ScoutingHitPattern::getHitPatternByAbsoluteIndex(int position) const {
+  if UNLIKELY ((position < 0 || position >= hitCount)) {
+    return Run3ScoutingHitPattern::EMPTY_PATTERN;
+  }
+  /*
+    Note: you are not taking a consecutive sequence of HIT_LENGTH bits starting from position * HIT_LENGTH
+     as the bit order in the words are reversed. 
+     e.g. if position = 0 you take the lowest 12 bits of the first word.
+
+     I hope this can clarify what is the memory layout of such thing
+
+    straight 01234567890123456789012345678901 | 23456789012345678901234567890123 | 4567
+    (global) 0         1         2         3  | 3       4         5         6    | 6  
+    words    [--------------0---------------] | [--------------1---------------] | [---   
+    word     01234567890123456789012345678901 | 01234567890123456789012345678901 | 0123
+    (str)   0         1         2         3  | 0         1         2         3  | 0
+          [--------------0---------------] | [--------------1---------------] | [---   
+    word     10987654321098765432109876543210 | 10987654321098765432109876543210 | 1098
+    (rev)   32         21        10        0 | 32         21        10        0 | 32  
+    reverse  10987654321098765432109876543210 | 32109876543210987654321098765432 | 5432
+             32         21        10        0 | 6  65        54        43      3   9
+
+     ugly enough, but it's not my fault, I was not even in CMS at that time   [gpetrucc] 
+    */
+
+  uint16_t bitEndOffset = (position + 1) * HIT_LENGTH;
+  uint8_t secondWord = (bitEndOffset >> 4);
+  uint8_t secondWordBits = bitEndOffset & (16 - 1);  // that is, bitEndOffset % 16
+  if (secondWordBits >= HIT_LENGTH) {                // full block is in this word
+    uint8_t lowBitsToTrash = secondWordBits - HIT_LENGTH;
+    uint16_t myResult = (hitPattern[secondWord] >> lowBitsToTrash) & ((1 << HIT_LENGTH) - 1);
+    return myResult;
+  } else {
+    uint8_t firstWordBits = HIT_LENGTH - secondWordBits;
+    uint16_t firstWordBlock = hitPattern[secondWord - 1] >> (16 - firstWordBits);
+    uint16_t secondWordBlock = hitPattern[secondWord] & ((1 << secondWordBits) - 1);
+    uint16_t myResult = firstWordBlock + (secondWordBlock << firstWordBits);
+    return myResult;
+  }
+}
+
+bool Run3ScoutingHitPattern::hasValidHitInPixelLayer(enum PixelSubdetector::SubDetector det, uint16_t layer) const {
+  for (int i = beginTrackHits; i < endTrackHits; ++i) {
+    uint16_t pattern = getHitPatternByAbsoluteIndex(i);
+    bool pixelHitFilter = ((det == 1 && pixelBarrelHitFilter(pattern)) || (det == 2 && pixelEndcapHitFilter(pattern)));
+    if (pixelHitFilter && (getLayer(pattern) == layer) && validHitFilter(pattern)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+int Run3ScoutingHitPattern::numberOfValidStripLayersWithMonoAndStereo(uint16_t stripdet, uint16_t layer) const {
+  bool hasMono[SubstrMask + 1][LayerMask + 1];
+  bool hasStereo[SubstrMask + 1][LayerMask + 1];
+  memset(hasMono, 0, sizeof(hasMono));
+  memset(hasStereo, 0, sizeof(hasStereo));
+
+  // mark which layers have mono/stereo hits
+  for (int i = beginTrackHits; i < endTrackHits; ++i) {
+    uint16_t pattern = getHitPatternByAbsoluteIndex(i);
+    uint16_t subStructure = getSubStructure(pattern);
+
+    if (validHitFilter(pattern) && stripHitFilter(pattern)) {
+      if (stripdet != 0 && subStructure != stripdet) {
+        continue;
+      }
+
+      if (layer != 0 && getSubSubStructure(pattern) != layer) {
+        continue;
+      }
+
+      switch (getSide(pattern)) {
+        case 0:  // mono
+          hasMono[subStructure][getLayer(pattern)] = true;
+          break;
+        case 1:  // stereo
+          hasStereo[subStructure][getLayer(pattern)] = true;
+          break;
+        default:;
+          break;
+      }
+    }
+  }
+
+  // count how many layers have mono and stereo hits
+  int count = 0;
+  for (int i = 0; i < SubstrMask + 1; ++i) {
+    for (int j = 0; j < LayerMask + 1; ++j) {
+      if (hasMono[i][j] && hasStereo[i][j]) {
+        count++;
+      }
+    }
+  }
+  return count;
+}
+
+int Run3ScoutingHitPattern::numberOfValidStripLayersWithMonoAndStereo() const {
+  auto category = TRACK_HITS;
+  std::bitset<128> side[2];
+  std::pair<uint8_t, uint8_t> range = getCategoryIndexRange(category);
+  for (int i = range.first; i < range.second; ++i) {
+    auto pattern = getHitPatternByAbsoluteIndex(i);
+    if (pattern > maxTrackerWord)
+      continue;
+    if (pattern < minStripWord)
+      continue;
+    uint16_t hitType = (pattern >> HitTypeOffset) & HitTypeMask;
+    if (hitType != HIT_TYPE::VALID)
+      continue;
+    auto apattern = (pattern - minTrackerWord) >> LayerOffset;
+    // assert(apattern<128);
+    side[getSide(pattern)].set(apattern);
+  }
+  // assert(numberOfValidStripLayersWithMonoAndStereo(0, 0)==int((side[0]&side[1]).count()));
+  return (side[0] & side[1]).count();
+}
+
+int Run3ScoutingHitPattern::numberOfValidTOBLayersWithMonoAndStereo(uint32_t layer) const {
+  return numberOfValidStripLayersWithMonoAndStereo(StripSubdetector::TOB, layer);
+}
+
+int Run3ScoutingHitPattern::numberOfValidTIBLayersWithMonoAndStereo(uint32_t layer) const {
+  return numberOfValidStripLayersWithMonoAndStereo(StripSubdetector::TIB, layer);
+}
+
+int Run3ScoutingHitPattern::numberOfValidTIDLayersWithMonoAndStereo(uint32_t layer) const {
+  return numberOfValidStripLayersWithMonoAndStereo(StripSubdetector::TID, layer);
+}
+
+int Run3ScoutingHitPattern::numberOfValidTECLayersWithMonoAndStereo(uint32_t layer) const {
+  return numberOfValidStripLayersWithMonoAndStereo(StripSubdetector::TEC, layer);
+}
+
+uint32_t Run3ScoutingHitPattern::getTrackerLayerCase(HitCategory category, uint16_t substr, uint16_t layer) const {
+  uint16_t tk_substr_layer =
+      (0x1 << SubDetectorOffset) + ((substr & SubstrMask) << SubstrOffset) + ((layer & LayerMask) << LayerOffset);
+
+  uint16_t mask = (SubDetectorMask << SubDetectorOffset) + (SubstrMask << SubstrOffset) + (LayerMask << LayerOffset);
+
+  // layer case 0: valid + (missing, off, bad) ==> with measurement
+  // layer case 1: missing + (off, bad) ==> without measurement
+  // layer case 2: off, bad ==> totally off or bad, cannot say much
+  // layer case NULL_RETURN: track outside acceptance or in gap ==> null
+  uint32_t layerCase = NULL_RETURN;
+  std::pair<uint8_t, uint8_t> range = getCategoryIndexRange(category);
+  for (int i = range.first; i < range.second; ++i) {
+    uint16_t pattern = getHitPatternByAbsoluteIndex(i);
+    if ((pattern & mask) == tk_substr_layer) {
+      uint16_t hitType = (pattern >> HitTypeOffset) & HitTypeMask;
+      if (hitType < layerCase) {
+        // BAD and INACTIVE as the same type (as INACTIVE)
+        layerCase = (hitType == HIT_TYPE::BAD ? (uint32_t)HIT_TYPE::INACTIVE : hitType);
+        if (layerCase == HIT_TYPE::VALID) {
+          break;
+        }
+      }
+    }
+  }
+  return layerCase;
+}
+
+uint16_t Run3ScoutingHitPattern::getTrackerMonoStereo(HitCategory category, uint16_t substr, uint16_t layer) const {
+  uint16_t tk_substr_layer =
+      (0x1 << SubDetectorOffset) + ((substr & SubstrMask) << SubstrOffset) + ((layer & LayerMask) << LayerOffset);
+  uint16_t mask = (SubDetectorMask << SubDetectorOffset) + (SubstrMask << SubstrOffset) + (LayerMask << LayerOffset);
+
+  //             0: neither a valid mono nor a valid stereo hit
+  //          MONO: valid mono hit
+  //        STEREO: valid stereo hit
+  // MONO | STEREO: both
+  uint16_t monoStereo = 0x0;
+  std::pair<uint8_t, uint8_t> range = getCategoryIndexRange(category);
+  for (int i = range.first; i < range.second; ++i) {
+    uint16_t pattern = getHitPatternByAbsoluteIndex(i);
+    if ((pattern & mask) == tk_substr_layer) {
+      uint16_t hitType = (pattern >> HitTypeOffset) & HitTypeMask;
+      if (hitType == HIT_TYPE::VALID) {
+        switch (getSide(pattern)) {
+          case 0:  // mono
+            monoStereo |= MONO;
+            break;
+          case 1:  // stereo
+            monoStereo |= STEREO;
+            break;
+        }
+      }
+
+      if (monoStereo == (MONO | STEREO)) {
+        break;
+      }
+    }
+  }
+  return monoStereo;
+}
+
+int Run3ScoutingHitPattern::pixelLayersWithMeasurement() const {
+  auto category = TRACK_HITS;
+  std::bitset<128> layerOk;
+  std::pair<uint8_t, uint8_t> range = getCategoryIndexRange(category);
+  for (int i = range.first; i < range.second; ++i) {
+    auto pattern = getHitPatternByAbsoluteIndex(i);
+    if UNLIKELY (!trackerHitFilter(pattern))
+      continue;
+    if (pattern > minStripWord)
+      continue;
+    uint16_t hitType = (pattern >> HitTypeOffset) & HitTypeMask;
+    if (hitType != HIT_TYPE::VALID)
+      continue;
+    pattern = (pattern - minTrackerWord) >> LayerOffset;
+    // assert(pattern<128);
+    layerOk.set(pattern);
+  }
+  // assert(pixelLayersWithMeasurementOld()==int(layerOk.count()));
+  return layerOk.count();
+}
+
+int Run3ScoutingHitPattern::trackerLayersWithMeasurement() const {
+  auto category = TRACK_HITS;
+  std::bitset<128> layerOk;
+  std::pair<uint8_t, uint8_t> range = getCategoryIndexRange(category);
+  for (int i = range.first; i < range.second; ++i) {
+    auto pattern = getHitPatternByAbsoluteIndex(i);
+    if UNLIKELY (!trackerHitFilter(pattern))
+      continue;
+    uint16_t hitType = (pattern >> HitTypeOffset) & HitTypeMask;
+    if (hitType != HIT_TYPE::VALID)
+      continue;
+    pattern = (pattern - minTrackerWord) >> LayerOffset;
+    // assert(pattern<128);
+    layerOk.set(pattern);
+  }
+  // assert(trackerLayersWithMeasurementOld()==int(layerOk.count()));
+  return layerOk.count();
+}
+
+int Run3ScoutingHitPattern::trackerLayersWithoutMeasurement(HitCategory category) const {
+  std::bitset<128> layerOk;
+  std::bitset<128> layerMissed;
+  std::pair<uint8_t, uint8_t> range = getCategoryIndexRange(category);
+  for (int i = range.first; i < range.second; ++i) {
+    auto pattern = getHitPatternByAbsoluteIndex(i);
+    if UNLIKELY (!trackerHitFilter(pattern))
+      continue;
+    uint16_t hitType = (pattern >> HitTypeOffset) & HitTypeMask;
+    pattern = (pattern - minTrackerWord) >> LayerOffset;
+    // assert(pattern<128);
+    if (hitType == HIT_TYPE::VALID)
+      layerOk.set(pattern);
+    if (hitType == HIT_TYPE::MISSING)
+      layerMissed.set(pattern);
+  }
+  layerMissed &= ~layerOk;
+
+  // assert(trackerLayersWithoutMeasurementOld(category)==int(layerMissed.count()));
+
+  return layerMissed.count();
+}
+
+int Run3ScoutingHitPattern::pixelBarrelLayersWithMeasurement() const {
+  int count = 0;
+  uint16_t NPixBarrel = 4;
+  for (uint16_t layer = 1; layer <= NPixBarrel; layer++) {
+    if (getTrackerLayerCase(TRACK_HITS, PixelSubdetector::PixelBarrel, layer) == HIT_TYPE::VALID) {
+      count++;
+    }
+  }
+  return count;
+}
+
+int Run3ScoutingHitPattern::pixelEndcapLayersWithMeasurement() const {
+  int count = 0;
+  uint16_t NPixForward = 3;
+  for (uint16_t layer = 1; layer <= NPixForward; layer++) {
+    if (getTrackerLayerCase(TRACK_HITS, PixelSubdetector::PixelEndcap, layer) == HIT_TYPE::VALID) {
+      count++;
+    }
+  }
+  return count;
+}
+
+int Run3ScoutingHitPattern::stripTIBLayersWithMeasurement() const {
+  int count = 0;
+  for (uint16_t layer = 1; layer <= 4; layer++) {
+    if (getTrackerLayerCase(TRACK_HITS, StripSubdetector::TIB, layer) == HIT_TYPE::VALID) {
+      count++;
+    }
+  }
+  return count;
+}
+
+int Run3ScoutingHitPattern::stripTIDLayersWithMeasurement() const {
+  int count = 0;
+  for (uint16_t layer = 1; layer <= 3; layer++) {
+    if (getTrackerLayerCase(TRACK_HITS, StripSubdetector::TID, layer) == HIT_TYPE::VALID) {
+      count++;
+    }
+  }
+  return count;
+}
+
+int Run3ScoutingHitPattern::stripTOBLayersWithMeasurement() const {
+  int count = 0;
+  for (uint16_t layer = 1; layer <= 6; layer++) {
+    if (getTrackerLayerCase(TRACK_HITS, StripSubdetector::TOB, layer) == HIT_TYPE::VALID) {
+      count++;
+    }
+  }
+  return count;
+}
+
+int Run3ScoutingHitPattern::stripTECLayersWithMeasurement() const {
+  int count = 0;
+  for (uint16_t layer = 1; layer <= 9; layer++) {
+    if (getTrackerLayerCase(TRACK_HITS, StripSubdetector::TEC, layer) == HIT_TYPE::VALID) {
+      count++;
+    }
+  }
+  return count;
+}
+
+int Run3ScoutingHitPattern::pixelBarrelLayersWithoutMeasurement(HitCategory category) const {
+  int count = 0;
+  uint16_t NPixBarrel = 4;
+  for (uint16_t layer = 1; layer <= NPixBarrel; layer++) {
+    if (getTrackerLayerCase(category, PixelSubdetector::PixelBarrel, layer) == HIT_TYPE::MISSING) {
+      count++;
+    }
+  }
+  return count;
+}
+
+int Run3ScoutingHitPattern::pixelEndcapLayersWithoutMeasurement(HitCategory category) const {
+  int count = 0;
+  uint16_t NPixForward = 3;
+  for (uint16_t layer = 1; layer <= NPixForward; layer++) {
+    if (getTrackerLayerCase(category, PixelSubdetector::PixelEndcap, layer) == HIT_TYPE::MISSING) {
+      count++;
+    }
+  }
+  return count;
+}
+
+int Run3ScoutingHitPattern::stripTIBLayersWithoutMeasurement(HitCategory category) const {
+  int count = 0;
+  for (uint16_t layer = 1; layer <= 4; layer++) {
+    if (getTrackerLayerCase(category, StripSubdetector::TIB, layer) == HIT_TYPE::MISSING) {
+      count++;
+    }
+  }
+  return count;
+}
+
+int Run3ScoutingHitPattern::stripTIDLayersWithoutMeasurement(HitCategory category) const {
+  int count = 0;
+  for (uint16_t layer = 1; layer <= 3; layer++) {
+    if (getTrackerLayerCase(category, StripSubdetector::TID, layer) == HIT_TYPE::MISSING) {
+      count++;
+    }
+  }
+  return count;
+}
+
+int Run3ScoutingHitPattern::stripTOBLayersWithoutMeasurement(HitCategory category) const {
+  int count = 0;
+  for (uint16_t layer = 1; layer <= 6; layer++) {
+    if (getTrackerLayerCase(category, StripSubdetector::TOB, layer) == HIT_TYPE::MISSING) {
+      count++;
+    }
+  }
+  return count;
+}
+
+int Run3ScoutingHitPattern::stripTECLayersWithoutMeasurement(HitCategory category) const {
+  int count = 0;
+  for (uint16_t layer = 1; layer <= 9; layer++) {
+    if (getTrackerLayerCase(category, StripSubdetector::TEC, layer) == HIT_TYPE::MISSING) {
+      count++;
+    }
+  }
+  return count;
+}
+
+int Run3ScoutingHitPattern::pixelBarrelLayersTotallyOffOrBad(HitCategory category) const {
+  int count = 0;
+  uint16_t NPixBarrel = 4;
+  for (uint16_t layer = 1; layer <= NPixBarrel; layer++) {
+    if (getTrackerLayerCase(category, PixelSubdetector::PixelBarrel, layer) == HIT_TYPE::INACTIVE) {
+      count++;
+    }
+  }
+  return count;
+}
+
+int Run3ScoutingHitPattern::pixelEndcapLayersTotallyOffOrBad(HitCategory category) const {
+  int count = 0;
+  uint16_t NPixForward = 3;
+  for (uint16_t layer = 1; layer <= NPixForward; layer++) {
+    if (getTrackerLayerCase(category, PixelSubdetector::PixelEndcap, layer) == HIT_TYPE::INACTIVE) {
+      count++;
+    }
+  }
+  return count;
+}
+
+int Run3ScoutingHitPattern::stripTIBLayersTotallyOffOrBad(HitCategory category) const {
+  int count = 0;
+  for (uint16_t layer = 1; layer <= 4; layer++) {
+    if (getTrackerLayerCase(category, StripSubdetector::TIB, layer) == HIT_TYPE::INACTIVE) {
+      count++;
+    }
+  }
+  return count;
+}
+
+int Run3ScoutingHitPattern::stripTIDLayersTotallyOffOrBad(HitCategory category) const {
+  int count = 0;
+  for (uint16_t layer = 1; layer <= 3; layer++) {
+    if (getTrackerLayerCase(category, StripSubdetector::TID, layer) == HIT_TYPE::INACTIVE) {
+      count++;
+    }
+  }
+  return count;
+}
+
+int Run3ScoutingHitPattern::stripTOBLayersTotallyOffOrBad(HitCategory category) const {
+  int count = 0;
+  for (uint16_t layer = 1; layer <= 6; layer++) {
+    if (getTrackerLayerCase(category, StripSubdetector::TOB, layer) == HIT_TYPE::INACTIVE) {
+      count++;
+    }
+  }
+  return count;
+}
+
+int Run3ScoutingHitPattern::stripTECLayersTotallyOffOrBad(HitCategory category) const {
+  int count = 0;
+  for (uint16_t layer = 1; layer <= 9; layer++) {
+    if (getTrackerLayerCase(category, StripSubdetector::TEC, layer) == HIT_TYPE::INACTIVE) {
+      count++;
+    }
+  }
+  return count;
+}
+
+int Run3ScoutingHitPattern::pixelBarrelLayersNull() const {
+  int count = 0;
+  uint16_t NPixBarrel = 4;
+  for (uint16_t layer = 1; layer <= NPixBarrel; layer++) {
+    if (getTrackerLayerCase(TRACK_HITS, PixelSubdetector::PixelBarrel, layer) == NULL_RETURN) {
+      count++;
+    }
+  }
+  return count;
+}
+
+int Run3ScoutingHitPattern::pixelEndcapLayersNull() const {
+  int count = 0;
+  uint16_t NPixForward = 3;
+  for (uint16_t layer = 1; layer <= NPixForward; layer++) {
+    if (getTrackerLayerCase(TRACK_HITS, PixelSubdetector::PixelEndcap, layer) == NULL_RETURN) {
+      count++;
+    }
+  }
+  return count;
+}
+
+int Run3ScoutingHitPattern::stripTIBLayersNull() const {
+  int count = 0;
+  for (uint16_t layer = 1; layer <= 4; layer++) {
+    if (getTrackerLayerCase(TRACK_HITS, StripSubdetector::TIB, layer) == NULL_RETURN) {
+      count++;
+    }
+  }
+  return count;
+}
+
+int Run3ScoutingHitPattern::stripTIDLayersNull() const {
+  int count = 0;
+  for (uint16_t layer = 1; layer <= 3; layer++) {
+    if (getTrackerLayerCase(TRACK_HITS, StripSubdetector::TID, layer) == NULL_RETURN) {
+      count++;
+    }
+  }
+  return count;
+}
+
+int Run3ScoutingHitPattern::stripTOBLayersNull() const {
+  int count = 0;
+  for (uint16_t layer = 1; layer <= 6; layer++) {
+    if (getTrackerLayerCase(TRACK_HITS, StripSubdetector::TOB, layer) == NULL_RETURN) {
+      count++;
+    }
+  }
+  return count;
+}
+
+int Run3ScoutingHitPattern::stripTECLayersNull() const {
+  int count = 0;
+  for (uint16_t layer = 1; layer <= 9; layer++) {
+    if (getTrackerLayerCase(TRACK_HITS, StripSubdetector::TEC, layer) == NULL_RETURN) {
+      count++;
+    }
+  }
+  return count;
+}
+
+void Run3ScoutingHitPattern::printHitPattern(HitCategory category, int position, std::ostream& stream) const {
+  uint16_t pattern = getHitPattern(category, position);
+  stream << "\t";
+  if (muonHitFilter(pattern)) {
+    stream << "muon";
+  } else if (trackerHitFilter(pattern)) {
+    stream << "tracker";
+  } else if (timingHitFilter(pattern)) {
+    stream << "timing";
+  }
+
+  stream << "\tsubstructure " << getSubStructure(pattern);
+  if (muonHitFilter(pattern)) {
+    stream << "\tstation " << getMuonStation(pattern);
+    if (muonDTHitFilter(pattern)) {
+      stream << "\tdt superlayer " << getDTSuperLayer(pattern);
+    } else if (muonCSCHitFilter(pattern)) {
+      stream << "\tcsc ring " << getCSCRing(pattern);
+    } else if (muonRPCHitFilter(pattern)) {
+      stream << "\trpc " << (getRPCregion(pattern) ? "endcaps" : "barrel") << ", layer " << getRPCLayer(pattern);
+    } else if (muonGEMHitFilter(pattern)) {
+      stream << "\tgem "
+             << " station " << getGEMStation(pattern) << ", layer" << getGEMLayer(pattern);
+    } else if (muonME0HitFilter(pattern)) {
+      stream << "\tme0 ";
+    } else {
+      stream << "(UNKNOWN Muon SubStructure!) \tsubsubstructure " << getSubStructure(pattern);
+    }
+  } else if (timingHitFilter(pattern)) {
+    stream << "\tdetector " << getSubStructure(pattern);
+  } else {
+    stream << "\tlayer " << getLayer(pattern);
+  }
+  stream << "\thit type " << getHitType(pattern);
+  stream << std::endl;
+}
+
+void Run3ScoutingHitPattern::print(HitCategory category, std::ostream& stream) const {
+  stream << "Run3ScoutingHitPattern" << std::endl;
+  for (int i = 0; i < numberOfAllHits(category); ++i) {
+    printHitPattern(category, i, stream);
+  }
+  std::ios_base::fmtflags flags = stream.flags();
+  stream.setf(std::ios_base::hex, std::ios_base::basefield);
+  stream.setf(std::ios_base::showbase);
+
+  for (int i = 0; i < this->numberOfAllHits(category); ++i) {
+    stream << getHitPattern(category, i) << std::endl;
+  }
+
+  stream.flags(flags);
+}
+
+uint16_t Run3ScoutingHitPattern::isStereo(DetId i, const TrackerTopology& ttopo) {
+  if (i.det() != DetId::Tracker) {
+    return 0;
+  }
+
+  switch (i.subdetId()) {
+    case PixelSubdetector::PixelBarrel:
+    case PixelSubdetector::PixelEndcap:
+      return 0;
+    case StripSubdetector::TIB:
+      return ttopo.tibIsStereo(i);
+    case StripSubdetector::TID:
+      return ttopo.tidIsStereo(i);
+    case StripSubdetector::TOB:
+      return ttopo.tobIsStereo(i);
+    case StripSubdetector::TEC:
+      return ttopo.tecIsStereo(i);
+    default:
+      return 0;
+  }
+}
+
+int Run3ScoutingHitPattern::muonStations(int subdet, int hitType) const {
+  int stations[5] = {0, 0, 0, 0, 0};
+  for (int i = beginTrackHits; i < endTrackHits; ++i) {
+    uint16_t pattern = getHitPatternByAbsoluteIndex(i);
+    if (muonHitFilter(pattern) && (subdet == 0 || int(getSubStructure(pattern)) == subdet) &&
+        (hitType == -1 || int(getHitType(pattern)) == hitType)) {
+      stations[getMuonStation(pattern)] = 1;
+    }
+  }
+
+  return stations[0] + stations[1] + stations[2] + stations[3] + stations[4];
+}
+
+int Run3ScoutingHitPattern::innermostMuonStationWithHits(int hitType) const {
+  int ret = 0;
+  for (int i = beginTrackHits; i < endTrackHits; ++i) {
+    uint16_t pattern = getHitPatternByAbsoluteIndex(i);
+    if (muonHitFilter(pattern) && (hitType == -1 || int(getHitType(pattern)) == hitType)) {
+      int stat = getMuonStation(pattern);
+      if (ret == 0 || stat < ret) {
+        ret = stat;
+      }
+    }
+  }
+
+  return ret;
+}
+
+int Run3ScoutingHitPattern::outermostMuonStationWithHits(int hitType) const {
+  int ret = 0;
+  for (int i = beginTrackHits; i < endTrackHits; ++i) {
+    uint16_t pattern = getHitPatternByAbsoluteIndex(i);
+    if (muonHitFilter(pattern) && (hitType == -1 || int(getHitType(pattern)) == hitType)) {
+      int stat = getMuonStation(pattern);
+      if (ret == 0 || stat > ret) {
+        ret = stat;
+      }
+    }
+  }
+  return ret;
+}
+
+int Run3ScoutingHitPattern::numberOfDTStationsWithRPhiView() const {
+  int stations[4] = {0, 0, 0, 0};
+  for (int i = beginTrackHits; i < endTrackHits; ++i) {
+    uint16_t pattern = getHitPatternByAbsoluteIndex(i);
+
+    if (muonDTHitFilter(pattern) && validHitFilter(pattern) && getDTSuperLayer(pattern) != 2) {
+      stations[getMuonStation(pattern) - 1] = 1;
+    }
+  }
+  return stations[0] + stations[1] + stations[2] + stations[3];
+}
+
+int Run3ScoutingHitPattern::numberOfDTStationsWithRZView() const {
+  int stations[4] = {0, 0, 0, 0};
+  for (int i = beginTrackHits; i < endTrackHits; ++i) {
+    uint16_t pattern = getHitPatternByAbsoluteIndex(i);
+    if (muonDTHitFilter(pattern) && validHitFilter(pattern) && getDTSuperLayer(pattern) == 2) {
+      stations[getMuonStation(pattern) - 1] = 1;
+    }
+  }
+  return stations[0] + stations[1] + stations[2] + stations[3];
+}
+
+int Run3ScoutingHitPattern::numberOfDTStationsWithBothViews() const {
+  int stations[4][2] = {{0, 0}, {0, 0}, {0, 0}, {0, 0}};
+  for (int i = beginTrackHits; i < endTrackHits; ++i) {
+    uint16_t pattern = getHitPatternByAbsoluteIndex(i);
+    if (muonDTHitFilter(pattern) && validHitFilter(pattern)) {
+      stations[getMuonStation(pattern) - 1][getDTSuperLayer(pattern) == 2] = 1;
+    }
+  }
+
+  return stations[0][0] * stations[0][1] + stations[1][0] * stations[1][1] + stations[2][0] * stations[2][1] +
+         stations[3][0] * stations[3][1];
+}
+
+void Run3ScoutingHitPattern::insertHit(const uint16_t pattern) {
+  int offset = hitCount * HIT_LENGTH;
+  for (int i = 0; i < HIT_LENGTH; i++) {
+    int pos = offset + i;
+    uint16_t bit = (pattern >> i) & 0x1;
+    //equivalent to hitPattern[pos / 16] += bit << ((offset + i) % 16);
+    hitPattern[pos >> 4] += bit << ((offset + i) & (16 - 1));
+  }
+  hitCount++;
+}
+
+bool Run3ScoutingHitPattern::insertTrackHit(const uint16_t pattern) {
+  // if begin is 0, this is the first hit of this type being inserted, so
+  // we need to update begin so it points to the correct index, the first
+  // empty index.
+  // unlikely, because it will happen only when inserting
+  // the first hit of this type
+  if UNLIKELY ((0 == beginTrackHits && 0 == endTrackHits)) {
+    beginTrackHits = hitCount;
+    // before the first hit of this type is inserted, there are no hits
+    endTrackHits = beginTrackHits;
+  }
+
+  insertHit(pattern);
+  endTrackHits++;
+
+  return true;
+}
+
+bool Run3ScoutingHitPattern::insertExpectedInnerHit(const uint16_t pattern) {
+  if UNLIKELY ((0 == beginInner && 0 == endInner)) {
+    beginInner = hitCount;
+    endInner = beginInner;
+  }
+
+  insertHit(pattern);
+  endInner++;
+
+  return true;
+}
+
+bool Run3ScoutingHitPattern::insertExpectedOuterHit(const uint16_t pattern) {
+  if UNLIKELY ((0 == beginOuter && 0 == endOuter)) {
+    beginOuter = hitCount;
+    endOuter = beginOuter;
+  }
+
+  insertHit(pattern);
+  endOuter++;
+
+  return true;
+}

--- a/DataFormats/Scouting/src/classes.h
+++ b/DataFormats/Scouting/src/classes.h
@@ -12,6 +12,7 @@
 #include "DataFormats/Scouting/interface/Run3ScoutingTrack.h"
 #include "DataFormats/Scouting/interface/Run3ScoutingVertex.h"
 #include "DataFormats/Scouting/interface/Run3ScoutingElectron.h"
+#include "DataFormats/Scouting/interface/Run3ScoutingHitPattern.h"
 #include "DataFormats/Scouting/interface/Run3ScoutingMuon.h"
 #include "DataFormats/Scouting/interface/Run3ScoutingPhoton.h"
 #include "DataFormats/Common/interface/Wrapper.h"

--- a/DataFormats/Scouting/src/classes_def.xml
+++ b/DataFormats/Scouting/src/classes_def.xml
@@ -42,8 +42,9 @@
   <class name="Run3ScoutingElectron" ClassVersion="3">
       <version ClassVersion="3" checksum="1086011373"/>
   </class>
-  <class name="Run3ScoutingMuon" ClassVersion="3">
+  <class name="Run3ScoutingMuon" ClassVersion="4">
       <version ClassVersion="3" checksum="3882497397"/>
+      <version ClassVersion="4" checksum="1012593148"/>
   </class>
   <class name="Run3ScoutingPhoton" ClassVersion="3">
       <version ClassVersion="3" checksum="1683146807"/>
@@ -51,6 +52,21 @@
   <class name="Run3ScoutingTrack" ClassVersion="3">
       <version ClassVersion="3" checksum="3352318277"/>
   </class>
+  <class name="Run3ScoutingHitPattern"/>
+  <ioread
+      sourceClass="Run3ScoutingMuon"
+      source="reco::HitPattern trk_hitPattern_"
+      version="[3]"
+      targetClass="Run3ScoutingMuon"
+      target="trk_run3ScoutingHitPattern_"
+      include="DataFormats/Scouting/interface/Run3ScoutingHitPattern.h"
+      >
+    <![CDATA[
+	     Run3ScoutingHitPattern nhp;
+	     nhp.fillRun3ScoutingHitPatternWithHitPattern(onfile.trk_hitPattern_);
+	     trk_run3ScoutingHitPattern_ = nhp;
+    ]]>
+  </ioread>
   <class name="std::vector<ScoutingCaloJet>"/>
   <class name="std::vector<ScoutingPFJet>"/>
   <class name="std::vector<ScoutingParticle>"/>

--- a/DataFormats/Scouting/src/fillRun3ScoutingHitPatternWithHitPattern.cc
+++ b/DataFormats/Scouting/src/fillRun3ScoutingHitPatternWithHitPattern.cc
@@ -1,0 +1,85 @@
+#include "DataFormats/Scouting/interface/Run3ScoutingHitPattern.h"
+#include "DataFormats/TrackReco/interface/HitPattern.h"
+
+/* This file contains the function used to read HitPattern and fill Run3ScoutingHitPattern (= HitPattern, v13) */
+
+constexpr unsigned short HitSize = reco::HitPattern::HIT_LENGTH;
+constexpr unsigned short PatternSize = reco::HitPattern::ARRAY_LENGTH;
+constexpr int MaxHits = reco::HitPattern::MaxHits;
+
+auto getHitFromTrackRecoHitPattern(const uint16_t hitPattern[], const int position, const int hitCount) {
+  if UNLIKELY ((position < 0 || position >= hitCount)) {
+    return Run3ScoutingHitPattern::EMPTY_PATTERN;
+  }
+
+  const uint16_t bitEndOffset = (position + 1) * HitSize;
+  const uint8_t secondWord = (bitEndOffset >> 4);
+  const uint8_t secondWordBits = bitEndOffset & (16 - 1);
+
+  if (secondWordBits >= HitSize) {
+    // full block is in this word
+    const uint8_t lowBitsToTrash = secondWordBits - HitSize;
+    uint16_t myResult = (hitPattern[secondWord] >> lowBitsToTrash) & ((1 << HitSize) - 1);
+    return myResult;
+  } else {
+    const uint8_t firstWordBits = HitSize - secondWordBits;
+    const uint16_t firstWordBlock = hitPattern[secondWord - 1] >> (16 - firstWordBits);
+    const uint16_t secondWordBlock = hitPattern[secondWord] & ((1 << secondWordBits) - 1);
+    uint16_t myResult = firstWordBlock + (secondWordBlock << firstWordBits);
+    return myResult;
+  }
+}
+
+auto hitTypeFromTrackRecoHitPattern(const uint16_t pattern,
+                                    const unsigned short HitTypeOffset,
+                                    const unsigned short HitTypeMask) {
+  constexpr uint16_t VALID_CONST = (uint16_t)TrackingRecHit::valid;
+  constexpr uint16_t MISSING_CONST = (uint16_t)TrackingRecHit::missing;
+  constexpr uint16_t INACTIVE_CONST = (uint16_t)TrackingRecHit::inactive;
+  constexpr uint16_t BAD_CONST = (uint16_t)TrackingRecHit::bad;
+
+  const uint16_t rawHitType = (pattern >> HitTypeOffset) & HitTypeMask;
+
+  TrackingRecHit::Type hitType = TrackingRecHit::valid;
+  switch (rawHitType) {
+    case VALID_CONST:
+      hitType = TrackingRecHit::valid;
+      break;
+    case MISSING_CONST:
+      hitType = TrackingRecHit::missing;
+      break;
+    case INACTIVE_CONST:
+      hitType = TrackingRecHit::inactive;
+      break;
+    case BAD_CONST:
+      hitType = TrackingRecHit::bad;
+      break;
+  }
+
+  return hitType;
+}
+
+void Run3ScoutingHitPattern::fillRun3ScoutingHitPatternWithHitPattern(const reco::HitPattern trackRecoHitPattern) {
+  for (int i = 0; i < MaxHits; i++) {
+    if (i >= trackRecoHitPattern.hitCount)
+      break;
+
+    uint16_t pattern = getHitFromTrackRecoHitPattern(trackRecoHitPattern.hitPattern, i, trackRecoHitPattern.hitCount);
+    if (pattern == 0) {
+      break;
+    }
+    if (!this->appendHit(
+            pattern,
+            hitTypeFromTrackRecoHitPattern(pattern, reco::HitPattern::HitTypeOffset, reco::HitPattern::HitTypeMask))) {
+      break;
+    }
+  }
+
+  this->hitCount = trackRecoHitPattern.hitCount;
+  this->beginTrackHits = trackRecoHitPattern.beginTrackHits;
+  this->endTrackHits = trackRecoHitPattern.endTrackHits;
+  this->beginInner = trackRecoHitPattern.beginInner;
+  this->endInner = trackRecoHitPattern.endInner;
+  this->beginOuter = trackRecoHitPattern.beginOuter;
+  this->endOuter = trackRecoHitPattern.endOuter;
+}

--- a/DataFormats/TrackReco/interface/HitPattern.h
+++ b/DataFormats/TrackReco/interface/HitPattern.h
@@ -126,6 +126,7 @@
 #include "DataFormats/ForwardDetId/interface/MTDDetId.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
+#include "DataFormats/Scouting/interface/Run3ScoutingHitPattern.h"
 #include "FWCore/Utilities/interface/Likely.h"
 
 #include <utility>
@@ -135,6 +136,7 @@
 #include <memory>
 
 class TrackerTopology;
+class Run3ScoutingHitPattern;
 
 namespace test {
   namespace TestHitPattern {
@@ -423,6 +425,8 @@ namespace reco {
     int numberOfDTStationsWithRPhiView() const;
     int numberOfDTStationsWithRZView() const;
     int numberOfDTStationsWithBothViews() const;
+
+    friend class ::Run3ScoutingHitPattern;
 
     //only used by ROOT IO rule to read v12 HitPatterns
     static bool fillNewHitPatternWithOldHitPattern_v12(const uint16_t oldHitPattern[],

--- a/HLTrigger/Muon/plugins/HLTScoutingMuonProducer.cc
+++ b/HLTrigger/Muon/plugins/HLTScoutingMuonProducer.cc
@@ -140,10 +140,14 @@ void HLTScoutingMuonProducer::produce(edm::StreamID sid, edm::Event& iEvent, edm
   std::vector<int> vtxInd;
   float minDR2 = 1e-06;
   int index = 0;
+  Run3ScoutingHitPattern run3ScoutingHitPattern;
 
   for (auto& muon : *ChargedCandidateCollection) {
     reco::RecoChargedCandidateRef muonRef = getRef(ChargedCandidateCollection, index);
     ++index;
+
+    run3ScoutingHitPattern.clear();
+
     if (muonRef.isNull() || !muonRef.isAvailable())
       continue;
 
@@ -222,6 +226,8 @@ void HLTScoutingMuonProducer::produce(edm::StreamID sid, edm::Event& iEvent, edm
       trackiso = (*TrackIsoMap)[muonRef];
     }
 
+    run3ScoutingHitPattern.fillRun3ScoutingHitPatternWithHitPattern(track->hitPattern());
+
     vtxInd.reserve(vtxMuPair.size());
     for (unsigned int i = 0; i < vtxMuPair.size(); i++) {
       float dr2_1 = reco::deltaR2(((vtxMuPair[i]).first), muon);
@@ -284,8 +290,9 @@ void HLTScoutingMuonProducer::produce(edm::StreamID sid, edm::Event& iEvent, edm
                            track->vx(),
                            track->vy(),
                            track->vz(),
-                           track->hitPattern(),
+                           run3ScoutingHitPattern,
                            vtxInd);
+
     vtxInd.clear();
   }
 

--- a/HLTrigger/Muon/plugins/HLTScoutingMuonProducer.h
+++ b/HLTrigger/Muon/plugins/HLTScoutingMuonProducer.h
@@ -39,6 +39,7 @@ Description: Producer for Run3ScoutingMuon
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
+#include "DataFormats/Scouting/interface/Run3ScoutingHitPattern.h"
 #include "DataFormats/Scouting/interface/Run3ScoutingMuon.h"
 #include "DataFormats/Scouting/interface/Run3ScoutingVertex.h"
 


### PR DESCRIPTION
### PR description:

This PR is meant to address issue #32219.
It is introducing a new Run3ScoutingHitPattern class in DataFormats/Scouting,  to be used for Run-3 scouting (in Run3ScoutingMuon). The class is a "frozen" copy of version 13 (present version) of reco::HitPattern.
A function is defined in order to fill Run3ScoutingHitPattern from reco::HitPattern as well as to define an IO rule for backwards compatibility (with version 3 of Run3ScoutingMuon).

### PR validation:

Rerunning the HLT step ("TEST"), and reading hit pattern for "TEST" and for original "HLT" instance, same objects are retrieved:
```
Events->Scan("Run3ScoutingMuons_hltScoutingMuonPacker__TEST.obj.trk_run3ScoutingHitPattern_.hitCount:Run3ScoutingMuons_hltScoutingMuonPacker__HLT.obj.trk_run3ScoutingHitPattern_.hitCount")
***********************************************
*    Row   * Instance * Run3Scout * Run3Scout *
***********************************************
*        0 *        0 *           *           *
*        1 *        0 *        13 *        13 *
*        2 *        0 *        11 *        11 *
*        2 *        1 *        14 *        14 *
*        3 *        0 *        12 *        12 *
*        4 *        0 *        13 *        13 *
*        5 *        0 *           *           *
*        6 *        0 *        15 *        15 *
*        7 *        0 *           *           *
*        8 *        0 *           *           *
*        9 *        0 *        12 *        12 *
***********************************************

```

FYI @dsperka @jsalfeld