### PR TITLE
improve robustness of a HLT customisation used for L1T re-emulation

### DIFF
--- a/HLTrigger/Configuration/python/CustomConfigs.py
+++ b/HLTrigger/Configuration/python/CustomConfigs.py
@@ -120,25 +120,28 @@ def HLTDropPrevious(process):
     return(process)
 
 
-def L1REPACK(process,sequence="Full"):
+def L1REPACK(process, sequence="Full"):
 
     from Configuration.Eras.Era_Run3_cff import Run3
-    l1repack = cms.Process('L1REPACK',Run3)
+    l1repack = cms.Process('L1REPACK', Run3)
     l1repack.load('Configuration.StandardSequences.SimL1EmulatorRepack_'+sequence+'_cff')
 
     for module in l1repack.es_sources_():
-        if (not hasattr(process,module)):
-            setattr(process,module,getattr(l1repack,module))
+        if not hasattr(process, module):
+            setattr(process, module, getattr(l1repack, module))
     for module in l1repack.es_producers_():
-        if (not hasattr(process,module)):
-            setattr(process,module,getattr(l1repack,module))
+        if not hasattr(process, module):
+            setattr(process, module, getattr(l1repack, module))
 
     for module in l1repack.SimL1Emulator.expandAndClone().moduleNames():
-        setattr(process,module,getattr(l1repack,module))
-    for task in l1repack.tasks_():
-        setattr(process,task,getattr(l1repack,task))
-    for sequence in l1repack.sequences_():
-        setattr(process,sequence,getattr(l1repack,sequence))
+        setattr(process, module, getattr(l1repack, module))
+    for taskName, task in l1repack.tasks_().items():
+        if l1repack.SimL1Emulator.contains(task):
+            setattr(process, taskName, task)
+    for sequenceName, sequence in l1repack.sequences_().items():
+        if l1repack.SimL1Emulator.contains(sequence):
+            setattr(process, sequenceName, sequence)
+
     process.SimL1Emulator = l1repack.SimL1Emulator
 
     for path in process.paths_():
@@ -147,43 +150,11 @@ def L1REPACK(process,sequence="Full"):
         getattr(process,path).insert(0,process.SimL1Emulator)
 
     # special L1T cleanup
-    cleanupL1T = ('SimL1TCalorimeter'
-                  ,'SimL1TCalorimeterTask'
-                  ,'SimL1TMuonCommon'
-                  ,'SimL1TMuonCommonTask'
-                  ,'SimL1TMuon'
-                  ,'SimL1TMuonTask'
-                  ,'SimL1TechnicalTriggers'
-                  ,'SimL1TechnicalTriggersTask'
-                  ,'SimL1EmulatorCore'
-                  ,'SimL1EmulatorCoreTask'
-                  ,'ecalDigiSequence'
-                  ,'ecalDigiTask'
-                  ,'hcalDigiSequence'
-                  ,'hcalDigiTask'
-                  ,'calDigi'
-                  ,'calDigiTask'
-                  ,'me0TriggerPseudoDigis'
-                  ,'me0TriggerPseudoDigiTask'
-                  ,'simMuonGEMPadTask'
-                  ,'hgcalTriggerPrimitives'
-                  ,'hgcalTriggerPrimitivesTask'
-                  ,'hgcalVFE'
-                  ,'hgcalVFEProducer'
-                  ,'hgcalBackEndLayer2'
-                  ,'hgcalBackEndLayer2Producer'
-                  ,'hgcalTowerMap'
-                  ,'hgcalTowerMapProducer'
-                  ,'hgcalConcentrator'
-                  ,'hgcalConcentratorProducer'
-                  ,'hgcalBackEndLayer1'
-                  ,'hgcalBackEndLayer1Producer'
-                  ,'hgcalTower'
-                  ,'hgcalTowerProducer'
-                  ,'hgcalTriggerGeometryESProducer')
-    for obj in cleanupL1T:
-        if hasattr(process,obj):
-            delattr(process,obj)
+    for obj in [
+      'hgcalTriggerGeometryESProducer',
+    ]:
+        if hasattr(process, obj):
+            delattr(process, obj)
 
     return process
 


### PR DESCRIPTION
#### PR description:

This PR is an attempt to make one of the customisations used by HLT a bit more robust against changes in L1T configurations.
I haven't tested this extensively, and I welcome feedback (@Martin-Grunewald , @silviodonato , @Sam-Harper , @fwyzard).

The function in question is `L1REPACK`, and it is used to re-rerun the L1-Trigger emulation together with the HLT reconstruction.

Due to how the L1-Trigger sequences are configured, `L1REPACK` presently loads in the `process` several objects (modules, sequences, tasks) which are not needed in Run-3 configs (e.g. Phase-2 modules), and then removes them a posteriori based on a list of hard-coded names. Under certain conditions, this can lead to invalid configs, as recently reported by a user.

The update here tries to make the removal a bit more robust, adding to the `process` only the objects that are used by the sequence `SimL1Emulator` (which, I think, is all HLT ultimately uses).

Still, I ended up keeping the list of "manual removals" due to one L1T `ESProducer`. Hopefully, this can be improved in the future.

#### PR validation:

Validated with the following test:
```bash
hltGetConfiguration /dev/CMSSW_12_2_0/GRun --globaltag auto:run3_hlt  --data --unprescale \
 --input /store/data/Run2018D/EphemeralHLTPhysics1/RAW/v1/000/323/775/00000/2E066536-5CF2-B340-A73B-209640F29FF6.root \
 --customise HLTrigger/Configuration/customizeHLTforCMSSW.customiseFor2018Input --l1-emulator uGT > hlt.py
(edmConfigDump hlt.py | grep -v 'L1T WARN: ') > hlt_dump.py
(edmConfigDump --prune hlt.py | grep -v 'L1T WARN: ') > hlt_dump_pruned.py
```
 * `hlt.py` works both before and after the PR
 * `python3 hlt_dump.py` does not work without the PR; after the PR, `cmsRun hlt_dump.py` works, and `hlt_dump.py` does not contain unnecessary L1T modules/sequences/tasks (e.g. L1T Phase-2 objects)
 * `hlt_dump_pruned.py` (the final pruned version of the full configuration) is unchanged by this PR (modulo one module which is kept on a `Task` instead being put directly on a Path, b/c `L1REPACK` deletes that particular Task manually without the PR)

*Note* : the `grep` bit is an hack to avoid 2 printouts from L1T that make their way into the stdout of `edmConfigDump`.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

N/A