### PR TITLE
migrate Alignment codes to new `PoolDBOutputService` methods

### DIFF
--- a/Alignment/CocoaApplication/src/CocoaAnalyzer.cc
+++ b/Alignment/CocoaApplication/src/CocoaAnalyzer.cc
@@ -1,5 +1,4 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
-#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 #include "CondFormats/DataRecord/interface/OpticalAlignmentsRcd.h"
 #include "CondFormats/OptAlignObjects/interface/OpticalAlignMeasurementInfo.h"
 #include <DD4hep/DD4hepUnits.h>

--- a/Alignment/CocoaFit/interface/CocoaDBMgr.h
+++ b/Alignment/CocoaFit/interface/CocoaDBMgr.h
@@ -15,6 +15,7 @@
 #include <string>
 #include <iostream>
 #include <map>
+#include <memory>
 
 class Event;
 class EventSetup;
@@ -45,13 +46,13 @@ public:
   bool DumpCocoaResults();
 
 private:
-  OpticalAlignments* BuildOpticalAlignments();
+  std::unique_ptr<OpticalAlignments> BuildOpticalAlignments();
   double GetEntryError(const Entry* entry);
   double GetEntryError(const Entry* entry1, const Entry* entry2);
 
   OpticalAlignInfo GetOptAlignInfoFromOptO(OpticalObject* opto);
 
-  std::pair<Alignments*, AlignmentErrorsExtended*> BuildAlignments(bool bDT);
+  std::pair<std::unique_ptr<Alignments>, std::unique_ptr<AlignmentErrorsExtended> > BuildAlignments(bool bDT);
   AlignTransform* GetAlignInfoFromOptO(OpticalObject* opto);
   AlignTransformErrorExtended* GetAlignInfoErrorFromOptO(OpticalObject* opto);
 

