### PR TITLE
Fix CMS deprecated warnings in RecoTracker/FinalTrackSelectors

### DIFF
--- a/RecoTracker/FinalTrackSelectors/interface/TrackMVAClassifier.h
+++ b/RecoTracker/FinalTrackSelectors/interface/TrackMVAClassifier.h
@@ -7,6 +7,7 @@
 
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
@@ -95,7 +96,7 @@ template <typename MVA, typename EventCache = void>
 class TrackMVAClassifier : public TrackMVAClassifierBase {
 public:
   explicit TrackMVAClassifier(const edm::ParameterSet& cfg)
-      : TrackMVAClassifierBase(cfg), mva(cfg.getParameter<edm::ParameterSet>("mva")) {}
+      : TrackMVAClassifierBase(cfg), mva(cfg.getParameter<edm::ParameterSet>("mva"), consumesCollector()) {}
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;

--- a/RecoTracker/FinalTrackSelectors/plugins/AnalyticalTrackSelector.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/AnalyticalTrackSelector.cc
@@ -13,7 +13,6 @@
 #include <memory>
 #include <algorithm>
 #include <map>
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"

--- a/RecoTracker/FinalTrackSelectors/plugins/DefaultTrackMVAClassifier.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/DefaultTrackMVAClassifier.cc
@@ -16,10 +16,14 @@ namespace {
 
   template <bool PROMPT>
   struct mva {
-    mva(const edm::ParameterSet &cfg)
+    mva(const edm::ParameterSet &cfg, edm::ConsumesCollector iC)
         : forestLabel_(cfg.getParameter<std::string>("GBRForestLabel")),
           dbFileName_(cfg.getParameter<std::string>("GBRForestFileName")),
-          useForestFromDB_((!forestLabel_.empty()) & dbFileName_.empty()) {}
+          useForestFromDB_((!forestLabel_.empty()) & dbFileName_.empty()) {
+      if (useForestFromDB_) {
+        forestToken_ = iC.esConsumes(edm::ESInputTag("", forestLabel_));
+      }
+    }
 
     void beginStream() {
       if (!dbFileName_.empty()) {
@@ -31,9 +35,7 @@ namespace {
     void initEvent(const edm::EventSetup &es) {
       forest_ = forestFromFile_.get();
       if (useForestFromDB_) {
-        edm::ESHandle<GBRForest> forestHandle;
-        es.get<GBRWrapperRcd>().get(forestLabel_, forestHandle);
-        forest_ = forestHandle.product();
+        forest_ = &es.getData(forestToken_);
       }
     }
 
@@ -114,6 +116,7 @@ namespace {
     const std::string forestLabel_;
     const std::string dbFileName_;
     const bool useForestFromDB_;
+    edm::ESGetToken<GBRForest, GBRWrapperRcd> forestToken_;
   };
 
   using TrackMVAClassifierDetached = TrackMVAClassifier<mva<false>>;

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackCutClassifier.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackCutClassifier.cc
@@ -160,7 +160,7 @@ namespace {
   }
 
   struct Cuts {
-    Cuts(const edm::ParameterSet& cfg) {
+    Cuts(const edm::ParameterSet& cfg, edm::ConsumesCollector) {
       isHLT = cfg.getParameter<bool>("isHLT");
       fillArrayF(minNdof, cfg, "minNdof");
       fillArrayF(maxChi2, cfg, "maxChi2");

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackLwtnnClassifier.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackLwtnnClassifier.cc
@@ -14,7 +14,9 @@
 
 namespace {
   struct lwtnn {
-    lwtnn(const edm::ParameterSet& cfg) : lwtnnLabel_(cfg.getParameter<std::string>("lwtnnLabel")) {}
+    lwtnn(const edm::ParameterSet& cfg, edm::ConsumesCollector iC)
+        : lwtnnLabel_(cfg.getParameter<std::string>("lwtnnLabel")),
+          lwtnnToken_(iC.esConsumes(edm::ESInputTag("", lwtnnLabel_))) {}
 
     static const char* name() { return "TrackLwtnnClassifier"; }
 
@@ -23,11 +25,7 @@ namespace {
     }
 
     void beginStream() {}
-    void initEvent(const edm::EventSetup& es) {
-      edm::ESHandle<lwt::LightweightNeuralNetwork> lwtnnHandle;
-      es.get<TrackingComponentsRecord>().get(lwtnnLabel_, lwtnnHandle);
-      neuralNetwork_ = lwtnnHandle.product();
-    }
+    void initEvent(const edm::EventSetup& es) { neuralNetwork_ = &es.getData(lwtnnToken_); }
 
     std::pair<float, bool> operator()(reco::Track const& trk,
                                       reco::BeamSpot const& beamSpot,
@@ -91,6 +89,7 @@ namespace {
     }
 
     std::string lwtnnLabel_;
+    edm::ESGetToken<lwt::LightweightNeuralNetwork, TrackingComponentsRecord> lwtnnToken_;
     const lwt::LightweightNeuralNetwork* neuralNetwork_;
   };
 

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackTfClassifier.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackTfClassifier.cc
@@ -14,8 +14,9 @@
 namespace {
   class TfDnn {
   public:
-    TfDnn(const edm::ParameterSet& cfg)
+    TfDnn(const edm::ParameterSet& cfg, edm::ConsumesCollector iC)
         : tfDnnLabel_(cfg.getParameter<std::string>("tfDnnLabel")),
+          tfDnnToken_(iC.esConsumes(edm::ESInputTag("", tfDnnLabel_))),
           session_(nullptr)
 
     {}
@@ -30,9 +31,7 @@ namespace {
 
     void initEvent(const edm::EventSetup& es) {
       if (session_ == nullptr) {
-        edm::ESHandle<TfGraphDefWrapper> tfDnnHandle;
-        es.get<TfGraphRecord>().get(tfDnnLabel_, tfDnnHandle);
-        session_ = tfDnnHandle.product()->getSession();
+        session_ = es.getData(tfDnnToken_).getSession();
       }
     }
 
@@ -96,6 +95,7 @@ namespace {
     }
 
     const std::string tfDnnLabel_;
+    const edm::ESGetToken<TfGraphDefWrapper, TfGraphRecord> tfDnnToken_;
     const tensorflow::Session* session_;
   };
 


### PR DESCRIPTION
#### PR description:

- removed unnessary include which caused a warning
- added esConsumes ability to TrackMVAClassifier

#### PR validation:

Code compiles. Nothing should cause a change to behavior.