### PR TITLE
add SOI check to HBHEPhase1Reconstructor

### DIFF
--- a/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
@@ -517,10 +517,10 @@ void HBHEPhase1Reconstructor::processData(const Collection& coll,
     const int maxTS = std::min(nRead, static_cast<int>(HBHEChannelInfo::MAXSAMPLES));
     const int soi = tsFromDB_ ? properties.paramTs->firstSample() : frame.presamples();
     const bool badSOI = !(maxTS >= 3 && soi > 0 && soi < maxTS - 1);
-    if(badSOI){
-        edm::LogWarning("HBHEDigi") << " bad SOI/maxTS in cell " << cell
-        << "\n expect maxTS >= 3 && soi > 0 && soi < maxTS - 1"
-        << "\n got maxTS = " << maxTS << ", SOI = " << soi;
+    if (badSOI) {
+      edm::LogWarning("HBHEDigi") << " bad SOI/maxTS in cell " << cell
+                                  << "\n expect maxTS >= 3 && soi > 0 && soi < maxTS - 1"
+                                  << "\n got maxTS = " << maxTS << ", SOI = " << soi;
     }
 
     const RawChargeFromSample<DFrame> rcfs(sipmQTSShift_, sipmQNTStoSum_, cond, properties, cs, soi, frame, maxTS);

--- a/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
@@ -516,6 +516,13 @@ void HBHEPhase1Reconstructor::processData(const Collection& coll,
     const int nRead = cs.size();
     const int maxTS = std::min(nRead, static_cast<int>(HBHEChannelInfo::MAXSAMPLES));
     const int soi = tsFromDB_ ? properties.paramTs->firstSample() : frame.presamples();
+    const bool badSOI = !(maxTS >= 3 && soi > 0 && soi < maxTS - 1);
+    if(badSOI){
+        edm::LogWarning("HBHEDigi") << " bad SOI/maxTS in cell " << cell
+        << "\n expect maxTS >= 3 && soi > 0 && soi < maxTS - 1"
+        << "\n got maxTS = " << maxTS << ", SOI = " << soi;
+    }
+
     const RawChargeFromSample<DFrame> rcfs(sipmQTSShift_, sipmQNTStoSum_, cond, properties, cs, soi, frame, maxTS);
     int soiCapid = 4;
 
@@ -584,7 +591,7 @@ void HBHEPhase1Reconstructor::processData(const Collection& coll,
                                 noisecorr,
                                 hwerr.first,
                                 hwerr.second,
-                                properties.taggedBadByDb || dropByZS);
+                                properties.taggedBadByDb || dropByZS || badSOI);
 
     // If needed, add the channel info to the output collection
     const bool makeThisRechit = !channelInfo->isDropped();


### PR DESCRIPTION
#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

This PR is to fix a crash in HBHEPhase1Reconstructor as reported in #35785

The reason of the crash is an out_of_range index "soi" of the vector "inputCharge" in [M3 reconstruction](https://github.com/cms-sw/cmssw/blob/CMSSW_12_2_0_pre1/RecoLocalCalo/HcalRecAlgos/src/HcalDeterministicFit.cc#L134)
To prevent similar crashes in the future, a check of SOI and max TS has been added to HBHEPhase1Reconstructor
`maxTS >= 3 && soi > 0 && soi < maxTS - 1` 
If this check fails, an edm::LogWarning will be generated and the corresponding channel will be dropped in HBHE reconstruction.

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

I followed [PRWorkflow](https://cms-sw.github.io/PRWorkflow.html) for the PR validation.
