### PR TITLE
Allow fast merge for file created using concurrent LuminosityBlocks

### DIFF
--- a/DataFormats/Provenance/src/IndexIntoFile.cc
+++ b/DataFormats/Provenance/src/IndexIntoFile.cc
@@ -1841,10 +1841,6 @@ namespace edm {
   bool IndexIntoFile::IndexIntoFileItrEntryOrder::entryContinues() const {
     auto entry = runOrLumisEntry(indexToLumi()).entry();
     return entry == invalidEntry;
-    /*if (entry == invalidEntry) {
-      return true;
-    }
-    return (indexToEventRange() != indexToLumi()) ; */
   }
 
   LuminosityBlockNumber_t IndexIntoFile::IndexIntoFileItrEntryOrder::peekAheadAtLumi() const {

--- a/DataFormats/Provenance/src/IndexIntoFile.cc
+++ b/DataFormats/Provenance/src/IndexIntoFile.cc
@@ -1725,6 +1725,288 @@ namespace edm {
     return indexIntoFile()->runOrLumiIndexes()[index].lumi();
   }
 
+  //*************************************
+  IndexIntoFile::IndexIntoFileItrEntryOrder::IndexIntoFileItrEntryOrder(IndexIntoFile const* indexIntoFile,
+                                                                        EntryType entryType,
+                                                                        int indexToRun,
+                                                                        int indexToLumi,
+                                                                        int indexToEventRange,
+                                                                        long long indexToEvent,
+                                                                        long long nEvents)
+      : IndexIntoFileItrImpl(
+            indexIntoFile, entryType, indexToRun, indexToLumi, indexToEventRange, indexToEvent, nEvents) {
+    auto const& runOrLumiEntries = this->indexIntoFile()->runOrLumiEntries();
+    fileOrderRunOrLumiEntry_.reserve(runOrLumiEntries.size());
+    auto const itBegin = runOrLumiEntries.begin();
+    auto itPresentEntryToRunOrLumis = runOrLumiEntries.begin();
+    auto itRestartSearchAt = runOrLumiEntries.begin();
+    EntryNumber_t endOfContiguousEventEntry = 0;
+    std::vector<bool> usedEntry(runOrLumiEntries.size(), false);
+    auto findFirstOpen = [](auto const& entries) {
+      return std::find(entries.begin(), entries.end(), false) - entries.begin();
+    };
+    while (fileOrderRunOrLumiEntry_.size() != runOrLumiEntries.size()) {
+      assert(itRestartSearchAt != runOrLumiEntries.end());
+      assert(itPresentEntryToRunOrLumis != runOrLumiEntries.end());
+
+      auto const index = itPresentEntryToRunOrLumis - itBegin;
+      if (usedEntry[index]) {
+        ++itPresentEntryToRunOrLumis;
+        continue;
+      }
+      assert(static_cast<std::size_t>(index) < runOrLumiEntries.size());
+      if (itPresentEntryToRunOrLumis->isRun()) {
+        //take Run as it is
+        fileOrderRunOrLumiEntry_.push_back(index);
+        usedEntry[index] = true;
+        itRestartSearchAt = runOrLumiEntries.begin() + findFirstOpen(usedEntry);
+        itPresentEntryToRunOrLumis = itRestartSearchAt;
+        continue;
+      }
+      auto const beginEvents = itPresentEntryToRunOrLumis->beginEvents();
+      if (beginEvents == invalidEntry) {
+        //this is an empty lumi. We want to preserve the order w.r.t previous entries
+        if (std::find(usedEntry.begin(), usedEntry.begin() + index, false) == usedEntry.begin() + index) {
+          fileOrderRunOrLumiEntry_.push_back(index);
+          usedEntry[index] = true;
+          itRestartSearchAt = runOrLumiEntries.begin() + findFirstOpen(usedEntry);
+          itPresentEntryToRunOrLumis = itRestartSearchAt;
+          continue;
+        }
+      } else if (beginEvents == endOfContiguousEventEntry) {
+        fileOrderRunOrLumiEntry_.push_back(index);
+        usedEntry[index] = true;
+        endOfContiguousEventEntry = itPresentEntryToRunOrLumis->endEvents();
+        itRestartSearchAt = runOrLumiEntries.begin() + findFirstOpen(usedEntry);
+        itPresentEntryToRunOrLumis = itRestartSearchAt;
+        continue;
+      }
+      ++itPresentEntryToRunOrLumis;
+    }
+  }
+
+  IndexIntoFile::IndexIntoFileItrImpl* IndexIntoFile::IndexIntoFileItrEntryOrder::clone() const {
+    return new IndexIntoFileItrEntryOrder(*this);
+  }
+
+  int IndexIntoFile::IndexIntoFileItrEntryOrder::processHistoryIDIndex() const {
+    if (type() == kEnd)
+      return invalidIndex;
+    return runOrLumisEntry(indexToRun()).processHistoryIDIndex();
+  }
+
+  RunNumber_t IndexIntoFile::IndexIntoFileItrEntryOrder::run() const {
+    if (type() == kEnd)
+      return invalidRun;
+    return runOrLumisEntry(indexToRun()).run();
+  }
+
+  LuminosityBlockNumber_t IndexIntoFile::IndexIntoFileItrEntryOrder::lumi() const {
+    if (type() == kEnd || type() == kRun)
+      return invalidLumi;
+    return runOrLumisEntry(indexToLumi()).lumi();
+  }
+
+  IndexIntoFile::EntryNumber_t IndexIntoFile::IndexIntoFileItrEntryOrder::entry() const {
+    if (type() == kEnd)
+      return invalidEntry;
+    if (type() == kRun)
+      return runOrLumisEntry(indexToRun()).entry();
+    if (type() == kLumi) {
+      auto entry = runOrLumisEntry(indexToLumi()).entry();
+      if (entry == invalidEntry) {
+        if (indexToLumi() + 1 < size()) {
+          if (runOrLumisEntry(indexToLumi()).lumi() != runOrLumisEntry(indexToLumi() + 1).lumi()) {
+            //find the end of this lumi
+            auto const& runLumiEntry = runOrLumisEntry(indexToLumi());
+            for (auto nextIndex = indexToLumi() + 1; nextIndex < size(); ++nextIndex) {
+              auto const& nextRunLumiEntry = runOrLumisEntry(nextIndex);
+              if (runLumiEntry.lumi() == nextRunLumiEntry.lumi() and runLumiEntry.run() == nextRunLumiEntry.run() and
+                  runLumiEntry.processHistoryIDIndex() == nextRunLumiEntry.processHistoryIDIndex()) {
+                auto nextEntry = nextRunLumiEntry.entry();
+                if (nextEntry != invalidEntry) {
+                  return nextEntry;
+                }
+              }
+            }
+            return continuedLumi;
+          }
+        }
+      }
+      return entry;
+    }
+    return runOrLumisEntry(indexToEventRange()).beginEvents() + indexToEvent();
+  }
+
+  bool IndexIntoFile::IndexIntoFileItrEntryOrder::entryContinues() const {
+    auto entry = runOrLumisEntry(indexToLumi()).entry();
+    return entry == invalidEntry;
+    /*if (entry == invalidEntry) {
+      return true;
+    }
+    return (indexToEventRange() != indexToLumi()) ; */
+  }
+
+  LuminosityBlockNumber_t IndexIntoFile::IndexIntoFileItrEntryOrder::peekAheadAtLumi() const {
+    if (indexToLumi() == invalidIndex)
+      return invalidLumi;
+    return runOrLumisEntry(indexToLumi()).lumi();
+  }
+
+  IndexIntoFile::EntryNumber_t IndexIntoFile::IndexIntoFileItrEntryOrder::peekAheadAtEventEntry() const {
+    if (indexToLumi() == invalidIndex)
+      return invalidEntry;
+    if (indexToEvent() >= nEvents())
+      return invalidEntry;
+    return runOrLumisEntry(indexToEventRange()).beginEvents() + indexToEvent();
+  }
+
+  void IndexIntoFile::IndexIntoFileItrEntryOrder::initializeLumi_() {
+    assert(indexToLumi() != invalidIndex);
+
+    setIndexToEventRange(invalidIndex);
+    setIndexToEvent(0);
+    setNEvents(0);
+
+    for (int i = 0; indexToLumi() + i < size(); ++i) {
+      if (runOrLumisEntry(indexToLumi() + i).isRun()) {
+        break;
+      } else if (runOrLumisEntry(indexToLumi() + i).lumi() == runOrLumisEntry(indexToLumi()).lumi()) {
+        if (runOrLumisEntry(indexToLumi() + i).beginEvents() == invalidEntry) {
+          continue;
+        }
+        setIndexToEventRange(indexToLumi() + i);
+        setIndexToEvent(0);
+        setNEvents(runOrLumisEntry(indexToEventRange()).endEvents() -
+                   runOrLumisEntry(indexToEventRange()).beginEvents());
+        break;
+      } else {
+        break;
+      }
+    }
+  }
+
+  bool IndexIntoFile::IndexIntoFileItrEntryOrder::nextEventRange() {
+    if (indexToEventRange() == invalidIndex)
+      return false;
+
+    // Look for the next event range, same lumi but different entry
+    for (int i = 1; indexToEventRange() + i < size(); ++i) {
+      if (runOrLumisEntry(indexToEventRange() + i).isRun()) {
+        return false;  // hit next run
+      } else if (runOrLumisEntry(indexToEventRange() + i).lumi() == runOrLumisEntry(indexToEventRange()).lumi()) {
+        if (runOrLumisEntry(indexToEventRange() + i).beginEvents() == invalidEntry) {
+          continue;  // same lumi but has no events, keep looking
+        }
+        setIndexToEventRange(indexToEventRange() + i);
+        setIndexToEvent(0);
+        setNEvents(runOrLumisEntry(indexToEventRange()).endEvents() -
+                   runOrLumisEntry(indexToEventRange()).beginEvents());
+        return true;  // found more events in this lumi
+      }
+      return false;  // hit next lumi
+    }
+    return false;  // hit the end of the IndexIntoFile
+  }
+
+  bool IndexIntoFile::IndexIntoFileItrEntryOrder::previousEventRange() {
+    if (indexToEventRange() == invalidIndex)
+      return false;
+    assert(indexToEventRange() < size());
+
+    // Look backward for a previous event range with events, same lumi but different entry
+    for (int i = 1; indexToEventRange() - i > 0; ++i) {
+      int newRange = indexToEventRange() - i;
+      if (runOrLumisEntry(newRange).isRun()) {
+        return false;  // hit run
+      } else if (isSameLumi(newRange, indexToEventRange())) {
+        if (runOrLumisEntry(newRange).beginEvents() == invalidEntry) {
+          continue;  // same lumi but has no events, keep looking
+        }
+        setIndexToEventRange(newRange);
+        setNEvents(runOrLumisEntry(indexToEventRange()).endEvents() -
+                   runOrLumisEntry(indexToEventRange()).beginEvents());
+        setIndexToEvent(nEvents() - 1);
+        return true;  // found previous event in this lumi
+      }
+      return false;  // hit previous lumi
+    }
+    return false;  // hit the beginning of the IndexIntoFile, 0th entry has to be a run
+  }
+
+  bool IndexIntoFile::IndexIntoFileItrEntryOrder::setToLastEventInRange(int index) {
+    if (runOrLumisEntry(index).beginEvents() == invalidEntry) {
+      return false;
+    }
+    setIndexToEventRange(index);
+    setNEvents(runOrLumisEntry(indexToEventRange()).endEvents() - runOrLumisEntry(indexToEventRange()).beginEvents());
+    assert(nEvents() > 0);
+    setIndexToEvent(nEvents() - 1);
+    return true;
+  }
+
+  bool IndexIntoFile::IndexIntoFileItrEntryOrder::skipLumiInRun() {
+    if (indexToLumi() == invalidIndex)
+      return false;
+    for (int i = 1; indexToLumi() + i < size(); ++i) {
+      int newLumi = indexToLumi() + i;
+      if (runOrLumisEntry(newLumi).isRun()) {
+        return false;  // hit next run
+      } else if (runOrLumisEntry(newLumi).lumi() == runOrLumisEntry(indexToLumi()).lumi()) {
+        continue;
+      }
+      setIndexToLumi(newLumi);
+      initializeLumi();
+      return true;  // hit next lumi
+    }
+    return false;  // hit the end of the IndexIntoFile
+  }
+
+  bool IndexIntoFile::IndexIntoFileItrEntryOrder::lumiEntryValid(int index) const {
+    auto entry = runOrLumisEntry(index).entry();
+    if (entry == invalidEntry) {
+      if (index + 1 < size()) {
+        if (runOrLumisEntry(index).lumi() != runOrLumisEntry(index + 1).lumi()) {
+          return true;
+        }
+      }
+    }
+    return entry != invalidEntry;
+  }
+
+  IndexIntoFile::EntryType IndexIntoFile::IndexIntoFileItrEntryOrder::getRunOrLumiEntryType(int index) const {
+    if (index < 0 || index >= size()) {
+      return kEnd;
+    } else if (runOrLumisEntry(index).isRun()) {
+      return kRun;
+    }
+    return kLumi;
+  }
+
+  bool IndexIntoFile::IndexIntoFileItrEntryOrder::isSameLumi(int index1, int index2) const {
+    if (index1 < 0 || index1 >= size() || index2 < 0 || index2 >= size()) {
+      return false;
+    }
+    return runOrLumisEntry(index1).lumi() == runOrLumisEntry(index2).lumi();
+  }
+
+  bool IndexIntoFile::IndexIntoFileItrEntryOrder::isSameRun(int index1, int index2) const {
+    if (index1 < 0 || index1 >= size() || index2 < 0 || index2 >= size()) {
+      return false;
+    }
+    return runOrLumisEntry(index1).run() == runOrLumisEntry(index2).run() &&
+           runOrLumisEntry(index1).processHistoryIDIndex() == runOrLumisEntry(index2).processHistoryIDIndex();
+  }
+
+  LuminosityBlockNumber_t IndexIntoFile::IndexIntoFileItrEntryOrder::lumi(int index) const {
+    if (index < 0 || index >= size()) {
+      return invalidLumi;
+    }
+    return runOrLumisEntry(index).lumi();
+  }
+
+  //*************************************
+
   IndexIntoFile::IndexIntoFileItr::IndexIntoFileItr(IndexIntoFile const* indexIntoFile,
                                                     SortOrder sortOrder,
                                                     EntryType entryType,
@@ -1738,8 +2020,12 @@ namespace edm {
       value_ptr<IndexIntoFileItrImpl> temp(new IndexIntoFileItrSorted(
           indexIntoFile, entryType, indexToRun, indexToLumi, indexToEventRange, indexToEvent, nEvents));
       swap(temp, impl_);
-    } else {
+    } else if (sortOrder == firstAppearanceOrder) {
       value_ptr<IndexIntoFileItrImpl> temp(new IndexIntoFileItrNoSort(
+          indexIntoFile, entryType, indexToRun, indexToLumi, indexToEventRange, indexToEvent, nEvents));
+      swap(temp, impl_);
+    } else {
+      value_ptr<IndexIntoFileItrImpl> temp(new IndexIntoFileItrEntryOrder(
           indexIntoFile, entryType, indexToRun, indexToLumi, indexToEventRange, indexToEvent, nEvents));
       swap(temp, impl_);
     }

--- a/DataFormats/Provenance/test/indexIntoFile3_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile3_t.cppunit.cc
@@ -21,6 +21,9 @@ class TestIndexIntoFile3 : public CppUnit::TestFixture {
   CPPUNIT_TEST(testIterEndWithEvent);
   CPPUNIT_TEST(testOverlappingLumis);
   CPPUNIT_TEST(testOverlappingLumisMore);
+  CPPUNIT_TEST(testOverlappingLumisOutOfOrderEvent);
+  CPPUNIT_TEST(testOverlappingLumisWithEndWithEmptyLumi);
+  CPPUNIT_TEST(testOverlappingLumisWithLumiEndOrderChanged);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -69,13 +72,16 @@ public:
   void testIterEndWithEvent();
   void testOverlappingLumis();
   void testOverlappingLumisMore();
+  void testOverlappingLumisOutOfOrderEvent();
+  void testOverlappingLumisWithEndWithEmptyLumi();
+  void testOverlappingLumisWithLumiEndOrderChanged();
 
   ProcessHistoryID nullPHID;
   ProcessHistoryID fakePHID1;
   ProcessHistoryID fakePHID2;
   ProcessHistoryID fakePHID3;
 
-  void check(edm::IndexIntoFile::IndexIntoFileItr const& iter,
+  bool check(edm::IndexIntoFile::IndexIntoFileItr const& iter,
              IndexIntoFile::EntryType type,
              int indexToRun,
              int indexToLumi,
@@ -100,7 +106,7 @@ public:
 ///registration of the test so that the runner can find it
 CPPUNIT_TEST_SUITE_REGISTRATION(TestIndexIntoFile3);
 
-void TestIndexIntoFile3::check(edm::IndexIntoFile::IndexIntoFileItr const& iter,
+bool TestIndexIntoFile3::check(edm::IndexIntoFile::IndexIntoFileItr const& iter,
                                IndexIntoFile::EntryType type,
                                int indexToRun,
                                int indexToLumi,
@@ -116,7 +122,7 @@ void TestIndexIntoFile3::check(edm::IndexIntoFile::IndexIntoFileItr const& iter,
     std::cout << "Iterator values " << iter.type() << "  " << iter.indexToRun() << "  " << iter.indexToLumi() << "  "
               << iter.indexToEventRange() << "  " << iter.indexToEvent() << "  " << iter.nEvents() << "\n";
   }
-  CPPUNIT_ASSERT(theyMatch);
+  return theyMatch;
 }
 
 void TestIndexIntoFile3::checkSkipped(int phIndexOfSkippedEvent,
@@ -216,41 +222,41 @@ void TestIndexIntoFile3::testIterEndWithEvent() {
     iterFirstCopy2 = iterFirstCopy;
     CPPUNIT_ASSERT(iterFirst == iterFirstCopy2);
     if (i == 0) {
-      check(iterFirst, kRun, 0, 1, 1, 0, 2);
+      CPPUNIT_ASSERT(check(iterFirst, kRun, 0, 1, 1, 0, 2));
       CPPUNIT_ASSERT(iterFirst.indexIntoFile() == &indexIntoFile);
       CPPUNIT_ASSERT(iterFirst.size() == 10);
     } else if (i == 1)
-      check(iterFirst, kLumi, 0, 1, 1, 0, 2);
+      CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 1, 1, 0, 2));
     else if (i == 2)
-      check(iterFirst, kLumi, 0, 2, 1, 0, 2);
+      CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 2, 1, 0, 2));
     else if (i == 3)
-      check(iterFirst, kLumi, 0, 3, 1, 0, 2);
+      CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 3, 1, 0, 2));
     else if (i == 4)
-      check(iterFirst, kEvent, 0, 3, 1, 0, 2);
+      CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 3, 1, 0, 2));
     else if (i == 5)
-      check(iterFirst, kEvent, 0, 3, 1, 1, 2);
+      CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 3, 1, 1, 2));
     else if (i == 6)
