### PR TITLE
Bug Fix for CLUE in BH section of HGCAL

### DIFF
--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.h
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.h
@@ -91,7 +91,7 @@ public:
                                    {
                                        1.3,
                                        1.3,
-                                       5.0,
+                                       1.3,
                                        0.0315,  // for scintillator
                                    });
     iDesc.add<bool>("dependSensor", true);


### PR DESCRIPTION
#### PR description:

Possibly for historical reasons dating back to the original
implementation of the _imaging_ algorithm, from which CLUE has been
derived, the critical distance in the BH section is treated differently.
There is no _physics driven motivation_ for this behaviour. This sets
the critical distance parameter equal all over the Silicon detectors
of HGCAL. The effect is visible in a much better separation of sibling
showers in the BH section.

#### PR validation:

Validated on a privately produced sample of two `CloseBy` photons in `BH` separated by `3.5cm` to test merging vs separation.

##### Before the fix
![BH43_Evt15_wrong_deltac](https://user-images.githubusercontent.com/1169991/137873316-b97c3f3e-ae1c-4d08-9150-4b705ab0ae13.png)

##### After the fix
![BH43_Evt15_correct_deltac](https://user-images.githubusercontent.com/1169991/137873387-b2401242-a889-40de-a7cb-4ba3a152c441.png)



