### PR TITLE
Move Phase2 wf in the short matrix to D77

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_2026.py
+++ b/Configuration/PyReleaseValidation/python/relval_2026.py
@@ -24,9 +24,11 @@ numWFIB.extend([28234.0]) #2026D60
 numWFIB.extend([31434.0]) #2026D68
 numWFIB.extend([32234.0]) #2026D70
 numWFIB.extend([34634.0]) #2026D76
-numWFIB.extend([34834.999]) #2026D76 premixing combined stage1+stage2 (ttbar+PU50 for PR test)
+numWFIB.extend([34834.99,34834.999]) #2026D76 premixing combined stage1+stage2 (ttbar+PU200, ttbar+PU50 for PR test)
 numWFIB.extend([34634.21,34834.21,34834.9921]) #2026D76 prodlike, prodlike PU, prodlike premix stage1+stage2
 numWFIB.extend([35034.0]) #2026D77
+numWFIB.extend([35234.99,35234.999]) #2026D77 premixing combined stage1+stage2 (ttbar+PU200, ttbar+PU50 for PR test)
+numWFIB.extend([35034.21,35234.21,35234.9921]) #2026D77 prodlike, prodlike PU, prodlike premix stage1+stage2
 numWFIB.extend([35434.0]) #2026D78
 numWFIB.extend([35834.0]) #2026D79
 numWFIB.extend([36234.0]) #2026D80

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -3327,6 +3327,7 @@ defaultDataSets['2023']='CMSSW_12_0_0_pre4-120X_mcRun3_2023_realistic_v2-v'
 defaultDataSets['2024']='CMSSW_12_0_0_pre4-120X_mcRun3_2024_realistic_v2-v'
 defaultDataSets['2026D49']='CMSSW_12_0_0_pre4-113X_mcRun4_realistic_v7_2026D49noPU-v'
 defaultDataSets['2026D76']='CMSSW_12_0_0_pre4-113X_mcRun4_realistic_v7_2026D76noPU-v'
+defaultDataSets['2026D77']='CMSSW_12_1_0_pre2-113X_mcRun4_realistic_v7_2026D77noPU-v'
 
 puDataSets = {}
 for key, value in defaultDataSets.items(): puDataSets[key+'PU'] = value

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -95,8 +95,8 @@ if __name__ == '__main__':
                      12434.0, #2023 ttbar
                      23234.0, #2026D49 ttbar (HLT TDR baseline w/ HGCal v11)
                      28234.0, #2026D60 (exercise HF nose)
-                     34634.0, #2026D76 ttbar (2021 new baseline)
-                     34834.999, #2026D76 ttbar premixing stage1+stage2, PU50
+                     35034.0, #2026D77 ttbar (2021 new baseline)
+                     35234.999, #2026D77 ttbar premixing stage1+stage2, PU50
                      38634.0, #2026D86 ttbar
                      25202.0, #2016 ttbar UP15 PU
                      250202.181, #2018 ttbar stage1 + stage2 premix


### PR DESCRIPTION
#### PR description:
As title said, we move PR test workflows of Phase-2 to D77 following the green light of PdmV, to move the D77 relvals from CMSSW_12_1_0_pre5. I use this chance also to define missing PU200 D76, in case it will be used for any testing in PR test.

https://its.cern.ch/jira/projects/PDMVRELVALS/issues/PDMVRELVALS-139

#### PR validation:
-

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
No need of backport.
