### PR TITLE
Update on the muon shower trigger for startup Run-3 (HadronicShowerTrigger-7)

### DIFF
--- a/DataFormats/L1TMuon/interface/RegionalMuonShower.h
+++ b/DataFormats/L1TMuon/interface/RegionalMuonShower.h
@@ -18,12 +18,16 @@ namespace l1t {
     RegionalMuonShower(bool oneNominalInTime = false,
                        bool oneNominalOutOfTime = false,
                        bool twoLooseInTime = false,
-                       bool twoLooseOutOfTime = false);
+                       bool twoLooseOutOfTime = false,
+                       bool oneTightInTime = false,
+                       bool oneTightOutOfTime = false);
 
     ~RegionalMuonShower();
 
     void setOneNominalInTime(const bool bit) { isOneNominalInTime_ = bit; }
     void setOneNominalOutOfTime(const bool bit) { isOneNominalOutOfTime_ = bit; }
+    void setOneTightInTime(const bool bit) { isOneTightInTime_ = bit; }
+    void setOneTightOutOfTime(const bool bit) { isOneTightOutOfTime_ = bit; }
     void setTwoLooseOutOfTime(const bool bit) { isTwoLooseOutOfTime_ = bit; }
     void setTwoLooseInTime(const bool bit) { isTwoLooseInTime_ = bit; }
 
