### PR TITLE
Minor update in the CSC/GEM-CSC trigger for Run-3: split regular ALCT-CLCT off from ALCT-CLCT-GEM matching

### DIFF
--- a/DQM/L1TMonitorClient/src/L1TdeCSCTPGClient.cc
+++ b/DQM/L1TMonitorClient/src/L1TdeCSCTPGClient.cc
@@ -268,4 +268,9 @@ void L1TdeCSCTPGClient::processHistograms(DQMStore::IGetter &igetter) {
   lctEmulSummary_eff_->getTH2F()->Divide(lctEmulSummary_num_->getTH2F(), lctEmulSummary_denom_->getTH2F(), 1, 1, "");
   alctEmulSummary_eff_->getTH2F()->Divide(alctEmulSummary_num_->getTH2F(), alctEmulSummary_denom_->getTH2F(), 1, 1, "");
   clctEmulSummary_eff_->getTH2F()->Divide(clctEmulSummary_num_->getTH2F(), clctEmulSummary_denom_->getTH2F(), 1, 1, "");
+
+  // set minima to 0.95 so the contrast comes out better!
+  lctDataSummary_eff_->getTH2F()->GetZaxis()->SetRangeUser(0.95, 1);
+  alctDataSummary_eff_->getTH2F()->GetZaxis()->SetRangeUser(0.95, 1);
+  clctDataSummary_eff_->getTH2F()->GetZaxis()->SetRangeUser(0.95, 1);
 }

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCGEMMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCGEMMotherboard.h
@@ -53,8 +53,11 @@ public:
   void setGEMGeometry(const GEMGeometry* g) { gem_g = g; }
 
 private:
-  // match ALCT-CLCT-GEM pairs
+  // match ALCT-CLCT-(2)GEM pairs
   void matchALCTCLCTGEM(bool bunch_crossing_mask[CSCConstants::MAX_ALCT_TBINS]);
+
+  // match ALCT-CLCT pairs
+  void matchALCTCLCT(bool bunch_crossing_mask[CSCConstants::MAX_ALCT_TBINS]);
 
   // match CLCT-2GEM pairs. The GEM coincidence cluster BX is considered the
   // reference
@@ -141,6 +144,8 @@ private:
   bool drop_low_quality_clct_no_gems_;
 
   // build LCT from ALCT/CLCT and GEM in ME1/b or ME2/1
+  bool build_lct_from_alct_clct_2gem_;
+  bool build_lct_from_alct_clct_1gem_;
   bool build_lct_from_alct_gem_;
   bool build_lct_from_clct_gem_;
 

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCMotherboard.h
@@ -182,6 +182,23 @@ protected:
   void checkConfigParameters();
 
   /*
+     For valid ALCTs in the trigger time window, look for CLCTs within the
+     match-time window. Valid CLCTs are matched in-time. If a match was found
+     for the best ALCT and best CLCT, also the second best ALCT and second
+     best CLCT are sent to a correlation function "correlateLCTs" that will
+     make the best-best pair and second-second pair (if applicable). This
+     "matchALCTCLCT" function used to be directly in the "run" function, but
+     was put in a separate procedure so it can be reused for the GEM-CSC
+     motherboards. The argument is a mask, which plays no role for regular
+     CSC motherboards (TMB or OTMB). It does play a role in the GEM-CSC
+     motherboard. Different kinds of LCTs can be made there (see
+     CSCGEMMotherboard class), and the matching follows a sequence of priority
+     (first ALCT-CLCT-(2)GEM, then ALCT-CLCT, then CLCT-2GEM, then ALCT-2GEM).
+     At each step bunch crossings are masked where at least one LCT was found.
+  */
+  void matchALCTCLCT(bool bunch_crossing_mask[CSCConstants::MAX_ALCT_TBINS]);
+
+  /*
     This function matches maximum two ALCTs with maximum two CLCTs in
     a bunch crossing. The best ALCT is considered the one with the highest
     quality in a BX. Similarly for the best CLCT. If there is just one

--- a/L1Trigger/CSCTriggerPrimitives/interface/GEMClusterProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/GEMClusterProcessor.h
@@ -27,11 +27,12 @@ public:
   /** Runs the CoPad processor code. */
   void run(const GEMPadDigiClusterCollection*);
 
-  /* Returns clusters for a given BX */
-  std::vector<GEMInternalCluster> getClusters(int bx) const;
-
-  /* Returns clusters around deltaBX for a given BX */
-  std::vector<GEMInternalCluster> getClusters(int bx, int deltaBX) const;
+  /* Returns clusters around deltaBX for a given BX
+    The parameter option determines which clusters should be returned
+    1: single and coincidence, 2: only coincidence, 3: only single
+  */
+  enum ClusterTypes { AllClusters = 1, SingleClusters = 2, CoincidenceClusters = 3 };
+  std::vector<GEMInternalCluster> getClusters(int bx, int deltaBX = 0, ClusterTypes option = AllClusters) const;
 
   /* Returns coincidence clusters for a given BX */
   std::vector<GEMInternalCluster> getCoincidenceClusters(int bx) const;

