### PR TITLE
dLyds perturbation2

### DIFF
--- a/Validation/CTPPS/plugins/CTPPSModifiedOpticalFunctionsESSource.cc
+++ b/Validation/CTPPS/plugins/CTPPSModifiedOpticalFunctionsESSource.cc
@@ -129,6 +129,10 @@ std::shared_ptr<LHCInterpolatedOpticalFunctionsSetCollection> CTPPSModifiedOptic
       double L_x_F = of_F.m_fcn_values[LHCOpticalFunctionsSet::eLx][i];
       double Lp_x = of_N.m_fcn_values[LHCOpticalFunctionsSet::eLpx][i];
 
+      double L_y_N = of_N.m_fcn_values[LHCOpticalFunctionsSet::eLy][i];
+      double L_y_F = of_F.m_fcn_values[LHCOpticalFunctionsSet::eLy][i];
+      double Lp_y = of_N.m_fcn_values[LHCOpticalFunctionsSet::eLpy][i];
+
       //printf("  xi = %.3f, Lp_x = %.3f, %.3f\n", xi, Lp_x, (L_x_F - L_x_N) / de_z);
 
       // apply modification scenario
@@ -166,6 +170,15 @@ std::shared_ptr<LHCInterpolatedOpticalFunctionsSetCollection> CTPPSModifiedOptic
         applied = true;
       }
 
+      if (scenario_ == "Lpy") {
+        const double a = 0.42, b = 0.015;  // dimensionless
+        const double de_Lp_y = factor_ * (a * xi + b) * Lp_y;
+        Lp_y += de_Lp_y;
+        L_y_N -= de_Lp_y * de_z / 2.;
+        L_y_F += de_Lp_y * de_z / 2.;
+        applied = true;
+      }
+
       // store updated values
       of_N.m_fcn_values[LHCOpticalFunctionsSet::exd][i] = x_d_N;
       of_F.m_fcn_values[LHCOpticalFunctionsSet::exd][i] = x_d_F;
@@ -175,6 +188,10 @@ std::shared_ptr<LHCInterpolatedOpticalFunctionsSetCollection> CTPPSModifiedOptic
 
       of_N.m_fcn_values[LHCOpticalFunctionsSet::eLpx][i] = Lp_x;
       of_F.m_fcn_values[LHCOpticalFunctionsSet::eLpx][i] = Lp_x;
+
+      of_N.m_fcn_values[LHCOpticalFunctionsSet::eLpy][i] = Lp_y;
+      of_F.m_fcn_values[LHCOpticalFunctionsSet::eLpy][i] = Lp_y;
+
     }
 
     // re-initialise splines

--- a/Validation/CTPPS/plugins/CTPPSModifiedOpticalFunctionsESSource.cc
+++ b/Validation/CTPPS/plugins/CTPPSModifiedOpticalFunctionsESSource.cc
@@ -191,7 +191,6 @@ std::shared_ptr<LHCInterpolatedOpticalFunctionsSetCollection> CTPPSModifiedOptic
 
       of_N.m_fcn_values[LHCOpticalFunctionsSet::eLpy][i] = Lp_y;
       of_F.m_fcn_values[LHCOpticalFunctionsSet::eLpy][i] = Lp_y;
-
     }
 
     // re-initialise splines


### PR DESCRIPTION
#### PR description:
The feature adds the perturbation of the optics due to dLy/ds on top of the existing ones due
to Lx, dLx/ds.

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

It is copy/paste of the method for dLx/ds; the numbers are from MAD-X studies ( to be updated in the PR). See 
for example https://indico.cern.ch/event/1087234/contributions/4576017/attachments/2338135/3985601/accep_2.pdf


<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
