### PR TITLE
Miscellaneous `Alignment/OfflineValidation` improvements

### DIFF
--- a/Alignment/OfflineValidation/macros/CMS_lumi.h
+++ b/Alignment/OfflineValidation/macros/CMS_lumi.h
@@ -35,7 +35,7 @@ float extraOverCmsTextSize = 0.76;
 TString lumi_13TeV = "20.1 fb^{-1}";
 TString lumi_8TeV = "19.7 fb^{-1}";
 TString lumi_7TeV = "5.1 fb^{-1}";
-TString lumi_0p45TeV = "";
+TString lumi_0p9TeV = "";
 TString lumi_sqrtS = "";
 bool drawLogo = false;
 
@@ -90,8 +90,8 @@ void CMS_lumi(TPad* pad, int iPeriod, int iPosX) {
     lumiText += lumi_13TeV;
     lumiText += " (#sqrt{s} = 13 TeV)";
   } else if (iPeriod == 5) {
-    lumiText += lumi_0p45TeV;
-    lumiText += " (#sqrt{s} = 0.45 TeV)";
+    lumiText += lumi_0p9TeV;
+    lumiText += " (#sqrt{s} = 0.9 TeV)";
   } else if (iPeriod == 7) {
     if (outOfFrame)
       lumiText += "#scale[0.85]{";

--- a/Alignment/OfflineValidation/macros/CMS_lumi.h
+++ b/Alignment/OfflineValidation/macros/CMS_lumi.h
@@ -35,6 +35,7 @@ float extraOverCmsTextSize = 0.76;
 TString lumi_13TeV = "20.1 fb^{-1}";
 TString lumi_8TeV = "19.7 fb^{-1}";
 TString lumi_7TeV = "5.1 fb^{-1}";
+TString lumi_0p45TeV = "";
 TString lumi_sqrtS = "";
 bool drawLogo = false;
 
@@ -88,6 +89,9 @@ void CMS_lumi(TPad* pad, int iPeriod, int iPosX) {
   } else if (iPeriod == 4) {
     lumiText += lumi_13TeV;
     lumiText += " (#sqrt{s} = 13 TeV)";
+  }  else if (iPeriod == 5) {
+    lumiText += lumi_0p45TeV;
+    lumiText += " (#sqrt{s} = 0.45 TeV)";
   } else if (iPeriod == 7) {
     if (outOfFrame)
       lumiText += "#scale[0.85]{";

--- a/Alignment/OfflineValidation/macros/CMS_lumi.h
+++ b/Alignment/OfflineValidation/macros/CMS_lumi.h
@@ -89,7 +89,7 @@ void CMS_lumi(TPad* pad, int iPeriod, int iPosX) {
   } else if (iPeriod == 4) {
     lumiText += lumi_13TeV;
     lumiText += " (#sqrt{s} = 13 TeV)";
-  }  else if (iPeriod == 5) {
+  } else if (iPeriod == 5) {
     lumiText += lumi_0p45TeV;
     lumiText += " (#sqrt{s} = 0.45 TeV)";
   } else if (iPeriod == 7) {

--- a/Alignment/OfflineValidation/macros/FitPVResiduals.C
+++ b/Alignment/OfflineValidation/macros/FitPVResiduals.C
@@ -4200,17 +4200,17 @@ params::measurement getTheRangeUser(TH1F *thePlot, Limits *lims, bool tag)
   if (theTitle.Contains("norm")) {
     if (theTitle.Contains("means")) {
       if (theTitle.Contains("dxy") || theTitle.Contains("dx") || theTitle.Contains("dy")) {
-        if (theTitle.Contains("phi") || theTitle.Contains("pT")) {
+        if (theTitle.Contains("phi") || theTitle.Contains("pT") || theTitle.Contains("ladder")) {
           result = std::make_pair(-lims->get_dxyPhiNormMax().first, lims->get_dxyPhiNormMax().first);
-        } else if (theTitle.Contains("eta")) {
+        } else if (theTitle.Contains("eta") || theTitle.Contains("mod")) {
           result = std::make_pair(-lims->get_dxyEtaNormMax().first, lims->get_dxyEtaNormMax().first);
         } else {
           result = std::make_pair(-0.8, 0.8);
         }
       } else if (theTitle.Contains("dz")) {
-        if (theTitle.Contains("phi") || theTitle.Contains("pT")) {
+        if (theTitle.Contains("phi") || theTitle.Contains("pT") || theTitle.Contains("ladder")) {
           result = std::make_pair(-lims->get_dzPhiNormMax().first, lims->get_dzPhiNormMax().first);
-        } else if (theTitle.Contains("eta")) {
+        } else if (theTitle.Contains("eta") || theTitle.Contains("mod")) {
           result = std::make_pair(-lims->get_dzEtaNormMax().first, lims->get_dzEtaNormMax().first);
         } else {
           result = std::make_pair(-0.8, 0.8);
@@ -4218,17 +4218,17 @@ params::measurement getTheRangeUser(TH1F *thePlot, Limits *lims, bool tag)
       }
     } else if (theTitle.Contains("widths")) {
       if (theTitle.Contains("dxy") || theTitle.Contains("dx") || theTitle.Contains("dy")) {
-        if (theTitle.Contains("phi")) {
+        if (theTitle.Contains("phi") || theTitle.Contains("ladder")) {
           result = std::make_pair(0., lims->get_dxyPhiNormMax().second);
-        } else if (theTitle.Contains("eta")) {
+        } else if (theTitle.Contains("eta") || theTitle.Contains("mod")) {
           result = std::make_pair(0., lims->get_dxyEtaNormMax().second);
         } else {
           result = std::make_pair(0., 2.);
         }
       } else if (theTitle.Contains("dz")) {
-        if (theTitle.Contains("phi")) {
+        if (theTitle.Contains("phi") || theTitle.Contains("ladder")) {
           result = std::make_pair(0., lims->get_dzPhiNormMax().second);
-        } else if (theTitle.Contains("eta")) {
+        } else if (theTitle.Contains("eta") || theTitle.Contains("mod")) {
           result = std::make_pair(0., lims->get_dzEtaNormMax().second);
         } else {
           result = std::make_pair(0., 2.);
@@ -4238,17 +4238,17 @@ params::measurement getTheRangeUser(TH1F *thePlot, Limits *lims, bool tag)
   } else {
     if (theTitle.Contains("means")) {
       if (theTitle.Contains("dxy") || theTitle.Contains("dx") || theTitle.Contains("dy")) {
-        if (theTitle.Contains("phi") || theTitle.Contains("pT")) {
+        if (theTitle.Contains("phi") || theTitle.Contains("pT") || theTitle.Contains("ladder")) {
           result = std::make_pair(-lims->get_dxyPhiMax().first, lims->get_dxyPhiMax().first);
-        } else if (theTitle.Contains("eta")) {
+        } else if (theTitle.Contains("eta") || theTitle.Contains("mod")) {
           result = std::make_pair(-lims->get_dxyEtaMax().first, lims->get_dxyEtaMax().first);
         } else {
           result = std::make_pair(-40., 40.);
         }
       } else if (theTitle.Contains("dz")) {
-        if (theTitle.Contains("phi") || theTitle.Contains("pT")) {
+        if (theTitle.Contains("phi") || theTitle.Contains("pT") || theTitle.Contains("ladder")) {
           result = std::make_pair(-lims->get_dzPhiMax().first, lims->get_dzPhiMax().first);
-        } else if (theTitle.Contains("eta")) {
+        } else if (theTitle.Contains("eta") || theTitle.Contains("mod")) {
           result = std::make_pair(-lims->get_dzEtaMax().first, lims->get_dzEtaMax().first);
         } else {
           result = std::make_pair(-80., 80.);
@@ -4256,17 +4256,17 @@ params::measurement getTheRangeUser(TH1F *thePlot, Limits *lims, bool tag)
       }
     } else if (theTitle.Contains("widths")) {
       if (theTitle.Contains("dxy") || theTitle.Contains("dx") || theTitle.Contains("dy")) {
-        if (theTitle.Contains("phi")) {
+        if (theTitle.Contains("phi") || theTitle.Contains("ladder")) {
           result = std::make_pair(0., lims->get_dxyPhiMax().second);
-        } else if (theTitle.Contains("eta")) {
+        } else if (theTitle.Contains("eta") || theTitle.Contains("mod")) {
           result = std::make_pair(0., lims->get_dxyEtaMax().second);
         } else {
           result = std::make_pair(0., 150.);
         }
       } else if (theTitle.Contains("dz")) {
-        if (theTitle.Contains("phi")) {
+        if (theTitle.Contains("phi") || theTitle.Contains("ladder") ) {
           result = std::make_pair(0., lims->get_dzPhiMax().second);
-        } else if (theTitle.Contains("eta")) {
+        } else if (theTitle.Contains("eta") || theTitle.Contains("mod")) {
           result = std::make_pair(0., lims->get_dzEtaMax().second);
         } else {
           result = std::make_pair(0., 300.);

--- a/Alignment/OfflineValidation/macros/FitPVResiduals.C
+++ b/Alignment/OfflineValidation/macros/FitPVResiduals.C
@@ -4264,7 +4264,7 @@ params::measurement getTheRangeUser(TH1F *thePlot, Limits *lims, bool tag)
           result = std::make_pair(0., 150.);
         }
       } else if (theTitle.Contains("dz")) {
-        if (theTitle.Contains("phi") || theTitle.Contains("ladder") ) {
+        if (theTitle.Contains("phi") || theTitle.Contains("ladder")) {
           result = std::make_pair(0., lims->get_dzPhiMax().second);
         } else if (theTitle.Contains("eta") || theTitle.Contains("mod")) {
           result = std::make_pair(0., lims->get_dzEtaMax().second);

--- a/Alignment/OfflineValidation/plugins/DMRChecker.cc
+++ b/Alignment/OfflineValidation/plugins/DMRChecker.cc
@@ -159,16 +159,16 @@ public:
     usesResource(TFileService::kSharedResource);
 
     TkTag_ = pset.getParameter<edm::InputTag>("TkTag");
-    theTrackCollectionToken = consumes<reco::TrackCollection>(TkTag_);
+    theTrackCollectionToken_ = consumes<reco::TrackCollection>(TkTag_);
 
     TriggerResultsTag_ = pset.getParameter<edm::InputTag>("TriggerResultsTag");
-    hltresultsToken = consumes<edm::TriggerResults>(TriggerResultsTag_);
+    hltresultsToken_ = consumes<edm::TriggerResults>(TriggerResultsTag_);
 
     BeamSpotTag_ = pset.getParameter<edm::InputTag>("BeamSpotTag");
-    beamspotToken = consumes<reco::BeamSpot>(BeamSpotTag_);
+    beamspotToken_ = consumes<reco::BeamSpot>(BeamSpotTag_);
 
     VerticesTag_ = pset.getParameter<edm::InputTag>("VerticesTag");
-    vertexToken = consumes<reco::VertexCollection>(VerticesTag_);
+    vertexToken_ = consumes<reco::VertexCollection>(VerticesTag_);
 
     // initialize conventional Tracker maps
 
@@ -463,10 +463,10 @@ private:
   edm::InputTag BeamSpotTag_;
   edm::InputTag VerticesTag_;
 
-  edm::EDGetTokenT<reco::TrackCollection> theTrackCollectionToken;
-  edm::EDGetTokenT<edm::TriggerResults> hltresultsToken;
-  edm::EDGetTokenT<reco::BeamSpot> beamspotToken;
-  edm::EDGetTokenT<reco::VertexCollection> vertexToken;
+  edm::EDGetTokenT<reco::TrackCollection> theTrackCollectionToken_;
+  edm::EDGetTokenT<edm::TriggerResults> hltresultsToken_;
+  edm::EDGetTokenT<reco::BeamSpot> beamspotToken_;
+  edm::EDGetTokenT<reco::VertexCollection> vertexToken_;
 
   std::map<std::string, std::pair<int, int> > triggerMap_;
   std::map<int, std::pair<int, float> > conditionsMap_;
@@ -492,8 +492,7 @@ private:
   void analyze(const edm::Event &event, const edm::EventSetup &setup) override {
     ievt++;
 
-    edm::Handle<reco::TrackCollection> trackCollection;
-    event.getByToken(theTrackCollectionToken, trackCollection);
+    edm::Handle<reco::TrackCollection> trackCollection = event.getHandle(theTrackCollectionToken_);
 
     // magnetic field setup
     const MagneticField *magneticField_ = &setup.getData(magFieldToken_);
@@ -555,8 +554,7 @@ private:
 
     //edm::LogVerbatim("DMRChecker") << "Reconstructed "<< tC.size() << " tracks" << std::endl ;
 
-    edm::Handle<edm::TriggerResults> hltresults;
-    event.getByToken(hltresultsToken, hltresults);
+    edm::Handle<edm::TriggerResults> hltresults = event.getHandle(hltresultsToken_);
     if (hltresults.isValid()) {
       const edm::TriggerNames &triggerNames_ = event.triggerNames(*hltresults);
       int ntrigs = hltresults->size();
@@ -1029,8 +1027,7 @@ private:
 
       //dxy with respect to the beamspot
       reco::BeamSpot beamSpot;
-      edm::Handle<reco::BeamSpot> beamSpotHandle;
-      event.getByToken(beamspotToken, beamSpotHandle);
+      edm::Handle<reco::BeamSpot> beamSpotHandle = event.getHandle(beamspotToken_);
       if (beamSpotHandle.isValid()) {
         beamSpot = *beamSpotHandle;
         math::XYZPoint point(beamSpot.x0(), beamSpot.y0(), beamSpot.z0());
@@ -1043,8 +1040,7 @@ private:
 
       //dxy with respect to the primary vertex
       reco::Vertex pvtx;
-      edm::Handle<reco::VertexCollection> vertexHandle;
-      event.getByToken(vertexToken, vertexHandle);
+      edm::Handle<reco::VertexCollection> vertexHandle = event.getHandle(vertexToken_);
       double mindxy = 100.;
       double dz = 100;
       if (vertexHandle.isValid()) {

--- a/Alignment/OfflineValidation/plugins/GeneralPurposeTrackAnalyzer.cc
+++ b/Alignment/OfflineValidation/plugins/GeneralPurposeTrackAnalyzer.cc
@@ -97,16 +97,16 @@ public:
     usesResource(TFileService::kSharedResource);
 
     TkTag_ = pset.getParameter<edm::InputTag>("TkTag");
-    theTrackCollectionToken = consumes<reco::TrackCollection>(TkTag_);
+    theTrackCollectionToken_ = consumes<reco::TrackCollection>(TkTag_);
 
     TriggerResultsTag_ = pset.getParameter<edm::InputTag>("TriggerResultsTag");
-    hltresultsToken = consumes<edm::TriggerResults>(TriggerResultsTag_);
+    hltresultsToken_ = consumes<edm::TriggerResults>(TriggerResultsTag_);
 
     BeamSpotTag_ = pset.getParameter<edm::InputTag>("BeamSpotTag");
-    beamspotToken = consumes<reco::BeamSpot>(BeamSpotTag_);
+    beamspotToken_ = consumes<reco::BeamSpot>(BeamSpotTag_);
 
     VerticesTag_ = pset.getParameter<edm::InputTag>("VerticesTag");
-    vertexToken = consumes<reco::VertexCollection>(VerticesTag_);
+    vertexToken_ = consumes<reco::VertexCollection>(VerticesTag_);
 
     isCosmics_ = pset.getParameter<bool>("isCosmics");
 
@@ -289,10 +289,10 @@ private:
 
   bool isCosmics_;
 
-  edm::EDGetTokenT<reco::TrackCollection> theTrackCollectionToken;
-  edm::EDGetTokenT<edm::TriggerResults> hltresultsToken;
-  edm::EDGetTokenT<reco::BeamSpot> beamspotToken;
-  edm::EDGetTokenT<reco::VertexCollection> vertexToken;
+  edm::EDGetTokenT<reco::TrackCollection> theTrackCollectionToken_;
+  edm::EDGetTokenT<edm::TriggerResults> hltresultsToken_;
+  edm::EDGetTokenT<reco::BeamSpot> beamspotToken_;
+  edm::EDGetTokenT<reco::VertexCollection> vertexToken_;
 
   std::map<std::string, std::pair<int, int> > triggerMap_;
   std::map<int, std::pair<int, float> > conditionsMap_;
@@ -304,12 +304,10 @@ private:
   {
     ievt++;
 
-    edm::Handle<reco::TrackCollection> trackCollection;
-    event.getByToken(theTrackCollectionToken, trackCollection);
+    edm::Handle<reco::TrackCollection> trackCollection = event.getHandle(theTrackCollectionToken_);
 
     // geometry setup
-    edm::ESHandle<TrackerGeometry> geometry = setup.getHandle(geomToken_);
-    const TrackerGeometry *theGeometry = &(*geometry);
+    const TrackerGeometry *theGeometry = &setup.getData(geomToken_);
 
     // switch on the phase1
     if ((theGeometry->isThere(GeomDetEnumerators::P1PXB)) || (theGeometry->isThere(GeomDetEnumerators::P1PXEC))) {
@@ -329,8 +327,7 @@ private:
     }
     //int iCounter=0;
 
-    edm::Handle<edm::TriggerResults> hltresults;
-    event.getByToken(hltresultsToken, hltresults);
+    edm::Handle<edm::TriggerResults> hltresults = event.getHandle(hltresultsToken_);
     if (hltresults.isValid()) {
       const edm::TriggerNames &triggerNames_ = event.triggerNames(*hltresults);
       int ntrigs = hltresults->size();
@@ -641,8 +638,7 @@ private:
 
       //dxy with respect to the beamspot
       reco::BeamSpot beamSpot;
-      edm::Handle<reco::BeamSpot> beamSpotHandle;
-      event.getByToken(beamspotToken, beamSpotHandle);
+      edm::Handle<reco::BeamSpot> beamSpotHandle = event.getHandle(beamspotToken_);
       if (beamSpotHandle.isValid()) {
         beamSpot = *beamSpotHandle;
         math::XYZPoint point(beamSpot.x0(), beamSpot.y0(), beamSpot.z0());
@@ -655,8 +651,7 @@ private:
 
       //dxy with respect to the primary vertex
       reco::Vertex pvtx;
-      edm::Handle<reco::VertexCollection> vertexHandle;
-      event.getByToken(vertexToken, vertexHandle);
+      edm::Handle<reco::VertexCollection> vertexHandle = event.getHandle(vertexToken_);
       double mindxy = 100.;
       double dz = 100;
       if (vertexHandle.isValid() && !isCosmics_) {

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -201,11 +201,7 @@ PrimaryVertexValidation::PrimaryVertexValidation(const edm::ParameterSet& iConfi
 }
 
 // Destructor
-PrimaryVertexValidation::~PrimaryVertexValidation() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
-}
-
+PrimaryVertexValidation::~PrimaryVertexValidation() = default;
 //
 // member functions
 //
@@ -270,9 +266,7 @@ void PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::Event
   //=======================================================
   // Retrieve tracker topology from geometry
   //=======================================================
-
-  edm::ESHandle<TrackerTopology> tTopoHandle = iSetup.getHandle(topoToken_);
-  const TrackerTopology* const tTopo = tTopoHandle.product();
+  const TrackerTopology* const tTopo = &iSetup.getData(topoToken_);
 
   //=======================================================
   // Retrieve geometry information

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -101,13 +101,13 @@ PrimaryVertexValidation::PrimaryVertexValidation(const edm::ParameterSet& iConfi
   runControlNumbers_ = iConfig.getUntrackedParameter<std::vector<unsigned int>>("runControlNumber", defaultRuns);
 
   edm::InputTag TrackCollectionTag_ = iConfig.getParameter<edm::InputTag>("TrackCollectionTag");
-  theTrackCollectionToken = consumes<reco::TrackCollection>(TrackCollectionTag_);
+  theTrackCollectionToken_ = consumes<reco::TrackCollection>(TrackCollectionTag_);
 
   edm::InputTag VertexCollectionTag_ = iConfig.getParameter<edm::InputTag>("VertexCollectionTag");
-  theVertexCollectionToken = consumes<reco::VertexCollection>(VertexCollectionTag_);
+  theVertexCollectionToken_ = consumes<reco::VertexCollection>(VertexCollectionTag_);
 
   edm::InputTag BeamspotTag_ = iConfig.getParameter<edm::InputTag>("BeamSpotTag");
-  theBeamspotToken = consumes<reco::BeamSpot>(BeamspotTag_);
+  theBeamspotToken_ = consumes<reco::BeamSpot>(BeamspotTag_);
 
   // select and configure the track filter
   theTrackFilter_ =
@@ -372,8 +372,7 @@ void PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::Event
   // Retrieve the Track information
   //=======================================================
 
-  edm::Handle<TrackCollection> trackCollectionHandle;
-  iEvent.getByToken(theTrackCollectionToken, trackCollectionHandle);
+  edm::Handle<TrackCollection> trackCollectionHandle = iEvent.getHandle(theTrackCollectionToken_);
   if (!trackCollectionHandle.isValid())
     return;
   auto const& tracks = *trackCollectionHandle;
@@ -386,7 +385,7 @@ void PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::Event
   edm::Handle<std::vector<Vertex>> vertices;
 
   try {
-    iEvent.getByToken(theVertexCollectionToken, vertices);
+    vertices = iEvent.getHandle(theVertexCollectionToken_);
   } catch (cms::Exception& er) {
     LogTrace("PrimaryVertexValidation") << "caught std::exception " << er.what() << std::endl;
   }
@@ -511,8 +510,7 @@ void PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::Event
   //=======================================================
 
   BeamSpot beamSpot;
-  edm::Handle<BeamSpot> beamSpotHandle;
-  iEvent.getByToken(theBeamspotToken, beamSpotHandle);
+  edm::Handle<BeamSpot> beamSpotHandle = iEvent.getHandle(theBeamspotToken_);
 
   if (beamSpotHandle.isValid()) {
     beamSpot = *beamSpotHandle;

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
@@ -192,9 +192,9 @@ private:
   // force to use beamspot in the vertex fit
   bool forceBeamSpotContraint_;
 
-  edm::EDGetTokenT<reco::TrackCollection> theTrackCollectionToken;
-  edm::EDGetTokenT<reco::VertexCollection> theVertexCollectionToken;
-  edm::EDGetTokenT<reco::BeamSpot> theBeamspotToken;
+  edm::EDGetTokenT<reco::TrackCollection> theTrackCollectionToken_;
+  edm::EDGetTokenT<reco::VertexCollection> theVertexCollectionToken_;
+  edm::EDGetTokenT<reco::BeamSpot> theBeamspotToken_;
 
   TTree* rootTree_;
 


### PR DESCRIPTION
#### PR description:

This PR provides a few miscellaneous improvements in the `Alignment/OfflineValidation`:
   * commit 489dd3795320392d49ef3cc2104d21fdaa236e60 streamlines the way from which the number of BPix L1 ladders and # modules in Z is fetched, by using the `PixelTopologyMap` class introduced in https://github.com/cms-sw/cmssw/pull/33319
   * commit 309aa0ed5edd8c7502f65b3d8ec4e2743117ecf9 rationalizes the token usage (in response to https://github.com/cms-sw/cmssw/pull/35931#discussion_r741016021)
   * commit 309aa0ed5edd8c7502f65b3d8ec4e2743117ecf9 adds provision for the pilot beam 2021 in the plotting macro
   * commit 108c8c07e604e8b1c2659959c180f64ff867af75 fixes a long-standing bug in the manual setting from configuration of the scale of the Layer 1 IP residual plots vs module number / ladder.

#### PR validation:

Passes unit tests.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