-      check(iterFirst, kEvent, 0, 3, 3, 0, 2);
+      CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 3, 3, 0, 2));
     else if (i == 7)
-      check(iterFirst, kEvent, 0, 3, 3, 1, 2);
+      CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 3, 3, 1, 2));
     else if (i == 8)
-      check(iterFirst, kLumi, 0, 4, 4, 0, 2);
+      CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 4, 4, 0, 2));
     else if (i == 9)
-      check(iterFirst, kEvent, 0, 4, 4, 0, 2);
+      CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 4, 4, 0, 2));
     else if (i == 10)
-      check(iterFirst, kEvent, 0, 4, 4, 1, 2);
+      CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 4, 4, 1, 2));
     else if (i == 11)
-      check(iterFirst, kRun, 5, 7, -1, 0, 0);
+      CPPUNIT_ASSERT(check(iterFirst, kRun, 5, 7, -1, 0, 0));
     else if (i == 12)
-      check(iterFirst, kRun, 6, 7, -1, 0, 0);
+      CPPUNIT_ASSERT(check(iterFirst, kRun, 6, 7, -1, 0, 0));
     else if (i == 13)
-      check(iterFirst, kLumi, 6, 7, -1, 0, 0);
+      CPPUNIT_ASSERT(check(iterFirst, kLumi, 6, 7, -1, 0, 0));
     else if (i == 14)
-      check(iterFirst, kLumi, 6, 8, 9, 0, 1);
+      CPPUNIT_ASSERT(check(iterFirst, kLumi, 6, 8, 9, 0, 1));
     else if (i == 15)
-      check(iterFirst, kLumi, 6, 9, 9, 0, 1);
+      CPPUNIT_ASSERT(check(iterFirst, kLumi, 6, 9, 9, 0, 1));
     else if (i == 16)
-      check(iterFirst, kEvent, 6, 9, 9, 0, 1);
+      CPPUNIT_ASSERT(check(iterFirst, kEvent, 6, 9, 9, 0, 1));
     else
       CPPUNIT_ASSERT(false);
 
@@ -357,41 +363,41 @@ void TestIndexIntoFile3::testIterEndWithEvent() {
     CPPUNIT_ASSERT(iterNum == iterNumCopy);
     CPPUNIT_ASSERT(iterNum == iterNumCopy2);
     if (i == 0) {
-      check(iterNum, kRun, 0, 1, 1, 0, 4);
+      CPPUNIT_ASSERT(check(iterNum, kRun, 0, 1, 1, 0, 4));
       CPPUNIT_ASSERT(iterNum.indexIntoFile() == &indexIntoFile);
       CPPUNIT_ASSERT(iterNum.size() == 10);
     } else if (i == 1)
-      check(iterNum, kLumi, 0, 1, 1, 0, 4);
+      CPPUNIT_ASSERT(check(iterNum, kLumi, 0, 1, 1, 0, 4));
     else if (i == 2)
-      check(iterNum, kLumi, 0, 2, 1, 0, 4);
+      CPPUNIT_ASSERT(check(iterNum, kLumi, 0, 2, 1, 0, 4));
     else if (i == 3)
-      check(iterNum, kLumi, 0, 3, 1, 0, 4);
+      CPPUNIT_ASSERT(check(iterNum, kLumi, 0, 3, 1, 0, 4));
     else if (i == 4)
-      check(iterNum, kEvent, 0, 3, 1, 0, 4);
+      CPPUNIT_ASSERT(check(iterNum, kEvent, 0, 3, 1, 0, 4));
     else if (i == 5)
-      check(iterNum, kEvent, 0, 3, 1, 1, 4);
+      CPPUNIT_ASSERT(check(iterNum, kEvent, 0, 3, 1, 1, 4));
     else if (i == 6)
-      check(iterNum, kEvent, 0, 3, 1, 2, 4);
+      CPPUNIT_ASSERT(check(iterNum, kEvent, 0, 3, 1, 2, 4));
     else if (i == 7)
-      check(iterNum, kEvent, 0, 3, 1, 3, 4);
+      CPPUNIT_ASSERT(check(iterNum, kEvent, 0, 3, 1, 3, 4));
     else if (i == 8)
-      check(iterNum, kLumi, 0, 4, 4, 0, 2);
+      CPPUNIT_ASSERT(check(iterNum, kLumi, 0, 4, 4, 0, 2));
     else if (i == 9)
-      check(iterNum, kEvent, 0, 4, 4, 0, 2);
+      CPPUNIT_ASSERT(check(iterNum, kEvent, 0, 4, 4, 0, 2));
     else if (i == 10)
-      check(iterNum, kEvent, 0, 4, 4, 1, 2);
+      CPPUNIT_ASSERT(check(iterNum, kEvent, 0, 4, 4, 1, 2));
     else if (i == 11)
-      check(iterNum, kRun, 5, 7, -1, 0, 0);
+      CPPUNIT_ASSERT(check(iterNum, kRun, 5, 7, -1, 0, 0));
     else if (i == 12)
-      check(iterNum, kRun, 6, 7, -1, 0, 0);
+      CPPUNIT_ASSERT(check(iterNum, kRun, 6, 7, -1, 0, 0));
     else if (i == 13)
-      check(iterNum, kLumi, 6, 7, -1, 0, 0);
+      CPPUNIT_ASSERT(check(iterNum, kLumi, 6, 7, -1, 0, 0));
     else if (i == 14)
-      check(iterNum, kLumi, 6, 8, 8, 0, 1);
+      CPPUNIT_ASSERT(check(iterNum, kLumi, 6, 8, 8, 0, 1));
     else if (i == 15)
-      check(iterNum, kLumi, 6, 9, 8, 0, 1);
+      CPPUNIT_ASSERT(check(iterNum, kLumi, 6, 9, 8, 0, 1));
     else if (i == 16)
-      check(iterNum, kEvent, 6, 9, 8, 0, 1);
+      CPPUNIT_ASSERT(check(iterNum, kEvent, 6, 9, 8, 0, 1));
     else
       CPPUNIT_ASSERT(false);
 
@@ -453,76 +459,205 @@ void TestIndexIntoFile3::testIterEndWithEvent() {
     if (i == 16)
       checkIDRunLumiEntry(iterNum, 1, 11, 102, 6);  // Event
   }
-  checkIDRunLumiEntry(iterFirst, -1, 0, 0, -1);  // Event
+  checkIDRunLumiEntry(iterNum, -1, 0, 0, -1);  // Event
 
+  {
+    edm::IndexIntoFile::IndexIntoFileItr iter3(
+        &indexIntoFile, IndexIntoFile::entryOrder, IndexIntoFile::kEvent, 0, 3, 2, 1, 2);
+    edm::IndexIntoFile::IndexIntoFileItr iter1(iter3);
+
+    CPPUNIT_ASSERT(iter1 == iter3);
+    CPPUNIT_ASSERT(iter1.indexIntoFile() == &indexIntoFile);
+    CPPUNIT_ASSERT(iter1.size() == 10);
+    CPPUNIT_ASSERT(iter1.type() == kEvent);
+    CPPUNIT_ASSERT(iter1.indexToRun() == 0);
+    CPPUNIT_ASSERT(iter1.indexToLumi() == 3);
+    CPPUNIT_ASSERT(iter1.indexToEventRange() == 2);
+    CPPUNIT_ASSERT(iter1.indexToEvent() == 1);
+    CPPUNIT_ASSERT(iter1.nEvents() == 2);
+
+    iter1 = ++iter3;
+    CPPUNIT_ASSERT(iter1 == iter3);
+
+    CPPUNIT_ASSERT(indexIntoFile.iterationWillBeInEntryOrder(IndexIntoFile::entryOrder) == true);
+
+    edm::IndexIntoFile::IndexIntoFileItr iterEntry = indexIntoFile.begin(IndexIntoFile::entryOrder);
+    edm::IndexIntoFile::IndexIntoFileItr iterEntryCopy = iterEntry;
+    edm::IndexIntoFile::IndexIntoFileItr iterEntryCopy2 = iterEntry;
+    edm::IndexIntoFile::IndexIntoFileItr iterEntryEnd = indexIntoFile.end(IndexIntoFile::entryOrder);
+    int i = 0;
+    for (i = 0; iterEntry != iterEntryEnd; ++iterEntry, ++iterEntryCopy, ++i) {
+      CPPUNIT_ASSERT(iterEntry == iterEntryCopy);
+      iterEntryCopy2 = iterEntryCopy;
+      CPPUNIT_ASSERT(iterEntry == iterEntryCopy2);
+      if (i == 0) {
+        CPPUNIT_ASSERT(check(iterEntry, kRun, 0, 1, 1, 0, 2));
+        CPPUNIT_ASSERT(iterEntry.indexIntoFile() == &indexIntoFile);
+        CPPUNIT_ASSERT(iterEntry.size() == 10);
+      } else if (i == 1)
+        CPPUNIT_ASSERT(check(iterEntry, kLumi, 0, 1, 1, 0, 2));
+      else if (i == 2)
+        CPPUNIT_ASSERT(check(iterEntry, kLumi, 0, 2, 1, 0, 2));
+      else if (i == 3)
+        CPPUNIT_ASSERT(check(iterEntry, kLumi, 0, 3, 1, 0, 2));
+      else if (i == 4)
+        CPPUNIT_ASSERT(check(iterEntry, kEvent, 0, 3, 1, 0, 2));
+      else if (i == 5)
+        CPPUNIT_ASSERT(check(iterEntry, kEvent, 0, 3, 1, 1, 2));
+      else if (i == 6)
+        CPPUNIT_ASSERT(check(iterEntry, kEvent, 0, 3, 3, 0, 2));
+      else if (i == 7)
+        CPPUNIT_ASSERT(check(iterEntry, kEvent, 0, 3, 3, 1, 2));
+      else if (i == 8)
+        CPPUNIT_ASSERT(check(iterEntry, kLumi, 0, 4, 4, 0, 2));
+      else if (i == 9)
+        CPPUNIT_ASSERT(check(iterEntry, kEvent, 0, 4, 4, 0, 2));
+      else if (i == 10)
+        CPPUNIT_ASSERT(check(iterEntry, kEvent, 0, 4, 4, 1, 2));
+      else if (i == 11)
+        CPPUNIT_ASSERT(check(iterEntry, kRun, 5, 7, -1, 0, 0));
+      else if (i == 12)
+        CPPUNIT_ASSERT(check(iterEntry, kRun, 6, 7, -1, 0, 0));
+      else if (i == 13)
+        CPPUNIT_ASSERT(check(iterEntry, kLumi, 6, 7, -1, 0, 0));
+      else if (i == 14)
+        CPPUNIT_ASSERT(check(iterEntry, kLumi, 6, 8, 9, 0, 1));
+      else if (i == 15)
+        CPPUNIT_ASSERT(check(iterEntry, kLumi, 6, 9, 9, 0, 1));
+      else if (i == 16)
+        CPPUNIT_ASSERT(check(iterEntry, kEvent, 6, 9, 9, 0, 1));
+      else
+        CPPUNIT_ASSERT(false);
+
+      if (i == 0)
+        CPPUNIT_ASSERT(iterEntry.firstEventEntryThisRun() == 0);
+      if (i == 10)
+        CPPUNIT_ASSERT(iterEntry.firstEventEntryThisRun() == 0);
+      if (i == 12)
+        CPPUNIT_ASSERT(iterEntry.firstEventEntryThisRun() == 6);
+
+      if (i == 0)
+        CPPUNIT_ASSERT(iterEntry.firstEventEntryThisLumi() == 0);
+      if (i == 1)
+        CPPUNIT_ASSERT(iterEntry.firstEventEntryThisLumi() == 0);
+      if (i == 2)
+        CPPUNIT_ASSERT(iterEntry.firstEventEntryThisLumi() == 0);
+      if (i == 3)
+        CPPUNIT_ASSERT(iterEntry.firstEventEntryThisLumi() == 0);
+      if (i == 10)
+        CPPUNIT_ASSERT(iterEntry.firstEventEntryThisLumi() == 4);
+      if (i == 12)
+        CPPUNIT_ASSERT(iterEntry.firstEventEntryThisLumi() == IndexIntoFile::invalidIndex);
+    }
+    CPPUNIT_ASSERT(i == 17);
+
+    for (i = 0, iterEntry = indexIntoFile.begin(IndexIntoFile::entryOrder); iterEntry != iterEntryEnd;
+         ++iterEntry, ++i) {
+      if (i == 0)
+        checkIDRunLumiEntry(iterEntry, 0, 11, 0, 0);  // Run
+      if (i == 1)
+        checkIDRunLumiEntry(iterEntry, 0, 11, 101, 0);  // Lumi
+      if (i == 2)
+        checkIDRunLumiEntry(iterEntry, 0, 11, 101, 1);  // Lumi
+      if (i == 3)
+        checkIDRunLumiEntry(iterEntry, 0, 11, 101, 2);  // Lumi
+      if (i == 4)
+        checkIDRunLumiEntry(iterEntry, 0, 11, 101, 0);  // Event
+      if (i == 5)
+        checkIDRunLumiEntry(iterEntry, 0, 11, 101, 1);  // Event
+      if (i == 6)
+        checkIDRunLumiEntry(iterEntry, 0, 11, 101, 2);  // Event
+      if (i == 7)
+        checkIDRunLumiEntry(iterEntry, 0, 11, 101, 3);  // Event
+      if (i == 8)
+        checkIDRunLumiEntry(iterEntry, 0, 11, 102, 3);  // Lumi
+      if (i == 9)
+        checkIDRunLumiEntry(iterEntry, 0, 11, 102, 4);  // Event
+      if (i == 10)
+        checkIDRunLumiEntry(iterEntry, 0, 11, 102, 5);  // Event
+      if (i == 11)
+        checkIDRunLumiEntry(iterEntry, 1, 11, 0, 1);  // Run
+      if (i == 12)
+        checkIDRunLumiEntry(iterEntry, 1, 11, 0, 2);  // Run
+      if (i == 13)
+        checkIDRunLumiEntry(iterEntry, 1, 11, 101, 4);  // Lumi
+      if (i == 14)
+        checkIDRunLumiEntry(iterEntry, 1, 11, 102, 5);  // Lumi
+      if (i == 15)
+        checkIDRunLumiEntry(iterEntry, 1, 11, 102, 6);  // Lumi
+      if (i == 16)
+        checkIDRunLumiEntry(iterEntry, 1, 11, 102, 6);  // Event
+    }
+    checkIDRunLumiEntry(iterEntry, -1, 0, 0, -1);  // Event
+  }
   iterFirst = indexIntoFile.begin(IndexIntoFile::firstAppearanceOrder);
-  check(iterFirst, kRun, 0, 1, 1, 0, 2);
+  CPPUNIT_ASSERT(check(iterFirst, kRun, 0, 1, 1, 0, 2));
 
   skipEventForward(iterFirst);
   checkSkipped(0, 11, 101, 0);
-  check(iterFirst, kRun, 0, 1, 1, 1, 2);
+  CPPUNIT_ASSERT(check(iterFirst, kRun, 0, 1, 1, 1, 2));
 
   skipEventForward(iterFirst);
   checkSkipped(0, 11, 101, 1);
-  check(iterFirst, kRun, 0, 1, 3, 0, 2);
+  CPPUNIT_ASSERT(check(iterFirst, kRun, 0, 1, 3, 0, 2));
 
   skipEventForward(iterFirst);
   checkSkipped(0, 11, 101, 2);
-  check(iterFirst, kRun, 0, 1, 3, 1, 2);
+  CPPUNIT_ASSERT(check(iterFirst, kRun, 0, 1, 3, 1, 2));
 
   skipEventForward(iterFirst);
   checkSkipped(0, 11, 101, 3);
-  check(iterFirst, kRun, 0, 4, 4, 0, 2);
+  CPPUNIT_ASSERT(check(iterFirst, kRun, 0, 4, 4, 0, 2));
 
   skipEventForward(iterFirst);
   checkSkipped(0, 11, 102, 4);
-  check(iterFirst, kRun, 0, 4, 4, 1, 2);
+  CPPUNIT_ASSERT(check(iterFirst, kRun, 0, 4, 4, 1, 2));
 
   skipEventForward(iterFirst);
   checkSkipped(0, 11, 102, 5);
-  check(iterFirst, kRun, 5, 7, -1, 0, 0);
+  CPPUNIT_ASSERT(check(iterFirst, kRun, 5, 7, -1, 0, 0));
 
   skipEventForward(iterFirst);
   checkSkipped(1, 11, 102, 6);
-  check(iterFirst, kEnd, -1, -1, -1, 0, 0);
+  CPPUNIT_ASSERT(check(iterFirst, kEnd, -1, -1, -1, 0, 0));
 
   skipEventForward(iterFirst);
   checkSkipped(-1, 0, 0, -1);
-  check(iterFirst, kEnd, -1, -1, -1, 0, 0);
+  CPPUNIT_ASSERT(check(iterFirst, kEnd, -1, -1, -1, 0, 0));
 
   iterFirst = indexIntoFile.begin(IndexIntoFile::firstAppearanceOrder);
   ++iterFirst;
 
   skipEventForward(iterFirst);
   checkSkipped(0, 11, 101, 0);
-  check(iterFirst, kLumi, 0, 1, 1, 1, 2);
+  CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 1, 1, 1, 2));
 
   skipEventForward(iterFirst);
   checkSkipped(0, 11, 101, 1);
-  check(iterFirst, kLumi, 0, 1, 3, 0, 2);
+  CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 1, 3, 0, 2));
 
   skipEventForward(iterFirst);
   checkSkipped(0, 11, 101, 2);
