### PR TITLE
Update customisePixelL1ClusterThresholdForRun2Input to adjust also the GPU producer

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -129,6 +129,9 @@ def customisePixelL1ClusterThresholdForRun2Input(process):
     for producer in producers_by_type(process, "SiPixelClusterProducer"):
         if hasattr(producer,"ClusterThreshold_L1"):
             producer.ClusterThreshold_L1 = 2000
+    for producer in producers_by_type(process, "SiPixelRawToClusterCUDA"):
+        if hasattr(producer,"clusterThreshold_layer1"):
+            producer.clusterThreshold_layer1 = 2000
 
     return process
 


### PR DESCRIPTION
#### PR description:

Update `customisePixelL1ClusterThresholdForRun2Input()` to adjust also the GPU producer with the Run 2 settings.

#### PR validation:

None.