### PR TITLE
Run3-alca211A Minor changes in the cfg's used for isotrack calibration of HCAL in Calibration/HcalCalibAlgos

### DIFF
--- a/Calibration/HcalCalibAlgos/macros/CalibFitPlots.C
+++ b/Calibration/HcalCalibAlgos/macros/CalibFitPlots.C
@@ -700,6 +700,10 @@ void FitHistExtended(const char* infile,
     numb = 22;
     for (int k = 0; k <= numb; ++k)
       xbins[k] = xbin[k];
+  } else if (type == 1) {
+    numb = 1;
+    xbins[0] = -25;
+    xbins[1] = 25;
   } else {
     int neta = numb / 2;
     for (int k = 0; k < neta; ++k) {

--- a/Calibration/HcalCalibAlgos/test/python/isoTrackAnalysis_cfg.py
+++ b/Calibration/HcalCalibAlgos/test/python/isoTrackAnalysis_cfg.py
@@ -30,7 +30,7 @@ process.TFileService = cms.Service("TFileService",
    fileName = cms.string('outputNew.root')
 )
 
-process.hcalIsoTrackAnalyzer.useRaw = 0   # 2 for Raw
+process.hcalIsoTrackAnalyzer.useRaw = 0   # 1 for Raw
 
 process.p = cms.Path(process.hcalIsoTrackAnalyzer)
 

--- a/Calibration/HcalCalibAlgos/test/python/isoTrackNoHLTAnalysis_cfg.py
+++ b/Calibration/HcalCalibAlgos/test/python/isoTrackNoHLTAnalysis_cfg.py
@@ -30,15 +30,12 @@ process.load('Calibration.HcalCalibAlgos.HcalIsoTrkAnalyzer_cff')
 process.HcalIsoTrkAnalyzer.triggers = []
 process.HcalIsoTrkAnalyzer.useRaw = 0   # 1 for Raw
 process.HcalIsoTrkAnalyzer.ignoreTriggers = True
-#process.HcalIsoTrkAnalyzer.processName  = 'HLTNew1'
-#process.HcalIsoTrkAnalyzer.producerName = 'ALCAISOTRACK'
-#process.HcalIsoTrkAnalyzer.moduleName   = 'IsoProd'
 
 process.source = cms.Source("PoolSource", 
                             fileNames = cms.untracked.vstring(
-        'file:PoolOutput.root'
-#       'file:/afs/cern.ch/user/h/huwang/work/public/for_Sunanda/ALCARECO_MC.root'
-    )
+                                'file:/eos/uscms/store/user/lpcrutgers/huiwang/HCAL/UL_DoublePion_E-50_RECO_DLPHIN_zeroOut_noPU-2021-09-21/MC_RECO_0.root',
+                                'file:/eos/uscms/store/user/lpcrutgers/huiwang/HCAL/UL_DoublePion_E-50_RECO_DLPHIN_zeroOut_noPU-2021-09-21/MC_RECO_1.root'
+                            )
 )
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )

--- a/Calibration/HcalCalibAlgos/test/python/isoTrackRecoAnalysis_cfg.py
+++ b/Calibration/HcalCalibAlgos/test/python/isoTrackRecoAnalysis_cfg.py
@@ -45,7 +45,7 @@ process.HcalIsoTrkAnalyzer.newDepth = [2, 4]
 process.HcalIsoTrkAnalyzer.hep17 = True
 process.HcalIsoTrkAnalyzer.dataType = 0 # 0 for jetHT else 1
 process.HcalIsoTrkAnalyzer.maximumEcalEnergy = 2.0 # set MIP cut  
-process.HcalIsoTrkAnalyzer.useRaw = 0   # 2 for Raw
+process.HcalIsoTrkAnalyzer.useRaw = 0   # 1 for Raw
 process.HcalIsoTrkAnalyzer.unCorrect = True
 
 process.HcalIsoTrkAnalyzer.EEHitEnergyThreshold1 = 0.00 # default 0.30

--- a/Calibration/HcalCalibAlgos/test/python/isoTrackStudy_cfg.py
+++ b/Calibration/HcalCalibAlgos/test/python/isoTrackStudy_cfg.py
@@ -55,7 +55,7 @@ process.hcalIsoTrackStudy.minLayerCrossed =  0
 process.hcalIsoTrackStudy.triggers = []
 process.hcalIsoTrackStudy.dataType = 1 #0 for jetHT else 1
 process.hcalIsoTrackStudy.maximumEcalEnergy = 100 # set MIP cut  
-#process.hcalIsoTrackStudy.useRaw = 2
+#process.hcalIsoTrackStudy.useRaw = 1
 
 process.p = cms.Path(process.hcalIsoTrackStudy)
 


### PR DESCRIPTION
#### PR description:

Minor changes in the cfg's used for isotrack calibration of HCAL in Calibration/HcalCalibAlgos

#### PR validation:

Use the modified cfg's and macros to test run data (pp collision at 900 Gev)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special