### PR TITLE
uses ESConsume in EDFilter Module PythiaFilterIsolatedTrack

### DIFF
--- a/GeneratorInterface/GenFilters/plugins/PythiaFilterIsolatedTrack.cc
+++ b/GeneratorInterface/GenFilters/plugins/PythiaFilterIsolatedTrack.cc
@@ -1,7 +1,6 @@
 #include "GeneratorInterface/GenFilters/plugins/PythiaFilterIsolatedTrack.h"
-#include "SimGeneral/HepPDTRecord/interface/ParticleDataTable.h"
+//#include "SimGeneral/HepPDTRecord/interface/ParticleDataTable.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 
 #include "CLHEP/Random/RandomEngine.h"
 #include "CLHEP/Units/GlobalPhysicalConstants.h"
@@ -96,7 +95,8 @@ PythiaFilterIsolatedTrack::PythiaFilterIsolatedTrack(const edm::ParameterSet &iC
       nAll_(0),
       nGood_(0),
       ecDist_(317.0),
-      ecRad_(129.0) {
+      ecRad_(129.0), 
+      pdt_(esConsumes<HepPDT::ParticleDataTable, PDTRecord>()) {
   edm::LogVerbatim("PythiaFilter") << "PythiaFilterIsolatedTrack: Eta " << minSeedEta_ << ":" << maxSeedEta_ << " p > "
                                    << minSeedMom_ << " Isolation Cone " << isolCone_ << " with p > " << minIsolTrackMom_
                                    << " OnlyHadron " << onlyHadrons_;
@@ -107,8 +107,8 @@ PythiaFilterIsolatedTrack::~PythiaFilterIsolatedTrack() {}
 // ------------ method called to produce the data  ------------
 bool PythiaFilterIsolatedTrack::filter(edm::Event &iEvent, edm::EventSetup const &iSetup) {
   ++nAll_;
-  edm::ESHandle<ParticleDataTable> pdt;
-  iSetup.getData(pdt);
+  
+  auto const& pdt = iSetup.getData(pdt_);
 
   edm::Handle<edm::HepMCProduct> evt;
   iEvent.getByToken(token_, evt);
@@ -126,9 +126,9 @@ bool PythiaFilterIsolatedTrack::filter(edm::Event &iEvent, edm::EventSetup const
        iter != myGenEvent->particles_end();
        ++iter) {
     const HepMC::GenParticle *p = *iter;
-    if (!(pdt->particle(p->pdg_id())))
+    if (!(pdt.particle(p->pdg_id())))
       continue;
-    int charge3 = pdt->particle(p->pdg_id())->ID().threeCharge();
+    int charge3 = pdt.particle(p->pdg_id())->ID().threeCharge();
     int status = p->status();
     double momentum = p->momentum().rho();
     double abseta = fabs(p->momentum().eta());
@@ -146,13 +146,13 @@ bool PythiaFilterIsolatedTrack::filter(edm::Event &iEvent, edm::EventSetup const
   unsigned int ntrk(0);
   for (std::vector<const HepMC::GenParticle *>::const_iterator it1 = seeds.begin(); it1 != seeds.end(); ++it1) {
     const HepMC::GenParticle *p1 = *it1;
-    if (!(pdt->particle(p1->pdg_id())))
+    if (!(pdt.particle(p1->pdg_id())))
       continue;
     if (p1->pdg_id() < -100 || p1->pdg_id() > 100 || (!onlyHadrons_)) {  // Select hadrons only
       std::pair<double, double> EtaPhi1 = GetEtaPhiAtEcal(p1->momentum().eta(),
                                                           p1->momentum().phi(),
                                                           p1->momentum().perp(),
-                                                          (pdt->particle(p1->pdg_id()))->ID().threeCharge() / 3,
+                                                          (pdt.particle(p1->pdg_id()))->ID().threeCharge() / 3,
                                                           0.0);
 
       // loop over all of the other charged particles in the event, and see if any are close by
@@ -167,7 +167,7 @@ bool PythiaFilterIsolatedTrack::filter(edm::Event &iEvent, edm::EventSetup const
           std::pair<double, double> EtaPhi2 = GetEtaPhiAtEcal(p2->momentum().eta(),
                                                               p2->momentum().phi(),
                                                               p2->momentum().perp(),
-                                                              (pdt->particle(p2->pdg_id()))->ID().threeCharge() / 3,
+                                                              (pdt.particle(p2->pdg_id()))->ID().threeCharge() / 3,
                                                               0.0);
 
           // find out how far apart the particles are

--- a/GeneratorInterface/GenFilters/plugins/PythiaFilterIsolatedTrack.cc
+++ b/GeneratorInterface/GenFilters/plugins/PythiaFilterIsolatedTrack.cc
@@ -1,5 +1,4 @@
 #include "GeneratorInterface/GenFilters/plugins/PythiaFilterIsolatedTrack.h"
-//#include "SimGeneral/HepPDTRecord/interface/ParticleDataTable.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
 #include "CLHEP/Random/RandomEngine.h"

--- a/GeneratorInterface/GenFilters/plugins/PythiaFilterIsolatedTrack.cc
+++ b/GeneratorInterface/GenFilters/plugins/PythiaFilterIsolatedTrack.cc
@@ -95,7 +95,7 @@ PythiaFilterIsolatedTrack::PythiaFilterIsolatedTrack(const edm::ParameterSet &iC
       nAll_(0),
       nGood_(0),
       ecDist_(317.0),
-      ecRad_(129.0), 
+      ecRad_(129.0),
       pdt_(esConsumes<HepPDT::ParticleDataTable, PDTRecord>()) {
   edm::LogVerbatim("PythiaFilter") << "PythiaFilterIsolatedTrack: Eta " << minSeedEta_ << ":" << maxSeedEta_ << " p > "
                                    << minSeedMom_ << " Isolation Cone " << isolCone_ << " with p > " << minIsolTrackMom_
@@ -107,8 +107,8 @@ PythiaFilterIsolatedTrack::~PythiaFilterIsolatedTrack() {}
 // ------------ method called to produce the data  ------------
 bool PythiaFilterIsolatedTrack::filter(edm::Event &iEvent, edm::EventSetup const &iSetup) {
   ++nAll_;
-  
-  auto const& pdt = iSetup.getData(pdt_);
+
+  auto const &pdt = iSetup.getData(pdt_);
 
   edm::Handle<edm::HepMCProduct> evt;
   iEvent.getByToken(token_, evt);

--- a/GeneratorInterface/GenFilters/plugins/PythiaFilterIsolatedTrack.h
+++ b/GeneratorInterface/GenFilters/plugins/PythiaFilterIsolatedTrack.h
@@ -61,13 +61,13 @@ public:
 
 private:
   // parameters
-  const edm::EDGetTokenT<edm::HepMCProduct> token_; // token to get the generated particles
-  const double maxSeedEta_;                         // maximum eta of the isolated track seed
-  const double minSeedEta_;                         // minimum eta of the isolated track seed
-  const double minSeedMom_;                         // minimum momentum of the isolated track seed
-  const double minIsolTrackMom_;                    // minimum prohibited momentum of a nearby track
-  const double isolCone_;                           // cone size (in mm) around the seed to consider a track "nearby"
-  const bool onlyHadrons_;                          // select only isolated hadrons
+  const edm::EDGetTokenT<edm::HepMCProduct> token_;  // token to get the generated particles
+  const double maxSeedEta_;                          // maximum eta of the isolated track seed
+  const double minSeedEta_;                          // minimum eta of the isolated track seed
+  const double minSeedMom_;                          // minimum momentum of the isolated track seed
+  const double minIsolTrackMom_;                     // minimum prohibited momentum of a nearby track
+  const double isolCone_;                            // cone size (in mm) around the seed to consider a track "nearby"
+  const bool onlyHadrons_;                           // select only isolated hadrons
 
   unsigned int nAll_, nGood_;
   double ecDist_;  //distance to ECAL andcap from IP (cm)

--- a/GeneratorInterface/GenFilters/plugins/PythiaFilterIsolatedTrack.h
+++ b/GeneratorInterface/GenFilters/plugins/PythiaFilterIsolatedTrack.h
@@ -33,6 +33,8 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 
+#include "SimGeneral/HepPDTRecord/interface/ParticleDataTable.h"
+
 namespace PythiaFilterIsoTracks {
   struct Counters {
     Counters() : nAll_(0), nGood_(0) {}
@@ -59,16 +61,18 @@ public:
 
 private:
   // parameters
-  const edm::EDGetTokenT<edm::HepMCProduct> token_;  // token to get the generated particles
-  const double maxSeedEta_;                          // maximum eta of the isolated track seed
-  const double minSeedEta_;                          // minimum eta of the isolated track seed
-  const double minSeedMom_;                          // minimum momentum of the isolated track seed
-  const double minIsolTrackMom_;                     // minimum prohibited momentum of a nearby track
-  const double isolCone_;                            // cone size (in mm) around the seed to consider a track "nearby"
-  const bool onlyHadrons_;                           // select only isolated hadrons
+  const edm::EDGetTokenT<edm::HepMCProduct> token_; // token to get the generated particles
+  const double maxSeedEta_;                         // maximum eta of the isolated track seed
+  const double minSeedEta_;                         // minimum eta of the isolated track seed
+  const double minSeedMom_;                         // minimum momentum of the isolated track seed
+  const double minIsolTrackMom_;                    // minimum prohibited momentum of a nearby track
+  const double isolCone_;                           // cone size (in mm) around the seed to consider a track "nearby"
+  const bool onlyHadrons_;                          // select only isolated hadrons
 
   unsigned int nAll_, nGood_;
   double ecDist_;  //distance to ECAL andcap from IP (cm)
   double ecRad_;   //radius of ECAL barrel (cm)
+
+  edm::ESGetToken<HepPDT::ParticleDataTable, PDTRecord> pdt_;
 };
 #endif


### PR DESCRIPTION
#### PR description:

Uses ESConsume to improve threading efficiency, followup from Issue: https://github.com/cms-sw/cmssw/issues/31061


#### PR validation:

Run local test, using 
`cmsRun GeneratorInterface/GenFilters/test/test_isotrack_cfg.py`

The test is a success (compiled and ran).
