### PR TITLE
MuonAlignment ASAN bug fix

### DIFF
--- a/Alignment/MuonAlignment/interface/MuonAlignmentInputDB.h
+++ b/Alignment/MuonAlignment/interface/MuonAlignmentInputDB.h
@@ -41,10 +41,10 @@ public:
                        const Alignments* dtAlignments,
                        const Alignments* cscAlignments,
                        const Alignments* gemAlignments,
-                       const Alignments* globalPositionRcd,
                        const AlignmentErrorsExtended* dtAlignmentErrorsExtended,
                        const AlignmentErrorsExtended* cscAlignmentErrorsExtended,
-                       const AlignmentErrorsExtended* gemAlignmentErrorsExtended);
+                       const AlignmentErrorsExtended* gemAlignmentErrorsExtended,
+                       const Alignments* globalPositionRcd);
   ~MuonAlignmentInputDB() override;
 
   // ---------- const member functions ---------------------
@@ -67,10 +67,10 @@ private:
   const Alignments* dtAlignments_;
   const Alignments* cscAlignments_;
   const Alignments* gemAlignments_;
-  const Alignments* globalPositionRcd_;
   const AlignmentErrorsExtended* dtAlignmentErrorsExtended_;
   const AlignmentErrorsExtended* cscAlignmentErrorsExtended_;
   const AlignmentErrorsExtended* gemAlignmentErrorsExtended_;
+  const Alignments* globalPositionRcd_;
 
   const bool m_getAPEs;
 };

--- a/Alignment/MuonAlignment/plugins/MuonGeometryDBConverter.cc
+++ b/Alignment/MuonAlignment/plugins/MuonGeometryDBConverter.cc
@@ -56,7 +56,7 @@ private:
   bool m_done;
   std::string m_input, m_output;
 
-  std::string m_dtLabel, m_cscLabel, m_gemLabel;
+  std::string m_dtLabel, m_cscLabel, m_gemLabel, m_dtAPELabel, m_cscAPELabel, m_gemAPELabel;
   double m_shiftErr, m_angleErr;
   std::string m_fileName;
   bool m_getAPEs;
@@ -76,6 +76,11 @@ private:
   edm::ESGetToken<Alignments, DTAlignmentRcd> dtAliToken_;
   edm::ESGetToken<Alignments, CSCAlignmentRcd> cscAliToken_;
   edm::ESGetToken<Alignments, GEMAlignmentRcd> gemAliToken_;
+
+  edm::ESGetToken<AlignmentErrorsExtended, DTAlignmentErrorExtendedRcd> dtAPEToken_;
+  edm::ESGetToken<AlignmentErrorsExtended, CSCAlignmentErrorExtendedRcd> cscAPEToken_;
+  edm::ESGetToken<AlignmentErrorsExtended, GEMAlignmentErrorExtendedRcd> gemAPEToken_;
+
   const edm::ESGetToken<Alignments, GlobalPositionRcd> gprToken_;
 };
 
