### PR TITLE
Validate TF1 if requested in BTagEntry

### DIFF
--- a/CondFormats/BTauObjects/interface/BTagCalibration.h
+++ b/CondFormats/BTauObjects/interface/BTagCalibration.h
@@ -28,7 +28,7 @@ class BTagCalibration {
 public:
   BTagCalibration() {}
   BTagCalibration(const std::string &tagger);
-  BTagCalibration(const std::string &tagger, const std::string &filename);
+  BTagCalibration(const std::string &tagger, const std::string &filename, bool validate);
   ~BTagCalibration() {}
 
   std::string tagger() const { return tagger_; }
@@ -36,8 +36,8 @@ public:
   void addEntry(const BTagEntry &entry);
   const std::vector<BTagEntry> &getEntries(const BTagEntry::Parameters &par) const;
 
-  void readCSV(std::istream &s);
-  void readCSV(const std::string &s);
+  void readCSV(std::istream &s, bool validate);
+  void readCSV(const std::string &s, bool validate);
   void makeCSV(std::ostream &s) const;
   std::string makeCSV() const;
 

--- a/CondFormats/BTauObjects/interface/BTagEntry.h
+++ b/CondFormats/BTauObjects/interface/BTagEntry.h
@@ -62,7 +62,7 @@ public:
   };
 
   BTagEntry() {}
-  BTagEntry(const std::string& csvLine);
+  BTagEntry(const std::string& csvLine, bool validate);
   BTagEntry(const std::string& func, Parameters p);
   BTagEntry(const TF1* func, Parameters p);
   BTagEntry(const TH1* histo, Parameters p);

--- a/CondFormats/BTauObjects/src/BTagCalibration.cc
+++ b/CondFormats/BTauObjects/src/BTagCalibration.cc
@@ -6,12 +6,13 @@
 
 BTagCalibration::BTagCalibration(const std::string &taggr) : tagger_(taggr) {}
 
