### PR TITLE
OMTF o2o upgrade

### DIFF
--- a/CondCore/L1TPlugins/src/UpgradeRecords2.cc
+++ b/CondCore/L1TPlugins/src/UpgradeRecords2.cc
@@ -14,6 +14,9 @@
 #include "CondFormats/DataRecord/interface/L1TMuonEndCapForestRcd.h"
 #include "CondFormats/DataRecord/interface/L1TMuonEndCapForestO2ORcd.h"
 
+#include "CondFormats/L1TObjects/interface/L1TMuonOverlapFwVersion.h"
+#include "CondFormats/DataRecord/interface/L1TMuonOverlapFwVersionRcd.h"
+#include "CondFormats/DataRecord/interface/L1TMuonOverlapFwVersionO2ORcd.h"
 #include "CondFormats/L1TObjects/interface/L1TMuonOverlapParams.h"
 #include "CondFormats/DataRecord/interface/L1TMuonOverlapParamsRcd.h"
 #include "CondFormats/DataRecord/interface/L1TMuonOverlapParamsO2ORcd.h"
@@ -32,6 +35,7 @@ REGISTER_PLUGIN(L1TMuonEndcapParamsRcd, L1TMuonEndCapParams);  // Temporary copy
 
 REGISTER_PLUGIN(L1TMuonEndCapParamsRcd, L1TMuonEndCapParams);
 REGISTER_PLUGIN(L1TMuonEndCapForestRcd, L1TMuonEndCapForest);
+REGISTER_PLUGIN(L1TMuonOverlapFwVersionRcd, L1TMuonOverlapFwVersion);
 REGISTER_PLUGIN(L1TMuonOverlapParamsRcd, L1TMuonOverlapParams);
 REGISTER_PLUGIN(L1TMuonBarrelParamsRcd, L1TMuonBarrelParams);
 REGISTER_PLUGIN(L1TMuonBarrelKalmanParamsRcd, L1TMuonBarrelKalmanParams);
@@ -39,6 +43,7 @@ REGISTER_PLUGIN(L1TMuonGlobalParamsRcd, L1TMuonGlobalParams);
 
 REGISTER_PLUGIN(L1TMuonEndCapParamsO2ORcd, L1TMuonEndCapParams);
 REGISTER_PLUGIN(L1TMuonEndCapForestO2ORcd, L1TMuonEndCapForest);
+REGISTER_PLUGIN(L1TMuonOverlapFwVersionO2ORcd, L1TMuonOverlapFwVersion);
 REGISTER_PLUGIN(L1TMuonOverlapParamsO2ORcd, L1TMuonOverlapParams);
 REGISTER_PLUGIN(L1TMuonBarrelParamsO2ORcd, L1TMuonBarrelParams);
 REGISTER_PLUGIN(L1TMuonGlobalParamsO2ORcd, L1TMuonGlobalParams);

