### PR TITLE
[12.0.X] Improve logging of BeamSpot DQM clients

### DIFF
--- a/DQM/BeamMonitor/plugins/BeamMonitor.cc
+++ b/DQM/BeamMonitor/plugins/BeamMonitor.cc
@@ -533,7 +533,8 @@ void BeamMonitor::beginLuminosityBlock(const LuminosityBlock& lumiSeg, const Eve
   DBloggerReturn_ = 0;
   if (onlineDbService_.isAvailable()) {
     onlineDbService_->logger().start();
-    onlineDbService_->logger().logInfo() << "BeamMonitor::beginLuminosityBlock - LS: " << lumiSeg.luminosityBlock();
+    onlineDbService_->logger().logInfo() << "BeamMonitor::beginLuminosityBlock - LS: " << lumiSeg.luminosityBlock()
+                                         << " - Run: " << lumiSeg.getRun().run();
   }
 
   int nthlumi = lumiSeg.luminosityBlock();

--- a/DQM/BeamMonitor/plugins/FakeBeamMonitor.cc
+++ b/DQM/BeamMonitor/plugins/FakeBeamMonitor.cc
@@ -527,7 +527,8 @@ void FakeBeamMonitor::beginLuminosityBlock(const LuminosityBlock& lumiSeg, const
   DBloggerReturn_ = 0;
   if (onlineDbService_.isAvailable()) {
     onlineDbService_->logger().start();
-    onlineDbService_->logger().logInfo() << "FakeBeamMonitor::beginLuminosityBlock - LS: " << lumiSeg.luminosityBlock();
+    onlineDbService_->logger().logInfo() << "FakeBeamMonitor::beginLuminosityBlock - LS: " << lumiSeg.luminosityBlock()
+                                         << " - Run: " << lumiSeg.getRun().run();
   }
 
   int nthlumi = lumiSeg.luminosityBlock();


### PR DESCRIPTION
#### PR description:
Improves the logging of the BeamSpot DQM clients by printing also the Run number at the beginning of the luminosity block, not only the lumi number. 

#### PR validation:
Code compiles plus validated with the unittest:
```cmsRun DQM/Integration/python/clients/beamfake_dqm_sourceclient-live_cfg.py unitTest=True```
The output of the log changes from:
```[2021-10-20 10:14:00.539860] INFO: FakeBeamMonitor::beginLuminosityBlock - LS: 1```
to
```[2021-10-20 12:30:26.825302] INFO: FakeBeamMonitor::beginLuminosityBlock - LS: 1 - Run: 344518```

#### Backport:
Backport of #35749