### PR TITLE
Trackster iteration filter for HGCAL electrons and photons

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterFromHGCalTrackster.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterFromHGCalTrackster.cc
@@ -82,7 +82,9 @@ void PFClusterFromHGCalTrackster::buildClusters(const edm::Handle<reco::PFRecHit
       }
     }
 
-    if (filterByTracksterIteration_ && std::find(filter_on_iterations_.begin(), filter_on_iterations_.end(), tst.ticlIteration()) == filter_on_iterations_.end()) {
+    if (filterByTracksterIteration_ &&
+        std::find(filter_on_iterations_.begin(), filter_on_iterations_.end(), tst.ticlIteration()) ==
+            filter_on_iterations_.end()) {
       continue;
     }
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterFromHGCalTrackster.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterFromHGCalTrackster.cc
@@ -10,8 +10,10 @@ public:
   PFClusterFromHGCalTrackster(const edm::ParameterSet& conf, edm::ConsumesCollector& cc)
       : InitialClusteringStepBase(conf, cc) {
     filterByTracksterPID_ = conf.getParameter<bool>("filterByTracksterPID");
+    filterByTracksterIteration_ = conf.getParameter<bool>("filterByTracksterIteration");
     pid_threshold_ = conf.getParameter<double>("pid_threshold");
     filter_on_categories_ = conf.getParameter<std::vector<int> >("filter_on_categories");
+    filter_on_iterations_ = conf.getParameter<std::vector<int> >("filter_on_iterations");
 
     tracksterToken_ = cc.consumes<std::vector<ticl::Trackster> >(conf.getParameter<edm::InputTag>("tracksterSrc"));
     clusterToken_ = cc.consumes<reco::CaloClusterCollection>(conf.getParameter<edm::InputTag>("clusterSrc"));
@@ -30,8 +32,10 @@ public:
 
 private:
   bool filterByTracksterPID_;
+  bool filterByTracksterIteration_;
   float pid_threshold_;
   std::vector<int> filter_on_categories_;
+  std::vector<int> filter_on_iterations_;
 
   edm::EDGetTokenT<std::vector<ticl::Trackster> > tracksterToken_;
   edm::Handle<std::vector<ticl::Trackster> > trackstersH_;
@@ -76,6 +80,10 @@ void PFClusterFromHGCalTrackster::buildClusters(const edm::Handle<reco::PFRecHit
       if (probTotal < pid_threshold_) {
         continue;
       }
+    }
+
+    if (filterByTracksterIteration_ && std::find(filter_on_iterations_.begin(), filter_on_iterations_.end(), tst.ticlIteration()) == filter_on_iterations_.end()) {
+      continue;
     }
 
     DetId seed;

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHGC_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHGC_cfi.py
@@ -53,7 +53,7 @@ _hgcalTracksterMapper_HGCal = cms.PSet(
     filterByTracksterPID = cms.bool(False),
     pid_threshold = cms.double(0.8),
     filter_on_categories = cms.vint32([0, 1]),
-    filterByTracksterIteration = cms.bool(False),
+    filterByTracksterIteration = cms.bool(True),
     filter_on_iterations = cms.vint32([0, 1]),
 )
 

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHGC_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHGC_cfi.py
@@ -53,6 +53,8 @@ _hgcalTracksterMapper_HGCal = cms.PSet(
     filterByTracksterPID = cms.bool(False),
     pid_threshold = cms.double(0.8),
     filter_on_categories = cms.vint32([0, 1]),
+    filterByTracksterIteration = cms.bool(False),
+    filter_on_iterations = cms.vint32([0, 1]),
 )
 
 particleFlowClusterHGCal = cms.EDProducer(


### PR DESCRIPTION
#### PR description:

This PR includes the following:
  * Option to filter the tracksters using their iterations [1] in `RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHGC_cfi.py`.
  * Apply a default selection for the above filter such that only the `TRKEM` and `EM` iterations are selected.

The effects of this filter can be found in [2]. To summarize:
 * Electron/photon energy resolution improves.
 * Reconstruction:
   * Electron reconstruction efficiency decreases by a few percent at low pT.
   * Photon reconstruction efficiency decreases overall (being studied).
   * Electron/photon mis-reconstruction rate decreases significantly -- so there's an overall gain in terms of reconstruction to mis-reconstruction efficiencies.

It'll be good to test with profiling enabled -- we should see some timing gains because of the reduction in mis-reconstructed electrons/photons.

[1] https://cmsdoxygen.web.cern.ch/cmsdoxygen/CMSSW_12_2_0_pre2/doc/html/d5/de3/classticl_1_1Trackster.html#ab8b9ce1d52b6b6f74dfbbce754079398

[2] https://indico.cern.ch/event/1095370/contributions/4622717/attachments/2349624/4007590/presentation_test_tracksterIterationFilter_EgammaReco_2021-11-19.pdf

Tagging the egamma validators @archiron and @beaudett.