### PR TITLE
Fireworks - GEM only mode for testbeam and qc8

### DIFF
--- a/Fireworks/Geometry/interface/FWRecoGeometryESProducer.h
+++ b/Fireworks/Geometry/interface/FWRecoGeometryESProducer.h
@@ -71,6 +71,7 @@ private:
   unsigned int m_current;
   bool m_tracker;
   bool m_muon;
+  bool m_gem;
   bool m_calo;
   bool m_timing;
 };

--- a/Fireworks/Geometry/interface/FWTGeoRecoGeometryESProducer.h
+++ b/Fireworks/Geometry/interface/FWTGeoRecoGeometryESProducer.h
@@ -101,6 +101,7 @@ private:
 
   bool m_tracker;
   bool m_muon;
+  bool m_gem;
   bool m_calo;
 };
 

--- a/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
+++ b/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
@@ -104,10 +104,11 @@ namespace {
 FWRecoGeometryESProducer::FWRecoGeometryESProducer(const edm::ParameterSet& pset) : m_current(-1) {
   m_tracker = pset.getUntrackedParameter<bool>("Tracker", true);
   m_muon = pset.getUntrackedParameter<bool>("Muon", true);
+  m_gem = pset.getUntrackedParameter<bool>("GEM", true);
   m_calo = pset.getUntrackedParameter<bool>("Calo", true);
   m_timing = pset.getUntrackedParameter<bool>("Timing", false);
   auto cc = setWhatProduced(this);
-  if (m_tracker or m_muon) {
+  if (m_tracker or m_muon or m_gem) {
     m_trackingGeomToken = cc.consumes();
   }
   if (m_timing) {
@@ -126,13 +127,13 @@ std::unique_ptr<FWRecoGeometry> FWRecoGeometryESProducer::produce(const FWRecoGe
 
   auto fwRecoGeometry = std::make_unique<FWRecoGeometry>();
 
-  if (m_tracker || m_muon) {
+  if (m_tracker || m_muon || m_gem) {
     m_trackingGeom = &record.get(m_trackingGeomToken);
-    DetId detId(DetId::Tracker, 0);
-    m_trackerGeom = static_cast<const TrackerGeometry*>(m_trackingGeom->slaveGeometry(detId));
   }
 
   if (m_tracker) {
+    DetId detId(DetId::Tracker, 0);
+    m_trackerGeom = static_cast<const TrackerGeometry*>(m_trackingGeom->slaveGeometry(detId));
     addPixelBarrelGeometry(*fwRecoGeometry);
     addPixelForwardGeometry(*fwRecoGeometry);
     addTIBGeometry(*fwRecoGeometry);
@@ -145,8 +146,10 @@ std::unique_ptr<FWRecoGeometry> FWRecoGeometryESProducer::produce(const FWRecoGe
     addDTGeometry(*fwRecoGeometry);
     addCSCGeometry(*fwRecoGeometry);
     addRPCGeometry(*fwRecoGeometry);
-    addGEMGeometry(*fwRecoGeometry);
     addME0Geometry(*fwRecoGeometry);
+  }
+  if (m_gem) {
+    addGEMGeometry(*fwRecoGeometry);
   }
   if (m_calo) {
     m_caloGeom = &record.get(m_caloGeomToken);

--- a/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
+++ b/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
@@ -104,10 +104,13 @@ namespace {
 FWRecoGeometryESProducer::FWRecoGeometryESProducer(const edm::ParameterSet& pset) : m_current(-1) {
   m_tracker = pset.getUntrackedParameter<bool>("Tracker", true);
   m_muon = pset.getUntrackedParameter<bool>("Muon", true);
-  m_gem = pset.getUntrackedParameter<bool>("GEM", true);
+  m_gem = pset.getUntrackedParameter<bool>("GEM", false);
   m_calo = pset.getUntrackedParameter<bool>("Calo", true);
   m_timing = pset.getUntrackedParameter<bool>("Timing", false);
   auto cc = setWhatProduced(this);
+
+  if (m_muon)
+    m_gem = true;
   if (m_tracker or m_muon or m_gem) {
     m_trackingGeomToken = cc.consumes();
   }

--- a/Fireworks/Geometry/src/FWTGeoRecoGeometryESProducer.cc
+++ b/Fireworks/Geometry/src/FWTGeoRecoGeometryESProducer.cc
@@ -63,10 +63,11 @@ namespace {
 FWTGeoRecoGeometryESProducer::FWTGeoRecoGeometryESProducer(const edm::ParameterSet& pset) : m_dummyMedium(nullptr) {
   m_tracker = pset.getUntrackedParameter<bool>("Tracker", true);
   m_muon = pset.getUntrackedParameter<bool>("Muon", true);
+  m_gem = pset.getUntrackedParameter<bool>("GEM", true);
   m_calo = pset.getUntrackedParameter<bool>("Calo", true);
 
   auto cc = setWhatProduced(this);
-  if (m_tracker || m_muon) {
+  if (m_tracker || m_muon || m_gem) {
     m_trackingGeomToken = cc.consumes();
   }
   if (m_tracker) {
@@ -290,7 +291,7 @@ std::unique_ptr<FWTGeoRecoGeometry> FWTGeoRecoGeometryESProducer::produce(const 
   top->SetVisibility(kFALSE);
   top->SetLineColor(kBlue);
 
-  if (m_tracker || m_muon) {
+  if (m_tracker || m_muon || m_gem) {
     m_trackingGeom = &record.get(m_trackingGeomToken);
   }
 
@@ -314,6 +315,9 @@ std::unique_ptr<FWTGeoRecoGeometry> FWTGeoRecoGeometryESProducer::produce(const 
     addCSCGeometry();
     addRPCGeometry();
     addME0Geometry();
+  }
+
+  if (m_gem) {
     addGEMGeometry();
   }
 

--- a/Fireworks/Geometry/src/FWTGeoRecoGeometryESProducer.cc
+++ b/Fireworks/Geometry/src/FWTGeoRecoGeometryESProducer.cc
@@ -63,8 +63,11 @@ namespace {
 FWTGeoRecoGeometryESProducer::FWTGeoRecoGeometryESProducer(const edm::ParameterSet& pset) : m_dummyMedium(nullptr) {
   m_tracker = pset.getUntrackedParameter<bool>("Tracker", true);
   m_muon = pset.getUntrackedParameter<bool>("Muon", true);
-  m_gem = pset.getUntrackedParameter<bool>("GEM", true);
+  m_gem = pset.getUntrackedParameter<bool>("GEM", false);
   m_calo = pset.getUntrackedParameter<bool>("Calo", true);
+
+  if (m_muon)
+    m_gem = true;
 
   auto cc = setWhatProduced(this);
   if (m_tracker || m_muon || m_gem) {


### PR DESCRIPTION
#### PR description:
- This PR allows fireworks to disable all detectors and enable GEM only.
- GEM is separated from the muon sub-detectors to enable this feature.
- GEM is off by default and turn on when muons is turned on or pset is used.
- Fireworks would be very helpful for both testbeam and QC8.
#### PR validation:
This does not run in runTheMatrix test workflows