### PR TITLE
[EGM] Undo relaxing of GSF nHit cuts for phase2

### DIFF
--- a/TrackingTools/GsfTracking/python/CkfElectronCandidateMaker_cff.py
+++ b/TrackingTools/GsfTracking/python/CkfElectronCandidateMaker_cff.py
@@ -27,6 +27,14 @@ TrajectoryFilterForElectrons = TrackingTools.TrajectoryFiltering.TrajectoryFilte
     minGoodStripCharge = dict(refToPSet_ = 'SiStripClusterChargeCutNone')
 )
 
+# Phase2 has extended outer-tracker coverage
+# so no need to relax cuts on number of hits at high eta 
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify(TrajectoryFilterForElectrons, 
+    highEtaSwitch = 5.0,
+    minHitsAtHighEta = 5
+)
+
 # Trajectory Builder
 import RecoTracker.CkfPattern.CkfTrajectoryBuilder_cfi
 TrajectoryBuilderForElectrons = RecoTracker.CkfPattern.CkfTrajectoryBuilder_cfi.CkfTrajectoryBuilder.clone(

--- a/TrackingTools/GsfTracking/python/GsfElectronFittingSmoother_cfi.py
+++ b/TrackingTools/GsfTracking/python/GsfElectronFittingSmoother_cfi.py
@@ -8,3 +8,11 @@ GsfElectronFittingSmoother = TrackingTools.TrackFitters.KFFittingSmoother_cfi.KF
     MinNumberOfHitsHighEta = 3,
     HighEtaSwitch = 2.5
 )
+
+# Phase2 has extended outer-tracker coverage 
+# so no need to relax cuts on number of hits at high eta  
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify(GsfElectronFittingSmoother, 
+    MinNumberOfHitsHighEta = 5,
+    HighEtaSwitch = 5.0
+)


### PR DESCRIPTION
#### PR description:

In the context of eta-extended-electrons (https://github.com/cms-sw/cmssw/pull/35309, which was merged some time ago) we had relaxed cuts on number of hits in tracker while reconstructing the GSF track. This is mostly relevant for Run3, i.e. Phase1 tracker geometry, where outer-tracker coverage ends soon after |eta|=2.5. In this PR, we are stopping to propagate these relaxation of cuts to Phase2, because phase2 outer-tracker has much better eta coverage, and thus the electrons would be eta-extended anyway. 

It was found in validation that, in phase2 the relaxation of cuts actually does more harm than good in very high PU scenario. 
Link: Slide 13 of https://indico.cern.ch/event/1085302/contributions/4563231/attachments/2332176/3974663/Release_Validation_Report_2021_10_21.pdf
  
This PR aims to solve that issue. 

This PR should not have any effect on Run3 (or Run2), the only effect is expected in Phase2. The effect should be visible only in high PU scenario.

#### PR validation:
`runTheMatrix.py -l 34834.999` ran fine. It is Phase2 ttbar with PU=50.
Then analysed its output AOD file, and compared some quantities before(in red) and after(in blue) this PR. 

1) `numberOfValidHits()` in GSF tracks from collection `Handle("vector<reco::GsfTrack>"), "electronGsfTracks"`.  As expected, after this PR there is no GSF track with nhit<5.
<img width="450" alt="Screen Shot 2021-10-28 at 18 01 31" src="https://user-images.githubusercontent.com/5052706/139293542-8ec2e064-a0b4-4b7d-b52b-2ba43dc03e25.png">

2) eta of electron from the collection `Handle("vector<reco::GsfElectron>"), "ecalDrivenGsfElectronsHGC"`. Only change observed after this PR is at high eta. 
<img width="450" alt="Screen Shot 2021-10-28 at 18 09 29" src="https://user-images.githubusercontent.com/5052706/139294675-1812d383-8390-475b-83e1-a7c0f410dac5.png">
 

This PR is not a backport. 
Backport not needed.
