### PR TITLE
Phase2-hgx292 Bug fix for real partial wafer simulations in versions V15 and V16

### DIFF
--- a/Geometry/HGCalCommonData/data/hgcalCons/v15/hgcalCons.xml
+++ b/Geometry/HGCalCommonData/data/hgcalCons/v15/hgcalCons.xml
@@ -26,7 +26,7 @@
     <Parameter name="GeometryMode" value="HGCalGeometryMode::Hexagon8Module" eval="false"/>
     <Parameter name="LevelZSide"          value="3"/>
     <Parameter name="LevelTop"            value="9"/>
-    <Parameter name="LevelTop"            value="11"/>
+    <Parameter name="LevelTop"            value="12"/>
     <Parameter name="WaferThickness"      value="[hgcal:WaferThickness]"/>
     <Parameter name="WaferThickness"      value="[hgcal:WaferThickness]"/>
     <Parameter name="WaferThickness"      value="[hgcal:WaferThickness]"/>
@@ -88,7 +88,7 @@
     <Parameter name="GeometryMode" value="HGCalGeometryMode::Hexagon8Module" eval="false"/>
     <Parameter name="LevelZSide"          value="3"/>
     <Parameter name="LevelTop"            value="9"/>
-    <Parameter name="LevelTop"            value="11"/>
+    <Parameter name="LevelTop"            value="12"/>
     <Parameter name="WaferThickness"      value="[hgcal:WaferThickness]"/>
     <Parameter name="WaferThickness"      value="[hgcal:WaferThickness]"/>
     <Parameter name="WaferThickness"      value="[hgcal:WaferThickness]"/>

--- a/Geometry/HGCalCommonData/data/hgcalCons/v16/hgcalCons.xml
+++ b/Geometry/HGCalCommonData/data/hgcalCons/v16/hgcalCons.xml
@@ -27,7 +27,7 @@
     <Parameter name="GeometryMode" value="HGCalGeometryMode::Hexagon8Module" eval="false"/>
     <Parameter name="LevelZSide"          value="3"/>
     <Parameter name="LevelTop"            value="9"/>
-    <Parameter name="LevelTop"            value="11"/>
+    <Parameter name="LevelTop"            value="12"/>
     <Parameter name="WaferThickness"      value="[hgcal:WaferThicknessFine]"/>
     <Parameter name="WaferThickness"      value="[hgcal:WaferThicknessCoarse1]"/>
     <Parameter name="WaferThickness"      value="[hgcal:WaferThicknessCoarse2]"/>
@@ -89,7 +89,7 @@
     <Parameter name="GeometryMode" value="HGCalGeometryMode::Hexagon8Module" eval="false"/>
     <Parameter name="LevelZSide"          value="3"/>
     <Parameter name="LevelTop"            value="9"/>
-    <Parameter name="LevelTop"            value="11"/>
+    <Parameter name="LevelTop"            value="12"/>
     <Parameter name="WaferThickness"      value="[hgcal:WaferThicknessFine]"/>
     <Parameter name="WaferThickness"      value="[hgcal:WaferThicknessCoarse1]"/>
     <Parameter name="WaferThickness"      value="[hgcal:WaferThicknessCoarse2]"/>

--- a/Geometry/HGCalCommonData/data/hgcalcell/v15/hgcalcell.xml
+++ b/Geometry/HGCalCommonData/data/hgcalcell/v15/hgcalcell.xml
@@ -21,27 +21,27 @@
     <Numeric name="PosSensitive" value="0"/>
     <String name="Material"      value="materials:Silicon"/>
     <String name="FullCell"      value="HGCalEECellFull0Fine"/>
-    <String name="FullSensitive" value="HGCalEESensitiveFull0Fine"/>
+    <String name="FullSensitive" value="HGCalEECellSensitiveFull0Fine"/>
     <Vector name="TruncatedCell" type="string" nEntries="3">
        HGCalEECellTrunc01Fine, HGCalEECellTrunc02Fine,
        HGCalEECellTrunc03Fine</Vector>
     <Vector name="TruncatedSensitive" type="string" nEntries="3">
-      HGCalEESensitiveTrunc01Fine, HGCalEESensitiveTrunc02Fine,
-      HGCalEESensitiveTrunc03Fine</Vector>
+      HGCalEECellSensitiveTrunc01Fine, HGCalEECellSensitiveTrunc02Fine,
+      HGCalEECellSensitiveTrunc03Fine</Vector>
     <Vector name="ExtendedCell" type="string" nEntries="3">
        HGCalEECellExten01Fine, HGCalEECellExten02Fine,
        HGCalEECellExten03Fine</Vector>
     <Vector name="ExtendedSensitive" type="string" nEntries="3">
-      HGCalEESensitiveExten01Fine, HGCalEESensitiveExten02Fine,
-      HGCalEESensitiveExten03Fine</Vector>
+      HGCalEECellSensitiveExten01Fine, HGCalEECellSensitiveExten02Fine,
+      HGCalEECellSensitiveExten03Fine</Vector>
     <Vector name="CornerCell" type="string" nEntries="6">
        HGCalEECellCorner01Fine, HGCalEECellCorner02Fine,
        HGCalEECellCorner03Fine, HGCalEECellCorner04Fine,
        HGCalEECellCorner05Fine, HGCalEECellCorner06Fine</Vector>
     <Vector name="CornerSensitive" type="string" nEntries="6">
-      HGCalEESensitiveCorner01Fine, HGCalEESensitiveCorner02Fine,
-      HGCalEESensitiveCorner03Fine, HGCalEESensitiveCorner04Fine,
-      HGCalEESensitiveCorner05Fine, HGCalEESensitiveCorner06Fine</Vector>
+      HGCalEECellSensitiveCorner01Fine, HGCalEECellSensitiveCorner02Fine,
+      HGCalEECellSensitiveCorner03Fine, HGCalEECellSensitiveCorner04Fine,
+      HGCalEECellSensitiveCorner05Fine, HGCalEECellSensitiveCorner06Fine</Vector>
   </Algorithm>
   <Algorithm name="hgcal:DDHGCalCell">
     <rParent name="hgcalwafer:HGCalCell"/>
@@ -52,27 +52,27 @@
     <Numeric name="PosSensitive" value="1"/>
     <String name="Material"      value="materials:Silicon"/>
     <String name="FullCell"      value="HGCalEECellFull1Fine"/>
-    <String name="FullSensitive" value="HGCalEESensitiveFull1Fine"/>
+    <String name="FullSensitive" value="HGCalEECellSensitiveFull1Fine"/>
     <Vector name="TruncatedCell" type="string" nEntries="3">
        HGCalEECellTrunc11Fine, HGCalEECellTrunc12Fine,
        HGCalEECellTrunc13Fine</Vector>
     <Vector name="TruncatedSensitive" type="string" nEntries="3">
-      HGCalEESensitiveTrunc11Fine, HGCalEESensitiveTrunc12Fine,
-      HGCalEESensitiveTrunc13Fine</Vector>
+      HGCalEECellSensitiveTrunc11Fine, HGCalEECellSensitiveTrunc12Fine,
+      HGCalEECellSensitiveTrunc13Fine</Vector>
     <Vector name="ExtendedCell" type="string" nEntries="3">
        HGCalEECellExten11Fine, HGCalEECellExten12Fine,
        HGCalEECellExten13Fine</Vector>
     <Vector name="ExtendedSensitive" type="string" nEntries="3">
-      HGCalEESensitiveExten11Fine, HGCalEESensitiveExten12Fine,
-      HGCalEESensitiveExten13Fine</Vector>
+      HGCalEECellSensitiveExten11Fine, HGCalEECellSensitiveExten12Fine,
+      HGCalEECellSensitiveExten13Fine</Vector>
     <Vector name="CornerCell" type="string" nEntries="6">
        HGCalEECellCorner11Fine, HGCalEECellCorner12Fine,
        HGCalEECellCorner13Fine, HGCalEECellCorner14Fine,
        HGCalEECellCorner15Fine, HGCalEECellCorner16Fine</Vector>
     <Vector name="CornerSensitive" type="string" nEntries="6">
-      HGCalEESensitiveCorner11Fine, HGCalEESensitiveCorner12Fine,
-      HGCalEESensitiveCorner13Fine, HGCalEESensitiveCorner14Fine,
-      HGCalEESensitiveCorner15Fine, HGCalEESensitiveCorner16Fine</Vector>
+      HGCalEECellSensitiveCorner11Fine, HGCalEECellSensitiveCorner12Fine,
+      HGCalEECellSensitiveCorner13Fine, HGCalEECellSensitiveCorner14Fine,
+      HGCalEECellSensitiveCorner15Fine, HGCalEECellSensitiveCorner16Fine</Vector>
   </Algorithm>
   <Algorithm name="hgcal:DDHGCalCell">
     <rParent name="hgcalwafer:HGCalCell"/>
@@ -83,27 +83,27 @@
     <Numeric name="PosSensitive" value="0"/>
     <String name="Material"      value="materials:Silicon"/>
     <String name="FullCell"      value="HGCalEECellFull0Coarse1"/>
-    <String name="FullSensitive" value="HGCalEESensitiveFull0Coarse1"/>
+    <String name="FullSensitive" value="HGCalEECellSensitiveFull0Coarse1"/>
     <Vector name="TruncatedCell" type="string" nEntries="3">
        HGCalEECellTrunc01Coarse1, HGCalEECellTrunc02Coarse1,
        HGCalEECellTrunc03Coarse1</Vector>
     <Vector name="TruncatedSensitive" type="string" nEntries="3">
-      HGCalEESensitiveTrunc01Coarse1, HGCalEESensitiveTrunc02Coarse1,
-      HGCalEESensitiveTrunc03Coarse1</Vector>
+      HGCalEECellSensitiveTrunc01Coarse1, HGCalEECellSensitiveTrunc02Coarse1,
+      HGCalEECellSensitiveTrunc03Coarse1</Vector>
     <Vector name="ExtendedCell" type="string" nEntries="3">
        HGCalEECellExten01Coarse1, HGCalEECellExten02Coarse1,
        HGCalEECellExten03Coarse1</Vector>
     <Vector name="ExtendedSensitive" type="string" nEntries="3">
-      HGCalEESensitiveExten01Coarse1, HGCalEESensitiveExten02Coarse1,
-      HGCalEESensitiveExten03Coarse1</Vector>
+      HGCalEECellSensitiveExten01Coarse1, HGCalEECellSensitiveExten02Coarse1,
+      HGCalEECellSensitiveExten03Coarse1</Vector>
     <Vector name="CornerCell" type="string" nEntries="6">
        HGCalEECellCorner01Coarse1, HGCalEECellCorner02Coarse1,
        HGCalEECellCorner03Coarse1, HGCalEECellCorner04Coarse1,
        HGCalEECellCorner05Coarse1, HGCalEECellCorner06Coarse1</Vector>
     <Vector name="CornerSensitive" type="string" nEntries="6">
