### PR TITLE
default initialize HiPuRhoProducer::postOrphan_

### DIFF
--- a/RecoHI/HiJetAlgos/plugins/HiPuRhoProducer.cc
+++ b/RecoHI/HiJetAlgos/plugins/HiPuRhoProducer.cc
@@ -85,7 +85,7 @@ private:
   // This checks if the tower is anomalous (if a calo tower).
   virtual void inputTowers();
 
-  bool postOrphan_;
+  bool postOrphan_ = false;
   bool setInitialValue_;
 
   const bool dropZeroTowers_;


### PR DESCRIPTION
to address 
`159.3 step3 RecoHI/HiJetAlgos/plugins/HiPuRhoProducer.cc:357:11: runtime error: load of value 16, which is not a valid value for type 'bool' `
from #35036 

@mandrenguyen 