### PR TITLE
HcalDQM: A quick fix for the empty DQM plot entries of extended Hcal FEDs (back port)

### DIFF
--- a/DQM/HcalCommon/src/Utilities.cc
+++ b/DQM/HcalCommon/src/Utilities.cc
@@ -12,6 +12,8 @@ namespace hcaldqm {
       uint16_t slot = 0;
       if (fed <= FED_VME_MAX) {
         slot = fed % 2 == 0 ? SLOT_uTCA_MIN : SLOT_uTCA_MIN + 6;
+      } else if ((fed >= 1100 && fed <= 1117) || (fed >= 1140 && fed <= 1148)) {
+        slot = fed >= 1140 ? SLOT_uTCA_MIN + 8 : fed % 2 == 0 ? SLOT_uTCA_MIN : SLOT_uTCA_MIN + 4;
       } else {
         slot = fed % 2 == 0 ? SLOT_uTCA_MIN : SLOT_uTCA_MIN + 6;
       }


### PR DESCRIPTION
#### PR description:
back port of #35741
Correct the fed to crate/slot mapping for the new HCAL FEDs, fix the empty bins in this [plot](https://cmsweb.cern.ch/dqm/online/session/kFKDPd).

#### PR validation:

Tested on Run 345952 data and [new plot](https://tinyurl.com/yjcllvu4) on testing DQM GUI shows fixed.


