### PR TITLE
MTD geometry: update ETL passive structure 

### DIFF
--- a/Configuration/Geometry/README.md
+++ b/Configuration/Geometry/README.md
@@ -91,6 +91,7 @@ Fast Timing system:
 * I12: Starting from I11, new ETL layout from MTD TDR
 * I13: Starting from I11, new ETL layout from post MTD TDR (2 sectors per disc face)
 * I14: Same as I13, updated sensor structure, disc z location and passive materials
+* I15: Same as I14, addition of notch and revision of envelope
 
 The script also handles the common and forward elements of the geometry:
 * O4: detailed cavern description, changes for modified CALO region for endcap part, no overlaps inside the Muon System 

--- a/Configuration/Geometry/python/dict2026Geometry.py
+++ b/Configuration/Geometry/python/dict2026Geometry.py
@@ -1567,6 +1567,34 @@ timingDict = {
            ],
        "era" : "phase2_timing, phase2_timing_layer, phase2_etlV4",
     },
+    "I15" : {
+        1 : [
+           'Geometry/MTDCommonData/data/mtdMaterial/v3/mtdMaterial.xml',
+           'Geometry/MTDCommonData/data/btl/v1/btl.xml',
+           'Geometry/MTDCommonData/data/etl/v7/etl.xml',
+           'Geometry/MTDCommonData/data/mtdParameters/v3/mtdStructureTopology.xml',
+           'Geometry/MTDCommonData/data/mtdParameters/v2/mtdParameters.xml',
+           ],
+       3 : [
+           'Geometry/MTDSimData/data/v2/mtdsens.xml'
+           ],
+       4 : [
+           'Geometry/MTDSimData/data/v2/mtdProdCuts.xml'
+           ],
+       "sim" : [
+           'from Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cff import *',
+           ],
+       "reco" :[
+           'from RecoMTD.DetLayers.mtdDetLayerGeometry_cfi import *',
+           'from Geometry.MTDGeometryBuilder.mtdParameters_cff import *',
+           'from Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cff import *',
+           'from Geometry.MTDNumberingBuilder.mtdTopology_cfi import *',
+           'from Geometry.MTDGeometryBuilder.mtdGeometry_cfi import *',
+           'from Geometry.MTDGeometryBuilder.idealForDigiMTDGeometry_cff import *',
+           'mtdGeometry.applyAlignment = cms.bool(False)'
+           ],
+       "era" : "phase2_timing, phase2_timing_layer, phase2_etlV4",
+    },
 }
 
 allDicts = [ commonDict, trackerDict, caloDict, muonDict, forwardDict, timingDict ]

