### PR TITLE
(Splash only) Special timing plot configuration for splash events

### DIFF
--- a/DQM/EcalMonitorClient/python/TimingClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/TimingClient_cfi.py
@@ -12,7 +12,7 @@ minTowerEntriesFwd = 24
 toleranceMeanFwd = 6.
 toleranceRMSFwd = 12.
 tailPopulThreshold = 0.4
-timeWindow = 25.
+timeWindow = 30.
 
 ecalTimingClient = cms.untracked.PSet(
     params = cms.untracked.PSet(

--- a/DQM/EcalMonitorClient/src/TimingClient.cc
+++ b/DQM/EcalMonitorClient/src/TimingClient.cc
@@ -72,7 +72,8 @@ namespace ecaldqm {
 
       DetId id(qItr->getId());
 
-      int minChannelEntries(minChannelEntries_);
+      //int minChannelEntries(minChannelEntries_);
+      int minChannelEntries(0);
       float meanThresh(toleranceMean_);
       float rmsThresh(toleranceRMS_);
 

--- a/DQM/EcalMonitorTasks/python/TimingTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/TimingTask_cfi.py
@@ -33,8 +33,8 @@ energyThresholdEEFwd = 6.7
 energyThresholdEB = 2.02
 timingVsBXThreshold = energyThresholdEB
 timeErrorThreshold = 3.
-timeWindow = 12.5
-summaryTimeWindow = 7.
+timeWindow = 30.
+summaryTimeWindow = 25.
 
 ecalTimingTask = cms.untracked.PSet(
     params = cms.untracked.PSet(

--- a/DQM/EcalMonitorTasks/src/TimingTask.cc
+++ b/DQM/EcalMonitorTasks/src/TimingTask.cc
@@ -80,12 +80,12 @@ namespace ecaldqm {
       float time(hit.time());
       float energy(hit.energy());
 
-      float chi2Threshold, energyThreshold;
+      float energyThreshold;
       if (id.subdetId() == EcalBarrel) {
-        chi2Threshold = chi2ThresholdEB_;
+        //chi2Threshold = chi2ThresholdEB_;
         energyThreshold = energyThresholdEB_;
       } else {
-        chi2Threshold = chi2ThresholdEE_;
+        //chi2Threshold = chi2ThresholdEE_;
         energyThreshold = (isForward(id)) ? energyThresholdEEFwd_ : energyThresholdEE_;
       }
 
@@ -103,8 +103,8 @@ namespace ecaldqm {
         meChi2.fill(getEcalDQMSetupObjects(), signedSubdet, hit.chi2());
 
       // Apply cut on chi2 of pulse shape fit
-      if (hit.chi2() > chi2Threshold)
-        return;
+      //if (hit.chi2() > chi2Threshold)
+      //  return;
 
       // Apply cut based on timing error of rechit
       if (hit.timeError() > timeErrorThreshold_)


### PR DESCRIPTION
#### PR description:

During splash events, we often have very poor signal shapes. In addition, it is useful to view these events in a wider time window than the default configuration. This PR changes the timing windows and removes a chi-square constraint to make DQM more useful during splash events. This is not meant to be merged into CMSSW.

#### PR validation:
Validated by the standard DQM configuration. No issues seen.

