### PR TITLE
Adding SiPixel on track charge and shape probs to MiniAOD content

### DIFF
--- a/Configuration/ProcessModifiers/python/miniAOD_skip_probQXY_cff.py
+++ b/Configuration/ProcessModifiers/python/miniAOD_skip_probQXY_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+miniAOD_skip_probQXY = cms.Modifier()

--- a/Configuration/ProcessModifiers/python/run2_miniAOD_UL_preWinter22_cff.py
+++ b/Configuration/ProcessModifiers/python/run2_miniAOD_UL_preWinter22_cff.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
+from Configuration.ProcessModifiers.miniAOD_skip_probQXY_cff import miniAOD_skip_probQXY
+
+# This modifier is for additional settings to run miniAOD on top of 
+# ultra-legacy (during LS2) Run-2 AOD produced prior to the Winter22
+# campaign where AOD event content was extended
+
+run2_miniAOD_UL_preWinter22 = cms.ModifierChain(run2_miniAOD_UL, miniAOD_skip_probQXY)

--- a/DataFormats/PatCandidates/interface/IsolatedTrack.h
+++ b/DataFormats/PatCandidates/interface/IsolatedTrack.h
@@ -93,22 +93,10 @@ namespace pat {
           trackQuality_(tkQual),
           dEdxStrip_(dEdxS),
           dEdxPixel_(dEdxP),
-          probQonTrack_(probQonTrack == 0.f        ? 0
-                        : probQonTrack < 1 / 255.f ? 1
-                        : probQonTrack == 1.f      ? 255
-                                                   : 255.f * probQonTrack + 0.5f),
-          probXYonTrack_(probXYonTrack == 0.f        ? 0
-                         : probXYonTrack < 1 / 255.f ? 1
-                         : probXYonTrack == 1.f      ? 255
-                                                     : 255.f * probXYonTrack + 0.5f),
-          probQonTrackNoLayer1_(probQonTrackNoLayer1 == 0.f        ? 0
-                                : probQonTrackNoLayer1 < 1 / 255.f ? 1
-                                : probQonTrackNoLayer1 == 1.f      ? 255
-                                                                   : 255.f * probQonTrackNoLayer1 + 0.5f),
-          probXYonTrackNoLayer1_(probXYonTrackNoLayer1 == 0.f        ? 0
-                                 : probXYonTrackNoLayer1 < 1 / 255.f ? 1
-                                 : probXYonTrackNoLayer1 == 1.f      ? 255
-                                                                     : 255.f * probXYonTrackNoLayer1 + 0.5f),
+          probQonTrack_(probEncapsulation(probQonTrack)),
+          probXYonTrack_(probEncapsulation(probXYonTrack)),
+          probQonTrackNoLayer1_(probEncapsulation(probQonTrackNoLayer1)),
+          probXYonTrackNoLayer1_(probEncapsulation(probXYonTrackNoLayer1)),
           hitPattern_(hp),
           crossedEcalStatus_(ecalst),
           crossedHcalStatus_(hcalst),
@@ -188,6 +176,19 @@ namespace pat {
     PackedCandidateRef packedCandRef_;  // stored only for packedPFCands/lostTracks. NULL for generalTracks
     PackedCandidateRef nearestPFPackedCandRef_;
     PackedCandidateRef nearestLostTrackPackedCandRef_;
+
+  private:
+    static uint8_t probEncapsulation(float prob) {
+       if(prob == 0.f) {
+         return 0;
+       } else if (prob < 1 / 255.f) {
+         return  1;
+       } else if (prob == 1.f) {
+         return 255;
+      } else {
+         return 255.f * prob + 0.5f;
+      }
+    }
   };
 
   typedef std::vector<IsolatedTrack> IsolatedTrackCollection;

--- a/DataFormats/PatCandidates/interface/IsolatedTrack.h
+++ b/DataFormats/PatCandidates/interface/IsolatedTrack.h
@@ -179,14 +179,14 @@ namespace pat {
 
   private:
     static uint8_t probEncapsulation(float prob) {
-       if(prob == 0.f) {
-         return 0;
-       } else if (prob < 1 / 255.f) {
-         return  1;
-       } else if (prob == 1.f) {
-         return 255;
+      if (prob == 0.f) {
+        return 0;
+      } else if (prob < 1 / 255.f) {
+        return 1;
+      } else if (prob == 1.f) {
+        return 255;
       } else {
-         return 255.f * prob + 0.5f;
+        return 255.f * prob + 0.5f;
       }
     }
   };

--- a/DataFormats/PatCandidates/interface/IsolatedTrack.h
+++ b/DataFormats/PatCandidates/interface/IsolatedTrack.h
@@ -36,6 +36,10 @@ namespace pat {
           trackQuality_(0),
           dEdxStrip_(0),
           dEdxPixel_(0),
+          probQonTrack_(0),
+          probXYonTrack_(0),
+          probQonTrackNoL1_(0),
+          probXYonTrackNoL1_(0),
           hitPattern_(reco::HitPattern()),
           crossedEcalStatus_(std::vector<uint16_t>()),
           crossedHcalStatus_(std::vector<uint32_t>()),
@@ -61,6 +65,10 @@ namespace pat {
                            const reco::HitPattern& hp,
                            float dEdxS,
                            float dEdxP,
+                           float probQonTrack,
+                           float probXYonTrack,
+                           float probQonTrackNoL1,
+                           float probXYonTrackNoL1,
                            int fromPV,
                            int tkQual,
                            const std::vector<uint16_t>& ecalst,
@@ -85,6 +93,10 @@ namespace pat {
           trackQuality_(tkQual),
           dEdxStrip_(dEdxS),
           dEdxPixel_(dEdxP),
+          probQonTrack_(probQonTrack),
+          probXYonTrack_(probXYonTrack),
+          probQonTrackNoL1_(probQonTrackNoL1),
+          probXYonTrackNoL1_(probXYonTrackNoL1),
           hitPattern_(hp),
           crossedEcalStatus_(ecalst),
           crossedHcalStatus_(hcalst),
@@ -123,6 +135,10 @@ namespace pat {
 
     float dEdxStrip() const { return dEdxStrip_; }
     float dEdxPixel() const { return dEdxPixel_; }
+    float probQonTrack() const { return probQonTrack_; }
+    float probXYonTrack() const { return probXYonTrack_; }
+    float probQonTrackNoL1() const { return probQonTrackNoL1_; }
+    float probXYonTrackNoL1() const { return probXYonTrackNoL1_; }
 
     //! just the status code part of an EcalChannelStatusCode for all crossed Ecal cells
     const std::vector<uint16_t>& crossedEcalStatus() const { return crossedEcalStatus_; }
@@ -149,6 +165,7 @@ namespace pat {
     int fromPV_;  //only stored for packedPFCandidates
     int trackQuality_;
     float dEdxStrip_, dEdxPixel_;  //in MeV/mm
+    float probQonTrack_, probXYonTrack_, probQonTrackNoL1_, probXYonTrackNoL1_;
 
     reco::HitPattern hitPattern_;
 

--- a/DataFormats/PatCandidates/interface/IsolatedTrack.h
+++ b/DataFormats/PatCandidates/interface/IsolatedTrack.h
@@ -93,10 +93,22 @@ namespace pat {
           trackQuality_(tkQual),
           dEdxStrip_(dEdxS),
           dEdxPixel_(dEdxP),
-          probQonTrack_(probQonTrack),
-          probXYonTrack_(probXYonTrack),
-          probQonTrackNoLayer1_(probQonTrackNoLayer1),
-          probXYonTrackNoLayer1_(probXYonTrackNoLayer1),
+          probQonTrack_(probQonTrack == 0.f        ? 0
+                        : probQonTrack < 1 / 255.f ? 1
+                        : probQonTrack == 1.f      ? 255
+                                                   : 255.f * probQonTrack + 0.5f),
+          probXYonTrack_(probXYonTrack == 0.f        ? 0
+                         : probXYonTrack < 1 / 255.f ? 1
+                         : probXYonTrack == 1.f      ? 255
+                                                     : 255.f * probXYonTrack + 0.5f),
+          probQonTrackNoLayer1_(probQonTrackNoLayer1 == 0.f        ? 0
+                                : probQonTrackNoLayer1 < 1 / 255.f ? 1
+                                : probQonTrackNoLayer1 == 1.f      ? 255
+                                                                   : 255.f * probQonTrackNoLayer1 + 0.5f),
+          probXYonTrackNoLayer1_(probXYonTrackNoLayer1 == 0.f        ? 0
+                                 : probXYonTrackNoLayer1 < 1 / 255.f ? 1
+                                 : probXYonTrackNoLayer1 == 1.f      ? 255
+                                                                     : 255.f * probXYonTrackNoLayer1 + 0.5f),
           hitPattern_(hp),
           crossedEcalStatus_(ecalst),
           crossedHcalStatus_(hcalst),
@@ -135,10 +147,10 @@ namespace pat {
 
     float dEdxStrip() const { return dEdxStrip_; }
     float dEdxPixel() const { return dEdxPixel_; }
-    float probQonTrack() const { return probQonTrack_; }
-    float probXYonTrack() const { return probXYonTrack_; }
-    float probQonTrackNoLayer1() const { return probQonTrackNoLayer1_; }
-    float probXYonTrackNoLayer1() const { return probXYonTrackNoLayer1_; }
+    float probQonTrack() const { return probQonTrack_ / 255.f; }
+    float probXYonTrack() const { return probXYonTrack_ / 255.f; }
+    float probQonTrackNoLayer1() const { return probQonTrackNoLayer1_ / 255.f; }
+    float probXYonTrackNoLayer1() const { return probXYonTrackNoLayer1_ / 255.f; }
 
     //! just the status code part of an EcalChannelStatusCode for all crossed Ecal cells
     const std::vector<uint16_t>& crossedEcalStatus() const { return crossedEcalStatus_; }
@@ -165,7 +177,7 @@ namespace pat {
     int fromPV_;  //only stored for packedPFCandidates
     int trackQuality_;
     float dEdxStrip_, dEdxPixel_;  //in MeV/mm
-    float probQonTrack_, probXYonTrack_, probQonTrackNoLayer1_, probXYonTrackNoLayer1_;
+    uint8_t probQonTrack_, probXYonTrack_, probQonTrackNoLayer1_, probXYonTrackNoLayer1_;
 
     reco::HitPattern hitPattern_;
 

--- a/DataFormats/PatCandidates/interface/IsolatedTrack.h
+++ b/DataFormats/PatCandidates/interface/IsolatedTrack.h
@@ -38,8 +38,8 @@ namespace pat {
           dEdxPixel_(0),
           probQonTrack_(0),
           probXYonTrack_(0),
-          probQonTrackNoL1_(0),
-          probXYonTrackNoL1_(0),
+          probQonTrackNoLayer1_(0),
+          probXYonTrackNoLayer1_(0),
           hitPattern_(reco::HitPattern()),
           crossedEcalStatus_(std::vector<uint16_t>()),
           crossedHcalStatus_(std::vector<uint32_t>()),
@@ -67,8 +67,8 @@ namespace pat {
                            float dEdxP,
                            float probQonTrack,
                            float probXYonTrack,
-                           float probQonTrackNoL1,
-                           float probXYonTrackNoL1,
+                           float probQonTrackNoLayer1,
+                           float probXYonTrackNoLayer1,
                            int fromPV,
                            int tkQual,
                            const std::vector<uint16_t>& ecalst,
@@ -95,8 +95,8 @@ namespace pat {
           dEdxPixel_(dEdxP),
           probQonTrack_(probQonTrack),
           probXYonTrack_(probXYonTrack),
-          probQonTrackNoL1_(probQonTrackNoL1),
-          probXYonTrackNoL1_(probXYonTrackNoL1),
+          probQonTrackNoLayer1_(probQonTrackNoLayer1),
+          probXYonTrackNoLayer1_(probXYonTrackNoLayer1),
           hitPattern_(hp),
           crossedEcalStatus_(ecalst),
           crossedHcalStatus_(hcalst),
@@ -137,8 +137,8 @@ namespace pat {
     float dEdxPixel() const { return dEdxPixel_; }
     float probQonTrack() const { return probQonTrack_; }
     float probXYonTrack() const { return probXYonTrack_; }
-    float probQonTrackNoL1() const { return probQonTrackNoL1_; }
-    float probXYonTrackNoL1() const { return probXYonTrackNoL1_; }
+    float probQonTrackNoLayer1() const { return probQonTrackNoLayer1_; }
+    float probXYonTrackNoLayer1() const { return probXYonTrackNoLayer1_; }
 
     //! just the status code part of an EcalChannelStatusCode for all crossed Ecal cells
     const std::vector<uint16_t>& crossedEcalStatus() const { return crossedEcalStatus_; }
@@ -165,7 +165,7 @@ namespace pat {
     int fromPV_;  //only stored for packedPFCandidates
     int trackQuality_;
     float dEdxStrip_, dEdxPixel_;  //in MeV/mm
-    float probQonTrack_, probXYonTrack_, probQonTrackNoL1_, probXYonTrackNoL1_;
+    float probQonTrack_, probXYonTrack_, probQonTrackNoLayer1_, probXYonTrackNoLayer1_;
 
     reco::HitPattern hitPattern_;
 

--- a/DataFormats/PatCandidates/interface/IsolatedTrack.h
+++ b/DataFormats/PatCandidates/interface/IsolatedTrack.h
@@ -93,10 +93,10 @@ namespace pat {
           trackQuality_(tkQual),
           dEdxStrip_(dEdxS),
           dEdxPixel_(dEdxP),
-          probQonTrack_(255.f * probQonTrack + 0.5f),
-          probXYonTrack_(255.f * probXYonTrack + 0.5f),
-          probQonTrackNoLayer1_(255.f * probQonTrackNoLayer1 + 0.5f),
-          probXYonTrackNoLayer1_(255.f * probXYonTrackNoLayer1 + 0.5f),
+          probQonTrack_(probQonTrack),
+          probXYonTrack_(probXYonTrack),
+          probQonTrackNoLayer1_(probQonTrackNoLayer1),
+          probXYonTrackNoLayer1_(probXYonTrackNoLayer1),
           hitPattern_(hp),
           crossedEcalStatus_(ecalst),
           crossedHcalStatus_(hcalst),
@@ -135,10 +135,10 @@ namespace pat {
 
     float dEdxStrip() const { return dEdxStrip_; }
     float dEdxPixel() const { return dEdxPixel_; }
-    float probQonTrack() const { return probQonTrack_ / 255.f; }
-    float probXYonTrack() const { return probXYonTrack_ / 255.f; }
-    float probQonTrackNoLayer1() const { return probQonTrackNoLayer1_ / 255.f; }
-    float probXYonTrackNoLayer1() const { return probXYonTrackNoLayer1_ / 255.f; }
+    float probQonTrack() const { return probQonTrack_; }
+    float probXYonTrack() const { return probXYonTrack_; }
+    float probQonTrackNoLayer1() const { return probQonTrackNoLayer1_; }
+    float probXYonTrackNoLayer1() const { return probXYonTrackNoLayer1_; }
 
     //! just the status code part of an EcalChannelStatusCode for all crossed Ecal cells
     const std::vector<uint16_t>& crossedEcalStatus() const { return crossedEcalStatus_; }
@@ -165,7 +165,7 @@ namespace pat {
     int fromPV_;  //only stored for packedPFCandidates
     int trackQuality_;
     float dEdxStrip_, dEdxPixel_;  //in MeV/mm
-    uint8_t probQonTrack_, probXYonTrack_, probQonTrackNoLayer1_, probXYonTrackNoLayer1_;
+    float probQonTrack_, probXYonTrack_, probQonTrackNoLayer1_, probXYonTrackNoLayer1_;
 
     reco::HitPattern hitPattern_;
 

--- a/DataFormats/PatCandidates/interface/IsolatedTrack.h
+++ b/DataFormats/PatCandidates/interface/IsolatedTrack.h
@@ -93,10 +93,10 @@ namespace pat {
           trackQuality_(tkQual),
           dEdxStrip_(dEdxS),
           dEdxPixel_(dEdxP),
-          probQonTrack_(probQonTrack),
-          probXYonTrack_(probXYonTrack),
-          probQonTrackNoLayer1_(probQonTrackNoLayer1),
-          probXYonTrackNoLayer1_(probXYonTrackNoLayer1),
+          probQonTrack_(255.f * probQonTrack + 0.5f),
+          probXYonTrack_(255.f * probXYonTrack + 0.5f),
+          probQonTrackNoLayer1_(255.f * probQonTrackNoLayer1 + 0.5f),
+          probXYonTrackNoLayer1_(255.f * probXYonTrackNoLayer1 + 0.5f),
           hitPattern_(hp),
           crossedEcalStatus_(ecalst),
           crossedHcalStatus_(hcalst),
@@ -135,10 +135,10 @@ namespace pat {
 
     float dEdxStrip() const { return dEdxStrip_; }
     float dEdxPixel() const { return dEdxPixel_; }
-    float probQonTrack() const { return probQonTrack_; }
-    float probXYonTrack() const { return probXYonTrack_; }
-    float probQonTrackNoLayer1() const { return probQonTrackNoLayer1_; }
-    float probXYonTrackNoLayer1() const { return probXYonTrackNoLayer1_; }
+    float probQonTrack() const { return probQonTrack_ / 255.f; }
+    float probXYonTrack() const { return probXYonTrack_ / 255.f; }
+    float probQonTrackNoLayer1() const { return probQonTrackNoLayer1_ / 255.f; }
+    float probXYonTrackNoLayer1() const { return probXYonTrackNoLayer1_ / 255.f; }
 
     //! just the status code part of an EcalChannelStatusCode for all crossed Ecal cells
     const std::vector<uint16_t>& crossedEcalStatus() const { return crossedEcalStatus_; }
@@ -165,7 +165,7 @@ namespace pat {
     int fromPV_;  //only stored for packedPFCandidates
     int trackQuality_;
     float dEdxStrip_, dEdxPixel_;  //in MeV/mm
-    float probQonTrack_, probXYonTrack_, probQonTrackNoLayer1_, probXYonTrackNoLayer1_;
+    uint8_t probQonTrack_, probXYonTrack_, probQonTrackNoLayer1_, probXYonTrackNoLayer1_;
 
     reco::HitPattern hitPattern_;
 

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -121,7 +121,8 @@
    <version ClassVersion="10" checksum="2244564938"/>
   </class>
 
-  <class name="pat::IsolatedTrack" ClassVersion="6">
+  <class name="pat::IsolatedTrack" ClassVersion="7">
+   <version ClassVersion="7" checksum="949138470"/>
    <version ClassVersion="6" checksum="3479592402"/>
    <version ClassVersion="5" checksum="139818330"/>
    <version ClassVersion="4" checksum="71166093"/>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -122,7 +122,7 @@
   </class>
 
   <class name="pat::IsolatedTrack" ClassVersion="6">
-   <version ClassVersion="6" checksum="949138470"/>
+   <version ClassVersion="6" checksum="701085142"/>
    <version ClassVersion="5" checksum="139818330"/>
    <version ClassVersion="4" checksum="71166093"/>
    <version ClassVersion="3" checksum="550880582"/>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -121,9 +121,8 @@
    <version ClassVersion="10" checksum="2244564938"/>
   </class>
 
-  <class name="pat::IsolatedTrack" ClassVersion="7">
-   <version ClassVersion="7" checksum="949138470"/>
-   <version ClassVersion="6" checksum="3479592402"/>
+  <class name="pat::IsolatedTrack" ClassVersion="6">
+   <version ClassVersion="6" checksum="949138470"/>
    <version ClassVersion="5" checksum="139818330"/>
    <version ClassVersion="4" checksum="71166093"/>
    <version ClassVersion="3" checksum="550880582"/>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -121,7 +121,8 @@
    <version ClassVersion="10" checksum="2244564938"/>
   </class>
 
-  <class name="pat::IsolatedTrack" ClassVersion="5">
+  <class name="pat::IsolatedTrack" ClassVersion="6">
+   <version ClassVersion="6" checksum="3479592402"/>
    <version ClassVersion="5" checksum="139818330"/>
    <version ClassVersion="4" checksum="71166093"/>
    <version ClassVersion="3" checksum="550880582"/>

--- a/DataFormats/TrackReco/interface/SiPixelTrackProbQXY.h
+++ b/DataFormats/TrackReco/interface/SiPixelTrackProbQXY.h
@@ -1,5 +1,5 @@
-#ifndef SiPixelTrackProbQXY_H
-#define SiPixelTrackProbQXY_H
+#ifndef DataFormats_TrackReco_SiPixelTrackProbQXY_H
+#define DataFormats_TrackReco_SiPixelTrackProbQXY_H
 
 #include <cstdint>
 #include <vector>
@@ -11,7 +11,7 @@ namespace reco {
   // Class defining the combined charge and shape probabilities for tracks that go through the SiPixel detector
   class SiPixelTrackProbQXY {
   public:
-    SiPixelTrackProbQXY() {}
+    SiPixelTrackProbQXY() = default;
 
     SiPixelTrackProbQXY(float probQonTrack, float probXYonTrack, float probQonTrackNoLayer1, float probXYonTrackNoLayer1)
         : probQonTrack_(probQonTrack),
@@ -19,25 +19,25 @@ namespace reco {
           probQonTrackNoLayer1_(probQonTrackNoLayer1),
           probXYonTrackNoLayer1_(probXYonTrackNoLayer1) {}
 
-    // Return the combined charge probabilities for tracks that go through the SiPixel detector
-    float probQonTrack() const { return probQonTrack_; }
+    //! Return the combined charge probabilities for tracks that go through the SiPixel detector
+    float probQ() const { return probQonTrack_; }
 
-    // Return the combined shape probabilities for tracks that go through the SiPixel detector
-    float probXYonTrack() const { return probXYonTrack_; }
+    //! Return the combined shape probabilities for tracks that go through the SiPixel detector
+    float probXY() const { return probXYonTrack_; }
 
-    // Return the combined charge probabilities for tracks that go through the SiPixel detector
-    // This version now excludes layer 1 which was known to be noisy for 2017/2018
-    float probQonTrackNoLayer1() const { return probQonTrackNoLayer1_; }
+    //! Return the combined charge probabilities for tracks that go through the SiPixel detector
+    //! This version now excludes layer 1 which was known to be noisy for 2017/2018
+    float probQNoLayer1() const { return probQonTrackNoLayer1_; }
 
-    // Return the combined shape probabilities for tracks that go through the SiPixel detector
-    // This version now excludes layer 1 which was known to be noisy for 2017/2018
-    float probXYonTrackNoLayer1() const { return probXYonTrackNoLayer1_; }
+    //! Return the combined shape probabilities for tracks that go through the SiPixel detector
+    //! This version now excludes layer 1 which was known to be noisy for 2017/2018
+    float probXYNoLayer1() const { return probXYonTrackNoLayer1_; }
 
   private:
-    float probQonTrack_;
-    float probXYonTrack_;
-    float probQonTrackNoLayer1_;
-    float probXYonTrackNoLayer1_;
+    float probQonTrack_ = 0;
+    float probXYonTrack_ = 0;
+    float probQonTrackNoLayer1_ = 0;
+    float probXYonTrackNoLayer1_ = 0;
   };
 
   typedef std::vector<SiPixelTrackProbQXY> SiPixelTrackProbQXYCollection;

--- a/DataFormats/TrackReco/interface/SiPixelTrackProbQXY.h
+++ b/DataFormats/TrackReco/interface/SiPixelTrackProbQXY.h
@@ -1,0 +1,50 @@
+#ifndef SiPixelTrackProbQXY_H
+#define SiPixelTrackProbQXY_H
+
+#include <cstdint>
+#include <vector>
+
+#include "DataFormats/Common/interface/Association.h"
+#include "DataFormats/Common/interface/RefVector.h"
+
+namespace reco {
+  // Class defining the combined charge and shape probabilities for tracks that go through the SiPixel detector
+  class SiPixelTrackProbQXY {
+  public:
+    SiPixelTrackProbQXY() {}
+
+    SiPixelTrackProbQXY(float probQonTrack, float probXYonTrack, float probQonTrackNoL1, float probXYonTrackNoL1)
+        : probQonTrack_(probQonTrack),
+          probXYonTrack_(probXYonTrack),
+          probQonTrackNoL1_(probQonTrackNoL1),
+          probXYonTrackNoL1_(probXYonTrackNoL1) {}
+
+    // Return the combined charge probabilities for tracks that go through the SiPixel detector
+    float probQonTrack() const { return probQonTrack_; }
+
+    // Return the combined shape probabilities for tracks that go through the SiPixel detector
+    float probXYonTrack() const { return probXYonTrack_; }
+
+    // Return the combined charge probabilities for tracks that go through the SiPixel detector
+    // This version now excludes layer 1 which was known to be noisy for 2017/2018
+    float probQonTrackNoL1() const { return probQonTrackNoL1_; }
+
+    // Return the combined shape probabilities for tracks that go through the SiPixel detector
+    // This version now excludes layer 1 which was known to be noisy for 2017/2018
+    float probXYonTrackNoL1() const { return probXYonTrackNoL1_; }
+
+  private:
+    float probQonTrack_;
+    float probXYonTrack_;
+    float probQonTrackNoL1_;
+    float probXYonTrackNoL1_;
+  };
+
+  typedef std::vector<SiPixelTrackProbQXY> SiPixelTrackProbQXYCollection;
+  typedef edm::Ref<SiPixelTrackProbQXYCollection> SiPixelTrackProbQXYRef;
+  typedef edm::RefProd<SiPixelTrackProbQXYCollection> SiPixelTrackProbQXYRefProd;
+  typedef edm::RefVector<SiPixelTrackProbQXYCollection> SiPixelTrackProbQXYRefVector;
+  typedef edm::Association<SiPixelTrackProbQXYCollection> SiPixelTrackProbQXYAssociation;
+
+}  // namespace reco
+#endif

--- a/DataFormats/TrackReco/interface/SiPixelTrackProbQXY.h
+++ b/DataFormats/TrackReco/interface/SiPixelTrackProbQXY.h
@@ -13,11 +13,11 @@ namespace reco {
   public:
     SiPixelTrackProbQXY() {}
 
-    SiPixelTrackProbQXY(float probQonTrack, float probXYonTrack, float probQonTrackNoL1, float probXYonTrackNoL1)
+    SiPixelTrackProbQXY(float probQonTrack, float probXYonTrack, float probQonTrackNoLayer1, float probXYonTrackNoLayer1)
         : probQonTrack_(probQonTrack),
           probXYonTrack_(probXYonTrack),
-          probQonTrackNoL1_(probQonTrackNoL1),
-          probXYonTrackNoL1_(probXYonTrackNoL1) {}
+          probQonTrackNoLayer1_(probQonTrackNoLayer1),
+          probXYonTrackNoLayer1_(probXYonTrackNoLayer1) {}
 
     // Return the combined charge probabilities for tracks that go through the SiPixel detector
     float probQonTrack() const { return probQonTrack_; }
@@ -27,17 +27,17 @@ namespace reco {
 
     // Return the combined charge probabilities for tracks that go through the SiPixel detector
     // This version now excludes layer 1 which was known to be noisy for 2017/2018
-    float probQonTrackNoL1() const { return probQonTrackNoL1_; }
+    float probQonTrackNoLayer1() const { return probQonTrackNoLayer1_; }
 
     // Return the combined shape probabilities for tracks that go through the SiPixel detector
     // This version now excludes layer 1 which was known to be noisy for 2017/2018
-    float probXYonTrackNoL1() const { return probXYonTrackNoL1_; }
+    float probXYonTrackNoLayer1() const { return probXYonTrackNoLayer1_; }
 
   private:
     float probQonTrack_;
     float probXYonTrack_;
-    float probQonTrackNoL1_;
-    float probXYonTrackNoL1_;
+    float probQonTrackNoLayer1_;
+    float probXYonTrackNoLayer1_;
   };
 
   typedef std::vector<SiPixelTrackProbQXY> SiPixelTrackProbQXYCollection;

--- a/DataFormats/TrackReco/interface/SiPixelTrackProbQXY.h
+++ b/DataFormats/TrackReco/interface/SiPixelTrackProbQXY.h
@@ -4,8 +4,8 @@
 #include <cstdint>
 #include <vector>
 
-#include "DataFormats/Common/interface/Association.h"
 #include "DataFormats/Common/interface/RefVector.h"
+#include "DataFormats/Common/interface/ValueMap.h"
 
 namespace reco {
   // Class defining the combined charge and shape probabilities for tracks that go through the SiPixel detector
@@ -13,11 +13,8 @@ namespace reco {
   public:
     SiPixelTrackProbQXY() = default;
 
-    SiPixelTrackProbQXY(float probQonTrack, float probXYonTrack, float probQonTrackNoLayer1, float probXYonTrackNoLayer1)
-        : probQonTrack_(probQonTrack),
-          probXYonTrack_(probXYonTrack),
-          probQonTrackNoLayer1_(probQonTrackNoLayer1),
-          probXYonTrackNoLayer1_(probXYonTrackNoLayer1) {}
+    SiPixelTrackProbQXY(float probQonTrack, float probXYonTrack)
+        : probQonTrack_(probQonTrack), probXYonTrack_(probXYonTrack) {}
 
     //! Return the combined charge probabilities for tracks that go through the SiPixel detector
     float probQ() const { return probQonTrack_; }
@@ -25,26 +22,16 @@ namespace reco {
     //! Return the combined shape probabilities for tracks that go through the SiPixel detector
     float probXY() const { return probXYonTrack_; }
 
-    //! Return the combined charge probabilities for tracks that go through the SiPixel detector
-    //! This version now excludes layer 1 which was known to be noisy for 2017/2018
-    float probQNoLayer1() const { return probQonTrackNoLayer1_; }
-
-    //! Return the combined shape probabilities for tracks that go through the SiPixel detector
-    //! This version now excludes layer 1 which was known to be noisy for 2017/2018
-    float probXYNoLayer1() const { return probXYonTrackNoLayer1_; }
-
   private:
     float probQonTrack_ = 0;
     float probXYonTrack_ = 0;
-    float probQonTrackNoLayer1_ = 0;
-    float probXYonTrackNoLayer1_ = 0;
   };
 
   typedef std::vector<SiPixelTrackProbQXY> SiPixelTrackProbQXYCollection;
+  typedef edm::ValueMap<SiPixelTrackProbQXY> SiPixelTrackProbQXYValueMap;
   typedef edm::Ref<SiPixelTrackProbQXYCollection> SiPixelTrackProbQXYRef;
   typedef edm::RefProd<SiPixelTrackProbQXYCollection> SiPixelTrackProbQXYRefProd;
   typedef edm::RefVector<SiPixelTrackProbQXYCollection> SiPixelTrackProbQXYRefVector;
-  typedef edm::Association<SiPixelTrackProbQXYCollection> SiPixelTrackProbQXYAssociation;
 
 }  // namespace reco
 #endif

--- a/DataFormats/TrackReco/src/classes.h
+++ b/DataFormats/TrackReco/src/classes.h
@@ -22,6 +22,7 @@
 #include "DataFormats/TrackReco/interface/DeDxHit.h"
 #include "DataFormats/TrackReco/interface/TrackDeDxHits.h"
 #include "DataFormats/TrackReco/interface/DeDxData.h"
+#include "DataFormats/TrackReco/interface/SiPixelTrackProbQXY.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/OneToManyWithQuality.h"
 #include "DataFormats/Common/interface/OneToManyWithQualityGeneric.h"

--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -508,14 +508,15 @@
    <class name="edm::Wrapper<reco::DeDxHitInfoAss>"/>
 
    <class name="reco::SiPixelTrackProbQXY"/>
+   <class name="reco::SiPixelTrackProbQXYValueMap"/>
    <class name="reco::SiPixelTrackProbQXYCollection"/>
    <class name="reco::SiPixelTrackProbQXYRef"/>
    <class name="reco::SiPixelTrackProbQXYRefProd"/>
    <class name="reco::SiPixelTrackProbQXYRefVector"/>
-   <class name="reco::SiPixelTrackProbQXYAssociation"/>
+   <class name="edm::ValueMap<reco::SiPixelTrackProbQXY>"/>
    <class name="edm::Wrapper<reco::SiPixelTrackProbQXY>"/>
+   <class name="edm::Wrapper<edm::ValueMap<reco::SiPixelTrackProbQXY> >"/>
    <class name="edm::Wrapper<reco::SiPixelTrackProbQXYCollection>"/>
-   <class name="edm::Wrapper<reco::SiPixelTrackProbQXYAssociation>"/>
 
 
    <class name="SeedStopInfo" persistent="false"/>

--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -507,6 +507,17 @@
    <class name="edm::Wrapper<reco::DeDxHitInfoCollection>"/>
    <class name="edm::Wrapper<reco::DeDxHitInfoAss>"/>
 
+   <class name="reco::SiPixelTrackProbQXY"/>
+   <class name="reco::SiPixelTrackProbQXYCollection"/>
+   <class name="reco::SiPixelTrackProbQXYRef"/>
+   <class name="reco::SiPixelTrackProbQXYRefProd"/>
+   <class name="reco::SiPixelTrackProbQXYRefVector"/>
+   <class name="reco::SiPixelTrackProbQXYAssociation"/>
+   <class name="edm::Wrapper<reco::SiPixelTrackProbQXY>"/>
+   <class name="edm::Wrapper<reco::SiPixelTrackProbQXYCollection>"/>
+   <class name="edm::Wrapper<reco::SiPixelTrackProbQXYAssociation>"/>
+
+
    <class name="SeedStopInfo" persistent="false"/>
    <class name="std::vector<SeedStopInfo>" persistent="false"/>
    <class name="edm::Wrapper<std::vector<SeedStopInfo> >" persistent="false"/>

--- a/PhysicsTools/PatAlgos/plugins/PATIsolatedTrackProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATIsolatedTrackProducer.cc
@@ -234,8 +234,7 @@ void pat::PATIsolatedTrackProducer::produce(edm::Event& iEvent, const edm::Event
   }
 
   // associate generalTracks with their combined ProbQ and ProbXY
-  edm::Handle<reco::SiPixelTrackProbQXYAssociation> gt2siPixelTrackProbQXY;
-  iEvent.getByToken(gt2siPixelTrackProbQXY_, gt2siPixelTrackProbQXY);
+  auto gt2siPixelTrackProbQXY = iEvent.getHandle(gt2siPixelTrackProbQXY_);
 
   const HcalChannelQuality* hcalQ = &iSetup.getData(hcalQToken_);
 
@@ -384,12 +383,12 @@ void pat::PATIsolatedTrackProducer::produce(edm::Event& iEvent, const edm::Event
 
     // get combined probQ and probXY
     float probQonTrack = 0, probXYonTrack = 0, probQonTrackNoLayer1 = 0, probXYonTrackNoLayer1 = 0;
-    if (gt2siPixelTrackProbQXY.isValid() && gt2siPixelTrackProbQXY->contains(tkref.id())) {
+    if (gt2siPixelTrackProbQXY_.isUninitialized() && gt2siPixelTrackProbQXY->contains(tkref.id())) {
       const reco::SiPixelTrackProbQXY* siPixelTrackProbQXY = (*gt2siPixelTrackProbQXY)[tkref].get();
-      probQonTrack = siPixelTrackProbQXY->probQonTrack();
-      probXYonTrack = siPixelTrackProbQXY->probXYonTrack();
-      probQonTrackNoLayer1 = siPixelTrackProbQXY->probQonTrackNoLayer1();
-      probXYonTrackNoLayer1 = siPixelTrackProbQXY->probXYonTrackNoLayer1();
+      probQonTrack = siPixelTrackProbQXY->probQ();
+      probXYonTrack = siPixelTrackProbQXY->probXY();
+      probQonTrackNoLayer1 = siPixelTrackProbQXY->probQNoLayer1();
+      probXYonTrackNoLayer1 = siPixelTrackProbQXY->probXYNoLayer1();
     }
 
     // get the associated ecal/hcal detectors

--- a/PhysicsTools/PatAlgos/plugins/PATIsolatedTrackProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATIsolatedTrackProducer.cc
@@ -383,13 +383,13 @@ void pat::PATIsolatedTrackProducer::produce(edm::Event& iEvent, const edm::Event
     int trackQuality = gentk.qualityMask();
 
     // get combined probQ and probXY
-    float probQonTrack = 0, probXYonTrack = 0, probQonTrackNoL1 = 0, probXYonTrackNoL1 = 0;
+    float probQonTrack = 0, probXYonTrack = 0, probQonTrackNoLayer1 = 0, probXYonTrackNoLayer1 = 0;
     if (gt2siPixelTrackProbQXY.isValid() && gt2siPixelTrackProbQXY->contains(tkref.id())) {
       const reco::SiPixelTrackProbQXY* siPixelTrackProbQXY = (*gt2siPixelTrackProbQXY)[tkref].get();
       probQonTrack = siPixelTrackProbQXY->probQonTrack();
       probXYonTrack = siPixelTrackProbQXY->probXYonTrack();
-      probQonTrackNoL1 = siPixelTrackProbQXY->probQonTrackNoL1();
-      probXYonTrackNoL1 = siPixelTrackProbQXY->probXYonTrackNoL1();
+      probQonTrackNoLayer1 = siPixelTrackProbQXY->probQonTrackNoLayer1();
+      probXYonTrackNoLayer1 = siPixelTrackProbQXY->probXYonTrackNoLayer1();
     }
 
     // get the associated ecal/hcal detectors
@@ -434,8 +434,8 @@ void pat::PATIsolatedTrackProducer::produce(edm::Event& iEvent, const edm::Event
                                           dEdxPixel,
                                           probQonTrack,
                                           probXYonTrack,
-                                          probQonTrackNoL1,
-                                          probXYonTrackNoL1,
+                                          probQonTrackNoLayer1,
+                                          probXYonTrackNoLayer1,
                                           fromPV,
                                           trackQuality,
                                           crossedEcalStatus,
@@ -528,7 +528,7 @@ void pat::PATIsolatedTrackProducer::produce(edm::Event& iEvent, const edm::Event
     // fill with default values
     reco::HitPattern hp;
     float dEdxPixel = -1, dEdxStrip = -1;
-    float probQonTrack = 0, probXYonTrack = 0, probQonTrackNoL1 = 0, probXYonTrackNoL1 = 0;
+    float probQonTrack = 0, probXYonTrack = 0, probQonTrackNoLayer1 = 0, probXYonTrackNoLayer1 = 0;
     int trackQuality = 0;
     std::vector<uint16_t> ecalStatus;
     std::vector<uint32_t> hcalStatus;
@@ -553,8 +553,8 @@ void pat::PATIsolatedTrackProducer::produce(edm::Event& iEvent, const edm::Event
                                           dEdxPixel,
                                           probQonTrack,
                                           probXYonTrack,
-                                          probQonTrackNoL1,
-                                          probXYonTrackNoL1,
+                                          probQonTrackNoLayer1,
+                                          probXYonTrackNoLayer1,
                                           fromPV,
                                           trackQuality,
                                           ecalStatus,

--- a/PhysicsTools/PatAlgos/python/slimming/isolatedTracks_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/isolatedTracks_cfi.py
@@ -39,6 +39,7 @@ isolatedTracks = cms.EDProducer("PATIsolatedTrackProducer",
     usePrecomputedDeDxStrip = cms.bool(True),        # if these are set to True, will get estimated DeDx from DeDxData branches
     usePrecomputedDeDxPixel = cms.bool(True),        # if set to False, will manually compute using dEdxHitInfo
     siPixelTrackProbQXY = cms.InputTag("siPixelTrackProbQXY"),
+    siPixelTrackProbQXYNoLayer1 = cms.InputTag("siPixelTrackProbQXY","NoLayer1"),
     pT_cut = cms.double(5.0),         # save tracks above this pt
     pT_cut_noIso = cms.double(20.0),  # for tracks with at least this pT, don't apply any iso cut
     pfIsolation_DR = cms.double(0.3),

--- a/PhysicsTools/PatAlgos/python/slimming/isolatedTracks_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/isolatedTracks_cfi.py
@@ -38,6 +38,7 @@ isolatedTracks = cms.EDProducer("PATIsolatedTrackProducer",
     addPrescaledDeDxTracks = cms.bool(False),
     usePrecomputedDeDxStrip = cms.bool(True),        # if these are set to True, will get estimated DeDx from DeDxData branches
     usePrecomputedDeDxPixel = cms.bool(True),        # if set to False, will manually compute using dEdxHitInfo
+    siPixelTrackProbQXY = cms.InputTag("siPixelTrackProbQXY"),
     pT_cut = cms.double(5.0),         # save tracks above this pt
     pT_cut_noIso = cms.double(20.0),  # for tracks with at least this pT, don't apply any iso cut
     pfIsolation_DR = cms.double(0.3),

--- a/PhysicsTools/PatAlgos/python/slimming/isolatedTracks_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/isolatedTracks_cfi.py
@@ -38,6 +38,7 @@ isolatedTracks = cms.EDProducer("PATIsolatedTrackProducer",
     addPrescaledDeDxTracks = cms.bool(False),
     usePrecomputedDeDxStrip = cms.bool(True),        # if these are set to True, will get estimated DeDx from DeDxData branches
     usePrecomputedDeDxPixel = cms.bool(True),        # if set to False, will manually compute using dEdxHitInfo
+    useSiPixelTrackProbQXY = cms.bool(True),         # Set to false if siPixelTrackProbQXY is not available (older AODs)
     siPixelTrackProbQXY = cms.InputTag("siPixelTrackProbQXY"),
     siPixelTrackProbQXYNoLayer1 = cms.InputTag("siPixelTrackProbQXY","NoLayer1"),
     pT_cut = cms.double(5.0),         # save tracks above this pt
@@ -69,7 +70,16 @@ isolatedTracks = cms.EDProducer("PATIsolatedTrackProducer",
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 pp_on_AA.toModify(isolatedTracks, useHighPurity = True)
 
+# full set of track extras not available in existing AOD
+from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
+from Configuration.Eras.Modifier_run2_miniAOD_94XFall17_cff import run2_miniAOD_94XFall17
+from Configuration.ProcessModifiers.run2_miniAOD_UL_preSummer20_cff import run2_miniAOD_UL_preSummer20
+from Configuration.ProcessModifiers.run2_miniAOD_pp_on_AA_103X_cff import run2_miniAOD_pp_on_AA_103X
+
+(run2_miniAOD_80XLegacy | run2_miniAOD_94XFall17 | run2_miniAOD_UL_preSummer20 | run2_miniAOD_pp_on_AA_103X).toModify(isolatedTracks, useSiPixelTrackProbQXY = False)
+
 def miniAOD_customizeIsolatedTracksFastSim(process):
     """Switch off dE/dx hit info on fast sim, as it's not available"""
     process.isolatedTracks.saveDeDxHitInfo = False
+    process.isolatedTracks.useSiPixelTrackProbQXY = False
     return process

--- a/PhysicsTools/PatAlgos/python/slimming/isolatedTracks_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/isolatedTracks_cfi.py
@@ -74,10 +74,9 @@ pp_on_AA.toModify(isolatedTracks, useHighPurity = True)
 from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
 from Configuration.Eras.Modifier_run2_miniAOD_94XFall17_cff import run2_miniAOD_94XFall17
 from Configuration.ProcessModifiers.run2_miniAOD_UL_preSummer20_cff import run2_miniAOD_UL_preSummer20
-from Configuration.ProcessModifiers.run2_miniAOD_UL_preWinter22_cff import run2_miniAOD_UL_preWinter22
 from Configuration.ProcessModifiers.run2_miniAOD_pp_on_AA_103X_cff import run2_miniAOD_pp_on_AA_103X
 
-(run2_miniAOD_80XLegacy | run2_miniAOD_94XFall17 | run2_miniAOD_UL_preSummer20 | run2_miniAOD_UL_preWinter22 
+(run2_miniAOD_80XLegacy | run2_miniAOD_94XFall17 | run2_miniAOD_UL_preSummer20  
 | run2_miniAOD_pp_on_AA_103X).toModify(isolatedTracks, useSiPixelTrackProbQXY = False)
 
 def miniAOD_customizeIsolatedTracksFastSim(process):

--- a/PhysicsTools/PatAlgos/python/slimming/isolatedTracks_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/isolatedTracks_cfi.py
@@ -74,9 +74,11 @@ pp_on_AA.toModify(isolatedTracks, useHighPurity = True)
 from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
 from Configuration.Eras.Modifier_run2_miniAOD_94XFall17_cff import run2_miniAOD_94XFall17
 from Configuration.ProcessModifiers.run2_miniAOD_UL_preSummer20_cff import run2_miniAOD_UL_preSummer20
+from Configuration.ProcessModifiers.run2_miniAOD_UL_preWinter22_cff import run2_miniAOD_UL_preWinter22
 from Configuration.ProcessModifiers.run2_miniAOD_pp_on_AA_103X_cff import run2_miniAOD_pp_on_AA_103X
 
-(run2_miniAOD_80XLegacy | run2_miniAOD_94XFall17 | run2_miniAOD_UL_preSummer20 | run2_miniAOD_pp_on_AA_103X).toModify(isolatedTracks, useSiPixelTrackProbQXY = False)
+(run2_miniAOD_80XLegacy | run2_miniAOD_94XFall17 | run2_miniAOD_UL_preSummer20 | run2_miniAOD_UL_preWinter22 
+| run2_miniAOD_pp_on_AA_103X).toModify(isolatedTracks, useSiPixelTrackProbQXY = False)
 
 def miniAOD_customizeIsolatedTracksFastSim(process):
     """Switch off dE/dx hit info on fast sim, as it's not available"""

--- a/PhysicsTools/PatAlgos/python/slimming/isolatedTracks_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/isolatedTracks_cfi.py
@@ -74,9 +74,10 @@ pp_on_AA.toModify(isolatedTracks, useHighPurity = True)
 from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
 from Configuration.Eras.Modifier_run2_miniAOD_94XFall17_cff import run2_miniAOD_94XFall17
 from Configuration.ProcessModifiers.run2_miniAOD_UL_preSummer20_cff import run2_miniAOD_UL_preSummer20
+from Configuration.ProcessModifiers.run2_miniAOD_UL_preWinter22_cff import run2_miniAOD_UL_preWinter22
 from Configuration.ProcessModifiers.run2_miniAOD_pp_on_AA_103X_cff import run2_miniAOD_pp_on_AA_103X
 
-(run2_miniAOD_80XLegacy | run2_miniAOD_94XFall17 | run2_miniAOD_UL_preSummer20  
+(run2_miniAOD_80XLegacy | run2_miniAOD_94XFall17 | run2_miniAOD_UL_preSummer20 | run2_miniAOD_UL_preWinter22 
 | run2_miniAOD_pp_on_AA_103X).toModify(isolatedTracks, useSiPixelTrackProbQXY = False)
 
 def miniAOD_customizeIsolatedTracksFastSim(process):

--- a/RecoTracker/Configuration/python/RecoTracker_EventContent_cff.py
+++ b/RecoTracker/Configuration/python/RecoTracker_EventContent_cff.py
@@ -35,7 +35,7 @@ RecoTrackerRECO = cms.PSet(
         'keep recoTrackExtras_conversionStepTracks_*_*', 
         'keep TrackingRecHitsOwned_conversionStepTracks_*_*',
         'keep *_ctfPixelLess_*_*', 
-        'keep *_dedxTruncated40_*_*',
+        'keep *_dedxTruncated40_*_*'
     )
 )
 RecoTrackerRECO.outputCommands.extend(RecoTrackerAOD.outputCommands)

--- a/RecoTracker/Configuration/python/RecoTracker_EventContent_cff.py
+++ b/RecoTracker/Configuration/python/RecoTracker_EventContent_cff.py
@@ -36,7 +36,6 @@ RecoTrackerRECO = cms.PSet(
         'keep TrackingRecHitsOwned_conversionStepTracks_*_*',
         'keep *_ctfPixelLess_*_*', 
         'keep *_dedxTruncated40_*_*',
-        'keep *_siPixelTrackProbQXY_*_*'
     )
 )
 RecoTrackerRECO.outputCommands.extend(RecoTrackerAOD.outputCommands)

--- a/RecoTracker/Configuration/python/RecoTracker_EventContent_cff.py
+++ b/RecoTracker/Configuration/python/RecoTracker_EventContent_cff.py
@@ -12,6 +12,7 @@ RecoTrackerAOD = cms.PSet(
         'keep *_dedxHarmonic2_*_*',
         'keep *_dedxPixelHarmonic2_*_*',
         'keep *_dedxHitInfo_*_*',
+        'keep *_siPixelTrackProbQXY_*_*',
         'keep *_trackExtrapolator_*_*',
         'keep *_generalTracks_MVAValues_*',
         'keep *_generalTracks_MVAVals_*'
@@ -34,7 +35,8 @@ RecoTrackerRECO = cms.PSet(
         'keep recoTrackExtras_conversionStepTracks_*_*', 
         'keep TrackingRecHitsOwned_conversionStepTracks_*_*',
         'keep *_ctfPixelLess_*_*', 
-        'keep *_dedxTruncated40_*_*'
+        'keep *_dedxTruncated40_*_*',
+        'keep *_siPixelTrackProbQXY_*_*'
     )
 )
 RecoTrackerRECO.outputCommands.extend(RecoTrackerAOD.outputCommands)

--- a/RecoTracker/Configuration/python/RecoTracker_cff.py
+++ b/RecoTracker/Configuration/python/RecoTracker_cff.py
@@ -21,13 +21,15 @@ from RecoTracker.Configuration.RecoTrackerNotStandard_cff import *
 
 ckftracks_woBHTask = cms.Task(iterTrackingTask,
                               electronSeedsSeqTask,
-                              doAlldEdXEstimatorsTask)
-ckftracks_woBH = cms.Sequence(ckftracks_woBHTask*doSiPixelTrackProbQXY)
+                              doAlldEdXEstimatorsTask,
+                              doSiPixelTrackProbQXYTask
+                             )
+ckftracks_woBH = cms.Sequence(ckftracks_woBHTask)
 ckftracksTask = ckftracks_woBHTask.copy() #+ beamhaloTracksSeq) # temporarily out, takes too much resources
 ckftracks = cms.Sequence(ckftracksTask) 
 
 ckftracks_wodEdXTask = ckftracksTask.copy()
-ckftracks_wodEdXTask.remove(doAlldEdXEstimatorsTask*doSiPixelTrackProbQXY)
+ckftracks_wodEdXTask.remove(doAlldEdXEstimatorsTask)
 ckftracks_wodEdX = cms.Sequence(ckftracks_wodEdXTask)
 
 ckftracks_plus_pixellessTask = cms.Task(ckftracksTask, ctfTracksPixelLessTask)

--- a/RecoTracker/Configuration/python/RecoTracker_cff.py
+++ b/RecoTracker/Configuration/python/RecoTracker_cff.py
@@ -10,6 +10,7 @@ import copy
 
 #dEdX reconstruction
 from RecoTracker.DeDx.dedxEstimators_cff import *
+from RecoTracker.DeDx.siPixelTrackProbQXYProducer_cff import *
 
 #BeamHalo tracking
 from RecoTracker.Configuration.RecoTrackerBHM_cff import *
@@ -21,12 +22,12 @@ from RecoTracker.Configuration.RecoTrackerNotStandard_cff import *
 ckftracks_woBHTask = cms.Task(iterTrackingTask,
                               electronSeedsSeqTask,
                               doAlldEdXEstimatorsTask)
-ckftracks_woBH = cms.Sequence(ckftracks_woBHTask)
+ckftracks_woBH = cms.Sequence(ckftracks_woBHTask*doSiPixelTrackProbQXY)
 ckftracksTask = ckftracks_woBHTask.copy() #+ beamhaloTracksSeq) # temporarily out, takes too much resources
 ckftracks = cms.Sequence(ckftracksTask) 
 
 ckftracks_wodEdXTask = ckftracksTask.copy()
-ckftracks_wodEdXTask.remove(doAlldEdXEstimatorsTask)
+ckftracks_wodEdXTask.remove(doAlldEdXEstimatorsTask*doSiPixelTrackProbQXY)
 ckftracks_wodEdX = cms.Sequence(ckftracks_wodEdXTask)
 
 ckftracks_plus_pixellessTask = cms.Task(ckftracksTask, ctfTracksPixelLessTask)

--- a/RecoTracker/Configuration/python/RecoTracker_cff.py
+++ b/RecoTracker/Configuration/python/RecoTracker_cff.py
@@ -22,7 +22,7 @@ from RecoTracker.Configuration.RecoTrackerNotStandard_cff import *
 ckftracks_woBHTask = cms.Task(iterTrackingTask,
                               electronSeedsSeqTask,
                               doAlldEdXEstimatorsTask,
-                              doSiPixelTrackProbQXYTask
+                              siPixelTrackProbQXY
                              )
 ckftracks_woBH = cms.Sequence(ckftracks_woBHTask)
 ckftracksTask = ckftracks_woBHTask.copy() #+ beamhaloTracksSeq) # temporarily out, takes too much resources

--- a/RecoTracker/DeDx/plugins/SiPixelTrackProbQXYProducer.cc
+++ b/RecoTracker/DeDx/plugins/SiPixelTrackProbQXYProducer.cc
@@ -102,12 +102,10 @@ void SiPixelTrackProbQXYProducer::produce(edm::StreamID id, edm::Event& iEvent, 
 
       // Have a separate variable that excludes Layer 1
       // Layer 1 was very noisy in 2017/2018
-      float probQNoLayer1 = 0;
-      float probXYNoLayer1 = 0;
       if (pixhit->geographicalId().subdetId() == PixelSubdetector::PixelBarrel &&
           tTopo->pxbLayer(pixhit->geographicalId()) != 1) {
-        probQNoLayer1 = pixhit->probabilityQ();
-        probXYNoLayer1 = pixhit->probabilityXY();
+        float probQNoLayer1 = pixhit->probabilityQ();
+        float probXYNoLayer1 = pixhit->probabilityXY();
         if (probQNoLayer1 != 0) {  // only save the non-zero rechits
           numRecHitsNoLayer1++;
           // Calculate alpha term needed for the combination

--- a/RecoTracker/DeDx/plugins/SiPixelTrackProbQXYProducer.cc
+++ b/RecoTracker/DeDx/plugins/SiPixelTrackProbQXYProducer.cc
@@ -23,10 +23,12 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
- #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
+//#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+//#include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
 
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/TrackReco/interface/Track.h"
@@ -60,7 +62,7 @@ using namespace reco;
 using namespace std;
 using namespace edm;
 
-SiPixelTrackProbQXYProducer::SiPixelTrackProbQXYProducer(const edm::ParameterSet& iConfig) {
+SiPixelTrackProbQXYProducer::SiPixelTrackProbQXYProducer(const edm::ParameterSet& iConfig) : tTopoToken_(esConsumes()) {
   produces<reco::SiPixelTrackProbQXYCollection>();
   produces<reco::SiPixelTrackProbQXYAssociation>();
   trackToken_ = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracks"));
@@ -102,9 +104,7 @@ void SiPixelTrackProbQXYProducer::produce(edm::Event& iEvent, const edm::EventSe
         continue;
 
       //Retrieve tracker topology from geometry
-      edm::ESHandle<TrackerTopology> TopoHandle;
-      iSetup.get<TrackerTopologyRcd>().get(TopoHandle);
-      const TrackerTopology* tTopo = TopoHandle.product();
+      const TrackerTopology* const tTopo = &iSetup.getData(tTopoToken_);
 
       // Have a separate variable that excludes Layer 1
       // Layer 1 was very noisy in 2017/2018

--- a/RecoTracker/DeDx/plugins/SiPixelTrackProbQXYProducer.cc
+++ b/RecoTracker/DeDx/plugins/SiPixelTrackProbQXYProducer.cc
@@ -1,0 +1,187 @@
+// -*- C++ -*-
+//
+// Package:    SiPixelTrackProbQXYProducer
+// Class:      SiPixelTrackProbQXYProducer
+//
+/**\class SiPixelTrackProbQXYProducer  SiPixelTrackProbQXYProducer.cc RecoTracker/DeDx/plugins/SiPixelTrackProbQXYProducer.cc
+
+ Description: SiPixel Charge and shape probabilities combined for tracks
+
+*/
+//
+// Original Author:  Tamas Almos Vami
+//         Created:  Mon Nov 17 14:09:02 CEST 2021
+//
+
+// system include files
+#include <memory>
+#include <cmath>
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
+ #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
+
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
+#include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
+#include "DataFormats/TrackReco/interface/SiPixelTrackProbQXY.h"
+
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+
+//
+// class declaration
+//
+
+class SiPixelTrackProbQXYProducer : public edm::stream::EDProducer<> {
+public:
+  explicit SiPixelTrackProbQXYProducer(const edm::ParameterSet&);
+  ~SiPixelTrackProbQXYProducer() override = default;
+
+private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  int factorial(int);
+
+  // ----------member data ---------------------------
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
+  edm::EDGetTokenT<reco::TrackCollection> trackToken_;
+};
+
+using namespace reco;
+using namespace std;
+using namespace edm;
+
+SiPixelTrackProbQXYProducer::SiPixelTrackProbQXYProducer(const edm::ParameterSet& iConfig) {
+  produces<reco::SiPixelTrackProbQXYCollection>();
+  produces<reco::SiPixelTrackProbQXYAssociation>();
+  trackToken_ = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracks"));
+}
+
+void SiPixelTrackProbQXYProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  edm::Handle<reco::TrackCollection> trackCollectionHandle;
+  iEvent.getByToken(trackToken_, trackCollectionHandle);
+  const TrackCollection& trackCollection(*trackCollectionHandle.product());
+  float probQonTrack = 0.0;
+  float probXYonTrack = 0.0;
+  float probQonTrackNoL1 = 0.0;
+  float probXYonTrackNoL1 = 0.0;
+  // creates the output collection
+  auto resultSiPixelTrackProbQXYColl = std::make_unique<reco::SiPixelTrackProbQXYCollection>();
+  std::vector<int> indices;
+
+  // Loop through the tracks
+  for (unsigned int j = 0; j < trackCollection.size(); j++) {
+    const reco::Track& track = trackCollection[j];
+
+    int numRecHits = 0;
+    int numRecHitsNoL1 = 0;
+    float probQonTrackWMulti = 1;
+    float probXYonTrackWMulti = 1;
+    float probQonTrackWMultiNoL1 = 1;
+    float probXYonTrackWMultiNoL1 = 1;
+
+    // Loop through the rechits on the given track
+    auto hb = track.recHitsBegin();
+    for (unsigned int h = 0; h < track.recHitsSize(); h++) {
+      auto recHit = *(hb + h);
+      const SiPixelRecHit* pixhit = dynamic_cast<const SiPixelRecHit*>(recHit);
+      if (pixhit == nullptr)
+        continue;
+      if (!pixhit->isValid())
+        continue;
+      if (pixhit->geographicalId().det() != DetId::Tracker)
+        continue;
+
+      //Retrieve tracker topology from geometry
+      edm::ESHandle<TrackerTopology> TopoHandle;
+      iSetup.get<TrackerTopologyRcd>().get(TopoHandle);
+      const TrackerTopology* tTopo = TopoHandle.product();
+
+      // Have a separate variable that excludes Layer 1
+      // Layer 1 was very noisy in 2017/2018
+      float probQNoL1 = 0;
+      float probXYNoL1 = 0;
+      if (tTopo->pxbLayer(pixhit->geographicalId()) != 1) {
+        probQNoL1 = pixhit->probabilityQ();
+        probXYNoL1 = pixhit->probabilityXY();
+        if (probQNoL1 != 0) {  // only save the non-zero rechits
+          numRecHitsNoL1++;
+          // Calculate alpha term needed for the combination
+          probQonTrackWMultiNoL1 *= probQNoL1;
+          probXYonTrackWMultiNoL1 *= probXYNoL1;
+        }
+      }
+
+      // Have a variable that includes all layers and disks
+      float probQ = 0;
+      float probXY = 0;
+      probQ = pixhit->probabilityQ();
+      probXY = pixhit->probabilityXY();
+
+      if (probQ == 0) {
+        continue;  // if any of the rechits have zero probQ, skip them
+      }
+      numRecHits++;
+
+      // Calculate alpha term needed for the combination
+      probQonTrackWMulti *= probQ;
+      probXYonTrackWMulti *= probXY;
+
+    }  // end looping on the rechits
+
+    // Combine the probabilities into a track level quantity
+    float logprobQonTrackWMulti = probQonTrackWMulti > 0 ? log(probQonTrackWMulti) : 0;
+    float logprobXYonTrackWMulti = probXYonTrackWMulti > 0 ? log(probXYonTrackWMulti) : 0;
+    float probQonTrackTerm = 0;
+    float probXYonTrackTerm = 0;
+    for (int iTkRh = 0; iTkRh < numRecHits; ++iTkRh) {
+      probQonTrackTerm += ((pow(-logprobQonTrackWMulti, iTkRh)) / (factorial(iTkRh)));
+      probXYonTrackTerm += ((pow(-logprobXYonTrackWMulti, iTkRh)) / (factorial(iTkRh)));
+    }
+
+    probQonTrack = probQonTrackWMulti * probQonTrackTerm;
+    probXYonTrack = probXYonTrackWMulti * probXYonTrackTerm;
+
+    // Repeat the above excluding Layer 1
+    float logprobQonTrackWMultiNoL1 = probQonTrackWMultiNoL1 > 0 ? log(probQonTrackWMultiNoL1) : 0;
+    float logprobXYonTrackWMultiNoL1 = probXYonTrackWMultiNoL1 > 0 ? log(probXYonTrackWMultiNoL1) : 0;
+    float probQonTrackTermNoL1 = 0;
+    float probXYonTrackTermNoL1 = 0;
+    for (int iTkRh = 0; iTkRh < numRecHitsNoL1; ++iTkRh) {
+      probQonTrackTermNoL1 += ((pow(-logprobQonTrackWMultiNoL1, iTkRh)) / (factorial(iTkRh)));
+      probXYonTrackTermNoL1 += ((pow(-logprobXYonTrackWMultiNoL1, iTkRh)) / (factorial(iTkRh)));
+    }
+
+    probQonTrackNoL1 = probQonTrackWMultiNoL1 * probQonTrackTermNoL1;
+    probXYonTrackNoL1 = probXYonTrackWMultiNoL1 * probXYonTrackTermNoL1;
+
+    reco::SiPixelTrackProbQXY siPixelTrackProbQXY =
+        SiPixelTrackProbQXY(probQonTrack, probXYonTrack, probQonTrackNoL1, probXYonTrackNoL1);
+    indices.push_back(resultSiPixelTrackProbQXYColl->size());
+    resultSiPixelTrackProbQXYColl->push_back(siPixelTrackProbQXY);
+  }  // end loop on track collection
+
+  edm::OrphanHandle<reco::SiPixelTrackProbQXYCollection> siPixelTrackProbQXYCollHandle =
+      iEvent.put(std::move(resultSiPixelTrackProbQXYColl));
+
+  //create map passing the handle to the matched collection
+  auto trackProbQXYMatch = std::make_unique<reco::SiPixelTrackProbQXYAssociation>(siPixelTrackProbQXYCollHandle);
+  reco::SiPixelTrackProbQXYAssociation::Filler filler(*trackProbQXYMatch);
+  filler.insert(trackCollectionHandle, indices.begin(), indices.end());
+  filler.fill();
+  iEvent.put(std::move(trackProbQXYMatch));
+}
+
+int SiPixelTrackProbQXYProducer::factorial(int n) { return (n == 1 || n == 0) ? 1 : factorial(n - 1) * n; }
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(SiPixelTrackProbQXYProducer);

--- a/RecoTracker/DeDx/python/siPixelTrackProbQXYProducer_cff.py
+++ b/RecoTracker/DeDx/python/siPixelTrackProbQXYProducer_cff.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+siPixelTrackProbQXY = cms.EDProducer("SiPixelTrackProbQXYProducer",
+    tracks                     = cms.InputTag("generalTracks"),
+)
+
+ 
+doSiPixelTrackProbQXYTask = cms.Task(siPixelTrackProbQXY)
+doSiPixelTrackProbQXY = cms.Sequence(doSiPixelTrackProbQXYTask)

--- a/RecoTracker/DeDx/python/siPixelTrackProbQXYProducer_cff.py
+++ b/RecoTracker/DeDx/python/siPixelTrackProbQXYProducer_cff.py
@@ -1,9 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+import RecoTracker.DeDx.siPixelTrackProbQXYProducer_cfi as _probQXY
 
-siPixelTrackProbQXY = cms.EDProducer("SiPixelTrackProbQXYProducer",
-    tracks                     = cms.InputTag("generalTracks"),
-)
+siPixelTrackProbQXY = _probQXY.siPixelTrackProbQXYProducer.clone()
 
- 
-doSiPixelTrackProbQXYTask = cms.Task(siPixelTrackProbQXY)
-doSiPixelTrackProbQXY = cms.Sequence(doSiPixelTrackProbQXYTask)

--- a/RecoTracker/DeDx/test/BuildFile.xml
+++ b/RecoTracker/DeDx/test/BuildFile.xml
@@ -17,8 +17,3 @@
   <flags EDM_PLUGIN="1"/>
 </library>
 
-<environment>
-  <bin file="testDeDxScripts.cpp">
-    <flags TEST_RUNNER_ARGS="/bin/bash RecoTracker/DeDx/test testProbQXY.sh"/>
-  </bin>
-</environment>

--- a/RecoTracker/DeDx/test/BuildFile.xml
+++ b/RecoTracker/DeDx/test/BuildFile.xml
@@ -11,7 +11,6 @@
 <use name="Geometry/Records"/>
 <use name="MagneticField/Records"/>
 <use name="MagneticField/Engine"/>
-<use name="SimDataFormats/Vertex"/>
 <use name="TrackingTools/PatternTools"/>
 <use name="root"/>
 

--- a/RecoTracker/DeDx/test/BuildFile.xml
+++ b/RecoTracker/DeDx/test/BuildFile.xml
@@ -14,25 +14,13 @@
 <use name="SimDataFormats/Vertex"/>
 <use name="TrackingTools/PatternTools"/>
 <use name="root"/>
-<library file="TrackAnalyzer.cc" name="TrackAnalyzer">
-  <flags EDM_PLUGIN="1"/>
-</library>
 
-<library file="TrackValidator.cc" name="TrackValidator">
-  <flags EDM_PLUGIN="1"/>
-</library>
-
-<library file="TrajectoryAnalyzer.cc" name="TrajectoryAnalyzer">
-  <flags EDM_PLUGIN="1"/>
-</library>
-
-<library file="FakeCPEFiller.cc" name="FakeCPEFiller">
-  <use name="SimTracker/TrackerHitAssociation"/>
+<library file="ProbQXYAna.cc" name="ProbQXYAna">
   <flags EDM_PLUGIN="1"/>
 </library>
 
 <environment>
-  <bin file="testMuonTrackRefitting.cpp">
-    <flags TEST_RUNNER_ARGS="/bin/bash RecoTracker/TrackProducer/test testMuonTrackRefitting.sh"/>
+  <bin file="testDeDxScripts.cpp">
+    <flags TEST_RUNNER_ARGS="/bin/bash RecoTracker/DeDx/test testProbQXY.sh"/>
   </bin>
 </environment>

--- a/RecoTracker/DeDx/test/BuildFile.xml
+++ b/RecoTracker/DeDx/test/BuildFile.xml
@@ -4,7 +4,6 @@
 <use name="DataFormats/TrackReco"/>
 <use name="RecoTracker/TrackProducer"/>
 <use name="TrackingTools/TransientTrack"/>
-<use name="clhep"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="Geometry/TrackerGeometryBuilder"/>

--- a/RecoTracker/DeDx/test/ProbQXYAna.cc
+++ b/RecoTracker/DeDx/test/ProbQXYAna.cc
@@ -41,6 +41,7 @@ void ProbQXYAna::analyze(edm::StreamID id, const edm::Event& iEvent, const edm::
   iEvent.getByToken(trackToken_, trackCollectionHandle);
   const auto trackCollection(*trackCollectionHandle.product());
   int numTrack = 0;
+  LogPrint("ProbQXYAna") << "Analyzing run " << iEvent.id().run() << " / event " << iEvent.id().event();
   for (const auto& track : trackCollection) {
     numTrack++;
     float probQonTrack = track.probQonTrack();

--- a/RecoTracker/DeDx/test/ProbQXYAna.cc
+++ b/RecoTracker/DeDx/test/ProbQXYAna.cc
@@ -1,0 +1,59 @@
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/PatCandidates/interface/IsolatedTrack.h"
+
+#include "DataFormats/TrackReco/interface/SiPixelTrackProbQXY.h"
+
+class ProbQXYAna : public edm::global::EDAnalyzer<> {
+public:
+  explicit ProbQXYAna(const edm::ParameterSet&);
+  ~ProbQXYAna() override = default;
+
+private:
+  virtual void analyze(edm::StreamID, const edm::Event&, const edm::EventSetup&) const override;
+
+  // ----------member data ---------------------------
+  const edm::EDGetTokenT<std::vector<pat::IsolatedTrack>> trackToken_;
+};
+
+using namespace reco;
+using namespace std;
+using namespace edm;
+
+ProbQXYAna::ProbQXYAna(const edm::ParameterSet& iConfig)
+    : trackToken_(consumes<std::vector<pat::IsolatedTrack>>(iConfig.getParameter<edm::InputTag>("tracks"))) {}
+
+void ProbQXYAna::analyze(edm::StreamID id, const edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  edm::Handle<std::vector<pat::IsolatedTrack>> trackCollectionHandle;
+  iEvent.getByToken(trackToken_, trackCollectionHandle);
+  const auto trackCollection(*trackCollectionHandle.product());
+  int numTrack = 0;
+  for (const auto& track : trackCollection) {
+    numTrack++;
+    float probQonTrack = track.probQonTrack();
+    float probXYonTrack = track.probXYonTrack();
+    float probQonTrackNoLayer1 = track.probQonTrackNoLayer1();
+    float probXYonTrackNoLayer1 = track.probXYonTrackNoLayer1();
+    LogPrint("ProbQXYAna") << "--------------------------------------------------";
+    LogPrint("ProbQXYAna") << "For track " << numTrack;
+    LogPrint("ProbQXYAna") << "probQonTrack: " << probQonTrack << " and probXYonTrack: " << probXYonTrack;
+    LogPrint("ProbQXYAna") << "probQonTrackNoLayer1: " << probQonTrackNoLayer1
+                           << " and probXYonTrackNoLayer1: " << probXYonTrackNoLayer1;
+  }
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(ProbQXYAna);

--- a/RecoTracker/DeDx/test/ProbQXYAna.cc
+++ b/RecoTracker/DeDx/test/ProbQXYAna.cc
@@ -41,6 +41,7 @@ void ProbQXYAna::analyze(edm::StreamID id, const edm::Event& iEvent, const edm::
   iEvent.getByToken(trackToken_, trackCollectionHandle);
   const auto trackCollection(*trackCollectionHandle.product());
   int numTrack = 0;
+  int numTrackWSmallProbQ = 0;
   LogPrint("ProbQXYAna") << "Analyzing run " << iEvent.id().run() << " / event " << iEvent.id().event();
   for (const auto& track : trackCollection) {
     numTrack++;
@@ -48,12 +49,18 @@ void ProbQXYAna::analyze(edm::StreamID id, const edm::Event& iEvent, const edm::
     float probXYonTrack = track.probXYonTrack();
     float probQonTrackNoLayer1 = track.probQonTrackNoLayer1();
     float probXYonTrackNoLayer1 = track.probXYonTrackNoLayer1();
-    LogPrint("ProbQXYAna") << "--------------------------------------------------";
-    LogPrint("ProbQXYAna") << "For track " << numTrack;
-    LogPrint("ProbQXYAna") << "probQonTrack: " << probQonTrack << " and probXYonTrack: " << probXYonTrack;
-    LogPrint("ProbQXYAna") << "probQonTrackNoLayer1: " << probQonTrackNoLayer1
+    LogPrint("ProbQXYAna") << "  --------------------------------------------------";
+    LogPrint("ProbQXYAna") << "  For track " << numTrack;
+    LogPrint("ProbQXYAna") << "  >> probQonTrack: " << probQonTrack << " and probXYonTrack: " << probXYonTrack;
+    LogPrint("ProbQXYAna") << "  >> probQonTrackNoLayer1: " << probQonTrackNoLayer1
                            << " and probXYonTrackNoLayer1: " << probXYonTrackNoLayer1;
+
+    if (probQonTrack < 0.1) {
+      numTrackWSmallProbQ++;
+    }
   }
+  LogPrint("ProbQXYAna") << "In this event the ratio of low probQ tracks / all tracks "
+                         << numTrackWSmallProbQ / float(numTrack);
 }
 
 //define this as a plug-in

--- a/RecoTracker/DeDx/test/ProbQXYFromMiniAOD.py
+++ b/RecoTracker/DeDx/test/ProbQXYFromMiniAOD.py
@@ -1,0 +1,49 @@
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
+process = cms.Process('RECO2',Run2_2018)
+
+options = VarParsing.VarParsing('analysis')
+options.register('globalTag',
+                 "auto:run2_mc", # default value
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.string, # string, int, or float
+                 "input file name")
+options.parseArguments()
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+    
+process.source = cms.Source("PoolSource",
+                            fileNames = cms.untracked.vstring(options.inputFiles),
+                            secondaryFileNames = cms.untracked.vstring()
+                            )
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(options.maxEvents)
+)
+
+process.options = cms.untracked.PSet()
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('step1 nevts:1'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, options.globalTag, '')
+
+process.probQXYAna  = cms.EDAnalyzer('ProbQXYAna',
+   tracks          = cms.InputTag("isolatedTracks")
+)
+
+# Path and EndPath definitions
+process.probQXYAna_step = cms.EndPath(process.probQXYAna)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.probQXYAna_step)

--- a/RecoTracker/DeDx/test/ProbQXYFromMiniAOD_cfg.py
+++ b/RecoTracker/DeDx/test/ProbQXYFromMiniAOD_cfg.py
@@ -6,7 +6,7 @@ process = cms.Process('RECO2',Run2_2018)
 
 options = VarParsing.VarParsing('analysis')
 options.register('globalTag',
-                 "auto:run2_mc", # default value
+                 "auto:run2_data", # default value
                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
                  VarParsing.VarParsing.varType.string, # string, int, or float
                  "input file name")

--- a/RecoTracker/DeDx/test/ProbQXYFromMiniAOD_cfg.py
+++ b/RecoTracker/DeDx/test/ProbQXYFromMiniAOD_cfg.py
@@ -27,13 +27,6 @@ process.maxEvents = cms.untracked.PSet(
 
 process.options = cms.untracked.PSet()
 
-# Production Info
-process.configurationMetadata = cms.untracked.PSet(
-    annotation = cms.untracked.string('step1 nevts:1'),
-    name = cms.untracked.string('Applications'),
-    version = cms.untracked.string('$Revision: 1.19 $')
-)
-
 # Other statements
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, options.globalTag, '')

--- a/RecoTracker/DeDx/test/testDeDxScripts.cpp
+++ b/RecoTracker/DeDx/test/testDeDxScripts.cpp
@@ -1,0 +1,2 @@
+#include "FWCore/Utilities/interface/TestHelper.h"
+RUNTEST()

--- a/RecoTracker/DeDx/test/testProbQXY.sh
+++ b/RecoTracker/DeDx/test/testProbQXY.sh
@@ -15,3 +15,11 @@ cmsDriver.py ReRECO --conditions auto:run2_data --customise Configuration/DataPr
 
 cmsRun ${LOCAL_TEST_DIR}/ProbQXYFromMiniAOD_cfg.py maxEvents=10 inputFiles=file:MiniAOD.root || die "Failure getting probQ and probXY from MINIAOD" $?
 rm MiniAOD.root
+
+# test MINIAOD signal MC
+echo -e "TESTING  Getting probQ and probXY from signal MC MINIAOD ...\n\n"
+cmsDriver.py ReRECOonMC --conditions 106X_upgrade2018_realistic_v11_L1v1 --datatier MINIAOD --era Run2_2018,pf_badHcalMitigation --eventcontent MINIAOD --number 10 --python_filename 4HLT2MiniAODonMC.py --scenario pp --step RAW2DIGI,L1Reco,RECO,EI,PAT --runUnscheduled --mc  --filein  /store/user/tvami/HSCP/HSCPgluino_M_1800/crab_PrivateHSCP_2018_Gluino_Mass1800_HLT_NoPU_v1/210612_042006/0000/HSCP_Gluino_Mass1800_HLT_1.root  --fileout file:MiniAODonMC.root
+
+cmsRun ${LOCAL_TEST_DIR}/ProbQXYFromMiniAOD_cfg.py maxEvents=10 inputFiles=file:MiniAODonMC.root || die "Failure getting probQ and probXY from Signal MC MINIAOD" $?
+rm MiniAODonMC.root
+

--- a/RecoTracker/DeDx/test/testProbQXY.sh
+++ b/RecoTracker/DeDx/test/testProbQXY.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+function die { echo $1: status $2 ; exit $2; }
+
+echo "TESTING Getting probQ and probXY from Analysis Data-Tier codes ..."
+echo -e "For now not doing anything, when there will be AOD and MiniAOD with this variable, this can be uncommented"
+# test AOD
+# Will come soon
+#echo "TESTING refitting from AOD ...\n\n"
+#cmsRun ${LOCAL_TEST_DIR}/ProbQXYFromMiniAOD.py maxEvents=100 inputFiles=/store/mc/RunIISummer20UL16RECO/DYJetsToMuMu_M-50_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/AODSIM/106X_mcRun2_asymptotic_v13-v2/00000/1D4FBF4B-7B8D-A04F-A108-B1BEB60558FA.root || die "Failure refitting from AOD" $?
+
+# test MINIAOD
+echo -e "TESTING  Getting probQ and probXY from MINIAOD ...\n\n"
+cmsDriver.py ReRECO --conditions auto:run2_data --customise Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018,Configuration/DataProcessing/Utils.addMonitoring --datatier MINIAOD --era Run2_2018,pf_badHcalMitigation --eventcontent MINIAOD --nThreads 8 --number 10 --python_filename 4HLT2MiniAOD.py --scenario pp --step RAW2DIGI,L1Reco,RECO,EI,PAT --runUnscheduled --data  --filein root://cms-xrd-global.cern.ch//store/data/Run2018C/SingleMuon/RAW/v1/000/319/337/00000/004ED286-5582-E811-8895-FA163E126126.root --fileout file:MiniAOD.root --era Run2_2018
+
+cmsRun ${LOCAL_TEST_DIR}/ProbQXYFromMiniAOD.py maxEvents=10 inputFiles=file:MiniAOD.root || die "Failure getting probQ and probXY from MINIAOD" $?
+rm MiniAOD.root

--- a/RecoTracker/DeDx/test/testProbQXY.sh
+++ b/RecoTracker/DeDx/test/testProbQXY.sh
@@ -11,7 +11,7 @@ echo -e "For now not doing anything, when there will be AOD and MiniAOD with thi
 
 # test MINIAOD
 echo -e "TESTING  Getting probQ and probXY from MINIAOD ...\n\n"
-cmsDriver.py ReRECO --conditions auto:run2_data --customise Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018,Configuration/DataProcessing/Utils.addMonitoring --datatier MINIAOD --era Run2_2018,pf_badHcalMitigation --eventcontent MINIAOD --nThreads 8 --number 10 --python_filename 4HLT2MiniAOD.py --scenario pp --step RAW2DIGI,L1Reco,RECO,EI,PAT --runUnscheduled --data  --filein root://cms-xrd-global.cern.ch//store/data/Run2018C/SingleMuon/RAW/v1/000/319/337/00000/004ED286-5582-E811-8895-FA163E126126.root --fileout file:MiniAOD.root --era Run2_2018
+cmsDriver.py ReRECO --conditions auto:run2_data --customise Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018 --datatier MINIAOD --eventcontent MINIAOD --number 10 --python_filename 4HLT2MiniAOD.py --scenario pp --step RAW2DIGI,L1Reco,RECO,PAT --data  --filein /store/data/Run2018C/SingleMuon/RAW/v1/000/319/337/00000/004ED286-5582-E811-8895-FA163E126126.root --fileout file:MiniAOD.root --era Run2_2018
 
-cmsRun ${LOCAL_TEST_DIR}/ProbQXYFromMiniAOD.py maxEvents=10 inputFiles=file:MiniAOD.root || die "Failure getting probQ and probXY from MINIAOD" $?
+cmsRun ${LOCAL_TEST_DIR}/ProbQXYFromMiniAOD_cfg.py maxEvents=10 inputFiles=file:MiniAOD.root || die "Failure getting probQ and probXY from MINIAOD" $?
 rm MiniAOD.root

--- a/RecoTracker/DeDx/test/testProbQXY.sh
+++ b/RecoTracker/DeDx/test/testProbQXY.sh
@@ -18,7 +18,7 @@ rm MiniAOD.root
 
 # test MINIAOD signal MC
 echo -e "TESTING  Getting probQ and probXY from signal MC MINIAOD ...\n\n"
-cmsDriver.py ReRECOonMC --conditions 106X_upgrade2018_realistic_v11_L1v1 --datatier MINIAOD --era Run2_2018,pf_badHcalMitigation --eventcontent MINIAOD --number 10 --python_filename 4HLT2MiniAODonMC.py --scenario pp --step RAW2DIGI,L1Reco,RECO,EI,PAT --runUnscheduled --mc  --filein  /store/user/tvami/HSCP/HSCPgluino_M_1800/crab_PrivateHSCP_2018_Gluino_Mass1800_HLT_NoPU_v1/210612_042006/0000/HSCP_Gluino_Mass1800_HLT_1.root  --fileout file:MiniAODonMC.root
+cmsDriver.py ReRECOonMC --conditions auto:phase1_2018_realistic --datatier MINIAOD --era Run2_2018 --eventcontent MINIAOD --number 10 --python_filename 4HLT2MiniAODonMC.py --scenario pp --step RAW2DIGI,L1Reco,RECO,PAT --mc  --filein  /store/user/tvami/HSCP/HSCPgluino_M_1800/crab_PrivateHSCP_2018_Gluino_Mass1800_HLT_NoPU_v1/210612_042006/0000/HSCP_Gluino_Mass1800_HLT_1.root  --fileout file:MiniAODonMC.root
 
 cmsRun ${LOCAL_TEST_DIR}/ProbQXYFromMiniAOD_cfg.py maxEvents=10 inputFiles=file:MiniAODonMC.root || die "Failure getting probQ and probXY from Signal MC MINIAOD" $?
 rm MiniAODonMC.root


### PR DESCRIPTION
#### PR description:

See request to ReRECO 2017/2018 SM and MET data in [1]. This assumed refitting tracks to get the required low-level pixel reco information. As an alternative (actually it's an improvement, so better than alternative) it was recommended to save the required information in the MiniAOD. This PR does that,  i.e. adds  SiPixel on track charge and shape probs to MiniAOD content. Since in 2017/2018 the Pixel layer 1 was very noisy, and alternative version that excludes L1 was added as well.

 * Adding it to RECO/AOD as a new object `siPixelTrackProbQXY`:
```
edm::ValueMap<reco::SiPixelTrackProbQXY>    "siPixelTrackProbQXY"       ""        "RECO"
edm::ValueMap<reco::SiPixelTrackProbQXY>    "siPixelTrackProbQXY"       "NoLayer1"        "RECO"
```

 * While adding it to MiniAOD as a member of the isolatedTracks collection.

Further details presented in the Tracking POG meeting on Monday [2]

[1] https://its.cern.ch/jira/browse/PDMVRERECO-48
[2] https://indico.cern.ch/event/1098365/#5-proposal-to-use-low-level-pi

#### PR validation:
 * Running MiniAOD
```
cmsDriver.py ReRECO --conditions auto:run2_data --customise Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018,Configuration/DataProcessing/Utils.addMonitoring --datatier MINIAOD --era Run2_2018,pf_badHcalMitigation --eventcontent MINIAOD --nThreads 8 --no_exec --number 100 --python_filename 4HLT2MiniAOD.py --scenario pp --step RAW2DIGI,L1Reco,RECO,EI,PAT --runUnscheduled --data  --filein root://cms-xrd-global.cern.ch//store/data/Run2018C/SingleMuon/RAW/v1/000/319/337/00000/004ED286-5582-E811-8895-FA163E126126.root --era Run2_2018
```
before the PR and after the PR the sizes change as follows:
-rw-r--r-- 1 tvami cms 8177333 Nov 24 16:30 ReRECO_RAW2DIGI_L1Reco_RECO_EI_PAT.root
--> 
-rw-r--r-- 1 tvami cms 8185759 Nov 24 16:26 ReRECO_RAW2DIGI_L1Reco_RECO_EI_PAT.root
i.e an 1.00103041 increase in size is expected.

A unit test has been implemented as well

 * Running AOD
```
cmsDriver.py ReRECO --conditions auto:run2_data --customise Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018 --datatier AOD --eventcontent AOD --number 100 --python_filename 4HLT2AOD.py --scenario pp --step RAW2DIGI,L1Reco,RECO --data  --filein file:/eos/cms/store/user/cmsbuild/store/data/Run2018C/SingleMuon/RAW/v1/000/319/337/00000/004ED286-5582-E811-8895-FA163E126126.root --fileout file:AOD.root --era Run2_2018
```
before the PR and after the PR the sizes of the AOD change as follows:
-rw-r--r--. 1 tvami zh 46456023 Dec  6 22:24 AOD.root
--> 
-rw-r--r--. 1 tvami zh 47673431 Dec  6 22:23 AOD.root
i.e an 1.0262056 increase in size is expected.

Here is the timing report for before the PR
```
 Time Summary: 
 - Min event:   3.1252
 - Max event:   42.8974
 - Avg event:   12.985
 - Total loop:  181.876
 - Total init:  67.6784
 - Total job:   249.563
 - EventSetup Lock: 0
 - EventSetup Get:  0
 Event Throughput: 0.549825 ev/s
 CPU Summary: 
 - Total loop:     1176.02
 - Total init:     51.0267
 - Total extra:    0
 - Total children: 0.125992
 - Total job:      1227.06
 ```

and after the PR
```
 Time Summary: 
 - Min event:   3.22021
 - Max event:   41.7722
 - Avg event:   13.0204
 - Total loop:  180.607
 - Total init:  66.0196
 - Total job:   246.629
 - EventSetup Lock: 0
 - EventSetup Get:  0
 Event Throughput: 0.55369 ev/s
 CPU Summary: 
 - Total loop:     1183.12
 - Total init:     50.1868
 - Total extra:    0
 - Total children: 0.117669
 - Total job:      1233.31
 ```

Content was validated on MC Signal samples, and on data as well, please see more plots in [2]

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Needs a backport in 10_6_X

cc @mmusich 