### PR TITLE
[DQM] Fix DTChamberEfficiencyTest esConsumes to use proper Transition

### DIFF
--- a/DQM/DTMonitorClient/src/DTChamberEfficiencyTest.cc
+++ b/DQM/DTMonitorClient/src/DTChamberEfficiencyTest.cc
@@ -25,7 +25,8 @@
 using namespace edm;
 using namespace std;
 
-DTChamberEfficiencyTest::DTChamberEfficiencyTest(const edm::ParameterSet& ps) : muonGeomToken_(esConsumes()) {
+DTChamberEfficiencyTest::DTChamberEfficiencyTest(const edm::ParameterSet& ps)
+    : muonGeomToken_(esConsumes<edm::Transition::EndLuminosityBlock>()) {
   edm::LogVerbatim("DTDQM|DTMonitorClient|DTChamberEfficiencyTest") << "[DTChamberEfficiencyTest]: Constructor";
 
   parameters = ps;


### PR DESCRIPTION
#### PR description:

This is a trivial fix to the `DTChamberEfficiencyTest` module, to specify the proper transition  to esConsumes.
The problem was spot in the deployment the DT Prompt Offline Analysis (POA) programs used to process CRAFT data.

#### PR validation:

The DT POA works as expected after the fix was deployed. As the module does not run in central workflows, I simply tested that a few `runTheMatrix.py` get to completion after the fix.
