### PR TITLE
PPS: consume association cuts from DB

### DIFF
--- a/CondFormats/PPSObjects/interface/PPSAssociationCuts.h
+++ b/CondFormats/PPSObjects/interface/PPSAssociationCuts.h
@@ -36,6 +36,10 @@ public:
     double getTiTrMin() const { return ti_tr_min_; }
     double getTiTrMax() const { return ti_tr_max_; }
 
+    // build TF1 representations of the mean and threshold functions
+    // NB: declared as const as it only modifies mutable class fields
+    void buildFunctions() const;
+
     // returns whether the specified cut is applied
     bool isApplied(Quantities quantity) const;
 
@@ -48,8 +52,8 @@ public:
     std::vector<std::string> s_thresholds_;
 
     // TF1 representation of the cut parameters - for run time evaluations
-    std::vector<std::shared_ptr<TF1> > f_means_ COND_TRANSIENT;
-    std::vector<std::shared_ptr<TF1> > f_thresholds_ COND_TRANSIENT;
+    mutable std::vector<std::shared_ptr<TF1> > f_means_ COND_TRANSIENT;
+    mutable std::vector<std::shared_ptr<TF1> > f_thresholds_ COND_TRANSIENT;
 
     // timing-tracking cuts
     double ti_tr_min_;

--- a/CondFormats/PPSObjects/src/PPSAssociationCuts.cc
+++ b/CondFormats/PPSObjects/src/PPSAssociationCuts.cc
@@ -23,13 +23,25 @@ PPSAssociationCuts::CutsPerArm::CutsPerArm(const edm::ParameterSet &iConfig, int
 
     std::string threshold = association_cuts.getParameter<std::string>(names[i] + "_cut_threshold");
     s_thresholds_.push_back(threshold);
-
-    f_means_.push_back(std::make_shared<TF1>("f", mean.c_str()));
-    f_thresholds_.push_back(std::make_shared<TF1>("f", threshold.c_str()));
   }
 
   ti_tr_min_ = association_cuts.getParameter<double>("ti_tr_min");
   ti_tr_max_ = association_cuts.getParameter<double>("ti_tr_max");
