### PR TITLE
Migrate module config in EgammaAnalysis to use default cfipython

### DIFF
--- a/EgammaAnalysis/ElectronTools/python/calibratedElectrons_cfi.py
+++ b/EgammaAnalysis/ElectronTools/python/calibratedElectrons_cfi.py
@@ -1,21 +1,18 @@
 
 import FWCore.ParameterSet.Config as cms
-
+import RecoEgamma.EgammaTools.calibratedElectronProducer_cfi  as _mod
 
 #==============================================================================
 # corrected pat electrons
 #==============================================================================
 
-calibratedElectrons = cms.EDProducer("CalibratedElectronProducer",
+calibratedElectrons = _mod.calibratedElectronProducer.clone(
 
     # input collections
     inputElectronsTag = cms.InputTag('gsfElectrons'),
     # name of the ValueMaps containing the regression outputs                               
     nameEnergyReg = cms.InputTag('eleRegressionEnergy:eneRegForGsfEle'),
     nameEnergyErrorReg = cms.InputTag('eleRegressionEnergy:eneErrorRegForGsfEle'),
-    # The rechits are needed to compute r9                                     
-    recHitCollectionEB = cms.InputTag('reducedEcalRecHitsEB'),
-    recHitCollectionEE = cms.InputTag('reducedEcalRecHitsEE'),
 
     outputGsfElectronCollectionLabel = cms.string('calibratedGsfElectrons'),
     # For conveniency  the ValueMaps are re-created with the new collection as key. The label of the ValueMap are defined below

--- a/EgammaAnalysis/ElectronTools/python/calibratedPatElectrons_cfi.py
+++ b/EgammaAnalysis/ElectronTools/python/calibratedPatElectrons_cfi.py
@@ -1,12 +1,12 @@
 
 import FWCore.ParameterSet.Config as cms
-
+import RecoEgamma.EgammaTools.calibratedPatElectronProducer_cfi as _mod
 
 #==============================================================================
 # corrected pat electrons
 #==============================================================================
 
-calibratedPatElectrons = cms.EDProducer("CalibratedPatElectronProducer",
+calibratedPatElectrons = _mod.calibratedPatElectronProducer.clone(
 
     # input collections
     inputPatElectronsTag = cms.InputTag("eleRegressionEnergy"),


### PR DESCRIPTION
#### PR description: 
Optimization of the python configurations: Improve maintainability by cleaning up the duplicated and cloning from the default/reference configurations. 

In this PR, 2 files were changed.  
        modified:   EgammaAnalysis/ElectronTools/python/calibratedElectrons_cfi.py
        modified:   EgammaAnalysis/ElectronTools/python/calibratedPatElectrons_cfi.py

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_12_2_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).