### PR TITLE
[HGCAL] makeHGCalValidationPlots.py crash due to python3

### DIFF
--- a/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
+++ b/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
@@ -85,7 +85,7 @@ def main(opts):
                          "kaon0L": "310", "kaon0S": "130",
                          "kaon-": "-321", "kaon+": "321"}
         hgcaloPart = [hgcalPlots.hgcalCaloParticlesPlotter]
-        for i_part, i_partID in particletypes.iteritems() :
+        for i_part, i_partID in particletypes.items() :
             hgcalPlots.append_hgcalCaloParticlesPlots(sample.files(), i_partID, i_part)
         val.doPlots(hgcaloPart, plotterDrawArgs=drawArgs)
 


### PR DESCRIPTION
#### PR description:

There is a crash in the 'makeHGCalValidationPlots.py' when using the `--collection all` option related to python3. I don't know how this one got away, but now it's OK, when using `--collection all` there is no crash. 

Thanks @ebrondol for the alert on the problem.

#### PR validation:

Local validation. 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not a backport. 

@rovere @felicepantaleo @lecriste @ebrondol 