-  check(iterFirst, kLumi, 0, 1, 3, 1, 2);
+  CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 1, 3, 1, 2));
 
   skipEventForward(iterFirst);
   checkSkipped(0, 11, 101, 3);
-  check(iterFirst, kLumi, 0, 4, 4, 0, 2);
+  CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 4, 4, 0, 2));
 
   skipEventForward(iterFirst);
   checkSkipped(0, 11, 102, 4);
-  check(iterFirst, kLumi, 0, 4, 4, 1, 2);
+  CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 4, 4, 1, 2));
 
   skipEventForward(iterFirst);
   checkSkipped(0, 11, 102, 5);
-  check(iterFirst, kRun, 5, 7, -1, 0, 0);
+  CPPUNIT_ASSERT(check(iterFirst, kRun, 5, 7, -1, 0, 0));
 
   ++iterFirst;
   ++iterFirst;
   ++iterFirst;
   skipEventForward(iterFirst);
   checkSkipped(1, 11, 102, 6);
-  check(iterFirst, kEnd, -1, -1, -1, 0, 0);
+  CPPUNIT_ASSERT(check(iterFirst, kEnd, -1, -1, -1, 0, 0));
 
   iterFirst = indexIntoFile.begin(IndexIntoFile::firstAppearanceOrder);
   ++iterFirst;
@@ -532,135 +667,135 @@ void TestIndexIntoFile3::testIterEndWithEvent() {
 
   skipEventForward(iterFirst);
   checkSkipped(0, 11, 101, 0);
-  check(iterFirst, kEvent, 0, 3, 1, 1, 2);
+  CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 3, 1, 1, 2));
 
   skipEventForward(iterFirst);
   checkSkipped(0, 11, 101, 1);
-  check(iterFirst, kEvent, 0, 3, 3, 0, 2);
+  CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 3, 3, 0, 2));
 
   skipEventForward(iterFirst);
   checkSkipped(0, 11, 101, 2);
-  check(iterFirst, kEvent, 0, 3, 3, 1, 2);
+  CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 3, 3, 1, 2));
 
   skipEventForward(iterFirst);
   checkSkipped(0, 11, 101, 3);
-  check(iterFirst, kLumi, 0, 4, 4, 0, 2);
+  CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 4, 4, 0, 2));
 
   ++iterFirst;
   skipEventForward(iterFirst);
   checkSkipped(0, 11, 102, 4);
-  check(iterFirst, kEvent, 0, 4, 4, 1, 2);
+  CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 4, 4, 1, 2));
 
   skipEventForward(iterFirst);
   checkSkipped(0, 11, 102, 5);
-  check(iterFirst, kRun, 5, 7, -1, 0, 0);
+  CPPUNIT_ASSERT(check(iterFirst, kRun, 5, 7, -1, 0, 0));
 
   iterFirst = indexIntoFile.begin(IndexIntoFile::firstAppearanceOrder);
   iterFirst.advanceToNextLumiOrRun();
-  check(iterFirst, kLumi, 0, 1, 1, 0, 2);
+  CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 1, 1, 0, 2));
   iterFirst.advanceToNextLumiOrRun();
-  check(iterFirst, kLumi, 0, 4, 4, 0, 2);
+  CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 4, 4, 0, 2));
   iterFirst.advanceToNextLumiOrRun();
-  check(iterFirst, kRun, 5, 7, -1, 0, 0);
+  CPPUNIT_ASSERT(check(iterFirst, kRun, 5, 7, -1, 0, 0));
   iterFirst.advanceToNextLumiOrRun();
-  check(iterFirst, kLumi, 6, 7, -1, 0, 0);
+  CPPUNIT_ASSERT(check(iterFirst, kLumi, 6, 7, -1, 0, 0));
   iterFirst.advanceToNextLumiOrRun();
-  check(iterFirst, kLumi, 6, 8, 9, 0, 1);
+  CPPUNIT_ASSERT(check(iterFirst, kLumi, 6, 8, 9, 0, 1));
   iterFirst.advanceToNextLumiOrRun();
-  check(iterFirst, kEnd, -1, -1, -1, 0, 0);
-
-  iterFirst = indexIntoFile.begin(IndexIntoFile::firstAppearanceOrder);
-  ++iterFirst;
-  ++iterFirst;
-  ++iterFirst;
-  ++iterFirst;
-  check(iterFirst, kEvent, 0, 3, 1, 0, 2);
-  iterFirst.advanceToNextLumiOrRun();
-  check(iterFirst, kLumi, 0, 4, 4, 0, 2);
-  ++iterFirst;
-  iterFirst.advanceToNextLumiOrRun();
-  check(iterFirst, kRun, 5, 7, -1, 0, 0);
+  CPPUNIT_ASSERT(check(iterFirst, kEnd, -1, -1, -1, 0, 0));
 
   iterFirst = indexIntoFile.begin(IndexIntoFile::firstAppearanceOrder);
   ++iterFirst;
   ++iterFirst;
   ++iterFirst;
   ++iterFirst;
-  check(iterFirst, kEvent, 0, 3, 1, 0, 2);
+  CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 3, 1, 0, 2));
+  iterFirst.advanceToNextLumiOrRun();
+  CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 4, 4, 0, 2));
+  ++iterFirst;
+  iterFirst.advanceToNextLumiOrRun();
+  CPPUNIT_ASSERT(check(iterFirst, kRun, 5, 7, -1, 0, 0));
+
+  iterFirst = indexIntoFile.begin(IndexIntoFile::firstAppearanceOrder);
+  ++iterFirst;
+  ++iterFirst;
+  ++iterFirst;
+  ++iterFirst;
+  CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 3, 1, 0, 2));
   iterFirst.advanceToNextRun();
-  check(iterFirst, kRun, 5, 7, -1, 0, 0);
+  CPPUNIT_ASSERT(check(iterFirst, kRun, 5, 7, -1, 0, 0));
 
   // Repeat skip tests with the other sort order
 
   iterNum = indexIntoFile.begin(IndexIntoFile::numericalOrder);
-  check(iterNum, kRun, 0, 1, 1, 0, 4);
+  CPPUNIT_ASSERT(check(iterNum, kRun, 0, 1, 1, 0, 4));
 
   skipEventForward(iterNum);
   checkSkipped(0, 11, 101, 3);
-  check(iterNum, kRun, 0, 1, 1, 1, 4);
+  CPPUNIT_ASSERT(check(iterNum, kRun, 0, 1, 1, 1, 4));
 
   skipEventForward(iterNum);
   checkSkipped(0, 11, 101, 2);
-  check(iterNum, kRun, 0, 1, 1, 2, 4);
+  CPPUNIT_ASSERT(check(iterNum, kRun, 0, 1, 1, 2, 4));
 
   skipEventForward(iterNum);
   checkSkipped(0, 11, 101, 1);
-  check(iterNum, kRun, 0, 1, 1, 3, 4);
+  CPPUNIT_ASSERT(check(iterNum, kRun, 0, 1, 1, 3, 4));
 
   skipEventForward(iterNum);
   checkSkipped(0, 11, 101, 0);
-  check(iterNum, kRun, 0, 4, 4, 0, 2);
+  CPPUNIT_ASSERT(check(iterNum, kRun, 0, 4, 4, 0, 2));
 
   skipEventForward(iterNum);
   checkSkipped(0, 11, 102, 5);
-  check(iterNum, kRun, 0, 4, 4, 1, 2);
+  CPPUNIT_ASSERT(check(iterNum, kRun, 0, 4, 4, 1, 2));
 
   skipEventForward(iterNum);
   checkSkipped(0, 11, 102, 4);
-  check(iterNum, kRun, 5, 7, -1, 0, 0);
+  CPPUNIT_ASSERT(check(iterNum, kRun, 5, 7, -1, 0, 0));
 
   skipEventForward(iterNum);
   checkSkipped(1, 11, 102, 6);
-  check(iterNum, kEnd, -1, -1, -1, 0, 0);
+  CPPUNIT_ASSERT(check(iterNum, kEnd, -1, -1, -1, 0, 0));
 
   skipEventForward(iterNum);
   checkSkipped(-1, 0, 0, -1);
-  check(iterNum, kEnd, -1, -1, -1, 0, 0);
+  CPPUNIT_ASSERT(check(iterNum, kEnd, -1, -1, -1, 0, 0));
 
   iterNum = indexIntoFile.begin(IndexIntoFile::numericalOrder);
   ++iterNum;
 
   skipEventForward(iterNum);
   checkSkipped(0, 11, 101, 3);
-  check(iterNum, kLumi, 0, 1, 1, 1, 4);
+  CPPUNIT_ASSERT(check(iterNum, kLumi, 0, 1, 1, 1, 4));
 
   skipEventForward(iterNum);
   checkSkipped(0, 11, 101, 2);
-  check(iterNum, kLumi, 0, 1, 1, 2, 4);
+  CPPUNIT_ASSERT(check(iterNum, kLumi, 0, 1, 1, 2, 4));
 
   skipEventForward(iterNum);
   checkSkipped(0, 11, 101, 1);
-  check(iterNum, kLumi, 0, 1, 1, 3, 4);
+  CPPUNIT_ASSERT(check(iterNum, kLumi, 0, 1, 1, 3, 4));
 
   skipEventForward(iterNum);
   checkSkipped(0, 11, 101, 0);
-  check(iterNum, kLumi, 0, 4, 4, 0, 2);
+  CPPUNIT_ASSERT(check(iterNum, kLumi, 0, 4, 4, 0, 2));
 
   skipEventForward(iterNum);
   checkSkipped(0, 11, 102, 5);
-  check(iterNum, kLumi, 0, 4, 4, 1, 2);
+  CPPUNIT_ASSERT(check(iterNum, kLumi, 0, 4, 4, 1, 2));
 
   skipEventForward(iterNum);
   checkSkipped(0, 11, 102, 4);
-  check(iterNum, kRun, 5, 7, -1, 0, 0);
+  CPPUNIT_ASSERT(check(iterNum, kRun, 5, 7, -1, 0, 0));
 
   ++iterNum;
   ++iterNum;
   ++iterNum;
-  check(iterNum, kLumi, 6, 8, 8, 0, 1);
+  CPPUNIT_ASSERT(check(iterNum, kLumi, 6, 8, 8, 0, 1));
   skipEventForward(iterNum);
   checkSkipped(1, 11, 102, 6);
-  check(iterNum, kEnd, -1, -1, -1, 0, 0);
+  CPPUNIT_ASSERT(check(iterNum, kEnd, -1, -1, -1, 0, 0));
 
   iterNum = indexIntoFile.begin(IndexIntoFile::numericalOrder);
   ++iterNum;
@@ -670,63 +805,63 @@ void TestIndexIntoFile3::testIterEndWithEvent() {
 
   skipEventForward(iterNum);
   checkSkipped(0, 11, 101, 3);
-  check(iterNum, kEvent, 0, 3, 1, 1, 4);
+  CPPUNIT_ASSERT(check(iterNum, kEvent, 0, 3, 1, 1, 4));
 
   skipEventForward(iterNum);
   checkSkipped(0, 11, 101, 2);
-  check(iterNum, kEvent, 0, 3, 1, 2, 4);
+  CPPUNIT_ASSERT(check(iterNum, kEvent, 0, 3, 1, 2, 4));
 
   skipEventForward(iterNum);
   checkSkipped(0, 11, 101, 1);
-  check(iterNum, kEvent, 0, 3, 1, 3, 4);
+  CPPUNIT_ASSERT(check(iterNum, kEvent, 0, 3, 1, 3, 4));
 
   skipEventForward(iterNum);
   checkSkipped(0, 11, 101, 0);
-  check(iterNum, kLumi, 0, 4, 4, 0, 2);
+  CPPUNIT_ASSERT(check(iterNum, kLumi, 0, 4, 4, 0, 2));
 
   ++iterNum;
   skipEventForward(iterNum);
   checkSkipped(0, 11, 102, 5);
-  check(iterNum, kEvent, 0, 4, 4, 1, 2);
+  CPPUNIT_ASSERT(check(iterNum, kEvent, 0, 4, 4, 1, 2));
 
   skipEventForward(iterNum);
   checkSkipped(0, 11, 102, 4);
-  check(iterNum, kRun, 5, 7, -1, 0, 0);
+  CPPUNIT_ASSERT(check(iterNum, kRun, 5, 7, -1, 0, 0));
 
   iterNum = indexIntoFile.begin(IndexIntoFile::numericalOrder);
   iterNum.advanceToNextLumiOrRun();
-  check(iterNum, kLumi, 0, 1, 1, 0, 4);
+  CPPUNIT_ASSERT(check(iterNum, kLumi, 0, 1, 1, 0, 4));
   iterNum.advanceToNextLumiOrRun();
-  check(iterNum, kLumi, 0, 4, 4, 0, 2);
+  CPPUNIT_ASSERT(check(iterNum, kLumi, 0, 4, 4, 0, 2));
   iterNum.advanceToNextLumiOrRun();
-  check(iterNum, kRun, 5, 7, -1, 0, 0);
+  CPPUNIT_ASSERT(check(iterNum, kRun, 5, 7, -1, 0, 0));
   iterNum.advanceToNextLumiOrRun();
-  check(iterNum, kLumi, 6, 7, -1, 0, 0);
+  CPPUNIT_ASSERT(check(iterNum, kLumi, 6, 7, -1, 0, 0));
   iterNum.advanceToNextLumiOrRun();
-  check(iterNum, kLumi, 6, 8, 8, 0, 1);
+  CPPUNIT_ASSERT(check(iterNum, kLumi, 6, 8, 8, 0, 1));
   iterNum.advanceToNextLumiOrRun();
-  check(iterNum, kEnd, -1, -1, -1, 0, 0);
-
-  iterNum = indexIntoFile.begin(IndexIntoFile::numericalOrder);
-  ++iterNum;
-  ++iterNum;
-  ++iterNum;
-  ++iterNum;
-  check(iterNum, kEvent, 0, 3, 1, 0, 4);
-  iterNum.advanceToNextLumiOrRun();
-  check(iterNum, kLumi, 0, 4, 4, 0, 2);
-  ++iterNum;
-  iterNum.advanceToNextLumiOrRun();
-  check(iterNum, kRun, 5, 7, -1, 0, 0);
+  CPPUNIT_ASSERT(check(iterNum, kEnd, -1, -1, -1, 0, 0));
 
   iterNum = indexIntoFile.begin(IndexIntoFile::numericalOrder);
   ++iterNum;
   ++iterNum;
   ++iterNum;
   ++iterNum;
-  check(iterNum, kEvent, 0, 3, 1, 0, 4);
+  CPPUNIT_ASSERT(check(iterNum, kEvent, 0, 3, 1, 0, 4));
+  iterNum.advanceToNextLumiOrRun();
+  CPPUNIT_ASSERT(check(iterNum, kLumi, 0, 4, 4, 0, 2));
+  ++iterNum;
+  iterNum.advanceToNextLumiOrRun();
+  CPPUNIT_ASSERT(check(iterNum, kRun, 5, 7, -1, 0, 0));
+
+  iterNum = indexIntoFile.begin(IndexIntoFile::numericalOrder);
+  ++iterNum;
+  ++iterNum;
+  ++iterNum;
+  ++iterNum;
+  CPPUNIT_ASSERT(check(iterNum, kEvent, 0, 3, 1, 0, 4));
   iterNum.advanceToNextRun();
-  check(iterNum, kRun, 5, 7, -1, 0, 0);
+  CPPUNIT_ASSERT(check(iterNum, kRun, 5, 7, -1, 0, 0));
 
   // Check backwards iteration
 
@@ -734,35 +869,35 @@ void TestIndexIntoFile3::testIterEndWithEvent() {
 
   skipEventBackward(iterFirst);
   checkSkipped(1, 11, 102, 6);
-  check(iterFirst, kRun, 5, 8, 9, 0, 1);
+  CPPUNIT_ASSERT(check(iterFirst, kRun, 5, 8, 9, 0, 1));
 
   skipEventBackward(iterFirst);
   checkSkipped(0, 11, 102, 5);
-  check(iterFirst, kRun, 0, 4, 4, 1, 2);
+  CPPUNIT_ASSERT(check(iterFirst, kRun, 0, 4, 4, 1, 2));
 
   skipEventBackward(iterFirst);
   checkSkipped(0, 11, 102, 4);
-  check(iterFirst, kRun, 0, 4, 4, 0, 2);
+  CPPUNIT_ASSERT(check(iterFirst, kRun, 0, 4, 4, 0, 2));
 
   skipEventBackward(iterFirst);
   checkSkipped(0, 11, 101, 3);
-  check(iterFirst, kRun, 0, 1, 3, 1, 2);
+  CPPUNIT_ASSERT(check(iterFirst, kRun, 0, 1, 3, 1, 2));
 
   skipEventBackward(iterFirst);
   checkSkipped(0, 11, 101, 2);
-  check(iterFirst, kRun, 0, 1, 3, 0, 2);
+  CPPUNIT_ASSERT(check(iterFirst, kRun, 0, 1, 3, 0, 2));
 
   skipEventBackward(iterFirst);
   checkSkipped(0, 11, 101, 1);
-  check(iterFirst, kRun, 0, 1, 1, 1, 2);
+  CPPUNIT_ASSERT(check(iterFirst, kRun, 0, 1, 1, 1, 2));
 
   skipEventBackward(iterFirst);
   checkSkipped(0, 11, 101, 0);
-  check(iterFirst, kRun, 0, 1, 1, 0, 2);
+  CPPUNIT_ASSERT(check(iterFirst, kRun, 0, 1, 1, 0, 2));
 
   skipEventBackward(iterFirst);
   checkSkipped(-1, 0, 0, -1);
-  check(iterFirst, kRun, 0, 1, 1, 0, 2);
+  CPPUNIT_ASSERT(check(iterFirst, kRun, 0, 1, 1, 0, 2));
 
   ++iterFirst;
   ++iterFirst;
@@ -774,79 +909,79 @@ void TestIndexIntoFile3::testIterEndWithEvent() {
   ++iterFirst;
   ++iterFirst;
   ++iterFirst;
-  check(iterFirst, kEvent, 0, 4, 4, 1, 2);
-
-  skipEventBackward(iterFirst);
-  checkSkipped(0, 11, 102, 4);
-  check(iterFirst, kEvent, 0, 4, 4, 0, 2);
-
-  skipEventBackward(iterFirst);
-  checkSkipped(0, 11, 101, 3);
-  check(iterFirst, kLumi, 0, 1, 3, 1, 2);
-
-  skipEventForward(iterFirst);
-  skipEventForward(iterFirst);
-  check(iterFirst, kLumi, 0, 4, 4, 1, 2);
+  CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 4, 4, 1, 2));
 
   skipEventBackward(iterFirst);
   checkSkipped(0, 11, 102, 4);
-  check(iterFirst, kLumi, 0, 4, 4, 0, 2);
+  CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 4, 4, 0, 2));
 
   skipEventBackward(iterFirst);
   checkSkipped(0, 11, 101, 3);
