### PR TITLE
Customisation snippet for full-range M0 default in HCAL reco

### DIFF
--- a/RecoLocalCalo/Configuration/python/customiseHBHEreco.py
+++ b/RecoLocalCalo/Configuration/python/customiseHBHEreco.py
@@ -1,9 +1,9 @@
 # Set M0 as default HCAL reconstruction over full HBHE Digi range
 # To be used in cmsDriver command: 
-# --customise RecoLocalCal/HcalRecProducers/M0defaultFullRange_cff.customiseM0
+# --customise RecoLocalCalo/Configuration/customiseHBHEreco.hbheUseM0FullRangePhase1
 
 import FWCore.ParameterSet.Config as cms
-def customiseM0(process):
+def hbheUseM0FullRangePhase1(process):
     if hasattr(process,'hbhereco'):
        process.hbhereco.cpu.tsFromDB = False
        process.hbhereco.cpu.recoParamsFromDB = False

--- a/RecoLocalCalo/HcalRecProducers/python/M0defaultFullRange_cff.py
+++ b/RecoLocalCalo/HcalRecProducers/python/M0defaultFullRange_cff.py
@@ -1,0 +1,19 @@
+# Set M0 as default HCAL reconstruction over full HBHE Digi range
+# To be used in cmsDriver command: 
+# --customise RecoLocalCal/HcalRecProducers/M0defaultFullRange_cff.customiseM0
+
+import FWCore.ParameterSet.Config as cms
+def customiseM0(process):
+    if hasattr(process,'hbhereco'):
+       process.hbhereco.cpu.tsFromDB = False
+       process.hbhereco.cpu.recoParamsFromDB = False
+       process.hbhereco.cpu.sipmQTSShift = -99
+       process.hbhereco.cpu.sipmQNTStoSum = 99
+       process.hbhereco.cpu.algorithm.useMahi = False
+       process.hbhereco.cpu.algorithm.useM2 = False
+       process.hbhereco.cpu.algorithm.useM3 = False
+       process.hbhereco.cpu.algorithm.correctForPhaseContainment = False
+       process.hbhereco.cpu.algorithm.firstSampleShift = -999
+       process.hbhereco.cpu.algorithm.samplesToAdd = 10
+
+    return(process)


### PR DESCRIPTION
#### PR description:

When added to cmsDriver  
     --customise RecoLocalCalo/Configuration/customiseHBHEreco.hbheUseM0FullRangePhase1
replaces MAHI with M0 settings "a la" Cosmics 
https://cmssdt.cern.ch/lxr/source/RecoLocalCalo/Configuration/python/RecoLocalCalo_Cosmics_cff.py#0022

#### PR validation:

Comparison of wf 11634.0 (TTbar 2021)  step3 w/wo this customization using edmConfigDump  looks as expected:

correctForPhaseContainment = cms.bool(False)    <-   correctForPhaseContainment = cms.bool(True),
firstSampleShift = cms.int32(-999)    <-   firstSampleShift = cms.int32(0)
samplesToAdd = cms.int32(10)   <-  samplesToAdd = cms.int32(2)
useMahi = cms.bool(False)   <-   useMahi = cms.bool(True)
recoParamsFromDB = cms.bool(False)   <-     recoParamsFromDB = cms.bool(True)
sipmQNTStoSum = cms.int32(99)  <-  sipmQNTStoSum = cms.int32(3)
sipmQTSShift = cms.int32(-99)  <-  sipmQTSShift = cms.int32(0)

#### This is not a backport
