### PR TITLE
Add clones for CSC trigger primitives for Run-3 and Phase-2 with CCLUT on (CCLUT-19)

### DIFF
--- a/L1Trigger/L1TMuon/python/simDigis_cff.py
+++ b/L1Trigger/L1TMuon/python/simDigis_cff.py
@@ -20,6 +20,13 @@ simCscTriggerPrimitiveDigis = L1Trigger.CSCTriggerPrimitives.cscTriggerPrimitive
     CSCComparatorDigiProducer = 'simMuonCSCDigis:MuonCSCComparatorDigi',
     CSCWireDigiProducer       = 'simMuonCSCDigis:MuonCSCWireDigi'
 )
+# For Run-3: turn on CCLUT in the MEX/1 chambers
+simCscTriggerPrimitiveDigisRun3 = simCscTriggerPrimitiveDigis.clone()
+simCscTriggerPrimitiveDigisRun3.commonParam.runCCLUT_OTMB = True
+
+# For Phase-2: turn on CCLUT in the ME1/3 and MEX/2 chambers
+simCscTriggerPrimitiveDigisPhase2 = simCscTriggerPrimitiveDigisRun3.clone()
+simCscTriggerPrimitiveDigisPhase2.commonParam.runCCLUT_TMB = True
 
 SimL1TMuonCommonTask = cms.Task(simDtTriggerPrimitiveDigis, simCscTriggerPrimitiveDigis)
 SimL1TMuonCommon = cms.Sequence(SimL1TMuonCommonTask)
@@ -106,16 +113,16 @@ phase2_trigger.toReplaceWith(SimL1TMuonTask, cms.Task(SimL1TMuonCommonTask, simT
 ## GEM TPs
 from L1Trigger.L1TGEM.simGEMDigis_cff import *
 _run3_SimL1TMuonTask = SimL1TMuonTask.copy()
-#_run3_SimL1TMuonTask.add(simMuonGEMPadTask)
+_run3_SimL1TMuonTask.add(simCscTriggerPrimitiveDigisRun3)
 
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
-#(stage2L1Trigger & run3_GEM).toReplaceWith( SimL1TMuonTask, _run3_SimL1TMuonTask )
 (stage2L1Trigger & run3_GEM).toReplaceWith( SimL1TMuonTask, cms.Task(simMuonGEMPadTask,_run3_SimL1TMuonTask) )
 
 ## ME0 TPs
 from L1Trigger.L1TGEM.me0TriggerDigis_cff import *
 _phase2_SimL1TMuonTask = SimL1TMuonTask.copy()
 _phase2_SimL1TMuonTask.add(me0TriggerAllDigiTask)
+_phase2_SimL1TMuonTask.add(simCscTriggerPrimitiveDigisPhase2)
 _phase2_GE0_SimL1TMuonTask = SimL1TMuonTask.copyAndExclude([me0TriggerAllDigiTask])
 
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon


### PR DESCRIPTION
#### PR description:

Vladimir Rekovic requested in the L1T Offline Software meeting that clones are added for the CSC Trigger Primitives when the comparator code lookup table algorithm (CCLUT) is on for the optical TMBs (in MEX/1 for Run-3) and also for the old "copper" TMBs (ME1/3, MEX/2 for Phase-2). That will allow us to study the interface between Phase-2 EMTF and Phase-2 CSC TPs with CCLUT on in all chambers.

#### PR validation:

Code compiles. I'll check a few WFs for Run-3 and Phase-2.

In WF 11634.0 I see the updated SimL1Emulator configuration
```
In [4]: print(process.SimL1Emulator)
simCaloStage2Layer1Digis,simCaloStage2Digis,simMuonGEMPadDigis,simMuonGEMPadDigiClusters, \
simDtTriggerPrimitiveDigis,simCscTriggerPrimitiveDigis,simTwinMuxDigis,simBmtfDigis,simKBmtfStubs, \
simKBmtfDigis,simEmtfDigis,simOmtfDigis,simGmtCaloSumDigis,simGmtStage2Digis,simEmtfShowers, \
simGmtShowerDigis,simCscTriggerPrimitiveDigisRun3,simGtExtFakeStage2Digis,simGtStage2Digis
```

The update is not going to change any WF because ```simCscTriggerPrimitiveDigisRun3``` or ```simCscTriggerPrimitiveDigisPhase2``` are not use by any producer/analyzer.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

@jiafulow @eyigitba @tahuang1991 