### PR TITLE
GEM - adding selected online dqm plots to offline dqm for data relval

### DIFF
--- a/DQMOffline/Muon/python/gem_dqm_offline_client_cff.py
+++ b/DQMOffline/Muon/python/gem_dqm_offline_client_cff.py
@@ -1,7 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
+from DQM.GEM.GEMDQMHarvester_cfi import *
 from DQMOffline.Muon.gemEfficiencyHarvester_cfi import *
 
 gemClients = cms.Sequence(
+    GEMDQMHarvester *
     gemEfficiencyHarvesterTightGlb *
-    gemEfficiencyHarvesterSta)
+    gemEfficiencyHarvesterSta
+    )

--- a/DQMOffline/Muon/python/gem_dqm_offline_client_cosmics_cff.py
+++ b/DQMOffline/Muon/python/gem_dqm_offline_client_cosmics_cff.py
@@ -1,7 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
+from DQM.GEM.GEMDQMHarvester_cfi import *
 from DQMOffline.Muon.gemEfficiencyHarvesterCosmics_cfi import *
 
 gemClientsCosmics = cms.Sequence(
+    GEMDQMHarvester *
     gemEfficiencyHarvesterCosmics *
-    gemEfficiencyHarvesterCosmicsOneLeg)
+    gemEfficiencyHarvesterCosmicsOneLeg
+    )

--- a/DQMOffline/Muon/python/gem_dqm_offline_source_cff.py
+++ b/DQMOffline/Muon/python/gem_dqm_offline_source_cff.py
@@ -1,8 +1,16 @@
 import FWCore.ParameterSet.Config as cms
 
+from DQM.GEM.GEMDigiSource_cfi import *
+from DQM.GEM.GEMRecHitSource_cfi import *
+
 from DQMOffline.Muon.gemEfficiencyAnalyzer_cfi import *
 
+GEMDigiSource.modeRelVal = True
+GEMRecHitSource.modeRelVal = True
+
 gemSources = cms.Sequence(
+    GEMDigiSource *
+    GEMRecHitSource *
     gemEfficiencyAnalyzerTightGlbSeq *
     gemEfficiencyAnalyzerStaSeq
 )

--- a/DQMOffline/Muon/python/gem_dqm_offline_source_cosmics_cff.py
+++ b/DQMOffline/Muon/python/gem_dqm_offline_source_cosmics_cff.py
@@ -1,7 +1,16 @@
 import FWCore.ParameterSet.Config as cms
 
+from DQM.GEM.GEMDigiSource_cfi import *
+from DQM.GEM.GEMRecHitSource_cfi import *
+
 from DQMOffline.Muon.gemEfficiencyAnalyzerCosmics_cfi import *
 
+GEMDigiSource.modeRelVal = True
+GEMRecHitSource.modeRelVal = True
+
 gemSourcesCosmics = cms.Sequence(
+    GEMDigiSource *
+    GEMRecHitSource *
     gemEfficiencyAnalyzerCosmics *
-    gemEfficiencyAnalyzerCosmicsOneLeg)
+    gemEfficiencyAnalyzerCosmicsOneLeg
+    )


### PR DESCRIPTION
#### PR description:
adding selected online dqm plots to offline dqm for data relval
- currently, we do not have any plots on gem digis and rechits for data relval
- this PR uses the online dqm process to add in a few selected plots

#### PR validation:
validated with wf 136.897 and 34611.0
