### PR TITLE
make HLT use "schedule" [12.1.X]

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -252,6 +252,7 @@ class ConfigBuilder(object):
         self.create_process()
         self.define_Configs()
         self.schedule = list()
+        self.scheduleIndexOfFirstHLTPath = None
 
         # we are doing three things here:
         # creating a process to catch errors
@@ -1525,7 +1526,6 @@ class ConfigBuilder(object):
             print("L1REPACK with '",sequence,"' is not supported! Supported choices are: ",supported)
             raise Exception('unsupported feature')
 
-
     def prepare_HLT(self, sequence = None):
         """ Enrich the schedule with the HLT simulation step"""
         if not sequence:
@@ -1560,7 +1560,7 @@ class ConfigBuilder(object):
             else:
                 self.executeAndRemember('process.loadHltConfiguration("%s",%s)'%(sequence.replace(',',':'),optionsForHLTConfig))
         else:
-            self.loadAndRemember('HLTrigger/Configuration/HLT_%s_cff'       % sequence)
+            self.loadAndRemember('HLTrigger/Configuration/HLT_%s_cff' % sequence)
 
         if self._options.isMC:
             self._options.customisation_file.append("HLTrigger/Configuration/customizeHLTforMC.customizeHLTforMC")
@@ -1572,10 +1572,13 @@ class ConfigBuilder(object):
             from HLTrigger.Configuration.CustomConfigs import ProcessName
             self.process = ProcessName(self.process)
 
-        self.schedule.append(self.process.HLTSchedule)
-        [self.blacklist_paths.append(path) for path in self.process.HLTSchedule if isinstance(path,(cms.Path,cms.EndPath))]
+        if self.process.schedule == None:
+            raise Exception('the HLT step did not attach a valid schedule to the process')
 
-        #this is a fake, to be removed with fastim migration and HLT menu dump
+        self.scheduleIndexOfFirstHLTPath = len(self.schedule)
+        [self.blacklist_paths.append(path) for path in self.process.schedule if isinstance(path,(cms.Path,cms.EndPath))]
+
+        # this is a fake, to be removed with fastim migration and HLT menu dump
         if self._options.fast:
             if not hasattr(self.process,'HLTEndSequence'):
                 self.executeAndRemember("process.HLTEndSequence = cms.Sequence( process.dummyModule )")
@@ -2241,27 +2244,29 @@ class ConfigBuilder(object):
 
         # dump the schedule
         self.pythonCfgCode += "\n# Schedule definition\n"
-        result = "process.schedule = cms.Schedule("
 
         # handling of the schedule
-        self.process.schedule = cms.Schedule()
-        for item in self.schedule:
-            if not isinstance(item, cms.Schedule):
+        pathNames = ['process.'+p.label_() for p in self.schedule]
+        if self.process.schedule == None:
+            self.process.schedule = cms.Schedule()
+            for item in self.schedule:
                 self.process.schedule.append(item)
-            else:
-                self.process.schedule.extend(item)
-
-        if hasattr(self.process,"HLTSchedule"):
-            beforeHLT = self.schedule[:self.schedule.index(self.process.HLTSchedule)]
-            afterHLT = self.schedule[self.schedule.index(self.process.HLTSchedule)+1:]
-            pathNames = ['process.'+p.label_() for p in beforeHLT]
-            result += ','.join(pathNames)+')\n'
-            result += 'process.schedule.extend(process.HLTSchedule)\n'
-            pathNames = ['process.'+p.label_() for p in afterHLT]
-            result += 'process.schedule.extend(['+','.join(pathNames)+'])\n'
+            result = 'process.schedule = cms.Schedule('+','.join(pathNames)+')\n'
         else:
-            pathNames = ['process.'+p.label_() for p in self.schedule]
-            result ='process.schedule = cms.Schedule('+','.join(pathNames)+')\n'
+            if not isinstance(self.scheduleIndexOfFirstHLTPath, int):
+                raise Exception('the schedule was imported from a cff in HLTrigger.Configuration, but the final index of the first HLT path is undefined')
+
+            for index, item in enumerate(self.schedule):
+                if index < self.scheduleIndexOfFirstHLTPath:
+                    self.process.schedule.insert(index, item)
+                else:
+                    self.process.schedule.append(item)
+
+            result = "# process.schedule imported from cff in HLTrigger.Configuration\n"
+            for index, item in enumerate(pathNames[:self.scheduleIndexOfFirstHLTPath]):
+                result += 'process.schedule.insert('+str(index)+', '+item+')\n'
+            if self.scheduleIndexOfFirstHLTPath < len(pathNames):
+                result += 'process.schedule.extend(['+','.join(pathNames[self.scheduleIndexOfFirstHLTPath:])+'])\n'
 
         self.pythonCfgCode += result
 

