### PR TITLE
Modification on r-phi distribution plots and fix on under/overflow bins in GEM onlineDQM

### DIFF
--- a/DQM/GEM/interface/GEMDQMBase.h
+++ b/DQM/GEM/interface/GEMDQMBase.h
@@ -100,7 +100,7 @@ public:
   template <class M, class K>
   class MEMapInfT {
   public:
-    MEMapInfT() : bOperating_(false){};
+    MEMapInfT() : bOperating_(false), bIsNoUnderOverflowBin_(false){};
 
     MEMapInfT(
         GEMDQMBase *pDQMBase, TString strName, TString strTitle, TString strTitleX = "", TString strTitleY = "Entries")
@@ -126,6 +126,7 @@ public:
           strTitleY_(strTitleY),
           bOperating_(true),
           bIsProfile_(false),
+          bIsNoUnderOverflowBin_(false),
           nBinsX_(nBinsX),
           dXL_(dXL),
           dXH_(dXH),
@@ -145,6 +146,7 @@ public:
           strTitleY_(strTitleY),
           bOperating_(true),
           bIsProfile_(false),
+          bIsNoUnderOverflowBin_(false),
           nBinsX_(-1),
           nBinsY_(-1),
           log_category_own_(pDQMBase->log_category_) {
@@ -170,6 +172,7 @@ public:
           strTitleY_(strTitleY),
           bOperating_(true),
           bIsProfile_(false),
+          bIsNoUnderOverflowBin_(false),
           nBinsX_(nBinsX),
           dXL_(dXL),
           dXH_(dXH),
@@ -200,6 +203,7 @@ public:
           strTitleY_(strTitleY),
           bOperating_(true),
           bIsProfile_(true),
+          bIsNoUnderOverflowBin_(false),
           nBinsX_(nBinsX),
           dXL_(dXL),
           dXH_(dXH),
@@ -223,6 +227,7 @@ public:
     //      strTitleX_(strTitleX),
     //      strTitleY_(strTitleY),
     //      bOperating_(true),
+    //      bIsNoUnderOverflowBin_(false),
     //      nBinsX_(nBinsX),
     //      dXL_(dXL),
     //      dXH_(dXH),
@@ -237,6 +242,7 @@ public:
     void SetOperating(Bool_t bOperating) { bOperating_ = bOperating; };
     void TurnOn() { bOperating_ = true; };
     void TurnOff() { bOperating_ = false; };
+    void SetNoUnderOverflowBin() { bIsNoUnderOverflowBin_ = true; };
 
     Bool_t isProfile() { return bIsProfile_; };
     void SetProfile(Bool_t bIsProfile) { bIsProfile_ = bIsProfile; };
@@ -286,10 +292,20 @@ public:
       dYH_ = dH;
     };
 
+    void SetPointUOFlow() {
+      dXU_ = dXL_ + (dXH_ - dXL_) / nBinsX_ * 0.5;
+      dXO_ = dXL_ + (dXH_ - dXL_) / nBinsX_ * (nBinsX_ - 0.5);
+      dYU_ = dYL_ + (dYH_ - dYL_) / nBinsY_ * 0.5;
+      dYO_ = dYL_ + (dYH_ - dYL_) / nBinsY_ * (nBinsY_ - 0.5);
+      dZU_ = dZL_ + (dZH_ - dZL_) / nBinsZ_ * 0.5;
+      dZO_ = dZL_ + (dZH_ - dZL_) / nBinsZ_ * (nBinsZ_ - 0.5);
+    };
+
     M &map() { return mapHist; }
     int bookND(BookingHelper &bh, K key) {
       if (!bOperating_)
         return 0;
+      SetPointUOFlow();
       if (bIsProfile_) {
         mapHist[key] = bh.bookProfile2D(
             strName_, strTitle_, nBinsX_, dXL_, dXH_, nBinsY_, dYL_, dYH_, dZL_, dZH_, strTitleX_, strTitleY_);
@@ -364,6 +380,12 @@ public:
       dqm::impl::MonitorElement *hist = FindHist(key);
       if (hist == nullptr)
         return -999;
+      if (bIsNoUnderOverflowBin_) {
+        if (x <= dXL_)
+          x = dXU_;
+        else if (x >= dXH_)
+          x = dXO_;
+      }
       hist->Fill(x);
       return 1;
     };
@@ -374,6 +396,16 @@ public:
       dqm::impl::MonitorElement *hist = FindHist(key);
       if (hist == nullptr)
         return -999;
+      if (bIsNoUnderOverflowBin_) {
+        if (x <= dXL_)
+          x = dXU_;
+        else if (x >= dXH_)
+          x = dXO_;
+        if (y <= dYL_)
+          y = dYU_;
+        else if (y >= dYH_)
+          y = dYO_;
+      }
       hist->Fill(x, y, w);
       return 1;
     };
@@ -404,13 +436,18 @@ public:
     TString strName_, strTitle_, strTitleX_, strTitleY_;
     Bool_t bOperating_;
     Bool_t bIsProfile_;
+    Bool_t bIsNoUnderOverflowBin_;
 
     std::vector<double> x_binning_;
     Int_t nBinsX_;
     Double_t dXL_, dXH_;
     Int_t nBinsY_;
     Double_t dYL_, dYH_;
+    Int_t nBinsZ_;
     Double_t dZL_, dZH_;
+    Double_t dXU_, dXO_;
+    Double_t dYU_, dYO_;
+    Double_t dZU_, dZO_;
 
     std::string log_category_own_;
   };
