### PR TITLE
small technical updates to HLTJetTiming{Filter,Producer}

### DIFF
--- a/HLTrigger/JetMET/plugins/BuildFile.xml
+++ b/HLTrigger/JetMET/plugins/BuildFile.xml
@@ -1,6 +1,7 @@
 <library file="*.cc" name="HLTriggerJetMETPlugins">
   <use name="CommonTools/Utils"/>
   <use name="DataFormats/Common"/>
+  <use name="DataFormats/EcalRecHit"/>
   <use name="DataFormats/HLTReco"/>
   <use name="DataFormats/JetReco"/>
   <use name="DataFormats/Math"/>
@@ -13,9 +14,11 @@
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/PluginManager"/>
   <use name="FWCore/Utilities"/>
-  <use name="HLTrigger/HLTcore"/>
+  <use name="Geometry/CaloGeometry"/>
+  <use name="Geometry/Records"/>
   <use name="TrackingTools/IPTools"/>
   <use name="TrackingTools/TransientTrack"/>
+  <use name="HLTrigger/HLTcore"/>
   <use name="HLTrigger/JetMET"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/HLTrigger/JetMET/plugins/HLTJetTimingFilter.cc
+++ b/HLTrigger/JetMET/plugins/HLTJetTimingFilter.cc
@@ -1,4 +1,7 @@
 #include "HLTJetTimingFilter.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "DataFormats/JetReco/interface/CaloJet.h"
+#include "DataFormats/JetReco/interface/PFJet.h"
 
 typedef HLTJetTimingFilter<reco::CaloJet> HLTCaloJetTimingFilter;
 typedef HLTJetTimingFilter<reco::PFJet> HLTPFJetTimingFilter;

--- a/HLTrigger/JetMET/plugins/HLTJetTimingFilter.h
+++ b/HLTrigger/JetMET/plugins/HLTJetTimingFilter.h
@@ -1,35 +1,22 @@
 /** \class HLTJetTimingFilter
  *
  *  \brief  This makes selections on the timing and associated ecal cells 
- *  produced by HLTJetTimingProducer
+ *          produced by HLTJetTimingProducer
  *  \author Matthew Citron
  *
  */
 #ifndef HLTrigger_JetMET_plugins_HLTJetTimingFilter_h
 #define HLTrigger_JetMET_plugins_HLTJetTimingFilter_h
 
-// system include files
 #include <memory>
 
-// user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "HLTrigger/HLTcore/interface/HLTFilter.h"
-
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "HLTrigger/HLTcore/interface/HLTFilter.h"
 #include "HLTrigger/HLTcore/interface/defaultModuleLabel.h"
 
-namespace edm {
-  class ConfigurationDescriptions;
-}
-
-//
-// class declaration
-//
 template <typename T>
 class HLTJetTimingFilter : public HLTFilter {
 public:
@@ -55,7 +42,6 @@ private:
   const double minPt_;
 };
 
-//Constructor
 template <typename T>
 HLTJetTimingFilter<T>::HLTJetTimingFilter(const edm::ParameterSet& iConfig)
     : HLTFilter(iConfig),
@@ -72,7 +58,6 @@ HLTJetTimingFilter<T>::HLTJetTimingFilter(const edm::ParameterSet& iConfig)
       jetCellsForTimingThresh_{iConfig.getParameter<unsigned int>("jetCellsForTimingThresh")},
       minPt_{iConfig.getParameter<double>("minJetPt")} {}
 
