### PR TITLE
Fix for crash in gpuClusterChargeCut.h after "warning too many clusters ..."

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu
@@ -607,7 +607,7 @@ namespace pixelgpudetails {
           digis_d.moduleInd(), clusters_d.moduleStart(), digis_d.clus(), wordCounter);
       cudaCheck(cudaGetLastError());
 
-      threadsPerBlock = 256;
+      threadsPerBlock = 256 + 128;
       blocks = maxNumModules;
 #ifdef GPU_DEBUG
       std::cout << "CUDA findClus kernel launch with " << blocks << " blocks of " << threadsPerBlock << " threads\n";

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/gpuClusterChargeCut.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/gpuClusterChargeCut.h
@@ -118,10 +118,10 @@ namespace gpuClustering {
           continue;  // not valid
         if (id[i] != thisModuleId)
           break;  // end of module
-	if (clusterId[i] == invalidModuleId){
+        if (clusterId[i] == invalidModuleId) {
           id[i] = invalidModuleId;
-	  continue;
-	}
+          continue;
+        }
         clusterId[i] = newclusId[clusterId[i]] - 1;
         if (clusterId[i] == invalidModuleId)
           id[i] = invalidModuleId;

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/gpuClusterChargeCut.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/gpuClusterChargeCut.h
@@ -118,6 +118,10 @@ namespace gpuClustering {
           continue;  // not valid
         if (id[i] != thisModuleId)
           break;  // end of module
+	if (clusterId[i] == invalidModuleId){
+          id[i] = invalidModuleId;
+	  continue;
+	}
         clusterId[i] = newclusId[clusterId[i]] - 1;
         if (clusterId[i] == invalidModuleId)
           id[i] = invalidModuleId;

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/gpuClustering.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/gpuClustering.h
@@ -135,6 +135,11 @@ namespace gpuClustering {
 #ifdef __CUDA_ARCH__
       // assume that we can cover the whole module with up to 16 blockDim.x-wide iterations
       constexpr int maxiter = 16;
+      if (threadIdx.x == 0 && (hist.size() / blockDim.x) >= maxiter)
+        printf("THIS IS NOT SUPPOSED TO HAPPEN too many hits in module %d: %d for block size %d\n",
+               thisModuleId,
+               hist.size(),
+               blockDim.x);
 #else
       auto maxiter = hist.size();
 #endif


### PR DESCRIPTION
#### PR description:

This issue occurs running on some `TTbar` data generated with `Run3` end-of-2024 conditions.
The full dataset can be found at https://cmsweb.cern.ch/das/request?instance=prod/phys03&input=file+dataset%3D%2FTTbar%2Ftsusa-TTbar_14TeV_GSDR_2024_121X_mcRun3_2024_realistic_v8_10k-58ae893e2544746328b272cd68e5d2f1%2FUSER, there is a trimmed file in `/afs/cern.ch/work/a/aczirkos/public/gpu_charge_crash_10_25/` containing the crashing event in `step2_2.root`, running on this should be enough to reproduce the error.

In case there are too many clusters in a module, the local reconstruction fails in `gpuClusterChargeCut.h` with the following error:

```
Warning too many clusters in module 824 in block 369: 2932 > 1024
terminate called after throwing an instance of 'std::runtime_error'
  what():  
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/16fe195e1e17677c5420a19d749bdb25/opt/cmssw/slc7_amd64_gcc900/cms/cmssw/CMSSW_12_1_X_2021-10-24-2300/src/HeterogeneousCore/CUDAUtilities/src/CachingHostAllocator.h, line 543:
cudaCheck(error = cudaEventRecord(search_key.ready_event, search_key.associated_stream));
cudaErrorIllegalAddress: an illegal memory access was encountered
```

There is a full log at `/afs/cern.ch/work/a/aczirkos/public/gpu_charge_crash_10_25/log`.

This is due to an indexing bug, where we set [`clusterId[i] = invalidModuleId` first](https://cmssdt.cern.ch/dxr/CMSSW/source/RecoLocalTracker/SiPixelClusterizer/plugins/gpuClusterChargeCut.h#61), and then we use this to index the [`newClusId` array](https://cmssdt.cern.ch/dxr/CMSSW/source/RecoLocalTracker/SiPixelClusterizer/plugins/gpuClusterChargeCut.h#121) which [has size `maxNumClustersPerModules`](https://cmssdt.cern.ch/dxr/CMSSW/source/RecoLocalTracker/SiPixelClusterizer/plugins/gpuClusterChargeCut.h#29). (`invalidModuleId` >  `maxNumClustersPerModules`)

This PR fixes this error.

#### PR validation:

This is a short recipe for reproducing the error, and checking that this PR fixes it.
On a GPU equipped machine:

```console
cmsrel CMSSW_12_1_X_2021-10-24-2300
cd CMSSW_12_1_X_2021-10-24-2300/src
cmsenv
git cms-addpkg RecoLocalTracker/SiPixelClusterizer
mkdir ../runtests
cd ../runtests
rsync -avzzr aczirkos@lxplus.cern.ch:/afs/cern.ch/work/a/aczirkos/public/gpu_charge_crash_10_25/* .
# run without fix
cmsRun step3.py
# apply fix and run with it
cd -
git apply ../runtests/fix.patch
scram b -j
cd -
cmsRun step3.py
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

kindly pinging @tsusa @connorpa 