### PR TITLE
MTD reconstruction: time back-propagation accounting for variable speed along trajectory

### DIFF
--- a/RecoMTD/TimingIDTools/plugins/TOFPIDProducer.cc
+++ b/RecoMTD/TimingIDTools/plugins/TOFPIDProducer.cc
@@ -46,8 +46,8 @@ private:
   edm::EDGetTokenT<edm::ValueMap<float>> tmtdToken_;
   edm::EDGetTokenT<edm::ValueMap<float>> sigmat0Token_;
   edm::EDGetTokenT<edm::ValueMap<float>> sigmatmtdToken_;
-  edm::EDGetTokenT<edm::ValueMap<float>> pathLengthToken_;
-  edm::EDGetTokenT<edm::ValueMap<float>> pToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> tofkToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> tofpToken_;
   edm::EDGetTokenT<reco::VertexCollection> vtxsToken_;
   double vtxMaxSigmaT_;
   double maxDz_;
@@ -62,8 +62,8 @@ TOFPIDProducer::TOFPIDProducer(const ParameterSet& iConfig)
       tmtdToken_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("tmtdSrc"))),
       sigmat0Token_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("sigmat0Src"))),
       sigmatmtdToken_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("sigmatmtdSrc"))),
-      pathLengthToken_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("pathLengthSrc"))),
-      pToken_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("pSrc"))),
+      tofkToken_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("tofkSrc"))),
+      tofpToken_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("tofpSrc"))),
       vtxsToken_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vtxsSrc"))),
       vtxMaxSigmaT_(iConfig.getParameter<double>("vtxMaxSigmaT")),
       maxDz_(iConfig.getParameter<double>("maxDz")),
@@ -91,10 +91,10 @@ void TOFPIDProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptio
       ->setComment("Input ValueMap for track time uncertainty at beamline");
   desc.add<edm::InputTag>("sigmatmtdSrc", edm::InputTag("trackExtenderWithMTD:generalTracksigmatmtd"))
       ->setComment("Input ValueMap for track time uncertainty at MTD");
-  desc.add<edm::InputTag>("pathLengthSrc", edm::InputTag("trackExtenderWithMTD:generalTrackPathLength"))
-      ->setComment("Input ValueMap for track path lengh from beamline to MTD");
-  desc.add<edm::InputTag>("pSrc", edm::InputTag("trackExtenderWithMTD:generalTrackp"))
-      ->setComment("Input ValueMap for track momentum magnitude (normally from refit with MTD hits)");
+  desc.add<edm::InputTag>("tofkSrc", edm::InputTag("trackExtenderWithMTD:generalTrackTofK"))
+      ->setComment("Input ValueMap for track tof as kaon");
+  desc.add<edm::InputTag>("tofpSrc", edm::InputTag("trackExtenderWithMTD:generalTrackTofP"))
+      ->setComment("Input ValueMap for track tof as proton");
   desc.add<edm::InputTag>("vtxsSrc", edm::InputTag("unsortedOfflinePrimaryVertices4DwithPID"))
       ->setComment("Input primary vertex collection");
   desc.add<double>("vtxMaxSigmaT", 0.025)
