### PR TITLE
fix for option "dbproxy" in `hltListPaths`

### DIFF
--- a/HLTrigger/Configuration/scripts/hltGetConfiguration
+++ b/HLTrigger/Configuration/scripts/hltGetConfiguration
@@ -78,8 +78,8 @@ parser.add_argument('--l1-emulator',
 
 parser.add_argument('--dbproxy',
                     dest    = 'proxy',
-                    action  = 'store_const',
-                    const   = 'True',                    
+                    action  = 'store_true',
+                    default = defaults.proxy,
                     help    = 'Use a socks proxy to connect outside CERN network (default: False)' )
 parser.add_argument('--dbproxyport',
                     dest    = 'proxy_port',

--- a/HLTrigger/Configuration/scripts/hltListPaths
+++ b/HLTrigger/Configuration/scripts/hltListPaths
@@ -62,8 +62,8 @@ parser.add_argument('menu',
                     help    = 'HLT menu to dump from the database. Supported formats are:\n  - /path/to/configuration[/Vn]\n  - [[{v1|v2|v3}/]{run3|run2|online|adg}:]/path/to/configuration[/Vn]\n  - run:runnumber\nThe possible converters are "v1", "v2, and "v3" (default).\nThe possible databases are "run3" (default, used for offline development), "run2" (used for accessing run2 offline development menus), "online" (used to extract online menus within Point 5) and "adg" (used to extract the online menus outside Point 5).\nIf no menu version is specified, the latest one is automatically used.\nIf "run:" is used instead, the HLT menu used for the given run number is looked up and used.\nNote other converters and databases exist as options but they are only for expert/special use.' )
 parser.add_argument('--dbproxy',
                     dest    = 'proxy',
-                    action  = 'store_const',
-                    const   = 'True',                    
+                    action  = 'store_true',
+                    default = defaults.proxy,
                     help    = 'Use a socks proxy to connect outside CERN network (default: False)' )
 parser.add_argument('--dbproxyport',
                     dest    = 'proxy_port',
@@ -108,4 +108,3 @@ config = parser.parse_args()
 paths  = getPathList(config)
 for path in paths:
   print(path)
-


### PR DESCRIPTION
#### PR description:

This PR provides a fix for cmd-line argument `--dbproxy` introduced in #35987 (see discussion post-merge in the latter PR).
The fix is needed to run correctly the HLT integration tests, and it will need to be backported to `12_1_X` and `12_0_X` (as #35987 was).

FYI: @Sam-Harper

#### PR validation:

Reproduced the error, and verified that this fix works as intended.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

N/A