### PR TITLE
remove unit test in RecoTauTag/HLTProducers

### DIFF
--- a/RecoTauTag/HLTProducers/test/BuildFile.xml
+++ b/RecoTauTag/HLTProducers/test/BuildFile.xml
@@ -1,7 +1,0 @@
-<environment>
-  <bin file="runtestRecoTauTagHLTProducers.cpp">
-    <flags TEST_RUNNER_ARGS=" /bin/bash RecoTauTag/HLTProducers/test runtests.sh"/>
-    <use name="FWCore/Utilities"/>
-  </bin>
-
-</environment>

--- a/RecoTauTag/HLTProducers/test/runtestRecoTauTagHLTProducers.cpp
+++ b/RecoTauTag/HLTProducers/test/runtestRecoTauTagHLTProducers.cpp
@@ -1,3 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-
-RUNTEST()

--- a/RecoTauTag/HLTProducers/test/runtests.sh
+++ b/RecoTauTag/HLTProducers/test/runtests.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-function die { echo $1: status $2 ;  exit $2; }
-
-cmsRun ${LOCAL_TEST_DIR}/testL2TauTagNN.py maxEvents=10 || die 'Failure using testL2TauTagNN.py' $?


### PR DESCRIPTION
#### PR description:

This PR removes a unit test introduced in #35640 (blame it on @missirol).
Policy is not to run the full HLT menu (+customisations) to test individual modules; see discussion in #35863.
A much simpler unit test for the module in question could be designed in the future.

#### PR validation:

Code compiles.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

N/A