### PR TITLE
Disable looper track reconstruction for >= Run2_2016

### DIFF
--- a/Configuration/Eras/python/Era_Run2_2016_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2016_cff.py
@@ -13,7 +13,8 @@ from Configuration.Eras.Modifier_pixel_2016_cff import pixel_2016
 from Configuration.Eras.Modifier_run2_jme_2016_cff import run2_jme_2016
 from Configuration.Eras.Modifier_strips_vfp30_2016_cff import strips_vfp30_2016
 from Configuration.Eras.Modifier_run2_ECAL_2016_cff import run2_ECAL_2016
+from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers
 
 Run2_2016 = cms.ModifierChain(run2_common, run2_25ns_specific,
- stage2L1Trigger, ctpps, ctpps_2016, run2_HLTconditions_2016, run2_ECAL_2016, run2_muon_2016, run2_egamma_2016, run2_L1prefiring, pixel_2016, run2_jme_2016, strips_vfp30_2016)
+                              stage2L1Trigger, ctpps, ctpps_2016, run2_HLTconditions_2016, run2_ECAL_2016, run2_muon_2016, run2_egamma_2016, run2_L1prefiring, pixel_2016, run2_jme_2016, strips_vfp30_2016, trackingNoLoopers)
 

--- a/Configuration/Eras/python/Era_Run2_2016_pA_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2016_pA_cff.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
 from Configuration.Eras.Modifier_pA_2016_cff import pA_2016
+from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers
 
-Run2_2016_pA = cms.ModifierChain(Run2_2016, pA_2016)
+Run2_2016_pA = cms.ModifierChain(Run2_2016.copyAndExclude([trackingNoLoopers]), pA_2016)
 

--- a/Configuration/Eras/python/Era_Run2_2017_ppRef_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2017_ppRef_cff.py
@@ -3,5 +3,6 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
 from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
 from Configuration.Eras.ModifierChain_trackingMkFitProd_cff import trackingMkFitProd
+from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers
 
-Run2_2017_ppRef = cms.ModifierChain(Run2_2017.copyAndExclude([trackingMkFitProd]), ppRef_2017)
+Run2_2017_ppRef = cms.ModifierChain(Run2_2017.copyAndExclude([trackingMkFitProd, trackingNoLoopers]), ppRef_2017)

--- a/Configuration/Eras/python/Era_Run2_2017_pp_on_XeXe_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2017_pp_on_XeXe_cff.py
@@ -3,5 +3,6 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.Eras.ModifierChain_trackingMkFitProd_cff import trackingMkFitProd
+from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers
 
-Run2_2017_pp_on_XeXe = cms.ModifierChain(Run2_2017.copyAndExclude([trackingMkFitProd]), pp_on_XeXe_2017)
+Run2_2017_pp_on_XeXe = cms.ModifierChain(Run2_2017.copyAndExclude([trackingMkFitProd,trackingNoLoopers]), pp_on_XeXe_2017)

--- a/Configuration/Eras/python/Era_Run2_2018_pp_on_AA_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2018_pp_on_AA_cff.py
@@ -4,5 +4,6 @@ from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 from Configuration.Eras.ModifierChain_trackingMkFitProd_cff import trackingMkFitProd
+from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers
 
-Run2_2018_pp_on_AA = cms.ModifierChain(Run2_2018.copyAndExclude([trackingMkFitProd]), pp_on_AA, pp_on_AA_2018)
+Run2_2018_pp_on_AA = cms.ModifierChain(Run2_2018.copyAndExclude([trackingMkFitProd, trackingNoLoopers]), pp_on_AA, pp_on_AA_2018)

--- a/Configuration/Eras/python/Era_Run3_pp_on_PbPb_cff.py
+++ b/Configuration/Eras/python/Era_Run3_pp_on_PbPb_cff.py
@@ -3,5 +3,6 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.Eras.Era_Run3_noMkFit_cff import Run3_noMkFit
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers
 
-Run3_pp_on_PbPb = cms.ModifierChain(Run3_noMkFit, pp_on_AA, pp_on_PbPb_run3)
+Run3_pp_on_PbPb = cms.ModifierChain(Run3_noMkFit.copyAndExclude([trackingNoLoopers]), pp_on_AA, pp_on_PbPb_run3)

--- a/Configuration/ProcessModifiers/python/trackingNoLoopers_cff.py
+++ b/Configuration/ProcessModifiers/python/trackingNoLoopers_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+# This modifier removes the looper tracks reconstruction
+trackingNoLoopers = cms.Modifier()