-      HGCalEESensitiveCorner01Coarse1, HGCalEESensitiveCorner02Coarse1,
-      HGCalEESensitiveCorner03Coarse1, HGCalEESensitiveCorner04Coarse1,
-      HGCalEESensitiveCorner05Coarse1, HGCalEESensitiveCorner06Coarse1</Vector>
+      HGCalEECellSensitiveCorner01Coarse1, HGCalEECellSensitiveCorner02Coarse1,
+      HGCalEECellSensitiveCorner03Coarse1, HGCalEECellSensitiveCorner04Coarse1,
+      HGCalEECellSensitiveCorner05Coarse1, HGCalEECellSensitiveCorner06Coarse1</Vector>
   </Algorithm>
   <Algorithm name="hgcal:DDHGCalCell">
     <rParent name="hgcalwafer:HGCalCell"/>
@@ -114,27 +114,27 @@
     <Numeric name="PosSensitive" value="1"/>
     <String name="Material"      value="materials:Silicon"/>
     <String name="FullCell"      value="HGCalEECellFull1Coarse1"/>
-    <String name="FullSensitive" value="HGCalEESensitiveFull1Coarse1"/>
+    <String name="FullSensitive" value="HGCalEECellSensitiveFull1Coarse1"/>
     <Vector name="TruncatedCell" type="string" nEntries="3">
        HGCalEECellTrunc11Coarse1, HGCalEECellTrunc12Coarse1,
        HGCalEECellTrunc13Coarse1</Vector>
     <Vector name="TruncatedSensitive" type="string" nEntries="3">
-      HGCalEESensitiveTrunc11Coarse1, HGCalEESensitiveTrunc12Coarse1,
-      HGCalEESensitiveTrunc13Coarse1</Vector>
+      HGCalEECellSensitiveTrunc11Coarse1, HGCalEECellSensitiveTrunc12Coarse1,
+      HGCalEECellSensitiveTrunc13Coarse1</Vector>
     <Vector name="ExtendedCell" type="string" nEntries="3">
        HGCalEECellExten11Coarse1, HGCalEECellExten12Coarse1,
        HGCalEECellExten13Coarse1</Vector>
     <Vector name="ExtendedSensitive" type="string" nEntries="3">
-      HGCalEESensitiveExten11Coarse1, HGCalEESensitiveExten12Coarse1,
-      HGCalEESensitiveExten13Coarse1</Vector>
+      HGCalEECellSensitiveExten11Coarse1, HGCalEECellSensitiveExten12Coarse1,
+      HGCalEECellSensitiveExten13Coarse1</Vector>
     <Vector name="CornerCell" type="string" nEntries="6">
        HGCalEECellCorner11Coarse1, HGCalEECellCorner12Coarse1,
        HGCalEECellCorner13Coarse1, HGCalEECellCorner14Coarse1,
        HGCalEECellCorner15Coarse1, HGCalEECellCorner16Coarse1</Vector>
     <Vector name="CornerSensitive" type="string" nEntries="6">
-      HGCalEESensitiveCorner11Coarse1, HGCalEESensitiveCorner12Coarse1,
-      HGCalEESensitiveCorner13Coarse1, HGCalEESensitiveCorner14Coarse1,
-      HGCalEESensitiveCorner15Coarse1, HGCalEESensitiveCorner16Coarse1</Vector>
+      HGCalEECellSensitiveCorner11Coarse1, HGCalEECellSensitiveCorner12Coarse1,
+      HGCalEECellSensitiveCorner13Coarse1, HGCalEECellSensitiveCorner14Coarse1,
+      HGCalEECellSensitiveCorner15Coarse1, HGCalEECellSensitiveCorner16Coarse1</Vector>
   </Algorithm>
   <Algorithm name="hgcal:DDHGCalCell">
     <rParent name="hgcalwafer:HGCalCell"/>
@@ -145,27 +145,27 @@
     <Numeric name="PosSensitive" value="0"/>
     <String name="Material"      value="materials:Silicon"/>
     <String name="FullCell"      value="HGCalEECellFull0Coarse2"/>
-    <String name="FullSensitive" value="HGCalEESensitiveFull0Coarse2"/>
+    <String name="FullSensitive" value="HGCalEECellSensitiveFull0Coarse2"/>
     <Vector name="TruncatedCell" type="string" nEntries="3">
        HGCalEECellTrunc01Coarse2, HGCalEECellTrunc02Coarse2,
        HGCalEECellTrunc03Coarse2</Vector>
     <Vector name="TruncatedSensitive" type="string" nEntries="3">
-      HGCalEESensitiveTrunc01Coarse2, HGCalEESensitiveTrunc02Coarse2,
-      HGCalEESensitiveTrunc03Coarse2</Vector>
+      HGCalEECellSensitiveTrunc01Coarse2, HGCalEECellSensitiveTrunc02Coarse2,
+      HGCalEECellSensitiveTrunc03Coarse2</Vector>
     <Vector name="ExtendedCell" type="string" nEntries="3">
        HGCalEECellExten01Coarse2, HGCalEECellExten02Coarse2,
        HGCalEECellExten03Coarse2</Vector>
     <Vector name="ExtendedSensitive" type="string" nEntries="3">
-      HGCalEESensitiveExten01Coarse2, HGCalEESensitiveExten02Coarse2,
-      HGCalEESensitiveExten03Coarse2</Vector>
+      HGCalEECellSensitiveExten01Coarse2, HGCalEECellSensitiveExten02Coarse2,
+      HGCalEECellSensitiveExten03Coarse2</Vector>
     <Vector name="CornerCell" type="string" nEntries="6">
        HGCalEECellCorner01Coarse2, HGCalEECellCorner02Coarse2,
        HGCalEECellCorner03Coarse2, HGCalEECellCorner04Coarse2,
        HGCalEECellCorner05Coarse2, HGCalEECellCorner06Coarse2</Vector>
     <Vector name="CornerSensitive" type="string" nEntries="6">
-      HGCalEESensitiveCorner01Coarse2, HGCalEESensitiveCorner02Coarse2,
-      HGCalEESensitiveCorner03Coarse2, HGCalEESensitiveCorner04Coarse2,
-      HGCalEESensitiveCorner05Coarse2, HGCalEESensitiveCorner06Coarse2</Vector>
+      HGCalEECellSensitiveCorner01Coarse2, HGCalEECellSensitiveCorner02Coarse2,
+      HGCalEECellSensitiveCorner03Coarse2, HGCalEECellSensitiveCorner04Coarse2,
+      HGCalEECellSensitiveCorner05Coarse2, HGCalEECellSensitiveCorner06Coarse2</Vector>
   </Algorithm>
   <Algorithm name="hgcal:DDHGCalCell">
     <rParent name="hgcalwafer:HGCalCell"/>
@@ -176,27 +176,27 @@
     <Numeric name="PosSensitive" value="1"/>
     <String name="Material"      value="materials:Silicon"/>
     <String name="FullCell"      value="HGCalEECellFull1Coarse2"/>
-    <String name="FullSensitive" value="HGCalEESensitiveFull1Coarse2"/>
+    <String name="FullSensitive" value="HGCalEECellSensitiveFull1Coarse2"/>
     <Vector name="TruncatedCell" type="string" nEntries="3">
        HGCalEECellTrunc11Coarse2, HGCalEECellTrunc12Coarse2,
        HGCalEECellTrunc13Coarse2</Vector>
     <Vector name="TruncatedSensitive" type="string" nEntries="3">
-      HGCalEESensitiveTrunc11Coarse2, HGCalEESensitiveTrunc12Coarse2,
-      HGCalEESensitiveTrunc13Coarse2</Vector>
+      HGCalEECellSensitiveTrunc11Coarse2, HGCalEECellSensitiveTrunc12Coarse2,
+      HGCalEECellSensitiveTrunc13Coarse2</Vector>
     <Vector name="ExtendedCell" type="string" nEntries="3">
        HGCalEECellExten11Coarse2, HGCalEECellExten12Coarse2,
        HGCalEECellExten13Coarse2</Vector>
     <Vector name="ExtendedSensitive" type="string" nEntries="3">
-      HGCalEESensitiveExten11Coarse2, HGCalEESensitiveExten12Coarse2,
-      HGCalEESensitiveExten13Coarse2</Vector>
+      HGCalEECellSensitiveExten11Coarse2, HGCalEECellSensitiveExten12Coarse2,
+      HGCalEECellSensitiveExten13Coarse2</Vector>
     <Vector name="CornerCell" type="string" nEntries="6">
        HGCalEECellCorner11Coarse2, HGCalEECellCorner12Coarse2,
        HGCalEECellCorner13Coarse2, HGCalEECellCorner14Coarse2,
        HGCalEECellCorner15Coarse2, HGCalEECellCorner16Coarse2</Vector>
     <Vector name="CornerSensitive" type="string" nEntries="6">
-      HGCalEESensitiveCorner11Coarse2, HGCalEESensitiveCorner12Coarse2,
-      HGCalEESensitiveCorner13Coarse2, HGCalEESensitiveCorner14Coarse2,
-      HGCalEESensitiveCorner15Coarse2, HGCalEESensitiveCorner16Coarse2</Vector>
+      HGCalEECellSensitiveCorner11Coarse2, HGCalEECellSensitiveCorner12Coarse2,
+      HGCalEECellSensitiveCorner13Coarse2, HGCalEECellSensitiveCorner14Coarse2,
+      HGCalEECellSensitiveCorner15Coarse2, HGCalEECellSensitiveCorner16Coarse2</Vector>
   </Algorithm>
   <Algorithm name="hgcal:DDHGCalCell">
     <rParent name="hgcalwafer:HGCalCell"/>
@@ -207,27 +207,27 @@
     <Numeric name="PosSensitive" value="0"/>
     <String name="Material"      value="materials:Silicon"/>
     <String name="FullCell"      value="HGCalHECellFull0Fine"/>
-    <String name="FullSensitive" value="HGCalHESiliconSensitiveFull0Fine"/>
+    <String name="FullSensitive" value="HGCalHESiliconCellSensitiveFull0Fine"/>
     <Vector name="TruncatedCell" type="string" nEntries="3">
        HGCalHECellTrunc01Fine, HGCalHECellTrunc02Fine,
        HGCalHECellTrunc03Fine</Vector>
     <Vector name="TruncatedSensitive" type="string" nEntries="3">
