### PR TITLE
Add ECAL and GEM tags to 122X GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,81 +2,81 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'                  : '121X_mcRun1_design_v6',
+    'run1_design'                  : '122X_mcRun1_design_v1',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'                      : '121X_mcRun1_realistic_v6',
+    'run1_mc'                      : '122X_mcRun1_realistic_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'                   : '121X_mcRun1_HeavyIon_v7',
+    'run1_mc_hi'                   : '122X_mcRun1_HeavyIon_v1',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'                 : '121X_mcRun2_startup_v8',
+    'run2_mc_50ns'                 : '122X_mcRun2_startup_v1',
     # GlobalTag for MC production (2015 L1 Trigger Stage1) with startup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
-    'run2_mc_l1stage1'             : '121X_mcRun2_asymptotic_l1stage1_v8',
+    'run2_mc_l1stage1'             : '122X_mcRun2_asymptotic_l1stage1_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'                  : '121X_mcRun2_design_v8',
+    'run2_design'                  : '122X_mcRun2_design_v1',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, prior to VFP change
-    'run2_mc_pre_vfp'              : '121X_mcRun2_asymptotic_preVFP_v8',
+    'run2_mc_pre_vfp'              : '122X_mcRun2_asymptotic_preVFP_v1',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, after VFP change
-    'run2_mc'                      : '121X_mcRun2_asymptotic_v8',
+    'run2_mc'                      : '122X_mcRun2_asymptotic_v1',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'              : '121X_mcRun2cosmics_asymptotic_deco_v8',
+    'run2_mc_cosmics'              : '122X_mcRun2cosmics_asymptotic_deco_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'                   : '121X_mcRun2_HeavyIon_v8',
+    'run2_mc_hi'                   : '122X_mcRun2_HeavyIon_v1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'                   : '121X_mcRun2_pA_v8',
+    'run2_mc_pa'                   : '122X_mcRun2_pA_v1',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'                    : '121X_dataRun2_v11',
+    'run2_data'                    : '122X_dataRun2_v1',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_HEfail'             : '121X_dataRun2_HEfail_v11',
+    'run2_data_HEfail'             : '122X_dataRun2_HEfail_v1',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'             : '121X_dataRun2_relval_v11',
+    'run2_data_relval'             : '122X_dataRun2_relval_v1',
     # GlobalTag for Run2 HI data
-    'run2_data_promptlike_hi'      : '121X_dataRun2_PromptLike_HI_v10',
+    'run2_data_promptlike_hi'      : '122X_dataRun2_PromptLike_HI_v1',
     # GlobalTag for Run3 HLT: it points to the online GT
-    'run3_hlt'                     : '121X_dataRun3_HLT_v11',
+    'run3_hlt'                     : '122X_dataRun3_HLT_v1',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'              : '121X_dataRun2_HLT_relval_v11',
+    'run2_hlt_relval'              : '122X_dataRun2_HLT_relval_v1',
     # GlobalTag for Run3 data relvals (express GT)
-    'run3_data_express'            : '121X_dataRun3_Express_v11',
+    'run3_data_express'            : '122X_dataRun3_Express_v1',
     # GlobalTag for Run3 data relvals
-    'run3_data_prompt'             : '121X_dataRun3_Prompt_v10',
+    'run3_data_prompt'             : '122X_dataRun3_Prompt_v1',
     # GlobalTag for Run3 offline data reprocessing
-    'run3_data'                    : '121X_dataRun3_v10',
+    'run3_data'                    : '122X_dataRun3_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'           : '121X_mc2017_design_v9',
+    'phase1_2017_design'           : '122X_mc2017_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'        : '121X_mc2017_realistic_v9',
+    'phase1_2017_realistic'        : '122X_mc2017_realistic_v1',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'          : '121X_mc2017cosmics_realistic_deco_v9',
+    'phase1_2017_cosmics'          : '122X_mc2017cosmics_realistic_deco_v1',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak'     : '121X_mc2017cosmics_realistic_peak_v9',
+    'phase1_2017_cosmics_peak'     : '122X_mc2017cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'           : '121X_upgrade2018_design_v8',
+    'phase1_2018_design'           : '122X_upgrade2018_design_v1',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'        : '121X_upgrade2018_realistic_v8',
+    'phase1_2018_realistic'        : '122X_upgrade2018_realistic_v1',
     # GlobalTag for MC production with realistic run-dependent (RD) conditions for full Phase1 2018 detector