--- a/Geometry/MTDCommonData/data/etl/v7/etl.xml
+++ b/Geometry/MTDCommonData/data/etl/v7/etl.xml
@@ -1,0 +1,4021 @@
+<?xml version="1.0"?>
+<DDDefinition>
+
+  <!-- Unit of measurement: mm  -->
+  <ConstantsSection label="etl.xml" eval="true">
+    <Constant name="ETL_thickness" value="([caloBase:Zpos0H]-[caloBase:Zpos10])"/>
+    <Constant name="ETLcenter" value="0.5*([caloBase:Zpos0H]+[caloBase:Zpos10])"/>
+    <Constant name="Disc1center" value="3000.75*mm"/>
+    <Constant name="Disc2center" value="3025.25*mm"/>
+    <Constant name="InnerCylinder_Rmax" value="300*mm"/>
+    <Constant name="ETLzmin" value="[caloBase:Zpos10]"/>
+    <Constant name="ETLz1" value="[caloBase:ZposAL]"/>
+    <Constant name="ETLz2" value="[caloBase:ZposAH]"/>
+    <Constant name="ETLzmax" value="[caloBase:Zpos0H]"/>
+    <Constant name="ETLrmin" value="[caloBase:Rmin11]"/>
+    <Constant name="ETLr1" value="[caloBase:Rmax10]"/>
+    <Constant name="ETLr2" value="[caloBase:Rmax10]+[caloBase:slope0]*([ETLz1]-[caloBase:Zpos10])"/>
+    <Constant name="ETLr3" value="[caloBase:Rmax10]+[caloBase:slope0]*([ETLz2]-[caloBase:Zpos10])"/>
+    <Constant name="ETLrmax" value="[caloBase:Rmax11]"/>
+    <Constant name="ETLr4" value="[caloBase:RposAL]"/>
+    <Constant name="ETLr5" value="[caloBase:RposAH]"/>
+    <Constant name="Disc_thickness" value="23.5*mm"/>
+    <Constant name="Al_Disc_thickness" value="7.5*mm"/>
+    <Constant name="Active_Disc_thickness" value="8*mm"/>
+    <Constant name="PatchPanel_Cables_FrontModcenter" value="3048.5*mm"/>
+    <Constant name="PatchPanel_Cables_thickness" value="21*mm"/>
+    <Constant name="FrontModerator_thickness" value="20*mm"/>
+    <Constant name="Active_Disc_thickness" value="8*mm"/>
+    <Constant name="BackSupportPlate_thickness" value="5*mm"/>
+    <!-- <Constant name="Disc_Rmin" value="315*mm"/> --> <!-- correct value, but not compatible with current modules placement -->
+    <Constant name="Disc_Rmin" value="300*mm"/>
+    <Constant name="Disc_Rmax" value="1190*mm"/>
+    <Constant name="PatchPanel_Rmin" value="1125*mm"/>
+    <Constant name="PatchPanel_Rmax" value="1195*mm"/>
+    <Constant name="Cables_Rmin" value="860*mm"/>
+    <Constant name="Cables_Rmax" value="1120*mm"/>
+    <Constant name="FrontModerator_Rmin" value="370*mm"/>
+    <Constant name="FrontModerator_Rmax" value="850*mm"/>
+    <Constant name="BackSupportPlate_Zmin" value="3038*mm"/>
+    <Constant name="BackSupportPlate_Z1" value="3043*mm"/>
+    <Constant name="BackSupportPlate_Z2" value="3059*mm"/>
+    <Constant name="BackSupportPlate_Z3" value="3140*mm"/>
+    <Constant name="BackSupportPlate_Z4" value="3180.5*mm"/>
+    <Constant name="BackSupportPlate_Zmax" value="3185.5*mm"/>
+    <Constant name="BackSupportPlate_Rmin" value="315*mm"/>
+    <Constant name="BackSupportPlate_R1" value="346*mm"/>
+    <Constant name="BackSupportPlate_R2" value="(([FrontModerator_Rmin]-[BackSupportPlate_R1])/([BackSupportPlate_Z2]-[BackSupportPlate_Zmin]))*([BackSupportPlate_Z1]-[BackSupportPlate_Zmin])+[BackSupportPlate_R1]"/>
+    <Constant name="BackSupportPlate_R3" value="(([FrontModerator_Rmin]-[BackSupportPlate_R1])/([BackSupportPlate_Z2]-[BackSupportPlate_Zmin]))*([BackSupportPlate_Z2]-[BackSupportPlate_Z1])+[BackSupportPlate_R1]"/>
+    <Constant name="BackSupportPlate_R4" value="1200*mm"/>
+    <Constant name="BackSupportPlate_R5" value="1281.5*mm"/>
+    <Constant name="BackSupportPlate_R6" value="(([BackSupportPlate_R5]-[BackSupportPlate_R4])/([BackSupportPlate_Z3]-[BackSupportPlate_Z2]))*([BackSupportPlate_Z2]+[BackSupportPlate_thickness]-[BackSupportPlate_Z2])+[BackSupportPlate_R4]"/>
+    <Constant name="BackSupportPlate_Rmax" value="1335*mm"/>
+    <Constant name="Notch_thickness" value="126.5*mm"/>
+    <Constant name="Notch_h2" value="350*mm"/>
+    <Constant name="Notch_bl2" value="281.5*mm"/>
+    <Constant name="Notch_h1" value="465*mm"/>
+    <Constant name="Notch_bl1" value="200*mm"/>
+    <Constant name="Notch_Rmin" value="1000*mm"/>
+    <Constant name="Notch_theta" value="32.7924191*deg"/>
+    <Constant name="NotchSubbox_width" value="160*mm"/>
+    <Constant name="ServiceExtVolume_Z1" value="3037*mm"/>
+    <Constant name="ServiceExtVolume_R1" value="[caloBase:Rmax10]+[caloBase:slope0]*([ServiceExtVolume_Z1]-[caloBase:Zpos10])"/>
+    <Constant name="ServiceExtVolume_R2" value="[caloBase:Rmax10]+[caloBase:slope0]*([BackSupportPlate_Z2]-[caloBase:Zpos10])"/>
+    <Constant name="ServiceExtVolume_R3" value="[caloBase:Rmax10]+[caloBase:slope0]*([BackSupportPlate_Z3]-[caloBase:Zpos10])"/>
+    <Constant name="ServiceExtVolume_R4" value="[caloBase:Rmax10]+[caloBase:slope0]*([BackSupportPlate_Z4]-[caloBase:Zpos10])"/>
+    <Constant name="InnerCylinder_center" value="0.5*([BackSupportPlate_Z2]+[caloBase:Zpos10])"/>
+    <Constant name="DeltaX" value="0.5*mm"/>
+    <Constant name="ServiceHybrid_Y" value="34*mm"/>
+    <Constant name="SensorModule_Y" value="25.85*mm"/>  <!-- 28.25mm - 2.4mm overlapping with SH -->
+    <Constant name="SensorModule_X" value="43.1*mm"/>
+    <Constant name="SensorModule_Z" value="7.58*mm"/> <!-- 2.75mm sensor module + 0.08mm Laird Film + 0.25mm Thermal Pad + 0.7mm connector gap + 1mm readout board + 2.8mm services-->
+    <Constant name="ServiceHybrid_X3" value="3*[SensorModule_X]"/>
+    <Constant name="ServiceHybrid_X6" value="6*[SensorModule_X]"/>
+    <Constant name="ServiceHybrid_X7" value="7*[SensorModule_X]"/>
+    <Constant name="ServiceHybrid_Z" value="6*mm"/>
+    <Constant name="DeltaY_ServiceModule" value="29.925*mm"/>  <!-- ServiceHybrid_Y/2 + SensorModule_Y/2 -->
+    <Constant name="DeltaX_Service3_Service6" value="194.45*mm"/>  <!-- DeltaX + ServiceHybrid_X3/2 + ServiceHybrid_X6/2 -->
+    <Constant name="DeltaX_Service3_Service7" value="216*mm"/>  <!-- DeltaX + ServiceHybrid_X3/2 + ServiceHybrid_X7/2 -->
+    <Constant name="DeltaX_Service6_Service7" value="280.65*mm"/>  <!-- DeltaX + ServiceHybrid_X6/2 + ServiceHybrid_X7/2 -->
+    <Constant name="PowerBoard_Z" value="4*mm"/>
+    <Constant name="servicesServiceHybrid_Z" value="2*mm"/>
+    <Constant name="LGADdy" value="21.2*mm"/>
+    <Constant name="LGADdx" value="42*mm"/>
+    <Constant name="EModule_Timingactive" value="0.05*mm"/>
+    <Constant name="LGAD_Substrate" value="0.25*mm"/>
+    <Constant name="LGAD_Z" value="0.3*mm"/>
+    <Constant name="glueLGAD_Z" value="0.1*mm"/>
+    <Constant name="bumpBonds_Z" value="0.1*mm"/>
+    <Constant name="lgadSep_Y" value="0.25*mm"/>
+    <Constant name="lgadSep_X" value="0.5*mm"/>
+    <Constant name="ETROCdy" value="22.3*mm"/>
+    <Constant name="ETROCdx" value="20.8*mm"/>
+    <Constant name="ETROC_Z" value="0.25*mm"/>
+    <Constant name="glueETROC_Z" value="0.05*mm"/>
+    <Constant name="etrocSep_Y" value="0.3*mm"/>
+    <Constant name="etrocSep_X" value="0.1*mm"/>
+    <Constant name="modulePCB_Z" value="0.45*mm"/>
+    <Constant name="connectorsGap_Z" value="0.7*mm"/>
+    <Constant name="ReadoutBoard_Z" value="1*mm"/>
+    <Constant name="servicesSensorModule_Z" value="2.8*mm"/>
+    <Constant name="y_start_front" value="-1190*mm + 33.05*mm + [SensorModule_Y]/2"/>
+    <Constant name="y_start_back" value="1190*mm - 16.05*mm - [ServiceHybrid_Y]/2"/>
+    <Constant name="x_offset" value="1*mm + [SensorModule_X]/2"/>
+    <Constant name="ThermalPad_Z" value="0.25*mm"/>
+    <Constant name="AlN_Base_Z" value="1.5*mm"/>
+    <Constant name="LairdFilm_Z" value="0.08*mm"/>
+    <Constant name="ETROC_translation_x" value="10.45*mm"/>
+    <Constant name="LairdFilm_translation_y" value="1.7*mm"/>
+    <Constant name="ETROC_translation_y" value="1.625*mm"/>
+    <Constant name="LGAD_translation_y" value="2.2*mm"/>
+    <Constant name="Disk_translation_z" value="7.75*mm"/>
+    <Constant name="SensorModule_translation_z" value="0.21*mm"/>
+    <Constant name="ThermalPad_translation_z" value="3.665*mm"/>
+    <Constant name="AlN_Base_translation_z" value="2.79*mm"/>
+    <Constant name="LairdFilm_translation_z" value="2*mm"/>
+    <Constant name="glueLGAD_translation_z" value="1.91*mm"/>
+    <Constant name="LGAD_translation_z" value="1.71*mm"/>
+    <Constant name="bumpBonds_translation_z" value="1.51*mm"/>
+    <Constant name="ETROC_translation_z" value="1.335*mm"/>
+    <Constant name="glueETROC_translation_z" value="1.185*mm"/>
+    <Constant name="modulePCB_translation_z" value="0.935*mm"/>
+    <Constant name="connectorsGap_translation_z" value="0.36*mm"/>
+    <Constant name="readoutBoard_translation_z" value="-0.49*mm"/>
+    <Constant name="servicesSensorModule_translation_z" value="-2.39*mm"/>
+    <Constant name="EModule_Timingactive_translation_z" value="-0.125*mm"/>
+    <Constant name="LGAD_Substrate_translation_z" value="0.025*mm"/>
+    <Constant name="PowerBoard_translation_z" value="1*mm"/>
+    <Constant name="servicesServiceHybrid_translation_z" value="-2*mm"/>
+    <Constant name="SensorModule_translation_z" value="0.21*mm"/>
+    <Constant name="ServiceHybrid_translation_z" value="1.*mm"/>
+    <Constant name="xoffset_servicehybrid" value="1*mm"/>
+
+    <Vector name="StartCopyNo_Front_Right" type="numeric" nEntries="28">
+      1, 7, 18, 33, 50, 69, 90, 112, 136, 161, 186, 207, 227, 247, 266,
+      285, 305, 325, 349, 374, 398, 421, 443, 463, 481, 497, 510, 517
+    </Vector>
+
+    <Vector name="StartCopyNo_Front_Left" type="numeric" nEntries="28">
+      1, 8, 21, 37, 55, 75, 97, 120, 144, 169, 193, 213, 233, 252, 271,
+      291, 311, 332, 357, 382, 406, 428, 449, 468, 485, 500, 511, 517
+    </Vector>
+
+    <Vector name="Offset_Front_Right" type="numeric" nEntries="28">
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 6, 7, 8, 8, 7, 6, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+    </Vector>
+
+    <Vector name="Offset_Front_Left" type="numeric" nEntries="28">
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 6, 7, 8, 8, 7, 6, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+    </Vector>
+
+    <Vector name="StartCopyNo_Back_Right" type="numeric" nEntries="28">
+      1, 10, 23, 39, 57, 77, 99, 122, 146, 171, 194, 214, 234, 254, 273,
+      293, 313, 335, 360, 384, 407, 430, 451, 470, 487, 501, 511, 514
+    </Vector>
+
+    <Vector name="StartCopyNo_Back_Left" type="numeric" nEntries="28">
+      1, 4, 14, 28, 45, 64, 85, 107, 130, 154, 179, 201, 221, 241, 260,
+      280, 300, 320, 343, 368, 392, 415, 437, 457, 475, 491, 504, 513
+    </Vector>
+
+    <Vector name="Offset_Back_Right" type="numeric" nEntries="28">
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 6, 7, 7, 8, 7, 6, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+    </Vector>
+
+    <Vector name="Offset_Back_Left" type="numeric" nEntries="28">
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 6, 7, 8, 7, 7, 6, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+    </Vector>
+
+  </ConstantsSection>
+
+  <RotationSection label="etl.xml">
+    <Rotation name="0" thetaX="90*deg" phiX="0*deg" thetaY="90*deg" phiY="90*deg" thetaZ="0*deg" phiZ="0*deg"/>
+    <Rotation name="270" thetaX="90*deg" phiX="270*deg" thetaY="90*deg" phiY="0*deg" thetaZ="0*deg" phiZ="0*deg"/>
+    <Rotation name="180" thetaX="90*deg" phiX="180*deg" thetaY="90*deg" phiY="270*deg" thetaZ="0*deg" phiZ="0*deg"/>
+    <Rotation name="90" thetaX="90*deg" phiX="90*deg" thetaY="90*deg" phiY="180*deg" thetaZ="0*deg" phiZ="0*deg"/>
+    <Rotation name="ReverseVert" thetaX="90*deg" phiX="0*deg" thetaY="90*deg" phiY="270*deg" thetaZ="180*deg" phiZ="0*deg"/>
+    <Rotation name="ReverseHor" thetaX="90*deg" phiX="180*deg" thetaY="90*deg" phiY="90*deg" thetaZ="180*deg" phiZ="0*deg"/>
+  </RotationSection>
+  
+  <SolidSection label="etl.xml">
+    <Polycone name="EndcapTimingLayer_0" startPhi="0*deg" deltaPhi="360*deg">
+              <ZSection z="[ETLzmin]" rMin="[ETLrmin]" rMax="[ETLr1]"/>
+              <ZSection z="[ETLz1]" rMin="[ETLrmin]" rMax="[ETLr2]"/>
+              <ZSection z="[ETLz1]" rMin="[ETLr4]" rMax="[ETLr2]"/>
+              <ZSection z="[ETLz2]" rMin="[ETLr5]" rMax="[ETLr3]"/>
+              <ZSection z="[ETLzmax]" rMin="[ETLr5]" rMax="[ETLrmax]"/>
+    </Polycone>
+    <Trapezoid name="Notch_ext" dz="0.5*[Notch_thickness]" alp1="0*deg" bl1="0.5*[Notch_bl1]" tl1="0.5*[Notch_bl1]" h1="0.5*[Notch_h1]" alp2="0*deg" bl2="0.5*[Notch_bl2]" tl2="0.5*[Notch_bl2]" h2="0.5*[Notch_h2]" phi="0*deg" theta="32.7924191*deg"/>
+    <UnionSolid name="EndcapTimingLayer_1">
+            <rSolid name="EndcapTimingLayer_0"/>
+            <rSolid name="Notch_ext"/>
+            <rRotation name="etl:180" />
+            <Translation x="-([Notch_Rmin]+0.5*[Notch_bl2])" y="0.*mm" z="0.5*[Notch_thickness]+[BackSupportPlate_Z2]"/>
+    </UnionSolid>
+    <UnionSolid name="EndcapTimingLayer">
+            <rSolid name="EndcapTimingLayer_1"/>
+            <rSolid name="Notch_ext"/>
+            <Translation x="([Notch_Rmin]+0.5*[Notch_bl2])" y="0.*mm" z="0.5*[Notch_thickness]+[BackSupportPlate_Z2]"/>
+    </UnionSolid>
+
+    <Tubs name="Disc" rMin="[Disc_Rmin]" rMax="[Disc_Rmax]" dz="0.5*[Disc_thickness]" startPhi="0*deg" deltaPhi="360*deg"/>
+    <Tubs name="Al_Disc" rMin="[Disc_Rmin]" rMax="[Disc_Rmax]" dz="0.5*[Al_Disc_thickness]" startPhi="0*deg" deltaPhi="360*deg"/>
+    <Tubs name="FrontModerator" rMin="[FrontModerator_Rmin]" rMax="[FrontModerator_Rmax]" dz="0.5*[FrontModerator_thickness]" startPhi="0*deg" deltaPhi="360*deg"/>
+    <Tubs name="Cables" rMin="[Cables_Rmin]" rMax="[Cables_Rmax]" dz="0.5*[PatchPanel_Cables_thickness]" startPhi="90*deg" deltaPhi="70.4*deg"/>
+    <Tubs name="PatchPanel" rMin="[PatchPanel_Rmin]" rMax="[PatchPanel_Rmax]" dz="0.5*[PatchPanel_Cables_thickness]" startPhi="12.2*deg" deltaPhi="155.6*deg"/>
+    <Polycone name="BackSupportPlate_0" startPhi="0*deg" deltaPhi="360*deg">
+            <ZSection z="[BackSupportPlate_Zmin]" rMin="[BackSupportPlate_Rmin]" rMax="[BackSupportPlate_R1]"/>
+            <ZSection z="[BackSupportPlate_Zmin]+[BackSupportPlate_thickness]" rMin="[BackSupportPlate_Rmin]" rMax="[BackSupportPlate_R2]"/>
+            <ZSection z="[BackSupportPlate_Zmin]+[BackSupportPlate_thickness]" rMin="[BackSupportPlate_R1]" rMax="[BackSupportPlate_R2]"/>
+            <ZSection z="[BackSupportPlate_Z2]" rMin="[BackSupportPlate_R3]" rMax="[FrontModerator_Rmin]"/>
+            <ZSection z="[BackSupportPlate_Z2]" rMin="[BackSupportPlate_R3]" rMax="[BackSupportPlate_R4]"/>
+            <ZSection z="[BackSupportPlate_Z2]+[BackSupportPlate_thickness]" rMin="[FrontModerator_Rmin]" rMax="[BackSupportPlate_R6]"/>
+            <ZSection z="[BackSupportPlate_Z2]+[BackSupportPlate_thickness]" rMin="[BackSupportPlate_R4]" rMax="[BackSupportPlate_R6]"/>
+            <ZSection z="[BackSupportPlate_Z3]" rMin="[BackSupportPlate_R5]-[BackSupportPlate_thickness]" rMax="[BackSupportPlate_R5]"/>
+            <ZSection z="[BackSupportPlate_Z4]" rMin="[BackSupportPlate_R5]-[BackSupportPlate_thickness]" rMax="[BackSupportPlate_R5]"/>
+            <ZSection z="[BackSupportPlate_Z4]" rMin="[BackSupportPlate_R5]-[BackSupportPlate_thickness]" rMax="[BackSupportPlate_Rmax]"/>
+            <ZSection z="[BackSupportPlate_Zmax]" rMin="[BackSupportPlate_R5]-[BackSupportPlate_thickness]" rMax="[BackSupportPlate_Rmax]"/>
+    </Polycone>
+    <Box name="SubBox1" dz="[Notch_thickness]" dx="0.5*([BackSupportPlate_Rmax]-[Notch_Rmin])" dy="0.5*[Notch_h1]"/>
+    <SubtractionSolid name="BackSupportPlate_1">
+            <rSolid name="BackSupportPlate_0"/>
+            <rSolid name="SubBox1"/>
+            <Translation x="[Notch_Rmin]+0.5*([BackSupportPlate_Rmax]-[Notch_Rmin])" y="0.*mm" z="0.5*[Notch_thickness]+[BackSupportPlate_Z2]"/>
+    </SubtractionSolid>
+    <SubtractionSolid name="BackSupportPlate_2">
+            <rSolid name="BackSupportPlate_1"/>
+            <rSolid name="SubBox1"/>
+            <Translation x="-([Notch_Rmin]+0.5*([BackSupportPlate_Rmax]-[Notch_Rmin]))" y="0.*mm" z="0.5*[Notch_thickness]+[BackSupportPlate_Z2]"/>
+    </SubtractionSolid>
+    <Trapezoid name="Notch_int" dz="0.5*([Notch_thickness]-[BackSupportPlate_thickness])" alp1="0*deg" bl1="0.5*([Notch_bl1]-[BackSupportPlate_thickness])" tl1="0.5*([Notch_bl1]-[BackSupportPlate_thickness])" h1="0.5*[Notch_h1]-[BackSupportPlate_thickness]" alp2="0*deg" bl2="0.5*([Notch_bl2]-[BackSupportPlate_thickness])" tl2="0.5*([Notch_bl2]-[BackSupportPlate_thickness])" h2="0.5*[Notch_h2]-[BackSupportPlate_thickness]" phi="0*deg" theta="[Notch_theta]"/>
+    <SubtractionSolid name="Notch_whole">
+            <rSolid name="Notch_ext"/>
+            <rSolid name="Notch_int"/>
+            <Translation x="[BackSupportPlate_thickness]" y="0.*mm" z="-[BackSupportPlate_thickness]"/>
+    </SubtractionSolid>
+    <SubtractionSolid name="Notch_left">
+            <rSolid name="Notch_whole"/>
+            <rSolid name="SubBox2"/>
+            <Translation x="[BackSupportPlate_thickness]+0.5*([Notch_bl2]-[Notch_bl1])" y="-0.5*[NotchSubbox_width]" z="0.5*[Notch_thickness]"/>
+    </SubtractionSolid>
+    <SubtractionSolid name="Notch_right">
+            <rSolid name="Notch_whole"/>
+            <rSolid name="SubBox2"/>
+            <Translation x="[BackSupportPlate_thickness]+0.5*([Notch_bl2]-[Notch_bl1])" y="0.5*[NotchSubbox_width]" z="0.5*[Notch_thickness]"/>
+    </SubtractionSolid>
+    <Box name="SubBox2" dz="2*[BackSupportPlate_thickness]" dx="0.5*[Notch_bl2]" dy="0.5*[NotchSubbox_width]"/>
+    <UnionSolid name="BackSupportPlate_3">
+            <rSolid name="BackSupportPlate_2"/>
+            <rSolid name="Notch_left"/>
+            <rRotation name="etl:180" />
+            <Translation x="-([Notch_Rmin]+0.5*[Notch_bl2])" y="0.*mm" z="0.5*[Notch_thickness]+[BackSupportPlate_Z2]"/>
+    </UnionSolid>
+    <UnionSolid name="BackSupportPlate">
+            <rSolid name="BackSupportPlate_3"/>
+            <rSolid name="Notch_right"/>
+            <Translation x="[Notch_Rmin]+0.5*[Notch_bl2]" y="0.*mm" z="0.5*[Notch_thickness]+[BackSupportPlate_Z2]"/>
+    </UnionSolid>
+    <Trapezoid name="Notch_cables" dz="0.5*([Notch_thickness]-[BackSupportPlate_thickness])" alp1="0*deg" bl1="0.5*[Notch_bl1]-[BackSupportPlate_thickness]" tl1="0.5*[Notch_bl1]-[BackSupportPlate_thickness]" h1="0.5*[Notch_h1]-[BackSupportPlate_thickness]" alp2="0*deg" bl2="0.5*[Notch_bl2]-[BackSupportPlate_thickness]" tl2="0.5*[Notch_bl2]-[BackSupportPlate_thickness]" h2="0.5*[Notch_h2]-[BackSupportPlate_thickness]" phi="0*deg" theta="[Notch_theta]"/>
+    <Polycone name="ServicesExtVolume1" startPhi="12.2*deg" deltaPhi="155.6*deg">
+            <ZSection z="[ETLzmin]" rMin="[Disc_Rmax]" rMax="[ETLr1]"/>
+            <ZSection z="[ServiceExtVolume_Z1]" rMin="[Disc_Rmax]" rMax="[ServiceExtVolume_R1]"/>
+            <ZSection z="[ServiceExtVolume_Z1]" rMin="[PatchPanel_Rmax]" rMax="[ServiceExtVolume_R1]"/>
+            <ZSection z="[BackSupportPlate_Z2]" rMin="[PatchPanel_Rmax]" rMax="[ServiceExtVolume_R2]"/>
+            <ZSection z="[BackSupportPlate_Z2]" rMin="[BackSupportPlate_R4]" rMax="[ServiceExtVolume_R2]"/>
+            <ZSection z="[BackSupportPlate_Z3]" rMin="[BackSupportPlate_R5]" rMax="[ServiceExtVolume_R3]"/>
+            <ZSection z="[BackSupportPlate_Z4]" rMin="[BackSupportPlate_R5]" rMax="[ServiceExtVolume_R4]"/>
+    </Polycone>
+    <Polycone name="ServicesExtVolume2" startPhi="192.2*deg" deltaPhi="155.6*deg">
+        <ZSection z="[ETLzmin]" rMin="[Disc_Rmax]" rMax="[ETLr1]"/>
+        <ZSection z="[ServiceExtVolume_Z1]" rMin="[Disc_Rmax]" rMax="[ServiceExtVolume_R1]"/>
+        <ZSection z="[ServiceExtVolume_Z1]" rMin="[PatchPanel_Rmax]" rMax="[ServiceExtVolume_R1]"/>
+        <ZSection z="[BackSupportPlate_Z2]" rMin="[PatchPanel_Rmax]" rMax="[ServiceExtVolume_R2]"/>
+        <ZSection z="[BackSupportPlate_Z2]" rMin="[BackSupportPlate_R4]" rMax="[ServiceExtVolume_R2]"/>
+        <ZSection z="[BackSupportPlate_Z3]" rMin="[BackSupportPlate_R5]" rMax="[ServiceExtVolume_R3]"/>
+        <ZSection z="[BackSupportPlate_Z4]" rMin="[BackSupportPlate_R5]" rMax="[ServiceExtVolume_R4]"/>
+    </Polycone>
+    <Tubs name="InnerCylinder" rMin="[ETLrmin]" rMax="[InnerCylinder_Rmax]" dz="0.5*([BackSupportPlate_Z2]-[ETLzmin])" startPhi="0*deg" deltaPhi="360*deg"/>
+    <Tubs name="InnerBrackets" rMin="[InnerCylinder_Rmax]" rMax="[Disc_Rmin]" dz="0.5*([BackSupportPlate_Z2]-[ETLzmin])" startPhi="0*deg" deltaPhi="360*deg"/>
+    
+    <!-- FRONT: face closest to IP, BACK: furthest from IP -->
+    <Tubs name="DiscSector_Front" rMin="[Disc_Rmin]" rMax="[Disc_Rmax]" dz="0.5*[Active_Disc_thickness]" startPhi="-90*deg" deltaPhi="180*deg"/> <!-- half-disc on front face -->
+    <Tubs name="DiscSector_Back" rMin="[Disc_Rmin]" rMax="[Disc_Rmax]" dz="0.5*[Active_Disc_thickness]" startPhi="-90*deg" deltaPhi="180*deg"/> <!-- half-disc on back face -->
+    
+    <Tubs name="Cables1" rMin="[Cables_Rmin]" rMax="[Cables_Rmax]" dz="0.5*[PatchPanel_Cables_thickness]" startPhi="90*deg" deltaPhi="8*deg"/>
+    <Tubs name="Cables2" rMin="[Cables_Rmin]" rMax="[Cables_Rmax]" dz="0.5*[PatchPanel_Cables_thickness]" startPhi="98*deg" deltaPhi="10.4*deg"/>
+    <Tubs name="Cables3" rMin="[Cables_Rmin]" rMax="[Cables_Rmax]" dz="0.5*[PatchPanel_Cables_thickness]" startPhi="108.4*deg" deltaPhi="10.4*deg"/>
+    <Tubs name="Cables4" rMin="[Cables_Rmin]" rMax="[Cables_Rmax]" dz="0.5*[PatchPanel_Cables_thickness]" startPhi="118.8*deg" deltaPhi="10.4*deg"/>
+    <Tubs name="Cables5" rMin="[Cables_Rmin]" rMax="[Cables_Rmax]" dz="0.5*[PatchPanel_Cables_thickness]" startPhi="129.2*deg" deltaPhi="10.4*deg"/>
+    <Tubs name="Cables6" rMin="[Cables_Rmin]" rMax="[Cables_Rmax]" dz="0.5*[PatchPanel_Cables_thickness]" startPhi="139.6*deg" deltaPhi="10.4*deg"/>
+    <Tubs name="Cables7" rMin="[Cables_Rmin]" rMax="[Cables_Rmax]" dz="0.5*[PatchPanel_Cables_thickness]" startPhi="150*deg" deltaPhi="10.4*deg"/>
+
+    <Box name="SensorModule" dx="0.5*[SensorModule_X]" dy="0.5*[SensorModule_Y]" dz="0.5*[SensorModule_Z]"/>
+    <Box name="ServiceHybrid3" dx="0.5*[ServiceHybrid_X3]" dy="0.5*[ServiceHybrid_Y]" dz="0.5*[ServiceHybrid_Z]"/>
+    <Box name="ServiceHybrid6" dx="0.5*[ServiceHybrid_X6]" dy="0.5*[ServiceHybrid_Y]" dz="0.5*[ServiceHybrid_Z]"/>
+    <Box name="ServiceHybrid7" dx="0.5*[ServiceHybrid_X7]" dy="0.5*[ServiceHybrid_Y]" dz="0.5*[ServiceHybrid_Z]"/>
+
+    <!-- boxes included in SensorModule volume -->
+    <Box name="ThermalPad" dx="0.5*[SensorModule_X]" dy="0.5*[SensorModule_Y]" dz="0.5*[ThermalPad_Z]"/>
+    <Box name="LairdFilm" dx="0.5*([ETROCdx]*2+[etrocSep_X])" dy="0.5*([ETROCdy]+0.5*[etrocSep_Y])" dz="0.5*[LairdFilm_Z]"/>
+    <Box name="AlN_Base" dx="0.5*[SensorModule_X]" dy="0.5*[SensorModule_Y]" dz="0.5*[AlN_Base_Z]"/>
+    <Box name="glueLGAD" dx="0.5*[LGADdx]" dy="0.5*[LGADdy]" dz="0.5*[glueLGAD_Z]"/>
+    <Box name="BumpBonds" dx="0.5*[LGADdx]" dy="0.5*[LGADdy]" dz="0.5*[bumpBonds_Z]"/>
+    <Box name="LGAD" dx="0.5*[LGADdx]" dy="0.5*[LGADdy]" dz="0.5*[LGAD_Z]"/>
+    <Box name="EModule_Timingactive" dx="0.5*[LGADdx]" dy="0.5*[LGADdy]" dz="0.5*[EModule_Timingactive]"/>
+    <Box name="LGAD_Substrate" dx="0.5*[LGADdx]" dy="0.5*[LGADdy]" dz="0.5*[LGAD_Substrate]"/>
+    <Box name="ETROC" dx="0.5*[ETROCdx]" dy="0.5*[ETROCdy]" dz="0.5*[ETROC_Z]"/>
+    <Box name="glueETROC" dx="0.5*[ETROCdx]" dy="0.5*[ETROCdy]" dz="0.5*[glueETROC_Z]"/>
+    <Box name="ModulePCB" dx="0.5*[ETROCdx]" dy="0.5*[ETROCdy]" dz="0.5*[modulePCB_Z]"/>
+    <Box name="connectorsGap" dx="0.5*[SensorModule_X]" dy="0.5*[SensorModule_Y]" dz="0.5*[connectorsGap_Z]"/>
+    <Box name="ReadoutBoard" dx="0.5*[SensorModule_X]" dy="0.5*[SensorModule_Y]" dz="0.5*[ReadoutBoard_Z]"/>
+    <Box name="servicesSensorModule" dx="0.5*[SensorModule_X]" dy="0.5*[SensorModule_Y]" dz="0.5*[servicesSensorModule_Z]"/>
+    
+    <!-- boxes included in ServiceHybrids volumes -->
+    <Box name="PowerBoard3" dx="0.5*[ServiceHybrid_X3]" dy="0.5*[ServiceHybrid_Y]" dz="0.5*[PowerBoard_Z]"/>
+    <Box name="servicesServiceHybrid3" dx="0.5*[ServiceHybrid_X3]" dy="0.5*[ServiceHybrid_Y]" dz="0.5*[servicesServiceHybrid_Z]"/>
+    <Box name="PowerBoard6" dx="0.5*[ServiceHybrid_X6]" dy="0.5*[ServiceHybrid_Y]" dz="0.5*[PowerBoard_Z]"/>
+    <Box name="servicesServiceHybrid6" dx="0.5*[ServiceHybrid_X6]" dy="0.5*[ServiceHybrid_Y]" dz="0.5*[servicesServiceHybrid_Z]"/>
+    <Box name="PowerBoard7" dx="0.5*[ServiceHybrid_X7]" dy="0.5*[ServiceHybrid_Y]" dz="0.5*[PowerBoard_Z]"/>
+    <Box name="servicesServiceHybrid7" dx="0.5*[ServiceHybrid_X7]" dy="0.5*[ServiceHybrid_Y]" dz="0.5*[servicesServiceHybrid_Z]"/>
+  </SolidSection>
+
+  <LogicalPartSection label="etl.xml">
+    <LogicalPart name="EndcapTimingLayer" category="unspecified">
+      <rSolid name="etl:EndcapTimingLayer"/>
+      <rMaterial name="materials:Air"/>
+    </LogicalPart>
+    <!-- Disc1Timing and Disc2Timing introduced to be compatible with previous scenarios. Can be replaced with 2 copies of DiscTiming, since the 2 disks are identical -->
+    <LogicalPart name="Disc1Timing" category="unspecified">
+      <rSolid name="etl:Disc"/>
+      <rMaterial name="materials:Air"/>
+    </LogicalPart>
+    <LogicalPart name="Disc2Timing" category="unspecified">
+      <rSolid name="etl:Disc"/>
+      <rMaterial name="materials:Air"/>
+    </LogicalPart>
+    <LogicalPart name="Al_Disc" category="unspecified">
+      <rSolid name="etl:Al_Disc"/>
+      <rMaterial name="materials:Aluminium"/>
+    </LogicalPart>
+    <LogicalPart name="FrontModerator" category="unspecified">
+      <rSolid name="etl:FrontModerator"/>
+      <rMaterial name="mtdMaterial:Borated_Polyethyl."/>
+    </LogicalPart>
+    <LogicalPart name="Cables" category="unspecified">
+      <rSolid name="etl:Cables"/>
+      <rMaterial name="materials:Air"/>
+    </LogicalPart>
+    <LogicalPart name="PatchPanel" category="unspecified">
+      <rSolid name="etl:PatchPanel"/>
+      <rMaterial name="mtdMaterial:ETLPatchPanel"/>
+    </LogicalPart>
+    <LogicalPart name="BackSupportPlate" category="unspecified">
+      <rSolid name="etl:BackSupportPlate"/>
+      <rMaterial name="materials:Carbon_fibre_str_Upgrade"/>
+    </LogicalPart>
+    <LogicalPart name="Notch_cables" category="unspecified">
+      <rSolid name="etl:Notch_cables"/>
+      <rMaterial name="mtdMaterial:ETLNotch"/>
+    </LogicalPart>
+    <LogicalPart name="ServicesExtVolume1" category="unspecified">
+      <rSolid name="etl:ServicesExtVolume1"/>
+      <rMaterial name="mtdMaterial:ETLServicesVolume"/>
+    </LogicalPart>
+    <LogicalPart name="ServicesExtVolume2" category="unspecified">
+      <rSolid name="etl:ServicesExtVolume2"/>
+      <rMaterial name="mtdMaterial:ETLServicesVolume"/>
+    </LogicalPart>
+    <LogicalPart name="InnerCylinder" category="unspecified">
+      <rSolid name="etl:InnerCylinder"/>
+      <rMaterial name="materials:Borosilicate_Glass"/>
+    </LogicalPart>
+    <LogicalPart name="InnerBrackets" category="unspecified">
+      <rSolid name="etl:InnerBrackets"/>
+      <rMaterial name="materials:Aluminium"/>
+    </LogicalPart>
+    
+    <!-- Cables sectors -->
+    <LogicalPart name="Cables1" category="unspecified">
+      <rSolid name="etl:Cables1"/>
+      <rMaterial name="mtdMaterial:Cables1"/>
+    </LogicalPart>
+    <LogicalPart name="Cables2" category="unspecified">
+      <rSolid name="etl:Cables2"/>
+      <rMaterial name="mtdMaterial:Cables2"/>
+    </LogicalPart>
+    <LogicalPart name="Cables3" category="unspecified">
+      <rSolid name="etl:Cables3"/>
+      <rMaterial name="mtdMaterial:Cables3"/>
+    </LogicalPart>
+    <LogicalPart name="Cables4" category="unspecified">
+      <rSolid name="etl:Cables4"/>
+      <rMaterial name="mtdMaterial:Cables4"/>
+    </LogicalPart>
+    <LogicalPart name="Cables5" category="unspecified">
+      <rSolid name="etl:Cables5"/>
+      <rMaterial name="mtdMaterial:Cables5"/>
+    </LogicalPart>
+    <LogicalPart name="Cables6" category="unspecified">
+      <rSolid name="etl:Cables6"/>
+      <rMaterial name="mtdMaterial:Cables6"/>
+    </LogicalPart>
+    <LogicalPart name="Cables7" category="unspecified">
+      <rSolid name="etl:Cables7"/>
+      <rMaterial name="mtdMaterial:Cables7"/>
+    </LogicalPart>
+    
+    <!-- Sectors on Disc1 -->
+    <LogicalPart name="DiscSector_Front" category="unspecified">
+      <rSolid name="etl:DiscSector_Front"/>
+      <rMaterial name="materials:Air"/>
+    </LogicalPart>
+    <LogicalPart name="DiscSector_Back" category="unspecified">
+      <rSolid name="etl:DiscSector_Back"/>
+      <rMaterial name="materials:Air"/>
+    </LogicalPart>
+    
+    <!-- Sensor module on front face  -->
+    <LogicalPart name="SensorModule_Front_Right" category="unspecified">
+      <rSolid name="etl:SensorModule"/>
+      <rMaterial name="materials:Air"/>
+    </LogicalPart>
+    <LogicalPart name="SensorModule_Front_Left" category="unspecified">
+      <rSolid name="etl:SensorModule"/>
+      <rMaterial name="materials:Air"/>
+    </LogicalPart>
+
+    <!-- Sensor module on back face  -->
+    <LogicalPart name="SensorModule_Back_Left" category="unspecified">
+      <rSolid name="etl:SensorModule"/>
+      <rMaterial name="materials:Air"/>
+    </LogicalPart>
+    <LogicalPart name="SensorModule_Back_Right" category="unspecified">
+      <rSolid name="etl:SensorModule"/>
+      <rMaterial name="materials:Air"/>
+    </LogicalPart>
+
+    <!-- Service Hybrids on front face -->
+    <LogicalPart name="ServiceHybrid3_Front" category="unspecified">
+      <rSolid name="etl:ServiceHybrid3"/>
+      <rMaterial name="materials:Air"/>
+    </LogicalPart>
+    <LogicalPart name="ServiceHybrid6_Front" category="unspecified">
+      <rSolid name="etl:ServiceHybrid6"/>
+      <rMaterial name="materials:Air"/>
+    </LogicalPart>
+    <LogicalPart name="ServiceHybrid7_Front" category="unspecified">
+      <rSolid name="etl:ServiceHybrid7"/>
+      <rMaterial name="materials:Air"/>
+    </LogicalPart>
+    
+    <!-- Service Hybrids on back face -->
+    <LogicalPart name="ServiceHybrid3_Back" category="unspecified">
+      <rSolid name="etl:ServiceHybrid3"/>
+      <rMaterial name="materials:Air"/>
+    </LogicalPart>
+    <LogicalPart name="ServiceHybrid6_Back" category="unspecified">
+      <rSolid name="etl:ServiceHybrid6"/>
+      <rMaterial name="materials:Air"/>
+    </LogicalPart>
+    <LogicalPart name="ServiceHybrid7_Back" category="unspecified">
+      <rSolid name="etl:ServiceHybrid7"/>
+      <rMaterial name="materials:Air"/>
+    </LogicalPart>
+    
+    
+    <!-- Elements composing the sensor module -->
+    <LogicalPart name="ThermalPad" category="unspecified">
+      <rSolid name="etl:ThermalPad"/>
+      <rMaterial name="materials:Epoxy"/>
+    </LogicalPart>
+    <LogicalPart name="LairdFilm" category="unspecified">
+      <rSolid name="etl:LairdFilm"/>
+      <rMaterial name="mtdMaterial:Laird"/>
+    </LogicalPart>
+    <LogicalPart name="AlN_Base" category="unspecified">
+      <rSolid name="etl:AlN_Base"/>
+      <rMaterial name="mtdMaterial:Aluminium_Nitride"/>
+    </LogicalPart>
+    <LogicalPart name="glueLGAD" category="unspecified">
+      <rSolid name="etl:glueLGAD"/>
+      <rMaterial name="materials:Epoxy"/>
+    </LogicalPart>
+    <LogicalPart name="BumpBonds" category="unspecified">
+      <rSolid name="etl:BumpBonds"/>
+      <rMaterial name="materials:Tin"/>
+    </LogicalPart>
+    <LogicalPart name="LGAD" category="unspecified">
+      <rSolid name="etl:LGAD"/>
+      <rMaterial name="materials:Air"/>
+    </LogicalPart>
+    <LogicalPart name="EModule_Timingactive" category="unspecified">
+      <rSolid name="etl:EModule_Timingactive"/>
+      <rMaterial name="materials:Silicon"/>
+    </LogicalPart>
+    <LogicalPart name="LGAD_Substrate" category="unspecified">
+      <rSolid name="etl:LGAD_Substrate"/>
+      <rMaterial name="materials:Silicon"/>
+    </LogicalPart>
+    <LogicalPart name="ETROC" category="unspecified">
+      <rSolid name="etl:ETROC"/>
+      <rMaterial name="materials:Silicon"/>
+    </LogicalPart>
+    <LogicalPart name="glueETROC" category="unspecified">
+      <rSolid name="etl:glueETROC"/>
+      <rMaterial name="materials:Epoxy"/>
+    </LogicalPart>
+    <LogicalPart name="ModulePCB" category="unspecified">
+      <rSolid name="etl:ModulePCB"/>
+      <rMaterial name="mtdMaterial:ServiceHybrid_PCB"/>
+    </LogicalPart>
+    <LogicalPart name="connectorsGap" category="unspecified">
+      <rSolid name="etl:connectorsGap"/>
+      <rMaterial name="materials:Air"/>
+    </LogicalPart>
+    <LogicalPart name="ReadoutBoard" category="unspecified">
+      <rSolid name="etl:ReadoutBoard"/>
+      <rMaterial name="mtdMaterial:ServiceHybrid_PCB"/>
+    </LogicalPart>
+    <LogicalPart name="servicesSensorModule" category="unspecified">
+      <rSolid name="etl:servicesSensorModule"/>
+      <rMaterial name="mtdMaterial:ServiceHybrid_PCB"/>
+    </LogicalPart>
+    
+    <!-- Elements composing the servicehybrids modules -->
+    <LogicalPart name="PowerBoard3" category="unspecified">
+      <rSolid name="etl:PowerBoard3"/>
+      <rMaterial name="mtdMaterial:ServiceHybrid_PCB"/>
+    </LogicalPart>
+    <LogicalPart name="PowerBoard6" category="unspecified">
+      <rSolid name="etl:PowerBoard6"/>
+      <rMaterial name="mtdMaterial:ServiceHybrid_PCB"/>
+    </LogicalPart>
+    <LogicalPart name="PowerBoard7" category="unspecified">
+      <rSolid name="etl:PowerBoard7"/>
+      <rMaterial name="mtdMaterial:ServiceHybrid_PCB"/>
+    </LogicalPart>
+    <LogicalPart name="servicesServiceHybrid3" category="unspecified">
+      <rSolid name="etl:servicesServiceHybrid3"/>
+      <rMaterial name="mtdMaterial:ServiceHybrid_PCB"/>
+    </LogicalPart>
+    <LogicalPart name="servicesServiceHybrid6" category="unspecified">
+      <rSolid name="etl:servicesServiceHybrid6"/>
+      <rMaterial name="mtdMaterial:ServiceHybrid_PCB"/>
+    </LogicalPart>
+    <LogicalPart name="servicesServiceHybrid7" category="unspecified">
+      <rSolid name="etl:servicesServiceHybrid7"/>
+      <rMaterial name="mtdMaterial:ServiceHybrid_PCB"/>
+    </LogicalPart>
+ </LogicalPartSection>
+  
+  <PosPartSection label="etl.xml">
+    <PosPart copyNumber="1">
+      <rParent name="caloBase:CALOECFront"/>
+      <rChild name="etl:EndcapTimingLayer"/>
+      <Translation x="0.*mm" y="0.*mm" z="0.*mm" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:EndcapTimingLayer"/>
+      <rChild name="etl:Disc1Timing"/>
+      <Translation x="0.*mm" y="0.*mm" z="[Disc1center]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:EndcapTimingLayer"/>
+      <rChild name="etl:Disc2Timing"/>
+      <Translation x="0.*mm" y="0.*mm" z="[Disc2center]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:EndcapTimingLayer"/>
+      <rChild name="etl:FrontModerator"/>
+      <Translation x="0.*mm" y="0.*mm" z="[PatchPanel_Cables_FrontModcenter]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:EndcapTimingLayer"/>
+      <rChild name="etl:Cables"/>
+      <Translation x="0.*mm" y="0.*mm" z="[PatchPanel_Cables_FrontModcenter]" />
+    </PosPart>
+    <PosPart copyNumber="2">
+      <rParent name="etl:EndcapTimingLayer"/>
+      <rChild name="etl:Cables"/>
+      <rRotation name="etl:ReverseVert" />
+      <Translation x="0.*mm" y="0.*mm" z="[PatchPanel_Cables_FrontModcenter]" />
+    </PosPart>
+    <PosPart copyNumber="3">
+      <rParent name="etl:EndcapTimingLayer"/>
+      <rChild name="etl:Cables"/>
+      <rRotation name="etl:180" />
+      <Translation x="0.*mm" y="0.*mm" z="[PatchPanel_Cables_FrontModcenter]" />
+    </PosPart>
+    <PosPart copyNumber="4">
+      <rParent name="etl:EndcapTimingLayer"/>
+      <rChild name="etl:Cables"/>
+      <rRotation name="etl:ReverseHor" />
+      <Translation x="0.*mm" y="0.*mm" z="[PatchPanel_Cables_FrontModcenter]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:EndcapTimingLayer"/>
+      <rChild name="etl:PatchPanel"/>
+      <Translation x="0.*mm" y="0.*mm" z="[PatchPanel_Cables_FrontModcenter]" />
+    </PosPart>
+    <PosPart copyNumber="2">
+        <rParent name="etl:EndcapTimingLayer"/>
+        <rChild name="etl:PatchPanel"/>
+        <rRotation name="etl:ReverseVert" />
+        <Translation x="0.*mm" y="0.*mm" z="[PatchPanel_Cables_FrontModcenter]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:EndcapTimingLayer"/>
+      <rChild name="etl:BackSupportPlate"/>
+      <Translation x="0.*mm" y="0.*mm" z="0.*mm" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:EndcapTimingLayer"/>
+      <rChild name="etl:Notch_cables"/>
+     <!-- <Translation x="[Notch_Rmin]+0.5*([Notch_bl2]-2*[BackSupportPlate_thickness])+[BackSupportPlate_thickness]" y="0.*mm" z="[Notch_cables_center]" /> -->
+     <Translation x="[Notch_Rmin]+0.5*[Notch_bl2]+[BackSupportPlate_thickness]" y="0.*mm" z="0.5*[Notch_thickness]+[BackSupportPlate_Z2]-[BackSupportPlate_thickness]"/>
+    </PosPart>
+    <PosPart copyNumber="2">
+      <rParent name="etl:EndcapTimingLayer"/>
+      <rChild name="etl:Notch_cables"/>
+      <rRotation name="etl:180" />
+     <!-- <Translation x="-[Notch_Rmin]-0.5*([Notch_bl2]-2*[BackSupportPlate_thickness])-[BackSupportPlate_thickness]" y="0.*mm" z="[Notch_cables_center]" /> -->
+     <Translation x="-([Notch_Rmin]+0.5*[Notch_bl2])-[BackSupportPlate_thickness]" y="0.*mm" z="0.5*[Notch_thickness]+[BackSupportPlate_Z2]-[BackSupportPlate_thickness]"/>
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:EndcapTimingLayer"/>
+      <rChild name="etl:ServicesExtVolume1"/>
+      <Translation x="0.*mm" y="0.*mm" z="0.*mm" />
+    </PosPart>
+    <PosPart copyNumber="1">
+        <rParent name="etl:EndcapTimingLayer"/>
+        <rChild name="etl:ServicesExtVolume2"/>
+        <Translation x="0.*mm" y="0.*mm" z="0.*mm" />
+    </PosPart>
+    <!-- <PosPart copyNumber="1">
+        <rParent name="etl:EndcapTimingLayer"/>
+        <rChild name="etl:InnerCylinder"/>
+        <Translation x="0.*mm" y="0.*mm" z="[InnerCylinder_center]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+        <rParent name="etl:EndcapTimingLayer"/>
+        <rChild name="etl:InnerBrackets"/>
+        <Translation x="0.*mm" y="0.*mm" z="[InnerCylinder_center]" />
+    </PosPart> -->
+    
+    <!-- Children volumes Cables -->
+    <PosPart copyNumber="1">
+      <rParent name="etl:Cables"/>
+      <rChild name="etl:Cables1"/>
+      <Translation x="0.*mm" y="0.*mm" z="0." />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:Cables"/>
+      <rChild name="etl:Cables2"/>
+      <Translation x="0.*mm" y="0.*mm" z="0." />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:Cables"/>
+      <rChild name="etl:Cables3"/>
+      <Translation x="0.*mm" y="0.*mm" z="0." />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:Cables"/>
+      <rChild name="etl:Cables4"/>
+      <Translation x="0.*mm" y="0.*mm" z="0." />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:Cables"/>
+      <rChild name="etl:Cables5"/>
+      <Translation x="0.*mm" y="0.*mm" z="0." />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:Cables"/>
+      <rChild name="etl:Cables6"/>
+      <Translation x="0.*mm" y="0.*mm" z="0." />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:Cables"/>
+      <rChild name="etl:Cables7"/>
+      <Translation x="0.*mm" y="0.*mm" z="0." />
+    </PosPart>
+    
+    
+    <!-- Children volumes Disc1Timing -->
+    <PosPart copyNumber="1">
+      <rParent name="etl:Disc1Timing"/>
+      <rChild name="etl:Al_Disc"/>
+      <Translation x="0.*mm" y="0.*mm" z="0." />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:Disc1Timing"/>
+      <rChild name="etl:DiscSector_Front"/>
+      <rRotation name="etl:0"/>
+      <Translation x="0.*mm" y="0.*mm" z="-1*[Disk_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="2">
+      <rParent name="etl:Disc1Timing"/>
+      <rChild name="etl:DiscSector_Front"/>
+      <rRotation name="etl:180"/>
+      <Translation x="0.*mm" y="0.*mm" z="-1*[Disk_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:Disc1Timing"/>
+      <rChild name="etl:DiscSector_Back"/>
+      <rRotation name="etl:0"/>
+      <Translation x="0.*mm" y="0.*mm" z="[Disk_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="2">
+      <rParent name="etl:Disc1Timing"/>
+      <rChild name="etl:DiscSector_Back"/>
+      <rRotation name="etl:180"/>
+      <Translation x="0.*mm" y="0.*mm" z="[Disk_translation_z]" />
+    </PosPart>
+
+    <!-- Children volumes Disc2Timing -->
+    <PosPart copyNumber="1">
+      <rParent name="etl:Disc2Timing"/>
+      <rChild name="etl:Al_Disc"/>
+      <Translation x="0.*mm" y="0.*mm" z="0." />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:Disc2Timing"/>
+      <rChild name="etl:DiscSector_Front"/>
+      <rRotation name="etl:0"/>
+      <Translation x="0.*mm" y="0.*mm" z="-1*[Disk_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="2">
+      <rParent name="etl:Disc2Timing"/>
+      <rChild name="etl:DiscSector_Front"/>
+      <rRotation name="etl:180"/>
+      <Translation x="0.*mm" y="0.*mm" z="-1*[Disk_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:Disc2Timing"/>
+      <rChild name="etl:DiscSector_Back"/>
+      <rRotation name="etl:0"/>
+      <Translation x="0.*mm" y="0.*mm" z="[Disk_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="2">
+      <rParent name="etl:Disc2Timing"/>
+      <rChild name="etl:DiscSector_Back"/>
+      <rRotation name="etl:180"/>
+      <Translation x="0.*mm" y="0.*mm" z="[Disk_translation_z]" />
+    </PosPart>
+    
+
+    <!-- Elements composing Servicehybrid_Front -->
+    <PosPart copyNumber="1">
+      <rParent name="etl:ServiceHybrid3_Front"/>
+      <rChild name="etl:PowerBoard3"/>
+      <Translation x="0.*mm" y="0.*mm" z="[PowerBoard_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:ServiceHybrid3_Front"/>
+      <rChild name="etl:servicesServiceHybrid3"/>
+      <Translation x="0.*mm" y="0.*mm" z="[servicesServiceHybrid_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:ServiceHybrid6_Front"/>
+      <rChild name="etl:PowerBoard6"/>
+      <Translation x="0.*mm" y="0.*mm" z="[PowerBoard_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:ServiceHybrid6_Front"/>
+      <rChild name="etl:servicesServiceHybrid6"/>
+      <Translation x="0.*mm" y="0.*mm" z="[servicesServiceHybrid_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:ServiceHybrid7_Front"/>
+      <rChild name="etl:PowerBoard7"/>
+      <Translation x="0.*mm" y="0.*mm" z="[PowerBoard_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:ServiceHybrid7_Front"/>
+      <rChild name="etl:servicesServiceHybrid7"/>
+      <Translation x="0.*mm" y="0.*mm" z="[servicesServiceHybrid_translation_z]" />
+    </PosPart>
+    
+    <!-- Elements composing Servicehybrid_Back -->
+    <PosPart copyNumber="1">
+      <rParent name="etl:ServiceHybrid3_Back"/>
+      <rChild name="etl:PowerBoard3"/>
+      <Translation x="0.*mm" y="0.*mm" z="-1*[PowerBoard_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:ServiceHybrid3_Back"/>
+      <rChild name="etl:servicesServiceHybrid3"/>
+      <Translation x="0.*mm" y="0.*mm" z="-1*[servicesServiceHybrid_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:ServiceHybrid6_Back"/>
+      <rChild name="etl:PowerBoard6"/>
+      <Translation x="0.*mm" y="0.*mm" z="-1*[PowerBoard_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:ServiceHybrid6_Back"/>
+      <rChild name="etl:servicesServiceHybrid6"/>
+      <Translation x="0.*mm" y="0.*mm" z="-1*[servicesServiceHybrid_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:ServiceHybrid7_Back"/>
+      <rChild name="etl:PowerBoard7"/>
+      <Translation x="0.*mm" y="0.*mm" z="-1*[PowerBoard_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:ServiceHybrid7_Back"/>
+      <rChild name="etl:servicesServiceHybrid7"/>
+      <Translation x="0.*mm" y="0.*mm" z="-1*[servicesServiceHybrid_translation_z]" />
+    </PosPart>
+    
+    
+    <!-- Elements composing SensorModule_Front_Right -->
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Front_Right"/>
+      <rChild name="etl:ThermalPad"/>
+      <Translation x="0.*mm" y="0.*mm" z="[ThermalPad_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Front_Right"/>
+      <rChild name="etl:AlN_Base"/>
+      <Translation x="0.*mm" y="0.*mm" z="[AlN_Base_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Front_Right"/>
+      <rChild name="etl:LairdFilm"/>
+      <Translation x="0.*mm" y="-1*[LairdFilm_translation_y]" z="[LairdFilm_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Front_Right"/>
+      <rChild name="etl:glueLGAD"/>
+      <Translation x="0.*mm" y="-1*[LGAD_translation_y]" z="[glueLGAD_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Front_Right"/>
+      <rChild name="etl:BumpBonds"/>
+      <Translation x="0.*mm" y="-1*[LGAD_translation_y]" z="[bumpBonds_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Front_Right"/>
+      <rChild name="etl:ETROC"/>
+      <Translation x="[ETROC_translation_x]" y="-1*[ETROC_translation_y]" z="[ETROC_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="2">
+      <rParent name="etl:SensorModule_Front_Right"/>
+      <rChild name="etl:ETROC"/>
+      <Translation x="-1*[ETROC_translation_x]" y="-1*[ETROC_translation_y]" z="[ETROC_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Front_Right"/>
+      <rChild name="etl:glueETROC"/>
+      <Translation x="[ETROC_translation_x]" y="-1*[ETROC_translation_y]" z="[glueETROC_translation_z]"  />
+    </PosPart>
+    <PosPart copyNumber="2">
+      <rParent name="etl:SensorModule_Front_Right"/>
+      <rChild name="etl:glueETROC"/>
+      <Translation x="-1*[ETROC_translation_x]" y="-1*[ETROC_translation_y]" z="[glueETROC_translation_z]"  />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Front_Right"/>
+      <rChild name="etl:ModulePCB"/>
+      <Translation x="[ETROC_translation_x]" y="-1*[ETROC_translation_y]" z="[modulePCB_translation_z]"  />
+    </PosPart>
+    <PosPart copyNumber="2">
+      <rParent name="etl:SensorModule_Front_Right"/>
+      <rChild name="etl:ModulePCB"/>
+      <Translation x="-1*[ETROC_translation_x]" y="-1*[ETROC_translation_y]" z="[modulePCB_translation_z]"  />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Front_Right"/>
+      <rChild name="etl:connectorsGap"/>
+      <Translation x="0.*mm" y="0." z="[connectorsGap_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Front_Right"/>
+      <rChild name="etl:ReadoutBoard"/>
+      <Translation x="0.*mm" y="0." z="[readoutBoard_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Front_Right"/>
+      <rChild name="etl:servicesSensorModule"/>
+      <Translation x="0.*mm" y="0." z="[servicesSensorModule_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Front_Right"/>
+      <rChild name="etl:LGAD"/>
+      <Translation x="0.*mm" y="-1*[LGAD_translation_y]" z="[LGAD_translation_z]" />
+    </PosPart>
+    <!-- definition of LGAD active/substrate volumes -->
+    <PosPart copyNumber="1">
+      <rParent name="etl:LGAD"/>
+      <rChild name="etl:EModule_Timingactive"/>
+      <Translation x="0.*mm" y="0.*mm" z="[EModule_Timingactive_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:LGAD"/>
+      <rChild name="etl:LGAD_Substrate"/>
+      <Translation x="0.*mm" y="0.*mm" z="[LGAD_Substrate_translation_z]" />
+    </PosPart>
+    
+    <!-- Elements composing SensorModule_Front_Left -->
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Front_Left"/>
+      <rChild name="etl:ThermalPad"/>
+      <Translation x="0.*mm" y="0.*mm" z="[ThermalPad_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Front_Left"/>
+      <rChild name="etl:AlN_Base"/>
+      <Translation x="0.*mm" y="0.*mm" z="[AlN_Base_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Front_Left"/>
+      <rChild name="etl:LairdFilm"/>
+      <Translation x="0.*mm" y="[LairdFilm_translation_y]" z="[LairdFilm_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Front_Left"/>
+      <rChild name="etl:glueLGAD"/>
+      <Translation x="0.*mm" y="[LGAD_translation_y]" z="[glueLGAD_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Front_Left"/>
+      <rChild name="etl:BumpBonds"/>
+      <Translation x="0.*mm" y="[LGAD_translation_y]" z="[bumpBonds_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Front_Left"/>
+      <rChild name="etl:ETROC"/>
+      <Translation x="[ETROC_translation_x]" y="[ETROC_translation_y]" z="[ETROC_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="2">
+      <rParent name="etl:SensorModule_Front_Left"/>
+      <rChild name="etl:ETROC"/>
+      <Translation x="-1*[ETROC_translation_x]" y="[ETROC_translation_y]" z="[ETROC_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Front_Left"/>
+      <rChild name="etl:glueETROC"/>
+      <Translation x="[ETROC_translation_x]" y="[ETROC_translation_y]" z="[glueETROC_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="2">
+      <rParent name="etl:SensorModule_Front_Left"/>
+      <rChild name="etl:glueETROC"/>
+      <Translation x="-1*[ETROC_translation_x]" y="[ETROC_translation_y]" z="[glueETROC_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Front_Left"/>
+      <rChild name="etl:ModulePCB"/>
+      <Translation x="[ETROC_translation_x]" y="[ETROC_translation_y]" z="[modulePCB_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="2">
+      <rParent name="etl:SensorModule_Front_Left"/>
+      <rChild name="etl:ModulePCB"/>
+      <Translation x="-1*[ETROC_translation_x]" y="[ETROC_translation_y]" z="[modulePCB_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Front_Left"/>
+      <rChild name="etl:connectorsGap"/>
+      <Translation x="0.*mm" y="0." z="[connectorsGap_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Front_Left"/>
+      <rChild name="etl:ReadoutBoard"/>
+      <Translation x="0.*mm" y="0." z="[readoutBoard_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Front_Left"/>
+      <rChild name="etl:servicesSensorModule"/>
+      <Translation x="0.*mm" y="0." z="[servicesSensorModule_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Front_Left"/>
+      <rChild name="etl:LGAD"/>
+      <Translation x="0.*mm" y="[LGAD_translation_y]" z="[LGAD_translation_z]" />
+    </PosPart>
+
+
+    <!-- Elements composing SensorModule_Back_Left -->
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Back_Left"/>
+      <rChild name="etl:ThermalPad"/>
+      <Translation x="0.*mm" y="0.*mm" z="-1*[ThermalPad_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Back_Left"/>
+      <rChild name="etl:AlN_Base"/>
+      <Translation x="0.*mm" y="0.*mm" z="-1*[AlN_Base_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Back_Left"/>
+      <rChild name="etl:LairdFilm"/>
+      <Translation x="0.*mm" y="-1*[LairdFilm_translation_y]" z="-1*[LairdFilm_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Back_Left"/>
+      <rChild name="etl:glueLGAD"/>
+      <Translation x="0.*mm" y="-1*[LGAD_translation_y]" z="-1*[glueLGAD_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Back_Left"/>
+      <rChild name="etl:BumpBonds"/>
+      <Translation x="0.*mm" y="-1*[LGAD_translation_y]" z="-1*[bumpBonds_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Back_Left"/>
+      <rChild name="etl:ETROC"/>
+      <Translation x="[ETROC_translation_x]" y="-1*[ETROC_translation_y]" z="-1*[ETROC_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="2">
+      <rParent name="etl:SensorModule_Back_Left"/>
+      <rChild name="etl:ETROC"/>
+      <Translation x="-1*[ETROC_translation_x]" y="-1*[ETROC_translation_y]" z="-1*[ETROC_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Back_Left"/>
+      <rChild name="etl:glueETROC"/>
+      <Translation x="[ETROC_translation_x]" y="-1*[ETROC_translation_y]" z="-1*[glueETROC_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="2">
+      <rParent name="etl:SensorModule_Back_Left"/>
+      <rChild name="etl:glueETROC"/>
+      <Translation x="-1*[ETROC_translation_x]" y="-1*[ETROC_translation_y]" z="-1*[glueETROC_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Back_Left"/>
+      <rChild name="etl:ModulePCB"/>
+      <Translation x="[ETROC_translation_x]" y="-1*[ETROC_translation_y]" z="-1*[modulePCB_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="2">
+      <rParent name="etl:SensorModule_Back_Left"/>
+      <rChild name="etl:ModulePCB"/>
+      <Translation x="-1*[ETROC_translation_x]" y="-1*[ETROC_translation_y]" z="-1*[modulePCB_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Back_Left"/>
+      <rChild name="etl:connectorsGap"/>
+      <Translation x="0.*mm" y="0." z="-1*[connectorsGap_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Back_Left"/>
+      <rChild name="etl:ReadoutBoard"/>
+      <Translation x="0.*mm" y="0." z="-1*[readoutBoard_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Back_Left"/>
+      <rChild name="etl:servicesSensorModule"/>
+      <Translation x="0.*mm" y="0." z="-1*[servicesSensorModule_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Back_Left"/>
+      <rChild name="etl:LGAD"/>
+      <rRotation name="etl:ReverseVert" />
+      <Translation x="0.*mm" y="-1*[LGAD_translation_y]" z="-1*[LGAD_translation_z]" />
+    </PosPart>
+    
+
+    
+    <!-- Elements composing SensorModule_Back_Right -->
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Back_Right"/>
+      <rChild name="etl:ThermalPad"/>
+      <Translation x="0.*mm" y="0.*mm" z="-1*[ThermalPad_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Back_Right"/>
+      <rChild name="etl:AlN_Base"/>
+      <Translation x="0.*mm" y="0.*mm" z="-1*[AlN_Base_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Back_Right"/>
+      <rChild name="etl:LairdFilm"/>
+      <Translation x="0.*mm" y="[LairdFilm_translation_y]" z="-1*[LairdFilm_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Back_Right"/>
+      <rChild name="etl:glueLGAD"/>
+      <Translation x="0.*mm" y="[LGAD_translation_y]" z="-1*[glueLGAD_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Back_Right"/>
+      <rChild name="etl:BumpBonds"/>
+      <Translation x="0.*mm" y="[LGAD_translation_y]" z="-1*[bumpBonds_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Back_Right"/>
+      <rChild name="etl:ETROC"/>
+      <Translation x="[ETROC_translation_x]" y="[ETROC_translation_y]" z="-1*[ETROC_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="2">
+      <rParent name="etl:SensorModule_Back_Right"/>
+      <rChild name="etl:ETROC"/>
+      <Translation x="-1*[ETROC_translation_x]" y="[ETROC_translation_y]" z="-1*[ETROC_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Back_Right"/>
+      <rChild name="etl:glueETROC"/>
+      <Translation x="[ETROC_translation_x]" y="[ETROC_translation_y]" z="-1*[glueETROC_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="2">
+      <rParent name="etl:SensorModule_Back_Right"/>
+      <rChild name="etl:glueETROC"/>
+      <Translation x="-1*[ETROC_translation_x]" y="[ETROC_translation_y]" z="-1*[glueETROC_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Back_Right"/>
+      <rChild name="etl:ModulePCB"/>
+      <Translation x="[ETROC_translation_x]" y="[ETROC_translation_y]" z="-1*[modulePCB_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="2">
+      <rParent name="etl:SensorModule_Back_Right"/>
+      <rChild name="etl:ModulePCB"/>
+      <Translation x="-1*[ETROC_translation_x]" y="[ETROC_translation_y]" z="-1*[modulePCB_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Back_Right"/>
+      <rChild name="etl:connectorsGap"/>
+      <Translation x="0.*mm" y="0." z="-1*[connectorsGap_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Back_Right"/>
+      <rChild name="etl:ReadoutBoard"/>
+      <Translation x="0.*mm" y="0." z="-1*[readoutBoard_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Back_Right"/>
+      <rChild name="etl:servicesSensorModule"/>
+      <Translation x="0.*mm" y="0." z="-1*[servicesSensorModule_translation_z]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="etl:SensorModule_Back_Right"/>
+      <rChild name="etl:LGAD"/>
+      <rRotation name="etl:ReverseVert" />
+      <Translation x="0.*mm" y="[LGAD_translation_y]" z="-1*[LGAD_translation_z]" />
+    </PosPart>
+  </PosPartSection>
+    
+
+  <!-- Algorithm Section begins -->
+  <!-- FRONT FACE  -->
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Right"/>
+  <Numeric name="N" value="6"/>
+  <Numeric name="StartCopyNo" value="1"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Front"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="1"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X7]/2), ([y_start_front]+[DeltaY_ServiceModule]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Left"/>
+  <Numeric name="N" value="7"/>
+  <Numeric name="StartCopyNo" value="1"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]+2*[DeltaY_ServiceModule]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Right"/>
+  <Numeric name="N" value="11"/>
+  <Numeric name="StartCopyNo" value="7"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]+2*[DeltaY_ServiceModule]+[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid6_Front"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="1"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid] +[ServiceHybrid_X6]/2), ([y_start_front]+3*[DeltaY_ServiceModule]+[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Front"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="2"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid] +[ServiceHybrid_X6]/2+[DeltaX_Service6_Service7]), ([y_start_front]+3*[DeltaY_ServiceModule]+[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Left"/>
+  <Numeric name="N" value="13"/>
+  <Numeric name="StartCopyNo" value="8"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]+4*[DeltaY_ServiceModule]+[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Right"/>
+  <Numeric name="N" value="15"/>
+  <Numeric name="StartCopyNo" value="18"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]+4*[DeltaY_ServiceModule]+2*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid3_Front"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="1"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid] +[ServiceHybrid_X3]/2), ([y_start_front]+5*[DeltaY_ServiceModule]+2*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid6_Front"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="2"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid] +[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]), ([y_start_front]+5*[DeltaY_ServiceModule]+2*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Front"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="3"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]+[DeltaX_Service6_Service7]), ([y_start_front]+5*[DeltaY_ServiceModule]+2*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Left"/>
+  <Numeric name="N" value="16"/>
+  <Numeric name="StartCopyNo" value="21"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]+6*[DeltaY_ServiceModule]+2*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Right"/>
+  <Numeric name="N" value="17"/>
+  <Numeric name="StartCopyNo" value="33"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]+6*[DeltaY_ServiceModule]+3*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid6_Front"/>
+  <Numeric name="N" value="3"/>
+  <Numeric name="StartCopyNo" value="3"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X6]/2), ([y_start_front]+7*[DeltaY_ServiceModule]+3*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Left"/>
+  <Numeric name="N" value="18"/>
+  <Numeric name="StartCopyNo" value="37"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]+8*[DeltaY_ServiceModule]+3*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Right"/>
+  <Numeric name="N" value="19"/>
+  <Numeric name="StartCopyNo" value="50"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]+8*[DeltaY_ServiceModule]+4*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid6_Front"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="6"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X6]/2), ([y_start_front]+9*[DeltaY_ServiceModule]+4*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Front"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="4"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X6]/2+[DeltaX_Service6_Service7]), ([y_start_front]+9*[DeltaY_ServiceModule]+4*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Left"/>
+  <Numeric name="N" value="20"/>
+  <Numeric name="StartCopyNo" value="55"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]+10*[DeltaY_ServiceModule]+4*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Right"/>
+  <Numeric name="N" value="21"/>
+  <Numeric name="StartCopyNo" value="69"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]+10*[DeltaY_ServiceModule]+5*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid3_Front"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="2"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_front]+11*[DeltaY_ServiceModule]+5*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid6_Front"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="7"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]), ([y_start_front]+11*[DeltaY_ServiceModule]+5*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Front"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="6"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]+[ServiceHybrid_X6]+[DeltaX]+[DeltaX_Service6_Service7]), ([y_start_front]+11*[DeltaY_ServiceModule]+5*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Left"/>
+  <Numeric name="N" value="22"/>
+  <Numeric name="StartCopyNo" value="75"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]+12*[DeltaY_ServiceModule]+5*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Right"/>
+  <Numeric name="N" value="22"/>
+  <Numeric name="StartCopyNo" value="90"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]+12*[DeltaY_ServiceModule]+6*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid3_Front"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="3"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_front]+13*[DeltaY_ServiceModule]+6*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid6_Front"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="9"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]), ([y_start_front]+13*[DeltaY_ServiceModule]+6*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Front"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="7"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]+[DeltaX_Service6_Service7]), ([y_start_front]+13*[DeltaY_ServiceModule]+6*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Left"/>
+  <Numeric name="N" value="23"/>
+  <Numeric name="StartCopyNo" value="97"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]+14*[DeltaY_ServiceModule]+6*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Right"/>
+  <Numeric name="N" value="24"/>
+  <Numeric name="StartCopyNo" value="112"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]+14*[DeltaY_ServiceModule]+7*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid6_Front"/>
+  <Numeric name="N" value="4"/>
+  <Numeric name="StartCopyNo" value="10"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X6]/2), ([y_start_front]+15*[DeltaY_ServiceModule]+7*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Left"/>
+  <Numeric name="N" value="24"/>
+  <Numeric name="StartCopyNo" value="120"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]+16*[DeltaY_ServiceModule]+7*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Right"/>
+  <Numeric name="N" value="25"/>
+  <Numeric name="StartCopyNo" value="136"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]+16*[DeltaY_ServiceModule]+8*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid6_Front"/>
+  <Numeric name="N" value="3"/>
+  <Numeric name="StartCopyNo" value="14"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X6]/2), ([y_start_front]+17*[DeltaY_ServiceModule]+8*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Front"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="9"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X6]/2+2*[ServiceHybrid_X6]+2*[DeltaX]+[DeltaX_Service6_Service7]), ([y_start_front]+17*[DeltaY_ServiceModule]+8*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Left"/>
+  <Numeric name="N" value="25"/>
+  <Numeric name="StartCopyNo" value="144"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]+18*[DeltaY_ServiceModule]+8*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Right"/>
+  <Numeric name="N" value="25"/>
+  <Numeric name="StartCopyNo" value="161"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]+18*[DeltaY_ServiceModule]+9*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid3_Front"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="4"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_front]+19*[DeltaY_ServiceModule]+9*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid6_Front"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="17"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6]), ([y_start_front]+19*[DeltaY_ServiceModule]+9*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Front"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="10"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6]+[DeltaX_Service6_Service7]), ([y_start_front]+19*[DeltaY_ServiceModule]+9*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Left"/>
+  <Numeric name="N" value="24"/>
+  <Numeric name="StartCopyNo" value="169"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+2*[SensorModule_X]+2*[DeltaX]), ([y_start_front]+20*[DeltaY_ServiceModule]+9*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Right"/>
+  <Numeric name="N" value="21"/>
+  <Numeric name="StartCopyNo" value="186"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+5*[SensorModule_X]+5*[DeltaX]), ([y_start_front]+20*[DeltaY_ServiceModule]+10*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid3_Front"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="6"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+6*[SensorModule_X]+6*[DeltaX]), ([y_start_front]+21*[DeltaY_ServiceModule]+10*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid6_Front"/>
+  <Numeric name="N" value="3"/>
+  <Numeric name="StartCopyNo" value="18"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+6*[SensorModule_X]+6*[DeltaX]+[DeltaX_Service3_Service6]), ([y_start_front]+21*[DeltaY_ServiceModule]+10*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Left"/>
+  <Numeric name="N" value="20"/>
+  <Numeric name="StartCopyNo" value="193"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+6*[SensorModule_X]+6*[DeltaX]), ([y_start_front]+22*[DeltaY_ServiceModule]+10*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Right"/>
+  <Numeric name="N" value="20"/>
+  <Numeric name="StartCopyNo" value="207"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+6*[SensorModule_X]+6*[DeltaX]), ([y_start_front]+22*[DeltaY_ServiceModule]+11*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid3_Front"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="7"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5.78+ --> [x_offset]+7*[SensorModule_X]+7*[DeltaX]), ([y_start_front]+23*[DeltaY_ServiceModule]+11*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid6_Front"/>
+  <Numeric name="N" value="3"/>
+  <Numeric name="StartCopyNo" value="21"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5.78+ --> [x_offset]+7*[SensorModule_X]+6*[DeltaX]+[DeltaX_Service3_Service6]), ([y_start_front]+23*[DeltaY_ServiceModule]+11*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Left"/>
+  <Numeric name="N" value="20"/>
+  <Numeric name="StartCopyNo" value="213"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX]), ([y_start_front]+24*[DeltaY_ServiceModule]+11*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Right"/>
+  <Numeric name="N" value="20"/>
+  <Numeric name="StartCopyNo" value="227"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX]), ([y_start_front]+24*[DeltaY_ServiceModule]+12*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid3_Front"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="8"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5.7+ --> [x_offset]+8*[SensorModule_X]+8*[DeltaX]), ([y_start_front]+25*[DeltaY_ServiceModule]+12*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Front"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="12"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5.7+ --> [x_offset]+8*[SensorModule_X]+8*[DeltaX]+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service7]), ([y_start_front]+25*[DeltaY_ServiceModule]+12*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Left"/>
+  <Numeric name="N" value="19"/>
+  <Numeric name="StartCopyNo" value="233"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+8*[SensorModule_X]+8*[DeltaX]), ([y_start_front]+26*[DeltaY_ServiceModule]+12*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Right"/>
+  <Numeric name="N" value="19"/>
+  <Numeric name="StartCopyNo" value="247"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+8*[SensorModule_X]+8*[DeltaX]), ([y_start_front]+26*[DeltaY_ServiceModule]+13*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid3_Front"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="10"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+9*[SensorModule_X]+9*[DeltaX]), ([y_start_front]+27*[DeltaY_ServiceModule]+13*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid6_Front"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="24"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+9*[SensorModule_X]+9*[DeltaX]+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6]), ([y_start_front]+27*[DeltaY_ServiceModule]+13*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Front"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="14"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+9*[SensorModule_X]+9*[DeltaX]+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6]+[DeltaX_Service6_Service7]), ([y_start_front]+27*[DeltaY_ServiceModule]+13*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Left"/>
+  <Numeric name="N" value="19"/>
+  <Numeric name="StartCopyNo" value="252"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+8*[SensorModule_X]+8*[DeltaX]), ([y_start_front]+28*[DeltaY_ServiceModule]+13*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Right"/>
+  <Numeric name="N" value="19"/>
+  <Numeric name="StartCopyNo" value="266"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+8*[SensorModule_X]+8*[DeltaX]), ([y_start_front]+28*[DeltaY_ServiceModule]+14*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid3_Front"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="12"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5.7+ --> [x_offset]+8*[SensorModule_X]+8*[DeltaX]), ([y_start_front]+29*[DeltaY_ServiceModule]+14*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Front"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="15"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5.7+ --> [x_offset]+8*[SensorModule_X]+8*[DeltaX]+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service7]), ([y_start_front]+29*[DeltaY_ServiceModule]+14*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Left"/>
+  <Numeric name="N" value="20"/>
+  <Numeric name="StartCopyNo" value="271"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX]), ([y_start_front]+30*[DeltaY_ServiceModule]+14*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Right"/>
+  <Numeric name="N" value="20"/>
+  <Numeric name="StartCopyNo" value="285"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX]), ([y_start_front]+30*[DeltaY_ServiceModule]+15*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid3_Front"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="14"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5.78+ --> [x_offset]+7*[SensorModule_X]+7*[DeltaX]), ([y_start_front]+31*[DeltaY_ServiceModule]+15*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid6_Front"/>
+  <Numeric name="N" value="3"/>
+  <Numeric name="StartCopyNo" value="25"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5.78+ --> [x_offset]+7*[SensorModule_X]+6*[DeltaX]+[DeltaX_Service3_Service6]), ([y_start_front]+31*[DeltaY_ServiceModule]+15*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Left"/>
+  <Numeric name="N" value="20"/>
+  <Numeric name="StartCopyNo" value="291"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+6*[SensorModule_X]+6*[DeltaX]), ([y_start_front]+32*[DeltaY_ServiceModule]+15*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Right"/>
+  <Numeric name="N" value="20"/>
+  <Numeric name="StartCopyNo" value="305"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+6*[SensorModule_X]+6*[DeltaX]), ([y_start_front]+32*[DeltaY_ServiceModule]+16*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid3_Front"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="15"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+6*[SensorModule_X]+6*[DeltaX]), ([y_start_front]+33*[DeltaY_ServiceModule]+16*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid6_Front"/>
+  <Numeric name="N" value="3"/>
+  <Numeric name="StartCopyNo" value="28"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+6*[SensorModule_X]+6*[DeltaX]+[DeltaX_Service3_Service6]), ([y_start_front]+33*[DeltaY_ServiceModule]+16*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Left"/>
+  <Numeric name="N" value="21"/>
+  <Numeric name="StartCopyNo" value="311"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+5*[SensorModule_X]+5*[DeltaX]), ([y_start_front]+34*[DeltaY_ServiceModule]+16*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Right"/>
+  <Numeric name="N" value="24"/>
+  <Numeric name="StartCopyNo" value="325"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+2*[SensorModule_X]+2*[DeltaX]), ([y_start_front]+34*[DeltaY_ServiceModule]+17*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid3_Front"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="16"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_front]+35*[DeltaY_ServiceModule]+17*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid6_Front"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="31"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6]), ([y_start_front]+35*[DeltaY_ServiceModule]+17*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Front"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="17"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6]+[DeltaX_Service6_Service7]), ([y_start_front]+35*[DeltaY_ServiceModule]+17*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Left"/>
+  <Numeric name="N" value="25"/>
+  <Numeric name="StartCopyNo" value="332"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]+36*[DeltaY_ServiceModule]+17*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Right"/>
+  <Numeric name="N" value="25"/>
+  <Numeric name="StartCopyNo" value="349"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]+36*[DeltaY_ServiceModule]+18*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid6_Front"/>
+  <Numeric name="N" value="3"/>
+  <Numeric name="StartCopyNo" value="32"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X6]/2), ([y_start_front]+37*[DeltaY_ServiceModule]+18*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Front"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="19"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X6]/2+2*[ServiceHybrid_X6]+2*[DeltaX]+[DeltaX_Service6_Service7]), ([y_start_front]+37*[DeltaY_ServiceModule]+18*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Left"/>
+  <Numeric name="N" value="25"/>
+  <Numeric name="StartCopyNo" value="357"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]+38*[DeltaY_ServiceModule]+18*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Right"/>
+  <Numeric name="N" value="24"/>
+  <Numeric name="StartCopyNo" value="374"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]+38*[DeltaY_ServiceModule]+19*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid6_Front"/>
+  <Numeric name="N" value="4"/>
+  <Numeric name="StartCopyNo" value="35"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X6]/2), ([y_start_front]+39*[DeltaY_ServiceModule]+19*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Left"/>
+  <Numeric name="N" value="24"/>
+  <Numeric name="StartCopyNo" value="382"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]+40*[DeltaY_ServiceModule]+19*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Right"/>
+  <Numeric name="N" value="23"/>
+  <Numeric name="StartCopyNo" value="398"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]+40*[DeltaY_ServiceModule]+20*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid3_Front"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="18"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_front]+41*[DeltaY_ServiceModule]+20*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid6_Front"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="39"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]), ([y_start_front]+41*[DeltaY_ServiceModule]+20*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Front"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="20"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]+[DeltaX_Service6_Service7]), ([y_start_front]+41*[DeltaY_ServiceModule]+20*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Left"/>
+  <Numeric name="N" value="22"/>
+  <Numeric name="StartCopyNo" value="406"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]+42*[DeltaY_ServiceModule]+20*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Right"/>
+  <Numeric name="N" value="22"/>
+  <Numeric name="StartCopyNo" value="421"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]+42*[DeltaY_ServiceModule]+21*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid3_Front"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="19"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_front]+43*[DeltaY_ServiceModule]+21*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid6_Front"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="40"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]), ([y_start_front]+43*[DeltaY_ServiceModule]+21*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Front"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="22"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]+[ServiceHybrid_X6]+[DeltaX]+[DeltaX_Service6_Service7]), ([y_start_front]+43*[DeltaY_ServiceModule]+21*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Left"/>
+  <Numeric name="N" value="21"/>
+  <Numeric name="StartCopyNo" value="428"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]+44*[DeltaY_ServiceModule]+21*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Right"/>
+  <Numeric name="N" value="20"/>
+  <Numeric name="StartCopyNo" value="443"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]+44*[DeltaY_ServiceModule]+22*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid6_Front"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="42"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X6]/2), ([y_start_front]+45*[DeltaY_ServiceModule]+22*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Front"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="23"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X6]/2+[DeltaX_Service6_Service7]), ([y_start_front]+45*[DeltaY_ServiceModule]+22*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Left"/>
+  <Numeric name="N" value="19"/>
+  <Numeric name="StartCopyNo" value="449"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]+46*[DeltaY_ServiceModule]+22*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Right"/>
+  <Numeric name="N" value="18"/>
+  <Numeric name="StartCopyNo" value="463"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]+46*[DeltaY_ServiceModule]+23*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid6_Front"/>
+  <Numeric name="N" value="3"/>
+  <Numeric name="StartCopyNo" value="43"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X6]/2), ([y_start_front]+47*[DeltaY_ServiceModule]+23*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Left"/>
+  <Numeric name="N" value="17"/>
+  <Numeric name="StartCopyNo" value="468"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]+48*[DeltaY_ServiceModule]+23*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Right"/>
+  <Numeric name="N" value="16"/>
+  <Numeric name="StartCopyNo" value="481"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]+48*[DeltaY_ServiceModule]+24*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid3_Front"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="20"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_front]+49*[DeltaY_ServiceModule]+24*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid6_Front"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="46"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]), ([y_start_front]+49*[DeltaY_ServiceModule]+24*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Front"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="25"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]+[DeltaX_Service6_Service7]), ([y_start_front]+49*[DeltaY_ServiceModule]+24*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Left"/>
+  <Numeric name="N" value="15"/>
+  <Numeric name="StartCopyNo" value="485"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]+50*[DeltaY_ServiceModule]+24*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Right"/>
+  <Numeric name="N" value="13"/>
+  <Numeric name="StartCopyNo" value="497"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]+50*[DeltaY_ServiceModule]+25*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid6_Front"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="47"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X6]/2), ([y_start_front]+51*[DeltaY_ServiceModule]+25*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Front"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="26"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X6]/2+[DeltaX_Service6_Service7]), ([y_start_front]+51*[DeltaY_ServiceModule]+25*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Left"/>
+  <Numeric name="N" value="11"/>
+  <Numeric name="StartCopyNo" value="500"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]+52*[DeltaY_ServiceModule]+25*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Right"/>
+  <Numeric name="N" value="7"/>
+  <Numeric name="StartCopyNo" value="510"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]+52*[DeltaY_ServiceModule]+26*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Front"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="27"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X7]/2), ([y_start_front]+53*[DeltaY_ServiceModule]+26*[SensorModule_Y]), ([ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+  <Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Front"/>
+  <String name="ChildName" value="etl:SensorModule_Front_Left"/>
+  <Numeric name="N" value="6"/>
+  <Numeric name="StartCopyNo" value="511"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]+54*[DeltaY_ServiceModule]+26*[SensorModule_Y]), ([SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+  </Algorithm>
+
+
+
+
+
+
+<!-- BACK FACE -->
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid3_Back"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="1"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_back]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+  <Numeric name="N" value="3"/>
+  <Numeric name="StartCopyNo" value="1"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]-[DeltaY_ServiceModule]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+  <Numeric name="N" value="9"/>
+  <Numeric name="StartCopyNo" value="1"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]-[DeltaY_ServiceModule]-[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid3_Back"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="2"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_back]-2*[DeltaY_ServiceModule]-[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Back"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="1"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service7]), ([y_start_back]-2*[DeltaY_ServiceModule]-[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+  <Numeric name="N" value="10"/>
+  <Numeric name="StartCopyNo" value="4"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]-3*[DeltaY_ServiceModule]-[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+  <Numeric name="N" value="13"/>
+  <Numeric name="StartCopyNo" value="10"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]-3*[DeltaY_ServiceModule]-2*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Back"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="2"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X7]/2), ([y_start_back]-4*[DeltaY_ServiceModule]-2*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+  <Numeric name="N" value="14"/>
+  <Numeric name="StartCopyNo" value="14"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]-5*[DeltaY_ServiceModule]-2*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+  <Numeric name="N" value="16"/>
+  <Numeric name="StartCopyNo" value="23"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]-5*[DeltaY_ServiceModule]-3*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid3_Back"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="3"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_back]-6*[DeltaY_ServiceModule]-3*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Back"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="4"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service7]), ([y_start_back]-6*[DeltaY_ServiceModule]-3*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+  <Numeric name="N" value="17"/>
+  <Numeric name="StartCopyNo" value="28"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]-7*[DeltaY_ServiceModule]-3*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+  <Numeric name="N" value="18"/>
+  <Numeric name="StartCopyNo" value="39"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]-7*[DeltaY_ServiceModule]-4*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid6_Back"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="1"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X6]/2), ([y_start_back]-8*[DeltaY_ServiceModule]-4*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Back"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="6"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X6]/2+[ServiceHybrid_X6]+[DeltaX]+[DeltaX_Service6_Service7]), ([y_start_back]-8*[DeltaY_ServiceModule]-4*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+  <Numeric name="N" value="19"/>
+  <Numeric name="StartCopyNo" value="45"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]-9*[DeltaY_ServiceModule]-4*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+  <Numeric name="N" value="20"/>
+  <Numeric name="StartCopyNo" value="57"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]-9*[DeltaY_ServiceModule]-5*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Back"/>
+  <Numeric name="N" value="3"/>
+  <Numeric name="StartCopyNo" value="7"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X7]/2), ([y_start_back]-10*[DeltaY_ServiceModule]-5*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+  <Numeric name="N" value="21"/>
+  <Numeric name="StartCopyNo" value="64"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]-11*[DeltaY_ServiceModule]-5*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+  <Numeric name="N" value="22"/>
+  <Numeric name="StartCopyNo" value="77"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]-11*[DeltaY_ServiceModule]-6*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid3_Back"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="4"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_back]-12*[DeltaY_ServiceModule]-6*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid6_Back"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="3"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]), ([y_start_back]-12*[DeltaY_ServiceModule]-6*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Back"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="10"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]+[ServiceHybrid_X6]+[DeltaX]+[DeltaX_Service6_Service7]), ([y_start_back]-12*[DeltaY_ServiceModule]-6*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+  <Numeric name="N" value="22"/>
+  <Numeric name="StartCopyNo" value="85"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]-13*[DeltaY_ServiceModule]-6*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+  <Numeric name="N" value="23"/>
+  <Numeric name="StartCopyNo" value="99"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]-13*[DeltaY_ServiceModule]-7*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid3_Back"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="5"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_back]-14*[DeltaY_ServiceModule]-7*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid6_Back"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="5"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]), ([y_start_back]-14*[DeltaY_ServiceModule]-7*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Back"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="11"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]+[DeltaX_Service6_Service7]), ([y_start_back]-14*[DeltaY_ServiceModule]-7*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+  <Numeric name="N" value="23"/>
+  <Numeric name="StartCopyNo" value="107"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]-15*[DeltaY_ServiceModule]-7*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+  <Numeric name="N" value="24"/>
+  <Numeric name="StartCopyNo" value="122"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]-15*[DeltaY_ServiceModule]-8*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid3_Back"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="6"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_back]-16*[DeltaY_ServiceModule]-8*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid6_Back"/>
+  <Numeric name="N" value="3"/>
+  <Numeric name="StartCopyNo" value="6"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6]), ([y_start_back]-16*[DeltaY_ServiceModule]-8*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+  <Numeric name="N" value="24"/>
+  <Numeric name="StartCopyNo" value="130"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]-17*[DeltaY_ServiceModule]-8*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+  <Numeric name="N" value="25"/>
+  <Numeric name="StartCopyNo" value="146"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]-17*[DeltaY_ServiceModule]-9*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid3_Back"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="8"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_back]-18*[DeltaY_ServiceModule]-9*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid6_Back"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="9"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6]), ([y_start_back]-18*[DeltaY_ServiceModule]-9*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Back"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="13"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6]+[ServiceHybrid_X6]+[DeltaX]+[DeltaX_Service6_Service7]), ([y_start_back]-18*[DeltaY_ServiceModule]-9*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+  <Numeric name="N" value="25"/>
+  <Numeric name="StartCopyNo" value="154"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]-19*[DeltaY_ServiceModule]-9*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+  <Numeric name="N" value="23"/>
+  <Numeric name="StartCopyNo" value="171"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+3*[SensorModule_X]+3*[DeltaX]), ([y_start_back]-19*[DeltaY_ServiceModule]-10*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid3_Back"/>
+  <Numeric name="N" value="3"/>
+  <Numeric name="StartCopyNo" value="10"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+4*[SensorModule_X]+4*[DeltaX]), ([y_start_back]-20*[DeltaY_ServiceModule]-10*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Back"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="14"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+4*[SensorModule_X]+4*[DeltaX]+2*[ServiceHybrid_X3]+2*[DeltaX]+[DeltaX_Service3_Service7]), ([y_start_back]-20*[DeltaY_ServiceModule]-10*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+  <Numeric name="N" value="22"/>
+  <Numeric name="StartCopyNo" value="179"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 1+ --> [x_offset]+4*[SensorModule_X]+4*[DeltaX]), ([y_start_back]-21*[DeltaY_ServiceModule]-10*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+  <Numeric name="N" value="20"/>
+  <Numeric name="StartCopyNo" value="194"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+6*[SensorModule_X]+6*[DeltaX]), ([y_start_back]-21*[DeltaY_ServiceModule]-11*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid3_Back"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="13"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX]), ([y_start_back]-22*[DeltaY_ServiceModule]-11*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Back"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="16"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX]+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service7]), ([y_start_back]-22*[DeltaY_ServiceModule]-11*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+  <Numeric name="N" value="20"/>
+  <Numeric name="StartCopyNo" value="201"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 1+ --> [x_offset]+6*[SensorModule_X]+6*[DeltaX]), ([y_start_back]-23*[DeltaY_ServiceModule]-11*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+  <Numeric name="N" value="20"/>
+  <Numeric name="StartCopyNo" value="214"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([SensorModule_X]/2+7*[SensorModule_X]+7*[DeltaX]), ([y_start_back]-23*[DeltaY_ServiceModule]-12*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid3_Back"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="15"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+8*[SensorModule_X]+8*[DeltaX]), ([y_start_back]-24*[DeltaY_ServiceModule]-12*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Back"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="18"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+8*[SensorModule_X]+8*[DeltaX]+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service7]), ([y_start_back]-24*[DeltaY_ServiceModule]-12*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+  <Numeric name="N" value="20"/>
+  <Numeric name="StartCopyNo" value="221"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX]), ([y_start_back]-25*[DeltaY_ServiceModule]-12*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+  <Numeric name="N" value="20"/>
+  <Numeric name="StartCopyNo" value="234"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX]), ([y_start_back]-25*[DeltaY_ServiceModule]-13*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid3_Back"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="17"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5+ --> [x_offset]+8*[SensorModule_X]+8*[DeltaX]), ([y_start_back]-26*[DeltaY_ServiceModule]-13*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Back"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="20"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5+ --> [x_offset]+8*[SensorModule_X]+8*[DeltaX]+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service7]), ([y_start_back]-26*[DeltaY_ServiceModule]-13*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+  <Numeric name="N" value="19"/>
+  <Numeric name="StartCopyNo" value="241"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+8*[SensorModule_X]+8*[DeltaX]), ([y_start_back]-27*[DeltaY_ServiceModule]-13*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+  <Numeric name="N" value="19"/>
+  <Numeric name="StartCopyNo" value="254"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+8*[SensorModule_X]+8*[DeltaX]), ([y_start_back]-27*[DeltaY_ServiceModule]-14*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid3_Back"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="19"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5+ --> [x_offset]+8*[SensorModule_X]+8*[DeltaX]), ([y_start_back]-28*[DeltaY_ServiceModule]-14*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Back"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="22"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5+ --> [x_offset]+8*[SensorModule_X]+8*[DeltaX]+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service7]), ([y_start_back]-28*[DeltaY_ServiceModule]-14*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+  <Numeric name="N" value="20"/>
+  <Numeric name="StartCopyNo" value="260"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX]), ([y_start_back]-29*[DeltaY_ServiceModule]-14*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+  <Numeric name="N" value="20"/>
+  <Numeric name="StartCopyNo" value="273"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX]), ([y_start_back]-29*[DeltaY_ServiceModule]-15*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid3_Back"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="21"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+8*[SensorModule_X]+8*[DeltaX]), ([y_start_back]-30*[DeltaY_ServiceModule]-15*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Back"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="24"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+8*[SensorModule_X]+8*[DeltaX]+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service7]), ([y_start_back]-30*[DeltaY_ServiceModule]-15*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+  <Numeric name="N" value="20"/>
+  <Numeric name="StartCopyNo" value="280"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([SensorModule_X]/2+7*[SensorModule_X]+7*[DeltaX]), ([y_start_back]-31*[DeltaY_ServiceModule]-15*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+  <Numeric name="N" value="20"/>
+  <Numeric name="StartCopyNo" value="293"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 1+ --> [x_offset]+6*[SensorModule_X]+6*[DeltaX]), ([y_start_back]-31*[DeltaY_ServiceModule]-16*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid3_Back"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="23"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX]), ([y_start_back]-32*[DeltaY_ServiceModule]-16*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Back"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="26"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX]+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service7]), ([y_start_back]-32*[DeltaY_ServiceModule]-16*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+  <Numeric name="N" value="20"/>
+  <Numeric name="StartCopyNo" value="300"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+6*[SensorModule_X]+6*[DeltaX]), ([y_start_back]-33*[DeltaY_ServiceModule]-16*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+  <Numeric name="N" value="22"/>
+  <Numeric name="StartCopyNo" value="313"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 1+ --> [x_offset]+4*[SensorModule_X]+4*[DeltaX]), ([y_start_back]-33*[DeltaY_ServiceModule]-17*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid3_Back"/>
+  <Numeric name="N" value="3"/>
+  <Numeric name="StartCopyNo" value="25"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+4*[SensorModule_X]+4*[DeltaX]), ([y_start_back]-34*[DeltaY_ServiceModule]-17*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Back"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="28"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+4*[SensorModule_X]+4*[DeltaX]+2*[ServiceHybrid_X3]+2*[DeltaX]+[DeltaX_Service3_Service7]), ([y_start_back]-34*[DeltaY_ServiceModule]-17*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+  <Numeric name="N" value="23"/>
+  <Numeric name="StartCopyNo" value="320"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+3*[SensorModule_X]+3*[DeltaX]), ([y_start_back]-35*[DeltaY_ServiceModule]-17*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+  <Numeric name="N" value="25"/>
+  <Numeric name="StartCopyNo" value="335"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]-35*[DeltaY_ServiceModule]-18*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid3_Back"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="28"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_back]-36*[DeltaY_ServiceModule]-18*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid6_Back"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="11"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6]), ([y_start_back]-36*[DeltaY_ServiceModule]-18*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Back"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="30"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6]+[ServiceHybrid_X6]+[DeltaX]+[DeltaX_Service6_Service7]), ([y_start_back]-36*[DeltaY_ServiceModule]-18*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+  <Numeric name="N" value="25"/>
+  <Numeric name="StartCopyNo" value="343"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]-37*[DeltaY_ServiceModule]-18*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+  <Numeric name="N" value="24"/>
+  <Numeric name="StartCopyNo" value="360"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]-37*[DeltaY_ServiceModule]-19*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid3_Back"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="30"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_back]-38*[DeltaY_ServiceModule]-19*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid6_Back"/>
+  <Numeric name="N" value="3"/>
+  <Numeric name="StartCopyNo" value="13"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6]), ([y_start_back]-38*[DeltaY_ServiceModule]-19*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+  <Numeric name="N" value="24"/>
+  <Numeric name="StartCopyNo" value="368"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]-39*[DeltaY_ServiceModule]-19*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+  <Numeric name="N" value="23"/>
+  <Numeric name="StartCopyNo" value="384"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]-39*[DeltaY_ServiceModule]-20*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid3_Back"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="32"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_back]-40*[DeltaY_ServiceModule]-20*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid6_Back"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="16"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]), ([y_start_back]-40*[DeltaY_ServiceModule]-20*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Back"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="31"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]+[DeltaX_Service6_Service7]), ([y_start_back]-40*[DeltaY_ServiceModule]-20*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+  <Numeric name="N" value="23"/>
+  <Numeric name="StartCopyNo" value="392"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]-41*[DeltaY_ServiceModule]-20*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+  <Numeric name="N" value="23"/>
+  <Numeric name="StartCopyNo" value="407"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]-41*[DeltaY_ServiceModule]-21*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid3_Back"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="33"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_back]-42*[DeltaY_ServiceModule]-21*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid6_Back"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="17"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]), ([y_start_back]-42*[DeltaY_ServiceModule]-21*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Back"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="33"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]+[ServiceHybrid_X6]+[DeltaX]+[DeltaX_Service6_Service7]), ([y_start_back]-42*[DeltaY_ServiceModule]-21*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+  <Numeric name="N" value="22"/>
+  <Numeric name="StartCopyNo" value="415"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]-43*[DeltaY_ServiceModule]-21*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+  <Numeric name="N" value="21"/>
+  <Numeric name="StartCopyNo" value="430"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]-43*[DeltaY_ServiceModule]-22*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Back"/>
+  <Numeric name="N" value="3"/>
+  <Numeric name="StartCopyNo" value="34"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X7]/2), ([y_start_back]-44*[DeltaY_ServiceModule]-22*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+  <Numeric name="N" value="20"/>
+  <Numeric name="StartCopyNo" value="437"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]-45*[DeltaY_ServiceModule]-22*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+  <Numeric name="N" value="19"/>
+  <Numeric name="StartCopyNo" value="451"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]-45*[DeltaY_ServiceModule]-23*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid6_Back"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="19"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X6]/2), ([y_start_back]-46*[DeltaY_ServiceModule]-23*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Back"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="37"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X6]/2+[ServiceHybrid_X6]+[DeltaX]+[DeltaX_Service6_Service7]), ([y_start_back]-46*[DeltaY_ServiceModule]-23*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+  <Numeric name="N" value="18"/>
+  <Numeric name="StartCopyNo" value="457"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]-47*[DeltaY_ServiceModule]-23*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+  <Numeric name="N" value="17"/>
+  <Numeric name="StartCopyNo" value="470"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]-47*[DeltaY_ServiceModule]-24*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid3_Back"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="34"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_back]-48*[DeltaY_ServiceModule]-24*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Back"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="38"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service7]), ([y_start_back]-48*[DeltaY_ServiceModule]-24*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+  <Numeric name="N" value="16"/>
+  <Numeric name="StartCopyNo" value="475"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]-49*[DeltaY_ServiceModule]-24*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+  <Numeric name="N" value="14"/>
+  <Numeric name="StartCopyNo" value="487"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]-49*[DeltaY_ServiceModule]-25*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Back"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="40"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X7]/2), ([y_start_back]-50*[DeltaY_ServiceModule]-25*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+  <Numeric name="N" value="13"/>
+  <Numeric name="StartCopyNo" value="491"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]-51*[DeltaY_ServiceModule]-25*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+  <Numeric name="N" value="10"/>
+  <Numeric name="StartCopyNo" value="501"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]-51*[DeltaY_ServiceModule]-26*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid3_Back"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="35"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_back]-52*[DeltaY_ServiceModule]-26*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid7_Back"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="42"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service7]), ([y_start_back]-52*[DeltaY_ServiceModule]-26*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Left"/>
+  <Numeric name="N" value="9"/>
+  <Numeric name="StartCopyNo" value="504"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]-53*[DeltaY_ServiceModule]-26*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:SensorModule_Back_Right"/>
+  <Numeric name="N" value="3"/>
+  <Numeric name="StartCopyNo" value="511"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]-53*[DeltaY_ServiceModule]-27*[SensorModule_Y]), (-1*[SensorModule_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+<Algorithm name="mtd:DDMTDLinear">
+  <rParent name="etl:DiscSector_Back"/>
+  <String name="ChildName" value="etl:ServiceHybrid3_Back"/>
+  <Numeric name="N" value="1"/>
+  <Numeric name="StartCopyNo" value="36"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+  <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_back]-54*[DeltaY_ServiceModule]-27*[SensorModule_Y]), (-1*[ServiceHybrid_translation_z]) </Vector>
+  <Numeric name="Theta" value="90.*deg"/>
+  <Numeric name="Phi" value="0.*deg"/>
+  <Numeric name="Theta_obj" value="90.*deg"/>
+  <Numeric name="Phi_obj" value="0.*deg"/>
+</Algorithm>
+
+
+</DDDefinition>

