### PR TITLE
PFID with DNNs - updated model trained on Run3Summer21

### DIFF
--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.cc
@@ -294,14 +294,14 @@ void GsfElectronProducer::fillDescriptions(edm::ConfigurationDescriptions& descr
     psd1.add<uint>("outputDim", 5);  // Number of output nodes of DNN
     psd1.add<std::vector<std::string>>(
         "modelsFiles",
-        {"RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/lowpT/lowpT_modelDNN.pb",
-         "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/highpTEB/highpTEB_modelDNN.pb",
-         "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/highpTEE/highpTEE_modelDNN.pb"});
+        {"RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/lowpT/lowpT_modelDNN.pb",
+         "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/highpTEB/highpTEB_modelDNN.pb",
+         "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/highpTEE/highpTEE_modelDNN.pb"});
     psd1.add<std::vector<std::string>>(
         "scalersFiles",
-        {"RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/lowpT/lowpT_scaler.txt",
-         "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/highpTEB/highpTEB_scaler.txt",
-         "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/highpTEE/highpTEE_scaler.txt"});
+        {"RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/lowpT/lowpT_scaler.txt",
+         "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/highpTEB/highpTEB_scaler.txt",
+         "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/highpTEE/highpTEE_scaler.txt"});
     psd1.add<bool>("useEBModelInGap", true);
     // preselection parameters
     desc.add<edm::ParameterSetDescription>("EleDNNPFid", psd1);

--- a/RecoEgamma/EgammaElectronProducers/python/gedGsfElectrons_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/gedGsfElectrons_cfi.py
@@ -20,17 +20,18 @@ gedGsfElectronsTmp = ecalDrivenGsfElectrons.clone(
                                          "gedelectron_EEUncertainty_offline_v1"],
     combinationRegressionWeightLabels = ["gedelectron_p4combination_offline"],
 
-    #Activate the evaluation of Egamma PFID DNN
+    #Egamma PFID DNN model configuration
     EleDNNPFid= dict(
+        outputTensorName = "sequential_1/FinalLayer/Softmax",
         modelsFiles = [
-            "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/lowpT/lowpT_modelDNN.pb",
-            "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/highpTEB/highpTEB_modelDNN.pb",
-            "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/highpTEE/highpTEE_modelDNN.pb"
+            "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/lowpT/lowpT_modelDNN.pb",
+            "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/EB_highpT/barrel_highpT_modelDNN.pb",
+            "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/EE_highpT/endcap_highpT_modelDNN.pb"
         ],
         scalersFiles = [
-            "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/lowpT/lowpT_scaler.txt",
-            "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/highpTEB/highpTEB_scaler.txt",
-            "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/highpTEE/highpTEE_scaler.txt"
+            "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/lowpT/lowpT_scaler.txt",
+            "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/EB_highpT/barrel_highpT_scaler.txt",
+            "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/EE_highpT/endcap_highpT_scaler.txt"
         ]
     )    
 )

--- a/RecoEgamma/EgammaPhotonProducers/python/gedPhotonSequence_cff.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/gedPhotonSequence_cff.py
@@ -14,12 +14,13 @@ gedPhotonsTmp = RecoEgamma.EgammaPhotonProducers.gedPhotons_cfi.gedPhotons.clone
     candidateP4type        = "fromEcalEnergy",
     outputPhotonCollection = "",
     reconstructionStep     = "tmp",
+    #Photon PFID DNN model configuration
     PhotonDNNPFid = dict(
-        modelsFiles = [ "RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/EB/EB_modelDNN.pb",
-                        "RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/EE/EE_modelDNN.pb"],
+        modelsFiles = [ "RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/Run3Summer21_120X/EB/barrel_modelDNN.pb",
+                        "RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/Run3Summer21_120X/EE/endcap_modelDNN.pb"],
         scalersFiles = [
-                    "RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/EB/EB_scaler.txt",
-                    "RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/EE/EE_scaler.txt"]
+                    "RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/Run3Summer21_120X/EB/barrel_scaler.txt",
+                    "RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/Run3Summer21_120X/EE/endcap_scaler.txt"]
     )
 )
 del gedPhotonsTmp.regressionConfig

