### PR TITLE
Migrate module config in Configuration, TauAnalysis to use default cfipython

### DIFF
--- a/Configuration/EcalTB/python/reco_application_2006_calibrate_cfg.py
+++ b/Configuration/EcalTB/python/reco_application_2006_calibrate_cfg.py
@@ -14,12 +14,12 @@ process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring('file:/u1/meridian/data/h4/2006/h4b.00013247.A.0.0.root')
 )
 
-process.ecal2006TBRecHit = cms.EDProducer("EcalRecHitProducer",
+process.load("RecoLocalCalo.EcalRecProducers.ecalRecHit_cfi")
+process.ecal2006TBRecHit = process.ecalRecHit.clone(
     EEuncalibRecHitCollection = cms.string(''),
     uncalibRecHitProducer = cms.string('ecal2006TBWeightUncalibRecHit'),
     EBuncalibRecHitCollection = cms.string('EcalUncalibRecHitsEB'),
-    EBrechitCollection = cms.string('EcalRecHitsEB'),
-    EErechitCollection = cms.string('')
+    EErechitCollection = ''
 )
 
 process.out = cms.OutputModule("PoolOutputModule",

--- a/TauAnalysis/MCEmbeddingTools/python/customisers.py
+++ b/TauAnalysis/MCEmbeddingTools/python/customisers.py
@@ -5,7 +5,6 @@
 from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
-
 ################################ Customizer for skimming ###########################
 ### There are four different parts.
 ##First step is the SELECT (former SKIM) part, where we identfy the events which are good for Embedding. Need to store RAWRECO [RAW is needed for the MERG and RECO for the CLEAN step]
@@ -443,9 +442,8 @@ def customisoptions(process):
         process.options = cms.untracked.PSet()
     process.options.emptyRunLumiMode = cms.untracked.string('doNotHandleEmptyRunsAndLumis')
     if not hasattr(process, "bunchSpacingProducer"):
-        process.bunchSpacingProducer = cms.EDProducer("BunchSpacingProducer")
-    process.bunchSpacingProducer.bunchSpacingOverride = cms.uint32(25)
-    process.bunchSpacingProducer.overrideBunchSpacing = cms.bool(True)
+        process.load('RecoLuminosity.LumiProducer.bunchSpacingProducer_cfi')
+        process.bunchSpacingProducer = process.bunchSpacingProducer.clone(overrideBunchSpacing = True)
     process.options.numberOfThreads = cms.untracked.uint32(1)
     process.options.numberOfStreams = cms.untracked.uint32(0)
     return process


### PR DESCRIPTION
#### PR description: 
Optimization of the python configurations: Improve maintainability by cleaning up the duplicated and cloning from the default/reference configurations. 

In this PR, 2 files were changed.  
        modified:   Configuration/EcalTB/python/reco_application_2006_calibrate_cfg.py
        modified:   TauAnalysis/MCEmbeddingTools/python/customisers.py

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_12_2_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).