### PR TITLE
Replace `boost/regex.hpp` with standard library `regex`

### DIFF
--- a/CalibTracker/SiStripCommon/interface/Book.h
+++ b/CalibTracker/SiStripCommon/interface/Book.h
@@ -10,7 +10,7 @@
 #include "TH2D.h"
 #include "TProfile.h"
 #include "TH3D.h"
-#include <boost/regex.hpp>
+#include <regex>
 #include <boost/iterator/filter_iterator.hpp>
 
 class Book {
@@ -25,10 +25,10 @@ class Book {
 
   struct match_name {
     match_name(string_t re) : expression(re) {}
-    bool operator()(const book_t::const_iterator::value_type& p) { return regex_match(p.first, expression); }
+    bool operator()(const book_t::const_iterator::value_type& p) { return std::regex_match(p.first, expression); }
 
   private:
-    boost::regex expression;
+    std::regex expression;
   };
 
 public:

--- a/Calibration/HcalAlCaRecoProducers/plugins/AlCaHBHEMuonProducer.cc
+++ b/Calibration/HcalAlCaRecoProducers/plugins/AlCaHBHEMuonProducer.cc
@@ -10,7 +10,6 @@
 #include <sstream>
 #include <fstream>
 #include <vector>
-#include <boost/regex.hpp>
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"

--- a/Calibration/HcalAlCaRecoProducers/plugins/AlCaIsoTracksProducer.cc
+++ b/Calibration/HcalAlCaRecoProducers/plugins/AlCaIsoTracksProducer.cc
@@ -10,7 +10,6 @@
 #include <sstream>
 #include <fstream>
 #include <vector>
-#include <boost/regex.hpp>
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"

--- a/CommonTools/Utils/src/TFileDirectory.cc
+++ b/CommonTools/Utils/src/TFileDirectory.cc
@@ -1,9 +1,8 @@
 #include <ostream>
 #include <iostream>
+#include <regex>
 
 #include "CommonTools/Utils/interface/TFileDirectory.h"
-
-#include "boost/regex.hpp"
 
 using namespace std;
 
@@ -75,11 +74,11 @@ TDirectory *TFileDirectory::_mkdir(TDirectory *dirPtr, const string &subdirName,
   }
   // if we're here, then this directory doesn't exist.  Is this
   // directory a subdirectory?
-  const boost::regex subdirRE("(.+?)/([^/]+)");
-  boost::smatch matches;
+  const std::regex subdirRE("(.+?)/([^/]+)");
+  std::smatch matches;
   TDirectory *parentDir = nullptr;
   string useName = subdirName;
-  if (boost::regex_match(subdirName, matches, subdirRE)) {
+  if (std::regex_match(subdirName, matches, subdirRE)) {
     parentDir = _mkdir(dirPtr, matches[1], description);
     useName = matches[2];
   } else {

--- a/DQM/HLTEvF/plugins/PSMonitorClient.cc
+++ b/DQM/HLTEvF/plugins/PSMonitorClient.cc
@@ -2,9 +2,6 @@
 #include <string>
 #include <cstring>
 
-// boost headers
-#include <boost/regex.hpp>
-
 // Root headers
 #include <TH1F.h>
 

--- a/DQM/HLTEvF/plugins/TriggerRatesMonitor.cc
+++ b/DQM/HLTEvF/plugins/TriggerRatesMonitor.cc
@@ -8,9 +8,6 @@
 
 #include <fmt/printf.h>
 
-// boost headers
-#include <boost/regex.hpp>
-
 // Root headers
 #include <TH1F.h>
 

--- a/DQMOffline/Trigger/plugins/HLTMuonRefMethod.cc
+++ b/DQMOffline/Trigger/plugins/HLTMuonRefMethod.cc
@@ -18,7 +18,7 @@
 #include <cmath>
 #include <climits>
 #include <boost/tokenizer.hpp>
-#include <boost/regex.hpp>
+#include <regex>
 
 #include <TH1.h>
 #include <TEfficiency.h>
@@ -55,9 +55,7 @@ private:
 };
 
 HLTMuonRefMethod::HLTMuonRefMethod(const edm::ParameterSet& pset) {
-  using VPSet = std::vector<edm::ParameterSet>;
   using vstring = std::vector<std::string>;
-  using elsc = boost::escaped_list_separator<char>;
 
   subDirs_ = pset.getUntrackedParameter<vstring>("subDirs");
   hltTriggers_ = pset.getUntrackedParameter<vstring>("hltTriggers");
@@ -69,9 +67,8 @@ HLTMuonRefMethod::HLTMuonRefMethod(const edm::ParameterSet& pset) {
 void HLTMuonRefMethod::beginJob() {}
 
 void HLTMuonRefMethod::dqmEndJob(DQMStore::IBooker& ibooker, DQMStore::IGetter& igetter) {
-  using vstring = std::vector<std::string>;
-  boost::regex metacharacters{"[\\^\\$\\.\\*\\+\\?\\|\\(\\)\\{\\}\\[\\]]"};
-  boost::smatch what;
+  std::regex metacharacters{"[\\^\\$\\.\\*\\+\\?\\|\\(\\)\\{\\}\\[\\]]"};
+  std::smatch what;
 
   // theDQM = 0;
   // theDQM = Service<DQMStore>().operator->();
@@ -85,7 +82,7 @@ void HLTMuonRefMethod::dqmEndJob(DQMStore::IBooker& ibooker, DQMStore::IGetter& 
     if (subDir[subDir.size() - 1] == '/')
       subDir.erase(subDir.size() - 1);
 
-    if (boost::regex_search(subDir, what, metacharacters)) {
+    if (std::regex_search(subDir, what, metacharacters)) {
       const string::size_type shiftPos = subDir.rfind('/');
       const string searchPath = subDir.substr(0, shiftPos);
       const string pattern = subDir.substr(shiftPos + 1, subDir.length());

--- a/DQMServices/StreamerIO/plugins/DQMFileIterator.cc
+++ b/DQMServices/StreamerIO/plugins/DQMFileIterator.cc
@@ -8,7 +8,7 @@
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/range.hpp>
-#include <boost/regex.hpp>
+#include <regex>
 #include <fmt/printf.h>
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -233,7 +233,7 @@ namespace dqmservices {
 
       directory_iterator dend;
       for (directory_iterator di(runPath); di != dend; ++di) {
-        const boost::regex fn_re("run(\\d+)_ls(\\d+)_([a-zA-Z0-9]+)(_.*)?\\.jsn");
+        const std::regex fn_re("run(\\d+)_ls(\\d+)_([a-zA-Z0-9]+)(_.*)?\\.jsn");
 
         const std::string filename = di->path().filename().string();
         const std::string fn = di->path().string();
@@ -242,8 +242,8 @@ namespace dqmservices {
           continue;
         }
 
-        boost::smatch result;
-        if (boost::regex_match(filename, result, fn_re)) {
+        std::smatch result;
+        if (std::regex_match(filename, result, fn_re)) {
           unsigned int run = std::stoi(result[1]);
           unsigned int lumi = std::stoi(result[2]);
           std::string label = result[3];

--- a/DQMServices/StreamerIO/plugins/RamdiskMonitor.cc
+++ b/DQMServices/StreamerIO/plugins/RamdiskMonitor.cc
@@ -1,12 +1,12 @@
 #include <filesystem>
 #include <map>
 #include <vector>
+#include <regex>
 #include <sys/stat.h>
 
 #include <fmt/printf.h>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/range.hpp>
-#include <boost/regex.hpp>
 
 #include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
@@ -178,7 +178,7 @@ namespace dqm {
 
     directory_iterator dend;
     for (directory_iterator di(runPath_); di != dend; ++di) {
-      const boost::regex fn_re("run(\\d+)_ls(\\d+)_([a-zA-Z0-9]+)(_.*)?\\.jsn");
+      const std::regex fn_re("run(\\d+)_ls(\\d+)_([a-zA-Z0-9]+)(_.*)?\\.jsn");
 
       const std::string filename = di->path().filename().string();
       const std::string fn = di->path().string();
@@ -187,8 +187,8 @@ namespace dqm {
         continue;
       }
 
-      boost::smatch result;
-      if (boost::regex_match(filename, result, fn_re)) {
+      std::smatch result;
+      if (std::regex_match(filename, result, fn_re)) {
         unsigned int run = std::stoi(result[1]);
         unsigned int lumi = std::stoi(result[2]);
         std::string label = result[3];
@@ -210,10 +210,7 @@ namespace dqm {
           // it's likely we have read it too soon
           filesSeen_.erase(filename);
 
-          std::string msg("Found, tried to load the json, but failed (");
-          msg += e.what();
-          msg += "): ";
-          edm::LogWarning("RamdiskMonitor") << msg;
+          edm::LogWarning("RamdiskMonitor") << "Found, tried to load the json, but failed (" << e.what() << "): ";
         }
       }
     }

--- a/DQMServices/StreamerIO/plugins/TriggerSelector.cc
+++ b/DQMServices/StreamerIO/plugins/TriggerSelector.cc
@@ -5,7 +5,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <iostream>
-#include <boost/regex.hpp>
+#include <regex>
 #include <algorithm>
 #include <cassert>
 
@@ -72,12 +72,11 @@ namespace dqmservices {
 
     // replace all possible alternate operators (.AND. and .OR.)
     {
-      using namespace boost;
       std::string temp;
-      temp = regex_replace(expression, regex(".AND."), "&&");
-      expression_ = regex_replace(temp, regex(".and."), "&&");
-      temp = regex_replace(expression_, regex(".OR."), "||");
-      expression_ = regex_replace(temp, regex(".or."), "||");
+      temp = std::regex_replace(expression, std::regex(".AND."), "&&");
+      expression_ = std::regex_replace(temp, std::regex(".and."), "&&");
+      temp = std::regex_replace(expression_, std::regex(".OR."), "||");
+      expression_ = std::regex_replace(temp, std::regex(".or."), "||");
     }
 
     // build decision tree

--- a/DataFormats/PatCandidates/interface/EventHypothesis.h
+++ b/DataFormats/PatCandidates/interface/EventHypothesis.h
@@ -3,8 +3,8 @@
 
 #include "DataFormats/Candidate/interface/CandidateFwd.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
-#include <boost/regex.hpp>
 
+#include <regex>
 #include <typeinfo>
 #include <iostream>
 #include <type_traits>
@@ -131,11 +131,11 @@ namespace pat {
     public:
       explicit RoleRegexpFilter(const std::string &roleRegexp) : re_(roleRegexp) {}
       bool operator()(const CandRefType &cand, const std::string &role) const override {
-        return boost::regex_match(role, re_);
+        return std::regex_match(role, re_);
       }
 
     private:
-      boost::regex re_;
+      std::regex re_;
     };
   }  // namespace eventhypothesis
 

--- a/EventFilter/L1TRawToDigi/src/MP7PacketReader.cc
+++ b/EventFilter/L1TRawToDigi/src/MP7PacketReader.cc
@@ -1,9 +1,7 @@
 #include "EventFilter/L1TRawToDigi/interface/MP7PacketReader.h"
 
 #include <iostream>
-
-using std::cout;
-using std::endl;
+#include <set>
 
 MP7PacketReader::MP7PacketReader(const std::string& path, uint32_t striphdr, uint32_t stripftr, uint32_t ikey)
     : reader_(path), header_(striphdr), footer_(stripftr), ikey_(ikey) {

--- a/Fireworks/Core/src/CmsShowNavigator.cc
+++ b/Fireworks/Core/src/CmsShowNavigator.cc
@@ -11,7 +11,6 @@
 
 // system include files
 #include <functional>
-#include "boost/regex.hpp"
 #include "TROOT.h"
 #include "TTree.h"
 #include "TFile.h"

--- a/Fireworks/Core/src/FWFileEntry.cc
+++ b/Fireworks/Core/src/FWFileEntry.cc
@@ -1,4 +1,4 @@
-#include <boost/regex.hpp>
+#include <regex>
 
 #include "TFile.h"
 #include "TEveTreeTools.h"
@@ -346,9 +346,9 @@ void FWFileEntry::runFilter(Filter* filter, const FWEventItemsManager* eiMng) {
       item->setEvent(nullptr);
     }
 
-    boost::regex re(std::string("\\$") + (*i)->name());
+    std::regex re(std::string("\\$") + (*i)->name());
 
-    if (boost::regex_search(interpretedSelection, re)) {
+    if (std::regex_search(interpretedSelection, re)) {
       const edm::TypeWithDict elementType(const_cast<TClass*>(item->type()));
       const edm::TypeWithDict wrapperType = edm::TypeWithDict::byName(edm::wrappedClassName(elementType.name()));
       std::string fullBranchName = m_event->getBranchNameFor(wrapperType.typeInfo(),
@@ -356,7 +356,7 @@ void FWFileEntry::runFilter(Filter* filter, const FWEventItemsManager* eiMng) {
                                                              item->productInstanceLabel().c_str(),
                                                              item->processName().c_str());
 
-      interpretedSelection = boost::regex_replace(interpretedSelection, re, fullBranchName + ".obj");
+      interpretedSelection = std::regex_replace(interpretedSelection, re, fullBranchName + ".obj");
 
       branch_names.push_back(fullBranchName);
 
@@ -456,8 +456,8 @@ void FWFileEntry::runFilter(Filter* filter, const FWEventItemsManager* eiMng) {
 bool FWFileEntry::filterEventsWithCustomParser(Filter* filterEntry) {
   std::string selection(filterEntry->m_selector->m_expression);
 
-  boost::regex re_spaces("\\s+");
-  selection = boost::regex_replace(selection, re_spaces, "");
+  std::regex re_spaces("\\s+");
+  selection = std::regex_replace(selection, re_spaces, "");
   if (selection.find("&&") != std::string::npos && selection.find("||") != std::string::npos) {
     // Combination of && and || operators not supported.
     return false;
@@ -483,10 +483,10 @@ bool FWFileEntry::filterEventsWithCustomParser(Filter* filterEntry) {
   if (selection.find("||") != std::string::npos)
     junction_mode = false;  // OR
 
-  boost::regex re("\\&\\&|\\|\\|");
+  std::regex re("\\&\\&|\\|\\|");
 
-  boost::sregex_token_iterator i(selection.begin(), selection.end(), re, -1);
-  boost::sregex_token_iterator j;
+  std::sregex_token_iterator i(selection.begin(), selection.end(), re, -1);
+  std::sregex_token_iterator j;
 
   // filters and how they enter in the logical expression
   std::vector<std::pair<unsigned int, bool>> filters;

--- a/Fireworks/Core/src/FWGeometryTableViewBase.cc
+++ b/Fireworks/Core/src/FWGeometryTableViewBase.cc
@@ -1,7 +1,6 @@
 #include <iostream>
 
 #include <functional>
-#include <boost/regex.hpp>
 
 #include "Fireworks/Core/interface/FWGeometryTableViewBase.h"
 #include "Fireworks/Core/interface/FWGeoTopNode.h"

--- a/Fireworks/Core/src/FWHLTTriggerTableView.cc
+++ b/Fireworks/Core/src/FWHLTTriggerTableView.cc
@@ -9,7 +9,7 @@
 // Original Author:
 //         Created:  Tue Jan 25 16:02:03 CET 2011
 //
-#include <boost/regex.hpp>
+#include <regex>
 
 #include "Fireworks/Core/interface/FWHLTTriggerTableView.h"
 #include "Fireworks/Core/interface/fwLog.h"
@@ -45,9 +45,9 @@ void FWHLTTriggerTableView::fillTable(fwlite::Event* event) {
     m_tableManager->dataChanged();
     return;
   }
-  boost::regex filter(m_regex.value());
+  std::regex filter(m_regex.value());
   for (unsigned int i = 0; i < triggerNames->size(); ++i) {
-    if (!boost::regex_search(triggerNames->triggerName(i), filter))
+    if (!std::regex_search(triggerNames->triggerName(i), filter))
       continue;
     m_columns.at(0).values.push_back(triggerNames->triggerName(i));
     m_columns.at(1).values.push_back(Form("%d", hTriggerResults->accept(i)));

--- a/Fireworks/Core/src/FWHLTValidator.cc
+++ b/Fireworks/Core/src/FWHLTValidator.cc
@@ -7,7 +7,7 @@
 // system include files
 #include <algorithm>
 #include <cstring>
-#include <boost/regex.hpp>
+#include <regex>
 
 // user include files
 #include "Fireworks/Core/interface/FWHLTValidator.h"
@@ -25,7 +25,7 @@ void FWHLTValidator::fillOptions(const char* iBegin,
                                  std::vector<std::pair<std::shared_ptr<std::string>, std::string> >& oOptions) const {
   oOptions.clear();
   std::string part(iBegin, iEnd);
-  part = boost::regex_replace(part, boost::regex(".*?(\\&\\&|\\|\\||\\s)+"), "");
+  part = std::regex_replace(part, std::regex(".*?(\\&\\&|\\|\\||\\s)+"), "");
 
   if (m_triggerNames.empty()) {
     edm::Handle<edm::TriggerResults> hTriggerResults;

--- a/Fireworks/Core/src/FWL1TriggerTableView.cc
+++ b/Fireworks/Core/src/FWL1TriggerTableView.cc
@@ -10,7 +10,6 @@
 //         Created:  Tue Jan 25 16:02:11 CET 2011
 //
 
-#include <boost/regex.hpp>
 #include "Fireworks/Core/interface/FWL1TriggerTableView.h"
 #include "Fireworks/Core/interface/fwLog.h"
 
@@ -22,6 +21,8 @@
 
 #include "DataFormats/L1GlobalTrigger/interface/L1GtTriggerMenuLite.h"
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h"
+
+#include <regex>
 
 FWL1TriggerTableView::FWL1TriggerTableView(TEveWindowSlot* iParent)
     : FWTriggerTableView(iParent, FWViewType::kTableL1) {
@@ -52,7 +53,7 @@ void FWL1TriggerTableView::fillTable(fwlite::Event* event) {
     int pfIndexTechTrig = -1;
     int pfIndexAlgoTrig = -1;
 
-    boost::regex filter(m_regex.value());
+    std::regex filter(m_regex.value());
 
     /// prescale factors
     std::vector<std::vector<int> > prescaleFactorsAlgoTrig = triggerMenuLite->gtPrescaleFactorsAlgoTrig();
@@ -83,7 +84,7 @@ void FWL1TriggerTableView::fillTable(fwlite::Event* event) {
       int errorCode = 0;
       const bool result = triggerMenuLite->gtTriggerResult(aName, dWord, errorCode);
 
-      if (!boost::regex_search(aName, filter))
+      if (!std::regex_search(aName, filter))
         continue;
 
       m_columns.at(0).values.push_back(aName);
@@ -102,7 +103,7 @@ void FWL1TriggerTableView::fillTable(fwlite::Event* event) {
 
     int tBitNumber = 0;
     int tBitResult = 0;
-    if (boost::regex_search(kTechTriggerName, filter)) {
+    if (std::regex_search(kTechTriggerName, filter)) {
       for (TechnicalTriggerWord::const_iterator tBitIt = ttWord.begin(), tBitEnd = ttWord.end(); tBitIt != tBitEnd;
            ++tBitIt, ++tBitNumber) {
         if (*tBitIt)

--- a/Fireworks/Core/src/expressionFormatHelpers.cc
+++ b/Fireworks/Core/src/expressionFormatHelpers.cc
@@ -10,11 +10,10 @@
 //         Created:  Fri Aug 22 12:25:04 EDT 2008
 //
 
-// system include files
-#include <boost/regex.hpp>
-
-// user include files
 #include "Fireworks/Core/src/expressionFormatHelpers.h"
+
+#include <cassert>
+#include <regex>
 
 //
 // constants, enums and typedefs
@@ -25,9 +24,9 @@ namespace fireworks {
     std::string oldToNewFormat(const std::string& iExpression) {
       //Backwards compatibility with old format: If find a $. or a () just remove them
       const std::string variable;
-      static boost::regex const reVarName("(\\$\\.)|(\\(\\))");
+      static std::regex const reVarName("(\\$\\.)|(\\(\\))");
 
-      return boost::regex_replace(iExpression, reVarName, variable);
+      return std::regex_replace(iExpression, reVarName, variable);
     }
 
     long indexFromNewFormatToOldFormat(const std::string& iNewFormat,

--- a/HLTrigger/Timer/plugins/FastTimerServiceClient.cc
+++ b/HLTrigger/Timer/plugins/FastTimerServiceClient.cc
@@ -1,9 +1,7 @@
 // C++ headers
 #include <string>
 #include <cstring>
-
-// boost headers
-#include <boost/regex.hpp>
+#include <regex>
 
 // Root headers
 #include <TH1F.h>
@@ -100,13 +98,13 @@ void FastTimerServiceClient::fillSummaryPlots(DQMStore::IBooker& booker, DQMStor
     // the plots are directly in the configured folder
     fillProcessSummaryPlots(booker, getter, m_dqm_path);
   } else {
-    static const boost::regex running_n_processes(".*/Running .*");
+    static const std::regex running_n_processes(".*/Running .*");
 
     booker.setCurrentFolder(m_dqm_path);
     std::vector<std::string> subdirs = getter.getSubdirs();
     for (auto const& subdir : subdirs) {
       // the plots are in a per-number-of-processes folder
-      if (boost::regex_match(subdir, running_n_processes)) {
+      if (std::regex_match(subdir, running_n_processes)) {
         booker.setCurrentFolder(subdir);
         if (getter.get(subdir + "/event time_real"))
           fillProcessSummaryPlots(booker, getter, subdir);
@@ -141,12 +139,12 @@ void FastTimerServiceClient::fillProcessSummaryPlots(DQMStore::IBooker& booker,
   double events = me->getTH1F()->GetEntries();
 
   // look for per-process directories
-  static const boost::regex process_name(".*/process .*");
+  static const std::regex process_name(".*/process .*");
 
   booker.setCurrentFolder(current_path);  // ?!?!?
   std::vector<std::string> subdirs = getter.getSubdirs();
   for (auto const& subdir : subdirs) {
-    if (boost::regex_match(subdir, process_name)) {
+    if (std::regex_match(subdir, process_name)) {
       getter.setCurrentFolder(subdir);
       // look for per-path plots inside each per-process directory
       std::vector<std::string> subsubdirs = getter.getSubdirs();
@@ -189,8 +187,8 @@ void FastTimerServiceClient::fillPathSummaryPlots(DQMStore::IBooker& booker,
     if (subsubdir.find(test) == std::string::npos)
       continue;
 
-    static const boost::regex prefix(current_path + "/path ");
-    std::string path = boost::regex_replace(subsubdir, prefix, "");
+    static const std::regex prefix(current_path + "/path ");
+    std::string path = std::regex_replace(subsubdir, prefix, "");
 
     paths_time->setBinLabel(ibin, path);
     paths_thread->setBinLabel(ibin, path);
@@ -366,14 +364,14 @@ void FastTimerServiceClient::fillPlotsVsLumi(DQMStore::IBooker& booker,
                                              MEPSet pset) {
   std::vector<std::string> menames;
 
-  static const boost::regex byls(".*byls");
-  static const boost::regex test(suffix);
+  static const std::regex byls(".*byls");
+  static const std::regex test(suffix);
   // get all MEs in the current_path
   getter.setCurrentFolder(current_path);
   std::vector<std::string> allmenames = getter.getMEs();
   for (auto const& m : allmenames) {
     // get only MEs vs LS
-    if (boost::regex_match(m, byls))
+    if (std::regex_match(m, byls))
       menames.push_back(m);
   }
   // if no MEs available, return

--- a/HLTrigger/Timer/plugins/ThroughputServiceClient.cc
+++ b/HLTrigger/Timer/plugins/ThroughputServiceClient.cc
@@ -1,9 +1,7 @@
 // C++ headers
 #include <string>
 #include <cstring>
-
-// boost headers
-#include <boost/regex.hpp>
+#include <regex>
 
 // Root headers
 #include <TH1F.h>
@@ -65,11 +63,11 @@ void ThroughputServiceClient::fillSummaryPlots(DQMStore::IBooker &booker, DQMSto
     // the plots are in the main folder
     folders.push_back(m_dqm_path);
   } else {
-    static const boost::regex running_n_processes(".*/Running .*");
+    static const std::regex running_n_processes(".*/Running .*");
     booker.setCurrentFolder(m_dqm_path);
     std::vector<std::string> subdirs = getter.getSubdirs();
     for (auto const &subdir : subdirs) {
-      if (boost::regex_match(subdir, running_n_processes)) {
+      if (std::regex_match(subdir, running_n_processes)) {
         if (getter.get(subdir + "/throughput_sourced"))
           // the plots are in a per-number-of-processes subfolder
           folders.push_back(subdir);

--- a/JetMETCorrections/IsolatedParticles/test/TestIsoSimTracks.cc
+++ b/JetMETCorrections/IsolatedParticles/test/TestIsoSimTracks.cc
@@ -36,7 +36,6 @@
 #include "DataFormats/CaloTowers/interface/CaloTower.h"
 #include "DataFormats/CaloTowers/interface/CaloTowerCollection.h"
 #include "DataFormats/EgammaReco/interface/SuperCluster.h"
-//#include "DataFormats/DTRecHit/interface/DTRecHitCollection.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
@@ -56,10 +55,6 @@
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 
-//#include "Geometry/DTGeometry/interface/DTLayer.h"
-//#include "Geometry/DTGeometry/interface/DTGeometry.h"
-//#include "Geometry/Records/interface/MuonGeometryRecord.h"
-
 #include "DataFormats/GeometrySurface/interface/Cylinder.h"
 #include "DataFormats/GeometrySurface/interface/Plane.h"
 
@@ -69,8 +64,6 @@
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
 #include "TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixPropagator.h"
-
-#include <boost/regex.hpp>
 
 #include "TrackingTools/TrackAssociator/interface/TrackDetectorAssociator.h"
 

--- a/JetMETCorrections/IsolatedParticles/test/TestIsoTracks.cc
+++ b/JetMETCorrections/IsolatedParticles/test/TestIsoTracks.cc
@@ -36,7 +36,6 @@
 #include "DataFormats/CaloTowers/interface/CaloTower.h"
 #include "DataFormats/CaloTowers/interface/CaloTowerCollection.h"
 #include "DataFormats/EgammaReco/interface/SuperCluster.h"
-//#include "DataFormats/DTRecHit/interface/DTRecHitCollection.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
@@ -56,10 +55,6 @@
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 
-//#include "Geometry/DTGeometry/interface/DTLayer.h"
-//#include "Geometry/DTGeometry/interface/DTGeometry.h"
-//#include "Geometry/Records/interface/MuonGeometryRecord.h"
-
 #include "DataFormats/GeometrySurface/interface/Cylinder.h"
 #include "DataFormats/GeometrySurface/interface/Plane.h"
 
@@ -69,8 +64,6 @@
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
 #include "TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixPropagator.h"
-
-#include <boost/regex.hpp>
 
 #include "TrackingTools/TrackAssociator/interface/TrackDetectorAssociator.h"
 

--- a/PhysicsTools/FWLite/src/TH1Store.cc
+++ b/PhysicsTools/FWLite/src/TH1Store.cc
@@ -3,8 +3,7 @@
 #include <fstream>
 #include <iomanip>
 #include <cassert>
-
-#include "boost/regex.hpp"
+#include <regex>
 
 #include "PhysicsTools/FWLite/interface/TH1Store.h"
 
@@ -101,11 +100,11 @@ TDirectory *TH1Store::_createDir(const string &dirName, TFile *filePtr) const {
   }
   // if we're here, then this directory doesn't exist.  Is this
   // directory a subdirectory?
-  const boost::regex subdirRE("(.+?)/([^/]+)");
-  boost::smatch matches;
+  const std::regex subdirRE("(.+?)/([^/]+)");
+  std::smatch matches;
   TDirectory *parentDir = nullptr;
   string useName = dirName;
-  if (boost::regex_match(dirName, matches, subdirRE)) {
+  if (std::regex_match(dirName, matches, subdirRE)) {
     parentDir = _createDir(matches[1], filePtr);
     useName = matches[2];
   } else {

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
@@ -16,7 +16,7 @@
 
 #include <vector>
 #include "boost/multi_array.hpp"
-#include <boost/regex.hpp>
+#include <regex>
 #include <map>
 
 #include <iostream>
@@ -692,10 +692,10 @@ LocalError PixelCPEClusterRepair::localError(DetParam const& theDetParam, Cluste
 }
 
 PixelCPEClusterRepair::Rule::Rule(const std::string& str) {
-  static const boost::regex rule("([A-Z]+)(\\s+(\\d+))?");
-  boost::cmatch match;
+  static const std::regex rule("([A-Z]+)(\\s+(\\d+))?");
+  std::cmatch match;
   // match and check it works
-  if (!regex_match(str.c_str(), match, rule))
+  if (!std::regex_match(str.c_str(), match, rule))
     throw cms::Exception("Configuration") << "Rule '" << str << "' not understood.\n";
 
   // subdet

--- a/RecoLuminosity/LumiProducer/plugins/CMSRunSummary2DB.cc
+++ b/RecoLuminosity/LumiProducer/plugins/CMSRunSummary2DB.cc
@@ -33,7 +33,7 @@
 #include <fstream>
 #include <vector>
 #include <string>
-#include <boost/regex.hpp>
+#include <regex>
 #include <boost/tokenizer.hpp>
 
 namespace lumi {
@@ -97,13 +97,13 @@ namespace lumi {
     bool isPhysics = false;
     std::string hk = rundata.hltkey;
     std::string lk = rundata.l1key;
-    boost::match_results<std::string::const_iterator> what;
-    const boost::regex lexpr("^TSC_.+_collisions_.+");
-    boost::regex_match(lk, what, lexpr, boost::match_default);
+    std::match_results<std::string::const_iterator> what;
+    const std::regex lexpr("^TSC_.+_collisions_.+");
+    std::regex_match(lk, what, lexpr, std::regex_constants::match_default);
     if (what[0].matched)
       isCollision = true;
-    const boost::regex hexpr("^/cdaq/physics/.+");
-    boost::regex_match(hk, what, hexpr, boost::match_default);
+    const std::regex hexpr("^/cdaq/physics/.+");
+    std::regex_match(hk, what, hexpr, std::regex_constants::match_default);
     if (what[0].matched)
       isPhysics = true;
     return (isCollision && isPhysics);

--- a/RecoLuminosity/LumiProducer/plugins/LumiCalculator.cc
+++ b/RecoLuminosity/LumiProducer/plugins/LumiCalculator.cc
@@ -11,7 +11,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include <boost/regex.hpp>
+#include <regex>
 #include <iostream>
 #include <map>
 #include "FWCore/Utilities/interface/EDGetToken.h"
@@ -349,9 +349,9 @@ void LumiCalculator::endJob() {}
 
 std::vector<std::string> LumiCalculator::splitpathstr(const std::string& strValue, const std::string separator) {
   std::vector<std::string> vecstrResult;
-  boost::regex re(separator);
-  boost::sregex_token_iterator p(strValue.begin(), strValue.end(), re, -1);
-  boost::sregex_token_iterator end;
+  std::regex re(separator);
+  std::sregex_token_iterator p(strValue.begin(), strValue.end(), re, -1);
+  std::sregex_token_iterator end;
   while (p != end) {
     vecstrResult.push_back(*p++);
   }

--- a/RecoLuminosity/LumiProducer/test/parseLSstate.cpp
+++ b/RecoLuminosity/LumiProducer/test/parseLSstate.cpp
@@ -26,8 +26,9 @@
 #include "RelationalAccess/ICursor.h"
 #include "RelationalAccess/ISchema.h"
 #include "RelationalAccess/ITable.h"
-#include <boost/regex.hpp>
 #include "RecoLuminosity/LumiProducer/interface/Utils.h"
+
+#include <regex>
 
 namespace lumitest {
   void stringSplit(const std::string& instr, char delim, std::vector<std::string>& results) {
@@ -79,9 +80,9 @@ int main(int argc, char** argv) {
     std::cout << "must specify the run number" << std::endl;
     return 0;
   }
-  const boost::regex physicsE("%PHYSICS_DECLARED&(true|false|N/A)&(true|false|N/A)%");
-  const boost::regex nameE("^CMS.LVL0:RUNSECTION_DELIMITER_DCSLHCFLAGS_([0-9]+)");
-  boost::match_results<std::string::const_iterator> what;
+  const std::regex physicsE("%PHYSICS_DECLARED&(true|false|N/A)&(true|false|N/A)%");
+  const std::regex nameE("^CMS.LVL0:RUNSECTION_DELIMITER_DCSLHCFLAGS_([0-9]+)");
+  std::match_results<std::string::const_iterator> what;
 
   //
   //query runinfo db
@@ -135,15 +136,15 @@ int main(int argc, char** argv) {
       std::string name = row["NAME"].data<std::string>();
       std::string value = row["STRING_VALUE"].data<std::string>();
       std::cout << "name: " << name << ", value: " << value << std::endl;
-      boost::regex_match(name, what, nameE, boost::match_default);
+      std::regex_match(name, what, nameE, std::regex_constants::match_default);
       std::string statChar;
       if (what[0].matched) {
         if (value == "null") {
           statChar = "P";  //is a pause
         } else {
-          boost::regex_search(value, what, physicsE, boost::match_default);
+          std::regex_search(value, what, physicsE, std::regex_constants::match_default);
           if (what[0].matched) {
-            std::string operatorBitValue = std::string(what[2].first, what[2].second);
+            std::string operatorBitValue{what[2].first, what[2].second};
             if (operatorBitValue == "true") {
               statChar = "T";
             } else {
@@ -161,7 +162,7 @@ int main(int argc, char** argv) {
     std::cout << "caught exception " << er.what() << std::endl;
     throw er;
   }
-  const boost::regex e("%*PHYSICS_DECLARED&(true)|(false)|(N/A)&(true)|(false)|(N/A)%");
+  const std::regex e("%*PHYSICS_DECLARED&(true)|(false)|(N/A)&(true)|(false)|(N/A)%");
 
   // float number as string for runsection delimiter,
   // "T" for true,"F" for false, "P" for pause

--- a/RecoLuminosity/LumiProducer/test/testBoostRegex.cpp
+++ b/RecoLuminosity/LumiProducer/test/testBoostRegex.cpp
@@ -3,40 +3,42 @@
 #include <fstream>
 #include <algorithm>
 #include <iterator>
-#include <boost/regex.hpp>
+#include <regex>
 #include <boost/tokenizer.hpp>
-int main(){
+int main() {
   std::string input("TK_HV_ON&N/A&N/A%PIX_HV_ON&N/A&N/A%LHC_RAMPING&false&false%PHYSICS_DECLARED&false&false%");
   std::string nameinput("CMS.LVL0:RUNSECTION_DELIMITER_DCSLHCFLAGS_5");
-  //const boost::regex e("TK_HV_ON&N/A&N/A%PIX_HV_ON&N/A&N/A%LHC_RAMPING&false&false%PHYSICS_DECLARED&(true|false|N/A)&(true|false|N/A)%$");
-  const boost::regex e("%PHYSICS_DECLARED&(true|false|N/A)&(true|false|N/A)%");
-  const boost::regex ename("^CMS.LVL0:RUNSECTION_DELIMITER_DCSLHCFLAGS_([0-9]+)");
-  boost::match_results<std::string::const_iterator> what;
-  boost::regex_search(input,what,e,boost::match_default);
-  if(what[0].matched){
-    std::cout<<"matched"<<std::endl;
-    std::cout<<std::string(what[1].first,what[1].second)<<std::endl;
-    std::cout<<std::string(what[2].first,what[2].second)<<std::endl;
+  //const std::regex e("TK_HV_ON&N/A&N/A%PIX_HV_ON&N/A&N/A%LHC_RAMPING&false&false%PHYSICS_DECLARED&(true|false|N/A)&(true|false|N/A)%$");
+  const std::regex e("%PHYSICS_DECLARED&(true|false|N/A)&(true|false|N/A)%");
+  const std::regex ename("^CMS.LVL0:RUNSECTION_DELIMITER_DCSLHCFLAGS_([0-9]+)");
+  std::match_results<std::string::const_iterator> what;
+  std::regex_search(input, what, e, std::regex_constants::match_default);
+  if (what[0].matched) {
+    std::cout << "matched" << std::endl;
+    std::cout << std::string(what[1].first, what[1].second) << std::endl;
+    std::cout << std::string(what[2].first, what[2].second) << std::endl;
   }
-  boost::regex_match(nameinput,what,ename,boost::match_default);
-  if(what[0].matched){ 
-    std::cout<<"named matched"<<std::endl;
-    std::cout<<std::string(what[1].first,what[1].second)<<std::endl;
+  std::regex_match(nameinput, what, ename, std::regex_constants::match_default);
+  if (what[0].matched) {
+    std::cout << "named matched" << std::endl;
+    std::cout << std::string(what[1].first, what[1].second) << std::endl;
   }
   std::string fname("fillsummary.dat");
   std::ifstream ins(fname.c_str());
   if (!ins.is_open()) {
-    std::cout<<"cannot open file "<<fname<<std::endl;
+    std::cout << "cannot open file " << fname << std::endl;
     return 0;
   }
-  typedef boost::tokenizer< boost::escaped_list_separator<char> > Tokenizer;
-  std::vector< std::string > result;
+  typedef boost::tokenizer<boost::escaped_list_separator<char> > Tokenizer;
+  std::vector<std::string> result;
   std::string line;
-  while(std::getline(ins,line)){
+  while (std::getline(ins, line)) {
     Tokenizer tok(line);
-    result.assign(tok.begin(),tok.end());
-    if (result.size()<3) continue;
-    std::cout<<"fill num "<<result[0]<<" , fill scheme "<<result[1]<<", ncolliding bunches "<<result[2]<<std::endl;
+    result.assign(tok.begin(), tok.end());
+    if (result.size() < 3)
+      continue;
+    std::cout << "fill num " << result[0] << " , fill scheme " << result[1] << ", ncolliding bunches " << result[2]
+              << std::endl;
     //std::copy(result.begin(),result.end(),std::ostream_iterator<std::string>(std::cout,","));
   }
 }

--- a/RecoTracker/FinalTrackSelectors/plugins/CosmicTrackSplitter.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/CosmicTrackSplitter.cc
@@ -49,8 +49,6 @@
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 #include "TrackingTools/TrackFitters/interface/TrajectoryStateCombiner.h"
 
-#include <boost/regex.hpp>
-
 /**
  * Configurables:
  *

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackerTrackHitFilter.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackerTrackHitFilter.cc
@@ -1,54 +1,43 @@
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
+#include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
+#include "DataFormats/TrackCandidate/interface/TrackCandidateCollection.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/TrackerRecHit2D/interface/ProjectedSiStripRecHit2D.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit1D.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
+#include "DataFormats/TrackingRecHit/interface/InvalidTrackingRecHit.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
-
-#include "DataFormats/Common/interface/View.h"
-#include "DataFormats/TrackReco/interface/TrackFwd.h"
-#include "DataFormats/TrackReco/interface/Track.h"
-#include "DataFormats/TrackCandidate/interface/TrackCandidateCollection.h"
-#include "DataFormats/TrackingRecHit/interface/InvalidTrackingRecHit.h"
-
+#include "FWCore/Utilities/interface/InputTag.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
-#include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
-#include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
-
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "Geometry/Records/interface/TrackerTopologyRcd.h"
-#include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
-
-//for S/N cut
-#include "DataFormats/TrackerRecHit2D/interface/ProjectedSiStripRecHit2D.h"
-#include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h"
-#include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
-#include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit1D.h"
-#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
 #include "RecoLocalTracker/SiStripClusterizer/interface/SiStripClusterInfo.h"
-//for angle cut
+#include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 #include "TrackingTools/PatternTools/interface/TrajectoryMeasurement.h"
-#include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
-#include "TrackingTools/TrackFitters/interface/TrajectoryStateCombiner.h"
-#include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
-#include "TMath.h"
-
 #include "TrackingTools/Records/interface/TransientRecHitRecord.h"
+#include "TrackingTools/TrackFitters/interface/TrajectoryStateCombiner.h"
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
 
-#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
+#include "TMath.h"
 
-#include <boost/regex.hpp>
-#include <map>
-//#include <math>
+#include <regex>
 
 /**
  * Configurables:
@@ -171,8 +160,8 @@ namespace reco {
     };  // class
 
     TrackerTrackHitFilter::Rule::Rule(const std::string &str) {
-      static const boost::regex rule("(keep|drop)\\s+([A-Z]+)(\\s+(\\d+))?");
-      boost::cmatch match;
+      static const std::regex rule("(keep|drop)\\s+([A-Z]+)(\\s+(\\d+))?");
+      std::cmatch match;
       std::string match_1;
       std::string match_2;
       std::string match_3;
@@ -220,13 +209,13 @@ namespace reco {
       // match a set of capital case chars (preceded by an arbitrary number of leading blanks),
       //followed b an arbitrary number of blanks, one or more digits (not necessary, they cannot also be,
       // another set of blank spaces and, again another *eventual* digit
-      // static boost::regex rule("\\s+([A-Z]+)(\\s+(\\d+)(\\.)?(\\d+))?(\\s+(\\d+)(\\.)?(\\d+))?");
-      static const boost::regex rule(
+      // static std::regex rule("\\s+([A-Z]+)(\\s+(\\d+)(\\.)?(\\d+))?(\\s+(\\d+)(\\.)?(\\d+))?");
+      static const std::regex rule(
           "([A-Z]+)"
           "\\s*(\\d+\\.*\\d*)?"
           "\\s*(\\d+\\.*\\d*)?");
 
-      boost::cmatch match;
+      std::cmatch match;
       std::string match_1;
       std::string match_2;
       std::string match_3;

--- a/TrackingTools/TrackAssociator/test/CaloMatchingExample.cc
+++ b/TrackingTools/TrackAssociator/test/CaloMatchingExample.cc
@@ -69,8 +69,6 @@
 
 #include "TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixPropagator.h"
 
-#include <boost/regex.hpp>
-
 #include "TrackingTools/TrackAssociator/interface/TrackDetectorAssociator.h"
 #include "TrackingTools/TrackAssociator/interface/TrackAssociatorParameters.h"
 

--- a/TrackingTools/TrackAssociator/test/TestTrackAssociator.cc
+++ b/TrackingTools/TrackAssociator/test/TestTrackAssociator.cc
@@ -71,8 +71,6 @@
 
 #include "TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixPropagator.h"
 
-#include <boost/regex.hpp>
-
 #include "TrackingTools/TrackAssociator/interface/TrackDetectorAssociator.h"
 #include "TrackingTools/TrackAssociator/interface/TrackAssociatorParameters.h"
 


### PR DESCRIPTION
#### PR description:

Title says it all: a boost feature is replaced with the corresponding standard library feature.

#### PR validation:

CMSSW compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport intended.