--- a/RecoEgamma/EgammaPhotonProducers/python/gedPhotons_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/gedPhotons_cfi.py
@@ -104,11 +104,11 @@ gedPhotons = cms.EDProducer("GEDPhotonProducer",
         inputTensorName = cms.string("FirstLayer_input"),
         outputTensorName = cms.string("sequential/FinalLayer/Sigmoid"),
         modelsFiles = cms.vstring(
-                                'RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/EB/EB_modelDNN.pb',
-                                'RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/EE/EE_modelDNN.pb'),
+                                'RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/v1/EB/EB_modelDNN.pb',
+                                'RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/v1/EE/EE_modelDNN.pb'),
         scalersFiles = cms.vstring(
-                    'RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/EB/EB_scaler.txt',
-                    'RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/EE/EE_scaler.txt'
+                    'RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/v1/EB/EB_scaler.txt',
+                    'RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/v1/EE/EE_scaler.txt'
         ),
         outputDim = cms.uint32(1),
         useEBModelInGap = cms.bool(True)

--- a/RecoEgamma/EgammaPhotonProducers/python/photons_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/photons_cfi.py
@@ -93,13 +93,13 @@ photons = cms.EDProducer("GEDPhotonProducer",
     PhotonDNNPFid = cms.PSet(
         enabled = cms.bool(False),
         inputTensorName = cms.string("FirstLayer_input"),
-        outputTensorName = cms.string("sequential/LastLayer/Softmax"),
+        outputTensorName = cms.string("sequential/FinalLayer/Sigmoid"),
         modelsFiles = cms.vstring(
-                                'RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/model_barrel.pb',
-                                'RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/model_endcap.pb'),
+                                'RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/v1/EB/EB_modelDNN.pb',
+                                'RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/v1/EE/EE_modelDNN.pb'),
         scalersFiles = cms.vstring(
-                    'RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/PhotonDNNScaler.txt',
-                    'RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/PhotonDNNScaler.txt'
+                    'RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/v1/EB/EB_scaler.txt',
+                    'RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/v1/EE/EE_scaler.txt'
         ),
         outputDim = cms.uint32(1),
         useEBModelInGap = cms.bool(True)

--- a/RecoEgamma/ElectronIdentification/src/ElectronDNNEstimator.cc
+++ b/RecoEgamma/ElectronIdentification/src/ElectronDNNEstimator.cc
@@ -1,6 +1,7 @@
 #include "RecoEgamma/ElectronIdentification/interface/ElectronDNNEstimator.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/FileInPath.h"
+#include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
 
 #include <iostream>
 #include <fstream>
@@ -86,8 +87,6 @@ const std::vector<std::string> ElectronDNNEstimator::dnnAvaibleInputs = {
 std::map<std::string, float> ElectronDNNEstimator::getInputsVars(const reco::GsfElectron& ele) const {
   // Prepare a map with all the defined variables
   std::map<std::string, float> variables;
-  reco::TrackRef myTrackRef = ele.closestCtfTrackRef();
-  bool validKF = (myTrackRef.isNonnull() && myTrackRef.isAvailable());
   variables["pt"] = ele.pt();
   variables["eta"] = ele.eta();
   variables["fbrem"] = ele.fbrem();
@@ -101,11 +100,11 @@ std::map<std::string, float> ElectronDNNEstimator::getInputsVars(const reco::Gsf
   variables["closestCtfTrackNormChi2"] = ele.closestCtfTrackNormChi2();
   variables["closestCtfTrackNLayers"] = ele.closestCtfTrackNLayers();
   variables["gsfTrack.missing_inner_hits"] =
-      (validKF) ? myTrackRef->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS) : -1.;
+      ele.gsfTrack()->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS);
   variables["dr03TkSumPt"] = ele.dr03TkSumPt();
   variables["dr03EcalRecHitSumEt"] = ele.dr03EcalRecHitSumEt();
   variables["dr03HcalTowerSumEt"] = ele.dr03HcalTowerSumEt();
-  variables["gsfTrack.normalizedChi2"] = (validKF) ? myTrackRef->normalizedChi2() : 0;
+  variables["gsfTrack.normalizedChi2"] = ele.gsfTrack()->normalizedChi2();
   variables["superCluster.eta"] = ele.superCluster()->eta();
   variables["ecalPFClusterIso"] = ele.ecalPFClusterIso();
   variables["hcalPFClusterIso"] = ele.hcalPFClusterIso();
@@ -119,8 +118,7 @@ std::map<std::string, float> ElectronDNNEstimator::getInputsVars(const reco::Gsf
   variables["1_minus_full5x5_e1x5_ratio_full5x5_e5x5"] = 1 - ele.full5x5_e1x5() / ele.full5x5_e5x5();
   variables["full5x5_e1x5_ratio_full5x5_e5x5"] = ele.full5x5_e1x5() / ele.full5x5_e5x5();
   variables["full5x5_r9"] = ele.full5x5_r9();
-  variables["gsfTrack.trackerLayersWithMeasurement"] =
-      (validKF) ? myTrackRef->hitPattern().trackerLayersWithMeasurement() : -1.;
+  variables["gsfTrack.trackerLayersWithMeasurement"] = ele.gsfTrack()->hitPattern().trackerLayersWithMeasurement();
   variables["superCluster.energy"] = ele.superCluster()->energy();
   variables["superCluster.rawEnergy"] = ele.superCluster()->rawEnergy();
   variables["superClusterFbrem"] = ele.superClusterFbrem();

--- a/RecoEgamma/ElectronIdentification/src/ElectronDNNEstimator.cc
+++ b/RecoEgamma/ElectronIdentification/src/ElectronDNNEstimator.cc
@@ -37,31 +37,51 @@ ElectronDNNEstimator::ElectronDNNEstimator(const egammaTools::DNNConfiguration& 
 
 std::vector<tensorflow::Session*> ElectronDNNEstimator::getSessions() const { return dnnHelper_.getSessions(); };
 
-const std::vector<std::string> ElectronDNNEstimator::dnnAvaibleInputs = {{"pt",
-                                                                          "eta",
-                                                                          "fbrem",
-                                                                          "abs(deltaEtaSuperClusterTrackAtVtx)",
-                                                                          "abs(deltaPhiSuperClusterTrackAtVtx)",
-                                                                          "full5x5_sigmaIetaIeta",
-                                                                          "full5x5_hcalOverEcal",
-                                                                          "eSuperClusterOverP",
-                                                                          "full5x5_e1x5",
-                                                                          "eEleClusterOverPout",
-                                                                          "closestCtfTrackNormChi2",
-                                                                          "closestCtfTrackNLayers",
-                                                                          "gsfTrack.missing_inner_hits",
-                                                                          "dr03TkSumPt",
-                                                                          "dr03EcalRecHitSumEt",
-                                                                          "dr03HcalTowerSumEt",
-                                                                          "gsfTrack.normalizedChi2",
-                                                                          "superCluster.eta",
-                                                                          "ecalPFClusterIso",
-                                                                          "hcalPFClusterIso",
-                                                                          "numberOfBrems",
-                                                                          "abs(deltaEtaSeedClusterTrackAtCalo)",
-                                                                          "hadronicOverEm",
-                                                                          "full5x5_e2x5Max",
-                                                                          "full5x5_e5x5"}};
+const std::vector<std::string> ElectronDNNEstimator::dnnAvaibleInputs = {
+    {"pt",
+     "eta",
+     "fbrem",
+     "abs(deltaEtaSuperClusterTrackAtVtx)",
+     "abs(deltaPhiSuperClusterTrackAtVtx)",
+     "full5x5_sigmaIetaIeta",
+     "full5x5_hcalOverEcal",
+     "eSuperClusterOverP",
+     "full5x5_e1x5",
+     "eEleClusterOverPout",
+     "closestCtfTrackNormChi2",
+     "closestCtfTrackNLayers",
+     "gsfTrack.missing_inner_hits",
+     "dr03TkSumPt",
+     "dr03EcalRecHitSumEt",
+     "dr03HcalTowerSumEt",
+     "gsfTrack.normalizedChi2",
+     "superCluster.eta",
+     "ecalPFClusterIso",
+     "hcalPFClusterIso",
+     "numberOfBrems",
+     "abs(deltaEtaSeedClusterTrackAtCalo)",
+     "hadronicOverEm",
+     "full5x5_e2x5Max",
+     "full5x5_e5x5",
+     "full5x5_sigmaIphiIphi",
+     "1_minus_full5x5_e1x5_ratio_full5x5_e5x5",
+     "full5x5_e1x5_ratio_full5x5_e5x5",
+     "full5x5_r9",
+     "gsfTrack.trackerLayersWithMeasurement",
+     "superCluster.energy",
+     "superCluster.rawEnergy",
+     "superClusterFbrem",
+     "1_ratio_ecalEnergy_minus_1_ratio_trackMomentumAtVtx.R",
+     "superCluster.preshowerEnergy_ratio_superCluster.rawEnergy",
+     "convVtxFitProb",
+     "superCluster.clustersSize",
+     "ecalEnergyError_ratio_ecalEnergy",
+     "superClusterFbrem_plus_superCluster.energy",
+     "superClusterFbrem_plus_superCluster.rawEnergy",
+     "trackMomentumError",
+     "trackMomentumError_ratio_pt",
+     "full5x5_e5x5_ratio_superCluster.rawEnergy",
+     "full5x5_e5x5_ratio_superCluster.energy"}};
 
 std::map<std::string, float> ElectronDNNEstimator::getInputsVars(const reco::GsfElectron& ele) const {
   // Prepare a map with all the defined variables
@@ -94,6 +114,31 @@ std::map<std::string, float> ElectronDNNEstimator::getInputsVars(const reco::Gsf
   variables["hadronicOverEm"] = ele.hcalOverEcalValid() ? ele.hadronicOverEm() : 0;
   variables["full5x5_e2x5Max"] = ele.full5x5_e2x5Max();
   variables["full5x5_e5x5"] = ele.full5x5_e5x5();
+
+  variables["full5x5_sigmaIphiIphi"] = ele.full5x5_sigmaIphiIphi();
+  variables["1_minus_full5x5_e1x5_ratio_full5x5_e5x5"] = 1 - ele.full5x5_e1x5() / ele.full5x5_e5x5();
+  variables["full5x5_e1x5_ratio_full5x5_e5x5"] = ele.full5x5_e1x5() / ele.full5x5_e5x5();
+  variables["full5x5_r9"] = ele.full5x5_r9();
+  variables["gsfTrack.hitPattern.trackerLayersWithMeasurement"] =
+      (validKF) ? myTrackRef->hitPattern().trackerLayersWithMeasurement() : -1.;
+  variables["superCluster.energy"] = ele.superCluster()->energy();
+  variables["superCluster.rawEnergy"] = ele.superCluster()->rawEnergy();
+  variables["superClusterFbrem"] = ele.superClusterFbrem();
+  variables["1_ratio_ecalEnergy_minus_1_ratio_trackMomentumAtVtx.R"] =
+      1 / ele.ecalEnergy() - 1 / ele.trackMomentumAtVtx().R();
+  variables["superCluster.preshowerEnergy_ratio_superCluster.rawEnergy"] =
+      ele.superCluster()->preshowerEnergy() / ele.superCluster()->rawEnergy();
+  variables["convVtxFitProb"] = ele.convVtxFitProb();
+  variables["superCluster.clustersSize"] = ele.superCluster()->clustersSize();
+  variables["ecalEnergyError_ratio_ecalEnergy"] = ele.ecalEnergyError() / ele.ecalEnergy();
+  variables["superClusterFbrem_plus_superCluster.energy"] = ele.superClusterFbrem() + ele.superCluster()->energy();
+  variables["superClusterFbrem_plus_superCluster.rawEnergy"] =
+      ele.superClusterFbrem() + ele.superCluster()->rawEnergy();
+  variables["trackMomentumError"] = ele.trackMomentumError();
+  variables["trackMomentumError_ratio_pt"] = ele.trackMomentumError() / ele.pt();
+  variables["full5x5_e5x5_ratio_superCluster.rawEnergy"] = ele.full5x5_e5x5() / ele.superCluster()->rawEnergy();
+  variables["full5x5_e5x5_ratio_superCluster.energy"] = ele.full5x5_e5x5() / ele.superCluster()->energy();
+
   // Define more variables here and use them directly in the model config!
   return variables;
 }

--- a/RecoEgamma/ElectronIdentification/src/ElectronDNNEstimator.cc
+++ b/RecoEgamma/ElectronIdentification/src/ElectronDNNEstimator.cc
@@ -119,7 +119,7 @@ std::map<std::string, float> ElectronDNNEstimator::getInputsVars(const reco::Gsf
   variables["1_minus_full5x5_e1x5_ratio_full5x5_e5x5"] = 1 - ele.full5x5_e1x5() / ele.full5x5_e5x5();
   variables["full5x5_e1x5_ratio_full5x5_e5x5"] = ele.full5x5_e1x5() / ele.full5x5_e5x5();
   variables["full5x5_r9"] = ele.full5x5_r9();
-  variables["gsfTrack.hitPattern.trackerLayersWithMeasurement"] =
+  variables["gsfTrack.trackerLayersWithMeasurement"] =
       (validKF) ? myTrackRef->hitPattern().trackerLayersWithMeasurement() : -1.;
   variables["superCluster.energy"] = ele.superCluster()->energy();
   variables["superCluster.rawEnergy"] = ele.superCluster()->rawEnergy();

--- a/RecoEgamma/PhotonIdentification/src/PhotonDNNEstimator.cc
+++ b/RecoEgamma/PhotonIdentification/src/PhotonDNNEstimator.cc
@@ -34,10 +34,10 @@ std::vector<tensorflow::Session*> PhotonDNNEstimator::getSessions() const { retu
 const std::vector<std::string> PhotonDNNEstimator::dnnAvaibleInputs = {{"pt",
                                                                         "eta",
                                                                         "hadTowOverEm",
-                                                                        "TrkSumPtHollow",
+                                                                        "trkSumPtHollowConeDR03",
                                                                         "EcalRecHit",
                                                                         "SigmaIetaIeta",
-                                                                        "SigmaIEtaIEtaFull5x5",
+                                                                        "SigmaIetaIetaFull5x5",
                                                                         "SigmaIEtaIPhiFull5x5",
                                                                         "EcalPFClusterIso",
                                                                         "HcalPFClusterIso",
@@ -51,10 +51,10 @@ std::map<std::string, float> PhotonDNNEstimator::getInputsVars(const reco::Photo
   variables["pt"] = photon.pt();
   variables["eta"] = photon.eta();
   variables["hadTowOverEm"] = photon.hadTowOverEmValid() ? photon.hadTowOverEm() : 0;
-  variables["TrkSumPtHollow"] = photon.trkSumPtHollowConeDR03();
+  variables["trkSumPtHollowConeDR03"] = photon.trkSumPtHollowConeDR03();
   variables["EcalRecHit"] = photon.ecalRecHitSumEtConeDR03();
   variables["SigmaIetaIeta"] = photon.sigmaIetaIeta();
-  variables["SigmaIEtaIEtaFull5x5"] = photon.full5x5_sigmaIetaIeta();
+  variables["SigmaIetaIetaFull5x5"] = photon.full5x5_sigmaIetaIeta();
   variables["SigmaIEtaIPhiFull5x5"] = photon.full5x5_showerShapeVariables().sigmaIetaIphi;
   variables["EcalPFClusterIso"] = photon.ecalPFClusterIso();
   variables["HcalPFClusterIso"] = photon.hcalPFClusterIso();

--- a/RecoParticleFlow/PFProducer/interface/PFEGammaFilters.h
+++ b/RecoParticleFlow/PFProducer/interface/PFEGammaFilters.h
@@ -57,6 +57,10 @@ private:
   float ele_dnnLowPtThr_;
   float ele_dnnHighPtBarrelThr_;
   float ele_dnnHighPtEndcapThr_;
+  // Thresholds for DNN Bkg ele pfid
+  float ele_dnnBkgLowPtThr_;
+  float ele_dnnBkgHighPtBarrelThr_;
+  float ele_dnnBkgHighPtEndcapThr_;
   // Threshold for DNN photon pfid
   float photon_dnnBarrelThr_;
   float photon_dnnEndcapThr_;

--- a/RecoParticleFlow/PFProducer/python/particleFlow_cff.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlow_cff.py
@@ -15,14 +15,22 @@ particleFlowTmp = particleFlow.clone()
 particleFlowTmp.PFEGammaFiltersParameters.allowEEEinPF = cms.bool(False)
 
 # Thresholds for e/gamma PFID DNN 
+# Thresholds for electron: Sig_isolated+Sig_nonIsolated
 particleFlowTmp.PFEGammaFiltersParameters.electronDnnThresholds = cms.PSet(
-            electronDnnHighPtBarrelThr = cms.double(0.122),
-            electronDnnHighPtEndcapThr = cms.double(0.072),
-            electronDnnLowPtThr = cms.double(0.081)
+            electronDnnHighPtBarrelThr = cms.double(0.068),
+            electronDnnHighPtEndcapThr = cms.double(0.056),
+            electronDnnLowPtThr = cms.double(0.075) 
         )
+# Thresholds for electron: Bkg_nonIsolated
+particleFlowTmp.PFEGammaFiltersParameters.electronDnnBkgThresholds = cms.PSet(
+            electronDnnBkgHighPtBarrelThr = cms.double(0.8),
+            electronDnnBkgHighPtEndcapThr = cms.double(0.75),
+            electronDnnBkgLowPtThr = cms.double(0.75) 
+        )
+# Thresholds for photons
 particleFlowTmp.PFEGammaFiltersParameters.photonDnnThresholds = cms.PSet(
-            photonDnnBarrelThr = cms.double(0.70),
-            photonDnnEndcapThr = cms.double(0.79)
+            photonDnnBarrelThr = cms.double(0.22),
+            photonDnnEndcapThr = cms.double(0.35)
 )
 
 from Configuration.Eras.Modifier_pf_badHcalMitigationOff_cff import pf_badHcalMitigationOff


### PR DESCRIPTION
#### PR description:

This PR updates the PFID DNN models trained on Run3Summer21 samples. A few additional variables have been included for electrons. 
The paths of the models have been updated as well as the thresholds defining the default working point. 
An additional threshold on the non-isolated background class has been included for electrons in PFEgammaFilters. 

This PR comes along two PRs for ElectronIdentification (https://github.com/cms-data/RecoEgamma-ElectronIdentification/pull/24) and PhotonIdentification (https://github.com/cms-data/RecoEgamma-PhotonIdentification/pull/10) data repositories.

#### PR validation:

For documentation about the changes in the model training and input variables please refer to the slides at: https://indico.cern.ch/event/1096395/#12-egm-updates-for-run-3-prepa. 

The correctness of the DNN configuration has been verified.  A validation of the physics performance of the PFID WPs is ongoing in the PF and Egamma group. 
