### PR TITLE
fix for invalid configs caused by L1T printouts

### DIFF
--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_CalouGT_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_CalouGT_cff.py
@@ -6,10 +6,10 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 def _print(ignored):
-    print("L1T WARN:  L1REPACK:CalouGT (intended for 2016/2017 data) only supports Stage 2 eras for now.")
-    print("L1T WARN:  Use a legacy version of L1REPACK for now.")
+    print("# L1T WARN:  L1REPACK:CalouGT (intended for 2016/2017 data) only supports Stage 2 eras for now.")
+    print("# L1T WARN:  Use a legacy version of L1REPACK for now.")
 stage2L1Trigger.toModify(None, _print)
-(~stage2L1Trigger).toModify(None, lambda x: print("L1T INFO:  L1REPACK:CalouGT (intended for 2016/2017 data), reemulates the Calo part, uses unpacked Muons, and reemulates uGT."))
+(~stage2L1Trigger).toModify(None, lambda x: print("# L1T INFO:  L1REPACK:CalouGT (intended for 2016/2017 data), reemulates the Calo part, uses unpacked Muons, and reemulates uGT."))
 
 # First, Unpack all inputs to L1:
 import EventFilter.L1TRawToDigi.bmtfDigis_cfi

--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_Full2015Data_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_Full2015Data_cff.py
@@ -6,10 +6,10 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 def _print(ignored):
-    print("L1T WARN:  L1REPACK:Full2015Data only supports Stage 2 eras for now.")
-    print("L1T WARN:  Use a legacy version of L1REPACK for now.")
+    print("# L1T WARN:  L1REPACK:Full2015Data only supports Stage 2 eras for now.")
+    print("# L1T WARN:  Use a legacy version of L1REPACK for now.")
 stage2L1Trigger.toModify(None, _print)
-(~stage2L1Trigger).toModify(None, lambda x: print("L1T INFO:  L1REPACK:Full2015Data will unpack all L1T inputs, re-emulated (Stage-2), and pack uGT, uGMT, and Calo Stage-2 output."))
+(~stage2L1Trigger).toModify(None, lambda x: print("# L1T INFO:  L1REPACK:Full2015Data will unpack all L1T inputs, re-emulated (Stage-2), and pack uGT, uGMT, and Calo Stage-2 output."))
 
 # First, Unpack all inputs to L1:
 import EventFilter.DTTFRawToDigi.dttfunpacker_cfi

--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_FullMC_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_FullMC_cff.py
@@ -6,10 +6,10 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 def _print(ignored):
-    print("L1T WARN:  L1REPACK:FullMC (intended for MC events with RAW eventcontent) only supports Stage 2 eras for now.")
-    print("L1T WARN:  Use a legacy version of L1REPACK for now.")
+    print("# L1T WARN:  L1REPACK:FullMC (intended for MC events with RAW eventcontent) only supports Stage 2 eras for now.")
+    print("# L1T WARN:  Use a legacy version of L1REPACK for now.")
 stage2L1Trigger.toModify(None, _print)
-(~stage2L1Trigger).toModify(None, lambda x: print("L1T INFO:  L1REPACK:FullMC  will unpack Calorimetry and Muon L1T inputs, re-emulate L1T (Stage-2), and pack uGT, uGMT, and Calo Stage-2 output."))
+(~stage2L1Trigger).toModify(None, lambda x: print("# L1T INFO:  L1REPACK:FullMC  will unpack Calorimetry and Muon L1T inputs, re-emulate L1T (Stage-2), and pack uGT, uGMT, and Calo Stage-2 output."))
 
 # First, Unpack all inputs to L1:
 

--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_FullSimTP_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_FullSimTP_cff.py
@@ -6,10 +6,10 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 def _print(ignored):
-    print("L1T WARN:  L1REPACK:FullSimTP (intended for 2016 data) only supports Stage 2 eras for now.")
-    print("L1T WARN:  Use a legacy version of L1REPACK for now.")
+    print("# L1T WARN:  L1REPACK:FullSimTP (intended for 2016 data) only supports Stage 2 eras for now.")
+    print("# L1T WARN:  Use a legacy version of L1REPACK for now.")
 stage2L1Trigger.toModify(None, _print)
