### PR TITLE
make HLT use "schedule"

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforALL.py
+++ b/HLTrigger/Configuration/python/customizeHLTforALL.py
@@ -2,6 +2,15 @@ import FWCore.ParameterSet.Config as cms
 
 def customizeHLTforAll(process, menuType = "GRun", _customInfo = None):
 
+    # rename "HLTSchedule" to "schedule":
+    # CMSSW policy is to have at most 1 schedule
+    # in the cms.Process, named "schedule"
+    if hasattr(process, 'HLTSchedule'):
+        if process.schedule_() != None:
+            raise Exception('process.schedule already exists')
+        process.setSchedule_(process.HLTSchedule)
+        del process.HLTSchedule
+
     if (_customInfo is not None):
 
         _maxEvents = _customInfo['maxEvents']

--- a/HLTrigger/Configuration/python/customizeHLTforNewDatasetDefinition.py
+++ b/HLTrigger/Configuration/python/customizeHLTforNewDatasetDefinition.py
@@ -15,7 +15,7 @@ def customizeHLTforNewDatasetDefinition(process):
             datasetPath = 'Dataset_'+dataset+'_v1'
             setattr( process, datasetPath, cms.Path( process.hltGtStage2Digis + getattr( process , 'hltPreDataset'+dataset ) +  getattr( process, 'hltDataset'+dataset ) + process.HLTEndSequence ) )
             # Append dataset path
-            process.HLTSchedule.insert( process.HLTSchedule.index( process.HLTriggerFinalPath ), getattr( process, datasetPath ) )
+            process.schedule.insert( process.schedule.index( process.HLTriggerFinalPath ), getattr( process, datasetPath ) )
             setattr( process.datasets, dataset, cms.vstring( datasetPath ) )
             streamPaths.append( datasetPath )
         # Set stream paths

--- a/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
+++ b/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
@@ -51,8 +51,6 @@ def customiseCommon(process):
         replace_with(process.Status_OnCPU, cms.Path(process.statusOnGPU + ~process.statusOnGPUFilter))
     else:
         process.Status_OnCPU = cms.Path(process.statusOnGPU + ~process.statusOnGPUFilter)
-        if 'HLTSchedule' in process.__dict__:
-            process.HLTSchedule.append(process.Status_OnCPU)
         if process.schedule is not None:
             process.schedule.append(process.Status_OnCPU)
 
@@ -60,11 +58,8 @@ def customiseCommon(process):
         replace_with(process.Status_OnGPU, cms.Path(process.statusOnGPU + process.statusOnGPUFilter))
     else:
         process.Status_OnGPU = cms.Path(process.statusOnGPU + process.statusOnGPUFilter)
-        if 'HLTSchedule' in process.__dict__:
-            process.HLTSchedule.append(process.Status_OnGPU)
         if process.schedule is not None:
             process.schedule.append(process.Status_OnGPU)
-
 
     # make the ScoutingCaloMuonOutput endpath compatible with using Tasks in the Scouting paths
     if 'hltOutputScoutingCaloMuon' in process.__dict__ and not 'hltPreScoutingCaloMuonOutputSmart' in process.__dict__:
@@ -230,9 +225,6 @@ def customisePixelLocalReconstruction(process):
     # workaround for AlCa paths
 
     if 'AlCa_LumiPixelsCounts_Random_v1' in process.__dict__:
-        if "HLTSchedule" in process.__dict__:
-            ind = process.HLTSchedule.index(process.AlCa_LumiPixelsCounts_Random_v1)
-            process.HLTSchedule.remove(process.AlCa_LumiPixelsCounts_Random_v1)
         # redefine the path to use the HLTDoLocalPixelSequence
         process.AlCa_LumiPixelsCounts_Random_v1 = cms.Path(
             process.HLTBeginSequenceRandom +
@@ -242,13 +234,8 @@ def customisePixelLocalReconstruction(process):
             process.HLTDoLocalPixelSequence +
             process.hltAlcaPixelClusterCounts +
             process.HLTEndSequence )
-        if "HLTSchedule" in process.__dict__:
-            process.HLTSchedule.insert(ind, process.AlCa_LumiPixelsCounts_Random_v1)
 
     if 'AlCa_LumiPixelsCounts_ZeroBias_v1' in process.__dict__:
-        if "HLTSchedule" in process.__dict__:
-            ind = process.HLTSchedule.index(process.AlCa_LumiPixelsCounts_ZeroBias_v1)
-            process.HLTSchedule.remove(process.AlCa_LumiPixelsCounts_ZeroBias_v1)
         # redefine the path to use the HLTDoLocalPixelSequence
         process.AlCa_LumiPixelsCounts_ZeroBias_v1 = cms.Path(
             process.HLTBeginSequence +
@@ -259,9 +246,6 @@ def customisePixelLocalReconstruction(process):
             process.HLTDoLocalPixelSequence +
             process.hltAlcaPixelClusterCounts +
             process.HLTEndSequence )
-        if "HLTSchedule" in process.__dict__:
-            process.HLTSchedule.insert(ind, process.AlCa_LumiPixelsCounts_ZeroBias_v1)
-
 
     # done
     return process
@@ -736,8 +720,6 @@ def _addConsumerPath(process):
         process.HLTDoLocalHcalTask,
     )
 
-    if 'HLTSchedule' in process.__dict__:
-        process.HLTSchedule.append(process.Consumer)
     if process.schedule is not None:
         process.schedule.append(process.Consumer)
 

--- a/RecoTauTag/HLTProducers/test/testL2TauTagNN.py
+++ b/RecoTauTag/HLTProducers/test/testL2TauTagNN.py
@@ -140,8 +140,7 @@ process.endjob_step = cms.EndPath(process.endOfProcess)
 
 
 # Schedule definition
-process.schedule = cms.Schedule()
-process.schedule.extend(process.HLTSchedule)
+# process.schedule imported from cff in HLTrigger.Configuration
 process.schedule.extend([process.endjob_step])
 from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
 associatePatAlgosToolsTask(process)


### PR DESCRIPTION
#### PR description:

The first step towards the resolution of #35842 could be the renaming of `HLTSchedule` to `schedule`, using one of the standard HLT customisation functions. This PR is an attempt at that.

The final solution will have to come eventually with a change in `ConfDB`.

Standalone configs in `test/` that use/assume `HLTSchedule` have been ignored for the moment (except for one that ~~I know is used~~ used to run in unit tests).

Merely technical; no changes expected.

FYI: @fwyzard @Sam-Harper

#### PR validation:

`addOnTests.py` and a few `runTheMatrix` wfs passed.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

N/A