### PR TITLE
Fixes to L2Tau CNN and deepTauID for HLT

### DIFF
--- a/RecoTauTag/HLTProducers/python/applyL2TauTag.py
+++ b/RecoTauTag/HLTProducers/python/applyL2TauTag.py
@@ -52,7 +52,8 @@ def update(process):
         nExpected = 2,
         L1TauSrc = 'hltL1sDoubleTauBigOR',
         L2Outcomes = 'hltL2TauTagNNProducer:DoubleTau',
-        DiscrWP = thWp[working_point]
+        DiscrWP = thWp[working_point],
+        l1TauPtThreshold = 250,
     )
     # L2 updated Sequence
     process.hltL2TauTagNNSequence = cms.Sequence(process.HLTDoCaloSequence + process.hltL1sDoubleTauBigOR + process.hltL2TauTagNNProducer)

--- a/RecoTauTag/HLTProducers/src/L2TauTagFilter.cc
+++ b/RecoTauTag/HLTProducers/src/L2TauTagFilter.cc
@@ -36,7 +36,7 @@ public:
         ->setComment("Which trigger should the L1 Taus collection pass");
     desc.add<edm::InputTag>("L2Outcomes", edm::InputTag(""))->setComment("L2 CNN outcomes");
     desc.add<double>("DiscrWP", 0.1227)->setComment("value of discriminator threshold");
-    desc.add<double>("l1TauPtThreshold", 250)->setComment("value of discriminator threshold");
+    desc.add<double>("l1TauPtThreshold", 250)->setComment("value of L1Tau pass-through pt threshold");
     descriptions.addWithDefaultLabel(desc);
   }
 