--- a/Geometry/MTDCommonData/data/etl/v7/etl.xml
+++ b/Geometry/MTDCommonData/data/etl/v7/etl.xml
@@ -167,15 +167,6 @@
     </Vector>
 
   </ConstantsSection>
-
-  <RotationSection label="etl.xml">
-    <Rotation name="0" thetaX="90*deg" phiX="0*deg" thetaY="90*deg" phiY="90*deg" thetaZ="0*deg" phiZ="0*deg"/>
-    <Rotation name="270" thetaX="90*deg" phiX="270*deg" thetaY="90*deg" phiY="0*deg" thetaZ="0*deg" phiZ="0*deg"/>
-    <Rotation name="180" thetaX="90*deg" phiX="180*deg" thetaY="90*deg" phiY="270*deg" thetaZ="0*deg" phiZ="0*deg"/>
-    <Rotation name="90" thetaX="90*deg" phiX="90*deg" thetaY="90*deg" phiY="180*deg" thetaZ="0*deg" phiZ="0*deg"/>
-    <Rotation name="ReverseVert" thetaX="90*deg" phiX="0*deg" thetaY="90*deg" phiY="270*deg" thetaZ="180*deg" phiZ="0*deg"/>
-    <Rotation name="ReverseHor" thetaX="90*deg" phiX="180*deg" thetaY="90*deg" phiY="90*deg" thetaZ="180*deg" phiZ="0*deg"/>
-  </RotationSection>
   
   <SolidSection label="etl.xml">
     <Polycone name="EndcapTimingLayer_0" startPhi="0*deg" deltaPhi="360*deg">