@@ -116,6 +121,9 @@ MuonGeometryDBConverter::MuonGeometryDBConverter(const edm::ParameterSet &iConfi
     m_dtLabel = iConfig.getParameter<std::string>("dtLabel");
     m_cscLabel = iConfig.getParameter<std::string>("cscLabel");
     m_gemLabel = iConfig.getParameter<std::string>("gemLabel");
+    m_dtAPELabel = iConfig.getParameter<std::string>("dtAPELabel");
+    m_cscAPELabel = iConfig.getParameter<std::string>("cscAPELabel");
+    m_gemAPELabel = iConfig.getParameter<std::string>("gemAPELabel");
     m_shiftErr = iConfig.getParameter<double>("shiftErr");
     m_angleErr = iConfig.getParameter<double>("angleErr");
     m_getAPEs = iConfig.getParameter<bool>("getAPEs");
@@ -124,6 +132,10 @@ MuonGeometryDBConverter::MuonGeometryDBConverter(const edm::ParameterSet &iConfi
     dtAliToken_ = esConsumes(edm::ESInputTag("", m_dtLabel));
     cscAliToken_ = esConsumes(edm::ESInputTag("", m_cscLabel));
     gemAliToken_ = esConsumes(edm::ESInputTag("", m_gemLabel));
+
+    dtAPEToken_ = esConsumes(edm::ESInputTag("", m_dtAPELabel));
+    cscAPEToken_ = esConsumes(edm::ESInputTag("", m_cscAPELabel));
+    gemAPEToken_ = esConsumes(edm::ESInputTag("", m_gemAPELabel));
 
     dtGeomToken_ = esConsumes(edm::ESInputTag("", idealGeometryLabelForInputXML));
     cscGeomToken_ = esConsumes(edm::ESInputTag("", idealGeometryLabelForInputXML));
@@ -173,6 +185,9 @@ void MuonGeometryDBConverter::analyze(const edm::Event &iEvent, const edm::Event
                                        &iSetup.getData(dtAliToken_),
                                        &iSetup.getData(cscAliToken_),
                                        &iSetup.getData(gemAliToken_),
+                                       &iSetup.getData(dtAPEToken_),
+                                       &iSetup.getData(cscAPEToken_),
+                                       &iSetup.getData(gemAPEToken_),
                                        &iSetup.getData(gprToken_));
       MuonAlignment *muonAlignment = new MuonAlignment(iSetup, inputMethod);
       if (m_getAPEs) {
@@ -216,6 +231,9 @@ void MuonGeometryDBConverter::fillDescriptions(edm::ConfigurationDescriptions &d
   desc.add<std::string>("dtLabel", "");
   desc.add<std::string>("cscLabel", "");
   desc.add<std::string>("gemLabel", "");
+  desc.add<std::string>("dtAPELabel", "");
+  desc.add<std::string>("cscAPELabel", "");
+  desc.add<std::string>("gemAPELabel", "");
   desc.add<double>("shiftErr", 1000.0);
   desc.add<double>("angleErr", 6.28);
   desc.add<bool>("getAPEs", true);

--- a/Alignment/MuonAlignment/src/MuonAlignmentInputDB.cc
+++ b/Alignment/MuonAlignment/src/MuonAlignmentInputDB.cc
@@ -58,20 +58,20 @@ MuonAlignmentInputDB::MuonAlignmentInputDB(const DTGeometry* dtGeometry,
                                            const Alignments* dtAlignments,
                                            const Alignments* cscAlignments,
                                            const Alignments* gemAlignments,
-                                           const Alignments* globalPositionRcd,
                                            const AlignmentErrorsExtended* dtAlignmentErrorsExtended,
                                            const AlignmentErrorsExtended* cscAlignmentErrorsExtended,
-                                           const AlignmentErrorsExtended* gemAlignmentErrorsExtended)
+                                           const AlignmentErrorsExtended* gemAlignmentErrorsExtended,
+                                           const Alignments* globalPositionRcd)
     : dtGeometry_(dtGeometry),
       cscGeometry_(cscGeometry),
       gemGeometry_(gemGeometry),
       dtAlignments_(dtAlignments),
       cscAlignments_(cscAlignments),
       gemAlignments_(gemAlignments),
-      globalPositionRcd_(globalPositionRcd),
       dtAlignmentErrorsExtended_(dtAlignmentErrorsExtended),
       cscAlignmentErrorsExtended_(cscAlignmentErrorsExtended),
       gemAlignmentErrorsExtended_(gemAlignmentErrorsExtended),
+      globalPositionRcd_(globalPositionRcd),
       m_getAPEs(true) {}
 
 // MuonAlignmentInputDB::MuonAlignmentInputDB(const MuonAlignmentInputDB& rhs)


### PR DESCRIPTION
#### PR description:

Resolve https://github.com/cms-sw/cmssw/issues/36053

- The issue was the DB converter created new APEs
- This PR fixed the issue; MuonAlignmentInputDB reads APEs from DB now

#### PR validation:

Test with Alignment/MuonAlignment/test/test_MuonGeometryDBConverter.sh
