### PR TITLE
fix for `testPhase2PixelNtuple` unit test

### DIFF
--- a/SLHCUpgradeSimulations/Geometry/test/phase2_digi_reco_pixelntuple_cfg.py
+++ b/SLHCUpgradeSimulations/Geometry/test/phase2_digi_reco_pixelntuple_cfg.py
@@ -111,8 +111,11 @@ process.endjob_step = cms.EndPath(process.endOfProcess)
 #process.FEVTDEBUGHLToutput_step = cms.EndPath(process.FEVTDEBUGHLToutput)
 
 # Schedule definition
-process.schedule = cms.Schedule(process.digitisation_step,process.L1simulation_step,process.L1TrackTrigger_step,process.digi2raw_step)
-process.schedule.extend(process.HLTSchedule)
+# process.schedule imported from cff in HLTrigger.Configuration
+process.schedule.insert(0, process.digitisation_step)
+process.schedule.insert(1, process.L1simulation_step)
+process.schedule.insert(2, process.L1TrackTrigger_step)
+process.schedule.insert(3, process.digi2raw_step)
 process.schedule.extend([process.raw2digi_step,process.L1Reco_step,process.reconstruction_step,process.user_step,process.endjob_step])
 from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
 associatePatAlgosToolsTask(process)


### PR DESCRIPTION
#### PR description:

This PR fixes a unit test of `SLHCUpgradeSimulations/Geometry` that stopped working after the integration of #35858
(see discussion in the latter for some more details).

#### PR validation:

The relevant cfg file now works (the unit test itself fails locally due to the input file not being available anymore).

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

N/A