### PR TITLE
Fixing memory bug in GsfElectronProducer

### DIFF
--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.cc
@@ -291,7 +291,7 @@ void GsfElectronProducer::fillDescriptions(edm::ConfigurationDescriptions& descr
     psd1.add<bool>("enabled", false);
     psd1.add<std::string>("inputTensorName", "FirstLayer_input");
     psd1.add<std::string>("outputTensorName", "sequential/FinalLayer/Softmax");
-    psd1.add<uint>("outputDim", 3);  // Dimension of output vector
+    psd1.add<uint>("outputDim", 5);  // Number of output nodes of DNN
     psd1.add<std::vector<std::string>>(
         "modelsFiles",
         {"RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/lowpT/lowpT_modelDNN.pb",


### PR DESCRIPTION
#### PR description:

This PR aims to fix a memory bug found by AddressSanitizer and reported in the github issue https://github.com/cms-sw/cmssw/issues/35760. The bug was introduced in the context of transitioning PF Egamma ID from BDT to DNN (https://github.com/cms-sw/cmssw/pull/35403). 

This PR is purely technical in nature; no change in physics is expected.

#### PR validation:

From `CMSSW_12_2_ASAN_X_2021-11-01-2300`, ran `runTheMatrix.py -l 11634.7`. It crashed with `AddressSanitizer: heap-buffer-overflow`. Then merged this branch, recompiled and ran the same workflow again. No crash happened. 

This PR is not a backport.
Backport not needed.
