### PR TITLE
Fix CMS deprecated warnings in RecoMuon/MuonIdentification

### DIFF
--- a/RecoMuon/MuonIdentification/interface/CSCTimingExtractor.h
+++ b/RecoMuon/MuonIdentification/interface/CSCTimingExtractor.h
@@ -17,10 +17,8 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 

--- a/RecoMuon/MuonIdentification/interface/DTTimingExtractor.h
+++ b/RecoMuon/MuonIdentification/interface/DTTimingExtractor.h
@@ -17,10 +17,8 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 

--- a/RecoMuon/MuonIdentification/interface/MuonShowerInformationFiller.h
+++ b/RecoMuon/MuonIdentification/interface/MuonShowerInformationFiller.h
@@ -59,6 +59,11 @@ class TransientTrackingRecHitBuilder;
 class GeometricSearchTracker;
 class GlobalTrackingGeometry;
 class MuonDetLayerGeometry;
+class TrackerRecoGeometryRecord;
+class GlobalTrackingGeometryRecord;
+class IdealMagneticFieldRecord;
+class MuonGeometryRecord;
+class TransientRecHitRecord;
 
 class MuonShowerInformationFiller {
 public:
@@ -185,11 +190,11 @@ private:
   unsigned long long theCacheId_TRH;
   unsigned long long theCacheId_MT;
 
-  std::string theTrackerRecHitBuilderName;
   edm::ESHandle<TransientTrackingRecHitBuilder> theTrackerRecHitBuilder;
+  edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> theTrackerRecHitBuilderToken;
 
-  std::string theMuonRecHitBuilderName;
   edm::ESHandle<TransientTrackingRecHitBuilder> theMuonRecHitBuilder;
+  edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> theMuonRecHitBuilderToken;
 
   edm::InputTag theDTRecHitLabel;
   edm::InputTag theCSCRecHitLabel;
@@ -212,5 +217,11 @@ private:
   edm::ESHandle<MagneticField> theField;
   edm::ESHandle<CSCGeometry> theCSCGeometry;
   edm::ESHandle<DTGeometry> theDTGeometry;
+
+  edm::ESGetToken<GeometricSearchTracker, TrackerRecoGeometryRecord> theTrackerToken;
+  edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> theTrackingGeometryToken;
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> theFieldToken;
+  edm::ESGetToken<CSCGeometry, MuonGeometryRecord> theCSCGeometryToken;
+  edm::ESGetToken<DTGeometry, MuonGeometryRecord> theDTGeometryToken;
 };
 #endif

--- a/RecoMuon/MuonIdentification/interface/MuonTimingFiller.h
+++ b/RecoMuon/MuonIdentification/interface/MuonTimingFiller.h
@@ -24,10 +24,8 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 

--- a/RecoMuon/MuonIdentification/src/CSCTimingExtractor.cc
+++ b/RecoMuon/MuonIdentification/src/CSCTimingExtractor.cc
@@ -19,10 +19,8 @@
 // user include files
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 

--- a/RecoMuon/MuonIdentification/src/DTTimingExtractor.cc
+++ b/RecoMuon/MuonIdentification/src/DTTimingExtractor.cc
@@ -19,10 +19,8 @@
 // user include files
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 

--- a/RecoMuon/MuonIdentification/src/MuonTimingFiller.cc
+++ b/RecoMuon/MuonIdentification/src/MuonTimingFiller.cc
@@ -20,10 +20,8 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 

--- a/RecoMuon/MuonIdentification/test/MuonTimingValidator.cc
+++ b/RecoMuon/MuonIdentification/test/MuonTimingValidator.cc
@@ -29,7 +29,6 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -89,6 +88,7 @@ MuonTimingValidator::MuonTimingValidator(const edm::ParameterSet& iConfig)
       DtTimeTokens_(consumes<reco::MuonTimeExtraMap>(DtTimeTags_)),
       CscTimeTags_(iConfig.getUntrackedParameter<edm::InputTag>("CscTiming")),
       CscTimeTokens_(consumes<reco::MuonTimeExtraMap>(CscTimeTags_)),
+      trackingGeometryToken_(esConsumes()),
       out(iConfig.getParameter<std::string>("out")),
       open(iConfig.getParameter<std::string>("open")),
       theMinEta(iConfig.getParameter<double>("etaMin")),
