### PR TITLE
MTD reconstruction validation: tracks and vertices

### DIFF
--- a/Validation/MtdValidation/plugins/BuildFile.xml
+++ b/Validation/MtdValidation/plugins/BuildFile.xml
@@ -8,6 +8,8 @@
 <use name="DQMServices/Core"/>
 <use name="SimDataFormats/Track"/>
 <use name="SimDataFormats/PileupSummaryInfo"/>
+<use name="SimGeneral/HepPDTESSource"/>
+<use name="SimGeneral/HepPDTRecord"/>
 <use name="Geometry/Records"/>
 <use name="SimDataFormats/TrackingAnalysis"/>
 <use name="SimTracker/VertexAssociation"/>

--- a/Validation/MtdValidation/plugins/MtdTracksHarvester.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksHarvester.cc
@@ -30,8 +30,10 @@ private:
   MonitorElement* meEtlEtaEff_[2];
   MonitorElement* meEtlPhiEff_[2];
   MonitorElement* meEtlPtEff_[2];
-  MonitorElement* mePtMatchEff_;
-  MonitorElement* meEtaMatchEff_;
+  MonitorElement* meMVAPtSelEff_;
+  MonitorElement* meMVAEtaSelEff_;
+  MonitorElement* meMVAPtMatchEff_;
+  MonitorElement* meMVAEtaMatchEff_;
 };
 
 // ------------ constructor and destructor --------------
@@ -61,17 +63,20 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   MonitorElement* meETLTrackEffEtaMtdZpos = igetter.get(folder_ + "TrackETLEffEtaMtdZpos");
   MonitorElement* meETLTrackEffPhiMtdZpos = igetter.get(folder_ + "TrackETLEffPhiMtdZpos");
   MonitorElement* meETLTrackEffPtMtdZpos = igetter.get(folder_ + "TrackETLEffPtMtdZpos");
-  MonitorElement* meTrackMatchedEffPtTot = igetter.get(folder_ + "MatchedEffPtTot");
-  MonitorElement* meTrackMatchedEffPtMtd = igetter.get(folder_ + "MatchedEffPtMtd");
-  MonitorElement* meTrackMatchedEffEtaTot = igetter.get(folder_ + "MatchedEffEtaTot");
-  MonitorElement* meTrackMatchedEffEtaMtd = igetter.get(folder_ + "MatchedEffEtaMtd");
+  MonitorElement* meMVATrackEffPtTot = igetter.get(folder_ + "MVAEffPtTot");
+  MonitorElement* meMVATrackMatchedEffPtTot = igetter.get(folder_ + "MVAMatchedEffPtTot");
+  MonitorElement* meMVATrackMatchedEffPtMtd = igetter.get(folder_ + "MVAMatchedEffPtMtd");
+  MonitorElement* meMVATrackEffEtaTot = igetter.get(folder_ + "MVAEffEtaTot");
+  MonitorElement* meMVATrackMatchedEffEtaTot = igetter.get(folder_ + "MVAMatchedEffEtaTot");
+  MonitorElement* meMVATrackMatchedEffEtaMtd = igetter.get(folder_ + "MVAMatchedEffEtaMtd");
 
   if (!meBTLTrackEffEtaTot || !meBTLTrackEffPhiTot || !meBTLTrackEffPtTot || !meBTLTrackEffEtaMtd ||
       !meBTLTrackEffPhiMtd || !meBTLTrackEffPtMtd || !meETLTrackEffEtaTotZneg || !meETLTrackEffPhiTotZneg ||
       !meETLTrackEffPtTotZneg || !meETLTrackEffEtaMtdZneg || !meETLTrackEffPhiMtdZneg || !meETLTrackEffPtMtdZneg ||
       !meETLTrackEffEtaTotZpos || !meETLTrackEffPhiTotZpos || !meETLTrackEffPtTotZpos || !meETLTrackEffEtaMtdZpos ||
-      !meETLTrackEffPhiMtdZpos || !meETLTrackEffPtMtdZpos || !meTrackMatchedEffPtTot || !meTrackMatchedEffPtMtd ||
-      !meTrackMatchedEffEtaTot || !meTrackMatchedEffEtaMtd) {
+      !meETLTrackEffPhiMtdZpos || !meETLTrackEffPtMtdZpos || !meMVATrackEffPtTot || !meMVATrackMatchedEffPtTot ||
+      !meMVATrackMatchedEffPtMtd || !meMVATrackEffEtaTot || !meMVATrackMatchedEffEtaTot ||
+      !meMVATrackMatchedEffEtaMtd) {
     edm::LogError("MtdTracksHarvester") << "Monitoring histograms not found!" << std::endl;
     return;
   }
@@ -123,16 +128,26 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
                                 meETLTrackEffPtTotZpos->getNbinsX(),
                                 meETLTrackEffPtTotZpos->getTH1()->GetXaxis()->GetXmin(),
                                 meETLTrackEffPtTotZpos->getTH1()->GetXaxis()->GetXmax());
-  mePtMatchEff_ = ibook.book1D("PtMatchEff",
-                               "Track matched to GEN efficiency VS Pt;Pt [GeV];Efficiency",
-                               meTrackMatchedEffPtTot->getNbinsX(),
-                               meTrackMatchedEffPtTot->getTH1()->GetXaxis()->GetXmin(),
-                               meTrackMatchedEffPtTot->getTH1()->GetXaxis()->GetXmax());
-  meEtaMatchEff_ = ibook.book1D("EtaMatchEff",
-                                "Track matched to GEN efficiency VS Eta;Eta;Efficiency",
-                                meTrackMatchedEffEtaTot->getNbinsX(),
-                                meTrackMatchedEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
-                                meTrackMatchedEffEtaTot->getTH1()->GetXaxis()->GetXmax());
+  meMVAPtSelEff_ = ibook.book1D("MVAPtSelEff",
+                                "Track selected efficiency VS Pt;Pt [GeV];Efficiency",
+                                meMVATrackEffPtTot->getNbinsX(),
+                                meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmin(),
+                                meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmax());
+  meMVAEtaSelEff_ = ibook.book1D("MVAEtaSelEff",
+                                 "Track selected efficiency VS Eta;Eta;Efficiency",
+                                 meMVATrackEffEtaTot->getNbinsX(),
+                                 meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
+                                 meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmax());
+  meMVAPtMatchEff_ = ibook.book1D("MVAPtMatchEff",
+                                  "Track matched to GEN efficiency VS Pt;Pt [GeV];Efficiency",
+                                  meMVATrackMatchedEffPtTot->getNbinsX(),
+                                  meMVATrackMatchedEffPtTot->getTH1()->GetXaxis()->GetXmin(),
+                                  meMVATrackMatchedEffPtTot->getTH1()->GetXaxis()->GetXmax());
+  meMVAEtaMatchEff_ = ibook.book1D("MVAEtaMatchEff",
+                                   "Track matched to GEN efficiency VS Eta;Eta;Efficiency",
+                                   meMVATrackMatchedEffEtaTot->getNbinsX(),
+                                   meMVATrackMatchedEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
+                                   meMVATrackMatchedEffEtaTot->getTH1()->GetXaxis()->GetXmax());
 
   meBtlEtaEff_->getTH1()->SetMinimum(0.);
   meBtlPhiEff_->getTH1()->SetMinimum(0.);
@@ -142,8 +157,10 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
     meEtlPhiEff_[i]->getTH1()->SetMinimum(0.);
     meEtlPtEff_[i]->getTH1()->SetMinimum(0.);
   }
-  mePtMatchEff_->getTH1()->SetMinimum(0.);
-  meEtaMatchEff_->getTH1()->SetMinimum(0.);
+  meMVAPtSelEff_->getTH1()->SetMinimum(0.);
+  meMVAEtaSelEff_->getTH1()->SetMinimum(0.);
+  meMVAPtMatchEff_->getTH1()->SetMinimum(0.);
+  meMVAEtaMatchEff_->getTH1()->SetMinimum(0.);
 
   // --- Calculate efficiency BTL
   for (int ibin = 1; ibin <= meBTLTrackEffEtaTot->getNbinsX(); ibin++) {
@@ -267,32 +284,59 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
     meEtlPtEff_[1]->setBinError(ibin, bin_err);
   }
 
