### PR TITLE
Fully implement fishbone in patatrack

### DIFF
--- a/CUDADataFormats/Track/interface/TrackSoAHeterogeneousT.h
+++ b/CUDADataFormats/Track/interface/TrackSoAHeterogeneousT.h
@@ -43,13 +43,11 @@ public:
   // this is chi2/ndof as not necessarely all hits are used in the fit
   eigenSoA::ScalarSoA<float, S> chi2;
 
+  eigenSoA::ScalarSoA<int8_t, S> nLayers;
+
   constexpr int nHits(int i) const { return detIndices.size(i); }
 
-  // we may store it if faster...
-  constexpr int nLayers(int i) const { return computeNumberOfLayers(i); }
-
-  // or store this one
-  constexpr bool isTriplet(int i) const { return nHits(i) == 3 || nLayers(i) == 3; }
+  constexpr bool isTriplet(int i) const { return nLayers(i) == 3; }
 
   constexpr int computeNumberOfLayers(int32_t i) const {
     // layers are in order and we assume tracks are either forward or backward

--- a/CUDADataFormats/Track/interface/TrackSoAHeterogeneousT.h
+++ b/CUDADataFormats/Track/interface/TrackSoAHeterogeneousT.h
@@ -55,9 +55,9 @@ public:
     // layers are in order and we assume tracks are either forward or backward
     auto pdet = detIndices.begin(i);
     int nl = 1;
-    auto ol = phase1PixelTopology::findLayer(*pdet);
+    auto ol = phase1PixelTopology::getLayer(*pdet);
     for (; pdet < detIndices.end(i); ++pdet) {
-      auto il = phase1PixelTopology::findLayer(*pdet, ol);
+      auto il = phase1PixelTopology::getLayer(*pdet); // , ol);
       if (il != ol)
         ++nl;
       ol = il;

--- a/CUDADataFormats/Track/interface/TrackSoAHeterogeneousT.h
+++ b/CUDADataFormats/Track/interface/TrackSoAHeterogeneousT.h
@@ -5,9 +5,11 @@
 #include <algorithm>
 
 #include "CUDADataFormats/Track/interface/TrajectoryStateSoAT.h"
+#include "Geometry/TrackerGeometryBuilder/interface/phase1PixelTopology.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/HistoContainer.h"
 
 #include "CUDADataFormats/Common/interface/HeterogeneousSoA.h"
+
 
 namespace pixelTrack {
   enum class Quality : uint8_t { bad = 0, edup, dup, loose, strict, tight, highPurity, notQuality };
@@ -42,7 +44,30 @@ public:
   // this is chi2/ndof as not necessarely all hits are used in the fit
   eigenSoA::ScalarSoA<float, S> chi2;
 
+
   constexpr int nHits(int i) const { return detIndices.size(i); }
+
+  // we may store it if faster...
+  constexpr int nLayers(int i) const { return computeNumberOfLayers(i); }
+
+  // or store this one
+  constexpr bool isTriplet(int i) const { return nHits(i) ==3 || nLayers(i)==3; }
+
+  constexpr int computeNumberOfLayers(int32_t i) const {
+    // layers are in order and we assume tracks are either forward or backward
+    auto  pdet=detIndices.begin(i);
+    int nl=1;
+    auto ol = phase1PixelTopology::findLayer(*pdet);
+    for (;pdet<detIndices.end(i); ++pdet) {
+      auto il = phase1PixelTopology::findLayer(*pdet,ol);
+      if (il!=ol) ++nl;
+      ol=il;
+    }
+    assert(nl>=3);
+    return nl;
+  }
+  
+
 
   // State at the Beam spot
   // phi,tip,1/pt,cotan(theta),zip

--- a/CUDADataFormats/Track/interface/TrackSoAHeterogeneousT.h
+++ b/CUDADataFormats/Track/interface/TrackSoAHeterogeneousT.h
@@ -55,7 +55,7 @@ public:
     int nl = 1;
     auto ol = phase1PixelTopology::getLayer(*pdet);
     for (; pdet < detIndices.end(i); ++pdet) {
-      auto il = phase1PixelTopology::getLayer(*pdet);  // , ol);
+      auto il = phase1PixelTopology::getLayer(*pdet);
       if (il != ol)
         ++nl;
       ol = il;

--- a/CUDADataFormats/Track/interface/TrackSoAHeterogeneousT.h
+++ b/CUDADataFormats/Track/interface/TrackSoAHeterogeneousT.h
@@ -57,7 +57,7 @@ public:
     int nl = 1;
     auto ol = phase1PixelTopology::getLayer(*pdet);
     for (; pdet < detIndices.end(i); ++pdet) {
-      auto il = phase1PixelTopology::getLayer(*pdet); // , ol);
+      auto il = phase1PixelTopology::getLayer(*pdet);  // , ol);
       if (il != ol)
         ++nl;
       ol = il;

--- a/CUDADataFormats/Track/interface/TrackSoAHeterogeneousT.h
+++ b/CUDADataFormats/Track/interface/TrackSoAHeterogeneousT.h
@@ -10,7 +10,6 @@
 
 #include "CUDADataFormats/Common/interface/HeterogeneousSoA.h"
 
-
 namespace pixelTrack {
   enum class Quality : uint8_t { bad = 0, edup, dup, loose, strict, tight, highPurity, notQuality };
   constexpr uint32_t qualitySize{uint8_t(Quality::notQuality)};
@@ -44,30 +43,28 @@ public:
   // this is chi2/ndof as not necessarely all hits are used in the fit
   eigenSoA::ScalarSoA<float, S> chi2;
 
-
   constexpr int nHits(int i) const { return detIndices.size(i); }
 
   // we may store it if faster...
   constexpr int nLayers(int i) const { return computeNumberOfLayers(i); }
 
   // or store this one
-  constexpr bool isTriplet(int i) const { return nHits(i) ==3 || nLayers(i)==3; }
+  constexpr bool isTriplet(int i) const { return nHits(i) == 3 || nLayers(i) == 3; }
 
   constexpr int computeNumberOfLayers(int32_t i) const {
     // layers are in order and we assume tracks are either forward or backward
-    auto  pdet=detIndices.begin(i);
-    int nl=1;
+    auto pdet = detIndices.begin(i);
+    int nl = 1;
     auto ol = phase1PixelTopology::findLayer(*pdet);
-    for (;pdet<detIndices.end(i); ++pdet) {
-      auto il = phase1PixelTopology::findLayer(*pdet,ol);
-      if (il!=ol) ++nl;
-      ol=il;
+    for (; pdet < detIndices.end(i); ++pdet) {
+      auto il = phase1PixelTopology::findLayer(*pdet, ol);
+      if (il != ol)
+        ++nl;
+      ol = il;
     }
-    assert(nl>=3);
+    assert(nl >= 3);
     return nl;
   }
-  
-
 
   // State at the Beam spot
   // phi,tip,1/pt,cotan(theta),zip

--- a/CUDADataFormats/Track/interface/TrackSoAHeterogeneousT.h
+++ b/CUDADataFormats/Track/interface/TrackSoAHeterogeneousT.h
@@ -60,7 +60,6 @@ public:
         ++nl;
       ol = il;
     }
-    assert(nl >= 3);
     return nl;
   }
 

--- a/DataFormats/Math/interface/choleskyInversion.h
+++ b/DataFormats/Math/interface/choleskyInversion.h
@@ -337,10 +337,9 @@ namespace math {
 
     // Eigen interface
     template <typename M1, typename M2>
-    inline constexpr  void __attribute__((always_inline))
-    invert(M1 const& src, M2& dst) {
-      if constexpr (M2::ColsAtCompileTime < 200)   // should be 7 but 
-         Inverter<M1, M2, M2::ColsAtCompileTime>::eval(src, dst);
+    inline constexpr void __attribute__((always_inline)) invert(M1 const& src, M2& dst) {
+      if constexpr (M2::ColsAtCompileTime < 200)  // should be 7 but
+        Inverter<M1, M2, M2::ColsAtCompileTime>::eval(src, dst);
       else
         dst = src.llt().solve(M1::Identity());  // ... this crashes on GPU
     }

--- a/DataFormats/Math/interface/choleskyInversion.h
+++ b/DataFormats/Math/interface/choleskyInversion.h
@@ -24,7 +24,6 @@ namespace math {
       for (int i = 0; i < N; ++i) {
         a[i][i] = src(i, i);
         for (int j = i + 1; j < N; ++j)
-          // a[i][j] =
           a[j][i] = src(i, j);
       }
 

--- a/DataFormats/Math/interface/choleskyInversion.h
+++ b/DataFormats/Math/interface/choleskyInversion.h
@@ -336,12 +336,13 @@ namespace math {
     };
 
     // Eigen interface
-    template <typename D1, typename D2>
-    inline constexpr void __attribute__((always_inline))
-    invert(Eigen::DenseBase<D1> const& src, Eigen::DenseBase<D2>& dst) {
-      using M1 = Eigen::DenseBase<D1>;
-      using M2 = Eigen::DenseBase<D2>;
-      Inverter<M1, M2, M2::ColsAtCompileTime>::eval(src, dst);
+    template <typename M1, typename M2>
+    inline constexpr  void __attribute__((always_inline))
+    invert(M1 const& src, M2& dst) {
+      if constexpr (M2::ColsAtCompileTime < 200)   // should be 7 but 
+         Inverter<M1, M2, M2::ColsAtCompileTime>::eval(src, dst);
+      else
+        dst = src.llt().solve(M1::Identity());  // ... this crashes on GPU
     }
 
   }  // namespace cholesky

--- a/DataFormats/Math/test/BuildFile.xml
+++ b/DataFormats/Math/test/BuildFile.xml
@@ -127,4 +127,10 @@
     <flags CUDA_FLAGS="-w"/>
   </bin>
 
+  <bin file="simpleCholeskyTest.cu">
+    <use name="cuda"/>
+    <use name="HeterogeneousCore/CUDAUtilities"/>
+    <flags CUDA_FLAGS="-w"/>
+  </bin>
+
 </iftool>

--- a/DataFormats/Math/test/CholeskyInvert_t.cpp
+++ b/DataFormats/Math/test/CholeskyInvert_t.cpp
@@ -138,6 +138,7 @@ int main() {
   go<5>(true);
   go<6>(true);
 
-  // go<10>();
+  go<10>(false);
+  go<10>(true);
   return 0;
 }

--- a/DataFormats/Math/test/CholeskyInvert_t.cu
+++ b/DataFormats/Math/test/CholeskyInvert_t.cu
@@ -198,14 +198,15 @@ int main() {
   go<4>(false);
   go<5>(false);
   go<6>(false);
+  go<7>(false);
+  go<10>(false);
 
   go<2>(true);
   go<3>(true);
   go<4>(true);
   go<5>(true);
   go<6>(true);
-
-  go<10>(false);
+  go<7>(true);
   go<10>(true);
   return 0;
 }

--- a/DataFormats/Math/test/CholeskyInvert_t.cu
+++ b/DataFormats/Math/test/CholeskyInvert_t.cu
@@ -85,7 +85,8 @@ template <int N>
 void go(bool soa) {
   constexpr unsigned int DIM = N;
   using MX = MXN<DIM>;
-  std::cout << "testing Matrix of dimension " << DIM << " size " << sizeof(MX) << " in " << (soa ? "SOA" : "AOS") << " mode" << std::endl;
+  std::cout << "testing Matrix of dimension " << DIM << " size " << sizeof(MX) << " in " << (soa ? "SOA" : "AOS")
+            << " mode" << std::endl;
 
   auto start = std::chrono::high_resolution_clock::now();
   auto delta = start - start;

--- a/DataFormats/Math/test/CholeskyInvert_t.cu
+++ b/DataFormats/Math/test/CholeskyInvert_t.cu
@@ -85,7 +85,7 @@ template <int N>
 void go(bool soa) {
   constexpr unsigned int DIM = N;
   using MX = MXN<DIM>;
-  std::cout << "testing Matrix of dimension " << DIM << " size " << sizeof(MX) << std::endl;
+  std::cout << "testing Matrix of dimension " << DIM << " size " << sizeof(MX) << " in " << (soa ? "SOA" : "AOS") << " mode" << std::endl;
 
   auto start = std::chrono::high_resolution_clock::now();
   auto delta = start - start;
@@ -204,6 +204,7 @@ int main() {
   go<5>(true);
   go<6>(true);
 
-  // go<10>();
+  go<10>(false);
+  go<10>(true);
   return 0;
 }

--- a/DataFormats/Math/test/simpleCholeskyTest.cu
+++ b/DataFormats/Math/test/simpleCholeskyTest.cu
@@ -1,0 +1,103 @@
+#include "DataFormats/Math/interface/choleskyInversion.h"
+
+using namespace math::cholesky;
+
+#include <Eigen/Core>
+#include <Eigen/Eigenvalues>
+
+#include <iomanip>
+#include <memory>
+#include <algorithm>
+#include <chrono>
+#include <random>
+
+#include <cassert>
+#include <iostream>
+#include <limits>
+
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireDevices.h"
+
+template <typename M, int N>
+__global__ void invert(M* mm, int n) {
+  auto i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i >= n)
+    return;
+
+  auto& m = mm[i];
+
+  printf("before %d %f %f %f\n", N, m(0, 0), m(1, 0), m(1, 1));
+
+  invertNN(m, m);
+
+  printf("after %d %f %f %f\n", N, m(0, 0), m(1, 0), m(1, 1));
+}
+
+template <typename M, int N>
+__global__ void invertE(M* mm, int n) {
+  auto i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i >= n)
+    return;
+
+  auto& m = mm[i];
+
+  printf("before %d %f %f %f\n", N, m(0, 0), m(1, 0), m(1, 1));
+
+  m = m.inverse();
+
+  printf("after %d %f %f %f\n", N, m(0, 0), m(1, 0), m(1, 1));
+}
+
+// generate matrices
+template <class M>
+void genMatrix(M& m) {
+  using T = typename std::remove_reference<decltype(m(0, 0))>::type;
+  int n = M::ColsAtCompileTime;
+  std::mt19937 eng;
+  // std::mt19937 eng2;
+  std::uniform_real_distribution<T> rgen(0., 1.);
+
+  // generate first diagonal elemets
+  for (int i = 0; i < n; ++i) {
+    double maxVal = i * 10000 / (n - 1) + 1;  // max condition is 10^4
+    m(i, i) = maxVal * rgen(eng);
+  }
+  for (int i = 0; i < n; ++i) {
+    for (int j = 0; j < i; ++j) {
+      double v = 0.3 * std::sqrt(m(i, i) * m(j, j));  // this makes the matrix pos defined
+      m(i, j) = v * rgen(eng);
+      m(j, i) = m(i, j);
+    }
+  }
+}
+
+template <int DIM>
+using MXN = Eigen::Matrix<double, DIM, DIM>;
+
+int main() {
+  cms::cudatest::requireDevices();
+
+  constexpr int DIM = 6;
+
+  using M = MXN<DIM>;
+
+  M m;
+
+  genMatrix(m);
+
+  printf("on CPU before %d %f %f %f\n", DIM, m(0, 0), m(1, 0), m(1, 1));
+
+  invertNN(m, m);
+
+  printf("on CPU after %d %f %f %f\n", DIM, m(0, 0), m(1, 0), m(1, 1));
+
+  double* d;
+  cudaMalloc(&d, sizeof(M));
+  cudaMemcpy(d, &m, sizeof(M), cudaMemcpyHostToDevice);
+  invert<M, DIM><<<1, 1>>>((M*)d, 1);
+  cudaCheck(cudaDeviceSynchronize());
+  invertE<M, DIM><<<1, 1>>>((M*)d, 1);
+  cudaCheck(cudaDeviceSynchronize());
+
+  return 0;
+}

--- a/Geometry/TrackerGeometryBuilder/interface/phase1PixelTopology.h
+++ b/Geometry/TrackerGeometryBuilder/interface/phase1PixelTopology.h
@@ -3,7 +3,6 @@
 
 #include <cstdint>
 #include <array>
-// #include "HeterogeneousCore/CUDAUtilities/interface/cudaCompat.h"
 
 namespace phase1PixelTopology {
 

--- a/Geometry/TrackerGeometryBuilder/interface/phase1PixelTopology.h
+++ b/Geometry/TrackerGeometryBuilder/interface/phase1PixelTopology.h
@@ -31,17 +31,17 @@ namespace phase1PixelTopology {
 #ifdef __CUDA_ARCH__
   __device__
 #endif
-  constexpr uint32_t layerStart[numberOfLayers + 1] = {0,
-                                                       96,
-                                                       320,
-                                                       672,  // barrel
-                                                       1184,
-                                                       1296,
-                                                       1408,  // positive endcap
-                                                       1520,
-                                                       1632,
-                                                       1744,  // negative endcap
-                                                       numberOfModules};
+      constexpr uint32_t layerStart[numberOfLayers + 1] = {0,
+                                                           96,
+                                                           320,
+                                                           672,  // barrel
+                                                           1184,
+                                                           1296,
+                                                           1408,  // positive endcap
+                                                           1520,
+                                                           1632,
+                                                           1744,  // negative endcap
+                                                           numberOfModules};
   constexpr char const* layerName[numberOfLayers] = {
       "BL1",
       "BL2",
@@ -88,7 +88,7 @@ namespace phase1PixelTopology {
 
   constexpr uint32_t maxModuleStride = findMaxModuleStride();
 
-  constexpr uint8_t findLayer(uint32_t detId, uint8_t sl=0) {
+  constexpr uint8_t findLayer(uint32_t detId, uint8_t sl = 0) {
     for (uint8_t i = sl; i < std::size(layerStart); ++i)
       if (detId < layerStart[i + 1])
         return i;
@@ -107,10 +107,12 @@ namespace phase1PixelTopology {
 #ifdef __CUDA_ARCH__
   __device__
 #endif
-  constexpr std::array<uint8_t, layerIndexSize> layer = map_to_array<layerIndexSize>(findLayerFromCompact);
+      constexpr std::array<uint8_t, layerIndexSize>
+          layer = map_to_array<layerIndexSize>(findLayerFromCompact);
 
-  constexpr uint8_t getLayer(uint32_t detId) { return phase1PixelTopology::layer[detId / phase1PixelTopology::maxModuleStride];}
-
+  constexpr uint8_t getLayer(uint32_t detId) {
+    return phase1PixelTopology::layer[detId / phase1PixelTopology::maxModuleStride];
+  }
 
   constexpr bool validateLayerIndex() {
     bool res = true;

--- a/Geometry/TrackerGeometryBuilder/interface/phase1PixelTopology.h
+++ b/Geometry/TrackerGeometryBuilder/interface/phase1PixelTopology.h
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 #include <array>
+// #include "HeterogeneousCore/CUDAUtilities/interface/cudaCompat.h"
 
 namespace phase1PixelTopology {
 
@@ -27,6 +28,9 @@ namespace phase1PixelTopology {
 
   constexpr uint32_t numberOfModules = 1856;
   constexpr uint32_t numberOfLayers = 10;
+#ifdef __CUDA_ARCH__
+  __device__
+#endif
   constexpr uint32_t layerStart[numberOfLayers + 1] = {0,
                                                        96,
                                                        320,
@@ -84,8 +88,8 @@ namespace phase1PixelTopology {
 
   constexpr uint32_t maxModuleStride = findMaxModuleStride();
 
-  constexpr uint8_t findLayer(uint32_t detId) {
-    for (uint8_t i = 0; i < std::size(layerStart); ++i)
+  constexpr uint8_t findLayer(uint32_t detId, uint8_t sl=0) {
+    for (uint8_t i = sl; i < std::size(layerStart); ++i)
       if (detId < layerStart[i + 1])
         return i;
     return std::size(layerStart);
@@ -100,7 +104,13 @@ namespace phase1PixelTopology {
   }
 
   constexpr uint32_t layerIndexSize = numberOfModules / maxModuleStride;
+#ifdef __CUDA_ARCH__
+  __device__
+#endif
   constexpr std::array<uint8_t, layerIndexSize> layer = map_to_array<layerIndexSize>(findLayerFromCompact);
+
+  constexpr uint8_t getLayer(uint32_t detId) { return phase1PixelTopology::layer[detId / phase1PixelTopology::maxModuleStride];}
+
 
   constexpr bool validateLayerIndex() {
     bool res = true;

--- a/Geometry/TrackerGeometryBuilder/test/BuildFile.xml
+++ b/Geometry/TrackerGeometryBuilder/test/BuildFile.xml
@@ -2,7 +2,6 @@
 <use name="Geometry/TrackerNumberingBuilder"/>
 <use name="Geometry/CommonDetUnit"/>
 <use name="FWCore/Framework"/>
-<use name="cuda"/>
 <library file="TrackerDigiGeometryAnalyzer.cc" name="TrackerDigiGeometryAnalyzer">
   <use name="Geometry/Records"/>
   <flags EDM_PLUGIN="1"/>
@@ -43,6 +42,7 @@
 
 <bin file="phase1PixelTopology_t.cu">
   <use name="HeterogeneousCore/CUDAUtilities"/>
+  <use name="cuda"/>
   <flags CUDA_FLAGS="-g -DGPU_DEBUG"/>
 </bin>
 

--- a/Geometry/TrackerGeometryBuilder/test/BuildFile.xml
+++ b/Geometry/TrackerGeometryBuilder/test/BuildFile.xml
@@ -2,6 +2,7 @@
 <use name="Geometry/TrackerNumberingBuilder"/>
 <use name="Geometry/CommonDetUnit"/>
 <use name="FWCore/Framework"/>
+<use name="cuda"/>
 <library file="TrackerDigiGeometryAnalyzer.cc" name="TrackerDigiGeometryAnalyzer">
   <use name="Geometry/Records"/>
   <flags EDM_PLUGIN="1"/>
@@ -40,7 +41,10 @@
   <flags EDM_PLUGIN="1"/>
 </library>
 
-<bin file="phase1PixelTopology_t.cpp"/>
+<bin file="phase1PixelTopology_t.cu">
+  <use name="HeterogeneousCore/CUDAUtilities"/>
+  <flags CUDA_FLAGS="-g -DGPU_DEBUG"/>
+</bin>
 
 <bin file="runTests.cpp" name="GeometryTrackerGeometryBuilderTestDriver">
   <use name="FWCore/Utilities"/>

--- a/Geometry/TrackerGeometryBuilder/test/phase1PixelTopology_t.cu
+++ b/Geometry/TrackerGeometryBuilder/test/phase1PixelTopology_t.cu
@@ -126,30 +126,21 @@ namespace {
 
 }  // namespace
 
-
 constexpr void testLayer() {
-
   for (auto i = 0U; i < phase1PixelTopology::numberOfModules; ++i) {
     uint32_t layer = phase1PixelTopology::getLayer(i);
-    uint32_t tLayer= phase1PixelTopology::findLayer(i);
-    assert(tLayer==layer);
+    uint32_t tLayer = phase1PixelTopology::findLayer(i);
+    assert(tLayer == layer);
     //std::cout << "module " << i << ": " << "layer " << layer << ", \"" << phase1PixelTopology::layerName[layer] << "\", [" << phase1PixelTopology::layerStart[layer] << ", " << phase1PixelTopology::layerStart[layer+1] << ")" << std::endl;
     assert(layer < phase1PixelTopology::numberOfLayers);
     assert(i >= phase1PixelTopology::layerStart[layer]);
     assert(i < phase1PixelTopology::layerStart[layer + 1]);
   }
-
-
 }
 
-
-__global__ 
-void kernel_testLayer() {
-  testLayer();
-}
+__global__ void kernel_testLayer() { testLayer(); }
 
 int main() {
-
   cms::cudatest::requireDevices();
 
   for (uint16_t ix = 0; ix < 80 * 2; ++ix) {
@@ -173,16 +164,16 @@ int main() {
   for (auto i = 0U; i < phase1PixelTopology::numberOfLayers; ++i) {
     std::cout << "layer " << i << ", \"" << phase1PixelTopology::layerName[i] << "\", ["
               << phase1PixelTopology::layerStart[i] << ", " << phase1PixelTopology::layerStart[i + 1] << ") "
-              << phase1PixelTopology::layerStart[i+1]-phase1PixelTopology::layerStart[i] 
-              << std::endl;
+              << phase1PixelTopology::layerStart[i + 1] - phase1PixelTopology::layerStart[i] << std::endl;
   }
 
-  std::cout << "maxModuleStide layerIndexSize " << phase1PixelTopology::maxModuleStride << ' ' << phase1PixelTopology::layerIndexSize << std::endl;
+  std::cout << "maxModuleStide layerIndexSize " << phase1PixelTopology::maxModuleStride << ' '
+            << phase1PixelTopology::layerIndexSize << std::endl;
 
   testLayer();
 
-  kernel_testLayer<<<1,1>>>();
-  cudaCheck(cudaDeviceSynchronize());  
+  kernel_testLayer<<<1, 1>>>();
+  cudaCheck(cudaDeviceSynchronize());
 
   return 0;
 }

--- a/Geometry/TrackerGeometryBuilder/test/phase1PixelTopology_t.cu
+++ b/Geometry/TrackerGeometryBuilder/test/phase1PixelTopology_t.cu
@@ -4,6 +4,9 @@
 
 #include "Geometry/TrackerGeometryBuilder/interface/phase1PixelTopology.h"
 
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireDevices.h"
+
 namespace {
 
   // original code from CMSSW_4_4
@@ -123,7 +126,32 @@ namespace {
 
 }  // namespace
 
+
+constexpr void testLayer() {
+
+  for (auto i = 0U; i < phase1PixelTopology::numberOfModules; ++i) {
+    uint32_t layer = phase1PixelTopology::getLayer(i);
+    uint32_t tLayer= phase1PixelTopology::findLayer(i);
+    assert(tLayer==layer);
+    //std::cout << "module " << i << ": " << "layer " << layer << ", \"" << phase1PixelTopology::layerName[layer] << "\", [" << phase1PixelTopology::layerStart[layer] << ", " << phase1PixelTopology::layerStart[layer+1] << ")" << std::endl;
+    assert(layer < phase1PixelTopology::numberOfLayers);
+    assert(i >= phase1PixelTopology::layerStart[layer]);
+    assert(i < phase1PixelTopology::layerStart[layer + 1]);
+  }
+
+
+}
+
+
+__global__ 
+void kernel_testLayer() {
+  testLayer();
+}
+
 int main() {
+
+  cms::cudatest::requireDevices();
+
   for (uint16_t ix = 0; ix < 80 * 2; ++ix) {
     auto ori = localXori(ix);
     auto xl = phase1PixelTopology::localX(ix);
@@ -144,17 +172,17 @@ int main() {
 
   for (auto i = 0U; i < phase1PixelTopology::numberOfLayers; ++i) {
     std::cout << "layer " << i << ", \"" << phase1PixelTopology::layerName[i] << "\", ["
-              << phase1PixelTopology::layerStart[i] << ", " << phase1PixelTopology::layerStart[i + 1] << ")"
+              << phase1PixelTopology::layerStart[i] << ", " << phase1PixelTopology::layerStart[i + 1] << ") "
+              << phase1PixelTopology::layerStart[i+1]-phase1PixelTopology::layerStart[i] 
               << std::endl;
   }
 
-  for (auto i = 0U; i < phase1PixelTopology::numberOfModules; ++i) {
-    auto layer = static_cast<const uint32_t>(phase1PixelTopology::layer[i / phase1PixelTopology::maxModuleStride]);
-    //std::cout << "module " << i << ": " << "layer " << layer << ", \"" << phase1PixelTopology::layerName[layer] << "\", [" << phase1PixelTopology::layerStart[layer] << ", " << phase1PixelTopology::layerStart[layer+1] << ")" << std::endl;
-    assert(layer < phase1PixelTopology::numberOfLayers);
-    assert(i >= phase1PixelTopology::layerStart[layer]);
-    assert(i < phase1PixelTopology::layerStart[layer + 1]);
-  }
+  std::cout << "maxModuleStide layerIndexSize " << phase1PixelTopology::maxModuleStride << ' ' << phase1PixelTopology::layerIndexSize << std::endl;
+
+  testLayer();
+
+  kernel_testLayer<<<1,1>>>();
+  cudaCheck(cudaDeviceSynchronize());  
 
   return 0;
 }

--- a/RecoPixelVertexing/PixelTrackFitting/interface/BrokenLine.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/BrokenLine.h
@@ -156,7 +156,7 @@ namespace brokenline {
 
     int mId = 1;
 
-    if constexpr (n>3) {
+    if constexpr (n > 3) {
       riemannFit::Vector2d middle = 0.5 * (hits.block(0, n - 1, 2, 1) + hits.block(0, 0, 2, 1));
       auto d1 = (hits.block(0, n / 2, 2, 1) - middle).squaredNorm();
       auto d2 = (hits.block(0, n / 2 - 1, 2, 1) - middle).squaredNorm();
@@ -260,7 +260,7 @@ namespace brokenline {
 
     int mId = 1;
 
-    if constexpr (n>3) {
+    if constexpr (n > 3) {
       riemannFit::Vector2d middle = 0.5 * (hits.block(0, n - 1, 2, 1) + hits.block(0, 0, 2, 1));
       auto d1 = (hits.block(0, n / 2, 2, 1) - middle).squaredNorm();
       auto d2 = (hits.block(0, n / 2 - 1, 2, 1) - middle).squaredNorm();

--- a/RecoPixelVertexing/PixelTrackFitting/interface/BrokenLine.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/BrokenLine.h
@@ -154,8 +154,15 @@ namespace brokenline {
     riemannFit::Vector2d dVec;
     riemannFit::Vector2d eVec;
 
-    dVec = hits.block(0, 1, 2, 1) - hits.block(0, 0, 2, 1);
-    eVec = hits.block(0, n - 1, 2, 1) - hits.block(0, n - 2, 2, 1);
+    riemannFit::Vector2d middle = 0.5*(hits.block(0, n - 1, 2, 1)+hits.block(0, 0, 2, 1));
+
+    auto d1 = (hits.block(0, n/2, 2, 1)-middle).squaredNorm();
+    auto d2 = (hits.block(0, n/2+1, 2, 1)-middle).squaredNorm();
+
+    int mId = d1<d2 ? n/2 : n/2+1;
+
+    dVec = hits.block(0, mId, 2, 1) - hits.block(0, 0, 2, 1);
+    eVec = hits.block(0, n - 1, 2, 1) - hits.block(0, mId, 2, 1);
     results.qCharge = riemannFit::cross2D(dVec, eVec) > 0 ? -1 : 1;
 
     const double slope = -results.qCharge / fast_fit(3);
@@ -249,8 +256,15 @@ namespace brokenline {
   __host__ __device__ inline void fastFit(const M3xN& hits, V4& result) {
     constexpr uint32_t n = M3xN::ColsAtCompileTime;
 
-    const riemannFit::Vector2d a = hits.block(0, n / 2, 2, 1) - hits.block(0, 0, 2, 1);
-    const riemannFit::Vector2d b = hits.block(0, n - 1, 2, 1) - hits.block(0, n / 2, 2, 1);
+    riemannFit::Vector2d middle = 0.5*(hits.block(0, n - 1, 2, 1)+hits.block(0, 0, 2, 1));
+
+    auto d1 = (hits.block(0, n/2, 2, 1)-middle).squaredNorm();
+    auto d2 = (hits.block(0, n/2+1, 2, 1)-middle).squaredNorm();
+
+    int mId = d1<d2 ? n/2 : n/2+1;
+
+    const riemannFit::Vector2d a = hits.block(0, mId, 2, 1) - hits.block(0, 0, 2, 1);
+    const riemannFit::Vector2d b = hits.block(0, n - 1, 2, 1) - hits.block(0, mId, 2, 1);
     const riemannFit::Vector2d c = hits.block(0, 0, 2, 1) - hits.block(0, n - 1, 2, 1);
 
     auto tmp = 0.5 / riemannFit::cross2D(c, a);

--- a/RecoPixelVertexing/PixelTrackFitting/interface/BrokenLine.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/BrokenLine.h
@@ -154,12 +154,14 @@ namespace brokenline {
     riemannFit::Vector2d dVec;
     riemannFit::Vector2d eVec;
 
-    riemannFit::Vector2d middle = 0.5 * (hits.block(0, n - 1, 2, 1) + hits.block(0, 0, 2, 1));
+    int mId = 1;
 
-    auto d1 = (hits.block(0, n / 2, 2, 1) - middle).squaredNorm();
-    auto d2 = (hits.block(0, n / 2 + 1, 2, 1) - middle).squaredNorm();
-
-    int mId = d1 < d2 ? n / 2 : n / 2 + 1;
+    if constexpr (n>3) {
+      riemannFit::Vector2d middle = 0.5 * (hits.block(0, n - 1, 2, 1) + hits.block(0, 0, 2, 1));
+      auto d1 = (hits.block(0, n / 2, 2, 1) - middle).squaredNorm();
+      auto d2 = (hits.block(0, n / 2 - 1, 2, 1) - middle).squaredNorm();
+      mId = d1 < d2 ? n / 2 : n / 2 - 1;
+    }
 
     dVec = hits.block(0, mId, 2, 1) - hits.block(0, 0, 2, 1);
     eVec = hits.block(0, n - 1, 2, 1) - hits.block(0, mId, 2, 1);
@@ -256,12 +258,14 @@ namespace brokenline {
   __host__ __device__ inline void fastFit(const M3xN& hits, V4& result) {
     constexpr uint32_t n = M3xN::ColsAtCompileTime;
 
-    riemannFit::Vector2d middle = 0.5 * (hits.block(0, n - 1, 2, 1) + hits.block(0, 0, 2, 1));
+    int mId = 1;
 
-    auto d1 = (hits.block(0, n / 2, 2, 1) - middle).squaredNorm();
-    auto d2 = (hits.block(0, n / 2 + 1, 2, 1) - middle).squaredNorm();
-
-    int mId = d1 < d2 ? n / 2 : n / 2 + 1;
+    if constexpr (n>3) {
+      riemannFit::Vector2d middle = 0.5 * (hits.block(0, n - 1, 2, 1) + hits.block(0, 0, 2, 1));
+      auto d1 = (hits.block(0, n / 2, 2, 1) - middle).squaredNorm();
+      auto d2 = (hits.block(0, n / 2 - 1, 2, 1) - middle).squaredNorm();
+      mId = d1 < d2 ? n / 2 : n / 2 - 1;
+    }
 
     const riemannFit::Vector2d a = hits.block(0, mId, 2, 1) - hits.block(0, 0, 2, 1);
     const riemannFit::Vector2d b = hits.block(0, n - 1, 2, 1) - hits.block(0, mId, 2, 1);

--- a/RecoPixelVertexing/PixelTrackFitting/interface/BrokenLine.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/BrokenLine.h
@@ -154,12 +154,12 @@ namespace brokenline {
     riemannFit::Vector2d dVec;
     riemannFit::Vector2d eVec;
 
-    riemannFit::Vector2d middle = 0.5*(hits.block(0, n - 1, 2, 1)+hits.block(0, 0, 2, 1));
+    riemannFit::Vector2d middle = 0.5 * (hits.block(0, n - 1, 2, 1) + hits.block(0, 0, 2, 1));
 
-    auto d1 = (hits.block(0, n/2, 2, 1)-middle).squaredNorm();
-    auto d2 = (hits.block(0, n/2+1, 2, 1)-middle).squaredNorm();
+    auto d1 = (hits.block(0, n / 2, 2, 1) - middle).squaredNorm();
+    auto d2 = (hits.block(0, n / 2 + 1, 2, 1) - middle).squaredNorm();
 
-    int mId = d1<d2 ? n/2 : n/2+1;
+    int mId = d1 < d2 ? n / 2 : n / 2 + 1;
 
     dVec = hits.block(0, mId, 2, 1) - hits.block(0, 0, 2, 1);
     eVec = hits.block(0, n - 1, 2, 1) - hits.block(0, mId, 2, 1);
@@ -256,12 +256,12 @@ namespace brokenline {
   __host__ __device__ inline void fastFit(const M3xN& hits, V4& result) {
     constexpr uint32_t n = M3xN::ColsAtCompileTime;
 
-    riemannFit::Vector2d middle = 0.5*(hits.block(0, n - 1, 2, 1)+hits.block(0, 0, 2, 1));
+    riemannFit::Vector2d middle = 0.5 * (hits.block(0, n - 1, 2, 1) + hits.block(0, 0, 2, 1));
 
-    auto d1 = (hits.block(0, n/2, 2, 1)-middle).squaredNorm();
-    auto d2 = (hits.block(0, n/2+1, 2, 1)-middle).squaredNorm();
+    auto d1 = (hits.block(0, n / 2, 2, 1) - middle).squaredNorm();
+    auto d2 = (hits.block(0, n / 2 + 1, 2, 1) - middle).squaredNorm();
 
-    int mId = d1<d2 ? n/2 : n/2+1;
+    int mId = d1 < d2 ? n / 2 : n / 2 + 1;
 
     const riemannFit::Vector2d a = hits.block(0, mId, 2, 1) - hits.block(0, 0, 2, 1);
     const riemannFit::Vector2d b = hits.block(0, n - 1, 2, 1) - hits.block(0, mId, 2, 1);

--- a/RecoPixelVertexing/PixelTriplets/plugins/BrokenLineFitOnGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/BrokenLineFitOnGPU.cc
@@ -28,7 +28,7 @@ void HelixFitOnGPU::launchBrokenLineKernelsOnCPU(HitsView const* hv, uint32_t hi
     if (fit5as4_) {
       // fit all as 4
       kernel_BLFastFit<4>(
-          tuples_, tupleMultiplicity_, hv,tkidGPU.get(), hitsGPU.get(), hits_geGPU.get(), fast_fit_resultsGPU.get(), 4,6, offset);
+          tuples_, tupleMultiplicity_, hv,tkidGPU.get(), hitsGPU.get(), hits_geGPU.get(), fast_fit_resultsGPU.get(), 4,8, offset);
 
       kernel_BLFit<4>(tupleMultiplicity_,
                       bField_,
@@ -61,9 +61,9 @@ void HelixFitOnGPU::launchBrokenLineKernelsOnCPU(HitsView const* hv, uint32_t hi
                       hits_geGPU.get(),
                       fast_fit_resultsGPU.get(),
                       offset);
-      // fit sexta (all 6)
+      // fit sexta and above (as 6)
       kernel_BLFastFit<6>(
-          tuples_, tupleMultiplicity_, hv,tkidGPU.get(), hitsGPU.get(), hits_geGPU.get(), fast_fit_resultsGPU.get(), 6,6, offset);
+          tuples_, tupleMultiplicity_, hv,tkidGPU.get(), hitsGPU.get(), hits_geGPU.get(), fast_fit_resultsGPU.get(), 6,8, offset);
 
       kernel_BLFit<6>(tupleMultiplicity_,
                       bField_,

--- a/RecoPixelVertexing/PixelTriplets/plugins/BrokenLineFitOnGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/BrokenLineFitOnGPU.cc
@@ -4,89 +4,84 @@ void HelixFitOnGPU::launchBrokenLineKernelsOnCPU(HitsView const* hv, uint32_t hi
   assert(tuples_);
 
   //  Fit internals
-  auto hitsGPU_ =
+  auto tkidGPU = std::make_unique<caConstants::tindex_type[]>(maxNumberOfConcurrentFits_);
+  auto hitsGPU =
       std::make_unique<double[]>(maxNumberOfConcurrentFits_ * sizeof(riemannFit::Matrix3xNd<4>) / sizeof(double));
-  auto hits_geGPU_ =
+  auto hits_geGPU =
       std::make_unique<float[]>(maxNumberOfConcurrentFits_ * sizeof(riemannFit::Matrix6x4f) / sizeof(float));
-  auto fast_fit_resultsGPU_ =
+  auto fast_fit_resultsGPU =
       std::make_unique<double[]>(maxNumberOfConcurrentFits_ * sizeof(riemannFit::Vector4d) / sizeof(double));
 
   for (uint32_t offset = 0; offset < maxNumberOfTuples; offset += maxNumberOfConcurrentFits_) {
     // fit triplets
     kernel_BLFastFit<3>(
-        tuples_, tupleMultiplicity_, hv, hitsGPU_.get(), hits_geGPU_.get(), fast_fit_resultsGPU_.get(), 3, offset);
+        tuples_, tupleMultiplicity_, hv,tkidGPU.get(), hitsGPU.get(), hits_geGPU.get(), fast_fit_resultsGPU.get(), 3, offset);
 
     kernel_BLFit<3>(tupleMultiplicity_,
                     bField_,
                     outputSoa_,
-                    hitsGPU_.get(),
-                    hits_geGPU_.get(),
-                    fast_fit_resultsGPU_.get(),
-                    3,
+                   tkidGPU.get(), hitsGPU.get(),
+                    hits_geGPU.get(),
+                    fast_fit_resultsGPU.get(),
                     offset);
 
     // fit quads
     kernel_BLFastFit<4>(
-        tuples_, tupleMultiplicity_, hv, hitsGPU_.get(), hits_geGPU_.get(), fast_fit_resultsGPU_.get(), 4, offset);
+        tuples_, tupleMultiplicity_, hv,tkidGPU.get(), hitsGPU.get(), hits_geGPU.get(), fast_fit_resultsGPU.get(), 4, offset);
 
     kernel_BLFit<4>(tupleMultiplicity_,
                     bField_,
                     outputSoa_,
-                    hitsGPU_.get(),
-                    hits_geGPU_.get(),
-                    fast_fit_resultsGPU_.get(),
-                    4,
+                   tkidGPU.get(), hitsGPU.get(),
+                    hits_geGPU.get(),
+                    fast_fit_resultsGPU.get(),
                     offset);
 
     if (fit5as4_) {
       // fit penta (only first 4)
       kernel_BLFastFit<4>(
-          tuples_, tupleMultiplicity_, hv, hitsGPU_.get(), hits_geGPU_.get(), fast_fit_resultsGPU_.get(), 5, offset);
+          tuples_, tupleMultiplicity_, hv,tkidGPU.get(), hitsGPU.get(), hits_geGPU.get(), fast_fit_resultsGPU.get(), 5, offset);
 
       kernel_BLFit<4>(tupleMultiplicity_,
                       bField_,
                       outputSoa_,
-                      hitsGPU_.get(),
-                      hits_geGPU_.get(),
-                      fast_fit_resultsGPU_.get(),
-                      5,
+                     tkidGPU.get(), hitsGPU.get(),
+                      hits_geGPU.get(),
+                      fast_fit_resultsGPU.get(),
                       offset);
       // fit sexta (only first 4)
       kernel_BLFastFit<4>(
-          tuples_, tupleMultiplicity_, hv, hitsGPU_.get(), hits_geGPU_.get(), fast_fit_resultsGPU_.get(), 6, offset);
+          tuples_, tupleMultiplicity_, hv,tkidGPU.get(), hitsGPU.get(), hits_geGPU.get(), fast_fit_resultsGPU.get(), 6, offset);
 
       kernel_BLFit<4>(tupleMultiplicity_,
                       bField_,
                       outputSoa_,
-                      hitsGPU_.get(),
-                      hits_geGPU_.get(),
-                      fast_fit_resultsGPU_.get(),
-                      6,
+                     tkidGPU.get(), hitsGPU.get(),
+                      hits_geGPU.get(),
+                      fast_fit_resultsGPU.get(),
                       offset);
     } else {
       // fit penta (all 5)
       kernel_BLFastFit<5>(
-          tuples_, tupleMultiplicity_, hv, hitsGPU_.get(), hits_geGPU_.get(), fast_fit_resultsGPU_.get(), 5, offset);
+          tuples_, tupleMultiplicity_, hv,tkidGPU.get(), hitsGPU.get(), hits_geGPU.get(), fast_fit_resultsGPU.get(), 5, offset);
 
       kernel_BLFit<5>(tupleMultiplicity_,
                       bField_,
                       outputSoa_,
-                      hitsGPU_.get(),
-                      hits_geGPU_.get(),
-                      fast_fit_resultsGPU_.get(),
-                      5,
+                     tkidGPU.get(), hitsGPU.get(),
+                      hits_geGPU.get(),
+                      fast_fit_resultsGPU.get(),
                       offset);
       // fit sexta (all 6)
       kernel_BLFastFit<6>(
-          tuples_, tupleMultiplicity_, hv, hitsGPU_.get(), hits_geGPU_.get(), fast_fit_resultsGPU_.get(), 6, offset);
+          tuples_, tupleMultiplicity_, hv,tkidGPU.get(), hitsGPU.get(), hits_geGPU.get(), fast_fit_resultsGPU.get(), 6, offset);
 
       kernel_BLFit<6>(tupleMultiplicity_,
                       bField_,
                       outputSoa_,
-                      hitsGPU_.get(),
-                      hits_geGPU_.get(),
-                      fast_fit_resultsGPU_.get(),
-                      6,
+                     tkidGPU.get(), hitsGPU.get(),
+                      hits_geGPU.get(),
+                      fast_fit_resultsGPU.get(),
                       offset);
     }
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/BrokenLineFitOnGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/BrokenLineFitOnGPU.cc
@@ -51,6 +51,18 @@ void HelixFitOnGPU::launchBrokenLineKernelsOnCPU(HitsView const* hv, uint32_t hi
                       fast_fit_resultsGPU_.get(),
                       5,
                       offset);
+      // fit sexta (only first 4)
+      kernel_BLFastFit<4>(
+          tuples_, tupleMultiplicity_, hv, hitsGPU_.get(), hits_geGPU_.get(), fast_fit_resultsGPU_.get(), 6, offset);
+
+      kernel_BLFit<4>(tupleMultiplicity_,
+                      bField_,
+                      outputSoa_,
+                      hitsGPU_.get(),
+                      hits_geGPU_.get(),
+                      fast_fit_resultsGPU_.get(),
+                      6,
+                      offset);
     } else {
       // fit penta (all 5)
       kernel_BLFastFit<5>(
@@ -63,6 +75,18 @@ void HelixFitOnGPU::launchBrokenLineKernelsOnCPU(HitsView const* hv, uint32_t hi
                       hits_geGPU_.get(),
                       fast_fit_resultsGPU_.get(),
                       5,
+                      offset);
+      // fit sexta (all 6)
+      kernel_BLFastFit<6>(
+          tuples_, tupleMultiplicity_, hv, hitsGPU_.get(), hits_geGPU_.get(), fast_fit_resultsGPU_.get(), 6, offset);
+
+      kernel_BLFit<6>(tupleMultiplicity_,
+                      bField_,
+                      outputSoa_,
+                      hitsGPU_.get(),
+                      hits_geGPU_.get(),
+                      fast_fit_resultsGPU_.get(),
+                      6,
                       offset);
     }
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/BrokenLineFitOnGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/BrokenLineFitOnGPU.cc
@@ -37,7 +37,7 @@ void HelixFitOnGPU::launchBrokenLineKernelsOnCPU(HitsView const* hv, uint32_t hi
                     hits_geGPU.get(),
                     fast_fit_resultsGPU.get());
 
-    if (fit5as4_) {
+    if (fitNas4_) {
       // fit all as 4
       kernel_BLFastFit<4>(tuples_,
                           tupleMultiplicity_,

--- a/RecoPixelVertexing/PixelTriplets/plugins/BrokenLineFitOnGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/BrokenLineFitOnGPU.cc
@@ -3,75 +3,116 @@
 void HelixFitOnGPU::launchBrokenLineKernelsOnCPU(HitsView const* hv, uint32_t hitsInFit, uint32_t maxNumberOfTuples) {
   assert(tuples_);
 
+  setlinebuf(stdout);
+
   //  Fit internals
   auto tkidGPU = std::make_unique<caConstants::tindex_type[]>(maxNumberOfConcurrentFits_);
   auto hitsGPU =
-      std::make_unique<double[]>(maxNumberOfConcurrentFits_ * sizeof(riemannFit::Matrix3xNd<4>) / sizeof(double));
+      std::make_unique<double[]>(maxNumberOfConcurrentFits_ * sizeof(riemannFit::Matrix3xNd<6>) / sizeof(double));
   auto hits_geGPU =
-      std::make_unique<float[]>(maxNumberOfConcurrentFits_ * sizeof(riemannFit::Matrix6x4f) / sizeof(float));
+      std::make_unique<float[]>(maxNumberOfConcurrentFits_ * sizeof(riemannFit::Matrix6xNf<6>) / sizeof(float));
   auto fast_fit_resultsGPU =
       std::make_unique<double[]>(maxNumberOfConcurrentFits_ * sizeof(riemannFit::Vector4d) / sizeof(double));
 
   for (uint32_t offset = 0; offset < maxNumberOfTuples; offset += maxNumberOfConcurrentFits_) {
     // fit triplets
-    kernel_BLFastFit<3>(
-        tuples_, tupleMultiplicity_, hv,tkidGPU.get(), hitsGPU.get(), hits_geGPU.get(), fast_fit_resultsGPU.get(), 3,3, offset);
+    kernel_BLFastFit<3>(tuples_,
+                        tupleMultiplicity_,
+                        hv,
+                        tkidGPU.get(),
+                        hitsGPU.get(),
+                        hits_geGPU.get(),
+                        fast_fit_resultsGPU.get(),
+                        3,
+                        3,
+                        offset);
 
     kernel_BLFit<3>(tupleMultiplicity_,
                     bField_,
                     outputSoa_,
-                   tkidGPU.get(), hitsGPU.get(),
+                    tkidGPU.get(),
+                    hitsGPU.get(),
                     hits_geGPU.get(),
-                    fast_fit_resultsGPU.get(),
-                    offset);
+                    fast_fit_resultsGPU.get());
 
     if (fit5as4_) {
       // fit all as 4
-      kernel_BLFastFit<4>(
-          tuples_, tupleMultiplicity_, hv,tkidGPU.get(), hitsGPU.get(), hits_geGPU.get(), fast_fit_resultsGPU.get(), 4,8, offset);
+      kernel_BLFastFit<4>(tuples_,
+                          tupleMultiplicity_,
+                          hv,
+                          tkidGPU.get(),
+                          hitsGPU.get(),
+                          hits_geGPU.get(),
+                          fast_fit_resultsGPU.get(),
+                          4,
+                          8,
+                          offset);
 
       kernel_BLFit<4>(tupleMultiplicity_,
                       bField_,
                       outputSoa_,
-                     tkidGPU.get(), hitsGPU.get(),
+                      tkidGPU.get(),
+                      hitsGPU.get(),
                       hits_geGPU.get(),
-                      fast_fit_resultsGPU.get(),
-                      offset);
-
+                      fast_fit_resultsGPU.get());
     } else {
-    // fit quads
-    kernel_BLFastFit<4>(
-        tuples_, tupleMultiplicity_, hv,tkidGPU.get(), hitsGPU.get(), hits_geGPU.get(), fast_fit_resultsGPU.get(), 4,4, offset);
+      // fit quads
+      kernel_BLFastFit<4>(tuples_,
+                          tupleMultiplicity_,
+                          hv,
+                          tkidGPU.get(),
+                          hitsGPU.get(),
+                          hits_geGPU.get(),
+                          fast_fit_resultsGPU.get(),
+                          4,
+                          4,
+                          offset);
 
-    kernel_BLFit<4>(tupleMultiplicity_,
-                    bField_,
-                    outputSoa_,
-                   tkidGPU.get(), hitsGPU.get(),
-                    hits_geGPU.get(),
-                    fast_fit_resultsGPU.get(),
-                    offset);
+      kernel_BLFit<4>(tupleMultiplicity_,
+                      bField_,
+                      outputSoa_,
+                      tkidGPU.get(),
+                      hitsGPU.get(),
+                      hits_geGPU.get(),
+                      fast_fit_resultsGPU.get());
       // fit penta (all 5)
-      kernel_BLFastFit<5>(
-          tuples_, tupleMultiplicity_, hv,tkidGPU.get(), hitsGPU.get(), hits_geGPU.get(), fast_fit_resultsGPU.get(), 5,5, offset);
+      kernel_BLFastFit<5>(tuples_,
+                          tupleMultiplicity_,
+                          hv,
+                          tkidGPU.get(),
+                          hitsGPU.get(),
+                          hits_geGPU.get(),
+                          fast_fit_resultsGPU.get(),
+                          5,
+                          5,
+                          offset);
 
       kernel_BLFit<5>(tupleMultiplicity_,
                       bField_,
                       outputSoa_,
-                     tkidGPU.get(), hitsGPU.get(),
+                      tkidGPU.get(),
+                      hitsGPU.get(),
                       hits_geGPU.get(),
-                      fast_fit_resultsGPU.get(),
-                      offset);
+                      fast_fit_resultsGPU.get());
       // fit sexta and above (as 6)
-      kernel_BLFastFit<6>(
-          tuples_, tupleMultiplicity_, hv,tkidGPU.get(), hitsGPU.get(), hits_geGPU.get(), fast_fit_resultsGPU.get(), 6,8, offset);
+      kernel_BLFastFit<6>(tuples_,
+                          tupleMultiplicity_,
+                          hv,
+                          tkidGPU.get(),
+                          hitsGPU.get(),
+                          hits_geGPU.get(),
+                          fast_fit_resultsGPU.get(),
+                          6,
+                          8,
+                          offset);
 
       kernel_BLFit<6>(tupleMultiplicity_,
                       bField_,
                       outputSoa_,
-                     tkidGPU.get(), hitsGPU.get(),
+                      tkidGPU.get(),
+                      hitsGPU.get(),
                       hits_geGPU.get(),
-                      fast_fit_resultsGPU.get(),
-                      offset);
+                      fast_fit_resultsGPU.get());
     }
 
   }  // loop on concurrent fits

--- a/RecoPixelVertexing/PixelTriplets/plugins/BrokenLineFitOnGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/BrokenLineFitOnGPU.cc
@@ -15,7 +15,7 @@ void HelixFitOnGPU::launchBrokenLineKernelsOnCPU(HitsView const* hv, uint32_t hi
   for (uint32_t offset = 0; offset < maxNumberOfTuples; offset += maxNumberOfConcurrentFits_) {
     // fit triplets
     kernel_BLFastFit<3>(
-        tuples_, tupleMultiplicity_, hv,tkidGPU.get(), hitsGPU.get(), hits_geGPU.get(), fast_fit_resultsGPU.get(), 3, offset);
+        tuples_, tupleMultiplicity_, hv,tkidGPU.get(), hitsGPU.get(), hits_geGPU.get(), fast_fit_resultsGPU.get(), 3,3, offset);
 
     kernel_BLFit<3>(tupleMultiplicity_,
                     bField_,
@@ -25,9 +25,23 @@ void HelixFitOnGPU::launchBrokenLineKernelsOnCPU(HitsView const* hv, uint32_t hi
                     fast_fit_resultsGPU.get(),
                     offset);
 
+    if (fit5as4_) {
+      // fit all as 4
+      kernel_BLFastFit<4>(
+          tuples_, tupleMultiplicity_, hv,tkidGPU.get(), hitsGPU.get(), hits_geGPU.get(), fast_fit_resultsGPU.get(), 4,6, offset);
+
+      kernel_BLFit<4>(tupleMultiplicity_,
+                      bField_,
+                      outputSoa_,
+                     tkidGPU.get(), hitsGPU.get(),
+                      hits_geGPU.get(),
+                      fast_fit_resultsGPU.get(),
+                      offset);
+
+    } else {
     // fit quads
     kernel_BLFastFit<4>(
-        tuples_, tupleMultiplicity_, hv,tkidGPU.get(), hitsGPU.get(), hits_geGPU.get(), fast_fit_resultsGPU.get(), 4, offset);
+        tuples_, tupleMultiplicity_, hv,tkidGPU.get(), hitsGPU.get(), hits_geGPU.get(), fast_fit_resultsGPU.get(), 4,4, offset);
 
     kernel_BLFit<4>(tupleMultiplicity_,
                     bField_,
@@ -36,34 +50,9 @@ void HelixFitOnGPU::launchBrokenLineKernelsOnCPU(HitsView const* hv, uint32_t hi
                     hits_geGPU.get(),
                     fast_fit_resultsGPU.get(),
                     offset);
-
-    if (fit5as4_) {
-      // fit penta (only first 4)
-      kernel_BLFastFit<4>(
-          tuples_, tupleMultiplicity_, hv,tkidGPU.get(), hitsGPU.get(), hits_geGPU.get(), fast_fit_resultsGPU.get(), 5, offset);
-
-      kernel_BLFit<4>(tupleMultiplicity_,
-                      bField_,
-                      outputSoa_,
-                     tkidGPU.get(), hitsGPU.get(),
-                      hits_geGPU.get(),
-                      fast_fit_resultsGPU.get(),
-                      offset);
-      // fit sexta (only first 4)
-      kernel_BLFastFit<4>(
-          tuples_, tupleMultiplicity_, hv,tkidGPU.get(), hitsGPU.get(), hits_geGPU.get(), fast_fit_resultsGPU.get(), 6, offset);
-
-      kernel_BLFit<4>(tupleMultiplicity_,
-                      bField_,
-                      outputSoa_,
-                     tkidGPU.get(), hitsGPU.get(),
-                      hits_geGPU.get(),
-                      fast_fit_resultsGPU.get(),
-                      offset);
-    } else {
       // fit penta (all 5)
       kernel_BLFastFit<5>(
-          tuples_, tupleMultiplicity_, hv,tkidGPU.get(), hitsGPU.get(), hits_geGPU.get(), fast_fit_resultsGPU.get(), 5, offset);
+          tuples_, tupleMultiplicity_, hv,tkidGPU.get(), hitsGPU.get(), hits_geGPU.get(), fast_fit_resultsGPU.get(), 5,5, offset);
 
       kernel_BLFit<5>(tupleMultiplicity_,
                       bField_,
@@ -74,7 +63,7 @@ void HelixFitOnGPU::launchBrokenLineKernelsOnCPU(HitsView const* hv, uint32_t hi
                       offset);
       // fit sexta (all 6)
       kernel_BLFastFit<6>(
-          tuples_, tupleMultiplicity_, hv,tkidGPU.get(), hitsGPU.get(), hits_geGPU.get(), fast_fit_resultsGPU.get(), 6, offset);
+          tuples_, tupleMultiplicity_, hv,tkidGPU.get(), hitsGPU.get(), hits_geGPU.get(), fast_fit_resultsGPU.get(), 6,6, offset);
 
       kernel_BLFit<6>(tupleMultiplicity_,
                       bField_,

--- a/RecoPixelVertexing/PixelTriplets/plugins/BrokenLineFitOnGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/BrokenLineFitOnGPU.cc
@@ -3,7 +3,9 @@
 void HelixFitOnGPU::launchBrokenLineKernelsOnCPU(HitsView const* hv, uint32_t hitsInFit, uint32_t maxNumberOfTuples) {
   assert(tuples_);
 
+#ifdef BROKENLINE_DEBUG
   setlinebuf(stdout);
+#endif
 
   //  Fit internals
   auto tkidGPU = std::make_unique<caConstants::tindex_type[]>(maxNumberOfConcurrentFits_);

--- a/RecoPixelVertexing/PixelTriplets/plugins/BrokenLineFitOnGPU.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/BrokenLineFitOnGPU.cu
@@ -37,7 +37,7 @@ void HelixFitOnGPU::launchBrokenLineKernels(HitsView const *hv,
     if (fit5as4_) {
       // fit all as 4
       kernel_BLFastFit<4><<<numberOfBlocks / 4, blockSize, 0, stream>>>(
-          tuples_, tupleMultiplicity_, hv,tkidGPU.get(), hitsGPU.get(), hits_geGPU.get(), fast_fit_resultsGPU.get(), 4,6, offset);
+          tuples_, tupleMultiplicity_, hv,tkidGPU.get(), hitsGPU.get(), hits_geGPU.get(), fast_fit_resultsGPU.get(), 4,8, offset);
       cudaCheck(cudaGetLastError());
 
       kernel_BLFit<4><<<numberOfBlocks / 4, blockSize, 0, stream>>>(tupleMultiplicity_,
@@ -73,9 +73,9 @@ void HelixFitOnGPU::launchBrokenLineKernels(HitsView const *hv,
                                                                     fast_fit_resultsGPU.get(),
                                                                     offset);
       cudaCheck(cudaGetLastError());
-      // fit sexta (all 6)
+      // fit sexta and above (as 6)
       kernel_BLFastFit<6><<<1, blockSize, 0, stream>>>(
-          tuples_, tupleMultiplicity_, hv,tkidGPU.get(), hitsGPU.get(), hits_geGPU.get(), fast_fit_resultsGPU.get(), 6,6, offset);
+          tuples_, tupleMultiplicity_, hv,tkidGPU.get(), hitsGPU.get(), hits_geGPU.get(), fast_fit_resultsGPU.get(), 6,8, offset);
       cudaCheck(cudaGetLastError());
 
       kernel_BLFit<6><<<1, blockSize, 0, stream>>>(tupleMultiplicity_,

--- a/RecoPixelVertexing/PixelTriplets/plugins/BrokenLineFitOnGPU.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/BrokenLineFitOnGPU.cu
@@ -21,7 +21,7 @@ void HelixFitOnGPU::launchBrokenLineKernels(HitsView const *hv,
 
   for (uint32_t offset = 0; offset < maxNumberOfTuples; offset += maxNumberOfConcurrentFits_) {
     // fit triplets
-    kernel_BLFastFit<3><<<numberOfBlocks/2, blockSize, 0, stream>>>(tuples_,
+    kernel_BLFastFit<3><<<numberOfBlocks, blockSize, 0, stream>>>(tuples_,
                                                                   tupleMultiplicity_,
                                                                   hv,
                                                                   tkidGPU.get(),
@@ -33,7 +33,7 @@ void HelixFitOnGPU::launchBrokenLineKernels(HitsView const *hv,
                                                                   offset);
     cudaCheck(cudaGetLastError());
 
-    kernel_BLFit<3><<<numberOfBlocks/2, blockSize, 0, stream>>>(tupleMultiplicity_,
+    kernel_BLFit<3><<<numberOfBlocks, blockSize, 0, stream>>>(tupleMultiplicity_,
                                                               bField_,
                                                               outputSoa_,
                                                               tkidGPU.get(),
@@ -44,7 +44,7 @@ void HelixFitOnGPU::launchBrokenLineKernels(HitsView const *hv,
 
     if (fit5as4_) {
       // fit all as 4
-      kernel_BLFastFit<4><<<numberOfBlocks, blockSize, 0, stream>>>(tuples_,
+      kernel_BLFastFit<4><<<numberOfBlocks/4, blockSize, 0, stream>>>(tuples_,
                                                                         tupleMultiplicity_,
                                                                         hv,
                                                                         tkidGPU.get(),
@@ -56,7 +56,7 @@ void HelixFitOnGPU::launchBrokenLineKernels(HitsView const *hv,
                                                                         offset);
       cudaCheck(cudaGetLastError());
 
-      kernel_BLFit<4><<<numberOfBlocks, blockSize, 0, stream>>>(tupleMultiplicity_,
+      kernel_BLFit<4><<<numberOfBlocks/4, blockSize, 0, stream>>>(tupleMultiplicity_,
                                                                     bField_,
                                                                     outputSoa_,
                                                                     tkidGPU.get(),
@@ -65,7 +65,7 @@ void HelixFitOnGPU::launchBrokenLineKernels(HitsView const *hv,
                                                                     fast_fit_resultsGPU.get());
     } else {
       // fit quads
-      kernel_BLFastFit<4><<<numberOfBlocks, blockSize, 0, stream>>>(tuples_,
+      kernel_BLFastFit<4><<<numberOfBlocks/4, blockSize, 0, stream>>>(tuples_,
                                                                         tupleMultiplicity_,
                                                                         hv,
                                                                         tkidGPU.get(),
@@ -77,7 +77,7 @@ void HelixFitOnGPU::launchBrokenLineKernels(HitsView const *hv,
                                                                         offset);
       cudaCheck(cudaGetLastError());
 
-      kernel_BLFit<4><<<numberOfBlocks, blockSize, 0, stream>>>(tupleMultiplicity_,
+      kernel_BLFit<4><<<numberOfBlocks/4, blockSize, 0, stream>>>(tupleMultiplicity_,
                                                                     bField_,
                                                                     outputSoa_,
                                                                     tkidGPU.get(),
@@ -97,7 +97,7 @@ void HelixFitOnGPU::launchBrokenLineKernels(HitsView const *hv,
                                                        offset);
       cudaCheck(cudaGetLastError());
 
-      kernel_BLFit<5><<<numberOfBlocks/4, blockSize, 0, stream>>>(tupleMultiplicity_,
+      kernel_BLFit<5><<<8, blockSize, 0, stream>>>(tupleMultiplicity_,
                                                    bField_,
                                                    outputSoa_,
                                                    tkidGPU.get(),

--- a/RecoPixelVertexing/PixelTriplets/plugins/BrokenLineFitOnGPU.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/BrokenLineFitOnGPU.cu
@@ -44,7 +44,7 @@ void HelixFitOnGPU::launchBrokenLineKernels(HitsView const *hv,
 
     if (fit5as4_) {
       // fit all as 4
-      kernel_BLFastFit<4><<<numberOfBlocks/4, blockSize, 0, stream>>>(tuples_,
+      kernel_BLFastFit<4><<<numberOfBlocks / 4, blockSize, 0, stream>>>(tuples_,
                                                                         tupleMultiplicity_,
                                                                         hv,
                                                                         tkidGPU.get(),
@@ -56,7 +56,7 @@ void HelixFitOnGPU::launchBrokenLineKernels(HitsView const *hv,
                                                                         offset);
       cudaCheck(cudaGetLastError());
 
-      kernel_BLFit<4><<<numberOfBlocks/4, blockSize, 0, stream>>>(tupleMultiplicity_,
+      kernel_BLFit<4><<<numberOfBlocks / 4, blockSize, 0, stream>>>(tupleMultiplicity_,
                                                                     bField_,
                                                                     outputSoa_,
                                                                     tkidGPU.get(),
@@ -65,7 +65,7 @@ void HelixFitOnGPU::launchBrokenLineKernels(HitsView const *hv,
                                                                     fast_fit_resultsGPU.get());
     } else {
       // fit quads
-      kernel_BLFastFit<4><<<numberOfBlocks/4, blockSize, 0, stream>>>(tuples_,
+      kernel_BLFastFit<4><<<numberOfBlocks / 4, blockSize, 0, stream>>>(tuples_,
                                                                         tupleMultiplicity_,
                                                                         hv,
                                                                         tkidGPU.get(),
@@ -77,7 +77,7 @@ void HelixFitOnGPU::launchBrokenLineKernels(HitsView const *hv,
                                                                         offset);
       cudaCheck(cudaGetLastError());
 
-      kernel_BLFit<4><<<numberOfBlocks/4, blockSize, 0, stream>>>(tupleMultiplicity_,
+      kernel_BLFit<4><<<numberOfBlocks / 4, blockSize, 0, stream>>>(tupleMultiplicity_,
                                                                     bField_,
                                                                     outputSoa_,
                                                                     tkidGPU.get(),
@@ -85,16 +85,16 @@ void HelixFitOnGPU::launchBrokenLineKernels(HitsView const *hv,
                                                                     hits_geGPU.get(),
                                                                     fast_fit_resultsGPU.get());
       // fit penta (all 5)
-      kernel_BLFastFit<5><<<numberOfBlocks/4, blockSize, 0, stream>>>(tuples_,
-                                                       tupleMultiplicity_,
-                                                       hv,
-                                                       tkidGPU.get(),
-                                                       hitsGPU.get(),
-                                                       hits_geGPU.get(),
-                                                       fast_fit_resultsGPU.get(),
-                                                       5,
-                                                       5,
-                                                       offset);
+      kernel_BLFastFit<5><<<numberOfBlocks / 4, blockSize, 0, stream>>>(tuples_,
+                                                                        tupleMultiplicity_,
+                                                                        hv,
+                                                                        tkidGPU.get(),
+                                                                        hitsGPU.get(),
+                                                                        hits_geGPU.get(),
+                                                                        fast_fit_resultsGPU.get(),
+                                                                        5,
+                                                                        5,
+                                                                        offset);
       cudaCheck(cudaGetLastError());
 
       kernel_BLFit<5><<<8, blockSize, 0, stream>>>(tupleMultiplicity_,

--- a/RecoPixelVertexing/PixelTriplets/plugins/BrokenLineFitOnGPU.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/BrokenLineFitOnGPU.cu
@@ -21,7 +21,7 @@ void HelixFitOnGPU::launchBrokenLineKernels(HitsView const *hv,
 
   for (uint32_t offset = 0; offset < maxNumberOfTuples; offset += maxNumberOfConcurrentFits_) {
     // fit triplets
-    kernel_BLFastFit<3><<<numberOfBlocks, blockSize, 0, stream>>>(tuples_,
+    kernel_BLFastFit<3><<<numberOfBlocks/2, blockSize, 0, stream>>>(tuples_,
                                                                   tupleMultiplicity_,
                                                                   hv,
                                                                   tkidGPU.get(),
@@ -33,7 +33,7 @@ void HelixFitOnGPU::launchBrokenLineKernels(HitsView const *hv,
                                                                   offset);
     cudaCheck(cudaGetLastError());
 
-    kernel_BLFit<3><<<numberOfBlocks, blockSize, 0, stream>>>(tupleMultiplicity_,
+    kernel_BLFit<3><<<numberOfBlocks/2, blockSize, 0, stream>>>(tupleMultiplicity_,
                                                               bField_,
                                                               outputSoa_,
                                                               tkidGPU.get(),
@@ -44,7 +44,7 @@ void HelixFitOnGPU::launchBrokenLineKernels(HitsView const *hv,
 
     if (fit5as4_) {
       // fit all as 4
-      kernel_BLFastFit<4><<<numberOfBlocks / 4, blockSize, 0, stream>>>(tuples_,
+      kernel_BLFastFit<4><<<numberOfBlocks, blockSize, 0, stream>>>(tuples_,
                                                                         tupleMultiplicity_,
                                                                         hv,
                                                                         tkidGPU.get(),
@@ -56,7 +56,7 @@ void HelixFitOnGPU::launchBrokenLineKernels(HitsView const *hv,
                                                                         offset);
       cudaCheck(cudaGetLastError());
 
-      kernel_BLFit<4><<<numberOfBlocks / 4, blockSize, 0, stream>>>(tupleMultiplicity_,
+      kernel_BLFit<4><<<numberOfBlocks, blockSize, 0, stream>>>(tupleMultiplicity_,
                                                                     bField_,
                                                                     outputSoa_,
                                                                     tkidGPU.get(),
@@ -65,7 +65,7 @@ void HelixFitOnGPU::launchBrokenLineKernels(HitsView const *hv,
                                                                     fast_fit_resultsGPU.get());
     } else {
       // fit quads
-      kernel_BLFastFit<4><<<numberOfBlocks / 4, blockSize, 0, stream>>>(tuples_,
+      kernel_BLFastFit<4><<<numberOfBlocks, blockSize, 0, stream>>>(tuples_,
                                                                         tupleMultiplicity_,
                                                                         hv,
                                                                         tkidGPU.get(),
@@ -77,7 +77,7 @@ void HelixFitOnGPU::launchBrokenLineKernels(HitsView const *hv,
                                                                         offset);
       cudaCheck(cudaGetLastError());
 
-      kernel_BLFit<4><<<numberOfBlocks / 4, blockSize, 0, stream>>>(tupleMultiplicity_,
+      kernel_BLFit<4><<<numberOfBlocks, blockSize, 0, stream>>>(tupleMultiplicity_,
                                                                     bField_,
                                                                     outputSoa_,
                                                                     tkidGPU.get(),
@@ -85,7 +85,7 @@ void HelixFitOnGPU::launchBrokenLineKernels(HitsView const *hv,
                                                                     hits_geGPU.get(),
                                                                     fast_fit_resultsGPU.get());
       // fit penta (all 5)
-      kernel_BLFastFit<5><<<1, blockSize, 0, stream>>>(tuples_,
+      kernel_BLFastFit<5><<<numberOfBlocks/4, blockSize, 0, stream>>>(tuples_,
                                                        tupleMultiplicity_,
                                                        hv,
                                                        tkidGPU.get(),
@@ -97,7 +97,7 @@ void HelixFitOnGPU::launchBrokenLineKernels(HitsView const *hv,
                                                        offset);
       cudaCheck(cudaGetLastError());
 
-      kernel_BLFit<5><<<1, blockSize, 0, stream>>>(tupleMultiplicity_,
+      kernel_BLFit<5><<<numberOfBlocks/4, blockSize, 0, stream>>>(tupleMultiplicity_,
                                                    bField_,
                                                    outputSoa_,
                                                    tkidGPU.get(),
@@ -106,7 +106,7 @@ void HelixFitOnGPU::launchBrokenLineKernels(HitsView const *hv,
                                                    fast_fit_resultsGPU.get());
       cudaCheck(cudaGetLastError());
       // fit sexta and above (as 6)
-      kernel_BLFastFit<6><<<1, blockSize, 0, stream>>>(tuples_,
+      kernel_BLFastFit<6><<<4, blockSize, 0, stream>>>(tuples_,
                                                        tupleMultiplicity_,
                                                        hv,
                                                        tkidGPU.get(),
@@ -118,7 +118,7 @@ void HelixFitOnGPU::launchBrokenLineKernels(HitsView const *hv,
                                                        offset);
       cudaCheck(cudaGetLastError());
 
-      kernel_BLFit<6><<<1, blockSize, 0, stream>>>(tupleMultiplicity_,
+      kernel_BLFit<6><<<4, blockSize, 0, stream>>>(tupleMultiplicity_,
                                                    bField_,
                                                    outputSoa_,
                                                    tkidGPU.get(),

--- a/RecoPixelVertexing/PixelTriplets/plugins/BrokenLineFitOnGPU.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/BrokenLineFitOnGPU.cu
@@ -50,12 +50,12 @@ void HelixFitOnGPU::launchBrokenLineKernels(HitsView const *hv,
     cudaCheck(cudaGetLastError());
 
     if (fit5as4_) {
-      // fit penta (only first 4)
-      kernel_BLFastFit<4><<<numberOfBlocks / 4, blockSize, 0, stream>>>(
+      // fit penta and sexta (only first 4, FIXME needs to load one per layer)
+      kernel_BLFastFit<4><<<1, blockSize, 0, stream>>>(
           tuples_, tupleMultiplicity_, hv, hitsGPU_.get(), hits_geGPU_.get(), fast_fit_resultsGPU_.get(), 5, offset);
       cudaCheck(cudaGetLastError());
 
-      kernel_BLFit<4><<<numberOfBlocks / 4, blockSize, 0, stream>>>(tupleMultiplicity_,
+      kernel_BLFit<4><<<1, blockSize, 0, stream>>>(tupleMultiplicity_,
                                                                     bField_,
                                                                     outputSoa_,
                                                                     hitsGPU_.get(),
@@ -64,13 +64,28 @@ void HelixFitOnGPU::launchBrokenLineKernels(HitsView const *hv,
                                                                     5,
                                                                     offset);
       cudaCheck(cudaGetLastError());
+      kernel_BLFastFit<4><<<1, blockSize, 0, stream>>>(
+          tuples_, tupleMultiplicity_, hv, hitsGPU_.get(), hits_geGPU_.get(), fast_fit_resultsGPU_.get(), 6, offset);
+      cudaCheck(cudaGetLastError());
+
+      kernel_BLFit<4><<<1, blockSize, 0, stream>>>(tupleMultiplicity_,
+                                                                    bField_,
+                                                                    outputSoa_,
+                                                                    hitsGPU_.get(),
+                                                                    hits_geGPU_.get(),
+                                                                    fast_fit_resultsGPU_.get(),
+                                                                    6,
+                                                                    offset);
+      cudaCheck(cudaGetLastError());
+
+
     } else {
       // fit penta (all 5)
-      kernel_BLFastFit<5><<<numberOfBlocks / 4, blockSize, 0, stream>>>(
+      kernel_BLFastFit<5><<<1, blockSize, 0, stream>>>(
           tuples_, tupleMultiplicity_, hv, hitsGPU_.get(), hits_geGPU_.get(), fast_fit_resultsGPU_.get(), 5, offset);
       cudaCheck(cudaGetLastError());
 
-      kernel_BLFit<5><<<numberOfBlocks / 4, blockSize, 0, stream>>>(tupleMultiplicity_,
+      kernel_BLFit<5><<<1, blockSize, 0, stream>>>(tupleMultiplicity_,
                                                                     bField_,
                                                                     outputSoa_,
                                                                     hitsGPU_.get(),
@@ -79,6 +94,21 @@ void HelixFitOnGPU::launchBrokenLineKernels(HitsView const *hv,
                                                                     5,
                                                                     offset);
       cudaCheck(cudaGetLastError());
+      // fit sexta (all 6)
+      kernel_BLFastFit<6><<<1, blockSize, 0, stream>>>(
+          tuples_, tupleMultiplicity_, hv, hitsGPU_.get(), hits_geGPU_.get(), fast_fit_resultsGPU_.get(), 6, offset);
+      cudaCheck(cudaGetLastError());
+
+      kernel_BLFit<6><<<1, blockSize, 0, stream>>>(tupleMultiplicity_,
+                                                                    bField_,
+                                                                    outputSoa_,
+                                                                    hitsGPU_.get(),
+                                                                    hits_geGPU_.get(),
+                                                                    fast_fit_resultsGPU_.get(),
+                                                                    6,
+                                                                    offset);
+      cudaCheck(cudaGetLastError());
+
     }
 
   }  // loop on concurrent fits

--- a/RecoPixelVertexing/PixelTriplets/plugins/BrokenLineFitOnGPU.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/BrokenLineFitOnGPU.cu
@@ -42,7 +42,7 @@ void HelixFitOnGPU::launchBrokenLineKernels(HitsView const *hv,
                                                               fast_fit_resultsGPU.get());
     cudaCheck(cudaGetLastError());
 
-    if (fit5as4_) {
+    if (fitNas4_) {
       // fit all as 4
       kernel_BLFastFit<4><<<numberOfBlocks / 4, blockSize, 0, stream>>>(tuples_,
                                                                         tupleMultiplicity_,

--- a/RecoPixelVertexing/PixelTriplets/plugins/BrokenLineFitOnGPU.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/BrokenLineFitOnGPU.h
@@ -101,13 +101,10 @@ __global__ void kernel_BLFastFit(Tuples const *__restrict__ foundNtuplets,
 
     float incr = std::max(1.f, float(nHits) / float(hitsInFit));
     float n = 0;
-    // int jold = -1;
     for (uint32_t i = 0; i < hitsInFit; ++i) {
       int j = int(n + 0.5f);  // round
       if (hitsInFit - 1 == i)
         j = nHits - 1;  // force last hit to ensure max lever arm.
-      // assert(j>jold);
-      // jold=j;
       assert(j < int(nHits));
       n += incr;
       auto hit = hitId[j];

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAConstants.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAConstants.h
@@ -44,6 +44,7 @@ namespace caConstants {
   constexpr uint32_t maxNumberOfLayerPairs = 20;
   constexpr uint32_t maxNumberOfLayers = 10;
   constexpr uint32_t maxTuples = maxNumberOfTuples;
+  constexpr int32_t maxHitsOnTrack = 10;
 
   // Modules constants
   constexpr uint32_t max_ladder_bpx0 = 12;
@@ -76,7 +77,7 @@ namespace caConstants {
   using OuterHitOfCellContainer = cms::cuda::VecArray<uint32_t, maxCellsPerHit>;
   using TuplesContainer = cms::cuda::OneToManyAssoc<hindex_type, maxTuples, 5 * maxTuples>;
   using HitToTuple = cms::cuda::OneToManyAssoc<tindex_type, -1, 4 * maxTuples>;  // 3.5 should be enough
-  using TupleMultiplicity = cms::cuda::OneToManyAssoc<tindex_type, 10, maxTuples>;
+  using TupleMultiplicity = cms::cuda::OneToManyAssoc<tindex_type, maxHitsOnTrack + 1, maxTuples>;
 
   struct OuterHitOfCell {
     OuterHitOfCellContainer* container;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAConstants.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAConstants.h
@@ -76,7 +76,7 @@ namespace caConstants {
   using OuterHitOfCellContainer = cms::cuda::VecArray<uint32_t, maxCellsPerHit>;
   using TuplesContainer = cms::cuda::OneToManyAssoc<hindex_type, maxTuples, 5 * maxTuples>;
   using HitToTuple = cms::cuda::OneToManyAssoc<tindex_type, -1, 4 * maxTuples>;  // 3.5 should be enough
-  using TupleMultiplicity = cms::cuda::OneToManyAssoc<tindex_type, 8, maxTuples>;
+  using TupleMultiplicity = cms::cuda::OneToManyAssoc<tindex_type, 10, maxTuples>;
 
   struct OuterHitOfCell {
     OuterHitOfCellContainer* container;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cc
@@ -129,6 +129,7 @@ void CAHitNtupletGeneratorKernelsCPU::launchKernels(HitsOnCPU const &hh, TkSoA *
   cms::cuda::finalizeBulk(device_hitTuple_apc_, tuples_d);
 
   kernel_fillHitDetIndices(tuples_d, hh.view(), detId_d);
+  kernel_fillNLayers(tracks_d);
 
   // remove duplicates (tracks that share a doublet)
   kernel_earlyDuplicateRemover(device_theCells_.get(), device_nCells_, tracks_d, quality_d, params_.dupPassThrough_);

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cc
@@ -124,7 +124,7 @@ void CAHitNtupletGeneratorKernelsCPU::launchKernels(HitsOnCPU const &hh, TkSoA *
                        quality_d,
                        params_.minHitsPerNtuplet_);
   if (params_.doStats_)
-    kernel_mark_used(hh.view(), device_theCells_.get(), device_nCells_);
+    kernel_mark_used(device_theCells_.get(), device_nCells_);
 
   cms::cuda::finalizeBulk(device_hitTuple_apc_, tuples_d);
 
@@ -159,7 +159,7 @@ void CAHitNtupletGeneratorKernelsCPU::classifyTuples(HitsOnCPU const &hh, TkSoA 
   }
 
   // remove duplicates (tracks that share a doublet)
-  kernel_fastDuplicateRemover(device_theCells_.get(), device_nCells_, tuples_d, tracks_d, params_.dupPassThrough_);
+  kernel_fastDuplicateRemover(device_theCells_.get(), device_nCells_, tracks_d, params_.dupPassThrough_);
 
   // fill hit->track "map"
   if (params_.doSharedHitCut_ || params_.doStats_) {
@@ -170,37 +170,21 @@ void CAHitNtupletGeneratorKernelsCPU::classifyTuples(HitsOnCPU const &hh, TkSoA 
 
   // remove duplicates (tracks that share at least one hit)
   if (params_.doSharedHitCut_) {
-    kernel_rejectDuplicate(hh.view(),
-                           tuples_d,
-                           tracks_d,
-                           quality_d,
-                           params_.minHitsForSharingCut_,
-                           params_.dupPassThrough_,
-                           device_hitToTuple_.get());
+    kernel_rejectDuplicate(
+        tracks_d, quality_d, params_.minHitsForSharingCut_, params_.dupPassThrough_, device_hitToTuple_.get());
 
     kernel_sharedHitCleaner(hh.view(),
-                            tuples_d,
                             tracks_d,
                             quality_d,
                             params_.minHitsForSharingCut_,
                             params_.dupPassThrough_,
                             device_hitToTuple_.get());
     if (params_.useSimpleTripletCleaner_) {
-      kernel_simpleTripletCleaner(hh.view(),
-                                  tuples_d,
-                                  tracks_d,
-                                  quality_d,
-                                  params_.minHitsForSharingCut_,
-                                  params_.dupPassThrough_,
-                                  device_hitToTuple_.get());
+      kernel_simpleTripletCleaner(
+          tracks_d, quality_d, params_.minHitsForSharingCut_, params_.dupPassThrough_, device_hitToTuple_.get());
     } else {
-      kernel_tripletCleaner(hh.view(),
-                            tuples_d,
-                            tracks_d,
-                            quality_d,
-                            params_.minHitsForSharingCut_,
-                            params_.dupPassThrough_,
-                            device_hitToTuple_.get());
+      kernel_tripletCleaner(
+          tracks_d, quality_d, params_.minHitsForSharingCut_, params_.dupPassThrough_, device_hitToTuple_.get());
     }
   }
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cc
@@ -128,8 +128,7 @@ void CAHitNtupletGeneratorKernelsCPU::launchKernels(HitsOnCPU const &hh, TkSoA *
 
   cms::cuda::finalizeBulk(device_hitTuple_apc_, tuples_d);
 
-  kernel_fillHitDetIndices(
-      tuples_d, hh.view(), detId_d);
+  kernel_fillHitDetIndices(tuples_d, hh.view(), detId_d);
 
   // remove duplicates (tracks that share a doublet)
   kernel_earlyDuplicateRemover(device_theCells_.get(), device_nCells_, tracks_d, quality_d, params_.dupPassThrough_);

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
@@ -88,10 +88,8 @@ void CAHitNtupletGeneratorKernelsGPU::launchKernels(HitsOnCPU const &hh, TkSoA *
   numberOfBlocks = (HitContainer::ctNOnes() + blockSize - 1) / blockSize;
   cms::cuda::finalizeBulk<<<numberOfBlocks, blockSize, 0, cudaStream>>>(device_hitTuple_apc_, tuples_d);
 
-   kernel_fillHitDetIndices<<<numberOfBlocks, blockSize, 0, cudaStream>>>(
-      tuples_d, hh.view(), detId_d);
+  kernel_fillHitDetIndices<<<numberOfBlocks, blockSize, 0, cudaStream>>>(tuples_d, hh.view(), detId_d);
   cudaCheck(cudaGetLastError());
-
 
   // remove duplicates (tracks that share a doublet)
   numberOfBlocks = nDoubletBlocks(blockSize);

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
@@ -90,6 +90,8 @@ void CAHitNtupletGeneratorKernelsGPU::launchKernels(HitsOnCPU const &hh, TkSoA *
 
   kernel_fillHitDetIndices<<<numberOfBlocks, blockSize, 0, cudaStream>>>(tuples_d, hh.view(), detId_d);
   cudaCheck(cudaGetLastError());
+  kernel_fillNLayers<<<numberOfBlocks, blockSize, 0, cudaStream>>>(tracks_d);
+  cudaCheck(cudaGetLastError());
 
   // remove duplicates (tracks that share a doublet)
   numberOfBlocks = nDoubletBlocks(blockSize);

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.h
@@ -59,7 +59,7 @@ namespace cAHitNtupletGenerator {
            uint32_t maxNumberOfDoublets,
            uint16_t minHitsForSharingCuts,
            bool useRiemannFit,
-           bool fit5as4,
+           bool fitNas4,
            bool includeJumpingForwardDoublets,
            bool earlyFishbone,
            bool lateFishbone,
@@ -84,7 +84,7 @@ namespace cAHitNtupletGenerator {
           maxNumberOfDoublets_(maxNumberOfDoublets),
           minHitsForSharingCut_(minHitsForSharingCuts),
           useRiemannFit_(useRiemannFit),
-          fit5as4_(fit5as4),
+          fitNas4_(fitNas4),
           includeJumpingForwardDoublets_(includeJumpingForwardDoublets),
           earlyFishbone_(earlyFishbone),
           lateFishbone_(lateFishbone),
@@ -109,7 +109,7 @@ namespace cAHitNtupletGenerator {
     const uint32_t maxNumberOfDoublets_;
     const uint16_t minHitsForSharingCut_;
     const bool useRiemannFit_;
-    const bool fit5as4_;
+    const bool fitNas4_;
     const bool includeJumpingForwardDoublets_;
     const bool earlyFishbone_;
     const bool lateFishbone_;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.h
@@ -185,8 +185,6 @@ public:
 
   void classifyTuples(HitsOnCPU const& hh, TkSoA* tuples_d, cudaStream_t cudaStream);
 
-  void fillHitDetIndices(HitsView const* hv, TkSoA* tuples_d, cudaStream_t cudaStream);
-
   void buildDoublets(HitsOnCPU const& hh, cudaStream_t stream);
   void allocateOnGPU(int32_t nHits, cudaStream_t stream);
   void cleanup(cudaStream_t cudaStream);

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsImpl.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsImpl.h
@@ -159,10 +159,12 @@ __global__ void kernel_earlyDuplicateRemover(GPUCACell const *cells,
 
     // find maxNl
     for (auto it : thisCell.tracks()) {
+      // if (tracks.nHits(it)==3) continue;
       auto nl = tracks.nLayers(it);
       maxNl = std::max(nl, maxNl);
     }
 
+    // if (maxNl<4) continue;
     // quad pass through (leave it her for tests)
     //  maxNl = std::min(4, maxNl);
 
@@ -729,6 +731,7 @@ __global__ void kernel_sharedHitCleaner(TrackingRecHit2DSOAView const *__restric
     for (auto it = hitToTuple.begin(idx); it != hitToTuple.end(idx); ++it) {
       if (quality[*it] < longTqual)
         continue;
+      // if (tracks.nHits(*it)==3) continue;
       auto nl = tracks.nLayers(*it);
       maxNl = std::max(nl, maxNl);
     }

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsImpl.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsImpl.h
@@ -390,7 +390,7 @@ __global__ void kernel_countMultiplicity(HitContainer const *__restrict__ foundN
     if (quality[it] == pixelTrack::Quality::edup)
       continue;
     assert(quality[it] == pixelTrack::Quality::bad);
-    if (nhits > 5)
+    if (nhits > 7)
       printf("wrong mult %d %d\n", it, nhits);
     assert(nhits < 8);
     tupleMultiplicity->count(nhits);
@@ -408,7 +408,7 @@ __global__ void kernel_fillMultiplicity(HitContainer const *__restrict__ foundNt
     if (quality[it] == pixelTrack::Quality::edup)
       continue;
     assert(quality[it] == pixelTrack::Quality::bad);
-    if (nhits > 5)
+    if (nhits > 7)
       printf("wrong mult %d %d\n", it, nhits);
     assert(nhits < 8);
     tupleMultiplicity->fill(nhits, it);

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsImpl.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsImpl.h
@@ -152,14 +152,11 @@ __global__ void kernel_earlyDuplicateRemover(GPUCACell const *cells,
 
     if (thisCell.tracks().size() < 2)
       continue;
-    //if (0==thisCell.theUsed) continue;
-    // if (thisCell.theDoubletId < 0) continue;
 
     int8_t maxNl = 0;
 
     // find maxNl
     for (auto it : thisCell.tracks()) {
-      // if (tracks.nHits(it)==3) continue;
       auto nl = tracks.nLayers(it);
       maxNl = std::max(nl, maxNl);
     }
@@ -191,7 +188,6 @@ __global__ void kernel_fastDuplicateRemover(GPUCACell const *__restrict__ cells,
     auto const &thisCell = cells[idx];
     if (thisCell.tracks().size() < 2)
       continue;
-    // if (thisCell.theDoubletId < 0) continue;
 
     float mc = maxScore;
     uint16_t im = tkNotFound;
@@ -694,7 +690,6 @@ __global__ void kernel_rejectDuplicate(TkSoA const *__restrict__ ptracks,
         if ((opi - opj) * (opi - opj) > dop)
           continue;
         auto nlj = tracks.nLayers(jt);
-        ;
         if (nlj < nli || (nlj == nli && (qj < qi || (qj == qi && score(it, nli) < score(jt, nlj)))))
           quality[jt] = reject;
         else {

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsImpl.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsImpl.h
@@ -143,8 +143,7 @@ __global__ void kernel_earlyDuplicateRemover(GPUCACell const *cells,
   // quality to mark rejected
   constexpr auto reject = pixelTrack::Quality::edup;  /// cannot be loose
 
-  auto const& tracks = *ptracks;
-
+  auto const &tracks = *ptracks;
 
   assert(nCells);
   auto first = threadIdx.x + blockIdx.x * blockDim.x;
@@ -687,7 +686,8 @@ __global__ void kernel_rejectDuplicate(TrackingRecHit2DSOAView const *__restrict
         auto dop = nSigma2 * (tracks.stateAtBS.covariance(jt)(9) + e2opi);
         if ((opi - opj) * (opi - opj) > dop)
           continue;
-        auto nlj = tracks.nLayers(jt);;
+        auto nlj = tracks.nLayers(jt);
+        ;
         if (nlj < nli || (nlj == nli && (qj < qi || (qj == qi && score(it, nli) < score(jt, nlj)))))
           quality[jt] = reject;
         else {
@@ -783,7 +783,8 @@ __global__ void kernel_tripletCleaner(TrackingRecHit2DSOAView const *__restrict_
       if (quality[*it] <= good)
         continue;
       onlyTriplets &= tracks.isTriplet(*it);
-      if (!onlyTriplets) break;
+      if (!onlyTriplets)
+        break;
     }
 
     // only triplets

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorOnGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorOnGPU.cc
@@ -194,7 +194,6 @@ PixelTrackHeterogeneous CAHitNtupletGeneratorOnGPU::makeTuplesAsync(TrackingRecH
 
   kernels.buildDoublets(hits_d, stream);
   kernels.launchKernels(hits_d, soa, stream);
-  kernels.fillHitDetIndices(hits_d.view(), soa, stream);  // in principle needed only if Hits not "available"
 
   HelixFitOnGPU fitter(bfield, m_params.fit5as4_);
   fitter.allocateOnGPU(&(soa->hitIndices), kernels.tupleMultiplicity(), soa);
@@ -226,7 +225,6 @@ PixelTrackHeterogeneous CAHitNtupletGeneratorOnGPU::makeTuples(TrackingRecHit2DC
 
   kernels.buildDoublets(hits_d, nullptr);
   kernels.launchKernels(hits_d, soa, nullptr);
-  kernels.fillHitDetIndices(hits_d.view(), soa, nullptr);  // in principle needed only if Hits not "available"
 
   if (0 == hits_d.nHits())
     return tracks;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorOnGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorOnGPU.cc
@@ -63,7 +63,7 @@ CAHitNtupletGeneratorOnGPU::CAHitNtupletGeneratorOnGPU(const edm::ParameterSet& 
                cfg.getParameter<unsigned int>("maxNumberOfDoublets"),
                cfg.getParameter<unsigned int>("minHitsForSharingCut"),
                cfg.getParameter<bool>("useRiemannFit"),
-               cfg.getParameter<bool>("fit5as4"),
+               cfg.getParameter<bool>("fitNas4"),
                cfg.getParameter<bool>("includeJumpingForwardDoublets"),
                cfg.getParameter<bool>("earlyFishbone"),
                cfg.getParameter<bool>("lateFishbone"),
@@ -152,8 +152,7 @@ void CAHitNtupletGeneratorOnGPU::fillDescriptions(edm::ParameterSetDescription& 
   desc.add<unsigned int>("minHitsForSharingCut", 10)
       ->setComment("Maximum number of hits in a tuple to clean also if the shared hit is on bpx1");
   desc.add<bool>("includeJumpingForwardDoublets", false);
-  desc.add<bool>("fit5as4", false)->setComment("fit only 4 hits out of N");
-  ;
+  desc.add<bool>("fitNas4", false)->setComment("fit only 4 hits out of N");
   desc.add<bool>("doClusterCut", true);
   desc.add<bool>("doZ0Cut", true);
   desc.add<bool>("doPtCut", true);
@@ -196,7 +195,7 @@ PixelTrackHeterogeneous CAHitNtupletGeneratorOnGPU::makeTuplesAsync(TrackingRecH
   kernels.buildDoublets(hits_d, stream);
   kernels.launchKernels(hits_d, soa, stream);
 
-  HelixFitOnGPU fitter(bfield, m_params.fit5as4_);
+  HelixFitOnGPU fitter(bfield, m_params.fitNas4_);
   fitter.allocateOnGPU(&(soa->hitIndices), kernels.tupleMultiplicity(), soa);
   if (m_params.useRiemannFit_) {
     fitter.launchRiemannKernels(hits_d.view(), hits_d.nHits(), caConstants::maxNumberOfQuadruplets, stream);
@@ -231,7 +230,7 @@ PixelTrackHeterogeneous CAHitNtupletGeneratorOnGPU::makeTuples(TrackingRecHit2DC
     return tracks;
 
   // now fit
-  HelixFitOnGPU fitter(bfield, m_params.fit5as4_);
+  HelixFitOnGPU fitter(bfield, m_params.fitNas4_);
   fitter.allocateOnGPU(&(soa->hitIndices), kernels.tupleMultiplicity(), soa);
 
   if (m_params.useRiemannFit_) {

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorOnGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorOnGPU.cc
@@ -152,7 +152,8 @@ void CAHitNtupletGeneratorOnGPU::fillDescriptions(edm::ParameterSetDescription& 
   desc.add<unsigned int>("minHitsForSharingCut", 10)
       ->setComment("Maximum number of hits in a tuple to clean also if the shared hit is on bpx1");
   desc.add<bool>("includeJumpingForwardDoublets", false);
-  desc.add<bool>("fit5as4", false)->setComment("fit only 4 hits out of N");;
+  desc.add<bool>("fit5as4", false)->setComment("fit only 4 hits out of N");
+  ;
   desc.add<bool>("doClusterCut", true);
   desc.add<bool>("doZ0Cut", true);
   desc.add<bool>("doPtCut", true);

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorOnGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorOnGPU.cc
@@ -149,17 +149,17 @@ void CAHitNtupletGeneratorOnGPU::fillDescriptions(edm::ParameterSetDescription& 
   desc.add<bool>("fillStatistics", false);
   desc.add<unsigned int>("minHitsPerNtuplet", 4);
   desc.add<unsigned int>("maxNumberOfDoublets", caConstants::maxNumberOfDoublets);
-  desc.add<unsigned int>("minHitsForSharingCut", 5)
+  desc.add<unsigned int>("minHitsForSharingCut", 10)
       ->setComment("Maximum number of hits in a tuple to clean also if the shared hit is on bpx1");
   desc.add<bool>("includeJumpingForwardDoublets", false);
-  desc.add<bool>("fit5as4", true);
+  desc.add<bool>("fit5as4", false)->setComment("fit only 4 hits out of N");;
   desc.add<bool>("doClusterCut", true);
   desc.add<bool>("doZ0Cut", true);
   desc.add<bool>("doPtCut", true);
   desc.add<bool>("useRiemannFit", false)->setComment("true for Riemann, false for BrokenLine");
   desc.add<bool>("doSharedHitCut", true)->setComment("Sharing hit nTuples cleaning");
   desc.add<bool>("dupPassThrough", false)->setComment("Do not reject duplicate");
-  desc.add<bool>("useSimpleTripletCleaner", false)->setComment("use alternate implementation");
+  desc.add<bool>("useSimpleTripletCleaner", true)->setComment("use alternate implementation");
 
   edm::ParameterSetDescription trackQualityCuts;
   trackQualityCuts.add<double>("chi2MaxPt", 10.)->setComment("max pT used to determine the pT-dependent chi2 cut");

--- a/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
@@ -38,20 +38,20 @@ public:
   using Quality = pixelTrack::Quality;
   static constexpr auto bad = pixelTrack::Quality::bad;
 
+  enum class StatusBit : uint16_t { used = 1, killed = 1 << 15 };
+
   GPUCACell() = default;
 
   __device__ __forceinline__ void init(CellNeighborsVector& cellNeighbors,
                                        CellTracksVector& cellTracks,
                                        Hits const& hh,
                                        int layerPairId,
-                                       int doubletId,
                                        hindex_type innerHitId,
                                        hindex_type outerHitId) {
     theInnerHitId = innerHitId;
     theOuterHitId = outerHitId;
-    theDoubletId_ = doubletId;
     theLayerPairId_ = layerPairId;
-    theUsed_ = 0;
+    theStatus_ = 0;
     theFishboneId = std::numeric_limits<hindex_type>::max();
 
     // optimization that depends on access pattern
@@ -131,8 +131,7 @@ public:
   constexpr unsigned int outer_hit_id() const { return theOuterHitId; }
 
   __device__ void print_cell() const {
-    printf("printing cell: %d, on layerPair: %d, innerHitId: %d, outerHitId: %d \n",
-           theDoubletId_,
+    printf("printing cell: on layerPair: %d, innerHitId: %d, outerHitId: %d \n",
            theLayerPairId_,
            theInnerHitId,
            theOuterHitId);
@@ -288,12 +287,13 @@ public:
     // the ntuplets is then saved if the number of hits it contains is greater
     // than a threshold
 
-    tmpNtuplet.push_back_unsafe(theDoubletId_);
+    auto doubletId = this - cells;
+    tmpNtuplet.push_back_unsafe(doubletId);
     assert(tmpNtuplet.size() <= 4);
 
     bool last = true;
     for (unsigned int otherCell : outerNeighbors()) {
-      if (cells[otherCell].theDoubletId_ < 0)
+      if (cells[otherCell].isKilled())
         continue;  // killed by earlyFishbone
       last = false;
       cells[otherCell].find_ntuplets<DEPTH - 1>(
@@ -334,13 +334,13 @@ public:
   }
 
   // Cell status management
-  __device__ __forceinline__ void kill() { theDoubletId_ = -1; }
-  __device__ __forceinline__ bool isKilled() const { return theDoubletId_ < 0; }
+  __device__ __forceinline__ void kill() { theStatus_ |= uint16_t(StatusBit::killed); }
+  __device__ __forceinline__ bool isKilled() const { return theStatus_ & uint16_t(StatusBit::killed); }
 
   __device__ __forceinline__ int16_t layerPairId() const { return theLayerPairId_; }
 
-  __device__ __forceinline__ bool unused() const { return 0 == theUsed_; }
-  __device__ __forceinline__ void setUsedBit(uint16_t bit) { theUsed_ |= bit; }
+  __device__ __forceinline__ bool unused() const { return 0 == (3 & theStatus_); }
+  __device__ __forceinline__ void setUsedBit(uint16_t mask) { theStatus_ |= mask; }
 
   __device__ __forceinline__ void setFishbone(hindex_type id) { theFishboneId = id; }
   __device__ __forceinline__ auto fishboneId() const { return theFishboneId; }
@@ -352,9 +352,8 @@ private:
   CellNeighbors* theOuterNeighbors;
   CellTracks* theTracks;
 
-  int32_t theDoubletId_;
   int16_t theLayerPairId_;
-  uint16_t theUsed_;  // tbd
+  uint16_t theStatus_;  // tbd
 
   float theInnerZ;
   float theInnerR;

--- a/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
@@ -309,7 +309,7 @@ public:
         {
           hindex_type hits[8];
           auto nh = 0U;
-          constexpr int maxFB = 0; // 2;  // for the time being let's limit this
+          constexpr int maxFB = 2;  // for the time being let's limit this
           int nfb = 0;
           for (auto c : tmpNtuplet) {
             hits[nh++] = cells[c].theInnerHitId;

--- a/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
@@ -339,7 +339,7 @@ public:
 
   __device__ __forceinline__ int16_t layerPairId() const { return theLayerPairId_; }
 
-  __device__ __forceinline__ bool unused() const { return 0 == (3 & theStatus_); }
+  __device__ __forceinline__ bool unused() const { return 0 == (uint16_t(StatusBit::kUsed) & theStatus_); }
   __device__ __forceinline__ void setStatusBits(StatusBit mask) { theStatus_ |= uint16_t(mask); }
 
   __device__ __forceinline__ void setFishbone(hindex_type id) { theFishboneId = id; }

--- a/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
@@ -309,7 +309,7 @@ public:
         {
           hindex_type hits[8];
           auto nh = 0U;
-          constexpr int maxFB = 2;  // for the time being let's limit this
+          constexpr int maxFB = 0; // 2;  // for the time being let's limit this
           int nfb = 0;
           for (auto c : tmpNtuplet) {
             hits[nh++] = cells[c].theInnerHitId;

--- a/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
@@ -309,18 +309,18 @@ public:
         {
           hindex_type hits[8];
           auto nh = 0U;
-          constexpr int maxFB = 2; // for the time being let's limit this
+          constexpr int maxFB = 2;  // for the time being let's limit this
           int nfb = 0;
           for (auto c : tmpNtuplet) {
             hits[nh++] = cells[c].theInnerHitId;
-            if (nfb<maxFB && cells[c].hasFishbone()) {
+            if (nfb < maxFB && cells[c].hasFishbone()) {
               ++nfb;
-              hits[nh++] = cells[c].theFishboneId; // fishbone hit is always outer than inner hit
+              hits[nh++] = cells[c].theFishboneId;  // fishbone hit is always outer than inner hit
             }
           }
-          assert(nh<8);
+          assert(nh < 8);
           hits[nh] = theOuterHitId;
-          auto it = foundNtuplets.bulkFill(apc, hits, nh+1);
+          auto it = foundNtuplets.bulkFill(apc, hits, nh + 1);
           if (it >= 0) {  // if negative is overflow....
             for (auto c : tmpNtuplet)
               cells[c].addTrack(it, cellTracks);

--- a/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
@@ -38,7 +38,7 @@ public:
   using Quality = pixelTrack::Quality;
   static constexpr auto bad = pixelTrack::Quality::bad;
 
-  enum class StatusBit : uint16_t { used = 1, killed = 1 << 15 };
+  enum class StatusBit : uint16_t { kUsed = 1, kInTrack = 2, kKilled = 1 << 15 };
 
   GPUCACell() = default;
 
@@ -318,7 +318,7 @@ public:
               hits[nh++] = cells[c].theFishboneId;  // fishbone hit is always outer than inner hit
             }
           }
-          assert(nh < 8);
+          assert(nh < caConstants::maxHitsOnTrack);
           hits[nh] = theOuterHitId;
           auto it = foundNtuplets.bulkFill(apc, hits, nh + 1);
           if (it >= 0) {  // if negative is overflow....
@@ -334,13 +334,13 @@ public:
   }
 
   // Cell status management
-  __device__ __forceinline__ void kill() { theStatus_ |= uint16_t(StatusBit::killed); }
-  __device__ __forceinline__ bool isKilled() const { return theStatus_ & uint16_t(StatusBit::killed); }
+  __device__ __forceinline__ void kill() { theStatus_ |= uint16_t(StatusBit::kKilled); }
+  __device__ __forceinline__ bool isKilled() const { return theStatus_ & uint16_t(StatusBit::kKilled); }
 
   __device__ __forceinline__ int16_t layerPairId() const { return theLayerPairId_; }
 
   __device__ __forceinline__ bool unused() const { return 0 == (3 & theStatus_); }
-  __device__ __forceinline__ void setUsedBit(uint16_t mask) { theStatus_ |= mask; }
+  __device__ __forceinline__ void setStatusBits(StatusBit mask) { theStatus_ |= uint16_t(mask); }
 
   __device__ __forceinline__ void setFishbone(hindex_type id) { theFishboneId = id; }
   __device__ __forceinline__ auto fishboneId() const { return theFishboneId; }

--- a/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
@@ -307,13 +307,20 @@ public:
             ((!startAt0) && hole0(hh, cells[tmpNtuplet[0]])))
 #endif
         {
-          hindex_type hits[6];
+          hindex_type hits[8];
           auto nh = 0U;
+          constexpr int maxFB = 2; // for the time being let's limit this
+          int nfb = 0;
           for (auto c : tmpNtuplet) {
             hits[nh++] = cells[c].theInnerHitId;
+            if (nfb<maxFB && cells[c].hasFishbone()) {
+              ++nfb;
+              hits[nh++] = cells[c].theFishboneId; // fishbone hit is always outer than inner hit
+            }
           }
+          assert(nh<8);
           hits[nh] = theOuterHitId;
-          auto it = foundNtuplets.bulkFill(apc, hits, tmpNtuplet.size() + 1);
+          auto it = foundNtuplets.bulkFill(apc, hits, nh+1);
           if (it >= 0) {  // if negative is overflow....
             for (auto c : tmpNtuplet)
               cells[c].addTrack(it, cellTracks);

--- a/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
@@ -52,6 +52,7 @@ public:
     theDoubletId_ = doubletId;
     theLayerPairId_ = layerPairId;
     theUsed_ = 0;
+    theFishboneId = std::numeric_limits<hindex_type>::max();
 
     // optimization that depends on access pattern
     theInnerZ = hh.zGlobal(innerHitId);
@@ -334,6 +335,12 @@ public:
   __device__ __forceinline__ bool unused() const { return 0 == theUsed_; }
   __device__ __forceinline__ void setUsedBit(uint16_t bit) { theUsed_ |= bit; }
 
+  __device__ __forceinline__ void setFishbone(hindex_type id) { theFishboneId = id; }
+  __device__ __forceinline__ auto fishboneId() const { return theFishboneId; }
+  __device__ __forceinline__ bool hasFishbone() const {
+    return theFishboneId != std::numeric_limits<hindex_type>::max();
+  }
+
 private:
   CellNeighbors* theOuterNeighbors;
   CellTracks* theTracks;
@@ -346,6 +353,7 @@ private:
   float theInnerR;
   hindex_type theInnerHitId;
   hindex_type theOuterHitId;
+  hindex_type theFishboneId;
 };
 
 template <>

--- a/RecoPixelVertexing/PixelTriplets/plugins/HelixFitOnGPU.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/HelixFitOnGPU.h
@@ -40,7 +40,7 @@ public:
 
   using TupleMultiplicity = caConstants::TupleMultiplicity;
 
-  explicit HelixFitOnGPU(float bf, bool fit5as4) : bField_(bf), fit5as4_(fit5as4) {}
+  explicit HelixFitOnGPU(float bf, bool fitNas4) : bField_(bf), fitNas4_(fitNas4) {}
   ~HelixFitOnGPU() { deallocateOnGPU(); }
 
   void setBField(double bField) { bField_ = bField; }
@@ -62,7 +62,7 @@ private:
   OutputSoA *outputSoa_;
   float bField_;
 
-  const bool fit5as4_;
+  const bool fitNas4_;
 };
 
 #endif  // RecoPixelVertexing_PixelTriplets_plugins_HelixFitOnGPU_h

--- a/RecoPixelVertexing/PixelTriplets/plugins/RiemannFitOnGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/RiemannFitOnGPU.cc
@@ -61,7 +61,7 @@ void HelixFitOnGPU::launchRiemannKernelsOnCPU(HitsView const *hv, uint32_t nhits
                       circle_fit_resultsGPU,
                       offset);
 
-    if (fit5as4_) {
+    if (fitNas4_) {
       // penta
       kernel_FastFit<4>(
           tuples_, tupleMultiplicity_, 5, hv, hitsGPU.get(), hits_geGPU.get(), fast_fit_resultsGPU.get(), offset);

--- a/RecoPixelVertexing/PixelTriplets/plugins/RiemannFitOnGPU.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/RiemannFitOnGPU.cu
@@ -74,7 +74,7 @@ void HelixFitOnGPU::launchRiemannKernels(HitsView const *hv,
                                                                     offset);
     cudaCheck(cudaGetLastError());
 
-    if (fit5as4_) {
+    if (fitNas4_) {
       // penta
       kernel_FastFit<4><<<numberOfBlocks / 4, blockSize, 0, stream>>>(
           tuples_, tupleMultiplicity_, 5, hv, hitsGPU.get(), hits_geGPU.get(), fast_fit_resultsGPU.get(), offset);

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuFishbone.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuFishbone.h
@@ -77,11 +77,12 @@ namespace gpuPixelDoublets {
           auto cos12 = x[ic] * x[jc] + y[ic] * y[jc] + z[ic] * z[jc];
           if (d[ic] != d[jc] && cos12 * cos12 >= 0.99999f * n[ic] * n[jc]) {
             // alligned:  kill farthest (prefer consecutive layers)
-            // if same layer prefer farthest (longer level arm)
+            // if same layer prefer farthest (longer level arm) and make space for intermediate hit
             bool sameLayer = l[ic] == l[jc];
             if (n[ic] > n[jc]) {
               if (sameLayer) {
                 cj.kill();  // closest
+                ci.setFishbone(cj.inner_hit_id());
               } else {
                 ci.kill();  // farthest
                 break;
@@ -91,6 +92,7 @@ namespace gpuPixelDoublets {
                 cj.kill();  // farthest
               } else {
                 ci.kill();  // closest
+                cj.setFishbone(ci.inner_hit_id());
                 break;
               }
             }

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoubletsAlgos.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoubletsAlgos.h
@@ -222,7 +222,7 @@ namespace gpuPixelDoublets {
             break;
           }  // move to SimpleVector??
           // int layerPairId, int doubletId, int innerHitId, int outerHitId)
-          cells[ind].init(*cellNeighbors, *cellTracks, hh, pairLayerId, ind, i, oi);
+          cells[ind].init(*cellNeighbors, *cellTracks, hh, pairLayerId, i, oi);
           isOuterHitOfCell[oi].push_back(ind);
 #ifdef GPU_DEBUG
           if (isOuterHitOfCell[oi].full())

--- a/RecoPixelVertexing/PixelVertexFinding/plugins/gpuVertexFinder.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/plugins/gpuVertexFinder.cc
@@ -34,7 +34,7 @@ namespace gpuVertexFinder {
       // initialize soa...
       soa->idv[idx] = -1;
 
-      if (nHits < 4)
+      if (tracks.isTriplet(idx))
         continue;  // no triplets
       if (quality[idx] < pixelTrack::Quality::highPurity)
         continue;

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -1000,10 +1000,10 @@ trackSelector = cms.EDFilter('TrackSelector',
                              cut = cms.string("")
 )
 
-cutstring = "numberOfValidHits == 3"
+cutstring = "hitPattern.trackerLayersWithMeasurement == 3"
 pixelTracks3hits = trackRefSelector.clone( cut = cutstring )
 
-cutstring = "numberOfValidHits >= 4"
+cutstring = "hitPattern.trackerLayersWithMeasurement >= 4"
 pixelTracks4hits = trackRefSelector.clone( cut = cutstring )
 
 cutstring = "pt > 0.9"
@@ -1014,7 +1014,7 @@ pixelTracksFromPV = generalTracksFromPV.clone(quality = "highPurity", ptMin = 0.
 #pixelTracksFromPVPt09 = generalTracksPt09.clone(quality = ["loose","tight","highPurity"], vertexTag = "pixelVertices", src = "pixelTracksFromPV")
 pixelTracksFromPVPt09 = pixelTracksFromPV.clone(ptMin = 0.9)
 
-cutstring = "numberOfValidHits >= 4"
+cutstring = "hitPattern.trackerLayersWithMeasurement >= 4"
 #pixelTracksFromPV4hits = trackRefSelector.clone( cut = cutstring, src = "pixelTracksFromPV" )
 pixelTracksFromPV4hits = pixelTracksFromPV.clone( numberOfValidPixelHits = 4 )
 
@@ -1124,7 +1124,7 @@ for key,value in quality.items():
     tracksPreValidationPixelTrackingOnly.add(locals()[label])
 #-----------         
     label = "pixelTracks4hits"+key
-    cutstring = "numberOfValidHits == 4 & qualityMask <= 7 & qualityMask >= " + str(qualityBit)
+    cutstring = "hitPattern.trackerLayersWithMeasurement >= 4 & qualityMask <= 7 & qualityMask >= " + str(qualityBit)
     locals()[label] = trackRefSelector.clone( cut = cutstring )
     tracksPreValidationPixelTrackingOnly.add(locals()[label])
     
@@ -1134,7 +1134,7 @@ for key,value in quality.items():
     tracksPreValidationPixelTrackingOnly.add(locals()[label])
 #--------    
     label = "pixelTracks3hits"+key
-    cutstring = "numberOfValidHits == 3 & qualityMask <= 7 & qualityMask >= " + str(qualityBit)
+    cutstring = "hitPattern.trackerLayersWithMeasurement == 3 & qualityMask <= 7 & qualityMask >= " + str(qualityBit)
     locals()[label] = trackRefSelector.clone( cut = cutstring )
     tracksPreValidationPixelTrackingOnly.add(locals()[label])
      


### PR DESCRIPTION
I eventually fully implemented the fishbone algorithm.
The main differences w/r/t previous code are

when the fishbone identifies 2 collinear doublets between the same layers it chooses the longest and store the intermediate hit
Those "new" hits are added to the track (max 2)
Fit is performed for all hits up to 6 (the hits are chosen to maximize lever arm)
all selections uses number of layers, not number of hits
from the MTV below one can observe that

efficiency is not affected: even improves
there is a clear reduction of fakes
resolution dramatically improves
vertexing is not affected
My conclusion is that Physics performance improved.

MTV
ttbar: http://innocent.home.cern.ch/innocent/RelVal/gpuMTV122fbnew/
single muon ideal: http://innocent.home.cern.ch/innocent/RelVal/SingleMuFlatIdeal_gpu122fbnew/

This PR focuses on Physics performance. Once settled, computational performance and code cleaning can be addressed in a purely technical PR.

expect regression!

p.s. Some technicality needed to be improve anyhow

Slides for TRK-POG in https://indico.cern.ch/event/1098365/#3-new-fishbone