### PR TITLE
default initialize TrajectorySeed::dir_

### DIFF
--- a/DataFormats/TrajectorySeed/interface/PropagationDirection.h
+++ b/DataFormats/TrajectorySeed/interface/PropagationDirection.h
@@ -1,6 +1,6 @@
 #ifndef dataFormats_PropagationDirection_H
 #define dataFormats_PropagationDirection_H
 
-enum PropagationDirection { oppositeToMomentum, alongMomentum, anyDirection };
+enum PropagationDirection { oppositeToMomentum, alongMomentum, anyDirection, invalidDirection };
 
 #endif

--- a/DataFormats/TrajectorySeed/interface/TrajectorySeed.h
+++ b/DataFormats/TrajectorySeed/interface/TrajectorySeed.h
@@ -59,7 +59,7 @@ public:
 private:
   RecHitContainer hits_;
   PTrajectoryStateOnDet tsos_;
-  PropagationDirection dir_;
+  PropagationDirection dir_ = oppositeToMomentum;  // = 0
 };
 
 inline void swap(TrajectorySeed& rh, TrajectorySeed& lh) noexcept { rh.swap(lh); }

--- a/DataFormats/TrajectorySeed/interface/TrajectorySeed.h
+++ b/DataFormats/TrajectorySeed/interface/TrajectorySeed.h
@@ -59,7 +59,7 @@ public:
 private:
   RecHitContainer hits_;
   PTrajectoryStateOnDet tsos_;
-  PropagationDirection dir_ = oppositeToMomentum;  // = 0
+  PropagationDirection dir_ = invalidDirection;
 };
 
 inline void swap(TrajectorySeed& rh, TrajectorySeed& lh) noexcept { rh.swap(lh); }


### PR DESCRIPTION
this is following the UBSAN issue reported in #35033 

```
138.2 step2
DataFormats/TrajectorySeed/interface/TrajectorySeed.h:44:3: runtime error: 
      load of value 10967, which is not a valid value for type 'PropagationDirection'
```