@@ -34,6 +38,8 @@ namespace l1t {
     bool isValid() const;
     bool isOneNominalInTime() const { return isOneNominalInTime_; }
     bool isOneNominalOutOfTime() const { return isOneNominalOutOfTime_; }
+    bool isOneTightInTime() const { return isOneTightInTime_; }
+    bool isOneTightOutOfTime() const { return isOneTightOutOfTime_; }
     bool isTwoLooseInTime() const { return isTwoLooseInTime_; }
     bool isTwoLooseOutOfTime() const { return isTwoLooseOutOfTime_; }
 
@@ -50,6 +56,8 @@ namespace l1t {
     // in time and out-of-time qualities. only 2 bits each.
     bool isOneNominalInTime_;
     bool isOneNominalOutOfTime_;
+    bool isOneTightInTime_;
+    bool isOneTightOutOfTime_;
     bool isTwoLooseInTime_;
     bool isTwoLooseOutOfTime_;
     int endcap_;       //    +/-1.  For ME+ and ME-.

--- a/DataFormats/L1TMuon/src/RegionalMuonShower.cc
+++ b/DataFormats/L1TMuon/src/RegionalMuonShower.cc
@@ -3,9 +3,13 @@
 l1t::RegionalMuonShower::RegionalMuonShower(bool oneNominalInTime,
                                             bool oneNominalOutOfTime,
                                             bool twoLooseInTime,
-                                            bool twoLooseOutOfTime)
+                                            bool twoLooseOutOfTime,
+                                            bool oneTightInTime,
+                                            bool oneTightOutOfTime)
     : isOneNominalInTime_(oneNominalInTime),
       isOneNominalOutOfTime_(oneNominalOutOfTime),
+      isOneTightInTime_(oneTightInTime),
+      isOneTightOutOfTime_(oneTightOutOfTime),
       isTwoLooseInTime_(twoLooseInTime),
       isTwoLooseOutOfTime_(twoLooseOutOfTime),
       endcap_(0),
@@ -15,10 +19,12 @@ l1t::RegionalMuonShower::RegionalMuonShower(bool oneNominalInTime,
 l1t::RegionalMuonShower::~RegionalMuonShower() {}
 
 bool l1t::RegionalMuonShower::isValid() const {
-  return isOneNominalInTime_ or isTwoLooseInTime_ or isOneNominalOutOfTime_ or isTwoLooseOutOfTime_;
+  return (isOneNominalInTime_ or isTwoLooseInTime_ or isOneTightInTime_ or isOneNominalOutOfTime_ or
+          isTwoLooseOutOfTime_ or isOneTightOutOfTime_);
 }
 
 bool l1t::RegionalMuonShower::operator==(const l1t::RegionalMuonShower& rhs) const {
   return (isTwoLooseInTime_ == rhs.isTwoLooseInTime() and isOneNominalInTime_ == rhs.isOneNominalInTime() and
-          isTwoLooseOutOfTime_ == rhs.isTwoLooseOutOfTime() and isOneNominalOutOfTime_ == rhs.isOneNominalOutOfTime());
+          isOneNominalInTime_ == rhs.isOneNominalInTime() and isTwoLooseOutOfTime_ == rhs.isTwoLooseOutOfTime() and
+          isOneTightOutOfTime_ == rhs.isOneTightOutOfTime() and isOneTightOutOfTime_ == rhs.isOneTightOutOfTime());
 }

--- a/DataFormats/L1TMuon/src/RegionalMuonShower.cc
+++ b/DataFormats/L1TMuon/src/RegionalMuonShower.cc
@@ -19,12 +19,10 @@ l1t::RegionalMuonShower::RegionalMuonShower(bool oneNominalInTime,
 l1t::RegionalMuonShower::~RegionalMuonShower() {}
 
 bool l1t::RegionalMuonShower::isValid() const {
-  return (isOneNominalInTime_ or isTwoLooseInTime_ or isOneTightInTime_ or isOneNominalOutOfTime_ or
-          isTwoLooseOutOfTime_ or isOneTightOutOfTime_);
+  return (isOneNominalInTime_ or isTwoLooseInTime_ or isOneTightInTime_);
 }
 
 bool l1t::RegionalMuonShower::operator==(const l1t::RegionalMuonShower& rhs) const {
   return (isTwoLooseInTime_ == rhs.isTwoLooseInTime() and isOneNominalInTime_ == rhs.isOneNominalInTime() and
-          isOneNominalInTime_ == rhs.isOneNominalInTime() and isTwoLooseOutOfTime_ == rhs.isTwoLooseOutOfTime() and
-          isOneTightOutOfTime_ == rhs.isOneTightOutOfTime() and isOneTightOutOfTime_ == rhs.isOneTightOutOfTime());
+          isOneNominalInTime_ == rhs.isOneNominalInTime());
 }

--- a/DataFormats/L1TMuon/src/RegionalMuonShower.cc
+++ b/DataFormats/L1TMuon/src/RegionalMuonShower.cc
@@ -24,5 +24,5 @@ bool l1t::RegionalMuonShower::isValid() const {
 
 bool l1t::RegionalMuonShower::operator==(const l1t::RegionalMuonShower& rhs) const {
   return (isTwoLooseInTime_ == rhs.isTwoLooseInTime() and isOneNominalInTime_ == rhs.isOneNominalInTime() and
-          isOneNominalInTime_ == rhs.isOneNominalInTime());
+          isOneTightInTime_ == rhs.isOneTightInTime());
 }

--- a/DataFormats/L1TMuon/src/classes_def.xml
+++ b/DataFormats/L1TMuon/src/classes_def.xml
@@ -13,7 +13,8 @@
   <class name="l1t::RegionalMuonCandBxCollection"/>
   <class name="edm::Wrapper<l1t::RegionalMuonCandBxCollection>"/>
 
-  <class name="l1t::RegionalMuonShower" ClassVersion="10">
+  <class name="l1t::RegionalMuonShower" ClassVersion="11">
+    <version ClassVersion="11" checksum="376206249"/>
     <version ClassVersion="10" checksum="3501434665"/>
   </class>
   <class name="std::vector<l1t::RegionalMuonShower>"/>

--- a/DataFormats/L1Trigger/interface/MuonShower.h
+++ b/DataFormats/L1Trigger/interface/MuonShower.h
@@ -30,20 +30,53 @@ namespace l1t {
     MuonShower(bool oneNominalInTime = false,
                bool oneNominalOutOfTime = false,
                bool twoLooseInTime = false,
-               bool twoLooseOutOfTime = false);
+               bool twoLooseOutOfTime = false,
+               bool oneTightInTime = false,
+               bool oneTightOutOfTime = false);
 
     ~MuonShower() override;
 
-    void setOneNominalInTime(const bool bit) { isOneNominalInTime_ = bit; }
-    void setOneNominalOutOfTime(const bool bit) { isOneNominalOutOfTime_ = bit; }
-    void setTwoLooseInTime(const bool bit) { isTwoLooseInTime_ = bit; }
-    void setTwoLooseOutOfTime(const bool bit) { isTwoLooseOutOfTime_ = bit; }
+    /*
+      In CMSSW we consider 3 valid cases:
+      - 1 nominal shower (baseline trigger for physics at Run-3)
+      - 1 tight shower (backup trigger)
+      - 2 loose showers (to extend the physics reach)
 
+      In the uGT and UTM library, the hadronic shower trigger data is split
+      over 4 bits: 2 for in-time trigger data, 2 for out-of-time trigger data
+      - mus0, mus1 for in-time
+      - musOutOfTime0, musOutOfTime1 for out-of-time
+
+      The mapping for Run-3 startup is as follows:
+      - 1 nominal shower -> 0b01 (mus0)
+      - 1 tight shower -> 0b10 (mus1)
+
+      The 2 loose showers case would be mapped onto musOutOfTime0 and musOutOfTime1 later during Run-3
+    */
+
+    void setMus0(const bool bit) { mus0_ = bit; }
+    void setMus1(const bool bit) { mus1_ = bit; }
+    void setMusOutOfTime0(const bool bit) { musOutOfTime0_ = bit; }
+    void setMusOutOfTime1(const bool bit) { musOutOfTime1_ = bit; }
+
+    bool mus0() const { return mus0_; }
+    bool mus1() const { return mus1_; }
+    bool musOutOfTime0() const { return musOutOfTime0_; }
+    bool musOutOfTime1() const { return musOutOfTime1_; }
+
+    // at least one bit must be valid
     bool isValid() const;
-    bool isOneNominalInTime() const { return isOneNominalInTime_; }
-    bool isOneNominalOutOfTime() const { return isOneNominalOutOfTime_; }
-    bool isTwoLooseInTime() const { return isTwoLooseInTime_; }
-    bool isTwoLooseOutOfTime() const { return isTwoLooseOutOfTime_; }
+
+    // useful members for trigger performance studies
+    // needed at startup Run-3
+    bool isOneNominalInTime() const { return mus0_; }
+    bool isOneTightInTime() const { return mus1_; }
+    // to be developed during Run-3
+    bool isTwoLooseInTime() const { return false; }
+    // these options require more study
+    bool isOneNominalOutOfTime() const { return false; }
+    bool isTwoLooseOutOfTime() const { return false; }
+    bool isOneTightOutOfTime() const { return false; }
 
     virtual bool operator==(const l1t::MuonShower& rhs) const;
     virtual inline bool operator!=(const l1t::MuonShower& rhs) const { return !(operator==(rhs)); };
@@ -51,10 +84,10 @@ namespace l1t {
   private:
     // Run-3 definitions as provided in DN-20-033
     // in time and out-of-time qualities. only 2 bits each.
-    bool isOneNominalInTime_;
-    bool isOneNominalOutOfTime_;
-    bool isTwoLooseInTime_;
-    bool isTwoLooseOutOfTime_;
+    bool mus0_;
+    bool mus1_;
+    bool musOutOfTime0_;
+    bool musOutOfTime1_;
   };
 
 }  // namespace l1t

