### PR TITLE
Migrate DT code to new PoolDBOutputService

### DIFF
--- a/CondFormats/DTObjects/test/stubs/DTConfigWrite.cc
+++ b/CondFormats/DTObjects/test/stubs/DTConfigWrite.cc
@@ -43,7 +43,7 @@ namespace edmtest {
       return;
     }
 
-    DTCCBConfig* conf = new DTCCBConfig("test_config");
+    DTCCBConfig conf("test_config");
 
     int status = 0;
     std::ifstream ifile("testConfig.txt");
@@ -57,7 +57,7 @@ namespace edmtest {
     int nbr;
     int ibr;
     ifile >> run >> nty;
-    conf->setStamp(run);
+    conf.setStamp(run);
     std::vector<DTConfigKey> fullKey;
     while (nty--) {
       ifile >> kty >> key;
@@ -66,21 +66,21 @@ namespace edmtest {
       confList.confKey = key;
       fullKey.push_back(confList);
     }
-    conf->setFullKey(fullKey);
+    conf.setFullKey(fullKey);
     while (ifile >> whe >> sta >> sec >> nbr) {
       std::vector<int> cfg;
       while (nbr--) {
         ifile >> ibr;
         cfg.push_back(ibr);
       }
-      status = conf->setConfigKey(whe, sta, sec, cfg);
+      status = conf.setConfigKey(whe, sta, sec, cfg);
       std::cout << whe << " " << sta << " " << sec << "  -> ";
       std::cout << "insert status: " << status << std::endl;
     }
 
     std::cout << "end of time : " << dbservice->endOfTime() << std::endl;
     if (dbservice->isNewTagRequest("DTCCBConfigRcd")) {
-      dbservice->createNewIOV<DTCCBConfig>(conf, dbservice->beginOfTime(), dbservice->endOfTime(), "DTCCBConfigRcd");
+      dbservice->createOneIOV<DTCCBConfig>(conf, dbservice->beginOfTime(), "DTCCBConfigRcd");
       //                      0xffffffff,"DTCCBConfigRcd");
     } else {
       std::cout << "already present tag" << std::endl;

--- a/CondFormats/DTObjects/test/stubs/DTDeadUpdate.cc
+++ b/CondFormats/DTObjects/test/stubs/DTDeadUpdate.cc
@@ -24,7 +24,7 @@ namespace edmtest {
 
   DTDeadUpdate::DTDeadUpdate(int i) : dSum(0) {}
 
-  DTDeadUpdate::~DTDeadUpdate() {}
+  DTDeadUpdate::~DTDeadUpdate() { delete dSum; }
 
   void DTDeadUpdate::analyze(const edm::Event& e, const edm::EventSetup& context) {
     if (dSum == 0)
@@ -69,12 +69,12 @@ namespace edmtest {
     fill_discCat("discCat_list.txt", dSum);
 
     if (dbservice->isNewTagRequest("DTDeadFlagRcd")) {
-      dbservice->createNewIOV<DTDeadFlag>(dSum, dbservice->beginOfTime(), dbservice->endOfTime(), "DTDeadFlagRcd");
+      dbservice->createOneIOV<DTDeadFlag>(*dSum, dbservice->beginOfTime(), "DTDeadFlagRcd");
     } else {
       std::cout << "already present tag" << std::endl;
       int currentRun = 10;
       //      dbservice->appendTillTime<DTDeadFlag>(
-      dbservice->appendSinceTime<DTDeadFlag>(dSum, currentRun, "DTDeadFlagRcd");
+      dbservice->appendOneIOV<DTDeadFlag>(*dSum, currentRun, "DTDeadFlagRcd");
       //      dbservice->appendSinceTime<DTDeadFlag>(
       //                 dlist,dbservice->currentTime(),"DTDeadFlagRcd");
     }

--- a/CondFormats/DTObjects/test/stubs/DTDeadWrite.cc
+++ b/CondFormats/DTObjects/test/stubs/DTDeadWrite.cc
@@ -39,20 +39,20 @@ namespace edmtest {
       return;
     }
 
-    DTDeadFlag* dlist = new DTDeadFlag("deadList");
+    DTDeadFlag dlist("deadList");
 
-    fill_dead_HV("dead_HV_list.txt", dlist);
-    fill_dead_TP("dead_TP_list.txt", dlist);
-    fill_dead_RO("dead_RO_list.txt", dlist);
-    fill_discCat("discCat_list.txt", dlist);
+    fill_dead_HV("dead_HV_list.txt", &dlist);
+    fill_dead_TP("dead_TP_list.txt", &dlist);
+    fill_dead_RO("dead_RO_list.txt", &dlist);
+    fill_discCat("discCat_list.txt", &dlist);
 
     if (dbservice->isNewTagRequest("DTDeadFlagRcd")) {
-      dbservice->createNewIOV<DTDeadFlag>(dlist, dbservice->beginOfTime(), dbservice->endOfTime(), "DTDeadFlagRcd");
+      dbservice->createOneIOV<DTDeadFlag>(dlist, dbservice->beginOfTime(), "DTDeadFlagRcd");
     } else {
       std::cout << "already present tag" << std::endl;
       int currentRun = 10;
       //      dbservice->appendTillTime<DTDeadFlag>(
-      dbservice->appendSinceTime<DTDeadFlag>(dlist, currentRun, "DTDeadFlagRcd");
+      dbservice->appendOneIOV<DTDeadFlag>(dlist, currentRun, "DTDeadFlagRcd");
       //      dbservice->appendSinceTime<DTDeadFlag>(
       //                 dlist,dbservice->currentTime(),"DTDeadFlagRcd");
     }

--- a/CondFormats/DTObjects/test/stubs/DTMapWrite.cc
+++ b/CondFormats/DTObjects/test/stubs/DTMapWrite.cc
@@ -43,7 +43,7 @@ namespace edmtest {
       return;
     }
 
-    DTReadOutMapping* ro_map = new DTReadOutMapping("cmssw_ROB", "cmssw_ROS");
+    DTReadOutMapping ro_map("cmssw_ROB", "cmssw_ROS");
     int status = 0;
     std::ifstream ifile("testMap.txt");
     int ddu;
@@ -58,14 +58,13 @@ namespace edmtest {
     int lay;
     int cel;
     while (ifile >> ddu >> ros >> rob >> tdc >> cha >> whe >> sta >> sec >> qua >> lay >> cel) {
-      status = ro_map->insertReadOutGeometryLink(ddu, ros, rob, tdc, cha, whe, sta, sec, qua, lay, cel);
+      status = ro_map.insertReadOutGeometryLink(ddu, ros, rob, tdc, cha, whe, sta, sec, qua, lay, cel);
       std::cout << ddu << " " << ros << " " << rob << " " << tdc << " " << cha << " " << whe << " " << sta << " " << sec
                 << " " << qua << " " << lay << " " << cel << "  -> ";
       std::cout << "insert status: " << status << std::endl;
     }
     if (dbservice->isNewTagRequest("DTReadOutMappingRcd")) {
-      dbservice->createNewIOV<DTReadOutMapping>(
-          ro_map, dbservice->beginOfTime(), dbservice->endOfTime(), "DTReadOutMappingRcd");
+      dbservice->createOneIOV<DTReadOutMapping>(ro_map, dbservice->beginOfTime(), "DTReadOutMappingRcd");
     } else {
       std::cout << "already present tag" << std::endl;
       //      dbservice->appendSinceTime<DTReadOutMapping>(

--- a/CondFormats/DTObjects/test/stubs/DTRangeT0Write.cc
+++ b/CondFormats/DTObjects/test/stubs/DTRangeT0Write.cc
@@ -43,7 +43,7 @@ namespace edmtest {
       return;
     }
 
-    DTRangeT0* rt0 = new DTRangeT0("cmssw_rt0");
+    DTRangeT0 rt0("cmssw_rt0");
 
     int status = 0;
     std::ifstream ifile("testRT0.txt");
@@ -54,13 +54,13 @@ namespace edmtest {
     int t0min;
     int t0max;
     while (ifile >> whe >> sta >> sec >> qua >> t0min >> t0max) {
-      status = rt0->set(whe, sta, sec, qua, t0min, t0max);
+      status = rt0.set(whe, sta, sec, qua, t0min, t0max);
       std::cout << whe << " " << sta << " " << sec << " " << qua << " " << t0min << " " << t0max << "  -> ";
       std::cout << "insert status: " << status << std::endl;
     }
 
     if (dbservice->isNewTagRequest("DTRangeT0Rcd")) {
-      dbservice->createNewIOV<DTRangeT0>(rt0, dbservice->beginOfTime(), dbservice->endOfTime(), "DTRangeT0Rcd");
+      dbservice->createOneIOV<DTRangeT0>(rt0, dbservice->beginOfTime(), "DTRangeT0Rcd");
     } else {
       std::cout << "already present tag" << std::endl;
       //      dbservice->appendSinceTime<DTRangeT0>(

--- a/CondFormats/DTObjects/test/stubs/DTT0Write.cc
+++ b/CondFormats/DTObjects/test/stubs/DTT0Write.cc
@@ -43,7 +43,7 @@ namespace edmtest {
       return;
     }
 
-    DTT0* t0 = new DTT0("cmssw_t0");
+    DTT0 t0("cmssw_t0");
 
     int status = 0;
     std::ifstream ifile("testT0.txt");
@@ -56,14 +56,14 @@ namespace edmtest {
     float t0m;
     float rms;
     while (ifile >> whe >> sta >> sec >> qua >> lay >> cel >> t0m >> rms) {
-      status = t0->set(whe, sta, sec, qua, lay, cel, t0m, rms, DTTimeUnits::counts);
+      status = t0.set(whe, sta, sec, qua, lay, cel, t0m, rms, DTTimeUnits::counts);
       std::cout << whe << " " << sta << " " << sec << " " << qua << " " << lay << " " << cel << " " << t0m << " " << rms
                 << "  -> ";
       std::cout << "insert status: " << status << std::endl;
     }
 
     if (dbservice->isNewTagRequest("DTT0Rcd")) {
-      dbservice->createNewIOV<DTT0>(t0, dbservice->beginOfTime(), dbservice->endOfTime(), "DTT0Rcd");
+      dbservice->createOneIOV<DTT0>(t0, dbservice->beginOfTime(), "DTT0Rcd");
     } else {
       std::cout << "already present tag" << std::endl;
       //      dbservice->appendSinceTime<DTT0>(

--- a/CondTools/DT/plugins/DTKeyedConfigDBInit.cc
+++ b/CondTools/DT/plugins/DTKeyedConfigDBInit.cc
@@ -50,15 +50,15 @@ void DTKeyedConfigDBInit::analyze(const edm::Event& e, const edm::EventSetup& c)
 
 void DTKeyedConfigDBInit::endJob() {
   edm::Service<cond::service::PoolDBOutputService> outdb;
-  DTKeyedConfig* bk = new DTKeyedConfig();
-  bk->setId(999999999);
-  bk->add("dummy");
-  cond::KeyedElement k(bk, 999999999);
-  outdb->writeOne(k.m_obj, k.m_key, container);
+  DTKeyedConfig bk;
+  bk.setId(999999999);
+  bk.add("dummy");
+  cond::KeyedElement k(&bk, 999999999);
+  outdb->writeOneIOV(*(k.m_obj), k.m_key, container);
 
-  std::vector<cond::Time_t>* kl = new std::vector<cond::Time_t>;
-  kl->push_back(999999999);
-  outdb->writeOne(kl, 1, iov);
+  std::vector<cond::Time_t> kl;
+  kl.push_back(999999999);
+  outdb->writeOneIOV(kl, 1, iov);
 
   return;
 }

--- a/CondTools/DT/src/DTKeyedConfigHandler.cc
+++ b/CondTools/DT/src/DTKeyedConfigHandler.cc
@@ -506,7 +506,6 @@ void DTKeyedConfigHandler::chkConfigList() {
   brickConfigQuery->addToOutputList("BRKID");
   brickConfigQuery->addToOutputList("BRKNAME");
   coral::ICursor& brickConfigCursor = brickConfigQuery->execute();
-  DTKeyedConfig* brickData = nullptr;
   std::vector<int> missingList;
   while (brickConfigCursor.next()) {
     const coral::AttributeList& row = brickConfigCursor.currentRow();
@@ -554,15 +553,15 @@ void DTKeyedConfigHandler::chkConfigList() {
     brickDataQuery->addToOutputList("CONFIGCMDS.CONFDATA");
     brickDataQuery->setCondition(brickCondition, bindVariableList);
     coral::ICursor& brickDataCursor = brickDataQuery->execute();
-    brickData = new DTKeyedConfig();
-    brickData->setId(brickConfigId);
+    DTKeyedConfig brickData;
+    brickData.setId(brickConfigId);
     while (brickDataCursor.next()) {
       const coral::AttributeList& row = brickDataCursor.currentRow();
-      brickData->add(row["CONFIGCMDS.CONFDATA"].data<std::string>());
+      brickData.add(row["CONFIGCMDS.CONFDATA"].data<std::string>());
     }
-    cond::KeyedElement k(brickData, brickConfigId);
+    cond::KeyedElement k(&brickData, brickConfigId);
     std::cout << "now writing brick: " << brickConfigId << std::endl;
-    outdb->writeOne(k.m_obj, k.m_key, brickContainer);
+    outdb->writeOneIOV(*(k.m_obj), k.m_key, brickContainer);
   }
 
   return;

--- a/CondTools/DT/src/DTUserKeyedConfigHandler.cc
+++ b/CondTools/DT/src/DTUserKeyedConfigHandler.cc
@@ -318,7 +318,6 @@ void DTUserKeyedConfigHandler::chkConfigList(const std::map<int, bool>& userBric
   brickConfigQuery->addToOutputList("BRKID");
   brickConfigQuery->addToOutputList("BRKNAME");
   coral::ICursor& brickConfigCursor = brickConfigQuery->execute();
-  DTKeyedConfig* brickData = nullptr;
   std::vector<int> missingList;
   std::vector<unsigned long long> checkedKeys;
   while (brickConfigCursor.next()) {
@@ -364,15 +363,15 @@ void DTUserKeyedConfigHandler::chkConfigList(const std::map<int, bool>& userBric
     brickDataQuery->addToOutputList("CONFIGCMDS.CONFDATA");
     brickDataQuery->setCondition(brickCondition, bindVariableList);
     coral::ICursor& brickDataCursor = brickDataQuery->execute();
-    brickData = new DTKeyedConfig();
-    brickData->setId(brickConfigId);
+    DTKeyedConfig brickData;
+    brickData.setId(brickConfigId);
     while (brickDataCursor.next()) {
       const coral::AttributeList& row = brickDataCursor.currentRow();
-      brickData->add(row["CONFIGCMDS.CONFDATA"].data<std::string>());
+      brickData.add(row["CONFIGCMDS.CONFDATA"].data<std::string>());
     }
-    cond::KeyedElement k(brickData, brickConfigId);
+    cond::KeyedElement k(&brickData, brickConfigId);
     std::cout << "now writing brick: " << brickConfigId << std::endl;
-    outdb->writeOne(k.m_obj, k.m_key, brickContainer);
+    outdb->writeOneIOV(*(k.m_obj), k.m_key, brickContainer);
   }
 
   return;


### PR DESCRIPTION
#### PR description:

Part of cms-AlCaDB/AlCaTools#28.
Migrate code under CondFormats/DTObjects and CondTools/DT.
Note that most of the changes are in test code.