### PR TITLE
AlCa DQM sequence for express stream

### DIFF
--- a/Configuration/DataProcessing/test/RunExpressProcessing.py
+++ b/Configuration/DataProcessing/test/RunExpressProcessing.py
@@ -29,6 +29,7 @@ class RunExpressProcessing:
         self.noOutput = False
         self.globalTag = None
         self.inputLFN = None
+        self.dqmSeq = None
         self.alcaRecos = None
         self.nThreads = None
 
@@ -86,6 +87,9 @@ class RunExpressProcessing:
                                      'eventContent' : dataTier,
                                      'moduleLabel' : "write_%s" % dataTier })
                 kwds['outputs'] = outputs
+                
+                if self.dqmSeq:
+                    kwds['dqmSeq'] = self.dqmSeq
 
                 if self.alcaRecos:
                     kwds['skims'] = self.alcaRecos
@@ -135,7 +139,7 @@ class RunExpressProcessing:
 
 if __name__ == '__main__':
     valid = ["scenario=", "raw", "reco", "fevt", "dqm", "dqmio", "no-output",
-             "global-tag=", "lfn=", 'alcarecos=', "nThreads="]
+             "global-tag=", "lfn=", 'alcarecos=', "dqmSeq=", "nThreads="]
     usage = \
 """
 RunExpressProcessing.py <options>
@@ -149,6 +153,7 @@ Where options are:
  --no-output (create config with no output, overrides other settings)
  --global-tag=GlobalTag
  --lfn=/store/input/lfn
+ --dqmSeq=dqmSeq_plus_separated_list
  --alcarecos=plus_seprated_list
  --nThreads=Number_of_cores_or_Threads_used
 
@@ -156,7 +161,7 @@ Examples:
 
 python RunExpressProcessing.py --scenario cosmics --global-tag GLOBALTAG --lfn /store/whatever --fevt --dqmio --alcarecos=TkAlCosmics0T+SiStripCalZeroBias
 
-python RunExpressProcessing.py --scenario pp --global-tag GLOBALTAG --lfn /store/whatever --fevt --dqmio --alcarecos=TkAlMinBias+SiStripCalZeroBias
+python RunExpressProcessing.py --scenario pp --global-tag GLOBALTAG --lfn /store/whatever --fevt --dqmio --dqmSeq=@express --alcarecos=TkAlMinBias+SiStripCalZeroBias
 
 """
     try:
@@ -188,6 +193,8 @@ python RunExpressProcessing.py --scenario pp --global-tag GLOBALTAG --lfn /store
             expressinator.globalTag = arg
         if opt == "--lfn" :
             expressinator.inputLFN = arg
+        if opt == "--dqmSeq":
+            expressinator.dqmSeq = [ x for x in arg.split('+') if len(x) > 0 ]
         if opt == "--alcarecos":
             expressinator.alcaRecos = [ x for x in arg.split('+') if len(x) > 0 ]
         if opt == "--nThreads":

