### PR TITLE
RecHit-based rho producer for HLT

### DIFF
--- a/RecoJets/JetProducers/BuildFile.xml
+++ b/RecoJets/JetProducers/BuildFile.xml
@@ -10,6 +10,7 @@
 <use name="SimDataFormats/Vertex"/>
 <use name="SimDataFormats/Track"/>
 <use name="RecoJets/JetAlgorithms"/>
+<use name="CondFormats/EcalObjects"/>
 <use name="JetMETCorrections/JetCorrector"/>
 <use name="DataFormats/CastorReco"/>
 <use name="CommonTools/MVAUtils"/>

--- a/RecoJets/JetProducers/BuildFile.xml
+++ b/RecoJets/JetProducers/BuildFile.xml
@@ -10,7 +10,6 @@
 <use name="SimDataFormats/Vertex"/>
 <use name="SimDataFormats/Track"/>
 <use name="RecoJets/JetAlgorithms"/>
-<use name="CondFormats/EcalObjects"/>
 <use name="JetMETCorrections/JetCorrector"/>
 <use name="DataFormats/CastorReco"/>
 <use name="CommonTools/MVAUtils"/>

--- a/RecoJets/JetProducers/plugins/BuildFile.xml
+++ b/RecoJets/JetProducers/plugins/BuildFile.xml
@@ -11,6 +11,7 @@
   <use name="Geometry/Records"/>
   <use name="CommonTools/UtilAlgos"/>
   <use name="CondFormats/JetMETObjects"/>
+  <use name="CondFormats/EcalObjects"/>
   <use name="JetMETCorrections/Objects"/>
   <use name="fastjet"/>
   <use name="fastjet-contrib"/>

--- a/RecoJets/JetProducers/plugins/BuildFile.xml
+++ b/RecoJets/JetProducers/plugins/BuildFile.xml
@@ -3,15 +3,20 @@
 <library file="*.cc" name="RecoJetsJetProducers_plugins">
   <use name="RecoJets/JetProducers"/>
   <use name="RecoJets/JetAlgorithms"/>
+  <use name="RecoEgamma/EgammaIsolationAlgos"/>
   <use name="FWCore/Framework"/>
+  <use name="FWCore/ParameterSet"/>
   <use name="DataFormats/BTauReco"/>
   <use name="DataFormats/JetReco"/>
   <use name="DataFormats/VertexReco"/>
+  <use name="DataFormats/HcalRecHit"/>
+  <use name="DataFormats/EcalRecHit"/>
   <use name="Geometry/CaloGeometry"/>
   <use name="Geometry/Records"/>
   <use name="CommonTools/UtilAlgos"/>
   <use name="CondFormats/JetMETObjects"/>
   <use name="CondFormats/EcalObjects"/>
+  <use name="CondFormats/DataRecord"/>
   <use name="JetMETCorrections/Objects"/>
   <use name="fastjet"/>
   <use name="fastjet-contrib"/>

