### PR TITLE
Add online DQM plots for Run 3 L1T shower trigger

### DIFF
--- a/DQM/L1TMonitor/interface/L1TStage2Shower.h
+++ b/DQM/L1TMonitor/interface/L1TStage2Shower.h
@@ -1,0 +1,43 @@
+#ifndef DQM_L1TMonitor_L1TStage2Shower_h
+#define DQM_L1TMonitor_L1TStage2Shower_h
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+
+#include "DataFormats/L1TMuon/interface/EMTFDaqOut.h"
+#include "DataFormats/L1TMuon/interface/EMTFHit.h"
+#include "DataFormats/L1TMuon/interface/EMTFTrack.h"
+#include "DataFormats/L1TMuon/interface/RegionalMuonCand.h"
+#include "DataFormats/CSCDigi/interface/CSCShowerDigiCollection.h"
+#include "DataFormats/L1TMuon/interface/RegionalMuonShower.h"
+
+class L1TStage2Shower : public DQMOneEDAnalyzer<> {
+public:
+  L1TStage2Shower(const edm::ParameterSet& ps);
+  ~L1TStage2Shower() override;
+
+protected:
+  void bookHistograms(DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&) override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+private:
+  edm::EDGetTokenT<l1t::RegionalMuonShowerBxCollection> EMTFShowerToken;
+  edm::EDGetTokenT<CSCShowerDigiCollection> CSCShowerToken;
+  std::string monitorDir;
+  bool verbose;
+
+
+  MonitorElement* cscShowerOccupancyLoose;
+  MonitorElement* cscShowerOccupancyNom;
+  MonitorElement* cscShowerOccupancyTight;
+  MonitorElement* cscShowerStationRing;
+  MonitorElement* cscShowerChamber;
+
+  MonitorElement* emtfShowerTypeOccupancy;
+};
+
+#endif

--- a/DQM/L1TMonitor/interface/L1TStage2Shower.h
+++ b/DQM/L1TMonitor/interface/L1TStage2Shower.h
@@ -30,7 +30,6 @@ private:
   std::string monitorDir;
   bool verbose;
 
-
   MonitorElement* cscShowerOccupancyLoose;
   MonitorElement* cscShowerOccupancyNom;
   MonitorElement* cscShowerOccupancyTight;

--- a/DQM/L1TMonitor/plugins/SealModule.cc
+++ b/DQM/L1TMonitor/plugins/SealModule.cc
@@ -60,6 +60,9 @@ DEFINE_FWK_MODULE(L1TStage2OMTF);
 #include "DQM/L1TMonitor/interface/L1TStage2EMTF.h"
 DEFINE_FWK_MODULE(L1TStage2EMTF);
 
+#include "DQM/L1TMonitor/interface/L1TStage2Shower.h"
+DEFINE_FWK_MODULE(L1TStage2Shower);
+
 #include "DQM/L1TMonitor/interface/L1TMP7ZeroSupp.h"
 DEFINE_FWK_MODULE(L1TMP7ZeroSupp);
 

--- a/DQM/L1TMonitor/python/L1TStage2Shower_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2Shower_cfi.py
@@ -1,0 +1,13 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+l1tStage2Shower = DQMEDAnalyzer(
+    "L1TStage2Shower",
+    emtfSource = cms.InputTag("emtfStage2Digis"),                   ## EMTF unpacker tag
+    cscSource = cms.InputTag("muonCSCDigis", "MuonCSCShowerDigi"),  ## CSC  unpacker tag
+#    emtfSource = cms.InputTag("simEmtfShowers", "EMTF"),           ## EMTF emulator tag
+#    cscSource = cms.InputTag("simCscTriggerPrimitiveDigis"),       ## CSC  emulator tag
+    monitorDir = cms.untracked.string("L1T/L1TStage2EMTF/Shower"), 
+    verbose = cms.untracked.bool(False),
+)
+

--- a/DQM/L1TMonitor/python/L1TStage2_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2_cff.py
@@ -18,6 +18,9 @@ from DQM.L1TMonitor.L1TStage2OMTF_cfi import *
 # EMTF
 from DQM.L1TMonitor.L1TStage2EMTF_cfi import *
 
