### PR TITLE
get rid of CMS deprecation warnings in some `Cond*` packages

### DIFF
--- a/CondFormats/SiPixelObjects/test/SiPixelFedCablingMapTestWriter.cc
+++ b/CondFormats/SiPixelObjects/test/SiPixelFedCablingMapTestWriter.cc
@@ -3,7 +3,7 @@
 #include <sstream>
 
 // user include files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
@@ -22,7 +22,7 @@ using namespace std;
 using namespace edm;
 using namespace sipixelobjects;
 
-class SiPixelFedCablingMapTestWriter : public edm::EDAnalyzer {
+class SiPixelFedCablingMapTestWriter : public edm::one::EDAnalyzer<> {
 public:
   explicit SiPixelFedCablingMapTestWriter(const edm::ParameterSet&);
   ~SiPixelFedCablingMapTestWriter();

--- a/CondTools/BeamSpot/plugins/BeamSpotRcdPrinter.cc
+++ b/CondTools/BeamSpot/plugins/BeamSpotRcdPrinter.cc
@@ -1,5 +1,4 @@
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"

--- a/CondTools/SiStrip/plugins/SiStripDetVOffReader.cc
+++ b/CondTools/SiStrip/plugins/SiStripDetVOffReader.cc
@@ -6,7 +6,6 @@
 // user include files
 #include "CondFormats/DataRecord/interface/SiStripCondDataRecords.h"
 #include "CondFormats/SiStripObjects/interface/SiStripDetVOff.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"


### PR DESCRIPTION
#### PR description:

Title says it all.

#### PR validation:

`cmssw` compiles

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
