### PR TITLE
Fix: exclude main PV from OtherPV_z in nano

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/VertexTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/VertexTableProducer.cc
@@ -135,9 +135,13 @@ void VertexTableProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
   auto otherPVsTable =
       std::make_unique<nanoaod::FlatTable>((*pvsIn).size() > 4 ? 3 : (*pvsIn).size() - 1, "Other" + pvName_, false);
   std::vector<float> pvsz;
-  for (size_t i = 1; i < (*pvsIn).size() && i < 4; i++)
+  std::vector<float> pvscores;
+  for (size_t i = 1; i < (*pvsIn).size() && i < 4; i++) {
     pvsz.push_back((*pvsIn)[i].position().z());
+    pvscores.push_back((*pvsScoreIn).get(pvsIn.id(), i));
+  }
   otherPVsTable->addColumn<float>("z", pvsz, "Z position of other primary vertices, excluding the main PV", 8);
+  otherPVsTable->addColumn<float>("score", pvscores, "scores of other primary vertices, excluding the main PV", 8);
 
   edm::Handle<edm::View<reco::VertexCompositePtrCandidate>> svsIn;
   iEvent.getByToken(svs_, svsIn);

--- a/PhysicsTools/NanoAOD/plugins/VertexTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/VertexTableProducer.cc
@@ -136,7 +136,7 @@ void VertexTableProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
       std::make_unique<nanoaod::FlatTable>((*pvsIn).size() > 4 ? 3 : (*pvsIn).size() - 1, "Other" + pvName_, false);
   std::vector<float> pvsz;
   for (size_t i = 1; i < (*pvsIn).size() && i < 4; i++)
-    pvsz.push_back((*pvsIn)[i - 1].position().z());
+    pvsz.push_back((*pvsIn)[i].position().z());
   otherPVsTable->addColumn<float>("z", pvsz, "Z position of other primary vertices, excluding the main PV", 8);
 
   edm::Handle<edm::View<reco::VertexCompositePtrCandidate>> svsIn;

--- a/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
@@ -551,6 +551,7 @@ nanoDQM = DQMEDAnalyzer("NanoAODDQM",
             plots = cms.VPSet(
                 NoPlot('_size'),
                 Plot1D('z', 'z', 20, -20, 20, 'Z position of other primary vertices, excluding the main PV'),
+                Plot1D('score', 'score', 20, 0, 300000, 'scores of other primary vertices, excluding the main PV'),
             )
         ),
         PPSLocalTrack = cms.PSet(


### PR DESCRIPTION
#### PR description:

- Exclude main PV from the list of other PVs 
- Add scores for other PVs, as discussed with @mariadalfonso 