### PR TITLE
Updates on summary plot of GEM onlineDQM, a backport to 12_0_X

### DIFF
--- a/DQM/GEM/interface/GEMDAQStatusSource.h
+++ b/DQM/GEM/interface/GEMDAQStatusSource.h
@@ -69,6 +69,7 @@ private:
   MEMap3Inf mapStatusErrVFATPerLayer_;
   MEMap4Inf mapStatusVFATPerCh_;
 
+  MonitorElement *h2SummaryStatusAll;
   MonitorElement *h2SummaryStatusWarning;
   MonitorElement *h2SummaryStatusError;
 

--- a/DQM/GEM/plugins/GEMDAQStatusSource.cc
+++ b/DQM/GEM/plugins/GEMDAQStatusSource.cc
@@ -142,9 +142,11 @@ void GEMDAQStatusSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run con
 
   GenerateMEPerChamber(ibooker);
 
+  h2SummaryStatusAll = CreateSummaryHist(ibooker, "chamberAllStatus");
   h2SummaryStatusWarning = CreateSummaryHist(ibooker, "chamberWarnings");
   h2SummaryStatusError = CreateSummaryHist(ibooker, "chamberErrors");
 
+  h2SummaryStatusAll->setTitle("Summary of all number of OH or VFAT status of each chambers");
   h2SummaryStatusWarning->setTitle("Summary of OH or VFAT warnings of each chambers");
   h2SummaryStatusError->setTitle("Summary of OH or VFAT errors of each chambers");
 }
@@ -302,6 +304,7 @@ void GEMDAQStatusSource::analyze(edm::Event const &event, edm::EventSetup const 
   }
 
   // WARNING: ME4IdsKey for region, station, layer, chamber (not iEta)
+  std::map<ME4IdsKey, bool> mapChamberAll;
   std::map<ME4IdsKey, bool> mapChamberWarning;
   std::map<ME4IdsKey, bool> mapChamberError;
 
@@ -356,6 +359,7 @@ void GEMDAQStatusSource::analyze(edm::Event const &event, edm::EventSetup const 
         mapChamberWarning[key4] = false;
       if (bErr)
         mapChamberError[key4] = false;
+      mapChamberAll[key4] = true;
     }
   }
 
@@ -410,11 +414,21 @@ void GEMDAQStatusSource::analyze(edm::Event const &event, edm::EventSetup const 
         mapStatusWarnVFATPerLayer_.Fill(key3, gid.chamber(), nIdxVFAT);
       if (bErr)
         mapStatusErrVFATPerLayer_.Fill(key3, gid.chamber(), nIdxVFAT);
+      mapChamberAll[key4Ch] = true;
     }
+  }
+
+  // Summarizing all presence of status of each chamber
+  for (auto const &[key4, bErr] : mapChamberAll) {
+    ME3IdsKey key3 = key4Tokey3(key4);
+    Int_t nChamber = keyToChamber(key4);
+    h2SummaryStatusAll->Fill(nChamber, mapStationToIdx_[key3]);
   }
 
   // Summarizing the warning occupancy
   for (auto const &[key4, bWarning] : mapChamberWarning) {
+    if (mapChamberError.find(key4) != mapChamberError.end())  // Avoiding any double-counting
+      continue;
     ME3IdsKey key3 = key4Tokey3(key4);
     Int_t nChamber = keyToChamber(key4);
     h2SummaryStatusWarning->Fill(nChamber, mapStationToIdx_[key3]);

--- a/DQM/GEM/plugins/GEMRecHitSource.cc
+++ b/DQM/GEM/plugins/GEMRecHitSource.cc
@@ -50,17 +50,17 @@ void GEMRecHitSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&
   mapTotalRecHitPerEvtLayer_ = MEMap3Inf(this,
                                          "rechits_per_layer",
                                          "Total number of RecHits per event for each layers",
-                                         50,
+                                         2000,
                                          -0.5,
-                                         99.5,
+                                         2000 - 0.5,
                                          "Number of RecHits",
                                          "Events");
   mapTotalRecHitPerEvtIEta_ = MEMap3Inf(this,
                                         "rechits_per_ieta",
                                         "Total number of RecHits per event for each eta partitions",
-                                        50,
+                                        300,
                                         -0.5,
-                                        99.5,
+                                        300 - 0.5,
                                         "Number of RecHits",
                                         "Events");
   mapCLSRecHit_ieta_ = MEMap3Inf(


### PR DESCRIPTION
#### PR description:
The criteria of the summary plot of GEM onlineDQM have been changed: From now on it goes red(error)/yellow(warning) which is determined by the ratio of error/warning status on each chamber.

Also binning of some plots have been changed to watch some recHit distribution more carefully.

#### PR validation:
Test are done and one can check again by `runTheMatrix` workflows

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
This is a backport of #35952 to CMSSW_12_0_X to be deployed on the current runs

@jshlee @watson-ij 