### PR TITLE
TkDQM: Add checks to avoid Segfault when a ME is not present at harvesting step

### DIFF
--- a/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1ResidualsExtra.cc
+++ b/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1ResidualsExtra.cc
@@ -396,7 +396,7 @@ void SiPixelPhase1ResidualsExtra::fillMEs(DQMStore::IBooker& iBooker, DQMStore::
     MonitorElement* me2_y = iGetter.get(
         "PixelPhase1/Tracks/ResidualsExtra/PXForward/DRnR_y_per_PXDisk_per_SignedBladePanel_PXRing_" + ring);
 
-    if (me_x == nullptr || me_y == nullptr || me2_x == nullptr || me2_x == nullptr) {
+    if (me_x == nullptr || me_y == nullptr || me2_x == nullptr || me2_y == nullptr) {
       edm::LogWarning("SiPixelPhase1ResidualsExtra")
           << "Residuals plots for Pixel FPIX Ring" << ring << " not found. Skipping ResidualsExtra plots generation.";
       continue;

--- a/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1ResidualsExtra.cc
+++ b/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1ResidualsExtra.cc
@@ -300,6 +300,11 @@ void SiPixelPhase1ResidualsExtra::fillMEs(DQMStore::IBooker& iBooker, DQMStore::
     MonitorElement* me2_y = iGetter.get(
         "PixelPhase1/Tracks/ResidualsExtra/PXBarrel/DRnR_y_per_SignedModule_per_SignedLadder_PXLayer_" + layer);
 
+    if(me_x == nullptr || me_y == nullptr || me2_x == nullptr || me2_x == nullptr){
+      edm::LogWarning("SiPixelPhase1ResidualsExtra") << "Residuals plots for Pixel BPIX Layer"<<layer<<" not found. Skipping ResidualsExtra plots generation.";
+      continue;
+    }
+
     for (int i = 1; i <= me_x->getNbinsY(); i++) {
       if (i == (me_x->getNbinsY() / 2 + 1))
         continue;  //Middle bin of y axis is empty
@@ -389,6 +394,12 @@ void SiPixelPhase1ResidualsExtra::fillMEs(DQMStore::IBooker& iBooker, DQMStore::
         "PixelPhase1/Tracks/ResidualsExtra/PXForward/DRnR_x_per_PXDisk_per_SignedBladePanel_PXRing_" + ring);
     MonitorElement* me2_y = iGetter.get(
         "PixelPhase1/Tracks/ResidualsExtra/PXForward/DRnR_y_per_PXDisk_per_SignedBladePanel_PXRing_" + ring);
+
+    if(me_x == nullptr || me_y == nullptr || me2_x == nullptr || me2_x == nullptr){
+      edm::LogWarning("SiPixelPhase1ResidualsExtra") << "Residuals plots for Pixel FPIX Ring"<<ring<<" not found. Skipping ResidualsExtra plots generation.";
+      continue;
+    }
+
     bool posSide = false;
     for (int j = 1; j <= me_x->getNbinsX(); j++) {
       if (j == 4)

--- a/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1ResidualsExtra.cc
+++ b/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1ResidualsExtra.cc
@@ -300,7 +300,7 @@ void SiPixelPhase1ResidualsExtra::fillMEs(DQMStore::IBooker& iBooker, DQMStore::
     MonitorElement* me2_y = iGetter.get(
         "PixelPhase1/Tracks/ResidualsExtra/PXBarrel/DRnR_y_per_SignedModule_per_SignedLadder_PXLayer_" + layer);
 
-    if (me_x == nullptr || me_y == nullptr || me2_x == nullptr || me2_x == nullptr) {
+    if (me_x == nullptr || me_y == nullptr || me2_x == nullptr || me2_y == nullptr) {
       edm::LogWarning("SiPixelPhase1ResidualsExtra")
           << "Residuals plots for Pixel BPIX Layer" << layer << " not found. Skipping ResidualsExtra plots generation.";
       continue;

--- a/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1ResidualsExtra.cc
+++ b/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1ResidualsExtra.cc
@@ -300,8 +300,9 @@ void SiPixelPhase1ResidualsExtra::fillMEs(DQMStore::IBooker& iBooker, DQMStore::
     MonitorElement* me2_y = iGetter.get(
         "PixelPhase1/Tracks/ResidualsExtra/PXBarrel/DRnR_y_per_SignedModule_per_SignedLadder_PXLayer_" + layer);
 
-    if(me_x == nullptr || me_y == nullptr || me2_x == nullptr || me2_x == nullptr){
-      edm::LogWarning("SiPixelPhase1ResidualsExtra") << "Residuals plots for Pixel BPIX Layer"<<layer<<" not found. Skipping ResidualsExtra plots generation.";
+    if (me_x == nullptr || me_y == nullptr || me2_x == nullptr || me2_x == nullptr) {
+      edm::LogWarning("SiPixelPhase1ResidualsExtra")
+          << "Residuals plots for Pixel BPIX Layer" << layer << " not found. Skipping ResidualsExtra plots generation.";
       continue;
     }
 
@@ -395,8 +396,9 @@ void SiPixelPhase1ResidualsExtra::fillMEs(DQMStore::IBooker& iBooker, DQMStore::
     MonitorElement* me2_y = iGetter.get(
         "PixelPhase1/Tracks/ResidualsExtra/PXForward/DRnR_y_per_PXDisk_per_SignedBladePanel_PXRing_" + ring);
 
-    if(me_x == nullptr || me_y == nullptr || me2_x == nullptr || me2_x == nullptr){
-      edm::LogWarning("SiPixelPhase1ResidualsExtra") << "Residuals plots for Pixel FPIX Ring"<<ring<<" not found. Skipping ResidualsExtra plots generation.";
+    if (me_x == nullptr || me_y == nullptr || me2_x == nullptr || me2_x == nullptr) {
+      edm::LogWarning("SiPixelPhase1ResidualsExtra")
+          << "Residuals plots for Pixel FPIX Ring" << ring << " not found. Skipping ResidualsExtra plots generation.";
       continue;
     }
 

--- a/DQM/TrackingMonitor/src/TrackFoldedOccupancyClient.cc
+++ b/DQM/TrackingMonitor/src/TrackFoldedOccupancyClient.cc
@@ -92,7 +92,7 @@ void TrackFoldedOccupancyClient::dqmEndJob(DQMStore::IBooker& ibooker, DQMStore:
   hname = "TrackEtaPhiInvertedoutofphase_";
   MonitorElement* TrackEtaPhiInvertedoutofphase = igetter.get(inFolder + hname + histTag_);
 
-  if(TrackEtaPhi == nullptr || TrackEtaPhiInverted == nullptr || TrackEtaPhiInvertedoutofphase == nullptr){
+  if (TrackEtaPhi == nullptr || TrackEtaPhiInverted == nullptr || TrackEtaPhiInvertedoutofphase == nullptr) {
     edm::LogWarning("TrackFoldedOccupancyClient") << "MEs needed for this module not found. Skipping.";
     return;
   }

--- a/DQM/TrackingMonitor/src/TrackFoldedOccupancyClient.cc
+++ b/DQM/TrackingMonitor/src/TrackFoldedOccupancyClient.cc
@@ -92,6 +92,11 @@ void TrackFoldedOccupancyClient::dqmEndJob(DQMStore::IBooker& ibooker, DQMStore:
   hname = "TrackEtaPhiInvertedoutofphase_";
   MonitorElement* TrackEtaPhiInvertedoutofphase = igetter.get(inFolder + hname + histTag_);
 
+  if(TrackEtaPhi == nullptr || TrackEtaPhiInverted == nullptr || TrackEtaPhiInvertedoutofphase == nullptr){
+    edm::LogWarning("TrackFoldedOccupancyClient") << "MEs needed for this module not found. Skipping.";
+    return;
+  }
+
   TkEtaPhi_Ratio_byFoldingmap->divide(TrackEtaPhi, TrackEtaPhiInverted, 1., 1., "");
   TkEtaPhi_Ratio_byFoldingmap_op->divide(TrackEtaPhi, TrackEtaPhiInvertedoutofphase, 1., 1., "");
 


### PR DESCRIPTION
#### PR description:

When a couple of TkDQM harvesting module don't find the MEs which in principle should had been produced in the previous step a segmentation fault happen, as reported here #36133. With this PR we introduce a couple of simple check to avoid the this behaviour, if MEs are not produced the modules will be skipped.

#### PR validation:

runTheMatrix.sh -l 10024 
runTheMatrix.sh -l 139.001 (with #36133 locally merged)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport and no backport needed