### PR TITLE
Change to new method in PoolDBOutputService for SiPixel CPE

### DIFF
--- a/CondTools/SiPixel/plugins/SiPixel2DTemplateDBObjectUploader.cc
+++ b/CondTools/SiPixel/plugins/SiPixel2DTemplateDBObjectUploader.cc
@@ -76,19 +76,19 @@ void SiPixel2DTemplateDBObjectUploader::beginJob() {}
 
 void SiPixel2DTemplateDBObjectUploader::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   //--- Make the POOL-ORA object to store the database object
-  SiPixel2DTemplateDBObject* obj = new SiPixel2DTemplateDBObject;
+  SiPixel2DTemplateDBObject obj;
 
   // Local variables
   const char* tempfile;
   int m;
 
   // Set the number of templates to be passed to the dbobject
-  obj->setNumOfTempl(theTemplateCalibrations.size());
+  obj.setNumOfTempl(theTemplateCalibrations.size());
   // Set the version of the template dbobject - this is an external parameter
-  obj->setVersion(theVersion);
+  obj.setVersion(theVersion);
 
   // Open the template file(s)
-  for (m = 0; m < obj->numOfTempl(); ++m) {
+  for (m = 0; m < obj.numOfTempl(); ++m) {
     edm::FileInPath file(theTemplateCalibrations[m].c_str());
     tempfile = (file.fullPath()).c_str();
     std::ifstream in_file(tempfile, std::ios::in);
@@ -116,15 +116,15 @@ void SiPixel2DTemplateDBObjectUploader::analyze(const edm::Event& iEvent, const 
         temp.c[1] = title_char[j + 1];
         temp.c[2] = title_char[j + 2];
         temp.c[3] = title_char[j + 3];
-        obj->push_back(temp.f);
-        obj->setMaxIndex(obj->maxIndex() + 1);
+        obj.push_back(temp.f);
+        obj.setMaxIndex(obj.maxIndex() + 1);
       }
 
       // Fill the dbobject
       in_file >> tempstore;
       while (!in_file.eof()) {
-        obj->setMaxIndex(obj->maxIndex() + 1);
-        obj->push_back(tempstore);
+        obj.setMaxIndex(obj.maxIndex() + 1);
+        obj.push_back(tempstore);
         in_file >> tempstore;
       }
 
@@ -195,7 +195,7 @@ void SiPixel2DTemplateDBObjectUploader::analyze(const edm::Event& iEvent, const 
             thisID = (short)theBarrelTemplateIds[iter];
         }
 
-        if (thisID == 10000 || (!(*obj).putTemplateID(detid.rawId(), thisID)))
+        if (thisID == 10000 || (!obj.putTemplateID(detid.rawId(), thisID)))
           edm::LogPrint("SiPixel2DTemplateDBObjectUploader")
               << " Could not fill barrel layer " << layer << ", module " << module << "\n";
         edm::LogPrint("SiPixel2DTemplateDBObjectUploader")
@@ -240,7 +240,7 @@ void SiPixel2DTemplateDBObjectUploader::analyze(const edm::Event& iEvent, const 
             thisID = (short)theEndcapTemplateIds[iter];
         }
 
-        if (thisID == 10000 || (!(*obj).putTemplateID(detid.rawId(), thisID)))
+        if (thisID == 10000 || (!obj.putTemplateID(detid.rawId(), thisID)))
           edm::LogPrint("SiPixel2DTemplateDBObjectUploader")
               << " Could not fill endcap det unit" << side << ", disk " << disk << ", blade " << blade << ", and panel "
               << panel << ".\n";
@@ -253,7 +253,7 @@ void SiPixel2DTemplateDBObjectUploader::analyze(const edm::Event& iEvent, const 
 
       //Print out the assignment of this detID
       short mapnum;
-      mapnum = (*obj).getTemplateID(detid.rawId());
+      mapnum = obj.getTemplateID(detid.rawId());
       edm::LogPrint("SiPixel2DTemplateDBObjectUploader")
           << "The DetID: " << detid.rawId() << " is mapped to the template: " << mapnum << "\n";
     }
@@ -264,9 +264,9 @@ void SiPixel2DTemplateDBObjectUploader::analyze(const edm::Event& iEvent, const 
   if (!poolDbService.isAvailable())  // Die if not available
     throw cms::Exception("NotAvailable") << "PoolDBOutputService not available";
   if (poolDbService->isNewTagRequest("SiPixel2DTemplateDBObjectRcd"))
-    poolDbService->writeOne(obj, poolDbService->beginOfTime(), "SiPixel2DTemplateDBObjectRcd");
+    poolDbService->writeOneIOV(obj, poolDbService->beginOfTime(), "SiPixel2DTemplateDBObjectRcd");
   else
-    poolDbService->writeOne(obj, poolDbService->currentTime(), "SiPixel2DTemplateDBObjectRcd");
+    poolDbService->writeOneIOV(obj, poolDbService->currentTime(), "SiPixel2DTemplateDBObjectRcd");
 }
 
 void SiPixel2DTemplateDBObjectUploader::endJob() {}

--- a/CondTools/SiPixel/plugins/SiPixelGenErrorDBObjectUploader.cc
+++ b/CondTools/SiPixel/plugins/SiPixelGenErrorDBObjectUploader.cc
@@ -75,20 +75,20 @@ void SiPixelGenErrorDBObjectUploader::beginJob() {}
 
 void SiPixelGenErrorDBObjectUploader::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   //--- Make the POOL-ORA object to store the database object
-  SiPixelGenErrorDBObject* obj = new SiPixelGenErrorDBObject;
+  SiPixelGenErrorDBObject obj;
 
   // Local variables
   const char* tempfile;
   int m;
 
   // Set the number of GenErrors to be passed to the dbobject
-  obj->setNumOfTempl(theGenErrorCalibrations.size());
+  obj.setNumOfTempl(theGenErrorCalibrations.size());
 
   // Set the version of the GenError dbobject - this is an external parameter
-  obj->setVersion(theVersion);
+  obj.setVersion(theVersion);
 
   // Open the GenError file(s)
-  for (m = 0; m < obj->numOfTempl(); ++m) {
+  for (m = 0; m < obj.numOfTempl(); ++m) {
     edm::FileInPath file(theGenErrorCalibrations[m].c_str());
     tempfile = (file.fullPath()).c_str();
     std::ifstream in_file(tempfile, std::ios::in);
@@ -117,8 +117,8 @@ void SiPixelGenErrorDBObjectUploader::analyze(const edm::Event& iEvent, const ed
         temp.c[1] = title_char[j + 1];
         temp.c[2] = title_char[j + 2];
         temp.c[3] = title_char[j + 3];
-        obj->push_back(temp.f);
-        obj->setMaxIndex(obj->maxIndex() + 1);
+        obj.push_back(temp.f);
+        obj.setMaxIndex(obj.maxIndex() + 1);
       }
 
       // Check if the magnetic field is the same as in the header of the input files
@@ -137,8 +137,8 @@ void SiPixelGenErrorDBObjectUploader::analyze(const edm::Event& iEvent, const ed
       // Fill the dbobject
       in_file >> tempstore;
       while (!in_file.eof()) {
-        obj->setMaxIndex(obj->maxIndex() + 1);
-        obj->push_back(tempstore);
+        obj.setMaxIndex(obj.maxIndex() + 1);
+        obj.push_back(tempstore);
         in_file >> tempstore;
       }
 
@@ -210,7 +210,7 @@ void SiPixelGenErrorDBObjectUploader::analyze(const edm::Event& iEvent, const ed
             thisID = (short)theBarrelGenErrIds[iter];
         }
 
-        if (thisID == 10000 || (!(*obj).putGenErrorID(detid.rawId(), thisID)))
+        if (thisID == 10000 || (!obj.putGenErrorID(detid.rawId(), thisID)))
           edm::LogPrint("SiPixelGenErrorDBObjectUploader")
               << " Could not fill barrel layer " << layer << ", module " << module << "\n";
         edm::LogPrint("SiPixelGenErrorDBObjectUploader")
@@ -254,7 +254,7 @@ void SiPixelGenErrorDBObjectUploader::analyze(const edm::Event& iEvent, const ed
             thisID = (short)theEndcapGenErrIds[iter];
         }
 
-        if (thisID == 10000 || (!(*obj).putGenErrorID(detid.rawId(), thisID)))
+        if (thisID == 10000 || (!obj.putGenErrorID(detid.rawId(), thisID)))
           edm::LogPrint("SiPixelGenErrorDBObjectUploader")
               << " Could not fill endcap det unit" << side << ", disk " << disk << ", blade " << blade << ", panel "
               << panel << ".\n";
@@ -266,7 +266,7 @@ void SiPixelGenErrorDBObjectUploader::analyze(const edm::Event& iEvent, const ed
 
       //Print out the assignment of this DetID
       short mapnum;
-      mapnum = (*obj).getGenErrorID(detid.rawId());
+      mapnum = obj.getGenErrorID(detid.rawId());
       edm::LogPrint("SiPixelGenErrorDBObjectUploader")
           << "The DetID: " << detid.rawId() << " is mapped to the template: " << mapnum << "\n";
     }
@@ -277,9 +277,9 @@ void SiPixelGenErrorDBObjectUploader::analyze(const edm::Event& iEvent, const ed
   if (!poolDbService.isAvailable())  // Die if not available
     throw cms::Exception("NotAvailable") << "PoolDBOutputService not available";
   if (poolDbService->isNewTagRequest("SiPixelGenErrorDBObjectRcd"))
-    poolDbService->writeOne(obj, poolDbService->beginOfTime(), "SiPixelGenErrorDBObjectRcd");
+    poolDbService->writeOneIOV(obj, poolDbService->beginOfTime(), "SiPixelGenErrorDBObjectRcd");
   else
-    poolDbService->writeOne(obj, poolDbService->currentTime(), "SiPixelGenErrorDBObjectRcd");
+    poolDbService->writeOneIOV(obj, poolDbService->currentTime(), "SiPixelGenErrorDBObjectRcd");
 }
 
 void SiPixelGenErrorDBObjectUploader::endJob() {}

--- a/CondTools/SiPixel/test/createTestDBObjects.sh
+++ b/CondTools/SiPixel/test/createTestDBObjects.sh
@@ -2,56 +2,56 @@
 
 function die { echo $1: status $2 ; exit $2; }
 
-echo "TESTING Pixel CPE DB codes ..."
+echo -e "TESTING Pixel CPE DB codes ..."
 
-echo "TESTING Pixel 1D Template DB code ..."
+echo -e "TESTING Pixel 1D Template DB code ..."
 cmsRun ${LOCAL_TEST_DIR}/SiPixelTemplateDBObjectUploader_cfg.py MagField=0.0 Fullname=SiPixelTemplateDBObject_phase1_0T_mc_BoR3_v1_bugfix Map=${LOCAL_TEST_DIR}/../data/phaseI_mapping.csv TemplateFilePath=CalibTracker/SiPixelESProducers/data/SiPixelTemplateDBObject_0T_phase1_BoR3_v1 || die "Failure running SiPixelTemplateDBObjectUploader_cfg.py" $? 
 
-echo "TESTING Pixel 1D GenErr DB code ..."
+echo -e "TESTING Pixel 1D GenErr DB code ..."
 cmsRun ${LOCAL_TEST_DIR}/SiPixelGenErrorDBObjectUploader_cfg.py MagField=0.0 Fullname=SiPixelGenErrorDBObject_phase1_0T_mc_BoR3_v1_bugfix Map=${LOCAL_TEST_DIR}/../data/phaseI_mapping.csv GenErrFilePath=CalibTracker/SiPixelESProducers/data/SiPixelTemplateDBObject_0T_phase1_BoR3_v1 || die "Failure running SiPixelGenErrorDBObjectUploader_cfg.py" $? 
 
-echo "TESTING Pixel 1D Template DB code for Phase-2 ..."
+echo -e "TESTING Pixel 1D Template DB code for Phase-2 ..."
 cmsRun ${LOCAL_TEST_DIR}/SiPixelTemplateDBObjectUploader_Phase2_cfg.py MagField=3.8 Version=7 Append=mc_25x100 Map=${LOCAL_TEST_DIR}/../data/phase2_T15_mapping.csv geometry=T15 TemplateFilePath=CalibTracker/SiPixelESProducers/data/Phase2_25by100_templates_2020October || die "Failure running SiPixelTemplateDBObjectUploader_Phase2_cfg.py" $? 
 
-echo "TESTING Pixel 1D GenErr DB code for Phase-2 ..."
+echo -e "TESTING Pixel 1D GenErr DB code for Phase-2 ..."
 cmsRun ${LOCAL_TEST_DIR}/SiPixelGenErrorDBObjectUploader_Phase2_cfg.py MagField=3.8 Version=7 Append=mc_25x100 Map=${LOCAL_TEST_DIR}/../data/phase2_T15_mapping.csv geometry=T15 GenErrFilePath=CalibTracker/SiPixelESProducers/data/Phase2_25by100_templates_2020October || die "Failure running SiPixelGenErrorDBObjectUploader_Phase2_cfg.py" $? 
 
-echo "TESTING Pixel 2D Template DB code for Phase-2 ..."
+echo -e "TESTING Pixel 2D Template DB code for Phase-2 ..."
 cmsRun  ${LOCAL_TEST_DIR}/SiPixel2DTemplateDBObjectUploader_Phase2_cfg.py MagField=3.8 Version=7 Append=mc_25x100 Map=${LOCAL_TEST_DIR}/../data/phase2_T15_mapping.csv TemplateFilePath=CalibTracker/SiPixelESProducers/data/Phase2_25by100_templates_2020October denominator=True || die "Failure running SiPixel2DTemplateDBObjectUploader_Phase2_cfg.py" $? 
 
-echo "TESTING SiPixelVCal DB codes ... \n\n"
+echo -e "TESTING SiPixelVCal DB codes ... \n\n"
 
-echo "TESTING Writing SiPixelVCal DB object ...\n\n"
+echo -e "TESTING Writing SiPixelVCal DB object ...\n\n"
 cmsRun  ${LOCAL_TEST_DIR}/SiPixelVCalDB_cfg.py || die "Failure running SiPixelVCalDB_cfg.py" $?
 
-echo "TESTING Reading SiPixelVCal DB object ...\n\n"
+echo -e "TESTING Reading SiPixelVCal DB object ...\n\n"
 cmsRun  ${LOCAL_TEST_DIR}/SiPixelVCalReader_cfg.py || die "Failure running SiPixelVCalReader_cfg.py" $?
 
-echo "TESTING SiPixelLorentzAngle DB codes ... \n\n"
+echo -e "TESTING SiPixelLorentzAngle DB codes ... \n\n"
 
-echo "TESTING Writing SiPixelLorentzAngle DB object ...\n\n"
+echo -e "TESTING Writing SiPixelLorentzAngle DB object ...\n\n"
 cmsRun  ${LOCAL_TEST_DIR}/SiPixelLorentzAngleDB_cfg.py || die "Failure running SiPixelLorentzAngleDB_cfg.py" $?
 
-echo "TESTING Reading SiPixelLorentzAngle DB object ...\n\n"
+echo -e "TESTING Reading SiPixelLorentzAngle DB object ...\n\n"
 cmsRun  ${LOCAL_TEST_DIR}/SiPixelLorentzAngleReader_cfg.py || die "Failure running SiPixelLorentzAngleReader_cfg.py" $?
 
-echo "TESTING SiPixelDynamicInefficiency DB codes ... \n\n"
+echo -e "TESTING SiPixelDynamicInefficiency DB codes ... \n\n"
 
-echo "TESTING Writing SiPixelDynamicInefficiency DB object ...\n\n"
+echo -e "TESTING Writing SiPixelDynamicInefficiency DB object ...\n\n"
 cmsRun  ${LOCAL_TEST_DIR}/SiPixelDynamicInefficiencyDB_cfg.py || die "Failure running SiPixelDynamicInefficiencyDB_cfg.py" $?
 
-echo "TESTING Reading SiPixelDynamicInefficiency DB object ...\n\n"
+echo -e "TESTING Reading SiPixelDynamicInefficiency DB object ...\n\n"
 cmsRun  ${LOCAL_TEST_DIR}/SiPixelDynamicInefficiencyReader_cfg.py || die "Failure running SiPixelDynamicInefficiencyReader_cfg.py" $?
 
-echo "TESTING SiPixelGain Scaling DB codes ... \n\n"
+echo -e "TESTING SiPixelGain Scaling DB codes ... \n\n"
 
-echo "TESTING Writing Scaled SiPixel Gain DB Object ...\n\n"
+echo -e "TESTING Writing Scaled SiPixel Gain DB Object ...\n\n"
 cmsRun  ${LOCAL_TEST_DIR}/SiPixelGainCalibScaler_cfg.py firstRun=278869 maxEvents=12000 || die "Failure running SiPixelGainCalibScaler_cfg.py" $?
 
-echo "TESTING SiPixelQuality DB codes ... \n\n"
+echo -e "TESTING SiPixelQuality DB codes ... \n\n"
 
-echo "TESTING Writing SiPixelQuality DB object ...\n\n"
+echo -e "TESTING Writing SiPixelQuality DB object ...\n\n"
 cmsRun  ${LOCAL_TEST_DIR}/SiPixelBadModuleByHandBuilder_cfg.py || die "Failure running SiPixelBadModuleByHandBuilder_cfg.py" $?
 
-echo "TESTING Reading SiPixelQuality DB object ...\n\n"
+echo -e "TESTING Reading SiPixelQuality DB object ...\n\n"
 cmsRun  ${LOCAL_TEST_DIR}/SiPixelBadModuleReader_cfg.py || die "Failure running SiPixelBadModuleReader_cfg.py" $?


### PR DESCRIPTION
#### PR description:

Change to new method of `writeOneIOV` in PoolDBOutputService for SiPixel CPE. This also meant changing the pointers to the instance of the object.

As part of https://github.com/cms-AlCaDB/AlCaTools/issues/28

#### PR validation:

`scramv1 b runtests` run fine

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