--- a/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
@@ -6,6 +6,9 @@ from Configuration.Eras.Modifier_fastSim_cff import fastSim
 from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
 from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary
 
+# for no-loopers
+from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers
+
 ###############################################
 # Low pT and detached tracks from pixel quadruplets
 ###############################################
@@ -156,6 +159,8 @@ detachedQuadStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryB
     maxDPhiForLooperReconstruction = cms.double(2.0),
     maxPtForLooperReconstruction = cms.double(0.7)
 )
+trackingNoLoopers.toModify(detachedQuadStepTrajectoryBuilder,
+                           maxPtForLooperReconstruction = 0.0)
 trackingPhase2PU140.toModify(detachedQuadStepTrajectoryBuilder,
     maxCand              = 2,
     alwaysUseInvalidHits = False,

--- a/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
@@ -10,6 +10,9 @@ from FastSimulation.Tracking.SeedingMigration import _hitSetProducerToFactoryPSe
 from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
 from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary
 
+# for no-loopers
+from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers
+
 ###############################################
 # Low pT and detached tracks from pixel triplets
 ###############################################
@@ -187,6 +190,8 @@ detachedTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajecto
     maxDPhiForLooperReconstruction = cms.double(2.0),
     maxPtForLooperReconstruction = cms.double(0.7) 
     )
+trackingNoLoopers.toModify(detachedTripletStepTrajectoryBuilder,
+                           maxPtForLooperReconstruction = 0.0)
 trackingLowPU.toModify(detachedTripletStepTrajectoryBuilder,
     maxCand = 2,
     alwaysUseInvalidHits = False,

--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -6,6 +6,9 @@ from Configuration.Eras.Modifier_fastSim_cff import fastSim
 from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
 from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary
 
+# for no-loopers
+from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers
+
 ### high-pT triplets ###
 
 # NEW CLUSTERS (remove previously used clusters)
@@ -196,6 +199,8 @@ highPtTripletStepTrajectoryBuilder = _GroupedCkfTrajectoryBuilder_cfi.GroupedCkf
     # of the outermost Tracker barrel layer (with B=3.8T)
     maxPtForLooperReconstruction = cms.double(0.7)
 )
+trackingNoLoopers.toModify(highPtTripletStepTrajectoryBuilder,
+                           maxPtForLooperReconstruction = 0.0)
 trackingPhase2PU140.toModify(highPtTripletStepTrajectoryBuilder,
     inOutTrajectoryFilter = dict(refToPSet_ = 'highPtTripletStepTrajectoryFilterInOut'),
     useSameTrajFilter = False,

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -6,6 +6,9 @@ from Configuration.Eras.Modifier_fastSim_cff import fastSim
 from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
 from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary
 
+# for no-loopers
+from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers
+
 ### STEP 0 ###
 
 # hit building
@@ -202,6 +205,8 @@ initialStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilde
     maxDPhiForLooperReconstruction = cms.double(2.0),
     maxPtForLooperReconstruction = cms.double(0.7)
 )
+trackingNoLoopers.toModify(initialStepTrajectoryBuilder,
+                           maxPtForLooperReconstruction = 0.0)
 trackingLowPU.toModify(initialStepTrajectoryBuilder, maxCand = 5)
 trackingPhase1.toModify(initialStepTrajectoryBuilder,
     minNrOfHitsForRebuild = 1,

--- a/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
@@ -4,6 +4,9 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
 from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary
 
+# for no-loopers
+from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers
+
 # This step runs over all clusters
 
 # run only if there are high pT jets
@@ -152,7 +155,9 @@ jetCoreRegionalStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajecto
     estimator = 'jetCoreRegionalStepChi2Est',
     maxDPhiForLooperReconstruction = cms.double(2.0),
     maxPtForLooperReconstruction = cms.double(0.7)
-    )    
+)
+trackingNoLoopers.toModify(jetCoreRegionalStepTrajectoryBuilder,
+                           maxPtForLooperReconstruction = 0.0)    
 jetCoreRegionalStepBarrelTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
     MeasurementTrackerName = '',
     trajectoryFilter = cms.PSet(refToPSet_ = cms.string('jetCoreRegionalStepBarrelTrajectoryFilter')),
