### PR TITLE
Use esConsumes in some Geometry/TrackerGeometryBuilder test EDModules

### DIFF
--- a/Geometry/TrackerGeometryBuilder/test/ModuleInfo.cc
+++ b/Geometry/TrackerGeometryBuilder/test/ModuleInfo.cc
@@ -22,7 +22,6 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/Utilities/interface/Exception.h"
@@ -64,24 +63,25 @@ using namespace cms_rounding;
 class ModuleInfo : public edm::one::EDAnalyzer<> {
 public:
   explicit ModuleInfo(const edm::ParameterSet&);
-  ~ModuleInfo() override;
 
-  void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
-  void endJob() override {}
 
 private:
   bool fromDDD_;
   bool printDDD_;
   double tolerance_;
+  edm::ESGetToken<GeometricDet, IdealGeometryRecord> rDDToken_;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> pDDToken_;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
 };
 
 ModuleInfo::ModuleInfo(const edm::ParameterSet& ps)
     : fromDDD_(ps.getParameter<bool>("fromDDD")),
       printDDD_(ps.getUntrackedParameter<bool>("printDDD", true)),
-      tolerance_(ps.getUntrackedParameter<double>("tolerance", 1.e-23)) {}
-
-ModuleInfo::~ModuleInfo() {}
+      tolerance_(ps.getUntrackedParameter<double>("tolerance", 1.e-23)),
+      rDDToken_(esConsumes()),
+      pDDToken_(esConsumes()),
+      tTopoToken_(esConsumes()) {}
 
 // ------------ method called to produce the data  ------------
 void ModuleInfo::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
@@ -98,18 +98,14 @@ void ModuleInfo::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
 
   // get the GeometricDet
   //
-  edm::ESHandle<GeometricDet> rDD;
-  iSetup.get<IdealGeometryRecord>().get(rDD);
+  auto const& rDD = iSetup.getData(rDDToken_);
 
-  edm::LogInfo("ModuleInfo") << " Top node is  " << rDD.product() << " " << rDD.product()->name() << std::endl;
-  edm::LogInfo("ModuleInfo") << " And Contains  Daughters: " << rDD.product()->deepComponents().size() << std::endl;
+  edm::LogInfo("ModuleInfo") << " Top node is  " << &rDD << " " << rDD.name() << std::endl;
+  edm::LogInfo("ModuleInfo") << " And Contains  Daughters: " << rDD.deepComponents().size() << std::endl;
   //
   //first instance tracking geometry
-  edm::ESHandle<TrackerGeometry> pDD;
-  iSetup.get<TrackerDigiGeometryRecord>().get(pDD);
-  edm::ESHandle<TrackerTopology> tTopo_handle;
-  iSetup.get<TrackerTopologyRcd>().get(tTopo_handle);
-  const TrackerTopology* tTopo = tTopo_handle.product();
+  auto const& pDD = iSetup.getData(pDDToken_);
+  const TrackerTopology* tTopo = &iSetup.getData(tTopoToken_);
   //
 
   // counters
@@ -149,7 +145,7 @@ void ModuleInfo::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
   unsigned int tec_r6_rphiN = 0;
   unsigned int tec_r7_rphiN = 0;
 
-  std::vector<const GeometricDet*> modules = (*rDD).deepComponents();
+  std::vector<const GeometricDet*> modules = rDD.deepComponents();
   Output << "************************ List of modules with positions ************************" << std::endl;
 
   for (auto& module : modules) {
@@ -401,7 +397,7 @@ void ModuleInfo::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
     }
 
     // Local axes from Reco
-    const GeomDet* geomdet = pDD->idToDet(module->geographicalId());
+    const GeomDet* geomdet = pDD.idToDet(module->geographicalId());
     // Global Coordinates (i,j,k)
     LocalVector xLocal(1, 0, 0);
     LocalVector yLocal(0, 1, 0);

