### PR TITLE
MTD geometry: replace string with string_view in MTDBaseNumber 

### DIFF
--- a/Geometry/MTDCommonData/interface/MTDBaseNumber.h
+++ b/Geometry/MTDCommonData/interface/MTDBaseNumber.h
@@ -19,12 +19,12 @@ public:
   ~MTDBaseNumber() {}
 
   void setSize(const int& size);
-  void addLevel(const std::string& name, const int& copyNumber);
+  void addLevel(const std::string_view& name, const int& copyNumber);
 
   int getLevels() const;
   int getCopyNumber(int level) const;
-  int getCopyNumber(const std::string& levelName) const;
-  std::string const& getLevelName(int level) const;
+  int getCopyNumber(const std::string_view& levelName) const;
+  std::string_view const& getLevelName(int level) const;
   int getCapacity();
 
   void reset();
@@ -32,7 +32,7 @@ public:
 protected:
   static constexpr int MAXLEVEL = 20;
 
-  std::vector<std::string> _sortedName;
+  std::vector<std::string_view> _sortedName;
   std::vector<int> _sortedCopyNumber;
   int _theLevels;
 };

--- a/Geometry/MTDCommonData/interface/MTDBaseNumber.h
+++ b/Geometry/MTDCommonData/interface/MTDBaseNumber.h
@@ -18,12 +18,12 @@ public:
   MTDBaseNumber(const MTDBaseNumber& aBaseNumber);
   ~MTDBaseNumber() {}
 
-  void setSize(const int& size);
-  void addLevel(const std::string_view& name, const int& copyNumber);
+  void setSize(const int size);
+  void addLevel(const std::string_view name, const int copyNumber);
 
   int getLevels() const;
   int getCopyNumber(int level) const;
-  int getCopyNumber(const std::string_view& levelName) const;
+  int getCopyNumber(const std::string_view levelName) const;
   std::string_view const& getLevelName(int level) const;
   int getCapacity();
 

