### PR TITLE
Delete stream modules before deleting their caches

### DIFF
--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptor.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptor.h
@@ -65,7 +65,7 @@ namespace edm {
       }
       EDAnalyzerAdaptor(const EDAnalyzerAdaptor&) = delete;                   // stop default
       const EDAnalyzerAdaptor& operator=(const EDAnalyzerAdaptor&) = delete;  // stop default
-      ~EDAnalyzerAdaptor() override {}
+      ~EDAnalyzerAdaptor() override { deleteModulesEarly(); }
 
       static void fillDescriptions(ConfigurationDescriptions& descriptions) { T::fillDescriptions(descriptions); }
       static void prevalidate(ConfigurationDescriptions& descriptions) { T::prevalidate(descriptions); }

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
@@ -126,6 +126,8 @@ namespace edm {
 
       std::vector<ConsumesInfo> consumesInfo() const;
 
+      void deleteModulesEarly();
+
     private:
       bool doEvent(EventTransitionInfo const&, ActivityRegistry*, ModuleCallingContext const*);
       void doPreallocate(PreallocationConfiguration const&);

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptor.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptor.h
@@ -53,7 +53,7 @@ namespace edm {
       }
       ProducingModuleAdaptor(const ProducingModuleAdaptor&) = delete;                   // stop default
       const ProducingModuleAdaptor& operator=(const ProducingModuleAdaptor&) = delete;  // stop default
-      ~ProducingModuleAdaptor() override {}
+      ~ProducingModuleAdaptor() override { this->deleteModulesEarly(); }
 
       static void fillDescriptions(ConfigurationDescriptions& descriptions) { T::fillDescriptions(descriptions); }
       static void prevalidate(ConfigurationDescriptions& descriptions) { T::prevalidate(descriptions); }

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
@@ -149,6 +149,8 @@ namespace edm {
 
       const ProducerBase* producer() { return m_streamModules[0]; }
 
+      void deleteModulesEarly();
+
     private:
       void doPreallocate(PreallocationConfiguration const&);
       virtual void preallocLumis(unsigned int) {}

--- a/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
@@ -54,6 +54,13 @@ EDAnalyzerAdaptorBase::~EDAnalyzerAdaptorBase() {
   }
 }
 
+void EDAnalyzerAdaptorBase::deleteModulesEarly() {
+  for (auto m : m_streamModules) {
+    delete m;
+  }
+  m_streamModules.clear();
+}
+
 //
 // assignment operators
 //

--- a/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
@@ -47,6 +47,14 @@ namespace edm {
       }
     }
 
+    template <typename T>
+    void ProducingModuleAdaptorBase<T>::deleteModulesEarly() {
+      for (auto m : m_streamModules) {
+        delete m;
+      }
+      m_streamModules.clear();
+    }
+
     //
     // member functions
     //


### PR DESCRIPTION
#### PR description:

It is now safe to access the various caches during a stream module's destructor.

#### PR validation:

Framework unit tests all pass.

fixes #36070