### PR TITLE
fix concurrent writing of SiStrip Condition tools output sqlite files

### DIFF
--- a/CalibTracker/SiStripESProducers/test/python/SiStripBadAPVListBuilder_byHand_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/SiStripBadAPVListBuilder_byHand_cfg.py
@@ -98,7 +98,7 @@ process.PoolDBOutputService = cms.Service("PoolDBOutputService",
         authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
     ),
     timetype = cms.untracked.string('runnumber'),
-    connect = cms.string('sqlite_file:dbfile.db'),
+    connect = cms.string('sqlite_file:SiStripBadComponentsToMask.db'),
     toPut = cms.VPSet(cms.PSet(
         record = cms.string('SiStripBadStrip'),
         tag = cms.string('SiStripBadComponentsToMask')

--- a/CondTools/SiStrip/test/SiStripApvSimulationParametersBuilder_cfg.py
+++ b/CondTools/SiStrip/test/SiStripApvSimulationParametersBuilder_cfg.py
@@ -15,7 +15,7 @@ process.PoolDBOutputService = cms.Service("PoolDBOutputService",
         authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
     ),
     timetype = cms.untracked.string('runnumber'),
-    connect = cms.string('sqlite_file:dbfile.db'),
+    connect = cms.string('sqlite_file:SiStripConditionsDBFile.db'),
     toPut = cms.VPSet(cms.PSet(
         record = cms.string('SiStripApvSimulationParametersRcd'),
         tag = cms.string('SiStripApvSimulationParameters_2016preVFP_v1')

--- a/CondTools/SiStrip/test/SiStripBadChannelBuilder_cfg.py
+++ b/CondTools/SiStrip/test/SiStripBadChannelBuilder_cfg.py
@@ -24,7 +24,7 @@ process.PoolDBOutputService = cms.Service("PoolDBOutputService",
         authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
     ),
     timetype = cms.untracked.string('runnumber'),
-    connect = cms.string('sqlite_file:dbfile.db'),
+    connect = cms.string('sqlite_file:SiStripConditionsDBFile.db'),
     toPut = cms.VPSet(cms.PSet(
         record = cms.string('SiStripBadStripRcd'),
         tag = cms.string('SiStripBadChannel_v1')

--- a/CondTools/SiStrip/test/SiStripBadChannelFromASCIIFile_cfg.py
+++ b/CondTools/SiStrip/test/SiStripBadChannelFromASCIIFile_cfg.py
@@ -17,7 +17,7 @@ process.PoolDBOutputService = cms.Service("PoolDBOutputService",
         authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
     ),
     timetype = cms.string('runnumber'),
-    connect = cms.string('sqlite_file:dbfile.db'),
+    connect = cms.string('sqlite_file:SiStripConditionsDBFile.db'),
     toPut = cms.VPSet(cms.PSet(
         record = cms.string('SiStripBadStrip'),
         tag = cms.string('SiStripBadChannel_v1')

--- a/CondTools/SiStrip/test/SiStripBadFiberBuilder_cfg.py
+++ b/CondTools/SiStrip/test/SiStripBadFiberBuilder_cfg.py
@@ -24,7 +24,7 @@ process.PoolDBOutputService = cms.Service("PoolDBOutputService",
         authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
     ),
     timetype = cms.untracked.string('runnumber'),
-    connect = cms.string('sqlite_file:dbfile.db'),
+    connect = cms.string('sqlite_file:SiStripConditionsDBFile.db'),
     toPut = cms.VPSet(cms.PSet(
         record = cms.string('SiStripBadStrip'),
         tag = cms.string('SiStripBadFiber_v1')

--- a/CondTools/SiStrip/test/SiStripBadModuleByHandBuilder_cfg.py
+++ b/CondTools/SiStrip/test/SiStripBadModuleByHandBuilder_cfg.py
@@ -27,7 +27,7 @@ process.PoolDBOutputService = cms.Service("PoolDBOutputService",
         authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
     ),
     timetype = cms.untracked.string('runnumber'),
-    connect = cms.string('sqlite_file:dbfile.db'),
+    connect = cms.string('sqlite_file:SiStripConditionsDBFile.db'),
     toPut = cms.VPSet(cms.PSet(
         record = cms.string('SiStripBadStrip'),
         tag = cms.string('SiStripBadModule_v1')

--- a/CondTools/SiStrip/test/SiStripBadStripReader_cfg.py
+++ b/CondTools/SiStrip/test/SiStripBadStripReader_cfg.py
@@ -29,7 +29,7 @@ process.PoolDBESSource = cms.ESSource("PoolDBESSource",
         record = cms.string('SiStripBadStripRcd'),
         tag = cms.string('SiStripBadChannel_v1')
     )),
-    connect = cms.string('sqlite_file:dbfile.db')
+    connect = cms.string('sqlite_file:SiStripConditionsDBFile.db')
 )
 
 process.prod = cms.EDAnalyzer("SiStripBadStripReader",

--- a/CondTools/SiStrip/test/SiStripCablingTrackerMap_cfg.py
+++ b/CondTools/SiStrip/test/SiStripCablingTrackerMap_cfg.py
@@ -24,7 +24,7 @@ process.siStripCond.toGet = cms.VPSet(cms.PSet(
     record = cms.string('SiStripFedCablingRcd'),
     tag = cms.string('SiStripFedCabling_Fake_30X')
 ))
-process.siStripCond.connect = 'sqlite_file:dbfile.db'
+process.siStripCond.connect = 'sqlite_file:SiStripConditionsDBFile.db'
 process.siStripCond.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/conddb'
 
 process.sistripconn = cms.ESProducer("SiStripConnectivity")

--- a/CondTools/SiStrip/test/SiStripDetVOffFakeBuilder_cfg.py
+++ b/CondTools/SiStrip/test/SiStripDetVOffFakeBuilder_cfg.py
@@ -24,7 +24,7 @@ process.PoolDBOutputService = cms.Service("PoolDBOutputService",
         authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
     ),
     timetype = cms.untracked.string('runnumber'),
-    connect = cms.string('sqlite_file:dbfile.db'),
+    connect = cms.string('sqlite_file:SiStripConditionsDBFile.db'),
     toPut = cms.VPSet(cms.PSet(
         record = cms.string('SiStripDetVOffRcd'),
         tag = cms.string('SiStripDetVOff_v1')

--- a/CondTools/SiStrip/test/SiStripFedCablingBuilder_cfg.py
+++ b/CondTools/SiStrip/test/SiStripFedCablingBuilder_cfg.py
@@ -27,7 +27,7 @@ process.PoolDBOutputService = cms.Service("PoolDBOutputService",
         authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
     ),
     timetype = cms.untracked.string('runnumber'),
-    connect = cms.string('sqlite_file:dbfile.db'),
+    connect = cms.string('sqlite_file:SiStripConditionsDBFile.db'),
     toPut = cms.VPSet(cms.PSet(
         record = cms.string('SiStripFedCablingRcd'),
         tag = cms.string('SiStripFedCabling_30X')

--- a/CondTools/SiStrip/test/SiStripFedCablingReader_cfg.py
+++ b/CondTools/SiStrip/test/SiStripFedCablingReader_cfg.py
@@ -25,7 +25,7 @@ process.poolDBESSource = cms.ESSource("PoolDBESSource",
         authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
     ),
     timetype = cms.untracked.string('runnumber'),
-    connect = cms.string('sqlite_file:dbfile.db'),
+    connect = cms.string('sqlite_file:SiStripConditionsDBFile.db'),
     toGet = cms.VPSet(cms.PSet(
         record = cms.string('SiStripFedCablingRcd'),
         tag = cms.string('SiStripFedCabling_30X')

--- a/CondTools/SiStrip/test/SiStripNoiseBuilder_cfg.py
+++ b/CondTools/SiStrip/test/SiStripNoiseBuilder_cfg.py
@@ -25,7 +25,7 @@ process.PoolDBOutputService = cms.Service("PoolDBOutputService",
                                           BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
                                           DBParameters = cms.PSet(authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')),
                                           timetype = cms.untracked.string('runnumber'),
-                                          connect = cms.string('sqlite_file:dbfile.db'),
+                                          connect = cms.string('sqlite_file:SiStripConditionsDBFile.db'),
                                           toPut = cms.VPSet(cms.PSet(record = cms.string('SiStripNoisesRcd'),
                                                                      tag = cms.string('SiStripNoise_test')
                                                                      )

--- a/CondTools/SiStrip/test/SiStripSummaryBuilder_cfg.py
+++ b/CondTools/SiStrip/test/SiStripSummaryBuilder_cfg.py
@@ -31,7 +31,7 @@ process.PoolDBOutputService = cms.Service("PoolDBOutputService",
         authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
     ),
     timetype = cms.untracked.string('runnumber'),
-    connect = cms.string('sqlite_file:dbfile.db'),
+    connect = cms.string('sqlite_file:SiStripConditionsDBFile.db'),
     toPut = cms.VPSet(cms.PSet(
         record = cms.string('SiStripSummaryRcd'),#different
         tag = cms.string('SiStripSummary_test1')

--- a/CondTools/SiStrip/test/SiStripSummaryReader_cfg.py
+++ b/CondTools/SiStrip/test/SiStripSummaryReader_cfg.py
@@ -34,7 +34,7 @@ process.poolDBESSource = cms.ESSource("PoolDBESSource",
         authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
     ),
     timetype = cms.untracked.string('runnumber'),
-    connect = cms.string('sqlite_file:dbfile.db'),
+    connect = cms.string('sqlite_file:SiStripConditionsDBFile.db'),
     toGet = cms.VPSet(cms.PSet(
         record = cms.string('SiStripSummaryRcd'),
         tag = cms.string('SiStripSummary_test1')

--- a/CondTools/SiStrip/test/SiStripThresholdBuilder_cfg.py
+++ b/CondTools/SiStrip/test/SiStripThresholdBuilder_cfg.py
@@ -32,7 +32,7 @@ process.PoolDBOutputService = cms.Service("PoolDBOutputService",
     BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
     DBParameters = cms.PSet(authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')),
     timetype = cms.untracked.string('runnumber'),
-    connect = cms.string('sqlite_file:dbfile.db'),
+    connect = cms.string('sqlite_file:SiStripConditionsDBFile.db'),
     toPut = cms.VPSet(cms.PSet(
         record = cms.string('SiStripThresholdRcd'),
         tag = cms.string('SiStripThreshold_Fake_30X')

--- a/CondTools/SiStrip/test/SiStripThresholdReader_cfg.py
+++ b/CondTools/SiStrip/test/SiStripThresholdReader_cfg.py
@@ -33,7 +33,7 @@ process.poolDBESSource = cms.ESSource("PoolDBESSource",
         authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
     ),
     timetype = cms.untracked.string('runnumber'),
-    connect = cms.string('sqlite_file:dbfile.db'),
+    connect = cms.string('sqlite_file:SiStripConditionsDBFile.db'),
     toGet = cms.VPSet(cms.PSet(
         record = cms.string('SiStripThresholdRcd'),
         tag = cms.string('SiStripThreshold_Fake_30X')

--- a/CondTools/SiStrip/test/testBuildersReaders.sh
+++ b/CondTools/SiStrip/test/testBuildersReaders.sh
@@ -2,9 +2,9 @@
 
 function die { echo $1: status $2 ; exit $2; }
 
-if test -f "dbfile.db"; then
+if test -f "SiStripConditionsDBFile.db"; then
     echo "cleaning the local test area"
-    rm -fr dbfile.db
+    rm -fr SiStripConditionsDBFile.db
 fi
 
 echo " testing CondTools/SiStrip"


### PR DESCRIPTION
#### PR description:

I noticed in various recent IBs that there are failures in either `CalibTracker/SiStripESProducers/` or `CondTools/SiStrip` unit tests after PR https://github.com/cms-sw/cmssw/pull/36035 was merged.
Some instances of recent errors:
   * [CMSSW_12_2_X_2021-11-22-2300, slc7_aarch64_gcc9](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/slc7_aarch64_gcc9/CMSSW_12_2_X_2021-11-22-2300/unitTestLogs/CalibTracker/SiStripESProducers#/15449)
   * [CMSSW_12_2_X_2021-11-22-2300, slc7_amd64_gcc10](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/slc7_amd64_gcc10/CMSSW_12_2_X_2021-11-22-2300/unitTestLogs/CondTools/SiStrip#/6697)
   * [CMSSW_12_2_X_2021-11-23-1100, slc7_amd64_gcc900](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/slc7_amd64_gcc900/CMSSW_12_2_X_2021-11-23-1100/unitTestLogs/CondTools/SiStrip#/6697)
   
I think this is due to a concurrent writing and deleting of the same `dbfile.db` file on the various tests.
The names are now changed in order to disentangle the two tests.

#### PR validation:

Unit tests were run with `scram b runtests`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A