### PR TITLE
Data Format for hadronic showers in muon system

### DIFF
--- a/DataFormats/MuonReco/interface/MuonRecHitCluster.h
+++ b/DataFormats/MuonReco/interface/MuonRecHitCluster.h
@@ -2,7 +2,6 @@
 #define DataFormats_MuonReco_MuonRecHitCluster_h
 
 #include <vector>
-#include "DataFormats/Common/interface/SortedCollection.h"
 #include "DataFormats/Math/interface/Vector3D.h"
 
 namespace reco {

--- a/DataFormats/MuonReco/interface/MuonRecHitCluster.h
+++ b/DataFormats/MuonReco/interface/MuonRecHitCluster.h
@@ -1,0 +1,66 @@
+#ifndef DataFormats_MuonReco_MuonRecHitCluster_h
+#define DataFormats_MuonReco_MuonRecHitCluster_h
+
+#include <vector>
+#include "DataFormats/Common/interface/SortedCollection.h"
+#include "DataFormats/Math/interface/Vector3D.h"
+
+namespace reco {
+
+  class MuonRecHitCluster {
+  public:
+    //default constructor
+    MuonRecHitCluster() = default;
+
+    MuonRecHitCluster(const math::RhoEtaPhiVectorF position,
+                      const int size,
+                      const int nStation,
+                      const float avgStation,
+                      const float time,
+                      const float timeSpread,
+                      const int nME11,
+                      const int nME12,
+                      const int nME41,
+                      const int nME42,
+                      const int nMB1,
+                      const int nMB2);
+
+    //
+    ~MuonRecHitCluster() = default;
+
+    float eta() const { return position_.Eta(); }
+    float phi() const { return position_.Phi(); }
+    float x() const { return position_.X(); }
+    float y() const { return position_.Y(); }
+    float z() const { return position_.Z(); }
+    float r() const { return position_.Rho(); }
+    int size() const { return size_; }
+    int nStation() const { return nStation_; }
+    float avgStation() const { return avgStation_; }
+    int nMB1() const { return nMB1_; }
+    int nMB2() const { return nMB2_; }
+    int nME11() const { return nME11_; }
+    int nME12() const { return nME12_; }
+    int nME41() const { return nME41_; }
+    int nME42() const { return nME42_; }
+    float time() const { return time_; }
+    float timeSpread() const { return timeSpread_; }
+
+  private:
+    math::RhoEtaPhiVectorF position_;
+    int size_;
+    int nStation_;
+    float avgStation_;
+    float time_;
+    float timeSpread_;
+    int nME11_;
+    int nME12_;
+    int nME41_;
+    int nME42_;
+    int nMB1_;
+    int nMB2_;
+  };
+
+  typedef std::vector<MuonRecHitCluster> MuonRecHitClusterCollection;
+}  // namespace reco
+#endif

--- a/DataFormats/MuonReco/src/MuonRecHitCluster.cc
+++ b/DataFormats/MuonReco/src/MuonRecHitCluster.cc
@@ -1,0 +1,26 @@
+#include "DataFormats/MuonReco/interface/MuonRecHitCluster.h"
+
+reco::MuonRecHitCluster::MuonRecHitCluster(const math::RhoEtaPhiVectorF position,
+                                           const int size,
+                                           const int nStation,
+                                           const float avgStation,
+                                           const float time,
+                                           const float timeSpread,
+                                           const int nME11,
+                                           const int nME12,
+                                           const int nME41,
+                                           const int nME42,
+                                           const int nMB1,
+                                           const int nMB2)
+    : position_(position),
+      size_(size),
+      nStation_(nStation),
+      avgStation_(avgStation),
+      time_(time),
+      timeSpread_(timeSpread),
+      nME11_(nME11),
+      nME12_(nME12),
+      nME41_(nME41),
+      nME42_(nME42),
+      nMB1_(nMB1),
+      nMB2_(nMB2) {}

--- a/DataFormats/MuonReco/src/classes.h
+++ b/DataFormats/MuonReco/src/classes.h
@@ -20,6 +20,7 @@
 #include "DataFormats/MuonReco/interface/MuonQuality.h"
 #include "DataFormats/MuonReco/interface/MuonCosmicCompatibility.h"
 #include "DataFormats/MuonReco/interface/MuonShower.h"
+#include "DataFormats/MuonReco/interface/MuonRecHitCluster.h"
 #include "DataFormats/MuonReco/interface/MuonToMuonMap.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/Common/interface/AssociationMap.h"

--- a/DataFormats/MuonReco/src/classes_def.xml
+++ b/DataFormats/MuonReco/src/classes_def.xml
@@ -164,6 +164,12 @@ initial version number of a class which has never been stored before.
   </class>
   <class name="edm::Wrapper<edm::ValueMap<reco::MuonShower> >"/>
 
+  <class name="reco::MuonRecHitCluster" ClassVersion="3">
+    <version ClassVersion="3" checksum="2080298867"/>
+  </class>
+  <class name="std::vector<reco::MuonRecHitCluster>"/>
+  <class name="edm::Wrapper<std::vector<reco::MuonRecHitCluster>>"/>
+
   <class name="std::vector<reco::MuonRef>"/>
   <class name="std::vector<reco::MuonRef>::const_iterator"/>
   <class name="edm::ValueMap<reco::MuonRef>"/>

--- a/HLTrigger/special/plugins/BuildFile.xml
+++ b/HLTrigger/special/plugins/BuildFile.xml
@@ -25,6 +25,7 @@
 <use name="DataFormats/METReco"/>
 <use name="DataFormats/Math"/>
 <use name="DataFormats/MuonDetId"/>
+<use name="DataFormats/MuonReco"/>
 <use name="DataFormats/RecoCandidate"/>
 <use name="DataFormats/TCDS"/>
 <use name="DataFormats/TrackReco"/>

--- a/HLTrigger/special/plugins/HLTMuonRecHitClusterFilter.cc
+++ b/HLTrigger/special/plugins/HLTMuonRecHitClusterFilter.cc
@@ -1,0 +1,106 @@
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+#include "DataFormats/MuonReco/interface/MuonRecHitCluster.h"
+
+class HLTMuonRecHitClusterFilter : public edm::global::EDFilter<> {
+public:
+  explicit HLTMuonRecHitClusterFilter(const edm::ParameterSet&);
+  ~HLTMuonRecHitClusterFilter() override = default;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  bool filter(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
+  const edm::EDGetTokenT<reco::MuonRecHitClusterCollection> cluster_token_;
+  const int min_N_;
+  const int min_Size_;
+  const int min_SizeMinusMB1_;
+  const int max_nMB1_;
+  const int max_nMB2_;
+  const int max_nME11_;
+  const int max_nME12_;
+  const int max_nME41_;
+  const int max_nME42_;
+  const int min_Nstation_;
+  const double min_AvgStation_;
+  const double min_Time_;
+  const double max_Time_;
+  const double min_Eta_;
+  const double max_Eta_;
+  const double max_TimeSpread_;
+};
+//
+// constructors and destructor
+//
+HLTMuonRecHitClusterFilter::HLTMuonRecHitClusterFilter(const edm::ParameterSet& iConfig)
+    : cluster_token_(consumes<reco::MuonRecHitClusterCollection>(iConfig.getParameter<edm::InputTag>("ClusterTag"))),
+      min_N_(iConfig.getParameter<int>("MinN")),
+      min_Size_(iConfig.getParameter<int>("MinSize")),
+      min_SizeMinusMB1_(iConfig.getParameter<int>("MinSizeMinusMB1")),
+      max_nMB1_(iConfig.getParameter<int>("Max_nMB1")),
+      max_nMB2_(iConfig.getParameter<int>("Max_nMB2")),
+      max_nME11_(iConfig.getParameter<int>("Max_nME11")),
+      max_nME12_(iConfig.getParameter<int>("Max_nME12")),
+      max_nME41_(iConfig.getParameter<int>("Max_nME41")),
+      max_nME42_(iConfig.getParameter<int>("Max_nME42")),
+      min_Nstation_(iConfig.getParameter<int>("MinNstation")),
+      min_AvgStation_(iConfig.getParameter<double>("MinAvgStation")),
+      min_Time_(iConfig.getParameter<double>("MinTime")),
+      max_Time_(iConfig.getParameter<double>("MaxTime")),
+      min_Eta_(iConfig.getParameter<double>("MinEta")),
+      max_Eta_(iConfig.getParameter<double>("MaxEta")),
+      max_TimeSpread_(iConfig.getParameter<double>("MaxTimeSpread")) {}
+
+void HLTMuonRecHitClusterFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("ClusterTag", edm::InputTag("hltCSCrechitClusters"));
+  desc.add<int>("MinN", 1);
+  desc.add<int>("MinSize", 50);
+  desc.add<int>("MinSizeMinusMB1", 0);
+  desc.add<int>("Max_nMB1", 0);
+  desc.add<int>("Max_nMB2", 0);
+  desc.add<int>("Max_nME11", 0);
+  desc.add<int>("Max_nME12", 0);
+  desc.add<int>("Max_nME41", 0);
+  desc.add<int>("Max_nME42", 0);
+  desc.add<int>("MinNstation", 0);
+  desc.add<double>("MinAvgStation", 0.0);
+  desc.add<double>("MinTime", -999);
+  desc.add<double>("MaxTime", 999);
+  desc.add<double>("MinEta", -1.0);
+  desc.add<double>("MaxEta", -1.0);
+  desc.add<double>("MaxTimeSpread", 999);
+  descriptions.addWithDefaultLabel(desc);
+}
+
+//
+// member functions
+//
+
+// ------------ method called on each new Event  ------------
+bool HLTMuonRecHitClusterFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  int nClusterPassed = 0;
+
+  auto const& rechitClusters = iEvent.get(cluster_token_);
+
+  for (auto const& cluster : rechitClusters) {
+    if ((cluster.size() >= min_Size_) && ((cluster.size() - cluster.nMB1()) >= min_SizeMinusMB1_) &&
+        (cluster.nMB1() <= max_nMB1_) && (cluster.nMB2() <= max_nMB2_) && (cluster.nME11() <= max_nME11_) &&
+        (cluster.nME12() <= max_nME12_) && (cluster.nME41() <= max_nME41_) && (cluster.nME42() <= max_nME42_) &&
+        (cluster.nStation() >= min_Nstation_) && (cluster.avgStation() >= min_AvgStation_) &&
+        ((min_Eta_ < 0.0) || (std::abs(cluster.eta()) >= min_Eta_)) &&
+        ((max_Eta_ < 0.0) || (std::abs(cluster.eta()) <= max_Eta_)) && (cluster.time() > min_Time_) &&
+        (cluster.time() <= max_Time_) && (cluster.timeSpread() <= max_TimeSpread_)) {
+      nClusterPassed++;
+    }
+  }
+
+  return (nClusterPassed >= min_N_);
+}
+
+DEFINE_FWK_MODULE(HLTMuonRecHitClusterFilter);