-      HGCalHESiliconSensitiveTrunc01Fine, HGCalHESiliconSensitiveTrunc02Fine,
-      HGCalHESiliconSensitiveTrunc03Fine</Vector>
+      HGCalHESiliconCellSensitiveTrunc01Fine, HGCalHESiliconCellSensitiveTrunc02Fine,
+      HGCalHESiliconCellSensitiveTrunc03Fine</Vector>
     <Vector name="ExtendedCell" type="string" nEntries="3">
        HGCalHECellExten01Fine, HGCalHECellExten02Fine,
        HGCalHECellExten03Fine</Vector>
     <Vector name="ExtendedSensitive" type="string" nEntries="3">
-      HGCalHESiliconSensitiveExten01Fine, HGCalHESiliconSensitiveExten02Fine,
-      HGCalHESiliconSensitiveExten03Fine</Vector>
+      HGCalHESiliconCellSensitiveExten01Fine, HGCalHESiliconCellSensitiveExten02Fine,
+      HGCalHESiliconCellSensitiveExten03Fine</Vector>
     <Vector name="CornerCell" type="string" nEntries="6">
        HGCalHECellCorner01Fine, HGCalHECellCorner02Fine,
        HGCalHECellCorner03Fine, HGCalHECellCorner04Fine,
        HGCalHECellCorner05Fine, HGCalHECellCorner06Fine</Vector>
     <Vector name="CornerSensitive" type="string" nEntries="6">
-      HGCalHESiliconSensitiveCorner01Fine, HGCalHESiliconSensitiveCorner02Fine,
-      HGCalHESiliconSensitiveCorner03Fine, HGCalHESiliconSensitiveCorner04Fine,
-      HGCalHESiliconSensitiveCorner05Fine, HGCalHESiliconSensitiveCorner06Fine</Vector>
+      HGCalHESiliconCellSensitiveCorner01Fine, HGCalHESiliconCellSensitiveCorner02Fine,
+      HGCalHESiliconCellSensitiveCorner03Fine, HGCalHESiliconCellSensitiveCorner04Fine,
+      HGCalHESiliconCellSensitiveCorner05Fine, HGCalHESiliconCellSensitiveCorner06Fine</Vector>
   </Algorithm>
   <Algorithm name="hgcal:DDHGCalCell">
     <rParent name="hgcalwafer:HGCalCell"/>
@@ -238,27 +238,27 @@
     <Numeric name="PosSensitive" value="0"/>
     <String name="Material"      value="materials:Silicon"/>
     <String name="FullCell"      value="HGCalHECellFull0Coarse1"/>
-    <String name="FullSensitive" value="HGCalHESiliconSensitiveFull0Coarse1"/>
+    <String name="FullSensitive" value="HGCalHESiliconCellSensitiveFull0Coarse1"/>
     <Vector name="TruncatedCell" type="string" nEntries="3">
        HGCalHECellTrunc01Coarse1, HGCalHECellTrunc02Coarse1,
        HGCalHECellTrunc03Coarse1</Vector>
     <Vector name="TruncatedSensitive" type="string" nEntries="3">
-      HGCalHESiliconSensitiveTrunc01Coarse1, HGCalHESiliconSensitiveTrunc02Coarse1,
-      HGCalHESiliconSensitiveTrunc03Coarse1</Vector>
+      HGCalHESiliconCellSensitiveTrunc01Coarse1, HGCalHESiliconCellSensitiveTrunc02Coarse1,
+      HGCalHESiliconCellSensitiveTrunc03Coarse1</Vector>
     <Vector name="ExtendedCell" type="string" nEntries="3">
        HGCalHECellExten01Coarse1, HGCalHECellExten02Coarse1,
        HGCalHECellExten03Coarse1</Vector>
     <Vector name="ExtendedSensitive" type="string" nEntries="3">
-      HGCalHESiliconSensitiveExten01Coarse1, HGCalHESiliconSensitiveExten02Coarse1,
-      HGCalHESiliconSensitiveExten03Coarse1</Vector>
+      HGCalHESiliconCellSensitiveExten01Coarse1, HGCalHESiliconCellSensitiveExten02Coarse1,
+      HGCalHESiliconCellSensitiveExten03Coarse1</Vector>
     <Vector name="CornerCell" type="string" nEntries="6">
        HGCalHECellCorner01Coarse1, HGCalHECellCorner02Coarse1,
        HGCalHECellCorner03Coarse1, HGCalHECellCorner04Coarse1,
        HGCalHECellCorner05Coarse1, HGCalHECellCorner06Coarse1</Vector>
     <Vector name="CornerSensitive" type="string" nEntries="6">
-      HGCalHESiliconSensitiveCorner01Coarse1, HGCalHESiliconSensitiveCorner02Coarse1,
-      HGCalHESiliconSensitiveCorner03Coarse1, HGCalHESiliconSensitiveCorner04Coarse1,
-      HGCalHESiliconSensitiveCorner05Coarse1, HGCalHESiliconSensitiveCorner06Coarse1</Vector>
+      HGCalHESiliconCellSensitiveCorner01Coarse1, HGCalHESiliconCellSensitiveCorner02Coarse1,
+      HGCalHESiliconCellSensitiveCorner03Coarse1, HGCalHESiliconCellSensitiveCorner04Coarse1,
+      HGCalHESiliconCellSensitiveCorner05Coarse1, HGCalHESiliconCellSensitiveCorner06Coarse1</Vector>
   </Algorithm>
   <Algorithm name="hgcal:DDHGCalCell">
     <rParent name="hgcalwafer:HGCalCell"/>
@@ -269,27 +269,27 @@
     <Numeric name="PosSensitive" value="0"/>
     <String name="Material"      value="materials:Silicon"/>
     <String name="FullCell"      value="HGCalHECellFull0Coarse2"/>
-    <String name="FullSensitive" value="HGCalHESiliconSensitiveFull0Coarse2"/>
+    <String name="FullSensitive" value="HGCalHESiliconCellSensitiveFull0Coarse2"/>
     <Vector name="TruncatedCell" type="string" nEntries="3">
        HGCalHECellTrunc01Coarse2, HGCalHECellTrunc02Coarse2,
        HGCalHECellTrunc03Coarse2</Vector>
     <Vector name="TruncatedSensitive" type="string" nEntries="3">
-      HGCalHESiliconSensitiveTrunc01Coarse2, HGCalHESiliconSensitiveTrunc02Coarse2,
-      HGCalHESiliconSensitiveTrunc03Coarse2</Vector>
+      HGCalHESiliconCellSensitiveTrunc01Coarse2, HGCalHESiliconCellSensitiveTrunc02Coarse2,
+      HGCalHESiliconCellSensitiveTrunc03Coarse2</Vector>
     <Vector name="ExtendedCell" type="string" nEntries="3">
        HGCalHECellExten01Coarse2, HGCalHECellExten02Coarse2,
        HGCalHECellExten03Coarse2</Vector>
     <Vector name="ExtendedSensitive" type="string" nEntries="3">
-      HGCalHESiliconSensitiveExten01Coarse2, HGCalHESiliconSensitiveExten02Coarse2,
-      HGCalHESiliconSensitiveExten03Coarse2</Vector>
+      HGCalHESiliconCellSensitiveExten01Coarse2, HGCalHESiliconCellSensitiveExten02Coarse2,
+      HGCalHESiliconCellSensitiveExten03Coarse2</Vector>
     <Vector name="CornerCell" type="string" nEntries="6">
        HGCalHECellCorner01Coarse2, HGCalHECellCorner02Coarse2,
        HGCalHECellCorner03Coarse2, HGCalHECellCorner04Coarse2,
        HGCalHECellCorner05Coarse2, HGCalHECellCorner06Coarse2</Vector>
     <Vector name="CornerSensitive" type="string" nEntries="6">
-      HGCalHESiliconSensitiveCorner01Coarse2, HGCalHESiliconSensitiveCorner02Coarse2,
-      HGCalHESiliconSensitiveCorner03Coarse2, HGCalHESiliconSensitiveCorner04Coarse2,
-      HGCalHESiliconSensitiveCorner05Coarse2, HGCalHESiliconSensitiveCorner06Coarse2</Vector>
+      HGCalHESiliconCellSensitiveCorner01Coarse2, HGCalHESiliconCellSensitiveCorner02Coarse2,
+      HGCalHESiliconCellSensitiveCorner03Coarse2, HGCalHESiliconCellSensitiveCorner04Coarse2,
+      HGCalHESiliconCellSensitiveCorner05Coarse2, HGCalHESiliconCellSensitiveCorner06Coarse2</Vector>
   </Algorithm>
 </PosPartSection>
 

--- a/Geometry/HGCalCommonData/data/hgcalcell/v16/hgcalcell.xml
+++ b/Geometry/HGCalCommonData/data/hgcalcell/v16/hgcalcell.xml
@@ -23,27 +23,27 @@
     <Numeric name="PosSensitive" value="0"/>
     <String name="Material"      value="materials:Silicon"/>
     <String name="FullCell"      value="HGCalEECellFull0Fine"/>
-    <String name="FullSensitive" value="HGCalEESensitiveFull0Fine"/>
+    <String name="FullSensitive" value="HGCalEECellSensitiveFull0Fine"/>
     <Vector name="TruncatedCell" type="string" nEntries="3">
        HGCalEECellTrunc01Fine, HGCalEECellTrunc02Fine,
        HGCalEECellTrunc03Fine</Vector>
     <Vector name="TruncatedSensitive" type="string" nEntries="3">
-      HGCalEESensitiveTrunc01Fine, HGCalEESensitiveTrunc02Fine,
-      HGCalEESensitiveTrunc03Fine</Vector>
+      HGCalEECellSensitiveTrunc01Fine, HGCalEECellSensitiveTrunc02Fine,
+      HGCalEECellSensitiveTrunc03Fine</Vector>
     <Vector name="ExtendedCell" type="string" nEntries="3">
        HGCalEECellExten01Fine, HGCalEECellExten02Fine,
        HGCalEECellExten03Fine</Vector>
     <Vector name="ExtendedSensitive" type="string" nEntries="3">
