### PR TITLE
remove redundant line causing compilation warning in `RecoTracker/TrackProducer/test/BuildFile.xml`

### DIFF
--- a/RecoTracker/TrackProducer/test/BuildFile.xml
+++ b/RecoTracker/TrackProducer/test/BuildFile.xml
@@ -33,6 +33,5 @@
 <environment>
   <bin file="testMuonTrackRefitting.cpp">
     <flags TEST_RUNNER_ARGS="/bin/bash RecoTracker/TrackProducer/test testMuonTrackRefitting.sh"/>
-    <use name="FWCore/Utilities"/>
   </bin>
 </environment>


### PR DESCRIPTION
#### PR description:

In PR https://github.com/cms-sw/cmssw/pull/35620 the file `RecoTracker/TrackProducer/test/BuildFile.xml` was touched in order to introduce a unit test. The inclusion of ` <use name="FWCore/Utilities"/>` for the unit test clause is redundant as it already included in main part of the file. This leads to a warning:
```console
***WARNING: Multiple usage of "FWCore/Utilities". Please cleanup "use" in "export" section of "src/RecoTracker/TrackProducer/test/BuildFile.xml"

```
The redundant line is removed here.

#### PR validation:

`cmssw` compiles

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