@@ -163,11 +168,14 @@ jetCoreRegionalStepBarrelTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTr
     lockHits = False,
     requireSeedHitsInRebuild = False
 )
+trackingNoLoopers.toModify(jetCoreRegionalStepBarrelTrajectoryBuilder,
+                           maxPtForLooperReconstruction = cms.double(0.0))    
 jetCoreRegionalStepEndcapTrajectoryBuilder = jetCoreRegionalStepTrajectoryBuilder.clone(
     trajectoryFilter = cms.PSet(refToPSet_ = cms.string('jetCoreRegionalStepEndcapTrajectoryFilter')),
     #clustersToSkip = cms.InputTag('jetCoreRegionalStepClusters'),
 )
-    
+trackingNoLoopers.toModify(jetCoreRegionalStepEndcapTrajectoryBuilder,
+                           maxPtForLooperReconstruction = cms.double(0.0))
 #customized cleaner for DeepCore
 from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import trajectoryCleanerBySharedHits
 jetCoreRegionalStepDeepCoreTrajectoryCleaner = trajectoryCleanerBySharedHits.clone(

--- a/RecoTracker/IterativeTracking/python/LowPtBarrelTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtBarrelTripletStep_cff.py
@@ -1,5 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
+# for no-loopers
+from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers
+
 # NEW CLUSTERS (remove previously used clusters)
 from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import *
 lowPtBarrelTripletStepClusters = trackClusterRemover.clone(
@@ -69,7 +72,8 @@ lowPtBarrelTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTraje
     # set the variable to a negative value to turn-off the looper reconstruction 
     #maxPtForLooperReconstruction = cms.double(-1.) 
     )
-
+trackingNoLoopers.toModify(lowPtBarrelTripletStepTrajectoryBuilder,
+                           maxPtForLooperReconstruction = 0.0)
 # MAKING OF TRACK CANDIDATES
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 lowPtBarrelTripletStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(

--- a/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
@@ -6,6 +6,9 @@ from Configuration.Eras.Modifier_fastSim_cff import fastSim
 from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
 from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary
 
+# for no-loopers
+from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers
+
 # NEW CLUSTERS (remove previously used clusters)
 lowPtQuadStepClusters = _cfg.clusterRemoverForIter('LowPtQuadStep')
 for _eraName, _postfix, _era in _cfg.nonDefaultEras():
@@ -144,6 +147,8 @@ lowPtQuadStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuil
     # of the outermost Tracker barrel layer (with B=3.8T)
     maxPtForLooperReconstruction = cms.double(0.7) 
 )
+trackingNoLoopers.toModify(lowPtQuadStepTrajectoryBuilder,
+                           maxPtForLooperReconstruction = 0.0)
 trackingPhase2PU140.toModify(lowPtQuadStepTrajectoryBuilder,
     minNrOfHitsForRebuild      = 1,
     keepOriginalIfRebuildFails = True,

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -7,6 +7,9 @@ from Configuration.Eras.Modifier_fastSim_cff import fastSim
 from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
 from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary
 
+# for no-loopers
+from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers
+
 # NEW CLUSTERS (remove previously used clusters)
 lowPtTripletStepClusters = _cfg.clusterRemoverForIter('LowPtTripletStep')
 for _eraName, _postfix, _era in _cfg.nonDefaultEras():
@@ -216,6 +219,8 @@ lowPtTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryB
     # of the outermost Tracker barrel layer (with B=3.8T)
     maxPtForLooperReconstruction = cms.double(0.7) 
 )
+trackingNoLoopers.toModify(lowPtTripletStepTrajectoryBuilder,
+                           maxPtForLooperReconstruction = 0.0)
 trackingLowPU.toModify(lowPtTripletStepTrajectoryBuilder, maxCand = 3)
 trackingPhase2PU140.toModify(lowPtTripletStepTrajectoryBuilder, 
     inOutTrajectoryFilter = dict(refToPSet_ = 'lowPtTripletStepTrajectoryFilterInOut'),

--- a/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
@@ -7,6 +7,9 @@ from Configuration.Eras.Modifier_fastSim_cff import fastSim
 from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
 from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary
 
+# for no-loopers
+from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers
+
 ###############################################################
 # Large impact parameter Tracking using mixed-triplet seeding #
 ###############################################################
@@ -276,7 +279,8 @@ mixedTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryB
     maxDPhiForLooperReconstruction = cms.double(2.0),
     maxPtForLooperReconstruction = cms.double(0.7) 
 )
-
+trackingNoLoopers.toModify(mixedTripletStepTrajectoryBuilder,
+                           maxPtForLooperReconstruction = 0.0)
 # MAKING OF TRACK CANDIDATES
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 # Give handle for CKF for HI

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -7,6 +7,9 @@ from Configuration.Eras.Modifier_fastSim_cff import fastSim
 from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
 from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary
 
+# for no-loopers
+from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers
+
 ##########################################################################
 # Large impact parameter tracking using TIB/TID/TEC stereo layer seeding #
 ##########################################################################
@@ -281,6 +284,8 @@ pixelLessStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuil
     maxDPhiForLooperReconstruction = cms.double(2.0),
     maxPtForLooperReconstruction   = cms.double(0.7)
 )
