### PR TITLE
`MonitorTrackResiduals`: do not apply PV compatibility cut when running cosmics [12.0.X]

### DIFF
--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigP5_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigP5_cff.py
@@ -94,6 +94,7 @@ SiStripMonitorTrack_hi.Mod_On           = True
 #MonitorTrackResiduals_cosmicTk.Tracks              = 'cosmictrackfinderP5'
 #MonitorTrackResiduals_cosmicTk.trajectoryInput     = 'cosmictrackfinderP5'
 #MonitorTrackResiduals_cosmicTk.Mod_On              = False
+#MonitorTrackResiduals_cosmicTk.VertexCut           = False
 
 # Clone for CKF Tracks
 #import DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi
@@ -101,6 +102,7 @@ SiStripMonitorTrack_hi.Mod_On           = True
 #MonitorTrackResiduals_ckf.Tracks                   = 'ctfWithMaterialTracksP5'
 #MonitorTrackResiduals_ckf.trajectoryInput          = 'ctfWithMaterialTracksP5'
 #MonitorTrackResiduals_ckf.Mod_On                   = False
+#MonitorTrackResiduals_ckf.VertexCut                = False
 
 # Clone for Road Search  Tracks
 #import DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi
@@ -108,6 +110,7 @@ SiStripMonitorTrack_hi.Mod_On           = True
 #MonitorTrackResiduals_rs.Tracks                    = 'rsWithMaterialTracksP5'
 #MonitorTrackResiduals_rs.trajectoryInput           = 'rsWithMaterialTracksP5'
 #MonitorTrackResiduals_rs.Mod_On                    = False
+#MonitorTrackResiduals_rs.VertexCut                 = False
 
 # Clone for General Track (for Collision data)
 import DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi

--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_Cosmic_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_Cosmic_cff.py
@@ -84,17 +84,20 @@ MonitorTrackResiduals_cosmicTk = DQM.TrackerMonitorTrack.MonitorTrackResiduals_c
 MonitorTrackResiduals_cosmicTk.trajectoryInput     = 'cosmictrackfinderP5'
 MonitorTrackResiduals_cosmicTk.Tracks              = 'cosmictrackfinderP5'
 MonitorTrackResiduals_cosmicTk.Mod_On              = False
+MonitorTrackResiduals_cosmicTk.VertexCut           = False
 # Clone for CKF Tracks
 MonitorTrackResiduals_ckf = DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi.MonitorTrackResiduals.clone()
 MonitorTrackResiduals_ckf.trajectoryInput          = 'ctfWithMaterialTracksP5'
 MonitorTrackResiduals_ckf.Tracks                   = 'ctfWithMaterialTracksP5'
 MonitorTrackResiduals_ckf.Mod_On                   = False
+MonitorTrackResiduals_ckf.VertexCut                = False
 # Clone for Road Search  Tracks
 #import DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi
 #MonitorTrackResiduals_rs = DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi.MonitorTrackResiduals.clone()
 #MonitorTrackResiduals_rs.trajectoryInput           = 'rsWithMaterialTracksP5'
 #MonitorTrackResiduals_rs.Tracks                    = 'rsWithMaterialTracksP5'
 #MonitorTrackResiduals_rs.Mod_On                    = False
+#MonitorTrackResiduals_rs.VertexCut                 = False
 
 # DQM Services
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer

--- a/DQM/TrackerMonitorTrack/interface/MonitorTrackResiduals.h
+++ b/DQM/TrackerMonitorTrack/interface/MonitorTrackResiduals.h
@@ -85,6 +85,7 @@ private:
 
   unsigned long long m_cacheID_;
   bool ModOn;
+  bool applyVertexCut_;
 
   GenericTriggerEventFlag *genTriggerEventFlag_;
   TrackerValidationVariables avalidator_;

--- a/DQM/TrackerMonitorTrack/python/MonitorTrackResiduals_cfi.py
+++ b/DQM/TrackerMonitorTrack/python/MonitorTrackResiduals_cfi.py
@@ -6,6 +6,7 @@ MonitorTrackResiduals = DQMEDAnalyzer("MonitorTrackResiduals",
     OutputMEsInRootFile = cms.bool(False),
     # should histogramms on module level be booked and filled?
     Mod_On = cms.bool(True),
+    VertexCut = cms.untracked.bool(True),
     OutputFileName = cms.string('test_monitortracks.root'),
     genericTriggerEventPSet = cms.PSet(),
     # bining and range for absolute and normalized residual histogramms

--- a/DQM/TrackerMonitorTrack/python/SiPixelMonitorTrackResiduals_cfi.py
+++ b/DQM/TrackerMonitorTrack/python/SiPixelMonitorTrackResiduals_cfi.py
@@ -6,6 +6,7 @@ SiPixelMonitorTrackResiduals = DQMEDAnalyzer("SiPixelMonitorTrackResiduals",
     OutputMEsInRootFile = cms.bool(False),
     # should histogramms on module level be booked and filled?
     Mod_On = cms.bool(False),
+    VertexCut = cms.untracked.bool(True),
     OutputFileName = cms.string('test_monitortracks.root'),
     genericTriggerEventPSet = cms.PSet(),                                              
     # bining and range for absolute and normalized residual histogramms


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/35811

#### PR description:

I was casually looking at the Strip residuals in a CRAFT 2021 run but they don't make much sense e.g. the number of hits in TIB1 (https://tinyurl.com/yzwdcdc6) is less than BPIX1 (https://tinyurl.com/ygftohy4).
Also the Strip EndCap residuals plots are empty (https://tinyurl.com/ygxqol8b).
I strongly suspect this is due to the Primary Vertex compatibility cut at: 

https://github.com/cms-sw/cmssw/blob/6d2f66057131baacc2fcbdd203588c41c885b42c/DQM/TrackerMonitorTrack/src/MonitorTrackResiduals.cc#L251

that makes no sense in cosmic data-taking and is severely limiting the phase-space from which the cosmic tracks are considered (https://tinyurl.com/yjzgap6c)
The correct behavior is implemented instead in the Pixel residuals code:

https://github.com/cms-sw/cmssw/blob/c6d002524ebec48c82fa8f23dc99ad4fd4f0ac01/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1TrackResiduals.cc#L80-L82

in which the PV compatibility cut is put in OR with a switch that is set to false in cosmics (and indeed the pixel residuals in cosmic runs are filled).
This PR implements the same mechanism also for Strip residuals.
#### No regression is expected for collision runs (pp or HI).

#### PR validation:

I've run workflow 138.2 (from 2021 cosmics commissioning, Run 343498) with 1000 events:
```console
runTheMatrix.py -l 138.2 -j 8 --command='-n 1000'
```
#### if this PR is a backport please specify the original PR and why you need to backport that PR:

backport of https://github.com/cms-sw/cmssw/pull/35811