### PR TITLE
[12_0_X] Add HLT_PixelClusters to DQM BeamSpot clients

### DIFF
--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -338,11 +338,12 @@ process.tracking_FirstStep = cms.Sequence(
     * process.recopixelvertexing)
 
 # triggerName for selecting pv for DIP publication, no wildcard needed here
-# it will pick all triggers which has these strings in theri name
+# it will pick all triggers which have these strings in their name
 process.dqmBeamMonitor.jetTrigger  = [
          "HLT_PAZeroBias_v", "HLT_ZeroBias_v", "HLT_QuadJet",
          "HLT_ZeroBias_",
-         "HLT_HI"]
+         "HLT_HI",
+         "HLT_PixelClusters"]
 
 # for HI only: select events based on the pixel cluster multiplicity
 if (process.runType.getRunType() == process.runType.hi_run):

--- a/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
@@ -160,11 +160,12 @@ if (process.runType.getRunType() == process.runType.pp_run or
     process.dqmBeamMonitor.PVFitter.errorScale = 0.95
 
     #TriggerName for selecting pv for DIP publication, NO wildcard needed here
-    #it will pick all triggers which has these strings in theri name
+    #it will pick all triggers which have these strings in their name
     process.dqmBeamMonitor.jetTrigger = cms.untracked.vstring(
         "HLT_HT300_Beamspot", "HLT_HT300_Beamspot",
         "HLT_PAZeroBias_v", "HLT_ZeroBias_", "HLT_QuadJet",
-        "HLT_HI")
+        "HLT_HI",
+        "HLT_PixelClusters")
 
     process.dqmBeamMonitor.hltResults = "TriggerResults::HLT"
 


### PR DESCRIPTION
#### PR description:
Backport of #35843
Since it was decided in https://its.cern.ch/jira/browse/CMSHLT-2174 to add the new _HLT_PixelClusters_WP1_ZeroBias_
path to the BeamSpot-related streams (`Express`, `ExpressAlignment` and `DQMOnlineBeamSpot`) this PR updates the DQM BeamSpot clients to pick up events from these new paths.

#### PR validation:
Code compiles.
This PR **must** be tested in DQM P5 online machines.

#### Backport
Backport of #35843
