### PR TITLE
[DD4hep] Add second name to elementary materials for Geant4 GDML

### DIFF
--- a/Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Modules/v2/ppstrackerMaterials.xml
+++ b/Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Modules/v2/ppstrackerMaterials.xml
@@ -31,15 +31,6 @@
    </MaterialFraction>
   </CompositeMaterial>
 
-  <CompositeMaterial name="PPS_FPix_TinLeadSolder" density="8.8*g/cm3" symbol=" " method="mixture by weight">
-    <MaterialFraction fraction="0.49377422">
-      <rMaterial name="materials:Tin"/>
-    </MaterialFraction>
-    <MaterialFraction fraction="0.50622577">
-      <rMaterial name="materials:Lead"/>
-    </MaterialFraction>
-  </CompositeMaterial>
-
   <CompositeMaterial name="PPS_Pix_Fwd_Bump" density="0.41391*g/cm3" symbol=" " method="mixture by weight">
     <MaterialFraction fraction="1.00">
       <rMaterial name="ppstrackerMaterials:PPS_FPix_TinLeadSolder"/>
@@ -51,31 +42,6 @@
       <rMaterial name="materials:Silicon"/>
     </MaterialFraction>
   </CompositeMaterial>
-
- <CompositeMaterial name="PPS_FPix_Kapton" density="1.4*g/cm3" symbol=" " method="mixture by weight">
-    <MaterialFraction fraction="0.6911352">
-      <rMaterial name="materials:Carbon"/>
-    </MaterialFraction>
-    <MaterialFraction fraction="0.026363">
-      <rMaterial name="materials:Hydrogen"/>
-    </MaterialFraction>
-    <MaterialFraction fraction="0.20923002">
-      <rMaterial name="materials:Oxygen"/>
-    </MaterialFraction>
-    <MaterialFraction fraction="0.0732717">
-      <rMaterial name="materials:Nitrogen"/>
-    </MaterialFraction>
-  </CompositeMaterial>
-
-  <CompositeMaterial name="PPS_FPix_Alumina" density="3.96*g/cm3" symbol=" " method="mixture by weight">
-    <MaterialFraction fraction="0.52924272">
-      <rMaterial name="materials:Aluminium"/>
-    </MaterialFraction>
-    <MaterialFraction fraction="0.47075728">
-      <rMaterial name="materials:Oxygen"/>
-    </MaterialFraction>
-  </CompositeMaterial>
-
 
   <CompositeMaterial name="PPS_Pix_Fwd_HDI" density="1.90587*g/cm3" symbol=" " method="mixture by weight">
     <MaterialFraction fraction="0.3718">
@@ -101,6 +67,24 @@
     </MaterialFraction>
   </CompositeMaterial>
  
+  <CompositeMaterial name="PPS_FPix_TinLeadSolder" density="8.8*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.49377422">
+      <rMaterial name="materials:Tin"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.50622577">
+      <rMaterial name="materials:Lead"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="PPS_FPix_Alumina" density="3.96*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.52924272">
+      <rMaterial name="materials:Aluminium"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.47075728">
+      <rMaterial name="materials:Oxygen"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
   <CompositeMaterial name="PPS_FPix_Epoxy" density="1.1*g/cm3" symbol=" " method="mixture by weight">
     <MaterialFraction fraction="0.7367217">
       <rMaterial name="materials:Carbon"/>
@@ -112,6 +96,22 @@
       <rMaterial name="materials:Oxygen"/>
     </MaterialFraction>
   </CompositeMaterial>
+
+ <CompositeMaterial name="PPS_FPix_Kapton" density="1.4*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.6911352">
+      <rMaterial name="materials:Carbon"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.026363">
+      <rMaterial name="materials:Hydrogen"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.20923002">
+      <rMaterial name="materials:Oxygen"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.0732717">
+      <rMaterial name="materials:Nitrogen"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
 </MaterialSection>
 
 </DDDefinition>

--- a/Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Modules/v2/ppstrackerMaterials.xml
+++ b/Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Modules/v2/ppstrackerMaterials.xml
@@ -31,6 +31,15 @@
    </MaterialFraction>
   </CompositeMaterial>
 
+  <CompositeMaterial name="PPS_FPix_TinLeadSolder" density="8.8*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.49377422">
+      <rMaterial name="materials:Tin"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.50622577">
+      <rMaterial name="materials:Lead"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
   <CompositeMaterial name="PPS_Pix_Fwd_Bump" density="0.41391*g/cm3" symbol=" " method="mixture by weight">
     <MaterialFraction fraction="1.00">
       <rMaterial name="ppstrackerMaterials:PPS_FPix_TinLeadSolder"/>
@@ -42,6 +51,31 @@
       <rMaterial name="materials:Silicon"/>
     </MaterialFraction>
   </CompositeMaterial>
