### PR TITLE
Improve DQM beamspot clients

### DIFF
--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 # Define here the BeamSpotOnline record name,
 # it will be used both in BeamMonitor setup and in payload creation/upload
 BSOnlineRecordName = 'BeamSpotOnlineLegacyObjectsRcd'
-BSOnlineTag = 'BeamSpotOnlinetLegacy'
+BSOnlineTag = 'BeamSpotOnlineLegacy'
 BSOnlineJobName = 'BeamSpotOnlineLegacy'
 BSOnlineOmsServiceUrl = 'http://cmsoms-services.cms:9949/urn:xdaq-application:lid=100/getRunAndLumiSection'
 useLockRecords = True

--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -83,6 +83,13 @@ else:
     # you may need to set manually the GT in the line below
     #process.GlobalTag.globaltag = '100X_upgrade2018_realistic_v10'
 
+#--------------------------------------------------------
+# Swap offline <-> online BeamSpot as in Express and HLT
+import RecoVertex.BeamSpotProducer.onlineBeamSpotESProducer_cfi as _mod
+process.BeamSpotESProducer = _mod.onlineBeamSpotESProducer.clone()
+import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
+process.offlineBeamSpot = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()
+
 #----------------------------
 # BeamMonitor
 process.load("DQM.BeamMonitor.BeamMonitor_Pixel_cff")
