### PR TITLE
Run3-gex98 Make use of esConsume in Geometry/CommonTopologies

### DIFF
--- a/Geometry/CommonTopologies/test/ValidateRadial.cc
+++ b/Geometry/CommonTopologies/test/ValidateRadial.cc
@@ -28,6 +28,7 @@ private:
   TFile* file_;
   const bool printOut_;
   const bool posOnly_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tokTrackerGeometry_;
 
   mutable float maxerrU = 0.;
   mutable float maxerrUV = 0.;
@@ -37,7 +38,8 @@ ValidateRadial::ValidateRadial(const edm::ParameterSet& cfg)
     : epsilon_(cfg.getParameter<double>("Epsilon")),
       file_(new TFile(cfg.getParameter<std::string>("FileName").c_str(), "RECREATE")),
       printOut_(cfg.getParameter<bool>("PrintOut")),
-      posOnly_(cfg.getParameter<bool>("PosOnly")) {
+      posOnly_(cfg.getParameter<bool>("PosOnly")),
+      tokTrackerGeometry_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>()) {
   std::cout << "I'm ALIVE" << std::endl;
 }
 
@@ -52,8 +54,7 @@ void ValidateRadial::analyze(const edm::Event& e, const edm::EventSetup& es) {
 std::vector<const TkRadialStripTopology*> ValidateRadial::get_list_of_radial_topologies(const edm::Event& e,
                                                                                         const edm::EventSetup& es) {
   std::vector<const TkRadialStripTopology*> topos;
-  edm::ESHandle<TrackerGeometry> theTrackerGeometry;
-  es.get<TrackerDigiGeometryRecord>().get(theTrackerGeometry);
+  auto theTrackerGeometry = es.getHandle(tokTrackerGeometry_);
   const uint32_t radial_detids[] = {402666125,   //TID r1
                                     402668833,   //TID r2
                                     402673476,   //TID r3


### PR DESCRIPTION
#### PR description:

Make use of esConsume in Geometry/CommonTopologies

#### PR validation:

Use runTheMatrix test workflows

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special