### PR TITLE
Change config files to include new metadata files needed for the new PCL devs

### DIFF
--- a/CondFormats/Common/test/CTPPSRPAlignmentCorrectionsDataRcd_prep.json
+++ b/CondFormats/Common/test/CTPPSRPAlignmentCorrectionsDataRcd_prep.json
@@ -1,0 +1,9 @@
+{
+    "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS", 
+    "destinationTags": {
+        "CTPPSRPAlignment_byPCL_v0_prompt": {}
+    }, 
+    "inputTag": "CTPPSRPAlignment_real_pcl", 
+    "since": null, 
+    "userText": "Tier0 PCL Upload for CTPPSRPAlignment"
+}

--- a/CondFormats/Common/test/CTPPSRPAlignmentCorrectionsDataRcd_prod.json
+++ b/CondFormats/Common/test/CTPPSRPAlignmentCorrectionsDataRcd_prod.json
@@ -1,0 +1,9 @@
+{
+    "destinationDatabase": "oracle://cms_orcon_prod/CMS_CONDITIONS", 
+    "destinationTags": {
+        "CTPPSRPAlignment_byPCL_v0_prompt": {}
+    }, 
+    "inputTag": "CTPPSRPAlignment_real_pcl", 
+    "since": null, 
+    "userText": "Tier0 PCL Upload for CTPPSRPAlignment"
+}

--- a/CondFormats/Common/test/PPSTimingCalibrationRcd_Sampic_prep.json
+++ b/CondFormats/Common/test/PPSTimingCalibrationRcd_Sampic_prep.json
@@ -1,0 +1,9 @@
+{
+    "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS", 
+    "destinationTags": {
+        "CTPPPSTimingCalibration_SAMPIC_byPCL_v0_prompt": {}
+    }, 
+    "inputTag": "DiamondSampicCalibration", 
+    "since": null, 
+    "userText": "Tier0 PCL Upload for PPSDiamondTimingCalibration (Sampic)"
+}

--- a/CondFormats/Common/test/PPSTimingCalibrationRcd_Sampic_prod.json
+++ b/CondFormats/Common/test/PPSTimingCalibrationRcd_Sampic_prod.json
@@ -1,0 +1,9 @@
+{
+    "destinationDatabase": "oracle://cms_orcon_prod/CMS_CONDITIONS", 
+    "destinationTags": {
+        "CTPPPSTimingCalibration_SAMPIC_byPCL_v0_prompt": {}
+    }, 
+    "inputTag": "DiamondSampicCalibration", 
+    "since": null, 
+    "userText": "Tier0 PCL Upload for PPSDiamondTimingCalibration (Sampic)"
+}

--- a/CondFormats/Common/test/PPSTimingCalibrationRcd_prep.json
+++ b/CondFormats/Common/test/PPSTimingCalibrationRcd_prep.json
@@ -1,0 +1,9 @@
+{
+    "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS", 
+    "destinationTags": {
+        "CTPPPSTimingCalibration_HPTDC_byPCL_v0_prompt": {}
+    }, 
+    "inputTag": "PPSDiamondTimingCalibration_pcl", 
+    "since": null, 
+    "userText": "Tier0 PCL Upload for PPSDiamondTimingCalibration (HPTDC)"
+}

--- a/CondFormats/Common/test/PPSTimingCalibrationRcd_prod.json
+++ b/CondFormats/Common/test/PPSTimingCalibrationRcd_prod.json
@@ -1,0 +1,9 @@
+{
+    "destinationDatabase": "oracle://cms_orcon_prod/CMS_CONDITIONS", 
+    "destinationTags": {
+        "CTPPPSTimingCalibration_HPTDC_byPCL_v0_prompt": {}
+    }, 
+    "inputTag": "PPSDiamondTimingCalibration_pcl", 
+    "since": null, 
+    "userText": "Tier0 PCL Upload for PPSDiamondTimingCalibration (HPTDC)"
+}

--- a/CondFormats/Common/test/ProduceDropBoxMetadata.py
+++ b/CondFormats/Common/test/ProduceDropBoxMetadata.py
@@ -70,13 +70,28 @@ EcalPedestalsRcd_prep_str = encodeJsonInString("EcalPedestal_prep.json")
 LumiCorrectionsRcd_prod_str = encodeJsonInString("LumiCorrections_prod.json")
 LumiCorrectionsRcd_prep_str = encodeJsonInString("LumiCorrections_prep.json")
 