@@ -189,7 +180,7 @@
     <UnionSolid name="EndcapTimingLayer_1">
             <rSolid name="EndcapTimingLayer_0"/>
             <rSolid name="Notch_ext"/>
-            <rRotation name="etl:180" />
+            <rRotation name="rotations:R180" />
             <Translation x="-([Notch_Rmin]+0.5*[Notch_bl2])" y="0.*mm" z="0.5*[Notch_thickness]+[BackSupportPlate_Z2]"/>
     </UnionSolid>
     <UnionSolid name="EndcapTimingLayer">
@@ -247,7 +238,7 @@
     <UnionSolid name="BackSupportPlate_3">
             <rSolid name="BackSupportPlate_2"/>
             <rSolid name="Notch_left"/>
-            <rRotation name="etl:180" />
+            <rRotation name="rotations:R180" />
             <Translation x="-([Notch_Rmin]+0.5*[Notch_bl2])" y="0.*mm" z="0.5*[Notch_thickness]+[BackSupportPlate_Z2]"/>
     </UnionSolid>
     <UnionSolid name="BackSupportPlate">
@@ -577,19 +568,19 @@
     <PosPart copyNumber="2">
       <rParent name="etl:EndcapTimingLayer"/>
       <rChild name="etl:Cables"/>
-      <rRotation name="etl:ReverseVert" />
+      <rRotation name="rotations:RPCD" />
       <Translation x="0.*mm" y="0.*mm" z="[PatchPanel_Cables_FrontModcenter]" />
     </PosPart>
     <PosPart copyNumber="3">
       <rParent name="etl:EndcapTimingLayer"/>
       <rChild name="etl:Cables"/>
