### PR TITLE
[10_6_X] Add producers/configs to refit muon tracks with standard TrackRefitter

### DIFF
--- a/RecoTracker/TrackProducer/plugins/TrackExtraRekeyer.cc
+++ b/RecoTracker/TrackProducer/plugins/TrackExtraRekeyer.cc
@@ -1,0 +1,62 @@
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/TrackReco/interface/TrackExtraFwd.h"
+
+class TrackExtraRekeyer : public edm::stream::EDProducer<> {
+public:
+  explicit TrackExtraRekeyer(const edm::ParameterSet &);
+  ~TrackExtraRekeyer() override {}
+
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+
+private:
+  void produce(edm::Event &, const edm::EventSetup &) override;
+
+  edm::EDGetTokenT<reco::TrackCollection> inputTrack_;
+  edm::EDGetTokenT<edm::Association<reco::TrackExtraCollection>> inputAssoc_;
+  edm::EDPutTokenT<reco::TrackCollection> outputTrack_;
+};
+
+TrackExtraRekeyer::TrackExtraRekeyer(const edm::ParameterSet &iConfig) {
+  inputTrack_ = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("src"));
+  inputAssoc_ =
+      consumes<edm::Association<reco::TrackExtraCollection>>(iConfig.getParameter<edm::InputTag>("association"));
+  outputTrack_ = produces<reco::TrackCollection>();
+}
+
+// ------------ method called for each event  ------------
+void TrackExtraRekeyer::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
+  using namespace edm;
+
+  auto const &tracks = iEvent.get(inputTrack_);
+  auto const &assoc = iEvent.get(inputAssoc_);
+
+  reco::TrackCollection tracksOut;
+
+  for (auto const &track : tracks) {
+    if (!assoc.contains(track.extra().id())) {
+      continue;
+    }
+    const reco::TrackExtraRef &trackextraref = assoc[track.extra()];
+    if (trackextraref.isNonnull()) {
+      auto &trackout = tracksOut.emplace_back(track);
+      trackout.setExtra(trackextraref);
+    }
+  }
+
+  iEvent.emplace(outputTrack_, std::move(tracksOut));
+}
+
+void TrackExtraRekeyer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.setComment("Simple prooducer to re-key muon tracks for refit");
+  desc.add<edm::InputTag>("src", edm::InputTag("generalTracks"))->setComment("input track collections");
+  desc.add<edm::InputTag>("association", edm::InputTag("muonReducedTrackExtras"))
+      ->setComment("input track association collection");
+  descriptions.addWithDefaultLabel(desc);
+}
+
+DEFINE_FWK_MODULE(TrackExtraRekeyer);

--- a/RecoTracker/TrackProducer/plugins/TrackExtraRekeyer.cc
+++ b/RecoTracker/TrackProducer/plugins/TrackExtraRekeyer.cc
@@ -1,34 +1,35 @@
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackReco/interface/TrackExtraFwd.h"
 
-class TrackExtraRekeyer : public edm::stream::EDProducer<> {
+class TrackExtraRekeyer : public edm::global::EDProducer<> {
 public:
   explicit TrackExtraRekeyer(const edm::ParameterSet &);
-  ~TrackExtraRekeyer() override {}
+  ~TrackExtraRekeyer() override = default;
 
   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
 private:
-  void produce(edm::Event &, const edm::EventSetup &) override;
+  void produce(edm::StreamID, edm::Event &, const edm::EventSetup &) const override;
 
-  edm::EDGetTokenT<reco::TrackCollection> inputTrack_;
-  edm::EDGetTokenT<edm::Association<reco::TrackExtraCollection>> inputAssoc_;
-  edm::EDPutTokenT<reco::TrackCollection> outputTrack_;
+  // memeber data
+  const edm::EDGetTokenT<reco::TrackCollection> inputTrack_;
+  const edm::EDGetTokenT<edm::Association<reco::TrackExtraCollection>> inputAssoc_;
+  const edm::EDPutTokenT<reco::TrackCollection> outputTrack_;
 };
 
-TrackExtraRekeyer::TrackExtraRekeyer(const edm::ParameterSet &iConfig) {
-  inputTrack_ = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("src"));
-  inputAssoc_ =
-      consumes<edm::Association<reco::TrackExtraCollection>>(iConfig.getParameter<edm::InputTag>("association"));
-  outputTrack_ = produces<reco::TrackCollection>();
-}
+TrackExtraRekeyer::TrackExtraRekeyer(const edm::ParameterSet &iConfig)
+    : inputTrack_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("src"))),
+      inputAssoc_(
+          consumes<edm::Association<reco::TrackExtraCollection>>(iConfig.getParameter<edm::InputTag>("association"))),
+      outputTrack_(produces<reco::TrackCollection>()) {}
 
 // ------------ method called for each event  ------------