+
+  buildFunctions();
+}
+
+//----------------------------------------------------------------------------------------------------
+
+void PPSAssociationCuts::CutsPerArm::buildFunctions() const
+{
+  f_means_.clear();
+  for (const auto &s : s_means_)
+    f_means_.push_back(std::make_shared<TF1>("f", s.c_str()));
+
+  f_thresholds_.clear();
+  for (const auto &s : s_thresholds_)
+    f_thresholds_.push_back(std::make_shared<TF1>("f", s.c_str()));
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -42,10 +54,20 @@ bool PPSAssociationCuts::CutsPerArm::isApplied(Quantities quantity) const {
 
 bool PPSAssociationCuts::CutsPerArm::isSatisfied(
     Quantities quantity, double x_near, double y_near, double xangle, double q_NF_diff) const {
+  // if cut not applied, then condition considered as satisfied
   if (!isApplied(quantity))
     return true;
+
+  // build functions if not already done
+  // (this may happen if data (string representation) are loaded from DB and the constructor is not executed)
+  if (f_means_.size() < s_means_.size())
+    buildFunctions();
+
+  // evaluate mean and threshold
   const double mean = evaluateExpression(f_means_.at(quantity), x_near, y_near, xangle);
   const double threshold = evaluateExpression(f_thresholds_.at(quantity), x_near, y_near, xangle);
+
+  // make comparison
   return fabs(q_NF_diff - mean) < threshold;
 }
 

--- a/CondFormats/PPSObjects/src/PPSAssociationCuts.cc
+++ b/CondFormats/PPSObjects/src/PPSAssociationCuts.cc
@@ -33,8 +33,7 @@ PPSAssociationCuts::CutsPerArm::CutsPerArm(const edm::ParameterSet &iConfig, int
 
 //----------------------------------------------------------------------------------------------------
 
-void PPSAssociationCuts::CutsPerArm::buildFunctions() const
-{
+void PPSAssociationCuts::CutsPerArm::buildFunctions() const {
   f_means_.clear();
   for (const auto &s : s_means_)
     f_means_.push_back(std::make_shared<TF1>("f", s.c_str()));

--- a/RecoPPS/ProtonReconstruction/python/ctppsProtons_cff.py
+++ b/RecoPPS/ProtonReconstruction/python/ctppsProtons_cff.py
@@ -8,10 +8,8 @@ from CalibPPS.ESProducers.ctppsOpticalFunctions_cff import *
 
 # import and adjust proton-reconstructions settings
 from RecoPPS.ProtonReconstruction.ctppsProtons_cfi import *
-from CalibPPS.ESProducers.ppsAssociationCuts_non_DB_cff import *
 
 ctppsProtons.lhcInfoLabel = ctppsLHCInfoLabel
-ctppsProtons.ppsAssociationCutsLabel = ppsAssociationCutsESSource.ppsAssociationCutsLabel
 
 ctppsProtons.pixelDiscardBXShiftedTracks = True
 ctppsProtons.default_time = -999.

--- a/Validation/CTPPS/python/simu_config/year_2016_cff.py
+++ b/Validation/CTPPS/python/simu_config/year_2016_cff.py
@@ -1,8 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
 from Validation.CTPPS.simu_config.base_cff import *
+
 import CalibPPS.ESProducers.ppsAssociationCuts_non_DB_cff as ac
-ac.use_single_infinite_iov_entry(ac.ppsAssociationCutsESSource,ac.p2016)
+ac.use_single_infinite_iov_entry(ac.ppsAssociationCutsESSource, ac.p2016)
+ppsAssociationCutsESSource = ac.ppsAssociationCutsESSource
 
 # base profile settings for 2016
 profile_base_2016 = profile_base.clone(

--- a/Validation/CTPPS/python/simu_config/year_2017_cff.py
+++ b/Validation/CTPPS/python/simu_config/year_2017_cff.py
@@ -1,8 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
 from Validation.CTPPS.simu_config.base_cff import *
+
 import CalibPPS.ESProducers.ppsAssociationCuts_non_DB_cff as ac
-ac.use_single_infinite_iov_entry(ac.ppsAssociationCutsESSource,ac.p2017)
+ac.use_single_infinite_iov_entry(ac.ppsAssociationCutsESSource, ac.p2017)
+ppsAssociationCutsESSource = ac.ppsAssociationCutsESSource
 
 from CalibPPS.ESProducers.ctppsOpticalFunctions_non_DB_cff import optics_2017 as selected_optics
 

--- a/Validation/CTPPS/python/simu_config/year_2018_cff.py
+++ b/Validation/CTPPS/python/simu_config/year_2018_cff.py
@@ -1,8 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
 from Validation.CTPPS.simu_config.base_cff import *
+
 import CalibPPS.ESProducers.ppsAssociationCuts_non_DB_cff as ac
-ac.use_single_infinite_iov_entry(ac.ppsAssociationCutsESSource,ac.p2018)
+ac.use_single_infinite_iov_entry(ac.ppsAssociationCutsESSource, ac.p2018)
+ppsAssociationCutsESSource = ac.ppsAssociationCutsESSource
 
 from CalibPPS.ESProducers.ctppsOpticalFunctions_non_DB_cff import optics_2018 as selected_optics
 

--- a/Validation/CTPPS/python/simu_config/year_2021_cff.py
+++ b/Validation/CTPPS/python/simu_config/year_2021_cff.py
@@ -1,8 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
 from Validation.CTPPS.simu_config.base_cff import *
+
 import CalibPPS.ESProducers.ppsAssociationCuts_non_DB_cff as ac
-ac.use_single_infinite_iov_entry(ac.ppsAssociationCutsESSource,ac.p2021)
+ac.use_single_infinite_iov_entry(ac.ppsAssociationCutsESSource, ac.p2021)
+ppsAssociationCutsESSource = ac.ppsAssociationCutsESSource
 
 from CalibPPS.ESProducers.ctppsOpticalFunctions_non_DB_cff import optics_2021 as selected_optics
 

--- a/Validation/CTPPS/python/simu_config/year_2022_cff.py
+++ b/Validation/CTPPS/python/simu_config/year_2022_cff.py
@@ -1,8 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
 from Validation.CTPPS.simu_config.base_cff import *
+
 import CalibPPS.ESProducers.ppsAssociationCuts_non_DB_cff as ac
-ac.use_single_infinite_iov_entry(ac.ppsAssociationCutsESSource,ac.p2022)
+ac.use_single_infinite_iov_entry(ac.ppsAssociationCutsESSource, ac.p2022)
+ppsAssociationCutsESSource = ac.ppsAssociationCutsESSource
 
 from CalibPPS.ESProducers.ctppsOpticalFunctions_non_DB_cff import optics_2022 as selected_optics
 


### PR DESCRIPTION
#### PR description:

This PR updates the default PPS reconstruction configuration to consume the `PPSAssociationCuts` from DB. A small correction is made to the condition format to ensure that all class fields are correctly initialised.

This PR needs to be considered together with an updated GT. In particular it was tested with `121X_dataRun3_Candidate_2021_10_21_12_37_53`.

This is a technical PR, no changes in results are expected.

#### PR validation:

The plots below compare results before (blue) and after this PR (red dashed)
  * [dirsim_cmp.pdf](https://github.com/cms-sw/cmssw/files/7389343/dirsim_cmp.pdf): for PPS direct simulation (+ reconstruction), Run2 and Run3
  * [reco_cmp.pdf](https://github.com/cms-sw/cmssw/files/7389344/reco_cmp.pdf): for PPS reconstruction, Run2 data

No differences observed as expected.


