### PR TITLE
 TkDQM: PixelPhase1 Summary plots

### DIFF
--- a/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
@@ -13,7 +13,7 @@ if 'unitTest=True' in sys.argv:
     unitTest=True
 
 #set to false for lxplus offline testing
-#live=False
+live=False
 offlineTesting=not live
 
 TAG ="PixelPhase1" 

--- a/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
@@ -13,7 +13,7 @@ if 'unitTest=True' in sys.argv:
     unitTest=True
 
 #set to false for lxplus offline testing
-live=False
+#live=False
 offlineTesting=not live
 
 TAG ="PixelPhase1" 

--- a/DQM/SiPixelPhase1Summary/interface/SiPixelPhase1Summary.h
+++ b/DQM/SiPixelPhase1Summary/interface/SiPixelPhase1Summary.h
@@ -78,6 +78,7 @@ private:
 
   //Error thresholds for the dead ROC plots
   std::vector<double> deadRocThresholds_;
+  std::vector<double> deadRocWarnThresholds_;
 
   //book the summary plots
   void bookSummaries(DQMStore::IBooker& iBooker);

--- a/DQM/SiPixelPhase1Summary/python/SiPixelPhase1Summary_cfi.py
+++ b/DQM/SiPixelPhase1Summary/python/SiPixelPhase1Summary_cfi.py
@@ -35,7 +35,8 @@ SiPixelPhase1SummaryOnline = DQMEDHarvester("SiPixelPhase1Summary",
             )
         ),
     # Number of dead ROCs required to generate an error. Order must be layers 1-4, ring1, ring2.
-    DeadROCErrorThreshold = cms.vdouble(0.2,0.2,0.2,0.2,0.2,0.2)
+    DeadROCErrorThreshold = cms.vdouble(0.2,0.2,0.2,0.2,0.2,0.2),
+    DeadROCWarningThreshold = cms.vdouble(0.1,0.1,0.1,0.1,0.1,0.1)
 )
 
 SiPixelPhase1SummaryOffline = DQMEDHarvester("SiPixelPhase1Summary",

--- a/DQM/SiPixelPhase1Summary/python/SiPixelPhase1Summary_cfi.py
+++ b/DQM/SiPixelPhase1Summary/python/SiPixelPhase1Summary_cfi.py
@@ -68,8 +68,8 @@ SiPixelPhase1SummaryOffline = DQMEDHarvester("SiPixelPhase1Summary",
             MapHist = cms.string("mean_charge")
             )
         ),
-        DeadROCErrorThreshold = cms.vdouble(0.2,0.2,0.2,0.2,0.2,0.2)
-
+        DeadROCErrorThreshold = cms.vdouble(0.2,0.2,0.2,0.2,0.2,0.2),
+        DeadROCWarningThreshold = cms.vdouble(0.1,0.1,0.1,0.1,0.1,0.1)
 )
 
 SiPixelPhase1SummaryCosmics = DQMEDHarvester("SiPixelPhase1Summary",
@@ -93,7 +93,8 @@ SiPixelPhase1SummaryCosmics = DQMEDHarvester("SiPixelPhase1Summary",
             MapHist = cms.string("mean_charge")
             )
         ),
-        DeadROCErrorThreshold = cms.vdouble(0.2,0.2,0.2,0.2,0.2,0.2)
+        DeadROCErrorThreshold = cms.vdouble(0.2,0.2,0.2,0.2,0.2,0.2),
+        DeadROCWarningThreshold = cms.vdouble(0.1,0.1,0.1,0.1,0.1,0.1)
 )
 
 from DQMServices.Core.DQMQualityTester import DQMQualityTester

--- a/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
+++ b/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
@@ -343,21 +343,6 @@ void SiPixelPhase1Summary::fillSummaries(DQMStore::IBooker& iBooker, DQMStore::I
 
           sumOfNonNegBins += summaryMap_["Grand"]->getBinContent(i + 1, j + 1);
         }