--- a/DataFormats/L1Trigger/src/MuonShower.cc
+++ b/DataFormats/L1Trigger/src/MuonShower.cc
@@ -1,19 +1,24 @@
 #include "DataFormats/L1Trigger/interface/MuonShower.h"
 
-l1t::MuonShower::MuonShower(bool oneNominalInTime, bool oneNominalOutOfTime, bool twoLooseInTime, bool twoLooseOutOfTime)
+l1t::MuonShower::MuonShower(bool oneNominalInTime,
+                            bool oneNominalOutOfTime,
+                            bool twoLooseInTime,
+                            bool twoLooseOutOfTime,
+                            bool oneTightInTime,
+                            bool oneTightOutOfTime)
     : L1Candidate(math::PtEtaPhiMLorentzVector{0., 0., 0., 0.}, 0., 0., 0., 0, 0),
-      isOneNominalInTime_(oneNominalInTime),
-      isOneNominalOutOfTime_(oneNominalOutOfTime),
-      isTwoLooseInTime_(twoLooseInTime),
-      isTwoLooseOutOfTime_(twoLooseOutOfTime) {}
+      // in this object it makes more sense to the different shower types to
+      // the 4 bits, so that the object easily interfaces with the uGT emulator
+      mus0_(oneNominalInTime),
+      mus1_(oneTightInTime),
+      musOutOfTime0_(false),
+      musOutOfTime1_(false) {}
 
 l1t::MuonShower::~MuonShower() {}
 
