### PR TITLE
Restored the ShieldingME4 and fixed all the MUON overlaps in muonYoke.xml

### DIFF
--- a/Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D86.xml
+++ b/Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D86.xml
@@ -72,7 +72,7 @@
     <Include ref='Geometry/MuonCommonData/data/mb3/2015/v2/mb3.xml'/>
     <Include ref='Geometry/MuonCommonData/data/mb4/2015/v2/mb4.xml'/>
     <Include ref='Geometry/MuonCommonData/data/mb4Shield/2021/v1/mb4Shield.xml'/>
-    <Include ref='Geometry/MuonCommonData/data/muonYoke/2026/v2/muonYoke.xml'/>
+    <Include ref='Geometry/MuonCommonData/data/muonYoke/2026/v1/muonYoke.xml'/>
     <Include ref='Geometry/MuonCommonData/data/mf/2026/v8/mf.xml'/>
     <Include ref='Geometry/MuonCommonData/data/csc/2021/v2/csc.xml'/>
     <Include ref='Geometry/MuonCommonData/data/rpcf/2026/v3/rpcf.xml'/>

--- a/Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D86.xml
+++ b/Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D86.xml
@@ -72,7 +72,7 @@
     <Include ref='Geometry/MuonCommonData/data/mb3/2015/v2/mb3.xml'/>
     <Include ref='Geometry/MuonCommonData/data/mb4/2015/v2/mb4.xml'/>
     <Include ref='Geometry/MuonCommonData/data/mb4Shield/2021/v1/mb4Shield.xml'/>
-    <Include ref='Geometry/MuonCommonData/data/muonYoke/2026/v1/muonYoke.xml'/>
+    <Include ref='Geometry/MuonCommonData/data/muonYoke/2026/v2/muonYoke.xml'/>
     <Include ref='Geometry/MuonCommonData/data/mf/2026/v8/mf.xml'/>
     <Include ref='Geometry/MuonCommonData/data/csc/2021/v2/csc.xml'/>
     <Include ref='Geometry/MuonCommonData/data/rpcf/2026/v3/rpcf.xml'/>

