### PR TITLE
use LogDebug instead of edm::LogInfo for PixelCPEGeneric

### DIFF
--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
@@ -76,7 +76,7 @@ PixelCPEGeneric::PixelCPEGeneric(edm::ParameterSet const& conf,
         throw cms::Exception("InvalidCalibrationLoaded")
             << "ERROR: GenErrors not filled correctly. Check the sqlite file. Using SiPixelTemplateDBObject version "
             << (*genErrorDBObject_).version();
-      edm::LogInfo("PixelCPEGeneric") << "Loaded genErrorDBObject v" << (*genErrorDBObject_).version();
+      LogDebug("PixelCPEGeneric") << "Loaded genErrorDBObject v" << (*genErrorDBObject_).version();
     } else {  // From file
       if (!SiPixelGenError::pushfile(-999, thePixelGenError_))
         throw cms::Exception("InvalidCalibrationLoaded")
@@ -169,9 +169,9 @@ LocalPoint PixelCPEGeneric::localPosition(DetParam const& theDetParam, ClusterPa
     if (useLAWidthFromGenError) {
       chargeWidthX = (-micronsToCm * gtempl.lorxwidth());
       chargeWidthY = (-micronsToCm * gtempl.lorywidth());
-      edm::LogInfo("PixelCPE localPosition():") << "redefine la width (gen-error)" << chargeWidthX << chargeWidthY;
+      LogDebug("PixelCPE localPosition():") << "redefine la width (gen-error)" << chargeWidthX << chargeWidthY;
     }
-    edm::LogInfo("PixelCPE localPosition():") << "GenError:" << gtemplID_;
+    LogDebug("PixelCPE localPosition():") << "GenError:" << gtemplID_;
 
     // These numbers come in microns from the qbin(...) call. Transform them to cm.
     theClusterParam.deltax = theClusterParam.deltax * micronsToCm;


### PR DESCRIPTION
The LogInfos replaced `if (debug` in #35441 , which is not particularly appropriate since LogInfo actually constructs a message and then drops it.

The effect of this is about 4.8% in phase-2 reco
- 2.1% in [PixelCPEGeneric::localPosition MessageSender::MessageSender](https://cmssdt.cern.ch/SDT/cgi-bin/igprof-navigator/CMSSW_12_2_X_2021-10-31-2300/slc7_amd64_gcc900/profiling/23434.21/igprofCPU_step3/121)
- 2.7% in [PixelCPEGeneric::localPosition  MessageSender::~MessageSender](https://cmssdt.cern.ch/SDT/cgi-bin/igprof-navigator/CMSSW_12_2_X_2021-10-31-2300/slc7_amd64_gcc900/profiling/23434.21/igprofCPU_step3/91)

The investigation was initially triggered by 140.56 step2 issuing excessive time warning for `ConversionTrackCandidateProducer:conversionTrackCandidates` running for more than 600 seconds for `Run: 326479 Event: 1579493`. In my tests this event now takes 146 s instead of 504 s.
