### PR TITLE
Migrate misc scripts to new `PoolDBOutputService` methods

### DIFF
--- a/Calibration/LumiAlCaRecoProducers/plugins/CorrPCCProducer.cc
+++ b/Calibration/LumiAlCaRecoProducers/plugins/CorrPCCProducer.cc
@@ -125,8 +125,6 @@ private:
   float pedestal_unc;
   TGraphErrors* pedestalGraph;
 
-  LumiCorrections* pccCorrections;
-
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
 };
 
@@ -567,15 +565,15 @@ void CorrPCCProducer::dqmEndRunProduce(edm::Run const& runSeg, const edm::EventS
     }
 
     //Writing the corrections to SQL lite file for db
-    pccCorrections = new LumiCorrections();
-    pccCorrections->setOverallCorrection(overallCorrection_);
-    pccCorrections->setType1Fraction(type1Frac);
-    pccCorrections->setType1Residual(mean_type1_residual);
-    pccCorrections->setType2Residual(mean_type2_residual);
-    pccCorrections->setCorrectionsBX(correctionScaleFactors_);
+    LumiCorrections pccCorrections;
+    pccCorrections.setOverallCorrection(overallCorrection_);
+    pccCorrections.setType1Fraction(type1Frac);
+    pccCorrections.setType1Residual(mean_type1_residual);
+    pccCorrections.setType2Residual(mean_type2_residual);
+    pccCorrections.setCorrectionsBX(correctionScaleFactors_);
 
     if (poolDbService.isAvailable()) {
-      poolDbService->writeOne<LumiCorrections>(pccCorrections, thisIOV, "LumiCorrectionsRcd");
+      poolDbService->writeOneIOV(pccCorrections, thisIOV, "LumiCorrectionsRcd");
     } else {
       throw std::runtime_error("PoolDBService required.");
     }

--- a/CondFormats/RecoMuonObjects/test/ProduceAgingObject.cc
+++ b/CondFormats/RecoMuonObjects/test/ProduceAgingObject.cc
@@ -99,18 +99,18 @@ ProduceAgingObject::~ProduceAgingObject() {}
 
 // -- Called for each event --
 void ProduceAgingObject::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  MuonSystemAging* muonAgingObject = new MuonSystemAging();
+  MuonSystemAging muonAgingObject;
 
-  muonAgingObject->m_DTChambEffs = m_DTChambEffs;
-  muonAgingObject->m_RPCChambEffs = m_RPCChambEffs;
-  muonAgingObject->m_CSCChambEffs = m_CSCChambEffs;
+  muonAgingObject.m_DTChambEffs = m_DTChambEffs;
+  muonAgingObject.m_RPCChambEffs = m_RPCChambEffs;
+  muonAgingObject.m_CSCChambEffs = m_CSCChambEffs;
 
-  muonAgingObject->m_GEMChambEffs = m_GEMChambEffs;
-  muonAgingObject->m_ME0ChambEffs = m_ME0ChambEffs;
+  muonAgingObject.m_GEMChambEffs = m_GEMChambEffs;
+  muonAgingObject.m_ME0ChambEffs = m_ME0ChambEffs;
 
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
   if (poolDbService.isAvailable())
-    poolDbService->writeOne(muonAgingObject, poolDbService->currentTime(), "MuonSystemAgingRcd");
+    poolDbService->writeOneIOV(muonAgingObject, poolDbService->currentTime(), "MuonSystemAgingRcd");
 }
 
 // -- Called at the beginning of each run --