-      <rRotation name="etl:180" />
+      <rRotation name="rotations:R180" />
       <Translation x="0.*mm" y="0.*mm" z="[PatchPanel_Cables_FrontModcenter]" />
     </PosPart>
     <PosPart copyNumber="4">
       <rParent name="etl:EndcapTimingLayer"/>
       <rChild name="etl:Cables"/>
-      <rRotation name="etl:ReverseHor" />
+      <rRotation name="rotations:180D" />
       <Translation x="0.*mm" y="0.*mm" z="[PatchPanel_Cables_FrontModcenter]" />
     </PosPart>
     <PosPart copyNumber="1">
@@ -600,7 +591,7 @@
     <PosPart copyNumber="2">
         <rParent name="etl:EndcapTimingLayer"/>
         <rChild name="etl:PatchPanel"/>
-        <rRotation name="etl:ReverseVert" />
+        <rRotation name="rotations:RPCD" />
         <Translation x="0.*mm" y="0.*mm" z="[PatchPanel_Cables_FrontModcenter]" />
     </PosPart>
     <PosPart copyNumber="1">
@@ -617,7 +608,7 @@
     <PosPart copyNumber="2">
       <rParent name="etl:EndcapTimingLayer"/>
       <rChild name="etl:Notch_cables"/>
