### PR TITLE
Updates on summary plot of GEM onlineDQM

### DIFF
--- a/DQM/GEM/interface/GEMDAQStatusSource.h
+++ b/DQM/GEM/interface/GEMDAQStatusSource.h
@@ -69,6 +69,7 @@ private:
   MEMap3Inf mapStatusErrVFATPerLayer_;
   MEMap4Inf mapStatusVFATPerCh_;
 
+  MonitorElement *h2SummaryStatusAll;
   MonitorElement *h2SummaryStatusWarning;
   MonitorElement *h2SummaryStatusError;
 

--- a/DQM/GEM/plugins/GEMDAQStatusSource.cc
+++ b/DQM/GEM/plugins/GEMDAQStatusSource.cc
@@ -142,9 +142,11 @@ void GEMDAQStatusSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run con
 
   GenerateMEPerChamber(ibooker);
 
+  h2SummaryStatusAll = CreateSummaryHist(ibooker, "chamberAllStatus");
   h2SummaryStatusWarning = CreateSummaryHist(ibooker, "chamberWarnings");
   h2SummaryStatusError = CreateSummaryHist(ibooker, "chamberErrors");
 
+  h2SummaryStatusAll->setTitle("Summary of all number of OH or VFAT status of each chambers");
   h2SummaryStatusWarning->setTitle("Summary of OH or VFAT warnings of each chambers");
   h2SummaryStatusError->setTitle("Summary of OH or VFAT errors of each chambers");
 }
@@ -302,6 +304,7 @@ void GEMDAQStatusSource::analyze(edm::Event const &event, edm::EventSetup const 
   }
 
   // WARNING: ME4IdsKey for region, station, layer, chamber (not iEta)
+  std::map<ME4IdsKey, bool> mapChamberAll;
   std::map<ME4IdsKey, bool> mapChamberWarning;
   std::map<ME4IdsKey, bool> mapChamberError;
 
@@ -356,6 +359,7 @@ void GEMDAQStatusSource::analyze(edm::Event const &event, edm::EventSetup const 
         mapChamberWarning[key4] = false;
       if (bErr)
         mapChamberError[key4] = false;
+      mapChamberAll[key4] = true;
     }
   }
 
@@ -410,11 +414,21 @@ void GEMDAQStatusSource::analyze(edm::Event const &event, edm::EventSetup const 
         mapStatusWarnVFATPerLayer_.Fill(key3, gid.chamber(), nIdxVFAT);
       if (bErr)
         mapStatusErrVFATPerLayer_.Fill(key3, gid.chamber(), nIdxVFAT);
+      mapChamberAll[key4Ch] = true;
     }
