### PR TITLE
PPS: association cut fix

### DIFF
--- a/CondCore/CTPPSPlugins/src/plugin.cc
+++ b/CondCore/CTPPSPlugins/src/plugin.cc
@@ -26,6 +26,12 @@
 #include "CondFormats/PPSObjects/interface/PPSAssociationCuts.h"
 #include "CondFormats/DataRecord/interface/PPSAssociationCutsRcd.h"
 
+namespace {
+    struct InitAssociationCuts {
+        void operator() (PPSAssociationCuts &cuts) { cuts.initialize(); }
+    };
+}
+
 REGISTER_PLUGIN(CTPPSBeamParametersRcd, CTPPSBeamParameters);
 REGISTER_PLUGIN(CTPPSPixelDAQMappingRcd, CTPPSPixelDAQMapping);
 REGISTER_PLUGIN(CTPPSPixelAnalysisMaskRcd, CTPPSPixelAnalysisMask);
@@ -39,4 +45,5 @@ REGISTER_PLUGIN(PPSDirectSimulationDataRcd, PPSDirectSimulationData);
 REGISTER_PLUGIN(PPSPixelTopologyRcd, PPSPixelTopology);
 REGISTER_PLUGIN(PPSAlignmentConfigRcd, PPSAlignmentConfig);
 REGISTER_PLUGIN(PPSAlignmentConfigurationRcd, PPSAlignmentConfiguration);
-REGISTER_PLUGIN(PPSAssociationCutsRcd, PPSAssociationCuts);
+
+REGISTER_PLUGIN_INIT(PPSAssociationCutsRcd, PPSAssociationCuts, InitAssociationCuts);

--- a/CondCore/CTPPSPlugins/src/plugin.cc
+++ b/CondCore/CTPPSPlugins/src/plugin.cc
@@ -27,10 +27,10 @@
 #include "CondFormats/DataRecord/interface/PPSAssociationCutsRcd.h"
 
 namespace {
-    struct InitAssociationCuts {
-        void operator() (PPSAssociationCuts &cuts) { cuts.initialize(); }
-    };
-}
+  struct InitAssociationCuts {
+    void operator()(PPSAssociationCuts &cuts) { cuts.initialize(); }
+  };
+}  // namespace
 
 REGISTER_PLUGIN(CTPPSBeamParametersRcd, CTPPSBeamParameters);
 REGISTER_PLUGIN(CTPPSPixelDAQMappingRcd, CTPPSPixelDAQMapping);

--- a/CondFormats/PPSObjects/interface/PPSAssociationCuts.h
+++ b/CondFormats/PPSObjects/interface/PPSAssociationCuts.h
@@ -37,8 +37,7 @@ public:
     double getTiTrMax() const { return ti_tr_max_; }
 
     // build TF1 representations of the mean and threshold functions
-    // NB: declared as const as it only modifies mutable class fields
-    void buildFunctions() const;
+    void buildFunctions();
 
     // returns whether the specified cut is applied
     bool isApplied(Quantities quantity) const;
@@ -52,8 +51,8 @@ public:
     std::vector<std::string> s_thresholds_;
 
     // TF1 representation of the cut parameters - for run time evaluations
-    mutable std::vector<std::shared_ptr<TF1> > f_means_ COND_TRANSIENT;
-    mutable std::vector<std::shared_ptr<TF1> > f_thresholds_ COND_TRANSIENT;
+    std::vector<std::shared_ptr<TF1> > f_means_ COND_TRANSIENT;
+    std::vector<std::shared_ptr<TF1> > f_thresholds_ COND_TRANSIENT;
 
     // timing-tracking cuts
     double ti_tr_min_;
@@ -69,6 +68,13 @@ public:
   PPSAssociationCuts(const edm::ParameterSet &iConfig);
 
   ~PPSAssociationCuts() {}
+
+  // builds run-time data members, useful e.g. after loading data from DB
+  void initialize()
+  {
+    for (auto &p : association_cuts_)
+      p.second.buildFunctions();
+  }
 
   const CutsPerArm &getAssociationCuts(const int sector) const { return association_cuts_.at(sector); }
 