-      <rRotation name="etl:180" />
+      <rRotation name="rotations:R180" />
      <!-- <Translation x="-[Notch_Rmin]-0.5*([Notch_bl2]-2*[BackSupportPlate_thickness])-[BackSupportPlate_thickness]" y="0.*mm" z="[Notch_cables_center]" /> -->
      <Translation x="-([Notch_Rmin]+0.5*[Notch_bl2])-[BackSupportPlate_thickness]" y="0.*mm" z="0.5*[Notch_thickness]+[BackSupportPlate_Z2]-[BackSupportPlate_thickness]"/>
     </PosPart>
@@ -689,25 +680,25 @@
     <PosPart copyNumber="1">
       <rParent name="etl:Disc1Timing"/>
       <rChild name="etl:DiscSector_Front"/>
-      <rRotation name="etl:0"/>
+      <rRotation name="rotations:000D"/>
       <Translation x="0.*mm" y="0.*mm" z="-1*[Disk_translation_z]" />
     </PosPart>
     <PosPart copyNumber="2">
       <rParent name="etl:Disc1Timing"/>
       <rChild name="etl:DiscSector_Front"/>
-      <rRotation name="etl:180"/>
+      <rRotation name="rotations:R180"/>
       <Translation x="0.*mm" y="0.*mm" z="-1*[Disk_translation_z]" />
     </PosPart>
     <PosPart copyNumber="1">
       <rParent name="etl:Disc1Timing"/>
       <rChild name="etl:DiscSector_Back"/>
