### PR TITLE
[DD4hep] Enable creation of reduced material geometry DB payloads

### DIFF
--- a/CondTools/Geometry/test/writehelpers/createExtended2021DD4hepPayloads.sh
+++ b/CondTools/Geometry/test/writehelpers/createExtended2021DD4hepPayloads.sh
@@ -15,9 +15,7 @@ compgen -G "*.txt" > /dev/null && sed -i {s/TagXX/${mytag}/g} *.txt
 sed -i {s/TagXX/${mytag}/g} splitExtended2021Database.sh
 
 # First read in the little XML files and create the
-# large XML file for the Phase1_R30F12_HCal Ideal scenario.
-# Input cff                                             Output file
-# GeometryExtended2021_cff                       geSingleBigFile.xml
+# big XML file for the Extended2021DD4hep scenario.
 cmsRun geometryExtended2021DD4hep_xmlwriter.py
 
 # Now convert the content of the large XML file into
@@ -31,63 +29,60 @@ cmsRun geometryExtended2021DD4hep_writer.py
 # Input the many XML files referenced by the cff file and
 # output a single big XML file.
 # This is repeated several times below.  The sed commands
-# serve to give the following sequence of input and output
+# serve to give the correct sequence of input and output
 # files
-#
-# Input cff                    Output file
-# GeometryIdeal_cff            giSingleBigFile.xml
-#
-# sed -i '{s/Extended2021/Extended2021ZeroMaterial/g}' geometryExtended2021DD4hep_xmlwriter.py
-# sed -i '{s/\/ge/\/gez/g}' geometryExtended2021DD4hep_xmlwriter.py
-# cmsRun geometryExtended2021DD4hep_xmlwriter.py
 
-# sed -i '{s/Extended2021ZeroMaterial/Extended2021FlatMinus05Percent/g}' geometryExtended2021DD4hep_xmlwriter.py
-# sed -i '{s/\/gez/\/geFM05/g}' geometryExtended2021DD4hep_xmlwriter.py
-# cmsRun geometryExtended2021DD4hep_xmlwriter.py
+sed -i '{s/ExtendedGeometry2021/ExtendedGeometry2021ZeroMaterial/g}' geometryExtended2021DD4hep_xmlwriter.py
+sed -i '{s/\/ge/\/gez/g}' geometryExtended2021DD4hep_xmlwriter.py
+cmsRun geometryExtended2021DD4hep_xmlwriter.py
 
-# sed -i '{s/Extended2021FlatMinus05Percent/Extended2021FlatMinus10Percent/g}' geometryExtended2021DD4hep_xmlwriter.py
-# sed -i '{s/\/geFM05/\/geFM10/g}' geometryExtended2021DD4hep_xmlwriter.py
-# cmsRun geometryExtended2021DD4hep_xmlwriter.py
+sed -i '{s/ExtendedGeometry2021ZeroMaterial/ExtendedGeometry2021FlatMinus05Percent/g}' geometryExtended2021DD4hep_xmlwriter.py
+sed -i '{s/\/gez/\/geFM05/g}' geometryExtended2021DD4hep_xmlwriter.py
+cmsRun geometryExtended2021DD4hep_xmlwriter.py
 
-# sed -i '{s/Extended2021FlatMinus10Percent/Extended2021FlatPlus05Percent/g}' geometryExtended2021DD4hep_xmlwriter.py
-# sed -i '{s/\/geFM10/\/geFP05/g}' geometryExtended2021DD4hep_xmlwriter.py
-# cmsRun geometryExtended2021DD4hep_xmlwriter.py
+sed -i '{s/ExtendedGeometry2021FlatMinus05Percent/ExtendedGeometry2021FlatMinus10Percent/g}' geometryExtended2021DD4hep_xmlwriter.py
+sed -i '{s/\/geFM05/\/geFM10/g}' geometryExtended2021DD4hep_xmlwriter.py
+cmsRun geometryExtended2021DD4hep_xmlwriter.py
 
