### PR TITLE
[10_6_X] Adding SiPixel on track charge and shape probs to MiniAOD content

### DIFF
--- a/DataFormats/PatCandidates/interface/IsolatedTrack.h
+++ b/DataFormats/PatCandidates/interface/IsolatedTrack.h
@@ -55,10 +55,10 @@ namespace pat {
 	  pfLepOverlap_(pfLepOverlap), pfNeutralSum_(pfNeutralSum),
 	  dz_(dz), dxy_(dxy), dzError_(dzError), dxyError_(dxyError),
           fromPV_(fromPV), trackQuality_(tkQual), dEdxStrip_(dEdxS), dEdxPixel_(dEdxP), 
-          probQonTrack_(255.f * probQonTrack + 0.5f),
-          probXYonTrack_(255.f * probXYonTrack + 0.5f),
-          probQonTrackNoLayer1_(255.f * probQonTrackNoLayer1 + 0.5f),
-          probXYonTrackNoLayer1_(255.f * probXYonTrackNoLayer1 + 0.5f),
+          probQonTrack_(probQonTrack),
+          probXYonTrack_(probXYonTrack),
+          probQonTrackNoLayer1_(probQonTrackNoLayer1),
+          probXYonTrackNoLayer1_(probXYonTrackNoLayer1),
           hitPattern_(hp), 
           crossedEcalStatus_(ecalst), crossedHcalStatus_(hcalst),
           deltaEta_(dEta), deltaPhi_(dPhi),
@@ -96,10 +96,10 @@ namespace pat {
         
         float dEdxStrip() const { return dEdxStrip_; }
         float dEdxPixel() const { return dEdxPixel_; }
-        float probQonTrack() const { return probQonTrack_ / 255.f; }
-        float probXYonTrack() const { return probXYonTrack_ / 255.f; }
-        float probQonTrackNoLayer1() const { return probQonTrackNoLayer1_ / 255.f; }
-        float probXYonTrackNoLayer1() const { return probXYonTrackNoLayer1_ / 255.f; }
+        float probQonTrack() const { return probQonTrack_; }
+        float probXYonTrack() const { return probXYonTrack_; }
+        float probQonTrackNoLayer1() const { return probQonTrackNoLayer1_; }
+        float probXYonTrackNoLayer1() const { return probXYonTrackNoLayer1_; }
 
 
         //! just the status code part of an EcalChannelStatusCode for all crossed Ecal cells
@@ -127,7 +127,7 @@ namespace pat {
         int fromPV_;  //only stored for packedPFCandidates
         int trackQuality_;
         float dEdxStrip_, dEdxPixel_; //in MeV/mm
-        uint8_t probQonTrack_, probXYonTrack_, probQonTrackNoLayer1_, probXYonTrackNoLayer1_;
+        float probQonTrack_, probXYonTrack_, probQonTrackNoLayer1_, probXYonTrackNoLayer1_;
         reco::HitPattern hitPattern_;
 
         std::vector<uint16_t> crossedEcalStatus_;

--- a/DataFormats/PatCandidates/interface/IsolatedTrack.h
+++ b/DataFormats/PatCandidates/interface/IsolatedTrack.h
@@ -55,10 +55,22 @@ namespace pat {
 	  pfLepOverlap_(pfLepOverlap), pfNeutralSum_(pfNeutralSum),
 	  dz_(dz), dxy_(dxy), dzError_(dzError), dxyError_(dxyError),
           fromPV_(fromPV), trackQuality_(tkQual), dEdxStrip_(dEdxS), dEdxPixel_(dEdxP), 
-          probQonTrack_(probQonTrack),
-          probXYonTrack_(probXYonTrack),
-          probQonTrackNoLayer1_(probQonTrackNoLayer1),
-          probXYonTrackNoLayer1_(probXYonTrackNoLayer1),
+          probQonTrack_(probQonTrack == 0.f        ? 0
+                        : probQonTrack < 1 / 255.f ? 1
+                        : probQonTrack == 1.f      ? 255
+                                                   : 255.f * probQonTrack + 0.5f),
+          probXYonTrack_(probXYonTrack == 0.f        ? 0
+                         : probXYonTrack < 1 / 255.f ? 1
+                         : probXYonTrack == 1.f      ? 255
+                                                     : 255.f * probXYonTrack + 0.5f),
+          probQonTrackNoLayer1_(probQonTrackNoLayer1 == 0.f        ? 0
+                                : probQonTrackNoLayer1 < 1 / 255.f ? 1
+                                : probQonTrackNoLayer1 == 1.f      ? 255
+                                                                   : 255.f * probQonTrackNoLayer1 + 0.5f),
+          probXYonTrackNoLayer1_(probXYonTrackNoLayer1 == 0.f        ? 0
+                                 : probXYonTrackNoLayer1 < 1 / 255.f ? 1
+                                 : probXYonTrackNoLayer1 == 1.f      ? 255
+                                                                     : 255.f * probXYonTrackNoLayer1 + 0.5f),
           hitPattern_(hp), 
           crossedEcalStatus_(ecalst), crossedHcalStatus_(hcalst),
           deltaEta_(dEta), deltaPhi_(dPhi),
@@ -96,11 +108,10 @@ namespace pat {
         
         float dEdxStrip() const { return dEdxStrip_; }
         float dEdxPixel() const { return dEdxPixel_; }
-        float probQonTrack() const { return probQonTrack_; }
-        float probXYonTrack() const { return probXYonTrack_; }
-        float probQonTrackNoLayer1() const { return probQonTrackNoLayer1_; }
-        float probXYonTrackNoLayer1() const { return probXYonTrackNoLayer1_; }
-
+        float probQonTrack() const { return probQonTrack_ / 255.f; }
+        float probXYonTrack() const { return probXYonTrack_ / 255.f; }
+        float probQonTrackNoLayer1() const { return probQonTrackNoLayer1_ / 255.f; }
+        float probXYonTrackNoLayer1() const { return probXYonTrackNoLayer1_ / 255.f; }
 
         //! just the status code part of an EcalChannelStatusCode for all crossed Ecal cells
         const std::vector<uint16_t>& crossedEcalStatus() const { return crossedEcalStatus_; }
@@ -127,7 +138,7 @@ namespace pat {
         int fromPV_;  //only stored for packedPFCandidates
         int trackQuality_;
         float dEdxStrip_, dEdxPixel_; //in MeV/mm
-        float probQonTrack_, probXYonTrack_, probQonTrackNoLayer1_, probXYonTrackNoLayer1_;
+        uint8_t probQonTrack_, probXYonTrack_, probQonTrackNoLayer1_, probXYonTrackNoLayer1_;
         reco::HitPattern hitPattern_;
 
         std::vector<uint16_t> crossedEcalStatus_;

--- a/DataFormats/PatCandidates/interface/IsolatedTrack.h
+++ b/DataFormats/PatCandidates/interface/IsolatedTrack.h
@@ -29,7 +29,9 @@ namespace pat {
           matchedCaloJetEmEnergy_(0.), matchedCaloJetHadEnergy_(0.),
 	  pfLepOverlap_(false), pfNeutralSum_(0.),
           dz_(0.), dxy_(0.), dzError_(0.), dxyError_(0.), fromPV_(-1), trackQuality_(0),
-          dEdxStrip_(0), dEdxPixel_(0), hitPattern_(reco::HitPattern()),
+          dEdxStrip_(0), dEdxPixel_(0),
+          probQonTrack_(0), probXYonTrack_(0), probQonTrackNoLayer1_(0), probXYonTrackNoLayer1_(0),
+          hitPattern_(reco::HitPattern()),
           crossedEcalStatus_(std::vector<uint16_t>()),
           crossedHcalStatus_(std::vector<uint32_t>()),
 	  deltaEta_(0), deltaPhi_(0),
@@ -41,7 +43,9 @@ namespace pat {
 			       bool pfLepOverlap, float pfNeutralSum,
                                const LorentzVector &p4, int charge, int id,
                                float dz, float dxy, float dzError, float dxyError,
-                               const reco::HitPattern &hp, float dEdxS, float dEdxP, int fromPV, int tkQual,
+                               const reco::HitPattern &hp, float dEdxS, float dEdxP,
+                               float probQonTrack, float probXYonTrack, float probQonTrackNoLayer1, float probXYonTrackNoLayer1,
+                               int fromPV, int tkQual,
                                const std::vector<uint16_t> &ecalst,
                                const std::vector<uint32_t> & hcalst, int dEta, int dPhi,
                                const PackedCandidateRef &pcref, const PackedCandidateRef &refToNearestPF, const PackedCandidateRef &refToNearestLostTrack) :
@@ -51,6 +55,10 @@ namespace pat {
 	  pfLepOverlap_(pfLepOverlap), pfNeutralSum_(pfNeutralSum),
 	  dz_(dz), dxy_(dxy), dzError_(dzError), dxyError_(dxyError),
           fromPV_(fromPV), trackQuality_(tkQual), dEdxStrip_(dEdxS), dEdxPixel_(dEdxP), 
+          probQonTrack_(255.f * probQonTrack + 0.5f),
+          probXYonTrack_(255.f * probXYonTrack + 0.5f),
+          probQonTrackNoLayer1_(255.f * probQonTrackNoLayer1 + 0.5f),
+          probXYonTrackNoLayer1_(255.f * probXYonTrackNoLayer1 + 0.5f),
           hitPattern_(hp), 
           crossedEcalStatus_(ecalst), crossedHcalStatus_(hcalst),
           deltaEta_(dEta), deltaPhi_(dPhi),
@@ -88,6 +96,11 @@ namespace pat {
         
         float dEdxStrip() const { return dEdxStrip_; }
         float dEdxPixel() const { return dEdxPixel_; }
+        float probQonTrack() const { return probQonTrack_ / 255.f; }
+        float probXYonTrack() const { return probXYonTrack_ / 255.f; }
+        float probQonTrackNoLayer1() const { return probQonTrackNoLayer1_ / 255.f; }
+        float probXYonTrackNoLayer1() const { return probXYonTrackNoLayer1_ / 255.f; }
+
 
         //! just the status code part of an EcalChannelStatusCode for all crossed Ecal cells
         const std::vector<uint16_t>& crossedEcalStatus() const { return crossedEcalStatus_; }
@@ -114,7 +127,7 @@ namespace pat {
         int fromPV_;  //only stored for packedPFCandidates
         int trackQuality_;
         float dEdxStrip_, dEdxPixel_; //in MeV/mm
-
+        uint8_t probQonTrack_, probXYonTrack_, probQonTrackNoLayer1_, probXYonTrackNoLayer1_;
         reco::HitPattern hitPattern_;
 
         std::vector<uint16_t> crossedEcalStatus_;

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -120,7 +120,8 @@
    <version ClassVersion="10" checksum="2244564938"/>
   </class>
 
-  <class name="pat::IsolatedTrack" ClassVersion="5">
+  <class name="pat::IsolatedTrack" ClassVersion="6">
+   <version ClassVersion="6" checksum="701085142"/>
    <version ClassVersion="5" checksum="139818330"/>
    <version ClassVersion="4" checksum="71166093"/>
    <version ClassVersion="3" checksum="550880582"/>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -121,7 +121,7 @@
   </class>
 
   <class name="pat::IsolatedTrack" ClassVersion="6">
-   <version ClassVersion="6" checksum="701085142"/>
+   <version ClassVersion="6" checksum="949138470"/>
    <version ClassVersion="5" checksum="139818330"/>
    <version ClassVersion="4" checksum="71166093"/>
    <version ClassVersion="3" checksum="550880582"/>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -121,7 +121,7 @@
   </class>
 
   <class name="pat::IsolatedTrack" ClassVersion="6">
-   <version ClassVersion="6" checksum="949138470"/>
+   <version ClassVersion="6" checksum="701085142"/>
    <version ClassVersion="5" checksum="139818330"/>
    <version ClassVersion="4" checksum="71166093"/>
    <version ClassVersion="3" checksum="550880582"/>

--- a/DataFormats/TrackReco/interface/SiPixelTrackProbQXY.h
+++ b/DataFormats/TrackReco/interface/SiPixelTrackProbQXY.h
@@ -1,0 +1,37 @@
+#ifndef DataFormats_TrackReco_SiPixelTrackProbQXY_H
+#define DataFormats_TrackReco_SiPixelTrackProbQXY_H
+
+#include <cstdint>
+#include <vector>
+
+#include "DataFormats/Common/interface/RefVector.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+
+namespace reco {
+  // Class defining the combined charge and shape probabilities for tracks that go through the SiPixel detector
+  class SiPixelTrackProbQXY {
+  public:
+    SiPixelTrackProbQXY() = default;
+
+    SiPixelTrackProbQXY(float probQonTrack, float probXYonTrack)
+        : probQonTrack_(probQonTrack), probXYonTrack_(probXYonTrack) {}
+
+    //! Return the combined charge probabilities for tracks that go through the SiPixel detector
+    float probQ() const { return probQonTrack_; }
+
+    //! Return the combined shape probabilities for tracks that go through the SiPixel detector
+    float probXY() const { return probXYonTrack_; }
+
+  private:
+    float probQonTrack_ = 0;
+    float probXYonTrack_ = 0;
+  };
+
+  typedef std::vector<SiPixelTrackProbQXY> SiPixelTrackProbQXYCollection;
+  typedef edm::ValueMap<SiPixelTrackProbQXY> SiPixelTrackProbQXYValueMap;
+  typedef edm::Ref<SiPixelTrackProbQXYCollection> SiPixelTrackProbQXYRef;
+  typedef edm::RefProd<SiPixelTrackProbQXYCollection> SiPixelTrackProbQXYRefProd;
+  typedef edm::RefVector<SiPixelTrackProbQXYCollection> SiPixelTrackProbQXYRefVector;
+
+}  // namespace reco
+#endif

--- a/DataFormats/TrackReco/src/classes.h
+++ b/DataFormats/TrackReco/src/classes.h
@@ -22,6 +22,7 @@
 #include "DataFormats/TrackReco/interface/DeDxHit.h"
 #include "DataFormats/TrackReco/interface/TrackDeDxHits.h"
 #include "DataFormats/TrackReco/interface/DeDxData.h"
+#include "DataFormats/TrackReco/interface/SiPixelTrackProbQXY.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/OneToManyWithQuality.h"
 #include "DataFormats/Common/interface/OneToManyWithQualityGeneric.h"

--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -507,6 +507,17 @@
    <class name="edm::Wrapper<reco::DeDxHitInfoCollection>"/>
    <class name="edm::Wrapper<reco::DeDxHitInfoAss>"/>
 
+   <class name="reco::SiPixelTrackProbQXY"/>
+   <class name="reco::SiPixelTrackProbQXYValueMap"/>
+   <class name="reco::SiPixelTrackProbQXYCollection"/>
+   <class name="reco::SiPixelTrackProbQXYRef"/>
+   <class name="reco::SiPixelTrackProbQXYRefProd"/>
+   <class name="reco::SiPixelTrackProbQXYRefVector"/>
+   <class name="edm::ValueMap<reco::SiPixelTrackProbQXY>"/>
+   <class name="edm::Wrapper<reco::SiPixelTrackProbQXY>"/>
+   <class name="edm::Wrapper<edm::ValueMap<reco::SiPixelTrackProbQXY> >"/>
+   <class name="edm::Wrapper<reco::SiPixelTrackProbQXYCollection>"/>
+
    <class name="SeedStopInfo" persistent="false"/>
    <class name="std::vector<SeedStopInfo>" persistent="false"/>
    <class name="edm::Wrapper<std::vector<SeedStopInfo> >" persistent="false"/>

--- a/PhysicsTools/PatAlgos/python/slimming/isolatedTracks_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/isolatedTracks_cfi.py
@@ -38,6 +38,9 @@ isolatedTracks = cms.EDProducer("PATIsolatedTrackProducer",
     addPrescaledDeDxTracks = cms.bool(False),
     usePrecomputedDeDxStrip = cms.bool(True),        # if these are set to True, will get estimated DeDx from DeDxData branches
     usePrecomputedDeDxPixel = cms.bool(True),        # if set to False, will manually compute using dEdxHitInfo
+    useSiPixelTrackProbQXY = cms.bool(True),         # Set to false if siPixelTrackProbQXY is not available (older AODs)
+    siPixelTrackProbQXY = cms.InputTag("siPixelTrackProbQXY"),
+    siPixelTrackProbQXYNoLayer1 = cms.InputTag("siPixelTrackProbQXY","NoLayer1"),
     pT_cut = cms.double(5.0),         # save tracks above this pt
     pT_cut_noIso = cms.double(20.0),  # for tracks with at least this pT, don't apply any iso cut
     pfIsolation_DR = cms.double(0.3),
@@ -62,7 +65,15 @@ isolatedTracks = cms.EDProducer("PATIsolatedTrackProducer",
     saveDeDxHitInfoCut = cms.string("(%s) || (%s)" % (_susySoftDisappearingTrackCut,_exoHighPtTrackCut)), 
 )
 
+# full set of track extras not available in existing AOD
+from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
+from Configuration.Eras.Modifier_run2_miniAOD_94XFall17_cff import run2_miniAOD_94XFall17
+from Configuration.ProcessModifiers.run2_miniAOD_UL_preSummer20_cff import run2_miniAOD_UL_preSummer20
+
+(run2_miniAOD_80XLegacy | run2_miniAOD_94XFall17 | run2_miniAOD_UL_preSummer20).toModify(isolatedTracks, useSiPixelTrackProbQXY = False)
+
 def miniAOD_customizeIsolatedTracksFastSim(process):
     """Switch off dE/dx hit info on fast sim, as it's not available"""
     process.isolatedTracks.saveDeDxHitInfo = False
+    process.isolatedTracks.useSiPixelTrackProbQXY = False
     return process

--- a/RecoTracker/Configuration/python/RecoTracker_EventContent_cff.py
+++ b/RecoTracker/Configuration/python/RecoTracker_EventContent_cff.py
@@ -22,6 +22,7 @@ RecoTrackerFEVT = cms.PSet(
         'keep *_dedxHitInfo_*_*',
         'keep *_dedxHarmonic2_*_*',
         'keep *_dedxPixelHarmonic2_*_*',
+        'keep *_siPixelTrackProbQXY_*_*',
         'keep *_trackExtrapolator_*_*',
         'keep recoTracks_cosmicDCTracks_*_*',
         'keep recoTrackExtras_cosmicDCTracks_*_*',
@@ -49,6 +50,7 @@ RecoTrackerRECO = cms.PSet(
         'keep *_dedxHitInfo_*_*',
         'keep *_dedxHarmonic2_*_*',
         'keep *_dedxPixelHarmonic2_*_*',
+        'keep *_siPixelTrackProbQXY_*_*',
         'keep *_trackExtrapolator_*_*',
         'keep recoTracks_cosmicDCTracks_*_*',
         'keep recoTrackExtras_cosmicDCTracks_*_*',
@@ -65,6 +67,7 @@ RecoTrackerAOD = cms.PSet(
         'keep *_dedxHarmonic2_*_*',
         'keep *_dedxPixelHarmonic2_*_*',
         'keep *_dedxHitInfo_*_*',
+        'keep *_siPixelTrackProbQXY_*_*',
         'keep *_trackExtrapolator_*_*',
         'keep *_generalTracks_MVAValues_*',
         'keep *_generalTracks_MVAVals_*'

--- a/RecoTracker/Configuration/python/RecoTracker_cff.py
+++ b/RecoTracker/Configuration/python/RecoTracker_cff.py
@@ -10,6 +10,7 @@ import copy
 
 #dEdX reconstruction
 from RecoTracker.DeDx.dedxEstimators_cff import *
+from RecoTracker.DeDx.siPixelTrackProbQXYProducer_cff import *
 
 #BeamHalo tracking
 from RecoTracker.Configuration.RecoTrackerBHM_cff import *
@@ -18,7 +19,7 @@ from RecoTracker.Configuration.RecoTrackerBHM_cff import *
 #special sequences, such as pixel-less
 from RecoTracker.Configuration.RecoTrackerNotStandard_cff import *
 
-ckftracks_woBH = cms.Sequence(iterTracking*electronSeedsSeq*doAlldEdXEstimators)
+ckftracks_woBH = cms.Sequence(iterTracking*electronSeedsSeq*doAlldEdXEstimators*doSiPixelTrackProbQXY)
 ckftracks = ckftracks_woBH.copy() #+ beamhaloTracksSeq) # temporarily out, takes too much resources
 
 ckftracks_wodEdX = ckftracks.copy()

--- a/RecoTracker/DeDx/plugins/SiPixelTrackProbQXYProducer.cc
+++ b/RecoTracker/DeDx/plugins/SiPixelTrackProbQXYProducer.cc
@@ -48,6 +48,7 @@ private:
   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
   // ----------member data ---------------------------
+  const bool debugFlag_;
   const edm::EDGetTokenT<reco::TrackCollection> trackToken_;
   const edm::EDPutTokenT<edm::ValueMap<reco::SiPixelTrackProbQXY>> putProbQXYVMToken_;
   const edm::EDPutTokenT<edm::ValueMap<reco::SiPixelTrackProbQXY>> putProbQXYNoLayer1VMToken_;
@@ -58,12 +59,13 @@ using namespace std;
 using namespace edm;
 
 SiPixelTrackProbQXYProducer::SiPixelTrackProbQXYProducer(const edm::ParameterSet& iConfig)
-    : trackToken_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracks"))),
+    : debugFlag_(iConfig.getUntrackedParameter<bool>("debug", false)),
+      trackToken_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracks"))),
       putProbQXYVMToken_(produces<edm::ValueMap<reco::SiPixelTrackProbQXY>>()),
       putProbQXYNoLayer1VMToken_(produces<edm::ValueMap<reco::SiPixelTrackProbQXY>>("NoLayer1")) {}
 
 void SiPixelTrackProbQXYProducer::produce(edm::StreamID id, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
-  bool debug = false;
+  bool debug = debugFlag_;
 
   // Retrieve track collection from the event
   auto trackCollectionHandle = iEvent.getHandle(trackToken_);
@@ -236,6 +238,7 @@ void SiPixelTrackProbQXYProducer::produce(edm::StreamID id, edm::Event& iEvent, 
 void SiPixelTrackProbQXYProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.setComment("Producer that creates SiPixel Charge and shape probabilities combined for tracks");
+  desc.addUntracked<bool>("debug", false);
   desc.add<edm::InputTag>("tracks", edm::InputTag("generalTracks"))
       ->setComment("Input track collection for the producer");
   descriptions.addWithDefaultLabel(desc);

--- a/RecoTracker/DeDx/plugins/SiPixelTrackProbQXYProducer.cc
+++ b/RecoTracker/DeDx/plugins/SiPixelTrackProbQXYProducer.cc
@@ -1,0 +1,194 @@
+// -*- C++ -*-
+//
+// Package:    SiPixelTrackProbQXYProducer
+// Class:      SiPixelTrackProbQXYProducer
+//
+/**\class SiPixelTrackProbQXYProducer  SiPixelTrackProbQXYProducer.cc RecoTracker/DeDx/plugins/SiPixelTrackProbQXYProducer.cc
+
+ Description: SiPixel Charge and shape probabilities combined for tracks
+
+*/
+//
+// Original Author:  Tamas Almos Vami
+//         Created:  Mon Nov 17 14:09:02 CEST 2021
+//
+
+// system include files
+#include <memory>
+
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
+#include "DataFormats/TrackReco/interface/SiPixelTrackProbQXY.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
+#include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
+
+//
+// class declaration
+//
+
+class SiPixelTrackProbQXYProducer : public edm::global::EDProducer<> {
+public:
+  explicit SiPixelTrackProbQXYProducer(const edm::ParameterSet&);
+  ~SiPixelTrackProbQXYProducer() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+
+  // ----------member data ---------------------------
+  const edm::EDGetTokenT<reco::TrackCollection> trackToken_;
+  const edm::EDPutTokenT<edm::ValueMap<reco::SiPixelTrackProbQXY>> putProbQXYVMToken_;
+  const edm::EDPutTokenT<edm::ValueMap<reco::SiPixelTrackProbQXY>> putProbQXYNoLayer1VMToken_;
+};
+
+using namespace reco;
+using namespace std;
+using namespace edm;
+
+SiPixelTrackProbQXYProducer::SiPixelTrackProbQXYProducer(const edm::ParameterSet& iConfig)
+    : trackToken_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracks"))),
+      putProbQXYVMToken_(produces<edm::ValueMap<reco::SiPixelTrackProbQXY>>()),
+      putProbQXYNoLayer1VMToken_(produces<edm::ValueMap<reco::SiPixelTrackProbQXY>>("NoLayer1")) {}
+
+void SiPixelTrackProbQXYProducer::produce(edm::StreamID id, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  // Retrieve track collection from the event
+  auto trackCollectionHandle = iEvent.getHandle(trackToken_);
+  const TrackCollection& trackCollection(*trackCollectionHandle.product());
+
+  // Retrieve tracker topology from geometry
+  edm::ESHandle<TrackerTopology> TopoHandle;
+  iSetup.get<TrackerTopologyRcd>().get(TopoHandle);
+  const TrackerTopology* tTopo = TopoHandle.product();
+  // Creates the output collection
+  auto resultSiPixelTrackProbQXYColl = std::make_unique<reco::SiPixelTrackProbQXYCollection>();
+  auto resultSiPixelTrackProbQXYNoLayer1Coll = std::make_unique<reco::SiPixelTrackProbQXYCollection>();
+
+  // Loop through the tracks
+  for (const auto& track : trackCollection) {
+    float probQonTrack = 0.0;
+    float probXYonTrack = 0.0;
+    float probQonTrackNoLayer1 = 0.0;
+    float probXYonTrackNoLayer1 = 0.0;
+    int numRecHits = 0;
+    int numRecHitsNoLayer1 = 0;
+    float probQonTrackWMulti = 1;
+    float probXYonTrackWMulti = 1;
+    float probQonTrackWMultiNoLayer1 = 1;
+    float probXYonTrackWMultiNoLayer1 = 1;
+    // Loop through the rechits on the given track
+    for (auto const& hit : track.recHits()) {
+      const SiPixelRecHit* pixhit = dynamic_cast<const SiPixelRecHit*>(hit);
+      if (pixhit == nullptr)
+        continue;
+      if (!pixhit->isValid())
+        continue;
+
+      // Have a separate variable that excludes Layer 1
+      // Layer 1 was very noisy in 2017/2018
+      if (pixhit->geographicalId().subdetId() == PixelSubdetector::PixelBarrel &&
+          tTopo->pxbLayer(pixhit->geographicalId()) != 1) {
+        float probQNoLayer1 = pixhit->probabilityQ();
+        float probXYNoLayer1 = pixhit->probabilityXY();
+        if (probQNoLayer1 != 0) {  // only save the non-zero rechits
+          numRecHitsNoLayer1++;
+          // Calculate alpha term needed for the combination
+          probQonTrackWMultiNoLayer1 *= probQNoLayer1;
+          probXYonTrackWMultiNoLayer1 *= probXYNoLayer1;
+        }
+      }
+
+      // Have a variable that includes all layers and disks
+      float probQ = pixhit->probabilityQ();
+      float probXY = pixhit->probabilityXY();
+
+      if (probQ == 0) {
+        continue;  // if any of the rechits have zero probQ, skip them
+      }
+      numRecHits++;
+
+      // Calculate alpha term needed for the combination
+      probQonTrackWMulti *= probQ;
+      probXYonTrackWMulti *= probXY;
+
+    }  // end looping on the rechits
+
+    // Combine the probabilities into a track level quantity
+    float logprobQonTrackWMulti = probQonTrackWMulti > 0 ? log(probQonTrackWMulti) : 0;
+    float logprobXYonTrackWMulti = probXYonTrackWMulti > 0 ? log(probXYonTrackWMulti) : 0;
+    float factQ = -logprobQonTrackWMulti;
+    float factXY = -logprobXYonTrackWMulti;
+    float probQonTrackTerm = 1.f + factQ;
+    float probXYonTrackTerm = 1.f + factXY;
+
+    for (int iTkRh = 2; iTkRh < numRecHits; ++iTkRh) {
+      factQ *= -logprobQonTrackWMulti / float(iTkRh);
+      factXY *= -logprobXYonTrackWMulti / float(iTkRh);
+      probQonTrackTerm += factQ;
+      probXYonTrackTerm += factXY;
+    }
+
+    probQonTrack = probQonTrackWMulti * probQonTrackTerm;
+    probXYonTrack = probXYonTrackWMulti * probXYonTrackTerm;
+
+    // Repeat the above excluding Layer 1
+    float logprobQonTrackWMultiNoLayer1 = probQonTrackWMultiNoLayer1 > 0 ? log(probQonTrackWMultiNoLayer1) : 0;
+    float logprobXYonTrackWMultiNoLayer1 = probXYonTrackWMultiNoLayer1 > 0 ? log(probXYonTrackWMultiNoLayer1) : 0;
+
+    float factQNoLayer1 = -logprobQonTrackWMultiNoLayer1;
+    float factXYNoLayer1 = -logprobXYonTrackWMultiNoLayer1;
+    float probQonTrackTermNoLayer1 = 1.f + factQNoLayer1;
+    float probXYonTrackTermNoLayer1 = 1.f + factXYNoLayer1;
+
+    for (int iTkRh = 2; iTkRh < numRecHits; ++iTkRh) {
+      factQNoLayer1 *= -logprobQonTrackWMultiNoLayer1 / float(iTkRh);
+      factXYNoLayer1 *= -logprobXYonTrackWMultiNoLayer1 / float(iTkRh);
+      probQonTrackTermNoLayer1 += factQNoLayer1;
+      probXYonTrackTermNoLayer1 += factXYNoLayer1;
+    }
+
+    probQonTrackNoLayer1 = probQonTrackWMultiNoLayer1 * probQonTrackTermNoLayer1;
+    probXYonTrackNoLayer1 = probXYonTrackWMultiNoLayer1 * probXYonTrackTermNoLayer1;
+
+    // Store the values in the collection
+    resultSiPixelTrackProbQXYColl->emplace_back(probQonTrack, probXYonTrack);
+    resultSiPixelTrackProbQXYNoLayer1Coll->emplace_back(probQonTrackNoLayer1, probXYonTrackNoLayer1);
+  }  // end loop on track collection
+
+  // Populate the event with the value map
+  auto trackProbQXYMatch = std::make_unique<edm::ValueMap<reco::SiPixelTrackProbQXY>>();
+  edm::ValueMap<reco::SiPixelTrackProbQXY>::Filler filler(*trackProbQXYMatch);
+  filler.insert(trackCollectionHandle, resultSiPixelTrackProbQXYColl->begin(), resultSiPixelTrackProbQXYColl->end());
+  filler.fill();
+  iEvent.put(putProbQXYVMToken_, std::move(trackProbQXYMatch));
+
+  auto trackProbQXYMatchNoLayer1 = std::make_unique<edm::ValueMap<reco::SiPixelTrackProbQXY>>();
+  edm::ValueMap<reco::SiPixelTrackProbQXY>::Filler fillerNoLayer1(*trackProbQXYMatchNoLayer1);
+  fillerNoLayer1.insert(trackCollectionHandle,
+                        resultSiPixelTrackProbQXYNoLayer1Coll->begin(),
+                        resultSiPixelTrackProbQXYNoLayer1Coll->end());
+  fillerNoLayer1.fill();
+  iEvent.put(putProbQXYNoLayer1VMToken_, std::move(trackProbQXYMatchNoLayer1));
+}
+
+void SiPixelTrackProbQXYProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.setComment("Producer that creates SiPixel Charge and shape probabilities combined for tracks");
+  desc.add<edm::InputTag>("tracks", edm::InputTag("generalTracks"))
+      ->setComment("Input track collection for the producer");
+  descriptions.addWithDefaultLabel(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(SiPixelTrackProbQXYProducer);

--- a/RecoTracker/DeDx/plugins/SiPixelTrackProbQXYProducer.cc
+++ b/RecoTracker/DeDx/plugins/SiPixelTrackProbQXYProducer.cc
@@ -162,7 +162,7 @@ void SiPixelTrackProbQXYProducer::produce(edm::StreamID id, edm::Event& iEvent, 
          factXY *= -logprobXYonTrackWMulti / float(iTkRh);
          probQonTrackTerm += factQ;
          probXYonTrackTerm += factXY;
-    }
+      }
     }
     probQonTrack = probQonTrackWMulti * probQonTrackTerm;
     probXYonTrack = probXYonTrackWMulti * probXYonTrackTerm;

--- a/RecoTracker/DeDx/plugins/SiPixelTrackProbQXYProducer.cc
+++ b/RecoTracker/DeDx/plugins/SiPixelTrackProbQXYProducer.cc
@@ -65,8 +65,6 @@ SiPixelTrackProbQXYProducer::SiPixelTrackProbQXYProducer(const edm::ParameterSet
       putProbQXYNoLayer1VMToken_(produces<edm::ValueMap<reco::SiPixelTrackProbQXY>>("NoLayer1")) {}
 
 void SiPixelTrackProbQXYProducer::produce(edm::StreamID id, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
-  bool debug = debugFlag_;
-
   // Retrieve track collection from the event
   auto trackCollectionHandle = iEvent.getHandle(trackToken_);
   const TrackCollection& trackCollection(*trackCollectionHandle.product());
@@ -95,7 +93,7 @@ void SiPixelTrackProbQXYProducer::produce(edm::StreamID id, edm::Event& iEvent, 
     float probQonTrackWMultiNoLayer1 = 1;
     float probXYonTrackWMultiNoLayer1 = 1;
     // Loop through the rechits on the given track
-    if(debug) {
+    if(debugFlag_) {
        LogPrint("SiPixelTrackProbQXYProducer") << "  -----------------------------------------------";
        LogPrint("SiPixelTrackProbQXYProducer") << "  For track " << numTrack;
     }
@@ -119,7 +117,7 @@ void SiPixelTrackProbQXYProducer::produce(edm::StreamID id, edm::Event& iEvent, 
           // Calculate alpha term needed for the combination
           probQonTrackWMultiNoLayer1 *= probQNoLayer1;
           probXYonTrackWMultiNoLayer1 *= probXYNoLayer1;
-          if(debug) {
+          if(debugFlag_) {
             LogDebug("SiPixelTrackProbQXYProducer") << "    >>>> For rechit excluding Layer 1: " << numRecHitsNoLayer1 << " ProbQ = " << probQNoLayer1;
       }
 
@@ -135,7 +133,7 @@ void SiPixelTrackProbQXYProducer::produce(edm::StreamID id, edm::Event& iEvent, 
       }
       numRecHits++;
 
-      if(debug) {
+      if(debugFlag_) {
         LogDebug("SiPixelTrackProbQXYProducer") << "    >>>> For rechit: " << numRecHits << " ProbQ = " << probQ;
       }
 
@@ -174,7 +172,7 @@ void SiPixelTrackProbQXYProducer::produce(edm::StreamID id, edm::Event& iEvent, 
        numTrackWSmallProbQ++;
     }
 
-    if(debug) {
+    if(debugFlag_) {
        LogPrint("SiPixelTrackProbQXYProducer") << "  >> probQonTrack = " << probQonTrack
         << " = " << probQonTrackWMulti << " * " << probQonTrackTerm;
     }
@@ -205,7 +203,7 @@ void SiPixelTrackProbQXYProducer::produce(edm::StreamID id, edm::Event& iEvent, 
     probQonTrackNoLayer1 = probQonTrackWMultiNoLayer1 * probQonTrackTermNoLayer1;
     probXYonTrackNoLayer1 = probXYonTrackWMultiNoLayer1 * probXYonTrackTermNoLayer1;
 
-    if(debug) {
+    if(debugFlag_) {
        LogPrint("SiPixelTrackProbQXYProducer") << "  >> probQonTrackNoLayer1 = " << probQonTrackNoLayer1
        << " = " << probQonTrackWMultiNoLayer1 << " * " << probQonTrackTermNoLayer1;
     }
@@ -215,7 +213,7 @@ void SiPixelTrackProbQXYProducer::produce(edm::StreamID id, edm::Event& iEvent, 
     resultSiPixelTrackProbQXYNoLayer1Coll->emplace_back(probQonTrackNoLayer1, probXYonTrackNoLayer1);
   }  // end loop on track collection
 
-  if(debug) {
+  if(debugFlag_) {
      LogPrint("SiPixelTrackProbQXYProducer") << "In this event the ratio of low probQ tracks / all tracks " << numTrackWSmallProbQ/float(numTrack);
   }
 

--- a/RecoTracker/DeDx/plugins/SiPixelTrackProbQXYProducer.cc
+++ b/RecoTracker/DeDx/plugins/SiPixelTrackProbQXYProducer.cc
@@ -63,9 +63,13 @@ SiPixelTrackProbQXYProducer::SiPixelTrackProbQXYProducer(const edm::ParameterSet
       putProbQXYNoLayer1VMToken_(produces<edm::ValueMap<reco::SiPixelTrackProbQXY>>("NoLayer1")) {}
 
 void SiPixelTrackProbQXYProducer::produce(edm::StreamID id, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  bool debug = false;
+
   // Retrieve track collection from the event
   auto trackCollectionHandle = iEvent.getHandle(trackToken_);
   const TrackCollection& trackCollection(*trackCollectionHandle.product());
+  int numTrack = 0;
+  int numTrackWSmallProbQ = 0;
 
   // Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> TopoHandle;
@@ -77,6 +81,7 @@ void SiPixelTrackProbQXYProducer::produce(edm::StreamID id, edm::Event& iEvent, 
 
   // Loop through the tracks
   for (const auto& track : trackCollection) {
+    numTrack++;
     float probQonTrack = 0.0;
     float probXYonTrack = 0.0;
     float probQonTrackNoLayer1 = 0.0;
@@ -88,6 +93,11 @@ void SiPixelTrackProbQXYProducer::produce(edm::StreamID id, edm::Event& iEvent, 
     float probQonTrackWMultiNoLayer1 = 1;
     float probXYonTrackWMultiNoLayer1 = 1;
     // Loop through the rechits on the given track
+    if(debug) {
+       LogPrint("SiPixelTrackProbQXYProducer") << "  -----------------------------------------------";
+       LogPrint("SiPixelTrackProbQXYProducer") << "  For track " << numTrack;
+    }
+
     for (auto const& hit : track.recHits()) {
       const SiPixelRecHit* pixhit = dynamic_cast<const SiPixelRecHit*>(hit);
       if (pixhit == nullptr)
@@ -97,15 +107,20 @@ void SiPixelTrackProbQXYProducer::produce(edm::StreamID id, edm::Event& iEvent, 
 
       // Have a separate variable that excludes Layer 1
       // Layer 1 was very noisy in 2017/2018
-      if (pixhit->geographicalId().subdetId() == PixelSubdetector::PixelBarrel &&
-          tTopo->pxbLayer(pixhit->geographicalId()) != 1) {
+      if ((pixhit->geographicalId().subdetId() == PixelSubdetector::PixelEndcap) ||
+         (pixhit->geographicalId().subdetId() == PixelSubdetector::PixelBarrel &&
+          tTopo->pxbLayer(pixhit->geographicalId()) != 1)) {
         float probQNoLayer1 = pixhit->probabilityQ();
         float probXYNoLayer1 = pixhit->probabilityXY();
-        if (probQNoLayer1 != 0) {  // only save the non-zero rechits
+        if (probQNoLayer1 > 0.f) {  // only save the non-zero rechits
           numRecHitsNoLayer1++;
           // Calculate alpha term needed for the combination
           probQonTrackWMultiNoLayer1 *= probQNoLayer1;
           probXYonTrackWMultiNoLayer1 *= probXYNoLayer1;
+          if(debug) {
+            LogDebug("SiPixelTrackProbQXYProducer") << "    >>>> For rechit excluding Layer 1: " << numRecHitsNoLayer1 << " ProbQ = " << probQNoLayer1;
+      }
+
         }
       }
 
@@ -118,6 +133,10 @@ void SiPixelTrackProbQXYProducer::produce(edm::StreamID id, edm::Event& iEvent, 
       }
       numRecHits++;
 
+      if(debug) {
+        LogDebug("SiPixelTrackProbQXYProducer") << "    >>>> For rechit: " << numRecHits << " ProbQ = " << probQ;
+      }
+
       // Calculate alpha term needed for the combination
       probQonTrackWMulti *= probQ;
       probXYonTrackWMulti *= probXY;
@@ -125,22 +144,38 @@ void SiPixelTrackProbQXYProducer::produce(edm::StreamID id, edm::Event& iEvent, 
     }  // end looping on the rechits
 
     // Combine the probabilities into a track level quantity
-    float logprobQonTrackWMulti = probQonTrackWMulti > 0 ? log(probQonTrackWMulti) : 0;
-    float logprobXYonTrackWMulti = probXYonTrackWMulti > 0 ? log(probXYonTrackWMulti) : 0;
+    float logprobQonTrackWMulti = probQonTrackWMulti > 0.f ? log(probQonTrackWMulti) : 0.f;
+    float logprobXYonTrackWMulti = probXYonTrackWMulti > 0.f ? log(probXYonTrackWMulti) : 0.f;
     float factQ = -logprobQonTrackWMulti;
     float factXY = -logprobXYonTrackWMulti;
-    float probQonTrackTerm = 1.f + factQ;
-    float probXYonTrackTerm = 1.f + factXY;
+    float probQonTrackTerm = 0.f;
+    float probXYonTrackTerm = 0.f;
 
-    for (int iTkRh = 2; iTkRh < numRecHits; ++iTkRh) {
-      factQ *= -logprobQonTrackWMulti / float(iTkRh);
-      factXY *= -logprobXYonTrackWMulti / float(iTkRh);
-      probQonTrackTerm += factQ;
-      probXYonTrackTerm += factXY;
+    if (numRecHits == 1 ) {
+      probQonTrackTerm = 1.f;
+      probXYonTrackTerm = 1.f;
+    } else if (numRecHits > 1 ) {
+      probQonTrackTerm =  1.f + factQ;
+      probXYonTrackTerm = 1.f + factXY;
+      for (int iTkRh = 2; iTkRh < numRecHits; ++iTkRh) {
+         factQ *= -logprobQonTrackWMulti / float(iTkRh);
+         factXY *= -logprobXYonTrackWMulti / float(iTkRh);
+         probQonTrackTerm += factQ;
+         probXYonTrackTerm += factXY;
     }
-
+    }
     probQonTrack = probQonTrackWMulti * probQonTrackTerm;
     probXYonTrack = probXYonTrackWMulti * probXYonTrackTerm;
+
+    // Count the number of tracks with small probQonTrack
+    if(probQonTrack < 0.1) {
+       numTrackWSmallProbQ++;
+    }
+
+    if(debug) {
+       LogPrint("SiPixelTrackProbQXYProducer") << "  >> probQonTrack = " << probQonTrack
+        << " = " << probQonTrackWMulti << " * " << probQonTrackTerm;
+    }
 
     // Repeat the above excluding Layer 1
     float logprobQonTrackWMultiNoLayer1 = probQonTrackWMultiNoLayer1 > 0 ? log(probQonTrackWMultiNoLayer1) : 0;
@@ -148,23 +183,39 @@ void SiPixelTrackProbQXYProducer::produce(edm::StreamID id, edm::Event& iEvent, 
 
     float factQNoLayer1 = -logprobQonTrackWMultiNoLayer1;
     float factXYNoLayer1 = -logprobXYonTrackWMultiNoLayer1;
-    float probQonTrackTermNoLayer1 = 1.f + factQNoLayer1;
-    float probXYonTrackTermNoLayer1 = 1.f + factXYNoLayer1;
+    float probQonTrackTermNoLayer1 = 0.f;
+    float probXYonTrackTermNoLayer1 = 0.f;
 
-    for (int iTkRh = 2; iTkRh < numRecHits; ++iTkRh) {
-      factQNoLayer1 *= -logprobQonTrackWMultiNoLayer1 / float(iTkRh);
-      factXYNoLayer1 *= -logprobXYonTrackWMultiNoLayer1 / float(iTkRh);
-      probQonTrackTermNoLayer1 += factQNoLayer1;
-      probXYonTrackTermNoLayer1 += factXYNoLayer1;
+    if (numRecHitsNoLayer1 == 1 ) {
+      probQonTrackTermNoLayer1 = 1.f;
+      probXYonTrackTermNoLayer1 = 1.f;
+    } else if (numRecHitsNoLayer1 > 1 ) {
+      probQonTrackTermNoLayer1 =  1.f + factQNoLayer1;
+      probXYonTrackTermNoLayer1 = 1.f + factXYNoLayer1;
+      for (int iTkRh = 2; iTkRh < numRecHitsNoLayer1; ++iTkRh) {
+        factQNoLayer1 *= -logprobQonTrackWMultiNoLayer1 / float(iTkRh);
+        factXYNoLayer1 *= -logprobXYonTrackWMultiNoLayer1 / float(iTkRh);
+        probQonTrackTermNoLayer1 += factQNoLayer1;
+        probXYonTrackTermNoLayer1 += factXYNoLayer1;
+      }
     }
 
     probQonTrackNoLayer1 = probQonTrackWMultiNoLayer1 * probQonTrackTermNoLayer1;
     probXYonTrackNoLayer1 = probXYonTrackWMultiNoLayer1 * probXYonTrackTermNoLayer1;
 
+    if(debug) {
+       LogPrint("SiPixelTrackProbQXYProducer") << "  >> probQonTrackNoLayer1 = " << probQonTrackNoLayer1
+       << " = " << probQonTrackWMultiNoLayer1 << " * " << probQonTrackTermNoLayer1;
+    }
+
     // Store the values in the collection
     resultSiPixelTrackProbQXYColl->emplace_back(probQonTrack, probXYonTrack);
     resultSiPixelTrackProbQXYNoLayer1Coll->emplace_back(probQonTrackNoLayer1, probXYonTrackNoLayer1);
   }  // end loop on track collection
+
+  if(debug) {
+     LogPrint("SiPixelTrackProbQXYProducer") << "In this event the ratio of low probQ tracks / all tracks " << numTrackWSmallProbQ/float(numTrack);
+  }
 
   // Populate the event with the value map
   auto trackProbQXYMatch = std::make_unique<edm::ValueMap<reco::SiPixelTrackProbQXY>>();

--- a/RecoTracker/DeDx/python/siPixelTrackProbQXYProducer_cff.py
+++ b/RecoTracker/DeDx/python/siPixelTrackProbQXYProducer_cff.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+import RecoTracker.DeDx.siPixelTrackProbQXYProducer_cfi as _probQXY
+
+siPixelTrackProbQXY = _probQXY.siPixelTrackProbQXYProducer.clone()
+
+doSiPixelTrackProbQXYTask = cms.Task(siPixelTrackProbQXY)
+doSiPixelTrackProbQXY = cms.Sequence(doSiPixelTrackProbQXYTask)

--- a/RecoTracker/DeDx/test/BuildFile.xml
+++ b/RecoTracker/DeDx/test/BuildFile.xml
@@ -17,8 +17,3 @@
   <flags EDM_PLUGIN="1"/>
 </library>
 
-<environment>
-  <bin file="testDeDxScripts.cpp">
-    <flags TEST_RUNNER_ARGS="/bin/bash RecoTracker/DeDx/test testProbQXY.sh"/>
-  </bin>
-</environment>

--- a/RecoTracker/DeDx/test/BuildFile.xml
+++ b/RecoTracker/DeDx/test/BuildFile.xml
@@ -1,0 +1,24 @@
+<use name="TrackingTools/Records"/>
+<use name="RecoTracker/Record"/>
+<use name="FWCore/Utilities"/>
+<use name="DataFormats/TrackReco"/>
+<use name="RecoTracker/TrackProducer"/>
+<use name="TrackingTools/TransientTrack"/>
+<use name="FWCore/Framework"/>
+<use name="FWCore/ParameterSet"/>
+<use name="Geometry/TrackerGeometryBuilder"/>
+<use name="Geometry/Records"/>
+<use name="MagneticField/Records"/>
+<use name="MagneticField/Engine"/>
+<use name="TrackingTools/PatternTools"/>
+<use name="root"/>
+
+<library file="ProbQXYAna.cc" name="ProbQXYAna">
+  <flags EDM_PLUGIN="1"/>
+</library>
+
+<environment>
+  <bin file="testDeDxScripts.cpp">
+    <flags TEST_RUNNER_ARGS="/bin/bash RecoTracker/DeDx/test testProbQXY.sh"/>
+  </bin>
+</environment>

--- a/RecoTracker/DeDx/test/ProbQXYAna.cc
+++ b/RecoTracker/DeDx/test/ProbQXYAna.cc
@@ -41,6 +41,7 @@ void ProbQXYAna::analyze(edm::StreamID id, const edm::Event& iEvent, const edm::
   iEvent.getByToken(trackToken_, trackCollectionHandle);
   const auto trackCollection(*trackCollectionHandle.product());
   int numTrack = 0;
+  int numTrackWSmallProbQ = 0;
   LogPrint("ProbQXYAna") << "Analyzing run " << iEvent.id().run() << " / event " << iEvent.id().event();
   for (const auto& track : trackCollection) {
     numTrack++;
@@ -48,12 +49,17 @@ void ProbQXYAna::analyze(edm::StreamID id, const edm::Event& iEvent, const edm::
     float probXYonTrack = track.probXYonTrack();
     float probQonTrackNoLayer1 = track.probQonTrackNoLayer1();
     float probXYonTrackNoLayer1 = track.probXYonTrackNoLayer1();
-    LogPrint("ProbQXYAna") << "--------------------------------------------------";
-    LogPrint("ProbQXYAna") << "For track " << numTrack;
-    LogPrint("ProbQXYAna") << "probQonTrack: " << probQonTrack << " and probXYonTrack: " << probXYonTrack;
-    LogPrint("ProbQXYAna") << "probQonTrackNoLayer1: " << probQonTrackNoLayer1
+    LogPrint("ProbQXYAna") << "  --------------------------------------------------";
+    LogPrint("ProbQXYAna") << "  For track " << numTrack;
+    LogPrint("ProbQXYAna") << "  >> probQonTrack: " << probQonTrack << " and probXYonTrack: " << probXYonTrack;
+    LogPrint("ProbQXYAna") << "  >> probQonTrackNoLayer1: " << probQonTrackNoLayer1
                            << " and probXYonTrackNoLayer1: " << probXYonTrackNoLayer1;
+
+    if (probQonTrack<0.1) {
+      numTrackWSmallProbQ++;
+    }
   }
+  LogPrint("ProbQXYAna") << "Ratio of low probQ tracks / all tracks " << numTrackWSmallProbQ/float(numTrack);
 }
 
 //define this as a plug-in

--- a/RecoTracker/DeDx/test/ProbQXYAna.cc
+++ b/RecoTracker/DeDx/test/ProbQXYAna.cc
@@ -1,0 +1,60 @@
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/PatCandidates/interface/IsolatedTrack.h"
+
+#include "DataFormats/TrackReco/interface/SiPixelTrackProbQXY.h"
+
+class ProbQXYAna : public edm::global::EDAnalyzer<> {
+public:
+  explicit ProbQXYAna(const edm::ParameterSet&);
+  ~ProbQXYAna() override = default;
+
+private:
+  virtual void analyze(edm::StreamID, const edm::Event&, const edm::EventSetup&) const override;
+
+  // ----------member data ---------------------------
+  const edm::EDGetTokenT<std::vector<pat::IsolatedTrack>> trackToken_;
+};
+
+using namespace reco;
+using namespace std;
+using namespace edm;
+
+ProbQXYAna::ProbQXYAna(const edm::ParameterSet& iConfig)
+    : trackToken_(consumes<std::vector<pat::IsolatedTrack>>(iConfig.getParameter<edm::InputTag>("tracks"))) {}
+
+void ProbQXYAna::analyze(edm::StreamID id, const edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  edm::Handle<std::vector<pat::IsolatedTrack>> trackCollectionHandle;
+  iEvent.getByToken(trackToken_, trackCollectionHandle);
+  const auto trackCollection(*trackCollectionHandle.product());
+  int numTrack = 0;
+  LogPrint("ProbQXYAna") << "Analyzing run " << iEvent.id().run() << " / event " << iEvent.id().event();
+  for (const auto& track : trackCollection) {
+    numTrack++;
+    float probQonTrack = track.probQonTrack();
+    float probXYonTrack = track.probXYonTrack();
+    float probQonTrackNoLayer1 = track.probQonTrackNoLayer1();
+    float probXYonTrackNoLayer1 = track.probXYonTrackNoLayer1();
+    LogPrint("ProbQXYAna") << "--------------------------------------------------";
+    LogPrint("ProbQXYAna") << "For track " << numTrack;
+    LogPrint("ProbQXYAna") << "probQonTrack: " << probQonTrack << " and probXYonTrack: " << probXYonTrack;
+    LogPrint("ProbQXYAna") << "probQonTrackNoLayer1: " << probQonTrackNoLayer1
+                           << " and probXYonTrackNoLayer1: " << probXYonTrackNoLayer1;
+  }
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(ProbQXYAna);

--- a/RecoTracker/DeDx/test/ProbQXYAna.cc
+++ b/RecoTracker/DeDx/test/ProbQXYAna.cc
@@ -59,7 +59,7 @@ void ProbQXYAna::analyze(edm::StreamID id, const edm::Event& iEvent, const edm::
       numTrackWSmallProbQ++;
     }
   }
-  LogPrint("ProbQXYAna") << "Ratio of low probQ tracks / all tracks " << numTrackWSmallProbQ/float(numTrack);
+  LogPrint("ProbQXYAna") << "In this event the ratio of low probQ tracks / all tracks " << numTrackWSmallProbQ/float(numTrack);
 }
 
 //define this as a plug-in

--- a/RecoTracker/DeDx/test/ProbQXYFromMiniAOD_cfg.py
+++ b/RecoTracker/DeDx/test/ProbQXYFromMiniAOD_cfg.py
@@ -1,0 +1,42 @@
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
+process = cms.Process('RECO2',Run2_2018)
+
+options = VarParsing.VarParsing('analysis')
+options.register('globalTag',
+                 "auto:run2_data", # default value
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.string, # string, int, or float
+                 "input file name")
+options.parseArguments()
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+    
+process.source = cms.Source("PoolSource",
+                            fileNames = cms.untracked.vstring(options.inputFiles),
+                            secondaryFileNames = cms.untracked.vstring()
+                            )
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(options.maxEvents)
+)
+
+process.options = cms.untracked.PSet()
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, options.globalTag, '')
+
+process.probQXYAna  = cms.EDAnalyzer('ProbQXYAna',
+   tracks          = cms.InputTag("isolatedTracks")
+)
+
+# Path and EndPath definitions
+process.probQXYAna_step = cms.EndPath(process.probQXYAna)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.probQXYAna_step)

--- a/RecoTracker/DeDx/test/testDeDxScripts.cpp
+++ b/RecoTracker/DeDx/test/testDeDxScripts.cpp
@@ -1,0 +1,2 @@
+#include "FWCore/Utilities/interface/TestHelper.h"
+RUNTEST()

--- a/RecoTracker/DeDx/test/testProbQXY.sh
+++ b/RecoTracker/DeDx/test/testProbQXY.sh
@@ -15,3 +15,11 @@ cmsDriver.py ReRECO --conditions auto:run2_data --customise Configuration/DataPr
 
 cmsRun ${LOCAL_TEST_DIR}/ProbQXYFromMiniAOD_cfg.py maxEvents=10 inputFiles=file:MiniAOD.root || die "Failure getting probQ and probXY from MINIAOD" $?
 rm MiniAOD.root
+
+# test MINIAOD signal MC
+echo -e "TESTING  Getting probQ and probXY from signal MC MINIAOD ...\n\n"
+cmsDriver.py ReRECOonMC --conditions 106X_upgrade2018_realistic_v11_L1v1 --datatier MINIAOD --era Run2_2018,pf_badHcalMitigation --eventcontent MINIAOD --number 10 --python_filename 4HLT2MiniAODonMC.py --scenario pp --step RAW2DIGI,L1Reco,RECO,EI,PAT --runUnscheduled --mc  --filein  /store/user/tvami/HSCP/HSCPgluino_M_1800/crab_PrivateHSCP_2018_Gluino_Mass1800_HLT_NoPU_v1/210612_042006/0000/HSCP_Gluino_Mass1800_HLT_1.root  --fileout file:MiniAODonMC.root
+
+cmsRun ${LOCAL_TEST_DIR}/ProbQXYFromMiniAOD_cfg.py maxEvents=10 inputFiles=file:MiniAODonMC.root || die "Failure getting probQ and probXY from Signal MC MINIAOD" $?
+rm MiniAODonMC.root
+

--- a/RecoTracker/DeDx/test/testProbQXY.sh
+++ b/RecoTracker/DeDx/test/testProbQXY.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+function die { echo $1: status $2 ; exit $2; }
+
+echo "TESTING Getting probQ and probXY from Analysis Data-Tier codes ..."
+echo -e "For now not doing anything, when there will be AOD and MiniAOD with this variable, this can be uncommented"
+# test AOD
+# Will come soon
+#echo "TESTING refitting from AOD ...\n\n"
+#cmsRun ${LOCAL_TEST_DIR}/ProbQXYFromMiniAOD.py maxEvents=100 inputFiles=/store/mc/RunIISummer20UL16RECO/DYJetsToMuMu_M-50_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/AODSIM/106X_mcRun2_asymptotic_v13-v2/00000/1D4FBF4B-7B8D-A04F-A108-B1BEB60558FA.root || die "Failure refitting from AOD" $?
+
+# test MINIAOD
+echo -e "TESTING  Getting probQ and probXY from MINIAOD ...\n\n"
+cmsDriver.py ReRECO --conditions auto:run2_data --customise Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018 --datatier MINIAOD --eventcontent MINIAOD --number 10 --python_filename 4HLT2MiniAOD.py --scenario pp --step RAW2DIGI,L1Reco,RECO,PAT --data  --filein /store/data/Run2018C/SingleMuon/RAW/v1/000/319/337/00000/004ED286-5582-E811-8895-FA163E126126.root --fileout file:MiniAOD.root --era Run2_2018
+
+cmsRun ${LOCAL_TEST_DIR}/ProbQXYFromMiniAOD_cfg.py maxEvents=10 inputFiles=file:MiniAOD.root || die "Failure getting probQ and probXY from MINIAOD" $?
+rm MiniAOD.root

--- a/RecoTracker/DeDx/test/testProbQXY.sh
+++ b/RecoTracker/DeDx/test/testProbQXY.sh
@@ -11,7 +11,7 @@ echo -e "For now not doing anything, when there will be AOD and MiniAOD with thi
 
 # test MINIAOD
 echo -e "TESTING  Getting probQ and probXY from MINIAOD ...\n\n"
-cmsDriver.py ReRECO --conditions auto:run2_data --customise Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018 --datatier MINIAOD --eventcontent MINIAOD --number 10 --python_filename 4HLT2MiniAOD.py --scenario pp --step RAW2DIGI,L1Reco,RECO,PAT --data  --filein /store/data/Run2018C/SingleMuon/RAW/v1/000/319/337/00000/004ED286-5582-E811-8895-FA163E126126.root --fileout file:MiniAOD.root --era Run2_2018
+cmsDriver.py ReRECO --conditions auto:run2_data --customise Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018 --datatier MINIAOD --eventcontent MINIAOD --number 10 --python_filename 4HLT2MiniAOD.py --scenario pp --step RAW2DIGI,L1Reco,RECO,PAT --data  --filein /store/data/Run2018C/SingleMuon/RAW/v1/000/319/337/00000/004ED286-5582-E811-8895-FA163E126126.root --fileout file:MiniAOD.root --era Run2_2018  --runUnscheduled 
 
 cmsRun ${LOCAL_TEST_DIR}/ProbQXYFromMiniAOD_cfg.py maxEvents=10 inputFiles=file:MiniAOD.root || die "Failure getting probQ and probXY from MINIAOD" $?
 rm MiniAOD.root


### PR DESCRIPTION
#### PR description:

See request to ReRECO 2017/2018 SM and MET data in [1]. This assumed refitting tracks to get the required low-level pixel reco information. As an alternative (actually it's an improvement, so better then alternative) it was recommended to save the required information in the MiniAOD. This PR does that,  i.e. adds  SiPixel on track charge and shape probs to MiniAOD content. Since in 2017/2018 the Pixel layer 1 was very noisy, and alternative version that excludes L1 was added as well.

Adding it to RECO/AOD as a new object `siPixelTrackProbQXY`:
```
edmDumpEventContent ReRECO_RAW2DIGI_L1Reco_RECO_EI.root | grep siPixelTrackProbQXY  
edm::Association<vector<reco::SiPixelTrackProbQXY> >    "siPixelTrackProbQXY"       ""                "RECO"    
vector<reco::SiPixelTrackProbQXY>     "siPixelTrackProbQXY"       ""                "RECO"    
```

While adding it to MiniAOD as a member of the isolatedTracks collection.

Please note that most of the changes in the PR are due to code-checks/code-formats.

Further details will be presented in the Tracking POG meeting on Monday [2]

[1] https://its.cern.ch/jira/browse/PDMVRERECO-48
[2] https://indico.cern.ch/event/1098365/#5-proposal-to-use-low-level-pi

#### PR validation:
Running 
```
cmsDriver.py ReRECO --conditions 106X_dataRun2_v24 --customise Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018,Configuration/DataProcessing/Utils.addMonitoring --datatier MINIAOD --era Run2_2018,pf_badHcalMitigation --eventcontent MINIAOD --nThreads 8 --no_exec --number 100 --python_filename 4HLT2MiniAOD.py --scenario pp --step RAW2DIGI,L1Reco,RECO,EI,PAT --runUnscheduled --data  --filein root://cms-xrd-global.cern.ch//store/data/Run2018C/SingleMuon/RAW/v1/000/319/337/00000/004ED286-5582-E811-8895-FA163E126126.root
```
before the PR and after the PR the sizes change as follows:
-rw-r--r-- 1 tvami cms 8177333 Nov 24 16:30 ReRECO_RAW2DIGI_L1Reco_RECO_EI_PAT.root
--> 
-rw-r--r-- 1 tvami cms 8185759 Nov 24 16:26 ReRECO_RAW2DIGI_L1Reco_RECO_EI_PAT.root
i.e an 1.00103041 increase in size is expected.

Here is the timing report for before the PR
```
 Time Summary: 
 - Min event:   3.23837
 - Max event:   31.758
 - Avg event:   11.6797
 - Total loop:  238.961
 - Total init:  111.42
 - Total job:   353.645
 - EventSetup Lock:   644.041
 - EventSetup Get:   110.653
 Event Throughput: 0.418479 ev/s
 CPU Summary: 
 - Total loop:  1052.11
 - Total init:  58.428
 - Total extra: 0
 - Total job:   1113.87
 ```

and after the PR
```
 Time Summary: 
 - Min event:   4.21454
 - Max event:   33.0982
 - Avg event:   12.851
 - Total loop:  272.262
 - Total init:  117.273
 - Total job:   392.587
 - EventSetup Lock:   788.184
 - EventSetup Get:   128.934
 Event Throughput: 0.367293 ev/s
 CPU Summary: 
 - Total loop:  1220.08
 - Total init:  64.1806
 - Total extra: 0
 - Total job:   1287.24
 ```

Content was validated on MC Signal samples, and on data as well, please see more plots in [2]

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of https://github.com/cms-sw/cmssw/pull/36247

cc @mmusich 