### PR TITLE
Fixed bug which was crashing ROOT in fitting empty histograms

### DIFF
--- a/DQM/BeamMonitor/plugins/Vx3DHLTAnalyzer.cc
+++ b/DQM/BeamMonitor/plugins/Vx3DHLTAnalyzer.cc
@@ -1239,7 +1239,8 @@ void Vx3DHLTAnalyzer::dqmEndLuminosityBlock(const LuminosityBlock& lumiBlock, co
       }
     }
     myGaussFit->SetRange(minXfit - (maxXfit - minXfit) / 2., maxXfit + (maxXfit - minXfit) / 2.);
-    if (Vx_X_Fit->getTH1()->GetEntries() > 0) Vx_X_Fit->getTH1()->Fit(myGaussFit, "QRL");
+    if (Vx_X_Fit->getTH1()->GetEntries() > 0)
+      Vx_X_Fit->getTH1()->Fit(myGaussFit, "QRL");
 
     myGaussFit->SetParameter(0, Vx_Y_Fit->getTH1()->GetMaximum());
     myGaussFit->SetParameter(1, Vx_Y_Fit->getTH1()->GetMean());
@@ -1259,7 +1260,8 @@ void Vx3DHLTAnalyzer::dqmEndLuminosityBlock(const LuminosityBlock& lumiBlock, co
       }
     }
     myGaussFit->SetRange(minXfit - (maxXfit - minXfit) / 2., maxXfit + (maxXfit - minXfit) / 2.);
-    if (Vx_Y_Fit->getTH1()->GetEntries() > 0) Vx_Y_Fit->getTH1()->Fit(myGaussFit, "QRL");
+    if (Vx_Y_Fit->getTH1()->GetEntries() > 0)
+      Vx_Y_Fit->getTH1()->Fit(myGaussFit, "QRL");
 
     myGaussFit->SetParameter(0, Vx_Z_Fit->getTH1()->GetMaximum());
     myGaussFit->SetParameter(1, Vx_Z_Fit->getTH1()->GetMean());
@@ -1279,7 +1281,8 @@ void Vx3DHLTAnalyzer::dqmEndLuminosityBlock(const LuminosityBlock& lumiBlock, co
       }
     }
     myGaussFit->SetRange(minXfit - (maxXfit - minXfit) / 2., maxXfit + (maxXfit - minXfit) / 2.);
-    if (Vx_Z_Fit->getTH1()->GetEntries() > 0) Vx_Z_Fit->getTH1()->Fit(myGaussFit, "QRL");
+    if (Vx_Z_Fit->getTH1()->GetEntries() > 0)
+      Vx_Z_Fit->getTH1()->Fit(myGaussFit, "QRL");
 
     delete myGaussFit;
   } else if ((nLumiFit != 0) && (lumiCounter % nLumiFit != 0) && (beginTimeOfFit != 0) && (runNumber != 0)) {

--- a/DQM/BeamMonitor/plugins/Vx3DHLTAnalyzer.cc
+++ b/DQM/BeamMonitor/plugins/Vx3DHLTAnalyzer.cc
@@ -1239,7 +1239,7 @@ void Vx3DHLTAnalyzer::dqmEndLuminosityBlock(const LuminosityBlock& lumiBlock, co
       }
     }
     myGaussFit->SetRange(minXfit - (maxXfit - minXfit) / 2., maxXfit + (maxXfit - minXfit) / 2.);
-    Vx_X_Fit->getTH1()->Fit(myGaussFit, "QRL");
+    if (Vx_X_Fit->getTH1()->GetEntries() > 0) Vx_X_Fit->getTH1()->Fit(myGaussFit, "QRL");
 
     myGaussFit->SetParameter(0, Vx_Y_Fit->getTH1()->GetMaximum());
     myGaussFit->SetParameter(1, Vx_Y_Fit->getTH1()->GetMean());
@@ -1259,7 +1259,7 @@ void Vx3DHLTAnalyzer::dqmEndLuminosityBlock(const LuminosityBlock& lumiBlock, co
       }
     }
     myGaussFit->SetRange(minXfit - (maxXfit - minXfit) / 2., maxXfit + (maxXfit - minXfit) / 2.);
-    Vx_Y_Fit->getTH1()->Fit(myGaussFit, "QRL");
+    if (Vx_Y_Fit->getTH1()->GetEntries() > 0) Vx_Y_Fit->getTH1()->Fit(myGaussFit, "QRL");
 
     myGaussFit->SetParameter(0, Vx_Z_Fit->getTH1()->GetMaximum());
     myGaussFit->SetParameter(1, Vx_Z_Fit->getTH1()->GetMean());
@@ -1279,7 +1279,7 @@ void Vx3DHLTAnalyzer::dqmEndLuminosityBlock(const LuminosityBlock& lumiBlock, co
       }
     }
     myGaussFit->SetRange(minXfit - (maxXfit - minXfit) / 2., maxXfit + (maxXfit - minXfit) / 2.);
-    Vx_Z_Fit->getTH1()->Fit(myGaussFit, "QRL");
+    if (Vx_Z_Fit->getTH1()->GetEntries() > 0) Vx_Z_Fit->getTH1()->Fit(myGaussFit, "QRL");
 
     delete myGaussFit;
   } else if ((nLumiFit != 0) && (lumiCounter % nLumiFit != 0) && (beginTimeOfFit != 0) && (runNumber != 0)) {

--- a/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
@@ -2,8 +2,8 @@ from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
 import sys
-from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
-process = cms.Process("BeamPixel", Run2_2018)
+from Configuration.Eras.Era_Run3_cff import Run3
+process = cms.Process("BeamMonitor", Run3)
 
 unitTest = False
 if 'unitTest=True' in sys.argv:


### PR DESCRIPTION
#### PR description:

I fixed a bug that was crashing ROOT: the application was trying to fit empty histograms.
Now I've protected the fit by checking whether the histogram is empty or not

#### PR validation:

Now the crash should not occur anymore

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N.A.