--- a/RecoMuon/MuonRechitClusterProducer/plugins/BuildFile.xml
+++ b/RecoMuon/MuonRechitClusterProducer/plugins/BuildFile.xml
@@ -1,0 +1,9 @@
+<use   name="FWCore/Framework"/>
+<use   name="FWCore/PluginManager"/>
+<use   name="FWCore/ParameterSet"/>
+<use   name="Geometry/CSCGeometry"/>
+<use   name="Geometry/DTGeometry"/>
+<use   name="Geometry/Records"/>
+<use   name="DataFormats/MuonReco"/>
+<use   name="fastjet"/>
+<flags EDM_PLUGIN="1"/>

--- a/RecoMuon/MuonRechitClusterProducer/plugins/RechitClusterProducer.cc
+++ b/RecoMuon/MuonRechitClusterProducer/plugins/RechitClusterProducer.cc
@@ -1,0 +1,268 @@
+#include <memory>
+#include <cmath>
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include "DataFormats/Common/interface/Ptr.h"
+#include "DataFormats/Math/interface/deltaPhi.h"
+#include "DataFormats/MuonReco/interface/MuonRecHitCluster.h"
+#include "Geometry/CSCGeometry/interface/CSCGeometry.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "DataFormats/MuonDetId/interface/CSCDetId.h"
+
+#include "fastjet/JetDefinition.hh"
+#include "fastjet/ClusterSequence.hh"
+#include "fastjet/PseudoJet.hh"
+
+#include "Geometry/CSCGeometry/interface/CSCGeometry.h"
+#include "Geometry/DTGeometry/interface/DTGeometry.h"
+#include "DataFormats/MuonDetId/interface/CSCDetId.h"
+#include "DataFormats/Math/interface/Vector3D.h"
+#include "DataFormats/Math/interface/PtEtaPhiMass.h"
+#include "DataFormats/DTRecHit/interface/DTRecHitCollection.h"
+#include "DataFormats/CSCRecHit/interface/CSCRecHit2DCollection.h"
+#include "DataFormats/MuonReco/interface/MuonRecHitCluster.h"
+
+typedef std::vector<reco::MuonRecHitCluster> RecHitClusterCollection;
+
+template <typename Trait>
+class RechitClusterProducerT : public edm::global::EDProducer<> {
+  typedef typename Trait::RecHitRef RechitRef;
+  typedef typename Trait::RecHitRefVector RecHitRefVector;
+
+public:
+  explicit RechitClusterProducerT(const edm::ParameterSet&);
+  ~RechitClusterProducerT() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  const edm::ESGetToken<typename Trait::GeometryType, MuonGeometryRecord> GeometryToken_;
+  edm::EDGetTokenT<typename Trait::InputType> InputToken_;
+  typedef std::vector<reco::MuonRecHitCluster> RecHitClusterCollection;
+
+  const double rParam_;      // distance paramter
+  const int nRechitMin_;     // min number of rechits
+  const int nStationThres_;  // min number of rechits to count towards nStation
+};
+
+template <typename Trait>
+RechitClusterProducerT<Trait>::RechitClusterProducerT(const edm::ParameterSet& iConfig)
+    : GeometryToken_(esConsumes<typename Trait::GeometryType, MuonGeometryRecord>()),
+      InputToken_(consumes<typename Trait::InputType>(iConfig.getParameter<edm::InputTag>("recHitLabel"))),
+      rParam_(iConfig.getParameter<double>("rParam")),
+      nRechitMin_(iConfig.getParameter<int>("nRechitMin")),
+      nStationThres_(iConfig.getParameter<int>("nStationThres")) {
+  produces<RecHitClusterCollection>();
+}
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+template <typename Trait>
+void RechitClusterProducerT<Trait>::produce(edm::StreamID, edm::Event& ev, const edm::EventSetup& iSetup) const {
+  auto const& geo = iSetup.getData(GeometryToken_);
+  auto const& rechits = ev.get(InputToken_);
+
+  std::vector<fastjet::PseudoJet> fjInput;
+  RecHitRefVector inputs_;
+
+  fastjet::JetDefinition jet_def(fastjet::cambridge_algorithm, rParam_);
+
+  inputs_.clear();
+  fjInput.clear();
+
+  Trait RecHitTrait;
+
+  int recIt = 0;
+  for (auto const& rechit : rechits) {
+    LocalPoint RecHitLocalPosition = rechit.localPosition();
+    auto detid = RecHitTrait.detid(rechit);
+    auto thischamber = geo.chamber(detid);
+    if (thischamber) {
+      GlobalPoint globalPosition = thischamber->toGlobal(RecHitLocalPosition);
+      float x = globalPosition.x();
+      float y = globalPosition.y();
+      float z = globalPosition.z();
+      RechitRef ref = RechitRef(&rechits, recIt);
+      inputs_.push_back(ref);
+      fjInput.push_back(fastjet::PseudoJet(x, y, z, globalPosition.mag()));
+      fjInput.back().set_user_index(recIt);
+    }
+    recIt++;
+  }
+  fastjet::ClusterSequence clus_seq(fjInput, jet_def);
+
+  //keep all the clusters
+  double ptmin = 0.0;
+  std::vector<fastjet::PseudoJet> fjJets = fastjet::sorted_by_pt(clus_seq.inclusive_jets(ptmin));
+
+  auto clusters = std::make_unique<RecHitClusterCollection>();
+  if (!fjJets.empty()) {
+    for (unsigned int ijet = 0; ijet < fjJets.size(); ++ijet) {
+      // get the fastjet jet
+      const fastjet::PseudoJet& fjJet = fjJets[ijet];
+
+      // skip if the cluster has too few rechits
+      if (int(fjJet.constituents().size()) < nRechitMin_)
+        continue;
+      // get the constituents from fastjet
+      RecHitRefVector rechits;
+      for (unsigned int i = 0; i < fjJet.constituents().size(); i++) {
+        auto index = fjJet.constituents()[i].user_index();
+        if (index >= 0 && static_cast<unsigned int>(index) < inputs_.size()) {
+          rechits.push_back(inputs_[index]);
+        }
+      }
+
+      //Derive cluster properties
+      int nStation = 0;
+      int totStation = 0;
+      float avgStation = 0.0;
+      std::map<int, int> station_count_map;
+      for (auto& rechit : rechits) {
+        station_count_map[RecHitTrait.station(*rechit)]++;
+      }
+      //station statistics
+      std::map<int, int>::iterator it;
+      for (auto const& [station, count] : station_count_map) {
+        if (count >= nStationThres_) {
+          nStation++;
+          avgStation += (station) * (count);
+          totStation += (count);
+        }
+      }
+      if (totStation != 0) {
+        avgStation = avgStation / totStation;
+      }
+      float invN = 1.f / rechits.size();
+      // cluster position is the average position of the constituent rechits
+      float jetX = fjJet.px() * invN;
+      float jetY = fjJet.py() * invN;
+      float jetZ = fjJet.pz() * invN;
+
+      math::RhoEtaPhiVectorF position(
+          std::sqrt(jetX * jetX + jetY * jetY), etaFromXYZ(jetX, jetY, jetZ), std::atan2(jetY, jetX));
+      Trait::emplace_back(clusters.get(), position, nStation, avgStation, rechits);
+    }
+  }
+  ev.put(std::move(clusters));
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+template <typename Trait>
+void RechitClusterProducerT<Trait>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<int>("nRechitMin", 50);
+  desc.add<double>("rParam", 0.4);
+  desc.add<int>("nStationThres", 10);
+  desc.add<edm::InputTag>("recHitLabel", edm::InputTag(Trait::recHitLabel()));
+  descriptions.add(Trait::producerName(), desc);
+}
+struct DTRecHitTrait {
+  using GeometryType = DTGeometry;
+  using InputType = DTRecHitCollection;
+  using RecHitRef = edm::Ref<DTRecHitCollection>;
+  using RecHitRefVector = edm::RefVector<DTRecHitCollection>;
+  static std::string recHitLabel() { return "dt1DRecHits"; }
+  static std::string producerName() { return "DTrechitClusterProducer"; }
+
+  static int station(const DTRecHit1DPair& dtRechit) { return detid(dtRechit).station(); }
+  static DTChamberId detid(const DTRecHit1DPair& dtRechit) {
+    DetId geoid = dtRechit.geographicalId();
+    DTChamberId dtdetid = DTChamberId(geoid);
+    return dtdetid;
+  }
+  static void emplace_back(RecHitClusterCollection* clusters,
+                           math::RhoEtaPhiVectorF const& position,
+                           int nStation,
+                           float avgStation,
+                           RecHitRefVector const& rechits) {
+    // compute nMB1, nMB2
+    int nMB1 = 0;
+    int nMB2 = 0;
+    for (auto& rechit : rechits) {
+      DetId geoid = rechit->geographicalId();
+      DTChamberId dtdetid = DTChamberId(geoid);
+      if (dtdetid.station() == 1)
+        nMB1++;
+      if (dtdetid.station() == 2)
+        nMB2++;
+    }
+    //set time, timespread, nME11,nME12 to 0
+    reco::MuonRecHitCluster cls(position, rechits.size(), nStation, avgStation, 0.0, 0.0, 0, 0, 0, 0, nMB1, nMB2);
+    clusters->emplace_back(cls);
+  }
+};
+
+struct CSCRecHitTrait {
+  using GeometryType = CSCGeometry;
+  using InputType = CSCRecHit2DCollection;
+  using RecHitRef = edm::Ref<CSCRecHit2DCollection>;
+  using RecHitRefVector = edm::RefVector<CSCRecHit2DCollection>;
+  static std::string recHitLabel() { return "csc2DRecHits"; }
+  static std::string producerName() { return "CSCrechitClusterProducer"; }
+
+  static int station(const CSCRecHit2D& cscRechit) { return CSCDetId::station(detid(cscRechit)); }
+  static CSCDetId detid(const CSCRecHit2D& cscRechit) { return cscRechit.cscDetId(); }
+  static void emplace_back(RecHitClusterCollection* clusters,
+                           math::RhoEtaPhiVectorF const& position,
+                           int nStation,
+                           float avgStation,
+                           RecHitRefVector const& rechits) {
+    int nME11 = 0;
+    int nME12 = 0;
+    int nME41 = 0;
+    int nME42 = 0;
+    float timeSpread = 0.0;
+    float time = 0.0;
+    float time_strip = 0.0;  // for timeSpread calculation
+    for (auto& rechit : rechits) {
+      CSCDetId cscdetid = rechit->cscDetId();
+      int stationRing = (CSCDetId::station(cscdetid) * 10 + CSCDetId::ring(cscdetid));
+      if (CSCDetId::ring(cscdetid) == 4)
+        stationRing = (CSCDetId::station(cscdetid) * 10 + 1);  // ME1/a has ring==4
+      if (stationRing == 11)
+        nME11++;
+      if (stationRing == 12)
+        nME12++;
+      if (stationRing == 41)
+        nME41++;
+      if (stationRing == 42)
+        nME42++;
+      time += (rechit->tpeak() + rechit->wireTime());
+      time_strip += rechit->tpeak();
+    }
+    float invN = 1.f / rechits.size();
+    time = (time / 2.f) * invN;
+    time_strip = time_strip * invN;
+
+    //derive cluster statistics
+    for (auto& rechit : rechits) {
+      timeSpread += (rechit->tpeak() - time_strip) * (rechit->tpeak() - time_strip);
+    }
+    timeSpread = std::sqrt(timeSpread * invN);
+
+    //set nMB1,nMB2 to 0
+    reco::MuonRecHitCluster cls(
+        position, rechits.size(), nStation, avgStation, time, timeSpread, nME11, nME12, nME41, nME42, 0, 0);
+    clusters->emplace_back(cls);
+  }
+};
+
+using DTrechitClusterProducer = RechitClusterProducerT<DTRecHitTrait>;
+using CSCrechitClusterProducer = RechitClusterProducerT<CSCRecHitTrait>;
+DEFINE_FWK_MODULE(DTrechitClusterProducer);
+DEFINE_FWK_MODULE(CSCrechitClusterProducer);

