### PR TITLE
Fix deprecated warnings in RecoJets/JetProducers

### DIFF
--- a/RecoJets/JetProducers/interface/JetIDHelper.h
+++ b/RecoJets/JetProducers/interface/JetIDHelper.h
@@ -16,6 +16,9 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
+class HcalTopology;
+class HcalRecNumberingRecord;
+
 namespace reco {
 
   namespace helper {
@@ -147,6 +150,8 @@ namespace reco {
       edm::EDGetTokenT<HFRecHitCollection> input_HFRecHits_token_;
       edm::EDGetTokenT<EBRecHitCollection> input_EBRecHits_token_;
       edm::EDGetTokenT<EERecHitCollection> input_EERecHits_token_;
+
+      edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> hcal_topo_token_;
     };
   }  // namespace helper
 }  // namespace reco

--- a/RecoJets/JetProducers/interface/QjetsAdder.h
+++ b/RecoJets/JetProducers/interface/QjetsAdder.h
@@ -4,13 +4,13 @@
 #include <memory>
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include "RecoJets/JetAlgorithms/interface/QjetsPlugin.h"
 
-class QjetsAdder : public edm::EDProducer {
+class QjetsAdder : public edm::stream::EDProducer<> {
 public:
   explicit QjetsAdder(const edm::ParameterSet& iConfig)
       : src_(iConfig.getParameter<edm::InputTag>("src")),
@@ -41,7 +41,6 @@ private:
   double jetRad_;
   std::string mJetAlgo_;
   int QjetsPreclustering_;
-  edm::Service<edm::RandomNumberGenerator> rng_;
 };
 
 #endif

--- a/RecoJets/JetProducers/plugins/PileupJPTJetIdProducer.cc
+++ b/RecoJets/JetProducers/plugins/PileupJPTJetIdProducer.cc
@@ -3,14 +3,12 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "DataFormats/JetReco/interface/Jet.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "DataFormats/Common/interface/ValueMap.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/EventSetup.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -19,7 +17,7 @@
 #include "DataFormats/JetReco/interface/JPTJet.h"
 
 // ------------------------------------------------------------------------------------------
-class PileupJPTJetIdProducer : public edm::EDProducer {
+class PileupJPTJetIdProducer : public edm::stream::EDProducer<> {
 public:
   explicit PileupJPTJetIdProducer(const edm::ParameterSet&);
   ~PileupJPTJetIdProducer() override;

--- a/RecoJets/JetProducers/src/JetIDHelper.cc
+++ b/RecoJets/JetProducers/src/JetIDHelper.cc
@@ -3,9 +3,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
@@ -57,6 +55,8 @@ reco::helper::JetIDHelper::JetIDHelper(edm::ParameterSet const &pset, edm::Consu
   input_HFRecHits_token_ = iC.consumes<HFRecHitCollection>(hfRecHitsColl_);
   input_EBRecHits_token_ = iC.consumes<EBRecHitCollection>(ebRecHitsColl_);
   input_EERecHits_token_ = iC.consumes<EERecHitCollection>(eeRecHitsColl_);
+
+  hcal_topo_token_ = iC.esConsumes();
 }
 
 void reco::helper::JetIDHelper::initValues() {
@@ -288,8 +288,7 @@ void reco::helper::JetIDHelper::classifyJetComponents(const edm::Event &event,
   RBX_energies.clear();
   LS_bad_energy = HF_OOT_energy = 0.;
 
-  edm::ESHandle<HcalTopology> theHcalTopology;
-  setup.get<HcalRecNumberingRecord>().get(theHcalTopology);
+  edm::ESHandle<HcalTopology> theHcalTopology = setup.getHandle(hcal_topo_token_);
 
   std::map<int, double> HPD_energy_map, RBX_energy_map;
   vector<double> EB_energies, EE_energies, HB_energies, HE_energies, short_energies, long_energies;


### PR DESCRIPTION
#### PR description:

- added esConsumes
- switched to non-legacy module base classes

#### PR validation:

Code compiles. None of the changes are meant to change the results.