### PR TITLE
`MonitorTrackResiduals`: do not apply PV compatibility cut when running cosmics

### DIFF
--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigP5_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigP5_cff.py
@@ -93,19 +93,22 @@ SiStripMonitorClusterReal = SiStripMonitorCluster.clone(
 import DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi
 SiStripMonitorTrack_cosmicTk = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone(
     TrackProducer = 'cosmictrackfinderP5',
-    Mod_On = False
+    Mod_On = False,
+    VertexCut = False
 )
 
 # Clone for CKF Tracks
 SiStripMonitorTrack_ckf = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone(
     TrackProducer = 'ctfWithMaterialTracksP5',
-    Mod_On = False
+    Mod_On = False,
+    VertexCut = False
 )
 
 # Clone fir Road Search  Tracks
 # SiStripMonitorTrack_rs = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone(
 #     TrackProducer = 'rsWithMaterialTracksP5',
-#     Mod_On = True
+#     Mod_On = True,
+#     VertexCut = False
 # )
 
 # Clone for General Tracks (for Collision)
@@ -126,7 +129,8 @@ SiStripMonitorTrack_hi = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStrip
 # MonitorTrackResiduals_cosmicTk = DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi.MonitorTrackResiduals.clone(
 #     Tracks = 'cosmictrackfinderP5',
 #     trajectoryInput = 'cosmictrackfinderP5',
-#     Mod_On = False
+#     Mod_On = False,
+#     VertexCut = False
 # )
 
 # Clone for CKF Tracks
@@ -135,6 +139,7 @@ SiStripMonitorTrack_hi = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStrip
 #     Tracks = 'ctfWithMaterialTracksP5',
 #     trajectoryInput = 'ctfWithMaterialTracksP5',
 #     Mod_On = False
+#     VertexCut = False
 # )
 
 # Clone for Road Search  Tracks
@@ -142,7 +147,8 @@ SiStripMonitorTrack_hi = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStrip
 # MonitorTrackResiduals_rs = DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi.MonitorTrackResiduals.clone(
 #     Tracks = 'rsWithMaterialTracksP5',
 #     trajectoryInput = 'rsWithMaterialTracksP5',
-#     Mod_On = False
+#     Mod_On = False,
+#     VertexCut = False
 # )
 
 # Clone for General Track (for Collision data)

--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_Cosmic_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_Cosmic_cff.py
@@ -87,19 +87,22 @@ from DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi import *
 MonitorTrackResiduals_cosmicTk = MonitorTrackResiduals.clone(
     trajectoryInput = 'cosmictrackfinderP5',
     Tracks = 'cosmictrackfinderP5',
-    Mod_On = False
+    Mod_On = False,
+    VertexCut = False
 )
 # Clone for CKF Tracks
 MonitorTrackResiduals_ckf = MonitorTrackResiduals.clone(
     trajectoryInput = 'ctfWithMaterialTracksP5',
     Tracks = 'ctfWithMaterialTracksP5',
-    Mod_On = False
+    Mod_On = False,
+    VertexCut = False
 )
 # Clone for Road Search  Tracks
 # MonitorTrackResiduals_rs = MonitorTrackResiduals.clone(
 #     trajectoryInput = 'rsWithMaterialTracksP5',
 #     Tracks = 'rsWithMaterialTracksP5',
-#     Mod_On = False
+#     Mod_On = False,
+#     VertexCut = False
 # )
 
 # DQM Services

--- a/DQM/TrackerMonitorTrack/interface/MonitorTrackResiduals.h
+++ b/DQM/TrackerMonitorTrack/interface/MonitorTrackResiduals.h
@@ -85,6 +85,7 @@ private:
 
   unsigned long long m_cacheID_;
   bool ModOn;
+  bool applyVertexCut_;
 
   GenericTriggerEventFlag *genTriggerEventFlag_;
   TrackerValidationVariables avalidator_;

--- a/DQM/TrackerMonitorTrack/python/MonitorTrackResiduals_cfi.py
+++ b/DQM/TrackerMonitorTrack/python/MonitorTrackResiduals_cfi.py
@@ -6,6 +6,7 @@ MonitorTrackResiduals = DQMEDAnalyzer("MonitorTrackResiduals",
     OutputMEsInRootFile = cms.bool(False),
     # should histogramms on module level be booked and filled?
     Mod_On = cms.bool(True),
+    VertexCut = cms.untracked.bool(True),
     OutputFileName = cms.string('test_monitortracks.root'),
     genericTriggerEventPSet = cms.PSet(),
     # bining and range for absolute and normalized residual histogramms

--- a/DQM/TrackerMonitorTrack/python/SiPixelMonitorTrackResiduals_cfi.py
+++ b/DQM/TrackerMonitorTrack/python/SiPixelMonitorTrackResiduals_cfi.py
@@ -6,6 +6,7 @@ SiPixelMonitorTrackResiduals = DQMEDAnalyzer("SiPixelMonitorTrackResiduals",
     OutputMEsInRootFile = cms.bool(False),
     # should histogramms on module level be booked and filled?
     Mod_On = cms.bool(False),
+    VertexCut = cms.untracked.bool(True),
     OutputFileName = cms.string('test_monitortracks.root'),
     genericTriggerEventPSet = cms.PSet(),                                              
     # bining and range for absolute and normalized residual histogramms


### PR DESCRIPTION
#### PR description:

I was casually looking at the Strip residuals in a CRAFT 2021 run but they don't make much sense e.g. the number of hits in TIB1 (https://tinyurl.com/yzwdcdc6) is less than BPIX1 (https://tinyurl.com/ygftohy4).
Also the Strip EndCap residuals plots are empty (https://tinyurl.com/ygxqol8b).
I strongly suspect this is due to the Primary Vertex compatibility cut at: 

https://github.com/cms-sw/cmssw/blob/6d2f66057131baacc2fcbdd203588c41c885b42c/DQM/TrackerMonitorTrack/src/MonitorTrackResiduals.cc#L251

that makes no sense in cosmic data-taking and is severely limiting the phase-space from which the cosmic tracks are considered (https://tinyurl.com/yjzgap6c)
The correct behavior is implemented instead in the Pixel residuals code:

https://github.com/cms-sw/cmssw/blob/c6d002524ebec48c82fa8f23dc99ad4fd4f0ac01/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1TrackResiduals.cc#L80-L82

in which the PV compatibility cut is put in OR with a switch that is set to false in cosmics (and indeed the pixel residuals in cosmic runs are filled).
This PR implements the same mechanism also for Strip residuals.
#### No regression is expected for collision runs (pp or HI).

#### PR validation:

I've run workflow 138.2 (from 2021 cosmics commissioning, Run 343498) with 1000 events:
```console
runTheMatrix.py -l 138.2 -j 8 --command='-n 1000'
```
in the vanilla release and with the modifications of this branch and obtained:

| CMSSW_12_1_X_2021-10-24-0000 as-is | CMSSW_12_1_X_2021-10-24-0000 + this PR |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/5082376/138601279-1cca69a5-8772-43f0-9352-a5f31895f2c1.png) | ![image](https://user-images.githubusercontent.com/5082376/138600813-35bd5c33-c4b6-436d-bf95-e4ab1e5b5bcc.png) |
| ![image](https://user-images.githubusercontent.com/5082376/138601298-69d9368a-740d-48f5-b144-6a7951e8e34b.png) | ![image](https://user-images.githubusercontent.com/5082376/138600842-6264eef1-f5bd-4e23-b4c0-dd549509063c.png) |

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, but should probably be backported.