### PR TITLE
Include PPS Association Cuts in data and MC GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -8,77 +8,77 @@ autoCond = {
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
     'run1_mc_hi'                   : '121X_mcRun1_HeavyIon_v7',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'                 : '121X_mcRun2_startup_v7',
+    'run2_mc_50ns'                 : '121X_mcRun2_startup_v8',
     # GlobalTag for MC production (2015 L1 Trigger Stage1) with startup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
-    'run2_mc_l1stage1'             : '121X_mcRun2_asymptotic_l1stage1_v7',
+    'run2_mc_l1stage1'             : '121X_mcRun2_asymptotic_l1stage1_v8',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'                  : '121X_mcRun2_design_v7',
+    'run2_design'                  : '121X_mcRun2_design_v8',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, prior to VFP change
-    'run2_mc_pre_vfp'              : '121X_mcRun2_asymptotic_preVFP_v7',
+    'run2_mc_pre_vfp'              : '121X_mcRun2_asymptotic_preVFP_v8',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, after VFP change
-    'run2_mc'                      : '121X_mcRun2_asymptotic_v7',
+    'run2_mc'                      : '121X_mcRun2_asymptotic_v8',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'              : '121X_mcRun2cosmics_asymptotic_deco_v7',
+    'run2_mc_cosmics'              : '121X_mcRun2cosmics_asymptotic_deco_v8',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'                   : '121X_mcRun2_HeavyIon_v7',
+    'run2_mc_hi'                   : '121X_mcRun2_HeavyIon_v8',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'                   : '121X_mcRun2_pA_v7',
+    'run2_mc_pa'                   : '121X_mcRun2_pA_v8',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'                    : '121X_dataRun2_v10',
+    'run2_data'                    : '121X_dataRun2_v11',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_HEfail'             : '121X_dataRun2_HEfail_v10',
+    'run2_data_HEfail'             : '121X_dataRun2_HEfail_v11',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'             : '121X_dataRun2_relval_v10',
+    'run2_data_relval'             : '121X_dataRun2_relval_v11',
     # GlobalTag for Run2 HI data
-    'run2_data_promptlike_hi'      : '121X_dataRun2_PromptLike_HI_v9',
+    'run2_data_promptlike_hi'      : '121X_dataRun2_PromptLike_HI_v10',
     # GlobalTag for Run3 HLT: it points to the online GT
-    'run3_hlt'                     : '121X_dataRun3_HLT_v9',
+    'run3_hlt'                     : '121X_dataRun3_HLT_v11',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'              : '121X_dataRun2_HLT_relval_v9',
+    'run2_hlt_relval'              : '121X_dataRun2_HLT_relval_v11',
     # GlobalTag for Run3 data relvals (express GT)
-    'run3_data_express'            : '121X_dataRun3_Express_v10',
+    'run3_data_express'            : '121X_dataRun3_Express_v11',
     # GlobalTag for Run3 data relvals
-    'run3_data_prompt'             : '121X_dataRun3_Prompt_v9',
+    'run3_data_prompt'             : '121X_dataRun3_Prompt_v10',
     # GlobalTag for Run3 offline data reprocessing
-    'run3_data'                    : '121X_dataRun3_v8',
+    'run3_data'                    : '121X_dataRun3_v10',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'           : '121X_mc2017_design_v7',
+    'phase1_2017_design'           : '121X_mc2017_design_v9',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'        : '121X_mc2017_realistic_v7',
+    'phase1_2017_realistic'        : '121X_mc2017_realistic_v9',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector, for PP reference run
     'phase1_2017_realistic_ppref'  :  '121X_mc2017_realistic_forppRef5TeV_v1',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'          : '121X_mc2017cosmics_realistic_deco_v7',
+    'phase1_2017_cosmics'          : '121X_mc2017cosmics_realistic_deco_v9',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak'     : '121X_mc2017cosmics_realistic_peak_v7',
+    'phase1_2017_cosmics_peak'     : '121X_mc2017cosmics_realistic_peak_v9',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'           : '121X_upgrade2018_design_v7',
+    'phase1_2018_design'           : '121X_upgrade2018_design_v8',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'        : '121X_upgrade2018_realistic_v7',
+    'phase1_2018_realistic'        : '121X_upgrade2018_realistic_v8',
     # GlobalTag for MC production with realistic run-dependent (RD) conditions for full Phase1 2018 detector
-    'phase1_2018_realistic_rd'     : '121X_upgrade2018_realistic_RD_v7',
+    'phase1_2018_realistic_rd'     : '121X_upgrade2018_realistic_RD_v8',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi'     : '121X_upgrade2018_realistic_HI_v7',
+    'phase1_2018_realistic_hi'     : '121X_upgrade2018_realistic_HI_v8',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' : '121X_upgrade2018_realistic_HEfail_v7',
+    'phase1_2018_realistic_HEfail' : '121X_upgrade2018_realistic_HEfail_v8',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'          : '121X_upgrade2018cosmics_realistic_deco_v9',
+    'phase1_2018_cosmics'          : '121X_upgrade2018cosmics_realistic_deco_v10',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak'     : '121X_upgrade2018cosmics_realistic_peak_v7',
+    'phase1_2018_cosmics_peak'     : '121X_upgrade2018cosmics_realistic_peak_v8',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'           : '121X_mcRun3_2021_design_v13',
+    'phase1_2021_design'           : '121X_mcRun3_2021_design_v15',
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'        : '121X_mcRun3_2021_realistic_v15',
+    'phase1_2021_realistic'        : '121X_mcRun3_2021_realistic_v17',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'          : '121X_mcRun3_2021cosmics_realistic_deco_v15',
+    'phase1_2021_cosmics'          : '121X_mcRun3_2021cosmics_realistic_deco_v17',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi'     : '121X_mcRun3_2021_realistic_HI_v15',
+    'phase1_2021_realistic_hi'     : '121X_mcRun3_2021_realistic_HI_v17',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '121X_mcRun3_2023_realistic_v14',
+    'phase1_2023_realistic'        : '121X_mcRun3_2023_realistic_v16',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '121X_mcRun3_2024_realistic_v14',
+    'phase1_2024_realistic'        : '121X_mcRun3_2024_realistic_v16',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             : '121X_mcRun4_realistic_v7'
+    'phase2_realistic'             : '121X_mcRun4_realistic_v8'
 }
 
 aliases = {


### PR DESCRIPTION
This PR adds the PPS Association Cuts record in data and MC GTs as requested in https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4507/1.html .

The record for data is: `PPSAssociationCuts_Run3_v2`
The record for MC is: `PPSAssociationCuts_Run3_v1_mc`

The GT diffs are below.

**mcRun2_startup**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun2_startup_v7/121X_mcRun2_startup_v8

**mcRun2_asymptotic_l1stage1**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun2_asymptotic_l1stage1_v7/121X_mcRun2_asymptotic_l1stage1_v8

**mcRun2_design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun2_design_v7/121X_mcRun2_design_v8

**mcRun2_asymptotic_preVFP**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun2_asymptotic_preVFP_v7/121X_mcRun2_asymptotic_preVFP_v8

**mcRun2_asymptotic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun2_asymptotic_v7/121X_mcRun2_asymptotic_v8

**mcRun2cosmics_asymptotic_deco**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun2cosmics_asymptotic_deco_v7/121X_mcRun2cosmics_asymptotic_deco_v8

**mcRun2_HeavyIon**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun2_HeavyIon_v7/121X_mcRun2_HeavyIon_v8

**mcRun2_pA**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun2_pA_v7/121X_mcRun2_pA_v8

**dataRun2**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_dataRun2_v11/121X_dataRun2_v9

**dataRun2_HEfail**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_dataRun2_HEfail_v11/121X_dataRun2_HEfail_v10

**dataRun2_relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_dataRun2_relval_v10/121X_dataRun2_relval_v11

**dataRun2_PromptLike_HI**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_dataRun2_PromptLike_HI_v10/121X_dataRun2_PromptLike_HI_v9

**dataRun3_HLT**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_dataRun3_HLT_v11/121X_dataRun3_HLT_v9

**dataRun2_HLT_relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_dataRun2_HLT_relval_v11/121X_dataRun2_HLT_relval_v9

**dataRun3_Express**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_dataRun3_Express_v10/121X_dataRun3_Express_v11

**dataRun3_Prompt**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_dataRun3_Prompt_v10/121X_dataRun3_Prompt_v9

**dataRun3**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_dataRun3_v10/121X_dataRun3_v8

**mc2017_design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mc2017_design_v7/121X_mc2017_design_v9

**mc2017_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mc2017_realistic_v7/121X_mc2017_realistic_v9
     
**mc2017cosmics_realistic_deco**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mc2017cosmics_realistic_deco_v7/121X_mc2017cosmics_realistic_deco_v9

**mc2017cosmics_realistic_peak**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mc2017cosmics_realistic_peak_v7/121X_mc2017cosmics_realistic_peak_v9

**upgrade2018_design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_upgrade2018_design_v7/121X_upgrade2018_design_v8

**upgrade2018_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_upgrade2018_realistic_v7/121X_upgrade2018_realistic_v8

**upgrade2018_realistic_RD**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_upgrade2018_realistic_RD_v7/121X_upgrade2018_realistic_RD_v8

**upgrade2018_realistic_HI**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_upgrade2018_realistic_HI_v7/121X_upgrade2018_realistic_HI_v8

**upgrade2018_realistic_HEfail**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_upgrade2018_realistic_HEfail_v7/121X_upgrade2018_realistic_HEfail_v8

**upgrade2018cosmics_realistic_deco**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_upgrade2018cosmics_realistic_deco_v10/121X_upgrade2018cosmics_realistic_deco_v9

**upgrade2018cosmics_realistic_peak**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_upgrade2018cosmics_realistic_peak_v7/121X_upgrade2018cosmics_realistic_peak_v8

**mcRun3_2021_design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021_design_v13/121X_mcRun3_2021_design_v15

**mcRun3_2021_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021_realistic_v15/121X_mcRun3_2021_realistic_v17

**mcRun3_2021cosmics_realistic_deco**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021cosmics_realistic_deco_v15/121X_mcRun3_2021cosmics_realistic_deco_v17

**mcRun3_2021_realistic_HI**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021_realistic_HI_v15/121X_mcRun3_2021_realistic_HI_v17

**mcRun3_2023_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2023_realistic_v14/121X_mcRun3_2023_realistic_v16

**mcRun3_2024_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2024_realistic_v14/121X_mcRun3_2024_realistic_v16

**mcRun4_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun4_realistic_v7/121X_mcRun4_realistic_v8

#### PR validation:

runTheMatrix.py -l limited,145,1325.516,281,1307,10424,7.21,11224,11024.2,250200.182,7.4,12034,7.23,12834,23234,138.2,138.1,136.8642,136.88811,136.897,11925 --ibeos -j16

It was tested together with PR #35766 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport is foreseen