-  for (int ibin = 1; ibin <= meTrackMatchedEffPtTot->getNbinsX(); ibin++) {
-    double eff = meTrackMatchedEffPtMtd->getBinContent(ibin) / meTrackMatchedEffPtTot->getBinContent(ibin);
-    double bin_err =
-        sqrt((meTrackMatchedEffPtMtd->getBinContent(ibin) *
-              (meTrackMatchedEffPtTot->getBinContent(ibin) - meTrackMatchedEffPtMtd->getBinContent(ibin))) /
-             pow(meTrackMatchedEffPtTot->getBinContent(ibin), 3));
-    if (meTrackMatchedEffPtTot->getBinContent(ibin) == 0) {
+  for (int ibin = 1; ibin <= meMVATrackEffPtTot->getNbinsX(); ibin++) {
+    double eff = meMVATrackMatchedEffPtTot->getBinContent(ibin) / meMVATrackEffPtTot->getBinContent(ibin);
+    double bin_err = sqrt((meMVATrackMatchedEffPtTot->getBinContent(ibin) *
+                           (meMVATrackEffPtTot->getBinContent(ibin) - meMVATrackMatchedEffPtTot->getBinContent(ibin))) /
+                          pow(meMVATrackEffPtTot->getBinContent(ibin), 3));
+    if (meMVATrackEffPtTot->getBinContent(ibin) == 0) {
       eff = 0;
       bin_err = 0;
     }
-    mePtMatchEff_->setBinContent(ibin, eff);
-    mePtMatchEff_->setBinError(ibin, bin_err);
+    meMVAPtSelEff_->setBinContent(ibin, eff);
+    meMVAPtSelEff_->setBinError(ibin, bin_err);
   }
 
-  for (int ibin = 1; ibin <= meTrackMatchedEffEtaTot->getNbinsX(); ibin++) {
-    double eff = meTrackMatchedEffEtaMtd->getBinContent(ibin) / meTrackMatchedEffEtaTot->getBinContent(ibin);
+  for (int ibin = 1; ibin <= meMVATrackEffEtaTot->getNbinsX(); ibin++) {
+    double eff = meMVATrackMatchedEffEtaTot->getBinContent(ibin) / meMVATrackEffEtaTot->getBinContent(ibin);
     double bin_err =
-        sqrt((meTrackMatchedEffEtaMtd->getBinContent(ibin) *
-              (meTrackMatchedEffEtaTot->getBinContent(ibin) - meTrackMatchedEffEtaMtd->getBinContent(ibin))) /
-             pow(meTrackMatchedEffEtaTot->getBinContent(ibin), 3));
-    if (meTrackMatchedEffEtaTot->getBinContent(ibin) == 0) {
+        sqrt((meMVATrackMatchedEffEtaTot->getBinContent(ibin) *
+              (meMVATrackEffEtaTot->getBinContent(ibin) - meMVATrackMatchedEffEtaTot->getBinContent(ibin))) /
+             pow(meMVATrackEffEtaTot->getBinContent(ibin), 3));
+    if (meMVATrackEffEtaTot->getBinContent(ibin) == 0) {
       eff = 0;
       bin_err = 0;
     }
-    meEtaMatchEff_->setBinContent(ibin, eff);
-    meEtaMatchEff_->setBinError(ibin, bin_err);
+    meMVAEtaSelEff_->setBinContent(ibin, eff);
+    meMVAEtaSelEff_->setBinError(ibin, bin_err);
+  }
+
+  for (int ibin = 1; ibin <= meMVATrackMatchedEffPtTot->getNbinsX(); ibin++) {
+    double eff = meMVATrackMatchedEffPtMtd->getBinContent(ibin) / meMVATrackMatchedEffPtTot->getBinContent(ibin);
+    double bin_err =
+        sqrt((meMVATrackMatchedEffPtMtd->getBinContent(ibin) *
+              (meMVATrackMatchedEffPtTot->getBinContent(ibin) - meMVATrackMatchedEffPtMtd->getBinContent(ibin))) /
+             pow(meMVATrackMatchedEffPtTot->getBinContent(ibin), 3));
+    if (meMVATrackMatchedEffPtTot->getBinContent(ibin) == 0) {
+      eff = 0;
+      bin_err = 0;
+    }
+    meMVAPtMatchEff_->setBinContent(ibin, eff);
+    meMVAPtMatchEff_->setBinError(ibin, bin_err);
+  }
+
+  for (int ibin = 1; ibin <= meMVATrackMatchedEffEtaTot->getNbinsX(); ibin++) {
+    double eff = meMVATrackMatchedEffEtaMtd->getBinContent(ibin) / meMVATrackMatchedEffEtaTot->getBinContent(ibin);
+    double bin_err =
+        sqrt((meMVATrackMatchedEffEtaMtd->getBinContent(ibin) *
+              (meMVATrackMatchedEffEtaTot->getBinContent(ibin) - meMVATrackMatchedEffEtaMtd->getBinContent(ibin))) /
+             pow(meMVATrackMatchedEffEtaTot->getBinContent(ibin), 3));
+    if (meMVATrackMatchedEffEtaTot->getBinContent(ibin) == 0) {
+      eff = 0;
+      bin_err = 0;
+    }
+    meMVAEtaMatchEff_->setBinContent(ibin, eff);
+    meMVAEtaMatchEff_->setBinError(ibin, bin_err);
   }
 }
 

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -63,7 +63,8 @@ private:
   const float trackMinEta_;
   const float trackMaxEta_;
 
-  static constexpr double etacut_ = 4;         // |eta| < 4;
+  static constexpr double etacutGEN_ = 4;      // |eta| < 4;
+  static constexpr double etacutREC_ = 3;      // |eta| < 3;
   static constexpr double pTcut_ = 0.7;        // PT > 0.7 GeV
   static constexpr double deltaZcut_ = 0.1;    // dz separation 1 mm
   static constexpr double deltaPTcut_ = 0.05;  // dPT < 5%
@@ -379,9 +380,9 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
 
       // select the reconstructed track
 
-      //if (primRecoVtx.trackWeight(trackref) < 0.5) {
-        //continue;
-      //}  // ONLY FOR TEST !!!!
+      if (primRecoVtx.trackWeight(trackref) < 0.5 || trackAssoc[trackref] == -1) {
+        continue;
+      }  // ONLY FOR TEST !!!!
 
       if (mvaRecSel(trackGen, primRecoVtx, t0Safe[trackref], Sigmat0Safe[trackref])) {
         meMVATrackEffPtTot_->Fill(trackGen.pt());
@@ -531,7 +532,7 @@ const bool MtdTracksValidation::mvaGenSel(const HepMC::GenParticle& gp, const fl
   if (gp.status() != 1) {
     return match;
   }
-  match = charge != 0.f && gp.momentum().perp() > pTcut_ && std::abs(gp.momentum().eta()) < etacut_;
+  match = charge != 0.f && gp.momentum().perp() > pTcut_ && std::abs(gp.momentum().eta()) < etacutGEN_;
   return match;
 }
 
@@ -540,7 +541,7 @@ const bool MtdTracksValidation::mvaRecSel(const reco::TrackBase& trk,
                                           const double& t0,
                                           const double& st0) {
   bool match = false;
-  match = trk.pt() > pTcut_ && std::abs(trk.vz() - vtx.z()) <= deltaZcut_;
+  match = trk.pt() > pTcut_ && std::abs(trk.eta()) < etacutREC_ && std::abs(trk.vz() - vtx.z()) <= deltaZcut_;
   if (st0 > 0.) {
     match = match && std::abs(t0 - vtx.t()) < 3. * st0;
   }

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -1,5 +1,3 @@
-#define EDM_ML_DEBUG
-
 #include <string>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -63,8 +61,8 @@ private:
   const float trackMinEta_;
   const float trackMaxEta_;
 
-  static constexpr double etacutGEN_ = 4;      // |eta| < 4;
-  static constexpr double etacutREC_ = 3;      // |eta| < 3;
+  static constexpr double etacutGEN_ = 4.;     // |eta| < 4;
+  static constexpr double etacutREC_ = 3.;     // |eta| < 3;
   static constexpr double pTcut_ = 0.7;        // PT > 0.7 GeV
   static constexpr double deltaZcut_ = 0.1;    // dz separation 1 mm
   static constexpr double deltaPTcut_ = 0.05;  // dPT < 5%
@@ -371,8 +369,6 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
 
   // select events with reco vertex close to true simulated primary vertex
   if (std::abs(primRecoVtx.z() - zsim) < deltaZcut_) {
-    edm::LogPrint("MtdTracksValidation") << "Reco z,t = " << primRecoVtx.z() << " " << primRecoVtx.t()
-                                         << " Sim z,t = " << zsim << " " << tsim;
     index = 0;
     for (const auto& trackGen : *GenRecTrackHandle) {
       const reco::TrackRef trackref(iEvent.getHandle(GenRecTrackToken_), index);
@@ -380,9 +376,9 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
 
       // select the reconstructed track
 
-      if (primRecoVtx.trackWeight(trackref) < 0.5 || trackAssoc[trackref] == -1) {
+      if (trackAssoc[trackref] == -1) {
         continue;
-      }  // ONLY FOR TEST !!!!
+      }
 
       if (mvaRecSel(trackGen, primRecoVtx, t0Safe[trackref], Sigmat0Safe[trackref])) {
         meMVATrackEffPtTot_->Fill(trackGen.pt());
@@ -391,7 +387,7 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
         double dZ = trackGen.vz() - zsim;
         double dT(-9999.);
         double pullT(-9999.);
-        if (Sigmat0Safe[trackref] != -1) {
+        if (Sigmat0Safe[trackref] != -1.) {
           dT = t0Safe[trackref] - tsim;
           pullT = dT / Sigmat0Safe[trackref];
         }
@@ -491,7 +487,7 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
   meMVATrackMatchedEffEtaMtd_ = ibook.book1D(
       "MVAMatchedEffEtaMtd", "Pt of tracks associated to LV matched to GEN with time; track eta ", 66, 0., 3.3);
   meMVATrackResTot_ = ibook.book1D(
-      "MVATrackRes", "t_{rec} - t_{sim} for LV associated tracks; t_{rec} - t_{sim} [ns] ", 70, -0.15, 0.15);
+      "MVATrackRes", "t_{rec} - t_{sim} for LV associated tracks; t_{rec} - t_{sim} [ns] ", 120, -0.15, 0.15);
   meMVATrackPullTot_ =
       ibook.book1D("MVATrackPull", "Pull for associated tracks; (t_{rec}-t_{sim})/#sigma_{t}", 50, -5., 5.);
   meMVATrackZposResTot_ = ibook.book1D(

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -119,10 +119,6 @@ private:
   MonitorElement* meTrackMVAQual_;
   MonitorElement* meTrackPathLenghtvsEta_;
 
-  MonitorElement* meVerNumber_;
-  MonitorElement* meVerZ_;
-  MonitorElement* meVerTime_;
-
   MonitorElement* meMVATrackEffPtTot_;
   MonitorElement* meMVATrackMatchedEffPtTot_;
   MonitorElement* meMVATrackMatchedEffPtMtd_;
@@ -344,18 +340,6 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
     }
   }  //RECO tracks loop
 
-  // --- Loop over the RECO vertices ---
-  int nv = 0;
-  for (const auto& v : *RecVertexHandle) {
-    if (v.isValid()) {
-      meVerZ_->Fill(v.z());
-      meVerTime_->Fill(v.t());
-      nv++;
-    } else
-      cout << "The vertex is not valid" << endl;
-  }
-  meVerNumber_->Fill(nv);
-
   // reco-gen matching used for MVA quality flag
   const auto& primRecoVtx = *(RecVertexHandle.product()->begin());
 
@@ -394,7 +378,9 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
         for (const auto& genP : mc->particle_range()) {
           // select status 1 genParticles and match them to the reconstructed track
 
-          float charge = pdTable->particle(HepPDT::ParticleID(genP->pdg_id()))->charge();
+          float charge = pdTable->particle(HepPDT::ParticleID(genP->pdg_id())) != nullptr
+                             ? pdTable->particle(HepPDT::ParticleID(genP->pdg_id()))->charge()
+                             : 0.f;
           if (mvaGenSel(*genP, charge)) {
             if (mvaGenRecMatch(*genP, zsim, trackGen)) {
               meMVATrackZposResTot_->Fill(dZ);
@@ -473,9 +459,6 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
   meTrackMVAQual_ = ibook.book1D("TrackMVAQual", "Track MVA Quality as stored in Value Map ; MVAQual", 100, 0, 1);
   meTrackPathLenghtvsEta_ = ibook.bookProfile(
       "TrackPathLenghtvsEta", "MTD Track pathlength vs MTD track Eta;|#eta|;Pathlength", 100, 0, 3.2, 100.0, 400.0, "S");
-  meVerZ_ = ibook.book1D("VerZ", "RECO Vertex Z;Z_{RECO} [cm]", 180, -18, 18);
-  meVerTime_ = ibook.book1D("VerTime", "RECO Vertex Time;t0 [ns]", 100, -1, 1);
-  meVerNumber_ = ibook.book1D("VerNumber", "RECO Vertex Number: Number of vertices", 100, 0, 500);
   meMVATrackEffPtTot_ = ibook.book1D("MVAEffPtTot", "Pt of tracks associated to LV; track pt [GeV] ", 110, 0., 11.);
   meMVATrackMatchedEffPtTot_ =
       ibook.book1D("MVAMatchedEffPtTot", "Pt of tracks associated to LV matched to GEN; track pt [GeV] ", 110, 0., 11.);

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -44,12 +44,22 @@ private:
 
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
+  //const bool mvaGenSel(const TrackingParticle&);
+  //const bool mvaRecSel(const reco::TrackBase&, const reco::Vertex&);
+  //const bool mvaGenRecMatch(const TrackingParticle&, const TrackingVertex&, const reco::TrackBase&);
+
   // ------------ member data ------------
 
   const std::string folder_;
   const float trackMinPt_;
   const float trackMinEta_;
   const float trackMaxEta_;
+
+  static constexpr double etacut_ = 4;         // |eta| < 4;
+  static constexpr double pTcut_ = 0.7;        // PT > 0.7 GeV
+  static constexpr double deltaZcut_ = 0.1;    // dz separation 1 mm
+  static constexpr double deltaPTcut_ = 0.05;  // dPT < 5%
+  static constexpr double deltaDRcut_ = 0.03;  // DeltaR separation
 
   edm::EDGetTokenT<reco::TrackCollection> GenRecTrackToken_;
   edm::EDGetTokenT<reco::TrackCollection> RecTrackToken_;
@@ -312,6 +322,13 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
     }
   }  //RECO tracks loop
 
+  //bool selectedVertex = false;
+
+  //if ( iv == 0 && iev == 0 ) {
+  //if ( std::abs(vertex->z() - vsim->position().z()) <= deltaZcut_ ) { continue; }
+  //selectedVertex = true;
+  //}
+
   // --- Loop over the RECO vertices ---
   int nv = 0;
   for (const auto& v : *RecVertexHandle) {
@@ -415,5 +432,33 @@ void MtdTracksValidation::fillDescriptions(edm::ConfigurationDescriptions& descr
 
   descriptions.add("mtdTracks", desc);
 }
+
+//const bool MtdTracksValidation::mvaGenSel(const TrackingParticle& tp) {
+//bool match = false;
+//if (tp.status() != 1) {
+//return match;
+//}
+//match = tp.threeCharge() != 0 && (tp.genParticles()[0])->pt() > pTcut_ && std::abs((tp.genParticles()[0])->eta()) < 4;
+//return match;
+//}
+
+//const bool MtdTracksValidation::mvaRecSel(const reco::TrackBase& trk, const reco::Vertex& vtx) {
+//bool match = false;
+//match = trk.pt() > pTcut_ && std::abs(trk.vz() - vtx.z()) <= deltaZcut_;
+//if (trk.covt0t0() > 0.) {
+//match = match && std::abs(trk.t0() - vtx.t()) < 3. * trk.covt0t0();
+//}
+//return match;
+//}
+
+//const bool MtdTracksValidation::mvaGenRecMatch(const TrackingParticle& tp,
+//const TrackingVertex& tv,
+//const reco::TrackBase& trk) {
+//bool match = false;
+//double dR2 = reco::deltaR2(tp.momentum(), trk.momentum());
+//match = std::abs(tp.pt() - trk.pt()) < deltaPTcut_ && dR2 < deltaDRcut_ * deltaDRcut_ &&
+//std::abs(trk.vz() - tv.position().z()) < deltaZcut_;
+//return match;
+//}
 
 DEFINE_FWK_MODULE(MtdTracksValidation);

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -361,7 +361,7 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
   auto GenEventHandle = makeValid(iEvent.getHandle(HepMCProductToken_));
   const HepMC::GenEvent* mc = GenEventHandle->GetEvent();
   double zsim = convertMmToCm((*(mc->vertices_begin()))->position().z());
-  double zt = (*(mc->vertices_begin()))->position().t() * CLHEP::mm / CLHEP::c_light;
+  double tsim = (*(mc->vertices_begin()))->position().t() * CLHEP::mm / CLHEP::c_light;
 
   auto pdt = iSetup.getHandle(particleTableToken_);
   const HepPDT::ParticleDataTable* pdTable = pdt.product();
@@ -386,7 +386,7 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
               double dT(-9999.);
               double pullT(-9999.);
               if (Sigmat0Pid[trackref] > 0.) {
-                dT = t0Pid[trackref] - zt;
+                dT = t0Pid[trackref] - tsim;
                 pullT = dT / Sigmat0Pid[trackref];
               }
               meTrackZposResTot_->Fill(dZ);
@@ -527,7 +527,7 @@ const bool MtdTracksValidation::mvaRecSel(const reco::TrackBase& trk,
   bool match = false;
   match = trk.pt() > pTcut_ && std::abs(trk.vz() - vtx.z()) <= deltaZcut_;
   if (st0 > 0.) {
-    match = match && std::abs(t0 - vtx.t() * CLHEP::mm / CLHEP::c_light) < 3. * st0;
+    match = match && std::abs(t0 - vtx.t()) < 3. * st0;
   }
   return match;
 }
@@ -538,7 +538,7 @@ const bool MtdTracksValidation::mvaGenRecMatch(const HepMC::GenParticle& genP,
   bool match = false;
   double dR2 = reco::deltaR2(genP.momentum(), trk.momentum());
   double genPT = genP.momentum().perp();
-  match = std::abs(genPT - trk.pt()) < genPT * deltaPTcut_ && dR2 < deltaDRcut_ * deltaDRcut_ &&
+  match = std::abs(genPT - trk.pt()) < trk.pt() * deltaPTcut_ && dR2 < deltaDRcut_ * deltaDRcut_ &&
           std::abs(trk.vz() - zsim) < deltaZcut_;
   return match;
 }

--- a/Validation/MtdValidation/plugins/Primary4DVertexHarvester.cc
+++ b/Validation/MtdValidation/plugins/Primary4DVertexHarvester.cc
@@ -45,11 +45,27 @@ void Primary4DVertexHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGe
   MonitorElement* meMVATrackEffEtaTot = igetter.get(folder_ + "MVAEffEtaTot");
   MonitorElement* meMVATrackMatchedEffEtaTot = igetter.get(folder_ + "MVAMatchedEffEtaTot");
   MonitorElement* meMVATrackMatchedEffEtaMtd = igetter.get(folder_ + "MVAMatchedEffEtaMtd");
+  MonitorElement* meRecoVtxVsLineDensity = igetter.get(folder_ + "RecoVtxVsLineDensity");
+  MonitorElement* meRecVerNumber = igetter.get(folder_ + "RecVerNumber");
 
   if (!meMVATrackEffPtTot || !meMVATrackMatchedEffPtTot || !meMVATrackMatchedEffPtMtd || !meMVATrackEffEtaTot ||
-      !meMVATrackMatchedEffEtaTot || !meMVATrackMatchedEffEtaMtd) {
+      !meMVATrackMatchedEffEtaTot || !meMVATrackMatchedEffEtaMtd || !meRecoVtxVsLineDensity || !meRecVerNumber) {
     edm::LogError("Primary4DVertexHarvester") << "Monitoring histograms not found!" << std::endl;
     return;
+  }
+
+  // Normalize line density plot
+  double nEvt = meRecVerNumber->getEntries();
+  if (nEvt > 0.) {
+    nEvt = 1. / nEvt;
+    double nEntries = meRecoVtxVsLineDensity->getEntries();
+    for (int ibin = 1; ibin <= meRecoVtxVsLineDensity->getNbinsX(); ibin++) {
+      double cont = meRecoVtxVsLineDensity->getBinContent(ibin) * nEvt;
+      double bin_err = meRecoVtxVsLineDensity->getBinError(ibin) * nEvt;
+      meRecoVtxVsLineDensity->setBinContent(ibin, cont);
+      meRecoVtxVsLineDensity->setBinError(ibin, bin_err);
+    }
+    meRecoVtxVsLineDensity->setEntries(nEntries);
   }
 
   // --- Book  histograms

--- a/Validation/MtdValidation/plugins/Primary4DVertexHarvester.cc
+++ b/Validation/MtdValidation/plugins/Primary4DVertexHarvester.cc
@@ -1,0 +1,150 @@
+#include <string>
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "DQMServices/Core/interface/DQMEDHarvester.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+
+#include "DataFormats/ForwardDetId/interface/ETLDetId.h"
+
+class Primary4DVertexHarvester : public DQMEDHarvester {
+public:
+  explicit Primary4DVertexHarvester(const edm::ParameterSet& iConfig);
+  ~Primary4DVertexHarvester() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+protected:
+  void dqmEndJob(DQMStore::IBooker&, DQMStore::IGetter&) override;
+
+private:
+  const std::string folder_;
+
+  // --- Histograms
+  MonitorElement* meMVAPtSelEff_;
+  MonitorElement* meMVAEtaSelEff_;
+  MonitorElement* meMVAPtMatchEff_;
+  MonitorElement* meMVAEtaMatchEff_;
+};
+
+// ------------ constructor and destructor --------------
+Primary4DVertexHarvester::Primary4DVertexHarvester(const edm::ParameterSet& iConfig)
+    : folder_(iConfig.getParameter<std::string>("folder")) {}
+
+Primary4DVertexHarvester::~Primary4DVertexHarvester() {}
+
+// ------------ endjob tasks ----------------------------
+void Primary4DVertexHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& igetter) {
+  // --- Get the monitoring histograms
+  MonitorElement* meMVATrackEffPtTot = igetter.get(folder_ + "MVAEffPtTot");
+  MonitorElement* meMVATrackMatchedEffPtTot = igetter.get(folder_ + "MVAMatchedEffPtTot");
+  MonitorElement* meMVATrackMatchedEffPtMtd = igetter.get(folder_ + "MVAMatchedEffPtMtd");
+  MonitorElement* meMVATrackEffEtaTot = igetter.get(folder_ + "MVAEffEtaTot");
+  MonitorElement* meMVATrackMatchedEffEtaTot = igetter.get(folder_ + "MVAMatchedEffEtaTot");
+  MonitorElement* meMVATrackMatchedEffEtaMtd = igetter.get(folder_ + "MVAMatchedEffEtaMtd");
+
+  if (
+      !meMVATrackEffPtTot || !meMVATrackMatchedEffPtTot || !meMVATrackMatchedEffPtMtd ||
+      !meMVATrackEffEtaTot || !meMVATrackMatchedEffEtaTot || !meMVATrackMatchedEffEtaMtd) {
+    edm::LogError("Primary4DVertexHarvester") << "Monitoring histograms not found!" << std::endl;
+    return;
+  }
+
+  // --- Book  histograms
+  ibook.cd(folder_);
+  meMVAPtSelEff_ = ibook.book1D("MVAPtSelEff",
+                               "Track selected efficiency VS Pt;Pt [GeV];Efficiency",
+                               meMVATrackEffPtTot->getNbinsX(),
+                               meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmin(),
+                               meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmax());
+  meMVAEtaSelEff_ = ibook.book1D("MVAEtaSelEff",
+                                "Track selected efficiency VS Eta;Eta;Efficiency",
+                                meMVATrackEffEtaTot->getNbinsX(),
+                                meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
+                                meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmax());
+  meMVAPtMatchEff_ = ibook.book1D("MVAPtMatchEff",
+                               "Track matched to GEN efficiency VS Pt;Pt [GeV];Efficiency",
+                               meMVATrackMatchedEffPtTot->getNbinsX(),
+                               meMVATrackMatchedEffPtTot->getTH1()->GetXaxis()->GetXmin(),
+                               meMVATrackMatchedEffPtTot->getTH1()->GetXaxis()->GetXmax());
+  meMVAEtaMatchEff_ = ibook.book1D("MVAEtaMatchEff",
+                                "Track matched to GEN efficiency VS Eta;Eta;Efficiency",
+                                meMVATrackMatchedEffEtaTot->getNbinsX(),
+                                meMVATrackMatchedEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
+                                meMVATrackMatchedEffEtaTot->getTH1()->GetXaxis()->GetXmax());
+
+  meMVAPtSelEff_->getTH1()->SetMinimum(0.);
+  meMVAEtaSelEff_->getTH1()->SetMinimum(0.);
+  meMVAPtMatchEff_->getTH1()->SetMinimum(0.);
+  meMVAEtaMatchEff_->getTH1()->SetMinimum(0.);
+
+  for (int ibin = 1; ibin <= meMVATrackEffPtTot->getNbinsX(); ibin++) {
+    double eff = meMVATrackMatchedEffPtTot->getBinContent(ibin) / meMVATrackEffPtTot->getBinContent(ibin);
+    double bin_err =
+        sqrt((meMVATrackMatchedEffPtTot->getBinContent(ibin) *
+              (meMVATrackEffPtTot->getBinContent(ibin) - meMVATrackMatchedEffPtTot->getBinContent(ibin))) /
+             pow(meMVATrackEffPtTot->getBinContent(ibin), 3));
+    if (meMVATrackEffPtTot->getBinContent(ibin) == 0) {
+      eff = 0;
+      bin_err = 0;
+    }
+    meMVAPtSelEff_->setBinContent(ibin, eff);
+    meMVAPtSelEff_->setBinError(ibin, bin_err);
+  }
+
+  for (int ibin = 1; ibin <= meMVATrackEffEtaTot->getNbinsX(); ibin++) {
+    double eff = meMVATrackMatchedEffEtaTot->getBinContent(ibin) / meMVATrackEffEtaTot->getBinContent(ibin);
+    double bin_err =
+        sqrt((meMVATrackMatchedEffEtaTot->getBinContent(ibin) *
+              (meMVATrackEffEtaTot->getBinContent(ibin) - meMVATrackMatchedEffEtaTot->getBinContent(ibin))) /
+             pow(meMVATrackEffEtaTot->getBinContent(ibin), 3));
+    if (meMVATrackEffEtaTot->getBinContent(ibin) == 0) {
+      eff = 0;
+      bin_err = 0;
+    }
+    meMVAEtaSelEff_->setBinContent(ibin, eff);
+    meMVAEtaSelEff_->setBinError(ibin, bin_err);
+  }
+
+  for (int ibin = 1; ibin <= meMVATrackMatchedEffPtTot->getNbinsX(); ibin++) {
+    double eff = meMVATrackMatchedEffPtMtd->getBinContent(ibin) / meMVATrackMatchedEffPtTot->getBinContent(ibin);
+    double bin_err =
+        sqrt((meMVATrackMatchedEffPtMtd->getBinContent(ibin) *
+              (meMVATrackMatchedEffPtTot->getBinContent(ibin) - meMVATrackMatchedEffPtMtd->getBinContent(ibin))) /
+             pow(meMVATrackMatchedEffPtTot->getBinContent(ibin), 3));
+    if (meMVATrackMatchedEffPtTot->getBinContent(ibin) == 0) {
+      eff = 0;
+      bin_err = 0;
+    }
+    meMVAPtMatchEff_->setBinContent(ibin, eff);
+    meMVAPtMatchEff_->setBinError(ibin, bin_err);
+  }
+
+  for (int ibin = 1; ibin <= meMVATrackMatchedEffEtaTot->getNbinsX(); ibin++) {
+    double eff = meMVATrackMatchedEffEtaMtd->getBinContent(ibin) / meMVATrackMatchedEffEtaTot->getBinContent(ibin);
+    double bin_err =
+        sqrt((meMVATrackMatchedEffEtaMtd->getBinContent(ibin) *
+              (meMVATrackMatchedEffEtaTot->getBinContent(ibin) - meMVATrackMatchedEffEtaMtd->getBinContent(ibin))) /
+             pow(meMVATrackMatchedEffEtaTot->getBinContent(ibin), 3));
+    if (meMVATrackMatchedEffEtaTot->getBinContent(ibin) == 0) {
+      eff = 0;
+      bin_err = 0;
+    }
+    meMVAEtaMatchEff_->setBinContent(ibin, eff);
+    meMVAEtaMatchEff_->setBinError(ibin, bin_err);
+  }
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ----------
+void Primary4DVertexHarvester::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+
+  desc.add<std::string>("folder", "MTD/Vertices/");
+
+  descriptions.add("Primary4DVertexPostProcessor", desc);
+}
+
+DEFINE_FWK_MODULE(Primary4DVertexHarvester);

--- a/Validation/MtdValidation/plugins/Primary4DVertexHarvester.cc
+++ b/Validation/MtdValidation/plugins/Primary4DVertexHarvester.cc
@@ -46,9 +46,8 @@ void Primary4DVertexHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGe
   MonitorElement* meMVATrackMatchedEffEtaTot = igetter.get(folder_ + "MVAMatchedEffEtaTot");
   MonitorElement* meMVATrackMatchedEffEtaMtd = igetter.get(folder_ + "MVAMatchedEffEtaMtd");
 
-  if (
-      !meMVATrackEffPtTot || !meMVATrackMatchedEffPtTot || !meMVATrackMatchedEffPtMtd ||
-      !meMVATrackEffEtaTot || !meMVATrackMatchedEffEtaTot || !meMVATrackMatchedEffEtaMtd) {
+  if (!meMVATrackEffPtTot || !meMVATrackMatchedEffPtTot || !meMVATrackMatchedEffPtMtd || !meMVATrackEffEtaTot ||
+      !meMVATrackMatchedEffEtaTot || !meMVATrackMatchedEffEtaMtd) {
     edm::LogError("Primary4DVertexHarvester") << "Monitoring histograms not found!" << std::endl;
     return;
   }
@@ -56,25 +55,25 @@ void Primary4DVertexHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGe
   // --- Book  histograms
   ibook.cd(folder_);
   meMVAPtSelEff_ = ibook.book1D("MVAPtSelEff",
-                               "Track selected efficiency VS Pt;Pt [GeV];Efficiency",
-                               meMVATrackEffPtTot->getNbinsX(),
-                               meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmin(),
-                               meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmax());
+                                "Track selected efficiency VS Pt;Pt [GeV];Efficiency",
+                                meMVATrackEffPtTot->getNbinsX(),
+                                meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmin(),
+                                meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmax());
   meMVAEtaSelEff_ = ibook.book1D("MVAEtaSelEff",
-                                "Track selected efficiency VS Eta;Eta;Efficiency",
-                                meMVATrackEffEtaTot->getNbinsX(),
-                                meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
-                                meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmax());
+                                 "Track selected efficiency VS Eta;Eta;Efficiency",
+                                 meMVATrackEffEtaTot->getNbinsX(),
+                                 meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
+                                 meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmax());
   meMVAPtMatchEff_ = ibook.book1D("MVAPtMatchEff",
-                               "Track matched to GEN efficiency VS Pt;Pt [GeV];Efficiency",
-                               meMVATrackMatchedEffPtTot->getNbinsX(),
-                               meMVATrackMatchedEffPtTot->getTH1()->GetXaxis()->GetXmin(),
-                               meMVATrackMatchedEffPtTot->getTH1()->GetXaxis()->GetXmax());
+                                  "Track matched to GEN efficiency VS Pt;Pt [GeV];Efficiency",
+                                  meMVATrackMatchedEffPtTot->getNbinsX(),
+                                  meMVATrackMatchedEffPtTot->getTH1()->GetXaxis()->GetXmin(),
+                                  meMVATrackMatchedEffPtTot->getTH1()->GetXaxis()->GetXmax());
   meMVAEtaMatchEff_ = ibook.book1D("MVAEtaMatchEff",
-                                "Track matched to GEN efficiency VS Eta;Eta;Efficiency",
-                                meMVATrackMatchedEffEtaTot->getNbinsX(),
-                                meMVATrackMatchedEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
-                                meMVATrackMatchedEffEtaTot->getTH1()->GetXaxis()->GetXmax());
+                                   "Track matched to GEN efficiency VS Eta;Eta;Efficiency",
+                                   meMVATrackMatchedEffEtaTot->getNbinsX(),
+                                   meMVATrackMatchedEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
+                                   meMVATrackMatchedEffEtaTot->getTH1()->GetXaxis()->GetXmax());
 
   meMVAPtSelEff_->getTH1()->SetMinimum(0.);
   meMVAEtaSelEff_->getTH1()->SetMinimum(0.);
@@ -83,10 +82,9 @@ void Primary4DVertexHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGe
 
   for (int ibin = 1; ibin <= meMVATrackEffPtTot->getNbinsX(); ibin++) {
     double eff = meMVATrackMatchedEffPtTot->getBinContent(ibin) / meMVATrackEffPtTot->getBinContent(ibin);
-    double bin_err =
-        sqrt((meMVATrackMatchedEffPtTot->getBinContent(ibin) *
-              (meMVATrackEffPtTot->getBinContent(ibin) - meMVATrackMatchedEffPtTot->getBinContent(ibin))) /
-             pow(meMVATrackEffPtTot->getBinContent(ibin), 3));
+    double bin_err = sqrt((meMVATrackMatchedEffPtTot->getBinContent(ibin) *
+                           (meMVATrackEffPtTot->getBinContent(ibin) - meMVATrackMatchedEffPtTot->getBinContent(ibin))) /
+                          pow(meMVATrackEffPtTot->getBinContent(ibin), 3));
     if (meMVATrackEffPtTot->getBinContent(ibin) == 0) {
       eff = 0;
       bin_err = 0;

--- a/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
+++ b/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
@@ -242,7 +242,6 @@ private:
   edm::EDGetTokenT<edm::ValueMap<float>> pathLengthToken_;
   edm::EDGetTokenT<edm::ValueMap<float>> momentumToken_;
   edm::EDGetTokenT<edm::ValueMap<float>> timeToken_;
-  edm::EDGetTokenT<edm::ValueMap<float>> sigmatimeToken_;
 
   edm::EDGetTokenT<edm::ValueMap<float>> t0SafePidToken_;
   edm::EDGetTokenT<edm::ValueMap<float>> sigmat0SafePidToken_;
@@ -266,9 +265,7 @@ private:
   MonitorElement* meTrackRes_[3];
   MonitorElement* meTrackPull_[3];
   MonitorElement* meTrackResMass_[3];
-  MonitorElement* meTrackPullMass_[3];
   MonitorElement* meTrackResMassTrue_[3];
-  MonitorElement* meTrackPullMassTrue_[3];
   MonitorElement* meMVATrackZposResTot_;
   MonitorElement* meTrackZposResTot_;
   MonitorElement* meTrackZposRes_[3];
@@ -307,13 +304,9 @@ private:
   MonitorElement* meTrackPullHighP_[3];
 
   MonitorElement* meTrackResMassProtons_[3];
-  MonitorElement* meTrackPullMassProtons_[3];
   MonitorElement* meTrackResMassTrueProtons_[3];
-  MonitorElement* meTrackPullMassTrueProtons_[3];
   MonitorElement* meTrackResMassPions_[3];
-  MonitorElement* meTrackPullMassPions_[3];
   MonitorElement* meTrackResMassTruePions_[3];
-  MonitorElement* meTrackPullMassTruePions_[3];
 };
 
 // constructors and destructor
@@ -340,7 +333,6 @@ Primary4DVertexValidation::Primary4DVertexValidation(const edm::ParameterSet& iC
   pathLengthToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("pathLengthSrc"));
   momentumToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("momentumSrc"));
   timeToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("timeSrc"));
-  sigmatimeToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("sigmaSrc"));
   t0SafePidToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("t0SafePID"));
   sigmat0SafePidToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("sigmat0SafePID"));
   trackMVAQualToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("trackMVAQual"));
