### PR TITLE
Using SOI+1 energy from MAHI as auxEnergy when M3 is not run

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h
@@ -115,13 +115,14 @@ public:
 
   void phase1Apply(const HBHEChannelInfo& channelData,
                    float& reconstructedEnergy,
+                   float& soiPlusOneEnergy,
                    float& reconstructedTime,
                    bool& useTriple,
                    float& chi2) const;
 
   void phase1Debug(const HBHEChannelInfo& channelData, MahiDebugInfo& mdi) const;
 
-  void doFit(std::array<float, 3>& correctedOutput, const int nbx) const;
+  void doFit(std::array<float, 4>& correctedOutput, const int nbx) const;
 
   void setPulseShapeTemplate(int pulseShapeId,
                              const HcalPulseShapes& ps,

--- a/RecoLocalCalo/HcalRecAlgos/src/SimpleHBHEPhase1Algo.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/SimpleHBHEPhase1Algo.cc
@@ -98,7 +98,7 @@ HBHERecHit SimpleHBHEPhase1Algo::reconstruct(const HBHEChannelInfo& info,
   }
 
   // Run Mahi
-  float m4E = 0.f, m4chi2 = -1.f;
+  float m4E = 0.f, m4ESOIPlusOne = 0.f, m4chi2 = -1.f;
   float m4T = 0.f;
   bool m4UseTriple = false;
 
@@ -107,8 +107,9 @@ HBHERecHit SimpleHBHEPhase1Algo::reconstruct(const HBHEChannelInfo& info,
   if (mahi) {
     mahiOOTpuCorr_->setPulseShapeTemplate(
         info.recoShape(), theHcalPulseShapes_, info.hasTimeInfo(), hcalTimeSlew_delay_, info.nSamples());
-    mahi->phase1Apply(info, m4E, m4T, m4UseTriple, m4chi2);
+    mahi->phase1Apply(info, m4E, m4ESOIPlusOne, m4T, m4UseTriple, m4chi2);
     m4E *= hbminusCorrectionFactor(channelId, m4E, isData);
+    m4ESOIPlusOne *= hbminusCorrectionFactor(channelId, m4ESOIPlusOne, isData);
   }
 
   // Finally, construct the rechit
@@ -134,7 +135,11 @@ HBHERecHit SimpleHBHEPhase1Algo::reconstruct(const HBHEChannelInfo& info,
     tdcTime += timeShift_;
   rh = HBHERecHit(channelId, rhE, rht, tdcTime);
   rh.setRawEnergy(m0E);
-  rh.setAuxEnergy(m3E);
+  if (method3) {
+    rh.setAuxEnergy(m3E);
+  } else {
+    rh.setAuxEnergy(m4ESOIPlusOne);
+  }
   rh.setChiSquared(rhX);
 
   // Set rechit aux words


### PR DESCRIPTION
#### PR description:
Adding SOI+1 energy from MAHI to HBHERecHit as auxEnergy when "Method 3" is not run. No changes expected in the output when "Method 3" is run. When it is not run, the "eaux()" method of the rechit will return a meaningful number instead of just 0.

A few minor changes were also made, streamlining MAHI code.

This change enables subsequent studies of SOI+1 energy for reconstructing long-lived particles.

#### PR validation:
The usual "runTheMatrix.py" tests were run.