-void TrackExtraRekeyer::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
+void TrackExtraRekeyer::produce(edm::StreamID, edm::Event &iEvent, const edm::EventSetup &iSetup) const {
   using namespace edm;
 
   auto const &tracks = iEvent.get(inputTrack_);

--- a/RecoTracker/TrackProducer/plugins/TrackProducerFromPatMuons.cc
+++ b/RecoTracker/TrackProducer/plugins/TrackProducerFromPatMuons.cc
@@ -1,0 +1,55 @@
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/TrackReco/interface/TrackExtraFwd.h"
+#include "DataFormats/PatCandidates/interface/Muon.h"
+
+class TrackProducerFromPatMuons : public edm::global::EDProducer<> {
+public:
+  explicit TrackProducerFromPatMuons(const edm::ParameterSet &);
+  ~TrackProducerFromPatMuons() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+
+private:
+  void produce(edm::StreamID, edm::Event &, const edm::EventSetup &) const override;
+
+  const edm::EDGetTokenT<std::vector<pat::Muon>> inputMuons_;
+  const edm::EDPutTokenT<reco::TrackCollection> outputTrack_;
+  const bool innerTrackOnly_;
+};
+
+TrackProducerFromPatMuons::TrackProducerFromPatMuons(const edm::ParameterSet &iConfig)
+    : inputMuons_(consumes<std::vector<pat::Muon>>(iConfig.getParameter<edm::InputTag>("src"))),
+      outputTrack_(produces<reco::TrackCollection>()),
+      innerTrackOnly_(iConfig.getParameter<bool>("innerTrackOnly")) {}
+
+// ------------ method called for each event  ------------
+void TrackProducerFromPatMuons::produce(edm::StreamID, edm::Event &iEvent, const edm::EventSetup &iSetup) const {
+  using namespace edm;
+
+  auto const &muons = iEvent.get(inputMuons_);
+
+  reco::TrackCollection tracksOut;
+
+  for (auto const &muon : muons) {
+    const reco::TrackRef trackRef = innerTrackOnly_ ? muon.innerTrack() : muon.muonBestTrack();
+    if (trackRef.isNonnull() && trackRef->extra().isAvailable()) {
+      tracksOut.emplace_back(*trackRef);
+    }
+  }
+  iEvent.emplace(outputTrack_, std::move(tracksOut));
+}
+
+void TrackProducerFromPatMuons::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.setComment("Simple prooducer to generate track from pat::muons ");
+  desc.add<edm::InputTag>("src", edm::InputTag("slimmedMuons"))->setComment("input track collections");
+  desc.add<bool>("innerTrackOnly", true)->setComment("use only inner track");
+  descriptions.addWithDefaultLabel(desc);
+}
+
+DEFINE_FWK_MODULE(TrackProducerFromPatMuons);

--- a/RecoTracker/TrackProducer/test/BuildFile.xml
+++ b/RecoTracker/TrackProducer/test/BuildFile.xml
@@ -1,29 +1,38 @@
-<use   name="TrackingTools/Records"/>
-<use   name="FWCore/Utilities"/>
-<use   name="DataFormats/TrackReco"/>
-<use   name="clhep"/>
-<use   name="FWCore/Framework"/>
-<use   name="FWCore/PluginManager"/>
-<use   name="FWCore/ParameterSet"/>
-<use   name="Geometry/TrackerGeometryBuilder"/>
-<use   name="Geometry/Records"/>
-<use   name="MagneticField/Records"/>
-<use   name="MagneticField/Engine"/>
-<use   name="SimDataFormats/Vertex"/>
-<use   name="TrackingTools/PatternTools"/>
-<use   name="root"/>
-<library   file="TrackAnalyzer.cc" name="TrackAnalyzer">
-  <flags   EDM_PLUGIN="1"/>
+<use name="TrackingTools/Records"/>
+<use name="FWCore/Utilities"/>
+<use name="DataFormats/TrackReco"/>
+<use name="clhep"/>
+<use name="FWCore/Framework"/>
+<use name="FWCore/ParameterSet"/>
+<use name="Geometry/TrackerGeometryBuilder"/>
+<use name="Geometry/Records"/>
+<use name="MagneticField/Records"/>
+<use name="MagneticField/Engine"/>
+<use name="SimDataFormats/Vertex"/>
+<use name="TrackingTools/PatternTools"/>
+<use name="root"/>
+<library file="TrackAnalyzer.cc" name="TrackAnalyzer">
+  <flags EDM_PLUGIN="1"/>
 </library>
