### PR TITLE
Speed up Puppi [10_6_X]

### DIFF
--- a/CommonTools/PileupAlgos/src/PuppiContainer.cc
+++ b/CommonTools/PileupAlgos/src/PuppiContainer.cc
@@ -100,18 +100,26 @@ double PuppiContainer::var_within_R(int iId, const vector<PuppiCandidate> & part
           if (dr2 < 0.0001)
             continue;
           auto const pt = cand.pt;
-          if (iId == 5)
-            var += (pt * pt / dr2);
-          else if (iId == 4)
-            var += pt;
-          else if (iId == 3)
-            var += (1. / dr2);
-          else if (iId == 2)
-            var += (1. / dr2);
-          else if (iId == 1)
-            var += pt;
-          else if (iId == 0)
-            var += (pt / dr2);
+          switch (iId) {
+            case 5:
+              var += (pt * pt / dr2);
+              break;
+            case 4:
+              var += pt;
+              break;
+            case 3:
+              var += (1. / dr2);
+              break;
+            case 2:
+              var += (1. / dr2);
+              break;
+            case 1:
+              var += pt;
+              break;
+            case 0:
+              var += (pt / dr2);
+              break;
+          }
         }
       }
     }


### PR DESCRIPTION
backport of #35799

Reason: to speed up ultra-legacy analysis processing.