### PR TITLE
Modernize analyzers in CondTools/RPC

### DIFF
--- a/CondTools/RPC/plugins/PVSSIDReader.cc
+++ b/CondTools/RPC/plugins/PVSSIDReader.cc
@@ -3,32 +3,31 @@
 #include <vector>
 
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "CondTools/RPC/interface/RPCDBSimSetUp.h"
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 #include "CondFormats/RPCObjects/interface/RPCObPVSSmap.h"
 #include "CondFormats/DataRecord/interface/RPCObPVSSmapRcd.h"
 
-class PVSSIDReader : public edm::EDAnalyzer {
+class PVSSIDReader : public edm::one::EDAnalyzer<> {
 public:
   PVSSIDReader(const edm::ParameterSet& iConfig);
   ~PVSSIDReader() override;
   void analyze(const edm::Event& evt, const edm::EventSetup& evtSetup) override;
+
+private:
+  edm::ESGetToken<RPCObPVSSmap, RPCObPVSSmapRcd> pvssmap_token_;
 };
 
-PVSSIDReader::PVSSIDReader(const edm::ParameterSet& iConfig) {}
+PVSSIDReader::PVSSIDReader(const edm::ParameterSet& iConfig) : pvssmap_token_(esConsumes()) {}
 
 PVSSIDReader::~PVSSIDReader() {}
 
 void PVSSIDReader::analyze(const edm::Event& evt, const edm::EventSetup& evtSetup) {
-  edm::ESHandle<RPCObPVSSmap> pvssmapRcd;
-  evtSetup.get<RPCObPVSSmapRcd>().get(pvssmapRcd);
+  const RPCObPVSSmap* pvssmap = &evtSetup.getData(pvssmap_token_);
   edm::LogInfo("PVSSIDReader") << "[PVSSIDReader::analyze] End Reading Pvssmap" << std::endl;
-
-  const RPCObPVSSmap* pvssmap = pvssmapRcd.product();
   std::vector<RPCObPVSSmap::Item> mypvssmap = pvssmap->ObIDMap_rpc;
   std::vector<RPCObPVSSmap::Item>::iterator ipvssmap;
 

--- a/CondTools/RPC/src/RPCDBPerformanceHandler.cc
+++ b/CondTools/RPC/src/RPCDBPerformanceHandler.cc
@@ -2,7 +2,6 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/CondTools/RPC/src/RPCStripNoisesRcdRead.cc
+++ b/CondTools/RPC/src/RPCStripNoisesRcdRead.cc
@@ -3,31 +3,31 @@
 #include <vector>
 
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "CondTools/RPC/interface/RPCDBSimSetUp.h"
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 #include "CondFormats/RPCObjects/interface/RPCStripNoises.h"
 #include "CondFormats/DataRecord/interface/RPCStripNoisesRcd.h"
 
-class RPCStripNoisesRcdRead : public edm::EDAnalyzer {
+class RPCStripNoisesRcdRead : public edm::one::EDAnalyzer<> {
 public:
   RPCStripNoisesRcdRead(const edm::ParameterSet& iConfig);
   ~RPCStripNoisesRcdRead() override;
   void analyze(const edm::Event& evt, const edm::EventSetup& evtSetup) override;
+
+private:
+  edm::ESGetToken<RPCStripNoises, RPCStripNoisesRcd> noise_RcdToken_;
 };
 
-RPCStripNoisesRcdRead::RPCStripNoisesRcdRead(const edm::ParameterSet& iConfig) {}
+RPCStripNoisesRcdRead::RPCStripNoisesRcdRead(const edm::ParameterSet& iConfig) : noise_RcdToken_(esConsumes()) {}
 
 RPCStripNoisesRcdRead::~RPCStripNoisesRcdRead() {}
 
 void RPCStripNoisesRcdRead::analyze(const edm::Event& evt, const edm::EventSetup& evtSetup) {
-  edm::ESHandle<RPCStripNoises> noiseRcd;
-  evtSetup.get<RPCStripNoisesRcd>().get(noiseRcd);
+  const RPCStripNoises* noiseRcd = &evtSetup.getData(noise_RcdToken_);
   edm::LogInfo("RPCStripNoisesReader") << "[RPCStripNoisesReader::analyze] End Reading RPCStripNoises" << std::endl;
-
   std::vector<RPCStripNoises::NoiseItem> vnoise = noiseRcd->getVNoise();
   std::vector<float> vcls = noiseRcd->getCls();
 


### PR DESCRIPTION
#### PR description:

This moves analyzers in plugins to esConsumes and uses one/EDAnalyzer as suggested in the 
CMSSW_12_2_CMSDEPRECATED_X_2021 IB

#### PR validation:

Compiles without warnings, tests ran

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

None