--- a/Alignment/CocoaFit/src/CocoaDBMgr.cc
+++ b/Alignment/CocoaFit/src/CocoaDBMgr.cc
@@ -55,7 +55,7 @@ bool CocoaDBMgr::DumpCocoaResults() {
   cond::Time_t appendTime = Fit::nEvent + 1;
   if (gomgr->GlobalOptions()["writeDBOptAlign"] > 0) {
     //----- Build OpticalAlignments
-    OpticalAlignments* optalign = BuildOpticalAlignments();
+    std::unique_ptr<OpticalAlignments> optalign = BuildOpticalAlignments();
 
     //--- Dump OpticalAlignments
     nrcd = optalign->opticalAlignments_.size();
@@ -67,21 +67,11 @@ bool CocoaDBMgr::DumpCocoaResults() {
       std::cout << " new OA to DB "
                 << "begin " << myDbService->beginOfTime() << " current " << myDbService->currentTime() << " end "
                 << myDbService->endOfTime() << std::endl;
-      myDbService->createNewIOV<OpticalAlignments>(
-          optalign,
-          myDbService->beginOfTime(),
-          myDbService->endOfTime(),
-          //						   myDbService->endOfTime(),
-          "OpticalAlignmentsRcd");
+      myDbService->createOneIOV<OpticalAlignments>(*optalign, myDbService->beginOfTime(), "OpticalAlignmentsRcd");
     } else {
       std::cout << " old OA to DB "
                 << " current " << myDbService->currentTime() << " end " << myDbService->endOfTime() << std::endl;
-      myDbService->appendSinceTime<OpticalAlignments>(
-          optalign,
-          //		      myDbService->endOfTime(),
-          appendTime,
-          //						       myDbService->currentTime(),
-          "OpticalAlignmentsRcd");
+      myDbService->appendOneIOV<OpticalAlignments>(*optalign, appendTime, "OpticalAlignmentsRcd");
     }
 
     /*    }catch(const cond::Exception& er) {
@@ -98,60 +88,53 @@ bool CocoaDBMgr::DumpCocoaResults() {
 
   if (gomgr->GlobalOptions()["writeDBAlign"] > 0) {
     // Build DT alignments and errors
-    std::pair<Alignments*, AlignmentErrorsExtended*> dtali = BuildAlignments(true);
-    Alignments* dt_Alignments = dtali.first;
-    AlignmentErrorsExtended* dt_AlignmentErrors = dtali.second;
+    const auto& dtali = BuildAlignments(true);
+    auto& dt_Alignments = dtali.first;
+    auto& dt_AlignmentErrors = dtali.second;
 
     // Dump DT alignments and errors
     nrcd = dt_Alignments->m_align.size();
     if (myDbService->isNewTagRequest("DTAlignmentRcd")) {
-      myDbService->createNewIOV<Alignments>(
-          &(*dt_Alignments), myDbService->beginOfTime(), myDbService->endOfTime(), "DTAlignmentRcd");
+      myDbService->createOneIOV<Alignments>(*dt_Alignments, myDbService->beginOfTime(), "DTAlignmentRcd");
     } else {
-      myDbService->appendSinceTime<Alignments>(&(*dt_Alignments),
-                                               appendTime,
-                                               //					       myDbService->currentTime(),
-                                               "DTAlignmentRcd");
+      myDbService->appendOneIOV<Alignments>(*dt_Alignments, appendTime, "DTAlignmentRcd");
     }
     if (ALIUtils::debug >= 2)
       std::cout << "DTAlignmentRcd WRITTEN TO DB : " << nrcd << std::endl;
 
     nrcd = dt_AlignmentErrors->m_alignError.size();
     if (myDbService->isNewTagRequest("DTAlignmentErrorExtendedRcd")) {
-      myDbService->createNewIOV<AlignmentErrorsExtended>(
-          &(*dt_AlignmentErrors), myDbService->beginOfTime(), myDbService->endOfTime(), "DTAlignmentErrorExtendedRcd");
+      myDbService->createOneIOV<AlignmentErrorsExtended>(
+          *dt_AlignmentErrors, myDbService->beginOfTime(), "DTAlignmentErrorExtendedRcd");
     } else {
-      myDbService->appendSinceTime<AlignmentErrorsExtended>(
-          &(*dt_AlignmentErrors), appendTime, "DTAlignmentErrorExtendedRcd");
+      myDbService->appendOneIOV<AlignmentErrorsExtended>(
+          *dt_AlignmentErrors, appendTime, "DTAlignmentErrorExtendedRcd");
     }
     if (ALIUtils::debug >= 2)
       std::cout << "DTAlignmentErrorExtendedRcd WRITTEN TO DB : " << nrcd << std::endl;
 
     // Build CSC alignments and errors
-    std::pair<Alignments*, AlignmentErrorsExtended*> cscali = BuildAlignments(false);
-    Alignments* csc_Alignments = cscali.first;
-    AlignmentErrorsExtended* csc_AlignmentErrors = cscali.second;
+    const auto& cscali = BuildAlignments(false);
+    auto& csc_Alignments = cscali.first;
+    auto& csc_AlignmentErrors = cscali.second;
 
     // Dump CSC alignments and errors
     nrcd = csc_Alignments->m_align.size();
     if (myDbService->isNewTagRequest("CSCAlignmentRcd")) {
-      myDbService->createNewIOV<Alignments>(
-          &(*csc_Alignments), myDbService->beginOfTime(), myDbService->endOfTime(), "CSCAlignmentRcd");
+      myDbService->createOneIOV<Alignments>(*csc_Alignments, myDbService->beginOfTime(), "CSCAlignmentRcd");
     } else {
-      myDbService->appendSinceTime<Alignments>(&(*csc_Alignments), appendTime, "CSCAlignmentRcd");
+      myDbService->appendOneIOV<Alignments>(*csc_Alignments, appendTime, "CSCAlignmentRcd");
     }
     if (ALIUtils::debug >= 2)
       std::cout << "CSCAlignmentRcd WRITTEN TO DB : " << nrcd << std::endl;
 
     nrcd = csc_AlignmentErrors->m_alignError.size();
     if (myDbService->isNewTagRequest("CSCAlignmentErrorExtendedRcd")) {
-      myDbService->createNewIOV<AlignmentErrorsExtended>(&(*csc_AlignmentErrors),
-                                                         myDbService->beginOfTime(),
-                                                         myDbService->endOfTime(),
-                                                         "CSCAlignmentErrorExtendedRcd");
+      myDbService->createOneIOV<AlignmentErrorsExtended>(
+          *csc_AlignmentErrors, myDbService->beginOfTime(), "CSCAlignmentErrorExtendedRcd");
     } else {
-      myDbService->appendSinceTime<AlignmentErrorsExtended>(
-          &(*csc_AlignmentErrors), appendTime, "CSCAlignmentErrorExtendedRcd");
+      myDbService->appendOneIOV<AlignmentErrorsExtended>(
+          *csc_AlignmentErrors, appendTime, "CSCAlignmentErrorExtendedRcd");
     }
     if (ALIUtils::debug >= 2)
       std::cout << "CSCAlignmentErrorExtendedRcd WRITTEN TO DB : " << nrcd << std::endl;
@@ -280,8 +263,8 @@ double CocoaDBMgr::GetEntryError(const Entry* entry1, const Entry* entry2) {
 }
 
 //-----------------------------------------------------------------------
-OpticalAlignments* CocoaDBMgr::BuildOpticalAlignments() {
-  OpticalAlignments* optalign = new OpticalAlignments;
+std::unique_ptr<OpticalAlignments> CocoaDBMgr::BuildOpticalAlignments() {
+  std::unique_ptr<OpticalAlignments> optalign = std::make_unique<OpticalAlignments>();
 
   static std::vector<OpticalObject*> optolist = Model::OptOList();
   static std::vector<OpticalObject*>::const_iterator ite;
@@ -298,9 +281,9 @@ OpticalAlignments* CocoaDBMgr::BuildOpticalAlignments() {
 }
 
 //-----------------------------------------------------------------------
-std::pair<Alignments*, AlignmentErrorsExtended*> CocoaDBMgr::BuildAlignments(bool bDT) {
-  Alignments* alignments = new Alignments;
-  AlignmentErrorsExtended* alignmentErrors = new AlignmentErrorsExtended;
+std::pair<std::unique_ptr<Alignments>, std::unique_ptr<AlignmentErrorsExtended> > CocoaDBMgr::BuildAlignments(bool bDT) {
+  std::unique_ptr<Alignments> alignments = std::make_unique<Alignments>();
+  std::unique_ptr<AlignmentErrorsExtended> alignmentErrors = std::make_unique<AlignmentErrorsExtended>();
 
   //read
   static std::vector<OpticalObject*> optolist = Model::OptOList();
@@ -326,7 +309,8 @@ std::pair<Alignments*, AlignmentErrorsExtended*> CocoaDBMgr::BuildAlignments(boo
   if (ALIUtils::debug >= 4)
     std::cout << "CocoaDBMgr::BuildAlignments end with n alignment " << alignments->m_align.size()
               << " n alignmentError " << alignmentErrors->m_alignError.size() << std::endl;
-  return std::pair<Alignments*, AlignmentErrorsExtended*>(alignments, alignmentErrors);
+
+  return std::make_pair(std::move(alignments), std::move(alignmentErrors));
 }
 
 //-----------------------------------------------------------------------

--- a/Alignment/CommonAlignmentProducer/interface/AlignmentProducerBase.h
+++ b/Alignment/CommonAlignmentProducer/interface/AlignmentProducerBase.h
@@ -215,7 +215,7 @@ private:
 
   /// Writes SurfaceDeformations (bows & kinks) to DB for given record name
   /// Takes over ownership of AlignmentSurfaceDeformations.
-  void writeDB(AlignmentSurfaceDeformations*, const std::string&, cond::Time_t) const;
+  void writeDB(const AlignmentSurfaceDeformations&, const std::string&, cond::Time_t) const;
 
   //========================== PRIVATE DATA ====================================
   //============================================================================

--- a/Alignment/CommonAlignmentProducer/plugins/GlobalTrackerMuonAlignment.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/GlobalTrackerMuonAlignment.cc
@@ -3347,7 +3347,7 @@ void GlobalTrackerMuonAlignment::writeGlPosRcd(CLHEP::HepVector& paramVec) {
 
   CLHEP::HepVector param0(6, 0);
 
-  Alignments* globalPositions = new Alignments();
+  Alignments globalPositions{};
 
   //Tracker
   AlignTransform tracker(
@@ -3417,11 +3417,11 @@ void GlobalTrackerMuonAlignment::writeGlPosRcd(CLHEP::HepVector& paramVec) {
             << std::endl;
   std::cout << calo.rotation() << std::endl;
 
-  globalPositions->m_align.push_back(tracker);
-  globalPositions->m_align.push_back(muon);
-  globalPositions->m_align.push_back(ecal);
-  globalPositions->m_align.push_back(hcal);
-  globalPositions->m_align.push_back(calo);
+  globalPositions.m_align.push_back(tracker);
+  globalPositions.m_align.push_back(muon);
+  globalPositions.m_align.push_back(ecal);
+  globalPositions.m_align.push_back(hcal);
+  globalPositions.m_align.push_back(calo);
 
   std::cout << "Uploading to the database..." << std::endl;
 
@@ -3435,10 +3435,7 @@ void GlobalTrackerMuonAlignment::writeGlPosRcd(CLHEP::HepVector& paramVec) {
   //    } else {
   //       poolDbService->appendSinceTime<Alignments>(&(*globalPositions), poolDbService->currentTime(), "GlobalPositionRcd");
   //    }
-  poolDbService->writeOne<Alignments>(&(*globalPositions),
-                                      poolDbService->currentTime(),
-                                      //poolDbService->beginOfTime(),
-                                      "GlobalPositionRcd");
+  poolDbService->writeOneIOV<Alignments>(globalPositions, poolDbService->currentTime(), "GlobalPositionRcd");
   std::cout << "done!" << std::endl;
 
   return;

--- a/Alignment/CommonAlignmentProducer/src/AlignmentProducerBase.cc
+++ b/Alignment/CommonAlignmentProducer/src/AlignmentProducerBase.cc
@@ -858,7 +858,7 @@ void AlignmentProducerBase::writeForRunRange(cond::Time_t time) {
 
     // Save surface deformations to database
     if (saveDeformationsToDB_) {
-      auto alignmentSurfaceDeformations = alignableTracker_->surfaceDeformations();
+      const auto alignmentSurfaceDeformations = *(alignableTracker_->surfaceDeformations());
       this->writeDB(alignmentSurfaceDeformations, "TrackerSurfaceDeformationRcd", time);
     }
   }
@@ -887,25 +887,23 @@ void AlignmentProducerBase::writeDB(Alignments* alignments,
                                     const std::string& errRcd,
                                     const AlignTransform* globalCoordinates,
                                     cond::Time_t time) const {
-  Alignments* tempAlignments = alignments;
-  AlignmentErrorsExtended* tempAlignmentErrorsExtended = alignmentErrors;
+  Alignments tempAlignments = *alignments;
+  AlignmentErrorsExtended tempAlignmentErrorsExtended = *alignmentErrors;
 
   // Call service
   edm::Service<cond::service::PoolDBOutputService> poolDb;
-  if (!poolDb.isAvailable()) {           // Die if not available
-    delete tempAlignments;               // promised to take over ownership...
-    delete tempAlignmentErrorsExtended;  // dito
+  if (!poolDb.isAvailable()) {  // Die if not available
     throw cms::Exception("NotAvailable") << "PoolDBOutputService not available";
   }
 
   if (globalCoordinates  // happens only if (applyDbAlignment_ == true)
       && globalCoordinates->transform() != AlignTransform::Transform::Identity) {
-    tempAlignments = new Alignments();                            // temporary storage for
-    tempAlignmentErrorsExtended = new AlignmentErrorsExtended();  // final alignments and errors
+    Alignments tempAlignments{};                            // temporary storage for
+    AlignmentErrorsExtended tempAlignmentErrorsExtended{};  // final alignments and errors
 
     GeometryAligner aligner;
     aligner.removeGlobalTransform(
-        alignments, alignmentErrors, *globalCoordinates, tempAlignments, tempAlignmentErrorsExtended);
+        alignments, alignmentErrors, *globalCoordinates, &tempAlignments, &tempAlignmentErrorsExtended);
 
     delete alignments;       // have to delete original alignments
     delete alignmentErrors;  // same thing for the errors
@@ -917,35 +915,28 @@ void AlignmentProducerBase::writeDB(Alignments* alignments,
 
   if (saveToDB_) {
     edm::LogInfo("Alignment") << "Writing Alignments for run " << time << " to " << alignRcd << ".";
-    poolDb->writeOne<Alignments>(tempAlignments, time, alignRcd);
-  } else {                  // poolDb->writeOne(..) takes over 'alignments' ownership,...
-    delete tempAlignments;  // ...otherwise we have to delete, as promised!
+    poolDb->writeOneIOV<Alignments>(tempAlignments, time, alignRcd);
   }
 
   if (saveApeToDB_) {
     edm::LogInfo("Alignment") << "Writing AlignmentErrorsExtended for run " << time << " to " << errRcd << ".";
-    poolDb->writeOne<AlignmentErrorsExtended>(tempAlignmentErrorsExtended, time, errRcd);
-  } else {                               // poolDb->writeOne(..) takes over 'alignmentErrors' ownership,...
-    delete tempAlignmentErrorsExtended;  // ...otherwise we have to delete, as promised!
+    poolDb->writeOneIOV<AlignmentErrorsExtended>(tempAlignmentErrorsExtended, time, errRcd);
   }
 }
 
 //------------------------------------------------------------------------------
-void AlignmentProducerBase::writeDB(AlignmentSurfaceDeformations* alignmentSurfaceDeformations,
+void AlignmentProducerBase::writeDB(const AlignmentSurfaceDeformations& alignmentSurfaceDeformations,
                                     const std::string& surfaceDeformationRcd,
                                     cond::Time_t time) const {
   // Call service
   edm::Service<cond::service::PoolDBOutputService> poolDb;
-  if (!poolDb.isAvailable()) {            // Die if not available
-    delete alignmentSurfaceDeformations;  // promised to take over ownership...
+  if (!poolDb.isAvailable()) {  // Die if not available
     throw cms::Exception("NotAvailable") << "PoolDBOutputService not available";
   }
 
   if (saveDeformationsToDB_) {
     edm::LogInfo("Alignment") << "Writing AlignmentSurfaceDeformations for run " << time << " to "
                               << surfaceDeformationRcd << ".";
-    poolDb->writeOne<AlignmentSurfaceDeformations>(alignmentSurfaceDeformations, time, surfaceDeformationRcd);
-  } else {                                // poolDb->writeOne(..) takes over 'surfaceDeformation' ownership,...
-    delete alignmentSurfaceDeformations;  // ...otherwise we have to delete, as promised!
+    poolDb->writeOneIOV<AlignmentSurfaceDeformations>(alignmentSurfaceDeformations, time, surfaceDeformationRcd);
   }
 }

--- a/Alignment/LaserAlignment/plugins/LaserAlignment.cc
+++ b/Alignment/LaserAlignment/plugins/LaserAlignment.cc
@@ -894,8 +894,8 @@ void LaserAlignment::endRunProduce(edm::Run& theRun, const edm::EventSetup& theS
 
   // store the estimated alignment parameters into the DB
   // first get them
-  Alignments* alignments = theAlignableTracker->alignments();
-  AlignmentErrorsExtended* alignmentErrors = theAlignableTracker->alignmentErrors();
+  Alignments alignments = *(theAlignableTracker->alignments());
+  AlignmentErrorsExtended alignmentErrors = *(theAlignableTracker->alignmentErrors());
 
   if (theStoreToDB) {
     std::cout << " [LaserAlignment::endRun] -- Storing the calculated alignment parameters to the DataBase:"
@@ -914,7 +914,7 @@ void LaserAlignment::endRunProduce(edm::Run& theRun, const edm::EventSetup& theS
     //     else {
     //       poolDbService->appendSinceTime<Alignments>( alignments, poolDbService->currentTime(), theAlignRecordName );
     //     }
-    poolDbService->writeOne<Alignments>(alignments, poolDbService->beginOfTime(), theAlignRecordName);
+    poolDbService->writeOneIOV<Alignments>(alignments, poolDbService->beginOfTime(), theAlignRecordName);
 
     //     if ( poolDbService->isNewTagRequest(theErrorRecordName) ) {
     //       poolDbService->createNewIOV<AlignmentErrorsExtended>( alignmentErrors, poolDbService->currentTime(), poolDbService->endOfTime(), theErrorRecordName );
@@ -922,7 +922,8 @@ void LaserAlignment::endRunProduce(edm::Run& theRun, const edm::EventSetup& theS
     //     else {
     //       poolDbService->appendSinceTime<AlignmentErrorsExtended>( alignmentErrors, poolDbService->currentTime(), theErrorRecordName );
     //     }
-    poolDbService->writeOne<AlignmentErrorsExtended>(alignmentErrors, poolDbService->beginOfTime(), theErrorRecordName);
+    poolDbService->writeOneIOV<AlignmentErrorsExtended>(
+        alignmentErrors, poolDbService->beginOfTime(), theErrorRecordName);
 
     std::cout << " [LaserAlignment::endRun] -- Storing done." << std::endl;
   }

--- a/Alignment/MuonAlignment/plugins/MuonMisalignedProducer.cc
+++ b/Alignment/MuonAlignment/plugins/MuonMisalignedProducer.cc
@@ -61,12 +61,12 @@ private:
   edm::ESGetToken<CSCGeometry, MuonGeometryRecord> esTokenCSC_;
   edm::ESGetToken<GEMGeometry, MuonGeometryRecord> esTokenGEM_;
 
-  Alignments* dt_Alignments;
-  AlignmentErrorsExtended* dt_AlignmentErrorsExtended;
-  Alignments* csc_Alignments;
-  AlignmentErrorsExtended* csc_AlignmentErrorsExtended;
-  Alignments* gem_Alignments;
-  AlignmentErrorsExtended* gem_AlignmentErrorsExtended;
+  Alignments dt_Alignments;
+  AlignmentErrorsExtended dt_AlignmentErrorsExtended;
+  Alignments csc_Alignments;
+  AlignmentErrorsExtended csc_AlignmentErrorsExtended;
+  Alignments gem_Alignments;
+  AlignmentErrorsExtended gem_AlignmentErrorsExtended;
 };
 
 //__________________________________________________________________________________________________
@@ -84,7 +84,7 @@ MuonMisalignedProducer::MuonMisalignedProducer(const edm::ParameterSet& p)
       esTokenGEM_(esConsumes(edm::ESInputTag("", "idealForMuonMisalignedProducer"))) {}
 
 //__________________________________________________________________________________________________
-MuonMisalignedProducer::~MuonMisalignedProducer() {}
+MuonMisalignedProducer::~MuonMisalignedProducer() = default;
 
 //__________________________________________________________________________________________________
 void MuonMisalignedProducer::analyze(const edm::Event& event, const edm::EventSetup& eventSetup) {
@@ -102,12 +102,12 @@ void MuonMisalignedProducer::analyze(const edm::Event& event, const edm::EventSe
   scenarioBuilder.applyScenario(theScenario);
 
   // Get alignments and errors
-  dt_Alignments = theAlignableMuon->dtAlignments();
-  dt_AlignmentErrorsExtended = theAlignableMuon->dtAlignmentErrorsExtended();
-  csc_Alignments = theAlignableMuon->cscAlignments();
-  csc_AlignmentErrorsExtended = theAlignableMuon->cscAlignmentErrorsExtended();
-  gem_Alignments = theAlignableMuon->gemAlignments();
-  gem_AlignmentErrorsExtended = theAlignableMuon->gemAlignmentErrorsExtended();
+  dt_Alignments = *(theAlignableMuon->dtAlignments());
+  dt_AlignmentErrorsExtended = *(theAlignableMuon->dtAlignmentErrorsExtended());
+  csc_Alignments = *(theAlignableMuon->cscAlignments());
+  csc_AlignmentErrorsExtended = *(theAlignableMuon->cscAlignmentErrorsExtended());
+  gem_Alignments = *(theAlignableMuon->gemAlignments());
+  gem_AlignmentErrorsExtended = *(theAlignableMuon->gemAlignmentErrorsExtended());
 
   // Misalign the EventSetup geometry
   /* GeometryAligner aligner;
@@ -132,17 +132,17 @@ void MuonMisalignedProducer::saveToDB(void) {
     throw cms::Exception("NotAvailable") << "PoolDBOutputService not available";
 
   // Store DT alignments and errors
-  poolDbService->writeOne<Alignments>(&(*dt_Alignments), poolDbService->beginOfTime(), theDTAlignRecordName);
-  poolDbService->writeOne<AlignmentErrorsExtended>(
-      &(*dt_AlignmentErrorsExtended), poolDbService->beginOfTime(), theDTErrorRecordName);
+  poolDbService->writeOneIOV<Alignments>(dt_Alignments, poolDbService->beginOfTime(), theDTAlignRecordName);
+  poolDbService->writeOneIOV<AlignmentErrorsExtended>(
+      dt_AlignmentErrorsExtended, poolDbService->beginOfTime(), theDTErrorRecordName);
 
   // Store CSC alignments and errors
-  poolDbService->writeOne<Alignments>(&(*csc_Alignments), poolDbService->beginOfTime(), theCSCAlignRecordName);
-  poolDbService->writeOne<AlignmentErrorsExtended>(
-      &(*csc_AlignmentErrorsExtended), poolDbService->beginOfTime(), theCSCErrorRecordName);
-  poolDbService->writeOne<Alignments>(&(*gem_Alignments), poolDbService->beginOfTime(), theGEMAlignRecordName);
-  poolDbService->writeOne<AlignmentErrorsExtended>(
-      &(*gem_AlignmentErrorsExtended), poolDbService->beginOfTime(), theGEMErrorRecordName);
+  poolDbService->writeOneIOV<Alignments>(csc_Alignments, poolDbService->beginOfTime(), theCSCAlignRecordName);
+  poolDbService->writeOneIOV<AlignmentErrorsExtended>(
+      csc_AlignmentErrorsExtended, poolDbService->beginOfTime(), theCSCErrorRecordName);
+  poolDbService->writeOneIOV<Alignments>(gem_Alignments, poolDbService->beginOfTime(), theGEMAlignRecordName);
+  poolDbService->writeOneIOV<AlignmentErrorsExtended>(
+      gem_AlignmentErrorsExtended, poolDbService->beginOfTime(), theGEMErrorRecordName);
 }
 //____________________________________________________________________________________________
 DEFINE_FWK_MODULE(MuonMisalignedProducer);

--- a/Alignment/MuonAlignment/src/MuonAlignment.cc
+++ b/Alignment/MuonAlignment/src/MuonAlignment.cc
@@ -251,8 +251,8 @@ void MuonAlignment::saveDTSurveyToDB(void) {
     throw cms::Exception("NotAvailable") << "PoolDBOutputService not available";
 
   // Get alignments and errors
-  Alignments* dtAlignments = new Alignments();
-  SurveyErrors* dtSurveyErrors = new SurveyErrors();
+  Alignments dtAlignments{};
+  SurveyErrors dtSurveyErrors{};
 
   align::Alignables alignableList;
   recursiveList(theAlignableMuon->DTBarrel(), alignableList);
@@ -268,13 +268,13 @@ void MuonAlignment::saveDTSurveyToDB(void) {
                          (*alignable)->id());
     SurveyError error((*alignable)->alignableObjectId(), (*alignable)->id(), (*alignable)->survey()->errors());
 
-    dtAlignments->m_align.push_back(value);
-    dtSurveyErrors->m_surveyErrors.push_back(error);
+    dtAlignments.m_align.push_back(value);
+    dtSurveyErrors.m_surveyErrors.push_back(error);
   }
 
   // Store DT alignments and errors
-  poolDbService->writeOne<Alignments>(&(*dtAlignments), poolDbService->currentTime(), theDTSurveyRecordName);
-  poolDbService->writeOne<SurveyErrors>(&(*dtSurveyErrors), poolDbService->currentTime(), theDTSurveyErrorRecordName);
+  poolDbService->writeOneIOV<Alignments>(dtAlignments, poolDbService->currentTime(), theDTSurveyRecordName);
+  poolDbService->writeOneIOV<SurveyErrors>(dtSurveyErrors, poolDbService->currentTime(), theDTSurveyErrorRecordName);
 }
 
 void MuonAlignment::saveCSCSurveyToDB(void) {
@@ -284,8 +284,8 @@ void MuonAlignment::saveCSCSurveyToDB(void) {
     throw cms::Exception("NotAvailable") << "PoolDBOutputService not available";
 
   // Get alignments and errors
-  Alignments* cscAlignments = new Alignments();
-  SurveyErrors* cscSurveyErrors = new SurveyErrors();
+  Alignments cscAlignments{};
+  SurveyErrors cscSurveyErrors{};
 
   align::Alignables alignableList;
   recursiveList(theAlignableMuon->CSCEndcaps(), alignableList);
@@ -301,13 +301,13 @@ void MuonAlignment::saveCSCSurveyToDB(void) {
                          (*alignable)->id());
     SurveyError error((*alignable)->alignableObjectId(), (*alignable)->id(), (*alignable)->survey()->errors());
 
-    cscAlignments->m_align.push_back(value);
-    cscSurveyErrors->m_surveyErrors.push_back(error);
+    cscAlignments.m_align.push_back(value);
+    cscSurveyErrors.m_surveyErrors.push_back(error);
   }
 
   // Store CSC alignments and errors
-  poolDbService->writeOne<Alignments>(&(*cscAlignments), poolDbService->currentTime(), theCSCSurveyRecordName);
-  poolDbService->writeOne<SurveyErrors>(&(*cscSurveyErrors), poolDbService->currentTime(), theCSCSurveyErrorRecordName);
+  poolDbService->writeOneIOV<Alignments>(cscAlignments, poolDbService->currentTime(), theCSCSurveyRecordName);
+  poolDbService->writeOneIOV<SurveyErrors>(cscSurveyErrors, poolDbService->currentTime(), theCSCSurveyErrorRecordName);
 }
 
 void MuonAlignment::saveSurveyToDB(void) {
@@ -322,13 +322,13 @@ void MuonAlignment::saveDTtoDB(void) {
     throw cms::Exception("NotAvailable") << "PoolDBOutputService not available";
 
   // Get alignments and errors
-  Alignments* dt_Alignments = theAlignableMuon->dtAlignments();
-  AlignmentErrorsExtended* dt_AlignmentErrorsExtended = theAlignableMuon->dtAlignmentErrorsExtended();
+  Alignments dt_Alignments = *(theAlignableMuon->dtAlignments());
+  AlignmentErrorsExtended dt_AlignmentErrorsExtended = *(theAlignableMuon->dtAlignmentErrorsExtended());
 
   // Store DT alignments and errors
-  poolDbService->writeOne<Alignments>(&(*dt_Alignments), poolDbService->currentTime(), theDTAlignRecordName);
-  poolDbService->writeOne<AlignmentErrorsExtended>(
-      &(*dt_AlignmentErrorsExtended), poolDbService->currentTime(), theDTErrorRecordName);
+  poolDbService->writeOneIOV<Alignments>(dt_Alignments, poolDbService->currentTime(), theDTAlignRecordName);
+  poolDbService->writeOneIOV<AlignmentErrorsExtended>(
+      dt_AlignmentErrorsExtended, poolDbService->currentTime(), theDTErrorRecordName);
 }
 
 void MuonAlignment::saveCSCtoDB(void) {
@@ -338,13 +338,13 @@ void MuonAlignment::saveCSCtoDB(void) {
     throw cms::Exception("NotAvailable") << "PoolDBOutputService not available";
 
   // Get alignments and errors
-  Alignments* csc_Alignments = theAlignableMuon->cscAlignments();
-  AlignmentErrorsExtended* csc_AlignmentErrorsExtended = theAlignableMuon->cscAlignmentErrorsExtended();
+  Alignments csc_Alignments = *(theAlignableMuon->cscAlignments());
+  AlignmentErrorsExtended csc_AlignmentErrorsExtended = *(theAlignableMuon->cscAlignmentErrorsExtended());
 
   // Store CSC alignments and errors
-  poolDbService->writeOne<Alignments>(&(*csc_Alignments), poolDbService->currentTime(), theCSCAlignRecordName);
-  poolDbService->writeOne<AlignmentErrorsExtended>(
-      &(*csc_AlignmentErrorsExtended), poolDbService->currentTime(), theCSCErrorRecordName);
+  poolDbService->writeOneIOV<Alignments>(csc_Alignments, poolDbService->currentTime(), theCSCAlignRecordName);
+  poolDbService->writeOneIOV<AlignmentErrorsExtended>(
+      csc_AlignmentErrorsExtended, poolDbService->currentTime(), theCSCErrorRecordName);
 }
 
 void MuonAlignment::saveGEMtoDB(void) {
@@ -354,13 +354,13 @@ void MuonAlignment::saveGEMtoDB(void) {
     throw cms::Exception("NotAvailable") << "PoolDBOutputService not available";
 
   // Get alignments and errors
-  Alignments* gem_Alignments = theAlignableMuon->gemAlignments();
-  AlignmentErrorsExtended* gem_AlignmentErrorsExtended = theAlignableMuon->gemAlignmentErrorsExtended();
+  Alignments gem_Alignments = *(theAlignableMuon->gemAlignments());
+  AlignmentErrorsExtended gem_AlignmentErrorsExtended = *(theAlignableMuon->gemAlignmentErrorsExtended());
 
   // Store CSC alignments and errors
-  poolDbService->writeOne<Alignments>(&(*gem_Alignments), poolDbService->currentTime(), theGEMAlignRecordName);
-  poolDbService->writeOne<AlignmentErrorsExtended>(
-      &(*gem_AlignmentErrorsExtended), poolDbService->currentTime(), theGEMErrorRecordName);
+  poolDbService->writeOneIOV<Alignments>(gem_Alignments, poolDbService->currentTime(), theGEMAlignRecordName);
+  poolDbService->writeOneIOV<AlignmentErrorsExtended>(
+      gem_AlignmentErrorsExtended, poolDbService->currentTime(), theGEMErrorRecordName);
 }
 
 void MuonAlignment::saveToDB(void) {

--- a/Alignment/OfflineValidation/plugins/TrackerGeometryCompare.cc
+++ b/Alignment/OfflineValidation/plugins/TrackerGeometryCompare.cc
@@ -261,9 +261,9 @@ void TrackerGeometryCompare::analyze(const edm::Event&, const edm::EventSetup& i
       if (!poolDbService.isAvailable())  // Die if not available
         throw cms::Exception("NotAvailable") << "PoolDBOutputService not available";
 
-      poolDbService->writeOne<Alignments>(&(*myAlignments), poolDbService->beginOfTime(), "TrackerAlignmentRcd");
-      poolDbService->writeOne<AlignmentErrorsExtended>(
-          &(*myAlignmentErrorsExtended), poolDbService->beginOfTime(), "TrackerAlignmentErrorExtendedRcd");
+      poolDbService->writeOneIOV<Alignments>(*myAlignments, poolDbService->beginOfTime(), "TrackerAlignmentRcd");
+      poolDbService->writeOneIOV<AlignmentErrorsExtended>(
+          *myAlignmentErrorsExtended, poolDbService->beginOfTime(), "TrackerAlignmentErrorExtendedRcd");
     }
 
     firstEvent_ = false;

--- a/Alignment/SurveyAnalysis/plugins/CreateSurveyRcds.cc
+++ b/Alignment/SurveyAnalysis/plugins/CreateSurveyRcds.cc
@@ -15,10 +15,6 @@
 #include "Geometry/CommonTopologies/interface/GeometryAligner.h"
 #include "CLHEP/Random/RandGauss.h"
 
-// Database
-#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
-
 CreateSurveyRcds::CreateSurveyRcds(const edm::ParameterSet& cfg)
     : tTopoToken_(esConsumes()),
       geomDetToken_(esConsumes()),

--- a/Alignment/SurveyAnalysis/plugins/SurveyDBUploader.cc
+++ b/Alignment/SurveyAnalysis/plugins/SurveyDBUploader.cc
@@ -16,19 +16,19 @@ SurveyDBUploader::SurveyDBUploader(const edm::ParameterSet& cfg)
       theErrors(nullptr) {}
 
 void SurveyDBUploader::endJob() {
-  theValues = new SurveyValues;
-  theErrors = new SurveyErrors;
+  SurveyValues theValues;
+  SurveyErrors theErrors;
 
-  theValues->m_align.reserve(65536);
-  theErrors->m_surveyErrors.reserve(65536);
+  theValues.m_align.reserve(65536);
+  theErrors.m_surveyErrors.reserve(65536);
 
   getSurveyInfo(SurveyInputBase::detector());
 
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
 
   if (poolDbService.isAvailable()) {
-    poolDbService->writeOne<SurveyValues>(theValues, poolDbService->currentTime(), theValueRcd);
-    poolDbService->writeOne<SurveyErrors>(theErrors, poolDbService->currentTime(), theErrorExtendedRcd);
+    poolDbService->writeOneIOV<SurveyValues>(theValues, poolDbService->currentTime(), theValueRcd);
+    poolDbService->writeOneIOV<SurveyErrors>(theErrors, poolDbService->currentTime(), theErrorExtendedRcd);
   } else
     throw cms::Exception("ConfigError") << "PoolDBOutputService is not available";
 }

--- a/Alignment/SurveyAnalysis/plugins/SurveyInputTrackerFromDB.cc
+++ b/Alignment/SurveyAnalysis/plugins/SurveyInputTrackerFromDB.cc
@@ -58,9 +58,9 @@ void SurveyInputTrackerFromDB::analyze(const edm::Event&, const edm::EventSetup&
     if (!poolDbService.isAvailable())  // Die if not available
       throw cms::Exception("NotAvailable") << "PoolDBOutputService not available";
 
-    poolDbService->writeOne<Alignments>(myAlignments, poolDbService->beginOfTime(), "TrackerAlignmentRcd");
-    poolDbService->writeOne<AlignmentErrorsExtended>(
-        myAlignmentErrorsExtended, poolDbService->beginOfTime(), "TrackerAlignmentErrorExtendedRcd");
+    poolDbService->writeOneIOV<Alignments>(*myAlignments, poolDbService->beginOfTime(), "TrackerAlignmentRcd");
+    poolDbService->writeOneIOV<AlignmentErrorsExtended>(
+        *myAlignmentErrorsExtended, poolDbService->beginOfTime(), "TrackerAlignmentErrorExtendedRcd");
 
     theFirstEvent = false;
   }

--- a/Alignment/TrackerAlignment/plugins/TrackerSystematicMisalignments.cc
+++ b/Alignment/TrackerAlignment/plugins/TrackerSystematicMisalignments.cc
@@ -198,8 +198,8 @@ void TrackerSystematicMisalignments::analyze(const edm::Event& event, const edm:
   applySystematicMisalignment(&(*theAlignableTracker));
 
   // -------------- writing out to alignment record --------------
-  Alignments* myAlignments = theAlignableTracker->alignments();
-  AlignmentErrorsExtended* myAlignmentErrorsExtended = theAlignableTracker->alignmentErrors();
+  Alignments myAlignments = *(theAlignableTracker->alignments());
+  AlignmentErrorsExtended myAlignmentErrorsExtended = *(theAlignableTracker->alignmentErrors());
 
   // Store alignment[Error]s to DB
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
@@ -210,9 +210,9 @@ void TrackerSystematicMisalignments::analyze(const edm::Event& event, const edm:
   if (!poolDbService.isAvailable())  // Die if not available
     throw cms::Exception("NotAvailable") << "PoolDBOutputService not available";
 
-  poolDbService->writeOne<Alignments>(&(*myAlignments), poolDbService->beginOfTime(), theAlignRecordName);
-  poolDbService->writeOne<AlignmentErrorsExtended>(
-      &(*myAlignmentErrorsExtended), poolDbService->beginOfTime(), theErrorRecordName);
+  poolDbService->writeOneIOV<Alignments>(myAlignments, poolDbService->beginOfTime(), theAlignRecordName);
+  poolDbService->writeOneIOV<AlignmentErrorsExtended>(
+      myAlignmentErrorsExtended, poolDbService->beginOfTime(), theErrorRecordName);
 }
 
 void TrackerSystematicMisalignments::applySystematicMisalignment(Alignable* ali) {

--- a/Alignment/TrackerAlignment/src/TrackerAlignment.cc
+++ b/Alignment/TrackerAlignment/src/TrackerAlignment.cc
@@ -238,8 +238,8 @@ void TrackerAlignment::saveToDB(void) {
     throw cms::Exception("NotAvailable") << "PoolDBOutputService not available";
 
   // Retrieve and store
-  Alignments* alignments = theAlignableTracker->alignments();
-  AlignmentErrorsExtended* alignmentErrors = theAlignableTracker->alignmentErrors();
+  Alignments alignments = *(theAlignableTracker->alignments());
+  AlignmentErrorsExtended alignmentErrors = *(theAlignableTracker->alignmentErrors());
 
   //   if ( poolDbService->isNewTagRequest(theAlignRecordName) )
   //     poolDbService->createNewIOV<Alignments>( alignments, poolDbService->endOfTime(),
@@ -248,7 +248,7 @@ void TrackerAlignment::saveToDB(void) {
   //     poolDbService->appendSinceTime<Alignments>( alignments, poolDbService->currentTime(),
   //                                                 theAlignRecordName );
   // In the two calls below it is assumed that the delete of "theAlignableTracker" is also deleting the two concerned payloads...
-  poolDbService->writeOneIOV<Alignments>(*alignments, poolDbService->currentTime(), theAlignRecordName);
+  poolDbService->writeOneIOV<Alignments>(alignments, poolDbService->currentTime(), theAlignRecordName);
   //   if ( poolDbService->isNewTagRequest(theErrorRecordName) )
   //     poolDbService->createNewIOV<AlignmentErrorsExtended>( alignmentErrors,
   //                                                   poolDbService->endOfTime(),
@@ -258,5 +258,5 @@ void TrackerAlignment::saveToDB(void) {
   //                                                      poolDbService->currentTime(),
   //                                                      theErrorRecordName );
   poolDbService->writeOneIOV<AlignmentErrorsExtended>(
-      *alignmentErrors, poolDbService->currentTime(), theErrorRecordName);
+      alignmentErrors, poolDbService->currentTime(), theErrorRecordName);
 }


### PR DESCRIPTION
#### PR description:

In response to https://github.com/cms-AlCaDB/AlCaTools/issues/28. 
Migrated Alignment-related codes to the usage of new `PoolDBOutputService` methods introduced at https://github.com/cms-sw/cmssw/pull/35048, by following the recommendations from this [presentation](https://indico.cern.ch/event/1088598/contributions/4580152/attachments/2333275/3976721/DBOutputService%20changes.pdf).
The relevant classes have been isolated using:
```console
git grep -l 'PoolDBOutputService' | grep Alignment | grep -E '.(cc|h)$'
```

#### PR validation:

`cmssw` compiles

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