@@ -407,23 +399,6 @@ void Primary4DVertexValidation::bookHistograms(DQMStore::IBooker& ibook,
       "TrackPull-MediumMVA", "Pull for tracks with 0.5 < MVA < 0.8; (t_{rec}-t_{sim})/#sigma_{t}", 100, -10., 10.);
   meTrackPull_[2] =
       ibook.book1D("TrackPull-HighMVA", "Pull for tracks with MVA > 0.8; (t_{rec}-t_{sim})/#sigma_{t}", 100, -10., 10.);
-  if (optionalPlots_) {
-    meTrackPullMass_[0] = ibook.book1D(
-        "TrackPullMass-LowMVA", "Pull for tracks with MVA < 0.5; (t_{rec}-t_{est})/#sigma_{t}", 100, -10., 10.);
-    meTrackPullMass_[1] = ibook.book1D(
-        "TrackPullMass-MediumMVA", "Pull for tracks with 0.5 < MVA < 0.8; (t_{rec}-t_{est})/#sigma_{t}", 100, -10., 10.);
-    meTrackPullMass_[2] = ibook.book1D(
-        "TrackPullMass-HighMVA", "Pull for tracks with MVA > 0.8; (t_{rec}-t_{est})/#sigma_{t}", 100, -10., 10.);
-    meTrackPullMassTrue_[0] = ibook.book1D(
-        "TrackPullMassTrue-LowMVA", "Pull for tracks with MVA < 0.5; (t_{est}-t_{sim})/#sigma_{t}", 100, -10., 10.);
-    meTrackPullMassTrue_[1] = ibook.book1D("TrackPullMassTrue-MediumMVA",
-                                           "Pull for tracks with 0.5 < MVA < 0.8; (t_{est}-t_{sim})/#sigma_{t}",
-                                           100,
-                                           -10.,
-                                           10.);
-    meTrackPullMassTrue_[2] = ibook.book1D(
-        "TrackPullMassTrue-HighMVA", "Pull for tracks with MVA > 0.8; (t_{est}-t_{sim})/#sigma_{t}", 100, -10., 10.);
-  }
   meMVATrackZposResTot_ = ibook.book1D(
       "MVATrackZposResTot", "Z_{PCA} - Z_{sim} for tracks from LV MVA sel.;Z_{PCA} - Z_{sim} [cm] ", 50, -0.1, 0.1);
   meTrackZposResTot_ =
