### PR TITLE
correct cfi files to link to latest PPS geometry

### DIFF
--- a/Geometry/VeryForwardGeometry/data/dd4hep/v4/geometryRPFromDD_2021.xml
+++ b/Geometry/VeryForwardGeometry/data/dd4hep/v4/geometryRPFromDD_2021.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0"?>
+<DDDefinition>
+  <open_geometry/>
+  <close_geometry/>
+  
+  <IncludeSection>
+    # common and strip files
+    <Include ref="Geometry/CMSCommonData/data/materials.xml"/>
+    <Include ref="Geometry/CMSCommonData/data/rotations.xml"/>
+    <Include ref="Geometry/CMSCommonData/data/extend/cmsextent.xml"/>
+    <Include ref="Geometry/CMSCommonData/data/cms/2017/v1/cms.xml"/>
+    <Include ref="Geometry/CMSCommonData/data/beampipe/2017/v1/beampipe.xml"/>
+    <Include ref="Geometry/CMSCommonData/data/cmsBeam.xml"/>
+    <Include ref="Geometry/CMSCommonData/data/cmsMother.xml"/>
+    <Include ref="Geometry/CMSCommonData/data/mgnt.xml"/>
+    <Include ref="Geometry/TrackerCommonData/data/trackermaterial/2021/v1/trackermaterial.xml"/>
+    <Include ref="Geometry/TrackerCommonData/data/pixfwdMaterials/2021/v2/pixfwdMaterials.xml"/>
+    <Include ref="Geometry/ForwardCommonData/data/forward.xml"/>
+    <Include ref="Geometry/ForwardCommonData/data/totemRotations.xml"/>
+    <Include ref="Geometry/ForwardCommonData/data/totemMaterials.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_000.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_001.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_002.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_003.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_004.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_005.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_020.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_021.xml"/>
+    <!--<Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_022.xml"/>-->
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_023.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_024.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_025.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_100.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_101.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_102.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_103.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_104.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_105.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_120.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_121.xml"/>
+    <!--<Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_122.xml"/>-->
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_123.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_124.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_125.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Hybrid/v2/RP_Hybrid.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Materials/v4/RP_Materials.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Transformations.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Detectors_Assembly.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_000.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_001.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_002.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_004.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_005.xml"/>
+    <!--<Include ref="Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_022.xml"/>-->
+    <Include ref="Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_024.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_025.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_100.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_101.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_102.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_104.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_105.xml"/>
+    <!--<Include ref="Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_122.xml"/>-->
+    <Include ref="Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_124.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_125.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Device.xml"/>
+
+    <Include ref="Geometry/VeryForwardData/data/RP_Vertical_Device/2021/Reco/v2/RP_Vertical_Device.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Horizontal_Device/2021/Reco/v2/RP_Horizontal_Device.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_2021/Stations/Reco/v2/RP_220_Right_Station.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_2021/Stations/Reco/v2/RP_210_Right_Station.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_2021/Stations/Reco/v2/RP_220_Left_Station.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_2021/Stations/Reco/v2/RP_210_Left_Station.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_2021/Stations/Reco/v1/RP_Stations_Assembly.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Sensitive_Dets.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_2021/Cuts_Per_Region/Reco/v1/RP_Cuts_Per_Region.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_2021/RP_Param_Beam_Region/v1/RP_Param_Beam_Region.xml"/>
+
+    # diamond files
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_Materials.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_Transformations.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_X_Distance.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_Parameters.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Timing_Station_Parameters.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Timing_Horizontal_Pot/v2/CTPPS_Timing_Horizontal_Pot.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Timing_Positive_Station/v1/CTPPS_Timing_Positive_Station.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Timing_Negative_Station/v1/CTPPS_Timing_Negative_Station.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_2021/Reco/v1/CTPPS_Timing_Stations_Assembly.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern1_Segment1.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern2_Segment1.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern2_Segment2.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern3_Segment1.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern3_Segment2.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern3_Segment3.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern3_Segment4.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern4_Segment1.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern4_Segment2.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern4_Segment3.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern4_Segment4.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern4_Segment5.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_2021/CTPPS_Diamond_Planes/CTPPS_Diamond_Plane1.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_2021/CTPPS_Diamond_Planes/CTPPS_Diamond_Plane2.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_2021/CTPPS_Diamond_Planes/CTPPS_Diamond_Plane3.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_2021/CTPPS_Diamond_Planes/CTPPS_Diamond_Plane4.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_2021/CTPPS_Diamond_Detector_Assembly/v1/CTPPS_Diamond_Detector_Assembly.xml"/>
+
+    # Totem Timing files
+    <Include ref="Geometry/VeryForwardData/data/TotemTiming/TotemTiming_Dist_Beam_Cent.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/TotemTiming/TotemTiming_DetectorAssembly.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/TotemTiming/TotemTiming_Parameters.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/TotemTiming/TotemTiming_Plane.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/TotemTiming/v1/TotemTiming_Station.xml"/>
+
+    # pixel files
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Modules/v2/ppstrackerMaterials.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Modules/v3/PPS_Pixel_Module_2x2_Run3.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Modules/v2/PPS_Pixel_Sens.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Assembly/v2/CTPPS_Pixel_Assembly_Box_Real_003.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Assembly/v2/CTPPS_Pixel_Assembly_Box_Real_023.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Assembly/v2/CTPPS_Pixel_Assembly_Box_Real_103.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Assembly/v2/CTPPS_Pixel_Assembly_Box_Real_123.xml"/>
+
+    # RP distance
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_2021/RP_Dist_Beam_Cent/Reco/v1/RP_Dist_Beam_Cent.xml"/>    
+            
+  </IncludeSection>
+</DDDefinition> 

