### PR TITLE
Replace `boost::ptr_vector` and `boost::ptr_list` with STL collections in RecoTauTag/RecoTau

### DIFF
--- a/RecoTauTag/RecoTau/interface/PFRecoTauChargedHadronPlugins.h
+++ b/RecoTauTag/RecoTau/interface/PFRecoTauChargedHadronPlugins.h
@@ -17,12 +17,11 @@
  *
  */
 
-#include <vector>
-#include <boost/ptr_container/ptr_vector.hpp>
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "RecoTauTag/RecoTau/interface/RecoTauPluginsCommon.h"
 
-#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include <vector>
 
 namespace reco {
 
@@ -35,10 +34,8 @@ namespace reco {
     class PFRecoTauChargedHadronBuilderPlugin : public RecoTauEventHolderPlugin {
     public:
       // Return a vector of pointers
-      typedef boost::ptr_vector<PFRecoTauChargedHadron> ChargedHadronVector;
-      // Storing the result in an auto ptr on function return allows
-      // allows us to safely release the ptr_vector in the virtual function
-      typedef std::unique_ptr<ChargedHadronVector> return_type;
+      typedef std::vector<std::unique_ptr<PFRecoTauChargedHadron>> ChargedHadronVector;
+      typedef ChargedHadronVector return_type;
       explicit PFRecoTauChargedHadronBuilderPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC)
           : RecoTauEventHolderPlugin(pset) {}
       ~PFRecoTauChargedHadronBuilderPlugin() override {}

--- a/RecoTauTag/RecoTau/interface/RecoTauBuilderPlugins.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauBuilderPlugins.h
@@ -30,8 +30,6 @@
  *
  */
 
-#include <boost/ptr_container/ptr_vector.hpp>
-
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
@@ -55,15 +53,15 @@ namespace reco {
     /* Class that constructs PFTau(s) from a Jet and its associated PiZeros */
     class RecoTauBuilderPlugin : public RecoTauEventHolderPlugin {
     public:
-      typedef boost::ptr_vector<reco::PFTau> output_type;
-      typedef std::unique_ptr<output_type> return_type;
+      typedef std::vector<std::unique_ptr<reco::PFTau>> output_type;
+      typedef output_type return_type;
 
       explicit RecoTauBuilderPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC)
           : RecoTauEventHolderPlugin(pset),
             // The vertex association configuration is specified with the quality cuts.
             vertexAssociator_(pset.getParameter<edm::ParameterSet>("qualityCuts"), std::move(iC)) {
         pfCandSrc_ = pset.getParameter<edm::InputTag>("pfCandSrc");
-        pfCand_token = iC.consumes<edm::View<reco::Candidate> >(pfCandSrc_);
+        pfCand_token = iC.consumes<edm::View<reco::Candidate>>(pfCandSrc_);
       };
 
       ~RecoTauBuilderPlugin() override {}
@@ -77,7 +75,7 @@ namespace reco {
                                      const std::vector<CandidatePtr>&) const = 0;
 
       /// Hack to be able to convert Ptrs to Refs
-      const edm::Handle<edm::View<reco::Candidate> >& getPFCands() const { return pfCands_; };
+      const edm::Handle<edm::View<reco::Candidate>>& getPFCands() const { return pfCands_; };
 
       /// Get primary vertex associated to this jet
       reco::VertexRef primaryVertex(const reco::JetBaseRef& jet) const {
@@ -95,9 +93,9 @@ namespace reco {
     private:
       edm::InputTag pfCandSrc_;
       // Handle to PFCandidates needed to build Refs
-      edm::Handle<edm::View<reco::Candidate> > pfCands_;
+      edm::Handle<edm::View<reco::Candidate>> pfCands_;
       reco::tau::RecoTauVertexAssociator vertexAssociator_;
-      edm::EDGetTokenT<edm::View<reco::Candidate> > pfCand_token;
+      edm::EDGetTokenT<edm::View<reco::Candidate>> pfCand_token;
     };
 
     /* Class that updates a PFTau's members (i.e. electron variables) */

--- a/RecoTauTag/RecoTau/interface/RecoTauCleaningTools.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauCleaningTools.h
@@ -13,13 +13,11 @@ namespace reco::tau {
     explicit RecoTauLexicographicalRanking(const RankingList& rankers) : rankers_(rankers) {}
     // Predicate to compare a and b
     bool operator()(const Type& a, const Type& b) const {
-      typename RankingList::const_iterator ranker = rankers_.begin();
-      while (ranker != rankers_.end()) {
+      for (auto const& ranker : rankers_) {
         double aResult = (*ranker)(a);
         double bResult = (*ranker)(b);
         if (aResult != bResult)
           return (aResult < bResult);
-        ++ranker;
       }
       // If all aare equal return false
       return false;
@@ -31,28 +29,21 @@ namespace reco::tau {
 
   template <typename Container, class OverlapFunction>
   Container cleanOverlaps(const Container& dirty) {
-    typedef typename Container::const_iterator Iterator;
     // Output container of clean objects
     Container clean;
     OverlapFunction overlapChecker;
-    for (Iterator candidate = dirty.begin(); candidate != dirty.end(); ++candidate) {
+    for (auto const& candidate : dirty) {
       // Check if this overlaps with a pizero already in the clean list
       bool overlaps = false;
-      for (Iterator cleaned = clean.begin(); cleaned != clean.end() && !overlaps; ++cleaned) {
-        overlaps = overlapChecker(*candidate, *cleaned);
+      for (auto cleaned = clean.begin(); cleaned != clean.end() && !overlaps; ++cleaned) {
+        overlaps = overlapChecker(candidate, *cleaned);
       }
       // If it didn't overlap with anything clean, add it to the clean list
       if (!overlaps)
-        clean.insert(clean.end(), *candidate);
+        clean.insert(clean.end(), candidate);
     }
     return clean;
   }
-
-  template <typename T>
-  class SortByDescendingPt {
-  public:
-    bool operator()(const T& a, const T& b) const { return a.pt() > b.pt(); }
-  };
 
 }  // namespace reco::tau
 

--- a/RecoTauTag/RecoTau/interface/RecoTauPiZeroPlugins.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauPiZeroPlugins.h
@@ -18,7 +18,6 @@
  */
 
 #include <vector>
-#include <boost/ptr_container/ptr_vector.hpp>
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 #include "RecoTauTag/RecoTau/interface/RecoTauPluginsCommon.h"
 
@@ -33,10 +32,8 @@ namespace reco {
     class RecoTauPiZeroBuilderPlugin : public RecoTauEventHolderPlugin {
     public:
       // Return a vector of pointers
-      typedef boost::ptr_vector<RecoTauPiZero> PiZeroVector;
-      // Storing the result in an auto ptr on function return allows
-      // allows us to safely release the ptr_vector in the virtual function
-      typedef std::unique_ptr<PiZeroVector> return_type;
+      typedef std::vector<std::unique_ptr<RecoTauPiZero>> PiZeroVector;
+      typedef PiZeroVector return_type;
       explicit RecoTauPiZeroBuilderPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC)
           : RecoTauEventHolderPlugin(pset) {}
       ~RecoTauPiZeroBuilderPlugin() override {}

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromGenericTrackPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromGenericTrackPlugin.cc
@@ -343,7 +343,7 @@ namespace reco {
         output.push_back(std::move(chargedHadron));
       }
 
-      return output.release();
+      return output;
     }
 
     typedef PFRecoTauChargedHadronFromGenericTrackPlugin<reco::Track> PFRecoTauChargedHadronFromTrackPlugin;

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromPFCandidatePlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromPFCandidatePlugin.cc
@@ -183,7 +183,7 @@ namespace reco {
           algo = PFRecoTauChargedHadron::kChargedPFCandidate;
         else
           algo = PFRecoTauChargedHadron::kPFNeutralHadron;
-        std::unique_ptr<PFRecoTauChargedHadron> chargedHadron(new PFRecoTauChargedHadron(**cand, algo));
+        auto chargedHadron = std::make_unique<PFRecoTauChargedHadron>(**cand, algo);
 
         const reco::PFCandidate* pfCand = dynamic_cast<const reco::PFCandidate*>(&**cand);
         if (pfCand) {
@@ -281,7 +281,7 @@ namespace reco {
         output.push_back(std::move(chargedHadron));
       }
 
-      return output.release();
+      return output;
     }
 
   }  // namespace tau

--- a/RecoTauTag/RecoTau/plugins/RecoTauBuilderCombinatoricPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauBuilderCombinatoricPlugin.cc
@@ -494,7 +494,7 @@ namespace reco {
         }
       }
 
-      return output.release();
+      return output;
     }
 
   }  // namespace tau

--- a/RecoTauTag/RecoTau/plugins/RecoTauBuilderConePlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauBuilderConePlugin.cc
@@ -245,7 +245,7 @@ namespace reco {
       } else {
         // If there is no leading charged candidate at all, return nothing - the
         // producer class that owns the plugin will build a null tau if desired.
-        return output.release();
+        return output;
       }
 
       // Find the leading neutral candidate
@@ -419,7 +419,7 @@ namespace reco {
       setTauQuantities(*tauPtr, minAbsPhotonSumPt_insideSignalCone_, minRelPhotonSumPt_insideSignalCone_);
 
       output.push_back(std::move(tauPtr));
-      return output.release();
+      return output;
     }
   }  // namespace tau
 }  // namespace reco

--- a/RecoTauTag/RecoTau/plugins/RecoTauCleaner.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauCleaner.cc
@@ -14,7 +14,6 @@
  *
  */
 
-#include <boost/ptr_container/ptr_vector.hpp>
 #include <algorithm>
 #include <memory>
 

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroCombinatoricPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroCombinatoricPlugin.cc
@@ -62,7 +62,7 @@ namespace reco {
       CandPtrs pfGammaCands = qcuts_.filterCandRefs(pfGammas(jet));
       // Check if we have anything to do...
       if (pfGammaCands.size() < choose_)
-        return output.release();
+        return output;
 
       // Define the valid range of gammas to use
       CandIter start_iter = pfGammaCands.begin();
@@ -81,8 +81,7 @@ namespace reco {
         std::unique_ptr<RecoTauPiZero> piZero(
             new RecoTauPiZero(0, totalP4, Candidate::Point(0, 0, 0), 111, 10001, true, RecoTauPiZero::kCombinatoric));
         // Add our daughters from this combination
-        for (ComboGenerator::combo_iterator candidate = combo->combo_begin(); candidate != combo->combo_end();
-             ++candidate) {
+        for (auto candidate = combo->combo_begin(); candidate != combo->combo_end(); ++candidate) {
           piZero->addDaughter(*candidate);
         }
         p4Builder_.set(*piZero);
@@ -91,9 +90,9 @@ namespace reco {
           piZero->setVertex(piZero->daughterPtr(0)->vertex());
 
         if ((maxMass_ < 0 || piZero->mass() < maxMass_) && piZero->mass() > minMass_)
-          output.push_back(piZero.get());
+          output.emplace_back(piZero.release());
       }
-      return output.release();
+      return output;
     }
 
   }  // namespace tau

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroProducer.cc
@@ -12,8 +12,6 @@
  */
 
 #include <algorithm>
-#include <boost/ptr_container/ptr_list.hpp>
-#include <boost/ptr_container/ptr_vector.hpp>
 #include <functional>
 #include <memory>
 
@@ -52,15 +50,14 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  typedef boost::ptr_vector<Builder> builderList;
-  typedef boost::ptr_vector<Ranker> rankerList;
-  typedef boost::ptr_vector<reco::RecoTauPiZero> PiZeroVector;
-  typedef boost::ptr_list<reco::RecoTauPiZero> PiZeroList;
+  typedef std::vector<std::unique_ptr<Ranker>> RankerList;
+  typedef Builder::return_type PiZeroVector;
+  typedef std::list<std::unique_ptr<reco::RecoTauPiZero>> PiZeroList;
 
-  typedef reco::tau::RecoTauLexicographicalRanking<rankerList, reco::RecoTauPiZero> PiZeroPredicate;
+  typedef reco::tau::RecoTauLexicographicalRanking<RankerList, reco::RecoTauPiZero> PiZeroPredicate;
 
-  builderList builders_;
-  rankerList rankers_;
+  std::vector<std::unique_ptr<Builder>> builders_;
+  RankerList rankers_;
   std::unique_ptr<PiZeroPredicate> predicate_;
   double piZeroMass_;
 
@@ -92,7 +89,7 @@ RecoTauPiZeroProducer::RecoTauPiZeroProducer(const edm::ParameterSet& pset) {
     // Get plugin name
     const std::string& pluginType = builderPSet->getParameter<std::string>("plugin");
     // Build the plugin
-    builders_.push_back(
+    builders_.emplace_back(
         RecoTauPiZeroBuilderPluginFactory::get()->create(pluginType, *builderPSet, consumesCollector()));
   }
 
@@ -100,7 +97,7 @@ RecoTauPiZeroProducer::RecoTauPiZeroProducer(const edm::ParameterSet& pset) {
   const VPSet& rankers = pset.getParameter<VPSet>("ranking");
   for (VPSet::const_iterator rankerPSet = rankers.begin(); rankerPSet != rankers.end(); ++rankerPSet) {
     const std::string& pluginType = rankerPSet->getParameter<std::string>("plugin");
-    rankers_.push_back(RecoTauPiZeroQualityPluginFactory::get()->create(pluginType, *rankerPSet));
+    rankers_.emplace_back(RecoTauPiZeroQualityPluginFactory::get()->create(pluginType, *rankerPSet));
   }
 
   // Build the sorting predicate
@@ -124,13 +121,11 @@ void RecoTauPiZeroProducer::produce(edm::Event& evt, const edm::EventSetup& es) 
 
   // Give each of our plugins a chance at doing something with the edm::Event
   for (auto& builder : builders_) {
-    builder.setup(evt, es);
+    builder->setup(evt, es);
   }
 
   // Make our association
-  std::unique_ptr<reco::JetPiZeroAssociation> association;
-
-  association = std::make_unique<reco::JetPiZeroAssociation>(reco::JetRefBaseProd(jetView));
+  auto association = std::make_unique<reco::JetPiZeroAssociation>(reco::JetRefBaseProd(jetView));
 
   // Loop over our jets
   size_t nJets = jetView->size();
@@ -147,23 +142,24 @@ void RecoTauPiZeroProducer::produce(edm::Event& evt, const edm::EventSetup& es) 
     // Compute the pi zeros from this jet for all the desired algorithms
     for (auto const& builder : builders_) {
       try {
-        PiZeroVector result(builder(*jet));
-        dirtyPiZeros.transfer(dirtyPiZeros.end(), result);
+        PiZeroVector result((*builder)(*jet));
+        std::move(result.begin(), result.end(), std::back_inserter(dirtyPiZeros));
       } catch (cms::Exception& exception) {
         edm::LogError("BuilderPluginException")
-            << "Exception caught in builder plugin " << builder.name() << ", rethrowing" << std::endl;
+            << "Exception caught in builder plugin " << builder->name() << ", rethrowing" << std::endl;
         throw exception;
       }
     }
     // Rank the candidates according to our quality plugins
-    dirtyPiZeros.sort(*predicate_);
+    dirtyPiZeros.sort([this](const auto& a, const auto& b) { return (*predicate_)(*a, *b); });
 
     // Keep track of the photons in the clean collection
     std::vector<reco::RecoTauPiZero> cleanPiZeros;
     std::set<reco::CandidatePtr> photonsInCleanCollection;
     while (!dirtyPiZeros.empty()) {
       // Pull our candidate pi zero from the front of the list
-      std::unique_ptr<reco::RecoTauPiZero> toAdd(dirtyPiZeros.pop_front().release());
+      std::unique_ptr<reco::RecoTauPiZero> toAdd(dirtyPiZeros.front().release());
+      dirtyPiZeros.pop_front();
       // If this doesn't pass our basic selection, discard it.
       if (!(*outputSelector_)(*toAdd)) {
         continue;
@@ -196,8 +192,10 @@ void RecoTauPiZeroProducer::produce(edm::Event& evt, const edm::EventSetup& es) 
         AddFourMomenta p4Builder_;
         p4Builder_.set(*toAdd);
         // Put this pi zero back into the collection of sorted dirty pizeros
-        PiZeroList::iterator insertionPoint =
-            std::lower_bound(dirtyPiZeros.begin(), dirtyPiZeros.end(), *toAdd, *predicate_);
+        auto insertionPoint =
+            std::lower_bound(dirtyPiZeros.begin(), dirtyPiZeros.end(), *toAdd, [this](const auto& a, const auto& b) {
+              return (*predicate_)(*a, b);
+            });
         dirtyPiZeros.insert(insertionPoint, std::move(toAdd));
       }
     }
@@ -222,7 +220,7 @@ void RecoTauPiZeroProducer::print(const std::vector<reco::RecoTauPiZero>& piZero
   for (auto const& piZero : piZeros) {
     out << piZero;
     out << "* Rankers:" << std::endl;
-    for (rankerList::const_iterator ranker = rankers_.begin(); ranker != rankers_.end(); ++ranker) {
+    for (auto const& ranker : rankers_) {
       out << "* " << std::setiosflags(std::ios::left) << std::setw(width) << ranker->name() << " "
           << std::resetiosflags(std::ios::left) << std::setprecision(3) << (*ranker)(piZero);
       out << std::endl;

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin.cc
@@ -94,9 +94,7 @@ namespace reco {
       //PFCandPtrs candsVector = qcuts_->filterCandRefs(pfGammas(jet));
 
       // Convert to stl::list to allow fast deletions
-      typedef std::list<reco::CandidatePtr> CandPtrList;
-      typedef std::list<reco::CandidatePtr>::iterator CandPtrListIter;
-      CandPtrList cands;
+      std::list<reco::CandidatePtr> cands;
       cands.insert(cands.end(), candsVector.begin(), candsVector.end());
 
       while (!cands.empty()) {
@@ -105,11 +103,11 @@ namespace reco {
         cands.pop_front();
 
         // Add a new candidate to our collection using this seed
-        std::unique_ptr<RecoTauPiZero> strip(new RecoTauPiZero(*seed, RecoTauPiZero::kStrips));
+        auto strip = std::make_unique<RecoTauPiZero>(*seed, RecoTauPiZero::kStrips);
         strip->addDaughter(seed);
 
         // Find all other objects in the strip
-        CandPtrListIter stripCand = cands.begin();
+        auto stripCand = cands.begin();
         while (stripCand != cands.end()) {
           if (fabs(strip->eta() - (*stripCand)->eta()) < etaAssociationDistance_ &&
               fabs(deltaPhi(*strip, **stripCand)) < phiAssociationDistance_) {
@@ -128,20 +126,22 @@ namespace reco {
         // Update the vertex
         if (strip->daughterPtr(0).isNonnull())
           strip->setVertex(strip->daughterPtr(0)->vertex());
-        output.push_back(strip.get());
+        output.emplace_back(strip.release());
       }
 
       // Check if we want to combine our strips
       if (combineStrips_ && output.size() > 1) {
         PiZeroVector stripCombinations;
         // Sort the output by descending pt
-        output.sort(output.begin(), output.end(), [&](auto& arg1, auto& arg2) { return arg1.pt() > arg2.pt(); });
+        std::sort(output.begin(), output.end(), [&](auto& arg1, auto& arg2) { return arg1->pt() > arg2->pt(); });
         // Get the end of interesting set of strips to try and combine
         PiZeroVector::const_iterator end_iter = takeNElements(output.begin(), output.end(), maxStrips_);
 
         // Look at all the combinations
-        for (PiZeroVector::const_iterator first = output.begin(); first != end_iter - 1; ++first) {
-          for (PiZeroVector::const_iterator second = first + 1; second != end_iter; ++second) {
+        for (PiZeroVector::const_iterator firstIter = output.begin(); firstIter != end_iter - 1; ++firstIter) {
+          for (PiZeroVector::const_iterator secondIter = firstIter + 1; secondIter != end_iter; ++secondIter) {
+            auto const& first = *firstIter;
+            auto const& second = *secondIter;
             Candidate::LorentzVector firstP4 = first->p4();
             Candidate::LorentzVector secondP4 = second->p4();
             // If we assume a certain mass for each strip apply it here.
@@ -149,15 +149,15 @@ namespace reco {
             secondP4 = applyMassConstraint(secondP4, combinatoricStripMassHypo_);
             Candidate::LorentzVector totalP4 = firstP4 + secondP4;
             // Make our new combined strip
-            std::unique_ptr<RecoTauPiZero> combinedStrips(
-                new RecoTauPiZero(0,
-                                  totalP4,
-                                  Candidate::Point(0, 0, 0),
-                                  //111, 10001, true, RecoTauPiZero::kCombinatoricStrips));
-                                  111,
-                                  10001,
-                                  true,
-                                  RecoTauPiZero::kUndefined));
+            auto combinedStrips =
+                std::make_unique<RecoTauPiZero>(0,
+                                                totalP4,
+                                                Candidate::Point(0, 0, 0),
+                                                //111, 10001, true, RecoTauPiZero::kCombinatoricStrips));
+                                                111,
+                                                10001,
+                                                true,
+                                                RecoTauPiZero::kUndefined);
 
             // Now loop over the strip members
             for (auto const& gamma : first->daughterPtrVector()) {
@@ -170,15 +170,14 @@ namespace reco {
             if (combinedStrips->daughterPtr(0).isNonnull())
               combinedStrips->setVertex(combinedStrips->daughterPtr(0)->vertex());
             // Add to our collection of combined strips
-            stripCombinations.push_back(combinedStrips.get());
+            stripCombinations.emplace_back(combinedStrips.release());
           }
         }
-        // When done doing all the combinations, add the combined strips to the
-        // output.
-        output.transfer(output.end(), stripCombinations);
+        // When done doing all the combinations, add the combined strips to the output.
+        std::move(stripCombinations.begin(), stripCombinations.end(), std::back_inserter(output));
       }
 
-      return output.release();
+      return output;
     }
   }  // namespace tau
 }  // namespace reco

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin2.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin2.cc
@@ -303,13 +303,15 @@ namespace reco {
       if (combineStrips_ && output.size() > 1) {
         PiZeroVector stripCombinations;
         // Sort the output by descending pt
-        output.sort(output.begin(), output.end(), [&](auto& arg1, auto& arg2) { return arg1.pt() > arg2.pt(); });
+        std::sort(output.begin(), output.end(), [&](auto& arg1, auto& arg2) { return arg1->pt() > arg2->pt(); });
         // Get the end of interesting set of strips to try and combine
         PiZeroVector::const_iterator end_iter = takeNElements(output.begin(), output.end(), maxStrips_);
 
         // Look at all the combinations
-        for (PiZeroVector::const_iterator first = output.begin(); first != end_iter - 1; ++first) {
-          for (PiZeroVector::const_iterator second = first + 1; second != end_iter; ++second) {
+        for (PiZeroVector::const_iterator firstIter = output.begin(); firstIter != end_iter - 1; ++firstIter) {
+          for (PiZeroVector::const_iterator secondIter = firstIter + 1; secondIter != end_iter; ++secondIter) {
+            auto const& first = *firstIter;
+            auto const& second = *secondIter;
             Candidate::LorentzVector firstP4 = first->p4();
             Candidate::LorentzVector secondP4 = second->p4();
             // If we assume a certain mass for each strip apply it here.
@@ -317,15 +319,15 @@ namespace reco {
             secondP4 = applyMassConstraint(secondP4, combinatoricStripMassHypo_);
             Candidate::LorentzVector totalP4 = firstP4 + secondP4;
             // Make our new combined strip
-            std::unique_ptr<RecoTauPiZero> combinedStrips(
-                new RecoTauPiZero(0,
-                                  totalP4,
-                                  Candidate::Point(0, 0, 0),
-                                  //111, 10001, true, RecoTauPiZero::kCombinatoricStrips));
-                                  111,
-                                  10001,
-                                  true,
-                                  RecoTauPiZero::kUndefined));
+            auto combinedStrips =
+                std::make_unique<RecoTauPiZero>(0,
+                                                totalP4,
+                                                Candidate::Point(0, 0, 0),
+                                                //111, 10001, true, RecoTauPiZero::kCombinatoricStrips));
+                                                111,
+                                                10001,
+                                                true,
+                                                RecoTauPiZero::kUndefined);
 
             // Now loop over the strip members
             for (auto const& gamma : first->daughterPtrVector()) {
@@ -343,10 +345,10 @@ namespace reco {
         }
         // When done doing all the combinations, add the combined strips to the
         // output.
-        output.transfer(output.end(), stripCombinations);
+        std::move(stripCombinations.begin(), stripCombinations.end(), std::back_inserter(output));
       }
 
-      return output.release();
+      return output;
     }
   }  // namespace tau
 }  // namespace reco

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroTrivialPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroTrivialPlugin.cc
@@ -46,7 +46,7 @@ namespace reco::tau {
       piZero->addDaughter(gamma);
       output.push_back(std::move(piZero));
     }
-    return output.release();
+    return output;
   }
 
 }  // namespace reco::tau

--- a/RecoTauTag/RecoTau/plugins/RecoTauProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauProducer.cc
@@ -192,22 +192,24 @@ void RecoTauProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
     // Loop over our builders and create the set of taus for this jet
     unsigned int nTausBuilt = 0;
     for (const auto& builder : builders_) {
-      // Get a ptr_vector of taus from the builder
+      // Get a std::vector of std::unique_ptr to taus from the builder
       reco::tau::RecoTauBuilderPlugin::output_type taus(
           (*builder)(jetRef, chargedHadrons, piZeros, uniqueRegionalCands));
 
       // Make sure all taus have their jetref set correctly
-      std::for_each(taus.begin(), taus.end(), [&](auto& arg) { arg.setjetRef(reco::JetBaseRef(jetRef)); });
+      std::for_each(taus.begin(), taus.end(), [&](auto& arg) { arg->setjetRef(reco::JetBaseRef(jetRef)); });
       // Copy without selection
       if (!outputSelector_.get()) {
-        output->insert(output->end(), taus.begin(), taus.end());
+        for (auto& tau : taus) {
+          output->push_back(*tau);
+        }
         nTausBuilt += taus.size();
       } else {
         // Copy only those that pass the selection.
         for (auto const& tau : taus) {
-          if ((*outputSelector_)(tau)) {
+          if ((*outputSelector_)(*tau)) {
             nTausBuilt++;
-            output->push_back(tau);
+            output->push_back(*tau);
           }
         }
       }
@@ -223,9 +225,9 @@ void RecoTauProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
   }
 
   // Loop over the taus we have created and apply our modifiers to the taus
-  for (reco::PFTauCollection::iterator tau = output->begin(); tau != output->end(); ++tau) {
+  for (auto& tau : *output) {
     for (const auto& modifier : modifiers_) {
-      (*modifier)(*tau);
+      (*modifier)(tau);
     }
   }
 


### PR DESCRIPTION
#### PR description:

The `boost::ptr_vector<T>` can be replaced by a `std::vector<std::unique_ptr<T>>` in modern C++. In the same way, the `boost::ptr_list<T>` can be replaced by a `std::list<std::unique_ptr<T>>`.

The only place in CMSSW where `ptr_vector` and `ptr_list` were still used was the `RecoTauTag/RecoTau` package, so this PR replaces all occurrences of these boost pointer collections in CMSSW. Note that `transfer` method from the boost pointer collections can be replaced with the [`std::move` overload for collection](https://en.cppreference.com/w/cpp/algorithm/move), which was done in this PR.

#### PR validation:

CMSSW compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport intended.
