### PR TITLE
remove message from unexpected CTP7 firmware ID

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Setup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Setup.cc
@@ -78,8 +78,8 @@ namespace l1t {
           //    res[0] = UnpackerFactory::get()->make("stage2::CaloLayer1Unpacker_v2");
           // }
           else {
-           // edm::LogWarning("L1T")
-           //     << "CaloLayer1Setup: unexpected CTP7 firmware ID, will try unpacking with default unpacker anyway";
+            // edm::LogWarning("L1T")
+            //     << "CaloLayer1Setup: unexpected CTP7 firmware ID, will try unpacking with default unpacker anyway";
             res[0] = UnpackerFactory::get()->make("stage2::CaloLayer1Unpacker");
           }
         }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Setup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Setup.cc
@@ -78,8 +78,8 @@ namespace l1t {
           //    res[0] = UnpackerFactory::get()->make("stage2::CaloLayer1Unpacker_v2");
           // }
           else {
-            edm::LogWarning("L1T")
-                << "CaloLayer1Setup: unexpected CTP7 firmware ID, will try unpacking with default unpacker anyway";
+           // edm::LogWarning("L1T")
+           //     << "CaloLayer1Setup: unexpected CTP7 firmware ID, will try unpacking with default unpacker anyway";
             res[0] = UnpackerFactory::get()->make("stage2::CaloLayer1Unpacker");
           }
         }


### PR DESCRIPTION
#### PR description:

This PR is just to comment out two lines to remove message from unexpected CTP7 firmware ID, which is causing hassle for debugging the ongoing collisions. Functionality is not changed.