--- a/Geometry/VeryForwardGeometry/python/dd4hep/geometryRPFromDD_2021_cfi.py
+++ b/Geometry/VeryForwardGeometry/python/dd4hep/geometryRPFromDD_2021_cfi.py
@@ -1,18 +1,1 @@
-import FWCore.ParameterSet.Config as cms
-
-DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
-                                            confGeomXMLFiles = cms.FileInPath('Geometry/VeryForwardGeometry/data/dd4hep/v1/geometryRPFromDD_2021.xml'),
-                                            appendToDataLabel = cms.string('XMLIdealGeometryESSource_CTPPS')
-)
-
-DDCompactViewESProducer = cms.ESProducer("DDCompactViewESProducer",
-                                            appendToDataLabel = cms.string('XMLIdealGeometryESSource_CTPPS')
-)
-
-ctppsGeometryESModule = cms.ESProducer("CTPPSGeometryESModule",
-    fromDD4hep = cms.untracked.bool(True),
-    isRun2 = cms.bool(False),
-    verbosity = cms.untracked.uint32(1),
-    compactViewTag = cms.string('XMLIdealGeometryESSource_CTPPS')
-)
-
+from Geometry.VeryForwardGeometry.dd4hep.v4.geometryRPFromDD_2021_cfi import *

--- a/Geometry/VeryForwardGeometry/python/dd4hep/v4/geometryRPFromDD_2021_cfi.py
+++ b/Geometry/VeryForwardGeometry/python/dd4hep/v4/geometryRPFromDD_2021_cfi.py
@@ -1,0 +1,18 @@
+import FWCore.ParameterSet.Config as cms
+
+DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
+                                            confGeomXMLFiles = cms.FileInPath('Geometry/VeryForwardGeometry/data/dd4hep/v4/geometryRPFromDD_2021.xml'),
+                                            appendToDataLabel = cms.string('XMLIdealGeometryESSource_CTPPS')
+)
+
+DDCompactViewESProducer = cms.ESProducer("DDCompactViewESProducer",
+                                            appendToDataLabel = cms.string('XMLIdealGeometryESSource_CTPPS')
+)
+
+ctppsGeometryESModule = cms.ESProducer("CTPPSGeometryESModule",
+    fromDD4hep = cms.untracked.bool(True),
+    isRun2 = cms.bool(False),
+    verbosity = cms.untracked.uint32(1),
+    compactViewTag = cms.string('XMLIdealGeometryESSource_CTPPS')
+)
+

