### PR TITLE
Use esConsumes in ListIds and TrackingMaterialAnalyser

### DIFF
--- a/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialAnalyser.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialAnalyser.cc
@@ -30,6 +30,7 @@
 TrackingMaterialAnalyser::TrackingMaterialAnalyser(const edm::ParameterSet& iPSet) {
   m_materialToken =
       consumes<std::vector<MaterialAccountingTrack> >(iPSet.getParameter<edm::InputTag>("MaterialAccounting"));
+  m_dddToken = esConsumes();
   m_groupNames = iPSet.getParameter<std::vector<std::string> >("Groups");
   const std::string& splitmode = iPSet.getParameter<std::string>("SplitMode");
   if (strcasecmp(splitmode.c_str(), "NearestLayer") == 0) {
@@ -152,8 +153,7 @@ void TrackingMaterialAnalyser::endJob(void) {
 //-------------------------------------------------------------------------
 void TrackingMaterialAnalyser::analyze(const edm::Event& event, const edm::EventSetup& setup) {
   using namespace edm;
-  ESTransientHandle<DDCompactView> hDDD;
-  setup.get<IdealGeometryRecord>().get(hDDD);
+  auto hDDD = setup.getHandle(m_dddToken);
 
   m_groups.reserve(m_groupNames.size());
   // Initialize m_groups iff it has size equal to zero, so that we are

--- a/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialAnalyser.h
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialAnalyser.h
@@ -33,6 +33,7 @@ private:
   void saveLayerPlots();
 
   edm::EDGetTokenT<std::vector<MaterialAccountingTrack> > m_materialToken;
+  edm::ESGetToken<DDCompactView, IdealGeometryRecord> m_dddToken;
   SplitMode m_splitMode;
   bool m_skipAfterLastDetector;
   bool m_skipBeforeFirstDetector;

--- a/SimTracker/TrackerMaterialAnalysis/plugins/dd4hep/DD4hep_ListIds.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/dd4hep/DD4hep_ListIds.cc
@@ -6,7 +6,6 @@
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ESTransientHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -32,17 +31,18 @@ private:
   // otherwise the matching will fail.
   bool printMaterial_;
   std::vector<std::string> materials_;
+  edm::ESGetToken<cms::DDCompactView, IdealGeometryRecord> cpvToken_;
 };
 
 DD4hep_ListIds::DD4hep_ListIds(const edm::ParameterSet &pset)
     : printMaterial_(pset.getUntrackedParameter<bool>("printMaterial")),
-      materials_(pset.getUntrackedParameter<std::vector<std::string> >("materials")) {}
+      materials_(pset.getUntrackedParameter<std::vector<std::string> >("materials")),
+      cpvToken_(esConsumes(edm::ESInputTag("", "CMS"))) {}
 
 DD4hep_ListIds::~DD4hep_ListIds() {}
 
 void DD4hep_ListIds::analyze(const edm::Event &evt, const edm::EventSetup &setup) {
-  edm::ESTransientHandle<cms::DDCompactView> cpv;
-  setup.get<IdealGeometryRecord>().get("CMS", cpv);
+  auto cpv = setup.getTransientHandle(cpvToken_);
 
   std::string attribute = "TkDDDStructure";
   cms::DDFilter filter(attribute, "");

--- a/SimTracker/TrackerMaterialAnalysis/plugins/dd4hep/DD4hep_TrackingMaterialAnalyser.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/dd4hep/DD4hep_TrackingMaterialAnalyser.cc
@@ -41,7 +41,7 @@ DD4hep_TrackingMaterialAnalyser::DD4hep_TrackingMaterialAnalyser(const edm::Para
         << "Invalid SplitMode \"" << splitmode
         << "\". Acceptable values are \"NearestLayer\", \"InnerLayer\", \"OuterLayer\".";
   }
-  m_tag = iPSet.getParameter<edm::ESInputTag>("DDDetector");
+  m_dddToken = esConsumes(iPSet.getParameter<edm::ESInputTag>("DDDetector"));
   m_skipAfterLastDetector = iPSet.getParameter<bool>("SkipAfterLastDetector");
   m_skipBeforeFirstDetector = iPSet.getParameter<bool>("SkipBeforeFirstDetector");
   m_saveSummaryPlot = iPSet.getParameter<bool>("SaveSummaryPlot");
@@ -153,8 +153,7 @@ void DD4hep_TrackingMaterialAnalyser::endJob(void) {
 //-------------------------------------------------------------------------
 void DD4hep_TrackingMaterialAnalyser::analyze(const edm::Event& event, const edm::EventSetup& setup) {
   using namespace edm;
-  ESTransientHandle<cms::DDCompactView> hDDD;
-  setup.get<IdealGeometryRecord>().get(m_tag, hDDD);
+  auto hDDD = setup.getTransientHandle(m_dddToken);
 
   m_groups.reserve(m_groupNames.size());
   // Initialize m_groups iff it has size equal to zero, so that we are

--- a/SimTracker/TrackerMaterialAnalysis/plugins/dd4hep/DD4hep_TrackingMaterialAnalyser.h
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/dd4hep/DD4hep_TrackingMaterialAnalyser.h
@@ -33,7 +33,7 @@ private:
   void saveLayerPlots();
 
   edm::EDGetTokenT<std::vector<MaterialAccountingTrack> > m_materialToken;
-  edm::ESInputTag m_tag;
+  edm::ESGetToken<cms::DDCompactView, IdealGeometryRecord> m_dddToken;
   SplitMode m_splitMode;
   bool m_skipAfterLastDetector;
   bool m_skipBeforeFirstDetector;


### PR DESCRIPTION
#### PR description:

Part of #31061.

#### PR validation:

Code compiles, and tests of `SimTracker/TrackerMaterialAnalysis` run successfully with https://github.com/cms-sw/cmssw/pull/35588.