--- a/Geometry/MTDCommonData/src/BTLNumberingScheme.cc
+++ b/Geometry/MTDCommonData/src/BTLNumberingScheme.cc
@@ -44,18 +44,19 @@ uint32_t BTLNumberingScheme::getUnitID(const MTDBaseNumber& baseNumber) const {
   const uint32_t modCopy(baseNumber.getCopyNumber(2));
   const uint32_t rodCopy(baseNumber.getCopyNumber(3));
 
-  const std::string& modName(baseNumber.getLevelName(2));  // name of module volume
+  const std::string_view& modName(baseNumber.getLevelName(2));  // name of module volume
   uint32_t pos = modName.find("Positive");
 
-  const uint32_t zside = (pos <= strlen(modName.c_str()) ? 1 : 0);
-  std::string baseName = modName.substr(modName.find(':') + 1);
+  const uint32_t zside = (pos <= modName.size() ? 1 : 0);
+  std::string_view baseName = modName.substr(modName.find(':') + 1);
 
-  // trick to accomodate both 54, 42 and 48 modules designs
-  const int modtyp(
-      ::atoi((baseName.substr(8, 1)).c_str()) == 9 || ::atoi((baseName.substr(8, 1)).c_str()) == 5 ||
-              (::atoi((baseName.substr(8, 1)).c_str()) == 7 && ::atoi((baseName.substr(7, 1)).c_str()) == 1)
-          ? ::atoi((baseName.substr(7, 1)).c_str()) + 1
-          : ::atoi((baseName.substr(7, 1)).c_str()));
+  int tmptyp = ::atoi(&baseName.at(7));
+  if (tmptyp == 17) {
+    tmptyp = 2;
+  } else if (tmptyp == 33) {
+    tmptyp = 3;
+  }
+  const int modtyp(tmptyp);
 
   // error checking
 

--- a/Geometry/MTDCommonData/src/ETLNumberingScheme.cc
+++ b/Geometry/MTDCommonData/src/ETLNumberingScheme.cc
@@ -36,10 +36,10 @@ uint32_t ETLNumberingScheme::getUnitID(const MTDBaseNumber& baseNumber) const {
 
   const uint32_t modCopy(baseNumber.getCopyNumber(2));
 
-  const std::string& ringName(baseNumber.getLevelName(3));  // name of ring volume
+  const std::string_view& ringName(baseNumber.getLevelName(3));  // name of ring volume
   int modtyp(0);
-  std::string baseName = ringName.substr(ringName.find(':') + 1);
-  int ringCopy(::atoi(baseName.c_str() + 4));
+  std::string_view baseName = ringName.substr(ringName.find(':') + 1);
+  int ringCopy(::atoi(baseName.data() + 4));
 
   uint32_t discN, sectorS, sectorN;
   if (!preTDR) {
@@ -55,7 +55,7 @@ uint32_t ETLNumberingScheme::getUnitID(const MTDBaseNumber& baseNumber) const {
 
   // Side choice: up to scenario D38 is given by level 7 (HGCal v9)
   int nSide(7);
-  const std::string& sideName(baseNumber.getLevelName(nSide));
+  const std::string_view& sideName(baseNumber.getLevelName(nSide));
   // Side choice: from scenario D41 is given by level 8 (HGCal v10)
   if (sideName.find("CALOECTSFront") != std::string::npos) {
     nSide = 8;

--- a/Geometry/MTDCommonData/src/MTDBaseNumber.cc
+++ b/Geometry/MTDCommonData/src/MTDBaseNumber.cc
@@ -7,7 +7,7 @@ MTDBaseNumber::MTDBaseNumber(const MTDBaseNumber& aBaseNumber)
       _sortedCopyNumber(aBaseNumber._sortedCopyNumber),
       _theLevels(aBaseNumber._theLevels) {}
 
-void MTDBaseNumber::setSize(const int& size) {
+void MTDBaseNumber::setSize(const int size) {
   if (size < MAXLEVEL) {
     _sortedName.resize(size);
     _sortedCopyNumber.resize(size);
@@ -18,7 +18,7 @@ void MTDBaseNumber::setSize(const int& size) {
   }
 }
 
-void MTDBaseNumber::addLevel(const std::string_view& name, const int& copyNumber) {
+void MTDBaseNumber::addLevel(const std::string_view name, const int copyNumber) {
   if (_theLevels == MAXLEVEL - 1) {
     throw cms::Exception("WrongMTDGeom") << "MTDBaseNumber required to add more levels than maximum allowed";
   }
@@ -31,7 +31,7 @@ int MTDBaseNumber::getLevels() const { return _theLevels; }
 
 int MTDBaseNumber::getCopyNumber(int level) const { return _sortedCopyNumber[level]; }
 
-int MTDBaseNumber::getCopyNumber(const std::string_view& levelName) const {
+int MTDBaseNumber::getCopyNumber(const std::string_view levelName) const {
   for (int iLevel = 0; iLevel < _theLevels; iLevel++) {
     if (_sortedName[iLevel] == levelName) {
       return _sortedCopyNumber[iLevel];

--- a/Geometry/MTDCommonData/src/MTDBaseNumber.cc
+++ b/Geometry/MTDCommonData/src/MTDBaseNumber.cc
@@ -18,7 +18,7 @@ void MTDBaseNumber::setSize(const int& size) {
   }
 }
 
-void MTDBaseNumber::addLevel(const std::string& name, const int& copyNumber) {
+void MTDBaseNumber::addLevel(const std::string_view& name, const int& copyNumber) {
   if (_theLevels == MAXLEVEL - 1) {
     throw cms::Exception("WrongMTDGeom") << "MTDBaseNumber required to add more levels than maximum allowed";
   }
@@ -31,7 +31,7 @@ int MTDBaseNumber::getLevels() const { return _theLevels; }
 
 int MTDBaseNumber::getCopyNumber(int level) const { return _sortedCopyNumber[level]; }
 
-int MTDBaseNumber::getCopyNumber(const std::string& levelName) const {
+int MTDBaseNumber::getCopyNumber(const std::string_view& levelName) const {
   for (int iLevel = 0; iLevel < _theLevels; iLevel++) {
     if (_sortedName[iLevel] == levelName) {
       return _sortedCopyNumber[iLevel];
@@ -40,7 +40,7 @@ int MTDBaseNumber::getCopyNumber(const std::string& levelName) const {
   return 0;
 }
 
-std::string const& MTDBaseNumber::getLevelName(int level) const { return _sortedName[level]; }
+std::string_view const& MTDBaseNumber::getLevelName(int level) const { return _sortedName[level]; }
 
 int MTDBaseNumber::getCapacity() { return _sortedName.capacity(); }
 

--- a/Geometry/MTDCommonData/test/DD4hep_TestMTDIdealGeometry.cc
+++ b/Geometry/MTDCommonData/test/DD4hep_TestMTDIdealGeometry.cc
@@ -312,8 +312,7 @@ void DD4hep_TestMTDIdealGeometry::theBaseNumber(cms::DDFilteredView& fv) {
   for (uint ii = 0; ii < fv.navPos().size(); ii++) {
     std::string_view name((fv.geoHistory()[ii])->GetName());
     size_t ipos = name.rfind('_');
-    thisN_.addLevel((static_cast<std::string_view>((fv.geoHistory()[ii])->GetName())).substr(0, ipos),
-                    fv.copyNos()[ii]);
+    thisN_.addLevel(name.substr(0, ipos), fv.copyNos()[ii]);
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("DD4hep_TestMTDIdealGeometry") << name.substr(0, ipos) << " " << fv.copyNos()[ii];
 #endif

--- a/Geometry/MTDCommonData/test/DD4hep_TestMTDIdealGeometry.cc
+++ b/Geometry/MTDCommonData/test/DD4hep_TestMTDIdealGeometry.cc
@@ -310,12 +310,12 @@ void DD4hep_TestMTDIdealGeometry::theBaseNumber(cms::DDFilteredView& fv) {
   thisN_.setSize(fv.navPos().size());
 
   for (uint ii = 0; ii < fv.navPos().size(); ii++) {
-    std::string name((fv.geoHistory()[ii])->GetName());
-    name.assign(name.erase(name.rfind('_')));
-    int copyN(fv.copyNos()[ii]);
-    thisN_.addLevel(name, copyN);
+    std::string_view name((fv.geoHistory()[ii])->GetName());
+    size_t ipos = name.rfind('_');
+    thisN_.addLevel((static_cast<std::string_view>((fv.geoHistory()[ii])->GetName())).substr(0, ipos),
+                    fv.copyNos()[ii]);
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("DD4hep_TestMTDIdealGeometry") << name << " " << copyN;
+    edm::LogVerbatim("DD4hep_TestMTDIdealGeometry") << name.substr(0, ipos) << " " << fv.copyNos()[ii];
 #endif
   }
 }

--- a/Geometry/MTDCommonData/test/TestMTDIdealGeometry.cc
+++ b/Geometry/MTDCommonData/test/TestMTDIdealGeometry.cc
@@ -275,11 +275,9 @@ void TestMTDIdealGeometry::theBaseNumber(const DDGeoHistory& gh) {
   thisN_.setSize(gh.size());
 
   for (uint i = gh.size(); i-- > 0;) {
-    std::string name(gh[i].logicalPart().name().name());
-    int copyN(gh[i].copyno());
-    thisN_.addLevel(name, copyN);
+    thisN_.addLevel(gh[i].logicalPart().name().name(), gh[i].copyno());
 #ifdef EDM_ML_DEBUG
-    edm::LogInfo("TestMTDIdealGeometry") << name << " " << copyN;
+    edm::LogInfo("TestMTDIdealGeometry") << gh[i].logicalPart().name().name() << " " << gh[i].copyno();
 #endif
   }
 }

--- a/Geometry/MTDGeometryBuilder/test/DD4hep_TestBTLPixelTopology.cc
+++ b/Geometry/MTDGeometryBuilder/test/DD4hep_TestBTLPixelTopology.cc
@@ -320,8 +320,7 @@ void DD4hep_TestBTLPixelTopology::theBaseNumber(cms::DDFilteredView& fv) {
   for (uint ii = 0; ii < fv.navPos().size(); ii++) {
     std::string_view name((fv.geoHistory()[ii])->GetName());
     size_t ipos = name.rfind('_');
-    thisN_.addLevel((static_cast<std::string_view>((fv.geoHistory()[ii])->GetName())).substr(0, ipos),
-                    fv.copyNos()[ii]);
+    thisN_.addLevel(name.substr(0, ipos), fv.copyNos()[ii]);
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("DD4hep_TestBTLPixelTopology") << name.substr(0, ipos) << " " << fv.copyNos()[ii];
 #endif

--- a/Geometry/MTDGeometryBuilder/test/DD4hep_TestBTLPixelTopology.cc
+++ b/Geometry/MTDGeometryBuilder/test/DD4hep_TestBTLPixelTopology.cc
@@ -318,12 +318,12 @@ void DD4hep_TestBTLPixelTopology::theBaseNumber(cms::DDFilteredView& fv) {
   thisN_.setSize(fv.navPos().size());
 
   for (uint ii = 0; ii < fv.navPos().size(); ii++) {
-    std::string name((fv.geoHistory()[ii])->GetName());
-    name.assign(name.erase(name.rfind('_')));
-    int copyN(fv.copyNos()[ii]);
-    thisN_.addLevel(name, copyN);
+    std::string_view name((fv.geoHistory()[ii])->GetName());
+    size_t ipos = name.rfind('_');
+    thisN_.addLevel((static_cast<std::string_view>((fv.geoHistory()[ii])->GetName())).substr(0, ipos),
+                    fv.copyNos()[ii]);
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("DD4hep_TestBTLPixelTopology") << name << " " << copyN;
+    edm::LogVerbatim("DD4hep_TestBTLPixelTopology") << name.substr(0, ipos) << " " << fv.copyNos()[ii];
 #endif
   }
 }

--- a/Geometry/MTDNumberingBuilder/plugins/CmsMTDConstruction.cc
+++ b/Geometry/MTDNumberingBuilder/plugins/CmsMTDConstruction.cc
@@ -122,11 +122,9 @@ void CmsMTDConstruction<DDFilteredView>::buildETLModule(DDFilteredView& fv, Geom
     baseNumber_.setSize(gh.size());
 
     for (uint i = gh.size(); i-- > 0;) {
-      std::string name(gh[i].logicalPart().name().name());
-      int copyN(gh[i].copyno());
-      baseNumber_.addLevel(name, copyN);
+      baseNumber_.addLevel(gh[i].logicalPart().name().name(), gh[i].copyno());
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("CmsMTDConstruction") << name << " " << copyN;
+      edm::LogVerbatim("CmsMTDConstruction") << gh[i].logicalPart().name().name() << " " << gh[i].copyno();
 #endif
     }
 
@@ -160,12 +158,12 @@ void CmsMTDConstruction<cms::DDFilteredView>::buildETLModule(cms::DDFilteredView
   baseNumber_.setSize(fv.copyNos().size());
 
   for (uint i = 0; i < fv.copyNos().size(); i++) {
-    std::string name((fv.geoHistory()[i])->GetName());
-    name.assign(name.erase(name.rfind('_')));
-    int copyN(fv.copyNos()[i]);
-    baseNumber_.addLevel(name, copyN);
+    std::string_view name((fv.geoHistory()[i])->GetName());
+    size_t ipos = name.rfind('_');
+    baseNumber_.addLevel((static_cast<std::string_view>((fv.geoHistory()[i])->GetName())).substr(0, ipos),
+                         fv.copyNos()[i]);
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("CmsMTDConstruction") << name << " " << copyN;
+    edm::LogVerbatim("CmsMTDConstruction") << name.substr(0, ipos) << " " << fv.copyNos()[i];
 #endif
   }
 

--- a/Geometry/MTDNumberingBuilder/plugins/CmsMTDConstruction.cc
+++ b/Geometry/MTDNumberingBuilder/plugins/CmsMTDConstruction.cc
@@ -160,8 +160,7 @@ void CmsMTDConstruction<cms::DDFilteredView>::buildETLModule(cms::DDFilteredView
   for (uint i = 0; i < fv.copyNos().size(); i++) {
     std::string_view name((fv.geoHistory()[i])->GetName());
     size_t ipos = name.rfind('_');
-    baseNumber_.addLevel((static_cast<std::string_view>((fv.geoHistory()[i])->GetName())).substr(0, ipos),
-                         fv.copyNos()[i]);
+    baseNumber_.addLevel(name.substr(0, ipos), fv.copyNos()[i]);
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("CmsMTDConstruction") << name.substr(0, ipos) << " " << fv.copyNos()[i];
 #endif


### PR DESCRIPTION
#### PR description:

Following recent discussions triggered by simulation performance reports, this PR update the ```MTDBaseNumber``` class, moving it from the use of ```string``` to the use of ```string_view```. This is possible since the object is just used locally to build a ```DetId``` and the underlying source of strings (geometry volume names) is always available to the code while being invoked. 

All the classes using this tool are updated accordingly. 

#### PR validation:

Unit tests pass, and the workflow 34634.0 runs successfully without any change in DQM output.
An igprof test on the GEN-SIM part of the workflow (10 events) show a reduction of the rank of the ```getBaseNumber``` method used inside ```MtdSD``` (already a minor contribution anyway):

 Original
```
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
            0.0  .........       0.10 / 0.10         MtdSD::setDetUnitId(G4Step const*) [1743]
[1748]      0.0       0.10       0.00 / 0.10       MtdSD::getBaseNumber(G4Step const*)
            0.0  .........       0.08 / 0.08         MTDBaseNumber::addLevel(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int const&) [1882]
            0.0  .........       0.02 / 0.02         MTDBaseNumber::reset() [2969]
```

Updated
```
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
            0.0  .........       0.04 / 0.06         MtdSD::setDetUnitId(G4Step const*) [2020]
[2294]      0.0       0.04       0.00 / 0.04       MtdSD::getBaseNumber(G4Step const*)
            0.0  .........       0.02 / 0.02         MTDBaseNumber::reset() [2988]
            0.0  .........       0.01 / 12.08        G4TouchableHistory::GetVolume(int) const [112]
            0.0  .........       0.01 / 9.97         _init [122]
```

A similar approach could be used for ```EcalBaseNumber```, which has a much higher impact on the GEN-SIM step performances.
