### PR TITLE
fix typo in `_loadOnlineBeamSpotESProducer`

### DIFF
--- a/RecoVertex/BeamSpotProducer/python/BeamSpot_cfi.py
+++ b/RecoVertex/BeamSpotProducer/python/BeamSpot_cfi.py
@@ -4,7 +4,7 @@ import RecoVertex.BeamSpotProducer.Modifiers as mods
 
 offlineBeamSpot = cms.EDProducer("BeamSpotProducer")
 
-def _loadOnlineBeamSpotESProduer(process):
+def _loadOnlineBeamSpotESProducer(process):
     import RecoVertex.BeamSpotProducer.onlineBeamSpotESProducer_cfi as _mod
     process.BeamSpotESProducer = _mod.onlineBeamSpotESProducer.clone(
         timeThreshold = 999999 # for express allow >48h old payloads for replays. DO NOT CHANGE
@@ -14,4 +14,4 @@ import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
 _onlineBeamSpotProducer = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()
 mods.offlineToOnlineBeamSpotSwap.toReplaceWith(offlineBeamSpot, _onlineBeamSpotProducer)
 
-applyOnlineBSESProducer = mods.offlineToOnlineBeamSpotSwap.makeProcessModifier(_loadOnlineBeamSpotESProduer)
+applyOnlineBSESProducer = mods.offlineToOnlineBeamSpotSwap.makeProcessModifier(_loadOnlineBeamSpotESProducer)


### PR DESCRIPTION
#### PR description:

Trivial typo fix. See https://github.com/cms-sw/cmssw/pull/35639#discussion_r729956308

#### PR validation:

None.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A 