-#PixelQuality
+#SiPixelQuality
 SiPixelQualityFromDbRcd_prompt_prod_str = encodeJsonInString("SiPixelQualityFromDbRcd_prompt_prod.json")
 SiPixelQualityFromDbRcd_prompt_prep_str = encodeJsonInString("SiPixelQualityFromDbRcd_prompt_prep.json")
 SiPixelQualityFromDbRcd_stuckTBM_prod_str = encodeJsonInString("SiPixelQualityFromDbRcd_stuckTBM_prod.json")
 SiPixelQualityFromDbRcd_stuckTBM_prep_str = encodeJsonInString("SiPixelQualityFromDbRcd_stuckTBM_prep.json")
 SiPixelQualityFromDbRcd_other_prod_str = encodeJsonInString("SiPixelQualityFromDbRcd_other_prod.json")
 SiPixelQualityFromDbRcd_other_prep_str = encodeJsonInString("SiPixelQualityFromDbRcd_other_prep.json")
+
+#SiPixelLorenzAngle
+SiPixelLorentzAngleRcd_prod_str =  encodeJsonInString("SiPixelLorentzAngleRcd_prod.json")
+SiPixelLorentzAngleRcd_multirun_prod_str =  encodeJsonInString("SiPixelLorentzAngleRcd_multirun_prod.json")
+SiPixelLorentzAngleRcd_prep_str = encodeJsonInString("SiPixelLorentzAngleRcd_prep.json")
+SiPixelLorentzAngleRcd_multirun_prep_str = encodeJsonInString("SiPixelLorentzAngleRcd_multirun_prep.json")
+
+#CT-PPS alignment and timing
+CTPPSRPAlignmentCorrectionsDataRcd_prod_str =  encodeJsonInString("CTPPSRPAlignmentCorrectionsDataRcd_prod.json")
+CTPPSRPAlignmentCorrectionsDataRcd_prep_str = encodeJsonInString("CTPPSRPAlignmentCorrectionsDataRcd_prep.json")
+PPSTimingCalibrationRcd_prod_str = encodeJsonInString("PPSTimingCalibrationRcd_prod.json")
+PPSTimingCalibrationRcd_prep_str = encodeJsonInString("PPSTimingCalibrationRcd_prep.json")
+PPSTimingCalibrationRcd_Sampic_prod_str = encodeJsonInString("PPSTimingCalibrationRcd_Sampic_prod.json")
+PPSTimingCalibrationRcd_Sampic_prep_str = encodeJsonInString("PPSTimingCalibrationRcd_Sampic_prep.json")
+
 
 # given a set of .json files in the current dir, ProduceDropBoxMetadata produces a sqlite containign the payload with the prod/and/prep metadata
 process.mywriter = cms.EDAnalyzer("ProduceDropBoxMetadata",
@@ -172,13 +187,39 @@ process.mywriter = cms.EDAnalyzer("ProduceDropBoxMetadata",
                                                                prodMetaData        = cms.untracked.string(SiPixelQualityFromDbRcd_other_prod_str),
                                                                prepMetaData        = cms.untracked.string(SiPixelQualityFromDbRcd_other_prep_str),
                                                                ),
+                                                      cms.PSet(record              = cms.untracked.string('SiPixelLorentzAngleRcd'),
+                                                               Source              = cms.untracked.string("AlcaHarvesting"),
+                                                               FileClass           = cms.untracked.string("ALCA"),
+                                                               prodMetaData        = cms.untracked.string(SiPixelLorentzAngleRcd_prod_str),
+                                                               prodMetaDataMultiRun = cms.untracked.string(SiPixelLorentzAngleRcd_multirun_prod_str),
+                                                               prepMetaData        = cms.untracked.string(SiPixelLorentzAngleRcd_prep_str),
+                                                               prepMetaDataMultiRun = cms.untracked.string(SiPixelLorentzAngleRcd_multirun_prep_str),
+                                                               ),
+                                                      cms.PSet(record              = cms.untracked.string('CTPPSRPAlignmentCorrectionsDataRcd'),
+                                                               Source              = cms.untracked.string("AlcaHarvesting"),
+                                                               FileClass           = cms.untracked.string("ALCA"),
+                                                               prodMetaData        = cms.untracked.string(CTPPSRPAlignmentCorrectionsDataRcd_prod_str),
+                                                               prepMetaData        = cms.untracked.string(CTPPSRPAlignmentCorrectionsDataRcd_prep_str),
+                                                               ),
+                                                      cms.PSet(record              = cms.untracked.string('PPSTimingCalibrationRcd'),
+                                                               Source              = cms.untracked.string("AlcaHarvesting"),
+                                                               FileClass           = cms.untracked.string("ALCA"),
+                                                               prodMetaData        = cms.untracked.string(PPSTimingCalibrationRcd_prod_str),
+                                                               prepMetaData        = cms.untracked.string(PPSTimingCalibrationRcd_prep_str),
+                                                               ),
+                                                      cms.PSet(record              = cms.untracked.string('PPSTimingCalibrationRcd_Sampic'),
+                                                               Source              = cms.untracked.string("AlcaHarvesting"),
+                                                               FileClass           = cms.untracked.string("ALCA"),
+                                                               prodMetaData        = cms.untracked.string(PPSTimingCalibrationRcd_Sampic_prod_str),
+                                                               prepMetaData        = cms.untracked.string(PPSTimingCalibrationRcd_Sampic_prep_str),
+                                                               ),
                                                       ),
                                   # this boolean will read the content of whichever payload is available and print its content to stoutput
                                   # set this to false if you write out a sqlite.db translating the json's into a payload
                                   read = cms.untracked.bool(False),
 
