### PR TITLE
Get rid of static warnings in CSC trigger emulator

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -1074,20 +1074,16 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::readoutCLCTs() const {
   const int max_late_tbin = CSCConstants::MAX_CLCT_TBINS - 1;
 
   // debugging messages when early_tbin or late_tbin has a suspicious value
-  bool debugTimeBins = true;
-  if (debugTimeBins) {
-    if (early_tbin < 0) {
-      edm::LogWarning("CSCCathodeLCTProcessor|SuspiciousParameters")
-          << "Early time bin (early_tbin) smaller than minimum allowed, which is 0. set early_tbin to 0.";
-      early_tbin = 0;
-    }
-    if (late_tbin > max_late_tbin) {
-      edm::LogWarning("CSCCathodeLCTProcessor|SuspiciousParameters")
-          << "Late time bin (late_tbin) larger than maximum allowed, which is " << max_late_tbin
-          << ". set early_tbin to max allowed";
-      late_tbin = CSCConstants::MAX_CLCT_TBINS - 1;
-    }
-    debugTimeBins = false;
+  if (early_tbin < 0) {
+    edm::LogWarning("CSCCathodeLCTProcessor|SuspiciousParameters")
+        << "Early time bin (early_tbin) smaller than minimum allowed, which is 0. set early_tbin to 0.";
+    early_tbin = 0;
+  }
+  if (late_tbin > max_late_tbin) {
+    edm::LogWarning("CSCCathodeLCTProcessor|SuspiciousParameters")
+        << "Late time bin (late_tbin) larger than maximum allowed, which is " << max_late_tbin
+        << ". set early_tbin to max allowed";
+    late_tbin = CSCConstants::MAX_CLCT_TBINS - 1;
   }
 
   // get the valid LCTs. No BX selection is done here

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -280,20 +280,16 @@ std::vector<CSCCorrelatedLCTDigi> CSCMotherboard::readoutLCTs() const {
   const int max_late_tbin = CSCConstants::MAX_LCT_TBINS - 1;
 
   // debugging messages when early_tbin or late_tbin has a suspicious value
-  bool debugTimeBins = true;
-  if (debugTimeBins) {
-    if (early_tbin < 0) {
-      edm::LogWarning("CSCMotherboard|SuspiciousParameters")
-          << "Early time bin (early_tbin) smaller than minimum allowed, which is 0. set early_tbin to 0.";
-      early_tbin = 0;
-    }
-    if (late_tbin > max_late_tbin) {
-      edm::LogWarning("CSCMotherboard|SuspiciousParameters")
-          << "Late time bin (late_tbin) larger than maximum allowed, which is " << max_late_tbin
-          << ". set early_tbin to max allowed";
-      late_tbin = CSCConstants::MAX_LCT_TBINS - 1;
-    }
-    debugTimeBins = false;
+  if (early_tbin < 0) {
+    edm::LogWarning("CSCMotherboard|SuspiciousParameters")
+        << "Early time bin (early_tbin) smaller than minimum allowed, which is 0. set early_tbin to 0.";
+    early_tbin = 0;
+  }
+  if (late_tbin > max_late_tbin) {
+    edm::LogWarning("CSCMotherboard|SuspiciousParameters")
+        << "Late time bin (late_tbin) larger than maximum allowed, which is " << max_late_tbin
+        << ". set early_tbin to max allowed";
+    late_tbin = CSCConstants::MAX_LCT_TBINS - 1;
   }
 
   // Start from the vector of all found correlated LCTs and select


### PR DESCRIPTION
#### PR description:

In response to https://github.com/cms-sw/cmssw/pull/35886#issuecomment-959244496. It's just two `if` statements around logwarnings around that were removed, so there should not be any changes in workflows.

#### PR validation:

Code compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

@perrotta @tahuang1991 