### PR TITLE
Use shared_ptr for MutableMonitorElementData

### DIFF
--- a/DQMServices/Core/interface/MonitorElement.h
+++ b/DQMServices/Core/interface/MonitorElement.h
@@ -26,6 +26,7 @@
 #include "TAxis.h"
 
 #include <mutex>
+#include <memory>
 #include <string>
 #include <atomic>
 #include <sstream>
@@ -136,9 +137,8 @@ namespace dqm::impl {
     };
 
   private:
-    MutableMonitorElementData *mutable_;  // only set if this is a mutable copy of this ME
+    std::shared_ptr<MutableMonitorElementData> mutable_;  // only set if this is a mutable copy of this ME
     // there are no immutable MEs at this time, but we might need them in the future.
-    bool is_owned_;  // true if we are responsible for deleting the mutable object.
     /** 
      * To do anything to the MEs data, one needs to obtain an access object.
      * This object will contain the lock guard if one is needed. We differentiate
@@ -176,7 +176,7 @@ namespace dqm::impl {
     // new ME. The new ME will own this data.
     MonitorElement(MonitorElementData &&data);
     // Create new ME and take ownership of this data.
-    MonitorElement(MutableMonitorElementData *data);
+    MonitorElement(std::shared_ptr<MutableMonitorElementData> data);
     // Create a new ME sharing data with this existing ME.
     MonitorElement(MonitorElement *me);
 
@@ -184,13 +184,13 @@ namespace dqm::impl {
     // is owned by the returned value.
     MonitorElementData cloneMEData();
 
-    // Remove access and ownership to the data. The flag is used for a sanity check.
-    MutableMonitorElementData *release(bool expectOwned);
+    // Remove access to the data.
+    std::shared_ptr<MutableMonitorElementData> release();
 
     // re-initialize this ME as a shared copy of the other.
     void switchData(MonitorElement *other);
     // re-initialize taking ownership of this data.
-    void switchData(MutableMonitorElementData *data);
+    void switchData(std::shared_ptr<MutableMonitorElementData> data);
 
     // Replace the ROOT object in this ME's data with the new object, taking
     // ownership. The old object is deleted.

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -338,7 +338,7 @@ namespace dqm::implementation {
       MonitorElement* oldme = *proto;
       assert(oldme->getScope() == key.scope_);
       prototypes.erase(proto);
-      auto medata = oldme->release(/* expectOwned */ true);  // destroy the ME, get its data.
+      auto medata = oldme->release();  // destroy the ME, get its data.
       // in this situation, nobody should be filling the ME concurrently.
       medata->data_.key_.id_ = key.id_;
       // We reuse the ME object here, even if we don't have to. This ensures
@@ -408,7 +408,7 @@ namespace dqm::implementation {
           // reuse that.
           MonitorElement* oldme = *proto;
           prototypes.erase(proto);
-          auto medata = oldme->release(/* expectOwned */ true);  // destroy the ME, get its data.
+          auto medata = oldme->release();  // destroy the ME, get its data.
           // in this situation, nobody should be filling the ME concurrently.
           medata->data_.key_.id_ = edm::LuminosityBlockID(run, lumi);
           // We reuse the ME object here, even if we don't have to. This ensures
@@ -518,7 +518,7 @@ namespace dqm::implementation {
       if (me->isValid() && checkScope(me->getScope()) == true) {
         // if we left the scope, simply release the data.
         debugTrackME("leaveLumi (release)", me, nullptr);
-        me->release(/* expectOwned */ false);
+        me->release();
       }
     }
   }
@@ -576,7 +576,7 @@ namespace dqm::implementation {
     meset.clear();
 
     for (MonitorElement* me : torecycle) {
-      auto medata = me->release(/* expectOwned */ true);  // destroy the ME, get its data.
+      auto medata = me->release();                        // destroy the ME, get its data.
       medata->data_.key_.id_ = edm::LuminosityBlockID();  // prototype
       // We reuse the ME object here, even if we don't have to. This ensures
       // that when running single-threaded without concurrent lumis/runs,


### PR DESCRIPTION
#### PR description:

Make sure DQMStore::localMEs_ never has stale pointer to the data. This avoids a crash when running with concurrent LuminosityBlocks with a DQMOneEDAnalyzer which has per lumi histograms.

This is an alternative to #35751.

#### PR validation:

Code compiles. A simple test which had failed now succeeds.

Resolves #35726