--- a/HLTrigger/Configuration/python/customizeHLTforALL.py
+++ b/HLTrigger/Configuration/python/customizeHLTforALL.py
@@ -2,6 +2,15 @@ import FWCore.ParameterSet.Config as cms
 
 def customizeHLTforAll(process, menuType = "GRun", _customInfo = None):
 
+    # rename "HLTSchedule" to "schedule":
+    # CMSSW policy is to have at most 1 schedule
+    # in the cms.Process, named "schedule"
+    if hasattr(process, 'HLTSchedule'):
+        if process.schedule_() != None:
+            raise Exception('process.schedule already exists')
+        process.setSchedule_(process.HLTSchedule)
+        del process.HLTSchedule
+
     if (_customInfo is not None):
 
         _maxEvents = _customInfo['maxEvents']

--- a/HLTrigger/Configuration/python/customizeHLTforNewDatasetDefinition.py
+++ b/HLTrigger/Configuration/python/customizeHLTforNewDatasetDefinition.py
@@ -15,7 +15,7 @@ def customizeHLTforNewDatasetDefinition(process):
             datasetPath = 'Dataset_'+dataset+'_v1'
             setattr( process, datasetPath, cms.Path( process.hltGtStage2Digis + getattr( process , 'hltPreDataset'+dataset ) +  getattr( process, 'hltDataset'+dataset ) + process.HLTEndSequence ) )
             # Append dataset path
-            process.HLTSchedule.insert( process.HLTSchedule.index( process.HLTriggerFinalPath ), getattr( process, datasetPath ) )
+            process.schedule.insert( process.schedule.index( process.HLTriggerFinalPath ), getattr( process, datasetPath ) )
             setattr( process.datasets, dataset, cms.vstring( datasetPath ) )
             streamPaths.append( datasetPath )
         # Set stream paths

--- a/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
+++ b/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
@@ -51,8 +51,6 @@ def customiseCommon(process):
         replace_with(process.Status_OnCPU, cms.Path(process.statusOnGPU + ~process.statusOnGPUFilter))
     else:
         process.Status_OnCPU = cms.Path(process.statusOnGPU + ~process.statusOnGPUFilter)
-        if 'HLTSchedule' in process.__dict__:
-            process.HLTSchedule.append(process.Status_OnCPU)
         if process.schedule is not None:
             process.schedule.append(process.Status_OnCPU)
 
@@ -60,11 +58,8 @@ def customiseCommon(process):
         replace_with(process.Status_OnGPU, cms.Path(process.statusOnGPU + process.statusOnGPUFilter))
     else:
         process.Status_OnGPU = cms.Path(process.statusOnGPU + process.statusOnGPUFilter)
-        if 'HLTSchedule' in process.__dict__:
-            process.HLTSchedule.append(process.Status_OnGPU)
         if process.schedule is not None:
             process.schedule.append(process.Status_OnGPU)
-
 
     # make the ScoutingCaloMuonOutput endpath compatible with using Tasks in the Scouting paths
     if 'hltOutputScoutingCaloMuon' in process.__dict__ and not 'hltPreScoutingCaloMuonOutputSmart' in process.__dict__:
@@ -244,9 +239,6 @@ def customisePixelLocalReconstruction(process):
     # workaround for AlCa paths
 
     if 'AlCa_LumiPixelsCounts_Random_v1' in process.__dict__:
-        if "HLTSchedule" in process.__dict__:
-            ind = process.HLTSchedule.index(process.AlCa_LumiPixelsCounts_Random_v1)
-            process.HLTSchedule.remove(process.AlCa_LumiPixelsCounts_Random_v1)
         # redefine the path to use the HLTDoLocalPixelSequence
         process.AlCa_LumiPixelsCounts_Random_v1 = cms.Path(
             process.HLTBeginSequenceRandom +
@@ -256,13 +248,8 @@ def customisePixelLocalReconstruction(process):
             process.HLTDoLocalPixelSequence +
             process.hltAlcaPixelClusterCounts +
             process.HLTEndSequence )
