### PR TITLE
Appropriately fill `PFCandidate::dnn_gamma_` data member in the constructors and copy operator

### DIFF
--- a/DataFormats/ParticleFlowCandidate/src/PFCandidate.cc
+++ b/DataFormats/ParticleFlowCandidate/src/PFCandidate.cc
@@ -45,6 +45,7 @@ PFCandidate::PFCandidate()
       dnn_e_bkgNonIsolated_(PFCandidate::bigMva_),
       dnn_e_bkgTau_(PFCandidate::bigMva_),
       dnn_e_bkgPhoton_(PFCandidate::bigMva_),
+      dnn_gamma_(PFCandidate::bigMva_),
       getter_(nullptr),
       storedRefsBitPattern_(0),
       time_(0.f),
@@ -89,6 +90,7 @@ PFCandidate::PFCandidate(Charge charge, const LorentzVector& p4, ParticleType pa
       dnn_e_bkgNonIsolated_(PFCandidate::bigMva_),
       dnn_e_bkgTau_(PFCandidate::bigMva_),
       dnn_e_bkgPhoton_(PFCandidate::bigMva_),
+      dnn_gamma_(PFCandidate::bigMva_),
       getter_(nullptr),
       storedRefsBitPattern_(0),
       time_(0.f),
@@ -150,6 +152,7 @@ PFCandidate::PFCandidate(PFCandidate const& iOther)
       dnn_e_bkgNonIsolated_(iOther.dnn_e_bkgNonIsolated_),
       dnn_e_bkgTau_(iOther.dnn_e_bkgTau_),
       dnn_e_bkgPhoton_(iOther.dnn_e_bkgPhoton_),
+      dnn_gamma_(iOther.dnn_gamma_),
       positionAtECALEntrance_(iOther.positionAtECALEntrance_),
       getter_(iOther.getter_),
       storedRefsBitPattern_(iOther.storedRefsBitPattern_),
@@ -199,6 +202,7 @@ PFCandidate& PFCandidate::operator=(PFCandidate const& iOther) {
   dnn_e_bkgNonIsolated_ = iOther.dnn_e_bkgNonIsolated_;
   dnn_e_bkgTau_ = iOther.dnn_e_bkgTau_;
   dnn_e_bkgPhoton_ = iOther.dnn_e_bkgPhoton_;
+  dnn_gamma_ = iOther.dnn_gamma_;
   positionAtECALEntrance_ = iOther.positionAtECALEntrance_;
   getter_ = iOther.getter_;
   storedRefsBitPattern_ = iOther.storedRefsBitPattern_;


### PR DESCRIPTION
#### PR description:

This PR fixes a bug which was introduced in https://github.com/cms-sw/cmssw/pull/35403.
`dnn_gamma_` was declared in `DataFormats/ParticleFlowCandidate/interface/PFCandidate.h`, but it was never initialised or filled.

#### PR validation:
Using Higgs->gamma gamma GEN-SIM-DIGI-RAW RelVal, ran the AOD step, and printed PFCandidate's `dnn_gamma()` score, when the PFCandidate is identified as a photon, i.e. pdgId is 22; and pT>20 GeV.
 
Before this PR:
```
 evt  0
PF-photon, pf cand pdgId= 22  pt= 33.189727783203125 dnn score  8.036290025386882e+20
PF-photon, pf cand pdgId= 22  pt= 74.13899230957031 dnn score  8.036290025386882e+20
 
 evt  1
PF-photon, pf cand pdgId= 22  pt= 20.03341293334961 dnn score  0.0
PF-photon, pf cand pdgId= 22  pt= 48.14902114868164 dnn score  2.883718096749398e-38
 
 evt  2
PF-photon, pf cand pdgId= 22  pt= 63.15763854980469 dnn score  -2.0328792349690342e-20
PF-photon, pf cand pdgId= 22  pt= 98.55475616455078 dnn score  0.0
 
 evt  3
PF-photon, pf cand pdgId= 22  pt= 104.18643951416016 dnn score  -6.0656864661723375e-05
 
 evt  4
PF-photon, pf cand pdgId= 22  pt= 55.326622009277344 dnn score  0.0
PF-photon, pf cand pdgId= 22  pt= 57.880157470703125 dnn score  0.0
```

After this PR:
```
 evt  0
PF-photon, pf cand pdgId= 22  pt= 33.189727783203125 dnn score  0.9908796548843384
PF-photon, pf cand pdgId= 22  pt= 74.13899230957031 dnn score  0.9941856265068054
 
 evt  1
PF-photon, pf cand pdgId= 22  pt= 20.03341293334961 dnn score  -999.0
PF-photon, pf cand pdgId= 22  pt= 48.14902114868164 dnn score  0.9918241500854492
 
 evt  2
PF-photon, pf cand pdgId= 22  pt= 63.15763854980469 dnn score  0.9920834898948669
PF-photon, pf cand pdgId= 22  pt= 98.55475616455078 dnn score  0.9920132160186768
 
 evt  3
PF-photon, pf cand pdgId= 22  pt= 104.18643951416016 dnn score  0.9921286106109619
 
 evt  4
PF-photon, pf cand pdgId= 22  pt= 55.326622009277344 dnn score  0.9912372827529907
PF-photon, pf cand pdgId= 22  pt= 57.880157470703125 dnn score  0.9917799234390259
```

`runTheMatrix.py -l 12434.0` ran fine.

This PR is not a backport.
Backport not needed.