### PR TITLE
add `process.runType.commissioning_run` in the supported types of `beampixel_dqm_sourceclient-live` [12.1.X]

### DIFF
--- a/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
@@ -107,7 +107,7 @@ process.pixelTracksTrackingRegions.RegionPSet.originZPos       = 0.
 #----------------------------
 if (process.runType.getRunType() == process.runType.pp_run or process.runType.getRunType() == process.runType.pp_run_stage1 or 
     process.runType.getRunType() == process.runType.cosmic_run or process.runType.getRunType() == process.runType.cosmic_run_stage1 or 
-    process.runType.getRunType() == process.runType.hpu_run):
+    process.runType.getRunType() == process.runType.hpu_run or process.runType.getRunType() == process.runType.commissioning_run ):
     print("[beampixel_dqm_sourceclient-live_cfg]::running pp")
 
 


### PR DESCRIPTION
backport of #35869

#### PR description:

To fix a crash observed in the test beam when a run of DQM type `commissioning_run` was taken (see  [log](https://cmsweb.cern.ch/dqm/dqm-square/tmp/content_parser_productionPARSER_job2.log))

#### PR validation:

None

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

backport of #35869