### PR TITLE
Workaround / fix in 12_1_X for Issue #35805, add default for “splashSwitch” in ECAL timing monitor. 

### DIFF
--- a/DQM/EcalMonitorTasks/src/TimingTask.cc
+++ b/DQM/EcalMonitorTasks/src/TimingTask.cc
@@ -33,7 +33,7 @@ namespace ecaldqm {
     energyThresholdEEFwd_ = _params.getUntrackedParameter<double>("energyThresholdEEFwd");
     timingVsBXThreshold_ = _params.getUntrackedParameter<double>("timingVsBXThreshold");
     timeErrorThreshold_ = _params.getUntrackedParameter<double>("timeErrorThreshold");
-    splashSwitch_ = _params.getUntrackedParameter<bool>("splashSwitch");
+    splashSwitch_ = _params.getUntrackedParameter<bool>("splashSwitch", false);
   }
 
   bool TimingTask::filterRunType(short const* _runType) {


### PR DESCRIPTION
#### PR description:

Urgent workaround / fix required for Issue #35805

#### PR validation:


Ran workflow in 12_0_3 that is reported to fail in the issue above. This is a trivial workaround. 

```
cmsrel CMSSW_12_0_3
cd CMSSW_12_0_3/src
cmsenv
git cms-merge-topic rappoccio:promptreco_bug_35805
cp /eos/cms/store/logs/prod/recent/PromptReco/PromptReco_Run345920_MinimumBias/Reco/vocms0314.cern.ch-129943-3-log.tar.gz .
tar -xzvf vocms0314.cern.ch-129943-3-log.tar.gz
cd job/WMTaskSpace/cmsRun1/
cmsRun PSet.py
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

None. 