### PR TITLE
Fixes related to beamspot DIP server for pilot run [12.0.X]

### DIFF
--- a/DQM/BeamMonitor/plugins/BeamSpotDipServer.cc
+++ b/DQM/BeamMonitor/plugins/BeamSpotDipServer.cc
@@ -55,6 +55,10 @@ BeamSpotDipServer::BeamSpotDipServer(const edm::ParameterSet& ps) {
 
   //
   dip = Dip::create("CmsBeamSpotServer");
+
+  //
+  dip->setDNSNode("dipns1,dipns2");
+
   edm::LogInfo("BeamSpotDipServer") << "reading from " << (readFromNFS ? "file (NFS)" : "database");
 }
 

--- a/DQM/BeamMonitor/test/beamspotdip_dqm_sourceclient-file_cfg.py
+++ b/DQM/BeamMonitor/test/beamspotdip_dqm_sourceclient-file_cfg.py
@@ -1,6 +1,14 @@
 from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
+# copy log4cplus.properties from >script directory< to >local<
+import sys
+import os
+from shutil import copy
+configFile = os.path.dirname(sys.argv[1]) + "/log4cplus.properties"
+print("copying " + configFile + " to local")
+copy(configFile,".")
+
 #
 process = cms.Process("BeamSpotDipServer")
 process.load("DQMServices.Core.DQM_cfg")

--- a/DQM/Integration/python/clients/beamspotdip_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamspotdip_dqm_sourceclient-live_cfg.py
@@ -1,6 +1,14 @@
 from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
+# copy log4cplus.properties from >script directory< to >local<
+import sys
+import os
+from shutil import copy
+configFile = os.path.dirname(sys.argv[1]) + "/log4cplus.properties"
+print("copying " + configFile + " to local")
+copy(configFile,".")
+
 #
 process = cms.Process("BeamSpotDipServer")
 process.load("DQMServices.Core.DQM_cfg")

--- a/DQM/Integration/python/clients/beamspotdip_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamspotdip_dqm_sourceclient-live_cfg.py
@@ -38,5 +38,8 @@ process.load("DQM.BeamMonitor.BeamSpotDipServer_cff")
 from DQM.Integration.config.online_customizations_cfi import *
 process = customise(process)
 
+# monitoring
+process.DQMMonitoringService = cms.Service("DQMMonitoringService")
+
 # path
 process.p = cms.Path( process.beamSpotDipServer )

--- a/DQM/Integration/python/clients/log4cplus.properties
+++ b/DQM/Integration/python/clients/log4cplus.properties
@@ -1,0 +1,14 @@
+# Set root logger level to WARN and its only appender to A1.
+log4cplus.rootLogger=WARN, A1
+
+# A1 is set to be a ConsoleAppender.
+log4cplus.appender.A1=log4cplus::ConsoleAppender
+log4cplus.appender.A1.ImmediateFlush=true
+log4cplus.appender.A1.logToStdErr=false
+
+# A1 uses PatternLayout.
+log4cplus.appender.A1.layout=log4cplus::PatternLayout
+log4cplus.appender.A1.layout.ConversionPattern=%d{%m/%d/%y %H:%M:%S} [%t] %-5p %c{2} %%%x%% - %m%n
+
+#log4cplus.logger.dip.system=INFO
+#log4cplus.logger.dip.publication=WARN


### PR DESCRIPTION
#### PR description:

- fixing warning related to missing log4cplus.properties file
- solved by performing a local copy to the working directory