### PR TITLE
Modernize several modules in TopQuarkAnalysis

### DIFF
--- a/CondFormats/PhysicsToolsObjects/interface/MVAComputer.h
+++ b/CondFormats/PhysicsToolsObjects/interface/MVAComputer.h
@@ -226,7 +226,8 @@ namespace PhysicsTools {
 
       MVAComputer &operator=(const MVAComputer &orig);
 
-      virtual std::vector<VarProcessor *> getProcessors() const;
+      virtual std::vector<VarProcessor *> getProcessors();
+      virtual std::vector<const VarProcessor *> getProcessors() const;
       void addProcessor(const VarProcessor *proc);
 
       // cacheId stuff to detect changes

--- a/CondFormats/PhysicsToolsObjects/src/MVAComputer.cc
+++ b/CondFormats/PhysicsToolsObjects/src/MVAComputer.cc
@@ -138,7 +138,13 @@ namespace PhysicsTools {
       return *this;
     }
 
-    std::vector<VarProcessor *> MVAComputer::getProcessors() const { return processors; }
+    std::vector<VarProcessor *> MVAComputer::getProcessors() { return processors; }
+
+    std::vector<const VarProcessor *> MVAComputer::getProcessors() const {
+      std::vector<const VarProcessor *> ret(processors.size());
+      std::copy(processors.begin(), processors.end(), ret.begin());
+      return ret;
+    }
 
     void MVAComputer::addProcessor(const VarProcessor *proc) {
       cacheId = getNextMVAComputerCacheId();

--- a/PhysicsTools/MVAComputer/interface/MVAComputerCache.h
+++ b/PhysicsTools/MVAComputer/interface/MVAComputerCache.h
@@ -13,8 +13,6 @@
 
 #include <memory>
 
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "PhysicsTools/MVAComputer/interface/Calibration.h"
 #include "PhysicsTools/MVAComputer/interface/MVAComputer.h"
 
@@ -32,34 +30,6 @@ namespace PhysicsTools {
 
     bool update(const Calibration::MVAComputer *computer);
     bool update(const Calibration::MVAComputerContainer *container, const char *calib);
-
-    template <class T>
-    bool update(const edm::EventSetup &es) {
-      edm::ESHandle<Calibration::MVAComputer> handle;
-      es.get<T>().get(handle);
-      return update(handle.product());
-    }
-
-    template <class T>
-    bool update(const edm::EventSetup &es, const char *calib) {
-      edm::ESHandle<Calibration::MVAComputerContainer> handle;
-      es.get<T>().get(handle);
-      return update(handle.product(), calib);
-    }
-
-    template <class T>
-    bool update(const char *label, const edm::EventSetup &es) {
-      edm::ESHandle<Calibration::MVAComputer> handle;
-      es.get<T>().get(label, handle);
-      return update(handle.product());
-    }
-
-    template <class T>
-    bool update(const char *label, const edm::EventSetup &es, const char *calib) {
-      edm::ESHandle<Calibration::MVAComputerContainer> handle;
-      es.get<T>().get(label, handle);
-      return update(handle.product(), calib);
-    }
 
     operator bool() const { return computer.get(); }
 

--- a/PhysicsTools/MVAComputer/src/MVAComputer.cc
+++ b/PhysicsTools/MVAComputer/src/MVAComputer.cc
@@ -58,12 +58,11 @@ namespace PhysicsTools {
       trainCalib->initFlags(flags);
 
     VarProcessor::ConfigCtx config(flags);
-    std::vector<Calibration::VarProcessor *> processors = calib->getProcessors();
+    std::vector<const Calibration::VarProcessor *> processors = calib->getProcessors();
 
-    for (std::vector<Calibration::VarProcessor *>::const_iterator iter = processors.begin(); iter != processors.end();
-         ++iter) {
-      std::string name = (*iter)->getInstanceName();
-      VarProcessor *processor = VarProcessor::create(name.c_str(), *iter, this);
+    for (const auto* calibProc : processors) {
+      std::string name = calibProc->getInstanceName();
+      VarProcessor *processor = VarProcessor::create(name.c_str(), calibProc, this);
       if (!processor)
         throw cms::Exception("UnknownProcessor") << name << " could not be instantiated." << std::endl;
 

--- a/PhysicsTools/MVAComputer/src/MVAComputer.cc
+++ b/PhysicsTools/MVAComputer/src/MVAComputer.cc
@@ -60,7 +60,7 @@ namespace PhysicsTools {
     VarProcessor::ConfigCtx config(flags);
     std::vector<const Calibration::VarProcessor *> processors = calib->getProcessors();
 
-    for (const auto* calibProc : processors) {
+    for (const auto *calibProc : processors) {
       std::string name = calibProc->getInstanceName();
       VarProcessor *processor = VarProcessor::create(name.c_str(), calibProc, this);
       if (!processor)

--- a/PhysicsTools/MVAComputer/test/testMVAComputerEvaluate.cc
+++ b/PhysicsTools/MVAComputer/test/testMVAComputerEvaluate.cc
@@ -1,10 +1,9 @@
 #include <iostream>
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/stream/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "PhysicsTools/MVAComputer/interface/MVAComputerCache.h"
@@ -20,7 +19,7 @@
 
 using namespace PhysicsTools;
 
-class testMVAComputerEvaluate : public edm::EDAnalyzer {
+class testMVAComputerEvaluate : public edm::stream::EDAnalyzer<> {
 public:
   explicit testMVAComputerEvaluate(const edm::ParameterSet& params);
 
@@ -48,7 +47,7 @@ void testMVAComputerEvaluate::analyze(const edm::Event& iEvent, const edm::Event
   // std::vector also works, but plain array has better performance
   // for fixed-size arrays (no internal malloc/free)
 
-  std::cout << "mva.eval(x = 1.0, y = 1.5) = " << result << std::endl;
+  edm::LogPrint("testMVAComputerEvaluate") << "mva.eval(x = 1.0, y = 1.5) = " << result;
 }
 
 // define this as a plug-in

--- a/PhysicsTools/MVAComputer/test/testMVAComputerEvaluate.cc
+++ b/PhysicsTools/MVAComputer/test/testMVAComputerEvaluate.cc
@@ -27,6 +27,7 @@ public:
   virtual void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup);
 
 private:
+  edm::ESGetToken<PhysicsTools::Calibration::MVAComputerContainer, MVADemoRcd> mvaToken_;
   MVAComputerCache mvaComputer;
 };
 
@@ -38,7 +39,7 @@ void testMVAComputerEvaluate::analyze(const edm::Event& iEvent, const edm::Event
   // you can use a MVAComputerContainer to pass around
   // multiple different MVA's in one event setup record
   // identify the right one by a definable name string
-  mvaComputer.update<MVADemoRcd>(iSetup, "testMVA");
+  mvaComputer.update(&iSetup.getData(mvaToken_), "testMVA");
 
   Variable::Value values[] = {Variable::Value("x", 1.0), Variable::Value("y", 1.5)};
 

--- a/TopQuarkAnalysis/TopEventSelection/plugins/TtFullHadSignalSelMVAComputer.cc
+++ b/TopQuarkAnalysis/TopEventSelection/plugins/TtFullHadSignalSelMVAComputer.cc
@@ -11,7 +11,7 @@
 #include "DataFormats/PatCandidates/interface/Flags.h"
 
 TtFullHadSignalSelMVAComputer::TtFullHadSignalSelMVAComputer(const edm::ParameterSet& cfg)
-    : jetsToken_(consumes<std::vector<pat::Jet> >(cfg.getParameter<edm::InputTag>("jets"))) {
+    : mvaToken_(esConsumes()), jetsToken_(consumes<std::vector<pat::Jet> >(cfg.getParameter<edm::InputTag>("jets"))) {
   produces<double>("DiscSel");
 }
 
@@ -20,7 +20,7 @@ TtFullHadSignalSelMVAComputer::~TtFullHadSignalSelMVAComputer() {}
 void TtFullHadSignalSelMVAComputer::produce(edm::Event& evt, const edm::EventSetup& setup) {
   std::unique_ptr<double> pOutDisc(new double);
 
-  mvaComputer.update<TtFullHadSignalSelMVARcd>(setup, "ttFullHadSignalSelMVA");
+  mvaComputer.update(&setup.getData(mvaToken_), "ttFullHadSignalSelMVA");
 
   edm::Handle<std::vector<pat::Jet> > jets;
   evt.getByToken(jetsToken_, jets);

--- a/TopQuarkAnalysis/TopEventSelection/plugins/TtFullHadSignalSelMVAComputer.cc
+++ b/TopQuarkAnalysis/TopEventSelection/plugins/TtFullHadSignalSelMVAComputer.cc
@@ -22,13 +22,6 @@ void TtFullHadSignalSelMVAComputer::produce(edm::Event& evt, const edm::EventSet
 
   mvaComputer.update<TtFullHadSignalSelMVARcd>(setup, "ttFullHadSignalSelMVA");
 
-  // read name of the last processor in the MVA calibration
-  // (to be used as meta information)
-  edm::ESHandle<PhysicsTools::Calibration::MVAComputerContainer> calibContainer;
-  setup.get<TtFullHadSignalSelMVARcd>().get(calibContainer);
-  std::vector<PhysicsTools::Calibration::VarProcessor*> processors =
-      (calibContainer->find("ttFullHadSignalSelMVA")).getProcessors();
-
   edm::Handle<std::vector<pat::Jet> > jets;
   evt.getByToken(jetsToken_, jets);
 

--- a/TopQuarkAnalysis/TopEventSelection/plugins/TtFullHadSignalSelMVAComputer.h
+++ b/TopQuarkAnalysis/TopEventSelection/plugins/TtFullHadSignalSelMVAComputer.h
@@ -2,7 +2,7 @@
 #define TtFullHadSignalSelMVAComputer_h
 
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "PhysicsTools/MVAComputer/interface/HelperMacros.h"
 #include "PhysicsTools/MVAComputer/interface/MVAComputerCache.h"
@@ -15,22 +15,18 @@
 MVA_COMPUTER_CONTAINER_DEFINE(TtFullHadSignalSelMVA);  // defines TopFullHadLepSignalSelMVARcd
 #endif
 
-class TtFullHadSignalSelMVAComputer : public edm::EDProducer {
+class TtFullHadSignalSelMVAComputer : public edm::stream::EDProducer<> {
 public:
   explicit TtFullHadSignalSelMVAComputer(const edm::ParameterSet&);
-  ~TtFullHadSignalSelMVAComputer() override;
 
 private:
-  void beginJob() override;
   void produce(edm::Event& evt, const edm::EventSetup& setup) override;
-  void endJob() override;
 
   edm::ESGetToken<PhysicsTools::Calibration::MVAComputerContainer, TtFullHadSignalSelMVARcd> mvaToken_;
   edm::EDGetTokenT<std::vector<pat::Jet> > jetsToken_;
+  edm::EDPutTokenT<double> putToken_;
 
   PhysicsTools::MVAComputerCache mvaComputer;
-
-  double DiscSel;
 };
 
 #endif

--- a/TopQuarkAnalysis/TopEventSelection/plugins/TtFullHadSignalSelMVAComputer.h
+++ b/TopQuarkAnalysis/TopEventSelection/plugins/TtFullHadSignalSelMVAComputer.h
@@ -25,6 +25,7 @@ private:
   void produce(edm::Event& evt, const edm::EventSetup& setup) override;
   void endJob() override;
 
+  edm::ESGetToken<PhysicsTools::Calibration::MVAComputerContainer, TtFullHadSignalSelMVARcd> mvaToken_;
   edm::EDGetTokenT<std::vector<pat::Jet> > jetsToken_;
 
   PhysicsTools::MVAComputerCache mvaComputer;

--- a/TopQuarkAnalysis/TopEventSelection/plugins/TtSemiLepSignalSelMVAComputer.cc
+++ b/TopQuarkAnalysis/TopEventSelection/plugins/TtSemiLepSignalSelMVAComputer.cc
@@ -11,16 +11,17 @@
 #include "DataFormats/PatCandidates/interface/Flags.h"
 
 TtSemiLepSignalSelMVAComputer::TtSemiLepSignalSelMVAComputer(const edm::ParameterSet& cfg)
-    : muonsToken_(consumes<edm::View<pat::Muon> >(cfg.getParameter<edm::InputTag>("muons"))),
+    : mvaToken_(esConsumes()),
+      muonsToken_(consumes<edm::View<pat::Muon> >(cfg.getParameter<edm::InputTag>("muons"))),
       jetsToken_(consumes<std::vector<pat::Jet> >(cfg.getParameter<edm::InputTag>("jets"))),
       METsToken_(consumes<edm::View<pat::MET> >(cfg.getParameter<edm::InputTag>("mets"))),
-    electronsToken_(consumes<edm::View<pat::Electron> >(cfg.getParameter<edm::InputTag>("elecs"))),
-  putToken_(produces("DiscSel")) {}
+      electronsToken_(consumes<edm::View<pat::Electron> >(cfg.getParameter<edm::InputTag>("elecs"))),
+      putToken_(produces("DiscSel")) {}
 
 TtSemiLepSignalSelMVAComputer::~TtSemiLepSignalSelMVAComputer() {}
 
 void TtSemiLepSignalSelMVAComputer::produce(edm::Event& evt, const edm::EventSetup& setup) {
-  mvaComputer.update<TtSemiLepSignalSelMVARcd>(setup, "ttSemiLepSignalSelMVA");
+  mvaComputer.update(&setup.getData(mvaToken_), "ttSemiLepSignalSelMVA");
 
   //make your preselection! This must!! be the same one as in TraintreeSaver.cc
   edm::Handle<edm::View<pat::MET> > MET_handle;

--- a/TopQuarkAnalysis/TopEventSelection/plugins/TtSemiLepSignalSelMVAComputer.h
+++ b/TopQuarkAnalysis/TopEventSelection/plugins/TtSemiLepSignalSelMVAComputer.h
@@ -2,7 +2,7 @@
 #define TtSemiLepSignalSelMVAComputer_h
 
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "PhysicsTools/MVAComputer/interface/HelperMacros.h"
 #include "PhysicsTools/MVAComputer/interface/MVAComputerCache.h"
@@ -18,15 +18,13 @@
 MVA_COMPUTER_CONTAINER_DEFINE(TtSemiLepSignalSelMVA);  // defines TopSemiLepLepSignalSelMVARcd
 #endif
 
-class TtSemiLepSignalSelMVAComputer : public edm::EDProducer {
+class TtSemiLepSignalSelMVAComputer : public edm::stream::EDProducer<> {
 public:
   explicit TtSemiLepSignalSelMVAComputer(const edm::ParameterSet&);
   ~TtSemiLepSignalSelMVAComputer() override;
 
 private:
-  void beginJob() override;
   void produce(edm::Event& evt, const edm::EventSetup& setup) override;
-  void endJob() override;
 
   double DeltaPhi(const math::XYZTLorentzVector& v1, const math::XYZTLorentzVector& v2);
   double DeltaR(const math::XYZTLorentzVector& v1, const math::XYZTLorentzVector& v2);
@@ -35,10 +33,9 @@ private:
   edm::EDGetTokenT<std::vector<pat::Jet> > jetsToken_;
   edm::EDGetTokenT<edm::View<pat::MET> > METsToken_;
   edm::EDGetTokenT<edm::View<pat::Electron> > electronsToken_;
+  edm::EDPutTokenT<double> putToken_;
 
   PhysicsTools::MVAComputerCache mvaComputer;
-
-  double DiscSel;
 };
 
 #endif

--- a/TopQuarkAnalysis/TopEventSelection/plugins/TtSemiLepSignalSelMVAComputer.h
+++ b/TopQuarkAnalysis/TopEventSelection/plugins/TtSemiLepSignalSelMVAComputer.h
@@ -29,6 +29,7 @@ private:
   double DeltaPhi(const math::XYZTLorentzVector& v1, const math::XYZTLorentzVector& v2);
   double DeltaR(const math::XYZTLorentzVector& v1, const math::XYZTLorentzVector& v2);
 
+  edm::ESGetToken<PhysicsTools::Calibration::MVAComputerContainer, TtSemiLepSignalSelMVARcd> mvaToken_;
   edm::EDGetTokenT<edm::View<pat::Muon> > muonsToken_;
   edm::EDGetTokenT<std::vector<pat::Jet> > jetsToken_;
   edm::EDGetTokenT<edm::View<pat::MET> > METsToken_;

--- a/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombMVAComputer.cc
+++ b/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombMVAComputer.cc
@@ -3,7 +3,8 @@
 #include "TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombMVAComputer.h"
 
 TtSemiLepJetCombMVAComputer::TtSemiLepJetCombMVAComputer(const edm::ParameterSet& cfg)
-    : lepsToken_(consumes<edm::View<reco::RecoCandidate>>(cfg.getParameter<edm::InputTag>("leps"))),
+    : mvaToken_(esConsumes()),
+      lepsToken_(consumes<edm::View<reco::RecoCandidate>>(cfg.getParameter<edm::InputTag>("leps"))),
       jetsToken_(consumes<std::vector<pat::Jet>>(cfg.getParameter<edm::InputTag>("jets"))),
       metsToken_(consumes<std::vector<pat::MET>>(cfg.getParameter<edm::InputTag>("mets"))),
       maxNJets_(cfg.getParameter<int>("maxNJets")),
@@ -22,7 +23,7 @@ void TtSemiLepJetCombMVAComputer::produce(edm::Event& evt, const edm::EventSetup
   std::unique_ptr<std::string> pOutMeth(new std::string);
   std::unique_ptr<int> pJetsConsidered(new int);
 
-  mvaComputer.update<TtSemiLepJetCombMVARcd>(setup, "ttSemiLepJetCombMVA");
+  mvaComputer.update(&setup.getData(mvaToken_), "ttSemiLepJetCombMVA");
 
   // read name of the processor that provides the MVA discriminator
   // (to be used as meta information)

--- a/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombMVAComputer.cc
+++ b/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombMVAComputer.cc
@@ -28,7 +28,7 @@ void TtSemiLepJetCombMVAComputer::produce(edm::Event& evt, const edm::EventSetup
   // (to be used as meta information)
   edm::ESHandle<PhysicsTools::Calibration::MVAComputerContainer> calibContainer;
   setup.get<TtSemiLepJetCombMVARcd>().get(calibContainer);
-  std::vector<PhysicsTools::Calibration::VarProcessor*> processors =
+  std::vector<const PhysicsTools::Calibration::VarProcessor*> processors =
       (calibContainer->find("ttSemiLepJetCombMVA")).getProcessors();
   *pOutMeth = (processors[processors.size() - 3])->getInstanceName();
   evt.put(std::move(pOutMeth), "Method");

--- a/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombMVAComputer.cc
+++ b/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombMVAComputer.cc
@@ -15,22 +15,19 @@ TtSemiLepJetCombMVAComputer::TtSemiLepJetCombMVAComputer(const edm::ParameterSet
   produces<int>("NumberOfConsideredJets");
 }
 
-TtSemiLepJetCombMVAComputer::~TtSemiLepJetCombMVAComputer() {}
-
 void TtSemiLepJetCombMVAComputer::produce(edm::Event& evt, const edm::EventSetup& setup) {
   std::unique_ptr<std::vector<std::vector<int>>> pOut(new std::vector<std::vector<int>>);
   std::unique_ptr<std::vector<double>> pOutDisc(new std::vector<double>);
   std::unique_ptr<std::string> pOutMeth(new std::string);
   std::unique_ptr<int> pJetsConsidered(new int);
 
-  mvaComputer.update(&setup.getData(mvaToken_), "ttSemiLepJetCombMVA");
+  const auto& calibContainer = setup.getData(mvaToken_);
+  mvaComputer.update(&calibContainer, "ttSemiLepJetCombMVA");
 
   // read name of the processor that provides the MVA discriminator
   // (to be used as meta information)
-  edm::ESHandle<PhysicsTools::Calibration::MVAComputerContainer> calibContainer;
-  setup.get<TtSemiLepJetCombMVARcd>().get(calibContainer);
   std::vector<const PhysicsTools::Calibration::VarProcessor*> processors =
-      (calibContainer->find("ttSemiLepJetCombMVA")).getProcessors();
+      (calibContainer.find("ttSemiLepJetCombMVA")).getProcessors();
   *pOutMeth = (processors[processors.size() - 3])->getInstanceName();
   evt.put(std::move(pOutMeth), "Method");
 
@@ -120,10 +117,6 @@ void TtSemiLepJetCombMVAComputer::produce(edm::Event& evt, const edm::EventSetup
   evt.put(std::move(pOutDisc), "Discriminators");
   evt.put(std::move(pJetsConsidered), "NumberOfConsideredJets");
 }
-
-void TtSemiLepJetCombMVAComputer::beginJob() {}
-
-void TtSemiLepJetCombMVAComputer::endJob() {}
 
 // implement the plugins for the computer container
 // -> register TtSemiLepJetCombMVARcd

--- a/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombMVAComputer.h
+++ b/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombMVAComputer.h
@@ -2,7 +2,7 @@
 #define TtSemiLepJetCombMVAComputer_h
 
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "PhysicsTools/MVAComputer/interface/HelperMacros.h"
 #include "PhysicsTools/MVAComputer/interface/MVAComputerCache.h"
@@ -18,23 +18,20 @@
 MVA_COMPUTER_CONTAINER_DEFINE(TtSemiLepJetCombMVA);  // defines TtSemiLepJetCombMVARcd
 #endif
 
-class TtSemiLepJetCombMVAComputer : public edm::EDProducer {
+class TtSemiLepJetCombMVAComputer : public edm::stream::EDProducer<> {
 public:
   explicit TtSemiLepJetCombMVAComputer(const edm::ParameterSet&);
-  ~TtSemiLepJetCombMVAComputer() override;
 
 private:
-  void beginJob() override;
   void produce(edm::Event& evt, const edm::EventSetup& setup) override;
-  void endJob() override;
 
   edm::ESGetToken<PhysicsTools::Calibration::MVAComputerContainer, TtSemiLepJetCombMVARcd> mvaToken_;
   edm::EDGetTokenT<edm::View<reco::RecoCandidate>> lepsToken_;
   edm::EDGetTokenT<std::vector<pat::Jet>> jetsToken_;
   edm::EDGetTokenT<std::vector<pat::MET>> metsToken_;
 
-  int maxNJets_;
-  int maxNComb_;
+  const int maxNJets_;
+  const int maxNComb_;
 
   PhysicsTools::MVAComputerCache mvaComputer;
 };

--- a/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombMVAComputer.h
+++ b/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombMVAComputer.h
@@ -28,6 +28,7 @@ private:
   void produce(edm::Event& evt, const edm::EventSetup& setup) override;
   void endJob() override;
 
+  edm::ESGetToken<PhysicsTools::Calibration::MVAComputerContainer, TtSemiLepJetCombMVARcd> mvaToken_;
   edm::EDGetTokenT<edm::View<reco::RecoCandidate>> lepsToken_;
   edm::EDGetTokenT<std::vector<pat::Jet>> jetsToken_;
   edm::EDGetTokenT<std::vector<pat::MET>> metsToken_;


### PR DESCRIPTION
#### PR description:

Part of #31061.

Also change `PhysicsTools::Calibration::MVAComputer::getProcessors() const` to return `const` pointers to contained `VarProcessor` processor objects as required by ESProduct policies.

#### PR validation:

Unit tests of `TopQuarkAnalysis/TopEventSelection`, `TopQuarkAnalysis/TopEventProducers`, and `TopQuarkAnalysis/TopJetCombination` succeed when run with https://github.com/cms-sw/cmssw/pull/35588.