-//Filter
 template <typename T>
 bool HLTJetTimingFilter<T>::hltFilter(edm::Event& iEvent,
                                       const edm::EventSetup& iSetup,
@@ -100,7 +85,6 @@ bool HLTJetTimingFilter<T>::hltFilter(edm::Event& iEvent,
   return njets >= minJets_;
 }
 
-// Fill descriptions
 template <typename T>
 void HLTJetTimingFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;

--- a/HLTrigger/JetMET/plugins/HLTJetTimingProducer.cc
+++ b/HLTrigger/JetMET/plugins/HLTJetTimingProducer.cc
@@ -1,4 +1,7 @@
 #include "HLTJetTimingProducer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "DataFormats/JetReco/interface/CaloJet.h"
+#include "DataFormats/JetReco/interface/PFJet.h"
 
 typedef HLTJetTimingProducer<reco::CaloJet> HLTCaloJetTimingProducer;
 typedef HLTJetTimingProducer<reco::PFJet> HLTPFJetTimingProducer;

--- a/HLTrigger/JetMET/plugins/HLTJetTimingProducer.h
+++ b/HLTrigger/JetMET/plugins/HLTJetTimingProducer.h
@@ -7,31 +7,23 @@
 #ifndef HLTrigger_JetMET_plugins_HLTJetTimingProducer_h
 #define HLTrigger_JetMET_plugins_HLTJetTimingProducer_h
 
-// system include files
 #include <memory>
+#include <cmath>
 
-// user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
-
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "DataFormats/Common/interface/ValueMap.h"
-
-#include "DataFormats/JetReco/interface/CaloJetCollection.h"
-#include "DataFormats/JetReco/interface/PFJetCollection.h"
-
+#include "DataFormats/Common/interface/SortedCollection.h"
+#include "DataFormats/EcalRecHit/interface/EcalRecHit.h"
+#include "DataFormats/Math/interface/deltaR.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
-#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "HLTrigger/HLTcore/interface/defaultModuleLabel.h"
-#include "DataFormats/Math/interface/deltaR.h"
 
-//
-// class declaration
-//
 template <typename T>
 class HLTJetTimingProducer : public edm::stream::EDProducer<> {
 public:
@@ -64,7 +56,6 @@ private:
   const double matchingRadius2_;
 };
 
-//Constructor
 template <typename T>
 HLTJetTimingProducer<T>::HLTJetTimingProducer(const edm::ParameterSet& iConfig)
     : caloGeometryToken_(esConsumes()),
@@ -84,7 +75,6 @@ HLTJetTimingProducer<T>::HLTJetTimingProducer(const edm::ParameterSet& iConfig)
   produces<edm::ValueMap<float>>("jetEcalEtForTiming");
 }
 
-//calculate jet time
 template <typename T>
 void HLTJetTimingProducer<T>::jetTimeFromEcalCells(
     const T& jet,
@@ -102,7 +92,7 @@ void HLTJetTimingProducer<T>::jetTimeFromEcalCells(
       continue;
     if (ecalRH.timeError() <= 0. || ecalRH.timeError() > ecalCellTimeErrorThresh_)
       continue;
-    if (fabs(ecalRH.time()) > ecalCellTimeThresh_)
+    if (std::abs(ecalRH.time()) > ecalCellTimeThresh_)
       continue;
     auto const pos = caloGeometry.getPosition(ecalRH.detid());
     if (reco::deltaR2(jet, pos) > matchingRadius2_)
@@ -116,7 +106,6 @@ void HLTJetTimingProducer<T>::jetTimeFromEcalCells(
   }
 }
 
-//Producer
 template <typename T>
 void HLTJetTimingProducer<T>::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   auto const& caloGeometry = iSetup.getData(caloGeometryToken_);
@@ -168,7 +157,6 @@ void HLTJetTimingProducer<T>::produce(edm::Event& iEvent, const edm::EventSetup&
   iEvent.put(std::move(jetCellsForTiming_out), "jetCellsForTiming");
 }
 
-// Fill descriptions
 template <typename T>
 void HLTJetTimingProducer<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;


### PR DESCRIPTION
#### PR description:

This PR is a simple technical followup to #35724, mainly to address https://github.com/cms-sw/cmssw/pull/35724#pullrequestreview-796416381.

Includes small adjustments for `#include` statements, `BuildFile.xml` content, and use of `std::abs` (instead of `fabs`).

FYI: @mcitron

#### PR validation:

`scram` builds.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

N/A