### PR TITLE
Add LCT Type plot to the CSC TP validation in MuonCSCDigis

### DIFF
--- a/Validation/MuonCSCDigis/python/cscDigiValidation_cfi.py
+++ b/Validation/MuonCSCDigis/python/cscDigiValidation_cfi.py
@@ -48,14 +48,14 @@ cscDigiValidation = DQMEDAnalyzer(
     preclctMaxBin = cms.vdouble(7, 224, 16),
     lctVars = cms.vstring(
         # For Run-2 eras
-        "quality", "wiregroup", "halfstrip", "pattern", "bend", "bx",
+        "quality", "wiregroup", "halfstrip", "pattern", "bend", "bx", "type",
         # Added in Run-3 eras
         # The quartstripbit and eighthstripbit are left out to prevent
         # too many plots being created by the release validation
         "quartstrip", "eighthstrip", "run3pattern", "slope"),
-    lctNBin = cms.vuint32(16, 116, 224, 16, 2, 16, 448, 896, 5, 16),
-    lctMinBin = cms.vdouble(0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
-    lctMaxBin = cms.vdouble(16, 116, 224, 16, 2, 16, 448, 896, 5, 16),
+    lctNBin = cms.vuint32(16, 116, 224, 16, 2, 16, 8, 448, 896, 5, 16),
+    lctMinBin = cms.vdouble(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+    lctMaxBin = cms.vdouble(16, 116, 224, 16, 2, 16, 8, 448, 896, 5, 16),
     isRun3 = cms.bool(False),
 )
 

--- a/Validation/MuonCSCDigis/src/CSCCorrelatedLCTDigiValidation.cc
+++ b/Validation/MuonCSCDigis/src/CSCCorrelatedLCTDigiValidation.cc
@@ -47,7 +47,7 @@ void CSCCorrelatedLCTDigiValidation::bookHistograms(DQMStore::IBooker &iBooker) 
 
   // do not analyze Run-3 properties in Run-1 and Run-2 eras
   if (!isRun3_) {
-    lctVars_.resize(6);
+    lctVars_.resize(7);
   }
 
   // chamber type
@@ -58,7 +58,7 @@ void CSCCorrelatedLCTDigiValidation::bookHistograms(DQMStore::IBooker &iBooker) 
       // lct variable
       for (unsigned iVar = 0; iVar < lctVars_.size(); iVar++) {
         if (std::find(chambersRun3_.begin(), chambersRun3_.end(), iType) == chambersRun3_.end()) {
-          if (iVar > 5)
+          if (iVar > 6)
             continue;
         }
         const std::string key("lct_" + lctVars_[iVar]);
@@ -68,6 +68,18 @@ void CSCCorrelatedLCTDigiValidation::bookHistograms(DQMStore::IBooker &iBooker) 
         chamberHistos[iTypeCorrected][key] =
             iBooker.book1D(histName, histTitle, lctNBin_[iVar], lctMinBin_[iVar], lctMaxBin_[iVar]);
         chamberHistos[iTypeCorrected][key]->getTH1()->SetMinimum(0);
+        // set bin labels for the "type" plot. very useful in ME1/1 and ME2/1
+        // when the GEM-CSC ILTs will be running
+        if (lctVars_[iVar] == "type") {
+          chamberHistos[iTypeCorrected][key]->setBinLabel(1, "CLCTALCT", 1);
+          chamberHistos[iTypeCorrected][key]->setBinLabel(2, "ALCTCLCT", 1);
+          chamberHistos[iTypeCorrected][key]->setBinLabel(3, "ALCTCLCTGEM", 1);
+          chamberHistos[iTypeCorrected][key]->setBinLabel(4, "ALCTCLCT2GEM", 1);
+          chamberHistos[iTypeCorrected][key]->setBinLabel(5, "ALCT2GEM", 1);
+          chamberHistos[iTypeCorrected][key]->setBinLabel(6, "CLCT2GEM", 1);
+          chamberHistos[iTypeCorrected][key]->setBinLabel(7, "CLCTONLY", 1);
+          chamberHistos[iTypeCorrected][key]->setBinLabel(8, "ALCTONLY", 1);
+        }
       }
     }
   }
@@ -102,6 +114,7 @@ void CSCCorrelatedLCTDigiValidation::analyze(const edm::Event &e, const edm::Eve
         chamberHistos[typeCorrected]["lct_halfstrip"]->Fill(lct->getStrip());
         chamberHistos[typeCorrected]["lct_bend"]->Fill(lct->getBend());
         chamberHistos[typeCorrected]["lct_bx"]->Fill(lct->getBX());
+        chamberHistos[typeCorrected]["lct_type"]->Fill(lct->getType());
         if (isRun3_) {
           // ignore these fields for chambers that do not enable the Run-3 algorithm
           if (std::find(chambersRun3_.begin(), chambersRun3_.end(), chamberType - 2) == chambersRun3_.end())


### PR DESCRIPTION
#### PR description:

I noticed that the LCT type [1] should be added in the MuonCSCDigis package. It is very useful to debug the trigger for Run-3 and Phase-2. Typically the type should be `ALCTCLCT` for ME1/3, MEX/2, ME3/1 and ME4/1. Any other type points to a bug. For ME1/1 and ME2/1 the type can be `ALCTCLCT`, `ALCTCLCTGEM`, `ALCTCLCT2GEM`, `ALCT2GEM`, or `CLCT2GEM` - depending on which type is allowed by the TMB/OTMB simulation. `CLCTALCT`, `CLCTONLY`, and `ALCTONLY` should never appear in the simulation.

[1]
```c++
  enum Type {
    CLCTALCT,      // CLCT-centric
    ALCTCLCT,      // ALCT-centric
    ALCTCLCTGEM,   // ALCT-CLCT-1 GEM pad
    ALCTCLCT2GEM,  // ALCT-CLCT-2 GEM pads in coincidence
    ALCT2GEM,      // ALCT-2 GEM pads in coincidence
    CLCT2GEM,      // CLCT-2 GEM pads in coincidence
    CLCTONLY,      // Missing ALCT
    ALCTONLY       // Missing CLCT
  };
```
in https://github.com/cms-sw/cmssw/blob/master/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h

#### PR validation:

Code compiles. Tested WF 11634.0

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N.A.

@tahuang1991 @giovanni-mocellin