### PR TITLE
convert mkfit output warnings to LogInfo

### DIFF
--- a/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
@@ -288,8 +288,8 @@ TrackCandidateCollection MkFitOutputConverter::convertCandidates(const MkFitOutp
             GlobalPoint(param[0], param[1], param[2]), GlobalVector(param[3], param[4], param[5]), state.charge, &mf),
         CurvilinearTrajectoryError(cov));
     if (!fts.curvilinearError().posDef()) {
-      edm::LogWarning("MkFitOutputConverter") << "Curvilinear error not pos-def\n"
-                                              << fts.curvilinearError().matrix() << "\ncandidate ignored";
+      edm::LogInfo("MkFitOutputConverter") << "Curvilinear error not pos-def\n"
+                                           << fts.curvilinearError().matrix() << "\ncandidate ignored";
       continue;
     }
 
@@ -298,7 +298,7 @@ TrackCandidateCollection MkFitOutputConverter::convertCandidates(const MkFitOutp
             ? convertInnermostState(fts, recHits, propagatorAlong, propagatorOpposite)
             : backwardFit(fts, recHits, propagatorAlong, propagatorOpposite, hitCloner, lastHitInvalid, lastHitChanged);
     if (!tsosDet.first.isValid()) {
-      edm::LogWarning("MkFitOutputConverter")
+      edm::LogInfo("MkFitOutputConverter")
           << "Backward fit of candidate " << candIndex << " failed, ignoring the candidate";
       continue;
     }


### PR DESCRIPTION
this is in a follow up to #35798 

the rate of warnings about bad candidates in the MkFitOutputConverter is too large to handle in production logs.
This PR silences them for now.

[136.874 log example](https://cmssdt.cern.ch/SDT/jenkins-artifacts/pull-request-integration/PR-52af3e/19857/runTheMatrix-results/136.874_RunEGamma2018C+RunEGamma2018C+HLTDR2_2018+RECODR2_2018reHLT_skimEGamma_Offline_L1TEgDQM+HARVEST2018_L1TEgDQM/step3_RunEGamma2018C+RunEGamma2018C+HLTDR2_2018+RECODR2_2018reHLT_skimEGamma_Offline_L1TEgDQM+HARVEST2018_L1TEgDQM.log)

