### PR TITLE
improvement of a workaround in `customizeHLTforPatatrack`

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
+++ b/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
@@ -237,29 +237,19 @@ def customisePixelLocalReconstruction(process):
 
 
     # workaround for AlCa paths
+    for AlCaPathName in ['AlCa_LumiPixelsCounts_Random_v1', 'AlCa_LumiPixelsCounts_ZeroBias_v1']:
+        if AlCaPathName in process.__dict__:
+            AlCaPath = getattr(process, AlCaPathName)
+            # replace hltSiPixelDigis+hltSiPixelClusters with HLTDoLocalPixelSequence
+            hasSiPixelDigis, hasSiPixelClusters = False, False
+            for (itemLabel, itemName) in AlCaPath.directDependencies():
+                if itemLabel != 'modules': continue
+                if itemName == 'hltSiPixelDigis': hasSiPixelDigis = True
+                elif itemName == 'hltSiPixelClusters': hasSiPixelClusters = True
+            if hasSiPixelDigis and hasSiPixelClusters:
+                AlCaPath.remove(process.hltSiPixelClusters)
+                AlCaPath.replace(process.hltSiPixelDigis, process.HLTDoLocalPixelSequence)
 
-    if 'AlCa_LumiPixelsCounts_Random_v1' in process.__dict__:
-        # redefine the path to use the HLTDoLocalPixelSequence
-        process.AlCa_LumiPixelsCounts_Random_v1 = cms.Path(
-            process.HLTBeginSequenceRandom +
-            process.hltScalersRawToDigi +
-            process.hltPreAlCaLumiPixelsCountsRandom +
-            process.hltPixelTrackerHVOn +
-            process.HLTDoLocalPixelSequence +
-            process.hltAlcaPixelClusterCounts +
-            process.HLTEndSequence )
-
-    if 'AlCa_LumiPixelsCounts_ZeroBias_v1' in process.__dict__:
-        # redefine the path to use the HLTDoLocalPixelSequence
-        process.AlCa_LumiPixelsCounts_ZeroBias_v1 = cms.Path(
-            process.HLTBeginSequence +
-            process.hltScalersRawToDigi +
-            process.hltL1sZeroBias +
-            process.hltPreAlCaLumiPixelsCountsZeroBias +
-            process.hltPixelTrackerHVOn +
-            process.HLTDoLocalPixelSequence +
-            process.hltAlcaPixelClusterCounts +
-            process.HLTEndSequence )
 
     # done
     return process


### PR DESCRIPTION
#### PR description:

Recent changes in the HLT menu [*] (addition of a module in the path `AlCa_LumiPixelsCounts_Random_v1`; see [CMSHLT-2189](https://its.cern.ch/jira/browse/CMSHLT-2189)) have created a conflict between the `12_2_X` GRun menu and a workaround used in `customizeHLTforPatatrack`.

This PR fixes the issue with a small improvement to said workaround.
The final solution will be to fix the HLT path directly in `ConfDB` (this is being followed up in TSG; see [CMSHLT-2195](https://its.cern.ch/jira/browse/CMSHLT-2195)).

FYI: @fwyzard

[*] ~~To be integrated in CMSSW in a separate PR later today.~~ See #36034.

#### PR validation:

Manual tests. Now the following works:
```bash
hltGetConfiguration /dev/CMSSW_12_2_0/GRun \
 --input $(dasgoclient -query "file dataset=/RelValVBFHZZ4Nu_14TeV/CMSSW_12_1_0_pre4-121X_mcRun3_2021_realistic_v10-v1/GEN-SIM-DIGI-RAW" -limit 1) \
 --globaltag auto:run3_mc_GRun --mc --eras Run3 --prescale none --max-events 50 \
 --customise HLTrigger/Configuration/customizeHLTforPatatrack.customizeHLTforPatatrack > hlt.py \
 && cmsRun hlt.py
```

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

N/A