### PR TITLE
add protection for missing products in `DQM/SiPixelPhase1Heterogeneous`

### DIFF
--- a/DQM/SiPixelPhase1Heterogeneous/plugins/SiPixelPhase1MonitorTrackSoA.cc
+++ b/DQM/SiPixelPhase1Heterogeneous/plugins/SiPixelPhase1MonitorTrackSoA.cc
@@ -26,7 +26,7 @@
 class SiPixelPhase1MonitorTrackSoA : public DQMEDAnalyzer {
 public:
   explicit SiPixelPhase1MonitorTrackSoA(const edm::ParameterSet&);
-  ~SiPixelPhase1MonitorTrackSoA() override;
+  ~SiPixelPhase1MonitorTrackSoA() override = default;
   void bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun, edm::EventSetup const& iSetup) override;
   void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
@@ -57,15 +57,17 @@ SiPixelPhase1MonitorTrackSoA::SiPixelPhase1MonitorTrackSoA(const edm::ParameterS
   minQuality_ = pixelTrack::qualityByName(iConfig.getParameter<std::string>("minQuality"));
 }
 
-SiPixelPhase1MonitorTrackSoA::~SiPixelPhase1MonitorTrackSoA() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
-}
-
+//
 // -- Analyze
 //
 void SiPixelPhase1MonitorTrackSoA::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  auto const& tsoa = *iEvent.get(tokenSoATrack_);
+  const auto& tsoaHandle = iEvent.getHandle(tokenSoATrack_);
+  if (!tsoaHandle.isValid()) {
+    edm::LogWarning("SiPixelPhase1MonitorTrackSoA") << "No Track SoA found \n returning!" << std::endl;
+    return;
+  }
+
+  auto const& tsoa = *((tsoaHandle.product())->get());
   auto maxTracks = tsoa.stride();
   auto const* quality = tsoa.qualityData();
   int32_t nTracks = 0;

--- a/DQM/SiPixelPhase1Heterogeneous/plugins/SiPixelPhase1MonitorVertexSoA.cc
+++ b/DQM/SiPixelPhase1Heterogeneous/plugins/SiPixelPhase1MonitorVertexSoA.cc
@@ -28,7 +28,7 @@ class SiPixelPhase1MonitorVertexSoA : public DQMEDAnalyzer {
 public:
   using IndToEdm = std::vector<uint16_t>;
   explicit SiPixelPhase1MonitorVertexSoA(const edm::ParameterSet&);
-  ~SiPixelPhase1MonitorVertexSoA() override;
+  ~SiPixelPhase1MonitorVertexSoA() override = default;
   void bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun, edm::EventSetup const& iSetup) override;
   void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
@@ -57,15 +57,17 @@ SiPixelPhase1MonitorVertexSoA::SiPixelPhase1MonitorVertexSoA(const edm::Paramete
   topFolderName_ = iConfig.getParameter<std::string>("TopFolderName");
 }
 
-SiPixelPhase1MonitorVertexSoA::~SiPixelPhase1MonitorVertexSoA() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
-}
-
+//
 // -- Analyze
 //
 void SiPixelPhase1MonitorVertexSoA::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  auto const& vsoa = *(iEvent.get(tokenSoAVertex_).get());
+  const auto& vsoaHandle = iEvent.getHandle(tokenSoAVertex_);
+  if (!vsoaHandle.isValid()) {
+    edm::LogWarning("SiPixelPhase1MonitorTrackSoA") << "No Vertex SoA found \n returning!" << std::endl;
+    return;
+  }
+
+  auto const& vsoa = *((vsoaHandle.product())->get());
   int nVertices = vsoa.nvFinal;
   auto bsHandle = iEvent.getHandle(tokenBeamSpot_);
   float x0 = 0., y0 = 0., z0 = 0., dxdz = 0., dydz = 0.;


### PR DESCRIPTION
#### PR description:

Add protections against missing event products in  `DQM/SiPixelPhase1Heterogeneous`.
Attempt to resolve https://github.com/cms-sw/cmssw/issues/36207.
Profited to make destructors `default`.

#### PR validation:

```console
runTheMatrix.py -l 136.8855,136.8885
...
136.8855_RunHLTPhy2018D+RunHLTPhy2018D+HLTDR2_2018+RECODR2_2018reHLT_Prompt_pixelTrackingOnly+HARVEST2018_pixelTrackingOnly Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Mon Nov 22 22:51:18 2021-date Mon Nov 22 22:44:06 2021; exit: 0 0 0 0
136.8885_RunJetHT2018D+RunJetHT2018D+HLTDR2_2018+RECODR2_2018reHLT_Prompt_pixelTrackingOnly+HARVEST2018_pixelTrackingOnly Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Mon Nov 22 22:48:35 2021-date Mon Nov 22 22:44:07 2021; exit: 0 0 0 0
2 2 2 2 tests passed, 0 0 0 0 failed	
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
