### PR TITLE
esConsumes migration of DT calibration codes

### DIFF
--- a/CalibMuon/DTCalibration/interface/DTSegmentSelector.h
+++ b/CalibMuon/DTCalibration/interface/DTSegmentSelector.h
@@ -14,6 +14,8 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
+#include "CondFormats/DataRecord/interface/DTStatusFlagRcd.h"
+#include "CondFormats/DTObjects/interface/DTStatusFlag.h"
 
 #include <vector>
 
@@ -38,6 +40,7 @@ private:
   double maxChi2_;
   double maxAnglePhi_;
   double maxAngleZ_;
+  edm::ESGetToken<DTStatusFlag, DTStatusFlagRcd> theStatusMapToken_;
 };
 
 #endif

--- a/CalibMuon/DTCalibration/interface/DTT0CorrectionFactory.h
+++ b/CalibMuon/DTCalibration/interface/DTT0CorrectionFactory.h
@@ -7,13 +7,16 @@
  *
  */
 #include "FWCore/PluginManager/interface/PluginFactory.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 namespace edm {
   class ParameterSet;
-}
+  class ConsumesCollector;
+}  // namespace edm
 namespace dtCalibration {
   class DTT0BaseCorrection;
 }
 
-typedef edmplugin::PluginFactory<dtCalibration::DTT0BaseCorrection *(const edm::ParameterSet &)> DTT0CorrectionFactory;
+typedef edmplugin::PluginFactory<dtCalibration::DTT0BaseCorrection *(const edm::ParameterSet &, edm::ConsumesCollector)>
+    DTT0CorrectionFactory;
 #endif

--- a/CalibMuon/DTCalibration/interface/DTTTrigCorrectionFactory.h
+++ b/CalibMuon/DTCalibration/interface/DTTTrigCorrectionFactory.h
@@ -8,14 +8,17 @@
  *  \author A. Vilela Pereira
  */
 #include "FWCore/PluginManager/interface/PluginFactory.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 namespace edm {
   class ParameterSet;
-}
+  class ConsumesCollector;
+}  // namespace edm
 namespace dtCalibration {
   class DTTTrigBaseCorrection;
 }
 
-typedef edmplugin::PluginFactory<dtCalibration::DTTTrigBaseCorrection *(const edm::ParameterSet &)>
+typedef edmplugin::PluginFactory<dtCalibration::DTTTrigBaseCorrection *(const edm::ParameterSet &,
+                                                                        edm::ConsumesCollector)>
     DTTTrigCorrectionFactory;
 #endif

--- a/CalibMuon/DTCalibration/interface/DTVDriftPluginFactory.h
+++ b/CalibMuon/DTCalibration/interface/DTVDriftPluginFactory.h
@@ -9,13 +9,16 @@
  */
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 namespace edm {
   class ParameterSet;
-}
+  class ConsumesCollector;
+}  // namespace edm
 namespace dtCalibration {
   class DTVDriftBaseAlgo;
 }
 
-typedef edmplugin::PluginFactory<dtCalibration::DTVDriftBaseAlgo *(const edm::ParameterSet &)> DTVDriftPluginFactory;
+typedef edmplugin::PluginFactory<dtCalibration::DTVDriftBaseAlgo *(const edm::ParameterSet &, edm::ConsumesCollector)>
+    DTVDriftPluginFactory;
 #endif

--- a/CalibMuon/DTCalibration/plugins/DTNoiseCalibration.cc
+++ b/CalibMuon/DTCalibration/plugins/DTNoiseCalibration.cc
@@ -48,12 +48,12 @@ DTNoiseCalibration::DTNoiseCalibration(const edm::ParameterSet& pset)
       useAbsoluteRate_(pset.getParameter<bool>("useAbsoluteRate")),
       readDB_(true),
       defaultTtrig_(0),
-      dbLabel_(pset.getUntrackedParameter<string>("dbLabel", "")),
       //fastAnalysis_( pset.getParameter<bool>("fastAnalysis", true) ),
       wireIdWithHisto_(std::vector<DTWireId>()),
       lumiMax_(3000),
