### PR TITLE
Fix timing PCLs by adding EDMToMeConverter

### DIFF
--- a/CalibPPS/TimingCalibration/python/ALCARECOPPSDiamondSampicTimingCalibHarvester_cff.py
+++ b/CalibPPS/TimingCalibration/python/ALCARECOPPSDiamondSampicTimingCalibHarvester_cff.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
-
+from DQMServices.Components.EDMtoMEConverter_cfi import EDMtoMEConverter
 from Geometry.VeryForwardGeometry.geometryRPFromDB_cfi import *
 from CalibPPS.TimingCalibration.PPSDiamondSampicTimingCalibrationPCLHarvester_cfi import *
 
@@ -9,5 +9,11 @@ DQMStore = cms.Service("DQMStore")
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 dqmEnv = DQMEDHarvester('DQMHarvestingMetadata',
                               subSystemFolder=cms.untracked.string('AlCaReco/PPSDiamondSampicTimingCalibrationPCL/AlignedChannels'))
-                              
-ALCAHARVESTPPSDiamondSampicTimingCalibration = cms.Sequence(PPSDiamondSampicTimingCalibrationPCLHarvester + dqmEnv)
+                   
+EDMtoMEConvertPPSTimingSampicCalibration = EDMtoMEConverter.clone()
+EDMtoMEConvertPPSTimingSampicCalibration.lumiInputTag = cms.InputTag("EDMtoMEConvertPPSTimingSampicCalibration", "MEtoEDMConverterLumi")
+EDMtoMEConvertPPSTimingSampicCalibration.runInputTag = cms.InputTag("EDMtoMEConvertPPSTimingSampicCalibration", "MEtoEDMConverterRun")
+           
+ALCAHARVESTPPSDiamondSampicTimingCalibration = cms.Sequence(EDMtoMEConvertPPSTimingSampicCalibration +
+						PPSDiamondSampicTimingCalibrationPCLHarvester +
+						dqmEnv)

--- a/CalibPPS/TimingCalibration/python/PPSTimingCalibrationHarvester_cff.py
+++ b/CalibPPS/TimingCalibration/python/PPSTimingCalibrationHarvester_cff.py
@@ -2,3 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.VeryForwardGeometry.geometryRPFromDB_cfi import *
 from CalibPPS.TimingCalibration.ppsTimingCalibrationPCLHarvester_cfi import *
+from DQMServices.Components.EDMtoMEConverter_cfi import EDMtoMEConverter
+
+EDMtoMEConvertPPSTimingCalibration = EDMtoMEConverter.clone()
+EDMtoMEConvertPPSTimingCalibration.lumiInputTag = cms.InputTag("EDMtoMEConvertPPSTimingCalibration", "MEtoEDMConverterLumi")
+EDMtoMEConvertPPSTimingCalibration.runInputTag = cms.InputTag("EDMtoMEConvertPPSTimingCalibration", "MEtoEDMConverterRun")
+
+                                        
+ALCAHARVESTPPSTimingCalibration = cms.Task(
+    EDMtoMEConvertPPSTimingCalibration,
+    ppsTimingCalibrationPCLHarvester
+)

--- a/Configuration/StandardSequences/python/AlCaHarvesting_cff.py
+++ b/Configuration/StandardSequences/python/AlCaHarvesting_cff.py
@@ -228,7 +228,6 @@ if ALCAHARVESTSiPixelQuality.debug == cms.untracked.bool(True) :
 
 # --------------------------------------------------------------------------------------
 # PPS calibration
-ALCAHARVESTPPSTimingCalibration = ppsTimingCalibrationPCLHarvester.clone()
 ALCAHARVESTPPSTimingCalibration_metadata = cms.PSet(record = cms.untracked.string('PPSTimingCalibrationRcd'))
 ALCAHARVESTPPSTimingCalibration_dbOutput = cms.PSet(record = cms.string('PPSTimingCalibrationRcd'),
                                                     tag = cms.string('PPSDiamondTimingCalibration_pcl'),


### PR DESCRIPTION
**PR description:**
This PR follows #35874 and addresses the issue for the timing PCLs (TDC and Sampic).

**PR validation:** 

- PCL of TDC was validated against relval 1041
- PCL of Sampic was validated using the manual test included in `CalibPPS/TimingCalibration/test/`