### PR TITLE
[PPS][NanoAOD] Generator-level proton information

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/GenProtonTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenProtonTableProducer.cc
@@ -45,7 +45,9 @@ GenProtonTableProducer::GenProtonTableProducer(const edm::ParameterSet& iConfig)
       puCandsToken_(consumes<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("srcPUProtons"))),
       protonsCut_(iConfig.getParameter<std::string>("cut")),
       table_name_(iConfig.getParameter<std::string>("name")),
-      tolerance_(iConfig.getParameter<double>("tolerance")) {}
+      tolerance_(iConfig.getParameter<double>("tolerance")) {
+  produces<nanoaod::FlatTable>();
+}
 
 void GenProtonTableProducer::produce(edm::Event& iEvent, const edm::EventSetup&) {
   // define the variables
@@ -94,7 +96,7 @@ void GenProtonTableProducer::fillDescriptions(edm::ConfigurationDescriptions& de
       ->setComment("input source for pruned gen-level particle candidates");
   desc.add<edm::InputTag>("srcPUProtons", edm::InputTag())->setComment("input source for pileup protons collection");
   desc.add<std::string>("cut", "")->setComment("proton kinematic selection");
-  desc.add<std::string>("name", "GenProtons")->setComment("flat table name");
+  desc.add<std::string>("name", "GenProton")->setComment("flat table name");
   desc.add<double>("tolerance", 1.e-3)
       ->setComment("relative difference between the signal and pileup protons pt and pz");
   descriptions.add("genProtonTable", desc);

--- a/PhysicsTools/NanoAOD/plugins/GenProtonTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenProtonTableProducer.cc
@@ -103,8 +103,7 @@ void GenProtonTableProducer::fillDescriptions(edm::ConfigurationDescriptions& de
   desc.add<std::string>("name", "GenProton")->setComment("flat table name");
   desc.add<std::string>("doc", "generator level information on (signal+PU) protons")
       ->setComment("flat table description");
-  desc.add<double>("tolerance", 1.e-3)
-      ->setComment("relative difference between the signal and pileup protons pt and pz");
+  desc.add<double>("tolerance", 1.e-3)->setComment("relative difference between the signal and pileup protons momenta");
   descriptions.add("genProtonTable", desc);
 }
 

--- a/PhysicsTools/NanoAOD/plugins/GenProtonTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenProtonTableProducer.cc
@@ -97,6 +97,8 @@ void GenProtonTableProducer::fillDescriptions(edm::ConfigurationDescriptions& de
       ->setComment("input source for pileup protons collection");
   desc.add<std::string>("cut", "")->setComment("proton kinematic selection");
   desc.add<std::string>("name", "GenProton")->setComment("flat table name");
+  desc.add<std::string>("doc", "generator level information on (signal+PU) protons")
+      ->setComment("flat table description");
   desc.add<double>("tolerance", 1.e-3)
       ->setComment("relative difference between the signal and pileup protons pt and pz");
   descriptions.add("genProtonTable", desc);

--- a/PhysicsTools/NanoAOD/plugins/GenProtonTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenProtonTableProducer.cc
@@ -1,0 +1,87 @@
+/****************************************************************************
+ *
+ * This is a part of PPS offline software.
+ * Authors:
+ *   Laurent Forthomme
+ *   Michael Pitt
+ *
+ ****************************************************************************/
+
+#include <memory>
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticleFwd.h"
+
+#include "DataFormats/NanoAOD/interface/FlatTable.h"
+
+class GenProtonTableProducer : public edm::stream::EDProducer<> {
+public:
+  explicit GenProtonTableProducer(const edm::ParameterSet&);
+  ~GenProtonTableProducer() override = default;
+
+private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
+  const edm::EDGetTokenT<reco::GenParticleCollection> prunedCandsToken_;
+  const edm::EDGetTokenT<reco::GenParticleCollection> puCandsToken_;
+  const StringCutObjectSelector<reco::Candidate> protonsCut_;
+  const std::string table_name_;
+  const double tolerance_;
+};
+
+GenProtonTableProducer::GenProtonTableProducer(const edm::ParameterSet& iConfig)
+    : prunedCandsToken_(consumes<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("srcPruned"))),
+      puCandsToken_(consumes<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("srcPUProtons"))),
+      protonsCut_(iConfig.getParameter<std::string>("cut")),
+      table_name_(iConfig.getParameter<std::string>("name")),
+      tolerance_(iConfig.getParameter<double>("tolerance")) {}
+
+void GenProtonTableProducer::produce(edm::Event& iEvent, const edm::EventSetup&) {
+  // define the variables
+  std::vector<float> pts, pzs, vzs;
+  std::vector<int> isPUs;
+  // first loop over signal protons
+  for (const auto& pruned_cand : iEvent.get(prunedCandsToken_)) {
+    if (!protonsCut_(pruned_cand))
+      continue;
+    pts.emplace_back(pruned_cand.pt());
+    pzs.emplace_back(pruned_cand.pz());
+    vzs.emplace_back(pruned_cand.vz());
+    isPUs.emplace_back(false);
+  }
+  // then loop over pruned candidates ; if already in signal protons, discard
+  for (const auto& pu_cand : iEvent.get(puCandsToken_)) {
+    if (!protonsCut_(pu_cand))
+      continue;
+    bool associated{false};
+    for (size_t i = 0; i < pts.size(); ++i) {
+      if (fabs(1. - pts.at(i) / pu_cand.pt()) < tolerance_ && fabs(1. - pzs.at(i) / pu_cand.pz()) < tolerance_) {
+        associated = true;
+        break;
+      }
+    }
+    if (associated)
+      continue;
+    pts.emplace_back(pu_cand.pt());
+    pzs.emplace_back(pu_cand.pz());
+    vzs.emplace_back(pu_cand.vz());
+    isPUs.emplace_back(true);
+  }
+
+  auto protons_table = std::make_unique<nanoaod::FlatTable>(isPUs.size(), table_name_, false);
+  protons_table->addColumn<float>("pt", pts, "proton transverse momentum", nanoaod::FlatTable::FloatColumn, 10);
+  protons_table->addColumn<float>("pz", pzs, "proton longitudinal momentum", nanoaod::FlatTable::FloatColumn, 10);
+  protons_table->addColumn<float>(
+      "vz", vzs, "proton vertex longitudinal coordinate", nanoaod::FlatTable::FloatColumn, 10);
+  protons_table->addColumn<int>("isPU", isPUs, "pileup proton?", nanoaod::FlatTable::IntColumn, 10);
+  iEvent.put(std::move(protons_table));
+}

--- a/PhysicsTools/NanoAOD/plugins/GenProtonTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenProtonTableProducer.cc
@@ -92,9 +92,10 @@ void GenProtonTableProducer::produce(edm::Event& iEvent, const edm::EventSetup&)
 
 void GenProtonTableProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("srcPruned", edm::InputTag())
+  desc.add<edm::InputTag>("srcPruned", edm::InputTag("prunedGenParticles"))
       ->setComment("input source for pruned gen-level particle candidates");
-  desc.add<edm::InputTag>("srcPUProtons", edm::InputTag())->setComment("input source for pileup protons collection");
+  desc.add<edm::InputTag>("srcPUProtons", edm::InputTag("genPUProtons"))
+      ->setComment("input source for pileup protons collection");
   desc.add<std::string>("cut", "")->setComment("proton kinematic selection");
   desc.add<std::string>("name", "GenProton")->setComment("flat table name");
   desc.add<double>("tolerance", 1.e-3)

--- a/PhysicsTools/NanoAOD/plugins/GenProtonTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenProtonTableProducer.cc
@@ -38,6 +38,7 @@ private:
   const StringCutObjectSelector<reco::Candidate> protonsCut_;
   const std::string table_name_;
   const double tolerance_;
+  bool use_alt_coll_{false};  ///< Are we using premix/mix collection name for PU protons?
 };
 
 GenProtonTableProducer::GenProtonTableProducer(const edm::ParameterSet& iConfig)
