### PR TITLE
force HLT tools to return "HLTSchedule"

### DIFF
--- a/HLTrigger/Configuration/python/Tools/confdbOfflineConverter.py
+++ b/HLTrigger/Configuration/python/Tools/confdbOfflineConverter.py
@@ -175,7 +175,10 @@ class OfflineConverter:
             stderr = subprocess.PIPE,
             shell = False,
             universal_newlines = True )
-        return sub.communicate()
+        out,err = sub.communicate()
+        # 12_0 uses "HLTSchedule", confdb was changed to make this "schedule", this resets it back for this release
+        out = out.replace("fragment.schedule","fragment.HLTSchedule").replace("process.schedule","process.HLTSchedule")
+        return out,err
 
 def help():
     sys.stdout.write("""Usage: %s OPTIONS


### PR DESCRIPTION
#### PR description:

This PR is specific to `12_0_X`, and is needed to ease HLT development for users in view of an upcoming update of `ConfDB` (external to CMSSW).

This change forces the HLT tools to return a `cms.Schedule` named "HLTSchedule", which is what `12_0_X` users currently expect (this is needed because in the near future `ConfDB` will return "schedule" instead of "HLTSchedule").

More information can be found in #35842 and #36237.

This change is copied from #36237 by @Sam-Harper.

This PR is merely technical, and no changes are expected.

#### PR validation:

None (relies on the validation done for #36237).

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

Not a backport. This PR is specific to `12_0_X`.