--- a/CondFormats/PPSObjects/interface/PPSAssociationCuts.h
+++ b/CondFormats/PPSObjects/interface/PPSAssociationCuts.h
@@ -70,8 +70,7 @@ public:
   ~PPSAssociationCuts() {}
 
   // builds run-time data members, useful e.g. after loading data from DB
-  void initialize()
-  {
+  void initialize() {
     for (auto &p : association_cuts_)
       p.second.buildFunctions();
   }

--- a/CondFormats/PPSObjects/interface/PPSAssociationCuts.h
+++ b/CondFormats/PPSObjects/interface/PPSAssociationCuts.h
@@ -75,7 +75,7 @@ public:
       p.second.buildFunctions();
   }
 
-  const CutsPerArm &getAssociationCuts(const int sector) const { return association_cuts_.at(sector); }
+  const CutsPerArm &getAssociationCuts(const int sector) const { return association_cuts_.find(sector)->second; }
 
   static edm::ParameterSetDescription getDefaultParameters();
 

--- a/CondFormats/PPSObjects/interface/PPSAssociationCuts.h
+++ b/CondFormats/PPSObjects/interface/PPSAssociationCuts.h
@@ -12,6 +12,7 @@ struct TF1;
 #include "CondFormats/Serialization/interface/Serializable.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/Exception.h"
 
 #include <iostream>
 #include <memory>
@@ -69,11 +70,11 @@ public:
 
   ~PPSAssociationCuts() {}
 
+  // checks if the data have a valid structure
+  bool isValid() const;
+
   // builds run-time data members, useful e.g. after loading data from DB
-  void initialize() {
-    for (auto &p : association_cuts_)
-      p.second.buildFunctions();
-  }
+  void initialize();
 
   const CutsPerArm &getAssociationCuts(const int sector) const { return association_cuts_.find(sector)->second; }
 

