### PR TITLE
Modify calculations for the SiPixel Lorentz Angle calibration in PCL

### DIFF
--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
@@ -44,6 +44,7 @@ private:
   const double fitProbCut_;
   const std::string recordName_;
   std::unique_ptr<TF1> f1;
+  float width_;
 
   SiPixelLorentzAngleCalibrationHistograms hists;
   const SiPixelLorentzAngle* currentLorentzAngle;
@@ -106,6 +107,7 @@ void SiPixelLorentzAnglePCLHarvester::beginRun(const edm::Run& iRun, const edm::
 
   for (auto det : geom->detsPXB()) {
     const PixelGeomDetUnit* pixelDet = dynamic_cast<const PixelGeomDetUnit*>(det);
+    width_ = pixelDet->surface().bounds().thickness();
     const auto& layer = tTopo->pxbLayer(pixelDet->geographicalId());
     const auto& module = tTopo->pxbModule(pixelDet->geographicalId());
     int i_index = module + (layer - 1) * hists.nModules_[layer - 1];
@@ -229,7 +231,7 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
   f1->SetParName(5, "quintic term");
 
   double p1_simul_newmodule = 0.294044;
-  double half_width = 0.0285 / 2 * 10000;  // pixel width in units of micro meter
+  double half_width = width_ * 10000 / 2;  // pixel half thickness in units of micro meter
 
   for (int j = 0; j < (int)hists.BPixnewDetIds_.size(); j++) {
     int new_index = j + 1 + hists.nModules_[hists.nlay - 1] + (hists.nlay - 1) * hists.nModules_[hists.nlay - 1];
@@ -279,8 +281,7 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
         (f1_halfwidth - f1_zerowidth) / half_width;  // tan_LA = (f1(x = half_width) - f1(x = 0)) / (half_width - 0)
     double errsq_LA = (pow(e1, 2) + pow((half_width * e2), 2) + pow((half_width * half_width * e3), 2) +
                        pow((half_width * half_width * half_width * e4), 2) +
-                       pow((half_width * half_width * half_width * half_width * e5), 2)) *
-                      pow(tan_LA, 2);  // Propagation of uncertainty
+                       pow((half_width * half_width * half_width * half_width * e5), 2));  // Propagation of uncertainty
     double error_LA = sqrt(errsq_LA);
 
     edm::LogPrint("LorentzAngle") << std::setprecision(4) << hists.BPixnewModule_[j] << "\t" << hists.BPixnewLayer_[j]
@@ -359,8 +360,7 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
           (f1_halfwidth - f1_zerowidth) / half_width;  // tan_LA = (f1(x = half_width) - f1(x = 0)) / (half_width - 0)
       double errsq_LA = (pow(e1, 2) + pow((half_width * e2), 2) + pow((half_width * half_width * e3), 2) +
                          pow((half_width * half_width * half_width * e4), 2) +
-                         pow((half_width * half_width * half_width * half_width * e5), 2)) *
-                        pow(tan_LA, 2);  // Propagation of uncertainty
+                         pow((half_width * half_width * half_width * half_width * e5), 2));  // Propagation of uncertainty
       double error_LA = sqrt(errsq_LA);
 
       edm::LogPrint("LorentzAngle") << std::setprecision(4) << i_module << "\t" << i_layer << "\t" << p0 << "\t" << e0

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
@@ -358,9 +358,10 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
 
       double tan_LA =
           (f1_halfwidth - f1_zerowidth) / half_width;  // tan_LA = (f1(x = half_width) - f1(x = 0)) / (half_width - 0)
-      double errsq_LA = (pow(e1, 2) + pow((half_width * e2), 2) + pow((half_width * half_width * e3), 2) +
-                         pow((half_width * half_width * half_width * e4), 2) +
-                         pow((half_width * half_width * half_width * half_width * e5), 2));  // Propagation of uncertainty
+      double errsq_LA =
+          (pow(e1, 2) + pow((half_width * e2), 2) + pow((half_width * half_width * e3), 2) +
+           pow((half_width * half_width * half_width * e4), 2) +
+           pow((half_width * half_width * half_width * half_width * e5), 2));  // Propagation of uncertainty
       double error_LA = sqrt(errsq_LA);
 
       edm::LogPrint("LorentzAngle") << std::setprecision(4) << i_module << "\t" << i_layer << "\t" << p0 << "\t" << e0

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLWorker.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLWorker.cc
@@ -379,7 +379,7 @@ void SiPixelLorentzAnglePCLWorker::analyze(edm::Event const& iEvent, edm::EventS
           const PixelTopology* topol = &(theGeomDet->specificTopology());
 
           float ypitch_ = topol->pitch().second;
-          float width_ = 0.0285;
+          float width_ = theGeomDet->surface().bounds().thickness();
 
           if (!topol)
             continue;


### PR DESCRIPTION
#### PR description:

Essentially a fix of the method: the previous implementation was not in line with the calibration method used to create the CPE objects. 

The calculation for LA is modified in this PR in order to take into account the changes on the drift-depth shape after irradiation.

As can be seen from this figure [1], the drift-depth shape changes from a solid blue line to an s-shaped (shown in red) curve after irradiation. The average displacement becomes smaller and the slope in the central region becomes larger.
In order to correct for the displacement around central region, Morris proposed to evaluate the LA at depth T/2 and obtain tan\theta_L = 2(D_1/2)/T as shown in green, which helps to monitor displacement of charge carriers around central region and thus is better for calibration purpose.

[1] https://github.com/CMSTrackerDPG/cmssw/files/7552567/LA_irradiated.pdf

<img width="654" alt="LAIrradiated" src="https://user-images.githubusercontent.com/5064110/143324777-e0d7ddd4-2f6c-442f-a2ec-03252c1cd675.png">

#### PR validation:
code compiles

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Would be nice to have it in 12_1_X T0 replay

Submitting the PR for @wweiphy 