### PR TITLE
update naming of output file of `testAlCaHarvesting` to avoid concurrency issues

### DIFF
--- a/Calibration/TkAlCaRecoProducers/test/parseFwkJobReport.py
+++ b/Calibration/TkAlCaRecoProducers/test/parseFwkJobReport.py
@@ -9,7 +9,8 @@ TARGET_LIST_OF_TAGS=['BeamSpotObject_ByLumi', 'BeamSpotObject_ByRun', 'BeamSpotO
 TARGET_DQM_FILES=1
 TARGET_DQM_FILENAME='./DQM_V0001_R000325022__Express__PCLTest__ALCAPROMPT.root'
 TARGET_DB_FILES=12
-TARGET_DB_FILENAME='sqlite_file:promptCalibConditions.db'
+TARGET_DB_FILENAME='sqlite_file:testPCLAlCaHarvesting.db'
+TARGET_XML_FILENAME='testPCLAlCaHarvesting.xml'
 TOTAL_TARGET_FILES=TARGET_DQM_FILES+TARGET_DB_FILES
 
 #_____________________________________________________
@@ -67,13 +68,13 @@ def parseXML(xmlfile):
 #_____________________________________________________
 def main():
     try:
-        f = open("FrameworkJobReport.xml")
+        f = open(TARGET_XML_FILENAME)
     except IOError:
-        print("FrameworkJobReport.xml is not accessible")
+        print("%s is not accessible" % TARGET_XML_FILENAME)
         sys.exit(1)
 
     # parse xml file
-    result = parseXML('FrameworkJobReport.xml')
+    result = parseXML(TARGET_XML_FILENAME)
     if(result==0):
         print("All is fine with the world!")
         sys.exit(0)

--- a/Calibration/TkAlCaRecoProducers/test/testAlCaHarvesting.sh
+++ b/Calibration/TkAlCaRecoProducers/test/testAlCaHarvesting.sh
@@ -5,10 +5,11 @@ function cleanTheHouse {
     rm -fr millepede.*
     rm -fr pede*
     rm -fr treeFile.root
+    rm -fr testPCLAlCaHarvesting.db
 }
 
 echo "TESTING Calibration/TkAlCaRecoProducers ..."
-cmsRun -e ${LOCAL_TEST_DIR}/testPCLAlCaHarvesting.py || die "Failure running testPCLAlCaHarvesting.py" $? 
+cmsRun -e -j testPCLAlCaHarvesting.xml ${LOCAL_TEST_DIR}/testPCLAlCaHarvesting.py || die "Failure running testPCLAlCaHarvesting.py" $?
 cleanTheHouse
 echo "PARSING Framework Job Report ..."
 python ${LOCAL_TEST_DIR}/parseFwkJobReport.py

--- a/Calibration/TkAlCaRecoProducers/test/testPCLAlCaHarvesting.py
+++ b/Calibration/TkAlCaRecoProducers/test/testPCLAlCaHarvesting.py
@@ -89,6 +89,11 @@ process.PoolDBOutputService.toPut.append(process.ALCAHARVESTBeamSpotHPByRun_dbOu
 process.PoolDBOutputService.toPut.append(process.ALCAHARVESTBeamSpotHPByLumi_dbOutput)
 
 ##
+## change the output sqlite file in order to avoid concurrent writing from other unit tests
+##
+process.PoolDBOutputService.connect = cms.string('sqlite_file:testPCLAlCaHarvesting.db')
+
+##
 ## Define the file metadatas
 ##
 process.pclMetadataWriter.recordsToMap.append(process.ALCAHARVESTSiStripQuality_metadata)


### PR DESCRIPTION
#### PR description:

Resolves https://github.com/cms-sw/cmssw/issues/36175 by changing the names output `sqlite` and `xml` (`FrameworkJobReport.xml`) files, since those could be used by other cmssw unit tests. 
`scram` starts all the tests from the top level cmssw dev directory and some tests create sub-directories but most unit tests just create file in cmssw top level dir.
See https://github.com/cms-sw/cmssw/issues/36175#issuecomment-975710398 and https://github.com/cms-sw/cmssw/issues/36175#issuecomment-975772532.

#### PR validation:

Unit tests run successfully

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
