### PR TITLE
Changes to accommodate Splash events in ECAL DQM [CMSSW_12_0_X]

### DIFF
--- a/DQM/EcalMonitorTasks/interface/TimingTask.h
+++ b/DQM/EcalMonitorTasks/interface/TimingTask.h
@@ -33,6 +33,7 @@ namespace ecaldqm {
     float energyThresholdEEFwd_;
     float timingVsBXThreshold_;
     float timeErrorThreshold_;
+    bool splashSwitch_;
 
     MESet* meTimeMapByLS;
   };

--- a/DQM/EcalMonitorTasks/python/TimingTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/TimingTask_cfi.py
@@ -46,7 +46,8 @@ ecalTimingTask = cms.untracked.PSet(
         energyThresholdEEFwd = cms.untracked.double(energyThresholdEEFwd),
         energyThresholdEB = cms.untracked.double(energyThresholdEB),
         timingVsBXThreshold = cms.untracked.double(timingVsBXThreshold),
-        timeErrorThreshold = cms.untracked.double(timeErrorThreshold)
+        timeErrorThreshold = cms.untracked.double(timeErrorThreshold),
+        splashSwitch = cms.untracked.bool(False)
     ),
     MEs = cms.untracked.PSet(
         TimeMap = cms.untracked.PSet(

--- a/DQM/EcalMonitorTasks/src/TimingTask.cc
+++ b/DQM/EcalMonitorTasks/src/TimingTask.cc
@@ -33,6 +33,7 @@ namespace ecaldqm {
     energyThresholdEEFwd_ = _params.getUntrackedParameter<double>("energyThresholdEEFwd");
     timingVsBXThreshold_ = _params.getUntrackedParameter<double>("timingVsBXThreshold");
     timeErrorThreshold_ = _params.getUntrackedParameter<double>("timeErrorThreshold");
+    splashSwitch_ = _params.getUntrackedParameter<bool>("splashSwitch");
   }
 
   bool TimingTask::filterRunType(short const* _runType) {
@@ -80,18 +81,12 @@ namespace ecaldqm {
       float time(hit.time());
       float energy(hit.energy());
 
-      float chi2Threshold, energyThreshold;
+      float energyThreshold;
       if (id.subdetId() == EcalBarrel) {
-        chi2Threshold = chi2ThresholdEB_;
         energyThreshold = energyThresholdEB_;
-      } else {
-        chi2Threshold = chi2ThresholdEE_;
-        energyThreshold = (isForward(id)) ? energyThresholdEEFwd_ : energyThresholdEE_;
-      }
-
-      if (id.subdetId() == EcalBarrel)
         signedSubdet = EcalBarrel;
-      else {
+      } else {
+        energyThreshold = (isForward(id)) ? energyThresholdEEFwd_ : energyThresholdEE_;
         EEDetId eeId(hit.id());
         if (eeId.zside() < 0)
           signedSubdet = -EcalEndcap;
@@ -102,10 +97,17 @@ namespace ecaldqm {
       if (energy > energyThreshold)
         meChi2.fill(getEcalDQMSetupObjects(), signedSubdet, hit.chi2());
 
-      // Apply cut on chi2 of pulse shape fit
-      if (hit.chi2() > chi2Threshold)
-        return;
+      if (!splashSwitch_) {  //Not applied for splash events
+        float chi2Threshold;
+        if (id.subdetId() == EcalBarrel)
+          chi2Threshold = chi2ThresholdEB_;
+        else
+          chi2Threshold = chi2ThresholdEE_;
 
+        //Apply cut on chi2 of pulse shape fit
+        if (hit.chi2() > chi2Threshold)
+          return;
+      }
       // Apply cut based on timing error of rechit
       if (hit.timeError() > timeErrorThreshold_)
         return;

--- a/DQM/Integration/python/clients/ecal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ecal_dqm_sourceclient-live_cfg.py
@@ -16,7 +16,7 @@ if unitTest:
     from DQM.Integration.config.unittestinputsource_cfi import options
 else:
     process.load("DQM.Integration.config.inputsource_cfi")
-    from DQM.Integration.config.inputsource_cfi import options
+    from DQM.Integration.config.inputsource_cfi import options, set_BeamSplashRun_settings
 
 process.load("DQM.Integration.config.environment_cfi")
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
@@ -87,6 +87,34 @@ process.MessageLogger = cms.Service("MessageLogger",
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(-1)
 )
+if not unitTest:
+  if options.BeamSplashRun:
+      set_BeamSplashRun_settings( process.source )
+      process.ecalMonitorTask.workerParameters.TimingTask.params.splashSwitch = True
+      process.ecalMonitorTask.workerParameters.TimingTask.MEs.TimeMap.zaxis.high = cms.untracked.double(30.)
+      process.ecalMonitorTask.workerParameters.TimingTask.MEs.TimeMap.zaxis.low = cms.untracked.double(-30.)
+      process.ecalMonitorTask.workerParameters.TimingTask.MEs.TimeMapByLS.zaxis.high = cms.untracked.double(30.)
+      process.ecalMonitorTask.workerParameters.TimingTask.MEs.TimeMapByLS.zaxis.low = cms.untracked.double(-30.)
+      process.ecalMonitorTask.workerParameters.TimingTask.MEs.TimeAll.xaxis.high = cms.untracked.double(30.)
+      process.ecalMonitorTask.workerParameters.TimingTask.MEs.TimeAll.xaxis.low = cms.untracked.double(-30.)
+      process.ecalMonitorTask.workerParameters.TimingTask.MEs.Time1D.xaxis.high = cms.untracked.double(30.)
+      process.ecalMonitorTask.workerParameters.TimingTask.MEs.Time1D.xaxis.low = cms.untracked.double(-30.)
+      process.ecalMonitorTask.workerParameters.TimingTask.MEs.TimeAllMap.zaxis.high = cms.untracked.double(25.)
+      process.ecalMonitorTask.workerParameters.TimingTask.MEs.TimeAllMap.zaxis.low = cms.untracked.double(-25.)
+      process.ecalMonitorTask.workerParameters.TimingTask.params.chi2ThresholdEE = cms.untracked.double(1000.)
+      process.ecalMonitorTask.workerParameters.TimingTask.params.chi2ThresholdEB = cms.untracked.double(1000.)
+
+      process.ecalMonitorClient.workerParameters.TimingClient.MEs.FwdvBkwd.yaxis.high = cms.untracked.double(30.)
+      process.ecalMonitorClient.workerParameters.TimingClient.MEs.FwdvBkwd.yaxis.low = cms.untracked.double(-30.)
+      process.ecalMonitorClient.workerParameters.TimingClient.MEs.FwdvBkwd.xaxis.high = cms.untracked.double(30.)
+      process.ecalMonitorClient.workerParameters.TimingClient.MEs.FwdvBkwd.xaxis.low = cms.untracked.double(-30.)
+      process.ecalMonitorClient.workerParameters.TimingClient.MEs.FwdBkwdDiff.xaxis.high = cms.untracked.double(25.)
+      process.ecalMonitorClient.workerParameters.TimingClient.MEs.FwdBkwdDiff.xaxis.low = cms.untracked.double(-25.)
+      process.ecalMonitorClient.workerParameters.TimingClient.MEs.MeanSM.xaxis.high = cms.untracked.double(30.)
+      process.ecalMonitorClient.workerParameters.TimingClient.MEs.MeanSM.xaxis.low = cms.untracked.double(-30.)
+      process.ecalMonitorClient.workerParameters.TimingClient.MEs.MeanAll.xaxis.high = cms.untracked.double(30.)
+      process.ecalMonitorClient.workerParameters.TimingClient.MEs.MeanAll.xaxis.low = cms.untracked.double(-30.)
+      process.ecalMonitorClient.workerParameters.TimingClient.params.minChannelEntries = cms.untracked.int32(0)
 
 process.ecalMonitorClient.verbosity = 0
 process.ecalMonitorClient.workers = ['IntegrityClient', 'OccupancyClient', 'PresampleClient', 'RawDataClient', 'TimingClient', 'SelectiveReadoutClient', 'TrigPrimClient', 'SummaryClient']


### PR DESCRIPTION
#### PR description:

During splash events, we often have very poor signal shapes. In addition, it is useful to view these events in a wider time window than the default configuration. This PR changes the timing windows and removes a chi-square constraint to make DQM more useful during splash events. This also adds an option `options.BeamSplashRun` to the ecal dqm client config to activate splash run mode in DQM, following the comment https://github.com/cms-sw/cmssw/pull/35734#issuecomment-946966467 

#### PR validation:

Validated by the standard Ecal DQM configuration by manually setting `options.BeamSplashRun` to True and False and comparing the output plots. Results look as expected.