-      HGCalEESensitiveExten01Fine, HGCalEESensitiveExten02Fine,
-      HGCalEESensitiveExten03Fine</Vector>
+      HGCalEECellSensitiveExten01Fine, HGCalEECellSensitiveExten02Fine,
+      HGCalEECellSensitiveExten03Fine</Vector>
     <Vector name="CornerCell" type="string" nEntries="6">
        HGCalEECellCorner01Fine, HGCalEECellCorner02Fine,
        HGCalEECellCorner03Fine, HGCalEECellCorner04Fine,
        HGCalEECellCorner05Fine, HGCalEECellCorner06Fine</Vector>
     <Vector name="CornerSensitive" type="string" nEntries="6">
-      HGCalEESensitiveCorner01Fine, HGCalEESensitiveCorner02Fine,
-      HGCalEESensitiveCorner03Fine, HGCalEESensitiveCorner04Fine,
-      HGCalEESensitiveCorner05Fine, HGCalEESensitiveCorner06Fine</Vector>
+      HGCalEECellSensitiveCorner01Fine, HGCalEECellSensitiveCorner02Fine,
+      HGCalEECellSensitiveCorner03Fine, HGCalEECellSensitiveCorner04Fine,
+      HGCalEECellSensitiveCorner05Fine, HGCalEECellSensitiveCorner06Fine</Vector>
   </Algorithm>
   <Algorithm name="hgcal:DDHGCalCell">
     <rParent name="hgcalwafer:HGCalCell"/>
@@ -54,27 +54,27 @@
     <Numeric name="PosSensitive" value="1"/>
     <String name="Material"      value="materials:Silicon"/>
     <String name="FullCell"      value="HGCalEECellFull1Fine"/>
-    <String name="FullSensitive" value="HGCalEESensitiveFull1Fine"/>
+    <String name="FullSensitive" value="HGCalEECellSensitiveFull1Fine"/>
     <Vector name="TruncatedCell" type="string" nEntries="3">
        HGCalEECellTrunc11Fine, HGCalEECellTrunc12Fine,
        HGCalEECellTrunc13Fine</Vector>
     <Vector name="TruncatedSensitive" type="string" nEntries="3">
-      HGCalEESensitiveTrunc11Fine, HGCalEESensitiveTrunc12Fine,
-      HGCalEESensitiveTrunc13Fine</Vector>
+      HGCalEECellSensitiveTrunc11Fine, HGCalEECellSensitiveTrunc12Fine,
+      HGCalEECellSensitiveTrunc13Fine</Vector>
     <Vector name="ExtendedCell" type="string" nEntries="3">
        HGCalEECellExten11Fine, HGCalEECellExten12Fine,
        HGCalEECellExten13Fine</Vector>
     <Vector name="ExtendedSensitive" type="string" nEntries="3">
-      HGCalEESensitiveExten11Fine, HGCalEESensitiveExten12Fine,
-      HGCalEESensitiveExten13Fine</Vector>
+      HGCalEECellSensitiveExten11Fine, HGCalEECellSensitiveExten12Fine,
+      HGCalEECellSensitiveExten13Fine</Vector>
     <Vector name="CornerCell" type="string" nEntries="6">
        HGCalEECellCorner11Fine, HGCalEECellCorner12Fine,
        HGCalEECellCorner13Fine, HGCalEECellCorner14Fine,
        HGCalEECellCorner15Fine, HGCalEECellCorner16Fine</Vector>
     <Vector name="CornerSensitive" type="string" nEntries="6">
-      HGCalEESensitiveCorner11Fine, HGCalEESensitiveCorner12Fine,
-      HGCalEESensitiveCorner13Fine, HGCalEESensitiveCorner14Fine,
-      HGCalEESensitiveCorner15Fine, HGCalEESensitiveCorner16Fine</Vector>
+      HGCalEECellSensitiveCorner11Fine, HGCalEECellSensitiveCorner12Fine,
+      HGCalEECellSensitiveCorner13Fine, HGCalEECellSensitiveCorner14Fine,
+      HGCalEECellSensitiveCorner15Fine, HGCalEECellSensitiveCorner16Fine</Vector>
   </Algorithm>
   <Algorithm name="hgcal:DDHGCalCell">
     <rParent name="hgcalwafer:HGCalCell"/>
@@ -85,27 +85,27 @@
     <Numeric name="PosSensitive" value="0"/>
     <String name="Material"      value="materials:Silicon"/>
     <String name="FullCell"      value="HGCalEECellFull0Coarse1"/>
-    <String name="FullSensitive" value="HGCalEESensitiveFull0Coarse1"/>
+    <String name="FullSensitive" value="HGCalEECellSensitiveFull0Coarse1"/>
     <Vector name="TruncatedCell" type="string" nEntries="3">
        HGCalEECellTrunc01Coarse1, HGCalEECellTrunc02Coarse1,
        HGCalEECellTrunc03Coarse1</Vector>
     <Vector name="TruncatedSensitive" type="string" nEntries="3">
-      HGCalEESensitiveTrunc01Coarse1, HGCalEESensitiveTrunc02Coarse1,
-      HGCalEESensitiveTrunc03Coarse1</Vector>
+      HGCalEECellSensitiveTrunc01Coarse1, HGCalEECellSensitiveTrunc02Coarse1,
+      HGCalEECellSensitiveTrunc03Coarse1</Vector>
     <Vector name="ExtendedCell" type="string" nEntries="3">
        HGCalEECellExten01Coarse1, HGCalEECellExten02Coarse1,
        HGCalEECellExten03Coarse1</Vector>
     <Vector name="ExtendedSensitive" type="string" nEntries="3">
-      HGCalEESensitiveExten01Coarse1, HGCalEESensitiveExten02Coarse1,
-      HGCalEESensitiveExten03Coarse1</Vector>
+      HGCalEECellSensitiveExten01Coarse1, HGCalEECellSensitiveExten02Coarse1,
+      HGCalEECellSensitiveExten03Coarse1</Vector>
     <Vector name="CornerCell" type="string" nEntries="6">
        HGCalEECellCorner01Coarse1, HGCalEECellCorner02Coarse1,
        HGCalEECellCorner03Coarse1, HGCalEECellCorner04Coarse1,
        HGCalEECellCorner05Coarse1, HGCalEECellCorner06Coarse1</Vector>
     <Vector name="CornerSensitive" type="string" nEntries="6">
-      HGCalEESensitiveCorner01Coarse1, HGCalEESensitiveCorner02Coarse1,
-      HGCalEESensitiveCorner03Coarse1, HGCalEESensitiveCorner04Coarse1,
-      HGCalEESensitiveCorner05Coarse1, HGCalEESensitiveCorner06Coarse1</Vector>
+      HGCalEECellSensitiveCorner01Coarse1, HGCalEECellSensitiveCorner02Coarse1,
+      HGCalEECellSensitiveCorner03Coarse1, HGCalEECellSensitiveCorner04Coarse1,
+      HGCalEECellSensitiveCorner05Coarse1, HGCalEECellSensitiveCorner06Coarse1</Vector>
   </Algorithm>
   <Algorithm name="hgcal:DDHGCalCell">
     <rParent name="hgcalwafer:HGCalCell"/>
@@ -116,27 +116,27 @@
     <Numeric name="PosSensitive" value="1"/>
     <String name="Material"      value="materials:Silicon"/>
     <String name="FullCell"      value="HGCalEECellFull1Coarse1"/>
-    <String name="FullSensitive" value="HGCalEESensitiveFull1Coarse1"/>
+    <String name="FullSensitive" value="HGCalEECellSensitiveFull1Coarse1"/>
     <Vector name="TruncatedCell" type="string" nEntries="3">
        HGCalEECellTrunc11Coarse1, HGCalEECellTrunc12Coarse1,
        HGCalEECellTrunc13Coarse1</Vector>
     <Vector name="TruncatedSensitive" type="string" nEntries="3">
-      HGCalEESensitiveTrunc11Coarse1, HGCalEESensitiveTrunc12Coarse1,
-      HGCalEESensitiveTrunc13Coarse1</Vector>
+      HGCalEECellSensitiveTrunc11Coarse1, HGCalEECellSensitiveTrunc12Coarse1,
+      HGCalEECellSensitiveTrunc13Coarse1</Vector>
     <Vector name="ExtendedCell" type="string" nEntries="3">
        HGCalEECellExten11Coarse1, HGCalEECellExten12Coarse1,
        HGCalEECellExten13Coarse1</Vector>
     <Vector name="ExtendedSensitive" type="string" nEntries="3">
-      HGCalEESensitiveExten11Coarse1, HGCalEESensitiveExten12Coarse1,
-      HGCalEESensitiveExten13Coarse1</Vector>
+      HGCalEECellSensitiveExten11Coarse1, HGCalEECellSensitiveExten12Coarse1,
+      HGCalEECellSensitiveExten13Coarse1</Vector>
     <Vector name="CornerCell" type="string" nEntries="6">
        HGCalEECellCorner11Coarse1, HGCalEECellCorner12Coarse1,
        HGCalEECellCorner13Coarse1, HGCalEECellCorner14Coarse1,
        HGCalEECellCorner15Coarse1, HGCalEECellCorner16Coarse1</Vector>
     <Vector name="CornerSensitive" type="string" nEntries="6">
-      HGCalEESensitiveCorner11Coarse1, HGCalEESensitiveCorner12Coarse1,
-      HGCalEESensitiveCorner13Coarse1, HGCalEESensitiveCorner14Coarse1,
-      HGCalEESensitiveCorner15Coarse1, HGCalEESensitiveCorner16Coarse1</Vector>
+      HGCalEECellSensitiveCorner11Coarse1, HGCalEECellSensitiveCorner12Coarse1,
+      HGCalEECellSensitiveCorner13Coarse1, HGCalEECellSensitiveCorner14Coarse1,
+      HGCalEECellSensitiveCorner15Coarse1, HGCalEECellSensitiveCorner16Coarse1</Vector>
   </Algorithm>
   <Algorithm name="hgcal:DDHGCalCell">
     <rParent name="hgcalwafer:HGCalCell"/>
@@ -147,27 +147,27 @@
     <Numeric name="PosSensitive" value="0"/>
     <String name="Material"      value="materials:Silicon"/>
     <String name="FullCell"      value="HGCalEECellFull0Coarse2"/>
-    <String name="FullSensitive" value="HGCalEESensitiveFull0Coarse2"/>
+    <String name="FullSensitive" value="HGCalEECellSensitiveFull0Coarse2"/>
     <Vector name="TruncatedCell" type="string" nEntries="3">
        HGCalEECellTrunc01Coarse2, HGCalEECellTrunc02Coarse2,
        HGCalEECellTrunc03Coarse2</Vector>
     <Vector name="TruncatedSensitive" type="string" nEntries="3">