--- a/Geometry/TrackerGeometryBuilder/test/TrackerDigiGeometryAnalyzer.cc
+++ b/Geometry/TrackerGeometryBuilder/test/TrackerDigiGeometryAnalyzer.cc
@@ -25,7 +25,6 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -55,22 +54,19 @@
 class TrackerDigiGeometryAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   explicit TrackerDigiGeometryAnalyzer(const edm::ParameterSet&);
-  ~TrackerDigiGeometryAnalyzer() override;
 
-  void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
-  void endJob() override {}
 
 private:
   void analyseTrapezoidal(const GeomDetUnit& det);
   void checkRotation(const GeomDetUnit& det);
   void checkTopology(const GeomDetUnit& det);
   std::ostream& cylindrical(std::ostream& os, const GlobalPoint& gp) const;
+
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> pDDToken_;
 };
 
-TrackerDigiGeometryAnalyzer::TrackerDigiGeometryAnalyzer(const edm::ParameterSet& iConfig) {}
-
-TrackerDigiGeometryAnalyzer::~TrackerDigiGeometryAnalyzer() {}
+TrackerDigiGeometryAnalyzer::TrackerDigiGeometryAnalyzer(const edm::ParameterSet& iConfig) : pDDToken_(esConsumes()) {}
 
 // ------------ method called to produce the data  ------------
 void TrackerDigiGeometryAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
