### PR TITLE
Few further esConsumes-related updates for CondFormats (RecoMuon and DT) test folders

### DIFF
--- a/CondFormats/DTObjects/test/stubs/DTConfigPrint.cc
+++ b/CondFormats/DTObjects/test/stubs/DTConfigPrint.cc
@@ -12,8 +12,6 @@ Toy EDAnalyzer for testing purposes only.
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "CondFormats/DTObjects/test/stubs/DTConfigPrint.h"
-#include "CondFormats/DTObjects/interface/DTCCBConfig.h"
-#include "CondFormats/DataRecord/interface/DTCCBConfigRcd.h"
 
 namespace edmtest {
 
@@ -27,6 +25,7 @@ namespace edmtest {
       catalog = "";
     else
       catalog = p.getParameter<std::string>("catalog");
+    es_token = esConsumes();
   }
 
   DTConfigPrint::DTConfigPrint(int i) {}
@@ -40,13 +39,12 @@ namespace edmtest {
     std::cout << " ---EVENT NUMBER " << e.id().event() << std::endl;
 
     // get configuration for current run
-    edm::ESHandle<DTCCBConfig> conf;
-    context.get<DTCCBConfigRcd>().get(conf);
-    std::cout << conf->version() << std::endl;
-    std::cout << std::distance(conf->begin(), conf->end()) << " data in the container" << std::endl;
+    const auto& conf = context.getData(es_token);
+    std::cout << conf.version() << std::endl;
+    std::cout << std::distance(conf.begin(), conf.end()) << " data in the container" << std::endl;
 
     // loop over chambers
-    DTCCBConfig::ccb_config_map configKeys(conf->configKeyMap());
+    DTCCBConfig::ccb_config_map configKeys(conf.configKeyMap());
     DTCCBConfig::ccb_config_iterator iter = configKeys.begin();
     DTCCBConfig::ccb_config_iterator iend = configKeys.end();
     while (iter != iend) {

--- a/CondFormats/DTObjects/test/stubs/DTConfigPrint.h
+++ b/CondFormats/DTObjects/test/stubs/DTConfigPrint.h
@@ -11,6 +11,9 @@ Toy EDAnalyzer for testing purposes only.
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include "CondFormats/DTObjects/interface/DTCCBConfig.h"
+#include "CondFormats/DataRecord/interface/DTCCBConfigRcd.h"
+
 //#include "CondFormats/DTObjects/interface/DTConfigList.h"
 //#include "CondTools/DT/interface/DTConfigHandler.h"
 //#include "CondTools/DT/interface/DTDBSession.h"
@@ -31,6 +34,7 @@ namespace edmtest {
     std::string catalog;
     std::string token;
     bool local;
+    edm::ESGetToken<DTCCBConfig, DTCCBConfigRcd> es_token;
     //    DTDBSession* session;
     //    const DTConfigList* rs;
     //    DTConfigHandler* ri;

--- a/CondFormats/DTObjects/test/stubs/DTDeadPrint.cc
+++ b/CondFormats/DTObjects/test/stubs/DTDeadPrint.cc
@@ -16,8 +16,7 @@ Toy EDAnalyzer for testing purposes only.
 
 namespace edmtest {
 
-  DTDeadPrint::DTDeadPrint(edm::ParameterSet const& p):
-  es_token(esConsumes()) {}
+  DTDeadPrint::DTDeadPrint(edm::ParameterSet const& p) : es_token(esConsumes()) {}
 
   DTDeadPrint::DTDeadPrint(int i) {}
 

--- a/CondFormats/DTObjects/test/stubs/DTDeadPrint.cc
+++ b/CondFormats/DTObjects/test/stubs/DTDeadPrint.cc
@@ -13,12 +13,11 @@ Toy EDAnalyzer for testing purposes only.
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "CondFormats/DTObjects/test/stubs/DTDeadPrint.h"
-#include "CondFormats/DTObjects/interface/DTDeadFlag.h"
-#include "CondFormats/DataRecord/interface/DTDeadFlagRcd.h"
 
 namespace edmtest {
 
-  DTDeadPrint::DTDeadPrint(edm::ParameterSet const& p) {}
+  DTDeadPrint::DTDeadPrint(edm::ParameterSet const& p):
+  es_token(esConsumes()) {}
 
   DTDeadPrint::DTDeadPrint(int i) {}
 
@@ -29,12 +28,11 @@ namespace edmtest {
     // Context is not used.
     std::cout << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
     std::cout << " ---EVENT NUMBER " << e.id().event() << std::endl;
-    edm::ESHandle<DTDeadFlag> dList;
-    context.get<DTDeadFlagRcd>().get(dList);
-    std::cout << dList->version() << std::endl;
-    std::cout << std::distance(dList->begin(), dList->end()) << " data in the container" << std::endl;
-    DTDeadFlag::const_iterator iter = dList->begin();
-    DTDeadFlag::const_iterator iend = dList->end();
+    const auto& dList = context.getData(es_token);
+    std::cout << dList.version() << std::endl;
+    std::cout << std::distance(dList.begin(), dList.end()) << " data in the container" << std::endl;
+    DTDeadFlag::const_iterator iter = dList.begin();
+    DTDeadFlag::const_iterator iend = dList.end();
     while (iter != iend) {
       const std::pair<DTDeadFlagId, DTDeadFlagData>& data = *iter++;
       const DTDeadFlagId& id = data.first;

--- a/CondFormats/DTObjects/test/stubs/DTDeadPrint.h
+++ b/CondFormats/DTObjects/test/stubs/DTDeadPrint.h
@@ -11,6 +11,9 @@ Toy EDAnalyzer for testing purposes only.
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include "CondFormats/DTObjects/interface/DTDeadFlag.h"
+#include "CondFormats/DataRecord/interface/DTDeadFlagRcd.h"
+
 namespace edmtest {
   class DTDeadPrint : public edm::EDAnalyzer {
   public:
@@ -20,5 +23,6 @@ namespace edmtest {
     virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
 
   private:
+    edm::ESGetToken<DTDeadFlag, DTDeadFlagRcd> es_token;
   };
 }  // namespace edmtest

--- a/CondFormats/DTObjects/test/stubs/DTDeadUpdate.cc
+++ b/CondFormats/DTObjects/test/stubs/DTDeadUpdate.cc
@@ -17,12 +17,10 @@ Toy EDAnalyzer for testing purposes only.
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 
 #include "CondFormats/DTObjects/test/stubs/DTDeadUpdate.h"
-#include "CondFormats/DTObjects/interface/DTDeadFlag.h"
-#include "CondFormats/DataRecord/interface/DTDeadFlagRcd.h"
 
 namespace edmtest {
 
-  DTDeadUpdate::DTDeadUpdate(edm::ParameterSet const& p) : dSum(0) {}
+  DTDeadUpdate::DTDeadUpdate(edm::ParameterSet const& p) : dSum(0), es_token(esConsumes()) {}
 
   DTDeadUpdate::DTDeadUpdate(int i) : dSum(0) {}
 
@@ -35,12 +33,11 @@ namespace edmtest {
     // Context is not used.
     std::cout << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
     std::cout << " ---EVENT NUMBER " << e.id().event() << std::endl;
-    edm::ESHandle<DTDeadFlag> dList;
-    context.get<DTDeadFlagRcd>().get(dList);
-    std::cout << dList->version() << std::endl;
-    std::cout << std::distance(dList->begin(), dList->end()) << " data in the container" << std::endl;
-    DTDeadFlag::const_iterator iter = dList->begin();
-    DTDeadFlag::const_iterator iend = dList->end();
+    const auto& dList = context.getData(es_token);
+    std::cout << dList.version() << std::endl;
+    std::cout << std::distance(dList.begin(), dList.end()) << " data in the container" << std::endl;
+    DTDeadFlag::const_iterator iter = dList.begin();
+    DTDeadFlag::const_iterator iend = dList.end();
     while (iter != iend) {
       const std::pair<DTDeadFlagId, DTDeadFlagData>& data = *iter++;
       const DTDeadFlagId& id = data.first;

--- a/CondFormats/DTObjects/test/stubs/DTDeadUpdate.h
+++ b/CondFormats/DTObjects/test/stubs/DTDeadUpdate.h
@@ -11,7 +11,8 @@ Toy EDAnalyzer for testing purposes only.
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-class DTDeadFlag;
+#include "CondFormats/DTObjects/interface/DTDeadFlag.h"
+#include "CondFormats/DataRecord/interface/DTDeadFlagRcd.h"
 
 namespace edmtest {
   class DTDeadUpdate : public edm::EDAnalyzer {
@@ -28,5 +29,6 @@ namespace edmtest {
     void fill_dead_RO(const char* file, DTDeadFlag* deadList);
     void fill_discCat(const char* file, DTDeadFlag* deadList);
     DTDeadFlag* dSum;
+    edm::ESGetToken<DTDeadFlag, DTDeadFlagRcd> es_token;
   };
 }  // namespace edmtest

--- a/CondFormats/DTObjects/test/stubs/DTFullMapPrint.cc
+++ b/CondFormats/DTObjects/test/stubs/DTFullMapPrint.cc
@@ -17,8 +17,7 @@ It gets a compact map from the EventSetup and dumps it as a full map.
 
 namespace edmtest {
 
-  DTFullMapPrint::DTFullMapPrint(edm::ParameterSet const& p):
-  es_token(esConsumes()) {}
+  DTFullMapPrint::DTFullMapPrint(edm::ParameterSet const& p) : es_token(esConsumes()) {}
 
   DTFullMapPrint::DTFullMapPrint(int i) {}
 

--- a/CondFormats/DTObjects/test/stubs/DTFullMapPrint.cc
+++ b/CondFormats/DTObjects/test/stubs/DTFullMapPrint.cc
@@ -14,12 +14,11 @@ It gets a compact map from the EventSetup and dumps it as a full map.
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "CondFormats/DTObjects/test/stubs/DTFullMapPrint.h"
-#include "CondFormats/DTObjects/interface/DTReadOutMapping.h"
-#include "CondFormats/DataRecord/interface/DTReadOutMappingRcd.h"
 
 namespace edmtest {
 
-  DTFullMapPrint::DTFullMapPrint(edm::ParameterSet const& p) {}
+  DTFullMapPrint::DTFullMapPrint(edm::ParameterSet const& p):
+  es_token(esConsumes()) {}
 
   DTFullMapPrint::DTFullMapPrint(int i) {}
 
@@ -30,9 +29,8 @@ namespace edmtest {
     // Context is not used.
     std::cout << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
     std::cout << " ---EVENT NUMBER " << e.id().event() << std::endl;
-    edm::ESHandle<DTReadOutMapping> dbMap;
-    context.get<DTReadOutMappingRcd>().get(dbMap);
-    const DTReadOutMapping* ro_map = dbMap->fullMap();
+    const auto& dbMap = context.getData(es_token);
+    const DTReadOutMapping* ro_map = dbMap.fullMap();
     std::cout << ro_map->mapCellTdc() << " - " << ro_map->mapRobRos() << std::endl;
     std::cout << std::distance(ro_map->begin(), ro_map->end()) << " connections in the map" << std::endl;
     DTReadOutMapping::const_iterator iter = ro_map->begin();

--- a/CondFormats/DTObjects/test/stubs/DTFullMapPrint.h
+++ b/CondFormats/DTObjects/test/stubs/DTFullMapPrint.h
@@ -11,6 +11,9 @@ Toy EDAnalyzer for testing purposes only.
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include "CondFormats/DTObjects/interface/DTReadOutMapping.h"
+#include "CondFormats/DataRecord/interface/DTReadOutMappingRcd.h"
+
 namespace edmtest {
   class DTFullMapPrint : public edm::EDAnalyzer {
   public:
@@ -20,5 +23,6 @@ namespace edmtest {
     virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
 
   private:
+    edm::ESGetToken<DTReadOutMapping, DTReadOutMappingRcd> es_token;
   };
 }  // namespace edmtest

--- a/CondFormats/DTObjects/test/stubs/DTMapPrint.cc
+++ b/CondFormats/DTObjects/test/stubs/DTMapPrint.cc
@@ -16,8 +16,7 @@ Toy EDAnalyzer for testing purposes only.
 
 namespace edmtest {
 
-  DTMapPrint::DTMapPrint(edm::ParameterSet const& p):
-  es_token(esConsumes())  {}
+  DTMapPrint::DTMapPrint(edm::ParameterSet const& p) : es_token(esConsumes()) {}
 
   DTMapPrint::DTMapPrint(int i) {}
 

--- a/CondFormats/DTObjects/test/stubs/DTMapPrint.cc
+++ b/CondFormats/DTObjects/test/stubs/DTMapPrint.cc
@@ -13,12 +13,11 @@ Toy EDAnalyzer for testing purposes only.
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "CondFormats/DTObjects/test/stubs/DTMapPrint.h"
-#include "CondFormats/DTObjects/interface/DTReadOutMapping.h"
-#include "CondFormats/DataRecord/interface/DTReadOutMappingRcd.h"
 
 namespace edmtest {
 
-  DTMapPrint::DTMapPrint(edm::ParameterSet const& p) {}
+  DTMapPrint::DTMapPrint(edm::ParameterSet const& p):
+  es_token(esConsumes())  {}
 
   DTMapPrint::DTMapPrint(int i) {}
 
@@ -29,12 +28,11 @@ namespace edmtest {
     // Context is not used.
     std::cout << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
     std::cout << " ---EVENT NUMBER " << e.id().event() << std::endl;
-    edm::ESHandle<DTReadOutMapping> ro_map;
-    context.get<DTReadOutMappingRcd>().get(ro_map);
-    std::cout << ro_map->mapCellTdc() << " - " << ro_map->mapRobRos() << std::endl;
-    std::cout << std::distance(ro_map->begin(), ro_map->end()) << " connections in the map" << std::endl;
-    DTReadOutMapping::const_iterator iter = ro_map->begin();
-    DTReadOutMapping::const_iterator iend = ro_map->end();
+    const auto& ro_map = context.getData(es_token);
+    std::cout << ro_map.mapCellTdc() << " - " << ro_map.mapRobRos() << std::endl;
+    std::cout << std::distance(ro_map.begin(), ro_map.end()) << " connections in the map" << std::endl;
+    DTReadOutMapping::const_iterator iter = ro_map.begin();
+    DTReadOutMapping::const_iterator iend = ro_map.end();
     while (iter != iend) {
       const DTReadOutGeometryLink& link = *iter++;
       std::cout << link.dduId << " " << link.rosId << " " << link.robId << " " << link.tdcId << " " << link.channelId

--- a/CondFormats/DTObjects/test/stubs/DTMapPrint.h
+++ b/CondFormats/DTObjects/test/stubs/DTMapPrint.h
@@ -11,6 +11,9 @@ Toy EDAnalyzer for testing purposes only.
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include "CondFormats/DTObjects/interface/DTReadOutMapping.h"
+#include "CondFormats/DataRecord/interface/DTReadOutMappingRcd.h"
+
 namespace edmtest {
   class DTMapPrint : public edm::EDAnalyzer {
   public:
@@ -20,5 +23,6 @@ namespace edmtest {
     virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
 
   private:
+    edm::ESGetToken<DTReadOutMapping, DTReadOutMappingRcd> es_token;
   };
 }  // namespace edmtest

--- a/CondFormats/DTObjects/test/stubs/DTRangeT0Print.cc
+++ b/CondFormats/DTObjects/test/stubs/DTRangeT0Print.cc
@@ -16,7 +16,7 @@ Toy EDAnalyzer for testing purposes only.
 
 namespace edmtest {
 
-  DTRangeT0Print::DTRangeT0Print(edm::ParameterSet const& p): es_token(esConsumes()) {}
+  DTRangeT0Print::DTRangeT0Print(edm::ParameterSet const& p) : es_token(esConsumes()) {}
 
   DTRangeT0Print::DTRangeT0Print(int i) {}
 

--- a/CondFormats/DTObjects/test/stubs/DTRangeT0Print.cc
+++ b/CondFormats/DTObjects/test/stubs/DTRangeT0Print.cc
@@ -13,12 +13,10 @@ Toy EDAnalyzer for testing purposes only.
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "CondFormats/DTObjects/test/stubs/DTRangeT0Print.h"
-#include "CondFormats/DTObjects/interface/DTRangeT0.h"
-#include "CondFormats/DataRecord/interface/DTRangeT0Rcd.h"
 
 namespace edmtest {
 
-  DTRangeT0Print::DTRangeT0Print(edm::ParameterSet const& p) {}
+  DTRangeT0Print::DTRangeT0Print(edm::ParameterSet const& p): es_token(esConsumes()) {}
 
   DTRangeT0Print::DTRangeT0Print(int i) {}
 
@@ -29,10 +27,9 @@ namespace edmtest {
     // Context is not used.
     std::cout << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
     std::cout << " ---EVENT NUMBER " << e.id().event() << std::endl;
-    edm::ESHandle<DTRangeT0> t0;
-    context.get<DTRangeT0Rcd>().get(t0);
-    std::cout << t0->version() << std::endl;
-    std::cout << std::distance(t0->begin(), t0->end()) << " data in the container" << std::endl;
+    const auto& t0 = context.getData(es_token);
+    std::cout << t0.version() << std::endl;
+    std::cout << std::distance(t0.begin(), t0.end()) << " data in the container" << std::endl;
   }
   DEFINE_FWK_MODULE(DTRangeT0Print);
 }  // namespace edmtest

--- a/CondFormats/DTObjects/test/stubs/DTRangeT0Print.h
+++ b/CondFormats/DTObjects/test/stubs/DTRangeT0Print.h
@@ -11,6 +11,9 @@ Toy EDAnalyzer for testing purposes only.
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include "CondFormats/DTObjects/interface/DTRangeT0.h"
+#include "CondFormats/DataRecord/interface/DTRangeT0Rcd.h"
+
 namespace edmtest {
   class DTRangeT0Print : public edm::EDAnalyzer {
   public:
@@ -20,5 +23,6 @@ namespace edmtest {
     virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
 
   private:
+    edm::ESGetToken<DTRangeT0, DTRangeT0Rcd> es_token;
   };
 }  // namespace edmtest

--- a/CondFormats/DTObjects/test/stubs/DTT0Print.cc
+++ b/CondFormats/DTObjects/test/stubs/DTT0Print.cc
@@ -13,12 +13,10 @@ Toy EDAnalyzer for testing purposes only.
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "CondFormats/DTObjects/test/stubs/DTT0Print.h"
-#include "CondFormats/DTObjects/interface/DTT0.h"
-#include "CondFormats/DataRecord/interface/DTT0Rcd.h"
 
 namespace edmtest {
 
-  DTT0Print::DTT0Print(edm::ParameterSet const& p) {}
+  DTT0Print::DTT0Print(edm::ParameterSet const& p): es_token(esConsumes()) {}
 
   DTT0Print::DTT0Print(int i) {}
 
@@ -29,14 +27,13 @@ namespace edmtest {
     // Context is not used.
     std::cout << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
     std::cout << " ---EVENT NUMBER " << e.id().event() << std::endl;
-    edm::ESHandle<DTT0> t0;
-    context.get<DTT0Rcd>().get(t0);
-    std::cout << t0->version() << std::endl;
-    std::cout << std::distance(t0->begin(), t0->end()) << " data in the container" << std::endl;
+    const auto& t0 = context.getData(es_token);
+    std::cout << t0.version() << std::endl;
+    std::cout << std::distance(t0.begin(), t0.end()) << " data in the container" << std::endl;
     float t0mean;
     float t0rms;
-    DTT0::const_iterator iter = t0->begin();
-    DTT0::const_iterator iend = t0->end();
+    DTT0::const_iterator iter = t0.begin();
+    DTT0::const_iterator iend = t0.end();
     while (iter != iend) {
       const DTT0Data& t0Data = *iter++;
       int channelId = t0Data.channelId;
@@ -48,7 +45,7 @@ namespace edmtest {
       DTChamberId cc(id.chamberId());
       std::cout << channelId << " " << id.rawId() << " " << cp->rawId() << " " << ch.rawId() << " " << cc.rawId()
                 << std::endl;
-      t0->get(id, t0mean, t0rms, DTTimeUnits::counts);
+      t0.get(id, t0mean, t0rms, DTTimeUnits::counts);
       std::cout << id.wheel() << " " << id.station() << " " << id.sector() << " " << id.superlayer() << " "
                 << id.layer() << " " << id.wire() << " -> " << t0Data.t0mean << " " << t0Data.t0rms << " -> " << t0mean
                 << " " << t0rms << std::endl;

--- a/CondFormats/DTObjects/test/stubs/DTT0Print.cc
+++ b/CondFormats/DTObjects/test/stubs/DTT0Print.cc
@@ -16,7 +16,7 @@ Toy EDAnalyzer for testing purposes only.
 
 namespace edmtest {
 
-  DTT0Print::DTT0Print(edm::ParameterSet const& p): es_token(esConsumes()) {}
+  DTT0Print::DTT0Print(edm::ParameterSet const& p) : es_token(esConsumes()) {}
 
   DTT0Print::DTT0Print(int i) {}
 

--- a/CondFormats/DTObjects/test/stubs/DTT0Print.h
+++ b/CondFormats/DTObjects/test/stubs/DTT0Print.h
@@ -11,6 +11,9 @@ Toy EDAnalyzer for testing purposes only.
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include "CondFormats/DTObjects/interface/DTT0.h"
+#include "CondFormats/DataRecord/interface/DTT0Rcd.h"
+
 namespace edmtest {
   class DTT0Print : public edm::EDAnalyzer {
   public:
@@ -20,5 +23,6 @@ namespace edmtest {
     virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
 
   private:
+    edm::ESGetToken<DTT0, DTT0Rcd> es_token;
   };
 }  // namespace edmtest

--- a/CondFormats/DTObjects/test/stubs/DTTtrigPrint.cc
+++ b/CondFormats/DTObjects/test/stubs/DTTtrigPrint.cc
@@ -13,12 +13,10 @@ Toy EDAnalyzer for testing purposes only.
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "CondFormats/DTObjects/test/stubs/DTTtrigPrint.h"
-#include "CondFormats/DTObjects/interface/DTTtrig.h"
-#include "CondFormats/DataRecord/interface/DTTtrigRcd.h"
 
 namespace edmtest {
 
-  DTTtrigPrint::DTTtrigPrint(edm::ParameterSet const& p) {}
+  DTTtrigPrint::DTTtrigPrint(edm::ParameterSet const& p): es_token(esConsumes()) {}
 
   DTTtrigPrint::DTTtrigPrint(int i) {}
 
@@ -29,12 +27,11 @@ namespace edmtest {
     // Context is not used.
     std::cout << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
     std::cout << " ---EVENT NUMBER " << e.id().event() << std::endl;
-    edm::ESHandle<DTTtrig> tTrig;
-    context.get<DTTtrigRcd>().get(tTrig);
-    std::cout << tTrig->version() << std::endl;
-    std::cout << std::distance(tTrig->begin(), tTrig->end()) << " data in the container" << std::endl;
-    DTTtrig::const_iterator iter = tTrig->begin();
-    DTTtrig::const_iterator iend = tTrig->end();
+    const auto& tTrig = context.getData(es_token);
+    std::cout << tTrig.version() << std::endl;
+    std::cout << std::distance(tTrig.begin(), tTrig.end()) << " data in the container" << std::endl;
+    DTTtrig::const_iterator iter = tTrig.begin();
+    DTTtrig::const_iterator iend = tTrig.end();
     while (iter != iend) {
       const DTTtrigId& trigId = iter->first;
       const DTTtrigData& trigData = iter->second;
@@ -42,24 +39,24 @@ namespace edmtest {
       float trigTrms;
       float trigKfac;
       float trigComp;
-      tTrig->get(trigId.wheelId,
-                 trigId.stationId,
-                 trigId.sectorId,
-                 trigId.slId,
-                 trigId.layerId,
-                 trigId.cellId,
-                 trigTime,
-                 trigTrms,
-                 trigKfac,
-                 DTTimeUnits::counts);
-      tTrig->get(trigId.wheelId,
-                 trigId.stationId,
-                 trigId.sectorId,
-                 trigId.slId,
-                 trigId.layerId,
-                 trigId.cellId,
-                 trigComp,
-                 DTTimeUnits::counts);
+      tTrig.get(trigId.wheelId,
+                trigId.stationId,
+                trigId.sectorId,
+                trigId.slId,
+                trigId.layerId,
+                trigId.cellId,
+                trigTime,
+                trigTrms,
+                trigKfac,
+                DTTimeUnits::counts);
+      tTrig.get(trigId.wheelId,
+                trigId.stationId,
+                trigId.sectorId,
+                trigId.slId,
+                trigId.layerId,
+                trigId.cellId,
+                trigComp,
+                DTTimeUnits::counts);
       std::cout << trigId.wheelId << " " << trigId.stationId << " " << trigId.sectorId << " " << trigId.slId << " "
                 << trigId.layerId << " " << trigId.cellId << " -> " << trigData.tTrig << " " << trigData.tTrms << " "
                 << trigData.kFact << " -> " << trigTime << " " << trigTrms << " " << trigKfac << " -> " << trigComp

--- a/CondFormats/DTObjects/test/stubs/DTTtrigPrint.cc
+++ b/CondFormats/DTObjects/test/stubs/DTTtrigPrint.cc
@@ -16,7 +16,7 @@ Toy EDAnalyzer for testing purposes only.
 
 namespace edmtest {
 
-  DTTtrigPrint::DTTtrigPrint(edm::ParameterSet const& p): es_token(esConsumes()) {}
+  DTTtrigPrint::DTTtrigPrint(edm::ParameterSet const& p) : es_token(esConsumes()) {}
 
   DTTtrigPrint::DTTtrigPrint(int i) {}
 

--- a/CondFormats/DTObjects/test/stubs/DTTtrigPrint.h
+++ b/CondFormats/DTObjects/test/stubs/DTTtrigPrint.h
@@ -11,6 +11,9 @@ Toy EDAnalyzer for testing purposes only.
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include "CondFormats/DTObjects/interface/DTTtrig.h"
+#include "CondFormats/DataRecord/interface/DTTtrigRcd.h"
+
 namespace edmtest {
   class DTTtrigPrint : public edm::EDAnalyzer {
   public:
@@ -20,5 +23,6 @@ namespace edmtest {
     virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
 
   private:
+    edm::ESGetToken<DTTtrig, DTTtrigRcd> es_token;
   };
 }  // namespace edmtest

--- a/CondFormats/RecoMuonObjects/test/ProduceAgingObject.cc
+++ b/CondFormats/RecoMuonObjects/test/ProduceAgingObject.cc
@@ -51,19 +51,21 @@ private:
   virtual void endJob() override{};
 
   void createRpcAgingMap();
-  void createDtAgingMap(const edm::ESHandle<DTGeometry>& dtGeom);
-  void createCscAgingMap(const edm::ESHandle<CSCGeometry>& cscGeom);
+  void createDtAgingMap(const DTGeometry& dtGeom);
+  void createCscAgingMap(const CSCGeometry& cscGeom);
   void printAgingMap(const std::map<uint32_t, float>& map, const std::string& type) const;
 
   // -- member data --
 
-  std::vector<std::string> m_RPCRegEx;
-  std::map<uint32_t, float> m_RPCChambEffs;
+  edm::ESGetToken<DTGeometry, MuonGeometryRecord> m_dtGeomToken;
+  edm::ESGetToken<CSCGeometry, MuonGeometryRecord> m_cscGeomToken;
 
   std::vector<std::string> m_DTRegEx;
-  std::map<uint32_t, float> m_DTChambEffs;
-
+  std::vector<std::string> m_RPCRegEx;
   std::vector<std::string> m_CSCRegEx;
+
+  std::map<uint32_t, float> m_DTChambEffs;
+  std::map<uint32_t, float> m_RPCChambEffs;
   std::map<uint32_t, std::pair<uint32_t, float>> m_CSCChambEffs;
 
   std::map<uint32_t, float> m_GEMChambEffs;
@@ -75,12 +77,11 @@ private:
 //
 
 ProduceAgingObject::ProduceAgingObject(const edm::ParameterSet& iConfig)
-
-{
-  m_DTRegEx = iConfig.getParameter<std::vector<std::string>>("dtRegEx");
-  m_RPCRegEx = iConfig.getParameter<std::vector<std::string>>("rpcRegEx");
-  m_CSCRegEx = iConfig.getParameter<std::vector<std::string>>("cscRegEx");
-
+    : m_dtGeomToken(esConsumes<edm::Transition::BeginRun>()),
+      m_cscGeomToken(esConsumes<edm::Transition::BeginRun>()),
+      m_DTRegEx(iConfig.getParameter<std::vector<std::string>>("dtRegEx")),
+      m_RPCRegEx(iConfig.getParameter<std::vector<std::string>>("rpcRegEx")),
+      m_CSCRegEx(iConfig.getParameter<std::vector<std::string>>("cscRegEx")) {
   for (auto gemId : iConfig.getParameter<std::vector<int>>("maskedGEMIDs")) {
     m_GEMChambEffs[gemId] = 0.;
   }
@@ -114,11 +115,8 @@ void ProduceAgingObject::analyze(const edm::Event& iEvent, const edm::EventSetup
 
 // -- Called at the beginning of each run --
 void ProduceAgingObject::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
-  edm::ESHandle<DTGeometry> dtGeom;
-  iSetup.get<MuonGeometryRecord>().get(dtGeom);
-
-  edm::ESHandle<CSCGeometry> cscGeom;
-  iSetup.get<MuonGeometryRecord>().get(cscGeom);
+  auto const& dtGeom = iSetup.getData(m_dtGeomToken);
+  auto const& cscGeom = iSetup.getData(m_cscGeomToken);
 
   createDtAgingMap(dtGeom);
   createCscAgingMap(cscGeom);
@@ -141,8 +139,8 @@ void ProduceAgingObject::createRpcAgingMap() {
 }
 
 /// -- Create DT aging map ------------
-void ProduceAgingObject::createDtAgingMap(const edm::ESHandle<DTGeometry>& dtGeom) {
-  const std::vector<const DTChamber*> chambers = dtGeom->chambers();
+void ProduceAgingObject::createDtAgingMap(const DTGeometry& dtGeom) {
+  const std::vector<const DTChamber*> chambers = dtGeom.chambers();
 
   std::cout << "[ProduceAgingObject] List of aged DT chambers (ChamberID, efficiency)" << std::endl;
   for (const DTChamber* ch : chambers) {
@@ -175,8 +173,8 @@ void ProduceAgingObject::createDtAgingMap(const edm::ESHandle<DTGeometry>& dtGeo
 }
 
 /// -- Create CSC aging map ------------
-void ProduceAgingObject::createCscAgingMap(const edm::ESHandle<CSCGeometry>& cscGeom) {
-  const auto chambers = cscGeom->chambers();
+void ProduceAgingObject::createCscAgingMap(const CSCGeometry& cscGeom) {
+  const auto chambers = cscGeom.chambers();
 
   std::cout << "[ProduceAgingObject] List of aged CSC chambers (ChamberID, efficiency, type)" << std::endl;
 

--- a/CondFormats/RecoMuonObjects/test/produceAgingObject_cfg.py
+++ b/CondFormats/RecoMuonObjects/test/produceAgingObject_cfg.py
@@ -5,7 +5,7 @@ process.load("CondCore.CondDB.CondDB_cfi")
 process.load('Configuration.StandardSequences.GeometryDB_cff')
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.autoCond import autoCond
-process.GlobalTag.globaltag = autoCond['run2_design']
+process.GlobalTag.globaltag = autoCond['phase2_realistic']
 
 process.CondDB.connect = 'sqlite_file:MuonSystemAging.db'
 


### PR DESCRIPTION
#### PR description:

This PR addresses the migration  to `esConsumes` of a few remaining modules, present in the `test/` folders of `CondFormats/RecoMuonObjects` and `CondFormats/DTObjects`, as reported [here](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc900/CMSSW_12_2_CMSDEPRECATED_X_2021-11-03-2300/CondFormats/RecoMuonObjects) and [here](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc900/CMSSW_12_2_CMSDEPRECATED_X_2021-11-03-2300/CondFormats/DTObjects).

#### PR validation:

AFAIK the code does not run in any central workflow.
Code compiles, passes code-checks and code-format, and a few cfgs from the test folders were exercised.
