### PR TITLE
Restore behaviour of skipBadFiles for non-existing files

### DIFF
--- a/IOPool/Input/src/RootPrimaryFileSequence.cc
+++ b/IOPool/Input/src/RootPrimaryFileSequence.cc
@@ -144,17 +144,21 @@ namespace edm {
   }
 
   bool RootPrimaryFileSequence::nextFile() {
-    if (!noMoreFiles())
-      setAtNextFile();
-    if (noMoreFiles()) {
-      return false;
-    }
+    do {
+      if (!noMoreFiles())
+        setAtNextFile();
+      if (noMoreFiles()) {
+        return false;
+      }
 
-    initFile(input_.skipBadFiles());
-
-    if (not rootFile()) {
-      return false;
-    }
+      initFile(input_.skipBadFiles());
+      if (rootFile()) {
+        break;
+      }
+      // If we are not skipping bad files and the file
+      // open failed, then initFile should have thrown
+      assert(input_.skipBadFiles());
+    } while (true);
 
     // make sure the new product registry is compatible with the main one
     std::string mergeInfo =


### PR DESCRIPTION
#### PR description:

In CMSSW 11_1_0, the execution of a configuration file which contains a PoolSource generates a segmentation fault if an input file is non-existing. This happens also if the parameter skipBadFiles is set to True. In previous versions (CMSSW 10.6) this parameter enabled to run on corrupted or non-existing files without leading to a crash. 

This has been fixed in CMSSW 11.3 by https://github.com/cms-sw/cmssw/pull/32373 

The present PR is a minimal fix, inspired by the latter, in order to restore the behaviour of skipBadFiles in CMSSW 11.1. (Initially a private fix, but might be useful to other people who need to run in CMSSW 11.1 due compatibility with older files.)  

#### PR validation:

The test carried out was to run on a collection of files containing missing files, and making sure the code does not terminate by a segmentation violation. 

