### PR TITLE
Updated DQMOffline/Muon package for Run3 

### DIFF
--- a/DQMOffline/Muon/interface/MuonIsolationDQM.h
+++ b/DQMOffline/Muon/interface/MuonIsolationDQM.h
@@ -63,7 +63,6 @@ class MuonIsolationDQM : public DQMEDAnalyzer {
   typedef edm::Handle<reco::IsoDepositMap> MuIsoDepHandle;
   typedef const reco::IsoDeposit MuIsoDepRef;
 
-
 public:
   //---------methods----------------------------
   explicit MuonIsolationDQM(const edm::ParameterSet&);
@@ -87,7 +86,6 @@ private:
   TH1* GetTH1FromMonitorElement(MonitorElement* me);
 
   //----------Static Variables---------------
-
 
   int vtxBin_;
   double vtxMin_;

--- a/DQMOffline/Muon/interface/MuonIsolationDQM.h
+++ b/DQMOffline/Muon/interface/MuonIsolationDQM.h
@@ -63,6 +63,7 @@ class MuonIsolationDQM : public DQMEDAnalyzer {
   typedef edm::Handle<reco::IsoDepositMap> MuIsoDepHandle;
   typedef const reco::IsoDeposit MuIsoDepRef;
 
+
 public:
   //---------methods----------------------------
   explicit MuonIsolationDQM(const edm::ParameterSet&);
@@ -86,6 +87,11 @@ private:
   TH1* GetTH1FromMonitorElement(MonitorElement* me);
 
   //----------Static Variables---------------
+
+
+  int vtxBin_;
+  double vtxMin_;
+  double vtxMax_;
 
   //Collection labels
   edm::EDGetTokenT<reco::VertexCollection> theVertexCollectionLabel_;

--- a/DQMOffline/Muon/python/EfficencyPlotter_cfi.py
+++ b/DQMOffline/Muon/python/EfficencyPlotter_cfi.py
@@ -110,45 +110,41 @@ effPlotterTightMiniAOD = DQMEDHarvester("EfficiencyPlotter",
 effPlotter=cms.Sequence(effPlotterLoose*effPlotterMedium*effPlotterTight)
 effPlotter_miniAOD=cms.Sequence(effPlotterLooseMiniAOD*effPlotterMediumMiniAOD*effPlotterTightMiniAOD)   
 
-effPlotterLoose_Phase2=effPlotterLoose.clone()
-effPlotterLoose_Phase2.vtxBin=20
-effPlotterLoose_Phase2.vtxMin=149.5
-effPlotterLoose_Phase2.vtxMax=249.5
-
-
-effPlotterMedium_Phase2=effPlotterMedium.clone()                                                                                            
-effPlotterMedium_Phase2.vtxBin=20                                                                                                           
-effPlotterMedium_Phase2.vtxMin=149.5                                                                                                        
-effPlotterMedium_Phase2.vtxMax=249.5 
-
-
-effPlotterTight_Phase2=effPlotterTight.clone()                                                                                              
-effPlotterTight_Phase2.vtxBin=20                                                                                                           
-effPlotterTight_Phase2.vtxMin=149.5                                                                                                         
-effPlotterTight_Phase2.vtxMax=249.5 
-
-effPlotterLooseMiniAOD_Phase2=effPlotterLooseMiniAOD.clone()                                                                                
-effPlotterLooseMiniAOD_Phase2.vtxBin=20                                                                                                     
-effPlotterLooseMiniAOD_Phase2.vtxMin=149.5                                                                                                 
-effPlotterLooseMiniAOD_Phase2.vtxMax=249.5                                                                                                
-
-effPlotterMediumMiniAOD_Phase2=effPlotterMediumMiniAOD.clone()                                                                              
-effPlotterMediumMiniAOD_Phase2.vtxBin=20                                                                                                   
-effPlotterMediumMiniAOD_Phase2.vtxMin=149.5                                                                                                 
-effPlotterMediumMiniAOD_Phase2.vtxMax=249.5                                                                                                
-
-effPlotterTightMiniAOD_Phase2=effPlotterTightMiniAOD.clone()                                                                                
-effPlotterTightMiniAOD_Phase2.vtxBin=20                                                                                                     
-effPlotterTightMiniAOD_Phase2.vtxMin=149.5                                                                                                  
-effPlotterTightMiniAOD_Phase2.vtxMax=249.5        
+effPlotterLoose_Phase2=effPlotterLoose.clone(
+    vtxBin=20
+    vtxMin=149.5
+    vtxMax=249.5
+)
+effPlotterMedium_Phase2=effPlotterMedium.clone(
+    vtxBin=20
+    vtxMin=149.5
+    vtxMax=249.5                                                                                           
+)
+effPlotterTight_Phase2=effPlotterTight.clone(
+    vtxBin=20
+    vtxMin=149.5
+    vtxMax=249.5                                                                                              
+)
+effPlotterLooseMiniAOD_Phase2=effPlotterLooseMiniAOD.clone(                                                                                
+    vtxBin=20
+    vtxMin=149.5
+    vtxMax=249.5
+)
+effPlotterMediumMiniAOD_Phase2=effPlotterMediumMiniAOD.clone(
+    vtxBin=20
+    vtxMin=149.5
+    vtxMax=249.5
+)                                                                              
+effPlotterTightMiniAOD_Phase2=effPlotterTightMiniAOD.clone(
+    vtxBin=20
+    vtxMin=149.5
+    vtxMax=249.5                                                                                
+)
 
 effPlotter_Phase2=cms.Sequence(effPlotterLoose_Phase2*effPlotterMedium_Phase2*effPlotterTight_Phase2)
 effPlotter_miniAOD_Phase2=cms.Sequence(effPlotterLooseMiniAOD_Phase2*effPlotterMediumMiniAOD_Phase2*effPlotterTightMiniAOD_Phase2)                                    
-                                                                                                             
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon                                                                         
 phase2_muon.toReplaceWith(effPlotter,effPlotter_Phase2)     
 phase2_muon.toReplaceWith(effPlotter_miniAOD,effPlotter_miniAOD_Phase2)  
-
-
 
 

--- a/DQMOffline/Muon/python/EfficencyPlotter_cfi.py
+++ b/DQMOffline/Muon/python/EfficencyPlotter_cfi.py
@@ -107,6 +107,8 @@ effPlotterTightMiniAOD = DQMEDHarvester("EfficiencyPlotter",
                                           )
 
 
+effPlotter=cms.Sequence(effPlotterLoose*effPlotterMedium*effPlotterTight)
+effPlotter_miniAOD=cms.Sequence(effPlotterLooseMiniAOD*effPlotterMediumMiniAOD*effPlotterTightMiniAOD)   
 
 effPlotterLoose_Phase2=effPlotterLoose.clone()
 effPlotterLoose_Phase2.vtxBin=20
@@ -125,9 +127,28 @@ effPlotterTight_Phase2.vtxBin=20
 effPlotterTight_Phase2.vtxMin=149.5                                                                                                         
 effPlotterTight_Phase2.vtxMax=249.5 
 
+effPlotterLooseMiniAOD_Phase2=effPlotterLooseMiniAOD.clone()                                                                                
+effPlotterLooseMiniAOD_Phase2.vtxBin=20                                                                                                     
+effPlotterLooseMiniAOD_Phase2.vtxMin=149.5                                                                                                 
+effPlotterLooseMiniAOD_Phase2.vtxMax=249.5                                                                                                
 
+effPlotterMediumMiniAOD_Phase2=effPlotterMediumMiniAOD.clone()                                                                              
+effPlotterMediumMiniAOD_Phase2.vtxBin=20                                                                                                   
+effPlotterMediumMiniAOD_Phase2.vtxMin=149.5                                                                                                 
+effPlotterMediumMiniAOD_Phase2.vtxMax=249.5                                                                                                
 
+effPlotterTightMiniAOD_Phase2=effPlotterTightMiniAOD.clone()                                                                                
+effPlotterTightMiniAOD_Phase2.vtxBin=20                                                                                                     
+effPlotterTightMiniAOD_Phase2.vtxMin=149.5                                                                                                  
+effPlotterTightMiniAOD_Phase2.vtxMax=249.5        
+
+effPlotter_Phase2=cms.Sequence(effPlotterLoose_Phase2*effPlotterMedium_Phase2*effPlotterTight_Phase2)
+effPlotter_miniAOD_Phase2=cms.Sequence(effPlotterLooseMiniAOD_Phase2*effPlotterMediumMiniAOD_Phase2*effPlotterTightMiniAOD_Phase2)                                    
+                                                                                                             
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon                                                                         
-phase2_muon.toReplaceWith(effPlotterLoose, effPlotterLoose_Phase2)
-phase2_muon.toReplaceWith(effPlotterMedium, effPlotterMedium_Phase2)        
-phase2_muon.toReplaceWith(effPlotterTight, effPlotterTight_Phase2)        
+phase2_muon.toReplaceWith(effPlotter,effPlotter_Phase2)     
+phase2_muon.toReplaceWith(effPlotter_miniAOD,effPlotter_miniAOD_Phase2)  
+
+
+
+

--- a/DQMOffline/Muon/python/EfficencyPlotter_cfi.py
+++ b/DQMOffline/Muon/python/EfficencyPlotter_cfi.py
@@ -111,33 +111,33 @@ effPlotter=cms.Sequence(effPlotterLoose*effPlotterMedium*effPlotterTight)
 effPlotter_miniAOD=cms.Sequence(effPlotterLooseMiniAOD*effPlotterMediumMiniAOD*effPlotterTightMiniAOD)   
 
 effPlotterLoose_Phase2=effPlotterLoose.clone(
-    vtxBin=20
-    vtxMin=149.5
+    vtxBin=20,
+    vtxMin=149.5,
     vtxMax=249.5
-)
+    )
 effPlotterMedium_Phase2=effPlotterMedium.clone(
-    vtxBin=20
-    vtxMin=149.5
+    vtxBin=20,
+    vtxMin=149.5,
     vtxMax=249.5                                                                                           
 )
 effPlotterTight_Phase2=effPlotterTight.clone(
-    vtxBin=20
-    vtxMin=149.5
+    vtxBin=20,
+    vtxMin=149.5,
     vtxMax=249.5                                                                                              
 )
 effPlotterLooseMiniAOD_Phase2=effPlotterLooseMiniAOD.clone(                                                                                
-    vtxBin=20
-    vtxMin=149.5
+    vtxBin=20,
+    vtxMin=149.5,
     vtxMax=249.5
 )
 effPlotterMediumMiniAOD_Phase2=effPlotterMediumMiniAOD.clone(
-    vtxBin=20
-    vtxMin=149.5
+    vtxBin=20,
+    vtxMin=149.5,
     vtxMax=249.5
 )                                                                              
 effPlotterTightMiniAOD_Phase2=effPlotterTightMiniAOD.clone(
-    vtxBin=20
-    vtxMin=149.5
+    vtxBin=20,
+    vtxMin=149.5,
     vtxMax=249.5                                                                                
 )
 

--- a/DQMOffline/Muon/python/EfficencyPlotter_cfi.py
+++ b/DQMOffline/Muon/python/EfficencyPlotter_cfi.py
@@ -12,9 +12,9 @@ effPlotterLoose = DQMEDHarvester("EfficiencyPlotter",
                                   etaMax = cms.double(2.5),
                                   phiMax = cms.double(3.2),
                                   ptMax  = cms.double(100),
-                                  vtxBin = cms.int32(10),
+                                  vtxBin = cms.int32(30),
                                   vtxMin = cms.double(0.5),
-                                  vtxMax = cms.double(40.5),
+                                  vtxMax = cms.double(149.5),
                                   MuonID = cms.string("Loose")
                                   )
 
@@ -30,9 +30,9 @@ effPlotterMedium = DQMEDHarvester("EfficiencyPlotter",
                                    etaMax = cms.double(2.5),
                                    phiMax = cms.double(3.2),
                                    ptMax  = cms.double(100),
-                                   vtxBin = cms.int32(10),
+                                   vtxBin = cms.int32(30),
                                    vtxMin = cms.double(0.5),
-                                   vtxMax = cms.double(40.5),
+                                   vtxMax = cms.double(149.5),
                                    MuonID = cms.string("Medium")
                                    )
 
@@ -48,9 +48,9 @@ effPlotterTight = DQMEDHarvester("EfficiencyPlotter",
                                   etaMax = cms.double(2.5),
                                   phiMax = cms.double(3.2),
                                   ptMax  = cms.double(100),
-                                  vtxBin = cms.int32(10),
+                                  vtxBin = cms.int32(30),
                                   vtxMin = cms.double(0.5),
-                                  vtxMax = cms.double(40.5),
+                                  vtxMax = cms.double(149.5),
                                   MuonID = cms.string("Tight")
                                   )
 effPlotterLooseMiniAOD = DQMEDHarvester("EfficiencyPlotter",
@@ -64,9 +64,9 @@ effPlotterLooseMiniAOD = DQMEDHarvester("EfficiencyPlotter",
                                           etaMax = cms.double(2.5),
                                           phiMax = cms.double(3.2),
                                           ptMax  = cms.double(100),
-                                          vtxBin = cms.int32(10),
+                                          vtxBin = cms.int32(30),
                                           vtxMin = cms.double(0.5),
-                                          vtxMax = cms.double(40.5),
+                                          vtxMax = cms.double(149.5),
                                           MuonID = cms.string("Loose")
                                           )
 
@@ -82,9 +82,9 @@ effPlotterMediumMiniAOD = DQMEDHarvester("EfficiencyPlotter",
                                            etaMax = cms.double(2.5),
                                            phiMax = cms.double(3.2),
                                            ptMax  = cms.double(100),
-                                           vtxBin = cms.int32(10),
+                                           vtxBin = cms.int32(30),
                                            vtxMin = cms.double(0.5),
-                                           vtxMax = cms.double(40.5),
+                                           vtxMax = cms.double(149.5),
                                            MuonID = cms.string("Medium")
                                            )
 
@@ -100,9 +100,9 @@ effPlotterTightMiniAOD = DQMEDHarvester("EfficiencyPlotter",
                                           etaMax = cms.double(2.5),
                                           phiMax = cms.double(3.2),
                                           ptMax  = cms.double(100),
-                                          vtxBin = cms.int32(10),
+                                          vtxBin = cms.int32(30),
                                           vtxMin = cms.double(0.5),
-                                          vtxMax = cms.double(40.5),
+                                          vtxMax = cms.double(149.5),
                                           MuonID = cms.string("Tight")
                                           )
 

--- a/DQMOffline/Muon/python/EfficencyPlotter_cfi.py
+++ b/DQMOffline/Muon/python/EfficencyPlotter_cfi.py
@@ -124,3 +124,10 @@ effPlotterTight_Phase2=effPlotterTight.clone()
 effPlotterTight_Phase2.vtxBin=20                                                                                                           
 effPlotterTight_Phase2.vtxMin=149.5                                                                                                         
 effPlotterTight_Phase2.vtxMax=249.5 
+
+
+
+from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon                                                                         
+phase2_muon.toReplaceWith(effPlotterLoose, effPlotterLoose_Phase2)
+phase2_muon.toReplaceWith(effPlotterMedium, effPlotterMedium_Phase2)        
+phase2_muon.toReplaceWith(effPlotterTight, effPlotterTight_Phase2)        

--- a/DQMOffline/Muon/python/EfficencyPlotter_cfi.py
+++ b/DQMOffline/Muon/python/EfficencyPlotter_cfi.py
@@ -107,3 +107,20 @@ effPlotterTightMiniAOD = DQMEDHarvester("EfficiencyPlotter",
                                           )
 
 
+
+effPlotterLoose_Phase2=effPlotterLoose.clone()
+effPlotterLoose_Phase2.vtxBin=20
+effPlotterLoose_Phase2.vtxMin=149.5
+effPlotterLoose_Phase2.vtxMax=249.5
+
+
+effPlotterMedium_Phase2=effPlotterMedium.clone()                                                                                            
+effPlotterMedium_Phase2.vtxBin=20                                                                                                           
+effPlotterMedium_Phase2.vtxMin=149.5                                                                                                        
+effPlotterMedium_Phase2.vtxMax=249.5 
+
+
+effPlotterTight_Phase2=effPlotterTight.clone()                                                                                              
+effPlotterTight_Phase2.vtxBin=20                                                                                                           
+effPlotterTight_Phase2.vtxMin=149.5                                                                                                         
+effPlotterTight_Phase2.vtxMax=249.5 

--- a/DQMOffline/Muon/python/muonAnalyzer_cff.py
+++ b/DQMOffline/Muon/python/muonAnalyzer_cff.py
@@ -23,12 +23,8 @@ muonAnalyzer = cms.Sequence(muonEnergyDepositAnalyzer*
                             TightMuonEfficiencyAnalyzer*
                             muonPFsequence*
                             muonRecoOneHLT)
-from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 
-from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
-phase2_muon.toReplaceWith(muonAnalyzer, muonAnalyzer.copyAndExclude([ # FIXME
-    muonEnergyDepositAnalyzer
-]))
+
 
 muonAnalyzer_miniAOD = cms.Sequence(muonRecoAnalyzer_miniAOD* 
                                     muonKinVsEtaAnalyzer_miniAOD*
@@ -49,3 +45,23 @@ muonAnalyzer_noHLT = cms.Sequence(muonEnergyDepositAnalyzer*
                                   MediumMuonEfficiencyAnalyzer*
                                   TightMuonEfficiencyAnalyzer*                                
                                   muonPFsequence)
+
+
+_muonAnalyzer_phase2=muonAnalyzer.clone()
+_muonAnalyzer_phase2 -= LooseMuonEfficiencyAnalyzer
+_muonAnalyzer_phase2 -= MediumMuonEfficiencyAnalyzer
+_muonAnalyzer_phase2 -= TightMuonEfficiencyAnalyzer
+_muonAnalyzer_phase2 -= muonRecoOneHLT
+_muonAnalyzer_phase2 += LooseMuonEfficiencyAnalyzer_Phase2
+_muonAnalyzer_phase2 += MediumMuonEfficiencyAnalyzer_Phase2                                                                                
+_muonAnalyzer_phase2 += TightMuonEfficiencyAnalyzer_Phase2
+
+
+
+
+
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel                                                                         
+from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon                                                                        
+phase2_muon.toReplaceWith(muonAnalyzer, _muonAnalyzer_phase2.copyAndExclude([ # FIXME                                                       
+    muonEnergyDepositAnalyzer                                                                                                               
+])) 

--- a/DQMOffline/Muon/python/muonAnalyzer_cff.py
+++ b/DQMOffline/Muon/python/muonAnalyzer_cff.py
@@ -18,9 +18,10 @@ muonAnalyzer = cms.Sequence(muonEnergyDepositAnalyzer*
                             staMuonSegmentAnalyzer*
                             muonKinVsEtaAnalyzer*
                             diMuonHistos*
-                            LooseMuonEfficiencyAnalyzer*
-                            MediumMuonEfficiencyAnalyzer*
-                            TightMuonEfficiencyAnalyzer*
+                            EfficiencyAnalyzer*
+                            #LooseMuonEfficiencyAnalyzer*
+                            #MediumMuonEfficiencyAnalyzer*
+                            #TightMuonEfficiencyAnalyzer*
                             muonPFsequence*
                             muonRecoOneHLT)
 
@@ -29,9 +30,10 @@ muonAnalyzer = cms.Sequence(muonEnergyDepositAnalyzer*
 muonAnalyzer_miniAOD = cms.Sequence(muonRecoAnalyzer_miniAOD* 
                                     muonKinVsEtaAnalyzer_miniAOD*
                                     diMuonHistos_miniAOD*
-                                    LooseMuonEfficiencyAnalyzer_miniAOD*
-                                    MediumMuonEfficiencyAnalyzer_miniAOD*
-                                    TightMuonEfficiencyAnalyzer_miniAOD*
+                                    EfficiencyAnalyzer_miniAOD*
+                                    #LooseMuonEfficiencyAnalyzer_miniAOD*
+                                    #MediumMuonEfficiencyAnalyzer_miniAOD*
+                                    #TightMuonEfficiencyAnalyzer_miniAOD*
                                     triggerMatchMonitor_miniAOD)
 
 muonAnalyzer_noHLT = cms.Sequence(muonEnergyDepositAnalyzer*
@@ -41,27 +43,12 @@ muonAnalyzer_noHLT = cms.Sequence(muonEnergyDepositAnalyzer*
                                   staMuonSegmentAnalyzer*
                                   muonKinVsEtaAnalyzer*
                                   diMuonHistos*
-                                  LooseMuonEfficiencyAnalyzer*
-                                  MediumMuonEfficiencyAnalyzer*
-                                  TightMuonEfficiencyAnalyzer*                                
+                                  EfficiencyAnalyzer* 
+                                  #LooseMuonEfficiencyAnalyzer*
+                                  #MediumMuonEfficiencyAnalyzer*
+                                  #TightMuonEfficiencyAnalyzer*                                
                                   muonPFsequence)
 
 
-_muonAnalyzer_phase2=muonAnalyzer.clone()
-_muonAnalyzer_phase2 -= LooseMuonEfficiencyAnalyzer
-_muonAnalyzer_phase2 -= MediumMuonEfficiencyAnalyzer
-_muonAnalyzer_phase2 -= TightMuonEfficiencyAnalyzer
-_muonAnalyzer_phase2 -= muonRecoOneHLT
-_muonAnalyzer_phase2 += LooseMuonEfficiencyAnalyzer_Phase2
-_muonAnalyzer_phase2 += MediumMuonEfficiencyAnalyzer_Phase2                                                                                
-_muonAnalyzer_phase2 += TightMuonEfficiencyAnalyzer_Phase2
 
 
-
-
-
-from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel                                                                         
-from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon                                                                        
-phase2_muon.toReplaceWith(muonAnalyzer, _muonAnalyzer_phase2.copyAndExclude([ # FIXME                                                       
-    muonEnergyDepositAnalyzer                                                                                                               
-])) 

--- a/DQMOffline/Muon/python/muonAnalyzer_cff.py
+++ b/DQMOffline/Muon/python/muonAnalyzer_cff.py
@@ -39,7 +39,3 @@ muonAnalyzer_noHLT = cms.Sequence(muonEnergyDepositAnalyzer*
                                   diMuonHistos*
                                   EfficiencyAnalyzer* 
                                   muonPFsequence)
-
-
-
-

--- a/DQMOffline/Muon/python/muonAnalyzer_cff.py
+++ b/DQMOffline/Muon/python/muonAnalyzer_cff.py
@@ -19,9 +19,6 @@ muonAnalyzer = cms.Sequence(muonEnergyDepositAnalyzer*
                             muonKinVsEtaAnalyzer*
                             diMuonHistos*
                             EfficiencyAnalyzer*
-                            #LooseMuonEfficiencyAnalyzer*
-                            #MediumMuonEfficiencyAnalyzer*
-                            #TightMuonEfficiencyAnalyzer*
                             muonPFsequence*
                             muonRecoOneHLT)
 
@@ -31,9 +28,6 @@ muonAnalyzer_miniAOD = cms.Sequence(muonRecoAnalyzer_miniAOD*
                                     muonKinVsEtaAnalyzer_miniAOD*
                                     diMuonHistos_miniAOD*
                                     EfficiencyAnalyzer_miniAOD*
-                                    #LooseMuonEfficiencyAnalyzer_miniAOD*
-                                    #MediumMuonEfficiencyAnalyzer_miniAOD*
-                                    #TightMuonEfficiencyAnalyzer_miniAOD*
                                     triggerMatchMonitor_miniAOD)
 
 muonAnalyzer_noHLT = cms.Sequence(muonEnergyDepositAnalyzer*
@@ -44,9 +38,6 @@ muonAnalyzer_noHLT = cms.Sequence(muonEnergyDepositAnalyzer*
                                   muonKinVsEtaAnalyzer*
                                   diMuonHistos*
                                   EfficiencyAnalyzer* 
-                                  #LooseMuonEfficiencyAnalyzer*
-                                  #MediumMuonEfficiencyAnalyzer*
-                                  #TightMuonEfficiencyAnalyzer*                                
                                   muonPFsequence)
 
 

--- a/DQMOffline/Muon/python/muonEfficiencyAnalyzer_cfi.py
+++ b/DQMOffline/Muon/python/muonEfficiencyAnalyzer_cfi.py
@@ -186,12 +186,12 @@ TightMuonEfficiencyAnalyzer_Phase2.vtxBin=20
 TightMuonEfficiencyAnalyzer_Phase2.vtxMax=249.5
 TightMuonEfficiencyAnalyzer_Phase2.vtxMin=149.5
 
-LooseMuonEfficiencyAnalyzer_Phase2=TightMuonEfficiencyAnalyzer.clone()                                                                      
+LooseMuonEfficiencyAnalyzer_Phase2=LooseMuonEfficiencyAnalyzer.clone()                                                                      
 LooseMuonEfficiencyAnalyzer_Phase2.vtxBin=20                                                                                                
 LooseMuonEfficiencyAnalyzer_Phase2.vtxMin=149.5  
 LooseMuonEfficiencyAnalyzer_Phase2.vtxMax=249.5
 
-MediumMuonEfficiencyAnalyzer_Phase2=TightMuonEfficiencyAnalyzer.clone()                                                                     
+MediumMuonEfficiencyAnalyzer_Phase2=MediumMuonEfficiencyAnalyzer.clone()                                                                    
 MediumMuonEfficiencyAnalyzer_Phase2.vtxBin=30                                                                                               
 MediumMuonEfficiencyAnalyzer_Phase2.vtxMin=149.5  
 MediumMuonEfficiencyAnalyzer_Phase2.vtxMax=249.5 

--- a/DQMOffline/Muon/python/muonEfficiencyAnalyzer_cfi.py
+++ b/DQMOffline/Muon/python/muonEfficiencyAnalyzer_cfi.py
@@ -173,13 +173,15 @@ MediumMuonEfficiencyAnalyzer_miniAOD = DQMEDAnalyzer('EfficiencyAnalyzer',
                                                       
                                                       vtxBin = cms.int32(30),
                                                       vtxMax = cms.double(149.5),
-                                                      vtxMin = cms.double(0.5),
-                                                      
+                                                      vtxMin = cms.double(0.5),                                                      
                                                       ID = cms.string("Medium"),
                                                       folder = cms.string("Muons_miniAOD/EfficiencyAnalyzer/")
-                                                      
                                                       )
 
+
+EfficiencyAnalyzer = cms.Sequence(TightMuonEfficiencyAnalyzer*LooseMuonEfficiencyAnalyzer*MediumMuonEfficiencyAnalyzer)
+
+EfficiencyAnalyzer_miniAOD = cms.Sequence(TightMuonEfficiencyAnalyzer_miniAOD*LooseMuonEfficiencyAnalyzer_miniAOD*MediumMuonEfficiencyAnalyzer_miniAOD)
 
 TightMuonEfficiencyAnalyzer_Phase2=TightMuonEfficiencyAnalyzer.clone()
 TightMuonEfficiencyAnalyzer_Phase2.vtxBin=20
@@ -192,6 +194,38 @@ LooseMuonEfficiencyAnalyzer_Phase2.vtxMin=149.5
 LooseMuonEfficiencyAnalyzer_Phase2.vtxMax=249.5
 
 MediumMuonEfficiencyAnalyzer_Phase2=MediumMuonEfficiencyAnalyzer.clone()                                                                    
-MediumMuonEfficiencyAnalyzer_Phase2.vtxBin=30                                                                                               
+MediumMuonEfficiencyAnalyzer_Phase2.vtxBin=20                                                                                               
 MediumMuonEfficiencyAnalyzer_Phase2.vtxMin=149.5  
 MediumMuonEfficiencyAnalyzer_Phase2.vtxMax=249.5 
+
+
+TightMuonEfficiencyAnalyzer_miniAOD_Phase2=TightMuonEfficiencyAnalyzer_miniAOD.clone()                                                      
+TightMuonEfficiencyAnalyzer_miniAOD_Phase2.vtxBin=20                                                                                       
+TightMuonEfficiencyAnalyzer_miniAOD_Phase2.vtxMax=249.5                                                                                     
+TightMuonEfficiencyAnalyzer_miniAOD_Phase2.vtxMin=149.5                                                                                    
+     
+
+LooseMuonEfficiencyAnalyzer_miniAOD_Phase2=LooseMuonEfficiencyAnalyzer_miniAOD.clone()                                                      
+LooseMuonEfficiencyAnalyzer_miniAOD_Phase2.vtxBin=20                                                                                       
+LooseMuonEfficiencyAnalyzer_miniAOD_Phase2.vtxMin=149.5                                                                                     
+LooseMuonEfficiencyAnalyzer_miniAOD_Phase2.vtxMax=249.5                                                                                    
+
+MediumMuonEfficiencyAnalyzer_miniAOD_Phase2=MediumMuonEfficiencyAnalyzer.clone()                                                           
+MediumMuonEfficiencyAnalyzer_miniAOD_Phase2.vtxBin=20                                                                                       
+MediumMuonEfficiencyAnalyzer_miniAOD_Phase2.vtxMin=149.5                                                                                    
+MediumMuonEfficiencyAnalyzer_miniAOD_Phase2.vtxMax=249.5                                                                                   
+                                                        
+
+EfficiencyAnalyzer_Phase2 = cms.Sequence(TightMuonEfficiencyAnalyzer_Phase2*LooseMuonEfficiencyAnalyzer_Phase2*MediumMuonEfficiencyAnalyzer_Phase2)
+
+EfficiencyAnalyzer_miniAOD_Phase2 = cms.Sequence(TightMuonEfficiencyAnalyzer_miniAOD_Phase2*LooseMuonEfficiencyAnalyzer_miniAOD_Phase2*MediumMuonEfficiencyAnalyzer_miniAOD_Phase2)                                                                                                    
+
+            
+from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon                                                                         
+phase2_muon.toReplaceWith(EfficiencyAnalyzer, EfficiencyAnalyzer_Phase2)                                                                   
+phase2_muon.toReplaceWith(EfficiencyAnalyzer_miniAOD, EfficiencyAnalyzer_miniAOD_Phase2)    
+                                                                                    
+
+
+
+

--- a/DQMOffline/Muon/python/muonEfficiencyAnalyzer_cfi.py
+++ b/DQMOffline/Muon/python/muonEfficiencyAnalyzer_cfi.py
@@ -184,38 +184,38 @@ EfficiencyAnalyzer = cms.Sequence(TightMuonEfficiencyAnalyzer*LooseMuonEfficienc
 EfficiencyAnalyzer_miniAOD = cms.Sequence(TightMuonEfficiencyAnalyzer_miniAOD*LooseMuonEfficiencyAnalyzer_miniAOD*MediumMuonEfficiencyAnalyzer_miniAOD)
 
 TightMuonEfficiencyAnalyzer_Phase2=TightMuonEfficiencyAnalyzer.clone(
-    vtxBin=20
-    vtxMin=149.5
+    vtxBin=20,
+    vtxMin=149.5,
     vtxMax=249.5
 )
 
 LooseMuonEfficiencyAnalyzer_Phase2=LooseMuonEfficiencyAnalyzer.clone(
-    vtxBin=20
-    vtxMin=149.5
+    vtxBin=20,
+    vtxMin=149.5,
     vtxMax=249.5 
 )                                                                     
 
 MediumMuonEfficiencyAnalyzer_Phase2=MediumMuonEfficiencyAnalyzer.clone(                                                                    
-    vtxBin=20
-    vtxMin=149.5
+    vtxBin=20,
+    vtxMin=149.5,
     vtxMax=249.5
 )
 
 TightMuonEfficiencyAnalyzer_miniAOD_Phase2=TightMuonEfficiencyAnalyzer_miniAOD.clone(                                                      
-    vtxBin=20
-    vtxMin=149.5
+    vtxBin=20,
+    vtxMin=149.5,
     vtxMax=249.5
 )
 
 LooseMuonEfficiencyAnalyzer_miniAOD_Phase2=LooseMuonEfficiencyAnalyzer_miniAOD.clone(
-    vtxBin=20
-    vtxMin=149.5
+    vtxBin=20,
+    vtxMin=149.5,
     vtxMax=249.5                                                      
 )
 
 MediumMuonEfficiencyAnalyzer_miniAOD_Phase2=MediumMuonEfficiencyAnalyzer.clone(
-    vtxBin=20
-    vtxMin=149.5
+    vtxBin=20,
+    vtxMin=149.5,
     vtxMax=249.5                                                           
 )
                                                         

--- a/DQMOffline/Muon/python/muonEfficiencyAnalyzer_cfi.py
+++ b/DQMOffline/Muon/python/muonEfficiencyAnalyzer_cfi.py
@@ -24,8 +24,8 @@ TightMuonEfficiencyAnalyzer = DQMEDAnalyzer('EfficiencyAnalyzer',
                                              phiMax = cms.double(3.2),
                                              phiMin = cms.double(-3.2),
                                              
-                                             vtxBin = cms.int32(10),
-                                             vtxMax = cms.double(40.5),
+                                             vtxBin = cms.int32(30),
+                                             vtxMax = cms.double(149.5),
                                              vtxMin = cms.double(0.5),
                                              
                                              ID = cms.string("Tight"),
@@ -52,8 +52,8 @@ TightMuonEfficiencyAnalyzer_miniAOD = DQMEDAnalyzer('EfficiencyAnalyzer',
                                                      phiMax = cms.double(3.2),
                                                      phiMin = cms.double(-3.2),
                                                      
-                                                     vtxBin = cms.int32(10),
-                                                     vtxMax = cms.double(40.5),
+                                                     vtxBin = cms.int32(30),
+                                                     vtxMax = cms.double(149.5),
                                                      vtxMin = cms.double(0.5),
                                                      
                                                      ID = cms.string("Tight"),
@@ -82,8 +82,8 @@ LooseMuonEfficiencyAnalyzer = DQMEDAnalyzer('EfficiencyAnalyzer',
                                              phiMax = cms.double(3.2),
                                              phiMin = cms.double(-3.2),
                                              
-                                             vtxBin = cms.int32(10),
-                                             vtxMax = cms.double(40.5),
+                                             vtxBin = cms.int32(30),
+                                             vtxMax = cms.double(149.5),
                                              vtxMin = cms.double(0.5),
                                              
                                              ID = cms.string("Loose"),
@@ -111,8 +111,8 @@ LooseMuonEfficiencyAnalyzer_miniAOD = DQMEDAnalyzer('EfficiencyAnalyzer',
                                                      phiMax = cms.double(3.2),
                                                      phiMin = cms.double(-3.2),
                                                      
-                                                     vtxBin = cms.int32(10),
-                                                     vtxMax = cms.double(40.5),
+                                                     vtxBin = cms.int32(30),
+                                                     vtxMax = cms.double(149.5),
                                                      vtxMin = cms.double(0.5),
 
                                                      ID = cms.string("Loose"),
@@ -142,13 +142,14 @@ MediumMuonEfficiencyAnalyzer = DQMEDAnalyzer('EfficiencyAnalyzer',
                                               phiMax = cms.double(3.2),
                                               phiMin = cms.double(-3.2),
                                               
-                                              vtxBin = cms.int32(10),
-                                              vtxMax = cms.double(40.5),
+                                              vtxBin = cms.int32(30),
+                                              vtxMax = cms.double(149.5),
                                               vtxMin = cms.double(0.5),
                                               
                                               ID = cms.string("Medium"),
                                               folder = cms.string("Muons/EfficiencyAnalyzer/")
                                               )
+
 MediumMuonEfficiencyAnalyzer_miniAOD = DQMEDAnalyzer('EfficiencyAnalyzer',
                                                       MuonServiceProxy,
                                                       MuonCollection  = cms.InputTag("slimmedMuons"),
@@ -170,11 +171,27 @@ MediumMuonEfficiencyAnalyzer_miniAOD = DQMEDAnalyzer('EfficiencyAnalyzer',
                                                       phiMax = cms.double(3.2),
                                                       phiMin = cms.double(-3.2),
                                                       
-                                                      vtxBin = cms.int32(10),
-                                                      vtxMax = cms.double(40.5),
+                                                      vtxBin = cms.int32(30),
+                                                      vtxMax = cms.double(149.5),
                                                       vtxMin = cms.double(0.5),
                                                       
                                                       ID = cms.string("Medium"),
                                                       folder = cms.string("Muons_miniAOD/EfficiencyAnalyzer/")
                                                       
                                                       )
+
+
+TightMuonEfficiencyAnalyzer_Phase2=TightMuonEfficiencyAnalyzer.clone()
+TightMuonEfficiencyAnalyzer_Phase2.vtxBin=20
+TightMuonEfficiencyAnalyzer_Phase2.vtxMax=249.5
+TightMuonEfficiencyAnalyzer_Phase2.vtxMin=149.5
+
+LooseMuonEfficiencyAnalyzer_Phase2=TightMuonEfficiencyAnalyzer.clone()                                                                      
+LooseMuonEfficiencyAnalyzer_Phase2.vtxBin=20                                                                                                
+LooseMuonEfficiencyAnalyzer_Phase2.vtxMin=149.5  
+LooseMuonEfficiencyAnalyzer_Phase2.vtxMax=249.5
+
+MediumMuonEfficiencyAnalyzer_Phase2=TightMuonEfficiencyAnalyzer.clone()                                                                     
+MediumMuonEfficiencyAnalyzer_Phase2.vtxBin=30                                                                                               
+MediumMuonEfficiencyAnalyzer_Phase2.vtxMin=149.5  
+MediumMuonEfficiencyAnalyzer_Phase2.vtxMax=249.5 

--- a/DQMOffline/Muon/python/muonEfficiencyAnalyzer_cfi.py
+++ b/DQMOffline/Muon/python/muonEfficiencyAnalyzer_cfi.py
@@ -183,49 +183,46 @@ EfficiencyAnalyzer = cms.Sequence(TightMuonEfficiencyAnalyzer*LooseMuonEfficienc
 
 EfficiencyAnalyzer_miniAOD = cms.Sequence(TightMuonEfficiencyAnalyzer_miniAOD*LooseMuonEfficiencyAnalyzer_miniAOD*MediumMuonEfficiencyAnalyzer_miniAOD)
 
-TightMuonEfficiencyAnalyzer_Phase2=TightMuonEfficiencyAnalyzer.clone()
-TightMuonEfficiencyAnalyzer_Phase2.vtxBin=20
-TightMuonEfficiencyAnalyzer_Phase2.vtxMax=249.5
-TightMuonEfficiencyAnalyzer_Phase2.vtxMin=149.5
+TightMuonEfficiencyAnalyzer_Phase2=TightMuonEfficiencyAnalyzer.clone(
+    vtxBin=20
+    vtxMin=149.5
+    vtxMax=249.5
+)
 
-LooseMuonEfficiencyAnalyzer_Phase2=LooseMuonEfficiencyAnalyzer.clone()                                                                      
-LooseMuonEfficiencyAnalyzer_Phase2.vtxBin=20                                                                                                
-LooseMuonEfficiencyAnalyzer_Phase2.vtxMin=149.5  
-LooseMuonEfficiencyAnalyzer_Phase2.vtxMax=249.5
+LooseMuonEfficiencyAnalyzer_Phase2=LooseMuonEfficiencyAnalyzer.clone(
+    vtxBin=20
+    vtxMin=149.5
+    vtxMax=249.5 
+)                                                                     
 
-MediumMuonEfficiencyAnalyzer_Phase2=MediumMuonEfficiencyAnalyzer.clone()                                                                    
-MediumMuonEfficiencyAnalyzer_Phase2.vtxBin=20                                                                                               
-MediumMuonEfficiencyAnalyzer_Phase2.vtxMin=149.5  
-MediumMuonEfficiencyAnalyzer_Phase2.vtxMax=249.5 
+MediumMuonEfficiencyAnalyzer_Phase2=MediumMuonEfficiencyAnalyzer.clone(                                                                    
+    vtxBin=20
+    vtxMin=149.5
+    vtxMax=249.5
+)
 
+TightMuonEfficiencyAnalyzer_miniAOD_Phase2=TightMuonEfficiencyAnalyzer_miniAOD.clone(                                                      
+    vtxBin=20
+    vtxMin=149.5
+    vtxMax=249.5
+)
 
-TightMuonEfficiencyAnalyzer_miniAOD_Phase2=TightMuonEfficiencyAnalyzer_miniAOD.clone()                                                      
-TightMuonEfficiencyAnalyzer_miniAOD_Phase2.vtxBin=20                                                                                       
-TightMuonEfficiencyAnalyzer_miniAOD_Phase2.vtxMax=249.5                                                                                     
-TightMuonEfficiencyAnalyzer_miniAOD_Phase2.vtxMin=149.5                                                                                    
-     
+LooseMuonEfficiencyAnalyzer_miniAOD_Phase2=LooseMuonEfficiencyAnalyzer_miniAOD.clone(
+    vtxBin=20
+    vtxMin=149.5
+    vtxMax=249.5                                                      
+)
 
-LooseMuonEfficiencyAnalyzer_miniAOD_Phase2=LooseMuonEfficiencyAnalyzer_miniAOD.clone()                                                      
-LooseMuonEfficiencyAnalyzer_miniAOD_Phase2.vtxBin=20                                                                                       
-LooseMuonEfficiencyAnalyzer_miniAOD_Phase2.vtxMin=149.5                                                                                     
-LooseMuonEfficiencyAnalyzer_miniAOD_Phase2.vtxMax=249.5                                                                                    
-
-MediumMuonEfficiencyAnalyzer_miniAOD_Phase2=MediumMuonEfficiencyAnalyzer.clone()                                                           
-MediumMuonEfficiencyAnalyzer_miniAOD_Phase2.vtxBin=20                                                                                       
-MediumMuonEfficiencyAnalyzer_miniAOD_Phase2.vtxMin=149.5                                                                                    
-MediumMuonEfficiencyAnalyzer_miniAOD_Phase2.vtxMax=249.5                                                                                   
+MediumMuonEfficiencyAnalyzer_miniAOD_Phase2=MediumMuonEfficiencyAnalyzer.clone(
+    vtxBin=20
+    vtxMin=149.5
+    vtxMax=249.5                                                           
+)
                                                         
-
 EfficiencyAnalyzer_Phase2 = cms.Sequence(TightMuonEfficiencyAnalyzer_Phase2*LooseMuonEfficiencyAnalyzer_Phase2*MediumMuonEfficiencyAnalyzer_Phase2)
 
 EfficiencyAnalyzer_miniAOD_Phase2 = cms.Sequence(TightMuonEfficiencyAnalyzer_miniAOD_Phase2*LooseMuonEfficiencyAnalyzer_miniAOD_Phase2*MediumMuonEfficiencyAnalyzer_miniAOD_Phase2)                                                                                                    
-
             
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon                                                                         
 phase2_muon.toReplaceWith(EfficiencyAnalyzer, EfficiencyAnalyzer_Phase2)                                                                   
-phase2_muon.toReplaceWith(EfficiencyAnalyzer_miniAOD, EfficiencyAnalyzer_miniAOD_Phase2)    
-                                                                                    
-
-
-
-
+phase2_muon.toReplaceWith(EfficiencyAnalyzer_miniAOD, EfficiencyAnalyzer_miniAOD_Phase2)

--- a/DQMOffline/Muon/python/muonIsolationDQM_cff.py
+++ b/DQMOffline/Muon/python/muonIsolationDQM_cff.py
@@ -56,24 +56,25 @@ MuIsoDQM_glb = DQMEDAnalyzer('MuonIsolationDQM',
                               )
 muIsoDQM_seq = cms.Sequence(MuIsoDQM_trk+MuIsoDQM_sta+MuIsoDQM_glb)
 
+MuIsoDQM_glb_Phase2=MuIsoDQM_glb.clone(
+    vtxBin=20
+    vtxMin=149.5
+    vtxMax=249.5
+)
 
-MuIsoDQM_glb_Phase2=MuIsoDQM_glb.clone()
-MuIsoDQM_glb_Phase2.vtxBin=20
-MuIsoDQM_glb_Phase2.vtxMax=249.5
-MuIsoDQM_glb_Phase2.vtxMin=149.5
+MuIsoDQM_trk_Phase2=MuIsoDQM_trk.clone(
+    vtxBin=20
+    vtxMin=149.5
+    vtxMax=249.5                                                                                                    
+)
 
-MuIsoDQM_trk_Phase2=MuIsoDQM_trk.clone()                                                                                                    
-MuIsoDQM_trk_Phase2.vtxBin=20                                                                                                               
-MuIsoDQM_trk_Phase2.vtxMax=249.5                                                                                                            
-MuIsoDQM_trk_Phase2.vtxMin=149.5
-
-MuIsoDQM_sta_Phase2=MuIsoDQM_sta.clone()                                                                                                    
-MuIsoDQM_sta_Phase2.vtxBin=20                                                                                                               
-MuIsoDQM_sta_Phase2.vtxMax=249.5                                                                                                            
-MuIsoDQM_sta_Phase2.vtxMin=149.5  
+MuIsoDQM_sta_Phase2=MuIsoDQM_sta.clone(
+    vtxBin=20
+    vtxMin=149.5
+    vtxMax=249.5                                                                                                    
+)
 
 muIsoDQM_seq_Phase2 = cms.Sequence(MuIsoDQM_trk_Phase2+MuIsoDQM_sta_Phase2+MuIsoDQM_glb_Phase2) 
-
 
 MuIsoDQM_trk_miniAOD = DQMEDAnalyzer('MuonIsolationDQM',
                                       Global_Muon_Label = cms.untracked.InputTag("slimmedMuons"),
@@ -127,26 +128,26 @@ MuIsoDQM_glb_miniAOD = DQMEDAnalyzer('MuonIsolationDQM',
                                       )
 muIsoDQM_seq_miniAOD = cms.Sequence(MuIsoDQM_trk_miniAOD+MuIsoDQM_sta_miniAOD+MuIsoDQM_glb_miniAOD)
 
-
-MuIsoDQM_glb_miniAOD_Phase2=MuIsoDQM_glb_miniAOD.clone()                                                                                   
-MuIsoDQM_glb_miniAOD_Phase2.vtxBin=20                                                                                                       
-MuIsoDQM_glb_miniAOD_Phase2.vtxMax=249.5                                                                                                   
-MuIsoDQM_glb_miniAOD_Phase2.vtxMin=149.5                                                                                           
+MuIsoDQM_glb_miniAOD_Phase2=MuIsoDQM_glb_miniAOD.clone(
+    vtxBin=20
+    vtxMin=149.5
+    vtxMax=249.5                                                                                   
+)
       
-MuIsoDQM_trk_miniAOD_Phase2=MuIsoDQM_trk_miniAOD.clone()                                                                                    
-MuIsoDQM_trk_miniAOD_Phase2.vtxBin=20                                                                                                       
-MuIsoDQM_trk_miniAOD_Phase2.vtxMax=249.5                                                                                 
-MuIsoDQM_trk_miniAOD_Phase2.vtxMin=149.5                                                                                                  
+MuIsoDQM_trk_miniAOD_Phase2=MuIsoDQM_trk_miniAOD.clone(
+    vtxBin=20
+    vtxMin=149.5
+    vtxMax=249.5                                                                                    
+)
 
-MuIsoDQM_sta_miniAOD_Phase2=MuIsoDQM_sta_miniAOD.clone()                                                                                    
-MuIsoDQM_sta_miniAOD_Phase2.vtxBin=20                                                                                           
-MuIsoDQM_sta_miniAOD_Phase2.vtxMax=249.5                                                                                                  
-MuIsoDQM_sta_miniAOD_Phase2.vtxMin=149.5                                                                                                   
+MuIsoDQM_sta_miniAOD_Phase2=MuIsoDQM_sta_miniAOD.clone(
+    vtxBin=20
+    vtxMin=149.5
+    vtxMax=249.5                                                                                    
+)
 
 muIsoDQM_seq_miniAOD_Phase2 = cms.Sequence(MuIsoDQM_trk_miniAOD_Phase2+MuIsoDQM_sta_miniAOD_Phase2+MuIsoDQM_glb_miniAOD_Phase2)   
-
 
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon                                                                         
 phase2_muon.toReplaceWith(muIsoDQM_seq, muIsoDQM_seq_Phase2)
 phase2_muon.toReplaceWith(muIsoDQM_seq_miniAOD, muIsoDQM_seq_miniAOD_Phase2)
-                                                                                    

--- a/DQMOffline/Muon/python/muonIsolationDQM_cff.py
+++ b/DQMOffline/Muon/python/muonIsolationDQM_cff.py
@@ -15,7 +15,10 @@ MuIsoDQM_trk = DQMEDAnalyzer('MuonIsolationDQM',
                               tkIsoDeposit_Label = cms.untracked.InputTag("muIsoDepositTk"),
                               hoIsoDeposit_Label = cms.untracked.InputTag("muIsoDepositCalByAssociatorTowers","ho"),
                               vertexLabel = cms.untracked.InputTag("offlinePrimaryVertices"),
-                              directory = cms.string("Muons/Isolation/tracker")                             
+                              directory = cms.string("Muons/Isolation/tracker"),
+                             vtxBin = cms.int32(30),
+                             vtxMax = cms.double(149.5),
+                             vtxMin = cms.double(0.5)                             
                               )
 
 MuIsoDQM_sta = DQMEDAnalyzer('MuonIsolationDQM',
@@ -29,7 +32,10 @@ MuIsoDQM_sta = DQMEDAnalyzer('MuonIsolationDQM',
                               tkIsoDeposit_Label = cms.untracked.InputTag("muIsoDepositTk"),
                               hoIsoDeposit_Label = cms.untracked.InputTag("muIsoDepositCalByAssociatorTowers","ho"),
                               vertexLabel = cms.untracked.InputTag("offlinePrimaryVertices"),
-                              directory = cms.string("Muons/Isolation/standalone")
+                              directory = cms.string("Muons/Isolation/standalone"),
+                             vtxBin = cms.int32(30),
+                             vtxMax = cms.double(149.5),
+                             vtxMin = cms.double(0.5)
                               )
 
 MuIsoDQM_glb = DQMEDAnalyzer('MuonIsolationDQM',
@@ -43,10 +49,30 @@ MuIsoDQM_glb = DQMEDAnalyzer('MuonIsolationDQM',
                               tkIsoDeposit_Label = cms.untracked.InputTag("muIsoDepositTk"),
                               hoIsoDeposit_Label = cms.untracked.InputTag("muIsoDepositCalByAssociatorTowers","ho"),
                               vertexLabel = cms.untracked.InputTag("offlinePrimaryVertices"),
-                              directory = cms.string("Muons/Isolation/global")
+                              directory = cms.string("Muons/Isolation/global"),
+                             vtxBin = cms.int32(30),
+                             vtxMax = cms.double(149.5),
+                             vtxMin = cms.double(0.5)
                               )
 muIsoDQM_seq = cms.Sequence(MuIsoDQM_trk+MuIsoDQM_sta+MuIsoDQM_glb)
 
+
+MuIsoDQM_glb_Phase2=MuIsoDQM_glb.clone()
+MuIsoDQM_glb_Phase2.vtxBin=20
+MuIsoDQM_glb_Phase2.vtxMax=249.5
+MuIsoDQM_glb_Phase2.vtxMin=149.5
+
+MuIsoDQM_trk_Phase2=MuIsoDQM_trk.clone()                                                                                                    
+MuIsoDQM_trk_Phase2.vtxBin=20                                                                                                               
+MuIsoDQM_trk_Phase2.vtxMax=249.5                                                                                                            
+MuIsoDQM_trk_Phase2.vtxMin=149.5
+
+MuIsoDQM_sta_Phase2=MuIsoDQM_sta.clone()                                                                                                    
+MuIsoDQM_sta_Phase2.vtxBin=20                                                                                                               
+MuIsoDQM_sta_Phase2.vtxMax=249.5                                                                                                            
+MuIsoDQM_sta_Phase2.vtxMin=149.5  
+
+muIsoDQM_seq_Phase2 = cms.Sequence(MuIsoDQM_trk_Phase2+MuIsoDQM_sta_Phase2+MuIsoDQM_glb_Phase2) 
 
 
 MuIsoDQM_trk_miniAOD = DQMEDAnalyzer('MuonIsolationDQM',
@@ -60,7 +86,10 @@ MuIsoDQM_trk_miniAOD = DQMEDAnalyzer('MuonIsolationDQM',
                                       tkIsoDeposit_Label = cms.untracked.InputTag("muIsoDepositTk"),
                                       hoIsoDeposit_Label = cms.untracked.InputTag("muIsoDepositCalByAssociatorTowers","ho"),
                                       vertexLabel = cms.untracked.InputTag("offlinePrimaryVertices"),
-                                      directory = cms.string("Muons_miniAOD/Isolation/tracker")                             
+                                      directory = cms.string("Muons_miniAOD/Isolation/tracker"),
+                                     vtxBin = cms.int32(30),
+                                     vtxMax = cms.double(149.5),
+                                     vtxMin = cms.double(0.5)                             
                                       )
 
 MuIsoDQM_sta_miniAOD = DQMEDAnalyzer('MuonIsolationDQM',
@@ -74,7 +103,10 @@ MuIsoDQM_sta_miniAOD = DQMEDAnalyzer('MuonIsolationDQM',
                                       tkIsoDeposit_Label = cms.untracked.InputTag("muIsoDepositTk"),
                                       hoIsoDeposit_Label = cms.untracked.InputTag("muIsoDepositCalByAssociatorTowers","ho"),
                                       vertexLabel = cms.untracked.InputTag("offlinePrimaryVertices"),
-                                      directory = cms.string("Muons_miniAOD/Isolation/standalone")
+                                      directory = cms.string("Muons_miniAOD/Isolation/standalone"),
+                                     vtxBin = cms.int32(30),
+                                     vtxMax = cms.double(149.5),
+                                     vtxMin = cms.double(0.5)
                                       )
 
 MuIsoDQM_glb_miniAOD = DQMEDAnalyzer('MuonIsolationDQM',
@@ -88,6 +120,33 @@ MuIsoDQM_glb_miniAOD = DQMEDAnalyzer('MuonIsolationDQM',
                                       tkIsoDeposit_Label = cms.untracked.InputTag("muIsoDepositTk"),
                                       hoIsoDeposit_Label = cms.untracked.InputTag("muIsoDepositCalByAssociatorTowers","ho"),
                                       vertexLabel = cms.untracked.InputTag("offlinePrimaryVertices"),
-                                      directory = cms.string("Muons_miniAOD/Isolation/global")
+                                      directory = cms.string("Muons_miniAOD/Isolation/global"),
+                                     vtxBin = cms.int32(30),
+                                     vtxMax = cms.double(149.5),
+                                     vtxMin = cms.double(0.5),
                                       )
 muIsoDQM_seq_miniAOD = cms.Sequence(MuIsoDQM_trk_miniAOD+MuIsoDQM_sta_miniAOD+MuIsoDQM_glb_miniAOD)
+
+
+MuIsoDQM_glb_miniAOD_Phase2=MuIsoDQM_glb_miniAOD.clone()                                                                                   
+MuIsoDQM_glb_miniAOD_Phase2.vtxBin=20                                                                                                       
+MuIsoDQM_glb_miniAOD_Phase2.vtxMax=249.5                                                                                                   
+MuIsoDQM_glb_miniAOD_Phase2.vtxMin=149.5                                                                                           
+      
+MuIsoDQM_trk_miniAOD_Phase2=MuIsoDQM_trk_miniAOD.clone()                                                                                    
+MuIsoDQM_trk_miniAOD_Phase2.vtxBin=20                                                                                                       
+MuIsoDQM_trk_miniAOD_Phase2.vtxMax=249.5                                                                                 
+MuIsoDQM_trk_miniAOD_Phase2.vtxMin=149.5                                                                                                  
+
+MuIsoDQM_sta_miniAOD_Phase2=MuIsoDQM_sta_miniAOD.clone()                                                                                    
+MuIsoDQM_sta_miniAOD_Phase2.vtxBin=20                                                                                           
+MuIsoDQM_sta_miniAOD_Phase2.vtxMax=249.5                                                                                                  
+MuIsoDQM_sta_miniAOD_Phase2.vtxMin=149.5                                                                                                   
+
+muIsoDQM_seq_miniAOD_Phase2 = cms.Sequence(MuIsoDQM_trk_miniAOD_Phase2+MuIsoDQM_sta_miniAOD_Phase2+MuIsoDQM_glb_miniAOD_Phase2)   
+
+
+from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon                                                                         
+phase2_muon.toReplaceWith(muIsoDQM_seq, muIsoDQM_seq_Phase2)
+phase2_muon.toReplaceWith(muIsoDQM_seq_miniAOD, muIsoDQM_seq_miniAOD_Phase2)
+                                                                                    

--- a/DQMOffline/Muon/python/muonIsolationDQM_cff.py
+++ b/DQMOffline/Muon/python/muonIsolationDQM_cff.py
@@ -57,20 +57,20 @@ MuIsoDQM_glb = DQMEDAnalyzer('MuonIsolationDQM',
 muIsoDQM_seq = cms.Sequence(MuIsoDQM_trk+MuIsoDQM_sta+MuIsoDQM_glb)
 
 MuIsoDQM_glb_Phase2=MuIsoDQM_glb.clone(
-    vtxBin=20
-    vtxMin=149.5
+    vtxBin=20,
+    vtxMin=149.5,
     vtxMax=249.5
 )
 
 MuIsoDQM_trk_Phase2=MuIsoDQM_trk.clone(
-    vtxBin=20
-    vtxMin=149.5
+    vtxBin=20,
+    vtxMin=149.5,
     vtxMax=249.5                                                                                                    
 )
 
 MuIsoDQM_sta_Phase2=MuIsoDQM_sta.clone(
-    vtxBin=20
-    vtxMin=149.5
+    vtxBin=20,
+    vtxMin=149.5,
     vtxMax=249.5                                                                                                    
 )
 
@@ -129,20 +129,20 @@ MuIsoDQM_glb_miniAOD = DQMEDAnalyzer('MuonIsolationDQM',
 muIsoDQM_seq_miniAOD = cms.Sequence(MuIsoDQM_trk_miniAOD+MuIsoDQM_sta_miniAOD+MuIsoDQM_glb_miniAOD)
 
 MuIsoDQM_glb_miniAOD_Phase2=MuIsoDQM_glb_miniAOD.clone(
-    vtxBin=20
-    vtxMin=149.5
+    vtxBin=20,
+    vtxMin=149.5,
     vtxMax=249.5                                                                                   
 )
       
 MuIsoDQM_trk_miniAOD_Phase2=MuIsoDQM_trk_miniAOD.clone(
-    vtxBin=20
-    vtxMin=149.5
+    vtxBin=20,
+    vtxMin=149.5,
     vtxMax=249.5                                                                                    
 )
 
 MuIsoDQM_sta_miniAOD_Phase2=MuIsoDQM_sta_miniAOD.clone(
-    vtxBin=20
-    vtxMin=149.5
+    vtxBin=20,
+    vtxMin=149.5,
     vtxMax=249.5                                                                                    
 )
 

--- a/DQMOffline/Muon/python/muonMonitors_cff.py
+++ b/DQMOffline/Muon/python/muonMonitors_cff.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 from DQM.TrackingMonitor.MonitorTrackSTAMuons_cfi import *
 from DQM.TrackingMonitor.MonitorTrackGLBMuons_cfi import *
 from DQM.TrackingMonitor.MonitorTrackInnerTrackMuons_cff import *
-from DQMOffline.Muon.dtSegmTask_cfi import *
+
 
 #dedicated analyzers for offline dqm 
 from DQMOffline.Muon.muonAnalyzer_cff import *
@@ -23,7 +23,6 @@ dqmInfoMuons = DQMEDAnalyzer('DQMEventInfo',
 muonTrackAnalyzers = cms.Sequence(MonitorTrackSTAMuons*MonitorTrackGLBMuons*MonitorTrackINNMuons)
 
 muonMonitors = cms.Sequence(muonTrackAnalyzers*
-                            dtSegmentsMonitor*
                             cscMonitor*
                             muonAnalyzer*
                             muonIdDQM*

--- a/DQMOffline/Muon/python/muonMonitors_cff.py
+++ b/DQMOffline/Muon/python/muonMonitors_cff.py
@@ -34,5 +34,3 @@ muonMonitors_miniAOD = cms.Sequence( muonAnalyzer_miniAOD*
 
 
 muonMonitorsAndQualityTests = cms.Sequence(muonMonitors*muonQualityTests)
-
-

--- a/DQMOffline/Muon/python/muonMonitors_cff.py
+++ b/DQMOffline/Muon/python/muonMonitors_cff.py
@@ -34,3 +34,5 @@ muonMonitors_miniAOD = cms.Sequence( muonAnalyzer_miniAOD*
 
 
 muonMonitorsAndQualityTests = cms.Sequence(muonMonitors*muonQualityTests)
+
+

--- a/DQMOffline/Muon/python/muonQualityTests_cff.py
+++ b/DQMOffline/Muon/python/muonQualityTests_cff.py
@@ -31,18 +31,20 @@ cosmicMuonQualityTests = cms.Sequence(ClientTrackEfficiencyTkTracks*
 
 muonQualityTests = cms.Sequence(muonSourcesQualityTests*
                                 muTrackResidualsTest*
-                                effPlotterLoose*
-                                effPlotterMedium*
-                                effPlotterTight*
+                                effPlotter*
+                                #effPlotterLoose*
+                                #effPlotterMedium*
+                                #effPlotterTight*
                                 muRecoTest*
                                 muonClientsQualityTests*
                                 muonTestSummary)
 
 muonQualityTests_miniAOD = cms.Sequence(muonSourcesQualityTests*
                                         muTrackResidualsTest*
-                                        effPlotterLooseMiniAOD*
-                                        effPlotterMediumMiniAOD*
-                                        effPlotterTightMiniAOD*
+                                        effPlotter_miniAOD*
+                                        #effPlotterLooseMiniAOD*
+                                        #effPlotterMediumMiniAOD*
+                                        #effPlotterTightMiniAOD*
                                         muRecoTest*
                                         muonClientsQualityTests*
                                         muonTestSummary*
@@ -50,10 +52,3 @@ muonQualityTests_miniAOD = cms.Sequence(muonSourcesQualityTests*
 
 
 
-muonQualityTests_Phase2 = cms.Sequence(effPlotterLoose_Phase2*                                                                              
-                                       effPlotterMedium_Phase2*                                                                             
-                                       effPlotterTight_Phase2) 
-
-
-from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon                                                                        
-phase2_muon.toReplaceWith(muonQualityTests, muonQualityTests_Phase2)

--- a/DQMOffline/Muon/python/muonQualityTests_cff.py
+++ b/DQMOffline/Muon/python/muonQualityTests_cff.py
@@ -47,3 +47,13 @@ muonQualityTests_miniAOD = cms.Sequence(muonSourcesQualityTests*
                                         muonClientsQualityTests*
                                         muonTestSummary*
                                         triggerMatchEffPlotterTightMiniAOD)
+
+
+
+muonQualityTests_Phase2 = cms.Sequence(effPlotterLoose_Phase2*                                                                              
+                                       effPlotterMedium_Phase2*                                                                             
+                                       effPlotterTight_Phase2) 
+
+
+from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon                                                                        
+phase2_muon.toReplaceWith(muonQualityTests, muonQualityTests_Phase2)

--- a/DQMOffline/Muon/python/muonQualityTests_cff.py
+++ b/DQMOffline/Muon/python/muonQualityTests_cff.py
@@ -32,9 +32,6 @@ cosmicMuonQualityTests = cms.Sequence(ClientTrackEfficiencyTkTracks*
 muonQualityTests = cms.Sequence(muonSourcesQualityTests*
                                 muTrackResidualsTest*
                                 effPlotter*
-                                #effPlotterLoose*
-                                #effPlotterMedium*
-                                #effPlotterTight*
                                 muRecoTest*
                                 muonClientsQualityTests*
                                 muonTestSummary)
@@ -42,9 +39,6 @@ muonQualityTests = cms.Sequence(muonSourcesQualityTests*
 muonQualityTests_miniAOD = cms.Sequence(muonSourcesQualityTests*
                                         muTrackResidualsTest*
                                         effPlotter_miniAOD*
-                                        #effPlotterLooseMiniAOD*
-                                        #effPlotterMediumMiniAOD*
-                                        #effPlotterTightMiniAOD*
                                         muRecoTest*
                                         muonClientsQualityTests*
                                         muonTestSummary*

--- a/DQMOffline/Muon/src/EfficiencyPlotter.cc
+++ b/DQMOffline/Muon/src/EfficiencyPlotter.cc
@@ -59,7 +59,7 @@ void EfficiencyPlotter::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter 
   h_eff_inner_pt_ID = ibooker.book1D("Eff_inner_pt_" + ID_, ID_ + " Eff. vs pt", ptBin, ptMin, ptMax);
   h_eff_inner_eta_ID = ibooker.book1D("Eff_inner_eta_" + ID_, ID_ + " Eff. vs #eta", etaBin, etaMin, etaMax);
   h_eff_inner_phi_ID = ibooker.book1D("Eff_inner_phi_" + ID_, ID_ + " Eff. vs #phi", phiBin, phiMin, phiMax);
-  h_eff_hp_eta_ID = ibooker.book1D("Eff_hp_eta_" + ID_, "High Pt " + ID_ + " Eff. vs #eta", etaBin, etaMin, etaMax);
+  h_eff_hp_eta_ID = ibooker.book1D("Eff_hp_eta_" + ID_, "High Pt (Pt>20)" + ID_ + " Eff. vs #eta", etaBin, etaMin, etaMax);
   h_eff_phi_ID = ibooker.book1D("Eff_phi_" + ID_, ID_ + " Eff. vs #phi", phiBin, phiMin, phiMax);
   h_eff_pt_ID = ibooker.book1D("Eff_pt_" + ID_, ID_ + " Eff. vs Pt", ptBin, ptMin, ptMax);
   h_eff_pt_EB_ID = ibooker.book1D("Eff_pt_EB_" + ID_, "Barrel: " + ID_ + " Eff. vs Pt", ptBin, ptMin, ptMax);

--- a/DQMOffline/Muon/src/EfficiencyPlotter.cc
+++ b/DQMOffline/Muon/src/EfficiencyPlotter.cc
@@ -59,7 +59,8 @@ void EfficiencyPlotter::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter 
   h_eff_inner_pt_ID = ibooker.book1D("Eff_inner_pt_" + ID_, ID_ + " Eff. vs pt", ptBin, ptMin, ptMax);
   h_eff_inner_eta_ID = ibooker.book1D("Eff_inner_eta_" + ID_, ID_ + " Eff. vs #eta", etaBin, etaMin, etaMax);
   h_eff_inner_phi_ID = ibooker.book1D("Eff_inner_phi_" + ID_, ID_ + " Eff. vs #phi", phiBin, phiMin, phiMax);
-  h_eff_hp_eta_ID = ibooker.book1D("Eff_hp_eta_" + ID_, "High Pt (Pt>20)" + ID_ + " Eff. vs #eta", etaBin, etaMin, etaMax);
+  h_eff_hp_eta_ID =
+      ibooker.book1D("Eff_hp_eta_" + ID_, "High Pt (Pt>20)" + ID_ + " Eff. vs #eta", etaBin, etaMin, etaMax);
   h_eff_phi_ID = ibooker.book1D("Eff_phi_" + ID_, ID_ + " Eff. vs #phi", phiBin, phiMin, phiMax);
   h_eff_pt_ID = ibooker.book1D("Eff_pt_" + ID_, ID_ + " Eff. vs Pt", ptBin, ptMin, ptMax);
   h_eff_pt_EB_ID = ibooker.book1D("Eff_pt_EB_" + ID_, "Barrel: " + ID_ + " Eff. vs Pt", ptBin, ptMin, ptMax);

--- a/DQMOffline/Muon/src/MuonIsolationDQM.cc
+++ b/DQMOffline/Muon/src/MuonIsolationDQM.cc
@@ -783,7 +783,8 @@ void MuonIsolationDQM::bookHistograms(DQMStore::IBooker& ibooker,
 
   //----Initialize 2D Histograms
   for (int var = 0; var < NUM_VARS_2D; var++) {
-    h_2D[var] = ibooker.bookProfile(names_2D[var] + "_VsPV", titles_2D[var] + " Vs PV", vtxBin_, vtxMin_, vtxMax_, 20, 0.0, 20.0);
+    h_2D[var] = ibooker.bookProfile(
+        names_2D[var] + "_VsPV", titles_2D[var] + " Vs PV", vtxBin_, vtxMin_, vtxMax_, 20, 0.0, 20.0);
     h_2D[var]->setAxisTitle("Number of PV", XAXIS);
     h_2D[var]->setAxisTitle(titles_2D[var] + " (GeV)", YAXIS);
     //    h_2D[var]->getTH1()->Sumw2();

--- a/DQMOffline/Muon/src/MuonIsolationDQM.cc
+++ b/DQMOffline/Muon/src/MuonIsolationDQM.cc
@@ -61,6 +61,10 @@ MuonIsolationDQM::MuonIsolationDQM(const edm::ParameterSet& iConfig) {
   requireGLBMuon = iConfig.getUntrackedParameter<bool>("requireGLBMuon");
   dirName = iConfig.getParameter<std::string>("directory");
 
+  vtxBin_ = iConfig.getParameter<int>("vtxBin");
+  vtxMin_ = iConfig.getParameter<double>("vtxMin");
+  vtxMax_ = iConfig.getParameter<double>("vtxMax");
+
   //--------Initialize tags-------
   theMuonCollectionLabel_ =
       consumes<edm::View<reco::Muon> >(iConfig.getUntrackedParameter<edm::InputTag>("Global_Muon_Label"));
@@ -209,12 +213,12 @@ void MuonIsolationDQM::InitStatics() {
   titles_2D[8] = "Relative Detector-Based Isolation, #Delta R = 0.4";
   titles_2D[9] = "Relative PF Isolation, #Delta R = 0.4";
 
-  main_titles_NVtxs[0] = "Sum PF Neutral Hadron Pt, #DeltaR = 0.4 ( 0 < N_{Vtx} < 15)";
-  main_titles_NVtxs[1] = "Sum PF Neutral Hadron Pt, #DeltaR = 0.4 (15 < N_{Vtx} < 30)";
-  main_titles_NVtxs[2] = "Sum PF Neutral Hadron Pt, #DeltaR = 0.4 (30 < N_{Vtx})";
-  main_titles_NVtxs[3] = "Sum PF Photon Et, #DeltaR = 0.4 ( 0 < N_{Vtx} < 15)";
-  main_titles_NVtxs[4] = "Sum PF Photon Et, #DeltaR = 0.4 (15 < N_{Vtx} < 30)";
-  main_titles_NVtxs[5] = "Sum PF Photon Et, #DeltaR = 0.4 (30 < N_{Vtx})";
+  main_titles_NVtxs[0] = "Sum PF Neutral Hadron Pt, #DeltaR = 0.4 ( 20 < N_{Vtx} < 50)";
+  main_titles_NVtxs[1] = "Sum PF Neutral Hadron Pt, #DeltaR = 0.4 (50 < N_{Vtx} < 80)";
+  main_titles_NVtxs[2] = "Sum PF Neutral Hadron Pt, #DeltaR = 0.4 (80 < N_{Vtx})";
+  main_titles_NVtxs[3] = "Sum PF Photon Et, #DeltaR = 0.4 ( 20 < N_{Vtx} < 50)";
+  main_titles_NVtxs[4] = "Sum PF Photon Et, #DeltaR = 0.4 (50 < N_{Vtx} < 80)";
+  main_titles_NVtxs[5] = "Sum PF Photon Et, #DeltaR = 0.4 (80 < N_{Vtx})";
 
 #ifdef DEBUG
   cout << "InitStatistics(): main titles 2D DONE " << endl;
@@ -365,12 +369,12 @@ void MuonIsolationDQM::InitStatics() {
   cout << "InitStatistics(): names 2D DONE " << endl;
 #endif
 
-  names_NVtxs[0] = "pfNeutralPt_R04_PV0to15";
-  names_NVtxs[1] = "pfNeutralPt_R04_PV15to30";
-  names_NVtxs[2] = "pfNeutralPt_R04_PV30toInf";
-  names_NVtxs[3] = "pfPhotonPt_R04_PV0to15";
-  names_NVtxs[4] = "pfPhotonPt_R04_PV15to30";
-  names_NVtxs[5] = "pfPhotonPt_R04_PV30toInf";
+  names_NVtxs[0] = "pfNeutralPt_R04_PV20to50";
+  names_NVtxs[1] = "pfNeutralPt_R04_PV50to80";
+  names_NVtxs[2] = "pfNeutralPt_R04_PV80toInf";
+  names_NVtxs[3] = "pfPhotonPt_R04_PV20to50";
+  names_NVtxs[4] = "pfPhotonPt_R04_PV50to80";
+  names_NVtxs[5] = "pfPhotonPt_R04_PV80toInf";
 
   //----------Parameters for binning of histograms---------
   //param[var][0] is the number of bins
@@ -779,8 +783,7 @@ void MuonIsolationDQM::bookHistograms(DQMStore::IBooker& ibooker,
 
   //----Initialize 2D Histograms
   for (int var = 0; var < NUM_VARS_2D; var++) {
-    h_2D[var] = ibooker.bookProfile(names_2D[var] + "_VsPV", titles_2D[var] + " Vs PV", 50, 0.5, 50.5, 20, 0.0, 20.0);
-
+    h_2D[var] = ibooker.bookProfile(names_2D[var] + "_VsPV", titles_2D[var] + " Vs PV", vtxBin_, vtxMin_, vtxMax_, 20, 0.0, 20.0);
     h_2D[var]->setAxisTitle("Number of PV", XAXIS);
     h_2D[var]->setAxisTitle(titles_2D[var] + " (GeV)", YAXIS);
     //    h_2D[var]->getTH1()->Sumw2();
@@ -827,15 +830,15 @@ void MuonIsolationDQM::FillHistos(int numPV) {
 #endif
 }
 void MuonIsolationDQM::FillNVtxHistos(int PV) {
-  if (PV < 15) {
+  if (PV >= 20 && PV < 50) {
     h_1D_NVTX[0]->Fill(theDataNVtx[0]);
     h_1D_NVTX[3]->Fill(theDataNVtx[3]);
   }
-  if (PV >= 15 && PV < 30) {
+  if (PV >= 50 && PV < 80) {
     h_1D_NVTX[1]->Fill(theDataNVtx[1]);
     h_1D_NVTX[4]->Fill(theDataNVtx[4]);
   }
-  if (PV >= 30) {
+  if (PV >= 80) {
     h_1D_NVTX[2]->Fill(theDataNVtx[2]);
     h_1D_NVTX[5]->Fill(theDataNVtx[5]);
   }

--- a/DQMOffline/Muon/src/SegmentTrackAnalyzer.cc
+++ b/DQMOffline/Muon/src/SegmentTrackAnalyzer.cc
@@ -246,13 +246,12 @@ void SegmentTrackAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSet
         segmFromCsc++;
       }
 
-#ifdef DEBUG                                                                                                                               
-      cout << "[SegmentTrackAnalyzer] # of segments from DT and CSC: " << segmFromDt << ", " << segmFromCsc << endl;                    
+#ifdef DEBUG
+      cout << "[SegmentTrackAnalyzer] # of segments from DT and CSC: " << segmFromDt << ", " << segmFromCsc << endl;
       cout << "[SegmentTrackAnalyzer] # of HITS from segments from DT: " << hitsFromSegmDt << endl;
-      cout << "[SegmentTrackAnalyzer] # of HITS from segments from CSC  " << hitsFromSegmCsc   << endl;
-#endif 
+      cout << "[SegmentTrackAnalyzer] # of HITS from segments from CSC  " << hitsFromSegmCsc << endl;
+#endif
     }
-
 
     // hits from track
     for (trackingRecHit_iterator recHit = recoTrack->recHitsBegin(); recHit != recoTrack->recHitsEnd(); ++recHit) {

--- a/DQMOffline/Muon/src/SegmentTrackAnalyzer.cc
+++ b/DQMOffline/Muon/src/SegmentTrackAnalyzer.cc
@@ -232,6 +232,7 @@ void SegmentTrackAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSet
       // hits from DT segments
       if (id.det() == DetId::Muon && id.subdetId() == MuonSubdetId::DT) {
         ++segmFromDt;
+
         const DTRecSegment4D* seg4D = dynamic_cast<const DTRecSegment4D*>((*segment)->hit());
         if ((*seg4D).hasPhi())
           hitsFromSegmDt += (*seg4D).phiSegment()->specificRecHits().size();
@@ -244,7 +245,14 @@ void SegmentTrackAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSet
         hitsFromSegmCsc += (*segment)->recHits().size();
         segmFromCsc++;
       }
+
+#ifdef DEBUG                                                                                                                               
+      cout << "[SegmentTrackAnalyzer] # of segments from DT and CSC: " << segmFromDt << ", " << segmFromCsc << endl;                    
+      cout << "[SegmentTrackAnalyzer] # of HITS from segments from DT: " << hitsFromSegmDt << endl;
+      cout << "[SegmentTrackAnalyzer] # of HITS from segments from CSC  " << hitsFromSegmCsc   << endl;
+#endif 
     }
+
 
     // hits from track
     for (trackingRecHit_iterator recHit = recoTrack->recHitsBegin(); recHit != recoTrack->recHitsEnd(); ++recHit) {


### PR DESCRIPTION
Some minor changes have been implemented in view of the next Run3 data taking and certification:

- Removed the DTSegmentMonitor folder (currently not used by the muon POG) 
- Changes in PU ranges to extend them for next Run3 and modified for Phase2
- Minor changes for some plot names 

It has been tested on the following samples: 

34850 ZMM, No PU, 14TeV, 2026 upgrade 
1330.0 ZMM, noPU, 13TeV standard
136.867 RunSingleMu2018B, standard