--- a/RecoJets/JetProducers/plugins/FixedGridRhoProducerFastjetFromRecHit.cc
+++ b/RecoJets/JetProducers/plugins/FixedGridRhoProducerFastjetFromRecHit.cc
@@ -114,7 +114,6 @@ void FixedGridRhoProducerFastjetFromRecHit::produce(edm::Event& iEvent, const ed
 
   bge_.set_particles(inputs);
   iEvent.put(std::make_unique<double>(bge_.rho()));
-  std::cout << "new rho from recHits " << bge_.rho() << std::endl;
 }
 
 void FixedGridRhoProducerFastjetFromRecHit::getHitP4(const DetId &detId, float hitE, TLorentzVector &hitp4, const CaloGeometry &caloGeometry) {
@@ -148,17 +147,5 @@ bool FixedGridRhoProducerFastjetFromRecHit::passedEcalNoiseCut(const EcalRecHit 
   if ( hit.energy() > (*thresholds)[hit.detid()]) passed=true;
   return passed;
 }
-
-//calotower-like flat noise threshold
-/*
-bool FixedGridRhoProducerFastjetFromRecHit::passedEcalNoiseCut(const EcalRecHit &hit,const EcalPFRecHitThresholds *thresholds) {
-  bool passed=false;
-  //if ( hit.energy() > (*thresholds)[hit.detid()]) passed=true;
-  //  const EcalDetId thisDetId(hit.detid());
-  if ( (hit.detid().subdetId() == EcalBarrel) &&  (hit.energy() >= 0.07 ) ) passed=true;
-  if ( (hit.detid().subdetId() == EcalEndcap) &&  (hit.energy() >= 0.3  ) ) passed=true;
-  return passed;
-}
-*/
 
 DEFINE_FWK_MODULE(FixedGridRhoProducerFastjetFromRecHit);

--- a/RecoJets/JetProducers/plugins/FixedGridRhoProducerFastjetFromRecHit.cc
+++ b/RecoJets/JetProducers/plugins/FixedGridRhoProducerFastjetFromRecHit.cc
@@ -136,16 +136,16 @@ void FixedGridRhoProducerFastjetFromRecHit::produce(edm::Event &iEvent, const ed
 }
 
 std::array<double, 4> FixedGridRhoProducerFastjetFromRecHit::getHitP4(const DetId &detId,
-                                                     double hitE,
-                                                     const CaloGeometry &caloGeometry) const {
+                                                                      double hitE,
+                                                                      const CaloGeometry &caloGeometry) const {
   const CaloSubdetectorGeometry *subDetGeom = caloGeometry.getSubdetectorGeometry(detId);
-    const auto &gpPos = subDetGeom->getGeometry(detId)->repPos();
-    const double thispt = hitE / cosh(gpPos.eta());
-    const double thispx = thispt * cos(gpPos.phi());
-    const double thispy = thispt * sin(gpPos.phi());
-    const double thispz = thispt * sinh(gpPos.eta());
-    std::array<double, 4> hitp4{{thispx, thispy, thispz, hitE}};
-    return hitp4; 
+  const auto &gpPos = subDetGeom->getGeometry(detId)->repPos();
+  const double thispt = hitE / cosh(gpPos.eta());
+  const double thispx = thispt * cos(gpPos.phi());
+  const double thispy = thispt * sin(gpPos.phi());
+  const double thispz = thispt * sinh(gpPos.eta());
+  std::array<double, 4> hitp4{{thispx, thispy, thispz, hitE}};
+  return hitp4;
 }
 
 //HCAL noise cleaning cuts.

--- a/RecoJets/JetProducers/plugins/FixedGridRhoProducerFastjetFromRecHit.cc
+++ b/RecoJets/JetProducers/plugins/FixedGridRhoProducerFastjetFromRecHit.cc
@@ -1,0 +1,164 @@
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "fastjet/tools/GridMedianBackgroundEstimator.hh"
+#include "FWCore/Framework/interface/Event.h"
+#include "DataFormats/Common/interface/View.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
+#include "TLorentzVector.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "DataFormats/Math/interface/Vector3D.h"
+#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
+#include "RecoEgamma/EgammaIsolationAlgos/interface/EgammaHcalIsolation.h"
+#include "CondFormats/EcalObjects/interface/EcalPFRecHitThresholds.h"
+#include "CondFormats/DataRecord/interface/EcalPFRecHitThresholdsRcd.h"
+
+class FixedGridRhoProducerFastjetFromRecHit : public edm::stream::EDProducer<> {
+public:
+  explicit FixedGridRhoProducerFastjetFromRecHit(const edm::ParameterSet& iConfig);
+  ~FixedGridRhoProducerFastjetFromRecHit() override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void getHitP4(const DetId &detId, float hitE, TLorentzVector &hitp4, const CaloGeometry &caloGeometry) ;
+  bool passedHcalNoiseCut(const HBHERecHit &hit);
+  bool passedEcalNoiseCut(const EcalRecHit &hit,const EcalPFRecHitThresholds *thresholds) ;
+
+  fastjet::GridMedianBackgroundEstimator bge_;
+  edm::EDGetTokenT<HBHERecHitCollection> hbheRecHitsTag_;
+  edm::EDGetTokenT<EcalRecHitCollection> ebRecHitsTag_;
+  edm::EDGetTokenT<EcalRecHitCollection> eeRecHitsTag_;
+
+  const EgammaHcalIsolation::arrayHB eThresHB_;
+  const EgammaHcalIsolation::arrayHE eThresHE_;
+
+  bool skipHCAL_;
+  bool skipECAL_;
+
+  const edm::ESGetToken<EcalPFRecHitThresholds, EcalPFRecHitThresholdsRcd> ecalPFRechitThresholdsToken_;
+  const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeometryToken_;
+};
+
+FixedGridRhoProducerFastjetFromRecHit::FixedGridRhoProducerFastjetFromRecHit(const edm::ParameterSet& iConfig) : 
+  bge_(iConfig.getParameter<double>("maxRapidity"), iConfig.getParameter<double>("gridSpacing")), 
+  hbheRecHitsTag_(consumes(iConfig.getParameter<edm::InputTag>("hbheRecHitsTag"))),
+  ebRecHitsTag_(consumes(iConfig.getParameter<edm::InputTag>("ebRecHitsTag"))),
+  eeRecHitsTag_(consumes(iConfig.getParameter<edm::InputTag>("eeRecHitsTag"))),
+  eThresHB_(iConfig.getParameter<EgammaHcalIsolation::arrayHB>("eThresHB")),
+  eThresHE_(iConfig.getParameter<EgammaHcalIsolation::arrayHE>("eThresHE")),
+  skipHCAL_(iConfig.getParameter<bool>("skipHCAL")),
+  skipECAL_(iConfig.getParameter<bool>("skipECAL")),
+  ecalPFRechitThresholdsToken_{esConsumes()},
+  caloGeometryToken_{esConsumes()} {
+  produces<double>();
+}
+
+void FixedGridRhoProducerFastjetFromRecHit::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>(("hbheRecHitsTag"), edm::InputTag("hltHbhereco"));
+  desc.add<edm::InputTag>(("ebRecHitsTag"), edm::InputTag("hltEcalRecHit","EcalRecHitsEB"));
+  desc.add<edm::InputTag>(("eeRecHitsTag"), edm::InputTag("hltEcalRecHit","EcalRecHitsEE"));
+  desc.add<bool>(("skipHCAL"), false);
+  desc.add<bool>(("skipECAL"), false);
+  //eThresHB/HE are from RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
+  desc.add<std::vector<double> >("eThresHB", {0.1, 0.2, 0.3, 0.3});
+  desc.add<std::vector<double> >("eThresHE", {0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2});
+  desc.add<double>("maxRapidity", 2.5);
+  desc.add<double>("gridSpacing", 0.55);
+  descriptions.add("hltFixedGridRhoProducerFastjetFromRecHit", desc);
+}
+
+FixedGridRhoProducerFastjetFromRecHit::~FixedGridRhoProducerFastjetFromRecHit() {}
+
+void FixedGridRhoProducerFastjetFromRecHit::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+
+  std::vector<fastjet::PseudoJet> inputs;
+  auto const& thresholds = iSetup.getData(ecalPFRechitThresholdsToken_);
+
+  if (skipHCAL_ && skipECAL_) {
+    throw cms::Exception("FixedGridRhoProducerFastjetFromRecHit")
+      << "skipHCAL and skipECAL both can't be True. Make at least one of them False.";
+  }
+
+  if ( !skipHCAL_ ) {
+    for (const auto &hit : iEvent.get(hbheRecHitsTag_) ) {
+      if (passedHcalNoiseCut(hit) ) {
+	TLorentzVector hitp4(0,0,0,0);
+	getHitP4(hit.id(), hit.energy(), hitp4, iSetup.getData(caloGeometryToken_)) ;
+	inputs.push_back(fastjet::PseudoJet(hitp4.Px(), hitp4.Py(), hitp4.Pz(), hitp4.E()));
+      }
+    }
+  }
+
+  if ( !skipECAL_ ) {
+    for (const auto &hit : iEvent.get(ebRecHitsTag_) ) {
+      if ( passedEcalNoiseCut(hit, &thresholds) ) {
+	TLorentzVector hitp4(0,0,0,0);
+	getHitP4(hit.id(), hit.energy(), hitp4, iSetup.getData(caloGeometryToken_)) ;
+	inputs.push_back(fastjet::PseudoJet(hitp4.Px(), hitp4.Py(), hitp4.Pz(), hitp4.E()));
+      }
+    }
+  
+    for (const auto &hit : iEvent.get(eeRecHitsTag_) ) {
+      if ( passedEcalNoiseCut(hit, &thresholds) ) {
+	TLorentzVector hitp4(0,0,0,0);
+	getHitP4(hit.id(), hit.energy(), hitp4, iSetup.getData(caloGeometryToken_)) ;
+	inputs.push_back(fastjet::PseudoJet(hitp4.Px(), hitp4.Py(), hitp4.Pz(), hitp4.E()));
+      }
+    }
+  }
+
+  bge_.set_particles(inputs);
+  iEvent.put(std::make_unique<double>(bge_.rho()));
+  std::cout << "new rho from recHits " << bge_.rho() << std::endl;
+}
+
+void FixedGridRhoProducerFastjetFromRecHit::getHitP4(const DetId &detId, float hitE, TLorentzVector &hitp4, const CaloGeometry &caloGeometry) {
+
+  const CaloSubdetectorGeometry* subDetGeom = caloGeometry.getSubdetectorGeometry(detId);
+  std::shared_ptr<const CaloCellGeometry> cellGeom = subDetGeom!=nullptr ? subDetGeom->getGeometry(detId) : std::shared_ptr<const CaloCellGeometry>();
+  if(cellGeom!=nullptr){
+    const auto &gpPos = cellGeom->repPos();
+    double thispt=hitE/cosh(gpPos.eta());
+    double thispx=thispt*cos(gpPos.phi());
+    double thispy=thispt*sin(gpPos.phi());
+    double thispz=thispt*sinh(gpPos.eta());
+    hitp4.SetPxPyPzE(thispx,thispy,thispz,hitE);
+  }else{
+    if(detId.rawId()!=0) edm::LogInfo("FixedGridRhoProducerFastjetFromRecHit") <<"Warning : Geometry not found for a calo hit, setting p4 as (0,0,0,0)" << std::endl;
+    hitp4.SetPxPyPzE(0,0,0,0);
+  }
+}
+
+bool FixedGridRhoProducerFastjetFromRecHit::passedHcalNoiseCut(const HBHERecHit &hit) {
+  bool passed=false;
+  const HcalDetId thisDetId(hit.detid());
+  const int thisDepth = thisDetId.depth();
+  if ( (thisDetId.subdet() == HcalBarrel) &&  (hit.energy() > eThresHB_[thisDepth-1]) ) passed=true;
+  else if ( (thisDetId.subdet() == HcalEndcap) &&  (hit.energy() > eThresHE_[thisDepth-1]) ) passed=true;
+  return passed;
+}
+
+bool FixedGridRhoProducerFastjetFromRecHit::passedEcalNoiseCut(const EcalRecHit &hit,const EcalPFRecHitThresholds *thresholds) {
+  bool passed=false;
+  if ( hit.energy() > (*thresholds)[hit.detid()]) passed=true;
+  return passed;
+}
+
+//calotower-like flat noise threshold
+/*
+bool FixedGridRhoProducerFastjetFromRecHit::passedEcalNoiseCut(const EcalRecHit &hit,const EcalPFRecHitThresholds *thresholds) {
+  bool passed=false;
+  //if ( hit.energy() > (*thresholds)[hit.detid()]) passed=true;
+  //  const EcalDetId thisDetId(hit.detid());
+  if ( (hit.detid().subdetId() == EcalBarrel) &&  (hit.energy() >= 0.07 ) ) passed=true;
+  if ( (hit.detid().subdetId() == EcalEndcap) &&  (hit.energy() >= 0.3  ) ) passed=true;
+  return passed;
+}
+*/
+
+DEFINE_FWK_MODULE(FixedGridRhoProducerFastjetFromRecHit);