-        if "HLTSchedule" in process.__dict__:
-            process.HLTSchedule.insert(ind, process.AlCa_LumiPixelsCounts_Random_v1)
 
     if 'AlCa_LumiPixelsCounts_ZeroBias_v1' in process.__dict__:
-        if "HLTSchedule" in process.__dict__:
-            ind = process.HLTSchedule.index(process.AlCa_LumiPixelsCounts_ZeroBias_v1)
-            process.HLTSchedule.remove(process.AlCa_LumiPixelsCounts_ZeroBias_v1)
         # redefine the path to use the HLTDoLocalPixelSequence
         process.AlCa_LumiPixelsCounts_ZeroBias_v1 = cms.Path(
             process.HLTBeginSequence +
@@ -273,9 +260,6 @@ def customisePixelLocalReconstruction(process):
             process.HLTDoLocalPixelSequence +
             process.hltAlcaPixelClusterCounts +
             process.HLTEndSequence )
-        if "HLTSchedule" in process.__dict__:
-            process.HLTSchedule.insert(ind, process.AlCa_LumiPixelsCounts_ZeroBias_v1)
-
 
     # done
     return process
@@ -741,8 +725,6 @@ def _addConsumerPath(process):
         process.HLTDoLocalHcalTask,
     )
 
-    if 'HLTSchedule' in process.__dict__:
-        process.HLTSchedule.append(process.Consumer)
     if process.schedule is not None:
         process.schedule.append(process.Consumer)
 

--- a/RecoTauTag/HLTProducers/test/testL2TauTagNN.py
+++ b/RecoTauTag/HLTProducers/test/testL2TauTagNN.py
@@ -140,8 +140,7 @@ process.endjob_step = cms.EndPath(process.endOfProcess)
 
 
 # Schedule definition
-process.schedule = cms.Schedule()
-process.schedule.extend(process.HLTSchedule)
+# process.schedule imported from cff in HLTrigger.Configuration
 process.schedule.extend([process.endjob_step])
 from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
 associatePatAlgosToolsTask(process)

--- a/SLHCUpgradeSimulations/Geometry/test/phase2_digi_reco_pixelntuple_cfg.py
+++ b/SLHCUpgradeSimulations/Geometry/test/phase2_digi_reco_pixelntuple_cfg.py
@@ -111,8 +111,11 @@ process.endjob_step = cms.EndPath(process.endOfProcess)
 #process.FEVTDEBUGHLToutput_step = cms.EndPath(process.FEVTDEBUGHLToutput)
 
 # Schedule definition
-process.schedule = cms.Schedule(process.digitisation_step,process.L1simulation_step,process.L1TrackTrigger_step,process.digi2raw_step)
-process.schedule.extend(process.HLTSchedule)
+# process.schedule imported from cff in HLTrigger.Configuration
+process.schedule.insert(0, process.digitisation_step)
+process.schedule.insert(1, process.L1simulation_step)
+process.schedule.insert(2, process.L1TrackTrigger_step)
+process.schedule.insert(3, process.digi2raw_step)
 process.schedule.extend([process.raw2digi_step,process.L1Reco_step,process.reconstruction_step,process.user_step,process.endjob_step])
 from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
 associatePatAlgosToolsTask(process)


### PR DESCRIPTION
backport of #35858 #36019

TSG would like to backport #35858 to `12_1_X` in view of an upcoming update of `ConfDB`.

(#36019 needs to be backported with it as well, to maintain a unit test functional.)

The goal is to ease the work of HLT developers, making `12_1_X` behave the same as `12_2_X` in terms of the name of the `cms.Schedule` provided by HLT configs.

More information can be found in #35842 and #36237.

This PR is merely technical, and no changes are expected.

#### PR description:

Copied from the description of #35858:

> The first step towards the resolution of #35842 could be the renaming of HLTSchedule to schedule, using one of the standard HLT customisation functions. This PR is an attempt at that.
>
> The final solution will have to come eventually with a change in ConfDB.
> 
> Standalone configs in test/ that use/assume HLTSchedule have been ignored for the moment (except for one that I know is used used to run in unit tests).
> 
> Merely technical; no changes expected.

#### PR validation:

`addOnTests` and unit tests.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

#35858 #36019 

Goal: user support for HLT development in `12_1_X`.