+  }
+
+  // Summarizing all presence of status of each chamber
+  for (auto const &[key4, bErr] : mapChamberAll) {
+    ME3IdsKey key3 = key4Tokey3(key4);
+    Int_t nChamber = keyToChamber(key4);
+    h2SummaryStatusAll->Fill(nChamber, mapStationToIdx_[key3]);
   }
 
   // Summarizing the warning occupancy
   for (auto const &[key4, bWarning] : mapChamberWarning) {
+    if ( mapChamberError.find(key4) != mapChamberError.end() )  // Avoiding any double-counting
+      continue;
     ME3IdsKey key3 = key4Tokey3(key4);
     Int_t nChamber = keyToChamber(key4);
     h2SummaryStatusWarning->Fill(nChamber, mapStationToIdx_[key3]);

--- a/DQM/GEM/plugins/GEMDAQStatusSource.cc
+++ b/DQM/GEM/plugins/GEMDAQStatusSource.cc
@@ -427,7 +427,7 @@ void GEMDAQStatusSource::analyze(edm::Event const &event, edm::EventSetup const 
 
   // Summarizing the warning occupancy
   for (auto const &[key4, bWarning] : mapChamberWarning) {
-    if ( mapChamberError.find(key4) != mapChamberError.end() )  // Avoiding any double-counting
+    if (mapChamberError.find(key4) != mapChamberError.end())  // Avoiding any double-counting
       continue;
     ME3IdsKey key3 = key4Tokey3(key4);
     Int_t nChamber = keyToChamber(key4);

--- a/DQM/GEM/plugins/GEMDQMHarvester.cc
+++ b/DQM/GEM/plugins/GEMDQMHarvester.cc
@@ -179,13 +179,13 @@ void GEMDQMHarvester::createSummaryVFAT(edm::Service<DQMStore> &store,
 }
 
 Int_t GEMDQMHarvester::assessOneBin(Float_t fAll, Float_t fNumOcc, Float_t fNumWarn, Float_t fNumErr) {
-  if ( fNumErr > 0.05 * fAll )  // The error status criterion
+  if (fNumErr > 0.05 * fAll)  // The error status criterion
     return 2;
-  else if ( fNumErr > 0.00 * fAll || fNumWarn > 0.05 * fAll )  // The warning status criterion
+  else if (fNumErr > 0.00 * fAll || fNumWarn > 0.05 * fAll)  // The warning status criterion
     return 3;
-  else if ( fNumOcc > 0 )
+  else if (fNumOcc > 0)
     return 1;
-  
+
   return 0;
 }
 
@@ -208,7 +208,7 @@ Float_t GEMDQMHarvester::refineSummaryHistogram(MonitorElement *h2Sum,
       Float_t fStatusErr = h2SrcStatusE->getBinContent(i, j);
 
       Int_t nRes = assessOneBin(fStatusAll, fOcc, fStatusWarn, fStatusErr);
-      if ( nRes == 1 ) 
+      if (nRes == 1)
         nFineBin++;
 
       h2Sum->setBinContent(i, j, (Float_t)nRes);

--- a/DQM/GEM/plugins/GEMDQMHarvester.cc
+++ b/DQM/GEM/plugins/GEMDQMHarvester.cc
@@ -46,9 +46,14 @@ protected:
                          MonitorElement *&h2Sum);
   Float_t refineSummaryHistogram(MonitorElement *h2Sum,
                                  MonitorElement *h2SrcOcc,
+                                 MonitorElement *h2SrcAllNum,
                                  MonitorElement *h2SrcStatusE,
-                                 MonitorElement *h2SrcStatusW = nullptr,
-                                 Bool_t bVarXBin = false);
+                                 MonitorElement *h2SrcStatusW);
+  Int_t refineSummaryVFAT(MonitorElement *h2Sum,
+                          MonitorElement *h2SrcOcc,
+                          MonitorElement *h2SrcStatusE,
+                          MonitorElement *h2SrcStatusW);
+  Int_t assessOneBin(Float_t fAll, Float_t fNumOcc, Float_t fNumWarn, Float_t fNumErr);
 
   Float_t fReportSummary_;
   std::string strOutFile_;
@@ -84,6 +89,7 @@ void GEMDQMHarvester::dqmEndLuminosityBlock(DQMStore::IBooker &,
 
 void GEMDQMHarvester::drawSummaryHistogram(edm::Service<DQMStore> &store) {
   std::string strSrcDigiOcc = "GEM/Digis/summaryOccDigi";
+  std::string strSrcStatusA = "GEM/DAQStatus/chamberAllStatus";
   std::string strSrcStatusW = "GEM/DAQStatus/chamberWarnings";
   std::string strSrcStatusE = "GEM/DAQStatus/chamberErrors";
 
@@ -94,13 +100,14 @@ void GEMDQMHarvester::drawSummaryHistogram(edm::Service<DQMStore> &store) {
   store->setCurrentFolder(strDirSummary_);
 
   MonitorElement *h2SrcDigiOcc = store->get(strSrcDigiOcc);
+  MonitorElement *h2SrcStatusA = store->get(strSrcStatusA);
   MonitorElement *h2SrcStatusW = store->get(strSrcStatusW);
   MonitorElement *h2SrcStatusE = store->get(strSrcStatusE);
 
-  if (h2SrcDigiOcc != nullptr && h2SrcStatusW != nullptr && h2SrcStatusE != nullptr) {
+  if (h2SrcDigiOcc != nullptr && h2SrcStatusA != nullptr && h2SrcStatusW != nullptr && h2SrcStatusE != nullptr) {
     MonitorElement *h2Sum = nullptr;
     createSummaryHist(store, h2SrcStatusE, h2Sum, listLayer_);
-    fReportSummary_ = refineSummaryHistogram(h2Sum, h2SrcDigiOcc, h2SrcStatusE, h2SrcStatusW, true);
+    fReportSummary_ = refineSummaryHistogram(h2Sum, h2SrcDigiOcc, h2SrcStatusA, h2SrcStatusE, h2SrcStatusW);
 
     for (const auto &strSuffix : listLayer_) {
       MonitorElement *h2SrcVFATOcc = store->get(strSrcVFATOcc + strSuffix);
@@ -110,7 +117,7 @@ void GEMDQMHarvester::drawSummaryHistogram(edm::Service<DQMStore> &store) {
         continue;
       MonitorElement *h2SumVFAT = nullptr;
       createSummaryVFAT(store, h2SrcVFATStatusE, strSuffix, h2SumVFAT);
-      refineSummaryHistogram(h2SumVFAT, h2SrcVFATOcc, h2SrcVFATStatusE, h2SrcVFATStatusW);
+      refineSummaryVFAT(h2SumVFAT, h2SrcVFATOcc, h2SrcVFATStatusE, h2SrcVFATStatusW);
       TString strNewTitle = h2SrcVFATStatusE->getTitle();
       h2SumVFAT->setTitle((const char *)strNewTitle.ReplaceAll("errors", "errors/warnings"));
       h2SumVFAT->setXTitle(h2SrcVFATStatusE->getAxisTitle(1));
@@ -171,41 +178,65 @@ void GEMDQMHarvester::createSummaryVFAT(edm::Service<DQMStore> &store,
   copyLabels(h2Src, h2Sum);
 }
 
+Int_t GEMDQMHarvester::assessOneBin(Float_t fAll, Float_t fNumOcc, Float_t fNumWarn, Float_t fNumErr) {
+  if ( fNumErr > 0.05 * fAll )  // The error status criterion
+    return 2;
+  else if ( fNumErr > 0.00 * fAll || fNumWarn > 0.05 * fAll )  // The warning status criterion
+    return 3;
+  else if ( fNumOcc > 0 )
+    return 1;
+  
+  return 0;
+}
+
 // FIXME: Need more study about how to summarize
 Float_t GEMDQMHarvester::refineSummaryHistogram(MonitorElement *h2Sum,
                                                 MonitorElement *h2SrcOcc,
+                                                MonitorElement *h2SrcStatusA,
                                                 MonitorElement *h2SrcStatusE,
-                                                MonitorElement *h2SrcStatusW,
-                                                Bool_t bVarXBin) {
+                                                MonitorElement *h2SrcStatusW) {
   Int_t nBinY = h2Sum->getNbinsY();
   Int_t nAllBin = 0, nFineBin = 0;
   for (Int_t j = 1; j <= nBinY; j++) {
     Int_t nBinX = h2Sum->getNbinsX();
-    if (bVarXBin) {
-      nBinX = (Int_t)(h2SrcOcc->getBinContent(0, j) + 0.5);
-      h2Sum->setBinContent(0, j, nBinX);
-    }
+    nBinX = (Int_t)(h2SrcOcc->getBinContent(0, j) + 0.5);
+    h2Sum->setBinContent(0, j, nBinX);
     for (Int_t i = 1; i <= nBinX; i++) {
       Float_t fOcc = h2SrcOcc->getBinContent(i, j);
-      Float_t fStatusWarn = (h2SrcStatusW != nullptr ? h2SrcStatusW->getBinContent(i, j) : 0.0);
+      Float_t fStatusAll = h2SrcStatusA->getBinContent(i, j);
+      Float_t fStatusWarn = h2SrcStatusW->getBinContent(i, j);
       Float_t fStatusErr = h2SrcStatusE->getBinContent(i, j);
 
-      Float_t fRes = 0;
-      if (fStatusErr > 0)
-        fRes = 2;
-      else if (fStatusWarn > 0)
-        fRes = 3;
-      else if (fOcc > 0) {
-        fRes = 1;
+      Int_t nRes = assessOneBin(fStatusAll, fOcc, fStatusWarn, fStatusErr);
+      if ( nRes == 1 ) 
         nFineBin++;
-      }
 
-      h2Sum->setBinContent(i, j, fRes);
+      h2Sum->setBinContent(i, j, (Float_t)nRes);
       nAllBin++;
     }
   }
 
   return ((Float_t)nFineBin) / nAllBin;
+}
+
+Int_t GEMDQMHarvester::refineSummaryVFAT(MonitorElement *h2Sum,
+                                         MonitorElement *h2SrcOcc,
+                                         MonitorElement *h2SrcStatusE,
+                                         MonitorElement *h2SrcStatusW) {
+  Int_t nBinY = h2Sum->getNbinsY();
+  for (Int_t j = 1; j <= nBinY; j++) {
+    Int_t nBinX = h2Sum->getNbinsX();
+    for (Int_t i = 1; i <= nBinX; i++) {
+      Float_t fOcc = h2SrcOcc->getBinContent(i, j);
+      Float_t fStatusWarn = h2SrcStatusW->getBinContent(i, j);
+      Float_t fStatusErr = h2SrcStatusE->getBinContent(i, j);
+      Float_t fStatusAll = fOcc + fStatusWarn + fStatusErr;
+      Int_t nRes = assessOneBin(fStatusAll, fOcc, fStatusWarn, fStatusErr);
+      h2Sum->setBinContent(i, j, (Float_t)nRes);
+    }
+  }
+
+  return 0;
 }
 
 DEFINE_FWK_MODULE(GEMDQMHarvester);

--- a/DQM/GEM/plugins/GEMRecHitSource.cc
+++ b/DQM/GEM/plugins/GEMRecHitSource.cc
@@ -50,17 +50,17 @@ void GEMRecHitSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&
   mapTotalRecHitPerEvtLayer_ = MEMap3Inf(this,
                                          "rechits_per_layer",
                                          "Total number of RecHits per event for each layers",
-                                         50,
+                                         2000,
                                          -0.5,
-                                         99.5,
+                                         2000 - 0.5,
                                          "Number of RecHits",
                                          "Events");
   mapTotalRecHitPerEvtIEta_ = MEMap3Inf(this,
                                         "rechits_per_ieta",
                                         "Total number of RecHits per event for each eta partitions",
-                                        50,
+                                        300,
                                         -0.5,
-                                        99.5,
+                                        300 - 0.5,
                                         "Number of RecHits",
                                         "Events");
   mapCLSRecHit_ieta_ = MEMap3Inf(


### PR DESCRIPTION
#### PR description:
The criteria of the summary plot of GEM onlineDQM have been changed: From now on it goes red(error)/yellow(warning) which is determined by the ratio of error/warning status on each chamber.

Also binning of some plots have been changed to watch some recHit distribution more carefully.

It will be good for this update to be implemented to the current central DQM, so a backport to 12_0_X will be made soon.

#### PR validation:
Test are done and one can check again by `runTheMatrix` workflows

@jshlee @watson-ij 