### PR TITLE
Include PPS persistent geometry in all GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,17 +24,17 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'                   : '121X_mcRun2_pA_v7',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'                    : '121X_dataRun2_v6',
+    'run2_data'                    : '121X_dataRun2_v7',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_HEfail'             : '121X_dataRun2_HEfail_v6',
+    'run2_data_HEfail'             : '121X_dataRun2_HEfail_v7',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'             : '121X_dataRun2_relval_v6',
+    'run2_data_relval'             : '121X_dataRun2_relval_v7',
     # GlobalTag for Run2 HI data
-    'run2_data_promptlike_hi'      : '121X_dataRun2_PromptLike_HI_v6',
+    'run2_data_promptlike_hi'      : '121X_dataRun2_PromptLike_HI_v7',
     # GlobalTag for Run3 HLT: it points to the online GT
     'run3_hlt'                     : '121X_dataRun3_HLT_v7',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'              : '121X_dataRun2_HLT_relval_v6',
+    'run2_hlt_relval'              : '121X_dataRun2_HLT_relval_v7',
     # GlobalTag for Run3 data relvals (express GT)
     'run3_data_express'            : '121X_dataRun3_Express_v8',
     # GlobalTag for Run3 data relvals

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,23 +24,23 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'                   : '121X_mcRun2_pA_v7',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'                    : '121X_dataRun2_v7',
+    'run2_data'                    : '121X_dataRun2_v8',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_HEfail'             : '121X_dataRun2_HEfail_v7',
+    'run2_data_HEfail'             : '121X_dataRun2_HEfail_v8',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'             : '121X_dataRun2_relval_v7',
+    'run2_data_relval'             : '121X_dataRun2_relval_v8',
     # GlobalTag for Run2 HI data
-    'run2_data_promptlike_hi'      : '121X_dataRun2_PromptLike_HI_v7',
+    'run2_data_promptlike_hi'      : '121X_dataRun2_PromptLike_HI_v8',
     # GlobalTag for Run3 HLT: it points to the online GT
-    'run3_hlt'                     : '121X_dataRun3_HLT_v7',
+    'run3_hlt'                     : '121X_dataRun3_HLT_v8',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'              : '121X_dataRun2_HLT_relval_v7',
+    'run2_hlt_relval'              : '121X_dataRun2_HLT_relval_v8',
     # GlobalTag for Run3 data relvals (express GT)
-    'run3_data_express'            : '121X_dataRun3_Express_v8',
+    'run3_data_express'            : '121X_dataRun3_Express_v9',
     # GlobalTag for Run3 data relvals
-    'run3_data_prompt'             : '121X_dataRun3_Prompt_v7',
+    'run3_data_prompt'             : '121X_dataRun3_Prompt_v8',
     # GlobalTag for Run3 offline data reprocessing
