### PR TITLE
Migrate Geometry to new `PoolDBOutputService` methods

### DIFF
--- a/CondTools/Geometry/plugins/CSCRecoIdealDBLoader.cc
+++ b/CondTools/Geometry/plugins/CSCRecoIdealDBLoader.cc
@@ -43,8 +43,8 @@ CSCRecoIdealDBLoader::CSCRecoIdealDBLoader(const edm::ParameterSet& iC) {
 void CSCRecoIdealDBLoader::beginRun(const edm::Run&, edm::EventSetup const& es) {
   edm::LogInfo("CSCRecoIdealDBLoader") << "CSCRecoIdealDBLoader::beginRun";
 
-  RecoIdealGeometry* rig = new RecoIdealGeometry;
-  CSCRecoDigiParameters* rdp = new CSCRecoDigiParameters;
+  RecoIdealGeometry rig;
+  CSCRecoDigiParameters rdp;
   edm::Service<cond::service::PoolDBOutputService> mydbservice;
   if (!mydbservice.isAvailable()) {
     edm::LogError("CSCRecoIdealDBLoader") << "PoolDBOutputService unavailable";
@@ -57,22 +57,20 @@ void CSCRecoIdealDBLoader::beginRun(const edm::Run&, edm::EventSetup const& es) 
   if (fromDD4hep_) {
     auto pDD = es.getTransientHandle(dd4HepCompactViewToken_);
     const cms::DDCompactView& cpv = *pDD;
-    cscgp.build(&cpv, *pMNDC, *rig, *rdp);
+    cscgp.build(&cpv, *pMNDC, rig, rdp);
   } else {
     auto pDD = es.getTransientHandle(compactViewToken_);
     const DDCompactView& cpv = *pDD;
-    cscgp.build(&cpv, *pMNDC, *rig, *rdp);
+    cscgp.build(&cpv, *pMNDC, rig, rdp);
   }
 
   if (mydbservice->isNewTagRequest("CSCRecoGeometryRcd")) {
-    mydbservice->createNewIOV<RecoIdealGeometry>(
-        rig, mydbservice->beginOfTime(), mydbservice->endOfTime(), "CSCRecoGeometryRcd");
+    mydbservice->createOneIOV(rig, mydbservice->beginOfTime(), "CSCRecoGeometryRcd");
   } else {
     edm::LogError("CSCRecoIdealDBLoader") << "CSCRecoGeometryRcd Tag is already present.";
   }
   if (mydbservice->isNewTagRequest("CSCRecoDigiParametersRcd")) {
-    mydbservice->createNewIOV<CSCRecoDigiParameters>(
-        rdp, mydbservice->beginOfTime(), mydbservice->endOfTime(), "CSCRecoDigiParametersRcd");
+    mydbservice->createOneIOV(rdp, mydbservice->beginOfTime(), "CSCRecoDigiParametersRcd");
   } else {
     edm::LogError("CSCRecoIdealDBLoader") << "CSCRecoDigiParametersRcd Tag is already present.";
   }

--- a/CondTools/Geometry/plugins/DTRecoIdealDBLoader.cc
+++ b/CondTools/Geometry/plugins/DTRecoIdealDBLoader.cc
@@ -42,7 +42,7 @@ DTRecoIdealDBLoader::DTRecoIdealDBLoader(const edm::ParameterSet& iC) {
 }
 
 void DTRecoIdealDBLoader::beginRun(const edm::Run&, edm::EventSetup const& es) {
-  RecoIdealGeometry* rig = new RecoIdealGeometry;
+  RecoIdealGeometry rig;
   edm::Service<cond::service::PoolDBOutputService> mydbservice;
   if (!mydbservice.isAvailable()) {
     edm::LogError("DTRecoIdealDBLoader") << "PoolDBOutputService unavailable";
@@ -55,15 +55,14 @@ void DTRecoIdealDBLoader::beginRun(const edm::Run&, edm::EventSetup const& es) {
   if (fromDD4hep_) {
     auto pDD = es.getTransientHandle(dd4HepCompactViewToken_);
     const cms::DDCompactView& cpv = *pDD;
-    dtgp.build(&cpv, *pMNDC, *rig);
+    dtgp.build(&cpv, *pMNDC, rig);
   } else {
     auto pDD = es.getTransientHandle(compactViewToken_);
     const DDCompactView& cpv = *pDD;
-    dtgp.build(&cpv, *pMNDC, *rig);
+    dtgp.build(&cpv, *pMNDC, rig);
   }
   if (mydbservice->isNewTagRequest("DTRecoGeometryRcd")) {
-    mydbservice->createNewIOV<RecoIdealGeometry>(
-        rig, mydbservice->beginOfTime(), mydbservice->endOfTime(), "DTRecoGeometryRcd");
+    mydbservice->createOneIOV(rig, mydbservice->beginOfTime(), "DTRecoGeometryRcd");
   } else {
     edm::LogError("DTRecoIdealDBLoader") << "DTRecoGeometryRcd Tag is already present.";
   }

--- a/CondTools/Geometry/plugins/GEMRecoIdealDBLoader.cc
+++ b/CondTools/Geometry/plugins/GEMRecoIdealDBLoader.cc
@@ -55,21 +55,20 @@ void GEMRecoIdealDBLoader::beginRun(const edm::Run&, edm::EventSetup const& es) 
     auto pMNDC = es.getHandle(muonGeomConstantsToken_);
 
     GEMGeometryParsFromDD rpcpd;
-    RecoIdealGeometry* rig = new RecoIdealGeometry;
+    RecoIdealGeometry rig;
 
     if (fromDD4hep_) {
       edm::LogVerbatim("GEMRecoIdealDBLoader") << "(0) GEMRecoIdealDBLoader - DD4hep ";
       auto pDD = es.getTransientHandle(dd4HepCompactViewToken_);
       const cms::DDCompactView& cpv = *pDD;
-      rpcpd.build(&cpv, *pMNDC, *rig);
+      rpcpd.build(&cpv, *pMNDC, rig);
     } else {
       edm::LogVerbatim("GEMRecoIdealDBLoader") << "(0) GEMRecoIdealDBLoader - DDD ";
       auto pDD = es.getTransientHandle(compactViewToken_);
       const DDCompactView& cpv = *pDD;
-      rpcpd.build(&cpv, *pMNDC, *rig);
+      rpcpd.build(&cpv, *pMNDC, rig);
     }
-    mydbservice->createNewIOV<RecoIdealGeometry>(
-        rig, mydbservice->beginOfTime(), mydbservice->endOfTime(), "GEMRecoGeometryRcd");
+    mydbservice->createOneIOV(rig, mydbservice->beginOfTime(), "GEMRecoGeometryRcd");
   } else {
     edm::LogError("GEMRecoIdealDBLoader") << "GEMRecoGeometryRcd Tag is already present";
   }

--- a/CondTools/Geometry/plugins/HcalParametersDBBuilder.cc
+++ b/CondTools/Geometry/plugins/HcalParametersDBBuilder.cc
@@ -47,7 +47,7 @@ void HcalParametersDBBuilder::fillDescriptions(edm::ConfigurationDescriptions& d
 }
 
 void HcalParametersDBBuilder::beginRun(const edm::Run&, edm::EventSetup const& es) {
-  HcalParameters* php = new HcalParameters;
+  HcalParameters php;
   edm::Service<cond::service::PoolDBOutputService> mydbservice;
   if (!mydbservice.isAvailable()) {
     edm::LogError("HcalParametersDBBuilder") << "PoolDBOutputService unavailable";
@@ -61,18 +61,17 @@ void HcalParametersDBBuilder::beginRun(const edm::Run&, edm::EventSetup const& e
     edm::LogVerbatim("HCalGeom") << "HcalParametersDBBuilder::Try to access cms::DDCompactView";
 #endif
     auto cpv = es.getTransientHandle(dd4HepCompactViewToken_);
-    builder.build((*cpv), *php);
+    builder.build((*cpv), php);
   } else {
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("HCalGeom") << "HcalParametersDBBuilder::Try to access DDCompactView";
 #endif
     auto cpv = es.getTransientHandle(compactViewToken_);
-    builder.build(&(*cpv), *php);
+    builder.build(&(*cpv), php);
   }
 
   if (mydbservice->isNewTagRequest("HcalParametersRcd")) {
-    mydbservice->createNewIOV<HcalParameters>(
-        php, mydbservice->beginOfTime(), mydbservice->endOfTime(), "HcalParametersRcd");
+    mydbservice->createOneIOV(php, mydbservice->beginOfTime(), "HcalParametersRcd");
   } else {
     edm::LogError("HcalParametersDBBuilder") << "HcalParameters and HcalParametersRcd Tag already present";
   }

--- a/CondTools/Geometry/plugins/ME0RecoIdealDBLoader.cc
+++ b/CondTools/Geometry/plugins/ME0RecoIdealDBLoader.cc
@@ -52,20 +52,19 @@ void ME0RecoIdealDBLoader::beginRun(const edm::Run&, edm::EventSetup const& es) 
   if (mydbservice->isNewTagRequest("ME0RecoGeometryRcd")) {
     auto pMNDC = es.getHandle(muonGeomConstantsToken_);
     ME0GeometryParsFromDD me0pd;
-    RecoIdealGeometry* rig = new RecoIdealGeometry;
+    RecoIdealGeometry rig;
     if (fromDD4hep_) {
       edm::LogVerbatim("ME0RecoIdealDBLoader") << "(0) ME0RecoIdealDBLoader - DD4hep ";
       auto pDD = es.getTransientHandle(dd4HepCompactViewToken_);
       const cms::DDCompactView& cpv = *pDD;
-      me0pd.build(&cpv, *pMNDC, *rig);
+      me0pd.build(&cpv, *pMNDC, rig);
     } else {
       edm::LogVerbatim("ME0RecoIdealDBLoader") << "(0) ME0RecoIdealDBLoader - DDD ";
       auto pDD = es.getTransientHandle(compactViewToken_);
       const DDCompactView& cpv = *pDD;
-      me0pd.build(&cpv, *pMNDC, *rig);
+      me0pd.build(&cpv, *pMNDC, rig);
     }
-    mydbservice->createNewIOV<RecoIdealGeometry>(
-        rig, mydbservice->beginOfTime(), mydbservice->endOfTime(), "ME0RecoGeometryRcd");
+    mydbservice->createOneIOV(rig, mydbservice->beginOfTime(), "ME0RecoGeometryRcd");
   } else {
     edm::LogError("ME0RecoIdealDBLoader") << "ME0RecoGeometryRcd Tag is already present";
   }

--- a/CondTools/Geometry/plugins/PGeometricDetBuilder.cc
+++ b/CondTools/Geometry/plugins/PGeometricDetBuilder.cc
@@ -121,7 +121,6 @@ void PGeometricDetBuilder::beginRun(const edm::Run&, edm::EventSetup const& es) 
     }  // level 2
     --lev;
   }
-  std::vector<const GeometricDet*> modules = tracker->deepComponents();
   if (mydbservice->isNewTagRequest("IdealGeometryRecord")) {
     mydbservice->createOneIOV(pgd, mydbservice->beginOfTime(), "IdealGeometryRecord");
   } else {

--- a/CondTools/Geometry/plugins/PGeometricDetBuilder.cc
+++ b/CondTools/Geometry/plugins/PGeometricDetBuilder.cc
@@ -45,7 +45,7 @@ PGeometricDetBuilder::PGeometricDetBuilder(const edm::ParameterSet& iConfig) {
 }
 
 void PGeometricDetBuilder::beginRun(const edm::Run&, edm::EventSetup const& es) {
-  PGeometricDet* pgd = new PGeometricDet;
+  PGeometricDet pgd;
   edm::Service<cond::service::PoolDBOutputService> mydbservice;
   if (!mydbservice.isAvailable()) {
     edm::LogError("PGeometricDetBuilder") << "PoolDBOutputService unavailable";
@@ -59,14 +59,14 @@ void PGeometricDetBuilder::beginRun(const edm::Run&, edm::EventSetup const& es) 
   const GeometricDet* tracker = &es.getData(geometricDetToken_);
 
   // so now I have the tracker itself. loop over all its components to store them.
-  putOne(tracker, pgd, 0);
+  putOne(tracker, &pgd, 0);
   std::vector<const GeometricDet*> tc = tracker->components();
   std::vector<const GeometricDet*>::const_iterator git = tc.begin();
   std::vector<const GeometricDet*>::const_iterator egit = tc.end();
   int count = 0;
   int lev = 1;
   for (; git != egit; ++git) {  // one level below "tracker"
-    putOne(*git, pgd, lev);
+    putOne(*git, &pgd, lev);
     std::vector<const GeometricDet*> inone = (*git)->components();
     if (inone.empty())
       ++count;
@@ -74,7 +74,7 @@ void PGeometricDetBuilder::beginRun(const edm::Run&, edm::EventSetup const& es) 
     std::vector<const GeometricDet*>::const_iterator egit2 = inone.end();
     ++lev;
     for (; git2 != egit2; ++git2) {  // level 2
-      putOne(*git2, pgd, lev);
+      putOne(*git2, &pgd, lev);
       std::vector<const GeometricDet*> intwo = (*git2)->components();
       if (intwo.empty())
         ++count;
@@ -82,7 +82,7 @@ void PGeometricDetBuilder::beginRun(const edm::Run&, edm::EventSetup const& es) 
       std::vector<const GeometricDet*>::const_iterator egit3 = intwo.end();
       ++lev;
       for (; git3 != egit3; ++git3) {  // level 3
-        putOne(*git3, pgd, lev);
+        putOne(*git3, &pgd, lev);
         std::vector<const GeometricDet*> inthree = (*git3)->components();
         if (inthree.empty())
           ++count;
@@ -90,7 +90,7 @@ void PGeometricDetBuilder::beginRun(const edm::Run&, edm::EventSetup const& es) 
         std::vector<const GeometricDet*>::const_iterator egit4 = inthree.end();
         ++lev;
         for (; git4 != egit4; ++git4) {  //level 4
-          putOne(*git4, pgd, lev);
+          putOne(*git4, &pgd, lev);
           std::vector<const GeometricDet*> infour = (*git4)->components();
           if (infour.empty())
             ++count;
@@ -98,7 +98,7 @@ void PGeometricDetBuilder::beginRun(const edm::Run&, edm::EventSetup const& es) 
           std::vector<const GeometricDet*>::const_iterator egit5 = infour.end();
           ++lev;
           for (; git5 != egit5; ++git5) {  // level 5
-            putOne(*git5, pgd, lev);
+            putOne(*git5, &pgd, lev);
             std::vector<const GeometricDet*> infive = (*git5)->components();
             if (infive.empty())
               ++count;
@@ -106,7 +106,7 @@ void PGeometricDetBuilder::beginRun(const edm::Run&, edm::EventSetup const& es) 
             std::vector<const GeometricDet*>::const_iterator egit6 = infive.end();
             ++lev;
             for (; git6 != egit6; ++git6) {  //level 6
-              putOne(*git6, pgd, lev);
+              putOne(*git6, &pgd, lev);
               std::vector<const GeometricDet*> insix = (*git6)->components();
               if (insix.empty())
                 ++count;
@@ -123,8 +123,7 @@ void PGeometricDetBuilder::beginRun(const edm::Run&, edm::EventSetup const& es) 
   }
   std::vector<const GeometricDet*> modules = tracker->deepComponents();
   if (mydbservice->isNewTagRequest("IdealGeometryRecord")) {
-    mydbservice->createNewIOV<PGeometricDet>(
-        pgd, mydbservice->beginOfTime(), mydbservice->endOfTime(), "IdealGeometryRecord");
+    mydbservice->createOneIOV(pgd, mydbservice->beginOfTime(), "IdealGeometryRecord");
   } else {
     edm::LogError("PGeometricDetBuilder") << "PGeometricDetBuilder Tag already present";
   }

--- a/CondTools/Geometry/plugins/PHGCalParametersDBBuilder.cc
+++ b/CondTools/Geometry/plugins/PHGCalParametersDBBuilder.cc
@@ -63,7 +63,7 @@ void PHGCalParametersDBBuilder::fillDescriptions(edm::ConfigurationDescriptions&
 }
 
 void PHGCalParametersDBBuilder::beginRun(const edm::Run&, edm::EventSetup const& es) {
-  PHGCalParameters* phgp = new PHGCalParameters;
+  PHGCalParameters phgp;
   edm::Service<cond::service::PoolDBOutputService> mydbservice;
   if (!mydbservice.isAvailable()) {
     edm::LogError("PHGCalParametersDBBuilder") << "PoolDBOutputService unavailable";
@@ -85,12 +85,11 @@ void PHGCalParametersDBBuilder::beginRun(const edm::Run&, edm::EventSetup const&
     auto cpv = es.getTransientHandle(compactViewToken_);
     builder.build(cpv.product(), *ptp, name_, namew_, namec_, namet_);
   }
-  swapParameters(ptp, phgp);
+  swapParameters(ptp, &phgp);
   delete ptp;
 
   if (mydbservice->isNewTagRequest("PHGCalParametersRcd")) {
-    mydbservice->createNewIOV<PHGCalParameters>(
-        phgp, mydbservice->beginOfTime(), mydbservice->endOfTime(), "PHGCalParametersRcd");
+    mydbservice->createOneIOV(phgp, mydbservice->beginOfTime(), "PHGCalParametersRcd");
   } else {
     edm::LogError("PHGCalParametersDBBuilder") << "PHGCalParameters and PHGCalParametersRcd Tag already present";
   }

--- a/CondTools/Geometry/plugins/PTrackerAdditionalParametersPerDetDBBuilder.cc
+++ b/CondTools/Geometry/plugins/PTrackerAdditionalParametersPerDetDBBuilder.cc
@@ -25,7 +25,7 @@ PTrackerAdditionalParametersPerDetDBBuilder::PTrackerAdditionalParametersPerDetD
     : geomDetToken_(esConsumes<edm::Transition::BeginRun>()) {}
 
 void PTrackerAdditionalParametersPerDetDBBuilder::beginRun(const edm::Run&, edm::EventSetup const& es) {
-  PTrackerAdditionalParametersPerDet* ptitp = new PTrackerAdditionalParametersPerDet;
+  PTrackerAdditionalParametersPerDet ptitp;
   edm::Service<cond::service::PoolDBOutputService> mydbservice;
   if (!mydbservice.isAvailable()) {
     edm::LogError("PTrackerAdditionalParametersPerDetDBBuilder") << "PoolDBOutputService unavailable";
@@ -38,13 +38,12 @@ void PTrackerAdditionalParametersPerDetDBBuilder::beginRun(const edm::Run&, edm:
   gd->deepComponents(comp);
 
   for (auto& i : comp) {
-    ptitp->setGeographicalId(i->geographicalId());
-    ptitp->setBricked(i->isBricked());
+    ptitp.setGeographicalId(i->geographicalId());
+    ptitp.setBricked(i->isBricked());
   }
 
   if (mydbservice->isNewTagRequest("PTrackerAdditionalParametersPerDetRcd")) {
-    mydbservice->createNewIOV<PTrackerAdditionalParametersPerDet>(
-        ptitp, mydbservice->beginOfTime(), mydbservice->endOfTime(), "PTrackerAdditionalParametersPerDetRcd");
+    mydbservice->createOneIOV(ptitp, mydbservice->beginOfTime(), "PTrackerAdditionalParametersPerDetRcd");
   } else {
     edm::LogError("PTrackerAdditionalParametersPerDetDBBuilder")
         << "PTrackerAdditionalParametersPerDet and PTrackerAdditionalParametersPerDetRcd Tag already present";

--- a/CondTools/Geometry/plugins/PTrackerParametersDBBuilder.cc
+++ b/CondTools/Geometry/plugins/PTrackerParametersDBBuilder.cc
@@ -31,7 +31,7 @@ PTrackerParametersDBBuilder::PTrackerParametersDBBuilder(const edm::ParameterSet
 }
 
 void PTrackerParametersDBBuilder::beginRun(const edm::Run&, edm::EventSetup const& es) {
-  PTrackerParameters* ptp = new PTrackerParameters;
+  PTrackerParameters ptp;
   edm::Service<cond::service::PoolDBOutputService> mydbservice;
   if (!mydbservice.isAvailable()) {
     edm::LogError("PTrackerParametersDBBuilder") << "PoolDBOutputService unavailable";
@@ -42,15 +42,14 @@ void PTrackerParametersDBBuilder::beginRun(const edm::Run&, edm::EventSetup cons
 
   if (!fromDD4hep_) {
     auto cpv = es.getTransientHandle(compactViewToken_);
-    builder.build(&(*cpv), *ptp);
+    builder.build(&(*cpv), ptp);
   } else {
     auto cpv = es.getTransientHandle(dd4HepCompactViewToken_);
-    builder.build(&(*cpv), *ptp);
+    builder.build(&(*cpv), ptp);
   }
 
   if (mydbservice->isNewTagRequest("PTrackerParametersRcd")) {
-    mydbservice->createNewIOV<PTrackerParameters>(
-        ptp, mydbservice->beginOfTime(), mydbservice->endOfTime(), "PTrackerParametersRcd");
+    mydbservice->createOneIOV(ptp, mydbservice->beginOfTime(), "PTrackerParametersRcd");
   } else {
     edm::LogError("PTrackerParametersDBBuilder") << "PTrackerParameters and PTrackerParametersRcd Tag already present";
   }

--- a/CondTools/Geometry/plugins/RPCRecoIdealDBLoader.cc
+++ b/CondTools/Geometry/plugins/RPCRecoIdealDBLoader.cc
@@ -41,7 +41,7 @@ RPCRecoIdealDBLoader::RPCRecoIdealDBLoader(const edm::ParameterSet& iC) {
 }
 
 void RPCRecoIdealDBLoader::beginRun(const edm::Run&, edm::EventSetup const& es) {
-  RecoIdealGeometry* rig = new RecoIdealGeometry;
+  RecoIdealGeometry rig;
   edm::Service<cond::service::PoolDBOutputService> mydbservice;
   if (!mydbservice.isAvailable()) {
     edm::LogError("RPCRecoIdealDBLoader") << "PoolDBOutputService unavailable";
@@ -54,15 +54,14 @@ void RPCRecoIdealDBLoader::beginRun(const edm::Run&, edm::EventSetup const& es) 
   if (fromDD4hep_) {
     auto pDD = es.getTransientHandle(dd4HepCompactViewToken_);
     const cms::DDCompactView& cpv = *pDD;
-    rpcpd.build(&cpv, *pMNDC, *rig);
+    rpcpd.build(&cpv, *pMNDC, rig);
   } else {
     auto pDD = es.getTransientHandle(compactViewToken_);
     const DDCompactView& cpv = *pDD;
-    rpcpd.build(&cpv, *pMNDC, *rig);
+    rpcpd.build(&cpv, *pMNDC, rig);
   }
   if (mydbservice->isNewTagRequest("RPCRecoGeometryRcd")) {
-    mydbservice->createNewIOV<RecoIdealGeometry>(
-        rig, mydbservice->beginOfTime(), mydbservice->endOfTime(), "RPCRecoGeometryRcd");
+    mydbservice->createOneIOV(rig, mydbservice->beginOfTime(), "RPCRecoGeometryRcd");
   } else {
     edm::LogError("RPCRecoIdealDBLoader") << "RPCRecoGeometryRcd Tag is already present.";
   }

--- a/CondTools/Geometry/plugins/XMLGeometryBuilder.cc
+++ b/CondTools/Geometry/plugins/XMLGeometryBuilder.cc
@@ -43,10 +43,10 @@ void XMLGeometryBuilder::beginJob() {
     return;
   }
 
-  FileBlob* pgf = new FileBlob(m_fname, m_zip);
+  FileBlob pgf(m_fname, m_zip);
 
   if (mydbservice->isNewTagRequest(m_record)) {
-    mydbservice->createNewIOV<FileBlob>(pgf, mydbservice->beginOfTime(), mydbservice->endOfTime(), m_record);
+    mydbservice->createOneIOV(pgf, mydbservice->beginOfTime(), m_record);
   } else {
     edm::LogError("XMLGeometryBuilder") << "GeometryFileRcd Tag already exist";
   }

--- a/Geometry/DTGeometry/test/DTRecoIdealDBLoader.cc
+++ b/Geometry/DTGeometry/test/DTRecoIdealDBLoader.cc
@@ -50,7 +50,7 @@ DTRecoIdealDBLoader::~DTRecoIdealDBLoader() { std::cout << "DTRecoIdealDBLoader:
 
 void DTRecoIdealDBLoader::analyze(const edm::Event& evt, const edm::EventSetup& es) {
   std::cout << "DTRecoIdealDBLoader::beginJob" << std::endl;
-  RecoIdealGeometry* rig = new RecoIdealGeometry;
+  RecoIdealGeometry rig;
 
   edm::Service<cond::service::PoolDBOutputService> mydbservice;
   if (!mydbservice.isAvailable()) {
@@ -62,13 +62,12 @@ void DTRecoIdealDBLoader::analyze(const edm::Event& evt, const edm::EventSetup& 
   const auto& pMNDC = &es.getData(tokDT_);
   DTGeometryParsFromDD dtgp;
 
-  dtgp.build(&cpv, *pMNDC, *rig);
-  std::cout << "RecoIdealGeometry " << rig->size() << std::endl;
+  dtgp.build(&cpv, *pMNDC, rig);
+  std::cout << "RecoIdealGeometry " << rig.size() << std::endl;
 
   if (mydbservice->isNewTagRequest("RecoIdealGeometryRcd")) {
     cout << "mydbservice " << mydbservice->beginOfTime() << " to " << mydbservice->endOfTime() << endl;
-    mydbservice->createNewIOV<RecoIdealGeometry>(
-        rig, mydbservice->beginOfTime(), mydbservice->endOfTime(), "RecoIdealGeometryRcd");
+    mydbservice->createOneIOV(rig, mydbservice->beginOfTime(), "RecoIdealGeometryRcd");
   } else {
     std::cout << "RecoIdealGeometryRcd Tag is already present." << std::endl;
   }


### PR DESCRIPTION
#### PR description:
Part of cms-AlCaDB/AlCaTools#28.
Migrated:
 - several plugins in ` CondTools/Geometry/plugins`
 - Geometry/DTGeometry/test/DTRecoIdealDBLoader.cc

#### PR validation:
Code compiles and `scramv1 b runtests` runs fine.

#### Backport:
N/A