### PR TITLE
Common alignment algorithm consumes migration

### DIFF
--- a/Alignment/CommonAlignmentAlgorithm/interface/IntegratedCalibrationPluginFactory.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/IntegratedCalibrationPluginFactory.h
@@ -13,7 +13,7 @@
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 #include "Alignment/CommonAlignmentAlgorithm/interface/IntegratedCalibrationBase.h"
 
-typedef edmplugin::PluginFactory<IntegratedCalibrationBase*(const edm::ParameterSet&, edm::ConsumesCollector &)>
+typedef edmplugin::PluginFactory<IntegratedCalibrationBase *(const edm::ParameterSet &, edm::ConsumesCollector &)>
     IntegratedCalibrationPluginFactory;
 
 #endif

--- a/Alignment/CommonAlignmentAlgorithm/interface/IntegratedCalibrationPluginFactory.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/IntegratedCalibrationPluginFactory.h
@@ -13,7 +13,7 @@
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 #include "Alignment/CommonAlignmentAlgorithm/interface/IntegratedCalibrationBase.h"
 
-typedef edmplugin::PluginFactory<IntegratedCalibrationBase*(const edm::ParameterSet&)>
+typedef edmplugin::PluginFactory<IntegratedCalibrationBase*(const edm::ParameterSet&, edm::ConsumesCollector &)>
     IntegratedCalibrationPluginFactory;
 
 #endif

--- a/Alignment/CommonAlignmentAlgorithm/plugins/SiPixelLorentzAngleCalibration.cc
+++ b/Alignment/CommonAlignmentAlgorithm/plugins/SiPixelLorentzAngleCalibration.cc
@@ -23,7 +23,6 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -37,6 +36,7 @@
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "TTree.h"
 #include "TFile.h"
@@ -54,7 +54,7 @@
 class SiPixelLorentzAngleCalibration : public IntegratedCalibrationBase {
 public:
   /// Constructor
-  explicit SiPixelLorentzAngleCalibration(const edm::ParameterSet &cfg);
+  explicit SiPixelLorentzAngleCalibration(const edm::ParameterSet &cfg, edm::ConsumesCollector& iC);
 
   /// Destructor
   ~SiPixelLorentzAngleCalibration() override = default;
@@ -116,7 +116,8 @@ private:
   const std::string outFileName_;
   const std::vector<std::string> mergeFileNames_;
   const std::string lorentzAngleLabel_;
-
+  const edm::ESGetToken<SiPixelLorentzAngle,SiPixelLorentzAngleRcd>lorentzAngleToken_;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magFieldToken_;
   edm::ESWatcher<SiPixelLorentzAngleRcd> watchLorentzAngleRcd_;
 
   // const AlignableTracker *alignableTracker_;
@@ -134,13 +135,15 @@ private:
 //======================================================================
 //======================================================================
 
-SiPixelLorentzAngleCalibration::SiPixelLorentzAngleCalibration(const edm::ParameterSet &cfg)
+SiPixelLorentzAngleCalibration::SiPixelLorentzAngleCalibration(const edm::ParameterSet &cfg, edm::ConsumesCollector& iC)
     : IntegratedCalibrationBase(cfg),
       saveToDB_(cfg.getParameter<bool>("saveToDB")),
       recordNameDBwrite_(cfg.getParameter<std::string>("recordNameDBwrite")),
       outFileName_(cfg.getParameter<std::string>("treeFile")),
       mergeFileNames_(cfg.getParameter<std::vector<std::string> >("mergeTreeFiles")),
       lorentzAngleLabel_(cfg.getParameter<std::string>("lorentzAngleLabel")),
+      lorentzAngleToken_(iC.esConsumes(edm::ESInputTag("", lorentzAngleLabel_))),
+      magFieldToken_(iC.esConsumes()),
       moduleGroupSelCfg_(cfg.getParameter<edm::ParameterSet>("LorentzAngleModuleGroups")) {}
 
 //======================================================================
@@ -165,9 +168,10 @@ void SiPixelLorentzAngleCalibration::beginRun(const edm::Run &run, const edm::Ev
     }
   }
 