--- a/Geometry/VeryForwardGeometry/python/geometryRPFromDD_2021_cfi.py
+++ b/Geometry/VeryForwardGeometry/python/geometryRPFromDD_2021_cfi.py
@@ -1,1 +1,1 @@
-from Geometry.VeryForwardGeometry.v1.geometryRPFromDD_2021_cfi import *
+from Geometry.VeryForwardGeometry.v2.geometryRPFromDD_2021_cfi import *

--- a/Geometry/VeryForwardGeometry/python/geometryRPFromDD_2022_cfi.py
+++ b/Geometry/VeryForwardGeometry/python/geometryRPFromDD_2022_cfi.py
@@ -1,1 +1,1 @@
-from Geometry.VeryForwardGeometry.v1.geometryRPFromDD_2022_cfi import *
+from Geometry.VeryForwardGeometry.v2.geometryRPFromDD_2022_cfi import *

--- a/Geometry/VeryForwardGeometry/python/v2/geometryRPFromDD_2021_cfi.py
+++ b/Geometry/VeryForwardGeometry/python/v2/geometryRPFromDD_2021_cfi.py
@@ -1,0 +1,142 @@
+import FWCore.ParameterSet.Config as cms
+
+# common and strip files
+totemGeomXMLFiles = cms.vstring(
+    'Geometry/CMSCommonData/data/materials.xml',
+    'Geometry/CMSCommonData/data/rotations.xml',
+    'Geometry/CMSCommonData/data/extend/cmsextent.xml',
+    'Geometry/CMSCommonData/data/cms/2017/v1/cms.xml',
+    'Geometry/CMSCommonData/data/beampipe/2017/v1/beampipe.xml',
+    'Geometry/CMSCommonData/data/cmsBeam.xml',
+    'Geometry/CMSCommonData/data/cmsMother.xml',
+    'Geometry/CMSCommonData/data/mgnt.xml',
+    'Geometry/TrackerCommonData/data/trackermaterial/2021/v1/trackermaterial.xml',
+    'Geometry/TrackerCommonData/data/pixfwdMaterials/2021/v2/pixfwdMaterials.xml',
+    'Geometry/ForwardCommonData/data/forward.xml',
+    'Geometry/ForwardCommonData/data/totemRotations.xml',
+    'Geometry/ForwardCommonData/data/totemMaterials.xml',
+    'Geometry/VeryForwardData/data/RP_Box.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_000.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_001.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_002.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_003.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_004.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_005.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_020.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_021.xml',
+#    'Geometry/VeryForwardData/data/RP_Boxv3//RP_Box_022.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_023.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_024.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_025.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_100.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_101.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_102.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_103.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_104.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_105.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_120.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_121.xml',
+#    'Geometry/VeryForwardData/data/RP_Boxv3//RP_Box_122.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_123.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_124.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_125.xml',
+    'Geometry/VeryForwardData/data/RP_Hybrid/v2/RP_Hybrid.xml',
+    'Geometry/VeryForwardData/data/RP_Materials/v4/RP_Materials.xml',
+    'Geometry/VeryForwardData/data/RP_Transformations.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_000.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_001.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_002.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_004.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_005.xml',
+#    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_022.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_024.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_025.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_100.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_101.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_102.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_104.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_105.xml',
+#    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_122.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_124.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_125.xml',
+    'Geometry/VeryForwardData/data/RP_Device.xml',
+    'Geometry/VeryForwardData/data/RP_Vertical_Device/2021/Reco/v2/RP_Vertical_Device.xml',
+    'Geometry/VeryForwardData/data/RP_Horizontal_Device/2021/Reco/v2/RP_Horizontal_Device.xml',
+    'Geometry/VeryForwardData/data/CTPPS_2021/Stations/Reco/v2/RP_220_Right_Station.xml',
+    'Geometry/VeryForwardData/data/CTPPS_2021/Stations/Reco/v2/RP_210_Right_Station.xml',
+    'Geometry/VeryForwardData/data/CTPPS_2021/Stations/Reco/v2/RP_220_Left_Station.xml',
+    'Geometry/VeryForwardData/data/CTPPS_2021/Stations/Reco/v2/RP_210_Left_Station.xml',
+    'Geometry/VeryForwardData/data/CTPPS_2021/Stations/Reco/v1/RP_Stations_Assembly.xml',
+
+    'Geometry/VeryForwardData/data/RP_Sensitive_Dets.xml',
+    'Geometry/VeryForwardData/data/CTPPS_2021/Cuts_Per_Region/Reco/v1/RP_Cuts_Per_Region.xml',
+
+    'Geometry/VeryForwardData/data/CTPPS_2021/RP_Param_Beam_Region/v1/RP_Param_Beam_Region.xml'
+    )
+
+# diamond files
+ctppsDiamondGeomXMLFiles = cms.vstring(
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Materials.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Transformations.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_X_Distance.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Parameters.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Timing_Station_Parameters.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Timing_Horizontal_Pot/v2/CTPPS_Timing_Horizontal_Pot.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Timing_Positive_Station/v1/CTPPS_Timing_Positive_Station.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Timing_Negative_Station/v1/CTPPS_Timing_Negative_Station.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_2021/Reco/v1/CTPPS_Timing_Stations_Assembly.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern1_Segment1.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern2_Segment1.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern2_Segment2.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern3_Segment1.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern3_Segment2.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern3_Segment3.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern3_Segment4.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern4_Segment1.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern4_Segment2.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern4_Segment3.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern4_Segment4.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern4_Segment5.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_2021/CTPPS_Diamond_Planes/CTPPS_Diamond_Plane1.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_2021/CTPPS_Diamond_Planes/CTPPS_Diamond_Plane2.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_2021/CTPPS_Diamond_Planes/CTPPS_Diamond_Plane3.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_2021/CTPPS_Diamond_Planes/CTPPS_Diamond_Plane4.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_2021/CTPPS_Diamond_Detector_Assembly/v1/CTPPS_Diamond_Detector_Assembly.xml'
+    )
+
+
+# Totem Timing files
+totemTimingGeomXMLFiles = cms.vstring(
+    # UFSDetectors
+    'Geometry/VeryForwardData/data/TotemTiming/TotemTiming_Dist_Beam_Cent.xml',
+    'Geometry/VeryForwardData/data/TotemTiming/TotemTiming_DetectorAssembly.xml',
+    'Geometry/VeryForwardData/data/TotemTiming/TotemTiming_Parameters.xml',
+    'Geometry/VeryForwardData/data/TotemTiming/TotemTiming_Plane.xml',
+    'Geometry/VeryForwardData/data/TotemTiming/v1/TotemTiming_Station.xml',
+    )
+
+# pixel files
+ctppsPixelGeomXMLFiles = cms.vstring(
+    'Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Modules/v2/ppstrackerMaterials.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Modules/v3/PPS_Pixel_Module_2x2_Run3.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Modules/v2/PPS_Pixel_Sens.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Assembly/v2/CTPPS_Pixel_Assembly_Box_Real_003.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Assembly/v2/CTPPS_Pixel_Assembly_Box_Real_023.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Assembly/v2/CTPPS_Pixel_Assembly_Box_Real_103.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Assembly/v2/CTPPS_Pixel_Assembly_Box_Real_123.xml'
+    )
+
+XMLIdealGeometryESSource_CTPPS = cms.ESSource("XMLIdealGeometryESSource",
+                                              geomXMLFiles = totemGeomXMLFiles + ctppsDiamondGeomXMLFiles + totemTimingGeomXMLFiles + ctppsPixelGeomXMLFiles,
+                                              rootNodeName = cms.string('cms:CMSE')
+                                              )
+
+# position of RPs
+XMLIdealGeometryESSource_CTPPS.geomXMLFiles.append("Geometry/VeryForwardData/data/CTPPS_2021/RP_Dist_Beam_Cent/Reco/v1/RP_Dist_Beam_Cent.xml")
+
+ctppsGeometryESModule = cms.ESProducer("CTPPSGeometryESModule",
+    verbosity = cms.untracked.uint32(1),
+    isRun2 = cms.bool(False),
+    compactViewTag = cms.string('XMLIdealGeometryESSource_CTPPS')
+)