-      <rRotation name="etl:0"/>
+      <rRotation name="rotations:000D"/>
       <Translation x="0.*mm" y="0.*mm" z="[Disk_translation_z]" />
     </PosPart>
     <PosPart copyNumber="2">
       <rParent name="etl:Disc1Timing"/>
       <rChild name="etl:DiscSector_Back"/>
-      <rRotation name="etl:180"/>
+      <rRotation name="rotations:R180"/>
       <Translation x="0.*mm" y="0.*mm" z="[Disk_translation_z]" />
     </PosPart>
 
@@ -720,25 +711,25 @@
     <PosPart copyNumber="1">
       <rParent name="etl:Disc2Timing"/>
       <rChild name="etl:DiscSector_Front"/>
-      <rRotation name="etl:0"/>
+      <rRotation name="rotations:000D"/>
       <Translation x="0.*mm" y="0.*mm" z="-1*[Disk_translation_z]" />
     </PosPart>
     <PosPart copyNumber="2">
       <rParent name="etl:Disc2Timing"/>
       <rChild name="etl:DiscSector_Front"/>
-      <rRotation name="etl:180"/>
+      <rRotation name="rotations:R180"/>
       <Translation x="0.*mm" y="0.*mm" z="-1*[Disk_translation_z]" />
     </PosPart>
     <PosPart copyNumber="1">
       <rParent name="etl:Disc2Timing"/>
       <rChild name="etl:DiscSector_Back"/>
