### PR TITLE
fix for out-of-bounds index in `HitPattern::getHitPatternByAbsoluteIndex`

### DIFF
--- a/DataFormats/TrackReco/src/HitPattern.cc
+++ b/DataFormats/TrackReco/src/HitPattern.cc
@@ -334,7 +334,7 @@ uint16_t HitPattern::getHitPatternByAbsoluteIndex(int position) const {
   } else {
     uint8_t firstWordBits = HIT_LENGTH - secondWordBits;
     uint16_t firstWordBlock = hitPattern[secondWord - 1] >> (16 - firstWordBits);
-    if (!secondWordBits)
+    if (secondWordBits == 0)
       return firstWordBlock;
     uint16_t secondWordBlock = hitPattern[secondWord] & ((1 << secondWordBits) - 1);
     uint16_t myResult = firstWordBlock + (secondWordBlock << firstWordBits);

--- a/DataFormats/TrackReco/src/HitPattern.cc
+++ b/DataFormats/TrackReco/src/HitPattern.cc
@@ -334,6 +334,8 @@ uint16_t HitPattern::getHitPatternByAbsoluteIndex(int position) const {
   } else {
     uint8_t firstWordBits = HIT_LENGTH - secondWordBits;
     uint16_t firstWordBlock = hitPattern[secondWord - 1] >> (16 - firstWordBits);
+    if (!secondWordBits)
+      return firstWordBlock;
     uint16_t secondWordBlock = hitPattern[secondWord] & ((1 << secondWordBits) - 1);
     uint16_t myResult = firstWordBlock + (secondWordBlock << firstWordBits);
     return myResult;


### PR DESCRIPTION
#### PR description:

This PR contains a minor technical fix to `HitPattern::getHitPatternByAbsoluteIndex`.

It was prompted by an error detected in [last week's UBSAN IB (`step4` of wf `4.22`)](https://cmssdt.cern.ch/SDT/jenkins-artifacts/ubsan_logs/CMSSW_12_2_X_2021-11-05-2300/logs/64/64af2f39a52f88113283751b65fc7259/log).

The error was coming from `secondWord==57` (out of bounds) when `position==75`.

Merely technical. No changes expected.

#### PR validation:

Tested wf `4.22` with a UBSAN IB.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

N/A