-      HGCalEESensitiveTrunc01Coarse2, HGCalEESensitiveTrunc02Coarse2,
-      HGCalEESensitiveTrunc03Coarse2</Vector>
+      HGCalEECellSensitiveTrunc01Coarse2, HGCalEECellSensitiveTrunc02Coarse2,
+      HGCalEECellSensitiveTrunc03Coarse2</Vector>
     <Vector name="ExtendedCell" type="string" nEntries="3">
        HGCalEECellExten01Coarse2, HGCalEECellExten02Coarse2,
        HGCalEECellExten03Coarse2</Vector>
     <Vector name="ExtendedSensitive" type="string" nEntries="3">
-      HGCalEESensitiveExten01Coarse2, HGCalEESensitiveExten02Coarse2,
-      HGCalEESensitiveExten03Coarse2</Vector>
+      HGCalEECellSensitiveExten01Coarse2, HGCalEECellSensitiveExten02Coarse2,
+      HGCalEECellSensitiveExten03Coarse2</Vector>
     <Vector name="CornerCell" type="string" nEntries="6">
        HGCalEECellCorner01Coarse2, HGCalEECellCorner02Coarse2,
        HGCalEECellCorner03Coarse2, HGCalEECellCorner04Coarse2,
        HGCalEECellCorner05Coarse2, HGCalEECellCorner06Coarse2</Vector>
     <Vector name="CornerSensitive" type="string" nEntries="6">
-      HGCalEESensitiveCorner01Coarse2, HGCalEESensitiveCorner02Coarse2,
-      HGCalEESensitiveCorner03Coarse2, HGCalEESensitiveCorner04Coarse2,
-      HGCalEESensitiveCorner05Coarse2, HGCalEESensitiveCorner06Coarse2</Vector>
+      HGCalEECellSensitiveCorner01Coarse2, HGCalEECellSensitiveCorner02Coarse2,
+      HGCalEECellSensitiveCorner03Coarse2, HGCalEECellSensitiveCorner04Coarse2,
+      HGCalEECellSensitiveCorner05Coarse2, HGCalEECellSensitiveCorner06Coarse2</Vector>
   </Algorithm>
   <Algorithm name="hgcal:DDHGCalCell">
     <rParent name="hgcalwafer:HGCalCell"/>
@@ -178,27 +178,27 @@
     <Numeric name="PosSensitive" value="1"/>
     <String name="Material"      value="materials:Silicon"/>
     <String name="FullCell"      value="HGCalEECellFull1Coarse2"/>
-    <String name="FullSensitive" value="HGCalEESensitiveFull1Coarse2"/>
+    <String name="FullSensitive" value="HGCalEECellSensitiveFull1Coarse2"/>
     <Vector name="TruncatedCell" type="string" nEntries="3">
        HGCalEECellTrunc11Coarse2, HGCalEECellTrunc12Coarse2,
        HGCalEECellTrunc13Coarse2</Vector>
     <Vector name="TruncatedSensitive" type="string" nEntries="3">
-      HGCalEESensitiveTrunc11Coarse2, HGCalEESensitiveTrunc12Coarse2,
-      HGCalEESensitiveTrunc13Coarse2</Vector>
+      HGCalEECellSensitiveTrunc11Coarse2, HGCalEECellSensitiveTrunc12Coarse2,
+      HGCalEECellSensitiveTrunc13Coarse2</Vector>
     <Vector name="ExtendedCell" type="string" nEntries="3">
        HGCalEECellExten11Coarse2, HGCalEECellExten12Coarse2,
        HGCalEECellExten13Coarse2</Vector>
     <Vector name="ExtendedSensitive" type="string" nEntries="3">
-      HGCalEESensitiveExten11Coarse2, HGCalEESensitiveExten12Coarse2,
-      HGCalEESensitiveExten13Coarse2</Vector>
+      HGCalEECellSensitiveExten11Coarse2, HGCalEECellSensitiveExten12Coarse2,
+      HGCalEECellSensitiveExten13Coarse2</Vector>
     <Vector name="CornerCell" type="string" nEntries="6">
        HGCalEECellCorner11Coarse2, HGCalEECellCorner12Coarse2,
        HGCalEECellCorner13Coarse2, HGCalEECellCorner14Coarse2,
        HGCalEECellCorner15Coarse2, HGCalEECellCorner16Coarse2</Vector>
     <Vector name="CornerSensitive" type="string" nEntries="6">
-      HGCalEESensitiveCorner11Coarse2, HGCalEESensitiveCorner12Coarse2,
-      HGCalEESensitiveCorner13Coarse2, HGCalEESensitiveCorner14Coarse2,
-      HGCalEESensitiveCorner15Coarse2, HGCalEESensitiveCorner16Coarse2</Vector>
+      HGCalEECellSensitiveCorner11Coarse2, HGCalEECellSensitiveCorner12Coarse2,
+      HGCalEECellSensitiveCorner13Coarse2, HGCalEECellSensitiveCorner14Coarse2,
+      HGCalEECellSensitiveCorner15Coarse2, HGCalEECellSensitiveCorner16Coarse2</Vector>
   </Algorithm>
   <Algorithm name="hgcal:DDHGCalCell">
     <rParent name="hgcalwafer:HGCalCell"/>
@@ -209,27 +209,27 @@
     <Numeric name="PosSensitive" value="0"/>
     <String name="Material"      value="materials:Silicon"/>
     <String name="FullCell"      value="HGCalHECellFull0Fine"/>
-    <String name="FullSensitive" value="HGCalHESiliconSensitiveFull0Fine"/>
+    <String name="FullSensitive" value="HGCalHESiliconCellSensitiveFull0Fine"/>
     <Vector name="TruncatedCell" type="string" nEntries="3">
        HGCalHECellTrunc01Fine, HGCalHECellTrunc02Fine,
        HGCalHECellTrunc03Fine</Vector>
     <Vector name="TruncatedSensitive" type="string" nEntries="3">
-      HGCalHESiliconSensitiveTrunc01Fine, HGCalHESiliconSensitiveTrunc02Fine,
-      HGCalHESiliconSensitiveTrunc03Fine</Vector>
+      HGCalHESiliconCellSensitiveTrunc01Fine, HGCalHESiliconCellSensitiveTrunc02Fine,
+      HGCalHESiliconCellSensitiveTrunc03Fine</Vector>
     <Vector name="ExtendedCell" type="string" nEntries="3">
        HGCalHECellExten01Fine, HGCalHECellExten02Fine,
        HGCalHECellExten03Fine</Vector>
     <Vector name="ExtendedSensitive" type="string" nEntries="3">
-      HGCalHESiliconSensitiveExten01Fine, HGCalHESiliconSensitiveExten02Fine,
-      HGCalHESiliconSensitiveExten03Fine</Vector>
+      HGCalHESiliconCellSensitiveExten01Fine, HGCalHESiliconCellSensitiveExten02Fine,
+      HGCalHESiliconCellSensitiveExten03Fine</Vector>
     <Vector name="CornerCell" type="string" nEntries="6">
        HGCalHECellCorner01Fine, HGCalHECellCorner02Fine,
        HGCalHECellCorner03Fine, HGCalHECellCorner04Fine,
        HGCalHECellCorner05Fine, HGCalHECellCorner06Fine</Vector>
     <Vector name="CornerSensitive" type="string" nEntries="6">
-      HGCalHESiliconSensitiveCorner01Fine, HGCalHESiliconSensitiveCorner02Fine,
-      HGCalHESiliconSensitiveCorner03Fine, HGCalHESiliconSensitiveCorner04Fine,
-      HGCalHESiliconSensitiveCorner05Fine, HGCalHESiliconSensitiveCorner06Fine</Vector>
+      HGCalHESiliconCellSensitiveCorner01Fine, HGCalHESiliconCellSensitiveCorner02Fine,
+      HGCalHESiliconCellSensitiveCorner03Fine, HGCalHESiliconCellSensitiveCorner04Fine,
+      HGCalHESiliconCellSensitiveCorner05Fine, HGCalHESiliconCellSensitiveCorner06Fine</Vector>
   </Algorithm>
   <Algorithm name="hgcal:DDHGCalCell">
     <rParent name="hgcalwafer:HGCalCell"/>
@@ -240,27 +240,27 @@
     <Numeric name="PosSensitive" value="0"/>
     <String name="Material"      value="materials:Silicon"/>
     <String name="FullCell"      value="HGCalHECellFull0Coarse1"/>
-    <String name="FullSensitive" value="HGCalHESiliconSensitiveFull0Coarse1"/>
+    <String name="FullSensitive" value="HGCalHESiliconCellSensitiveFull0Coarse1"/>
     <Vector name="TruncatedCell" type="string" nEntries="3">
        HGCalHECellTrunc01Coarse1, HGCalHECellTrunc02Coarse1,
        HGCalHECellTrunc03Coarse1</Vector>
     <Vector name="TruncatedSensitive" type="string" nEntries="3">
-      HGCalHESiliconSensitiveTrunc01Coarse1, HGCalHESiliconSensitiveTrunc02Coarse1,
-      HGCalHESiliconSensitiveTrunc03Coarse1</Vector>
+      HGCalHESiliconCellSensitiveTrunc01Coarse1, HGCalHESiliconCellSensitiveTrunc02Coarse1,
+      HGCalHESiliconCellSensitiveTrunc03Coarse1</Vector>
     <Vector name="ExtendedCell" type="string" nEntries="3">
        HGCalHECellExten01Coarse1, HGCalHECellExten02Coarse1,
        HGCalHECellExten03Coarse1</Vector>
     <Vector name="ExtendedSensitive" type="string" nEntries="3">
-      HGCalHESiliconSensitiveExten01Coarse1, HGCalHESiliconSensitiveExten02Coarse1,
-      HGCalHESiliconSensitiveExten03Coarse1</Vector>
+      HGCalHESiliconCellSensitiveExten01Coarse1, HGCalHESiliconCellSensitiveExten02Coarse1,
+      HGCalHESiliconCellSensitiveExten03Coarse1</Vector>
     <Vector name="CornerCell" type="string" nEntries="6">
        HGCalHECellCorner01Coarse1, HGCalHECellCorner02Coarse1,
        HGCalHECellCorner03Coarse1, HGCalHECellCorner04Coarse1,
        HGCalHECellCorner05Coarse1, HGCalHECellCorner06Coarse1</Vector>
     <Vector name="CornerSensitive" type="string" nEntries="6">
