### PR TITLE
Migrate to new DBOutputService methods for L1Trigger & L1TriggerExt

### DIFF
--- a/CondTools/L1Trigger/src/DataWriter.cc
+++ b/CondTools/L1Trigger/src/DataWriter.cc
@@ -84,7 +84,7 @@ namespace l1t {
 
     if (poolDb->isNewTagRequest(esRecordName)) {
       sinceRun = poolDb->beginOfTime();
-      poolDb->createNewIOV(payloadToken, sinceRun, esRecordName);
+      poolDb->createOneIOV(payloadToken, sinceRun, esRecordName);
     } else {
       cond::TagInfo_t tagInfo;
       poolDb->tagInfo(esRecordName, tagInfo);
@@ -96,7 +96,7 @@ namespace l1t {
       }
 
       if (tagInfo.lastInterval.payloadId != payloadToken) {
-        poolDb->appendSinceTime(payloadToken, sinceRun, esRecordName);
+        poolDb->appendOneIOV(payloadToken, sinceRun, esRecordName);
       } else {
         iovUpdated = false;
         edm::LogVerbatim("L1-O2O") << "IOV already up to date.";

--- a/CondTools/L1TriggerExt/src/DataWriterExt.cc
+++ b/CondTools/L1TriggerExt/src/DataWriterExt.cc
@@ -85,7 +85,7 @@ namespace l1t {
 
     if (poolDb->isNewTagRequest(esRecordName)) {
       sinceRun = poolDb->beginOfTime();
-      poolDb->createNewIOV(payloadToken, sinceRun, esRecordName);
+      poolDb->createOneIOV(payloadToken, sinceRun, esRecordName);
     } else {
       cond::TagInfo_t tagInfo;
       poolDb->tagInfo(esRecordName, tagInfo);
@@ -97,7 +97,7 @@ namespace l1t {
       }
 
       if (tagInfo.lastInterval.payloadId != payloadToken) {
-        poolDb->appendSinceTime(payloadToken, sinceRun, esRecordName);
+        poolDb->appendOneIOV(payloadToken, sinceRun, esRecordName);
       } else {
         iovUpdated = false;
         edm::LogVerbatim("L1-O2O") << "IOV already up to date.";


### PR DESCRIPTION
#### PR description:

New DBOutputService reference based methods migration for L1Trigger and L1TriggerExt packages as requested by Francesco. Since the payload object is already passed as reference, no further modification except for methods changes.

#### PR validation:

Code compiles and local build test run.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport and no backport expected.
