### PR TITLE
Clean unused dependencies from BuildFiles

### DIFF
--- a/Alignment/CocoaApplication/BuildFile.xml
+++ b/Alignment/CocoaApplication/BuildFile.xml
@@ -2,6 +2,5 @@
 <use   name="root"/>
 <use   name="dd4hep"/>
 <use   name="Alignment/CocoaFit"/>
-<use   name="CondCore/DBOutputService"/>
 <use   name="DetectorDescription/DDCMS"/>
 <flags   EDM_PLUGIN="1"/>

--- a/CalibTracker/SiPixelGainCalibration/plugins/BuildFile.xml
+++ b/CalibTracker/SiPixelGainCalibration/plugins/BuildFile.xml
@@ -6,7 +6,6 @@
   <use name="CalibTracker/SiPixelESProducers"/>
   <use name="CondFormats/DataRecord"/>
   <use name="CondFormats/SiPixelObjects"/>
-  <use name="CondCore/DBOutputService"/>
   <use name="root"/>
   <use name="rootminuit"/>
   <use name="Geometry/Records"/>

--- a/CalibTracker/SiStripLorentzAngle/plugins/BuildFile.xml
+++ b/CalibTracker/SiStripLorentzAngle/plugins/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="CondCore/DBOutputService"/>
 <use name="DQM/SiStripCommon"/>
 <use name="DQMServices/Core"/>
 <use name="DataFormats/Common"/>

--- a/Calibration/HcalCalibAlgos/BuildFile.xml
+++ b/Calibration/HcalCalibAlgos/BuildFile.xml
@@ -1,9 +1,6 @@
 <use name="root"/>
 <use name="rootgraphics"/>
 <use name="rootminuit"/>
-<use name="FWCore/Framework"/>
-<use name="FWCore/ParameterSet"/>
-<use name="FWCore/ServiceRegistry"/>
 <use name="FWCore/Utilities"/>
 <use name="CommonTools/UtilAlgos"/>
 <use name="DataFormats/EcalDetId"/>
@@ -11,7 +8,6 @@
 <use name="DataFormats/DetId"/>
 <use name="DataFormats/HcalRecHit"/>
 <use name="Geometry/HcalTowerAlgo"/>
-<use name="Geometry/Records"/>
 <use name="CondTools/Hcal"/>
 <use name="Calibration/Tools"/>
 <use name="DataFormats/EcalRecHit"/>

--- a/Calibration/HcalCalibAlgos/plugins/BuildFile.xml
+++ b/Calibration/HcalCalibAlgos/plugins/BuildFile.xml
@@ -14,6 +14,7 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
+<use name="FWCore/ServiceRegistry"/>
 <use name="FWCore/Utilities"/>
 <use name="Geometry/Records"/>
 <use name="HLTrigger/HLTcore"/>

--- a/CondCore/PhysicsToolsPlugins/test/BuildFile.xml
+++ b/CondCore/PhysicsToolsPlugins/test/BuildFile.xml
@@ -1,5 +1,4 @@
 <use name="CondCore/Utilities"/>
 <use name="FWCore/PluginManager"/>
-<use name="CondFormats/Common"/>
 <bin file="test_DropBoxMetadata_PayloadInspector.cpp" name="test_DropBoxMetadata_PayloadInspector">
 </bin>

--- a/CondFormats/Common/test/BuildFile.xml
+++ b/CondFormats/Common/test/BuildFile.xml
@@ -10,10 +10,6 @@
 <bin file="SmallWORMDict_t.cpp">
 </bin>
 
-<use name="FWCore/Framework"/>
-<use name="FWCore/ParameterSet"/>
-<use name="CondCore/DBOutputService"/>
-<use name="CondFormats/DataRecord"/>
 <use name="root"/>
 
 <bin file="testSerializationCommon.cpp">

--- a/DataFormats/HGCDigi/BuildFile.xml
+++ b/DataFormats/HGCDigi/BuildFile.xml
@@ -1,6 +1,5 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/ForwardDetId"/>
-<use name="DataFormats/HcalDetId"/>
 <use name="DataFormats/DetId"/>
 <export>
   <lib name="1"/>