@@ -138,8 +138,7 @@ void MuonTimingValidator::analyze(const edm::Event& iEvent, const edm::EventSetu
   iEvent.getByToken(CscTimeTokens_, timeMap3);
   const reco::MuonTimeExtraMap& timeMapCSC = *timeMap3;
 
-  edm::ESHandle<GlobalTrackingGeometry> theTrackingGeometry;
-  iSetup.get<GlobalTrackingGeometryRecord>().get(theTrackingGeometry);
+  edm::ESHandle<GlobalTrackingGeometry> theTrackingGeometry = iSetup.getHandle(trackingGeometryToken_);
 
   reco::MuonCollection::const_iterator imuon;
 

--- a/RecoMuon/MuonIdentification/test/MuonTimingValidator.h
+++ b/RecoMuon/MuonIdentification/test/MuonTimingValidator.h
@@ -8,7 +8,7 @@
  */
 
 // Base Class Headers
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 
 #include "SimDataFormats/Track/interface/SimTrack.h"
@@ -44,20 +44,21 @@ class TH2F;
 //class SimTrackRef;
 //class MuonRef;
 class MuonServiceProxy;
+class GlobalTrackingGeometryRecord;
 
-class MuonTimingValidator : public edm::EDAnalyzer {
+class MuonTimingValidator : public edm::one::EDAnalyzer<> {
 public:
   explicit MuonTimingValidator(const edm::ParameterSet&);
-  ~MuonTimingValidator();
+  ~MuonTimingValidator() override;
 
   typedef std::pair<reco::TrackRef, SimTrackRef> CandToSim;
   typedef std::pair<reco::TrackRef, SimTrackRef> CandStaSim;
   typedef std::pair<reco::TrackRef, SimTrackRef> CandMuonSim;
 
 private:
-  virtual void beginJob();
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void endJob();
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
 
   virtual float calculateDistance(const math::XYZVector&, const math::XYZVector&);
   virtual TH1F* divideErr(TH1F*, TH1F*, TH1F*);
@@ -75,6 +76,8 @@ private:
   edm::InputTag CscTimeTags_;
   edm::EDGetTokenT<reco::MuonTimeExtraMap> CscTimeTokens_;
   edm::InputTag SIMtrackTags_;
+
+  edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> trackingGeometryToken_;
 
   std::string out, open;
   double theMinEta, theMaxEta, theMinPt, thePtCut, theMinPtres, theMaxPtres, theScale;

--- a/RecoMuon/MuonIdentification/test/TestMuons.cc
+++ b/RecoMuon/MuonIdentification/test/TestMuons.cc
@@ -10,7 +10,7 @@
  */
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -25,32 +25,34 @@
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 
-class TestMuons : public edm::EDAnalyzer {
+class TestMuons : public edm::one::EDAnalyzer<> {
 public:
   explicit TestMuons(const edm::ParameterSet&);
   virtual ~TestMuons() {}
 
   virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  void printMuonCollections(const edm::Handle<edm::View<reco::Muon> >& muons);
+  void printMuonCollections(const edm::Handle<edm::View<reco::Muon>>& muons);
   void checkTimeMaps(const edm::Event& iEvent, const edm::Handle<reco::MuonCollection>& muons);
   void checkPFMap(const edm::Event& iEvent, const edm::Handle<reco::MuonCollection>& muons);
 
 private:
   edm::InputTag theInput;
+  edm::EDGetTokenT<edm::View<reco::Muon>> theMuonsVToken;
+  edm::EDGetTokenT<reco::MuonCollection> theMuonsToken;
 };
 #endif
 
 TestMuons::TestMuons(const edm::ParameterSet& iConfig) {
   theInput = iConfig.getParameter<edm::InputTag>("InputCollection");
+  theMuonsVToken = consumes(theInput);
+  theMuonsToken = consumes(theInput);
 }
 
 void TestMuons::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  edm::Handle<edm::View<reco::Muon> > muonsV;
-  iEvent.getByLabel(theInput, muonsV);
+  edm::Handle<edm::View<reco::Muon>> muonsV = iEvent.getHandle(theMuonsVToken);
   printMuonCollections(muonsV);
 
-  edm::Handle<reco::MuonCollection> muons;
-  iEvent.getByLabel(theInput, muons);
+  edm::Handle<reco::MuonCollection> muons = iEvent.getHandle(theMuonsToken);
 
   checkTimeMaps(iEvent, muons);
   checkPFMap(iEvent, muons);
@@ -75,7 +77,7 @@ void TestMuons::checkTimeMaps(const edm::Event& iEvent, const edm::Handle<reco::
   }
 }
 
-void TestMuons::printMuonCollections(const edm::Handle<edm::View<reco::Muon> >& muons) {
+void TestMuons::printMuonCollections(const edm::Handle<edm::View<reco::Muon>>& muons) {
   for (edm::View<reco::Muon>::const_iterator muon = muons->begin(); muon != muons->end(); ++muon) {
     std::cout << "\n----------------------------------------------------" << std::endl;
     std::cout << "Muon (pt,eta,phi): " << muon->pt() << ", " << muon->eta() << ", " << muon->phi() << std::endl;
@@ -124,7 +126,7 @@ void TestMuons::printMuonCollections(const edm::Handle<edm::View<reco::Muon> >& 
 void TestMuons::checkPFMap(const edm::Event& iEvent, const edm::Handle<reco::MuonCollection>& muons) {
   std::cout << "checkPFMaps" << std::endl;
 
-  edm::Handle<edm::ValueMap<reco::PFCandidatePtr> > pfMap;
+  edm::Handle<edm::ValueMap<reco::PFCandidatePtr>> pfMap;
   iEvent.getByLabel("particleFlow", theInput.label(), pfMap);
 
   for (unsigned int imucount = 0; imucount < muons->size(); ++imucount) {


### PR DESCRIPTION
#### PR description:

- Added esConsumes and consumes
- Moved test modules away from legacy modules
- Removed unnecesary includes

#### PR validation:

Code compiles. Changes are not meant to change any results.