+trackingNoLoopers.toModify(pixelLessStepTrajectoryBuilder,
+                           maxPtForLooperReconstruction = 0.0)
 
 # MAKING OF TRACK CANDIDATES
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi

--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -7,6 +7,9 @@ from Configuration.Eras.Modifier_fastSim_cff import fastSim
 from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
 from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary
 
+# for no-loopers
+from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers
+
 # NEW CLUSTERS (remove previously used clusters)
 pixelPairStepClusters = _cfg.clusterRemoverForIter('PixelPairStep')
 for _eraName, _postfix, _era in _cfg.nonDefaultEras():
@@ -279,6 +282,8 @@ pixelPairStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuil
     maxDPhiForLooperReconstruction = cms.double(2.0),
     maxPtForLooperReconstruction = cms.double(0.7) 
 )
+trackingNoLoopers.toModify(pixelPairStepTrajectoryBuilder,
+                           maxPtForLooperReconstruction = 0.0)
 trackingLowPU.toModify(pixelPairStepTrajectoryBuilder, maxCand = 2)
 _seedExtension = dict(
     inOutTrajectoryFilter = dict(refToPSet_ = 'pixelPairStepTrajectoryFilterInOut'),

--- a/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
@@ -6,6 +6,9 @@ from Configuration.Eras.Modifier_fastSim_cff import fastSim
 from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
 from RecoTracker.IterativeTracking.dnnQualityCuts import qualityCutDictionary
 
+# for no-loopers
+from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers
+
 #######################################################################
 # Very large impact parameter tracking using TOB + TEC ring 5 seeding #
 #######################################################################
@@ -251,6 +254,8 @@ tobTecStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder
     maxDPhiForLooperReconstruction = cms.double(2.0),
     maxPtForLooperReconstruction   = cms.double(0.7)
 )
+trackingNoLoopers.toModify(tobTecStepTrajectoryBuilder,
+                           maxPtForLooperReconstruction = 0.0)
 # Important note for LowPU: in RunI_TobTecStep the
 # inOutTrajectoryFilter parameter is spelled as
 # inOutTrajectoryFilterName, and I suspect it has no effect there. I


### PR DESCRIPTION
#### PR description:

It has been suggested that disabling the "looper"  [^1] track reconstruction would save some reco computing time while not hindering any specific physics signal reconstruction.
A possible exception was identified with the B-Physics signals.
For this purpose a dedicated set of samples has been requested in this JIRA ticket [PDMVRELVALS-128](https://its.cern.ch/jira/projects/PDMVRELVALS/issues/PDMVRELVALS-128) to be studied by the BPH group.
The outcome of the study has been presented at the [Tracking POG meeting of 18.08.2021](https://indico.cern.ch/event/1087315/contributions/4571634/attachments/2329725/3969669/TRK_BPH_mkFit%26loopers_Adriano.pdf).
Based on the conclusions that 

> "disabling loopers seems not to affect the topologies we are interested into. Some increase in the # of candidates is seen in line with expectations (@ lowp T & low eta). For some cases the performances are even better."

we proceed with the disabling for all eras >=Run2_2016, excluding the dedicated Heavy Ion ones.

#### PR validation:

Technically validated by running:  
```
 runTheMatrix.py -l limited -j 4 --ibeos
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

cc: @vmariani @AdrianoDee 

[^1]: trajectories of low-energy particles (either from PU or from the underlying event of the main scattering) which are spiralling in the magnetic field within the Tracker radius. For comparison pT=0.63 GeV is the maximum pT for a charged particle to loop within the 1.1m radius of the outermost Tracker barrel layer (with B=3.8T). 