-(~stage2L1Trigger).toModify(None, lambda x: print("L1T INFO:  L1REPACK:FullSimTP (intended for 2016 data) will unpack all L1T inputs, re-emulate Trigger Primitives, re-emulate L1T (Stage-2), and pack uGT, uGMT, and Calo Stage-2 output."))
+(~stage2L1Trigger).toModify(None, lambda x: print("# L1T INFO:  L1REPACK:FullSimTP (intended for 2016 data) will unpack all L1T inputs, re-emulate Trigger Primitives, re-emulate L1T (Stage-2), and pack uGT, uGMT, and Calo Stage-2 output."))
 
 # First, Unpack all inputs to L1:
 import EventFilter.L1TRawToDigi.bmtfDigis_cfi

--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_Full_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_Full_cff.py
@@ -8,10 +8,10 @@ from Configuration.Eras.Modifier_stage2L1Trigger_2017_cff import stage2L1Trigger
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 
 def _print(ignored):
-    print("L1T WARN:  L1REPACK:Full (intended for 2016 data) only supports Stage 2 eras for now.")
-    print("L1T WARN:  Use a legacy version of L1REPACK for now.")
+    print("# L1T WARN:  L1REPACK:Full (intended for 2016 data) only supports Stage 2 eras for now.")
+    print("# L1T WARN:  Use a legacy version of L1REPACK for now.")
 stage2L1Trigger.toModify(None, _print)
-(~stage2L1Trigger).toModify(None, lambda x: print("L1T INFO:  L1REPACK:Full (intended for 2016 & 2017 data) will unpack all L1T inputs, re-emulated (Stage-2), and pack uGT, uGMT, and Calo Stage-2 output."))
+(~stage2L1Trigger).toModify(None, lambda x: print("# L1T INFO:  L1REPACK:Full (intended for 2016 & 2017 data) will unpack all L1T inputs, re-emulated (Stage-2), and pack uGT, uGMT, and Calo Stage-2 output."))
 
 # First, Unpack all inputs to L1:
 

--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_uGT_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_uGT_cff.py
@@ -6,10 +6,10 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 def _print(ignored):
-    print("L1T WARN:  L1REPACK:Full (intended for 2016 data) only supports Stage 2 eras for now.")
-    print("L1T WARN:  Use a legacy version of L1REPACK for now.")
+    print("# L1T WARN:  L1REPACK:Full (intended for 2016 data) only supports Stage 2 eras for now.")
+    print("# L1T WARN:  Use a legacy version of L1REPACK for now.")
 stage2L1Trigger.toModify(None, _print)
-(~stage2L1Trigger).toModify(None, lambda x: print("L1T INFO:  L1REPACK:uGT (intended for 2016 data) will unpack uGMT and CaloLaye2 outputs and re-emulate uGT"))
+(~stage2L1Trigger).toModify(None, lambda x: print("# L1T INFO:  L1REPACK:uGT (intended for 2016 data) will unpack uGMT and CaloLaye2 outputs and re-emulate uGT"))
 
 
 # First, inputs to uGT:


### PR DESCRIPTION
#### PR description:

This PR ~~redirects to `stderr`~~ adjusts a few printouts in `cff` files used for the L1T repacking step.

These printouts can currently lead to invalid configuration files; for example, these commands
```bash
cmsDriver.py step0 --no_exec -s L1REPACK:FullMC --mc --conditions auto:run3_mc_GRun --era Run3
edmConfigDump step0_L1REPACK.py > dump.py
python3 dump.py
```
currently lead to this crash
```
    L1T WARN:  L1REPACK:FullMC (intended for MC events with RAW eventcontent) only supports Stage 2 eras for now.
        ^
SyntaxError: invalid syntax
```
#### PR validation:

Manual checks, e.g.
```bash
for era in Run1_pA Run2_25ns Run3; do
  for l1temu in CalouGT Full2015Data FullMC FullSimTP Full uGT; do
    cmsDriver.py step0 --no_exec -s L1REPACK:"${l1temu}" --conditions none --era ${era}
    edmConfigDump step0_L1REPACK.py > dump.py
    python3 dump.py
  done
done
```

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

N/A