@@ -66,8 +67,8 @@ void GenProtonTableProducer::produce(edm::Event& iEvent, const edm::EventSetup&)
   }
   // then loop over pruned candidates ; if already in signal protons, discard
   edm::Handle<reco::GenParticleCollection> hPUCands;
-  if (!iEvent.getByToken(puCandsToken_, hPUCands))
-    iEvent.getByToken(puAltCandsToken_, hPUCands);
+  if (use_alt_coll_ || !iEvent.getByToken(puCandsToken_, hPUCands))
+    use_alt_coll_ = iEvent.getByToken(puAltCandsToken_, hPUCands);
   for (const auto& pu_cand : *hPUCands) {
     if (!protonsCut_(pu_cand))
       continue;

--- a/PhysicsTools/NanoAOD/plugins/GenProtonTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenProtonTableProducer.cc
@@ -28,6 +28,8 @@ public:
   explicit GenProtonTableProducer(const edm::ParameterSet&);
   ~GenProtonTableProducer() override = default;
 
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+
 private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
@@ -85,3 +87,17 @@ void GenProtonTableProducer::produce(edm::Event& iEvent, const edm::EventSetup&)
   protons_table->addColumn<int>("isPU", isPUs, "pileup proton?", nanoaod::FlatTable::IntColumn, 10);
   iEvent.put(std::move(protons_table));
 }
