### PR TITLE
Fix concurrent lumi usage in DQMStore [12_0]

### DIFF
--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -563,6 +563,14 @@ namespace dqm::implementation {
       auto other = this->findME(me);
       if (other) {
         // we still have a global one, so we can just remove this.
+        for (auto& locals : localMEs_) {
+          auto itLocal = locals.second.find(me);
+          if (itLocal != locals.second.end() and (*itLocal)->mutable_ == me->mutable_) {
+            debugTrackME("cleanupLumi (switchData)", *itLocal, me);
+            (*itLocal)->switchData(other);
+            break;
+          }
+        }
         debugTrackME("cleanupLumi (delete)", nullptr, me);
         delete me;
       } else {


### PR DESCRIPTION
#### PR description:

Avoid deleting the MonitorElement meta data for localMEs.
Backport of #35751.

#### PR validation:
Code compiles and simple job which was failing before now succeeds. Also varified with valgrind.
