### PR TITLE
ECAL PoolDBOutput code migration

### DIFF
--- a/CalibCalorimetry/EcalTPGTools/plugins/EcalTPGDBCopy.cc
+++ b/CalibCalorimetry/EcalTPGTools/plugins/EcalTPGDBCopy.cc
@@ -148,99 +148,80 @@ void EcalTPGDBCopy::copyToDB(const edm::EventSetup& evtSetup, const std::string&
   std::string recordName = m_records[container];
 
   if (container == "EcalTPGPedestals") {
-    const auto handle = evtSetup.getHandle(pedestalsToken_);
-    const EcalTPGPedestals* obj = handle.product();
-    dbOutput->createOneIOV<const EcalTPGPedestals>(*obj, dbOutput->beginOfTime(), recordName);
+    const auto& obj = evtSetup.getData(pedestalsToken_);
+    dbOutput->createOneIOV<const EcalTPGPedestals>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGLinearizationConst") {
-    const auto handle = evtSetup.getHandle(linearizationConstToken_);
-    const EcalTPGLinearizationConst* obj = handle.product();
-    dbOutput->createOneIOV<const EcalTPGLinearizationConst>(*obj, dbOutput->beginOfTime(), recordName);
+    const auto& obj = evtSetup.getData(linearizationConstToken_);
+    dbOutput->createOneIOV<const EcalTPGLinearizationConst>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGSlidingWindow") {
-    const auto handle = evtSetup.getHandle(slidingWindowToken_);
-    const EcalTPGSlidingWindow* obj = handle.product();
-    dbOutput->createOneIOV<const EcalTPGSlidingWindow>(*obj, dbOutput->beginOfTime(), recordName);
+    const auto& obj = evtSetup.getData(slidingWindowToken_);
+    dbOutput->createOneIOV<const EcalTPGSlidingWindow>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGFineGrainEBIdMap") {
-    const auto handle = evtSetup.getHandle(fineGrainEBIdMapToken_);
-    const EcalTPGFineGrainEBIdMap* obj = handle.product();
-    dbOutput->createOneIOV<const EcalTPGFineGrainEBIdMap>(*obj, dbOutput->beginOfTime(), recordName);
+    const auto& obj = evtSetup.getData(fineGrainEBIdMapToken_);
+    dbOutput->createOneIOV<const EcalTPGFineGrainEBIdMap>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGFineGrainStripEE") {
-    const auto handle = evtSetup.getHandle(fineGrainStripEEToken_);
-    const EcalTPGFineGrainStripEE* obj = handle.product();
-    dbOutput->createOneIOV<const EcalTPGFineGrainStripEE>(*obj, dbOutput->beginOfTime(), recordName);
+    const auto& obj = evtSetup.getData(fineGrainStripEEToken_);
+    dbOutput->createOneIOV<const EcalTPGFineGrainStripEE>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGFineGrainTowerEE") {
-    const auto handle = evtSetup.getHandle(fineGrainTowerEEToken_);
-    const EcalTPGFineGrainTowerEE* obj = handle.product();
-    dbOutput->createOneIOV<const EcalTPGFineGrainTowerEE>(*obj, dbOutput->beginOfTime(), recordName);
+    const auto& obj = evtSetup.getData(fineGrainTowerEEToken_);
+    dbOutput->createOneIOV<const EcalTPGFineGrainTowerEE>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGLutIdMap") {
-    const auto handle = evtSetup.getHandle(lutIdMapToken_);
-    const EcalTPGLutIdMap* obj = handle.product();
-    dbOutput->createOneIOV<const EcalTPGLutIdMap>(*obj, dbOutput->beginOfTime(), recordName);
+    const auto& obj = evtSetup.getData(lutIdMapToken_);
+    dbOutput->createOneIOV<const EcalTPGLutIdMap>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGWeightIdMap") {
-    const auto handle = evtSetup.getHandle(weightIdMapToken_);
-    const EcalTPGWeightIdMap* obj = handle.product();
-    dbOutput->createOneIOV<const EcalTPGWeightIdMap>(*obj, dbOutput->beginOfTime(), recordName);
+    const auto& obj = evtSetup.getData(weightIdMapToken_);
+    dbOutput->createOneIOV<const EcalTPGWeightIdMap>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGWeightGroup") {
-    const auto handle = evtSetup.getHandle(weightGroupToken_);
-    const EcalTPGWeightGroup* obj = handle.product();
-    dbOutput->createOneIOV<const EcalTPGWeightGroup>(*obj, dbOutput->beginOfTime(), recordName);
+    const auto& obj = evtSetup.getData(weightGroupToken_);
+    dbOutput->createOneIOV<const EcalTPGWeightGroup>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGOddWeightIdMap") {
-    const auto handle = evtSetup.getHandle(oddWeightIdMapToken_);
-    const EcalTPGOddWeightIdMap* obj = handle.product();
-    dbOutput->createOneIOV<const EcalTPGOddWeightIdMap>(*obj, dbOutput->beginOfTime(), recordName);
+    const auto& obj = evtSetup.getData(oddWeightIdMapToken_);
+    dbOutput->createOneIOV<const EcalTPGOddWeightIdMap>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGOddWeightGroup") {
-    const auto handle = evtSetup.getHandle(oddWeightGroupToken_);
-    const EcalTPGOddWeightGroup* obj = handle.product();
-    dbOutput->createOneIOV<const EcalTPGOddWeightGroup>(*obj, dbOutput->beginOfTime(), recordName);
+    const auto& obj = evtSetup.getData(oddWeightGroupToken_);
+    dbOutput->createOneIOV<const EcalTPGOddWeightGroup>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGTPMode") {
-    const auto handle = evtSetup.getHandle(tpModeToken_);
-    const EcalTPGTPMode* obj = handle.product();
-    dbOutput->createOneIOV<const EcalTPGTPMode>(*obj, dbOutput->beginOfTime(), recordName);
+    const auto& obj = evtSetup.getData(tpModeToken_);
+    dbOutput->createOneIOV<const EcalTPGTPMode>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGLutGroup") {
-    const auto handle = evtSetup.getHandle(lutGroupToken_);
-    const EcalTPGLutGroup* obj = handle.product();
-    dbOutput->createOneIOV<const EcalTPGLutGroup>(*obj, dbOutput->beginOfTime(), recordName);
+    const auto& obj = evtSetup.getData(lutGroupToken_);
+    dbOutput->createOneIOV<const EcalTPGLutGroup>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGFineGrainEBGroup") {
-    const auto handle = evtSetup.getHandle(fineGrainEBGroupToken_);
-    const EcalTPGFineGrainEBGroup* obj = handle.product();
-    dbOutput->createOneIOV<const EcalTPGFineGrainEBGroup>(*obj, dbOutput->beginOfTime(), recordName);
+    const auto& obj = evtSetup.getData(fineGrainEBGroupToken_);
+    dbOutput->createOneIOV<const EcalTPGFineGrainEBGroup>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGPhysicsConst") {
-    const auto handle = evtSetup.getHandle(physicsConstToken_);
-    const EcalTPGPhysicsConst* obj = handle.product();
-    dbOutput->createOneIOV<const EcalTPGPhysicsConst>(*obj, dbOutput->beginOfTime(), recordName);
+    const auto& obj = evtSetup.getData(physicsConstToken_);
+    dbOutput->createOneIOV<const EcalTPGPhysicsConst>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGCrystalStatus") {
-    const auto handle = evtSetup.getHandle(crystalStatusToken_);
-    const EcalTPGCrystalStatus* obj = handle.product();
-    dbOutput->createOneIOV<const EcalTPGCrystalStatus>(*obj, dbOutput->beginOfTime(), recordName);
+    const auto& obj = evtSetup.getData(crystalStatusToken_);
+    dbOutput->createOneIOV<const EcalTPGCrystalStatus>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGTowerStatus") {
-    const auto handle = evtSetup.getHandle(towerStatusToken_);
-    const EcalTPGTowerStatus* obj = handle.product();
-    dbOutput->createOneIOV<const EcalTPGTowerStatus>(*obj, dbOutput->beginOfTime(), recordName);
+    const auto& obj = evtSetup.getData(towerStatusToken_);
+    dbOutput->createOneIOV<const EcalTPGTowerStatus>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGSpike") {
-    const auto handle = evtSetup.getHandle(spikeToken_);
-    const EcalTPGSpike* obj = handle.product();
-    dbOutput->createOneIOV<const EcalTPGSpike>(*obj, dbOutput->beginOfTime(), recordName);
+    const auto& obj = evtSetup.getData(spikeToken_);
+    dbOutput->createOneIOV<const EcalTPGSpike>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGStripStatus") {
-    const auto handle = evtSetup.getHandle(stripStatusToken_);
-    const EcalTPGStripStatus* obj = handle.product();
-    dbOutput->createOneIOV<const EcalTPGStripStatus>(*obj, dbOutput->beginOfTime(), recordName);
+    const auto& obj = evtSetup.getData(stripStatusToken_);
+    dbOutput->createOneIOV<const EcalTPGStripStatus>(obj, dbOutput->beginOfTime(), recordName);
 
   } else {
     throw cms::Exception("Unknown container");

--- a/CalibCalorimetry/EcalTPGTools/plugins/EcalTPGDBCopy.cc
+++ b/CalibCalorimetry/EcalTPGTools/plugins/EcalTPGDBCopy.cc
@@ -150,117 +150,116 @@ void EcalTPGDBCopy::copyToDB(const edm::EventSetup& evtSetup, const std::string&
   if (container == "EcalTPGPedestals") {
     const auto handle = evtSetup.getHandle(pedestalsToken_);
     const EcalTPGPedestals* obj = handle.product();
-    dbOutput->createNewIOV<const EcalTPGPedestals>(
-        new EcalTPGPedestals(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTPGPedestals>(
+        *obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGLinearizationConst") {
     const auto handle = evtSetup.getHandle(linearizationConstToken_);
     const EcalTPGLinearizationConst* obj = handle.product();
-    dbOutput->createNewIOV<const EcalTPGLinearizationConst>(
-        new EcalTPGLinearizationConst(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTPGLinearizationConst>(
+        *obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGSlidingWindow") {
     const auto handle = evtSetup.getHandle(slidingWindowToken_);
     const EcalTPGSlidingWindow* obj = handle.product();
-    dbOutput->createNewIOV<const EcalTPGSlidingWindow>(
-        new EcalTPGSlidingWindow(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTPGSlidingWindow>(
+        *obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGFineGrainEBIdMap") {
     const auto handle = evtSetup.getHandle(fineGrainEBIdMapToken_);
     const EcalTPGFineGrainEBIdMap* obj = handle.product();
-    dbOutput->createNewIOV<const EcalTPGFineGrainEBIdMap>(
-        new EcalTPGFineGrainEBIdMap(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTPGFineGrainEBIdMap>(
+        *obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGFineGrainStripEE") {
     const auto handle = evtSetup.getHandle(fineGrainStripEEToken_);
     const EcalTPGFineGrainStripEE* obj = handle.product();
-    dbOutput->createNewIOV<const EcalTPGFineGrainStripEE>(
-        new EcalTPGFineGrainStripEE(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTPGFineGrainStripEE>(
+        *obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGFineGrainTowerEE") {
     const auto handle = evtSetup.getHandle(fineGrainTowerEEToken_);
     const EcalTPGFineGrainTowerEE* obj = handle.product();
-    dbOutput->createNewIOV<const EcalTPGFineGrainTowerEE>(
-        new EcalTPGFineGrainTowerEE(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTPGFineGrainTowerEE>(
+        *obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGLutIdMap") {
     const auto handle = evtSetup.getHandle(lutIdMapToken_);
     const EcalTPGLutIdMap* obj = handle.product();
-    dbOutput->createNewIOV<const EcalTPGLutIdMap>(
-        new EcalTPGLutIdMap(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTPGLutIdMap>(
+        *obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGWeightIdMap") {
     const auto handle = evtSetup.getHandle(weightIdMapToken_);
     const EcalTPGWeightIdMap* obj = handle.product();
-    dbOutput->createNewIOV<const EcalTPGWeightIdMap>(
-        new EcalTPGWeightIdMap(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTPGWeightIdMap>(
+        *obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGWeightGroup") {
     const auto handle = evtSetup.getHandle(weightGroupToken_);
     const EcalTPGWeightGroup* obj = handle.product();
-    dbOutput->createNewIOV<const EcalTPGWeightGroup>(
-        new EcalTPGWeightGroup(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTPGWeightGroup>(
+        *obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGOddWeightIdMap") {
     const auto handle = evtSetup.getHandle(oddWeightIdMapToken_);
     const EcalTPGOddWeightIdMap* obj = handle.product();
-    dbOutput->createNewIOV<const EcalTPGOddWeightIdMap>(
-        new EcalTPGOddWeightIdMap(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTPGOddWeightIdMap>(
+        *obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGOddWeightGroup") {
     const auto handle = evtSetup.getHandle(oddWeightGroupToken_);
     const EcalTPGOddWeightGroup* obj = handle.product();
-    dbOutput->createNewIOV<const EcalTPGOddWeightGroup>(
-        new EcalTPGOddWeightGroup(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTPGOddWeightGroup>(
+        *obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGTPMode") {
     const auto handle = evtSetup.getHandle(tpModeToken_);
     const EcalTPGTPMode* obj = handle.product();
-    dbOutput->createNewIOV<const EcalTPGTPMode>(
-        new EcalTPGTPMode(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTPGTPMode>(
+        *obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGLutGroup") {
     const auto handle = evtSetup.getHandle(lutGroupToken_);
     const EcalTPGLutGroup* obj = handle.product();
-    dbOutput->createNewIOV<const EcalTPGLutGroup>(
-        new EcalTPGLutGroup(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTPGLutGroup>(
+        *obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGFineGrainEBGroup") {
     const auto handle = evtSetup.getHandle(fineGrainEBGroupToken_);
     const EcalTPGFineGrainEBGroup* obj = handle.product();
-    dbOutput->createNewIOV<const EcalTPGFineGrainEBGroup>(
-        new EcalTPGFineGrainEBGroup(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTPGFineGrainEBGroup>(
+        *obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGPhysicsConst") {
     const auto handle = evtSetup.getHandle(physicsConstToken_);
     const EcalTPGPhysicsConst* obj = handle.product();
-    dbOutput->createNewIOV<const EcalTPGPhysicsConst>(
-        new EcalTPGPhysicsConst(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTPGPhysicsConst>(
+        *obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGCrystalStatus") {
     const auto handle = evtSetup.getHandle(crystalStatusToken_);
     const EcalTPGCrystalStatus* obj = handle.product();
-    dbOutput->createNewIOV<const EcalTPGCrystalStatus>(
-        new EcalTPGCrystalStatus(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTPGCrystalStatus>(
+        *obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGTowerStatus") {
     const auto handle = evtSetup.getHandle(towerStatusToken_);
     const EcalTPGTowerStatus* obj = handle.product();
-    dbOutput->createNewIOV<const EcalTPGTowerStatus>(
-        new EcalTPGTowerStatus(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTPGTowerStatus>(
+        *obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGSpike") {
     const auto handle = evtSetup.getHandle(spikeToken_);
     const EcalTPGSpike* obj = handle.product();
-
-    dbOutput->createNewIOV<const EcalTPGSpike>(
-        new EcalTPGSpike(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTPGSpike>(
+        *obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGStripStatus") {
     const auto handle = evtSetup.getHandle(stripStatusToken_);
     const EcalTPGStripStatus* obj = handle.product();
-    dbOutput->createNewIOV<const EcalTPGStripStatus>(
-        new EcalTPGStripStatus(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTPGStripStatus>(
+        *obj, dbOutput->beginOfTime(), recordName);
 
   } else {
     throw cms::Exception("Unknown container");

--- a/CalibCalorimetry/EcalTPGTools/plugins/EcalTPGDBCopy.cc
+++ b/CalibCalorimetry/EcalTPGTools/plugins/EcalTPGDBCopy.cc
@@ -150,116 +150,97 @@ void EcalTPGDBCopy::copyToDB(const edm::EventSetup& evtSetup, const std::string&
   if (container == "EcalTPGPedestals") {
     const auto handle = evtSetup.getHandle(pedestalsToken_);
     const EcalTPGPedestals* obj = handle.product();
-    dbOutput->createOneIOV<const EcalTPGPedestals>(
-        *obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTPGPedestals>(*obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGLinearizationConst") {
     const auto handle = evtSetup.getHandle(linearizationConstToken_);
     const EcalTPGLinearizationConst* obj = handle.product();
-    dbOutput->createOneIOV<const EcalTPGLinearizationConst>(
-        *obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTPGLinearizationConst>(*obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGSlidingWindow") {
     const auto handle = evtSetup.getHandle(slidingWindowToken_);
     const EcalTPGSlidingWindow* obj = handle.product();
-    dbOutput->createOneIOV<const EcalTPGSlidingWindow>(
-        *obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTPGSlidingWindow>(*obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGFineGrainEBIdMap") {
     const auto handle = evtSetup.getHandle(fineGrainEBIdMapToken_);
     const EcalTPGFineGrainEBIdMap* obj = handle.product();
-    dbOutput->createOneIOV<const EcalTPGFineGrainEBIdMap>(
-        *obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTPGFineGrainEBIdMap>(*obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGFineGrainStripEE") {
     const auto handle = evtSetup.getHandle(fineGrainStripEEToken_);
     const EcalTPGFineGrainStripEE* obj = handle.product();
-    dbOutput->createOneIOV<const EcalTPGFineGrainStripEE>(
-        *obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTPGFineGrainStripEE>(*obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGFineGrainTowerEE") {
     const auto handle = evtSetup.getHandle(fineGrainTowerEEToken_);
     const EcalTPGFineGrainTowerEE* obj = handle.product();
-    dbOutput->createOneIOV<const EcalTPGFineGrainTowerEE>(
-        *obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTPGFineGrainTowerEE>(*obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGLutIdMap") {
     const auto handle = evtSetup.getHandle(lutIdMapToken_);
     const EcalTPGLutIdMap* obj = handle.product();
-    dbOutput->createOneIOV<const EcalTPGLutIdMap>(
-        *obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTPGLutIdMap>(*obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGWeightIdMap") {
     const auto handle = evtSetup.getHandle(weightIdMapToken_);
     const EcalTPGWeightIdMap* obj = handle.product();
-    dbOutput->createOneIOV<const EcalTPGWeightIdMap>(
-        *obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTPGWeightIdMap>(*obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGWeightGroup") {
     const auto handle = evtSetup.getHandle(weightGroupToken_);
     const EcalTPGWeightGroup* obj = handle.product();
-    dbOutput->createOneIOV<const EcalTPGWeightGroup>(
-        *obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTPGWeightGroup>(*obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGOddWeightIdMap") {
     const auto handle = evtSetup.getHandle(oddWeightIdMapToken_);
     const EcalTPGOddWeightIdMap* obj = handle.product();
-    dbOutput->createOneIOV<const EcalTPGOddWeightIdMap>(
-        *obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTPGOddWeightIdMap>(*obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGOddWeightGroup") {
     const auto handle = evtSetup.getHandle(oddWeightGroupToken_);
     const EcalTPGOddWeightGroup* obj = handle.product();
-    dbOutput->createOneIOV<const EcalTPGOddWeightGroup>(
-        *obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTPGOddWeightGroup>(*obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGTPMode") {
     const auto handle = evtSetup.getHandle(tpModeToken_);
     const EcalTPGTPMode* obj = handle.product();
-    dbOutput->createOneIOV<const EcalTPGTPMode>(
-        *obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTPGTPMode>(*obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGLutGroup") {
     const auto handle = evtSetup.getHandle(lutGroupToken_);
     const EcalTPGLutGroup* obj = handle.product();
-    dbOutput->createOneIOV<const EcalTPGLutGroup>(
-        *obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTPGLutGroup>(*obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGFineGrainEBGroup") {
     const auto handle = evtSetup.getHandle(fineGrainEBGroupToken_);
     const EcalTPGFineGrainEBGroup* obj = handle.product();
-    dbOutput->createOneIOV<const EcalTPGFineGrainEBGroup>(
-        *obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTPGFineGrainEBGroup>(*obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGPhysicsConst") {
     const auto handle = evtSetup.getHandle(physicsConstToken_);
     const EcalTPGPhysicsConst* obj = handle.product();
-    dbOutput->createOneIOV<const EcalTPGPhysicsConst>(
-        *obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTPGPhysicsConst>(*obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGCrystalStatus") {
     const auto handle = evtSetup.getHandle(crystalStatusToken_);
     const EcalTPGCrystalStatus* obj = handle.product();
-    dbOutput->createOneIOV<const EcalTPGCrystalStatus>(
-        *obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTPGCrystalStatus>(*obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGTowerStatus") {
     const auto handle = evtSetup.getHandle(towerStatusToken_);
     const EcalTPGTowerStatus* obj = handle.product();
-    dbOutput->createOneIOV<const EcalTPGTowerStatus>(
-        *obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTPGTowerStatus>(*obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGSpike") {
     const auto handle = evtSetup.getHandle(spikeToken_);
     const EcalTPGSpike* obj = handle.product();
-    dbOutput->createOneIOV<const EcalTPGSpike>(
-        *obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTPGSpike>(*obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGStripStatus") {
     const auto handle = evtSetup.getHandle(stripStatusToken_);
     const EcalTPGStripStatus* obj = handle.product();
-    dbOutput->createOneIOV<const EcalTPGStripStatus>(
-        *obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTPGStripStatus>(*obj, dbOutput->beginOfTime(), recordName);
 
   } else {
     throw cms::Exception("Unknown container");

--- a/CondFormats/EcalObjects/test/stubs/EcalTimeBiasCorrectionsFillInitial.cc
+++ b/CondFormats/EcalObjects/test/stubs/EcalTimeBiasCorrectionsFillInitial.cc
@@ -12,7 +12,7 @@
 
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESProducts.h"
 
 #include "CondFormats/EcalObjects/interface/EcalTimeBiasCorrections.h"
@@ -27,7 +27,7 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 
-class EcalTimeBiasCorrectionsFillInitial : public edm::EDAnalyzer {
+class EcalTimeBiasCorrectionsFillInitial : public edm::one::EDAnalyzer<> {
 public:
   explicit EcalTimeBiasCorrectionsFillInitial(const edm::ParameterSet &);
   ~EcalTimeBiasCorrectionsFillInitial();
@@ -41,7 +41,7 @@ private:
   std::vector<double> EEtimeCorrAmplitudeBins_;
   std::vector<double> EEtimeCorrShiftBins_;
 
-  EcalTimeBiasCorrections *bias_;
+  EcalTimeBiasCorrections bias_;
 };
 
 EcalTimeBiasCorrectionsFillInitial::EcalTimeBiasCorrectionsFillInitial(const edm::ParameterSet &ps) {
@@ -60,15 +60,13 @@ EcalTimeBiasCorrectionsFillInitial::EcalTimeBiasCorrectionsFillInitial(const edm
                                         "different from EEtimeCorrShiftBins.";
   }
 
-  bias_ = new EcalTimeBiasCorrections();
+  copy(EBtimeCorrAmplitudeBins_.begin(), EBtimeCorrAmplitudeBins_.end(), back_inserter(bias_.EBTimeCorrAmplitudeBins));
 
-  copy(EBtimeCorrAmplitudeBins_.begin(), EBtimeCorrAmplitudeBins_.end(), back_inserter(bias_->EBTimeCorrAmplitudeBins));
+  copy(EBtimeCorrShiftBins_.begin(), EBtimeCorrShiftBins_.end(), back_inserter(bias_.EBTimeCorrShiftBins));
 
-  copy(EBtimeCorrShiftBins_.begin(), EBtimeCorrShiftBins_.end(), back_inserter(bias_->EBTimeCorrShiftBins));
+  copy(EEtimeCorrAmplitudeBins_.begin(), EEtimeCorrAmplitudeBins_.end(), back_inserter(bias_.EETimeCorrAmplitudeBins));
 
-  copy(EEtimeCorrAmplitudeBins_.begin(), EEtimeCorrAmplitudeBins_.end(), back_inserter(bias_->EETimeCorrAmplitudeBins));
-
-  copy(EEtimeCorrShiftBins_.begin(), EEtimeCorrShiftBins_.end(), back_inserter(bias_->EETimeCorrShiftBins));
+  copy(EEtimeCorrShiftBins_.begin(), EEtimeCorrShiftBins_.end(), back_inserter(bias_.EETimeCorrShiftBins));
 }
 
 EcalTimeBiasCorrectionsFillInitial::~EcalTimeBiasCorrectionsFillInitial() {}
@@ -77,7 +75,7 @@ void EcalTimeBiasCorrectionsFillInitial::analyze(const edm::Event &iEvent, const
 void EcalTimeBiasCorrectionsFillInitial::endJob() {
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
   if (poolDbService.isAvailable()) {
-    poolDbService->writeOne(this->bias_, poolDbService->beginOfTime(), "EcalTimeBiasCorrectionsRcd");
+    poolDbService->writeOneIOV(bias_, poolDbService->beginOfTime(), "EcalTimeBiasCorrectionsRcd");
   }
 }
 

--- a/CondTools/Ecal/interface/EcalTestDevDB.h
+++ b/CondTools/Ecal/interface/EcalTestDevDB.h
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <map>
+#include <memory>
 
 namespace edm {
   class ParameterSet;
@@ -44,16 +45,16 @@ public:
 
   void analyze(const edm::Event& evt, const edm::EventSetup& evtSetup) override;
 
-  EcalPedestals* generateEcalPedestals();
-  EcalADCToGeVConstant* generateEcalADCToGeVConstant();
-  EcalIntercalibConstants* generateEcalIntercalibConstants();
-  EcalLinearCorrections* generateEcalLinearCorrections();
-  EcalGainRatios* generateEcalGainRatios();
-  EcalWeightXtalGroups* generateEcalWeightXtalGroups();
-  EcalTBWeights* generateEcalTBWeights();
-  EcalLaserAPDPNRatios* generateEcalLaserAPDPNRatios(uint32_t i_run);
-  EcalLaserAlphas* generateEcalLaserAlphas();
-  EcalLaserAPDPNRatiosRef* generateEcalLaserAPDPNRatiosRef();
+  std::shared_ptr<EcalPedestals> generateEcalPedestals();
+  std::shared_ptr<EcalADCToGeVConstant> generateEcalADCToGeVConstant();
+  std::shared_ptr<EcalIntercalibConstants> generateEcalIntercalibConstants();
+  std::shared_ptr<EcalLinearCorrections> generateEcalLinearCorrections();
+  std::shared_ptr<EcalGainRatios> generateEcalGainRatios();
+  std::shared_ptr<EcalWeightXtalGroups> generateEcalWeightXtalGroups();
+  std::shared_ptr<EcalTBWeights> generateEcalTBWeights();
+  std::shared_ptr<EcalLaserAPDPNRatios> generateEcalLaserAPDPNRatios(uint32_t i_run);
+  std::shared_ptr<EcalLaserAlphas> generateEcalLaserAlphas();
+  std::shared_ptr<EcalLaserAPDPNRatiosRef> generateEcalLaserAPDPNRatiosRef();
 
 private:
   std::string m_timetype;

--- a/CondTools/Ecal/interface/EcalTestDevDB.h
+++ b/CondTools/Ecal/interface/EcalTestDevDB.h
@@ -1,7 +1,7 @@
-#ifndef ECALTESTDEVDB_H
-#define ECALTESTDEVDB_H
+#ifndef CondTools_Ecal_EcalTestDevDB_h
+#define CondTools_Ecal_EcalTestDevDB_h
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "CondCore/CondDB/interface/Exception.h"
 
 #include "FWCore/Framework/interface/IOVSyncValue.h"
@@ -37,7 +37,7 @@ namespace edm {
   class EventSetup;
 }  // namespace edm
 
-class EcalTestDevDB : public edm::EDAnalyzer {
+class EcalTestDevDB : public edm::one::EDAnalyzer<> {
 public:
   explicit EcalTestDevDB(const edm::ParameterSet& iConfig);
   ~EcalTestDevDB() override;

--- a/CondTools/Ecal/plugins/StoreESCondition.cc
+++ b/CondTools/Ecal/plugins/StoreESCondition.cc
@@ -71,77 +71,77 @@ void StoreESCondition::endJob() {
       if (!toAppend) {
         edm::LogInfo("StoreESCondition") << " before create "
                                          << "\n";
-        mydbservice->createNewIOV<ESChannelStatus>(mycali, newTime, mydbservice->endOfTime(), "ESChannelStatusRcd");
+        mydbservice->createOneIOV<ESChannelStatus>(*mycali, newTime, "ESChannelStatusRcd");
         edm::LogInfo("StoreESCondition") << " after create "
                                          << "\n";
       } else {
         edm::LogInfo("StoreESCondition") << " before append "
                                          << "\n";
-        mydbservice->appendSinceTime<ESChannelStatus>(mycali, newTime, "ESChannelStatusRcd");
+        mydbservice->appendOneIOV<ESChannelStatus>(*mycali, newTime, "ESChannelStatusRcd");
         edm::LogInfo("StoreESCondition") << " after append "
                                          << "\n";
       }
     } else if (objectName_[i] == "ESIntercalibConstants") {
       ESIntercalibConstants* myintercalib = readESIntercalibConstantsFromFile(inpFileName_[i].c_str());
       if (!toAppend) {
-        mydbservice->createNewIOV<ESIntercalibConstants>(
-            myintercalib, newTime, mydbservice->endOfTime(), "ESIntercalibConstantsRcd");
+        mydbservice->createOneIOV<ESIntercalibConstants>(
+            *myintercalib, newTime, "ESIntercalibConstantsRcd");
       } else {
-        mydbservice->appendSinceTime<ESIntercalibConstants>(myintercalib, newTime, "ESIntercalibConstantsRcd");
+        mydbservice->appendOneIOV<ESIntercalibConstants>(*myintercalib, newTime, "ESIntercalibConstantsRcd");
       }
     } else if (objectName_[i] == "ESTimeSampleWeights") {
       ESTimeSampleWeights* myintercalib = readESTimeSampleWeightsFromFile(inpFileName_[i].c_str());
       if (!toAppend) {
-        mydbservice->createNewIOV<ESTimeSampleWeights>(
-            myintercalib, newTime, mydbservice->endOfTime(), "ESTimeSampleWeightsRcd");
+        mydbservice->createOneIOV<ESTimeSampleWeights>(
+            *myintercalib, newTime, "ESTimeSampleWeightsRcd");
       } else {
-        mydbservice->appendSinceTime<ESTimeSampleWeights>(myintercalib, newTime, "ESTimeSampleWeightsRcd");
+        mydbservice->appendOneIOV<ESTimeSampleWeights>(*myintercalib, newTime, "ESTimeSampleWeightsRcd");
       }
     } else if (objectName_[i] == "ESGain") {
       ESGain* myintercalib = readESGainFromFile(inpFileName_[i].c_str());
       if (!toAppend) {
-        mydbservice->createNewIOV<ESGain>(myintercalib, newTime, mydbservice->endOfTime(), "ESGainRcd");
+        mydbservice->createOneIOV<ESGain>(*myintercalib, newTime, "ESGainRcd");
       } else {
-        mydbservice->appendSinceTime<ESGain>(myintercalib, newTime, "ESGainRcd");
+        mydbservice->appendOneIOV<ESGain>(*myintercalib, newTime, "ESGainRcd");
       }
     } else if (objectName_[i] == "ESMissingEnergyCalibration") {
       ESMissingEnergyCalibration* myintercalib = readESMissingEnergyFromFile(inpFileName_[i].c_str());
       if (!toAppend) {
-        mydbservice->createNewIOV<ESMissingEnergyCalibration>(
-            myintercalib, newTime, mydbservice->endOfTime(), "ESMissingEnergyCalibrationRcd");
+        mydbservice->createOneIOV<ESMissingEnergyCalibration>(
+            *myintercalib, newTime, "ESMissingEnergyCalibrationRcd");
       } else {
-        mydbservice->appendSinceTime<ESMissingEnergyCalibration>(
-            myintercalib, newTime, "ESMissingEnergyCalibrationRcd");
+        mydbservice->appendOneIOV<ESMissingEnergyCalibration>(
+            *myintercalib, newTime, "ESMissingEnergyCalibrationRcd");
       }
     } else if (objectName_[i] == "ESRecHitRatioCuts") {
       ESRecHitRatioCuts* myintercalib = readESRecHitRatioCutsFromFile(inpFileName_[i].c_str());
       if (!toAppend) {
-        mydbservice->createNewIOV<ESRecHitRatioCuts>(
-            myintercalib, newTime, mydbservice->endOfTime(), "ESRecHitRatioCutsRcd");
+        mydbservice->createOneIOV<ESRecHitRatioCuts>(
+            *myintercalib, newTime, "ESRecHitRatioCutsRcd");
       } else {
-        mydbservice->appendSinceTime<ESRecHitRatioCuts>(myintercalib, newTime, "ESRecHitRatioCutsRcd");
+        mydbservice->appendOneIOV<ESRecHitRatioCuts>(*myintercalib, newTime, "ESRecHitRatioCutsRcd");
       }
     } else if (objectName_[i] == "ESThresholds") {
       ESThresholds* myintercalib = readESThresholdsFromFile(inpFileName_[i].c_str());
       if (!toAppend) {
-        mydbservice->createNewIOV<ESThresholds>(myintercalib, newTime, mydbservice->endOfTime(), "ESThresholdsRcd");
+        mydbservice->createOneIOV<ESThresholds>(*myintercalib, newTime, "ESThresholdsRcd");
       } else {
-        mydbservice->appendSinceTime<ESThresholds>(myintercalib, newTime, "ESThresholdsRcd");
+        mydbservice->appendOneIOV<ESThresholds>(*myintercalib, newTime, "ESThresholdsRcd");
       }
     } else if (objectName_[i] == "ESPedestals") {
       ESPedestals* myintercalib = readESPedestalsFromFile(inpFileName_[i].c_str());
       if (!toAppend) {
-        mydbservice->createNewIOV<ESPedestals>(myintercalib, newTime, mydbservice->endOfTime(), "ESPedestalsRcd");
+        mydbservice->createOneIOV<ESPedestals>(*myintercalib, newTime, "ESPedestalsRcd");
       } else {
-        mydbservice->appendSinceTime<ESPedestals>(myintercalib, newTime, "ESPedestalsRcd");
+        mydbservice->appendOneIOV<ESPedestals>(*myintercalib, newTime, "ESPedestalsRcd");
       }
     } else if (objectName_[i] == "ESEEIntercalibConstants") {
       ESEEIntercalibConstants* myintercalib = readESEEIntercalibConstantsFromFile(inpFileName_[i].c_str());
       if (!toAppend) {
-        mydbservice->createNewIOV<ESEEIntercalibConstants>(
-            myintercalib, newTime, mydbservice->endOfTime(), "ESEEIntercalibConstantsRcd");
+        mydbservice->createOneIOV<ESEEIntercalibConstants>(
+            *myintercalib, newTime, "ESEEIntercalibConstantsRcd");
       } else {
-        mydbservice->appendSinceTime<ESEEIntercalibConstants>(myintercalib, newTime, "ESEEIntercalibConstantsRcd");
+        mydbservice->appendOneIOV<ESEEIntercalibConstants>(*myintercalib, newTime, "ESEEIntercalibConstantsRcd");
       }
     } else {
       edm::LogError("StoreESCondition") << "Object " << objectName_[i] << " is not supported by this program."

--- a/CondTools/Ecal/plugins/StoreESCondition.cc
+++ b/CondTools/Ecal/plugins/StoreESCondition.cc
@@ -84,16 +84,14 @@ void StoreESCondition::endJob() {
     } else if (objectName_[i] == "ESIntercalibConstants") {
       ESIntercalibConstants* myintercalib = readESIntercalibConstantsFromFile(inpFileName_[i].c_str());
       if (!toAppend) {
-        mydbservice->createOneIOV<ESIntercalibConstants>(
-            *myintercalib, newTime, "ESIntercalibConstantsRcd");
+        mydbservice->createOneIOV<ESIntercalibConstants>(*myintercalib, newTime, "ESIntercalibConstantsRcd");
       } else {
         mydbservice->appendOneIOV<ESIntercalibConstants>(*myintercalib, newTime, "ESIntercalibConstantsRcd");
       }
     } else if (objectName_[i] == "ESTimeSampleWeights") {
       ESTimeSampleWeights* myintercalib = readESTimeSampleWeightsFromFile(inpFileName_[i].c_str());
       if (!toAppend) {
-        mydbservice->createOneIOV<ESTimeSampleWeights>(
-            *myintercalib, newTime, "ESTimeSampleWeightsRcd");
+        mydbservice->createOneIOV<ESTimeSampleWeights>(*myintercalib, newTime, "ESTimeSampleWeightsRcd");
       } else {
         mydbservice->appendOneIOV<ESTimeSampleWeights>(*myintercalib, newTime, "ESTimeSampleWeightsRcd");
       }
@@ -107,17 +105,14 @@ void StoreESCondition::endJob() {
     } else if (objectName_[i] == "ESMissingEnergyCalibration") {
       ESMissingEnergyCalibration* myintercalib = readESMissingEnergyFromFile(inpFileName_[i].c_str());
       if (!toAppend) {
-        mydbservice->createOneIOV<ESMissingEnergyCalibration>(
-            *myintercalib, newTime, "ESMissingEnergyCalibrationRcd");
+        mydbservice->createOneIOV<ESMissingEnergyCalibration>(*myintercalib, newTime, "ESMissingEnergyCalibrationRcd");
       } else {
-        mydbservice->appendOneIOV<ESMissingEnergyCalibration>(
-            *myintercalib, newTime, "ESMissingEnergyCalibrationRcd");
+        mydbservice->appendOneIOV<ESMissingEnergyCalibration>(*myintercalib, newTime, "ESMissingEnergyCalibrationRcd");
       }
     } else if (objectName_[i] == "ESRecHitRatioCuts") {
       ESRecHitRatioCuts* myintercalib = readESRecHitRatioCutsFromFile(inpFileName_[i].c_str());
       if (!toAppend) {
-        mydbservice->createOneIOV<ESRecHitRatioCuts>(
-            *myintercalib, newTime, "ESRecHitRatioCutsRcd");
+        mydbservice->createOneIOV<ESRecHitRatioCuts>(*myintercalib, newTime, "ESRecHitRatioCutsRcd");
       } else {
         mydbservice->appendOneIOV<ESRecHitRatioCuts>(*myintercalib, newTime, "ESRecHitRatioCutsRcd");
       }
@@ -138,8 +133,7 @@ void StoreESCondition::endJob() {
     } else if (objectName_[i] == "ESEEIntercalibConstants") {
       ESEEIntercalibConstants* myintercalib = readESEEIntercalibConstantsFromFile(inpFileName_[i].c_str());
       if (!toAppend) {
-        mydbservice->createOneIOV<ESEEIntercalibConstants>(
-            *myintercalib, newTime, "ESEEIntercalibConstantsRcd");
+        mydbservice->createOneIOV<ESEEIntercalibConstants>(*myintercalib, newTime, "ESEEIntercalibConstantsRcd");
       } else {
         mydbservice->appendOneIOV<ESEEIntercalibConstants>(*myintercalib, newTime, "ESEEIntercalibConstantsRcd");
       }

--- a/CondTools/Ecal/plugins/StoreESCondition.cc
+++ b/CondTools/Ecal/plugins/StoreESCondition.cc
@@ -7,7 +7,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <fstream>
-#include <iostream>
 #include <string>
 #include <cstring>
 #include <ctime>
@@ -65,7 +64,7 @@ void StoreESCondition::endJob() {
                                      << newTime << "\n";
     if (objectName_[i] == "ESChannelStatus") {
       edm::LogInfo("StoreESCondition") << " ESChannelStatus file " << inpFileName_[i] << "\n";
-      ESChannelStatus* mycali = readESChannelStatusFromFile(inpFileName_[i].c_str());
+      const auto mycali = readESChannelStatusFromFile(inpFileName_[i].c_str());
       edm::LogInfo("StoreESCondition") << " ESChannelStatus file read "
                                        << "\n";
       if (!toAppend) {
@@ -82,71 +81,69 @@ void StoreESCondition::endJob() {
                                          << "\n";
       }
     } else if (objectName_[i] == "ESIntercalibConstants") {
-      ESIntercalibConstants* myintercalib = readESIntercalibConstantsFromFile(inpFileName_[i].c_str());
+      const auto myintercalib = readESIntercalibConstantsFromFile(inpFileName_[i].c_str());
       if (!toAppend) {
         mydbservice->createOneIOV<ESIntercalibConstants>(*myintercalib, newTime, "ESIntercalibConstantsRcd");
       } else {
         mydbservice->appendOneIOV<ESIntercalibConstants>(*myintercalib, newTime, "ESIntercalibConstantsRcd");
       }
     } else if (objectName_[i] == "ESTimeSampleWeights") {
-      ESTimeSampleWeights* myintercalib = readESTimeSampleWeightsFromFile(inpFileName_[i].c_str());
+      const auto myintercalib = readESTimeSampleWeightsFromFile(inpFileName_[i].c_str());
       if (!toAppend) {
         mydbservice->createOneIOV<ESTimeSampleWeights>(*myintercalib, newTime, "ESTimeSampleWeightsRcd");
       } else {
         mydbservice->appendOneIOV<ESTimeSampleWeights>(*myintercalib, newTime, "ESTimeSampleWeightsRcd");
       }
     } else if (objectName_[i] == "ESGain") {
-      ESGain* myintercalib = readESGainFromFile(inpFileName_[i].c_str());
+      const auto myintercalib = readESGainFromFile(inpFileName_[i].c_str());
       if (!toAppend) {
         mydbservice->createOneIOV<ESGain>(*myintercalib, newTime, "ESGainRcd");
       } else {
         mydbservice->appendOneIOV<ESGain>(*myintercalib, newTime, "ESGainRcd");
       }
     } else if (objectName_[i] == "ESMissingEnergyCalibration") {
-      ESMissingEnergyCalibration* myintercalib = readESMissingEnergyFromFile(inpFileName_[i].c_str());
+      const auto myintercalib = readESMissingEnergyFromFile(inpFileName_[i].c_str());
       if (!toAppend) {
         mydbservice->createOneIOV<ESMissingEnergyCalibration>(*myintercalib, newTime, "ESMissingEnergyCalibrationRcd");
       } else {
         mydbservice->appendOneIOV<ESMissingEnergyCalibration>(*myintercalib, newTime, "ESMissingEnergyCalibrationRcd");
       }
     } else if (objectName_[i] == "ESRecHitRatioCuts") {
-      ESRecHitRatioCuts* myintercalib = readESRecHitRatioCutsFromFile(inpFileName_[i].c_str());
+      const auto myintercalib = readESRecHitRatioCutsFromFile(inpFileName_[i].c_str());
       if (!toAppend) {
         mydbservice->createOneIOV<ESRecHitRatioCuts>(*myintercalib, newTime, "ESRecHitRatioCutsRcd");
       } else {
         mydbservice->appendOneIOV<ESRecHitRatioCuts>(*myintercalib, newTime, "ESRecHitRatioCutsRcd");
       }
     } else if (objectName_[i] == "ESThresholds") {
-      ESThresholds* myintercalib = readESThresholdsFromFile(inpFileName_[i].c_str());
+      const auto myintercalib = readESThresholdsFromFile(inpFileName_[i].c_str());
       if (!toAppend) {
         mydbservice->createOneIOV<ESThresholds>(*myintercalib, newTime, "ESThresholdsRcd");
       } else {
         mydbservice->appendOneIOV<ESThresholds>(*myintercalib, newTime, "ESThresholdsRcd");
       }
     } else if (objectName_[i] == "ESPedestals") {
-      ESPedestals* myintercalib = readESPedestalsFromFile(inpFileName_[i].c_str());
+      const auto myintercalib = readESPedestalsFromFile(inpFileName_[i].c_str());
       if (!toAppend) {
         mydbservice->createOneIOV<ESPedestals>(*myintercalib, newTime, "ESPedestalsRcd");
       } else {
         mydbservice->appendOneIOV<ESPedestals>(*myintercalib, newTime, "ESPedestalsRcd");
       }
     } else if (objectName_[i] == "ESEEIntercalibConstants") {
-      ESEEIntercalibConstants* myintercalib = readESEEIntercalibConstantsFromFile(inpFileName_[i].c_str());
+      const auto myintercalib = readESEEIntercalibConstantsFromFile(inpFileName_[i].c_str());
       if (!toAppend) {
         mydbservice->createOneIOV<ESEEIntercalibConstants>(*myintercalib, newTime, "ESEEIntercalibConstantsRcd");
       } else {
         mydbservice->appendOneIOV<ESEEIntercalibConstants>(*myintercalib, newTime, "ESEEIntercalibConstantsRcd");
       }
     } else {
-      edm::LogError("StoreESCondition") << "Object " << objectName_[i] << " is not supported by this program."
-                                        << "\n";
+      edm::LogError("StoreESCondition") << "Object " << objectName_[i] << " is not supported by this program.";
     }
     // if more records write here else if ....
 
     writeToLogFileResults(messChar);
 
-    edm::LogInfo("StoreESCondition") << "Finished endJob"
-                                     << "\n";
+    edm::LogInfo("StoreESCondition") << "Finished endJob";
   }
 
   delete[] messChar;
@@ -201,25 +198,20 @@ void StoreESCondition::fillHeader(char* header) {
   strcpy(header, user);
 }
 
-ESThresholds* StoreESCondition::readESThresholdsFromFile(const char* inputFile) {
+std::shared_ptr<ESThresholds> StoreESCondition::readESThresholdsFromFile(const char* inputFile) {
   std::ifstream ESThresholdsFile(edm::FileInPath(inputFile).fullPath().c_str());
   float ts2, zs;  //2nd time sample, ZS threshold
   ESThresholdsFile >> ts2;
   ESThresholdsFile >> zs;
-  ESThresholds* esThresholds = new ESThresholds(ts2, zs);
+  auto esThresholds = std::make_shared<ESThresholds>(ts2, zs);
 
   return esThresholds;
 }
 
-ESEEIntercalibConstants* StoreESCondition::readESEEIntercalibConstantsFromFile(const char* inputFile) {
+std::shared_ptr<ESEEIntercalibConstants> StoreESCondition::readESEEIntercalibConstantsFromFile(const char* inputFile) {
   std::ifstream ESEEIntercalibFile(edm::FileInPath(inputFile).fullPath().c_str());
   float gammaLow0, alphaLow0, gammaHigh0, alphaHigh0, gammaLow1, alphaLow1, gammaHigh1, alphaHigh1, gammaLow2,
       alphaLow2, gammaHigh2, alphaHigh2, gammaLow3, alphaLow3, gammaHigh3, alphaHigh3;
-  //  const float ESEEIntercalibValue[16];
-  //  for (int i = 0; i < 16; ++i) {
-  //    ESEEIntercalibFile >> ESEEIntercalibValue[i];
-  //  }
-  //  ESEEIntercalibConstants* eseeIntercalibConstants = new ESEEIntercalibConstants(ESEEIntercalibValue);
   ESEEIntercalibFile >> gammaLow0;
   ESEEIntercalibFile >> alphaLow0;
   ESEEIntercalibFile >> gammaHigh0;
@@ -236,27 +228,27 @@ ESEEIntercalibConstants* StoreESCondition::readESEEIntercalibConstantsFromFile(c
   ESEEIntercalibFile >> alphaLow3;
   ESEEIntercalibFile >> gammaHigh3;
   ESEEIntercalibFile >> alphaHigh3;
-  ESEEIntercalibConstants* eseeIntercalibConstants = new ESEEIntercalibConstants(gammaLow0,
-                                                                                 alphaLow0,
-                                                                                 gammaHigh0,
-                                                                                 alphaHigh0,
-                                                                                 gammaLow1,
-                                                                                 alphaLow1,
-                                                                                 gammaHigh1,
-                                                                                 alphaHigh1,
-                                                                                 gammaLow2,
-                                                                                 alphaLow2,
-                                                                                 gammaHigh2,
-                                                                                 alphaHigh2,
-                                                                                 gammaLow3,
-                                                                                 alphaLow3,
-                                                                                 gammaHigh3,
-                                                                                 alphaHigh3);
+  auto eseeIntercalibConstants = std::make_shared<ESEEIntercalibConstants>(gammaLow0,
+                                                                           alphaLow0,
+                                                                           gammaHigh0,
+                                                                           alphaHigh0,
+                                                                           gammaLow1,
+                                                                           alphaLow1,
+                                                                           gammaHigh1,
+                                                                           alphaHigh1,
+                                                                           gammaLow2,
+                                                                           alphaLow2,
+                                                                           gammaHigh2,
+                                                                           alphaHigh2,
+                                                                           gammaLow3,
+                                                                           alphaLow3,
+                                                                           gammaHigh3,
+                                                                           alphaHigh3);
 
   return eseeIntercalibConstants;
 }
 
-ESMissingEnergyCalibration* StoreESCondition::readESMissingEnergyFromFile(const char* inputFile) {
+std::shared_ptr<ESMissingEnergyCalibration> StoreESCondition::readESMissingEnergyFromFile(const char* inputFile) {
   std::ifstream ESMissingEnergyFile(edm::FileInPath(inputFile).fullPath().c_str());
   float ConstAEta0, ConstBEta0, ConstAEta1, ConstBEta1, ConstAEta2, ConstBEta2, ConstAEta3, ConstBEta3;
   ESMissingEnergyFile >> ConstAEta0;
@@ -267,14 +259,14 @@ ESMissingEnergyCalibration* StoreESCondition::readESMissingEnergyFromFile(const 
   ESMissingEnergyFile >> ConstBEta2;
   ESMissingEnergyFile >> ConstAEta3;
   ESMissingEnergyFile >> ConstBEta3;
-  ESMissingEnergyCalibration* esMissingEnergy = new ESMissingEnergyCalibration(
+  auto esMissingEnergy = std::make_shared<ESMissingEnergyCalibration>(
       ConstAEta0, ConstBEta0, ConstAEta1, ConstBEta1, ConstAEta2, ConstBEta2, ConstAEta3, ConstBEta3);
 
   return esMissingEnergy;
 }
 
-ESPedestals* StoreESCondition::readESPedestalsFromFile(const char* inputFile) {
-  ESPedestals* esPedestals = new ESPedestals();
+std::shared_ptr<ESPedestals> StoreESCondition::readESPedestalsFromFile(const char* inputFile) {
+  auto esPedestals = std::make_shared<ESPedestals>();
 
   // int ped[2][2][40][40][32];
   // for (int i=0; i<2; ++i)
@@ -319,7 +311,7 @@ ESPedestals* StoreESCondition::readESPedestalsFromFile(const char* inputFile) {
   return esPedestals;
 }
 
-ESRecHitRatioCuts* StoreESCondition::readESRecHitRatioCutsFromFile(const char* inputFile) {
+std::shared_ptr<ESRecHitRatioCuts> StoreESCondition::readESRecHitRatioCutsFromFile(const char* inputFile) {
   std::ifstream ESRecHitRatioCutsFile(edm::FileInPath(inputFile).fullPath().c_str());
 
   float r12Low, r23Low, r12High, r23High;
@@ -327,33 +319,23 @@ ESRecHitRatioCuts* StoreESCondition::readESRecHitRatioCutsFromFile(const char* i
   ESRecHitRatioCutsFile >> r23Low;
   ESRecHitRatioCutsFile >> r12High;
   ESRecHitRatioCutsFile >> r23High;
-  ESRecHitRatioCuts* esRecHitRatioCuts = new ESRecHitRatioCuts(r12Low, r23Low, r12High, r23High);
-  //  cout<<"We are in RH ratio cut : gain : " << esgain_<<endl;
-
-  // HG (R12Low, R23Low, R12High, R23High)
-  //  ESRecHitRatioCuts* esRecHitRatioCuts;
-  //if (esgain_ == 2) esRecHitRatioCuts = new ESRecHitRatioCuts(-99999., 0.24, 0.61, 2.23);
-  //  if (esgain_ == 2) esRecHitRatioCuts = new ESRecHitRatioCuts(-99999., 0.61, 0.24, 2.23); // HG
-  //  else esRecHitRatioCuts = new ESRecHitRatioCuts(-99999., 0.2, 0.39, 2.8);
-  // LG (R12Low, R23Low, R12High, R23High)
-  //ESRecHitRatioCuts* esRecHitRatioCuts = new ESRecHitRatioCuts(-99999., 99999., -99999., 99999.); // first running
-  //ESRecHitRatioCuts* esRecHitRatioCuts = new ESRecHitRatioCuts(-99999., 0.2, 0.39, 2.8);
+  auto esRecHitRatioCuts = std::make_shared<ESRecHitRatioCuts>(r12Low, r23Low, r12High, r23High);
 
   return esRecHitRatioCuts;
 }
 
-ESGain* StoreESCondition::readESGainFromFile(const char* inputFile) {
+std::shared_ptr<ESGain> StoreESCondition::readESGainFromFile(const char* inputFile) {
   std::ifstream amplFile(edm::FileInPath(inputFile).fullPath().c_str());
 
   int gain;
   amplFile >> gain;
   edm::LogInfo("StoreESCondition") << "gain : " << gain << "\n";
 
-  ESGain* esGain = new ESGain(gain);  // 1: LG, 2: HG
+  auto esGain = std::make_shared<ESGain>(gain);  // 1: LG, 2: HG
   return esGain;
 }
 
-ESTimeSampleWeights* StoreESCondition::readESTimeSampleWeightsFromFile(const char* inputFile) {
+std::shared_ptr<ESTimeSampleWeights> StoreESCondition::readESTimeSampleWeightsFromFile(const char* inputFile) {
   std::ifstream amplFile(edm::FileInPath(inputFile).fullPath().c_str());
 
   float w[3];
@@ -364,12 +346,12 @@ ESTimeSampleWeights* StoreESCondition::readESTimeSampleWeightsFromFile(const cha
     edm::LogInfo("StoreESCondition") << "weight : " << k << " " << w[k] << "\n";
   }
 
-  ESTimeSampleWeights* esWeights = new ESTimeSampleWeights(w[0], w[1], w[2]);
+  auto esWeights = std::make_shared<ESTimeSampleWeights>(w[0], w[1], w[2]);
   return esWeights;
 }
 
-ESIntercalibConstants* StoreESCondition::readESIntercalibConstantsFromFile(const char* inputFile) {
-  ESIntercalibConstants* ical = new ESIntercalibConstants();
+std::shared_ptr<ESIntercalibConstants> StoreESCondition::readESIntercalibConstantsFromFile(const char* inputFile) {
+  auto ical = std::make_shared<ESIntercalibConstants>();
 
   std::ifstream mipFile(edm::FileInPath(inputFile).fullPath().c_str());
 
@@ -396,7 +378,7 @@ ESIntercalibConstants* StoreESCondition::readESIntercalibConstantsFromFile(const
   return ical;
 }
 
-ESChannelStatus* StoreESCondition::readESChannelStatusFromFile(const char* inputFile) {
+std::shared_ptr<ESChannelStatus> StoreESCondition::readESChannelStatusFromFile(const char* inputFile) {
   int z[1000], p[1000], x[1000], y[1000], nsensors;
   std::ifstream statusFile(edm::FileInPath(inputFile).fullPath().c_str());
   statusFile >> nsensors;
@@ -409,7 +391,7 @@ ESChannelStatus* StoreESCondition::readESChannelStatusFromFile(const char* input
   for (int i = 0; i < nsensors; ++i) {
     statusFile >> z[i] >> p[i] >> x[i] >> y[i];
   }
-  ESChannelStatus* ecalStatus = new ESChannelStatus();
+  auto ecalStatus = std::make_shared<ESChannelStatus>();
   int Nbstatus = 0, Nbstrip = 0;
   for (int istrip = ESDetId::ISTRIP_MIN; istrip <= ESDetId::ISTRIP_MAX; istrip++) {
     for (int ix = ESDetId::IX_MIN; ix <= ESDetId::IX_MAX; ix++) {

--- a/CondTools/Ecal/plugins/StoreESCondition.h
+++ b/CondTools/Ecal/plugins/StoreESCondition.h
@@ -5,7 +5,7 @@
 
 #include <string>
 #include <map>
-#include <iostream>
+#include <memory>
 #include <fstream>
 #include <cstdio>
 #include <typeinfo>
@@ -30,15 +30,15 @@ namespace edm {
 
 class StoreESCondition : public edm::one::EDAnalyzer<> {
 public:
-  ESThresholds* readESThresholdsFromFile(const char*);
-  ESPedestals* readESPedestalsFromFile(const char*);
-  ESRecHitRatioCuts* readESRecHitRatioCutsFromFile(const char*);
-  ESGain* readESGainFromFile(const char*);
-  ESTimeSampleWeights* readESTimeSampleWeightsFromFile(const char*);
-  ESChannelStatus* readESChannelStatusFromFile(const char*);
-  ESIntercalibConstants* readESIntercalibConstantsFromFile(const char*);
-  ESMissingEnergyCalibration* readESMissingEnergyFromFile(const char*);
-  ESEEIntercalibConstants* readESEEIntercalibConstantsFromFile(const char*);
+  std::shared_ptr<ESThresholds> readESThresholdsFromFile(const char*);
+  std::shared_ptr<ESPedestals> readESPedestalsFromFile(const char*);
+  std::shared_ptr<ESRecHitRatioCuts> readESRecHitRatioCutsFromFile(const char*);
+  std::shared_ptr<ESGain> readESGainFromFile(const char*);
+  std::shared_ptr<ESTimeSampleWeights> readESTimeSampleWeightsFromFile(const char*);
+  std::shared_ptr<ESChannelStatus> readESChannelStatusFromFile(const char*);
+  std::shared_ptr<ESIntercalibConstants> readESIntercalibConstantsFromFile(const char*);
+  std::shared_ptr<ESMissingEnergyCalibration> readESMissingEnergyFromFile(const char*);
+  std::shared_ptr<ESEEIntercalibConstants> readESEEIntercalibConstantsFromFile(const char*);
   void writeToLogFile(std::string, std::string, unsigned long long);
   void writeToLogFileResults(char*);
 

--- a/CondTools/Ecal/plugins/StoreESCondition.h
+++ b/CondTools/Ecal/plugins/StoreESCondition.h
@@ -1,7 +1,7 @@
-#ifndef StoreESCondition_h
-#define StoreESCondition_h
+#ifndef CondTools_Ecal_StoreESCondition_h
+#define CondTools_Ecal_StoreESCondition_h
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include <string>
 #include <map>
@@ -28,7 +28,7 @@ namespace edm {
   class EventSetup;
 }  // namespace edm
 
-class StoreESCondition : public edm::EDAnalyzer {
+class StoreESCondition : public edm::one::EDAnalyzer<> {
 public:
   ESThresholds* readESThresholdsFromFile(const char*);
   ESPedestals* readESPedestalsFromFile(const char*);

--- a/CondTools/Ecal/plugins/StoreEcalCondition.cc
+++ b/CondTools/Ecal/plugins/StoreEcalCondition.cc
@@ -72,66 +72,66 @@ void StoreEcalCondition::endJob() {
     if (objectName_[i] == "EcalWeightXtalGroups") {
       EcalWeightXtalGroups* mycali = readEcalWeightXtalGroupsFromFile(inpFileName_[i].c_str());
       if (!toAppend) {
-        mydbservice->createNewIOV<EcalWeightXtalGroups>(
-            mycali, newTime, mydbservice->endOfTime(), "EcalWeightXtalGroupsRcd");
+        mydbservice->createOneIOV<EcalWeightXtalGroups>(
+            *mycali, newTime, "EcalWeightXtalGroupsRcd");
       } else {
-        mydbservice->appendSinceTime<EcalWeightXtalGroups>(mycali, newTime, "EcalWeightXtalGroupsRcd");
+        mydbservice->appendOneIOV<EcalWeightXtalGroups>(*mycali, newTime, "EcalWeightXtalGroupsRcd");
       }
     } else if (objectName_[i] == "EcalTBWeights") {
       EcalTBWeights* mycali = readEcalTBWeightsFromFile(inpFileName_[i].c_str());
       if (!toAppend) {
-        mydbservice->createNewIOV<EcalTBWeights>(mycali, newTime, mydbservice->endOfTime(), "EcalTBWeightsRcd");
+        mydbservice->createOneIOV<EcalTBWeights>(*mycali, newTime, "EcalTBWeightsRcd");
       } else {
-        mydbservice->appendSinceTime<EcalTBWeights>(mycali, newTime, "EcalTBWeightsRcd");
+        mydbservice->appendOneIOV<EcalTBWeights>(*mycali, newTime, "EcalTBWeightsRcd");
       }
     } else if (objectName_[i] == "EcalADCToGeVConstant") {
       EcalADCToGeVConstant* mycali = readEcalADCToGeVConstantFromFile(inpFileName_[i].c_str());
       if (!toAppend) {
-        mydbservice->createNewIOV<EcalADCToGeVConstant>(
-            mycali, newTime, mydbservice->endOfTime(), "EcalADCToGeVConstantRcd");
+        mydbservice->createOneIOV<EcalADCToGeVConstant>(
+            *mycali, newTime, "EcalADCToGeVConstantRcd");
       } else {
-        mydbservice->appendSinceTime<EcalADCToGeVConstant>(mycali, newTime, "EcalADCToGeVConstantRcd");
+        mydbservice->appendOneIOV<EcalADCToGeVConstant>(*mycali, newTime, "EcalADCToGeVConstantRcd");
       }
     } else if (objectName_[i] == "EcalIntercalibConstants") {
       EcalIntercalibConstants* mycali =
           readEcalIntercalibConstantsFromFile(inpFileName_[i].c_str(), inpFileNameEE_[i].c_str());
       if (!toAppend) {
-        mydbservice->createNewIOV<EcalIntercalibConstants>(
-            mycali, newTime, mydbservice->endOfTime(), "EcalIntercalibConstantsRcd");
+        mydbservice->createOneIOV<EcalIntercalibConstants>(
+            *mycali, newTime, "EcalIntercalibConstantsRcd");
       } else {
-        mydbservice->appendSinceTime<EcalIntercalibConstants>(mycali, newTime, "EcalIntercalibConstantsRcd");
+        mydbservice->appendOneIOV<EcalIntercalibConstants>(*mycali, newTime, "EcalIntercalibConstantsRcd");
       }
     } else if (objectName_[i] == "EcalPFRecHitThresholds") {
       EcalPFRecHitThresholds* mycali =
           readEcalPFRecHitThresholdsFromFile(inpFileName_[i].c_str(), inpFileNameEE_[i].c_str());
       if (!toAppend) {
-        mydbservice->createNewIOV<EcalPFRecHitThresholds>(
-            mycali, newTime, mydbservice->endOfTime(), "EcalPFRecHitThresholdsRcd");
+        mydbservice->createOneIOV<EcalPFRecHitThresholds>(
+            *mycali, newTime, "EcalPFRecHitThresholdsRcd");
       } else {
-        mydbservice->appendSinceTime<EcalPFRecHitThresholds>(mycali, newTime, "EcalPFRecHitThresholdsRcd");
+        mydbservice->appendOneIOV<EcalPFRecHitThresholds>(*mycali, newTime, "EcalPFRecHitThresholdsRcd");
       }
     } else if (objectName_[i] == "EcalIntercalibConstantsMC") {
       EcalIntercalibConstantsMC* mycali =
           readEcalIntercalibConstantsMCFromFile(inpFileName_[i].c_str(), inpFileNameEE_[i].c_str());
       if (!toAppend) {
-        mydbservice->createNewIOV<EcalIntercalibConstantsMC>(
-            mycali, newTime, mydbservice->endOfTime(), "EcalIntercalibConstantsMCRcd");
+        mydbservice->createOneIOV<EcalIntercalibConstantsMC>(
+            *mycali, newTime, "EcalIntercalibConstantsMCRcd");
       } else {
-        mydbservice->appendSinceTime<EcalIntercalibConstantsMC>(mycali, newTime, "EcalIntercalibConstantsMCRcd");
+        mydbservice->appendOneIOV<EcalIntercalibConstantsMC>(*mycali, newTime, "EcalIntercalibConstantsMCRcd");
       }
     } else if (objectName_[i] == "EcalGainRatios") {
       EcalGainRatios* mycali = readEcalGainRatiosFromFile(inpFileName_[i].c_str());
       if (!toAppend) {
-        mydbservice->createNewIOV<EcalGainRatios>(mycali, newTime, mydbservice->endOfTime(), "EcalGainRatiosRcd");
+        mydbservice->createOneIOV<EcalGainRatios>(*mycali, newTime, "EcalGainRatiosRcd");
       } else {
-        mydbservice->appendSinceTime<EcalGainRatios>(mycali, newTime, "EcalGainRatiosRcd");
+        mydbservice->appendOneIOV<EcalGainRatios>(*mycali, newTime, "EcalGainRatiosRcd");
       }
     } else if (objectName_[i] == "EcalChannelStatus") {
       EcalChannelStatus* mycali = readEcalChannelStatusFromFile(inpFileName_[i].c_str());
       if (!toAppend) {
-        mydbservice->createNewIOV<EcalChannelStatus>(mycali, newTime, mydbservice->endOfTime(), "EcalChannelStatusRcd");
+        mydbservice->createOneIOV<EcalChannelStatus>(*mycali, newTime, "EcalChannelStatusRcd");
       } else {
-        mydbservice->appendSinceTime<EcalChannelStatus>(mycali, newTime, "EcalChannelStatusRcd");
+        mydbservice->appendOneIOV<EcalChannelStatus>(*mycali, newTime, "EcalChannelStatusRcd");
       }
     } else {
       edm::LogError("StoreEcalCondition")

--- a/CondTools/Ecal/plugins/StoreEcalCondition.cc
+++ b/CondTools/Ecal/plugins/StoreEcalCondition.cc
@@ -72,8 +72,7 @@ void StoreEcalCondition::endJob() {
     if (objectName_[i] == "EcalWeightXtalGroups") {
       EcalWeightXtalGroups* mycali = readEcalWeightXtalGroupsFromFile(inpFileName_[i].c_str());
       if (!toAppend) {
-        mydbservice->createOneIOV<EcalWeightXtalGroups>(
-            *mycali, newTime, "EcalWeightXtalGroupsRcd");
+        mydbservice->createOneIOV<EcalWeightXtalGroups>(*mycali, newTime, "EcalWeightXtalGroupsRcd");
       } else {
         mydbservice->appendOneIOV<EcalWeightXtalGroups>(*mycali, newTime, "EcalWeightXtalGroupsRcd");
       }
@@ -87,8 +86,7 @@ void StoreEcalCondition::endJob() {
     } else if (objectName_[i] == "EcalADCToGeVConstant") {
       EcalADCToGeVConstant* mycali = readEcalADCToGeVConstantFromFile(inpFileName_[i].c_str());
       if (!toAppend) {
-        mydbservice->createOneIOV<EcalADCToGeVConstant>(
-            *mycali, newTime, "EcalADCToGeVConstantRcd");
+        mydbservice->createOneIOV<EcalADCToGeVConstant>(*mycali, newTime, "EcalADCToGeVConstantRcd");
       } else {
         mydbservice->appendOneIOV<EcalADCToGeVConstant>(*mycali, newTime, "EcalADCToGeVConstantRcd");
       }
@@ -96,8 +94,7 @@ void StoreEcalCondition::endJob() {
       EcalIntercalibConstants* mycali =
           readEcalIntercalibConstantsFromFile(inpFileName_[i].c_str(), inpFileNameEE_[i].c_str());
       if (!toAppend) {
-        mydbservice->createOneIOV<EcalIntercalibConstants>(
-            *mycali, newTime, "EcalIntercalibConstantsRcd");
+        mydbservice->createOneIOV<EcalIntercalibConstants>(*mycali, newTime, "EcalIntercalibConstantsRcd");
       } else {
         mydbservice->appendOneIOV<EcalIntercalibConstants>(*mycali, newTime, "EcalIntercalibConstantsRcd");
       }
@@ -105,8 +102,7 @@ void StoreEcalCondition::endJob() {
       EcalPFRecHitThresholds* mycali =
           readEcalPFRecHitThresholdsFromFile(inpFileName_[i].c_str(), inpFileNameEE_[i].c_str());
       if (!toAppend) {
-        mydbservice->createOneIOV<EcalPFRecHitThresholds>(
-            *mycali, newTime, "EcalPFRecHitThresholdsRcd");
+        mydbservice->createOneIOV<EcalPFRecHitThresholds>(*mycali, newTime, "EcalPFRecHitThresholdsRcd");
       } else {
         mydbservice->appendOneIOV<EcalPFRecHitThresholds>(*mycali, newTime, "EcalPFRecHitThresholdsRcd");
       }
@@ -114,8 +110,7 @@ void StoreEcalCondition::endJob() {
       EcalIntercalibConstantsMC* mycali =
           readEcalIntercalibConstantsMCFromFile(inpFileName_[i].c_str(), inpFileNameEE_[i].c_str());
       if (!toAppend) {
-        mydbservice->createOneIOV<EcalIntercalibConstantsMC>(
-            *mycali, newTime, "EcalIntercalibConstantsMCRcd");
+        mydbservice->createOneIOV<EcalIntercalibConstantsMC>(*mycali, newTime, "EcalIntercalibConstantsMCRcd");
       } else {
         mydbservice->appendOneIOV<EcalIntercalibConstantsMC>(*mycali, newTime, "EcalIntercalibConstantsMCRcd");
       }

--- a/CondTools/Ecal/plugins/StoreEcalCondition.cc
+++ b/CondTools/Ecal/plugins/StoreEcalCondition.cc
@@ -8,14 +8,11 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <fstream>
-#include <iostream>
 #include <string>
 #include <cstring>
 #include <ctime>
 #include <unistd.h>
 
-using std::cout;
-using std::endl;
 using std::string;
 
 StoreEcalCondition::StoreEcalCondition(const edm::ParameterSet& iConfig) {
@@ -39,7 +36,7 @@ StoreEcalCondition::StoreEcalCondition(const edm::ParameterSet& iConfig) {
 void StoreEcalCondition::endJob() {
   edm::Service<cond::service::PoolDBOutputService> mydbservice;
   if (!mydbservice.isAvailable()) {
-    edm::LogError("StoreEcalCondition") << "PoolDBOutputService is unavailable" << std::endl;
+    edm::LogError("StoreEcalCondition") << "PoolDBOutputService is unavailable";
     return;
   }
 
@@ -66,78 +63,73 @@ void StoreEcalCondition::endJob() {
       newTime = (cond::Time_t)since_[i];
     }
     edm::LogInfo("StoreEcalCondition") << "Reading " << objectName_[i] << " from file and writing to DB with newTime "
-                                       << newTime << endl;
-    std::cout << "Reading " << objectName_[i] << " from file and writing to DB with newTime " << newTime << endl;
+                                       << newTime;
 
     if (objectName_[i] == "EcalWeightXtalGroups") {
-      EcalWeightXtalGroups* mycali = readEcalWeightXtalGroupsFromFile(inpFileName_[i].c_str());
+      const auto mycali = readEcalWeightXtalGroupsFromFile(inpFileName_[i].c_str());
       if (!toAppend) {
         mydbservice->createOneIOV<EcalWeightXtalGroups>(*mycali, newTime, "EcalWeightXtalGroupsRcd");
       } else {
         mydbservice->appendOneIOV<EcalWeightXtalGroups>(*mycali, newTime, "EcalWeightXtalGroupsRcd");
       }
     } else if (objectName_[i] == "EcalTBWeights") {
-      EcalTBWeights* mycali = readEcalTBWeightsFromFile(inpFileName_[i].c_str());
+      const auto mycali = readEcalTBWeightsFromFile(inpFileName_[i].c_str());
       if (!toAppend) {
         mydbservice->createOneIOV<EcalTBWeights>(*mycali, newTime, "EcalTBWeightsRcd");
       } else {
         mydbservice->appendOneIOV<EcalTBWeights>(*mycali, newTime, "EcalTBWeightsRcd");
       }
     } else if (objectName_[i] == "EcalADCToGeVConstant") {
-      EcalADCToGeVConstant* mycali = readEcalADCToGeVConstantFromFile(inpFileName_[i].c_str());
+      const auto mycali = readEcalADCToGeVConstantFromFile(inpFileName_[i].c_str());
       if (!toAppend) {
         mydbservice->createOneIOV<EcalADCToGeVConstant>(*mycali, newTime, "EcalADCToGeVConstantRcd");
       } else {
         mydbservice->appendOneIOV<EcalADCToGeVConstant>(*mycali, newTime, "EcalADCToGeVConstantRcd");
       }
     } else if (objectName_[i] == "EcalIntercalibConstants") {
-      EcalIntercalibConstants* mycali =
-          readEcalIntercalibConstantsFromFile(inpFileName_[i].c_str(), inpFileNameEE_[i].c_str());
+      const auto mycali = readEcalIntercalibConstantsFromFile(inpFileName_[i].c_str(), inpFileNameEE_[i].c_str());
       if (!toAppend) {
         mydbservice->createOneIOV<EcalIntercalibConstants>(*mycali, newTime, "EcalIntercalibConstantsRcd");
       } else {
         mydbservice->appendOneIOV<EcalIntercalibConstants>(*mycali, newTime, "EcalIntercalibConstantsRcd");
       }
     } else if (objectName_[i] == "EcalPFRecHitThresholds") {
-      EcalPFRecHitThresholds* mycali =
-          readEcalPFRecHitThresholdsFromFile(inpFileName_[i].c_str(), inpFileNameEE_[i].c_str());
+      const auto mycali = readEcalPFRecHitThresholdsFromFile(inpFileName_[i].c_str(), inpFileNameEE_[i].c_str());
       if (!toAppend) {
         mydbservice->createOneIOV<EcalPFRecHitThresholds>(*mycali, newTime, "EcalPFRecHitThresholdsRcd");
       } else {
         mydbservice->appendOneIOV<EcalPFRecHitThresholds>(*mycali, newTime, "EcalPFRecHitThresholdsRcd");
       }
     } else if (objectName_[i] == "EcalIntercalibConstantsMC") {
-      EcalIntercalibConstantsMC* mycali =
-          readEcalIntercalibConstantsMCFromFile(inpFileName_[i].c_str(), inpFileNameEE_[i].c_str());
+      const auto mycali = readEcalIntercalibConstantsMCFromFile(inpFileName_[i].c_str(), inpFileNameEE_[i].c_str());
       if (!toAppend) {
         mydbservice->createOneIOV<EcalIntercalibConstantsMC>(*mycali, newTime, "EcalIntercalibConstantsMCRcd");
       } else {
         mydbservice->appendOneIOV<EcalIntercalibConstantsMC>(*mycali, newTime, "EcalIntercalibConstantsMCRcd");
       }
     } else if (objectName_[i] == "EcalGainRatios") {
-      EcalGainRatios* mycali = readEcalGainRatiosFromFile(inpFileName_[i].c_str());
+      const auto mycali = readEcalGainRatiosFromFile(inpFileName_[i].c_str());
       if (!toAppend) {
         mydbservice->createOneIOV<EcalGainRatios>(*mycali, newTime, "EcalGainRatiosRcd");
       } else {
         mydbservice->appendOneIOV<EcalGainRatios>(*mycali, newTime, "EcalGainRatiosRcd");
       }
     } else if (objectName_[i] == "EcalChannelStatus") {
-      EcalChannelStatus* mycali = readEcalChannelStatusFromFile(inpFileName_[i].c_str());
+      const auto mycali = readEcalChannelStatusFromFile(inpFileName_[i].c_str());
       if (!toAppend) {
         mydbservice->createOneIOV<EcalChannelStatus>(*mycali, newTime, "EcalChannelStatusRcd");
       } else {
         mydbservice->appendOneIOV<EcalChannelStatus>(*mycali, newTime, "EcalChannelStatusRcd");
       }
     } else {
-      edm::LogError("StoreEcalCondition")
-          << "Object " << objectName_[i] << " is not supported by this program." << endl;
+      edm::LogError("StoreEcalCondition") << "Object " << objectName_[i] << " is not supported by this program.";
     }
 
     //      writeToLogFile(objectName_[i], inpFileName_[i], since_[i]);
     //writeToLogFileResults("finished OK\n");
     writeToLogFileResults(messChar);
 
-    edm::LogInfo("StoreEcalCondition") << "Finished endJob" << endl;
+    edm::LogInfo("StoreEcalCondition") << "Finished endJob";
   }
 
   delete[] messChar;
@@ -241,12 +233,12 @@ void StoreEcalCondition::fillHeader(char* header)
  */
 
 //-------------------------------------------------------------
-EcalWeightXtalGroups* StoreEcalCondition::readEcalWeightXtalGroupsFromFile(const char* inputFile) {
+std::shared_ptr<EcalWeightXtalGroups> StoreEcalCondition::readEcalWeightXtalGroupsFromFile(const char* inputFile) {
   //-------------------------------------------------------------
 
   // Code taken from EcalWeightTools/test/MakeOfflineDbFromAscii.cpp
 
-  EcalWeightXtalGroups* xtalGroups = new EcalWeightXtalGroups();
+  auto xtalGroups = std::make_shared<EcalWeightXtalGroups>();
   std::ifstream groupid_in(inputFile);
 
   if (!groupid_in.is_open()) {
@@ -259,22 +251,22 @@ EcalWeightXtalGroups* StoreEcalCondition::readEcalWeightXtalGroupsFromFile(const
   std::ostringstream str;
   groupid_in >> smnumber;
   if (smnumber == -99999) {
-    edm::LogError("StoreEcalCondition") << "ERROR: SM number not found in file" << endl;
+    edm::LogError("StoreEcalCondition") << "ERROR: SM number not found in file";
     return nullptr;
   }
-  str << "sm= " << smnumber << endl;
+  str << "sm= " << smnumber << "\n";
   sm_constr_ = smnumber;
 
   char temp[256];
   //Reading the other 5 header lines containing various informations
   for (int i = 0; i <= 5; i++) {
     groupid_in.getline(temp, 255);
-    str << temp << endl;
+    str << temp << "\n";
   }
 
   // Skip the nGroup/Mean line
   groupid_in.getline(temp, 255);
-  str << temp << endl;
+  str << temp << "\n";
 
   edm::LogInfo("StoreEcalCondition") << "GROUPID file " << str.str();
 
@@ -296,7 +288,7 @@ EcalWeightXtalGroups* StoreEcalCondition::readEcalWeightXtalGroupsFromFile(const
   }  //loop iphi
 
   if (xtals != 1700) {
-    edm::LogError("StoreEcalCondition") << "ERROR:  GROUPID file did not contain data for 1700 crystals" << endl;
+    edm::LogError("StoreEcalCondition") << "ERROR:  GROUPID file did not contain data for 1700 crystals";
     return nullptr;
   }
 
@@ -307,12 +299,12 @@ EcalWeightXtalGroups* StoreEcalCondition::readEcalWeightXtalGroupsFromFile(const
 }
 
 //-------------------------------------------------------------
-EcalTBWeights* StoreEcalCondition::readEcalTBWeightsFromFile(const char* inputFile) {
+std::shared_ptr<EcalTBWeights> StoreEcalCondition::readEcalTBWeightsFromFile(const char* inputFile) {
   //-------------------------------------------------------------
 
   // Zabi code to be written here
 
-  EcalTBWeights* tbwgt = new EcalTBWeights();
+  auto tbwgt = std::make_shared<EcalTBWeights>();
 
   std::ifstream WeightsFileTB(inputFile);
   if (!WeightsFileTB.is_open()) {
@@ -327,13 +319,13 @@ EcalTBWeights* StoreEcalCondition::readEcalTBWeightsFromFile(const char* inputFi
   if (smnumber == -99999)
     return nullptr;
 
-  str << "sm= " << smnumber << endl;
+  str << "sm= " << smnumber << "\n";
 
   char temp[256];
   //Reading the other 5 header lines containing various informations
   for (int i = 0; i <= 5; i++) {
     WeightsFileTB.getline(temp, 255);
-    str << temp << endl;
+    str << temp << "\n";
   }
 
   edm::LogInfo("StoreEcalCondition") << "Weights file " << str.str();
@@ -369,7 +361,7 @@ EcalTBWeights* StoreEcalCondition::readEcalTBWeightsFromFile(const char* inputFi
         wgt1(0, j) = ww;
         str << ww << " ";
       }  // loop Samples
-      str << std::endl;
+      str << "\n";
 
       //Pedestal weights
       for (int j = 0; j < nSamples; ++j) {
@@ -378,7 +370,7 @@ EcalTBWeights* StoreEcalCondition::readEcalTBWeightsFromFile(const char* inputFi
         wgt1(1, j) = ww;
         str << ww << " ";
       }  //loop Samples
-      str << std::endl;
+      str << "\n";
 
       //Timing weights
       for (int j = 0; j < nSamples; ++j) {
@@ -387,7 +379,7 @@ EcalTBWeights* StoreEcalCondition::readEcalTBWeightsFromFile(const char* inputFi
         wgt1(2, j) = ww;
         str << ww << " ";
       }  //loop Samples
-      str << std::endl;
+      str << "\n";
 
       for (int j = 0; j < nSamples; ++j) {
         // fill chi2 matrix
@@ -398,7 +390,7 @@ EcalTBWeights* StoreEcalCondition::readEcalTBWeightsFromFile(const char* inputFi
           chisq1(j, k) = ww;
           str << ww << " ";
         }  //loop samples
-        str << std::endl;
+        str << "\n";
       }  //loop lines
 
       //WEIGHTS AFTER GAIN SWITCH
@@ -408,7 +400,7 @@ EcalTBWeights* StoreEcalCondition::readEcalTBWeightsFromFile(const char* inputFi
         wgt2(0, j) = ww;
         str << ww << " ";
       }  // loop Samples
-      str << std::endl;
+      str << "\n";
 
       //Pedestal weights
       for (int j = 0; j < nSamples; ++j) {
@@ -417,7 +409,7 @@ EcalTBWeights* StoreEcalCondition::readEcalTBWeightsFromFile(const char* inputFi
         wgt2(1, j) = ww;
         str << ww << " ";
       }  //loop Samples
-      str << std::endl;
+      str << "\n";
 
       //Timing weights
       for (int j = 0; j < nSamples; ++j) {
@@ -426,7 +418,7 @@ EcalTBWeights* StoreEcalCondition::readEcalTBWeightsFromFile(const char* inputFi
         wgt2(2, j) = ww;
         str << ww << " ";
       }  //loop Samples
-      str << std::endl;
+      str << "\n";
 
       for (int j = 0; j < nSamples; ++j) {
         // fill chi2 matrix
@@ -437,7 +429,7 @@ EcalTBWeights* StoreEcalCondition::readEcalTBWeightsFromFile(const char* inputFi
           chisq2(j, k) = ww;
           str << ww << " ";
         }  //loop samples
-        str << std::endl;
+        str << "\n";
       }  //loop lines
 
       LogDebug("StoreEcalCondition") << str.str();
@@ -455,7 +447,7 @@ EcalTBWeights* StoreEcalCondition::readEcalTBWeightsFromFile(const char* inputFi
 }
 
 //-------------------------------------------------------------
-EcalADCToGeVConstant* StoreEcalCondition::readEcalADCToGeVConstantFromFile(const char* inputFile) {
+std::shared_ptr<EcalADCToGeVConstant> StoreEcalCondition::readEcalADCToGeVConstantFromFile(const char* inputFile) {
   //-------------------------------------------------------------
 
   FILE* inpFile;  // input file
@@ -471,26 +463,26 @@ EcalADCToGeVConstant* StoreEcalCondition::readEcalADCToGeVConstantFromFile(const
 
   fgets(line, 255, inpFile);
   int sm_number = atoi(line);
-  str << "sm= " << sm_number << endl;
+  str << "sm= " << sm_number << "\n";
 
   fgets(line, 255, inpFile);
   //int nevents=atoi(line); // not necessary here just for online conddb
 
   fgets(line, 255, inpFile);
   string gen_tag = to_string(line);
-  str << "gen tag " << gen_tag << endl;  // should I use this?
+  str << "gen tag " << gen_tag << "\n";  // should I use this?
 
   fgets(line, 255, inpFile);
   string cali_method = to_string(line);
-  str << "cali method " << cali_method << endl;  // not important
+  str << "cali method " << cali_method << "\n";  // not important
 
   fgets(line, 255, inpFile);
   string cali_version = to_string(line);
-  str << "cali version " << cali_version << endl;  // not important
+  str << "cali version " << cali_version << "\n";  // not important
 
   fgets(line, 255, inpFile);
   string cali_type = to_string(line);
-  str << "cali type " << cali_type << endl;  // not important
+  str << "cali type " << cali_type << "\n";  // not important
 
   edm::LogInfo("StoreEcalCondition") << "ADCToGeV file " << str.str();
 
@@ -508,17 +500,17 @@ EcalADCToGeVConstant* StoreEcalCondition::readEcalADCToGeVConstantFromFile(const
   sm_constr_ = sm_number;
 
   // barrel and endcaps the same
-  EcalADCToGeVConstant* agc = new EcalADCToGeVConstant(adc_to_gev, adc_to_gev_ee);
+  auto agc = std::make_shared<EcalADCToGeVConstant>(adc_to_gev, adc_to_gev_ee);
   edm::LogInfo("StoreEcalCondition") << "ADCtoGeV scale written into the DB";
   return agc;
 }
 
 //-------------------------------------------------------------
-EcalPFRecHitThresholds* StoreEcalCondition::readEcalPFRecHitThresholdsFromFile(const char* inputFile,
-                                                                               const char* inputFileEE) {
+std::shared_ptr<EcalPFRecHitThresholds> StoreEcalCondition::readEcalPFRecHitThresholdsFromFile(
+    const char* inputFile, const char* inputFileEE) {
   //-------------------------------------------------------------
 
-  EcalPFRecHitThresholds* ical = new EcalPFRecHitThresholds();
+  auto ical = std::make_shared<EcalPFRecHitThresholds>();
 
   FILE* inpFile;  // input file
   inpFile = fopen(inputFile, "r");
@@ -541,7 +533,7 @@ EcalPFRecHitThresholds* StoreEcalCondition::readEcalPFRecHitThresholdsFromFile(c
   while (fgets(line, 255, inpFile)) {
     sscanf(line, "%d %d %f ", &ieta, &iphi, &thresh);
     if (ii == 0)
-      cout << "crystal " << ieta << "/" << iphi << " Thresh= " << thresh << endl;
+      edm::LogVerbatim("StoreEcalCondition") << "crystal " << ieta << "/" << iphi << " Thresh= " << thresh << "\n";
 
     if (EBDetId::validDetId(ieta, iphi)) {
       EBDetId ebid(ieta, iphi);
@@ -555,8 +547,6 @@ EcalPFRecHitThresholds* StoreEcalCondition::readEcalPFRecHitThresholdsFromFile(c
 
   edm::LogInfo("StoreEcalCondition") << "Read PF RecHits for " << ii << " xtals ";
 
-  cout << " I read the thresholds for " << ii << " crystals " << endl;
-
   FILE* inpFileEE;  // input file
   inpFileEE = fopen(inputFileEE, "r");
   if (!inpFileEE) {
@@ -567,7 +557,8 @@ EcalPFRecHitThresholds* StoreEcalCondition::readEcalPFRecHitThresholdsFromFile(c
   while (fgets(line, 255, inpFileEE)) {
     sscanf(line, "%d %d %d %f ", &ix, &iy, &iz, &thresh);
     if (ii == 0)
-      cout << "crystal " << ix << "/" << iy << "/" << iz << " Thresh= " << thresh << endl;
+      edm::LogVerbatim("StoreEcalCondition")
+          << "crystal " << ix << "/" << iy << "/" << iz << " Thresh= " << thresh << "\n";
     if (EEDetId::validDetId(ix, iy, iz)) {
       EEDetId eeid(ix, iy, iz);
       ical->setValue(eeid.rawId(), thresh);
@@ -578,16 +569,17 @@ EcalPFRecHitThresholds* StoreEcalCondition::readEcalPFRecHitThresholdsFromFile(c
   //    inf.close();           // close inp. file
   fclose(inpFileEE);  // close inp. file
 
-  cout << "loop on EE channels done - number of crystals =" << ii << std::endl;
+  edm::LogInfo("StoreEcalCondition") << "loop on EE channels done - number of crystals =" << ii;
 
   return ical;
 }
+
 //-------------------------------------------------------------
-EcalIntercalibConstants* StoreEcalCondition::readEcalIntercalibConstantsFromFile(const char* inputFile,
-                                                                                 const char* inputFileEE) {
+std::shared_ptr<EcalIntercalibConstants> StoreEcalCondition::readEcalIntercalibConstantsFromFile(
+    const char* inputFile, const char* inputFileEE) {
   //-------------------------------------------------------------
 
-  EcalIntercalibConstants* ical = new EcalIntercalibConstants();
+  auto ical = std::make_shared<EcalIntercalibConstants>();
 
   FILE* inpFile;  // input file
   inpFile = fopen(inputFile, "r");
@@ -605,7 +597,7 @@ EcalIntercalibConstants* StoreEcalCondition::readEcalIntercalibConstantsFromFile
   int sm_number = 0;
   int nchan = 1700;
   sm_number = atoi(line);
-  str << "sm= " << sm_number << endl;
+  str << "sm= " << sm_number << "\n";
   if (sm_number != -1) {
     nchan = 1700;
   } else {
@@ -617,19 +609,19 @@ EcalIntercalibConstants* StoreEcalCondition::readEcalIntercalibConstantsFromFile
 
   fgets(line, 255, inpFile);
   string gen_tag = to_string(line);
-  str << "gen tag " << gen_tag << endl;  // should I use this?
+  str << "gen tag " << gen_tag << "\n";  // should I use this?
 
   fgets(line, 255, inpFile);
   string cali_method = to_string(line);
-  str << "cali method " << cali_method << endl;  // not important
+  str << "cali method " << cali_method << "\n";  // not important
 
   fgets(line, 255, inpFile);
   string cali_version = to_string(line);
-  str << "cali version " << cali_version << endl;  // not important
+  str << "cali version " << cali_version << "\n";  // not important
 
   fgets(line, 255, inpFile);
   string cali_type = to_string(line);
-  str << "cali type " << cali_type << endl;  // not important
+  str << "cali type " << cali_type << "\n";  // not important
 
   edm::LogInfo("StoreEcalCondition") << "Intercalibration file " << str.str();
 
@@ -652,11 +644,12 @@ EcalIntercalibConstants* StoreEcalCondition::readEcalIntercalibConstantsFromFile
     }
   } else {
     // this is for the whole Barrel
-    cout << "mode ALL BARREL" << endl;
+    edm::LogInfo("StoreEcalCondition") << "mode ALL BARREL";
     while (fgets(line, 255, inpFile)) {
       sscanf(line, "%d %d %f %f %d", &sm_num[ii], &cry_num[ii], &calib[ii], &calib_rms[ii], &calib_status[ii]);
       if (ii == 0)
-        cout << "crystal " << cry_num[ii] << " of sm " << sm_num[ii] << " cali= " << calib[ii] << endl;
+        edm::LogVerbatim("StoreEcalCondition")
+            << "crystal " << cry_num[ii] << " of sm " << sm_num[ii] << " cali= " << calib[ii] << "\n";
       ii++;
     }
   }
@@ -666,9 +659,8 @@ EcalIntercalibConstants* StoreEcalCondition::readEcalIntercalibConstantsFromFile
 
   edm::LogInfo("StoreEcalCondition") << "Read intercalibrations for " << ii << " xtals ";
 
-  cout << " I read the calibrations for " << ii << " crystals " << endl;
   if (ii != nchan)
-    edm::LogWarning("StoreEcalCondition") << "Some crystals missing. Missing channels will be set to 0" << endl;
+    edm::LogWarning("StoreEcalCondition") << "Some crystals missing. Missing channels will be set to 0";
 
   // Get channel ID
 
@@ -685,12 +677,12 @@ EcalIntercalibConstants* StoreEcalCondition::readEcalIntercalibConstantsFromFile
     ical->setValue(ebid.rawId(), calib[i]);
 
     if (i == 0)
-      cout << "crystal " << cry_num[i] << " of sm " << sm_num[i] << " in slot " << slot_num << " calib= " << calib[i]
-           << endl;
+      edm::LogVerbatim("StoreEcalCondition") << "crystal " << cry_num[i] << " of sm " << sm_num[i] << " in slot "
+                                             << slot_num << " calib= " << calib[i] << "\n";
 
   }  // loop over channels
 
-  cout << "loop on channels done" << endl;
+  edm::LogInfo("StoreEcalCondition") << "loop on channels done";
 
   FILE* inpFileEE;  // input file
   inpFileEE = fopen(inputFileEE, "r");
@@ -714,7 +706,7 @@ EcalIntercalibConstants* StoreEcalCondition::readEcalIntercalibConstantsFromFile
     }
 
   } else {
-    cout << "... now reading EE file ..." << endl;
+    edm::LogInfo("StoreEcalCondition") << "... now reading EE file ...";
 
     int ii = 0;
     while (fgets(line, 255, inpFileEE)) {
@@ -722,7 +714,8 @@ EcalIntercalibConstants* StoreEcalCondition::readEcalIntercalibConstantsFromFile
       float calibee;
       sscanf(line, "%d %d %d %f", &iz, &ix, &iy, &calibee);
       if (ii <= 0)
-        cout << "crystal " << iz << "/" << ix << "/" << iy << " cali=" << calibee << endl;
+        edm::LogVerbatim("StoreEcalCondition")
+            << "crystal " << iz << "/" << ix << "/" << iy << " cali=" << calibee << "\n";
 
       if (EEDetId::validDetId(ix, iy, iz)) {
         EEDetId eedetid(ix, iy, iz);
@@ -735,17 +728,17 @@ EcalIntercalibConstants* StoreEcalCondition::readEcalIntercalibConstantsFromFile
     fclose(inpFileEE);  // close inp. file
   }
 
-  cout << "loop on EE channels done" << endl;
+  edm::LogInfo("StoreEcalCondition") << "loop on EE channels done";
 
   return ical;
 }
 
 //-------------------------------------------------------------
-EcalIntercalibConstantsMC* StoreEcalCondition::readEcalIntercalibConstantsMCFromFile(const char* inputFile,
-                                                                                     const char* inputFileEE) {
+std::shared_ptr<EcalIntercalibConstantsMC> StoreEcalCondition::readEcalIntercalibConstantsMCFromFile(
+    const char* inputFile, const char* inputFileEE) {
   //-------------------------------------------------------------
 
-  EcalIntercalibConstantsMC* ical = new EcalIntercalibConstantsMC();
+  auto ical = std::make_shared<EcalIntercalibConstantsMC>();
 
   FILE* inpFile;  // input file
   inpFile = fopen(inputFile, "r");
@@ -763,7 +756,7 @@ EcalIntercalibConstantsMC* StoreEcalCondition::readEcalIntercalibConstantsMCFrom
   int sm_number = 0;
   int nchan = 1700;
   sm_number = atoi(line);
-  str << "sm= " << sm_number << endl;
+  str << "sm= " << sm_number << "\n";
   if (sm_number != -1) {
     nchan = 1700;
   } else {
@@ -775,19 +768,19 @@ EcalIntercalibConstantsMC* StoreEcalCondition::readEcalIntercalibConstantsMCFrom
 
   fgets(line, 255, inpFile);
   string gen_tag = to_string(line);
-  str << "gen tag " << gen_tag << endl;  // should I use this?
+  str << "gen tag " << gen_tag << "\n";  // should I use this?
 
   fgets(line, 255, inpFile);
   string cali_method = to_string(line);
-  str << "cali method " << cali_method << endl;  // not important
+  str << "cali method " << cali_method << "\n";  // not important
 
   fgets(line, 255, inpFile);
   string cali_version = to_string(line);
-  str << "cali version " << cali_version << endl;  // not important
+  str << "cali version " << cali_version << "\n";  // not important
 
   fgets(line, 255, inpFile);
   string cali_type = to_string(line);
-  str << "cali type " << cali_type << endl;  // not important
+  str << "cali type " << cali_type << "\n";  // not important
 
   edm::LogInfo("StoreEcalCondition") << "Intercalibration file " << str.str();
 
@@ -810,11 +803,12 @@ EcalIntercalibConstantsMC* StoreEcalCondition::readEcalIntercalibConstantsMCFrom
     }
   } else {
     // this is for the whole Barrel
-    cout << "mode ALL BARREL" << endl;
+    edm::LogInfo("StoreEcalCondition") << "mode ALL BARREL";
     while (fgets(line, 255, inpFile)) {
       sscanf(line, "%d %d %f %f %d", &sm_num[ii], &cry_num[ii], &calib[ii], &calib_rms[ii], &calib_status[ii]);
       if (ii == 0)
-        cout << "crystal " << cry_num[ii] << " of sm " << sm_num[ii] << " cali= " << calib[ii] << endl;
+        edm::LogVerbatim("StoreEcalCondition")
+            << "crystal " << cry_num[ii] << " of sm " << sm_num[ii] << " cali= " << calib[ii] << "\n";
       ii++;
     }
   }
@@ -824,9 +818,8 @@ EcalIntercalibConstantsMC* StoreEcalCondition::readEcalIntercalibConstantsMCFrom
 
   edm::LogInfo("StoreEcalCondition") << "Read intercalibrations for " << ii << " xtals ";
 
-  cout << " I read the calibrations for " << ii << " crystals " << endl;
   if (ii != nchan)
-    edm::LogWarning("StoreEcalCondition") << "Some crystals missing. Missing channels will be set to 0" << endl;
+    edm::LogWarning("StoreEcalCondition") << "Some crystals missing. Missing channels will be set to 0";
 
   // Get channel ID
 
@@ -843,12 +836,12 @@ EcalIntercalibConstantsMC* StoreEcalCondition::readEcalIntercalibConstantsMCFrom
     ical->setValue(ebid.rawId(), calib[i]);
 
     if (i == 0)
-      cout << "crystal " << cry_num[i] << " of sm " << sm_num[i] << " in slot " << slot_num << " calib= " << calib[i]
-           << endl;
+      edm::LogVerbatim("StoreEcalCondition") << "crystal " << cry_num[i] << " of sm " << sm_num[i] << " in slot "
+                                             << slot_num << " calib= " << calib[i] << "\n";
 
   }  // loop over channels
 
-  cout << "loop on channels done" << endl;
+  edm::LogInfo("StoreEcalCondition") << "loop on channels done";
 
   FILE* inpFileEE;  // input file
   inpFileEE = fopen(inputFileEE, "r");
@@ -872,7 +865,7 @@ EcalIntercalibConstantsMC* StoreEcalCondition::readEcalIntercalibConstantsMCFrom
     }
 
   } else {
-    cout << "... now reading EE file ..." << endl;
+    edm::LogInfo("StoreEcalCondition") << "... now reading EE file ...";
 
     int ii = 0;
     while (fgets(line, 255, inpFileEE)) {
@@ -880,7 +873,8 @@ EcalIntercalibConstantsMC* StoreEcalCondition::readEcalIntercalibConstantsMCFrom
       float calibee;
       sscanf(line, "%d %d %d %f", &iz, &ix, &iy, &calibee);
       if (ii <= 0)
-        cout << "crystal " << iz << "/" << ix << "/" << iy << " cali=" << calibee << endl;
+        edm::LogVerbatim("StoreEcalCondition")
+            << "crystal " << iz << "/" << ix << "/" << iy << " cali=" << calibee << "\n";
 
       if (EEDetId::validDetId(ix, iy, iz)) {
         EEDetId eedetid(ix, iy, iz);
@@ -893,7 +887,7 @@ EcalIntercalibConstantsMC* StoreEcalCondition::readEcalIntercalibConstantsMCFrom
     fclose(inpFileEE);  // close inp. file
   }
 
-  cout << "loop on EE channels done" << endl;
+  edm::LogInfo("StoreEcalCondition") << "loop on EE channels done";
 
   return ical;
 }
@@ -919,11 +913,11 @@ int StoreEcalCondition::convertFromConstructionSMToSlot(int sm_constr, int sm_sl
 }
 
 //-------------------------------------------------------------
-EcalGainRatios* StoreEcalCondition::readEcalGainRatiosFromFile(const char* inputFile) {
+std::shared_ptr<EcalGainRatios> StoreEcalCondition::readEcalGainRatiosFromFile(const char* inputFile) {
   //-------------------------------------------------------------
 
   // create gain ratios
-  EcalGainRatios* gratio = new EcalGainRatios;
+  auto gratio = std::make_shared<EcalGainRatios>();
 
   FILE* inpFile;  // input file
   inpFile = fopen(inputFile, "r");
@@ -939,27 +933,27 @@ EcalGainRatios* StoreEcalCondition::readEcalGainRatiosFromFile(const char* input
   string sm_or_all = to_string(line);
   int sm_number = 0;
   sm_number = atoi(line);
-  str << "sm= " << sm_number << endl;
+  str << "sm= " << sm_number << "\n";
 
   fgets(line, 255, inpFile);
   //int nevents=atoi(line);
 
   fgets(line, 255, inpFile);
   string gen_tag = to_string(line);
-  str << "gen tag " << gen_tag << endl;
+  str << "gen tag " << gen_tag << "\n";
 
   fgets(line, 255, inpFile);
   string cali_method = to_string(line);
-  str << "cali method " << cali_method << endl;
+  str << "cali method " << cali_method << "\n";
 
   fgets(line, 255, inpFile);
   string cali_version = to_string(line);
-  str << "cali version " << cali_version << endl;
+  str << "cali version " << cali_version << "\n";
 
   fgets(line, 255, inpFile);
   string cali_type = to_string(line);
 
-  str << "cali type " << cali_type << endl;
+  str << "cali type " << cali_type << "\n";
 
   edm::LogInfo("StoreEcalCondition") << "GainRatio file " << str.str();
 
@@ -983,7 +977,7 @@ EcalGainRatios* StoreEcalCondition::readEcalGainRatiosFromFile(const char* input
 
     edm::LogInfo("StoreEcalCondition") << "Read gainRatios for " << ii << " xtals ";
     if (ii != 1700)
-      edm::LogWarning("StoreEcalCondition") << " Missing crystals:: missing channels will be set to 0" << endl;
+      edm::LogWarning("StoreEcalCondition") << " Missing crystals:: missing channels will be set to 0";
 
     // Get channel ID
     sm_constr_ = sm_number;
@@ -992,7 +986,6 @@ EcalGainRatios* StoreEcalCondition::readEcalGainRatiosFromFile(const char* input
       // EBDetId(int index1, int index2, int mode = ETAPHIMODE)
       // sm and crys index SMCRYSTALMODE index1 is SM index2 is crystal number a la H4
       EBDetId ebid(sm_slot_, cry_num[i], EBDetId::SMCRYSTALMODE);
-      // cout << "ebid.rawId()"<< ebid.rawId()<< endl;
       EcalMGPAGainRatio gr;
       gr.setGain12Over6(g6_g12[i]);
       gr.setGain6Over1(g1_g12[i] / g6_g12[i]);
@@ -1001,13 +994,14 @@ EcalGainRatios* StoreEcalCondition::readEcalGainRatiosFromFile(const char* input
 
   } else {
     // this is for the whole Barrel
-    cout << "mode ALL BARREL" << endl;
+    edm::LogInfo("StoreEcalCondition") << "mode ALL BARREL";
     while (fgets(line, 255, inpFile)) {
       int eta = 0;
       int phi = 0;
       sscanf(line, "%d %d %d %f %f", &hash1, &eta, &phi, &g1_g12[ii], &g6_g12[ii]);
       if (ii < 20)
-        cout << "crystal eta/phi=" << eta << "/" << phi << " g1_12/g6_12= " << g1_g12[ii] << "/" << g6_g12[ii] << endl;
+        edm::LogVerbatim("StoreEcalCondition")
+            << "crystal eta/phi=" << eta << "/" << phi << " g1_12/g6_12= " << g1_g12[ii] << "/" << g6_g12[ii] << "\n";
 
       if (g1_g12[ii] < 9 || g1_g12[ii] > 15)
         g1_g12[ii] = 12.0;
@@ -1015,9 +1009,9 @@ EcalGainRatios* StoreEcalCondition::readEcalGainRatiosFromFile(const char* input
         g6_g12[ii] = 2.0;
 
       if (eta < -85 || eta > 85 || eta == 0)
-        std::cout << "error!!!" << endl;
+        edm::LogVerbatim("StoreEcalCondition") << "error!!!\n";
       if (phi < 1 || phi > 360)
-        std::cout << "error!!!" << endl;
+        edm::LogVerbatim("StoreEcalCondition") << "error!!!\n";
 
       EBDetId ebid(eta, phi, EBDetId::ETAPHIMODE);
       EcalMGPAGainRatio gr;
@@ -1030,9 +1024,9 @@ EcalGainRatios* StoreEcalCondition::readEcalGainRatiosFromFile(const char* input
 
     fclose(inpFile);  // close inp. file
     if (ii != 61200)
-      edm::LogWarning("StoreEcalCondition") << " Missing crystals !!!!!!!" << endl;
+      edm::LogWarning("StoreEcalCondition") << " Missing crystals !!!!!!!";
 
-    std::cout << "number of crystals read:" << ii << endl;
+    edm::LogInfo("StoreEcalCondition") << "number of crystals read:" << ii;
   }
 
   for (int iX = EEDetId::IX_MIN; iX <= EEDetId::IX_MAX; ++iX) {
@@ -1053,15 +1047,15 @@ EcalGainRatios* StoreEcalCondition::readEcalGainRatiosFromFile(const char* input
     }
   }
 
-  std::cout << " gratio pointer=" << gratio << endl;
+  edm::LogInfo("StoreEcalCondition") << " gratio pointer=" << gratio;
 
-  std::cout << "now leaving" << endl;
+  edm::LogInfo("StoreEcalCondition") << "now leaving";
 
   return gratio;
 }
 
-EcalChannelStatus* StoreEcalCondition::readEcalChannelStatusFromFile(const char* inputFile) {
-  EcalChannelStatus* status = new EcalChannelStatus();
+std::shared_ptr<EcalChannelStatus> StoreEcalCondition::readEcalChannelStatusFromFile(const char* inputFile) {
+  auto status = std::make_shared<EcalChannelStatus>();
   // barrel
   for (int ieta = -EBDetId::MAX_IETA; ieta <= EBDetId::MAX_IETA; ++ieta) {
     if (ieta == 0)
@@ -1088,8 +1082,7 @@ EcalChannelStatus* StoreEcalCondition::readEcalChannelStatusFromFile(const char*
     }
   }
 
-  //        edm::LogInfo("EcalTrivialConditionRetriever") << "Reading channel status from file " << edm::FileInPath(channelStatusFile_).fullPath().c_str() ;
-  std::cout << "Reading channel status from file " << inputFile << std::endl;
+  edm::LogInfo("StoreEcalCondition") << "Reading channel status from file " << inputFile;
   FILE* ifile = fopen(inputFile, "r");
   if (!ifile)
     throw cms::Exception("Cannot open ECAL channel status file");
@@ -1098,22 +1091,22 @@ EcalChannelStatus* StoreEcalCondition::readEcalChannelStatusFromFile(const char*
 
   fgets(line, 255, ifile);
   std::string gen_tag = line;
-  std::cout << "Gen tag " << gen_tag << std::endl;
+  edm::LogVerbatim("StoreEcalCondition") << "Gen tag " << gen_tag << "\n";
 
   fgets(line, 255, ifile);
   std::string comment = line;
-  std::cout << "Gen comment " << comment << std::endl;
+  edm::LogVerbatim("StoreEcalCondition") << "Gen comment " << comment << "\n";
 
   int iovRunStart(0);
   fgets(line, 255, ifile);
   sscanf(line, "%d", &iovRunStart);
-  std::cout << "IOV START " << iovRunStart << std::endl;
+  edm::LogVerbatim("StoreEcalCondition") << "IOV START " << iovRunStart << "\n";
   //if -1 start of time
 
   int iovRunEnd(0);
   fgets(line, 255, ifile);
   sscanf(line, "%d", &iovRunEnd);
-  std::cout << "IOV END " << iovRunEnd << std::endl;
+  edm::LogVerbatim("StoreEcalCondition") << "IOV END " << iovRunEnd << "\n";
   //if -1 end of time
 
   int ii = 0;
@@ -1125,7 +1118,8 @@ EcalChannelStatus* StoreEcalCondition::readEcalChannelStatusFromFile(const char*
     aStrStream << line;
     aStrStream >> EBorEE >> hashedIndex >> chStatus;
     //	    if(ii==0)
-    std::cout << EBorEE << " hashedIndex " << hashedIndex << " status " << chStatus << std::endl;
+    edm::LogVerbatim("StoreEcalCondition")
+        << EBorEE << " hashedIndex " << hashedIndex << " status " << chStatus << "\n";
 
     if (EBorEE == "EB") {
       EBDetId aEBDetId = EBDetId::unhashIndex(hashedIndex);
@@ -1147,7 +1141,7 @@ EcalChannelStatus* StoreEcalCondition::readEcalChannelStatusFromFile(const char*
       for (int ieta = iymin; ieta <= iymax; ieta++) {
         for (int iphi = ixmin; iphi <= ixmax; iphi++) {
           int ixt = ieta * 20 + iphi + 1;
-          std::cout << "killing crystal " << ism << "/" << ixt << endl;
+          edm::LogVerbatim("StoreEcalCondition") << "killing crystal " << ism << "/" << ixt << "\n";
           EBDetId ebid(ism, ixt, EBDetId::SMCRYSTALMODE);
           status->setValue(ebid, 1);
         }

--- a/CondTools/Ecal/plugins/StoreEcalCondition.h
+++ b/CondTools/Ecal/plugins/StoreEcalCondition.h
@@ -5,7 +5,7 @@
 
 #include <string>
 #include <map>
-#include <iostream>
+#include <memory>
 #include <fstream>
 #include <cstdio>
 #include <typeinfo>
@@ -38,14 +38,14 @@ namespace edm {
 
 class StoreEcalCondition : public edm::one::EDAnalyzer<> {
 public:
-  EcalWeightXtalGroups* readEcalWeightXtalGroupsFromFile(const char*);
-  EcalTBWeights* readEcalTBWeightsFromFile(const char*);
-  EcalADCToGeVConstant* readEcalADCToGeVConstantFromFile(const char*);
-  EcalIntercalibConstants* readEcalIntercalibConstantsFromFile(const char*, const char*);
-  EcalPFRecHitThresholds* readEcalPFRecHitThresholdsFromFile(const char*, const char*);
-  EcalIntercalibConstantsMC* readEcalIntercalibConstantsMCFromFile(const char*, const char*);
-  EcalGainRatios* readEcalGainRatiosFromFile(const char*);
-  EcalChannelStatus* readEcalChannelStatusFromFile(const char*);
+  std::shared_ptr<EcalWeightXtalGroups> readEcalWeightXtalGroupsFromFile(const char*);
+  std::shared_ptr<EcalTBWeights> readEcalTBWeightsFromFile(const char*);
+  std::shared_ptr<EcalADCToGeVConstant> readEcalADCToGeVConstantFromFile(const char*);
+  std::shared_ptr<EcalIntercalibConstants> readEcalIntercalibConstantsFromFile(const char*, const char*);
+  std::shared_ptr<EcalPFRecHitThresholds> readEcalPFRecHitThresholdsFromFile(const char*, const char*);
+  std::shared_ptr<EcalIntercalibConstantsMC> readEcalIntercalibConstantsMCFromFile(const char*, const char*);
+  std::shared_ptr<EcalGainRatios> readEcalGainRatiosFromFile(const char*);
+  std::shared_ptr<EcalChannelStatus> readEcalChannelStatusFromFile(const char*);
   void writeToLogFile(std::string, std::string, unsigned long long);
   void writeToLogFileResults(char*);
   int convertFromConstructionSMToSlot(int, int);

--- a/CondTools/Ecal/plugins/StoreEcalCondition.h
+++ b/CondTools/Ecal/plugins/StoreEcalCondition.h
@@ -1,7 +1,7 @@
-#ifndef StoreEcalCondition_h
-#define StoreEcalCondition_h
+#ifndef CondTools_Ecal_StoreEcalCondition_h
+#define CondTools_Ecal_StoreEcalCondition_h
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include <string>
 #include <map>
@@ -36,7 +36,7 @@ namespace edm {
 // class decleration
 //
 
-class StoreEcalCondition : public edm::EDAnalyzer {
+class StoreEcalCondition : public edm::one::EDAnalyzer<> {
 public:
   EcalWeightXtalGroups* readEcalWeightXtalGroupsFromFile(const char*);
   EcalTBWeights* readEcalTBWeightsFromFile(const char*);

--- a/CondTools/Ecal/src/ESDBCopy.cc
+++ b/CondTools/Ecal/src/ESDBCopy.cc
@@ -75,40 +75,34 @@ void ESDBCopy::copyToDB(const edm::EventSetup& evtSetup, const std::string& cont
   std::string recordName = m_records[container];
 
   if (container == "ESPedestals") {
-    const auto* obj = &evtSetup.getData(esPedestalsToken_);
-    edm::LogInfo("ESDBCopy") << "ped pointer is: " << obj;
-    dbOutput->createNewIOV<const ESPedestals>(
-        new ESPedestals(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    const auto obj = evtSetup.getData(esPedestalsToken_);
+    edm::LogInfo("ESDBCopy") << "ped pointer is: " << &obj;
+    dbOutput->createOneIOV<const ESPedestals>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "ESADCToGeVConstant") {
-    const auto* obj = &evtSetup.getData(esADCToGeVConstantToken_);
-    edm::LogInfo("ESDBCopy") << "adc pointer is: " << obj;
-    dbOutput->createNewIOV<const ESADCToGeVConstant>(
-        new ESADCToGeVConstant(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    const auto obj = evtSetup.getData(esADCToGeVConstantToken_);
+    edm::LogInfo("ESDBCopy") << "adc pointer is: " << &obj;
+    dbOutput->createOneIOV<const ESADCToGeVConstant>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "ESChannelStatus") {
-    const auto* obj = &evtSetup.getData(esChannelStatusToken_);
-    edm::LogInfo("ESDBCopy") << "channel status pointer is: " << obj;
-    dbOutput->createNewIOV<const ESChannelStatus>(
-        new ESChannelStatus(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    const auto obj = evtSetup.getData(esChannelStatusToken_);
+    edm::LogInfo("ESDBCopy") << "channel status pointer is: " << &obj;
+    dbOutput->createOneIOV<const ESChannelStatus>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "ESIntercalibConstants") {
-    const auto* obj = &evtSetup.getData(esIntercalibConstantsToken_);
-    edm::LogInfo("ESDBCopy") << "inter pointer is: " << obj;
-    dbOutput->createNewIOV<const ESIntercalibConstants>(
-        new ESIntercalibConstants(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    const auto obj = evtSetup.getData(esIntercalibConstantsToken_);
+    edm::LogInfo("ESDBCopy") << "inter pointer is: " << &obj;
+    dbOutput->createOneIOV<const ESIntercalibConstants>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "ESWeightStripGroups") {
-    const auto* obj = &evtSetup.getData(esWeightStripGroupsToken_);
-    edm::LogInfo("ESDBCopy") << "weight pointer is: " << obj;
-    dbOutput->createNewIOV<const ESWeightStripGroups>(
-        new ESWeightStripGroups(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    const auto obj = evtSetup.getData(esWeightStripGroupsToken_);
+    edm::LogInfo("ESDBCopy") << "weight pointer is: " << &obj;
+    dbOutput->createOneIOV<const ESWeightStripGroups>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "ESTBWeights") {
-    const auto* obj = &evtSetup.getData(esTBWeightsToken_);
-    edm::LogInfo("ESDBCopy") << "tbweight pointer is: " << obj;
-    dbOutput->createNewIOV<const ESTBWeights>(
-        new ESTBWeights(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    const auto obj = evtSetup.getData(esTBWeightsToken_);
+    edm::LogInfo("ESDBCopy") << "tbweight pointer is: " << &obj;
+    dbOutput->createOneIOV<const ESTBWeights>(obj, dbOutput->beginOfTime(), recordName);
 
   } else {
     throw cms::Exception("Unknown container");

--- a/CondTools/Ecal/src/ESDBCopy.cc
+++ b/CondTools/Ecal/src/ESDBCopy.cc
@@ -75,32 +75,32 @@ void ESDBCopy::copyToDB(const edm::EventSetup& evtSetup, const std::string& cont
   std::string recordName = m_records[container];
 
   if (container == "ESPedestals") {
-    const auto obj = evtSetup.getData(esPedestalsToken_);
+    const auto& obj = evtSetup.getData(esPedestalsToken_);
     edm::LogInfo("ESDBCopy") << "ped pointer is: " << &obj;
     dbOutput->createOneIOV<const ESPedestals>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "ESADCToGeVConstant") {
-    const auto obj = evtSetup.getData(esADCToGeVConstantToken_);
+    const auto& obj = evtSetup.getData(esADCToGeVConstantToken_);
     edm::LogInfo("ESDBCopy") << "adc pointer is: " << &obj;
     dbOutput->createOneIOV<const ESADCToGeVConstant>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "ESChannelStatus") {
-    const auto obj = evtSetup.getData(esChannelStatusToken_);
+    const auto& obj = evtSetup.getData(esChannelStatusToken_);
     edm::LogInfo("ESDBCopy") << "channel status pointer is: " << &obj;
     dbOutput->createOneIOV<const ESChannelStatus>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "ESIntercalibConstants") {
-    const auto obj = evtSetup.getData(esIntercalibConstantsToken_);
+    const auto& obj = evtSetup.getData(esIntercalibConstantsToken_);
     edm::LogInfo("ESDBCopy") << "inter pointer is: " << &obj;
     dbOutput->createOneIOV<const ESIntercalibConstants>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "ESWeightStripGroups") {
-    const auto obj = evtSetup.getData(esWeightStripGroupsToken_);
+    const auto& obj = evtSetup.getData(esWeightStripGroupsToken_);
     edm::LogInfo("ESDBCopy") << "weight pointer is: " << &obj;
     dbOutput->createOneIOV<const ESWeightStripGroups>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "ESTBWeights") {
-    const auto obj = evtSetup.getData(esTBWeightsToken_);
+    const auto& obj = evtSetup.getData(esTBWeightsToken_);
     edm::LogInfo("ESDBCopy") << "tbweight pointer is: " << &obj;
     dbOutput->createOneIOV<const ESTBWeights>(obj, dbOutput->beginOfTime(), recordName);
 

--- a/CondTools/Ecal/src/EcalDBCopy.cc
+++ b/CondTools/Ecal/src/EcalDBCopy.cc
@@ -209,200 +209,167 @@ void EcalDBCopy::copyToDB(const edm::EventSetup& evtSetup, const std::string& co
   std::string recordName = m_records[container];
 
   if (container == "EcalPedestals") {
-    const auto obj = evtSetup.getData(ecalPedestalToken_);
+    const auto& obj = evtSetup.getData(ecalPedestalToken_);
     edm::LogInfo("EcalDBCopy") << "ped pointer is: " << &obj << std::endl;
-    dbOutput->createOneIOV<const EcalPedestals>(
-        obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalPedestals>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalADCToGeVConstant") {
-    const auto obj = evtSetup.getData(ecalADCtoGeVToken_);
+    const auto& obj = evtSetup.getData(ecalADCtoGeVToken_);
     edm::LogInfo("EcalDBCopy") << "adc pointer is: " << &obj << std::endl;
-    dbOutput->createOneIOV<const EcalADCToGeVConstant>(
-        obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalADCToGeVConstant>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTimeCalibConstants") {
-    const auto obj = evtSetup.getData(ecalTimeCalibToken_);
+    const auto& obj = evtSetup.getData(ecalTimeCalibToken_);
     edm::LogInfo("EcalDBCopy") << "adc pointer is: " << &obj << std::endl;
-    dbOutput->createOneIOV<const EcalTimeCalibConstants>(
-        obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTimeCalibConstants>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalChannelStatus") {
-    const auto obj = evtSetup.getData(ecalChannelStatusToken_);
+    const auto& obj = evtSetup.getData(ecalChannelStatusToken_);
     edm::LogInfo("EcalDBCopy") << "channel status pointer is: " << &obj << std::endl;
-    dbOutput->createOneIOV<const EcalChannelStatus>(
-        obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalChannelStatus>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalDQMChannelStatus") {
-    const auto obj = evtSetup.getData(ecalDQMChannelStatusToken_);
+    const auto& obj = evtSetup.getData(ecalDQMChannelStatusToken_);
     edm::LogInfo("EcalDBCopy") << "DQM channel status pointer is: " << &obj << std::endl;
-    dbOutput->createOneIOV<const EcalDQMChannelStatus>(
-        obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalDQMChannelStatus>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalDQMTowerStatus") {
-    const auto obj = evtSetup.getData(ecalDQMTowerStatusToken_);
+    const auto& obj = evtSetup.getData(ecalDQMTowerStatusToken_);
     edm::LogInfo("EcalDBCopy") << "DQM Tower status pointer is: " << &obj << std::endl;
-    dbOutput->createOneIOV<const EcalDQMTowerStatus>(
-        obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalDQMTowerStatus>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalDCSTowerStatus") {
-    const auto obj = evtSetup.getData(ecalDCSTowerStatusToken_);
+    const auto& obj = evtSetup.getData(ecalDCSTowerStatusToken_);
     edm::LogInfo("EcalDBCopy") << "channel status pointer is: " << &obj << std::endl;
-    dbOutput->createOneIOV<const EcalDCSTowerStatus>(
-        obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalDCSTowerStatus>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalDAQTowerStatus") {
-    const auto obj = evtSetup.getData(ecalDAQTowerStatusToken_);
+    const auto& obj = evtSetup.getData(ecalDAQTowerStatusToken_);
     edm::LogInfo("EcalDBCopy") << "DAQ channel status pointer is: " << &obj << std::endl;
-    dbOutput->createOneIOV<const EcalDAQTowerStatus>(
-        obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalDAQTowerStatus>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGCrystalStatus") {
-    const auto obj = evtSetup.getData(ecalTPGCrystalStatusToken_);
+    const auto& obj = evtSetup.getData(ecalTPGCrystalStatusToken_);
     edm::LogInfo("EcalDBCopy") << "TPG channel status pointer is: " << &obj << std::endl;
-    dbOutput->createOneIOV<const EcalTPGCrystalStatus>(
-        obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTPGCrystalStatus>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGTowerStatus") {
-    const auto obj = evtSetup.getData(ecalTPGTowerStatusToken_);
+    const auto& obj = evtSetup.getData(ecalTPGTowerStatusToken_);
     edm::LogInfo("EcalDBCopy") << "TPG tower status pointer is: " << &obj << std::endl;
-    dbOutput->createOneIOV<const EcalTPGTowerStatus>(
-        obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTPGTowerStatus>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalIntercalibConstants") {
-    const auto obj = evtSetup.getData(ecalIntercalibConstantsToken_);
+    const auto& obj = evtSetup.getData(ecalIntercalibConstantsToken_);
     edm::LogInfo("EcalDBCopy") << "inter pointer is: " << &obj << std::endl;
-    dbOutput->createOneIOV<const EcalIntercalibConstants>(
-        obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalIntercalibConstants>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalLinearCorrections") {
-    const auto obj = evtSetup.getData(ecalLinearCorrectionsToken_);
+    const auto& obj = evtSetup.getData(ecalLinearCorrectionsToken_);
     edm::LogInfo("EcalDBCopy") << "inter pointer is: " << &obj << std::endl;
-    dbOutput->createOneIOV<const EcalLinearCorrections>(
-        obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalLinearCorrections>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalIntercalibConstantsMC") {
-    const auto obj = evtSetup.getData(ecalIntercalibConstantsMCToken_);
+    const auto& obj = evtSetup.getData(ecalIntercalibConstantsMCToken_);
     edm::LogInfo("EcalDBCopy") << "intercalib MC pointer is: " << &obj << std::endl;
-    dbOutput->createOneIOV<const EcalIntercalibConstantsMC>(
-        obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalIntercalibConstantsMC>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalIntercalibErrors") {
-    const auto obj = evtSetup.getData(ecalIntercalibErrorsToken_);
+    const auto& obj = evtSetup.getData(ecalIntercalibErrorsToken_);
     edm::LogInfo("EcalDBCopy") << "inter pointer is: " << &obj << std::endl;
-    dbOutput->createOneIOV<const EcalIntercalibErrors>(
-        obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalIntercalibErrors>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalGainRatios") {
-    const auto obj = evtSetup.getData(ecalGainRatiosToken_);
+    const auto& obj = evtSetup.getData(ecalGainRatiosToken_);
     edm::LogInfo("EcalDBCopy") << "gain pointer is: " << &obj << std::endl;
-    dbOutput->createOneIOV<const EcalGainRatios>(
-        obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalGainRatios>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalWeightXtalGroups") {
-    const auto obj = evtSetup.getData(ecalWeightXtalGroupsToken_);
+    const auto& obj = evtSetup.getData(ecalWeightXtalGroupsToken_);
     edm::LogInfo("EcalDBCopy") << "weight pointer is: " << &obj << std::endl;
-    dbOutput->createOneIOV<const EcalWeightXtalGroups>(
-        obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalWeightXtalGroups>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTBWeights") {
-    const auto obj = evtSetup.getData(ecalTBWeightsToken_);
+    const auto& obj = evtSetup.getData(ecalTBWeightsToken_);
     edm::LogInfo("EcalDBCopy") << "tbweight pointer is: " << &obj << std::endl;
-    dbOutput->createOneIOV<const EcalTBWeights>(
-        obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTBWeights>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalLaserAlphas") {
-    const auto obj = evtSetup.getData(ecalLaserAlphasToken_);
+    const auto& obj = evtSetup.getData(ecalLaserAlphasToken_);
     edm::LogInfo("EcalDBCopy") << "ecalLaserAlpha pointer is: " << &obj << std::endl;
-    dbOutput->createOneIOV<const EcalLaserAlphas>(
-        obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalLaserAlphas>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalLaserAPDPNRatios") {
-    const auto obj = evtSetup.getData(ecalLaserAPDPNRatiosToken_);
+    const auto& obj = evtSetup.getData(ecalLaserAPDPNRatiosToken_);
     edm::LogInfo("EcalDBCopy") << "tbweight pointer is: " << &obj << std::endl;
-    dbOutput->createOneIOV<const EcalLaserAPDPNRatios>(
-        obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalLaserAPDPNRatios>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalLaserAPDPNRatiosRef") {
-    const auto obj = evtSetup.getData(ecalLaserAPDPNRatiosRefToken_);
+    const auto& obj = evtSetup.getData(ecalLaserAPDPNRatiosRefToken_);
     edm::LogInfo("EcalDBCopy") << "tbweight pointer is: " << &obj << std::endl;
-    dbOutput->createOneIOV<const EcalLaserAPDPNRatiosRef>(
-        obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalLaserAPDPNRatiosRef>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalClusterCrackCorrParameters") {
-    const auto obj = evtSetup.getData(ecalClusterCrackCorrParametersToken_);
+    const auto& obj = evtSetup.getData(ecalClusterCrackCorrParametersToken_);
     edm::LogInfo("EcalDBCopy") << "cluster crack pointer is: " << &obj << std::endl;
-    dbOutput->createOneIOV<const EcalClusterCrackCorrParameters>(
-        obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalClusterCrackCorrParameters>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalPFRecHitThresholds") {
-    const auto obj = evtSetup.getData(ecalPFRecHitThresholdsToken_);
+    const auto& obj = evtSetup.getData(ecalPFRecHitThresholdsToken_);
     edm::LogInfo("EcalDBCopy") << "Ecal PF rec hit thresholds pointer is: " << &obj << std::endl;
-    dbOutput->createOneIOV<const EcalPFRecHitThresholds>(
-        obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalPFRecHitThresholds>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalClusterEnergyUncertaintyParameters") {
-    const auto obj = evtSetup.getData(ecalClusterEnergyUncertaintyParametersToken_);
+    const auto& obj = evtSetup.getData(ecalClusterEnergyUncertaintyParametersToken_);
     edm::LogInfo("EcalDBCopy") << "tbweight pointer is: " << &obj << std::endl;
-    dbOutput->createOneIOV<const EcalClusterEnergyUncertaintyParameters>(
-        obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalClusterEnergyUncertaintyParameters>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalClusterEnergyCorrectionParameters") {
-    const auto obj = evtSetup.getData(ecalClusterEnergyCorrectionParametersToken_);
+    const auto& obj = evtSetup.getData(ecalClusterEnergyCorrectionParametersToken_);
     edm::LogInfo("EcalDBCopy") << "tbweight pointer is: " << &obj << std::endl;
-    dbOutput->createOneIOV<const EcalClusterEnergyCorrectionParameters>(
-        obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalClusterEnergyCorrectionParameters>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalClusterEnergyCorrectionObjectSpecificParameters") {
-    const auto obj = evtSetup.getData(ecalClusterEnergyCorrectionObjectSpecificParametersToken_);
+    const auto& obj = evtSetup.getData(ecalClusterEnergyCorrectionObjectSpecificParametersToken_);
     edm::LogInfo("EcalDBCopy") << "tbweight pointer is: " << &obj << std::endl;
     dbOutput->createOneIOV<const EcalClusterEnergyCorrectionObjectSpecificParameters>(
-        obj,
-        dbOutput->beginOfTime(),
-        recordName);
+        obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalClusterLocalContCorrParameters") {
-    const auto obj = evtSetup.getData(ecalClusterLocalContCorrParametersToken_);
+    const auto& obj = evtSetup.getData(ecalClusterLocalContCorrParametersToken_);
     edm::LogInfo("EcalDBCopy") << "tbweight pointer is: " << &obj << std::endl;
-    dbOutput->createOneIOV<const EcalClusterLocalContCorrParameters>(
-        obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalClusterLocalContCorrParameters>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EBAlignment") {
-    const auto obj = evtSetup.getData(ebAlignmentToken_);
+    const auto& obj = evtSetup.getData(ebAlignmentToken_);
     edm::LogInfo("EcalDBCopy") << "EB alignment pointer is: " << &obj << std::endl;
-    dbOutput->createOneIOV<const Alignments>(
-        obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const Alignments>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EEAlignment") {
-    const auto obj = evtSetup.getData(eeAlignmentToken_);
+    const auto& obj = evtSetup.getData(eeAlignmentToken_);
     edm::LogInfo("EcalDBCopy") << "EE alignment pointer is: " << &obj << std::endl;
-    dbOutput->createOneIOV<const Alignments>(
-        obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const Alignments>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "ESAlignment") {
-    const auto obj = evtSetup.getData(esAlignmentToken_);
+    const auto& obj = evtSetup.getData(esAlignmentToken_);
     edm::LogInfo("EcalDBCopy") << "ES alignment pointer is: " << &obj << std::endl;
-    dbOutput->createOneIOV<const Alignments>(
-        obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const Alignments>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTimeOffsetConstant") {
-    const auto obj = evtSetup.getData(ecalTimeOffsetConstantToken_);
+    const auto& obj = evtSetup.getData(ecalTimeOffsetConstantToken_);
     edm::LogInfo("EcalDBCopy") << "TimeOffset pointer is: " << &obj << std::endl;
-    dbOutput->createOneIOV<const EcalTimeOffsetConstant>(
-        obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalTimeOffsetConstant>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalSampleMask") {
-    const auto obj = evtSetup.getData(ecalSampleMaskToken_);
+    const auto& obj = evtSetup.getData(ecalSampleMaskToken_);
     edm::LogInfo("EcalDBCopy") << "sample mask pointer is: " << &obj << std::endl;
-    dbOutput->createOneIOV<const EcalSampleMask>(
-        obj, dbOutput->beginOfTime(), recordName);
+    dbOutput->createOneIOV<const EcalSampleMask>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalSimPulseShape") {
-    const auto obj = evtSetup.getData(ecalSimPulseShapeToken_);
-    dbOutput->createOneIOV<const EcalSimPulseShape>(
-        obj, dbOutput->beginOfTime(), recordName);
+    const auto& obj = evtSetup.getData(ecalSimPulseShapeToken_);
+    dbOutput->createOneIOV<const EcalSimPulseShape>(obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTimeBiasCorrections") {
-    const auto obj = evtSetup.getData(ecalTimeBiasCorrectionsToken_);
+    const auto& obj = evtSetup.getData(ecalTimeBiasCorrectionsToken_);
     edm::LogInfo("EcalDBCopy") << "TimeBiasCorrections pointer is: " << &obj << std::endl;
     EcalTimeBiasCorrections bias_;
     std::vector<float> vect = obj.EBTimeCorrAmplitudeBins;
@@ -416,7 +383,7 @@ void EcalDBCopy::copyToDB(const edm::EventSetup& evtSetup, const std::string& co
     dbOutput->writeOneIOV(bias_, dbOutput->beginOfTime(), "EcalTimeBiasCorrectionsRcd");
 
   } else if (container == "EcalSamplesCorrelation") {
-    const auto obj = evtSetup.getData(ecalSamplesCorrelationToken_);
+    const auto& obj = evtSetup.getData(ecalSamplesCorrelationToken_);
     edm::LogInfo("EcalDBCopy") << "SamplesCorrelation pointer is: " << &obj << std::endl;
     EcalSamplesCorrelation correl_;
     std::vector<double> vect = obj.EBG12SamplesCorrelation;

--- a/CondTools/Ecal/src/EcalDBCopy.cc
+++ b/CondTools/Ecal/src/EcalDBCopy.cc
@@ -209,240 +209,229 @@ void EcalDBCopy::copyToDB(const edm::EventSetup& evtSetup, const std::string& co
   std::string recordName = m_records[container];
 
   if (container == "EcalPedestals") {
-    const EcalPedestals* obj = &evtSetup.getData(ecalPedestalToken_);
-    edm::LogInfo("EcalDBCopy") << "ped pointer is: " << obj << std::endl;
-    dbOutput->createNewIOV<const EcalPedestals>(
-        new EcalPedestals(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    const auto obj = evtSetup.getData(ecalPedestalToken_);
+    edm::LogInfo("EcalDBCopy") << "ped pointer is: " << &obj << std::endl;
+    dbOutput->createOneIOV<const EcalPedestals>(
+        obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalADCToGeVConstant") {
-    const EcalADCToGeVConstant* obj = &evtSetup.getData(ecalADCtoGeVToken_);
-    edm::LogInfo("EcalDBCopy") << "adc pointer is: " << obj << std::endl;
-
-    dbOutput->createNewIOV<const EcalADCToGeVConstant>(
-        new EcalADCToGeVConstant(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    const auto obj = evtSetup.getData(ecalADCtoGeVToken_);
+    edm::LogInfo("EcalDBCopy") << "adc pointer is: " << &obj << std::endl;
+    dbOutput->createOneIOV<const EcalADCToGeVConstant>(
+        obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTimeCalibConstants") {
-    const EcalTimeCalibConstants* obj = &evtSetup.getData(ecalTimeCalibToken_);
-    edm::LogInfo("EcalDBCopy") << "adc pointer is: " << obj << std::endl;
-
-    dbOutput->createNewIOV<const EcalTimeCalibConstants>(
-        new EcalTimeCalibConstants(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    const auto obj = evtSetup.getData(ecalTimeCalibToken_);
+    edm::LogInfo("EcalDBCopy") << "adc pointer is: " << &obj << std::endl;
+    dbOutput->createOneIOV<const EcalTimeCalibConstants>(
+        obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalChannelStatus") {
-    const EcalChannelStatus* obj = &evtSetup.getData(ecalChannelStatusToken_);
-    edm::LogInfo("EcalDBCopy") << "channel status pointer is: " << obj << std::endl;
-
-    dbOutput->createNewIOV<const EcalChannelStatus>(
-        new EcalChannelStatus(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    const auto obj = evtSetup.getData(ecalChannelStatusToken_);
+    edm::LogInfo("EcalDBCopy") << "channel status pointer is: " << &obj << std::endl;
+    dbOutput->createOneIOV<const EcalChannelStatus>(
+        obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalDQMChannelStatus") {
-    const EcalDQMChannelStatus* obj = &evtSetup.getData(ecalDQMChannelStatusToken_);
-    edm::LogInfo("EcalDBCopy") << "DQM channel status pointer is: " << obj << std::endl;
-    dbOutput->createNewIOV<const EcalDQMChannelStatus>(
-        new EcalDQMChannelStatus(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    const auto obj = evtSetup.getData(ecalDQMChannelStatusToken_);
+    edm::LogInfo("EcalDBCopy") << "DQM channel status pointer is: " << &obj << std::endl;
+    dbOutput->createOneIOV<const EcalDQMChannelStatus>(
+        obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalDQMTowerStatus") {
-    const EcalDQMTowerStatus* obj = &evtSetup.getData(ecalDQMTowerStatusToken_);
-    edm::LogInfo("EcalDBCopy") << "DQM Tower status pointer is: " << obj << std::endl;
-    dbOutput->createNewIOV<const EcalDQMTowerStatus>(
-        new EcalDQMTowerStatus(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    const auto obj = evtSetup.getData(ecalDQMTowerStatusToken_);
+    edm::LogInfo("EcalDBCopy") << "DQM Tower status pointer is: " << &obj << std::endl;
+    dbOutput->createOneIOV<const EcalDQMTowerStatus>(
+        obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalDCSTowerStatus") {
-    const EcalDCSTowerStatus* obj = &evtSetup.getData(ecalDCSTowerStatusToken_);
-    edm::LogInfo("EcalDBCopy") << "channel status pointer is: " << obj << std::endl;
-
-    dbOutput->createNewIOV<const EcalDCSTowerStatus>(
-        new EcalDCSTowerStatus(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    const auto obj = evtSetup.getData(ecalDCSTowerStatusToken_);
+    edm::LogInfo("EcalDBCopy") << "channel status pointer is: " << &obj << std::endl;
+    dbOutput->createOneIOV<const EcalDCSTowerStatus>(
+        obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalDAQTowerStatus") {
-    const EcalDAQTowerStatus* obj = &evtSetup.getData(ecalDAQTowerStatusToken_);
-    edm::LogInfo("EcalDBCopy") << "DAQ channel status pointer is: " << obj << std::endl;
-
-    dbOutput->createNewIOV<const EcalDAQTowerStatus>(
-        new EcalDAQTowerStatus(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    const auto obj = evtSetup.getData(ecalDAQTowerStatusToken_);
+    edm::LogInfo("EcalDBCopy") << "DAQ channel status pointer is: " << &obj << std::endl;
+    dbOutput->createOneIOV<const EcalDAQTowerStatus>(
+        obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGCrystalStatus") {
-    const EcalTPGCrystalStatus* obj = &evtSetup.getData(ecalTPGCrystalStatusToken_);
-    edm::LogInfo("EcalDBCopy") << "TPG channel status pointer is: " << obj << std::endl;
-
-    dbOutput->createNewIOV<const EcalTPGCrystalStatus>(
-        new EcalTPGCrystalStatus(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    const auto obj = evtSetup.getData(ecalTPGCrystalStatusToken_);
+    edm::LogInfo("EcalDBCopy") << "TPG channel status pointer is: " << &obj << std::endl;
+    dbOutput->createOneIOV<const EcalTPGCrystalStatus>(
+        obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTPGTowerStatus") {
-    const EcalTPGTowerStatus* obj = &evtSetup.getData(ecalTPGTowerStatusToken_);
-    edm::LogInfo("EcalDBCopy") << "TPG tower status pointer is: " << obj << std::endl;
-
-    dbOutput->createNewIOV<const EcalTPGTowerStatus>(
-        new EcalTPGTowerStatus(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    const auto obj = evtSetup.getData(ecalTPGTowerStatusToken_);
+    edm::LogInfo("EcalDBCopy") << "TPG tower status pointer is: " << &obj << std::endl;
+    dbOutput->createOneIOV<const EcalTPGTowerStatus>(
+        obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalIntercalibConstants") {
-    const EcalIntercalibConstants* obj = &evtSetup.getData(ecalIntercalibConstantsToken_);
-    edm::LogInfo("EcalDBCopy") << "inter pointer is: " << obj << std::endl;
-    dbOutput->createNewIOV<const EcalIntercalibConstants>(
-        new EcalIntercalibConstants(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    const auto obj = evtSetup.getData(ecalIntercalibConstantsToken_);
+    edm::LogInfo("EcalDBCopy") << "inter pointer is: " << &obj << std::endl;
+    dbOutput->createOneIOV<const EcalIntercalibConstants>(
+        obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalLinearCorrections") {
-    const EcalLinearCorrections* obj = &evtSetup.getData(ecalLinearCorrectionsToken_);
-    edm::LogInfo("EcalDBCopy") << "inter pointer is: " << obj << std::endl;
-    dbOutput->createNewIOV<const EcalLinearCorrections>(
-        new EcalLinearCorrections(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    const auto obj = evtSetup.getData(ecalLinearCorrectionsToken_);
+    edm::LogInfo("EcalDBCopy") << "inter pointer is: " << &obj << std::endl;
+    dbOutput->createOneIOV<const EcalLinearCorrections>(
+        obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalIntercalibConstantsMC") {
-    const EcalIntercalibConstantsMC* obj = &evtSetup.getData(ecalIntercalibConstantsMCToken_);
-    edm::LogInfo("EcalDBCopy") << "intercalib MC pointer is: " << obj << std::endl;
-    dbOutput->createNewIOV<const EcalIntercalibConstantsMC>(
-        new EcalIntercalibConstantsMC(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    const auto obj = evtSetup.getData(ecalIntercalibConstantsMCToken_);
+    edm::LogInfo("EcalDBCopy") << "intercalib MC pointer is: " << &obj << std::endl;
+    dbOutput->createOneIOV<const EcalIntercalibConstantsMC>(
+        obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalIntercalibErrors") {
-    const EcalIntercalibErrors* obj = &evtSetup.getData(ecalIntercalibErrorsToken_);
-    edm::LogInfo("EcalDBCopy") << "inter pointer is: " << obj << std::endl;
-    dbOutput->createNewIOV<const EcalIntercalibErrors>(
-        new EcalIntercalibErrors(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    const auto obj = evtSetup.getData(ecalIntercalibErrorsToken_);
+    edm::LogInfo("EcalDBCopy") << "inter pointer is: " << &obj << std::endl;
+    dbOutput->createOneIOV<const EcalIntercalibErrors>(
+        obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalGainRatios") {
-    const EcalGainRatios* obj = &evtSetup.getData(ecalGainRatiosToken_);
-    edm::LogInfo("EcalDBCopy") << "gain pointer is: " << obj << std::endl;
-    dbOutput->createNewIOV<const EcalGainRatios>(
-        new EcalGainRatios(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    const auto obj = evtSetup.getData(ecalGainRatiosToken_);
+    edm::LogInfo("EcalDBCopy") << "gain pointer is: " << &obj << std::endl;
+    dbOutput->createOneIOV<const EcalGainRatios>(
+        obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalWeightXtalGroups") {
-    const EcalWeightXtalGroups* obj = &evtSetup.getData(ecalWeightXtalGroupsToken_);
-    edm::LogInfo("EcalDBCopy") << "weight pointer is: " << obj << std::endl;
-    dbOutput->createNewIOV<const EcalWeightXtalGroups>(
-        new EcalWeightXtalGroups(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    const auto obj = evtSetup.getData(ecalWeightXtalGroupsToken_);
+    edm::LogInfo("EcalDBCopy") << "weight pointer is: " << &obj << std::endl;
+    dbOutput->createOneIOV<const EcalWeightXtalGroups>(
+        obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTBWeights") {
-    const EcalTBWeights* obj = &evtSetup.getData(ecalTBWeightsToken_);
-    edm::LogInfo("EcalDBCopy") << "tbweight pointer is: " << obj << std::endl;
-    dbOutput->createNewIOV<const EcalTBWeights>(
-        new EcalTBWeights(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    const auto obj = evtSetup.getData(ecalTBWeightsToken_);
+    edm::LogInfo("EcalDBCopy") << "tbweight pointer is: " << &obj << std::endl;
+    dbOutput->createOneIOV<const EcalTBWeights>(
+        obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalLaserAlphas") {
-    const EcalLaserAlphas* obj = &evtSetup.getData(ecalLaserAlphasToken_);
-    edm::LogInfo("EcalDBCopy") << "ecalLaserAlpha pointer is: " << obj << std::endl;
-    dbOutput->createNewIOV<const EcalLaserAlphas>(
-        new EcalLaserAlphas(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    const auto obj = evtSetup.getData(ecalLaserAlphasToken_);
+    edm::LogInfo("EcalDBCopy") << "ecalLaserAlpha pointer is: " << &obj << std::endl;
+    dbOutput->createOneIOV<const EcalLaserAlphas>(
+        obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalLaserAPDPNRatios") {
-    const EcalLaserAPDPNRatios* obj = &evtSetup.getData(ecalLaserAPDPNRatiosToken_);
-    edm::LogInfo("EcalDBCopy") << "tbweight pointer is: " << obj << std::endl;
-    dbOutput->createNewIOV<const EcalLaserAPDPNRatios>(
-        new EcalLaserAPDPNRatios(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    const auto obj = evtSetup.getData(ecalLaserAPDPNRatiosToken_);
+    edm::LogInfo("EcalDBCopy") << "tbweight pointer is: " << &obj << std::endl;
+    dbOutput->createOneIOV<const EcalLaserAPDPNRatios>(
+        obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalLaserAPDPNRatiosRef") {
-    const EcalLaserAPDPNRatiosRef* obj = &evtSetup.getData(ecalLaserAPDPNRatiosRefToken_);
-    edm::LogInfo("EcalDBCopy") << "tbweight pointer is: " << obj << std::endl;
-    dbOutput->createNewIOV<const EcalLaserAPDPNRatiosRef>(
-        new EcalLaserAPDPNRatiosRef(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    const auto obj = evtSetup.getData(ecalLaserAPDPNRatiosRefToken_);
+    edm::LogInfo("EcalDBCopy") << "tbweight pointer is: " << &obj << std::endl;
+    dbOutput->createOneIOV<const EcalLaserAPDPNRatiosRef>(
+        obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalClusterCrackCorrParameters") {
-    const EcalClusterCrackCorrParameters* obj = &evtSetup.getData(ecalClusterCrackCorrParametersToken_);
-    edm::LogInfo("EcalDBCopy") << "cluster crack pointer is: " << obj << std::endl;
-    dbOutput->createNewIOV<const EcalClusterCrackCorrParameters>(
-        new EcalClusterCrackCorrParameters(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    const auto obj = evtSetup.getData(ecalClusterCrackCorrParametersToken_);
+    edm::LogInfo("EcalDBCopy") << "cluster crack pointer is: " << &obj << std::endl;
+    dbOutput->createOneIOV<const EcalClusterCrackCorrParameters>(
+        obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalPFRecHitThresholds") {
-    const EcalPFRecHitThresholds* obj = &evtSetup.getData(ecalPFRecHitThresholdsToken_);
-    edm::LogInfo("EcalDBCopy") << "Ecal PF rec hit thresholds pointer is: " << obj << std::endl;
-    dbOutput->createNewIOV<const EcalPFRecHitThresholds>(
-        new EcalPFRecHitThresholds(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    const auto obj = evtSetup.getData(ecalPFRecHitThresholdsToken_);
+    edm::LogInfo("EcalDBCopy") << "Ecal PF rec hit thresholds pointer is: " << &obj << std::endl;
+    dbOutput->createOneIOV<const EcalPFRecHitThresholds>(
+        obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalClusterEnergyUncertaintyParameters") {
-    const EcalClusterEnergyUncertaintyParameters* obj = &evtSetup.getData(ecalClusterEnergyUncertaintyParametersToken_);
-    edm::LogInfo("EcalDBCopy") << "tbweight pointer is: " << obj << std::endl;
-    dbOutput->createNewIOV<const EcalClusterEnergyUncertaintyParameters>(
-        new EcalClusterEnergyUncertaintyParameters(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    const auto obj = evtSetup.getData(ecalClusterEnergyUncertaintyParametersToken_);
+    edm::LogInfo("EcalDBCopy") << "tbweight pointer is: " << &obj << std::endl;
+    dbOutput->createOneIOV<const EcalClusterEnergyUncertaintyParameters>(
+        obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalClusterEnergyCorrectionParameters") {
-    const EcalClusterEnergyCorrectionParameters* obj = &evtSetup.getData(ecalClusterEnergyCorrectionParametersToken_);
-    edm::LogInfo("EcalDBCopy") << "tbweight pointer is: " << obj << std::endl;
-    dbOutput->createNewIOV<const EcalClusterEnergyCorrectionParameters>(
-        new EcalClusterEnergyCorrectionParameters(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    const auto obj = evtSetup.getData(ecalClusterEnergyCorrectionParametersToken_);
+    edm::LogInfo("EcalDBCopy") << "tbweight pointer is: " << &obj << std::endl;
+    dbOutput->createOneIOV<const EcalClusterEnergyCorrectionParameters>(
+        obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalClusterEnergyCorrectionObjectSpecificParameters") {
-    const EcalClusterEnergyCorrectionObjectSpecificParameters* obj =
-        &evtSetup.getData(ecalClusterEnergyCorrectionObjectSpecificParametersToken_);
-    edm::LogInfo("EcalDBCopy") << "tbweight pointer is: " << obj << std::endl;
-    dbOutput->createNewIOV<const EcalClusterEnergyCorrectionObjectSpecificParameters>(
-        new EcalClusterEnergyCorrectionObjectSpecificParameters(*obj),
+    const auto obj = evtSetup.getData(ecalClusterEnergyCorrectionObjectSpecificParametersToken_);
+    edm::LogInfo("EcalDBCopy") << "tbweight pointer is: " << &obj << std::endl;
+    dbOutput->createOneIOV<const EcalClusterEnergyCorrectionObjectSpecificParameters>(
+        obj,
         dbOutput->beginOfTime(),
-        dbOutput->endOfTime(),
         recordName);
 
   } else if (container == "EcalClusterLocalContCorrParameters") {
-    const EcalClusterLocalContCorrParameters* obj = &evtSetup.getData(ecalClusterLocalContCorrParametersToken_);
-    edm::LogInfo("EcalDBCopy") << "tbweight pointer is: " << obj << std::endl;
-    dbOutput->createNewIOV<const EcalClusterLocalContCorrParameters>(
-        new EcalClusterLocalContCorrParameters(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    const auto obj = evtSetup.getData(ecalClusterLocalContCorrParametersToken_);
+    edm::LogInfo("EcalDBCopy") << "tbweight pointer is: " << &obj << std::endl;
+    dbOutput->createOneIOV<const EcalClusterLocalContCorrParameters>(
+        obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EBAlignment") {
-    const Alignments* obj = &evtSetup.getData(ebAlignmentToken_);
-    edm::LogInfo("EcalDBCopy") << "EB alignment pointer is: " << obj << std::endl;
-    dbOutput->createNewIOV<const Alignments>(
-        new Alignments(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    const auto obj = evtSetup.getData(ebAlignmentToken_);
+    edm::LogInfo("EcalDBCopy") << "EB alignment pointer is: " << &obj << std::endl;
+    dbOutput->createOneIOV<const Alignments>(
+        obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EEAlignment") {
-    const Alignments* obj = &evtSetup.getData(eeAlignmentToken_);
-    edm::LogInfo("EcalDBCopy") << "EE alignment pointer is: " << obj << std::endl;
-    dbOutput->createNewIOV<const Alignments>(
-        new Alignments(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    const auto obj = evtSetup.getData(eeAlignmentToken_);
+    edm::LogInfo("EcalDBCopy") << "EE alignment pointer is: " << &obj << std::endl;
+    dbOutput->createOneIOV<const Alignments>(
+        obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "ESAlignment") {
-    const Alignments* obj = &evtSetup.getData(esAlignmentToken_);
-    edm::LogInfo("EcalDBCopy") << "ES alignment pointer is: " << obj << std::endl;
-    dbOutput->createNewIOV<const Alignments>(
-        new Alignments(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    const auto obj = evtSetup.getData(esAlignmentToken_);
+    edm::LogInfo("EcalDBCopy") << "ES alignment pointer is: " << &obj << std::endl;
+    dbOutput->createOneIOV<const Alignments>(
+        obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTimeOffsetConstant") {
-    const EcalTimeOffsetConstant* obj = &evtSetup.getData(ecalTimeOffsetConstantToken_);
-    edm::LogInfo("EcalDBCopy") << "TimeOffset pointer is: " << obj << std::endl;
-    dbOutput->createNewIOV<const EcalTimeOffsetConstant>(
-        new EcalTimeOffsetConstant(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    const auto obj = evtSetup.getData(ecalTimeOffsetConstantToken_);
+    edm::LogInfo("EcalDBCopy") << "TimeOffset pointer is: " << &obj << std::endl;
+    dbOutput->createOneIOV<const EcalTimeOffsetConstant>(
+        obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalSampleMask") {
-    const EcalSampleMask* obj = &evtSetup.getData(ecalSampleMaskToken_);
-    edm::LogInfo("EcalDBCopy") << "sample mask pointer is: " << obj << std::endl;
-    dbOutput->createNewIOV<const EcalSampleMask>(
-        new EcalSampleMask(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    const auto obj = evtSetup.getData(ecalSampleMaskToken_);
+    edm::LogInfo("EcalDBCopy") << "sample mask pointer is: " << &obj << std::endl;
+    dbOutput->createOneIOV<const EcalSampleMask>(
+        obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalSimPulseShape") {
-    const EcalSimPulseShape* obj = &evtSetup.getData(ecalSimPulseShapeToken_);
-    dbOutput->createNewIOV<const EcalSimPulseShape>(
-        new EcalSimPulseShape(*obj), dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+    const auto obj = evtSetup.getData(ecalSimPulseShapeToken_);
+    dbOutput->createOneIOV<const EcalSimPulseShape>(
+        obj, dbOutput->beginOfTime(), recordName);
 
   } else if (container == "EcalTimeBiasCorrections") {
-    const EcalTimeBiasCorrections* obj = &evtSetup.getData(ecalTimeBiasCorrectionsToken_);
-    edm::LogInfo("EcalDBCopy") << "TimeBiasCorrections pointer is: " << obj << std::endl;
-    EcalTimeBiasCorrections* bias_;
-    bias_ = new EcalTimeBiasCorrections();
-    std::vector<float> vect = obj->EBTimeCorrAmplitudeBins;
-    copy(vect.begin(), vect.end(), back_inserter(bias_->EBTimeCorrAmplitudeBins));
-    vect = obj->EBTimeCorrShiftBins;
-    copy(vect.begin(), vect.end(), back_inserter(bias_->EBTimeCorrShiftBins));
-    vect = obj->EETimeCorrAmplitudeBins;
-    copy(vect.begin(), vect.end(), back_inserter(bias_->EETimeCorrAmplitudeBins));
-    vect = obj->EETimeCorrShiftBins;
-    copy(vect.begin(), vect.end(), back_inserter(bias_->EETimeCorrShiftBins));
-    dbOutput->writeOne(bias_, dbOutput->beginOfTime(), "EcalTimeBiasCorrectionsRcd");
+    const auto obj = evtSetup.getData(ecalTimeBiasCorrectionsToken_);
+    edm::LogInfo("EcalDBCopy") << "TimeBiasCorrections pointer is: " << &obj << std::endl;
+    EcalTimeBiasCorrections bias_;
+    std::vector<float> vect = obj.EBTimeCorrAmplitudeBins;
+    copy(vect.begin(), vect.end(), back_inserter(bias_.EBTimeCorrAmplitudeBins));
+    vect = obj.EBTimeCorrShiftBins;
+    copy(vect.begin(), vect.end(), back_inserter(bias_.EBTimeCorrShiftBins));
+    vect = obj.EETimeCorrAmplitudeBins;
+    copy(vect.begin(), vect.end(), back_inserter(bias_.EETimeCorrAmplitudeBins));
+    vect = obj.EETimeCorrShiftBins;
+    copy(vect.begin(), vect.end(), back_inserter(bias_.EETimeCorrShiftBins));
+    dbOutput->writeOneIOV(bias_, dbOutput->beginOfTime(), "EcalTimeBiasCorrectionsRcd");
 
   } else if (container == "EcalSamplesCorrelation") {
-    const EcalSamplesCorrelation* obj = &evtSetup.getData(ecalSamplesCorrelationToken_);
-    edm::LogInfo("EcalDBCopy") << "SamplesCorrelation pointer is: " << obj << std::endl;
-    EcalSamplesCorrelation* correl_;
-    correl_ = new EcalSamplesCorrelation();
-    std::vector<double> vect = obj->EBG12SamplesCorrelation;
-    copy(vect.begin(), vect.end(), back_inserter(correl_->EBG12SamplesCorrelation));
-    vect = obj->EBG6SamplesCorrelation;
-    copy(vect.begin(), vect.end(), back_inserter(correl_->EBG6SamplesCorrelation));
-    vect = obj->EBG1SamplesCorrelation;
-    copy(vect.begin(), vect.end(), back_inserter(correl_->EBG1SamplesCorrelation));
-    vect = obj->EEG12SamplesCorrelation;
-    copy(vect.begin(), vect.end(), back_inserter(correl_->EEG12SamplesCorrelation));
-    vect = obj->EEG6SamplesCorrelation;
-    copy(vect.begin(), vect.end(), back_inserter(correl_->EEG6SamplesCorrelation));
-    vect = obj->EEG1SamplesCorrelation;
-    copy(vect.begin(), vect.end(), back_inserter(correl_->EEG1SamplesCorrelation));
-    dbOutput->writeOne(correl_, dbOutput->beginOfTime(), "EcalSamplesCorrelationRcd");
+    const auto obj = evtSetup.getData(ecalSamplesCorrelationToken_);
+    edm::LogInfo("EcalDBCopy") << "SamplesCorrelation pointer is: " << &obj << std::endl;
+    EcalSamplesCorrelation correl_;
+    std::vector<double> vect = obj.EBG12SamplesCorrelation;
+    copy(vect.begin(), vect.end(), back_inserter(correl_.EBG12SamplesCorrelation));
+    vect = obj.EBG6SamplesCorrelation;
+    copy(vect.begin(), vect.end(), back_inserter(correl_.EBG6SamplesCorrelation));
+    vect = obj.EBG1SamplesCorrelation;
+    copy(vect.begin(), vect.end(), back_inserter(correl_.EBG1SamplesCorrelation));
+    vect = obj.EEG12SamplesCorrelation;
+    copy(vect.begin(), vect.end(), back_inserter(correl_.EEG12SamplesCorrelation));
+    vect = obj.EEG6SamplesCorrelation;
+    copy(vect.begin(), vect.end(), back_inserter(correl_.EEG6SamplesCorrelation));
+    vect = obj.EEG1SamplesCorrelation;
+    copy(vect.begin(), vect.end(), back_inserter(correl_.EEG1SamplesCorrelation));
+    dbOutput->writeOneIOV(correl_, dbOutput->beginOfTime(), "EcalSamplesCorrelationRcd");
 
   } else {
     throw cms::Exception("Unknown container");

--- a/CondTools/Ecal/src/EcalPFRecHitThresholdsMaker.cc
+++ b/CondTools/Ecal/src/EcalPFRecHitThresholdsMaker.cc
@@ -44,7 +44,7 @@ void EcalPFRecHitThresholdsMaker::analyze(const edm::Event& evt, const edm::Even
 
   const auto laser = evtSetup.getHandle(ecalLaserDbServiceToken_);
 
-  EcalPFRecHitThresholds* pfthresh = new EcalPFRecHitThresholds();
+  EcalPFRecHitThresholds pfthresh;
 
   //    const EcalIntercalibConstantMap& icalMap = ical_db->getMap();
 
@@ -75,7 +75,7 @@ void EcalPFRecHitThresholdsMaker::analyze(const edm::Event& evt, const edm::Even
         if (iPhi == 100)
           edm::LogInfo("EcalPFRecHitThresholdsMaker") << "Thresh(GeV)=" << thresh << std::endl;
 
-        pfthresh->insert(std::make_pair(ebdetid.rawId(), thresh));
+        pfthresh.insert(std::make_pair(ebdetid.rawId(), thresh));
       }
     }
   }
@@ -97,7 +97,7 @@ void EcalPFRecHitThresholdsMaker::analyze(const edm::Event& evt, const edm::Even
         lasercalib = laser->getLaserCorrection(eedetid, evt.time());  // TODO correct time
 
         EcalPFRecHitThreshold thresh = aped.rms_x12 * calib * adc_EE * lasercalib * m_nsigma;
-        pfthresh->insert(std::make_pair(eedetid.rawId(), thresh));
+        pfthresh.insert(std::make_pair(eedetid.rawId(), thresh));
       }
       if (EEDetId::validDetId(iX, iY, -1)) {
         EEDetId eedetid(iX, iY, -1);
@@ -113,7 +113,7 @@ void EcalPFRecHitThresholdsMaker::analyze(const edm::Event& evt, const edm::Even
         lasercalib = laser->getLaserCorrection(eedetid, evt.time());  // TODO correct time
 
         EcalPFRecHitThreshold thresh = aped.rms_x12 * calib * adc_EE * lasercalib * m_nsigma;
-        pfthresh->insert(std::make_pair(eedetid.rawId(), thresh));
+        pfthresh.insert(std::make_pair(eedetid.rawId(), thresh));
 
         if (iX == 50)
           edm::LogInfo("EcalPFRecHitThresholdsMaker") << "Thresh(GeV)=" << thresh << std::endl;
@@ -121,8 +121,7 @@ void EcalPFRecHitThresholdsMaker::analyze(const edm::Event& evt, const edm::Even
     }
   }
 
-  dbOutput->createNewIOV<const EcalPFRecHitThresholds>(
-      pfthresh, dbOutput->beginOfTime(), dbOutput->endOfTime(), "EcalPFRecHitThresholdsRcd");
+  dbOutput->createOneIOV<const EcalPFRecHitThresholds>(pfthresh, dbOutput->beginOfTime(), "EcalPFRecHitThresholdsRcd");
 
   edm::LogInfo("EcalPFRecHitThresholdsMaker") << "EcalPFRecHitThresholdsMaker wrote it " << std::endl;
 }

--- a/CondTools/Ecal/src/EcalTestDevDB.cc
+++ b/CondTools/Ecal/src/EcalTestDevDB.cc
@@ -81,131 +81,120 @@ void EcalTestDevDB::analyze(const edm::Event& evt, const edm::EventSetup& evtSet
       std::cout << "Starting Transaction for run " << irun << "..." << std::flush;
 
       if (container == "EcalPedestals") {
-        EcalPedestals* condObject = generateEcalPedestals();
-
+        const auto* condObject = generateEcalPedestals();
         if (irun == m_firstRun && dbOutput->isNewTagRequest(recordName)) {
           // create new
           std::cout << "First One " << std::endl;
-          dbOutput->createNewIOV<const EcalPedestals>(
-              condObject, dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+          dbOutput->createOneIOV<const EcalPedestals>(*condObject, dbOutput->beginOfTime(), recordName);
         } else {
           // append
           std::cout << "Old One " << std::endl;
-          dbOutput->appendSinceTime<const EcalPedestals>(condObject, irun, recordName);
+          dbOutput->appendOneIOV<const EcalPedestals>(*condObject, irun, recordName);
         }
 
       } else if (container == "EcalADCToGeVConstant") {
-        EcalADCToGeVConstant* condObject = generateEcalADCToGeVConstant();
+        const auto* condObject = generateEcalADCToGeVConstant();
         if (irun == m_firstRun && dbOutput->isNewTagRequest(recordName)) {
           // create new
           std::cout << "First One " << std::endl;
-          dbOutput->createNewIOV<const EcalADCToGeVConstant>(
-              condObject, dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+          dbOutput->createOneIOV<const EcalADCToGeVConstant>(*condObject, dbOutput->beginOfTime(), recordName);
         } else {
           // append
           std::cout << "Old One " << std::endl;
-          dbOutput->appendSinceTime<const EcalADCToGeVConstant>(condObject, irun, recordName);
+          dbOutput->appendOneIOV<const EcalADCToGeVConstant>(*condObject, irun, recordName);
         }
 
       } else if (container == "EcalIntercalibConstants") {
-        EcalIntercalibConstants* condObject = generateEcalIntercalibConstants();
+        const auto* condObject = generateEcalIntercalibConstants();
         if (irun == m_firstRun && dbOutput->isNewTagRequest(recordName)) {
           // create new
           std::cout << "First One " << std::endl;
-          dbOutput->createNewIOV<const EcalIntercalibConstants>(
-              condObject, dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+          dbOutput->createOneIOV<const EcalIntercalibConstants>(*condObject, dbOutput->beginOfTime(), recordName);
         } else {
           // append
           std::cout << "Old One " << std::endl;
-          dbOutput->appendSinceTime<const EcalIntercalibConstants>(condObject, irun, recordName);
+          dbOutput->appendOneIOV<const EcalIntercalibConstants>(*condObject, irun, recordName);
         }
       } else if (container == "EcalLinearCorrections") {
-        EcalLinearCorrections* condObject = generateEcalLinearCorrections();
+        const auto* condObject = generateEcalLinearCorrections();
         if (irun == m_firstRun && dbOutput->isNewTagRequest(recordName)) {
           // create new
           std::cout << "First One " << std::endl;
-          dbOutput->createNewIOV<const EcalLinearCorrections>(
-              condObject, dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+          dbOutput->createOneIOV<const EcalLinearCorrections>(*condObject, dbOutput->beginOfTime(), recordName);
         } else {
           // append
           std::cout << "Old One " << std::endl;
-          dbOutput->appendSinceTime<const EcalLinearCorrections>(condObject, irun, recordName);
+          dbOutput->appendOneIOV<const EcalLinearCorrections>(*condObject, irun, recordName);
         }
 
       } else if (container == "EcalGainRatios") {
-        EcalGainRatios* condObject = generateEcalGainRatios();
+        const auto* condObject = generateEcalGainRatios();
         if (irun == m_firstRun && dbOutput->isNewTagRequest(recordName)) {
           // create new
           std::cout << "First One " << std::endl;
-          dbOutput->createNewIOV<const EcalGainRatios>(
-              condObject, dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+          dbOutput->createOneIOV<const EcalGainRatios>(*condObject, dbOutput->beginOfTime(), recordName);
         } else {
           // append
           std::cout << "Old One " << std::endl;
-          dbOutput->appendSinceTime<const EcalGainRatios>(condObject, irun, recordName);
+          dbOutput->appendOneIOV<const EcalGainRatios>(*condObject, irun, recordName);
         }
 
       } else if (container == "EcalWeightXtalGroups") {
-        EcalWeightXtalGroups* condObject = generateEcalWeightXtalGroups();
+        const auto* condObject = generateEcalWeightXtalGroups();
         if (irun == m_firstRun && dbOutput->isNewTagRequest(recordName)) {
           // create new
           std::cout << "First One " << std::endl;
-          dbOutput->createNewIOV<const EcalWeightXtalGroups>(
-              condObject, dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+          dbOutput->createOneIOV<const EcalWeightXtalGroups>(*condObject, dbOutput->beginOfTime(), recordName);
         } else {
           // append
           std::cout << "Old One " << std::endl;
-          dbOutput->appendSinceTime<const EcalWeightXtalGroups>(condObject, irun, recordName);
+          dbOutput->appendOneIOV<const EcalWeightXtalGroups>(*condObject, irun, recordName);
         }
 
       } else if (container == "EcalTBWeights") {
-        EcalTBWeights* condObject = generateEcalTBWeights();
+        const auto condObject = generateEcalTBWeights();
         if (irun == m_firstRun && dbOutput->isNewTagRequest(recordName)) {
           // create new
           std::cout << "First One " << std::endl;
-          dbOutput->createNewIOV<const EcalTBWeights>(
-              condObject, dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+          dbOutput->createOneIOV<const EcalTBWeights>(*condObject, dbOutput->beginOfTime(), recordName);
         } else {
           // append
           std::cout << "Old One " << std::endl;
-          dbOutput->appendSinceTime<const EcalTBWeights>(condObject, irun, recordName);
+          dbOutput->appendOneIOV<const EcalTBWeights>(*condObject, irun, recordName);
         }
 
       } else if (container == "EcalLaserAPDPNRatios") {
-        EcalLaserAPDPNRatios* condObject = generateEcalLaserAPDPNRatios(irun);
+        const auto* condObject = generateEcalLaserAPDPNRatios(irun);
         if (irun == m_firstRun && dbOutput->isNewTagRequest(recordName)) {
           // create new
           std::cout << "First One " << std::endl;
-          dbOutput->createNewIOV<const EcalLaserAPDPNRatios>(
-              condObject, dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+          dbOutput->createOneIOV<const EcalLaserAPDPNRatios>(*condObject, dbOutput->beginOfTime(), recordName);
         } else {
           // append
           std::cout << "Old One " << std::endl;
-          dbOutput->appendSinceTime<const EcalLaserAPDPNRatios>(condObject, irun, recordName);
+          dbOutput->appendOneIOV<const EcalLaserAPDPNRatios>(*condObject, irun, recordName);
         }
       } else if (container == "EcalLaserAPDPNRatiosRef") {
-        EcalLaserAPDPNRatiosRef* condObject = generateEcalLaserAPDPNRatiosRef();
+        const auto* condObject = generateEcalLaserAPDPNRatiosRef();
         if (irun == m_firstRun && dbOutput->isNewTagRequest(recordName)) {
           // create new
           std::cout << "First One " << std::endl;
-          dbOutput->createNewIOV<const EcalLaserAPDPNRatiosRef>(
-              condObject, dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+          dbOutput->createOneIOV<const EcalLaserAPDPNRatiosRef>(*condObject, dbOutput->beginOfTime(), recordName);
         } else {
           // append
           std::cout << "Old One " << std::endl;
-          dbOutput->appendSinceTime<const EcalLaserAPDPNRatiosRef>(condObject, irun, recordName);
+          dbOutput->appendOneIOV<const EcalLaserAPDPNRatiosRef>(*condObject, irun, recordName);
         }
       } else if (container == "EcalLaserAlphas") {
-        EcalLaserAlphas* condObject = generateEcalLaserAlphas();
+        const auto* condObject = generateEcalLaserAlphas();
         if (irun == m_firstRun && dbOutput->isNewTagRequest(recordName)) {
           // create new
           std::cout << "First One " << std::endl;
-          dbOutput->createNewIOV<const EcalLaserAlphas>(
-              condObject, dbOutput->beginOfTime(), dbOutput->endOfTime(), recordName);
+          dbOutput->createOneIOV<const EcalLaserAlphas>(*condObject, dbOutput->beginOfTime(), recordName);
         } else {
           // append
           std::cout << "Old One " << std::endl;
-          dbOutput->appendSinceTime<const EcalLaserAlphas>(condObject, irun, recordName);
+          dbOutput->appendOneIOV<const EcalLaserAlphas>(*condObject, irun, recordName);
         }
       } else {
         std::cout << "it does not work yet for " << container << "..." << std::flush;

--- a/CondTools/Ecal/src/EcalTestDevDB.cc
+++ b/CondTools/Ecal/src/EcalTestDevDB.cc
@@ -17,7 +17,6 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include <map>
 #include <vector>
 
 using namespace std;
@@ -81,7 +80,7 @@ void EcalTestDevDB::analyze(const edm::Event& evt, const edm::EventSetup& evtSet
       edm::LogInfo("EcalTestDevDB") << "Starting Transaction for run " << irun << "...";
 
       if (container == "EcalPedestals") {
-        const auto* condObject = generateEcalPedestals();
+        const auto condObject = generateEcalPedestals();
         if (irun == m_firstRun && dbOutput->isNewTagRequest(recordName)) {
           // create new
           edm::LogInfo("EcalTestDevDB") << "First One ";
@@ -93,7 +92,7 @@ void EcalTestDevDB::analyze(const edm::Event& evt, const edm::EventSetup& evtSet
         }
 
       } else if (container == "EcalADCToGeVConstant") {
-        const auto* condObject = generateEcalADCToGeVConstant();
+        const auto condObject = generateEcalADCToGeVConstant();
         if (irun == m_firstRun && dbOutput->isNewTagRequest(recordName)) {
           // create new
           edm::LogInfo("EcalTestDevDB") << "First One ";
@@ -105,7 +104,7 @@ void EcalTestDevDB::analyze(const edm::Event& evt, const edm::EventSetup& evtSet
         }
 
       } else if (container == "EcalIntercalibConstants") {
-        const auto* condObject = generateEcalIntercalibConstants();
+        const auto condObject = generateEcalIntercalibConstants();
         if (irun == m_firstRun && dbOutput->isNewTagRequest(recordName)) {
           // create new
           edm::LogInfo("EcalTestDevDB") << "First One ";
@@ -116,7 +115,7 @@ void EcalTestDevDB::analyze(const edm::Event& evt, const edm::EventSetup& evtSet
           dbOutput->appendOneIOV<const EcalIntercalibConstants>(*condObject, irun, recordName);
         }
       } else if (container == "EcalLinearCorrections") {
-        const auto* condObject = generateEcalLinearCorrections();
+        const auto condObject = generateEcalLinearCorrections();
         if (irun == m_firstRun && dbOutput->isNewTagRequest(recordName)) {
           // create new
           edm::LogInfo("EcalTestDevDB") << "First One ";
@@ -128,7 +127,7 @@ void EcalTestDevDB::analyze(const edm::Event& evt, const edm::EventSetup& evtSet
         }
 
       } else if (container == "EcalGainRatios") {
-        const auto* condObject = generateEcalGainRatios();
+        const auto condObject = generateEcalGainRatios();
         if (irun == m_firstRun && dbOutput->isNewTagRequest(recordName)) {
           // create new
           edm::LogInfo("EcalTestDevDB") << "First One ";
@@ -140,7 +139,7 @@ void EcalTestDevDB::analyze(const edm::Event& evt, const edm::EventSetup& evtSet
         }
 
       } else if (container == "EcalWeightXtalGroups") {
-        const auto* condObject = generateEcalWeightXtalGroups();
+        const auto condObject = generateEcalWeightXtalGroups();
         if (irun == m_firstRun && dbOutput->isNewTagRequest(recordName)) {
           // create new
           edm::LogInfo("EcalTestDevDB") << "First One ";
@@ -164,7 +163,7 @@ void EcalTestDevDB::analyze(const edm::Event& evt, const edm::EventSetup& evtSet
         }
 
       } else if (container == "EcalLaserAPDPNRatios") {
-        const auto* condObject = generateEcalLaserAPDPNRatios(irun);
+        const auto condObject = generateEcalLaserAPDPNRatios(irun);
         if (irun == m_firstRun && dbOutput->isNewTagRequest(recordName)) {
           // create new
           edm::LogInfo("EcalTestDevDB") << "First One ";
@@ -175,7 +174,7 @@ void EcalTestDevDB::analyze(const edm::Event& evt, const edm::EventSetup& evtSet
           dbOutput->appendOneIOV<const EcalLaserAPDPNRatios>(*condObject, irun, recordName);
         }
       } else if (container == "EcalLaserAPDPNRatiosRef") {
-        const auto* condObject = generateEcalLaserAPDPNRatiosRef();
+        const auto condObject = generateEcalLaserAPDPNRatiosRef();
         if (irun == m_firstRun && dbOutput->isNewTagRequest(recordName)) {
           // create new
           edm::LogInfo("EcalTestDevDB") << "First One ";
@@ -186,7 +185,7 @@ void EcalTestDevDB::analyze(const edm::Event& evt, const edm::EventSetup& evtSet
           dbOutput->appendOneIOV<const EcalLaserAPDPNRatiosRef>(*condObject, irun, recordName);
         }
       } else if (container == "EcalLaserAlphas") {
-        const auto* condObject = generateEcalLaserAlphas();
+        const auto condObject = generateEcalLaserAlphas();
         if (irun == m_firstRun && dbOutput->isNewTagRequest(recordName)) {
           // create new
           edm::LogInfo("EcalTestDevDB") << "First One ";
@@ -204,10 +203,10 @@ void EcalTestDevDB::analyze(const edm::Event& evt, const edm::EventSetup& evtSet
 }
 
 //-------------------------------------------------------------
-EcalPedestals* EcalTestDevDB::generateEcalPedestals() {
+std::shared_ptr<EcalPedestals> EcalTestDevDB::generateEcalPedestals() {
   //-------------------------------------------------------------
 
-  EcalPedestals* peds = new EcalPedestals();
+  auto peds = std::make_shared<EcalPedestals>();
   EcalPedestals::Item item;
   for (int iEta = -EBDetId::MAX_IETA; iEta <= EBDetId::MAX_IETA; ++iEta) {
     if (iEta == 0)
@@ -228,19 +227,19 @@ EcalPedestals* EcalTestDevDB::generateEcalPedestals() {
 }
 
 //-------------------------------------------------------------
-EcalADCToGeVConstant* EcalTestDevDB::generateEcalADCToGeVConstant() {
+std::shared_ptr<EcalADCToGeVConstant> EcalTestDevDB::generateEcalADCToGeVConstant() {
   //-------------------------------------------------------------
 
   double r = (double)std::rand() / (double(RAND_MAX) + double(1));
-  EcalADCToGeVConstant* agc = new EcalADCToGeVConstant(36. + r * 4., 60. + r * 4);
+  auto agc = std::make_shared<EcalADCToGeVConstant>(36. + r * 4., 60. + r * 4);
   return agc;
 }
 
 //-------------------------------------------------------------
-EcalIntercalibConstants* EcalTestDevDB::generateEcalIntercalibConstants() {
+std::shared_ptr<EcalIntercalibConstants> EcalTestDevDB::generateEcalIntercalibConstants() {
   //-------------------------------------------------------------
 
-  EcalIntercalibConstants* ical = new EcalIntercalibConstants();
+  auto ical = std::make_shared<EcalIntercalibConstants>();
 
   for (int ieta = -EBDetId::MAX_IETA; ieta <= EBDetId::MAX_IETA; ++ieta) {
     if (ieta == 0)
@@ -256,10 +255,10 @@ EcalIntercalibConstants* EcalTestDevDB::generateEcalIntercalibConstants() {
 }
 
 //-------------------------------------------------------------
-EcalLinearCorrections* EcalTestDevDB::generateEcalLinearCorrections() {
+std::shared_ptr<EcalLinearCorrections> EcalTestDevDB::generateEcalLinearCorrections() {
   //-------------------------------------------------------------
 
-  EcalLinearCorrections* ical = new EcalLinearCorrections();
+  auto ical = std::make_shared<EcalLinearCorrections>();
 
   for (int ieta = -EBDetId::MAX_IETA; ieta <= EBDetId::MAX_IETA; ++ieta) {
     if (ieta == 0)
@@ -317,11 +316,11 @@ EcalLinearCorrections* EcalTestDevDB::generateEcalLinearCorrections() {
 }
 
 //-------------------------------------------------------------
-EcalGainRatios* EcalTestDevDB::generateEcalGainRatios() {
+std::shared_ptr<EcalGainRatios> EcalTestDevDB::generateEcalGainRatios() {
   //-------------------------------------------------------------
 
   // create gain ratios
-  EcalGainRatios* gratio = new EcalGainRatios;
+  auto gratio = std::make_shared<EcalGainRatios>();
 
   for (int ieta = -EBDetId::MAX_IETA; ieta <= EBDetId::MAX_IETA; ++ieta) {
     if (ieta == 0)
@@ -343,10 +342,10 @@ EcalGainRatios* EcalTestDevDB::generateEcalGainRatios() {
 }
 
 //-------------------------------------------------------------
-EcalWeightXtalGroups* EcalTestDevDB::generateEcalWeightXtalGroups() {
+std::shared_ptr<EcalWeightXtalGroups> EcalTestDevDB::generateEcalWeightXtalGroups() {
   //-------------------------------------------------------------
 
-  EcalWeightXtalGroups* xtalGroups = new EcalWeightXtalGroups();
+  auto xtalGroups = std::make_shared<EcalWeightXtalGroups>();
   for (int ieta = -EBDetId::MAX_IETA; ieta <= EBDetId::MAX_IETA; ++ieta) {
     if (ieta == 0)
       continue;
@@ -359,10 +358,10 @@ EcalWeightXtalGroups* EcalTestDevDB::generateEcalWeightXtalGroups() {
 }
 
 //-------------------------------------------------------------
-EcalTBWeights* EcalTestDevDB::generateEcalTBWeights() {
+std::shared_ptr<EcalTBWeights> EcalTestDevDB::generateEcalTBWeights() {
   //-------------------------------------------------------------
 
-  EcalTBWeights* tbwgt = new EcalTBWeights();
+  auto tbwgt = std::make_shared<EcalTBWeights>();
 
   // create weights for each distinct group ID
   int nMaxTDC = 10;
@@ -406,10 +405,10 @@ EcalTBWeights* EcalTestDevDB::generateEcalTBWeights() {
 }
 
 //--------------------------------------------------------------
-EcalLaserAPDPNRatios* EcalTestDevDB::generateEcalLaserAPDPNRatios(uint32_t i_run) {
+std::shared_ptr<EcalLaserAPDPNRatios> EcalTestDevDB::generateEcalLaserAPDPNRatios(uint32_t i_run) {
   //--------------------------------------------------------------
 
-  EcalLaserAPDPNRatios* laser = new EcalLaserAPDPNRatios();
+  auto laser = std::make_shared<EcalLaserAPDPNRatios>();
 
   EcalLaserAPDPNRatios::EcalLaserAPDPNpair APDPNpair;
   EcalLaserAPDPNRatios::EcalLaserTimeStamp TimeStamp;
@@ -554,10 +553,10 @@ EcalLaserAPDPNRatios* EcalTestDevDB::generateEcalLaserAPDPNRatios(uint32_t i_run
 }
 
 //--------------------------------------------------------------
-EcalLaserAPDPNRatiosRef* EcalTestDevDB::generateEcalLaserAPDPNRatiosRef() {
+std::shared_ptr<EcalLaserAPDPNRatiosRef> EcalTestDevDB::generateEcalLaserAPDPNRatiosRef() {
   //--------------------------------------------------------------
 
-  EcalLaserAPDPNRatiosRef* laser = new EcalLaserAPDPNRatiosRef();
+  auto laser = std::make_shared<EcalLaserAPDPNRatiosRef>();
 
   EcalLaserAPDPNref APDPNref;
 
@@ -611,10 +610,10 @@ EcalLaserAPDPNRatiosRef* EcalTestDevDB::generateEcalLaserAPDPNRatiosRef() {
 }
 
 //--------------------------------------------------------------
-EcalLaserAlphas* EcalTestDevDB::generateEcalLaserAlphas() {
+std::shared_ptr<EcalLaserAlphas> EcalTestDevDB::generateEcalLaserAlphas() {
   //--------------------------------------------------------------
 
-  EcalLaserAlphas* laser = new EcalLaserAlphas();
+  auto laser = std::make_shared<EcalLaserAlphas>();
 
   EcalLaserAlpha Alpha;
 

--- a/CondTools/Ecal/src/EcalTestDevDB.cc
+++ b/CondTools/Ecal/src/EcalTestDevDB.cc
@@ -74,21 +74,21 @@ void EcalTestDevDB::analyze(const edm::Event& evt, const edm::EventSetup& evtSet
 
       // Arguments 0 0 mean infinite IOV
       if (m_firstRun == 0 && m_lastRun == 0) {
-        std::cout << "Infinite IOV mode" << std::endl;
+        edm::LogInfo("EcalTestDevDB") << "Infinite IOV mode";
         irun = edm::IOVSyncValue::endOfTime().eventID().run();
       }
 
-      std::cout << "Starting Transaction for run " << irun << "..." << std::flush;
+      edm::LogInfo("EcalTestDevDB") << "Starting Transaction for run " << irun << "...";
 
       if (container == "EcalPedestals") {
         const auto* condObject = generateEcalPedestals();
         if (irun == m_firstRun && dbOutput->isNewTagRequest(recordName)) {
           // create new
-          std::cout << "First One " << std::endl;
+          edm::LogInfo("EcalTestDevDB") << "First One ";
           dbOutput->createOneIOV<const EcalPedestals>(*condObject, dbOutput->beginOfTime(), recordName);
         } else {
           // append
-          std::cout << "Old One " << std::endl;
+          edm::LogInfo("EcalTestDevDB") << "Old One ";
           dbOutput->appendOneIOV<const EcalPedestals>(*condObject, irun, recordName);
         }
 
@@ -96,11 +96,11 @@ void EcalTestDevDB::analyze(const edm::Event& evt, const edm::EventSetup& evtSet
         const auto* condObject = generateEcalADCToGeVConstant();
         if (irun == m_firstRun && dbOutput->isNewTagRequest(recordName)) {
           // create new
-          std::cout << "First One " << std::endl;
+          edm::LogInfo("EcalTestDevDB") << "First One ";
           dbOutput->createOneIOV<const EcalADCToGeVConstant>(*condObject, dbOutput->beginOfTime(), recordName);
         } else {
           // append
-          std::cout << "Old One " << std::endl;
+          edm::LogInfo("EcalTestDevDB") << "Old One ";
           dbOutput->appendOneIOV<const EcalADCToGeVConstant>(*condObject, irun, recordName);
         }
 
@@ -108,22 +108,22 @@ void EcalTestDevDB::analyze(const edm::Event& evt, const edm::EventSetup& evtSet
         const auto* condObject = generateEcalIntercalibConstants();
         if (irun == m_firstRun && dbOutput->isNewTagRequest(recordName)) {
           // create new
-          std::cout << "First One " << std::endl;
+          edm::LogInfo("EcalTestDevDB") << "First One ";
           dbOutput->createOneIOV<const EcalIntercalibConstants>(*condObject, dbOutput->beginOfTime(), recordName);
         } else {
           // append
-          std::cout << "Old One " << std::endl;
+          edm::LogInfo("EcalTestDevDB") << "Old One ";
           dbOutput->appendOneIOV<const EcalIntercalibConstants>(*condObject, irun, recordName);
         }
       } else if (container == "EcalLinearCorrections") {
         const auto* condObject = generateEcalLinearCorrections();
         if (irun == m_firstRun && dbOutput->isNewTagRequest(recordName)) {
           // create new
-          std::cout << "First One " << std::endl;
+          edm::LogInfo("EcalTestDevDB") << "First One ";
           dbOutput->createOneIOV<const EcalLinearCorrections>(*condObject, dbOutput->beginOfTime(), recordName);
         } else {
           // append
-          std::cout << "Old One " << std::endl;
+          edm::LogInfo("EcalTestDevDB") << "Old One ";
           dbOutput->appendOneIOV<const EcalLinearCorrections>(*condObject, irun, recordName);
         }
 
@@ -131,11 +131,11 @@ void EcalTestDevDB::analyze(const edm::Event& evt, const edm::EventSetup& evtSet
         const auto* condObject = generateEcalGainRatios();
         if (irun == m_firstRun && dbOutput->isNewTagRequest(recordName)) {
           // create new
-          std::cout << "First One " << std::endl;
+          edm::LogInfo("EcalTestDevDB") << "First One ";
           dbOutput->createOneIOV<const EcalGainRatios>(*condObject, dbOutput->beginOfTime(), recordName);
         } else {
           // append
-          std::cout << "Old One " << std::endl;
+          edm::LogInfo("EcalTestDevDB") << "Old One ";
           dbOutput->appendOneIOV<const EcalGainRatios>(*condObject, irun, recordName);
         }
 
@@ -143,11 +143,11 @@ void EcalTestDevDB::analyze(const edm::Event& evt, const edm::EventSetup& evtSet
         const auto* condObject = generateEcalWeightXtalGroups();
         if (irun == m_firstRun && dbOutput->isNewTagRequest(recordName)) {
           // create new
-          std::cout << "First One " << std::endl;
+          edm::LogInfo("EcalTestDevDB") << "First One ";
           dbOutput->createOneIOV<const EcalWeightXtalGroups>(*condObject, dbOutput->beginOfTime(), recordName);
         } else {
           // append
-          std::cout << "Old One " << std::endl;
+          edm::LogInfo("EcalTestDevDB") << "Old One ";
           dbOutput->appendOneIOV<const EcalWeightXtalGroups>(*condObject, irun, recordName);
         }
 
@@ -155,11 +155,11 @@ void EcalTestDevDB::analyze(const edm::Event& evt, const edm::EventSetup& evtSet
         const auto condObject = generateEcalTBWeights();
         if (irun == m_firstRun && dbOutput->isNewTagRequest(recordName)) {
           // create new
-          std::cout << "First One " << std::endl;
+          edm::LogInfo("EcalTestDevDB") << "First One ";
           dbOutput->createOneIOV<const EcalTBWeights>(*condObject, dbOutput->beginOfTime(), recordName);
         } else {
           // append
-          std::cout << "Old One " << std::endl;
+          edm::LogInfo("EcalTestDevDB") << "Old One ";
           dbOutput->appendOneIOV<const EcalTBWeights>(*condObject, irun, recordName);
         }
 
@@ -167,37 +167,37 @@ void EcalTestDevDB::analyze(const edm::Event& evt, const edm::EventSetup& evtSet
         const auto* condObject = generateEcalLaserAPDPNRatios(irun);
         if (irun == m_firstRun && dbOutput->isNewTagRequest(recordName)) {
           // create new
-          std::cout << "First One " << std::endl;
+          edm::LogInfo("EcalTestDevDB") << "First One ";
           dbOutput->createOneIOV<const EcalLaserAPDPNRatios>(*condObject, dbOutput->beginOfTime(), recordName);
         } else {
           // append
-          std::cout << "Old One " << std::endl;
+          edm::LogInfo("EcalTestDevDB") << "Old One ";
           dbOutput->appendOneIOV<const EcalLaserAPDPNRatios>(*condObject, irun, recordName);
         }
       } else if (container == "EcalLaserAPDPNRatiosRef") {
         const auto* condObject = generateEcalLaserAPDPNRatiosRef();
         if (irun == m_firstRun && dbOutput->isNewTagRequest(recordName)) {
           // create new
-          std::cout << "First One " << std::endl;
+          edm::LogInfo("EcalTestDevDB") << "First One ";
           dbOutput->createOneIOV<const EcalLaserAPDPNRatiosRef>(*condObject, dbOutput->beginOfTime(), recordName);
         } else {
           // append
-          std::cout << "Old One " << std::endl;
+          edm::LogInfo("EcalTestDevDB") << "Old One ";
           dbOutput->appendOneIOV<const EcalLaserAPDPNRatiosRef>(*condObject, irun, recordName);
         }
       } else if (container == "EcalLaserAlphas") {
         const auto* condObject = generateEcalLaserAlphas();
         if (irun == m_firstRun && dbOutput->isNewTagRequest(recordName)) {
           // create new
-          std::cout << "First One " << std::endl;
+          edm::LogInfo("EcalTestDevDB") << "First One ";
           dbOutput->createOneIOV<const EcalLaserAlphas>(*condObject, dbOutput->beginOfTime(), recordName);
         } else {
           // append
-          std::cout << "Old One " << std::endl;
+          edm::LogInfo("EcalTestDevDB") << "Old One ";
           dbOutput->appendOneIOV<const EcalLaserAlphas>(*condObject, irun, recordName);
         }
       } else {
-        std::cout << "it does not work yet for " << container << "..." << std::flush;
+        edm::LogWarning("EcalTestDevDB") << "it does not work yet for " << container << "...";
       }
     }
   }
@@ -381,7 +381,6 @@ EcalTBWeights* EcalTestDevDB::generateEcalTBWeights() {
       for (size_t i = 0; i < 3; ++i) {
         for (size_t j = 0; j < 10; ++j) {
           double ww = igrp * itdc * r + i * 10. + j;
-          //std::cout << "row: " << i << " col: " << j << " -  val: " << ww  << std::endl;
           mat1(i, j) = ww;
           mat2(i, j) = 100 + ww;
         }
@@ -417,12 +416,12 @@ EcalLaserAPDPNRatios* EcalTestDevDB::generateEcalLaserAPDPNRatios(uint32_t i_run
 
   //  if((m_firstRun == 0 && i_run == 0) || (m_firstRun == 1 && i_run == 1)){
 
-  std::cout << "First & last run: " << i_run << " " << m_firstRun << " " << m_lastRun << " " << std::endl;
+  edm::LogInfo("EcalTestDevDB") << "First & last run: " << i_run << " " << m_firstRun << " " << m_lastRun;
   if (m_firstRun == i_run && (i_run == 0 || i_run == 1)) {
     APDPNpair.p1 = (double(1) + 1 / double(log(exp(1) + double((i_run - m_firstRun) * 10)))) / double(2);
     APDPNpair.p2 = (double(1) + 1 / double(log(exp(1) + double((i_run - m_firstRun) * 10) + double(10)))) / double(2);
     APDPNpair.p3 = double(0);
-    std::cout << i_run << " " << m_firstRun << " " << APDPNpair.p1 << " " << APDPNpair.p2 << std::endl;
+    edm::LogInfo("EcalTestDevDB") << i_run << " " << m_firstRun << " " << APDPNpair.p1 << " " << APDPNpair.p2;
 
     for (int iEta = -EBDetId::MAX_IETA; iEta <= EBDetId::MAX_IETA; ++iEta) {
       if (iEta == 0)
@@ -437,7 +436,7 @@ EcalLaserAPDPNRatios* EcalTestDevDB::generateEcalLaserAPDPNRatios(uint32_t i_run
         if (hi < static_cast<int>(laser->getLaserMap().size())) {
           laser->setValue(hi, APDPNpair);
         } else {
-          edm::LogError("EcalTestDevDB") << "error with laser Map (ratio)!" << std::endl;
+          edm::LogError("EcalTestDevDB") << "error with laser Map (ratio)!";
           continue;
         }
       }
@@ -458,7 +457,7 @@ EcalLaserAPDPNRatios* EcalTestDevDB::generateEcalLaserAPDPNRatios(uint32_t i_run
         if (hi < static_cast<int>(laser->getLaserMap().size())) {
           laser->setValue(hi, APDPNpair);
         } else {
-          edm::LogError("EcalTestDevDB") << "error with laser Map (ratio)!" << std::endl;
+          edm::LogError("EcalTestDevDB") << "error with laser Map (ratio)!";
           continue;
         }
 
@@ -472,21 +471,19 @@ EcalLaserAPDPNRatios* EcalTestDevDB::generateEcalLaserAPDPNRatios(uint32_t i_run
         if (hi < static_cast<int>(laser->getLaserMap().size())) {
           laser->setValue(hi, APDPNpair);
         } else {
-          edm::LogError("EcalTestDevDB") << "error with laser Map (ratio)!" << std::endl;
+          edm::LogError("EcalTestDevDB") << "error with laser Map (ratio)!";
           continue;
         }
       }
     }
 
-    std::cout << std::endl;
     for (int i = 0; i < 92; i++) {
       if (i < static_cast<int>(laser->getTimeMap().size())) {
         TimeStamp.t1 = edm::Timestamp(1380 * (i_run - m_firstRun) + 15 * i);
         TimeStamp.t2 = edm::Timestamp(1380 * (i_run - m_firstRun + 1) + 15 * i);
         laser->setTime(i, TimeStamp);
-        //std::cout << " Timestamp for " << i << " : " << TimeStamp.t1.value() << " , " << TimeStamp.t2.value() << std::endl;
       } else {
-        edm::LogError("EcalTestDevDB") << "error with laser Map (time)!" << std::endl;
+        edm::LogError("EcalTestDevDB") << "error with laser Map (time)!";
         continue;
       }
     }
@@ -495,7 +492,7 @@ EcalLaserAPDPNRatios* EcalTestDevDB::generateEcalLaserAPDPNRatios(uint32_t i_run
     APDPNpair.p1 = (double(1) + 1 / double(log(exp(1) + double((i_run - m_firstRun) * 10)))) / double(2);
     APDPNpair.p2 = (double(1) + 1 / double(log(exp(1) + double((i_run - m_firstRun) * 10) + double(10)))) / double(2);
     APDPNpair.p3 = double(0);
-    std::cout << i_run << " " << m_firstRun << " " << APDPNpair.p1 << " " << APDPNpair.p2 << std::endl;
+    edm::LogInfo("EcalTestDevDB") << i_run << " " << m_firstRun << " " << APDPNpair.p1 << " " << APDPNpair.p2;
 
     for (int iEta = -EBDetId::MAX_IETA; iEta <= EBDetId::MAX_IETA; ++iEta) {
       if (iEta == 0)
@@ -507,7 +504,7 @@ EcalLaserAPDPNRatios* EcalTestDevDB::generateEcalLaserAPDPNRatios(uint32_t i_run
         if (hi < static_cast<int>(laser->getLaserMap().size())) {
           laser->setValue(hi, APDPNpair);
         } else {
-          edm::LogError("EcalTestDevDB") << "error with laser Map (ratio)!" << std::endl;
+          edm::LogError("EcalTestDevDB") << "error with laser Map (ratio)!";
         }
       }
     }
@@ -523,7 +520,7 @@ EcalLaserAPDPNRatios* EcalTestDevDB::generateEcalLaserAPDPNRatios(uint32_t i_run
         if (hi < static_cast<int>(laser->getLaserMap().size())) {
           laser->setValue(hi, APDPNpair);
         } else {
-          edm::LogError("EcalTestDevDB") << "error with laser Map (ratio)!" << std::endl;
+          edm::LogError("EcalTestDevDB") << "error with laser Map (ratio)!";
           continue;
         }
 
@@ -535,21 +532,19 @@ EcalLaserAPDPNRatios* EcalTestDevDB::generateEcalLaserAPDPNRatios(uint32_t i_run
         if (hi < static_cast<int>(laser->getLaserMap().size())) {
           laser->setValue(hi, APDPNpair);
         } else {
-          edm::LogError("EcalTestDevDB") << "error with laser Map (ratio)!" << std::endl;
+          edm::LogError("EcalTestDevDB") << "error with laser Map (ratio)!";
           continue;
         }
       }
     }
 
-    std::cout << std::endl;
     for (int i = 0; i < 92; i++) {
       if (i < static_cast<int>(laser->getTimeMap().size())) {
         TimeStamp.t1 = edm::Timestamp(1380 * (i_run - m_firstRun) + 15 * i);
         TimeStamp.t2 = edm::Timestamp(1380 * (i_run - m_firstRun + 1) + 15 * i);
         laser->setTime(i, TimeStamp);
-        //std::cout << " Timestamp for " << i << " : " << TimeStamp.t1.value() << " , " << TimeStamp.t2.value() << std::endl;
       } else {
-        edm::LogError("EcalTestDevDB") << "error with laser Map (time)!" << std::endl;
+        edm::LogError("EcalTestDevDB") << "error with laser Map (time)!";
         continue;
       }
     }
@@ -577,7 +572,7 @@ EcalLaserAPDPNRatiosRef* EcalTestDevDB::generateEcalLaserAPDPNRatiosRef() {
       if (hi < static_cast<int>(laser->getMap().size())) {
         laser->setValue(hi, APDPNref);
       } else {
-        edm::LogError("EcalTestDevDB") << "error with laser Map (ref)!" << std::endl;
+        edm::LogError("EcalTestDevDB") << "error with laser Map (ref)!";
       }
     }
   }
@@ -594,7 +589,7 @@ EcalLaserAPDPNRatiosRef* EcalTestDevDB::generateEcalLaserAPDPNRatiosRef() {
       if (hi < static_cast<int>(laser->getMap().size())) {
         laser->setValue(hi, APDPNref);
       } else {
-        edm::LogError("EcalTestDevDB") << "error with laser Map (ref)!" << std::endl;
+        edm::LogError("EcalTestDevDB") << "error with laser Map (ref)!";
       }
 
       if (!EEDetId::validDetId(iX, iY, -1))
@@ -607,7 +602,7 @@ EcalLaserAPDPNRatiosRef* EcalTestDevDB::generateEcalLaserAPDPNRatiosRef() {
       if (hi < static_cast<int>(laser->getMap().size())) {
         laser->setValue(hi, APDPNref);
       } else {
-        edm::LogError("EcalTestDevDB") << "error with laser Map (ref)!" << std::endl;
+        edm::LogError("EcalTestDevDB") << "error with laser Map (ref)!";
       }
     }
   }
@@ -634,7 +629,7 @@ EcalLaserAlphas* EcalTestDevDB::generateEcalLaserAlphas() {
       if (hi < static_cast<int>(laser->getMap().size())) {
         laser->setValue(hi, Alpha);
       } else {
-        edm::LogError("EcalTestDevDB") << "error with laser Map (alpha)!" << std::endl;
+        edm::LogError("EcalTestDevDB") << "error with laser Map (alpha)!";
       }
     }
   }
@@ -651,7 +646,7 @@ EcalLaserAlphas* EcalTestDevDB::generateEcalLaserAlphas() {
       if (hi < static_cast<int>(laser->getMap().size())) {
         laser->setValue(hi, Alpha);
       } else {
-        edm::LogError("EcalTestDevDB") << "error with laser Map (alpha)!" << std::endl;
+        edm::LogError("EcalTestDevDB") << "error with laser Map (alpha)!";
       }
 
       if (!EEDetId::validDetId(iX, iY, -1))
@@ -663,7 +658,7 @@ EcalLaserAlphas* EcalTestDevDB::generateEcalLaserAlphas() {
       if (hi < static_cast<int>(laser->getMap().size())) {
         laser->setValue(hi, Alpha);
       } else {
-        edm::LogError("EcalTestDevDB") << "error with laser Map (alpha)!" << std::endl;
+        edm::LogError("EcalTestDevDB") << "error with laser Map (alpha)!";
       }
     }
   }

--- a/Geometry/CaloEventSetup/interface/CaloGeometryDBWriter.h
+++ b/Geometry/CaloEventSetup/interface/CaloGeometryDBWriter.h
@@ -17,32 +17,32 @@ public:
 
   static void write(const TrVec& tvec, const DimVec& dvec, const IVec& ivec, const std::string& tag) {
     const IVec dins;
-    PCaloGeometry* peg = new PCaloGeometry(tvec, dvec, ivec, dins);
+    const PCaloGeometry peg(tvec, dvec, ivec, dins);
 
     edm::Service<cond::service::PoolDBOutputService> mydbservice;
     if (!mydbservice.isAvailable()) {
       edm::LogError("PCaloDBGeometryBuilder") << "PoolDBOutputService unavailable";
     } else {
       if (mydbservice->isNewTagRequest(tag)) {
-        mydbservice->createNewIOV<PCaloGeometry>(peg, mydbservice->beginOfTime(), mydbservice->endOfTime(), tag);
+        mydbservice->createOneIOV<PCaloGeometry>(peg, mydbservice->beginOfTime(), tag);
       } else {
-        mydbservice->appendSinceTime<PCaloGeometry>(peg, mydbservice->currentTime(), tag);
+        mydbservice->appendOneIOV<PCaloGeometry>(peg, mydbservice->currentTime(), tag);
       }
     }
   }
 
   static void writeIndexed(
       const TrVec& tvec, const DimVec& dvec, const IVec& ivec, const IVec& dins, const std::string& tag) {
-    PCaloGeometry* peg = new PCaloGeometry(tvec, dvec, ivec, dins);
+    const PCaloGeometry peg(tvec, dvec, ivec, dins);
 
     edm::Service<cond::service::PoolDBOutputService> mydbservice;
     if (!mydbservice.isAvailable()) {
       edm::LogError("PCaloDBGeometryBuilder") << "PoolDBOutputService unavailable";
     } else {
       if (mydbservice->isNewTagRequest(tag)) {
-        mydbservice->createNewIOV<PCaloGeometry>(peg, mydbservice->beginOfTime(), mydbservice->endOfTime(), tag);
+        mydbservice->createOneIOV<PCaloGeometry>(peg, mydbservice->beginOfTime(), tag);
       } else {
-        mydbservice->appendSinceTime<PCaloGeometry>(peg, mydbservice->currentTime(), tag);
+        mydbservice->appendOneIOV<PCaloGeometry>(peg, mydbservice->currentTime(), tag);
       }
     }
   }

--- a/Geometry/CaloEventSetup/test/CaloAlignmentRcdWrite.cc
+++ b/Geometry/CaloEventSetup/test/CaloAlignmentRcdWrite.cc
@@ -63,8 +63,8 @@ void CaloAlignmentRcdWrite::writeAlignments(const edm::EventSetup& evtSetup, edm
 void CaloAlignmentRcdWrite::analyze(const edm::Event& /*evt*/, const edm::EventSetup& evtSetup) {
   if (nEventCalls_ > 0) {
     edm::LogInfo("CaloAlignmentRcdWrite") << "Writing to DB to be done only once, "
-      << "set 'untracked PSet maxEvents = {untracked int32 input = 1}'."
-      << "(Your writing should be fine.)";
+                                          << "set 'untracked PSet maxEvents = {untracked int32 input = 1}'."
+                                          << "(Your writing should be fine.)";
     return;
   }
 

--- a/Geometry/CaloEventSetup/test/CaloAlignmentRcdWrite.cc
+++ b/Geometry/CaloEventSetup/test/CaloAlignmentRcdWrite.cc
@@ -7,6 +7,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "Utilities/General/interface/ClassName.h"
 
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 
@@ -47,23 +48,23 @@ void CaloAlignmentRcdWrite::writeAlignments(const edm::EventSetup& evtSetup, edm
 
   std::string recordName = Demangle(typeid(T).name())();
 
-  std::cout << "Uploading alignments to the database: " << recordName << std::endl;
+  edm::LogInfo("CaloAlignmentRcdWrite") << "Uploading alignments to the database: " << recordName;
 
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
 
   if (!poolDbService.isAvailable())
     throw cms::Exception("NotAvailable") << "PoolDBOutputService not available";
 
-  Alignments* alignments = new Alignments(alignmentsES);
+  const Alignments alignments(alignmentsES);
 
-  poolDbService->writeOne<Alignments>(&(*alignments), poolDbService->currentTime(), recordName);
+  poolDbService->writeOneIOV<Alignments>(alignments, poolDbService->currentTime(), recordName);
 }
 
 void CaloAlignmentRcdWrite::analyze(const edm::Event& /*evt*/, const edm::EventSetup& evtSetup) {
   if (nEventCalls_ > 0) {
-    std::cout << "Writing to DB to be done only once, "
-              << "set 'untracked PSet maxEvents = {untracked int32 input = 1}'."
-              << "(Your writing should be fine.)" << std::endl;
+    edm::LogInfo("CaloAlignmentRcdWrite") << "Writing to DB to be done only once, "
+      << "set 'untracked PSet maxEvents = {untracked int32 input = 1}'."
+      << "(Your writing should be fine.)";
     return;
   }
 
@@ -71,7 +72,7 @@ void CaloAlignmentRcdWrite::analyze(const edm::Event& /*evt*/, const edm::EventS
   writeAlignments<EEAlignmentRcd>(evtSetup, eeToken_);
   writeAlignments<ESAlignmentRcd>(evtSetup, esToken_);
 
-  std::cout << "done!" << std::endl;
+  edm::LogInfo("CaloAlignmentRcdWrite") << "done!";
   nEventCalls_++;
 }
 

--- a/Geometry/CaloEventSetup/test/testAli2File_cfg.py
+++ b/Geometry/CaloEventSetup/test/testAli2File_cfg.py
@@ -2,6 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("read")
 process.load('CondCore.CondDB.CondDB_cfi')
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.threshold = "INFO"
+process.MessageLogger.cerr.CaloAlignmentRcdWrite = dict()
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)

--- a/Geometry/CaloEventSetup/test/testWriteESAlignments_cfg.py
+++ b/Geometry/CaloEventSetup/test/testWriteESAlignments_cfg.py
@@ -2,6 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("read")
 process.load('CondCore.CondDB.CondDB_cfi')
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.threshold = "INFO"
+process.MessageLogger.cerr.WriteESAlignments = dict()
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)

--- a/Geometry/CaloEventSetup/test/zeroAli2File_cfg.py
+++ b/Geometry/CaloEventSetup/test/zeroAli2File_cfg.py
@@ -2,6 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("read")
 process.load('CondCore.CondDB.CondDB_cfi')
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.threshold = "INFO"
+process.MessageLogger.cerr.CaloAlignmentRcdWrite = dict()
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)

--- a/Geometry/EcalAlgo/interface/WriteESAlignments.h
+++ b/Geometry/EcalAlgo/interface/WriteESAlignments.h
@@ -42,7 +42,7 @@ private:
                const DVec& z,
                AliVec& va);
 
-  void write(const Alignments &ali);
+  void write(const Alignments& ali);
 
   edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometryToken_;
   edm::ESGetToken<Alignments, ESAlignmentRcd> alignmentToken_;

--- a/Geometry/EcalAlgo/interface/WriteESAlignments.h
+++ b/Geometry/EcalAlgo/interface/WriteESAlignments.h
@@ -1,5 +1,5 @@
-#ifndef SOMEPACKAGE_WRITEESALIGNMENTS_H
-#define SOMEPACKAGE_WRITEESALIGNMENTS_H 1
+#ifndef Geometry_EcalAlgo_WriteESAlignments_h
+#define Geometry_EcalAlgo_WriteESAlignments_h
 
 namespace edm {
   class ConsumesCollector;
@@ -13,7 +13,6 @@ namespace edm {
 
 class WriteESAlignments {
 public:
-  typedef Alignments* AliPtr;
   typedef std::vector<AlignTransform> AliVec;
 
   typedef AlignTransform::Translation Trl;
@@ -43,7 +42,7 @@ private:
                const DVec& z,
                AliVec& va);
 
-  void write(AliPtr aliPtr);
+  void write(const Alignments &ali);
 
   edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometryToken_;
   edm::ESGetToken<Alignments, ESAlignmentRcd> alignmentToken_;

--- a/Geometry/EcalAlgo/src/WriteESAlignments.cc
+++ b/Geometry/EcalAlgo/src/WriteESAlignments.cc
@@ -40,7 +40,7 @@ void WEA::writeAlignments(const edm::EventSetup& eventSetup,
   write(ali);
 }
 
-void WEA::write(const Alignments &ali) {
+void WEA::write(const Alignments& ali) {
   edm::LogVerbatim("WriteESAlignments") << "Uploading ES alignments to the database";
 
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
@@ -98,11 +98,15 @@ void WEA::convert(const edm::EventSetup& eS,
     edm::LogVerbatim("WriteESAlignments") << "For i = " << i << ", alpha = " << 1000. * alpha << " mr";
     edm::LogVerbatim("WriteESAlignments") << "For i = " << i << ", beta  = " << 1000. * beta << " mr";
     edm::LogVerbatim("WriteESAlignments") << "For i = " << i << ", gamma = " << 1000. * gamma << " mr";
-    edm::LogVerbatim("WriteESAlignments") << " For i = " << i << ", L_n = " << L_n << "   Euler angles=" << InvL_n.eulerAngles() << "\n";
+    edm::LogVerbatim("WriteESAlignments")
+        << " For i = " << i << ", L_n = " << L_n << "   Euler angles=" << InvL_n.eulerAngles() << "\n";
     edm::LogVerbatim("WriteESAlignments") << "For i = " << i << ", t_n=" << t_n;
-    edm::LogVerbatim("WriteESAlignments") << "For i = " << i << ", G_p=" << G_p << "   Euler angles=" << G_p.eulerAngles() << "\n";
-    edm::LogVerbatim("WriteESAlignments") << " For i = " << i << ", InvL_n = " << InvL_n << "   Euler angles=" << InvL_n.eulerAngles() << "\n";
-    edm::LogVerbatim("WriteESAlignments") << " For i =" << i << ", G_n = " << G_n << "    Euler angles=" << G_n.eulerAngles() << "\n";
+    edm::LogVerbatim("WriteESAlignments")
+        << "For i = " << i << ", G_p=" << G_p << "   Euler angles=" << G_p.eulerAngles() << "\n";
+    edm::LogVerbatim("WriteESAlignments")
+        << " For i = " << i << ", InvL_n = " << InvL_n << "   Euler angles=" << InvL_n.eulerAngles() << "\n";
+    edm::LogVerbatim("WriteESAlignments")
+        << " For i =" << i << ", G_n = " << G_n << "    Euler angles=" << G_n.eulerAngles() << "\n";
     edm::LogVerbatim("WriteESAlignments") << " For i =" << i << ", s_n = " << s_n;
     edm::LogVerbatim("WriteESAlignments") << "++++++++++++++++++++++++++\n\n";
 

--- a/Geometry/EcalAlgo/src/WriteESAlignments.cc
+++ b/Geometry/EcalAlgo/src/WriteESAlignments.cc
@@ -2,6 +2,7 @@
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 
@@ -31,23 +32,23 @@ void WEA::writeAlignments(const edm::EventSetup& eventSetup,
   assert(ytranslVec.size() == k_nA);
   assert(ztranslVec.size() == k_nA);
 
-  AliPtr aliPtr(new Alignments);  // writeOne will take ownership!
-  AliVec& vali(aliPtr->m_align);
+  Alignments ali;
+  AliVec& vali(ali.m_align);
 
   convert(eventSetup, alphaVec, betaVec, gammaVec, xtranslVec, ytranslVec, ztranslVec, vali);
 
-  write(aliPtr);
+  write(ali);
 }
 
-void WEA::write(WEA::AliPtr aliPtr) {
-  std::cout << "Uploading ES alignments to the database" << std::endl;
+void WEA::write(const Alignments &ali) {
+  edm::LogVerbatim("WriteESAlignments") << "Uploading ES alignments to the database";
 
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
 
   if (!poolDbService.isAvailable())
     throw cms::Exception("NotAvailable") << "PoolDBOutputService not available";
 
-  poolDbService->writeOne<Alignments>(&(*aliPtr), poolDbService->currentTime(), "ESAlignmentRcd");
+  poolDbService->writeOneIOV<Alignments>(ali, poolDbService->currentTime(), "ESAlignmentRcd");
 }
 
 void WEA::convert(const edm::EventSetup& eS,
@@ -92,20 +93,18 @@ void WEA::convert(const edm::EventSetup& eS,
 
     const Trl s_n(t_n + s_p + q_I - InvL_n * q_I);
 
-    std::cout << "For i = " << i << ", q_I=" << q_I << std::endl;
-    std::cout << "For i = " << i << ", s_p=" << s_p << std::endl;
-    std::cout << "For i = " << i << ", alpha = " << 1000. * alpha << " mr" << std::endl;
-    std::cout << "For i = " << i << ", beta  = " << 1000. * beta << " mr" << std::endl;
-    std::cout << "For i = " << i << ", gamma = " << 1000. * gamma << " mr" << std::endl;
-    std::cout << " For i = " << i << ", L_n = " << L_n << "   Euler angles=" << InvL_n.eulerAngles() << "\n"
-              << std::endl;
-    std::cout << "For i = " << i << ", t_n=" << t_n << std::endl;
-    std::cout << "For i = " << i << ", G_p=" << G_p << "   Euler angles=" << G_p.eulerAngles() << "\n" << std::endl;
-    std::cout << " For i = " << i << ", InvL_n = " << InvL_n << "   Euler angles=" << InvL_n.eulerAngles() << "\n"
-              << std::endl;
-    std::cout << " For i =" << i << ", G_n = " << G_n << "    Euler angles=" << G_n.eulerAngles() << "\n" << std::endl;
-    std::cout << " For i =" << i << ", s_n = " << s_n << std::endl;
-    std::cout << "++++++++++++++++++++++++++\n\n" << std::endl;
+    edm::LogVerbatim("WriteESAlignments") << "For i = " << i << ", q_I=" << q_I;
+    edm::LogVerbatim("WriteESAlignments") << "For i = " << i << ", s_p=" << s_p;
+    edm::LogVerbatim("WriteESAlignments") << "For i = " << i << ", alpha = " << 1000. * alpha << " mr";
+    edm::LogVerbatim("WriteESAlignments") << "For i = " << i << ", beta  = " << 1000. * beta << " mr";
+    edm::LogVerbatim("WriteESAlignments") << "For i = " << i << ", gamma = " << 1000. * gamma << " mr";
+    edm::LogVerbatim("WriteESAlignments") << " For i = " << i << ", L_n = " << L_n << "   Euler angles=" << InvL_n.eulerAngles() << "\n";
+    edm::LogVerbatim("WriteESAlignments") << "For i = " << i << ", t_n=" << t_n;
+    edm::LogVerbatim("WriteESAlignments") << "For i = " << i << ", G_p=" << G_p << "   Euler angles=" << G_p.eulerAngles() << "\n";
+    edm::LogVerbatim("WriteESAlignments") << " For i = " << i << ", InvL_n = " << InvL_n << "   Euler angles=" << InvL_n.eulerAngles() << "\n";
+    edm::LogVerbatim("WriteESAlignments") << " For i =" << i << ", G_n = " << G_n << "    Euler angles=" << G_n.eulerAngles() << "\n";
+    edm::LogVerbatim("WriteESAlignments") << " For i =" << i << ", s_n = " << s_n;
+    edm::LogVerbatim("WriteESAlignments") << "++++++++++++++++++++++++++\n\n";
 
     va.emplace_back(AlignTransform(s_n, G_n, id));
   }


### PR DESCRIPTION
#### PR description:

This PR migrates ECAL related code to new PoolDBOutput functions `writeOneIOV`, `createOneIOV`, and `appendOneIOV` as described in https://indico.cern.ch/event/1088598/contributions/4580152/attachments/2333275/3976721/DBOutputService%20changes.pdf .
Some code cleaning is done in addition.

#### PR validation:

The code compiles and test configurations (if existing) were run without an issue.