### PR TITLE
Add a configuration function to disable track-gen matching in step3 from cmsDriver

### DIFF
--- a/SimTracker/TrackAssociation/python/disableTrackMCMatch.py
+++ b/SimTracker/TrackAssociation/python/disableTrackMCMatch.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+#
+def disableTrackMCMatch(process):
+    
+    if hasattr(process,'prunedTpClusterProducer'):
+        process.prunedTpClusterProducer.throwOnMissingCollections = cms.bool(False)
+        
+    if hasattr(process,'prunedTrackMCMatch'):
+        process.prunedTrackMCMatch.throwOnMissingTPCollection = cms.bool(False)
+        
+    return process


### PR DESCRIPTION

#### PR description:
PR #33774 added new products to the RAWSIM format which are required to run the RECOSIM step. It is possible to disable this, but only at config level and not from cmsDriver. This PR adds a function to be passed to cmsDriver with the `--customise` flag.
This is required to run the step3 on older files, which is needed by some groups.
The command that first triggered this issue was 
```
cmsDriver.py step3 --filein root://cms-xrd-global.cern.ch//store/mc/Run3Winter21DRMiniAOD/DYToLL_M-50_TuneCP5_14TeV-pythia8/GEN-SIM-DIGI-RAW/FlatPU30to80FEVT_112X_mcRun3_2021_realistic_v16-v2/270024/72e988b6-0ffe-401f-bf81-5ae5c722e5f3.root  --fileout file:step3.root --mc --eventcontent AODSIM --datatier AODSIM --conditions 120X_mcRun3_2021_realistic_v9 --step RAW2DIGI,RECO,RECOSIM,EI --nThreads 4 --era Run3 --python_filename MC_step3_Run3Trigger_120X_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 10
```
in 12_0_X, which now works.
After this PR is accepted we will also require a backport for that release.

#### PR validation:

Checked on a cmsDriver invocation that the resulting process has the correct flags set

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, but will be backported later.