-      <rRotation name="etl:0"/>
+      <rRotation name="rotations:000D"/>
       <Translation x="0.*mm" y="0.*mm" z="[Disk_translation_z]" />
     </PosPart>
     <PosPart copyNumber="2">
       <rParent name="etl:Disc2Timing"/>
       <rChild name="etl:DiscSector_Back"/>
-      <rRotation name="etl:180"/>
+      <rRotation name="rotations:R180"/>
       <Translation x="0.*mm" y="0.*mm" z="[Disk_translation_z]" />
     </PosPart>
     
@@ -1048,7 +1039,7 @@
     <PosPart copyNumber="1">
       <rParent name="etl:SensorModule_Back_Left"/>
       <rChild name="etl:LGAD"/>
-      <rRotation name="etl:ReverseVert" />
+      <rRotation name="rotations:RPCD" />
       <Translation x="0.*mm" y="-1*[LGAD_translation_y]" z="-1*[LGAD_translation_z]" />
     </PosPart>
     
@@ -1128,7 +1119,7 @@
     <PosPart copyNumber="1">
       <rParent name="etl:SensorModule_Back_Right"/>
       <rChild name="etl:LGAD"/>
-      <rRotation name="etl:ReverseVert" />
+      <rRotation name="rotations:RPCD" />
       <Translation x="0.*mm" y="[LGAD_translation_y]" z="-1*[LGAD_translation_z]" />
     </PosPart>
   </PosPartSection>

--- a/Geometry/MTDCommonData/data/mtdMaterial/v3/mtdMaterial.xml
+++ b/Geometry/MTDCommonData/data/mtdMaterial/v3/mtdMaterial.xml
@@ -159,6 +159,28 @@
         <rMaterial name="materials:Borated Polyethyl."/>
       </MaterialFraction>
     </CompositeMaterial>
+    <CompositeMaterial name="ETLServicesVolume" density="161.58972*mg/cm3" symbol=" " method="mixture by weight">
+      <MaterialFraction fraction="0.98">
+        <rMaterial name="materials:Air"/>
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02">
+        <rMaterial name="materials:StainlessSteel"/>
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="ETLNotch" density="843.819822*mg/cm3" symbol=" " method="mixture by weight">
+      <MaterialFraction fraction="0.873">
+        <rMaterial name="materials:Air"/>
+      </MaterialFraction>
+      <MaterialFraction fraction="0.018">
+        <rMaterial name="materials:StainlessSteel"/>
+      </MaterialFraction>
+      <MaterialFraction fraction="0.037">
+        <rMaterial name="materials:Kevlar"/>
+      </MaterialFraction>
+      <MaterialFraction fraction="0.072">
+        <rMaterial name="materials:Copper"/>
+      </MaterialFraction>
+    </CompositeMaterial>
   </MaterialSection>
-
+  
 </DDDefinition>


### PR DESCRIPTION
#### PR description:

Addition of the revised description of ETL mother volume and passive structure to include the notch and the cables inside it (work by @martatornago ). This version I15 of MTD requires the recently added calo envelope O9 (added by @bsunanda in #36013 . See https://indico.cern.ch/event/1083649/contributions/4556808/attachments/2325151/3960278/ETLGeometryUpdateD86.pdf .

#### PR validation:

These updates have been tested privately for consistency with the engineering drawings and absence of overlaps. A screenshot from the event display:

<img width="352" alt="Schermata 2021-11-08 alle 15 49 15" src="https://user-images.githubusercontent.com/4058194/141101011-1b044d46-6dd9-4814-a979-44980380518c.png">
.