-      HGCalHESiliconSensitiveCorner01Coarse1, HGCalHESiliconSensitiveCorner02Coarse1,
-      HGCalHESiliconSensitiveCorner03Coarse1, HGCalHESiliconSensitiveCorner04Coarse1,
-      HGCalHESiliconSensitiveCorner05Coarse1, HGCalHESiliconSensitiveCorner06Coarse1</Vector>
+      HGCalHESiliconCellSensitiveCorner01Coarse1, HGCalHESiliconCellSensitiveCorner02Coarse1,
+      HGCalHESiliconCellSensitiveCorner03Coarse1, HGCalHESiliconCellSensitiveCorner04Coarse1,
+      HGCalHESiliconCellSensitiveCorner05Coarse1, HGCalHESiliconCellSensitiveCorner06Coarse1</Vector>
   </Algorithm>
   <Algorithm name="hgcal:DDHGCalCell">
     <rParent name="hgcalwafer:HGCalCell"/>
@@ -271,27 +271,27 @@
     <Numeric name="PosSensitive" value="0"/>
     <String name="Material"      value="materials:Silicon"/>
     <String name="FullCell"      value="HGCalHECellFull0Coarse2"/>
-    <String name="FullSensitive" value="HGCalHESiliconSensitiveFull0Coarse2"/>
+    <String name="FullSensitive" value="HGCalHESiliconCellSensitiveFull0Coarse2"/>
     <Vector name="TruncatedCell" type="string" nEntries="3">
        HGCalHECellTrunc01Coarse2, HGCalHECellTrunc02Coarse2,
        HGCalHECellTrunc03Coarse2</Vector>
     <Vector name="TruncatedSensitive" type="string" nEntries="3">
-      HGCalHESiliconSensitiveTrunc01Coarse2, HGCalHESiliconSensitiveTrunc02Coarse2,
-      HGCalHESiliconSensitiveTrunc03Coarse2</Vector>
+      HGCalHESiliconCellSensitiveTrunc01Coarse2, HGCalHESiliconCellSensitiveTrunc02Coarse2,
+      HGCalHESiliconCellSensitiveTrunc03Coarse2</Vector>
     <Vector name="ExtendedCell" type="string" nEntries="3">
        HGCalHECellExten01Coarse2, HGCalHECellExten02Coarse2,
        HGCalHECellExten03Coarse2</Vector>
     <Vector name="ExtendedSensitive" type="string" nEntries="3">
-      HGCalHESiliconSensitiveExten01Coarse2, HGCalHESiliconSensitiveExten02Coarse2,
-      HGCalHESiliconSensitiveExten03Coarse2</Vector>
+      HGCalHESiliconCellSensitiveExten01Coarse2, HGCalHESiliconCellSensitiveExten02Coarse2,
+      HGCalHESiliconCellSensitiveExten03Coarse2</Vector>
     <Vector name="CornerCell" type="string" nEntries="6">
        HGCalHECellCorner01Coarse2, HGCalHECellCorner02Coarse2,
        HGCalHECellCorner03Coarse2, HGCalHECellCorner04Coarse2,
        HGCalHECellCorner05Coarse2, HGCalHECellCorner06Coarse2</Vector>
     <Vector name="CornerSensitive" type="string" nEntries="6">
-      HGCalHESiliconSensitiveCorner01Coarse2, HGCalHESiliconSensitiveCorner02Coarse2,
-      HGCalHESiliconSensitiveCorner03Coarse2, HGCalHESiliconSensitiveCorner04Coarse2,
-      HGCalHESiliconSensitiveCorner05Coarse2, HGCalHESiliconSensitiveCorner06Coarse2</Vector>
+      HGCalHESiliconCellSensitiveCorner01Coarse2, HGCalHESiliconCellSensitiveCorner02Coarse2,
+      HGCalHESiliconCellSensitiveCorner03Coarse2, HGCalHESiliconCellSensitiveCorner04Coarse2,
+      HGCalHESiliconCellSensitiveCorner05Coarse2, HGCalHESiliconCellSensitiveCorner06Coarse2</Vector>
   </Algorithm>
 </PosPartSection>
 

--- a/Geometry/HGCalCommonData/data/hgcalwafer/v15/hgcalwafer.xml
+++ b/Geometry/HGCalCommonData/data/hgcalwafer/v15/hgcalwafer.xml
@@ -566,7 +566,7 @@
       0, 0, 0, 0, 0, 1, 0 </Vector>
     <Vector name="Layers" type="numeric" nEntries="9"> 
       0, 1, 2, 3, 5, 3, 4, 3, 6 </Vector>
-    <String name="SenseName"    value="HGCalHECellSensitive0Fine"/>
+    <String name="SenseName"    value="HGCalHESiliconCellSensitive0Fine"/>
     <Numeric name="SenseType"    value="0"/>
     <Numeric name="SenseThick"   value="[CellThicknessFine]"/>
     <Numeric name="PosSensitive" value="0"/>
@@ -603,7 +603,7 @@
       0, 0, 0, 0, 0, 1, 0 </Vector>
     <Vector name="Layers" type="numeric" nEntries="9"> 
       0, 1, 2, 3, 5, 3, 4, 3, 6 </Vector>
-    <String name="SenseName"    value="HGCalHECellSensitive0Coarse1"/>
+    <String name="SenseName"    value="HGCalHESiliconCellSensitive0Coarse1"/>
     <Numeric name="SenseType"    value="1"/>
     <Numeric name="SenseThick"   value="[CellThicknessCoarse1]"/>
     <Numeric name="PosSensitive" value="0"/>
@@ -640,7 +640,7 @@
       0, 0, 0, 0, 0, 1, 0 </Vector>
     <Vector name="Layers" type="numeric" nEntries="9"> 
       0, 1, 2, 3, 5, 3, 4, 3, 6 </Vector>
-    <String name="SenseName"    value="HGCalHECellSensitive0Coarse2"/>
+    <String name="SenseName"    value="HGCalHESiliconCellSensitive0Coarse2"/>
     <Numeric name="SenseType"    value="2"/>
     <Numeric name="SenseThick"   value="[CellThicknessCoarse2]"/>
     <Numeric name="PosSensitive" value="0"/>

--- a/Geometry/HGCalCommonData/data/hgcalwafer/v16/hgcalwafer.xml
+++ b/Geometry/HGCalCommonData/data/hgcalwafer/v16/hgcalwafer.xml
@@ -562,7 +562,7 @@
       0, 0, 0, 0, 0, 1, 0 </Vector>
     <Vector name="Layers" type="numeric" nEntries="9"> 
       0, 1, 2, 3, 5, 3, 4, 3, 6 </Vector>
-    <String name="SenseName"    value="HGCalHECellSensitive0Fine"/>
+    <String name="SenseName"    value="HGCalHESiliconCellSensitive0Fine"/>
     <Numeric name="SenseType"    value="0"/>
     <Numeric name="SenseThick"   value="[CellThicknessFine]"/>
     <Numeric name="PosSensitive" value="0"/>
@@ -598,7 +598,7 @@
       0, 0, 0, 0, 0, 1, 0 </Vector>
     <Vector name="Layers" type="numeric" nEntries="9"> 
       0, 1, 2, 3, 5, 3, 4, 3, 6 </Vector>
-    <String name="SenseName"    value="HGCalHECellSensitive0Coarse1"/>
+    <String name="SenseName"    value="HGCalHESiliconCellSensitive0Coarse1"/>
     <Numeric name="SenseType"    value="1"/>
     <Numeric name="SenseThick"   value="[CellThicknessCoarse1]"/>
     <Numeric name="PosSensitive" value="0"/>
@@ -634,7 +634,7 @@
       0, 0, 0, 0, 0, 1, 0 </Vector>
     <Vector name="Layers" type="numeric" nEntries="9"> 
       0, 1, 2, 3, 5, 3, 4, 3, 6 </Vector>
-    <String name="SenseName"    value="HGCalHECellSensitive0Coarse2"/>
+    <String name="SenseName"    value="HGCalHESiliconCellSensitive0Coarse2"/>
     <Numeric name="SenseType"    value="2"/>
     <Numeric name="SenseThick"   value="[CellThicknessCoarse2]"/>
     <Numeric name="PosSensitive" value="0"/>

--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -1226,7 +1226,7 @@ void HGCalDDDConstants::waferFromPosition(const double x,
   }
   if ((std::abs(waferU) <= hgpar_->waferUVMax_) && (celltype >= 0)) {
     cellHex(xx, yy, celltype, cellU, cellV, extend, debug);
-    wt = ((celltype < 2) ? (hgpar_->cellThickness_[celltype] / hgpar_->waferThick_) : 1.0);
+    wt = (((celltype < 2) && (mode_ != HGCalGeometryMode::Hexagon8Module)) ? (hgpar_->cellThickness_[celltype] / hgpar_->waferThick_) : 1.0);
   } else {
     cellU = cellV = 2 * hgpar_->nCellsFine_;
     wt = 1.0;

--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -1226,7 +1226,9 @@ void HGCalDDDConstants::waferFromPosition(const double x,
   }
   if ((std::abs(waferU) <= hgpar_->waferUVMax_) && (celltype >= 0)) {
     cellHex(xx, yy, celltype, cellU, cellV, extend, debug);
-    wt = (((celltype < 2) && (mode_ != HGCalGeometryMode::Hexagon8Module)) ? (hgpar_->cellThickness_[celltype] / hgpar_->waferThick_) : 1.0);
+    wt = (((celltype < 2) && (mode_ != HGCalGeometryMode::Hexagon8Module))
+              ? (hgpar_->cellThickness_[celltype] / hgpar_->waferThick_)
+              : 1.0);
   } else {
     cellU = cellV = 2 * hgpar_->nCellsFine_;
     wt = 1.0;

--- a/Geometry/HGCalCommonData/test/python/dumpHGCalV16_cfg.py
+++ b/Geometry/HGCalCommonData/test/python/dumpHGCalV16_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("DUMP")
-process.load("Geometry.HGCalCommonData.testHGCV16XML_cfi")
+process.load("Geometry.HGCalCommonData.testHGCalV16XML_cfi")
 process.load('FWCore.MessageService.MessageLogger_cfi')
 
 if 'MessageLogger' in process.__dict__:

--- a/Geometry/HGCalGeometry/test/HGCalGeometryRotTest.cc
+++ b/Geometry/HGCalGeometry/test/HGCalGeometryRotTest.cc
@@ -15,7 +15,10 @@
 
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/HGCalGeometry/interface/HGCalGeometry.h"
+#include "DataFormats/Math/interface/GeantUnits.h"
 #include "DataFormats/ForwardDetId/interface/HGCSiliconDetId.h"
+
+using namespace geant_units::operators;
 
 class HGCalGeometryRotTest : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
@@ -77,10 +80,12 @@ void HGCalGeometryRotTest::beginRun(const edm::Run&, const edm::EventSetup& iSet
     for (auto lay : layers_) {
       HGCSiliconDetId detId(det, 1, types_[k], lay - layerOff, waferU_[k], waferV_[k], cellU_[k], cellV_[k]);
       GlobalPoint global = geom->getPosition(DetId(detId));
+      double phi2 = global.phi();
       auto xy = geom->topology().dddConstants().waferPosition(lay - layerOff, waferU_[k], waferV_[k], true);
+      double phi1 = std::atan2(xy.second, xy.first);
       edm::LogVerbatim("HGCalGeom") << "Layer: " << lay << " U " << waferU_[k] << " V " << waferV_[k] << " Position ("
-                                    << xy.first << ", " << xy.second << ")";
-      edm::LogVerbatim("HGCalGeom") << detId << " Position " << global;
+                                    << xy.first << ", " << xy.second << ") phi " << convertRadToDeg(phi1);
+      edm::LogVerbatim("HGCalGeom") << detId << " Position " << global << " phi " << convertRadToDeg(phi2); 
     }
   }
 }

--- a/Geometry/HGCalGeometry/test/HGCalGeometryRotTest.cc
+++ b/Geometry/HGCalGeometry/test/HGCalGeometryRotTest.cc
@@ -85,7 +85,7 @@ void HGCalGeometryRotTest::beginRun(const edm::Run&, const edm::EventSetup& iSet
       double phi1 = std::atan2(xy.second, xy.first);
       edm::LogVerbatim("HGCalGeom") << "Layer: " << lay << " U " << waferU_[k] << " V " << waferV_[k] << " Position ("
                                     << xy.first << ", " << xy.second << ") phi " << convertRadToDeg(phi1);
-      edm::LogVerbatim("HGCalGeom") << detId << " Position " << global << " phi " << convertRadToDeg(phi2); 
+      edm::LogVerbatim("HGCalGeom") << detId << " Position " << global << " phi " << convertRadToDeg(phi2);
     }
   }
 }

