### PR TITLE
A few fixes for  DQM/L1TMonitor L1TGT and L1TRate

### DIFF
--- a/DQM/L1TMonitor/src/L1TGT.cc
+++ b/DQM/L1TMonitor/src/L1TGT.cc
@@ -747,13 +747,12 @@ void L1TGT::countPfsIndicesPerLs() {
   // count the number of pairs (lsNumber, pfIndex) per Ls
   // there are no duplicate entries, and pairs are sorted after both members
   // ... and fill again the histogram
+  int pfsIndicesPerLs = 1;
   for (CItVecPair cIt = m_pairLsNumberPfIndex.begin(); cIt != m_pairLsNumberPfIndex.end(); ++cIt) {
-    int pfsIndicesPerLs = 1;
-
     if ((*cIt).first == previousLsNumber) {
       if ((*cIt).second != previousPfsIndex) {
-        pfsIndicesPerLs++;
         previousPfsIndex = (*cIt).second;
+        pfsIndicesPerLs++;
       }
 
     } else {
@@ -765,7 +764,6 @@ void L1TGT::countPfsIndicesPerLs() {
       // new Ls
       previousLsNumber = (*cIt).first;
       previousPfsIndex = (*cIt).second;
-
       pfsIndicesPerLs = 1;
     }
   }

--- a/DQM/L1TMonitor/src/L1TRate.cc
+++ b/DQM/L1TMonitor/src/L1TRate.cc
@@ -495,12 +495,11 @@ bool L1TRate::getXSexFitsPython(const edm::ParameterSet& ps) {
           foundFit = true;
           break;
         }
-
-        if (!foundFit) {
-          noError = false;
-          string eName = "WARNING_PY_MISSING_FIT";
-          m_ErrorMonitor->Fill(eName);
-        }
+      }
+      if (!foundFit) {
+        noError = false;
+        string eName = "WARNING_PY_MISSING_FIT";
+        m_ErrorMonitor->Fill(eName);
       }
     }
   }


### PR DESCRIPTION
#### PR description:

Starting from the identification of some dead assignment in DQM/L1TMonitor/src/L1TRate.cc and DQM/L1TMonitor/src/L1TGT.cc by the static analyzer I noticed something that looked like a bug in the implementation of the logic.
The fixes look simple enough, and I propose them here for having them evaluated by the responsibles of the code

#### PR validation:

It builds without errors