### PR TITLE
Add HLT paths on the Pixel OnlineDQM client for Beam test

### DIFF
--- a/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
@@ -160,7 +160,7 @@ process.load('HLTrigger.HLTfilters.hltHighLevel_cfi')
 if (process.runType.getRunType() == process.runType.hi_run):
     process.hltHighLevel.HLTPaths = ['HLT_ZeroBias_*' , 'HLT_HIZeroBias_*' , 'HLT_ZeroBias1_*' , 'HLT_PAZeroBias_*' , 'HLT_PAZeroBias1_*', 'HLT_PAL1MinimumBiasHF_OR_SinglePixelTrack_*','HLT*SingleMu*' , 'HLT_HICentralityVeto*' , 'HLT_HIMinimumBias*','HLT_HIPhysics*']
 else:
-    process.hltHighLevel.HLTPaths = ['HLT_ZeroBias_*' , 'HLT_ZeroBias1_*' , 'HLT_PAZeroBias_*' , 'HLT_PAZeroBias1_*', 'HLT_PAL1MinimumBiasHF_OR_SinglePixelTrack_*','HLT*SingleMu*']
+    process.hltHighLevel.HLTPaths = ['HLT_*PixelClusters*', 'HLT_*ETT*', 'HLT_ZeroBias_*' , 'HLT_ZeroBias1_*' , 'HLT_PAZeroBias_*' , 'HLT_PAZeroBias1_*', 'HLT_PAL1MinimumBiasHF_OR_SinglePixelTrack_*','HLT*SingleMu*']
 process.hltHighLevel.andOr = True
 process.hltHighLevel.throw =  False
 


### PR DESCRIPTION
#### PR description:

Add two HLT paths on Pixel OnlineDQM client in order to get some pixel stream during Beam test. This PR is not meant to be merged, we use it to be integrated locally at P5

#### PR validation:

It has been tested on RAW data.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

PR to CMSSW release which is actually used at P5. 