@@ -450,6 +487,8 @@ public:
     Int_t nNumEtaPartitions_;  // the number of eta partitions of the chambers
     Int_t nMaxVFAT_;  // the number of all VFATs in each chamber (= # of VFATs in eta partition * nNumEtaPartitions_)
     Int_t nNumDigi_;  // the number of digis of each VFAT
+
+    Float_t fMinPhi_;
   };
 
 public:

--- a/DQM/GEM/interface/GEMDigiSource.h
+++ b/DQM/GEM/interface/GEMDigiSource.h
@@ -49,6 +49,7 @@ private:
   edm::EDGetTokenT<LumiScalersCollection> lumiScalers_;
 
   MEMap3Inf mapTotalDigi_layer_;
+  MEMap3Inf mapDigiWheel_layer_;
   MEMap3Inf mapDigiOcc_ieta_;
   MEMap3Inf mapDigiOcc_phi_;
   MEMap3Inf mapTotalDigiPerEvtLayer_;
@@ -60,6 +61,8 @@ private:
   MonitorElement* h2SummaryOcc_;
 
   Int_t nBXMin_, nBXMax_;
+  Float_t fRadiusMin_;
+  Float_t fRadiusMax_;
 
   Bool_t bModeRelVal_;
 };

--- a/DQM/GEM/plugins/GEMDigiSource.cc
+++ b/DQM/GEM/plugins/GEMDigiSource.cc
@@ -168,7 +168,7 @@ void GEMDigiSource::analyze(edm::Event const& event, edm::EventSetup const& even
         GlobalPoint digi_global_pos = surface.toGlobal(iEta->centreOfStrip(d->strip()));
         Float_t fPhi = (Float_t)digi_global_pos.phi();
         Float_t fPhiDeg = fPhi * 180.0 / M_PI;
-        fPhiDeg = (fPhi >= -0.5 ? fPhi : fPhi + 360);
+        fPhiDeg = (fPhiDeg >= -0.5 ? fPhiDeg : fPhiDeg + 360);
         mapDigiOcc_phi_.Fill(key3, fPhiDeg);  // Phi
 
         // Filling of R-Phi occupancy

--- a/DQM/GEM/plugins/GEMDigiSource.cc
+++ b/DQM/GEM/plugins/GEMDigiSource.cc
@@ -28,8 +28,8 @@ void GEMDigiSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, 
   nBXMax_ = 10;
   fRadiusMin_ = 120.0;
   fRadiusMax_ = 250.0;
-  float radS = -5.0 / 180 * 3.141592;
-  float radL = 355.0 / 180 * 3.141592;
+  float radS = -5.0 / 180 * M_PI;
+  float radL = 355.0 / 180 * M_PI;
 
   mapTotalDigi_layer_ = MEMap3Inf(this, "det", "Digi Occupancy", 36, 0.5, 36.5, 24, -0.5, 24 - 0.5, "Chamber", "VFAT");
   mapDigiWheel_layer_ = MEMap3Inf(
@@ -102,7 +102,7 @@ int GEMDigiSource::ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) {
   mapTotalDigi_layer_.SetLabelForVFATs(key, stationInfo.nNumEtaPartitions_, 2);
 
   mapDigiWheel_layer_.SetBinLowEdgeX(stationInfo.fMinPhi_);
-  mapDigiWheel_layer_.SetBinHighEdgeX(stationInfo.fMinPhi_ + 2 * 3.141592);
+  mapDigiWheel_layer_.SetBinHighEdgeX(stationInfo.fMinPhi_ + 2 * M_PI);
   mapDigiWheel_layer_.SetNbinsX(nNumVFATPerEta * stationInfo.nNumChambers_);
   mapDigiWheel_layer_.SetNbinsY(stationInfo.nNumEtaPartitions_);
   mapDigiWheel_layer_.bookND(bh, key);
@@ -167,13 +167,13 @@ void GEMDigiSource::analyze(edm::Event const& event, edm::EventSetup const& even
 
         GlobalPoint digi_global_pos = surface.toGlobal(iEta->centreOfStrip(d->strip()));
         Float_t fPhi = (Float_t)digi_global_pos.phi();
-        Float_t fPhiDeg = fPhi * 180.0 / 3.141592;
+        Float_t fPhiDeg = fPhi * 180.0 / M_PI;
         fPhiDeg = (fPhi >= -0.5 ? fPhi : fPhi + 360);
         mapDigiOcc_phi_.Fill(key3, fPhiDeg);  // Phi
 
         // Filling of R-Phi occupancy
         Float_t fR = fRadiusMin_ + (fRadiusMax_ - fRadiusMin_) * (eId.ieta() - 0.5) / stationInfo.nNumEtaPartitions_;
-        Float_t fPhiShift = (fPhi >= stationInfo.fMinPhi_ ? fPhi : fPhi + 2 * 3.141592);
+        Float_t fPhiShift = (fPhi >= stationInfo.fMinPhi_ ? fPhi : fPhi + 2 * M_PI);
         mapDigiWheel_layer_.Fill(key3, fPhiShift, fR);
 
         mapDigiOccPerCh_.Fill(key4Ch, d->strip(), eId.ieta());  // Per chamber

--- a/DQM/GEM/plugins/GEMDigiSource.cc
+++ b/DQM/GEM/plugins/GEMDigiSource.cc
@@ -26,8 +26,14 @@ void GEMDigiSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, 
 
   nBXMin_ = -10;
   nBXMax_ = 10;
+  fRadiusMin_ = 120.0;
+  fRadiusMax_ = 250.0;
+  float radS = -5.0 / 180 * 3.141592;
+  float radL = 355.0 / 180 * 3.141592;
 
   mapTotalDigi_layer_ = MEMap3Inf(this, "det", "Digi Occupancy", 36, 0.5, 36.5, 24, -0.5, 24 - 0.5, "Chamber", "VFAT");
+  mapDigiWheel_layer_ = MEMap3Inf(
+      this, "rphi_occ", "Digi R-Phi Occupancy", 360, radS, radL, 8, fRadiusMin_, fRadiusMax_, "#phi (rad)", "R [cm]");
   mapDigiOcc_ieta_ = MEMap3Inf(this, "occ_ieta", "Digi iEta Occupancy", 8, 0.5, 8.5, "iEta", "Number of fired digis");
   mapDigiOcc_phi_ =
       MEMap3Inf(this, "occ_phi", "Digi Phi Occupancy", 108, -5, 355, "#phi (degree)", "Number of fired digis");
@@ -39,6 +45,7 @@ void GEMDigiSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, 
                                        99.5,
                                        "Number of fired digis",
                                        "Events");
+  mapTotalDigiPerEvtLayer_.SetNoUnderOverflowBin();
   mapTotalDigiPerEvtIEta_ = MEMap3Inf(this,
                                       "digis_per_ieta",
                                       "Total number of digis per event for each eta partitions",
@@ -47,6 +54,7 @@ void GEMDigiSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, 
                                       99.5,
                                       "Number of fired digis",
                                       "Events");
+  mapTotalDigiPerEvtIEta_.SetNoUnderOverflowBin();
 
   mapBX_ = MEMap2Inf(this, "bx", "Digi Bunch Crossing", 21, nBXMin_ - 0.5, nBXMax_ + 0.5, "Bunch crossing");
 
@@ -54,6 +62,7 @@ void GEMDigiSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, 
 
   if (bModeRelVal_) {
     mapTotalDigi_layer_.TurnOff();
+    mapDigiWheel_layer_.TurnOff();
     mapDigiOccPerCh_.TurnOff();
   }
 
@@ -84,11 +93,19 @@ int GEMDigiSource::ProcessWithMEMap2WithEta(BookingHelper& bh, ME3IdsKey key) {
 int GEMDigiSource::ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) {
   MEStationInfo& stationInfo = mapStationInfo_[key];
 
+  int nNumVFATPerEta = stationInfo.nMaxVFAT_ / stationInfo.nNumEtaPartitions_;
+
   mapTotalDigi_layer_.SetBinConfX(stationInfo.nNumChambers_);
   mapTotalDigi_layer_.SetBinConfY(stationInfo.nMaxVFAT_, -0.5);
   mapTotalDigi_layer_.bookND(bh, key);
   mapTotalDigi_layer_.SetLabelForChambers(key, 1);
   mapTotalDigi_layer_.SetLabelForVFATs(key, stationInfo.nNumEtaPartitions_, 2);
+
+  mapDigiWheel_layer_.SetBinLowEdgeX(stationInfo.fMinPhi_);
+  mapDigiWheel_layer_.SetBinHighEdgeX(stationInfo.fMinPhi_ + 2 * 3.141592);
+  mapDigiWheel_layer_.SetNbinsX(nNumVFATPerEta * stationInfo.nNumChambers_);
+  mapDigiWheel_layer_.SetNbinsY(stationInfo.nNumEtaPartitions_);
+  mapDigiWheel_layer_.bookND(bh, key);
 
   mapDigiOcc_ieta_.SetBinConfX(stationInfo.nNumEtaPartitions_);
   mapDigiOcc_ieta_.bookND(bh, key);
@@ -130,6 +147,7 @@ void GEMDigiSource::analyze(edm::Event const& event, edm::EventSetup const& even
     ME4IdsKey key4Ch{gid.region(), gid.station(), gid.layer(), gid.chamber()};
     std::map<Int_t, bool> bTagVFAT;
     bTagVFAT.clear();
+    MEStationInfo& stationInfo = mapStationInfo_[key3];
     const BoundPlane& surface = GEMGeometry_->idToDet(gid)->surface();
     if (total_digi_layer.find(key3) == total_digi_layer.end())
       total_digi_layer[key3] = 0;
@@ -148,10 +166,15 @@ void GEMDigiSource::analyze(edm::Event const& event, edm::EventSetup const& even
         mapDigiOcc_ieta_.Fill(key3, eId.ieta());  // Eta (partition)
 
         GlobalPoint digi_global_pos = surface.toGlobal(iEta->centreOfStrip(d->strip()));
-        Float_t fPhiDeg = ((Float_t)digi_global_pos.phi()) * 180.0 / 3.141592;
-        if (fPhiDeg < -5.0)
-          fPhiDeg += 360.0;
+        Float_t fPhi = (Float_t)digi_global_pos.phi();
+        Float_t fPhiDeg = fPhi * 180.0 / 3.141592;
+        fPhiDeg = (fPhi >= -0.5 ? fPhi : fPhi + 360);
         mapDigiOcc_phi_.Fill(key3, fPhiDeg);  // Phi
+
+        // Filling of R-Phi occupancy
+        Float_t fR = fRadiusMin_ + (fRadiusMax_ - fRadiusMin_) * (eId.ieta() - 0.5) / stationInfo.nNumEtaPartitions_;
+        Float_t fPhiShift = (fPhi >= stationInfo.fMinPhi_ ? fPhi : fPhi + 2 * 3.141592);
+        mapDigiWheel_layer_.Fill(key3, fPhiShift, fR);
 
         mapDigiOccPerCh_.Fill(key4Ch, d->strip(), eId.ieta());  // Per chamber
 

--- a/DQM/GEM/plugins/GEMRecHitSource.cc
+++ b/DQM/GEM/plugins/GEMRecHitSource.cc
@@ -38,8 +38,8 @@ void GEMRecHitSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&
   nCLSMax_ = 10;
   fRadiusMin_ = 120.0;
   fRadiusMax_ = 250.0;
-  float radS = -5.0 / 180 * 3.141592;
-  float radL = 355.0 / 180 * 3.141592;
+  float radS = -5.0 / 180 * M_PI;
+  float radL = 355.0 / 180 * M_PI;
 
   mapTotalRecHit_layer_ = MEMap3Inf(this, "det", "RecHit Occupancy", 36, 0.5, 36.5, 8, 0.5, 8.5, "Chamber", "iEta");
   mapRecHitWheel_layer_ = MEMap3Inf(
@@ -131,7 +131,7 @@ int GEMRecHitSource::ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) {
   mapTotalRecHit_layer_.SetLabelForIEta(key, 2);
 
   mapRecHitWheel_layer_.SetBinLowEdgeX(stationInfo.fMinPhi_);
-  mapRecHitWheel_layer_.SetBinHighEdgeX(stationInfo.fMinPhi_ + 2 * 3.141592);
+  mapRecHitWheel_layer_.SetBinHighEdgeX(stationInfo.fMinPhi_ + 2 * M_PI);
   mapRecHitWheel_layer_.SetNbinsX(nNumVFATPerEta * stationInfo.nNumChambers_);
   mapRecHitWheel_layer_.SetNbinsY(stationInfo.nNumEtaPartitions_);
   mapRecHitWheel_layer_.bookND(bh, key);
@@ -203,14 +203,14 @@ void GEMRecHitSource::analyze(edm::Event const& event, edm::EventSetup const& ev
 
         // Filling of R-Phi occupancy
         Float_t fR = fRadiusMin_ + (fRadiusMax_ - fRadiusMin_) * (eId.ieta() - 0.5) / stationInfo.nNumEtaPartitions_;
-        Float_t fPhiShift = (fPhi >= stationInfo.fMinPhi_ ? fPhi : fPhi + 2 * 3.141592);
+        Float_t fPhiShift = (fPhi >= stationInfo.fMinPhi_ ? fPhi : fPhi + 2 * M_PI);
         mapRecHitWheel_layer_.Fill(key3, fPhiShift, fR);
 
         // Filling of RecHit (iEta)
         mapRecHitOcc_ieta_.Fill(key3, eId.ieta());
 
         // Filling of RecHit (phi)
-        Float_t fPhiDeg = fPhi * 180.0 / 3.141592;
+        Float_t fPhiDeg = fPhi * 180.0 / M_PI;
         fPhiDeg = (fPhi >= -0.5 ? fPhi : fPhi + 360);
         mapRecHitOcc_phi_.Fill(key3, fPhiDeg);
 

--- a/DQM/GEM/plugins/GEMRecHitSource.cc
+++ b/DQM/GEM/plugins/GEMRecHitSource.cc
@@ -211,7 +211,7 @@ void GEMRecHitSource::analyze(edm::Event const& event, edm::EventSetup const& ev
 
         // Filling of RecHit (phi)
         Float_t fPhiDeg = fPhi * 180.0 / M_PI;
-        fPhiDeg = (fPhi >= -0.5 ? fPhi : fPhi + 360);
+        fPhiDeg = (fPhiDeg >= -0.5 ? fPhiDeg : fPhiDeg + 360);
         mapRecHitOcc_phi_.Fill(key3, fPhiDeg);
 
         // For total RecHits

--- a/DQM/GEM/src/GEMDQMBase.cc
+++ b/DQM/GEM/src/GEMDQMBase.cc
@@ -86,6 +86,7 @@ int GEMDQMBase::loadChambers() {
         ME3IdsKey key3(region_number, station_number, layer_number);
         mapStationInfo_[key3] =
             MEStationInfo(region_number, station_number, layer_number, num_superchambers, num_etas, num_vfat, num_digi);
+        mapStationInfo_[key3].fMinPhi_ = -0.088344;  // FIXME
       }
     }
   }


### PR DESCRIPTION
#### PR description:
Some requests on r-phi distributions are applied; finer binning on phi direction, more plots for digi.

Also, the under/overflow bins of 1D histograms are not displayed well. It has been fixed.

#### PR validation:
Tests are done and one can check again by `runTheMatrix` workflows

@jshlee @watson-ij 