### PR TITLE
Include new L1 trigger tags in Run-3 MC GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -66,17 +66,17 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak'     : '121X_upgrade2018cosmics_realistic_peak_v6',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'           : '121X_mcRun3_2021_design_v10',
+    'phase1_2021_design'           : '121X_mcRun3_2021_design_v11',
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'        : '121X_mcRun3_2021_realistic_v12',
+    'phase1_2021_realistic'        : '121X_mcRun3_2021_realistic_v13',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'          : '121X_mcRun3_2021cosmics_realistic_deco_v12',
+    'phase1_2021_cosmics'          : '121X_mcRun3_2021cosmics_realistic_deco_v13',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi'     : '121X_mcRun3_2021_realistic_HI_v12',
+    'phase1_2021_realistic_hi'     : '121X_mcRun3_2021_realistic_HI_v13',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '121X_mcRun3_2023_realistic_v11',
+    'phase1_2023_realistic'        : '121X_mcRun3_2023_realistic_v12',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '121X_mcRun3_2024_realistic_v11',
+    'phase1_2024_realistic'        : '121X_mcRun3_2024_realistic_v12',
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             : '121X_mcRun4_realistic_v6'
 }


### PR DESCRIPTION
#### PR description:

Include new L1 trigger tags in Run-3 MC GTs as requested in [0]. The validations were requested with RelVals and they came back positive [1,2], so I've created new GTs, and the diffs are:

* 121X_mcRun3_2021_design_v11
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021_design_v10/121X_mcRun3_2021_design_v11
* 121X_mcRun3_2021_realistic_v13
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021_realistic_v12/121X_mcRun3_2021_realistic_v13
* 121X_mcRun3_2021cosmics_realistic_deco_v13
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021cosmics_realistic_deco_v12/121X_mcRun3_2021cosmics_realistic_deco_v13
* 121X_mcRun3_2021_realistic_HI_v13
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021_realistic_HI_v12/121X_mcRun3_2021_realistic_HI_v13
* 121X_mcRun3_2023_realistic_v12
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2023_realistic_v11/121X_mcRun3_2023_realistic_v12
* 121X_mcRun3_2024_realistic_v12
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2024_realistic_v11/121X_mcRun3_2024_realistic_v12

[0] https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4471/1/1.html
[1] https://its.cern.ch/jira/browse/PDMVRELVALS-133
[2] https://indico.cern.ch/event/1088598/#10-l1t-ugmt-tag-update-validat

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
