### PR TITLE
[AlCa] Move away from edm::EDAnalyzer LegacyModule in AlCaRecoTriggerBitsRcdRead

### DIFF
--- a/CondTools/HLT/src/AlCaRecoTriggerBitsRcdRead.cc
+++ b/CondTools/HLT/src/AlCaRecoTriggerBitsRcdRead.cc
@@ -28,7 +28,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -38,14 +38,14 @@
 #include "CondFormats/HLTObjects/interface/AlCaRecoTriggerBits.h"
 #include "CondFormats/DataRecord/interface/AlCaRecoTriggerBitsRcd.h"
 
-class AlCaRecoTriggerBitsRcdRead : public edm::EDAnalyzer {
+class AlCaRecoTriggerBitsRcdRead : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   explicit AlCaRecoTriggerBitsRcdRead(const edm::ParameterSet &cfg);
   ~AlCaRecoTriggerBitsRcdRead() override {}
 
   void analyze(const edm::Event &evt, const edm::EventSetup &evtSetup) override {}
   void beginRun(const edm::Run &run, const edm::EventSetup &evtSetup) override;
-  void endJob() override;
+  void endRun(edm::Run const &, edm::EventSetup const &) override;
 
 private:
   // types
@@ -132,7 +132,7 @@ void AlCaRecoTriggerBitsRcdRead::beginRun(const edm::Run &run, const edm::EventS
 }
 
 ///////////////////////////////////////////////////////////////////////
-void AlCaRecoTriggerBitsRcdRead::endJob() {
+void AlCaRecoTriggerBitsRcdRead::endRun(edm::Run const &, edm::EventSetup const &) {
   // Print for very last IOV, not treated yet in beginRun(..):
   this->printMap(firstRun_, lastRun_, lastTriggerBits_);
 }

--- a/CondTools/HLT/src/AlCaRecoTriggerBitsRcdUpdate.cc
+++ b/CondTools/HLT/src/AlCaRecoTriggerBitsRcdUpdate.cc
@@ -16,7 +16,7 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -28,12 +28,14 @@
 // Rcd for reading old one:
 #include "CondFormats/DataRecord/interface/AlCaRecoTriggerBitsRcd.h"
 
-class AlCaRecoTriggerBitsRcdUpdate : public edm::EDAnalyzer {
+class AlCaRecoTriggerBitsRcdUpdate : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   explicit AlCaRecoTriggerBitsRcdUpdate(const edm::ParameterSet &cfg);
   ~AlCaRecoTriggerBitsRcdUpdate() override {}
 
   void analyze(const edm::Event &evt, const edm::EventSetup &evtSetup) override;
+  void beginRun(const edm::Run &run, const edm::EventSetup &evtSetup) override {}
+  void endRun(edm::Run const &, edm::EventSetup const &) override {}
 
 private:
   typedef std::map<std::string, std::string> TriggerMap;


### PR DESCRIPTION
#### PR description:

This is an update of AlCaRecoTriggerBitsRcdRead.cc in order to move from legacy module edm::EDAnalyzer to `edm::one::EDAnalyzer`.

#### PR validation:

It compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
