### PR TITLE
Changes to OnlineBeamMonitor DQM client and plugin

### DIFF
--- a/DQM/BeamMonitor/plugins/OnlineBeamMonitor.cc
+++ b/DQM/BeamMonitor/plugins/OnlineBeamMonitor.cc
@@ -109,11 +109,15 @@ void OnlineBeamMonitor::bookHistograms(DQMStore::IBooker& ibooker,
   // create and cd into new folder
   ibooker.setCurrentFolder(monitorName_ + "Validation");
   //Book histograms
-  bsChoice_ = ibooker.book1D("bsChoice",
-                             "Choice between HLT (+1) and Legacy (-1) BS",
-                             lastLumi - firstLumi + 1,
-                             firstLumi - 0.5,
-                             lastLumi + 0.5);
+  bsChoice_ = ibooker.bookProfile("bsChoice",
+                                  "BS Choice (+1): HLT - (-1): Legacy - (-10): Fake BS - (0): No Transient ",
+                                  lastLumi - firstLumi + 1,
+                                  firstLumi - 0.5,
+                                  lastLumi + 0.5,
+                                  100,
+                                  -10,
+                                  1,
+                                  "");
   bsChoice_->setAxisTitle("Lumisection", 1);
   bsChoice_->setAxisTitle("Choice", 2);
 }
@@ -236,18 +240,18 @@ void OnlineBeamMonitor::globalEndLuminosityBlock(const LuminosityBlock& iLumi, c
   if (beamSpotsMap_.find("Transient") != beamSpotsMap_.end()) {
     if (beamSpotsMap_.find("HLT") != beamSpotsMap_.end() &&
         beamSpotsMap_["Transient"].x0() == beamSpotsMap_["HLT"].x0()) {
-      bsChoice_->setBinContent(iLumi.id().luminosityBlock(), 1);
+      bsChoice_->Fill(iLumi.id().luminosityBlock(), 1);
       bsChoice_->setBinError(iLumi.id().luminosityBlock(), 0.05);
     } else if (beamSpotsMap_.find("Legacy") != beamSpotsMap_.end() &&
                beamSpotsMap_["Transient"].x0() == beamSpotsMap_["Legacy"].x0()) {
-      bsChoice_->setBinContent(iLumi.id().luminosityBlock(), -1);
+      bsChoice_->Fill(iLumi.id().luminosityBlock(), -1);
       bsChoice_->setBinError(iLumi.id().luminosityBlock(), 0.05);
     } else {
-      bsChoice_->setBinContent(iLumi.id().luminosityBlock(), -10);
+      bsChoice_->Fill(iLumi.id().luminosityBlock(), -10);
       bsChoice_->setBinError(iLumi.id().luminosityBlock(), 0.05);
     }
   } else {
-    bsChoice_->setBinContent(iLumi.id().luminosityBlock(), 0);
+    bsChoice_->Fill(iLumi.id().luminosityBlock(), 0);
     bsChoice_->setBinError(iLumi.id().luminosityBlock(), 0.05);
   }
 

--- a/DQM/Integration/python/clients/onlinebeammonitor_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/onlinebeammonitor_dqm_sourceclient-live_cfg.py
@@ -4,11 +4,10 @@ import FWCore.ParameterSet.Config as cms
 # Define once the BeamSpotOnline record name,
 # will be used both in BeamMonitor setup and in payload creation/upload
 
-#from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
-#process = cms.Process("BeamMonitor", Run2_2018) # FIMXE
 import sys
-from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
-process = cms.Process("OnlineBeamMonitor", Run2_2018)
+
+from Configuration.Eras.Era_Run3_cff import Run3
+process = cms.Process("OnlineBeamMonitor", Run3)
 
 # Message logger
 #process.load("FWCore.MessageLogger.MessageLogger_cfi")
@@ -42,13 +41,13 @@ if unitTest:
   )
 
   options.register('runNumber',
-                  336055,
+                  346508,
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.int,
                   "Run number. This run number has to be present in the dataset configured with the dataset option.")
 
   options.register('dataset',
-                  '/ExpressCosmics/Commissioning2019-Express-v1/FEVT',
+                  '/ExpressPhysics/Commissioning2021-Express-v1/FEVT',
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.string,
                   "Dataset name like '/ExpressCosmics/Commissioning2019-Express-v1/FEVT'")
@@ -102,7 +101,7 @@ if unitTest:
   process.source = cms.Source("EmptySource")
   process.source.numberEventsInRun=cms.untracked.uint32(100)
   process.source.firstRun = cms.untracked.uint32(options.runNumber)
-  process.source.firstLuminosityBlock = cms.untracked.uint32(49)
+  process.source.firstLuminosityBlock = cms.untracked.uint32(1)
   process.source.numberEventsInLuminosityBlock = cms.untracked.uint32(2)
   process.maxEvents = cms.untracked.PSet(
               input = cms.untracked.int32(100)
@@ -123,17 +122,17 @@ process.BeamSpotESProducer = cms.ESProducer("OnlineBeamSpotESProducer")
 # DQM Live Environment
 #-----------------------------
 process.load("DQM.Integration.config.environment_cfi")
-process.dqmEnv.subSystemFolder = 'TrackingHLTBeamspotStream'
-process.dqmSaver.tag           = 'TrackingHLTBeamspotStream'
+process.dqmEnv.subSystemFolder = 'OnlineBeamMonitor'
+process.dqmSaver.tag           = 'OnlineBeamMonitor'
 process.dqmSaver.runNumber     = options.runNumber
-process.dqmSaverPB.tag         = 'TrackingHLTBeamspotStream'
+process.dqmSaverPB.tag         = 'OnlineBeamMonitor'
 process.dqmSaverPB.runNumber   = options.runNumber
 
 #-----------------------------
 # BeamMonitor
 #-----------------------------
 process.dqmOnlineBeamMonitor = cms.EDProducer("OnlineBeamMonitor",
-MonitorName = cms.untracked.string("onlineBeamMonitor")
+MonitorName = cms.untracked.string("OnlineBeamMonitor")
 )
 
 #---------------


### PR DESCRIPTION
#### PR description:
Changes to OnlineBeamMonitor DQM Client
- Moved the content of `TrackingHLTBeamspotStream` and `onlineBeamMonitor` folder to a single folder `OnlineBeamMonitor`
- Moved BSChoice plot from TH1 to TProfile for better run-to-run comparison
- Changed era modifier
- Changed unit test to use more recent run (346508) from LHC pilot beam (October 2021)

#### PR validation:

Validated with: 
```cmsRun DQM/Integration/python/clients/onlinebeammonitor_dqm_sourceclient-live_cfg.py unitTest=True```
which produce the new plot:

<img width="1083" alt="Screenshot 2021-11-01 at 18 20 12" src="https://user-images.githubusercontent.com/46677792/139715462-a8addf79-ecca-44fe-8a73-63360ea46162.png">

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not a backport and no backport is needed

FYI: @francescobrivio @gennai @mmusich 