### PR TITLE
fix SiStrip online DQM client for `commissioning_run` key [12.0.X]

### DIFF
--- a/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
@@ -217,7 +217,10 @@ process.hltHighLevel.throw =  False
 # Scheduling
 #--------------------------
 process.SiStripSources_LocalReco = cms.Sequence(process.siStripFEDMonitor*process.SiStripMonitorDigi*process.SiStripMonitorClusterReal)
-process.DQMCommon                = cms.Sequence(process.stripQTester*process.trackingQTester*process.dqmEnv*process.dqmEnvTr*process.dqmSaver*process.dqmSaverPB)
+if (process.runType.getRunType() == process.runType.commissioning_run):
+    process.DQMCommon                = cms.Sequence(process.dqmEnv*process.dqmEnvTr*process.dqmSaver*process.dqmSaverPB)
+else:
+    process.DQMCommon                = cms.Sequence(process.stripQTester*process.trackingQTester*process.dqmEnv*process.dqmEnvTr*process.dqmSaver*process.dqmSaverPB)
 if (process.runType.getRunType() == process.runType.hi_run):
     process.RecoForDQM_LocalReco     = cms.Sequence(process.siPixelDigis*process.siStripDigis*process.trackerlocalreco)
 else :
@@ -300,7 +303,8 @@ if (process.runType.getRunType() == process.runType.commissioning_run):
     process.SiStripFedMonitor = cms.Sequence(process.siStripFEDMonitor)
     process.p = cms.Path(
         process.siStripFEDCheck *
-        process.SiStripFedMonitor
+        process.SiStripFedMonitor *
+        process.DQMCommon
     )
 
 #else :


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/36104

#### PR description:

It was noticed that during the Fall 2021 LHC beam test the [run 346316](https://cmsoms.cern.ch/cms/runs/report?cms_run=346316&cms_run_sequence=GLOBAL-RUN) acquired with the `commissioning_run` DQM key, didn't produce all the desired plots (essentially the SiStrip readout view summaries): see [link to online DQM](https://cmsweb.cern.ch/dqm/online/start?runnr=346316;dataset=/Global/Online/ALL;sampletype=online_data;filter=all;referencepos=overlay;referenceshow=customise;referencenorm=True;referenceobj1=refobj;referenceobj2=none;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=Everything;size=M;root=SiStrip;focus=;zoom=no;).
This based on private tests from @arossi83 (thanks!) is apparently due to the missing  `process.DQMCommon` sequence in the path.
This PR fixes the problem.

#### PR validation:

Private, but if possible it would be good to do a replay of run 346316 using this branch.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/36104
