### PR TITLE
[ONLY FOR TESTING] [Basic2DGenericPFlowPositionCalc] Round PF cluster depth value if it is very close to an integer

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.cc
@@ -281,11 +281,9 @@ void Basic2DGenericPFlowPositionCalc::calculateAndSetPositionActual(reco::PFClus
     z *= norm_inverse;
     depth *= norm_inverse;
     cluster.setPosition(math::XYZPoint(x, y, z));
+    if (std::abs(std::round(depth) - depth) < 0.001)
+      depth = std::round(depth);  //eg. force 3.999 to 4.000
     cluster.setDepth(depth);
-    //force 0.99999999 to 1.0000000
-    if ((depth-int(depth+0.5))<0.001){
-        cluster.setDepth(int(depth+0.5));
-    }
     cluster.calculatePositionREP();
   }
 }

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.cc
@@ -282,6 +282,10 @@ void Basic2DGenericPFlowPositionCalc::calculateAndSetPositionActual(reco::PFClus
     depth *= norm_inverse;
     cluster.setPosition(math::XYZPoint(x, y, z));
     cluster.setDepth(depth);
+    //force 0.99999999 to 1.0000000
+    if ((depth-int(depth+0.5))<0.001){
+        cluster.setDepth(int(depth+0.5));
+    }
     cluster.calculatePositionREP();
   }
 }

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.cc
@@ -281,11 +281,8 @@ void Basic2DGenericPFlowPositionCalc::calculateAndSetPositionActual(reco::PFClus
     z *= norm_inverse;
     depth *= norm_inverse;
     cluster.setPosition(math::XYZPoint(x, y, z));
+    if(std::abs(std::round(depth)-depth)<0.001) depth = std::round(depth); //eg. force 3.999 to 4.000
     cluster.setDepth(depth);
-    //force 0.99999999 to 1.0000000
-    if ((depth-int(depth+0.5))<0.001){
-        cluster.setDepth(int(depth+0.5));
-    }
     cluster.calculatePositionREP();
   }
 }

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.cc
@@ -281,8 +281,11 @@ void Basic2DGenericPFlowPositionCalc::calculateAndSetPositionActual(reco::PFClus
     z *= norm_inverse;
     depth *= norm_inverse;
     cluster.setPosition(math::XYZPoint(x, y, z));
-    if(std::abs(std::round(depth)-depth)<0.001) depth = std::round(depth); //eg. force 3.999 to 4.000
     cluster.setDepth(depth);
+    //force 0.99999999 to 1.0000000
+    if ((depth-int(depth+0.5))<0.001){
+        cluster.setDepth(int(depth+0.5));
+    }
     cluster.calculatePositionREP();
   }
 }


### PR DESCRIPTION
Details in https://github.com/cms-sw/cmssw/issues/35923
This fix resolves the GPU/CPU differences reported in the PFJet at HLT.
Please note that this bug affected also the CPU reconstruction! 

An alternative way to implement this fix is https://github.com/cms-sw/cmssw/commit/2077cfd519ed174a887bf762f18f2ff0d4053405, ie. by rounding value `(cluster2.depth() - cluster1.depth())` before using it.
