### PR TITLE
migrate SiPixel codes to new `PoolDBOutputService` methods

### DIFF
--- a/CalibTracker/SiPixelConnectivity/test/SiPixelFedCablingMapWriter.cc
+++ b/CalibTracker/SiPixelConnectivity/test/SiPixelFedCablingMapWriter.cc
@@ -70,7 +70,7 @@ void SiPixelFedCablingMapWriter::analyze(const edm::Event& iEvent, const edm::Ev
 void SiPixelFedCablingMapWriter::beginJob() {}
 
 void SiPixelFedCablingMapWriter::endJob() {
-  SiPixelFedCablingMap* result = new SiPixelFedCablingMap(cabling);
+  SiPixelFedCablingMap result(cabling);
   LogInfo("Now NEW writing to DB");
   edm::Service<cond::service::PoolDBOutputService> mydbservice;
   if (!mydbservice.isAvailable()) {
@@ -84,10 +84,9 @@ void SiPixelFedCablingMapWriter::endJob() {
 
   try {
     if (mydbservice->isNewTagRequest(record_)) {
-      mydbservice->createNewIOV<SiPixelFedCablingMap>(
-          result, mydbservice->beginOfTime(), mydbservice->endOfTime(), record_);
+      mydbservice->createOneIOV<SiPixelFedCablingMap>(result, mydbservice->beginOfTime(), record_);
     } else {
-      mydbservice->appendSinceTime<SiPixelFedCablingMap>(result, mydbservice->currentTime(), record_);
+      mydbservice->appendOneIOV<SiPixelFedCablingMap>(result, mydbservice->currentTime(), record_);
     }
   } catch (std::exception& e) {
     LogError("std::exception:  ") << e.what();

--- a/CalibTracker/SiPixelGainCalibration/plugins/SiPixelGainCalibrationAnalysis.cc
+++ b/CalibTracker/SiPixelGainCalibration/plugins/SiPixelGainCalibrationAnalysis.cc
@@ -17,8 +17,6 @@ Implementation:
 //
 
 // user include files
-#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
-
 #include "SiPixelGainCalibrationAnalysis.h"
 #include <sstream>
 #include <vector>

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
@@ -412,7 +412,7 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
   edm::Service<cond::service::PoolDBOutputService> mydbservice;
   if (mydbservice.isAvailable()) {
     try {
-      mydbservice->writeOneIOV(LorentzAngle.get(), mydbservice->currentTime(), recordName_);
+      mydbservice->writeOneIOV(*LorentzAngle, mydbservice->currentTime(), recordName_);
     } catch (const cond::Exception& er) {
       edm::LogError("SiPixelLorentzAngleDB") << er.what() << std::endl;
     } catch (const std::exception& er) {

--- a/CalibTracker/SiPixelQuality/plugins/SiPixelStatusHarvester.h
+++ b/CalibTracker/SiPixelQuality/plugins/SiPixelStatusHarvester.h
@@ -97,10 +97,10 @@ private:
                                        std::map<edm::LuminosityBlockNumber_t, edm::LuminosityBlockNumber_t> IOV);
 
   // boolean function to check whether two SiPixelQualitys (pyloads) are identical
-  bool equal(SiPixelQuality* a, SiPixelQuality* b);
+  bool equal(SiPixelQuality a, SiPixelQuality b);
 
   // Tag constructor
-  void constructTag(std::map<int, SiPixelQuality*> siPixelQualityTag,
+  void constructTag(std::map<int, SiPixelQuality> siPixelQualityTag,
                     edm::Service<cond::service::PoolDBOutputService>& poolDbService,
                     std::string tagName,
                     edm::Run const& iRun);

--- a/CondFormats/SiPixelObjects/test/FastSiPixelFEDChannelContainerFromQuality.cc
+++ b/CondFormats/SiPixelObjects/test/FastSiPixelFEDChannelContainerFromQuality.cc
@@ -85,7 +85,7 @@ private:
   const bool isMC_;
   const bool removeEmptyPayloads_;
 
-  SiPixelFEDChannelContainer* myQualities;
+  std::unique_ptr<SiPixelFEDChannelContainer> myQualities;
 
   inline unsigned int closest_from_above(std::vector<unsigned int> const& vec, unsigned int value) {
     auto const it = std::lower_bound(vec.begin(), vec.end(), value);
@@ -115,10 +115,10 @@ FastSiPixelFEDChannelContainerFromQuality::FastSiPixelFEDChannelContainerFromQua
   m_connectionPool.configure();
 
   //now do what ever initialization is needed
-  myQualities = new SiPixelFEDChannelContainer();
+  myQualities = std::make_unique<SiPixelFEDChannelContainer>();
 }
 
-FastSiPixelFEDChannelContainerFromQuality::~FastSiPixelFEDChannelContainerFromQuality() { delete myQualities; }
+FastSiPixelFEDChannelContainerFromQuality::~FastSiPixelFEDChannelContainerFromQuality() = default;
 
 void FastSiPixelFEDChannelContainerFromQuality::analyze(const edm::Event& evt, const edm::EventSetup& evtSetup) {
   std::stringstream ss;

--- a/CondFormats/SiPixelObjects/test/SiPixelFEDChannelContainerFromQualityConverter.cc
+++ b/CondFormats/SiPixelObjects/test/SiPixelFEDChannelContainerFromQualityConverter.cc
@@ -60,7 +60,7 @@ private:
   const bool printdebug_;
   const bool isMC_;
   const bool removeEmptyPayloads_;
-  SiPixelFEDChannelContainer* myQualities;
+  std::unique_ptr<SiPixelFEDChannelContainer> myQualities;
 
   int IOVcount_;
   edm::ESWatcher<SiPixelQualityFromDbRcd> SiPixelQualityWatcher_;
@@ -78,12 +78,10 @@ SiPixelFEDChannelContainerFromQualityConverter::SiPixelFEDChannelContainerFromQu
       isMC_(iConfig.getUntrackedParameter<bool>("isMC", true)),
       removeEmptyPayloads_(iConfig.getUntrackedParameter<bool>("removeEmptyPayloads", false)) {
   //now do what ever initialization is needed
-  myQualities = new SiPixelFEDChannelContainer();
+  myQualities = std::make_unique<SiPixelFEDChannelContainer>();
 }
 
-SiPixelFEDChannelContainerFromQualityConverter::~SiPixelFEDChannelContainerFromQualityConverter() {
-  delete myQualities;
-}
+SiPixelFEDChannelContainerFromQualityConverter::~SiPixelFEDChannelContainerFromQualityConverter() = default;
 
 //
 // member functions

--- a/CondFormats/SiPixelObjects/test/SiPixelFedCablingMapTestWriter.cc
+++ b/CondFormats/SiPixelObjects/test/SiPixelFedCablingMapTestWriter.cc
@@ -45,7 +45,7 @@ SiPixelFedCablingMapTestWriter::SiPixelFedCablingMapTestWriter(const edm::Parame
 void SiPixelFedCablingMapTestWriter::endJob() {
   cout << "Convert Tree to Map";
 
-  SiPixelFedCablingMap* cablingMap = new SiPixelFedCablingMap(cablingTree);
+  const auto& cablingMap = SiPixelFedCablingMap(cablingTree);
   cout << "Now writing to DB" << endl;
   edm::Service<cond::service::PoolDBOutputService> mydbservice;
   if (!mydbservice.isAvailable()) {
@@ -57,10 +57,9 @@ void SiPixelFedCablingMapTestWriter::endJob() {
 
   try {
     if (mydbservice->isNewTagRequest(m_record)) {
-      mydbservice->createNewIOV<SiPixelFedCablingMap>(
-          cablingMap, mydbservice->beginOfTime(), mydbservice->endOfTime(), m_record);
+      mydbservice->createOneIOV<SiPixelFedCablingMap>(cablingMap, mydbservice->beginOfTime(), m_record);
     } else {
-      mydbservice->appendSinceTime<SiPixelFedCablingMap>(cablingMap, mydbservice->currentTime(), m_record);
+      mydbservice->appendOneIOV<SiPixelFedCablingMap>(cablingMap, mydbservice->currentTime(), m_record);
     }
   } catch (std::exception& e) {
     cout << "std::exception:  " << e.what();

--- a/CondFormats/SiPixelObjects/test/SiPixelQualityProbabilitiesTestWriter.cc
+++ b/CondFormats/SiPixelObjects/test/SiPixelQualityProbabilitiesTestWriter.cc
@@ -51,7 +51,7 @@ private:
   const std::string m_SnapshotInputs;
   const std::string m_record;
   const bool printdebug_;
-  SiPixelQualityProbabilities* myProbabilities;
+  std::unique_ptr<SiPixelQualityProbabilities> myProbabilities;
 };
 
 //
@@ -63,10 +63,10 @@ SiPixelQualityProbabilitiesTestWriter::SiPixelQualityProbabilitiesTestWriter(con
       m_record(iConfig.getParameter<std::string>("record")),
       printdebug_(iConfig.getUntrackedParameter<bool>("printDebug", false)) {
   //now do what ever initialization is needed
-  myProbabilities = new SiPixelQualityProbabilities();
+  myProbabilities = std::make_unique<SiPixelQualityProbabilities>();
 }
 
-SiPixelQualityProbabilitiesTestWriter::~SiPixelQualityProbabilitiesTestWriter() { delete myProbabilities; }
+SiPixelQualityProbabilitiesTestWriter::~SiPixelQualityProbabilitiesTestWriter() = default;
 
 //
 // member functions

--- a/CondFormats/SiPixelObjects/test/SiPixelQualityProbabilitiesWriteFromASCII.cc
+++ b/CondFormats/SiPixelObjects/test/SiPixelQualityProbabilitiesWriteFromASCII.cc
@@ -50,7 +50,7 @@ private:
   const std::string m_ProbInputs;
   const std::string m_record;
   const bool printdebug_;
-  SiPixelQualityProbabilities* myProbabilities;
+  std::unique_ptr<SiPixelQualityProbabilities> myProbabilities;
 };
 
 //
@@ -61,10 +61,10 @@ SiPixelQualityProbabilitiesWriteFromASCII::SiPixelQualityProbabilitiesWriteFromA
       m_record(iConfig.getParameter<std::string>("record")),
       printdebug_(iConfig.getUntrackedParameter<bool>("printDebug", false)) {
   //now do what ever initialization is needed
-  myProbabilities = new SiPixelQualityProbabilities();
+  myProbabilities = std::make_unique<SiPixelQualityProbabilities>();
 }
 
-SiPixelQualityProbabilitiesWriteFromASCII::~SiPixelQualityProbabilitiesWriteFromASCII() { delete myProbabilities; }
+SiPixelQualityProbabilitiesWriteFromASCII::~SiPixelQualityProbabilitiesWriteFromASCII() = default;
 
 //
 // member functions

--- a/CondTools/SiPixel/plugins/SiPixelCalibConfigurationObjectMaker.cc
+++ b/CondTools/SiPixel/plugins/SiPixelCalibConfigurationObjectMaker.cc
@@ -76,7 +76,7 @@ SiPixelCalibConfigurationObjectMaker::~SiPixelCalibConfigurationObjectMaker() = 
 
 void SiPixelCalibConfigurationObjectMaker::analyze(const edm::Event&, const edm::EventSetup&) {
   pos::PixelCalibConfiguration fancyCalib(inputfilename);
-  SiPixelCalibConfiguration* myCalib = new SiPixelCalibConfiguration(fancyCalib);
+  SiPixelCalibConfiguration myCalib(fancyCalib);
 
   std::string fixedmode = fancyCalib.mode();
   std::string tobereplaced = "WithSLink";
@@ -84,16 +84,16 @@ void SiPixelCalibConfigurationObjectMaker::analyze(const edm::Event&, const edm:
   if (fixedmode.find(tobereplaced) != std::string::npos)
     fixedmode.erase(fixedmode.find(tobereplaced), tobereplaced.length());
   edm::LogPrint("SiPixelCalibConfigurationObjectMaker") << "mode = " << fixedmode << std::endl;
-  myCalib->setCalibrationMode(fixedmode);
+  myCalib.setCalibrationMode(fixedmode);
 
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
 
   if (poolDbService.isAvailable()) {
     if (poolDbService->isNewTagRequest("SiPixelCalibConfigurationRcd")) {
-      poolDbService->createNewIOV<SiPixelCalibConfiguration>(
-          myCalib, poolDbService->beginOfTime(), poolDbService->endOfTime(), "SiPixelCalibConfigurationRcd");
+      poolDbService->createOneIOV<SiPixelCalibConfiguration>(
+          myCalib, poolDbService->beginOfTime(), "SiPixelCalibConfigurationRcd");
     } else {
-      poolDbService->appendSinceTime<SiPixelCalibConfiguration>(
+      poolDbService->appendOneIOV<SiPixelCalibConfiguration>(
           myCalib, poolDbService->currentTime(), "SiPixelCalibConfigurationRcd");
     }
   }

--- a/CondTools/SiPixel/plugins/SiPixelCondObjBuilder.cc
+++ b/CondTools/SiPixel/plugins/SiPixelCondObjBuilder.cc
@@ -49,7 +49,7 @@ namespace cms {
     float maxgain = 10;
     float minped = 0;
     float maxped = 255;
-    SiPixelGainCalibration_ = new SiPixelGainCalibration(minped, maxped, mingain, maxgain);
+    SiPixelGainCalibration_ = std::make_unique<SiPixelGainCalibration>(minped, maxped, mingain, maxgain);
 
     const TrackerGeometry* pDD = &iSetup.getData(pddToken_);
     edm::LogInfo("SiPixelCondObjBuilder") << " There are " << pDD->dets().size() << " detectors" << std::endl;
@@ -185,11 +185,11 @@ namespace cms {
       //           SiPixelGainCalibration_, tillTime , callbackToken);
 
       if (mydbservice->isNewTagRequest(recordName_)) {
-        mydbservice->createNewIOV<SiPixelGainCalibration>(
-            SiPixelGainCalibration_, mydbservice->beginOfTime(), mydbservice->endOfTime(), recordName_);
+        mydbservice->createOneIOV<SiPixelGainCalibration>(
+            *SiPixelGainCalibration_, mydbservice->beginOfTime(), recordName_);
       } else {
-        mydbservice->appendSinceTime<SiPixelGainCalibration>(
-            SiPixelGainCalibration_, mydbservice->currentTime(), recordName_);
+        mydbservice->appendOneIOV<SiPixelGainCalibration>(
+            *SiPixelGainCalibration_, mydbservice->currentTime(), recordName_);
       }
       edm::LogInfo(" --- all OK");
     } catch (const cond::Exception& er) {

--- a/CondTools/SiPixel/plugins/SiPixelCondObjBuilder.h
+++ b/CondTools/SiPixel/plugins/SiPixelCondObjBuilder.h
@@ -45,7 +45,7 @@ namespace cms {
     edm::ParameterSet conf_;
     bool appendMode_;
     edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> pddToken_;
-    SiPixelGainCalibration* SiPixelGainCalibration_;
+    std::unique_ptr<SiPixelGainCalibration> SiPixelGainCalibration_;
     SiPixelGainCalibrationService SiPixelGainCalibrationService_;
     std::string recordName_;
 

--- a/CondTools/SiPixel/plugins/SiPixelCondObjForHLTBuilder.cc
+++ b/CondTools/SiPixel/plugins/SiPixelCondObjForHLTBuilder.cc
@@ -62,7 +62,7 @@ namespace cms {
     float maxgain = 10;
     float minped = 0;
     float maxped = 255;
-    SiPixelGainCalibration_ = new SiPixelGainCalibrationForHLT(minped, maxped, mingain, maxgain);
+    SiPixelGainCalibration_ = std::make_unique<SiPixelGainCalibrationForHLT>(minped, maxped, mingain, maxgain);
 
     const TrackerGeometry* pDD = &iSetup.getData(tkGeometryToken_);
     edm::LogInfo("SiPixelCondObjForHLTBuilder") << " There are " << pDD->dets().size() << " detectors" << std::endl;
@@ -246,11 +246,11 @@ namespace cms {
       //           SiPixelGainCalibration_, tillTime , callbackToken);
 
       if (mydbservice->isNewTagRequest(recordName_)) {
-        mydbservice->createNewIOV<SiPixelGainCalibrationForHLT>(
-            SiPixelGainCalibration_, mydbservice->beginOfTime(), mydbservice->endOfTime(), recordName_);
+        mydbservice->createOneIOV<SiPixelGainCalibrationForHLT>(
+            *SiPixelGainCalibration_, mydbservice->beginOfTime(), recordName_);
       } else {
-        mydbservice->appendSinceTime<SiPixelGainCalibrationForHLT>(
-            SiPixelGainCalibration_, mydbservice->currentTime(), recordName_);
+        mydbservice->appendOneIOV<SiPixelGainCalibrationForHLT>(
+            *SiPixelGainCalibration_, mydbservice->currentTime(), recordName_);
       }
       edm::LogInfo(" --- all OK");
     } catch (const cond::Exception& er) {

--- a/CondTools/SiPixel/plugins/SiPixelCondObjForHLTBuilder.h
+++ b/CondTools/SiPixel/plugins/SiPixelCondObjForHLTBuilder.h
@@ -46,7 +46,7 @@ namespace cms {
 
     edm::ParameterSet conf_;
     bool appendMode_;
-    SiPixelGainCalibrationForHLT* SiPixelGainCalibration_;
+    std::unique_ptr<SiPixelGainCalibrationForHLT> SiPixelGainCalibration_;
     SiPixelGainCalibrationForHLTService SiPixelGainCalibrationService_;
     std::string recordName_;
 

--- a/CondTools/SiPixel/plugins/SiPixelCondObjOfflineBuilder.cc
+++ b/CondTools/SiPixel/plugins/SiPixelCondObjOfflineBuilder.cc
@@ -61,7 +61,7 @@ namespace cms {
     float maxped = 100.;
     float mingain = 0.;
     float maxgain = 10.;
-    SiPixelGainCalibration_ = new SiPixelGainCalibrationOffline(minped, maxped, mingain, maxgain);
+    SiPixelGainCalibration_ = std::make_unique<SiPixelGainCalibrationOffline>(minped, maxped, mingain, maxgain);
 
     const TrackerGeometry* pDD = &iSetup.getData(pddToken_);
     edm::LogInfo("SiPixelCondObjOfflineBuilder") << " There are " << pDD->dets().size() << " detectors" << std::endl;
@@ -232,11 +232,11 @@ namespace cms {
 
     try {
       if (mydbservice->isNewTagRequest(recordName_)) {
-        mydbservice->createNewIOV<SiPixelGainCalibrationOffline>(
-            SiPixelGainCalibration_, mydbservice->beginOfTime(), mydbservice->endOfTime(), recordName_);
+        mydbservice->createOneIOV<SiPixelGainCalibrationOffline>(
+            *SiPixelGainCalibration_, mydbservice->beginOfTime(), recordName_);
       } else {
-        mydbservice->appendSinceTime<SiPixelGainCalibrationOffline>(
-            SiPixelGainCalibration_, mydbservice->currentTime(), recordName_);
+        mydbservice->appendOneIOV<SiPixelGainCalibrationOffline>(
+            *SiPixelGainCalibration_, mydbservice->currentTime(), recordName_);
       }
       edm::LogInfo(" --- all OK");
     } catch (const cond::Exception& er) {

--- a/CondTools/SiPixel/plugins/SiPixelCondObjOfflineBuilder.h
+++ b/CondTools/SiPixel/plugins/SiPixelCondObjOfflineBuilder.h
@@ -44,7 +44,7 @@ namespace cms {
     edm::ParameterSet conf_;
     bool appendMode_;
     edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> pddToken_;
-    SiPixelGainCalibrationOffline* SiPixelGainCalibration_;
+    std::unique_ptr<SiPixelGainCalibrationOffline> SiPixelGainCalibration_;
     SiPixelGainCalibrationOfflineService SiPixelGainCalibrationService_;
     std::string recordName_;
 

--- a/CondTools/SiPixel/plugins/SiPixelDynamicInefficiencyDB.cc
+++ b/CondTools/SiPixel/plugins/SiPixelDynamicInefficiencyDB.cc
@@ -34,7 +34,7 @@ SiPixelDynamicInefficiencyDB::~SiPixelDynamicInefficiencyDB() = default;
 // Analyzer: Functions that gets called by framework every event
 
 void SiPixelDynamicInefficiencyDB::analyze(const edm::Event& e, const edm::EventSetup& es) {
-  SiPixelDynamicInefficiency* DynamicInefficiency = new SiPixelDynamicInefficiency();
+  SiPixelDynamicInefficiency DynamicInefficiency;
 
   //Retrieve tracker topology from geometry
   const TrackerTopology* const tTopo = &es.getData(tkTopoToken_);
@@ -51,22 +51,22 @@ void SiPixelDynamicInefficiencyDB::analyze(const edm::Event& e, const edm::Event
 
   //Put BPix masks
   mask = tTopo->pxbDetId(max, LADDER, MODULE).rawId();
-  DynamicInefficiency->putDetIdmask(mask);
+  DynamicInefficiency.putDetIdmask(mask);
   mask = tTopo->pxbDetId(LAYER, max, MODULE).rawId();
-  DynamicInefficiency->putDetIdmask(mask);
+  DynamicInefficiency.putDetIdmask(mask);
   mask = tTopo->pxbDetId(LAYER, LADDER, max).rawId();
-  DynamicInefficiency->putDetIdmask(mask);
+  DynamicInefficiency.putDetIdmask(mask);
   //Put FPix masks
   mask = tTopo->pxfDetId(max, DISK, BLADE, PANEL, MODULE).rawId();
-  DynamicInefficiency->putDetIdmask(mask);
+  DynamicInefficiency.putDetIdmask(mask);
   mask = tTopo->pxfDetId(SIDE, max, BLADE, PANEL, MODULE).rawId();
-  DynamicInefficiency->putDetIdmask(mask);
+  DynamicInefficiency.putDetIdmask(mask);
   mask = tTopo->pxfDetId(SIDE, DISK, max, PANEL, MODULE).rawId();
-  DynamicInefficiency->putDetIdmask(mask);
+  DynamicInefficiency.putDetIdmask(mask);
   mask = tTopo->pxfDetId(SIDE, DISK, BLADE, max, MODULE).rawId();
-  DynamicInefficiency->putDetIdmask(mask);
+  DynamicInefficiency.putDetIdmask(mask);
   mask = tTopo->pxfDetId(SIDE, DISK, BLADE, PANEL, max).rawId();
-  DynamicInefficiency->putDetIdmask(mask);
+  DynamicInefficiency.putDetIdmask(mask);
 
   //Put PixelGeomFactors
   for (Parameters::iterator it = thePixelGeomFactors_.begin(); it != thePixelGeomFactors_.end(); ++it) {
@@ -83,13 +83,13 @@ void SiPixelDynamicInefficiencyDB::analyze(const edm::Event& e, const edm::Event
       DetId detID = tTopo->pxbDetId(layer, ladder, module);
       edm::LogPrint("SiPixelDynamicInefficiencyDB") << "Putting Pixel geom BPix layer " << layer << " ladder " << ladder
                                                     << " module " << module << " factor " << factor << std::endl;
-      DynamicInefficiency->putPixelGeomFactor(detID.rawId(), factor);
+      DynamicInefficiency.putPixelGeomFactor(detID.rawId(), factor);
     } else if (det == "fpix") {
       DetId detID = tTopo->pxfDetId(side, disk, blade, panel, module);
       edm::LogPrint("SiPixelDynamicInefficiencyDB")
           << "Putting Pixel geom FPix side " << side << " disk " << disk << " blade " << blade << " panel " << panel
           << " module " << module << " factor " << factor << std::endl;
-      DynamicInefficiency->putPixelGeomFactor(detID.rawId(), factor);
+      DynamicInefficiency.putPixelGeomFactor(detID.rawId(), factor);
     } else
       edm::LogError("SiPixelDynamicInefficiencyDB")
           << "SiPixelDynamicInefficiencyDB input detector part is neither bpix nor fpix" << std::endl;
@@ -111,13 +111,13 @@ void SiPixelDynamicInefficiencyDB::analyze(const edm::Event& e, const edm::Event
       edm::LogPrint("SiPixelDynamicInefficiencyDB")
           << "Putting Column geom BPix layer " << layer << " ladder " << ladder << " module " << module << " factor "
           << factor << std::endl;
-      DynamicInefficiency->putColGeomFactor(detID.rawId(), factor);
+      DynamicInefficiency.putColGeomFactor(detID.rawId(), factor);
     } else if (det == "fpix") {
       DetId detID = tTopo->pxfDetId(side, disk, blade, panel, module);
       edm::LogPrint("SiPixelDynamicInefficiencyDB")
           << "Putting Column geom FPix side " << side << " disk " << disk << " blade " << blade << " panel " << panel
           << " module " << module << " factor " << factor << std::endl;
-      DynamicInefficiency->putColGeomFactor(detID.rawId(), factor);
+      DynamicInefficiency.putColGeomFactor(detID.rawId(), factor);
     } else
       edm::LogError("SiPixelDynamicInefficiencyDB")
           << "SiPixelDynamicInefficiencyDB input detector part is neither bpix nor fpix" << std::endl;
@@ -138,13 +138,13 @@ void SiPixelDynamicInefficiencyDB::analyze(const edm::Event& e, const edm::Event
       DetId detID = tTopo->pxbDetId(layer, ladder, module);
       edm::LogPrint("SiPixelDynamicInefficiencyDB") << "Putting Chip geom BPix layer " << layer << " ladder " << ladder
                                                     << " module " << module << " factor " << factor << std::endl;
-      DynamicInefficiency->putChipGeomFactor(detID.rawId(), factor);
+      DynamicInefficiency.putChipGeomFactor(detID.rawId(), factor);
     } else if (det == "fpix") {
       DetId detID = tTopo->pxfDetId(side, disk, blade, panel, module);
       edm::LogPrint("SiPixelDynamicInefficiencyDB")
           << "Putting Chip geom FPix side " << side << " disk " << disk << " blade " << blade << " panel " << panel
           << " module " << module << " factor " << factor << std::endl;
-      DynamicInefficiency->putChipGeomFactor(detID.rawId(), factor);
+      DynamicInefficiency.putChipGeomFactor(detID.rawId(), factor);
     } else
       edm::LogError("SiPixelDynamicInefficiencyDB")
           << "SiPixelDynamicInefficiencyDB input detector part is neither bpix nor fpix" << std::endl;
@@ -166,26 +166,26 @@ void SiPixelDynamicInefficiencyDB::analyze(const edm::Event& e, const edm::Event
       edm::LogPrint("SiPixelDynamicInefficiencyDB")
           << "Putting PU efficiency BPix layer " << layer << " ladder " << ladder << " module " << module
           << " factor size " << factor.size() << std::endl;
-      DynamicInefficiency->putPUFactor(detID.rawId(), factor);
+      DynamicInefficiency.putPUFactor(detID.rawId(), factor);
     } else if (det == "fpix") {
       DetId detID = tTopo->pxfDetId(side, disk, blade, panel, module);
       edm::LogPrint("SiPixelDynamicInefficiencyDB")
           << "Putting PU efficiency FPix side " << side << " disk " << disk << " blade " << blade << " panel " << panel
           << " module " << module << " factor size " << factor.size() << std::endl;
-      DynamicInefficiency->putPUFactor(detID.rawId(), factor);
+      DynamicInefficiency.putPUFactor(detID.rawId(), factor);
     }
   }
   //Put theInstLumiScaleFactor
-  DynamicInefficiency->puttheInstLumiScaleFactor(theInstLumiScaleFactor_);
+  DynamicInefficiency.puttheInstLumiScaleFactor(theInstLumiScaleFactor_);
 
   edm::Service<cond::service::PoolDBOutputService> mydbservice;
   if (mydbservice.isAvailable()) {
     try {
       if (mydbservice->isNewTagRequest(recordName_)) {
-        mydbservice->createNewIOV<SiPixelDynamicInefficiency>(
-            DynamicInefficiency, mydbservice->beginOfTime(), mydbservice->endOfTime(), recordName_);
+        mydbservice->createOneIOV<SiPixelDynamicInefficiency>(
+            DynamicInefficiency, mydbservice->beginOfTime(), recordName_);
       } else {
-        mydbservice->appendSinceTime<SiPixelDynamicInefficiency>(
+        mydbservice->appendOneIOV<SiPixelDynamicInefficiency>(
             DynamicInefficiency, mydbservice->currentTime(), recordName_);
       }
     } catch (const cond::Exception& er) {

--- a/CondTools/SiPixel/plugins/SiPixelGainCalibrationReadDQMFile.cc
+++ b/CondTools/SiPixel/plugins/SiPixelGainCalibrationReadDQMFile.cc
@@ -115,11 +115,10 @@ void SiPixelGainCalibrationReadDQMFile::fillDatabase(const edm::EventSetup &iSet
     }
   }
 
-  auto theGainCalibrationDbInput =
-      std::make_unique<SiPixelGainCalibration>(pedlow_ * 0.999, pedhi_ * 1.001, gainlow_ * 0.999, gainhi_ * 1.001);
-  auto theGainCalibrationDbInputHLT = std::make_unique<SiPixelGainCalibrationForHLT>(
+  SiPixelGainCalibration theGainCalibrationDbInput(pedlow_ * 0.999, pedhi_ * 1.001, gainlow_ * 0.999, gainhi_ * 1.001);
+  SiPixelGainCalibrationForHLT theGainCalibrationDbInputHLT(
       pedlow_ * 0.999, pedhi_ * 1.001, gainlow_ * 0.999, gainhi_ * 1.001);
-  auto theGainCalibrationDbInputOffline = std::make_unique<SiPixelGainCalibrationOffline>(
+  SiPixelGainCalibrationOffline theGainCalibrationDbInputOffline(
       pedlow_ * 0.999, pedhi_ * 1.001, gainlow_ * 0.999, gainhi_ * 1.001);
 
   uint32_t nchannels = 0;
@@ -205,13 +204,13 @@ void SiPixelGainCalibrationReadDQMFile::fillDatabase(const edm::EventSetup &iSet
     //    int nrows=tempgain->GetNbinsY();
     //    int ncols=tempgain->GetNbinsX();
     //    edm::LogPrint("SiPixelGainCalibrationReadDQMFile") << "next histo " << tempgain->GetTitle() << " has nrow,ncol:" << nrows << ","<< ncols << std::endl;
-    size_t nrowsrocsplit = theGainCalibrationDbInputHLT->getNumberOfRowsToAverageOver();
-    if (theGainCalibrationDbInputOffline->getNumberOfRowsToAverageOver() != nrowsrocsplit)
+    size_t nrowsrocsplit = theGainCalibrationDbInputHLT.getNumberOfRowsToAverageOver();
+    if (theGainCalibrationDbInputOffline.getNumberOfRowsToAverageOver() != nrowsrocsplit)
       throw cms::Exception("GainCalibration Payload configuration error")
           << "[SiPixelGainCalibrationAnalysis::fillDatabase] ERROR the SiPixelGainCalibrationOffline and "
              "SiPixelGainCalibrationForHLT database payloads have different settings for the number of rows per roc: "
-          << theGainCalibrationDbInputHLT->getNumberOfRowsToAverageOver() << "(HLT), "
-          << theGainCalibrationDbInputOffline->getNumberOfRowsToAverageOver() << "(offline)";
+          << theGainCalibrationDbInputHLT.getNumberOfRowsToAverageOver() << "(HLT), "
+          << theGainCalibrationDbInputOffline.getNumberOfRowsToAverageOver() << "(offline)";
     std::vector<char> theSiPixelGainCalibrationPerPixel;
     std::vector<char> theSiPixelGainCalibrationPerColumn;
     std::vector<char> theSiPixelGainCalibrationGainPerColPedPerPixel;
@@ -325,11 +324,11 @@ void SiPixelGainCalibrationReadDQMFile::fillDatabase(const edm::EventSetup &iSet
         float gain = gains[jrow];
 
         if (ped > pedlow_ && gain > gainlow_ && ped < pedhi_ && gain < gainhi_) {
-          theGainCalibrationDbInput->setData(ped, gain, theSiPixelGainCalibrationPerPixel);
-          theGainCalibrationDbInputOffline->setDataPedestal(ped, theSiPixelGainCalibrationGainPerColPedPerPixel);
+          theGainCalibrationDbInput.setData(ped, gain, theSiPixelGainCalibrationPerPixel);
+          theGainCalibrationDbInputOffline.setDataPedestal(ped, theSiPixelGainCalibrationGainPerColPedPerPixel);
         } else {
-          theGainCalibrationDbInput->setDeadPixel(theSiPixelGainCalibrationPerPixel);
-          theGainCalibrationDbInputOffline->setDeadPixel(theSiPixelGainCalibrationGainPerColPedPerPixel);
+          theGainCalibrationDbInput.setDeadPixel(theSiPixelGainCalibrationPerPixel);
+          theGainCalibrationDbInputOffline.setDeadPixel(theSiPixelGainCalibrationGainPerColPedPerPixel);
         }
 
         if (jrow % nrowsrocsplit == 0) {
@@ -360,15 +359,15 @@ void SiPixelGainCalibrationReadDQMFile::fillDatabase(const edm::EventSetup &iSet
 
           if (gainforthiscol[iglobalrow] > gainlow_ && gainforthiscol[iglobalrow] < gainhi_ &&
               pedforthiscol[iglobalrow] > pedlow_ && pedforthiscol[iglobalrow] < pedhi_) {
-            theGainCalibrationDbInputOffline->setDataGain(
+            theGainCalibrationDbInputOffline.setDataGain(
                 gainforthiscol[iglobalrow], nrowsrocsplit, theSiPixelGainCalibrationGainPerColPedPerPixel);
-            theGainCalibrationDbInputHLT->setData(
+            theGainCalibrationDbInputHLT.setData(
                 pedforthiscol[iglobalrow], gainforthiscol[iglobalrow], theSiPixelGainCalibrationPerColumn);
           } else {
             //	    edm::LogPrint("SiPixelGainCalibrationReadDQMFile") << pedforthiscol[iglobalrow] << " " << gainforthiscol[iglobalrow] << std::endl;
-            theGainCalibrationDbInputOffline->setDeadColumn(nrowsrocsplit,
-                                                            theSiPixelGainCalibrationGainPerColPedPerPixel);
-            theGainCalibrationDbInputHLT->setDeadColumn(nrowsrocsplit, theSiPixelGainCalibrationPerColumn);
+            theGainCalibrationDbInputOffline.setDeadColumn(nrowsrocsplit,
+                                                           theSiPixelGainCalibrationGainPerColPedPerPixel);
+            theGainCalibrationDbInputHLT.setDeadColumn(nrowsrocsplit, theSiPixelGainCalibrationPerColumn);
           }
         }
       }
@@ -384,15 +383,15 @@ void SiPixelGainCalibrationReadDQMFile::fillDatabase(const edm::EventSetup &iSet
 
     //    edm::LogPrint("SiPixelGainCalibrationReadDQMFile") <<"putting things in db..." << std::endl;
     // now start creating the various database objects
-    if (!theGainCalibrationDbInput->put(detid, range, ncols))
+    if (!theGainCalibrationDbInput.put(detid, range, ncols))
       edm::LogError("SiPixelGainCalibrationAnalysis")
           << "warning: detid already exists for Offline (gain per col, ped per pixel) calibration database"
           << std::endl;
-    if (!theGainCalibrationDbInputOffline->put(detid, offlinerange, ncols))
+    if (!theGainCalibrationDbInputOffline.put(detid, offlinerange, ncols))
       edm::LogError("SiPixelGainCalibrationAnalysis")
           << "warning: detid already exists for Offline (gain per col, ped per pixel) calibration database"
           << std::endl;
-    if (!theGainCalibrationDbInputHLT->put(detid, hltrange, ncols))
+    if (!theGainCalibrationDbInputHLT.put(detid, hltrange, ncols))
       edm::LogError("SiPixelGainCalibrationAnalysis")
           << "warning: detid already exists for HLT (pedestal and gain per column) calibration database" << std::endl;
 
@@ -451,20 +450,20 @@ void SiPixelGainCalibrationReadDQMFile::fillDatabase(const edm::EventSetup &iSet
           << "now doing SiPixelGainCalibrationForHLTRcd payload..." << std::endl;
       if (mydbservice->isNewTagRequest(record_)) {
         mydbservice->createOneIOV<SiPixelGainCalibrationForHLT>(
-            *theGainCalibrationDbInputHLT, mydbservice->beginOfTime(), "SiPixelGainCalibrationForHLTRcd");
+            theGainCalibrationDbInputHLT, mydbservice->beginOfTime(), "SiPixelGainCalibrationForHLTRcd");
       } else {
         mydbservice->appendOneIOV<SiPixelGainCalibrationForHLT>(
-            *theGainCalibrationDbInputHLT, mydbservice->currentTime(), "SiPixelGainCalibrationForHLTRcd");
+            theGainCalibrationDbInputHLT, mydbservice->currentTime(), "SiPixelGainCalibrationForHLTRcd");
       }
     } else if (record_ == "SiPixelGainCalibrationOfflineRcd") {
       edm::LogPrint("SiPixelGainCalibrationReadDQMFile")
           << "now doing SiPixelGainCalibrationOfflineRcd payload..." << std::endl;
       if (mydbservice->isNewTagRequest(record_)) {
         mydbservice->createOneIOV<SiPixelGainCalibrationOffline>(
-            *theGainCalibrationDbInputOffline, mydbservice->beginOfTime(), "SiPixelGainCalibrationOfflineRcd");
+            theGainCalibrationDbInputOffline, mydbservice->beginOfTime(), "SiPixelGainCalibrationOfflineRcd");
       } else {
         mydbservice->appendOneIOV<SiPixelGainCalibrationOffline>(
-            *theGainCalibrationDbInputOffline, mydbservice->currentTime(), "SiPixelGainCalibrationOfflineRcd");
+            theGainCalibrationDbInputOffline, mydbservice->currentTime(), "SiPixelGainCalibrationOfflineRcd");
       }
     }
     edm::LogInfo(" --- all OK");

--- a/CondTools/SiPixel/plugins/SiPixelGainCalibrationRejectNoisyAndDead.cc
+++ b/CondTools/SiPixel/plugins/SiPixelGainCalibrationRejectNoisyAndDead.cc
@@ -86,9 +86,11 @@ void SiPixelGainCalibrationRejectNoisyAndDead::fillDatabase(const edm::EventSetu
       << "New payload will have pedlow,hi " << pedlow_ << "," << pedhi_ << " and gainlow,hi " << gainlow_ << ","
       << gainhi_ << endl;
   if (record_ == "SiPixelGainCalibrationOfflineRcd")
-    theGainCalibrationDbInputOffline_ = new SiPixelGainCalibrationOffline(pedlow_, pedhi_, gainlow_, gainhi_);
+    theGainCalibrationDbInputOffline_ =
+        std::make_unique<SiPixelGainCalibrationOffline>(pedlow_, pedhi_, gainlow_, gainhi_);
   if (record_ == "SiPixelGainCalibrationForHLTRcd")
-    theGainCalibrationDbInputForHLT_ = new SiPixelGainCalibrationForHLT(pedlow_, pedhi_, gainlow_, gainhi_);
+    theGainCalibrationDbInputForHLT_ =
+        std::make_unique<SiPixelGainCalibrationForHLT>(pedlow_, pedhi_, gainlow_, gainhi_);
 
   int nnoisy = 0;
   int ndead = 0;
@@ -361,26 +363,22 @@ void SiPixelGainCalibrationRejectNoisyAndDead::fillDatabase(const edm::EventSetu
       edm::LogPrint("SiPixelGainCalibrationRejectNoisyAndDead")
           << "now doing SiPixelGainCalibrationOfflineRcd payload..." << std::endl;
       if (mydbservice->isNewTagRequest("SiPixelGainCalibrationOfflineRcd")) {
-        mydbservice->createNewIOV<SiPixelGainCalibrationOffline>(theGainCalibrationDbInputOffline_,
-                                                                 mydbservice->beginOfTime(),
-                                                                 mydbservice->endOfTime(),
-                                                                 "SiPixelGainCalibrationOfflineRcd");
+        mydbservice->createOneIOV<SiPixelGainCalibrationOffline>(
+            *theGainCalibrationDbInputOffline_, mydbservice->beginOfTime(), "SiPixelGainCalibrationOfflineRcd");
       } else {
-        mydbservice->appendSinceTime<SiPixelGainCalibrationOffline>(
-            theGainCalibrationDbInputOffline_, mydbservice->currentTime(), "SiPixelGainCalibrationOfflineRcd");
+        mydbservice->appendOneIOV<SiPixelGainCalibrationOffline>(
+            *theGainCalibrationDbInputOffline_, mydbservice->currentTime(), "SiPixelGainCalibrationOfflineRcd");
       }
     }
     if (record_ == "SiPixelGainCalibrationForHLTRcd") {
       edm::LogPrint("SiPixelGainCalibrationRejectNoisyAndDead")
           << "now doing SiPixelGainCalibrationForHLTRcd payload..." << std::endl;
       if (mydbservice->isNewTagRequest("SiPixelGainCalibrationForHLTRcd")) {
-        mydbservice->createNewIOV<SiPixelGainCalibrationForHLT>(theGainCalibrationDbInputForHLT_,
-                                                                mydbservice->beginOfTime(),
-                                                                mydbservice->endOfTime(),
-                                                                "SiPixelGainCalibrationForHLTRcd");
+        mydbservice->createOneIOV<SiPixelGainCalibrationForHLT>(
+            *theGainCalibrationDbInputForHLT_, mydbservice->beginOfTime(), "SiPixelGainCalibrationForHLTRcd");
       } else {
-        mydbservice->appendSinceTime<SiPixelGainCalibrationForHLT>(
-            theGainCalibrationDbInputForHLT_, mydbservice->currentTime(), "SiPixelGainCalibrationForHLTRcd");
+        mydbservice->appendOneIOV<SiPixelGainCalibrationForHLT>(
+            *theGainCalibrationDbInputForHLT_, mydbservice->currentTime(), "SiPixelGainCalibrationForHLTRcd");
       }
     }
   }

--- a/CondTools/SiPixel/plugins/SiPixelGainCalibrationRejectNoisyAndDead.h
+++ b/CondTools/SiPixel/plugins/SiPixelGainCalibrationRejectNoisyAndDead.h
@@ -43,10 +43,10 @@ private:
   edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> pddToken_;
   SiPixelGainCalibrationOfflineService SiPixelGainCalibrationOfflineService_;
   //SiPixelGainCalibrationForHLTService SiPixelGainCalibrationService_;
-  SiPixelGainCalibrationOffline *theGainCalibrationDbInputOffline_;
+  std::unique_ptr<SiPixelGainCalibrationOffline> theGainCalibrationDbInputOffline_;
 
   SiPixelGainCalibrationForHLTService SiPixelGainCalibrationForHLTService_;
-  SiPixelGainCalibrationForHLT *theGainCalibrationDbInputForHLT_;
+  std::unique_ptr<SiPixelGainCalibrationForHLT> theGainCalibrationDbInputForHLT_;
 
   void analyze(const edm::Event &, const edm::EventSetup &) override;
 

--- a/CondTools/SiPixel/plugins/SiPixelLorentzAngleDB.cc
+++ b/CondTools/SiPixel/plugins/SiPixelLorentzAngleDB.cc
@@ -35,7 +35,7 @@ SiPixelLorentzAngleDB::~SiPixelLorentzAngleDB() = default;
 // Analyzer: Functions that gets called by framework every event
 
 void SiPixelLorentzAngleDB::analyze(const edm::Event& e, const edm::EventSetup& es) {
-  SiPixelLorentzAngle* LorentzAngle = new SiPixelLorentzAngle();
+  SiPixelLorentzAngle LorentzAngle;
 
   //Retrieve tracker topology from geometry
   const TrackerTopology* tTopo = &es.getData(tkTopoToken_);
@@ -62,7 +62,7 @@ void SiPixelLorentzAngleDB::analyze(const edm::Event& e, const edm::EventSetup& 
           for (Parameters::iterator it = ModuleParameters_.begin(); it != ModuleParameters_.end(); ++it) {
             if (it->getParameter<unsigned int>("rawid") == detidc.rawId()) {
               float lorentzangle = (float)it->getParameter<double>("angle");
-              LorentzAngle->putLorentzAngle(detid.rawId(), lorentzangle);
+              LorentzAngle.putLorentzAngle(detid.rawId(), lorentzangle);
               edm::LogPrint("SiPixelLorentzAngleDB")
                   << " individual value=" << lorentzangle << " put into rawid=" << detid.rawId() << endl;
             }
@@ -73,7 +73,7 @@ void SiPixelLorentzAngleDB::analyze(const edm::Event& e, const edm::EventSetup& 
             if (it->getParameter<unsigned int>("module") == tTopo->pxbModule(detidc.rawId()) &&
                 it->getParameter<unsigned int>("layer") == tTopo->pxbLayer(detidc.rawId())) {
               float lorentzangle = (float)it->getParameter<double>("angle");
-              LorentzAngle->putLorentzAngle(detid.rawId(), lorentzangle);
+              LorentzAngle.putLorentzAngle(detid.rawId(), lorentzangle);
             }
           }
 
@@ -94,7 +94,7 @@ void SiPixelLorentzAngleDB::analyze(const edm::Event& e, const edm::EventSetup& 
         for (Parameters::iterator it = ModuleParameters_.begin(); it != ModuleParameters_.end(); ++it) {
           if (it->getParameter<unsigned int>("rawid") == detidc.rawId()) {
             float lorentzangle = (float)it->getParameter<double>("angle");
-            LorentzAngle->putLorentzAngle(detid.rawId(), lorentzangle);
+            LorentzAngle.putLorentzAngle(detid.rawId(), lorentzangle);
             edm::LogPrint("SiPixelLorentzAngleDB")
                 << " individual value=" << lorentzangle << " put into rawid=" << detid.rawId() << endl;
           }
@@ -107,7 +107,7 @@ void SiPixelLorentzAngleDB::analyze(const edm::Event& e, const edm::EventSetup& 
               it->getParameter<unsigned int>("HVgroup") ==
                   HVgroup(tTopo->pxfPanel(detidc.rawId()), tTopo->pxfModule(detidc.rawId()))) {
             float lorentzangle = (float)it->getParameter<double>("angle");
-            LorentzAngle->putLorentzAngle(detid.rawId(), lorentzangle);
+            LorentzAngle.putLorentzAngle(detid.rawId(), lorentzangle);
           }
         }
 
@@ -122,10 +122,9 @@ void SiPixelLorentzAngleDB::analyze(const edm::Event& e, const edm::EventSetup& 
   if (mydbservice.isAvailable()) {
     try {
       if (mydbservice->isNewTagRequest(recordName_)) {
-        mydbservice->createNewIOV<SiPixelLorentzAngle>(
-            LorentzAngle, mydbservice->beginOfTime(), mydbservice->endOfTime(), recordName_);
+        mydbservice->createOneIOV<SiPixelLorentzAngle>(LorentzAngle, mydbservice->beginOfTime(), recordName_);
       } else {
-        mydbservice->appendSinceTime<SiPixelLorentzAngle>(LorentzAngle, mydbservice->currentTime(), recordName_);
+        mydbservice->appendOneIOV<SiPixelLorentzAngle>(LorentzAngle, mydbservice->currentTime(), recordName_);
       }
     } catch (const cond::Exception& er) {
       edm::LogError("SiPixelLorentzAngleDB") << er.what() << std::endl;

--- a/CondTools/SiPixel/plugins/SiPixelVCalDB.cc
+++ b/CondTools/SiPixel/plugins/SiPixelVCalDB.cc
@@ -14,7 +14,7 @@ SiPixelVCalDB::~SiPixelVCalDB() = default;
 
 // Analyzer: Functions that gets called by framework every event
 void SiPixelVCalDB::analyze(const edm::Event& e, const edm::EventSetup& iSetup) {
-  SiPixelVCal* vcal = new SiPixelVCal();
+  SiPixelVCal vcal;
   bool phase1 = true;
 
   // Retrieve tracker topology from geometry
@@ -43,7 +43,7 @@ void SiPixelVCalDB::analyze(const edm::Event& e, const edm::EventSetup& iSetup) 
             edm::LogPrint("SiPixelVCalDB") << ";  VCal slope " << slope << ", offset " << offset;
             // edm::LogInfo("SiPixelVCalDB")  << "  detId " << rawDetId << " \t
             // VCal slope " << slope << ", offset " << offset;
-            vcal->putSlopeAndOffset(detid, slope, offset);
+            vcal.putSlopeAndOffset(detid, slope, offset);
           }
         }
         edm::LogPrint("SiPixelVCalDB") << std::endl;
@@ -70,7 +70,7 @@ void SiPixelVCalDB::analyze(const edm::Event& e, const edm::EventSetup& iSetup) 
             edm::LogPrint("SiPixelVCalDB") << ";  VCal slope " << slope << ", offset " << offset;
             // edm::LogInfo("SiPixelVCalDB")  << "  detId " << rawDetId << " \t
             // VCal slope " << slope << ", offset " << offset;
-            vcal->putSlopeAndOffset(rawDetId, slope, offset);
+            vcal.putSlopeAndOffset(rawDetId, slope, offset);
           }
         }
         edm::LogPrint("SiPixelVCalDB") << std::endl;
@@ -86,9 +86,9 @@ void SiPixelVCalDB::analyze(const edm::Event& e, const edm::EventSetup& iSetup) 
   if (mydbservice.isAvailable()) {
     try {
       if (mydbservice->isNewTagRequest(recordName_)) {
-        mydbservice->createNewIOV<SiPixelVCal>(vcal, mydbservice->beginOfTime(), mydbservice->endOfTime(), recordName_);
+        mydbservice->createOneIOV<SiPixelVCal>(vcal, mydbservice->beginOfTime(), recordName_);
       } else {
-        mydbservice->appendSinceTime<SiPixelVCal>(vcal, mydbservice->currentTime(), recordName_);
+        mydbservice->appendOneIOV<SiPixelVCal>(vcal, mydbservice->currentTime(), recordName_);
       }
     } catch (const cond::Exception& er) {
       edm::LogError("SiPixelVCalDB") << er.what() << std::endl;

--- a/CondTools/SiPixel/plugins/SiPixelVCalDB.h
+++ b/CondTools/SiPixel/plugins/SiPixelVCalDB.h
@@ -5,8 +5,8 @@
 #include <map>
 #include <memory>
 #include <string>
-#include "CondFormats/SiPixelObjects/interface/SiPixelVCal.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelVCal.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/TrackerCommon/interface/PixelBarrelName.h"
 #include "DataFormats/TrackerCommon/interface/PixelEndcapName.h"
@@ -31,8 +31,8 @@ public:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
 private:
-  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tkGeomToken_;
-  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tkTopoToken_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tkGeomToken_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tkTopoToken_;
   std::string recordName_;
   typedef std::vector<edm::ParameterSet> Parameters;
   Parameters BPixParameters_;

--- a/CondTools/SiPixel/src/PixelPopConCalibSourceHandler.cc
+++ b/CondTools/SiPixel/src/PixelPopConCalibSourceHandler.cc
@@ -40,7 +40,6 @@
 #include "CalibFormats/SiPixelObjects/interface/PixelCalibConfiguration.h"
 
 // test poolDBOutput
-#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
 using namespace std;
@@ -286,8 +285,8 @@ void PixelPopConCalibSourceHandler::getNewObjects_file() {
 
   // use online code to parse the file
   pos::PixelCalibConfiguration fancyCalib(inputFilename);
-  SiPixelCalibConfiguration *calibConfig = new SiPixelCalibConfiguration(fancyCalib);
+  auto calibConfig = std::make_shared<SiPixelCalibConfiguration>(fancyCalib);
 
-  m_to_transfer.push_back(std::make_pair(calibConfig, _sinceIOV));
+  m_iovs.insert(std::make_pair(_sinceIOV, calibConfig));
 
 }  // void PixelPopConCalibSourceHandler::getNewObjects_file()


### PR DESCRIPTION
#### PR description:

In response to https://github.com/cms-AlCaDB/AlCaTools/issues/28. 
Migrated SiPixel-related codes to the usage of new `PoolDBOutputService` methods introduced at https://github.com/cms-sw/cmssw/pull/35048, by following the recommendations from this [presentation](https://indico.cern.ch/event/1088598/contributions/4580152/attachments/2333275/3976721/DBOutputService%20changes.pdf).
The relevant classes have been isolated using:
```console
git grep -l 'PoolDBOutputService' | grep SiPixel | grep -E '.(cc|h)$'
```

#### PR validation:

`cmssw` compiles

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

cc:  @SanjanaSekhar 