### PR TITLE
Fix calculation of smeared MET on MiniAOD

### DIFF
--- a/DataFormats/PatCandidates/interface/Jet.h
+++ b/DataFormats/PatCandidates/interface/Jet.h
@@ -177,6 +177,20 @@ namespace pat {
     void scaleEnergy(double fScale) override { scaleEnergy(fScale, "Unscaled"); }
     void scaleEnergy(double fScale, const std::string& level);
 
+    // Methods to work with a JER correction factor
+    //
+    // is the JER correction factor valid, i.e. has it been written using the saveJerFactor method
+    bool isJerFactorValid() const;
+
+    // load the currently saved JER correction factor and check whether the factor was propely set before loading
+    float loadJerFactor() const;
+
+    // save a JER correction factor
+    void saveJerFactor(float jerFactor_);
+
+    // reset a saved JER correction factor
+    void resetJerFactor();
+
   private:
     /// index of the set of jec factors with given label; returns -1 if no set
     /// of jec factors exists with the given label
@@ -649,6 +663,10 @@ namespace pat {
 
     // ---- id functions ----
     reco::JetID jetID_;
+
+    // ---- JER correction factor ----
+    float jerFactor;
+    bool jerFactorValid;
 
   private:
     // ---- helper functions ----

--- a/DataFormats/PatCandidates/interface/Jet.h
+++ b/DataFormats/PatCandidates/interface/Jet.h
@@ -183,10 +183,10 @@ namespace pat {
     bool isJerFactorValid() const;
 
     // load the currently saved JER correction factor and check whether the factor was propely set before loading
-    float loadJerFactor() const;
+    float jerFactor() const;
 
     // save a JER correction factor
-    void saveJerFactor(float jerFactor_);
+    void setJerFactor(float jerFactor);
 
     // reset a saved JER correction factor
     void resetJerFactor();
@@ -665,8 +665,8 @@ namespace pat {
     reco::JetID jetID_;
 
     // ---- JER correction factor ----
-    float jerFactor;
-    bool jerFactorValid;
+    float jerFactor_;
+    bool jerFactorValid_;
 
   private:
     // ---- helper functions ----

--- a/DataFormats/PatCandidates/src/Jet.cc
+++ b/DataFormats/PatCandidates/src/Jet.cc
@@ -14,8 +14,8 @@ Jet::Jet()
       embeddedCaloTowers_(false),
       embeddedPFCandidates_(false),
       jetCharge_(0.),
-      jerFactor(0.0),
-      jerFactorValid(false) {}
+      jerFactor_(0.0),
+      jerFactorValid_(false) {}
 
 /// constructor from a reco::Jet
 Jet::Jet(const reco::Jet& aJet)
@@ -23,8 +23,8 @@ Jet::Jet(const reco::Jet& aJet)
       embeddedCaloTowers_(false),
       embeddedPFCandidates_(false),
       jetCharge_(0.0),
-      jerFactor(0.0),
-      jerFactorValid(false) {
+      jerFactor_(0.0),
+      jerFactorValid_(false) {
   tryImportSpecific(aJet);
 }
 
@@ -34,8 +34,8 @@ Jet::Jet(const edm::Ptr<reco::Jet>& aJetRef)
       embeddedCaloTowers_(false),
       embeddedPFCandidates_(false),
       jetCharge_(0.0),
-      jerFactor(0.0),
-      jerFactorValid(false) {
+      jerFactor_(0.0),
+      jerFactorValid_(false) {
   tryImportSpecific(*aJetRef);
 }
 
@@ -45,8 +45,8 @@ Jet::Jet(const edm::RefToBase<reco::Jet>& aJetRef)
       embeddedCaloTowers_(false),
       embeddedPFCandidates_(false),
       jetCharge_(0.0),
-      jerFactor(0.0),
-      jerFactorValid(false) {
+      jerFactor_(0.0),
+      jerFactorValid_(false) {
   tryImportSpecific(*aJetRef);
 }
 
@@ -618,12 +618,12 @@ void Jet::addSubjets(pat::JetPtrCollection const& pieces, std::string const& lab
 }
 
 // is the JER correction factor valid, i.e. has it been written using the saveJerFactor method
-bool Jet::isJerFactorValid() const { return jerFactorValid; }
+bool Jet::isJerFactorValid() const { return jerFactorValid_; }
 
 // load the currently saved JER correction factor and check whether the factor was propely set before loading
-float Jet::loadJerFactor() const {
+float Jet::jerFactor() const {
   if (isJerFactorValid()) {
-    return jerFactor;
+    return jerFactor_;
   } else {
     throw cms::Exception(
         "Loading JER factor of a pat::Jet, but it was not set properly before. You need to save a JER factor first, "
@@ -633,13 +633,13 @@ float Jet::loadJerFactor() const {
 }
 
 // save a JER correction factor
-void Jet::saveJerFactor(float jerFactor_) {
-  jerFactor = jerFactor_;
-  jerFactorValid = true;
+void Jet::setJerFactor(float jerFactor) {
+  jerFactor_ = jerFactor;
+  jerFactorValid_ = true;
 }
 
 // reset a saved JER correction factor
 void Jet::resetJerFactor() {
-  jerFactor = 0.0;
-  jerFactorValid = false;
+  jerFactor_ = 0.0;
+  jerFactorValid_ = false;
 }

--- a/DataFormats/PatCandidates/src/Jet.cc
+++ b/DataFormats/PatCandidates/src/Jet.cc
@@ -10,23 +10,43 @@ using namespace pat;
 
 /// default constructor
 Jet::Jet()
-    : PATObject<reco::Jet>(reco::Jet()), embeddedCaloTowers_(false), embeddedPFCandidates_(false), jetCharge_(0.) {}
+    : PATObject<reco::Jet>(reco::Jet()),
+      embeddedCaloTowers_(false),
+      embeddedPFCandidates_(false),
+      jetCharge_(0.),
+      jerFactor(0.0),
+      jerFactorValid(false) {}
 
 /// constructor from a reco::Jet
 Jet::Jet(const reco::Jet& aJet)
-    : PATObject<reco::Jet>(aJet), embeddedCaloTowers_(false), embeddedPFCandidates_(false), jetCharge_(0.0) {
+    : PATObject<reco::Jet>(aJet),
+      embeddedCaloTowers_(false),
+      embeddedPFCandidates_(false),
+      jetCharge_(0.0),
+      jerFactor(0.0),
+      jerFactorValid(false) {
   tryImportSpecific(aJet);
 }
 
 /// constructor from ref to reco::Jet
 Jet::Jet(const edm::Ptr<reco::Jet>& aJetRef)
-    : PATObject<reco::Jet>(aJetRef), embeddedCaloTowers_(false), embeddedPFCandidates_(false), jetCharge_(0.0) {
+    : PATObject<reco::Jet>(aJetRef),
+      embeddedCaloTowers_(false),
+      embeddedPFCandidates_(false),
+      jetCharge_(0.0),
+      jerFactor(0.0),
+      jerFactorValid(false) {
   tryImportSpecific(*aJetRef);
 }
 
 /// constructor from ref to reco::Jet
 Jet::Jet(const edm::RefToBase<reco::Jet>& aJetRef)
-    : PATObject<reco::Jet>(aJetRef), embeddedCaloTowers_(false), embeddedPFCandidates_(false), jetCharge_(0.0) {
+    : PATObject<reco::Jet>(aJetRef),
+      embeddedCaloTowers_(false),
+      embeddedPFCandidates_(false),
+      jetCharge_(0.0),
+      jerFactor(0.0),
+      jerFactorValid(false) {
   tryImportSpecific(*aJetRef);
 }
 
@@ -595,4 +615,31 @@ pat::JetPtrCollection const& Jet::subjets(std::string const& label) const {
 void Jet::addSubjets(pat::JetPtrCollection const& pieces, std::string const& label) {
   subjetCollections_.push_back(pieces);
   subjetLabels_.push_back(label);
+}
+
+// is the JER correction factor valid, i.e. has it been written using the saveJerFactor method
+bool Jet::isJerFactorValid() const { return jerFactorValid; }
+
+// load the currently saved JER correction factor and check whether the factor was propely set before loading
+float Jet::loadJerFactor() const {
+  if (isJerFactorValid()) {
+    return jerFactor;
+  } else {
+    throw cms::Exception(
+        "Loading JER factor of a pat::Jet, but it was not set properly before. You need to save a JER factor first, "
+        "see methods in pat::Jet.");
+    return 0.0;
+  }
+}
+
+// save a JER correction factor
+void Jet::saveJerFactor(float jerFactor_) {
+  jerFactor = jerFactor_;
+  jerFactorValid = true;
+}
+
+// reset a saved JER correction factor
+void Jet::resetJerFactor() {
+  jerFactor = 0.0;
+  jerFactorValid = false;
 }

--- a/DataFormats/PatCandidates/src/Jet.cc
+++ b/DataFormats/PatCandidates/src/Jet.cc
@@ -634,8 +634,14 @@ float Jet::jerFactor() const {
 
 // save a JER correction factor
 void Jet::setJerFactor(float jerFactor) {
-  jerFactor_ = jerFactor;
-  jerFactorValid_ = true;
+  if (isJerFactorValid()) {
+    throw cms::Exception(
+        "Setting a JER factor although the JER factor was already set before."
+        "Please reset the JER factor before setting a new one, see methods in pat::Jet");
+  } else {
+    jerFactor_ = jerFactor;
+    jerFactorValid_ = true;
+  }
 }
 
 // reset a saved JER correction factor

--- a/DataFormats/PatCandidates/src/MET.cc
+++ b/DataFormats/PatCandidates/src/MET.cc
@@ -342,9 +342,8 @@ void MET::setUncShift(double px, double py, double sumEt, METUncertainty shift, 
     //changing reference to only get the uncertainty shift and not the smeared one
     // which is performed independently
     shift = (MET::METUncertainty)(METUncertainty::METUncertaintySize + shift + 1);
-    const PackedMETUncertainty &ref = uncertainties_[METUncertainty::NoShift];
-    uncertainties_[shift].set(
-        px + ref.dpx() - this->px(), py + ref.dpy() - this->py(), sumEt + ref.dsumEt() - this->sumEt());
+    const PackedMETUncertainty &ref = corrections_[METCorrectionType::Smear];
+    uncertainties_[shift].set(px - ref.dpx() - this->px(), py - ref.dpy() - this->py(), sumEt - ref.dsumEt() - this->sumEt() );
   } else
     uncertainties_[shift].set(px - this->px(), py - this->py(), sumEt - this->sumEt());
 }

--- a/DataFormats/PatCandidates/src/MET.cc
+++ b/DataFormats/PatCandidates/src/MET.cc
@@ -343,7 +343,8 @@ void MET::setUncShift(double px, double py, double sumEt, METUncertainty shift, 
     // which is performed independently
     shift = (MET::METUncertainty)(METUncertainty::METUncertaintySize + shift + 1);
     const PackedMETUncertainty &ref = corrections_[METCorrectionType::Smear];
-    uncertainties_[shift].set(px - ref.dpx() - this->px(), py - ref.dpy() - this->py(), sumEt - ref.dsumEt() - this->sumEt() );
+    uncertainties_[shift].set(
+        px - ref.dpx() - this->px(), py - ref.dpy() - this->py(), sumEt - ref.dsumEt() - this->sumEt());
   } else
     uncertainties_[shift].set(px - this->px(), py - this->py(), sumEt - this->sumEt());
 }

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -262,9 +262,6 @@
    <version ClassVersion="11" checksum="4153489469"/>
    <version ClassVersion="10" checksum="3393361159"/>
   </class>
-  <ioread sourceClass = "pat::Jet" version="[1-17]" targetClass="pat::Jet" source="" target="jerFactorValid_">
-    <![CDATA[jerFactorValid_ = false;]]>
-  </ioread>
   <ioread sourceClass = "pat::Jet" version="[1-11]" targetClass="pat::Jet" source="int partonFlavour_" target="jetFlavourInfo_">
     <![CDATA[jetFlavourInfo_ = reco::JetFlavourInfo(0,onfile.partonFlavour_);]]>
   </ioread>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -248,7 +248,8 @@
              newObj->setPflowIsolationVariables(pfIsoVar);]]>
   </ioread>
 
-  <class name="pat::Jet"  ClassVersion="17">
+  <class name="pat::Jet"  ClassVersion="18">
+   <version ClassVersion="18" checksum="1291486363"/>
    <version ClassVersion="17" checksum="739868501"/>
    <field name="daughtersTemp_" transient="true"/>
    <version ClassVersion="16" checksum="4069285947"/>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -249,7 +249,7 @@
   </ioread>
 
   <class name="pat::Jet"  ClassVersion="18">
-   <version ClassVersion="18" checksum="1291486363"/>
+   <version ClassVersion="18" checksum="3195476741"/>
    <version ClassVersion="17" checksum="739868501"/>
    <field name="daughtersTemp_" transient="true"/>
    <version ClassVersion="16" checksum="4069285947"/>
@@ -262,6 +262,9 @@
    <version ClassVersion="11" checksum="4153489469"/>
    <version ClassVersion="10" checksum="3393361159"/>
   </class>
+  <ioread sourceClass = "pat::Jet" version="[1-17]" targetClass="pat::Jet" source="" target="jerFactorValid_">
+    <![CDATA[jerFactorValid_ = false;]]>
+  </ioread>
   <ioread sourceClass = "pat::Jet" version="[1-11]" targetClass="pat::Jet" source="int partonFlavour_" target="jetFlavourInfo_">
     <![CDATA[jetFlavourInfo_ = reco::JetFlavourInfo(0,onfile.partonFlavour_);]]>
   </ioread>

--- a/JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
+++ b/JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
@@ -66,14 +66,10 @@ namespace PFJetMETcorrInputProducer_namespace {
   // therefore general template just returns 1
   // specialized template for pat::Jets returns desired userFloat value if available
   template <typename T>
-  class RetrieveJerT
-  {
-    public:
-      RetrieveJerT(){}
-      float operator()(const T& jet) const
-      {
-        return 1.0;
-      }
+  class RetrieveJerT {
+  public:
+    RetrieveJerT() {}
+    float operator()(const T& jet) const { return 1.0; }
   };
 
 }  // namespace PFJetMETcorrInputProducer_namespace
@@ -213,7 +209,7 @@ private:
         corrJetP4 = jetCorrExtractor_(jet, jetCorr.product(), jetCorrEtaMax_, &rawJetP4);
       // retrieve JER factors in case of pat::Jets (done via specialized template defined for pat::Jets) and apply it
       const static PFJetMETcorrInputProducer_namespace::RetrieveJerT<T> retrieveJER{};
-      corrJetP4*=retrieveJER(jet);
+      corrJetP4 *= retrieveJER(jet);
 
       if (corrJetP4.pt() > type1JetPtThreshold_) {
         reco::Candidate::LorentzVector rawJetP4offsetCorr = rawJetP4;

--- a/JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
+++ b/JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
@@ -62,9 +62,9 @@ namespace PFJetMETcorrInputProducer_namespace {
   };
 
   // functor to retrieve JER factors of jets
-  // only possible for pat::Jets because of their userFloat ability
-  // therefore general template just returns 1
-  // specialized template for pat::Jets returns desired userFloat value if available
+  // for pat::Jet a previously saved JER factor is retrieved
+  // general template just returns 1
+  // specialized template for pat::Jet returns desired JER correction value if available
   template <typename T>
   class RetrieveJerT {
   public:

--- a/JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
+++ b/JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
@@ -61,6 +61,21 @@ namespace PFJetMETcorrInputProducer_namespace {
     reco::Candidate::LorentzVector operator()(const T& jet) const { return jet.p4(); }
   };
 
+  // functor to retrieve JER factors of jets
+  // only possible for pat::Jets because of their userFloat ability
+  // therefore general template just returns 1
+  // specialized template for pat::Jets returns desired userFloat value if available
+  template <typename T>
+  class RetrieveJerT
+  {
+    public:
+      RetrieveJerT(){}
+      float operator()(const T& jet) const
+      {
+        return 1.0;
+      }
+  };
+
 }  // namespace PFJetMETcorrInputProducer_namespace
 
 template <typename T, typename Textractor>
@@ -196,6 +211,9 @@ private:
         corrJetP4 = jetCorrExtractor_(jet, jetCorrLabel_.label(), jetCorrEtaMax_, &rawJetP4);
       else
         corrJetP4 = jetCorrExtractor_(jet, jetCorr.product(), jetCorrEtaMax_, &rawJetP4);
+      // retrieve JER factors in case of pat::Jets (done via specialized template defined for pat::Jets) and apply it
+      const static PFJetMETcorrInputProducer_namespace::RetrieveJerT<T> retrieveJER{};
+      corrJetP4*=retrieveJER(jet);
 
       if (corrJetP4.pt() > type1JetPtThreshold_) {
         reco::Candidate::LorentzVector rawJetP4offsetCorr = rawJetP4;

--- a/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
+++ b/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
@@ -288,7 +288,7 @@ public:
       }
 
       T smearedJet = jet;
-      SmearedJetProducer_namespace::SmearJet(smearedJet,smearFactor);
+      SmearedJetProducer_namespace::SmearJet(smearedJet, smearFactor);
 
       if (m_debug) {
         std::cout << "smeared jet (" << smearFactor << "):  pt: " << smearedJet.pt() << "  eta: " << smearedJet.eta()

--- a/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
+++ b/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
@@ -104,6 +104,7 @@ namespace SmearedJetProducer_namespace {
   template <>
   inline void SmearJet<pat::Jet>(pat::Jet& jet, float smearfactor) {
     jet.scaleEnergy(smearfactor);
+    jet.resetJerFactor();
     jet.setJerFactor(smearfactor);
   }
 }  // namespace SmearedJetProducer_namespace

--- a/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
+++ b/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
@@ -104,7 +104,7 @@ namespace SmearedJetProducer_namespace {
   template <>
   inline void SmearJet<pat::Jet>(pat::Jet& jet, float smearfactor) {
     jet.scaleEnergy(smearfactor);
-    jet.saveJerFactor(smearfactor);
+    jet.setJerFactor(smearfactor);
   }
 }  // namespace SmearedJetProducer_namespace
 

--- a/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
+++ b/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
@@ -288,7 +288,7 @@ public:
       }
 
       T smearedJet = jet;
-      smearedJet.scaleEnergy(smearFactor);
+      SmearedJetProducer_namespace::SmearJet(smearedJet,smearFactor);
 
       if (m_debug) {
         std::cout << "smeared jet (" << smearFactor << "):  pt: " << smearedJet.pt() << "  eta: " << smearedJet.eta()

--- a/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
+++ b/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
@@ -26,6 +26,7 @@
 #include "DataFormats/JetReco/interface/GenJet.h"
 #include "DataFormats/JetReco/interface/GenJetCollection.h"
 #include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/PatCandidates/interface/Jet.h"
 
 #include "JetMETCorrections/Modules/interface/JetResolution.h"
 

--- a/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
+++ b/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
@@ -101,7 +101,7 @@ namespace SmearedJetProducer_namespace {
   }
   // template specialization for pat::Jets to store the JER factor
   template <>
-  void SmearJet<pat::Jet>(pat::Jet& jet, float smearfactor) {
+  inline void SmearJet<pat::Jet>(pat::Jet& jet, float smearfactor) {
     jet.scaleEnergy(smearfactor);
     jet.addUserFloat("SmearFactor", smearfactor);
   }

--- a/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
+++ b/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
@@ -93,6 +93,20 @@ namespace pat {
   };
 };  // namespace pat
 
+namespace SmearedJetProducer_namespace {
+  // template function to apply JER
+  template <typename T>
+  void SmearJet(T& jet, float smearfactor) {
+    jet.scaleEnergy(smearfactor);
+  }
+  // template specialization for pat::Jets to store the JER factor
+  template <>
+  void SmearJet<pat::Jet>(pat::Jet& jet, float smearfactor) {
+    jet.scaleEnergy(smearfactor);
+    jet.addUserFloat("SmearFactor", smearfactor);
+  }
+}  // namespace SmearedJetProducer_namespace
+
 template <typename T>
 class SmearedJetProducerT : public edm::stream::EDProducer<> {
   using JetCollection = std::vector<T>;

--- a/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
+++ b/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
@@ -104,7 +104,7 @@ namespace SmearedJetProducer_namespace {
   template <>
   inline void SmearJet<pat::Jet>(pat::Jet& jet, float smearfactor) {
     jet.scaleEnergy(smearfactor);
-    jet.addUserFloat("SmearFactor", smearfactor);
+    jet.saveJerFactor(smearfactor);
   }
 }  // namespace SmearedJetProducer_namespace
 

--- a/PhysicsTools/PatUtils/plugins/PATPFJetMETcorrInputProducer.cc
+++ b/PhysicsTools/PatUtils/plugins/PATPFJetMETcorrInputProducer.cc
@@ -30,7 +30,7 @@ namespace PFJetMETcorrInputProducer_namespace {
         uncorrected_jet = jet.p4();
       // remove JER correction factor from pat::Jets
       if (jet.isJerFactorValid()) {
-        uncorrected_jet *= (1.0 / jet.loadJerFactor());
+        uncorrected_jet *= (1.0 / jet.jerFactor());
       }
       return uncorrected_jet;
     }
@@ -45,7 +45,7 @@ namespace PFJetMETcorrInputProducer_namespace {
     RetrieveJerT() {}
     float operator()(const pat::Jet& jet) const {
       if (jet.isJerFactorValid()) {
-        return jet.loadJerFactor();
+        return jet.jerFactor();
       } else
         return 1.0;
     }

--- a/PhysicsTools/PatUtils/plugins/PATPFJetMETcorrInputProducer.cc
+++ b/PhysicsTools/PatUtils/plugins/PATPFJetMETcorrInputProducer.cc
@@ -29,8 +29,8 @@ namespace PFJetMETcorrInputProducer_namespace {
       else
         uncorrected_jet = jet.p4();
       // remove JER correction factor from pat::Jets
-      if (jet.hasUserFloat("SmearFactor")) {
-        uncorrected_jet *= (1.0 / jet.userFloat("SmearFactor"));
+      if (jet.isJerFactorValid()) {
+        uncorrected_jet *= (1.0 / jet.loadJerFactor());
       }
       return uncorrected_jet;
     }
@@ -44,8 +44,8 @@ namespace PFJetMETcorrInputProducer_namespace {
   public:
     RetrieveJerT() {}
     float operator()(const pat::Jet& jet) const {
-      if (jet.hasUserFloat("SmearFactor")) {
-        return jet.userFloat("SmearFactor");
+      if (jet.isJerFactorValid()) {
+        return jet.loadJerFactor();
       } else
         return 1.0;
     }

--- a/PhysicsTools/PatUtils/plugins/PATPFJetMETcorrInputProducer.cc
+++ b/PhysicsTools/PatUtils/plugins/PATPFJetMETcorrInputProducer.cc
@@ -16,8 +16,8 @@ namespace PFJetMETcorrInputProducer_namespace {
     bool isPatJet(const pat::Jet& jet) const { return true; }
   };
 
-  // template specialization for pat::Jets
-  // remove JER correction if JER factor was saved as userFloat previously
+  // template specialization for pat::Jet
+  // remove JER correction if JER factor was saved previously
   template <>
   class RawJetExtractorT<pat::Jet> {
   public:

--- a/PhysicsTools/PatUtils/plugins/PATPFJetMETcorrInputProducer.cc
+++ b/PhysicsTools/PatUtils/plugins/PATPFJetMETcorrInputProducer.cc
@@ -29,8 +29,8 @@ namespace PFJetMETcorrInputProducer_namespace {
       else
         uncorrected_jet = jet.p4();
       // remove JER correction factor from pat::Jets
-      if(jet.hasUserFloat("SmearFactor")) {
-           uncorrected_jet*=(1.0/jet.userFloat("SmearFactor"));
+      if (jet.hasUserFloat("SmearFactor")) {
+        uncorrected_jet *= (1.0 / jet.userFloat("SmearFactor"));
       }
       return uncorrected_jet;
     }
@@ -40,17 +40,15 @@ namespace PFJetMETcorrInputProducer_namespace {
   // retrieve JER factor if it was saved previously
   // otherwise just return 1
   template <>
-  class RetrieveJerT<pat::Jet>
-  {
-    public:
-      RetrieveJerT(){}
-      float operator()(const pat::Jet& jet) const
-      {
-        if(jet.hasUserFloat("SmearFactor")) {
-            return jet.userFloat("SmearFactor");
-        }
-        else return 1.0;
-      }
+  class RetrieveJerT<pat::Jet> {
+  public:
+    RetrieveJerT() {}
+    float operator()(const pat::Jet& jet) const {
+      if (jet.hasUserFloat("SmearFactor")) {
+        return jet.userFloat("SmearFactor");
+      } else
+        return 1.0;
+    }
   };
 
 }  // namespace PFJetMETcorrInputProducer_namespace

--- a/PhysicsTools/PatUtils/plugins/SmearedJetProducer.cc
+++ b/PhysicsTools/PatUtils/plugins/SmearedJetProducer.cc
@@ -1,7 +1,8 @@
+#include "PhysicsTools/PatUtils/interface/SmearedJetProducerT.h"
+
 #include "DataFormats/JetReco/interface/CaloJet.h"
 #include "DataFormats/JetReco/interface/PFJet.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
-#include "PhysicsTools/PatUtils/interface/SmearedJetProducerT.h"
 
 typedef SmearedJetProducerT<reco::CaloJet> SmearedCaloJetProducer;
 typedef SmearedJetProducerT<reco::PFJet> SmearedPFJetProducer;

--- a/PhysicsTools/PatUtils/plugins/SmearedJetProducer.cc
+++ b/PhysicsTools/PatUtils/plugins/SmearedJetProducer.cc
@@ -1,21 +1,6 @@
 #include "DataFormats/JetReco/interface/CaloJet.h"
 #include "DataFormats/JetReco/interface/PFJet.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
-
-namespace SmearedJetProducer_namespace {
-  // template function to apply JER
-  template <typename T>
-  void SmearJet(T& jet, float smearfactor) {
-    jet.scaleEnergy(smearfactor);
-  }
-  // template specialization for pat::Jets to store the JER factor
-  template <>
-  void SmearJet<pat::Jet>(pat::Jet& jet, float smearfactor) {
-    jet.scaleEnergy(smearfactor);
-    jet.addUserFloat("SmearFactor", smearfactor);
-  }
-}  // namespace SmearedJetProducer_namespace
-
 #include "PhysicsTools/PatUtils/interface/SmearedJetProducerT.h"
 
 typedef SmearedJetProducerT<reco::CaloJet> SmearedCaloJetProducer;

--- a/PhysicsTools/PatUtils/plugins/SmearedJetProducer.cc
+++ b/PhysicsTools/PatUtils/plugins/SmearedJetProducer.cc
@@ -3,18 +3,18 @@
 #include "DataFormats/PatCandidates/interface/Jet.h"
 
 namespace SmearedJetProducer_namespace {
-    // template function to apply JER
-    template <typename T>
-    void SmearJet(T& jet, float smearfactor) {
-        jet.scaleEnergy(smearfactor);
-    }
-    // template specialization for pat::Jets to store the JER factor
-    template <>
-    void SmearJet<pat::Jet>(pat::Jet& jet, float smearfactor) {
-        jet.scaleEnergy(smearfactor);
-        jet.addUserFloat("SmearFactor",smearfactor);
-    }
-}
+  // template function to apply JER
+  template <typename T>
+  void SmearJet(T& jet, float smearfactor) {
+    jet.scaleEnergy(smearfactor);
+  }
+  // template specialization for pat::Jets to store the JER factor
+  template <>
+  void SmearJet<pat::Jet>(pat::Jet& jet, float smearfactor) {
+    jet.scaleEnergy(smearfactor);
+    jet.addUserFloat("SmearFactor", smearfactor);
+  }
+}  // namespace SmearedJetProducer_namespace
 
 #include "PhysicsTools/PatUtils/interface/SmearedJetProducerT.h"
 

--- a/PhysicsTools/PatUtils/plugins/SmearedJetProducer.cc
+++ b/PhysicsTools/PatUtils/plugins/SmearedJetProducer.cc
@@ -1,8 +1,22 @@
-#include "PhysicsTools/PatUtils/interface/SmearedJetProducerT.h"
-
 #include "DataFormats/JetReco/interface/CaloJet.h"
 #include "DataFormats/JetReco/interface/PFJet.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
+
+namespace SmearedJetProducer_namespace {
+    // template function to apply JER
+    template <typename T>
+    void SmearJet(T& jet, float smearfactor) {
+        jet.scaleEnergy(smearfactor);
+    }
+    // template specialization for pat::Jets to store the JER factor
+    template <>
+    void SmearJet<pat::Jet>(pat::Jet& jet, float smearfactor) {
+        jet.scaleEnergy(smearfactor);
+        jet.addUserFloat("SmearFactor",smearfactor);
+    }
+}
+
+#include "PhysicsTools/PatUtils/interface/SmearedJetProducerT.h"
 
 typedef SmearedJetProducerT<reco::CaloJet> SmearedCaloJetProducer;
 typedef SmearedJetProducerT<reco::PFJet> SmearedPFJetProducer;


### PR DESCRIPTION
#### PR description:

This pull request fixes the incorrect calculation of the nominal smeared missing transverse energy (MET). The underyling problem is the application of the JER correction factors. These factors are applied in PhysicsTools/PatUtils/interface/SmearedJetProducerT.h but later not considered when reverting to the uncorrected jets in  JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h.
This results in the problem that the JER correction factors in the smeared MET calculation effectively cancels and therefore the smeared MET is basically the same as the regular type1-corrected MET. After the changes shown below, the nominal smeared MET distributions from MiniAOD are similar to the ones obtained from NanoAOD.

This pull request includes the following:

PhysicsTools/PatUtils/plugins/SmearedJetProducer.cc
- adds a template function (SmearJet in SmearedJetProducer_namespace) to apply the JER
- if the type of the jet is not pat::Jet it reproduces what has been done so far (using the scaleEnergy function to apply the JER factor to the jet)
- if the jet is of type pat::Jet, it does the same but additionally adds the JER factor as a userFloat to the pat::Jet (needed to later remove JER from the jets in the corresponding MET module)

PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
- use the template function explained above

PhysicsTools/PatUtils/plugins/PATPFJetMETcorrInputProducer.cc
- edit pat::Jet template specialization of the already existing RawJetExtractor class to consider a possible JER correction factor, which was added as a userFloat previously, during the jet correction removal  (if a JER factor was applied, it is now removed by applying 1/factor)
- pat::Jet template specialization, which retrieves a previously saved JER factor, of the template class/functor explained below

JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
- add a template class/functor to retrieve JER correction factors
- in generic implementation it only applies 1 as a factor therefore doing nothing
- in case of pat::Jet, see above

Finally, there is also a mistake when saving the JERup and JERdown varied smearedMET. The different contributions of the nominal smeared MET correction and the JERup and JERdown variations are not separated correctly from on another. After the changes shown below, the varied smeared MET distributions from MiniAOD are similar to the ones obtained from NanoAOD.

DataFormats/PatCandidates/src/MET.cc
- to get the corrections/deltas for the JER variations of the smeared MET, the calculation now takes the up/down-varied smeared MET (px,py,...) and subtracts the contributions from the nominal smeared MET corrections (ref.dpx(),ref.dpy(),...) as well as the nominal type1-corrected MET (this->px(),this->py(),...)
- the previous implementation is a mystery to me :D

#### PR validation:

- 'runTheMatrix.py -l limited -i all' worked besides some workflows which had CMSDAS errors despite a working certificate
- 'scram b runtest' worked