--- a/RecoJets/JetProducers/plugins/FixedGridRhoProducerFastjetFromRecHit.cc
+++ b/RecoJets/JetProducers/plugins/FixedGridRhoProducerFastjetFromRecHit.cc
@@ -144,15 +144,15 @@ std::array<double, 4> FixedGridRhoProducerFastjetFromRecHit::getHitP4(const DetI
   const double thispx = thispt * cos(gpPos.phi());
   const double thispy = thispt * sin(gpPos.phi());
   const double thispz = thispt * sinh(gpPos.eta());
-  return std::array<double, 4> {{thispx, thispy, thispz, hitE}};
+  return std::array<double, 4>{{thispx, thispy, thispz, hitE}};
 }
 
 //HCAL noise cleaning cuts.
 bool FixedGridRhoProducerFastjetFromRecHit::passedHcalNoiseCut(const HBHERecHit &hit) const {
   const auto thisDetId = hit.id();
   const auto thisDepth = thisDetId.depth();
-  return (thisDetId.subdet() == HcalBarrel && hit.energy() > eThresHB_[thisDepth - 1]) || 
-    (thisDetId.subdet() == HcalEndcap && hit.energy() > eThresHE_[thisDepth - 1]);
+  return (thisDetId.subdet() == HcalBarrel && hit.energy() > eThresHB_[thisDepth - 1]) ||
+         (thisDetId.subdet() == HcalEndcap && hit.energy() > eThresHE_[thisDepth - 1]);
 }
 
 //ECAL noise cleaning cuts using per-crystal PF-recHit thresholds.