--- a/Geometry/VeryForwardGeometry/python/v2/geometryRPFromDD_2022_cfi.py
+++ b/Geometry/VeryForwardGeometry/python/v2/geometryRPFromDD_2022_cfi.py
@@ -1,0 +1,142 @@
+import FWCore.ParameterSet.Config as cms
+
+# common and strip files
+totemGeomXMLFiles = cms.vstring(
+    'Geometry/CMSCommonData/data/materials.xml',
+    'Geometry/CMSCommonData/data/rotations.xml',
+    'Geometry/CMSCommonData/data/extend/cmsextent.xml',
+    'Geometry/CMSCommonData/data/cms/2017/v1/cms.xml',
+    'Geometry/CMSCommonData/data/beampipe/2017/v1/beampipe.xml',
+    'Geometry/CMSCommonData/data/cmsBeam.xml',
+    'Geometry/CMSCommonData/data/cmsMother.xml',
+    'Geometry/CMSCommonData/data/mgnt.xml',
+    'Geometry/TrackerCommonData/data/trackermaterial/2021/v1/trackermaterial.xml',
+    'Geometry/TrackerCommonData/data/pixfwdMaterials/2021/v2/pixfwdMaterials.xml',
+    'Geometry/ForwardCommonData/data/forward.xml',
+    'Geometry/ForwardCommonData/data/totemRotations.xml',
+    'Geometry/ForwardCommonData/data/totemMaterials.xml',
+    'Geometry/VeryForwardData/data/RP_Box.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_000.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_001.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_002.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_003.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_004.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_005.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_020.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_021.xml',
+#    'Geometry/VeryForwardData/data/RP_Boxv3//RP_Box_022.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_023.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_024.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_025.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_100.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_101.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_102.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_103.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_104.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_105.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_120.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_121.xml',
+#    'Geometry/VeryForwardData/data/RP_Boxv3//RP_Box_122.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_123.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_124.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_125.xml',
+    'Geometry/VeryForwardData/data/RP_Hybrid/v2/RP_Hybrid.xml',
+    'Geometry/VeryForwardData/data/RP_Materials/v4/RP_Materials.xml',
+    'Geometry/VeryForwardData/data/RP_Transformations.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_000.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_001.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_002.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_004.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_005.xml',
+#    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_022.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_024.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_025.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_100.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_101.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_102.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_104.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_105.xml',
+#    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_122.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_124.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_125.xml',
+    'Geometry/VeryForwardData/data/RP_Device.xml',
+    'Geometry/VeryForwardData/data/RP_Vertical_Device/2021/Reco/v2/RP_Vertical_Device.xml',
+    'Geometry/VeryForwardData/data/RP_Horizontal_Device/2021/Reco/v2/RP_Horizontal_Device.xml',
+    'Geometry/VeryForwardData/data/CTPPS_2021/Stations/Reco/v2/RP_220_Right_Station.xml',
+    'Geometry/VeryForwardData/data/CTPPS_2021/Stations/Reco/v2/RP_210_Right_Station.xml',
+    'Geometry/VeryForwardData/data/CTPPS_2021/Stations/Reco/v2/RP_220_Left_Station.xml',
+    'Geometry/VeryForwardData/data/CTPPS_2021/Stations/Reco/v2/RP_210_Left_Station.xml',
+    'Geometry/VeryForwardData/data/CTPPS_2021/Stations/Reco/v1/RP_Stations_Assembly.xml',
+
+    'Geometry/VeryForwardData/data/RP_Sensitive_Dets.xml',
+    'Geometry/VeryForwardData/data/CTPPS_2021/Cuts_Per_Region/Reco/v1/RP_Cuts_Per_Region.xml',
+
+    'Geometry/VeryForwardData/data/CTPPS_2021/RP_Param_Beam_Region/v1/RP_Param_Beam_Region.xml'
+    )
+
+# diamond files
+ctppsDiamondGeomXMLFiles = cms.vstring(
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Materials.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Transformations.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_X_Distance.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Parameters.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Timing_Station_Parameters.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Timing_Horizontal_Pot/v2/CTPPS_Timing_Horizontal_Pot.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Timing_Positive_Station/v1/CTPPS_Timing_Positive_Station.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Timing_Negative_Station/v1/CTPPS_Timing_Negative_Station.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_2021/Reco/v1/CTPPS_Timing_Stations_Assembly.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern1_Segment1.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern2_Segment1.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern2_Segment2.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern3_Segment1.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern3_Segment2.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern3_Segment3.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern3_Segment4.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern4_Segment1.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern4_Segment2.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern4_Segment3.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern4_Segment4.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern4_Segment5.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_2021/CTPPS_Diamond_Planes/CTPPS_Diamond_Plane1.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_2021/CTPPS_Diamond_Planes/CTPPS_Diamond_Plane2.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_2021/CTPPS_Diamond_Planes/CTPPS_Diamond_Plane3.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_2021/CTPPS_Diamond_Planes/CTPPS_Diamond_Plane4.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_2021/CTPPS_Diamond_Detector_Assembly/v1/CTPPS_Diamond_Detector_Assembly.xml'
+    )
+
+
+# Totem Timing files
+totemTimingGeomXMLFiles = cms.vstring(
+    # UFSDetectors
+    'Geometry/VeryForwardData/data/TotemTiming/TotemTiming_Dist_Beam_Cent.xml',
+    'Geometry/VeryForwardData/data/TotemTiming/TotemTiming_DetectorAssembly.xml',
+    'Geometry/VeryForwardData/data/TotemTiming/TotemTiming_Parameters.xml',
+    'Geometry/VeryForwardData/data/TotemTiming/TotemTiming_Plane.xml',
+    'Geometry/VeryForwardData/data/TotemTiming/v1/TotemTiming_Station.xml',
+    )
+
+# pixel files
+ctppsPixelGeomXMLFiles = cms.vstring(
+    'Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Modules/v2/ppstrackerMaterials.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Modules/v3/PPS_Pixel_Module_2x2_Run3.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Modules/v2/PPS_Pixel_Sens.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Assembly/v2/CTPPS_Pixel_Assembly_Box_Real_003.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Assembly/v2/CTPPS_Pixel_Assembly_Box_Real_023.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Assembly/v2/CTPPS_Pixel_Assembly_Box_Real_103.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Assembly/v2/CTPPS_Pixel_Assembly_Box_Real_123.xml'
+    )
+
+XMLIdealGeometryESSource_CTPPS = cms.ESSource("XMLIdealGeometryESSource",
+                                              geomXMLFiles = totemGeomXMLFiles + ctppsDiamondGeomXMLFiles + totemTimingGeomXMLFiles + ctppsPixelGeomXMLFiles,
+                                              rootNodeName = cms.string('cms:CMSE')
+                                              )
+
+# position of RPs
+XMLIdealGeometryESSource_CTPPS.geomXMLFiles.append("Geometry/VeryForwardData/data/CTPPS_2021/RP_Dist_Beam_Cent/Reco/v1/RP_Dist_Beam_Cent.xml")
+
+ctppsGeometryESModule = cms.ESProducer("CTPPSGeometryESModule",
+    verbosity = cms.untracked.uint32(1),
+    isRun2 = cms.bool(False),
+    compactViewTag = cms.string('XMLIdealGeometryESSource_CTPPS')
+)


### PR DESCRIPTION
#### PR description:

Given the corrected material introduced in #35961, this PR is meant to correct the cfi files (2021 and 2022) to point to the latest PPS geometry with the corrected material. No major changes are proposed. One dd4hep cfi file is updated to contain a link to the latest dd4hep geometry (now v4).

#### PR validation:

Geometry dump script confirms no error related to the reco geometry. PPS direct simulation confirms no change in the geometry. Script to produce DB payload for DDD and dd4hep used to confirm no issues with the list of XML files. More details [here](https://twiki.cern.ch/twiki/bin/view/CMS/PPSGeometryFix122X) 

Basic checks passed.
Code checks passed.
Matrix test passed 42 41 40 30 18 4 1 1 1 1 tests passed, 0 0 0 0 0 0 0 0 0 0 failed

FYI @fabferro @jan-kaspar @wpcarvalho 