--- a/CondFormats/PPSObjects/src/PPSAssociationCuts.cc
+++ b/CondFormats/PPSObjects/src/PPSAssociationCuts.cc
@@ -33,7 +33,7 @@ PPSAssociationCuts::CutsPerArm::CutsPerArm(const edm::ParameterSet &iConfig, int
 
 //----------------------------------------------------------------------------------------------------
 
-void PPSAssociationCuts::CutsPerArm::buildFunctions() const {
+void PPSAssociationCuts::CutsPerArm::buildFunctions() {
   f_means_.clear();
   for (const auto &s : s_means_)
     f_means_.push_back(std::make_shared<TF1>("f", s.c_str()));
@@ -56,11 +56,6 @@ bool PPSAssociationCuts::CutsPerArm::isSatisfied(
   // if cut not applied, then condition considered as satisfied
   if (!isApplied(quantity))
     return true;
-
-  // build functions if not already done
-  // (this may happen if data (string representation) are loaded from DB and the constructor is not executed)
-  if (f_means_.size() < s_means_.size())
-    buildFunctions();
 
   // evaluate mean and threshold
   const double mean = evaluateExpression(f_means_[quantity], x_near, y_near, xangle);

--- a/CondFormats/PPSObjects/src/PPSAssociationCuts.cc
+++ b/CondFormats/PPSObjects/src/PPSAssociationCuts.cc
@@ -110,13 +110,15 @@ edm::ParameterSetDescription PPSAssociationCuts::getDefaultParameters() {
 
 //----------------------------------------------------------------------------------------------------
 
-bool PPSAssociationCuts::isValid() const
-{
+bool PPSAssociationCuts::isValid() const {
   // valid if association_cuts_ have two entries, with keys 0 and 1
-  if (association_cuts_.size() != 2) return false;
+  if (association_cuts_.size() != 2)
+    return false;
 
-  if (association_cuts_.find(0) == association_cuts_.end()) return false;
-  if (association_cuts_.find(1) == association_cuts_.end()) return false;
+  if (association_cuts_.find(0) == association_cuts_.end())
+    return false;
+  if (association_cuts_.find(1) == association_cuts_.end())
+    return false;
 
   return true;
 }

--- a/CondFormats/PPSObjects/src/PPSAssociationCuts.cc
+++ b/CondFormats/PPSObjects/src/PPSAssociationCuts.cc
@@ -46,7 +46,7 @@ void PPSAssociationCuts::CutsPerArm::buildFunctions() const {
 //----------------------------------------------------------------------------------------------------
 
 bool PPSAssociationCuts::CutsPerArm::isApplied(Quantities quantity) const {
-  return (!s_thresholds_.at(quantity).empty()) && (!s_means_.at(quantity).empty());
+  return (!s_thresholds_[quantity].empty()) && (!s_means_[quantity].empty());
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -63,8 +63,8 @@ bool PPSAssociationCuts::CutsPerArm::isSatisfied(
     buildFunctions();
 
   // evaluate mean and threshold
-  const double mean = evaluateExpression(f_means_.at(quantity), x_near, y_near, xangle);
-  const double threshold = evaluateExpression(f_thresholds_.at(quantity), x_near, y_near, xangle);
+  const double mean = evaluateExpression(f_means_[quantity], x_near, y_near, xangle);
+  const double threshold = evaluateExpression(f_thresholds_[quantity], x_near, y_near, xangle);
 
   // make comparison
   return fabs(q_NF_diff - mean) < threshold;

--- a/CondFormats/PPSObjects/src/PPSAssociationCuts.cc
+++ b/CondFormats/PPSObjects/src/PPSAssociationCuts.cc
@@ -27,8 +27,6 @@ PPSAssociationCuts::CutsPerArm::CutsPerArm(const edm::ParameterSet &iConfig, int
 
   ti_tr_min_ = association_cuts.getParameter<double>("ti_tr_min");
   ti_tr_max_ = association_cuts.getParameter<double>("ti_tr_max");
-
-  buildFunctions();
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -83,6 +81,8 @@ PPSAssociationCuts::PPSAssociationCuts(const edm::ParameterSet &iConfig) {
   unsigned int i = 0;
   for (const int &sector : {45, 56})
     association_cuts_[i++] = CutsPerArm(iConfig, sector);
+
+  initialize();
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -106,6 +106,29 @@ edm::ParameterSetDescription PPSAssociationCuts::getDefaultParameters() {
   desc.add<double>("ti_tr_max", +1.)->setComment("maximum value for timing-tracking association cut");
 
   return desc;
+}
+
+//----------------------------------------------------------------------------------------------------
+
+bool PPSAssociationCuts::isValid() const
+{
+  // valid if association_cuts_ have two entries, with keys 0 and 1
+  if (association_cuts_.size() != 2) return false;
+
+  if (association_cuts_.find(0) == association_cuts_.end()) return false;
+  if (association_cuts_.find(1) == association_cuts_.end()) return false;
+
+  return true;
+}
+
+//----------------------------------------------------------------------------------------------------
+
+void PPSAssociationCuts::initialize() {
+  if (!isValid())
+    throw cms::Exception("PPS") << "Invalid structure of PPSAssociationCuts.";
+
+  for (auto &p : association_cuts_)
+    p.second.buildFunctions();
 }
 
 //----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
#### PR description:

This is a bugfix PR to address the issues raised in:
  * https://github.com/cms-sw/cmssw/issues/35928
  * https://github.com/cms-sw/cmssw/issues/35936

The proposal is based mainly on these suggestions:
  * https://github.com/cms-sw/cmssw/issues/35928#issuecomment-956208463
  * https://github.com/cms-sw/cmssw/issues/35936#issuecomment-956242043


#### PR validation:

The plots below compare results before (blue) and after this PR (red dashed):
  * [dirsim_cmp.pdf](https://github.com/cms-sw/cmssw/files/7453777/dirsim_cmp.pdf): for PPS direct simulation (+ reconstruction), Run2 and Run3
  * [reco_cmp.pdf](https://github.com/cms-sw/cmssw/files/7453779/reco_cmp.pdf): for PPS reconstruction, Run2 data

No differences observed as expected.