--- a/PhysicsTools/PatAlgos/BuildFile.xml
+++ b/PhysicsTools/PatAlgos/BuildFile.xml
@@ -16,6 +16,7 @@
 <use name="PhysicsTools/PatUtils"/>
 <use name="PhysicsTools/TensorFlow"/>
 <use name="PhysicsTools/ONNXRuntime"/>
+<use name="TrackingTools/Records"/>
 <use name="clhep"/>
 <export>
   <lib name="1"/>

--- a/PhysicsTools/PatAlgos/plugins/BuildFile.xml
+++ b/PhysicsTools/PatAlgos/plugins/BuildFile.xml
@@ -33,6 +33,7 @@
   <use name="RecoMET/METAlgorithms"/>
   <use name="RecoTracker/DeDx"/>
   <use name="TrackingTools/IPTools"/>
+  <use name="TrackingTools/Records"/>
   <use name="RecoTauTag/RecoTau"/>
   <use name="root"/>
 </library>

--- a/PhysicsTools/PatUtils/BuildFile.xml
+++ b/PhysicsTools/PatUtils/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="TrackingTools/Records"/>
 <use name="CommonTools/Utils"/>
 <use name="DataFormats/Math"/>
 <use name="DataFormats/Candidate"/>

--- a/RecoEgamma/EgammaElectronProducers/plugins/BuildFile.xml
+++ b/RecoEgamma/EgammaElectronProducers/plugins/BuildFile.xml
@@ -30,7 +30,6 @@
 <use name="TrackingTools/Records"/>
 <use name="TrackingTools/TrajectoryParametrization"/>
 <use name="TrackingTools/TrajectoryState"/>
-<use name="PhysicsTools/TensorFlow" />
 <library file="*.cc" name="RecoEgammaEgammaElectronProducersPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/RecoHI/HiTracking/BuildFile.xml
+++ b/RecoHI/HiTracking/BuildFile.xml
@@ -1,7 +1,6 @@
 <use name="DataFormats/BeamSpot"/>
 <use name="DataFormats/CaloTowers"/>
 <use name="DataFormats/Math"/>
-<use name="DataFormats/TrackerCommon"/>
 <use name="DataFormats/ParticleFlowReco"/>
 <use name="DataFormats/ParticleFlowCandidate"/>
 <use name="DataFormats/TrackReco"/>

--- a/RecoLocalCalo/HGCalRecAlgos/test/BuildFile.xml
+++ b/RecoLocalCalo/HGCalRecAlgos/test/BuildFile.xml
@@ -1,7 +1,6 @@
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Framework"/>
-<use name="Geometry/HGCalGeometry"/>
 <use name="Geometry/Records"/>
 <use name="RecoLocalCalo/HGCalRecAlgos"/>
 <flags EDM_PLUGIN="1"/>

--- a/Validation/HcalHits/BuildFile.xml
+++ b/Validation/HcalHits/BuildFile.xml
@@ -1,5 +1,4 @@
 <use name="DataFormats/HcalDetId"/>
-<use name="DataFormats/HepMCCandidate"/>
 <use name="DataFormats/Math"/>
 <use name="DQMServices/Core"/>
 <use name="FWCore/Framework"/>

--- a/Validation/MtdValidation/plugins/BuildFile.xml
+++ b/Validation/MtdValidation/plugins/BuildFile.xml
@@ -8,7 +8,6 @@
 <use name="DQMServices/Core"/>
 <use name="SimDataFormats/Track"/>
 <use name="SimDataFormats/PileupSummaryInfo"/>
-<use name="SimGeneral/HepPDTESSource"/>
 <use name="SimGeneral/HepPDTRecord"/>
 <use name="Geometry/Records"/>
 <use name="SimDataFormats/TrackingAnalysis"/>


### PR DESCRIPTION
#### PR description:

Another quick BuildFile cleaning PR in the style of many before (for example https://github.com/cms-sw/cmssw/pull/35701).

In many cases, the dependencies had to be moved to the appropriate BuildFile, for example from a plugins directory to the library directory or vice versa.

In one place, a missing include has been added to not cause a false positive in my BuildFile checker.

This PR cleans unnecessary includes from CMSSW BuildFiles that were recently added for 12_2_0_pre2.

#### PR validation:

CMSSW compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport intended.