### PR TITLE
Modernize analyzers in CondFormats/RPCObjects/test

### DIFF
--- a/CondFormats/RPCObjects/test/RPCReadOutMapAnalyzer.cc
+++ b/CondFormats/RPCObjects/test/RPCReadOutMapAnalyzer.cc
@@ -3,7 +3,6 @@
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -42,9 +41,9 @@ void RPCReadOutMapAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSe
 
   const RPCReadOutMapping* map;
   if (m_flag) {
-    map = iSetup.getHandle(readoutMappingToken_).product()->convert();
+    map = iSetup.getData(readoutMappingToken_).convert();
   } else {
-    map = iSetup.getHandle(mapZeroToken_).product();
+    map = &iSetup.getData(mapZeroToken_);
   }
   cout << "version: " << map->version() << endl;
 

--- a/CondFormats/RPCObjects/test/RPCReadOutMapBuilder.cc
+++ b/CondFormats/RPCObjects/test/RPCReadOutMapBuilder.cc
@@ -4,7 +4,7 @@
 #include <sstream>
 
 // user include files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CondFormats/RPCObjects/interface/RPCReadOutMapping.h"
@@ -23,13 +23,13 @@
 using namespace std;
 using namespace edm;
 
-class RPCReadOutMapBuilder : public edm::EDAnalyzer {
+class RPCReadOutMapBuilder : public edm::one::EDAnalyzer<> {
 public:
   explicit RPCReadOutMapBuilder(const edm::ParameterSet&);
-  ~RPCReadOutMapBuilder();
+  ~RPCReadOutMapBuilder() override = default;
+  void analyze(const edm::Event&, const edm::EventSetup&) override{};
   virtual void beginJob();
   virtual void endJob();
-  virtual void analyze(const edm::Event&, const edm::EventSetup&) {}
 
 private:
   RPCReadOutMapping* cabling;
@@ -42,8 +42,6 @@ RPCReadOutMapBuilder::RPCReadOutMapBuilder(const edm::ParameterSet& iConfig)
   ::putenv(const_cast<char*>(std::string("CORAL_AUTH_USER=me").c_str()));
   ::putenv(const_cast<char*>(std::string("CORAL_AUTH_PASSWORD=test").c_str()));
 }
-
-RPCReadOutMapBuilder::~RPCReadOutMapBuilder() { cout << "DTOR called" << endl; }
 
 // ------------ method called to store map -------------------
 void RPCReadOutMapBuilder::endJob() {

--- a/CondFormats/RPCObjects/test/RPCReadOutMapBuilder.cc
+++ b/CondFormats/RPCObjects/test/RPCReadOutMapBuilder.cc
@@ -28,8 +28,8 @@ public:
   explicit RPCReadOutMapBuilder(const edm::ParameterSet&);
   ~RPCReadOutMapBuilder() override = default;
   void analyze(const edm::Event&, const edm::EventSetup&) override{};
-  virtual void beginJob();
-  virtual void endJob();
+  void beginJob() override;
+  void endJob() override;
 
 private:
   RPCReadOutMapping* cabling;


### PR DESCRIPTION
#### PR description:

This moves analyzers in tests to esConsumes and uses one/EDAnalyzer as suggested in the 
CMSSW_12_2_CMSDEPRECATED_X_2021 IB
Removes a dummy destructor

#### PR validation:

Tests ran, compiles without warnings

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
