### PR TITLE
Run3-gex98B Use ESGetToken in EDAnalyzers of SimTracker/SiPhase2Digitizer

### DIFF
--- a/SimTracker/SiPhase2Digitizer/plugins/PreMixingPhase2TrackerWorker.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/PreMixingPhase2TrackerWorker.cc
@@ -3,7 +3,6 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/ProducesCollector.h"
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"

--- a/SimTracker/SiPhase2Digitizer/test/PixelTestBeamValidation.cc
+++ b/SimTracker/SiPhase2Digitizer/test/PixelTestBeamValidation.cc
@@ -49,8 +49,8 @@ PixelTestBeamValidation::PixelTestBeamValidation(const edm::ParameterSet& iConfi
       simTrackToken_(consumes<edm::SimTrackContainer>(iConfig.getParameter<edm::InputTag>("SimTrackSource"))),
       topoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd>()),
       geomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>()),
-  topoBToken_(esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>()),
-  geomBToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()) {
+      topoBToken_(esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>()),
+      geomBToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()) {
   LogDebug("PixelTestBeamValidation") << ">>> Construct PixelTestBeamValidation ";
 
   // The value to be used for ToT == 0 in electrons

--- a/SimTracker/SiPhase2Digitizer/test/PixelTestBeamValidation.cc
+++ b/SimTracker/SiPhase2Digitizer/test/PixelTestBeamValidation.cc
@@ -9,16 +9,12 @@
 
 // CMSSW Framework
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
 
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
 
 // CMSSW Data formats
 #include "DataFormats/Math/interface/CMSUnits.h"
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/MeasurementPoint.h"
 
@@ -50,7 +46,11 @@ PixelTestBeamValidation::PixelTestBeamValidation(const edm::ParameterSet& iConfi
       digiToken_(consumes<edm::DetSetVector<PixelDigi>>(iConfig.getParameter<edm::InputTag>("PixelDigiSource"))),
       digiSimLinkToken_(
           consumes<edm::DetSetVector<PixelDigiSimLink>>(iConfig.getParameter<edm::InputTag>("PixelDigiSimSource"))),
-      simTrackToken_(consumes<edm::SimTrackContainer>(iConfig.getParameter<edm::InputTag>("SimTrackSource"))) {
+      simTrackToken_(consumes<edm::SimTrackContainer>(iConfig.getParameter<edm::InputTag>("SimTrackSource"))),
+      topoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd>()),
+      geomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>()),
+  topoBToken_(esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>()),
+  geomBToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()) {
   LogDebug("PixelTestBeamValidation") << ">>> Construct PixelTestBeamValidation ";
 
   // The value to be used for ToT == 0 in electrons
@@ -172,13 +172,8 @@ void PixelTestBeamValidation::analyze(const edm::Event& iEvent, const edm::Event
   }
 
   // Tracker geometry and topology
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
-  const TrackerTopology* topo = tTopoHandle.product();
-
-  edm::ESHandle<TrackerGeometry> geomHandle;
-  iSetup.get<TrackerDigiGeometryRecord>().get(geomType_, geomHandle);
-  const TrackerGeometry* tkGeom = geomHandle.product();
+  const TrackerTopology* topo = &iSetup.getData(topoToken_);
+  const TrackerGeometry* tkGeom = &iSetup.getData(geomToken_);
 
   // Let's loop over the detectors
   for (auto const& dunit : tkGeom->detUnits()) {
@@ -350,14 +345,10 @@ void PixelTestBeamValidation::bookHistograms(DQMStore::IBooker& ibooker,
                                              edm::Run const& iRun,
                                              edm::EventSetup const& iSetup) {
   // Get Geometry to associate a folder to each Pixel subdetector
-  edm::ESHandle<TrackerGeometry> geomHandle;
-  iSetup.get<TrackerDigiGeometryRecord>().get(geomType_, geomHandle);
-  const TrackerGeometry* tkGeom = geomHandle.product();
+  const TrackerGeometry* tkGeom = &iSetup.getData(geomBToken_);
 
   // Tracker Topology (layers, modules, side, etc..)
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
-  const TrackerTopology* topo = tTopoHandle.product();
+  const TrackerTopology* topo = &iSetup.getData(topoBToken_);
 
   const std::string top_folder = config_.getParameter<std::string>("TopFolderName");
 

--- a/SimTracker/SiPhase2Digitizer/test/PixelTestBeamValidation.h
+++ b/SimTracker/SiPhase2Digitizer/test/PixelTestBeamValidation.h
@@ -193,6 +193,5 @@ private:
   const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
   const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoBToken_;
   const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomBToken_;
-
 };
 #endif

--- a/SimTracker/SiPhase2Digitizer/test/PixelTestBeamValidation.h
+++ b/SimTracker/SiPhase2Digitizer/test/PixelTestBeamValidation.h
@@ -33,6 +33,10 @@
 #include "SimDataFormats/Track/interface/SimTrackContainer.h"
 #include "DataFormats/DetId/interface/DetId.h"
 
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+
 // system
 #include <string>
 #include <set>
@@ -185,5 +189,10 @@ private:
   const edm::EDGetTokenT<edm::DetSetVector<PixelDigi>> digiToken_;
   const edm::EDGetTokenT<edm::DetSetVector<PixelDigiSimLink>> digiSimLinkToken_;
   const edm::EDGetTokenT<edm::SimTrackContainer> simTrackToken_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoBToken_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomBToken_;
+
 };
 #endif

--- a/SimTracker/SiPhase2Digitizer/test/TBeamTest.cc
+++ b/SimTracker/SiPhase2Digitizer/test/TBeamTest.cc
@@ -20,7 +20,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
@@ -74,15 +73,17 @@ private:
   void fillClusterWidth(DigiMEs& mes, float dphi, float width);
   edm::ParameterSet config_;
   std::map<std::string, DigiMEs> detMEs;
-  edm::InputTag otDigiSrc_;
-  edm::InputTag digiSimLinkSrc_;
-  edm::InputTag simTrackSrc_;
-  std::string geomType_;
+  const edm::InputTag otDigiSrc_;
+  const edm::InputTag digiSimLinkSrc_;
+  const edm::InputTag simTrackSrc_;
+  const std::string geomType_;
 
-  std::vector<double> phiValues;
+  const std::vector<double> phiValues;
   const edm::EDGetTokenT<edm::DetSetVector<Phase2TrackerDigi> > otDigiToken_;
   const edm::EDGetTokenT<edm::DetSetVector<PixelDigiSimLink> > otDigiSimLinkToken_;
   const edm::EDGetTokenT<edm::SimTrackContainer> simTrackToken_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
 };
 //
 // constructors