-                                  # toRead lists of record naemes to be sought inside the DropBoxMetadataRcd payload avaialble to the ProduceDropBoxMetadata; for instance, if write is True, you're reading back the metadata you've just entered in the payload from the .json files
-                                  toRead = cms.untracked.vstring('BeamSpotObjectsRcdByRun','BeamSpotObjectsRcdByLumi','BeamSpotObjectsRcdHPByLumi','BeamSpotObjectsRcdHPByRun','SiStripBadStripRcd','SiStripApvGainRcd','TrackerAlignmentRcd','SiStripApvGainRcdAfterAbortGap','SiStripApvGainRcdAAG','EcalPedestalsRcd',"LumiCorrectionsRcd","SiPixelQualityFromDbRcd_prompt","SiPixelQualityFromDbRcd_stuckTBM","SiPixelQualityFromDbRcd_other") # same strings as fType
+                                  # toRead lists of record names to be sought inside the DropBoxMetadataRcd payload avaialble to the ProduceDropBoxMetadata; for instance, if write is True, you're reading back the metadata you've just entered in the payload from the .json files
+                                  toRead = cms.untracked.vstring('BeamSpotObjectsRcdByRun','BeamSpotObjectsRcdByLumi','BeamSpotObjectsRcdHPByLumi','BeamSpotObjectsRcdHPByRun','SiStripBadStripRcd','SiStripApvGainRcd','TrackerAlignmentRcd','SiStripApvGainRcdAfterAbortGap','SiStripApvGainRcdAAG','EcalPedestalsRcd',"LumiCorrectionsRcd","SiPixelQualityFromDbRcd_prompt","SiPixelQualityFromDbRcd_stuckTBM","SiPixelQualityFromDbRcd_other","SiPixelLorentzAngleRcd","CTPPSRPAlignmentCorrectionsDataRcd","PPSTimingCalibrationRcd","PPSTimingCalibrationRcd_Sampic") # same strings as fType
                                   )
 
 process.p = cms.Path(process.mywriter)
@@ -201,10 +242,7 @@ if process.mywriter.write:
                                               )
     
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
-process.GlobalTag.globaltag = '92X_dataRun2_Express_Queue'
-
-#process.GlobalTag.connect   = 'frontier://PromptProd/CMS_CONDITIONS'
-#process.GlobalTag.connect   = 'sqlite_file:/data/franzoni/92x/CMSSW_9_2_X_2017-05-16-1100_metadata/src/CondFormats/Common/test/last-iov-DropBoxMetadata_v5.1_express.db'
+process.GlobalTag.globaltag = '121X_dataRun3_Express_Queue'
 
 # Set to True if you want to read a DropBoxMetadata payload from a local sqlite
 # specify the name of the sqlitefile.db and the tag name; the payload loaded will be for run 300000