-    'run3_data'                    : '121X_dataRun3_v6',
+    'run3_data'                    : '121X_dataRun3_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'           : '121X_mc2017_design_v7',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -8,77 +8,77 @@ autoCond = {
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
     'run1_mc_hi'                   : '121X_mcRun1_HeavyIon_v7',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'                 : '121X_mcRun2_startup_v6',
+    'run2_mc_50ns'                 : '121X_mcRun2_startup_v7',
     # GlobalTag for MC production (2015 L1 Trigger Stage1) with startup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
-    'run2_mc_l1stage1'             : '121X_mcRun2_asymptotic_l1stage1_v6',
+    'run2_mc_l1stage1'             : '121X_mcRun2_asymptotic_l1stage1_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'                  : '121X_mcRun2_design_v6',
+    'run2_design'                  : '121X_mcRun2_design_v7',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, prior to VFP change
-    'run2_mc_pre_vfp'              : '121X_mcRun2_asymptotic_preVFP_v6',
+    'run2_mc_pre_vfp'              : '121X_mcRun2_asymptotic_preVFP_v7',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, after VFP change
-    'run2_mc'                      : '121X_mcRun2_asymptotic_v6',
+    'run2_mc'                      : '121X_mcRun2_asymptotic_v7',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'              : '121X_mcRun2cosmics_asymptotic_deco_v6',
+    'run2_mc_cosmics'              : '121X_mcRun2cosmics_asymptotic_deco_v7',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'                   : '121X_mcRun2_HeavyIon_v6',
+    'run2_mc_hi'                   : '121X_mcRun2_HeavyIon_v7',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'                   : '121X_mcRun2_pA_v6',
+    'run2_mc_pa'                   : '121X_mcRun2_pA_v7',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'                    : '121X_dataRun2_v5',
+    'run2_data'                    : '121X_dataRun2_v6',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_HEfail'             : '121X_dataRun2_HEfail_v5',
+    'run2_data_HEfail'             : '121X_dataRun2_HEfail_v6',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'             : '121X_dataRun2_relval_v5',
+    'run2_data_relval'             : '121X_dataRun2_relval_v6',
     # GlobalTag for Run2 HI data
-    'run2_data_promptlike_hi'      : '121X_dataRun2_PromptLike_HI_v5',
+    'run2_data_promptlike_hi'      : '121X_dataRun2_PromptLike_HI_v6',
     # GlobalTag for Run3 HLT: it points to the online GT
-    'run3_hlt'                     : '121X_dataRun3_HLT_v6',
+    'run3_hlt'                     : '121X_dataRun3_HLT_v7',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'              : '121X_dataRun2_HLT_relval_v5',
+    'run2_hlt_relval'              : '121X_dataRun2_HLT_relval_v6',
     # GlobalTag for Run3 data relvals (express GT)
-    'run3_data_express'            : '121X_dataRun3_Express_v6',
+    'run3_data_express'            : '121X_dataRun3_Express_v8',
     # GlobalTag for Run3 data relvals
-    'run3_data_prompt'             : '121X_dataRun3_Prompt_v6',
+    'run3_data_prompt'             : '121X_dataRun3_Prompt_v7',
     # GlobalTag for Run3 offline data reprocessing
-    'run3_data'                    : '121X_dataRun3_v5',
+    'run3_data'                    : '121X_dataRun3_v6',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'           : '121X_mc2017_design_v6',
+    'phase1_2017_design'           : '121X_mc2017_design_v7',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'        : '121X_mc2017_realistic_v6',
+    'phase1_2017_realistic'        : '121X_mc2017_realistic_v7',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector, for PP reference run
     'phase1_2017_realistic_ppref'  :  '120X_mc2017_realistic_forppRef5TeV_v2',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'          : '121X_mc2017cosmics_realistic_deco_v6',
+    'phase1_2017_cosmics'          : '121X_mc2017cosmics_realistic_deco_v7',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak'     : '121X_mc2017cosmics_realistic_peak_v6',
+    'phase1_2017_cosmics_peak'     : '121X_mc2017cosmics_realistic_peak_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'           : '121X_upgrade2018_design_v6',
+    'phase1_2018_design'           : '121X_upgrade2018_design_v7',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'        : '121X_upgrade2018_realistic_v6',
+    'phase1_2018_realistic'        : '121X_upgrade2018_realistic_v7',
     # GlobalTag for MC production with realistic run-dependent (RD) conditions for full Phase1 2018 detector
-    'phase1_2018_realistic_rd'     : '121X_upgrade2018_realistic_RD_v6',
+    'phase1_2018_realistic_rd'     : '121X_upgrade2018_realistic_RD_v7',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi'     : '121X_upgrade2018_realistic_HI_v6',
+    'phase1_2018_realistic_hi'     : '121X_upgrade2018_realistic_HI_v7',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' : '121X_upgrade2018_realistic_HEfail_v6',
+    'phase1_2018_realistic_HEfail' : '121X_upgrade2018_realistic_HEfail_v7',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'          : '121X_upgrade2018cosmics_realistic_deco_v8',
+    'phase1_2018_cosmics'          : '121X_upgrade2018cosmics_realistic_deco_v9',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak'     : '121X_upgrade2018cosmics_realistic_peak_v6',
+    'phase1_2018_cosmics_peak'     : '121X_upgrade2018cosmics_realistic_peak_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'           : '121X_mcRun3_2021_design_v11',
+    'phase1_2021_design'           : '121X_mcRun3_2021_design_v12',
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'        : '121X_mcRun3_2021_realistic_v13',
+    'phase1_2021_realistic'        : '121X_mcRun3_2021_realistic_v14',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'          : '121X_mcRun3_2021cosmics_realistic_deco_v13',
+    'phase1_2021_cosmics'          : '121X_mcRun3_2021cosmics_realistic_deco_v14',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi'     : '121X_mcRun3_2021_realistic_HI_v13',
+    'phase1_2021_realistic_hi'     : '121X_mcRun3_2021_realistic_HI_v14',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '121X_mcRun3_2023_realistic_v12',
+    'phase1_2023_realistic'        : '121X_mcRun3_2023_realistic_v13',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '121X_mcRun3_2024_realistic_v12',
+    'phase1_2024_realistic'        : '121X_mcRun3_2024_realistic_v13',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             : '121X_mcRun4_realistic_v6'
+    'phase2_realistic'             : '121X_mcRun4_realistic_v7'
 }
 
 aliases = {

--- a/Geometry/VeryForwardGeometry/python/geometryRPFromDB_cfi.py
+++ b/Geometry/VeryForwardGeometry/python/geometryRPFromDB_cfi.py
@@ -1,15 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
-XMLIdealGeometryESSource_CTPPS = cms.ESProducer("XMLIdealGeometryESProducer",
-    rootDDName = cms.string('cms:CMSE'),
-    label = cms.string('CTPPS'),
-    appendToDataLabel = cms.string('XMLIdealGeometryESSource_CTPPS')
-)
-
 ctppsGeometryESModule = cms.ESProducer("CTPPSGeometryESModule",
+    fromPreprocessedDB = cms.untracked.bool(True),
     verbosity = cms.untracked.uint32(1),
     isRun2 = cms.bool(False),
-    compactViewTag = cms.string('XMLIdealGeometryESSource_CTPPS')
 )
 
 from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016


### PR DESCRIPTION
#### PR description:

This PR adds the PPS geometry (DDD) defined by the persistent object PDetGeomDesc to the MC and data GTs, as requested in https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4497.html and validated according to https://indico.cern.ch/event/1048769/contributions/4406163/attachments/2263922/3843371/PPS_AlCADBMeeting__2021-06-14.pdf

The new tags for MC are:
PPSRECO_Geometry_121YV1_2017_mc
PPSRECO_Geometry_121YV1_2018_mc
PPSRECO_Geometry_121YV2_2021_mc

And for data:
PPSRECO_Geometry_121YV3

[edit] PPSRECO_Geometry_121YV2 had to be updated to PPSRECO_Geometry_121YV3 to have the since from IOV=1.

The diffs between the old and new GTs are below [*].

It also switches the proton reconstruction configuration file to consume the geometry persistent object loaded from DB instead of the XMLFile Blob, as it was attempted in PR #34549.

[*] GT diffs:

**mcRun2_startup**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun2_startup_v6/121X_mcRun2_startup_v7

**mcRun2_asymptotic_l1stage1**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun2_asymptotic_l1stage1_v6/121X_mcRun2_asymptotic_l1stage1_v7

**mcRun2_design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun2_design_v6/121X_mcRun2_design_v7

**mcRun2_asymptotic_preVFP**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun2_asymptotic_preVFP_v6/121X_mcRun2_asymptotic_preVFP_v7

**mcRun2_asymptotic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun2_asymptotic_v6/121X_mcRun2_asymptotic_v7

**mcRun2cosmics_asymptotic_deco**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun2cosmics_asymptotic_deco_v6/121X_mcRun2cosmics_asymptotic_deco_v7

**mcRun2_HeavyIon**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun2_HeavyIon_v6/121X_mcRun2_HeavyIon_v7

**mcRun2_pA**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun2_pA_v6/121X_mcRun2_pA_v7

**dataRun2**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_dataRun2_v5/121X_dataRun2_v8

**dataRun2_HEfail**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_dataRun2_HEfail_v5/121X_dataRun2_HEfail_v8

**dataRun2_relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_dataRun2_relval_v5/121X_dataRun2_relval_v8

**dataRun2_PromptLike_HI**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_dataRun2_PromptLike_HI_v5/121X_dataRun2_PromptLike_HI_v8

**dataRun3_HLT**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_dataRun3_HLT_v6/121X_dataRun3_HLT_v8

**dataRun2_HLT_relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_dataRun2_HLT_relval_v5/121X_dataRun2_HLT_relval_v8

**dataRun3_Express**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_dataRun3_Express_v6/121X_dataRun3_Express_v9

**dataRun3_Prompt**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_dataRun3_Prompt_v6/121X_dataRun3_Prompt_v8

**dataRun3**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_dataRun3_v5/121X_dataRun3_v7

**mc2017_design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mc2017_design_v6/121X_mc2017_design_v7

**mc2017_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mc2017_realistic_v6/121X_mc2017_realistic_v7

**mc2017cosmics_realistic_deco**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mc2017cosmics_realistic_deco_v6/121X_mc2017cosmics_realistic_deco_v7

**mc2017cosmics_realistic_peak**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mc2017cosmics_realistic_peak_v6/121X_mc2017cosmics_realistic_peak_v7

**upgrade2018_design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_upgrade2018_design_v6/121X_upgrade2018_design_v7

**upgrade2018_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_upgrade2018_realistic_v6/121X_upgrade2018_realistic_v7

**upgrade2018_realistic_RD**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_upgrade2018_realistic_RD_v6/121X_upgrade2018_realistic_RD_v7

**upgrade2018_realistic_HI**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_upgrade2018_realistic_HI_v6/121X_upgrade2018_realistic_HI_v7

**upgrade2018_realistic_HEfail**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_upgrade2018_realistic_HEfail_v6/121X_upgrade2018_realistic_HEfail_v7

**upgrade2018cosmics_realistic_deco**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_upgrade2018cosmics_realistic_deco_v8/121X_upgrade2018cosmics_realistic_deco_v9

**upgrade2018cosmics_realistic_peak**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_upgrade2018cosmics_realistic_peak_v6/121X_upgrade2018cosmics_realistic_peak_v7

**mcRun3_2021_design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021_design_v11/121X_mcRun3_2021_design_v12

**mcRun3_2021_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021_realistic_v13/121X_mcRun3_2021_realistic_v14

**mcRun3_2021cosmics_realistic_deco**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021cosmics_realistic_deco_v13/121X_mcRun3_2021cosmics_realistic_deco_v14

**mcRun3_2021_realistic_HI**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021_realistic_HI_v13/121X_mcRun3_2021_realistic_HI_v14

**mcRun3_2023_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2023_realistic_v12/121X_mcRun3_2023_realistic_v13

**mcRun3_2024_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2024_realistic_v12/121X_mcRun3_2024_realistic_v13

**mcRun4_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun4_realistic_v6/121X_mcRun4_realistic_v7


FYI, @wpcarvalho @fabferro @jan-kaspar @vavati @clemencia 

#### PR validation:

runTheMatrix.py -l limited,145,1325.516,281,1307,10424,7.21,11224,11024.2,250200.182,7.4,12034,7.23,12834,23234,138.2,138.1,136.8642,136.88811,136.897,11925 --ibeos -j8

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

no backport is foreseen.
