### PR TITLE
Adding muon MVA ID

### DIFF
--- a/DataFormats/MuonReco/interface/Muon.h
+++ b/DataFormats/MuonReco/interface/Muon.h
@@ -233,10 +233,12 @@ namespace reco {
       MvaVVTight = 1UL << 31,
       LowPtMvaLoose = 1UL << 32,
       LowPtMvaMedium = 1UL << 33,
+      MvaIDwpMedium = 1UL << 34,
+      MvaIDwpTight = 1UL << 35,
     };
 
     bool passed(uint64_t selection) const { return (selectors_ & selection) == selection; }
-    bool passed(Selector selection) const { return passed(static_cast<unsigned int>(selection)); }
+    bool passed(Selector selection) const { return passed(static_cast<uint64_t>(selection)); }
     uint64_t selectors() const { return selectors_; }
     void setSelectors(uint64_t selectors) { selectors_ = selectors; }
     void setSelector(Selector selector, bool passed) {

--- a/DataFormats/MuonReco/interface/MuonSelectors.h
+++ b/DataFormats/MuonReco/interface/MuonSelectors.h
@@ -139,6 +139,8 @@ namespace muon {
       {"MvaVVTight", reco::Muon::MvaVVTight},
       {"LowPtMvaLoose", reco::Muon::LowPtMvaLoose},
       {"LowPtMvaMedium", reco::Muon::LowPtMvaMedium},
+      {"MvaIDwpMedium", reco::Muon::MvaIDwpMedium},
+      {"MvaIDwpTight", reco::Muon::MvaIDwpTight},
       {nullptr, (reco::Muon::Selector)-1}};
 
   reco::Muon::Selector selectorFromString(const std::string& label);

--- a/DataFormats/PatCandidates/interface/Muon.h
+++ b/DataFormats/PatCandidates/interface/Muon.h
@@ -293,7 +293,11 @@ namespace pat {
     /// Soft Muon MVA
     float softMvaValue() const { return softMvaValue_; }
     void setSoftMvaValue(float softmva) { softMvaValue_ = softmva; }
-
+    
+    /// Muon MVA ID
+    float mvaIDValue() const { return mvaIDValue_; }
+    void setMvaIDValue(float mvaID) { mvaIDValue_ = mvaID; }
+    
     // 1/beta for prompt particle hypothesis
     /// (time is constraint to the bunch crossing time)
     float inverseBeta() const { return inverseBeta_; }
@@ -418,6 +422,7 @@ namespace pat {
     /// Muon MVA
     float mvaValue_;
     float lowptMvaValue_;
+    float mvaIDValue_;
     float softMvaValue_;
 
     /// Inverse beta

--- a/DataFormats/PatCandidates/interface/Muon.h
+++ b/DataFormats/PatCandidates/interface/Muon.h
@@ -293,11 +293,11 @@ namespace pat {
     /// Soft Muon MVA
     float softMvaValue() const { return softMvaValue_; }
     void setSoftMvaValue(float softmva) { softMvaValue_ = softmva; }
-    
+
     /// Muon MVA ID
     float mvaIDValue() const { return mvaIDValue_; }
     void setMvaIDValue(float mvaID) { mvaIDValue_ = mvaID; }
-    
+
     // 1/beta for prompt particle hypothesis
     /// (time is constraint to the bunch crossing time)
     float inverseBeta() const { return inverseBeta_; }

--- a/DataFormats/PatCandidates/src/Muon.cc
+++ b/DataFormats/PatCandidates/src/Muon.cc
@@ -33,6 +33,7 @@ Muon::Muon()
       jetPtRel_(0),
       mvaValue_(0),
       lowptMvaValue_(0),
+      mvaIDValue_(0),
       softMvaValue_(0),
       inverseBeta_(0),
       inverseBetaErr_(0) {
@@ -64,6 +65,7 @@ Muon::Muon(const reco::Muon& aMuon)
       jetPtRel_(0),
       mvaValue_(0),
       lowptMvaValue_(0),
+      mvaIDValue_(0),
       softMvaValue_(0),
       inverseBeta_(0),
       inverseBetaErr_(0) {
@@ -95,6 +97,7 @@ Muon::Muon(const edm::RefToBase<reco::Muon>& aMuonRef)
       jetPtRel_(0),
       mvaValue_(0),
       lowptMvaValue_(0),
+      mvaIDValue_(0),
       softMvaValue_(0),
       inverseBeta_(0),
       inverseBetaErr_(0) {
@@ -126,6 +129,7 @@ Muon::Muon(const edm::Ptr<reco::Muon>& aMuonRef)
       jetPtRel_(0),
       mvaValue_(0),
       lowptMvaValue_(0),
+      mvaIDValue_(0),
       softMvaValue_(0),
       inverseBeta_(0),
       inverseBetaErr_(0) {

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -67,7 +67,8 @@
   </ioread>
 
 
-  <class name="pat::Muon"  ClassVersion="28">
+  <class name="pat::Muon"  ClassVersion="29">
+   <version ClassVersion="29" checksum="3346528095"/>
    <version ClassVersion="28" checksum="282262684"/>
    <version ClassVersion="27" checksum="3473399161"/>
    <version ClassVersion="26" checksum="1156855644"/>

--- a/PhysicsTools/PatAlgos/interface/MuonMvaIDEstimator.h
+++ b/PhysicsTools/PatAlgos/interface/MuonMvaIDEstimator.h
@@ -1,0 +1,37 @@
+#ifndef __PhysicsTools_PatAlgos_MuonMvaIDEstimator__
+#define __PhysicsTools_PatAlgos_MuonMvaIDEstimator__
+
+#include <memory>
+#include <string>
+#include "PhysicsTools/ONNXRuntime/interface/ONNXRuntime.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+#include "FWCore/Framework/interface/stream/EDAnalyzer.h"
+//
+
+namespace pat {
+  class Muon;
+}
+
+namespace edm {
+  class FileInPath;
+}
+
+namespace pat {
+class MuonMvaIDEstimator {
+ public:
+  MuonMvaIDEstimator(const edm::FileInPath& weightsfile);
+  ~MuonMvaIDEstimator();
+	 
+	   static void fillDescriptions(edm::ConfigurationDescriptions &);
+	   static std::unique_ptr<cms::Ort::ONNXRuntime> initializeGlobalCache(const edm::ParameterSet &);
+	   static void globalEndJob(const cms::Ort::ONNXRuntime *);
+	   std::vector<float> computeMVAID(const pat::Muon& imuon) const;
+	   
+	private:
+	   std::vector<std::string> flav_names_;             // names of the output scores
+	   std::vector<std::string> input_names_;            // names of each input group - the ordering is important!
+           std::unique_ptr<const cms::Ort::ONNXRuntime> randomForest_;
+	 };
+};	 
+#endif

--- a/PhysicsTools/PatAlgos/interface/MuonMvaIDEstimator.h
+++ b/PhysicsTools/PatAlgos/interface/MuonMvaIDEstimator.h
@@ -24,7 +24,6 @@ namespace pat {
     ~MuonMvaIDEstimator() = default;
 
     static void fillDescriptions(edm::ConfigurationDescriptions &);
-    static std::unique_ptr<cms::Ort::ONNXRuntime> initializeGlobalCache(const edm::ParameterSet &);
     static void globalEndJob(const cms::Ort::ONNXRuntime *);
     std::vector<float> computeMVAID(const pat::Muon &imuon) const;
 

--- a/PhysicsTools/PatAlgos/interface/MuonMvaIDEstimator.h
+++ b/PhysicsTools/PatAlgos/interface/MuonMvaIDEstimator.h
@@ -1,5 +1,5 @@
-#ifndef __PhysicsTools_PatAlgos_MuonMvaIDEstimator__
-#define __PhysicsTools_PatAlgos_MuonMvaIDEstimator__
+#ifndef PhysicsTools_PatAlgos_MuonMvaIDEstimator_h
+#define PhysicsTools_PatAlgos_MuonMvaIDEstimator_h
 
 #include <memory>
 #include <string>
@@ -21,7 +21,7 @@ namespace pat {
   class MuonMvaIDEstimator {
   public:
     MuonMvaIDEstimator(const edm::FileInPath &weightsfile);
-    ~MuonMvaIDEstimator();
+    ~MuonMvaIDEstimator() = default;
 
     static void fillDescriptions(edm::ConfigurationDescriptions &);
     static std::unique_ptr<cms::Ort::ONNXRuntime> initializeGlobalCache(const edm::ParameterSet &);

--- a/PhysicsTools/PatAlgos/interface/MuonMvaIDEstimator.h
+++ b/PhysicsTools/PatAlgos/interface/MuonMvaIDEstimator.h
@@ -18,20 +18,20 @@ namespace edm {
 }
 
 namespace pat {
-class MuonMvaIDEstimator {
- public:
-  MuonMvaIDEstimator(const edm::FileInPath& weightsfile);
-  ~MuonMvaIDEstimator();
-	 
-	   static void fillDescriptions(edm::ConfigurationDescriptions &);
-	   static std::unique_ptr<cms::Ort::ONNXRuntime> initializeGlobalCache(const edm::ParameterSet &);
-	   static void globalEndJob(const cms::Ort::ONNXRuntime *);
-	   std::vector<float> computeMVAID(const pat::Muon& imuon) const;
-	   
-	private:
-	   std::vector<std::string> flav_names_;             // names of the output scores
-	   std::vector<std::string> input_names_;            // names of each input group - the ordering is important!
-           std::unique_ptr<const cms::Ort::ONNXRuntime> randomForest_;
-	 };
-};	 
+  class MuonMvaIDEstimator {
+  public:
+    MuonMvaIDEstimator(const edm::FileInPath &weightsfile);
+    ~MuonMvaIDEstimator();
+
+    static void fillDescriptions(edm::ConfigurationDescriptions &);
+    static std::unique_ptr<cms::Ort::ONNXRuntime> initializeGlobalCache(const edm::ParameterSet &);
+    static void globalEndJob(const cms::Ort::ONNXRuntime *);
+    std::vector<float> computeMVAID(const pat::Muon &imuon) const;
+
+  private:
+    std::vector<std::string> flav_names_;   // names of the output scores
+    std::vector<std::string> input_names_;  // names of each input group - the ordering is important!
+    std::unique_ptr<const cms::Ort::ONNXRuntime> randomForest_;
+  };
+};  // namespace pat
 #endif

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -1049,15 +1049,18 @@ void PATMuonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
     // MVA ID
     float mvaID = 0.0;
+    constexpr int MVAsentinelValue = -99;
+    constexpr float mvaIDmediumCut = 0.12;
+    constexpr float mvaIDtightCut = 0.48;
     if (computeMuonIDMVA_) {
       if (muon.isLooseMuon() && muon.passed(reco::Muon::PFIsoTight)) {
         mvaID = globalCache()->muonMvaIDEstimator().computeMVAID(muon)[1];
       } else {
-        mvaID = -99;
+        mvaID = MVAsentinelValue;
       }
       muon.setMvaIDValue(mvaID);
-      muon.setSelector(reco::Muon::MvaIDwpMedium, muon.mvaIDValue() > 0.12);
-      muon.setSelector(reco::Muon::MvaIDwpTight, muon.mvaIDValue() > 0.48);
+      muon.setSelector(reco::Muon::MvaIDwpMedium, muon.mvaIDValue() > mvaIDmediumCut);
+      muon.setSelector(reco::Muon::MvaIDwpTight, muon.mvaIDValue() > mvaIDtightCut);
     }
 
     //SOFT MVA

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -1049,15 +1049,15 @@ void PATMuonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
     // MVA ID
     float mvaID = 0.0;
-    if (computeMuonIDMVA_){
-	  mvaID = globalCache()->muonMvaIDEstimator().computeMVAID(muon)[1];
-	  muon.setMvaIDValue(mvaID);
-	  if(muon.isLooseMuon() && muon.passed(reco::Muon::PFIsoTight)){
-	    muon.setSelector(reco::Muon::MvaIDwpMedium, muon.mvaIDValue() > 0.12);
+    if (computeMuonIDMVA_) {
+      mvaID = globalCache()->muonMvaIDEstimator().computeMVAID(muon)[1];
+      muon.setMvaIDValue(mvaID);
+      if (muon.isLooseMuon() && muon.passed(reco::Muon::PFIsoTight)) {
+        muon.setSelector(reco::Muon::MvaIDwpMedium, muon.mvaIDValue() > 0.12);
         muon.setSelector(reco::Muon::MvaIDwpTight, muon.mvaIDValue() > 0.48);
-	   }
+      }
     }
-    
+
     //SOFT MVA
     if (computeSoftMuonMVA_) {
       float mva = globalCache()->softMuonMvaEstimator().computeMva(muon);

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -1050,12 +1050,12 @@ void PATMuonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     // MVA ID
     float mvaID = 0.0;
     if (computeMuonIDMVA_) {
-      mvaID = globalCache()->muonMvaIDEstimator().computeMVAID(muon)[1];
-      muon.setMvaIDValue(mvaID);
       if (muon.isLooseMuon() && muon.passed(reco::Muon::PFIsoTight)) {
-        muon.setSelector(reco::Muon::MvaIDwpMedium, muon.mvaIDValue() > 0.12);
-        muon.setSelector(reco::Muon::MvaIDwpTight, muon.mvaIDValue() > 0.48);
-      }
+        mvaID = globalCache()->muonMvaIDEstimator().computeMVAID(muon)[1];}
+      else{mvaID=-99;}
+      muon.setMvaIDValue(mvaID);
+      muon.setSelector(reco::Muon::MvaIDwpMedium, muon.mvaIDValue() > 0.12);
+      muon.setSelector(reco::Muon::MvaIDwpTight, muon.mvaIDValue() > 0.48);
     }
 
     //SOFT MVA

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -1053,7 +1053,7 @@ void PATMuonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     constexpr float mvaIDmediumCut = 0.08;
     constexpr float mvaIDtightCut = 0.6;
     if (computeMuonIDMVA_) {
-      if (muon.isLooseMuon() && muon.passed(reco::Muon::PFIsoTight)) {
+      if (muon.isLooseMuon()) {
         mvaID = globalCache()->muonMvaIDEstimator().computeMVAID(muon)[1];
       } else {
         mvaID = MVAsentinelValue;

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -1051,7 +1051,7 @@ void PATMuonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     float mvaID = 0.0;
     constexpr int MVAsentinelValue = -99;
     constexpr float mvaIDmediumCut = 0.08;
-    constexpr float mvaIDtightCut = 0.6;
+    constexpr float mvaIDtightCut = 0.49;
     if (computeMuonIDMVA_) {
       if (muon.isLooseMuon()) {
         mvaID = globalCache()->muonMvaIDEstimator().computeMVAID(muon)[1];

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -1051,8 +1051,10 @@ void PATMuonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     float mvaID = 0.0;
     if (computeMuonIDMVA_) {
       if (muon.isLooseMuon() && muon.passed(reco::Muon::PFIsoTight)) {
-        mvaID = globalCache()->muonMvaIDEstimator().computeMVAID(muon)[1];}
-      else{mvaID=-99;}
+        mvaID = globalCache()->muonMvaIDEstimator().computeMVAID(muon)[1];
+      } else {
+        mvaID = -99;
+      }
       muon.setMvaIDValue(mvaID);
       muon.setSelector(reco::Muon::MvaIDwpMedium, muon.mvaIDValue() > 0.12);
       muon.setSelector(reco::Muon::MvaIDwpTight, muon.mvaIDValue() > 0.48);

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -1050,8 +1050,8 @@ void PATMuonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     // MVA ID
     float mvaID = 0.0;
     constexpr int MVAsentinelValue = -99;
-    constexpr float mvaIDmediumCut = 0.12;
-    constexpr float mvaIDtightCut = 0.48;
+    constexpr float mvaIDmediumCut = 0.08;
+    constexpr float mvaIDtightCut = 0.6;
     if (computeMuonIDMVA_) {
       if (muon.isLooseMuon() && muon.passed(reco::Muon::PFIsoTight)) {
         mvaID = globalCache()->muonMvaIDEstimator().computeMVAID(muon)[1];

--- a/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py
@@ -110,7 +110,9 @@ patMuons = cms.EDProducer("PATMuonProducer",
     # Depends on MiniIsolation, so only works in miniaod
     # Don't forget to set flags properly in miniAOD_tools.py                      
     computeMuonMVA = cms.bool(False),
+    computeMuonIDMVA = cms.bool(False),
     mvaTrainingFile      = cms.FileInPath("RecoMuon/MuonIdentification/data/mu_2017_BDTG.weights.xml"),
+    mvaIDTrainingFile      = cms.FileInPath("RecoMuon/MuonIdentification/data/mvaID.onnx"),
     lowPtmvaTrainingFile = cms.FileInPath("RecoMuon/MuonIdentification/data/mu_lowpt_BDTG.weights.xml"),
     recomputeBasicSelectors = cms.bool(True),
     mvaUseJec = cms.bool(True),

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -31,6 +31,7 @@ def miniAOD_customizeCommon(process):
 
     process.patMuons.computeMiniIso = True
     process.patMuons.computeMuonMVA = True
+    process.patMuons.computeMuonIDMVA = True
     process.patMuons.computeSoftMuonMVA = True
 
     process.patMuons.addTriggerMatching = True

--- a/PhysicsTools/PatAlgos/src/MuonMvaIDEstimator.cc
+++ b/PhysicsTools/PatAlgos/src/MuonMvaIDEstimator.cc
@@ -12,7 +12,7 @@ using namespace cms::Ort;
 
 MuonMvaIDEstimator::MuonMvaIDEstimator(const edm::FileInPath &weightsfile) {
   randomForest_ = std::make_unique<ONNXRuntime>(weightsfile.fullPath());
-  std::cout << randomForest_.get() << std::endl;
+  LogDebug("MuonMvaIDEstimator") << randomForest_.get();
 }
 
 void MuonMvaIDEstimator::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {

--- a/PhysicsTools/PatAlgos/src/MuonMvaIDEstimator.cc
+++ b/PhysicsTools/PatAlgos/src/MuonMvaIDEstimator.cc
@@ -22,78 +22,85 @@
 using namespace pat;
 using namespace cms::Ort;
 
-MuonMvaIDEstimator::MuonMvaIDEstimator(const edm::FileInPath& weightsfile){
+MuonMvaIDEstimator::MuonMvaIDEstimator(const edm::FileInPath &weightsfile) {
   randomForest_ = std::make_unique<ONNXRuntime>(weightsfile.fullPath());
   std::cout << randomForest_.get() << std::endl;
 }
 
-
 MuonMvaIDEstimator::~MuonMvaIDEstimator() {}
- 
- void MuonMvaIDEstimator::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
-   // pfDeepBoostedJetTags
-   edm::ParameterSetDescription desc;
-   desc.add<edm::FileInPath>("mvaIDTrainingFile",
-                             edm::FileInPath("RecoMuon/MuonIdentification/data/mvaID.onnx"));
-   desc.add<std::vector<std::string>>("flav_names",
-                                      std::vector<std::string>{
-                                          "probBAD",
-                                          "probGOOD",
-                                      });
- 
-   descriptions.addWithDefaultLabel(desc);
- }
- 
- std::unique_ptr<cms::Ort::ONNXRuntime> MuonMvaIDEstimator::initializeGlobalCache(const edm::ParameterSet &iConfig) {
-   return std::make_unique<cms::Ort::ONNXRuntime>(iConfig.getParameter<edm::FileInPath>("mvaIDTrainingFile").fullPath());
- }
- void MuonMvaIDEstimator::globalEndJob(const cms::Ort::ONNXRuntime *cache) {}
- const reco::Muon::ArbitrationType arbitrationType = reco::Muon::SegmentAndTrackArbitration;
- std::vector<float> MuonMvaIDEstimator::computeMVAID(const pat::Muon& muon) const {
-   float local_chi2  = muon.combinedQuality().chi2LocalPosition;
-   float kink  = muon.combinedQuality().trkKink;  
-     
-   float segment_comp =  muon.segmentCompatibility( arbitrationType);  
-   float n_MatchedStations = muon.numberOfMatchedStations();   
-   float pt = muon.pt();
-   float eta = muon.eta();
-   float global_muon = muon.isGlobalMuon(); 
-   float Valid_pixel;
-   float tracker_layers;
-   float validFraction; 
-   if (muon.innerTrack().isNonnull()){
-       Valid_pixel  = muon.innerTrack()->hitPattern().numberOfValidPixelHits();
-       tracker_layers  = muon.innerTrack()->hitPattern().trackerLayersWithMeasurement();
-       validFraction   = muon.innerTrack()->validFraction();
-       }
-   else{
-       Valid_pixel = -99.;
-       tracker_layers = -99.0;
-       validFraction   = -99.0;
-       } 
-   float norm_chi2; 
-   float n_Valid_hits;
-   if (muon.globalTrack().isNonnull()){
-       norm_chi2  = muon.globalTrack()->normalizedChi2();
-       n_Valid_hits = muon.globalTrack()->hitPattern().numberOfValidMuonHits(); 
-       }
-   else{
-       norm_chi2  = muon.innerTrack()->normalizedChi2();
-       n_Valid_hits = muon.innerTrack()->hitPattern().numberOfValidMuonHits();
-       }
-   std::vector<std::string> input_names_ {"float_input"};
-   std::vector<float> vars = {global_muon,validFraction,norm_chi2,local_chi2,kink,segment_comp,n_Valid_hits,n_MatchedStations,Valid_pixel,tracker_layers,pt,eta};
-   std::vector<std::string> flav_names_{"probBAD","probGOOD"};
-   //for (long unsigned int i=0; i < vars.size(); i++){
-   //  input_values_.emplace_back(vars[i]);
-   //}
-   cms::Ort::FloatArrays input_values_;
-   //cms::Ort::FloatArrays outputs;
-   input_values_.emplace_back(vars);
-   std::vector<float> outputs;  // init as all zeros
-   //std::cout << Form("%d -- %d",input_values_[10], input_values_[11]) << std::endl;
-   std::cout << randomForest_.get() << std::endl;
-   outputs = randomForest_->run(input_names_, input_values_, {}, {"probabilities"})[0];
-   assert(outputs.size() == flav_names_.size());
-   return outputs;
+
+void MuonMvaIDEstimator::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+  // pfDeepBoostedJetTags
+  edm::ParameterSetDescription desc;
+  desc.add<edm::FileInPath>("mvaIDTrainingFile", edm::FileInPath("RecoMuon/MuonIdentification/data/mvaID.onnx"));
+  desc.add<std::vector<std::string>>("flav_names",
+                                     std::vector<std::string>{
+                                         "probBAD",
+                                         "probGOOD",
+                                     });
+
+  descriptions.addWithDefaultLabel(desc);
+}
+
+std::unique_ptr<cms::Ort::ONNXRuntime> MuonMvaIDEstimator::initializeGlobalCache(const edm::ParameterSet &iConfig) {
+  return std::make_unique<cms::Ort::ONNXRuntime>(iConfig.getParameter<edm::FileInPath>("mvaIDTrainingFile").fullPath());
+}
+void MuonMvaIDEstimator::globalEndJob(const cms::Ort::ONNXRuntime *cache) {}
+const reco::Muon::ArbitrationType arbitrationType = reco::Muon::SegmentAndTrackArbitration;
+std::vector<float> MuonMvaIDEstimator::computeMVAID(const pat::Muon &muon) const {
+  float local_chi2 = muon.combinedQuality().chi2LocalPosition;
+  float kink = muon.combinedQuality().trkKink;
+
+  float segment_comp = muon.segmentCompatibility(arbitrationType);
+  float n_MatchedStations = muon.numberOfMatchedStations();
+  float pt = muon.pt();
+  float eta = muon.eta();
+  float global_muon = muon.isGlobalMuon();
+  float Valid_pixel;
+  float tracker_layers;
+  float validFraction;
+  if (muon.innerTrack().isNonnull()) {
+    Valid_pixel = muon.innerTrack()->hitPattern().numberOfValidPixelHits();
+    tracker_layers = muon.innerTrack()->hitPattern().trackerLayersWithMeasurement();
+    validFraction = muon.innerTrack()->validFraction();
+  } else {
+    Valid_pixel = -99.;
+    tracker_layers = -99.0;
+    validFraction = -99.0;
+  }
+  float norm_chi2;
+  float n_Valid_hits;
+  if (muon.globalTrack().isNonnull()) {
+    norm_chi2 = muon.globalTrack()->normalizedChi2();
+    n_Valid_hits = muon.globalTrack()->hitPattern().numberOfValidMuonHits();
+  } else {
+    norm_chi2 = muon.innerTrack()->normalizedChi2();
+    n_Valid_hits = muon.innerTrack()->hitPattern().numberOfValidMuonHits();
+  }
+  std::vector<std::string> input_names_{"float_input"};
+  std::vector<float> vars = {global_muon,
+                             validFraction,
+                             norm_chi2,
+                             local_chi2,
+                             kink,
+                             segment_comp,
+                             n_Valid_hits,
+                             n_MatchedStations,
+                             Valid_pixel,
+                             tracker_layers,
+                             pt,
+                             eta};
+  std::vector<std::string> flav_names_{"probBAD", "probGOOD"};
+  //for (long unsigned int i=0; i < vars.size(); i++){
+  //  input_values_.emplace_back(vars[i]);
+  //}
+  cms::Ort::FloatArrays input_values_;
+  //cms::Ort::FloatArrays outputs;
+  input_values_.emplace_back(vars);
+  std::vector<float> outputs;  // init as all zeros
+  //std::cout << Form("%d -- %d",input_values_[10], input_values_[11]) << std::endl;
+  std::cout << randomForest_.get() << std::endl;
+  outputs = randomForest_->run(input_names_, input_values_, {}, {"probabilities"})[0];
+  assert(outputs.size() == flav_names_.size());
+  return outputs;
 }

--- a/PhysicsTools/PatAlgos/src/MuonMvaIDEstimator.cc
+++ b/PhysicsTools/PatAlgos/src/MuonMvaIDEstimator.cc
@@ -1,0 +1,99 @@
+#include "PhysicsTools/PatAlgos/interface/MuonMvaIDEstimator.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+//#include "FWCore/Framework/interface/stream/EDProducer.h"
+//#include "FWCore/Utilities/interface/StreamID.h"
+//#include "FWCore/Framework/interface/stream/EDAnalyzer.h"
+
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "CommonTools/MVAUtils/interface/GBRForestTools.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/MuonReco/interface/MuonSelectors.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/JetReco/interface/PFJet.h"
+#include "DataFormats/JetReco/interface/PFJetCollection.h"
+#include "DataFormats/PatCandidates/interface/Muon.h"
+#include "JetMETCorrections/JetCorrector/interface/JetCorrector.h"
+
+using namespace pat;
+using namespace cms::Ort;
+
+MuonMvaIDEstimator::MuonMvaIDEstimator(const edm::FileInPath& weightsfile){
+  randomForest_ = std::make_unique<ONNXRuntime>(weightsfile.fullPath());
+  std::cout << randomForest_.get() << std::endl;
+}
+
+
+MuonMvaIDEstimator::~MuonMvaIDEstimator() {}
+ 
+ void MuonMvaIDEstimator::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+   // pfDeepBoostedJetTags
+   edm::ParameterSetDescription desc;
+   desc.add<edm::FileInPath>("mvaIDTrainingFile",
+                             edm::FileInPath("RecoMuon/MuonIdentification/data/mvaID.onnx"));
+   desc.add<std::vector<std::string>>("flav_names",
+                                      std::vector<std::string>{
+                                          "probBAD",
+                                          "probGOOD",
+                                      });
+ 
+   descriptions.addWithDefaultLabel(desc);
+ }
+ 
+ std::unique_ptr<cms::Ort::ONNXRuntime> MuonMvaIDEstimator::initializeGlobalCache(const edm::ParameterSet &iConfig) {
+   return std::make_unique<cms::Ort::ONNXRuntime>(iConfig.getParameter<edm::FileInPath>("mvaIDTrainingFile").fullPath());
+ }
+ void MuonMvaIDEstimator::globalEndJob(const cms::Ort::ONNXRuntime *cache) {}
+ const reco::Muon::ArbitrationType arbitrationType = reco::Muon::SegmentAndTrackArbitration;
+ std::vector<float> MuonMvaIDEstimator::computeMVAID(const pat::Muon& muon) const {
+   float local_chi2  = muon.combinedQuality().chi2LocalPosition;
+   float kink  = muon.combinedQuality().trkKink;  
+     
+   float segment_comp =  muon.segmentCompatibility( arbitrationType);  
+   float n_MatchedStations = muon.numberOfMatchedStations();   
+   float pt = muon.pt();
+   float eta = muon.eta();
+   float global_muon = muon.isGlobalMuon(); 
+   float Valid_pixel;
+   float tracker_layers;
+   float validFraction; 
+   if (muon.innerTrack().isNonnull()){
+       Valid_pixel  = muon.innerTrack()->hitPattern().numberOfValidPixelHits();
+       tracker_layers  = muon.innerTrack()->hitPattern().trackerLayersWithMeasurement();
+       validFraction   = muon.innerTrack()->validFraction();
+       }
+   else{
+       Valid_pixel = -99.;
+       tracker_layers = -99.0;
+       validFraction   = -99.0;
+       } 
+   float norm_chi2; 
+   float n_Valid_hits;
+   if (muon.globalTrack().isNonnull()){
+       norm_chi2  = muon.globalTrack()->normalizedChi2();
+       n_Valid_hits = muon.globalTrack()->hitPattern().numberOfValidMuonHits(); 
+       }
+   else{
+       norm_chi2  = muon.innerTrack()->normalizedChi2();
+       n_Valid_hits = muon.innerTrack()->hitPattern().numberOfValidMuonHits();
+       }
+   std::vector<std::string> input_names_ {"float_input"};
+   std::vector<float> vars = {global_muon,validFraction,norm_chi2,local_chi2,kink,segment_comp,n_Valid_hits,n_MatchedStations,Valid_pixel,tracker_layers,pt,eta};
+   std::vector<std::string> flav_names_{"probBAD","probGOOD"};
+   //for (long unsigned int i=0; i < vars.size(); i++){
+   //  input_values_.emplace_back(vars[i]);
+   //}
+   cms::Ort::FloatArrays input_values_;
+   //cms::Ort::FloatArrays outputs;
+   input_values_.emplace_back(vars);
+   std::vector<float> outputs;  // init as all zeros
+   //std::cout << Form("%d -- %d",input_values_[10], input_values_[11]) << std::endl;
+   std::cout << randomForest_.get() << std::endl;
+   outputs = randomForest_->run(input_names_, input_values_, {}, {"probabilities"})[0];
+   assert(outputs.size() == flav_names_.size());
+   return outputs;
+}

--- a/PhysicsTools/PatAlgos/src/MuonMvaIDEstimator.cc
+++ b/PhysicsTools/PatAlgos/src/MuonMvaIDEstimator.cc
@@ -7,7 +7,6 @@
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
 #include "DataFormats/PatCandidates/interface/Muon.h"
 
-
 using namespace pat;
 using namespace cms::Ort;
 

--- a/PhysicsTools/PatAlgos/src/MuonMvaIDEstimator.cc
+++ b/PhysicsTools/PatAlgos/src/MuonMvaIDEstimator.cc
@@ -50,7 +50,6 @@ const reco::Muon::ArbitrationType arbitrationType = reco::Muon::SegmentAndTrackA
 std::vector<float> MuonMvaIDEstimator::computeMVAID(const pat::Muon &muon) const {
   float local_chi2 = muon.combinedQuality().chi2LocalPosition;
   float kink = muon.combinedQuality().trkKink;
-
   float segment_comp = muon.segmentCompatibility(arbitrationType);
   float n_MatchedStations = muon.numberOfMatchedStations();
   float pt = muon.pt();
@@ -73,9 +72,12 @@ std::vector<float> MuonMvaIDEstimator::computeMVAID(const pat::Muon &muon) const
   if (muon.globalTrack().isNonnull()) {
     norm_chi2 = muon.globalTrack()->normalizedChi2();
     n_Valid_hits = muon.globalTrack()->hitPattern().numberOfValidMuonHits();
-  } else {
+  } else if(muon.innerTrack().isNonnull()){
     norm_chi2 = muon.innerTrack()->normalizedChi2();
     n_Valid_hits = muon.innerTrack()->hitPattern().numberOfValidMuonHits();
+  } else {
+    norm_chi2 = -99;
+    n_Valid_hits = -99;
   }
   std::vector<std::string> input_names_{"float_input"};
   std::vector<float> vars = {global_muon,
@@ -99,7 +101,7 @@ std::vector<float> MuonMvaIDEstimator::computeMVAID(const pat::Muon &muon) const
   input_values_.emplace_back(vars);
   std::vector<float> outputs;  // init as all zeros
   //std::cout << Form("%d -- %d",input_values_[10], input_values_[11]) << std::endl;
-  std::cout << randomForest_.get() << std::endl;
+  //std::cout << randomForest_.get() << std::endl;
   outputs = randomForest_->run(input_names_, input_values_, {}, {"probabilities"})[0];
   assert(outputs.size() == flav_names_.size());
   return outputs;

--- a/PhysicsTools/PatAlgos/src/MuonMvaIDEstimator.cc
+++ b/PhysicsTools/PatAlgos/src/MuonMvaIDEstimator.cc
@@ -72,7 +72,7 @@ std::vector<float> MuonMvaIDEstimator::computeMVAID(const pat::Muon &muon) const
   if (muon.globalTrack().isNonnull()) {
     norm_chi2 = muon.globalTrack()->normalizedChi2();
     n_Valid_hits = muon.globalTrack()->hitPattern().numberOfValidMuonHits();
-  } else if(muon.innerTrack().isNonnull()){
+  } else if (muon.innerTrack().isNonnull()) {
     norm_chi2 = muon.innerTrack()->normalizedChi2();
     n_Valid_hits = muon.innerTrack()->hitPattern().numberOfValidMuonHits();
   } else {

--- a/PhysicsTools/PatAlgos/src/MuonMvaIDEstimator.cc
+++ b/PhysicsTools/PatAlgos/src/MuonMvaIDEstimator.cc
@@ -27,9 +27,6 @@ void MuonMvaIDEstimator::fillDescriptions(edm::ConfigurationDescriptions &descri
   descriptions.addWithDefaultLabel(desc);
 }
 
-std::unique_ptr<cms::Ort::ONNXRuntime> MuonMvaIDEstimator::initializeGlobalCache(const edm::ParameterSet &iConfig) {
-  return std::make_unique<cms::Ort::ONNXRuntime>(iConfig.getParameter<edm::FileInPath>("mvaIDTrainingFile").fullPath());
-}
 void MuonMvaIDEstimator::globalEndJob(const cms::Ort::ONNXRuntime *cache) {}
 const reco::Muon::ArbitrationType arbitrationType = reco::Muon::SegmentAndTrackArbitration;
 std::vector<float> MuonMvaIDEstimator::computeMVAID(const pat::Muon &muon) const {


### PR DESCRIPTION
#### PR description:
This PR includes the implementation of a new muon identification approach using a MVA:

- This development has been presented in several Muon POG meetings: https://indico.cern.ch/event/1034615/#4-update-on-mva-id 
- The analysis is documented in this Analysis Note: https://gitlab.cern.ch/tdr/notes/AN-21-107
- Twiki: https://twiki.cern.ch/twiki/bin/view/CMS/LeptonMVAID
- In the output there are 3 changes: a new branch with the output of the MVA (muon.mvaIDValue()), two new Selectors with the definition of the proposed Working Points (reco::Muon::MvaIDwpMedium, reco::Muon::MvaIDwpTight) 
- Related PR: to include the MVA model in data repository, in .onnx format -> https://github.com/cms-data/RecoMuon-MuonIdentification/pull/7 

#### PR validation:
- We check the output of the new branch and Working Points running runTheMatrix and everything looks fine.
- We execute the basic tests  suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).
