### PR TITLE
mitigate high CPU cost of HBHE hit position calculation in EgammaHcalIsolation

### DIFF
--- a/RecoEgamma/EgammaIsolationAlgos/interface/EgammaHcalIsolation.h
+++ b/RecoEgamma/EgammaIsolationAlgos/interface/EgammaHcalIsolation.h
@@ -135,7 +135,8 @@ public:
   }
 
 private:
-  double goodHitEnergy(const GlobalPoint &pclu,
+  double goodHitEnergy(float pcluEta,
+                       float pcluPhi,
                        const HBHERecHit &hit,
                        int depth,
                        int ieta,


### PR DESCRIPTION
costs of computing HCAL isolation in egamma has increased significantly after #33666
- [12_0_0_pre3](https://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre3/11834.21/step3/cpu_endjob/1108) has \~0.14% of reco time in isolation
- [12_0_0_pre4](https://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/11834.21/step3/cpu_endjob/27) has 8.9%
    - [12_1_0_pre4](https://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre4/11834.21/step3/cpu_endjob/28) has a similar fraction

This PR mitigates the situation by reordering the calls.

However, a better refactoring of the code should be considered in near future. Some options are
- accumulate all needed isolation types in one loop over rechits
- precompute (η,φ) of rechits in a separate producer in a `ValueMap` and use it when dR computations are needed
@wrtabb @SohamBhattacharya 
