### PR TITLE
Fix errors in RepeatingCachedRootSource test

### DIFF
--- a/IOPool/Input/test/testRepeatingCachedRootSource.sh
+++ b/IOPool/Input/test/testRepeatingCachedRootSource.sh
@@ -4,4 +4,4 @@ function die { echo $1: status $2 ;  exit $2; }
 
 cmsRun -j PoolInputRepeatingSourceTest_jobreport.xml ${LOCALTOP}/src/IOPool/Input/test/PrePoolInputTest_cfg.py PoolInputRepeatingSource.root 11 561 7 6 3 || die 'Failure using PrePoolInputTest_cfg.py' $?
 
-cmsRun ${LOCALTOP}/src/IOPool/Input/test/test_repeating_cfg.py || die 'Failed cmsRun test_repeating_cfg.py'
+cmsRun ${LOCALTOP}/src/IOPool/Input/test/test_repeating_cfg.py || die 'Failed cmsRun test_repeating_cfg.py' $?

--- a/IOPool/Input/test/test_repeating_cfg.py
+++ b/IOPool/Input/test/test_repeating_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
-process.source = cms.Source("RepeatingCachedRootSource", fileName = cms.untracked.string("file:PoolInputTest.root"), repeatNEvents = cms.untracked.uint32(2))
+process.source = cms.Source("RepeatingCachedRootSource", fileName = cms.untracked.string("file:PoolInputRepeatingSource.root"), repeatNEvents = cms.untracked.uint32(2))
 
 process.maxEvents.input = 10000
 


### PR DESCRIPTION
#### PR description:

The TestIOPoolInputRepeating unit test has been silently failing with this output:

```
+ cmsRun /data/cmsbld/jenkins/workspace/ib-run-qa/CMSSW_12_2_ASAN_X_2021-11-03-2300/src/IOPool/Input/test/test_repeating_cfg.py
04-Nov-2021 08:51:56 CET  Initiating request to open file file:PoolInputTest.root
----- Begin Fatal Exception 04-Nov-2021 08:51:57 CET-----------------------
An exception of category 'FileOpenError' occurred while
   [0] Constructing the EventProcessor
   [1] Constructing input source of type RepeatingCachedRootSource
   [2] Calling StorageFactory::open()
   [3] Calling File::sysopen()
Exception Message:
Failed to open the file 'PoolInputTest.root'
   Additional Info:
      [a] open() failed with system error 'No such file or directory' (error code 2)
----- End Fatal Exception -------------------------------------------------
+ die 'Failed cmsRun test_repeating_cfg.py'
+ echo Failed cmsRun test_repeating_cfg.py: status
Failed cmsRun test_repeating_cfg.py: status
+ exit

---> test TestIOPoolInputRepeating succeeded
```

There's two problems here, one is that the filename in the test_repeating_cfg.py isn't consistent with the filename used in the previous step, PoolInputRepeatingSource.root.  The second problem is a missing `$?` to the `die` command.

#### PR validation:

With these changes, the TestIOPoolInputRepeating fails with a crash in `edm::ProcessBlockHelper::initializeFromPrimaryInput ()` (output below) with `this` set to nullptr, because apparently RepeatingCachedRootSource was broken by the process block persistence changes, and we didn't notice because the unit test was broken.