-  check(iterFirst, kLumi, 0, 1, 3, 1, 2);
+  CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 1, 3, 1, 2));
+
+  skipEventForward(iterFirst);
+  skipEventForward(iterFirst);
+  CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 4, 4, 1, 2));
+
+  skipEventBackward(iterFirst);
+  checkSkipped(0, 11, 102, 4);
+  CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 4, 4, 0, 2));
+
+  skipEventBackward(iterFirst);
+  checkSkipped(0, 11, 101, 3);
+  CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 1, 3, 1, 2));
 
   iterFirst.advanceToNextRun();
   iterFirst.advanceToEvent();
-  check(iterFirst, kEvent, 6, 9, 9, 0, 1);
+  CPPUNIT_ASSERT(check(iterFirst, kEvent, 6, 9, 9, 0, 1));
 
   skipEventBackward(iterFirst);
   checkSkipped(0, 11, 102, 5);
-  check(iterFirst, kRun, 0, 4, 4, 1, 2);
+  CPPUNIT_ASSERT(check(iterFirst, kRun, 0, 4, 4, 1, 2));
 
   iterFirst.advanceToNextRun();
   ++iterFirst;
   ++iterFirst;
   ++iterFirst;
-  check(iterFirst, kLumi, 6, 8, 9, 0, 1);
+  CPPUNIT_ASSERT(check(iterFirst, kLumi, 6, 8, 9, 0, 1));
 
   skipEventBackward(iterFirst);
   checkSkipped(0, 11, 102, 5);
-  check(iterFirst, kRun, 0, 4, 4, 1, 2);
+  CPPUNIT_ASSERT(check(iterFirst, kRun, 0, 4, 4, 1, 2));
 
   iterNum = indexIntoFile.end(IndexIntoFile::numericalOrder);
 
   skipEventBackward(iterNum);
   checkSkipped(1, 11, 102, 6);
-  check(iterNum, kRun, 5, 8, 8, 0, 1);
+  CPPUNIT_ASSERT(check(iterNum, kRun, 5, 8, 8, 0, 1));
 
   skipEventBackward(iterNum);
   checkSkipped(0, 11, 102, 4);
-  check(iterNum, kRun, 0, 4, 4, 1, 2);
+  CPPUNIT_ASSERT(check(iterNum, kRun, 0, 4, 4, 1, 2));
 
   skipEventBackward(iterNum);
   checkSkipped(0, 11, 102, 5);
-  check(iterNum, kRun, 0, 4, 4, 0, 2);
+  CPPUNIT_ASSERT(check(iterNum, kRun, 0, 4, 4, 0, 2));
 
   skipEventBackward(iterNum);
   checkSkipped(0, 11, 101, 0);
-  check(iterNum, kRun, 0, 1, 1, 3, 4);
+  CPPUNIT_ASSERT(check(iterNum, kRun, 0, 1, 1, 3, 4));
 
   skipEventBackward(iterNum);
   checkSkipped(0, 11, 101, 1);
-  check(iterNum, kRun, 0, 1, 1, 2, 4);
+  CPPUNIT_ASSERT(check(iterNum, kRun, 0, 1, 1, 2, 4));
 
   skipEventBackward(iterNum);
   checkSkipped(0, 11, 101, 2);
-  check(iterNum, kRun, 0, 1, 1, 1, 4);
+  CPPUNIT_ASSERT(check(iterNum, kRun, 0, 1, 1, 1, 4));
 
   skipEventBackward(iterNum);
   checkSkipped(0, 11, 101, 3);
-  check(iterNum, kRun, 0, 1, 1, 0, 4);
+  CPPUNIT_ASSERT(check(iterNum, kRun, 0, 1, 1, 0, 4));
 
   skipEventBackward(iterNum);
   checkSkipped(-1, 0, 0, -1);
-  check(iterNum, kRun, 0, 1, 1, 0, 4);
+  CPPUNIT_ASSERT(check(iterNum, kRun, 0, 1, 1, 0, 4));
 
   ++iterNum;
   ++iterNum;
@@ -858,45 +993,45 @@ void TestIndexIntoFile3::testIterEndWithEvent() {
   ++iterNum;
   ++iterNum;
   ++iterNum;
-  check(iterNum, kEvent, 0, 4, 4, 1, 2);
-
-  skipEventBackward(iterNum);
-  checkSkipped(0, 11, 102, 5);
-  check(iterNum, kEvent, 0, 4, 4, 0, 2);
-
-  skipEventBackward(iterNum);
-  checkSkipped(0, 11, 101, 0);
-  check(iterNum, kLumi, 0, 1, 1, 3, 4);
-
-  skipEventForward(iterNum);
-  skipEventForward(iterNum);
-  check(iterNum, kLumi, 0, 4, 4, 1, 2);
+  CPPUNIT_ASSERT(check(iterNum, kEvent, 0, 4, 4, 1, 2));
 
   skipEventBackward(iterNum);
   checkSkipped(0, 11, 102, 5);
-  check(iterNum, kLumi, 0, 4, 4, 0, 2);
+  CPPUNIT_ASSERT(check(iterNum, kEvent, 0, 4, 4, 0, 2));
 
   skipEventBackward(iterNum);
   checkSkipped(0, 11, 101, 0);
-  check(iterNum, kLumi, 0, 1, 1, 3, 4);
+  CPPUNIT_ASSERT(check(iterNum, kLumi, 0, 1, 1, 3, 4));
+
+  skipEventForward(iterNum);
+  skipEventForward(iterNum);
+  CPPUNIT_ASSERT(check(iterNum, kLumi, 0, 4, 4, 1, 2));
+
+  skipEventBackward(iterNum);
+  checkSkipped(0, 11, 102, 5);
+  CPPUNIT_ASSERT(check(iterNum, kLumi, 0, 4, 4, 0, 2));
+
+  skipEventBackward(iterNum);
+  checkSkipped(0, 11, 101, 0);
+  CPPUNIT_ASSERT(check(iterNum, kLumi, 0, 1, 1, 3, 4));
 
   iterNum.advanceToNextRun();
   iterNum.advanceToEvent();
-  check(iterNum, kEvent, 6, 9, 8, 0, 1);
+  CPPUNIT_ASSERT(check(iterNum, kEvent, 6, 9, 8, 0, 1));
 
   skipEventBackward(iterNum);
   checkSkipped(0, 11, 102, 4);
-  check(iterNum, kRun, 0, 4, 4, 1, 2);
+  CPPUNIT_ASSERT(check(iterNum, kRun, 0, 4, 4, 1, 2));
 
   iterNum.advanceToNextRun();
   ++iterNum;
   ++iterNum;
   ++iterNum;
-  check(iterNum, kLumi, 6, 8, 8, 0, 1);
+  CPPUNIT_ASSERT(check(iterNum, kLumi, 6, 8, 8, 0, 1));
 
   skipEventBackward(iterNum);
   checkSkipped(0, 11, 102, 4);
-  check(iterNum, kRun, 0, 4, 4, 1, 2);
+  CPPUNIT_ASSERT(check(iterNum, kRun, 0, 4, 4, 1, 2));
 }
 
 void TestIndexIntoFile3::testOverlappingLumis() {
@@ -940,41 +1075,41 @@ void TestIndexIntoFile3::testOverlappingLumis() {
     int i = 0;
     for (i = 0; iterFirst != iterFirstEnd; ++iterFirst, ++i) {
       if (i == 0) {
-        check(iterFirst, kRun, 0, 1, -1, 0, 0);
+        CPPUNIT_ASSERT(check(iterFirst, kRun, 0, 1, -1, 0, 0));
         CPPUNIT_ASSERT(iterFirst.indexIntoFile() == &indexIntoFile);
         CPPUNIT_ASSERT(iterFirst.size() == 11);
       }
       //values are 'IndexIntoFile::EntryType' 'indexToRun' 'indexToLumi' 'indexToEventRange' 'indexToEvent' 'nEvents'
       else if (i == 1)
-        check(iterFirst, kLumi, 0, 1, -1, 0, 0);
+        CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 1, -1, 0, 0));
       else if (i == 2)
-        check(iterFirst, kLumi, 0, 3, 2, 0, 4);
+        CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 3, 2, 0, 4));
       else if (i == 3)
-        check(iterFirst, kEvent, 0, 3, 2, 0, 4);
+        CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 3, 2, 0, 4));
       else if (i == 4)
-        check(iterFirst, kEvent, 0, 3, 2, 1, 4);
+        CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 3, 2, 1, 4));
       else if (i == 5)
-        check(iterFirst, kEvent, 0, 3, 2, 2, 4);
+        CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 3, 2, 2, 4));
       else if (i == 6)
-        check(iterFirst, kEvent, 0, 3, 2, 3, 4);
+        CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 3, 2, 3, 4));
       else if (i == 7)
-        check(iterFirst, kLumi, 0, 5, 4, 0, 1);
+        CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 5, 4, 0, 1));
       else if (i == 8)
-        check(iterFirst, kEvent, 0, 5, 4, 0, 1);
+        CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 5, 4, 0, 1));
       else if (i == 9)
-        check(iterFirst, kEvent, 0, 5, 5, 0, 1);
+        CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 5, 5, 0, 1));
       else if (i == 10)
-        check(iterFirst, kRun, 6, 8, -1, 0, 0);
+        CPPUNIT_ASSERT(check(iterFirst, kRun, 6, 8, -1, 0, 0));
       else if (i == 11)
-        check(iterFirst, kRun, 7, 8, -1, 0, 0);
+        CPPUNIT_ASSERT(check(iterFirst, kRun, 7, 8, -1, 0, 0));
       else if (i == 12)
-        check(iterFirst, kLumi, 7, 8, -1, 0, 0);
+        CPPUNIT_ASSERT(check(iterFirst, kLumi, 7, 8, -1, 0, 0));
       else if (i == 13)
-        check(iterFirst, kLumi, 7, 9, 10, 0, 1);
+        CPPUNIT_ASSERT(check(iterFirst, kLumi, 7, 9, 10, 0, 1));
       else if (i == 14)
-        check(iterFirst, kLumi, 7, 10, 10, 0, 1);
+        CPPUNIT_ASSERT(check(iterFirst, kLumi, 7, 10, 10, 0, 1));
       else if (i == 15)
-        check(iterFirst, kEvent, 7, 10, 10, 0, 1);
+        CPPUNIT_ASSERT(check(iterFirst, kEvent, 7, 10, 10, 0, 1));
       else
         CPPUNIT_ASSERT(false);
 
@@ -1001,68 +1136,129 @@ void TestIndexIntoFile3::testOverlappingLumis() {
     for (i = 0; iterFirst != iterFirstEnd; ++iterFirst, ++i) {
       //values are 'IndexIntoFile::EntryType' 'indexToRun' 'indexToLumi' 'indexToEventRange' 'indexToEvent' 'nEvents'
       if (i == 0) {
-        check(iterFirst, kRun, 0, 2, 1, 0, 2);
+        CPPUNIT_ASSERT(check(iterFirst, kRun, 0, 2, 1, 0, 2));
 
         iterFirst.getLumisInRun(lumis);
         std::vector<LuminosityBlockNumber_t> expected{102, 103, 104};
         CPPUNIT_ASSERT(lumis == expected);
       } else if (i == 1)
-        check(iterFirst, kLumi, 0, 2, 1, 0, 2);
+        CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 2, 1, 0, 2));
       else if (i == 2)
-        check(iterFirst, kEvent, 0, 2, 1, 0, 2);
+        CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 2, 1, 0, 2));
       else if (i == 3)
-        check(iterFirst, kEvent, 0, 2, 1, 1, 2);
+        CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 2, 1, 1, 2));
       else if (i == 4)
-        check(iterFirst, kLumi, 0, 4, 3, 0, 4);
+        CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 4, 3, 0, 4));
       else if (i == 5)
-        check(iterFirst, kEvent, 0, 4, 3, 0, 4);
+        CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 4, 3, 0, 4));
       else if (i == 6)
-        check(iterFirst, kEvent, 0, 4, 3, 1, 4);
+        CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 4, 3, 1, 4));
       else if (i == 7)
-        check(iterFirst, kEvent, 0, 4, 3, 2, 4);
+        CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 4, 3, 2, 4));
       else if (i == 8)
-        check(iterFirst, kEvent, 0, 4, 3, 3, 4);
+        CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 4, 3, 3, 4));
       else if (i == 9)
-        check(iterFirst, kLumi, 0, 5, -1, 0, 0);
+        CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 5, -1, 0, 0));
       else if (i == 10)
-        check(iterFirst, kRun, 6, 8, -1, 0, 0);
+        CPPUNIT_ASSERT(check(iterFirst, kRun, 6, 8, -1, 0, 0));
       else if (i == 11)
-        check(iterFirst, kRun, 7, 8, -1, 0, 0);
+        CPPUNIT_ASSERT(check(iterFirst, kRun, 7, 8, -1, 0, 0));
       else if (i == 12)
-        check(iterFirst, kLumi, 7, 8, -1, 0, 0);
+        CPPUNIT_ASSERT(check(iterFirst, kLumi, 7, 8, -1, 0, 0));
       else if (i == 13)
-        check(iterFirst, kLumi, 7, 9, 9, 0, 1);
+        CPPUNIT_ASSERT(check(iterFirst, kLumi, 7, 9, 9, 0, 1));
       else if (i == 14)
-        check(iterFirst, kLumi, 7, 10, 9, 0, 1);
+        CPPUNIT_ASSERT(check(iterFirst, kLumi, 7, 10, 9, 0, 1));
       else if (i == 15)
-        check(iterFirst, kEvent, 7, 10, 9, 0, 1);
+        CPPUNIT_ASSERT(check(iterFirst, kEvent, 7, 10, 9, 0, 1));
       else
         CPPUNIT_ASSERT(false);
+    }
+    CPPUNIT_ASSERT(i == 16);
+  }
+  {
+    edm::IndexIntoFile::IndexIntoFileItr iterFirst = indexIntoFile.begin(IndexIntoFile::entryOrder);
+    edm::IndexIntoFile::IndexIntoFileItr iterFirstEnd = indexIntoFile.end(IndexIntoFile::entryOrder);
+    int i = 0;
+    for (i = 0; iterFirst != iterFirstEnd; ++iterFirst, ++i) {
+      //values are 'IndexIntoFile::EntryType' 'indexToRun' 'indexToLumi' 'indexToEventRange' 'indexToEvent' 'nEvents'
+      if (i == 0) {
+        CPPUNIT_ASSERT(check(iterFirst, kRun, 0, 1, -1, 0, 0));
+        CPPUNIT_ASSERT(iterFirst.indexIntoFile() == &indexIntoFile);
+        CPPUNIT_ASSERT(iterFirst.size() == 11);
+      }
+      //values are 'IndexIntoFile::EntryType' 'indexToRun' 'indexToLumi' 'indexToEventRange' 'indexToEvent' 'nEvents'
+      else if (i == 1)
+        CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 1, -1, 0, 0));
+      else if (i == 2)
+        CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 3, 2, 0, 4));
+      else if (i == 3)
+        CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 3, 2, 0, 4));
+      else if (i == 4)
+        CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 3, 2, 1, 4));
+      else if (i == 5)
+        CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 3, 2, 2, 4));
+      else if (i == 6)
+        CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 3, 2, 3, 4));
+      else if (i == 7)
+        CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 5, 4, 0, 1));
+      else if (i == 8)
+        CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 5, 4, 0, 1));
+      else if (i == 9)
+        CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 5, 5, 0, 1));
+      else if (i == 10)
+        CPPUNIT_ASSERT(check(iterFirst, kRun, 6, 8, -1, 0, 0));
+      else if (i == 11)
+        CPPUNIT_ASSERT(check(iterFirst, kRun, 7, 8, -1, 0, 0));
+      else if (i == 12)
+        CPPUNIT_ASSERT(check(iterFirst, kLumi, 7, 8, -1, 0, 0));
+      else if (i == 13)
+        CPPUNIT_ASSERT(check(iterFirst, kLumi, 7, 9, 10, 0, 1));
+      else if (i == 14)
+        CPPUNIT_ASSERT(check(iterFirst, kLumi, 7, 10, 10, 0, 1));
+      else if (i == 15)
+        CPPUNIT_ASSERT(check(iterFirst, kEvent, 7, 10, 10, 0, 1));
+      else
+        CPPUNIT_ASSERT(false);
+
+      if (i == 1)
+        CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 0);
+      if (i == 9)
+        CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 0);
+      if (i == 11)
+        CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 6);
+
+      if (i == 2)
+        CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == 0);
+      if (i == 9)
+        CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == 4);
+      if (i == 11)
+        CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == IndexIntoFile::invalidIndex);
     }
     CPPUNIT_ASSERT(i == 16);
   }
 
   {
     edm::IndexIntoFile::IndexIntoFileItr testIter = indexIntoFile.findPosition(11, 103, 7);
-    check(testIter, kRun, 0, 4, 3, 3, 4);
+    CPPUNIT_ASSERT(check(testIter, kRun, 0, 4, 3, 3, 4));
     ++testIter;
-    check(testIter, kLumi, 0, 4, 3, 3, 4);
+    CPPUNIT_ASSERT(check(testIter, kLumi, 0, 4, 3, 3, 4));
     ++testIter;
-    check(testIter, kEvent, 0, 4, 3, 3, 4);
+    CPPUNIT_ASSERT(check(testIter, kEvent, 0, 4, 3, 3, 4));
     ++testIter;
-    check(testIter, kLumi, 0, 5, -1, 0, 0);
+    CPPUNIT_ASSERT(check(testIter, kLumi, 0, 5, -1, 0, 0));
   }
   {
     edm::IndexIntoFile::IndexIntoFileItr testIter = indexIntoFile.findPosition(11, 0, 7);
-    check(testIter, kRun, 0, 4, 3, 3, 4);
+    CPPUNIT_ASSERT(check(testIter, kRun, 0, 4, 3, 3, 4));
     ++testIter;
-    check(testIter, kLumi, 0, 4, 3, 3, 4);
+    CPPUNIT_ASSERT(check(testIter, kLumi, 0, 4, 3, 3, 4));
     ++testIter;
-    check(testIter, kEvent, 0, 4, 3, 3, 4);
+    CPPUNIT_ASSERT(check(testIter, kEvent, 0, 4, 3, 3, 4));
     ++testIter;
-    check(testIter, kLumi, 0, 5, -1, 0, 0);
+    CPPUNIT_ASSERT(check(testIter, kLumi, 0, 5, -1, 0, 0));
     skipEventBackward(testIter);
-    check(testIter, kLumi, 0, 4, 3, 3, 4);
+    CPPUNIT_ASSERT(check(testIter, kLumi, 0, 4, 3, 3, 4));
   }
 }
 
