### PR TITLE
ECAL PoolDBOutput code migration part 2

### DIFF
--- a/CalibCalorimetry/EcalTrivialCondModules/src/EcalLaserCondTools.cc
+++ b/CalibCalorimetry/EcalTrivialCondModules/src/EcalLaserCondTools.cc
@@ -164,7 +164,7 @@ void EcalLaserCondTools::from_hdf_to_db() {
     hsize_t iov_dim[1] = {nCrystals};
     memspace = H5Screate_simple(1, iov_dim, nullptr);
 
-    auto corrSet = std::make_unique<EcalLaserAPDPNRatios>();
+    EcalLaserAPDPNRatios corrSet;
     for (unsigned int iIov = skipIov_; iIov < nIovs && iIov < unsigned(nIovs_); ++iIov) {
       EcalLaserAPDPNRatios::EcalLaserTimeStamp t;
       iovStart = uint64_t(t1[iIov]) << 32;
@@ -172,7 +172,7 @@ void EcalLaserCondTools::from_hdf_to_db() {
         t.t1 = edm::Timestamp(uint64_t(t1[iIov]) << 32);
         t.t2 = edm::Timestamp(uint64_t(t2[iIov][iLme]) << 32);
         t.t3 = edm::Timestamp(uint64_t(t3[iIov]) << 32);
-        corrSet->setTime(iLme, t);
+        corrSet.setTime(iLme, t);
       }
 
       hsize_t offset[2] = {iIov, 0};      // shift rows: iIov, columns: 0
@@ -229,7 +229,7 @@ void EcalLaserCondTools::from_hdf_to_db() {
           fprintf(ferr_, "%d %d %f %f %f\n", t1[iIov], (int)detid, corr.p1, corr.p2, corr.p3);
           corr.p1 = corr.p2 = corr.p3 = 1;
         }
-        corrSet->setValue((int)detid, corr);
+        corrSet.setValue((int)detid, corr);
       }
 
       try {
@@ -244,7 +244,7 @@ void EcalLaserCondTools::from_hdf_to_db() {
         if (verb_ > 1)
           std::cout << "[" << timeToString(t.tv_sec) << "] "
                     << "Write IOV " << iIov << " starting from " << timeToString(iovStart >> 32) << "... ";
-        db_->writeOneIOV(*corrSet, iovStart, "EcalLaserAPDPNRatiosRcd");
+        db_->writeOneIOV(corrSet, iovStart, "EcalLaserAPDPNRatiosRcd");
       } catch (const cms::Exception& e) {
         if (verb_ > 1)
           std::cout << "Failed. ";
@@ -372,7 +372,7 @@ void EcalLaserCondTools::processIov(CorrReader& r, int t1, int t2[EcalLaserCondT
     return;
   }
 
-  auto corrSet = std::make_unique<EcalLaserAPDPNRatios>();
+  EcalLaserAPDPNRatios corrSet;
 
   EcalLaserAPDPNRatios::EcalLaserTimeStamp t;
   iovStart = uint64_t(t1) << 32;
@@ -380,7 +380,7 @@ void EcalLaserCondTools::processIov(CorrReader& r, int t1, int t2[EcalLaserCondT
     t.t1 = edm::Timestamp(uint64_t(t1) << 32);
     t.t2 = edm::Timestamp(uint64_t(t2[i]) << 32);
     t.t3 = edm::Timestamp(uint64_t(t3) << 32);
-    corrSet->setTime(i, t);
+    corrSet.setTime(i, t);
   }
 
   constexpr int ncrystals = 75848;
@@ -421,7 +421,7 @@ void EcalLaserCondTools::processIov(CorrReader& r, int t1, int t2[EcalLaserCondT
                 << "p3 = " << corr.p3 << "\n";
     }
 
-    corrSet->setValue((int)detid, corr);
+    corrSet.setValue((int)detid, corr);
   }
 
   try {
@@ -437,7 +437,7 @@ void EcalLaserCondTools::processIov(CorrReader& r, int t1, int t2[EcalLaserCondT
     if (verb_ > 1)
       std::cout << "[" << timeToString(t.tv_sec) << "] "
                 << "Write IOV " << iIov << " starting from " << timeToString(iovStart >> 32) << "... ";
-    db_->writeOneIOV(*corrSet, iovStart, "EcalLaserAPDPNRatiosRcd");
+    db_->writeOneIOV(corrSet, iovStart, "EcalLaserAPDPNRatiosRcd");
   } catch (const cms::Exception& e) {
     std::cout << "Failed.\nException cathed while writting to cond DB" << e.what() << "\n";
   }

--- a/CondTools/Ecal/plugins/EcalMustacheSCParametersMaker.cc
+++ b/CondTools/Ecal/plugins/EcalMustacheSCParametersMaker.cc
@@ -50,11 +50,11 @@ EcalMustacheSCParametersMaker::EcalMustacheSCParametersMaker(const edm::Paramete
     : parametersToken_(esConsumes<EcalMustacheSCParameters, EcalMustacheSCParametersRcd>()) {}
 
 void EcalMustacheSCParametersMaker::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  edm::ESHandle<EcalMustacheSCParameters> esParamsHandle_ = iSetup.getHandle(parametersToken_);
+  const auto& esParams = iSetup.getData(parametersToken_);
 
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
   if (poolDbService.isAvailable()) {
-    poolDbService->writeOneIOV(*esParamsHandle_.product(), poolDbService->currentTime(), "EcalMustacheSCParametersRcd");
+    poolDbService->writeOneIOV(esParams, poolDbService->currentTime(), "EcalMustacheSCParametersRcd");
   } else {
     throw cms::Exception("PoolDBService") << "No PoolDBService available.";
   }

--- a/CondTools/Ecal/plugins/EcalSCDynamicDPhiParametersMaker.cc
+++ b/CondTools/Ecal/plugins/EcalSCDynamicDPhiParametersMaker.cc
@@ -50,12 +50,11 @@ EcalSCDynamicDPhiParametersMaker::EcalSCDynamicDPhiParametersMaker(const edm::Pa
     : parametersToken_(esConsumes<EcalSCDynamicDPhiParameters, EcalSCDynamicDPhiParametersRcd>()) {}
 
 void EcalSCDynamicDPhiParametersMaker::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  edm::ESHandle<EcalSCDynamicDPhiParameters> esParamsHandle_ = iSetup.getHandle(parametersToken_);
+  const auto& esParams = iSetup.getData(parametersToken_);
 
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
   if (poolDbService.isAvailable()) {
-    poolDbService->writeOneIOV(
-        *esParamsHandle_.product(), poolDbService->currentTime(), "EcalSCDynamicDPhiParametersRcd");
+    poolDbService->writeOneIOV(esParams, poolDbService->currentTime(), "EcalSCDynamicDPhiParametersRcd");
   } else {
     throw cms::Exception("PoolDBService") << "No PoolDBService available.";
   }

--- a/SimCalorimetry/EcalSelectiveReadoutProducers/src/EcalSRCondTools.cc
+++ b/SimCalorimetry/EcalSelectiveReadoutProducers/src/EcalSRCondTools.cc
@@ -66,7 +66,7 @@ EcalSRCondTools::~EcalSRCondTools() {}
 void EcalSRCondTools::analyze(const edm::Event& event, const edm::EventSetup& es) {
   if (done_)
     return;
-  EcalSRSettings* sr = new EcalSRSettings;
+  EcalSRSettings sr;
 
   if (mode_ == "online_config" || mode_ == "combine_config") {
     string fname = ps_.getParameter<string>("onlineSrpConfigFile");
@@ -74,11 +74,11 @@ void EcalSRCondTools::analyze(const edm::Event& event, const edm::EventSetup& es
     if (!f.good()) {
       throw cms::Exception("EcalSRCondTools") << "Failed to open file " << fname;
     }
-    importSrpConfigFile(*sr, f, true);
+    importSrpConfigFile(sr, f, true);
   }
 
   if (mode_ == "python_config" || mode_ == "combine_config") {
-    importParameterSet(*sr, ps_);
+    importParameterSet(sr, ps_);
   }
 
   if (!(mode_ == "python_config" || mode_ == "online_config" || mode_ == "combine_config" || (mode_ == "read"))) {
@@ -87,9 +87,9 @@ void EcalSRCondTools::analyze(const edm::Event& event, const edm::EventSetup& es
   }
 
   if (iomode_write_) {
-    sr->bxGlobalOffset_ = ps_.getParameter<int>("bxGlobalOffset");
-    sr->automaticSrpSelect_ = ps_.getParameter<int>("automaticSrpSelect");
-    sr->automaticMasks_ = ps_.getParameter<int>("automaticMasks");
+    sr.bxGlobalOffset_ = ps_.getParameter<int>("bxGlobalOffset");
+    sr.automaticSrpSelect_ = ps_.getParameter<int>("automaticSrpSelect");
+    sr.automaticMasks_ = ps_.getParameter<int>("automaticMasks");
 
     edm::Service<cond::service::PoolDBOutputService> db;
     if (!db.isAvailable()) {
@@ -98,7 +98,7 @@ void EcalSRCondTools::analyze(const edm::Event& event, const edm::EventSetup& es
     //fillup DB
     //create new infinite IOV
     cond::Time_t firstSinceTime = db->beginOfTime();
-    db->writeOneIOV(*sr, firstSinceTime, "EcalSRSettingsRcd");
+    db->writeOneIOV(sr, firstSinceTime, "EcalSRSettingsRcd");
     done_ = true;
   } else {  //read mode
     const edm::ESHandle<EcalSRSettings> hSr = es.getHandle(hSrToken_);
@@ -135,7 +135,6 @@ void EcalSRCondTools::analyze(const edm::Event& event, const edm::EventSetup& es
       }
     }
   }
-  delete sr;
 }
 
 void EcalSRCondTools::importParameterSet(EcalSRSettings& sr, const edm::ParameterSet& ps) {


### PR DESCRIPTION
#### PR description:

This is a follow-up PR for #35781 to use instances instead of pointers for some ECAL related functions that use `writeOneIOV`.

#### PR validation:

Code compiles and test configurations (as far as available) run.