### PR TITLE
Migrate BeamSpot codes to new `PoolDBOutputService` methods

### DIFF
--- a/Calibration/TkAlCaRecoProducers/plugins/AlcaBeamSpotHarvester.cc
+++ b/Calibration/TkAlCaRecoProducers/plugins/AlcaBeamSpotHarvester.cc
@@ -75,30 +75,30 @@ void AlcaBeamSpotHarvester::endRun(const edm::Run &iRun, const edm::EventSetup &
 
   if (poolDbService.isAvailable()) {
     for (AlcaBeamSpotManager::bsMap_iterator it = beamSpotMap.begin(); it != beamSpotMap.end(); it++) {
-      BeamSpotObjects *aBeamSpot = new BeamSpotObjects();
-      aBeamSpot->SetType(it->second.second.type());
-      aBeamSpot->SetPosition(it->second.second.x0(), it->second.second.y0(), it->second.second.z0());
+      BeamSpotObjects aBeamSpot;
+      aBeamSpot.SetType(it->second.second.type());
+      aBeamSpot.SetPosition(it->second.second.x0(), it->second.second.y0(), it->second.second.z0());
       if (sigmaZValue_ == -1) {
-        aBeamSpot->SetSigmaZ(it->second.second.sigmaZ());
+        aBeamSpot.SetSigmaZ(it->second.second.sigmaZ());
       } else {
-        aBeamSpot->SetSigmaZ(sigmaZValue_);
+        aBeamSpot.SetSigmaZ(sigmaZValue_);
       }
-      aBeamSpot->Setdxdz(it->second.second.dxdz());
-      aBeamSpot->Setdydz(it->second.second.dydz());
-      aBeamSpot->SetBeamWidthX(it->second.second.BeamWidthX());
-      aBeamSpot->SetBeamWidthY(it->second.second.BeamWidthY());
-      aBeamSpot->SetEmittanceX(it->second.second.emittanceX());
-      aBeamSpot->SetEmittanceY(it->second.second.emittanceY());
-      aBeamSpot->SetBetaStar(it->second.second.betaStar());
+      aBeamSpot.Setdxdz(it->second.second.dxdz());
+      aBeamSpot.Setdydz(it->second.second.dydz());
+      aBeamSpot.SetBeamWidthX(it->second.second.BeamWidthX());
+      aBeamSpot.SetBeamWidthY(it->second.second.BeamWidthY());
+      aBeamSpot.SetEmittanceX(it->second.second.emittanceX());
+      aBeamSpot.SetEmittanceY(it->second.second.emittanceY());
+      aBeamSpot.SetBetaStar(it->second.second.betaStar());
 
       for (int i = 0; i < 7; ++i) {
         for (int j = 0; j < 7; ++j) {
-          aBeamSpot->SetCovariance(i, j, it->second.second.covariance(i, j));
+          aBeamSpot.SetCovariance(i, j, it->second.second.covariance(i, j));
         }
       }
 
       if (sigmaZValue_ > 0) {
-        aBeamSpot->SetCovariance(3, 3, 0.000025);
+        aBeamSpot.SetCovariance(3, 3, 0.000025);
       }
 
       cond::Time_t thisIOV = 1;
@@ -130,12 +130,7 @@ void AlcaBeamSpotHarvester::endRun(const edm::Run &iRun, const edm::EventSetup &
       }
       if (poolDbService->isNewTagRequest(outputrecordName_)) {
         edm::LogInfo("AlcaBeamSpotHarvester") << "new tag requested" << std::endl;
-        // poolDbService->createNewIOV<BeamSpotObjects>(aBeamSpot,
-        // poolDbService->beginOfTime(),poolDbService->endOfTime(),"BeamSpotObjectsRcd");
-        // poolDbService->createNewIOV<BeamSpotObjects>(aBeamSpot,
-        // poolDbService->currentTime(),
-        // poolDbService->endOfTime(),"BeamSpotObjectsRcd");
-        poolDbService->writeOne<BeamSpotObjects>(aBeamSpot, thisIOV, outputrecordName_);
+        poolDbService->writeOneIOV<BeamSpotObjects>(aBeamSpot, thisIOV, outputrecordName_);
         if (dumpTxt_ && beamSpotOutputBase_ == "lumibased") {
           beamspot::dumpBeamSpotTxt(outFile, currentBS);
 
@@ -149,9 +144,7 @@ void AlcaBeamSpotHarvester::endRun(const edm::Run &iRun, const edm::EventSetup &
         }
       } else {
         edm::LogInfo("AlcaBeamSpotHarvester") << "no new tag requested, appending IOV" << std::endl;
-        // poolDbService->appendSinceTime<BeamSpotObjects>(aBeamSpot,
-        // poolDbService->currentTime(),"BeamSpotObjectsRcd");
-        poolDbService->writeOne<BeamSpotObjects>(aBeamSpot, thisIOV, outputrecordName_);
+        poolDbService->writeOneIOV<BeamSpotObjects>(aBeamSpot, thisIOV, outputrecordName_);
         if (dumpTxt_ && beamSpotOutputBase_ == "lumibased") {
           beamspot::dumpBeamSpotTxt(outFile, currentBS);
         }

--- a/DQM/BeamMonitor/plugins/BeamMonitor.cc
+++ b/DQM/BeamMonitor/plugins/BeamMonitor.cc
@@ -1355,48 +1355,48 @@ void BeamMonitor::FitAndFill(const LuminosityBlock& lumiSeg, int& lastlumi, int&
       //     }
 
       // Create the BeamSpotOnlineObjects object
-      BeamSpotOnlineObjects* BSOnline = new BeamSpotOnlineObjects();
-      BSOnline->SetLastAnalyzedLumi(LSRange.second);
-      BSOnline->SetLastAnalyzedRun(theBeamFitter->getRunNumber());
-      BSOnline->SetLastAnalyzedFill(0);  // To be updated with correct LHC Fill number
-      BSOnline->SetPosition(bs.x0(), bs.y0(), bs.z0());
-      BSOnline->SetSigmaZ(bs.sigmaZ());
-      BSOnline->SetBeamWidthX(bs.BeamWidthX());
-      BSOnline->SetBeamWidthY(bs.BeamWidthY());
-      BSOnline->SetBeamWidthXError(bs.BeamWidthXError());
-      BSOnline->SetBeamWidthYError(bs.BeamWidthYError());
-      BSOnline->Setdxdz(bs.dxdz());
-      BSOnline->Setdydz(bs.dydz());
-      BSOnline->SetType(bs.type());
-      BSOnline->SetEmittanceX(bs.emittanceX());
-      BSOnline->SetEmittanceY(bs.emittanceY());
-      BSOnline->SetBetaStar(bs.betaStar());
+      BeamSpotOnlineObjects BSOnline;
+      BSOnline.SetLastAnalyzedLumi(LSRange.second);
+      BSOnline.SetLastAnalyzedRun(theBeamFitter->getRunNumber());
+      BSOnline.SetLastAnalyzedFill(0);  // To be updated with correct LHC Fill number
+      BSOnline.SetPosition(bs.x0(), bs.y0(), bs.z0());
+      BSOnline.SetSigmaZ(bs.sigmaZ());
+      BSOnline.SetBeamWidthX(bs.BeamWidthX());
+      BSOnline.SetBeamWidthY(bs.BeamWidthY());
+      BSOnline.SetBeamWidthXError(bs.BeamWidthXError());
+      BSOnline.SetBeamWidthYError(bs.BeamWidthYError());
+      BSOnline.Setdxdz(bs.dxdz());
+      BSOnline.Setdydz(bs.dydz());
+      BSOnline.SetType(bs.type());
+      BSOnline.SetEmittanceX(bs.emittanceX());
+      BSOnline.SetEmittanceY(bs.emittanceY());
+      BSOnline.SetBetaStar(bs.betaStar());
       for (int i = 0; i < 7; ++i) {
         for (int j = 0; j < 7; ++j) {
-          BSOnline->SetCovariance(i, j, bs.covariance(i, j));
+          BSOnline.SetCovariance(i, j, bs.covariance(i, j));
         }
       }
-      BSOnline->SetNumTracks(theBeamFitter->getNTracks());
-      BSOnline->SetNumPVs(theBeamFitter->getNPVs());
-      BSOnline->SetUsedEvents((int)DipPVInfo_[0]);
-      BSOnline->SetMeanPV(DipPVInfo_[1]);
-      BSOnline->SetMeanErrorPV(DipPVInfo_[2]);
-      BSOnline->SetRmsPV(DipPVInfo_[3]);
-      BSOnline->SetRmsErrorPV(DipPVInfo_[4]);
-      BSOnline->SetMaxPVs((int)DipPVInfo_[5]);
+      BSOnline.SetNumTracks(theBeamFitter->getNTracks());
+      BSOnline.SetNumPVs(theBeamFitter->getNPVs());
+      BSOnline.SetUsedEvents((int)DipPVInfo_[0]);
+      BSOnline.SetMeanPV(DipPVInfo_[1]);
+      BSOnline.SetMeanErrorPV(DipPVInfo_[2]);
+      BSOnline.SetRmsPV(DipPVInfo_[3]);
+      BSOnline.SetRmsErrorPV(DipPVInfo_[4]);
+      BSOnline.SetMaxPVs((int)DipPVInfo_[5]);
       auto creationTime =
           std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch())
               .count();
-      BSOnline->SetCreationTime(creationTime);
+      BSOnline.SetCreationTime(creationTime);
 
       std::pair<time_t, time_t> timeForDIP = theBeamFitter->getRefTime();
-      BSOnline->SetStartTimeStamp(timeForDIP.first);
-      BSOnline->SetStartTime(getGMTstring(timeForDIP.first));
-      BSOnline->SetEndTimeStamp(timeForDIP.second);
-      BSOnline->SetEndTime(getGMTstring(timeForDIP.second));
+      BSOnline.SetStartTimeStamp(timeForDIP.first);
+      BSOnline.SetStartTime(getGMTstring(timeForDIP.first));
+      BSOnline.SetEndTimeStamp(timeForDIP.second);
+      BSOnline.SetEndTime(getGMTstring(timeForDIP.second));
 
       edm::LogInfo("BeamMonitor") << "FitAndFill::[PayloadCreation] BeamSpotOnline object created: \n" << std::endl;
-      edm::LogInfo("BeamMonitor") << *BSOnline << std::endl;
+      edm::LogInfo("BeamMonitor") << BSOnline << std::endl;
 
       // Create the payload for BeamSpotOnlineObjects object
       if (onlineDbService_.isAvailable()) {
@@ -1414,18 +1414,18 @@ void BeamMonitor::FitAndFill(const LuminosityBlock& lumiSeg, int& lastlumi, int&
         onlineDbService_->logger().logInfo() << "\n" << bs;
         onlineDbService_->logger().logInfo()
             << "BeamMonitor::FitAndFill - [PayloadCreation] BeamSpotOnline object created:";
-        onlineDbService_->logger().logInfo() << "\n" << *BSOnline;
+        onlineDbService_->logger().logInfo() << "\n" << BSOnline;
         onlineDbService_->logger().logInfo() << "BeamMonitor - Additional parameters for DIP:";
-        onlineDbService_->logger().logInfo() << "Events used in the fit: " << BSOnline->GetUsedEvents();
-        onlineDbService_->logger().logInfo() << "Mean PV               : " << BSOnline->GetMeanPV();
-        onlineDbService_->logger().logInfo() << "Mean PV Error         : " << BSOnline->GetMeanErrorPV();
-        onlineDbService_->logger().logInfo() << "Rms PV                : " << BSOnline->GetRmsPV();
-        onlineDbService_->logger().logInfo() << "Rms PV Error          : " << BSOnline->GetRmsErrorPV();
-        onlineDbService_->logger().logInfo() << "Max PVs               : " << BSOnline->GetMaxPVs();
-        onlineDbService_->logger().logInfo() << "StartTime             : " << BSOnline->GetStartTime();
-        onlineDbService_->logger().logInfo() << "StartTimeStamp        : " << BSOnline->GetStartTimeStamp();
-        onlineDbService_->logger().logInfo() << "EndTime               : " << BSOnline->GetEndTime();
-        onlineDbService_->logger().logInfo() << "EndTimeStamp          : " << BSOnline->GetEndTimeStamp();
+        onlineDbService_->logger().logInfo() << "Events used in the fit: " << BSOnline.GetUsedEvents();
+        onlineDbService_->logger().logInfo() << "Mean PV               : " << BSOnline.GetMeanPV();
+        onlineDbService_->logger().logInfo() << "Mean PV Error         : " << BSOnline.GetMeanErrorPV();
+        onlineDbService_->logger().logInfo() << "Rms PV                : " << BSOnline.GetRmsPV();
+        onlineDbService_->logger().logInfo() << "Rms PV Error          : " << BSOnline.GetRmsErrorPV();
+        onlineDbService_->logger().logInfo() << "Max PVs               : " << BSOnline.GetMaxPVs();
+        onlineDbService_->logger().logInfo() << "StartTime             : " << BSOnline.GetStartTime();
+        onlineDbService_->logger().logInfo() << "StartTimeStamp        : " << BSOnline.GetStartTimeStamp();
+        onlineDbService_->logger().logInfo() << "EndTime               : " << BSOnline.GetEndTime();
+        onlineDbService_->logger().logInfo() << "EndTimeStamp          : " << BSOnline.GetEndTimeStamp();
         onlineDbService_->logger().logInfo() << "BeamMonitor::FitAndFill - [PayloadCreation] onlineDbService available";
         onlineDbService_->logger().logInfo()
             << "BeamMonitor::FitAndFill - [PayloadCreation] SetCreationTime: " << creationTime
@@ -1433,7 +1433,7 @@ void BeamMonitor::FitAndFill(const LuminosityBlock& lumiSeg, int& lastlumi, int&
         try {
           onlineDbService_->writeIOVForNextLumisection(BSOnline, recordName_);
           onlineDbService_->logger().logInfo()
-              << "BeamMonitor::FitAndFill - [PayloadCreation] writeForNextLumisection executed correctly";
+              << "BeamMonitor::FitAndFill - [PayloadCreation] writeIOVForNextLumisection executed correctly";
         } catch (const std::exception& e) {
           onlineDbService_->logger().logError() << "BeamMonitor - Error writing record: " << recordName_
                                                 << " for Run: " << frun << " - Lumi: " << LSRange.second;

--- a/DQM/BeamMonitor/plugins/FakeBeamMonitor.cc
+++ b/DQM/BeamMonitor/plugins/FakeBeamMonitor.cc
@@ -1384,51 +1384,48 @@ void FakeBeamMonitor::FitAndFill(const LuminosityBlock& lumiSeg, int& lastlumi, 
   //     }
 
   // Create the BeamSpotOnlineObjects object
-  BeamSpotOnlineObjects* BSOnline = new BeamSpotOnlineObjects();
-  BSOnline->SetLastAnalyzedLumi(LSRange.second);
-  BSOnline->SetLastAnalyzedRun(frun);
-  BSOnline->SetLastAnalyzedFill(0);  // To be updated with correct LHC Fill number
-  BSOnline->SetPosition(bs.x0(), bs.y0(), bs.z0());
-  BSOnline->SetSigmaZ(bs.sigmaZ());
-  BSOnline->SetBeamWidthX(bs.BeamWidthX());
-  BSOnline->SetBeamWidthY(bs.BeamWidthY());
-  BSOnline->SetBeamWidthXError(bs.BeamWidthXError());
-  BSOnline->SetBeamWidthYError(bs.BeamWidthYError());
-  BSOnline->Setdxdz(bs.dxdz());
-  BSOnline->Setdydz(bs.dydz());
-  BSOnline->SetType(bs.type());
-  BSOnline->SetEmittanceX(bs.emittanceX());
-  BSOnline->SetEmittanceY(bs.emittanceY());
-  BSOnline->SetBetaStar(bs.betaStar());
+  BeamSpotOnlineObjects BSOnline;
+  BSOnline.SetLastAnalyzedLumi(LSRange.second);
+  BSOnline.SetLastAnalyzedRun(frun);
+  BSOnline.SetLastAnalyzedFill(0);  // To be updated with correct LHC Fill number
+  BSOnline.SetPosition(bs.x0(), bs.y0(), bs.z0());
+  BSOnline.SetSigmaZ(bs.sigmaZ());
+  BSOnline.SetBeamWidthX(bs.BeamWidthX());
+  BSOnline.SetBeamWidthY(bs.BeamWidthY());
+  BSOnline.SetBeamWidthXError(bs.BeamWidthXError());
+  BSOnline.SetBeamWidthYError(bs.BeamWidthYError());
+  BSOnline.Setdxdz(bs.dxdz());
+  BSOnline.Setdydz(bs.dydz());
+  BSOnline.SetType(bs.type());
+  BSOnline.SetEmittanceX(bs.emittanceX());
+  BSOnline.SetEmittanceY(bs.emittanceY());
+  BSOnline.SetBetaStar(bs.betaStar());
   for (int i = 0; i < 7; ++i) {
     for (int j = 0; j < 7; ++j) {
-      BSOnline->SetCovariance(i, j, bs.covariance(i, j));
+      BSOnline.SetCovariance(i, j, bs.covariance(i, j));
     }
   }
-  //      BSOnline->SetNumTracks(theBeamFitter->getNTracks());
-  //      BSOnline->SetNumPVs(theBeamFitter->getNPVs());
-  BSOnline->SetNumTracks(50);
-  BSOnline->SetNumPVs(10);
-  BSOnline->SetUsedEvents((int)DipPVInfo_[0]);
-  BSOnline->SetMeanPV(DipPVInfo_[1]);
-  BSOnline->SetMeanErrorPV(DipPVInfo_[2]);
-  BSOnline->SetRmsPV(DipPVInfo_[3]);
-  BSOnline->SetRmsErrorPV(DipPVInfo_[4]);
-  BSOnline->SetMaxPVs((int)DipPVInfo_[5]);
+  BSOnline.SetNumTracks(50);
+  BSOnline.SetNumPVs(10);
+  BSOnline.SetUsedEvents((int)DipPVInfo_[0]);
+  BSOnline.SetMeanPV(DipPVInfo_[1]);
+  BSOnline.SetMeanErrorPV(DipPVInfo_[2]);
+  BSOnline.SetRmsPV(DipPVInfo_[3]);
+  BSOnline.SetRmsErrorPV(DipPVInfo_[4]);
+  BSOnline.SetMaxPVs((int)DipPVInfo_[5]);
   auto creationTime =
       std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-  BSOnline->SetCreationTime(creationTime);
+  BSOnline.SetCreationTime(creationTime);
 
   // use fake timestamps from 1970.01.01 00:00:00 to 1970.01.01 00:00:01 GMT
   std::pair<time_t, time_t> timeForDIP = std::make_pair(0, 1);
-  BSOnline->SetStartTimeStamp(timeForDIP.first);
-  BSOnline->SetStartTime(getGMTstring(timeForDIP.first));
-  BSOnline->SetEndTimeStamp(timeForDIP.second);
-  BSOnline->SetEndTime(getGMTstring(timeForDIP.second));
+  BSOnline.SetStartTimeStamp(timeForDIP.first);
+  BSOnline.SetStartTime(getGMTstring(timeForDIP.first));
+  BSOnline.SetEndTimeStamp(timeForDIP.second);
+  BSOnline.SetEndTime(getGMTstring(timeForDIP.second));
 
   edm::LogInfo("FakeBeamMonitor") << "FitAndFill::[PayloadCreation] BeamSpotOnline object created: \n" << std::endl;
-  edm::LogInfo("FakeBeamMonitor") << *BSOnline << std::endl;
-  //std::cout << "------------------> fitted BS: " << *BSOnline << std::endl;
+  edm::LogInfo("FakeBeamMonitor") << BSOnline << std::endl;
 
   // Create the payload for BeamSpotOnlineObjects object
   if (onlineDbService_.isAvailable()) {
@@ -1444,25 +1441,25 @@ void FakeBeamMonitor::FitAndFill(const LuminosityBlock& lumiSeg, int& lastlumi, 
     onlineDbService_->logger().logInfo() << "\n" << bs;
     onlineDbService_->logger().logInfo()
         << "FakeBeamMonitor::FitAndFill - [PayloadCreation] BeamSpotOnline object created:";
-    onlineDbService_->logger().logInfo() << "\n" << *BSOnline;
+    onlineDbService_->logger().logInfo() << "\n" << BSOnline;
     onlineDbService_->logger().logInfo() << "FakeBeamMonitor - Additional parameters for DIP:";
-    onlineDbService_->logger().logInfo() << "Events used in the fit: " << BSOnline->GetUsedEvents();
-    onlineDbService_->logger().logInfo() << "Mean PV               : " << BSOnline->GetMeanPV();
-    onlineDbService_->logger().logInfo() << "Mean PV Error         : " << BSOnline->GetMeanErrorPV();
-    onlineDbService_->logger().logInfo() << "Rms PV                : " << BSOnline->GetRmsPV();
-    onlineDbService_->logger().logInfo() << "Rms PV Error          : " << BSOnline->GetRmsErrorPV();
-    onlineDbService_->logger().logInfo() << "Max PVs               : " << BSOnline->GetMaxPVs();
-    onlineDbService_->logger().logInfo() << "StartTime             : " << BSOnline->GetStartTime();
-    onlineDbService_->logger().logInfo() << "StartTimeStamp        : " << BSOnline->GetStartTimeStamp();
-    onlineDbService_->logger().logInfo() << "EndTime               : " << BSOnline->GetEndTime();
-    onlineDbService_->logger().logInfo() << "EndTimeStamp          : " << BSOnline->GetEndTimeStamp();
+    onlineDbService_->logger().logInfo() << "Events used in the fit: " << BSOnline.GetUsedEvents();
+    onlineDbService_->logger().logInfo() << "Mean PV               : " << BSOnline.GetMeanPV();
+    onlineDbService_->logger().logInfo() << "Mean PV Error         : " << BSOnline.GetMeanErrorPV();
+    onlineDbService_->logger().logInfo() << "Rms PV                : " << BSOnline.GetRmsPV();
+    onlineDbService_->logger().logInfo() << "Rms PV Error          : " << BSOnline.GetRmsErrorPV();
+    onlineDbService_->logger().logInfo() << "Max PVs               : " << BSOnline.GetMaxPVs();
+    onlineDbService_->logger().logInfo() << "StartTime             : " << BSOnline.GetStartTime();
+    onlineDbService_->logger().logInfo() << "StartTimeStamp        : " << BSOnline.GetStartTimeStamp();
+    onlineDbService_->logger().logInfo() << "EndTime               : " << BSOnline.GetEndTime();
+    onlineDbService_->logger().logInfo() << "EndTimeStamp          : " << BSOnline.GetEndTimeStamp();
     onlineDbService_->logger().logInfo() << "FakeBeamMonitor::FitAndFill - [PayloadCreation] onlineDbService available";
     onlineDbService_->logger().logInfo() << "FakeBeamMonitor::FitAndFill - [PayloadCreation] SetCreationTime: "
                                          << creationTime << " [epoch in microseconds]";
     try {
       onlineDbService_->writeIOVForNextLumisection(BSOnline, recordName_);
       onlineDbService_->logger().logInfo()
-          << "FakeBeamMonitor::FitAndFill - [PayloadCreation] writeForNextLumisection executed correctly";
+          << "FakeBeamMonitor::FitAndFill - [PayloadCreation] writeIOVForNextLumisection executed correctly";
     } catch (const std::exception& e) {
       onlineDbService_->logger().logError() << "FakeBeamMonitor - Error writing record: " << recordName_
                                             << " for Run: " << frun << " - Lumi: " << LSRange.second;

--- a/RecoVertex/BeamSpotProducer/plugins/BeamSpotWrite2DB.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/BeamSpotWrite2DB.cc
@@ -97,22 +97,22 @@ void BeamSpotWrite2DB::endJob() {
   fasciiFile >> tag >> emittanceY;
   fasciiFile >> tag >> betastar;
 
-  BeamSpotObjects* abeam = new BeamSpotObjects();
+  BeamSpotObjects abeam;
 
-  abeam->SetType(type);
-  abeam->SetPosition(x, y, z);
-  abeam->SetSigmaZ(sigmaZ);
-  abeam->Setdxdz(dxdz);
-  abeam->Setdydz(dydz);
-  abeam->SetBeamWidthX(beamWidthX);
-  abeam->SetBeamWidthY(beamWidthY);
-  abeam->SetEmittanceX(emittanceX);
-  abeam->SetEmittanceY(emittanceY);
-  abeam->SetBetaStar(betastar);
+  abeam.SetType(type);
+  abeam.SetPosition(x, y, z);
+  abeam.SetSigmaZ(sigmaZ);
+  abeam.Setdxdz(dxdz);
+  abeam.Setdydz(dydz);
+  abeam.SetBeamWidthX(beamWidthX);
+  abeam.SetBeamWidthY(beamWidthY);
+  abeam.SetEmittanceX(emittanceX);
+  abeam.SetEmittanceY(emittanceY);
+  abeam.SetBetaStar(betastar);
 
   for (int i = 0; i < 7; ++i) {
     for (int j = 0; j < 7; ++j) {
-      abeam->SetCovariance(i, j, cov[i][j]);
+      abeam.SetCovariance(i, j, cov[i][j]);
     }
   }
 
@@ -123,11 +123,10 @@ void BeamSpotWrite2DB::endJob() {
     edm::LogPrint("BeamSpotWrite2DB") << "poolDBService available";
     if (poolDbService->isNewTagRequest("BeamSpotObjectsRcd")) {
       edm::LogPrint("BeamSpotWrite2DB") << "new tag requested";
-      poolDbService->createNewIOV<BeamSpotObjects>(
-          abeam, poolDbService->beginOfTime(), poolDbService->endOfTime(), "BeamSpotObjectsRcd");
+      poolDbService->createOneIOV<BeamSpotObjects>(abeam, poolDbService->beginOfTime(), "BeamSpotObjectsRcd");
     } else {
       edm::LogPrint("BeamSpotWrite2DB") << "no new tag requested";
-      poolDbService->appendSinceTime<BeamSpotObjects>(abeam, poolDbService->currentTime(), "BeamSpotObjectsRcd");
+      poolDbService->appendOneIOV<BeamSpotObjects>(abeam, poolDbService->currentTime(), "BeamSpotObjectsRcd");
     }
   }
   edm::LogPrint("BeamSpotWrite2DB") << "[BeamSpotWrite2DB] endJob done \n";

--- a/RecoVertex/BeamSpotProducer/src/BeamFitter.cc
+++ b/RecoVertex/BeamSpotProducer/src/BeamFitter.cc
@@ -744,13 +744,13 @@ void BeamFitter::dumpTxtFile(std::string &fileName, bool append) {
 }
 
 void BeamFitter::write2DB() {
-  BeamSpotObjects *pBSObjects = new BeamSpotObjects();
+  BeamSpotObjects pBSObjects;
 
-  pBSObjects->SetPosition(fbeamspot.position().X(), fbeamspot.position().Y(), fbeamspot.position().Z());
+  pBSObjects.SetPosition(fbeamspot.position().X(), fbeamspot.position().Y(), fbeamspot.position().Z());
   //std::cout << " wrote: x= " << fbeamspot.position().X() << " y= "<< fbeamspot.position().Y() << " z= " << fbeamspot.position().Z() << std::endl;
-  pBSObjects->SetSigmaZ(fbeamspot.sigmaZ());
-  pBSObjects->Setdxdz(fbeamspot.dxdz());
-  pBSObjects->Setdydz(fbeamspot.dydz());
+  pBSObjects.SetSigmaZ(fbeamspot.sigmaZ());
+  pBSObjects.Setdxdz(fbeamspot.dxdz());
+  pBSObjects.Setdydz(fbeamspot.dydz());
   //if (inputBeamWidth_ > 0 ) {
   //  std::cout << " beam width value forced to be " << inputBeamWidth_ << std::endl;
   //  pBSObjects->SetBeamWidthX(inputBeamWidth_);
@@ -758,13 +758,13 @@ void BeamFitter::write2DB() {
   //} else {
   // need to fix this
   //std::cout << " using default value, 15e-4, for beam width!!!"<<std::endl;
-  pBSObjects->SetBeamWidthX(fbeamspot.BeamWidthX());
-  pBSObjects->SetBeamWidthY(fbeamspot.BeamWidthY());
+  pBSObjects.SetBeamWidthX(fbeamspot.BeamWidthX());
+  pBSObjects.SetBeamWidthY(fbeamspot.BeamWidthY());
   //}
 
   for (int i = 0; i < 7; ++i) {
     for (int j = 0; j < 7; ++j) {
-      pBSObjects->SetCovariance(i, j, fbeamspot.covariance(i, j));
+      pBSObjects.SetCovariance(i, j, fbeamspot.covariance(i, j));
     }
   }
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
@@ -772,11 +772,10 @@ void BeamFitter::write2DB() {
     std::cout << "poolDBService available" << std::endl;
     if (poolDbService->isNewTagRequest("BeamSpotObjectsRcd")) {
       std::cout << "new tag requested" << std::endl;
-      poolDbService->createNewIOV<BeamSpotObjects>(
-          pBSObjects, poolDbService->beginOfTime(), poolDbService->endOfTime(), "BeamSpotObjectsRcd");
+      poolDbService->createOneIOV<BeamSpotObjects>(pBSObjects, poolDbService->beginOfTime(), "BeamSpotObjectsRcd");
     } else {
       std::cout << "no new tag requested" << std::endl;
-      poolDbService->appendSinceTime<BeamSpotObjects>(pBSObjects, poolDbService->currentTime(), "BeamSpotObjectsRcd");
+      poolDbService->appendOneIOV<BeamSpotObjects>(pBSObjects, poolDbService->currentTime(), "BeamSpotObjectsRcd");
     }
   }
 }


### PR DESCRIPTION
#### PR description:
Part of cms-AlCaDB/AlCaTools#28
Updates to BeamSpot-related codes to:
 - Create objects on stack (as suggested in [this slide](https://indico.cern.ch/event/1088598/contributions/4580152/attachments/2333275/3976721/DBOutputService%20changes.pdf#page=5&zoom=page-fit,-232,595) by @ggovi)
 - Use `writeOneIOV` instead of `writeOne`
 - Use `appendOneIOV` instead of `appendSinceTime`


#### PR validation:
Code compiles

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
N/A

FYI: @dzuolo @mmusich