### PR TITLE
Fix SyntaxWarning in trackselectionRefitting.py

### DIFF
--- a/Alignment/CommonAlignment/python/tools/trackselectionRefitting.py
+++ b/Alignment/CommonAlignment/python/tools/trackselectionRefitting.py
@@ -336,7 +336,7 @@ def getSequence(process, collection,
                                   **(mod[2])), src
         modules.append(getattr(process, src))
     else:
-        if mods[-1][-1]["method"] is "load" and \
+        if mods[-1][-1]["method"] == "load" and \
                 not mods[-1][-1].get("clone", False):
             print("Name of the last module needs to be modifiable.")
             sys.exit(1)


### PR DESCRIPTION
This PR fixes the following syntax warning I spotted when running
`scram b`:

```
src/Alignment/CommonAlignment/python/tools/trackselectionRefitting.py:339: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if mods[-1][-1]["method"] is "load" and \
```