@@ -642,71 +617,6 @@ void Primary4DVertexValidation::bookHistograms(DQMStore::IBooker& ibook,
                      100,
                      -1.,
                      1.);
-
-    meTrackPullMassProtons_[0] = ibook.book1D("TrackPullMass-Protons-LowMVA",
-                                              "Pull for proton tracks with MVA < 0.5; (t_{rec}-t_{est})/#sigma_{t}",
-                                              100,
-                                              -10.,
-                                              10.);
-    meTrackPullMassProtons_[1] =
-        ibook.book1D("TrackPullMass-Protons-MediumMVA",
-                     "Pull for proton tracks with 0.5 < MVA < 0.8; (t_{rec}-t_{est})/#sigma_{t}",
-                     100,
-                     -10.,
-                     10.);
-    meTrackPullMassProtons_[2] = ibook.book1D("TrackPullMass-Protons-HighMVA",
-                                              "Pull for proton tracks with MVA > 0.8; (t_{rec}-t_{est})/#sigma_{t}",
-                                              100,
-                                              -10.,
-                                              10.);
-    meTrackPullMassTrueProtons_[0] = ibook.book1D("TrackPullMassTrue-Protons-LowMVA",
-                                                  "Pull for proton tracks with MVA < 0.5; (t_{est}-t_{sim})/#sigma_{t}",
-                                                  100,
-                                                  -10.,
-                                                  10.);
-    meTrackPullMassTrueProtons_[1] =
-        ibook.book1D("TrackPullMassTrue-Protons-MediumMVA",
-                     "Pull for proton tracks with 0.5 < MVA < 0.8; (t_{est}-t_{sim})/#sigma_{t}",
-                     100,
-                     -10.,
-                     10.);
-    meTrackPullMassTrueProtons_[2] = ibook.book1D("TrackPullMassTrue-Protons-HighMVA",
-                                                  "Pull for proton tracks with MVA > 0.8; (t_{est}-t_{sim})/#sigma_{t}",
-                                                  100,
-                                                  -10.,
-                                                  10.);
-
-    meTrackPullMassPions_[0] = ibook.book1D("TrackPullMass-Pions-LowMVA",
-                                            "Pull for pion tracks with MVA < 0.5; (t_{rec}-t_{est})/#sigma_{t}",
-                                            100,
-                                            -10.,
-                                            10.);
-    meTrackPullMassPions_[1] = ibook.book1D("TrackPullMass-Pions-MediumMVA",
-                                            "Pull for pion tracks with 0.5 < MVA < 0.8; (t_{rec}-t_{est})/#sigma_{t}",
-                                            100,
-                                            -10.,
-                                            10.);
-    meTrackPullMassPions_[2] = ibook.book1D("TrackPullMass-Pions-HighMVA",
-                                            "Pull for pion tracks with MVA > 0.8; (t_{rec}-t_{est})/#sigma_{t}",
-                                            100,
-                                            -10.,
-                                            10.);
-    meTrackPullMassTruePions_[0] = ibook.book1D("TrackPullMassTrue-Pions-LowMVA",
-                                                "Pull for pion tracks with MVA < 0.5; (t_{est}-t_{sim})/#sigma_{t}",
-                                                100,
-                                                -10.,
-                                                10.);
-    meTrackPullMassTruePions_[1] =
-        ibook.book1D("TrackPullMassTrue-Pions-MediumMVA",
-                     "Pull for pion tracks with 0.5 < MVA < 0.8; (t_{est}-t_{sim})/#sigma_{t}",
-                     100,
-                     -10.,
-                     10.);
-    meTrackPullMassTruePions_[2] = ibook.book1D("TrackPullMassTrue-Pions-HighMVA",
-                                                "Pull for pion tracks with MVA > 0.8; (t_{est}-t_{sim})/#sigma_{t}",
-                                                100,
-                                                -10.,
-                                                10.);
   }
 }
 
