### PR TITLE
Extending SeedingHitSet & SeedGeneratorFromProtoTracksEDProducer

### DIFF
--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletEDProducerT.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletEDProducerT.cc
@@ -15,7 +15,10 @@
 namespace {
   void fillNtuplets(RegionsSeedingHitSets::RegionFiller& seedingHitSetsFiller, const OrderedHitSeeds& quadruplets) {
     for (const auto& quad : quadruplets) {
-      seedingHitSetsFiller.emplace_back(quad[0], quad[1], quad[2], quad[3]);
+      if (quad.size() == 3)
+        seedingHitSetsFiller.emplace_back(quad[0], quad[1], quad[2]);
+      if (quad.size() == 4)
+        seedingHitSetsFiller.emplace_back(quad[0], quad[1], quad[2], quad[3]);
     }
   }
 }  // namespace

--- a/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.cc
@@ -139,8 +139,7 @@ void SeedGeneratorFromProtoTracksEDProducer::produce(edm::Event& ev, const edm::
         GlobalTrackingRegion region(mom_perp, vtx, 0.2, 0.2);
 
         seedCreator_.init(region, es, nullptr);
-
-        if (hits.size() == 4 and not includeFourthHit_)
+        if (hits.size() > 3 and not includeFourthHit_)
           seedCreator_.makeSeed(*result, {hits[0], hits[1], hits[2]});
         else
           seedCreator_.makeSeed(*result, hits);

--- a/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.cc
@@ -141,9 +141,9 @@ void SeedGeneratorFromProtoTracksEDProducer::produce(edm::Event& ev, const edm::
         seedCreator_.init(region, es, nullptr);
 
         if (hits.size() == 4 and not includeFourthHit_)
-          seedCreator_.makeSeed(*result, SeedingHitSet({hits[0], hits[1], hits[2]}));
+          seedCreator_.makeSeed(*result, {hits[0], hits[1], hits[2]});
         else
-          seedCreator_.makeSeed(*result, SeedingHitSet(hits));
+          seedCreator_.makeSeed(*result, hits);
       }
     }
   }

--- a/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.cc
@@ -19,7 +19,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <vector>
 
 using namespace edm;
@@ -140,12 +139,11 @@ void SeedGeneratorFromProtoTracksEDProducer::produce(edm::Event& ev, const edm::
         GlobalTrackingRegion region(mom_perp, vtx, 0.2, 0.2);
 
         seedCreator_.init(region, es, nullptr);
-        seedCreator_.makeSeed(
-            *result,
-            SeedingHitSet(hits[0],
-                          hits[1],
-                          hits.size() > 2 ? hits[2] : SeedingHitSet::nullPtr(),
-                          (includeFourthHit_ && hits.size() > 3) ? hits[3] : SeedingHitSet::nullPtr()));
+
+        if (hits.size() == 4 and not includeFourthHit_)
+          seedCreator_.makeSeed(*result, SeedingHitSet({hits[0], hits[1], hits[2]}));
+        else
+          seedCreator_.makeSeed(*result, SeedingHitSet(hits));
       }
     }
   }

--- a/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.h
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.h
@@ -3,13 +3,10 @@
 #include "FWCore/Utilities/interface/Visibility.h"
 
 #include "FWCore/Framework/interface/stream/EDProducer.h"
-#include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "RecoTracker/TkSeedGenerator/interface/SeedFromProtoTrack.h"
 #include "SeedFromConsecutiveHitsCreator.h"