-bool l1t::MuonShower::isValid() const {
-  return isOneNominalInTime_ or isTwoLooseInTime_ or isOneNominalOutOfTime_ or isTwoLooseOutOfTime_;
-}
+bool l1t::MuonShower::isValid() const { return mus0_ or mus1_ or musOutOfTime0_ or musOutOfTime1_; }
 
 bool l1t::MuonShower::operator==(const l1t::MuonShower& rhs) const {
-  return (isTwoLooseInTime_ == rhs.isTwoLooseInTime() and isOneNominalInTime_ == rhs.isOneNominalInTime() and
-          isTwoLooseOutOfTime_ == rhs.isTwoLooseOutOfTime() and isOneNominalOutOfTime_ == rhs.isOneNominalOutOfTime());
+  return (mus0_ == rhs.mus0() and mus1_ == rhs.mus1() and musOutOfTime0_ == rhs.musOutOfTime0() and
+          musOutOfTime1_ == rhs.musOutOfTime1());
 }

--- a/DataFormats/L1Trigger/src/classes_def.xml
+++ b/DataFormats/L1Trigger/src/classes_def.xml
@@ -103,7 +103,8 @@
   <class name="l1t::MuonVectorRef"/>
   <class name="edm::Wrapper<l1t::MuonVectorRef>"/>
 
-  <class name="l1t::MuonShower" ClassVersion="10">
+  <class name="l1t::MuonShower" ClassVersion="11">
+   <version ClassVersion="11" checksum="3610959089"/>
    <version ClassVersion="10" checksum="3869296059"/>
   </class>
   <class name="edm::Ptr<l1t::MuonShower>"/>

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCAnodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCAnodeLCTProcessor.h
@@ -136,6 +136,7 @@ protected:
   unsigned showerMaxInTBin_;
   unsigned showerMinOutTBin_;
   unsigned showerMaxOutTBin_;
+  unsigned minLayersCentralTBin_;
 
   /** Configuration parameters. */
   unsigned int fifo_tbins, fifo_pretrig, drift_delay;

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
@@ -191,6 +191,7 @@ protected:
   unsigned showerMaxInTBin_;
   unsigned showerMinOutTBin_;
   unsigned showerMaxOutTBin_;
+  unsigned minLayersCentralTBin_;
 
   /** Configuration parameters. */
   unsigned int fifo_tbins, fifo_pretrig;  // only for test beam mode.