@@ -1193,7 +1103,6 @@ void Primary4DVertexValidation::analyze(const edm::Event& iEvent, const edm::Eve
   const auto& pathLength = iEvent.get(pathLengthToken_);
   const auto& momentum = iEvent.get(momentumToken_);
   const auto& time = iEvent.get(timeToken_);
-  const auto& sigmatime = iEvent.get(sigmatimeToken_);
   const auto& t0Safe = iEvent.get(t0SafePidToken_);
   const auto& sigmat0Safe = iEvent.get(sigmat0SafePidToken_);
   const auto& mtdQualMVA = iEvent.get(trackMVAQualToken_);
@@ -1290,9 +1199,7 @@ void Primary4DVertexValidation::analyze(const edm::Event& iEvent, const edm::Eve
 
             if (optionalPlots_) {
               meTrackResMass_[0]->Fill(t0Safe[*iTrack] - tEst);
-              meTrackPullMass_[0]->Fill((t0Safe[*iTrack] - tEst) / sigmat0Safe[*iTrack]);
               meTrackResMassTrue_[0]->Fill(tEst - tsim);
-              meTrackPullMassTrue_[0]->Fill((tEst - tsim) / sigmatime[*iTrack]);
             }
 
             if ((*iTrack)->p() <= 2) {
@@ -1306,14 +1213,10 @@ void Primary4DVertexValidation::analyze(const edm::Event& iEvent, const edm::Eve
             if (optionalPlots_) {
               if (std::abs((*tp_info)->pdgId()) == 2212) {
                 meTrackResMassProtons_[0]->Fill(t0Safe[*iTrack] - tEst);
-                meTrackPullMassProtons_[0]->Fill((t0Safe[*iTrack] - tEst) / sigmat0Safe[*iTrack]);
                 meTrackResMassTrueProtons_[0]->Fill(tEst - tsim);
-                meTrackPullMassTrueProtons_[0]->Fill((tEst - tsim) / sigmatime[*iTrack]);
               } else if (std::abs((*tp_info)->pdgId()) == 211) {
                 meTrackResMassPions_[0]->Fill(t0Safe[*iTrack] - tEst);
-                meTrackPullMassPions_[0]->Fill((t0Safe[*iTrack] - tEst) / sigmat0Safe[*iTrack]);
                 meTrackResMassTruePions_[0]->Fill(tEst - tsim);
-                meTrackPullMassTruePions_[0]->Fill((tEst - tsim) / sigmatime[*iTrack]);
               }
             }
 
@@ -1325,9 +1228,7 @@ void Primary4DVertexValidation::analyze(const edm::Event& iEvent, const edm::Eve
 
             if (optionalPlots_) {
               meTrackResMass_[1]->Fill(t0Safe[*iTrack] - tEst);
-              meTrackPullMass_[1]->Fill((t0Safe[*iTrack] - tEst) / sigmat0Safe[*iTrack]);
               meTrackResMassTrue_[1]->Fill(tEst - tsim);
-              meTrackPullMassTrue_[1]->Fill((tEst - tsim) / sigmatime[*iTrack]);
             }
 
             if ((*iTrack)->p() <= 2) {
@@ -1341,14 +1242,10 @@ void Primary4DVertexValidation::analyze(const edm::Event& iEvent, const edm::Eve
             if (optionalPlots_) {
               if (std::abs((*tp_info)->pdgId()) == 2212) {
                 meTrackResMassProtons_[1]->Fill(t0Safe[*iTrack] - tEst);
-                meTrackPullMassProtons_[1]->Fill((t0Safe[*iTrack] - tEst) / sigmat0Safe[*iTrack]);
                 meTrackResMassTrueProtons_[1]->Fill(tEst - tsim);
-                meTrackPullMassTrueProtons_[1]->Fill((tEst - tsim) / sigmatime[*iTrack]);
               } else if (std::abs((*tp_info)->pdgId()) == 211) {
                 meTrackResMassPions_[1]->Fill(t0Safe[*iTrack] - tEst);
-                meTrackPullMassPions_[1]->Fill((t0Safe[*iTrack] - tEst) / sigmat0Safe[*iTrack]);
                 meTrackResMassTruePions_[1]->Fill(tEst - tsim);
-                meTrackPullMassTruePions_[1]->Fill((tEst - tsim) / sigmatime[*iTrack]);
               }
             }
 
@@ -1360,9 +1257,7 @@ void Primary4DVertexValidation::analyze(const edm::Event& iEvent, const edm::Eve
 
             if (optionalPlots_) {
               meTrackResMass_[2]->Fill(t0Safe[*iTrack] - tEst);
-              meTrackPullMass_[2]->Fill((t0Safe[*iTrack] - tEst) / sigmat0Safe[*iTrack]);
               meTrackResMassTrue_[2]->Fill(tEst - tsim);
-              meTrackPullMassTrue_[2]->Fill((tEst - tsim) / sigmatime[*iTrack]);
             }
 
             if ((*iTrack)->p() <= 2) {
@@ -1376,14 +1271,10 @@ void Primary4DVertexValidation::analyze(const edm::Event& iEvent, const edm::Eve
             if (optionalPlots_) {
               if (std::abs((*tp_info)->pdgId()) == 2212) {
                 meTrackResMassProtons_[2]->Fill(t0Safe[*iTrack] - tEst);
-                meTrackPullMassProtons_[2]->Fill((t0Safe[*iTrack] - tEst) / sigmat0Safe[*iTrack]);
                 meTrackResMassTrueProtons_[2]->Fill(tEst - tsim);
-                meTrackPullMassTrueProtons_[2]->Fill((tEst - tsim) / sigmatime[*iTrack]);
               } else if (std::abs((*tp_info)->pdgId()) == 211) {
                 meTrackResMassPions_[2]->Fill(t0Safe[*iTrack] - tEst);
-                meTrackPullMassPions_[2]->Fill((t0Safe[*iTrack] - tEst) / sigmat0Safe[*iTrack]);
                 meTrackResMassTruePions_[2]->Fill(tEst - tsim);
-                meTrackPullMassTruePions_[2]->Fill((tEst - tsim) / sigmatime[*iTrack]);
               }
             }
           }

--- a/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
+++ b/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
@@ -355,8 +355,8 @@ void Primary4DVertexValidation::bookHistograms(DQMStore::IBooker& ibook,
   meTrackEffEtaTot_ = ibook.book1D("EffEtaTot", "Pt of tracks associated to LV; track eta ", 66, 0., 3.3);
   meTrackMatchedEffEtaTot_ =
       ibook.book1D("MatchedEffEtaTot", "Pt of tracks associated to LV matched to TP; track eta ", 66, 0., 3.3);
-  meTrackMatchedEffEtaMtd_ =
-      ibook.book1D("MatchedEffEtaMtd", "Pt of tracks associated to LV matched to TP with time; track eta ", 66, 0., 3.3);
+  meTrackMatchedEffEtaMtd_ = ibook.book1D(
+      "MatchedEffEtaMtd", "Pt of tracks associated to LV matched to TP with time; track eta ", 66, 0., 3.3);
   meTrackResTot_ = ibook.book1D("TrackRes", "t_{rec} - t_{sim} for tracks; t_{rec} - t_{sim} [ns] ", 70, -0.15, 0.15);
   meTrackRes_[0] = ibook.book1D(
       "TrackRes-LowMVA", "t_{rec} - t_{sim} for tracks with MVA < 0.5; t_{rec} - t_{sim} [ns] ", 100, -1., 1.);
@@ -1200,7 +1200,7 @@ void Primary4DVertexValidation::analyze(const edm::Event& iEvent, const edm::Eve
         if (vertex->trackWeight(*iTrack) < trackweightTh_)
           continue;
 
-        if (iv == 0) {
+        if (iv == 0 && iev == 0) {
           meTrackEffPtTot_->Fill((*iTrack)->pt());
           meTrackEffEtaTot_->Fill(std::abs((*iTrack)->eta()));
         }

--- a/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
+++ b/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
@@ -290,6 +290,9 @@ private:
   MonitorElement* meRecoPVPosSignal_;
   MonitorElement* meRecoPVPosSignalNotHighestPt_;
   MonitorElement* meRecoVtxVsLineDensity_;
+  MonitorElement* meRecVerNumber_;
+  MonitorElement* meRecPVZ_;
+  MonitorElement* meRecPVT_;
   MonitorElement* meSimPVZ_;
 
   //some tests
@@ -467,6 +470,9 @@ void Primary4DVertexValidation::bookHistograms(DQMStore::IBooker& ibook,
                    200);
   meRecoVtxVsLineDensity_ =
       ibook.book1D("RecoVtxVsLineDensity", "#Reco vertices/mm/event; line density [#vtx/mm/event]", 160, 0., 4.);
+  meRecVerNumber_ = ibook.book1D("RecVerNumber", "RECO Vertex Number: Number of vertices", 50, 0, 250);
+  meRecPVZ_ = ibook.book1D("recPVZ", "Weighted #Rec vertices/mm", 400, -20., 20.);
+  meRecPVT_ = ibook.book1D("recPVT", "#Rec vertices/10 ps", 200, -1., 1.);
   meSimPVZ_ = ibook.book1D("simPVZ", "Weighted #Sim vertices/mm", 400, -20., 20.);
 
   //some tests
@@ -1294,8 +1300,13 @@ void Primary4DVertexValidation::analyze(const edm::Event& iEvent, const edm::Eve
     return lineDensityPar_[0] * exp(-0.5 * argl * argl);
   };
 
+  meRecVerNumber_->Fill(recopv.size());
   for (unsigned int ir = 0; ir < recopv.size(); ir++) {
     meRecoVtxVsLineDensity_->Fill(puLineDensity(recopv.at(ir).z));
+    meRecPVZ_->Fill(recopv.at(ir).z, 1. / puLineDensity(recopv.at(ir).z));
+    if (recopv.at(ir).recVtx->tError() > 0.) {
+      meRecPVT_->Fill(recopv.at(ir).recVtx->t());
+    }
     if (debug_) {
       edm::LogPrint("Primary4DVertexValidation") << "************* IR: " << ir;
       edm::LogPrint("Primary4DVertexValidation")

--- a/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
+++ b/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
@@ -434,9 +434,9 @@ void Primary4DVertexValidation::bookHistograms(DQMStore::IBooker& ibook,
   meDeltaZrealreal_ = ibook.book1D("DeltaZrealreal", "#Delta Z real-real; |#Delta Z (r-r)| [cm]", 100, 0, 0.5);
   meDeltaZfakefake_ = ibook.book1D("DeltaZfakefake", "#Delta Z fake-fake; |#Delta Z (f-f)| [cm]", 100, 0, 0.5);
   meDeltaZfakereal_ = ibook.book1D("DeltaZfakereal", "#Delta Z fake-real; |#Delta Z (f-r)| [cm]", 100, 0, 0.5);
-  meDeltaTrealreal_ = ibook.book1D("DeltaTrealreal", "#Delta T real-real; |#Delta T (r-r)| [sigma]", 100, -10., 10.);
-  meDeltaTfakefake_ = ibook.book1D("DeltaTfakefake", "#Delta T fake-fake; |#Delta T (f-f)| [sigma]", 100, -10., 10.);
-  meDeltaTfakereal_ = ibook.book1D("DeltaTfakereal", "#Delta T fake-real; |#Delta T (f-r)| [sigma]", 100, -10., 10.);
+  meDeltaTrealreal_ = ibook.book1D("DeltaTrealreal", "#Delta T real-real; |#Delta T (r-r)| [sigma]", 60, 0., 30.);
+  meDeltaTfakefake_ = ibook.book1D("DeltaTfakefake", "#Delta T fake-fake; |#Delta T (f-f)| [sigma]", 60, 0., 30.);
+  meDeltaTfakereal_ = ibook.book1D("DeltaTfakereal", "#Delta T fake-real; |#Delta T (f-r)| [sigma]", 60, 0., 30.);
   meRecoPosInSimCollection_ = ibook.book1D(
       "RecoPosInSimCollection", "Sim signal vertex index associated to Reco signal vertex; Sim PV index", 200, 0, 200);
   meRecoPosInRecoOrigCollection_ =

--- a/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
+++ b/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
@@ -212,12 +212,12 @@ private:
   static constexpr double c_ = 2.99792458e1;  //c in cm/ns
   static constexpr double mvaL_ = 0.5;        //MVA cuts for MVA categories
   static constexpr double mvaH_ = 0.8;
-  static constexpr double selNdof_ = 4;
-  static constexpr double maxRank_ = 8;
-  static constexpr double maxTry_ = 10;
-  static constexpr double zWosMatchMax_ = 1;
-  static constexpr double etacutGEN_ = 4;    // |eta| < 4;
-  static constexpr double etacutREC_ = 3;    // |eta| < 3;
+  static constexpr double selNdof_ = 4.;
+  static constexpr double maxRank_ = 8.;
+  static constexpr double maxTry_ = 10.;
+  static constexpr double zWosMatchMax_ = 1.;
+  static constexpr double etacutGEN_ = 4.;   // |eta| < 4;
+  static constexpr double etacutREC_ = 3.;   // |eta| < 3;
   static constexpr double pTcut_ = 0.7;      // PT > 0.7 GeV
   static constexpr double deltaZcut_ = 0.1;  // dz separation 1 mm
 
@@ -367,8 +367,8 @@ void Primary4DVertexValidation::bookHistograms(DQMStore::IBooker& ibook,
   meMVATrackMatchedEffEtaMtd_ = ibook.book1D(
       "MVAMatchedEffEtaMtd", "Pt of tracks associated to LV matched to TP with time; track eta ", 66, 0., 3.3);
   meMVATrackResTot_ = ibook.book1D(
-      "MVATrackRes", "t_{rec} - t_{sim} for tracks from LV MVA sel.; t_{rec} - t_{sim} [ns] ", 70, -0.15, 0.15);
-  meTrackResTot_ = ibook.book1D("TrackRes", "t_{rec} - t_{sim} for tracks; t_{rec} - t_{sim} [ns] ", 70, -0.15, 0.15);
+      "MVATrackRes", "t_{rec} - t_{sim} for tracks from LV MVA sel.; t_{rec} - t_{sim} [ns] ", 120, -0.15, 0.15);
+  meTrackResTot_ = ibook.book1D("TrackRes", "t_{rec} - t_{sim} for tracks; t_{rec} - t_{sim} [ns] ", 120, -0.15, 0.15);
   meTrackRes_[0] = ibook.book1D(
       "TrackRes-LowMVA", "t_{rec} - t_{sim} for tracks with MVA < 0.5; t_{rec} - t_{sim} [ns] ", 100, -1., 1.);
   meTrackRes_[1] = ibook.book1D(
@@ -455,7 +455,7 @@ void Primary4DVertexValidation::bookHistograms(DQMStore::IBooker& ibook,
                    100,
                    -1.,
                    1.);
-  meTimeRes_ = ibook.book1D("TimeRes", "t_{rec} - t_{sim} ;t_{rec} - t_{sim} [ns] ", 100, -1., 1.);
+  meTimeRes_ = ibook.book1D("TimeRes", "t_{rec} - t_{sim} ;t_{rec} - t_{sim} [ns] ", 40, -0.2, 0.2);
   meTimePull_ = ibook.book1D("TimePull", "Pull; t_{rec} - t_{sim}/#sigma_{t rec}", 100, -10., 10.);
   meTimeSignalRes_ =
       ibook.book1D("TimeSignalRes", "t_{rec} - t_{sim} for signal ;t_{rec} - t_{sim} [ns] ", 40, -0.2, 0.2);
@@ -1218,10 +1218,6 @@ void Primary4DVertexValidation::analyze(const edm::Event& iEvent, const edm::Eve
       }
       double vzsim = simpv.at(iev).z;
       double vtsim = simpv.at(iev).t * simUnit_;
-      if (selectedVtxMatching) {
-        edm::LogPrint("Primary4DVertexValidation")
-            << "Reco z,t = " << vertex->z() << " " << vertex->t() << " Sim z,t = " << vzsim << " " << vtsim;
-      }
 
       for (auto iTrack = vertex->tracks_begin(); iTrack != vertex->tracks_end(); ++iTrack) {
         if (trackAssoc[*iTrack] == -1) {

--- a/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
+++ b/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
@@ -244,6 +244,8 @@ private:
   bool optionalPlots_;
 
   //histogram declaration
+  MonitorElement* meTrackResTot_;
+  MonitorElement* meTrackPullTot_;
   MonitorElement* meTrackRes_[3];
   MonitorElement* meTrackPull_[3];
   MonitorElement* meTrackResMass_[3];
@@ -275,6 +277,11 @@ private:
   MonitorElement* meSimPVZ_;
 
   //some tests
+  MonitorElement* meTrackResLowPTot_;
+  MonitorElement* meTrackResHighPTot_;
+  MonitorElement* meTrackPullLowPTot_;
+  MonitorElement* meTrackPullHighPTot_;
+
   MonitorElement* meTrackResLowP_[3];
   MonitorElement* meTrackResHighP_[3];
   MonitorElement* meTrackPullLowP_[3];
@@ -330,6 +337,7 @@ void Primary4DVertexValidation::bookHistograms(DQMStore::IBooker& ibook,
                                                edm::EventSetup const& iSetup) {
   ibook.setCurrentFolder(folder_);
   // --- histograms booking
+  meTrackResTot_ = ibook.book1D("TrackRes", "t_{rec} - t_{sim} for tracks; t_{rec} - t_{sim} [ns] ", 70, -0.15, 0.15);
   meTrackRes_[0] = ibook.book1D(
       "TrackRes-LowMVA", "t_{rec} - t_{sim} for tracks with MVA < 0.5; t_{rec} - t_{sim} [ns] ", 100, -1., 1.);
   meTrackRes_[1] = ibook.book1D(
@@ -359,6 +367,7 @@ void Primary4DVertexValidation::bookHistograms(DQMStore::IBooker& ibook,
                                           -1.,
                                           1.);
   }
+  meTrackPullTot_ = ibook.book1D("TrackPull", "Pull for tracks; (t_{rec}-t_{sim})/#sigma_{t}", 100, -10., 10.);
   meTrackPull_[0] =
       ibook.book1D("TrackPull-LowMVA", "Pull for tracks with MVA < 0.5; (t_{rec}-t_{sim})/#sigma_{t}", 100, -10., 10.);
   meTrackPull_[1] = ibook.book1D(
@@ -412,7 +421,7 @@ void Primary4DVertexValidation::bookHistograms(DQMStore::IBooker& ibook,
   meTimeRes_ = ibook.book1D("TimeRes", "t_{rec} - t_{sim} ;t_{rec} - t_{sim} [ns] ", 100, -1., 1.);
   meTimePull_ = ibook.book1D("TimePull", "Pull; t_{rec} - t_{sim}/#sigma_{t rec}", 100, -10., 10.);
   meTimeSignalRes_ =
-      ibook.book1D("TimeSignalRes", "t_{rec} - t_{sim} for signal ;t_{rec} - t_{sim} [ns] ", 100, -1., 1.);
+      ibook.book1D("TimeSignalRes", "t_{rec} - t_{sim} for signal ;t_{rec} - t_{sim} [ns] ", 40, -0.2, 0.2);
   meTimeSignalPull_ =
       ibook.book1D("TimeSignalPull", "Pull for signal; t_{rec} - t_{sim}/#sigma_{t rec}", 100, -10., 10.);
   mePUvsRealV_ =
@@ -447,6 +456,8 @@ void Primary4DVertexValidation::bookHistograms(DQMStore::IBooker& ibook,
   meSimPVZ_ = ibook.book1D("simPVZ", "#Sim vertices/mm", 400, -20., 20.);
 
   //some tests
+  meTrackResLowPTot_ = ibook.book1D(
+      "TrackResLowP", "t_{rec} - t_{sim} for tracks with p < 2 GeV; t_{rec} - t_{sim} [ns] ", 70, -0.15, 0.15);
   meTrackResLowP_[0] =
       ibook.book1D("TrackResLowP-LowMVA",
                    "t_{rec} - t_{sim} for tracks with MVA < 0.5 and p < 2 GeV; t_{rec} - t_{sim} [ns] ",
@@ -465,6 +476,8 @@ void Primary4DVertexValidation::bookHistograms(DQMStore::IBooker& ibook,
                    100,
                    -1.,
                    1.);
+  meTrackResHighPTot_ = ibook.book1D(
+      "TrackResHighP", "t_{rec} - t_{sim} for tracks with p > 2 GeV; t_{rec} - t_{sim} [ns] ", 70, -0.15, 0.15);
   meTrackResHighP_[0] =
       ibook.book1D("TrackResHighP-LowMVA",
                    "t_{rec} - t_{sim} for tracks with MVA < 0.5 and p > 2 GeV; t_{rec} - t_{sim} [ns] ",
@@ -483,6 +496,8 @@ void Primary4DVertexValidation::bookHistograms(DQMStore::IBooker& ibook,
                    100,
                    -1.,
                    1.);
+  meTrackPullLowPTot_ =
+      ibook.book1D("TrackPullLowP", "Pull for tracks with p < 2 GeV; (t_{rec}-t_{sim})/#sigma_{t}", 100, -10., 10.);
   meTrackPullLowP_[0] = ibook.book1D("TrackPullLowP-LowMVA",
                                      "Pull for tracks with MVA < 0.5 and p < 2 GeV; (t_{rec}-t_{sim})/#sigma_{t}",
                                      100,
@@ -498,6 +513,8 @@ void Primary4DVertexValidation::bookHistograms(DQMStore::IBooker& ibook,
                                      100,
                                      -10.,
                                      10.);
+  meTrackPullHighPTot_ =
+      ibook.book1D("TrackPullHighP", "Pull for tracks with p > 2 GeV; (t_{rec}-t_{sim})/#sigma_{t}", 100, -10., 10.);
   meTrackPullHighP_[0] = ibook.book1D("TrackPullHighP-LowMVA",
                                       "Pull for tracks with MVA < 0.5 and p > 2 GeV; (t_{rec}-t_{sim})/#sigma_{t}",
                                       100,
@@ -1185,6 +1202,16 @@ void Primary4DVertexValidation::analyze(const edm::Event& iEvent, const edm::Eve
 
           if (sigmat0Safe[*iTrack] == -1)
             continue;
+
+          meTrackResTot_->Fill(t0Safe[*iTrack] - tsim);
+          meTrackPullTot_->Fill((t0Safe[*iTrack] - tsim) / sigmat0Safe[*iTrack]);
+          if ((*iTrack)->p() <= 2) {
+            meTrackResLowPTot_->Fill(t0Safe[*iTrack] - tsim);
+            meTrackPullLowPTot_->Fill((t0Safe[*iTrack] - tsim) / sigmat0Safe[*iTrack]);
+          } else {
+            meTrackResHighPTot_->Fill(t0Safe[*iTrack] - tsim);
+            meTrackPullHighPTot_->Fill((t0Safe[*iTrack] - tsim) / sigmat0Safe[*iTrack]);
+          }
 
           if (mtdQualMVA[(*iTrack)] < mvaL_) {
             meTrackZposRes_[0]->Fill(dZ);

--- a/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
+++ b/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
@@ -216,7 +216,8 @@ private:
   static constexpr double maxRank_ = 8;
   static constexpr double maxTry_ = 10;
   static constexpr double zWosMatchMax_ = 1;
-  static constexpr double etacut_ = 4;       // |eta| < 4;
+  static constexpr double etacutGEN_ = 4;    // |eta| < 4;
+  static constexpr double etacutREC_ = 3;    // |eta| < 3;
   static constexpr double pTcut_ = 0.7;      // PT > 0.7 GeV
   static constexpr double deltaZcut_ = 0.1;  // dz separation 1 mm
 
@@ -1209,7 +1210,7 @@ void Primary4DVertexValidation::analyze(const edm::Event& iEvent, const edm::Eve
 
       bool selectedVtxMatching = recopv.at(iv).sim == iev && simpv.at(iev).rec == iv &&
                                  simpv.at(iev).eventId.bunchCrossing() == 0 && simpv.at(iev).eventId.event() == 0 &&
-                                 iv == 0;
+                                 recopv.at(iv).OriginalIndex == 0;
       if (selectedVtxMatching && !recopv.at(iv).is_signal()) {
         edm::LogWarning("Primary4DVertexValidation")
             << "Reco vtx leading match inconsistent: BX/ID " << simpv.at(iev).eventId.bunchCrossing() << " "
@@ -1587,7 +1588,7 @@ const bool Primary4DVertexValidation::mvaTPSel(const TrackingParticle& tp) {
   if (tp.status() != 1) {
     return match;
   }
-  match = tp.charge() != 0 && tp.pt() > pTcut_ && std::abs(tp.eta()) < etacut_;
+  match = tp.charge() != 0 && tp.pt() > pTcut_ && std::abs(tp.eta()) < etacutGEN_;
   return match;
 }
 
@@ -1596,7 +1597,7 @@ const bool Primary4DVertexValidation::mvaRecSel(const reco::TrackBase& trk,
                                                 const double& t0,
                                                 const double& st0) {
   bool match = false;
-  match = trk.pt() > pTcut_ && std::abs(trk.vz() - vtx.z()) <= deltaZcut_;
+  match = trk.pt() > pTcut_ && std::abs(trk.eta()) < etacutREC_ && std::abs(trk.vz() - vtx.z()) <= deltaZcut_;
   if (st0 > 0.) {
     match = match && std::abs(t0 - vtx.t()) < 3. * st0;
   }

--- a/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
+++ b/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
@@ -425,36 +425,36 @@ void Primary4DVertexValidation::bookHistograms(DQMStore::IBooker& ibook,
         "TrackPullMassTrue-HighMVA", "Pull for tracks with MVA > 0.8; (t_{est}-t_{sim})/#sigma_{t}", 100, -10., 10.);
   }
   meMVATrackZposResTot_ = ibook.book1D(
-      "MVATrackZposResTot", "Z_{PCA} - Z_{sim} for tracks from LV MVA sel.;Z_{PCA} - Z_{sim} [cm] ", 100, -0.1, 0.1);
+      "MVATrackZposResTot", "Z_{PCA} - Z_{sim} for tracks from LV MVA sel.;Z_{PCA} - Z_{sim} [cm] ", 50, -0.1, 0.1);
   meTrackZposResTot_ =
-      ibook.book1D("TrackZposResTot", "Z_{PCA} - Z_{sim} for tracks;Z_{PCA} - Z_{sim} [cm] ", 100, -1., 1.);
+      ibook.book1D("TrackZposResTot", "Z_{PCA} - Z_{sim} for tracks;Z_{PCA} - Z_{sim} [cm] ", 50, -0.5, 0.5);
   meTrackZposRes_[0] = ibook.book1D(
-      "TrackZposRes-LowMVA", "Z_{PCA} - Z_{sim} for tracks with MVA < 0.5;Z_{PCA} - Z_{sim} [cm] ", 100, -1., 1.);
+      "TrackZposRes-LowMVA", "Z_{PCA} - Z_{sim} for tracks with MVA < 0.5;Z_{PCA} - Z_{sim} [cm] ", 50, -0.5, 0.5);
   meTrackZposRes_[1] = ibook.book1D("TrackZposRes-MediumMVA",
                                     "Z_{PCA} - Z_{sim} for tracks with 0.5 < MVA < 0.8 ;Z_{PCA} - Z_{sim} [cm] ",
-                                    100,
-                                    -1.,
-                                    1.);
+                                    50,
+                                    -0.5,
+                                    0.5);
   meTrackZposRes_[2] = ibook.book1D(
-      "TrackZposRes-HighMVA", "Z_{PCA} - Z_{sim} for tracks with MVA > 0.8 ;Z_{PCA} - Z_{sim} [cm] ", 100, -1., 1.);
+      "TrackZposRes-HighMVA", "Z_{PCA} - Z_{sim} for tracks with MVA > 0.8 ;Z_{PCA} - Z_{sim} [cm] ", 50, -0.5, 0.5);
   meTrack3DposRes_[0] =
       ibook.book1D("Track3DposRes-LowMVA",
                    "3dPos_{PCA} - 3dPos_{sim} for tracks with MVA < 0.5 ;3dPos_{PCA} - 3dPos_{sim} [cm] ",
-                   100,
-                   -1.,
-                   1.);
+                   50,
+                   -0.5,
+                   0.5);
   meTrack3DposRes_[1] =
       ibook.book1D("Track3DposRes-MediumMVA",
                    "3dPos_{PCA} - 3dPos_{sim} for tracks with 0.5 < MVA < 0.8 ;3dPos_{PCA} - 3dPos_{sim} [cm] ",
-                   100,
-                   -1.,
-                   1.);
+                   50,
+                   -0.5,
+                   0.5);
   meTrack3DposRes_[2] =
       ibook.book1D("Track3DposRes-HighMVA",
                    "3dPos_{PCA} - 3dPos_{sim} for tracks with MVA > 0.8;3dPos_{PCA} - 3dPos_{sim} [cm] ",
-                   100,
-                   -1.,
-                   1.);
+                   50,
+                   -0.5,
+                   0.5);
   meTimeRes_ = ibook.book1D("TimeRes", "t_{rec} - t_{sim} ;t_{rec} - t_{sim} [ns] ", 40, -0.2, 0.2);
   meTimePull_ = ibook.book1D("TimePull", "Pull; t_{rec} - t_{sim}/#sigma_{t rec}", 100, -10., 10.);
   meTimeSignalRes_ =

--- a/Validation/MtdValidation/python/MtdPostProcessor_cff.py
+++ b/Validation/MtdValidation/python/MtdPostProcessor_cff.py
@@ -2,5 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 from Validation.MtdValidation.btlSimHitsPostProcessor_cfi import btlSimHitsPostProcessor
 from Validation.MtdValidation.MtdTracksPostProcessor_cfi import MtdTracksPostProcessor
+from Validation.MtdValidation.Primary4DVertexPostProcessor_cfi import Primary4DVertexPostProcessor
 
-mtdValidationPostProcessor = cms.Sequence(btlSimHitsPostProcessor + MtdTracksPostProcessor)
+mtdValidationPostProcessor = cms.Sequence(btlSimHitsPostProcessor + MtdTracksPostProcessor + Primary4DVertexPostProcessor)


### PR DESCRIPTION
#### PR description:

This PR extends the previous work integrated in #35482 in several ways:

- cleaning of existing plots for 4D vertex validation;
- move into vertex class plots for vertex validation previously in track validation;
- addition in track validation class of plots based on a reco-sim truth matching using ```GenParticle```s associated to the true PV, as done for the selection sued to compute the MVA MTD quality flag.

An harvester has been introduced also for ```MtdTracksValidation``` class

#### PR validation:

Test wf 34634.0 and 34834.0 (PU privately built) runs and produces expected plots.
