### PR TITLE
Add intermediate bosons to LHE collection in nanoAOD

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/LHETablesProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/LHETablesProducer.cc
@@ -70,7 +70,7 @@ public:
     for (unsigned int i = 0, n = pup.size(); i < n; ++i) {
       int status = hepeup.ISTUP[i];
       int idabs = std::abs(hepeup.IDUP[i]);
-      if (status == 1 || status == -1) {
+      if (status == 1 || status == -1 || (status == 2 && (idabs >= 23 && idabs <= 25))) {
         TLorentzVector p4(pup[i][0], pup[i][1], pup[i][2], pup[i][3]);  // x,y,z,t
         vals_pid.push_back(hepeup.IDUP[i]);
         vals_spin.push_back(hepeup.SPINUP[i]);


### PR DESCRIPTION
#### PR description:
Add intermediate bosons (Z, W, H) in the LHE table in nanoAOD, which are currently missing since they have status=2.

#### PR validation:
Checked that it works on a few different samples including intermediate bosons (ZH, TT). 
This change adds typically 1 item/evt to the LHEPart collection in samples with intermediate bosons. b/item is typically around 9, so the size increase is negligible (~a few permill of total size, and only for some specific samples).