--- a/L1Trigger/CSCTriggerPrimitives/python/params/showerParams.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/params/showerParams.py
@@ -9,7 +9,11 @@ showerPSet = cms.PSet(
     ##    loose -> 'loose anode or loose cathode'
     ##    nominal -> 'nominal anode or nominal cathode'
     ##    tight -> 'tight anode or tight cathode'
-    source  = cms.uint32(0),
+    ## 3: cathode and anode showers
+    ##    loose -> 'loose anode and loose cathode'
+    ##    nominal -> 'nominal anode and nominal cathode'
+    ##    tight -> 'tight anode and tight cathode'
+    source  = cms.uint32(3),
 
     ## settings for cathode showers (counting CSCComparatorDigi)
     cathodeShower = cms.PSet(
@@ -21,53 +25,55 @@ showerPSet = cms.PSet(
             # ME1/1
             100, 100, 100,
             # ME1/2
-            54, 55, 61,
+            19, 38, 42,
             # ME1/3
-            20, 20, 30,
+            8, 11, 15,
             # ME2/1
-            35, 35, 35,
+            17, 33, 35,
             # ME2/2
-            29, 29, 35,
+            10, 20, 24,
             # ME3/1
-            35, 35, 40,
+            15, 31, 33,
             # ME3/2
-            24, 25, 30,
+            9, 18, 22,
             # ME4/1
-            36, 40, 40,
+            17, 34, 36,
             # ME4/2
-            26, 30, 30
+            11, 22, 26
         ),
         showerMinInTBin = cms.uint32(6),
         showerMaxInTBin = cms.uint32(8),
         showerMinOutTBin = cms.uint32(2),
         showerMaxOutTBin = cms.uint32(5),
+        minLayersCentralTBin = cms.uint32(5),
     ),
     ## settings for anode showers (counting CSCWireDigi)
     anodeShower = cms.PSet(
         ## {loose, nominal, tight} thresholds for hit counters
         showerThresholds = cms.vuint32(
             # ME1/1
-            104, 105, 107,
+            140, 140, 140,
             # ME1/2
-            92, 100, 102,
+            20, 41, 45,
             # ME1/3
-            32, 33, 48,
+            8, 12, 16,
             # ME2/1
-            133, 134, 136,
+            28, 56, 58,
             # ME2/2
-            83, 84, 86,
+            9, 18, 22,
             # ME3/1
-            130, 131, 133,
+            26, 55, 57,
             # ME3/2
-            74, 80, 87,
+            8, 16, 20,
             # ME4/1
-            127, 128, 130,
+            31, 62, 64,
             # ME4/2
-            88, 89, 94
+            13, 27, 31
         ),
         showerMinInTBin = cms.uint32(8),
-        showerMaxInTBin = cms.uint32(10),
+        showerMaxInTBin = cms.uint32(8),
         showerMinOutTBin = cms.uint32(4),
         showerMaxOutTBin = cms.uint32(7),
+        minLayersCentralTBin = cms.uint32(5),
     )
 )

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -99,7 +99,7 @@ CSCCathodeLCTProcessor::CSCCathodeLCTProcessor(unsigned endcap,
   showerMaxInTBin_ = shower.getParameter<unsigned>("showerMaxInTBin");
   showerMinOutTBin_ = shower.getParameter<unsigned>("showerMinOutTBin");
   showerMaxOutTBin_ = shower.getParameter<unsigned>("showerMaxOutTBin");
-
+  minLayersCentralTBin_ = shower.getParameter<unsigned>("minLayersCentralTBin");
   thePreTriggerDigis.clear();
 
   // quality control of stubs
@@ -180,7 +180,6 @@ void CSCCathodeLCTProcessor::clear() {
     secondCLCT[bx].clear();
   }
   inTimeHMT_ = 0;
-  outTimeHMT_ = 0;
 }
 
 std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::run(const CSCComparatorDigiCollection* compdc) {
@@ -1174,20 +1173,44 @@ CSCCLCTDigi CSCCathodeLCTProcessor::getSecondCLCT(int bx) const {
 void CSCCathodeLCTProcessor::encodeHighMultiplicityBits(
     const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_HALF_STRIPS_RUN2_TRIGGER]) {
   inTimeHMT_ = 0;
-  outTimeHMT_ = 0;
+
+  auto layerTime = [=](unsigned time) { return time == CSCConstants::CLCT_CENTRAL_BX; };
+  // Calculate layers with hits
+  unsigned nLayersWithHits = 0;
+  for (int i_layer = 0; i_layer < CSCConstants::NUM_LAYERS; i_layer++) {
+    bool atLeastOneWGHit = false;
+    for (int i_hstrip = 0; i_hstrip < CSCConstants::MAX_NUM_HALF_STRIPS_RUN2_TRIGGER; i_hstrip++) {
+      // there is at least one halfstrip...
+      if (!halfstrip[i_layer][i_hstrip].empty()) {
+        auto times = halfstrip[i_layer][i_hstrip];
+        int nLayerTime = std::count_if(times.begin(), times.end(), layerTime);
+        // ...for which at least one time bin was on for the central BX
+        if (nLayerTime > 0) {
+          atLeastOneWGHit = true;
+          break;
+        }
+      }
+    }
+    // add this layer to the number of layers hit
+    if (atLeastOneWGHit) {
+      nLayersWithHits++;
+    }
+  }
+
+  // require at least nLayersWithHits for the central time bin
+  // do nothing if there are not enough layers with hits
+  if (nLayersWithHits < minLayersCentralTBin_)
+    return;
 
   // functions for in-time and out-of-time
   auto inTime = [=](unsigned time) { return time >= showerMinInTBin_ and time <= showerMaxInTBin_; };
-  auto outTime = [=](unsigned time) { return time >= showerMinOutTBin_ and time <= showerMaxOutTBin_; };
 
   // count the half-strips in-time and out-time
   unsigned hitsInTime = 0;
-  unsigned hitsOutTime = 0;
   for (int i_layer = 0; i_layer < CSCConstants::NUM_LAYERS; i_layer++) {
     for (int i_hstrip = 0; i_hstrip < CSCConstants::MAX_NUM_HALF_STRIPS_RUN2_TRIGGER; i_hstrip++) {
       auto times = halfstrip[i_layer][i_hstrip];
       hitsInTime += std::count_if(times.begin(), times.end(), inTime);
-      hitsOutTime += std::count_if(times.begin(), times.end(), outTime);
     }
   }
 
@@ -1204,12 +1227,9 @@ void CSCCathodeLCTProcessor::encodeHighMultiplicityBits(
     if (hitsInTime >= station_thresholds[i]) {
       inTimeHMT_ = i + 1;
     }
-    if (hitsOutTime >= station_thresholds[i]) {
-      outTimeHMT_ = i + 1;
-    }
   }
 
   // no shower object is created here. that is done at a later stage
-  // in the motherboar, where potentially the trigger decisions from
+  // in the motherboard, where the trigger decisions from
   // anode hit counters and cathode hit counters are combined
 }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -570,34 +570,30 @@ void CSCMotherboard::encodeHighMultiplicityBits() {
   // get the high multiplicity
   // for anode this reflects what is already in the anode CSCShowerDigi object
   unsigned cathodeInTime = clctProc->getInTimeHMT();
-  unsigned cathodeOutTime = clctProc->getOutTimeHMT();
   unsigned anodeInTime = alctProc->getInTimeHMT();
-  unsigned anodeOutTime = alctProc->getOutTimeHMT();
 
   // assign the bits
   unsigned inTimeHMT_;
-  unsigned outTimeHMT_;
 
   // set the value according to source
   switch (showerSource_) {
     case 0:
       inTimeHMT_ = cathodeInTime;
-      outTimeHMT_ = cathodeOutTime;
       break;
     case 1:
       inTimeHMT_ = anodeInTime;
-      outTimeHMT_ = anodeOutTime;
       break;
     case 2:
       inTimeHMT_ = anodeInTime | cathodeInTime;
-      outTimeHMT_ = anodeOutTime | cathodeOutTime;
+      break;
+    case 3:
+      inTimeHMT_ = anodeInTime & cathodeInTime;
       break;
     default:
       inTimeHMT_ = cathodeInTime;
-      outTimeHMT_ = cathodeOutTime;
       break;
   };
 
   // create a new object
-  shower_ = CSCShowerDigi(inTimeHMT_, outTimeHMT_, theTrigChamber);
+  shower_ = CSCShowerDigi(inTimeHMT_, 0, theTrigChamber);
 }

--- a/L1Trigger/L1TMuonEndCap/interface/SectorProcessorShower.h
+++ b/L1Trigger/L1TMuonEndCap/interface/SectorProcessorShower.h
@@ -32,9 +32,14 @@ private:
   bool is_in_sector_csc(int tp_endcap, int tp_sector) const;
 
   int verbose_, endcap_, sector_;
+  // nominal trigger for physics
   bool enableOneNominalShower_;
+  // backup trigger
+  bool enableOneTightShower_;
+  // trigger to extend the physics reach
   bool enableTwoLooseShowers_;
   unsigned nNominalShowers_;
+  unsigned nTightShowers_;
   unsigned nLooseShowers_;
 };
 