@@ -166,7 +173,7 @@ process.pixelTracksHP = cms.EDProducer( "TrackCollectionFilterCloner",
 
 import DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi
 process.pixelTracksMonitor = DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi.TrackerCollisionTrackMon.clone(
-   FolderName                = 'BeamMonitor/Tracking/pixelTracks',
+   FolderName                = 'BeamMonitorLegacy/Tracking/pixelTracks',
    TrackProducer             = 'pixelTracks',
    allTrackProducer          = 'pixelTracks',
    beamSpot                  = "offlineBeamSpot",
@@ -213,7 +220,7 @@ process.tracks2monitor.cut = 'pt > 1 & abs(eta) < 2.4'
 
 #
 process.selectedPixelTracksMonitor = process.pixelTracksMonitor.clone(
-   FolderName       = 'BeamMonitor/Tracking/selectedPixelTracks',
+   FolderName       = 'BeamMonitorLegacy/Tracking/selectedPixelTracks',
    TrackProducer    = 'tracks2monitor',
    allTrackProducer = 'tracks2monitor'
 )
@@ -248,7 +255,7 @@ process.monitor = cms.Sequence(process.dqmBeamMonitor
 # BeamSpotProblemMonitor
 
 #
-process.dqmBeamSpotProblemMonitor.monitorName = "BeamMonitor/BeamSpotProblemMonitor"
+process.dqmBeamSpotProblemMonitor.monitorName = "BeamMonitorLegacy/BeamSpotProblemMonitor"
 process.dqmBeamSpotProblemMonitor.AlarmONThreshold  = 15 # was 10
 process.dqmBeamSpotProblemMonitor.AlarmOFFThreshold = 17 # was 12
 process.dqmBeamSpotProblemMonitor.nCosmicTrk        = 10
@@ -304,6 +311,7 @@ process.siStripDigis.ProductLabel        = rawDataInputTag
 process.load("RecoVertex.BeamSpotProducer.BeamSpot_cfi")
 
 process.dqmBeamMonitor.OnlineMode = True
+process.dqmBeamMonitor.monitorName = "BeamMonitorLegacy"
 process.dqmBeamMonitor.recordName = BSOnlineRecordName
 process.dqmBeamMonitor.useLockRecords = useLockRecords
 
@@ -321,11 +329,13 @@ from RecoVertex.PrimaryVertexProducer.OfflinePixel3DPrimaryVertices_cfi import *
 process.pixelVertices = pixelVertices.clone(
   TkFilterParameters = dict( minPt = process.pixelTracksTrackingRegions.RegionPSet.ptMin)
 )
+process.pixelTracksTrackingRegions.RegionPSet.ptMin = 0.1
 process.pixelTracksTrackingRegions.RegionPSet.originRadius = 0.4
-process.pixelTracksTrackingRegions.RegionPSet.originHalfLength = 12
-process.pixelTracksTrackingRegions.RegionPSet.originXPos =  0.08
-process.pixelTracksTrackingRegions.RegionPSet.originYPos = -0.03
-process.pixelTracksTrackingRegions.RegionPSet.originZPos = 0.
+# The following parameters were used in 2018 HI:
+#process.pixelTracksTrackingRegions.RegionPSet.originHalfLength = 12
+#process.pixelTracksTrackingRegions.RegionPSet.originXPos =  0.08
+#process.pixelTracksTrackingRegions.RegionPSet.originYPos = -0.03
+#process.pixelTracksTrackingRegions.RegionPSet.originZPos = 0.
 
 process.tracking_FirstStep = cms.Sequence(
       process.siPixelDigis 

--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -329,8 +329,8 @@ from RecoVertex.PrimaryVertexProducer.OfflinePixel3DPrimaryVertices_cfi import *
 process.pixelVertices = pixelVertices.clone(
   TkFilterParameters = dict( minPt = process.pixelTracksTrackingRegions.RegionPSet.ptMin)
 )
-process.pixelTracksTrackingRegions.RegionPSet.ptMin = 0.1
-process.pixelTracksTrackingRegions.RegionPSet.originRadius = 0.4
+#process.pixelTracksTrackingRegions.RegionPSet.ptMin = 0.1       # used in PilotBeam 2021, but not ok for standard collisions
+process.pixelTracksTrackingRegions.RegionPSet.originRadius = 0.4 # used in PilotBeam 2021, to be checked again for standard collisions
 # The following parameters were used in 2018 HI:
 #process.pixelTracksTrackingRegions.RegionPSet.originHalfLength = 12
 #process.pixelTracksTrackingRegions.RegionPSet.originXPos =  0.08

--- a/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
@@ -120,22 +120,28 @@ process.monitor = cms.Sequence(process.dqmBeamMonitor)
 from DQM.Integration.config.online_customizations_cfi import *
 process = customise(process)
 
+#-----------------------------------------------------------
+# Swap offline <-> online BeamSpot as in Express and HLT
+import RecoVertex.BeamSpotProducer.onlineBeamSpotESProducer_cfi as _mod
+process.BeamSpotESProducer = _mod.onlineBeamSpotESProducer.clone()
+import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
+process.offlineBeamSpot = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()
+
 #--------------------------
 # Proton-Proton Stuff
 #--------------------------
 
 if (process.runType.getRunType() == process.runType.pp_run or
     process.runType.getRunType() == process.runType.pp_run_stage1 or
-    process.runType.getRunType() == process.runType.cosmic_run or
-    process.runType.getRunType() == process.runType.cosmic_run_stage1 or 
     process.runType.getRunType() == process.runType.hpu_run or
-    process.runType.getRunType() == process.runType.hi_run):
+    process.runType.getRunType() == process.runType.hi_run or
+    process.runType.getRunType() == process.runType.commissioning_run):
 
     print("[beamhlt_dqm_sourceclient-live_cfg]:: Running pp")
 
     process.load("RecoVertex.BeamSpotProducer.BeamSpot_cfi")
 
-    process.dqmBeamMonitor.monitorName = 'BeamMonitor'
+    process.dqmBeamMonitor.monitorName = 'BeamMonitorHLT'
 
     process.dqmBeamMonitor.OnlineMode = True              
     process.dqmBeamMonitor.recordName = BSOnlineRecordName


### PR DESCRIPTION
#### PR description:
Forward port of #35918

Updates to the Legacy and HLT BeamSpot DQM clients:
- Fixed the names of the output DQM folder so that the DQM is more clear:
   - 1 folder for BeamMonitorLegacy
   - 1 folder for BeamMonitorLHT
   - previous BeamMonitor folder is removed
- Added the offline <-> online beamspot swap same as in express and HLT
- In the BeamSpot Legacy clients I also fixed the pixelTracksTrackingRegions parameters to remove the 2018 HI customization that was left there (thanks @mmusich!). Overall this should increase the number of tracks reconstructed by the Legacy client so that it can fit PVs and eventually the Beamspot.
- Fixed a typo in the name of the Legacy BeamSpotOnline tag

**[Important Note]** 
This PR contains an additional commit to remove the following customization in the BeamSpot Legacy DQM client:
```
process.pixelTracksTrackingRegions.RegionPSet.ptMin = 0.1
```
This customization was used in 12_0_X during PilotBeam 2021 data taking due to the special collision conditions, but should not be applied for standard collision.

#### PR validation:
Validated with DQM playback system and also during data-taking, see https://github.com/cms-sw/cmssw/pull/35918#issuecomment-956087758 and https://github.com/cms-sw/cmssw/pull/35918#issuecomment-956119341 for the outcome of the data-taking.

#### Backport
A backport to 12_0_X is provided in #35918
A backport to 12_1_X is provided in #35935

