### PR TITLE
fix memory bug in DNN-based ID (packport of #35984)

### DIFF
--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.cc
@@ -291,7 +291,7 @@ void GsfElectronProducer::fillDescriptions(edm::ConfigurationDescriptions& descr
     psd1.add<bool>("enabled", false);
     psd1.add<std::string>("inputTensorName", "FirstLayer_input");
     psd1.add<std::string>("outputTensorName", "sequential/FinalLayer/Softmax");
-    psd1.add<uint>("outputDim", 3);  // Dimension of output vector
+    psd1.add<uint>("outputDim", 5);  // Number of output nodes of DNN
     psd1.add<std::vector<std::string>>(
         "modelsFiles",
         {"RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/lowpT/lowpT_modelDNN.pb",


### PR DESCRIPTION
see details in #35984

I'm proposing a backport to avoid seeing random differences in comparisons due to the two uninitialized variables as seen e.g. in https://github.com/cms-sw/cmssw/pull/36089#issuecomment-966401112

@swagata87 

