### PR TITLE
HCAL: switch off auxiliary M3 reconstruction fit for Run3

### DIFF
--- a/RecoEgamma/EgammaHLTProducers/python/HLTEgPhaseIITestSequence_cff.py
+++ b/RecoEgamma/EgammaHLTProducers/python/HLTEgPhaseIITestSequence_cff.py
@@ -2654,3 +2654,6 @@ hltTTRBWR = cms.ESProducer("TkTransientTrackingRecHitBuilderESProducer",
     PixelCPE = cms.string('PixelCPEGeneric'),
     StripCPE = cms.string('StripCPEfromTrackAngle')
 )
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(hltHbhereco, algorithm = dict(useM3 = False))

--- a/RecoEgamma/EgammaHLTProducers/python/HLTEgPhaseIITestSequence_cff.py
+++ b/RecoEgamma/EgammaHLTProducers/python/HLTEgPhaseIITestSequence_cff.py
@@ -2654,6 +2654,3 @@ hltTTRBWR = cms.ESProducer("TkTransientTrackingRecHitBuilderESProducer",
     PixelCPE = cms.string('PixelCPEGeneric'),
     StripCPE = cms.string('StripCPEfromTrackAngle')
 )
-
-from Configuration.Eras.Modifier_run3_common_cff import run3_common
-run3_common.toModify(hltHbhereco, algorithm = dict(useM3 = False))

--- a/RecoLocalCalo/HcalRecProducers/python/HBHEPhase1Reconstructor_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HBHEPhase1Reconstructor_cfi.py
@@ -112,5 +112,5 @@ hbheprereco.pulseShapeParametersQIE8.TrianglePeakTS = 10000
 from Configuration.Eras.Modifier_run2_HE_2017_cff import run2_HE_2017
 run2_HE_2017.toModify(hbheprereco, saveEffectivePedestal = True)
 
-from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
-run3_HB.toModify(hbheprereco, algorithm = dict(applyLegacyHBMCorrection = False))
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(hbheprereco, algorithm = dict(applyLegacyHBMCorrection = False, useM3 = False))


### PR DESCRIPTION
#### PR description:

M3 signal fit is an auxiliary one (MAHI is default), but it stays activated in HCAL Offline reconstruction (while swithed off since long time for HLT) and it wasn't explcitly looked at in the context of Run3 preparations and it's _not_ used by any downstream consumers.
HCAL is now discussing to possibly use corresponding HBHERecHit member (auxEnergy) for saving next-to-trigger BX (SOI+1 in HCAL notations) energy from MAHI for LLP studies.  

NB: this PR (once backported) serves as a workaround for recently reported issue  https://github.com/cms-sw/cmssw/issues/35785
while (in parallel) HCAL DPG figures out what went wrong with M3 as reported here:
https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/2294.html

#### PR validation:

runTheMatrix.py -l limited
