### PR TITLE
Faster CSCCLCTDigi::clear()

### DIFF
--- a/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
@@ -173,7 +173,7 @@ public:
   void setCompCode(const int16_t code) { compCode_ = code; }
 
   // comparator hits in this CLCT
-  const ComparatorContainer& getHits() const { return hits_; }
+  const ComparatorContainer& getHits() const { return hits_.empty() ? emptyContainer() : hits_; }
 
   void setHits(const ComparatorContainer& hits) { hits_ = hits; }
 
@@ -197,6 +197,7 @@ public:
   void setRun3(bool isRun3);
 
 private:
+  static const ComparatorContainer& emptyContainer();
   uint16_t valid_;
   uint16_t quality_;
   // Run-1/2 pattern number.
@@ -232,7 +233,6 @@ private:
 
   // which hits are in this CLCT?
   ComparatorContainer hits_;
-
   Version version_;
 };
 

--- a/DataFormats/CSCDigi/src/CSCCLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCLCTDigi.cc
@@ -13,6 +13,22 @@
 
 enum Pattern_Info { NUM_LAYERS = 6, CLCT_PATTERN_WIDTH = 11 };
 
+namespace {
+  CSCCLCTDigi::ComparatorContainer makeEmptyContainer() {
+    CSCCLCTDigi::ComparatorContainer ret;
+    ret.resize(NUM_LAYERS);
+    for (auto& p : ret) {
+      p.resize(CLCT_PATTERN_WIDTH);
+    }
+    return ret;
+  }
+}  // namespace
+
+CSCCLCTDigi::ComparatorContainer const& CSCCLCTDigi::emptyContainer() {
+  static ComparatorContainer const s_container = makeEmptyContainer();
+  return s_container;
+}
+
 /// Constructors
 CSCCLCTDigi::CSCCLCTDigi(const uint16_t valid,
                          const uint16_t quality,
@@ -45,12 +61,8 @@ CSCCLCTDigi::CSCCLCTDigi(const uint16_t valid,
       run3_eighth_strip_bit_(run3_eighth_strip_bit),
       run3_pattern_(run3_pattern),
       run3_slope_(run3_slope),
-      version_(version) {
-  hits_.resize(NUM_LAYERS);
-  for (auto& p : hits_) {
-    p.resize(CLCT_PATTERN_WIDTH);
-  }
-}
+      hits_(),
+      version_(version) {}
 
 /// Default
 CSCCLCTDigi::CSCCLCTDigi() {
@@ -77,10 +89,6 @@ void CSCCLCTDigi::clear() {
   run3_slope_ = 0;
   version_ = Version::Legacy;
   hits_.clear();
-  hits_.resize(NUM_LAYERS);
-  for (auto& p : hits_) {
-    p.resize(CLCT_PATTERN_WIDTH);
-  }
 }
 
 // slope in number of half-strips/layer


### PR DESCRIPTION
#### PR description:

The clear was a substantial fraction of a short L1Repack job. This can be see in the IB page's IgProf report for workflow 136.731.

#### PR validation:

Code compiles. I ran workflow 136.731 which worked fine. I also ran igProf after the change and the function no longer shows up.