### PR TITLE
[Backport]:  Customisation snippet for full-range M0 default in HCAL reco

### DIFF
--- a/RecoLocalCalo/Configuration/python/customiseHBHEreco.py
+++ b/RecoLocalCalo/Configuration/python/customiseHBHEreco.py
@@ -1,9 +1,9 @@
 # Set M0 as default HCAL reconstruction over full HBHE Digi range
 # To be used in cmsDriver command: 
-# --customise RecoLocalCal/HcalRecProducers/M0defaultFullRange_cff.customiseM0
+# --customise RecoLocalCalo/Configuration/customiseHBHEreco.hbheUseM0FullRangePhase1
 
 import FWCore.ParameterSet.Config as cms
-def customiseM0(process):
+def hbheUseM0FullRangePhase1(process):
     if hasattr(process,'hbhereco'):
        process.hbhereco.cpu.tsFromDB = False
        process.hbhereco.cpu.recoParamsFromDB = False

--- a/RecoLocalCalo/HcalRecProducers/python/M0defaultFullRange_cff.py
+++ b/RecoLocalCalo/HcalRecProducers/python/M0defaultFullRange_cff.py
@@ -1,0 +1,19 @@
+# Set M0 as default HCAL reconstruction over full HBHE Digi range
+# To be used in cmsDriver command: 
+# --customise RecoLocalCal/HcalRecProducers/M0defaultFullRange_cff.customiseM0
+
+import FWCore.ParameterSet.Config as cms
+def customiseM0(process):
+    if hasattr(process,'hbhereco'):
+       process.hbhereco.cpu.tsFromDB = False
+       process.hbhereco.cpu.recoParamsFromDB = False
+       process.hbhereco.cpu.sipmQTSShift = -99
+       process.hbhereco.cpu.sipmQNTStoSum = 99
+       process.hbhereco.cpu.algorithm.useMahi = False
+       process.hbhereco.cpu.algorithm.useM2 = False
+       process.hbhereco.cpu.algorithm.useM3 = False
+       process.hbhereco.cpu.algorithm.correctForPhaseContainment = False
+       process.hbhereco.cpu.algorithm.firstSampleShift = -999
+       process.hbhereco.cpu.algorithm.samplesToAdd = 10
+
+    return(process)


### PR DESCRIPTION
#### PR description:

Backport of https://github.com/cms-sw/cmssw/pull/36161

At PPD Coordination on Wed. 17 Nov. it was agreed to use this customization for pilot beam re-reco instead of default MAHI, as HCAL time alignment was quite questionable during data taking.