-        if (i == 1 && j > 1) {
-          summaryMap_["Grand"]->setBinContent(i + 1, j + 1, -1);
-        } else {
-          if (deadROCSummary->getBinContent(i + 1, j + 1) < deadRocWarnThresholds_[i * 4 + j])
-            summaryMap_["Grand"]->setBinContent(i + 1, j + 1, 1);
-
-          else if (deadROCSummary->getBinContent(i + 1, j + 1) > deadRocWarnThresholds_[i * 4 + j] &&
-                   deadROCSummary->getBinContent(i + 1, j + 1) < deadRocThresholds_[i * 4 + j])
-            summaryMap_["Grand"]->setBinContent(i + 1, j + 1, 0.8);
-
-          else
-            summaryMap_["Grand"]->setBinContent(i + 1, j + 1, 0);
-
-          sumOfNonNegBins += summaryMap_["Grand"]->getBinContent(i + 1, j + 1);
-        }
       }
     }
   }

--- a/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
+++ b/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
@@ -250,12 +250,12 @@ void SiPixelPhase1Summary::fillSummaries(DQMStore::IBooker& iBooker, DQMStore::I
                        << ((i > 3) ? ((minus) ? "-" : "+") : "") << (j + 1);
         histName = histNameStream.str();
         MonitorElement* me = iGetter.get(histName);
-	
+
         if (!me) {
           edm::LogWarning("SiPixelPhase1Summary") << "ME " << histName << " is not available !!";
           continue;  // Ignore non-existing MEs, as this can cause the whole thing to crash
         }
-	
+
         if (summaryMap_[name] == nullptr) {
           edm::LogWarning("SiPixelPhase1Summary") << "Summary map " << name << " is not available !!";
           continue;  // Based on reported errors it seems possible that we're trying to access a non-existant summary map, so if the map doesn't exist but we're trying to access it here we'll skip it instead.
@@ -287,11 +287,11 @@ void SiPixelPhase1Summary::fillSummaries(DQMStore::IBooker& iBooker, DQMStore::I
     deadROCSummary->setBinContent(2, 3, -1);
     deadROCSummary->setBinContent(2, 4, -1);
 =======
-    deadROCSummary->setBinContent( 2, 3, -1 );
-    deadROCSummary->setBinContent( 2, 4, -1 );
+    deadROCSummary->setBinContent(2, 3, -1);
+    deadROCSummary->setBinContent(2, 4, -1);
 >>>>>>> c133370fadb77d8f7a171d98ca7ee4ab5600c34d
   }
-  
+
   //Sum of non-negative bins for the reportSummary
   float sumOfNonNegBins = 0.;
   //Now we will use the other summary maps to create the overall map.
@@ -304,9 +304,9 @@ void SiPixelPhase1Summary::fillSummaries(DQMStore::IBooker& iBooker, DQMStore::I
       }
       for (int j = 0; j < 4; j++) {  // !??!?!? yAxisLabels_.size() ?!?!?!
         summaryMap_["Grand"]->setBinContent(
-					    i + 1,
-					    j + 1,
-					    1);  // This resets the map to be good. We only then set it to 0 if there has been a problem in one of the other summaries.
+            i + 1,
+            j + 1,
+            1);  // This resets the map to be good. We only then set it to 0 if there has been a problem in one of the other summaries.
         for (auto const& mapInfo : summaryPlotName_) {  //Check summary maps
           auto name = mapInfo.first;
           if (summaryMap_[name] == nullptr) {
@@ -350,23 +350,21 @@ void SiPixelPhase1Summary::fillSummaries(DQMStore::IBooker& iBooker, DQMStore::I
           sumOfNonNegBins += summaryMap_["Grand"]->getBinContent(i + 1, j + 1);
         }
 =======
-        if (i == 1 && j > 1)
-	  {
-	    summaryMap_["Grand"]->setBinContent( i+1,  j+1,  -1);
-	  }
-	else
-	  { 
-	    if (deadROCSummary->getBinContent(i + 1, j + 1) < deadRocWarnThresholds_[i * 4 + j])
-	      summaryMap_["Grand"]->setBinContent(i + 1, j + 1, 1);
-	    
-	    else if (deadROCSummary->getBinContent(i + 1, j + 1) > deadRocWarnThresholds_[i*4 + j] && deadROCSummary->getBinContent(i + 1, j + 1) < deadRocThresholds_[i * 4 + j])
-	      summaryMap_["Grand"]->setBinContent(i + 1, j + 1, 0.8);
-	    
-	    else
-	      summaryMap_["Grand"]->setBinContent(i + 1, j + 1, 0);
-	    
-	    sumOfNonNegBins += summaryMap_["Grand"]->getBinContent(i + 1, j + 1);
-	  }
+        if (i == 1 && j > 1) {
+          summaryMap_["Grand"]->setBinContent(i + 1, j + 1, -1);
+        } else {
+          if (deadROCSummary->getBinContent(i + 1, j + 1) < deadRocWarnThresholds_[i * 4 + j])
+            summaryMap_["Grand"]->setBinContent(i + 1, j + 1, 1);
+
+          else if (deadROCSummary->getBinContent(i + 1, j + 1) > deadRocWarnThresholds_[i * 4 + j] &&
+                   deadROCSummary->getBinContent(i + 1, j + 1) < deadRocThresholds_[i * 4 + j])
+            summaryMap_["Grand"]->setBinContent(i + 1, j + 1, 0.8);
+
+          else
+            summaryMap_["Grand"]->setBinContent(i + 1, j + 1, 0);
+
+          sumOfNonNegBins += summaryMap_["Grand"]->getBinContent(i + 1, j + 1);
+        }
 >>>>>>> c133370fadb77d8f7a171d98ca7ee4ab5600c34d
       }
     }
@@ -379,7 +377,7 @@ void SiPixelPhase1Summary::fillTrendPlots(DQMStore::IBooker& iBooker, DQMStore::
   // If we're running in online mode and the lumi section is not modulo 10, return. Offline running always uses lumiSec=0, so it will pass this test.
   if (lumiSec % 10 != 0)
     return;
-  
+
   if (runOnEndLumi_) {
     MonitorElement* nClustersAll = iGetter.get("PixelPhase1/Phase1_MechanicalView/num_clusters_per_Lumisection_PXAll");
     if (nClustersAll == nullptr) {

--- a/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
+++ b/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
@@ -283,13 +283,8 @@ void SiPixelPhase1Summary::fillSummaries(DQMStore::IBooker& iBooker, DQMStore::I
       nROCs = tempProfile->GetBinContent(i + 1);
     }
     deadROCSummary->setBinContent(xBin, yBin, nROCs / nRocsPerTrend[i]);
-<<<<<<< HEAD
     deadROCSummary->setBinContent(2, 3, -1);
     deadROCSummary->setBinContent(2, 4, -1);
-=======
-    deadROCSummary->setBinContent(2, 3, -1);
-    deadROCSummary->setBinContent(2, 4, -1);
->>>>>>> c133370fadb77d8f7a171d98ca7ee4ab5600c34d
   }
 
   //Sum of non-negative bins for the reportSummary
@@ -333,7 +328,6 @@ void SiPixelPhase1Summary::fillSummaries(DQMStore::IBooker& iBooker, DQMStore::I
       }
       for (int j = 0; j < 4; j++) {  // !??!?!? yAxisLabels_.size() ?!?!?!
         //Ignore the bins without detectors in them
-<<<<<<< HEAD
         if (i == 1 && j > 1) {
           summaryMap_["Grand"]->setBinContent(i + 1, j + 1, -1);
         } else {
@@ -349,7 +343,6 @@ void SiPixelPhase1Summary::fillSummaries(DQMStore::IBooker& iBooker, DQMStore::I
 
           sumOfNonNegBins += summaryMap_["Grand"]->getBinContent(i + 1, j + 1);
         }
-=======
         if (i == 1 && j > 1) {
           summaryMap_["Grand"]->setBinContent(i + 1, j + 1, -1);
         } else {
@@ -365,7 +358,6 @@ void SiPixelPhase1Summary::fillSummaries(DQMStore::IBooker& iBooker, DQMStore::I
 
           sumOfNonNegBins += summaryMap_["Grand"]->getBinContent(i + 1, j + 1);
         }
->>>>>>> c133370fadb77d8f7a171d98ca7ee4ab5600c34d
       }
     }
   }


### PR DESCRIPTION
#### Title: 

TkDQM: PixelPhase1 Summary plots 

#### PR description:

The aim of this PR is to Implement a 3 state (GOOD, WARNING, ERROR) Summary Maps for PixelPhase1 in ONLINE DQM.  Pixel online client tested locally over RAW data. 

#### Links of the last presentation in TkDQM bi-weekly meeting:

https://indico.cern.ch/event/1000820/#b-407796-tracker-dqm 

#### PR validation:

Checks are done with workflow 136.892 and no changes are observed.

#### If this PR is a backport please specify the original PR and why you need to backport that PR:

NA 
