### PR TITLE
 Remove deprecation warnings from several `Calib*` subsystem 

### DIFF
--- a/CalibTracker/SiPixelConnectivity/test/SiPixelFedCablingMapWriter.cc
+++ b/CalibTracker/SiPixelConnectivity/test/SiPixelFedCablingMapWriter.cc
@@ -3,7 +3,7 @@
 #include <sstream>
 
 // user include files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -19,7 +19,7 @@ using namespace std;
 using namespace edm;
 using namespace sipixelobjects;
 
-class SiPixelFedCablingMapWriter : public edm::EDAnalyzer {
+class SiPixelFedCablingMapWriter : public edm::one::EDAnalyzer<> {
 public:
   explicit SiPixelFedCablingMapWriter(const edm::ParameterSet& cfg);
   ~SiPixelFedCablingMapWriter();
@@ -50,9 +50,7 @@ SiPixelFedCablingMapWriter::SiPixelFedCablingMapWriter(const edm::ParameterSet& 
   //::putenv(const_cast<char*>(std::string("CORAL_AUTH_PASSWORD=none").c_str()));
 }
 
-SiPixelFedCablingMapWriter::~SiPixelFedCablingMapWriter() {
-  //  delete cabling;
-}
+SiPixelFedCablingMapWriter::~SiPixelFedCablingMapWriter() = default;
 
 void SiPixelFedCablingMapWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   static int first(1);

--- a/CalibTracker/SiPixelGainCalibration/plugins/SiPixelCalibDigiProducer.h
+++ b/CalibTracker/SiPixelGainCalibration/plugins/SiPixelCalibDigiProducer.h
@@ -23,7 +23,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
@@ -52,7 +52,7 @@
 // class decleration
 //
 
-class SiPixelCalibDigiProducer : public edm::EDProducer {
+class SiPixelCalibDigiProducer : public edm::stream::EDProducer<> {
 public:
   explicit SiPixelCalibDigiProducer(const edm::ParameterSet& iConfig);
   ~SiPixelCalibDigiProducer() override;

--- a/CalibTracker/SiPixelGainCalibration/plugins/SiPixelGainCalibrationAnalysis.h
+++ b/CalibTracker/SiPixelGainCalibration/plugins/SiPixelGainCalibrationAnalysis.h
@@ -21,7 +21,6 @@ Implementation:
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "CalibTracker/SiPixelTools/interface/SiPixelOfflineCalibAnalysisBase.h"
 
 #include "FWCore/Framework/interface/Event.h"

--- a/CalibTracker/SiPixelGainCalibration/test/SimpleTestPrintOutPixelCalibAnalyzer.cc
+++ b/CalibTracker/SiPixelGainCalibration/test/SimpleTestPrintOutPixelCalibAnalyzer.cc
@@ -21,41 +21,23 @@
 
 // user include files
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/SiPixelDigi/interface/SiPixelCalibDigi.h"
-
 #include "CalibTracker/SiPixelGainCalibration/test/SimpleTestPrintOutPixelCalibAnalyzer.h"
-
-//
-// constants, enums and typedefs
-//
-
-//
-// static data member definitions
-//
 
 //
 // constructors and destructor
 //
-SimpleTestPrintOutPixelCalibAnalyzer::SimpleTestPrintOutPixelCalibAnalyzer(const edm::ParameterSet& iConfig)
-
-{
+SimpleTestPrintOutPixelCalibAnalyzer::SimpleTestPrintOutPixelCalibAnalyzer(const edm::ParameterSet& iConfig) {
   tPixelCalibDigi = consumes<edm::DetSetVector<SiPixelCalibDigi> >(edm::InputTag("siPixelCalibDigis"));
-}
-
-SimpleTestPrintOutPixelCalibAnalyzer::~SimpleTestPrintOutPixelCalibAnalyzer() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
 }
 
 //
 // member functions
 //
-void SimpleTestPrintOutPixelCalibAnalyzer::printInfo(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void SimpleTestPrintOutPixelCalibAnalyzer::printInfo(const edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   using namespace edm;
 
   Handle<DetSetVector<SiPixelCalibDigi> > pIn;
@@ -66,23 +48,19 @@ void SimpleTestPrintOutPixelCalibAnalyzer::printInfo(const edm::Event& iEvent, c
     uint32_t detid = digiIter->id;
     DetSet<SiPixelCalibDigi>::const_iterator ipix;
     for (ipix = digiIter->data.begin(); ipix != digiIter->end(); ++ipix) {
-      std::cout << std::endl;
+      edm::LogPrint("SimpleTestPrintOutPixelCalibAnalyzer") << std::endl;
       for (uint32_t ipoint = 0; ipoint < ipix->getnpoints(); ++ipoint)
-        std::cout << "\t Det ID " << detid << " row:" << ipix->row() << " col:" << ipix->col() << " point " << ipoint
-                  << " has " << ipix->getnentries(ipoint) << " entries, adc: " << ipix->getsum(ipoint)
-                  << ", adcsq: " << ipix->getsumsquares(ipoint) << std::endl;
+        edm::LogPrint("SimpleTestPrintOutPixelCalibAnalyzer")
+            << "\t Det ID " << detid << " row:" << ipix->row() << " col:" << ipix->col() << " point " << ipoint
+            << " has " << ipix->getnentries(ipoint) << " entries, adc: " << ipix->getsum(ipoint)
+            << ", adcsq: " << ipix->getsumsquares(ipoint) << std::endl;
     }
   }
 }
 // ------------ method called to for each event  ------------
-void SimpleTestPrintOutPixelCalibAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void SimpleTestPrintOutPixelCalibAnalyzer::analyze(edm::StreamID id,
+                                                   edm::Event const& iEvent,
+                                                   edm::EventSetup const& iSetup) const {
   using namespace edm;
-
   printInfo(iEvent, iSetup);
 }
-
-// ------------ method called once each job just before starting event loop  ------------
-void SimpleTestPrintOutPixelCalibAnalyzer::beginJob() {}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void SimpleTestPrintOutPixelCalibAnalyzer::endJob() {}

--- a/CalibTracker/SiPixelGainCalibration/test/SimpleTestPrintOutPixelCalibAnalyzer.h
+++ b/CalibTracker/SiPixelGainCalibration/test/SimpleTestPrintOutPixelCalibAnalyzer.h
@@ -20,7 +20,7 @@
 #include <memory>
 
 // user include files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -32,18 +32,15 @@
 // class decleration
 //
 
-class SimpleTestPrintOutPixelCalibAnalyzer : public edm::EDAnalyzer {
+class SimpleTestPrintOutPixelCalibAnalyzer : public edm::global::EDAnalyzer<> {
 public:
   explicit SimpleTestPrintOutPixelCalibAnalyzer(const edm::ParameterSet&);
-  ~SimpleTestPrintOutPixelCalibAnalyzer();
+  ~SimpleTestPrintOutPixelCalibAnalyzer() = default;
 
 private:
-  virtual void beginJob();
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void printInfo(const edm::Event&,
-                         const edm::EventSetup&);  // print method added by Freya, this way the analyzer stays clean
-  virtual void endJob();
-
+  virtual void analyze(edm::StreamID, edm::Event const& event, edm::EventSetup const&) const override;
+  virtual void printInfo(const edm::Event&, const edm::EventSetup&)
+      const;  // print method added by Freya, this way the analyzer stays clean
   // ----------member data ---------------------------
   edm::EDGetTokenT<edm::DetSetVector<SiPixelCalibDigi> > tPixelCalibDigi;
 };

--- a/CalibTracker/SiPixelIsAliveCalibration/src/SiPixelIsAliveCalibration.cc
+++ b/CalibTracker/SiPixelIsAliveCalibration/src/SiPixelIsAliveCalibration.cc
@@ -21,8 +21,6 @@
 #include <memory>
 
 // user include files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "CalibTracker/SiPixelTools/interface/SiPixelOfflineCalibAnalysisBase.h"

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
@@ -5,7 +5,6 @@
 #include <iostream>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromData.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromData.cc
@@ -4,7 +4,6 @@
 #include <memory>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/CalibTracker/SiStripDCS/plugins/SiStripDetVOffPrinter.cc
+++ b/CalibTracker/SiStripDCS/plugins/SiStripDetVOffPrinter.cc
@@ -1,5 +1,4 @@
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"

--- a/CalibTracker/SiStripDCS/test/Synchronization/SyncDCSO2O.cc
+++ b/CalibTracker/SiStripDCS/test/Synchronization/SyncDCSO2O.cc
@@ -5,8 +5,6 @@
 #include "CondFormats/Common/interface/TimeConversions.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "CondFormats/SiStripObjects/interface/SiStripDetVOff.h"
-#include "CondFormats/DataRecord/interface/SiStripCondDataRecords.h"
 
 #include <iostream>
 #include <algorithm>
@@ -14,7 +12,7 @@
 #include "TFile.h"
 #include "TCanvas.h"
 
-SyncDCSO2O::SyncDCSO2O(const edm::ParameterSet& iConfig) {
+SyncDCSO2O::SyncDCSO2O(const edm::ParameterSet& iConfig) : dcsToken_(esConsumes()) {
   // get all digi collections
   digiProducersList_ = iConfig.getParameter<Parameters>("DigiProducersList");
 }
@@ -88,8 +86,7 @@ SyncDCSO2O::~SyncDCSO2O() {
 void SyncDCSO2O::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
 
-  ESHandle<SiStripDetVOff> detVOff;
-  iSetup.get<SiStripDetVOffRcd>().get(detVOff);
+  const SiStripDetVOff* detVOff = &iSetup.getData(dcsToken_);
 
   std::vector<uint32_t> detIds;
   detVOff->getDetIds(detIds);

--- a/CalibTracker/SiStripDCS/test/Synchronization/SyncDCSO2O.h
+++ b/CalibTracker/SiStripDCS/test/Synchronization/SyncDCSO2O.h
@@ -19,7 +19,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -31,12 +31,15 @@
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/SiStripDigi/interface/SiStripDigi.h"
 
+#include "CondFormats/SiStripObjects/interface/SiStripDetVOff.h"
+#include "CondFormats/DataRecord/interface/SiStripCondDataRecords.h"
+
 #include <vector>
 
 #include "TH1F.h"
 #include "TGraph.h"
 
-class SyncDCSO2O : public edm::EDAnalyzer {
+class SyncDCSO2O : public edm::one::EDAnalyzer<> {
 public:
   explicit SyncDCSO2O(const edm::ParameterSet&);
   ~SyncDCSO2O();
@@ -51,6 +54,7 @@ private:
   TGraph* buildGraph(TH1F* histo, Float_t* timeArray);
 
   // ----------member data ---------------------------
+  const edm::ESGetToken<SiStripDetVOff, SiStripDetVOffRcd> dcsToken_;
   edm::Handle<edm::DetSetVector<SiStripDigi> > digiDetsetVector_[4];
   typedef std::vector<edm::ParameterSet> Parameters;
   Parameters digiProducersList_;

--- a/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEffFromCalibTree.cc
+++ b/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEffFromCalibTree.cc
@@ -7,7 +7,6 @@
 #include <sstream>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/ESHandle.h"

--- a/CalibTracker/SiStripHitEfficiency/src/HitEff.cc
+++ b/CalibTracker/SiStripHitEfficiency/src/HitEff.cc
@@ -12,7 +12,6 @@
 #include <iostream>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 

--- a/Calibration/TkAlCaRecoProducers/test/DQMRootFileReader.cc
+++ b/Calibration/TkAlCaRecoProducers/test/DQMRootFileReader.cc
@@ -20,12 +20,9 @@ Implementation:
 #include <vector>
 
 // user include files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
@@ -35,19 +32,16 @@ using std::endl;
 //
 // class declaration
 //
-class DQMRootFileReader : public edm::EDAnalyzer {
+class DQMRootFileReader : public edm::one::EDAnalyzer<> {
 public:
   typedef dqm::legacy::DQMStore DQMStore;
   explicit DQMRootFileReader(const edm::ParameterSet &);
-  ~DQMRootFileReader();
+  ~DQMRootFileReader() override = default;
 
-  virtual void analyze(const edm::Event &, const edm::EventSetup &);
-
-  virtual void endJob(void);
+  void analyze(const edm::Event &, const edm::EventSetup &) override;
 
 private:
   // ----------member data ---------------------------
-
   // back-end interface
   DQMStore *dbe;
   std::string filename;
@@ -59,17 +53,7 @@ private:
 DQMRootFileReader::DQMRootFileReader(const edm::ParameterSet &iConfig) {
   // get hold of back-end interface
   dbe = edm::Service<DQMStore>().operator->();
-
   filename = iConfig.getUntrackedParameter<std::string>("RootFileName", "test_playback.root");
-}
-
-DQMRootFileReader::~DQMRootFileReader() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
-}
-
-void DQMRootFileReader::endJob(void) {
-  // dbe->save("test.root");
 }
 
 //


### PR DESCRIPTION
#### PR description:

Title says is all. Went systematically through all `CMSDEPRECATED_X` warnings for some `Calib*` subsystem.
   * removed `EventSetup::get()` calls
   * migrated away from deprecated `EDModule`s API
   * put class headers of plugins in the same file as implementation 
   * modernized code
  
#### PR validation:

`cmssw compiles`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