+
+ <CompositeMaterial name="PPS_FPix_Kapton" density="1.4*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.6911352">
+      <rMaterial name="materials:Carbon"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.026363">
+      <rMaterial name="materials:Hydrogen"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.20923002">
+      <rMaterial name="materials:Oxygen"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.0732717">
+      <rMaterial name="materials:Nitrogen"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="PPS_FPix_Alumina" density="3.96*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.52924272">
+      <rMaterial name="materials:Aluminium"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.47075728">
+      <rMaterial name="materials:Oxygen"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
 
   <CompositeMaterial name="PPS_Pix_Fwd_HDI" density="1.90587*g/cm3" symbol=" " method="mixture by weight">
     <MaterialFraction fraction="0.3718">
@@ -67,24 +101,6 @@
     </MaterialFraction>
   </CompositeMaterial>
  
-  <CompositeMaterial name="PPS_FPix_TinLeadSolder" density="8.8*g/cm3" symbol=" " method="mixture by weight">
-    <MaterialFraction fraction="0.49377422">
-      <rMaterial name="materials:Tin"/>
-    </MaterialFraction>
-    <MaterialFraction fraction="0.50622577">
-      <rMaterial name="materials:Lead"/>
-    </MaterialFraction>
-  </CompositeMaterial>
-
-  <CompositeMaterial name="PPS_FPix_Alumina" density="3.96*g/cm3" symbol=" " method="mixture by weight">
-    <MaterialFraction fraction="0.52924272">
-      <rMaterial name="materials:Aluminium"/>
-    </MaterialFraction>
-    <MaterialFraction fraction="0.47075728">
-      <rMaterial name="materials:Oxygen"/>
-    </MaterialFraction>
-  </CompositeMaterial>
-
   <CompositeMaterial name="PPS_FPix_Epoxy" density="1.1*g/cm3" symbol=" " method="mixture by weight">
     <MaterialFraction fraction="0.7367217">
       <rMaterial name="materials:Carbon"/>
@@ -96,22 +112,6 @@
       <rMaterial name="materials:Oxygen"/>
     </MaterialFraction>
   </CompositeMaterial>
-
- <CompositeMaterial name="PPS_FPix_Kapton" density="1.4*g/cm3" symbol=" " method="mixture by weight">
-    <MaterialFraction fraction="0.6911352">
-      <rMaterial name="materials:Carbon"/>
-    </MaterialFraction>
-    <MaterialFraction fraction="0.026363">
-      <rMaterial name="materials:Hydrogen"/>
-    </MaterialFraction>
-    <MaterialFraction fraction="0.20923002">
-      <rMaterial name="materials:Oxygen"/>
-    </MaterialFraction>
-    <MaterialFraction fraction="0.0732717">
-      <rMaterial name="materials:Nitrogen"/>
-    </MaterialFraction>
-  </CompositeMaterial>
-
 </MaterialSection>
 
 </DDDefinition>

--- a/SimG4Core/PrintGeomInfo/test/python/g4OverlapCheckDD4hep_cfg.py
+++ b/SimG4Core/PrintGeomInfo/test/python/g4OverlapCheckDD4hep_cfg.py
@@ -21,7 +21,8 @@ process.g4SimHits.G4CheckOverlap.Depth      = cms.int32(-1)
 # tells if NodeName is G4Region or G4PhysicalVolume
 process.g4SimHits.G4CheckOverlap.RegionFlag = cms.bool(False)
 # list of names
-process.g4SimHits.G4CheckOverlap.NodeNames  = cms.vstring('OCMS_1')
+process.g4SimHits.G4CheckOverlap.NodeNames  = cms.vstring('cms:OCMS_1')
+# process.g4SimHits.G4CheckOverlap.NodeNames  = cms.vstring('DefaultRegionForTheWorld')
 # enable dump gdml file 
 process.g4SimHits.G4CheckOverlap.gdmlFlag   = cms.bool(False)
 # if defined a G4PhysicsVolume info is printed


### PR DESCRIPTION
Elementary materials inside ROOT and Geant4 use two names, called variously the "name" and "title" or the "name" and "symbol". With DD4hep, redefined elements were given the second name "CMS element" because it was thought that this second name was not used. However, it does show up in Geant4 GDML and causes confusion when multiple elements all have "CMS element" as a second name.

It should be noted that our code uses ROOT elements unchanged by default, unless they have atomic masses that differ from the standard atomic masses specified for Geant4, in which case the elements are redefined.

This PR leaves ROOT elements unchanged, but for those elements our code redefines to make their atomic masses match the Geant4 standard, their two names are made to match each other. Thus, ROOT elements have names like "HYDROGEN (H)", while redefined elements have names like "Oxygen (Oxygen)". The format of the names doesn't matter as long as the names are unique.

This PR also promotes to Warning messages about composite materials that have undefined components. It is planned to make this condition an exception, with the Warning message as a first step to allow changing any remaining cases in Phase 2 before the exception is implemented.

A simple fix of the DD4hep overlap check config is also included in this PR.

#### PR validation:

The `SimG4Core/PrintGeomInfo/test/python/g4OverlapCheckDD4hep_cfg.py` was run to check the Geant4 materials list and the GDML file to verify that they contain unique element names for both names.

No backport is needed.