### PR TITLE
migrate SiStrip codes to new `PoolDBOutputService` methods

### DIFF
--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripApvGainBuilderFromTag.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripApvGainBuilderFromTag.cc
@@ -40,7 +40,7 @@ void SiStripApvGainBuilderFromTag::analyze(const edm::Event& evt, const edm::Eve
   inputApvGain.getDetIds(inputDetIds);
 
   // Prepare the new object
-  SiStripApvGain* obj = new SiStripApvGain();
+  SiStripApvGain obj;
 
   uint32_t count = 0;
   for (const auto det : tGeom.detUnits()) {
@@ -94,7 +94,7 @@ void SiStripApvGainBuilderFromTag::analyze(const edm::Event& evt, const edm::Eve
       }
       count++;
       SiStripApvGain::Range range(theSiStripVector.begin(), theSiStripVector.end());
-      if (!obj->put(detid, range))
+      if (!obj.put(detid, range))
         edm::LogError("SiStripApvGainGeneratorFromTag") << " detid already exists" << std::endl;
     }
   }
@@ -104,10 +104,9 @@ void SiStripApvGainBuilderFromTag::analyze(const edm::Event& evt, const edm::Eve
 
   if (mydbservice.isAvailable()) {
     if (mydbservice->isNewTagRequest("SiStripApvGainRcd2")) {
-      mydbservice->createNewIOV<SiStripApvGain>(
-          obj, mydbservice->beginOfTime(), mydbservice->endOfTime(), "SiStripApvGainRcd2");
+      mydbservice->createOneIOV<SiStripApvGain>(obj, mydbservice->beginOfTime(), "SiStripApvGainRcd2");
     } else {
-      mydbservice->appendSinceTime<SiStripApvGain>(obj, mydbservice->currentTime(), "SiStripApvGainRcd2");
+      mydbservice->appendOneIOV<SiStripApvGain>(obj, mydbservice->currentTime(), "SiStripApvGainRcd2");
     }
   } else {
     edm::LogError("SiStripApvGainBuilderFromTag") << "Service is unavailable" << std::endl;

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripNoiseNormalizedWithApvGainBuilder.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripNoiseNormalizedWithApvGainBuilder.cc
@@ -30,7 +30,7 @@ void SiStripNoiseNormalizedWithApvGainBuilder::analyze(const edm::Event& evt, co
   inputApvGain.getDetIds(inputDetIds);
 
   // Prepare the new object
-  SiStripNoises* obj = new SiStripNoises();
+  SiStripNoises obj;
 
   stripLengthMode_ = pset_.getParameter<bool>("StripLengthMode");
 
@@ -72,7 +72,7 @@ void SiStripNoiseNormalizedWithApvGainBuilder::analyze(const edm::Event& evt, co
             noise = ((linearSlope * stripLength + linearQuote) / electronsPerADC_) * gain;
             if (count < printDebug_)
               printLog(detId, stripId + 128 * j, noise);
-            obj->setData(noise, theSiStripVector);
+            obj.setData(noise, theSiStripVector);
           }
         }
       } else {
@@ -88,13 +88,13 @@ void SiStripNoiseNormalizedWithApvGainBuilder::analyze(const edm::Event& evt, co
               noise = minimumPosValue_;
             if (count < printDebug_)
               printLog(detId, stripId + 128 * j, noise);
-            obj->setData(noise, theSiStripVector);
+            obj.setData(noise, theSiStripVector);
           }
         }
       }
       ++count;
 
-      if (!obj->put(detId, theSiStripVector)) {
+      if (!obj.put(detId, theSiStripVector)) {
         edm::LogError("SiStripNoisesFakeESSource::produce ") << " detid already exists" << std::endl;
       }
     }
