### PR TITLE
Fixed cms deprecated warnings in MuonAnalysis/MuonAssociators

### DIFF
--- a/DQMOffline/L1Trigger/interface/L1TTauOffline.h
+++ b/DQMOffline/L1Trigger/interface/L1TTauOffline.h
@@ -22,7 +22,6 @@
 // FWCore
 #include "FWCore/Common/interface/Provenance.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"

--- a/DQMOffline/L1Trigger/src/L1TMuonDQMOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TMuonDQMOffline.cc
@@ -108,7 +108,7 @@ double MuonGmtPair::getVar(const L1TMuonDQMOffline::EffType type) const {
 
 //__________DQM_base_class_______________________________________________
 L1TMuonDQMOffline::L1TMuonDQMOffline(const ParameterSet& ps)
-    : m_propagator(ps.getParameter<edm::ParameterSet>("muProp")),
+    : m_propagator(ps.getParameter<edm::ParameterSet>("muProp"), consumesCollector()),
       m_effTypes({kEffPt, kEffPhi, kEffEta, kEffVtx}),
       m_resTypes({kResPt, kResQOverPt, kResPhi, kResEta}),
       m_etaRegions({kEtaRegionAll, kEtaRegionBmtf, kEtaRegionOmtf, kEtaRegionEmtf}),
@@ -179,7 +179,6 @@ void L1TMuonDQMOffline::dqmBeginRun(const edm::Run& run, const edm::EventSetup& 
     cout << "[L1TMuonDQMOffline:] Called beginRun." << endl;
   bool changed = true;
   m_hltConfig.init(run, iSetup, m_trigProcess, changed);
-  m_propagator.init(iSetup);
 }
 
 //_____________________________________________________________________
@@ -211,6 +210,8 @@ void L1TMuonDQMOffline::bookHistograms(DQMStore::IBooker& ibooker, const edm::Ru
 
 //_____________________________________________________________________
 void L1TMuonDQMOffline::analyze(const Event& iEvent, const EventSetup& eventSetup) {
+  m_propagator.init(eventSetup);
+
   Handle<reco::MuonCollection> muons;
   iEvent.getByToken(m_MuonInputTag, muons);
   Handle<BeamSpot> beamSpot;

--- a/L1Trigger/L1TNtuples/interface/L1AnalysisRecoMuon2.h
+++ b/L1Trigger/L1TNtuples/interface/L1AnalysisRecoMuon2.h
@@ -26,6 +26,7 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 //vertices bp
 #include "DataFormats/VertexReco/interface/Vertex.h"
@@ -39,7 +40,7 @@
 namespace L1Analysis {
   class L1AnalysisRecoMuon2 {
   public:
-    L1AnalysisRecoMuon2(const edm::ParameterSet& pset);
+    L1AnalysisRecoMuon2(const edm::ParameterSet& pset, edm::ConsumesCollector);
     ~L1AnalysisRecoMuon2();
 
     void init(const edm::EventSetup& eventSetup);

--- a/L1Trigger/L1TNtuples/src/L1AnalysisRecoMuon2.cc
+++ b/L1Trigger/L1TNtuples/src/L1AnalysisRecoMuon2.cc
@@ -7,9 +7,9 @@
 using namespace std;
 using namespace muon;
 
-L1Analysis::L1AnalysisRecoMuon2::L1AnalysisRecoMuon2(const edm::ParameterSet& pset)
-    : muPropagator1st_(pset.getParameter<edm::ParameterSet>("muProp1st")),
-      muPropagator2nd_(pset.getParameter<edm::ParameterSet>("muProp2nd")) {}
+L1Analysis::L1AnalysisRecoMuon2::L1AnalysisRecoMuon2(const edm::ParameterSet& pset, edm::ConsumesCollector iC)
+    : muPropagator1st_(pset.getParameter<edm::ParameterSet>("muProp1st"), iC),
+      muPropagator2nd_(pset.getParameter<edm::ParameterSet>("muProp2nd"), iC) {}
 
 L1Analysis::L1AnalysisRecoMuon2::~L1AnalysisRecoMuon2() {}
 

--- a/MuonAnalysis/MuonAssociators/interface/L1MuonMatcherAlgo.h
+++ b/MuonAnalysis/MuonAssociators/interface/L1MuonMatcherAlgo.h
@@ -20,6 +20,7 @@
 #include "DataFormats/L1Trigger/interface/L1MuonParticle.h"
 #include "DataFormats/L1Trigger/interface/Muon.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 #include "CommonTools/Utils/interface/AnySelector.h"
@@ -27,7 +28,7 @@
 
 class L1MuonMatcherAlgo {
 public:
-  explicit L1MuonMatcherAlgo(const edm::ParameterSet &iConfig);
+  explicit L1MuonMatcherAlgo(const edm::ParameterSet &iConfig, edm::ConsumesCollector);
   ~L1MuonMatcherAlgo();
 
   /// Call this method at the beginning of each run, to initialize geometry, magnetic field and propagators

--- a/MuonAnalysis/MuonAssociators/interface/MatcherUsingTracksAlgorithm.h
+++ b/MuonAnalysis/MuonAssociators/interface/MatcherUsingTracksAlgorithm.h
@@ -16,6 +16,7 @@
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -26,9 +27,13 @@
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateClosestToPoint.h"
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 
+class IdealMagneticFieldRecord;
+class TrackingComponentsRecord;
+class GlobalTrackingGeometryRecord;
+
 class MatcherUsingTracksAlgorithm {
 public:
-  explicit MatcherUsingTracksAlgorithm(const edm::ParameterSet &iConfig);
+  explicit MatcherUsingTracksAlgorithm(const edm::ParameterSet &iConfig, edm::ConsumesCollector);
   virtual ~MatcherUsingTracksAlgorithm() {}
 
   /// Call this method at the beginning of each run, to initialize geometry, magnetic field and propagators
@@ -130,6 +135,10 @@ private:
   edm::ESHandle<MagneticField> magfield_;
   edm::ESHandle<Propagator> propagator_;
   edm::ESHandle<GlobalTrackingGeometry> geometry_;
+
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magfieldToken_;
+  edm::ESGetToken<Propagator, TrackingComponentsRecord> propagatorToken_;
+  edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> geometryToken_;
 
   /// Get track reference out of a Candidate (via dynamic_cast to reco::RecoCandidate)
   reco::TrackRef getTrack(const reco::Candidate &reco, WhichTrack which) const;

--- a/MuonAnalysis/MuonAssociators/interface/PropagateToMuon.h
+++ b/MuonAnalysis/MuonAssociators/interface/PropagateToMuon.h
@@ -18,6 +18,7 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "RecoMuon/DetLayers/interface/MuonDetLayerGeometry.h"
@@ -27,13 +28,16 @@
 #include "SimDataFormats/Vertex/interface/SimVertexContainer.h"
 
 class DetLayer;
+class IdealMagneticFieldRecord;
+class TrackingComponentsRecord;
+class MuonRecoGeometryRecord;
 
 class PropagateToMuon {
 public:
-  explicit PropagateToMuon(const edm::ParameterSet &iConfig);
+  explicit PropagateToMuon(const edm::ParameterSet &iConfig, edm::ConsumesCollector);
   ~PropagateToMuon();
 
-  /// Call this method at the beginning of each run, to initialize geometry, magnetic field and propagators
+  /// Call this method at the beginning of each event, to initialize geometry, magnetic field and propagators
   void init(const edm::EventSetup &iSetup);
 
   /// Extrapolate reco::Track to the muon station 2, return an invalid TSOS if it fails
@@ -78,6 +82,10 @@ private:
   edm::ESHandle<MagneticField> magfield_;
   edm::ESHandle<Propagator> propagator_, propagatorAny_, propagatorOpposite_;
   edm::ESHandle<MuonDetLayerGeometry> muonGeometry_;
+
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magfieldToken_;
+  edm::ESGetToken<Propagator, TrackingComponentsRecord> propagatorToken_, propagatorAnyToken_, propagatorOppositeToken_;
+  edm::ESGetToken<MuonDetLayerGeometry, MuonRecoGeometryRecord> muonGeometryToken_;
   // simplified geometry for track propagation
   const BoundCylinder *barrelCylinder_;
   const BoundDisk *endcapDiskPos_[3], *endcapDiskNeg_[3];

--- a/MuonAnalysis/MuonAssociators/plugins/L1MuonMatcher.cc
+++ b/MuonAnalysis/MuonAssociators/plugins/L1MuonMatcher.cc
@@ -9,7 +9,7 @@
   \version  $Id: L1MuonMatcher.cc,v 1.4 2011/03/31 09:59:33 gpetrucc Exp $
 */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
@@ -29,14 +29,12 @@
 
 namespace pat {
 
-  class L1MuonMatcher : public edm::EDProducer {
+  class L1MuonMatcher : public edm::stream::EDProducer<> {
   public:
     explicit L1MuonMatcher(const edm::ParameterSet &iConfig);
     ~L1MuonMatcher() override {}
 
     void produce(edm::Event &iEvent, const edm::EventSetup &iSetup) override;
-
-    void beginRun(const edm::Run &iRun, const edm::EventSetup &iSetup) override;
 
   private:
     typedef pat::TriggerObjectStandAlone PATPrimitive;
@@ -74,7 +72,7 @@ namespace pat {
 }  // namespace pat
 
 pat::L1MuonMatcher::L1MuonMatcher(const edm::ParameterSet &iConfig)
-    : matcher_(iConfig),
+    : matcher_(iConfig, consumesCollector()),
       recoToken_(consumes<edm::View<reco::Candidate> >(iConfig.getParameter<edm::InputTag>("src"))),
       labelL1_(iConfig.getParameter<std::string>("setL1Label")),
       labelProp_(iConfig.getParameter<std::string>("setPropLabel")),
@@ -109,6 +107,8 @@ pat::L1MuonMatcher::L1MuonMatcher(const edm::ParameterSet &iConfig)
 void pat::L1MuonMatcher::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   using namespace edm;
   using namespace std;
+
+  matcher_.init(iSetup);
 
   Handle<View<reco::Candidate> > reco;
   Handle<vector<l1extra::L1MuonParticle> > l1s;
@@ -254,8 +254,6 @@ void pat::L1MuonMatcher::storeExtraInfo(edm::Event &iEvent,
   filler.fill();
   iEvent.put(std::move(valMap), label);
 }
-
-void pat::L1MuonMatcher::beginRun(const edm::Run &iRun, const edm::EventSetup &iSetup) { matcher_.init(iSetup); }
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 using namespace pat;

--- a/MuonAnalysis/MuonAssociators/plugins/MatcherByPulls.cc
+++ b/MuonAnalysis/MuonAssociators/plugins/MatcherByPulls.cc
@@ -21,7 +21,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -44,7 +44,7 @@
  */
 namespace pat {
   template <typename T>
-  class MatcherByPulls : public edm::EDProducer {
+  class MatcherByPulls : public edm::stream::EDProducer<> {
   public:
     explicit MatcherByPulls(const edm::ParameterSet&);
     ~MatcherByPulls() override;

--- a/MuonAnalysis/MuonAssociators/plugins/MatcherUsingTracks.cc
+++ b/MuonAnalysis/MuonAssociators/plugins/MatcherUsingTracks.cc
@@ -9,7 +9,7 @@
   \version  $Id: MatcherUsingTracks.cc,v 1.5 2010/07/12 20:56:11 gpetrucc Exp $
 */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
@@ -29,7 +29,7 @@ namespace edm {
 
 namespace pat {
 
-  class MatcherUsingTracks : public edm::EDProducer {
+  class MatcherUsingTracks : public edm::stream::EDProducer<> {
   public:
     explicit MatcherUsingTracks(const edm::ParameterSet &iConfig);
     ~MatcherUsingTracks() override {}
@@ -61,7 +61,7 @@ namespace pat {
 pat::MatcherUsingTracks::MatcherUsingTracks(const edm::ParameterSet &iConfig)
     : srcToken_(consumes<edm::View<reco::Candidate> >(iConfig.getParameter<edm::InputTag>("src"))),
       matchedToken_(consumes<edm::View<reco::Candidate> >(iConfig.getParameter<edm::InputTag>("matched"))),
-      algo_(iConfig),
+      algo_(iConfig, consumesCollector()),
       dontFailOnMissingInput_(iConfig.existsAs<bool>("dontFailOnMissingInput")
                                   ? iConfig.getParameter<bool>("dontFailOnMissingInput")
                                   : false),

--- a/MuonAnalysis/MuonAssociators/plugins/MuonCleanerBySegments.cc
+++ b/MuonAnalysis/MuonAssociators/plugins/MuonCleanerBySegments.cc
@@ -20,7 +20,7 @@
   \version  $Id: MuonCleanerBySegments.cc,v 1.1 2012/08/11 13:00:50 gpetrucc Exp $
 */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -35,7 +35,7 @@
 namespace modules {
 
   template <typename T>
-  class MuonCleanerBySegmentsT : public edm::EDProducer {
+  class MuonCleanerBySegmentsT : public edm::stream::EDProducer<> {
   public:
     explicit MuonCleanerBySegmentsT(const edm::ParameterSet &iConfig);
     ~MuonCleanerBySegmentsT() override {}

--- a/MuonAnalysis/MuonAssociators/plugins/MuonMCClassifier.cc
+++ b/MuonAnalysis/MuonAssociators/plugins/MuonMCClassifier.cc
@@ -37,7 +37,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -62,7 +62,7 @@
 
 //
 // class decleration
-class MuonMCClassifier : public edm::EDProducer {
+class MuonMCClassifier : public edm::stream::EDProducer<> {
 public:
   explicit MuonMCClassifier(const edm::ParameterSet &);
   ~MuonMCClassifier() override;

--- a/MuonAnalysis/MuonAssociators/plugins/TriggerObjectFilterByCollection.cc
+++ b/MuonAnalysis/MuonAssociators/plugins/TriggerObjectFilterByCollection.cc
@@ -20,19 +20,19 @@
 #include <vector>
 #include <algorithm>
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h"
 
-class TriggerObjectFilterByCollection : public edm::EDProducer {
+class TriggerObjectFilterByCollection : public edm::global::EDProducer<> {
 public:
   explicit TriggerObjectFilterByCollection(const edm::ParameterSet &iConfig);
   ~TriggerObjectFilterByCollection() override {}
 
-  void produce(edm::Event &iEvent, const edm::EventSetup &iSetup) override;
+  void produce(edm::StreamID, edm::Event &iEvent, const edm::EventSetup &iSetup) const override;
 
 private:
   edm::EDGetTokenT<std::vector<pat::TriggerObjectStandAlone>> src_;
@@ -53,7 +53,7 @@ TriggerObjectFilterByCollection::TriggerObjectFilterByCollection(const edm::Para
   }
 }
 
-void TriggerObjectFilterByCollection::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
+void TriggerObjectFilterByCollection::produce(edm::StreamID, edm::Event &iEvent, const edm::EventSetup &iSetup) const {
   using namespace edm;
 
   Handle<std::vector<pat::TriggerObjectStandAlone>> src;

--- a/MuonAnalysis/MuonAssociators/src/L1MuonMatcherAlgo.cc
+++ b/MuonAnalysis/MuonAssociators/src/L1MuonMatcherAlgo.cc
@@ -2,8 +2,8 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-L1MuonMatcherAlgo::L1MuonMatcherAlgo(const edm::ParameterSet &iConfig)
-    : prop_(iConfig),
+L1MuonMatcherAlgo::L1MuonMatcherAlgo(const edm::ParameterSet &iConfig, edm::ConsumesCollector iCollector)
+    : prop_(iConfig, iCollector),
       useStage2L1_(iConfig.existsAs<bool>("useStage2L1") ? iConfig.getParameter<bool>("useStage2L1") : false),
       preselectionCut_(
           (iConfig.existsAs<std::string>("preselection")) ? iConfig.getParameter<std::string>("preselection") : ""),


### PR DESCRIPTION
#### PR description:

- added esConsumes to helper classes
- converted modules to thread friendly versions

#### PR validation:

Code compiles.