### PR TITLE
add `makeTrackValidationPlots` test unit

### DIFF
--- a/Validation/RecoTrack/test/BuildFile.xml
+++ b/Validation/RecoTrack/test/BuildFile.xml
@@ -1,0 +1,4 @@
+<bin name="testMakeTrackValidationPlots" file="TestDriver.cpp">
+  <flags TEST_RUNNER_ARGS="/bin/bash Validation/RecoTrack/test test_makeTrackValidationPlots.sh"/>
+  <use name="FWCore/Utilities"/>
+</bin>

--- a/Validation/RecoTrack/test/TestDriver.cpp
+++ b/Validation/RecoTrack/test/TestDriver.cpp
@@ -1,0 +1,2 @@
+#include "FWCore/Utilities/interface/TestHelper.h"
+RUNTEST()

--- a/Validation/RecoTrack/test/test_makeTrackValidationPlots.sh
+++ b/Validation/RecoTrack/test/test_makeTrackValidationPlots.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+function die { echo $1: status $2; exit $2; }
+REMOTE="/store/group/phys_tracking/cmssw_unittests/"
+DQMFILE="DQM_V0001_R000000001__RelValTTbar_14TeV__CMSSW_12_1_0_pre5-121X_mcRun3_2021_realistic_v15-v1__DQMIO.root"
+COMMMAND=`xrdfs cms-xrd-global.cern.ch locate ${REMOTE}${DQMFILE}`
+STATUS=$?
+echo "xrdfs command status = "$STATUS
+if [ $STATUS -eq 0 ]; then
+    echo "Using file ${DQMFILE}. Running in ${LOCAL_TEST_DIR}."
+    xrdcp root://cms-xrd-global.cern.ch/${REMOTE}${DQMFILE} ${LOCAL_TEST_DIR}
+    (makeTrackValidationPlots.py ${LOCAL_TEST_DIR}/${DQMFILE}) || die 'failed running makeTrackValidationPlots.py $DQMFILE' $?
+    rm -fr ${LOCAL_TEST_DIR}/${DQMFILE}
+else 
+  die "SKIPPING test, file ${DQMFILE} not found" 0
+fi


### PR DESCRIPTION
#### PR description:

As it seems that this crucial script for the tracking validation and development gets frequently broken (see  https://github.com/cms-sw/cmssw/issues/35827 and https://github.com/cms-sw/cmssw/issues/35225) I provide here some unit test that should make sure that it's not unintentionally left broken.

#### PR validation:

The unit test run locally

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