-<library   file="TrackValidator.cc" name="TrackValidator">
-  <use   name="TrackingTools/TransientTrack"/>
-  <flags   EDM_PLUGIN="1"/>
+
+<library file="TrackValidator.cc" name="TrackValidator">
+  <use name="TrackingTools/TransientTrack"/>
+  <flags EDM_PLUGIN="1"/>
 </library>
-<library   file="TrajectoryAnalyzer.cc" name="TrajectoryAnalyzer">
-  <flags   EDM_PLUGIN="1"/>
+
+<library file="TrajectoryAnalyzer.cc" name="TrajectoryAnalyzer">
+  <flags EDM_PLUGIN="1"/>
 </library>
-<library   file="FakeCPEFiller.cc" name="FakeCPEFiller">
-  <use   name="SimTracker/TrackerHitAssociation"/>
-  <use   name="RecoTracker/TransientTrackingRecHit"/>
-  <flags   EDM_PLUGIN="1"/>
+
+<library file="FakeCPEFiller.cc" name="FakeCPEFiller">
+  <use name="SimTracker/TrackerHitAssociation"/>
+  <use name="RecoTracker/TransientTrackingRecHit"/>
+  <flags EDM_PLUGIN="1"/>
 </library>
+
+<environment>
+  <bin file="testMuonTrackRefitting.cpp">
+    <flags TEST_RUNNER_ARGS="/bin/bash RecoTracker/TrackProducer/test testMuonTrackRefitting.sh"/>
+    <use name="FWCore/Utilities"/>
+  </bin>
+</environment>

--- a/RecoTracker/TrackProducer/test/refitFromAOD.py
+++ b/RecoTracker/TrackProducer/test/refitFromAOD.py
@@ -1,0 +1,84 @@
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
+process = cms.Process('RECO2',Run2_2016)
+
+options = VarParsing.VarParsing('analysis')
+options.register('globalTag',
+                 "auto:run2_mc", # default value
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.string, # string, int, or float
+                 "input file name")
+options.parseArguments()
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.Reconstruction_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.source = cms.Source("PoolSource",
+                            fileNames = cms.untracked.vstring(options.inputFiles),
+                            secondaryFileNames = cms.untracked.vstring()
+                            )
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(options.maxEvents)
+)
+
+process.options = cms.untracked.PSet()
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('step1 nevts:1'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+# Output definition
+
+process.RECOSIMoutput = cms.OutputModule("PoolOutputModule",
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string(''),
+        filterName = cms.untracked.string('')
+    ),
+    fileName = cms.untracked.string('step1_RECO.root'),
+    outputCommands = process.RECOSIMEventContent.outputCommands,
+    splitLevel = cms.untracked.int32(0)
+)
+
+# Additional output definition
+process.RECOSIMoutput.outputCommands = cms.untracked.vstring("keep *_myRefittedTracks_*_*")
+
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, options.globalTag, '')
+
+import RecoTracker.TrackProducer.trackExtraRekeyer_cfi
+process.trackExtraRekeyer = RecoTracker.TrackProducer.trackExtraRekeyer_cfi.trackExtraRekeyer.clone(
+    src = "generalTracks",
+    association = "muonReducedTrackExtras"
+)
+
+import RecoTracker.TrackProducer.TrackRefitter_cfi
+process.myRefittedTracks = RecoTracker.TrackProducer.TrackRefitter_cfi.TrackRefitter.clone(
+    src= 'trackExtraRekeyer',
+    NavigationSchool = '',
+    Fitter = 'FlexibleKFFittingSmoother'
+)
+
+# Path and EndPath definitions
+process.reconstruction_step = cms.Path(process.trackExtraRekeyer*process.myRefittedTracks)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RECOSIMoutput_step = cms.EndPath(process.RECOSIMoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.reconstruction_step,process.endjob_step,process.RECOSIMoutput_step)