--- a/Geometry/MuonCommonData/data/muonYoke/2026/v2/muonYoke.xml
+++ b/Geometry/MuonCommonData/data/muonYoke/2026/v2/muonYoke.xml
@@ -1,0 +1,4507 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../../../../DetectorDescription/Schema/DDLSchema.xsd">
+<!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+<!-- Last update: 24 November 2021, Sergio Lo Meo - sergio.lo.meo@cern.ch -->
+<!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <SolidSection label="muonYoke.xml">
+    <Cone name="YN12_a" dz="0.245*m" rMin1="0.9243*m" rMax1="2.6300*m" rMin2="0.8900*m" rMax2="2.6300*m" startPhi="75*deg" deltaPhi="30*deg"/>
+    <Tubs name="YN12_b" rMin="0.7250*m" rMax="2.6300*m" dz="0.0500*m" startPhi="75*deg" deltaPhi="30*deg"/>
+    <Tubs name="YN12_c" rMin="0.8500*m" rMax="2.6300*m" dz="0.1640*m" startPhi="75*deg" deltaPhi="30*deg"/>
+    <Tubs name="YE1_a" rMin="0.8500*m" rMax="1.1349*m" dz="0.3550*m" startPhi="75*deg" deltaPhi="30*deg"/>
+    <TruncTubs name="YE1_bl" rMin="1.1349*m" rMax="7.20024*m" cutAtStart="6.9549*m" cutAtDelta="7.20024*m" cutInside="false" startPhi="0*deg" deltaPhi="15*deg" zHalf="0.2959*m"/>
+    <TruncTubs name="YE1_br" rMin="1.1349*m" rMax="7.20024*m" cutAtStart="7.20024*m" cutAtDelta="6.9549*m" cutInside="false" startPhi="0*deg" deltaPhi="15*deg" zHalf="0.2959*m"/>
+    <UnionSolid name="YE1_b">
+      <rSolid name="YE1_bl"/>
+      <rSolid name="YE1_br"/>
+      <rRotation name="rotations:R345"/>
+    </UnionSolid>
+    <Tubs name="YE12" rMin="0.9350*m" rMax="1.1350*m" dz="0.2675*m" startPhi="75*deg" deltaPhi="30*deg"/>
+    <Tubs name="YE2_a" rMin="0.9500*m" rMax="1.3599*m" dz="0.3600*m" startPhi="75*deg" deltaPhi="30*deg"/>
+    <TruncTubs name="YE2_bl" rMin="1.3599*m" rMax="7.20024*m" cutAtStart="6.9549*m" cutAtDelta="7.20024*m" cutInside="false" startPhi="0*deg" deltaPhi="15*deg" zHalf="0.2959*m"/>
+    <TruncTubs name="YE2_br" rMin="1.3599*m" rMax="7.20024*m" cutAtStart="7.20024*m" cutAtDelta="6.9549*m" cutInside="false" startPhi="0*deg" deltaPhi="15*deg" zHalf="0.2959*m"/>
+    <UnionSolid name="YE2_b">
+      <rSolid name="YE2_bl"/>
+      <rSolid name="YE2_br"/>
+      <rRotation name="rotations:R345"/>
+    </UnionSolid>
+    <Tubs name="YE23" rMin="1.0400*m" rMax="1.3600*m" dz="0.2675*m" startPhi="75*deg" deltaPhi="30*deg"/>
+    <Tubs name="YE3_a" rMin="1.0400*m" rMax="1.5299*m" dz="0.175*m" startPhi="75*deg" deltaPhi="30*deg"/>
+    <TruncTubs name="YE3_bl" rMin="1.5299*m" rMax="7.20024*m" cutAtStart="6.9549*m" cutAtDelta="7.20024*m" cutInside="false" startPhi="0*deg" deltaPhi="15*deg" zHalf="0.116*m"/>
+    <TruncTubs name="YE3_br" rMin="1.5299*m" rMax="7.20024*m" cutAtStart="7.20024*m" cutAtDelta="6.9549*m" cutInside="false" startPhi="0*deg" deltaPhi="15*deg" zHalf="0.116*m"/>
+    <UnionSolid name="YE3_b">
+      <rSolid name="YE3_bl"/>
+      <rSolid name="YE3_br"/>
+      <rRotation name="rotations:R345"/>
+    </UnionSolid>
+    <Tubs name="YE34" rMin="1.1300*m" rMax="1.5300*m" dz="0.2725*m" startPhi="75*deg" deltaPhi="30*deg"/>
+    <Tubs name="ShieldingME4" rMin="1.1300*m" rMax="2.5000*m" dz="0.0375*m - 4.55*mm" startPhi="75*deg" deltaPhi="30*deg"/>
+    <TruncTubs name="YE4l" rMin="2.5001*m" rMax="7.20024*m" cutAtStart="6.9549*m" cutAtDelta="7.20024*m" cutInside="false" startPhi="0*deg" deltaPhi="15*deg" zHalf="0.0624*m"/>
+    <TruncTubs name="YE4r" rMin="2.5001*m" rMax="7.20024*m" cutAtStart="7.20024*m" cutAtDelta="6.9549*m" cutInside="false" startPhi="0*deg" deltaPhi="15*deg" zHalf="0.0624*m"/>
+    <UnionSolid name="YE4">
+      <rSolid name="YE4l"/>
+      <rSolid name="YE4r"/>
+      <rRotation name="rotations:R345"/>
+    </UnionSolid>
+    <TruncTubs name="YE4_in_l" rMin="2.7001*m" rMax="7.20024*m" cutAtStart="6.7549*m" cutAtDelta="7.00024*m" cutInside="false" startPhi="0*deg" deltaPhi="15*deg" zHalf="0.0375*m"/>
+    <TruncTubs name="YE4_in_r" rMin="2.7001*m" rMax="7.20024*m" cutAtStart="7.00024*m" cutAtDelta="6.7549*m" cutInside="false" startPhi="0*deg" deltaPhi="15*deg" zHalf="0.0375*m"/>
+    <UnionSolid name="YE4_in">
+      <rSolid name="YE4_in_l"/>
+      <rSolid name="YE4_in_r"/>
+      <rRotation name="rotations:R345"/>
+    </UnionSolid>		
+    <Trapezoid name="YB1_w0_b1" dz="0.63395*m" alp1="-7.63074*deg" bl1="0.186343*m" tl1="0.198401*m" h1="0.045*m" alp2="-7.63074*deg" bl2="0.186343*m" tl2="0.198401*m" h2="0.045*m" phi="0*deg" theta="0*deg"/>
+    <Box name="YB1_w0_b2" dx="0.7925*m - 0.000001040716*m" dy="0.0450*m" dz="0.62495*m"/>
+    <Trapezoid name="YB1_w0_b3" dz="1.268*m" alp1="7.63074*deg" bl1="0.257742*m" tl1="0.2698*m" h1="0.045*m" alp2="7.63074*deg" bl2="0.257742*m" tl2="0.2698*m" h2="0.045*m" phi="0*deg" theta="0*deg"/>
+    <Trapezoid name="YB1_w1_b1" dz="1.2679*m" alp1="-7.63074*deg" bl1="0.186343*m" tl1="0.198401*m" h1="0.045*m" alp2="-7.63074*deg" bl2="0.186343*m" tl2="0.198401*m" h2="0.045*m" phi="0*deg" theta="0*deg"/>
+    <Box name="YB1_w1_b2" dx="0.21695*m" dy="0.0450*m" dz="0.186*m"/>
+    <Box name="YB1_w1_b3" dx="0.08*m" dy="0.0450*m - 0.00000245782*m - 0.00000284419*m" dz="0.186*m"/>
+    <Box name="YB1_w1_b4" dx="0.2700*m - 0.000207145*m" dy="0.0450*m - 0.00000284419*m" dz="0.186*m"/>
+    <Box name="YB1_w1_b5" dx="0.08*m" dy="0.0450*m - 0.00000245782*m" dz="0.186*m"/>
+    <Box name="YB1_w1_b6" dx="0.14555*m" dy="0.0450*m" dz="0.186*m"/>
+    <Box name="YB1_w1_b7" dx="0.7925*m - 0.000000165104*m - 0.000000713952*m" dy="0.0450*m - 0.00000305385*m" dz="1.0639*m"/>
+    <Trapezoid name="YB1_w1_b8" dz="1.2679*m" alp1="7.63074*deg" bl1="0.257742*m" tl1="0.2698*m" h1="0.045*m" alp2="7.63074*deg" bl2="0.257742*m" tl2="0.2698*m" h2="0.045*m" phi="0*deg" theta="0*deg"/>
+    <Trapezoid name="YB1_w2_b1" dz="1.2679*m" alp1="-7.63074*deg" bl1="0.186343*m" tl1="0.198401*m" h1="0.045*m" alp2="-7.63074*deg" bl2="0.186343*m" tl2="0.198401*m" h2="0.045*m" phi="0*deg" theta="0*deg"/>
+    <Box name="YB1_w2_b2" dx="0.79244*m" dy="0.0450*m - 0.00000305385*m" dz="1.2500*m"/>
+    <Trapezoid name="YB1_w2_b3" dz="1.2679*m" alp1="7.63074*deg" bl1="0.257742*m" tl1="0.2698*m" h1="0.045*m - 0.00000282824*m" alp2="7.63074*deg" bl2="0.257742*m" tl2="0.2698*m" h2="0.045*m - 0.00000282824*m" phi="0*deg" theta="0*deg"/>
+    <Trapezoid name="YB1_w0_m" dz="0.63395*m - 1.0*mm" alp1="0*deg" bl1="1.2607*m - 1.0*mm" tl1="1.3143*m - 1.0*mm" h1="0.1000*m - 0.00000305385*m - 1.0*mm" alp2="0*deg" bl2="1.2607*m - 1.0*mm" tl2="1.3143*m - 1.0*mm" h2="0.1000*m - 0.00000305385*m - 1.0*mm" phi="0*deg" theta="0*deg"/>
+    <Trapezoid name="YB1_w1_m1" dz="0.195*m" alp1="-7.6321701*deg" bl1="0.4154*m" tl1="0.4422*m" h1="0.1000*m" alp2="-7.6321701*deg" bl2="0.4154*m" tl2="0.4422*m" h2="0.1000*m" phi="0*deg" theta="0*deg"/>
+    <Box name="YB1_w1_m2" dx="0.08*m - 0.000026056*m - 1.0*mm" dy="0.1000*m" dz="0.195*m"/>
+    <Box name="YB1_w1_m3" dx="0.2700*m" dy="0.1000*m - 0.00000284419*m" dz="0.195*m"/>
+    <Box name="YB1_w1_m4" dx="0.08*m - 0.000284419*m" dy="0.1000*m - 0.00000284419*m" dz="0.195*m"/>
+    <Trapezoid name="YB1_w1_m5" dz="0.195*m" alp1="7.6321701*deg" bl1="0.4154*m" tl1="0.4422*m - 0.000000896967*m" h1="0.1000*m" alp2="7.6321701*deg" bl2="0.4154*m" tl2="0.4422*m  - 0.000000896967*m" h2="0.1000*m" phi="0*deg" theta="0*deg"/>
+    <Trapezoid name="YB1_w1_m6" dz="1.0729*m" alp1="0*deg" bl1="1.2607*m - 1.0*mm" tl1="1.3143*m - 1.0*mm" h1="0.1000*m - 0.00000282824*m" alp2="0*deg" bl2="1.2607*m - 1.0*mm" tl2="1.3143*m - 1.0*mm" h2="0.1000*m - 0.00000282824*m" phi="0*deg" theta="0*deg"/>
+    <Trapezoid name="YB1_w2_m1" dz="1.2679*m - 1.0*mm" alp1="0*deg" bl1="1.2607*m - 1.0*mm" tl1="1.3143*m - 1.0*mm" h1="0.1000*m - 1.0*mm" alp2="0*deg" bl2="1.2607*m - 1.0*mm" tl2="1.3143*m - 1.0*mm" h2="0.1000*m - 1.0*mm" phi="0*deg" theta="0*deg"/>
+    <Box name="YBSepar2_w0" dx="0.0369*m" dy="0.2225*m - 0.000000120219*m" dz="0.63405*m - 0.001*m"/>
+    <Box name="YBSepar2_w1" dx="0.0369*m" dy="0.2225*m - 0.000000820541*m - 0.00000738487*m" dz="1.2679*m"/>
+    <Box name="YBSepar2_w2" dx="0.0369*m" dy="0.2225*m - 0.000000120219*m" dz="1.2679*m"/>
+    <Trapezoid name="YB2_w0_b1" dz="0.63395*m" alp1="-7.63074*deg" bl1="0.185862*m" tl1="0.19725*m" h1="0.0425*m" alp2="-7.63074*deg" bl2="0.185862*m" tl2="0.19725*m" h2="0.0425*m" phi="0*deg" theta="0*deg"/>
+    <Box name="YB2_w0_b2" dx="1.09675*m  - 0.00000362891*m" dy="0.0425*m" dz="0.62495*m"/>
+    <Trapezoid name="YB2_w0_b3" dz="0.63395*m" alp1="7.63074*deg" bl1="0.150916*m" tl1="0.162304*m" h1="0.0425*m - 0.00000277556*m" alp2="7.63074*deg" bl2="0.150916*m" tl2="0.162304*m" h2="0.0425*m - 0.00000277556*m" phi="0*deg" theta="0*deg"/>
+    <Trapezoid name="YB2_w1_b1" dz="1.2679*m" alp1="-7.63074*deg" bl1="0.185862*m" tl1="0.19725*m" h1="0.0425*m" alp2="-7.63074*deg" bl2="0.185862*m" tl2="0.19725*m" h2="0.0425*m" phi="0*deg" theta="0*deg"/>
+    <Box name="YB2_w1_b2" dx="0.31595*m - 0.00000413552*m" dy="0.0425*m" dz="0.186*m"/>
+    <Box name="YB2_w1_b3" dx="0.08*m" dy="0.0425*m" dz="0.186*m"/>
+    <Box name="YB2_w1_b4" dx="0.2700*m - 0.003*m" dy="0.0425*m" dz="0.186*m"/>
+    <Box name="YB2_w1_b5" dx="0.08*m" dy="0.0425*m" dz="0.186*m"/>
+    <Box name="YB2_w1_b6" dx="0.3509*m  - 0.0000023802*m" dy="0.0425*m" dz="0.186*m"/>
+    <Box name="YB2_w1_b7" dx="1.09675*m - 0.00000362891*m" dy="0.0425*m" dz="1.0639*m"/>
+    <Trapezoid name="YB2_w1_b8" dz="1.2679*m" alp1="7.63074*deg" bl1="0.150916*m" tl1="0.162304*m" h1="0.0425*m" alp2="7.63074*deg" bl2="0.150916*m" tl2="0.162304*m" h2="0.0425*m" phi="0*deg" theta="0*deg"/>
+    <Trapezoid name="YB2_w2_b1" dz="1.2679*m" alp1="-7.63074*deg" bl1="0.185862*m" tl1="0.19725*m" h1="0.0425*m" alp2="-7.63074*deg" bl2="0.185862*m" tl2="0.19725*m" h2="0.0425*m" phi="0*deg" theta="0*deg"/>
+    <Box name="YB2_w2_b2" dx="1.09675*m - 0.00000362891*m" dy="0.0425*m" dz="1.2500*m"/>
+    <Trapezoid name="YB2_w2_b3" dz="1.2679*m" alp1="7.63074*deg" bl1="0.150916*m" tl1="0.162304*m" h1="0.0425*m - 0.00000277556*m" alp2="7.63074*deg" bl2="0.150916*m" tl2="0.162304*m" h2="0.0425*m - 0.00000277556*m" phi="0*deg" theta="0*deg"/>
+    <Trapezoid name="YB2_w0_m" dz="0.63395*m - 0.1*mm" alp1="0*deg" bl1="1.4563*m - 0.1*mm" tl1="1.5769*m - 0.1*mm" h1="0.2250*m - 0.1*mm" alp2="0*deg" bl2="1.4563*m - 0.1*mm" tl2="1.5769*m - 0.1*mm" h2="0.2250*m - 0.1*mm" phi="0*deg" theta="0*deg"/>
+    <Trapezoid name="YB2_w1_m1" dz="0.195*m - 0.1*mm" alp1="-7.6321701*deg" bl1="0.5132*m - 0.1*mm" tl1="0.5735*m -0.1*mm" h1="0.2250*m - 0.1*mm" alp2="-7.6321701*deg" bl2="0.5132*m - 0.1*mm" tl2="0.5735*m - 0.1*mm" h2="0.2250*m - 0.1*mm" phi="0*deg" theta="0*deg"/>
+    <Box name="YB2_w1_m2" dx="0.08*m - 0.00000128175*m" dy="0.2250*m - 0.0000100001*m - 0.000000878882*m" dz="0.195*m"/>
+    <Box name="YB2_w1_m3" dx="0.2700*m - 0.0010879*m" dy="0.2250*m - 0.00000500004*m" dz="0.195*m"/>
+    <Box name="YB2_w1_m4" dx="0.08*m - 0.00000500004*m" dy="0.2250*m - 0.00000500004*m" dz="0.195*m"/>
+    <Trapezoid name="YB2_w1_m5" dz="0.195*m - 0.1*mm" alp1="7.6321701*deg" bl1="0.5132*m - 0.1*mm" tl1="0.5735*m - 0.1*mm" h1="0.2250*m - 0.1*mm" alp2="7.6321701*deg" bl2="0.5132*m - 0.1*mm" tl2="0.5735*m - 0.1*mm" h2="0.2250*m - 0.1*mm" phi="0*deg" theta="0*deg"/>
+    <Trapezoid name="YB2_w1_m6" dz="1.0729*m - 0.1*mm" alp1="0*deg" bl1="1.4563*m - 0.1*mm" tl1="1.5769*m - 0.1*mm" h1="0.2250*m - 0.00000899323*m - 0.1*mm" alp2="0*deg" bl2="1.4563*m - 0.1*mm" tl2="1.5769*m - 0.1*mm" h2="0.2250*m - 0.00000899323*m - 0.1*mm" phi="0*deg" theta="0*deg"/>
+    <Trapezoid name="YB2_w2_m1" dz="1.2679*m - 1.0*mm" alp1="0*deg" bl1="1.4563*m - 1.0*mm" tl1="1.5769*m - 1.0*mm" h1="0.2250*m - 1.0*mm" alp2="0*deg" bl2="1.4563*m - 1.0*mm" tl2="1.5769*m - 1.0*mm" h2="0.2250*m - 1.0*mm" phi="0*deg" theta="0*deg"/>
+    <Trapezoid name="YB2_w0_t1" dz="0.63395*m" alp1="-7.63074*deg" bl1="0.170592*m" tl1="0.18198*m" h1="0.0425*m" alp2="-7.63074*deg" bl2="0.170592*m" tl2="0.18198*m" h2="0.0425*m" phi="0*deg" theta="0*deg"/>
+    <Box name="YB2_w0_t2" dx="1.1837*m" dy="0.0425*m" dz="0.62495*m"/>
+    <Trapezoid name="YB2_w0_t3" dz="0.63395*m" alp1="7.63074*deg" bl1="0.222589*m - 0.000230615*m" tl1="0.233977*m - 0.000230615*m" h1="0.0425*m" alp2="7.63074*deg" bl2="0.222589*m - 0.000230615*m" tl2="0.233977*m - 0.000230615*m" h2="0.0425*m" phi="0*deg" theta="0*deg"/>
+    <Trapezoid name="YB2_w1_t1" dz="1.2679*m-0.00022993*m" alp1="-7.63074*deg" bl1="0.170592*m -0.00022993*m" tl1="0.18198*m-0.00022993*m" h1="0.0425*m - 0.00000120486*m - 0.00000992626*m" alp2="-7.63074*deg" bl2="0.170592*m-0.00022993*m" tl2="0.18198*m-0.00022993*m" h2="0.0425*m  - 0.00000120486*m  - 0.00000992626*m" phi="0*deg" theta="0*deg"/>
+    <Box name="YB2_w1_t2" dx="0.4029*m - 0.0000014786*m - 0.00000132987*m" dy="0.0425*m - 0.00000139205*m" dz="0.186*m"/>
+    <Box name="YB2_w1_t3" dx="0.08*m" dy="0.0425*m - 0.00000302717*m" dz="0.186*m"/>
+    <Box name="YB2_w1_t4" dx="0.2700*m - 0.000500004*m" dy="0.0425*m" dz="0.186*m"/>
+    <Box name="YB2_w1_t5" dx="0.08*m" dy="0.0425*m" dz="0.186*m"/>
+    <Box name="YB2_w1_t6" dx="0.3509*m" dy="0.0425*m - 0.00000813113*m" dz="0.186*m"/>
+    <Box name="YB2_w1_t7" dx="1.1837*m - 0.000000724682*m" dy="0.0425*m" dz="1.0639*m"/>
+    <Trapezoid name="YB2_w1_t8" dz="1.2679*m" alp1="7.63074*deg" bl1="0.222589*m" tl1="0.233977*m" h1="0.0425*m - 0.000000437559*m - 0.00000797313*m" alp2="7.63074*deg" bl2="0.222589*m" tl2="0.233977*m" h2="0.0425*m - 0.000000437559*m  - 0.00000797313*m" phi="0*deg" theta="0*deg"/>
+    <Trapezoid name="YB2_w2_t1" dz="1.2679*m" alp1="-7.63074*deg" bl1="0.170592*m" tl1="0.18198*m" h1="0.0425*m - 0.00000230615*m" alp2="-7.63074*deg" bl2="0.170592*m" tl2="0.18198*m" h2="0.0425*m - 0.00000230615*m" phi="0*deg" theta="0*deg"/>
+    <Box name="YB2_w2_t2" dx="1.1837*m" dy="0.0425*m" dz="1.2500*m"/>
+    <Trapezoid name="YB2_w2_t3" dz="1.2679*m" alp1="7.63074*deg" bl1="0.170592*m" tl1="0.18198*m" h1="0.0425*m" alp2="7.63074*deg" bl2="0.170592*m" tl2="0.18198*m" h2="0.0425*m" phi="0*deg" theta="0*deg"/>
+    <Box name="YBSepar3_w0" dx="0.0494*m" dy="0.2025*m - 0.00000352829*m" dz="0.63395*m"/>
+    <Box name="YBSepar3_w1" dx="0.0494*m" dy="0.2025*m - 0.00000352829*m" dz="1.2679*m"/>
+    <Box name="YBSepar3_w2" dx="0.0494*m" dy="0.2025*m - 0.00000352829*m" dz="1.2679*m"/>
+    <Trapezoid name="YB3_w0_b1" dz="0.63395*m" alp1="-7.63074*deg" bl1="0.169235*m - 0.000680958*m" tl1="0.180623*m - 0.000680958*m" h1="0.0425*m" alp2="-7.63074*deg" bl2="0.169235*m - 0.000680958*m" tl2="0.180623*m - 0.000680958*m" h2="0.0425*m" phi="0*deg" theta="0*deg"/>
+    <Box name="YB3_w0_b2" dx="1.34475*m" dy="0.0425*m" dz="0.62495*m"/>
+    <Trapezoid name="YB3_w0_b3" dz="0.63395*m" alp1="7.63074*deg" bl1="0.194191*m" tl1="0.205578*m" h1="0.0425*m - 0.00000876162*m" alp2="7.63074*deg" bl2="0.194191*m" tl2="0.205578*m" h2="0.0425*m - 0.00000876162*m" phi="0*deg" theta="0*deg"/>
+    <Trapezoid name="YB3_w1_b1" dz="1.2679*m" alp1="-7.63074*deg" bl1="0.169235*m - 0.00000630826*m" tl1="0.180623*m - 0.00000630826*m" h1="0.0425*m" alp2="-7.63074*deg" bl2="0.169235*m - 0.00000630826*m" tl2="0.180623*m - 0.00000630826*m" h2="0.0425*m" phi="0*deg" theta="0*deg"/>
+    <Box name="YB3_w1_b2" dx="0.4700*m - 0.0000807408*m" dy="0.0425*m" dz="0.186*m"/>
+    <Box name="YB3_w1_b3" dx="0.08*m - 0.000163912*m" dy="0.0425*m" dz="0.186*m"/>
+    <Box name="YB3_w1_b4" dx="0.2700*m" dy="0.0425*m - 0.00000146301*m" dz="0.186*m"/>
+    <Box name="YB3_w1_b5" dx="0.08*m - 0.000292602*m" dy="0.0425*m" dz="0.186*m"/>
+    <Box name="YB3_w1_b6" dx="0.44495*m - 0.00000111774*m - 0.000000195269*m" dy="0.0425*m - 0.00000519394*m" dz="0.186*m"/>
+    <Box name="YB3_w1_b7" dx="1.34475*m" dy="0.0425*m - 0.00000147966*m" dz="1.0639*m"/>
+    <Trapezoid name="YB3_w1_b8" dz="1.2679*m" alp1="7.63074*deg" bl1="0.194191*m - 0.00000630826*m" tl1="0.205578*m - 0.00000630826*m" h1="0.0425*m - 0.00000387392*m" alp2="7.63074*deg" bl2="0.194191*m - 0.00000630826*m" tl2="0.205578*m - 0.00000630826*m" h2="0.0425*m - 0.00000387392*m" phi="0*deg" theta="0*deg"/>
+    <Trapezoid name="YB3_w2_b1" dz="1.2679*m" alp1="-7.63074*deg" bl1="0.169237*m" tl1="0.180625*m" h1="0.0425*m" alp2="-7.63074*deg" bl2="0.169237*m" tl2="0.180625*m" h2="0.0425*m" phi="0*deg" theta="0*deg"/>
+    <Box name="YB3_w2_b2" dx="1.34468*m - 0.00000121798*m" dy="0.0425*m - 0.00000121798*m" dz="1.2500*m"/>
+    <Trapezoid name="YB3_w2_b3" dz="1.2679*m" alp1="7.63074*deg" bl1="0.169237*m" tl1="0.180625*m" h1="0.0425*m" alp2="7.63074*deg" bl2="0.169237*m" tl2="0.180625*m" h2="0.0425*m" phi="0*deg" theta="0*deg"/>
+    <Trapezoid name="YB3_w0_m" dz="0.63395*m" alp1="0*deg" bl1="1.731*m - 0.00239102*m" tl1="1.8515*m - 0.00239102*m" h1="0.2250*m  - 0.00000147966*m" alp2="0*deg" bl2="1.731*m - 0.00239102*m" tl2="1.8515*m - 0.00239102*m" h2="0.2250*m - 0.00000147966*m" phi="0*deg" theta="0*deg"/>
+    <Trapezoid name="YB3_w1_m1" dz="0.195*m -0.1*mm" alp1="-7.6259161*deg" bl1="0.65055*m - 0.1*mm" tl1="0.7108*m -0.1*mm" h1="0.2250*m - 0.0000261358*m - 0.1*mm" alp2="-7.6259161*deg" bl2="0.65055*m - 0.1*mm" tl2="0.7108*m - 0.1*mm" h2="0.2250*m - 0.0000261358*m - 0.1*mm" phi="0*deg" theta="0*deg"/> 
+    <Box name="YB3_w1_m2" dx="0.08*m - 0.00000143878*m - 1.0*mm" dy="0.2250*m" dz="0.195*m"/> 
+    <Box name="YB3_w1_m3" dx="0.2700*m" dy="0.2250*m - 0.000000878882*m - 1.0*mm" dz="0.195*m"/>
+    <Box name="YB3_w1_m4" dx="0.08*m - 0.000175776*m" dy="0.2250*m" dz="0.195*m"/>
+    <Trapezoid name="YB3_w1_m5" dz="0.195*m - 0.1*mm" alp1="7.6259161*deg" bl1="0.65055*m - 0.1*mm" tl1="0.7108*m - 0.1*mm" h1="0.2250*m - 0.1*mm" alp2="7.6259161*deg" bl2="0.65055*m -0.1*mm" tl2="0.7108*m -0.1*mm" h2="0.2250*m -0.1*mm" phi="0*deg" theta="0*deg"/>
+    <Trapezoid name="YB3_w1_m6" dz="1.0729*m - 0.00005*m" alp1="0*deg" bl1="1.731*m - 0.00005*m" tl1="1.8515*m - 0.00005*m" h1="0.2250*m - 0.00005*m" alp2="0*deg" bl2="1.731*m - 0.00005*m" tl2="1.8515*m - 0.00005*m" h2="0.2250*m  - 0.00005*m" phi="0*deg" theta="0*deg"/>
+    <Trapezoid name="YB3_w2_m1" dz="1.2679*m - 0.00005*m" alp1="0*deg" bl1="1.731*m - 0.00005*m" tl1="1.8515*m - 0.00005*m" h1="0.2250*m - 0.00005*m" alp2="0*deg" bl2="1.731*m - 0.00005*m" tl2="1.8515*m - 0.00005*m" h2="0.2250*m - 0.00005*m" phi="0*deg" theta="0*deg"/>
+    <Trapezoid name="YB3_w0_t1" dz="0.63395*m" alp1="-7.63074*deg" bl1="0.245512*m - 0.000167856*m" tl1="0.2569*m - 0.000167856*m" h1="0.0425*m" alp2="-7.63074*deg" bl2="0.245512*m - 0.000167856*m" tl2="0.2569*m - 0.000167856*m" h2="0.0425*m" phi="0*deg" theta="0*deg"/>
+    <Box name="YB3_w0_t2" dx="1.43693*m - 0.00000210212*m" dy="0.0425*m" dz="0.62495*m"/>
+    <Trapezoid name="YB3_w0_t3" dz="0.63395*m" alp1="7.63074*deg" bl1="0.169087*m" tl1="0.180475*m" h1="0.0425*m" alp2="7.63074*deg" bl2="0.169087*m" tl2="0.180475*m" h2="0.0425*m" phi="0*deg" theta="0*deg"/>
+    <Trapezoid name="YB3_w1_t1" dz="1.2679*m" alp1="-7.63074*deg" bl1="0.245514*m" tl1="0.256901*m" h1="0.0425*m" alp2="-7.63074*deg" bl2="0.245514*m" tl2="0.256901*m" h2="0.0425*m" phi="0*deg" theta="0*deg"/>
+    <Box name="YB3_w1_t2" dx="0.4653*m - 0.0000119433*m" dy="0.0425*m" dz="0.186*m"/>
+    <Box name="YB3_w1_t3" dx="0.08*m" dy="0.0425*m" dz="0.186*m"/>
+    <Box name="YB3_w1_t4" dx="0.2700*m - 0.0001749356*m" dy="0.0425*m" dz="0.186*m"/>
+    <Box name="YB3_w1_t5" dx="0.08*m" dy="0.0425*m" dz="0.186*m"/>
+    <Box name="YB3_w1_t6" dx="0.5418*m - 0.000009*m" dy="0.0425*m" dz="0.186*m"/>
+    <Box name="YB3_w1_t7" dx="1.437*m - 0.00000247035*m - 0.000000480318*m" dy="0.0425*m - 0.00000136796*m" dz="1.0639*m"/>
+    <Trapezoid name="YB3_w1_t8" dz="1.2679*m" alp1="7.63074*deg" bl1="0.169015*m" tl1="0.180403*m" h1="0.0425*m - 0.00000368825*m" alp2="7.63074*deg" bl2="0.169015*m" tl2="0.180403*m" h2="0.0425*m - 0.00000368825*m" phi="0*deg" theta="0*deg"/>
+    <Trapezoid name="YB3_w2_t1" dz="1.2679*m" alp1="-7.63074*deg" bl1="0.245514*m" tl1="0.256901*m" h1="0.0425*m" alp2="-7.63074*deg" bl2="0.245514*m" tl2="0.256901*m" h2="0.0425*m" phi="0*deg" theta="0*deg"/>
+    <Box name="YB3_w2_t2" dx="1.437*m - 0.00000246843*m" dy="0.0425*m - 0.000000842895*m" dz="1.2500*m"/>
+    <Trapezoid name="YB3_w2_t3" dz="1.2679*m" alp1="7.63074*deg" bl1="0.169015*m" tl1="0.180403*m" h1="0.0425*m" alp2="7.63074*deg" bl2="0.169015*m" tl2="0.180403*m" h2="0.0425*m" phi="0*deg" theta="0*deg"/> 
+    <Box name="CHIMHOLE_IRON_P" dx="0.27*m" dy="0.63/2*m" dz="0.1861*m"/>
+    <Box name="CHIMHOLE_IRON_N" dx="0.42*m" dy="0.63/2*m" dz="0.1861*m"/>
+    <SubtractionSolid name="YB1Chim_w1N_b3">
+      <rSolid name="YB1_w1_b3"/>
+      <rSolid name="CHIMHOLE_IRON_N"/>
+      <rRotation name="rotations:000D"/>
+      <Translation x="0.35*m" y="0.*fm" z="0.*fm"/>
+    </SubtractionSolid>
+    <SubtractionSolid name="YB1Chim_w1N_b5">
+      <rSolid name="YB1_w1_b5"/>
+      <rSolid name="CHIMHOLE_IRON_N"/>
+      <rRotation name="rotations:000D"/>
+      <Translation x="-0.35*m" y="0.*fm" z="0.*fm"/>
+    </SubtractionSolid>
+    <SubtractionSolid name="YB1Chim_w1N_m3">
+      <rSolid name="YB1_w1_m3"/>
+      <rSolid name="CHIMHOLE_IRON_N"/>
+      <rRotation name="rotations:000D"/>
+      <Translation x="0.*m" y="0.*fm" z="9*mm"/>
+    </SubtractionSolid>
+    <SubtractionSolid name="YB1Chim_w1N_m2">
+      <rSolid name="YB1_w1_m2"/>
+      <rSolid name="CHIMHOLE_IRON_N"/>
+      <rRotation name="rotations:000D"/>
+      <Translation x="0.35*m" y="0.*fm" z="9*mm"/>
+    </SubtractionSolid>
+    <SubtractionSolid name="YB1Chim_w1N_m4">
+      <rSolid name="YB1_w1_m4"/>
+      <rSolid name="CHIMHOLE_IRON_N"/>
+      <rRotation name="rotations:000D"/>
+      <Translation x="-0.35*m" y="0.*fm" z="9*mm"/>
+    </SubtractionSolid>
+    <SubtractionSolid name="YB2Chim_w1N_b3">
+      <rSolid name="YB2_w1_b3"/>
+      <rSolid name="CHIMHOLE_IRON_N"/>
+      <rRotation name="rotations:000D"/>
+      <Translation x="0.35*m" y="0.*fm" z="0.*fm"/>
+    </SubtractionSolid>
+    <SubtractionSolid name="YB2Chim_w1N_b5">
+      <rSolid name="YB2_w1_b5"/>
+      <rSolid name="CHIMHOLE_IRON_N"/>
+      <rRotation name="rotations:000D"/>
+      <Translation x="-0.35*m" y="0.*fm" z="0.*fm"/>
+    </SubtractionSolid>
+    <SubtractionSolid name="YB2Chim_w1N_m3">
+      <rSolid name="YB2_w1_m3"/>
+      <rSolid name="CHIMHOLE_IRON_N"/>
+      <rRotation name="rotations:000D"/>
+      <Translation x="0.*m" y="0.*fm" z="9*mm"/>
+    </SubtractionSolid>
+    <SubtractionSolid name="YB2Chim_w1N_m2">
+      <rSolid name="YB2_w1_m2"/>
+      <rSolid name="CHIMHOLE_IRON_N"/>
+      <rRotation name="rotations:000D"/>
+      <Translation x="0.35*m" y="0.*fm" z="9*mm"/>
+    </SubtractionSolid>
+    <SubtractionSolid name="YB2Chim_w1N_m4">
+      <rSolid name="YB2_w1_m4"/>
+      <rSolid name="CHIMHOLE_IRON_N"/>
+      <rRotation name="rotations:000D"/>
+      <Translation x="-0.35*m" y="0.*fm" z="9*mm"/>
+    </SubtractionSolid>
+    <SubtractionSolid name="YB2Chim_w1N_t3">
+      <rSolid name="YB2_w1_t3"/>
+      <rSolid name="CHIMHOLE_IRON_N"/>
+      <rRotation name="rotations:000D"/>
+      <Translation x="0.35*m" y="0.*fm" z="0.*fm"/>
+    </SubtractionSolid>
+    <SubtractionSolid name="YB2Chim_w1N_t5">
+      <rSolid name="YB2_w1_t5"/>
+      <rSolid name="CHIMHOLE_IRON_N"/>
+      <rRotation name="rotations:000D"/>
+      <Translation x="-0.35*m" y="0.*fm" z="0.*fm"/>
+    </SubtractionSolid>
+    <SubtractionSolid name="YB3Chim_w1N_b3">
+      <rSolid name="YB3_w1_b3"/>
+      <rSolid name="CHIMHOLE_IRON_N"/>
+      <rRotation name="rotations:000D"/>
+      <Translation x="0.35*m" y="0.*fm" z="0.*fm"/>
+    </SubtractionSolid>
+    <SubtractionSolid name="YB3Chim_w1N_b5">
+      <rSolid name="YB3_w1_b5"/>
+      <rSolid name="CHIMHOLE_IRON_N"/>
+      <rRotation name="rotations:000D"/>
+      <Translation x="-0.35*m" y="0.*fm" z="0.*fm"/>
+    </SubtractionSolid>
+    <SubtractionSolid name="YB3Chim_w1N_m3">
+      <rSolid name="YB3_w1_m3"/>
+      <rSolid name="CHIMHOLE_IRON_N"/>
+      <rRotation name="rotations:000D"/>
+      <Translation x="0.*m" y="0.*fm" z="9.*mm"/>
+    </SubtractionSolid>
+    <SubtractionSolid name="YB3Chim_w1N_m2">
+      <rSolid name="YB3_w1_m2"/>
+      <rSolid name="CHIMHOLE_IRON_N"/>
+      <rRotation name="rotations:000D"/>
+      <Translation x="0.35*m" y="0.*fm" z="9.*mm"/>
+    </SubtractionSolid>
+    <SubtractionSolid name="YB3Chim_w1N_m4">
+      <rSolid name="YB3_w1_m4"/>
+      <rSolid name="CHIMHOLE_IRON_N"/>
+      <rRotation name="rotations:000D"/>
+      <Translation x="-0.35*m" y="0.*fm" z="9.*mm"/>
+    </SubtractionSolid>
+    <SubtractionSolid name="YB3Chim_w1N_t3">
+      <rSolid name="YB3_w1_t3"/>
+      <rSolid name="CHIMHOLE_IRON_N"/>
+      <rRotation name="rotations:000D"/>
+      <Translation x="0.35*m" y="0.*fm" z="0.*fm"/>
+    </SubtractionSolid>
+    <SubtractionSolid name="YB3Chim_w1N_t5">
+      <rSolid name="YB3_w1_b5"/>
+      <rSolid name="CHIMHOLE_IRON_N"/>
+      <rRotation name="rotations:000D"/>
+      <Translation x="-0.35*m" y="0.*fm" z="0.*fm"/>
+    </SubtractionSolid>
+    <SubtractionSolid name="YB1Chim_w1P_m3">
+      <rSolid name="YB1_w1_m3"/>
+      <rSolid name="CHIMHOLE_IRON_P"/>
+      <rRotation name="rotations:000D"/>
+      <Translation x="0.*m" y="0.*fm" z="-9.*mm"/>
+    </SubtractionSolid>
+    <SubtractionSolid name="YB2Chim_w1P_m3">
+      <rSolid name="YB2_w1_m3"/>
+      <rSolid name="CHIMHOLE_IRON_P"/>
+      <rRotation name="rotations:000D"/>
+      <Translation x="0.*m" y="0.*fm" z="-9.*mm"/>
+    </SubtractionSolid>
+    <SubtractionSolid name="YB3Chim_w1P_m3">
+      <rSolid name="YB3_w1_m3"/>
+      <rSolid name="CHIMHOLE_IRON_P"/>
+      <rRotation name="rotations:000D"/>
+      <Translation x="0.*m" y="0.*fm" z="-9.*mm"/>
+    </SubtractionSolid>
+    <!--- #### Non iron volumes -->
+    <Box name="YBSepar_1" dx="3.75*cm" dy="43.4669*cm" dz="1.268*m"/>
+  </SolidSection>
+  <LogicalPartSection label="muonYoke.xml">
+    <LogicalPart name="YN12p_a" category="unspecified">
+      <rSolid name="YN12_a"/>
+      <rMaterial name="materials:AISI-1018-Steel"/>
+    </LogicalPart>
+    <LogicalPart name="YN12p_b" category="unspecified">
+      <rSolid name="YN12_b"/>
+      <rMaterial name="materials:AISI-1018-Steel"/>
+    </LogicalPart>
+    <LogicalPart name="YN12p_c" category="unspecified">
+      <rSolid name="YN12_c"/>
+      <rMaterial name="materials:AISI-1018-Steel"/>
+    </LogicalPart>
+    <LogicalPart name="YE1p_a" category="unspecified">
+      <rSolid name="YE1_a"/>
+      <rMaterial name="materials:AISI-1018-Steel"/>
+    </LogicalPart>
+    <LogicalPart name="YE1p_b" category="unspecified">
+      <rSolid name="YE1_b"/>
+      <rMaterial name="materials:AISI-1018-Steel"/>
+    </LogicalPart>
+    <LogicalPart name="YE12" category="unspecified">
+      <rSolid name="YE12"/>
+      <rMaterial name="materials:AISI-1018-Steel"/>
+    </LogicalPart>
+    <LogicalPart name="YE2p_a" category="unspecified">
+      <rSolid name="YE2_a"/>
+      <rMaterial name="materials:AISI-1018-Steel"/>
+    </LogicalPart>
+    <LogicalPart name="YE2p_b" category="unspecified">
+      <rSolid name="YE2_b"/>
+      <rMaterial name="materials:AISI-1018-Steel"/>
+    </LogicalPart>
+    <LogicalPart name="YE23" category="unspecified">
+      <rSolid name="YE23"/>
+      <rMaterial name="materials:AISI-1018-Steel"/>
+    </LogicalPart>
+    <LogicalPart name="YE3p_a" category="unspecified">
+      <rSolid name="YE3_a"/>
+      <rMaterial name="materials:AISI-1018-Steel"/>
+    </LogicalPart>
+    <LogicalPart name="YE3p_b" category="unspecified">
+      <rSolid name="YE3_b"/>
+      <rMaterial name="materials:AISI-1018-Steel"/>
+    </LogicalPart>
+    <LogicalPart name="YE34" category="unspecified">
+      <rSolid name="YE34"/>
+      <rMaterial name="materials:AISI-1018-Steel"/>
+    </LogicalPart>
+    <LogicalPart name="ShieldingME4" category="unspecified">
+      <rSolid name="ShieldingME4"/>
+      <rMaterial name="materials:AISI-1018-Steel"/>
+    </LogicalPart>
+    <LogicalPart name="YE4" category="unspecified"> 
+      <rSolid name="YE4"/> 
+      <rMaterial name="materials:AISI-1018-Steel"/> 
+    </LogicalPart> 
+    <LogicalPart name="YE4_in" category="unspecified"> 
+      <rSolid name="YE4_in"/> 
+      <rMaterial name="materials:Heavy Boron concrete"/> 
+    </LogicalPart> 
+    <LogicalPart name="YB1_w0_b1" category="unspecified">
+      <rSolid name="YB1_w0_b1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w0_b4" category="unspecified">
+      <rSolid name="YB1_w0_b1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w0_b2" category="unspecified">
+      <rSolid name="YB1_w0_b2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w0_b5" category="unspecified">
+      <rSolid name="YB1_w0_b2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w0_b3" category="unspecified">
+      <rSolid name="YB1_w0_b3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w1P_b1" category="unspecified">
+      <rSolid name="YB1_w1_b1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w1N_b1" category="unspecified">
+      <rSolid name="YB1_w1_b1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w1P_b2" category="unspecified">
+      <rSolid name="YB1_w1_b2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w1N_b2" category="unspecified">
+      <rSolid name="YB1_w1_b2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w1P_b3" category="unspecified">
+      <rSolid name="YB1_w1_b3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w1N_b3" category="unspecified">
+      <rSolid name="YB1_w1_b3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w1P_b4" category="unspecified">
+      <rSolid name="YB1_w1_b4"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w1N_b4" category="unspecified">
+      <rSolid name="YB1_w1_b4"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w1P_b5" category="unspecified">
+      <rSolid name="YB1_w1_b5"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w1N_b5" category="unspecified">
+      <rSolid name="YB1_w1_b5"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w1P_b6" category="unspecified">
+      <rSolid name="YB1_w1_b6"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w1N_b6" category="unspecified">
+      <rSolid name="YB1_w1_b6"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w1P_b7" category="unspecified">
+      <rSolid name="YB1_w1_b7"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w1N_b7" category="unspecified">
+      <rSolid name="YB1_w1_b7"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w1P_b8" category="unspecified">
+      <rSolid name="YB1_w1_b8"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w1N_b8" category="unspecified">
+      <rSolid name="YB1_w1_b8"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w2P_b1" category="unspecified">
+      <rSolid name="YB1_w2_b1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w2N_b1" category="unspecified">
+      <rSolid name="YB1_w2_b1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w2P_b2" category="unspecified">
+      <rSolid name="YB1_w2_b2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w2N_b2" category="unspecified">
+      <rSolid name="YB1_w2_b2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w2P_b3" category="unspecified">
+      <rSolid name="YB1_w2_b3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w2N_b3" category="unspecified">
+      <rSolid name="YB1_w2_b3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w0_m1" category="unspecified">
+      <rSolid name="YB1_w0_m"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w0_m2" category="unspecified">
+      <rSolid name="YB1_w0_m"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w1P_m1" category="unspecified">
+      <rSolid name="YB1_w1_m1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w1N_m1" category="unspecified">
+      <rSolid name="YB1_w1_m1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w1P_m2" category="unspecified">
+      <rSolid name="YB1_w1_m2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w1N_m2" category="unspecified">
+      <rSolid name="YB1_w1_m2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w1P_m3" category="unspecified">
+      <rSolid name="YB1_w1_m3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w1N_m3" category="unspecified">
+      <rSolid name="YB1_w1_m3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w1P_m4" category="unspecified">
+      <rSolid name="YB1_w1_m4"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w1N_m4" category="unspecified">
+      <rSolid name="YB1_w1_m4"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w1P_m5" category="unspecified">
+      <rSolid name="YB1_w1_m5"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w1N_m5" category="unspecified">
+      <rSolid name="YB1_w1_m5"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w1P_m6" category="unspecified">
+      <rSolid name="YB1_w1_m6"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w1N_m6" category="unspecified">
+      <rSolid name="YB1_w1_m6"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w2P_m1" category="unspecified">
+      <rSolid name="YB1_w2_m1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1_w2N_m1" category="unspecified">
+      <rSolid name="YB1_w2_m1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YBSepar2_w0_1" category="unspecified">
+      <rSolid name="YBSepar2_w0"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YBSepar2_w0_2" category="unspecified">
+      <rSolid name="YBSepar2_w0"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YBSepar2_w1P" category="unspecified">
+      <rSolid name="YBSepar2_w1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YBSepar2_w1N" category="unspecified">
+      <rSolid name="YBSepar2_w1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YBSepar2_w2P" category="unspecified">
+      <rSolid name="YBSepar2_w2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YBSepar2_w2N" category="unspecified">
+      <rSolid name="YBSepar2_w2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w0_b1" category="unspecified">
+      <rSolid name="YB2_w0_b1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w0_b4" category="unspecified">
+      <rSolid name="YB2_w0_b1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w0_b2" category="unspecified">
+      <rSolid name="YB2_w0_b2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w0_b5" category="unspecified">
+      <rSolid name="YB2_w0_b2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w0_b3" category="unspecified">
+      <rSolid name="YB2_w0_b3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w0_b6" category="unspecified">
+      <rSolid name="YB2_w0_b3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1P_b1" category="unspecified">
+      <rSolid name="YB2_w1_b1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1N_b1" category="unspecified">
+      <rSolid name="YB2_w1_b1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1P_b2" category="unspecified">
+      <rSolid name="YB2_w1_b2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1N_b2" category="unspecified">
+      <rSolid name="YB2_w1_b2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1P_b3" category="unspecified">
+      <rSolid name="YB2_w1_b3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1N_b3" category="unspecified">
+      <rSolid name="YB2_w1_b3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1P_b4" category="unspecified">
+      <rSolid name="YB2_w1_b4"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1N_b4" category="unspecified">
+      <rSolid name="YB2_w1_b4"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1P_b5" category="unspecified">
+      <rSolid name="YB2_w1_b5"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1N_b5" category="unspecified">
+      <rSolid name="YB2_w1_b5"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1P_b6" category="unspecified">
+      <rSolid name="YB2_w1_b6"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1N_b6" category="unspecified">
+      <rSolid name="YB2_w1_b6"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1P_b7" category="unspecified">
+      <rSolid name="YB2_w1_b7"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1N_b7" category="unspecified">
+      <rSolid name="YB2_w1_b7"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1P_b8" category="unspecified">
+      <rSolid name="YB2_w1_b8"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1N_b8" category="unspecified">
+      <rSolid name="YB2_w1_b8"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w2P_b1" category="unspecified">
+      <rSolid name="YB2_w2_b1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w2N_b1" category="unspecified">
+      <rSolid name="YB2_w2_b1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w2P_b2" category="unspecified">
+      <rSolid name="YB2_w2_b2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w2N_b2" category="unspecified">
+      <rSolid name="YB2_w2_b2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w2P_b3" category="unspecified">
+      <rSolid name="YB2_w2_b3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w2N_b3" category="unspecified">
+      <rSolid name="YB2_w2_b3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w0_m1" category="unspecified">
+      <rSolid name="YB2_w0_m"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w0_m2" category="unspecified">
+      <rSolid name="YB2_w0_m"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1P_m1" category="unspecified">
+      <rSolid name="YB2_w1_m1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1N_m1" category="unspecified">
+      <rSolid name="YB2_w1_m1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1P_m2" category="unspecified">
+      <rSolid name="YB2_w1_m2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1N_m2" category="unspecified">
+      <rSolid name="YB2_w1_m2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1P_m3" category="unspecified">
+      <rSolid name="YB2_w1_m3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1N_m3" category="unspecified">
+      <rSolid name="YB2_w1_m3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1P_m4" category="unspecified">
+      <rSolid name="YB2_w1_m4"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1N_m4" category="unspecified">
+      <rSolid name="YB2_w1_m4"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1P_m5" category="unspecified">
+      <rSolid name="YB2_w1_m5"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1N_m5" category="unspecified">
+      <rSolid name="YB2_w1_m5"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1P_m6" category="unspecified">
+      <rSolid name="YB2_w1_m6"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1N_m6" category="unspecified">
+      <rSolid name="YB2_w1_m6"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w2P_m1" category="unspecified">
+      <rSolid name="YB2_w2_m1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w2N_m1" category="unspecified">
+      <rSolid name="YB2_w2_m1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w0_t1" category="unspecified">
+      <rSolid name="YB2_w0_t1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w0_t4" category="unspecified">
+      <rSolid name="YB2_w0_t1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w0_t2" category="unspecified">
+      <rSolid name="YB2_w0_t2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w0_t5" category="unspecified">
+      <rSolid name="YB2_w0_t2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w0_t3" category="unspecified">
+      <rSolid name="YB2_w0_t3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w0_t6" category="unspecified">
+      <rSolid name="YB2_w0_t3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1P_t1" category="unspecified">
+      <rSolid name="YB2_w1_t1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1N_t1" category="unspecified">
+      <rSolid name="YB2_w1_t1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1P_t2" category="unspecified">
+      <rSolid name="YB2_w1_t2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1N_t2" category="unspecified">
+      <rSolid name="YB2_w1_t2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1P_t3" category="unspecified">
+      <rSolid name="YB2_w1_t3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1N_t3" category="unspecified">
+      <rSolid name="YB2_w1_t3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1P_t4" category="unspecified">
+      <rSolid name="YB2_w1_t4"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1N_t4" category="unspecified">
+      <rSolid name="YB2_w1_t4"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1P_t5" category="unspecified">
+      <rSolid name="YB2_w1_t5"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1N_t5" category="unspecified">
+      <rSolid name="YB2_w1_t5"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1P_t6" category="unspecified">
+      <rSolid name="YB2_w1_t6"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1N_t6" category="unspecified">
+      <rSolid name="YB2_w1_t6"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1P_t7" category="unspecified">
+      <rSolid name="YB2_w1_t7"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1N_t7" category="unspecified">
+      <rSolid name="YB2_w1_t7"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1P_t8" category="unspecified">
+      <rSolid name="YB2_w1_t8"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w1N_t8" category="unspecified">
+      <rSolid name="YB2_w1_t8"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w2P_t1" category="unspecified">
+      <rSolid name="YB2_w2_t1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w2N_t1" category="unspecified">
+      <rSolid name="YB2_w2_t1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w2P_t2" category="unspecified">
+      <rSolid name="YB2_w2_t2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w2N_t2" category="unspecified">
+      <rSolid name="YB2_w2_t2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w2P_t3" category="unspecified">
+      <rSolid name="YB2_w2_t3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2_w2N_t3" category="unspecified">
+      <rSolid name="YB2_w2_t3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YBSepar3_w0_1" category="unspecified">
+      <rSolid name="YBSepar3_w0"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YBSepar3_w0_2" category="unspecified">
+      <rSolid name="YBSepar3_w0"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YBSepar3_w1P" category="unspecified">
+      <rSolid name="YBSepar3_w1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YBSepar3_w1N" category="unspecified">
+      <rSolid name="YBSepar3_w1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YBSepar3_w2P" category="unspecified">
+      <rSolid name="YBSepar3_w2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YBSepar3_w2N" category="unspecified">
+      <rSolid name="YBSepar3_w2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w0_b1" category="unspecified">
+      <rSolid name="YB3_w0_b1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w0_b4" category="unspecified">
+      <rSolid name="YB3_w0_b1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w0_b2" category="unspecified">
+      <rSolid name="YB3_w0_b2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w0_b5" category="unspecified">
+      <rSolid name="YB3_w0_b2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w0_b3" category="unspecified">
+      <rSolid name="YB3_w0_b3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w0_b6" category="unspecified">
+      <rSolid name="YB3_w0_b3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1P_b1" category="unspecified">
+      <rSolid name="YB3_w1_b1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1N_b1" category="unspecified">
+      <rSolid name="YB3_w1_b1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1P_b2" category="unspecified">
+      <rSolid name="YB3_w1_b2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1N_b2" category="unspecified">
+      <rSolid name="YB3_w1_b2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1P_b3" category="unspecified">
+      <rSolid name="YB3_w1_b3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1N_b3" category="unspecified">
+      <rSolid name="YB3_w1_b3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1P_b4" category="unspecified">
+      <rSolid name="YB3_w1_b4"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1N_b4" category="unspecified">
+      <rSolid name="YB3_w1_b4"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1P_b5" category="unspecified">
+      <rSolid name="YB3_w1_b5"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1N_b5" category="unspecified">
+      <rSolid name="YB3_w1_b5"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1P_b6" category="unspecified">
+      <rSolid name="YB3_w1_b6"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1N_b6" category="unspecified">
+      <rSolid name="YB3_w1_b6"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1P_b7" category="unspecified">
+      <rSolid name="YB3_w1_b7"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1N_b7" category="unspecified">
+      <rSolid name="YB3_w1_b7"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1P_b8" category="unspecified">
+      <rSolid name="YB3_w1_b8"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1N_b8" category="unspecified">
+      <rSolid name="YB3_w1_b8"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w2P_b1" category="unspecified">
+      <rSolid name="YB3_w2_b1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w2N_b1" category="unspecified">
+      <rSolid name="YB3_w2_b1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w2P_b2" category="unspecified">
+      <rSolid name="YB3_w2_b2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w2N_b2" category="unspecified">
+      <rSolid name="YB3_w2_b2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w2P_b3" category="unspecified">
+      <rSolid name="YB3_w2_b3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w2N_b3" category="unspecified">
+      <rSolid name="YB3_w2_b3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w0_m1" category="unspecified">
+      <rSolid name="YB3_w0_m"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w0_m2" category="unspecified">
+      <rSolid name="YB3_w0_m"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1P_m1" category="unspecified">
+      <rSolid name="YB3_w1_m1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1N_m1" category="unspecified">
+      <rSolid name="YB3_w1_m1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1P_m2" category="unspecified">
+      <rSolid name="YB3_w1_m2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1N_m2" category="unspecified">
+      <rSolid name="YB3_w1_m2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1P_m3" category="unspecified">
+      <rSolid name="YB3_w1_m3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1N_m3" category="unspecified">
+      <rSolid name="YB3_w1_m3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1P_m4" category="unspecified">
+      <rSolid name="YB3_w1_m4"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1N_m4" category="unspecified">
+      <rSolid name="YB3_w1_m4"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1P_m5" category="unspecified">
+      <rSolid name="YB3_w1_m5"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1N_m5" category="unspecified">
+      <rSolid name="YB3_w1_m5"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1P_m6" category="unspecified">
+      <rSolid name="YB3_w1_m6"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1N_m6" category="unspecified">
+      <rSolid name="YB3_w1_m6"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w2P_m1" category="unspecified">
+      <rSolid name="YB3_w2_m1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w2N_m1" category="unspecified">
+      <rSolid name="YB3_w2_m1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w0_t1" category="unspecified">
+      <rSolid name="YB3_w0_t1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w0_t4" category="unspecified">
+      <rSolid name="YB3_w0_t1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w0_t2" category="unspecified">
+      <rSolid name="YB3_w0_t2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w0_t5" category="unspecified">
+      <rSolid name="YB3_w0_t2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w0_t3" category="unspecified">
+      <rSolid name="YB3_w0_t3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w0_t6" category="unspecified">
+      <rSolid name="YB3_w0_t3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1P_t1" category="unspecified">
+      <rSolid name="YB3_w1_t1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1N_t1" category="unspecified">
+      <rSolid name="YB3_w1_t1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1P_t2" category="unspecified">
+      <rSolid name="YB3_w1_t2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1N_t2" category="unspecified">
+      <rSolid name="YB3_w1_t2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1P_t3" category="unspecified">
+      <rSolid name="YB3_w1_t3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1N_t3" category="unspecified">
+      <rSolid name="YB3_w1_t3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1P_t4" category="unspecified">
+      <rSolid name="YB3_w1_t4"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1N_t4" category="unspecified">
+      <rSolid name="YB3_w1_t4"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1P_t5" category="unspecified">
+      <rSolid name="YB3_w1_t5"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1N_t5" category="unspecified">
+      <rSolid name="YB3_w1_t5"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1P_t6" category="unspecified">
+      <rSolid name="YB3_w1_t6"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1N_t6" category="unspecified">
+      <rSolid name="YB3_w1_t6"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1P_t7" category="unspecified">
+      <rSolid name="YB3_w1_t7"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1N_t7" category="unspecified">
+      <rSolid name="YB3_w1_t7"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1P_t8" category="unspecified">
+      <rSolid name="YB3_w1_t8"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w1N_t8" category="unspecified">
+      <rSolid name="YB3_w1_t8"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w2P_t1" category="unspecified">
+      <rSolid name="YB3_w2_t1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w2N_t1" category="unspecified">
+      <rSolid name="YB3_w2_t1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w2P_t2" category="unspecified">
+      <rSolid name="YB3_w2_t2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w2N_t2" category="unspecified">
+      <rSolid name="YB3_w2_t2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w2P_t3" category="unspecified">
+      <rSolid name="YB3_w2_t3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3_w2N_t3" category="unspecified">
+      <rSolid name="YB3_w2_t3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="CHIMHOLE_IRON_P" category="unspecified">
+      <rSolid name="CHIMHOLE_IRON_P"/>
+      <rMaterial name="materials:Air"/>
+    </LogicalPart>
+    <LogicalPart name="CHIMHOLE_IRON_N" category="unspecified">
+      <rSolid name="CHIMHOLE_IRON_N"/>
+      <rMaterial name="materials:Air"/>
+    </LogicalPart>
+    <LogicalPart name="YB1Chim_w1N_b3" category="unspecified">
+      <rSolid name="YB1Chim_w1N_b3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1Chim_w1N_b5" category="unspecified">
+      <rSolid name="YB1Chim_w1N_b5"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1Chim_w1N_m3" category="unspecified">
+      <rSolid name="YB1Chim_w1N_m3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1Chim_w1N_m2" category="unspecified">
+      <rSolid name="YB1Chim_w1N_m2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1Chim_w1N_m4" category="unspecified">
+      <rSolid name="YB1Chim_w1N_m4"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2Chim_w1N_b3" category="unspecified">
+      <rSolid name="YB2Chim_w1N_b3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2Chim_w1N_b5" category="unspecified">
+      <rSolid name="YB2Chim_w1N_b5"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2Chim_w1N_m3" category="unspecified">
+      <rSolid name="YB2Chim_w1N_m3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2Chim_w1N_m2" category="unspecified">
+      <rSolid name="YB2Chim_w1N_m2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2Chim_w1N_m4" category="unspecified">
+      <rSolid name="YB2Chim_w1N_m4"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2Chim_w1N_t3" category="unspecified">
+      <rSolid name="YB2Chim_w1N_t3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2Chim_w1N_t5" category="unspecified">
+      <rSolid name="YB2Chim_w1N_t5"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3Chim_w1N_b3" category="unspecified">
+      <rSolid name="YB3Chim_w1N_b3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3Chim_w1N_b5" category="unspecified">
+      <rSolid name="YB3Chim_w1N_b5"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3Chim_w1N_m3" category="unspecified">
+      <rSolid name="YB3Chim_w1N_m3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3Chim_w1N_m2" category="unspecified">
+      <rSolid name="YB3Chim_w1N_m2"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3Chim_w1N_m4" category="unspecified">
+      <rSolid name="YB3Chim_w1N_m4"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3Chim_w1N_t3" category="unspecified">
+      <rSolid name="YB3Chim_w1N_t3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3Chim_w1N_t5" category="unspecified">
+      <rSolid name="YB3Chim_w1N_t5"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB1Chim_w1P_m3" category="unspecified">
+      <rSolid name="YB1Chim_w1P_m3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB2Chim_w1P_m3" category="unspecified">
+      <rSolid name="YB2Chim_w1P_m3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <LogicalPart name="YB3Chim_w1P_m3" category="unspecified">
+      <rSolid name="YB3Chim_w1P_m3"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+    <!--- #### Non iron volumes -->
+    <LogicalPart name="YBSepar_1" category="unspecified">
+      <rSolid name="YBSepar_1"/>
+      <rMaterial name="materials:M_Steel-008"/>
+    </LogicalPart>
+  </LogicalPartSection>
+  <PosPartSection label="muonYoke.xml">
+    <Algorithm name="global:DDAngular">
+      <rParent name="mf:MEP"/>
+      <String name="ChildName" value="YN12p_a"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="0*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="0"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 6.5900*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="mf:MEP"/>
+      <String name="ChildName" value="YN12p_b"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="0*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="0"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 6.885*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="mf:MEP"/>
+      <String name="ChildName" value="YN12p_c"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="0*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="0"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 7.099*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="mf:MEP"/>
+      <String name="ChildName" value="YE1p_a"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="0*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="0"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 7.62*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="mf:MEP"/>
+      <String name="ChildName" value="YE1p_b"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="0*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="0*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 7.565*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0*deg, 0.*deg, 0*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="mf:MEP"/>
+      <String name="ChildName" value="YE12"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="0*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="0"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 8.2425*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="mf:MEP"/>
+      <String name="ChildName" value="YE2p_a"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="0*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="0"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 8.870*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="mf:MEP"/>
+      <String name="ChildName" value="YE2p_b"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="0*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="0*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 8.82*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0*deg, 0.*deg, 0*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="mf:MEP"/>
+      <String name="ChildName" value="YE23"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="0*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="0"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 9.4975*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="mf:MEP"/>
+      <String name="ChildName" value="YE3p_a"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="0*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="0"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 9.950*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="mf:MEP"/>
+      <String name="ChildName" value="YE3p_b"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="0*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="0*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 9.9*m - 0.495*cm </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0*deg, 0.*deg, 0*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="mf:MEP"/>
+      <String name="ChildName" value="YE34"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="0*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="0"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 10.4075*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="mf:MEP"/>
+      <String name="ChildName" value="ShieldingME4"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="0*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="0"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 10.7175*m + 0.455*cm</Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="mf:MEP"/> 
+      <String  name="ChildName"   value="YE4"/> 
+      <Numeric name="StartCopyNo" value="1" />
+      <Numeric name="IncrCopyNo"  value="1" />
+      <Numeric name="N"           value="12"/> 
+      <Numeric name="StartAngle"  value="0*deg"/> 
+      <Numeric name="RangeAngle"  value="360*deg"/> 
+      <Numeric name="Radius"      value="0*m"/> 
+      <Vector  name="Center" type="numeric" nEntries="3"> 0, 0, 10.7425*m + 0.455*cm</Vector>
+      <Vector  name="RotateSolid" type="numeric" nEntries="3"> 0*deg, 0.*deg, 0*deg </Vector>
+    </Algorithm>
+    <PosPart copyNumber="3">
+      <rParent name="muonYoke:YE4"/>
+      <rChild name="YE4_in"/>
+    </PosPart>
+    <Algorithm name="global:DDAngular">
+      <rParent name="mf:MEN"/>
+      <String name="ChildName" value="YN12p_a"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="0*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="0"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 6.5900*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="mf:MEN"/>
+      <String name="ChildName" value="YN12p_b"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="0*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="0"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 6.885*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="mf:MEN"/>
+      <String name="ChildName" value="YN12p_c"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="0*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="0"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 7.099*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="mf:MEN"/>
+      <String name="ChildName" value="YE1p_a"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="0*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="0"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 7.62*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="mf:MEN"/>
+      <String name="ChildName" value="YE1p_b"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="0*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="0*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 7.565*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0*deg, 0.*deg, 0*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="mf:MEN"/>
+      <String name="ChildName" value="YE12"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="0*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="0"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 8.2425*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="mf:MEN"/>
+      <String name="ChildName" value="YE2p_a"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="0*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="0"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 8.870*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="mf:MEN"/>
+      <String name="ChildName" value="YE2p_b"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="0*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="0*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 8.82*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0*deg, 0.*deg, 0*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="mf:MEN"/>
+      <String name="ChildName" value="YE23"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="0*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="0"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 9.4975*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="mf:MEN"/>
+      <String name="ChildName" value="YE3p_a"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="0*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="0"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 9.950*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="mf:MEN"/>
+      <String name="ChildName" value="YE3p_b"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="0*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="0*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 9.9*m - 0.495*cm </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0*deg, 0.*deg, 0*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="mf:MEN"/>
+      <String name="ChildName" value="YE34"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="0*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="0"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 10.4075*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="mf:MEN"/>
+      <String name="ChildName" value="ShieldingME4"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="0*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="0"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 10.7175*m + 0.455*cm </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="mf:MEN"/> 
+      <String  name="ChildName"   value="YE4"/> 
+      <Numeric name="StartCopyNo" value="1" />
+      <Numeric name="IncrCopyNo"  value="1" />
+      <Numeric name="N"           value="12"/> 
+      <Numeric name="StartAngle"  value="0*deg"/> 
+      <Numeric name="RangeAngle"  value="360*deg"/> 
+      <Numeric name="Radius"      value="0*m"/> 
+      <Vector  name="Center" type="numeric" nEntries="3"> 0, 0, 10.7425*m + 0.455*cm </Vector>
+      <Vector  name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0*deg, 0.*deg </Vector>
+    </Algorithm> 
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_0"/>
+      <String name="ChildName" value="YB1_w0_b1"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="12.7713*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="4.77821*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.63395*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -102.7713*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_0"/>
+      <String name="ChildName" value="YB1_w0_b4"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="12.7713*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="4.77821*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, -0.63395*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -102.7713*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_0"/>
+      <String name="ChildName" value="YB1_w0_b2"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="0.8778*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="4.66055*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.62495*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90.8778*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_0"/>
+      <String name="ChildName" value="YB1_w0_b5"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="0.8778*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="4.66055*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, -0.62495*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90.8778*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_0"/>
+      <String name="ChildName" value="YB1_w0_b3"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="348.0664*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="4.76294*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -78.0664*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_1P"/>
+      <String name="ChildName" value="YB1_w1P_b1"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="12.7713*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="4.77821*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -102.7713*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_1N"/>
+      <String name="ChildName" value="YB1_w1N_b1"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="12.7713*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="4.77821*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -102.7713*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_1P"/>
+      <String name="ChildName" value="YB1_w1P_b2"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="7.9027*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="4.70468*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0639*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -97.9027*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_1N"/>
+      <String name="ChildName" value="YB1_w1N_b2"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="7.9027*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="4.70468*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0639*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -97.9027*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_1P"/>
+      <String name="ChildName" value="YB1_w1P_b3"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="4.294*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="4.67312*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0639*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -94.294*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_1N"/>
+      <String name="ChildName" value="YB1_w1N_b3"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="2"/>
+      <Numeric name="StartAngle" value="4.294*deg"/>
+      <Numeric name="RangeAngle" value="30*deg"/>
+      <Numeric name="Radius" value="4.67312*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0639*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -94.294*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_1N"/>
+      <String name="ChildName" value="YB1_w1N_b3"/>
+      <Numeric name="StartCopyNo" value="4"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="9"/>
+      <Numeric name="StartAngle" value="94.294*deg"/>
+      <Numeric name="RangeAngle" value="240*deg"/>
+      <Numeric name="Radius" value="4.67312*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0639*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -94.294*deg </Vector>
+    </Algorithm>
+    <PosPart copyNumber="3">
+      <rParent name="muonBase:MBWheel_1N"/>
+      <rChild name="YB1Chim_w1N_b3"/>
+      <rRotation name="rotations:R330"/>
+      <Translation x="4.67312*m*cos(64.294*deg)" y="4.67312*m*sin(64.294*deg)" z="1.0639*m"/>
+    </PosPart>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_1P"/>
+      <String name="ChildName" value="YB1_w1P_b4"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="3"/>
+      <Numeric name="StartAngle" value="0*deg"/>
+      <Numeric name="RangeAngle" value="60*deg"/>
+      <Numeric name="Radius" value="4.66*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0639*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_1P"/>
+      <String name="ChildName" value="YB1_w1P_b4"/>
+      <Numeric name="StartCopyNo" value="5"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="8"/>
+      <Numeric name="StartAngle" value="120*deg"/>
+      <Numeric name="RangeAngle" value="210*deg"/>
+      <Numeric name="Radius" value="4.66*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0639*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_1N"/>
+      <String name="ChildName" value="YB1_w1N_b4"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="2"/>
+      <Numeric name="StartAngle" value="0*deg"/>
+      <Numeric name="RangeAngle" value="30*deg"/>
+      <Numeric name="Radius" value="4.66*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0639*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_1N"/>
+      <String name="ChildName" value="YB1_w1N_b4"/>
+      <Numeric name="StartCopyNo" value="4"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="9"/>
+      <Numeric name="StartAngle" value="90*deg"/>
+      <Numeric name="RangeAngle" value="240*deg"/>
+      <Numeric name="Radius" value="4.66*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0639*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_1P"/>
+      <String name="ChildName" value="YB1_w1P_b5"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="355.706*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="4.67312*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0639*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -85.706*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_1N"/>
+      <String name="ChildName" value="YB1_w1N_b5"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="2"/>
+      <Numeric name="StartAngle" value="355.706*deg"/>
+      <Numeric name="RangeAngle" value="30*deg"/>
+      <Numeric name="Radius" value="4.67312*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0639*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, 94.294*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_1N"/>
+      <String name="ChildName" value="YB1_w1N_b5"/>
+      <Numeric name="StartCopyNo" value="4"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="9 "/>
+      <Numeric name="StartAngle" value="85.706*deg"/>
+      <Numeric name="RangeAngle" value="240*deg"/>
+      <Numeric name="Radius" value="4.67312*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0639*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, 94.294*deg </Vector>
+    </Algorithm>
+    <PosPart copyNumber="3">
+      <rParent name="muonBase:MBWheel_1N"/>
+      <rChild name="YB1Chim_w1N_b5"/>
+      <rRotation name="rotations:R330"/>
+      <Translation x="4.67312*m*cos(55.706*deg)" y="4.67312*m*sin(55.706*deg)" z="1.0639*m"/>
+    </PosPart>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_1P"/>
+      <String name="ChildName" value="YB1_w1P_b6"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="352.9603*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="4.6954*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0639*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -82.9603*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_1N"/>
+      <String name="ChildName" value="YB1_w1N_b6"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="352.9603*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="4.6954*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0639*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, 97.0397*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_1P"/>
+      <String name="ChildName" value="YB1_w1P_b7"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="0.8778*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="4.66055*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.186*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90.8778*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_1N"/>
+      <String name="ChildName" value="YB1_w1N_b7"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="0.8778*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="4.66055*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, -0.186*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90.8778*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_1P"/>
+      <String name="ChildName" value="YB1_w1P_b8"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="348.0664*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="4.76294*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -78.0664*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_1N"/>
+      <String name="ChildName" value="YB1_w1N_b8"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="348.0664*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="4.76294*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -78.0664*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_2P"/>
+      <String name="ChildName" value="YB1_w2P_b1"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="12.7713*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="4.77821*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -102.7713*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_2N"/>
+      <String name="ChildName" value="YB1_w2N_b1"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="12.7713*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="4.77821*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -102.7713*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_2P"/>
+      <String name="ChildName" value="YB1_w2P_b2"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="0.8778*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="4.66055*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90.8778*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_2N"/>
+      <String name="ChildName" value="YB1_w2N_b2"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="0.8778*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="4.66055*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90.8778*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_2P"/>
+      <String name="ChildName" value="YB1_w2P_b3"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="348.0664*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="4.76294*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -78.0664*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_2N"/>
+      <String name="ChildName" value="YB1_w2N_b3"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="348.0664*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="4.76294*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -78.0664*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_0"/>
+      <String name="ChildName" value="YB1_w0_m1"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="0*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="4.805*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.63395*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_0"/>
+      <String name="ChildName" value="YB1_w0_m2"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="0*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="4.805*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, -0.63395*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_1P"/>
+      <String name="ChildName" value="YB1_w1P_m1"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="10.132*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="4.88113*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.073*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -100.132*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_1N"/>
+      <String name="ChildName" value="YB1_w1N_m1"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="10.132*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="4.88113*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.073*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -100.132*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_1P"/>
+      <String name="ChildName" value="YB1_w1P_m2"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="4.1649*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="4.81772*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0729*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -94.1649*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_1N"/>
+      <String name="ChildName" value="YB1_w1N_m2"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="2"/>
+      <Numeric name="StartAngle" value="4.1649*deg"/>
+      <Numeric name="RangeAngle" value="30*deg"/>
+      <Numeric name="Radius" value="4.81772*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0729*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -94.1649*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_1N"/>
+      <String name="ChildName" value="YB1_w1N_m2"/>
+      <Numeric name="StartCopyNo" value="4"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="9"/>
+      <Numeric name="StartAngle" value="94.1649*deg"/>
+      <Numeric name="RangeAngle" value="240*deg"/>
+      <Numeric name="Radius" value="4.81772*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0729*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -94.1649*deg </Vector>
+    </Algorithm>
+    <PosPart copyNumber="3">
+      <rParent name="muonBase:MBWheel_1N"/>
+      <rChild name="YB1Chim_w1N_m2"/>
+      <rRotation name="rotations:R330"/>
+      <Translation x="4.81772*m*cos(64.1649*deg)" y="4.81772*m*sin(64.1649*deg)" z="1.0729*m"/>
+    </PosPart>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_1P"/>
+      <String name="ChildName" value="YB1_w1P_m3"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="3"/>
+      <Numeric name="StartAngle" value="0*deg"/>
+      <Numeric name="RangeAngle" value="60*deg"/>
+      <Numeric name="Radius" value="4.805*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0729*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_1P"/>
+      <String name="ChildName" value="YB1_w1P_m3"/>
+      <Numeric name="StartCopyNo" value="5"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="8"/>
+      <Numeric name="StartAngle" value="120*deg"/>
+      <Numeric name="RangeAngle" value="210*deg"/>
+      <Numeric name="Radius" value="4.805*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0729*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+    </Algorithm>
+    <PosPart copyNumber="4">
+      <rParent name="muonBase:MBWheel_1P"/>
+      <rChild name="YB1Chim_w1P_m3"/>
+      <rRotation name="rotations:000D"/>
+      <Translation x="4.805*m*cos(90.*deg)" y="4.805*m*sin(90.*deg)" z="-1.0729*m"/>
+    </PosPart>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_1N"/>
+      <String name="ChildName" value="YB1_w1N_m3"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="2"/>
+      <Numeric name="StartAngle" value="0*deg"/>
+      <Numeric name="RangeAngle" value="30*deg"/>
+      <Numeric name="Radius" value="4.805*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0729*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_1N"/>
+      <String name="ChildName" value="YB1_w1N_m3"/>
+      <Numeric name="StartCopyNo" value="4"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="9"/>
+      <Numeric name="StartAngle" value="90*deg"/>
+      <Numeric name="RangeAngle" value="240*deg"/>
+      <Numeric name="Radius" value="4.805*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0729*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+    </Algorithm>
+    <PosPart copyNumber="3">
+      <rParent name="muonBase:MBWheel_1N"/>
+      <rChild name="YB1Chim_w1N_m3"/>
+      <rRotation name="rotations:R330"/>
+      <Translation x="4.805*m*cos(60*deg)" y="4.805*m*sin(60*deg)" z="1.0729*m"/>
+    </PosPart>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_1P"/>
+      <String name="ChildName" value="YB1_w1P_m4"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="355.8351*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="4.81772*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0729*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -85.8351*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_1N"/>
+      <String name="ChildName" value="YB1_w1N_m4"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="2"/>
+      <Numeric name="StartAngle" value="355.8351*deg"/>
+      <Numeric name="RangeAngle" value="30*deg"/>
+      <Numeric name="Radius" value="4.81772*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0729*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -85.8351*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_1N"/>
+      <String name="ChildName" value="YB1_w1N_m4"/>
+      <Numeric name="StartCopyNo" value="4"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="9"/>
+      <Numeric name="StartAngle" value="85.8351*deg"/>
+      <Numeric name="RangeAngle" value="240*deg"/>
+      <Numeric name="Radius" value="4.81772*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0729*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -85.8351*deg </Vector>
+    </Algorithm>
+    <PosPart copyNumber="3">
+      <rParent name="muonBase:MBWheel_1N"/>
+      <rChild name="YB1Chim_w1N_m4"/>
+      <rRotation name="rotations:R330"/>
+      <Translation x="4.81772*m*cos(55.8351*deg)" y="4.81772*m*sin(55.8351*deg)" z="1.0729*m"/>
+    </PosPart>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_1P"/>
+      <String name="ChildName" value="YB1_w1P_m5"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="349.8677*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="4.88113*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0729*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -79.8677*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_1N"/>
+      <String name="ChildName" value="YB1_w1N_m5"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="349.8677*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="4.88113*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0729*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -79.8677*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_1P"/>
+      <String name="ChildName" value="YB1_w1P_m6"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="0*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="4.805*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.195*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_1N"/>
+      <String name="ChildName" value="YB1_w1N_m6"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="0*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="4.805*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, -0.195*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_2P"/>
+      <String name="ChildName" value="YB1_w2P_m1"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="0*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="4.805*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_2N"/>
+      <String name="ChildName" value="YB1_w2N_m1"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="0*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="4.805*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_0"/>
+      <String name="ChildName" value="YBSepar2_w0_1"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="12.776*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="5.25767*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.63405*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -102.776*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_0"/>
+      <String name="ChildName" value="YBSepar2_w0_2"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="12.776*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="5.25767*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, -0.63405*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -102.776*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_1P"/>
+      <String name="ChildName" value="YBSepar2_w1P"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="12.776*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="5.25767*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -102.776*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_1N"/>
+      <String name="ChildName" value="YBSepar2_w1N"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="12.776*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="5.25767*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -102.776*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_2P"/>
+      <String name="ChildName" value="YBSepar2_w2P"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="12.776*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="5.25767*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -102.776*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_2N"/>
+      <String name="ChildName" value="YBSepar2_w2N"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="12.776*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="5.25767*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -102.776*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_0"/>
+      <String name="ChildName" value="YB2_w0_b1"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="13.0847*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="5.5362413*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.63395*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -103.0847*deg </Vector>
+    </Algorithm>
+    <Algorithm name="global:DDAngular">
+      <rParent name="muonBase:MBWheel_0"/>
+      <String name="ChildName" value="YB2_w0_b4"/>
+      <Numeric name="StartCopyNo" value="1"/>
+      <Numeric name="IncrCopyNo" value="1"/>
+      <Numeric name="N" value="12"/>
+      <Numeric name="StartAngle" value="13.0847*deg"/>
+      <Numeric name="RangeAngle" value="360*deg"/>
+      <Numeric name="Radius" value="5.5362413*m"/>
+      <Vector name="Center" type="numeric" nEntries="3"> 0, 0, -0.63395*m </Vector>
+      <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -103.0847*deg </Vector>
+    </Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_0"/>
+			<String name="ChildName" value="YB2_w0_b2"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="359.6287*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.39261*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.62495*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -89.6287*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_0"/>
+			<String name="ChildName" value="YB2_w0_b5"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="359.6287*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.39261*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -0.62495*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -89.6287*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_0"/>
+			<String name="ChildName" value="YB2_w0_b3"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="346.5635*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.54426*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.63395*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -76.5635*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_0"/>
+			<String name="ChildName" value="YB2_w0_b6"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="346.5635*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.54426*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -0.63395*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -76.5635*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB2_w1P_b1"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="13.0847*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.5362413*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -103.0847*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB2_w1N_b1"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="13.0847*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.5362413*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -103.0847*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB2_w1P_b2"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="7.8748*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.44384*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -97.8748*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB2_w1N_b2"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="7.8748*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.44384*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -97.8748*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB2_w1P_b3"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="3.7125*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.40384*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -93.7125*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB2_w1N_b3"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="2"/>
+			<Numeric name="StartAngle" value="3.7125*deg"/>
+			<Numeric name="RangeAngle" value="30*deg"/>
+			<Numeric name="Radius" value="5.40384*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -93.7125*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB2_w1N_b3"/>
+			<Numeric name="StartCopyNo" value="4"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="9"/>
+			<Numeric name="StartAngle" value="93.7125*deg"/>
+			<Numeric name="RangeAngle" value="240*deg"/>
+			<Numeric name="Radius" value="5.40384*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -93.7125*deg </Vector>
+		</Algorithm>
+		<PosPart copyNumber="3">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<rChild name="YB2Chim_w1N_b3"/>
+			<rRotation name="rotations:R330"/>
+			<Translation x="5.40384*m*cos(63.7125*deg)" y="5.40384*m*sin(63.7125*deg)" z="1.0639*m"/>
+		</PosPart>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB2_w1P_b4"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="3"/>
+			<Numeric name="StartAngle" value="0*deg"/>
+			<Numeric name="RangeAngle" value="60*deg"/>
+			<Numeric name="Radius" value="5.3925*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB2_w1P_b4"/>
+			<Numeric name="StartCopyNo" value="5"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="8"/>
+			<Numeric name="StartAngle" value="120*deg"/>
+			<Numeric name="RangeAngle" value="210*deg"/>
+			<Numeric name="Radius" value="5.3925*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB2_w1N_b4"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="2"/>
+			<Numeric name="StartAngle" value="0*deg"/>
+			<Numeric name="RangeAngle" value="30*deg"/>
+			<Numeric name="Radius" value="5.3925*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB2_w1N_b4"/>
+			<Numeric name="StartCopyNo" value="4"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="9"/>
+			<Numeric name="StartAngle" value="90*deg"/>
+			<Numeric name="RangeAngle" value="240*deg"/>
+			<Numeric name="Radius" value="5.3925*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB2_w1P_b5"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="356.2875*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.40384*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -86.2875*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB2_w1N_b5"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="2"/>
+			<Numeric name="StartAngle" value="356.2875*deg"/>
+			<Numeric name="RangeAngle" value="30*deg"/>
+			<Numeric name="Radius" value="5.40384*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -86.2875*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB2_w1N_b5"/>
+			<Numeric name="StartCopyNo" value="4"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="9"/>
+			<Numeric name="StartAngle" value="86.2875*deg"/>
+			<Numeric name="RangeAngle" value="240*deg"/>
+			<Numeric name="Radius" value="5.40384*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -86.2875*deg </Vector>
+		</Algorithm>
+		<PosPart copyNumber="3">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<rChild name="YB2Chim_w1N_b5"/>
+			<rRotation name="rotations:R330"/>
+			<Translation x="5.40384*m*cos(56.2875*deg)" y="5.40384*m*sin(56.2875*deg)" z="1.0639*m"/>
+		</PosPart>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB2_w1P_b6"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="351.7612*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.44873*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -81.7612*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB2_w1N_b6"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="351.7612*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.44873*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -81.7612*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB2_w1P_b7"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="359.6287*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.39261*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.186*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -89.6287*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB2_w1N_b7"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="359.6287*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.39261*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -0.186*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -89.6287*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB2_w1P_b8"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="346.5635*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.54426*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -76.5635*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB2_w1N_b8"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="346.5635*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.54426*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -76.5635*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_2P"/>
+			<String name="ChildName" value="YB2_w2P_b1"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="13.0847*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.5362413*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -103.0847*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_2N"/>
+			<String name="ChildName" value="YB2_w2N_b1"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="13.0847*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.5362413*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -103.0847*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_2P"/>
+			<String name="ChildName" value="YB2_w2P_b2"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="359.6287*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.39261*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -89.6287*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_2N"/>
+			<String name="ChildName" value="YB2_w2N_b2"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="359.6287*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.39261*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -89.6287*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_2P"/>
+			<String name="ChildName" value="YB2_w2P_b3"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="346.5635*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.54426*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -76.5635*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_2N"/>
+			<String name="ChildName" value="YB2_w2N_b3"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="346.5635*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.54426*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -76.5635*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_0"/>
+			<String name="ChildName" value="YB2_w0_m1"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="0*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.66*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.63395*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_0"/>
+			<String name="ChildName" value="YB2_w0_m2"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="0*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.66*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -0.63395*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB2_w1P_m1"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="9.7567*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.74307*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0729*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -99.7567*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB2_w1N_m1"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="9.7567*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.74307*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0729*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -99.7567*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB2_w1P_m2"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="3.5375*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.67081*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0729*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -93.5375*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB2_w1N_m2"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="2"/>
+			<Numeric name="StartAngle" value="3.5375*deg"/>
+			<Numeric name="RangeAngle" value="30*deg"/>
+			<Numeric name="Radius" value="5.67081*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0729*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -93.5375*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB2_w1N_m2"/>
+			<Numeric name="StartCopyNo" value="4"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="9"/>
+			<Numeric name="StartAngle" value="93.5375*deg"/>
+			<Numeric name="RangeAngle" value="240*deg"/>
+			<Numeric name="Radius" value="5.67081*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0729*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -93.5375*deg </Vector>
+		</Algorithm>
+		<PosPart copyNumber="3">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<rChild name="YB2Chim_w1N_m2"/>
+			<rRotation name="rotations:R330"/>
+			<Translation x="5.67081*m*cos(63.5375*deg)" y="5.67081*m*sin(63.5375*deg)" z="1.0729*m"/>
+		</PosPart>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB2_w1P_m3"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="3"/>
+			<Numeric name="StartAngle" value="0*deg"/>
+			<Numeric name="RangeAngle" value="60*deg"/>
+			<Numeric name="Radius" value="5.66*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0729*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB2_w1P_m3"/>
+			<Numeric name="StartCopyNo" value="5"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="8"/>
+			<Numeric name="StartAngle" value="120*deg"/>
+			<Numeric name="RangeAngle" value="210*deg"/>
+			<Numeric name="Radius" value="5.66*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0729*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+		</Algorithm>
+		<PosPart copyNumber="4">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<rChild name="YB2Chim_w1P_m3"/>
+			<rRotation name="rotations:000D"/>
+			<Translation x="5.66*m*cos(90.*deg)" y="5.66*m*sin(90.*deg)" z="-1.0729*m"/>
+		</PosPart>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB2_w1N_m3"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="2"/>
+			<Numeric name="StartAngle" value="0*deg"/>
+			<Numeric name="RangeAngle" value="30*deg"/>
+			<Numeric name="Radius" value="5.66*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0729*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB2_w1N_m3"/>
+			<Numeric name="StartCopyNo" value="4"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="9"/>
+			<Numeric name="StartAngle" value="90*deg"/>
+			<Numeric name="RangeAngle" value="240*deg"/>
+			<Numeric name="Radius" value="5.66*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0729*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+		</Algorithm>
+		<PosPart copyNumber="3">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<rChild name="YB2Chim_w1N_m3"/>
+			<rRotation name="rotations:R330"/>
+			<Translation x="5.66*m*cos(60*deg)" y="5.66*m*sin(60*deg)" z="1.0729*m"/>
+		</PosPart>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB2_w1P_m4"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="356.4625*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.67081*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0729*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -86.4625*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB2_w1N_m4"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="2"/>
+			<Numeric name="StartAngle" value="356.4625*deg"/>
+			<Numeric name="RangeAngle" value="30*deg"/>
+			<Numeric name="Radius" value="5.67081*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0729*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -86.4625*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB2_w1N_m4"/>
+			<Numeric name="StartCopyNo" value="4"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="9"/>
+			<Numeric name="StartAngle" value="86.4625*deg"/>
+			<Numeric name="RangeAngle" value="240*deg"/>
+			<Numeric name="Radius" value="5.67081*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0729*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -86.4625*deg </Vector>
+		</Algorithm>
+		<PosPart copyNumber="3">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<rChild name="YB2Chim_w1N_m4"/>
+			<rRotation name="rotations:R330"/>
+			<Translation x="5.67081*m*cos(56.4625*deg)" y="5.67081*m*sin(56.4625*deg)" z="1.0729*m"/>
+		</PosPart>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB2_w1P_m5"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="350.2433*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.74307*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0729*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -80.2433*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB2_w1N_m5"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="350.2433*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.74307*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0729*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -80.2433*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB2_w1P_m6"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="0*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.66*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.195*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB2_w1N_m6"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="0*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.66*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -0.195*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_2P"/>
+			<String name="ChildName" value="YB2_w2P_m1"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="0*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.66*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_2N"/>
+			<String name="ChildName" value="YB2_w2N_m1"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="0*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.66*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_0"/>
+			<String name="ChildName" value="YB2_w0_t1"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="13.3987*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.0933547*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.63395*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -103.3987*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_0"/>
+			<String name="ChildName" value="YB2_w0_t4"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="13.3987*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.0933547*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -0.63395*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -103.3987*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_0"/>
+			<String name="ChildName" value="YB2_w0_t2"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="0.5026*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.92773*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.62495*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90.5026*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_0"/>
+			<String name="ChildName" value="YB2_w0_t5"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="0.5026*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.92773*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -0.62495*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90.5026*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_0"/>
+			<String name="ChildName" value="YB2_w0_t3"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="347.0779*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.0815176*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.63395*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -77.0779*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_0"/>
+			<String name="ChildName" value="YB2_w0_t6"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="347.0779*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.0815176*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -0.63395*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -77.0779*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB2_w1P_t1"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="13.3987*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.0933547*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -103.3987*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB2_w1N_t1"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="13.3987*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.0933547*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -103.3987*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB2_w1P_t2"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="7.9976*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.98572*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -97.9976*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB2_w1N_t2"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="7.9976*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.98572*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -97.9976*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB2_w1P_t3"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="3.3782*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.93782*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -93.3782*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB2_w1N_t3"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="2"/>
+			<Numeric name="StartAngle" value="3.3782*deg"/>
+			<Numeric name="RangeAngle" value="30*deg"/>
+			<Numeric name="Radius" value="5.93782*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -93.3782*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB2_w1N_t3"/>
+			<Numeric name="StartCopyNo" value="4"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="9"/>
+			<Numeric name="StartAngle" value="93.3782*deg"/>
+			<Numeric name="RangeAngle" value="240*deg"/>
+			<Numeric name="Radius" value="5.93782*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -93.3782*deg </Vector>
+		</Algorithm>
+		<PosPart copyNumber="3">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<rChild name="YB2Chim_w1N_t3"/>
+			<rRotation name="rotations:R330"/>
+			<Translation x="5.93782*m*cos(63.3782*deg)" y="5.93782*m*sin(63.3782*deg)" z="1.0639*m"/>
+		</PosPart>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB2_w1P_t4"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="3"/>
+			<Numeric name="StartAngle" value="0*deg"/>
+			<Numeric name="RangeAngle" value="60*deg"/>
+			<Numeric name="Radius" value="5.9275*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB2_w1P_t4"/>
+			<Numeric name="StartCopyNo" value="5"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="8"/>
+			<Numeric name="StartAngle" value="120*deg"/>
+			<Numeric name="RangeAngle" value="210*deg"/>
+			<Numeric name="Radius" value="5.9275*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB2_w1N_t4"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="2"/>
+			<Numeric name="StartAngle" value="0*deg"/>
+			<Numeric name="RangeAngle" value="30*deg"/>
+			<Numeric name="Radius" value="5.9275*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB2_w1N_t4"/>
+			<Numeric name="StartCopyNo" value="4"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="9"/>
+			<Numeric name="StartAngle" value="90*deg"/>
+			<Numeric name="RangeAngle" value="240*deg"/>
+			<Numeric name="Radius" value="5.9275*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB2_w1P_t5"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="356.6218*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.93782*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -86.6218*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB2_w1N_t5"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="2"/>
+			<Numeric name="StartAngle" value="356.6218*deg"/>
+			<Numeric name="RangeAngle" value="30*deg"/>
+			<Numeric name="Radius" value="5.93782*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -86.6218*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB2_w1N_t5"/>
+			<Numeric name="StartCopyNo" value="4"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="9"/>
+			<Numeric name="StartAngle" value="86.6218*deg"/>
+			<Numeric name="RangeAngle" value="240*deg"/>
+			<Numeric name="Radius" value="5.93782*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -86.6218*deg </Vector>
+		</Algorithm>
+		<PosPart copyNumber="3">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<rChild name="YB2Chim_w1N_t5"/>
+			<rRotation name="rotations:R330"/>
+			<Translation x="5.93782*m*cos(56.6218*deg)" y="5.93782*m*sin(56.6218*deg)" z="1.0639*m"/>
+		</PosPart>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB2_w1P_t6"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="352.4959*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.9787*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -82.4959*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB2_w1N_t6"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="352.4959*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.9787*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -82.4959*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB2_w1P_t7"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="0.5026*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.92773*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.186*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90.5026*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB2_w1N_t7"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="0.5026*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.92773*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -0.186*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90.5026*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB2_w1P_t8"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="347.0779*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.0815176*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -77.0779*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB2_w1N_t8"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="347.0779*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.0815176*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -77.0779*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_2P"/>
+			<String name="ChildName" value="YB2_w2P_t1"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="13.3987*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.0933547*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -103.3987*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_2N"/>
+			<String name="ChildName" value="YB2_w2N_t1"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="13.3987*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.0933547*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -103.3987*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_2P"/>
+			<String name="ChildName" value="YB2_w2P_t2"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="0.5026*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.92773*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90.5026*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_2N"/>
+			<String name="ChildName" value="YB2_w2N_t2"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="0.5026*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="5.92773*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90.5026*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_2P"/>
+			<String name="ChildName" value="YB2_w2P_t3"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="347.0779*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.0815176*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -77.0779*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_2N"/>
+			<String name="ChildName" value="YB2_w2N_t3"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="347.0779*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.0815176*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -77.0779*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_0"/>
+			<String name="ChildName" value="YBSepar3_w0_1"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="346.8409*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.33895*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.63395*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -76.8409*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_0"/>
+			<String name="ChildName" value="YBSepar3_w0_2"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="346.8409*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.33895*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -0.63395*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -76.8409*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YBSepar3_w1P"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="346.8409*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.33895*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -76.8409*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YBSepar3_w1N"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="346.8409*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.33895*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -76.8409*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_2P"/>
+			<String name="ChildName" value="YBSepar3_w2P"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="346.8409*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.33895*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -76.8409*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_2N"/>
+			<String name="ChildName" value="YBSepar3_w2N"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="346.8409*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.33895*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -76.8409*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_0"/>
+			<String name="ChildName" value="YB3_w0_b1"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="13.5332*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.60077*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.63395*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -103.5332*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_0"/>
+			<String name="ChildName" value="YB3_w0_b4"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="13.5332*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.60077*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -0.63395*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -103.5332*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_0"/>
+			<String name="ChildName" value="YB3_w0_b2"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="0.2228*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.41755*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.62495*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90.2228*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_0"/>
+			<String name="ChildName" value="YB3_w0_b5"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="0.2228*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.41755*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -0.62495*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90.2228*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_0"/>
+			<String name="ChildName" value="YB3_w0_b3"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="346.6776*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.59498*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.63395*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -76.6776*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_0"/>
+			<String name="ChildName" value="YB3_w0_b6"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="346.6776*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.59498*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -0.63395*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -76.6776*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB3_w1P_b1"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="13.5332*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.60077*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -103.5332*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB3_w1N_b1"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="13.5332*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.60077*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -103.5332*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB3_w1P_b2"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="7.9814*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.48027*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -97.9814*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB3_w1N_b2"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="7.9814*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.48027*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -97.9814*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB3_w1P_b3"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="3.1208*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.42703*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -93.1208*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB3_w1N_b3"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="2"/>
+			<Numeric name="StartAngle" value="3.1208*deg"/>
+			<Numeric name="RangeAngle" value="30*deg"/>
+			<Numeric name="Radius" value="6.42703*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -93.1208*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB3_w1N_b3"/>
+			<Numeric name="StartCopyNo" value="4"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="9"/>
+			<Numeric name="StartAngle" value="93.1208*deg"/>
+			<Numeric name="RangeAngle" value="240*deg"/>
+			<Numeric name="Radius" value="6.42703*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -93.1208*deg </Vector>
+		</Algorithm>
+		<PosPart copyNumber="3">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<rChild name="YB3Chim_w1N_b3"/>
+			<rRotation name="rotations:R330"/>
+			<Translation x="6.42703*m*cos(63.1208*deg)" y="6.42703*m*sin(63.1208*deg)" z="1.0639*m"/>
+		</PosPart>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB3_w1P_b4"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="3"/>
+			<Numeric name="StartAngle" value="0*deg"/>
+			<Numeric name="RangeAngle" value="60*deg"/>
+			<Numeric name="Radius" value="6.4175*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB3_w1P_b4"/>
+			<Numeric name="StartCopyNo" value="5"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="8"/>
+			<Numeric name="StartAngle" value="120*deg"/>
+			<Numeric name="RangeAngle" value="210*deg"/>
+			<Numeric name="Radius" value="6.4175*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB3_w1N_b4"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="2"/>
+			<Numeric name="StartAngle" value="0*deg"/>
+			<Numeric name="RangeAngle" value="30*deg"/>
+			<Numeric name="Radius" value="6.4175*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB3_w1N_b4"/>
+			<Numeric name="StartCopyNo" value="4"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="9"/>
+			<Numeric name="StartAngle" value="90*deg"/>
+			<Numeric name="RangeAngle" value="240*deg"/>
+			<Numeric name="Radius" value="6.4175*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB3_w1P_b5"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="356.8792*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.42703*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -86.8792*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB3_w1N_b5"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="2"/>
+			<Numeric name="StartAngle" value="356.8792*deg"/>
+			<Numeric name="RangeAngle" value="30*deg"/>
+			<Numeric name="Radius" value="6.42703*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -86.8792*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB3_w1N_b5"/>
+			<Numeric name="StartCopyNo" value="4"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="9"/>
+			<Numeric name="StartAngle" value="86.8792*deg"/>
+			<Numeric name="RangeAngle" value="240*deg"/>
+			<Numeric name="Radius" value="6.42703*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -86.8792*deg </Vector>
+		</Algorithm>
+		<PosPart copyNumber="3">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<rChild name="YB3Chim_w1N_b5"/>
+			<rRotation name="rotations:R330"/>
+			<Translation x="6.42703*m*cos(56.8792*deg)" y="6.42703*m*sin(56.8792*deg)" z="1.0639*m"/>
+		</PosPart>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB3_w1P_b6"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="352.2371*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.47686*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -82.2371*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB3_w1N_b6"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="352.2371*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.47686*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -82.2371*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB3_w1P_b7"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="0.2228*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.41755*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.186*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90.2228*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB3_w1N_b7"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="0.2228*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.41755*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -0.186*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90.2228*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB3_w1P_b8"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="346.6776*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.59498*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -76.6776*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB3_w1N_b8"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="346.6776*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.59498*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -76.6776*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_2P"/>
+			<String name="ChildName" value="YB3_w2P_b1"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="13.5332*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.60077*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -103.5332*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_2N"/>
+			<String name="ChildName" value="YB3_w2N_b1"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="13.5332*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.60077*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -103.5332*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_2P"/>
+			<String name="ChildName" value="YB3_w2P_b2"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="0.2234*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.41755*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90.2234*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_2N"/>
+			<String name="ChildName" value="YB3_w2N_b2"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="0.2234*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.41755*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90.2234*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_2P"/>
+			<String name="ChildName" value="YB3_w2P_b3"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="346.6782*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.59496*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -76.6782*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_2N"/>
+			<String name="ChildName" value="YB3_w2N_b3"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="346.6782*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.59496*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -76.6782*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_0"/>
+			<String name="ChildName" value="YB3_w0_m1"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="0*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.685*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.63395*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_0"/>
+			<String name="ChildName" value="YB3_w0_m2"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="0*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.685*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -0.63395*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB3_w1P_m1"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="9.4324*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.77662*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0729*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -99.4324*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB3_w1N_m1"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="9.4324*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.77662*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0729*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -99.4324*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB3_w1P_m2"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="2.9962*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.69415*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0729*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -92.9962*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB3_w1N_m2"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="2"/>
+			<Numeric name="StartAngle" value="2.9962*deg"/>
+			<Numeric name="RangeAngle" value="30*deg"/>
+			<Numeric name="Radius" value="6.69415*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0729*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -92.9962*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB3_w1N_m2"/>
+			<Numeric name="StartCopyNo" value="4"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="9"/>
+			<Numeric name="StartAngle" value="92.9962*deg"/>
+			<Numeric name="RangeAngle" value="240*deg"/>
+			<Numeric name="Radius" value="6.69415*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0729*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -92.9962*deg </Vector>
+		</Algorithm>
+		<PosPart copyNumber="3">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<rChild name="YB3Chim_w1N_m2"/>
+			<rRotation name="rotations:R330"/>
+			<Translation x="6.69415*m*cos(62.9962*deg)" y="6.69415*m*sin(62.9962*deg)" z="1.0729*m"/>
+		</PosPart>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB3_w1P_m3"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="3"/>
+			<Numeric name="StartAngle" value="0*deg"/>
+			<Numeric name="RangeAngle" value="60*deg"/>
+			<Numeric name="Radius" value="6.685*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0729*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB3_w1P_m3"/>
+			<Numeric name="StartCopyNo" value="8"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="8"/>
+			<Numeric name="StartAngle" value="120*deg"/>
+			<Numeric name="RangeAngle" value="210*deg"/>
+			<Numeric name="Radius" value="6.685*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0729*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+		</Algorithm>
+		<PosPart copyNumber="4">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<rChild name="YB3Chim_w1P_m3"/>
+			<rRotation name="rotations:000D"/>
+			<Translation x="6.685*m*cos(90.*deg)" y="6.685*m*sin(90.*deg)" z="-1.0729*m"/>
+		</PosPart>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB3_w1N_m3"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="2"/>
+			<Numeric name="StartAngle" value="0*deg"/>
+			<Numeric name="RangeAngle" value="30*deg"/>
+			<Numeric name="Radius" value="6.685*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0729*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB3_w1N_m3"/>
+			<Numeric name="StartCopyNo" value="4"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="9"/>
+			<Numeric name="StartAngle" value="90*deg"/>
+			<Numeric name="RangeAngle" value="240*deg"/>
+			<Numeric name="Radius" value="6.685*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0729*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+		</Algorithm>
+		<PosPart copyNumber="3">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<rChild name="YB3Chim_w1N_m3"/>
+			<rRotation name="rotations:R330"/>
+			<Translation x="6.685*m*cos(60*deg)" y="6.685*m*sin(60*deg)" z="1.0729*m"/>
+		</PosPart>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB3_w1P_m4"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="357.0038*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.69415*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0729*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -87.0038*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB3_w1N_m4"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="2"/>
+			<Numeric name="StartAngle" value="357.0038*deg"/>
+			<Numeric name="RangeAngle" value="30*deg"/>
+			<Numeric name="Radius" value="6.69415*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0729*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -87.0038*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB3_w1N_m4"/>
+			<Numeric name="StartCopyNo" value="4"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="9"/>
+			<Numeric name="StartAngle" value="87.0038*deg"/>
+			<Numeric name="RangeAngle" value="240*deg"/>
+			<Numeric name="Radius" value="6.69415*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0729*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -87.0038*deg </Vector>
+		</Algorithm>
+		<PosPart copyNumber="3">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<rChild name="YB3Chim_w1N_m4"/>
+			<rRotation name="rotations:R330"/>
+			<Translation x="6.69415*m*cos(57.0038*deg)" y="6.69415*m*sin(57.0038*deg)" z="1.0729*m"/>
+		</PosPart>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB3_w1P_m5"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="350.5676*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.77662*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0729*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -80.5676*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB3_w1N_m5"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="350.5676*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.77662*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0729*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -80.5676*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB3_w1P_m6"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="0*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.685*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.195*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB3_w1N_m6"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="0*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.685*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -0.195*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_2P"/>
+			<String name="ChildName" value="YB3_w2P_m1"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="0*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.685*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_2N"/>
+			<String name="ChildName" value="YB3_w2N_m1"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="0*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.685*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_0"/>
+			<String name="ChildName" value="YB3_w0_t1"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="13.0516*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="7.13687*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.63395*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -103.0516*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_0"/>
+			<String name="ChildName" value="YB3_w0_t4"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="13.0516*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="7.13687*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -0.63395*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -103.0516*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_0"/>
+			<String name="ChildName" value="YB3_w0_t2"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="359.3702*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.95292*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.62495*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -89.3702*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_0"/>
+			<String name="ChildName" value="YB3_w0_t5"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="359.3702*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.95292*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -0.62495*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -89.3702*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_0"/>
+			<String name="ChildName" value="YB3_w0_t3"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="346.3521*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="7.15451*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.63395*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -76.3521*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_0"/>
+			<String name="ChildName" value="YB3_w0_t6"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="346.3521*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="7.15451*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -0.63395*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -76.3521*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB3_w1P_t1"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="13.0516*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="7.13687*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -103.0516*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB3_w1N_t1"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="13.0516*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="7.13687*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -103.0516*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB3_w1P_t2"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="7.337*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="7.0100*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -97.337*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB3_w1N_t2"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="7.337*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="7.0100*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -97.337*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB3_w1P_t3"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="2.8811*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.9613*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -92.8811*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB3_w1N_t3"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="2"/>
+			<Numeric name="StartAngle" value="2.8811*deg"/>
+			<Numeric name="RangeAngle" value="30*deg"/>
+			<Numeric name="Radius" value="6.9613*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -92.8811*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB3_w1N_t3"/>
+			<Numeric name="StartCopyNo" value="4"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="9"/>
+			<Numeric name="StartAngle" value="92.8811*deg"/>
+			<Numeric name="RangeAngle" value="240*deg"/>
+			<Numeric name="Radius" value="6.9613*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -92.8811*deg </Vector>
+		</Algorithm>
+		<PosPart copyNumber="3">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<rChild name="YB3Chim_w1N_t3"/>
+			<rRotation name="rotations:R330"/>
+			<Translation x="6.9613*m*cos(62.8811*deg)" y="6.9613*m*sin(62.8811*deg)" z="1.0639*m"/>
+		</PosPart>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB3_w1P_t4"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="3"/>
+			<Numeric name="StartAngle" value="0*deg"/>
+			<Numeric name="RangeAngle" value="60*deg"/>
+			<Numeric name="Radius" value="6.9525*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB3_w1P_t4"/>
+			<Numeric name="StartCopyNo" value="5"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="8"/>
+			<Numeric name="StartAngle" value="120*deg"/>
+			<Numeric name="RangeAngle" value="210*deg"/>
+			<Numeric name="Radius" value="6.9525*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB3_w1N_t4"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="2"/>
+			<Numeric name="StartAngle" value="0*deg"/>
+			<Numeric name="RangeAngle" value="30*deg"/>
+			<Numeric name="Radius" value="6.9525*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB3_w1N_t4"/>
+			<Numeric name="StartCopyNo" value="4"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="9"/>
+			<Numeric name="StartAngle" value="90*deg"/>
+			<Numeric name="RangeAngle" value="240*deg"/>
+			<Numeric name="Radius" value="6.9525*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -90*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB3_w1P_t5"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="357.1189*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.9613*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -87.1189*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB3_w1N_t5"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="2"/>
+			<Numeric name="StartAngle" value="357.1189*deg"/>
+			<Numeric name="RangeAngle" value="30*deg"/>
+			<Numeric name="Radius" value="6.9613*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -87.1189*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB3_w1N_t5"/>
+			<Numeric name="StartCopyNo" value="4"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="9"/>
+			<Numeric name="StartAngle" value="87.1189*deg"/>
+			<Numeric name="RangeAngle" value="240*deg"/>
+			<Numeric name="Radius" value="6.9613*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -87.1189*deg </Vector>
+		</Algorithm>
+		<PosPart copyNumber="3">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<rChild name="YB3Chim_w1N_t5"/>
+			<rRotation name="rotations:R330"/>
+			<Translation x="6.9613*m*cos(57.1189*deg)" y="6.9613*m*sin(57.1189*deg)" z="1.0639*m"/>
+		</PosPart>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB3_w1P_t6"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="352.0437*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="7.02008*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -82.0437*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB3_w1N_t6"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="352.0437*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="7.02008*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.0639*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -82.0437*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB3_w1P_t7"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="359.3696*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.95292*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.186*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -89.3696*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB3_w1N_t7"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="359.3696*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.95292*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, -0.186*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -89.3696*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1P"/>
+			<String name="ChildName" value="YB3_w1P_t8"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="346.3516*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="7.15453*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -76.3516*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_1N"/>
+			<String name="ChildName" value="YB3_w1N_t8"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="346.3516*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="7.15453*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -76.3516*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_2P"/>
+			<String name="ChildName" value="YB3_w2P_t1"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="13.0516*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="7.13687*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -103.0516*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_2N"/>
+			<String name="ChildName" value="YB3_w2N_t1"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="13.0516*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="7.13687*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -103.0516*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_2P"/>
+			<String name="ChildName" value="YB3_w2P_t2"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="359.3696*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.95292*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -89.3696*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_2N"/>
+			<String name="ChildName" value="YB3_w2N_t2"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="359.3696*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="6.95292*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -89.3696*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_2P"/>
+			<String name="ChildName" value="YB3_w2P_t3"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="346.3516*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="7.15453*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -76.3516*deg </Vector>
+		</Algorithm>
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_2N"/>
+			<String name="ChildName" value="YB3_w2N_t3"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="StartAngle" value="346.3516*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Numeric name="Radius" value="7.15453*m"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, -76.3516*deg </Vector>
+		</Algorithm>
+		<!--- #### Non iron volumes -->
+		<Algorithm name="global:DDAngular">
+			<rParent name="muonBase:MBWheel_0"/>
+			<String name="ChildName" value="YBSepar_1"/>
+			<Numeric name="StartCopyNo" value="1"/>
+			<Numeric name="IncrCopyNo" value="1"/>
+			<Numeric name="N" value="12"/>
+			<Numeric name="Radius" value="4.23467*m"/>
+			<Numeric name="StartAngle" value="79.8900*deg"/>
+			<Numeric name="RangeAngle" value="360*deg"/>
+			<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0.*m </Vector>
+			<Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, 270.00*deg </Vector>
+		</Algorithm>
+	</PosPartSection>
+</DDDefinition>


### PR DESCRIPTION
**PR description:**

Restored the ShieldingME4 and fixed all the MUON overlaps in muonYoke.xml
A new version of muonYoke.xml is created (i.e 2026/v2/muonYoke.xml)  

@bsunanda @ianna @cvuosalo @civanch  @etcherniaev : FYI 

**PR validation:**

1) validation by "cmsShow.exe -c overlaps.fwc --sim-geom-file cmsSimGeom-2026.root"

2) validation by "nohup cmsRun SimG4Core/PrintGeomInfo/test/python/g4OverlapCheck2026_cfg.py >& overlaps.out &" 
Muon's volumes are not present in the overlaps.out file.
 

**if this PR is a backport please specify the original PR and why you need to backport that PR:**

nothing special