### PR TITLE
improved element-removal in HLTProcess (hltGetConfiguration)

### DIFF
--- a/HLTrigger/Configuration/python/Tools/confdb.py
+++ b/HLTrigger/Configuration/python/Tools/confdb.py
@@ -208,6 +208,7 @@ _customInfo['maxEvents' ]=  %s
 _customInfo['globalTag' ]= "%s"
 _customInfo['inputFile' ]=  %s
 _customInfo['realData'  ]=  %s
+
 from HLTrigger.Configuration.customizeHLTforALL import customizeHLTforAll
 %%(process)s = customizeHLTforAll(%%(process)s,"%s",_customInfo)
 """ % (self.config.type,_gtData,_gtMc,self.config.type,self.config.type,self.config.events,self.config.globaltag,self.source,self.config.data,self.config.type)
@@ -235,6 +236,14 @@ modifyHLTforEras(%(process)s)
             customiseValues[0] = customiseValues[0].replace("/",".")
             self.data += "from "+customiseValues[0]+" import "+customiseValues[1]+"\n"
             self.data += "process = "+customiseValues[1]+"(process)\n"
+
+
+  # apply corrections to respect python syntax
+  def applySyntaxCorrections(self):
+      # remove any remaining "+"s, commas, and extra whitespaces
+      # before the first element in every (End)Path
+      self.data = re.sub(r'\bcms.EndPath\(([ ,\+])*', 'cms.EndPath( ', self.data)
+      self.data = re.sub(r'\bcms.Path\(([ ,\+])*', 'cms.Path( ', self.data)
 
 
   # customize the configuration according to the options
@@ -314,6 +323,9 @@ if 'hltGetConditions' in %(dict)s and 'HLTriggerFirstPath' in %(dict)s :
 
     # add specific customisations
     self.specificCustomize()
+
+    # fix remaining syntax errors (if any)
+    self.applySyntaxCorrections()
 
 
   def addGlobalOptions(self):
@@ -552,6 +564,7 @@ if 'PrescaleService' in process.__dict__:
   def updateMessageLogger(self):
     # request summary informations from the MessageLogger
     self.data += """
+# show summaries from trigger analysers used at HLT
 if 'MessageLogger' in %(dict)s:
     %(process)s.MessageLogger.TriggerSummaryProducerAOD = cms.untracked.PSet()
     %(process)s.MessageLogger.L1GtTrigReport = cms.untracked.PSet()
@@ -893,6 +906,7 @@ if 'GlobalTag' in %%(dict)s:
       self.parent = self.expand_filenames(self.config.parent)
 
     self.data += """
+# source module (EDM inputs)
 %(process)s.source = cms.Source( "PoolSource",
 """
     self.append_filenames("fileNames", self.source)


### PR DESCRIPTION
#### PR description:

~~This PR adds an extra check in the function that converts the outputs from ConfDB into a HLT configuration file, in order to ensure certain syntax errors are avoided. This converter is most commonly used when downloading a menu using `hltGetConfiguration`.~~

This PR adds an improvement in how `HLTProcess` removes certain elements from the `python` output obtained from ConfDB (functionality used for certain types of HLT configuration files). This comes into play, for example, when downloading a menu using `hltGetConfiguration`.

This update leads to no change for the menus that are currently in use (those are obviously converted without any syntax errors already) [*].

~~The additional syntax check~~ This update was needed when downloading from ConfDB a particular menu that made use of Tasks (`hltGetConfiguration` removes some modules a posteriori depending on the menu, and afterwards there was one comma too many inside one Task). Some details are in https://github.com/cms-sw/hlt-confdb/issues/32.

FYI: @Sam-Harper @fwyzard

[*] I took this chance to add a couple of comments to the output of `hltGetConfiguration` (independent of the syntax check added in this PR).

#### PR validation:

Private tests. Verified that `hltGetConfiguration` produces the same configuration for all menus in `/dev/CMSSW_12_2_0/`, and that the original issue with one Task-based menu is solved.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

N/A