--- a/RecoTracker/TrackProducer/test/refitFromMINIAOD.py
+++ b/RecoTracker/TrackProducer/test/refitFromMINIAOD.py
@@ -1,0 +1,83 @@
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
+process = cms.Process('RECO2',Run2_2016)
+
+options = VarParsing.VarParsing('analysis')
+options.register('globalTag',
+                 "auto:run2_mc", # default value
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.string, # string, int, or float
+                 "input file name")
+options.parseArguments()
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.Reconstruction_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+    
+process.source = cms.Source("PoolSource",
+                            fileNames = cms.untracked.vstring(options.inputFiles),
+                            secondaryFileNames = cms.untracked.vstring()
+                            )
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(options.maxEvents)
+)
+
+process.options = cms.untracked.PSet()
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('step1 nevts:1'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+# Output definition
+
+process.RECOSIMoutput = cms.OutputModule("PoolOutputModule",
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string(''),
+        filterName = cms.untracked.string('')
+    ),
+    fileName = cms.untracked.string('step1_RECO.root'),
+    outputCommands = process.RECOSIMEventContent.outputCommands,
+    splitLevel = cms.untracked.int32(0)
+)
+
+# Additional output definition
+process.RECOSIMoutput.outputCommands = cms.untracked.vstring("keep *_myRefittedTracks_*_*")
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, options.globalTag, '')
+
+import RecoTracker.TrackProducer.trackProducerFromPatMuons_cfi
+process.tracksFromMuons  = RecoTracker.TrackProducer.trackProducerFromPatMuons_cfi.trackProducerFromPatMuons.clone(
+    src = "slimmedMuons",
+    innerTrackOnly = True
+)
+
+import RecoTracker.TrackProducer.TrackRefitter_cfi
+process.myRefittedTracks = RecoTracker.TrackProducer.TrackRefitter_cfi.TrackRefitter.clone(
+    src = 'tracksFromMuons',
+    NavigationSchool = '',
+    Fitter = 'FlexibleKFFittingSmoother'
+)
+                                         
+# Path and EndPath definitions
+process.reconstruction_step = cms.Path(process.tracksFromMuons*process.myRefittedTracks)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RECOSIMoutput_step = cms.EndPath(process.RECOSIMoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.reconstruction_step,process.endjob_step,process.RECOSIMoutput_step)

--- a/RecoTracker/TrackProducer/test/testMuonTrackRefitting.cpp
+++ b/RecoTracker/TrackProducer/test/testMuonTrackRefitting.cpp
@@ -1,0 +1,2 @@
+#include "FWCore/Utilities/interface/TestHelper.h"
+RUNTEST()

--- a/RecoTracker/TrackProducer/test/testMuonTrackRefitting.sh
+++ b/RecoTracker/TrackProducer/test/testMuonTrackRefitting.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+function die { echo $1: status $2 ; exit $2; }
+
+echo "TESTING Refitting from Analysis Data-Tier codes ..."
+
+# test AOD
+echo "TESTING refitting from AOD ...\n\n"
+cmsRun ${LOCAL_TEST_DIR}/refitFromAOD.py maxEvents=100 inputFiles=/store/mc/RunIISummer20UL16RECO/DYJetsToMuMu_M-50_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/AODSIM/106X_mcRun2_asymptotic_v13-v2/00000/1D4FBF4B-7B8D-A04F-A108-B1BEB60558FA.root || die "Failure refitting from AOD" $?
+
+# test MINIAOD
+echo "TESTING refitting from MINIAOD ...\n\n"
+cmsRun ${LOCAL_TEST_DIR}/refitFromMINIAOD.py maxEvents=100 inputFiles=/store/mc/RunIISummer20UL16MiniAOD/DYJetsToMuMu_M-50_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/MINIAODSIM/106X_mcRun2_asymptotic_v13-v2/00000/01916D91-A314-D947-A420-388891D62FEA.root || die "Failure refitting from MINIAOD" $?


### PR DESCRIPTION
#### PR description:

Almost a complete backport of https://github.com/cms-sw/cmssw/pull/35620
except that for example `consumes(edm::InputTag)` has no matching function in 10_6_X

This refitting feature is nice to have in 10_6_X as some UltraLegacy analysis could make use of it.

#### PR validation:

The newly introduced unit tests work nicely.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is a backport of https://github.com/cms-sw/cmssw/pull/35620

All credits to @bendavid @mmusich 