### PR TITLE
Track DNN update on mkFit tracks

### DIFF
--- a/Configuration/Eras/python/Era_Run2_2017_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2017_cff.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
-
+from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
 from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 from Configuration.Eras.Modifier_run2_ECAL_2017_cff import run2_ECAL_2017
@@ -27,5 +27,5 @@ from Configuration.Eras.Modifier_strips_vfp30_2016_cff import strips_vfp30_2016
 
 Run2_2017 = cms.ModifierChain(Run2_2016.copyAndExclude([run2_muon_2016, run2_HLTconditions_2016, run2_ECAL_2016, run2_egamma_2016,pixel_2016,run2_jme_2016, strips_vfp30_2016, ctpps_2016]),
                               phase1Pixel, run2_ECAL_2017, run2_HF_2017, run2_HCAL_2017, run2_HE_2017, run2_HEPlan1_2017, 
-                              trackingPhase1, trackingMkFitProd, run2_GEM_2017, stage2L1Trigger_2017, run2_HLTconditions_2017, run2_muon_2017,run2_egamma_2017, ctpps_2017, run2_jme_2017)
+                              trackingPhase1, trackdnn, trackingMkFitProd, run2_GEM_2017, stage2L1Trigger_2017, run2_HLTconditions_2017, run2_muon_2017,run2_egamma_2017, ctpps_2017, run2_jme_2017)
 

--- a/Configuration/Eras/python/Era_Run2_2018_highBetaStar_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2018_highBetaStar_cff.py
@@ -3,4 +3,4 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
 from Configuration.Eras.Modifier_highBetaStar_2018_cff import highBetaStar_2018
 
-Run2_2018_highBetaStar = cms.ModifierChain(Run2_2018, highBetaStar_2018)
+Run2_2018_highBetaStar = cms.ModifierChain(Run2_2018.copyAndExclude([trackdnn]), highBetaStar_2018)

--- a/Configuration/Eras/python/Era_Run2_2018_highBetaStar_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2018_highBetaStar_cff.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
-
+from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
 from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
 from Configuration.Eras.Modifier_highBetaStar_2018_cff import highBetaStar_2018
 

--- a/Configuration/Eras/python/Era_Run2_2018_pp_on_AA_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2018_pp_on_AA_cff.py
@@ -6,8 +6,5 @@ from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 from Configuration.Eras.ModifierChain_trackingMkFitProd_cff import trackingMkFitProd
 from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers
 
-<<<<<<< HEAD
-Run2_2018_pp_on_AA = cms.ModifierChain(Run2_2018.copyAndExclude([trackingMkFitProd, trackingNoLoopers]), pp_on_AA, pp_on_AA_2018)
-=======
-Run2_2018_pp_on_AA = cms.ModifierChain(Run2_2018.copyAndExclude([trackingMkFitProd, trackdnn]), pp_on_AA, pp_on_AA_2018)
->>>>>>> remove dnn in the heavy ion track selection
+Run2_2018_pp_on_AA = cms.ModifierChain(Run2_2018.copyAndExclude([trackingMkFitProd, trackdnn, trackingNoLoopers]), pp_on_AA, pp_on_AA_2018)
+

--- a/Configuration/Eras/python/Era_Run2_2018_pp_on_AA_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2018_pp_on_AA_cff.py
@@ -6,4 +6,8 @@ from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 from Configuration.Eras.ModifierChain_trackingMkFitProd_cff import trackingMkFitProd
 from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers
 
+<<<<<<< HEAD
 Run2_2018_pp_on_AA = cms.ModifierChain(Run2_2018.copyAndExclude([trackingMkFitProd, trackingNoLoopers]), pp_on_AA, pp_on_AA_2018)
+=======
+Run2_2018_pp_on_AA = cms.ModifierChain(Run2_2018.copyAndExclude([trackingMkFitProd, trackdnn]), pp_on_AA, pp_on_AA_2018)
+>>>>>>> remove dnn in the heavy ion track selection

--- a/Configuration/Eras/python/Era_Run2_2018_pp_on_AA_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2018_pp_on_AA_cff.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
-
+from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
 from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018

--- a/Configuration/Eras/python/Era_Run3_noMkFit_cff.py
+++ b/Configuration/Eras/python/Era_Run3_noMkFit_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
-
+from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
 from Configuration.Eras.Era_Run3_cff import Run3
 from Configuration.Eras.ModifierChain_trackingMkFitProd_cff import trackingMkFitProd
 