--- a/CondCore/Utilities/plugins/Module_2XML.cc
+++ b/CondCore/Utilities/plugins/Module_2XML.cc
@@ -192,6 +192,7 @@ PAYLOAD_2XML_MODULE(pluginUtilities_payload2xml) {
   PAYLOAD_2XML_CLASS(L1TMuonEndCapParams);
   PAYLOAD_2XML_CLASS(L1TMuonGlobalParams);
   PAYLOAD_2XML_CLASS(L1TMuonOverlapParams);
+  PAYLOAD_2XML_CLASS(L1TMuonOverlapFwVersion);
   PAYLOAD_2XML_CLASS(L1TUtmAlgorithm);
   PAYLOAD_2XML_CLASS(L1TUtmBin);
   PAYLOAD_2XML_CLASS(L1TUtmCondition);

--- a/CondCore/Utilities/plugins/Module_2XML.cc
+++ b/CondCore/Utilities/plugins/Module_2XML.cc
@@ -203,6 +203,8 @@ PAYLOAD_2XML_MODULE(pluginUtilities_payload2xml) {
   PAYLOAD_2XML_CLASS(L1TUtmTriggerMenu);
   PAYLOAD_2XML_CLASS(L1TriggerKey);
   PAYLOAD_2XML_CLASS(L1TriggerKeyList);
+  PAYLOAD_2XML_CLASS(L1TriggerKeyExt);
+  PAYLOAD_2XML_CLASS(L1TriggerKeyListExt);
   PAYLOAD_2XML_CLASS(LHCInfo);
   PAYLOAD_2XML_CLASS(METCorrectorParametersCollection);
   PAYLOAD_2XML_CLASS(MEtXYcorrectParametersCollection);

--- a/CondCore/Utilities/src/CondFormats.h
+++ b/CondCore/Utilities/src/CondFormats.h
@@ -262,6 +262,8 @@
 #include "CondFormats/L1TObjects/interface/L1TGlobalPrescalesVetosFract.h"
 #include "CondFormats/L1TObjects/interface/L1TriggerKey.h"
 #include "CondFormats/L1TObjects/interface/L1TriggerKeyList.h"
+#include "CondFormats/L1TObjects/interface/L1TriggerKeyExt.h"
+#include "CondFormats/L1TObjects/interface/L1TriggerKeyListExt.h"
 #include "CondFormats/PhysicsToolsObjects/interface/Histogram3D.h"
 #include "CondFormats/PhysicsToolsObjects/interface/PerformancePayload.h"
 #include "CondFormats/PhysicsToolsObjects/interface/PerformancePayloadFromTFormula.h"

--- a/CondCore/Utilities/src/CondFormats.h
+++ b/CondCore/Utilities/src/CondFormats.h
@@ -248,6 +248,7 @@
 #include "CondFormats/L1TObjects/interface/L1TMuonEndCapParams.h"
 #include "CondFormats/L1TObjects/interface/L1TMuonGlobalParams.h"
 #include "CondFormats/L1TObjects/interface/L1TMuonOverlapParams.h"
+#include "CondFormats/L1TObjects/interface/L1TMuonOverlapFwVersion.h"
 #include "CondFormats/L1TObjects/interface/L1TUtmAlgorithm.h"
 #include "CondFormats/L1TObjects/interface/L1TUtmBin.h"
 #include "CondFormats/L1TObjects/interface/L1TUtmCondition.h"

--- a/CondFormats/DataRecord/interface/L1TMuonOverlapFwVersionO2ORcd.h
+++ b/CondFormats/DataRecord/interface/L1TMuonOverlapFwVersionO2ORcd.h
@@ -1,0 +1,30 @@
+#ifndef L1TMTFOverlapFwVersionRcd_L1TMuonOverlapFwVersionO2ORcd_h
+#define L1TMTFOverlapFwVersionRcd_L1TMuonOverlapFwVersionO2ORcd_h
+// -*- C++ -*-
+//
+// Package:     CondFormats/DataRecord
+// Class  :     L1TMuonOverlapFwVersionRcd
+//
+/**\class L1TMuonOverlapFwVersionRcd L1TMuonOverlapFwVersionRcd.h CondFormats/DataRecord/interface/L1TMuonOverlapFwVersionRcd.h
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Author:      Michal Szleper
+// Created:     Wed, 20 Oct 2020 13:55:50 GMT
+//
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+#include "CondFormats/DataRecord/interface/L1TriggerKeyListExtRcd.h"
+#include "CondFormats/DataRecord/interface/L1TriggerKeyExtRcd.h"
+#include "CondFormats/DataRecord/interface/L1TMuonOverlapFwVersionRcd.h"
+class L1TMuonOverlapFwVersionO2ORcd
+    : public edm::eventsetup::DependentRecordImplementation<
+          L1TMuonOverlapFwVersionO2ORcd,
+          edm::mpl::Vector<L1TriggerKeyListExtRcd, L1TriggerKeyExtRcd, L1TMuonOverlapFwVersionRcd> > {};
+
+#endif

--- a/CondFormats/DataRecord/interface/L1TMuonOverlapFwVersionRcd.h
+++ b/CondFormats/DataRecord/interface/L1TMuonOverlapFwVersionRcd.h
@@ -20,6 +20,7 @@
 
 #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 
-class L1TMuonOverlapFwVersionRcd : public edm::eventsetup::EventSetupRecordImplementation<L1TMuonOverlapFwVersionRcd> {};
+class L1TMuonOverlapFwVersionRcd : public edm::eventsetup::EventSetupRecordImplementation<L1TMuonOverlapFwVersionRcd> {
+};
 
 #endif

--- a/CondFormats/DataRecord/interface/L1TMuonOverlapFwVersionRcd.h
+++ b/CondFormats/DataRecord/interface/L1TMuonOverlapFwVersionRcd.h
@@ -1,0 +1,25 @@
+#ifndef L1TMTFOverlapFwVersionRcd_L1TMTFOverlapFwVersionRcd_h
+#define L1TMTFOverlapFwVersionRcd_L1TMTFOverlapFwVersionRcd_h
+// -*- C++ -*-
+//
+// Package:     CondFormats/DataRecord
+// Class  :     L1TMuonOverlapFwVersionRcd
+//
+/**\class L1TMuonOverlapFwVersionRcd L1TMuonOverlapFwVersionRcd.h CondFormats/DataRecord/interface/L1TMuonOverlapFwVersionRcd.h
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Author:      Michal Szleper
+// Created:     Wed, 20 May 2020 13:50:35 GMT
+//
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class L1TMuonOverlapFwVersionRcd : public edm::eventsetup::EventSetupRecordImplementation<L1TMuonOverlapFwVersionRcd> {};
+
+#endif

--- a/CondFormats/DataRecord/src/L1TMuonOverlapFwVersionO2ORcd.cc
+++ b/CondFormats/DataRecord/src/L1TMuonOverlapFwVersionO2ORcd.cc
@@ -1,0 +1,15 @@
+// -*- C++ -*-
+//
+// Package:     CondFormats/DataRecord
+// Class  :     L1TMuonOverlapFwVersionRcd
+//
+// Implementation:
+//     [Notes on implementation]
+//
+// Author:      Michal Szleper
+// Created:     Wed, 20 Oct 2020 13:58:35 GMT
+
+#include "CondFormats/DataRecord/interface/L1TMuonOverlapFwVersionO2ORcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(L1TMuonOverlapFwVersionO2ORcd);

--- a/CondFormats/DataRecord/src/L1TMuonOverlapFwVersionRcd.cc
+++ b/CondFormats/DataRecord/src/L1TMuonOverlapFwVersionRcd.cc
@@ -1,0 +1,15 @@
+// -*- C++ -*-
+//
+// Package:     CondFormats/DataRecord
+// Class  :     L1TMuonOverlapFwVersionRcd
+//
+// Implementation:
+//     [Notes on implementation]
+//
+// Author:      Michal Szleper
+// Created:     Wed, 20 Oct 2020 13:57:35 GMT
+
+#include "CondFormats/DataRecord/interface/L1TMuonOverlapFwVersionRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(L1TMuonOverlapFwVersionRcd);

--- a/CondFormats/L1TObjects/interface/L1TMuonOverlapFwVersion.h
+++ b/CondFormats/L1TObjects/interface/L1TMuonOverlapFwVersion.h
@@ -13,14 +13,14 @@
 ///////////////////////////////////////
 class L1TMuonOverlapFwVersion {
 public:
-
   L1TMuonOverlapFwVersion() {
     algorithmVer_ = 0x110;
     layersVer_ = 0x6;
     patternsVer_ = 0x3;
     synthDate_ = "2018-9-18 21:26:2";
   }
-  L1TMuonOverlapFwVersion(unsigned algoV, unsigned layersV, unsigned patternsV, std::string sDate){
+  L1TMuonOverlapFwVersion(unsigned algoV, unsigned layersV, unsigned patternsV, std::string
+sDate){
     algorithmVer_ = algoV;
     layersVer_ = layersV;
     patternsVer_ = patternsV;

--- a/CondFormats/L1TObjects/interface/L1TMuonOverlapFwVersion.h
+++ b/CondFormats/L1TObjects/interface/L1TMuonOverlapFwVersion.h
@@ -21,10 +21,10 @@ public:
     synthDate_ = "2018-9-18 21:26:2";
   }
   L1TMuonOverlapFwVersion(unsigned algoV, unsigned layersV, unsigned patternsV, std::string sDate){
-   algorithmVer_ = algoV;
-   layersVer_ = layersV;
-   patternsVer_ = patternsV;
-   synthDate_ = sDate;
+    algorithmVer_ = algoV;
+    layersVer_ = layersV;
+    patternsVer_ = patternsV;
+    synthDate_ = sDate;
   }
   ~L1TMuonOverlapFwVersion() {}
 

--- a/CondFormats/L1TObjects/interface/L1TMuonOverlapFwVersion.h
+++ b/CondFormats/L1TObjects/interface/L1TMuonOverlapFwVersion.h
@@ -19,8 +19,7 @@ public:
     patternsVer_ = 0x3;
     synthDate_ = "2018-9-18 21:26:2";
   }
-  L1TMuonOverlapFwVersion(unsigned algoV, unsigned layersV, unsigned patternsV, std::string
-sDate){
+  L1TMuonOverlapFwVersion(unsigned algoV, unsigned layersV, unsigned patternsV, std::string sDate) {
     algorithmVer_ = algoV;
     layersVer_ = layersV;
     patternsVer_ = patternsV;

--- a/CondFormats/L1TObjects/interface/L1TMuonOverlapFwVersion.h
+++ b/CondFormats/L1TObjects/interface/L1TMuonOverlapFwVersion.h
@@ -1,0 +1,50 @@
+#ifndef L1TMuonOverlapFwVersion_h
+#define L1TMuonOverlapFwVersion_h
+
+#include <memory>
+#include <iostream>
+#include <vector>
+#include <cmath>
+
+#include "CondFormats/Serialization/interface/Serializable.h"
+#include "CondFormats/L1TObjects/interface/LUT.h"
+
+///////////////////////////////////////
+///////////////////////////////////////
+class L1TMuonOverlapFwVersion {
+public:
+
+  L1TMuonOverlapFwVersion() {
+    algorithmVer_ = 0x110;
+    layersVer_ = 0x6;
+    patternsVer_ = 0x3;
+    synthDate_ = "2018-9-18 21:26:2";
+  }
+  L1TMuonOverlapFwVersion(unsigned algoV, unsigned layersV, unsigned patternsV, std::string sDate){
+   algorithmVer_ = algoV;
+   layersVer_ = layersV;
+   patternsVer_ = patternsV;
+   synthDate_ = sDate;
+  }
+  ~L1TMuonOverlapFwVersion() {}
+
+  unsigned algoVersion() const { return algorithmVer_; }
+  unsigned layersVersion() const { return layersVer_; }
+  unsigned fwVersion() const { return layersVer_; }
+  unsigned patternsVersion() const { return patternsVer_; }
+  std::string synthDate() const { return synthDate_; }
+  void setAlgoVersion(unsigned algoV) { algorithmVer_ = algoV; }
+  void setLayersVersion(unsigned layersV) { layersVer_ = layersV; }
+  void setFwVersion(unsigned layersV) { layersVer_ = layersV; }
+  void setPatternsVersion(unsigned patternsV) { patternsVer_ = patternsV; }
+  void setSynthDate(std::string sDate) { synthDate_ = sDate; }
+
+  ///Firmware configuration parameters
+  unsigned algorithmVer_;
+  unsigned layersVer_;
+  unsigned patternsVer_;
+  std::string synthDate_;
+
+  COND_SERIALIZABLE;
+};
+#endif

--- a/CondFormats/L1TObjects/src/L1TMuonOverlapFwVersion.cc
+++ b/CondFormats/L1TObjects/src/L1TMuonOverlapFwVersion.cc
@@ -1,0 +1,1 @@
+#include "CondFormats/L1TObjects/interface/L1TMuonOverlapFwVersion.h"

--- a/CondFormats/L1TObjects/src/T_EventSetup_L1TMuonOverlapFwVersion.cc
+++ b/CondFormats/L1TObjects/src/T_EventSetup_L1TMuonOverlapFwVersion.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/L1TObjects/interface/L1TMuonOverlapFwVersion.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+TYPELOOKUP_DATA_REG(L1TMuonOverlapFwVersion);

--- a/CondFormats/L1TObjects/src/classes.h
+++ b/CondFormats/L1TObjects/src/classes.h
@@ -51,6 +51,7 @@
 #include "CondFormats/L1TObjects/interface/CaloConfig.h"
 
 #include "CondFormats/L1TObjects/interface/L1TMuonOverlapParams.h"
+#include "CondFormats/L1TObjects/interface/L1TMuonOverlapFwVersion.h"
 #include "CondFormats/L1TObjects/interface/L1TMuonGlobalParams.h"
 #include "CondFormats/L1TObjects/interface/L1TMuonBarrelParams.h"
 #include "CondFormats/L1TObjects/interface/L1TMuonBarrelKalmanParams.h"
@@ -96,6 +97,8 @@ namespace CondFormats_L1TObjects {
     //    std::vector<L1RPCConeDefinition::TLPSize> dummy15;
     //    std::vector<L1RPCConeDefinition::TRingToTower> dummy15a;
     //    std::vector<L1RPCConeDefinition::TRingToLP> dummy15b;
+    L1TMuonOverlapFwVersion dummy15;
+
     L1TMuonGlobalParams dummy16;
     std::vector<L1TMuonGlobalParams::Node> dummy16a;
 

--- a/CondFormats/L1TObjects/src/classes_def.xml
+++ b/CondFormats/L1TObjects/src/classes_def.xml
@@ -11,6 +11,9 @@
     <field name="uparams_" mapping="blob"/>  
   </class>
 
+  <class name="L1TMuonOverlapFwVersion">
+  </class>
+
   <class name="L1TMuonEndCapParams">
   </class>
 

--- a/CondTools/L1TriggerExt/plugins/SealModule.cc
+++ b/CondTools/L1TriggerExt/plugins/SealModule.cc
@@ -61,6 +61,11 @@ REGISTER_L1_WRITER(L1TMuonEndCapParamsO2ORcd, L1TMuonEndCapParams);
 
 REGISTER_L1_WRITER(L1TMuonEndCapForestO2ORcd, L1TMuonEndCapForest);
 
+#include "CondFormats/L1TObjects/interface/L1TMuonOverlapFwVersion.h"
+#include "CondFormats/DataRecord/interface/L1TMuonOverlapFwVersionO2ORcd.h"
+
+REGISTER_L1_WRITER(L1TMuonOverlapFwVersionO2ORcd, L1TMuonOverlapFwVersion);
+
 #include "CondFormats/L1TObjects/interface/L1TMuonOverlapParams.h"
 #include "CondFormats/DataRecord/interface/L1TMuonOverlapParamsO2ORcd.h"
 

--- a/CondTools/L1TriggerExt/python/L1CondEnumExt_cfi.py
+++ b/CondTools/L1TriggerExt/python/L1CondEnumExt_cfi.py
@@ -11,5 +11,6 @@ class L1CondEnumExt:
     L1TCaloParams=7
     L1TGlobalPrescalesVetosFract=8
     L1TMuonEndCapForest=9
-    NumL1Cond=10
+    L1TMuonOverlapFwVersion=10
+    NumL1Cond=11
     

--- a/CondTools/L1TriggerExt/python/L1ConfigTSCPayloadsExt_cff.py
+++ b/CondTools/L1TriggerExt/python/L1ConfigTSCPayloadsExt_cff.py
@@ -2,6 +2,7 @@ from L1TriggerConfig.L1TConfigProducers.L1TUtmTriggerMenuOnline_cfi import *
 from L1TriggerConfig.L1TConfigProducers.L1TMuonBarrelParamsOnline_cfi import *
 from L1TriggerConfig.L1TConfigProducers.L1TMuonGlobalParamsOnline_cfi import *
 from L1TriggerConfig.L1TConfigProducers.L1TMuonOverlapParamsOnline_cfi import *
+from L1TriggerConfig.L1TConfigProducers.L1TMuonOverlapFwVersionOnline_cfi import *
 from L1TriggerConfig.L1TConfigProducers.L1TMuonEndCapParamsOnline_cfi import *
 from L1TriggerConfig.L1TConfigProducers.L1TMuonEndCapForestOnline_cfi import *
 from L1TriggerConfig.L1TConfigProducers.L1TCaloParamsOnline_cfi import *
@@ -16,6 +17,7 @@ def setTSCPayloadsDB(process, DBConnect, DBAuth, protoDBConnect, protoDBAuth):
     process.L1TMuonEndCapForestOnlineProd.onlineDB     = cms.string( DBConnect )
     process.L1TMuonGlobalParamsOnlineProd.onlineDB     = cms.string( DBConnect )
     process.L1TMuonOverlapParamsOnlineProd.onlineDB    = cms.string( DBConnect )
+    process.L1TMuonOverlapFwVersionOnlineProd.onlineDB = cms.string( DBConnect )
     process.L1TUtmTriggerMenuOnlineProd.onlineDB       = cms.string( DBConnect )
 
     process.L1TCaloParamsOnlineProd.onlineAuthentication           = cms.string( DBAuth )
@@ -25,15 +27,18 @@ def setTSCPayloadsDB(process, DBConnect, DBAuth, protoDBConnect, protoDBAuth):
     process.L1TMuonEndCapForestOnlineProd.onlineAuthentication     = cms.string( DBAuth )
     process.L1TMuonGlobalParamsOnlineProd.onlineAuthentication     = cms.string( DBAuth )
     process.L1TMuonOverlapParamsOnlineProd.onlineAuthentication    = cms.string( DBAuth )
+    process.L1TMuonOverlapFwVersionOnlineProd.onlineAuthentication = cms.string( DBAuth )
     process.L1TUtmTriggerMenuOnlineProd.onlineAuthentication       = cms.string( DBAuth )
 
     process.l1caloparProtodb.connect                         = cms.string( protoDBConnect )
     process.l1bmtfparProtodb.connect                         = cms.string( protoDBConnect )
     process.l1emtfparProtodb.connect                         = cms.string( protoDBConnect )
+#    process.l1omtfparProtodb.connect                         = cms.string( protoDBConnect )
     process.l1gmtparProtodb.connect                          = cms.string( protoDBConnect )
     process.l1caloparProtodb.DBParameters.authenticationPath = cms.untracked.string( protoDBAuth )
     process.l1bmtfparProtodb.DBParameters.authenticationPath = cms.untracked.string( protoDBAuth )
     process.l1emtfparProtodb.DBParameters.authenticationPath = cms.untracked.string( protoDBAuth )
+#    process.l1omtfparProtodb.DBParameters.authenticationPath = cms.untracked.string( protoDBAuth )
     process.l1gmtparProtodb.DBParameters.authenticationPath  = cms.untracked.string( protoDBAuth )
 
 def liftPayloadSafetyFor(process, systems):
@@ -55,4 +60,5 @@ def liftPayloadSafetyFor(process, systems):
 
     if 'OMTF' in systems:
         process.L1TMuonOverlapParamsOnlineProd.transactionSafe    = cms.bool(False)
+        process.L1TMuonOverlapFwVersionOnlineProd.transactionSafe = cms.bool(False)
 

--- a/CondTools/L1TriggerExt/python/L1O2OTagsExt_cfi.py
+++ b/CondTools/L1TriggerExt/python/L1O2OTagsExt_cfi.py
@@ -11,6 +11,7 @@ def initL1O2OTagsExt():
     initL1O2OTagsExt.tagBaseVec[ L1CondEnumExt.L1TUtmTriggerMenu ] = "Stage2v0_hlt"
     initL1O2OTagsExt.tagBaseVec[ L1CondEnumExt.L1TGlobalPrescalesVetosFract ] = "Stage2v0_hlt"
     initL1O2OTagsExt.tagBaseVec[ L1CondEnumExt.L1TMuonBarrelParams ] = "Stage2v1_hlt"
+    initL1O2OTagsExt.tagBaseVec[ L1CondEnumExt.L1TMuonOverlapFwVersion ] = "Stage2v0_hlt"
     initL1O2OTagsExt.tagBaseVec[ L1CondEnumExt.L1TMuonOverlapParams ] = "Stage2v0_hlt"
     initL1O2OTagsExt.tagBaseVec[ L1CondEnumExt.L1TMuonEndCapParams ] = "Stage2v3_hlt"
     initL1O2OTagsExt.tagBaseVec[ L1CondEnumExt.L1TMuonEndCapForest ] = "Stage2v1_hlt"

--- a/CondTools/L1TriggerExt/python/L1SubsystemParamsExt_cfi.py
+++ b/CondTools/L1TriggerExt/python/L1SubsystemParamsExt_cfi.py
@@ -42,6 +42,12 @@ def initL1SubsystemsExt( tagBaseVec = [],
             key = cms.string(objectKey)
         ),
         cms.PSet(
+            record = cms.string('L1TMuonOverlapFwVersionO2ORcd'),
+            tag = cms.string('L1TMuonOverlapFwVersion_' + tagBaseVec[ L1CondEnumExt.L1TMuonOverlapFwVersion ]),
+            type = cms.string('L1TMuonOverlapFwVersion'),
+            key = cms.string(objectKey)
+        ),
+        cms.PSet(
             record = cms.string('L1TMuonOverlapParamsO2ORcd'),
             tag = cms.string('L1TMuonOverlapParams_' + tagBaseVec[ L1CondEnumExt.L1TMuonOverlapParams ]),
             type = cms.string('L1TMuonOverlapParams'),

--- a/L1Trigger/L1TMuonOverlap/plugins/L1TMuonOverlapFwVersionESProducer.cc
+++ b/L1Trigger/L1TMuonOverlap/plugins/L1TMuonOverlapFwVersionESProducer.cc
@@ -12,7 +12,6 @@
 #include "L1Trigger/L1TMuonOverlap/plugins/L1TMuonOverlapFwVersionESProducer.h"
 
 L1TMuonOverlapFwVersionESProducer::L1TMuonOverlapFwVersionESProducer(const edm::ParameterSet& theConfig) {
-
   setWhatProduced(this, &L1TMuonOverlapFwVersionESProducer::produceFwVersion);
 
   unsigned algoV = theConfig.getParameter<unsigned>("algoVersion");
@@ -27,7 +26,8 @@ L1TMuonOverlapFwVersionESProducer::L1TMuonOverlapFwVersionESProducer(const edm::
 
 L1TMuonOverlapFwVersionESProducer::~L1TMuonOverlapFwVersionESProducer() {}
 
-L1TMuonOverlapFwVersionESProducer::ReturnType L1TMuonOverlapFwVersionESProducer::produceFwVersion(const L1TMuonOverlapFwVersionRcd& iRecord) {
+L1TMuonOverlapFwVersionESProducer::ReturnType L1TMuonOverlapFwVersionESProducer::produceFwVersion(
+    const L1TMuonOverlapFwVersionRcd& iRecord) {
   return std::make_unique<L1TMuonOverlapFwVersion>(params);
 }
 

--- a/L1Trigger/L1TMuonOverlap/plugins/L1TMuonOverlapFwVersionESProducer.cc
+++ b/L1Trigger/L1TMuonOverlap/plugins/L1TMuonOverlapFwVersionESProducer.cc
@@ -1,0 +1,35 @@
+#include "sstream"
+
+// user include files
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ESProducts.h"
+
+#include "CondFormats/L1TObjects/interface/L1TMuonOverlapFwVersion.h"
+#include "CondFormats/DataRecord/interface/L1TMuonOverlapFwVersionRcd.h"
+
+#include "L1Trigger/L1TMuonOverlap/plugins/L1TMuonOverlapFwVersionESProducer.h"
+
+L1TMuonOverlapFwVersionESProducer::L1TMuonOverlapFwVersionESProducer(const edm::ParameterSet& theConfig) {
+
+  setWhatProduced(this, &L1TMuonOverlapFwVersionESProducer::produceFwVersion);
+
+  unsigned algoV = theConfig.getParameter<unsigned>("algoVersion");
+  unsigned layersV = theConfig.getParameter<unsigned>("layersVersion");
+  unsigned patternsV = theConfig.getParameter<unsigned>("patternsVersion");
+  std::string sDate = theConfig.getParameter<std::string>("synthDate");
+  params.setAlgoVersion(algoV);
+  params.setLayersVersion(layersV);
+  params.setPatternsVersion(patternsV);
+  params.setSynthDate(sDate);
+}
+
+L1TMuonOverlapFwVersionESProducer::~L1TMuonOverlapFwVersionESProducer() {}
+
+L1TMuonOverlapFwVersionESProducer::ReturnType L1TMuonOverlapFwVersionESProducer::produceFwVersion(const L1TMuonOverlapFwVersionRcd& iRecord) {
+  return std::make_unique<L1TMuonOverlapFwVersion>(params);
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_EVENTSETUP_MODULE(L1TMuonOverlapFwVersionESProducer);

--- a/L1Trigger/L1TMuonOverlap/plugins/L1TMuonOverlapFwVersionESProducer.h
+++ b/L1Trigger/L1TMuonOverlap/plugins/L1TMuonOverlapFwVersionESProducer.h
@@ -1,0 +1,24 @@
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ESProducts.h"
+
+#include "CondFormats/L1TObjects/interface/L1TMuonOverlapFwVersion.h"
+#include "CondFormats/DataRecord/interface/L1TMuonOverlapFwVersionRcd.h"
+
+class L1TMuonOverlapFwVersionESProducer : public edm::ESProducer {
+public:
+  L1TMuonOverlapFwVersionESProducer(const edm::ParameterSet&);
+  ~L1TMuonOverlapFwVersionESProducer() override;
+
+  using ReturnType = std::unique_ptr<L1TMuonOverlapFwVersion>;
+
+  ReturnType produceFwVersion(const L1TMuonOverlapFwVersionRcd&);
+
+private:
+  L1TMuonOverlapFwVersion params;
+};

--- a/L1Trigger/L1TMuonOverlap/python/fakeOmtfFwVersion_cff.py
+++ b/L1Trigger/L1TMuonOverlap/python/fakeOmtfFwVersion_cff.py
@@ -1,0 +1,18 @@
+import FWCore.ParameterSet.Config as cms
+
+omtfFwVersionSource = cms.ESSource(
+    "EmptyESSource",
+    recordName = cms.string('L1TMuonOverlapFwVersionRcd'),
+    iovIsRunNotTime = cms.bool(True),
+    firstValid = cms.vuint32(1)
+)
+
+###OMTF FW ESProducer.
+omtfFwVersion = cms.ESProducer(
+    "L1TMuonOverlapFwVersionESProducer",
+    algoVersion = cms.uint32(0x110),
+    layersVersion = cms.uint32(6),
+    patternsVersion = cms.uint32(3),
+    synthDate = cms.string("2001-01-01 00:00")
+)
+

--- a/L1TriggerConfig/L1TConfigProducers/python/L1TMuonOverlapFwVersionOnline_cfi.py
+++ b/L1TriggerConfig/L1TConfigProducers/python/L1TMuonOverlapFwVersionOnline_cfi.py
@@ -1,0 +1,26 @@
+import FWCore.ParameterSet.Config as cms
+
+from L1Trigger.L1TMuonOverlap.fakeOmtfFwVersion_cff import *
+
+#from CondCore.CondDB.CondDB_cfi import CondDB
+#CondDB.connect = cms.string('oracle://cms_orcon_prod/CMS_CONDITIONS')
+#CondDB.connect = cms.string('oracle://cms_orcon_adg/CMS_CONDITIONS')
+#CondDB.connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS')
+
+#l1omtfparProtodb = cms.ESSource("PoolDBESSource",
+#       CondDB,
+#       toGet = cms.VPSet(
+#            cms.PSet(
+#                 record = cms.string('L1TMuonOverlapFwVersionRcd'),
+#                 tag    = cms.string("L1TMuonOverlapFwVersionPrototype_Stage2v0_hlt")
+#            )
+#       )
+#)
+
+L1TMuonOverlapFwVersionOnlineProd = cms.ESProducer("L1TMuonOverlapFwVersionOnlineProd",
+    onlineAuthentication = cms.string('.'),
+    forceGeneration      = cms.bool(False),
+    onlineDB             = cms.string('oracle://CMS_OMDS_LB/CMS_TRG_R'),
+#    onlineDB             = cms.string('oracle://cms_omds_adg/CMS_TRG_R'),
+    transactionSafe      = cms.bool(True) # nothrow guarantee if set to False: carry on no matter what
+)

--- a/L1TriggerConfig/L1TConfigProducers/python/L1TMuonOverlapFwVersionOnline_cfi.py
+++ b/L1TriggerConfig/L1TConfigProducers/python/L1TMuonOverlapFwVersionOnline_cfi.py
@@ -2,25 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 from L1Trigger.L1TMuonOverlap.fakeOmtfFwVersion_cff import *
 
-#from CondCore.CondDB.CondDB_cfi import CondDB
-#CondDB.connect = cms.string('oracle://cms_orcon_prod/CMS_CONDITIONS')
-#CondDB.connect = cms.string('oracle://cms_orcon_adg/CMS_CONDITIONS')
-#CondDB.connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS')
-
-#l1omtfparProtodb = cms.ESSource("PoolDBESSource",
-#       CondDB,
-#       toGet = cms.VPSet(
-#            cms.PSet(
-#                 record = cms.string('L1TMuonOverlapFwVersionRcd'),
-#                 tag    = cms.string("L1TMuonOverlapFwVersionPrototype_Stage2v0_hlt")
-#            )
-#       )
-#)
-
 L1TMuonOverlapFwVersionOnlineProd = cms.ESProducer("L1TMuonOverlapFwVersionOnlineProd",
     onlineAuthentication = cms.string('.'),
     forceGeneration      = cms.bool(False),
     onlineDB             = cms.string('oracle://CMS_OMDS_LB/CMS_TRG_R'),
-#    onlineDB             = cms.string('oracle://cms_omds_adg/CMS_TRG_R'),
     transactionSafe      = cms.bool(True) # nothrow guarantee if set to False: carry on no matter what
 )

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapFwVersionOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapFwVersionOnlineProd.cc
@@ -12,33 +12,35 @@
 #include "xercesc/util/PlatformUtils.hpp"
 using namespace XERCES_CPP_NAMESPACE;
 
-class L1TMuonOverlapFwVersionOnlineProd : public L1ConfigOnlineProdBaseExt<L1TMuonOverlapFwVersionO2ORcd, L1TMuonOverlapFwVersion> {
+class L1TMuonOverlapFwVersionOnlineProd
+    : public L1ConfigOnlineProdBaseExt<L1TMuonOverlapFwVersionO2ORcd, L1TMuonOverlapFwVersion> {
 private:
   const bool transactionSafe;
   const edm::ESGetToken<L1TMuonOverlapFwVersion, L1TMuonOverlapFwVersionRcd> baseSettings_token;
 
 public:
-  std::unique_ptr<const L1TMuonOverlapFwVersion> newObject(const std::string& objectKey, const L1TMuonOverlapFwVersionO2ORcd& record) override;
+  std::unique_ptr<const L1TMuonOverlapFwVersion> newObject(const std::string& objectKey,
+                                                           const L1TMuonOverlapFwVersionO2ORcd& record) override;
 
   L1TMuonOverlapFwVersionOnlineProd(const edm::ParameterSet&);
   ~L1TMuonOverlapFwVersionOnlineProd(void) override {}
 };
 
 void replaceAll(std::string& str, const std::string& from, const std::string& to) {
-  if(from.empty())
+  if (from.empty())
     return;
   size_t start_pos = 0;
-  while((start_pos = str.find(from, start_pos)) != std::string::npos) {
+  while ((start_pos = str.find(from, start_pos)) != std::string::npos) {
     str.replace(start_pos, from.length(), to);
     start_pos += to.length();
   }
 }
 
 void removeAll(std::string& str, const std::string& from, const std::string& to) {
-  if(from.empty())
+  if (from.empty())
     return;
   size_t start_pos = 0;
-  while((start_pos = str.find(from, start_pos)) != std::string::npos) {
+  while ((start_pos = str.find(from, start_pos)) != std::string::npos) {
     size_t end_pos = str.find(to) + to.length();
     int length = end_pos - start_pos;
     str.replace(start_pos, length, "");
@@ -47,21 +49,22 @@ void removeAll(std::string& str, const std::string& from, const std::string& to)
 
 L1TMuonOverlapFwVersionOnlineProd::L1TMuonOverlapFwVersionOnlineProd(const edm::ParameterSet& iConfig)
     : L1ConfigOnlineProdBaseExt<L1TMuonOverlapFwVersionO2ORcd, L1TMuonOverlapFwVersion>(iConfig),
-    transactionSafe(iConfig.getParameter<bool>("transactionSafe")),
-    baseSettings_token(wrappedSetWhatProduced(iConfig).consumes()) {}
+      transactionSafe(iConfig.getParameter<bool>("transactionSafe")),
+      baseSettings_token(wrappedSetWhatProduced(iConfig).consumes()) {}
 
 std::unique_ptr<const L1TMuonOverlapFwVersion> L1TMuonOverlapFwVersionOnlineProd::newObject(
     const std::string& objectKey, const L1TMuonOverlapFwVersionO2ORcd& record) {
-
   const L1TMuonOverlapFwVersionRcd& baseRcd = record.template getRecord<L1TMuonOverlapFwVersionRcd>();
   auto const& baseSettings = baseRcd.get(baseSettings_token);
 
   if (objectKey.empty()) {
-    edm::LogError("L1-O2O: L1TMuonOverlapFwVersionOnlineProd") << "Key is empty, returning empty L1TMuonOverlapFwVersion";
+    edm::LogError("L1-O2O: L1TMuonOverlapFwVersionOnlineProd")
+        << "Key is empty, returning empty L1TMuonOverlapFwVersion";
     if (transactionSafe)
       throw std::runtime_error("SummaryForFunctionManager: OMTF  | Faulty  | Empty objectKey");
     else {
-      edm::LogError("L1-O2O: L1TMuonOverlapFwVersionOnlineProd") << "returning unmodified prototype of L1TMuonOverlapFwVersion";
+      edm::LogError("L1-O2O: L1TMuonOverlapFwVersionOnlineProd")
+          << "returning unmodified prototype of L1TMuonOverlapFwVersion";
       return std::make_unique<const L1TMuonOverlapFwVersion>(baseSettings);
     }
   }
@@ -73,7 +76,6 @@ std::unique_ptr<const L1TMuonOverlapFwVersion> L1TMuonOverlapFwVersionOnlineProd
   std::string algoV_string, layersV_string, patternsV_string, synthDate;
 
   try {
-
     payload = l1t::OnlineDBqueryHelper::fetch({"CONF"}, "OMTF_CLOBS", objectKey, m_omdsReader)["CONF"];
 
   } catch (std::runtime_error& e) {
@@ -81,7 +83,8 @@ std::unique_ptr<const L1TMuonOverlapFwVersion> L1TMuonOverlapFwVersionOnlineProd
     if (transactionSafe)
       throw std::runtime_error(std::string("SummaryForFunctionManager: OMTF  | Faulty  | ") + e.what());
     else {
-      edm::LogError("L1-O2O: L1TMuonOverlapFwVersionOnlineProd") << "returning unmodified prototype of L1TMuonOverlapFwVersion";
+      edm::LogError("L1-O2O: L1TMuonOverlapFwVersionOnlineProd")
+          << "returning unmodified prototype of L1TMuonOverlapFwVersion";
       return std::make_unique<const L1TMuonOverlapFwVersion>(baseSettings);
     }
   }
@@ -92,22 +95,22 @@ std::unique_ptr<const L1TMuonOverlapFwVersion> L1TMuonOverlapFwVersionOnlineProd
     output.close();
   }
 
-// finally push all payloads to the XML parser and construct the TrigSystem object
+  // finally push all payloads to the XML parser and construct the TrigSystem object
   l1t::XmlConfigParser xmlRdr;
   l1t::TriggerSystem parsedXMLs;
 
   try {
 
-// no need to read all the HW settings, just define a dummy processor
+    // no need to read all the HW settings, just define a dummy processor
     hw_fake = "<system id=\"OMTF\">  </system>";
     xmlRdr.readDOMFromString(hw_fake);
     parsedXMLs.addProcessor("processors", "processors", "all_crates", "all_slots");
     xmlRdr.readRootElement(parsedXMLs);
 
-// INFRA payload needs some editing to be suitable for the standard XML parser
-    replaceAll(payload,"infra","algo");
-    removeAll(payload,"<context id=\"daq","</context>");
-    removeAll(payload,"<context id=\"OMTF","</context>");
+    // INFRA payload needs some editing to be suitable for the standard XML parser
+    replaceAll(payload, "infra", "algo");
+    removeAll(payload, "<context id=\"daq", "</context>");
+    removeAll(payload, "<context id=\"OMTF", "</context>");
     xmlRdr.readDOMFromString(payload);
     xmlRdr.readRootElement(parsedXMLs);
 
@@ -118,7 +121,8 @@ std::unique_ptr<const L1TMuonOverlapFwVersion> L1TMuonOverlapFwVersionOnlineProd
     if (transactionSafe)
       throw std::runtime_error(std::string("SummaryForFunctionManager: OMTF  | Faulty at parsing XML  | ") + e.what());
     else {
-      edm::LogError("L1-O2O: L1TMuonOverlapFwVersionOnlineProd") << "returning unmodified prototype of L1TMuonOverlapFwVersion";
+      edm::LogError("L1-O2O: L1TMuonOverlapFwVersionOnlineProd")
+          << "returning unmodified prototype of L1TMuonOverlapFwVersion";
       return std::make_unique<const L1TMuonOverlapFwVersion>(baseSettings);
     }
   }
@@ -137,9 +141,10 @@ std::unique_ptr<const L1TMuonOverlapFwVersion> L1TMuonOverlapFwVersionOnlineProd
   sslayersV >> layersV;
   sspatternsV << std::hex << patternsV_string.c_str();
   sspatternsV >> patternsV;
-  auto retval = std::make_unique<const L1TMuonOverlapFwVersion>(algoV,layersV,patternsV,synthDate);
+  auto retval = std::make_unique<const L1TMuonOverlapFwVersion>(algoV, layersV, patternsV, synthDate);
 
-  edm::LogInfo("L1-O2O: L1TMuonOverlapFwVersionOnlineProd") << "SummaryForFunctionManager: OMTF  | OK      | All looks good";
+  edm::LogInfo("L1-O2O: L1TMuonOverlapFwVersionOnlineProd")
+      << "SummaryForFunctionManager: OMTF  | OK      | All looks good";
   return retval;
 }
 

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapFwVersionOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapFwVersionOnlineProd.cc
@@ -100,7 +100,6 @@ std::unique_ptr<const L1TMuonOverlapFwVersion> L1TMuonOverlapFwVersionOnlineProd
   l1t::TriggerSystem parsedXMLs;
 
   try {
-
     // no need to read all the HW settings, just define a dummy processor
     hw_fake = "<system id=\"OMTF\">  </system>";
     xmlRdr.readDOMFromString(hw_fake);

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapFwVersionOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapFwVersionOnlineProd.cc
@@ -23,7 +23,7 @@ public:
                                                            const L1TMuonOverlapFwVersionO2ORcd& record) override;
 
   L1TMuonOverlapFwVersionOnlineProd(const edm::ParameterSet&);
-  ~L1TMuonOverlapFwVersionOnlineProd(void) override {}
+  ~L1TMuonOverlapFwVersionOnlineProd(void) override = default;
 };
 
 void replaceAll(std::string& str, const std::string& from, const std::string& to) {

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapFwVersionOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapFwVersionOnlineProd.cc
@@ -75,7 +75,6 @@ std::unique_ptr<const L1TMuonOverlapFwVersion> L1TMuonOverlapFwVersionOnlineProd
   try {
 
     payload = l1t::OnlineDBqueryHelper::fetch({"CONF"}, "OMTF_CLOBS", objectKey, m_omdsReader)["CONF"];
-//    removeAll(payload,"<!--","-->");
 
   } catch (std::runtime_error& e) {
     edm::LogError("L1-O2O: L1TMuonOverlapFwVersionOnlineProd") << e.what();
@@ -129,14 +128,6 @@ std::unique_ptr<const L1TMuonOverlapFwVersion> L1TMuonOverlapFwVersionOnlineProd
   layersV_string = conf["layersVer"].getValueAsStr();
   patternsV_string = conf["patternsVer"].getValueAsStr();
   synthDate = conf["synthDate"].getValueAsStr();
-
-// DEBUG PRINTOUTS TO BE REMOVED LATER
-//    std::cout<<" *** objectKey: "<<objectKey<<std::endl;
-//    std::cout<<" *** payload: "<<payload<<std::endl;
-//    std::cout<<" *** algorithmVer: "<<algoV_string<<std::endl;
-//    std::cout<<" *** layersVer: "<<layersV_string<<std::endl;
-//    std::cout<<" *** patternsVer: "<<patternsV_string<<std::endl;
-//    std::cout<<" *** synthDate: "<<synthDate<<std::endl;
 
   unsigned algoV, layersV, patternsV;
   std::stringstream ssalgoV, sslayersV, sspatternsV;

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapFwVersionOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapFwVersionOnlineProd.cc
@@ -69,13 +69,13 @@ std::unique_ptr<const L1TMuonOverlapFwVersion> L1TMuonOverlapFwVersionOnlineProd
   edm::LogInfo("L1-O2O: L1TMuonOverlapFwVersionOnlineProd")
       << "Producing L1TMuonOverlapFwVersion for key = " << objectKey;
 
-  std::string infra_payload, payload, hw_fake;
+  std::string payload, hw_fake;
   std::string algoV_string, layersV_string, patternsV_string, synthDate;
 
   try {
 
-    infra_payload = l1t::OnlineDBqueryHelper::fetch({"CONF"}, "OMTF_CLOBS", objectKey, m_omdsReader)["CONF"];
-//    removeAll(infra_payload,"<!--","-->");
+    payload = l1t::OnlineDBqueryHelper::fetch({"CONF"}, "OMTF_CLOBS", objectKey, m_omdsReader)["CONF"];
+//    removeAll(payload,"<!--","-->");
 
   } catch (std::runtime_error& e) {
     edm::LogError("L1-O2O: L1TMuonOverlapFwVersionOnlineProd") << e.what();
@@ -106,13 +106,9 @@ std::unique_ptr<const L1TMuonOverlapFwVersion> L1TMuonOverlapFwVersionOnlineProd
     xmlRdr.readRootElement(parsedXMLs);
 
 // INFRA payload needs some editing to be suitable for the standard XML parser
-//    replaceAll(infra_payload,"infra","algo");
-//    removeAll(infra_payload,"</context",">");
-    payload = "<algo id=\"OMTF\"> ";
-    std::string str_P1 = infra_payload.substr(infra_payload.find("<context id=\"processors\">"),std::string::npos);
-    std::string str_P2 = str_P1.substr(0,str_P1.find("</context>") + 10);
-    payload.append(str_P2);
-    payload.append(" </algo>");
+    replaceAll(payload,"infra","algo");
+    removeAll(payload,"<context id=\"daq","</context>");
+    removeAll(payload,"<context id=\"OMTF","</context>");
     xmlRdr.readDOMFromString(payload);
     xmlRdr.readRootElement(parsedXMLs);
 

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapFwVersionOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapFwVersionOnlineProd.cc
@@ -1,0 +1,160 @@
+#include <iostream>
+#include <fstream>
+
+#include "CondTools/L1TriggerExt/interface/L1ConfigOnlineProdBaseExt.h"
+#include "CondFormats/L1TObjects/interface/L1TMuonOverlapFwVersion.h"
+#include "CondFormats/DataRecord/interface/L1TMuonOverlapFwVersionRcd.h"
+#include "CondFormats/DataRecord/interface/L1TMuonOverlapFwVersionO2ORcd.h"
+#include "L1Trigger/L1TCommon/interface/TriggerSystem.h"
+#include "L1Trigger/L1TCommon/interface/XmlConfigParser.h"
+#include "OnlineDBqueryHelper.h"
+
+#include "xercesc/util/PlatformUtils.hpp"
+using namespace XERCES_CPP_NAMESPACE;
+
+class L1TMuonOverlapFwVersionOnlineProd : public L1ConfigOnlineProdBaseExt<L1TMuonOverlapFwVersionO2ORcd, L1TMuonOverlapFwVersion> {
+private:
+  const bool transactionSafe;
+  const edm::ESGetToken<L1TMuonOverlapFwVersion, L1TMuonOverlapFwVersionRcd> baseSettings_token;
+
+public:
+  std::unique_ptr<const L1TMuonOverlapFwVersion> newObject(const std::string& objectKey, const L1TMuonOverlapFwVersionO2ORcd& record) override;
+
+  L1TMuonOverlapFwVersionOnlineProd(const edm::ParameterSet&);
+  ~L1TMuonOverlapFwVersionOnlineProd(void) override {}
+};
+
+void replaceAll(std::string& str, const std::string& from, const std::string& to) {
+  if(from.empty())
+    return;
+  size_t start_pos = 0;
+  while((start_pos = str.find(from, start_pos)) != std::string::npos) {
+    str.replace(start_pos, from.length(), to);
+    start_pos += to.length();
+  }
+}
+
+void removeAll(std::string& str, const std::string& from, const std::string& to) {
+  if(from.empty())
+    return;
+  size_t start_pos = 0;
+  while((start_pos = str.find(from, start_pos)) != std::string::npos) {
+    size_t end_pos = str.find(to) + to.length();
+    int length = end_pos - start_pos;
+    str.replace(start_pos, length, "");
+  }
+}
+
+L1TMuonOverlapFwVersionOnlineProd::L1TMuonOverlapFwVersionOnlineProd(const edm::ParameterSet& iConfig)
+    : L1ConfigOnlineProdBaseExt<L1TMuonOverlapFwVersionO2ORcd, L1TMuonOverlapFwVersion>(iConfig),
+    transactionSafe(iConfig.getParameter<bool>("transactionSafe")),
+    baseSettings_token(wrappedSetWhatProduced(iConfig).consumes()) {}
+
+std::unique_ptr<const L1TMuonOverlapFwVersion> L1TMuonOverlapFwVersionOnlineProd::newObject(
+    const std::string& objectKey, const L1TMuonOverlapFwVersionO2ORcd& record) {
+
+  const L1TMuonOverlapFwVersionRcd& baseRcd = record.template getRecord<L1TMuonOverlapFwVersionRcd>();
+  auto const& baseSettings = baseRcd.get(baseSettings_token);
+
+  if (objectKey.empty()) {
+    edm::LogError("L1-O2O: L1TMuonOverlapFwVersionOnlineProd") << "Key is empty, returning empty L1TMuonOverlapFwVersion";
+    if (transactionSafe)
+      throw std::runtime_error("SummaryForFunctionManager: OMTF  | Faulty  | Empty objectKey");
+    else {
+      edm::LogError("L1-O2O: L1TMuonOverlapFwVersionOnlineProd") << "returning unmodified prototype of L1TMuonOverlapFwVersion";
+      return std::make_unique<const L1TMuonOverlapFwVersion>(baseSettings);
+    }
+  }
+
+  edm::LogInfo("L1-O2O: L1TMuonOverlapFwVersionOnlineProd")
+      << "Producing L1TMuonOverlapFwVersion for key = " << objectKey;
+
+  std::string infra_payload, payload, hw_fake;
+  std::string algoV_string, layersV_string, patternsV_string, synthDate;
+
+  try {
+
+    infra_payload = l1t::OnlineDBqueryHelper::fetch({"CONF"}, "OMTF_CLOBS", objectKey, m_omdsReader)["CONF"];
+//    removeAll(infra_payload,"<!--","-->");
+
+  } catch (std::runtime_error& e) {
+    edm::LogError("L1-O2O: L1TMuonOverlapFwVersionOnlineProd") << e.what();
+    if (transactionSafe)
+      throw std::runtime_error(std::string("SummaryForFunctionManager: OMTF  | Faulty  | ") + e.what());
+    else {
+      edm::LogError("L1-O2O: L1TMuonOverlapFwVersionOnlineProd") << "returning unmodified prototype of L1TMuonOverlapFwVersion";
+      return std::make_unique<const L1TMuonOverlapFwVersion>(baseSettings);
+    }
+  }
+  // for debugging dump the configs to local files
+  {
+    std::ofstream output(std::string("/tmp/").append(objectKey.substr(0, objectKey.find('/'))).append(".xml"));
+    output << objectKey;
+    output.close();
+  }
+
+// finally push all payloads to the XML parser and construct the TrigSystem object
+  l1t::XmlConfigParser xmlRdr;
+  l1t::TriggerSystem parsedXMLs;
+
+  try {
+
+// no need to read all the HW settings, just define a dummy processor
+    hw_fake = "<system id=\"OMTF\">  </system>";
+    xmlRdr.readDOMFromString(hw_fake);
+    parsedXMLs.addProcessor("processors", "processors", "all_crates", "all_slots");
+    xmlRdr.readRootElement(parsedXMLs);
+
+// INFRA payload needs some editing to be suitable for the standard XML parser
+//    replaceAll(infra_payload,"infra","algo");
+//    removeAll(infra_payload,"</context",">");
+    payload = "<algo id=\"OMTF\"> ";
+    std::string str_P1 = infra_payload.substr(infra_payload.find("<context id=\"processors\">"),std::string::npos);
+    std::string str_P2 = str_P1.substr(0,str_P1.find("</context>") + 10);
+    payload.append(str_P2);
+    payload.append(" </algo>");
+    xmlRdr.readDOMFromString(payload);
+    xmlRdr.readRootElement(parsedXMLs);
+
+    parsedXMLs.setConfigured();
+
+  } catch (std::runtime_error& e) {
+    edm::LogError("L1-O2O: L1TMuonOverlapFwVersionOnlineProd") << e.what();
+    if (transactionSafe)
+      throw std::runtime_error(std::string("SummaryForFunctionManager: OMTF  | Faulty at parsing XML  | ") + e.what());
+    else {
+      edm::LogError("L1-O2O: L1TMuonOverlapFwVersionOnlineProd") << "returning unmodified prototype of L1TMuonOverlapFwVersion";
+      return std::make_unique<const L1TMuonOverlapFwVersion>(baseSettings);
+    }
+  }
+
+  std::map<std::string, l1t::Parameter> conf = parsedXMLs.getParameters("processors");
+  algoV_string = conf["algorithmVer"].getValueAsStr();
+  layersV_string = conf["layersVer"].getValueAsStr();
+  patternsV_string = conf["patternsVer"].getValueAsStr();
+  synthDate = conf["synthDate"].getValueAsStr();
+
+// DEBUG PRINTOUTS TO BE REMOVED LATER
+//    std::cout<<" *** objectKey: "<<objectKey<<std::endl;
+//    std::cout<<" *** payload: "<<payload<<std::endl;
+//    std::cout<<" *** algorithmVer: "<<algoV_string<<std::endl;
+//    std::cout<<" *** layersVer: "<<layersV_string<<std::endl;
+//    std::cout<<" *** patternsVer: "<<patternsV_string<<std::endl;
+//    std::cout<<" *** synthDate: "<<synthDate<<std::endl;
+
+  unsigned algoV, layersV, patternsV;
+  std::stringstream ssalgoV, sslayersV, sspatternsV;
+  ssalgoV << std::hex << algoV_string.c_str();
+  ssalgoV >> algoV;
+  sslayersV << std::hex << layersV_string.c_str();
+  sslayersV >> layersV;
+  sspatternsV << std::hex << patternsV_string.c_str();
+  sspatternsV >> patternsV;
+  auto retval = std::make_unique<const L1TMuonOverlapFwVersion>(algoV,layersV,patternsV,synthDate);
+
+  edm::LogInfo("L1-O2O: L1TMuonOverlapFwVersionOnlineProd") << "SummaryForFunctionManager: OMTF  | OK      | All looks good";
+  return retval;
+}
+
+//define this as a plug-in
+DEFINE_FWK_EVENTSETUP_MODULE(L1TMuonOverlapFwVersionOnlineProd);

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapObjectKeysOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapObjectKeysOnlineProd.cc
@@ -11,7 +11,7 @@ public:
   void fillObjectKeys(L1TriggerKeyExt* pL1TriggerKey) override;
 
   L1TMuonOverlapObjectKeysOnlineProd(const edm::ParameterSet&);
-  ~L1TMuonOverlapObjectKeysOnlineProd(void) override {}
+  ~L1TMuonOverlapObjectKeysOnlineProd(void) override = default;
 };
 
 L1TMuonOverlapObjectKeysOnlineProd::L1TMuonOverlapObjectKeysOnlineProd(const edm::ParameterSet& iConfig)

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapObjectKeysOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapObjectKeysOnlineProd.cc
@@ -20,23 +20,20 @@ L1TMuonOverlapObjectKeysOnlineProd::L1TMuonOverlapObjectKeysOnlineProd(const edm
 }
 
 void L1TMuonOverlapObjectKeysOnlineProd::fillObjectKeys(L1TriggerKeyExt* pL1TriggerKey) {
-
   std::string OMTFKey = pL1TriggerKey->subsystemKey(L1TriggerKeyExt::kOMTF);
 
   std::string tscKey = OMTFKey.substr(0, OMTFKey.find(':'));
   std::string algo_key, infra_key;
 
-// L1TMuonOverlapFwVersion and L1TMuonOverlapParams keys to be found from INFRA and ALGO, respectively
+  // L1TMuonOverlapFwVersion and L1TMuonOverlapParams keys to be found from INFRA and ALGO, respectively
 
   try {
-
     std::map<std::string, std::string> keys =
-      l1t::OnlineDBqueryHelper::fetch({"ALGO", "INFRA"}, "OMTF_KEYS", tscKey, m_omdsReader);
+        l1t::OnlineDBqueryHelper::fetch({"ALGO", "INFRA"}, "OMTF_KEYS", tscKey, m_omdsReader);
     algo_key = keys["ALGO"];
     infra_key = keys["INFRA"];
 
   } catch (std::runtime_error& e) {
-
     edm::LogError("L1-O2O L1TMuonOverlapObjectKeysOnlineProd") << "Cannot get OMTF_KEYS ";
 
     if (transactionSafe)
@@ -50,13 +47,11 @@ void L1TMuonOverlapObjectKeysOnlineProd::fillObjectKeys(L1TriggerKeyExt* pL1Trig
       pL1TriggerKey->add("L1TMuonOverlapParamsO2ORcd", "L1TMuonOverlapParams", "OMTF_ALGO_EMPTY");
       return;
     }
-
   }
 
   pL1TriggerKey->add("L1TMuonOverlapFwVersionO2ORcd", "L1TMuonOverlapFwVersion", infra_key);
 
   pL1TriggerKey->add("L1TMuonOverlapParamsO2ORcd", "L1TMuonOverlapParams", algo_key);
-
 }
 
 //define this as a plug-in

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapObjectKeysOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapObjectKeysOnlineProd.cc
@@ -1,6 +1,7 @@
 #include <iostream>
 #include "CondTools/L1TriggerExt/interface/L1ObjectKeysOnlineProdBaseExt.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "OnlineDBqueryHelper.h"
 
 class L1TMuonOverlapObjectKeysOnlineProd : public L1ObjectKeysOnlineProdBaseExt {
 private:
@@ -19,36 +20,43 @@ L1TMuonOverlapObjectKeysOnlineProd::L1TMuonOverlapObjectKeysOnlineProd(const edm
 }
 
 void L1TMuonOverlapObjectKeysOnlineProd::fillObjectKeys(L1TriggerKeyExt* pL1TriggerKey) {
+
   std::string OMTFKey = pL1TriggerKey->subsystemKey(L1TriggerKeyExt::kOMTF);
 
-  std::string stage2Schema = "CMS_TRG_L1_CONF";
-
   std::string tscKey = OMTFKey.substr(0, OMTFKey.find(':'));
+  std::string algo_key, infra_key;
 
-  std::vector<std::string> queryStrings;
-  queryStrings.push_back("ALGO");
+// L1TMuonOverlapFwVersion and L1TMuonOverlapParams keys to be found from INFRA and ALGO, respectively
 
-  std::string algo_key;
+  try {
 
-  // select ALGO from CMS_TRG_L1_CONF.OMTF_KEYS where ID = tscKey ;
-  l1t::OMDSReader::QueryResults queryResult = m_omdsReader.basicQuery(
-      queryStrings, stage2Schema, "OMTF_KEYS", "OMTF_KEYS.ID", m_omdsReader.singleAttribute(tscKey));
+    std::map<std::string, std::string> keys =
+      l1t::OnlineDBqueryHelper::fetch({"ALGO", "INFRA"}, "OMTF_KEYS", tscKey, m_omdsReader);
+    algo_key = keys["ALGO"];
+    infra_key = keys["INFRA"];
 
-  if (queryResult.queryFailed() || queryResult.numberRows() != 1 || !queryResult.fillVariable("ALGO", algo_key)) {
-    edm::LogError("L1-O2O L1TMuonOverlapObjectKeysOnlineProd") << "Cannot get OMTF_KEYS.ALGO ";
+  } catch (std::runtime_error& e) {
+
+    edm::LogError("L1-O2O L1TMuonOverlapObjectKeysOnlineProd") << "Cannot get OMTF_KEYS ";
 
     if (transactionSafe)
       throw std::runtime_error("SummaryForFunctionManager: OMTF  | Faulty  | Broken key");
     else {
       edm::LogError("L1-O2O: L1TMuonOverlapObjectKeysOnlineProd")
+          << "forcing L1TMuonOverlapFwVersion key to be = 'OMTF_INFRA_EMPTY' with baseline settings";
+      pL1TriggerKey->add("L1TMuonOverlapFwVersionO2ORcd", "L1TMuonOverlapFwVersion", "OMTF_INFRA_EMPTY");
+      edm::LogError("L1-O2O: L1TMuonOverlapObjectKeysOnlineProd")
           << "forcing L1TMuonOverlapParams key to be = 'OMTF_ALGO_EMPTY' (known to exist)";
       pL1TriggerKey->add("L1TMuonOverlapParamsO2ORcd", "L1TMuonOverlapParams", "OMTF_ALGO_EMPTY");
       return;
     }
+
   }
 
-  // simply assign the algo key to the record
+  pL1TriggerKey->add("L1TMuonOverlapFwVersionO2ORcd", "L1TMuonOverlapFwVersion", infra_key);
+
   pL1TriggerKey->add("L1TMuonOverlapParamsO2ORcd", "L1TMuonOverlapParams", algo_key);
+
 }
 
 //define this as a plug-in

--- a/L1TriggerConfig/Utilities/src/L1TMuonOverlapFwVersionTester.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonOverlapFwVersionTester.cc
@@ -45,15 +45,13 @@ void L1TMuonOverlapFwVersionTester::analyze(const edm::Event &iEvent, const edm:
 
   edm::LogInfo("L1TMuonOverlapFwVersionTester")
       << "*** Contents of L1TMuonOverlapFwVersion: algoVersion() = " << data.algoVersion()
-      << ", layersVersion() = " << data.layersVersion()
-      << ", patternsVersion() = " << data.patternsVersion()
+      << ", layersVersion() = " << data.layersVersion() << ", patternsVersion() = " << data.patternsVersion()
       << ", synthDate() = " << data.synthDate();
 
   if (writeToDB) {
     edm::Service<cond::service::PoolDBOutputService> poolDb;
     if (poolDb.isAvailable()) {
-      edm::LogInfo("L1TMuonOverlapFwVersionTester")
-          << "*** Writing payload to DB";
+      edm::LogInfo("L1TMuonOverlapFwVersionTester") << "*** Writing payload to DB";
       cond::Time_t firstSinceTime = poolDb->beginOfTime();
       poolDb->writeOneIOV(
           data, firstSinceTime, (isO2Opayload ? "L1TMuonOverlapFwVersionO2ORcd" : "L1TMuonOverlapFwVersionRcd"));

--- a/L1TriggerConfig/Utilities/src/L1TMuonOverlapFwVersionTester.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonOverlapFwVersionTester.cc
@@ -54,10 +54,9 @@ void L1TMuonOverlapFwVersionTester::analyze(const edm::Event &iEvent, const edm:
       cout << "Writing payload to DB" << endl;
       cond::Time_t firstSinceTime = poolDb->beginOfTime();
       poolDb->writeOne(
-        ptr1.get(), firstSinceTime, (isO2Opayload ? "L1TMuonOverlapFwVersionO2ORcd" : "L1TMuonOverlapFwVersionRcd"));
+          ptr1.get(), firstSinceTime, (isO2Opayload ? "L1TMuonOverlapFwVersionO2ORcd" : "L1TMuonOverlapFwVersionRcd"));
     }
   }
-
 }
 
 #include "FWCore/PluginManager/interface/ModuleDef.h"

--- a/L1TriggerConfig/Utilities/src/L1TMuonOverlapFwVersionTester.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonOverlapFwVersionTester.cc
@@ -1,7 +1,7 @@
 #include <iomanip>
 #include <iostream>
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -17,7 +17,7 @@
 
 using namespace std;
 
-class L1TMuonOverlapFwVersionTester : public edm::EDAnalyzer {
+class L1TMuonOverlapFwVersionTester : public edm::one::EDAnalyzer<> {
 private:
   bool isO2Opayload;
   bool writeToDB;
@@ -27,7 +27,7 @@ private:
 public:
   void analyze(const edm::Event &, const edm::EventSetup &) override;
 
-  explicit L1TMuonOverlapFwVersionTester(const edm::ParameterSet &pset) : edm::EDAnalyzer() {
+  explicit L1TMuonOverlapFwVersionTester(const edm::ParameterSet &pset) : edm::one::EDAnalyzer<>() {
     isO2Opayload = pset.getUntrackedParameter<bool>("isO2Opayload", false);
     writeToDB = pset.getUntrackedParameter<bool>("writeToDB", false);
     esToken = esConsumes<L1TMuonOverlapFwVersion, L1TMuonOverlapFwVersionRcd>();

--- a/L1TriggerConfig/Utilities/src/L1TMuonOverlapFwVersionTester.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonOverlapFwVersionTester.cc
@@ -1,0 +1,67 @@
+#include <iomanip>
+#include <iostream>
+
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "CondFormats/DataRecord/interface/L1TMuonOverlapFwVersionRcd.h"
+#include "CondFormats/DataRecord/interface/L1TMuonOverlapFwVersionO2ORcd.h"
+#include "CondFormats/L1TObjects/interface/L1TMuonOverlapFwVersion.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
+#include "CondCore/CondDB/interface/Session.h"
+
+using namespace std;
+
+class L1TMuonOverlapFwVersionTester : public edm::EDAnalyzer {
+private:
+  bool isO2Opayload;
+  bool writeToDB;
+
+public:
+  void analyze(const edm::Event &, const edm::EventSetup &) override;
+
+  explicit L1TMuonOverlapFwVersionTester(const edm::ParameterSet &pset) : edm::EDAnalyzer() {
+    isO2Opayload = pset.getUntrackedParameter<bool>("isO2Opayload", false);
+    writeToDB = pset.getUntrackedParameter<bool>("writeToDB", false);
+  }
+  ~L1TMuonOverlapFwVersionTester(void) override {}
+};
+
+void L1TMuonOverlapFwVersionTester::analyze(const edm::Event &iEvent, const edm::EventSetup &evSetup) {
+  edm::ESHandle<L1TMuonOverlapFwVersion> handle1;
+  if (isO2Opayload)
+    evSetup.get<L1TMuonOverlapFwVersionO2ORcd>().get(handle1);
+  else
+    evSetup.get<L1TMuonOverlapFwVersionRcd>().get(handle1);
+  std::shared_ptr<L1TMuonOverlapFwVersion> ptr1(new L1TMuonOverlapFwVersion(*(handle1.product())));
+
+  cout << "Contents of L1TMuonOverlapFwVersion: " << endl;
+
+  cout << " algoVersion() = " << ptr1->algoVersion() << endl;
+  cout << " layersVersion() = " << ptr1->layersVersion() << endl;
+  cout << " patternsVersion() = " << ptr1->patternsVersion() << endl;
+  cout << " synthDate() = " << ptr1->synthDate() << endl;
+
+  if (writeToDB) {
+    edm::Service<cond::service::PoolDBOutputService> poolDb;
+    if (poolDb.isAvailable()) {
+      cout << "Writing payload to DB" << endl;
+      cond::Time_t firstSinceTime = poolDb->beginOfTime();
+      poolDb->writeOne(
+        ptr1.get(), firstSinceTime, (isO2Opayload ? "L1TMuonOverlapFwVersionO2ORcd" : "L1TMuonOverlapFwVersionRcd"));
+    }
+  }
+
+}
+
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ModuleFactory.h"
+
+DEFINE_FWK_MODULE(L1TMuonOverlapFwVersionTester);

--- a/L1TriggerConfig/Utilities/test/dumpL1TMuonOverlapFwVersion.py
+++ b/L1TriggerConfig/Utilities/test/dumpL1TMuonOverlapFwVersion.py
@@ -1,0 +1,121 @@
+from __future__ import print_function
+# to test the communication with DBS and produce the csctf configuration
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("QWE")
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cout.enable = cms.untracked.bool(True)
+process.MessageLogger.cout.threshold = cms.untracked.string('INFO')
+process.MessageLogger.debugModules = cms.untracked.vstring('*')
+
+import FWCore.ParameterSet.VarParsing as VarParsing
+options = VarParsing.VarParsing()
+options.register('topKey',
+                 '', # empty default value
+#                 'TSCKEY_DUMMY:RSKEY_DUMMY',
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "object key")
+options.register('systemKey',
+#                 '', # empty default value
+                 'L1TMuonOverlapFwVersion_DUMMY',
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "object key")
+options.register('outputDBConnect',
+                 'sqlite_file:./l1config.db', # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Connection string for output DB")
+options.register('DBConnect',
+                 'oracle://cms_omds_adg/CMS_TRG_R', # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "OMDS connect string")
+options.register('DBAuth',
+                 '.', # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Authentication path for the DB")
+options.parseArguments()
+
+# sanity checks
+if ( len(options.topKey) and len(options.systemKey) ) or ( len(options.topKey)==0 and len(options.systemKey)==0 ) :
+    print("Specify either the topKey (top-level tsc:rs key) or systemKey (system specific tsc:rs key), but not both")
+    exit(1)
+
+# standard CMSSW stuff
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1) )
+process.source = cms.Source("EmptySource")
+
+# add dummy L1TriggerKeyList so as to suppress framework related warning
+process.load("CondTools.L1TriggerExt.L1TriggerKeyListDummyExt_cff")
+
+# produce L1TriggerKey for the subsystem online producers
+if len(options.topKey) :
+    # parent L1TriggerKey that will seed system-specific key to be automatically generated below
+    process.load("CondTools.L1TriggerExt.L1TriggerKeyRcdSourceExt_cfi")
+    process.load("CondTools.L1TriggerExt.L1SubsystemKeysOnlineExt_cfi")
+    process.L1SubsystemKeysOnlineExt.tscKey = cms.string( options.topKey.split(':')[0] )
+    process.L1SubsystemKeysOnlineExt.rsKey  = cms.string( options.topKey.split(':')[1] )
+    process.L1SubsystemKeysOnlineExt.onlineAuthentication = cms.string( options.DBAuth )
+    process.L1SubsystemKeysOnlineExt.forceGeneration = cms.bool(True)
+    # using the parent L1TriggerKey above start generation of system-specific (labeled) L1TriggerKeys and pack them the main (unlabeled) L1TriggerKey (just one subsystem here)
+    process.load("CondTools.L1TriggerExt.L1TriggerKeyOnlineExt_cfi")
+    process.L1TriggerKeyOnlineExt.subsystemLabels = cms.vstring('OMTF')
+    # include the system-specific subkeys ESProducer (generates OMTF labeled L1TriggerKey)
+    process.load("L1TriggerConfig.L1TConfigProducers.L1TMuonOverlapObjectKeysOnline_cfi")
+    process.L1TMuonOverlapObjectKeysOnline.onlineAuthentication = cms.string( options.DBAuth    )
+    process.L1TMuonOverlapObjectKeysOnline.onlineDB             = cms.string( options.DBConnect )
+else :
+    # instantiate manually the system-specific L1TriggerKey using the subsystemKey option
+    process.load("CondTools.L1TriggerExt.L1TriggerKeyDummyExt_cff")
+    process.L1TriggerKeyDummyExt.tscKey = cms.string('TSCKEY_DUMMY')
+    process.L1TriggerKeyDummyExt.objectKeys = cms.VPSet(
+        cms.PSet(
+            record = cms.string('L1TMuonOverlapFwVersionO2ORcd'),
+            type = cms.string('L1TMuonOverlapFwVersion'),
+            key = cms.string(options.systemKey)
+        )
+    )
+
+# Online producer for the payload 
+process.load("L1TriggerConfig.L1TConfigProducers.L1TMuonOverlapFwVersionOnline_cfi")
+#process.load("L1Trigger.L1TMuonOverlap.fakeOmtfFwVersion_cff")
+#process.L1TMuonOverlapFwVersionOnlineProd.onlineAuthentication = cms.string( options.DBAuth )
+#process.L1TMuonOverlapFwVersionOnlineProd.onlineDB             = cms.string( options.DBConnect )
+#
+process.getter = cms.EDAnalyzer("EventSetupRecordDataGetter",
+   toGet = cms.VPSet(cms.PSet(
+       record = cms.string('L1TMuonOverlapFwVersionO2ORcd'),
+#       record = cms.string('L1TMuonOverlapFwVersionRcd'),
+       data   = cms.vstring('L1TMuonOverlapFwVersion')
+   )),
+   verbose = cms.untracked.bool(True)
+)
+
+process.l1mow = cms.EDAnalyzer("L1TMuonOverlapFwVersionTester", writeToDB = cms.untracked.bool(True), isO2Opayload = cms.untracked.bool(False))
+
+from CondCore.CondDB.CondDB_cfi import CondDB
+CondDB.connect = cms.string(options.outputDBConnect)
+
+outputDB = cms.Service("PoolDBOutputService",
+    CondDB,
+    toPut   = cms.VPSet(
+        cms.PSet(
+#            record = cms.string('L1TMuonOverlapFwVersionO2ORcd'),
+            record = cms.string('L1TMuonOverlapFwVersionRcd'),
+            tag = cms.string('L1TMuonOverlapFwVersion_Stage2v0_hlt')
+        ),
+        cms.PSet(
+            record = cms.string("L1TriggerKeyListExtRcd"),
+            tag = cms.string("L1TriggerKeyListExt_Stage2v0_hlt")
+        )
+    )
+)
+
+outputDB.DBParameters.authenticationPath = options.DBAuth
+process.add_(outputDB)
+
+process.p = cms.Path(process.getter + process.l1mow)
+

--- a/L1TriggerConfig/Utilities/test/uploadOmtfFwVersion.py
+++ b/L1TriggerConfig/Utilities/test/uploadOmtfFwVersion.py
@@ -1,0 +1,42 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("tester")
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cout.enable = cms.untracked.bool(True)
+process.MessageLogger.cout.threshold = cms.untracked.string('DEBUG')
+process.MessageLogger.debugModules = cms.untracked.vstring('*')
+
+process.source = cms.Source("EmptySource", firstRun = cms.untracked.uint32(3))
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1) )
+
+process.load("L1Trigger.L1TMuonOverlap.fakeOmtfFwVersion_cff")
+
+process.getter = cms.EDAnalyzer("EventSetupRecordDataGetter",
+   toGet = cms.VPSet(
+       cms.PSet(
+           record = cms.string('L1TMuonOverlapFwVersionRcd'),
+           data   = cms.vstring('L1TMuonOverlapFwVersion')
+       )
+   ),
+   verbose = cms.untracked.bool(True)
+)
+
+from CondCore.CondDB.CondDB_cfi import CondDB
+CondDB.connect = cms.string('sqlite:l1config.db')
+
+outputDB = cms.Service("PoolDBOutputService",
+                       CondDB,
+                       toPut   = cms.VPSet(
+                           cms.PSet(
+                               record = cms.string('L1TMuonOverlapFwVersionRcd'),
+                               tag = cms.string('L1TMuonOverlapFwVersionPrototype_Stage2v0_hlt')
+                           )
+                       )
+)
+outputDB.DBParameters.authenticationPath = '.'
+process.add_(outputDB)
+
+process.l1opw = cms.EDAnalyzer("L1TMuonOverlapFwVersionTester", isO2Opayload = cms.untracked.bool(False), writeToDB = cms.untracked.bool(True))
+
+process.p = cms.Path(process.getter + process.l1opw)
+

--- a/L1TriggerConfig/Utilities/test/viewOmtfFwVersion.py
+++ b/L1TriggerConfig/Utilities/test/viewOmtfFwVersion.py
@@ -1,0 +1,57 @@
+from __future__ import print_function
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("tester")
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cout.enable = cms.untracked.bool(True)
+process.MessageLogger.cout.threshold = cms.untracked.string('DEBUG')
+process.MessageLogger.debugModules = cms.untracked.vstring('*')
+
+import FWCore.ParameterSet.VarParsing as VarParsing
+options = VarParsing.VarParsing()
+options.register('db',
+                 'static',
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Source DB: prod/prep/static/sqlite"
+)
+options.register('run',
+                 1,
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Run (IOV)"
+)
+options.parseArguments()
+
+if options.db == "static" :
+    process.load('L1Trigger.L1TMuonOverlap.fakeOmtfFwVersion_cff')
+else :
+    if   options.db == "prod" :
+        sourceDB = "frontier://FrontierProd/CMS_CONDITIONS"
+    elif options.db == "prep" :
+        sourceDB = "frontier://FrontierPrep/CMS_CONDITIONS"
+    elif "sqlite" in options.db :
+        sourceDB = options.db
+    else :
+        print("Unknown input DB: ", options.db, " should be static/prod/prep/sqlite:...")
+        exit(0)
+
+    from CondCore.CondDB.CondDB_cfi import CondDB
+    CondDB.connect = cms.string(sourceDB)
+    process.l1conddb = cms.ESSource("PoolDBESSource",
+       CondDB,
+       toGet   = cms.VPSet(
+            cms.PSet(
+                 record = cms.string('L1TMuonOverlapFwVersionRcd'),
+                 tag = cms.string("L1TMuonOverlapFwVersionPrototype_Stage2v0_hlt")
+            )
+       )
+    )
+
+process.source = cms.Source("EmptySource", firstRun = cms.untracked.uint32(options.run))
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1) )
+
+process.l1mor = cms.EDAnalyzer("L1TMuonOverlapFwVersionTester", isO2Opayload = cms.untracked.bool(False), writeToDB = cms.untracked.bool(False))
+
+process.p = cms.Path(process.l1mor)
+


### PR DESCRIPTION
#### PR description:

Created a new OMTF configuration object L1TMuonOverlapFwVersion to be used in o2o, a dedicated ES producer and a new o2o online producer.  Also necessary was an appropriate modification in L1TMuonOverlapObjectKeysOnlineProd.cc and little additions and modifications in several other packages in order to include the new record.  There is also some standalone test code of the new record in Utilities, which is of lesser importance.

#### PR validation:

The code has been tested with o2o.sh independently by myself and Hyejin Kwon, with input from the OMDS and output in a local sqlite file.  Everything was checked to work such as expected from o2o.  Writing and reading the new record in a standalone way was also tested using the code in Utilities.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