--- a/L1Trigger/CSCTriggerPrimitives/python/params/tmbParams.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/params/tmbParams.py
@@ -66,6 +66,8 @@ tmbPhase2GEM = tmbPhase2.clone(
     # efficiency recovery switches
     dropLowQualityALCTsNoGEMs = cms.bool(False),
     dropLowQualityCLCTsNoGEMs = cms.bool(True),
+    buildLCTfromALCTCLCTand2GEM = cms.bool(True),
+    buildLCTfromALCTCLCTand1GEM = cms.bool(True),
     buildLCTfromALCTandGEM = cms.bool(True),
     buildLCTfromCLCTandGEM = cms.bool(True),
     # assign GEM-CSC bending angle. Works only for

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
@@ -10,6 +10,8 @@ CSCGEMMotherboard::CSCGEMMotherboard(unsigned endcap,
     : CSCMotherboard(endcap, station, sector, subsector, chamber, conf),
       drop_low_quality_alct_no_gems_(tmbParams_.getParameter<bool>("dropLowQualityALCTsNoGEMs")),
       drop_low_quality_clct_no_gems_(tmbParams_.getParameter<bool>("dropLowQualityCLCTsNoGEMs")),
+      build_lct_from_alct_clct_2gem_(tmbParams_.getParameter<bool>("buildLCTfromALCTCLCTand2GEM")),
+      build_lct_from_alct_clct_1gem_(tmbParams_.getParameter<bool>("buildLCTfromALCTCLCTand1GEM")),
       build_lct_from_alct_gem_(tmbParams_.getParameter<bool>("buildLCTfromALCTandGEM")),
       build_lct_from_clct_gem_(tmbParams_.getParameter<bool>("buildLCTfromCLCTandGEM")) {
   // case for ME1/1
@@ -104,32 +106,47 @@ void CSCGEMMotherboard::run(const CSCWireDigiCollection* wiredc,
 
   /*
     Mask for bunch crossings were LCTs were previously found
-    If LCTs were found in BXi for ALCT-CLCT-2GEM, ALCT-CLCT-1GEM
-    or ALCT-CLCT matches, we do not consider BXi in the future. This is
-    because we consider  ALCT-CLCT-2GEM, ALCT-CLCT-1GEM, ALCT-CLCT of
-    higher quality than CLCT-2GEM and ALCT-2GEM LCTs. The mask is passsed
-    from one function to the next.
+    If LCTs were found in BXi for ALCT-CLCT-2GEM or ALCT-CLCT-1GEM,
+    we do not consider BXi in the future. This is
+    because we consider ALCT-CLCT-2GEM > ALCT-CLCT-1GEM > ALCT-CLCT
+    > CLCT-2GEM > ALCT-2GEM. The mask is passsed from one function to the next.
   */
   bool bunch_crossing_mask[CSCConstants::MAX_ALCT_TBINS] = {false};
 
-  // Step 4: ALCT-centric matching
-  matchALCTCLCTGEM(bunch_crossing_mask);
+  // Step 4: ALCT-CLCT-2GEM and ALCT-CLCT-1GEM matching
+  if (build_lct_from_alct_clct_2gem_ or build_lct_from_alct_clct_1gem_) {
+    matchALCTCLCTGEM(bunch_crossing_mask);
+  }
 
-  // Step 5: CLCT-2GEM matching for BX's that were not previously masked
+  // Step 5: regular ALCT-CLCT matching (always enabled)
+  CSCMotherboard::matchALCTCLCT(bunch_crossing_mask);
+
+  // Step 6: CLCT-2GEM matching for BX's that were not previously masked
   if (build_lct_from_clct_gem_) {
     matchCLCT2GEM(bunch_crossing_mask);
   }
 
-  // Step 6: ALCT-2GEM matching for BX's that were not previously masked
+  // Step 7: ALCT-2GEM matching for BX's that were not previously masked
   if (build_lct_from_alct_gem_) {
     matchALCT2GEM(bunch_crossing_mask);
   }
 
-  // Step 7: Select at most 2 LCTs per BX
+  // Step 8: Select at most 2 LCTs per BX
   selectLCTs();
 }
 
 void CSCGEMMotherboard::matchALCTCLCTGEM(bool bunch_crossing_mask[CSCConstants::MAX_ALCT_TBINS]) {
+  // no matching is done for GE2/1 geometries with 8 eta partitions
+  if (isME21_ and !hasGE21Geometry16Partitions_)
+    return;
+
+  // check if we can build LCTs with exclusively 1 GEM, exclusive 2 GEM,
+  // or inclusively 1 or 2 GEM hits
+  GEMClusterProcessor::ClusterTypes option = GEMClusterProcessor::AllClusters;
+  ;
+  if (!build_lct_from_alct_clct_2gem_)
+    option = GEMClusterProcessor::CoincidenceClusters;
+
   // array to mask CLCTs
   bool used_clct_mask[CSCConstants::MAX_CLCT_TBINS] = {false};
 
@@ -157,7 +174,7 @@ void CSCGEMMotherboard::matchALCTCLCTGEM(bool bunch_crossing_mask[CSCConstants::
                            alctProc->getSecondALCT(bx_alct),
                            clctProc->getBestCLCT(bx_clct),
                            clctProc->getSecondCLCT(bx_clct),
-                           clusterProc_->getClusters(bx_alct, max_delta_bx_alct_gem_),
+                           clusterProc_->getClusters(bx_alct, max_delta_bx_alct_gem_, option),
                            allLCTs_(bx_alct, mbx, 0),
                            allLCTs_(bx_alct, mbx, 1));
 
@@ -292,116 +309,102 @@ void CSCGEMMotherboard::correlateLCTsGEM(const CSCALCTDigi& bALCT,
                                          const GEMInternalClusters& clusters,
                                          CSCCorrelatedLCTDigi& lct1,
                                          CSCCorrelatedLCTDigi& lct2) const {
-  if (isME21_ and !hasGE21Geometry16Partitions_) {
-    // This is an 8-eta partition GE2/1 geometry for which the GE2/1-ME2/1 integrated
-    // local trigger is not configured. Matching only ALCTs with CLCTs in ME2/1.
+  // case where there no valid clusters
+  if (clusters.empty())
+    return;
 
-    // do regular ALCT-CLCT correlation
-    CSCMotherboard::correlateLCTs(bALCT, sALCT, bCLCT, sCLCT, lct1, lct2, CSCCorrelatedLCTDigi::ALCTCLCT);
-  } else {
-    // temporary container
-    std::vector<CSCCorrelatedLCTDigi> lcts;
+  // temporary container
+  std::vector<CSCCorrelatedLCTDigi> lcts;
 
-    CSCALCTDigi bestALCT = bALCT;
-    CSCALCTDigi secondALCT = sALCT;
-    CSCCLCTDigi bestCLCT = bCLCT;
-    CSCCLCTDigi secondCLCT = sCLCT;
+  CSCALCTDigi bestALCT = bALCT;
+  CSCALCTDigi secondALCT = sALCT;
+  CSCCLCTDigi bestCLCT = bCLCT;
+  CSCCLCTDigi secondCLCT = sCLCT;
 
-    if (!bestALCT.isValid()) {
-      edm::LogError("CSCGEMMotherboard") << "Best ALCT invalid in correlateLCTsGEM!";
-      return;
-    }
+  // Sanity checks on the ALCT and CLCT
+  if (!bestALCT.isValid()) {
+    edm::LogError("CSCGEMMotherboard") << "Best ALCT invalid in correlateLCTsGEM!";
+    return;
+  }
 
-    if (!bestCLCT.isValid()) {
-      edm::LogError("CSCGEMMotherboard") << "Best CLCT invalid in correlateLCTsGEM!";
-      return;
-    }
+  if (!bestCLCT.isValid()) {
+    edm::LogError("CSCGEMMotherboard") << "Best CLCT invalid in correlateLCTsGEM!";
+    return;
+  }
 
-    // case where there no valid clusters
-    if (clusters.empty()) {
-      // drop the low-quality ALCTs and CLCTs
-      dropLowQualityALCTNoClusters(bestALCT, GEMInternalCluster());
-      dropLowQualityALCTNoClusters(secondALCT, GEMInternalCluster());
-      dropLowQualityCLCTNoClusters(bestCLCT, GEMInternalCluster());
-      dropLowQualityCLCTNoClusters(secondCLCT, GEMInternalCluster());
+  // at this point, we have at least one valid cluster, and we're either dealing
+  // wit GE1/1 or GE2/1 with 16 partitions, both are OK for GEM-CSC trigger
 
-      // do regular ALCT-CLCT correlation
-      CSCMotherboard::correlateLCTs(bALCT, sALCT, bCLCT, sCLCT, lct1, lct2, CSCCorrelatedLCTDigi::ALCTCLCT);
-    }
-    // case with at least one valid cluster
-    else {
-      // before matching ALCT-CLCT pairs with clusters, we check if we need
-      // to drop particular low quality ALCTs or CLCTs without matching clusters
-      // drop low quality CLCTs if no clusters and flags are set
-      GEMInternalCluster bestALCTCluster, secondALCTCluster;
-      GEMInternalCluster bestCLCTCluster, secondCLCTCluster;
-      cscGEMMatcher_->bestClusterBXLoc(bestALCT, clusters, bestALCTCluster);
-      cscGEMMatcher_->bestClusterBXLoc(secondALCT, clusters, secondALCTCluster);
-      cscGEMMatcher_->bestClusterBXLoc(bestCLCT, clusters, bestCLCTCluster);
-      cscGEMMatcher_->bestClusterBXLoc(secondCLCT, clusters, secondCLCTCluster);
+  // before matching ALCT-CLCT pairs with clusters, we check if we need
+  // to drop particular low quality ALCTs or CLCTs without matching clusters
+  // drop low quality CLCTs if no clusters and flags are set
+  GEMInternalCluster bestALCTCluster, secondALCTCluster;
+  GEMInternalCluster bestCLCTCluster, secondCLCTCluster;
+  cscGEMMatcher_->bestClusterBXLoc(bestALCT, clusters, bestALCTCluster);
+  cscGEMMatcher_->bestClusterBXLoc(secondALCT, clusters, secondALCTCluster);
+  cscGEMMatcher_->bestClusterBXLoc(bestCLCT, clusters, bestCLCTCluster);
+  cscGEMMatcher_->bestClusterBXLoc(secondCLCT, clusters, secondCLCTCluster);
 
-      dropLowQualityALCTNoClusters(bestALCT, bestALCTCluster);
-      dropLowQualityALCTNoClusters(secondALCT, secondALCTCluster);
-      dropLowQualityCLCTNoClusters(bestCLCT, bestCLCTCluster);
-      dropLowQualityCLCTNoClusters(secondCLCT, secondCLCTCluster);
+  dropLowQualityALCTNoClusters(bestALCT, bestALCTCluster);
+  dropLowQualityALCTNoClusters(secondALCT, secondALCTCluster);
+  dropLowQualityCLCTNoClusters(bestCLCT, bestCLCTCluster);
+  dropLowQualityCLCTNoClusters(secondCLCT, secondCLCTCluster);
 
-      // check which ALCTs and CLCTs are valid after dropping the low-quality ones
-      copyValidToInValid(bestALCT, secondALCT, bestCLCT, secondCLCT);
+  // check which ALCTs and CLCTs are valid after dropping the low-quality ones
+  copyValidToInValid(bestALCT, secondALCT, bestCLCT, secondCLCT);
 
-      // We can now check possible triplets and construct all LCTs with
-      // valid ALCT, valid CLCTs and coincidence clusters
-      GEMInternalCluster bbCluster, bsCluster, sbCluster, ssCluster;
-      cscGEMMatcher_->bestClusterBXLoc(bestALCT, bestCLCT, clusters, bbCluster);
-      cscGEMMatcher_->bestClusterBXLoc(bestALCT, secondCLCT, clusters, bsCluster);
-      cscGEMMatcher_->bestClusterBXLoc(secondALCT, bestCLCT, clusters, sbCluster);
-      cscGEMMatcher_->bestClusterBXLoc(secondALCT, secondCLCT, clusters, ssCluster);
+  // We can now check possible triplets and construct all LCTs with
+  // valid ALCT, valid CLCTs and coincidence clusters
+  GEMInternalCluster bbCluster, bsCluster, sbCluster, ssCluster;
+  cscGEMMatcher_->bestClusterBXLoc(bestALCT, bestCLCT, clusters, bbCluster);
+  cscGEMMatcher_->bestClusterBXLoc(bestALCT, secondCLCT, clusters, bsCluster);
+  cscGEMMatcher_->bestClusterBXLoc(secondALCT, bestCLCT, clusters, sbCluster);
+  cscGEMMatcher_->bestClusterBXLoc(secondALCT, secondCLCT, clusters, ssCluster);
 
-      // At this point it is still possible that certain pairs with high-quality
-      // ALCTs and CLCTs do not have matching clusters. In that case we construct
-      // a regular ALCT-CLCT type LCT. For instance, it could be that two muons went
-      // through the chamber, produced 2 ALCTs, 2 CLCTs, but only 1 GEM cluster - because
-      // GEM cluster efficiency is not 100% (closer to 95%). So we don't require
-      // all clusters to be valid. If they are valid, the LCTs is constructed accordingly.
-      // But we do require that the ALCT and CLCT are valid for each pair.
-      CSCCorrelatedLCTDigi lctbb, lctbs, lctsb, lctss;
-      if (bestALCT.isValid() and bestCLCT.isValid()) {
-        constructLCTsGEM(bestALCT, bestCLCT, bbCluster, lctbb);
-        lcts.push_back(lctbb);
-      }
-      if (bestALCT.isValid() and secondCLCT.isValid() and (secondCLCT != bestCLCT)) {
-        constructLCTsGEM(bestALCT, secondCLCT, bsCluster, lctbs);
-        lcts.push_back(lctbs);
-      }
-      if (bestCLCT.isValid() and secondALCT.isValid() and (secondALCT != bestALCT)) {
-        constructLCTsGEM(secondALCT, bestCLCT, sbCluster, lctsb);
-        lcts.push_back(lctsb);
-      }
-      if (secondALCT.isValid() and secondCLCT.isValid() and (secondALCT != bestALCT) and (secondCLCT != bestCLCT)) {
-        constructLCTsGEM(secondALCT, secondCLCT, ssCluster, lctss);
-        lcts.push_back(lctss);
-      }
+  // At this point it is still possible that certain pairs with high-quality
+  // ALCTs and CLCTs do not have matching clusters. In that case we construct
+  // a regular ALCT-CLCT type LCT. For instance, it could be that two muons went
+  // through the chamber, produced 2 ALCTs, 2 CLCTs, but only 1 GEM cluster - because
+  // GEM cluster efficiency is not 100% (closer to 95%). So we don't require
+  // all clusters to be valid. If they are valid, the LCTs is constructed accordingly.
+  // But we do require that the ALCT and CLCT are valid for each pair.
+  CSCCorrelatedLCTDigi lctbb, lctbs, lctsb, lctss;
+  if (bestALCT.isValid() and bestCLCT.isValid()) {
+    constructLCTsGEM(bestALCT, bestCLCT, bbCluster, lctbb);
+    lcts.push_back(lctbb);
+  }
+  if (bestALCT.isValid() and secondCLCT.isValid() and (secondCLCT != bestCLCT)) {
+    constructLCTsGEM(bestALCT, secondCLCT, bsCluster, lctbs);
+    lcts.push_back(lctbs);
+  }
+  if (bestCLCT.isValid() and secondALCT.isValid() and (secondALCT != bestALCT)) {
+    constructLCTsGEM(secondALCT, bestCLCT, sbCluster, lctsb);
+    lcts.push_back(lctsb);
+  }
+  if (secondALCT.isValid() and secondCLCT.isValid() and (secondALCT != bestALCT) and (secondCLCT != bestCLCT)) {
+    constructLCTsGEM(secondALCT, secondCLCT, ssCluster, lctss);
+    lcts.push_back(lctss);
+  }
 
-      // no LCTs
-      if (lcts.empty())
-        return;
+  // no LCTs
+  if (lcts.empty())
+    return;
 
-      // sort by bending angle
-      sortLCTsByBending(lcts);
+  // sort by bending angle
+  sortLCTsByBending(lcts);
 
-      // retain best two
-      lcts.resize(CSCConstants::MAX_LCTS_PER_CSC);
+  // retain best two
+  lcts.resize(CSCConstants::MAX_LCTS_PER_CSC);
 
-      // assign and set the track number
-      if (lcts[0].isValid()) {
-        lct1 = lcts[0];
-        lct1.setTrknmb(1);
-      }
+  // assign the track number
+  if (lcts[0].isValid()) {
+    lct1 = lcts[0];
+    lct1.setTrknmb(1);
+  }
 
-      if (lcts[1].isValid()) {
-        lct2 = lcts[1];
-        lct2.setTrknmb(2);
-      }
-    }
+  if (lcts[1].isValid()) {
+    lct2 = lcts[1];
+    lct2.setTrknmb(2);
   }
 }
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
@@ -137,15 +137,15 @@ void CSCGEMMotherboard::run(const CSCWireDigiCollection* wiredc,
 
 void CSCGEMMotherboard::matchALCTCLCTGEM(bool bunch_crossing_mask[CSCConstants::MAX_ALCT_TBINS]) {
   // no matching is done for GE2/1 geometries with 8 eta partitions
+  // this has been superseded by 16-eta partition geometries
   if (isME21_ and !hasGE21Geometry16Partitions_)
     return;
 
-  // check if we can build LCTs with exclusively 1 GEM, exclusive 2 GEM,
-  // or inclusively 1 or 2 GEM hits
+  // by default we will try to match with both single clusters and coincidence clusters
+  // if we do not build ALCT-CLCT-2GEM type LCTs, consider only single clusters
   GEMClusterProcessor::ClusterTypes option = GEMClusterProcessor::AllClusters;
-  ;
   if (!build_lct_from_alct_clct_2gem_)
-    option = GEMClusterProcessor::CoincidenceClusters;
+    option = GEMClusterProcessor::SingleClusters;
 
   // array to mask CLCTs
   bool used_clct_mask[CSCConstants::MAX_CLCT_TBINS] = {false};
@@ -195,6 +195,7 @@ void CSCGEMMotherboard::matchALCTCLCTGEM(bool bunch_crossing_mask[CSCConstants::
 
 void CSCGEMMotherboard::matchCLCT2GEM(bool bunch_crossing_mask[CSCConstants::MAX_ALCT_TBINS]) {
   // no matching is done for GE2/1 geometries with 8 eta partitions
+  // this has been superseded by 16-eta partition geometries
   if (isME21_ and !hasGE21Geometry16Partitions_)
     return;
 
@@ -253,6 +254,7 @@ void CSCGEMMotherboard::matchCLCT2GEM(bool bunch_crossing_mask[CSCConstants::MAX
 
 void CSCGEMMotherboard::matchALCT2GEM(bool bunch_crossing_mask[CSCConstants::MAX_ALCT_TBINS]) {
   // no matching is done for GE2/1 geometries with 8 eta partitions
+  // this has been superseded by 16-eta partition geometries
   if (isME21_ and !hasGE21Geometry16Partitions_)
     return;
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -159,6 +159,17 @@ void CSCMotherboard::run(const CSCWireDigiCollection* wiredc, const CSCComparato
   if (alctV.empty() and clctV.empty())
     return;
 
+  // step 3: match the ALCTs to the CLCTs
+  // note that the bunch_crossing_mask is irrelevant for regular ALCT-CLCT
+  // matching
+  bool bunch_crossing_mask[CSCConstants::MAX_ALCT_TBINS] = {false};
+  matchALCTCLCT(bunch_crossing_mask);
+
+  // Step 4: Select at most 2 LCTs per BX
+  selectLCTs();
+}
+
+void CSCMotherboard::matchALCTCLCT(bool bunch_crossing_mask[CSCConstants::MAX_ALCT_TBINS]) {
   // array to mask CLCTs
   bool used_clct_mask[CSCConstants::MAX_CLCT_TBINS] = {false};
 
@@ -207,6 +218,8 @@ void CSCMotherboard::run(const CSCWireDigiCollection* wiredc, const CSCComparato
           if (allLCTs_(bx_alct, mbx, 0).isValid()) {
             is_matched = true;
             used_clct_mask[bx_clct] = true;
+            bunch_crossing_mask[bx_alct] = true;
+            bx_clct_matched = bx_clct;
             if (match_earliest_clct_only_)
               break;
           }
@@ -249,9 +262,6 @@ void CSCMotherboard::run(const CSCWireDigiCollection* wiredc, const CSCComparato
       }
     }
   }
-
-  // Step 4: Select at most 2 LCTs per BX
-  selectLCTs();
 }
 
 // Returns vector of read-out correlated LCTs, if any.  Starts with

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -207,6 +207,12 @@ void CSCMotherboard::matchALCTCLCT(bool bunch_crossing_mask[CSCConstants::MAX_AL
         // do not consider previously matched CLCTs
         if (drop_used_clcts && used_clct_mask[bx_clct])
           continue;
+        // only consider >=4 layer CLCTs for ALCT-CLCT type LCTs
+        // this condition is lowered to >=3 layers for CLCTs in the
+        // matchALCTCLCTGEM function
+        if (clctProc->getBestCLCT(bx_clct).getQuality() <= 3)
+          continue;
+        // a valid CLCT with sufficient layers!
         if (clctProc->getBestCLCT(bx_clct).isValid()) {
           if (infoV > 1)
             LogTrace("CSCMotherboard") << "Successful ALCT-CLCT match: bx_alct = " << bx_alct
@@ -381,7 +387,18 @@ void CSCMotherboard::correlateLCTs(const CSCALCTDigi& bALCT,
   CSCCLCTDigi bestCLCT = bCLCT;
   CSCCLCTDigi secondCLCT = sCLCT;
 
+  // extra check to make sure that both CLCTs have at least 4 layers
+  // for regular ALCT-CLCT type LCTs. A check was already done on the
+  // best CLCT, but not yet on the second best CLCT. The check on best
+  // CLCT is repeated for completeness
+  if (bestCLCT.getQuality() <= 3)
+    bestCLCT.clear();
+  if (secondCLCT.getQuality() <= 3)
+    secondCLCT.clear();
+
   // check which ALCTs and CLCTs are valid
+  // if the best ALCT/CLCT is valid, but the second ALCT/CLCT is not,
+  // the information is copied over
   copyValidToInValid(bestALCT, secondALCT, bestCLCT, secondCLCT);
 
   // ALCT-only LCTs

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -160,8 +160,6 @@ void CSCMotherboard::run(const CSCWireDigiCollection* wiredc, const CSCComparato
     return;
 
   // step 3: match the ALCTs to the CLCTs
-  // note that the bunch_crossing_mask is irrelevant for regular ALCT-CLCT
-  // matching
   bool bunch_crossing_mask[CSCConstants::MAX_ALCT_TBINS] = {false};
   matchALCTCLCT(bunch_crossing_mask);
 
@@ -176,6 +174,15 @@ void CSCMotherboard::matchALCTCLCT(bool bunch_crossing_mask[CSCConstants::MAX_AL
   // Step 3: ALCT-centric ALCT-to-CLCT matching
   int bx_clct_matched = 0;  // bx of last matched CLCT
   for (int bx_alct = 0; bx_alct < CSCConstants::MAX_ALCT_TBINS; bx_alct++) {
+
+    // do not consider LCT building in this BX if the mask was set
+    // this check should have no effect on the regular LCT finding
+    // it does play a role in the LCT finding for GEM-CSC ILTs
+    // namely, if a GEM-CSC ILT was found a bunch crossing, the
+    // algorithm would skip the bunch crossing for regular LCT finding
+    if (bunch_crossing_mask[bx_alct])
+      continue;
+
     // There should be at least one valid CLCT or ALCT for a
     // correlated LCT to be formed.  Decision on whether to reject
     // non-complete LCTs (and if yes of which type) is made further

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -174,7 +174,6 @@ void CSCMotherboard::matchALCTCLCT(bool bunch_crossing_mask[CSCConstants::MAX_AL
   // Step 3: ALCT-centric ALCT-to-CLCT matching
   int bx_clct_matched = 0;  // bx of last matched CLCT
   for (int bx_alct = 0; bx_alct < CSCConstants::MAX_ALCT_TBINS; bx_alct++) {
-
     // do not consider LCT building in this BX if the mask was set
     // this check should have no effect on the regular LCT finding
     // it does play a role in the LCT finding for GEM-CSC ILTs

--- a/L1Trigger/CSCTriggerPrimitives/src/GEMClusterProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/GEMClusterProcessor.cc
@@ -51,25 +51,18 @@ void GEMClusterProcessor::run(const GEMPadDigiClusterCollection* in_clusters) {
   doCoordinateConversion();
 }
 
-std::vector<GEMInternalCluster> GEMClusterProcessor::getClusters(int bx) const {
-  std::vector<GEMInternalCluster> output;
-
-  for (const auto& cl : clusters_) {
-    // valid single clusters with the right BX
-    if (cl.bx() == bx and cl.isValid()) {
-      output.push_back(cl);
-    }
-  }
-
-  return output;
-}
-
-std::vector<GEMInternalCluster> GEMClusterProcessor::getClusters(int bx, int deltaBX) const {
+std::vector<GEMInternalCluster> GEMClusterProcessor::getClusters(int bx, int deltaBX, ClusterTypes option) const {
   std::vector<GEMInternalCluster> output;
 
   for (const auto& cl : clusters_) {
     // valid single clusters with the right BX
     if (std::abs(cl.bx() - bx) <= deltaBX and cl.isValid()) {
+      // ignore the single clusters
+      if (option == SingleClusters and !cl.isCoincidence())
+        continue;
+      // ignore the coincidence clusters
+      if (option == CoincidenceClusters and cl.isCoincidence())
+        continue;
       output.push_back(cl);
     }
   }

--- a/L1Trigger/CSCTriggerPrimitives/src/GEMClusterProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/GEMClusterProcessor.cc
@@ -57,11 +57,11 @@ std::vector<GEMInternalCluster> GEMClusterProcessor::getClusters(int bx, int del
   for (const auto& cl : clusters_) {
     // valid single clusters with the right BX
     if (std::abs(cl.bx() - bx) <= deltaBX and cl.isValid()) {
-      // ignore the single clusters
-      if (option == SingleClusters and !cl.isCoincidence())
-        continue;
       // ignore the coincidence clusters
-      if (option == CoincidenceClusters and cl.isCoincidence())
+      if (option == SingleClusters and cl.isCoincidence())
+        continue;
+      // ignore the single clusters
+      if (option == CoincidenceClusters and !cl.isCoincidence())
         continue;
       output.push_back(cl);
     }

--- a/L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesAnalyzer.cc
+++ b/L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesAnalyzer.cc
@@ -20,6 +20,7 @@
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 
 #include "TH1F.h"
+#include "TH2F.h"
 #include "TPostScript.h"
 #include "TCanvas.h"
 #include "TFile.h"
@@ -56,6 +57,8 @@ private:
                 TString chamber,
                 TPostScript *ps,
                 TCanvas *c1) const;
+
+  void make2DPlot(TH2F *effMon, TPostScript *ps, TCanvas *c1) const;
 
   // plots of data vs emulator
   std::string rootFileName_;
@@ -203,6 +206,22 @@ void CSCTriggerPrimitivesAnalyzer::makeDataVsEmulatorPlots() {
     }
   }
 
+  if (!useB904_) {
+    TH2F *h_lctDataSummary_eff = (TH2F *)directory->Get("lct_csctp_data_summary_eff");
+    make2DPlot(h_lctDataSummary_eff, ps, c1);
+    TH2F *h_alctDataSummary_eff = (TH2F *)directory->Get("alct_csctp_data_summary_eff");
+    make2DPlot(h_alctDataSummary_eff, ps, c1);
+    TH2F *h_clctDataSummary_eff = (TH2F *)directory->Get("clct_csctp_data_summary_eff");
+    make2DPlot(h_clctDataSummary_eff, ps, c1);
+
+    TH2F *h_lctEmulSummary_eff = (TH2F *)directory->Get("lct_csctp_emul_summary_eff");
+    make2DPlot(h_lctEmulSummary_eff, ps, c1);
+    TH2F *h_alctEmulSummary_eff = (TH2F *)directory->Get("alct_csctp_emul_summary_eff");
+    make2DPlot(h_alctEmulSummary_eff, ps, c1);
+    TH2F *h_clctEmulSummary_eff = (TH2F *)directory->Get("clct_csctp_emul_summary_eff");
+    make2DPlot(h_clctEmulSummary_eff, ps, c1);
+  }
+
   ps->Close();
   // close the DQM file
   theFile->Close();
@@ -262,6 +281,18 @@ void CSCTriggerPrimitivesAnalyzer::makePlot(TH1F *dataMon,
   diffMon->GetXaxis()->SetTitleSize(0.05);
   diffMon->GetYaxis()->SetTitleSize(0.05);
   diffMon->Draw("ep");
+  c1->Update();
+}
+
+void CSCTriggerPrimitivesAnalyzer::make2DPlot(TH2F *effMon, TPostScript *ps, TCanvas *c1) const {
+  ps->NewPage();
+
+  TString runTitle = "(CMS Run " + std::to_string(runNumber_) + ")";
+  if (useB904_)
+    runTitle = "(B904 Cosmic Run " + TString(B904RunNumber_) + ")";
+  gStyle->SetOptStat(0);
+  effMon->SetTitle(effMon->GetTitle() + runTitle);
+  effMon->Draw("colz");
   c1->Update();
 }
 

--- a/L1Trigger/CSCTriggerPrimitives/test/runCSCTriggerPrimitiveProducer_cfg.py
+++ b/L1Trigger/CSCTriggerPrimitives/test/runCSCTriggerPrimitiveProducer_cfg.py
@@ -120,7 +120,7 @@ if useB904Data:
 ## l1 emulator
 l1csc = process.cscTriggerPrimitiveDigis
 if options.l1:
-      l1csc.commonParam.runCCLUT = options.runCCLUT
+      l1csc.commonParam.runCCLUT = cms.bool(options.runCCLUT)
       l1csc.commonParam.runCCLUT_OTMB = cms.bool(options.runCCLUTOTMB)
       l1csc.commonParam.runCCLUT_TMB = cms.bool(options.runCCLUTTMB)
       l1csc.commonParam.runME11ILT = options.runME11ILT

--- a/L1Trigger/CSCTriggerPrimitives/test/runCSCTriggerPrimitiveProducer_cfg.py
+++ b/L1Trigger/CSCTriggerPrimitives/test/runCSCTriggerPrimitiveProducer_cfg.py
@@ -28,8 +28,6 @@ options.register("useB904ME234s2", False, VarParsing.multiplicity.singleton, Var
                  "Set to True when using B904 ME1/1 data (also works for MEX/2 and ME1/3).")
 options.register("run3", True, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
                  "Set to True when using Run-3 data.")
-options.register("runCCLUT", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
-                 "Set to True when using the CCLUT algorithm (to be superseded soon).")
 options.register("runCCLUTOTMB", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
                  "Set to True when using the CCLUT OTMB algorithm.")
 options.register("runCCLUTTMB", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
@@ -120,7 +118,6 @@ if useB904Data:
 ## l1 emulator
 l1csc = process.cscTriggerPrimitiveDigis
 if options.l1:
-      l1csc.commonParam.runCCLUT = cms.bool(options.runCCLUT)
       l1csc.commonParam.runCCLUT_OTMB = cms.bool(options.runCCLUTOTMB)
       l1csc.commonParam.runCCLUT_TMB = cms.bool(options.runCCLUTTMB)
       l1csc.commonParam.runME11ILT = options.runME11ILT


### PR DESCRIPTION
#### PR description:

In this PR I put the ALCT-CLCT matching in a separate function `matchALCTCLCT`, so it can be reused in the CSCGEMMotherboard class. Reason is that the CSCGEMMotherboard builds LCTs in Run-3 according to the following priority: (1) ALCT-CLCT-2GEM (2) ALCT-CLCT-1GEM (3) ALCT-CLCT (4) CLCT-2GEM (5) ALCT-2GEM. Previously step (3) was taken together with (1) and (2), but they should be independent. This is because all options except (3) can be switched off. (3) is always on.

#### PR validation:

Tested with Run-3 single muon guns.

Also tested on 26k events of 2018D ZeroBias. 
[CSC_dataVsEmul_CMS_Run_322022_PR36046.pdf](https://github.com/cms-sw/cmssw/files/7622382/CSC_dataVsEmul_CMS_Run_322022_PR36046.pdf)

The instructions are: 
```
cmsRun L1Trigger/CSCTriggerPrimitives/test/runCSCTriggerPrimitiveProducer_cfg.py l1=True mc=False maxEvents=10000 \
run3=False dqm=True unpack=True \
inputFiles=file:A82FA3CF-86AD-E811-B097-FA163E0F0F4B.root,file:C69DD8C2-86AD-E811-BE39-FA163E8EFCB8.root,file:F87A285E-87AD-E811-89A7-FA163E0481A2.root,file:18B49402-90AE-E811-972C-FA163E3D0B36.root \
selectCSCs=True

cmsRun L1Trigger/CSCTriggerPrimitives/test/runCSCL1TDQMClient_cfg.py mc=False run3=False

RunNumberLabel="322022";
cmsRun L1Trigger/CSCTriggerPrimitives/test/runCSCTriggerPrimitiveAnalyzer_cfg.py \
dataVsEmulation=True dataVsEmulationFile="file:DQM_V0001_R000322022__Global__CMSSW_X_Y_Z__RECO.root" runNumber=$RunNumberLabel
```
where the 4 ROOT files are 2018D EDM RAW data files from the ZeroBias dataset.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

@tahuang1991 @giovanni-mocellin @rathjd
