### PR TITLE
Fix charged and neutral candidate converters for reco::Jets

### DIFF
--- a/RecoBTag/FeatureTools/interface/ChargedCandidateConverter.h
+++ b/RecoBTag/FeatureTools/interface/ChargedCandidateConverter.h
@@ -53,20 +53,22 @@ namespace btagbtvdeep {
 
     // subjet related
     const auto* patJet = dynamic_cast<const pat::Jet*>(&jet);
-    if (!patJet) {
-      throw edm::Exception(edm::errors::InvalidReference) << "Input is not a pat::Jet.";
-    }
 
-    if (patJet->nSubjetCollections() > 0) {
-      auto subjets = patJet->subjets();
-      // sort by pt
-      std::sort(subjets.begin(), subjets.end(), [](const edm::Ptr<pat::Jet>& p1, const edm::Ptr<pat::Jet>& p2) {
-        return p1->pt() > p2->pt();
-      });
-      c_pf_features.drsubjet1 = !subjets.empty() ? reco::deltaR(*c_pf, *subjets.at(0)) : -1;
-      c_pf_features.drsubjet2 = subjets.size() > 1 ? reco::deltaR(*c_pf, *subjets.at(1)) : -1;
+    if (patJet) {
+      if (patJet->nSubjetCollections() > 0) {
+        auto subjets = patJet->subjets();
+        // sort by pt
+        std::sort(subjets.begin(), subjets.end(), [](const edm::Ptr<pat::Jet>& p1, const edm::Ptr<pat::Jet>& p2) {
+          return p1->pt() > p2->pt();
+        });
+        c_pf_features.drsubjet1 = !subjets.empty() ? reco::deltaR(*c_pf, *subjets.at(0)) : -1;
+        c_pf_features.drsubjet2 = subjets.size() > 1 ? reco::deltaR(*c_pf, *subjets.at(1)) : -1;
+      } else {
+        // AK4 jets don't have subjets
+        c_pf_features.drsubjet1 = -1;
+        c_pf_features.drsubjet2 = -1;
+      }
     } else {
-      // AK4 jets don't have subjets
       c_pf_features.drsubjet1 = -1;
       c_pf_features.drsubjet2 = -1;
     }

--- a/RecoBTag/FeatureTools/interface/ChargedCandidateConverter.h
+++ b/RecoBTag/FeatureTools/interface/ChargedCandidateConverter.h
@@ -51,27 +51,9 @@ namespace btagbtvdeep {
 
     c_pf_features.drminsv = catch_infs_and_bound(drminpfcandsv, 0, -1. * jetR, 0, -1. * jetR);
 
-    // subjet related
-    const auto* patJet = dynamic_cast<const pat::Jet*>(&jet);
-
-    if (patJet) {
-      if (patJet->nSubjetCollections() > 0) {
-        auto subjets = patJet->subjets();
-        // sort by pt
-        std::sort(subjets.begin(), subjets.end(), [](const edm::Ptr<pat::Jet>& p1, const edm::Ptr<pat::Jet>& p2) {
-          return p1->pt() > p2->pt();
-        });
-        c_pf_features.drsubjet1 = !subjets.empty() ? reco::deltaR(*c_pf, *subjets.at(0)) : -1;
-        c_pf_features.drsubjet2 = subjets.size() > 1 ? reco::deltaR(*c_pf, *subjets.at(1)) : -1;
-      } else {
-        // AK4 jets don't have subjets
-        c_pf_features.drsubjet1 = -1;
-        c_pf_features.drsubjet2 = -1;
-      }
-    } else {
-      c_pf_features.drsubjet1 = -1;
-      c_pf_features.drsubjet2 = -1;
-    }
+    std::pair<float, float> drSubjetFeatures = getDRSubjetFeatures(jet, c_pf);
+    c_pf_features.drsubjet1 = drSubjetFeatures.first;
+    c_pf_features.drsubjet2 = drSubjetFeatures.second;
   }
 
   void packedCandidateToFeatures(const pat::PackedCandidate* c_pf,

--- a/RecoBTag/FeatureTools/interface/NeutralCandidateConverter.h
+++ b/RecoBTag/FeatureTools/interface/NeutralCandidateConverter.h
@@ -32,18 +32,20 @@ namespace btagbtvdeep {
                                         NeutralCandidateFeatures& n_pf_features) {
     const auto* patJet = dynamic_cast<const pat::Jet*>(&jet);
 
-    if (!patJet) {
-      throw edm::Exception(edm::errors::InvalidReference) << "Input is not a pat::Jet.";
-    }
     // Do Subjets
-    if (patJet->nSubjetCollections() > 0) {
-      auto subjets = patJet->subjets();
-      // sort by pt
-      std::sort(subjets.begin(), subjets.end(), [](const edm::Ptr<pat::Jet>& p1, const edm::Ptr<pat::Jet>& p2) {
-        return p1->pt() > p2->pt();
-      });
-      n_pf_features.drsubjet1 = !subjets.empty() ? reco::deltaR(*n_pf, *subjets.at(0)) : -1;
-      n_pf_features.drsubjet2 = subjets.size() > 1 ? reco::deltaR(*n_pf, *subjets.at(1)) : -1;
+    if (patJet) {
+      if (patJet->nSubjetCollections() > 0) {
+        auto subjets = patJet->subjets();
+        // sort by pt
+        std::sort(subjets.begin(), subjets.end(), [](const edm::Ptr<pat::Jet>& p1, const edm::Ptr<pat::Jet>& p2) {
+          return p1->pt() > p2->pt();
+        });
+        n_pf_features.drsubjet1 = !subjets.empty() ? reco::deltaR(*n_pf, *subjets.at(0)) : -1;
+        n_pf_features.drsubjet2 = subjets.size() > 1 ? reco::deltaR(*n_pf, *subjets.at(1)) : -1;
+      } else {
+        n_pf_features.drsubjet1 = -1;
+        n_pf_features.drsubjet2 = -1;
+      }
     } else {
       n_pf_features.drsubjet1 = -1;
       n_pf_features.drsubjet2 = -1;

--- a/RecoBTag/FeatureTools/interface/NeutralCandidateConverter.h
+++ b/RecoBTag/FeatureTools/interface/NeutralCandidateConverter.h
@@ -30,26 +30,9 @@ namespace btagbtvdeep {
                                         const float& drminpfcandsv,
                                         const float& jetR,
                                         NeutralCandidateFeatures& n_pf_features) {
-    const auto* patJet = dynamic_cast<const pat::Jet*>(&jet);
-
-    // Do Subjets
-    if (patJet) {
-      if (patJet->nSubjetCollections() > 0) {
-        auto subjets = patJet->subjets();
-        // sort by pt
-        std::sort(subjets.begin(), subjets.end(), [](const edm::Ptr<pat::Jet>& p1, const edm::Ptr<pat::Jet>& p2) {
-          return p1->pt() > p2->pt();
-        });
-        n_pf_features.drsubjet1 = !subjets.empty() ? reco::deltaR(*n_pf, *subjets.at(0)) : -1;
-        n_pf_features.drsubjet2 = subjets.size() > 1 ? reco::deltaR(*n_pf, *subjets.at(1)) : -1;
-      } else {
-        n_pf_features.drsubjet1 = -1;
-        n_pf_features.drsubjet2 = -1;
-      }
-    } else {
-      n_pf_features.drsubjet1 = -1;
-      n_pf_features.drsubjet2 = -1;
-    }
+    std::pair<float, float> drSubjetFeatures = getDRSubjetFeatures(jet, n_pf);
+    n_pf_features.drsubjet1 = drSubjetFeatures.first;
+    n_pf_features.drsubjet2 = drSubjetFeatures.second;
 
     // Jet relative vars
     n_pf_features.ptrel = catch_infs_and_bound(n_pf->pt() / jet.pt(), 0, -1, 0, -1);

--- a/RecoBTag/FeatureTools/interface/deep_helpers.h
+++ b/RecoBTag/FeatureTools/interface/deep_helpers.h
@@ -75,6 +75,8 @@ namespace btagbtvdeep {
   float quality_from_pfcand(const reco::PFCandidate &pfcand);
   float lost_inner_hits_from_pfcand(const reco::PFCandidate &pfcand);
 
+  std::pair<float, float> getDRSubjetFeatures(const reco::Jet &jet, const reco::Candidate *cand);
+
   // struct to hold preprocessing parameters
   struct PreprocessParams {
     struct VarInfo {

--- a/RecoBTag/FeatureTools/src/deep_helpers.cc
+++ b/RecoBTag/FeatureTools/src/deep_helpers.cc
@@ -119,4 +119,31 @@ namespace btagbtvdeep {
     return int16_t((qualityFlags & lostInnerHitsMask) >> lostInnerHitsShift) - 1;
   }
 
+  std::pair<float, float> getDRSubjetFeatures(const reco::Jet &jet, const reco::Candidate *cand) {
+    const auto *patJet = dynamic_cast<const pat::Jet *>(&jet);
+    std::pair<float, float> features;
+    // Do Subjets
+    if (patJet) {
+      if (patJet->nSubjetCollections() > 0) {
+        const auto &subjets = patJet->subjets();
+        const auto largest = std::max_element(
+            subjets.begin(), subjets.end(), [](const edm::Ptr<pat::Jet> &p1, const edm::Ptr<pat::Jet> &p2) {
+              return p1->pt() < p2->pt();
+            });
+        const auto secondLargest = std::max_element(
+            subjets.begin(), subjets.end(), [&largest](const edm::Ptr<pat::Jet> &p1, const edm::Ptr<pat::Jet> &p2) {
+              return ((p2 != (*largest)) && (p1->pt() < p2->pt()));
+            });
+        features.first = !subjets.empty() ? reco::deltaR(*cand, *subjets[largest - subjets.begin()]) : -1;
+        features.second = subjets.size() > 1 ? reco::deltaR(*cand, *subjets[secondLargest - subjets.begin()]) : -1;
+      } else {
+        features.first = -1;
+        features.second = -1;
+      }
+    } else {
+      features.first = -1;
+      features.second = -1;
+    }
+    return features;
+  }
 }  // namespace btagbtvdeep

--- a/RecoBTag/FeatureTools/src/deep_helpers.cc
+++ b/RecoBTag/FeatureTools/src/deep_helpers.cc
@@ -126,9 +126,11 @@ namespace btagbtvdeep {
     if (patJet) {
       if (patJet->nSubjetCollections() > 0) {
         auto subjets = patJet->subjets();
-        std::nth_element(subjets.begin(), subjets.begin()+1, subjets.end(), [](const edm::Ptr<pat::Jet> &p1, const edm::Ptr<pat::Jet> &p2) {
-          return p1->pt() > p2->pt();
-        });
+        std::nth_element(
+            subjets.begin(),
+            subjets.begin() + 1,
+            subjets.end(),
+            [](const edm::Ptr<pat::Jet> &p1, const edm::Ptr<pat::Jet> &p2) { return p1->pt() > p2->pt(); });
         features.first = !subjets.empty() ? reco::deltaR(*cand, *subjets[0]) : -1;
         features.second = subjets.size() > 1 ? reco::deltaR(*cand, *subjets[1]) : -1;
       } else {

--- a/RecoBTag/FeatureTools/src/deep_helpers.cc
+++ b/RecoBTag/FeatureTools/src/deep_helpers.cc
@@ -125,17 +125,12 @@ namespace btagbtvdeep {
     // Do Subjets
     if (patJet) {
       if (patJet->nSubjetCollections() > 0) {
-        const auto &subjets = patJet->subjets();
-        const auto largest = std::max_element(
-            subjets.begin(), subjets.end(), [](const edm::Ptr<pat::Jet> &p1, const edm::Ptr<pat::Jet> &p2) {
-              return p1->pt() < p2->pt();
-            });
-        const auto secondLargest = std::max_element(
-            subjets.begin(), subjets.end(), [&largest](const edm::Ptr<pat::Jet> &p1, const edm::Ptr<pat::Jet> &p2) {
-              return ((p2 != (*largest)) && (p1->pt() < p2->pt()));
-            });
-        features.first = !subjets.empty() ? reco::deltaR(*cand, *subjets[largest - subjets.begin()]) : -1;
-        features.second = subjets.size() > 1 ? reco::deltaR(*cand, *subjets[secondLargest - subjets.begin()]) : -1;
+        auto subjets = patJet->subjets();
+        std::nth_element(subjets.begin(), subjets.begin()+1, subjets.end(), [](const edm::Ptr<pat::Jet> &p1, const edm::Ptr<pat::Jet> &p2) {
+          return p1->pt() > p2->pt();
+        });
+        features.first = !subjets.empty() ? reco::deltaR(*cand, *subjets[0]) : -1;
+        features.second = subjets.size() > 1 ? reco::deltaR(*cand, *subjets[1]) : -1;
       } else {
         features.first = -1;
         features.second = -1;


### PR DESCRIPTION
#### PR description:

This PR allows the evaluation of DeepJet on `reco::Jet`s, which to my understanding should have worked before the latest change. With the current logic, only `pat::Jet`s are accepted.
The fix is needed to use DeepJet at HLT. For the `reco::` case, features needed for DeepDoubleX are filled with the same dummy variables as in the case of no subjets.

#### PR validation:
Code compiles.
`40 39 38 29 18 4 1 1 1 tests passed, 0 0 0 0 0 0 0 0 0 failed`
Also, tested on data and MC samples, running a modified HLT menu with DeepJet instead of DeepCSV.


#### if this PR is a backport please specify the original PR and why you need to backport that PR:
N/A
