### PR TITLE
add basic data run3 reco and apply to splash events as a wf 138.3; fix tools for simple lumi list

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixUtil.py
+++ b/Configuration/PyReleaseValidation/python/MatrixUtil.py
@@ -151,7 +151,11 @@ class InputInfo(object):
       if self.ls:
         for run in self.ls.keys():
           run_lumis = []
-          for rng in self.ls[run]: run_lumis.append(str(rng[0])+","+str(rng[1]))
+          for rng in self.ls[run]:
+              if isinstance(rng, int):
+                  run_lumis.append(str(rng))
+              else:
+                  run_lumis.append(str(rng[0])+","+str(rng[1]))
           query_lumis.append(":".join(run_lumis))
       return query_lumis
 

--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -437,7 +437,7 @@ workflows[137.8] = ['',['RunEGamma2018C','HLTDR2_2018','RECODR2_2018reHLT_skimEG
 workflows[138.1] = ['',['RunCosmics2021','RECOCOSDPROMPTRUN3','ALCACOSDPROMPTRUN3','HARVESTDCPROMPTRUN3']]
 workflows[138.2] = ['',['RunCosmics2021','RECOCOSDEXPRUN3','ALCACOSDEXPRUN3','HARVESTDCEXPRUN3']]
 ### 2021 Splash events
-workflows[138.3] = ['',['RunMinimumBias2021Splash','RECODR3','HARVESTDR3']]
+workflows[138.3] = ['',['RunMinimumBias2021Splash','RECODR3Splash','HARVESTDR3']]
 
 #### Test of lumi section boundary crossing with run2 2018D ####
 workflows[136.8861] = ['',['RunEGamma2018Dml1','HLTDR2_2018ml','RECODR2_2018reHLT_skimEGamma_Prompt_L1TEgDQM','HARVEST2018_L1TEgDQM_Prompt']]

--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -436,6 +436,8 @@ workflows[137.8] = ['',['RunEGamma2018C','HLTDR2_2018','RECODR2_2018reHLT_skimEG
 ### LS2 - MWGR ###
 workflows[138.1] = ['',['RunCosmics2021','RECOCOSDPROMPTRUN3','ALCACOSDPROMPTRUN3','HARVESTDCPROMPTRUN3']]
 workflows[138.2] = ['',['RunCosmics2021','RECOCOSDEXPRUN3','ALCACOSDEXPRUN3','HARVESTDCEXPRUN3']]
+### 2021 Splash events
+workflows[138.3] = ['',['RunMinimumBias2021Splash','RECODR3','HARVESTDR3']]
 
 #### Test of lumi section boundary crossing with run2 2018D ####
 workflows[136.8861] = ['',['RunEGamma2018Dml1','HLTDR2_2018ml','RECODR2_2018reHLT_skimEGamma_Prompt_L1TEgDQM','HARVEST2018_L1TEgDQM_Prompt']]

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -497,6 +497,11 @@ steps['RunCosmics2021']={'INPUT':InputInfo(dataSet='/ExpressCosmics/Commissionin
 ##Run 344518 @ 0T 2021CRUZET
 steps['RunCosmics2021CRUZET']={'INPUT':InputInfo(dataSet='/Cosmics/Commissioning2021-v1/RAW',label='2021CRUZET',run=[344518],events=100000,location='STD')}
 
+#### run3 Splash ####
+##Run 345881
+steps['RunMinimumBias2021Splash']={'INPUT':InputInfo(dataSet='/MinimumBias/Commissioning2021-v1/RAW',label='2021Splash',ls={345881: [782, 790, 796, 801, 1031, 1037]},events=100000,location='STD')}
+
+
 #### Test of lumi section boundary crossing with run2 2018D ####
 Run2018Dml1={320822: [[1,1]] , 320823: [[1,1]]}
 Run2018Dml2={320822: [[1,2]]}
@@ -1904,6 +1909,8 @@ steps['RECODR2_25ns']=merge([{'--scenario':'pp','--conditions':'auto:run2_data_r
 steps['RECODR2_2016']=merge([{'--scenario':'pp','--conditions':'auto:run2_data_relval','--era':'Run2_2016','--customise':'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2016'},dataReco])
 steps['RECODR2_2017']=merge([{'--scenario':'pp','--conditions':'auto:run2_data_relval','--era':'Run2_2017','--customise':'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017'},dataReco])
 steps['RECODR2_2018']=merge([{'--scenario':'pp','--conditions':'auto:run2_data_relval','--era':'Run2_2018','--customise':'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018'},dataReco])
+#Run 3
+steps['RECODR3']=merge([{'--scenario':'pp','--conditions':'auto:run3_data_prompt','--era':'Run3','--customise':'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3'},dataReco])
 
 steps['RECODR2AlCaEle']=merge([{'--scenario':'pp','--conditions':'auto:run2_data_relval','--customise':'Configuration/DataProcessing/RecoTLR.customisePromptRun2',},dataRecoAlCaCalo])
 
@@ -2802,6 +2809,10 @@ steps['HARVEST2018_L1TEgDQM_MULTIRUN'] = merge([ {
         # hardcode the input files since we need multiple, from each of the RECO steps.
         '--filein':"file:step6_inDQM.root,file:step3_inDQM.root",
     }, steps['HARVEST2018_L1TEgDQM'] ])
+
+
+#RUN3
+steps['HARVESTDR3'] = merge([ {'--conditions':'auto:run3_data_prompt','--era':'Run3'}, steps['HARVESTD'] ])
 
 steps['DQMHLTonAOD_2017']={
     '-s':'DQM:offlineHLTSourceOnAOD', ### DQM-only workflow on AOD input: for HLT

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1911,6 +1911,7 @@ steps['RECODR2_2017']=merge([{'--scenario':'pp','--conditions':'auto:run2_data_r
 steps['RECODR2_2018']=merge([{'--scenario':'pp','--conditions':'auto:run2_data_relval','--era':'Run2_2018','--customise':'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018'},dataReco])
 #Run 3
 steps['RECODR3']=merge([{'--scenario':'pp','--conditions':'auto:run3_data_prompt','--era':'Run3','--customise':'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3'},dataReco])
+steps['RECODR3Splash']=merge([{'-n': 2},steps['RECODR3']])
 
 steps['RECODR2AlCaEle']=merge([{'--scenario':'pp','--conditions':'auto:run2_data_relval','--customise':'Configuration/DataProcessing/RecoTLR.customisePromptRun2',},dataRecoAlCaCalo])
 

--- a/Configuration/PyReleaseValidation/scripts/das-selected-lumis.py
+++ b/Configuration/PyReleaseValidation/scripts/das-selected-lumis.py
@@ -17,7 +17,10 @@ lumi_data = lumi_data['data']
 
 def match_in(sub_list,lumi_list):
   for i in range(int(sub_list[0]),int(sub_list[1])+1):
-    if i >= int(lumi_list[0]) and i <= int(lumi_list[1]): return True
+    if len(lumi_list) == 1:
+      if i == int(lumi_list[0]): return True
+    else:
+      if i >= int(lumi_list[0]) and i <= int(lumi_list[1]): return True
   return False
 
 def check_lumi_ranges(given_lumi_list , sub_range):

--- a/FWCore/PythonUtilities/python/LumiList.py
+++ b/FWCore/PythonUtilities/python/LumiList.py
@@ -111,10 +111,13 @@ class LumiList(object):
             newLumis = []
             for lumi in sorted(self.compactList[run]):
                 # If the next lumi starts inside or just after the last just change the endpoint of the first
-                if newLumis and newLumis[-1][0] <= lumi[0] <= newLumis[-1][1] + 1:
-                    newLumis[-1][1] = max(newLumis[-1][1], lumi[1])
-                else:
+                if isinstance(lumi, int):
                     newLumis.append(lumi)
+                else:
+                    if newLumis and newLumis[-1][0] <= lumi[0] <= newLumis[-1][1] + 1:
+                        newLumis[-1][1] = max(newLumis[-1][1], lumi[1])
+                    else:
+                        newLumis.append(lumi)
             self.compactList[run] = newLumis
 
     def __sub__(self, other): # Things from self not in other
@@ -272,6 +275,9 @@ class LumiList(object):
         for run in runs:
             lumis = self.compactList[run]
             for lumiPair in sorted(lumis):
+                if isinstance(lumiPair, int):
+                    parts.append(str("%s:%s" % (run, lumiPair)))
+                    continue
                 if lumiPair[0] == lumiPair[1]:
                     parts.append(str("%s:%s" % (run, lumiPair[0])))
                 else:


### PR DESCRIPTION
This is mostly an idea, but can become a full PR for the splash test data reco for run3.
The lumi and run `345881: [782, 790, 796, 801, 1031, 1037]` are from https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/2293/1/1/1/1.html


I may need inputs from 
- @cms-sw/pdmv-l2 on how to better name the job fragments
- @cms-sw/alca-l2 on a choice of GT

we will also need the files in an accessible place
```
/store/data/Commissioning2021/MinimumBias/RAW/v1/000/345/881/00000/0eeadc99-21db-416a-8e4d-892c8d2844d6.root
/store/data/Commissioning2021/MinimumBias/RAW/v1/000/345/881/00000/2c1fb516-292c-45df-a64a-607790834cd6.root
/store/data/Commissioning2021/MinimumBias/RAW/v1/000/345/881/00000/9356f54b-11d2-4dad-8eaa-74b77436c3b8.root
/store/data/Commissioning2021/MinimumBias/RAW/v1/000/345/881/00000/be2a33cc-ef19-422f-a10b-d719098ef08c.root
/store/data/Commissioning2021/MinimumBias/RAW/v1/000/345/881/00000/dc29ee8f-aa45-423c-a16d-0c42d5a725aa.root
/store/data/Commissioning2021/MinimumBias/RAW/v1/000/345/881/00000/ff6b4c8c-066a-4be0-9611-f5928b43896b.root
```
I was not able to access the files with the regular xrootd read (cms-xrd-global.cern.ch). Some help to get these (or a better replacement) transferred is appreciated.

after the files are available, the number of events will likely need to be updated so that just 1 or 2 events is processed to avoid timeouts.


@drkovalskyi 
