### PR TITLE
Rename `.icc` files in CommonTools/Statistics to `.h` files

### DIFF
--- a/CommonTools/Statistics/interface/hsm_1d.h
+++ b/CommonTools/Statistics/interface/hsm_1d.h
@@ -1,5 +1,5 @@
-#ifndef _HSM_1D_ICC_
-#define _HSM_1D_ICC_
+#ifndef CommonTools_Statistics_hsm_1d_h
+#define CommonTools_Statistics_hsm_1d_h
 
 #include "CommonTools/Statistics/interface/StatisticsException.h"
 

--- a/CommonTools/Statistics/interface/lms_1d.h
+++ b/CommonTools/Statistics/interface/lms_1d.h
@@ -1,5 +1,5 @@
-#ifndef _LMS_1D_ICC_
-#define _LMS_1D_ICC_
+#ifndef CommonTools_Statistics_lms_1d_h
+#define CommonTools_Statistics_lms_1d_h
 
 #include "CommonTools/Statistics/interface/StatisticsException.h"
 

--- a/CommonTools/Statistics/interface/median.h
+++ b/CommonTools/Statistics/interface/median.h
@@ -1,5 +1,5 @@
-#ifndef MEDIAN_ICC
-#define MEDIAN_ICC
+#ifndef CommonTools_Statistics_median_h
+#define CommonTools_Statistics_median_h
 
 #include <vector>
 #include <algorithm>

--- a/CommonTools/Statistics/src/hsm_1d.cc
+++ b/CommonTools/Statistics/src/hsm_1d.cc
@@ -1,1 +1,0 @@
-#include "CommonTools/Statistics/interface/hsm_1d.icc"

--- a/CommonTools/Statistics/src/lms_1d.cc
+++ b/CommonTools/Statistics/src/lms_1d.cc
@@ -1,1 +1,0 @@
-#include "CommonTools/Statistics/interface/lms_1d.icc"

--- a/CommonTools/Statistics/src/median.cc
+++ b/CommonTools/Statistics/src/median.cc
@@ -1,1 +1,0 @@
-#include "CommonTools/Statistics/interface/median.icc"

--- a/RecoVertex/VertexTools/src/hsm_3d.cc
+++ b/RecoVertex/VertexTools/src/hsm_3d.cc
@@ -1,5 +1,5 @@
 #include "RecoVertex/VertexTools/interface/hsm_3d.h"
-#include "CommonTools/Statistics/interface/hsm_1d.icc"
+#include "CommonTools/Statistics/interface/hsm_1d.h"
 #include "RecoVertex/VertexPrimitives/interface/VertexException.h"
 
 #include <iostream>

--- a/RecoVertex/VertexTools/src/lms_3d.cc
+++ b/RecoVertex/VertexTools/src/lms_3d.cc
@@ -1,4 +1,4 @@
-#include "CommonTools/Statistics/interface/lms_1d.icc"
+#include "CommonTools/Statistics/interface/lms_1d.h"
 #include "RecoVertex/VertexTools/interface/lms_3d.h"
 #include "RecoVertex/VertexPrimitives/interface/VertexException.h"
 #include <vector>


### PR DESCRIPTION
#### PR description:

It's not good that there were no real header files for some of the functions in `CommonTools/Statistics` this meant that other packages like ` RecoVertex/VertexTools` had to include these `.icc` files, which is not the idea.

Either we have a `.h` file where the templated function is forward-declared and then the `.icc` file with the implementation is included, or the just put the full implementation in the `.h` file as usual in CMSSW. This PR implements the latter solution.

#### PR validation:

CMSSW compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport intended.