@@ -57,7 +57,7 @@ public:
       throw cms::Exception("Inconsistent Data", "L2TauTagFilter::hltFilter") << "CNN output size != L1 taus size \n";
     }
     for (size_t l1_idx = 0; l1_idx < l1Taus.size(); l1_idx++) {
-      if (L2Outcomes[l1_idx] >= discrWP_ || l1Taus[l1_idx]->polarP4().pt() > l1PtTh_) {
+      if (L2Outcomes[l1_idx] >= discrWP_ || l1Taus[l1_idx]->pt() > l1PtTh_) {
         filterproduct.addObject(nTauPassed, l1Taus[l1_idx]);
         nTauPassed++;
       }

--- a/RecoTauTag/HLTProducers/src/L2TauTagFilter.cc
+++ b/RecoTauTag/HLTProducers/src/L2TauTagFilter.cc
@@ -26,7 +26,8 @@ public:
         l1TauSrc_(cfg.getParameter<edm::InputTag>("L1TauSrc")),
         l1TauSrcToken_(consumes<trigger::TriggerFilterObjectWithRefs>(l1TauSrc_)),
         l2OutcomesToken_(consumes<std::vector<float>>(cfg.getParameter<edm::InputTag>("L2Outcomes"))),
-        discrWP_(cfg.getParameter<double>("DiscrWP")) {}
+        discrWP_(cfg.getParameter<double>("DiscrWP")),
+        l1PtTh_(cfg.getParameter<double>("l1TauPtThreshold")) {}
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
     makeHLTFilterDescription(desc);
@@ -35,6 +36,7 @@ public:
         ->setComment("Which trigger should the L1 Taus collection pass");
     desc.add<edm::InputTag>("L2Outcomes", edm::InputTag(""))->setComment("L2 CNN outcomes");
     desc.add<double>("DiscrWP", 0.1227)->setComment("value of discriminator threshold");
+    desc.add<double>("l1TauPtThreshold", 250)->setComment("value of discriminator threshold");
     descriptions.addWithDefaultLabel(desc);
   }
 
@@ -55,7 +57,7 @@ public:
       throw cms::Exception("Inconsistent Data", "L2TauTagFilter::hltFilter") << "CNN output size != L1 taus size \n";
     }
     for (size_t l1_idx = 0; l1_idx < l1Taus.size(); l1_idx++) {
-      if (L2Outcomes[l1_idx] >= discrWP_) {
+      if (L2Outcomes[l1_idx] >= discrWP_ || l1Taus[l1_idx]->polarP4().pt() > l1PtTh_) {
         filterproduct.addObject(nTauPassed, l1Taus[l1_idx]);
         nTauPassed++;
       }
@@ -70,6 +72,7 @@ private:
   const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> l1TauSrcToken_;
   const edm::EDGetTokenT<std::vector<float>> l2OutcomesToken_;
   const double discrWP_;
+  const double l1PtTh_;
 };
 
 //define this as a plug-in

--- a/RecoTauTag/HLTProducers/src/L2TauTagNNProducer.cc
+++ b/RecoTauTag/HLTProducers/src/L2TauTagNNProducer.cc
@@ -255,18 +255,21 @@ void L2TauNNProducer::fillDescriptions(edm::ConfigurationDescriptions& descripti
   edm::ParameterSetDescription desc;
   desc.add<int>("debugLevel", 0)->setComment("set debug level for printing out info");
   edm::ParameterSetDescription l1TausPset;
-  l1TausPset.add<std::string>("L1CollectionName", "")->setComment("Name of collections");
-  l1TausPset.add<edm::InputTag>("L1TauTrigger", edm::InputTag(""))
+  l1TausPset.add<std::string>("L1CollectionName", "DoubleTau")->setComment("Name of collections");
+  l1TausPset.add<edm::InputTag>("L1TauTrigger", edm::InputTag("hltL1sDoubleTauBigOR"))
       ->setComment("Which trigger should the L1 Taus collection pass");
-  desc.addVPSet("L1Taus", l1TausPset);
-  desc.add<edm::InputTag>("hbheInput", edm::InputTag(""))->setComment("HBHE recHit collection");
-  desc.add<edm::InputTag>("hoInput", edm::InputTag(""))->setComment("HO recHit Collection");
-  desc.add<edm::InputTag>("ebInput", edm::InputTag(""))->setComment("EB recHit Collection");
-  desc.add<edm::InputTag>("eeInput", edm::InputTag(""))->setComment("EE recHit Collection");
+  edm::ParameterSet l1TausPSetDefault;
+  l1TausPSetDefault.addParameter<std::string>("L1CollectionName", "DoubleTau");
+  l1TausPSetDefault.addParameter<edm::InputTag>("L1TauTrigger", edm::InputTag("hltL1sDoubleTauBigOR"));
+  desc.addVPSet("L1Taus", l1TausPset, {l1TausPSetDefault});
+  desc.add<edm::InputTag>("hbheInput", edm::InputTag("hltHbhereco"))->setComment("HBHE recHit collection");
+  desc.add<edm::InputTag>("hoInput", edm::InputTag("hltHoreco"))->setComment("HO recHit Collection");
+  desc.add<edm::InputTag>("ebInput", edm::InputTag("hltEcalRecHit:EcalRecHitsEB"))->setComment("EB recHit Collection");
+  desc.add<edm::InputTag>("eeInput", edm::InputTag("hltEcalRecHit:EcalRecHitsEE"))->setComment("EE recHit Collection");
   desc.add<edm::InputTag>("pataVertices", edm::InputTag("hltPixelVerticesSoA"))
       ->setComment("patatrack vertices collection");
   desc.add<edm::InputTag>("pataTracks", edm::InputTag("hltPixelTracksSoA"))->setComment("patatrack collection");
-  desc.add<edm::InputTag>("BeamSpot", edm::InputTag(""))->setComment("BeamSpot Collection");
+  desc.add<edm::InputTag>("BeamSpot", edm::InputTag("hltOnlineBeamSpot"))->setComment("BeamSpot Collection");
   desc.add<uint>("maxVtx", 100)->setComment("max output collection size (number of accepted vertices)");
   desc.add<double>("fractionSumPt2", 0.3)->setComment("threshold on sumPt2 fraction of the leading vertex");
   desc.add<double>("minSumPt2", 0.)->setComment("min sumPt2");

--- a/RecoTauTag/HLTProducers/src/L2TauTagNNProducer.cc
+++ b/RecoTauTag/HLTProducers/src/L2TauTagNNProducer.cc
@@ -406,8 +406,8 @@ void L2TauNNProducer::fillL1TauVars(tensorflow::Tensor& cellGridMatrix, const st
         auto getCell = [&](NNInputs input) -> float& {
           return getCellImpl(cellGridMatrix, tau_idx, phi_idx, eta_idx, input);
         };
-        getCell(NNInputs::l1Tau_pt) = allTaus[tau_idx]->polarP4().pt();
-        getCell(NNInputs::l1Tau_eta) = allTaus[tau_idx]->polarP4().eta();
+        getCell(NNInputs::l1Tau_pt) = allTaus[tau_idx]->pt();
+        getCell(NNInputs::l1Tau_eta) = allTaus[tau_idx]->eta();
         getCell(NNInputs::l1Tau_hwIso) = allTaus[tau_idx]->hwIso();
       }
     }
@@ -678,8 +678,8 @@ void L2TauNNProducer::fillPatatracks(tensorflow::Tensor& cellGridMatrix,
   };
   const int nTaus = static_cast<int>(allTaus.size());
   for (tau_idx = 0; tau_idx < nTaus; tau_idx++) {
-    const float tauEta = allTaus[tau_idx]->polarP4().eta();
-    const float tauPhi = allTaus[tau_idx]->polarP4().phi();
+    const float tauEta = allTaus[tau_idx]->eta();
+    const float tauPhi = allTaus[tau_idx]->phi();
 
     auto maxTracks = patatracks_tsoa.stride();
     auto const* quality = patatracks_tsoa.qualityData();
@@ -829,7 +829,7 @@ void L2TauNNProducer::produce(edm::Event& event, const edm::EventSetup& eventset
     for (size_t tau_pos = 0; tau_pos < nTau; ++tau_pos) {
       const auto tau_idx = TauCollectionMap[inp_idx][tau_pos];
       if (debugLevel_ > 0) {
-        edm::LogInfo("DebugInfo") << event.id().event() << " \t " << (allTaus[tau_idx])->polarP4().pt() << " \t "
+        edm::LogInfo("DebugInfo") << event.id().event() << " \t " << (allTaus[tau_idx])->pt() << " \t "
                                   << tau_score.at(tau_idx) << std::endl;
       }
       (*tau_tags)[tau_pos] = tau_score.at(tau_idx);

--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -1163,9 +1163,9 @@ public:
     desc.add<bool>("save_inputs", false);
     desc.add<bool>("is_online", false);
 
-    desc.add<std::vector<std::string>>("VSeWP");
-    desc.add<std::vector<std::string>>("VSmuWP");
-    desc.add<std::vector<std::string>>("VSjetWP");
+    desc.add<std::vector<std::string>>("VSeWP", {"-1."});
+    desc.add<std::vector<std::string>>("VSmuWP", {"-1."});
+    desc.add<std::vector<std::string>>("VSjetWP", {"-1."});
 
     desc.addUntracked<edm::InputTag>("basicTauDiscriminators", edm::InputTag("basicTauDiscriminators"));
     desc.addUntracked<edm::InputTag>("basicTauDiscriminatorsdR03", edm::InputTag("basicTauDiscriminatorsdR03"));


### PR DESCRIPTION
#### PR description:

This PR fixes critical issues found in L2NNTag modules and deepTauID for HLT. The PR contains the following changes:
* Add default values for configurable parameters where those have not been set to allow correct parsing to ConfDB;
* Allow a pass-through at L2 for all L1 taus with pt above a configurable threshold in L2NNTauTag to avoid observed drop of efficiency for taus with gen_vis_pt > 500 GeV (for gen_vis_pt < 500 GeV the algo efficiency is above 90%). We estimated that the rate with the pass-though threshold of 250 GeV (default) does not significantly change: for the 3 kHz Working Point (WP) it goes from 2999.7 Hz to 3026.4 Hz (0.9%); changes are similar for other WPs.

The changes are simple fixes and do not change behavior of the modules, but on the other hand are critical as without them L2Tau CNN and deepTauID cannot be deployed at HLT.

We plan a backport to 12_1_X as soon as this PR is accepted. 

#### PR validation:

Standard tests passed

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
