### PR TITLE
HGCAL Pattern Recognition using FastJet

### DIFF
--- a/Configuration/ProcessModifiers/python/fastJetTICL_cff.py
+++ b/Configuration/ProcessModifiers/python/fastJetTICL_cff.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+# This modifier is for injecting CLUE3D-based iterations in TICL.
+
+fastJetTICL =  cms.Modifier()

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -381,6 +381,52 @@ upgradeWFs['vectorHits'] = UpgradeWorkflow_vectorHits(
     offset = 0.9,
 )
 
+# Special TICL Pattern recognition Workflows
+class UpgradeWorkflow_ticl_clue3D(UpgradeWorkflow):
+    def setup_(self, step, stepName, stepDict, k, properties):
+        if 'RecoGlobal' in step:
+            stepDict[stepName][k] = merge([self.step3, stepDict[step][k]])
+        if 'HARVESTGlobal' in step:
+            stepDict[stepName][k] = merge([self.step4, stepDict[step][k]])
+    def condition(self, fragment, stepList, key, hasHarvest):
+        return (fragment=="TTbar_14TeV" or 'CloseByPGun_CE' in fragment) and '2026' in key
+upgradeWFs['ticl_clue3D'] = UpgradeWorkflow_ticl_clue3D(
+    steps = [
+        'RecoGlobal',
+        'HARVESTGlobal'
+    ],
+    PU = [
+        'RecoGlobal',
+        'HARVESTGlobal'
+    ],
+    suffix = '_ticl_clue3D',
+    offset = 0.201,
+)
+upgradeWFs['ticl_clue3D'].step3 = {'--procModifiers': 'clue3D'}
+upgradeWFs['ticl_clue3D'].step4 = {'--procModifiers': 'clue3D'}
+
+class UpgradeWorkflow_ticl_FastJet(UpgradeWorkflow):
+    def setup_(self, step, stepName, stepDict, k, properties):
+        if 'RecoGlobal' in step:
+            stepDict[stepName][k] = merge([self.step3, stepDict[step][k]])
+        if 'HARVESTGlobal' in step:
+            stepDict[stepName][k] = merge([self.step4, stepDict[step][k]])
+    def condition(self, fragment, stepList, key, hasHarvest):
+        return (fragment=="TTbar_14TeV" or 'CloseByPGun_CE' in fragment) and '2026' in key
+upgradeWFs['ticl_FastJet'] = UpgradeWorkflow_ticl_FastJet(
+    steps = [
+        'RecoGlobal',
+        'HARVESTGlobal'
+    ],
+    PU = [
+        'RecoGlobal',
+        'HARVESTGlobal'
+    ],
+    suffix = '_ticl_FastJet',
+    offset = 0.202,
+)
+upgradeWFs['ticl_FastJet'].step3 = {'--procModifiers': 'fastJetTICL'}
+upgradeWFs['ticl_FastJet'].step4 = {'--procModifiers': 'fastJetTICL'}
 
 # Track DNN workflows
 class UpgradeWorkflow_trackdnn(UpgradeWorkflow):

--- a/RecoHGCal/TICL/plugins/BuildFile.xml
+++ b/RecoHGCal/TICL/plugins/BuildFile.xml
@@ -29,6 +29,7 @@
 <use name="TrackingTools/GeomPropagators"/>
 <use name="TrackingTools/Records"/>
 <use name="TrackingTools/TrajectoryState"/>
+<use name="fastjet"/>
 <library file="*.cc" name="RecoHGCalTICLPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/RecoHGCal/TICL/plugins/PatternRecognitionPluginFactory.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionPluginFactory.cc
@@ -1,6 +1,7 @@
 #include "RecoHGCal/TICL/plugins/PatternRecognitionPluginFactory.h"
 #include "PatternRecognitionbyCA.h"
 #include "PatternRecognitionbyCLUE3D.h"
+#include "PatternRecognitionbyFastJet.h"
 #include "FWCore/ParameterSet/interface/ValidatedPluginFactoryMacros.h"
 #include "FWCore/ParameterSet/interface/ValidatedPluginMacros.h"
 
