### PR TITLE
Add protection in RelMon for nanoAODDQM processing (backport)

### DIFF
--- a/Utilities/RelMon/python/dqm_interfaces.py
+++ b/Utilities/RelMon/python/dqm_interfaces.py
@@ -675,7 +675,7 @@ class DirWalkerFile(object):
                     directory.subdirs.append(subdir)
                     if depth==1:
                         print("Appended.")
-            else:
+            elif name != '':
                 # We have probably an histo. Let's make the plot and the png.        
                 if obj_type[:2]!="TH" and obj_type[:3]!="TPr" :
                     continue


### PR DESCRIPTION
#### PR description:

This PR adds a small protection in RelMon against empty histogram names in Physics/NanoAODDQM/LHEPdfWeight, Physics/NanoAODDQM/LHEScaleWeight and Physics/NanoAODDQM/PSWeight.

#### PR validation:

Local tests by running ValidateMatrix.py on DQMIO files.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of #36119. The backport to CMSSW_11_0_X is needed because this release branch is used in the RelMon configuration at https://cms-pdmv.cern.ch/relmonservice/. The plan is to upgrade to the latest CMSSW release. This backport will be used as a temporary solution to process DQMIO files produced with 12_2_X. 