--- a/RecoJets/JetProducers/plugins/FixedGridRhoProducerFastjetFromRecHit.cc
+++ b/RecoJets/JetProducers/plugins/FixedGridRhoProducerFastjetFromRecHit.cc
@@ -1,3 +1,18 @@
+/*
+
+Author: Swagata Mukherjee
+
+Date: November 2021
+
+This producer computes rho from ECAL and HCAL recHits. 
+The current plan is to use it in egamma and muon HLT, who currently use 
+the other producer called FixedGridRhoProducerFastjet.
+At HLT, FixedGridRhoProducerFastjet takes calotowers as input and computes rho.
+But calotowers are expected to be phased out sometime in Run3.
+So this recHit-based rho producer, FixedGridRhoProducerFastjetFromRecHit, can be used as an alternative.
+
+*/
+
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -18,15 +33,15 @@
 
 class FixedGridRhoProducerFastjetFromRecHit : public edm::stream::EDProducer<> {
 public:
-  explicit FixedGridRhoProducerFastjetFromRecHit(const edm::ParameterSet& iConfig);
+  explicit FixedGridRhoProducerFastjetFromRecHit(const edm::ParameterSet &iConfig);
   ~FixedGridRhoProducerFastjetFromRecHit() override;
-  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
 private:
-  void produce(edm::Event&, const edm::EventSetup&) override;
-  void getHitP4(const DetId &detId, float hitE, TLorentzVector &hitp4, const CaloGeometry &caloGeometry) ;
+  void produce(edm::Event &, const edm::EventSetup &) override;
+  void getHitP4(const DetId &detId, float hitE, TLorentzVector &hitp4, const CaloGeometry &caloGeometry);
   bool passedHcalNoiseCut(const HBHERecHit &hit);
-  bool passedEcalNoiseCut(const EcalRecHit &hit,const EcalPFRecHitThresholds *thresholds) ;
+  bool passedEcalNoiseCut(const EcalRecHit &hit, const EcalPFRecHitThresholds *thresholds);
 
   fastjet::GridMedianBackgroundEstimator bge_;
   edm::EDGetTokenT<HBHERecHitCollection> hbheRecHitsTag_;
@@ -36,6 +51,8 @@ private:
   const EgammaHcalIsolation::arrayHB eThresHB_;
   const EgammaHcalIsolation::arrayHE eThresHE_;
 
+  //Muon HLT currently use ECAL-only rho for ECAL isolation,
+  //and HCAL-only rho for HCAL isolation. So, this skipping option is needed.
   bool skipHCAL_;
   bool skipECAL_;
 
@@ -43,27 +60,29 @@ private:
   const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeometryToken_;
 };
 