@@ -96,7 +97,9 @@ TBeamTest::TBeamTest(const edm::ParameterSet& iConfig)
       phiValues(iConfig.getParameter<std::vector<double> >("PhiAngles")),
       otDigiToken_(consumes<edm::DetSetVector<Phase2TrackerDigi> >(otDigiSrc_)),
       otDigiSimLinkToken_(consumes<edm::DetSetVector<PixelDigiSimLink> >(digiSimLinkSrc_)),
-      simTrackToken_(consumes<edm::SimTrackContainer>(simTrackSrc_)) {
+      simTrackToken_(consumes<edm::SimTrackContainer>(simTrackSrc_)),
+      topoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd>()),
+      geomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>(edm::ESInputTag{"", geomType_})) {
   edm::LogInfo("TBeamTest") << ">>> Construct TBeamTest ";
 }
 
@@ -127,16 +130,11 @@ void TBeamTest::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   edm::Handle<edm::SimTrackContainer> simTrackHandle;
   iEvent.getByToken(simTrackToken_, simTrackHandle);
 
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
-  const TrackerTopology* tTopo = tTopoHandle.product();
+  const TrackerTopology* tTopo = &iSetup.getData(topoToken_);
 
   edm::ESWatcher<TrackerDigiGeometryRecord> theTkDigiGeomWatcher;
   if (theTkDigiGeomWatcher.check(iSetup)) {
-    edm::ESHandle<TrackerGeometry> geomHandle;
-    iSetup.get<TrackerDigiGeometryRecord>().get(geomType_, geomHandle);
-
-    const TrackerGeometry* tkGeom = geomHandle.product();
+    const TrackerGeometry* tkGeom = &iSetup.getData(geomToken_);
 
     edm::DetSetVector<Phase2TrackerDigi>::const_iterator DSViter;
     std::string moduleType;


### PR DESCRIPTION
#### PR description:

Use ESGetToken in EDAnalyzers of SimTracker/SiPhase2Digitizer

#### PR validation:

Use runTheMatrix test workflows

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special