### PR TITLE
Force integral depth value for layer-wise PF clusters

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.cc
@@ -201,6 +201,8 @@ void Basic2DGenericPFlowPositionCalc::calculateAndSetPositionActual(reco::PFClus
   cluster.setLayer(max_e_layer);
 
   // calculate the position
+  bool single_depth = true;
+  int ref_depth = -1;
   double depth = 0.0;
   double position_norm = 0.0;
   double x(0.0), y(0.0), z(0.0);
@@ -232,7 +234,12 @@ void Basic2DGenericPFlowPositionCalc::calculateAndSetPositionActual(reco::PFClus
             (cell_layer == PFLayer::HCAL_ENDCAP && detectorEnum == 2 && refhit.depth() == depth) || detectorEnum == 0)
           threshold = std::get<2>(_logWeightDenom)[j];
       }
-
+      
+      if (ref_depth < 0) ref_depth = refhit.depth(); // Initialize reference depth
+      else if (refhit.depth() != ref_depth) {
+        // Found a rechit with a different depth
+        single_depth = false;
+      }
       const auto rh_energy = rhf.energy * rhf.fraction;
       const auto norm =
           (rhf.fraction < _minFractionInCalc ? 0.0f : std::max(0.0f, vdt::fast_logf(rh_energy * threshold)));
@@ -279,7 +286,8 @@ void Basic2DGenericPFlowPositionCalc::calculateAndSetPositionActual(reco::PFClus
     x *= norm_inverse;
     y *= norm_inverse;
     z *= norm_inverse;
-    depth *= norm_inverse;
+    if (single_depth) depth = ref_depth;
+    else depth *= norm_inverse;
     cluster.setPosition(math::XYZPoint(x, y, z));
     cluster.setDepth(depth);
     cluster.calculatePositionREP();

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.cc
@@ -234,8 +234,9 @@ void Basic2DGenericPFlowPositionCalc::calculateAndSetPositionActual(reco::PFClus
             (cell_layer == PFLayer::HCAL_ENDCAP && detectorEnum == 2 && refhit.depth() == depth) || detectorEnum == 0)
           threshold = std::get<2>(_logWeightDenom)[j];
       }
-      
-      if (ref_depth < 0) ref_depth = refhit.depth(); // Initialize reference depth
+
+      if (ref_depth < 0)
+        ref_depth = refhit.depth();  // Initialize reference depth
       else if (refhit.depth() != ref_depth) {
         // Found a rechit with a different depth
         single_depth = false;
@@ -286,8 +287,10 @@ void Basic2DGenericPFlowPositionCalc::calculateAndSetPositionActual(reco::PFClus
     x *= norm_inverse;
     y *= norm_inverse;
     z *= norm_inverse;
-    if (single_depth) depth = ref_depth;
-    else depth *= norm_inverse;
+    if (single_depth)
+      depth = ref_depth;
+    else
+      depth *= norm_inverse;
     cluster.setPosition(math::XYZPoint(x, y, z));
     cluster.setDepth(depth);
     cluster.calculatePositionREP();

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterizer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterizer.cc
@@ -175,10 +175,10 @@ std::vector<PFMultiDepthClusterizer::ClusterLink> PFMultiDepthClusterizer::link(
       const reco::PFCluster& cluster1 = clusters[i];
       const reco::PFCluster& cluster2 = clusters[j];
 
-      auto dz = (cluster2.depth() - cluster1.depth());
+      auto dz = ((int)cluster2.depth() - (int)cluster1.depth());
 
       //Do not link at the same layer and only link inside out!
-      if (dz < 0.0f || std::abs(dz) < 0.2f)
+      if (dz < 0.0 || std::abs(dz) < 0.2)
         continue;
 
       auto const& crep1 = cluster1.positionREP();

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterizer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterizer.cc
@@ -35,7 +35,7 @@ private:
 
   class ClusterLink {
   public:
-    ClusterLink(unsigned int i, unsigned int j, double DR, double DZ, double energy) {
+    ClusterLink(unsigned int i, unsigned int j, double DR, int DZ, double energy) {
       from_ = i;
       to_ = j;
       linkDR_ = DR;
@@ -48,14 +48,14 @@ private:
     unsigned int from() const { return from_; }
     unsigned int to() const { return to_; }
     double dR() const { return linkDR_; }
-    double dZ() const { return linkDZ_; }
+    int dZ() const { return linkDZ_; }
     double energy() const { return linkE_; }
 
   private:
     unsigned int from_;
     unsigned int to_;
     double linkDR_;
-    double linkDZ_;
+    int linkDZ_;
     double linkE_;
   };
 
@@ -175,10 +175,11 @@ std::vector<PFMultiDepthClusterizer::ClusterLink> PFMultiDepthClusterizer::link(
       const reco::PFCluster& cluster1 = clusters[i];
       const reco::PFCluster& cluster2 = clusters[j];
 
+      // PFCluster depth stored as double but HCAL layer clusters have integral depths only
       auto dz = ((int)cluster2.depth() - (int)cluster1.depth());
 
       //Do not link at the same layer and only link inside out!
-      if (dz < 0.0 || std::abs(dz) < 0.2)
+      if (dz <= 0)
         continue;
 
       auto const& crep1 = cluster1.positionREP();
@@ -221,7 +222,7 @@ std::vector<PFMultiDepthClusterizer::ClusterLink> PFMultiDepthClusterizer::prune
           mask[j] = true;
         } else if (link1.dZ() > link2.dZ()) {
           mask[i] = true;
-        } else if (fabs(link1.dZ() - link2.dZ()) < 0.2) {  //if same layer-pick based on transverse compatibility
+        } else {  //if same layer-pick based on transverse compatibility
           if (link1.dR() < link2.dR()) {
             mask[j] = true;
           } else if (link1.dR() > link2.dR()) {

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterizer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterizer.cc
@@ -176,7 +176,7 @@ std::vector<PFMultiDepthClusterizer::ClusterLink> PFMultiDepthClusterizer::link(
       const reco::PFCluster& cluster2 = clusters[j];
 
       // PFCluster depth stored as double but HCAL layer clusters have integral depths only
-      auto dz = ((int)cluster2.depth() - (int)cluster1.depth());
+      auto dz = (static_cast<int>(cluster2.depth()) - static_cast<int>(cluster1.depth()));
 
       //Do not link at the same layer and only link inside out!
       if (dz <= 0)


### PR DESCRIPTION
#### PR description:

This addresses #35923 by setting the PFCluster depth to the PFRecHit integer depth when all rechits have the same depth value. The PFCluster depth takes on non-integer values for multidepth clusters, so this parameter must remain a double. 

#### PR validation:

Passes all matrix tests in `runTheMatrix.py -l limited -i all --ibeos`. As shown below, HBHE PFCluster depths no longer contain rounding errors. 

![HBHE_PFCluster_depth_comparison](https://user-images.githubusercontent.com/14944512/141228795-a780c8a1-2d6b-4626-939e-001a107dbce1.png)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not a backport

@hatakeyamak @bendavid @rappoccio @laurenhay @silviodonato