+# Shower
+from DQM.L1TMonitor.L1TStage2Shower_cfi import *
+
 # uGMT
 from DQM.L1TMonitor.L1TStage2uGMT_cff import *
 
@@ -37,6 +40,9 @@ l1tStage2OnlineDQM = cms.Sequence(
     l1tStage2BmtfOnlineDQMSeq +
     l1tStage2Omtf +
     l1tStage2Emtf +
+# Do not include shower DQM module in the sequence because there is no EMTF shower unpacker (as of CMSSW_12_2_0_pre2).
+# It will be enabled once the EMTF shower unpacker is ready.
+#    l1tStage2Shower +  
     l1tStage2uGMTOnlineDQMSeq +
     l1tObjectsTiming +
     l1tStage2uGTOnlineDQMSeq

--- a/DQM/L1TMonitor/src/L1TStage2Shower.cc
+++ b/DQM/L1TMonitor/src/L1TStage2Shower.cc
@@ -1,0 +1,157 @@
+#include <string>
+#include <vector>
+#include <iostream>
+#include <map>
+
+#include "DQM/L1TMonitor/interface/L1TStage2Shower.h"
+
+L1TStage2Shower::L1TStage2Shower(const edm::ParameterSet& ps)
+    : EMTFShowerToken(consumes<l1t::RegionalMuonShowerBxCollection>(ps.getParameter<edm::InputTag>("emtfSource"))),
+      CSCShowerToken(consumes<CSCShowerDigiCollection>(ps.getParameter<edm::InputTag>("cscSource"))),
+      monitorDir(ps.getUntrackedParameter<std::string>("monitorDir", "")),
+      verbose(ps.getUntrackedParameter<bool>("verbose", false)) {}
+
+L1TStage2Shower::~L1TStage2Shower() {}
+
+void L1TStage2Shower::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, const edm::EventSetup&) {
+  ibooker.setCurrentFolder(monitorDir);
+
+  const std::array<std::string, 9> suffix_label{
+      {"4/2", "4/1", "3/2", "3/1", " 2/2", "2/1", "1/3", "1/2", "1/1"}};
+
+  // CSC local shower
+  cscShowerOccupancyLoose = ibooker.book2D("cscShowerOccupancyLoose", "CSC Loose Shower Occupancy", 36, 1, 37, 18, 0, 18);
+  cscShowerOccupancyLoose->setAxisTitle("Chamber", 1);
+  for (int ybin = 1; ybin <= 9; ++ybin) {
+    cscShowerOccupancyLoose->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    cscShowerOccupancyLoose->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+  }
+
+  cscShowerOccupancyNom = ibooker.book2D("cscShowerOccupancyNom", "CSC Nominal Shower Occupancy", 36, 1, 37, 18, 0, 18);
+  cscShowerOccupancyNom->setAxisTitle("Chamber", 1);
+  for (int ybin = 1; ybin <= 9; ++ybin) {
+    cscShowerOccupancyNom->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    cscShowerOccupancyNom->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+  }
+
+  cscShowerOccupancyTight = ibooker.book2D("cscShowerOccupancyTight", "CSC Tight Shower Occupancy", 36, 1, 37, 18, 0, 18);
+  cscShowerOccupancyTight->setAxisTitle("Chamber", 1);
+  for (int ybin = 1; ybin <= 9; ++ybin) {
+    cscShowerOccupancyTight->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    cscShowerOccupancyTight->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+  }
+
+  cscShowerStationRing = ibooker.book2D("cscShowerStationRing", "CSC shower types in stations and rings", 4, 0, 4, 18, 0, 18);
+  cscShowerStationRing->setAxisTitle("Type", 1);
+  cscShowerStationRing->setBinLabel(1, "Total", 1);
+  cscShowerStationRing->setBinLabel(2, "Loose", 1);
+  cscShowerStationRing->setBinLabel(3, "Nominal", 1);
+  cscShowerStationRing->setBinLabel(4, "Tight", 1);
+  for (int ybin = 1; ybin <= 9; ++ybin) {
+    cscShowerStationRing->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    cscShowerStationRing->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+  }
+
+  cscShowerChamber = ibooker.book2D("cscShowerChamber", "CSC shower types in chambers", 36, 1, 37, 4, 0, 4);
+  cscShowerChamber->setAxisTitle("Chamber", 1);
+  cscShowerChamber->setAxisTitle("Type", 2);
+  cscShowerChamber->setBinLabel(1, "Total", 2);
+  cscShowerChamber->setBinLabel(2, "Loose", 2);
+  cscShowerChamber->setBinLabel(3, "Nominal", 2);
+  cscShowerChamber->setBinLabel(4, "Tight", 2);
+ 
+  // EMTF regional shower
+  emtfShowerTypeOccupancy = ibooker.book2D("emtfShowerTypeOccupancy", "EMTF shower Type Occupancy", 6, 1, 7, 8, 0, 8);
+  emtfShowerTypeOccupancy->setAxisTitle("Sector", 1);
+  emtfShowerTypeOccupancy->setBinLabel(8, "ME+ Tight",  2);
+  emtfShowerTypeOccupancy->setBinLabel(7, "ME+ 2Loose", 2);
+  emtfShowerTypeOccupancy->setBinLabel(6, "ME+ Nom",    2);
+  emtfShowerTypeOccupancy->setBinLabel(5, "ME+ Tot",    2);
+  emtfShowerTypeOccupancy->setBinLabel(4, "ME- Tot",    2);
+  emtfShowerTypeOccupancy->setBinLabel(3, "ME- Nom",    2);
+  emtfShowerTypeOccupancy->setBinLabel(2, "ME- 2Loose", 2);
+  emtfShowerTypeOccupancy->setBinLabel(1, "ME- Tight",  2);
+}
+
+void L1TStage2Shower::analyze(const edm::Event& e, const edm::EventSetup& c) {
+  edm::Handle<l1t::RegionalMuonShowerBxCollection> EmtfShowers;
+  e.getByToken(EMTFShowerToken, EmtfShowers);
+
+  edm::Handle<CSCShowerDigiCollection> CscShowers;
+  e.getByToken(CSCShowerToken, CscShowers);
+
+  const std::map<std::pair<int, int>, int> histIndexCSC = {{{1, 1}, 8},
+                                                           {{1, 2}, 7},
+                                                           {{1, 3}, 6},
+                                                           {{2, 1}, 5},
+                                                           {{2, 2}, 4},
+                                                           {{3, 1}, 3},
+                                                           {{3, 2}, 2},
+                                                           {{4, 1}, 1},
+                                                           {{4, 2}, 0}};
+
+  // Fill CSC local shower plots
+  for (auto element = CscShowers->begin(); element != CscShowers->end(); ++element) {
+    auto detId = (*element).first;
+    int endcap  = (detId.endcap() == 1 ? 1 : -1);
+    int station = detId.station();
+    int ring    = detId.ring();
+    int chamber = detId.chamber();
+    int sr = histIndexCSC.at({station, ring});
+    if (endcap == -1) sr = 17 - sr;
+    float evt_wgt = (station > 1 && ring == 1) ? 0.5 : 1.0;
+
+    auto cscShower    = (*element).second.first;
+    auto cscShowerEnd = (*element).second.second;
+    for (; cscShower != cscShowerEnd; ++cscShower) {
+      if (station > 1 && (ring % 2) == 1) {
+        if (cscShower->isLooseInTime()) cscShowerOccupancyLoose->Fill(chamber * 2,     sr, evt_wgt);
+        if (cscShower->isNominalInTime()) cscShowerOccupancyNom->Fill(chamber * 2,     sr, evt_wgt);
+        if (cscShower->isTightInTime()) cscShowerOccupancyTight->Fill(chamber * 2,     sr, evt_wgt);
+        if (cscShower->isLooseInTime()) cscShowerOccupancyLoose->Fill(chamber * 2 - 1, sr, evt_wgt);
+        if (cscShower->isNominalInTime()) cscShowerOccupancyNom->Fill(chamber * 2 - 1, sr, evt_wgt);
+        if (cscShower->isTightInTime()) cscShowerOccupancyTight->Fill(chamber * 2 - 1, sr, evt_wgt);
+      }
+      else {
+        if (cscShower->isLooseInTime()) cscShowerOccupancyLoose->Fill(chamber, sr);
+        if (cscShower->isNominalInTime()) cscShowerOccupancyNom->Fill(chamber, sr);
+        if (cscShower->isTightInTime()) cscShowerOccupancyTight->Fill(chamber, sr);
+      }      
+
+      cscShowerStationRing->Fill(0.5, sr);
+      if (cscShower->isLooseInTime())   cscShowerStationRing->Fill(1.5, sr);
+      if (cscShower->isNominalInTime()) cscShowerStationRing->Fill(2.5, sr);
+      if (cscShower->isTightInTime())   cscShowerStationRing->Fill(3.5, sr);
+
+      if (station > 1 && (ring % 2) == 1) {
+        cscShowerChamber->Fill(chamber * 2,     0.5, evt_wgt);
+        cscShowerChamber->Fill(chamber * 2 - 1, 0.5, evt_wgt);
+        if (cscShower->isLooseInTime())   cscShowerChamber->Fill(chamber * 2,     1.5, evt_wgt);
+        if (cscShower->isNominalInTime()) cscShowerChamber->Fill(chamber * 2,     2.5, evt_wgt);
+        if (cscShower->isTightInTime())   cscShowerChamber->Fill(chamber * 2,     3.5, evt_wgt);
+        if (cscShower->isLooseInTime())   cscShowerChamber->Fill(chamber * 2 - 1, 1.5, evt_wgt);
+        if (cscShower->isNominalInTime()) cscShowerChamber->Fill(chamber * 2 - 1, 2.5, evt_wgt);
+        if (cscShower->isTightInTime())   cscShowerChamber->Fill(chamber * 2 - 1, 3.5, evt_wgt);
+      }
+      else {
+        cscShowerChamber->Fill(chamber, 0.5);
+        if (cscShower->isLooseInTime())   cscShowerChamber->Fill(chamber, 1.5);
+        if (cscShower->isNominalInTime()) cscShowerChamber->Fill(chamber, 2.5);
+        if (cscShower->isTightInTime())   cscShowerChamber->Fill(chamber, 3.5);
+      }
+    }
+  }
+
+  // Fill EMTF regional shower plots
+  for (auto Shower = EmtfShowers->begin(); Shower != EmtfShowers->end(); ++Shower) {
+    int endcap = Shower->endcap();
+    int sector = Shower->sector();
+    if (not Shower->isValid()) continue;
+    if (Shower->isOneNominalInTime() or Shower->isTwoLooseInTime() or Shower->isOneTightInTime()) {
+      if (Shower->isOneTightInTime())   emtfShowerTypeOccupancy->Fill(sector, (endcap == 1) ? 7.5 : 0.5);
+      if (Shower->isTwoLooseInTime())   emtfShowerTypeOccupancy->Fill(sector, (endcap == 1) ? 6.5 : 1.5);
+      if (Shower->isOneNominalInTime()) emtfShowerTypeOccupancy->Fill(sector, (endcap == 1) ? 5.5 : 2.5);
+      emtfShowerTypeOccupancy->Fill(sector, (endcap == 1) ? 4.5 : 3.5);
+    }
+  }
+}

