### PR TITLE
 Fix for multiprocessing in RecoTrack Validation script [12.1.X]

### DIFF
--- a/Validation/RecoTrack/python/plotting/plotting.py
+++ b/Validation/RecoTrack/python/plotting/plotting.py
@@ -49,7 +49,8 @@ def _setStyle():
 def _getObject(tdirectory, name):
     obj = tdirectory.Get(name)
     if not obj:
-        print("Did not find {obj} from {dir}".format(obj=name, dir=tdirectory.GetPath()))
+        if verbose:
+            print("Did not find {obj} from {dir}".format(obj=name, dir=tdirectory.GetPath()))
         return None
     return obj
 

--- a/Validation/RecoTrack/python/plotting/validation.py
+++ b/Validation/RecoTrack/python/plotting/validation.py
@@ -1201,6 +1201,7 @@ def _doPlotsForPlotter(self, plotter, sample, limitSubFoldersOnlyTo=None):
         if not os.path.exists(newdir):
             os.makedirs(newdir, exist_ok=True)
 
+        plotterFolder.create(self._openFiles, self._labels, dqmSubFolder)
         p = multiprocessing.Process(target=self._doPlots, args=(plotterFolder, dqmSubFolder, newsubdir, newdir, iProc, return_dict))
         proc.append((plotterFolder, dqmSubFolder, p))
         p.start()
@@ -1294,7 +1295,6 @@ class SimpleValidation:
             self._openFiles = []
 
     def _doPlots(self, plotterFolder, dqmSubFolder, newsubdir, newdir, iProc, return_dict):
-        plotterFolder.create(self._openFiles, self._labels, dqmSubFolder)
         fileList = plotterFolder.draw(directory=newdir, **self._plotterDrawArgs)
 
         if len(fileList) == 0:
@@ -1362,7 +1362,6 @@ class SeparateValidation:
             self._openFiles = []
 
     def _doPlots(self, plotterFolder, dqmSubFolder, newsubdir, newdir, iProc, return_dict):
-        plotterFolder.create(self._openFiles, self._labels, dqmSubFolder)
         fileList = plotterFolder.draw(directory=newdir, **self._plotterDrawArgs)
 
         # check if plots are produced


### PR DESCRIPTION
backport of #35884

#### PR description:

This PR fixes a race condition introduced with the `multiprocessing` package.
No change is expected in the output as this concerns a plotting script.
Would be nice to have for validation purposes in this release cycle.

#### PR validation:

The errors reported in #35827 are gone.
```console
cmsrel CMSSW_12_1_X_2021-10-27-2300
cd CMSSW_12_1_X_2021-10-27-2300/src/
git cms-merge-topic 35884
scramv1 b -j 20
cmsenv
voms-proxy-init -voms cms
cmsDriver.py step3 -s RAW2DIGI,RECO:reconstruction_trackingOnly,VALIDATION:@trackingOnlyValidation,DQM:@trackingOnlyDQM --conditions auto:phase1_2021_realistic --datatier GEN-SIM-RECO,DQMIO -n 10 --eventcontent RECOSIM,DQM --geometry DB:Extended --era Run3 --filein /store/relval/CMSSW_12_1_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_121X_mcRun3_2021_realistic_v10_HighStat-v2/2580000/0e28f61f-234c-4358-874b-1fa4744b8d72.root --fileout file:step3.root --nThreads 8 --no_exec
cmsDriver.py step4 -s HARVESTING:@trackingOnlyValidation+@trackingOnlyDQM --conditions auto:phase1_2021_realistic --mc --geometry DB:Extended --scenario pp --filetype DQM --era Run3 -n 100 --filein file:step3_inDQM.root --fileout file:step4.root --no_exec
cmsRun step3_RAW2DIGI_RECO_VALIDATION_DQM.py
cmsRun step4_HARVESTING.py
makeTrackValidationPlots.py DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of  #35884