### PR TITLE
Read out the CSC cathode shower in TMB/OTMB (HadronicShowerTrigger-9)

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
@@ -33,6 +33,7 @@
 #include "DataFormats/CSCDigi/interface/CSCComparatorDigiCollection.h"
 #include "DataFormats/CSCDigi/interface/CSCCLCTDigi.h"
 #include "DataFormats/CSCDigi/interface/CSCCLCTPreTriggerDigi.h"
+#include "DataFormats/CSCDigi/interface/CSCShowerDigi.h"
 #include "L1Trigger/CSCTriggerPrimitives/interface/CSCBaseboard.h"
 #include "L1Trigger/CSCTriggerPrimitives/interface/LCTQualityControl.h"
 #include "L1Trigger/CSCTriggerPrimitives/interface/ComparatorCodeLUT.h"
@@ -89,12 +90,17 @@ public:
   unsigned getInTimeHMT() const { return inTimeHMT_; }
   unsigned getOutTimeHMT() const { return outTimeHMT_; }
 
+  /** Returns shower bits */
+  CSCShowerDigi readoutShower() const;
+
 protected:
   /** Best LCT in this chamber, as found by the processor. */
   CSCCLCTDigi bestCLCT[CSCConstants::MAX_CLCT_TBINS];
 
   /** Second best LCT in this chamber, as found by the processor. */
   CSCCLCTDigi secondCLCT[CSCConstants::MAX_CLCT_TBINS];
+
+  CSCShowerDigi shower_;
 
   /** Access routines to comparator digis. */
   bool getDigis(const CSCComparatorDigiCollection* compdc);

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCTriggerPrimitivesBuilder.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCTriggerPrimitivesBuilder.h
@@ -81,8 +81,9 @@ public:
              CSCCLCTPreTriggerCollection& oc_pretrig,
              CSCCorrelatedLCTDigiCollection& oc_lct,
              CSCCorrelatedLCTDigiCollection& oc_sorted_lct,
-             CSCShowerDigiCollection& oc_shower,
              CSCShowerDigiCollection& oc_shower_anode,
+             CSCShowerDigiCollection& oc_shower_cathode,
+             CSCShowerDigiCollection& oc_shower,
              GEMCoPadDigiCollection& oc_gemcopad);
 
   /** Max values of trigger labels for all CSCs; used to construct TMB

--- a/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.cc
+++ b/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.cc
@@ -169,6 +169,7 @@ CSCTriggerPrimitivesProducer::CSCTriggerPrimitivesProducer(const edm::ParameterS
   if (keepShowers_) {
     produces<CSCShowerDigiCollection>();
     produces<CSCShowerDigiCollection>("Anode");
+    produces<CSCShowerDigiCollection>("Cathode");
   }
   if (runILT_) {
     produces<GEMCoPadDigiCollection>();
@@ -268,6 +269,7 @@ void CSCTriggerPrimitivesProducer::produce(edm::Event& ev, const edm::EventSetup
   std::unique_ptr<CSCCorrelatedLCTDigiCollection> oc_sorted_lct(new CSCCorrelatedLCTDigiCollection);
   std::unique_ptr<CSCShowerDigiCollection> oc_shower(new CSCShowerDigiCollection);
   std::unique_ptr<CSCShowerDigiCollection> oc_shower_anode(new CSCShowerDigiCollection);
+  std::unique_ptr<CSCShowerDigiCollection> oc_shower_cathode(new CSCShowerDigiCollection);
   std::unique_ptr<GEMCoPadDigiCollection> oc_gemcopad(new GEMCoPadDigiCollection);
 
   if (!wireDigis.isValid()) {
@@ -296,8 +298,9 @@ void CSCTriggerPrimitivesProducer::produce(edm::Event& ev, const edm::EventSetup
                     *oc_pretrig,
                     *oc_lct,
                     *oc_sorted_lct,
-                    *oc_shower,
                     *oc_shower_anode,
+                    *oc_shower_cathode,
+                    *oc_shower,
                     *oc_gemcopad);
     if (!checkBadChambers_)
       delete temp;
@@ -318,6 +321,7 @@ void CSCTriggerPrimitivesProducer::produce(edm::Event& ev, const edm::EventSetup
   if (keepShowers_) {
     ev.put(std::move(oc_shower));
     ev.put(std::move(oc_shower_anode), "Anode");
+    ev.put(std::move(oc_shower_cathode), "Cathode");
   }
   // only put GEM copad collections in the event when the
   // integrated local triggers are running

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -1166,6 +1166,9 @@ CSCCLCTDigi CSCCathodeLCTProcessor::getSecondCLCT(int bx) const {
   return lct;
 }
 
+/** Returns shower bits */
+CSCShowerDigi CSCCathodeLCTProcessor::readoutShower() const { return shower_; }
+
 void CSCCathodeLCTProcessor::encodeHighMultiplicityBits(
     const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_HALF_STRIPS_RUN2_TRIGGER]) {
   inTimeHMT_ = 0;
@@ -1225,7 +1228,6 @@ void CSCCathodeLCTProcessor::encodeHighMultiplicityBits(
     }
   }
 
-  // no shower object is created here. that is done at a later stage
-  // in the motherboard, where the trigger decisions from
-  // anode hit counters and cathode hit counters are combined
+  // create a new object
+  shower_ = CSCShowerDigi(inTimeHMT_, false, theTrigChamber);
 }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc
@@ -154,8 +154,9 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
                                         CSCCLCTPreTriggerCollection& oc_pretrig,
                                         CSCCorrelatedLCTDigiCollection& oc_lct,
                                         CSCCorrelatedLCTDigiCollection& oc_sorted_lct,
-                                        CSCShowerDigiCollection& oc_shower,
                                         CSCShowerDigiCollection& oc_shower_anode,
+                                        CSCShowerDigiCollection& oc_shower_cathode,
+                                        CSCShowerDigiCollection& oc_shower,
                                         GEMCoPadDigiCollection& oc_gemcopad) {
   // CSC geometry.
   for (int endc = min_endcap; endc <= max_endcap; endc++) {
@@ -228,6 +229,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
             // showers
             const CSCShowerDigi& shower = tmb->readoutShower();
             const CSCShowerDigi& anodeShower = tmb->alctProc->readoutShower();
+            const CSCShowerDigi& cathodeShower = tmb->clctProc->readoutShower();
 
             put(alctV, oc_alct, detid, tmb->getCSCName() + " ALCT digi");
             put(clctV, oc_clct, detid, tmb->getCSCName() + " CLCT digi");
@@ -241,6 +243,8 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               oc_shower.insertDigi(detid, shower);
             if (anodeShower.isValid())
               oc_shower_anode.insertDigi(detid, anodeShower);
+            if (cathodeShower.isValid())
+              oc_shower_cathode.insertDigi(detid, cathodeShower);
 
             if (!(alctV.empty() && clctV.empty() && lctV.empty()) and infoV > 1) {
               LogTrace("L1CSCTrigger") << "CSCTriggerPrimitivesBuilder got results in " << detid;


### PR DESCRIPTION
#### PR description:

Read out the CSC cathode shower in TMB/OTMB. Previously the L1T CSC TP emulator read out the anode showers, and the combined showers. This minor update also adds the cathode showers formed in the CLCT logic on the TMB/OTMB.

#### PR validation:

Code compiles. Tested WF with 11634.0

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N.A.

@tahuang1991 @barvic @giovanni-mocellin @Nik-Menendez