### PR TITLE
finalise `esConsumes` migration of HLT pkgs

### DIFF
--- a/CommonTools/TriggerUtils/src/GenericTriggerEventFlag.cc
+++ b/CommonTools/TriggerUtils/src/GenericTriggerEventFlag.cc
@@ -717,7 +717,7 @@ std::vector<std::string> GenericTriggerEventFlag::expressionsFromDB(const std::s
           << "Label " << dbLabel_ << " not found in DB for 'AlCaRecoTriggerBitsRcd'";
     return std::vector<std::string>(1, configError_);
   }
-  AlCaRecoTriggerBits const& alCaRecoTriggerBits = setup.get<AlCaRecoTriggerBitsRcd>().get(alCaRecoTriggerBitsToken_);
+  auto const& alCaRecoTriggerBits = setup.getData(alCaRecoTriggerBitsToken_);
   const std::map<std::string, std::string>& expressionMap = alCaRecoTriggerBits.m_alcarecoToTrig;
   std::map<std::string, std::string>::const_iterator listIter = expressionMap.find(key);
   if (listIter == expressionMap.end()) {

--- a/DQM/HLTEvF/plugins/LumiMonitor.cc
+++ b/DQM/HLTEvF/plugins/LumiMonitor.cc
@@ -1,6 +1,4 @@
 #include <string>
-#include <vector>
-#include <map>
 
 #include "DQM/TrackingMonitor/interface/GetLumi.h"
 #include "DQMServices/Core/interface/DQMGlobalEDAnalyzer.h"
@@ -9,7 +7,6 @@
 #include "DataFormats/Scalers/interface/LumiScalers.h"
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -58,6 +55,8 @@ private:
   static MEbinning getHistoPSet(const edm::ParameterSet& pset);
   static MEbinning getHistoLSPSet(const edm::ParameterSet& pset);
 
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> const trkTopoToken_;
+
   std::string folderName_;
 
   edm::EDGetTokenT<LumiScalersCollection> lumiScalersToken_;
@@ -83,7 +82,8 @@ private:
 // -----------------------------
 
 LumiMonitor::LumiMonitor(const edm::ParameterSet& config)
-    : folderName_(config.getParameter<std::string>("FolderName")),
+    : trkTopoToken_{esConsumes()},
+      folderName_(config.getParameter<std::string>("FolderName")),
       lumiScalersToken_(consumes<LumiScalersCollection>(config.getParameter<edm::InputTag>("scalers"))),
       lumi_binning_(getHistoPSet(
           config.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>("lumiPSet"))),
@@ -222,7 +222,7 @@ void LumiMonitor::dqmAnalyze(edm::Event const& event,
     edm::Handle<edmNew::DetSetVector<SiPixelCluster>> pixelClusters;
     event.getByToken(pixelClustersToken_, pixelClusters);
     if (pixelClusters.isValid()) {
-      auto const& tTopo = edm::get<TrackerTopology, TrackerTopologyRcd>(setup);
+      auto const& tTopo = setup.getData(trkTopoToken_);
 
       // Count the number of clusters with at least a minimum
       // number of pixels per cluster and at least a minimum charge.

--- a/DQM/HLTEvF/plugins/TriggerBxMonitor.cc
+++ b/DQM/HLTEvF/plugins/TriggerBxMonitor.cc
@@ -11,7 +11,6 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/Run.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -20,14 +19,12 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/Provenance/interface/ProcessHistory.h"
-#include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "DataFormats/L1TGlobal/interface/GlobalAlgBlk.h"
 #include "CondFormats/DataRecord/interface/L1TUtmTriggerMenuRcd.h"
 #include "CondFormats/L1TObjects/interface/L1TUtmTriggerMenu.h"
 #include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
 #include "DQMServices/Core/interface/DQMGlobalEDAnalyzer.h"
-#include "DQMServices/Core/interface/DQMStore.h"
 
 namespace {
 
@@ -103,6 +100,7 @@ private:
   };
 
   // module configuration
+  const edm::ESGetToken<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd> m_l1tMenuToken;
   const edm::EDGetTokenT<GlobalAlgBlkBxCollection> m_l1t_results;
   const edm::EDGetTokenT<edm::TriggerResults> m_hlt_results;
   const std::string m_dqm_path;
@@ -127,6 +125,7 @@ void TriggerBxMonitor::fillDescriptions(edm::ConfigurationDescriptions& descript
 
 TriggerBxMonitor::TriggerBxMonitor(edm::ParameterSet const& config)
     :  // module configuration
+      m_l1tMenuToken{esConsumes()},
       m_l1t_results(consumes<GlobalAlgBlkBxCollection>(config.getUntrackedParameter<edm::InputTag>("l1tResults"))),
       m_hlt_results(consumes<edm::TriggerResults>(config.getUntrackedParameter<edm::InputTag>("hltResults"))),
       m_dqm_path(config.getUntrackedParameter<std::string>("dqmPath")),
@@ -229,7 +228,7 @@ void TriggerBxMonitor::bookHistograms(DQMStore::IBooker& booker,
 
     // book the individual histograms for the L1 triggers that are included in the L1 menu
     booker.setCurrentFolder(m_dqm_path + "/L1T");
-    auto const& l1tMenu = edm::get<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd>(setup);
+    auto const& l1tMenu = setup.getData(m_l1tMenuToken);
     for (auto const& keyval : l1tMenu.getAlgorithmMap()) {
       unsigned int bit = keyval.second.getIndex();
       std::string const& name = fmt::sprintf("%s (bit %d)", keyval.first, bit);
@@ -296,7 +295,7 @@ void TriggerBxMonitor::dqmAnalyze(edm::Event const& event,
 
   // monitor the bx distribution for the L1 triggers
   {
-    auto const& bxvector = edm::get(event, m_l1t_results);
+    auto const& bxvector = event.get(m_l1t_results);
     if (not bxvector.isEmpty(0)) {
       auto const& results = bxvector.at(0, 0);
       for (unsigned int i = 0; i < GlobalAlgBlk::maxPhysicsTriggers; ++i)
@@ -312,7 +311,7 @@ void TriggerBxMonitor::dqmAnalyze(edm::Event const& event,
 
   // monitor the bx distribution for the HLT triggers
   if (histograms.hltConfig.inited()) {
-    auto const& hltResults = edm::get(event, m_hlt_results);
+    auto const& hltResults = event.get(m_hlt_results);
     for (unsigned int i = 0; i < hltResults.size(); ++i) {
       if (hltResults.at(i).accept()) {
         if (m_make_1d_plots and histograms.hlt_bx.at(i))

--- a/DQM/HLTEvF/plugins/TriggerRatesMonitor.cc
+++ b/DQM/HLTEvF/plugins/TriggerRatesMonitor.cc
@@ -20,7 +20,6 @@
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
@@ -28,13 +27,11 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/Provenance/interface/ProcessHistory.h"
-#include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "DataFormats/L1TGlobal/interface/GlobalAlgBlk.h"
 #include "CondFormats/DataRecord/interface/L1TUtmTriggerMenuRcd.h"
 #include "CondFormats/L1TObjects/interface/L1TUtmTriggerMenu.h"
 #include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
-#include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/DQMGlobalEDAnalyzer.h"
 
 namespace {
@@ -139,6 +136,7 @@ private:
   };
 
   // module configuration
+  const edm::ESGetToken<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd> m_l1tMenuToken;
   const edm::EDGetTokenT<GlobalAlgBlkBxCollection> m_l1t_results;
   const edm::EDGetTokenT<edm::TriggerResults> m_hlt_results;
   const std::string m_dqm_path;
@@ -159,6 +157,7 @@ void TriggerRatesMonitor::fillDescriptions(edm::ConfigurationDescriptions &descr
 
 TriggerRatesMonitor::TriggerRatesMonitor(edm::ParameterSet const &config)
     :  // module configuration
+      m_l1tMenuToken{esConsumes()},
       m_l1t_results(consumes<GlobalAlgBlkBxCollection>(config.getUntrackedParameter<edm::InputTag>("l1tResults"))),
       m_hlt_results(consumes<edm::TriggerResults>(config.getUntrackedParameter<edm::InputTag>("hltResults"))),
       m_dqm_path(config.getUntrackedParameter<std::string>("dqmPath")),
@@ -238,7 +237,7 @@ void TriggerRatesMonitor::bookHistograms(DQMStore::IBooker &booker,
 
   // book the rate histograms for the L1 triggers that are included in the L1 menu
   booker.setCurrentFolder(m_dqm_path + "/L1T");
-  auto const &l1tMenu = edm::get<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd>(setup);
+  auto const &l1tMenu = setup.getData(m_l1tMenuToken);
   for (auto const &keyval : l1tMenu.getAlgorithmMap()) {
     unsigned int bit = keyval.second.getIndex();
     bool masked = false;  // FIXME read L1 masks once they will be avaiable in the EventSetup
@@ -333,7 +332,7 @@ void TriggerRatesMonitor::dqmAnalyze(edm::Event const &event,
     histograms.tcds_counts[event.experimentType()]->Fill(lumisection);
 
   // monitor the L1 triggers rates
-  auto const &bxvector = edm::get(event, m_l1t_results);
+  auto const &bxvector = event.get(m_l1t_results);
   if (not bxvector.isEmpty(0)) {
     auto const &results = bxvector.at(0, 0);
     for (unsigned int i = 0; i < GlobalAlgBlk::maxPhysicsTriggers; ++i)
@@ -344,9 +343,8 @@ void TriggerRatesMonitor::dqmAnalyze(edm::Event const &event,
 
   // monitor the HLT triggers and datsets rates
   if (histograms.hltConfig.inited()) {
-    edm::TriggerResults const &hltResults = edm::get(event, m_hlt_results);
-    if (hltResults.size() == histograms.hltIndices.size()) {
-    } else {
+    auto const &hltResults = event.get(m_hlt_results);
+    if (hltResults.size() != histograms.hltIndices.size()) {
       edm::LogWarning("TriggerRatesMonitor")
           << "This should never happen: the number of HLT paths has changed since the beginning of the run";
     }

--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTExtraProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTExtraProducer.cc
@@ -177,6 +177,8 @@ private:
 
   const Tokens tokens_;
 
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> const caloGeomToken_;
+
   float minPtToSaveHits_;
   bool saveHitsPlusPi_;
   bool saveHitsPlusHalfPi_;
@@ -193,6 +195,7 @@ EgammaHLTExtraProducer::Tokens::Tokens(const edm::ParameterSet& pset, edm::Consu
 
 EgammaHLTExtraProducer::EgammaHLTExtraProducer(const edm::ParameterSet& pset)
     : tokens_(pset, consumesCollector()),
+      caloGeomToken_{esConsumes()},
       minPtToSaveHits_(pset.getParameter<double>("minPtToSaveHits")),
       saveHitsPlusPi_(pset.getParameter<bool>("saveHitsPlusPi")),
       saveHitsPlusHalfPi_(pset.getParameter<bool>("saveHitsPlusHalfPi")),
@@ -295,8 +298,7 @@ void EgammaHLTExtraProducer::produce(edm::StreamID streamID,
     egTrigObjColls.emplace_back(std::move(egTrigObjs));
   }
 
-  edm::ESHandle<CaloGeometry> caloGeomHandle;
-  eventSetup.get<CaloGeometryRecord>().get(caloGeomHandle);
+  auto const caloGeomHandle = eventSetup.getHandle(caloGeomToken_);
 
   auto filterAndStoreRecHits = [caloGeomHandle, &event, this](const auto& egTrigObjs, const auto& tokenLabels) {
     for (const auto& tokenLabel : tokenLabels) {

--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTPhase2ExtraProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTPhase2ExtraProducer.cc
@@ -1,8 +1,6 @@
-
 #include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
@@ -33,7 +31,7 @@
 #include <vector>
 #include <unordered_map>
 
-//class compliments EgammaHLTExtraProducer and adds all the phase-II specific E/g HLT debug information to the event
+//class complements EgammaHLTExtraProducer and adds all the phase-II specific E/g HLT debug information to the event
 //this allows phase-II to be factorised from the standard class rather than having to extend EgammaHLTExtraProducer to deal with it
 //although to be fair, given all the phase-II code is now in the release, the need for this factorisation is not as great
 //and ultimately it could be merged into EgammaHLTExtraProducer
@@ -82,7 +80,6 @@ namespace {
 class EgammaHLTPhase2ExtraProducer : public edm::global::EDProducer<> {
 public:
   explicit EgammaHLTPhase2ExtraProducer(const edm::ParameterSet& pset);
-  ~EgammaHLTPhase2ExtraProducer() override {}
 
   void produce(edm::StreamID streamID, edm::Event& event, const edm::EventSetup& eventSetup) const override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
@@ -155,6 +152,8 @@ private:
 
   const Tokens tokens_;
 
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> const caloGeomToken_;
+
   float minPtToSaveHits_;
   bool saveHitsPlusPi_;
   bool saveHitsPlusHalfPi_;
@@ -173,6 +172,7 @@ EgammaHLTPhase2ExtraProducer::Tokens::Tokens(const edm::ParameterSet& pset, edm:
 
 EgammaHLTPhase2ExtraProducer::EgammaHLTPhase2ExtraProducer(const edm::ParameterSet& pset)
     : tokens_(pset, consumesCollector()),
+      caloGeomToken_{esConsumes()},
       minPtToSaveHits_(pset.getParameter<double>("minPtToSaveHits")),
       saveHitsPlusPi_(pset.getParameter<bool>("saveHitsPlusPi")),
       saveHitsPlusHalfPi_(pset.getParameter<bool>("saveHitsPlusHalfPi")),
@@ -226,13 +226,14 @@ void EgammaHLTPhase2ExtraProducer::produce(edm::StreamID streamID,
   auto l1trks = event.getHandle(tokens_.l1Trks);
   auto l1TrkToTrkPartMap = event.getHandle(tokens_.l1TrkToTrkPartMap);
 
-  edm::ESHandle<CaloGeometry> caloGeomHandle;
-  eventSetup.get<CaloGeometryRecord>().get(caloGeomHandle);
+  auto const caloGeomHandle = eventSetup.getHandle(caloGeomToken_);
+
   for (const auto& tokenLabel : tokens_.hgcal) {
     auto handle = event.getHandle(tokenLabel.first);
     auto recHits = filterRecHits(*egTrigObjs, handle, *caloGeomHandle);
     event.put(std::move(recHits), tokenLabel.second);
   }
+
   auto storeCountRecHits = [&event](const auto& tokenLabels, const auto& thresholds, const std::string& prefixLabel) {
     for (const auto& tokenLabel : tokenLabels) {
       auto handle = event.getHandle(tokenLabel.first);

--- a/RecoTauTag/HLTProducers/interface/VertexFromTrackProducer.h
+++ b/RecoTauTag/HLTProducers/interface/VertexFromTrackProducer.h
@@ -16,22 +16,12 @@
 //
 //
 
-// system include files
 #include <memory>
 
-// user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/global/EDProducer.h"
-
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Utilities/interface/InputTag.h"
-
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
-#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
@@ -39,14 +29,9 @@
 #include "DataFormats/RecoCandidate/interface/RecoCandidate.h"
 #include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
 
-//
-// class declaration
-//
-
 class VertexFromTrackProducer : public edm::global::EDProducer<> {
 public:
   explicit VertexFromTrackProducer(const edm::ParameterSet&);
-  ~VertexFromTrackProducer() override;
 
   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 

--- a/RecoTauTag/HLTProducers/src/L2TauTagFilter.cc
+++ b/RecoTauTag/HLTProducers/src/L2TauTagFilter.cc
@@ -9,11 +9,9 @@
 
 // user include files
 #include "HLTrigger/HLTcore/interface/HLTFilter.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"

--- a/RecoTauTag/HLTProducers/src/VertexFromTrackProducer.cc
+++ b/RecoTauTag/HLTProducers/src/VertexFromTrackProducer.cc
@@ -1,29 +1,13 @@
 #include "RecoTauTag/HLTProducers/interface/VertexFromTrackProducer.h"
-
-#include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-#include "FWCore/Framework/interface/ESHandle.h"
-
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/EgammaCandidates/interface/Electron.h"
 #include "DataFormats/Math/interface/Point3D.h"
 #include "DataFormats/Math/interface/Error.h"
-#include "DataFormats/EgammaCandidates/interface/Electron.h"
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidate.h"
 
-//using namespace reco;
-
-//
-// constants, enums and typedefs
-//
-
-//
-// static data member definitions
-//
-
-//
-// constructors and destructor
-//
 VertexFromTrackProducer::VertexFromTrackProducer(const edm::ParameterSet& conf)
     : trackToken(consumes<edm::View<reco::Track> >(conf.getParameter<edm::InputTag>("trackLabel"))),
       candidateToken(consumes<edm::View<reco::RecoCandidate> >(conf.getParameter<edm::InputTag>("trackLabel"))),
@@ -45,13 +29,6 @@ VertexFromTrackProducer::VertexFromTrackProducer(const edm::ParameterSet& conf)
   produces<reco::VertexCollection>();
 }
 
-VertexFromTrackProducer::~VertexFromTrackProducer() {}
-
-//
-// member functions
-//
-
-// ------------ method called to produce the data  ------------
 void VertexFromTrackProducer::produce(edm::StreamID iStreamId,
                                       edm::Event& iEvent,
                                       const edm::EventSetup& iSetup) const {


### PR DESCRIPTION
#### PR description:

This PR is part of #31061.

It should complete the `esConsumes` migration of packages that require a signature from HLT.

It includes minor cleanup of a couple of unrelated modules.

Merely technical. No changes expected.

#### PR validation:

`scram` builds.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

N/A