### PR TITLE
Add stub of `DropBoxMetadata` payload inspector

### DIFF
--- a/CondCore/AlignmentPlugins/plugins/TrackerAlignment_PayloadInspector.cc
+++ b/CondCore/AlignmentPlugins/plugins/TrackerAlignment_PayloadInspector.cc
@@ -305,11 +305,11 @@ namespace {
   //******************************************//
 
   template <AlignmentPI::partitions q>
-  class TrackerAlignmentSummary : public PlotImage<Alignments, SINGLE_IOV> {
+  class TrackerAlignmentSummary : public PlotImage<Alignments, MULTI_IOV> {
   public:
     TrackerAlignmentSummary()
-        : PlotImage<Alignments, SINGLE_IOV>("Comparison of all coordinates between two geometries for " +
-                                            getStringFromPart(q)) {}
+        : PlotImage<Alignments, MULTI_IOV>("Comparison of all coordinates between two geometries for " +
+                                           getStringFromPart(q)) {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();

--- a/CondCore/HLTPlugins/plugins/AlCaRecoTriggerBits_PayloadInspector.cc
+++ b/CondCore/HLTPlugins/plugins/AlCaRecoTriggerBits_PayloadInspector.cc
@@ -18,14 +18,13 @@ namespace {
   /************************************************
     Display AlCaRecoTriggerBits mapping
   *************************************************/
-  class AlCaRecoTriggerBits_Display : public PlotImage<AlCaRecoTriggerBits> {
+  class AlCaRecoTriggerBits_Display : public PlotImage<AlCaRecoTriggerBits, SINGLE_IOV> {
   public:
-    AlCaRecoTriggerBits_Display() : PlotImage<AlCaRecoTriggerBits>("Table of AlCaRecoTriggerBits") {
-      setSingleIov(true);
-    }
+    AlCaRecoTriggerBits_Display() : PlotImage<AlCaRecoTriggerBits, SINGLE_IOV>("Table of AlCaRecoTriggerBits") {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> > &iovs) override {
-      auto iov = iovs.front();
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
       std::shared_ptr<AlCaRecoTriggerBits> payload = fetchPayload(std::get<1>(iov));
 
       std::string IOVsince = std::to_string(std::get<0>(iov));
@@ -51,7 +50,7 @@ namespace {
       y_x1.push_back(y);
       s_x1.push_back("#scale[1.2]{Key}");
       y_x2.push_back(y);
-      s_x2.push_back("#scale[1.2]{in IOV: " + IOVsince + "}");
+      s_x2.push_back("#scale[1.2]{tag: " + tag.name + " in IOV: " + IOVsince + "}");
 
       y -= pitch / 2.;
       y_line.push_back(y);

--- a/CondCore/PhysicsToolsPlugins/interface/DropBoxMetaDataPayloadInspectorHelper.h
+++ b/CondCore/PhysicsToolsPlugins/interface/DropBoxMetaDataPayloadInspectorHelper.h
@@ -1,0 +1,77 @@
+#ifndef DropBoxMetaDataPayloadInspectorHelper_H
+#define DropBoxMetaDataPayloadInspectorHelper_H
+
+#include "TH1.h"
+#include "TH2.h"
+#include "TStyle.h"
+#include "TCanvas.h"
+
+#include <fmt/printf.h>
+#include <fstream>
+#include <boost/tokenizer.hpp>
+#include <boost/range/adaptor/indexed.hpp>
+#include "CondFormats/Common/interface/DropBoxMetadata.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+namespace DPMetaDataHelper {
+  class RecordMetaDataInfo {
+  public:
+    /// Constructor
+    RecordMetaDataInfo(DropBoxMetadata::Parameters params) {
+      const auto& theParameters = params.getParameterMap();
+      for (const auto& [key, val] : theParameters) {
+        if (key.find("prep") != std::string::npos) {
+          m_prepmetadata = val;
+        } else if (key.find("prod") != std::string::npos) {
+          m_prodmetadata = val;
+        } else if (key.find("mult") != std::string::npos) {
+          m_multimetadata = val;
+        }
+      }
+    }
+    /// Destructor
+    ~RecordMetaDataInfo() = default;
+
+  public:
+    const std::string getPrepMetaData() const { return m_prepmetadata; }
+    const std::string getProdMetaData() const { return m_prodmetadata; }
+    const std::string getMultiMetaData() const { return m_multimetadata; }
+
+  private:
+    std::string m_prepmetadata;
+    std::string m_prodmetadata;
+    std::string m_multimetadata;
+  };
+
+  using recordMap = std::map<std::string, RecordMetaDataInfo>;
+
+  class DBMetaDataTableDisplay {
+  public:
+    DBMetaDataTableDisplay(DPMetaDataHelper::recordMap theMap) : m_Map(theMap) {}
+    ~DBMetaDataTableDisplay() = default;
+
+    void printMetaDatas() {
+      for (const auto& [key, val] : m_Map) {
+        std::cout << "key:" << key << "\n\n" << std::endl;
+        std::cout << "prep:" << replaceAll(val.getPrepMetaData(), std::string("&quot;"), std::string("'")) << "\n"
+                  << std::endl;
+        std::cout << "prod:" << replaceAll(val.getProdMetaData(), std::string("&quot;"), std::string("'")) << "\n"
+                  << std::endl;
+        std::cout << "multi:" << replaceAll(val.getMultiMetaData(), std::string("&quot;"), std::string("'")) << "\n"
+                  << std::endl;
+      }
+    }
+
+  private:
+    DPMetaDataHelper::recordMap m_Map;
+    std::string replaceAll(std::string str, const std::string& from, const std::string& to) {
+      size_t start_pos = 0;
+      while ((start_pos = str.find(from, start_pos)) != std::string::npos) {
+        str.replace(start_pos, from.length(), to);
+        start_pos += to.length();  // Handles case where 'to' is a substring of 'from'
+      }
+      return str;
+    }
+  };
+}  // namespace DPMetaDataHelper
+#endif

--- a/CondCore/PhysicsToolsPlugins/interface/DropBoxMetaDataPayloadInspectorHelper.h
+++ b/CondCore/PhysicsToolsPlugins/interface/DropBoxMetaDataPayloadInspectorHelper.h
@@ -13,7 +13,7 @@
 #include "CondFormats/Common/interface/DropBoxMetadata.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-namespace DPMetaDataHelper {
+namespace DBoxMetadataHelper {
   class RecordMetaDataInfo {
   public:
     /// Constructor
@@ -46,12 +46,12 @@ namespace DPMetaDataHelper {
 
   using recordMap = std::map<std::string, RecordMetaDataInfo>;
 
-  inline const std::vector<std::string> getAllRecords(const DPMetaDataHelper::recordMap& recordSet) {
+  inline const std::vector<std::string> getAllRecords(const DBoxMetadataHelper::recordMap& recordSet) {
     std::vector<std::string> records;
     std::transform(recordSet.begin(),
                    recordSet.end(),
                    std::inserter(records, records.end()),
-                   [](std::pair<std::string, DPMetaDataHelper::RecordMetaDataInfo> recordSetEntry) -> std::string {
+                   [](std::pair<std::string, DBoxMetadataHelper::RecordMetaDataInfo> recordSetEntry) -> std::string {
                      return recordSetEntry.first;
                    });
     return records;
@@ -73,61 +73,68 @@ namespace DPMetaDataHelper {
 
   class DBMetaDataTableDisplay {
   public:
-    DBMetaDataTableDisplay(DPMetaDataHelper::recordMap theMap) : m_Map(theMap) {}
+    DBMetaDataTableDisplay(DBoxMetadataHelper::recordMap theMap) : m_Map(theMap) {}
     ~DBMetaDataTableDisplay() = default;
 
     void printMetaDatas() {
       for (const auto& [key, val] : m_Map) {
-        std::cout << "key: " << key << "\n\n" << std::endl;
-        std::cout << "prep: " << cleanJson(val.getPrepMetaData()) << "\n" << std::endl;
-        std::cout << "prod: " << cleanJson(val.getProdMetaData()) << "\n" << std::endl;
+        edm::LogPrint("DropBoxMetadataPIHelper") << "key: " << key << "\n\n" << std::endl;
+        edm::LogPrint("DropBoxMetadataPIHelper") << "prep: " << cleanJson(val.getPrepMetaData()) << "\n" << std::endl;
+        edm::LogPrint("DropBoxMetadataPIHelper") << "prod: " << cleanJson(val.getProdMetaData()) << "\n" << std::endl;
         // check, since it's optional
         if (val.hasMultiMetaData()) {
-          std::cout << "multi: " << cleanJson(val.getMultiMetaData()) << "\n" << std::endl;
+          edm::LogPrint("DropBoxMetadataPIHelper") << "multi: " << cleanJson(val.getMultiMetaData()) << "\n"
+                                                   << std::endl;
         }
       }
     }
 
-    void printOneKey(const DPMetaDataHelper::RecordMetaDataInfo& oneKey) {
-      std::cout << "prep: " << cleanJson(oneKey.getPrepMetaData()) << "\n" << std::endl;
-      std::cout << "prod: " << cleanJson(oneKey.getProdMetaData()) << "\n" << std::endl;
+    void printOneKey(const DBoxMetadataHelper::RecordMetaDataInfo& oneKey) {
+      edm::LogPrint("DropBoxMetadataPIHelper") << "prep: " << cleanJson(oneKey.getPrepMetaData()) << std::endl;
+      edm::LogPrint("DropBoxMetadataPIHelper") << "prod: " << cleanJson(oneKey.getProdMetaData()) << std::endl;
       // check, since it's optional
       if (oneKey.hasMultiMetaData()) {
-        std::cout << "multi: " << cleanJson(oneKey.getMultiMetaData()) << "\n" << std::endl;
+        edm::LogPrint("DropBoxMetadataPIHelper") << "multi: " << cleanJson(oneKey.getMultiMetaData()) << std::endl;
       }
+      edm::LogPrint("DropBoxMetadataPIHelper") << "\n" << std::endl;
     }
 
-    void printDiffWithMetadata(const DPMetaDataHelper::recordMap& theRefMap) {
-      std::cout << "Target has: " << m_Map.size() << " records, reference has: " << theRefMap.size() << " records"
-                << std::endl;
+    void printDiffWithMetadata(const DBoxMetadataHelper::recordMap& theRefMap) {
+      edm::LogPrint("DropBoxMetadataPIHelper")
+          << "Target has: " << m_Map.size() << " records, reference has: " << theRefMap.size() << " records"
+          << std::endl;
 
-      const auto& ref_records = DPMetaDataHelper::getAllRecords(theRefMap);
-      const auto& tar_records = DPMetaDataHelper::getAllRecords(m_Map);
+      const auto& ref_records = DBoxMetadataHelper::getAllRecords(theRefMap);
+      const auto& tar_records = DBoxMetadataHelper::getAllRecords(m_Map);
 
-      const auto& diff = DPMetaDataHelper::set_difference(ref_records, tar_records);
-      const auto& common = DPMetaDataHelper::set_intersection(ref_records, tar_records);
+      const auto& diff = DBoxMetadataHelper::set_difference(ref_records, tar_records);
+      const auto& common = DBoxMetadataHelper::set_intersection(ref_records, tar_records);
 
       // do first the common parts
       for (const auto& key : common) {
-        std::cout << "key: " << key << "\n" << std::endl;
+        edm::LogPrint("DropBoxMetadataPIHelper") << "key: " << key << "\n" << std::endl;
         const auto& val = m_Map.at(key);
         const auto& refval = theRefMap.at(key);
 
         if ((val.getPrepMetaData()).compare(refval.getPrepMetaData()) != 0) {
-          std::cout << "found difference in prep metadata!" << std::endl;
-          std::cout << " in target: " << cleanJson(val.getPrepMetaData()) << std::endl;
-          std::cout << " in reference: " << cleanJson(refval.getPrepMetaData()) << std::endl;
+          edm::LogPrint("DropBoxMetadataPIHelper") << "found difference in prep metadata!" << std::endl;
+          edm::LogPrint("DropBoxMetadataPIHelper") << " in target: " << cleanJson(val.getPrepMetaData()) << std::endl;
+          edm::LogPrint("DropBoxMetadataPIHelper")
+              << " in reference: " << cleanJson(refval.getPrepMetaData()) << std::endl;
         }
         if ((val.getProdMetaData()).compare(refval.getProdMetaData()) != 0) {
-          std::cout << "found difference in prod metadata!" << std::endl;
-          std::cout << " in target: " << cleanJson(val.getProdMetaData()) << std::endl;
-          std::cout << " in reference: " << cleanJson(refval.getProdMetaData()) << std::endl;
+          edm::LogPrint("DropBoxMetadataPIHelper") << "found difference in prod metadata!" << std::endl;
+          edm::LogPrint("DropBoxMetadataPIHelper") << " in target: " << cleanJson(val.getProdMetaData()) << std::endl;
+          edm::LogPrint("DropBoxMetadataPIHelper")
+              << " in reference: " << cleanJson(refval.getProdMetaData()) << std::endl;
         }
         if ((val.getMultiMetaData()).compare(refval.getMultiMetaData()) != 0) {
-          std::cout << "found difference in multi metadata!" << std::endl;
-          std::cout << " in target: " << cleanJson(val.getMultiMetaData()) << std::endl;
-          std::cout << " in reference: " << cleanJson(refval.getMultiMetaData()) << std::endl;
+          edm::LogPrint("DropBoxMetadataPIHelper") << "found difference in multi metadata!" << std::endl;
+          edm::LogPrint("DropBoxMetadataPIHelper") << " in target: " << cleanJson(val.getMultiMetaData()) << std::endl;
+          edm::LogPrint("DropBoxMetadataPIHelper")
+              << " in reference: " << cleanJson(refval.getMultiMetaData()) << std::endl;
         }
+        edm::LogPrint("DropBoxMetadataPIHelper") << "\n" << std::endl;
       }
 
       // if interesction is not the union check for extra differences
@@ -137,7 +144,7 @@ namespace DPMetaDataHelper {
           for (const auto& ref : ref_records) {
             if (std::find(tar_records.begin(), tar_records.end(), ref) == tar_records.end()) {
               const auto& refval = theRefMap.at(ref);
-              std::cout << "key: " << ref << " not present in target! \n" << std::endl;
+              edm::LogPrint("DropBoxMetadataPIHelper") << "key: " << ref << " not present in target! \n" << std::endl;
               printOneKey(refval);
             }
           }
@@ -146,8 +153,9 @@ namespace DPMetaDataHelper {
         else if (tar_records.size() > ref_records.size()) {
           for (const auto& tar : tar_records) {
             if (std::find(ref_records.begin(), ref_records.end(), tar) == ref_records.end()) {
-              const auto& tarval = theRefMap.at(tar);
-              std::cout << "key: " << tar << " not present in reference! \n" << std::endl;
+              const auto& tarval = m_Map.at(tar);
+              edm::LogPrint("DropBoxMetadataPIHelper") << "key: " << tar << " not present in reference! \n"
+                                                       << std::endl;
               printOneKey(tarval);
             }
           }
@@ -156,7 +164,7 @@ namespace DPMetaDataHelper {
     }
 
   private:
-    DPMetaDataHelper::recordMap m_Map;
+    DBoxMetadataHelper::recordMap m_Map;
 
     std::string replaceAll(std::string str, const std::string& from, const std::string& to) {
       size_t start_pos = 0;
@@ -172,5 +180,5 @@ namespace DPMetaDataHelper {
       return out;
     }
   };
-}  // namespace DPMetaDataHelper
+}  // namespace DBoxMetadataHelper
 #endif

--- a/CondCore/PhysicsToolsPlugins/interface/DropBoxMetaDataPayloadInspectorHelper.h
+++ b/CondCore/PhysicsToolsPlugins/interface/DropBoxMetaDataPayloadInspectorHelper.h
@@ -36,6 +36,7 @@ namespace DPMetaDataHelper {
     const std::string getPrepMetaData() const { return m_prepmetadata; }
     const std::string getProdMetaData() const { return m_prodmetadata; }
     const std::string getMultiMetaData() const { return m_multimetadata; }
+    const bool hasMultiMetaData() const { return !m_multimetadata.empty(); }
 
   private:
     std::string m_prepmetadata;
@@ -45,6 +46,31 @@ namespace DPMetaDataHelper {
 
   using recordMap = std::map<std::string, RecordMetaDataInfo>;
 
+  inline const std::vector<std::string> getAllRecords(const DPMetaDataHelper::recordMap& recordSet) {
+    std::vector<std::string> records;
+    std::transform(recordSet.begin(),
+                   recordSet.end(),
+                   std::inserter(records, records.end()),
+                   [](std::pair<std::string, DPMetaDataHelper::RecordMetaDataInfo> recordSetEntry) -> std::string {
+                     return recordSetEntry.first;
+                   });
+    return records;
+  }
+
+  inline std::vector<std::string> set_difference(std::vector<std::string> const& v1,
+                                                 std::vector<std::string> const& v2) {
+    std::vector<std::string> diff;
+    std::set_difference(std::begin(v1), std::end(v1), std::begin(v2), std::end(v2), std::back_inserter(diff));
+    return diff;
+  }
+
+  inline std::vector<std::string> set_intersection(std::vector<std::string> const& v1,
+                                                   std::vector<std::string> const& v2) {
+    std::vector<std::string> common;
+    std::set_intersection(std::begin(v1), std::end(v1), std::begin(v2), std::end(v2), std::back_inserter(common));
+    return common;
+  }
+
   class DBMetaDataTableDisplay {
   public:
     DBMetaDataTableDisplay(DPMetaDataHelper::recordMap theMap) : m_Map(theMap) {}
@@ -52,18 +78,86 @@ namespace DPMetaDataHelper {
 
     void printMetaDatas() {
       for (const auto& [key, val] : m_Map) {
-        std::cout << "key:" << key << "\n\n" << std::endl;
-        std::cout << "prep:" << replaceAll(val.getPrepMetaData(), std::string("&quot;"), std::string("'")) << "\n"
-                  << std::endl;
-        std::cout << "prod:" << replaceAll(val.getProdMetaData(), std::string("&quot;"), std::string("'")) << "\n"
-                  << std::endl;
-        std::cout << "multi:" << replaceAll(val.getMultiMetaData(), std::string("&quot;"), std::string("'")) << "\n"
-                  << std::endl;
+        std::cout << "key: " << key << "\n\n" << std::endl;
+        std::cout << "prep: " << cleanJson(val.getPrepMetaData()) << "\n" << std::endl;
+        std::cout << "prod: " << cleanJson(val.getProdMetaData()) << "\n" << std::endl;
+        // check, since it's optional
+        if (val.hasMultiMetaData()) {
+          std::cout << "multi: " << cleanJson(val.getMultiMetaData()) << "\n" << std::endl;
+        }
+      }
+    }
+
+    void printOneKey(const DPMetaDataHelper::RecordMetaDataInfo& oneKey) {
+      std::cout << "prep: " << cleanJson(oneKey.getPrepMetaData()) << "\n" << std::endl;
+      std::cout << "prod: " << cleanJson(oneKey.getProdMetaData()) << "\n" << std::endl;
+      // check, since it's optional
+      if (oneKey.hasMultiMetaData()) {
+        std::cout << "multi: " << cleanJson(oneKey.getMultiMetaData()) << "\n" << std::endl;
+      }
+    }
+
+    void printDiffWithMetadata(const DPMetaDataHelper::recordMap& theRefMap) {
+      std::cout << "Target has: " << m_Map.size() << " records, reference has: " << theRefMap.size() << " records"
+                << std::endl;
+
+      const auto& ref_records = DPMetaDataHelper::getAllRecords(theRefMap);
+      const auto& tar_records = DPMetaDataHelper::getAllRecords(m_Map);
+
+      const auto& diff = DPMetaDataHelper::set_difference(ref_records, tar_records);
+      const auto& common = DPMetaDataHelper::set_intersection(ref_records, tar_records);
+
+      // do first the common parts
+      for (const auto& key : common) {
+        std::cout << "key: " << key << "\n" << std::endl;
+        const auto& val = m_Map.at(key);
+        const auto& refval = theRefMap.at(key);
+
+        if ((val.getPrepMetaData()).compare(refval.getPrepMetaData()) != 0) {
+          std::cout << "found difference in prep metadata!" << std::endl;
+          std::cout << " in target: " << cleanJson(val.getPrepMetaData()) << std::endl;
+          std::cout << " in reference: " << cleanJson(refval.getPrepMetaData()) << std::endl;
+        }
+        if ((val.getProdMetaData()).compare(refval.getProdMetaData()) != 0) {
+          std::cout << "found difference in prod metadata!" << std::endl;
+          std::cout << " in target: " << cleanJson(val.getProdMetaData()) << std::endl;
+          std::cout << " in reference: " << cleanJson(refval.getProdMetaData()) << std::endl;
+        }
+        if ((val.getMultiMetaData()).compare(refval.getMultiMetaData()) != 0) {
+          std::cout << "found difference in multi metadata!" << std::endl;
+          std::cout << " in target: " << cleanJson(val.getMultiMetaData()) << std::endl;
+          std::cout << " in reference: " << cleanJson(refval.getMultiMetaData()) << std::endl;
+        }
+      }
+
+      // if interesction is not the union check for extra differences
+      if (!diff.empty()) {
+        // check if the reference has more records than target
+        if (ref_records.size() > tar_records.size()) {
+          for (const auto& ref : ref_records) {
+            if (std::find(tar_records.begin(), tar_records.end(), ref) == tar_records.end()) {
+              const auto& refval = theRefMap.at(ref);
+              std::cout << "key: " << ref << " not present in target! \n" << std::endl;
+              printOneKey(refval);
+            }
+          }
+        }
+        // then check if the target has more records than the reference
+        else if (tar_records.size() > ref_records.size()) {
+          for (const auto& tar : tar_records) {
+            if (std::find(ref_records.begin(), ref_records.end(), tar) == ref_records.end()) {
+              const auto& tarval = theRefMap.at(tar);
+              std::cout << "key: " << tar << " not present in reference! \n" << std::endl;
+              printOneKey(tarval);
+            }
+          }
+        }
       }
     }
 
   private:
     DPMetaDataHelper::recordMap m_Map;
+
     std::string replaceAll(std::string str, const std::string& from, const std::string& to) {
       size_t start_pos = 0;
       while ((start_pos = str.find(from, start_pos)) != std::string::npos) {
@@ -71,6 +165,11 @@ namespace DPMetaDataHelper {
         start_pos += to.length();  // Handles case where 'to' is a substring of 'from'
       }
       return str;
+    }
+
+    std::string cleanJson(std::string str) {
+      std::string out = replaceAll(str, std::string("&quot;"), std::string("'"));
+      return out;
     }
   };
 }  // namespace DPMetaDataHelper

--- a/CondCore/PhysicsToolsPlugins/plugins/BuildFile.xml
+++ b/CondCore/PhysicsToolsPlugins/plugins/BuildFile.xml
@@ -1,0 +1,4 @@
+<library file="DropBoxMetadata_PayloadInspector.cc" name="DropBoxMetadata_PayloadInspector">
+  <use name="CondCore/Utilities"/>
+  <use name="CondCore/CondDB"/>
+</library>

--- a/CondCore/PhysicsToolsPlugins/plugins/DropBoxMetadata_PayloadInspector.cc
+++ b/CondCore/PhysicsToolsPlugins/plugins/DropBoxMetadata_PayloadInspector.cc
@@ -1,0 +1,68 @@
+/*!
+  \file DropBoxMetadata_PayloadInspector
+  \Payload Inspector Plugin for DropBoxMetadata
+  \author M. Musich
+  \version $Revision: 1.0 $
+  \date $Date: 2018/03/18 10:01:00 $
+*/
+
+#include "CondCore/Utilities/interface/PayloadInspectorModule.h"
+#include "CondCore/Utilities/interface/PayloadInspector.h"
+#include "CondCore/CondDB/interface/Time.h"
+
+// the data format of the condition to be inspected
+#include "CondFormats/Common/interface/DropBoxMetadata.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+// system includes
+#include <memory>
+#include <sstream>
+#include <iostream>
+
+// include ROOT
+#include "TProfile.h"
+#include "TH2F.h"
+#include "TLegend.h"
+#include "TCanvas.h"
+#include "TLine.h"
+#include "TStyle.h"
+#include "TLatex.h"
+#include "TPave.h"
+#include "TPaveStats.h"
+#include "TPaletteAxis.h"
+
+namespace {
+
+  using namespace cond::payloadInspector;
+
+  /************************************************
+     DropBoxMetadata Payload Inspector of 1 IOV 
+  *************************************************/
+  class DropBoxMetadataTest : public Histogram1D<DropBoxMetadata, SINGLE_IOV> {
+  public:
+    DropBoxMetadataTest()
+        : Histogram1D<DropBoxMetadata, SINGLE_IOV>("Test DropBoxMetadata", "Test DropBoxMetadata", 1, 0.0, 1.0) {}
+
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
+        std::shared_ptr<DropBoxMetadata> payload = Base::fetchPayload(std::get<1>(iov));
+        if (payload.get()) {
+          std::vector<std::string> records = payload->getAllRecords();
+          for (const auto& record : records) {
+            std::cout << "record: " << record << std::endl;
+            const auto& parameters = payload->getRecordParameters(record);
+            const auto& recordParams = parameters.getParameterMap();
+            for (const auto& [key, val] : recordParams) {
+              std::cout << key << " : "
+                        << " value: " << val << std::endl;
+            }
+          }
+        }
+      }
+      return true;
+    }
+  };
+}  // namespace
+
+PAYLOAD_INSPECTOR_MODULE(DropBoxMetadata) { PAYLOAD_INSPECTOR_CLASS(DropBoxMetadataTest); }

--- a/CondCore/PhysicsToolsPlugins/plugins/DropBoxMetadata_PayloadInspector.cc
+++ b/CondCore/PhysicsToolsPlugins/plugins/DropBoxMetadata_PayloadInspector.cc
@@ -97,14 +97,14 @@ namespace {
       std::vector<std::string> records = payload->getAllRecords();
       TCanvas canvas("Canv", "Canv", 1200, 100 * records.size());
 
-      DPMetaDataHelper::recordMap theRecordMap;
+      DBoxMetadataHelper::recordMap theRecordMap;
       for (const auto& record : records) {
         edm::LogPrint("DropBoxMetadata_PayloadInspector") << "record: " << record << std::endl;
         const auto& parameters = payload->getRecordParameters(record);
-        theRecordMap.insert(std::make_pair(record, DPMetaDataHelper::RecordMetaDataInfo(parameters)));
+        theRecordMap.insert(std::make_pair(record, DBoxMetadataHelper::RecordMetaDataInfo(parameters)));
       }
 
-      DPMetaDataHelper::DBMetaDataTableDisplay theDisplay(theRecordMap);
+      DBoxMetadataHelper::DBMetaDataTableDisplay theDisplay(theRecordMap);
       theDisplay.printMetaDatas();
 
       std::string fileName(m_imageFileName);
@@ -151,26 +151,26 @@ namespace {
 
       // first payload
       std::vector<std::string> f_records = first_payload->getAllRecords();
-      DPMetaDataHelper::recordMap f_theRecordMap;
+      DBoxMetadataHelper::recordMap f_theRecordMap;
       for (const auto& record : f_records) {
         //edm::LogPrint("DropBoxMetadata_PayloadInspector") << "record: " << record << std::endl;
         const auto& parameters = first_payload->getRecordParameters(record);
-        f_theRecordMap.insert(std::make_pair(record, DPMetaDataHelper::RecordMetaDataInfo(parameters)));
+        f_theRecordMap.insert(std::make_pair(record, DBoxMetadataHelper::RecordMetaDataInfo(parameters)));
       }
 
-      DPMetaDataHelper::DBMetaDataTableDisplay f_theDisplay(f_theRecordMap);
+      DBoxMetadataHelper::DBMetaDataTableDisplay f_theDisplay(f_theRecordMap);
       //f_theDisplay.printMetaDatas();
 
       // last payload
       std::vector<std::string> l_records = last_payload->getAllRecords();
-      DPMetaDataHelper::recordMap l_theRecordMap;
+      DBoxMetadataHelper::recordMap l_theRecordMap;
       for (const auto& record : l_records) {
         //edm::LogPrint("DropBoxMetadata_PayloadInspector") << "record: " << record << std::endl;
         const auto& parameters = last_payload->getRecordParameters(record);
-        l_theRecordMap.insert(std::make_pair(record, DPMetaDataHelper::RecordMetaDataInfo(parameters)));
+        l_theRecordMap.insert(std::make_pair(record, DBoxMetadataHelper::RecordMetaDataInfo(parameters)));
       }
 
-      DPMetaDataHelper::DBMetaDataTableDisplay l_theDisplay(l_theRecordMap);
+      DBoxMetadataHelper::DBMetaDataTableDisplay l_theDisplay(l_theRecordMap);
       //l_theDisplay.printMetaDatas();
 
       l_theDisplay.printDiffWithMetadata(f_theRecordMap);

--- a/CondCore/PhysicsToolsPlugins/plugins/DropBoxMetadata_PayloadInspector.cc
+++ b/CondCore/PhysicsToolsPlugins/plugins/DropBoxMetadata_PayloadInspector.cc
@@ -18,6 +18,7 @@
 #include <memory>
 #include <sstream>
 #include <iostream>
+#include <boost/algorithm/string/replace.hpp>
 
 // include ROOT
 #include "TProfile.h"
@@ -50,19 +51,80 @@ namespace {
         if (payload.get()) {
           std::vector<std::string> records = payload->getAllRecords();
           for (const auto& record : records) {
-            std::cout << "record: " << record << std::endl;
+            edm::LogPrint("DropBoxMetadata_PayloadInspector") << "record: " << record << std::endl;
             const auto& parameters = payload->getRecordParameters(record);
             const auto& recordParams = parameters.getParameterMap();
             for (const auto& [key, val] : recordParams) {
-              std::cout << key << " : "
-                        << " value: " << val << std::endl;
+              if (val.find("&quot;") != std::string::npos) {
+                const auto& replaced = replaceAll(val, std::string("&quot;"), std::string("'"));
+                edm::LogPrint("DropBoxMetadata_PayloadInspector") << key << " : " << replaced << std::endl;
+              } else {
+                edm::LogPrint("DropBoxMetadata_PayloadInspector") << key << " : " << val << std::endl;
+              }
             }
           }
         }
       }
       return true;
     }
+
+  private:
+    std::string replaceAll(std::string str, const std::string& from, const std::string& to) {
+      size_t start_pos = 0;
+      while ((start_pos = str.find(from, start_pos)) != std::string::npos) {
+        str.replace(start_pos, from.length(), to);
+        start_pos += to.length();  // Handles case where 'to' is a substring of 'from'
+      }
+      return str;
+    }
+  };
+
+  /************************************************
+     DropBoxMetadata Payload Inspector of 1 IOV 
+  *************************************************/
+  class DropBoxMetadata_Display : public PlotImage<DropBoxMetadata, SINGLE_IOV> {
+  public:
+    DropBoxMetadata_Display() : PlotImage<DropBoxMetadata, SINGLE_IOV>("DropBoxMetadata Display of contents") {}
+
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
+      std::shared_ptr<DropBoxMetadata> payload = fetchPayload(std::get<1>(iov));
+
+      std::vector<std::string> records = payload->getAllRecords();
+      TCanvas canvas("Canv", "Canv", 1200, 100 * records.size());
+
+      for (const auto& record : records) {
+        edm::LogPrint("DropBoxMetadata_PayloadInspector") << "record: " << record << std::endl;
+        const auto& parameters = payload->getRecordParameters(record);
+        const auto& recordParams = parameters.getParameterMap();
+        for (const auto& [key, val] : recordParams) {
+          if (val.find("&quot;") != std::string::npos) {
+            const auto& replaced = replaceAll(val, std::string("&quot;"), std::string("'"));
+            edm::LogPrint("DropBoxMetadata_PayloadInspector") << key << " : " << replaced << std::endl;
+          } else {
+            edm::LogPrint("DropBoxMetadata_PayloadInspector") << key << " : " << val << std::endl;
+          }
+        }
+      }
+      std::string fileName(m_imageFileName);
+      canvas.SaveAs(fileName.c_str());
+      return true;
+    }
+
+  private:
+    std::string replaceAll(std::string str, const std::string& from, const std::string& to) {
+      size_t start_pos = 0;
+      while ((start_pos = str.find(from, start_pos)) != std::string::npos) {
+        str.replace(start_pos, from.length(), to);
+        start_pos += to.length();  // Handles case where 'to' is a substring of 'from'
+      }
+      return str;
+    }
   };
 }  // namespace
 
-PAYLOAD_INSPECTOR_MODULE(DropBoxMetadata) { PAYLOAD_INSPECTOR_CLASS(DropBoxMetadataTest); }
+PAYLOAD_INSPECTOR_MODULE(DropBoxMetadata) {
+  PAYLOAD_INSPECTOR_CLASS(DropBoxMetadataTest);
+  PAYLOAD_INSPECTOR_CLASS(DropBoxMetadata_Display);
+}

--- a/CondCore/PhysicsToolsPlugins/plugins/DropBoxMetadata_PayloadInspector.cc
+++ b/CondCore/PhysicsToolsPlugins/plugins/DropBoxMetadata_PayloadInspector.cc
@@ -14,6 +14,9 @@
 #include "CondFormats/Common/interface/DropBoxMetadata.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+// helper classes
+#include "CondCore/PhysicsToolsPlugins/interface/DropBoxMetaDataPayloadInspectorHelper.h"
+
 // system includes
 #include <memory>
 #include <sstream>
@@ -94,33 +97,32 @@ namespace {
       std::vector<std::string> records = payload->getAllRecords();
       TCanvas canvas("Canv", "Canv", 1200, 100 * records.size());
 
+      DPMetaDataHelper::recordMap theRecordMap;
       for (const auto& record : records) {
         edm::LogPrint("DropBoxMetadata_PayloadInspector") << "record: " << record << std::endl;
         const auto& parameters = payload->getRecordParameters(record);
-        const auto& recordParams = parameters.getParameterMap();
-        for (const auto& [key, val] : recordParams) {
-          if (val.find("&quot;") != std::string::npos) {
-            const auto& replaced = replaceAll(val, std::string("&quot;"), std::string("'"));
-            edm::LogPrint("DropBoxMetadata_PayloadInspector") << key << " : " << replaced << std::endl;
-          } else {
-            edm::LogPrint("DropBoxMetadata_PayloadInspector") << key << " : " << val << std::endl;
-          }
-        }
+        theRecordMap.insert(std::make_pair(record, DPMetaDataHelper::RecordMetaDataInfo(parameters)));
       }
+
+      DPMetaDataHelper::DBMetaDataTableDisplay theDisplay(theRecordMap);
+      theDisplay.printMetaDatas();
+
+      //const auto& recordParams = parameters.getParameterMap();
+      // for (const auto& [key, val] : recordParams) {
+      //   if (val.find("&quot;") != std::string::npos) {
+      //     const auto& replaced = replaceAll(val, std::string("&quot;"), std::string("'"));
+      //     edm::LogPrint("DropBoxMetadata_PayloadInspector") << key << " : " << replaced << std::endl;
+      //   } else {
+      //     edm::LogPrint("DropBoxMetadata_PayloadInspector") << key << " : " << val << std::endl;
+      //   }
+      // }
+
       std::string fileName(m_imageFileName);
       canvas.SaveAs(fileName.c_str());
       return true;
     }
 
   private:
-    std::string replaceAll(std::string str, const std::string& from, const std::string& to) {
-      size_t start_pos = 0;
-      while ((start_pos = str.find(from, start_pos)) != std::string::npos) {
-        str.replace(start_pos, from.length(), to);
-        start_pos += to.length();  // Handles case where 'to' is a substring of 'from'
-      }
-      return str;
-    }
   };
 }  // namespace
 

--- a/CondCore/PhysicsToolsPlugins/test/BuildFile.xml
+++ b/CondCore/PhysicsToolsPlugins/test/BuildFile.xml
@@ -1,0 +1,5 @@
+<use name="CondCore/Utilities"/>
+<use name="FWCore/PluginManager"/>
+<use name="CondFormats/Common"/>
+<bin file="test_DropBoxMetadata_PayloadInspector.cpp" name="test_DropBoxMetadata_PayloadInspector">
+</bin>

--- a/CondCore/PhysicsToolsPlugins/test/test_DropBoxMetadata_PayloadInspector.cpp
+++ b/CondCore/PhysicsToolsPlugins/test/test_DropBoxMetadata_PayloadInspector.cpp
@@ -1,0 +1,42 @@
+#include <iostream>
+#include <sstream>
+#include "CondCore/Utilities/interface/PayloadInspector.h"
+#include "CondCore/PhysicsToolsPlugins/plugins/DropBoxMetadata_PayloadInspector.cc"
+
+#include "FWCore/PluginManager/interface/PluginManager.h"
+#include "FWCore/PluginManager/interface/standard.h"
+#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+int main(int argc, char** argv) {
+  Py_Initialize();
+  edmplugin::PluginManager::Config config;
+  edmplugin::PluginManager::configure(edmplugin::standard::config());
+
+  std::vector<edm::ParameterSet> psets;
+  edm::ParameterSet pSet;
+  pSet.addParameter("@service_type", std::string("SiteLocalConfigService"));
+  psets.push_back(pSet);
+  edm::ServiceToken servToken(edm::ServiceRegistry::createSet(psets));
+  edm::ServiceRegistry::Operate operate(servToken);
+
+  std::string connectionString("frontier://FrontierProd/CMS_CONDITIONS");
+
+  std::string tag = "DropBoxMetadata_v5.1_express";
+  cond::Time_t start = static_cast<unsigned long long>(1);
+  cond::Time_t end = static_cast<unsigned long long>(346361);
+
+  edm::LogPrint("test_DropBoxMetadata_PayloadInspector") << "## test Display" << std::endl;
+
+  DropBoxMetadata_Display histo1;
+  histo1.process(connectionString, PI::mk_input(tag, start, start));
+  edm::LogPrint("test_DropBoxMetadata_PayloadInspector") << histo1.data() << std::endl;
+
+  edm::LogPrint("test_DropBoxMetadata_PayloadInspector") << "## test Compare" << std::endl;
+
+  DropBoxMetadata_Compare histo2;
+  histo2.process(connectionString, PI::mk_input(tag, start, end));
+  edm::LogPrint("test_DropBoxMetadata_PayloadInspector") << histo2.data() << std::endl;
+
+  Py_Finalize();
+}

--- a/CondCore/PhysicsToolsPlugins/test/test_DropBoxMetadata_PayloadInspector.sh
+++ b/CondCore/PhysicsToolsPlugins/test/test_DropBoxMetadata_PayloadInspector.sh
@@ -26,3 +26,12 @@ getPayloadData.py \
     --iovs '{"start_iov": "345684", "end_iov": "345684"}' \
     --db Prod \
     --test
+
+getPayloadData.py \
+    --plugin pluginDropBoxMetadata_PayloadInspector \
+    --plot plot_DropBoxMetadata_Compare \
+    --tag DropBoxMetadata_v5.1_express \
+    --time_type Run \
+    --iovs '{"start_iov": "345684", "end_iov": "346361"}' \
+    --db Prod \
+    --test

--- a/CondCore/PhysicsToolsPlugins/test/test_DropBoxMetadata_PayloadInspector.sh
+++ b/CondCore/PhysicsToolsPlugins/test/test_DropBoxMetadata_PayloadInspector.sh
@@ -17,3 +17,12 @@ getPayloadData.py \
     --iovs '{"start_iov": "345684", "end_iov": "345684"}' \
     --db Prod \
     --test
+
+getPayloadData.py \
+    --plugin pluginDropBoxMetadata_PayloadInspector \
+    --plot plot_DropBoxMetadata_Display \
+    --tag DropBoxMetadata_v5.1_express \
+    --time_type Run \
+    --iovs '{"start_iov": "345684", "end_iov": "345684"}' \
+    --db Prod \
+    --test

--- a/CondCore/PhysicsToolsPlugins/test/test_DropBoxMetadata_PayloadInspector.sh
+++ b/CondCore/PhysicsToolsPlugins/test/test_DropBoxMetadata_PayloadInspector.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Save current working dir so img can be outputted there later
+W_DIR=$(pwd);
+# Set SCRAM architecture var
+SCRAM_ARCH=slc7_amd64_gcc900;
+export SCRAM_ARCH;
+source /afs/cern.ch/cms/cmsset_default.sh;
+eval `scram run -sh`;
+
+mkdir -p $W_DIR/results
+
+getPayloadData.py \
+    --plugin pluginDropBoxMetadata_PayloadInspector \
+    --plot plot_DropBoxMetadataTest \
+    --tag DropBoxMetadata_v5.1_express \
+    --time_type Run \
+    --iovs '{"start_iov": "345684", "end_iov": "345684"}' \
+    --db Prod \
+    --test

--- a/CondFormats/Common/interface/DropBoxMetadata.h
+++ b/CondFormats/Common/interface/DropBoxMetadata.h
@@ -43,6 +43,8 @@ public:
 
   bool knowsRecord(const std::string& record) const;
 
+  const std::vector<std::string> getAllRecords() const;
+
 protected:
 private:
   std::map<std::string, DropBoxMetadata::Parameters> recordSet;

--- a/CondFormats/Common/src/DropBoxMetadata.cc
+++ b/CondFormats/Common/src/DropBoxMetadata.cc
@@ -8,6 +8,7 @@
  */
 
 #include "CondFormats/Common/interface/DropBoxMetadata.h"
+#include <algorithm>  // for std::transform
 
 using std::map;
 using std::string;
@@ -42,4 +43,15 @@ bool DropBoxMetadata::knowsRecord(const std::string& record) const {
     return true;
 
   return false;
+}
+
+const std::vector<std::string> DropBoxMetadata::getAllRecords() const {
+  std::vector<std::string> records;
+  std::transform(recordSet.begin(),
+                 recordSet.end(),
+                 std::inserter(records, records.end()),
+                 [](std::pair<std::string, DropBoxMetadata::Parameters> recordSetEntry) -> std::string {
+                   return recordSetEntry.first;
+                 });
+  return records;
 }


### PR DESCRIPTION
#### PR description:

This PR introduces a stub of  payload inspector for the `DropBoxMetadata`class, which is used to store the PCL upload configurations, in order to provide display and comparisons of the various PCL metadata JSON-based files. 
In order to do so, a change in the `CondFormat` is necessary, but as only an accessor is added, there's no schema evolution policy breakage. 
For the time being only the infrastructural changes are introduced, while the actual plotting will be addressed at a later time from @tlampen.
I introduce here also examples and unit tests in the `CondCore/PhysicsToolsPlugins/test` folder.
I profit of this PR to make a minor update to the `AlCaRecoTriggerBits_PayloadInspector` (commit https://github.com/mmusich/cmssw/commit/67617011ef71a64fb4fb7a4bfdeda7d5eb1503e4) and to fix a bug in (commit https://github.com/mmusich/cmssw/commit/0c13523b4a6f154a4b2709a6e0a5accde61f3c84)

#### PR validation:

Passes the introduced unit tests.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A