### PR TITLE
Fixes for double delete in using DBOutputService

### DIFF
--- a/Alignment/CommonAlignmentAlgorithm/plugins/SiPixelLorentzAngleCalibration.cc
+++ b/Alignment/CommonAlignmentAlgorithm/plugins/SiPixelLorentzAngleCalibration.cc
@@ -337,7 +337,7 @@ void SiPixelLorentzAngleCalibration::endOfJob() {
     if (saveToDB_) {  // If requested, write out to DB
       edm::Service<cond::service::PoolDBOutputService> dbService;
       if (dbService.isAvailable()) {
-        dbService->writeOne(&output, firstRunOfIOV, recordNameDBwrite_);
+        dbService->writeOneIOV(output, firstRunOfIOV, recordNameDBwrite_);
       } else {
         edm::LogError("BadConfig") << "@SUB=SiPixelLorentzAngleCalibration::endOfJob"
                                    << "No PoolDBOutputService available, but saveToDB true!";

--- a/Alignment/CommonAlignmentAlgorithm/plugins/SiStripLorentzAngleCalibration.cc
+++ b/Alignment/CommonAlignmentAlgorithm/plugins/SiStripLorentzAngleCalibration.cc
@@ -377,7 +377,7 @@ void SiStripLorentzAngleCalibration::endOfJob() {
     if (saveToDB_) {  // If requested, write out to DB
       edm::Service<cond::service::PoolDBOutputService> dbService;
       if (dbService.isAvailable()) {
-        dbService->writeOne(&output, firstRunOfIOV, recordNameDBwrite_);
+        dbService->writeOneIOV(output, firstRunOfIOV, recordNameDBwrite_);
       } else {
         edm::LogError("BadConfig") << "@SUB=SiStripLorentzAngleCalibration::endOfJob"
                                    << "No PoolDBOutputService available, but saveToDB true!";

--- a/Alignment/TrackerAlignment/src/TrackerAlignment.cc
+++ b/Alignment/TrackerAlignment/src/TrackerAlignment.cc
@@ -247,7 +247,8 @@ void TrackerAlignment::saveToDB(void) {
   //   else
   //     poolDbService->appendSinceTime<Alignments>( alignments, poolDbService->currentTime(),
   //                                                 theAlignRecordName );
-  poolDbService->writeOne<Alignments>(alignments, poolDbService->currentTime(), theAlignRecordName);
+  // In the two calls below it is assumed that the delete of "theAlignableTracker" is also deleting the two concerned payloads...
+  poolDbService->writeOneIOV<Alignments>(*alignments, poolDbService->currentTime(), theAlignRecordName);
   //   if ( poolDbService->isNewTagRequest(theErrorRecordName) )
   //     poolDbService->createNewIOV<AlignmentErrorsExtended>( alignmentErrors,
   //                                                   poolDbService->endOfTime(),
@@ -256,5 +257,6 @@ void TrackerAlignment::saveToDB(void) {
   //     poolDbService->appendSinceTime<AlignmentErrorsExtended>( alignmentErrors,
   //                                                      poolDbService->currentTime(),
   //                                                      theErrorRecordName );
-  poolDbService->writeOne<AlignmentErrorsExtended>(alignmentErrors, poolDbService->currentTime(), theErrorRecordName);
+  poolDbService->writeOneIOV<AlignmentErrorsExtended>(
+      *alignmentErrors, poolDbService->currentTime(), theErrorRecordName);
 }

--- a/Alignment/TrackerAlignment/test/ApeAdder.cpp
+++ b/Alignment/TrackerAlignment/test/ApeAdder.cpp
@@ -91,8 +91,9 @@ void ApeAdder::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   if (!poolDbService.isAvailable())  // Die if not available
     throw cms::Exception("NotAvailable") << "PoolDBOutputService not available";
 
-  // Save to DB
-  poolDbService->writeOne<AlignmentErrorsExtended>(alignmentErrors, poolDbService->beginOfTime(), theErrorRecordName);
+  // Save to DB (assuming that the delete below will also delete the concerned payload )
+  poolDbService->writeOneIOV<AlignmentErrorsExtended>(
+      *alignmentErrors, poolDbService->beginOfTime(), theErrorRecordName);
 
   delete theAlignableTracker;
 }

--- a/CalibCalorimetry/EcalTrivialCondModules/src/EcalLaserCondTools.cc
+++ b/CalibCalorimetry/EcalTrivialCondModules/src/EcalLaserCondTools.cc
@@ -244,7 +244,7 @@ void EcalLaserCondTools::from_hdf_to_db() {
         if (verb_ > 1)
           std::cout << "[" << timeToString(t.tv_sec) << "] "
                     << "Write IOV " << iIov << " starting from " << timeToString(iovStart >> 32) << "... ";
-        db_->writeOne(corrSet.get(), iovStart, "EcalLaserAPDPNRatiosRcd");
+        db_->writeOneIOV(*corrSet, iovStart, "EcalLaserAPDPNRatiosRcd");
       } catch (const cms::Exception& e) {
         if (verb_ > 1)
           std::cout << "Failed. ";
@@ -437,7 +437,7 @@ void EcalLaserCondTools::processIov(CorrReader& r, int t1, int t2[EcalLaserCondT
     if (verb_ > 1)
       std::cout << "[" << timeToString(t.tv_sec) << "] "
                 << "Write IOV " << iIov << " starting from " << timeToString(iovStart >> 32) << "... ";
-    db_->writeOne(corrSet.get(), iovStart, "EcalLaserAPDPNRatiosRcd");
+    db_->writeOneIOV(*corrSet, iovStart, "EcalLaserAPDPNRatiosRcd");
   } catch (const cms::Exception& e) {
     std::cout << "Failed.\nException cathed while writting to cond DB" << e.what() << "\n";
   }

--- a/CalibPPS/TimingCalibration/plugins/PPSDiamondSampicTimingCalibrationPCLHarvester.cc
+++ b/CalibPPS/TimingCalibration/plugins/PPSDiamondSampicTimingCalibrationPCLHarvester.cc
@@ -257,7 +257,7 @@ void PPSDiamondSampicTimingCalibrationPCLHarvester::calibDb(DQMStore::IGetter& i
   auto calibPPS = PPSTimingCalibration(formula, params, time_info);
   // write the object
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
-  poolDbService->writeOne(&calibPPS, poolDbService->currentTime(), "PPSTimingCalibrationRcd");
+  poolDbService->writeOneIOV(calibPPS, poolDbService->currentTime(), "PPSTimingCalibrationRcd");
 }
 
 //------------------------------------------------------------------------------

--- a/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLHarvester.cc
+++ b/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLHarvester.cc
@@ -133,7 +133,7 @@ void SiStripGainsPCLHarvester::dqmEndJob(DQMStore::IBooker& ibooker_, DQMStore::
 
   if (doStoreOnDB) {
     if (poolDbService.isAvailable())
-      poolDbService->writeOne(theAPVGains.get(), poolDbService->currentTime(), m_Record);
+      poolDbService->writeOneIOV(*theAPVGains, poolDbService->currentTime(), m_Record);
     else
       throw std::runtime_error("PoolDBService required.");
   } else {

--- a/Calibration/EcalCalibAlgos/src/ECALpedestalPCLHarvester.cc
+++ b/Calibration/EcalCalibAlgos/src/ECALpedestalPCLHarvester.cc
@@ -144,7 +144,7 @@ void ECALpedestalPCLHarvester::dqmEndJob(DQMStore::IBooker& ibooker_, DQMStore::
     throw std::runtime_error("PoolDBService required.");
   }
 
-  poolDbService->writeOne(&pedestals, poolDbService->currentTime(), "EcalPedestalsRcd");
+  poolDbService->writeOneIOV(pedestals, poolDbService->currentTime(), "EcalPedestalsRcd");
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------

--- a/CommonTools/MVAUtils/plugins/GBRForestWriter.cc
+++ b/CommonTools/MVAUtils/plugins/GBRForestWriter.cc
@@ -169,7 +169,7 @@ void GBRForestWriter::analyze(const edm::Event&, const edm::EventSetup&) {
         std::string outputRecord = (*job)->outputRecord_;
         if (gbrForests.size() > 1)
           outputRecord.append("_").append(gbrForest->first);
-        dbService->writeOne(gbrForest->second, dbService->beginOfTime(), outputRecord);
+        dbService->writeOneIOV(*gbrForest->second, dbService->beginOfTime(), outputRecord);
       }
     }
 

--- a/CondFormats/PCLConfig/plugins/AlignPCLThresholdsWriter.cc
+++ b/CondFormats/PCLConfig/plugins/AlignPCLThresholdsWriter.cc
@@ -179,7 +179,7 @@ void AlignPCLThresholdsWriter::analyze(const edm::Event& iEvent, const edm::Even
   if (poolDbService.isAvailable()) {
     cond::Time_t valid_time = poolDbService->currentTime();
     // this writes the payload to begin in current run defined in cfg
-    poolDbService->writeOne(myThresholds, valid_time, m_record);
+    poolDbService->writeOneIOV(*myThresholds, valid_time, m_record);
   }
 }
 

--- a/CondFormats/SiPixelObjects/test/FastSiPixelFEDChannelContainerFromQuality.cc
+++ b/CondFormats/SiPixelObjects/test/FastSiPixelFEDChannelContainerFromQuality.cc
@@ -420,10 +420,10 @@ void FastSiPixelFEDChannelContainerFromQuality::endJob() {
     cond::Time_t valid_time = poolDbService->currentTime();
     // this writes the payload to begin in current run defined in cfg
     if (!isMC_) {
-      poolDbService->writeOne(myQualities, valid_time, m_record);
+      poolDbService->writeOneIOV(*myQualities, valid_time, m_record);
     } else {
       // for MC IOV since=1
-      poolDbService->writeOne(myQualities, 1, m_record);
+      poolDbService->writeOneIOV(*myQualities, 1, m_record);
     }
   }
 }

--- a/CondFormats/SiPixelObjects/test/SiPixelFEDChannelContainerFromQualityConverter.cc
+++ b/CondFormats/SiPixelObjects/test/SiPixelFEDChannelContainerFromQualityConverter.cc
@@ -226,10 +226,10 @@ void SiPixelFEDChannelContainerFromQualityConverter::endJob() {
     cond::Time_t valid_time = poolDbService->currentTime();
     // this writes the payload to begin in current run defined in cfg
     if (!isMC_) {
-      poolDbService->writeOne(myQualities, valid_time, m_record);
+      poolDbService->writeOneIOV(*myQualities, valid_time, m_record);
     } else {
       // for MC IOV since=1
-      poolDbService->writeOne(myQualities, 1, m_record);
+      poolDbService->writeOneIOV(*myQualities, 1, m_record);
     }
   }
 }

--- a/CondFormats/SiPixelObjects/test/SiPixelFEDChannelContainerWriteFromASCII.cc
+++ b/CondFormats/SiPixelObjects/test/SiPixelFEDChannelContainerWriteFromASCII.cc
@@ -153,7 +153,7 @@ void SiPixelFEDChannelContainerWriteFromASCII::endJob() {
   if (poolDbService.isAvailable()) {
     cond::Time_t valid_time = poolDbService->currentTime();
     // this writes the payload to begin in current run defined in cfg
-    poolDbService->writeOne(myQualities, valid_time, m_record);
+    poolDbService->writeOneIOV(*myQualities, valid_time, m_record);
   }
 }
 

--- a/CondFormats/SiPixelObjects/test/SiPixelQualityProbabilitiesTestWriter.cc
+++ b/CondFormats/SiPixelObjects/test/SiPixelQualityProbabilitiesTestWriter.cc
@@ -136,7 +136,7 @@ void SiPixelQualityProbabilitiesTestWriter::endJob() {
   if (poolDbService.isAvailable()) {
     cond::Time_t valid_time = poolDbService->currentTime();
     // this writes the payload to begin in current run defined in cfg
-    poolDbService->writeOne(myProbabilities, valid_time, m_record);
+    poolDbService->writeOneIOV(*myProbabilities, valid_time, m_record);
   }
 }
 

--- a/CondFormats/SiPixelObjects/test/SiPixelQualityProbabilitiesWriteFromASCII.cc
+++ b/CondFormats/SiPixelObjects/test/SiPixelQualityProbabilitiesWriteFromASCII.cc
@@ -127,7 +127,7 @@ void SiPixelQualityProbabilitiesWriteFromASCII::endJob() {
   if (poolDbService.isAvailable()) {
     cond::Time_t valid_time = poolDbService->currentTime();
     // this writes the payload to begin in current run defined in cfg
-    poolDbService->writeOne(myProbabilities, valid_time, m_record);
+    poolDbService->writeOneIOV(*myProbabilities, valid_time, m_record);
   }
 }
 

--- a/CondTools/BeamSpot/plugins/BeamSpotOnlineRecordsWriter.cc
+++ b/CondTools/BeamSpot/plugins/BeamSpotOnlineRecordsWriter.cc
@@ -207,18 +207,16 @@ void BeamSpotOnlineRecordsWriter::endJob() {
       edm::LogPrint("BeamSpotOnlineRecordsWriter") << "new tag requested";
       if (fuseNewSince) {
         edm::LogPrint("BeamSpotOnlineRecordsWriter") << "Using a new Since: " << fnewSince;
-        poolDbService->createNewIOV<BeamSpotOnlineObjects>(
-            abeam.release(), fnewSince, poolDbService->endOfTime(), fLabel);
+        poolDbService->createOneIOV<BeamSpotOnlineObjects>(*abeam, fnewSince, fLabel);
       } else
-        poolDbService->createNewIOV<BeamSpotOnlineObjects>(
-            abeam.release(), poolDbService->beginOfTime(), poolDbService->endOfTime(), fLabel);
+        poolDbService->createOneIOV<BeamSpotOnlineObjects>(*abeam, poolDbService->beginOfTime(), fLabel);
     } else {
       edm::LogPrint("BeamSpotOnlineRecordsWriter") << "no new tag requested";
       if (fuseNewSince) {
         edm::LogPrint("BeamSpotOnlineRecordsWriter") << "Using a new Since: " << fnewSince;
-        poolDbService->appendSinceTime<BeamSpotOnlineObjects>(abeam.release(), fnewSince, fLabel);
+        poolDbService->appendOneIOV<BeamSpotOnlineObjects>(*abeam, fnewSince, fLabel);
       } else
-        poolDbService->appendSinceTime<BeamSpotOnlineObjects>(abeam.release(), poolDbService->currentTime(), fLabel);
+        poolDbService->appendOneIOV<BeamSpotOnlineObjects>(*abeam, poolDbService->currentTime(), fLabel);
     }
   }
   edm::LogPrint("BeamSpotOnlineRecordsWriter") << "[BeamSpotOnlineRecordsWriter] endJob done \n";

--- a/CondTools/CTPPS/plugins/PPSTimingCalibrationWriter.cc
+++ b/CondTools/CTPPS/plugins/PPSTimingCalibrationWriter.cc
@@ -43,7 +43,7 @@ void PPSTimingCalibrationWriter::analyze(const edm::Event& iEvent, const edm::Ev
   // store the calibration into a DB object
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
   if (poolDbService.isAvailable())
-    poolDbService->writeOne(hTimingCalib.product(), poolDbService->currentTime(), "PPSTimingCalibrationRcd");
+    poolDbService->writeOneIOV(*hTimingCalib.product(), poolDbService->currentTime(), "PPSTimingCalibrationRcd");
   else
     throw cms::Exception("PPSTimingCalibrationWriter") << "PoolDBService required.";
 }

--- a/CondTools/CTPPS/plugins/WriteCTPPSBeamParameters.cc
+++ b/CondTools/CTPPS/plugins/WriteCTPPSBeamParameters.cc
@@ -67,7 +67,7 @@ void WriteCTPPSBeamParameters::analyze(const edm::Event& iEvent, const edm::Even
   // Write to database or sqlite file
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
   if (poolDbService.isAvailable())
-    poolDbService->writeOne(p, ilumi, "CTPPSBeamParametersRcd");
+    poolDbService->writeOneIOV(*p, ilumi, "CTPPSBeamParametersRcd");
   // poolDbService->writeOne( p, poolDbService->currentTime(), "CTPPSBeamParametersRcd"  );
   else
     throw std::runtime_error("PoolDBService required.");

--- a/CondTools/CTPPS/plugins/WritePPSAlignmentConfig.cc
+++ b/CondTools/CTPPS/plugins/WritePPSAlignmentConfig.cc
@@ -41,7 +41,7 @@ void WritePPSAlignmentConfig::analyze(const edm::Event &iEvent, const edm::Event
   // store the data in a DB object
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
   if (poolDbService.isAvailable()) {
-    poolDbService->writeOne(&ppsAlignmentConfig, poolDbService->currentTime(), "PPSAlignmentConfigRcd");
+    poolDbService->writeOneIOV(ppsAlignmentConfig, poolDbService->currentTime(), "PPSAlignmentConfigRcd");
   } else {
     throw cms::Exception("WritePPSAlignmentConfig") << "PoolDBService required.";
   }

--- a/CondTools/CTPPS/plugins/WritePPSAlignmentConfiguration.cc
+++ b/CondTools/CTPPS/plugins/WritePPSAlignmentConfiguration.cc
@@ -41,7 +41,7 @@ void WritePPSAlignmentConfiguration::analyze(const edm::Event &iEvent, const edm
   // store the data in a DB object
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
   if (poolDbService.isAvailable()) {
-    poolDbService->writeOne(&ppsAlignmentConfiguration, poolDbService->currentTime(), "PPSAlignmentConfigurationRcd");
+    poolDbService->writeOneIOV(ppsAlignmentConfiguration, poolDbService->currentTime(), "PPSAlignmentConfigurationRcd");
   } else {
     throw cms::Exception("WritePPSAlignmentConfiguration") << "PoolDBService required.";
   }

--- a/CondTools/CTPPS/src/CTPPSRPAlignmentInfoAnalyzer.cc
+++ b/CondTools/CTPPS/src/CTPPSRPAlignmentInfoAnalyzer.cc
@@ -85,7 +85,7 @@ void CTPPSRPAlignmentInfoAnalyzer::analyze(const edm::Event& iEvent, const edm::
   const CTPPSRPAlignmentCorrectionsData* pCTPPSRPAlignmentCorrectionsData = alignments.product();
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
   if (poolDbService.isAvailable()) {
-    poolDbService->writeOne(pCTPPSRPAlignmentCorrectionsData, iov_, record_);
+    poolDbService->writeOneIOV(*pCTPPSRPAlignmentCorrectionsData, iov_, record_);
   }
 }
 

--- a/CondTools/CTPPS/src/WriteCTPPSPixelAnalysisMask.cc
+++ b/CondTools/CTPPS/src/WriteCTPPSPixelAnalysisMask.cc
@@ -73,7 +73,7 @@ void WriteCTPPSPixelAnalysisMask::analyze(const edm::Event &, edm::EventSetup co
   const CTPPSPixelAnalysisMask *pCTPPSPixelAnalysisMask = hAnalysisMask.product();  // Analysis Mask
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
   if (poolDbService.isAvailable()) {
-    poolDbService->writeOne(pCTPPSPixelAnalysisMask, analysismaskiov_, /*m_record*/ record_);
+    poolDbService->writeOneIOV(*pCTPPSPixelAnalysisMask, analysismaskiov_, /*m_record*/ record_);
   }
 }
 

--- a/CondTools/CTPPS/src/WriteCTPPSPixelDAQMapping.cc
+++ b/CondTools/CTPPS/src/WriteCTPPSPixelDAQMapping.cc
@@ -72,7 +72,7 @@ void WriteCTPPSPixelDAQMapping::analyze(const edm::Event &, edm::EventSetup cons
   const CTPPSPixelDAQMapping *pCTPPSPixelDAQMapping = hMapping.product();  // DAQ Mapping
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
   if (poolDbService.isAvailable()) {
-    poolDbService->writeOne(pCTPPSPixelDAQMapping, daqmappingiov_, /*m_record*/ record_);
+    poolDbService->writeOneIOV(*pCTPPSPixelDAQMapping, daqmappingiov_, /*m_record*/ record_);
   }
 }
 

--- a/CondTools/Ecal/plugins/EcalMustacheSCParametersMaker.cc
+++ b/CondTools/Ecal/plugins/EcalMustacheSCParametersMaker.cc
@@ -54,7 +54,7 @@ void EcalMustacheSCParametersMaker::analyze(const edm::Event& iEvent, const edm:
 
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
   if (poolDbService.isAvailable()) {
-    poolDbService->writeOne(esParamsHandle_.product(), poolDbService->currentTime(), "EcalMustacheSCParametersRcd");
+    poolDbService->writeOneIOV(*esParamsHandle_.product(), poolDbService->currentTime(), "EcalMustacheSCParametersRcd");
   } else {
     throw cms::Exception("PoolDBService") << "No PoolDBService available.";
   }

--- a/CondTools/Ecal/plugins/EcalSCDynamicDPhiParametersMaker.cc
+++ b/CondTools/Ecal/plugins/EcalSCDynamicDPhiParametersMaker.cc
@@ -54,7 +54,8 @@ void EcalSCDynamicDPhiParametersMaker::analyze(const edm::Event& iEvent, const e
 
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
   if (poolDbService.isAvailable()) {
-    poolDbService->writeOne(esParamsHandle_.product(), poolDbService->currentTime(), "EcalSCDynamicDPhiParametersRcd");
+    poolDbService->writeOneIOV(
+        *esParamsHandle_.product(), poolDbService->currentTime(), "EcalSCDynamicDPhiParametersRcd");
   } else {
     throw cms::Exception("PoolDBService") << "No PoolDBService available.";
   }

--- a/CondTools/Hcal/interface/BoostIODBWriter.h
+++ b/CondTools/Hcal/interface/BoostIODBWriter.h
@@ -71,7 +71,7 @@ void BoostIODBWriter<DataType>::analyze(const edm::Event& iEvent, const edm::Eve
 
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
   if (poolDbService.isAvailable())
-    poolDbService->writeOne(datum.release(), poolDbService->currentTime(), record_);
+    poolDbService->writeOneIOV(*datum, poolDbService->currentTime(), record_);
   else
     throw cms::Exception("ConfigurationError") << "PoolDBOutputService is not available, "
                                                << "please configure it properly" << std::endl;

--- a/CondTools/Hcal/plugins/BufferedBoostIODBWriter.cc
+++ b/CondTools/Hcal/plugins/BufferedBoostIODBWriter.cc
@@ -63,7 +63,7 @@ void BufferedBoostIODBWriter::analyze(const edm::Event& iEvent, const edm::Event
 
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
   if (poolDbService.isAvailable())
-    poolDbService->writeOne(fcp.release(), poolDbService->currentTime(), record);
+    poolDbService->writeOneIOV(*fcp, poolDbService->currentTime(), record);
   else
     throw cms::Exception("ConfigurationError") << "PoolDBOutputService is not available, "
                                                << "please configure it properly" << std::endl;

--- a/CondTools/RunInfo/interface/BTransitionAnalyzer.h
+++ b/CondTools/RunInfo/interface/BTransitionAnalyzer.h
@@ -59,7 +59,7 @@ namespace cond {
           edm::LogInfo("BTransitionAnalyzer")
               << "Exporting payload corresponding to the calibrations for magnetic field "
               << (bFieldLabel == bOnLabel ? "ON" : "OFF") << " starting from run number: " << run.run() << std::endl;
-          mydbservice->writeOne(payloadHandle.product(), run.run(), demangledName(typeid(R)));
+          mydbservice->writeOneIOV(*payloadHandle.product(), run.run(), demangledName(typeid(R)));
         } else {
           edm::LogInfo("BTransitionAnalyzer") << "The payload corresponding to the calibrations for magnetic field "
                                               << (bFieldLabel == bOnLabel ? "ON" : "OFF") << " is still valid for run "

--- a/CondTools/SiPhase2Tracker/plugins/DTCCablingMapProducer.cc
+++ b/CondTools/SiPhase2Tracker/plugins/DTCCablingMapProducer.cc
@@ -269,7 +269,7 @@ void DTCCablingMapProducer::endJob() {
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
 
   if (poolDbService.isAvailable()) {
-    poolDbService->writeOne(pCablingMap_.release(), iovBeginTime_, record_);
+    poolDbService->writeOneIOV(*pCablingMap_, iovBeginTime_, record_);
   } else {
     throw cms::Exception("PoolDBServiceNotFound") << "A running PoolDBService instance is required.";
   }

--- a/CondTools/SiPhase2Tracker/plugins/DTCCablingMapTestProducer.cc
+++ b/CondTools/SiPhase2Tracker/plugins/DTCCablingMapTestProducer.cc
@@ -78,7 +78,7 @@ void DTCCablingMapTestProducer::beginJob() {
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
 
   if (poolDbService.isAvailable())
-    poolDbService->writeOne(pCablingMap_.release(), iovBeginTime_, recordName_);
+    poolDbService->writeOneIOV(*pCablingMap_, iovBeginTime_, recordName_);
   else
     throw std::runtime_error("PoolDBService required.");
 }

--- a/CondTools/SiPhase2Tracker/plugins/SiPhase2OuterTrackerLorentzAngleWriter.cc
+++ b/CondTools/SiPhase2Tracker/plugins/SiPhase2OuterTrackerLorentzAngleWriter.cc
@@ -133,7 +133,7 @@ void SiPhase2OuterTrackerLorentzAngleWriter::analyze(const edm::Event& iEvent, c
   auto lorentzAngle = std::make_unique<SiPhase2OuterTrackerLorentzAngle>();
   lorentzAngle->putLorentzAngles(detsLAtoDB);
   edm::LogInfo("SiPhase2OuterTrackerLorentzAngleWriter") << "currentTime " << mydbservice->currentTime() << std::endl;
-  mydbservice->writeOne(lorentzAngle.release(), mydbservice->currentTime(), m_record);
+  mydbservice->writeOneIOV(*lorentzAngle, mydbservice->currentTime(), m_record);
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------

--- a/CondTools/SiStrip/plugins/SiStripApvGainRescaler.cc
+++ b/CondTools/SiStrip/plugins/SiStripApvGainRescaler.cc
@@ -128,7 +128,7 @@ void SiStripApvGainRescaler::analyze(const edm::Event& iEvent, const edm::EventS
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
 
   if (poolDbService.isAvailable())
-    poolDbService->writeOne(theAPVGains.get(), poolDbService->currentTime(), m_Record);
+    poolDbService->writeOneIOV(*theAPVGains, poolDbService->currentTime(), m_Record);
   else
     throw std::runtime_error("PoolDBService required.");
 }

--- a/CondTools/SiStrip/plugins/SiStripChannelGainFromDBMiscalibrator.cc
+++ b/CondTools/SiStrip/plugins/SiStripChannelGainFromDBMiscalibrator.cc
@@ -239,7 +239,7 @@ void SiStripChannelGainFromDBMiscalibrator::analyze(const edm::Event& iEvent, co
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
 
   if (poolDbService.isAvailable())
-    poolDbService->writeOne(theAPVGains.get(), poolDbService->currentTime(), m_Record);
+    poolDbService->writeOneIOV(*theAPVGains, poolDbService->currentTime(), m_Record);
   else
     throw std::runtime_error("PoolDBService required.");
 }

--- a/CondTools/SiStrip/plugins/SiStripNoisesFromDBMiscalibrator.cc
+++ b/CondTools/SiStrip/plugins/SiStripNoisesFromDBMiscalibrator.cc
@@ -254,7 +254,7 @@ void SiStripNoisesFromDBMiscalibrator::analyze(const edm::Event& iEvent, const e
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
 
   if (poolDbService.isAvailable())
-    poolDbService->writeOne(theSiStripNoises.get(), poolDbService->currentTime(), "SiStripNoisesRcd");
+    poolDbService->writeOneIOV(*theSiStripNoises, poolDbService->currentTime(), "SiStripNoisesRcd");
   else
     throw std::runtime_error("PoolDBService required.");
 }

--- a/JetMETCorrections/FFTJetModules/plugins/FFTJetCorrectorDBWriter.cc
+++ b/JetMETCorrections/FFTJetModules/plugins/FFTJetCorrectorDBWriter.cc
@@ -81,7 +81,7 @@ void FFTJetCorrectorDBWriter::analyze(const edm::Event& iEvent, const edm::Event
 
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
   if (poolDbService.isAvailable())
-    poolDbService->writeOne(fcp.release(), poolDbService->currentTime(), record);
+    poolDbService->writeOneIOV(*fcp, poolDbService->currentTime(), record);
   else
     throw cms::Exception("ConfigurationError") << "PoolDBOutputService is not available, "
                                                << "please configure it properly" << std::endl;

--- a/L1Trigger/L1TMuonOverlap/plugins/L1TMuonOverlapParamsDBProducer.cc
+++ b/L1Trigger/L1TMuonOverlap/plugins/L1TMuonOverlapParamsDBProducer.cc
@@ -32,7 +32,7 @@ void L1MuonOverlapParamsDBProducer::analyze(const edm::Event& ev, const edm::Eve
   std::string recordName = "L1TMuonOverlapParamsRcd";
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
   if (poolDbService.isAvailable()) {
-    poolDbService->writeOne(omtfParams.get(), poolDbService->currentTime(), recordName);
+    poolDbService->writeOneIOV(*omtfParams, poolDbService->currentTime(), recordName);
   }
 }
 ///////////////////////////////////////////////////////////////

--- a/L1Trigger/L1TMuonOverlapPhase1/plugins/L1MuonOverlapPhase1ParamsDBProducer.cc
+++ b/L1Trigger/L1TMuonOverlapPhase1/plugins/L1MuonOverlapPhase1ParamsDBProducer.cc
@@ -30,7 +30,7 @@ void L1MuonOverlapPhase1ParamsDBProducer::analyze(const edm::Event& ev, const ed
   std::string recordName = "L1TMuonOverlapParamsRcd";
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
   if (poolDbService.isAvailable()) {
-    poolDbService->writeOne(omtfParams.get(), poolDbService->currentTime(), recordName);
+    poolDbService->writeOneIOV(*omtfParams, poolDbService->currentTime(), recordName);
   }
   edm::LogVerbatim("L1MuonOverlapParamsDBProducer") << " analyze() line " << __LINE__ << std::endl;
 }

--- a/L1TriggerConfig/Utilities/src/L1KeyListWriter.cc
+++ b/L1TriggerConfig/Utilities/src/L1KeyListWriter.cc
@@ -31,7 +31,7 @@ void L1KeyListWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& e
   edm::Service<cond::service::PoolDBOutputService> poolDb;
   if (poolDb.isAvailable()) {
     cond::Time_t firstSinceTime = poolDb->beginOfTime();
-    poolDb->writeOne(ptr1.get(), firstSinceTime, "L1TriggerKeyListExtRcd");
+    poolDb->writeOneIOV(*ptr1, firstSinceTime, "L1TriggerKeyListExtRcd");
   }
 }
 

--- a/L1TriggerConfig/Utilities/src/L1KeyWriter.cc
+++ b/L1TriggerConfig/Utilities/src/L1KeyWriter.cc
@@ -31,7 +31,7 @@ void L1KeyWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& evSet
   edm::Service<cond::service::PoolDBOutputService> poolDb;
   if (poolDb.isAvailable()) {
     cond::Time_t firstSinceTime = poolDb->beginOfTime();
-    poolDb->writeOne(ptr1.get(), firstSinceTime, "L1TriggerKeyExtRcd");
+    poolDb->writeOneIOV(*ptr1, firstSinceTime, "L1TriggerKeyExtRcd");
   }
 }
 

--- a/L1TriggerConfig/Utilities/src/L1MenuWriter.cc
+++ b/L1TriggerConfig/Utilities/src/L1MenuWriter.cc
@@ -41,7 +41,7 @@ void L1MenuWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& evSe
   edm::Service<cond::service::PoolDBOutputService> poolDb;
   if (poolDb.isAvailable()) {
     cond::Time_t firstSinceTime = poolDb->beginOfTime();
-    poolDb->writeOne(ptr1.get(), firstSinceTime, (isO2Opayload ? "L1TUtmTriggerMenuO2ORcd" : "L1TUtmTriggerMenuRcd"));
+    poolDb->writeOneIOV(*ptr1, firstSinceTime, (isO2Opayload ? "L1TUtmTriggerMenuO2ORcd" : "L1TUtmTriggerMenuRcd"));
   }
 }
 

--- a/L1TriggerConfig/Utilities/src/L1TCaloParamsUpdater.cc
+++ b/L1TriggerConfig/Utilities/src/L1TCaloParamsUpdater.cc
@@ -41,7 +41,7 @@ void L1TCaloParamsUpdater::analyze(const edm::Event& iEvent, const edm::EventSet
   edm::Service<cond::service::PoolDBOutputService> poolDb;
   if (poolDb.isAvailable()) {
     cond::Time_t firstSinceTime = poolDb->beginOfTime();
-    poolDb->writeOne(ptr1.get(), firstSinceTime, "L1TCaloStage2ParamsTweakedRcd");
+    poolDb->writeOneIOV(*ptr1, firstSinceTime, "L1TCaloStage2ParamsTweakedRcd");
   }
 }
 

--- a/L1TriggerConfig/Utilities/src/L1TCaloParamsWriter.cc
+++ b/L1TriggerConfig/Utilities/src/L1TCaloParamsWriter.cc
@@ -41,7 +41,7 @@ void L1TCaloStage2ParamsWriter::analyze(const edm::Event& iEvent, const edm::Eve
   edm::Service<cond::service::PoolDBOutputService> poolDb;
   if (poolDb.isAvailable()) {
     cond::Time_t firstSinceTime = poolDb->beginOfTime();
-    poolDb->writeOne(ptr1.get(), firstSinceTime, (isO2Opayload ? "L1TCaloParamsO2ORcd" : "L1TCaloParamsRcd"));
+    poolDb->writeOneIOV(*ptr1, firstSinceTime, (isO2Opayload ? "L1TCaloParamsO2ORcd" : "L1TCaloParamsRcd"));
   }
 }
 

--- a/L1TriggerConfig/Utilities/src/L1TGlobalPrescalesVetosWriter.cc
+++ b/L1TriggerConfig/Utilities/src/L1TGlobalPrescalesVetosWriter.cc
@@ -41,8 +41,8 @@ void L1TGlobalPrescalesVetosWriter::analyze(const edm::Event& iEvent, const edm:
   edm::Service<cond::service::PoolDBOutputService> poolDb;
   if (poolDb.isAvailable()) {
     cond::Time_t firstSinceTime = poolDb->beginOfTime();
-    poolDb->writeOne(
-        ptr1.get(), firstSinceTime, (isO2Opayload ? "L1TGlobalPrescalesVetosO2ORcd" : "L1TGlobalPrescalesVetosRcd"));
+    poolDb->writeOneIOV(
+        *ptr1, firstSinceTime, (isO2Opayload ? "L1TGlobalPrescalesVetosO2ORcd" : "L1TGlobalPrescalesVetosRcd"));
   }
 }
 

--- a/L1TriggerConfig/Utilities/src/L1TMuonBarrelParamsWriter.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonBarrelParamsWriter.cc
@@ -47,10 +47,9 @@ void L1TMuonBarrelParamsWriter::analyze(const edm::Event& iEvent, const edm::Eve
   edm::Service<cond::service::PoolDBOutputService> poolDb;
   if (poolDb.isAvailable()) {
     cond::Time_t firstSinceTime = poolDb->beginOfTime();
-    poolDb->writeOne(
-        ptr1.get(), firstSinceTime, (isO2Opayload ? "L1TMuonBarrelParamsO2ORcd" : "L1TMuonBarrelParamsRcd"));
+    poolDb->writeOneIOV(*ptr1, firstSinceTime, (isO2Opayload ? "L1TMuonBarrelParamsO2ORcd" : "L1TMuonBarrelParamsRcd"));
     if (not isO2Opayload)
-      poolDb->writeOne(ptr2.get(), firstSinceTime, ("L1TMuonBarrelKalmanParamsRcd"));
+      poolDb->writeOneIOV(*ptr2, firstSinceTime, ("L1TMuonBarrelKalmanParamsRcd"));
   }
 }
 

--- a/L1TriggerConfig/Utilities/src/L1TMuonEndCapForestWriter.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonEndCapForestWriter.cc
@@ -42,8 +42,7 @@ void L1TMuonEndCapForestWriter::analyze(const edm::Event& iEvent, const edm::Eve
   edm::Service<cond::service::PoolDBOutputService> poolDb;
   if (poolDb.isAvailable()) {
     cond::Time_t firstSinceTime = poolDb->beginOfTime();
-    poolDb->writeOne(
-        ptr1.get(), firstSinceTime, (isO2Opayload ? "L1TMuonEndCapForestO2ORcd" : "L1TMuonEndCapForestRcd"));
+    poolDb->writeOneIOV(*ptr1, firstSinceTime, (isO2Opayload ? "L1TMuonEndCapForestO2ORcd" : "L1TMuonEndCapForestRcd"));
   }
 }
 

--- a/L1TriggerConfig/Utilities/src/L1TMuonEndCapParamsWriter.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonEndCapParamsWriter.cc
@@ -42,8 +42,7 @@ void L1TMuonEndCapParamsWriter::analyze(const edm::Event& iEvent, const edm::Eve
   edm::Service<cond::service::PoolDBOutputService> poolDb;
   if (poolDb.isAvailable()) {
     cond::Time_t firstSinceTime = poolDb->beginOfTime();
-    poolDb->writeOne(
-        ptr1.get(), firstSinceTime, (isO2Opayload ? "L1TMuonEndCapParamsO2ORcd" : "L1TMuonEndCapParamsRcd"));
+    poolDb->writeOneIOV(*ptr1, firstSinceTime, (isO2Opayload ? "L1TMuonEndCapParamsO2ORcd" : "L1TMuonEndCapParamsRcd"));
   }
 }
 

--- a/L1TriggerConfig/Utilities/src/L1TMuonGlobalParamsWriter.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonGlobalParamsWriter.cc
@@ -41,8 +41,7 @@ void L1TMuonGlobalParamsWriter::analyze(const edm::Event& iEvent, const edm::Eve
   edm::Service<cond::service::PoolDBOutputService> poolDb;
   if (poolDb.isAvailable()) {
     cond::Time_t firstSinceTime = poolDb->beginOfTime();
-    poolDb->writeOne(
-        ptr1.get(), firstSinceTime, (isO2Opayload ? "L1TMuonGlobalParamsO2ORcd" : "L1TMuonGlobalParamsRcd"));
+    poolDb->writeOneIOV(*ptr1, firstSinceTime, (isO2Opayload ? "L1TMuonGlobalParamsO2ORcd" : "L1TMuonGlobalParamsRcd"));
   }
 }
 

--- a/L1TriggerConfig/Utilities/src/L1TMuonOverlapParamsWriter.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonOverlapParamsWriter.cc
@@ -31,7 +31,7 @@ void L1TMuonOverlapParamsWriter::analyze(const edm::Event& iEvent, const edm::Ev
   edm::Service<cond::service::PoolDBOutputService> poolDb;
   if (poolDb.isAvailable()) {
     cond::Time_t firstSinceTime = poolDb->beginOfTime();
-    poolDb->writeOne(ptr1.get(), firstSinceTime, "L1TMuonOverlapPatternParamsRcd");
+    poolDb->writeOneIOV(*ptr1, firstSinceTime, "L1TMuonOverlapPatternParamsRcd");
   }
 }
 

--- a/SimCalorimetry/EcalSelectiveReadoutProducers/src/EcalSRCondTools.cc
+++ b/SimCalorimetry/EcalSelectiveReadoutProducers/src/EcalSRCondTools.cc
@@ -98,7 +98,7 @@ void EcalSRCondTools::analyze(const edm::Event& event, const edm::EventSetup& es
     //fillup DB
     //create new infinite IOV
     cond::Time_t firstSinceTime = db->beginOfTime();
-    db->writeOne(sr, firstSinceTime, "EcalSRSettingsRcd");
+    db->writeOneIOV(*sr, firstSinceTime, "EcalSRSettingsRcd");
     done_ = true;
   } else {  //read mode
     const edm::ESHandle<EcalSRSettings> hSr = es.getHandle(hSrToken_);


### PR DESCRIPTION
Follows up https://github.com/cms-sw/cmssw/pull/35048 and https://github.com/cms-sw/cmssw/pull/35556
This PR contains fixes for a number of cases where the call of the DBOutputService interface is resulting in a double delete caused by the changes introduced in https://github.com/cms-sw/cmssw/pull/35048.

Additionally, few changes (like for example  in CondTools/SiPhase2Tracker/plugins/DTCCablingMapProducer.cc ) are only introduced to improve the memory management.

Tests: unit tests and integration tests