### PR TITLE
Run3-hcs326 Avoid using legacy EDAnalyzer in CalibCalorimetry/HcalAlgos

### DIFF
--- a/CalibCalorimetry/HcalAlgos/interface/HcalLedAnalysis.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalLedAnalysis.h
@@ -2,11 +2,7 @@
 #define HcalLedAnalysis_H
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
 
 #include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
 

--- a/CalibCalorimetry/HcalAlgos/interface/HcalPedestalAnalysis.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalPedestalAnalysis.h
@@ -2,11 +2,7 @@
 #define HcalPedestalAnalysis_H
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
 

--- a/CalibCalorimetry/HcalAlgos/test/MapTester.cc
+++ b/CalibCalorimetry/HcalAlgos/test/MapTester.cc
@@ -50,7 +50,7 @@ private:
   bool generateTextfiles_;
   bool generateEmap_;
 
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
 
   // ----------member data ---------------------------
   const edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> tok_topo_;

--- a/CalibCalorimetry/HcalAlgos/test/MapTester.cc
+++ b/CalibCalorimetry/HcalAlgos/test/MapTester.cc
@@ -25,7 +25,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -40,10 +40,10 @@
 // class decleration
 //
 
-class MapTester : public edm::EDAnalyzer {
+class MapTester : public edm::one::EDAnalyzer<> {
 public:
   explicit MapTester(const edm::ParameterSet&);
-  ~MapTester();
+  ~MapTester() override = default;
 
 private:
   unsigned int mapIOV_;  //1 for first set, 2 for second, ...
@@ -61,8 +61,6 @@ MapTester::MapTester(const edm::ParameterSet& iConfig) : tok_topo_(esConsumes<Hc
   generateTextfiles_ = iConfig.getParameter<bool>("generateTextfiles");
   generateEmap_ = iConfig.getParameter<bool>("generateEmap");
 }
-
-MapTester::~MapTester() {}
 
 // ------------ method called to for each event  ------------
 void MapTester::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {


### PR DESCRIPTION
#### PR description:

Avoid using legacy EDAnalyzer in CalibCalorimetry/HcalAlgos

#### PR validation:

Use the runTheMatrix test workflows

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special