@@ -1090,68 +1286,1089 @@ void TestIndexIntoFile3::testOverlappingLumisMore() {
 
   std::vector<LuminosityBlockNumber_t> lumis;
 
-  edm::IndexIntoFile::IndexIntoFileItr iterFirst = indexIntoFile.begin(IndexIntoFile::firstAppearanceOrder);
-  edm::IndexIntoFile::IndexIntoFileItr iterFirstEnd = indexIntoFile.end(IndexIntoFile::firstAppearanceOrder);
-  int i = 0;
-  for (i = 0; iterFirst != iterFirstEnd; ++iterFirst, ++i) {
-    if (i == 0) {
-      check(iterFirst, kRun, 0, 2, 1, 0, 3);
-      CPPUNIT_ASSERT(iterFirst.indexIntoFile() == &indexIntoFile);
-      CPPUNIT_ASSERT(iterFirst.size() == 10);
+  {
+    edm::IndexIntoFile::IndexIntoFileItr iterFirst = indexIntoFile.begin(IndexIntoFile::firstAppearanceOrder);
+    edm::IndexIntoFile::IndexIntoFileItr iterFirstEnd = indexIntoFile.end(IndexIntoFile::firstAppearanceOrder);
+    int i = 0;
+    for (i = 0; iterFirst != iterFirstEnd; ++iterFirst, ++i) {
+      switch (i) {
+        case 0: {
+          CPPUNIT_ASSERT(check(iterFirst, kRun, 0, 2, 1, 0, 3));
+          CPPUNIT_ASSERT(iterFirst.indexIntoFile() == &indexIntoFile);
+          CPPUNIT_ASSERT(iterFirst.size() == 10);
 
-      iterFirst.getLumisInRun(lumis);
-      std::vector<LuminosityBlockNumber_t> expected{101, 102};
-      CPPUNIT_ASSERT(lumis == expected);
+          iterFirst.getLumisInRun(lumis);
+          std::vector<LuminosityBlockNumber_t> expected{101, 102};
+          CPPUNIT_ASSERT(lumis == expected);
+          break;
+        }
+          //values are 'IndexIntoFile::EntryType' 'indexToRun' 'indexToLumi' 'indexToEventRange' 'indexToEvent' 'nEvents'
+        case 1: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 2, 1, 0, 3));
+          break;
+        }
+        case 2: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 2, 1, 0, 3));
+          break;
+        }
+        case 3: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 2, 1, 1, 3));
+          break;
+        }
+        case 4: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 2, 1, 2, 3));
+          break;
+        }
+        case 5: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 2, 2, 0, 1));
+          break;
+        }
+        case 6: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 4, 3, 0, 1));
+          break;
+        }
+        case 7: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 4, 3, 0, 1));
+          break;
+        }
+        case 8: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 4, 4, 0, 1));
+          break;
+        }
+        case 9: {
+          CPPUNIT_ASSERT(check(iterFirst, kRun, 5, 7, -1, 0, 0));
+
+          iterFirst.getLumisInRun(lumis);
+          std::vector<LuminosityBlockNumber_t> expected{101, 102};
+          CPPUNIT_ASSERT(lumis == expected);
+          break;
+        }
+        case 10: {
+          CPPUNIT_ASSERT(check(iterFirst, kRun, 6, 7, -1, 0, 0));
+          break;
+        }
+        case 11: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 6, 7, -1, 0, 0));
+          break;
+        }
+        case 12: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 6, 8, 9, 0, 1));
+          break;
+        }
+        case 13: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 6, 9, 9, 0, 1));
+          break;
+        }
+        case 14: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 6, 9, 9, 0, 1));
+          break;
+        }
+        default: {
+          CPPUNIT_ASSERT(false);
+        }
+      }
+      if (i == 0)
+        CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 0);
+      if (i == 8)
+        CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 0);
+      if (i == 10)
+        CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 6);
+
+      if (i == 0)
+        CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == 0);
+      if (i == 8)
+        CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == 4);
+      if (i == 10)
+        CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == IndexIntoFile::invalidIndex);
     }
-    //values are 'IndexIntoFile::EntryType' 'indexToRun' 'indexToLumi' 'indexToEventRange' 'indexToEvent' 'nEvents'
-    else if (i == 1)
-      check(iterFirst, kLumi, 0, 2, 1, 0, 3);
-    else if (i == 2)
-      check(iterFirst, kEvent, 0, 2, 1, 0, 3);
-    else if (i == 3)
-      check(iterFirst, kEvent, 0, 2, 1, 1, 3);
-    else if (i == 4)
-      check(iterFirst, kEvent, 0, 2, 1, 2, 3);
-    else if (i == 5)
-      check(iterFirst, kEvent, 0, 2, 2, 0, 1);
-    else if (i == 6)
-      check(iterFirst, kLumi, 0, 4, 3, 0, 1);
-    else if (i == 7)
-      check(iterFirst, kEvent, 0, 4, 3, 0, 1);
-    else if (i == 8)
-      check(iterFirst, kEvent, 0, 4, 4, 0, 1);
-    else if (i == 9) {
-      check(iterFirst, kRun, 5, 7, -1, 0, 0);
-
-      iterFirst.getLumisInRun(lumis);
-      std::vector<LuminosityBlockNumber_t> expected{101, 102};
-      CPPUNIT_ASSERT(lumis == expected);
-    } else if (i == 10)
-      check(iterFirst, kRun, 6, 7, -1, 0, 0);
-    else if (i == 11)
-      check(iterFirst, kLumi, 6, 7, -1, 0, 0);
-    else if (i == 12)
-      check(iterFirst, kLumi, 6, 8, 9, 0, 1);
-    else if (i == 13)
-      check(iterFirst, kLumi, 6, 9, 9, 0, 1);
-    else if (i == 14)
-      check(iterFirst, kEvent, 6, 9, 9, 0, 1);
-    else
-      CPPUNIT_ASSERT(false);
-
-    if (i == 0)
-      CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 0);
-    if (i == 8)
-      CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 0);
-    if (i == 10)
-      CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 6);
-
-    if (i == 0)
-      CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == 0);
-    if (i == 8)
-      CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == 4);
-    if (i == 10)
-      CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == IndexIntoFile::invalidIndex);
+    CPPUNIT_ASSERT(i == 15);
   }
