### PR TITLE
remove unnecessary check in HLT-DQM module

### DIFF
--- a/DQM/HLTEvF/plugins/HLTObjectsMonitor.cc
+++ b/DQM/HLTEvF/plugins/HLTObjectsMonitor.cc
@@ -495,11 +495,6 @@ void HLTObjectsMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup&
                 int q1q2 = q1 * q2;
                 plot.q1q2ME.first->Fill(q1q2);
 
-                if (abs(id) != abs(id2))
-                  edm::LogInfo("HLTObjectsMonitor")
-                      << plot.pathNAME << " " << plot.moduleNAME << " objects have different ID !?!" << abs(id)
-                      << " and " << abs(id2);
-
                 if ((id + id2) == 0) {  // check di-object system charge and flavor
 
                   TLorentzVector v2;

--- a/DQM/HLTEvF/plugins/HLTObjectsMonitor.cc
+++ b/DQM/HLTEvF/plugins/HLTObjectsMonitor.cc
@@ -481,7 +481,7 @@ void HLTObjectsMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup&
               if (key != key1 &&
                   kCnt1 > kCnt0) {  // avoid filling hists with same objs && avoid double counting separate objs
 
-                double pt2 = objects[key1].phi();
+                double pt2 = objects[key1].pt();
                 double eta2 = objects[key1].eta();
                 double phi2 = objects[key1].phi();
                 int id2 = objects[key1].id();


### PR DESCRIPTION
#### PR description:

This PR removes an unnecessary check in a DQM module related to HLT.

It addresses #23200 (more details can be found in the latter issue).

It also includes a small bugfix found along the way. The latter might lead to differences in some DQM outputs (1 ME of `HLTObjectsMonitor`).

#### PR validation:

`scram` builds.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

N/A