-# sed -i '{s/Extended2021FlatPlus05Percent/Extended2021FlatPlus10Percent/g}' geometryExtended2021DD4hep_xmlwriter.py
-# sed -i '{s/\/geFP05/\/geFP10/g}' geometryExtended2021DD4hep_xmlwriter.py
-# cmsRun geometryExtended2021DD4hep_xmlwriter.py
+sed -i '{s/ExtendedGeometry2021FlatMinus10Percent/ExtendedGeometry2021FlatPlus05Percent/g}' geometryExtended2021DD4hep_xmlwriter.py
+sed -i '{s/\/geFM10/\/geFP05/g}' geometryExtended2021DD4hep_xmlwriter.py
+cmsRun geometryExtended2021DD4hep_xmlwriter.py
+
+sed -i '{s/ExtendedGeometry2021FlatPlus05Percent/ExtendedGeometry2021FlatPlus10Percent/g}' geometryExtended2021DD4hep_xmlwriter.py
+sed -i '{s/\/geFP05/\/geFP10/g}' geometryExtended2021DD4hep_xmlwriter.py
+cmsRun geometryExtended2021DD4hep_xmlwriter.py
 
 # Read the one big XML file and output a record to the
 # database with the an identifying tag
 # This is repeated several times below.  The sed commands
-# serve to give the following sequence of input file and output
+# serve to give the correct sequence of input file and output
 # tag
-#
+# To start:
 # Input file                Output tag
 # gezSingleBigFile.xml      XMLFILE_Geometry_${mytag}_Extended2021ZeroMaterial_mc
-#
-# sed -i '{s/Extended/Extended2021ZeroMaterial/g}' xmlgeometrywriter.py
-# sed -i '{s/\/ge/\/gez/g}' xmlgeometrywriter.py
-# cmsRun xmlgeometrywriter.py
 
-# sed -i '{s/Extended2021ZeroMaterial/Extended2021FlatMinus05Percent/g}' xmlgeometrywriter.py
-# sed -i '{s/\/gez/\/geFM05/g}' xmlgeometrywriter.py
-# cmsRun xmlgeometrywriter.py
+sed -i '{s/Extended/Extended2021ZeroMaterial/g}' xmlgeometrywriter.py
+sed -i '{s/\/ge/\/gez/g}' xmlgeometrywriter.py
+cmsRun xmlgeometrywriter.py
 
-# sed -i '{s/Extended2021FlatMinus05Percent/Extended2021FlatMinus10Percent/g}' xmlgeometrywriter.py
-# sed -i '{s/\/geFM05/\/geFM10/g}' xmlgeometrywriter.py
-# cmsRun xmlgeometrywriter.py
+sed -i '{s/Extended2021ZeroMaterial/Extended2021FlatMinus05Percent/g}' xmlgeometrywriter.py
+sed -i '{s/\/gez/\/geFM05/g}' xmlgeometrywriter.py
+cmsRun xmlgeometrywriter.py
 
-# sed -i '{s/Extended2021FlatMinus10Percent/Extended2021FlatPlus05Percent/g}' xmlgeometrywriter.py
-# sed -i '{s/\/geFM10/\/geFP05/g}' xmlgeometrywriter.py
-# cmsRun xmlgeometrywriter.py
+sed -i '{s/Extended2021FlatMinus05Percent/Extended2021FlatMinus10Percent/g}' xmlgeometrywriter.py
+sed -i '{s/\/geFM05/\/geFM10/g}' xmlgeometrywriter.py
+cmsRun xmlgeometrywriter.py
 
