### PR TITLE
switch loop index to uint from uint16 in FlagsCleanerECAL

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/plugins/FlagsCleanerECAL.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/FlagsCleanerECAL.cc
@@ -28,7 +28,7 @@ FlagsCleanerECAL::FlagsCleanerECAL(const edm::ParameterSet& conf, edm::ConsumesC
 void FlagsCleanerECAL::clean(const edm::Handle<reco::PFRecHitCollection>& input, std::vector<bool>& mask) {
   auto const& hits = *input;
 
-  for (uint16_t idx = 0; idx < hits.size(); ++idx) {
+  for (uint idx = 0; idx < hits.size(); ++idx) {
     if (!mask[idx])
       continue;  // don't need to re-mask things :-)
     const reco::PFRecHit& rechit = hits[idx];


### PR DESCRIPTION
this should resolve the problem reported in #35750

In the problematic event there are more than `max(uint16)` rechits and the loop index can never reach that value by incrementing.