-
-#include <string>
 
 class dso_hidden SeedGeneratorFromProtoTracksEDProducer : public edm::stream::EDProducer<> {
 public:

--- a/RecoTracker/TkSeedingLayers/interface/SeedingHitSet.h
+++ b/RecoTracker/TkSeedingLayers/interface/SeedingHitSet.h
@@ -2,6 +2,10 @@
 #define TkSeedingLayers_SeedingHitSet_H
 
 #include "DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include <vector>
+#include <algorithm>
 
 class SeedingHitSet {
 public:
@@ -11,40 +15,41 @@ public:
 
   static ConstRecHitPointer nullPtr() { return nullptr; }
 
-  SeedingHitSet() { theRecHits[0] = theRecHits[1] = theRecHits[2] = theRecHits[3] = nullptr; }
+  SeedingHitSet() = default;
 
-  SeedingHitSet(ConstRecHitPointer one, ConstRecHitPointer two)
-  // : theRecHits{{one,two,ConstRecHitPointer()}}
-  {
-    theRecHits[0] = one;
-    theRecHits[1] = two;
-    theRecHits[2] = theRecHits[3] = nullptr;
-  }
+  SeedingHitSet(ConstRecHitPointer one, ConstRecHitPointer two) : theRecHits({one, two}) { setSize(); }
+
   SeedingHitSet(ConstRecHitPointer one, ConstRecHitPointer two, ConstRecHitPointer three)
-  // : theRecHits{{one,two,three}},
-  {
-    theRecHits[0] = one;
-    theRecHits[1] = two;
-    theRecHits[2] = three;
-    theRecHits[3] = nullptr;
+      : theRecHits({one, two, three}) {
+    setSize();
   }
 
-  SeedingHitSet(ConstRecHitPointer one, ConstRecHitPointer two, ConstRecHitPointer three, ConstRecHitPointer four) {
-    theRecHits[0] = one;
-    theRecHits[1] = two;
-    theRecHits[2] = three;
-    theRecHits[3] = four;
+  SeedingHitSet(ConstRecHitPointer one, ConstRecHitPointer two, ConstRecHitPointer three, ConstRecHitPointer four)
+      : theRecHits({one, two, three, four}) {
+    setSize();
   }
 
-  ConstRecHitPointer const *data() const { return theRecHits; }
+  SeedingHitSet(const std::vector<ConstRecHitPointer> &hits) : theRecHits(hits) { setSize(); }
+  SeedingHitSet(std::vector<ConstRecHitPointer> &hits) : theRecHits(std::move(hits)) { setSize(); }
+  SeedingHitSet(const std::initializer_list<ConstRecHitPointer> &hits) : theRecHits(hits) { setSize(); }
 
-  unsigned int size() const { return theRecHits[3] ? 4 : (theRecHits[2] ? 3 : (theRecHits[1] ? 2 : 0)); }
+  ConstRecHitPointer const *data() const { return theRecHits.data(); }
+
+  unsigned int size() const { return theSize; }
 
   ConstRecHitPointer get(unsigned int i) const { return theRecHits[i]; }
   ConstRecHitPointer operator[](unsigned int i) const { return theRecHits[i]; }
 
-private:
-  ConstRecHitPointer theRecHits[4];
+protected:
+  std::vector<ConstRecHitPointer> theRecHits;
+  unsigned int theSize = 0;
+
+  void setSize() {
+    theSize = 0;
+    while (theRecHits[++theSize] and theSize < theRecHits.size())
+      ;
+    theSize = theSize > 1 ? theSize : 0;
+  }
 };
 
 #endif

--- a/RecoTracker/TkSeedingLayers/interface/SeedingHitSet.h
+++ b/RecoTracker/TkSeedingLayers/interface/SeedingHitSet.h
@@ -30,8 +30,6 @@ public:
   }
 
   SeedingHitSet(const std::vector<ConstRecHitPointer> &hits) : theRecHits(hits) { setSize(); }
-  SeedingHitSet(std::vector<ConstRecHitPointer> &hits) : theRecHits(std::move(hits)) { setSize(); }
-  SeedingHitSet(const std::initializer_list<ConstRecHitPointer> &hits) : theRecHits(hits) { setSize(); }
 
   ConstRecHitPointer const *data() const { return theRecHits.data(); }
 


### PR DESCRIPTION
#### PR description:

This PR replaces the fixed size (4) hit container in the SeedingHitSet with an std::vector. The SeedGeneratorFromProtoTracksEDProducer is adapted accordingly. The former constructors are kept for backward-compatibility. 

#### PR validation:

Technical PR but some regression expected at HLT level when pixel tracks are used as seeds and more hits are used (see also https://github.com/cms-sw/cmssw/pull/36215).

Run3 HLT tracking single iteration results documented [here](https://indico.cern.ch/event/1099590/contributions/4626741/attachments/2357907/4024340/TriggerReview_Dec21_TRK.pdf).

All tests run.
