### PR TITLE
customize `OnlineBeamSpotESProducer` inputs to be refreshed at each LS in online DQM

### DIFF
--- a/DQM/Integration/python/config/FrontierCondition_GT_cfi.py
+++ b/DQM/Integration/python/config/FrontierCondition_GT_cfi.py
@@ -2,3 +2,21 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.FrontierConditions_GlobalTag_cff import *
 from Configuration.AlCa.autoCond import autoCond
 GlobalTag.globaltag = autoCond['run3_hlt']
+
+#############################################
+#
+#              DO NOT REMOVE
+#
+# This GlobalTag customization is necessary to 
+# refresh the online BeamSpot ESProducer inputs
+# used by the online DQM clients at every LS
+# (as it done in the HLT menu).
+##############################################
+GlobalTag.toGet = cms.VPSet(
+    cms.PSet( record = cms.string( "BeamSpotOnlineLegacyObjectsRcd" ),
+              refreshTime = cms.uint64( 1 ),
+            ),
+    cms.PSet( record = cms.string( "BeamSpotOnlineHLTObjectsRcd" ),
+              refreshTime = cms.uint64( 1 )
+            )
+)


### PR DESCRIPTION
#### PR description:

During the 2021 October LHC beam test run it was noticed that, while in the first run with reasonable placing of the LHC luminous region (346373) an online beamspot measurement was available at around LS=10 (see [online DQM GUI](https://cmsweb.cern.ch/dqm/online/start?runnr=346373;dataset=/Global/Online/ALL;sampletype=online_data;filter=all;referencepos=overlay;referenceshow=customise;referencenorm=True;referenceobj1=refobj;referenceobj2=none;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=Everything;size=M;root=onlineBeamMonitor/Debug;focus=onlineBeamMonitor/Debug/hxLumibased%20BeamSpotTransient;zoom=yes;) and log of the upload to the [Conditions Database](https://cms-conddb.cern.ch/cmsDbBrowser/logs/show_O2O_log/Prod/BeamSpotOnlineHLT/2021-10-28%2021:01:37.330229)), 

![image](https://user-images.githubusercontent.com/5082376/139413394-f2491741-2cf4-4544-8a9d-412eabfc3417.png)

the information about the change of condition was not propagated properly to the other clients (see e.g. this plot from the same run of the track distance w.r.t BeamSpot: [online DQM GUI](https://cmsweb.cern.ch/dqm/online/start?runnr=346373;dataset=/Global/Online/ALL;sampletype=online_data;filter=all;referencepos=overlay;referenceshow=customise;referencenorm=True;referenceobj1=refobj;referenceobj2=none;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=Everything;size=M;root=Tracking/TrackParameters/GeneralProperties;focus=Tracking/TrackParameters/GeneralProperties/DistanceOfClosestApproachToBS_GenTk;zoom=yes;)).

![image](https://user-images.githubusercontent.com/5082376/139413049-35698382-7ab8-491f-ac5a-cfe7d4867ebb.png)

This likely means that at P5 the refresh of the conditions needed for the `OnlineBeamSposESProducer` arbitration was not enabled (as I think the frontier connection is configured as for the HLT).
We provide here the same customization of the `GlobalTag` `ESSource` used in the HLT menu to recover this issue.
I notice *en passant* that the next run (346374) did pick up the right conditions in the online GUI ( [link](https://cmsweb.cern.ch/dqm/online/start?runnr=346373;dataset=/Global/Online/ALL;sampletype=online_data;filter=all;referencepos=overlay;referenceshow=all;referencenorm=True;referenceobj1=other%3A346374%3A%3A%3A;referenceobj2=none;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=Everything;size=M;root=Tracking/TrackParameters/GeneralProperties;focus=Tracking/TrackParameters/GeneralProperties/DistanceOfClosestApproachToBS_GenTk;zoom=yes;) ) and the [Express DQM](https://tinyurl.com/yzeul67a) instead picked up the right conditions in both cases, corroborating the case for a missing refresh of the input.

#### PR validation:

The backport of this PR should be tested in the DQM online playback system using run 346373.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, but will be backported.
cc:
@gennai @francescobrivio @mtosi @vmariani 