### PR TITLE
Use noRunLumiSort in non-NANO Merge jobs

### DIFF
--- a/Configuration/DataProcessing/python/Merge.py
+++ b/Configuration/DataProcessing/python/Merge.py
@@ -59,6 +59,8 @@ def mergeProcess(*inputFiles, **options):
             process.source.bypassVersionCheck = CfgTypes.untracked.bool(True)
         if dropDQM:
             process.source.inputCommands = CfgTypes.untracked.vstring('keep *','drop *_EDMtoMEConverter_*_*')
+        if not mergeNANO:
+            process.source.noRunLumiSort = CfgTypes.untracked.bool(True)
     process.source.fileNames = CfgTypes.untracked(CfgTypes.vstring())
     for entry in inputFiles:
         process.source.fileNames.append(str(entry))


### PR DESCRIPTION
#### PR description:

This PR enables `noRunLumiSort` (feature added in https://github.com/cms-sw/cmssw/pull/36026) in non-NANO Merge jobs. This mode should allow files produced by jobs using concurrent LuminosityBlocks be merged with fast cloning.

#### PR validation:

Unit tests run.