### PR TITLE
add dependency for DQM/EcalMonitorTasks on DataFormats/Scalers for UBSAN

### DIFF
--- a/DQM/EcalMonitorTasks/BuildFile.xml
+++ b/DQM/EcalMonitorTasks/BuildFile.xml
@@ -9,6 +9,7 @@
 <use name="DataFormats/TCDS"/>
 <use name="DataFormats/L1GlobalTrigger"/>
 <use name="DataFormats/L1GlobalMuonTrigger"/>
+<use name="DataFormats/Scalers"/> <!-- needed in UBSAN builds for typeinfo for LumiScalers -->
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>


### PR DESCRIPTION
#### PR description:

PR #35990 adds a dependency from DQM/EcalMonitorTasks to DataFormats/Scalers:

https://github.com/cms-sw/cmssw/blob/3908b5dfeb419bad35d7e51f8b5c5419e7287bd9/DQM/EcalMonitorTasks/src/OccupancyTask.cc#L8

UBSAN builds need the typeinfo for LumiScalers.  This PR adds that dependency to the BuildFile.xml to resolve the issue.

#### PR validation:

Without this fix, compilation in CMSSW_12_2_UBSAN_X_2021-11-19-2300 fails with the error
```
OccupancyTask.cc.o:(.data.rel+0x218): undefined reference to typeinfo for LumiScalers
```
This PR error resolves the link error.  This is a purely technical fix which should have no performance impact.