+
+void GenProtonTableProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("srcPruned", edm::InputTag())
+      ->setComment("input source for pruned gen-level particle candidates");
+  desc.add<edm::InputTag>("srcPUProtons", edm::InputTag())->setComment("input source for pileup protons collection");
+  desc.add<std::string>("cut", "")->setComment("proton kinematic selection");
+  desc.add<std::string>("name", "GenProtons")->setComment("flat table name");
+  desc.add<double>("tolerance", 1.e-3)
+      ->setComment("relative difference between the signal and pileup protons pt and pz");
+  descriptions.add("genProtonTable", desc);
+}
+
+DEFINE_FWK_MODULE(GenProtonTableProducer);

--- a/PhysicsTools/NanoAOD/plugins/GenProtonTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenProtonTableProducer.cc
@@ -90,10 +90,10 @@ void GenProtonTableProducer::produce(edm::Event& iEvent, const edm::EventSetup&)
   }
 
   auto protons_table = std::make_unique<nanoaod::FlatTable>(isPUs.size(), table_name_, false);
-  protons_table->addColumn<float>("px", pxs, "proton horizontal momentum");
-  protons_table->addColumn<float>("py", pys, "proton vertical momentum");
-  protons_table->addColumn<float>("pz", pzs, "proton longitudinal momentum");
-  protons_table->addColumn<float>("vz", vzs, "proton vertex longitudinal coordinate");
+  protons_table->addColumn<float>("px", pxs, "proton horizontal momentum", 8);
+  protons_table->addColumn<float>("py", pys, "proton vertical momentum", 8);
+  protons_table->addColumn<float>("pz", pzs, "proton longitudinal momentum", 8);
+  protons_table->addColumn<float>("vz", vzs, "proton vertex longitudinal coordinate", 8);
   protons_table->addColumn<bool>("isPU", isPUs, "pileup proton?");
   iEvent.put(std::move(protons_table));
 }

--- a/PhysicsTools/NanoAOD/plugins/GenProtonTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenProtonTableProducer.cc
@@ -34,7 +34,7 @@ private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
   const edm::EDGetTokenT<reco::GenParticleCollection> prunedCandsToken_;
-  const edm::EDGetTokenT<reco::GenParticleCollection> puCandsToken_;
+  const edm::EDGetTokenT<reco::GenParticleCollection> puCandsToken_, puAltCandsToken_;
   const StringCutObjectSelector<reco::Candidate> protonsCut_;
   const std::string table_name_;
   const double tolerance_;
@@ -42,7 +42,8 @@ private:
 
 GenProtonTableProducer::GenProtonTableProducer(const edm::ParameterSet& iConfig)
     : prunedCandsToken_(consumes<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("srcPruned"))),
