### PR TITLE
migrate to `esConsumes` several test codes in the SiPixel area

### DIFF
--- a/CondFormats/SiPixelObjects/test/FastSiPixelFEDChannelContainerFromQuality.cc
+++ b/CondFormats/SiPixelObjects/test/FastSiPixelFEDChannelContainerFromQuality.cc
@@ -24,8 +24,6 @@
 #include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingTree.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelQuality.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"

--- a/CondFormats/SiPixelObjects/test/SiPixelBadFEDChannelSimulationSanityChecker.cc
+++ b/CondFormats/SiPixelObjects/test/SiPixelBadFEDChannelSimulationSanityChecker.cc
@@ -26,11 +26,15 @@ private:
   virtual void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
   // ----------member data ---------------------------
+  const edm::ESGetToken<SiPixelFEDChannelContainer, SiPixelStatusScenariosRcd> siPixelBadFEDChToken_;
+  const edm::ESGetToken<SiPixelQualityProbabilities, SiPixelStatusScenarioProbabilityRcd> siPixelQPToken_;
   const bool printdebug_;
 };
 
 SiPixelBadFEDChannelSimulationSanityChecker::SiPixelBadFEDChannelSimulationSanityChecker(edm::ParameterSet const& p)
-    : printdebug_(p.getUntrackedParameter<bool>("printDebug", true)) {
+    : siPixelBadFEDChToken_(esConsumes()),
+      siPixelQPToken_(esConsumes()),
+      printdebug_(p.getUntrackedParameter<bool>("printDebug", true)) {
   edm::LogInfo("SiPixelBadFEDChannelSimulationSanityChecker")
       << "SiPixelBadFEDChannelSimulationSanityChecker" << std::endl;
 }
@@ -55,9 +59,7 @@ void SiPixelBadFEDChannelSimulationSanityChecker::analyze(const edm::Event& e, c
   }
 
   //this part gets the handle of the event source and the record (i.e. the Database)
-  edm::ESHandle<SiPixelFEDChannelContainer> qualityCollectionHandle;
-  context.get<SiPixelStatusScenariosRcd>().get(qualityCollectionHandle);
-  const SiPixelFEDChannelContainer* quality_map = qualityCollectionHandle.product();
+  const SiPixelFEDChannelContainer* quality_map = &context.getData(siPixelBadFEDChToken_);
 
   edm::eventsetup::EventSetupRecordKey recordKey2(
       edm::eventsetup::EventSetupRecordKey::TypeTag::findType("SiPixelStatusScenarioProbabilityRcd>"));
@@ -69,9 +71,7 @@ void SiPixelBadFEDChannelSimulationSanityChecker::analyze(const edm::Event& e, c
   }
 
   //this part gets the handle of the event source and the record (i.e. the Database)
-  edm::ESHandle<SiPixelQualityProbabilities> scenarioProbabilityHandle;
-  context.get<SiPixelStatusScenarioProbabilityRcd>().get(scenarioProbabilityHandle);
-  const SiPixelQualityProbabilities* myProbabilities = scenarioProbabilityHandle.product();
+  const SiPixelQualityProbabilities* myProbabilities = &context.getData(siPixelQPToken_);
 
   SiPixelFEDChannelContainer::SiPixelBadFEDChannelsScenarioMap m_qualities = quality_map->getScenarioMap();
   SiPixelQualityProbabilities::probabilityMap m_probabilities = myProbabilities->getProbability_Map();

--- a/CondFormats/SiPixelObjects/test/SiPixelFEDChannelContainerFromQualityConverter.cc
+++ b/CondFormats/SiPixelObjects/test/SiPixelFEDChannelContainerFromQualityConverter.cc
@@ -53,6 +53,9 @@ private:
   virtual void endJob() override;
 
   // ----------member data ---------------------------
+  const edm::ESGetToken<SiPixelQuality, SiPixelQualityFromDbRcd> siPixelQualityToken_;
+  const edm::ESGetToken<SiPixelFedCablingMap, SiPixelFedCablingMapRcd> siPixelCablingToken_;
+
   const std::string m_record;
   const bool printdebug_;
   const bool isMC_;
@@ -68,7 +71,9 @@ private:
 //
 SiPixelFEDChannelContainerFromQualityConverter::SiPixelFEDChannelContainerFromQualityConverter(
     const edm::ParameterSet& iConfig)
-    : m_record(iConfig.getParameter<std::string>("record")),
+    : siPixelQualityToken_(esConsumes()),
+      siPixelCablingToken_(esConsumes()),
+      m_record(iConfig.getParameter<std::string>("record")),
       printdebug_(iConfig.getUntrackedParameter<bool>("printDebug", false)),
       isMC_(iConfig.getUntrackedParameter<bool>("isMC", true)),
       removeEmptyPayloads_(iConfig.getUntrackedParameter<bool>("removeEmptyPayloads", false)) {
@@ -95,11 +100,8 @@ void SiPixelFEDChannelContainerFromQualityConverter::analyze(const edm::Event& i
 
   if (hasQualityIOV) {
     //Retrieve the strip quality from conditions
-    edm::ESHandle<SiPixelQuality> siPixelQuality_;
-    iSetup.get<SiPixelQualityFromDbRcd>().get(siPixelQuality_);
-
-    edm::ESHandle<SiPixelFedCablingMap> cablingMapHandle;
-    iSetup.get<SiPixelFedCablingMapRcd>().get(cablingMapHandle);
+    edm::ESHandle<SiPixelQuality> siPixelQuality_ = iSetup.getHandle(siPixelQualityToken_);
+    edm::ESHandle<SiPixelFedCablingMap> cablingMapHandle = iSetup.getHandle(siPixelCablingToken_);
 
     std::string scenario = std::to_string(RunNumber_) + "_" + std::to_string(LuminosityBlockNumber_);
 

--- a/CondFormats/SiPixelObjects/test/SiPixelFEDChannelContainerTestReader.cc
+++ b/CondFormats/SiPixelObjects/test/SiPixelFEDChannelContainerTestReader.cc
@@ -24,12 +24,14 @@ private:
   virtual void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
   // ----------member data ---------------------------
+  const edm::ESGetToken<SiPixelFEDChannelContainer, SiPixelStatusScenariosRcd> siPixelBadFEDChToken_;
   const bool printdebug_;
   const std::string formatedOutput_;
 };
 
 SiPixelFEDChannelContainerTestReader::SiPixelFEDChannelContainerTestReader(edm::ParameterSet const& p)
-    : printdebug_(p.getUntrackedParameter<bool>("printDebug", true)),
+    : siPixelBadFEDChToken_(esConsumes()),
+      printdebug_(p.getUntrackedParameter<bool>("printDebug", true)),
       formatedOutput_(p.getUntrackedParameter<std::string>("outputFile", "")) {
   edm::LogInfo("SiPixelFEDChannelContainerTestReader") << "SiPixelFEDChannelContainerTestReader" << std::endl;
 }
@@ -54,11 +56,8 @@ void SiPixelFEDChannelContainerTestReader::analyze(const edm::Event& e, const ed
   }
 
   //this part gets the handle of the event source and the record (i.e. the Database)
-  edm::ESHandle<SiPixelFEDChannelContainer> qualityCollectionHandle;
-  edm::LogInfo("SiPixelFEDChannelContainerTestReader") << "got eshandle" << std::endl;
-
-  context.get<SiPixelStatusScenariosRcd>().get(qualityCollectionHandle);
-  edm::LogInfo("SiPixelFEDChannelContainerTestReader") << "got context" << std::endl;
+  edm::ESHandle<SiPixelFEDChannelContainer> qualityCollectionHandle = context.getHandle(siPixelBadFEDChToken_);
+  edm::LogInfo("SiPixelFEDChannelContainerTestReader") << "got eshandle from context" << std::endl;
 
   const SiPixelFEDChannelContainer* quality_map = qualityCollectionHandle.product();
   edm::LogInfo("SiPixelFEDChannelContainerTestReader") << "got SiPixelFEDChannelContainer* " << std::endl;

--- a/CondFormats/SiPixelObjects/test/SiPixelFedCablingMapAnalyzer.cc
+++ b/CondFormats/SiPixelObjects/test/SiPixelFedCablingMapAnalyzer.cc
@@ -1,6 +1,6 @@
 //#include <memory>
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -17,27 +17,27 @@ using namespace edm;
 using namespace sipixelobjects;
 
 // class declaration
-class SiPixelFedCablingMapAnalyzer : public edm::EDAnalyzer {
+class SiPixelFedCablingMapAnalyzer : public edm::one::EDAnalyzer<> {
 public:
-  explicit SiPixelFedCablingMapAnalyzer(const edm::ParameterSet&) {}
+  explicit SiPixelFedCablingMapAnalyzer(const edm::ParameterSet&) : fedCablingToken_(esConsumes()) {}
   ~SiPixelFedCablingMapAnalyzer();
   virtual void analyze(const edm::Event&, const edm::EventSetup&);
 
 private:
+  edm::ESGetToken<SiPixelFedCablingMap, SiPixelFedCablingMapRcd> fedCablingToken_;
 };
 
-SiPixelFedCablingMapAnalyzer::~SiPixelFedCablingMapAnalyzer() {}
+SiPixelFedCablingMapAnalyzer::~SiPixelFedCablingMapAnalyzer() = default;
 
 void SiPixelFedCablingMapAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  std::cout << "====== SiPixelFedCablingMapAnalyzer" << std::endl;
+  LogPrint("SiPixelFedCablingMapAnalyzer") << "====== SiPixelFedCablingMapAnalyzer" << std::endl;
 
-  edm::ESHandle<SiPixelFedCablingMap> map;
-  iSetup.get<SiPixelFedCablingMapRcd>().get(map);
+  const SiPixelFedCablingMap* map = &iSetup.getData(fedCablingToken_);
 
   LogInfo(" got map, version: ") << map->version();
   auto tree = map->cablingTree();
-  LogInfo("PRINT MAP:") << tree->print(100);
-  LogInfo("PRINT MAP, end:");
+  LogInfo("SiPixelFedCablingMapAnalyzer") << "PRINT MAP:" << tree->print(100);
+  LogInfo("SiPixelFedCablingMapAnalyzer") << "PRINT MAP, end:";
 }
 
 //define this as a plug-in

--- a/CondFormats/SiPixelObjects/test/SiPixelQualityProbabilitiesTestReader.cc
+++ b/CondFormats/SiPixelObjects/test/SiPixelQualityProbabilitiesTestReader.cc
@@ -22,12 +22,14 @@ private:
   virtual void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
   // ----------member data ---------------------------
+  const edm::ESGetToken<SiPixelQualityProbabilities, SiPixelStatusScenarioProbabilityRcd> siPixelQPToken_;
   const bool printdebug_;
   const std::string formatedOutput_;
 };
 
 SiPixelQualityProbabilitiesTestReader::SiPixelQualityProbabilitiesTestReader(edm::ParameterSet const& p)
-    : printdebug_(p.getUntrackedParameter<bool>("printDebug", true)),
+    : siPixelQPToken_(esConsumes()),
+      printdebug_(p.getUntrackedParameter<bool>("printDebug", true)),
       formatedOutput_(p.getUntrackedParameter<std::string>("outputFile", "")) {
   edm::LogInfo("SiPixelQualityProbabilitiesTestReader") << "SiPixelQualityProbabilitiesTestReader" << std::endl;
 }
@@ -52,11 +54,8 @@ void SiPixelQualityProbabilitiesTestReader::analyze(const edm::Event& e, const e
   }
 
   //this part gets the handle of the event source and the record (i.e. the Database)
-  edm::ESHandle<SiPixelQualityProbabilities> scenarioProbabilityHandle;
-  edm::LogInfo("SiPixelQualityProbabilitiesTestReader") << "got eshandle" << std::endl;
-
-  context.get<SiPixelStatusScenarioProbabilityRcd>().get(scenarioProbabilityHandle);
-  edm::LogInfo("SiPixelQualityProbabilitiesTestReader") << "got context" << std::endl;
+  edm::ESHandle<SiPixelQualityProbabilities> scenarioProbabilityHandle = context.getHandle(siPixelQPToken_);
+  edm::LogInfo("SiPixelQualityProbabilitiesTestReader") << "got eshandle from context" << std::endl;
 
   const SiPixelQualityProbabilities* myProbabilities = scenarioProbabilityHandle.product();
   edm::LogInfo("SiPixelQualityProbabilitiesTestReader") << "got SiPixelQualityProbabilities* " << std::endl;

--- a/CondFormats/SiPixelObjects/test/SiPixelTestSummary.cc
+++ b/CondFormats/SiPixelObjects/test/SiPixelTestSummary.cc
@@ -2,7 +2,7 @@
 
 #include <string.h>
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -20,17 +20,18 @@ using std::string;
 using namespace std;
 
 // ----------------------------------------------------------------------
-class SiPixelTestSummary : public edm::EDAnalyzer {
+class SiPixelTestSummary : public edm::one::EDAnalyzer<> {
 public:
-  explicit SiPixelTestSummary(const edm::ParameterSet&) {}
+  explicit SiPixelTestSummary(const edm::ParameterSet&) : geomToken_(esConsumes()) {}
   ~SiPixelTestSummary();
   virtual void analyze(const edm::Event&, const edm::EventSetup&);
 
 private:
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
 };
 
 // ----------------------------------------------------------------------
-SiPixelTestSummary::~SiPixelTestSummary() {}
+SiPixelTestSummary::~SiPixelTestSummary() = default;
 
 // ----------------------------------------------------------------------
 void SiPixelTestSummary::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
@@ -38,8 +39,7 @@ void SiPixelTestSummary::analyze(const edm::Event& iEvent, const edm::EventSetup
 
   SiPixelDetSummary a(1);
 
-  edm::ESHandle<TrackerGeometry> pDD;
-  iSetup.get<TrackerDigiGeometryRecord>().get(pDD);
+  const TrackerGeometry* pDD = &iSetup.getData(geomToken_);
 
   cout << "**********************************************************************" << endl;
   cout << " *** Geometry node for TrackerGeom is  " << &(*pDD) << std::endl;


### PR DESCRIPTION
resolves https://github.com/cms-AlCaDB/AlCaTools/issues/50

#### PR description:

In response to https://github.com/cms-AlCaDB/AlCaTools/issues/50.
Profited to modernize the code.

#### PR validation:

`cmssw` compiles

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
cc:
@SanjanaSekhar