--- a/Geometry/HGCalGeometry/test/HGCalGeometryRotTest.cc
+++ b/Geometry/HGCalGeometry/test/HGCalGeometryRotTest.cc
@@ -15,10 +15,10 @@
 
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/HGCalGeometry/interface/HGCalGeometry.h"
-#include "DataFormats/Math/interface/GeantUnits.h"
+#include "DataFormats/Math/interface/angle_units.h"
 #include "DataFormats/ForwardDetId/interface/HGCSiliconDetId.h"
 
-using namespace geant_units::operators;
+using namespace angle_units::operators;
 
 class HGCalGeometryRotTest : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:

--- a/Geometry/HGCalSimData/data/hgcsensv15.xml
+++ b/Geometry/HGCalSimData/data/hgcsensv15.xml
@@ -3,12 +3,12 @@
 
 <SpecParSection label="hgcsens.xml" eval="true">
   <SpecPar name="hgcee">
-    <PartSelector path="//HGCalEESensitive.*"/>  
+    <PartSelector path="//HGCalEECellSensitive.*"/>  
     <Parameter name="SensitiveDetector" value="HGCalSensitiveDetector" eval="false"/>
     <Parameter name="ReadOutName" value="HGCHitsEE" eval="false"/>
   </SpecPar>
   <SpecPar name="hgchesil">
-    <PartSelector path="//HGCalHESiliconSensitive.*"/> 
+    <PartSelector path="//HGCalHESiliconCellSensitive.*"/> 
     <Parameter name="SensitiveDetector" value="HGCalSensitiveDetector" eval="false"/>
     <Parameter name="ReadOutName" value="HGCHitsHEfront" eval="false"/>
   </SpecPar>

--- a/SimG4CMS/Calo/plugins/HGCalSensitiveDetectorBuilder.cc
+++ b/SimG4CMS/Calo/plugins/HGCalSensitiveDetectorBuilder.cc
@@ -19,6 +19,8 @@
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+//#define EDM_ML_DEBUG
+
 class HGCalSensitiveDetectorBuilder : public SensitiveDetectorMakerBase {
 public:
   explicit HGCalSensitiveDetectorBuilder(edm::ParameterSet const& p, edm::ConsumesCollector cc)
@@ -49,6 +51,12 @@ public:
                                                                                                   : nullptr));
     auto sd = std::make_unique<HGCalSD>(iname, hgc, clg, p, man);
     SimActivityRegistryEnroller::enroll(reg, sd.get());
+#ifdef EDM_ML_DEBUG
+    const auto& dets = clg.logicalNames(iname);
+    edm::LogVerbatim("HGCSim") << "HGCalSensitiveDetectorBuilder for " << iname << " utilizes " << dets.size() << " detectors";
+    for (unsigned int k = 0; k < dets.size(); ++k)
+      edm::LogVerbatim("HGCSim") << "Detector [" << k << "] " << dets[k];
+#endif
     return sd;
   }
 

--- a/SimG4CMS/Calo/plugins/HGCalSensitiveDetectorBuilder.cc
+++ b/SimG4CMS/Calo/plugins/HGCalSensitiveDetectorBuilder.cc
@@ -53,7 +53,8 @@ public:
     SimActivityRegistryEnroller::enroll(reg, sd.get());
 #ifdef EDM_ML_DEBUG
     const auto& dets = clg.logicalNames(iname);
-    edm::LogVerbatim("HGCSim") << "HGCalSensitiveDetectorBuilder for " << iname << " utilizes " << dets.size() << " detectors";
+    edm::LogVerbatim("HGCSim") << "HGCalSensitiveDetectorBuilder for " << iname << " utilizes " << dets.size()
+                               << " detectors";
     for (unsigned int k = 0; k < dets.size(); ++k)
       edm::LogVerbatim("HGCSim") << "Detector [" << k << "] " << dets[k];
 #endif

--- a/SimG4CMS/Calo/src/HGCalNumberingScheme.cc
+++ b/SimG4CMS/Calo/src/HGCalNumberingScheme.cc
@@ -68,7 +68,7 @@ uint32_t HGCalNumberingScheme::getUnitID(int layer, int module, int cell, int iz
       index = HGCSiliconDetId(det_, iz, waferType, layer, waferU, waferV, cellU, cellV).rawId();
 #ifdef EDM_ML_DEBUG
       edm::LogVerbatim("HGCSim") << "OK WaferType " << waferType << " Wafer " << waferU << ":" << waferV << " Cell "
-                                 << cellU << ":" << cellV;
+                                 << cellU << ":" << cellV << " input " << cell << " wt " << wt  << " Mode " << mode_;
     } else {
       edm::LogVerbatim("HGCSim") << "Bad WaferType " << waferType << " for Layer:u:v " << layer << ":" << waferU << ":"
                                  << waferV;
@@ -96,11 +96,10 @@ uint32_t HGCalNumberingScheme::getUnitID(int layer, int module, int cell, int iz
     }
   }
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HGCSim") << "HGCalNumberingScheme::i/p " << det_ << ":" << layer << ":" << module << ":" << cell
-                             << ":" << iz << ":" << pos.x() << ":" << pos.y() << ":" << pos.z() << " ID " << std::hex
-                             << index << std::dec << " wt " << wt;
   bool matchOnly = (mode_ == HGCalGeometryMode::Hexagon8Module) ? true : false;
   bool debug = (mode_ == HGCalGeometryMode::Hexagon8Module) ? true : false;
+  if (debug) 
+    edm::LogVerbatim("HGCSim") << "HGCalNumberingScheme::i/p " << det_ << ":" << layer << ":" << module << ":" << cell << ":" << iz << ":" << pos.x() << ":" << pos.y() << ":" << pos.z() << " ID " << std::hex << index << std::dec << " wt " << wt;
   checkPosition(index, pos, matchOnly, debug);
 #endif
   return index;
