### PR TITLE
Speed up b and c jet energy regression in NanoAOD with ONNXRuntime

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/BJetEnergyRegressionMVA.cc
+++ b/PhysicsTools/NanoAOD/plugins/BJetEnergyRegressionMVA.cc
@@ -29,15 +29,12 @@
 
 class BJetEnergyRegressionMVA : public BaseMVAValueMapProducer<pat::Jet> {
 public:
-  explicit BJetEnergyRegressionMVA(const edm::ParameterSet& iConfig)
-      : BaseMVAValueMapProducer<pat::Jet>(iConfig),
-        pvsrc_(edm::stream::EDProducer<>::consumes<std::vector<reco::Vertex>>(
-            iConfig.getParameter<edm::InputTag>("pvsrc"))),
-        svsrc_(edm::stream::EDProducer<>::consumes<edm::View<reco::VertexCompositePtrCandidate>>(
-            iConfig.getParameter<edm::InputTag>("svsrc"))),
-        rhosrc_(edm::stream::EDProducer<>::consumes<double>(iConfig.getParameter<edm::InputTag>("rhosrc")))
+  explicit BJetEnergyRegressionMVA(const edm::ParameterSet& iConfig, const BaseMVACache* cache)
+      : BaseMVAValueMapProducer<pat::Jet>(iConfig, cache),
+        pvsrc_(consumes<std::vector<reco::Vertex>>(iConfig.getParameter<edm::InputTag>("pvsrc"))),
+        svsrc_(consumes<edm::View<reco::VertexCompositePtrCandidate>>(iConfig.getParameter<edm::InputTag>("svsrc"))),
+        rhosrc_(consumes<double>(iConfig.getParameter<edm::InputTag>("rhosrc"))) {}
 
-  {}
   void readAdditionalCollections(edm::Event& iEvent, const edm::EventSetup&) override {
     iEvent.getByToken(pvsrc_, pvs_);
     iEvent.getByToken(svsrc_, svs_);

--- a/PhysicsTools/NanoAOD/python/jets_cff.py
+++ b/PhysicsTools/NanoAOD/python/jets_cff.py
@@ -286,13 +286,14 @@ for modifier in run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2:
 
 
 bjetNN= cms.EDProducer("BJetEnergyRegressionMVA",
-    backend = cms.string("TF"),
+    backend = cms.string("ONNX"),
+    batch_eval = cms.bool(True),
     src = cms.InputTag("linkedObjects","jets"),
     pvsrc = cms.InputTag("offlineSlimmedPrimaryVertices"),
     svsrc = cms.InputTag("slimmedSecondaryVertices"),
     rhosrc = cms.InputTag("fixedGridRhoFastjetAll"),
 
-    weightFile =  cms.FileInPath("PhysicsTools/NanoAOD/data/breg_training_2018.pb"),
+    weightFile =  cms.FileInPath("PhysicsTools/NanoAOD/data/breg_training_2018.onnx"),
     name = cms.string("JetRegNN"),
     isClassifier = cms.bool(False),
     variablesOrder = cms.vstring(["Jet_pt","Jet_eta","rho","Jet_mt","Jet_leadTrackPt","Jet_leptonPtRel","Jet_leptonDeltaR","Jet_neHEF",
@@ -330,8 +331,8 @@ bjetNN= cms.EDProducer("BJetEnergyRegressionMVA",
     isEle = cms.string("?abs(userInt('leptonPdgId'))==11?1:0"),
     isOther = cms.string("?userInt('leptonPdgId')==0?1:0"),
     ),
-     inputTensorName = cms.string("ffwd_inp"),
-     outputTensorName = cms.string("ffwd_out/BiasAdd"),
+     inputTensorName = cms.string("ffwd_inp:0"),
+     outputTensorName = cms.string("ffwd_out/BiasAdd:0"),
      outputNames = cms.vstring(["corr","res"]),
      outputFormulas = cms.vstring(["at(0)*0.27912887930870056+1.0545977354049683","0.5*(at(2)-at(1))*0.27912887930870056"]),
      nThreads = cms.uint32(1),
@@ -339,13 +340,15 @@ bjetNN= cms.EDProducer("BJetEnergyRegressionMVA",
 )
 
 cjetNN= cms.EDProducer("BJetEnergyRegressionMVA",
-    backend = cms.string("TF"),
+    backend = cms.string("ONNX"),
+    batch_eval = cms.bool(True),
+
     src = cms.InputTag("linkedObjects","jets"),
     pvsrc = cms.InputTag("offlineSlimmedPrimaryVertices"),
     svsrc = cms.InputTag("slimmedSecondaryVertices"),
     rhosrc = cms.InputTag("fixedGridRhoFastjetAll"),
 
-    weightFile =  cms.FileInPath("PhysicsTools/NanoAOD/data/creg_training_2018.pb"),
+    weightFile =  cms.FileInPath("PhysicsTools/NanoAOD/data/creg_training_2018.onnx"),
     name = cms.string("JetRegNN"),
     isClassifier = cms.bool(False),
     variablesOrder = cms.vstring(["Jet_pt","Jet_eta","rho","Jet_mt","Jet_leadTrackPt","Jet_leptonPtRel","Jet_leptonDeltaR",
@@ -383,8 +386,8 @@ cjetNN= cms.EDProducer("BJetEnergyRegressionMVA",
     isEle = cms.string("?abs(userInt('leptonPdgId'))==11?1:0"),
     isOther = cms.string("?userInt('leptonPdgId')==0?1:0"),
     ),
-     inputTensorName = cms.string("ffwd_inp"),
-     outputTensorName = cms.string("ffwd_out/BiasAdd"),
+     inputTensorName = cms.string("ffwd_inp:0"),
+     outputTensorName = cms.string("ffwd_out/BiasAdd:0"),
      outputNames = cms.vstring(["corr","res"]),
      outputFormulas = cms.vstring(["at(0)*0.24325256049633026+0.993854820728302","0.5*(at(2)-at(1))*0.24325256049633026"]),
      nThreads = cms.uint32(1),
@@ -516,16 +519,16 @@ run2_miniAOD_80XLegacy.toModify( fatJetTable.variables, n3b1 = None)
 for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016:
   modifier.toModify( fatJetTable.variables, jetId = Var("userInt('tightId')*2+userInt('looseId')",int,doc="Jet ID flags bit1 is loose, bit2 is tight"))
 
-run2_jme_2016.toModify( bjetNN, weightFile = cms.FileInPath("PhysicsTools/NanoAOD/data/breg_training_2016.pb") )
+run2_jme_2016.toModify( bjetNN, weightFile = cms.FileInPath("PhysicsTools/NanoAOD/data/breg_training_2016.onnx") )
 run2_jme_2016.toModify( bjetNN,outputFormulas = cms.vstring(["at(0)*0.31976690888404846+1.047176718711853","0.5*(at(2)-at(1))*0.31976690888404846"]))
 
-run2_jme_2017.toModify( bjetNN, weightFile = cms.FileInPath("PhysicsTools/NanoAOD/data/breg_training_2017.pb") )
+run2_jme_2017.toModify( bjetNN, weightFile = cms.FileInPath("PhysicsTools/NanoAOD/data/breg_training_2017.onnx") )
 run2_jme_2017.toModify( bjetNN,outputFormulas = cms.vstring(["at(0)*0.28225210309028625+1.055067777633667","0.5*(at(2)-at(1))*0.28225210309028625"]))
 
-run2_jme_2016.toModify( cjetNN, weightFile = cms.FileInPath("PhysicsTools/NanoAOD/data/creg_training_2016.pb") )
+run2_jme_2016.toModify( cjetNN, weightFile = cms.FileInPath("PhysicsTools/NanoAOD/data/creg_training_2016.onnx") )
 run2_jme_2016.toModify( cjetNN,outputFormulas = cms.vstring(["at(0)*0.28862622380256653+0.9908722639083862","0.5*(at(2)-at(1))*0.28862622380256653"]))
 
-run2_jme_2017.toModify( cjetNN, weightFile = cms.FileInPath("PhysicsTools/NanoAOD/data/creg_training_2017.pb") )
+run2_jme_2017.toModify( cjetNN, weightFile = cms.FileInPath("PhysicsTools/NanoAOD/data/creg_training_2017.onnx") )
 run2_jme_2017.toModify( cjetNN,outputFormulas = cms.vstring(["at(0)*0.24718524515628815+0.9927206635475159","0.5*(at(2)-at(1))*0.24718524515628815"]))
 
 

--- a/PhysicsTools/NanoAOD/python/jets_cff.py
+++ b/PhysicsTools/NanoAOD/python/jets_cff.py
@@ -335,8 +335,6 @@ bjetNN= cms.EDProducer("BJetEnergyRegressionMVA",
      outputTensorName = cms.string("ffwd_out/BiasAdd:0"),
      outputNames = cms.vstring(["corr","res"]),
      outputFormulas = cms.vstring(["at(0)*0.27912887930870056+1.0545977354049683","0.5*(at(2)-at(1))*0.27912887930870056"]),
-     nThreads = cms.uint32(1),
-     singleThreadPool = cms.string("no_threads"),
 )
 
 cjetNN= cms.EDProducer("BJetEnergyRegressionMVA",
@@ -390,8 +388,6 @@ cjetNN= cms.EDProducer("BJetEnergyRegressionMVA",
      outputTensorName = cms.string("ffwd_out/BiasAdd:0"),
      outputNames = cms.vstring(["corr","res"]),
      outputFormulas = cms.vstring(["at(0)*0.24325256049633026+0.993854820728302","0.5*(at(2)-at(1))*0.24325256049633026"]),
-     nThreads = cms.uint32(1),
-     singleThreadPool = cms.string("no_threads"),
 )
 
 

--- a/PhysicsTools/PatAlgos/BuildFile.xml
+++ b/PhysicsTools/PatAlgos/BuildFile.xml
@@ -15,6 +15,7 @@
 <use name="PhysicsTools/IsolationAlgos"/>
 <use name="PhysicsTools/PatUtils"/>
 <use name="PhysicsTools/TensorFlow"/>
+<use name="PhysicsTools/ONNXRuntime"/>
 <use name="clhep"/>
 <export>
   <lib name="1"/>

--- a/PhysicsTools/PatAlgos/interface/BaseMVAValueMapProducer.h
+++ b/PhysicsTools/PatAlgos/interface/BaseMVAValueMapProducer.h
@@ -46,6 +46,7 @@
 #include "DataFormats/PatCandidates/interface/Muon.h"
 #include "DataFormats/PatCandidates/interface/Electron.h"
 #include "PhysicsTools/TensorFlow/interface/TensorFlow.h"
+#include "PhysicsTools/ONNXRuntime/interface/ONNXRuntime.h"
 
 #include <string>
 //
@@ -64,7 +65,9 @@ public:
         weightfilename_(iConfig.getParameter<edm::FileInPath>("weightFile").fullPath()),
         isClassifier_(iConfig.getParameter<bool>("isClassifier")),
         tmva_(backend_ == "TMVA"),
-        tf_(backend_ == "TF") {
+        tf_(backend_ == "TF"),
+        onnx_(backend_ == "ONNX"),
+        batch_eval_(iConfig.getParameter<bool>("batch_eval")) {
     if (tmva_)
       reader_ = new TMVA::Reader();
     edm::ParameterSet const& varsPSet = iConfig.getParameter<edm::ParameterSet>("variables");
@@ -87,18 +90,22 @@ public:
     } else if (tf_) {
       tensorflow::setLogging("3");
       graph_ = tensorflow::loadGraphDef(weightfilename_);
+      size_t nThreads = iConfig.getParameter<unsigned int>("nThreads");
+      session_ = tensorflow::createSession(graph_, nThreads);
+    } else if (onnx_) {
+      ort_ = std::make_unique<cms::Ort::ONNXRuntime>(weightfilename_);
+    } else {
+      throw cms::Exception("ConfigError") << "Only 'TF', 'ONNX' and 'TMVA' backends are supported\n";
+    }
+    if (tf_ || onnx_) {
       inputTensorName_ = iConfig.getParameter<std::string>("inputTensorName");
       outputTensorName_ = iConfig.getParameter<std::string>("outputTensorName");
       output_names_ = iConfig.getParameter<std::vector<std::string>>("outputNames");
       for (const auto& s : iConfig.getParameter<std::vector<std::string>>("outputFormulas")) {
         output_formulas_.push_back(StringObjectFunction<std::vector<float>>(s));
       }
-      size_t nThreads = iConfig.getParameter<unsigned int>("nThreads");
-      session_ = tensorflow::createSession(graph_, nThreads);
-
-    } else {
-      throw cms::Exception("ConfigError") << "Only 'TF' and 'TMVA' backends are supported\n";
     }
+
     if (tmva_)
       produces<edm::ValueMap<float>>();
     else {
@@ -135,6 +142,7 @@ private:
   tensorflow::GraphDef* graph_;
   tensorflow::Session* session_;
   std::string singleThreadPool_;
+  std::unique_ptr<cms::Ort::ONNXRuntime> ort_;
 
   std::string name_;
   std::string backend_;
@@ -142,6 +150,8 @@ private:
   bool isClassifier_;
   bool tmva_;
   bool tf_;
+  bool onnx_;
+  bool batch_eval_;
   std::string inputTensorName_;
   std::string outputTensorName_;
   std::vector<std::string> output_names_;
@@ -157,35 +167,77 @@ void BaseMVAValueMapProducer<T>::produce(edm::Event& iEvent, const edm::EventSet
   for (auto& v : mvaOut)
     v.reserve(src->size());
 
-  for (auto const& o : *src) {
-    for (auto const& p : funcs_) {
-      setValue(p.first, p.second(o));
+  if (batch_eval_) {
+    std::vector<float> data;
+    data.reserve(src->size() * positions_.size());
+    for (auto const& o : *src) {
+      for (auto const& p : funcs_) {
+        setValue(p.first, p.second(o));
+      }
+      fillAdditionalVariables(o);
+      data.insert(data.end(), values_.begin(), values_.end());
     }
-    fillAdditionalVariables(o);
-    if (tmva_) {
-      mvaOut[0].push_back(isClassifier_ ? reader_->EvaluateMVA(name_) : reader_->EvaluateRegression(name_)[0]);
-    }
+
+    std::vector<float> outputs;
     if (tf_) {
-      //currently support only one input sensor to reuse the TMVA like config
-      tensorflow::TensorShape input_size{1, (long long int)positions_.size()};
+      tensorflow::TensorShape input_size{(long long int)src->size(), (long long int)positions_.size()};
       tensorflow::NamedTensorList input_tensors;
       input_tensors.resize(1);
       input_tensors[0] =
           tensorflow::NamedTensor(inputTensorName_, tensorflow::Tensor(tensorflow::DT_FLOAT, input_size));
-      for (size_t j = 0; j < values_.size(); j++) {
-        input_tensors[0].second.matrix<float>()(0, j) = values_[j];
+      for (unsigned i = 0; i < data.size(); ++i) {
+        input_tensors[0].second.flat<float>()(i) = data[i];
       }
-      std::vector<tensorflow::Tensor> outputs;
-      std::vector<std::string> names;
-      names.push_back(outputTensorName_);
-      tensorflow::run(session_, input_tensors, names, &outputs, singleThreadPool_);
+      std::vector<tensorflow::Tensor> output_tensors;
+      tensorflow::run(session_, input_tensors, {outputTensorName_}, &output_tensors, singleThreadPool_);
+      for (unsigned i = 0; i < output_tensors.at(0).NumElements(); ++i) {
+        outputs.push_back(output_tensors.at(0).flat<float>()(i));
+      }
+    } else if (onnx_) {
+      cms::Ort::FloatArrays inputs{data};
+      outputs = ort_->run({inputTensorName_}, inputs, {}, {outputTensorName_}, src->size())[0];
+    }
+
+    const unsigned outdim = outputs.size() / src->size();
+    for (unsigned i = 0; i < src->size(); ++i) {
+      std::vector<float> tmpOut(outputs.begin() + i * outdim, outputs.begin() + (i + 1) * outdim);
+      for (size_t k = 0; k < output_names_.size(); k++) {
+        mvaOut[k].push_back(output_formulas_[k](tmpOut));
+      }
+    }
+  } else {
+    for (auto const& o : *src) {
+      for (auto const& p : funcs_) {
+        setValue(p.first, p.second(o));
+      }
+      fillAdditionalVariables(o);
+      if (tmva_) {
+        mvaOut[0].push_back(isClassifier_ ? reader_->EvaluateMVA(name_) : reader_->EvaluateRegression(name_)[0]);
+      }
       std::vector<float> tmpOut;
-      for (int k = 0; k < outputs.at(0).matrix<float>().dimension(1); k++)
-        tmpOut.push_back(outputs.at(0).matrix<float>()(0, k));
+      if (tf_) {
+        //currently support only one input sensor to reuse the TMVA like config
+        tensorflow::TensorShape input_size{1, (long long int)positions_.size()};
+        tensorflow::NamedTensorList input_tensors;
+        input_tensors.resize(1);
+        input_tensors[0] =
+            tensorflow::NamedTensor(inputTensorName_, tensorflow::Tensor(tensorflow::DT_FLOAT, input_size));
+        for (size_t j = 0; j < values_.size(); j++) {
+          input_tensors[0].second.matrix<float>()(0, j) = values_[j];
+        }
+        std::vector<tensorflow::Tensor> outputs;
+        tensorflow::run(session_, input_tensors, {outputTensorName_}, &outputs, singleThreadPool_);
+        for (int k = 0; k < outputs.at(0).matrix<float>().dimension(1); k++)
+          tmpOut.push_back(outputs.at(0).matrix<float>()(0, k));
+      } else if (onnx_) {
+        cms::Ort::FloatArrays inputs{values_};
+        tmpOut = ort_->run({inputTensorName_}, inputs, {}, {outputTensorName_})[0];
+      }
       for (size_t k = 0; k < output_names_.size(); k++)
         mvaOut[k].push_back(output_formulas_[k](tmpOut));
     }
   }
+
   size_t k = 0;
   for (auto& m : mvaOut) {
     std::unique_ptr<edm::ValueMap<float>> mvaV(new edm::ValueMap<float>());
@@ -208,7 +260,7 @@ edm::ParameterSetDescription BaseMVAValueMapProducer<T>::getDescription() {
   variables.setAllowAnything();
   desc.add<edm::ParameterSetDescription>("variables", variables)->setComment("list of input variable definitions");
   desc.add<edm::FileInPath>("weightFile")->setComment("xml weight file");
-  desc.add<std::string>("backend", "TMVA")->setComment("TMVA or TF");
+  desc.add<std::string>("backend", "TMVA")->setComment("TMVA, TF or ONNX");
   desc.add<std::string>("inputTensorName", "")->setComment("Name of tensorflow input tensor in the model");
   desc.add<std::string>("outputTensorName", "")->setComment("Name of tensorflow output tensor in the model");
   desc.add<std::vector<std::string>>("outputNames", std::vector<std::string>())
@@ -217,6 +269,7 @@ edm::ParameterSetDescription BaseMVAValueMapProducer<T>::getDescription() {
       ->setComment("Formulas to be used to post process the output");
   desc.add<unsigned int>("nThreads", 1)->setComment("number of threads");
   desc.add<std::string>("singleThreadPool", "no_threads");
+  desc.add<bool>("batch_eval", false)->setComment("Run inference in batch instead of per-object");
 
   return desc;
 }

--- a/PhysicsTools/PatAlgos/interface/BaseMVAValueMapProducer.h
+++ b/PhysicsTools/PatAlgos/interface/BaseMVAValueMapProducer.h
@@ -213,28 +213,29 @@ void BaseMVAValueMapProducer<T>::produce(edm::Event& iEvent, const edm::EventSet
       fillAdditionalVariables(o);
       if (tmva_) {
         mvaOut[0].push_back(isClassifier_ ? reader_->EvaluateMVA(name_) : reader_->EvaluateRegression(name_)[0]);
-      }
-      std::vector<float> tmpOut;
-      if (tf_) {
-        //currently support only one input sensor to reuse the TMVA like config
-        tensorflow::TensorShape input_size{1, (long long int)positions_.size()};
-        tensorflow::NamedTensorList input_tensors;
-        input_tensors.resize(1);
-        input_tensors[0] =
-            tensorflow::NamedTensor(inputTensorName_, tensorflow::Tensor(tensorflow::DT_FLOAT, input_size));
-        for (size_t j = 0; j < values_.size(); j++) {
-          input_tensors[0].second.matrix<float>()(0, j) = values_[j];
+      } else {
+        std::vector<float> tmpOut;
+        if (tf_) {
+          //currently support only one input sensor to reuse the TMVA like config
+          tensorflow::TensorShape input_size{1, (long long int)positions_.size()};
+          tensorflow::NamedTensorList input_tensors;
+          input_tensors.resize(1);
+          input_tensors[0] =
+              tensorflow::NamedTensor(inputTensorName_, tensorflow::Tensor(tensorflow::DT_FLOAT, input_size));
+          for (size_t j = 0; j < values_.size(); j++) {
+            input_tensors[0].second.matrix<float>()(0, j) = values_[j];
+          }
+          std::vector<tensorflow::Tensor> outputs;
+          tensorflow::run(session_, input_tensors, {outputTensorName_}, &outputs, singleThreadPool_);
+          for (int k = 0; k < outputs.at(0).matrix<float>().dimension(1); k++)
+            tmpOut.push_back(outputs.at(0).matrix<float>()(0, k));
+        } else if (onnx_) {
+          cms::Ort::FloatArrays inputs{values_};
+          tmpOut = ort_->run({inputTensorName_}, inputs, {}, {outputTensorName_})[0];
         }
-        std::vector<tensorflow::Tensor> outputs;
-        tensorflow::run(session_, input_tensors, {outputTensorName_}, &outputs, singleThreadPool_);
-        for (int k = 0; k < outputs.at(0).matrix<float>().dimension(1); k++)
-          tmpOut.push_back(outputs.at(0).matrix<float>()(0, k));
-      } else if (onnx_) {
-        cms::Ort::FloatArrays inputs{values_};
-        tmpOut = ort_->run({inputTensorName_}, inputs, {}, {outputTensorName_})[0];
+        for (size_t k = 0; k < output_names_.size(); k++)
+          mvaOut[k].push_back(output_formulas_[k](tmpOut));
       }
-      for (size_t k = 0; k < output_names_.size(); k++)
-        mvaOut[k].push_back(output_formulas_[k](tmpOut));
     }
   }
 


### PR DESCRIPTION
Requires: https://github.com/cms-data/PhysicsTools-NanoAOD/pull/13

---

#### PR description:


This PR changes the b and c jet energy regression in NanoAOD from TF to ONNXRuntime. Batch evaluation is also implemented to run inference on all jets in an event together instead of jet-by-jet. Overall speed-up is 3-4x.

On a TTBar hadronic sample:

[before]
```
TimeReport   0.006052     0.006052     0.006052  bjetNN
TimeReport   0.005448     0.005448     0.005448  cjetNN
```

[after]
```
TimeReport   0.001650     0.001650     0.001650  bjetNN
TimeReport   0.001485     0.001485     0.001485  cjetNN
```

#### PR validation:

Tested on UL NanoAODv9 workflows and obtained identical output values for b and c jet energy regression.