@@ -105,10 +105,9 @@ void SiStripNoiseNormalizedWithApvGainBuilder::analyze(const edm::Event& evt, co
 
   if (mydbservice.isAvailable()) {
     if (mydbservice->isNewTagRequest("SiStripNoisesRcd")) {
-      mydbservice->createNewIOV<SiStripNoises>(
-          obj, mydbservice->beginOfTime(), mydbservice->endOfTime(), "SiStripNoisesRcd");
+      mydbservice->createOneIOV<SiStripNoises>(obj, mydbservice->beginOfTime(), "SiStripNoisesRcd");
     } else {
-      mydbservice->appendSinceTime<SiStripNoises>(obj, mydbservice->currentTime(), "SiStripNoisesRcd");
+      mydbservice->appendOneIOV<SiStripNoises>(obj, mydbservice->currentTime(), "SiStripNoisesRcd");
     }
   } else {
     edm::LogError("SiStripNoiseNormalizedWithApvGainBuilder") << "Service is unavailable" << std::endl;

--- a/CalibTracker/SiStripLorentzAngle/plugins/SiStripCalibLorentzAngle.cc
+++ b/CalibTracker/SiStripLorentzAngle/plugins/SiStripCalibLorentzAngle.cc
@@ -2,7 +2,6 @@
 #include <string>
 #include <iostream>
 #include <fstream>
-#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"

--- a/CalibTracker/SiStripQuality/plugins/SiStripBadStripFromQualityDBWriter.cc
+++ b/CalibTracker/SiStripQuality/plugins/SiStripBadStripFromQualityDBWriter.cc
@@ -55,7 +55,7 @@ void SiStripBadStripFromQualityDBWriter::dqmEndJob(DQMStore::IBooker& /*booker*/
     else
       time = openIOVAtTime_;
 
-    dbservice->writeOne(payload.release(), time, rcdName_);
+    dbservice->writeOneIOV(*payload, time, rcdName_);
   } else {
     edm::LogError("SiStripBadStripFromQualityDBWriter") << "Service is unavailable" << std::endl;
   }

--- a/CondFormats/PhysicsToolsObjects/test/SiStripDeDx2DBuilder.cc
+++ b/CondFormats/PhysicsToolsObjects/test/SiStripDeDx2DBuilder.cc
@@ -39,7 +39,7 @@ void SiStripDeDx2DBuilder::analyze(const edm::Event& evt, const edm::EventSetup&
       << "... creating dummy PhysicsToolsObjects::Calibration::HistogramD2D Data for Run " << run << "\n " << std::endl;
 
   //  PhysicsToolsObjects::Calibration::HistogramD2D* obj = new PhysicsTools::Calibration::HistogramD2D(300, 0., 3., 1000,0.,1000.);
-  PhysicsTools::Calibration::VHistogramD2D* obj = new PhysicsTools::Calibration::VHistogramD2D();
+  PhysicsTools::Calibration::VHistogramD2D obj;
 
   for (int ih = 0; ih < 3; ih++) {
     PhysicsTools::Calibration::HistogramD2D myhist(300, 0., 3., 1000, 0., 1000.);
@@ -49,8 +49,8 @@ void SiStripDeDx2DBuilder::analyze(const edm::Event& evt, const edm::EventSetup&
       }
     }
 
-    (obj->vHist).push_back(myhist);
-    (obj->vValues).push_back(ih);
+    (obj.vHist).push_back(myhist);
+    (obj.vValues).push_back(ih);
   }
 
   //  SiStripDetInfoFileReader reader(fp_.fullPath());
@@ -72,7 +72,7 @@ void SiStripDeDx2DBuilder::analyze(const edm::Event& evt, const edm::EventSetup&
   //     }
 
   //     PhysicsToolsObjects::Calibration::HistogramD2D::Range range(theSiStripVector.begin(),theSiStripVector.end());
-  //     if ( ! obj->put(it->first,range) )
+  //     if ( ! obj.put(it->first,range) )
 
   //      edm::LogError("PhysicsToolsObjects::Calibration::HistogramD2DBuilder")<<"[PhysicsToolsObjects::Calibration::HistogramD2DBuilder::analyze] detid already exists"<<std::endl;
   //  }
@@ -82,10 +82,10 @@ void SiStripDeDx2DBuilder::analyze(const edm::Event& evt, const edm::EventSetup&
 
   if (mydbservice.isAvailable()) {
     if (mydbservice->isNewTagRequest("SiStripDeDxProton_2D_Rcd")) {
-      mydbservice->createNewIOV<PhysicsTools::Calibration::VHistogramD2D>(
-          obj, mydbservice->beginOfTime(), mydbservice->endOfTime(), "SiStripDeDxProton_2D_Rcd");
+      mydbservice->createOneIOV<PhysicsTools::Calibration::VHistogramD2D>(
+          obj, mydbservice->beginOfTime(), "SiStripDeDxProton_2D_Rcd");
     } else {
-      mydbservice->appendSinceTime<PhysicsTools::Calibration::VHistogramD2D>(
+      mydbservice->appendOneIOV<PhysicsTools::Calibration::VHistogramD2D>(
           obj, mydbservice->currentTime(), "SiStripDeDxProton_2D_Rcd");
     }
   } else {

--- a/CondFormats/PhysicsToolsObjects/test/SiStripDeDx3DBuilder.cc
+++ b/CondFormats/PhysicsToolsObjects/test/SiStripDeDx3DBuilder.cc
@@ -39,14 +39,13 @@ void SiStripDeDx3DBuilder::analyze(const edm::Event& evt, const edm::EventSetup&
       << "... creating dummy PhysicsToolsObjects::Calibration::HistogramD3D Data for Run " << run << "\n " << std::endl;
 
   //  PhysicsToolsObjects::Calibration::HistogramD2D* obj = new PhysicsTools::Calibration::HistogramD2D(300, 0., 3., 1000,0.,1000.);
-  PhysicsTools::Calibration::HistogramD3D* obj =
-      new PhysicsTools::Calibration::HistogramD3D(5, 0, 5, 100, 0., 3., 100, 0., 1000.);
+  PhysicsTools::Calibration::HistogramD3D obj(5, 0, 5, 100, 0., 3., 100, 0., 1000.);
 
   for (int ix = 0; ix < 5; ix++) {
     for (int iy = 0; iy < 100; iy++) {
       for (int iz = 0; iz < 100; iz++) {
         //        edm::LogInfo("SiStripDeDx3DBuilder") << "X = " << ix << " Y = " << iy << " Z = " << iz << std::endl;
-        obj->setBinContent(ix, iy, iz, ix + 2 * iy + 3 * iz);
+        obj.setBinContent(ix, iy, iz, ix + 2 * iy + 3 * iz);
       }
     }
   }
@@ -57,10 +56,10 @@ void SiStripDeDx3DBuilder::analyze(const edm::Event& evt, const edm::EventSetup&
 
   if (mydbservice.isAvailable()) {
     if (mydbservice->isNewTagRequest("SiStripDeDxProton_3D_Rcd")) {
-      mydbservice->createNewIOV<PhysicsTools::Calibration::HistogramD3D>(
-          obj, mydbservice->beginOfTime(), mydbservice->endOfTime(), "SiStripDeDxProton_3D_Rcd");
+      mydbservice->createOneIOV<PhysicsTools::Calibration::HistogramD3D>(
+          obj, mydbservice->beginOfTime(), "SiStripDeDxProton_3D_Rcd");
     } else {
-      mydbservice->appendSinceTime<PhysicsTools::Calibration::HistogramD3D>(
+      mydbservice->appendOneIOV<PhysicsTools::Calibration::HistogramD3D>(
           obj, mydbservice->currentTime(), "SiStripDeDxProton_3D_Rcd");
     }
   } else {

--- a/CondFormats/PhysicsToolsObjects/test/SiStripDeDxMipBuilder.cc
+++ b/CondFormats/PhysicsToolsObjects/test/SiStripDeDxMipBuilder.cc
@@ -16,12 +16,11 @@ void SiStripDeDxMipBuilder::analyze(const edm::Event& evt, const edm::EventSetup
       << "... creating dummy PhysicsToolsObjects::Calibration::HistogramD2D Data for Run " << run << "\n " << std::endl;
 
   //  PhysicsToolsObjects::Calibration::HistogramD2D* obj = new PhysicsTools::Calibration::HistogramD2D(300, 0., 3., 1000,0.,1000.);
-  PhysicsTools::Calibration::HistogramD2D* obj =
-      new PhysicsTools::Calibration::HistogramD2D(300, 0., 3., 1000, 0., 1000.);
+  PhysicsTools::Calibration::HistogramD2D obj(300, 0., 3., 1000, 0., 1000.);
 
   for (int ix = 0; ix < 300; ix++) {
     for (int iy = 0; iy < 1000; iy++) {
-      obj->setBinContent(ix, iy, iy / 999.);
+      obj.setBinContent(ix, iy, iy / 999.);
     }
   }
 
@@ -44,7 +43,7 @@ void SiStripDeDxMipBuilder::analyze(const edm::Event& evt, const edm::EventSetup
   //     }
 
   //     PhysicsToolsObjects::Calibration::HistogramD2D::Range range(theSiStripVector.begin(),theSiStripVector.end());
-  //     if ( ! obj->put(it->first,range) )
+  //     if ( ! obj.put(it->first,range) )
 
   //      edm::LogError("PhysicsToolsObjects::Calibration::HistogramD2DBuilder")<<"[PhysicsToolsObjects::Calibration::HistogramD2DBuilder::analyze] detid already exists"<<std::endl;
   //  }
@@ -54,10 +53,10 @@ void SiStripDeDxMipBuilder::analyze(const edm::Event& evt, const edm::EventSetup
 
   if (mydbservice.isAvailable()) {
     if (mydbservice->isNewTagRequest("SiStripDeDxMipRcd")) {
-      mydbservice->createNewIOV<PhysicsTools::Calibration::HistogramD2D>(
-          obj, mydbservice->beginOfTime(), mydbservice->endOfTime(), "SiStripDeDxMipRcd");
+      mydbservice->createOneIOV<PhysicsTools::Calibration::HistogramD2D>(
+          obj, mydbservice->beginOfTime(), "SiStripDeDxMipRcd");
     } else {
-      mydbservice->appendSinceTime<PhysicsTools::Calibration::HistogramD2D>(
+      mydbservice->appendOneIOV<PhysicsTools::Calibration::HistogramD2D>(
           obj, mydbservice->currentTime(), "SiStripDeDxMipRcd");
     }
   } else {

--- a/CondTools/SiStrip/plugins/SiStripApvGainBuilder.cc
+++ b/CondTools/SiStrip/plugins/SiStripApvGainBuilder.cc
@@ -14,7 +14,7 @@ void SiStripApvGainBuilder::analyze(const edm::Event& evt, const edm::EventSetup
   edm::LogInfo("SiStripApvGainBuilder") << "... creating dummy SiStripApvGain Data for Run " << run << "\n "
                                         << std::endl;
 
-  SiStripApvGain* obj = new SiStripApvGain();
+  SiStripApvGain obj;
 
   int count = -1;
   for (const auto& it : SiStripDetInfoFileReader::read(fp_.fullPath()).getAllData()) {
@@ -30,7 +30,7 @@ void SiStripApvGainBuilder::analyze(const edm::Event& evt, const edm::EventSetup
     }
 
     SiStripApvGain::Range range(theSiStripVector.begin(), theSiStripVector.end());
-    if (!obj->put(it.first, range))
+    if (!obj.put(it.first, range))
       edm::LogError("SiStripApvGainBuilder") << "[SiStripApvGainBuilder::analyze] detid already exists" << std::endl;
   }
 
@@ -39,10 +39,9 @@ void SiStripApvGainBuilder::analyze(const edm::Event& evt, const edm::EventSetup
 
   if (mydbservice.isAvailable()) {
     if (mydbservice->isNewTagRequest("SiStripApvGainRcd")) {
-      mydbservice->createNewIOV<SiStripApvGain>(
-          obj, mydbservice->beginOfTime(), mydbservice->endOfTime(), "SiStripApvGainRcd");
+      mydbservice->createOneIOV<SiStripApvGain>(obj, mydbservice->beginOfTime(), "SiStripApvGainRcd");
     } else {
-      mydbservice->appendSinceTime<SiStripApvGain>(obj, mydbservice->currentTime(), "SiStripApvGainRcd");
+      mydbservice->appendOneIOV<SiStripApvGain>(obj, mydbservice->currentTime(), "SiStripApvGainRcd");
     }
   } else {
     edm::LogError("SiStripApvGainBuilder") << "Service is unavailable" << std::endl;

--- a/CondTools/SiStrip/plugins/SiStripDetVOffFakeBuilder.cc
+++ b/CondTools/SiStrip/plugins/SiStripDetVOffFakeBuilder.cc
@@ -51,7 +51,7 @@ void SiStripDetVOffFakeBuilder::analyze(const edm::Event& evt, const edm::EventS
   edm::LogInfo("SiStripDetVOffFakeBuilder")
       << "... creating dummy SiStripDetVOff Data for Run " << run << "\n " << std::endl;
 
-  SiStripDetVOff* SiStripDetVOff_ = new SiStripDetVOff();
+  SiStripDetVOff SiStripDetVOff_;
 
   // std::vector<uint32_t> TheDetIdHVVector;
 
@@ -61,19 +61,19 @@ void SiStripDetVOffFakeBuilder::analyze(const edm::Event& evt, const edm::EventS
     int lv = rand() % 20;
     if (hv <= 2) {
       edm::LogInfo("SiStripDetVOffFakeBuilder") << "detid: " << *it << " HV\t OFF" << std::endl;
-      SiStripDetVOff_->put(*it, 1, -1);
+      SiStripDetVOff_.put(*it, 1, -1);
       // TheDetIdHVVector.push_back(*it);
     }
     if (lv <= 2) {
       edm::LogInfo("SiStripDetVOffFakeBuilder") << "detid: " << *it << " LV\t OFF" << std::endl;
-      SiStripDetVOff_->put(*it, -1, 1);
+      SiStripDetVOff_.put(*it, -1, 1);
       // TheDetIdHVVector.push_back(*it);
     }
     if (lv <= 2 || hv <= 2)
       edm::LogInfo("SiStripDetVOffFakeBuilder") << "detid: " << *it << " V\t OFF" << std::endl;
   }
 
-  // SiStripDetVOff_->put(TheDetIdHVVector);
+  // SiStripDetVOff_.put(TheDetIdHVVector);
 
   //End now write DetVOff data in DB
   edm::Service<cond::service::PoolDBOutputService> mydbservice;
@@ -81,10 +81,9 @@ void SiStripDetVOffFakeBuilder::analyze(const edm::Event& evt, const edm::EventS
   if (mydbservice.isAvailable()) {
     try {
       if (mydbservice->isNewTagRequest("SiStripDetVOffRcd")) {
-        mydbservice->createNewIOV<SiStripDetVOff>(
-            SiStripDetVOff_, mydbservice->beginOfTime(), mydbservice->endOfTime(), "SiStripDetVOffRcd");
+        mydbservice->createOneIOV<SiStripDetVOff>(SiStripDetVOff_, mydbservice->beginOfTime(), "SiStripDetVOffRcd");
       } else {
-        mydbservice->appendSinceTime<SiStripDetVOff>(SiStripDetVOff_, mydbservice->currentTime(), "SiStripDetVOffRcd");
+        mydbservice->appendOneIOV<SiStripDetVOff>(SiStripDetVOff_, mydbservice->currentTime(), "SiStripDetVOffRcd");
       }
     } catch (const cond::Exception& er) {
       edm::LogError("SiStripDetVOffFakeBuilder") << er.what() << std::endl;

--- a/CondTools/SiStrip/plugins/SiStripFedCablingBuilder.cc
+++ b/CondTools/SiStrip/plugins/SiStripFedCablingBuilder.cc
@@ -91,17 +91,16 @@ void SiStripFedCablingBuilder::beginRun(const edm::Run& run, const edm::EventSet
 
   edm::LogVerbatim("SiStripFedCablingBuilder") << "[SiStripFedCablingBuilder::" << __func__ << "]"
                                                << " Copying FED cabling...";
-  SiStripFedCabling* obj = new SiStripFedCabling(*(fed.product()));
+  SiStripFedCabling obj(*(fed.product()));
 
   //End now write sistripnoises data in DB
   edm::Service<cond::service::PoolDBOutputService> mydbservice;
 
   if (mydbservice.isAvailable()) {
     if (mydbservice->isNewTagRequest("SiStripFedCablingRcd")) {
-      mydbservice->createNewIOV<SiStripFedCabling>(
-          obj, mydbservice->beginOfTime(), mydbservice->endOfTime(), "SiStripFedCablingRcd");
+      mydbservice->createOneIOV<SiStripFedCabling>(obj, mydbservice->beginOfTime(), "SiStripFedCablingRcd");
     } else {
-      mydbservice->appendSinceTime<SiStripFedCabling>(obj, mydbservice->currentTime(), "SiStripFedCablingRcd");
+      mydbservice->appendOneIOV<SiStripFedCabling>(obj, mydbservice->currentTime(), "SiStripFedCablingRcd");
     }
   } else {
     edm::LogError("SiStripFedCablingBuilder") << "Service is unavailable" << std::endl;

--- a/CondTools/SiStrip/plugins/SiStripNoisesBuilder.cc
+++ b/CondTools/SiStrip/plugins/SiStripNoisesBuilder.cc
@@ -13,7 +13,7 @@ void SiStripNoisesBuilder::analyze(const edm::Event& evt, const edm::EventSetup&
 
   edm::LogInfo("SiStripNoisesBuilder") << "... creating dummy SiStripNoises Data for Run " << run << "\n " << std::endl;
 
-  SiStripNoises* obj = new SiStripNoises();
+  SiStripNoises obj;
 
   int count = -1;
   for (const auto& it : SiStripDetInfoFileReader::read(fp_.fullPath()).getAllData()) {
@@ -28,14 +28,14 @@ void SiStripNoisesBuilder::analyze(const edm::Event& evt, const edm::EventSetup&
       //double badStripProb = .5;
       //bool disable = (CLHEP::RandFlat::shoot(1.) < badStripProb ? true:false);
 
-      obj->setData(noise, theSiStripVector);
+      obj.setData(noise, theSiStripVector);
       if (count < static_cast<int>(printdebug_))
         edm::LogInfo("SiStripNoisesBuilder")
             << "detid " << it.first << " \t"
             << " strip " << strip << " \t" << noise << " \t" << theSiStripVector.back() / 10 << " \t" << std::endl;
     }
 
-    if (!obj->put(it.first, theSiStripVector))
+    if (!obj.put(it.first, theSiStripVector))
       edm::LogError("SiStripNoisesBuilder") << "[SiStripNoisesBuilder::analyze] detid already exists" << std::endl;
   }
 
@@ -44,11 +44,10 @@ void SiStripNoisesBuilder::analyze(const edm::Event& evt, const edm::EventSetup&
 
   if (mydbservice.isAvailable()) {
     if (mydbservice->isNewTagRequest("SiStripNoisesRcd")) {
-      mydbservice->createNewIOV<SiStripNoises>(
-          obj, mydbservice->beginOfTime(), mydbservice->endOfTime(), "SiStripNoisesRcd");
+      mydbservice->createOneIOV<SiStripNoises>(obj, mydbservice->beginOfTime(), "SiStripNoisesRcd");
     } else {
       //mydbservice->createNewIOV<SiStripNoises>(obj,mydbservice->currentTime(),"SiStripNoisesRcd");
-      mydbservice->appendSinceTime<SiStripNoises>(obj, mydbservice->currentTime(), "SiStripNoisesRcd");
+      mydbservice->appendOneIOV<SiStripNoises>(obj, mydbservice->currentTime(), "SiStripNoisesRcd");
     }
   } else {
     edm::LogError("SiStripNoisesBuilder") << "Service is unavailable" << std::endl;

--- a/CondTools/SiStrip/plugins/SiStripPedestalsBuilder.cc
+++ b/CondTools/SiStrip/plugins/SiStripPedestalsBuilder.cc
@@ -14,7 +14,7 @@ void SiStripPedestalsBuilder::analyze(const edm::Event& evt, const edm::EventSet
   edm::LogInfo("SiStripPedestalsBuilder")
       << "... creating dummy SiStripPedestals Data for Run " << run << "\n " << std::endl;
 
-  SiStripPedestals* obj = new SiStripPedestals();
+  SiStripPedestals obj;
 
   int count = -1;
   for (const auto& it : SiStripDetInfoFileReader::read(fp_.fullPath()).getAllData()) {
@@ -30,11 +30,11 @@ void SiStripPedestalsBuilder::analyze(const edm::Event& evt, const edm::EventSet
       if (count < static_cast<int>(printdebug_))
         edm::LogInfo("SiStripPedestalsBuilder") << "detid " << it.first << " \t"
                                                 << " strip " << strip << " \t" << ped << " \t" << std::endl;
-      obj->setData(ped, theSiStripVector);
+      obj.setData(ped, theSiStripVector);
     }
 
     //SiStripPedestals::Range range(theSiStripVector.begin(),theSiStripVector.end());
-    if (!obj->put(it.first, theSiStripVector))
+    if (!obj.put(it.first, theSiStripVector))
       edm::LogError("SiStripPedestalsBuilder")
           << "[SiStripPedestalsBuilder::analyze] detid already exists" << std::endl;
   }
@@ -44,11 +44,10 @@ void SiStripPedestalsBuilder::analyze(const edm::Event& evt, const edm::EventSet
 
   if (mydbservice.isAvailable()) {
     if (mydbservice->isNewTagRequest("SiStripPedestalsRcd")) {
-      mydbservice->createNewIOV<SiStripPedestals>(
-          obj, mydbservice->beginOfTime(), mydbservice->endOfTime(), "SiStripPedestalsRcd");
+      mydbservice->createOneIOV<SiStripPedestals>(obj, mydbservice->beginOfTime(), "SiStripPedestalsRcd");
     } else {
       //mydbservice->createNewIOV<SiStripPedestals>(obj,mydbservice->currentTime(),"SiStripPedestalsRcd");
-      mydbservice->appendSinceTime<SiStripPedestals>(obj, mydbservice->currentTime(), "SiStripPedestalsRcd");
+      mydbservice->appendOneIOV<SiStripPedestals>(obj, mydbservice->currentTime(), "SiStripPedestalsRcd");
     }
   } else {
     edm::LogError("SiStripPedestalsBuilder") << "Service is unavailable" << std::endl;

--- a/CondTools/SiStrip/plugins/SiStripSummaryBuilder.cc
+++ b/CondTools/SiStrip/plugins/SiStripSummaryBuilder.cc
@@ -13,8 +13,8 @@ void SiStripSummaryBuilder::analyze(const edm::Event& evt, const edm::EventSetup
   edm::LogInfo("SiStripSummaryBuilder") << "... creating dummy SiStripSummary Data for Run " << run << "\n "
                                         << std::endl;
 
-  SiStripSummary* obj = new SiStripSummary();
-  obj->setRunNr(run);
+  SiStripSummary obj;
+  obj.setRunNr(run);
 
   //* DISCOVER SET OF HISTOGRAMS & QUANTITIES TO BE UPLOADED*//
 
@@ -51,12 +51,12 @@ void SiStripSummaryBuilder::analyze(const edm::Event& evt, const edm::EventSetup
       }
     }
   }
-  obj->setUserDBContent(userDBContent);
+  obj.setUserDBContent(userDBContent);
 
   std::stringstream ss1;
   ss1 << "QUANTITIES TO BE INSERTED IN DB :"
       << " \n";
-  std::vector<std::string> userDBContentA = obj->getUserDBContent();
+  std::vector<std::string> userDBContentA = obj.getUserDBContent();
   for (size_t i = 0; i < userDBContentA.size(); ++i)
     ss1 << userDBContentA[i] << std::endl;
   edm::LogInfo("SiStripSummaryBuilder") << ss1.str();
@@ -73,7 +73,7 @@ void SiStripSummaryBuilder::analyze(const edm::Event& evt, const edm::EventSetup
     for (size_t j = 0; j < values.size(); ++j)
       ss2 << "\n\t\t " << userDBContent[j] << " " << values[j];
 
-    obj->put(detid, values, userDBContent);
+    obj.put(detid, values, userDBContent);
 
     // See CondFormats/SiStripObjects/SiStripSummary.h for detid definitions
 
@@ -103,10 +103,9 @@ void SiStripSummaryBuilder::analyze(const edm::Event& evt, const edm::EventSetup
 
   if (mydbservice.isAvailable()) {
     if (mydbservice->isNewTagRequest("SiStripSummaryRcd")) {
-      mydbservice->createNewIOV<SiStripSummary>(
-          obj, mydbservice->beginOfTime(), mydbservice->endOfTime(), "SiStripSummaryRcd");
+      mydbservice->createOneIOV<SiStripSummary>(obj, mydbservice->beginOfTime(), "SiStripSummaryRcd");
     } else {
-      mydbservice->appendSinceTime<SiStripSummary>(obj, mydbservice->currentTime(), "SiStripSummaryRcd");
+      mydbservice->appendOneIOV<SiStripSummary>(obj, mydbservice->currentTime(), "SiStripSummaryRcd");
     }
   } else {
     edm::LogError("SiStripSummaryBuilder") << "Service is unavailable" << std::endl;

--- a/CondTools/SiStrip/plugins/SiStripThresholdBuilder.cc
+++ b/CondTools/SiStrip/plugins/SiStripThresholdBuilder.cc
@@ -14,7 +14,7 @@ void SiStripThresholdBuilder::analyze(const edm::Event& evt, const edm::EventSet
   edm::LogInfo("SiStripThresholdBuilder")
       << "... creating dummy SiStripThreshold Data for Run " << run << "\n " << std::endl;
 
-  SiStripThreshold* obj = new SiStripThreshold();
+  SiStripThreshold obj;
 
   int count = -1;
   for (const auto& it : SiStripDetInfoFileReader::read(fp_.fullPath()).getAllData()) {
@@ -32,7 +32,7 @@ void SiStripThresholdBuilder::analyze(const edm::Event& evt, const edm::EventSet
       }
       float cTh = (CLHEP::RandFlat::shoot(1.) * 30.);
 
-      obj->setData(strip, lTh, hTh, cTh, theSiStripVector);
+      obj.setData(strip, lTh, hTh, cTh, theSiStripVector);
       if (count < (int)printdebug_) {
         std::stringstream ss;
         theSiStripVector.back().print(ss);
@@ -45,10 +45,10 @@ void SiStripThresholdBuilder::analyze(const edm::Event& evt, const edm::EventSet
             << "FirstStrip_and_Hth: " << theSiStripVector.back().FirstStrip_and_Hth << " \n"
             << ss.str() << std::endl;
       }
-      obj->setData(strip + 1, lTh, hTh, theSiStripVector);
+      obj.setData(strip + 1, lTh, hTh, theSiStripVector);
       strip = (uint16_t)(CLHEP::RandFlat::shoot(strip + 2, 128 * it.second.nApvs));
     }
-    if (!obj->put(it.first, theSiStripVector))
+    if (!obj.put(it.first, theSiStripVector))
       edm::LogError("SiStripThresholdBuilder")
           << "[SiStripThresholdBuilder::analyze] detid already exists" << std::endl;
   }
@@ -58,10 +58,9 @@ void SiStripThresholdBuilder::analyze(const edm::Event& evt, const edm::EventSet
 
   if (mydbservice.isAvailable()) {
     if (mydbservice->isNewTagRequest("SiStripThresholdRcd")) {
-      mydbservice->createNewIOV<SiStripThreshold>(
-          obj, mydbservice->beginOfTime(), mydbservice->endOfTime(), "SiStripThresholdRcd");
+      mydbservice->createOneIOV<SiStripThreshold>(obj, mydbservice->beginOfTime(), "SiStripThresholdRcd");
     } else {
-      mydbservice->appendSinceTime<SiStripThreshold>(obj, mydbservice->currentTime(), "SiStripThresholdRcd");
+      mydbservice->appendOneIOV<SiStripThreshold>(obj, mydbservice->currentTime(), "SiStripThresholdRcd");
     }
   } else {
     edm::LogError("SiStripThresholdBuilder") << "Service is unavailable" << std::endl;


### PR DESCRIPTION
#### PR description:

In response to https://github.com/cms-AlCaDB/AlCaTools/issues/28. 
Migrated SiStrip-related codes to the usage of new `PoolDBOutputService` methods introduced at https://github.com/cms-sw/cmssw/pull/35048, by following the recommendations from this [presentation](https://indico.cern.ch/event/1088598/contributions/4580152/attachments/2333275/3976721/DBOutputService%20changes.pdf).
The relevant classes have been isolated using:
```console
git grep -l 'PoolDBOutputService' | grep SiStrip | grep -E '.(cc|h)$'
```

#### PR validation:

`cmssw` compiles

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

cc:
@robervalwalsh @mdelcourt @FlorianBury
