### PR TITLE
Migrate to the new ref. based writeOneIOV() in Alignment package

### DIFF
--- a/Alignment/CommonAlignmentAlgorithm/plugins/SiPixelLorentzAngleCalibration.cc
+++ b/Alignment/CommonAlignmentAlgorithm/plugins/SiPixelLorentzAngleCalibration.cc
@@ -337,7 +337,7 @@ void SiPixelLorentzAngleCalibration::endOfJob() {
     if (saveToDB_) {  // If requested, write out to DB
       edm::Service<cond::service::PoolDBOutputService> dbService;
       if (dbService.isAvailable()) {
-        dbService->writeOne(&output, firstRunOfIOV, recordNameDBwrite_);
+        dbService->writeOneIOV(output, firstRunOfIOV, recordNameDBwrite_);
       } else {
         edm::LogError("BadConfig") << "@SUB=SiPixelLorentzAngleCalibration::endOfJob"
                                    << "No PoolDBOutputService available, but saveToDB true!";

--- a/Alignment/CommonAlignmentAlgorithm/plugins/SiStripBackplaneCalibration.cc
+++ b/Alignment/CommonAlignmentAlgorithm/plugins/SiStripBackplaneCalibration.cc
@@ -377,7 +377,7 @@ void SiStripBackplaneCalibration::endOfJob() {
     if (saveToDB_) {  // If requested, write out to DB
       edm::Service<cond::service::PoolDBOutputService> dbService;
       if (dbService.isAvailable()) {
-        dbService->writeOne(output, firstRunOfIOV, recordNameDBwrite_);
+        dbService->writeOneIOV(*output, firstRunOfIOV, recordNameDBwrite_);
         // no 'delete output;': writeOne(..) took over ownership
       } else {
         delete output;

--- a/Alignment/CommonAlignmentAlgorithm/plugins/SiStripLorentzAngleCalibration.cc
+++ b/Alignment/CommonAlignmentAlgorithm/plugins/SiStripLorentzAngleCalibration.cc
@@ -377,7 +377,7 @@ void SiStripLorentzAngleCalibration::endOfJob() {
     if (saveToDB_) {  // If requested, write out to DB
       edm::Service<cond::service::PoolDBOutputService> dbService;
       if (dbService.isAvailable()) {
-        dbService->writeOne(&output, firstRunOfIOV, recordNameDBwrite_);
+        dbService->writeOneIOV(output, firstRunOfIOV, recordNameDBwrite_);
       } else {
         edm::LogError("BadConfig") << "@SUB=SiStripLorentzAngleCalibration::endOfJob"
                                    << "No PoolDBOutputService available, but saveToDB true!";

--- a/Alignment/CommonAlignmentProducer/plugins/GlobalTrackerMuonAlignment.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/GlobalTrackerMuonAlignment.cc
@@ -3435,7 +3435,7 @@ void GlobalTrackerMuonAlignment::writeGlPosRcd(CLHEP::HepVector& paramVec) {
   //    } else {
   //       poolDbService->appendSinceTime<Alignments>(&(*globalPositions), poolDbService->currentTime(), "GlobalPositionRcd");
   //    }
-  poolDbService->writeOne<Alignments>(&(*globalPositions),
+  poolDbService->writeOneIOV<Alignments>((*globalPositions),
                                       poolDbService->currentTime(),
                                       //poolDbService->beginOfTime(),
                                       "GlobalPositionRcd");

--- a/Alignment/CommonAlignmentProducer/plugins/GlobalTrackerMuonAlignment.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/GlobalTrackerMuonAlignment.cc
@@ -3436,9 +3436,9 @@ void GlobalTrackerMuonAlignment::writeGlPosRcd(CLHEP::HepVector& paramVec) {
   //       poolDbService->appendSinceTime<Alignments>(&(*globalPositions), poolDbService->currentTime(), "GlobalPositionRcd");
   //    }
   poolDbService->writeOneIOV<Alignments>((*globalPositions),
-                                      poolDbService->currentTime(),
-                                      //poolDbService->beginOfTime(),
-                                      "GlobalPositionRcd");
+                                         poolDbService->currentTime(),
+                                         //poolDbService->beginOfTime(),
+                                         "GlobalPositionRcd");
   std::cout << "done!" << std::endl;
 
   return;

--- a/Alignment/CommonAlignmentProducer/src/AlignmentProducerBase.cc
+++ b/Alignment/CommonAlignmentProducer/src/AlignmentProducerBase.cc
@@ -917,14 +917,14 @@ void AlignmentProducerBase::writeDB(Alignments* alignments,
 
   if (saveToDB_) {
     edm::LogInfo("Alignment") << "Writing Alignments for run " << time << " to " << alignRcd << ".";
-    poolDb->writeOne<Alignments>(tempAlignments, time, alignRcd);
+    poolDb->writeOneIOV<Alignments>(*tempAlignments, time, alignRcd);
   } else {                  // poolDb->writeOne(..) takes over 'alignments' ownership,...
     delete tempAlignments;  // ...otherwise we have to delete, as promised!
   }
 
   if (saveApeToDB_) {
     edm::LogInfo("Alignment") << "Writing AlignmentErrorsExtended for run " << time << " to " << errRcd << ".";
-    poolDb->writeOne<AlignmentErrorsExtended>(tempAlignmentErrorsExtended, time, errRcd);
+    poolDb->writeOneIOV<AlignmentErrorsExtended>(*tempAlignmentErrorsExtended, time, errRcd);
   } else {                               // poolDb->writeOne(..) takes over 'alignmentErrors' ownership,...
     delete tempAlignmentErrorsExtended;  // ...otherwise we have to delete, as promised!
   }
@@ -944,7 +944,7 @@ void AlignmentProducerBase::writeDB(AlignmentSurfaceDeformations* alignmentSurfa
   if (saveDeformationsToDB_) {
     edm::LogInfo("Alignment") << "Writing AlignmentSurfaceDeformations for run " << time << " to "
                               << surfaceDeformationRcd << ".";
-    poolDb->writeOne<AlignmentSurfaceDeformations>(alignmentSurfaceDeformations, time, surfaceDeformationRcd);
+    poolDb->writeOneIOV<AlignmentSurfaceDeformations>(*alignmentSurfaceDeformations, time, surfaceDeformationRcd);
   } else {                                // poolDb->writeOne(..) takes over 'surfaceDeformation' ownership,...
     delete alignmentSurfaceDeformations;  // ...otherwise we have to delete, as promised!
   }

--- a/Alignment/LaserAlignment/plugins/LaserAlignment.cc
+++ b/Alignment/LaserAlignment/plugins/LaserAlignment.cc
@@ -914,7 +914,7 @@ void LaserAlignment::endRunProduce(edm::Run& theRun, const edm::EventSetup& theS
     //     else {
     //       poolDbService->appendSinceTime<Alignments>( alignments, poolDbService->currentTime(), theAlignRecordName );
     //     }
-    poolDbService->writeOne<Alignments>(alignments, poolDbService->beginOfTime(), theAlignRecordName);
+    poolDbService->writeOneIOV<Alignments>(*alignments, poolDbService->beginOfTime(), theAlignRecordName);
 
     //     if ( poolDbService->isNewTagRequest(theErrorRecordName) ) {
     //       poolDbService->createNewIOV<AlignmentErrorsExtended>( alignmentErrors, poolDbService->currentTime(), poolDbService->endOfTime(), theErrorRecordName );
@@ -922,7 +922,7 @@ void LaserAlignment::endRunProduce(edm::Run& theRun, const edm::EventSetup& theS
     //     else {
     //       poolDbService->appendSinceTime<AlignmentErrorsExtended>( alignmentErrors, poolDbService->currentTime(), theErrorRecordName );
     //     }
-    poolDbService->writeOne<AlignmentErrorsExtended>(alignmentErrors, poolDbService->beginOfTime(), theErrorRecordName);
+    poolDbService->writeOneIOV<AlignmentErrorsExtended>(*alignmentErrors, poolDbService->beginOfTime(), theErrorRecordName);
 
     std::cout << " [LaserAlignment::endRun] -- Storing done." << std::endl;
   }

--- a/Alignment/LaserAlignment/plugins/LaserAlignment.cc
+++ b/Alignment/LaserAlignment/plugins/LaserAlignment.cc
@@ -922,7 +922,8 @@ void LaserAlignment::endRunProduce(edm::Run& theRun, const edm::EventSetup& theS
     //     else {
     //       poolDbService->appendSinceTime<AlignmentErrorsExtended>( alignmentErrors, poolDbService->currentTime(), theErrorRecordName );
     //     }
-    poolDbService->writeOneIOV<AlignmentErrorsExtended>(*alignmentErrors, poolDbService->beginOfTime(), theErrorRecordName);
+    poolDbService->writeOneIOV<AlignmentErrorsExtended>(
+        *alignmentErrors, poolDbService->beginOfTime(), theErrorRecordName);
 
     std::cout << " [LaserAlignment::endRun] -- Storing done." << std::endl;
   }

--- a/Alignment/MuonAlignment/plugins/MuonMisalignedProducer.cc
+++ b/Alignment/MuonAlignment/plugins/MuonMisalignedProducer.cc
@@ -132,17 +132,17 @@ void MuonMisalignedProducer::saveToDB(void) {
     throw cms::Exception("NotAvailable") << "PoolDBOutputService not available";
 
   // Store DT alignments and errors
-  poolDbService->writeOne<Alignments>(&(*dt_Alignments), poolDbService->beginOfTime(), theDTAlignRecordName);
-  poolDbService->writeOne<AlignmentErrorsExtended>(
-      &(*dt_AlignmentErrorsExtended), poolDbService->beginOfTime(), theDTErrorRecordName);
+  poolDbService->writeOneIOV<Alignments>((*dt_Alignments), poolDbService->beginOfTime(), theDTAlignRecordName);
+  poolDbService->writeOneIOV<AlignmentErrorsExtended>(
+      (*dt_AlignmentErrorsExtended), poolDbService->beginOfTime(), theDTErrorRecordName);
 
   // Store CSC alignments and errors
-  poolDbService->writeOne<Alignments>(&(*csc_Alignments), poolDbService->beginOfTime(), theCSCAlignRecordName);
-  poolDbService->writeOne<AlignmentErrorsExtended>(
-      &(*csc_AlignmentErrorsExtended), poolDbService->beginOfTime(), theCSCErrorRecordName);
-  poolDbService->writeOne<Alignments>(&(*gem_Alignments), poolDbService->beginOfTime(), theGEMAlignRecordName);
-  poolDbService->writeOne<AlignmentErrorsExtended>(
-      &(*gem_AlignmentErrorsExtended), poolDbService->beginOfTime(), theGEMErrorRecordName);
+  poolDbService->writeOneIOV<Alignments>((*csc_Alignments), poolDbService->beginOfTime(), theCSCAlignRecordName);
+  poolDbService->writeOneIOV<AlignmentErrorsExtended>(
+      (*csc_AlignmentErrorsExtended), poolDbService->beginOfTime(), theCSCErrorRecordName);
+  poolDbService->writeOneIOV<Alignments>((*gem_Alignments), poolDbService->beginOfTime(), theGEMAlignRecordName);
+  poolDbService->writeOneIOV<AlignmentErrorsExtended>(
+      (*gem_AlignmentErrorsExtended), poolDbService->beginOfTime(), theGEMErrorRecordName);
 }
 //____________________________________________________________________________________________
 DEFINE_FWK_MODULE(MuonMisalignedProducer);

--- a/Alignment/MuonAlignment/src/MuonAlignment.cc
+++ b/Alignment/MuonAlignment/src/MuonAlignment.cc
@@ -271,8 +271,8 @@ void MuonAlignment::saveDTSurveyToDB(void) {
   }
 
   // Store DT alignments and errors
-  poolDbService->writeOne<Alignments>(&(*dtAlignments), poolDbService->currentTime(), theDTSurveyRecordName);
-  poolDbService->writeOne<SurveyErrors>(&(*dtSurveyErrors), poolDbService->currentTime(), theDTSurveyErrorRecordName);
+  poolDbService->writeOneIOV<Alignments>((*dtAlignments), poolDbService->currentTime(), theDTSurveyRecordName);
+  poolDbService->writeOneIOV<SurveyErrors>((*dtSurveyErrors), poolDbService->currentTime(), theDTSurveyErrorRecordName);
 }
 
 void MuonAlignment::saveCSCSurveyToDB(void) {
@@ -304,8 +304,8 @@ void MuonAlignment::saveCSCSurveyToDB(void) {
   }
 
   // Store CSC alignments and errors
-  poolDbService->writeOne<Alignments>(&(*cscAlignments), poolDbService->currentTime(), theCSCSurveyRecordName);
-  poolDbService->writeOne<SurveyErrors>(&(*cscSurveyErrors), poolDbService->currentTime(), theCSCSurveyErrorRecordName);
+  poolDbService->writeOneIOV<Alignments>((*cscAlignments), poolDbService->currentTime(), theCSCSurveyRecordName);
+  poolDbService->writeOneIOV<SurveyErrors>((*cscSurveyErrors), poolDbService->currentTime(), theCSCSurveyErrorRecordName);
 }
 
 void MuonAlignment::saveSurveyToDB(void) {
@@ -324,9 +324,9 @@ void MuonAlignment::saveDTtoDB(void) {
   AlignmentErrorsExtended* dt_AlignmentErrorsExtended = theAlignableMuon->dtAlignmentErrorsExtended();
 
   // Store DT alignments and errors
-  poolDbService->writeOne<Alignments>(&(*dt_Alignments), poolDbService->currentTime(), theDTAlignRecordName);
-  poolDbService->writeOne<AlignmentErrorsExtended>(
-      &(*dt_AlignmentErrorsExtended), poolDbService->currentTime(), theDTErrorRecordName);
+  poolDbService->writeOneIOV<Alignments>((*dt_Alignments), poolDbService->currentTime(), theDTAlignRecordName);
+  poolDbService->writeOneIOV<AlignmentErrorsExtended>(
+      (*dt_AlignmentErrorsExtended), poolDbService->currentTime(), theDTErrorRecordName);
 }
 
 void MuonAlignment::saveCSCtoDB(void) {
@@ -340,9 +340,9 @@ void MuonAlignment::saveCSCtoDB(void) {
   AlignmentErrorsExtended* csc_AlignmentErrorsExtended = theAlignableMuon->cscAlignmentErrorsExtended();
 
   // Store CSC alignments and errors
-  poolDbService->writeOne<Alignments>(&(*csc_Alignments), poolDbService->currentTime(), theCSCAlignRecordName);
-  poolDbService->writeOne<AlignmentErrorsExtended>(
-      &(*csc_AlignmentErrorsExtended), poolDbService->currentTime(), theCSCErrorRecordName);
+  poolDbService->writeOneIOV<Alignments>((*csc_Alignments), poolDbService->currentTime(), theCSCAlignRecordName);
+  poolDbService->writeOneIOV<AlignmentErrorsExtended>(
+      (*csc_AlignmentErrorsExtended), poolDbService->currentTime(), theCSCErrorRecordName);
 }
 
 void MuonAlignment::saveGEMtoDB(void) {
@@ -356,9 +356,9 @@ void MuonAlignment::saveGEMtoDB(void) {
   AlignmentErrorsExtended* gem_AlignmentErrorsExtended = theAlignableMuon->gemAlignmentErrorsExtended();
 
   // Store CSC alignments and errors
-  poolDbService->writeOne<Alignments>(&(*gem_Alignments), poolDbService->currentTime(), theGEMAlignRecordName);
-  poolDbService->writeOne<AlignmentErrorsExtended>(
-      &(*gem_AlignmentErrorsExtended), poolDbService->currentTime(), theGEMErrorRecordName);
+  poolDbService->writeOneIOV<Alignments>((*gem_Alignments), poolDbService->currentTime(), theGEMAlignRecordName);
+  poolDbService->writeOneIOV<AlignmentErrorsExtended>(
+      (*gem_AlignmentErrorsExtended), poolDbService->currentTime(), theGEMErrorRecordName);
 }
 
 void MuonAlignment::saveToDB(void) {

--- a/Alignment/MuonAlignment/src/MuonAlignment.cc
+++ b/Alignment/MuonAlignment/src/MuonAlignment.cc
@@ -305,7 +305,8 @@ void MuonAlignment::saveCSCSurveyToDB(void) {
 
   // Store CSC alignments and errors
   poolDbService->writeOneIOV<Alignments>((*cscAlignments), poolDbService->currentTime(), theCSCSurveyRecordName);
-  poolDbService->writeOneIOV<SurveyErrors>((*cscSurveyErrors), poolDbService->currentTime(), theCSCSurveyErrorRecordName);
+  poolDbService->writeOneIOV<SurveyErrors>(
+      (*cscSurveyErrors), poolDbService->currentTime(), theCSCSurveyErrorRecordName);
 }
 
 void MuonAlignment::saveSurveyToDB(void) {

--- a/Alignment/OfflineValidation/plugins/TrackerGeometryCompare.cc
+++ b/Alignment/OfflineValidation/plugins/TrackerGeometryCompare.cc
@@ -261,9 +261,9 @@ void TrackerGeometryCompare::analyze(const edm::Event&, const edm::EventSetup& i
       if (!poolDbService.isAvailable())  // Die if not available
         throw cms::Exception("NotAvailable") << "PoolDBOutputService not available";
 
-      poolDbService->writeOne<Alignments>(&(*myAlignments), poolDbService->beginOfTime(), "TrackerAlignmentRcd");
-      poolDbService->writeOne<AlignmentErrorsExtended>(
-          &(*myAlignmentErrorsExtended), poolDbService->beginOfTime(), "TrackerAlignmentErrorExtendedRcd");
+      poolDbService->writeOneIOV<Alignments>((*myAlignments), poolDbService->beginOfTime(), "TrackerAlignmentRcd");
+      poolDbService->writeOneIOV<AlignmentErrorsExtended>(
+          (*myAlignmentErrorsExtended), poolDbService->beginOfTime(), "TrackerAlignmentErrorExtendedRcd");
     }
 
     firstEvent_ = false;

--- a/Alignment/SurveyAnalysis/plugins/SurveyDBUploader.cc
+++ b/Alignment/SurveyAnalysis/plugins/SurveyDBUploader.cc
@@ -27,8 +27,8 @@ void SurveyDBUploader::endJob() {
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
 
   if (poolDbService.isAvailable()) {
-    poolDbService->writeOne<SurveyValues>(theValues, poolDbService->currentTime(), theValueRcd);
-    poolDbService->writeOne<SurveyErrors>(theErrors, poolDbService->currentTime(), theErrorExtendedRcd);
+    poolDbService->writeOneIOV<SurveyValues>(*theValues, poolDbService->currentTime(), theValueRcd);
+    poolDbService->writeOneIOV<SurveyErrors>(*theErrors, poolDbService->currentTime(), theErrorExtendedRcd);
   } else
     throw cms::Exception("ConfigError") << "PoolDBOutputService is not available";
 }

--- a/Alignment/SurveyAnalysis/plugins/SurveyInputTrackerFromDB.cc
+++ b/Alignment/SurveyAnalysis/plugins/SurveyInputTrackerFromDB.cc
@@ -58,9 +58,9 @@ void SurveyInputTrackerFromDB::analyze(const edm::Event&, const edm::EventSetup&
     if (!poolDbService.isAvailable())  // Die if not available
       throw cms::Exception("NotAvailable") << "PoolDBOutputService not available";
 
-    poolDbService->writeOne<Alignments>(myAlignments, poolDbService->beginOfTime(), "TrackerAlignmentRcd");
-    poolDbService->writeOne<AlignmentErrorsExtended>(
-        myAlignmentErrorsExtended, poolDbService->beginOfTime(), "TrackerAlignmentErrorExtendedRcd");
+    poolDbService->writeOneIOV<Alignments>(*myAlignments, poolDbService->beginOfTime(), "TrackerAlignmentRcd");
+    poolDbService->writeOneIOV<AlignmentErrorsExtended>(
+        *myAlignmentErrorsExtended, poolDbService->beginOfTime(), "TrackerAlignmentErrorExtendedRcd");
 
     theFirstEvent = false;
   }

--- a/Alignment/TrackerAlignment/plugins/MisalignedTrackerESProducer.cc
+++ b/Alignment/TrackerAlignment/plugins/MisalignedTrackerESProducer.cc
@@ -120,8 +120,8 @@ std::unique_ptr<TrackerGeometry> MisalignedTrackerESProducer::produce(const Trac
       alignments->clear();
       alignmentErrors->clear();
     }
-    poolDbService->writeOne<Alignments>(alignments, poolDbService->currentTime(), theAlignRecordName);
-    poolDbService->writeOne<AlignmentErrorsExtended>(alignmentErrors, poolDbService->currentTime(), theErrorRecordName);
+    poolDbService->writeOneIOV<Alignments>(*alignments, poolDbService->currentTime(), theAlignRecordName);
+    poolDbService->writeOneIOV<AlignmentErrorsExtended>(*alignmentErrors, poolDbService->currentTime(), theErrorRecordName);
   } else {
     // poolDbService::writeOne takes over ownership
     // we have to delete in the case that containers are not written

--- a/Alignment/TrackerAlignment/plugins/MisalignedTrackerESProducer.cc
+++ b/Alignment/TrackerAlignment/plugins/MisalignedTrackerESProducer.cc
@@ -121,7 +121,8 @@ std::unique_ptr<TrackerGeometry> MisalignedTrackerESProducer::produce(const Trac
       alignmentErrors->clear();
     }
     poolDbService->writeOneIOV<Alignments>(*alignments, poolDbService->currentTime(), theAlignRecordName);
-    poolDbService->writeOneIOV<AlignmentErrorsExtended>(*alignmentErrors, poolDbService->currentTime(), theErrorRecordName);
+    poolDbService->writeOneIOV<AlignmentErrorsExtended>(
+        *alignmentErrors, poolDbService->currentTime(), theErrorRecordName);
   } else {
     // poolDbService::writeOne takes over ownership
     // we have to delete in the case that containers are not written

--- a/Alignment/TrackerAlignment/plugins/TrackerSystematicMisalignments.cc
+++ b/Alignment/TrackerAlignment/plugins/TrackerSystematicMisalignments.cc
@@ -210,9 +210,9 @@ void TrackerSystematicMisalignments::analyze(const edm::Event& event, const edm:
   if (!poolDbService.isAvailable())  // Die if not available
     throw cms::Exception("NotAvailable") << "PoolDBOutputService not available";
 
-  poolDbService->writeOne<Alignments>(&(*myAlignments), poolDbService->beginOfTime(), theAlignRecordName);
-  poolDbService->writeOne<AlignmentErrorsExtended>(
-      &(*myAlignmentErrorsExtended), poolDbService->beginOfTime(), theErrorRecordName);
+  poolDbService->writeOneIOV<Alignments>((*myAlignments), poolDbService->beginOfTime(), theAlignRecordName);
+  poolDbService->writeOneIOV<AlignmentErrorsExtended>(
+      (*myAlignmentErrorsExtended), poolDbService->beginOfTime(), theErrorRecordName);
 }
 
 void TrackerSystematicMisalignments::applySystematicMisalignment(Alignable* ali) {

--- a/Alignment/TrackerAlignment/src/TrackerAlignment.cc
+++ b/Alignment/TrackerAlignment/src/TrackerAlignment.cc
@@ -256,5 +256,6 @@ void TrackerAlignment::saveToDB(void) {
   //     poolDbService->appendSinceTime<AlignmentErrorsExtended>( alignmentErrors,
   //                                                      poolDbService->currentTime(),
   //                                                      theErrorRecordName );
-  poolDbService->writeOneIOV<AlignmentErrorsExtended>(*alignmentErrors, poolDbService->currentTime(), theErrorRecordName);
+  poolDbService->writeOneIOV<AlignmentErrorsExtended>(
+      *alignmentErrors, poolDbService->currentTime(), theErrorRecordName);
 }

--- a/Alignment/TrackerAlignment/src/TrackerAlignment.cc
+++ b/Alignment/TrackerAlignment/src/TrackerAlignment.cc
@@ -247,7 +247,7 @@ void TrackerAlignment::saveToDB(void) {
   //   else
   //     poolDbService->appendSinceTime<Alignments>( alignments, poolDbService->currentTime(),
   //                                                 theAlignRecordName );
-  poolDbService->writeOne<Alignments>(alignments, poolDbService->currentTime(), theAlignRecordName);
+  poolDbService->writeOneIOV<Alignments>(*alignments, poolDbService->currentTime(), theAlignRecordName);
   //   if ( poolDbService->isNewTagRequest(theErrorRecordName) )
   //     poolDbService->createNewIOV<AlignmentErrorsExtended>( alignmentErrors,
   //                                                   poolDbService->endOfTime(),
@@ -256,5 +256,5 @@ void TrackerAlignment::saveToDB(void) {
   //     poolDbService->appendSinceTime<AlignmentErrorsExtended>( alignmentErrors,
   //                                                      poolDbService->currentTime(),
   //                                                      theErrorRecordName );
-  poolDbService->writeOne<AlignmentErrorsExtended>(alignmentErrors, poolDbService->currentTime(), theErrorRecordName);
+  poolDbService->writeOneIOV<AlignmentErrorsExtended>(*alignmentErrors, poolDbService->currentTime(), theErrorRecordName);
 }


### PR DESCRIPTION
#### PR description:

The new reference based method of the DBOutputService, writeOneIOV(), is introduced to keep the ownership of DB payload at the client side. The client will need to take care of the object memory. This PR migrates the old method, writeOne(), to writeOneIOV() in the following code:

 - Alignment/CommonAlignmentAlgorithm/plugins/SiPixelLorentzAngleCalibration.cc
 - Alignment/CommonAlignmentAlgorithm/plugins/SiStripBackplaneCalibration.cc
 - Alignment/CommonAlignmentAlgorithm/plugins/SiStripLorentzAngleCalibration.cc
 - Alignment/CommonAlignmentProducer/plugins/GlobalTrackerMuonAlignment.cc
 - Alignment/CommonAlignmentProducer/src/AlignmentProducerBase.cc
 - Alignment/LaserAlignment/plugins/LaserAlignment.cc
 - Alignment/MuonAlignment/plugins/MuonMisalignedProducer.cc
 - Alignment/MuonAlignment/src/MuonAlignment.cc
 - Alignment/OfflineValidation/plugins/TrackerGeometryCompare.cc
 - Alignment/SurveyAnalysis/plugins/SurveyDBUploader.cc
 - Alignment/SurveyAnalysis/plugins/SurveyInputTrackerFromDB.cc
 - Alignment/TrackerAlignment/plugins/MisalignedTrackerESProducer.cc
 - Alignment/TrackerAlignment/plugins/TrackerSystematicMisalignments.cc
 - Alignment/TrackerAlignment/src/TrackerAlignment.cc

** Please note that for payload objects created with 'new' function are not freed!

#### PR validation:

Code compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport and no backport is foreseen.