-# sed -i '{s/Extended2021FlatPlus05Percent/Extended2021FlatPlus10Percent/g}' xmlgeometrywriter.py
-# sed -i '{s/\/geFP05/\/geFP10/g}' xmlgeometrywriter.py
-# cmsRun xmlgeometrywriter.py
+sed -i '{s/Extended2021FlatMinus10Percent/Extended2021FlatPlus05Percent/g}' xmlgeometrywriter.py
+sed -i '{s/\/geFM10/\/geFP05/g}' xmlgeometrywriter.py
+cmsRun xmlgeometrywriter.py
+
+sed -i '{s/Extended2021FlatPlus05Percent/Extended2021FlatPlus10Percent/g}' xmlgeometrywriter.py
+sed -i '{s/\/geFP05/\/geFP10/g}' xmlgeometrywriter.py
+cmsRun xmlgeometrywriter.py
 
 # All the database objects were written into one database
 # (myfile.db) in the steps above.  Extract the different
 # pieces into separate database files.  These are the payloads
-# that get uploaded to the dropbox.  There is one for each tag
+# that get uploaded to the DB.  There is one for each tag
 ./splitExtended2021Database.sh

--- a/CondTools/Geometry/test/writehelpers/splitExtended2021Database.sh
+++ b/CondTools/Geometry/test/writehelpers/splitExtended2021Database.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 
 conddb --yes --db myfile.db copy XMLFILE_Geometry_TagXX_Extended2021_mc --destdb GeometryFileExtended2021.db
+conddb --yes --db myfile.db copy XMLFILE_Geometry_TagXX_Extended2021ZeroMaterial_mc --destdb GeometryFileExtended2021ZeroMaterial.db
+conddb --yes --db myfile.db copy XMLFILE_Geometry_TagXX_Extended2021FlatMinus05Percent_mc --destdb GeometryFileExtended2021FlatMinus05Percent.db
+conddb --yes --db myfile.db copy XMLFILE_Geometry_TagXX_Extended2021FlatMinus10Percent_mc --destdb GeometryFileExtended2021FlatMinus10Percent.db
+conddb --yes --db myfile.db copy XMLFILE_Geometry_TagXX_Extended2021FlatPlus05Percent_mc --destdb GeometryFileExtended2021FlatPlus05Percent.db
+conddb --yes --db myfile.db copy XMLFILE_Geometry_TagXX_Extended2021FlatPlus10Percent_mc --destdb GeometryFileExtended2021FlatPlus10Percent.db
 conddb --yes --db myfile.db copy TKRECO_Geometry_TagXX                  --destdb TKRECO_Geometry.db
 conddb --yes --db myfile.db copy TKParameters_Geometry_TagXX            --destdb TKParameters_Geometry.db
 conddb --yes --db myfile.db copy EBRECO_Geometry_TagXX                  --destdb EBRECO_Geometry.db
@@ -10,7 +15,6 @@ conddb --yes --db myfile.db copy HCALRECO_Geometry_TagXX                --destdb
 conddb --yes --db myfile.db copy HCALParameters_Geometry_TagXX          --destdb HCALParameters_Geometry.db
 conddb --yes --db myfile.db copy CTRECO_Geometry_TagXX                  --destdb CTRECO_Geometry.db
 conddb --yes --db myfile.db copy ZDCRECO_Geometry_TagXX                 --destdb ZDCRECO_Geometry.db
-conddb --yes --db myfile.db copy CASTORRECO_Geometry_TagXX              --destdb CASTORRECO_Geometry.db
 conddb --yes --db myfile.db copy CSCRECO_Geometry_TagXX                 --destdb CSCRECO_Geometry.db
 conddb --yes --db myfile.db copy CSCRECODIGI_Geometry_TagXX             --destdb CSCRECODIGI_Geometry.db
 conddb --yes --db myfile.db copy DTRECO_Geometry_TagXX                  --destdb DTRECO_Geometry.db


### PR DESCRIPTION
Reduced material geometry scenarios are used for calibrations and special studies. This PR enables the creation of the five Run 3 reduced material scenarios with DD4hep. They are:

Zero material
Flat +5% material
Flat +10% material
Flat -5% material
Flat -10% material

#### PR validation:

The five DB payloads were successfully created and uploaded to the DB. They were checked to see that they differ from the standard big XML file only in material content.

Backporting to 12_0 is probably not possible at this late stage.