-    'phase1_2018_realistic_rd'     : '121X_upgrade2018_realistic_RD_v8',
+    'phase1_2018_realistic_rd'     : '122X_upgrade2018_realistic_RD_v1',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi'     : '121X_upgrade2018_realistic_HI_v8',
+    'phase1_2018_realistic_hi'     : '122X_upgrade2018_realistic_HI_v1',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' : '121X_upgrade2018_realistic_HEfail_v8',
+    'phase1_2018_realistic_HEfail' : '122X_upgrade2018_realistic_HEfail_v1',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'          : '121X_upgrade2018cosmics_realistic_deco_v10',
+    'phase1_2018_cosmics'          : '122X_upgrade2018cosmics_realistic_deco_v1',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak'     : '121X_upgrade2018cosmics_realistic_peak_v8',
+    'phase1_2018_cosmics_peak'     : '122X_upgrade2018cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'           : '121X_mcRun3_2021_design_v16',
+    'phase1_2021_design'           : '122X_mcRun3_2021_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'        : '121X_mcRun3_2021_realistic_v18',
+    'phase1_2021_realistic'        : '122X_mcRun3_2021_realistic_v1',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'          : '121X_mcRun3_2021cosmics_realistic_deco_v18',
+    'phase1_2021_cosmics'          : '122X_mcRun3_2021cosmics_realistic_deco_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi'     : '121X_mcRun3_2021_realistic_HI_v18',
+    'phase1_2021_realistic_hi'     : '122X_mcRun3_2021_realistic_HI_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '121X_mcRun3_2023_realistic_v17',
+    'phase1_2023_realistic'        : '122X_mcRun3_2023_realistic_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '121X_mcRun3_2024_realistic_v17',
+    'phase1_2024_realistic'        : '122X_mcRun3_2024_realistic_v1',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             : '121X_mcRun4_realistic_v8'
+    'phase2_realistic'             : '122X_mcRun4_realistic_v1'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:

This PR is to include the ECAL Linearization Constant tag in the mcRun4 and mcRun3 GTs, as requested in https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4529.html

It also includes a new EcalLaserAPDPNRatios ECAL tag in the Run3 offline GT.

There is also the inclusion of the GEMeMap tag in the run3 offline GT, as requested in https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4524.html.

The tags included in the GTs are:
ECAL Linearization Constant (in mcRun4 and mcRun3 GTs except the _design_ one),  `EcalTPGLinearizationConst_UL_2018_mc_EE_BTCP_116_SIC_1`

EcalLaserAPDPNRatios (in Run3 offline GT), `EcalLaserAPDPNRatios_offline_Run3_v1`

GEMeMap (in the Run3 offline GT), `GEMeMap_Full_v2`


Since all 122X Queues have been created we also updated all other GTs in autoCond to 122X.

The diffs in GTs are below. We expect to see differences only in the mcRun4 and mcRun3 (except the design one) and Run3 offline GTs:

**run1_design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//122X_mcRun1_design_v1/121X_mcRun1_design_v6

**run1_mc**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//122X_mcRun1_realistic_v1/121X_mcRun1_realistic_v6

**run1_mc_hi**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//122X_mcRun1_HeavyIon_v1/121X_mcRun1_HeavyIon_v7

**run2_mc_50ns**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//122X_mcRun2_startup_v1/121X_mcRun2_startup_v8

**run2_mc_l1stage1**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//122X_mcRun2_asymptotic_l1stage1_v1/121X_mcRun2_asymptotic_l1stage1_v8

**run2_design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//122X_mcRun2_design_v1/121X_mcRun2_design_v8