@@ -124,10 +124,6 @@ void TOFPIDProducer::fillValueMap(edm::Event& iEvent,
 }
 
 void TOFPIDProducer::produce(edm::Event& ev, const edm::EventSetup& es) {
-  constexpr double m_k = 0.493677;                                    //[GeV]
-  constexpr double m_p = 0.9382720813;                                //[GeV]
-  constexpr double c_cm_ns = CLHEP::c_light * CLHEP::ns / CLHEP::cm;  //[cm/ns]
-  constexpr double c_inv = 1.0 / c_cm_ns;
 
   edm::Handle<reco::TrackCollection> tracksH;
   ev.getByToken(tracksToken_, tracksH);
@@ -149,13 +145,13 @@ void TOFPIDProducer::produce(edm::Event& ev, const edm::EventSetup& es) {
   ev.getByToken(sigmatmtdToken_, sigmatmtdH);
   const auto& sigmatmtdIn = *sigmatmtdH;
 
-  edm::Handle<edm::ValueMap<float>> pathLengthH;
-  ev.getByToken(pathLengthToken_, pathLengthH);
-  const auto& pathLengthIn = *pathLengthH;
+  edm::Handle<edm::ValueMap<float>> tofkH;
+  ev.getByToken(tofkToken_, tofkH);
+  const auto& tofkIn = *tofkH;
 
-  edm::Handle<edm::ValueMap<float>> pH;
-  ev.getByToken(pToken_, pH);
-  const auto& pIn = *pH;
+  edm::Handle<edm::ValueMap<float>> tofpH;
+  ev.getByToken(tofpToken_, tofpH);
+  const auto& tofpIn = *tofpH;
 
   edm::Handle<reco::VertexCollection> vtxsH;
   ev.getByToken(vtxsToken_, vtxsH);
@@ -249,16 +245,8 @@ void TOFPIDProducer::produce(edm::Event& ev, const edm::EventSetup& es) {
         }
 
         double tmtd = tmtdIn[trackref];
-        double pathlength = pathLengthIn[trackref];
-        double magp = pIn[trackref];
-
-        double gammasq_k = 1. + magp * magp / m_k / m_k;
-        double beta_k = std::sqrt(1. - 1. / gammasq_k);
-        double t0_k = tmtd - pathlength / beta_k * c_inv;
-
-        double gammasq_p = 1. + magp * magp / m_p / m_p;
-        double beta_p = std::sqrt(1. - 1. / gammasq_p);
-        double t0_p = tmtd - pathlength / beta_p * c_inv;
+        double t0_k = tmtd - tofkIn[trackref];
+        double t0_p = tmtd - tofpIn[trackref];
 
         double chisqmin = chisqnom;
 

--- a/RecoMTD/TimingIDTools/plugins/TOFPIDProducer.cc
+++ b/RecoMTD/TimingIDTools/plugins/TOFPIDProducer.cc
@@ -128,33 +128,19 @@ void TOFPIDProducer::produce(edm::Event& ev, const edm::EventSetup& es) {
   ev.getByToken(tracksToken_, tracksH);
   const auto& tracks = *tracksH;
 
-  edm::Handle<edm::ValueMap<float>> t0H;
-  ev.getByToken(t0Token_, t0H);
-  const auto& t0In = *t0H;
+  const auto& t0In = ev.get(t0Token_);
 
-  edm::Handle<edm::ValueMap<float>> tmtdH;
-  ev.getByToken(tmtdToken_, tmtdH);
-  const auto& tmtdIn = *tmtdH;
+  const auto& tmtdIn = ev.get(tmtdToken_);
 
-  edm::Handle<edm::ValueMap<float>> sigmat0H;
-  ev.getByToken(sigmat0Token_, sigmat0H);
-  const auto& sigmat0In = *sigmat0H;
+  const auto& sigmat0In = ev.get(sigmat0Token_);
 
-  edm::Handle<edm::ValueMap<float>> sigmatmtdH;
-  ev.getByToken(sigmatmtdToken_, sigmatmtdH);
-  const auto& sigmatmtdIn = *sigmatmtdH;
+  const auto& sigmatmtdIn = ev.get(sigmatmtdToken_);
 
-  edm::Handle<edm::ValueMap<float>> tofkH;
-  ev.getByToken(tofkToken_, tofkH);
-  const auto& tofkIn = *tofkH;
+  const auto& tofkIn = ev.get(tofkToken_);
 
-  edm::Handle<edm::ValueMap<float>> tofpH;
-  ev.getByToken(tofpToken_, tofpH);
-  const auto& tofpIn = *tofpH;
+  const auto& tofpIn = ev.get(tofpToken_);
 
-  edm::Handle<reco::VertexCollection> vtxsH;
-  ev.getByToken(vtxsToken_, vtxsH);
-  const auto& vtxs = *vtxsH;
+  const auto& vtxs = ev.get(vtxsToken_);
 
   //output value maps (PID probabilities and recalculated time at beamline)
   std::vector<float> t0OutRaw;

--- a/RecoMTD/TimingIDTools/plugins/TOFPIDProducer.cc
+++ b/RecoMTD/TimingIDTools/plugins/TOFPIDProducer.cc
@@ -124,7 +124,6 @@ void TOFPIDProducer::fillValueMap(edm::Event& iEvent,
 }
 
 void TOFPIDProducer::produce(edm::Event& ev, const edm::EventSetup& es) {
-
   edm::Handle<reco::TrackCollection> tracksH;
   ev.getByToken(tracksToken_, tracksH);
   const auto& tracks = *tracksH;

--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -98,8 +98,8 @@ namespace {
     TrackSegments() = default;
 
     inline uint32_t addSegment(float tPath, float tMom2) {
-      segmentPathOvc_.emplace_back(static_cast<float>(tPath * c_inv));
-      segmentMom2_.emplace_back(static_cast<float>(tMom2));
+      segmentPathOvc_.emplace_back(tPath * c_inv);
+      segmentMom2_.emplace_back(tMom2);
       nSegment_++;
 
       LogTrace("TrackExtenderWithMTD") << "addSegment # " << nSegment_ << " s = " << tPath
@@ -111,7 +111,7 @@ namespace {
     inline float computeTof(float mass_inv2) const {
       float tof(0.f);
       for (uint32_t iSeg = 0; iSeg < nSegment_; iSeg++) {
-        float gammasq = 1.f + segmentMom2_[iSeg] * static_cast<float>(mass_inv2);
+        float gammasq = 1.f + segmentMom2_[iSeg] * mass_inv2;
         float beta = std::sqrt(1.f - 1.f / gammasq);
         tof += segmentPathOvc_[iSeg] / beta;
 

--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -98,8 +98,8 @@ namespace {
     TrackSegments() = default;
 
     inline uint32_t addSegment(double tPath, double tMom2) {
-      segmentPathOvc_.emplace_back(tPath * c_inv);
-      segmentMom2_.emplace_back(tMom2);
+      segmentPathOvc_.emplace_back(static_cast<float>(tPath * c_inv));
+      segmentMom2_.emplace_back(static_cast<float>(tMom2));
       nSegment_++;
 
       LogTrace("TrackExtenderWithMTD") << "addSegment # " << nSegment_ << " s = " << tPath
@@ -109,17 +109,17 @@ namespace {
     }
 
     inline double computeTof(double mass_inv2) const {
-      double tof(0.);
+      float tof(0.f);
       for (uint32_t iSeg = 0; iSeg < nSegment_; iSeg++) {
-        double gammasq = 1. + segmentMom2_[iSeg] * mass_inv2;
-        double beta = std::sqrt(1. - 1. / gammasq);
+        float gammasq = 1.f + segmentMom2_[iSeg] * static_cast<float>(mass_inv2);
+        float beta = std::sqrt(1.f - 1.f / gammasq);
         tof += segmentPathOvc_[iSeg] / beta;
 
         LogTrace("TrackExtenderWithMTD") << " TOF Segment # " << iSeg + 1 << " p = " << std::sqrt(segmentMom2_[iSeg])
                                          << " tof = " << tof;
       }
 
-      return tof;
+      return static_cast<double>(tof);
     }
 
     inline uint32_t size() const { return nSegment_; }
@@ -137,12 +137,13 @@ namespace {
       if (iSegment >= nSegment_) {
         throw cms::Exception("TrackExtenderWithMTD") << "Requesting non existing track segment #" << iSegment;
       }
-      return std::make_pair(segmentPathOvc_[iSegment], segmentMom2_[iSegment]);
+      return std::make_pair(static_cast<double>(segmentPathOvc_[iSegment]),
+                            static_cast<double>(segmentMom2_[iSegment]));
     }
 
     uint32_t nSegment_ = 0;
-    std::vector<double> segmentPathOvc_;
-    std::vector<double> segmentMom2_;
+    std::vector<float> segmentPathOvc_;
+    std::vector<float> segmentMom2_;
   };
 
   struct TrackTofPidInfo {

--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -1,5 +1,3 @@
-#define EDM_ML_DEBUG
-
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -826,7 +824,8 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
     for (const auto& trj : trajwithmtd) {
       const auto& thetrj = (updateTraj_ ? trj : trajs.front());
       float pathLength = 0.f, tmtd = 0.f, sigmatmtd = -1.f, tofpi = 0.f, tofk = 0.f, tofp = 0.f;
-      LogTrace("TrackExtenderWithMTD") << "Refit track " << itrack << " p/pT = " << track.p() << " " << track.pt();
+      LogTrace("TrackExtenderWithMTD") << "Refit track " << itrack << " p/pT = " << track.p() << " " << track.pt()
+                                       << " eta = " << track.eta();
       reco::Track result = buildTrack(track,
                                       thetrj,
                                       trj,
@@ -879,7 +878,9 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
         }
         npixBarrel.push_back(backtrack.hitPattern().numberOfValidPixelBarrelHits());
         npixEndcap.push_back(backtrack.hitPattern().numberOfValidPixelEndcapHits());
-        LogTrace("TrackExtenderWithMTD") << "tmtd " << tmtdMap << " +/- " << sigmatmtdMap << " t0 " << t0Map << " +/- " << sigmat0Map << " tof pi/K/p " << tofpiMap << " " << tofkMap << " " << tofpMap;
+        LogTrace("TrackExtenderWithMTD") << "tmtd " << tmtdMap << " +/- " << sigmatmtdMap << " t0 " << t0Map << " +/- "
+                                         << sigmat0Map << " tof pi/K/p " << tofpiMap << " " << tofkMap << " "
+                                         << tofpMap;
       } else {
         LogTrace("TrackExtenderWithMTD") << "Error in the MTD track refitting. This should not happen";
       }
@@ -962,13 +963,10 @@ namespace {
           if (pl.second == 0.)
             continue;
 
-          //const double tot_pl = pathlength0 + std::abs(pl.second);
           const double t_vtx = useVtxConstraint ? vtxTime : 0.;
 
           constexpr double vtx_res = 0.008;
           const double t_vtx_err = useVtxConstraint ? vtx_res : bsTimeSpread;
-
-          //constexpr double t_res_manual = 0.035;
 
           double lastpmag2 = trs0.getSegment(0).second;
 
@@ -978,17 +976,6 @@ namespace {
               if (!est.first)
                 continue;
 
-              //TrackTofPidInfo tof = computeTrackTofPidInfo(pmag2,
-                                                           //tot_pl,
-                                                           //trs0,
-                                                           //hit.time(),
-                                                           //t_res_manual,  //put hit error by hand for the moment
-                                                           //t_vtx,
-                                                           //t_vtx_err,  //put vtx error by hand for the moment
-                                                           //false,
-                                                           //TofCalc::cost);
-
-              LogTrace("TrackExtenderWithMTD") << "Cand hit t = " << hit.time() << " +/- " << hit.timeError() << " p/lastp " << std::sqrt(pmag2) << " / " << std::sqrt(lastpmag2);
               TrackTofPidInfo tof = computeTrackTofPidInfo(lastpmag2,
                                                            std::abs(pl.second),
                                                            trs0,
@@ -1227,8 +1214,8 @@ reco::Track TrackExtenderWithMTDT<TrackCollection>::buildTrack(const reco::Track
       thiterror = mtdhit->timeError();
       validmtd = true;
     } else if (ihitcount == 2 && ietlcount == 2) {
-      std::pair <double,double> lastStep = trs.getSegment(0);
-      double etlpathlength = std::abs(lastStep.first/c_inv);
+      std::pair<double, double> lastStep = trs.getSegment(0);
+      double etlpathlength = std::abs(lastStep.first / c_inv);
       //
       // The information of the two ETL hits is combined and attributed to the innermost hit
       //
@@ -1240,7 +1227,7 @@ reco::Track TrackExtenderWithMTDT<TrackCollection>::buildTrack(const reco::Track
         const MTDTrackingRecHit* mtdhit1 = static_cast<const MTDTrackingRecHit*>((*ihit1).recHit()->hit());
         const MTDTrackingRecHit* mtdhit2 = static_cast<const MTDTrackingRecHit*>((*(ihit1 + 1)).recHit()->hit());
         TrackTofPidInfo tofInfo = computeTrackTofPidInfo(
-          lastStep.second, etlpathlength, trs, mtdhit1->time(), mtdhit1->timeError(), 0., 0., true, TofCalc::cost);
+            lastStep.second, etlpathlength, trs, mtdhit1->time(), mtdhit1->timeError(), 0., 0., true, TofCalc::cost);
         //
         // Protect against incompatible times
         //

--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -63,41 +63,41 @@ using namespace edm;
 using namespace reco;
 
 namespace {
-  constexpr double c_cm_ns = geant_units::operators::convertMmToCm(CLHEP::c_light);  // [mm/ns] -> [cm/ns]
-  constexpr double c_inv = 1.0 / c_cm_ns;
+  constexpr float c_cm_ns = geant_units::operators::convertMmToCm(CLHEP::c_light);  // [mm/ns] -> [cm/ns]
+  constexpr float c_inv = 1.0f / c_cm_ns;
 
   class MTDHitMatchingInfo {
   public:
     MTDHitMatchingInfo() {
       hit = nullptr;
-      estChi2 = std::numeric_limits<double>::max();
-      timeChi2 = std::numeric_limits<double>::max();
+      estChi2 = std::numeric_limits<float>::max();
+      timeChi2 = std::numeric_limits<float>::max();
     }
 
     //Operator used to sort the hits while performing the matching step at the MTD
     inline bool operator<(const MTDHitMatchingInfo& m2) const {
       //only for good matching in time use estChi2, otherwise use mostly time compatibility
-      constexpr double chi2_cut = 10.;
-      constexpr double low_weight = 3.;
-      constexpr double high_weight = 8.;
+      constexpr float chi2_cut = 10.f;
+      constexpr float low_weight = 3.f;
+      constexpr float high_weight = 8.f;
       if (timeChi2 < chi2_cut && m2.timeChi2 < chi2_cut)
         return chi2(low_weight) < m2.chi2(low_weight);
       else
         return chi2(high_weight) < m2.chi2(high_weight);
     }
 
-    inline double chi2(double timeWeight = 1.) const { return estChi2 + timeWeight * timeChi2; }
+    inline float chi2(float timeWeight = 1.f) const { return estChi2 + timeWeight * timeChi2; }
 
     const MTDTrackingRecHit* hit;
-    double estChi2;
-    double timeChi2;
+    float estChi2;
+    float timeChi2;
   };
 
   class TrackSegments {
   public:
     TrackSegments() = default;
 
-    inline uint32_t addSegment(double tPath, double tMom2) {
+    inline uint32_t addSegment(float tPath, float tMom2) {
       segmentPathOvc_.emplace_back(static_cast<float>(tPath * c_inv));
       segmentMom2_.emplace_back(static_cast<float>(tMom2));
       nSegment_++;
@@ -108,7 +108,7 @@ namespace {
       return nSegment_;
     }
 
-    inline float computeTof(double mass_inv2) const {
+    inline float computeTof(float mass_inv2) const {
       float tof(0.f);
       for (uint32_t iSeg = 0; iSeg < nSegment_; iSeg++) {
         float gammasq = 1.f + segmentMom2_[iSeg] * static_cast<float>(mass_inv2);
@@ -146,54 +146,54 @@ namespace {
   };
 
   struct TrackTofPidInfo {
-    double tmtd;
-    double tmtderror;
-    double pathlength;
+    float tmtd;
+    float tmtderror;
+    float pathlength;
 
-    double betaerror;
+    float betaerror;
 
-    double dt;
-    double dterror;
-    double dtchi2;
+    float dt;
+    float dterror;
+    float dtchi2;
 
-    double dt_best;
-    double dterror_best;
-    double dtchi2_best;
+    float dt_best;
+    float dterror_best;
+    float dtchi2_best;
 
-    double gammasq_pi;
-    double beta_pi;
-    double dt_pi;
+    float gammasq_pi;
+    float beta_pi;
+    float dt_pi;
 
-    double gammasq_k;
-    double beta_k;
-    double dt_k;
+    float gammasq_k;
+    float beta_k;
+    float dt_k;
 
-    double gammasq_p;
-    double beta_p;
-    double dt_p;
+    float gammasq_p;
+    float beta_p;
+    float dt_p;
 
-    double prob_pi;
-    double prob_k;
-    double prob_p;
+    float prob_pi;
+    float prob_k;
+    float prob_p;
   };
 
   enum class TofCalc { kCost = 1, kSegm = 2, kMixd = 3 };
 
-  const TrackTofPidInfo computeTrackTofPidInfo(double magp2,
-                                               double length,
+  const TrackTofPidInfo computeTrackTofPidInfo(float magp2,
+                                               float length,
                                                TrackSegments trs,
-                                               double t_mtd,
-                                               double t_mtderr,
-                                               double t_vtx,
-                                               double t_vtx_err,
+                                               float t_mtd,
+                                               float t_mtderr,
+                                               float t_vtx,
+                                               float t_vtx_err,
                                                bool addPIDError = true,
                                                TofCalc choice = TofCalc::kCost) {
-    constexpr double m_pi = 0.13957018;
-    constexpr double m_pi_inv2 = 1.0 / m_pi / m_pi;
-    constexpr double m_k = 0.493677;
-    constexpr double m_k_inv2 = 1.0 / m_k / m_k;
-    constexpr double m_p = 0.9382720813;
-    constexpr double m_p_inv2 = 1.0 / m_p / m_p;
+    constexpr float m_pi = 0.13957018f;
+    constexpr float m_pi_inv2 = 1.0f / m_pi / m_pi;
+    constexpr float m_k = 0.493677f;
+    constexpr float m_k_inv2 = 1.0f / m_k / m_k;
+    constexpr float m_p = 0.9382720813f;
+    constexpr float m_p_inv2 = 1.0f / m_p / m_p;
 
     TrackTofPidInfo tofpid;
 
@@ -201,8 +201,8 @@ namespace {
     tofpid.tmtderror = t_mtderr;
     tofpid.pathlength = length;
 
-    auto deltat = [&](const double mass_inv2, const double betatmp) {
-      double res(1.);
+    auto deltat = [&](const float mass_inv2, const float betatmp) {
+      float res(1.f);
       switch (choice) {
         case TofCalc::kCost:
           res = tofpid.pathlength / betatmp * c_inv;
@@ -217,21 +217,21 @@ namespace {
       return res;
     };
 
-    tofpid.gammasq_pi = 1. + magp2 * m_pi_inv2;
-    tofpid.beta_pi = std::sqrt(1. - 1. / tofpid.gammasq_pi);
+    tofpid.gammasq_pi = 1.f + magp2 * m_pi_inv2;
+    tofpid.beta_pi = std::sqrt(1.f - 1.f / tofpid.gammasq_pi);
     tofpid.dt_pi = deltat(m_pi_inv2, tofpid.beta_pi);
 
-    tofpid.gammasq_k = 1. + magp2 * m_k_inv2;
-    tofpid.beta_k = std::sqrt(1. - 1. / tofpid.gammasq_k);
+    tofpid.gammasq_k = 1.f + magp2 * m_k_inv2;
+    tofpid.beta_k = std::sqrt(1.f - 1.f / tofpid.gammasq_k);
     tofpid.dt_k = deltat(m_k_inv2, tofpid.beta_k);
 
-    tofpid.gammasq_p = 1. + magp2 * m_p_inv2;
-    tofpid.beta_p = std::sqrt(1. - 1. / tofpid.gammasq_p);
+    tofpid.gammasq_p = 1.f + magp2 * m_p_inv2;
+    tofpid.beta_p = std::sqrt(1.f - 1.f / tofpid.gammasq_p);
     tofpid.dt_p = deltat(m_p_inv2, tofpid.beta_p);
 
     tofpid.dt = tofpid.tmtd - tofpid.dt_pi - t_vtx;  //assume by default the pi hypothesis
     tofpid.dterror = sqrt(tofpid.tmtderror * tofpid.tmtderror + t_vtx_err * t_vtx_err);
-    tofpid.betaerror = 0;
+    tofpid.betaerror = 0.f;
     if (addPIDError) {
       tofpid.dterror =
           sqrt(tofpid.dterror * tofpid.dterror + (tofpid.dt_p - tofpid.dt_pi) * (tofpid.dt_p - tofpid.dt_pi));
@@ -244,29 +244,29 @@ namespace {
     tofpid.dterror_best = tofpid.dterror;
     tofpid.dtchi2_best = tofpid.dtchi2;
 
-    tofpid.prob_pi = -1.;
-    tofpid.prob_k = -1.;
-    tofpid.prob_p = -1.;
+    tofpid.prob_pi = -1.f;
+    tofpid.prob_k = -1.f;
+    tofpid.prob_p = -1.f;
 
     if (!addPIDError) {
       //*TODO* deal with heavier nucleons and/or BSM case here?
-      double chi2_pi = tofpid.dtchi2;
-      double chi2_k =
+      float chi2_pi = tofpid.dtchi2;
+      float chi2_k =
           (tofpid.tmtd - tofpid.dt_k - t_vtx) * (tofpid.tmtd - tofpid.dt_k - t_vtx) / (tofpid.dterror * tofpid.dterror);
-      double chi2_p =
+      float chi2_p =
           (tofpid.tmtd - tofpid.dt_p - t_vtx) * (tofpid.tmtd - tofpid.dt_p - t_vtx) / (tofpid.dterror * tofpid.dterror);
 
-      double rawprob_pi = exp(-0.5 * chi2_pi);
-      double rawprob_k = exp(-0.5 * chi2_k);
-      double rawprob_p = exp(-0.5 * chi2_p);
-      double normprob = 1. / (rawprob_pi + rawprob_k + rawprob_p);
+      float rawprob_pi = exp(-0.5f * chi2_pi);
+      float rawprob_k = exp(-0.5f * chi2_k);
+      float rawprob_p = exp(-0.5f * chi2_p);
+      float normprob = 1.f / (rawprob_pi + rawprob_k + rawprob_p);
 
       tofpid.prob_pi = rawprob_pi * normprob;
       tofpid.prob_k = rawprob_k * normprob;
       tofpid.prob_p = rawprob_p * normprob;
 
-      double prob_heavy = 1. - tofpid.prob_pi;
-      constexpr double heavy_threshold = 0.75;
+      float prob_heavy = 1.f - tofpid.prob_pi;
+      constexpr float heavy_threshold = 0.75f;
 
       if (prob_heavy > heavy_threshold) {
         if (chi2_k < chi2_p) {
@@ -305,20 +305,20 @@ namespace {
   bool trackPathLength(const Trajectory& traj,
                        const TrajectoryStateClosestToBeamLine& tscbl,
                        const Propagator* thePropagator,
-                       double& pathlength,
+                       float& pathlength,
                        TrackSegments& trs) {
-    pathlength = 0.;
+    pathlength = 0.f;
 
     bool validpropagation = true;
-    double oldp = traj.measurements().begin()->updatedState().globalMomentum().mag();
-    double pathlength1 = 0.;
-    double pathlength2 = 0.;
+    float oldp = traj.measurements().begin()->updatedState().globalMomentum().mag();
+    float pathlength1 = 0.f;
+    float pathlength2 = 0.f;
 
     //add pathlength layer by layer
     for (auto it = traj.measurements().begin(); it != traj.measurements().end() - 1; ++it) {
       const auto& propresult = thePropagator->propagateWithPath(it->updatedState(), (it + 1)->updatedState().surface());
-      double layerpathlength = std::abs(propresult.second);
-      if (layerpathlength == 0.) {
+      float layerpathlength = std::abs(propresult.second);
+      if (layerpathlength == 0.f) {
         validpropagation = false;
       }
       pathlength1 += layerpathlength;
@@ -340,7 +340,7 @@ namespace {
     auto const& aSurface = traj.direction() == alongMomentum ? traj.firstMeasurement().updatedState().surface()
                                                              : traj.lastMeasurement().updatedState().surface();
     pathlength2 = thePropagator->propagateWithPath(tscblPCA, aSurface).second;
-    if (pathlength2 == 0.) {
+    if (pathlength2 == 0.f) {
       validpropagation = false;
     }
     pathlength = pathlength1 + pathlength2;
@@ -356,9 +356,9 @@ namespace {
   bool trackPathLength(const Trajectory& traj,
                        const reco::BeamSpot& bs,
                        const Propagator* thePropagator,
-                       double& pathlength,
+                       float& pathlength,
                        TrackSegments& trs) {
-    pathlength = 0.;
+    pathlength = 0.f;
 
     TrajectoryStateClosestToBeamLine tscbl;
     bool tscbl_status = getTrajectoryStateClosestToBeamLine(traj, bs, thePropagator, tscbl);
@@ -388,42 +388,42 @@ public:
 
   TransientTrackingRecHit::ConstRecHitContainer tryBTLLayers(const TrajectoryStateOnSurface&,
                                                              const Trajectory& traj,
-                                                             const double,
-                                                             const double,
+                                                             const float,
+                                                             const float,
                                                              const TrackSegments&,
                                                              const MTDTrackingDetSetVector&,
                                                              const MTDDetLayerGeometry*,
                                                              const MagneticField* field,
                                                              const Propagator* prop,
                                                              const reco::BeamSpot& bs,
-                                                             const double vtxTime,
+                                                             const float vtxTime,
                                                              const bool matchVertex,
                                                              MTDHitMatchingInfo& bestHit) const;
 
   TransientTrackingRecHit::ConstRecHitContainer tryETLLayers(const TrajectoryStateOnSurface&,
                                                              const Trajectory& traj,
-                                                             const double,
-                                                             const double,
+                                                             const float,
+                                                             const float,
                                                              const TrackSegments&,
                                                              const MTDTrackingDetSetVector&,
                                                              const MTDDetLayerGeometry*,
                                                              const MagneticField* field,
                                                              const Propagator* prop,
                                                              const reco::BeamSpot& bs,
-                                                             const double vtxTime,
+                                                             const float vtxTime,
                                                              const bool matchVertex,
                                                              MTDHitMatchingInfo& bestHit) const;
 
   void fillMatchingHits(const DetLayer*,
                         const TrajectoryStateOnSurface&,
                         const Trajectory&,
-                        const double,
-                        const double,
+                        const float,
+                        const float,
                         const TrackSegments&,
                         const MTDTrackingDetSetVector&,
                         const Propagator*,
                         const reco::BeamSpot&,
-                        const double&,
+                        const float&,
                         const bool,
                         TransientTrackingRecHit::ConstRecHitContainer&,
                         MTDHitMatchingInfo&) const;
@@ -705,7 +705,7 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
         genVtxPosition.x(), genVtxPosition.y(), genVtxPosition.z(), genVtxTime);
   }
 
-  double vtxTime = 0.;
+  float vtxTime = 0.f;
   if (useVertex_) {
     if (useSimVertex_ && genPV) {
       vtxTime = genPV->t();
@@ -717,9 +717,9 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
   unsigned itrack = 0;
 
   for (const auto& track : tracks) {
-    double trackVtxTime = 0.;
+    float trackVtxTime = 0.f;
     if (useVertex_) {
-      double dz;
+      float dz;
       if (useSimVertex_)
         dz = std::abs(track.dz(math::XYZPoint(*genPV)));
       else
@@ -741,8 +741,8 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
       bool tscbl_status = getTrajectoryStateClosestToBeamLine(trajs.front(), bs, prop, tscbl);
 
       if (tscbl_status) {
-        double pmag2 = tscbl.trackStateAtPCA().momentum().mag2();
-        double pathlength0;
+        float pmag2 = tscbl.trackStateAtPCA().momentum().mag2();
+        float pathlength0;
         TrackSegments trs0;
         trackPathLength(trajs.front(), tscbl, prop, pathlength0, trs0);
 
@@ -757,7 +757,7 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
                                            prop,
                                            bs,
                                            trackVtxTime,
-                                           trackVtxTime != 0.,
+                                           trackVtxTime != 0.f,
                                            mBTL);
         mtdthits.insert(mtdthits.end(), btlhits.begin(), btlhits.end());
 
@@ -774,7 +774,7 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
                                            prop,
                                            bs,
                                            trackVtxTime,
-                                           trackVtxTime != 0.,
+                                           trackVtxTime != 0.f,
                                            mETL);
         mtdthits.insert(mtdthits.end(), etlhits.begin(), etlhits.end());
       }
@@ -828,10 +828,10 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
         extras->back().setTrajParams(trajParams, chi2s);
         //create the track
         output->push_back(result);
-        btlMatchChi2.push_back(mBTL.hit ? mBTL.estChi2 : -1);
-        etlMatchChi2.push_back(mETL.hit ? mETL.estChi2 : -1);
-        btlMatchTimeChi2.push_back(mBTL.hit ? mBTL.timeChi2 : -1);
-        etlMatchTimeChi2.push_back(mETL.hit ? mETL.timeChi2 : -1);
+        btlMatchChi2.push_back(mBTL.hit ? mBTL.estChi2 : -1.f);
+        etlMatchChi2.push_back(mETL.hit ? mETL.estChi2 : -1.f);
+        btlMatchTimeChi2.push_back(mBTL.hit ? mBTL.timeChi2 : -1.f);
+        etlMatchTimeChi2.push_back(mETL.hit ? mETL.timeChi2 : -1.f);
         pathLengthMap = pathLength;
         tmtdMap = tmtd;
         sigmatmtdMap = sigmatmtd;
@@ -872,12 +872,12 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
     assocOrigTrkRaw.push_back(iMap);
 
     if (iMap == -1) {
-      btlMatchChi2.push_back(-1.);
-      etlMatchChi2.push_back(-1.);
-      btlMatchTimeChi2.push_back(-1.);
-      etlMatchTimeChi2.push_back(-1.);
-      npixBarrel.push_back(-1.);
-      npixEndcap.push_back(-1.);
+      btlMatchChi2.push_back(-1.f);
+      etlMatchChi2.push_back(-1.f);
+      btlMatchTimeChi2.push_back(-1.f);
+      etlMatchTimeChi2.push_back(-1.f);
+      npixBarrel.push_back(-1.f);
+      npixEndcap.push_back(-1.f);
     }
 
     ++itrack;
@@ -913,10 +913,10 @@ namespace {
                          const Trajectory& traj,
                          const DetLayer* layer,
                          const TrajectoryStateOnSurface& tsos,
-                         const double pmag2,
-                         const double pathlength0,
+                         const float pmag2,
+                         const float pathlength0,
                          const TrackSegments& trs0,
-                         const double vtxTime,
+                         const float vtxTime,
                          const reco::BeamSpot& bs,
                          const float bsTimeSpread,
                          const Propagator* prop,
@@ -936,12 +936,12 @@ namespace {
           if (pl.second == 0.)
             continue;
 
-          const double t_vtx = useVtxConstraint ? vtxTime : 0.;
+          const float t_vtx = useVtxConstraint ? vtxTime : 0.f;
 
-          constexpr double vtx_res = 0.008;
-          const double t_vtx_err = useVtxConstraint ? vtx_res : bsTimeSpread;
+          constexpr float vtx_res = 0.008f;
+          const float t_vtx_err = useVtxConstraint ? vtx_res : bsTimeSpread;
 
-          double lastpmag2 = trs0.getSegmentPathAndMom2(0).second;
+          float lastpmag2 = trs0.getSegmentPathAndMom2(0).second;
 
           for (auto detitr = range.first; detitr != range.second; ++detitr) {
             for (const auto& hit : *detitr) {
@@ -976,15 +976,15 @@ template <class TrackCollection>
 TransientTrackingRecHit::ConstRecHitContainer TrackExtenderWithMTDT<TrackCollection>::tryBTLLayers(
     const TrajectoryStateOnSurface& tsos,
     const Trajectory& traj,
-    const double pmag2,
-    const double pathlength0,
+    const float pmag2,
+    const float pathlength0,
     const TrackSegments& trs0,
     const MTDTrackingDetSetVector& hits,
     const MTDDetLayerGeometry* geo,
     const MagneticField* field,
     const Propagator* prop,
     const reco::BeamSpot& bs,
-    const double vtxTime,
+    const float vtxTime,
     const bool matchVertex,
     MTDHitMatchingInfo& bestHit) const {
   const vector<const DetLayer*>& layers = geo->allBTLLayers();
@@ -1000,15 +1000,15 @@ template <class TrackCollection>
 TransientTrackingRecHit::ConstRecHitContainer TrackExtenderWithMTDT<TrackCollection>::tryETLLayers(
     const TrajectoryStateOnSurface& tsos,
     const Trajectory& traj,
-    const double pmag2,
-    const double pathlength0,
+    const float pmag2,
+    const float pathlength0,
     const TrackSegments& trs0,
     const MTDTrackingDetSetVector& hits,
     const MTDDetLayerGeometry* geo,
     const MagneticField* field,
     const Propagator* prop,
     const reco::BeamSpot& bs,
-    const double vtxTime,
+    const float vtxTime,
     const bool matchVertex,
     MTDHitMatchingInfo& bestHit) const {
   const vector<const DetLayer*>& layers = geo->allETLLayers();
@@ -1017,7 +1017,7 @@ TransientTrackingRecHit::ConstRecHitContainer TrackExtenderWithMTDT<TrackCollect
   bestHit = MTDHitMatchingInfo();
   for (const DetLayer* ilay : layers) {
     const BoundDisk& disk = static_cast<const ForwardDetLayer*>(ilay)->specificSurface();
-    const double diskZ = disk.position().z();
+    const float diskZ = disk.position().z();
 
     if (tsos.globalPosition().z() * diskZ < 0)
       continue;  // only propagate to the disk that's on the same side
@@ -1039,13 +1039,13 @@ template <class TrackCollection>
 void TrackExtenderWithMTDT<TrackCollection>::fillMatchingHits(const DetLayer* ilay,
                                                               const TrajectoryStateOnSurface& tsos,
                                                               const Trajectory& traj,
-                                                              const double pmag2,
-                                                              const double pathlength0,
+                                                              const float pmag2,
+                                                              const float pathlength0,
                                                               const TrackSegments& trs0,
                                                               const MTDTrackingDetSetVector& hits,
                                                               const Propagator* prop,
                                                               const reco::BeamSpot& bs,
-                                                              const double& vtxTime,
+                                                              const float& vtxTime,
                                                               const bool matchVertex,
                                                               TransientTrackingRecHit::ConstRecHitContainer& output,
                                                               MTDHitMatchingInfo& bestHit) const {
@@ -1133,13 +1133,13 @@ reco::Track TrackExtenderWithMTDT<TrackCollection>::buildTrack(const reco::Track
 
   int ndof = traj.ndof();
 
-  double t0 = 0.;
-  double covt0t0 = -1.;
+  float t0 = 0.f;
+  float covt0t0 = -1.f;
   pathLengthOut = -1.f;  // if there is no MTD flag the pathlength with -1
   tmtdOut = 0.f;
   sigmatmtdOut = -1.f;
-  double betaOut = 0.;
-  double covbetabeta = -1.;
+  float betaOut = 0.f;
+  float covbetabeta = -1.f;
 
   auto routput = [&]() {
     return reco::Track(traj.chiSquared(),
@@ -1158,11 +1158,11 @@ reco::Track TrackExtenderWithMTDT<TrackCollection>::buildTrack(const reco::Track
 
   //compute path length for time backpropagation, using first MTD hit for the momentum
   if (hasMTD) {
-    double pathlength;
+    float pathlength;
     TrackSegments trs;
     bool validpropagation = trackPathLength(trajWithMtd, bs, thePropagator, pathlength, trs);
-    double thit = 0.;
-    double thiterror = -1.;
+    float thit = 0.f;
+    float thiterror = -1.f;
     bool validmtd = false;
 
     if (!validpropagation) {
@@ -1187,12 +1187,12 @@ reco::Track TrackExtenderWithMTDT<TrackCollection>::buildTrack(const reco::Track
       thiterror = mtdhit->timeError();
       validmtd = true;
     } else if (ihitcount == 2 && ietlcount == 2) {
-      std::pair<double, double> lastStep = trs.getSegmentPathAndMom2(0);
-      double etlpathlength = std::abs(lastStep.first * c_cm_ns);
+      std::pair<float, float> lastStep = trs.getSegmentPathAndMom2(0);
+      float etlpathlength = std::abs(lastStep.first * c_cm_ns);
       //
       // The information of the two ETL hits is combined and attributed to the innermost hit
       //
-      if (etlpathlength == 0.) {
+      if (etlpathlength == 0.f) {
         validpropagation = false;
       } else {
         pathlength -= etlpathlength;
@@ -1200,13 +1200,13 @@ reco::Track TrackExtenderWithMTDT<TrackCollection>::buildTrack(const reco::Track
         const MTDTrackingRecHit* mtdhit1 = static_cast<const MTDTrackingRecHit*>((*ihit1).recHit()->hit());
         const MTDTrackingRecHit* mtdhit2 = static_cast<const MTDTrackingRecHit*>((*(ihit1 + 1)).recHit()->hit());
         TrackTofPidInfo tofInfo = computeTrackTofPidInfo(
-            lastStep.second, etlpathlength, trs, mtdhit1->time(), mtdhit1->timeError(), 0., 0., true, TofCalc::kCost);
+            lastStep.second, etlpathlength, trs, mtdhit1->time(), mtdhit1->timeError(), 0.f, 0.f, true, TofCalc::kCost);
         //
         // Protect against incompatible times
         //
-        double err1 = tofInfo.dterror * tofInfo.dterror;
-        double err2 = mtdhit2->timeError() * mtdhit2->timeError();
-        if (cms_rounding::roundIfNear0(err1) == 0. || cms_rounding::roundIfNear0(err2) == 0.) {
+        float err1 = tofInfo.dterror * tofInfo.dterror;
+        float err2 = mtdhit2->timeError() * mtdhit2->timeError();
+        if (cms_rounding::roundIfNear0(err1) == 0.f || cms_rounding::roundIfNear0(err2) == 0.f) {
           edm::LogError("TrackExtenderWithMTD")
               << "MTD tracking hits with zero time uncertainty: " << err1 << " " << err2;
         } else {
@@ -1215,9 +1215,9 @@ reco::Track TrackExtenderWithMTDT<TrackCollection>::buildTrack(const reco::Track
             // Subtract the ETL time of flight from the outermost measurement, and combine it in a weighted average with the innermost
             // the mass ambiguity related uncertainty on the time of flight is added as an additional uncertainty
             //
-            err1 = 1. / err1;
-            err2 = 1. / err2;
-            thiterror = 1. / (err1 + err2);
+            err1 = 1.f / err1;
+            err2 = 1.f / err2;
+            thiterror = 1.f / (err1 + err2);
             thit = (tofInfo.dt * err1 + mtdhit2->time() * err2) * thiterror;
             thiterror = std::sqrt(thiterror);
             LogDebug("TrackExtenderWithMTD") << "p trk = " << p.mag() << " ETL hits times/errors: " << mtdhit1->time()
@@ -1236,7 +1236,7 @@ reco::Track TrackExtenderWithMTDT<TrackCollection>::buildTrack(const reco::Track
     if (validmtd && validpropagation) {
       //here add the PID uncertainty for later use in the 1st step of 4D vtx reconstruction
       TrackTofPidInfo tofInfo =
-          computeTrackTofPidInfo(p.mag2(), pathlength, trs, thit, thiterror, 0., 0., true, TofCalc::kSegm);
+          computeTrackTofPidInfo(p.mag2(), pathlength, trs, thit, thiterror, 0.f, 0.f, true, TofCalc::kSegm);
       pathLengthOut = pathlength;  // set path length if we've got a timing hit
       tmtdOut = thit;
       sigmatmtdOut = thiterror;

--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -108,7 +108,7 @@ namespace {
       return nSegment_;
     }
 
-    inline double computeTof(double mass_inv2) const {
+    inline float computeTof(double mass_inv2) const {
       float tof(0.f);
       for (uint32_t iSeg = 0; iSeg < nSegment_; iSeg++) {
         float gammasq = 1.f + segmentMom2_[iSeg] * static_cast<float>(mass_inv2);
@@ -119,7 +119,7 @@ namespace {
                                          << " tof = " << tof;
       }
 
-      return static_cast<double>(tof);
+      return tof;
     }
 
     inline uint32_t size() const { return nSegment_; }
@@ -133,12 +133,11 @@ namespace {
       return nSegment_;
     }
 
-    inline std::pair<double, double> getSegmentPathAndMom2(uint32_t iSegment) const {
+    inline std::pair<float, float> getSegmentPathAndMom2(uint32_t iSegment) const {
       if (iSegment >= nSegment_) {
         throw cms::Exception("TrackExtenderWithMTD") << "Requesting non existing track segment #" << iSegment;
       }
-      return std::make_pair(static_cast<double>(segmentPathOvc_[iSegment]),
-                            static_cast<double>(segmentMom2_[iSegment]));
+      return std::make_pair(segmentPathOvc_[iSegment], segmentMom2_[iSegment]);
     }
 
     uint32_t nSegment_ = 0;


### PR DESCRIPTION
#### PR description:

This PR proposes a revision of last stage of ```RecoMTD```, namely ```TrackExtenderWithMTD``` and ```TofPIDProducer``` to account for the fact that the particle speed along the trajectory is not constantly equal to the initial one, as assumed in the current code.

Effects are expected to be negligible for relativistic particles, but may induce O(several ps) biases for low momentum particles, depending on the mass used in the time back-propagation.

This PR adds three new ```ValueMap``` into the AOD event content, corresponding to the time of flight for three mass hypotheses (pion, kaon and proton) to be used by the ```TofPIDProducer```. 

The PR is based on the work documented in https://indico.cern.ch/event/1098101/contributions/4620485/attachments/2349416/4007038/MTDDPG_RECO_20211119.pdf

#### PR validation:

The code has been tested with both no PU and <PU>=200 samples (geometry scenario D77, 100 events).