### PR TITLE
provide a reconstruction scenario for the `commissioning_run` type introduced in #34832

### DIFF
--- a/DQM/Integration/python/clients/visualization-live-secondInstance_cfg.py
+++ b/DQM/Integration/python/clients/visualization-live-secondInstance_cfg.py
@@ -19,7 +19,7 @@ else:
 # this is needed to map the names of the run-types chosen by DQM to the scenarios, ideally we could converge to the same names
 #scenarios = {'pp_run': 'ppEra_Run2_2016','cosmic_run':'cosmicsEra_Run2_2016','hi_run':'HeavyIons'}
 #scenarios = {'pp_run': 'ppEra_Run2_2016','pp_run_stage1': 'ppEra_Run2_2016','cosmic_run':'cosmicsEra_Run2_2016','cosmic_run_stage1':'cosmicsEra_Run2_2016','hi_run':'HeavyIonsEra_Run2_HI'}
-scenarios = {'pp_run': 'ppEra_Run3','cosmic_run':'cosmicsEra_Run3','hi_run':'ppEra_Run2_2016_pA'}
+scenarios = {'pp_run': 'ppEra_Run3','cosmic_run':'cosmicsEra_Run3','hi_run':'ppEra_Run2_2016_pA', 'commissioning_run':'cosmicsEra_Run3'}
 
 if not runType.getRunTypeName() in scenarios.keys():
     msg = "Error getting the scenario out of the 'runkey', no mapping for: %s\n"%runType.getRunTypeName()

--- a/DQM/Integration/python/clients/visualization-live_cfg.py
+++ b/DQM/Integration/python/clients/visualization-live_cfg.py
@@ -19,7 +19,7 @@ else:
 # this is needed to map the names of the run-types chosen by DQM to the scenarios, ideally we could converge to the same names
 #scenarios = {'pp_run': 'ppEra_Run2_2016','cosmic_run':'cosmicsEra_Run2_2016','hi_run':'HeavyIons'}
 #scenarios = {'pp_run': 'ppEra_Run2_2016','pp_run_stage1': 'ppEra_Run2_2016','cosmic_run':'cosmicsEra_Run2_2016','cosmic_run_stage1':'cosmicsEra_Run2_2016','hi_run':'HeavyIonsEra_Run2_HI'}
-scenarios = {'pp_run': 'ppEra_Run3','cosmic_run':'cosmicsEra_Run3','hi_run':'ppEra_Run2_2016_pA'}
+scenarios = {'pp_run': 'ppEra_Run3','cosmic_run':'cosmicsEra_Run3','hi_run':'ppEra_Run2_2016_pA', 'commissioning_run':'cosmicsEra_Run3'}
 
 if not runType.getRunTypeName() in scenarios.keys():
     msg = "Error getting the scenario out of the 'runkey', no mapping for: %s\n"%runType.getRunTypeName()


### PR DESCRIPTION
#### PR description:

PR #34832 introduced DQM runType `commissioning_run` in order to define a new clause in the SiStrip online client to be used when there are no physics triggers. 
The central DQM team (@LukaLambrecht) showed [today at the Joint Operations meeting](https://docs.google.com/document/d/15Gm1hqImLY-Q9eMv_mME_y3dOJ9MLLYDGQkWsSX3IKY/edit#heading=h.la5p1umrft78) that a test could be carried out successfully using this new run type, but that was crashing the visualization client for lack of an appropriate reconstruction scenario. 
After consultation with @rgerosa we concluded that since the strips tests will be conducted in periods without stable beams, these events can be reconstructed as cosmics.
This PR provides the necessary changes to `DQM/Integration/python/clients/visualization-live_cfg.py ` and `DQM/Integration/python/clients/visualization-live-secondInstance_cfg.py`

#### PR validation:

At the moment none, it needs more validation online.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A, but needs to be backported.
