### PR TITLE
Fix CMS deprecated warnings in CommonTools/RecoAlgos

### DIFF
--- a/CommonTools/RecoAlgos/plugins/CaloRecHitCandidateProducer.cc
+++ b/CommonTools/RecoAlgos/plugins/CaloRecHitCandidateProducer.cc
@@ -1,4 +1,4 @@
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/RecoCandidate/interface/CaloRecHitCandidate.h"
 
@@ -6,7 +6,7 @@ namespace reco {
   namespace modules {
 
     template <typename HitCollection>
-    class CaloRecHitCandidateProducer : public edm::EDProducer {
+    class CaloRecHitCandidateProducer : public edm::global::EDProducer<> {
     public:
       /// constructor
       CaloRecHitCandidateProducer(const edm::ParameterSet &cfg)
@@ -16,9 +16,9 @@ namespace reco {
 
     private:
       /// process one event
-      void produce(edm::Event &, const edm::EventSetup &) override;
+      void produce(edm::StreamID, edm::Event &, const edm::EventSetup &) const override;
       /// source collection tag
-      edm::EDGetTokenT<HitCollection> srcToken_;
+      const edm::EDGetTokenT<HitCollection> srcToken_;
     };
   }  // namespace modules
 }  // namespace reco
@@ -31,7 +31,9 @@ namespace reco {
   namespace modules {
 
     template <typename HitCollection>
-    void CaloRecHitCandidateProducer<HitCollection>::produce(edm::Event &evt, const edm::EventSetup &) {
+    void CaloRecHitCandidateProducer<HitCollection>::produce(edm::StreamID,
+                                                             edm::Event &evt,
+                                                             const edm::EventSetup &) const {
       using namespace edm;
       using namespace reco;
       using namespace std;

--- a/CommonTools/RecoAlgos/plugins/ShallowCloneProducer.cc
+++ b/CommonTools/RecoAlgos/plugins/ShallowCloneProducer.cc
@@ -13,13 +13,13 @@
  */
 
 #include "DataFormats/Candidate/interface/ShallowCloneCandidate.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
 template <typename C>
-class ShallowCloneProducer : public edm::EDProducer {
+class ShallowCloneProducer : public edm::global::EDProducer<> {
 public:
   /// constructor from parameter set
   explicit ShallowCloneProducer(const edm::ParameterSet&);
@@ -28,9 +28,9 @@ public:
 
 private:
   /// process an event
-  void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
   /// labels of the collection to be converted
-  edm::EDGetTokenT<C> srcToken_;
+  const edm::EDGetTokenT<C> srcToken_;
 };
 
 template <typename C>
@@ -43,7 +43,7 @@ template <typename C>
 ShallowCloneProducer<C>::~ShallowCloneProducer() {}
 
 template <typename C>
-void ShallowCloneProducer<C>::produce(edm::Event& evt, const edm::EventSetup&) {
+void ShallowCloneProducer<C>::produce(edm::StreamID, edm::Event& evt, const edm::EventSetup&) const {
   std::unique_ptr<reco::CandidateCollection> coll(new reco::CandidateCollection);
   edm::Handle<C> masterCollection;
   evt.getByToken(srcToken_, masterCollection);


### PR DESCRIPTION
#### PR description:

- added esConsumes
- moved to thread friendly module classes

#### PR validation:

Code compiles. Changes should not cause any change to results.