### PR TITLE
Additional esConsumes in HLTriggerOffline/Muon

### DIFF
--- a/HLTriggerOffline/Muon/interface/HLTMuonPlotter.h
+++ b/HLTriggerOffline/Muon/interface/HLTMuonPlotter.h
@@ -130,7 +130,7 @@ private:
   StringCutObjectSelector<reco::GenParticle> *genMuonSelector_;
   StringCutObjectSelector<reco::Muon> *recMuonSelector_;
 
-  L1MuonMatcherAlgo l1Matcher_;
+  hltriggeroffline::L1MuonMatcherAlgo l1Matcher_;
 
   std::map<std::string, MonitorElement *> elements_;
 };

--- a/HLTriggerOffline/Muon/interface/HLTMuonPlotter.h
+++ b/HLTriggerOffline/Muon/interface/HLTMuonPlotter.h
@@ -12,10 +12,8 @@
 #include "HLTriggerOffline/Muon/interface/L1MuonMatcherAlgo.h"
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
@@ -53,6 +51,7 @@ class HLTMuonPlotter {
 public:
   typedef dqm::legacy::DQMStore DQMStore;
   typedef dqm::legacy::MonitorElement MonitorElement;
+  using ESTokens = hltriggeroffline::L1MuonMatcherAlgo::ESTokens;
 
   HLTMuonPlotter(const edm::ParameterSet &,
                  std::string,
@@ -60,7 +59,8 @@ public:
                  const std::vector<std::string> &,
                  const std::tuple<edm::EDGetTokenT<trigger::TriggerEventWithRefs>,
                                   edm::EDGetTokenT<reco::GenParticleCollection>,
-                                  edm::EDGetTokenT<reco::MuonCollection>> &);
+                                  edm::EDGetTokenT<reco::MuonCollection>> &,
+                 const ESTokens &);
 
   ~HLTMuonPlotter() {
     delete genMuonSelector_;
@@ -75,6 +75,13 @@ public:
                     edm::EDGetTokenT<reco::GenParticleCollection>,
                     edm::EDGetTokenT<reco::MuonCollection>>
   getTokens(const edm::ParameterSet &, edm::ConsumesCollector &&);
+
+  static std::tuple<edm::ESGetToken<MagneticField, IdealMagneticFieldRecord>,
+                    edm::ESGetToken<Propagator, TrackingComponentsRecord>,
+                    edm::ESGetToken<Propagator, TrackingComponentsRecord>,
+                    edm::ESGetToken<Propagator, TrackingComponentsRecord>,
+                    edm::ESGetToken<MuonDetLayerGeometry, MuonRecoGeometryRecord>>
+      getESTokens(edm::ConsumesCollector);
 
 private:
   struct MatchStruct {

--- a/HLTriggerOffline/Muon/interface/L1MuonMatcherAlgo.h
+++ b/HLTriggerOffline/Muon/interface/L1MuonMatcherAlgo.h
@@ -23,187 +23,189 @@
 #include "HLTriggerOffline/Muon/interface/PropagateToMuon.h"
 #include <cmath>
 
-class L1MuonMatcherAlgo {
-public:
-  explicit L1MuonMatcherAlgo(const edm::ParameterSet &iConfig);
-  ~L1MuonMatcherAlgo();
+namespace hltriggeroffline {
 
-  /// Call this method at the beginning of each run, to initialize geometry,
-  /// magnetic field and propagators
-  void init(const edm::EventSetup &iSetup);
+  class L1MuonMatcherAlgo {
+  public:
+    explicit L1MuonMatcherAlgo(const edm::ParameterSet &iConfig);
+    ~L1MuonMatcherAlgo();
 
-  /// Extrapolate reco::Track to the muon station 2, return an invalid TSOS if
-  /// it fails
-  TrajectoryStateOnSurface extrapolate(const reco::Track &tk) const { return prop_.extrapolate(tk); }
+    /// Call this method at the beginning of each run, to initialize geometry,
+    /// magnetic field and propagators
+    void init(const edm::EventSetup &iSetup);
 
-  /// Extrapolate reco::Candidate to the muon station 2, return an invalid TSOS
-  /// if it fails
-  TrajectoryStateOnSurface extrapolate(const reco::Candidate &tk) const { return prop_.extrapolate(tk); }
+    /// Extrapolate reco::Track to the muon station 2, return an invalid TSOS if
+    /// it fails
+    TrajectoryStateOnSurface extrapolate(const reco::Track &tk) const { return prop_.extrapolate(tk); }
 
-  /// Extrapolate a FreeTrajectoryState to the muon station 2, return an invalid
-  /// TSOS if it fails
-  TrajectoryStateOnSurface extrapolate(const FreeTrajectoryState &state) const { return prop_.extrapolate(state); }
+    /// Extrapolate reco::Candidate to the muon station 2, return an invalid TSOS
+    /// if it fails
+    TrajectoryStateOnSurface extrapolate(const reco::Candidate &tk) const { return prop_.extrapolate(tk); }
 
-  /// Return the propagator to second muon station (in case it's needed)
-  PropagateToMuon &propagatorToMuon() { return prop_; }
-  /// Return the propagator to second muon station (in case it's needed)
-  const PropagateToMuon &propagatorToMuon() const { return prop_; }
+    /// Extrapolate a FreeTrajectoryState to the muon station 2, return an invalid
+    /// TSOS if it fails
+    TrajectoryStateOnSurface extrapolate(const FreeTrajectoryState &state) const { return prop_.extrapolate(state); }
 
-  /// Try to match one track to one L1. Return true if succeeded (and update
-  /// deltaR, deltaPhi and propagated TSOS accordingly) The preselection cut on
-  /// L1, if specified in the config, is applied before the match
-  bool match(const reco::Track &tk,
-             const l1extra::L1MuonParticle &l1,
-             float &deltaR,
-             float &deltaPhi,
-             TrajectoryStateOnSurface &propagated) const {
-    propagated = extrapolate(tk);
-    return propagated.isValid() ? match(propagated, l1, deltaR, deltaPhi) : false;
-  }
+    /// Return the propagator to second muon station (in case it's needed)
+    PropagateToMuon &propagatorToMuon() { return prop_; }
+    /// Return the propagator to second muon station (in case it's needed)
+    const PropagateToMuon &propagatorToMuon() const { return prop_; }
 
-  /// Try to match one track to one L1. Return true if succeeded (and update
-  /// deltaR, deltaPhi and propagated TSOS accordingly) The preselection cut on
-  /// L1, if specified in the config, is applied before the match
-  bool match(const reco::Candidate &c,
-             const l1extra::L1MuonParticle &l1,
-             float &deltaR,
-             float &deltaPhi,
-             TrajectoryStateOnSurface &propagated) const {
-    propagated = extrapolate(c);
-    return propagated.isValid() ? match(propagated, l1, deltaR, deltaPhi) : false;
-  }
+    /// Try to match one track to one L1. Return true if succeeded (and update
+    /// deltaR, deltaPhi and propagated TSOS accordingly) The preselection cut on
+    /// L1, if specified in the config, is applied before the match
+    bool match(const reco::Track &tk,
+               const l1extra::L1MuonParticle &l1,
+               float &deltaR,
+               float &deltaPhi,
+               TrajectoryStateOnSurface &propagated) const {
+      propagated = extrapolate(tk);
+      return propagated.isValid() ? match(propagated, l1, deltaR, deltaPhi) : false;
+    }
 
-  /// Try to match one track to one L1. Return true if succeeded (and update
-  /// deltaR, deltaPhi accordingly) The preselection cut on L1, if specified in
-  /// the config, is applied before the match
-  bool match(TrajectoryStateOnSurface &propagated,
-             const l1extra::L1MuonParticle &l1,
-             float &deltaR,
-             float &deltaPhi) const;
+    /// Try to match one track to one L1. Return true if succeeded (and update
+    /// deltaR, deltaPhi and propagated TSOS accordingly) The preselection cut on
+    /// L1, if specified in the config, is applied before the match
+    bool match(const reco::Candidate &c,
+               const l1extra::L1MuonParticle &l1,
+               float &deltaR,
+               float &deltaPhi,
+               TrajectoryStateOnSurface &propagated) const {
+      propagated = extrapolate(c);
+      return propagated.isValid() ? match(propagated, l1, deltaR, deltaPhi) : false;
+    }
 
-  /// Find the best match to L1, and return its index in the vector (and update
-  /// deltaR, deltaPhi and propagated TSOS accordingly) Returns -1 if the match
-  /// fails The preselection cut on L1, if specified in the config, is applied
-  /// before the match
-  int match(const reco::Track &tk,
-            const std::vector<l1extra::L1MuonParticle> &l1,
-            float &deltaR,
-            float &deltaPhi,
-            TrajectoryStateOnSurface &propagated) const {
-    propagated = extrapolate(tk);
-    return propagated.isValid() ? match(propagated, l1, deltaR, deltaPhi) : -1;
-  }
+    /// Try to match one track to one L1. Return true if succeeded (and update
+    /// deltaR, deltaPhi accordingly) The preselection cut on L1, if specified in
+    /// the config, is applied before the match
+    bool match(TrajectoryStateOnSurface &propagated,
+               const l1extra::L1MuonParticle &l1,
+               float &deltaR,
+               float &deltaPhi) const;
 
-  /// Find the best match to L1, and return its index in the vector (and update
-  /// deltaR, deltaPhi and propagated TSOS accordingly) Returns -1 if the match
-  /// fails The preselection cut on L1, if specified in the config, is applied
-  /// before the match
-  int match(const reco::Candidate &c,
-            const std::vector<l1extra::L1MuonParticle> &l1,
-            float &deltaR,
-            float &deltaPhi,
-            TrajectoryStateOnSurface &propagated) const {
-    propagated = extrapolate(c);
-    return propagated.isValid() ? match(propagated, l1, deltaR, deltaPhi) : -1;
-  }
+    /// Find the best match to L1, and return its index in the vector (and update
+    /// deltaR, deltaPhi and propagated TSOS accordingly) Returns -1 if the match
+    /// fails The preselection cut on L1, if specified in the config, is applied
+    /// before the match
+    int match(const reco::Track &tk,
+              const std::vector<l1extra::L1MuonParticle> &l1,
+              float &deltaR,
+              float &deltaPhi,
+              TrajectoryStateOnSurface &propagated) const {
+      propagated = extrapolate(tk);
+      return propagated.isValid() ? match(propagated, l1, deltaR, deltaPhi) : -1;
+    }
 
-  /// Find the best match to L1, and return its index in the vector (and update
-  /// deltaR, deltaPhi accordingly) Returns -1 if the match fails The
-  /// preselection cut on L1, if specified in the config, is applied before the
-  /// match
-  int match(TrajectoryStateOnSurface &propagated,
-            const std::vector<l1extra::L1MuonParticle> &l1,
-            float &deltaR,
-            float &deltaPhi) const;
+    /// Find the best match to L1, and return its index in the vector (and update
+    /// deltaR, deltaPhi and propagated TSOS accordingly) Returns -1 if the match
+    /// fails The preselection cut on L1, if specified in the config, is applied
+    /// before the match
+    int match(const reco::Candidate &c,
+              const std::vector<l1extra::L1MuonParticle> &l1,
+              float &deltaR,
+              float &deltaPhi,
+              TrajectoryStateOnSurface &propagated) const {
+      propagated = extrapolate(c);
+      return propagated.isValid() ? match(propagated, l1, deltaR, deltaPhi) : -1;
+    }
 
-  /// Find the best match to L1, and return its index in the vector (and update
-  /// deltaR, deltaPhi and propagated TSOS accordingly) Returns -1 if the match
-  /// fails Only the objects passing the selector will be allowed for the match.
-  /// If you don't need a selector, just use an AnySelector (CommonTools/Utils)
-  /// which accepts everything
+    /// Find the best match to L1, and return its index in the vector (and update
+    /// deltaR, deltaPhi accordingly) Returns -1 if the match fails The
+    /// preselection cut on L1, if specified in the config, is applied before the
+    /// match
+    int match(TrajectoryStateOnSurface &propagated,
+              const std::vector<l1extra::L1MuonParticle> &l1,
+              float &deltaR,
+              float &deltaPhi) const;
+
+    /// Find the best match to L1, and return its index in the vector (and update
+    /// deltaR, deltaPhi and propagated TSOS accordingly) Returns -1 if the match
+    /// fails Only the objects passing the selector will be allowed for the match.
+    /// If you don't need a selector, just use an AnySelector (CommonTools/Utils)
+    /// which accepts everything
+    template <typename Collection, typename Selector>
+    int matchGeneric(const reco::Track &tk,
+                     const Collection &l1,
+                     const Selector &sel,
+                     float &deltaR,
+                     float &deltaPhi,
+                     TrajectoryStateOnSurface &propagated) const {
+      propagated = extrapolate(tk);
+      return propagated.isValid() ? matchGeneric(propagated, l1, sel, deltaR, deltaPhi) : -1;
+    }
+
+    /// Find the best match to L1, and return its index in the vector (and update
+    /// deltaR, deltaPhi and propagated TSOS accordingly) Returns -1 if the match
+    /// fails Only the objects passing the selector will be allowed for the match.
+    /// If you don't need a selector, just use an AnySelector (CommonTools/Utils)
+    /// which accepts everything
+    template <typename Collection, typename Selector>
+    int matchGeneric(const reco::Candidate &c,
+                     const Collection &l1,
+                     const Selector &sel,
+                     float &deltaR,
+                     float &deltaPhi,
+                     TrajectoryStateOnSurface &propagated) const {
+      propagated = extrapolate(c);
+      return propagated.isValid() ? matchGeneric(propagated, l1, sel, deltaR, deltaPhi) : -1;
+    }
+
+    /// Find the best match to L1, and return its index in the vector (and update
+    /// deltaR, deltaPhi accordingly) Returns -1 if the match fails Only the
+    /// objects passing the selector will be allowed for the match. The selector
+    /// defaults to an AnySelector (CommonTools/Utils) which just accepts
+    /// everything
+    template <typename Collection, typename Selector>
+    int matchGeneric(TrajectoryStateOnSurface &propagated,
+                     const Collection &l1,
+                     const Selector &sel,
+                     float &deltaR,
+                     float &deltaPhi) const;
+
+  private:
+    PropagateToMuon prop_;
+
+    typedef StringCutObjectSelector<l1extra::L1MuonParticle> L1Selector;
+    /// Preselection cut to apply to L1 candidates before matching
+    L1Selector preselectionCut_;
+
+    /// Matching cuts
+    double deltaR2_, deltaPhi_;
+
+    /// Sort by deltaPhi instead of deltaR
+    bool sortByDeltaPhi_;
+  };
+
   template <typename Collection, typename Selector>
-  int matchGeneric(const reco::Track &tk,
-                   const Collection &l1,
-                   const Selector &sel,
-                   float &deltaR,
-                   float &deltaPhi,
-                   TrajectoryStateOnSurface &propagated) const {
-    propagated = extrapolate(tk);
-    return propagated.isValid() ? matchGeneric(propagated, l1, sel, deltaR, deltaPhi) : -1;
-  }
-
-  /// Find the best match to L1, and return its index in the vector (and update
-  /// deltaR, deltaPhi and propagated TSOS accordingly) Returns -1 if the match
-  /// fails Only the objects passing the selector will be allowed for the match.
-  /// If you don't need a selector, just use an AnySelector (CommonTools/Utils)
-  /// which accepts everything
-  template <typename Collection, typename Selector>
-  int matchGeneric(const reco::Candidate &c,
-                   const Collection &l1,
-                   const Selector &sel,
-                   float &deltaR,
-                   float &deltaPhi,
-                   TrajectoryStateOnSurface &propagated) const {
-    propagated = extrapolate(c);
-    return propagated.isValid() ? matchGeneric(propagated, l1, sel, deltaR, deltaPhi) : -1;
-  }
-
-  /// Find the best match to L1, and return its index in the vector (and update
-  /// deltaR, deltaPhi accordingly) Returns -1 if the match fails Only the
-  /// objects passing the selector will be allowed for the match. The selector
-  /// defaults to an AnySelector (CommonTools/Utils) which just accepts
-  /// everything
-  template <typename Collection, typename Selector>
-  int matchGeneric(TrajectoryStateOnSurface &propagated,
-                   const Collection &l1,
-                   const Selector &sel,
-                   float &deltaR,
-                   float &deltaPhi) const;
-
-private:
-  PropagateToMuon prop_;
-
-  typedef StringCutObjectSelector<l1extra::L1MuonParticle> L1Selector;
-  /// Preselection cut to apply to L1 candidates before matching
-  L1Selector preselectionCut_;
-
-  /// Matching cuts
-  double deltaR2_, deltaPhi_;
-
-  /// Sort by deltaPhi instead of deltaR
-  bool sortByDeltaPhi_;
-};
-
-template <typename Collection, typename Selector>
-int L1MuonMatcherAlgo::matchGeneric(TrajectoryStateOnSurface &propagated,
-                                    const Collection &l1s,
-                                    const Selector &sel,
-                                    float &deltaR,
-                                    float &deltaPhi) const {
-  typedef typename Collection::value_type obj;
-  int match = -1;
-  double minDeltaPhi = deltaPhi_;
-  double minDeltaR2 = deltaR2_;
-  GlobalPoint pos = propagated.globalPosition();
-  for (int i = 0, n = l1s.size(); i < n; ++i) {
-    const obj &l1 = l1s[i];
-    if (sel(l1)) {
-      double thisDeltaPhi = ::deltaPhi(double(pos.phi()), l1.phi());
-      double thisDeltaR2 = ::deltaR2(double(pos.eta()), double(pos.phi()), l1.eta(), l1.phi());
-      if ((fabs(thisDeltaPhi) < deltaPhi_) && (thisDeltaR2 < deltaR2_)) {                               // check both
-        if (sortByDeltaPhi_ ? (fabs(thisDeltaPhi) < fabs(minDeltaPhi)) : (thisDeltaR2 < minDeltaR2)) {  // sort on one
-          match = i;
-          deltaR = std::sqrt(thisDeltaR2);
-          deltaPhi = thisDeltaPhi;
-          if (sortByDeltaPhi_)
-            minDeltaPhi = thisDeltaPhi;
-          else
-            minDeltaR2 = thisDeltaR2;
+  int L1MuonMatcherAlgo::matchGeneric(TrajectoryStateOnSurface &propagated,
+                                      const Collection &l1s,
+                                      const Selector &sel,
+                                      float &deltaR,
+                                      float &deltaPhi) const {
+    typedef typename Collection::value_type obj;
+    int match = -1;
+    double minDeltaPhi = deltaPhi_;
+    double minDeltaR2 = deltaR2_;
+    GlobalPoint pos = propagated.globalPosition();
+    for (int i = 0, n = l1s.size(); i < n; ++i) {
+      const obj &l1 = l1s[i];
+      if (sel(l1)) {
+        double thisDeltaPhi = ::deltaPhi(double(pos.phi()), l1.phi());
+        double thisDeltaR2 = ::deltaR2(double(pos.eta()), double(pos.phi()), l1.eta(), l1.phi());
+        if ((fabs(thisDeltaPhi) < deltaPhi_) && (thisDeltaR2 < deltaR2_)) {                               // check both
+          if (sortByDeltaPhi_ ? (fabs(thisDeltaPhi) < fabs(minDeltaPhi)) : (thisDeltaR2 < minDeltaR2)) {  // sort on one
+            match = i;
+            deltaR = std::sqrt(thisDeltaR2);
+            deltaPhi = thisDeltaPhi;
+            if (sortByDeltaPhi_)
+              minDeltaPhi = thisDeltaPhi;
+            else
+              minDeltaR2 = thisDeltaR2;
+          }
         }
       }
     }
+    return match;
   }
-  return match;
-}
-
+}  // namespace hltriggeroffline
 #endif

--- a/HLTriggerOffline/Muon/interface/L1MuonMatcherAlgo.h
+++ b/HLTriggerOffline/Muon/interface/L1MuonMatcherAlgo.h
@@ -19,6 +19,7 @@
 #include "DataFormats/Math/interface/deltaR.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "HLTriggerOffline/Muon/interface/PropagateToMuon.h"
 #include <cmath>
@@ -27,7 +28,9 @@ namespace hltriggeroffline {
 
   class L1MuonMatcherAlgo {
   public:
-    explicit L1MuonMatcherAlgo(const edm::ParameterSet &iConfig);
+    using ESTokens = PropagateToMuon::ESTokens;
+
+    explicit L1MuonMatcherAlgo(const edm::ParameterSet &iConfig, const ESTokens &iTokens);
     ~L1MuonMatcherAlgo();
 
     /// Call this method at the beginning of each run, to initialize geometry,

--- a/HLTriggerOffline/Muon/interface/PropagateToMuon.h
+++ b/HLTriggerOffline/Muon/interface/PropagateToMuon.h
@@ -1,5 +1,5 @@
-#ifndef MuonAnalysis_MuonAssociators_interface_PropagateToMuon_h
-#define MuonAnalysis_MuonAssociators_interface_PropagateToMuon_h
+#ifndef HLTriggerOffline_Muon_interface_PropagateToMuon_h
+#define HLTriggerOffline_Muon_interface_PropagateToMuon_h
 //
 //
 
@@ -26,59 +26,64 @@ class DetLayer;  // #include "TrackingTools/DetLayers/interface/DetLayer.h" //
 #include "TrackingTools/GeomPropagators/interface/Propagator.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 
-class PropagateToMuon {
-public:
-  explicit PropagateToMuon(const edm::ParameterSet &iConfig);
-  ~PropagateToMuon();
+//This is a nearly identical copy to MuonAnalysis/MuonAssociators/interface/PropagateToMuon.h
 
-  /// Call this method at the beginning of each run, to initialize geometry,
-  /// magnetic field and propagators
-  void init(const edm::EventSetup &iSetup);
+namespace hltriggeroffline {
 
-  /// Extrapolate reco::Track to the muon station 2, return an invalid TSOS if
-  /// it fails
-  TrajectoryStateOnSurface extrapolate(const reco::Track &tk) const { return extrapolate(startingState(tk)); }
+  class PropagateToMuon {
+  public:
+    explicit PropagateToMuon(const edm::ParameterSet &iConfig);
+    ~PropagateToMuon();
 
-  /// Extrapolate reco::Candidate to the muon station 2, return an invalid TSOS
-  /// if it fails
-  TrajectoryStateOnSurface extrapolate(const reco::Candidate &tk) const { return extrapolate(startingState(tk)); }
+    /// Call this method at the beginning of each run, to initialize geometry,
+    /// magnetic field and propagators
+    void init(const edm::EventSetup &iSetup);
 
-  /// Extrapolate a FreeTrajectoryState to the muon station 2, return an invalid
-  /// TSOS if it fails
-  TrajectoryStateOnSurface extrapolate(const FreeTrajectoryState &state) const;
+    /// Extrapolate reco::Track to the muon station 2, return an invalid TSOS if
+    /// it fails
+    TrajectoryStateOnSurface extrapolate(const reco::Track &tk) const { return extrapolate(startingState(tk)); }
 
-private:
-  enum WhichTrack { None, TrackerTk, MuonTk, GlobalTk };
-  enum WhichState { AtVertex, Innermost, Outermost };
+    /// Extrapolate reco::Candidate to the muon station 2, return an invalid TSOS
+    /// if it fails
+    TrajectoryStateOnSurface extrapolate(const reco::Candidate &tk) const { return extrapolate(startingState(tk)); }
 
-  /// Labels for input collections
-  bool useSimpleGeometry_;
-  WhichTrack whichTrack_;
-  WhichState whichState_;
+    /// Extrapolate a FreeTrajectoryState to the muon station 2, return an invalid
+    /// TSOS if it fails
+    TrajectoryStateOnSurface extrapolate(const FreeTrajectoryState &state) const;
 
-  /// for cosmics, some things change: the along-opposite is not in-out, nor the
-  /// innermost/outermost states are in-out really
-  bool cosmicPropagation_;
+  private:
+    enum WhichTrack { None, TrackerTk, MuonTk, GlobalTk };
+    enum WhichState { AtVertex, Innermost, Outermost };
 
-  // needed services for track propagation
-  edm::ESHandle<MagneticField> magfield_;
-  edm::ESHandle<Propagator> propagator_, propagatorAny_, propagatorOpposite_;
-  edm::ESHandle<MuonDetLayerGeometry> muonGeometry_;
-  // simplified geometry for track propagation
-  const BoundCylinder *barrelCylinder_;
-  const BoundDisk *endcapDiskPos_, *endcapDiskNeg_;
-  double barrelHalfLength_;
-  std::pair<float, float> endcapRadii_;
+    /// Labels for input collections
+    bool useSimpleGeometry_;
+    WhichTrack whichTrack_;
+    WhichState whichState_;
 
-  /// Starting state for the propagation
-  FreeTrajectoryState startingState(const reco::Candidate &reco) const;
+    /// for cosmics, some things change: the along-opposite is not in-out, nor the
+    /// innermost/outermost states are in-out really
+    bool cosmicPropagation_;
 
-  /// Starting state for the propagation
-  FreeTrajectoryState startingState(const reco::Track &tk) const;
+    // needed services for track propagation
+    edm::ESHandle<MagneticField> magfield_;
+    edm::ESHandle<Propagator> propagator_, propagatorAny_, propagatorOpposite_;
+    edm::ESHandle<MuonDetLayerGeometry> muonGeometry_;
+    // simplified geometry for track propagation
+    const BoundCylinder *barrelCylinder_;
+    const BoundDisk *endcapDiskPos_, *endcapDiskNeg_;
+    double barrelHalfLength_;
+    std::pair<float, float> endcapRadii_;
 
-  /// Get the best TSOS on one of the chambres of this DetLayer, or an invalid
-  /// TSOS if none match
-  TrajectoryStateOnSurface getBestDet(const TrajectoryStateOnSurface &tsos, const DetLayer *station) const;
-};
+    /// Starting state for the propagation
+    FreeTrajectoryState startingState(const reco::Candidate &reco) const;
+
+    /// Starting state for the propagation
+    FreeTrajectoryState startingState(const reco::Track &tk) const;
+
+    /// Get the best TSOS on one of the chambres of this DetLayer, or an invalid
+    /// TSOS if none match
+    TrajectoryStateOnSurface getBestDet(const TrajectoryStateOnSurface &tsos, const DetLayer *station) const;
+  };
+}  // namespace hltriggeroffline
 
 #endif

--- a/HLTriggerOffline/Muon/interface/PropagateToMuon.h
+++ b/HLTriggerOffline/Muon/interface/PropagateToMuon.h
@@ -18,6 +18,7 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "RecoMuon/DetLayers/interface/MuonDetLayerGeometry.h"
@@ -26,13 +27,25 @@ class DetLayer;  // #include "TrackingTools/DetLayers/interface/DetLayer.h" //
 #include "TrackingTools/GeomPropagators/interface/Propagator.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 
+class IdealMagneticFieldRecord;
+class TrackingComponentsRecord;
+class MuonRecoGeometryRecord;
+
 //This is a nearly identical copy to MuonAnalysis/MuonAssociators/interface/PropagateToMuon.h
 
 namespace hltriggeroffline {
 
   class PropagateToMuon {
   public:
-    explicit PropagateToMuon(const edm::ParameterSet &iConfig);
+    using ESTokens = std::tuple<edm::ESGetToken<MagneticField, IdealMagneticFieldRecord>,
+                                edm::ESGetToken<Propagator, TrackingComponentsRecord>,
+                                edm::ESGetToken<Propagator, TrackingComponentsRecord>,
+                                edm::ESGetToken<Propagator, TrackingComponentsRecord>,
+                                edm::ESGetToken<MuonDetLayerGeometry, MuonRecoGeometryRecord>>;
+
+    static ESTokens getESTokens(edm::ConsumesCollector);
+
+    explicit PropagateToMuon(const edm::ParameterSet &iConfig, const ESTokens &);
     ~PropagateToMuon();
 
     /// Call this method at the beginning of each run, to initialize geometry,
@@ -68,6 +81,11 @@ namespace hltriggeroffline {
     edm::ESHandle<MagneticField> magfield_;
     edm::ESHandle<Propagator> propagator_, propagatorAny_, propagatorOpposite_;
     edm::ESHandle<MuonDetLayerGeometry> muonGeometry_;
+
+    edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magfieldToken_;
+    edm::ESGetToken<Propagator, TrackingComponentsRecord> propagatorToken_, propagatorAnyToken_,
+        propagatorOppositeToken_;
+    edm::ESGetToken<MuonDetLayerGeometry, MuonRecoGeometryRecord> muonGeometryToken_;
     // simplified geometry for track propagation
     const BoundCylinder *barrelCylinder_;
     const BoundDisk *endcapDiskPos_, *endcapDiskNeg_;

--- a/HLTriggerOffline/Muon/src/HLTMuonPlotter.cc
+++ b/HLTriggerOffline/Muon/src/HLTMuonPlotter.cc
@@ -30,10 +30,11 @@ HLTMuonPlotter::HLTMuonPlotter(const ParameterSet &pset,
                                const std::vector<string> &stepLabels,
                                const std::tuple<edm::EDGetTokenT<trigger::TriggerEventWithRefs>,
                                                 edm::EDGetTokenT<reco::GenParticleCollection>,
-                                                edm::EDGetTokenT<reco::MuonCollection>> &tokens)
+                                                edm::EDGetTokenT<reco::MuonCollection>> &tokens,
+                               const ESTokens &esTokens)
     :
 
-      l1Matcher_(pset) {
+      l1Matcher_(pset, esTokens) {
   hltPath_ = hltPath;
   moduleLabels_ = moduleLabels;
   stepLabels_ = stepLabels;
@@ -270,6 +271,15 @@ HLTMuonPlotter::getTokens(const edm::ParameterSet &pset, edm::ConsumesCollector 
       myTuple(_hltTriggerSummaryRAW, _genParticleLabel, _recMuonLabel);
 
   return (myTuple);
+}
+
+std::tuple<edm::ESGetToken<MagneticField, IdealMagneticFieldRecord>,
+           edm::ESGetToken<Propagator, TrackingComponentsRecord>,
+           edm::ESGetToken<Propagator, TrackingComponentsRecord>,
+           edm::ESGetToken<Propagator, TrackingComponentsRecord>,
+           edm::ESGetToken<MuonDetLayerGeometry, MuonRecoGeometryRecord>>
+HLTMuonPlotter::getESTokens(edm::ConsumesCollector iC) {
+  return hltriggeroffline::PropagateToMuon::getESTokens(iC);
 }
 
 void HLTMuonPlotter::findMatches(vector<MatchStruct> &matches,

--- a/HLTriggerOffline/Muon/src/HLTMuonValidator.cc
+++ b/HLTriggerOffline/Muon/src/HLTMuonValidator.cc
@@ -59,6 +59,8 @@ private:
              edm::EDGetTokenT<reco::GenParticleCollection>,
              edm::EDGetTokenT<reco::MuonCollection>>
       myTokens_;
+
+  HLTMuonPlotter::ESTokens myESTokens_;
 };
 
 //////////////////////////////////////////////////////////////////////////////
@@ -79,6 +81,7 @@ HLTMuonValidator::HLTMuonValidator(const ParameterSet &pset)
       hltProcessName_(pset.getParameter<string>("hltProcessName")),
       hltPathsToCheck_(pset.getParameter<vstring>("hltPathsToCheck")) {
   myTokens_ = HLTMuonPlotter::getTokens(pset_, consumesCollector());
+  myESTokens_ = HLTMuonPlotter::getESTokens(consumesCollector());
 }
 
 vector<string> HLTMuonValidator::moduleLabels(string path) {
@@ -159,7 +162,7 @@ void HLTMuonValidator::dqmBeginRun(const edm::Run &iRun, const edm::EventSetup &
     vector<string> steps = stepLabels(labels);
 
     if (!labels.empty() && !steps.empty()) {
-      HLTMuonPlotter analyzer(pset_, shortpath, labels, steps, myTokens_);
+      HLTMuonPlotter analyzer(pset_, shortpath, labels, steps, myTokens_, myESTokens_);
       analyzers_.push_back(analyzer);
     }
   }

--- a/HLTriggerOffline/Muon/src/L1MuonMatcherAlgo.cc
+++ b/HLTriggerOffline/Muon/src/L1MuonMatcherAlgo.cc
@@ -4,8 +4,8 @@
 
 using namespace hltriggeroffline;
 
-L1MuonMatcherAlgo::L1MuonMatcherAlgo(const edm::ParameterSet &iConfig)
-    : prop_(iConfig),
+L1MuonMatcherAlgo::L1MuonMatcherAlgo(const edm::ParameterSet &iConfig, const ESTokens &tokens)
+    : prop_(iConfig, tokens),
       preselectionCut_(iConfig.existsAs<std::string>("preselection") ? iConfig.getParameter<std::string>("preselection")
                                                                      : ""),
       deltaR2_(std::pow(iConfig.getParameter<double>("maxDeltaR"), 2)),

--- a/HLTriggerOffline/Muon/src/L1MuonMatcherAlgo.cc
+++ b/HLTriggerOffline/Muon/src/L1MuonMatcherAlgo.cc
@@ -2,6 +2,8 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+using namespace hltriggeroffline;
+
 L1MuonMatcherAlgo::L1MuonMatcherAlgo(const edm::ParameterSet &iConfig)
     : prop_(iConfig),
       preselectionCut_(iConfig.existsAs<std::string>("preselection") ? iConfig.getParameter<std::string>("preselection")

--- a/HLTriggerOffline/Muon/src/PropagateToMuon.cc
+++ b/HLTriggerOffline/Muon/src/PropagateToMuon.cc
@@ -17,13 +17,31 @@
 
 using namespace hltriggeroffline;
 
-PropagateToMuon::PropagateToMuon(const edm::ParameterSet &iConfig)
+PropagateToMuon::ESTokens PropagateToMuon::getESTokens(edm::ConsumesCollector iCollector) {
+  ESTokens ret;
+  std::get<0>(ret) = iCollector.esConsumes<edm::Transition::BeginRun>();
+  std::get<1>(ret) =
+      iCollector.esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", "SteppingHelixPropagatorAlong"));
+  std::get<2>(ret) =
+      iCollector.esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", "SteppingHelixPropagatorAny"));
+  std::get<3>(ret) =
+      iCollector.esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", "SteppingHelixPropagatorOpposite"));
+  std::get<4>(ret) = iCollector.esConsumes<edm::Transition::BeginRun>();
+  return ret;
+}
+
+PropagateToMuon::PropagateToMuon(const edm::ParameterSet &iConfig, const ESTokens &iTokens)
     : useSimpleGeometry_(iConfig.getParameter<bool>("useSimpleGeometry")),
       whichTrack_(None),
       whichState_(AtVertex),
       cosmicPropagation_(iConfig.existsAs<bool>("cosmicPropagationHypothesis")
                              ? iConfig.getParameter<bool>("cosmicPropagationHypothesis")
-                             : false) {
+                             : false),
+      magfieldToken_(std::get<0>(iTokens)),
+      propagatorToken_(std::get<1>(iTokens)),
+      propagatorAnyToken_(std::get<2>(iTokens)),
+      propagatorOppositeToken_(std::get<3>(iTokens)),
+      muonGeometryToken_(std::get<4>(iTokens)) {
   std::string whichTrack = iConfig.getParameter<std::string>("useTrack");
   if (whichTrack == "none") {
     whichTrack_ = None;
@@ -56,11 +74,11 @@ PropagateToMuon::PropagateToMuon(const edm::ParameterSet &iConfig)
 PropagateToMuon::~PropagateToMuon() {}
 
 void PropagateToMuon::init(const edm::EventSetup &iSetup) {
-  iSetup.get<IdealMagneticFieldRecord>().get(magfield_);
-  iSetup.get<TrackingComponentsRecord>().get("SteppingHelixPropagatorAlong", propagator_);
-  iSetup.get<TrackingComponentsRecord>().get("SteppingHelixPropagatorOpposite", propagatorOpposite_);
-  iSetup.get<TrackingComponentsRecord>().get("SteppingHelixPropagatorAny", propagatorAny_);
-  iSetup.get<MuonRecoGeometryRecord>().get(muonGeometry_);
+  magfield_ = iSetup.getHandle(magfieldToken_);
+  propagator_ = iSetup.getHandle(propagatorToken_);
+  propagatorOpposite_ = iSetup.getHandle(propagatorOppositeToken_);
+  propagatorAny_ = iSetup.getHandle(propagatorAnyToken_);
+  muonGeometry_ = iSetup.getHandle(muonGeometryToken_);
 
   const DetLayer *dt2 = muonGeometry_->allDTLayers()[1];
   const DetLayer *csc2Pos = muonGeometry_->forwardCSCLayers()[2];

--- a/HLTriggerOffline/Muon/src/PropagateToMuon.cc
+++ b/HLTriggerOffline/Muon/src/PropagateToMuon.cc
@@ -15,6 +15,8 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+using namespace hltriggeroffline;
+
 PropagateToMuon::PropagateToMuon(const edm::ParameterSet &iConfig)
     : useSimpleGeometry_(iConfig.getParameter<bool>("useSimpleGeometry")),
       whichTrack_(None),


### PR DESCRIPTION
#### PR description:

- fixed two cases of C++ _one definition rule_ violations by encapsulating classes in a new namespace.
- Added esConsumes to PropagateToMuon

#### PR validation:

- Code compiles.
- It is possible that fixing the _one definintion rule_ violations will cause a change in the histograms as the violation resulted in binary incompatibility between the same named types.