-  CPPUNIT_ASSERT(i == 15);
+
+  {
+    edm::IndexIntoFile::IndexIntoFileItr iterFirst = indexIntoFile.begin(IndexIntoFile::entryOrder);
+    edm::IndexIntoFile::IndexIntoFileItr iterFirstEnd = indexIntoFile.end(IndexIntoFile::entryOrder);
+    int i = 0;
+    for (i = 0; iterFirst != iterFirstEnd; ++iterFirst, ++i) {
+      switch (i) {
+        case 0: {
+          CPPUNIT_ASSERT(check(iterFirst, kRun, 0, 2, 1, 0, 3));
+          CPPUNIT_ASSERT(iterFirst.indexIntoFile() == &indexIntoFile);
+          CPPUNIT_ASSERT(iterFirst.size() == 10);
+
+          iterFirst.getLumisInRun(lumis);
+          std::vector<LuminosityBlockNumber_t> expected{101, 102};
+          CPPUNIT_ASSERT(lumis == expected);
+          break;
+        }
+        //values are 'IndexIntoFile::EntryType' 'indexToRun' 'indexToLumi' 'indexToEventRange' 'indexToEvent' 'nEvents'
+        case 1: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 2, 1, 0, 3));
+          break;
+        }
+        case 2: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 2, 1, 0, 3));
+          break;
+        }
+        case 3: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 2, 1, 1, 3));
+          break;
+        }
+        case 4: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 2, 1, 2, 3));
+          break;
+        }
+        case 5: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 2, 2, 0, 1));
+          break;
+        }
+        case 6: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 4, 3, 0, 1));
+          break;
+        }
+        case 7: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 4, 3, 0, 1));
+          break;
+        }
+        case 8: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 4, 4, 0, 1));
+          break;
+        }
+        case 9: {
+          CPPUNIT_ASSERT(check(iterFirst, kRun, 5, 7, -1, 0, 0));
+
+          iterFirst.getLumisInRun(lumis);
+          std::vector<LuminosityBlockNumber_t> expected{101, 102};
+          CPPUNIT_ASSERT(lumis == expected);
+          break;
+        }
+        case 10: {
+          CPPUNIT_ASSERT(check(iterFirst, kRun, 6, 7, -1, 0, 0));
+          break;
+        }
+        case 11: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 6, 7, -1, 0, 0));
+          break;
+        }
+        case 12: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 6, 8, 9, 0, 1));
+          break;
+        }
+        case 13: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 6, 9, 9, 0, 1));
+          break;
+        }
+        case 14: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 6, 9, 9, 0, 1));
+          break;
+        }
+        default:
+          CPPUNIT_ASSERT(false);
+      }
+
+      if (i == 0)
+        CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 0);
+      if (i == 8)
+        CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 0);
+      if (i == 10)
+        CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 6);
+
+      if (i == 0)
+        CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == 0);
+      if (i == 8)
+        CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == 4);
+      if (i == 10)
+        CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == IndexIntoFile::invalidIndex);
+    }
+    CPPUNIT_ASSERT(i == 15);
+  }
+}
+
+void TestIndexIntoFile3::testOverlappingLumisOutOfOrderEvent() {
+  edm::IndexIntoFile indexIntoFile;
+  indexIntoFile.addEntry(fakePHID1, 11, 101, 7, 0);  // Event
+  indexIntoFile.addEntry(fakePHID1, 11, 101, 6, 1);  // Event
+  indexIntoFile.addEntry(fakePHID1, 11, 101, 5, 2);  // Event
+  //Dummy Lumi gets added
+  indexIntoFile.addEntry(fakePHID1, 11, 102, 5, 3);  // Event
+  //Another dummy lumi gets added
+  indexIntoFile.addEntry(fakePHID1, 11, 101, 4, 4);  // Event
+  indexIntoFile.addEntry(fakePHID1, 11, 101, 0, 0);  // Lumi
+
+  indexIntoFile.addEntry(fakePHID1, 11, 102, 4, 5);  // Event
+  indexIntoFile.addEntry(fakePHID1, 11, 102, 0, 1);  // Lumi
+  indexIntoFile.addEntry(fakePHID1, 11, 0, 0, 0);    // Run
+  indexIntoFile.addEntry(fakePHID2, 11, 0, 0, 1);    // Run
+  indexIntoFile.addEntry(fakePHID2, 11, 101, 0, 2);  // Lumi
+  indexIntoFile.addEntry(fakePHID2, 11, 102, 0, 3);  // Lumi
+  indexIntoFile.addEntry(fakePHID2, 11, 102, 4, 6);  // Event
+  indexIntoFile.addEntry(fakePHID2, 11, 102, 0, 4);  // Lumi
+  indexIntoFile.addEntry(fakePHID2, 11, 0, 0, 2);    // Run
+  indexIntoFile.sortVector_Run_Or_Lumi_Entries();
+
+  std::vector<LuminosityBlockNumber_t> lumis;
+
+  {
+    edm::IndexIntoFile::IndexIntoFileItr iterFirst = indexIntoFile.begin(IndexIntoFile::firstAppearanceOrder);
+    edm::IndexIntoFile::IndexIntoFileItr iterFirstEnd = indexIntoFile.end(IndexIntoFile::firstAppearanceOrder);
+    int i = 0;
+    for (i = 0; iterFirst != iterFirstEnd; ++iterFirst, ++i) {
+      switch (i) {
+        case 0: {
+          CPPUNIT_ASSERT(check(iterFirst, kRun, 0, 2, 1, 0, 3));  // run 11
+          CPPUNIT_ASSERT(iterFirst.indexIntoFile() == &indexIntoFile);
+          CPPUNIT_ASSERT(iterFirst.size() == 10);
+
+          iterFirst.getLumisInRun(lumis);
+          std::vector<LuminosityBlockNumber_t> expected{101, 102};
+          CPPUNIT_ASSERT(lumis == expected);
+          CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 0);
+          CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == 0);
+          break;
+        }
+          //values are 'IndexIntoFile::EntryType' 'indexToRun' 'indexToLumi' 'indexToEventRange' 'indexToEvent' 'nEvents'
+        case 1: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 2, 1, 0, 3));  // lumi 11/101
+          break;
+        }
+        case 2: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 2, 1, 0, 3));  // event 11/101/7
+          break;
+        }
+        case 3: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 2, 1, 1, 3));  // event 11/101/6
+          break;
+        }
+        case 4: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 2, 1, 2, 3));  // event 11/101/5
+          break;
+        }
+        case 5: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 2, 2, 0, 1));
+          break;
+        }
+        case 6: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 4, 3, 0, 1));
+          break;
+        }
+        case 7: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 4, 3, 0, 1));
+          break;
+        }
+        case 8: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 4, 4, 0, 1));
+          CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 0);
+          CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == 3);
+          break;
+        }
+        case 9: {
+          CPPUNIT_ASSERT(check(iterFirst, kRun, 5, 7, -1, 0, 0));
+
+          iterFirst.getLumisInRun(lumis);
+          std::vector<LuminosityBlockNumber_t> expected{101, 102};
+          CPPUNIT_ASSERT(lumis == expected);
+          break;
+        }
+        case 10: {
+          CPPUNIT_ASSERT(check(iterFirst, kRun, 6, 7, -1, 0, 0));
+          CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 6);
+          CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == IndexIntoFile::invalidIndex);
+          break;
+        }
+        case 11: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 6, 7, -1, 0, 0));
+          break;
+        }
+        case 12: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 6, 8, 9, 0, 1));
+          break;
+        }
+        case 13: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 6, 9, 9, 0, 1));
+          break;
+        }
+        case 14: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 6, 9, 9, 0, 1));
+          break;
+        }
+        default: {
+          CPPUNIT_ASSERT(false);
+        }
+      }
+    }
+    CPPUNIT_ASSERT(i == 15);
+  }
+
+  {
+    edm::IndexIntoFile::IndexIntoFileItr iterFirst = indexIntoFile.begin(IndexIntoFile::entryOrder);
+    edm::IndexIntoFile::IndexIntoFileItr iterFirstEnd = indexIntoFile.end(IndexIntoFile::entryOrder);
+    int i = 0;
+    for (i = 0; iterFirst != iterFirstEnd; ++iterFirst, ++i) {
+      /*std::cout << "out of order run:" << iterFirst.run() << " lumi:" << iterFirst.lumi()
+                << " firstEventEntryThisRun:" << iterFirst.firstEventEntryThisRun()
+                << " firstEventEntryThisLumi:" << iterFirst.firstEventEntryThisLumi() << std::endl; */
+      switch (i) {
+        case 0: {
+          CPPUNIT_ASSERT(check(iterFirst, kRun, 0, 1, 1, 0, 3));  // run 11
+          CPPUNIT_ASSERT(iterFirst.indexIntoFile() == &indexIntoFile);
+          CPPUNIT_ASSERT(iterFirst.size() == 10);
+
+          iterFirst.getLumisInRun(lumis);
+          std::vector<LuminosityBlockNumber_t> expected{101, 102};
+          CPPUNIT_ASSERT(lumis == expected);
+          CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 0);
+          CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == 0);
+          break;
+        }
+        //values are 'IndexIntoFile::EntryType' 'indexToRun' 'indexToLumi' 'indexToEventRange' 'indexToEvent' 'nEvents'
+        case 1: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 1, 1, 0, 3));  // lumi 11/101
+          CPPUNIT_ASSERT(iterFirst.entryContinues());
+          break;
+        }
+        case 2: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 1, 1, 0, 3));  // event 11/101/7
+          break;
+        }
+        case 3: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 1, 1, 1, 3));  // event 11/101/6
+          break;
+        }
+        case 4: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 1, 1, 2, 3));  // event 11/101/5
+          break;
+        }
+        case 5: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 2, 2, 0, 1));  // lumi 11/102
+          CPPUNIT_ASSERT(iterFirst.entryContinues());
+          break;
+        }
+        case 6: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 2, 2, 0, 1));  // event 11/102/3
+          break;
+        }
+        case 7: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 3, 3, 0, 1));  // lumi 11/101
+          CPPUNIT_ASSERT(not iterFirst.entryContinues());
+          break;
+        }
+        case 8: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 3, 3, 0, 1));  // event 11/101/4
+          CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 0);
+          CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == 4);
+          break;
+        }
+        case 9: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 4, 4, 0, 1));  // lumi 11/102
+          CPPUNIT_ASSERT(not iterFirst.entryContinues());
+          break;
+        }
+        case 10: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 4, 4, 0, 1));  // event 11/102/4
+          break;
+        }
+        case 11: {
+          CPPUNIT_ASSERT(check(iterFirst, kRun, 5, 7, -1, 0, 0));  //Run Phid 2 11
+
+          iterFirst.getLumisInRun(lumis);
+          std::vector<LuminosityBlockNumber_t> expected{101, 102};
+          CPPUNIT_ASSERT(lumis == expected);
+
+          CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 6);
+          CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == IndexIntoFile::invalidIndex);
+          break;
+        }
+        case 12: {
+          CPPUNIT_ASSERT(check(iterFirst, kRun, 6, 7, -1, 0, 0));
+          break;
+        }
+        case 13: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 6, 7, -1, 0, 0));
+          break;
+        }
+        case 14: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 6, 8, 9, 0, 1));
+          break;
+        }
+        case 15: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 6, 9, 9, 0, 1));
+          break;
+        }
+        case 16: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 6, 9, 9, 0, 1));
+          break;
+        }
+        default:
+          CPPUNIT_ASSERT(false);
+      }
+    }
+    CPPUNIT_ASSERT(i == 17);
+  }
+}
+
+void TestIndexIntoFile3::testOverlappingLumisWithEndWithEmptyLumi() {
+  // from a failed job
+  edm::IndexIntoFile indexIntoFile;
+  indexIntoFile.addEntry(fakePHID1, 1, 1, 2, 0);    // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 1, 5, 1);    // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 2, 8, 2);    // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 2, 6, 3);    // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 1, 3, 4);    // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 2, 9, 5);    // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 1, 4, 6);    // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 1, 1, 7);    // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 2, 7, 8);    // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 1, 0, 0);    // Lumi
+  indexIntoFile.addEntry(fakePHID1, 1, 2, 10, 9);   // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 2, 0, 1);    // Lumi
+  indexIntoFile.addEntry(fakePHID1, 1, 3, 12, 10);  // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 3, 11, 11);  // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 3, 15, 12);  // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 3, 14, 13);  // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 4, 18, 14);  // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 4, 17, 15);  // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 4, 20, 16);  // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 3, 13, 17);  // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 3, 0, 2);    // Lumi
+  indexIntoFile.addEntry(fakePHID1, 1, 4, 19, 18);  // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 4, 16, 19);  // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 4, 0, 3);    // Lumi
+  indexIntoFile.addEntry(fakePHID1, 1, 0, 0, 0);    // Run
+  indexIntoFile.sortVector_Run_Or_Lumi_Entries();
+
+  std::vector<LuminosityBlockNumber_t> lumis;
+
+  {
+    edm::IndexIntoFile::IndexIntoFileItr iterFirst = indexIntoFile.begin(IndexIntoFile::firstAppearanceOrder);
+    edm::IndexIntoFile::IndexIntoFileItr iterFirstEnd = indexIntoFile.end(IndexIntoFile::firstAppearanceOrder);
+    int i = 0;
+    for (i = 0; iterFirst != iterFirstEnd; ++iterFirst, ++i) {
+      //std::cout << "out of order run:" << iterFirst.run() << " lumi:" << iterFirst.lumi()
+      //          << " firstEventEntryThisRun:" << iterFirst.firstEventEntryThisRun()
+      //          << " firstEventEntryThisLumi:" << iterFirst.firstEventEntryThisLumi() << std::endl;
+      switch (i) {
+        case 0: {
+          CPPUNIT_ASSERT(check(iterFirst, kRun, 0, 4, 1, 0, 2));  // run 1
+          CPPUNIT_ASSERT(iterFirst.indexIntoFile() == &indexIntoFile);
+          CPPUNIT_ASSERT(iterFirst.size() == 13);
+          iterFirst.getLumisInRun(lumis);
+          std::vector<LuminosityBlockNumber_t> expected{1, 2, 3, 4};
+          CPPUNIT_ASSERT(lumis == expected);
+          CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 0);
+          CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == 0);
+          break;
+        }
+          //values are 'IndexIntoFile::EntryType' 'indexToRun' 'indexToLumi' 'indexToEventRange' 'indexToEvent' 'nEvents'
+        case 1: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 4, 1, 0, 2));  // lumi 1/1
+          break;
+        }
+        case 2: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 4, 1, 0, 2));  // event 1/1/2
+          break;
+        }
+        case 3: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 4, 1, 1, 2));  // event 1/1/5
+          break;
+        }
+        case 4: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 4, 2, 0, 1));  // event 1/1/3
+          break;
+        }
+        case 5: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 4, 3, 0, 2));  // event 1/1/4
+          break;
+        }
+        case 6: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 4, 3, 1, 2));  // event 1/1/1
+          break;
+        }
+        case 7: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 8, 5, 0, 2));  // lumi 1/2
+          break;
+        }
+        case 8: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 8, 5, 0, 2));  // event 1/2/8
+          CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 0);
+          CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == 2);
+          break;
+        }
+        case 9: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 8, 5, 1, 2));  // event 1/2/6
+          break;
+        }
+        case 10: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 8, 6, 0, 1));  // event 1/2/9
+          break;
+        }
+        case 11: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 8, 7, 0, 1));  // event 1/2/7
+          break;
+        }
+        case 12: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 8, 8, 0, 1));  // event 1/2/10
+          break;
+        }
+        case 13: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 10, 9, 0, 4));  // lumi 1/3
+          break;
+        }
+        case 14: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 10, 9, 0, 4));  // event 1/3/12
+          break;
+        }
+        case 15: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 10, 9, 1, 4));  // event 1/3/11
+          break;
+        }
+        case 16: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 10, 9, 2, 4));  // event 1/3/15
+          break;
+        }
+        case 17: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 10, 9, 3, 4));  // event 1/3/14
+          break;
+        }
+        case 18: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 10, 10, 0, 1));  // event 1/3/13
+          break;
+        }
+        case 19: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 12, 11, 0, 3));  // lumi 1/4
+          break;
+        }
+        case 20: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 12, 11, 0, 3));  // event 1/4/18
+          break;
+        }
+        case 21: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 12, 11, 1, 3));  // event 1/4/17
+          break;
+        }
+        case 22: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 12, 11, 2, 3));  // event 1/4/20
+          break;
+        }
+        case 23: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 12, 12, 0, 2));  // event 1/4/19
+          break;
+        }
+        case 24: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 12, 12, 1, 2));  // event 1/4/16
+          break;
+        }
+        default: {
+          CPPUNIT_ASSERT(false);
+        }
+      }
+    }
+    CPPUNIT_ASSERT(i == 25);
+  }
+
+  {
+    edm::IndexIntoFile::IndexIntoFileItr iterFirst = indexIntoFile.begin(IndexIntoFile::entryOrder);
+    edm::IndexIntoFile::IndexIntoFileItr iterFirstEnd = indexIntoFile.end(IndexIntoFile::entryOrder);
+    int i = 0;
+    for (i = 0; iterFirst != iterFirstEnd; ++iterFirst, ++i) {
+      //std::cout << "out of order run:" << iterFirst.run() << " lumi:" << iterFirst.lumi()
+      //          << " firstEventEntryThisRun:" << iterFirst.firstEventEntryThisRun()
+      //          << " firstEventEntryThisLumi:" << iterFirst.firstEventEntryThisLumi() << std::endl;
+      switch (i) {
+        case 0: {
+          CPPUNIT_ASSERT(check(iterFirst, kRun, 0, 1, 1, 0, 2));  // run 1
+          CPPUNIT_ASSERT(iterFirst.run() == 1);
+          CPPUNIT_ASSERT(iterFirst.indexIntoFile() == &indexIntoFile);
+          CPPUNIT_ASSERT(iterFirst.size() == 13);
+
+          iterFirst.getLumisInRun(lumis);
+          std::vector<LuminosityBlockNumber_t> expected{1, 2, 3, 4};
+          //CPPUNIT_ASSERT(lumis == expected);
+          CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 0);
+          CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == 0);
+          break;
+        }
+        //values are 'IndexIntoFile::EntryType' 'indexToRun' 'indexToLumi' 'indexToEventRange' 'indexToEvent' 'nEvents'
+        case 1: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 1, 1, 0, 2));  // lumi 1/1
+          CPPUNIT_ASSERT(iterFirst.lumi() == 1);
+          CPPUNIT_ASSERT(iterFirst.entryContinues());
+          break;
+        }
+        case 2: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 1, 1, 0, 2));  // event 1/1/2
+          break;
+        }
+        case 3: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 1, 1, 1, 2));  // event 1/1/5
+          break;
+        }
+        case 4: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 2, 2, 0, 2));  // lumi 1/2
+          CPPUNIT_ASSERT(iterFirst.lumi() == 2);
+          CPPUNIT_ASSERT(iterFirst.entryContinues());
+          break;
+        }
+        case 5: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 2, 2, 0, 2));  // event 1/2/8
+          break;
+        }
+        case 6: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 2, 2, 1, 2));  // event 1/2/6
+          break;
+        }
+        case 7: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 3, 3, 0, 1));  // lumi 1/1
+          CPPUNIT_ASSERT(iterFirst.lumi() == 1);
+          CPPUNIT_ASSERT(iterFirst.entryContinues());
+          break;
+        }
+        case 8: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 3, 3, 0, 1));  // event 1/1/3
+          CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 0);
+          CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == 4);
+          break;
+        }
+        case 9: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 4, 4, 0, 1));  // lumi 1/2
+          CPPUNIT_ASSERT(iterFirst.lumi() == 2);
+          CPPUNIT_ASSERT(iterFirst.entryContinues());
+          break;
+        }
+        case 10: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 4, 4, 0, 1));  // event 1/2/9
+          break;
+        }
+        case 11: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 6, 5, 0, 2));  // lumi 1/1   5
+          CPPUNIT_ASSERT(iterFirst.lumi() == 1);
+          CPPUNIT_ASSERT(not iterFirst.entryContinues());
+          break;
+        }
+        case 12: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 6, 5, 0, 2));  // event 1/1/4
+          break;
+        }
+        case 13: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 6, 5, 1, 2));  // event 1/1/1
+          break;
+        }
+        case 14: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 8, 7, 0, 1));  // lumi 1/2
+          CPPUNIT_ASSERT(iterFirst.lumi() == 2);
+          CPPUNIT_ASSERT(not iterFirst.entryContinues());
+          break;
+        }
+        case 15: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 8, 7, 0, 1));  // event 1/2/7
+          break;
+        }
+        case 16: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 8, 8, 0, 1));  // event 1/2/10
+          CPPUNIT_ASSERT(iterFirst.lumi() == 2);
+          break;
+        }
+        case 17: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 9, 9, 0, 4));  // lumi 1/3
+          CPPUNIT_ASSERT(iterFirst.lumi() == 3);
+          CPPUNIT_ASSERT(iterFirst.entryContinues());
+          break;
+        }
+        case 18: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 9, 9, 0, 4));  // event 1/3/12
+          break;
+        }
+        case 19: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 9, 9, 1, 4));  // event 1/3/11
+          break;
+        }
+        case 20: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 9, 9, 2, 4));  // event 1/3/15
+          break;
+        }
+        case 21: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 9, 9, 3, 4));  // event 1/3/14
+          break;
+        }
+        case 22: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 10, 10, 0, 3));  // lumi 1/4
+          CPPUNIT_ASSERT(iterFirst.lumi() == 4);
+          CPPUNIT_ASSERT(iterFirst.entryContinues());
+          break;
+        }
+        case 23: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 10, 10, 0, 3));  // event 1/4/16
+          break;
+        }
+        case 24: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 10, 10, 1, 3));  // event 1/4/17
+          break;
+        }
+        case 25: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 10, 10, 2, 3));  // event 1/4/18
+          break;
+        }
+        case 26: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 11, 11, 0, 1));  // lumi 1/3
+          CPPUNIT_ASSERT(iterFirst.lumi() == 3);
+          CPPUNIT_ASSERT(not iterFirst.entryContinues());
+          break;
+        }
+        case 27: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 11, 11, 0, 1));  // event 1/3/13
+          break;
+        }
+        case 28: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 12, 12, 0, 2));  // lumi 1/4
+          CPPUNIT_ASSERT(iterFirst.lumi() == 4);
+          CPPUNIT_ASSERT(not iterFirst.entryContinues());
+          break;
+        }
+        case 29: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 12, 12, 0, 2));  // event 1/4/19
+          break;
+        }
+        case 30: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 12, 12, 1, 2));  // event 1/4/16
+          break;
+        }
+
+        default:
+          CPPUNIT_ASSERT(false);
+      }
+    }
+    CPPUNIT_ASSERT(i == 31);
+  }
+}
+
+void TestIndexIntoFile3::testOverlappingLumisWithLumiEndOrderChanged() {
+  // from a failed job
+  edm::IndexIntoFile indexIntoFile;
+  indexIntoFile.addEntry(fakePHID1, 1, 1, 2, 0);    // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 1, 5, 1);    // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 2, 8, 2);    // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 2, 6, 3);    // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 1, 3, 4);    // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 2, 9, 5);    // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 1, 4, 6);    // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 2, 7, 7);    // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 2, 10, 8);   // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 2, 0, 0);    // Lumi
+  indexIntoFile.addEntry(fakePHID1, 1, 1, 1, 9);    // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 1, 0, 1);    // Lumi
+  indexIntoFile.addEntry(fakePHID1, 1, 3, 12, 10);  // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 3, 11, 11);  // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 3, 15, 12);  // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 3, 14, 13);  // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 4, 18, 14);  // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 4, 17, 15);  // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 4, 20, 16);  // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 4, 19, 17);  // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 4, 16, 18);  // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 4, 0, 2);    // Lumi
+  indexIntoFile.addEntry(fakePHID1, 1, 3, 13, 19);  // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 3, 0, 3);    // Lumi
+  indexIntoFile.addEntry(fakePHID1, 1, 0, 0, 0);    // Run
+  indexIntoFile.sortVector_Run_Or_Lumi_Entries();
+
+  std::vector<LuminosityBlockNumber_t> lumis;
+
+  {
+    edm::IndexIntoFile::IndexIntoFileItr iterFirst = indexIntoFile.begin(IndexIntoFile::firstAppearanceOrder);
+    edm::IndexIntoFile::IndexIntoFileItr iterFirstEnd = indexIntoFile.end(IndexIntoFile::firstAppearanceOrder);
+    int i = 0;
+    for (i = 0; iterFirst != iterFirstEnd; ++iterFirst, ++i) {
+      //std::cout << "out of order run:" << iterFirst.run() << " lumi:" << iterFirst.lumi()
+      //          << " firstEventEntryThisRun:" << iterFirst.firstEventEntryThisRun()
+      //          << " firstEventEntryThisLumi:" << iterFirst.firstEventEntryThisLumi() << std::endl;
+      switch (i) {
+        case 0: {
+          CPPUNIT_ASSERT(check(iterFirst, kRun, 0, 4, 1, 0, 2));  // run 1
+          CPPUNIT_ASSERT(iterFirst.indexIntoFile() == &indexIntoFile);
+          CPPUNIT_ASSERT(iterFirst.size() == 11);
+          iterFirst.getLumisInRun(lumis);
+          std::vector<LuminosityBlockNumber_t> expected{1, 2, 3, 4};
+          CPPUNIT_ASSERT(lumis == expected);
+          CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 0);
+          CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == 0);
+          break;
+        }
+          //values are 'IndexIntoFile::EntryType' 'indexToRun' 'indexToLumi' 'indexToEventRange' 'indexToEvent' 'nEvents'
+        case 1: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 4, 1, 0, 2));  // lumi 1/1
+          break;
+        }
+        case 2: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 4, 1, 0, 2));  // event 1/1/2
+          break;
+        }
+        case 3: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 4, 1, 1, 2));  // event 1/1/5
+          break;
+        }
+        case 4: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 4, 2, 0, 1));  // event 1/1/3
+          break;
+        }
+        case 5: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 4, 3, 0, 1));  // event 1/1/4
+          break;
+        }
+        case 6: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 4, 4, 0, 1));  // event 1/1/1
+          break;
+        }
+        case 7: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 7, 5, 0, 2));  // lumi 1/2
+          break;
+        }
+        case 8: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 7, 5, 0, 2));  // event 1/2/8
+          CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 0);
+          CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == 2);
+          break;
+        }
+        case 9: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 7, 5, 1, 2));  // event 1/2/6
+          break;
+        }
+        case 10: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 7, 6, 0, 1));  // event 1/2/9
+          break;
+        }
+        case 11: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 7, 7, 0, 2));  // event 1/2/7
+          break;
+        }
+        case 12: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 7, 7, 1, 2));  // event 1/2/10
+          break;
+        }
+        case 13: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 9, 8, 0, 4));  // lumi 1/3
+          break;
+        }
+        case 14: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 9, 8, 0, 4));  // event 1/3/12
+          break;
+        }
+        case 15: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 9, 8, 1, 4));  // event 1/3/11
+          break;
+        }
+        case 16: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 9, 8, 2, 4));  // event 1/3/15
+          break;
+        }
+        case 17: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 9, 8, 3, 4));  // event 1/3/14
+          break;
+        }
+        case 18: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 9, 9, 0, 1));  // event 1/3/13
+          break;
+        }
+        case 19: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 10, 10, 0, 5));  // lumi 1/4
+          break;
+        }
+        case 20: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 10, 10, 0, 5));  // event 1/4/18
+          break;
+        }
+        case 21: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 10, 10, 1, 5));  // event 1/4/17
+          break;
+        }
+        case 22: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 10, 10, 2, 5));  // event 1/4/20
+          break;
+        }
+        case 23: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 10, 10, 3, 5));  // event 1/4/19
+          break;
+        }
+        case 24: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 10, 10, 4, 5));  // event 1/4/16
+          break;
+        }
+        default: {
+          CPPUNIT_ASSERT(false);
+        }
+      }
+    }
+    CPPUNIT_ASSERT(i == 25);
+  }
+
+  {
+    edm::IndexIntoFile::IndexIntoFileItr iterFirst = indexIntoFile.begin(IndexIntoFile::entryOrder);
+    edm::IndexIntoFile::IndexIntoFileItr iterFirstEnd = indexIntoFile.end(IndexIntoFile::entryOrder);
+    int i = 0;
+    for (i = 0; iterFirst != iterFirstEnd; ++iterFirst, ++i) {
+      //std::cout << "out of order run:" << iterFirst.run() << " lumi:" << iterFirst.lumi()
+      //          << " firstEventEntryThisRun:" << iterFirst.firstEventEntryThisRun()
+      //          << " firstEventEntryThisLumi:" << iterFirst.firstEventEntryThisLumi() << std::endl;
+      switch (i) {
+        case 0: {
+          CPPUNIT_ASSERT(check(iterFirst, kRun, 0, 1, 1, 0, 2));  // run 1
+          CPPUNIT_ASSERT(iterFirst.run() == 1);
+          CPPUNIT_ASSERT(iterFirst.indexIntoFile() == &indexIntoFile);
+          CPPUNIT_ASSERT(iterFirst.size() == 11);
+
+          iterFirst.getLumisInRun(lumis);
+          std::vector<LuminosityBlockNumber_t> expected{1, 2, 3, 4};
+          //CPPUNIT_ASSERT(lumis == expected);
+          CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 0);
+          CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == 0);
+          break;
+        }
+        //values are 'IndexIntoFile::EntryType' 'indexToRun' 'indexToLumi' 'indexToEventRange' 'indexToEvent' 'nEvents'
+        case 1: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 1, 1, 0, 2));  // lumi 1/1
+          CPPUNIT_ASSERT(iterFirst.lumi() == 1);
+          CPPUNIT_ASSERT(iterFirst.entryContinues());
+          break;
+        }
+        case 2: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 1, 1, 0, 2));  // event 1/1/2
+          break;
+        }
+        case 3: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 1, 1, 1, 2));  // event 1/1/5
+          break;
+        }
+        case 4: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 2, 2, 0, 2));  // lumi 1/2
+          CPPUNIT_ASSERT(iterFirst.lumi() == 2);
+          CPPUNIT_ASSERT(iterFirst.entryContinues());
+          break;
+        }
+        case 5: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 2, 2, 0, 2));  // event 1/2/8
+          break;
+        }
+        case 6: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 2, 2, 1, 2));  // event 1/2/6
+          break;
+        }
+        case 7: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 3, 3, 0, 1));  // lumi 1/1
+          CPPUNIT_ASSERT(iterFirst.lumi() == 1);
+          CPPUNIT_ASSERT(iterFirst.entryContinues());
+          break;
+        }
+        case 8: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 3, 3, 0, 1));  // event 1/1/3
+          CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 0);
+          CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == 4);
+          break;
+        }
+        case 9: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 4, 4, 0, 1));  // lumi 1/2
+          CPPUNIT_ASSERT(iterFirst.lumi() == 2);
+          CPPUNIT_ASSERT(iterFirst.entryContinues());
+          break;
+        }
+        case 10: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 4, 4, 0, 1));  // event 1/2/9
+          break;
+        }
+        case 11: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 5, 5, 0, 1));  // lumi 1/1   5
+          CPPUNIT_ASSERT(iterFirst.lumi() == 1);
+          CPPUNIT_ASSERT(iterFirst.entryContinues());
+          break;
+        }
+        case 12: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 5, 5, 0, 1));  // event 1/1/4
+          break;
+        }
+        case 13: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 6, 6, 0, 2));  // lumi 1/2
+          CPPUNIT_ASSERT(iterFirst.lumi() == 2);
+          CPPUNIT_ASSERT(not iterFirst.entryContinues());
+          break;
+        }
+        case 14: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 6, 6, 0, 2));  // event 1/2/7
+          break;
+        }
+        case 15: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 6, 6, 1, 2));  // event 1/2/10
+          CPPUNIT_ASSERT(iterFirst.lumi() == 2);
+          break;
+        }
+        case 16: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 7, 7, 0, 1));  // lumi 1/1
+          CPPUNIT_ASSERT(iterFirst.lumi() == 1);
+          CPPUNIT_ASSERT(not iterFirst.entryContinues());
+          break;
+        }
+        case 17: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 7, 7, 0, 1));  // event 1/1/1
+          break;
+        }
+        case 18: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 8, 8, 0, 4));  // lumi 1/3
+          CPPUNIT_ASSERT(iterFirst.lumi() == 3);
+          CPPUNIT_ASSERT(iterFirst.entryContinues());
+          break;
+        }
+        case 19: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 8, 8, 0, 4));  // event 1/3/12
+          break;
+        }
+        case 20: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 8, 8, 1, 4));  // event 1/3/11
+          break;
+        }
+        case 21: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 8, 8, 2, 4));  // event 1/3/15
+          break;
+        }
+        case 22: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 8, 8, 3, 4));  // event 1/3/14
+          break;
+        }
+        case 23: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 9, 9, 0, 5));  // lumi 1/4
+          CPPUNIT_ASSERT(iterFirst.lumi() == 4);
+          CPPUNIT_ASSERT(not iterFirst.entryContinues());
+          break;
+        }
+        case 24: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 9, 9, 0, 5));  // event 1/4/16
+          break;
+        }
+        case 25: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 9, 9, 1, 5));  // event 1/4/17
+          break;
+        }
+        case 26: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 9, 9, 2, 5));  // event 1/4/18
+          break;
+        }
+        case 27: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 9, 9, 3, 5));  // event 1/4/19
+          break;
+        }
+        case 28: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 9, 9, 4, 5));  // event 1/4/16
+          break;
+        }
+        case 29: {
+          CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 10, 10, 0, 1));  // lumi 1/3
+          CPPUNIT_ASSERT(iterFirst.lumi() == 3);
+          CPPUNIT_ASSERT(not iterFirst.entryContinues());
+          break;
+        }
+        case 30: {
+          CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 10, 10, 0, 1));  // event 1/3/13
+          break;
+        }
+
+        default:
+          CPPUNIT_ASSERT(false);
+      }
+    }
+    CPPUNIT_ASSERT(i == 31);
+  }
 }

