### PR TITLE
Fix for threadsafety of L1T Phase2 DQM

### DIFF
--- a/DQMOffline/L1Trigger/interface/L1TPhase2CorrelatorOffline.h
+++ b/DQMOffline/L1Trigger/interface/L1TPhase2CorrelatorOffline.h
@@ -75,8 +75,8 @@ private:
 
   void computeResponseResolution();
 
+  std::vector<float> getQuantile(float quant, TH2F* hist);
   void medianResponseCorrResolution(MonitorElement* in2D, MonitorElement* response, MonitorElement* resolution);
-  void medianResponse(MonitorElement* in2D, MonitorElement* response);
 
   struct SimpleObject {
     float pt, eta, phi;


### PR DESCRIPTION
#### PR description:

This PR fixes the thread-safety issue noted in #35994 (and not fixed) and includes some minor cleanup. Instead of the TContext attempt this PR rewrites `QuantilesX()` to avoid a temporary histogram and thus the multithreading issue.

#### PR validation:

Tested with `runTheMatrix.py -l 23234.103 --job-reports -t 4 --ibeos`.
