### PR TITLE
removed refs to `HLTSchedule` outside of `HLTrigger/Configuration`

### DIFF
--- a/Calibration/IsolatedParticles/test/python/HLT_IsoTrig_Data_New1.py
+++ b/Calibration/IsolatedParticles/test/python/HLT_IsoTrig_Data_New1.py
@@ -239,7 +239,6 @@ process.schedule.extend([process.FastTimerOutput])
 
 # Automatic addition of the customisation function from SLHCUpgradeSimulations.Configuration.postLS1Customs
 from SLHCUpgradeSimulations.Configuration.postLS1Customs import *
-process = customise_HLT(process)
 process = customisePostLS1(process)
 
 # Automatic addition of the customisation function from SimGeneral.MixingModule.fullMixCustomize_cff

--- a/Calibration/IsolatedParticles/test/python/HLT_IsoTrig_MC_New0.py
+++ b/Calibration/IsolatedParticles/test/python/HLT_IsoTrig_MC_New0.py
@@ -198,7 +198,6 @@ process = customizeHLTforMC(process)
 
 # Automatic addition of the customisation function from SLHCUpgradeSimulations.Configuration.postLS1Customs
 #from SLHCUpgradeSimulations.Configuration.postLS1Customs import *
-#process = customise_HLT(process)
 #process = customisePostLS1(process)
 
 # Automatic addition of the customisation function from SimGeneral.MixingModule.fullMixCustomize_cff

--- a/Calibration/IsolatedParticles/test/python/HLT_IsoTrig_MC_New1.py
+++ b/Calibration/IsolatedParticles/test/python/HLT_IsoTrig_MC_New1.py
@@ -228,7 +228,6 @@ process = customizeHLTforMC(process)
 
 # Automatic addition of the customisation function from SLHCUpgradeSimulations.Configuration.postLS1Customs
 #from SLHCUpgradeSimulations.Configuration.postLS1Customs import *
-#process = customise_HLT(process)
 #process = customisePostLS1(process)
 
 # Automatic addition of the customisation function from SimGeneral.MixingModule.fullMixCustomize_cff

--- a/Calibration/IsolatedParticles/test/python/HLT_IsoTrig_MC_New2.py
+++ b/Calibration/IsolatedParticles/test/python/HLT_IsoTrig_MC_New2.py
@@ -312,7 +312,6 @@ process = customizeHLTforMC(process)
 
 # Automatic addition of the customisation function from SLHCUpgradeSimulations.Configuration.postLS1Customs
 #from SLHCUpgradeSimulations.Configuration.postLS1Customs import *
-#process = customise_HLT(process)
 #process = customisePostLS1(process)
 
 # Automatic addition of the customisation function from SimGeneral.MixingModule.fullMixCustomize_cff

