### PR TITLE
Update mkFit for CMSSW_12_2_0

### DIFF
--- a/RecoTracker/MkFit/plugins/MkFitIterationConfigESProducer.cc
+++ b/RecoTracker/MkFit/plugins/MkFitIterationConfigESProducer.cc
@@ -14,10 +14,10 @@
 namespace {
   using namespace mkfit;
 
-  void partitionSeeds0(const TrackerInfo &trk_info,
-                       const TrackVec &in_seeds,
-                       const EventOfHits &eoh,
-                       IterationSeedPartition &part) {
+  [[maybe_unused]] void partitionSeeds0(const TrackerInfo &trk_info,
+                                        const TrackVec &in_seeds,
+                                        const EventOfHits &eoh,
+                                        IterationSeedPartition &part) {
     const size_t size = in_seeds.size();
 
     for (size_t i = 0; i < size; ++i) {
@@ -82,6 +82,109 @@ namespace {
       part.m_sort_score[i] = maxEta_regSort * (reg - TrackerInfo::Reg_Barrel) + eta;
     }
   }
+
+  [[maybe_unused]] void partitionSeeds1(const TrackerInfo &trk_info,
+                                        const TrackVec &in_seeds,
+                                        const EventOfHits &eoh,
+                                        IterationSeedPartition &part) {
+    const LayerInfo &tib1 = trk_info.m_layers[4];
+    const LayerInfo &tob1 = trk_info.m_layers[10];
+
+    const LayerInfo &tidp1 = trk_info.m_layers[21];
+    const LayerInfo &tidn1 = trk_info.m_layers[48];
+
+    const LayerInfo &tecp1 = trk_info.m_layers[27];
+    const LayerInfo &tecn1 = trk_info.m_layers[54];
+
+    // Merge first two layers to account for mono/stereo coverage.
+    // TrackerInfo could hold joint limits for sub-detectors.
+    const auto &L = trk_info.m_layers;
+    const float tidp_rin = std::min(L[21].m_rin, L[22].m_rin);
+    const float tidp_rout = std::max(L[21].m_rout, L[22].m_rout);
+    const float tecp_rin = std::min(L[27].m_rin, L[28].m_rin);
+    const float tecp_rout = std::max(L[27].m_rout, L[28].m_rout);
+    const float tidn_rin = std::min(L[48].m_rin, L[49].m_rin);
+    const float tidn_rout = std::max(L[48].m_rout, L[49].m_rout);
+    const float tecn_rin = std::min(L[54].m_rin, L[55].m_rin);
+    const float tecn_rout = std::max(L[54].m_rout, L[55].m_rout);
+
+    // Bias towards more aggressive transition-region assignemnts.
+    // With current tunning it seems to make things a bit worse.
+    const float tid_z_extra = 0.0f;  // 5.0f;
+    const float tec_z_extra = 0.0f;  // 10.0f;
+
+    const int size = in_seeds.size();
+
+    auto barrel_pos_check = [](const Track &S, float maxR, float rin, float zmax) -> bool {
+      bool inside = maxR > rin && S.zAtR(rin) < zmax;
+      return inside;
+    };
+
+    auto barrel_neg_check = [](const Track &S, float maxR, float rin, float zmin) -> bool {
+      bool inside = maxR > rin && S.zAtR(rin) > zmin;
+      return inside;
+    };
+
+    auto endcap_pos_check = [](const Track &S, float maxR, float rout, float rin, float zmin) -> bool {
+      bool inside = maxR > rout ? S.zAtR(rout) > zmin : (maxR > rin && S.zAtR(maxR) > zmin);
+      return inside;
+    };
+
+    auto endcap_neg_check = [](const Track &S, float maxR, float rout, float rin, float zmax) -> bool {
+      bool inside = maxR > rout ? S.zAtR(rout) < zmax : (maxR > rin && S.zAtR(maxR) < zmax);
+      return inside;
+    };
+
+    for (int i = 0; i < size; ++i) {
+      const Track &S = in_seeds[i];
+
+      HitOnTrack hot = S.getLastHitOnTrack();
+      float eta = eoh[hot.layer].GetHit(hot.index).eta();
+
+      // Region to be defined by propagation / intersection tests
+      TrackerInfo::EtaRegion reg;
+
+      const bool z_dir_pos = S.pz() > 0;
+      const float maxR = S.maxReachRadius();
+
+      if (z_dir_pos) {
+        bool in_tib = barrel_pos_check(S, maxR, tib1.m_rin, tib1.m_zmax);
+        bool in_tob = barrel_pos_check(S, maxR, tob1.m_rin, tob1.m_zmax);
+
+        if (!in_tib && !in_tob) {
+          reg = TrackerInfo::Reg_Endcap_Pos;
+        } else {
+          bool in_tid = endcap_pos_check(S, maxR, tidp_rout, tidp_rin, tidp1.m_zmin - tid_z_extra);
+          bool in_tec = endcap_pos_check(S, maxR, tecp_rout, tecp_rin, tecp1.m_zmin - tec_z_extra);
+
+          if (!in_tid && !in_tec) {
+            reg = TrackerInfo::Reg_Barrel;
+          } else {
+            reg = TrackerInfo::Reg_Transition_Pos;
+          }
+        }
+      } else {
+        bool in_tib = barrel_neg_check(S, maxR, tib1.m_rin, tib1.m_zmin);
+        bool in_tob = barrel_neg_check(S, maxR, tob1.m_rin, tob1.m_zmin);
+
+        if (!in_tib && !in_tob) {
+          reg = TrackerInfo::Reg_Endcap_Neg;
+        } else {
+          bool in_tid = endcap_neg_check(S, maxR, tidn_rout, tidn_rin, tidn1.m_zmax + tid_z_extra);
+          bool in_tec = endcap_neg_check(S, maxR, tecn_rout, tecn_rin, tecn1.m_zmax + tec_z_extra);
+
+          if (!in_tid && !in_tec) {
+            reg = TrackerInfo::Reg_Barrel;
+          } else {
+            reg = TrackerInfo::Reg_Transition_Neg;
+          }
+        }
+      }
+
+      part.m_region[i] = reg;
+      part.m_sort_score[i] = 7.0f * (reg - 2) + eta;
+    }
+  }
 }  // namespace
 
 class MkFitIterationConfigESProducer : public edm::ESProducer {
@@ -111,7 +214,7 @@ void MkFitIterationConfigESProducer::fillDescriptions(edm::ConfigurationDescript
 std::unique_ptr<mkfit::IterationConfig> MkFitIterationConfigESProducer::produce(
     const TrackerRecoGeometryRecord &iRecord) {
   auto it_conf = mkfit::ConfigJson_Load_File(configFile_);
-  it_conf->m_partition_seeds = partitionSeeds0;
+  it_conf->m_partition_seeds = partitionSeeds1;
   return it_conf;
 }
 


### PR DESCRIPTION
### PR description:

This PR follows #35652 and updates mkFit in view of CMSSW_12_2_0.

In detail, this PR:
- updates the mkFit track seed partition function for the definition of parallel tasks;
- updates the mkFit track seed converter to account for matched hits in track seeds;
- (via cms-sw/cmsdist#7427 and cms-data/RecoTracker-MkFit#7) updates mkFit release and configurations in order to improve the overall physics performance at track-building level for tracking iterations where mkFit is enabled (as in PR #35660).

It requires cms-sw/cmsdist#7427 and cms-data/RecoTracker-MkFit#7.
Note: these PRs were updated in response to BTV results in https://its.cern.ch/jira/browse/PDMVRELVALS-136, in order to improve the track impact parameter resolution in tracks reconstructed in pixel-triplet-seeded iterations. Effects of the update on track reconstructions efficiency and fakes are small.


### PR validation:

Details of performance after this PR have been presented at TRK POG meeting on November 1st: 
https://indico.cern.ch/event/1092090/#2-mkfit-status-report

Full MTV results, including the update of cms-sw/cmsdist#7427 and cms-data/RecoTracker-MkFit#7 on November 9th:
- TTbar with PU: https://mmasciovecchio.web.cern.ch/MkFit_hitSelectionWindows_Nov21/MTV_TTbar_PU_PR35974_updateNov9_12X/
- High-pT QCD without PU: https://mmasciovecchio.web.cern.ch/MkFit_hitSelectionWindows_Nov21/MTV_highPtQCD_noPU_PR35974_updateNov9_12X/

