### PR TITLE
Include EndLuminosityBlock transition in the esConsumes for LumiAlCaRecoProducer

### DIFF
--- a/Calibration/LumiAlCaRecoProducers/plugins/RawPCCProducer.cc
+++ b/Calibration/LumiAlCaRecoProducers/plugins/RawPCCProducer.cc
@@ -56,7 +56,7 @@ private:
 
 //--------------------------------------------------------------------------------------------------
 RawPCCProducer::RawPCCProducer(const edm::ParameterSet& iConfig)
-    : lumiCorrectionsToken_(esConsumes()),
+    : lumiCorrectionsToken_(esConsumes<edm::Transition::EndLuminosityBlock>()),
       putToken_{produces<LumiInfo, edm::Transition::EndLuminosityBlock>(
           iConfig.getParameter<edm::ParameterSet>("RawPCCProducerParameters")
               .getUntrackedParameter<std::string>("outputProductName", "alcaLumi"))},


### PR DESCRIPTION
#### PR description:

Resolves the issue mentioned here
https://github.com/cms-sw/cmssw/pull/36095#issuecomment-967839661
by including EndLuminosityBlock transition in the esConsumes for LumiAlCaRecoProducer

#### PR validation:
The previously offended wf,
 `runTheMatrix.py -l 1020.0`
 runs fine now.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A