--- a/CondFormats/Common/test/SiPixelLorentzAngleRcd_multirun_prep.json
+++ b/CondFormats/Common/test/SiPixelLorentzAngleRcd_multirun_prep.json
@@ -1,0 +1,9 @@
+{
+    "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS", 
+    "destinationTags": {
+        "SiPixelLorentzAngle_byPCL_multirun_v0_prompt": {}
+    }, 
+    "inputTag": "SiPixelLA_pcl", 
+    "since": null, 
+    "userText": "Multirun Upload for SiPixelLA (prep)"
+}

--- a/CondFormats/Common/test/SiPixelLorentzAngleRcd_multirun_prod.json
+++ b/CondFormats/Common/test/SiPixelLorentzAngleRcd_multirun_prod.json
@@ -1,0 +1,9 @@
+{
+    "destinationDatabase": "oracle://cms_orcon_prod/CMS_CONDITIONS", 
+    "destinationTags": {
+        "SiPixelLorentzAngle_byPCL_multirun_v0_prompt": {}
+    }, 
+    "inputTag": "SiPixelLA_pcl", 
+    "since": null, 
+    "userText": "Multirun Upload for SiPixelLorentzAngle"
+}

--- a/CondFormats/Common/test/SiPixelLorentzAngleRcd_prep.json
+++ b/CondFormats/Common/test/SiPixelLorentzAngleRcd_prep.json
@@ -1,0 +1,9 @@
+{
+    "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS", 
+    "destinationTags": {
+        "SiPixelLorentzAngle_byPCL_v0_prompt": {}
+    }, 
+    "inputTag": "SiPixelLA_pcl", 
+    "since": null, 
+    "userText": "Tier0 PCL Upload for SiPixelLA (prep)"
+}

--- a/CondFormats/Common/test/SiPixelLorentzAngleRcd_prod.json
+++ b/CondFormats/Common/test/SiPixelLorentzAngleRcd_prod.json
@@ -1,0 +1,9 @@
+{
+    "destinationDatabase": "oracle://cms_orcon_prod/CMS_CONDITIONS", 
+    "destinationTags": {
+        "SiPixelLorentzAngle_byPCL_v0_prompt": {}
+    }, 
+    "inputTag": "SiPixelLA_pcl", 
+    "since": null, 
+    "userText": "Tier0 PCL Upload for SiPixelLorentzAngle"
+}


### PR DESCRIPTION
#### PR description:

Change config files to include new metadata files needed for the PCL due to the ongoing 3+1 developments:
 * CT-PPS alignment
 * CT-PPS timing (HPTDC)
 * CT-PPS timing (SAMPIC)
 * SiPixel Lorentz Angle

FYI @vavati @SanjanaSekhar

#### PR validation:

Running `cmsRun CondFormats/Common/test/ProduceDropBoxMetadata.py`
I get the new payload which now contains:
```
--- record: SiPixelLorentzAngleRcd
           key: FileClass value: ALCA
           key: Source value: AlcaHarvesting
           key: prepMetaData value: {&quot;destinationDatabase&quot;: &quot;oracle://cms_orcoff_prep/CMS_CONDITIONS&quot;, &quot;destinationTags&quot;: {&quot;SiPixelLorentzAngle_byPCL_v0_prompt&quot;: {}}, &quot;inputTag&quot;: &quot;SiPixelLA_pcl&quot;, &quot;since&quot;: null, &quot;userText&quot;: &quot;Tier0 PCL Upload for SiPixelLA (prep)&quot;}
           key: prepMetaDataMultiRun value: {&quot;destinationDatabase&quot;: &quot;oracle://cms_orcoff_prep/CMS_CONDITIONS&quot;, &quot;destinationTags&quot;: {&quot;SiPixelLorentzAngle_byPCL_multirun_v0_prompt&quot;: {}}, &quot;inputTag&quot;: &quot;SiPixelLA_pcl&quot;, &quot;since&quot;: null, &quot;userText&quot;: &quot;Multirun Upload for SiPixelLA (prep)&quot;}
           key: prodMetaData value: {&quot;destinationDatabase&quot;: &quot;oracle://cms_orcon_prod/CMS_CONDITIONS&quot;, &quot;destinationTags&quot;: {&quot;SiPixelLorentzAngle_byPCL_v0_prompt&quot;: {}}, &quot;inputTag&quot;: &quot;SiPixelLA_pcl&quot;, &quot;since&quot;: null, &quot;userText&quot;: &quot;Tier0 PCL Upload for SiPixelLorentzAngle&quot;}
           key: prodMetaDataMultiRun value: {&quot;destinationDatabase&quot;: &quot;oracle://cms_orcon_prod/CMS_CONDITIONS&quot;, &quot;destinationTags&quot;: {&quot;SiPixelLorentzAngle_byPCL_multirun_v0_prompt&quot;: {}}, &quot;inputTag&quot;: &quot;SiPixelLA_pcl&quot;, &quot;since&quot;: null, &quot;userText&quot;: &quot;Multirun Upload for SiPixelLorentzAngle&quot;}

--- record: CTPPSRPAlignmentCorrectionsDataRcd
           key: FileClass value: ALCA
           key: Source value: AlcaHarvesting
           key: prepMetaData value: {&quot;destinationDatabase&quot;: &quot;oracle://cms_orcoff_prep/CMS_CONDITIONS&quot;, &quot;destinationTags&quot;: {&quot;CTPPSRPAlignment_byPCL_v0_prompt&quot;: {}}, &quot;inputTag&quot;: &quot;CTPPSRPAlignment_real_pcl&quot;, &quot;since&quot;: null, &quot;userText&quot;: &quot;Tier0 PCL Upload for CTPPSRPAlignment&quot;}
           key: prodMetaData value: {&quot;destinationDatabase&quot;: &quot;oracle://cms_orcon_prod/CMS_CONDITIONS&quot;, &quot;destinationTags&quot;: {&quot;CTPPSRPAlignment_byPCL_v0_prompt&quot;: {}}, &quot;inputTag&quot;: &quot;CTPPSRPAlignment_real_pcl&quot;, &quot;since&quot;: null, &quot;userText&quot;: &quot;Tier0 PCL Upload for CTPPSRPAlignment&quot;}

--- record: PPSTimingCalibrationRcd
           key: FileClass value: ALCA
           key: Source value: AlcaHarvesting
           key: prepMetaData value: {&quot;destinationDatabase&quot;: &quot;oracle://cms_orcoff_prep/CMS_CONDITIONS&quot;, &quot;destinationTags&quot;: {&quot;CTPPPSTimingCalibration_HPTDC_byPCL_v0_prompt&quot;: {}}, &quot;inputTag&quot;: &quot;PPSDiamondTimingCalibration_pcl&quot;, &quot;since&quot;: null, &quot;userText&quot;: &quot;Tier0 PCL Upload for PPSDiamondTimingCalibration (HPTDC)&quot;}
           key: prodMetaData value: {&quot;destinationDatabase&quot;: &quot;oracle://cms_orcon_prod/CMS_CONDITIONS&quot;, &quot;destinationTags&quot;: {&quot;CTPPPSTimingCalibration_HPTDC_byPCL_v0_prompt&quot;: {}}, &quot;inputTag&quot;: &quot;PPSDiamondTimingCalibration_pcl&quot;, &quot;since&quot;: null, &quot;userText&quot;: &quot;Tier0 PCL Upload for PPSDiamondTimingCalibration (HPTDC)&quot;}

--- record: PPSTimingCalibrationRcd_Sampic
           key: FileClass value: ALCA
           key: Source value: AlcaHarvesting
           key: prepMetaData value: {&quot;destinationDatabase&quot;: &quot;oracle://cms_orcoff_prep/CMS_CONDITIONS&quot;, &quot;destinationTags&quot;: {&quot;CTPPPSTimingCalibration_SAMPIC_byPCL_v0_prompt&quot;: {}}, &quot;inputTag&quot;: &quot;DiamondSampicCalibration&quot;, &quot;since&quot;: null, &quot;userText&quot;: &quot;Tier0 PCL Upload for PPSDiamondTimingCalibration (Sampic)&quot;}
           key: prodMetaData value: {&quot;destinationDatabase&quot;: &quot;oracle://cms_orcon_prod/CMS_CONDITIONS&quot;, &quot;destinationTags&quot;: {&quot;CTPPPSTimingCalibration_SAMPIC_byPCL_v0_prompt&quot;: {}}, &quot;inputTag&quot;: &quot;DiamondSampicCalibration&quot;, &quot;since&quot;: null, &quot;userText&quot;: &quot;Tier0 PCL Upload for PPSDiamondTimingCalibration (Sampic)&quot;}
Begin processing the 1st record. Run 300000, Event 1, LumiSection 1 on stream 0 at 18-Oct-2021 22:59:22.511 CEST
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

Resolves https://github.com/cms-AlCaDB/AlCaTools/issues/42