-Run3_noMkFit = Run3.copyAndExclude([trackingMkFitProd])
+Run3_noMkFit = cms.ModifierChain(Run3.copyAndExclude([trackingMkFitProd]), trackdnn_CKF)

--- a/Configuration/Eras/python/Era_Run3_noMkFit_cff.py
+++ b/Configuration/Eras/python/Era_Run3_noMkFit_cff.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
+from Configuration.ProcessModifiers.trackdnn_CKF_cff import trackdnn_CKF
 from Configuration.Eras.Era_Run3_cff import Run3
 from Configuration.Eras.ModifierChain_trackingMkFitProd_cff import trackingMkFitProd
 

--- a/Configuration/Eras/python/Era_Run3_pp_on_PbPb_cff.py
+++ b/Configuration/Eras/python/Era_Run3_pp_on_PbPb_cff.py
@@ -6,8 +6,5 @@ from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
 from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers
 
-<<<<<<< HEAD
-Run3_pp_on_PbPb = cms.ModifierChain(Run3_noMkFit.copyAndExclude([trackingNoLoopers]), pp_on_AA, pp_on_PbPb_run3)
-=======
-Run3_pp_on_PbPb = cms.ModifierChain(Run3_noMkFit.copyAndExclude([trackdnn, trackdnn_CKF]), pp_on_AA, pp_on_PbPb_run3)
->>>>>>> remove dnn in the heavy ion track selection
+Run3_pp_on_PbPb = cms.ModifierChain(Run3_noMkFit.copyAndExclude([trackdnn, trackdnn_CKF, trackingNoLoopers]), pp_on_AA, pp_on_PbPb_run3)
+

--- a/Configuration/Eras/python/Era_Run3_pp_on_PbPb_cff.py
+++ b/Configuration/Eras/python/Era_Run3_pp_on_PbPb_cff.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
-
+from Configuration.ProcessModifiers.trackdnn_CKF_cff import trackdnn_CKF
+from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
 from Configuration.Eras.Era_Run3_noMkFit_cff import Run3_noMkFit
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3

--- a/Configuration/Eras/python/Era_Run3_pp_on_PbPb_cff.py
+++ b/Configuration/Eras/python/Era_Run3_pp_on_PbPb_cff.py
@@ -5,4 +5,8 @@ from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
 from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers
 
+<<<<<<< HEAD
 Run3_pp_on_PbPb = cms.ModifierChain(Run3_noMkFit.copyAndExclude([trackingNoLoopers]), pp_on_AA, pp_on_PbPb_run3)
+=======
+Run3_pp_on_PbPb = cms.ModifierChain(Run3_noMkFit.copyAndExclude([trackdnn, trackdnn_CKF]), pp_on_AA, pp_on_PbPb_run3)
+>>>>>>> remove dnn in the heavy ion track selection

--- a/Configuration/ProcessModifiers/python/trackdnn_CKF_cff.py
+++ b/Configuration/ProcessModifiers/python/trackdnn_CKF_cff.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
 # This modifier sets the used tracking classifier to be a deep neural network instead of the BDT
-trackdnn = cms.Modifier()
 
