### PR TITLE
Confdb schedule->HLTSchedule 1210

### DIFF
--- a/HLTrigger/Configuration/python/Tools/confdbOfflineConverter.py
+++ b/HLTrigger/Configuration/python/Tools/confdbOfflineConverter.py
@@ -139,7 +139,10 @@ class OfflineConverter:
             stderr = subprocess.PIPE,
             shell = False,
             universal_newlines = True )
-        return sub.communicate()
+        out,err = sub.communicate()
+        #12_0, 12_1 use HLTSchedule, confdb was changed to make this schedule, this resets it back to that for those releases
+        out = out.replace("fragment.schedule","fragment.HLTSchedule").replace("process.schedule","process.HLTSchedule")
+        return out,err
 
 def help():
     sys.stdout.write("""Usage: %s OPTIONS


### PR DESCRIPTION
#### PR description:

The HLT  has been using HLTSchedule as its schedule. However this has been fixed in 12_2_0. We now need to adjust confdb to output schedule. 

This will change the output for all releases and thus we need to fix this for 12_1 and 12_0 as the code will expect confdb to supply HLTScheule when its supplying schedule.

There are two options as I see them
1) backport the changes to make everything use schedule to https://github.com/cms-sw/cmssw/pull/35858
2) simply adjust the confdb output back to "HLTSchedule" in these releases

I have no opinion on which one to do, honestly option 1) is probably more correct.  This is option 2), if we dont like it, we can do option 1) or something else. 

#### PR validation:

Output with this PR is unchanged
Output with this PR with the new converter is unchanged

#### Backports

Note, this is special as it fixes a problem in 12_0 , 12_1 that does not exist in 12_2. Hence it doesnt go to the master branch. 