--- a/FastSimulation/Calorimetry/test/neutrinogun_fastsim_cfg.py
+++ b/FastSimulation/Calorimetry/test/neutrinogun_fastsim_cfg.py
@@ -111,6 +111,4 @@ process.hcalHitsValidation_step = cms.EndPath(
 
 
 # Schedule definition
-process.schedule = cms.Schedule(process.HLTSchedule)
 process.schedule.extend([process.hcalHitsValidation_step,process.FEVTDEBUGHLToutput_step])
-

--- a/FastSimulation/Calorimetry/test/piongun_fastsim_cfg.py
+++ b/FastSimulation/Calorimetry/test/piongun_fastsim_cfg.py
@@ -110,6 +110,4 @@ process.hcalHitsValidation_step = cms.EndPath(
     )
 
 # Schedule definition
-process.schedule = cms.Schedule(process.HLTSchedule)
 process.schedule.extend([process.hcalHitsValidation_step,process.FEVTDEBUGHLToutput_step])
-

--- a/FastSimulation/Validation/test/Template_cfg.py
+++ b/FastSimulation/Validation/test/Template_cfg.py
@@ -53,8 +53,6 @@ process.load("FastSimulation.Configuration.HLT_cff")
 process.HLTEndSequence = cms.Sequence(process.reconstructionWithFamos)
 
 # Schedule the HLT paths
-process.schedule = cms.Schedule()
-process.schedule.extend(process.HLTSchedule)
 
 # If uncommented : All events are reconstructed, including those rejected at L1/HLT
 process.reconstruction = cms.Path(process.reconstructionWithFamos)

--- a/HLTrigger/special/test/test_AsymFilters_cfg.py
+++ b/HLTrigger/special/test/test_AsymFilters_cfg.py
@@ -92,8 +92,6 @@ process.HLT_L1_BSC_BeamGas = cms.Path( process.HLTBeginSequence  + process.hltL1
 
 process.HLT_L1_HF_BeamGas = cms.Path( process.HLTBeginSequence   + process.hltL1sL1BptxXORBscMinBiasOR  + process.HLTDoLocalHF + process.hltHFAsymmetryFilter + process.HLTEndSequence )
 
-process.m_HLTSchedule = cms.Schedule( *(process.HLTriggerFirstPath, process.HLT_L1_BSC_BeamGas, process.HLT_L1_HF_BeamGas, process.HLTriggerFinalPath, process.HLTAnalyzerEndpath ))
-
 
 #Deal with the global tag
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
@@ -107,7 +105,5 @@ process.out_step     = cms.EndPath( process.hltTimer + process.output)
 
 
 # Schedule definition
-
-process.schedule = cms.Schedule(process.m_HLTSchedule)
+process.schedule = cms.Schedule(*( process.HLTriggerFirstPath, process.HLT_L1_BSC_BeamGas, process.HLT_L1_HF_BeamGas, process.HLTriggerFinalPath, process.HLTAnalyzerEndpath ))
 process.schedule.extend([process.endjob_step,process.out_step])
-

--- a/HLTrigger/special/test/test_CosmicsFilters_cfg.py
+++ b/HLTrigger/special/test/test_CosmicsFilters_cfg.py
@@ -156,8 +156,6 @@ process.HLTRegionalCosmicSeeding = cms.Sequence( process.hltSiPixelDigis + proce
 
 process.HLT_TrackerCosmics_RegionalCosmicTracking = cms.Path( process.HLTBeginSequence + process.hltL1sTrackerCosmics + process.hltPreTrackerCosmics + process.hltTrackerCosmicsPattern + process.HLTL2muonrecoSequenceNoVtx + process.HLTRegionalCosmicSeeding + process.HLTEndSequence )
 
-process.m_HLTSchedule = cms.Schedule( *(process.HLTriggerFirstPath, process.HLT_TrackerCosmics_RegionalCosmicTracking, process.HLTriggerFinalPath, process.HLTAnalyzerEndpath ))
-
 
 #Deal with the global tag
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
@@ -171,9 +169,5 @@ process.out_step     = cms.EndPath( process.hltTimer + process.output)
 
 
 # Schedule definition
-
-process.schedule = cms.Schedule(process.m_HLTSchedule)
-#process.schedule = cms.Schedule(process.HLTSchedule)
-
+process.schedule = cms.Schedule(*( process.HLTriggerFirstPath, process.HLT_TrackerCosmics_RegionalCosmicTracking, process.HLTriggerFinalPath, process.HLTAnalyzerEndpath ))
 process.schedule.extend([process.endjob_step,process.out_step])
-

--- a/HLTrigger/special/test/test_HaloFilters_cfg.py
+++ b/HLTrigger/special/test/test_HaloFilters_cfg.py
@@ -104,9 +104,6 @@ process.hltTrackerHaloFilter = cms.EDFilter( "HLTTrackerHaloFilter",
 process.HLT_BeamHalo = cms.Path( process.HLTBeginSequence  + process.hltL1sL1BptxXORBscMinBiasOR  + process.HLTDoLocalPixel + process.hltPixelActivityFilter + process.HLTDoLocalStrips + process.hltTrackerHaloFilter + process.HLTEndSequence )
 
 
-process.m_HLTSchedule = cms.Schedule( *(process.HLTriggerFirstPath, process.HLT_BeamHalo, process.HLTriggerFinalPath, process.HLTAnalyzerEndpath ))
-
-
 #Deal with the global tag
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 process.GlobalTag.connect   = 'frontier://FrontierProd/CMS_COND_31X_GLOBALTAG'
@@ -119,8 +116,5 @@ process.out_step     = cms.EndPath( process.hltTimer + process.output)
 
 
 # Schedule definition
-
-process.schedule = cms.Schedule(process.m_HLTSchedule)
-
+process.schedule = cms.Schedule(*( process.HLTriggerFirstPath, process.HLT_BeamHalo, process.HLTriggerFinalPath, process.HLTAnalyzerEndpath ))
 process.schedule.extend([process.endjob_step,process.out_step])
-

--- a/HLTriggerOffline/Tau/test/runHLTTauValidation_WithHLT.py
+++ b/HLTriggerOffline/Tau/test/runHLTTauValidation_WithHLT.py
@@ -33,7 +33,6 @@ process.load("Configuration.StandardSequences.L1TriggerDefaultMenu_cff")
 # run HLT
 process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 process.load("HLTrigger.Configuration.HLT_2E30_cff")
-process.schedule = process.HLTSchedule
 
 process.hltL1gtTrigReport = cms.EDAnalyzer( "L1GtTrigReport",
     UseL1GlobalTriggerRecord = cms.bool( False ),

--- a/L1Trigger/L1TCommon/test/devHLT.py
+++ b/L1Trigger/L1TCommon/test/devHLT.py
@@ -133,7 +133,6 @@ process.endjob_step = cms.EndPath(process.endOfProcess)
 
 # Schedule definition
 process.schedule = cms.Schedule(process.digitisation_step,process.L1simulation_step,process.digi2raw_step,process.debug_step)
-#process.schedule.extend(process.HLTSchedule)
 #process.schedule.extend([process.endjob_step,process.FEVTDEBUGHLToutput_step])
 process.schedule.extend([process.endjob_step])
 

--- a/L1Trigger/L1TMuonCPPF/test/step2_DIGI_L1_DIGI2RAW_HLT.py
+++ b/L1Trigger/L1TMuonCPPF/test/step2_DIGI_L1_DIGI2RAW_HLT.py
@@ -123,9 +123,11 @@ process.endjob_step = cms.EndPath(process.endOfProcess)
 process.FEVTDEBUGHLToutput_step = cms.EndPath(process.FEVTDEBUGHLToutput)
 
 # Schedule definition
-process.schedule = cms.Schedule(process.digitisation_step,process.emulatorCppfDigis_step,process.L1simulation_step,process.digi2raw_step)
-#process.schedule = cms.Schedule(process.digitisation_step,process.L1simulation_step,process.digi2raw_step)
-process.schedule.extend(process.HLTSchedule)
+# process.schedule imported from cff in HLTrigger.Configuration
+process.schedule.insert(0, process.digitisation_step)
+process.schedule.insert(1, process.emulatorCppfDigis_step)
+process.schedule.insert(2, process.L1simulation_step)
+process.schedule.insert(3, process.digi2raw_step)
 process.schedule.extend([process.endjob_step,process.FEVTDEBUGHLToutput_step])
 from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
 associatePatAlgosToolsTask(process)

--- a/RecoParticleFlow/Configuration/test/IntegrationTestWithHLT_cfg.py
+++ b/RecoParticleFlow/Configuration/test/IntegrationTestWithHLT_cfg.py
@@ -58,9 +58,7 @@ process.hltTrigReport = cms.EDAnalyzer( "HLTrigReport",
     HLTriggerResults = cms.InputTag( 'TriggerResults','','HLT' )
 )
 process.HLTAnalyzerEndpath = cms.EndPath( hltL1GtTrigReport + process.hltTrigReport )
-process.HLTSchedule.append(process.HLTAnalyzerEndpath)
-process.schedule = cms.Schedule()
-process.schedule.extend(process.HLTSchedule)
+process.schedule.append(process.HLTAnalyzerEndpath)
 
 # If uncommented : All events are reconstructed, including those rejected at L1/HLT
 # process.reconstruction = cms.Path(process.reconstructionWithFamos)

--- a/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
+++ b/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
@@ -26,8 +26,6 @@ def customisePostLS1_Common(process):
         process = customise_Reco(process)
     if hasattr(process,'digitisation_step') or ( hasattr(process,'mix') and hasattr(process.mix,'digitizers')):
         process = customise_Digi_Common(process)
-    if hasattr(process,'HLTSchedule'):
-        process = customise_HLT(process)
     if hasattr(process,'L1simulation_step'):
         process = customise_L1Emulator(process)
     if hasattr(process,'dqmoffline_step'):
@@ -776,10 +774,6 @@ def customise_RawToDigi(process):
 
 
 def customise_DigiToRaw(process):
-    return process
-
-
-def customise_HLT(process):
     return process
 
 

--- a/SimG4Core/Configuration/test/dd4hep_ZMM_Run3_Step2_cfg.py
+++ b/SimG4Core/Configuration/test/dd4hep_ZMM_Run3_Step2_cfg.py
@@ -116,8 +116,10 @@ process.endjob_step = cms.EndPath(process.endOfProcess)
 process.FEVTDEBUGHLToutput_step = cms.EndPath(process.FEVTDEBUGHLToutput)
 
 # Schedule definition
-process.schedule = cms.Schedule(process.digitisation_step,process.L1simulation_step,process.digi2raw_step)
-process.schedule.extend(process.HLTSchedule)
+# process.schedule imported from cff in HLTrigger.Configuration
+process.schedule.insert(0, process.digitisation_step)
+process.schedule.insert(1, process.L1simulation_step)
+process.schedule.insert(2, process.digi2raw_step)
 process.schedule.extend([process.endjob_step,process.FEVTDEBUGHLToutput_step])
 from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
 associatePatAlgosToolsTask(process)

--- a/SimG4Core/Configuration/test/ddd_ZMM_Run3_Step2_cfg.py
+++ b/SimG4Core/Configuration/test/ddd_ZMM_Run3_Step2_cfg.py
@@ -115,8 +115,10 @@ process.endjob_step = cms.EndPath(process.endOfProcess)
 process.FEVTDEBUGHLToutput_step = cms.EndPath(process.FEVTDEBUGHLToutput)
 
 # Schedule definition
-process.schedule = cms.Schedule(process.digitisation_step,process.L1simulation_step,process.digi2raw_step)
-process.schedule.extend(process.HLTSchedule)
+# process.schedule imported from cff in HLTrigger.Configuration
+process.schedule.insert(0, process.digitisation_step)
+process.schedule.insert(1, process.L1simulation_step)
+process.schedule.insert(2, process.digi2raw_step)
 process.schedule.extend([process.endjob_step,process.FEVTDEBUGHLToutput_step])
 from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
 associatePatAlgosToolsTask(process)

--- a/Validation/RecoHI/test/step1_HLT.py
+++ b/Validation/RecoHI/test/step1_HLT.py
@@ -59,6 +59,5 @@ process.endjob_step = cms.Path(process.endOfProcess)
 process.out_step = cms.EndPath(process.output)
 
 # Schedule definition
-process.schedule = cms.Schedule()
-process.schedule.extend(process.HLTSchedule)
+# process.schedule imported from cff in HLTrigger.Configuration
 process.schedule.extend([process.endjob_step,process.out_step])


### PR DESCRIPTION
#### PR description:

This PR is a minor technical follow-up of #35858 related to [this comment](https://github.com/cms-sw/cmssw/pull/35858#issuecomment-962415846).

Given the plan to remove the object `HLTSchedule` in the near future (see #35842), the usage of `HLTSchedule` is removed in various configuration files, mostly in `test/` folders.

#### PR validation:

Verified that the affected configs are fixed if they were crashing b/c of `HLTSchedule`.
Most of these configs are old and already broken anyways for unrelated reasons
(still, references to `HLTSchedule` are removed there too, in the interest of clarity).

Unit tests passed.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

N/A