### PR TITLE
[ASAN] fix unit tests by setting NO_TEST_PREFIX flag for ASAN IB

### DIFF
--- a/DQM/Integration/test/BuildFile.xml
+++ b/DQM/Integration/test/BuildFile.xml
@@ -1,3 +1,6 @@
+<ifrelease name="_ASAN_">
+  <flags NO_TEST_PREFIX="1"/>
+</ifrelease>
 <test name="TestDQMOnlineClient-beam_dqm_sourceclient" command="runtest.sh beam_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-beampixel_dqm_sourceclient" command="runtest.sh beampixel_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-castor_dqm_sourceclient" command="runtest.sh castor_dqm_sourceclient-live_cfg.py"/>


### PR DESCRIPTION
Unit tests for  `DQM/Integration` hang [a] for ASAN IBs as scram sets `LD_PRELOAD=libasan.so` for each unit tests. Running tests without LD_PRELOAD works. https://github.com/cms-sw/cmsdist/pull/7469 Allows tests to instruct scram to not add test prefix. This should fix the unit tests for ASAN IBs.  

[a] https://cmssdt.cern.ch/SDT/cgi-bin/logreader/slc7_amd64_gcc10/CMSSW_12_2_ASAN_X_2021-11-24-2300/unitTestLogs/DQM/Integration#/
```
===== Test "TestDQMOnlineClient-beam_dqm_sourceclient" ====
+ [[ 1 -eq 0 ]]
+ [[ -z '' ]]
+ LOCAL_TEST_DIR=.
+ [[ -z '' ]]
+ CLIENTS_DIR=./src/DQM/Integration/python/clients
+ mkdir -p ./upload
+ cmsRun ./src/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py unitTest=True
Querying DAS for files...
the query is file run=344518 dataset=/ExpressCosmics/Commissioning2021-Express-v1/FEVT lumi=1

---> test TestDQMOnlineClient-beam_dqm_sourceclient had ERRORS
TestTime:3600
^^^^ End Test TestDQMOnlineClient-beam_dqm_sourceclient ^^^^
```