### PR TITLE
Fix PPS persistent geometry tag in data GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,23 +24,23 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'                   : '121X_mcRun2_pA_v7',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'                    : '121X_dataRun2_v8',
+    'run2_data'                    : '121X_dataRun2_v10',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_HEfail'             : '121X_dataRun2_HEfail_v8',
+    'run2_data_HEfail'             : '121X_dataRun2_HEfail_v10',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'             : '121X_dataRun2_relval_v8',
+    'run2_data_relval'             : '121X_dataRun2_relval_v10',
     # GlobalTag for Run2 HI data
-    'run2_data_promptlike_hi'      : '121X_dataRun2_PromptLike_HI_v8',
+    'run2_data_promptlike_hi'      : '121X_dataRun2_PromptLike_HI_v9',
     # GlobalTag for Run3 HLT: it points to the online GT
-    'run3_hlt'                     : '121X_dataRun3_HLT_v8',
+    'run3_hlt'                     : '121X_dataRun3_HLT_v9',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'              : '121X_dataRun2_HLT_relval_v8',
+    'run2_hlt_relval'              : '121X_dataRun2_HLT_relval_v9',
     # GlobalTag for Run3 data relvals (express GT)
-    'run3_data_express'            : '121X_dataRun3_Express_v9',
+    'run3_data_express'            : '121X_dataRun3_Express_v10',
     # GlobalTag for Run3 data relvals
-    'run3_data_prompt'             : '121X_dataRun3_Prompt_v8',
+    'run3_data_prompt'             : '121X_dataRun3_Prompt_v9',
     # GlobalTag for Run3 offline data reprocessing
-    'run3_data'                    : '121X_dataRun3_v7',
+    'run3_data'                    : '121X_dataRun3_v8',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'           : '121X_mc2017_design_v7',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector


### PR DESCRIPTION
#### PR description:

This PR is a bug-fix  for the data GTs with PPS persistent geometry tags introduced in PR#35772 . The newly introduced tag was crashing two RelVal workflows as reported in https://github.com/cms-sw/cmssw/issues/35828. 

This PR fixes workflow 136.8562 and PR#35761 is fixing the workflow 149.0, as mentioned in https://github.com/cms-sw/cmssw/issues/35828#issuecomment-951070312 

The GT diffs are as follows:

**dataRun2**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_dataRun2_v10/121X_dataRun2_v8

**dataRun2_HEfail**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_dataRun2_HEfail_v10/121X_dataRun2_HEfail_v8

**dataRun2_relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_dataRun2_relval_v10/121X_dataRun2_relval_v8

**dataRun2_PromptLike_HI**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_dataRun2_PromptLike_HI_v8/121X_dataRun2_PromptLike_HI_v9

**dataRun3_HLT**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_dataRun3_HLT_v8/121X_dataRun3_HLT_v9

**dataRun2_HLT_relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_dataRun2_HLT_relval_v8/121X_dataRun2_HLT_relval_v9

**dataRun3_Express**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_dataRun3_Express_v10/121X_dataRun3_Express_v9

**dataRun3_Prompt**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_dataRun3_Prompt_v8/121X_dataRun3_Prompt_v9

**dataRun3**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_dataRun3_v7/121X_dataRun3_v8

#### PR validation:

It was tested with a few data workflows [*] but for this PR, we should mainly include the failing one as reported above:

runTheMatrix.py -l limited,136.8562 --ibeos -j16 

addOnTests.py -j16

[*] 134.813,134.901,136.8642,134.701,134.702,136.768,136.769,136.77,136.771,140.56,140.5611,140.57,134.0,134.99601,134.99602,134.99603,134.99901,138.2,1001.2,1030.0,1040.0,1041.0,138.1,136.897,136.8562,136.8561,136.8501,136.732,136.7721,136.7722,136.789,136.791,136.7952,136.801,136.813,136.825,136.837,136.745,136.756,136.767,136.778,136.868,136.88,136.892,136.897,138.1,138.2,1001.2,1030.0,1040.0,1040.1,1041.0

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport and no backport foreseen.