--- a/DataFormats/Provenance/test/indexIntoFile_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile_t.cppunit.cc
@@ -176,6 +176,16 @@ void TestIndexIntoFile::testEmptyIndex() {
   CPPUNIT_ASSERT(iterFirstEnd.indexToEvent() == 0);
   CPPUNIT_ASSERT(iterFirstEnd.nEvents() == 0);
 
+  edm::IndexIntoFile::IndexIntoFileItr iterEntryEnd = indexIntoFile.end(IndexIntoFile::entryOrder);
+  CPPUNIT_ASSERT(iterEntryEnd.indexIntoFile() == &indexIntoFile);
+  CPPUNIT_ASSERT(iterEntryEnd.size() == 0);
+  CPPUNIT_ASSERT(iterEntryEnd.type() == kEnd);
+  CPPUNIT_ASSERT(iterEntryEnd.indexToRun() == IndexIntoFile::invalidIndex);
+  CPPUNIT_ASSERT(iterEntryEnd.indexToLumi() == IndexIntoFile::invalidIndex);
+  CPPUNIT_ASSERT(iterEntryEnd.indexToEventRange() == IndexIntoFile::invalidIndex);
+  CPPUNIT_ASSERT(iterEntryEnd.indexToEvent() == 0);
+  CPPUNIT_ASSERT(iterEntryEnd.nEvents() == 0);
+
   edm::IndexIntoFile::IndexIntoFileItr iterNum = indexIntoFile.begin(IndexIntoFile::numericalOrder);
   CPPUNIT_ASSERT(iterNum == iterNumEnd);
 
@@ -189,6 +199,15 @@ void TestIndexIntoFile::testEmptyIndex() {
   skipEventBackward(iterFirst);
   checkSkipped(-1, 0, 0, -1);
   check(iterFirst, kEnd, -1, -1, -1, 0, 0);
+
+  {
+    auto iterEntry = indexIntoFile.begin(IndexIntoFile::entryOrder);
+    CPPUNIT_ASSERT(iterEntry == iterEntryEnd);
+
+    skipEventBackward(iterEntry);
+    checkSkipped(-1, 0, 0, -1);
+    check(iterEntry, kEnd, -1, -1, -1, 0, 0);
+  }
 }
 
 void TestIndexIntoFile::testIterEndWithLumi() {
@@ -245,6 +264,29 @@ void TestIndexIntoFile::testIterEndWithLumi() {
   }
   CPPUNIT_ASSERT(i == 5);
 
+  // Now repeat the above tests for the entry iteration
+
+  edm::IndexIntoFile::IndexIntoFileItr iterEntry = indexIntoFile.begin(IndexIntoFile::entryOrder);
+  edm::IndexIntoFile::IndexIntoFileItr iterEntryEnd = indexIntoFile.end(IndexIntoFile::entryOrder);
+  for (i = 0; iterEntry != iterEntryEnd; ++iterEntry, ++i) {
+    if (i == 0)
+      check(iterEntry, kRun, 0, 1, -1, 0, 0);
+    else if (i == 1)
+      check(iterEntry, kLumi, 0, 1, -1, 0, 0);
+    else if (i == 2)
+      check(iterEntry, kRun, 2, 3, -1, 0, 0);
+    else if (i == 3)
+      check(iterEntry, kLumi, 2, 3, -1, 0, 0);
+    else if (i == 4)
+      check(iterEntry, kLumi, 2, 4, -1, 0, 0);
+    else
+      CPPUNIT_ASSERT(false);
+
+    CPPUNIT_ASSERT(iterEntry.firstEventEntryThisRun() == IndexIntoFile::invalidEntry);
+    CPPUNIT_ASSERT(iterEntry.firstEventEntryThisLumi() == IndexIntoFile::invalidEntry);
+  }
+  CPPUNIT_ASSERT(i == 5);
+
   iterFirst = indexIntoFile.begin(IndexIntoFile::firstAppearanceOrder);
 
   skipEventForward(iterFirst);
@@ -256,6 +298,12 @@ void TestIndexIntoFile::testIterEndWithLumi() {
   skipEventForward(iterNum);
   checkSkipped(-1, 0, 0, -1);
   check(iterNum, kEnd, -1, -1, -1, 0, 0);
+
+  iterEntry = indexIntoFile.begin(IndexIntoFile::entryOrder);
+
+  skipEventForward(iterEntry);
+  checkSkipped(-1, 0, 0, -1);
+  check(iterEntry, kEnd, -1, -1, -1, 0, 0);
 }
 
 void TestIndexIntoFile::testIterEndWithRun() {
@@ -308,6 +356,28 @@ void TestIndexIntoFile::testIterEndWithRun() {
   }
   CPPUNIT_ASSERT(i == 4);
 
+  // Now repeat the above tests for the entry iteration
+
+  edm::IndexIntoFile::IndexIntoFileItr iterEntry = indexIntoFile.begin(IndexIntoFile::entryOrder);
+  edm::IndexIntoFile::IndexIntoFileItr iterEntryEnd = indexIntoFile.end(IndexIntoFile::entryOrder);
+  i = 0;
+  for (; iterEntry != iterEntryEnd; ++iterEntry, ++i) {
+    if (i == 0)
+      check(iterEntry, kRun, 0, -1, -1, 0, 0);
+    else if (i == 1)
+      check(iterEntry, kRun, 1, -1, -1, 0, 0);
+    else if (i == 2)
+      check(iterEntry, kRun, 2, -1, -1, 0, 0);
+    else if (i == 3)
+      check(iterEntry, kRun, 3, -1, -1, 0, 0);
+    else
+      CPPUNIT_ASSERT(false);
+
+    CPPUNIT_ASSERT(iterEntry.firstEventEntryThisRun() == IndexIntoFile::invalidEntry);
+    CPPUNIT_ASSERT(iterEntry.firstEventEntryThisLumi() == IndexIntoFile::invalidEntry);
+  }
+  CPPUNIT_ASSERT(i == 4);
+
   iterFirst = indexIntoFile.begin(IndexIntoFile::firstAppearanceOrder);
 
   skipEventForward(iterFirst);
@@ -335,6 +405,20 @@ void TestIndexIntoFile::testIterEndWithRun() {
   check(iterNum, kRun, 3, -1, -1, 0, 0);
   iterNum.advanceToNextLumiOrRun();
   check(iterNum, kEnd, -1, -1, -1, 0, 0);
+
+  iterEntry = indexIntoFile.begin(IndexIntoFile::entryOrder);
+
+  skipEventForward(iterEntry);
+  checkSkipped(-1, 0, 0, -1);
+  check(iterEntry, kEnd, -1, -1, -1, 0, 0);
+
+  iterEntry = indexIntoFile.begin(IndexIntoFile::entryOrder);
+  iterEntry.advanceToNextLumiOrRun();
+  check(iterEntry, kRun, 2, -1, -1, 0, 0);
+  ++iterEntry;
+  check(iterEntry, kRun, 3, -1, -1, 0, 0);
+  iterEntry.advanceToNextLumiOrRun();
+  check(iterEntry, kEnd, -1, -1, -1, 0, 0);
 }
 
 void TestIndexIntoFile::testIterLastLumiRangeNoEvents() {
@@ -419,6 +503,37 @@ void TestIndexIntoFile::testIterLastLumiRangeNoEvents() {
       CPPUNIT_ASSERT(false);
   }
   CPPUNIT_ASSERT(i == 11);
+
+  edm::IndexIntoFile::IndexIntoFileItr iterEntry = indexIntoFile.begin(IndexIntoFile::entryOrder);
+  edm::IndexIntoFile::IndexIntoFileItr iterEntryEnd = indexIntoFile.end(IndexIntoFile::entryOrder);
+  i = 0;
+  for (; iterEntry != iterEntryEnd; ++iterEntry, ++i) {
+    if (i == 0)
+      check(iterEntry, kRun, 0, 1, 1, 0, 1);
+    else if (i == 1)
+      check(iterEntry, kLumi, 0, 1, 1, 0, 1);
+    else if (i == 2)
+      check(iterEntry, kLumi, 0, 2, 1, 0, 1);
+    else if (i == 3)
+      check(iterEntry, kEvent, 0, 2, 1, 0, 1);
+    else if (i == 4)
+      check(iterEntry, kLumi, 0, 3, 3, 0, 1);
+    else if (i == 5)
+      check(iterEntry, kLumi, 0, 4, 3, 0, 1);
+    else if (i == 6)
+      check(iterEntry, kEvent, 0, 4, 3, 0, 1);
+    else if (i == 7)
+      check(iterEntry, kRun, 5, 6, 6, 0, 1);
+    else if (i == 8)
+      check(iterEntry, kLumi, 5, 6, 6, 0, 1);
+    else if (i == 9)
+      check(iterEntry, kLumi, 5, 7, 6, 0, 1);
+    else if (i == 10)
+      check(iterEntry, kEvent, 5, 7, 6, 0, 1);
+    else
+      CPPUNIT_ASSERT(false);
+  }
+  CPPUNIT_ASSERT(i == 11);
 }
 
 void TestIndexIntoFile::testSkip() {
@@ -489,6 +604,35 @@ void TestIndexIntoFile::testSkip() {
   skipEventForward(iterNum);
   checkSkipped(-1, 0, 0, -1);
   check(iterNum, kEnd, -1, -1, -1, 0, 0);
+  {
+    edm::IndexIntoFile::IndexIntoFileItr iterEntry = indexIntoFile.begin(IndexIntoFile::entryOrder);
+
+    skipEventForward(iterEntry);
+    checkSkipped(0, 1, 101, 0);
+    check(iterEntry, kRun, 0, 3, -1, 0, 0);
+
+    skipEventForward(iterEntry);
+    checkSkipped(-1, 0, 0, -1);
+    check(iterEntry, kEnd, -1, -1, -1, 0, 0);
+
+    skipEventBackward(iterEntry);
+    checkSkipped(0, 1, 101, 0);
+    check(iterEntry, kRun, 0, 1, 1, 0, 1);
+
+    skipEventBackward(iterEntry);
+    checkSkipped(-1, 0, 0, -1);
+    check(iterEntry, kRun, 0, 1, 1, 0, 1);
+
+    iterEntry = indexIntoFile.begin(IndexIntoFile::entryOrder);
+    ++iterEntry;
+    skipEventForward(iterEntry);
+    checkSkipped(0, 1, 101, 0);
+    check(iterEntry, kLumi, 0, 3, -1, 0, 0);
+
+    skipEventForward(iterEntry);
+    checkSkipped(-1, 0, 0, -1);
+    check(iterEntry, kEnd, -1, -1, -1, 0, 0);
+  }
 }
 
 void TestIndexIntoFile::testSkip2() {
@@ -573,6 +717,40 @@ void TestIndexIntoFile::testSkip2() {
   skipEventForward(iterNum);
   checkSkipped(0, 2, 101, 1);
   check(iterNum, kRun, 4, 7, -1, 0, 0);
+
+  {
+    edm::IndexIntoFile::IndexIntoFileItr iterEntry = indexIntoFile.begin(IndexIntoFile::entryOrder);
+
+    skipEventForward(iterEntry);
+    checkSkipped(0, 1, 101, 0);
+    check(iterEntry, kRun, 0, 3, -1, 0, 0);
+
+    skipEventForward(iterEntry);
+    checkSkipped(0, 2, 101, 1);
+    check(iterEntry, kRun, 4, 7, -1, 0, 0);
+
+    skipEventForward(iterEntry);
+    checkSkipped(-1, 0, 0, -1);
+    check(iterEntry, kEnd, -1, -1, -1, 0, 0);
+
+    skipEventBackward(iterEntry);
+    checkSkipped(0, 2, 101, 1);
+    check(iterEntry, kRun, 4, 5, 5, 0, 1);
+
+    skipEventBackward(iterEntry);
+    checkSkipped(0, 1, 101, 0);
+    check(iterEntry, kRun, 0, 1, 1, 0, 1);
+
+    iterEntry = indexIntoFile.begin(IndexIntoFile::entryOrder);
+    ++iterEntry;
+    skipEventForward(iterEntry);
+    checkSkipped(0, 1, 101, 0);
+    check(iterEntry, kLumi, 0, 3, -1, 0, 0);
+
+    skipEventForward(iterEntry);
+    checkSkipped(0, 2, 101, 1);
+    check(iterEntry, kRun, 4, 7, -1, 0, 0);
+  }
 }
 
 void TestIndexIntoFile::testSkip3() {
@@ -602,6 +780,14 @@ void TestIndexIntoFile::testSkip3() {
   skipEventForward(iterNum);
   checkSkipped(0, 2, 102, 0);
   check(iterNum, kRun, 2, 6, -1, 0, 0);
+
+  {
+    edm::IndexIntoFile::IndexIntoFileItr iterEntry = indexIntoFile.begin(IndexIntoFile::entryOrder);
+
+    skipEventForward(iterEntry);
+    checkSkipped(0, 2, 102, 0);
+    check(iterEntry, kRun, 2, 6, -1, 0, 0);
+  }
 }
 
 void TestIndexIntoFile::testReduce() {

--- a/FWCore/Framework/interface/LuminosityBlockPrincipal.h
+++ b/FWCore/Framework/interface/LuminosityBlockPrincipal.h
@@ -48,6 +48,8 @@ namespace edm {
 
     void setRunPrincipal(std::shared_ptr<RunPrincipal> rp) { runPrincipal_ = rp; }
 
+    void setWillBeContinued(bool iContinued) { willBeContinued_ = iContinued; }
+
     LuminosityBlockIndex index() const { return index_; }
 
     LuminosityBlockID id() const { return aux().id(); }
@@ -71,6 +73,9 @@ namespace edm {
 
     void put(ProductResolverIndex index, std::unique_ptr<WrapperBase> edp) const;
 
+    ///The source is replaying overlapping LuminosityBlocks and this is not the last part for this LumiosityBlock
+    bool willBeContinued() const { return willBeContinued_; }
+
   private:
     unsigned int transitionIndex_() const override;
 
@@ -79,6 +84,8 @@ namespace edm {
     LuminosityBlockAuxiliary aux_;
 
     LuminosityBlockIndex index_;
+
+    bool willBeContinued_ = false;
   };
 }  // namespace edm
 #endif

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -1758,17 +1758,19 @@ namespace edm {
 
   void EventProcessor::writeLumiAsync(WaitingTaskHolder task, LuminosityBlockPrincipal& lumiPrincipal) {
     using namespace edm::waiting_task;
-    chain::first([&](auto nextTask) {
-      ServiceRegistry::Operate op(serviceToken_);
+    if (not lumiPrincipal.willBeContinued()) {
+      chain::first([&](auto nextTask) {
+        ServiceRegistry::Operate op(serviceToken_);
 
-      lumiPrincipal.runPrincipal().mergeableRunProductMetadata()->writeLumi(lumiPrincipal.luminosityBlock());
-      schedule_->writeLumiAsync(nextTask, lumiPrincipal, &processContext_, actReg_.get());
-    }) | chain::ifThen(not subProcesses_.empty(), [this, &lumiPrincipal](auto nextTask) {
-      ServiceRegistry::Operate op(serviceToken_);
-      for (auto& s : subProcesses_) {
-        s.writeLumiAsync(nextTask, lumiPrincipal);
-      }
-    }) | chain::lastTask(std::move(task));
+        lumiPrincipal.runPrincipal().mergeableRunProductMetadata()->writeLumi(lumiPrincipal.luminosityBlock());
+        schedule_->writeLumiAsync(nextTask, lumiPrincipal, &processContext_, actReg_.get());
+      }) | chain::ifThen(not subProcesses_.empty(), [this, &lumiPrincipal](auto nextTask) {
+        ServiceRegistry::Operate op(serviceToken_);
+        for (auto& s : subProcesses_) {
+          s.writeLumiAsync(nextTask, lumiPrincipal);
+        }
+      }) | chain::lastTask(std::move(task));
+    }
   }
 
   void EventProcessor::deleteLumiFromCache(LuminosityBlockProcessingStatus& iStatus) {

--- a/FWCore/Framework/src/LuminosityBlockPrincipal.cc
+++ b/FWCore/Framework/src/LuminosityBlockPrincipal.cc
@@ -16,6 +16,7 @@ namespace edm {
   void LuminosityBlockPrincipal::fillLuminosityBlockPrincipal(ProcessHistory const* processHistory,
                                                               DelayedReader* reader) {
     fillPrincipal(aux_.processHistoryID(), processHistory, reader);
+    willBeContinued_ = false;
   }
 
   void LuminosityBlockPrincipal::put(BranchDescription const& bd, std::unique_ptr<WrapperBase> edp) const {

--- a/IOPool/Common/test/BuildFile.xml
+++ b/IOPool/Common/test/BuildFile.xml
@@ -9,4 +9,6 @@
     <use name="FWCore/Utilities"/>
   </bin>
 
+  <test name="testIOPoolCommonLumiOverlap" command="test_overlap_lumi_fast_copy.sh"/>
+
 </environment>

--- a/IOPool/Common/test/copy_overlap_lumi_cfg.py
+++ b/IOPool/Common/test/copy_overlap_lumi_cfg.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("READ")
+
+process.source = cms.Source("PoolSource",
+                            fileNames = cms.untracked.vstring("file:test_overlap_lumi.root"),
+                            noRunLumiSort = cms.untracked.bool(True) )
+
+process.out = cms.OutputModule("PoolOutputModule", fileName = cms.untracked.string("copy_test_overlap_lumi.root"))
+
+process.o = cms.EndPath(process.out)

--- a/IOPool/Common/test/make_overlap_lumi_cfg.py
+++ b/IOPool/Common/test/make_overlap_lumi_cfg.py
@@ -11,7 +11,7 @@ process.thing = cms.EDProducer("ThingProducer", offsetDelta = cms.int32(1))
 process.sleep = cms.EDProducer("timestudy::SleepingProducer",
     ivalue = cms.int32(1),
     consumes = cms.VInputTag(),
-                               eventTimes = cms.vdouble(1.0, 0.001, 0.001))
+    eventTimes = cms.vdouble(1.0, 0.001, 0.001))
 
 process.o = cms.OutputModule("PoolOutputModule", fileName = cms.untracked.string("test_overlap_lumi.root"))
 

--- a/IOPool/Common/test/make_overlap_lumi_cfg.py
+++ b/IOPool/Common/test/make_overlap_lumi_cfg.py
@@ -1,0 +1,24 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("EmptySource",
+                            numberEventsInLuminosityBlock = cms.untracked.uint32(5))
+
+process.thing = cms.EDProducer("ThingProducer", offsetDelta = cms.int32(1))
+
+
+process.sleep = cms.EDProducer("timestudy::SleepingProducer",
+    ivalue = cms.int32(1),
+    consumes = cms.VInputTag(),
+                               eventTimes = cms.vdouble(1.0, 0.001, 0.001))
+
+process.o = cms.OutputModule("PoolOutputModule", fileName = cms.untracked.string("test_overlap_lumi.root"))
+
+process.p = cms.Path( process.sleep )
+
+process.maxEvents.input = 20
+
+process.options.numberOfThreads = 8
+
+process.e = cms.EndPath(process.o, cms.Task(process.thing))

--- a/IOPool/Common/test/test_overlap_lumi_fast_copy.sh
+++ b/IOPool/Common/test/test_overlap_lumi_fast_copy.sh
@@ -2,8 +2,6 @@
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
 
-printenv
-
 LOCAL_TEST_DIR=src/IOPool/Common/test
 
 cmsRun ${LOCAL_TEST_DIR}/make_overlap_lumi_cfg.py || die "cmsRun make_overlap_lumi_cfg.py failed" $?

--- a/IOPool/Common/test/test_overlap_lumi_fast_copy.sh
+++ b/IOPool/Common/test/test_overlap_lumi_fast_copy.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Pass in name and status
+function die { echo $1: status $2 ;  exit $2; }
+
+printenv
+
+LOCAL_TEST_DIR=src/IOPool/Common/test
+
+cmsRun ${LOCAL_TEST_DIR}/make_overlap_lumi_cfg.py || die "cmsRun make_overlap_lumi_cfg.py failed" $?
+
+cmsRun -e -j overlap_lumi_FrameworkJobReport.xml ${LOCAL_TEST_DIR}/copy_overlap_lumi_cfg.py || die "cmsRun copy_overlap_lumi_cfg.py failed" $?
+
+grep '<FastCopying>1</FastCopying>' overlap_lumi_FrameworkJobReport.xml || die "fast copying did not occur" 1

--- a/IOPool/Input/src/RepeatingCachedRootSource.cc
+++ b/IOPool/Input/src/RepeatingCachedRootSource.cc
@@ -267,7 +267,8 @@ std::unique_ptr<RootFile> RepeatingCachedRootSource::makeRootFile(
                                     -1,                          //treeMaxVirtualSize(),
                                     processingMode(),
                                     runHelper_,
-                                    true,  //noEventSort_,
+                                    false,  //noRunLumiSort_
+                                    true,   //noEventSort_,
                                     selectorRules_,
                                     InputType::Primary,
                                     branchIDListHelper(),

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -1800,6 +1800,7 @@ namespace edm {
     } else {
       auto history = processHistoryRegistry_->getMapped(lumiPrincipal.aux().processHistoryID());
       lumiPrincipal.fillLuminosityBlockPrincipal(history, nullptr);
+      lumiPrincipal.setWillBeContinued(true);
     }
     ++indexIntoFileIter_;
   }

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -155,6 +155,7 @@ namespace edm {
                      int treeMaxVirtualSize,
                      InputSource::ProcessingMode processingMode,
                      RunHelperBase* runHelper,
+                     bool noRunLumiSort,
                      bool noEventSort,
                      ProductSelectorRules const& productSelectorRules,
                      InputType inputType,
@@ -184,8 +185,9 @@ namespace edm {
         indexIntoFileSharedPtr_(new IndexIntoFile),
         indexIntoFile_(*indexIntoFileSharedPtr_),
         orderedProcessHistoryIDs_(orderedProcessHistoryIDs),
-        indexIntoFileBegin_(
-            indexIntoFile_.begin(noEventSort ? IndexIntoFile::firstAppearanceOrder : IndexIntoFile::numericalOrder)),
+        indexIntoFileBegin_(indexIntoFile_.begin(
+            noRunLumiSort ? IndexIntoFile::entryOrder
+                          : (noEventSort ? IndexIntoFile::firstAppearanceOrder : IndexIntoFile::numericalOrder))),
         indexIntoFileEnd_(indexIntoFileBegin_),
         indexIntoFileIter_(indexIntoFileBegin_),
         storedMergeableRunProductMetadata_((inputType == InputType::Primary) ? new StoredMergeableRunProductMetadata
@@ -194,6 +196,7 @@ namespace edm {
         eventProcessHistoryIter_(eventProcessHistoryIDs_.begin()),
         savedRunAuxiliary_(),
         skipAnyEvents_(skipAnyEvents),
+        noRunLumiSort_(noRunLumiSort),
         noEventSort_(noEventSort),
         enforceGUIDInFileName_(enforceGUIDInFileName),
         whyNotFastClonable_(0),
@@ -509,10 +512,12 @@ namespace edm {
     }
 
     initializeDuplicateChecker(indexesIntoFiles, currentIndexIntoFile);
-    indexIntoFileIter_ = indexIntoFileBegin_ =
-        indexIntoFile_.begin(noEventSort ? IndexIntoFile::firstAppearanceOrder : IndexIntoFile::numericalOrder);
-    indexIntoFileEnd_ =
-        indexIntoFile_.end(noEventSort ? IndexIntoFile::firstAppearanceOrder : IndexIntoFile::numericalOrder);
+    indexIntoFileIter_ = indexIntoFileBegin_ = indexIntoFile_.begin(
+        noRunLumiSort ? IndexIntoFile::entryOrder
+                      : (noEventSort ? IndexIntoFile::firstAppearanceOrder : IndexIntoFile::numericalOrder));
+    indexIntoFileEnd_ = indexIntoFile_.end(
+        noRunLumiSort ? IndexIntoFile::entryOrder
+                      : (noEventSort ? IndexIntoFile::firstAppearanceOrder : IndexIntoFile::numericalOrder));
     runHelper_->setForcedRunOffset(indexIntoFileBegin_ == indexIntoFileEnd_ ? 1 : indexIntoFileBegin_.run());
     eventProcessHistoryIter_ = eventProcessHistoryIDs_.begin();
 
@@ -738,7 +743,8 @@ namespace edm {
 
     // From here on, record all reasons we can't fast clone.
     IndexIntoFile::SortOrder sortOrder =
-        (noEventSort_ ? IndexIntoFile::firstAppearanceOrder : IndexIntoFile::numericalOrder);
+        (noRunLumiSort_ ? IndexIntoFile::entryOrder
+                        : (noEventSort_ ? IndexIntoFile::firstAppearanceOrder : IndexIntoFile::numericalOrder));
     if (!indexIntoFile_.iterationWillBeInEntryOrder(sortOrder)) {
       whyNotFastClonable_ += (noEventSort_ ? FileBlock::RunOrLumiNotContiguous : FileBlock::EventsToBeSorted);
     }
@@ -1496,6 +1502,9 @@ namespace edm {
     IndexIntoFile::SortOrder sortOrder = IndexIntoFile::numericalOrder;
     if (noEventSort_)
       sortOrder = IndexIntoFile::firstAppearanceOrder;
+    if (noRunLumiSort_) {
+      sortOrder = IndexIntoFile::entryOrder;
+    }
 
     IndexIntoFile::IndexIntoFileItr iter =
         indexIntoFile_.findPosition(sortOrder, eventID.run(), eventID.luminosityBlock(), eventID.event());
@@ -1780,13 +1789,18 @@ namespace edm {
       return;
     }
     // End code for backward compatibility before the existence of lumi trees.
-    lumiTree_.setEntryNumber(indexIntoFileIter_.entry());
-    // NOTE: we use 0 for the index since do not do delayed reads for LuminosityBlockPrincipals
-    lumiTree_.insertEntryForIndex(0);
-    auto history = processHistoryRegistry_->getMapped(lumiPrincipal.aux().processHistoryID());
-    lumiPrincipal.fillLuminosityBlockPrincipal(history, lumiTree_.resetAndGetRootDelayedReader());
-    // Read in all the products now.
-    lumiPrincipal.readAllFromSourceAndMergeImmediately();
+    if (not indexIntoFileIter_.entryContinues()) {
+      lumiTree_.setEntryNumber(indexIntoFileIter_.entry());
+      // NOTE: we use 0 for the index since do not do delayed reads for LuminosityBlockPrincipals
+      lumiTree_.insertEntryForIndex(0);
+      auto history = processHistoryRegistry_->getMapped(lumiPrincipal.aux().processHistoryID());
+      lumiPrincipal.fillLuminosityBlockPrincipal(history, lumiTree_.resetAndGetRootDelayedReader());
+      // Read in all the products now.
+      lumiPrincipal.readAllFromSourceAndMergeImmediately();
+    } else {
+      auto history = processHistoryRegistry_->getMapped(lumiPrincipal.aux().processHistoryID());
+      lumiPrincipal.fillLuminosityBlockPrincipal(history, nullptr);
+    }
     ++indexIntoFileIter_;
   }
 

--- a/IOPool/Input/src/RootFile.h
+++ b/IOPool/Input/src/RootFile.h
@@ -84,6 +84,7 @@ namespace edm {
              int treeMaxVirtualSize,
              InputSource::ProcessingMode processingMode,
              RunHelperBase* runHelper,
+             bool noRunLumiSort,
              bool noEventSort,
              ProductSelectorRules const& productSelectorRules,
              InputType inputType,
@@ -140,6 +141,7 @@ namespace edm {
                    processingMode,
                    runHelper,
                    false,
+                   false,
                    productSelectorRules,
                    inputType,
                    branchIDListHelper,
@@ -189,6 +191,7 @@ namespace edm {
                    treeMaxVirtualSize,
                    InputSource::RunsLumisAndEvents,
                    runHelper,
+                   false,
                    false,
                    productSelectorRules,
                    inputType,
@@ -371,6 +374,7 @@ namespace edm {
     std::vector<EventProcessHistoryID>::const_iterator eventProcessHistoryIter_;  // backward compatibility
     edm::propagate_const<std::shared_ptr<RunAuxiliary>> savedRunAuxiliary_;
     bool skipAnyEvents_;
+    bool noRunLumiSort_;
     bool noEventSort_;
     bool enforceGUIDInFileName_;
     int whyNotFastClonable_;

--- a/IOPool/Input/src/RootPrimaryFileSequence.cc
+++ b/IOPool/Input/src/RootPrimaryFileSequence.cc
@@ -29,7 +29,8 @@ namespace edm {
         orderedProcessHistoryIDs_(),
         eventSkipperByID_(EventSkipperByID::create(pset).release()),
         initialNumberOfEventsToSkip_(pset.getUntrackedParameter<unsigned int>("skipEvents")),
-        noEventSort_(pset.getUntrackedParameter<bool>("noEventSort")),
+        noRunLumiSort_(pset.getUntrackedParameter<bool>("noRunLumiSort")),
+        noEventSort_(noRunLumiSort_ ? true : pset.getUntrackedParameter<bool>("noEventSort")),
         treeCacheSize_(noEventSort_ ? pset.getUntrackedParameter<unsigned int>("cacheSize") : 0U),
         duplicateChecker_(new DuplicateChecker(pset)),
         usingGoToEvent_(false),
@@ -149,6 +150,7 @@ namespace edm {
                                       input_.treeMaxVirtualSize(),
                                       input_.processingMode(),
                                       input_.runHelper(),
+                                      noRunLumiSort_,
                                       noEventSort_,
                                       input_.productSelectorRules(),
                                       InputType::Primary,
@@ -411,6 +413,10 @@ namespace edm {
             "Note 1: Events within the same lumi will always be processed contiguously.\n"
             "Note 2: Lumis within the same run will always be processed contiguously.\n"
             "Note 3: Any sorting occurs independently in each input file (no sorting across input files).");
+    desc.addUntracked<bool>("noRunLumiSort", false)
+        ->setComment(
+            "True:  Process runs, lumis and events in the order they appear in the file.\n"
+            "False: Follow settings based on 'noEventSort' setting.");
     desc.addUntracked<unsigned int>("cacheSize", roottree::defaultCacheSize)
         ->setComment("Size of ROOT TTree prefetch cache.  Affects performance.");
     std::string defaultString("permissive");

--- a/IOPool/Input/src/RootPrimaryFileSequence.h
+++ b/IOPool/Input/src/RootPrimaryFileSequence.h
@@ -74,6 +74,7 @@ namespace edm {
     edm::propagate_const<std::shared_ptr<FileBlock>> fb_;
     edm::propagate_const<std::shared_ptr<EventSkipperByID>> eventSkipperByID_;
     int initialNumberOfEventsToSkip_;
+    bool noRunLumiSort_;
     bool noEventSort_;
     unsigned int treeCacheSize_;
     edm::propagate_const<std::shared_ptr<DuplicateChecker>> duplicateChecker_;


### PR DESCRIPTION
#### PR description:

- add a new option to PoolSource to replay events in exact TTree entry order
- added `LuminosityBlockPrincipal::willBeContinued` to denote when the Source wants to generate additional event groupings for a given LuminosityBlock
- The framework will only tell OutputModules to write a LuminosityBlock when `willBeContinued` is false.

NOTE: this new playback mode is not suited to be used with any module's in the job that require one and only one begin/end LuminosityBlock transitions to fire for a given LuminosityBlock or which read data from the LuminosityBlock.

#### PR validation:

Code compiles. The new unit tests and all existing framework unit tests pass.