### PR TITLE
switch loop index to uint from uint16 in FlagsCleanerECAL (backport of #35768)

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/plugins/FlagsCleanerECAL.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/FlagsCleanerECAL.cc
@@ -28,7 +28,7 @@ FlagsCleanerECAL::FlagsCleanerECAL(const edm::ParameterSet& conf, edm::ConsumesC
 void FlagsCleanerECAL::clean(const edm::Handle<reco::PFRecHitCollection>& input, std::vector<bool>& mask) {
   auto const& hits = *input;
 
-  for (uint16_t idx = 0; idx < hits.size(); ++idx) {
+  for (uint idx = 0; idx < hits.size(); ++idx) {
     if (!mask[idx])
       continue;  // don't need to re-mask things :-)
     const reco::PFRecHit& rechit = hits[idx];


### PR DESCRIPTION
backport of #35768

tested with `cmsDriver.py RAW2RECO_slpashes21_Run345881 --conditions 120X_dataRun3_Express_v2 --customise Configuration/DataProcessing/RecoTLR.customiseExpress --data --datatier RECO --era Run3 --eventcontent RECO --filein "file:/afs/cern.ch/user/d/dkonst/public/splashEvents2021/skimSplashEvents2021_run_345881_2_CMSSW_12_0_2_patch2.root" --fileout "file:step2.root"  --no_exec  --number 10 --process reRECO --python_filename RAW2RECO_slpashes21_Run345881.py --scenario pp --step RAW2DIGI,L1Reco,RECO --customise_commands "process.source.eventsToProcess = cms.untracked.VEventRange('345881:790:18567','345881:782:18370','345881:796:18724','345881:801:18840','345881:1031:24241','345881:1037:24375')"
`

apparently the file has only to splash events. Still, with this fix both events are processed 
```
TimeEvent> 24241 345881 946.489
TimeEvent> 24375 345881 1306.25
```
