### PR TITLE
Removing obsolete code from CaloLayer1Setup - 12_1_X

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Setup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Setup.cc
@@ -70,18 +70,7 @@ namespace l1t {
                       << amc << " fw 0x" << std::hex << fw << std::dec;
       if (fed == 1354 || fed == 1356 || fed == 1358) {
         if (board < 18) {
-          if (fw == 0x12345678) {
-            res[0] = UnpackerFactory::get()->make("stage2::CaloLayer1Unpacker");
-          }
-          // e.g.
-          // else if (fw == 0xdeadbeef) {
-          //    res[0] = UnpackerFactory::get()->make("stage2::CaloLayer1Unpacker_v2");
-          // }
-          else {
-            edm::LogWarning("L1T")
-                << "CaloLayer1Setup: unexpected CTP7 firmware ID, will try unpacking with default unpacker anyway";
-            res[0] = UnpackerFactory::get()->make("stage2::CaloLayer1Unpacker");
-          }
+          res[0] = UnpackerFactory::get()->make("stage2::CaloLayer1Unpacker");
         }
       }
 


### PR DESCRIPTION
Backport of #35940

Originally coded by @BenjaminRS

"This PR removes obsolete code from the CaloLayer1 area which has been causing spurious elog warnings as described in Issue#34309. As suggested in this comment to PR#35873 I have removed the if else statement which was now obsolete"

#### PR validation:

Identical fix as already merged in master
It builds
