### PR TITLE
[DD4hep] Increase precision of Trapezoid definitions to prevent complaints from Native Geant4 10.7

### DIFF
--- a/DetectorDescription/OfflineDBLoader/src/DDCoreToDDXMLOutput.cc
+++ b/DetectorDescription/OfflineDBLoader/src/DDCoreToDDXMLOutput.cc
@@ -180,6 +180,10 @@ void DDCoreToDDXMLOutput::solid(const dd4hep::Solid& solid, const cms::DDParsing
     }
     case cms::DDSolidShape::ddtrap: {
       dd4hep::Trap rs(solid);
+      xos << std::setprecision(8);
+      // Precision of 8 is needed to prevent complaints from Native Geant4 10.7 about
+      // small deviations from planarity of trapezoid faces.
+
       xos << "<Trapezoid name=\"" << trimShapeName(rs.name()) << "\""
           << " dz=\"" << rs.dZ() << "*mm\""
           << " theta=\"" << convertRadToDeg(rs.theta()) << "*deg\""
@@ -192,6 +196,12 @@ void DDCoreToDDXMLOutput::solid(const dd4hep::Solid& solid, const cms::DDParsing
           << " bl2=\"" << rs.bottomLow2() << "*mm\""
           << " tl2=\"" << rs.topLow2() << "*mm\""
           << " alp2=\"" << convertRadToDeg(rs.alpha2()) << "*deg\"/>" << std::endl;
+      xos << std::setprecision(5);
+      // Before CMSSW_12_1_0_pre5, all solids, including Trapezoids, had precision of 5.
+      // In tests With Native Geant4 10.7, this precision caused complaints, as explained above.
+      // To minimize changes, the precision was increased only for Trapezoids.
+      // In future, when there is an opportunity to revise the geometry, it might be
+      // desirable to use precision of 8 for all solids for consistency.
       break;
     }
     case cms::DDSolidShape::ddcons: {

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDTECModuleAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDTECModuleAlgo.cc
@@ -471,6 +471,11 @@ static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, 
     bl2 = 0.5 * topFrame2RHeight;
     thet = atan((bl1 - bl2) / (2. * dz));
 
+    constexpr double minDimension = 5.e-8;  // mm value == 5.e-11 meters
+    if (bl2 < minDimension) {
+      // If Trapezoid dimension is too tiny, reset to reasonable minimum value that is still effectively zero.
+      bl2 = minDimension;
+    }
     solid = Trap(dz, thet, 0, h1, bl1, bl1, 0, h1, bl2, bl2, 0);
     ns.addSolid(ns.prepend(name), solid);
     edm::LogVerbatim("TECGeom") << "Solid:\t" << name << " " << solid.name() << " Trap made of " << topFrameMat


### PR DESCRIPTION
Native Geant4 in the Geant4 IB performs strict tests on trapezoid solids, while VecGeom Geant4 used in the master is more lenient. Native Geant4 requires all trapezoid dimensions to be non-zero, and it requires trapezoid faces to be planar down to the nanometer scale.

The DD4hep big XML file in the DB uses precision 5 for solids. At this precision, the trapezoids `tidmodule0:TIDModule0StereoKaptonCut` and `tecmodule1s:TECModule1TopFrame2` get zero values for their `bl2` and `tl2` parameters. In fact, these two solids are not true Trapezoids and should probably be defined as Trd1 or something similar, but historically they were defined as Trapezoids with two vanishingly small but non-zero dimensions. In addition, at precision 5, some trapezoid faces show deviation from being planar at the nanometer scale.

Since the Run 3 geometry has been finalized, this PR attempts to make the smallest revision possible to remove the complaints from Native Geant4. In the revised DD4hep big XML file, the precision of Trapezoids (only) is increased from 5 to 8. In addition, the `bl2` and `tl2` parameters of Trapezoid `tecmodule1s:TECModule1TopFrame2` are increased from 5.e-14 to 5.e-8 millimeters. This new value should still be small enough to have the same effect as the original, but it doesn't require an excessive precision to represent.

After this PR, the revised DD4hep big XML file will be uploaded to the DB, and a PR will be submitted to put this big 
XML file into the DD4hep Global Tag. We can consider at that point whether the revised Global Tag will be suitable for 12_1. With the revision, regression will probably not be preserved since numeric values will change, but no significant changes would be expected.

This PR resolves issue #35655.

#### PR validation:

The revised big XML file from this PR was compared with the previous one to check that the only change was the addition of three digits to each Trapezoid parameter. Simulation was run with Native Geant4, and no complaints were generated.


Backporting to 12_0 is probably not advised at this late stage for 12_0.