### PR TITLE
Use esConsumes in TTClusterAssociator and TTClusterBuilder

### DIFF
--- a/L1Trigger/TrackTrigger/plugins/TTClusterBuilder.cc
+++ b/L1Trigger/TrackTrigger/plugins/TTClusterBuilder.cc
@@ -18,11 +18,9 @@ void TTClusterBuilder<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, const
   this->RetrieveRawHits(rawHits, iEvent);
 
   // Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHandle = iSetup.getHandle(tTopoToken);
-  const TrackerTopology* const tTopo = tTopoHandle.product();
-
-  edm::ESHandle<TrackerGeometry> tGeomHandle = iSetup.getHandle(tGeomToken);
-  const TrackerGeometry* const theTrackerGeom = tGeomHandle.product();
+  const TrackerTopology* const tTopo = &iSetup.getData(tTopoToken);
+  const TrackerGeometry* const theTrackerGeom = &iSetup.getData(tGeomToken);
+  auto const& theClusterFindingAlgo = iSetup.getData(theClusterFindingAlgoToken);
 
   // Loop on the OT stacks
   for (auto gd = theTrackerGeom->dets().begin(); gd != theTrackerGeom->dets().end(); gd++) {
@@ -49,9 +47,9 @@ void TTClusterBuilder<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, const
     /// calls the constructor to the Cluster class!
     bool isPSP = (theTrackerGeom->getDetectorType(lowerDetid) == TrackerGeometry::ModuleType::Ph2PSP);
     if (lowerHitFind != rawHits.end())
-      theClusterFindingAlgoHandle->Cluster(lowerHits, lowerHitFind->second, isPSP);
+      theClusterFindingAlgo.Cluster(lowerHits, lowerHitFind->second, isPSP);
     if (upperHitFind != rawHits.end())
-      theClusterFindingAlgoHandle->Cluster(upperHits, upperHitFind->second, false);
+      theClusterFindingAlgo.Cluster(upperHits, upperHitFind->second, false);
 
     /// Create TTCluster objects and store them
     /// Use the FastFiller with edmNew::DetSetVector

--- a/L1Trigger/TrackTrigger/plugins/TTClusterBuilder.h
+++ b/L1Trigger/TrackTrigger/plugins/TTClusterBuilder.h
@@ -50,7 +50,7 @@ public:
 
 private:
   /// Data members
-  edm::ESHandle<TTClusterAlgorithm<T> > theClusterFindingAlgoHandle;
+  edm::ESGetToken<TTClusterAlgorithm<T>, TTClusterAlgorithmRecord> theClusterFindingAlgoToken;
   edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken;
   edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tGeomToken;
   std::vector<edm::EDGetTokenT<edm::DetSetVector<Phase2TrackerDigi> > > rawHitTokens;
@@ -58,8 +58,6 @@ private:
   bool storeLocalCoord;
 
   /// Mandatory methods
-  void beginRun(const edm::Run& run, const edm::EventSetup& iSetup) override;
-  void endRun(const edm::Run& run, const edm::EventSetup& iSetup) override;
   void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
   /// Get hits
@@ -79,6 +77,7 @@ template <typename T>
 TTClusterBuilder<T>::TTClusterBuilder(const edm::ParameterSet& iConfig) {
   ADCThreshold = iConfig.getParameter<unsigned int>("ADCThreshold");
   storeLocalCoord = iConfig.getParameter<bool>("storeLocalCoord");
+  theClusterFindingAlgoToken = esConsumes();
   tTopoToken = esConsumes<TrackerTopology, TrackerTopologyRcd>();
   tGeomToken = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
 
@@ -93,17 +92,6 @@ TTClusterBuilder<T>::TTClusterBuilder(const edm::ParameterSet& iConfig) {
 /// Destructor
 template <typename T>
 TTClusterBuilder<T>::~TTClusterBuilder() {}
-
-/// Begin run
-template <typename T>
-void TTClusterBuilder<T>::beginRun(const edm::Run& run, const edm::EventSetup& iSetup) {
-  /// Get the clustering algorithm
-  iSetup.get<TTClusterAlgorithmRecord>().get(theClusterFindingAlgoHandle);
-}
-
-/// End run
-template <typename T>
-void TTClusterBuilder<T>::endRun(const edm::Run& run, const edm::EventSetup& iSetup) {}
 
 /// Implement the producer
 template <>

--- a/SimTracker/TrackTriggerAssociation/plugins/TTClusterAssociator.cc
+++ b/SimTracker/TrackTriggerAssociation/plugins/TTClusterAssociator.cc
@@ -24,7 +24,7 @@ void TTClusterAssociator<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, co
   iEvent.getByToken(tpToken_, trackingParticleHandle_);
 
   //  const TrackerTopology* const tTopo = theTrackerTopology_.product();
-  const TrackerGeometry* const theTrackerGeom = theTrackerGeometry_.product();
+  const TrackerGeometry* const theTrackerGeom = &iSetup.getData(theTrackerGeometryToken_);
 
   /// Preliminary task: map SimTracks by TrackingParticle
   /// Prepare the map

--- a/SimTracker/TrackTriggerAssociation/plugins/TTClusterAssociator.h
+++ b/SimTracker/TrackTriggerAssociation/plugins/TTClusterAssociator.h
@@ -26,7 +26,6 @@
 #include "SimTracker/TrackTriggerAssociation/interface/TTClusterAssociationMap.h"
 #include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
 #include "L1Trigger/TrackTrigger/interface/TTStubAlgorithm.h"
 #include "L1Trigger/TrackTrigger/interface/TTStubAlgorithmRecord.h"
@@ -62,8 +61,7 @@ private:
   edm::EDGetTokenT<std::vector<TrackingParticle> > tpToken_;
   std::vector<edm::EDGetTokenT<edmNew::DetSetVector<TTCluster<T> > > > ttClustersTokens_;
 
-  edm::ESHandle<TrackerGeometry> theTrackerGeometry_;
-  edm::ESHandle<TrackerTopology> theTrackerTopology_;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> theTrackerGeometryToken_;
 
   /// Mandatory methods
   void beginRun(const edm::Run& run, const edm::EventSetup& iSetup) override;
@@ -93,6 +91,8 @@ TTClusterAssociator<T>::TTClusterAssociator(const edm::ParameterSet& iConfig) {
 
     produces<TTClusterAssociationMap<T> >(iTag.instance());
   }
+
+  theTrackerGeometryToken_ = esConsumes();
 }
 
 /// Destructor
@@ -102,10 +102,6 @@ TTClusterAssociator<T>::~TTClusterAssociator() {}
 /// Begin run
 template <typename T>
 void TTClusterAssociator<T>::beginRun(const edm::Run& run, const edm::EventSetup& iSetup) {
-  /// Get the geometry
-  iSetup.get<TrackerDigiGeometryRecord>().get(theTrackerGeometry_);
-  iSetup.get<TrackerTopologyRcd>().get(theTrackerTopology_);
-
   /// Print some information when loaded
   edm::LogInfo("TTClusterAssociator< ") << templateNameFinder<T>() << " > loaded.";
 }


### PR DESCRIPTION
#### PR description:

Part of #31061.

#### PR validation:

Matrix workflows `23234.0,35034.0,28234.0,23234.21,23234.103,23234.9,23434.21,34634.0,34634.21,34834.21,35034.21,35034.0,35234.21` succeed when run with https://github.com/cms-sw/cmssw/pull/35588.