### PR TITLE
[Tracker Alignment] update split vertex validation

### DIFF
--- a/Alignment/OfflineValidation/macros/FitPVResiduals.C
+++ b/Alignment/OfflineValidation/macros/FitPVResiduals.C
@@ -99,6 +99,12 @@ PVValidationVariables::PVValidationVariables(
 
   // check if the base dir exists
   file = TFile::Open(fileName.Data(), "READ");
+
+  if (!file) {
+    std::cout << "ERROR! file " << fileName.Data() << " does not exist!" << std::endl;
+    assert(false);
+  }
+
   if (file->Get(baseDir.Data())) {
     std::cout << "found base directory: " << baseDir.Data() << std::endl;
   } else {

--- a/Alignment/OfflineValidation/macros/FitPVResolution.C
+++ b/Alignment/OfflineValidation/macros/FitPVResolution.C
@@ -8,6 +8,7 @@
 #include "TCanvas.h"
 #include "TObject.h"
 #include "TStyle.h"
+#include "TSystem.h"
 #include "TClass.h"
 #include "TLegend.h"
 #include "TObjString.h"
@@ -24,6 +25,15 @@
 #define PLOTTING_MACRO  // to remove message logger
 #include "Alignment/OfflineValidation/interface/PVValidationHelpers.h"
 #include "Alignment/OfflineValidation/macros/CMS_lumi.h"
+
+/* 
+   Store here the globals binning settings
+*/
+
+float SUMPTMIN = 1.;
+float SUMPTMAX = 1e3;
+int TRACKBINS = 60;
+int VTXBINS = 40;
 
 /* 
    This is an auxilliary class to store the list of files
@@ -65,10 +75,16 @@ PVResolutionVariables::PVResolutionVariables(
 
   // check if the base dir exists
   file = TFile::Open(fileName.Data(), "READ");
+
+  if (!file) {
+    std::cout << "ERROR! file " << fileName.Data() << " does not exist!" << std::endl;
+    assert(false);
+  }
+
   if (file->Get(baseDir.Data())) {
-    std::cout << "found base directory: " << baseDir.Data() << std::endl;
+    std::cout << fileName.Data() << ", found base directory: " << baseDir.Data() << std::endl;
   } else {
-    std::cout << "no directory named: " << baseDir.Data() << std::endl;
+    std::cout << fileName.Data() << ", no directory named: " << baseDir.Data() << std::endl;
     assert(false);
   }
 }
@@ -118,9 +134,19 @@ statmode::fitParams fitResolutions(TH1* hist, bool singleTime = false);
 void makeNiceTrendPlotStyle(TH1* hist, Int_t color, Int_t style);
 void adjustMaximum(TH1F* histos[], int size);
 
+// inline function
+namespace pvresol {
+  int check(const double a[], int n) {
+    //while (--n > 0 && a[n] == a[0])    // exact match
+    while (--n > 0 && (a[n] - a[0]) < 0.01)  // merged input files, protection agains numerical precision
+      ;
+    return n != 0;
+  }
+}  // namespace pvresol
+
 // MAIN
 //*************************************************************
-void FitPVResolution(TString namesandlabels, TString theDate = "") {
+void FitPVResolution(TString namesandlabels, TString theDate = "", bool isStrict = false) {
   //*************************************************************
 
   bool fromLoader = false;
@@ -203,23 +229,128 @@ void FitPVResolution(TString namesandlabels, TString theDate = "") {
     std::cout << "FitPVResolution::FitPVResolution(): label[" << j << "] " << LegLabels[j] << std::endl;
   }
 
+  // get the binnings
+  TH1F* theBinHistos[nFiles_];
+  double theSumPtMin_[nFiles_];
+  double theSumPtMax_[nFiles_];
+  double theTrackBINS_[nFiles_];
+  double theVtxBINS_[nFiles_];
+
+  for (Int_t i = 0; i < nFiles_; i++) {
+    fins[i]->cd("PrimaryVertexResolution/BinningFeatures/");
+    if (gDirectory->GetListOfKeys()->Contains("h_profileBinnings")) {
+      gDirectory->GetObject("h_profileBinnings", theBinHistos[i]);
+      theSumPtMin_[i] =
+          theBinHistos[i]->GetBinContent(1) / (theBinHistos[i]->GetEntries() / theBinHistos[i]->GetNbinsX());
+      std::cout << "File n. " << i << " has theSumPtMin[" << i << "] = " << theSumPtMin_[i] << std::endl;
+      theSumPtMax_[i] =
+          theBinHistos[i]->GetBinContent(2) / (theBinHistos[i]->GetEntries() / theBinHistos[i]->GetNbinsX());
+      std::cout << "File n. " << i << " has theSumPtMax[" << i << "] = " << theSumPtMax_[i] << std::endl;
+      theTrackBINS_[i] =
+          theBinHistos[i]->GetBinContent(3) / (theBinHistos[i]->GetEntries() / theBinHistos[i]->GetNbinsX());
+      std::cout << "File n. " << i << " has theTrackBINS[" << i << "] = " << theTrackBINS_[i] << std::endl;
+      theVtxBINS_[i] =
+          theBinHistos[i]->GetBinContent(4) / (theBinHistos[i]->GetEntries() / theBinHistos[i]->GetNbinsX());
+      std::cout << "File n. " << i << " has theVtxBINS[" << i << "] = " << theVtxBINS_[i] << std::endl;
+    } else {
+      theSumPtMin_[i] = 1.;
+      std::cout << "File n. " << i << " getting the default minimum sum pT range: " << theSumPtMin_[i] << std::endl;
+      theSumPtMax_[i] = 1e3;
+      std::cout << "File n. " << i << " getting the default maxmum sum pT range: " << theSumPtMax_[i] << std::endl;
+      theTrackBINS_[i] = 60.;
+      std::cout << "File n. " << i << " getting the default number of tracks bins: " << theTrackBINS_[i] << std::endl;
+      theTrackBINS_[i] = 40.;
+      std::cout << "File n. " << i << " getting the default number of vertices bins: " << theVtxBINS_[i] << std::endl;
+    }
+  }
+
+  // checks if all minimum sum pT ranges coincide
+  // if not, exits
+  if (pvresol::check(theSumPtMin_, nFiles_)) {
+    std::cout << "======================================================" << std::endl;
+    std::cout << "FitPVResolution::FitPVResolution(): the minimum sum pT is different" << std::endl;
+    std::cout << "exiting..." << std::endl;
+    exit(EXIT_FAILURE);
+  } else {
+    SUMPTMIN = theSumPtMin_[0];
+    std::cout << "======================================================" << std::endl;
+    std::cout << "FitPVResolution::FitPVResolution(): the minimum sum pT is: " << SUMPTMIN << std::endl;
+    std::cout << "======================================================" << std::endl;
+  }
+
+  // checks if all maximum sum pT ranges coincide
+  // if not, exits
+  if (pvresol::check(theSumPtMax_, nFiles_)) {
+    std::cout << "======================================================" << std::endl;
+    std::cout << "FitPVResolution::FitPVResolution(): the maximum sum pT is different" << std::endl;
+    std::cout << "exiting..." << std::endl;
+    exit(EXIT_FAILURE);
+  } else {
+    SUMPTMAX = theSumPtMax_[0];
+    std::cout << "======================================================" << std::endl;
+    std::cout << "FitPVResolution::FitPVResolution(): the maximum sum pT is: " << SUMPTMAX << std::endl;
+    std::cout << "======================================================" << std::endl;
+  }
+
+  // checks if all number of tracks bins coincide
+  // if not, exits
+  if (pvresol::check(theTrackBINS_, nFiles_)) {
+    std::cout << "======================================================" << std::endl;
+    std::cout << "FitPVResolution::FitPVResolution(): the number of track bins is different" << std::endl;
+    if (isStrict) {
+      std::cout << "exiting..." << std::endl;
+      std::cout << "======================================================" << std::endl;
+      exit(EXIT_FAILURE);  //this is stricter
+    } else {
+      TRACKBINS = *std::max_element(theTrackBINS_, theTrackBINS_ + nFiles_);
+      std::cout << "chosen the maximum: " << TRACKBINS << std::endl;
+      std::cout << "======================================================" << std::endl;
+    }
+  } else {
+    TRACKBINS = int(theTrackBINS_[0]);
+    std::cout << "======================================================" << std::endl;
+    std::cout << "FitPVResolution::FitPVResolution(): the number of track bins is: " << TRACKBINS << std::endl;
+    std::cout << "======================================================" << std::endl;
+  }
+
+  // checks if all number of vertices bins coincide
+  // if not, exits
+  if (pvresol::check(theVtxBINS_, nFiles_)) {
+    std::cout << "======================================================" << std::endl;
+    std::cout << "FitPVResolution::FitPVResolution(): the number of vertices bins is different" << std::endl;
+    if (isStrict) {
+      std::cout << "exiting..." << std::endl;
+      std::cout << "======================================================" << std::endl;
+      exit(EXIT_FAILURE);  //this is stricter
+    } else {
+      VTXBINS = *std::max_element(theVtxBINS_, theVtxBINS_ + nFiles_);
+      std::cout << "chosen the maximum: " << VTXBINS << std::endl;
+      std::cout << "======================================================" << std::endl;
+    }
+  } else {
+    VTXBINS = int(theVtxBINS_[0]);
+    std::cout << "======================================================" << std::endl;
+    std::cout << "FitPVResolution::FitPVResolution(): the number of vertices bins is: " << VTXBINS << std::endl;
+    std::cout << "======================================================" << std::endl;
+  }
+
   // max vertices
-  const int max_n_vertices = 40;
-  std::array<float, max_n_vertices + 1> myNVtx_bins_;
+  const int max_n_vertices = std::min(40, VTXBINS);  // take the minimum to avoid overflow
+  std::vector<float> myNVtx_bins_;
   for (float i = 0; i <= max_n_vertices; i++) {
-    myNVtx_bins_[i] = 1. + i;
+    myNVtx_bins_.push_back(1. + i);
   }
 
   // max track
-  const int max_n_tracks = 60;
-  std::array<float, max_n_tracks + 1> myNTrack_bins_;
+  const int max_n_tracks = std::min(60, TRACKBINS);  // take the minimum to avoid overflow
+  std::vector<float> myNTrack_bins_;
   for (float i = 0; i <= max_n_tracks; i++) {
-    myNTrack_bins_[i] = 1 + i * 2;
+    myNTrack_bins_.push_back(1 + i * 2);
   }
 
   // max sumPt
   const int max_sum_pt = 30;
-  std::array<float, max_sum_pt + 1> mypT_bins_ = PVValHelper::makeLogBins<float, max_sum_pt>(1., 1e3);
+  std::array<float, max_sum_pt + 1> mypT_bins_ = PVValHelper::makeLogBins<float, max_sum_pt>(SUMPTMIN, SUMPTMAX);
 
   // define the maps
   std::unordered_map<std::string, TH1F*> hpulls_;
@@ -857,7 +988,7 @@ void fillTrendPlotByIndex(TH1F* trendPlot,
       std::smatch match;
       if (std::regex_search(iterator.first, match, toMatch) && match.size() > 1) {
         result = match.str(1);
-        bin = std::stoi(result) + 1;
+        bin = std::stoi(result);
       } else {
         result = std::string("");
         continue;

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexResolution.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexResolution.py
@@ -15,6 +15,10 @@ class PrimaryVertexResolution(GenericValidationData, ValidationWithPlots):
         # N.B.: the reference needs to be updated each time the format of the output is changed
         "pvresolutionreference": ("/store/group/alca_trackeralign/validation/PVResolution/Reference/PrimaryVertexResolution_phaseIMC92X_upgrade2017_Ideal.root"),
         "multiIOV":"False",
+        "startScale":"1.",
+        "endScale":"1000.",
+        "nTracksBins":"60.",
+        "nVtxBins":"40."
     }
     #mandatories = {"isda","ismc","runboundary","trackcollection","vertexcollection","lumilist","ptCut","etaCut","runControl","numberOfBins"}
     mandatories = {"runControl","runboundary","doTriggerSelection","triggerBits","trackcollection"}

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexResolutionTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexResolutionTemplates.py
@@ -64,9 +64,12 @@ process.PrimaryVertexResolution = cms.EDAnalyzer('SplitVertexResolution',
                                                  minVertexNdf        = cms.untracked.double(10.),
                                                  minVertexMeanWeight = cms.untracked.double(0.5),
                                                  runControl = cms.untracked.bool(.oO[runControl]Oo.),
-                                                 runControlNumber = cms.untracked.vuint32(runboundary)
+                                                 runControlNumber = cms.untracked.vuint32(runboundary),
+                                                 sumpTStartScale = cms.untracked.double(.oO[startScale]Oo.),
+                                                 sumpTEndScale = cms.untracked.double(.oO[endScale]Oo.),
+                                                 nTrackBins = cms.untracked.double(.oO[nTracksBins]Oo.),
+                                                 nVtxBins = cms.untracked.double(.oO[nVtxBins]Oo.)
                                                  )
-
 """
 
 ####################################################################

--- a/Alignment/OfflineValidation/test/PrimaryVertexResolution_cfg.py
+++ b/Alignment/OfflineValidation/test/PrimaryVertexResolution_cfg.py
@@ -171,7 +171,11 @@ process.PrimaryVertexResolution = cms.EDAnalyzer('SplitVertexResolution',
                                                  minVertexNdf        = cms.untracked.double(10.),
                                                  minVertexMeanWeight = cms.untracked.double(0.5),
                                                  runControl = cms.untracked.bool(True),
-                                                 runControlNumber = cms.untracked.vuint32(320040)
+                                                 runControlNumber = cms.untracked.vuint32(320040),
+                                                 sumpTStartScale = cms.untracked.double(1.),
+                                                 sumpTEndScale = cms.untracked.double(1000.),
+                                                 nTrackBins = cms.untracked.double(60.),
+                                                 nVtxBins = cms.untracked.double(40.)
                                                  )
 
 process.TFileService = cms.Service("TFileService",

--- a/Alignment/OfflineValidation/test/PrimaryVertexResolution_templ_cfg.py
+++ b/Alignment/OfflineValidation/test/PrimaryVertexResolution_templ_cfg.py
@@ -148,7 +148,11 @@ process.PrimaryVertexResolution = cms.EDAnalyzer('SplitVertexResolution',
                                                  minVertexNdf        = cms.untracked.double(10.),
                                                  minVertexMeanWeight = cms.untracked.double(0.5),
                                                  runControl = cms.untracked.bool(True),
-                                                 runControlNumber = cms.untracked.vuint32(int(XXX_RUN_XXX))
+                                                 runControlNumber = cms.untracked.vuint32(int(XXX_RUN_XXX)),
+                                                 sumpTStartScale = cms.untracked.double(1.),
+                                                 sumpTEndScale = cms.untracked.double(1000.),
+                                                 nTrackBins = cms.untracked.double(60.),
+                                                 nVtxBins = cms.untracked.double(40.)
                                                  )
 
 process.TFileService = cms.Service("TFileService",


### PR DESCRIPTION
#### PR description:

The purpose of this PR is to update the codes for the Split Vertex validation used in Tracker Alignment to make the x-axis limits of the trend plots vs vertex sumPt and the binnings of the profiles vs #tracks and #vertices to be configurable.
The current setup is sort of hardcoded and optimized for the 13TeV collisions and this was a shortcoming found during the validation of the alignment candidates for the Fall 2021 LHC beam test at sqrt=900GeV.
The configurability is percolated all the way down to the all-in-one meta-tool and some checks on the coincidence of the x-axis setup are introduced in the plotting macro `FitPVResolution`.  
I profit of this PR to introduce `fillDescriptions` method to `SplitVertexResolution`. 

#### PR validation:

Private. Some results are available [here](http://musich.web.cern.ch/musich/testBeamTest/splitVertex/v4/)
as example:

![image](https://user-images.githubusercontent.com/5082376/142682453-c1204168-7593-4da0-b465-5a525f6ad395.png)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
