### PR TITLE
ES consume migration of LumiAlCaRecoProducer

### DIFF
--- a/Calibration/LumiAlCaRecoProducers/plugins/RawPCCProducer.cc
+++ b/Calibration/LumiAlCaRecoProducers/plugins/RawPCCProducer.cc
@@ -41,6 +41,7 @@ private:
   void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const final;
 
   edm::EDGetTokenT<reco::PixelClusterCounts> pccToken_;
+  const edm::ESGetToken<LumiCorrections, LumiCorrectionsRcd> lumiCorrectionsToken_;
   const edm::EDPutTokenT<LumiInfo> putToken_;
   const std::string takeAverageValue_;  //Output average values
 
@@ -55,7 +56,8 @@ private:
 
 //--------------------------------------------------------------------------------------------------
 RawPCCProducer::RawPCCProducer(const edm::ParameterSet& iConfig)
-    : putToken_{produces<LumiInfo, edm::Transition::EndLuminosityBlock>(
+    : lumiCorrectionsToken_(esConsumes()),
+      putToken_{produces<LumiInfo, edm::Transition::EndLuminosityBlock>(
           iConfig.getParameter<edm::ParameterSet>("RawPCCProducerParameters")
               .getUntrackedParameter<std::string>("outputProductName", "alcaLumi"))},
       takeAverageValue_{iConfig.getParameter<edm::ParameterSet>("RawPCCProducerParameters")
@@ -123,9 +125,8 @@ void RawPCCProducer::globalEndLuminosityBlockProduce(edm::LuminosityBlock& lumiS
 
   std::vector<float> correctionScaleFactors;
   if (applyCorr_) {
-    edm::ESHandle<LumiCorrections> corrHandle;
-    iSetup.get<LumiCorrectionsRcd>().get(corrHandle);
-    const LumiCorrections* pccCorrections = corrHandle.product();
+    //Get PCC corrections from the event setup through a token
+    const auto pccCorrections = &iSetup.getData(lumiCorrectionsToken_);
     correctionScaleFactors = pccCorrections->getCorrectionsBX();
   } else {
     correctionScaleFactors.resize(LumiConstants::numBX, 1.0);


### PR DESCRIPTION
#### PR description:

ES consume migration of LumiAlCaRecoProducer

#### PR validation:

I tried to run the unit tests but got file not found error :( 
Maybe it will work for Jenkins
Anyway the code compiles

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
