### PR TITLE
speedup: use cached RhoEtaPhi from caloCellGeometry in EgammaHcalIsolation

### DIFF
--- a/RecoEgamma/EgammaIsolationAlgos/src/EgammaHcalIsolation.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/src/EgammaHcalIsolation.cc
@@ -9,13 +9,14 @@
 #include <Math/VectorUtil.h>
 
 //CMSSW includes
-#include "RecoEgamma/EgammaIsolationAlgos/interface/EgammaHcalIsolation.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/RecoCandidate/interface/RecoCandidate.h"
+#include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
 #include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "DataFormats/RecoCandidate/interface/RecoCandidate.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "DataFormats/Math/interface/deltaR.h"
+#include "RecoEgamma/EgammaIsolationAlgos/interface/EgammaHcalIsolation.h"
 
 double scaleToE(const double &eta) { return 1.; }
 double scaleToEt(const double &eta) { return std::sin(2. * std::atan(std::exp(-eta))); }
@@ -150,7 +151,7 @@ double EgammaHcalIsolation::goodHitEnergy(float pcluEta,
   if (!(goodHBe or goodHEe))
     return 0.;
 
-  const auto phit = caloGeometry_.getPosition(hit.detid());
+  const auto phit = caloGeometry_.getGeometry(hit.detid())->repPos();
   const float phitEta = phit.eta();
 
   if (extIncRule_ == InclusionRule::withinConeAroundCluster or intIncRule_ == InclusionRule::withinConeAroundCluster) {


### PR DESCRIPTION
this is a technical PR

using 11834.21 (as in "enable profiling"), but tested in a local area with 12_1_0_pre5 as of #35955:
- before (as in #35955) 2.56 counts or 0.77% of reco time in [EgammaHcalIsolation::getHcalSum igprof](https://slava77sk.web.cern.ch/slava77sk/reco/cgi-bin/igprof-navigator/sw-121X/CMSSW_12_1_0_pre5-sign1128.f33bdaa.11834.21.step3.20.pp/476)
- after : 1.91 counts or 0.59% of reco time [EgammaHcalIsolation::getHcalSum igprof](https://slava77sk.web.cern.ch/slava77sk/reco/cgi-bin/igprof-navigator/sw-121X/CMSSW_12_1_0_pre5-sign1128.d17315a.11834.21.step3.20.pp/591)

about 25% speedup.

@VinInn  Thank you.
