### PR TITLE
 expand tracker-driven coverage for electron seeds; jetCore mitigation (bp of #35892)

### DIFF
--- a/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
@@ -1068,7 +1068,9 @@ void PFEGammaAlgo::removeOrLinkECALClustersToKFTracks() {
             }
           }  // loop over tracks in primary vertex
              // if associated to good non-GSF matched track remove this cluster
-          if (PFTrackAlgoTools::isGoodForEGMPrimary(trackref->algo()) && nexhits == 0 && fromprimaryvertex) {
+          if ((PFTrackAlgoTools::isGoodForEGMPrimary(trackref->algo()) ||
+               PFTrackAlgoTools::isGoodForEGMPrimary(trackref->originalAlgo())) &&
+              nexhits == 0 && fromprimaryvertex) {
             closestECAL.setFlag(false);
           }
         }

--- a/RecoParticleFlow/PFTracking/plugins/ElectronSeedMerger.cc
+++ b/RecoParticleFlow/PFTracking/plugins/ElectronSeedMerger.cc
@@ -87,7 +87,7 @@ void ElectronSeedMerger::produce(edm::StreamID, Event& iEvent, const EventSetup&
       }
       if (hitShared == (hitSeed - 1)) {
         newSeed.setCtfTrack(tSeed.ctfTrack());
-      } else if (hitShared > 0 && !newSeed.isTrackerDriven()) {
+      } else if ((hitShared > 0 || tSeed.nHits() == 0) && !newSeed.isTrackerDriven()) {
         //try to find hits in the full track
         unsigned int hitSharedOnTrack = 0;
         for (auto const& eh : newSeed.recHits()) {

--- a/RecoParticleFlow/PFTracking/plugins/ElectronSeedMerger.cc
+++ b/RecoParticleFlow/PFTracking/plugins/ElectronSeedMerger.cc
@@ -40,77 +40,62 @@ ElectronSeedMerger::ElectronSeedMerger(const ParameterSet& iConfig)
 
 // ------------ method called to produce the data  ------------
 void ElectronSeedMerger::produce(edm::StreamID, Event& iEvent, const EventSetup& iSetup) const {
+  //HANDLE THE INPUT SEED COLLECTIONS
+  auto const &eSeeds = iEvent.get(ecalSeedToken_);
+
+  ElectronSeedCollection tSeedsEmpty;
+  auto const &tSeeds = tkSeedToken_.isUninitialized() ? tSeedsEmpty : iEvent.get(tkSeedToken_);
+
   //CREATE OUTPUT COLLECTION
   auto output = std::make_unique<ElectronSeedCollection>();
-
-  //HANDLE THE INPUT SEED COLLECTIONS
-  Handle<ElectronSeedCollection> EcalBasedSeeds;
-  iEvent.getByToken(ecalSeedToken_, EcalBasedSeeds);
-  ElectronSeedCollection ESeed = *(EcalBasedSeeds.product());
-
-  Handle<ElectronSeedCollection> TkBasedSeeds;
-  ElectronSeedCollection TSeed;
-  if (!tkSeedToken_.isUninitialized()) {
-    iEvent.getByToken(tkSeedToken_, TkBasedSeeds);
-    TSeed = *(TkBasedSeeds.product());
-  }
+  output->reserve(eSeeds.size()+tSeeds.size());
 
   //VECTOR FOR MATCHED SEEDS
-  vector<bool> TSeedMatched;
-  for (unsigned int it = 0; it < TSeed.size(); it++) {
-    TSeedMatched.push_back(false);
-  }
+  vector<bool> tSeedsMatched(tSeeds.size(), false);
 
   //LOOP OVER THE ECAL SEED COLLECTION
-  ElectronSeedCollection::const_iterator e_beg = ESeed.begin();
-  ElectronSeedCollection::const_iterator e_end = ESeed.end();
-  for (; e_beg != e_end; ++e_beg) {
-    ElectronSeed NewSeed = *(e_beg);
-    bool AlreadyMatched = false;
+  for (auto newSeed : eSeeds) {//  make a copy
 
     //LOOP OVER THE TK SEED COLLECTION
-    for (unsigned int it = 0; it < TSeed.size(); it++) {
-      if (AlreadyMatched)
-        continue;
+    int it = -1;
+    for (auto const &tSeed : tSeeds) {
+      it++;
 
       //HITS FOR TK SEED
       unsigned int hitShared = 0;
       unsigned int hitSeed = 0;
-      for (auto const& eh : e_beg->recHits()) {
+      for (auto const& eh : newSeed.recHits()) {
         if (!eh.isValid())
           continue;
         hitSeed++;
-        bool Shared = false;
-        for (auto const& th : TSeed[it].recHits()) {
+
+        for (auto const& th : tSeed.recHits()) {
           if (!th.isValid())
             continue;
-          //CHECK THE HIT COMPATIBILITY: put back sharesInput
-          // as soon Egamma solves the bug on the seed collection
-          if (eh.sharesInput(&th, TrackingRecHit::all))
-            Shared = true;
-          //   if(eh->geographicalId() == th->geographicalId() &&
-          // 	     (eh->localPosition() - th->localPosition()).mag() < 0.001) Shared=true;
+          //CHECK THE HIT COMPATIBILITY
+          if (eh.sharesInput(&th, TrackingRecHit::all)) {
+            hitShared++;
+            break;
+          }
         }
-        if (Shared)
-          hitShared++;
       }
       if (hitShared == hitSeed) {
-        AlreadyMatched = true;
-        TSeedMatched[it] = true;
-        NewSeed.setCtfTrack(TSeed[it].ctfTrack());
+        tSeedsMatched[it] = true;
+        newSeed.setCtfTrack(tSeed.ctfTrack());
+        break;
       }
       if (hitShared == (hitSeed - 1)) {
-        NewSeed.setCtfTrack(TSeed[it].ctfTrack());
+        newSeed.setCtfTrack(tSeed.ctfTrack());
       }
     }
 
-    output->push_back(NewSeed);
+    output->push_back(newSeed);
   }
 
   //FILL THE COLLECTION WITH UNMATCHED TK-BASED SEED
-  for (unsigned int it = 0; it < TSeed.size(); it++) {
-    if (!TSeedMatched[it])
-      output->push_back(TSeed[it]);
+  for (unsigned int it = 0; it < tSeeds.size(); it++) {
+    if (!tSeedsMatched[it])
+      output->push_back(tSeeds[it]);
   }
 
   //PUT THE MERGED COLLECTION IN THE EVENT

--- a/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.cc
@@ -356,9 +356,6 @@ void GoodSeedProducer::produce(Event& iEvent, const EventSetup& iSetup) {
       auto tketa = tkmom.eta();
       auto tkpt = std::sqrt(tkmom.perp2());
       auto const& Seed = (*trackRef->seedRef());
-      if (Seed.nHits() == 0) {  //if DeepCore is used in jetCore iteration the seed are hitless, in case skip
-        continue;
-      }
 
       if (!disablePreId_) {
         int ipteta = getBin(Tk[i].eta(), Tk[i].pt());


### PR DESCRIPTION
Changes in this PR were motivated to mitigate the situation with tracks reconstructed multiple times, one of them jet core after introduction of mkFit to the non-jetCore iterations. 

This was presented in TRK POG on Nov 1: https://indico.cern.ch/event/1092090/#3-interplay-in-high-pt-electro

see more details in #35892