--- a/RecoMuon/MuonRechitClusterProducer/python/rechitCluster_cff.py
+++ b/RecoMuon/MuonRechitClusterProducer/python/rechitCluster_cff.py
@@ -1,0 +1,18 @@
+import FWCore.ParameterSet.Config as cms
+
+import RecoMuon.MuonRechitClusterProducer.CSCrechitClusterProducer_cfi as CSCcluster 
+import RecoMuon.MuonRechitClusterProducer.DTrechitClusterProducer_cfi as DTcluster
+
+ca4CSCrechitClusters= CSCcluster.CSCrechitClusterProducer.clone(
+    recHitLabel = "csc2DRecHits",
+    nRechitMin  = 50,
+    rParam      = 0.4,
+    nStationThres = 10, 
+) 
+ca4DTrechitClusters = DTcluster.DTrechitClusterProducer.clone(
+    recHitLabel = "dt1DRecHits",
+    nRechitMin  = 50,
+    rParam      = 0.4,
+    nStationThres = 10, 
+) 
+

--- a/RecoMuon/MuonRechitClusterProducer/python/rechitCluster_cff.py
+++ b/RecoMuon/MuonRechitClusterProducer/python/rechitCluster_cff.py
@@ -1,15 +1,15 @@
 import FWCore.ParameterSet.Config as cms
 
