### PR TITLE
`SiStripSourceConfigP5_cff` remove parameters added by mistake in #35811

### DIFF
--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigP5_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigP5_cff.py
@@ -94,21 +94,18 @@ import DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi
 SiStripMonitorTrack_cosmicTk = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone(
     TrackProducer = 'cosmictrackfinderP5',
     Mod_On = False,
-    VertexCut = False
 )
 
 # Clone for CKF Tracks
 SiStripMonitorTrack_ckf = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone(
     TrackProducer = 'ctfWithMaterialTracksP5',
     Mod_On = False,
-    VertexCut = False
 )
 
 # Clone fir Road Search  Tracks
 # SiStripMonitorTrack_rs = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone(
 #     TrackProducer = 'rsWithMaterialTracksP5',
 #     Mod_On = True,
-#     VertexCut = False
 # )
 
 # Clone for General Tracks (for Collision)


### PR DESCRIPTION
resolves https://github.com/cms-sw/cmssw/issues/35813

#### PR description:

Title says it all.

#### PR validation:

Run DQM integration tests.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
