### PR TITLE
add eras for running Run2 without mkFit

### DIFF
--- a/Configuration/Eras/python/Era_Run2_2017_noMkFit_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2017_noMkFit_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.ProcessModifiers.trackdnn_CKF_cff import trackdnn_CKF
+from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+from Configuration.Eras.ModifierChain_trackingMkFitProd_cff import trackingMkFitProd
+
+Run2_2017_noMkFit = cms.ModifierChain(Run2_2017.copyAndExclude([trackingMkFitProd]), trackdnn_CKF)

--- a/Configuration/Eras/python/Era_Run2_2018_noMkFit_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2018_noMkFit_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.ProcessModifiers.trackdnn_CKF_cff import trackdnn_CKF
+from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
+from Configuration.Eras.ModifierChain_trackingMkFitProd_cff import trackingMkFitProd
+
+Run2_2018_noMkFit = cms.ModifierChain(Run2_2018.copyAndExclude([trackingMkFitProd]), trackdnn_CKF)

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -21,6 +21,7 @@ class Eras (object):
                  'Run2_2016_trackingLowPU',
                  'Run2_2016_pA',
                  'Run2_2017',
+                 'Run2_2017_noMkFit',
                  'Run2_2017_FastSim', #new modifier for Phase1 FastSim, skips the muon GEM sequence
                  'Run2_2017_trackingRun2',
                  'Run2_2017_trackingLowPU',
@@ -31,6 +32,7 @@ class Eras (object):
                  'Run2_2018_pp_on_AA',
                  'Run2_2018_pp_on_AA_noHCALmitigation',
                  'Run2_2018_highBetaStar',
+                 'Run2_2018_noMkFit',
                  'Run3',
                  'Run3_noMkFit',
                  'Run3_pp_on_PbPb',


### PR DESCRIPTION
#### PR description:

In case there's need to re-run data workflows for 2017 and 2018 without the mkFit for reference, see e.g.: https://its.cern.ch/jira/browse/PDMVRERECO-47

#### PR validation:

cmssw compiles.


#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

cc:
@vmariani @mmasciov @slava77 