@@ -8,4 +9,5 @@ EDM_REGISTER_VALIDATED_PLUGINFACTORY(PatternRecognitionFactory, "PatternRecognit
 EDM_REGISTER_VALIDATED_PLUGINFACTORY(PatternRecognitionHFNoseFactory, "PatternRecognitionHFNoseFactory");
 DEFINE_EDM_VALIDATED_PLUGIN(PatternRecognitionFactory, ticl::PatternRecognitionbyCA<TICLLayerTiles>, "CA");
 DEFINE_EDM_VALIDATED_PLUGIN(PatternRecognitionFactory, ticl::PatternRecognitionbyCLUE3D<TICLLayerTiles>, "CLUE3D");
+DEFINE_EDM_VALIDATED_PLUGIN(PatternRecognitionFactory, ticl::PatternRecognitionbyFastJet<TICLLayerTiles>, "FastJet");
 DEFINE_EDM_VALIDATED_PLUGIN(PatternRecognitionHFNoseFactory, ticl::PatternRecognitionbyCA<TICLLayerTilesHFNose>, "CA");

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyFastJet.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyFastJet.cc
@@ -1,0 +1,329 @@
+// Author: Marco Rovere - marco.rovere@cern.ch
+// Date: 04/2021
+#include <algorithm>
+#include <set>
+#include <vector>
+
+#include "tbb/task_arena.h"
+#include "tbb/tbb.h"
+
+#include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/Math/interface/LorentzVector.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "PatternRecognitionbyFastJet.h"
+
+#include "TrackstersPCA.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+
+#include "fastjet/ClusterSequence.hh"
+
+
+using namespace ticl;
+using namespace fastjet;
+
+  template <typename TILES>
+PatternRecognitionbyFastJet<TILES>::PatternRecognitionbyFastJet(const edm::ParameterSet &conf,
+    const CacheBase *cache,
+    edm::ConsumesCollector iC)
+  : PatternRecognitionAlgoBaseT<TILES>(conf, cache, iC),
+  caloGeomToken_(iC.esConsumes<CaloGeometry, CaloGeometryRecord>()),
+  minNumLayerCluster_(conf.getParameter<int>("minNumLayerCluster")),
+  eidInputName_(conf.getParameter<std::string>("eid_input_name")),
+  eidOutputNameEnergy_(conf.getParameter<std::string>("eid_output_name_energy")),
+  eidOutputNameId_(conf.getParameter<std::string>("eid_output_name_id")),
+  eidMinClusterEnergy_(conf.getParameter<double>("eid_min_cluster_energy")),
+  eidNLayers_(conf.getParameter<int>("eid_n_layers")),
+  eidNClusters_(conf.getParameter<int>("eid_n_clusters")),
+  eidSession_(nullptr) {
+    // mount the tensorflow graph onto the session when set
+    const TrackstersCache *trackstersCache = dynamic_cast<const TrackstersCache *>(cache);
+    if (trackstersCache == nullptr || trackstersCache->eidGraphDef == nullptr) {
+      throw cms::Exception("MissingGraphDef")
+        << "PatternRecognitionbyFastJet received an empty graph definition from the global cache";
+    }
+    eidSession_ = tensorflow::createSession(trackstersCache->eidGraphDef);
+  }
+
+template <typename TILES>
+void PatternRecognitionbyFastJet<TILES>::makeTracksters(
+    const typename PatternRecognitionAlgoBaseT<TILES>::Inputs &input,
+    std::vector<Trackster> &result,
+    std::unordered_map<int, std::vector<int>> &seedToTracksterAssociation) {
+  // Protect from events with no seeding regions
+  if (input.regions.empty())
+    return;
+
+  edm::EventSetup const &es = input.es;
+  const CaloGeometry &geom = es.getData(caloGeomToken_);
+  rhtools_.setGeometry(geom);
+
+  int type = input.tiles[0].typeT();
+  int nEtaBin = (type == 1) ? ticl::TileConstantsHFNose::nEtaBins : ticl::TileConstants::nEtaBins;
+  int nPhiBin = (type == 1) ? ticl::TileConstantsHFNose::nPhiBins : ticl::TileConstants::nPhiBins;
+
+  // We need to partition the two sides of the HGCAL detector
+  auto lastLayerPerSide = static_cast<unsigned int>(rhtools_.lastLayer(false)) - 1;
+  unsigned int maxLayer = 2 * lastLayerPerSide - 1;
+  std::vector<fastjet::PseudoJet> fjInputs;
+  fjInputs.clear();
+  for (unsigned int currentLayer = 0; currentLayer <= maxLayer ; ++currentLayer) {
+    if (currentLayer == lastLayerPerSide) {
+      if (PatternRecognitionAlgoBaseT<TILES>::algo_verbosity_ > PatternRecognitionAlgoBaseT<TILES>::Basic) {
+        edm::LogVerbatim("PatternRecogntionbyFastJet") << "Creating FastJet at later "
+          << currentLayer
+          << " with " << fjInputs.size() << " LayerClusters in input";
+      }
+      fastjet::ClusterSequence sequence(fjInputs, JetDefinition(antikt_algorithm, 0.1));
+      auto jets = fastjet::sorted_by_pt(sequence.inclusive_jets(0));
+      if (PatternRecognitionAlgoBaseT<TILES>::algo_verbosity_ > PatternRecognitionAlgoBaseT<TILES>::Basic) {
+        edm::LogVerbatim("PatternRecogntionbyFastJet") << "FastJet produced "
+          << jets.size() << " jets/trackster";
+      }
+
+      auto trackster_idx = result.size();
+      result.resize(trackster_idx + jets.size());
+      for (const auto &pj : jets) {
+        for (const auto &component : pj.constituents()) {
+          result[trackster_idx].vertices().push_back(component.user_index());
+          result[trackster_idx].vertex_multiplicity().push_back(1);
+          if (PatternRecognitionAlgoBaseT<TILES>::algo_verbosity_ > PatternRecognitionAlgoBaseT<TILES>::Basic) {
+            edm::LogVerbatim("PatternRecogntionbyFastJet") << "Jet has "
+              << pj.constituents().size() << " components that are stored in trackster " << trackster_idx;
+          }
+        }
+        trackster_idx++;
+      }
+      fjInputs.clear();
+    }
+    const auto &tileOnLayer = input.tiles[currentLayer];
+    for (int ieta = 0; ieta <= nEtaBin; ++ieta) {
+      auto offset = ieta * nPhiBin;
+      if (PatternRecognitionAlgoBaseT<TILES>::algo_verbosity_ > PatternRecognitionAlgoBaseT<TILES>::Advanced) {
+        edm::LogVerbatim("PatternRecogntionbyFastJet") << "offset: " << offset;
+      }
+      for (int iphi = 0; iphi <= nPhiBin; ++iphi) {
+        if (PatternRecognitionAlgoBaseT<TILES>::algo_verbosity_ > PatternRecognitionAlgoBaseT<TILES>::Advanced) {
+          edm::LogVerbatim("PatternRecogntionbyFastJet") << "iphi: " << iphi;
+          edm::LogVerbatim("PatternRecogntionbyFastJet")
+            << "Entries in tileBin: " << tileOnLayer[offset + iphi].size();
+        }
+        for (auto clusterIdx : tileOnLayer[offset + iphi]) {
+          // Skip masked layer clusters
+          if (input.mask[clusterIdx] == 0.) {
+            if (PatternRecognitionAlgoBaseT<TILES>::algo_verbosity_ > PatternRecognitionAlgoBaseT<TILES>::Advanced) {
+              edm::LogVerbatim("PatternRecogntionbyFastJet") << "Skipping masked layerIdx " << clusterIdx;
+            }
+            continue;
+          }
+          // Should we correct for the position of the PV?
+          auto const & cl = input.layerClusters[clusterIdx];
+          math::XYZVector direction(cl.x(), cl.y(), cl.z());
+          direction = direction.Unit();
+          direction *= cl.energy();
+          auto fpj = fastjet::PseudoJet(direction.X(), direction.Y(), direction.Z(), cl.energy());
+          fpj.set_user_index(clusterIdx);
+          fjInputs.push_back(fpj);
+        }  // End of loop on the clusters on currentLayer
+      }  // End of loop over phi-bin region
+    }  // End of loop over eta-bin region
+  }  // End of loop over layers
+  if (PatternRecognitionAlgoBaseT<TILES>::algo_verbosity_ > PatternRecognitionAlgoBaseT<TILES>::Basic) {
+    edm::LogVerbatim("PatternRecogntionbyFastJet") << "Creating FastJet for the opposite side with " << fjInputs.size() << " LayerClusters in input";
+  }
+  fastjet::ClusterSequence sequence(fjInputs, JetDefinition(antikt_algorithm, 0.1));
+  auto jets = fastjet::sorted_by_pt(sequence.inclusive_jets(0));
+  if (PatternRecognitionAlgoBaseT<TILES>::algo_verbosity_ > PatternRecognitionAlgoBaseT<TILES>::Basic) {
+    edm::LogVerbatim("PatternRecogntionbyFastJet") << "FastJet produced "
+      << jets.size() << " jets/trackster";
+  }
+
+  auto trackster_idx = result.size();
+  result.resize(trackster_idx + jets.size());
+  for (const auto &pj : jets) {
+    for (const auto &component : pj.constituents()) {
+      result[trackster_idx].vertices().push_back(component.user_index());
+      result[trackster_idx].vertex_multiplicity().push_back(1);
+      if (PatternRecognitionAlgoBaseT<TILES>::algo_verbosity_ > PatternRecognitionAlgoBaseT<TILES>::Basic) {
+        edm::LogVerbatim("PatternRecogntionbyFastJet") << "Jet has "
+          << pj.constituents().size() << " components that are stored in trackster " << trackster_idx;
+      }
+    }
+    trackster_idx++;
+  }
+  fjInputs.clear();
+
+  ticl::assignPCAtoTracksters(result,
+                              input.layerClusters,
+                              input.layerClustersTime,
+                              rhtools_.getPositionLayer(rhtools_.lastLayerEE(false), false).z());
+
+  // run energy regression and ID
+  energyRegressionAndID(input.layerClusters, result);
+  if (PatternRecognitionAlgoBaseT<TILES>::algo_verbosity_ > PatternRecognitionAlgoBaseT<TILES>::Basic) {
+    for (auto const &t : result) {
+      edm::LogVerbatim("PatternRecogntionbyFastJet") << "Barycenter: " << t.barycenter();
+      edm::LogVerbatim("PatternRecogntionbyFastJet") << "LCs: " << t.vertices().size();
+      edm::LogVerbatim("PatternRecogntionbyFastJet") << "Energy: " << t.raw_energy();
+      edm::LogVerbatim("PatternRecogntionbyFastJet") << "Regressed: " << t.regressed_energy();
+    }
+  }
+
+}
+
+template <typename TILES>
+void PatternRecognitionbyFastJet<TILES>::energyRegressionAndID(const std::vector<reco::CaloCluster> &layerClusters,
+                                                              std::vector<Trackster> &tracksters) {
+  // Energy regression and particle identification strategy:
+  //
+  // 1. Set default values for regressed energy and particle id for each trackster.
+  // 2. Store indices of tracksters whose total sum of cluster energies is above the
+  //    eidMinClusterEnergy_ (GeV) treshold. Inference is not applied for soft tracksters.
+  // 3. When no trackster passes the selection, return.
+  // 4. Create input and output tensors. The batch dimension is determined by the number of
+  //    selected tracksters.
+  // 5. Fill input tensors with layer cluster features. Per layer, clusters are ordered descending
+  //    by energy. Given that tensor data is contiguous in memory, we can use pointer arithmetic to
+  //    fill values, even with batching.
+  // 6. Zero-fill features for empty clusters in each layer.
+  // 7. Batched inference.
+  // 8. Assign the regressed energy and id probabilities to each trackster.
+  //
+  // Indices used throughout this method:
+  // i -> batch element / trackster
+  // j -> layer
+  // k -> cluster
+  // l -> feature
+
+  // set default values per trackster, determine if the cluster energy threshold is passed,
+  // and store indices of hard tracksters
+  std::vector<int> tracksterIndices;
+  for (int i = 0; i < static_cast<int>(tracksters.size()); i++) {
+    // calculate the cluster energy sum (2)
+    // note: after the loop, sumClusterEnergy might be just above the threshold which is enough to
+    // decide whether to run inference for the trackster or not
+    float sumClusterEnergy = 0.;
+    for (const unsigned int &vertex : tracksters[i].vertices()) {
+      sumClusterEnergy += static_cast<float>(layerClusters[vertex].energy());
+      // there might be many clusters, so try to stop early
+      if (sumClusterEnergy >= eidMinClusterEnergy_) {
+        // set default values (1)
+        tracksters[i].setRegressedEnergy(0.f);
+        tracksters[i].zeroProbabilities();
+        tracksterIndices.push_back(i);
+        break;
+      }
+    }
+  }
+
+  // do nothing when no trackster passes the selection (3)
+  int batchSize = static_cast<int>(tracksterIndices.size());
+  if (batchSize == 0) {
+    return;
+  }
+
+  // create input and output tensors (4)
+  tensorflow::TensorShape shape({batchSize, eidNLayers_, eidNClusters_, eidNFeatures_});
+  tensorflow::Tensor input(tensorflow::DT_FLOAT, shape);
+  tensorflow::NamedTensorList inputList = {{eidInputName_, input}};
+
+  std::vector<tensorflow::Tensor> outputs;
+  std::vector<std::string> outputNames;
+  if (!eidOutputNameEnergy_.empty()) {
+    outputNames.push_back(eidOutputNameEnergy_);
+  }
+  if (!eidOutputNameId_.empty()) {
+    outputNames.push_back(eidOutputNameId_);
+  }
+
+  // fill input tensor (5)
+  for (int i = 0; i < batchSize; i++) {
+    const Trackster &trackster = tracksters[tracksterIndices[i]];
+
+    // per layer, we only consider the first eidNClusters_ clusters in terms of energy, so in order
+    // to avoid creating large / nested structures to do the sorting for an unknown number of total
+    // clusters, create a sorted list of layer cluster indices to keep track of the filled clusters
+    std::vector<int> clusterIndices(trackster.vertices().size());
+    for (int k = 0; k < (int)trackster.vertices().size(); k++) {
+      clusterIndices[k] = k;
+    }
+    sort(clusterIndices.begin(), clusterIndices.end(), [&layerClusters, &trackster](const int &a, const int &b) {
+      return layerClusters[trackster.vertices(a)].energy() > layerClusters[trackster.vertices(b)].energy();
+    });
+
+    // keep track of the number of seen clusters per layer
+    std::vector<int> seenClusters(eidNLayers_);
+
+    // loop through clusters by descending energy
+    for (const int &k : clusterIndices) {
+      // get features per layer and cluster and store the values directly in the input tensor
+      const reco::CaloCluster &cluster = layerClusters[trackster.vertices(k)];
+      int j = rhtools_.getLayerWithOffset(cluster.hitsAndFractions()[0].first) - 1;
+      if (j < eidNLayers_ && seenClusters[j] < eidNClusters_) {
+        // get the pointer to the first feature value for the current batch, layer and cluster
+        float *features = &input.tensor<float, 4>()(i, j, seenClusters[j], 0);
+
+        // fill features
+        *(features++) = float(cluster.energy() / float(trackster.vertex_multiplicity(k)));
+        *(features++) = float(std::abs(cluster.eta()));
+        *(features) = float(cluster.phi());
+
+        // increment seen clusters
+        seenClusters[j]++;
+      }
+    }
+
+    // zero-fill features of empty clusters in each layer (6)
+    for (int j = 0; j < eidNLayers_; j++) {
+      for (int k = seenClusters[j]; k < eidNClusters_; k++) {
+        float *features = &input.tensor<float, 4>()(i, j, k, 0);
+        for (int l = 0; l < eidNFeatures_; l++) {
+          *(features++) = 0.f;
+        }
+      }
+    }
+  }
+
+  // run the inference (7)
+  tensorflow::run(eidSession_, inputList, outputNames, &outputs);
+
+  // store regressed energy per trackster (8)
+  if (!eidOutputNameEnergy_.empty()) {
+    // get the pointer to the energy tensor, dimension is batch x 1
+    float *energy = outputs[0].flat<float>().data();
+
+    for (const int &i : tracksterIndices) {
+      tracksters[i].setRegressedEnergy(*(energy++));
+    }
+  }
+
+  // store id probabilities per trackster (8)
+  if (!eidOutputNameId_.empty()) {
+    // get the pointer to the id probability tensor, dimension is batch x id_probabilities.size()
+    int probsIdx = eidOutputNameEnergy_.empty() ? 0 : 1;
+    float *probs = outputs[probsIdx].flat<float>().data();
+
+    for (const int &i : tracksterIndices) {
+      tracksters[i].setProbabilities(probs);
+      probs += tracksters[i].id_probabilities().size();
+    }
+  }
+}
+
+template <typename TILES>
+void PatternRecognitionbyFastJet<TILES>::fillPSetDescription(edm::ParameterSetDescription &iDesc) {
+  iDesc.add<int>("algo_verbosity", 0);
+  iDesc.add<int>("minNumLayerCluster", 5)->setComment("Not Inclusive");
+  iDesc.add<std::string>("eid_input_name", "input");
+  iDesc.add<std::string>("eid_output_name_energy", "output/regressed_energy");
+  iDesc.add<std::string>("eid_output_name_id", "output/id_probabilities");
+  iDesc.add<double>("eid_min_cluster_energy", 1.);
+  iDesc.add<int>("eid_n_layers", 50);
+  iDesc.add<int>("eid_n_clusters", 10);
+}
+
+template class ticl::PatternRecognitionbyFastJet<TICLLayerTiles>;

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyFastJet.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyFastJet.cc
@@ -1,5 +1,5 @@
 // Author: Marco Rovere - marco.rovere@cern.ch
-// Date: 04/2021
+// Date: 10/2021
 #include <algorithm>
 #include <set>
 #include <vector>
@@ -99,12 +99,12 @@ void PatternRecognitionbyFastJet<TILES>::makeTracksters(
   const CaloGeometry &geom = es.getData(caloGeomToken_);
   rhtools_.setGeometry(geom);
 
-  int type = input.tiles[0].typeT();
-  int nEtaBin = (type == 1) ? ticl::TileConstantsHFNose::nEtaBins : ticl::TileConstants::nEtaBins;
-  int nPhiBin = (type == 1) ? ticl::TileConstantsHFNose::nPhiBins : ticl::TileConstants::nPhiBins;
+  constexpr auto isHFnose = std::is_same<TILES, TICLLayerTilesHFNose>::value;
+  constexpr int nEtaBin = TILES::constants_type_t::nEtaBins;
+  constexpr int nPhiBin = TILES::constants_type_t::nPhiBins;
 
   // We need to partition the two sides of the HGCAL detector
-  auto lastLayerPerSide = static_cast<unsigned int>(rhtools_.lastLayer(false)) - 1;
+  auto lastLayerPerSide = static_cast<unsigned int>(rhtools_.lastLayer(isHFnose)) - 1;
   unsigned int maxLayer = 2 * lastLayerPerSide - 1;
   std::vector<fastjet::PseudoJet> fjInputs;
   fjInputs.clear();
@@ -150,7 +150,7 @@ void PatternRecognitionbyFastJet<TILES>::makeTracksters(
   ticl::assignPCAtoTracksters(result,
                               input.layerClusters,
                               input.layerClustersTime,
-                              rhtools_.getPositionLayer(rhtools_.lastLayerEE(false), false).z());
+                              rhtools_.getPositionLayer(rhtools_.lastLayerEE(isHFnose), isHFnose).z());
 
   // run energy regression and ID
   energyRegressionAndID(input.layerClusters, result);

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyFastJet.h
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyFastJet.h
@@ -1,5 +1,5 @@
 // Author: Marco Rovere - marco.rovere@cern.ch
-// Date: 04/2021
+// Date: 10/2021
 
 #ifndef __RecoHGCal_TICL_PRbyFASTJET_H__
 #define __RecoHGCal_TICL_PRbyFASTJET_H__

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyFastJet.h
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyFastJet.h
@@ -9,7 +9,9 @@
 
 // fwd declaration
 
-namespace fastjet { class PseudoJet;};
+namespace fastjet {
+  class PseudoJet;
+};
 
 namespace ticl {
   template <typename TILES>
@@ -27,7 +29,6 @@ namespace ticl {
     static void fillPSetDescription(edm::ParameterSetDescription& iDesc);
 
   private:
-
     edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeomToken_;
     const double antikt_radius_;
     const int minNumLayerCluster_;
@@ -43,7 +44,7 @@ namespace ticl {
 
     static const int eidNFeatures_ = 3;
 
-    void buildJetAndTracksters(std::vector<fastjet::PseudoJet> &, std::vector<ticl::Trackster> &);
+    void buildJetAndTracksters(std::vector<fastjet::PseudoJet>&, std::vector<ticl::Trackster>&);
   };
 
 }  // namespace ticl

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyFastJet.h
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyFastJet.h
@@ -7,6 +7,10 @@
 #include "RecoHGCal/TICL/interface/PatternRecognitionAlgoBase.h"
 #include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
 
+// fwd declaration
+
+namespace fastjet { class PseudoJet;};
+
 namespace ticl {
   template <typename TILES>
   class PatternRecognitionbyFastJet final : public PatternRecognitionAlgoBaseT<TILES> {
@@ -25,6 +29,7 @@ namespace ticl {
   private:
 
     edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeomToken_;
+    const double antikt_radius_;
     const int minNumLayerCluster_;
     const std::string eidInputName_;
     const std::string eidOutputNameEnergy_;
@@ -37,6 +42,8 @@ namespace ticl {
     tensorflow::Session* eidSession_;
 
     static const int eidNFeatures_ = 3;
+
+    void buildJetAndTracksters(std::vector<fastjet::PseudoJet> &, std::vector<ticl::Trackster> &);
   };
 
 }  // namespace ticl

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyFastJet.h
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyFastJet.h
@@ -1,0 +1,43 @@
+// Author: Marco Rovere - marco.rovere@cern.ch
+// Date: 04/2021
+
+#ifndef __RecoHGCal_TICL_PRbyFASTJET_H__
+#define __RecoHGCal_TICL_PRbyFASTJET_H__
+#include <memory>  // unique_ptr
+#include "RecoHGCal/TICL/interface/PatternRecognitionAlgoBase.h"
+#include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
+
+namespace ticl {
+  template <typename TILES>
+  class PatternRecognitionbyFastJet final : public PatternRecognitionAlgoBaseT<TILES> {
+  public:
+    PatternRecognitionbyFastJet(const edm::ParameterSet& conf, const CacheBase* cache, edm::ConsumesCollector);
+    ~PatternRecognitionbyFastJet() override = default;
+
+    void makeTracksters(const typename PatternRecognitionAlgoBaseT<TILES>::Inputs& input,
+                        std::vector<Trackster>& result,
+                        std::unordered_map<int, std::vector<int>>& seedToTracksterAssociation) override;
+
+    void energyRegressionAndID(const std::vector<reco::CaloCluster>& layerClusters, std::vector<Trackster>& result);
+
+    static void fillPSetDescription(edm::ParameterSetDescription& iDesc);
+
+  private:
+
+    edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeomToken_;
+    const int minNumLayerCluster_;
+    const std::string eidInputName_;
+    const std::string eidOutputNameEnergy_;
+    const std::string eidOutputNameId_;
+    const float eidMinClusterEnergy_;
+    const int eidNLayers_;
+    const int eidNClusters_;
+
+    hgcal::RecHitTools rhtools_;
+    tensorflow::Session* eidSession_;
+
+    static const int eidNFeatures_ = 3;
+  };
+
+}  // namespace ticl
+#endif

--- a/RecoHGCal/TICL/plugins/TrackstersProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersProducer.cc
@@ -135,12 +135,17 @@ void TrackstersProducer::fillDescriptions(edm::ConfigurationDescriptions& descri
   // CA Plugin
   edm::ParameterSetDescription pluginDesc;
   pluginDesc.addNode(edm::PluginDescription<PatternRecognitionFactory>("type", "CA", true));
-
-  // CLUE3D Plugin
   desc.add<edm::ParameterSetDescription>("pluginPatternRecognitionByCA", pluginDesc);
+  //
+  // CLUE3D Plugin
   edm::ParameterSetDescription pluginDescClue3D;
   pluginDescClue3D.addNode(edm::PluginDescription<PatternRecognitionFactory>("type", "CLUE3D", true));
   desc.add<edm::ParameterSetDescription>("pluginPatternRecognitionByCLUE3D", pluginDescClue3D);
+
+  // FastJet Plugin
+  edm::ParameterSetDescription pluginDescFastJet;
+  pluginDescFastJet.addNode(edm::PluginDescription<PatternRecognitionFactory>("type", "FastJet", true));
+  desc.add<edm::ParameterSetDescription>("pluginPatternRecognitionByFastJet", pluginDescFastJet);
 
   descriptions.add("trackstersProducer", desc);
 }

--- a/RecoHGCal/TICL/python/FastJetStep_cff.py
+++ b/RecoHGCal/TICL/python/FastJetStep_cff.py
@@ -1,0 +1,32 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoHGCal.TICL.TICLSeedingRegions_cff import ticlSeedingGlobal, ticlSeedingGlobalHFNose
+from RecoHGCal.TICL.trackstersProducer_cfi import trackstersProducer as _trackstersProducer
+from RecoHGCal.TICL.filteredLayerClustersProducer_cfi import filteredLayerClustersProducer as _filteredLayerClustersProducer
+from RecoHGCal.TICL.multiClustersFromTrackstersProducer_cfi import multiClustersFromTrackstersProducer as _multiClustersFromTrackstersProducer
+
+# CLUSTER FILTERING/MASKING
+
+filteredLayerClustersFastJet = _filteredLayerClustersProducer.clone(
+    clusterFilter = "ClusterFilterByAlgoAndSize",
+    min_cluster_size = 3, # inclusive
+    algo_number = 8,
+    iteration_label = "FastJet"
+)
+
+# PATTERN RECOGNITION
+
+ticlTrackstersFastJet = _trackstersProducer.clone(
+    filtered_mask = "filteredLayerClustersFastJet:FastJet",
+    seeding_regions = "ticlSeedingGlobal",
+    itername = "FastJet",
+    patternRecognitionBy = "FastJet",
+    pluginPatternRecognitionByFastJet = dict (
+        algo_verbosity = 2
+    )
+)
+
+ticlFastJetStepTask = cms.Task(ticlSeedingGlobal
+    ,filteredLayerClustersFastJet
+    ,ticlTrackstersFastJet)
+

--- a/RecoHGCal/TICL/python/iterativeTICL_cff.py
+++ b/RecoHGCal/TICL/python/iterativeTICL_cff.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
+from RecoHGCal.TICL.FastJetStep_cff import *
 from RecoHGCal.TICL.CLUE3DHighStep_cff import *
 from RecoHGCal.TICL.CLUE3DLowStep_cff import *
 from RecoHGCal.TICL.MIPStep_cff import *
@@ -30,6 +31,9 @@ ticlIterationsTask = cms.Task(
 
 from Configuration.ProcessModifiers.clue3D_cff import clue3D
 clue3D.toModify(ticlIterationsTask, func=lambda x : x.add(ticlCLUE3DHighStepTask,ticlCLUE3DLowStepTask))
+
+from Configuration.ProcessModifiers.fastJetTICL_cff import fastJetTICL
+fastJetTICL.toModify(ticlIterationsTask, func=lambda x : x.add(ticlFastJetStepTask))
 
 ticlIterLabels = [_step.itername.value() for _iteration in ticlIterationsTask for _step in _iteration if (_step._TypedParameterizable__type == "TrackstersProducer")]
 


### PR DESCRIPTION
#### PR description:

A novel pattern recognition plugin has been added to the `TICL` framework based on `FastJet`.
At present, only `anti-kt` clustering algorithm has been added. All algorithms from the rich `FastJet` library could be tested using different configurations.
A `processModifier` has been added to allow the end-user to enable this plugin. The modifier is called `fastJetTICL`.
The modifier has been added in such a way that all the validation plots for the Tracksters produced by the `FastJet` pattern recognition will be automatically produced.
At present jets are translated into `Tracksters`. As a future development, if needed, we could save also the reconstructed `jets`.
It would be nice to have this code integrated into the release, even if not bundled to any official workflow, to allow interested people to develop on top of that.

You can find some more information about its `performance` (it's quite hard to call them as such, as of yet...) [here](https://indico.cern.ch/event/1088389/contributions/4575464/attachments/2331927/3974172/20211021_HGCAL_WM_FastJet_MR.pdf).
This PR has also been recently _announced_ during [this](https://indico.cern.ch/event/1095576/contributions/4608272/attachments/2345071/3998685/HGCAL%20Reco%20meeting%20November%202021.pdf) reconstruction meeting.

#### PR validation:

Run on `Phase2` dedicated workflows and private _multiparticle_ samples w/o issues.

