### PR TITLE
[Tracker Alignment] Miscellanea graphical fixes for PV-related validations

### DIFF
--- a/Alignment/OfflineValidation/macros/FitPVResiduals.C
+++ b/Alignment/OfflineValidation/macros/FitPVResiduals.C
@@ -4073,9 +4073,9 @@ void makeNewPairOfAxes(TH2F *h)
   } else {
     // this is a L1 map
     axmin = 0.5;
-    axmax = nModZ_+0.5;
+    axmax = nModZ_ + 0.5;
     aymin = 0.5;
-    aymax = nLadders_+0.5;
+    aymax = nLadders_ + 0.5;
   }
 
   // Remove the current axis

--- a/Alignment/OfflineValidation/macros/FitPVResiduals.C
+++ b/Alignment/OfflineValidation/macros/FitPVResiduals.C
@@ -2669,7 +2669,7 @@ void arrangeCanvas2D(
     //meanmaps[i]->Draw("colzsame"); // draw the "color palette"
 
     makeNewPairOfAxes(meanmaps[i]);
-
+  
     pt[i]->Draw("same");
     pt2[i]->Draw("same");
     pt3[i]->Draw("same");
@@ -2681,7 +2681,7 @@ void arrangeCanvas2D(
 
     widthmaps[i]->Draw("colz1");
     makeNewPairOfAxes(widthmaps[i]);
-
+   
     widthmaps[i]->GetZaxis()->SetRangeUser(0., maxwidth);
 
     pt[i]->Draw("same");
@@ -4054,13 +4054,29 @@ void makeNewXAxis(TH1F *h)
 void makeNewPairOfAxes(TH2F *h)
 /*--------------------------------------------------------------------*/
 {
-  int ndivx = 505;
-  float axmin = -etaRange;
-  float axmax = etaRange;
+  TString myTitle = h->GetName();
+  // fake defaults
+  float axmin = -999;
+  float axmax = 999.;
+  float aymin = -999;
+  float aymax = 999.;
+  int ndivx = h->GetXaxis()->GetNdivisions();
+  int ndivy = h->GetYaxis()->GetNdivisions(); 
 
-  int ndivy = 510;
-  float aymin = -TMath::Pi();
-  float aymax = TMath::Pi();
+  if (!myTitle.Contains("L1Map")) {
+    ndivx = 505;
+    ndivy = 510;
+    axmin = -etaRange;
+    axmax = etaRange;
+    aymin = -TMath::Pi();
+    aymax = TMath::Pi();  
+  } else { 
+    // this is a L1 map
+    axmin = 0.5;	  
+    axmax = 8.5;	  
+    aymin = 0.5; 
+    aymax = 12.5;  
+  }
 
   // Remove the current axis
   h->GetXaxis()->SetLabelOffset(999);

--- a/Alignment/OfflineValidation/macros/FitPVResiduals.C
+++ b/Alignment/OfflineValidation/macros/FitPVResiduals.C
@@ -2669,7 +2669,7 @@ void arrangeCanvas2D(
     //meanmaps[i]->Draw("colzsame"); // draw the "color palette"
 
     makeNewPairOfAxes(meanmaps[i]);
-  
+
     pt[i]->Draw("same");
     pt2[i]->Draw("same");
     pt3[i]->Draw("same");
@@ -2681,7 +2681,7 @@ void arrangeCanvas2D(
 
     widthmaps[i]->Draw("colz1");
     makeNewPairOfAxes(widthmaps[i]);
-   
+
     widthmaps[i]->GetZaxis()->SetRangeUser(0., maxwidth);
 
     pt[i]->Draw("same");
@@ -2780,7 +2780,7 @@ void arrangeFitCanvas(TCanvas *canv, TH1F *meanplots[100], Int_t nFiles, TString
         hnewUp->Draw("same");
         makeNewXAxis(hnewUp);
       }
-      fright[j]->Draw("sames");
+      fright[j]->Draw("same");
       fleft[j]->Draw("same");
       fall[j]->Draw("same");
     }
@@ -4061,7 +4061,7 @@ void makeNewPairOfAxes(TH2F *h)
   float aymin = -999;
   float aymax = 999.;
   int ndivx = h->GetXaxis()->GetNdivisions();
-  int ndivy = h->GetYaxis()->GetNdivisions(); 
+  int ndivy = h->GetYaxis()->GetNdivisions();
 
   if (!myTitle.Contains("L1Map")) {
     ndivx = 505;
@@ -4069,13 +4069,13 @@ void makeNewPairOfAxes(TH2F *h)
     axmin = -etaRange;
     axmax = etaRange;
     aymin = -TMath::Pi();
-    aymax = TMath::Pi();  
-  } else { 
+    aymax = TMath::Pi();
+  } else {
     // this is a L1 map
-    axmin = 0.5;	  
-    axmax = 8.5;	  
-    aymin = 0.5; 
-    aymax = 12.5;  
+    axmin = 0.5;
+    axmax = nModZ_+0.5;
+    aymin = 0.5;
+    aymax = nLadders_+0.5;
   }
 
   // Remove the current axis

--- a/Alignment/OfflineValidation/macros/FitPVResolution.C
+++ b/Alignment/OfflineValidation/macros/FitPVResolution.C
@@ -32,8 +32,8 @@
 
 float SUMPTMIN = 1.;
 float SUMPTMAX = 1e3;
-int TRACKBINS = 60;
-int VTXBINS = 40;
+int TRACKBINS = 120;
+int VTXBINS = 60;
 
 /* 
    This is an auxilliary class to store the list of files
@@ -257,9 +257,9 @@ void FitPVResolution(TString namesandlabels, TString theDate = "", bool isStrict
       std::cout << "File n. " << i << " getting the default minimum sum pT range: " << theSumPtMin_[i] << std::endl;
       theSumPtMax_[i] = 1e3;
       std::cout << "File n. " << i << " getting the default maxmum sum pT range: " << theSumPtMax_[i] << std::endl;
-      theTrackBINS_[i] = 60.;
+      theTrackBINS_[i] = 120.;
       std::cout << "File n. " << i << " getting the default number of tracks bins: " << theTrackBINS_[i] << std::endl;
-      theTrackBINS_[i] = 40.;
+      theTrackBINS_[i] = 60.;
       std::cout << "File n. " << i << " getting the default number of vertices bins: " << theVtxBINS_[i] << std::endl;
     }
   }
@@ -335,17 +335,17 @@ void FitPVResolution(TString namesandlabels, TString theDate = "", bool isStrict
   }
 
   // max vertices
-  const int max_n_vertices = std::min(40, VTXBINS);  // take the minimum to avoid overflow
+  const int max_n_vertices = std::min(60, VTXBINS);  // take the minimum to avoid overflow
   std::vector<float> myNVtx_bins_;
   for (float i = 0; i <= max_n_vertices; i++) {
-    myNVtx_bins_.push_back(1. + i);
+    myNVtx_bins_.push_back(i - 0.5f);
   }
 
   // max track
-  const int max_n_tracks = std::min(60, TRACKBINS);  // take the minimum to avoid overflow
+  const int max_n_tracks = std::min(120, TRACKBINS);  // take the minimum to avoid overflow
   std::vector<float> myNTrack_bins_;
   for (float i = 0; i <= max_n_tracks; i++) {
-    myNTrack_bins_.push_back(1 + i * 2);
+    myNTrack_bins_.push_back(i - 0.5f);
   }
 
   // max sumPt
@@ -988,7 +988,7 @@ void fillTrendPlotByIndex(TH1F* trendPlot,
       std::smatch match;
       if (std::regex_search(iterator.first, match, toMatch) && match.size() > 1) {
         result = match.str(1);
-        bin = std::stoi(result);
+        bin = std::stoi(result) + 1;
       } else {
         result = std::string("");
         continue;
@@ -1131,6 +1131,7 @@ void setPVResolStyle() {
 
   writeExtraText = true;  // if extra text
   lumi_13TeV = "p-p collisions";
+  lumi_0p9TeV = "p-p collisions";
   extraText = "Internal";
 
   TH1::StatOverflows(kTRUE);

--- a/Alignment/OfflineValidation/src/PVValidationHelpers.cc
+++ b/Alignment/OfflineValidation/src/PVValidationHelpers.cc
@@ -165,9 +165,11 @@ std::vector<float> PVValHelper::generateBins(int n, float start, float range)
   float interval = range / (n - 1);
   std::iota(v.begin(), v.end(), 1.);
 
-  //std::cout<<" interval:"<<interval<<std::endl;
-  //for(float &a : v) { std::cout<< a << " ";  }
-  //std::cout<< "\n";
+  /*
+    std::cout<<" interval:"<<interval<<std::endl;
+    for(float &a : v) { std::cout<< a << " ";  }
+    std::cout<< "\n";
+  */
 
   std::for_each(begin(v), end(v), [&](float& a) { a = start + ((a - 1) * interval); });
 


### PR DESCRIPTION
#### PR description:

Follow-up of PR https://github.com/cms-sw/cmssw/pull/36178, fixes an off-by-one bin mistake in the population of the Split Vertex resolution plots.
I profit to fix a couple of other bug in the `FitPVResiduals.C` macro.

#### PR validation:

Private. Tested on 2021 Beam Test data, see e.g. [here](http://musich.web.cern.ch/musich/testBeamTest/splitVertex/v5/)
![image](https://user-images.githubusercontent.com/5082376/143272232-f6d0c8de-0009-40e1-ae69-6c8fef42f4c0.png)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, but will need to be backported together with #36178

