### PR TITLE
[Tracker Alignment] remove `getByLabel` and allow to fetch vertex collection from configuration (12.0.X)

### DIFF
--- a/Alignment/OfflineValidation/plugins/DMRChecker.cc
+++ b/Alignment/OfflineValidation/plugins/DMRChecker.cc
@@ -1036,8 +1036,7 @@ private:
       //dxy with respect to the primary vertex
       reco::Vertex pvtx;
       edm::Handle<reco::VertexCollection> vertexHandle;
-      reco::VertexCollection vertexCollection;
-      event.getByLabel("offlinePrimaryVertices", vertexHandle);
+      event.getByToken(vertexToken, vertexHandle);
       double mindxy = 100.;
       double dz = 100;
       if (vertexHandle.isValid()) {

--- a/Alignment/OfflineValidation/plugins/GeneralPurposeTrackAnalyzer.cc
+++ b/Alignment/OfflineValidation/plugins/GeneralPurposeTrackAnalyzer.cc
@@ -627,8 +627,7 @@ private:
       //dxy with respect to the primary vertex
       reco::Vertex pvtx;
       edm::Handle<reco::VertexCollection> vertexHandle;
-      reco::VertexCollection vertexCollection;
-      event.getByLabel("offlinePrimaryVertices", vertexHandle);
+      event.getByToken(vertexToken, vertexHandle);
       double mindxy = 100.;
       double dz = 100;
       if (vertexHandle.isValid() && !isCosmics_) {


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/35931

#### PR description:

Trivial bug-fix in debugging modules. No regression expected in any tests.

#### PR validation:

Private, but it will be tested by unit test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

backport of https://github.com/cms-sw/cmssw/pull/35931