-      puCandsToken_(consumes<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("srcPUProtons"))),
+      puCandsToken_(mayConsume<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("srcPUProtons"))),
+      puAltCandsToken_(mayConsume<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("srcAltPUProtons"))),
       protonsCut_(iConfig.getParameter<std::string>("cut")),
       table_name_(iConfig.getParameter<std::string>("name")),
       tolerance_(iConfig.getParameter<double>("tolerance")) {
@@ -99,6 +100,8 @@ void GenProtonTableProducer::fillDescriptions(edm::ConfigurationDescriptions& de
       ->setComment("input source for pruned gen-level particle candidates");
   desc.add<edm::InputTag>("srcPUProtons", edm::InputTag("genPUProtons"))
       ->setComment("input source for pileup protons collection");
+  desc.add<edm::InputTag>("srcAltPUProtons", edm::InputTag("genPUProtons", "genPUProtons"))
+      ->setComment("alternative input source for pileup protons collection (for premix-mix backward compatibility)");
   desc.add<std::string>("cut", "")->setComment("proton kinematic selection");
   desc.add<std::string>("name", "GenProton")->setComment("flat table name");
   desc.add<std::string>("doc", "generator level information on (signal+PU) protons")

--- a/PhysicsTools/NanoAOD/plugins/GenProtonTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenProtonTableProducer.cc
@@ -65,7 +65,10 @@ void GenProtonTableProducer::produce(edm::Event& iEvent, const edm::EventSetup&)
     isPUs.emplace_back(false);
   }
   // then loop over pruned candidates ; if already in signal protons, discard
-  for (const auto& pu_cand : iEvent.get(puCandsToken_)) {
+  edm::Handle<reco::GenParticleCollection> hPUCands;
+  if (!iEvent.getByToken(puCandsToken_, hPUCands))
+    iEvent.getByToken(puAltCandsToken_, hPUCands);
+  for (const auto& pu_cand : *hPUCands) {
     if (!protonsCut_(pu_cand))
       continue;
     bool associated{false};

--- a/PhysicsTools/NanoAOD/plugins/GenProtonTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenProtonTableProducer.cc
@@ -52,7 +52,7 @@ GenProtonTableProducer::GenProtonTableProducer(const edm::ParameterSet& iConfig)
 void GenProtonTableProducer::produce(edm::Event& iEvent, const edm::EventSetup&) {
   // define the variables
   std::vector<float> pts, pzs, vzs;
-  std::vector<int> isPUs;
+  std::vector<bool> isPUs;
   // first loop over signal protons
   for (const auto& pruned_cand : iEvent.get(prunedCandsToken_)) {
     if (!protonsCut_(pruned_cand))
@@ -85,7 +85,7 @@ void GenProtonTableProducer::produce(edm::Event& iEvent, const edm::EventSetup&)
   protons_table->addColumn<float>("pt", pts, "proton transverse momentum");
   protons_table->addColumn<float>("pz", pzs, "proton longitudinal momentum");
   protons_table->addColumn<float>("vz", vzs, "proton vertex longitudinal coordinate");
-  protons_table->addColumn<int>("isPU", isPUs, "pileup proton?");
+  protons_table->addColumn<bool>("isPU", isPUs, "pileup proton?");
   iEvent.put(std::move(protons_table));
 }
 

--- a/PhysicsTools/NanoAOD/plugins/GenProtonTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenProtonTableProducer.cc
@@ -82,11 +82,10 @@ void GenProtonTableProducer::produce(edm::Event& iEvent, const edm::EventSetup&)
   }
 
   auto protons_table = std::make_unique<nanoaod::FlatTable>(isPUs.size(), table_name_, false);
-  protons_table->addColumn<float>("pt", pts, "proton transverse momentum", nanoaod::FlatTable::FloatColumn, 10);
-  protons_table->addColumn<float>("pz", pzs, "proton longitudinal momentum", nanoaod::FlatTable::FloatColumn, 10);
-  protons_table->addColumn<float>(
-      "vz", vzs, "proton vertex longitudinal coordinate", nanoaod::FlatTable::FloatColumn, 10);
-  protons_table->addColumn<int>("isPU", isPUs, "pileup proton?", nanoaod::FlatTable::IntColumn, 10);
+  protons_table->addColumn<float>("pt", pts, "proton transverse momentum");
+  protons_table->addColumn<float>("pz", pzs, "proton longitudinal momentum");
+  protons_table->addColumn<float>("vz", vzs, "proton vertex longitudinal coordinate");
+  protons_table->addColumn<int>("isPU", isPUs, "pileup proton?");
   iEvent.put(std::move(protons_table));
 }
 

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -82,7 +82,7 @@ nanoSequence = cms.Sequence(nanoSequenceCommon + nanoSequenceOnlyData + nanoSequ
 nanoTableTaskFS = cms.Task(genParticleTask, particleLevelTask, jetMCTask, muonMCTask, electronMCTask, lowPtElectronMCTask, photonMCTask,
                             tauMCTask, boostedTauMCTask,
                             metMCTable, ttbarCatMCProducersTask, globalTablesMCTask, cms.Task(btagWeightTable), ttbarCategoryTableTask,
-                            genWeightsTableTask, genVertexTablesTask, genParticleTablesTask, particleLevelTablesTask)
+                            genWeightsTableTask, genVertexTablesTask, genParticleTablesTask, genProtonTablesTask, particleLevelTablesTask)
 
 nanoSequenceFS = cms.Sequence(nanoSequenceCommon + cms.Sequence(nanoTableTaskFS))
 
@@ -105,7 +105,7 @@ def nanoAOD_addTauIds(process):
 
 def nanoAOD_addBoostedTauIds(process):
     updatedBoostedTauName = "slimmedTausBoostedNewID"
-    boostedTauIdEmbedder = tauIdConfig.TauIDEmbedder(process, debug=False, 
+    boostedTauIdEmbedder = tauIdConfig.TauIDEmbedder(process, debug=False,
                                                      originalTauName = "slimmedTausBoosted",
                                                      updatedTauName = updatedBoostedTauName,
                                                      postfix="Boosted",
@@ -118,7 +118,7 @@ def nanoAOD_addBoostedTauIds(process):
     process.boostedTauTask = _boostedTauTask.copy()
 
     return process
- 
+
 
 from PhysicsTools.PatAlgos.tools.jetTools import updateJetCollection
 def nanoAOD_addDeepInfo(process,addDeepBTag,addDeepFlavour):
@@ -202,7 +202,7 @@ def nanoAOD_recalibrateMETs(process,isData):
         process.patJetsPuppi.addGenJetMatch = cms.bool(False)
 
         print("nanoAOD_PuppiV15_switch.reclusterJets is true")
-    
+
     runMetCorAndUncFromMiniAOD(process,isData=isData,metType="Puppi",postfix="Puppi",jetFlavor="AK4PFPuppi", recoMetFromPFCs=bool(nanoAOD_PuppiV15_switch.recoMetFromPFCs), reclusterJets=bool(nanoAOD_PuppiV15_switch.reclusterJets))
     process.nanoSequenceCommon.insert(2,cms.Sequence(process.puppiMETSequence+process.fullPatMetSequencePuppi))
 
@@ -393,10 +393,10 @@ def nanoAOD_customizeMC(process):
         modifier.toModify(process, lambda p: nanoAOD_runMETfixEE2017(p,isData=False))
     return process
 
-###increasing the precision of selected GenParticles.                                                                                                 
+###increasing the precision of selected GenParticles.
 def nanoWmassGenCustomize(process):
     pdgSelection="?(abs(pdgId) == 11|| abs(pdgId)==13 || abs(pdgId)==15 ||abs(pdgId)== 12 || abs(pdgId)== 14 || abs(pdgId)== 16|| abs(pdgId)== 24|| pdgId== 23)"
-    # Keep precision same as default RECO for selected particles                                                                                       
+    # Keep precision same as default RECO for selected particles
     ptPrecision="{}?{}:{}".format(pdgSelection, CandVars.pt.precision.value(),genParticleTable.variables.pt.precision.value())
     process.genParticleTable.variables.pt.precision=cms.string(ptPrecision)
     phiPrecision="{} ? {} : {}".format(pdgSelection, CandVars.phi.precision.value(), genParticleTable.variables.phi.precision.value())

--- a/PhysicsTools/NanoAOD/python/protons_cff.py
+++ b/PhysicsTools/NanoAOD/python/protons_cff.py
@@ -64,7 +64,7 @@ singleRPTable = cms.EDProducer("SimpleProtonTrackFlatTableProducer",
     ),
 )
 
-protonTablesTask = cms.Task(filteredProtons, genProtonTable, multiRPTable)
+protonTablesTask = cms.Task(filteredProtons,protonTable,multiRPTable)
 if singleRPProtons: protonTablesTask.add(singleRPTable)
 
 genProtonTablesTask = cms.Task(genProtonTable)

--- a/PhysicsTools/NanoAOD/python/protons_cff.py
+++ b/PhysicsTools/NanoAOD/python/protons_cff.py
@@ -73,8 +73,7 @@ genProtonTablesTask = cms.Task(genProtonTable)
 
 # input GEN-level PU protons collection introduced in 9_4_X cycle
 run2_miniAOD_80XLegacy.toReplaceWith(genProtonTablesTask, cms.Task())
-# re-MiniAODv2 appears to have this extra label
-(run2_nanoAOD_94XMiniAODv1 | run2_nanoAOD_94XMiniAODv2).toModify(genProtonTable,
-    # PU protons source could have an extra 'genPUProtons' collection name for some samples
+# PU protons tag could have an extra 'genPUProtons' collection name for some eras
+run2_nanoAOD_94XMiniAODv2.toModify(genProtonTable,
     srcPUProtons = cms.InputTag('genPUProtons', 'genPUProtons')
 )

--- a/PhysicsTools/NanoAOD/python/protons_cff.py
+++ b/PhysicsTools/NanoAOD/python/protons_cff.py
@@ -20,12 +20,6 @@ protonTable = cms.EDProducer("ProtonProducer",
 protonTable.tagRecoProtonsSingle = cms.InputTag("filteredProtons" if singleRPProtons else "ctppsProtons","singleRP")
 
 
-genProtonTable = _genproton.clone(
-    cut = cms.string('(pdgId == 2212) && (abs(pz) > 5200) && (abs(pz) < 6467.5)'), # xi in [0.015, 0.2]
-    # PU protons source could have an extra 'genPUProtons' collection name for some samples
-    # srcPUProtons = cms.InputTag('genPUProtons', 'genPUProtons'),
-)
-
 multiRPTable = cms.EDProducer("SimpleProtonTrackFlatTableProducer",
     src = cms.InputTag("filteredProtons","multiRP"),
     cut = cms.string(""),
@@ -71,7 +65,16 @@ for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_
     modifier.toReplaceWith(protonTablesTask, cms.Task())
 
 # GEN-level signal/PU protons collection
+genProtonTable = _genproton.clone(
+    cut = cms.string('(pdgId == 2212) && (abs(pz) > 5200) && (abs(pz) < 6467.5)') # xi in [0.015, 0.2]
+)
+
 genProtonTablesTask = cms.Task(genProtonTable)
 
 # input GEN-level PU protons collection introduced in 9_4_X cycle
 run2_miniAOD_80XLegacy.toReplaceWith(genProtonTablesTask, cms.Task())
+# re-MiniAODv2 appears to have this extra label
+(run2_nanoAOD_94XMiniAODv1 | run2_nanoAOD_94XMiniAODv2).toModify(genProtonTable,
+    # PU protons source could have an extra 'genPUProtons' collection name for some samples
+    srcPUProtons = cms.InputTag('genPUProtons', 'genPUProtons')
+)

--- a/PhysicsTools/NanoAOD/python/protons_cff.py
+++ b/PhysicsTools/NanoAOD/python/protons_cff.py
@@ -22,7 +22,8 @@ protonTable.tagRecoProtonsSingle = cms.InputTag("filteredProtons" if singleRPPro
 
 genProtonTable = _genproton.clone(
     srcPruned = cms.InputTag('prunedGenParticles'),
-    srcPUProtons = cms.InputTag('genPUProtons'), #FIXME could have an extra 'genPUProtons' collection name for some samples
+    #srcPUProtons = cms.InputTag('genPUProtons'), #FIXME could have an extra 'genPUProtons' collection name for some samples
+    srcPUProtons = cms.InputTag('genPUProtons', 'genPUProtons'),
     cut = cms.string('(pdgId == 2212) && (abs(pz) > 5200) && (abs(pz) < 6467.5)'), # xi in [0.015, 0.2]
 )
 

--- a/PhysicsTools/NanoAOD/python/protons_cff.py
+++ b/PhysicsTools/NanoAOD/python/protons_cff.py
@@ -61,9 +61,6 @@ singleRPTable = cms.EDProducer("SimpleProtonTrackFlatTableProducer",
 protonTablesTask = cms.Task(filteredProtons,protonTable,multiRPTable)
 if singleRPProtons: protonTablesTask.add(singleRPTable)
 
-for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2, run2_nanoAOD_94X2016, run2_nanoAOD_102Xv1:
-    modifier.toReplaceWith(protonTablesTask, cms.Task())
-
 # GEN-level signal/PU protons collection
 genProtonTable = _genproton.clone(
     cut = cms.string('(pdgId == 2212) && (abs(pz) > 5200) && (abs(pz) < 6467.5)') # xi in [0.015, 0.2]
@@ -71,5 +68,7 @@ genProtonTable = _genproton.clone(
 
 genProtonTablesTask = cms.Task(genProtonTable)
 
-# input GEN-level PU protons collection introduced after 9_4_X cycle
-(run2_miniAOD_80XLegacy | run2_nanoAOD_94XMiniAODv1 | run2_nanoAOD_94XMiniAODv2).toReplaceWith(genProtonTablesTask, cms.Task())
+for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2, run2_nanoAOD_94X2016, run2_nanoAOD_102Xv1:
+    modifier.toReplaceWith(protonTablesTask, cms.Task())
+    # input GEN-level PU protons collection only introduced for UL and 12_X_Y
+    modifier.toReplaceWith(genProtonTablesTask, cms.Task())

--- a/PhysicsTools/NanoAOD/python/protons_cff.py
+++ b/PhysicsTools/NanoAOD/python/protons_cff.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from PhysicsTools.NanoAOD.common_cff import *
+from PhysicsTools.NanoAOD.genProtonTable_cfi import genProtonTable as _genproton
 from PhysicsTools.NanoAOD.nano_eras_cff import *
 from RecoPPS.ProtonReconstruction.ppsFilteredProtonProducer_cfi import *
 
@@ -18,6 +19,12 @@ protonTable = cms.EDProducer("ProtonProducer",
 )
 protonTable.tagRecoProtonsSingle = cms.InputTag("filteredProtons" if singleRPProtons else "ctppsProtons","singleRP")
 
+
+genProtonTable = _genproton.clone(
+    srcPruned = cms.InputTag('prunedGenParticles'),
+    srcPUProtons = cms.InputTag('genPUProtons'), #FIXME could have an extra 'genPUProtons' collection name for some samples
+    cut = cms.string('(pdgId == 2212) && (abs(pz) > 5200) && (abs(pz) < 6467.5)'), # xi in [0.015, 0.2]
+)
 
 multiRPTable = cms.EDProducer("SimpleProtonTrackFlatTableProducer",
     src = cms.InputTag("filteredProtons","multiRP"),
@@ -53,11 +60,11 @@ singleRPTable = cms.EDProducer("SimpleProtonTrackFlatTableProducer",
         thetaY = Var("thetaY",float,doc="th y",precision=10),
     ),
     externalVariables = cms.PSet(
-        decRPId = ExtVar("protonTable:protonRPId",int,doc="Detector ID",precision=8), 
+        decRPId = ExtVar("protonTable:protonRPId",int,doc="Detector ID",precision=8),
     ),
 )
 
-protonTablesTask = cms.Task(filteredProtons,protonTable,multiRPTable)
+protonTablesTask = cms.Task(filteredProtons, genProtonTable, protonTable, multiRPTable)
 if singleRPProtons: protonTablesTask.add(singleRPTable)
 
 for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2, run2_nanoAOD_94X2016, run2_nanoAOD_102Xv1:

--- a/PhysicsTools/NanoAOD/python/protons_cff.py
+++ b/PhysicsTools/NanoAOD/python/protons_cff.py
@@ -64,8 +64,10 @@ singleRPTable = cms.EDProducer("SimpleProtonTrackFlatTableProducer",
     ),
 )
 
-protonTablesTask = cms.Task(filteredProtons, genProtonTable, protonTable, multiRPTable)
+protonTablesTask = cms.Task(filteredProtons, genProtonTable, multiRPTable)
 if singleRPProtons: protonTablesTask.add(singleRPTable)
+
+genProtonTablesTask = cms.Task(genProtonTable)
 
 for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2, run2_nanoAOD_94X2016, run2_nanoAOD_102Xv1:
     modifier.toReplaceWith(protonTablesTask, cms.Task())

--- a/PhysicsTools/NanoAOD/python/protons_cff.py
+++ b/PhysicsTools/NanoAOD/python/protons_cff.py
@@ -21,9 +21,9 @@ protonTable.tagRecoProtonsSingle = cms.InputTag("filteredProtons" if singleRPPro
 
 
 genProtonTable = _genproton.clone(
-    srcPUProtons = cms.InputTag('genPUProtons', 'genPUProtons'),
-    # PU protons source could have an extra 'genPUProtons' collection name for some samples
     cut = cms.string('(pdgId == 2212) && (abs(pz) > 5200) && (abs(pz) < 6467.5)'), # xi in [0.015, 0.2]
+    # PU protons source could have an extra 'genPUProtons' collection name for some samples
+    # srcPUProtons = cms.InputTag('genPUProtons', 'genPUProtons'),
 )
 
 multiRPTable = cms.EDProducer("SimpleProtonTrackFlatTableProducer",

--- a/PhysicsTools/NanoAOD/python/protons_cff.py
+++ b/PhysicsTools/NanoAOD/python/protons_cff.py
@@ -71,9 +71,5 @@ genProtonTable = _genproton.clone(
 
 genProtonTablesTask = cms.Task(genProtonTable)
 
-# input GEN-level PU protons collection introduced in 9_4_X cycle
-run2_miniAOD_80XLegacy.toReplaceWith(genProtonTablesTask, cms.Task())
-# PU protons tag could have an extra 'genPUProtons' collection name for some eras
-run2_nanoAOD_94XMiniAODv2.toModify(genProtonTable,
-    srcPUProtons = cms.InputTag('genPUProtons', 'genPUProtons')
-)
+# input GEN-level PU protons collection introduced after 9_4_X cycle
+(run2_miniAOD_80XLegacy | run2_nanoAOD_94XMiniAODv1 | run2_nanoAOD_94XMiniAODv2).toReplaceWith(genProtonTablesTask, cms.Task())

--- a/PhysicsTools/NanoAOD/python/protons_cff.py
+++ b/PhysicsTools/NanoAOD/python/protons_cff.py
@@ -67,7 +67,11 @@ singleRPTable = cms.EDProducer("SimpleProtonTrackFlatTableProducer",
 protonTablesTask = cms.Task(filteredProtons,protonTable,multiRPTable)
 if singleRPProtons: protonTablesTask.add(singleRPTable)
 
-genProtonTablesTask = cms.Task(genProtonTable)
-
 for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2, run2_nanoAOD_94X2016, run2_nanoAOD_102Xv1:
     modifier.toReplaceWith(protonTablesTask, cms.Task())
+
+# GEN-level signal/PU protons collection
+genProtonTablesTask = cms.Task(genProtonTable)
+
+# input GEN-level PU protons collection introduced in 9_4_X cycle
+run2_miniAOD_80XLegacy.toReplaceWith(genProtonTablesTask, cms.Task())

--- a/PhysicsTools/NanoAOD/python/protons_cff.py
+++ b/PhysicsTools/NanoAOD/python/protons_cff.py
@@ -21,9 +21,8 @@ protonTable.tagRecoProtonsSingle = cms.InputTag("filteredProtons" if singleRPPro
 
 
 genProtonTable = _genproton.clone(
-    srcPruned = cms.InputTag('prunedGenParticles'),
-    #srcPUProtons = cms.InputTag('genPUProtons'), #FIXME could have an extra 'genPUProtons' collection name for some samples
     srcPUProtons = cms.InputTag('genPUProtons', 'genPUProtons'),
+    # PU protons source could have an extra 'genPUProtons' collection name for some samples
     cut = cms.string('(pdgId == 2212) && (abs(pz) > 5200) && (abs(pz) < 6467.5)'), # xi in [0.015, 0.2]
 )
 


### PR DESCRIPTION
#### PR description:

This PR introduces a new flat table for the storage of GEN-level proton properties at NanoAOD level. As described [in this cross-POG presentation](https://indico.cern.ch/event/1079178/contributions/4606748) the expected new collection size is at the order of 12-19 B/event, with a ~0.03 ms/event filling time.
The stored proton attributes are:
* its vertex longitudinal coordinate (to point at simulated vertex position)
* its transverse and longitudinal momentum (providing Mandelstam-t and the adimensional xi fractional momentum loss)
* a boolean flag stating if the proton arises from signal (e.g. central exclusive processes), or from pileup.

#### PR validation:

Code developed in 10_6_X, forward-ported to master branch, and tested in both environments. Compiles, produces the expected output ; matrix tests running.

#### if this PR is a backport please specify the original PR and why you need to backport that PR: N/A

Before submitting your pull requests, make sure you followed this checklist:
- [x] verify that the PR is really intended for the chosen branch
- [x] verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- [x] verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

cc: @michael-pitt, @fabferro 