-BTagCalibration::BTagCalibration(const std::string &taggr, const std::string &filename) : tagger_(taggr) {
+BTagCalibration::BTagCalibration(const std::string &taggr, const std::string &filename, bool validate)
+    : tagger_(taggr) {
   std::ifstream ifs(filename);
   if (!ifs.good()) {
     throw cms::Exception("BTagCalibration") << "input file not available: " << filename;
   }
-  readCSV(ifs);
+  readCSV(ifs, validate);
   ifs.close();
 }
 
@@ -25,18 +26,18 @@ const std::vector<BTagEntry> &BTagCalibration::getEntries(const BTagEntry::Param
   return data_.at(tok);
 }
 
-void BTagCalibration::readCSV(const std::string &s) {
+void BTagCalibration::readCSV(const std::string &s, bool validate) {
   std::stringstream buff(s);
-  readCSV(buff);
+  readCSV(buff, validate);
 }
 
-void BTagCalibration::readCSV(std::istream &s) {
+void BTagCalibration::readCSV(std::istream &s, bool validate) {
   std::string line;
 
   // firstline might be the header
   getline(s, line);
   if (line.find("OperatingPoint") == std::string::npos) {
-    addEntry(BTagEntry(line));
+    addEntry(BTagEntry(line, validate));
   }
 
   while (getline(s, line)) {
@@ -44,7 +45,7 @@ void BTagCalibration::readCSV(std::istream &s) {
     if (line.empty()) {  // skip empty lines
       continue;
     }
-    addEntry(BTagEntry(line));
+    addEntry(BTagEntry(line, validate));
   }
 }
 

--- a/CondFormats/BTauObjects/src/BTagEntry.cc
+++ b/CondFormats/BTauObjects/src/BTagEntry.cc
@@ -28,7 +28,7 @@ BTagEntry::Parameters::Parameters(OperatingPoint op,
   std::transform(sysType.begin(), sysType.end(), sysType.begin(), ::tolower);
 }
 
-BTagEntry::BTagEntry(const std::string& csvLine) {
+BTagEntry::BTagEntry(const std::string& csvLine, bool validate) {
   // make tokens
   std::stringstream buff(csvLine);
   std::vector<std::string> vec;
@@ -54,9 +54,11 @@ BTagEntry::BTagEntry(const std::string& csvLine) {
 
   // make formula
   formula = vec[10];
-  TF1 f1("", formula.c_str());  // compile formula to check validity
-  if (f1.IsZombie()) {
-    throw cms::Exception("BTagCalibration") << "Invalid csv line; formula does not compile: " << csvLine;
+  if (validate) {
+    TF1 f1("", formula.c_str());  // compile formula to check validity
+    if (f1.IsZombie()) {
+      throw cms::Exception("BTagCalibration") << "Invalid csv line; formula does not compile: " << csvLine;
+    }
   }
 
   // make parameters

--- a/CondFormats/BTauObjects/test/testBTagCalibration.cpp
+++ b/CondFormats/BTauObjects/test/testBTagCalibration.cpp
@@ -18,7 +18,7 @@ int main() {
       "0, comb, down, 0, 1, 2, 3, 4, 5, 6, \"2*x\" \n");
   stringstream csv1Stream(csv1);
   BTagCalibration b1("csv");
-  b1.readCSV(csv1Stream);
+  b1.readCSV(csv1Stream, true);
 
   // assert correct length of vectors
   auto e1 = b1.getEntries(BTagEntry::Parameters(BTagEntry::OP_LOOSE, "comb", "central"));
@@ -37,7 +37,7 @@ int main() {
   csv2Stream1 << tggr << ";" << BTagEntry::makeCSVHeader() << csv2_1 << csv2_2;
   csv2Stream2 << tggr << ";" << BTagEntry::makeCSVHeader() << csv2_2 << csv2_1;
   BTagCalibration b2(tggr);
-  b2.readCSV(csv2Stream1);
+  b2.readCSV(csv2Stream1, true);
 
   stringstream csv3Stream;
   b2.makeCSV(csv3Stream);

--- a/CondFormats/BTauObjects/test/testBTagEntry.cpp
+++ b/CondFormats/BTauObjects/test/testBTagEntry.cpp
@@ -39,7 +39,7 @@ int main() {
 
   // csv constructor
   string csv = "0, comb, up, 0, 1, 2, 3, 4, 5, 6, \"2*x\" \n";
-  auto b4 = BTagEntry(csv);
+  auto b4 = BTagEntry(csv, true);
   auto csv2 = b4.makeCSVLine();
   assert(b4.params.etaMin == 1);
   assert(b4.params.etaMax == 2);

--- a/CondTools/BTau/plugins/BTagCalibrationDbCreator.cc
+++ b/CondTools/BTau/plugins/BTagCalibrationDbCreator.cc
@@ -3,7 +3,7 @@
 #include <iostream>
 #include <sstream>
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -11,7 +11,7 @@
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 #include "CondFormats/BTauObjects/interface/BTagCalibration.h"
 
-class BTagCalibrationDbCreator : public edm::EDAnalyzer {
+class BTagCalibrationDbCreator : public edm::one::EDAnalyzer<> {
 public:
   BTagCalibrationDbCreator(const edm::ParameterSet&);
   void beginJob() override;
@@ -29,7 +29,7 @@ BTagCalibrationDbCreator::BTagCalibrationDbCreator(const edm::ParameterSet& p)
       tagger_(p.getUntrackedParameter<std::string>("tagger")) {}
 
 void BTagCalibrationDbCreator::beginJob() {
-  auto calib = new BTagCalibration(tagger_, csvFile_);
+  auto calib = new BTagCalibration(tagger_, csvFile_, true);
   edm::Service<cond::service::PoolDBOutputService> s;
   if (s.isAvailable()) {
     if (s->isNewTagRequest(tagger_)) {

--- a/CondTools/BTau/test/testBTagCalibrationReader.cpp
+++ b/CondTools/BTau/test/testBTagCalibrationReader.cpp
@@ -28,7 +28,7 @@ int main() {
       "1, test, down,    1, -2, 2, 50, 500, 0, 999, \"1.9*x\" \n");
   stringstream csv1Stream(csv1);
   BTagCalibration bc1("csv");
-  bc1.readCSV(csv1Stream);
+  bc1.readCSV(csv1Stream, true);
 
   // test pt-dependent function
   BTagCalibrationReader bcr1(BTagEntry::OP_LOOSE);

--- a/PhysicsTools/NanoAOD/plugins/BTagSFProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/BTagSFProducer.cc
@@ -54,12 +54,13 @@ public:
            measurementTypesB_.size() == nDiscs && measurementTypesC_.size() == nDiscs &&
            measurementTypesUDSG_.size() == nDiscs && sysTypes_.size() == nDiscs);
 
+    bool validate = iConfig.getUntrackedParameter<bool>("validate");
     for (unsigned int iDisc = 0; iDisc < nDiscs; ++iDisc) {
       if (weightFiles_[iDisc] != "unavailable") {
         // setup calibration
         BTagCalibration calib;
         edm::FileInPath fip(weightFiles_[iDisc]);
-        calib = BTagCalibration(discShortNames_[iDisc], fip.fullPath());
+        calib = BTagCalibration(discShortNames_[iDisc], fip.fullPath(), validate);
 
         // determine op
         std::string opname;
@@ -143,7 +144,7 @@ public:
     desc.add<std::vector<std::string>>("sysTypes")
         ->setComment(
             "\"up\", \"central\", \"down\", but arbitrary strings possible, like \"up_generator\" or \"up_jec\"");
-
+    desc.addUntracked<bool>("validate", false)->setComment("validate the function expressions in the weightFiles");
     descriptions.add("BTagWeightTable", desc);
   }
 


### PR DESCRIPTION
#### PR description:

Validating the BTagEntry everytime it was read from the CSV file was dominating the Nano jobs startup times. Converting that to be optional made the module's startup time > 25x faster.

During an earlier buggy version of this PR, I found that even with validation turned off, cmsRun will cause ROOT to generate an exception if an invalid string is passed to TF1.

#### PR validation:

Code compiles. Running RelVal 23434.21 step 5 did not generate any errors.