### PR TITLE
fix for two `esConsumes` calls in HLT-DQM

### DIFF
--- a/DQM/HLTEvF/plugins/TriggerBxMonitor.cc
+++ b/DQM/HLTEvF/plugins/TriggerBxMonitor.cc
@@ -125,7 +125,7 @@ void TriggerBxMonitor::fillDescriptions(edm::ConfigurationDescriptions& descript
 
 TriggerBxMonitor::TriggerBxMonitor(edm::ParameterSet const& config)
     :  // module configuration
-      m_l1tMenuToken{esConsumes()},
+      m_l1tMenuToken{esConsumes<edm::Transition::BeginRun>()},
       m_l1t_results(consumes<GlobalAlgBlkBxCollection>(config.getUntrackedParameter<edm::InputTag>("l1tResults"))),
       m_hlt_results(consumes<edm::TriggerResults>(config.getUntrackedParameter<edm::InputTag>("hltResults"))),
       m_dqm_path(config.getUntrackedParameter<std::string>("dqmPath")),

--- a/DQM/HLTEvF/plugins/TriggerRatesMonitor.cc
+++ b/DQM/HLTEvF/plugins/TriggerRatesMonitor.cc
@@ -157,7 +157,7 @@ void TriggerRatesMonitor::fillDescriptions(edm::ConfigurationDescriptions &descr
 
 TriggerRatesMonitor::TriggerRatesMonitor(edm::ParameterSet const &config)
     :  // module configuration
-      m_l1tMenuToken{esConsumes()},
+      m_l1tMenuToken{esConsumes<edm::Transition::BeginRun>()},
       m_l1t_results(consumes<GlobalAlgBlkBxCollection>(config.getUntrackedParameter<edm::InputTag>("l1tResults"))),
       m_hlt_results(consumes<edm::TriggerResults>(config.getUntrackedParameter<edm::InputTag>("hltResults"))),
       m_dqm_path(config.getUntrackedParameter<std::string>("dqmPath")),


### PR DESCRIPTION
#### PR description:

This PR fixes a bug introduced in #36100. Two `esConsumes` calls are now corrected to cope with run-based transitions.

Thanks to @Dr15Jones for reporting the bug(s).

#### PR validation:

`scram` builds (couldn't find quickly a workflow to test the relevant modules).

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A