### PR TITLE
Simplify the ReusableObjectHolder

### DIFF
--- a/FWCore/Utilities/interface/ReusableObjectHolder.h
+++ b/FWCore/Utilities/interface/ReusableObjectHolder.h
@@ -69,11 +69,11 @@
 //         Created:  Fri, 31 July 2014 14:29:41 GMT
 //
 
-#include <memory>
-#include <cassert>
 #include <atomic>
-#include "tbb/task.h"
-#include "tbb/concurrent_queue.h"
+#include <cassert>
+#include <memory>
+
+#include <tbb/concurrent_queue.h>
 
 namespace edm {
   template <class T, class Deleter = std::default_delete<T>>

--- a/FWCore/Utilities/interface/ReusableObjectHolder.h
+++ b/FWCore/Utilities/interface/ReusableObjectHolder.h
@@ -17,19 +17,23 @@
 
  This class manages the cache of reusable objects and therefore an instance of this
  class must live as long as you want the cache to live.
- 
- The primary way of using the class it to call makeOrGetAndClear
- An example use would be
- \code
- auto objectToUse = holder.makeOrGetAndClear([]() { return new MyObject(10); },   //makes new one
-                                             [](MyObject* old) { old->reset(); }  //resets old one
- );
- \endcode
- 
- If you always want to set the values you can use makeOrGet
+
+ The primary way of using the class is to call makeOrGet:
  \code
  auto objectToUse = holder.makeOrGet([]() { return new MyObject(); });
- objectToUse->setValue(3);
+ use(*objectToUse);
+ \endcode
+
+ If the returned object should be be automatically set or reset, call makeOrGetAndClear:
+ \code
+ auto objectToUse = holder.makeOrGetAndClear([]() { return new MyObject(10); },   // makes new objects
+                                             [](MyObject* old) { old->reset(); }  // resets any object before returning it
+ );
+ \endcode
+ which is equivalent to
+ \code
+ auto objectToUse = holder.makeOrGet([]() { return new MyObject(10); });
+ objectToUse->reset();
  \endcode
  
  NOTE: If you hold onto the std::shared_ptr<> until another call to the ReusableObjectHolder,

--- a/FWCore/Utilities/interface/ReusableObjectHolder.h
+++ b/FWCore/Utilities/interface/ReusableObjectHolder.h
@@ -121,7 +121,7 @@ namespace edm {
                                 }};
     }
 
-    ///If there isn't an object already available, creates a new one using iFunc
+    ///Takes an object from the queue if one is available, or creates one using iFunc.
     template <typename F>
     std::shared_ptr<T> makeOrGet(F iFunc) {
       std::shared_ptr<T> returnValue;
@@ -131,15 +131,11 @@ namespace edm {
       return returnValue;
     }
 
-    ///If there is an object already available, passes the object to iClearFunc and then
-    /// returns the object.
-    ///If there is not an object already available, creates a new one using iMakeFunc
+    ///Takes an object from the queue if one is available, or creates one using iMakeFunc.
+    ///Then, passes the object to iClearFunc, and returns it.
     template <typename FM, typename FC>
     std::shared_ptr<T> makeOrGetAndClear(FM iMakeFunc, FC iClearFunc) {
-      std::shared_ptr<T> returnValue;
-      while (!(returnValue = tryToGet())) {
-        add(makeUnique(iMakeFunc()));
-      }
+      std::shared_ptr<T> returnValue = makeOrGet(iMakeFunc);
       iClearFunc(returnValue.get());
       return returnValue;
     }

--- a/FWCore/Utilities/interface/ReusableObjectHolder.h
+++ b/FWCore/Utilities/interface/ReusableObjectHolder.h
@@ -21,16 +21,14 @@
  The primary way of using the class it to call makeOrGetAndClear
  An example use would be
  \code
- auto objectToUse = holder.makeOrGetAndClear(
-                             []() { return new MyObject(10); }, //makes new one
-                             [](MyObject* old) {old->reset(); } //resets old one
-                    );
+ auto objectToUse = holder.makeOrGetAndClear([]() { return new MyObject(10); },   //makes new one
+                                             [](MyObject* old) { old->reset(); }  //resets old one
+ );
  \endcode
  
  If you always want to set the values you can use makeOrGet
  \code
- auto objectToUse = holder.makeOrGet(
-                         []() { return new MyObject(); });
+ auto objectToUse = holder.makeOrGet([]() { return new MyObject(); });
  objectToUse->setValue(3);
  \endcode
  
@@ -115,22 +113,22 @@ namespace edm {
       }
     }
 
-    ///Takes an object from the queue if one is available, or creates one using iFunc.
-    template <typename F>
-    std::shared_ptr<T> makeOrGet(F iFunc) {
+    ///Takes an object from the queue if one is available, or creates one using iMakeFunc.
+    template <typename FM>
+    std::shared_ptr<T> makeOrGet(FM&& iMakeFunc) {
       std::unique_ptr<T, Deleter> item;
       if (m_availableQueue.try_pop(item)) {
         return wrapCustomDeleter(std::move(item));
       } else {
-        return wrapCustomDeleter(makeUnique(iFunc()));
+        return wrapCustomDeleter(makeUnique(iMakeFunc()));
       }
     }
 
     ///Takes an object from the queue if one is available, or creates one using iMakeFunc.
     ///Then, passes the object to iClearFunc, and returns it.
     template <typename FM, typename FC>
-    std::shared_ptr<T> makeOrGetAndClear(FM iMakeFunc, FC iClearFunc) {
-      std::shared_ptr<T> returnValue = makeOrGet(iMakeFunc);
+    std::shared_ptr<T> makeOrGetAndClear(FM&& iMakeFunc, FC&& iClearFunc) {
+      std::shared_ptr<T> returnValue = makeOrGet(std::forward<FM>(iMakeFunc));
       iClearFunc(returnValue.get());
       return returnValue;
     }


### PR DESCRIPTION
#### PR description:

Simplify the `ReusableObjectHolder`:
  - remove unused includes
  - reduce code duplication
  - do not add new objects to the cache before returning them
  - check if try_pop was successful instead of the value of the temporary objects

#### PR validation:

Unit tests pass.