-      dtGeomToken_(esConsumes()),
-      ttrigToken_(esConsumes(edm::ESInputTag("", pset.getParameter<string>("dbLabel")))) {
+      dtGeomToken_(esConsumes<edm::Transition::BeginRun>()),
+      ttrigToken_(
+          esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", pset.getUntrackedParameter<string>("dbLabel")))) {
   // Get the debug parameter for verbose output
   //debug = ps.getUntrackedParameter<bool>("debug");
   /*// The analysis type

--- a/CalibMuon/DTCalibration/plugins/DTNoiseCalibration.h
+++ b/CalibMuon/DTCalibration/plugins/DTNoiseCalibration.h
@@ -64,7 +64,6 @@ private:
 
   bool readDB_;
   int defaultTtrig_;
-  std::string dbLabel_;
 
   std::vector<DTWireId> wireIdWithHisto_;
   unsigned int lumiMax_;

--- a/CalibMuon/DTCalibration/plugins/DTResidualCalibration.cc
+++ b/CalibMuon/DTCalibration/plugins/DTResidualCalibration.cc
@@ -36,7 +36,7 @@ DTResidualCalibration::DTResidualCalibration(const edm::ParameterSet& pset)
       segment4DLabel_(pset.getParameter<edm::InputTag>("segment4DLabel")),
       rootBaseDir_(pset.getUntrackedParameter<std::string>("rootBaseDir", "DT/Residuals")),
       detailedAnalysis_(pset.getUntrackedParameter<bool>("detailedAnalysis", false)),
-      dtGeomToken_(esConsumes()) {
+      dtGeomToken_(esConsumes<edm::Transition::BeginRun>()) {
   edm::ConsumesCollector collector(consumesCollector());
   select_ = new DTSegmentSelector(pset, collector);
 

--- a/CalibMuon/DTCalibration/plugins/DTT0AbsoluteReferenceCorrection.cc
+++ b/CalibMuon/DTCalibration/plugins/DTT0AbsoluteReferenceCorrection.cc
@@ -24,8 +24,10 @@ using namespace edm;
 
 namespace dtCalibration {
 
-  DTT0AbsoluteReferenceCorrection::DTT0AbsoluteReferenceCorrection(const ParameterSet& pset)
-      : calibChamber_(pset.getParameter<string>("calibChamber")), reference_(pset.getParameter<double>("reference")) {
+  DTT0AbsoluteReferenceCorrection::DTT0AbsoluteReferenceCorrection(const ParameterSet& pset, edm::ConsumesCollector cc)
+      : calibChamber_(pset.getParameter<string>("calibChamber")),
+        reference_(pset.getParameter<double>("reference")),
+        t0Token_(cc.esConsumes<edm::Transition::BeginRun>()) {
     //DTChamberId chosenChamberId;
     if (!calibChamber_.empty() && calibChamber_ != "None" && calibChamber_ != "All") {
       stringstream linestr;
@@ -43,7 +45,7 @@ namespace dtCalibration {
   void DTT0AbsoluteReferenceCorrection::setES(const EventSetup& setup) {
     // Get t0 record from DB
     ESHandle<DTT0> t0H;
-    setup.get<DTT0Rcd>().get(t0H);
+    t0H = setup.getHandle(t0Token_);
     t0Map_ = &*t0H;
     LogVerbatim("Calibration") << "[DTT0AbsoluteReferenceCorrection] T0 version: " << t0H->version();
   }

--- a/CalibMuon/DTCalibration/plugins/DTT0AbsoluteReferenceCorrection.h
+++ b/CalibMuon/DTCalibration/plugins/DTT0AbsoluteReferenceCorrection.h
@@ -11,7 +11,10 @@
 
 #include "CalibMuon/DTCalibration/interface/DTT0BaseCorrection.h"
 #include "DataFormats/MuonDetId/interface/DTChamberId.h"
-
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "CondFormats/DataRecord/interface/DTT0Rcd.h"
+#include "CondFormats/DTObjects/interface/DTT0.h"
 #include <string>
 
 namespace edm {
@@ -25,7 +28,7 @@ namespace dtCalibration {
   class DTT0AbsoluteReferenceCorrection : public DTT0BaseCorrection {
   public:
     // Constructor
-    DTT0AbsoluteReferenceCorrection(const edm::ParameterSet&);
+    DTT0AbsoluteReferenceCorrection(const edm::ParameterSet&, edm::ConsumesCollector);
 
     // Destructor
     ~DTT0AbsoluteReferenceCorrection() override;
@@ -41,6 +44,7 @@ namespace dtCalibration {
 
     DTChamberId chosenChamberId_;
     const DTT0* t0Map_;
+    edm::ESGetToken<DTT0, DTT0Rcd> t0Token_;
   };
 
 }  // namespace dtCalibration

--- a/CalibMuon/DTCalibration/plugins/DTT0ChamberReferenceCorrection.cc
+++ b/CalibMuon/DTCalibration/plugins/DTT0ChamberReferenceCorrection.cc
@@ -23,7 +23,7 @@ using namespace edm;
 namespace dtCalibration {
 
   DTT0ChamberReferenceCorrection::DTT0ChamberReferenceCorrection(const ParameterSet& pset, edm::ConsumesCollector cc)
-      : calibChamber_(pset.getParameter<string>("calibChamber")), t0Token_(cc.esConsumes()) {
+      : calibChamber_(pset.getParameter<string>("calibChamber")), t0Token_(cc.esConsumes<edm::Transition::BeginRun>()) {
     //DTChamberId chosenChamberId;
     if (!calibChamber_.empty() && calibChamber_ != "None" && calibChamber_ != "All") {
       stringstream linestr;

--- a/CalibMuon/DTCalibration/plugins/DTT0Correction.cc
+++ b/CalibMuon/DTCalibration/plugins/DTT0Correction.cc
@@ -20,6 +20,7 @@
 
 #include "CalibMuon/DTCalibration/interface/DTT0CorrectionFactory.h"
 #include "CalibMuon/DTCalibration/interface/DTT0BaseCorrection.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include <iostream>
 #include <fstream>
@@ -29,9 +30,10 @@ using namespace std;
 
 DTT0Correction::DTT0Correction(const ParameterSet& pset)
     : correctionAlgo_{DTT0CorrectionFactory::get()->create(pset.getParameter<string>("correctionAlgo"),
-                                                           pset.getParameter<ParameterSet>("correctionAlgoConfig"))},
-      dtGeomToken_(esConsumes()),
-      t0Token_(esConsumes()) {
+                                                           pset.getParameter<ParameterSet>("correctionAlgoConfig"),
+                                                           consumesCollector())},
+      dtGeomToken_(esConsumes<edm::Transition::BeginRun>()),
+      t0Token_(esConsumes<edm::Transition::BeginRun>()) {
   LogVerbatim("Calibration") << "[DTT0Correction] Constructor called" << endl;
 }
 

--- a/CalibMuon/DTCalibration/plugins/DTT0FEBPathCorrection.cc
+++ b/CalibMuon/DTCalibration/plugins/DTT0FEBPathCorrection.cc
@@ -26,7 +26,7 @@ using namespace edm;
 namespace dtCalibration {
 
   DTT0FEBPathCorrection::DTT0FEBPathCorrection(const ParameterSet& pset, edm::ConsumesCollector cc)
-      : calibChamber_(pset.getParameter<string>("calibChamber")), t0Token_(cc.esConsumes()) {
+      : calibChamber_(pset.getParameter<string>("calibChamber")), t0Token_(cc.esConsumes<edm::Transition::BeginRun>()) {
     //DTChamberId chosenChamberId;
     if (!calibChamber_.empty() && calibChamber_ != "None" && calibChamber_ != "All") {
       stringstream linestr;

--- a/CalibMuon/DTCalibration/plugins/DTT0FillChamberFromDB.cc
+++ b/CalibMuon/DTCalibration/plugins/DTT0FillChamberFromDB.cc
@@ -24,8 +24,11 @@ using namespace edm;
 
 namespace dtCalibration {
 
-  DTT0FillChamberFromDB::DTT0FillChamberFromDB(const ParameterSet& pset)
-      : dbLabelRef_(pset.getParameter<string>("dbLabelRef")), chamberRef_(pset.getParameter<string>("chamberId")) {
+  DTT0FillChamberFromDB::DTT0FillChamberFromDB(const ParameterSet& pset, edm::ConsumesCollector cc)
+      : chamberRef_(pset.getParameter<string>("chamberId")),
+        t0Token_(cc.esConsumes<edm::Transition::BeginRun>()),
+        t0RefToken_(
+            cc.esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", pset.getParameter<string>("dbLabelRef")))) {
     //DTChamberId chosenChamberId;
     if (!chamberRef_.empty() && chamberRef_ != "None") {
       stringstream linestr;
@@ -42,14 +45,12 @@ namespace dtCalibration {
 
   void DTT0FillChamberFromDB::setES(const EventSetup& setup) {
     // Get t0 record from DB
-    ESHandle<DTT0> t0H;
-    setup.get<DTT0Rcd>().get(t0H);
+    ESHandle<DTT0> t0H = setup.getHandle(t0Token_);
     t0Map_ = &*t0H;
     LogVerbatim("Calibration") << "[DTT0FillChamberFromDB] T0 version: " << t0H->version();
 
     // Get reference t0 DB
-    ESHandle<DTT0> t0RefH;
-    setup.get<DTT0Rcd>().get(dbLabelRef_, t0RefH);
+    ESHandle<DTT0> t0RefH = setup.getHandle(t0RefToken_);
     t0MapRef_ = &*t0RefH;
     LogVerbatim("Calibration") << "[DTT0FillChamberFromDB] Reference T0 version: " << t0RefH->version();
   }

--- a/CalibMuon/DTCalibration/plugins/DTT0FillChamberFromDB.h
+++ b/CalibMuon/DTCalibration/plugins/DTT0FillChamberFromDB.h
@@ -11,6 +11,9 @@
 
 #include "CalibMuon/DTCalibration/interface/DTT0BaseCorrection.h"
 #include "DataFormats/MuonDetId/interface/DTChamberId.h"
+#include "CondFormats/DataRecord/interface/DTT0Rcd.h"
+#include "CondFormats/DTObjects/interface/DTT0.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include <string>
 
@@ -25,7 +28,7 @@ namespace dtCalibration {
   class DTT0FillChamberFromDB : public DTT0BaseCorrection {
   public:
     // Constructor
-    DTT0FillChamberFromDB(const edm::ParameterSet &);
+    DTT0FillChamberFromDB(const edm::ParameterSet &, edm::ConsumesCollector cc);
 
     // Destructor
     ~DTT0FillChamberFromDB() override;
@@ -34,13 +37,14 @@ namespace dtCalibration {
     DTT0Data correction(const DTWireId &) override;
 
   private:
-    std::string dbLabelRef_;
     std::string chamberRef_;
 
     DTChamberId chosenChamberId_;
 
     const DTT0 *t0MapRef_;
     const DTT0 *t0Map_;
+    edm::ESGetToken<DTT0, DTT0Rcd> t0Token_;
+    edm::ESGetToken<DTT0, DTT0Rcd> t0RefToken_;
   };
 
 }  // namespace dtCalibration

--- a/CalibMuon/DTCalibration/plugins/DTT0FillDefaultFromDB.cc
+++ b/CalibMuon/DTCalibration/plugins/DTT0FillDefaultFromDB.cc
@@ -19,21 +19,21 @@ using namespace edm;
 
 namespace dtCalibration {
 
-  DTT0FillDefaultFromDB::DTT0FillDefaultFromDB(const ParameterSet& pset)
-      : dbLabelRef_(pset.getParameter<string>("dbLabelRef")) {}
+  DTT0FillDefaultFromDB::DTT0FillDefaultFromDB(const ParameterSet& pset, edm::ConsumesCollector cc)
+      : t0Token_(cc.esConsumes<edm::Transition::BeginRun>()),
+        t0RefToken_(
+            cc.esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", pset.getParameter<string>("dbLabelRef")))) {}
 
   DTT0FillDefaultFromDB::~DTT0FillDefaultFromDB() {}
 
   void DTT0FillDefaultFromDB::setES(const EventSetup& setup) {
     // Get t0 record from DB
-    ESHandle<DTT0> t0H;
-    setup.get<DTT0Rcd>().get(t0H);
+    ESHandle<DTT0> t0H = setup.getHandle(t0Token_);
     t0Map_ = &*t0H;
     LogVerbatim("Calibration") << "[DTT0FillDefaultFromDB] T0 version: " << t0H->version();
 
     // Get reference t0 DB
-    ESHandle<DTT0> t0RefH;
-    setup.get<DTT0Rcd>().get(dbLabelRef_, t0RefH);
+    ESHandle<DTT0> t0RefH = setup.getHandle(t0RefToken_);
     t0MapRef_ = &*t0RefH;
     LogVerbatim("Calibration") << "[DTT0FillDefaultFromDB] Reference T0 version: " << t0RefH->version();
   }

--- a/CalibMuon/DTCalibration/plugins/DTT0FillDefaultFromDB.h
+++ b/CalibMuon/DTCalibration/plugins/DTT0FillDefaultFromDB.h
@@ -10,6 +10,10 @@
  */
 
 #include "CalibMuon/DTCalibration/interface/DTT0BaseCorrection.h"
+#include "DataFormats/MuonDetId/interface/DTChamberId.h"
+#include "CondFormats/DataRecord/interface/DTT0Rcd.h"
+#include "CondFormats/DTObjects/interface/DTT0.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include <string>
 
@@ -24,7 +28,7 @@ namespace dtCalibration {
   class DTT0FillDefaultFromDB : public DTT0BaseCorrection {
   public:
     // Constructor
-    DTT0FillDefaultFromDB(const edm::ParameterSet &);
+    DTT0FillDefaultFromDB(const edm::ParameterSet &, edm::ConsumesCollector cc);
 
     // Destructor
     ~DTT0FillDefaultFromDB() override;
@@ -33,10 +37,11 @@ namespace dtCalibration {
     DTT0Data correction(const DTWireId &) override;
 
   private:
-    std::string dbLabelRef_;
-
     const DTT0 *t0MapRef_;
     const DTT0 *t0Map_;
+
+    edm::ESGetToken<DTT0, DTT0Rcd> t0Token_;
+    edm::ESGetToken<DTT0, DTT0Rcd> t0RefToken_;
   };
 
 }  // namespace dtCalibration

--- a/CalibMuon/DTCalibration/plugins/DTT0WireInChamberReferenceCorrection.h
+++ b/CalibMuon/DTCalibration/plugins/DTT0WireInChamberReferenceCorrection.h
@@ -12,7 +12,11 @@
 #include "CalibMuon/DTCalibration/interface/DTT0BaseCorrection.h"
 #include "DataFormats/MuonDetId/interface/DTChamberId.h"
 #include "FWCore/Framework/interface/ESHandle.h"
-
+#include "CondFormats/DataRecord/interface/DTT0Rcd.h"
+#include "CondFormats/DTObjects/interface/DTT0.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include <string>
 
 namespace edm {
@@ -27,7 +31,7 @@ namespace dtCalibration {
   class DTT0WireInChamberReferenceCorrection : public DTT0BaseCorrection {
   public:
     // Constructor
-    DTT0WireInChamberReferenceCorrection(const edm::ParameterSet&);
+    DTT0WireInChamberReferenceCorrection(const edm::ParameterSet&, edm::ConsumesCollector);
 
     // Destructor
     ~DTT0WireInChamberReferenceCorrection() override;
@@ -43,6 +47,9 @@ namespace dtCalibration {
     DTChamberId chosenChamberId_;
     const DTT0* t0Map_;
     edm::ESHandle<DTGeometry> dtGeom_;
+
+    edm::ESGetToken<DTT0, DTT0Rcd> t0Token_;
+    edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomToken_;
   };
 
 }  // namespace dtCalibration

--- a/CalibMuon/DTCalibration/plugins/DTTPDeadWriter.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTPDeadWriter.cc
@@ -33,10 +33,10 @@ using namespace std;
 using namespace edm;
 
 // Constructor
-DTTPDeadWriter::DTTPDeadWriter(const ParameterSet& pset) : dtGeomToken_(esConsumes()) {
+DTTPDeadWriter::DTTPDeadWriter(const ParameterSet& pset) : dtGeomToken_(esConsumes<edm::Transition::BeginRun>()) {
   // get selected debug option
   debug = pset.getUntrackedParameter<bool>("debug", false);
-  t0Token_ = esConsumes(edm::ESInputTag("", pset.getParameter<string>("debug")));
+  t0Token_ = esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", pset.getParameter<string>("debug")));
 
   // Create the object to be written to DB
   tpDeadList = new DTDeadFlag();

--- a/CalibMuon/DTCalibration/plugins/DTTTrigConstantShift.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigConstantShift.cc
@@ -12,6 +12,7 @@
 #include "DataFormats/MuonDetId/interface/DTSuperLayerId.h"
 #include "CondFormats/DTObjects/interface/DTTtrig.h"
 #include "CondFormats/DataRecord/interface/DTTtrigRcd.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include <cmath>
 
@@ -20,10 +21,10 @@ using namespace edm;
 
 namespace dtCalibration {
 
-  DTTTrigConstantShift::DTTTrigConstantShift(const ParameterSet& pset)
-      : dbLabel_(pset.getUntrackedParameter<string>("dbLabel", "")),
-        calibChamber_(pset.getParameter<string>("calibChamber")),
-        value_(pset.getParameter<double>("value")) {
+  DTTTrigConstantShift::DTTTrigConstantShift(const ParameterSet& pset, edm::ConsumesCollector cc)
+      : calibChamber_(pset.getParameter<string>("calibChamber")), value_(pset.getParameter<double>("value")) {
+    ttrigToken_ =
+        cc.esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", pset.getUntrackedParameter<string>("dbLabel")));
     LogVerbatim("Calibration") << "[DTTTrigConstantShift] Applying constant correction value: " << value_ << endl;
 
     if (!calibChamber_.empty() && calibChamber_ != "None" && calibChamber_ != "All") {
@@ -41,8 +42,7 @@ namespace dtCalibration {
 
   void DTTTrigConstantShift::setES(const EventSetup& setup) {
     // Get tTrig record from DB
-    ESHandle<DTTtrig> tTrig;
-    setup.get<DTTtrigRcd>().get(dbLabel_, tTrig);
+    ESHandle<DTTtrig> tTrig = setup.getHandle(ttrigToken_);
     tTrigMap_ = &*tTrig;
   }
 

--- a/CalibMuon/DTCalibration/plugins/DTTTrigConstantShift.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigConstantShift.h
@@ -11,6 +11,8 @@
 
 #include "CalibMuon/DTCalibration/interface/DTTTrigBaseCorrection.h"
 #include "DataFormats/MuonDetId/interface/DTChamberId.h"
+#include "CondFormats/DataRecord/interface/DTTtrigRcd.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include <string>
 
@@ -25,7 +27,7 @@ namespace dtCalibration {
   class DTTTrigConstantShift : public DTTTrigBaseCorrection {
   public:
     // Constructor
-    DTTTrigConstantShift(const edm::ParameterSet&);
+    DTTTrigConstantShift(const edm::ParameterSet&, edm::ConsumesCollector);
 
     // Destructor
     ~DTTTrigConstantShift() override;
@@ -34,12 +36,12 @@ namespace dtCalibration {
     DTTTrigData correction(const DTSuperLayerId&) override;
 
   private:
-    std::string dbLabel_;
     std::string calibChamber_;
     double value_;
 
     const DTTtrig* tTrigMap_;
     DTChamberId chosenChamberId_;
+    edm::ESGetToken<DTTtrig, DTTtrigRcd> ttrigToken_;
   };
 
 }  // namespace dtCalibration

--- a/CalibMuon/DTCalibration/plugins/DTTTrigCorrection.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigCorrection.h
@@ -11,6 +11,10 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "Geometry/DTGeometry/interface/DTGeometry.h"
+#include "CondFormats/DataRecord/interface/DTTtrigRcd.h"
 
 #include <string>
 
@@ -37,10 +41,11 @@ public:
 
 protected:
 private:
-  std::string dbLabel_;
-
   const DTTtrig* tTrigMap_;
   edm::ESHandle<DTGeometry> muonGeom_;
+
+  edm::ESGetToken<DTTtrig, DTTtrigRcd> ttrigToken_;
+  edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomToken_;
 
   std::unique_ptr<dtCalibration::DTTTrigBaseCorrection> correctionAlgo_;
 };

--- a/CalibMuon/DTCalibration/plugins/DTTTrigCorrectionFirst.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigCorrectionFirst.cc
@@ -26,13 +26,13 @@ using namespace edm;
 using namespace std;
 
 DTTTrigCorrectionFirst::DTTTrigCorrectionFirst(const ParameterSet& pset)
-    : dtGeomToken_(esConsumes()), ttrigToken_(esConsumes(edm::ESInputTag("", pset.getParameter<string>("dbLabel")))) {
+    : dtGeomToken_(esConsumes<edm::Transition::BeginRun>()),
+      ttrigToken_(
+          esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", pset.getUntrackedParameter<string>("dbLabel")))) {
   debug = pset.getUntrackedParameter<bool>("debug", false);
   ttrigMin = pset.getUntrackedParameter<double>("ttrigMin", 0);
   ttrigMax = pset.getUntrackedParameter<double>("ttrigMax", 5000);
   rmsLimit = pset.getUntrackedParameter<double>("rmsLimit", 5.);
-
-  dbLabel = pset.getUntrackedParameter<string>("dbLabel", "");
 }
 
 DTTTrigCorrectionFirst::~DTTTrigCorrectionFirst() {}

--- a/CalibMuon/DTCalibration/plugins/DTTTrigCorrectionFirst.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigCorrectionFirst.h
@@ -43,8 +43,6 @@ private:
   const DTTtrig* tTrigMap;
   const edm::ESGetToken<DTTtrig, DTTtrigRcd> ttrigToken_;
 
-  std::string dbLabel;
-
   bool debug;
   double ttrigMin, ttrigMax, rmsLimit;
 };

--- a/CalibMuon/DTCalibration/plugins/DTTTrigFillWithAverage.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigFillWithAverage.cc
@@ -18,8 +18,11 @@ using namespace edm;
 
 namespace dtCalibration {
 
-  DTTTrigFillWithAverage::DTTTrigFillWithAverage(const ParameterSet& pset) : foundAverage_(false) {
-    dbLabel = pset.getUntrackedParameter<string>("dbLabel", "");
+  DTTTrigFillWithAverage::DTTTrigFillWithAverage(const ParameterSet& pset, edm::ConsumesCollector cc)
+      : foundAverage_(false) {
+    ttrigToken_ =
+        cc.esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", pset.getUntrackedParameter<string>("dbLabel")));
+    dtGeomToken_ = cc.esConsumes<edm::Transition::BeginRun>();
   }
 
   DTTTrigFillWithAverage::~DTTTrigFillWithAverage() {}
@@ -27,11 +30,11 @@ namespace dtCalibration {
   void DTTTrigFillWithAverage::setES(const EventSetup& setup) {
     // Get tTrig record from DB
     ESHandle<DTTtrig> tTrig;
-    setup.get<DTTtrigRcd>().get(dbLabel, tTrig);
+    tTrig = setup.getHandle(ttrigToken_);
     tTrigMap_ = &*tTrig;
 
     // Get geometry from Event Setup
-    setup.get<MuonGeometryRecord>().get(muonGeom_);
+    muonGeom_ = setup.getHandle(dtGeomToken_);
   }
 
   DTTTrigData DTTTrigFillWithAverage::correction(const DTSuperLayerId& slId) {

--- a/CalibMuon/DTCalibration/plugins/DTTTrigFillWithAverage.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigFillWithAverage.h
@@ -10,6 +10,9 @@
 
 #include "CalibMuon/DTCalibration/interface/DTTTrigBaseCorrection.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "CondFormats/DataRecord/interface/DTTtrigRcd.h"
 
 namespace edm {
   class ParameterSet;
@@ -23,7 +26,7 @@ namespace dtCalibration {
   class DTTTrigFillWithAverage : public DTTTrigBaseCorrection {
   public:
     // Constructor
-    DTTTrigFillWithAverage(const edm::ParameterSet&);
+    DTTTrigFillWithAverage(const edm::ParameterSet&, edm::ConsumesCollector);
 
     // Destructor
     ~DTTTrigFillWithAverage() override;
@@ -37,7 +40,8 @@ namespace dtCalibration {
     const DTTtrig* tTrigMap_;
     edm::ESHandle<DTGeometry> muonGeom_;
 
-    std::string dbLabel;
+    edm::ESGetToken<DTTtrig, DTTtrigRcd> ttrigToken_;
+    edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomToken_;
 
     struct {
       float aveMean;

--- a/CalibMuon/DTCalibration/plugins/DTTTrigMatchRPhi.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigMatchRPhi.cc
@@ -19,16 +19,16 @@ using namespace edm;
 
 namespace dtCalibration {
 
-  DTTTrigMatchRPhi::DTTTrigMatchRPhi(const ParameterSet& pset) {
-    dbLabel = pset.getUntrackedParameter<string>("dbLabel", "");
+  DTTTrigMatchRPhi::DTTTrigMatchRPhi(const ParameterSet& pset, edm::ConsumesCollector cc) {
+    ttrigToken_ =
+        cc.esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", pset.getUntrackedParameter<string>("dbLabel")));
   }
 
   DTTTrigMatchRPhi::~DTTTrigMatchRPhi() {}
 
   void DTTTrigMatchRPhi::setES(const EventSetup& setup) {
     // Get tTrig record from DB
-    ESHandle<DTTtrig> tTrig;
-    setup.get<DTTtrigRcd>().get(dbLabel, tTrig);
+    ESHandle<DTTtrig> tTrig = setup.getHandle(ttrigToken_);
     tTrigMap_ = &*tTrig;
   }
 

--- a/CalibMuon/DTCalibration/plugins/DTTTrigMatchRPhi.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigMatchRPhi.h
@@ -9,6 +9,8 @@
  */
 
 #include "CalibMuon/DTCalibration/interface/DTTTrigBaseCorrection.h"
+#include "CondFormats/DataRecord/interface/DTTtrigRcd.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include <string>
 
@@ -23,7 +25,7 @@ namespace dtCalibration {
   class DTTTrigMatchRPhi : public DTTTrigBaseCorrection {
   public:
     // Constructor
-    DTTTrigMatchRPhi(const edm::ParameterSet&);
+    DTTTrigMatchRPhi(const edm::ParameterSet&, edm::ConsumesCollector);
 
     // Destructor
     ~DTTTrigMatchRPhi() override;
@@ -33,8 +35,7 @@ namespace dtCalibration {
 
   private:
     const DTTtrig* tTrigMap_;
-
-    std::string dbLabel;
+    edm::ESGetToken<DTTtrig, DTTtrigRcd> ttrigToken_;
   };
 
 }  // namespace dtCalibration

--- a/CalibMuon/DTCalibration/plugins/DTTTrigOffsetCalibration.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigOffsetCalibration.cc
@@ -38,8 +38,8 @@ DTTTrigOffsetCalibration::DTTTrigOffsetCalibration(const ParameterSet& pset)
     : theRecHits4DLabel_(pset.getParameter<InputTag>("recHits4DLabel")),
       doTTrigCorrection_(pset.getUntrackedParameter<bool>("doT0SegCorrection", false)),
       theCalibChamber_(pset.getUntrackedParameter<string>("calibChamber", "All")),
-      dbLabel_(pset.getUntrackedParameter<string>("dbLabel", "")),
-      ttrigToken_(esConsumes(edm::ESInputTag("", pset.getParameter<string>("dbLabel")))),
+      ttrigToken_(
+          esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", pset.getUntrackedParameter<string>("dbLabel")))),
       dtGeomToken_(esConsumes()) {
   LogVerbatim("Calibration") << "[DTTTrigOffsetCalibration] Constructor called!";
 

--- a/CalibMuon/DTCalibration/plugins/DTTTrigOffsetCalibration.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigOffsetCalibration.h
@@ -47,7 +47,6 @@ private:
   edm::InputTag theRecHits4DLabel_;
   bool doTTrigCorrection_;
   std::string theCalibChamber_;
-  std::string dbLabel_;
 
   TFile* rootFile_;
   const DTTtrig* tTrigMap_;

--- a/CalibMuon/DTCalibration/plugins/DTTTrigResidualCorrection.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigResidualCorrection.h
@@ -9,6 +9,10 @@
  */
 
 #include "CalibMuon/DTCalibration/interface/DTTTrigBaseCorrection.h"
+#include "CondFormats/DataRecord/interface/DTTtrigRcd.h"
+#include "CondFormats/DataRecord/interface/DTMtimeRcd.h"
+#include "CondFormats/DataRecord/interface/DTRecoConditionsVdriftRcd.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include <string>
 
@@ -29,7 +33,7 @@ namespace dtCalibration {
   class DTTTrigResidualCorrection : public DTTTrigBaseCorrection {
   public:
     // Constructor
-    DTTTrigResidualCorrection(const edm::ParameterSet&);
+    DTTTrigResidualCorrection(const edm::ParameterSet&, edm::ConsumesCollector cc);
 
     // Destructor
     ~DTTTrigResidualCorrection() override;
@@ -45,7 +49,6 @@ namespace dtCalibration {
 
     std::string rootBaseDir_;
     bool useFit_;
-    std::string dbLabel_;
     bool useSlopesCalib_;
 
     double vDriftEff_[5][14][4][3];
@@ -56,6 +59,10 @@ namespace dtCalibration {
     bool readLegacyVDriftDB;             // which one to use
 
     DTResidualFitter* fitter_;
+
+    edm::ESGetToken<DTTtrig, DTTtrigRcd> ttrigToken_;
+    edm::ESGetToken<DTMtime, DTMtimeRcd> mTimeMapToken_;
+    edm::ESGetToken<DTRecoConditions, DTRecoConditionsVdriftRcd> vDriftMapToken_;
   };
 
 }  // namespace dtCalibration

--- a/CalibMuon/DTCalibration/plugins/DTTTrigT0SegCorrection.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigT0SegCorrection.cc
@@ -23,18 +23,18 @@ using namespace edm;
 
 namespace dtCalibration {
 
-  DTTTrigT0SegCorrection::DTTTrigT0SegCorrection(const ParameterSet& pset) {
+  DTTTrigT0SegCorrection::DTTTrigT0SegCorrection(const ParameterSet& pset, edm::ConsumesCollector cc) {
     string t0SegRootFile = pset.getParameter<string>("t0SegRootFile");
     rootFile_ = new TFile(t0SegRootFile.c_str(), "READ");
-    dbLabel = pset.getUntrackedParameter<string>("dbLabel", "");
+    ttrigToken_ =
+        cc.esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", pset.getUntrackedParameter<string>("dbLabel")));
   }
 
   DTTTrigT0SegCorrection::~DTTTrigT0SegCorrection() { delete rootFile_; }
 
   void DTTTrigT0SegCorrection::setES(const EventSetup& setup) {
     // Get tTrig record from DB
-    ESHandle<DTTtrig> tTrig;
-    setup.get<DTTtrigRcd>().get(dbLabel, tTrig);
+    ESHandle<DTTtrig> tTrig = setup.getHandle(ttrigToken_);
     tTrigMap_ = &*tTrig;
   }
 

--- a/CalibMuon/DTCalibration/plugins/DTTTrigT0SegCorrection.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigT0SegCorrection.h
@@ -9,12 +9,15 @@
  */
 
 #include "CalibMuon/DTCalibration/interface/DTTTrigBaseCorrection.h"
+#include "CondFormats/DataRecord/interface/DTTtrigRcd.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include <string>
 
 namespace edm {
   class ParameterSet;
-}
+  class ConsumesCollector;
+}  // namespace edm
 
 class DTTtrig;
 
@@ -26,7 +29,7 @@ namespace dtCalibration {
   class DTTTrigT0SegCorrection : public DTTTrigBaseCorrection {
   public:
     // Constructor
-    DTTTrigT0SegCorrection(const edm::ParameterSet&);
+    DTTTrigT0SegCorrection(const edm::ParameterSet&, edm::ConsumesCollector);
 
     // Destructor
     ~DTTTrigT0SegCorrection() override;
@@ -40,9 +43,8 @@ namespace dtCalibration {
 
     TFile* rootFile_;
 
-    std::string dbLabel;
-
     const DTTtrig* tTrigMap_;
+    edm::ESGetToken<DTTtrig, DTTtrigRcd> ttrigToken_;
   };
 
 }  // namespace dtCalibration

--- a/CalibMuon/DTCalibration/plugins/DTVDriftMeanTimer.cc
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftMeanTimer.cc
@@ -29,7 +29,7 @@ using namespace edm;
 
 namespace dtCalibration {
 
-  DTVDriftMeanTimer::DTVDriftMeanTimer(const ParameterSet& pset) {
+  DTVDriftMeanTimer::DTVDriftMeanTimer(const ParameterSet& pset, edm::ConsumesCollector cc) {
     string rootFileName = pset.getParameter<string>("rootFileName");
     rootFile_ = new TFile(rootFileName.c_str(), "READ");
     fitter_ = new DTMeanTimerFitter(rootFile_);

--- a/CalibMuon/DTCalibration/plugins/DTVDriftMeanTimer.h
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftMeanTimer.h
@@ -10,6 +10,7 @@
 
 #include "CalibMuon/DTCalibration/interface/DTVDriftBaseAlgo.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 class TFile;
 class DTMeanTimerFitter;
@@ -18,7 +19,7 @@ namespace dtCalibration {
 
   class DTVDriftMeanTimer : public DTVDriftBaseAlgo {
   public:
-    DTVDriftMeanTimer(edm::ParameterSet const&);
+    DTVDriftMeanTimer(edm::ParameterSet const&, edm::ConsumesCollector);
     ~DTVDriftMeanTimer() override;
 
     void setES(const edm::EventSetup& setup) override;

--- a/CalibMuon/DTCalibration/plugins/DTVDriftSegment.h
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftSegment.h
@@ -10,6 +10,12 @@
 
 #include "CalibMuon/DTCalibration/interface/DTVDriftBaseAlgo.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "CondFormats/DataRecord/interface/DTMtimeRcd.h"
+#include "CondFormats/DataRecord/interface/DTRecoConditionsVdriftRcd.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 
 #include <string>
 
@@ -23,7 +29,7 @@ namespace dtCalibration {
 
   class DTVDriftSegment : public DTVDriftBaseAlgo {
   public:
-    DTVDriftSegment(edm::ParameterSet const&);
+    DTVDriftSegment(edm::ParameterSet const&, edm::ConsumesCollector);
     ~DTVDriftSegment() override;
 
     void setES(const edm::EventSetup& setup) override;
@@ -40,6 +46,9 @@ namespace dtCalibration {
     bool readLegacyVDriftDB;             // which one to use
     TFile* rootFile_;
     DTResidualFitter* fitter_;
+
+    edm::ESGetToken<DTMtime, DTMtimeRcd> mTimeMapToken_;
+    edm::ESGetToken<DTRecoConditions, DTRecoConditionsVdriftRcd> vDriftMapToken_;
   };
 
 }  // namespace dtCalibration

--- a/CalibMuon/DTCalibration/plugins/DTVDriftWriter.cc
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftWriter.cc
@@ -33,14 +33,15 @@ using namespace std;
 using namespace edm;
 
 DTVDriftWriter::DTVDriftWriter(const ParameterSet& pset)
-    : mTimeMapToken_(esConsumes()),
-      vDriftMapToken_(esConsumes()),
-      dtGeomToken_(esConsumes()),
+    : mTimeMapToken_(esConsumes<edm::Transition::BeginRun>()),
+      vDriftMapToken_(esConsumes<edm::Transition::BeginRun>()),
+      dtGeomToken_(esConsumes<edm::Transition::BeginRun>()),
       granularity_(pset.getUntrackedParameter<string>("calibGranularity", "bySL")),
       mTimeMap_(nullptr),
       vDriftMap_(nullptr),
       vDriftAlgo_{DTVDriftPluginFactory::get()->create(pset.getParameter<string>("vDriftAlgo"),
-                                                       pset.getParameter<ParameterSet>("vDriftAlgoConfig"))} {
+                                                       pset.getParameter<ParameterSet>("vDriftAlgoConfig"),
+                                                       consumesCollector())} {
   LogVerbatim("Calibration") << "[DTVDriftWriter]Constructor called!";
 
   if (granularity_ != "bySL")

--- a/CalibMuon/DTCalibration/plugins/DTVDriftWriter.h
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftWriter.h
@@ -15,6 +15,7 @@
 #include "CondFormats/DataRecord/interface/DTMtimeRcd.h"
 #include "CondFormats/DataRecord/interface/DTRecoConditionsVdriftRcd.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include <string>
 

--- a/CalibMuon/DTCalibration/plugins/SealModule.cc
+++ b/CalibMuon/DTCalibration/plugins/SealModule.cc
@@ -37,6 +37,7 @@
 #include "CalibMuon/DTCalibration/plugins/DTT0FillChamberFromDB.h"
 #include "CalibMuon/DTCalibration/plugins/DTT0WireInChamberReferenceCorrection.h"
 #include "CalibMuon/DTCalibration/plugins/DTT0AbsoluteReferenceCorrection.h"
+#include "CalibMuon/DTCalibration/plugins/DTT0FEBPathCorrection.h"
 
 #include "CalibMuon/DTCalibration/interface/DTVDriftPluginFactory.h"
 #include "CalibMuon/DTCalibration/plugins/DTVDriftMeanTimer.h"
@@ -78,6 +79,7 @@ DEFINE_EDM_PLUGIN(DTT0CorrectionFactory,
 DEFINE_EDM_PLUGIN(DTT0CorrectionFactory,
                   dtCalibration::DTT0AbsoluteReferenceCorrection,
                   "DTT0AbsoluteReferenceCorrection");
+DEFINE_EDM_PLUGIN(DTT0CorrectionFactory, dtCalibration::DTT0FEBPathCorrection, "DTT0FEBPathCorrection");
 
 DEFINE_EDM_PLUGIN(DTVDriftPluginFactory, dtCalibration::DTVDriftMeanTimer, "DTVDriftMeanTimer");
 DEFINE_EDM_PLUGIN(DTVDriftPluginFactory, dtCalibration::DTVDriftSegment, "DTVDriftSegment");

--- a/CalibMuon/DTCalibration/python/dtT0AbsoluteReferenceCorrection_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtT0AbsoluteReferenceCorrection_cfg.py
@@ -8,9 +8,6 @@ process.MessageLogger.debugModules = cms.untracked.vstring('dtT0AbsoluteReferenc
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 process.GlobalTag.globaltag = ''
 
-#process.load("Configuration.StandardSequences.GeometryDB_cff")
-#process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-#process.GlobalTag.globaltag = ''
 process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff")
 process.load("Geometry.DTGeometry.dtGeometry_cfi")

--- a/CalibMuon/DTCalibration/python/dtT0FillChamberFromDBCorrection_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtT0FillChamberFromDBCorrection_cfg.py
@@ -7,6 +7,7 @@ process.MessageLogger.debugModules = cms.untracked.vstring('dtT0FillChamberFromD
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 process.GlobalTag.globaltag = ''
+
 process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff")
 process.load("Geometry.DTGeometry.dtGeometry_cfi")

--- a/CalibMuon/DTCalibration/python/dtT0FillDefaultFromDBCorrection_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtT0FillDefaultFromDBCorrection_cfg.py
@@ -7,6 +7,7 @@ process.MessageLogger.debugModules = cms.untracked.vstring('dtT0FillDefaultFromD
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 process.GlobalTag.globaltag = ''
+
 process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff")
 process.load("Geometry.DTGeometry.dtGeometry_cfi")

--- a/CalibMuon/DTCalibration/python/dtTTrigCorrection_cfi.py
+++ b/CalibMuon/DTCalibration/python/dtTTrigCorrection_cfi.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 dtTTrigCorrection = cms.EDAnalyzer("DTTTrigCorrectionFirst",
     debug = cms.untracked.bool(False),
+    dbLabel = cms.untracked.string(''),
     ttrigMax = cms.untracked.double(700.0),
     ttrigMin = cms.untracked.double(200.0),
     rmsLimit = cms.untracked.double(8.)

--- a/CalibMuon/DTCalibration/src/DTSegmentSelector.cc
+++ b/CalibMuon/DTCalibration/src/DTSegmentSelector.cc
@@ -22,6 +22,7 @@ DTSegmentSelector::DTSegmentSelector(edm::ParameterSet const& pset, edm::Consume
       maxAnglePhi_(pset.getParameter<double>("maxAnglePhi")),
       maxAngleZ_(pset.getParameter<double>("maxAngleZ")) {
   muonToken_ = iC.consumes<reco::MuonCollection>(muonTags_);
+  theStatusMapToken_ = iC.esConsumes();
 }
 
 bool DTSegmentSelector::operator()(DTRecSegment4D const& segment,
@@ -68,7 +69,7 @@ bool DTSegmentSelector::operator()(DTRecSegment4D const& segment,
 
   edm::ESHandle<DTStatusFlag> statusMap;
   if (checkNoisyChannels_)
-    setup.get<DTStatusFlagRcd>().get(statusMap);
+    statusMap = setup.getHandle(theStatusMapToken_);
 
   // Get the Phi 2D segment
   int nPhiHits = -1;

--- a/CalibMuon/DTCalibration/test/DBTools/DTT0Analyzer.cc
+++ b/CalibMuon/DTCalibration/test/DBTools/DTT0Analyzer.cc
@@ -25,18 +25,19 @@ DTT0Analyzer::DTT0Analyzer(const ParameterSet& pset) {
   string rootFileName = pset.getUntrackedParameter<string>("rootFileName");
   theFile = new TFile(rootFileName.c_str(), "RECREATE");
   theFile->cd();
+  t0Token_ = esConsumes<edm::Transition::BeginRun>();
+  dtGeomToken_ = esConsumes<edm::Transition::BeginRun>();
 }
 
 DTT0Analyzer::~DTT0Analyzer() { theFile->Close(); }
 
 void DTT0Analyzer::beginRun(const edm::Run&, const edm::EventSetup& eventSetup) {
   //Get the t0 map from the DB
-  ESHandle<DTT0> t0;
-  eventSetup.get<DTT0Rcd>().get(t0);
+  ESHandle<DTT0> t0 = eventSetup.getHandle(t0Token_);
   tZeroMap = &*t0;
 
   // Get the DT Geometry
-  eventSetup.get<MuonGeometryRecord>().get(dtGeom);
+  dtGeom = eventSetup.getHandle(dtGeomToken_);
 }
 
 void DTT0Analyzer::endJob() {

--- a/CalibMuon/DTCalibration/test/DBTools/DTT0Analyzer.h
+++ b/CalibMuon/DTCalibration/test/DBTools/DTT0Analyzer.h
@@ -10,9 +10,13 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "DataFormats/MuonDetId/interface/DTLayerId.h"
 #include "DataFormats/MuonDetId/interface/DTWireId.h"
 #include "Geometry/DTGeometry/interface/DTGeometry.h"
+#include "CondFormats/DataRecord/interface/DTT0Rcd.h"
+#include "CondFormats/DTObjects/interface/DTT0.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 
 #include <string>
 #include <fstream>
@@ -53,5 +57,8 @@ private:
   // Map of the t0 and sigma histos by layer
   std::map<DTLayerId, TH1D*> theMeanHistoMap;
   std::map<DTLayerId, TH1D*> theSigmaHistoMap;
+
+  edm::ESGetToken<DTT0, DTT0Rcd> t0Token_;
+  edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomToken_;
 };
 #endif

--- a/CalibMuon/DTCalibration/test/DBTools/DTTTrigAnalyzer.cc
+++ b/CalibMuon/DTCalibration/test/DBTools/DTTTrigAnalyzer.cc
@@ -26,14 +26,14 @@ DTTTrigAnalyzer::DTTTrigAnalyzer(const ParameterSet &pset) {
   theFile->cd();
   //The k factor to compute ttrig
   //kfactor = pset.getUntrackedParameter<double>("kfactor",0);
-  dbLabel = pset.getUntrackedParameter<string>("dbLabel", "");
+  ttrigToken_ =
+      esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", pset.getUntrackedParameter<string>("dbLabel")));
 }
 
 DTTTrigAnalyzer::~DTTTrigAnalyzer() { theFile->Close(); }
 
 void DTTTrigAnalyzer::beginRun(const edm::Run &, const edm::EventSetup &eventSetup) {
-  ESHandle<DTTtrig> tTrig;
-  eventSetup.get<DTTtrigRcd>().get(dbLabel, tTrig);
+  ESHandle<DTTtrig> tTrig = eventSetup.getHandle(ttrigToken_);
   tTrigMap = &*tTrig;
   cout << "[DTTTrigAnalyzer] TTrig version: " << tTrig->version() << endl;
 }

--- a/CalibMuon/DTCalibration/test/DBTools/DTTTrigAnalyzer.h
+++ b/CalibMuon/DTCalibration/test/DBTools/DTTTrigAnalyzer.h
@@ -11,6 +11,7 @@
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/MuonDetId/interface/DTWireId.h"
+#include "CondFormats/DataRecord/interface/DTTtrigRcd.h"
 
 #include <string>
 #include <fstream>
@@ -47,8 +48,6 @@ private:
   //The t0 map
   const DTTtrig* tTrigMap;
 
-  std::string dbLabel;
-
   //The k factor
   //double kfactor;
 
@@ -62,5 +61,7 @@ private:
   std::map<std::vector<int>, TH1D*> theTMeanDistribMap;
   std::map<std::vector<int>, TH1D*> theSigmaDistribMap;
   std::map<std::vector<int>, TH1D*> theKFactorDistribMap;
+
+  edm::ESGetToken<DTTtrig, DTTtrigRcd> ttrigToken_;
 };
 #endif

--- a/CalibMuon/DTCalibration/test/DBTools/DTVDriftAnalyzer.cc
+++ b/CalibMuon/DTCalibration/test/DBTools/DTVDriftAnalyzer.cc
@@ -28,20 +28,20 @@ DTVDriftAnalyzer::DTVDriftAnalyzer(const ParameterSet& pset)
   string rootFileName = pset.getUntrackedParameter<string>("rootFileName");
   theFile = new TFile(rootFileName.c_str(), "RECREATE");
   theFile->cd();
+  mTimeMapToken_ = esConsumes<edm::Transition::BeginRun>();
+  vDriftMapToken_ = esConsumes<edm::Transition::BeginRun>();
 }
 
 DTVDriftAnalyzer::~DTVDriftAnalyzer() { theFile->Close(); }
 
 void DTVDriftAnalyzer::beginRun(const edm::Run& run, const edm::EventSetup& eventSetup) {
   if (readLegacyVDriftDB) {
-    ESHandle<DTMtime> mTime;
-    eventSetup.get<DTMtimeRcd>().get(mTime);
+    ESHandle<DTMtime> mTime = eventSetup.getHandle(mTimeMapToken_);
     mTimeMap = &*mTime;
     vDriftMap_ = nullptr;
     edm::LogVerbatim("DTVDriftAnalyzer") << "[DTVDriftAnalyzer] MTime version: " << mTime->version() << endl;
   } else {
-    ESHandle<DTRecoConditions> hVdrift;
-    eventSetup.get<DTRecoConditionsVdriftRcd>().get(hVdrift);
+    ESHandle<DTRecoConditions> hVdrift = eventSetup.getHandle(vDriftMapToken_);
     vDriftMap_ = &*hVdrift;
     mTimeMap = nullptr;
     // Consistency check: no parametrization is implemented for the time being

--- a/CalibMuon/DTCalibration/test/DBTools/DTVDriftAnalyzer.h
+++ b/CalibMuon/DTCalibration/test/DBTools/DTVDriftAnalyzer.h
@@ -11,6 +11,8 @@
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/MuonDetId/interface/DTWireId.h"
+#include "CondFormats/DataRecord/interface/DTMtimeRcd.h"
+#include "CondFormats/DataRecord/interface/DTRecoConditionsVdriftRcd.h"
 
 #include <string>
 #include <fstream>
@@ -56,5 +58,8 @@ private:
   // Map of the vdrift, reso distributions by wheel/station/SL
   std::map<std::vector<int>, TH1D*> theVDriftDistribMap;
   std::map<std::vector<int>, TH1D*> theResoDistribMap;
+
+  edm::ESGetToken<DTMtime, DTMtimeRcd> mTimeMapToken_;
+  edm::ESGetToken<DTRecoConditions, DTRecoConditionsVdriftRcd> vDriftMapToken_;
 };
 #endif

--- a/CalibMuon/DTCalibration/test/DBTools/DumpFileToDB.cc
+++ b/CalibMuon/DTCalibration/test/DBTools/DumpFileToDB.cc
@@ -36,6 +36,7 @@ using namespace std;
 DumpFileToDB::DumpFileToDB(const ParameterSet& pset) {
   dbToDump = pset.getUntrackedParameter<string>("dbToDump", "TTrigDB");
   format = pset.getUntrackedParameter<string>("dbFormat", "Legacy");
+  ttrigToken_ = esConsumes<edm::Transition::BeginRun>();
 
   cout << "Writing DB: " << dbToDump << " with format: " << format << endl;
 
@@ -329,8 +330,7 @@ vector<int> DumpFileToDB::readChannelsMap(stringstream& linestr) {
 void DumpFileToDB::beginRun(const edm::Run& run, const edm::EventSetup& setup) {
   if (diffMode) {
     if (dbToDump == "TTrigDB") {  // read the original DB
-      ESHandle<DTTtrig> tTrig;
-      setup.get<DTTtrigRcd>().get(tTrig);
+      ESHandle<DTTtrig> tTrig = setup.getHandle(ttrigToken_);
       tTrigMapOrig = &*tTrig;
       cout << "[DumpDBToFile] TTrig version: " << tTrig->version() << endl;
     }

--- a/CalibMuon/DTCalibration/test/DBTools/DumpFileToDB.h
+++ b/CalibMuon/DTCalibration/test/DBTools/DumpFileToDB.h
@@ -11,6 +11,7 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "CondFormats/DataRecord/interface/DTTtrigRcd.h"
 
 #include <string>
 #include <fstream>
@@ -49,5 +50,7 @@ private:
   // sum the correction in the txt file (for the mean value) to what is input DB
   bool diffMode;
   const DTTtrig* tTrigMapOrig;
+
+  edm::ESGetToken<DTTtrig, DTTtrigRcd> ttrigToken_;
 };
 #endif

--- a/CalibMuon/DTCalibration/test/DBTools/FakeTTrig.cc
+++ b/CalibMuon/DTCalibration/test/DBTools/FakeTTrig.cc
@@ -44,8 +44,9 @@ FakeTTrig::FakeTTrig(const ParameterSet& pset) : dataBaseWriteWasDone(false) {
 
   // further configurable smearing
   smearing = pset.getUntrackedParameter<double>("smearing");
-  dbLabel = pset.getUntrackedParameter<string>("dbLabel", "");
-
+  ttrigToken_ =
+      esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", pset.getUntrackedParameter<string>("dbLabel")));
+  dtGeomToken_ = esConsumes<edm::Transition::BeginRun>();
   // get random engine
   edm::Service<edm::RandomNumberGenerator> rng;
   if (!rng.isAvailable()) {
@@ -58,11 +59,11 @@ FakeTTrig::~FakeTTrig() { cout << "[FakeTTrig] Destructor called! " << endl; }
 
 void FakeTTrig::beginRun(const edm::Run&, const EventSetup& setup) {
   cout << "[FakeTTrig] entered into beginRun! " << endl;
-  setup.get<MuonGeometryRecord>().get(muonGeom);
+  muonGeom = setup.getHandle(dtGeomToken_);
 
   // Get the tTrig reference map
   if (ps.getUntrackedParameter<bool>("readDB", true))
-    setup.get<DTTtrigRcd>().get(dbLabel, tTrigMapRef);
+    tTrigMapRef = setup.getHandle(ttrigToken_);
 }
 
 void FakeTTrig::beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const&) {

--- a/CalibMuon/DTCalibration/test/DBTools/FakeTTrig.h
+++ b/CalibMuon/DTCalibration/test/DBTools/FakeTTrig.h
@@ -15,7 +15,9 @@
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "Geometry/DTGeometry/interface/DTGeometry.h"
+#include "CondFormats/DataRecord/interface/DTTtrigRcd.h"
 #include <string>
 class DTGeometry;
 class DTSuperLayer;
@@ -47,8 +49,6 @@ private:
 
   double smearing;
 
-  std::string dbLabel;
-
   /// tTrig from the DB
   float tTrigRef;
   float tTrigRMSRef;
@@ -58,5 +58,8 @@ private:
   edm::ESHandle<DTTtrig> tTrigMapRef;
 
   bool dataBaseWriteWasDone;
+
+  edm::ESGetToken<DTTtrig, DTTtrigRcd> ttrigToken_;
+  edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomToken_;
 };
 #endif

--- a/CalibMuon/DTCalibration/test/DBTools/ShiftTTrigDB.cc
+++ b/CalibMuon/DTCalibration/test/DBTools/ShiftTTrigDB.cc
@@ -30,7 +30,10 @@ ShiftTTrigDB::ShiftTTrigDB(const ParameterSet& pset) {
   shifts = pset.getParameter<vector<double> >("shifts");
   //Read the chambers to be shifted
   vector<ParameterSet> parameters = pset.getParameter<vector<ParameterSet> >("chambers");
-  dbLabel = pset.getUntrackedParameter<string>("dbLabel", "");
+
+  ttrigToken_ =
+      esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", pset.getUntrackedParameter<string>("dbLabel")));
+  dtGeomToken_ = esConsumes<edm::Transition::BeginRun>();
 
   int counter = 0;
   for (vector<ParameterSet>::iterator parameter = parameters.begin(); parameter != parameters.end(); ++parameter) {
@@ -55,12 +58,10 @@ ShiftTTrigDB::ShiftTTrigDB(const ParameterSet& pset) {
 ShiftTTrigDB::~ShiftTTrigDB() {}
 
 void ShiftTTrigDB::beginRun(const edm::Run&, const EventSetup& setup) {
-  ESHandle<DTTtrig> tTrig;
-  setup.get<DTTtrigRcd>().get(dbLabel, tTrig);
+  ESHandle<DTTtrig> tTrig = setup.getHandle(ttrigToken_);
   tTrigMap = &*tTrig;
   cout << "[ShiftTTrigDB]: TTrig version: " << tTrig->version() << endl;
-
-  setup.get<MuonGeometryRecord>().get(muonGeom);
+  muonGeom = setup.getHandle(dtGeomToken_);
 }
 
 void ShiftTTrigDB::endJob() {

--- a/CalibMuon/DTCalibration/test/DBTools/ShiftTTrigDB.h
+++ b/CalibMuon/DTCalibration/test/DBTools/ShiftTTrigDB.h
@@ -11,6 +11,9 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "Geometry/DTGeometry/interface/DTGeometry.h"
+#include "CondFormats/DataRecord/interface/DTTtrigRcd.h"
 
 #include <map>
 #include <string>
@@ -40,11 +43,12 @@ private:
   const DTTtrig* tTrigMap;
   edm::ESHandle<DTGeometry> muonGeom;
 
-  std::string dbLabel;
-
   std::vector<std::vector<int> > chambers;
   std::vector<double> shifts;
   std::map<std::vector<int>, double> mapShiftsByChamber;
   bool debug;
+
+  edm::ESGetToken<DTTtrig, DTTtrigRcd> ttrigToken_;
+  edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomToken_;
 };
 #endif


### PR DESCRIPTION
#### PR description:
Some parts of CalibMuon/DTCalibration package was migrated in https://github.com/cms-sw/cmssw/pull/35336.
This PR migrates the rest of it. With this PR, the esConsumes migration of this package should be complete. Note that we have not addressed the issue of EDAnalyzers needing to be `one` module. That will be a separate PR. This PR only addressees esConsumes migration.

#### PR validation:
Validated by local tests, performed by running the following config files: 
`CalibMuon/DTCalibration/python/dtT0AbsoluteReferenceCorrection_cfg.py` , 
`CalibMuon/DTCalibration/python/dtT0FillChamberFromDBCorrection_cfg.py`,
`CalibMuon/DTCalibration/python/dtT0FillDefaultFromDBCorrection_cfg.py`,
`CalibMuon/DTCalibration/python/dtTTrigConstantShiftCorrection_cfg.py`,
`CalibMuon/DTCalibration/python/dtTTrigCorrection_cfi.py`

`runTheMatrix.py -l 12434.0` also ran fine.

This PR is not a backport.
Backport not needed.

[With thanks to Carlo Battilana]
