### PR TITLE
TkDQM: Remove Phase0 pixelCertification module from sequences

### DIFF
--- a/DQM/SiPixelCommon/python/SiPixelOfflineDQM_client_cff.py
+++ b/DQM/SiPixelCommon/python/SiPixelOfflineDQM_client_cff.py
@@ -44,8 +44,7 @@ PixelOfflineDQMClient = cms.Sequence(sipixelEDAClient)
 PixelOfflineDQMClientWithDataCertification = cms.Sequence(sipixelQTester+
                                                           sipixelEDAClient+
                                                           sipixelDaqInfo+
-                                                          sipixelDcsInfo+
-                                                          sipixelCertification)
+                                                          sipixelDcsInfo)
 PixelOfflineDQMClientNoDataCertification = cms.Sequence(sipixelQTester+
                                                           sipixelEDAClient)
 PixelOfflineDQMClientNoDataCertification_cosmics = cms.Sequence(sipixelQTester+

--- a/DQM/SiPixelCommon/python/SiPixelP5DQM_client_cff.py
+++ b/DQM/SiPixelCommon/python/SiPixelP5DQM_client_cff.py
@@ -23,5 +23,4 @@ sipixelCertification = DQMEDHarvester("SiPixelCertification")
 PixelP5DQMClient = cms.Sequence(sipixelEDAClientP5)
 PixelP5DQMClientWithDataCertification = cms.Sequence(sipixelEDAClientP5+
                                                           sipixelDaqInfo+
-							  sipixelDcsInfo+
-							  sipixelCertification)
+							  sipixelDcsInfo)

--- a/DQMOffline/Configuration/python/DQMOffline_CRT_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_CRT_cff.py
@@ -14,7 +14,6 @@ from DQMOffline.EGamma.egammaDataCertification_cff import *
 from DQMOffline.Trigger.DQMOffline_Trigger_Cert_cff import *
 
 crt_dqmoffline = cms.Sequence( siStripCertificationInfo *
-                               sipixelCertification *
                                ecalCertification *
                                dtCertificationSummary *
                                rpcDataCertification *
@@ -25,8 +24,4 @@ crt_dqmoffline = cms.Sequence( siStripCertificationInfo *
                                egammaDataCertificationTask *
                                dqmOfflineTriggerCert )
 
-from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-phase1Pixel.toReplaceWith(crt_dqmoffline, crt_dqmoffline.copyAndExclude([ # FIXME
-#    dqmOfflineTriggerCert, # No HLT yet for 2017, so no need to run the DQM (avoiding excessive printouts)
-    sipixelCertification # segfaults with pixel harvesting plots missing
-]))
+

--- a/DQMOffline/Configuration/python/DQMOffline_Certification_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_Certification_cff.py
@@ -13,8 +13,7 @@ DQMCertTrackerStrip = cms.Sequence(siStripDaqInfo *
 				   siStripCertificationInfo)
 
 DQMCertTrackerPixel = cms.Sequence(sipixelDaqInfo *
-				   sipixelDcsInfo *
-				   sipixelCertification)
+				   sipixelDcsInfo)
 
 DQMCertTracking = cms.Sequence(trackingCertificationInfo) 
 
@@ -37,14 +36,6 @@ DQMCertCommon = cms.Sequence( DQMCertTrackerStrip *
 			      DQMCertTracking *
 			      DQMCertEGamma *
 			      DQMCertTrigger)
-
-from DQM.SiPixelPhase1Config.SiPixelPhase1OfflineDQM_harvesting_cff import *
-from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-
-phase1Pixel.toReplaceWith(DQMCertTrackerPixel,DQMCertTrackerPixel.copyAndExclude([ # FIXME
-    sipixelCertification # segfaults when included
-]))
-
 
 DQMCertCommonFakeHLT = cms.Sequence( DQMCertCommon )
 DQMCertCommonFakeHLT.remove( dqmOfflineTriggerCert )


### PR DESCRIPTION
#### PR description:
Removes ```pixelCertification``` module from relevant sequences. Fixes crashes as reported [here](https://github.com/cms-sw/cmssw/pull/36203#issuecomment-976311314).
#### PR validation:
Wf 136.73 runs.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
NA
