### PR TITLE
Migrate some ALCA code to new `PoolDBOutputService` methods

### DIFF
--- a/CondFormats/PhysicsToolsObjects/test/TFormulaWriter.cc
+++ b/CondFormats/PhysicsToolsObjects/test/TFormulaWriter.cc
@@ -1,11 +1,10 @@
-#include "CondFormats/PhysicsToolsObjects/test/TFormulaWriter.h"
-
-#include "FWCore/Utilities/interface/Exception.h"
-
-#include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 
 #include "CondFormats/PhysicsToolsObjects/interface/PhysicsTFormulaPayload.h"
+#include "CondFormats/PhysicsToolsObjects/test/TFormulaWriter.h"
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/Exception.h"
 
 #include <TFile.h>
 #include <TFormula.h>
@@ -48,9 +47,9 @@ void TFormulaWriter::analyze(const edm::Event&, const edm::EventSetup&) {
     limits.push_back(vfloat(0., 1.e+6));
     std::vector<std::string> formulas;
     formulas.push_back((formula->GetExpFormula("p")).Data());
-    PhysicsTFormulaPayload* formulaPayload = new PhysicsTFormulaPayload(limits, formulas);
+    PhysicsTFormulaPayload formulaPayload(limits, formulas);
     delete formula;
-    dbService->writeOne(formulaPayload, dbService->beginOfTime(), (*job)->outputRecord_);
+    dbService->writeOneIOV(formulaPayload, dbService->beginOfTime(), (*job)->outputRecord_);
   }
 
   std::cout << "done." << std::endl;

--- a/CondFormats/PhysicsToolsObjects/test/TGraphWriter.cc
+++ b/CondFormats/PhysicsToolsObjects/test/TGraphWriter.cc
@@ -1,11 +1,10 @@
-#include "CondFormats/PhysicsToolsObjects/test/TGraphWriter.h"
-
-#include "FWCore/Utilities/interface/Exception.h"
-
-#include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 
 #include "CondFormats/PhysicsToolsObjects/interface/PhysicsTGraphPayload.h"
+#include "CondFormats/PhysicsToolsObjects/test/TGraphWriter.h"
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/Exception.h"
 
 #include <TFile.h>
 #include <TGraph.h>
@@ -42,9 +41,9 @@ void TGraphWriter::analyze(const edm::Event&, const edm::EventSetup&) {
       throw cms::Exception("TGraphWriter") << " Failed to access PoolDBOutputService !!\n";
     std::cout << " writing TGraph = " << (*job)->graphName_ << " to SQLlite file, record = " << (*job)->outputRecord_
               << "." << std::endl;
-    PhysicsTGraphPayload* graphPayload = new PhysicsTGraphPayload(*graph);
+    PhysicsTGraphPayload graphPayload(*graph);
     delete graph;
-    dbService->writeOne(graphPayload, dbService->beginOfTime(), (*job)->outputRecord_);
+    dbService->writeOneIOV(graphPayload, dbService->beginOfTime(), (*job)->outputRecord_);
   }
 
   std::cout << "done." << std::endl;

--- a/CondTools/HLT/src/AlCaRecoTriggerBitsRcdUpdate.cc
+++ b/CondTools/HLT/src/AlCaRecoTriggerBitsRcdUpdate.cc
@@ -40,7 +40,7 @@ private:
   bool removeKeysFromMap(const std::vector<std::string> &keys, TriggerMap &triggerMap) const;
   bool replaceKeysFromMap(const std::vector<edm::ParameterSet> &alcarecoReplace, TriggerMap &triggerMap) const;
   bool addTriggerLists(const std::vector<edm::ParameterSet> &triggerListsAdd, AlCaRecoTriggerBits &bits) const;
-  void writeBitsToDB(const std::unique_ptr<AlCaRecoTriggerBits> &bitsToWrite) const;
+  void writeBitsToDB(const AlCaRecoTriggerBits &bitsToWrite) const;
 
   edm::ESGetToken<AlCaRecoTriggerBits, AlCaRecoTriggerBitsRcd> triggerBitsToken_;
   unsigned int nEventCalls_;
@@ -94,7 +94,7 @@ void AlCaRecoTriggerBitsRcdUpdate::analyze(const edm::Event &evt, const edm::Eve
   this->replaceKeysFromMap(alcarecoReplace_, bitsToWrite->m_alcarecoToTrig);
 
   // finally write to DB
-  this->writeBitsToDB(bitsToWrite);
+  this->writeBitsToDB(*bitsToWrite);
 }
 
 ///////////////////////////////////////////////////////////////////////
@@ -171,7 +171,7 @@ bool AlCaRecoTriggerBitsRcdUpdate::addTriggerLists(const std::vector<edm::Parame
 }
 
 ///////////////////////////////////////////////////////////////////////
-void AlCaRecoTriggerBitsRcdUpdate::writeBitsToDB(const std::unique_ptr<AlCaRecoTriggerBits> &bitsToWrite) const {
+void AlCaRecoTriggerBitsRcdUpdate::writeBitsToDB(const AlCaRecoTriggerBits &bitsToWrite) const {
   edm::LogInfo("") << "Uploading to the database...";
 
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
@@ -179,9 +179,7 @@ void AlCaRecoTriggerBitsRcdUpdate::writeBitsToDB(const std::unique_ptr<AlCaRecoT
     throw cms::Exception("NotAvailable") << "PoolDBOutputService not available.\n";
   }
 
-  // FIXME: Have to check that timetype is run number! How?
-  const std::string recordName("AlCaRecoTriggerBitsRcd");
-  poolDbService->writeOneIOV(*bitsToWrite, firstRunIOV_, recordName);
+  poolDbService->writeOneIOV(bitsToWrite, firstRunIOV_, "AlCaRecoTriggerBitsRcd");
 
   edm::LogInfo("") << "...done for runs " << firstRunIOV_ << " to " << lastRunIOV_ << " (< 0 meaning infinity)!";
 }


### PR DESCRIPTION
#### PR description:
Part of cms-AlCaDB/AlCaTools#28
Migrated to use the new PoolDBOutput methods in `CondFormats/PhysicsToolsObjects/test/T*Writer.cc` and
restructured the AlCaRecoTriggerBits writer (thanks @ggovi for the help!)

#### PR validation:
Code compiles and `scramv1 b runtests` runs fine

#### Backport:
N/A


FYI @cms-sw/alca-l2 @hjkwon260