-import RecoMuon.MuonRechitClusterProducer.CSCrechitClusterProducer_cfi as CSCcluster 
-import RecoMuon.MuonRechitClusterProducer.DTrechitClusterProducer_cfi as DTcluster
+import RecoMuon.MuonRechitClusterProducer.cscRechitClusterProducer_cfi as CSCcluster 
+import RecoMuon.MuonRechitClusterProducer.dtRechitClusterProducer_cfi as DTcluster
 
-ca4CSCrechitClusters= CSCcluster.CSCrechitClusterProducer.clone(
+ca4CSCrechitClusters= CSCcluster.cscRechitClusterProducer.clone(
     recHitLabel = "csc2DRecHits",
     nRechitMin  = 50,
     rParam      = 0.4,
     nStationThres = 10, 
 ) 
-ca4DTrechitClusters = DTcluster.DTrechitClusterProducer.clone(
+ca4DTrechitClusters = DTcluster.dtRechitClusterProducer.clone(
     recHitLabel = "dt1DRecHits",
     nRechitMin  = 50,
     rParam      = 0.4,


### PR DESCRIPTION
#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

This PR creates new data formats to contain hadronic showers in the Muon system. Specifically, CSC and DT rechits are clustered with Cambridge-Aachen(CA) algorithm by calling `fast-jet` directly. The new cluster objects keep the persistent reference pointers to the constituent rechit collection. 

This is an essential ingredient for an HLT path for LLP in Run 3. 
This PR supersedes #35543, and expand to 

Detailed information are presented in these meetings:
[Presentation at Muon POG meeting, Oct 25](https://indico.cern.ch/event/1089528/contributions/4580166/attachments/2333729/3977503/HMT_MuonPOG_Oct25.pdf
)
[Presentation at Reco meeting, Oct 15](https://indico.cern.ch/event/1086298/contributions/4569185/attachments/2328991/3968157/Reco_Oct15.pdf)


<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->
