### PR TITLE
[Tracker Alignment] move run-based analysis of `PrimaryVertexValidation` to `beginRun`

### DIFF
--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
@@ -70,16 +70,21 @@
 // class decleration
 //
 
-class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedResources> {
+class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::SharedResources> {
 public:
   explicit PrimaryVertexValidation(const edm::ParameterSet&);
   ~PrimaryVertexValidation() override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
+  // framework provided methods
   void beginJob() override;
+  void beginRun(edm::Run const& iRun, edm::EventSetup const& iSetup) override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endRun(edm::Run const&, edm::EventSetup const&) override{};
   void endJob() override;
+
+  // user defined methods
   bool isBFieldConsistentWithMode(const edm::EventSetup& iSetup) const;
   std::pair<long long, long long> getRunTime(const edm::EventSetup& iSetup) const;
   bool isHit2D(const TrackingRecHit& hit, const PVValHelper::detectorPhase& thePhase) const;
@@ -148,10 +153,11 @@ private:
   // tokens form the EventSetup
   const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magFieldToken_;
   const edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> trackingGeomToken_;
-  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
   const edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> ttkToken_;
   const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
-  const edm::ESGetToken<RunInfo, RunInfoRcd> runInfoToken_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoTokenBR_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomTokenBR_;
+  const edm::ESGetToken<RunInfo, RunInfoRcd> runInfoTokenBR_;
 
   const int compressionSettings_;  // determines the ROOT compression settings in TFileService
   bool storeNtuple_;

--- a/Alignment/OfflineValidation/plugins/SplitVertexResolution.cc
+++ b/Alignment/OfflineValidation/plugins/SplitVertexResolution.cc
@@ -290,7 +290,7 @@ SplitVertexResolution::SplitVertexResolution(const edm::ParameterSet& iConfig)
   std::copy(vect.begin(), vect.begin() + nVtxBins_ + 1, myNVtx_bins_.begin());
 }
 
-SplitVertexResolution::~SplitVertexResolution() {}
+SplitVertexResolution::~SplitVertexResolution() = default;
 
 // ------------ method called for each event  ------------
 void SplitVertexResolution::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {


### PR DESCRIPTION
#### PR description:

Follow-up to https://github.com/cms-sw/cmssw/pull/35983, further optimization by doing run-based analysis of `PrimaryVertexValidation` in the `beginRun` method.

#### PR validation:

Unit tests pass.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A 
