### PR TITLE
added check to avoid seg-fault in HLTScoutingPFProducer

### DIFF
--- a/HLTrigger/JetMET/plugins/HLTScoutingPFProducer.cc
+++ b/HLTrigger/JetMET/plugins/HLTScoutingPFProducer.cc
@@ -196,7 +196,7 @@ void HLTScoutingPFProducer::produce(edm::StreamID sid, edm::Event &iEvent, edm::
       std::vector<int> candIndices;
       if (doCandidates) {
         for (auto &cand : jet.getPFConstituents()) {
-          if (not(cand.isAvailable() and cand.isNonnull())) {
+          if (not(cand.isNonnull() and cand.isAvailable())) {
             throw cms::Exception("HLTScoutingPFProducer")
                 << "invalid reference to reco::PFCandidate from reco::PFJet::getPFConstituents()";
           }

--- a/HLTrigger/JetMET/plugins/HLTScoutingPFProducer.cc
+++ b/HLTrigger/JetMET/plugins/HLTScoutingPFProducer.cc
@@ -196,6 +196,10 @@ void HLTScoutingPFProducer::produce(edm::StreamID sid, edm::Event &iEvent, edm::
       std::vector<int> candIndices;
       if (doCandidates) {
         for (auto &cand : jet.getPFConstituents()) {
+          if (not(cand.isAvailable() and cand.isNonnull())) {
+            throw cms::Exception("HLTScoutingPFProducer")
+                << "invalid reference to reco::PFCandidate from reco::PFJet::getPFConstituents()";
+          }
           if (cand->pt() > pfCandidatePtCut && std::abs(cand->eta()) < pfCandidateEtaCut) {
             //search for the candidate in the collection
             float minDR2 = 0.0001;


### PR DESCRIPTION
#### PR description:

This PR simply adds a check (throwing an exception upon failure) in `HLTScoutingPFProducer`, to prevent a crash due to an invalid reference to a `reco::PFCandidate`. This could occur, for example, if the input jet and PF-candidate collections fed to the producer are inconsistent (and the constituents of the input jets are not available anymore).

This type of crash was observed in a recent IB build (see [this comment](https://github.com/cms-sw/cmssw/pull/35863#issuecomment-953519150)); the underlying misconfiguration related to that crash is to be fixed in `ConfDB`, and is under investigation.

#### PR validation:

Private tests.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A