--- a/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapShowerProducer.cc
+++ b/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapShowerProducer.cc
@@ -42,9 +42,11 @@ void L1TMuonEndCapShowerProducer::fillDescriptions(edm::ConfigurationDescription
   edm::ParameterSetDescription desc;
   // these are different shower selections that can be enabled
   desc.add<bool>("enableOneNominalShowers", true);
+  desc.add<bool>("enableOneTightShowers", true);
   desc.add<bool>("enableTwoLooseShowers", false);
   desc.add<unsigned>("nLooseShowers", 2);
   desc.add<unsigned>("nNominalShowers", 1);
+  desc.add<unsigned>("nTightShowers", 1);
   desc.add<edm::InputTag>("CSCShowerInput", edm::InputTag("simCscTriggerPrimitiveDigis"));
   descriptions.add("simEmtfShowersDef", desc);
   descriptions.setComment("This is the generic cfi file for the EMTF shower producer");

--- a/L1Trigger/L1TMuonEndCap/src/SectorProcessorShower.cc
+++ b/L1Trigger/L1TMuonEndCap/src/SectorProcessorShower.cc
@@ -10,8 +10,10 @@ void SectorProcessorShower::configure(const edm::ParameterSet& pset, int endcap,
 
   enableTwoLooseShowers_ = pset.getParameter<bool>("enableTwoLooseShowers");
   enableOneNominalShower_ = pset.getParameter<bool>("enableOneNominalShowers");
+  enableOneTightShower_ = pset.getParameter<bool>("enableOneTightShowers");
   nLooseShowers_ = pset.getParameter<unsigned>("nLooseShowers");
   nNominalShowers_ = pset.getParameter<unsigned>("nNominalShowers");
+  nTightShowers_ = pset.getParameter<unsigned>("nTightShowers");
 }
 
 void SectorProcessorShower::process(const CSCShowerDigiCollection& in_showers,
@@ -47,26 +49,27 @@ void SectorProcessorShower::process(const CSCShowerDigiCollection& in_showers,
       selected_showers.begin(), selected_showers.end(), [](CSCShowerDigi p) { return p.isLooseInTime(); }));
   const unsigned nNominalInTime(std::count_if(
       selected_showers.begin(), selected_showers.end(), [](CSCShowerDigi p) { return p.isNominalInTime(); }));
-  const unsigned nLooseOutOfTime(std::count_if(
-      selected_showers.begin(), selected_showers.end(), [](CSCShowerDigi p) { return p.isLooseOutOfTime(); }));
-  const unsigned nNominalOutOfTime(std::count_if(
-      selected_showers.begin(), selected_showers.end(), [](CSCShowerDigi p) { return p.isNominalOutOfTime(); }));
+  const unsigned nTightInTime(std::count_if(
+      selected_showers.begin(), selected_showers.end(), [](CSCShowerDigi p) { return p.isTightInTime(); }));
 
   const bool hasTwoLooseInTime(nLooseInTime >= nLooseShowers_);
   const bool hasOneNominalInTime(nNominalInTime >= nNominalShowers_);
-  const bool hasTwoLooseOutOfTime(nLooseOutOfTime >= nLooseShowers_);
-  const bool hasOneNominalOutOfTime(nNominalOutOfTime >= nNominalShowers_);
+  const bool hasOneTightInTime(nTightInTime >= nTightShowers_);
 
-  const bool acceptLoose(enableTwoLooseShowers_ and (hasTwoLooseInTime or hasTwoLooseOutOfTime));
-  const bool acceptNominal(enableOneNominalShower_ and (hasOneNominalInTime or hasOneNominalOutOfTime));
+  // for startup Run-3 we're not considering out of time triggers
+  const bool acceptLoose(enableTwoLooseShowers_ and hasTwoLooseInTime);
+  const bool acceptNominal(enableOneNominalShower_ and hasOneNominalInTime);
+  const bool acceptTight(enableOneTightShower_ and hasOneTightInTime);
+
   // trigger condition
-  const bool accept(acceptLoose or acceptNominal);
+  const bool accept(acceptLoose or acceptNominal or acceptTight);
 
   if (accept) {
     // shower output
-    l1t::RegionalMuonShower out_shower(
-        hasOneNominalInTime, hasOneNominalOutOfTime, hasTwoLooseInTime, hasTwoLooseOutOfTime);
-    out_shower.setEndcap(endcap_);
+    l1t::RegionalMuonShower out_shower(hasOneNominalInTime, false, hasTwoLooseInTime, false, hasOneTightInTime, false);
+    // convert [1,2] to [1, -1]
+    const int endcap(endcap_ == 1 ? 1 : -1);
+    out_shower.setEndcap(endcap);
     out_shower.setSector(sector_);
     out_showers.push_back(0, out_shower);
   }


### PR DESCRIPTION
#### PR description:

For startup Run-3 we aim to have 2 trigger modes for muon shower: (1) >=1 nominal shower (main trigger for physics analysis) and (2) >=1 tight shower (backup trigger for physics analysis). 
- This PR introduces the tight showers in the EMTF and uGMT. 
- It also removes the out-of-time trigger option (something that needs more study during Run-3). 
- The >=2 loose showers option is disabled since we're not considering that for Run-3 either (also needs more study). 
- The anode and cathode thresholds were updated following optimization studies with Zerobias samples for rate and MC signal samples for efficiency. 
- A layer requirement of >=5 layers was added to the cathode and anode showers to reduce the trigger rate. 
- Finally, the shower trigger in the motherboard requires by default the presence of an anode shower and a cathode shower (also reduces the trigger rate).

Relevant presentation here: https://indico.cern.ch/event/1090753/contributions/4585330/attachments/2335554/3980792/CSCShower_SD_20211027.pdf

#### PR validation:

Code compiles. Tested with Run-2 ZeroBias and Run-3 MC samples.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

@tahuang1991 @Nik-Menendez 