### PR TITLE
BeamSpot + Rho variables in nanoAODs

### DIFF
--- a/DataFormats/NanoAOD/interface/FlatTable.h
+++ b/DataFormats/NanoAOD/interface/FlatTable.h
@@ -43,7 +43,8 @@ namespace nanoaod {
       UInt8,
       Bool,
       UInt32,
-      Double
+      Double,
+      Int8
     };  // We could have other Float types with reduced mantissa, and similar
 
     FlatTable() : size_(0) {}
@@ -143,6 +144,8 @@ namespace nanoaod {
         return ColumnType::Int;
       else if constexpr (std::is_same<T, uint8_t>())
         return ColumnType::UInt8;
+      else if constexpr (std::is_same<T, int8_t>())
+        return ColumnType::Int8;
       else if constexpr (std::is_same<T, bool>())
         return ColumnType::Bool;
       else if constexpr (std::is_same<T, uint32_t>())
@@ -191,6 +194,8 @@ namespace nanoaod {
         return table.ints_;
       else if constexpr (std::is_same<T, uint8_t>())
         return table.uint8s_;
+      else if constexpr (std::is_same<T, int8_t>())
+        return table.int8s_;
       else if constexpr (std::is_same<T, bool>())
         return table.uint8s_;
       else if constexpr (std::is_same<T, uint32_t>())
@@ -208,6 +213,7 @@ namespace nanoaod {
     std::vector<float> floats_;
     std::vector<int> ints_;
     std::vector<uint8_t> uint8s_;
+    std::vector<int8_t> int8s_;
     std::vector<uint32_t> uint32s_;
     std::vector<double> doubles_;
   };

--- a/DataFormats/NanoAOD/src/FlatTable.cc
+++ b/DataFormats/NanoAOD/src/FlatTable.cc
@@ -19,6 +19,9 @@ void nanoaod::FlatTable::addExtension(const nanoaod::FlatTable& other) {
       case ColumnType::Int:
         addColumn<int>(other.columnName(i), other.columnData<int>(i), other.columnDoc(i));
         break;
+      case ColumnType::Int8:
+        addColumn<int8_t>(other.columnName(i), other.columnData<int>(i), other.columnDoc(i));
+        break;
       case ColumnType::Bool:
         addColumn<bool>(other.columnName(i), other.columnData<bool>(i), other.columnDoc(i));
         break;
@@ -45,6 +48,8 @@ double nanoaod::FlatTable::getAnyValue(unsigned int row, unsigned int column) co
       return *(beginData<float>(column) + row);
     case ColumnType::Int:
       return *(beginData<int>(column) + row);
+    case ColumnType::Int8:
+      return *(beginData<int8_t>(column) + row);
     case ColumnType::Bool:
       return *(beginData<bool>(column) + row);
     case ColumnType::UInt8:

--- a/DataFormats/NanoAOD/src/classes.h
+++ b/DataFormats/NanoAOD/src/classes.h
@@ -4,3 +4,5 @@
 #include "DataFormats/NanoAOD/interface/MergeableCounterTable.h"
 #include "DataFormats/NanoAOD/interface/UniqueString.h"
 #include "DataFormats/Common/interface/Wrapper.h"
+
+std::vector<int8_t> svi8;

--- a/DataFormats/NanoAOD/src/classes_def.xml
+++ b/DataFormats/NanoAOD/src/classes_def.xml
@@ -23,6 +23,7 @@
     <class name="nanoaod::MergeableCounterTable::VIntColumn" ClassVersion="3">
         <version ClassVersion="3" checksum="2535066991"/>
     </class>
+    <class name="std::vector<int8_t>" />
     <class name="std::vector<nanoaod::MergeableCounterTable::FloatColumn>" />
     <class name="std::vector<nanoaod::MergeableCounterTable::VFloatColumn>" />
     <class name="std::vector<nanoaod::MergeableCounterTable::IntColumn>" />

--- a/DataFormats/NanoAOD/src/classes_def.xml
+++ b/DataFormats/NanoAOD/src/classes_def.xml
@@ -3,7 +3,8 @@
         <version ClassVersion="3" checksum="3066258528"/>
     </class>
     <class name="std::vector<nanoaod::FlatTable::Column>" />
-    <class name="nanoaod::FlatTable" ClassVersion="4">
+    <class name="nanoaod::FlatTable" ClassVersion="5">
+        <version ClassVersion="5" checksum="4251670483"/>
         <version ClassVersion="4" checksum="656493391"/>
         <version ClassVersion="3" checksum="2443023556"/>
     </class>

--- a/PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h
+++ b/PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h
@@ -127,6 +127,8 @@ public:
         vars_.push_back(std::make_unique<UIntVar>(vname, varPSet));
       else if (type == "float")
         vars_.push_back(std::make_unique<FloatVar>(vname, varPSet));
+      else if (type == "int8")
+        vars_.push_back(std::make_unique<Int8Var>(vname, varPSet));
       else if (type == "uint8")
         vars_.push_back(std::make_unique<UInt8Var>(vname, varPSet));
       else if (type == "bool")
@@ -164,6 +166,7 @@ protected:
   typedef FuncVariable<T, StringObjectFunction<T>, int> IntVar;
   typedef FuncVariable<T, StringObjectFunction<T>, unsigned int> UIntVar;
   typedef FuncVariable<T, StringObjectFunction<T>, float> FloatVar;
+  typedef FuncVariable<T, StringObjectFunction<T>, int8_t> Int8Var;
   typedef FuncVariable<T, StringObjectFunction<T>, uint8_t> UInt8Var;
   typedef FuncVariable<T, StringCutObjectSelector<T>, bool> BoolVar;
   std::vector<std::unique_ptr<Variable<T>>> vars_;
@@ -192,6 +195,9 @@ public:
         else if (type == "double")
           extvars_.push_back(
               std::make_unique<DoubleExtVar>(vname, varPSet, this->consumesCollector(), this->skipNonExistingSrc_));
+        else if (type == "int8")
+          extvars_.push_back(
+              std::make_unique<Int8ExtVar>(vname, varPSet, this->consumesCollector(), this->skipNonExistingSrc_));
         else if (type == "uint8")
           extvars_.push_back(
               std::make_unique<UInt8ExtVar>(vname, varPSet, this->consumesCollector(), this->skipNonExistingSrc_));
@@ -246,6 +252,7 @@ protected:
   typedef ValueMapVariable<T, float> FloatExtVar;
   typedef ValueMapVariable<T, double, float> DoubleExtVar;
   typedef ValueMapVariable<T, bool> BoolExtVar;
+  typedef ValueMapVariable<T, int, int8_t> Int8ExtVar;
   typedef ValueMapVariable<T, int, uint8_t> UInt8ExtVar;
   std::vector<std::unique_ptr<ExtVariable<T>>> extvars_;
 };

--- a/PhysicsTools/NanoAOD/plugins/NanoAODDQM.cc
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODDQM.cc
@@ -92,6 +92,9 @@ private:
         case FlatTable::ColumnType::Int:
           vfill<int>(table, icol, rowsel);
           break;
+        case FlatTable::ColumnType::Int8:
+          vfill<int8_t>(table, icol, rowsel);
+          break;
         case FlatTable::ColumnType::UInt8:
           vfill<uint8_t>(table, icol, rowsel);
           break;

--- a/PhysicsTools/NanoAOD/plugins/SimpleFlatTableProducerPlugins.cc
+++ b/PhysicsTools/NanoAOD/plugins/SimpleFlatTableProducerPlugins.cc
@@ -21,6 +21,9 @@ typedef SimpleFlatTableProducer<CTPPSLocalTrackLite> SimpleLocalTrackFlatTablePr
 #include "DataFormats/Math/interface/Point3D.h"
 typedef EventSingletonSimpleFlatTableProducer<math::XYZPointF> SimpleXYZPointFlatTableProducer;
 
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+typedef EventSingletonSimpleFlatTableProducer<reco::BeamSpot> SimpleBeamspotFlatTableProducer;
+
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(SimpleCandidateFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleGenEventFlatTableProducer);
@@ -29,3 +32,4 @@ DEFINE_FWK_MODULE(SimpleHTXSFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleProtonTrackFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleLocalTrackFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleXYZPointFlatTableProducer);
+DEFINE_FWK_MODULE(SimpleBeamspotFlatTableProducer);

--- a/PhysicsTools/NanoAOD/plugins/TableOutputBranches.cc
+++ b/PhysicsTools/NanoAOD/plugins/TableOutputBranches.cc
@@ -19,6 +19,9 @@ void TableOutputBranches::defineBranchesFromFirstEvent(const nanoaod::FlatTable 
       case nanoaod::FlatTable::ColumnType::Int:
         m_intBranches.emplace_back(var, tab.columnDoc(i), "I");
         break;
+      case nanoaod::FlatTable::ColumnType::Int8:
+        m_int8Branches.emplace_back(var, tab.columnDoc(i), "b");
+        break;
       case nanoaod::FlatTable::ColumnType::UInt8:
         m_uint8Branches.emplace_back(var, tab.columnDoc(i), "b");
         break;

--- a/PhysicsTools/NanoAOD/plugins/TableOutputBranches.h
+++ b/PhysicsTools/NanoAOD/plugins/TableOutputBranches.h
@@ -43,6 +43,7 @@ private:
   TBranch *m_counterBranch = nullptr;
   std::vector<NamedBranchPtr> m_floatBranches;
   std::vector<NamedBranchPtr> m_intBranches;
+  std::vector<NamedBranchPtr> m_int8Branches;
   std::vector<NamedBranchPtr> m_uint8Branches;
   std::vector<NamedBranchPtr> m_uint32Branches;
   std::vector<NamedBranchPtr> m_doubleBranches;

--- a/PhysicsTools/NanoAOD/python/globals_cff.py
+++ b/PhysicsTools/NanoAOD/python/globals_cff.py
@@ -18,6 +18,7 @@ beamSpotTable = cms.EDProducer("SimpleBeamspotFlatTableProducer",
 
 rhoTable = cms.EDProducer("GlobalVariablesTableProducer",
     variables = cms.PSet(
+        fixedGridRhoAll = ExtVar( cms.InputTag("fixedGridRhoAll"), "double", doc = "rho from all PF Candidates, no foreground removal (for isolation of prompt photons)" ),
         fixedGridRhoFastjetAll = ExtVar( cms.InputTag("fixedGridRhoFastjetAll"), "double", doc = "rho from all PF Candidates, used e.g. for JECs" ),
         fixedGridRhoFastjetCentralNeutral = ExtVar( cms.InputTag("fixedGridRhoFastjetCentralNeutral"), "double", doc = "rho from neutral PF Candidates with |eta| < 2.5, used e.g. for rho corrections of some lepton isolations" ),
         fixedGridRhoFastjetCentralCalo = ExtVar( cms.InputTag("fixedGridRhoFastjetCentralCalo"), "double", doc = "rho from calo towers with |eta| < 2.5, used e.g. egamma PFCluster isolation" ),

--- a/PhysicsTools/NanoAOD/python/globals_cff.py
+++ b/PhysicsTools/NanoAOD/python/globals_cff.py
@@ -17,6 +17,7 @@ beamSpotTable = cms.EDProducer("SimpleBeamspotFlatTableProducer",
 )
 
 rhoTable = cms.EDProducer("GlobalVariablesTableProducer",
+    name = cms.string("Rho"),
     variables = cms.PSet(
         fixedGridRhoAll = ExtVar( cms.InputTag("fixedGridRhoAll"), "double", doc = "rho from all PF Candidates, no foreground removal (for isolation of prompt photons)" ),
         fixedGridRhoFastjetAll = ExtVar( cms.InputTag("fixedGridRhoFastjetAll"), "double", doc = "rho from all PF Candidates, used e.g. for JECs" ),

--- a/PhysicsTools/NanoAOD/python/globals_cff.py
+++ b/PhysicsTools/NanoAOD/python/globals_cff.py
@@ -1,6 +1,21 @@
 import FWCore.ParameterSet.Config as cms
 from PhysicsTools.NanoAOD.common_cff import *
 
+beamSpotTable = cms.EDProducer("SimpleBeamspotFlatTableProducer",
+    src = cms.InputTag("offlineBeamSpot"),
+    name = cms.string("BeamSpot"),
+    doc = cms.string("offlineBeamSpot, the offline reconstructed beamspot"),
+    singleton = cms.bool(True),  # there's always exactly one MET per event
+    extension = cms.bool(False), # this is the main table for the MET
+    variables = cms.PSet(
+       type = Var("type()","int8",doc="BeamSpot type (Unknown = -1, Fake = 0, LHC = 1, Tracker = 2)"),
+       z = Var("position().z()",float,doc="BeamSpot center, z coordinate (cm)",precision=-1),
+       zError = Var("z0Error()",float,doc="Error on BeamSpot center, z coordinate (cm)",precision=-1),
+       sigmaZ = Var("sigmaZ()",float,doc="Width of BeamSpot in z (cm)",precision=-1),
+       sigmaZError = Var("sigmaZ0Error()",float,doc="Error on width of BeamSpot in z (cm)",precision=-1),
+    ),
+)
+
 rhoTable = cms.EDProducer("GlobalVariablesTableProducer",
     variables = cms.PSet(
         fixedGridRhoFastjetAll = ExtVar( cms.InputTag("fixedGridRhoFastjetAll"), "double", doc = "rho from all PF Candidates, used e.g. for JECs" ),
@@ -53,5 +68,5 @@ genFilterTable = cms.EDProducer("SimpleGenFilterFlatTableProducerLumi",
         ),
 )
 
-globalTablesTask = cms.Task(rhoTable)
+globalTablesTask = cms.Task(beamSpotTable, rhoTable)
 globalTablesMCTask = cms.Task(puTable,genTable,genFilterTable)

--- a/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
@@ -855,16 +855,31 @@ nanoDQM = DQMEDAnalyzer("NanoAODDQM",
                 Plot1D('rawMVAoldDMdR032017v2', 'rawMVAoldDMdR032017v2', 20, -1, 1, 'byIsolationMVArun2017v2DBoldDMdR0p3wLT raw output discriminator (2017v2)'),
             )
         ),
-	L1PreFiringWeight = cms.PSet(
-		sels = cms.PSet(),
-		plots = cms.VPSet(
-			Plot1D('Nom', 'Nom', 21, 0.8, 1.01, 'L1 prefiring weight nominal'),
-			Plot1D('Up', 'Up', 21, 0.8, 1.01, 'L1 prefiring weight uncertainy up'),
-			Plot1D('Dn', 'Dn', 21, 0.8, 1.01, 'L1 prefiring weight uncertainty down'),
-			Plot1D('ECAL_Nom', 'ECAL_Nom', 21, 0.8, 1.01, 'L1 prefiring weight for ECAL objects nominal'),
-			Plot1D('Muon_Nom', 'Muon_Nom', 21, 0.8, 1.01, 'L1 prefiring weight for muons nominal'),
-		)
+        L1PreFiringWeight = cms.PSet(
+            sels = cms.PSet(),
+            plots = cms.VPSet(
+                Plot1D('Nom', 'Nom', 21, 0.8, 1.01, 'L1 prefiring weight nominal'),
+                Plot1D('Up', 'Up', 21, 0.8, 1.01, 'L1 prefiring weight uncertainy up'),
+                Plot1D('Dn', 'Dn', 21, 0.8, 1.01, 'L1 prefiring weight uncertainty down'),
+                Plot1D('ECAL_Nom', 'ECAL_Nom', 21, 0.8, 1.01, 'L1 prefiring weight for ECAL objects nominal'),
+                Plot1D('Muon_Nom', 'Muon_Nom', 21, 0.8, 1.01, 'L1 prefiring weight for muons nominal'),
+            )
 
-	),
+        ),
+        BeamSpot = cms.PSet(
+            sels = cms.PSet(),
+            plots = cms.VPSet(
+                Plot1D('z', 'z', 20, 0.5, 1.5, 'BeamSpot center, z coordinate (cm)'),         
+                Plot1D('zError', 'zError', 20, 0., 0.01, 'Error on BeamSpot center, z coordinate (cm)'),         
+                Plot1D('sigmaZ', 'sigmaZ', 20, 0., 10, 'Width of BeamSpot in z (cm)'),         
+                Plot1D('sigmaZError', 'sigmaZError', 20, 0., 0.01, 'Error on width of BeamSpot in z (cm)'),         
+            )
+        ),
+        Rho = cms.PSet(
+            sels = cms.PSet(),
+            plots = cms.VPSet(
+                Plot1D('fixedGridRhoAll', 'fixedGridRhoAll', 100, 0, 80, 'rho from all PF Candidates, no foreground removal (for isolation of prompt photons)'),
+            )
+        ),
     )
 )

--- a/PhysicsTools/NanoAOD/python/photons_cff.py
+++ b/PhysicsTools/NanoAOD/python/photons_cff.py
@@ -189,7 +189,7 @@ photonTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
         cutBased = Var(
             "userInt('cutbasedID_loose')+userInt('cutbasedID_medium')+userInt('cutbasedID_tight')",
             int,
-            doc="cut-based ID bitmap, Fall17V2, (0:fail, 1:loose, 2:medium, 3:tight)"
+            doc="cut-based ID bitmap, Fall17V2, (0:fail, 1:loose, 2:medium, 3:tight)",
         ),
         cutBased_Fall17V1Bitmap = Var(
             "userInt('cutbasedIDV1_loose')+2*userInt('cutbasedIDV1_medium')+4*userInt('cutbasedIDV1_tight')",
@@ -199,7 +199,7 @@ photonTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
         vidNestedWPBitmap = Var(
             "userInt('VIDNestedWPBitmap')",
             int,
-            doc="Fall17V2 " + make_bitmapVID_docstring(photon_id_modules_WorkingPoints_nanoAOD)
+            doc="Fall17V2 " + make_bitmapVID_docstring(photon_id_modules_WorkingPoints_nanoAOD),
         ),
         electronVeto = Var("passElectronVeto()",bool,doc="pass electron veto"),
         pixelSeed = Var("hasPixelSeed()",bool,doc="has pixel seed"),

--- a/PhysicsTools/NanoAOD/test/nano_cfg.py
+++ b/PhysicsTools/NanoAOD/test/nano_cfg.py
@@ -6,6 +6,9 @@ process = cms.Process('NANO',Run2_2017,run2_nanoAOD_92X)
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 
 process.load("Configuration.StandardSequences.GeometryDB_cff")
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 process.load('Configuration.StandardSequences.Services_cff')
 from Configuration.AlCa.autoCond import autoCond


### PR DESCRIPTION
#### PR description:

This PR introduces the photon variables required to allow H->gamma gamma to move to nanoAODs.
The changes were discussed in [this](https://indico.cern.ch/event/1085967/#4-hgg-photon-updates-for-nano) XPOG meeting.

### EDIT

The photons related variables were moved to https://github.com/cms-sw/cmssw/pull/36526