### PR TITLE
Changing of binning of GEM digi plots on GEM onlineDQM, backport to CMSSW_12_0_X

### DIFF
--- a/DQM/GEM/plugins/GEMDAQStatusSource.cc
+++ b/DQM/GEM/plugins/GEMDAQStatusSource.cc
@@ -38,7 +38,7 @@ void GEMDAQStatusSource::SetLabelAMC13Status(MonitorElement *h2Status) {
   h2Status->setBinLabel(unBinPos++, "S-link error", 2);
   h2Status->setBinLabel(unBinPos++, "Wrong FED ID", 2);
 
-  h2Status->setBinLabel(1, "GE11-N", 1);
+  h2Status->setBinLabel(1, "GE11-M", 1);
   h2Status->setBinLabel(2, "GE11-P", 1);
 }
 
@@ -107,8 +107,8 @@ void GEMDAQStatusSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run con
 
   h2AMC13Status_ =
       ibooker.book2D("amc13_status", "AMC13 Status;AMC13;", 2, 0.5, 2.5, nBitAMC13_, 0.5, nBitAMC13_ + 0.5);
-  h2AMCStatusNeg_ = ibooker.book2D("amc_status_GE11-N",
-                                   "AMC Status GE11-N;AMC slot;",
+  h2AMCStatusNeg_ = ibooker.book2D("amc_status_GE11-M",
+                                   "AMC Status GE11-M;AMC slot;",
                                    nAMCSlots_,
                                    -0.5,
                                    nAMCSlots_ - 0.5,

--- a/DQM/GEM/plugins/GEMDigiSource.cc
+++ b/DQM/GEM/plugins/GEMDigiSource.cc
@@ -102,7 +102,7 @@ int GEMDigiSource::ProcessWithMEMap3WithChamber(BookingHelper& bh, ME4IdsKey key
   int nNumVFATPerEta = stationInfo.nMaxVFAT_ / stationInfo.nNumEtaPartitions_;
   int nNumCh = stationInfo.nNumDigi_;
 
-  mapDigiOccPerCh_.SetBinConfX(nNumCh * nNumVFATPerEta);
+  mapDigiOccPerCh_.SetBinConfX(nNumCh * nNumVFATPerEta, -0.5);
   mapDigiOccPerCh_.SetBinConfY(stationInfo.nNumEtaPartitions_);
   mapDigiOccPerCh_.bookND(bh, key);
   mapDigiOccPerCh_.SetLabelForIEta(key, 2);


### PR DESCRIPTION
#### PR description:
A binning of some plots is changed; the range of indices of GEM digis is 0-383 currently, while the binning in the previous version covers 1-384, related to #35733.

Also, some namings have been changed, which is related to #35690.

#### PR validation:
Test are done and one can check again by `runTheMatrix` workflows

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
This is a backport of #35690 and #35733 to CMSSW_12_0_X to be deployed on the upcoming runs

@jshlee @watson-ij 