### PR TITLE
Speed up Puppi

### DIFF
--- a/CommonTools/PileupAlgos/src/PuppiContainer.cc
+++ b/CommonTools/PileupAlgos/src/PuppiContainer.cc
@@ -101,18 +101,26 @@ double PuppiContainer::var_within_R(int iId,
         if (dr2 < 0.0001)
           continue;
         auto const pt = cand.pt;
-        if (iId == 5)
-          var += (pt * pt / dr2);
-        else if (iId == 4)
-          var += pt;
-        else if (iId == 3)
-          var += (1. / dr2);
-        else if (iId == 2)
-          var += (1. / dr2);
-        else if (iId == 1)
-          var += pt;
-        else if (iId == 0)
-          var += (pt / dr2);
+        switch (iId) {
+          case 5:
+            var += (pt * pt / dr2);
+            break;
+          case 4:
+            var += pt;
+            break;
+          case 3:
+            var += (1. / dr2);
+            break;
+          case 2:
+            var += (1. / dr2);
+            break;
+          case 1:
+            var += pt;
+            break;
+          case 0:
+            var += (pt / dr2);
+            break;
+        }
       }
     }
   }


### PR DESCRIPTION
#### PR description:

Switches tend to be faster than else if when more than a couple of (simple) cases exist (better optimization by the compiler). This change in particular made Puppi 23% faster (tested on a ttbar UL sample in 10_6_X).

#### PR validation:

Code compiles and runs successfully, no changes expected or observed.

This PR will be backported to 10_6_X to speed up ultra-legacy analysis processing. Backports to other releases can be made upon request.