### PR TITLE
Include reduced material DD4HEP geometry scenarios in Run-3 MC GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -64,17 +64,17 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak'     : '121X_upgrade2018cosmics_realistic_peak_v8',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'           : '121X_mcRun3_2021_design_v15',
+    'phase1_2021_design'           : '121X_mcRun3_2021_design_v16',
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'        : '121X_mcRun3_2021_realistic_v17',
+    'phase1_2021_realistic'        : '121X_mcRun3_2021_realistic_v18',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'          : '121X_mcRun3_2021cosmics_realistic_deco_v17',
+    'phase1_2021_cosmics'          : '121X_mcRun3_2021cosmics_realistic_deco_v18',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi'     : '121X_mcRun3_2021_realistic_HI_v17',
+    'phase1_2021_realistic_hi'     : '121X_mcRun3_2021_realistic_HI_v18',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '121X_mcRun3_2023_realistic_v16',
+    'phase1_2023_realistic'        : '121X_mcRun3_2023_realistic_v17',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '121X_mcRun3_2024_realistic_v16',
+    'phase1_2024_realistic'        : '121X_mcRun3_2024_realistic_v17',
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             : '121X_mcRun4_realistic_v8'
 }


### PR DESCRIPTION
#### PR description:

Include reduced material DD4hep geometry scenarios in Run-3 MC GTs as requested in [1]

I've created new GTs

* 121X_mcRun3_2021_design_v16
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021_design_v15/121X_mcRun3_2021_design_v16
* 121X_mcRun3_2021_realistic_v18
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021_realistic_v17/121X_mcRun3_2021_realistic_v18
* 121X_mcRun3_2021cosmics_realistic_deco_v18
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021cosmics_realistic_deco_v17/121X_mcRun3_2021cosmics_realistic_deco_v18
* 121X_mcRun3_2021_realistic_HI_v18
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2021_realistic_HI_v17/121X_mcRun3_2021_realistic_HI_v18
* 121X_mcRun3_2023_realistic_v17
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2023_realistic_v16/121X_mcRun3_2023_realistic_v17
* 121X_mcRun3_2024_realistic_v17
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/121X_mcRun3_2024_realistic_v16/121X_mcRun3_2024_realistic_v17

The diffs are only in the requested tags of 
```
XMLFILE_Geometry_121DD4hepV2_Extended2021ZeroMaterial_mc, label: ZeroMaterial

XMLFILE_Geometry_121DD4hepV2_Extended2021FlatMinus05Percent_mc, label: FlatMinus05Percent

XMLFILE_Geometry_121DD4hepV2_Extended2021FlatMinus10Percent_mc, label: FlatMinus10Percent

XMLFILE_Geometry_121DD4hepV2_Extended2021FlatPlus05Percent_mc, label: FlatPlus05Percent

XMLFILE_Geometry_121DD4hepV2_Extended2021FlatPlus10Percent_mc, label: FlatPlus10Percent
```

[1] https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4510.html

#### PR validation:

The tags are not consumed by default but only in special campaigns. 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A


cc @cvuosalo 


resolves https://github.com/cms-AlCaDB/AlCaTools/issues/47