--- a/DQM/L1TMonitor/src/L1TStage2Shower.cc
+++ b/DQM/L1TMonitor/src/L1TStage2Shower.cc
@@ -76,11 +76,8 @@ void L1TStage2Shower::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&
 }
 
 void L1TStage2Shower::analyze(const edm::Event& e, const edm::EventSetup& c) {
-  edm::Handle<l1t::RegionalMuonShowerBxCollection> EmtfShowers;
-  e.getByToken(EMTFShowerToken, EmtfShowers);
-
-  edm::Handle<CSCShowerDigiCollection> CscShowers;
-  e.getByToken(CSCShowerToken, CscShowers);
+  l1t::RegionalMuonShowerBxCollection const& EmtfShowers = e.get(EMTFShowerToken);
+  CSCShowerDigiCollection const& CscShowers = e.get(CSCShowerToken);
 
   const std::map<std::pair<int, int>, int> histIndexCSC = {{{1, 1}, 8},
                                                            {{1, 2}, 7},
@@ -93,8 +90,8 @@ void L1TStage2Shower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                                                            {{4, 2}, 0}};
 
   // Fill CSC local shower plots
-  for (auto element = CscShowers->begin(); element != CscShowers->end(); ++element) {
-    auto detId = (*element).first;
+  for (auto const& element : CscShowers) {
+    auto detId = element.first;
     int endcap = (detId.endcap() == 1 ? 1 : -1);
     int station = detId.station();
     int ring = detId.ring();
@@ -104,8 +101,8 @@ void L1TStage2Shower::analyze(const edm::Event& e, const edm::EventSetup& c) {
       sr = 17 - sr;
     float evt_wgt = (station > 1 && ring == 1) ? 0.5 : 1.0;
 
-    auto cscShower = (*element).second.first;
-    auto cscShowerEnd = (*element).second.second;
+    auto cscShower = element.second.first;
+    auto cscShowerEnd = element.second.second;
     for (; cscShower != cscShowerEnd; ++cscShower) {
       if (station > 1 && (ring % 2) == 1) {
         if (cscShower->isLooseInTime())
@@ -165,17 +162,17 @@ void L1TStage2Shower::analyze(const edm::Event& e, const edm::EventSetup& c) {
   }
 
   // Fill EMTF regional shower plots
-  for (auto Shower = EmtfShowers->begin(); Shower != EmtfShowers->end(); ++Shower) {
-    int endcap = Shower->endcap();
-    int sector = Shower->sector();
-    if (not Shower->isValid())
+  for (auto const& Shower : EmtfShowers) {
+    if (not Shower.isValid())
       continue;
-    if (Shower->isOneNominalInTime() or Shower->isTwoLooseInTime() or Shower->isOneTightInTime()) {
-      if (Shower->isOneTightInTime())
+    if (Shower.isOneNominalInTime() or Shower.isTwoLooseInTime() or Shower.isOneTightInTime()) {
+      int endcap = Shower.endcap();
+      int sector = Shower.sector();
+      if (Shower.isOneTightInTime())
         emtfShowerTypeOccupancy->Fill(sector, (endcap == 1) ? 7.5 : 0.5);
-      if (Shower->isTwoLooseInTime())
+      if (Shower.isTwoLooseInTime())
         emtfShowerTypeOccupancy->Fill(sector, (endcap == 1) ? 6.5 : 1.5);
-      if (Shower->isOneNominalInTime())
+      if (Shower.isOneNominalInTime())
         emtfShowerTypeOccupancy->Fill(sector, (endcap == 1) ? 5.5 : 2.5);
       emtfShowerTypeOccupancy->Fill(sector, (endcap == 1) ? 4.5 : 3.5);
     }

--- a/DQM/L1TMonitor/src/L1TStage2Shower.cc
+++ b/DQM/L1TMonitor/src/L1TStage2Shower.cc
@@ -16,11 +16,11 @@ L1TStage2Shower::~L1TStage2Shower() {}
 void L1TStage2Shower::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, const edm::EventSetup&) {
   ibooker.setCurrentFolder(monitorDir);
 
-  const std::array<std::string, 9> suffix_label{
-      {"4/2", "4/1", "3/2", "3/1", " 2/2", "2/1", "1/3", "1/2", "1/1"}};
+  const std::array<std::string, 9> suffix_label{{"4/2", "4/1", "3/2", "3/1", " 2/2", "2/1", "1/3", "1/2", "1/1"}};
 
   // CSC local shower
-  cscShowerOccupancyLoose = ibooker.book2D("cscShowerOccupancyLoose", "CSC Loose Shower Occupancy", 36, 1, 37, 18, 0, 18);
+  cscShowerOccupancyLoose =
+      ibooker.book2D("cscShowerOccupancyLoose", "CSC Loose Shower Occupancy", 36, 1, 37, 18, 0, 18);
   cscShowerOccupancyLoose->setAxisTitle("Chamber", 1);
   for (int ybin = 1; ybin <= 9; ++ybin) {
     cscShowerOccupancyLoose->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
@@ -34,14 +34,16 @@ void L1TStage2Shower::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&
     cscShowerOccupancyNom->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
   }
 
-  cscShowerOccupancyTight = ibooker.book2D("cscShowerOccupancyTight", "CSC Tight Shower Occupancy", 36, 1, 37, 18, 0, 18);
+  cscShowerOccupancyTight =
+      ibooker.book2D("cscShowerOccupancyTight", "CSC Tight Shower Occupancy", 36, 1, 37, 18, 0, 18);
   cscShowerOccupancyTight->setAxisTitle("Chamber", 1);
   for (int ybin = 1; ybin <= 9; ++ybin) {
     cscShowerOccupancyTight->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
     cscShowerOccupancyTight->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
   }
 
-  cscShowerStationRing = ibooker.book2D("cscShowerStationRing", "CSC shower types in stations and rings", 4, 0, 4, 18, 0, 18);
+  cscShowerStationRing =
+      ibooker.book2D("cscShowerStationRing", "CSC shower types in stations and rings", 4, 0, 4, 18, 0, 18);
   cscShowerStationRing->setAxisTitle("Type", 1);
   cscShowerStationRing->setBinLabel(1, "Total", 1);
   cscShowerStationRing->setBinLabel(2, "Loose", 1);
@@ -59,18 +61,18 @@ void L1TStage2Shower::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&
   cscShowerChamber->setBinLabel(2, "Loose", 2);
   cscShowerChamber->setBinLabel(3, "Nominal", 2);
   cscShowerChamber->setBinLabel(4, "Tight", 2);
- 
+
   // EMTF regional shower
   emtfShowerTypeOccupancy = ibooker.book2D("emtfShowerTypeOccupancy", "EMTF shower Type Occupancy", 6, 1, 7, 8, 0, 8);
   emtfShowerTypeOccupancy->setAxisTitle("Sector", 1);
-  emtfShowerTypeOccupancy->setBinLabel(8, "ME+ Tight",  2);
+  emtfShowerTypeOccupancy->setBinLabel(8, "ME+ Tight", 2);
   emtfShowerTypeOccupancy->setBinLabel(7, "ME+ 2Loose", 2);
-  emtfShowerTypeOccupancy->setBinLabel(6, "ME+ Nom",    2);
-  emtfShowerTypeOccupancy->setBinLabel(5, "ME+ Tot",    2);
-  emtfShowerTypeOccupancy->setBinLabel(4, "ME- Tot",    2);
-  emtfShowerTypeOccupancy->setBinLabel(3, "ME- Nom",    2);
+  emtfShowerTypeOccupancy->setBinLabel(6, "ME+ Nom", 2);
+  emtfShowerTypeOccupancy->setBinLabel(5, "ME+ Tot", 2);
+  emtfShowerTypeOccupancy->setBinLabel(4, "ME- Tot", 2);
+  emtfShowerTypeOccupancy->setBinLabel(3, "ME- Nom", 2);
   emtfShowerTypeOccupancy->setBinLabel(2, "ME- 2Loose", 2);
-  emtfShowerTypeOccupancy->setBinLabel(1, "ME- Tight",  2);
+  emtfShowerTypeOccupancy->setBinLabel(1, "ME- Tight", 2);
 }
 
 void L1TStage2Shower::analyze(const edm::Event& e, const edm::EventSetup& c) {
@@ -93,51 +95,71 @@ void L1TStage2Shower::analyze(const edm::Event& e, const edm::EventSetup& c) {
   // Fill CSC local shower plots
   for (auto element = CscShowers->begin(); element != CscShowers->end(); ++element) {
     auto detId = (*element).first;
-    int endcap  = (detId.endcap() == 1 ? 1 : -1);
+    int endcap = (detId.endcap() == 1 ? 1 : -1);
     int station = detId.station();
-    int ring    = detId.ring();
+    int ring = detId.ring();
     int chamber = detId.chamber();
     int sr = histIndexCSC.at({station, ring});
-    if (endcap == -1) sr = 17 - sr;
+    if (endcap == -1)
+      sr = 17 - sr;
     float evt_wgt = (station > 1 && ring == 1) ? 0.5 : 1.0;
 
-    auto cscShower    = (*element).second.first;
+    auto cscShower = (*element).second.first;
     auto cscShowerEnd = (*element).second.second;
     for (; cscShower != cscShowerEnd; ++cscShower) {
       if (station > 1 && (ring % 2) == 1) {
-        if (cscShower->isLooseInTime()) cscShowerOccupancyLoose->Fill(chamber * 2,     sr, evt_wgt);
-        if (cscShower->isNominalInTime()) cscShowerOccupancyNom->Fill(chamber * 2,     sr, evt_wgt);
-        if (cscShower->isTightInTime()) cscShowerOccupancyTight->Fill(chamber * 2,     sr, evt_wgt);
-        if (cscShower->isLooseInTime()) cscShowerOccupancyLoose->Fill(chamber * 2 - 1, sr, evt_wgt);
-        if (cscShower->isNominalInTime()) cscShowerOccupancyNom->Fill(chamber * 2 - 1, sr, evt_wgt);
-        if (cscShower->isTightInTime()) cscShowerOccupancyTight->Fill(chamber * 2 - 1, sr, evt_wgt);
+        if (cscShower->isLooseInTime())
+          cscShowerOccupancyLoose->Fill(chamber * 2, sr, evt_wgt);
+        if (cscShower->isNominalInTime())
+          cscShowerOccupancyNom->Fill(chamber * 2, sr, evt_wgt);
+        if (cscShower->isTightInTime())
+          cscShowerOccupancyTight->Fill(chamber * 2, sr, evt_wgt);
+        if (cscShower->isLooseInTime())
+          cscShowerOccupancyLoose->Fill(chamber * 2 - 1, sr, evt_wgt);
+        if (cscShower->isNominalInTime())
+          cscShowerOccupancyNom->Fill(chamber * 2 - 1, sr, evt_wgt);
+        if (cscShower->isTightInTime())
+          cscShowerOccupancyTight->Fill(chamber * 2 - 1, sr, evt_wgt);
+      } else {
+        if (cscShower->isLooseInTime())
+          cscShowerOccupancyLoose->Fill(chamber, sr);
+        if (cscShower->isNominalInTime())
+          cscShowerOccupancyNom->Fill(chamber, sr);
+        if (cscShower->isTightInTime())
+          cscShowerOccupancyTight->Fill(chamber, sr);
       }
-      else {
-        if (cscShower->isLooseInTime()) cscShowerOccupancyLoose->Fill(chamber, sr);
-        if (cscShower->isNominalInTime()) cscShowerOccupancyNom->Fill(chamber, sr);
-        if (cscShower->isTightInTime()) cscShowerOccupancyTight->Fill(chamber, sr);
-      }      
 
       cscShowerStationRing->Fill(0.5, sr);
-      if (cscShower->isLooseInTime())   cscShowerStationRing->Fill(1.5, sr);
-      if (cscShower->isNominalInTime()) cscShowerStationRing->Fill(2.5, sr);
-      if (cscShower->isTightInTime())   cscShowerStationRing->Fill(3.5, sr);
+      if (cscShower->isLooseInTime())
+        cscShowerStationRing->Fill(1.5, sr);
+      if (cscShower->isNominalInTime())
+        cscShowerStationRing->Fill(2.5, sr);
+      if (cscShower->isTightInTime())
+        cscShowerStationRing->Fill(3.5, sr);
 
       if (station > 1 && (ring % 2) == 1) {
-        cscShowerChamber->Fill(chamber * 2,     0.5, evt_wgt);
+        cscShowerChamber->Fill(chamber * 2, 0.5, evt_wgt);
         cscShowerChamber->Fill(chamber * 2 - 1, 0.5, evt_wgt);
-        if (cscShower->isLooseInTime())   cscShowerChamber->Fill(chamber * 2,     1.5, evt_wgt);
-        if (cscShower->isNominalInTime()) cscShowerChamber->Fill(chamber * 2,     2.5, evt_wgt);
-        if (cscShower->isTightInTime())   cscShowerChamber->Fill(chamber * 2,     3.5, evt_wgt);
-        if (cscShower->isLooseInTime())   cscShowerChamber->Fill(chamber * 2 - 1, 1.5, evt_wgt);
-        if (cscShower->isNominalInTime()) cscShowerChamber->Fill(chamber * 2 - 1, 2.5, evt_wgt);
-        if (cscShower->isTightInTime())   cscShowerChamber->Fill(chamber * 2 - 1, 3.5, evt_wgt);
-      }
-      else {
+        if (cscShower->isLooseInTime())
+          cscShowerChamber->Fill(chamber * 2, 1.5, evt_wgt);
+        if (cscShower->isNominalInTime())
+          cscShowerChamber->Fill(chamber * 2, 2.5, evt_wgt);
+        if (cscShower->isTightInTime())
+          cscShowerChamber->Fill(chamber * 2, 3.5, evt_wgt);
+        if (cscShower->isLooseInTime())
+          cscShowerChamber->Fill(chamber * 2 - 1, 1.5, evt_wgt);
+        if (cscShower->isNominalInTime())
+          cscShowerChamber->Fill(chamber * 2 - 1, 2.5, evt_wgt);
+        if (cscShower->isTightInTime())
+          cscShowerChamber->Fill(chamber * 2 - 1, 3.5, evt_wgt);
+      } else {
         cscShowerChamber->Fill(chamber, 0.5);
-        if (cscShower->isLooseInTime())   cscShowerChamber->Fill(chamber, 1.5);
-        if (cscShower->isNominalInTime()) cscShowerChamber->Fill(chamber, 2.5);
-        if (cscShower->isTightInTime())   cscShowerChamber->Fill(chamber, 3.5);
+        if (cscShower->isLooseInTime())
+          cscShowerChamber->Fill(chamber, 1.5);
+        if (cscShower->isNominalInTime())
+          cscShowerChamber->Fill(chamber, 2.5);
+        if (cscShower->isTightInTime())
+          cscShowerChamber->Fill(chamber, 3.5);
       }
     }
   }
@@ -146,11 +168,15 @@ void L1TStage2Shower::analyze(const edm::Event& e, const edm::EventSetup& c) {
   for (auto Shower = EmtfShowers->begin(); Shower != EmtfShowers->end(); ++Shower) {
     int endcap = Shower->endcap();
     int sector = Shower->sector();
-    if (not Shower->isValid()) continue;
+    if (not Shower->isValid())
+      continue;
     if (Shower->isOneNominalInTime() or Shower->isTwoLooseInTime() or Shower->isOneTightInTime()) {
-      if (Shower->isOneTightInTime())   emtfShowerTypeOccupancy->Fill(sector, (endcap == 1) ? 7.5 : 0.5);
-      if (Shower->isTwoLooseInTime())   emtfShowerTypeOccupancy->Fill(sector, (endcap == 1) ? 6.5 : 1.5);
-      if (Shower->isOneNominalInTime()) emtfShowerTypeOccupancy->Fill(sector, (endcap == 1) ? 5.5 : 2.5);
+      if (Shower->isOneTightInTime())
+        emtfShowerTypeOccupancy->Fill(sector, (endcap == 1) ? 7.5 : 0.5);
+      if (Shower->isTwoLooseInTime())
+        emtfShowerTypeOccupancy->Fill(sector, (endcap == 1) ? 6.5 : 1.5);
+      if (Shower->isOneNominalInTime())
+        emtfShowerTypeOccupancy->Fill(sector, (endcap == 1) ? 5.5 : 2.5);
       emtfShowerTypeOccupancy->Fill(sector, (endcap == 1) ? 4.5 : 3.5);
     }
   }


### PR DESCRIPTION
#### PR description:

Added L1T DQM module for CSC local shower and EMTF regional shower in the Run 3 trigger.

This DQM module is complete and tested with Run 3 MC samples.
As of CMSSW_12_2_0_pre2, there is an unpacker for CSC showers ([PR#35461](https://github.com/cms-sw/cmssw/pull/35461))but not for EMTF showers. Therefore at the moment the shower DQM cannot be used in data-taking and is not enabled in the online DQM sequence. It will be enabled once the EMTF shower unpacker is ready.
In this PR we do not expect any change in the output.

#### PR validation:

The DQM plots are tested with HTo2LongLivedTo4b samples and Neutrino gun samples. 
Passed the unit test and matrix test as there should be no change in the output.
Code format changes are applied.

@dildick may want to watch this.
