### PR TITLE
Fix to DQM issue 35813: crash in UnitTest of DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py

### DIFF
--- a/DQM/SiStripMonitorTrack/python/SiStripMonitorTrack_cfi.py
+++ b/DQM/SiStripMonitorTrack/python/SiStripMonitorTrack_cfi.py
@@ -19,6 +19,7 @@ SiStripMonitorTrack = DQMEDAnalyzer(
     ModulesToBeExcluded = cms.vuint32(),
 
     Mod_On        = cms.bool(False),
+    VertexCut = cms.untracked.bool(True),
     OffHisto_On   = cms.bool(True),
     Trend_On      = cms.bool(False),
     HistoFlag_On  = cms.bool(False),


### PR DESCRIPTION
Declaring VertexCut type in  DQM/SiStripMonitorTrack/python/SiStripMonitorTrack_cfi.py  which is imported from DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py

Following https://github.com/cms-sw/cmssw/pull/35811

Fixes https://github.com/cms-sw/cmssw/issues/35813