--- a/CondTools/BTau/plugins/BTagCalibrationDbCreator.cc
+++ b/CondTools/BTau/plugins/BTagCalibrationDbCreator.cc
@@ -29,14 +29,10 @@ BTagCalibrationDbCreator::BTagCalibrationDbCreator(const edm::ParameterSet& p)
       tagger_(p.getUntrackedParameter<std::string>("tagger")) {}
 
 void BTagCalibrationDbCreator::beginJob() {
-  auto calib = new BTagCalibration(tagger_, csvFile_, true);
+  BTagCalibration calib(tagger_, csvFile_, true);
   edm::Service<cond::service::PoolDBOutputService> s;
   if (s.isAvailable()) {
-    if (s->isNewTagRequest(tagger_)) {
-      s->createNewIOV<BTagCalibration>(calib, s->beginOfTime(), s->endOfTime(), tagger_);
-    } else {
-      s->appendSinceTime<BTagCalibration>(calib, 111, tagger_);
-    }
+    s->writeOneIOV(calib, s->beginOfTime(), tagger_);
   } else {
     std::cout << "ERROR: DB service not available" << std::endl;
   }

--- a/MuonAnalysis/MomentumScaleCalibration/plugins/DBWriter.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/plugins/DBWriter.cc
@@ -39,10 +39,10 @@ DBWriter::~DBWriter() {
 
 // ------------ method called to for each event  ------------
 void DBWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  MuScleFitDBobject* dbObject = new MuScleFitDBobject;
+  MuScleFitDBobject dbObject;
 
-  dbObject->identifiers = corrector_->identifiers();
-  dbObject->parameters = corrector_->parameters();
+  dbObject.identifiers = corrector_->identifiers();
+  dbObject.parameters = corrector_->parameters();
 
   //   if( dbObject->identifiers.size() != dbObject->parameters.size() ) {
   //     std::cout << "Error: size of parameters("<<dbObject->parameters.size()<<") and identifiers("<<dbObject->identifiers.size()<<") don't match" << std::endl;
@@ -64,10 +64,9 @@ void DBWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) 
   edm::Service<cond::service::PoolDBOutputService> mydbservice;
   if (mydbservice.isAvailable()) {
     if (mydbservice->isNewTagRequest("MuScleFitDBobjectRcd")) {
-      mydbservice->createNewIOV<MuScleFitDBobject>(
-          dbObject, mydbservice->beginOfTime(), mydbservice->endOfTime(), "MuScleFitDBobjectRcd");
+      mydbservice->createOneIOV<MuScleFitDBobject>(dbObject, mydbservice->beginOfTime(), "MuScleFitDBobjectRcd");
     } else {
-      mydbservice->appendSinceTime<MuScleFitDBobject>(dbObject, mydbservice->currentTime(), "MuScleFitDBobjectRcd");
+      mydbservice->appendOneIOV<MuScleFitDBobject>(dbObject, mydbservice->currentTime(), "MuScleFitDBobjectRcd");
     }
   } else {
     edm::LogError("DBWriter") << "Service is unavailable" << std::endl;

--- a/PhysicsTools/MVAComputer/test/testWriteMVAComputerCondDB.cc
+++ b/PhysicsTools/MVAComputer/test/testWriteMVAComputerCondDB.cc
@@ -58,8 +58,8 @@ void testWriteMVAComputerCondDB::endJob() {
   // *                                                                         *
   // ***************************************************************************
 
-  MVAComputerContainer* container = new MVAComputerContainer();
-  MVAComputer* computer = &container->add("test");
+  MVAComputerContainer container;
+  MVAComputer* computer = &container.add("test");
 
   // vars
 
@@ -204,8 +204,7 @@ void testWriteMVAComputerCondDB::endJob() {
   if (!dbService.isAvailable())
     return;
 
-  dbService->createNewIOV<MVAComputerContainer>(
-      container, dbService->beginOfTime(), dbService->endOfTime(), "BTauGenericMVAJetTagComputerRcd");
+  dbService->createOneIOV(container, dbService->beginOfTime(), "BTauGenericMVAJetTagComputerRcd");
 }
 
 // define this as a plug-in

--- a/RecoHI/HiCentralityAlgos/plugins/CentralityTableProducer.cc
+++ b/RecoHI/HiCentralityAlgos/plugins/CentralityTableProducer.cc
@@ -118,8 +118,8 @@ void CentralityTableProducer::endJob() {
     // Get values from root file
     CB = (CentralityBins*)inputTFile_->Get(Form("%s/run%d", rootTag_.data(), runnum_));
     cout << rootTag_.data() << endl;
-    CT = new CentralityTable();
-    CT->m_table.reserve(CB->getNbins());
+    CentralityTable CT;
+    CT.m_table.reserve(CB->getNbins());
 
     text_ << "# BinEdge NpartMean NpartVar NcollMean NcollVar NhardMean NhardVar bMean bVar" << endl;
     for (int j = 0; j < CB->getNbins(); j++) {
@@ -134,18 +134,14 @@ void CentralityTableProducer::endJob() {
       thisBin->b.mean = CB->bMeanOfBin(j);
       thisBin->b.var = CB->bSigmaOfBin(j);
       printBin(thisBin);
-      CT->m_table.push_back(*thisBin);
+      CT.m_table.push_back(*thisBin);
       if (thisBin)
         delete thisBin;
     }
 
     edm::Service<cond::service::PoolDBOutputService> pool;
     if (pool.isAvailable()) {
-      if (pool->isNewTagRequest("HeavyIonRcd")) {
-        pool->createNewIOV<CentralityTable>(CT, pool->beginOfTime(), pool->endOfTime(), "HeavyIonRcd");
-      } else {
-        pool->appendSinceTime<CentralityTable>(CT, pool->currentTime(), "HeavyIonRcd");
-      }
+      pool->writeOneIOV(CT, pool->currentTime(), "HeavyIonRcd");
     }
   }
 }

--- a/RecoHI/HiCentralityAlgos/plugins/CentralityTableProducer.cc
+++ b/RecoHI/HiCentralityAlgos/plugins/CentralityTableProducer.cc
@@ -59,7 +59,6 @@ private:
   string rootTag_;
   ofstream text_;
 
-  CentralityTable* CT;
   const CentralityBins* CB;
 
   unsigned int runnum_;

--- a/RecoMuon/GlobalTrackingTools/test/DYTTuner.cc
+++ b/RecoMuon/GlobalTrackingTools/test/DYTTuner.cc
@@ -49,7 +49,6 @@ private:
   double MinEnVal, MaxEnVal, IntegralCut, MaxEstVal;
   unsigned int MinNumValues, MaxValPlots, NBinsPlots;
   bool saveROOTfile;
-  DYTThrObject* thresholds;
   std::map<DetId, std::vector<double> > mapId;
   std::map<DetId, TH1F*> EstPlots;
   edm::EDGetTokenT<DYTestimators> dytInfoToken;
@@ -120,7 +119,7 @@ void DYTTuner::beginJob() {}
 void DYTTuner::endJob() {
   if (saveROOTfile)
     writePlots();
-  thresholds = new DYTThrObject();
+  DYTThrObject thresholds;
 
   // Full barrel/endcap computation
   std::map<DetId, std::vector<double> >::iterator it;
@@ -161,17 +160,17 @@ void DYTTuner::endJob() {
         int station = CSCDetId(id).station();
         obj.thr = endcapCut[station - 1];
       }
-      thresholds->thrsVec.push_back(obj);
+      thresholds.thrsVec.push_back(obj);
       continue;
     }
     obj.thr = doIntegral(estValCh, id);
-    thresholds->thrsVec.push_back(obj);
+    thresholds.thrsVec.push_back(obj);
   }
 
   // Writing to DB
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
   if (poolDbService.isAvailable()) {
-    poolDbService->writeOne(thresholds, poolDbService->beginOfTime(), "DYTThrObjectRcd");
+    poolDbService->writeOneIOV(thresholds, poolDbService->beginOfTime(), "DYTThrObjectRcd");
   } else
     throw cms::Exception("NotAvailable") << "PoolDBOutputService is not available.";
 }

--- a/RecoParticleFlow/PFClusterTools/test/ProducePFCalibrationObject.cc
+++ b/RecoParticleFlow/PFClusterTools/test/ProducePFCalibrationObject.cc
@@ -99,13 +99,12 @@ void ProducePFCalibrationObject::beginRun(const edm::Run& run, const edm::EventS
     PhysicsTFormulaPayload allTFormulas(limitsToWrite, formulasToWrite);
 
     // put them in the container
-    PerformancePayloadFromTFormula* pfCalibrationFormulas =
-        new PerformancePayloadFromTFormula(resToWrite, binsToWrite, allTFormulas);
+    PerformancePayloadFromTFormula pfCalibrationFormulas(resToWrite, binsToWrite, allTFormulas);
 
     // actually write to DB
     edm::Service<cond::service::PoolDBOutputService> dbOut;
     if (dbOut.isAvailable()) {
-      dbOut->writeOne<PerformancePayloadFromTFormula>(pfCalibrationFormulas, 1, record);
+      dbOut->writeOneIOV(pfCalibrationFormulas, 1, record);
     }
   }
 

--- a/SimGeneral/MixingModule/plugins/Mixing2DB.cc
+++ b/SimGeneral/MixingModule/plugins/Mixing2DB.cc
@@ -48,7 +48,7 @@ void Mixing2DB::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
 // ------------ method called once each job just after ending the event loop  ------------
 void Mixing2DB::endJob() {
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
-  MixingModuleConfig* config = new MixingModuleConfig();
-  config->read(cfi_);
-  poolDbService->writeOne<MixingModuleConfig>(config, poolDbService->currentTime(), "MixingRcd");
+  MixingModuleConfig config;
+  config.read(cfi_);
+  poolDbService->writeOneIOV(config, poolDbService->currentTime(), "MixingRcd");
 }


### PR DESCRIPTION
#### PR description:
Part of cms-AlCaDB/AlCaTools#28.
Migrated the following packages:
- Calibration/LumiAlCaRecoProducers/plugins/CorrPCCProducer.cc
- CondFormats/RecoMuonObjects/test/ProduceAgingObject.cc
- CondTools/BTau/plugins/BTagCalibrationDbCreator.cc
- MuonAnalysis/MomentumScaleCalibration/plugins/DBWriter.cc
- PhysicsTools/MVAComputer/test/testWriteMVAComputerCondDB.cc
- RecoHI/HiCentralityAlgos/plugins/CentralityTableProducer.cc
- RecoMuon/GlobalTrackingTools/test/DYTTuner.cc
- RecoParticleFlow/PFClusterTools/test/ProducePFCalibrationObject.cc
- SimGeneral/MixingModule/plugins/Mixing2DB.cc

#### PR validation:
Code compiles and `scramv1 b runtests` runs fine.

#### Backport:
N/A