@@ -109,7 +108,7 @@ uint32_t HGCalNumberingScheme::getUnitID(int layer, int module, int cell, int iz
 void HGCalNumberingScheme::checkPosition(uint32_t index, const G4ThreeVector& pos, bool matchOnly, bool debug) const {
   std::pair<float, float> xy;
   bool ok(false);
-  double z1(0), tolR(12.0), tolZ(1.0);
+  double z1(0), tolR(14.0), tolZ(1.0);
   int lay(-1);
   if (index == 0) {
   } else if (DetId(index).det() == DetId::HGCalHSi) {
@@ -118,7 +117,7 @@ void HGCalNumberingScheme::checkPosition(uint32_t index, const G4ThreeVector& po
     xy = hgcons_.locateCell(lay, id.waferU(), id.waferV(), id.cellU(), id.cellV(), false, true);
     z1 = hgcons_.waferZ(lay, false);
     ok = true;
-    tolR = 12.0;
+    tolR = 14.0;
     tolZ = 1.0;
   } else if (DetId(index).det() == DetId::HGCalHSc) {
     HGCScintillatorDetId id = HGCScintillatorDetId(index);
@@ -151,13 +150,16 @@ void HGCalNumberingScheme::checkPosition(uint32_t index, const G4ThreeVector& po
                                  << outok << " " << ck;
       edm::LogVerbatim("HGCSim") << "Original " << pos.x() << ":" << pos.y() << " return " << xy.first << ":"
                                  << xy.second;
-      if (DetId(index).det() == DetId::HGCalHSi) {
+      if ((DetId(index).det() == DetId::HGCalEE) || (DetId(index).det() == DetId::HGCalHSi)) {
         double wt = 0, xx = ((pos.z() > 0) ? pos.x() : -pos.x());
         int waferU, waferV, cellU, cellV, waferType;
         hgcons_.waferFromPosition(xx, pos.y(), lay, waferU, waferV, cellU, cellV, waferType, wt, false, true);
         xy = hgcons_.locateCell(lay, waferU, waferV, cellU, cellV, false, true, true);
-        edm::LogVerbatim("HGCSim") << "HGCalNumberingScheme " << HGCSiliconDetId(index) << " position " << xy.first
-                                   << ":" << xy.second;
+	double dx = (xx - xy.first);
+	double dy = (pos.y() - xy.second);
+	double dR = std::sqrt(dx * dx + dy * dy);
+	ck = (dR > tolR) ? " ***** ERROR *****" : "";
+        edm::LogVerbatim("HGCSim") << "HGCalNumberingScheme " << HGCSiliconDetId(index) << " original position " << xx << ":" << pos.y() << " derived " << xy.first << ":" << xy.second << " Difference " << dR << ck;
       }
     }
   }

--- a/SimG4CMS/Calo/src/HGCalNumberingScheme.cc
+++ b/SimG4CMS/Calo/src/HGCalNumberingScheme.cc
@@ -68,7 +68,7 @@ uint32_t HGCalNumberingScheme::getUnitID(int layer, int module, int cell, int iz
       index = HGCSiliconDetId(det_, iz, waferType, layer, waferU, waferV, cellU, cellV).rawId();
 #ifdef EDM_ML_DEBUG
       edm::LogVerbatim("HGCSim") << "OK WaferType " << waferType << " Wafer " << waferU << ":" << waferV << " Cell "
-                                 << cellU << ":" << cellV << " input " << cell << " wt " << wt  << " Mode " << mode_;
+                                 << cellU << ":" << cellV << " input " << cell << " wt " << wt << " Mode " << mode_;
     } else {
       edm::LogVerbatim("HGCSim") << "Bad WaferType " << waferType << " for Layer:u:v " << layer << ":" << waferU << ":"
                                  << waferV;
@@ -98,8 +98,10 @@ uint32_t HGCalNumberingScheme::getUnitID(int layer, int module, int cell, int iz
 #ifdef EDM_ML_DEBUG
   bool matchOnly = (mode_ == HGCalGeometryMode::Hexagon8Module) ? true : false;
   bool debug = (mode_ == HGCalGeometryMode::Hexagon8Module) ? true : false;
-  if (debug) 
-    edm::LogVerbatim("HGCSim") << "HGCalNumberingScheme::i/p " << det_ << ":" << layer << ":" << module << ":" << cell << ":" << iz << ":" << pos.x() << ":" << pos.y() << ":" << pos.z() << " ID " << std::hex << index << std::dec << " wt " << wt;
+  if (debug)
+    edm::LogVerbatim("HGCSim") << "HGCalNumberingScheme::i/p " << det_ << ":" << layer << ":" << module << ":" << cell
+                               << ":" << iz << ":" << pos.x() << ":" << pos.y() << ":" << pos.z() << " ID " << std::hex
+                               << index << std::dec << " wt " << wt;
   checkPosition(index, pos, matchOnly, debug);
 #endif
   return index;
@@ -155,11 +157,13 @@ void HGCalNumberingScheme::checkPosition(uint32_t index, const G4ThreeVector& po
         int waferU, waferV, cellU, cellV, waferType;
         hgcons_.waferFromPosition(xx, pos.y(), lay, waferU, waferV, cellU, cellV, waferType, wt, false, true);
         xy = hgcons_.locateCell(lay, waferU, waferV, cellU, cellV, false, true, true);
-	double dx = (xx - xy.first);
-	double dy = (pos.y() - xy.second);
-	double dR = std::sqrt(dx * dx + dy * dy);
-	ck = (dR > tolR) ? " ***** ERROR *****" : "";
-        edm::LogVerbatim("HGCSim") << "HGCalNumberingScheme " << HGCSiliconDetId(index) << " original position " << xx << ":" << pos.y() << " derived " << xy.first << ":" << xy.second << " Difference " << dR << ck;
+        double dx = (xx - xy.first);
+        double dy = (pos.y() - xy.second);
+        double dR = std::sqrt(dx * dx + dy * dy);
+        ck = (dR > tolR) ? " ***** ERROR *****" : "";
+        edm::LogVerbatim("HGCSim") << "HGCalNumberingScheme " << HGCSiliconDetId(index) << " original position " << xx
+                                   << ":" << pos.y() << " derived " << xy.first << ":" << xy.second << " Difference "
+                                   << dR << ck;
       }
     }
   }

--- a/SimG4CMS/Calo/src/HGCalNumberingScheme.cc
+++ b/SimG4CMS/Calo/src/HGCalNumberingScheme.cc
@@ -96,8 +96,8 @@ uint32_t HGCalNumberingScheme::getUnitID(int layer, int module, int cell, int iz
     }
   }
 #ifdef EDM_ML_DEBUG
-  bool matchOnly = (mode_ == HGCalGeometryMode::Hexagon8Module) ? true : false;
-  bool debug = (mode_ == HGCalGeometryMode::Hexagon8Module) ? true : false;
+  bool matchOnly = (mode_ == HGCalGeometryMode::Hexagon8Module);
+  bool debug = (mode_ == HGCalGeometryMode::Hexagon8Module);
   if (debug)
     edm::LogVerbatim("HGCSim") << "HGCalNumberingScheme::i/p " << det_ << ":" << layer << ":" << module << ":" << cell
                                << ":" << iz << ":" << pos.x() << ":" << pos.y() << ":" << pos.z() << " ID " << std::hex

--- a/SimG4CMS/Calo/src/HGCalSD.cc
+++ b/SimG4CMS/Calo/src/HGCalSD.cc
@@ -141,9 +141,15 @@ uint32_t HGCalSD::setDetUnitId(const G4Step* aStep) {
       module = touch->GetReplicaNumber(3);
       cell = touch->GetReplicaNumber(1);
     } else {
-      layer = touch->GetReplicaNumber(2);
-      module = touch->GetReplicaNumber(1);
+      layer = touch->GetReplicaNumber(3);
+      module = touch->GetReplicaNumber(2);
     }
+#ifdef EDM_ML_DEBUG
+    edm::LogVerbatim("HGCSim") << "DepthsTop: " << touch->GetHistoryDepth() << ":" << levelT1_ << ":" << levelT2_
+                               << " name " << touch->GetVolume(0)->GetName() << " layer:module:cell " << layer << ":"
+                               << module << ":" << cell;
+    printDetectorLevels(touch);
+#endif
   } else if ((touch->GetHistoryDepth() == levelT1_) || (touch->GetHistoryDepth() == levelT2_)) {
     layer = touch->GetReplicaNumber(0);
 #ifdef EDM_ML_DEBUG

--- a/SimG4CMS/Calo/test/python/runHGC5_cfg.py
+++ b/SimG4CMS/Calo/test/python/runHGC5_cfg.py
@@ -5,7 +5,7 @@ process = cms.Process("PROD",Phase2C11)
 
 process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 process.load("IOMC.EventVertexGenerators.VtxSmearedGauss_cfi")
-process.load('Configuration.Geometry.GeometryExtended2026D84Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D83Reco_cff')
 process.load("Configuration.StandardSequences.MagneticField_cff")
 process.load("Configuration.EventContent.EventContent_cff")
 process.load('Configuration.StandardSequences.Generator_cff')
@@ -28,7 +28,7 @@ process.RandomNumberGeneratorService.VtxSmeared.initialSeed = 123456789
 process.Timing = cms.Service("Timing")
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(10)
+    input = cms.untracked.int32(100)
 )
 
 process.source = cms.Source("EmptySource",
@@ -39,8 +39,8 @@ process.source = cms.Source("EmptySource",
 process.generator = cms.EDProducer("FlatRandomEGunProducer",
     PGunParameters = cms.PSet(
         PartID = cms.vint32(211),
-        MinEta = cms.double(1.75),
-        MaxEta = cms.double(2.50),
+        MinEta = cms.double(1.52),
+        MaxEta = cms.double(3.00),
         MinPhi = cms.double(-3.1415926),
         MaxPhi = cms.double(3.1415926),
         MinE   = cms.double(100.00),

--- a/SimG4CMS/Calo/test/python/runHGC6_cfg.py
+++ b/SimG4CMS/Calo/test/python/runHGC6_cfg.py
@@ -28,7 +28,7 @@ process.RandomNumberGeneratorService.VtxSmeared.initialSeed = 123456789
 process.Timing = cms.Service("Timing")
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(10)
+    input = cms.untracked.int32(100)
 )
 
 process.source = cms.Source("EmptySource",
@@ -39,8 +39,8 @@ process.source = cms.Source("EmptySource",
 process.generator = cms.EDProducer("FlatRandomEGunProducer",
     PGunParameters = cms.PSet(
         PartID = cms.vint32(13),
-        MinEta = cms.double(1.75),
-        MaxEta = cms.double(2.50),
+        MinEta = cms.double(1.52),
+        MaxEta = cms.double(3.00),
         MinPhi = cms.double(-3.1415926),
         MaxPhi = cms.double(3.1415926),
         MinE   = cms.double(100.00),

--- a/SimG4Core/PrintGeomInfo/test/python/g4OverlapCheck2026_cfg.py
+++ b/SimG4Core/PrintGeomInfo/test/python/g4OverlapCheck2026_cfg.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.Eras.Era_Phase2C11_cff import Phase2C11
 process = cms.Process('SIM',Phase2C11)
 #process.load('Configuration.Geometry.GeometryExtended2026D77Reco_cff')
-process.load('Configuration.Geometry.GeometryExtended2026D83Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D86Reco_cff')
 
 process.load('FWCore.MessageService.MessageLogger_cfi')
 
@@ -18,9 +18,9 @@ process = checkOverlap(process)
 process.g4SimHits.CheckGeometry = True
 
 # Geant4 geometry check 
-process.g4SimHits.G4CheckOverlap.OutputBaseName = cms.string("cms2026D83")
+process.g4SimHits.G4CheckOverlap.OutputBaseName = cms.string("cms2026D86")
 process.g4SimHits.G4CheckOverlap.OverlapFlag = cms.bool(True)
-process.g4SimHits.G4CheckOverlap.Tolerance  = cms.double(0.1)
+process.g4SimHits.G4CheckOverlap.Tolerance  = cms.double(0.01)
 process.g4SimHits.G4CheckOverlap.Resolution = cms.int32(10000)
 process.g4SimHits.G4CheckOverlap.Depth      = cms.int32(-1)
 # tells if NodeName is G4Region or G4PhysicalVolume

--- a/SimG4Core/PrintGeomInfo/test/python/g4OverlapCheck2026_cfg.py
+++ b/SimG4Core/PrintGeomInfo/test/python/g4OverlapCheck2026_cfg.py
@@ -3,8 +3,8 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Phase2C11_cff import Phase2C11
 process = cms.Process('SIM',Phase2C11)
-#process.load('Configuration.Geometry.GeometryExtended2026D77Reco_cff')
-process.load('Configuration.Geometry.GeometryExtended2026D86Reco_cff')
+#process.load('Configuration.Geometry.GeometryExtended2026D77_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D86_cff')
 
 process.load('FWCore.MessageService.MessageLogger_cfi')
 


### PR DESCRIPTION
#### PR description:

Bug fix for real partial wafer simulations in versions V15 and V16. This involves declaration of proper Sensitive Detector volumes and inhibition of using additional weights which was needed for virtual partial wafers used in V11..V14

#### PR validation:

Make use of the runTheMatrix test workflows and also overlap testing

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special
