### PR TITLE
expand tracker-driven coverage for electron seeds; jetCore mitigation

### DIFF
--- a/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
@@ -1068,7 +1068,9 @@ void PFEGammaAlgo::removeOrLinkECALClustersToKFTracks() {
             }
           }  // loop over tracks in primary vertex
              // if associated to good non-GSF matched track remove this cluster
-          if (PFTrackAlgoTools::isGoodForEGMPrimary(trackref->algo()) && nexhits == 0 && fromprimaryvertex) {
+          if ((PFTrackAlgoTools::isGoodForEGMPrimary(trackref->algo()) ||
+               PFTrackAlgoTools::isGoodForEGMPrimary(trackref->originalAlgo())) &&
+              nexhits == 0 && fromprimaryvertex) {
             closestECAL.setFlag(false);
           }
         }

--- a/RecoParticleFlow/PFTracking/plugins/ElectronSeedMerger.cc
+++ b/RecoParticleFlow/PFTracking/plugins/ElectronSeedMerger.cc
@@ -87,7 +87,7 @@ void ElectronSeedMerger::produce(edm::StreamID, Event& iEvent, const EventSetup&
       }
       if (hitShared == (hitSeed - 1)) {
         newSeed.setCtfTrack(tSeed.ctfTrack());
-      } else if (hitShared > 0 && !newSeed.isTrackerDriven()) {
+      } else if ((hitShared > 0 || tSeed.nHits() == 0) && !newSeed.isTrackerDriven()) {
         //try to find hits in the full track
         unsigned int hitSharedOnTrack = 0;
         for (auto const& eh : newSeed.recHits()) {

--- a/RecoParticleFlow/PFTracking/plugins/ElectronSeedMerger.cc
+++ b/RecoParticleFlow/PFTracking/plugins/ElectronSeedMerger.cc
@@ -40,77 +40,62 @@ ElectronSeedMerger::ElectronSeedMerger(const ParameterSet& iConfig)
 
 // ------------ method called to produce the data  ------------
 void ElectronSeedMerger::produce(edm::StreamID, Event& iEvent, const EventSetup& iSetup) const {
+  //HANDLE THE INPUT SEED COLLECTIONS
+  auto const &eSeeds = iEvent.get(ecalSeedToken_);
+
+  ElectronSeedCollection tSeedsEmpty;
+  auto const &tSeeds = tkSeedToken_.isUninitialized() ? tSeedsEmpty : iEvent.get(tkSeedToken_);
+
   //CREATE OUTPUT COLLECTION
   auto output = std::make_unique<ElectronSeedCollection>();
-
-  //HANDLE THE INPUT SEED COLLECTIONS
-  Handle<ElectronSeedCollection> EcalBasedSeeds;
-  iEvent.getByToken(ecalSeedToken_, EcalBasedSeeds);
-  ElectronSeedCollection ESeed = *(EcalBasedSeeds.product());
-
-  Handle<ElectronSeedCollection> TkBasedSeeds;
-  ElectronSeedCollection TSeed;
-  if (!tkSeedToken_.isUninitialized()) {
-    iEvent.getByToken(tkSeedToken_, TkBasedSeeds);
-    TSeed = *(TkBasedSeeds.product());
-  }
+  output->reserve(eSeeds.size()+tSeeds.size());
 
   //VECTOR FOR MATCHED SEEDS
-  vector<bool> TSeedMatched;
-  for (unsigned int it = 0; it < TSeed.size(); it++) {
-    TSeedMatched.push_back(false);
-  }
+  vector<bool> tSeedsMatched(tSeeds.size(), false);
 
   //LOOP OVER THE ECAL SEED COLLECTION
-  ElectronSeedCollection::const_iterator e_beg = ESeed.begin();
-  ElectronSeedCollection::const_iterator e_end = ESeed.end();
-  for (; e_beg != e_end; ++e_beg) {
-    ElectronSeed NewSeed = *(e_beg);
-    bool AlreadyMatched = false;
+  for (auto newSeed : eSeeds) {//  make a copy
 
     //LOOP OVER THE TK SEED COLLECTION
-    for (unsigned int it = 0; it < TSeed.size(); it++) {
-      if (AlreadyMatched)
-        continue;
+    int it = -1;
+    for (auto const &tSeed : tSeeds) {
+      it++;
 
       //HITS FOR TK SEED
       unsigned int hitShared = 0;
       unsigned int hitSeed = 0;
-      for (auto const& eh : e_beg->recHits()) {
+      for (auto const& eh : newSeed.recHits()) {
         if (!eh.isValid())
           continue;
         hitSeed++;
-        bool Shared = false;
-        for (auto const& th : TSeed[it].recHits()) {
+
+        for (auto const& th : tSeed.recHits()) {
           if (!th.isValid())
             continue;
-          //CHECK THE HIT COMPATIBILITY: put back sharesInput
-          // as soon Egamma solves the bug on the seed collection
-          if (eh.sharesInput(&th, TrackingRecHit::all))
-            Shared = true;
-          //   if(eh->geographicalId() == th->geographicalId() &&
-          // 	     (eh->localPosition() - th->localPosition()).mag() < 0.001) Shared=true;
+          //CHECK THE HIT COMPATIBILITY
+          if (eh.sharesInput(&th, TrackingRecHit::all)) {
+            hitShared++;
+            break;
+          }
         }
-        if (Shared)
-          hitShared++;
       }
       if (hitShared == hitSeed) {
-        AlreadyMatched = true;
-        TSeedMatched[it] = true;
-        NewSeed.setCtfTrack(TSeed[it].ctfTrack());
+        tSeedsMatched[it] = true;
+        newSeed.setCtfTrack(tSeed.ctfTrack());
+        break;
       }
       if (hitShared == (hitSeed - 1)) {
-        NewSeed.setCtfTrack(TSeed[it].ctfTrack());
+        newSeed.setCtfTrack(tSeed.ctfTrack());
       }
     }
 
-    output->push_back(NewSeed);
+    output->push_back(newSeed);
   }
 
   //FILL THE COLLECTION WITH UNMATCHED TK-BASED SEED
-  for (unsigned int it = 0; it < TSeed.size(); it++) {
-    if (!TSeedMatched[it])
-      output->push_back(TSeed[it]);
+  for (unsigned int it = 0; it < tSeeds.size(); it++) {
+    if (!tSeedsMatched[it])
+      output->push_back(tSeeds[it]);
   }
 
   //PUT THE MERGED COLLECTION IN THE EVENT

--- a/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.cc
@@ -356,9 +356,6 @@ void GoodSeedProducer::produce(Event& iEvent, const EventSetup& iSetup) {
       auto tketa = tkmom.eta();
       auto tkpt = std::sqrt(tkmom.perp2());
       auto const& Seed = (*trackRef->seedRef());
-      if (Seed.nHits() == 0) {  //if DeepCore is used in jetCore iteration the seed are hitless, in case skip
-        continue;
-      }
 
       if (!disablePreId_) {
         int ipteta = getBin(Tk[i].eta(), Tk[i].pt());


### PR DESCRIPTION
Changes in this PR were motivated to mitigate the situation with tracks reconstructed multiple times, one of them jet core after introduction of mkFit to the non-jetCore iterations. Such tracks are more predominantly assigned to jetCore algorithm.

EGM/electron reco has some dependence on this:
- jetCore is not counted in PFEgammaAlgo as isGoodForEGMPrimary : to address this the same check is extended to track's `originalAlgo` to take into account also the other iteration that may have reconstructed the same track
- jetCore seeds are not included in the definition of ecalDrivenElectronSeeds and in the subsequent step where ecalDrivenElectronSeeds are merged with the trackerDrivenElectronSeeds (including jetCore) the check by seed hits alone is failing to assign a matching track to the ecal-driven seeds. To address this, the loop to match the hits is extended to include all of the track hits.

This was presented in TRK POG on Nov 1: https://indico.cern.ch/event/1092090/#3-interplay-in-high-pt-electro

Illustrations of the issue:
 in pre4 Z'->ee https://tinyurl.com/yfd22fxr  the track algorithm is more dominantly the jetCore (starts at 100 GeV)
<img width="735" alt="image" src="https://user-images.githubusercontent.com/4676718/139381429-0e55ad0b-3aa2-41bb-9142-d81b02ac0ad9.png">

the reconstructed electron provenance https://tinyurl.com/yg4rfp7c is showing a drop in the tracker-driven electrons { provenance: +1 ecal; -1 tracker; 0 either; +2 ecal-only; -2 tracker-only}
<img width="734" alt="image" src="https://user-images.githubusercontent.com/4676718/139382384-54d88fd3-fde8-4dc0-b418-8de2c952361d.png">

After this PR, on the same sample, only 100 events
default tracking with mkFit (red is new, black is pre4)
<img width="762" alt="wfZpEEec070801a56_ele2all_provenance" src="https://user-images.githubusercontent.com/4676718/139382480-8e65b1ae-3707-42ee-bae0-46cde3173750.png">

even in the CKF tracking (reco with `Run3_noMkFit`) there is a noticeable increase in the tracker-driven categorization and decrease in the ecal-only
<img width="757" alt="wfZpEEec070801a56-ckf_ele2all_provenance" src="https://user-images.githubusercontent.com/4676718/139382579-7ecf8382-8398-47df-b84a-ce013f556c34.png">