@@ -78,13 +74,12 @@ void TrackerDigiGeometryAnalyzer::analyze(const edm::Event& iEvent, const edm::E
   //
   // get the TrackerGeom
   //
-  edm::ESHandle<TrackerGeometry> pDD;
-  iSetup.get<TrackerDigiGeometryRecord>().get(pDD);
-  PRINT("TrackerDigiGeometryAnalyzer") << " Geometry node for TrackerGeom is  " << &(*pDD) << '\n';
-  PRINT("TrackerDigiGeometryAnalyzer") << " I have " << pDD->detUnits().size() << " detectors" << '\n';
-  PRINT("TrackerDigiGeometryAnalyzer") << " I have " << pDD->detTypes().size() << " types" << '\n';
+  auto const& pDD = iSetup.getData(pDDToken_);
+  PRINT("TrackerDigiGeometryAnalyzer") << " Geometry node for TrackerGeom is  " << &pDD << '\n';
+  PRINT("TrackerDigiGeometryAnalyzer") << " I have " << pDD.detUnits().size() << " detectors" << '\n';
+  PRINT("TrackerDigiGeometryAnalyzer") << " I have " << pDD.detTypes().size() << " types" << '\n';
 
-  for (auto const& it : pDD->detUnits()) {
+  for (auto const& it : pDD.detUnits()) {
     if (dynamic_cast<const PixelGeomDetUnit*>((it)) != nullptr) {
       const BoundPlane& p = (dynamic_cast<const PixelGeomDetUnit*>((it)))->specificSurface();
       PRINT("TrackerDigiGeometryAnalyzer") << it->geographicalId() << " RadLeng Pixel " << p.mediumProperties().radLen()
@@ -100,7 +95,7 @@ void TrackerDigiGeometryAnalyzer::analyze(const edm::Event& iEvent, const edm::E
     //analyseTrapezoidal(*it);
   }
 
-  for (auto const& it : pDD->detTypes()) {
+  for (auto const& it : pDD.detTypes()) {
     if (dynamic_cast<const PixelGeomDetType*>((it)) != nullptr) {
       const PixelTopology& p = (dynamic_cast<const PixelGeomDetType*>((it)))->specificTopology();
       PRINT("TrackerDigiGeometryAnalyzer") << " PIXEL Det "  // << it->geographicalId()

--- a/Geometry/TrackerGeometryBuilder/test/TrackerMapTool.cc
+++ b/Geometry/TrackerGeometryBuilder/test/TrackerMapTool.cc
@@ -30,7 +30,6 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -53,32 +52,17 @@
 class TrackerMapTool : public edm::one::EDAnalyzer<> {
 public:
   explicit TrackerMapTool(const edm::ParameterSet&);
-  ~TrackerMapTool() override;
 
-  void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
-  void endJob() override {}
+
+private:
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> pDDToken_;
 };
-
-//
-// constants, enums and typedefs
-//
-
-//
-// static data member definitions
-//
 
 //
 // constructors and destructor
 //
-TrackerMapTool::TrackerMapTool(const edm::ParameterSet& iConfig) {
-  //now do what ever initialization is needed
-}
-
-TrackerMapTool::~TrackerMapTool() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
-}
+TrackerMapTool::TrackerMapTool(const edm::ParameterSet& iConfig) : pDDToken_(esConsumes()) {}
 
 //
 // member functions
@@ -116,11 +100,10 @@ void TrackerMapTool::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
   //
   // get the TrackerGeom
   //
-  edm::ESHandle<TrackerGeometry> pDD;
-  iSetup.get<TrackerDigiGeometryRecord>().get(pDD);
-  edm::LogInfo("TrackerMapTool") << " Geometry node for TrackerGeom is  " << &(*pDD);
-  edm::LogInfo("TrackerMapTool") << " I have " << pDD->dets().size() << " detectors";
-  edm::LogInfo("TrackerMapTool") << " I have " << pDD->detTypes().size() << " types";
+  auto const& pDD = iSetup.getData(pDDToken_);
+  edm::LogInfo("TrackerMapTool") << " Geometry node for TrackerGeom is  " << &pDD;
+  edm::LogInfo("TrackerMapTool") << " I have " << pDD.dets().size() << " detectors";
+  edm::LogInfo("TrackerMapTool") << " I have " << pDD.detTypes().size() << " types";
   int spicchif[] = {24, 24, 40, 56, 40, 56, 80};
   int spicchib[] = {20, 32, 44, 30, 38, 46, 56, 42, 48, 54, 60, 66, 74};
 
@@ -140,8 +123,8 @@ void TrackerMapTool::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
   float width, length, thickness, widthAtHalfLength;
   std::ofstream output("tracker.dat", std::ios::out);
 
-  auto begin = pDD->detUnits().begin();
-  auto end = pDD->detUnits().end();
+  auto begin = pDD.detUnits().begin();
+  auto end = pDD.detUnits().end();
 
   for (; begin != end; ++begin) {
     ntotmod++;

--- a/Geometry/TrackerGeometryBuilder/test/TrackerParametersAnalyzer.cc
+++ b/Geometry/TrackerGeometryBuilder/test/TrackerParametersAnalyzer.cc
@@ -1,7 +1,6 @@
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "Geometry/Records/interface/PTrackerParametersRcd.h"
@@ -11,26 +10,26 @@
 
 class TrackerParametersAnalyzer : public edm::one::EDAnalyzer<> {
 public:
-  explicit TrackerParametersAnalyzer(const edm::ParameterSet&) {}
+  explicit TrackerParametersAnalyzer(const edm::ParameterSet&) : ptpToken_(esConsumes()) {}
 
-  void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
-  void endJob() override {}
+
+private:
+  edm::ESGetToken<PTrackerParameters, PTrackerParametersRcd> ptpToken_;
 };
 
 void TrackerParametersAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   edm::LogVerbatim("TrackerParametersAnalyzer") << "Here I am";
 
-  edm::ESHandle<PTrackerParameters> ptp;
-  iSetup.get<PTrackerParametersRcd>().get(ptp);
+  auto const& ptp = iSetup.getData(ptpToken_);
 
-  for (const auto& vitem : ptp->vitems) {
+  for (const auto& vitem : ptp.vitems) {
     edm::LogVerbatim("TrackerParametersAnalyzer") << vitem.id << " has " << vitem.vpars.size() << ":";
     for (const auto& in : vitem.vpars) {
       edm::LogVerbatim("TrackerParametersAnalyzer") << in << ";";
     }
   }
-  for (int vpar : ptp->vpars) {
+  for (int vpar : ptp.vpars) {
     std::cout << vpar << "; ";
   }
 }


### PR DESCRIPTION
#### PR description:

Part of #31061.

#### PR validation:

Unit tests of `Geometry/TrackerGeometryBuilder` succeed when run with https://github.com/cms-sw/cmssw/pull/35588.