-  edm::ESHandle<SiPixelLorentzAngle> lorentzAngleHandle;
-  const auto &lorentzAngleRcd = setup.get<SiPixelLorentzAngleRcd>();
-  lorentzAngleRcd.get(lorentzAngleLabel_, lorentzAngleHandle);
+    const SiPixelLorentzAngle* lorentzAngleHandle;
+    lorentzAngleHandle= &setup.getData(lorentzAngleToken_);
+    const auto &lorentzAngleRcd = setup.get<SiPixelLorentzAngleRcd>();
+
   if (cachedLorentzAngleInputs_.find(firstRun) == cachedLorentzAngleInputs_.end()) {
     cachedLorentzAngleInputs_.emplace(firstRun, SiPixelLorentzAngle(*lorentzAngleHandle));
   } else {
@@ -202,8 +206,8 @@ unsigned int SiPixelLorentzAngleCalibration::derivatives(std::vector<ValuesIndex
     const int index =
         moduleGroupSelector_->getParameterIndexFromDetId(hit.det()->geographicalId(), eventInfo.eventId().run());
     if (index >= 0) {  // otherwise not treated
-      edm::ESHandle<MagneticField> magneticField;
-      setup.get<IdealMagneticFieldRecord>().get(magneticField);
+
+      const MagneticField* magneticField = &setup.getData(magFieldToken_);
       const GlobalVector bField(magneticField->inTesla(hit.det()->surface().position()));
       const LocalVector bFieldLocal(hit.det()->surface().toLocal(bField));
       const double dZ = hit.det()->surface().bounds().thickness();  // it is a float only...

--- a/Alignment/CommonAlignmentAlgorithm/plugins/SiPixelLorentzAngleCalibration.cc
+++ b/Alignment/CommonAlignmentAlgorithm/plugins/SiPixelLorentzAngleCalibration.cc
@@ -142,7 +142,7 @@ SiPixelLorentzAngleCalibration::SiPixelLorentzAngleCalibration(const edm::Parame
       outFileName_(cfg.getParameter<std::string>("treeFile")),
       mergeFileNames_(cfg.getParameter<std::vector<std::string> >("mergeTreeFiles")),
       lorentzAngleLabel_(cfg.getParameter<std::string>("lorentzAngleLabel")),
-      lorentzAngleToken_(iC.esConsumes(edm::ESInputTag("", lorentzAngleLabel_))),
+      lorentzAngleToken_(iC.esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", lorentzAngleLabel_))),
       magFieldToken_(iC.esConsumes()),
       moduleGroupSelCfg_(cfg.getParameter<edm::ParameterSet>("LorentzAngleModuleGroups")) {}
 
@@ -168,8 +168,7 @@ void SiPixelLorentzAngleCalibration::beginRun(const edm::Run &run, const edm::Ev
     }
   }
 
-  const SiPixelLorentzAngle *lorentzAngleHandle;
-  lorentzAngleHandle = &setup.getData(lorentzAngleToken_);
+  const SiPixelLorentzAngle *lorentzAngleHandle = &setup.getData(lorentzAngleToken_);
   const auto &lorentzAngleRcd = setup.get<SiPixelLorentzAngleRcd>();
 
   if (cachedLorentzAngleInputs_.find(firstRun) == cachedLorentzAngleInputs_.end()) {

--- a/Alignment/CommonAlignmentAlgorithm/plugins/SiPixelLorentzAngleCalibration.cc
+++ b/Alignment/CommonAlignmentAlgorithm/plugins/SiPixelLorentzAngleCalibration.cc
@@ -54,7 +54,7 @@
 class SiPixelLorentzAngleCalibration : public IntegratedCalibrationBase {
 public:
   /// Constructor
-  explicit SiPixelLorentzAngleCalibration(const edm::ParameterSet &cfg, edm::ConsumesCollector& iC);
+  explicit SiPixelLorentzAngleCalibration(const edm::ParameterSet &cfg, edm::ConsumesCollector &iC);
 
   /// Destructor
   ~SiPixelLorentzAngleCalibration() override = default;
@@ -116,7 +116,7 @@ private:
   const std::string outFileName_;
   const std::vector<std::string> mergeFileNames_;
   const std::string lorentzAngleLabel_;
-  const edm::ESGetToken<SiPixelLorentzAngle,SiPixelLorentzAngleRcd>lorentzAngleToken_;
+  const edm::ESGetToken<SiPixelLorentzAngle, SiPixelLorentzAngleRcd> lorentzAngleToken_;
   const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magFieldToken_;
   edm::ESWatcher<SiPixelLorentzAngleRcd> watchLorentzAngleRcd_;
 
@@ -135,7 +135,7 @@ private:
 //======================================================================
 //======================================================================
 
-SiPixelLorentzAngleCalibration::SiPixelLorentzAngleCalibration(const edm::ParameterSet &cfg, edm::ConsumesCollector& iC)
+SiPixelLorentzAngleCalibration::SiPixelLorentzAngleCalibration(const edm::ParameterSet &cfg, edm::ConsumesCollector &iC)
     : IntegratedCalibrationBase(cfg),
       saveToDB_(cfg.getParameter<bool>("saveToDB")),
       recordNameDBwrite_(cfg.getParameter<std::string>("recordNameDBwrite")),
@@ -168,9 +168,9 @@ void SiPixelLorentzAngleCalibration::beginRun(const edm::Run &run, const edm::Ev
     }
   }
 
-    const SiPixelLorentzAngle* lorentzAngleHandle;
-    lorentzAngleHandle= &setup.getData(lorentzAngleToken_);
-    const auto &lorentzAngleRcd = setup.get<SiPixelLorentzAngleRcd>();
+  const SiPixelLorentzAngle *lorentzAngleHandle;
+  lorentzAngleHandle = &setup.getData(lorentzAngleToken_);
+  const auto &lorentzAngleRcd = setup.get<SiPixelLorentzAngleRcd>();
 
   if (cachedLorentzAngleInputs_.find(firstRun) == cachedLorentzAngleInputs_.end()) {
     cachedLorentzAngleInputs_.emplace(firstRun, SiPixelLorentzAngle(*lorentzAngleHandle));
@@ -207,7 +207,7 @@ unsigned int SiPixelLorentzAngleCalibration::derivatives(std::vector<ValuesIndex
         moduleGroupSelector_->getParameterIndexFromDetId(hit.det()->geographicalId(), eventInfo.eventId().run());
     if (index >= 0) {  // otherwise not treated
 
-      const MagneticField* magneticField = &setup.getData(magFieldToken_);
+      const MagneticField *magneticField = &setup.getData(magFieldToken_);
       const GlobalVector bField(magneticField->inTesla(hit.det()->surface().position()));
       const LocalVector bFieldLocal(hit.det()->surface().toLocal(bField));
       const double dZ = hit.det()->surface().bounds().thickness();  // it is a float only...

--- a/Alignment/CommonAlignmentAlgorithm/plugins/SiStripBackplaneCalibration.cc
+++ b/Alignment/CommonAlignmentAlgorithm/plugins/SiStripBackplaneCalibration.cc
@@ -39,6 +39,7 @@
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "TTree.h"
 #include "TFile.h"
@@ -54,7 +55,7 @@
 class SiStripBackplaneCalibration : public IntegratedCalibrationBase {
 public:
   /// Constructor
-  explicit SiStripBackplaneCalibration(const edm::ParameterSet &cfg);
+  explicit SiStripBackplaneCalibration(const edm::ParameterSet &cfg, edm::ConsumesCollector& iC);
 
   /// Destructor
   ~SiStripBackplaneCalibration() override;
@@ -135,13 +136,18 @@ private:
 
   TkModuleGroupSelector *moduleGroupSelector_;
   const edm::ParameterSet moduleGroupSelCfg_;
+  const edm::ESGetToken<SiStripLatency,SiStripLatencyRcd> latencyToken_;
+  const edm::ESGetToken<SiStripLorentzAngle,SiStripLorentzAngleRcd>lorentzAngleToken_;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magFieldToken_;
+  const edm::ESGetToken<SiStripBackPlaneCorrection,SiStripBackPlaneCorrectionRcd>backPlaneCorrToken_;
+
 };
 
 //======================================================================
 //======================================================================
 //======================================================================
 
-SiStripBackplaneCalibration::SiStripBackplaneCalibration(const edm::ParameterSet &cfg)
+SiStripBackplaneCalibration::SiStripBackplaneCalibration(const edm::ParameterSet &cfg, edm::ConsumesCollector& iC)
     : IntegratedCalibrationBase(cfg),
       readoutModeName_(cfg.getParameter<std::string>("readoutMode")),
       saveToDB_(cfg.getParameter<bool>("saveToDB")),
@@ -150,7 +156,11 @@ SiStripBackplaneCalibration::SiStripBackplaneCalibration(const edm::ParameterSet
       mergeFileNames_(cfg.getParameter<std::vector<std::string> >("mergeTreeFiles")),
       siStripBackPlaneCorrInput_(nullptr),
       moduleGroupSelector_(nullptr),
-      moduleGroupSelCfg_(cfg.getParameter<edm::ParameterSet>("BackplaneModuleGroups")) {
+      moduleGroupSelCfg_(cfg.getParameter<edm::ParameterSet>("BackplaneModuleGroups")),
+      latencyToken_(iC.esConsumes()),
+      lorentzAngleToken_(iC.esConsumes(edm::ESInputTag("", readoutModeName_))),
+      magFieldToken_(iC.esConsumes()),
+      backPlaneCorrToken_(iC.esConsumes(edm::ESInputTag("", readoutModeName_))){
   // SiStripLatency::singleReadOutMode() returns
   // 1: all in peak, 0: all in deco, -1: mixed state
   // (in principle one could treat even mixed state APV by APV...)
@@ -187,8 +197,8 @@ unsigned int SiStripBackplaneCalibration::derivatives(std::vector<ValuesIndexPai
 
   outDerivInds.clear();
 
-  edm::ESHandle<SiStripLatency> latency;
-  setup.get<SiStripLatencyRcd>().get(latency);
+  const SiStripLatency* latency;
+  latency = &setup.getData(latencyToken_);
   const int16_t mode = latency->singleReadOutMode();
 
   if (mode == readoutMode_) {
@@ -197,16 +207,16 @@ unsigned int SiStripBackplaneCalibration::derivatives(std::vector<ValuesIndexPai
       const int index =
           moduleGroupSelector_->getParameterIndexFromDetId(hit.det()->geographicalId(), eventInfo.eventId().run());
       if (index >= 0) {  // otherwise not treated
-        edm::ESHandle<MagneticField> magneticField;
-        setup.get<IdealMagneticFieldRecord>().get(magneticField);
+        const MagneticField* magneticField = &setup.getData(magFieldToken_);
         const GlobalVector bField(magneticField->inTesla(hit.det()->surface().position()));
         const LocalVector bFieldLocal(hit.det()->surface().toLocal(bField));
         //std::cout << "SiStripBackplaneCalibration derivatives " << readoutModeName_ << std::endl;
         const double dZ = hit.det()->surface().bounds().thickness();          // it's a float only...
         const double tanPsi = tsos.localParameters().mixedFormatVector()[1];  //float...
 
-        edm::ESHandle<SiStripLorentzAngle> lorentzAngleHandle;
-        setup.get<SiStripLorentzAngleRcd>().get(readoutModeName_, lorentzAngleHandle);
+
+        const SiStripLorentzAngle* lorentzAngleHandle;
+        lorentzAngleHandle = &setup.getData(lorentzAngleToken_); 
         // Yes, mobility (= LA/By) stored in object called LA...
         const double mobility = lorentzAngleHandle->getLorentzAngle(hit.det()->geographicalId());
         // shift due to dead back plane has two parts:
@@ -393,16 +403,17 @@ void SiStripBackplaneCalibration::endOfJob() {
 //======================================================================
 bool SiStripBackplaneCalibration::checkBackPlaneCorrectionInput(const edm::EventSetup &setup,
                                                                 const EventInfo &eventInfo) {
-  edm::ESHandle<SiStripBackPlaneCorrection> backPlaneCorrHandle;
+  const SiStripBackPlaneCorrection * backPlaneCorrHandle;
   if (!siStripBackPlaneCorrInput_) {
-    setup.get<SiStripBackPlaneCorrectionRcd>().get(readoutModeName_, backPlaneCorrHandle);
+    backPlaneCorrHandle = &setup.getData(backPlaneCorrToken_);
     siStripBackPlaneCorrInput_ = new SiStripBackPlaneCorrection(*backPlaneCorrHandle);
     // FIXME: Should we call 'watchBackPlaneCorrRcd_.check(setup)' as well?
     //        Otherwise could be that next check has to check via following 'else', though
     //        no new IOV has started... (to be checked)
   } else {
     if (watchBackPlaneCorrRcd_.check(setup)) {  // new IOV of input - but how to check peak vs deco?
-      setup.get<SiStripBackPlaneCorrectionRcd>().get(readoutModeName_, backPlaneCorrHandle);
+      backPlaneCorrHandle = &setup.getData(backPlaneCorrToken_);
+
       if (backPlaneCorrHandle->getBackPlaneCorrections()               // but only bad if non-identical values
           != siStripBackPlaneCorrInput_->getBackPlaneCorrections()) {  // (comparing maps)
         // Maps are containers sorted by key, but comparison problems may arise from

--- a/Alignment/CommonAlignmentAlgorithm/plugins/SiStripBackplaneCalibration.cc
+++ b/Alignment/CommonAlignmentAlgorithm/plugins/SiStripBackplaneCalibration.cc
@@ -29,7 +29,6 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"

--- a/Alignment/CommonAlignmentAlgorithm/plugins/SiStripBackplaneCalibration.cc
+++ b/Alignment/CommonAlignmentAlgorithm/plugins/SiStripBackplaneCalibration.cc
@@ -55,7 +55,7 @@
 class SiStripBackplaneCalibration : public IntegratedCalibrationBase {
 public:
   /// Constructor
-  explicit SiStripBackplaneCalibration(const edm::ParameterSet &cfg, edm::ConsumesCollector& iC);
+  explicit SiStripBackplaneCalibration(const edm::ParameterSet &cfg, edm::ConsumesCollector &iC);
 
   /// Destructor
   ~SiStripBackplaneCalibration() override;
@@ -136,18 +136,17 @@ private:
 
   TkModuleGroupSelector *moduleGroupSelector_;
   const edm::ParameterSet moduleGroupSelCfg_;
-  const edm::ESGetToken<SiStripLatency,SiStripLatencyRcd> latencyToken_;
-  const edm::ESGetToken<SiStripLorentzAngle,SiStripLorentzAngleRcd>lorentzAngleToken_;
+  const edm::ESGetToken<SiStripLatency, SiStripLatencyRcd> latencyToken_;
+  const edm::ESGetToken<SiStripLorentzAngle, SiStripLorentzAngleRcd> lorentzAngleToken_;
   const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magFieldToken_;
-  const edm::ESGetToken<SiStripBackPlaneCorrection,SiStripBackPlaneCorrectionRcd>backPlaneCorrToken_;
-
+  const edm::ESGetToken<SiStripBackPlaneCorrection, SiStripBackPlaneCorrectionRcd> backPlaneCorrToken_;
 };
 
 //======================================================================
 //======================================================================
 //======================================================================
 
-SiStripBackplaneCalibration::SiStripBackplaneCalibration(const edm::ParameterSet &cfg, edm::ConsumesCollector& iC)
+SiStripBackplaneCalibration::SiStripBackplaneCalibration(const edm::ParameterSet &cfg, edm::ConsumesCollector &iC)
     : IntegratedCalibrationBase(cfg),
       readoutModeName_(cfg.getParameter<std::string>("readoutMode")),
       saveToDB_(cfg.getParameter<bool>("saveToDB")),
@@ -160,7 +159,7 @@ SiStripBackplaneCalibration::SiStripBackplaneCalibration(const edm::ParameterSet
       latencyToken_(iC.esConsumes()),
       lorentzAngleToken_(iC.esConsumes(edm::ESInputTag("", readoutModeName_))),
       magFieldToken_(iC.esConsumes()),
-      backPlaneCorrToken_(iC.esConsumes(edm::ESInputTag("", readoutModeName_))){
+      backPlaneCorrToken_(iC.esConsumes(edm::ESInputTag("", readoutModeName_))) {
   // SiStripLatency::singleReadOutMode() returns
   // 1: all in peak, 0: all in deco, -1: mixed state
   // (in principle one could treat even mixed state APV by APV...)
@@ -197,7 +196,7 @@ unsigned int SiStripBackplaneCalibration::derivatives(std::vector<ValuesIndexPai
 
   outDerivInds.clear();
 
-  const SiStripLatency* latency;
+  const SiStripLatency *latency;
   latency = &setup.getData(latencyToken_);
   const int16_t mode = latency->singleReadOutMode();
 
@@ -207,16 +206,15 @@ unsigned int SiStripBackplaneCalibration::derivatives(std::vector<ValuesIndexPai
       const int index =
           moduleGroupSelector_->getParameterIndexFromDetId(hit.det()->geographicalId(), eventInfo.eventId().run());
       if (index >= 0) {  // otherwise not treated
-        const MagneticField* magneticField = &setup.getData(magFieldToken_);
+        const MagneticField *magneticField = &setup.getData(magFieldToken_);
         const GlobalVector bField(magneticField->inTesla(hit.det()->surface().position()));
         const LocalVector bFieldLocal(hit.det()->surface().toLocal(bField));
         //std::cout << "SiStripBackplaneCalibration derivatives " << readoutModeName_ << std::endl;
         const double dZ = hit.det()->surface().bounds().thickness();          // it's a float only...
         const double tanPsi = tsos.localParameters().mixedFormatVector()[1];  //float...
 
-
-        const SiStripLorentzAngle* lorentzAngleHandle;
-        lorentzAngleHandle = &setup.getData(lorentzAngleToken_); 
+        const SiStripLorentzAngle *lorentzAngleHandle;
+        lorentzAngleHandle = &setup.getData(lorentzAngleToken_);
         // Yes, mobility (= LA/By) stored in object called LA...
         const double mobility = lorentzAngleHandle->getLorentzAngle(hit.det()->geographicalId());
         // shift due to dead back plane has two parts:
@@ -403,7 +401,7 @@ void SiStripBackplaneCalibration::endOfJob() {
 //======================================================================
 bool SiStripBackplaneCalibration::checkBackPlaneCorrectionInput(const edm::EventSetup &setup,
                                                                 const EventInfo &eventInfo) {
-  const SiStripBackPlaneCorrection * backPlaneCorrHandle;
+  const SiStripBackPlaneCorrection *backPlaneCorrHandle;
   if (!siStripBackPlaneCorrInput_) {
     backPlaneCorrHandle = &setup.getData(backPlaneCorrToken_);
     siStripBackPlaneCorrInput_ = new SiStripBackPlaneCorrection(*backPlaneCorrHandle);

--- a/Alignment/CommonAlignmentAlgorithm/plugins/SiStripBackplaneCalibration.cc
+++ b/Alignment/CommonAlignmentAlgorithm/plugins/SiStripBackplaneCalibration.cc
@@ -156,7 +156,7 @@ SiStripBackplaneCalibration::SiStripBackplaneCalibration(const edm::ParameterSet
       moduleGroupSelector_(nullptr),
       moduleGroupSelCfg_(cfg.getParameter<edm::ParameterSet>("BackplaneModuleGroups")),
       latencyToken_(iC.esConsumes()),
-      lorentzAngleToken_(iC.esConsumes(edm::ESInputTag("", readoutModeName_))),
+      lorentzAngleToken_(iC.esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", readoutModeName_))),
       magFieldToken_(iC.esConsumes()),
       backPlaneCorrToken_(iC.esConsumes(edm::ESInputTag("", readoutModeName_))) {
   // SiStripLatency::singleReadOutMode() returns
@@ -195,8 +195,7 @@ unsigned int SiStripBackplaneCalibration::derivatives(std::vector<ValuesIndexPai
 
   outDerivInds.clear();
 
-  const SiStripLatency *latency;
-  latency = &setup.getData(latencyToken_);
+  const SiStripLatency *latency = &setup.getData(latencyToken_);
   const int16_t mode = latency->singleReadOutMode();
 
   if (mode == readoutMode_) {
@@ -212,8 +211,7 @@ unsigned int SiStripBackplaneCalibration::derivatives(std::vector<ValuesIndexPai
         const double dZ = hit.det()->surface().bounds().thickness();          // it's a float only...
         const double tanPsi = tsos.localParameters().mixedFormatVector()[1];  //float...
 
-        const SiStripLorentzAngle *lorentzAngleHandle;
-        lorentzAngleHandle = &setup.getData(lorentzAngleToken_);
+        const SiStripLorentzAngle *lorentzAngleHandle = &setup.getData(lorentzAngleToken_);
         // Yes, mobility (= LA/By) stored in object called LA...
         const double mobility = lorentzAngleHandle->getLorentzAngle(hit.det()->geographicalId());
         // shift due to dead back plane has two parts:
@@ -400,7 +398,7 @@ void SiStripBackplaneCalibration::endOfJob() {
 //======================================================================
 bool SiStripBackplaneCalibration::checkBackPlaneCorrectionInput(const edm::EventSetup &setup,
                                                                 const EventInfo &eventInfo) {
-  const SiStripBackPlaneCorrection *backPlaneCorrHandle;
+  const SiStripBackPlaneCorrection *backPlaneCorrHandle = nullptr;
   if (!siStripBackPlaneCorrInput_) {
     backPlaneCorrHandle = &setup.getData(backPlaneCorrToken_);
     siStripBackPlaneCorrInput_ = new SiStripBackPlaneCorrection(*backPlaneCorrHandle);

--- a/Alignment/CommonAlignmentAlgorithm/plugins/SiStripLorentzAngleCalibration.cc
+++ b/Alignment/CommonAlignmentAlgorithm/plugins/SiStripLorentzAngleCalibration.cc
@@ -27,7 +27,7 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -53,7 +53,7 @@
 class SiStripLorentzAngleCalibration : public IntegratedCalibrationBase {
 public:
   /// Constructor
-  explicit SiStripLorentzAngleCalibration(const edm::ParameterSet &cfg);
+  explicit SiStripLorentzAngleCalibration(const edm::ParameterSet &cfg, edm::ConsumesCollector& iC);
 
   /// Destructor
   ~SiStripLorentzAngleCalibration() override = default;
@@ -130,20 +130,30 @@ private:
 
   std::unique_ptr<TkModuleGroupSelector> moduleGroupSelector_;
   const edm::ParameterSet moduleGroupSelCfg_;
+
+  const edm::ESGetToken<SiStripLatency,SiStripLatencyRcd> latencyToken_;
+  const edm::ESGetToken<SiStripLorentzAngle,SiStripLorentzAngleRcd>lorentzAngleToken_;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magFieldToken_;
+  const edm::ESGetToken<SiStripBackPlaneCorrection,SiStripBackPlaneCorrectionRcd>backPlaneCorrToken_;
+
 };
 
 //======================================================================
 //======================================================================
 //======================================================================
 
-SiStripLorentzAngleCalibration::SiStripLorentzAngleCalibration(const edm::ParameterSet &cfg)
+SiStripLorentzAngleCalibration::SiStripLorentzAngleCalibration(const edm::ParameterSet &cfg, edm::ConsumesCollector& iC)
     : IntegratedCalibrationBase(cfg),
       readoutModeName_(cfg.getParameter<std::string>("readoutMode")),
       saveToDB_(cfg.getParameter<bool>("saveToDB")),
       recordNameDBwrite_(cfg.getParameter<std::string>("recordNameDBwrite")),
       outFileName_(cfg.getParameter<std::string>("treeFile")),
       mergeFileNames_(cfg.getParameter<std::vector<std::string> >("mergeTreeFiles")),
-      moduleGroupSelCfg_(cfg.getParameter<edm::ParameterSet>("LorentzAngleModuleGroups")) {
+      moduleGroupSelCfg_(cfg.getParameter<edm::ParameterSet>("LorentzAngleModuleGroups")),
+      latencyToken_(iC.esConsumes()),
+      lorentzAngleToken_(iC.esConsumes(edm::ESInputTag("", readoutModeName_))),
+      magFieldToken_(iC.esConsumes()),
+      backPlaneCorrToken_(iC.esConsumes(edm::ESInputTag("", readoutModeName_))) {
   // SiStripLatency::singleReadOutMode() returns
   // 1: all in peak, 0: all in deco, -1: mixed state
   // (in principle one could treat even mixed state APV by APV...)
@@ -180,9 +190,10 @@ void SiStripLorentzAngleCalibration::beginRun(const edm::Run &run, const edm::Ev
     }
   }
 
-  edm::ESHandle<SiStripLorentzAngle> lorentzAngleHandle;
-  const auto &lorentzAngleRcd = setup.get<SiStripLorentzAngleRcd>();
-  lorentzAngleRcd.get(readoutModeName_, lorentzAngleHandle);
+    const SiStripLorentzAngle* lorentzAngleHandle;
+    lorentzAngleHandle= &setup.getData(lorentzAngleToken_);
+    const auto &lorentzAngleRcd = setup.get<SiStripLorentzAngleRcd>();
+ // const SiStripLorentzAngle lorentzAngleRcd = setup.getData(lorentzAngleToken_);
   if (cachedLorentzAngleInputs_.find(firstRun) == cachedLorentzAngleInputs_.end()) {
     cachedLorentzAngleInputs_.emplace(firstRun, SiStripLorentzAngle(*lorentzAngleHandle));
   } else {
@@ -212,8 +223,8 @@ unsigned int SiStripLorentzAngleCalibration::derivatives(std::vector<ValuesIndex
                                                          const EventInfo &eventInfo) const {
   outDerivInds.clear();
 
-  edm::ESHandle<SiStripLatency> latency;
-  setup.get<SiStripLatencyRcd>().get(latency);
+  const SiStripLatency* latency;
+  latency = &setup.getData(latencyToken_);
   const int16_t mode = latency->singleReadOutMode();
   if (mode == readoutMode_) {
     if (hit.det()) {  // otherwise 'constraint hit' or whatever
@@ -221,8 +232,7 @@ unsigned int SiStripLorentzAngleCalibration::derivatives(std::vector<ValuesIndex
       const int index =
           moduleGroupSelector_->getParameterIndexFromDetId(hit.det()->geographicalId(), eventInfo.eventId().run());
       if (index >= 0) {  // otherwise not treated
-        edm::ESHandle<MagneticField> magneticField;
-        setup.get<IdealMagneticFieldRecord>().get(magneticField);
+        const MagneticField* magneticField = &setup.getData(magFieldToken_);
         const GlobalVector bField(magneticField->inTesla(hit.det()->surface().position()));
         const LocalVector bFieldLocal(hit.det()->surface().toLocal(bField));
         const double dZ = this->effectiveThickness(hit.det(), mode, setup);

--- a/Alignment/CommonAlignmentAlgorithm/plugins/SiStripLorentzAngleCalibration.cc
+++ b/Alignment/CommonAlignmentAlgorithm/plugins/SiStripLorentzAngleCalibration.cc
@@ -150,7 +150,7 @@ SiStripLorentzAngleCalibration::SiStripLorentzAngleCalibration(const edm::Parame
       mergeFileNames_(cfg.getParameter<std::vector<std::string> >("mergeTreeFiles")),
       moduleGroupSelCfg_(cfg.getParameter<edm::ParameterSet>("LorentzAngleModuleGroups")),
       latencyToken_(iC.esConsumes()),
-      lorentzAngleToken_(iC.esConsumes(edm::ESInputTag("", readoutModeName_))),
+      lorentzAngleToken_(iC.esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", readoutModeName_))),
       magFieldToken_(iC.esConsumes()),
       backPlaneCorrToken_(iC.esConsumes(edm::ESInputTag("", readoutModeName_))) {
   // SiStripLatency::singleReadOutMode() returns
@@ -189,8 +189,7 @@ void SiStripLorentzAngleCalibration::beginRun(const edm::Run &run, const edm::Ev
     }
   }
 
-  const SiStripLorentzAngle *lorentzAngleHandle;
-  lorentzAngleHandle = &setup.getData(lorentzAngleToken_);
+  const SiStripLorentzAngle *lorentzAngleHandle = &setup.getData(lorentzAngleToken_);
   const auto &lorentzAngleRcd = setup.get<SiStripLorentzAngleRcd>();
   if (cachedLorentzAngleInputs_.find(firstRun) == cachedLorentzAngleInputs_.end()) {
     cachedLorentzAngleInputs_.emplace(firstRun, SiStripLorentzAngle(*lorentzAngleHandle));
@@ -221,8 +220,7 @@ unsigned int SiStripLorentzAngleCalibration::derivatives(std::vector<ValuesIndex
                                                          const EventInfo &eventInfo) const {
   outDerivInds.clear();
 
-  const SiStripLatency *latency;
-  latency = &setup.getData(latencyToken_);
+  const SiStripLatency *latency = &setup.getData(latencyToken_);
   const int16_t mode = latency->singleReadOutMode();
   if (mode == readoutMode_) {
     if (hit.det()) {  // otherwise 'constraint hit' or whatever

--- a/Alignment/CommonAlignmentAlgorithm/plugins/SiStripLorentzAngleCalibration.cc
+++ b/Alignment/CommonAlignmentAlgorithm/plugins/SiStripLorentzAngleCalibration.cc
@@ -192,7 +192,6 @@ void SiStripLorentzAngleCalibration::beginRun(const edm::Run &run, const edm::Ev
   const SiStripLorentzAngle *lorentzAngleHandle;
   lorentzAngleHandle = &setup.getData(lorentzAngleToken_);
   const auto &lorentzAngleRcd = setup.get<SiStripLorentzAngleRcd>();
-  // const SiStripLorentzAngle lorentzAngleRcd = setup.getData(lorentzAngleToken_);
   if (cachedLorentzAngleInputs_.find(firstRun) == cachedLorentzAngleInputs_.end()) {
     cachedLorentzAngleInputs_.emplace(firstRun, SiStripLorentzAngle(*lorentzAngleHandle));
   } else {

--- a/Alignment/CommonAlignmentAlgorithm/plugins/SiStripLorentzAngleCalibration.cc
+++ b/Alignment/CommonAlignmentAlgorithm/plugins/SiStripLorentzAngleCalibration.cc
@@ -400,10 +400,9 @@ double SiStripLorentzAngleCalibration::effectiveThickness(const GeomDet *det,
     return 0.;
   double dZ = det->surface().bounds().thickness();  // it is a float only...
   const SiStripDetId id(det->geographicalId());
-  edm::ESHandle<SiStripBackPlaneCorrection> backPlaneHandle;
+  const SiStripBackPlaneCorrection *backPlaneHandle = &setup.getData(backPlaneCorrToken_);
   // FIXME: which one? DepRcd->get(handle) or Rcd->get(readoutModeName_, handle)??
   // setup.get<SiStripBackPlaneCorrectionDepRcd>().get(backPlaneHandle); // get correct mode
-  setup.get<SiStripBackPlaneCorrectionRcd>().get(readoutModeName_, backPlaneHandle);
   const double bpCor = backPlaneHandle->getBackPlaneCorrection(id);  // it's a float...
   //  std::cout << "bpCor " << bpCor << " in subdet " << id.subdetId() << std::endl;
   dZ *= (1. - bpCor);

--- a/Alignment/CommonAlignmentAlgorithm/plugins/SiStripLorentzAngleCalibration.cc
+++ b/Alignment/CommonAlignmentAlgorithm/plugins/SiStripLorentzAngleCalibration.cc
@@ -53,7 +53,7 @@
 class SiStripLorentzAngleCalibration : public IntegratedCalibrationBase {
 public:
   /// Constructor
-  explicit SiStripLorentzAngleCalibration(const edm::ParameterSet &cfg, edm::ConsumesCollector& iC);
+  explicit SiStripLorentzAngleCalibration(const edm::ParameterSet &cfg, edm::ConsumesCollector &iC);
 
   /// Destructor
   ~SiStripLorentzAngleCalibration() override = default;
@@ -131,18 +131,17 @@ private:
   std::unique_ptr<TkModuleGroupSelector> moduleGroupSelector_;
   const edm::ParameterSet moduleGroupSelCfg_;
 
-  const edm::ESGetToken<SiStripLatency,SiStripLatencyRcd> latencyToken_;
-  const edm::ESGetToken<SiStripLorentzAngle,SiStripLorentzAngleRcd>lorentzAngleToken_;
+  const edm::ESGetToken<SiStripLatency, SiStripLatencyRcd> latencyToken_;
+  const edm::ESGetToken<SiStripLorentzAngle, SiStripLorentzAngleRcd> lorentzAngleToken_;
   const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magFieldToken_;
-  const edm::ESGetToken<SiStripBackPlaneCorrection,SiStripBackPlaneCorrectionRcd>backPlaneCorrToken_;
-
+  const edm::ESGetToken<SiStripBackPlaneCorrection, SiStripBackPlaneCorrectionRcd> backPlaneCorrToken_;
 };
 
 //======================================================================
 //======================================================================
 //======================================================================
 
-SiStripLorentzAngleCalibration::SiStripLorentzAngleCalibration(const edm::ParameterSet &cfg, edm::ConsumesCollector& iC)
+SiStripLorentzAngleCalibration::SiStripLorentzAngleCalibration(const edm::ParameterSet &cfg, edm::ConsumesCollector &iC)
     : IntegratedCalibrationBase(cfg),
       readoutModeName_(cfg.getParameter<std::string>("readoutMode")),
       saveToDB_(cfg.getParameter<bool>("saveToDB")),
@@ -190,10 +189,10 @@ void SiStripLorentzAngleCalibration::beginRun(const edm::Run &run, const edm::Ev
     }
   }
 
-    const SiStripLorentzAngle* lorentzAngleHandle;
-    lorentzAngleHandle= &setup.getData(lorentzAngleToken_);
-    const auto &lorentzAngleRcd = setup.get<SiStripLorentzAngleRcd>();
- // const SiStripLorentzAngle lorentzAngleRcd = setup.getData(lorentzAngleToken_);
+  const SiStripLorentzAngle *lorentzAngleHandle;
+  lorentzAngleHandle = &setup.getData(lorentzAngleToken_);
+  const auto &lorentzAngleRcd = setup.get<SiStripLorentzAngleRcd>();
+  // const SiStripLorentzAngle lorentzAngleRcd = setup.getData(lorentzAngleToken_);
   if (cachedLorentzAngleInputs_.find(firstRun) == cachedLorentzAngleInputs_.end()) {
     cachedLorentzAngleInputs_.emplace(firstRun, SiStripLorentzAngle(*lorentzAngleHandle));
   } else {
@@ -223,7 +222,7 @@ unsigned int SiStripLorentzAngleCalibration::derivatives(std::vector<ValuesIndex
                                                          const EventInfo &eventInfo) const {
   outDerivInds.clear();
 
-  const SiStripLatency* latency;
+  const SiStripLatency *latency;
   latency = &setup.getData(latencyToken_);
   const int16_t mode = latency->singleReadOutMode();
   if (mode == readoutMode_) {
@@ -232,7 +231,7 @@ unsigned int SiStripLorentzAngleCalibration::derivatives(std::vector<ValuesIndex
       const int index =
           moduleGroupSelector_->getParameterIndexFromDetId(hit.det()->geographicalId(), eventInfo.eventId().run());
       if (index >= 0) {  // otherwise not treated
-        const MagneticField* magneticField = &setup.getData(magFieldToken_);
+        const MagneticField *magneticField = &setup.getData(magFieldToken_);
         const GlobalVector bField(magneticField->inTesla(hit.det()->surface().position()));
         const LocalVector bFieldLocal(hit.det()->surface().toLocal(bField));
         const double dZ = this->effectiveThickness(hit.det(), mode, setup);

--- a/Alignment/CommonAlignmentProducer/interface/AlignmentProducerBase.h
+++ b/Alignment/CommonAlignmentProducer/interface/AlignmentProducerBase.h
@@ -143,7 +143,7 @@ private:
   void createMonitors(edm::ConsumesCollector&);
 
   /// Creates the calibrations
-  void createCalibrations();
+  void createCalibrations(edm::ConsumesCollector&);
 
   /// Checks if one of the EventSetup-Records has changed
   bool setupChanged(const edm::EventSetup&);

--- a/Alignment/CommonAlignmentProducer/src/AlignmentProducerBase.cc
+++ b/Alignment/CommonAlignmentProducer/src/AlignmentProducerBase.cc
@@ -93,7 +93,7 @@ AlignmentProducerBase::AlignmentProducerBase(const edm::ParameterSet& config, ed
 
   createAlignmentAlgorithm(iC);
   createMonitors(iC);
-  createCalibrations();
+  createCalibrations(iC);
 }
 
 //------------------------------------------------------------------------------
@@ -297,11 +297,11 @@ void AlignmentProducerBase::createMonitors(edm::ConsumesCollector& iC) {
 }
 
 //------------------------------------------------------------------------------
-void AlignmentProducerBase::createCalibrations() {
+void AlignmentProducerBase::createCalibrations(edm::ConsumesCollector& iC) {
   const auto& calibrations = config_.getParameter<edm::VParameterSet>("calibrations");
   for (const auto& iCalib : calibrations) {
-    calibrations_.emplace_back(
-        IntegratedCalibrationPluginFactory::get()->create(iCalib.getParameter<std::string>("calibrationName"), iCalib));
+    calibrations_.emplace_back(IntegratedCalibrationPluginFactory::get()->create(
+        iCalib.getParameter<std::string>("calibrationName"), iCalib, iC));
   }
 }
 


### PR DESCRIPTION
#### PR description:

This PR completes the consumes migration of Alignment/CommonAlignmentAlgorithm package. Resolves https://github.com/cms-AlCaDB/AlCaTools/issues/44

#### PR validation:

WF 1001.0 ran successfully.

1001.0_RunMinBias2011A+RunMinBias2011A+TIER0EXP+ALCAEXP+ALCAHARVDSIPIXELCALRUN1+ALCAHARVD1+ALCAHARVD2+ALCAHARVD3+ALCAHARVD4+ALCAHARVD5+ALCAHARVD7 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED Step5-PASSED Step6-PASSED Step7-PASSED Step8-PASSED Step9-PASSED  - time date Wed Oct 27 13:41:09 2021-date Wed Oct 27 13:32:12 2021; exit: 0 0 0 0 0 0 0 0 0 0
1 1 1 1 1 1 1 1 1 1 tests passed, 0 0 0 0 0 0 0 0 0 0 failed


#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not a backport, no backport is needed.