### PR TITLE
Fix for FastSim decays of exotic-descendent SM particles decaying outside pipe

### DIFF
--- a/FastSimulation/SimplifiedGeometryPropagator/interface/ParticleManager.h
+++ b/FastSimulation/SimplifiedGeometryPropagator/interface/ParticleManager.h
@@ -146,7 +146,9 @@ inline bool isExotic(int pdgid_) {
   return ((pdgid >= 1000000 && pdgid < 4000000 && pdgid != 3000022) ||  // SUSY, R-hadron, and technicolor particles
           pdgid == 17 ||                                                // 4th generation lepton
           pdgid == 34 ||                                                // W-prime
-          pdgid == 37);                                                 // charged Higgs
+          pdgid == 37 ||                                                // charged Higgs  
+          pdgid == 39);                                                 // bulk graviton
+ 
 }
 
 #endif

--- a/FastSimulation/SimplifiedGeometryPropagator/interface/ParticleManager.h
+++ b/FastSimulation/SimplifiedGeometryPropagator/interface/ParticleManager.h
@@ -146,9 +146,8 @@ inline bool isExotic(int pdgid_) {
   return ((pdgid >= 1000000 && pdgid < 4000000 && pdgid != 3000022) ||  // SUSY, R-hadron, and technicolor particles
           pdgid == 17 ||                                                // 4th generation lepton
           pdgid == 34 ||                                                // W-prime
-          pdgid == 37 ||                                                // charged Higgs  
+          pdgid == 37 ||                                                // charged Higgs
           pdgid == 39);                                                 // bulk graviton
- 
 }
 
 #endif

--- a/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
@@ -224,10 +224,16 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle() {
       }
     }
 
-    // particle must not decay before it reaches the beam pipe
+    // FastSim will not make hits out of particles that decay before reaching the beam pipe
     if (endVertex && endVertex->position().perp2() * lengthUnitConversionFactor2_ < beamPipeRadius2_) {
       continue;
     }
+
+    // SM particles that descend from exotics and cross the beam pipe radius should make hits but not be decayed 
+    if (productionVertex->position().perp2() * lengthUnitConversionFactor2_ < beamPipeRadius2_ &&
+	endVertex && endVertex->position().perp2() * lengthUnitConversionFactor2_ > beamPipeRadius2_) {
+      exoticRelativesChecker(productionVertex, exoticRelativeId, 0);
+    }    
 
     // make the particle
     std::unique_ptr<Particle> newParticle(

--- a/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
@@ -216,7 +216,8 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle() {
     }
     // particles which do not descend from exotics must be produced within the beampipe
     int exoticRelativeId = 0;
-    if (productionVertex->position().perp2() * lengthUnitConversionFactor2_ > beamPipeRadius2_)  //
+    const bool producedWithinBeamPipe = productionVertex->position().perp2() * lengthUnitConversionFactor2_ < beamPipeRadius2_;
+    if (producedWithinBeamPipe)
     {
       exoticRelativesChecker(productionVertex, exoticRelativeId, 0);
       if (!isExotic(exoticRelativeId)) {
@@ -225,13 +226,13 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle() {
     }
 
     // FastSim will not make hits out of particles that decay before reaching the beam pipe
-    if (endVertex && endVertex->position().perp2() * lengthUnitConversionFactor2_ < beamPipeRadius2_) {
+    const bool decayedWithinBeamPipe = endVertex && endVertex->position().perp2() * lengthUnitConversionFactor2_ < beamPipeRadius2_;
+    if (decayedWithinBeamPipe) {
       continue;
     }
 
     // SM particles that descend from exotics and cross the beam pipe radius should make hits but not be decayed
-    if (productionVertex->position().perp2() * lengthUnitConversionFactor2_ < beamPipeRadius2_ && endVertex &&
-        endVertex->position().perp2() * lengthUnitConversionFactor2_ > beamPipeRadius2_) {
+    if (producedWithinBeamPipe && !decayedWithinBeamPipe) {
       exoticRelativesChecker(productionVertex, exoticRelativeId, 0);
     }
 

--- a/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
@@ -229,11 +229,11 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle() {
       continue;
     }
 
-    // SM particles that descend from exotics and cross the beam pipe radius should make hits but not be decayed 
-    if (productionVertex->position().perp2() * lengthUnitConversionFactor2_ < beamPipeRadius2_ &&
-	endVertex && endVertex->position().perp2() * lengthUnitConversionFactor2_ > beamPipeRadius2_) {
+    // SM particles that descend from exotics and cross the beam pipe radius should make hits but not be decayed
+    if (productionVertex->position().perp2() * lengthUnitConversionFactor2_ < beamPipeRadius2_ && endVertex &&
+        endVertex->position().perp2() * lengthUnitConversionFactor2_ > beamPipeRadius2_) {
       exoticRelativesChecker(productionVertex, exoticRelativeId, 0);
-    }    
+    }
 
     // make the particle
     std::unique_ptr<Particle> newParticle(

--- a/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
@@ -216,9 +216,9 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle() {
     }
     // particles which do not descend from exotics must be produced within the beampipe
     int exoticRelativeId = 0;
-    const bool producedWithinBeamPipe = productionVertex->position().perp2() * lengthUnitConversionFactor2_ < beamPipeRadius2_;
-    if (producedWithinBeamPipe)
-    {
+    const bool producedWithinBeamPipe =
+        productionVertex->position().perp2() * lengthUnitConversionFactor2_ < beamPipeRadius2_;
+    if (producedWithinBeamPipe) {
       exoticRelativesChecker(productionVertex, exoticRelativeId, 0);
       if (!isExotic(exoticRelativeId)) {
         continue;
@@ -226,7 +226,8 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle() {
     }
 
     // FastSim will not make hits out of particles that decay before reaching the beam pipe
-    const bool decayedWithinBeamPipe = endVertex && endVertex->position().perp2() * lengthUnitConversionFactor2_ < beamPipeRadius2_;
+    const bool decayedWithinBeamPipe =
+        endVertex && endVertex->position().perp2() * lengthUnitConversionFactor2_ < beamPipeRadius2_;
     if (decayedWithinBeamPipe) {
       continue;
     }


### PR DESCRIPTION

#### PR description:

This PR fixes a bug creating a problem first identified in 

https://hypernews.cern.ch/HyperNews/CMS/get/famos/765.html

Jaebak found that some b- and d-mesons produced in the decays of exotic particles, which cross the beam pipe radius, have their decay performed twice, with sim hits created for each copy. This causes problems for some high-pT b-jets, as well as the MET in events that contain such jets. A few lines are added to ParticleManager.cc which results in FastSim deciding to not decay such particles further, and rather take only the original generator-determined decay trees. FastSim will still propagate these particles and create secondaries/material interactions, but it won't decay them. 

#### PR validation:

This issue was also seen in signal events of a Bulk Graviton model G->HH, H->bb, where G has a mass > 1 TeV and H is the SM Higgs boson. The bug fix in this PR results in a stark improvement of the jet response at high pT:

https://www.desy.de/~mrowietm/fastsimplots/graviton_exotic/fastsim_comparison/comparison.png

By construction, neither the original problem or these changes will affect purely SM events. 

This PR will need to be backported to any and all production releases that may be used for BSM signal MC production. 
