### PR TITLE
restrict RunHI2011 to 182124:40, used in the short matrix wf 140.53

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -100,7 +100,7 @@ steps['ZElSkim2011B']={'INPUT':InputInfo(dataSet='/DoubleElectron/Run2011B-ZElec
 steps['HighMet2011B']={'INPUT':InputInfo(dataSet='/Jet/Run2011B-HighMET-19Nov2011-v1/RAW-RECO',label='2011B',run=Run2011BSk)}
 
 steps['RunHI2010']={'INPUT':InputInfo(dataSet='/HIAllPhysics/HIRun2010-v1/RAW',label='hi2010',run=[152698],events=10000,location='STD')}
-steps['RunHI2011']={'INPUT':InputInfo(dataSet='/HIMinBiasUPC/HIRun2011-v1/RAW',label='hi2011',run=[182124],events=10000,location='STD')}
+steps['RunHI2011']={'INPUT':InputInfo(dataSet='/HIMinBiasUPC/HIRun2011-v1/RAW',label='hi2011',ls={182124: [40]},events=10000,location='STD')}
 steps['RunPA2013']={'INPUT':InputInfo(dataSet='/PAMinBiasUPC/HIRun2013-v1/RAW',label='pa2013',run=[211313],events=10000,location='STD')}
 
 Run2015HI={263400: [[65,904]]}


### PR DESCRIPTION
this is to improve stability in PR tests where DAS occasionally returns different files for wf 140.53

Due to a rather large number of files in 182124  /HIMinBiasUPC/HIRun2011-v1/RAW (301 file) the order of files in the das query changes occasionally, which leads to different events produced in PR tests for wf 140.53.

This PR is selecting LS 40 from the run, which should select just one file, the same file that was processed in the PR tests for this workflow in a recent IB CMSSW_12_1_X_2021-10-28-2300. The number of events in the selection is still fairly large (1428) for PR-like or even somewhat longer tests.

I'm not sure if the LS selection in relval_steps.py directly applies to relval submission, where more events may be needed. However, it's very likely that we will not run relvals for this data (I see that the last `/HIMinBiasUPC/CMSSW_*/DQMIO` was in 11_1_0)