+trackdnn_CKF = cms.Modifier()

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackTfClassifier.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackTfClassifier.cc
@@ -20,12 +20,11 @@ namespace {
 
     {}
 
-    static const char* name() { return "TrackTfClassifier"; }
+    static const char* name() { return "trackTfClassifierDefault"; }
 
     static void fillDescriptions(edm::ParameterSetDescription& desc) {
       desc.add<std::string>("tfDnnLabel", "trackSelectionTf");
     }
-
     void beginStream() {}
 
     void initEvent(const edm::EventSetup& es) {

--- a/RecoTracker/FinalTrackSelectors/python/trackSelectionTf_CKF_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/trackSelectionTf_CKF_cfi.py
@@ -1,0 +1,7 @@
+from RecoTracker.FinalTrackSelectors.tfGraphDefProducer_cfi import tfGraphDefProducer as _tfGraphDefProducer
+
+trackSelectionTf_CKF = _tfGraphDefProducer.clone(
+    ComponentName = "trackSelectionTf_CKF",
+    FileName = "RecoTracker/FinalTrackSelectors/data/TrackTfClassifier/CKF_2021Run3.pb"
+)
+

--- a/RecoTracker/FinalTrackSelectors/python/trackSelectionTf_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/trackSelectionTf_cfi.py
@@ -1,5 +1,7 @@
 from RecoTracker.FinalTrackSelectors.tfGraphDefProducer_cfi import tfGraphDefProducer as _tfGraphDefProducer
 trackSelectionTf = _tfGraphDefProducer.clone(
     ComponentName = "trackSelectionTf",
-    FileName = "RecoTracker/FinalTrackSelectors/data/TrackTfClassifier/QCDFlatPU_QCDHighPt_ZEE_DisplacedSUSY_2020.pb"
+    FileName = "RecoTracker/FinalTrackSelectors/data/TrackTfClassifier/MkFit4plus3_2021Run3.pb"
 )
+
+

--- a/RecoTracker/FinalTrackSelectors/python/trackTfClassifier_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/trackTfClassifier_cfi.py
@@ -1,5 +1,5 @@
 from Configuration.ProcessModifiers.trackdnn_CKF_cff import trackdnn_CKF
-import RecoTracker.FinalTrackSelectors.TrackTfClassifier_cfi as _mod
+import RecoTracker.FinalTrackSelectors.trackTfClassifierDefault_cfi as _mod
 
-trackTfClassifier = _mod.TrackTfClassifier.clone()
+trackTfClassifier = _mod.trackTfClassifierDefault.clone()
 trackdnn_CKF.toModify(trackTfClassifier.mva, tfDnnLabel = 'trackSelectionTf_CKF')

--- a/RecoTracker/FinalTrackSelectors/python/trackTfClassifier_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/trackTfClassifier_cfi.py
@@ -1,0 +1,5 @@
+from Configuration.ProcessModifiers.trackdnn_CKF_cff import trackdnn_CKF
+import RecoTracker.FinalTrackSelectors.TrackTfClassifier_cfi as _mod
+
+trackTfClassifier = _mod.TrackTfClassifier.clone()
+trackdnn_CKF.toModify(trackTfClassifier.mva, tfDnnLabel = 'trackSelectionTf_CKF')

--- a/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
@@ -3,8 +3,8 @@ import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 
 #for dnn classifier
-from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
-from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary
+from Configuration.ProcessModifiers.trackdnn_cff import trackdnn 
+from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary 
 
 # for no-loopers
 from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers
@@ -240,12 +240,14 @@ detachedQuadStep = TrackMVAClassifierDetached.clone(
     qualityCuts = [-0.5,0.0,0.5]
 )
 
-from RecoTracker.FinalTrackSelectors.TrackTfClassifier_cfi import *
+from RecoTracker.FinalTrackSelectors.trackTfClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionTf_cfi import *
-trackdnn.toReplaceWith(detachedQuadStep, TrackTfClassifier.clone(
+from RecoTracker.FinalTrackSelectors.trackSelectionTf_CKF_cfi import *
+trackdnn.toReplaceWith(detachedQuadStep, trackTfClassifier.clone(
     src = 'detachedQuadStepTracks',
-    qualityCuts = qualityCutDictionary['DetachedQuadStep']
+    qualityCuts = qualityCutDictionary.DetachedQuadStep.value()
 ))
+
 
 highBetaStar_2018.toModify(detachedQuadStep,qualityCuts = [-0.7,0.0,0.5])
 pp_on_AA.toModify(detachedQuadStep, 

--- a/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
@@ -3,8 +3,8 @@ import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 
 #for dnn classifier
-from Configuration.ProcessModifiers.trackdnn_cff import trackdnn 
-from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary 
+from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
+from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary
 
 # for no-loopers
 from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers

--- a/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
@@ -7,8 +7,8 @@ from Configuration.Eras.Modifier_fastSim_cff import fastSim
 from FastSimulation.Tracking.SeedingMigration import _hitSetProducerToFactoryPSet
 
 #for dnn classifier
-from Configuration.ProcessModifiers.trackdnn_cff import trackdnn 
-from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary 
+from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
+from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary
 
 # for no-loopers
 from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers

--- a/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
@@ -7,8 +7,8 @@ from Configuration.Eras.Modifier_fastSim_cff import fastSim
 from FastSimulation.Tracking.SeedingMigration import _hitSetProducerToFactoryPSet
 
 #for dnn classifier
-from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
-from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary
+from Configuration.ProcessModifiers.trackdnn_cff import trackdnn 
+from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary 
 
 # for no-loopers
 from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers
@@ -290,11 +290,12 @@ trackingPhase1.toReplaceWith(detachedTripletStep, detachedTripletStepClassifier1
     qualityCuts = [-0.2,0.3,0.8]
 ))
 
-from RecoTracker.FinalTrackSelectors.TrackTfClassifier_cfi import *
+from RecoTracker.FinalTrackSelectors.trackTfClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionTf_cfi import *
-trackdnn.toReplaceWith(detachedTripletStep, TrackTfClassifier.clone(
+from RecoTracker.FinalTrackSelectors.trackSelectionTf_CKF_cfi import *
+trackdnn.toReplaceWith(detachedTripletStep, trackTfClassifier.clone(
      src = 'detachedTripletStepTracks',
-     qualityCuts = qualityCutDictionary['DetachedTripletStep'],
+     qualityCuts = qualityCutDictionary.DetachedTripletStep.value()
 ))
 (trackdnn & fastSim).toModify(detachedTripletStep,vertices = 'firstStepPrimaryVerticesBeforeMixing')
 

--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -3,8 +3,8 @@ import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 
 #for dnn classifier
-from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
-from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary
+from Configuration.ProcessModifiers.trackdnn_cff import trackdnn 
+from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary 
 
 # for no-loopers
 from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers
@@ -282,13 +282,13 @@ highPtTripletStep = TrackMVAClassifierPrompt.clone(
      qualityCuts = [0.2,0.3,0.4]
 )
 
-from RecoTracker.FinalTrackSelectors.TrackTfClassifier_cfi import *
+from RecoTracker.FinalTrackSelectors.trackTfClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionTf_cfi import *
-trackdnn.toReplaceWith(highPtTripletStep, TrackTfClassifier.clone(
+from RecoTracker.FinalTrackSelectors.trackSelectionTf_CKF_cfi import *
+trackdnn.toReplaceWith(highPtTripletStep, trackTfClassifier.clone(
     src = 'highPtTripletStepTracks',
-    qualityCuts = qualityCutDictionary['HighPtTripletStep'],
+    qualityCuts = qualityCutDictionary.HighPtTripletStep.value()
 ))
-
 highBetaStar_2018.toModify(highPtTripletStep,qualityCuts = [-0.2,0.3,0.4])
 pp_on_AA.toModify(highPtTripletStep, 
         mva = dict(GBRForestLabel = 'HIMVASelectorHighPtTripletStep_Phase1'),

--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -3,8 +3,8 @@ import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 
 #for dnn classifier
-from Configuration.ProcessModifiers.trackdnn_cff import trackdnn 
-from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary 
+from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
+from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary
 
 # for no-loopers
 from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -3,8 +3,8 @@ from Configuration.Eras.Modifier_tracker_apv_vfp30_2016_cff import tracker_apv_v
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 
 #for dnn classifier
-from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
-from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary
+from Configuration.ProcessModifiers.trackdnn_cff import trackdnn 
+from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary 
 
 # for no-loopers
 from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers
@@ -335,13 +335,16 @@ trackingPhase1.toReplaceWith(initialStep, initialStepClassifier1.clone(
      qualityCuts = [-0.95,-0.85,-0.75]
 ))
 
-from RecoTracker.FinalTrackSelectors.TrackTfClassifier_cfi import *
+from RecoTracker.FinalTrackSelectors.trackTfClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionTf_cfi import *
-trackdnn.toReplaceWith(initialStep, TrackTfClassifier.clone(
+from RecoTracker.FinalTrackSelectors.trackSelectionTf_CKF_cfi import *
+trackdnn.toReplaceWith(initialStep, trackTfClassifier.clone(
         src         = 'initialStepTracks',
-        qualityCuts = qualityCutDictionary["InitialStep"]
+        qualityCuts = qualityCutDictionary.InitialStep.value()
 ))
+
 (trackdnn & fastSim).toModify(initialStep,vertices = 'firstStepPrimaryVerticesBeforeMixing')
+
 
 pp_on_AA.toModify(initialStep, 
         mva         = dict(GBRForestLabel = 'HIMVASelectorInitialStep_Phase1'),

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -3,8 +3,8 @@ from Configuration.Eras.Modifier_tracker_apv_vfp30_2016_cff import tracker_apv_v
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 
 #for dnn classifier
-from Configuration.ProcessModifiers.trackdnn_cff import trackdnn 
-from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary 
+from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
+from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary
 
 # for no-loopers
 from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers

--- a/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 #for dnn classifier
-from Configuration.ProcessModifiers.trackdnn_cff import trackdnn 
-from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary 
+from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
+from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary
 
 # for no-loopers
 from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers

--- a/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 #for dnn classifier
-from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
-from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary
+from Configuration.ProcessModifiers.trackdnn_cff import trackdnn 
+from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary 
 
 # for no-loopers
 from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers
@@ -282,18 +282,20 @@ trackingPhase1.toReplaceWith(jetCoreRegionalStepBarrel, jetCoreRegionalStep.clon
      src = 'jetCoreRegionalStepBarrelTracks',
 ))
 
-from RecoTracker.FinalTrackSelectors.TrackTfClassifier_cfi import *
+from RecoTracker.FinalTrackSelectors.trackTfClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionTf_cfi import *
-trackdnn.toReplaceWith(jetCoreRegionalStep, TrackTfClassifier.clone(
+from RecoTracker.FinalTrackSelectors.trackSelectionTf_CKF_cfi import *
+trackdnn.toReplaceWith(jetCoreRegionalStep, trackTfClassifier.clone(
      src = 'jetCoreRegionalStepTracks',
-     qualityCuts = qualityCutDictionary["JetCoreRegionalStep"],
+     qualityCuts = qualityCutDictionary.JetCoreRegionalStep.value()
 ))
-trackdnn.toReplaceWith(jetCoreRegionalStepBarrel, TrackTfClassifier.clone(
+trackdnn.toReplaceWith(jetCoreRegionalStepBarrel, trackTfClassifier.clone(
      src = 'jetCoreRegionalStepBarrelTracks',
-     qualityCuts = qualityCutDictionary["JetCoreRegionalStep"],
+     qualityCuts = qualityCutDictionary.JetCoreRegionalStep.value()
 ))
 
 fastSim.toModify(jetCoreRegionalStep,vertices = 'firstStepPrimaryVerticesBeforeMixing')
+
 
 jetCoreRegionalStepEndcap = jetCoreRegionalStep.clone(
     src = 'jetCoreRegionalStepEndcapTracks',

--- a/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
@@ -3,8 +3,8 @@ import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 
 #for dnn classifier
-from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
-from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary
+from Configuration.ProcessModifiers.trackdnn_cff import trackdnn 
+from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary 
 
 # for no-loopers
 from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers
@@ -231,13 +231,13 @@ lowPtQuadStep = TrackMVAClassifierPrompt.clone(
      qualityCuts = [-0.7,-0.35,-0.15]
 )
 
-from RecoTracker.FinalTrackSelectors.TrackTfClassifier_cfi import *
+from RecoTracker.FinalTrackSelectors.trackTfClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionTf_cfi import *
-trackdnn.toReplaceWith(lowPtQuadStep, TrackTfClassifier.clone(
+from RecoTracker.FinalTrackSelectors.trackSelectionTf_CKF_cfi import *
+trackdnn.toReplaceWith(lowPtQuadStep, trackTfClassifier.clone(
     src = 'lowPtQuadStepTracks',
-    qualityCuts = qualityCutDictionary["LowPtQuadStep"]
+    qualityCuts = qualityCutDictionary.LowPtQuadStep.value()
 ))
-
 highBetaStar_2018.toModify(lowPtQuadStep,qualityCuts = [-0.9,-0.35,-0.15])
 pp_on_AA.toModify(lowPtQuadStep, 
         mva         = dict(GBRForestLabel = 'HIMVASelectorLowPtQuadStep_Phase1'),

--- a/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
@@ -3,8 +3,8 @@ import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 
 #for dnn classifier
-from Configuration.ProcessModifiers.trackdnn_cff import trackdnn 
-from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary 
+from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
+from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary
 
 # for no-loopers
 from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -4,8 +4,8 @@ import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 
 #for dnn classifier
-from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
-from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary
+from Configuration.ProcessModifiers.trackdnn_cff import trackdnn 
+from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary 
 
 # for no-loopers
 from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers
@@ -310,13 +310,13 @@ trackingPhase1.toReplaceWith(lowPtTripletStep, lowPtTripletStep.clone(
      qualityCuts = [-0.4,0.0,0.3],
 ))
 
-from RecoTracker.FinalTrackSelectors.TrackTfClassifier_cfi import *
+from RecoTracker.FinalTrackSelectors.trackTfClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionTf_cfi import *
-trackdnn.toReplaceWith(lowPtTripletStep, TrackTfClassifier.clone(
+from RecoTracker.FinalTrackSelectors.trackSelectionTf_CKF_cfi import *
+trackdnn.toReplaceWith(lowPtTripletStep, trackTfClassifier.clone(
     src = 'lowPtTripletStepTracks',
-    qualityCuts = qualityCutDictionary['LowPtTripletStep']
+    qualityCuts = qualityCutDictionary.LowPtTripletStep.value()
 ))
-
 highBetaStar_2018.toModify(lowPtTripletStep,qualityCuts = [-0.7,-0.3,-0.1])
 pp_on_AA.toModify(lowPtTripletStep, 
         mva         = dict(GBRForestLabel = 'HIMVASelectorLowPtTripletStep_Phase1'),

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -4,8 +4,8 @@ import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 
 #for dnn classifier
-from Configuration.ProcessModifiers.trackdnn_cff import trackdnn 
-from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary 
+from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
+from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary
 
 # for no-loopers
 from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers

--- a/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
@@ -4,8 +4,8 @@ import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 
 #for dnn classifier
-from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
-from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary
+from Configuration.ProcessModifiers.trackdnn_cff import trackdnn 
+from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary 
 
 # for no-loopers
 from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers
@@ -375,11 +375,12 @@ trackingPhase1.toReplaceWith(mixedTripletStep, mixedTripletStepClassifier1.clone
     qualityCuts = [-0.5,0.0,0.5]
 ))
 
-from RecoTracker.FinalTrackSelectors.TrackTfClassifier_cfi import *
+from RecoTracker.FinalTrackSelectors.trackTfClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionTf_cfi import *
-trackdnn.toReplaceWith(mixedTripletStep, TrackTfClassifier.clone(
+from RecoTracker.FinalTrackSelectors.trackSelectionTf_CKF_cfi import *
+trackdnn.toReplaceWith(mixedTripletStep, trackTfClassifier.clone(
     src = 'mixedTripletStepTracks',
-    qualityCuts = qualityCutDictionary['MixedTripletStep']
+    qualityCuts = qualityCutDictionary.MixedTripletStep.value()
 ))
 (trackdnn & fastSim).toModify(mixedTripletStep,vertices = 'firstStepPrimaryVerticesBeforeMixing')
 

--- a/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
@@ -4,8 +4,8 @@ import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 
 #for dnn classifier
-from Configuration.ProcessModifiers.trackdnn_cff import trackdnn 
-from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary 
+from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
+from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary
 
 # for no-loopers
 from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -4,8 +4,8 @@ import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 
 #for dnn classifier
-from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
-from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary
+from Configuration.ProcessModifiers.trackdnn_cff import trackdnn 
+from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary 
 
 # for no-loopers
 from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers
@@ -385,11 +385,12 @@ trackingPhase1.toReplaceWith(pixelLessStep, pixelLessStepClassifier1.clone(
     qualityCuts = [-0.4,0.0,0.4]
 ))
 
-from RecoTracker.FinalTrackSelectors.TrackTfClassifier_cfi import *
+from RecoTracker.FinalTrackSelectors.trackTfClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionTf_cfi import *
-trackdnn.toReplaceWith(pixelLessStep, TrackTfClassifier.clone(
+from RecoTracker.FinalTrackSelectors.trackSelectionTf_CKF_cfi import *
+trackdnn.toReplaceWith(pixelLessStep, trackTfClassifier.clone(
     src         = 'pixelLessStepTracks',
-    qualityCuts = qualityCutDictionary['PixelLessStep']
+    qualityCuts = qualityCutDictionary.PixelLessStep.value()
 ))
 (trackdnn & fastSim).toModify(pixelLessStep,vertices = 'firstStepPrimaryVerticesBeforeMixing')
 

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -4,8 +4,8 @@ import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 
 #for dnn classifier
-from Configuration.ProcessModifiers.trackdnn_cff import trackdnn 
-from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary 
+from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
+from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary
 
 # for no-loopers
 from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers

--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -4,8 +4,8 @@ import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 
 #for dnn classifier
-from Configuration.ProcessModifiers.trackdnn_cff import trackdnn 
-from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary 
+from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
+from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary
 
 # for no-loopers
 from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers

--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -4,8 +4,8 @@ import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 
 #for dnn classifier
-from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
-from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary
+from Configuration.ProcessModifiers.trackdnn_cff import trackdnn 
+from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary 
 
 # for no-loopers
 from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers
@@ -372,11 +372,12 @@ pixelPairStep =  TrackMVAClassifierPrompt.clone(
 )
 trackingPhase1.toModify(pixelPairStep, mva=dict(GBRForestLabel = 'MVASelectorPixelPairStep_Phase1'))
 
-from RecoTracker.FinalTrackSelectors.TrackTfClassifier_cfi import *
+from RecoTracker.FinalTrackSelectors.trackTfClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionTf_cfi import *
-trackdnn.toReplaceWith(pixelPairStep, TrackTfClassifier.clone(
+from RecoTracker.FinalTrackSelectors.trackSelectionTf_CKF_cfi import *
+trackdnn.toReplaceWith(pixelPairStep, trackTfClassifier.clone(
     src='pixelPairStepTracks',
-    qualityCuts=qualityCutDictionary['PixelPairStep']
+    qualityCuts=qualityCutDictionary.PixelPairStep.value()
 ))
 
 highBetaStar_2018.toModify(pixelPairStep,qualityCuts = [-0.95,0.0,0.3])

--- a/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
@@ -3,8 +3,8 @@ import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 
 #for dnn classifier
-from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
-from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary
+from Configuration.ProcessModifiers.trackdnn_cff import trackdnn 
+from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary 
 
 # for no-loopers
 from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers
@@ -413,11 +413,12 @@ trackingPhase1.toReplaceWith(tobTecStep, tobTecStepClassifier1.clone(
      qualityCuts = [-0.6,-0.45,-0.3]
 ))
 
-from RecoTracker.FinalTrackSelectors.TrackTfClassifier_cfi import *
+from RecoTracker.FinalTrackSelectors.trackTfClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionTf_cfi import *
-trackdnn.toReplaceWith(tobTecStep, TrackTfClassifier.clone(
+from RecoTracker.FinalTrackSelectors.trackSelectionTf_CKF_cfi import *
+trackdnn.toReplaceWith(tobTecStep, trackTfClassifier.clone(
      src         = 'tobTecStepTracks',
-     qualityCuts = qualityCutDictionary["TobTecStep"]
+     qualityCuts = qualityCutDictionary.TobTecStep.value()
 ))
 (trackdnn & fastSim).toModify(tobTecStep,vertices = 'firstStepPrimaryVerticesBeforeMixing')
 

--- a/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
@@ -3,8 +3,8 @@ import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 
 #for dnn classifier
-from Configuration.ProcessModifiers.trackdnn_cff import trackdnn 
-from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary 
+from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
+from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary
 
 # for no-loopers
 from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers

--- a/RecoTracker/IterativeTracking/python/dnnQualityCuts.py
+++ b/RecoTracker/IterativeTracking/python/dnnQualityCuts.py
@@ -30,5 +30,3 @@ trackdnn_CKF.toModify(qualityCutDictionary,
    TobTecStep          =        [-0.67, -0.54, -0.40],
    JetCoreRegionalStep =        [0.00, 0.03, 0.68]
 )
-
-

--- a/RecoTracker/IterativeTracking/python/dnnQualityCuts.py
+++ b/RecoTracker/IterativeTracking/python/dnnQualityCuts.py
@@ -1,14 +1,34 @@
 # https://indico.cern.ch/event/947686/contributions/3981867/attachments/2090510/3512658/TrackingDNN_24_8_2020.pdf
-qualityCutDictionary = {
-   'InitialStep':                  [-0.2, 0.15, 0.40],
-   'LowPtQuadStep':                [-0.2, 0.10, 0.45],
-   'HighPtTripletStep':            [0.55, 0.60, 0.65],
-   'LowPtTripletStep':             [-0.2, -0.1, 0.10],
-   'DetachedQuadStep':             [-0.3, 0.20, 0.55],
-   'DetachedTripletStep':          [-0.5, -0.1, 0.40],
-   'PixelPairStep':                [-0.4, -0.35, -0.3],
-   'MixedTripletStep':             [-0.7, -0.5, -0.3],
-   'PixelLessStep':                [-0.8, -0.7, -0.6],
-   'TobTecStep':                   [-0.6, -0.55, -0.5],
-   'JetCoreRegionalStep':          [0.20, 0.30, 0.50]
-}
+import FWCore.ParameterSet.Config as cms
+qualityCutDictionary = cms.PSet(
+   InitialStep         =        cms.vdouble(-0.48, 0.03, 0.25),
+   LowPtQuadStep       =        cms.vdouble(-0.33, 0.18, 0.41),
+   HighPtTripletStep   =        cms.vdouble(0.48, 0.55, 0.62),
+   LowPtTripletStep    =        cms.vdouble(-0.21, 0.17, 0.41),
+   DetachedQuadStep    =        cms.vdouble(-0.62, -0.09 ,0.50),
+   DetachedTripletStep =        cms.vdouble(-0.52, 0.04, 0.76),
+   PixelPairStep       =        cms.vdouble(-0.47, -0.33, -0.05),
+   MixedTripletStep    =        cms.vdouble(-0.87, -0.61 ,-0.13),
+   PixelLessStep       =        cms.vdouble(-0.20, -0.10, 0.40),
+   TobTecStep          =        cms.vdouble(-0.44, -0.26, -0.14), 
+   JetCoreRegionalStep =        cms.vdouble(-0.14, 0.13, 0.61)
+
+)
+
+from Configuration.ProcessModifiers.trackdnn_CKF_cff import trackdnn_CKF
+
+trackdnn_CKF.toModify(qualityCutDictionary, 
+   InitialStep         =        [-0.49, 0.08, 0.34],
+   LowPtQuadStep       =        [-0.29, 0.17, 0.39],
+   HighPtTripletStep   =        [0.5, 0.58, 0.65],
+   LowPtTripletStep    =        [-0.30, 0.06, 0.32],
+   DetachedQuadStep    =        [-0.61, -0.09, 0.51],
+   DetachedTripletStep =        [-0.38, 0.31, 0.83],
+   PixelPairStep       =        [-0.25, -0.07, 0.19],
+   MixedTripletStep    =        [-0.86, -0.57, -0.12],
+   PixelLessStep       =        [-0.81, -0.61, -0.17],
+   TobTecStep          =        [-0.67, -0.54, -0.40],
+   JetCoreRegionalStep =        [0.00, 0.03, 0.68]
+)
+
+

--- a/RecoTracker/IterativeTracking/python/iterativeTk_cff.py
+++ b/RecoTracker/IterativeTracking/python/iterativeTk_cff.py
@@ -24,8 +24,7 @@ from RecoTracker.FinalTrackSelectors.MergeTrackCollections_cff import *
 from RecoTracker.ConversionSeedGenerators.ConversionStep_cff import *
 
 import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
-from RecoTracker.FinalTrackSelectors.TrackTfClassifier_cfi import *
-
+from RecoTracker.FinalTrackSelectors.trackTfClassifier_cfi import *
 
 trackdnn_source = cms.ESSource("EmptyESSource", recordName = cms.string("TfGraphRecord"), firstValid = cms.vuint32(1), iovIsRunNotTime = cms.bool(True) )
 iterTrackingEarlyTask = _cfg.createEarlyTask("", "", globals())
@@ -46,5 +45,7 @@ iterTrackingTask = cms.Task(InitialStepPreSplittingTask,
 
 _iterTrackingTask_trackdnn = iterTrackingTask.copy()
 _iterTrackingTask_trackdnn.add(trackdnn_source)                       
-trackdnn.toReplaceWith(iterTrackingTask, _iterTrackingTask_trackdnn)
+trackdnn.toReplaceWith(iterTrackingTask, _iterTrackingTask_trackdnn
+)
+
 iterTracking = cms.Sequence(iterTrackingTask)

--- a/RecoTracker/IterativeTracking/python/iterativeTk_cff.py
+++ b/RecoTracker/IterativeTracking/python/iterativeTk_cff.py
@@ -45,7 +45,5 @@ iterTrackingTask = cms.Task(InitialStepPreSplittingTask,
 
 _iterTrackingTask_trackdnn = iterTrackingTask.copy()
 _iterTrackingTask_trackdnn.add(trackdnn_source)                       
-trackdnn.toReplaceWith(iterTrackingTask, _iterTrackingTask_trackdnn
-)
-
+trackdnn.toReplaceWith(iterTrackingTask, _iterTrackingTask_trackdnn)
 iterTracking = cms.Sequence(iterTrackingTask)


### PR DESCRIPTION
#### PR description:

Set DNN trained with MkFit tracks instead of the BDTs as the default for the MkFit track selection.
Keep BDTs as the default for the CKF track selection.
Add a backup DNN trained with CKF tracks. Include trackdnn_CKF in the process to enable this DNN
