### PR TITLE
technical fix for `PixelJetPuId`

### DIFF
--- a/HLTrigger/JetMET/plugins/PixelJetPuId.cc
+++ b/HLTrigger/JetMET/plugins/PixelJetPuId.cc
@@ -20,6 +20,7 @@ Implementation:
 
 // system include files
 #include <memory>
+#include <algorithm>
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -149,13 +150,13 @@ void PixelJetPuId::produce(edm::StreamID sid, edm::Event& iEvent, const edm::Eve
   //get tracks
   Handle<std::vector<reco::Track> > tracks;
   iEvent.getByToken(tracksToken, tracks);
-  unsigned int tsize = tracks->size();
-  float teta[tsize], tphi[tsize];
-  unsigned int i = 0;
+  uint const asize = std::max(1u, (uint)tracks->size());
+  float teta[asize], tphi[asize];
+  uint tsize = 0;
   for (auto const& tr : *tracks) {
-    teta[i] = tr.eta();
-    tphi[i] = tr.phi();
-    ++i;
+    teta[tsize] = tr.eta();
+    tphi[tsize] = tr.phi();
+    ++tsize;
   }
 
   //get jets


### PR DESCRIPTION
#### PR description:

This PR fixes an UBSAN-IB error from the HLT module `PixelJetPuId`, as reported in #35008.

This update is merely technical [*]. No changes in outputs are expected.

[*] Now, if `tracks.size()==0`, the two arrays are created with `size=1` (not `0`), but are still not used.

#### PR validation:

Verified that the update solves the original error, using a recent UBSAN IB.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

N/A