--- a/Configuration/DataProcessing/test/run_CfgTest.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest.sh
@@ -13,10 +13,10 @@ function runTest { echo $1 ; python3 $1 || die "Failure for configuration: $1" $
 
 runTest "${LOCAL_TEST_DIR}/RunRepack.py --select-events HLT:path1,HLT:path2 --lfn /store/whatever"
 
-declare -a arr=("cosmicsEra_Run2_2018" "ppEra_Run2_2018" "ppEra_Run2_2018_highBetaStar" "ppEra_Run2_2018_pp_on_AA" "cosmicsHybridEra_Run2_2018" "cosmicsEra_Run3" "ppEra_Run3")
+declare -a arr=("ppEra_Run2_2018" "ppEra_Run2_2018_highBetaStar" "ppEra_Run2_2018_pp_on_AA" "ppEra_Run3")
 for scenario in "${arr[@]}"
 do
-     runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario $scenario --global-tag GLOBALTAG --lfn /store/whatever --fevt --dqmio  --alcareco TkAlMinBias+SiStripCalMinBias "
+     runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario $scenario --global-tag GLOBALTAG --lfn /store/whatever --fevt --dqmio  --alcareco TkAlMinBias+SiStripCalMinBias --dqmSeq=@express"
      runTest "${LOCAL_TEST_DIR}/RunVisualizationProcessing.py --scenario $scenario --lfn /store/whatever --global-tag GLOBALTAG --fevt"
      runTest "${LOCAL_TEST_DIR}/RunAlcaHarvesting.py --scenario $scenario --lfn /store/whatever --dataset /A/B/C --global-tag GLOBALTAG --workflows=BeamSpotByRun,BeamSpotByLumi,SiStripQuality"
 done
@@ -24,13 +24,16 @@ done
 declare -a arr=("cosmicsEra_Run2_2018" "cosmicsHybridEra_Run2_2018" "cosmicsEra_Run3")
 for scenario in "${arr[@]}"
 do
-     runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario $scenario --global-tag GLOBALTAG --lfn /store/whatever --fevt --dqmio  --alcareco SiStripCalCosmicsNano "
+     runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario $scenario --global-tag GLOBALTAG --lfn /store/whatever --fevt --dqmio  --alcareco SiStripCalCosmicsNano"
+     runTest "${LOCAL_TEST_DIR}/RunVisualizationProcessing.py --scenario $scenario --lfn /store/whatever --global-tag GLOBALTAG --fevt"
+     runTest "${LOCAL_TEST_DIR}/RunAlcaHarvesting.py --scenario $scenario --lfn /store/whatever --dataset /A/B/C --global-tag GLOBALTAG --workflows=BeamSpotByRun,BeamSpotByLumi,SiStripQuality"
+
 done
 
 declare -a arr=("HeavyIonsEra_Run2_2018")
 for scenario in "${arr[@]}"
 do
-     runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario $scenario --global-tag GLOBALTAG --lfn /store/whatever --fevt --dqmio  --alcareco TkAlMinBiasHI+SiStripCalMinBias "
+     runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario $scenario --global-tag GLOBALTAG --lfn /store/whatever --fevt --dqmio  --alcareco TkAlMinBiasHI+SiStripCalMinBias"
      runTest "${LOCAL_TEST_DIR}/RunAlcaHarvesting.py --scenario $scenario --lfn /store/whatever --dataset /A/B/C --global-tag GLOBALTAG --workflows=BeamSpotByRun,BeamSpotByLumi,SiStripQuality"
      runTest "${LOCAL_TEST_DIR}/RunAlcaSkimming.py --scenario $scenario --lfn=/store/whatever --global-tag GLOBALTAG --skims SiStripCalZeroBias,SiStripCalMinBias,PromptCalibProd"
      runTest "${LOCAL_TEST_DIR}/RunDQMHarvesting.py --scenario $scenario --lfn /store/whatever --run 12345 --dataset /A/B/C --global-tag GLOBALTAG"
@@ -58,7 +61,7 @@ do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias --PhysicsSkim=@SingleMuon"
 done
 
-runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario AlCaTestEnable --global-tag GLOBALTAG --lfn /store/whatever --alcareco PromptCalibProdEcalPedestals "
+runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario AlCaTestEnable --global-tag GLOBALTAG --lfn /store/whatever --alcareco PromptCalibProdEcalPedestals"
 runTest "${LOCAL_TEST_DIR}/RunAlcaSkimming.py --scenario AlCaTestEnable --lfn=/store/whatever --global-tag GLOBALTAG --skims PromptCalibProdEcalPedestals"
 runTest "${LOCAL_TEST_DIR}/RunAlcaHarvesting.py --scenario AlCaTestEnable --lfn /store/whatever --dataset /A/B/C --global-tag GLOBALTAG --alcapromptdataset=PromptCalibProdEcalPedestals"
 
@@ -69,7 +72,7 @@ runTest "${LOCAL_TEST_DIR}/RunAlcaHarvesting.py --scenario AlCaLumiPixels --lfn 
 declare -a arr=("trackingOnlyEra_Run2_2018" "trackingOnlyEra_Run2_2018_highBetaStar" "trackingOnlyEra_Run2_2018_pp_on_AA" "trackingOnlyEra_Run3")
 for scenario in "${arr[@]}"
 do
-    runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario $scenario --global-tag GLOBALTAG  --lfn /store/whatever  --alcarecos=TkAlMinBias+PromptCalibProdBeamSpotHP"
+    runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario $scenario --global-tag GLOBALTAG  --lfn /store/whatever  --alcarecos=TkAlMinBias+PromptCalibProdBeamSpotHPi --dqmSeq=@trackingOnlyDQM"
     runTest "${LOCAL_TEST_DIR}/RunAlcaSkimming.py --scenario $scenario --lfn /store/whatever --global-tag GLOBALTAG --skims TkAlMinBias,PromptCalibProdBeamSpotHP"
     runTest "${LOCAL_TEST_DIR}/RunAlcaSkimming.py --scenario $scenario --lfn /store/whatever --global-tag GLOBALTAG --skims TkAlMinBias,PromptCalibProdBeamSpotHPLowPU"
     runTest "${LOCAL_TEST_DIR}/RunAlcaHarvesting.py --scenario $scenario --lfn /store/whatever --dataset /A/B/C --global-tag GLOBALTAG --alcapromptdataset=PromptCalibProdBeamSpotHP"


### PR DESCRIPTION
#### PR description:

Added @express to Express pp AlCas and to UnitTest Configuration/DataProcessing/test/run_CfgTest.sh

Express AlCaRecos were taking as default DQM sequence @standardDQM which is not appropiated since not all products are available in reconstruction from AlCaReco stream. @express contains a subset of DQM sequences which fits better the AlCa streams

The corner cases for HeavyIons and Cosmics, in principle are running by default reduced sequences driven by HI and Cosmics scenarios, so the default DQM sequence seems to work  and no dedicated @expressHI or @expressCosmics are needed (see below for Validation of this statement, up to GlobalTag settings). For a full validation I would need advice from @tvami about which GTs to use for Cosmics and HI

This PR solves issue #35586

Following changes suggested by @mmusich (thanks a lot!!) in:
#35586 (comment)

I understand this PR should go hand by hand with changes in Tier0 configuration for future processings setting @express there, in particular :

https://github.com/dmwm/T0/blob/master/etc/ProdOfflineConfiguration.py#L227 no DQM sequences mentioned explicitly
in https://github.com/dmwm/T0/blob/master/src/python/T0/RunConfig/Tier0Config.py#L890 initialized to an empty sequence

FYI: @mmusich @slava77 @tvami @jpata 

#### PR validation:

- Tested that Configuration/DataProcessing/test/run_CfgTest.sh creates valid python configurations
- HI case: tested that it runs up to GlobalTag needs the following command
 
 python3 Configuration/DataProcessing/test/RunExpressProcessing.py --scenario HeavyIonsEra_Run2_2018 --global-tag 121X_mcRun3_2021_realistic_v11Based_forExpressRateStudies --lfn file:./F4CD260A-B956-084B-AFC3-EBFFB2A4E177.root --fevt --dqmio --alcareco TkAlMinBiasHI+SiStripCalMinBias

where input file came from: xrdcp root://cms-xrd-global.cern.ch//store/hidata/HIRun2018A/HIDoubleMuon/RAW/v1/000/327/554/00000/F4CD260A-B956-084B-AFC3-EBFFB2A4E177.root .

- Cosmic case: tested that it runs up to GlobalTag needs the following command

python3 Configuration/DataProcessing/test/RunExpressProcessing.py --scenario cosmicsEra_Run2_2018 --global-tag 121X_mcRun3_2021_realistic_v11Based_forExpressRateStudies --lfn file:./eaceff12-9817-41eb-bc10-c133fbb62bf2.root --fevt --dqmio --alcareco SiStripCalCosmicsNano

where input file came from: xrdcp root://cms-xrd-global.cern.ch//store/data/Commissioning2021/Cosmics/RAW/v1/000/345/823/00000/eaceff12-9817-41eb-bc10-c133fbb62bf2.root .