```
+ cmsRun /mnt/data1/dsr/CMSSW_12_1_0_pre3/src/IOPool/Input/test/test_repeating_cfg.py
05-Nov-2021 09:42:57 EDT  Initiating request to open file file:PoolInputRepeatingSource.root
05-Nov-2021 09:42:57 EDT  Successfully opened file file:PoolInputRepeatingSource.root


A fatal system signal has occurred: segmentation violation
The following is the call stack containing the origin of the signal.

Fri Nov  5 09:42:57 EDT 2021
Thread 5 (Thread 0x7fd41b5ff700 (LWP 164845) "cmsRun"):
#0  0x00007fd43b9c7a35 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
#1  0x00007fd43bfbf85c in __gthread_cond_wait (__mutex=<optimized out>, __cond=<optimized out>) at /data/cmsbld/jenkins/workspace/auto-builds/CMSSW_11_1_0_pre6-slc7_amd64_gcc900/build/CMSSW_11_1_0_pre6-build/BUILD/slc7_amd64_gcc900/external/gcc/9.3.0/gcc-9.3.0/obj/x86_64-unknown-linux-gnu/libstdc++-v3/include/x86_64-unknown-linux-gnu/bits/gthr-default.h:865
#2  std::condition_variable::wait (this=<optimized out>, __lock=...) at ../../../../../libstdc++-v3/src/c++11/condition_variable.cc:53
#3  0x00007fd43d537012 in TFilePrefetch::GetPendingBlock() () from /cvmfs/cms.cern.ch/slc7_amd64_gcc900/cms/cmssw/CMSSW_12_1_0_pre3/external/slc7_amd64_gcc900/lib/libRIO.so
#4  0x00007fd43d5385a8 in TFilePrefetch::ReadListOfBlocks() () from /cvmfs/cms.cern.ch/slc7_amd64_gcc900/cms/cmssw/CMSSW_12_1_0_pre3/external/slc7_amd64_gcc900/lib/libRIO.so
#5  0x00007fd43d5385f0 in TFilePrefetch::ThreadProc(void*) () from /cvmfs/cms.cern.ch/slc7_amd64_gcc900/cms/cmssw/CMSSW_12_1_0_pre3/external/slc7_amd64_gcc900/lib/libRIO.so
#6  0x00007fd43da1f258 in TThread::Function(void*) () from /cvmfs/cms.cern.ch/slc7_amd64_gcc900/cms/cmssw/CMSSW_12_1_0_pre3/external/slc7_amd64_gcc900/lib/libThread.so
#7  0x00007fd43b9c3ea5 in start_thread () from /lib64/libpthread.so.0
#8  0x00007fd43b6ec9fd in clone () from /lib64/libc.so.6
Thread 4 (Thread 0x7fd41c3ff700 (LWP 164844) "cmsRun"):
#0  0x00007fd43b9c7a35 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
#1  0x00007fd43bfbf85c in __gthread_cond_wait (__mutex=<optimized out>, __cond=<optimized out>) at /data/cmsbld/jenkins/workspace/auto-builds/CMSSW_11_1_0_pre6-slc7_amd64_gcc900/build/CMSSW_11_1_0_pre6-build/BUILD/slc7_amd64_gcc900/external/gcc/9.3.0/gcc-9.3.0/obj/x86_64-unknown-linux-gnu/libstdc++-v3/include/x86_64-unknown-linux-gnu/bits/gthr-default.h:865
#2  std::condition_variable::wait (this=<optimized out>, __lock=...) at ../../../../../libstdc++-v3/src/c++11/condition_variable.cc:53
#3  0x00007fd43d537012 in TFilePrefetch::GetPendingBlock() () from /cvmfs/cms.cern.ch/slc7_amd64_gcc900/cms/cmssw/CMSSW_12_1_0_pre3/external/slc7_amd64_gcc900/lib/libRIO.so
#4  0x00007fd43d5385a8 in TFilePrefetch::ReadListOfBlocks() () from /cvmfs/cms.cern.ch/slc7_amd64_gcc900/cms/cmssw/CMSSW_12_1_0_pre3/external/slc7_amd64_gcc900/lib/libRIO.so
#5  0x00007fd43d5385f0 in TFilePrefetch::ThreadProc(void*) () from /cvmfs/cms.cern.ch/slc7_amd64_gcc900/cms/cmssw/CMSSW_12_1_0_pre3/external/slc7_amd64_gcc900/lib/libRIO.so
#6  0x00007fd43da1f258 in TThread::Function(void*) () from /cvmfs/cms.cern.ch/slc7_amd64_gcc900/cms/cmssw/CMSSW_12_1_0_pre3/external/slc7_amd64_gcc900/lib/libThread.so
#7  0x00007fd43b9c3ea5 in start_thread () from /lib64/libpthread.so.0
#8  0x00007fd43b6ec9fd in clone () from /lib64/libc.so.6
Thread 3 (Thread 0x7fd41d11d700 (LWP 164843) "cmsRun"):
#0  0x00007fd43b9c7a35 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
#1  0x00007fd43bfbf85c in __gthread_cond_wait (__mutex=<optimized out>, __cond=<optimized out>) at /data/cmsbld/jenkins/workspace/auto-builds/CMSSW_11_1_0_pre6-slc7_amd64_gcc900/build/CMSSW_11_1_0_pre6-build/BUILD/slc7_amd64_gcc900/external/gcc/9.3.0/gcc-9.3.0/obj/x86_64-unknown-linux-gnu/libstdc++-v3/include/x86_64-unknown-linux-gnu/bits/gthr-default.h:865
#2  std::condition_variable::wait (this=<optimized out>, __lock=...) at ../../../../../libstdc++-v3/src/c++11/condition_variable.cc:53
#3  0x00007fd43d537012 in TFilePrefetch::GetPendingBlock() () from /cvmfs/cms.cern.ch/slc7_amd64_gcc900/cms/cmssw/CMSSW_12_1_0_pre3/external/slc7_amd64_gcc900/lib/libRIO.so
#4  0x00007fd43d5385a8 in TFilePrefetch::ReadListOfBlocks() () from /cvmfs/cms.cern.ch/slc7_amd64_gcc900/cms/cmssw/CMSSW_12_1_0_pre3/external/slc7_amd64_gcc900/lib/libRIO.so
#5  0x00007fd43d5385f0 in TFilePrefetch::ThreadProc(void*) () from /cvmfs/cms.cern.ch/slc7_amd64_gcc900/cms/cmssw/CMSSW_12_1_0_pre3/external/slc7_amd64_gcc900/lib/libRIO.so
#6  0x00007fd43da1f258 in TThread::Function(void*) () from /cvmfs/cms.cern.ch/slc7_amd64_gcc900/cms/cmssw/CMSSW_12_1_0_pre3/external/slc7_amd64_gcc900/lib/libThread.so
#7  0x00007fd43b9c3ea5 in start_thread () from /lib64/libpthread.so.0
#8  0x00007fd43b6ec9fd in clone () from /lib64/libc.so.6
Thread 2 (Thread 0x7fd41f38f700 (LWP 164836) "cmsRun"):
#0  0x00007fd43b9cb1d9 in waitpid () from /lib64/libpthread.so.0
#1  0x00007fd43582e5a7 in edm::service::cmssw_stacktrace_fork() () from /cvmfs/cms.cern.ch/slc7_amd64_gcc900/cms/cmssw/CMSSW_12_1_0_pre3/lib/slc7_amd64_gcc900/pluginFWCoreServicesPlugins.so
#2  0x00007fd43582f23a in edm::service::InitRootHandlers::stacktraceHelperThread() () from /cvmfs/cms.cern.ch/slc7_amd64_gcc900/cms/cmssw/CMSSW_12_1_0_pre3/lib/slc7_amd64_gcc900/pluginFWCoreServicesPlugins.so
#3  0x00007fd43bfc4af0 in std::execute_native_thread_routine (__p=0x7fd41f567ff0) at ../../../../../libstdc++-v3/src/c++11/thread.cc:80
#4  0x00007fd43b9c3ea5 in start_thread () from /lib64/libpthread.so.0
#5  0x00007fd43b6ec9fd in clone () from /lib64/libc.so.6
Thread 1 (Thread 0x7fd439847540 (LWP 164783) "cmsRun"):
#0  0x00007fd43b6e1ccd in poll () from /lib64/libc.so.6
#1  0x00007fd43582e9d7 in full_read.constprop () from /cvmfs/cms.cern.ch/slc7_amd64_gcc900/cms/cmssw/CMSSW_12_1_0_pre3/lib/slc7_amd64_gcc900/pluginFWCoreServicesPlugins.so
#2  0x00007fd43582f30c in edm::service::InitRootHandlers::stacktraceFromThread() () from /cvmfs/cms.cern.ch/slc7_amd64_gcc900/cms/cmssw/CMSSW_12_1_0_pre3/lib/slc7_amd64_gcc900/pluginFWCoreServicesPlugins.so
#3  0x00007fd4358327bb in sig_dostack_then_abort () from /cvmfs/cms.cern.ch/slc7_amd64_gcc900/cms/cmssw/CMSSW_12_1_0_pre3/lib/slc7_amd64_gcc900/pluginFWCoreServicesPlugins.so
#4  <signal handler called>
#5  0x00007fd43ec7f801 in edm::ProcessBlockHelper::initializeFromPrimaryInput (During symbol reading: const value length mismatch for 'std::filesystem::__file_clock::_S_epoch_diff', got 8, expected 0
#6  0x00007fd41e7c54b4 in edm::RootFile::RootFile (this=0x7fd41d7fda00, fileName="file:PoolInputRepeatingSource.root", processConfiguration=..., logicalFileName="file:PoolInputRepeatingSource.root", filePtr=std::shared_ptr<edm::InputFile> (use count 10, weak count 0) = {...}, eventSkipperByID=std::shared_ptr<edm::EventSkipperByID> (use count 4, weak count 0) = {...}, skipAnyEvents=false, remainingEvents=10000, remainingLumis=-1, nStreams=1, treeCacheSize=20971520, treeMaxVirtualSize=-1, processingMode=edm::InputSource::RunsLumisAndEvents, runHelper=0x7fd439408460, noEventSort=true, productSelectorRules=..., inputType=edm::InputType::Primary, branchIDListHelper=std::shared_ptr<edm::BranchIDListHelper> (use count 6, weak count 0) = {...}, processBlockHelper=0x0, thinnedAssociationsHelper=std::shared_ptr<edm::ThinnedAssociationsHelper> (use count 6, weak count 0) = {...}, associationsFromSecondary=0x0, duplicateChecker=std::shared_ptr<edm::DuplicateChecker> (use count 4, weak count 0) = {...}, dropDescendants=false, processHistoryRegistry=..., indexesIntoFiles=std::vector of length 1, capacity 1 = {...}, currentIndexIntoFile=0, orderedProcessHistoryIDs=std::vector of length 1, capacity 1 = {...}, bypassVersionCheck=false, labelRawDataLikeMC=true, usingGoToEvent=false, enablePrefetching=true, enforceGUIDInFileName=false) at /mnt/data1/dsr/CMSSW_12_1_0_pre3/src/IOPool/Input/src/RootFile.cc:553
#7  0x00007fd41e7af187 in std::make_unique<edm::RootFile, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, edm::ProcessConfiguration const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::shared_ptr<edm::InputFile>&, std::shared_ptr<edm::EventSkipperByID>&, bool&, int, int, int, unsigned int const&, int, edm::InputSource::ProcessingMode, edm::propagate_const<std::unique_ptr<edm::RunHelperBase, std::default_delete<edm::RunHelperBase> > >&, bool, edm::ProductSelectorRules&, edm::InputType, std::shared_ptr<edm::BranchIDListHelper>&, decltype(nullptr), std::shared_ptr<edm::ThinnedAssociationsHelper>&, decltype(nullptr), std::shared_ptr<edm::DuplicateChecker>&, bool, edm::ProcessHistoryRegistry&, std::vector<std::shared_ptr<edm::IndexIntoFile>, std::allocator<std::shared_ptr<edm::IndexIntoFile> > >&, int, std::vector<edm::Hash<2>, std::allocator<edm::Hash<2> > >&, bool, bool, bool, bool, bool>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, edm::ProcessConfiguration const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::shared_ptr<edm::InputFile>&, std::shared_ptr<edm::EventSkipperByID>&, bool&, int&&, int&&, int&&, unsigned int const&, int&&, edm::InputSource::ProcessingMode&&, edm::propagate_const<std::unique_ptr<edm::RunHelperBase, std::default_delete<edm::RunHelperBase> > >&, bool&&, edm::ProductSelectorRules&, edm::InputType&&, std::shared_ptr<edm::BranchIDListHelper>&, decltype(nullptr)&&, std::shared_ptr<edm::ThinnedAssociationsHelper>&, decltype(nullptr)&&, std::shared_ptr<edm::DuplicateChecker>&, bool&&, edm::ProcessHistoryRegistry&, std::vector<std::shared_ptr<edm::IndexIntoFile>, std::allocator<std::shared_ptr<edm::IndexIntoFile> > >&, int&&, std::vector<edm::Hash<2>, std::allocator<edm::Hash<2> > >&, bool&&, bool&&, bool&&, bool&&, bool&&) () at /cvmfs/cms.cern.ch/slc7_amd64_gcc900/external/gcc/9.3.0/include/c++/9.3.0/bits/unique_ptr.h:857
#8  0x00007fd41e7ac296 in edm::RepeatingCachedRootSource::makeRootFile (this=0x7fd41f7f5f80, logicalFileName="file:PoolInputRepeatingSource.root", pName="file:PoolInputRepeatingSource.root", isSkipping=false, filePtr=std::shared_ptr<edm::InputFile> (use count 10, weak count 0) = {...}, skipper=std::shared_ptr<edm::EventSkipperByID> (use count 4, weak count 0) = {...}, duplicateChecker=std::shared_ptr<edm::DuplicateChecker> (use count 4, weak count 0) = {...}, indexesIntoFiles=std::vector of length 1, capacity 1 = {...}) at /mnt/data1/dsr/CMSSW_12_1_0_pre3/src/IOPool/Input/src/RepeatingCachedRootSource.cc:287
#9  0x00007fd41e7ab2f3 in edm::RepeatingCachedRootSource::RepeatingCachedRootSource (this=0x7fd41f7f5f80, pset=..., desc=...) at /mnt/data1/dsr/CMSSW_12_1_0_pre3/src/IOPool/Input/src/RepeatingCachedRootSource.cc:161
#10 0x00007fd41e7b90dd in std::make_unique<edm::RepeatingCachedRootSource, edm::ParameterSet const&, edm::InputSourceDescription const&> () at /cvmfs/cms.cern.ch/slc7_amd64_gcc900/external/gcc/9.3.0/include/c++/9.3.0/bits/unique_ptr.h:857
#11 0x00007fd41e7b8cb1 in edmplugin::PluginFactory<edm::InputSource* (edm::ParameterSet const&, edm::InputSourceDescription const&)>::PMaker<edm::RepeatingCachedRootSource>::create(edm::ParameterSet const&, edm::InputSourceDescription const&) const (this=0x7fd41e8b34b8 <s_maker365>, args#0=..., args#1=...) at /cvmfs/cms.cern.ch/slc7_amd64_gcc900/cms/cmssw/CMSSW_12_1_0_pre3/src/FWCore/PluginManager/interface/PluginFactory.h:56
#12 0x00007fd43e6a9e79 in edmplugin::PluginFactory<edm::InputSource* (edm::ParameterSet const&, edm::InputSourceDescription const&)>::create(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, edm::ParameterSet const&, edm::InputSourceDescription const&) const (During symbol reading: const value length mismatch for 'std::filesystem::__file_clock::_S_epoch_diff', got 8, expected 0
#13 0x00007fd43e6a9b55 in edm::InputSourceFactory::makeInputSource (this=0x7fd43ea7ff40 <edm::InputSourceFactory::singleInstance_>, conf=..., desc=...) at /mnt/data1/dsr/CMSSW_12_1_0_pre3/src/FWCore/Framework/src/InputSourceFactory.cc:32
#14 0x00007fd43e5ae1fc in edm::<lambda()>::operator()(void) const (__closure=0x7ffd143daea0) at /mnt/data1/dsr/CMSSW_12_1_0_pre3/src/FWCore/Framework/src/EventProcessor.cc:185
#15 0x00007fd43e5bf098 in edm::convertException::wrap<edm::makeInput(edm::ParameterSet&, const edm::CommonParams&, std::shared_ptr<edm::ProductRegistry>, std::shared_ptr<edm::BranchIDListHelper>, const std::shared_ptr<edm::ProcessBlockHelper>&, std::shared_ptr<edm::ThinnedAssociationsHelper>, std::shared_ptr<edm::ActivityRegistry>, std::shared_ptr<const edm::ProcessConfiguration>, const edm::PreallocationConfiguration&)::<lambda()> >(edm::<lambda()>) (iFunc=...) at /cvmfs/cms.cern.ch/slc7_amd64_gcc900/cms/cmssw/CMSSW_12_1_0_pre3/src/FWCore/Utilities/interface/ConvertException.h:21
#16 0x00007fd43e5ae76e in edm::makeInput (params=..., common=..., preg=std::shared_ptr<edm::ProductRegistry> (use count 4, weak count 0) = {...}, branchIDListHelper=std::shared_ptr<edm::BranchIDListHelper> (use count 6, weak count 0) = {...}, processBlockHelper=std::shared_ptr<edm::ProcessBlockHelper> (use count 3, weak count 0) = {...}, thinnedAssociationsHelper=std::shared_ptr<edm::ThinnedAssociationsHelper> (use count 6, weak count 0) = {...}, areg=std::shared_ptr<edm::ActivityRegistry> (use count 5, weak count 0) = {...}, processConfiguration=std::shared_ptr<const edm::ProcessConfiguration> (use count 2, weak count 0) = {...}, allocations=...) at /mnt/data1/dsr/CMSSW_12_1_0_pre3/src/FWCore/Framework/src/EventProcessor.cc:184
#17 0x00007fd43e5b1560 in edm::EventProcessor::init (During symbol reading: const value length mismatch for 'std::filesystem::__file_clock::_S_epoch_diff', got 8, expected 0
#18 0x00007fd43e5b071f in edm::EventProcessor::EventProcessor (this=0x7fd43774ee00, processDesc=std::shared_ptr<edm::ProcessDesc> (use count 2, weak count 0) = {...}, token=..., legacy=edm::serviceregistry::kTokenOverrides) at /mnt/data1/dsr/CMSSW_12_1_0_pre3/src/FWCore/Framework/src/EventProcessor.cc:339
#19 0x00000000004384b8 in std::make_unique<edm::EventProcessor, std::shared_ptr<edm::ProcessDesc>&, edm::ServiceToken&, edm::serviceregistry::ServiceLegacy> () at /cvmfs/cms.cern.ch/slc7_amd64_gcc900/external/gcc/9.3.0/include/c++/9.3.0/bits/unique_ptr.h:857
#20 0x0000000000432c98 in <lambda()>::<lambda()>::operator()(void) const (During symbol reading: const value length mismatch for '__itt_null', got 24, expected 0
#21 0x0000000000434e24 in tbb::detail::d1::task_arena_function<main(int, char**)::<lambda()>::<lambda()>, void>::operator()(void) const (this=0x7ffd143dc3b0) at /cvmfs/cms.cern.ch/slc7_amd64_gcc900/external/tbb/v2021.3.0-0d3445be0620ff199ed816ed832b2f97/include/oneapi/tbb/task_arena.h:63
#22 0x00007fd43c7dd302 in tbb::detail::r1::task_arena_impl::execute (ta=..., d=warning: RTTI symbol not found for class 'tbb::detail::d1::task_arena_function<main::{lambda()#1}::operator()() const::{lambda()#1}, void>'
#23 0x0000000000434d2d in tbb::detail::d1::task_arena::execute_impl<void, main(int, char**)::<lambda()>::<lambda()> >(<lambda()>::<lambda()> &) (this=0x7ffd143dc6d0, f=...) at /cvmfs/cms.cern.ch/slc7_amd64_gcc900/external/tbb/v2021.3.0-0d3445be0620ff199ed816ed832b2f97/include/oneapi/tbb/task_arena.h:269
#24 0x0000000000434b29 in tbb::detail::d1::task_arena::execute<main(int, char**)::<lambda()>::<lambda()> >(<lambda()>::<lambda()> &&) (this=0x7ffd143dc6d0, f=...) at /cvmfs/cms.cern.ch/slc7_amd64_gcc900/external/tbb/v2021.3.0-0d3445be0620ff199ed816ed832b2f97/include/oneapi/tbb/task_arena.h:418
#25 0x0000000000434016 in <lambda()>::operator()(void) const (__closure=0x7ffd143dcef0) at /mnt/data1/dsr/CMSSW_12_1_0_pre3/src/FWCore/Framework/bin/cmsRun.cpp:297
#26 0x0000000000434b3d in edm::convertException::wrap<main(int, char**)::<lambda()> >(<lambda()>) (iFunc=...) at /cvmfs/cms.cern.ch/slc7_amd64_gcc900/cms/cmssw/CMSSW_12_1_0_pre3/src/FWCore/Utilities/interface/ConvertException.h:21
#27 0x00000000004348f5 in main (argc=2, argv=0x7ffd143dd128) at /mnt/data1/dsr/CMSSW_12_1_0_pre3/src/FWCore/Framework/bin/cmsRun.cpp:123

Current Modules:

Module: none (crashed)

A fatal system signal has occurred: segmentation violation
/mnt/data1/dsr/CMSSW_12_1_0_pre3/src/IOPool/Input/test/testRepeatingCachedRootSource.sh: line 7: 164783 Segmentation fault      cmsRun ${LOCALTOP}/src/IOPool/Input/test/test_repeating_cfg.py
+ die 'Failed cmsRun test_repeating_cfg.py' 139
+ echo Failed cmsRun test_repeating_cfg.py: status 139
Failed cmsRun test_repeating_cfg.py: status 139
+ exit 139

---> test TestIOPoolInputRepeating had ERRORS
```