### PR TITLE
Add option to EMTF to use custom pT lookup tables for efficiency and rate studies

### DIFF
--- a/L1Trigger/L1TMuonEndCap/interface/EMTFSetup.h
+++ b/L1Trigger/L1TMuonEndCap/interface/EMTFSetup.h
@@ -72,6 +72,9 @@ private:
   unsigned fw_ver_;
   unsigned pt_lut_ver_;
   unsigned pc_lut_ver_;
+
+  std::string xmlLutVersion_;
+  bool useCustomLUTs_;
 };
 
 #endif

--- a/L1Trigger/L1TMuonEndCap/python/simEmtfDigis_cfi.py
+++ b/L1Trigger/L1TMuonEndCap/python/simEmtfDigis_cfi.py
@@ -13,6 +13,10 @@ simEmtfDigisMC = cms.EDProducer("L1TMuonEndCapTrackProducer",
     # Verbosity level
     verbosity = cms.untracked.int32(0),
 
+    # expert options to use the pT lookup tables in default directory L1Trigger/L1TMuonEndCap/data/pt_xmls/$xmlLutVersion/
+    xmlLutVersion = cms.string(''),
+    useCustomLUTs = cms.bool(False),
+
     # Configure by firmware version, which may be different than the default parameters in this file
     FWConfig = cms.bool(True),
 

--- a/L1Trigger/L1TMuonEndCap/src/EMTFSetup.cc
+++ b/L1Trigger/L1TMuonEndCap/src/EMTFSetup.cc
@@ -29,6 +29,9 @@ EMTFSetup::EMTFSetup(const edm::ParameterSet& iConfig, edm::ConsumesCollector iC
     throw cms::Exception("L1TMuonEndCap") << "Cannot recognize the era option: " << era();
   }
 
+  xmlLutVersion_ = iConfig.getParameter<std::string>("xmlLutVersion");
+  useCustomLUTs_ = iConfig.getParameter<bool>("useCustomLUTs");
+
   // No era setup for displaced pT assignment engine
   pt_assign_engine_dxy_ = std::make_unique<PtAssignmentEngineDxy>();
 
@@ -62,7 +65,11 @@ void EMTFSetup::reload(const edm::Event& iEvent, const edm::EventSetup& iSetup) 
   sector_processor_lut_.read(iEvent.isRealData(), get_pc_lut_version());
 
   // Reload pT LUT if necessary
-  pt_assign_engine_->load(get_pt_lut_version(), condition_helper_.getForest());
+  if (useCustomLUTs_) {
+    pt_assign_engine_->read(get_pt_lut_version(), xmlLutVersion_);
+  } else {
+    pt_assign_engine_->load(get_pt_lut_version(), condition_helper_.getForest());
+  }
 
   return;
 }


### PR DESCRIPTION
#### PR description:

The EMTF should have an option to load custom pT lookup tables from the directory `L1Trigger/L1TMuonEndCap/data/pt_xmls/` rather than from the conditions database for testing purposes. When `useCustomLUTs` is set to True, the `EMTFSetup` class directs the `PtAssignmentEngine` class to load 400 xml files from `L1Trigger/L1TMuonEndCap/data/pt_xmls/${xmlLutVersion}/${mode}/` where xmlLutVersion is a version number, and `mode` is a number that corresponds to the EMTF track mode (`3, 5, 9, 6, 10, 12, 7, 11, 13, 14, 15`). This allows us to use the retrained BDT LUTs on Run-3 MC single muon for efficiency studies, and Run-3 neutrino gun or Run-2 ZeroBias data for rate studies.

#### PR validation:

Tested with a Run-3 single muon gun.
Ran `scram b code-format; scram b code-checks; scram b runtests`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

@jrotter2 @eyigitba @jiafulow @abrinke1 