### PR TITLE
[DQM] Add ZeroBias to DT Online DQM [12_0_X]

### DIFF
--- a/DQM/Integration/python/clients/dt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/dt_dqm_sourceclient-live_cfg.py
@@ -41,7 +41,7 @@ process.dqmSaverPB.runNumber = options.runNumber
 #Enable HLT*Mu* filtering to monitor on Muon events
 #OR HLT_Physics* to monitor FEDs in commissioning runs
 if not unitTest:
-    process.source.SelectEvents = cms.untracked.vstring("HLT*Mu*","HLT_*Physics*",'HLT_ZeroBias*')
+    process.source.SelectEvents = cms.untracked.vstring("HLT*Mu*","HLT_*Physics*","HLT_ZeroBias*")
 
 # DT reco and DQM sequences
 process.load("Configuration.StandardSequences.GeometryRecoDB_cff")

--- a/DQM/Integration/python/clients/dt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/dt_dqm_sourceclient-live_cfg.py
@@ -41,7 +41,7 @@ process.dqmSaverPB.runNumber = options.runNumber
 #Enable HLT*Mu* filtering to monitor on Muon events
 #OR HLT_Physics* to monitor FEDs in commissioning runs
 if not unitTest:
-    process.source.SelectEvents = cms.untracked.vstring("HLT*Mu*","HLT_*Physics*")
+    process.source.SelectEvents = cms.untracked.vstring("HLT*Mu*","HLT_*Physics*",'HLT_ZeroBias*')
 
 # DT reco and DQM sequences
 process.load("Configuration.StandardSequences.GeometryRecoDB_cff")


### PR DESCRIPTION
#### PR description:

Add the ZeroBias HLT path to DT Online DQM client in order to get more data during Beam Test. 
This PR is not meant to be merged, we would just need it to be integrated locally at P5.

#### PR validation:

Just tested with ipython.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

PR to the CMSSW release which is presently used at P5.