**run2_mc_pre_vfp**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//122X_mcRun2_asymptotic_preVFP_v1/121X_mcRun2_asymptotic_preVFP_v8

**run2_mc**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//122X_mcRun2_asymptotic_v1/121X_mcRun2_asymptotic_v8

**run2_mc_cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//122X_mcRun2cosmics_asymptotic_deco_v1/121X_mcRun2cosmics_asymptotic_deco_v8

**run2_mc_hi**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//122X_mcRun2_HeavyIon_v1/121X_mcRun2_HeavyIon_v8

**run2_mc_pa**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//122X_mcRun2_pA_v1/121X_mcRun2_pA_v8

**run2_data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//122X_dataRun2_v1/121X_dataRun2_v11

**run2_data_HEfail**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//122X_dataRun2_HEfail_v1/121X_dataRun2_HEfail_v11

**run2_data_relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//122X_dataRun2_relval_v1/121X_dataRun2_relval_v11

**run2_data_promptlike_hi**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//122X_dataRun2_PromptLike_HI_v1/121X_dataRun2_PromptLike_HI_v10

**run3_hlt**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//122X_dataRun3_HLT_v1/121X_dataRun3_HLT_v11

**run2_hlt_relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//122X_dataRun2_HLT_relval_v1/121X_dataRun2_HLT_relval_v11

**run3_data_express**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//122X_dataRun3_Express_v1/121X_dataRun3_Express_v11

**run3_data_prompt**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//122X_dataRun3_Prompt_v1/121X_dataRun3_Prompt_v10

**run3_data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//122X_dataRun3_v1/121X_dataRun3_v10

**phase1_2017_design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//122X_mc2017_design_v1/121X_mc2017_design_v9

**phase1_2017_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//122X_mc2017_realistic_v1/121X_mc2017_realistic_v9

**phase1_2017_cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//122X_mc2017cosmics_realistic_deco_v1/121X_mc2017cosmics_realistic_deco_v9

**phase1_2017_cosmics_peak**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//122X_mc2017cosmics_realistic_peak_v1/121X_mc2017cosmics_realistic_peak_v9

**phase1_2018_design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//122X_upgrade2018_design_v1/121X_upgrade2018_design_v8

**phase1_2018_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//122X_upgrade2018_realistic_v1/121X_upgrade2018_realistic_v8

**phase1_2018_realistic_rd**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//122X_upgrade2018_realistic_RD_v1/121X_upgrade2018_realistic_RD_v8

**phase1_2018_realistic_hi**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//122X_upgrade2018_realistic_HI_v1/121X_upgrade2018_realistic_HI_v8

**phase1_2018_realistic_HEfail**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//122X_upgrade2018_realistic_HEfail_v1/121X_upgrade2018_realistic_HEfail_v8

**phase1_2018_cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//122X_upgrade2018cosmics_realistic_deco_v1/121X_upgrade2018cosmics_realistic_deco_v10

**phase1_2018_cosmics_peak**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//122X_upgrade2018cosmics_realistic_peak_v1/121X_upgrade2018cosmics_realistic_peak_v8

**phase1_2021_design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//122X_mcRun3_2021_design_v1/121X_mcRun3_2021_design_v16

**phase1_2021_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//122X_mcRun3_2021_realistic_v1/121X_mcRun3_2021_realistic_v18

**phase1_2021_cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//122X_mcRun3_2021cosmics_realistic_deco_v1/121X_mcRun3_2021cosmics_realistic_deco_v18

**phase1_2021_realistic_hi**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//122X_mcRun3_2021_realistic_HI_v1/121X_mcRun3_2021_realistic_HI_v18

**phase1_2023_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//122X_mcRun3_2023_realistic_v1/121X_mcRun3_2023_realistic_v17

**phase1_2024_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//122X_mcRun3_2024_realistic_v1/121X_mcRun3_2024_realistic_v17

**phase2_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//122X_mcRun4_realistic_v1/121X_mcRun4_realistic_v8



#### PR validation:

runTheMatrix.py -l limited,136.897,7.23,12834.0 --ibeos -j16

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
it is not a backport
