### PR TITLE
Run3-alca211C Add generatedparticles to the list of saved objects for IsoTrack AlCaRecoDB

### DIFF
--- a/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalIsoTrkFilterNoHLT_Output_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalIsoTrkFilterNoHLT_Output_cff.py
@@ -18,6 +18,7 @@ OutALCARECOHcalCalIsoTrkFilterNoHLT_noDrop = cms.PSet(
         'keep *_generalTracksExtra_*_*',
         'keep *_offlinePrimaryVertices_*_*',
         'keep *_TkAlIsoProdFilter_*_*',
+        'keep *_genParticles_*_*',
         )
 )
 

--- a/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalIsoTrkFilter_Output_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalIsoTrkFilter_Output_cff.py
@@ -21,6 +21,7 @@ OutALCARECOHcalCalIsoTrkFilter_noDrop = cms.PSet(
         'keep *_generalTracksExtra_*_*',
         'keep *_offlinePrimaryVertices_*_*',
         'keep *_TkAlIsoProdFilter_*_*',
+        'keep *_genParticles_*_*',
         )
 )
 

--- a/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalIsoTrkNoHLT_Output_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalIsoTrkNoHLT_Output_cff.py
@@ -19,6 +19,7 @@ OutALCARECOHcalCalIsoTrkNoHLT_noDrop = cms.PSet(
         'keep *_hbhereco_*_*',
         'keep edmTriggerResults_*_*_*',
         'keep triggerTriggerEvent_*_*_*',
+        'keep *_genParticles_*_*',
         )
 )
 

--- a/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalIsoTrkProducerFilter_Output_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalIsoTrkProducerFilter_Output_cff.py
@@ -11,6 +11,7 @@ OutALCARECOHcalCalIsoTrkProducerFilter_noDrop = cms.PSet(
     outputCommands = cms.untracked.vstring( 
         'keep *_alcaHcalIsotrkProducer_HcalIsoTrack_*',
         'keep *_alcaHcalIsotrkProducer_HcalIsoTrackEvent_*',
+        'keep *_genParticles_*_*',
         )
 )
 


### PR DESCRIPTION
#### PR description:

Add generatedparticles to the list of saved objects for IsoTrack AlCaRecoDB. It only adds for MC samples

#### PR validation:

Use runTheMatrix test workflows 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special