-FixedGridRhoProducerFastjetFromRecHit::FixedGridRhoProducerFastjetFromRecHit(const edm::ParameterSet& iConfig) : 
-  bge_(iConfig.getParameter<double>("maxRapidity"), iConfig.getParameter<double>("gridSpacing")), 
-  hbheRecHitsTag_(consumes(iConfig.getParameter<edm::InputTag>("hbheRecHitsTag"))),
-  ebRecHitsTag_(consumes(iConfig.getParameter<edm::InputTag>("ebRecHitsTag"))),
-  eeRecHitsTag_(consumes(iConfig.getParameter<edm::InputTag>("eeRecHitsTag"))),
-  eThresHB_(iConfig.getParameter<EgammaHcalIsolation::arrayHB>("eThresHB")),
-  eThresHE_(iConfig.getParameter<EgammaHcalIsolation::arrayHE>("eThresHE")),
-  skipHCAL_(iConfig.getParameter<bool>("skipHCAL")),
-  skipECAL_(iConfig.getParameter<bool>("skipECAL")),
-  ecalPFRechitThresholdsToken_{esConsumes()},
-  caloGeometryToken_{esConsumes()} {
+FixedGridRhoProducerFastjetFromRecHit::FixedGridRhoProducerFastjetFromRecHit(const edm::ParameterSet &iConfig)
+    : bge_(iConfig.getParameter<double>("maxRapidity"), iConfig.getParameter<double>("gridSpacing")),
+      hbheRecHitsTag_(consumes(iConfig.getParameter<edm::InputTag>("hbheRecHitsTag"))),
+      ebRecHitsTag_(consumes(iConfig.getParameter<edm::InputTag>("ebRecHitsTag"))),
+      eeRecHitsTag_(consumes(iConfig.getParameter<edm::InputTag>("eeRecHitsTag"))),
+      eThresHB_(iConfig.getParameter<EgammaHcalIsolation::arrayHB>("eThresHB")),
+      eThresHE_(iConfig.getParameter<EgammaHcalIsolation::arrayHE>("eThresHE")),
+      skipHCAL_(iConfig.getParameter<bool>("skipHCAL")),
+      skipECAL_(iConfig.getParameter<bool>("skipECAL")),
+      ecalPFRechitThresholdsToken_{esConsumes()},
+      caloGeometryToken_{esConsumes()} {
   produces<double>();
 }
 
-void FixedGridRhoProducerFastjetFromRecHit::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void FixedGridRhoProducerFastjetFromRecHit::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>(("hbheRecHitsTag"), edm::InputTag("hltHbhereco"));
-  desc.add<edm::InputTag>(("ebRecHitsTag"), edm::InputTag("hltEcalRecHit","EcalRecHitsEB"));
-  desc.add<edm::InputTag>(("eeRecHitsTag"), edm::InputTag("hltEcalRecHit","EcalRecHitsEE"));
-  desc.add<bool>(("skipHCAL"), false);
-  desc.add<bool>(("skipECAL"), false);
+  //We use raw recHits and not the PF recHits, because in Phase1 muon and egamma HLT,
+  //PF recHit collection is regional, while the full raw recHit collection is available.
+  desc.add<edm::InputTag>("hbheRecHitsTag", edm::InputTag("hltHbhereco"));
+  desc.add<edm::InputTag>("ebRecHitsTag", edm::InputTag("hltEcalRecHit", "EcalRecHitsEB"));
+  desc.add<edm::InputTag>("eeRecHitsTag", edm::InputTag("hltEcalRecHit", "EcalRecHitsEE"));
+  desc.add<bool>("skipHCAL", false);
+  desc.add<bool>("skipECAL", false);
   //eThresHB/HE are from RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
   desc.add<std::vector<double> >("eThresHB", {0.1, 0.2, 0.3, 0.3});
   desc.add<std::vector<double> >("eThresHE", {0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2});
@@ -74,40 +93,39 @@ void FixedGridRhoProducerFastjetFromRecHit::fillDescriptions(edm::ConfigurationD
 
 FixedGridRhoProducerFastjetFromRecHit::~FixedGridRhoProducerFastjetFromRecHit() {}
 
-void FixedGridRhoProducerFastjetFromRecHit::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-
+void FixedGridRhoProducerFastjetFromRecHit::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   std::vector<fastjet::PseudoJet> inputs;
-  auto const& thresholds = iSetup.getData(ecalPFRechitThresholdsToken_);
+  auto const &thresholds = iSetup.getData(ecalPFRechitThresholdsToken_);
 
   if (skipHCAL_ && skipECAL_) {
     throw cms::Exception("FixedGridRhoProducerFastjetFromRecHit")
-      << "skipHCAL and skipECAL both can't be True. Make at least one of them False.";
+        << "skipHCAL and skipECAL both can't be True. Make at least one of them False.";
   }
 
-  if ( !skipHCAL_ ) {
-    for (const auto &hit : iEvent.get(hbheRecHitsTag_) ) {
-      if (passedHcalNoiseCut(hit) ) {
-	TLorentzVector hitp4(0,0,0,0);
-	getHitP4(hit.id(), hit.energy(), hitp4, iSetup.getData(caloGeometryToken_)) ;
-	inputs.push_back(fastjet::PseudoJet(hitp4.Px(), hitp4.Py(), hitp4.Pz(), hitp4.E()));
+  if (!skipHCAL_) {
+    for (const auto &hit : iEvent.get(hbheRecHitsTag_)) {
+      if (passedHcalNoiseCut(hit)) {
+        TLorentzVector hitp4(0, 0, 0, 0);
+        getHitP4(hit.id(), hit.energy(), hitp4, iSetup.getData(caloGeometryToken_));
+        inputs.push_back(fastjet::PseudoJet(hitp4.Px(), hitp4.Py(), hitp4.Pz(), hitp4.E()));
       }
     }
   }
 
-  if ( !skipECAL_ ) {
-    for (const auto &hit : iEvent.get(ebRecHitsTag_) ) {
-      if ( passedEcalNoiseCut(hit, &thresholds) ) {
-	TLorentzVector hitp4(0,0,0,0);
-	getHitP4(hit.id(), hit.energy(), hitp4, iSetup.getData(caloGeometryToken_)) ;
-	inputs.push_back(fastjet::PseudoJet(hitp4.Px(), hitp4.Py(), hitp4.Pz(), hitp4.E()));
+  if (!skipECAL_) {
+    for (const auto &hit : iEvent.get(ebRecHitsTag_)) {
+      if (passedEcalNoiseCut(hit, &thresholds)) {
+        TLorentzVector hitp4(0, 0, 0, 0);
+        getHitP4(hit.id(), hit.energy(), hitp4, iSetup.getData(caloGeometryToken_));
+        inputs.push_back(fastjet::PseudoJet(hitp4.Px(), hitp4.Py(), hitp4.Pz(), hitp4.E()));
       }
     }
-  
-    for (const auto &hit : iEvent.get(eeRecHitsTag_) ) {
-      if ( passedEcalNoiseCut(hit, &thresholds) ) {
-	TLorentzVector hitp4(0,0,0,0);
-	getHitP4(hit.id(), hit.energy(), hitp4, iSetup.getData(caloGeometryToken_)) ;
-	inputs.push_back(fastjet::PseudoJet(hitp4.Px(), hitp4.Py(), hitp4.Pz(), hitp4.E()));
+
+    for (const auto &hit : iEvent.get(eeRecHitsTag_)) {
+      if (passedEcalNoiseCut(hit, &thresholds)) {
+        TLorentzVector hitp4(0, 0, 0, 0);
+        getHitP4(hit.id(), hit.energy(), hitp4, iSetup.getData(caloGeometryToken_));
+        inputs.push_back(fastjet::PseudoJet(hitp4.Px(), hitp4.Py(), hitp4.Pz(), hitp4.E()));
       }
     }
   }
@@ -116,35 +134,46 @@ void FixedGridRhoProducerFastjetFromRecHit::produce(edm::Event& iEvent, const ed
   iEvent.put(std::make_unique<double>(bge_.rho()));
 }
 
-void FixedGridRhoProducerFastjetFromRecHit::getHitP4(const DetId &detId, float hitE, TLorentzVector &hitp4, const CaloGeometry &caloGeometry) {
-
-  const CaloSubdetectorGeometry* subDetGeom = caloGeometry.getSubdetectorGeometry(detId);
-  std::shared_ptr<const CaloCellGeometry> cellGeom = subDetGeom!=nullptr ? subDetGeom->getGeometry(detId) : std::shared_ptr<const CaloCellGeometry>();
-  if(cellGeom!=nullptr){
+void FixedGridRhoProducerFastjetFromRecHit::getHitP4(const DetId &detId,
+                                                     float hitE,
+                                                     TLorentzVector &hitp4,
+                                                     const CaloGeometry &caloGeometry) {
+  const CaloSubdetectorGeometry *subDetGeom = caloGeometry.getSubdetectorGeometry(detId);
+  std::shared_ptr<const CaloCellGeometry> cellGeom =
+      subDetGeom != nullptr ? subDetGeom->getGeometry(detId) : std::shared_ptr<const CaloCellGeometry>();
+  if (cellGeom != nullptr) {
     const auto &gpPos = cellGeom->repPos();
-    double thispt=hitE/cosh(gpPos.eta());
-    double thispx=thispt*cos(gpPos.phi());
-    double thispy=thispt*sin(gpPos.phi());
-    double thispz=thispt*sinh(gpPos.eta());
-    hitp4.SetPxPyPzE(thispx,thispy,thispz,hitE);
-  }else{
-    if(detId.rawId()!=0) edm::LogInfo("FixedGridRhoProducerFastjetFromRecHit") <<"Warning : Geometry not found for a calo hit, setting p4 as (0,0,0,0)" << std::endl;
-    hitp4.SetPxPyPzE(0,0,0,0);
+    double thispt = hitE / cosh(gpPos.eta());
+    double thispx = thispt * cos(gpPos.phi());
+    double thispy = thispt * sin(gpPos.phi());
+    double thispz = thispt * sinh(gpPos.eta());
+    hitp4.SetPxPyPzE(thispx, thispy, thispz, hitE);
+  } else {
+    if (detId.rawId() != 0)
+      edm::LogInfo("FixedGridRhoProducerFastjetFromRecHit")
+          << "Warning : Geometry not found for a calo hit, setting p4 as (0,0,0,0)" << std::endl;
+    hitp4.SetPxPyPzE(0, 0, 0, 0);
   }
 }
 
+//HCAL noise cleaning cuts.
 bool FixedGridRhoProducerFastjetFromRecHit::passedHcalNoiseCut(const HBHERecHit &hit) {
-  bool passed=false;
+  bool passed = false;
   const HcalDetId thisDetId(hit.detid());
   const int thisDepth = thisDetId.depth();
-  if ( (thisDetId.subdet() == HcalBarrel) &&  (hit.energy() > eThresHB_[thisDepth-1]) ) passed=true;
-  else if ( (thisDetId.subdet() == HcalEndcap) &&  (hit.energy() > eThresHE_[thisDepth-1]) ) passed=true;
+  if ((thisDetId.subdet() == HcalBarrel) && (hit.energy() > eThresHB_[thisDepth - 1]))
+    passed = true;
+  else if ((thisDetId.subdet() == HcalEndcap) && (hit.energy() > eThresHE_[thisDepth - 1]))
+    passed = true;
   return passed;
 }
 
-bool FixedGridRhoProducerFastjetFromRecHit::passedEcalNoiseCut(const EcalRecHit &hit,const EcalPFRecHitThresholds *thresholds) {
-  bool passed=false;
-  if ( hit.energy() > (*thresholds)[hit.detid()]) passed=true;
+//ECAL noise cleaning cuts using per-crystal PF-recHit thresholds.
+bool FixedGridRhoProducerFastjetFromRecHit::passedEcalNoiseCut(const EcalRecHit &hit,
+                                                               const EcalPFRecHitThresholds *thresholds) {
+  bool passed = false;
+  if (hit.energy() > (*thresholds)[hit.detid()])
+    passed = true;
   return passed;
 }
 

--- a/RecoJets/JetProducers/plugins/FixedGridRhoProducerFastjetFromRecHit.cc
+++ b/RecoJets/JetProducers/plugins/FixedGridRhoProducerFastjetFromRecHit.cc
@@ -19,7 +19,6 @@ So this recHit-based rho producer, FixedGridRhoProducerFastjetFromRecHit, can be
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
-#include "DataFormats/Math/interface/LorentzVector.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"


### PR DESCRIPTION
#### PR description:

In an attempt to phase-out calotowers, this PR adds a new rho producer which is recHit-based. It takes the raw recHits of ECAL and HCAL as input and computes rho using fastjet. The new producer code is kept in `RecoJets/JetProducers/plugins/` because other rho producer codes are also there. But this one is primarily aimed for HLT. According to current plan, egamma and muon HLT can use it in Run3, in order to phase out calotowers. Until Run2, calotower-based rho was used in egamma and muon HLT. 

#### PR validation:

Ran egamma HLT after adding a module for the new rho producer. Relevant part of HLT config is this:
```
process.hltRhoNew = cms.EDProducer( "FixedGridRhoProducerFastjetFromRecHit",
    hbheRecHitsTag = cms.InputTag( "hltHbhereco" ),
    ebRecHitsTag = cms.InputTag( 'hltEcalRecHit','EcalRecHitsEB' ),
    eeRecHitsTag = cms.InputTag( 'hltEcalRecHit','EcalRecHitsEE' ),
    eThresHB = cms.vdouble(0.1, 0.2, 0.3, 0.3),
    eThresHE = cms.vdouble(0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2),
    maxRapidity = cms.double( 2.5 ),
    gridSpacing = cms.double( 0.55 ),
    skipHCAL = cms.bool(False),
    skipECAL = cms.bool(False)
)
```
Then compared calotower-based rho and recHit-based rho, and found that they are fairly close. 

<img width="500" alt="Screen Shot 2021-08-31 at 14 08 40 (1)" src="https://user-images.githubusercontent.com/5052706/142257391-91e9c5ec-279a-4560-8fcc-d3f01e14c662.png">

Note that an exact match is neither expected, nor required. One reason of the small difference is different noise-cleaning cuts in calotower creation code. 

Muon HLT team validated this producer independently, and found that their HLT performance remain very similar after moving to recHit-based rho. This is discussed in TSG meeting today: https://indico.cern.ch/event/1097086/contributions/4618454/attachments/2347696/4003696/20211117_TSG_MuonHLTIso_DropCaloTower_KPLee_v2.pdf

This PR is not a backport. 
A backport to `12_1_X` might be needed for HLT studies.

Thanks to Muon POG, in particular @KyeongPil-Lee, for validating the producer in the context of muon HLT. 

With thanks to @Sam-Harper, for useful discussions. 