### PR TITLE
Add epsilon in comparison of probabilities in SiPixelRecHitQuality

### DIFF
--- a/DataFormats/TrackerRecHit2D/interface/SiPixelRecHitQuality.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiPixelRecHitQuality.h
@@ -109,12 +109,9 @@ public:
     //------------------------------------------------------
     //
     inline void setProbabilityXY(float prob, QualWordType& qualWord) const {
-      if (prob < 0.0f) {
-        warningOutOfBoundProb("XY", prob, qualWord);
-        prob = 0;
-      } else if (prob > 1.0f && prob < 1.0f + std::numeric_limits<float>::epsilon()) {
+      if (prob > 1.0f && prob <= 1.0f + std::numeric_limits<float>::epsilon()) {
         prob = 1;
-      } else if (prob > 1.0f + std::numeric_limits<float>::epsilon()) {
+      } else if (prob < 0.0f || prob > 1.0f + std::numeric_limits<float>::epsilon()) {
         warningOutOfBoundProb("XY", prob, qualWord);
         prob = 0;
       }
@@ -124,12 +121,9 @@ public:
       qualWord |= ((raw & probX_mask) << probX_shift);
     }
     inline void setProbabilityQ(float prob, QualWordType& qualWord) const {
-      if (prob < 0.0f) {
-        warningOutOfBoundProb("Q", prob, qualWord);
-        prob = 0;
-      } else if (prob > 1.0f && prob < 1.0f + std::numeric_limits<float>::epsilon()) {
+      if (prob > 1.0f && prob <= 1.0f + std::numeric_limits<float>::epsilon()) {
         prob = 1;
-      } else if (prob > 1.0f + std::numeric_limits<float>::epsilon()) {
+      } else if (prob < 0.0f || prob > 1.0f + std::numeric_limits<float>::epsilon()) {
         warningOutOfBoundProb("Q", prob, qualWord);
         prob = 0;
       }

--- a/DataFormats/TrackerRecHit2D/interface/SiPixelRecHitQuality.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiPixelRecHitQuality.h
@@ -1,7 +1,6 @@
 #ifndef DataFormats_SiPixelRecHitQuality_h
 #define DataFormats_SiPixelRecHitQuality_h 1
 
-//--- pow():
 #include <cmath>
 
 class SiPixelRecHitQuality {
@@ -110,7 +109,12 @@ public:
     //------------------------------------------------------
     //
     inline void setProbabilityXY(float prob, QualWordType& qualWord) const {
-      if (prob < 0 || prob > 1) {
+      if (prob < 0.0f) {
+        warningOutOfBoundProb("XY", prob, qualWord);
+        prob = 0;
+      } else if (prob > 1.0f && prob < 1.0f + std::numeric_limits<float>::epsilon()) {
+        prob = 1;
+      } else if (prob > 1.0f + std::numeric_limits<float>::epsilon()) {
         warningOutOfBoundProb("XY", prob, qualWord);
         prob = 0;
       }
@@ -120,7 +124,12 @@ public:
       qualWord |= ((raw & probX_mask) << probX_shift);
     }
     inline void setProbabilityQ(float prob, QualWordType& qualWord) const {
-      if (prob < 0 || prob > 1) {
+      if (prob < 0.0f) {
+        warningOutOfBoundProb("Q", prob, qualWord);
+        prob = 0;
+      } else if (prob > 1.0f && prob < 1.0f + std::numeric_limits<float>::epsilon()) {
+        prob = 1;
+      } else if (prob > 1.0f + std::numeric_limits<float>::epsilon()) {
         warningOutOfBoundProb("Q", prob, qualWord);
         prob = 0;
       }

--- a/DataFormats/TrackerRecHit2D/src/SiPixelRecHitQuality.cc
+++ b/DataFormats/TrackerRecHit2D/src/SiPixelRecHitQuality.cc
@@ -59,18 +59,18 @@ void SiPixelRecHitQuality::warningObsolete() {
 }
 
 void SiPixelRecHitQuality::warningOutOfBoundQbin(int iValue, QualWordType const& iQualWord) {
-  edm::LogWarning("OutOfBounds") << "Qbin outside the bounds of the quality word. Defaulting to Qbin=0. Qbin = "
-                                 << iValue << " QualityWord = " << iQualWord;
+  edm::LogWarning("OutOfBounds") << "Qbin outside the bounds of the quality word: Qbin = " << iValue
+                                 << " and QualityWord = " << iQualWord << " --> Now defaulting to Qbin = 0.0";
 }
 
 void SiPixelRecHitQuality::warningOutOfBoundProb(const char* iName, float iProb, QualWordType const& iQualWord) {
-  edm::LogWarning("OutOfBounds") << "Prob " << iName
-                                 << " outside the bounds of the quality word. Defaulting to Prob=0. Prob = " << iProb
-                                 << " QualityWord = " << iQualWord;
+  edm::LogWarning("OutOfBounds") << "Prob" << iName << " outside the bounds of the quality word: Prob" << iName
+                                 << " = 1+" << iProb - 1 << " and QualityWord = " << iQualWord
+                                 << " --> Now defaulting to Prob" << iName << " = 0.0";
 }
 
 void SiPixelRecHitQuality::warningOutOfBoundRaw(const char* iName, int iRaw, QualWordType const& iQualWord) {
-  edm::LogWarning("OutOfBounds") << "Probability " << iName
-                                 << " outside the bounds of the quality word. Defaulting to Prob=0. Raw = " << iRaw
-                                 << " QualityWord = " << iQualWord;
+  edm::LogWarning("OutOfBounds") << "Probability" << iName << " outside the bounds of the quality word: Raw = " << iRaw
+                                 << " and QualityWord = " << iQualWord << " --> Now defaulting to Prob" << iName
+                                 << " = 0.0";
 }

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco2D.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco2D.cc
@@ -681,7 +681,7 @@ int SiPixelTemplateReco2D::PixelTempReco2D(int id,
   } else {
     sigmay = 10000.f;
   }
-  if (id > 0) {
+  if (id >= 0) {  //if id < 0 bypass interpolation (used in calibration)
     // Do chi2 probability calculation
     double meanxy = (double)(npixel * templ2D.chi2ppix());
     double chi2scale = (double)templ2D.chi2scale();


### PR DESCRIPTION
#### PR description:

When doing some refitting I notice this MSG
```
%MSG-w OutOfBounds:  TrackRefitter:RefitterForDeDx 13-Nov-2021 21:07:38 CET  Run: 319450 Event: 228163659
Prob Q outside the bounds of the quality word. Defaulting to Prob=0. Prob = 1 QualityWord = 1
%MSG
```

Which seems to be due to machine precision error in the comparison. This PR adds an epsilon to the comparison to 1. 

EDIT: the PR also fixes an edge case when TemplateID can be 0. And then if the probs are 1+epsilon they are set to 1, otherwise the original warning, with an improved msg is brought back.

#### PR validation:


Reran the code that gave the warning msg above --> Now it's gone.
I'm not sure these are the correct timing value to look at but
```
Before
TimeReport ---------- Event  Summary ---[sec]----
TimeReport       event loop CPU/event = 0.558920
TimeReport      event loop Real/event = 0.959158
TimeReport     sum Streams Real/event = 0.909626
TimeReport efficiency CPU/Real/thread = 0.582719

TimeReport ---------- Modules in Path: p ---[Real sec]----
TimeReport   0.200814     0.200814  RefitterForDeDx
```

After PR
```
TimeReport ---------- Event  Summary ---[sec]----
TimeReport       event loop CPU/event = 0.550824
TimeReport      event loop Real/event = 0.952079
TimeReport     sum Streams Real/event = 0.910521
TimeReport efficiency CPU/Real/thread = 0.578549


TimeReport ---------- Modules in Path: p ---[Real sec]----
TimeReport   0.193779     0.193779  RefitterForDeDx
```


#### if this PR is a backport please specify the original PR and why you need to backport that PR:

I'd like to have a backport to 10_6_X, this could actually have a (prob little) effect on Physics analysis