### PR TITLE
Modification on r-phi distribution plots and fix on under/overflow bins in GEM onlineDQM, a backport to 12_0_X

### DIFF
--- a/DQM/GEM/interface/GEMDQMBase.h
+++ b/DQM/GEM/interface/GEMDQMBase.h
@@ -100,7 +100,7 @@ public:
   template <class M, class K>
   class MEMapInfT {
   public:
-    MEMapInfT() : bOperating_(false){};
+    MEMapInfT() : bOperating_(false), bIsNoUnderOverflowBin_(false){};
 
     MEMapInfT(
         GEMDQMBase *pDQMBase, TString strName, TString strTitle, TString strTitleX = "", TString strTitleY = "Entries")
@@ -126,6 +126,7 @@ public:
           strTitleY_(strTitleY),
           bOperating_(true),
           bIsProfile_(false),
+          bIsNoUnderOverflowBin_(false),
           nBinsX_(nBinsX),
           dXL_(dXL),
           dXH_(dXH),
@@ -145,6 +146,7 @@ public:
           strTitleY_(strTitleY),
           bOperating_(true),
           bIsProfile_(false),
+          bIsNoUnderOverflowBin_(false),
           nBinsX_(-1),
           nBinsY_(-1),
           log_category_own_(pDQMBase->log_category_) {
@@ -170,6 +172,7 @@ public:
           strTitleY_(strTitleY),
           bOperating_(true),
           bIsProfile_(false),
+          bIsNoUnderOverflowBin_(false),
           nBinsX_(nBinsX),
           dXL_(dXL),
           dXH_(dXH),
@@ -200,6 +203,7 @@ public:
           strTitleY_(strTitleY),
           bOperating_(true),
           bIsProfile_(true),
+          bIsNoUnderOverflowBin_(false),
           nBinsX_(nBinsX),
           dXL_(dXL),
           dXH_(dXH),
@@ -223,6 +227,7 @@ public:
     //      strTitleX_(strTitleX),
     //      strTitleY_(strTitleY),
     //      bOperating_(true),
+    //      bIsNoUnderOverflowBin_(false),
     //      nBinsX_(nBinsX),
     //      dXL_(dXL),
     //      dXH_(dXH),
@@ -237,6 +242,7 @@ public:
     void SetOperating(Bool_t bOperating) { bOperating_ = bOperating; };
     void TurnOn() { bOperating_ = true; };
     void TurnOff() { bOperating_ = false; };
+    void SetNoUnderOverflowBin() { bIsNoUnderOverflowBin_ = true; };
 
     Bool_t isProfile() { return bIsProfile_; };
     void SetProfile(Bool_t bIsProfile) { bIsProfile_ = bIsProfile; };
@@ -286,10 +292,20 @@ public:
       dYH_ = dH;
     };
 
+    void SetPointUOFlow() {
+      dXU_ = dXL_ + (dXH_ - dXL_) / nBinsX_ * 0.5;
+      dXO_ = dXL_ + (dXH_ - dXL_) / nBinsX_ * (nBinsX_ - 0.5);
+      dYU_ = dYL_ + (dYH_ - dYL_) / nBinsY_ * 0.5;
+      dYO_ = dYL_ + (dYH_ - dYL_) / nBinsY_ * (nBinsY_ - 0.5);
+      dZU_ = dZL_ + (dZH_ - dZL_) / nBinsZ_ * 0.5;
+      dZO_ = dZL_ + (dZH_ - dZL_) / nBinsZ_ * (nBinsZ_ - 0.5);
+    };
+
     M &map() { return mapHist; }
     int bookND(BookingHelper &bh, K key) {
       if (!bOperating_)
         return 0;
+      SetPointUOFlow();
       if (bIsProfile_) {
         mapHist[key] = bh.bookProfile2D(
             strName_, strTitle_, nBinsX_, dXL_, dXH_, nBinsY_, dYL_, dYH_, dZL_, dZH_, strTitleX_, strTitleY_);
@@ -364,6 +380,12 @@ public:
       dqm::impl::MonitorElement *hist = FindHist(key);
       if (hist == nullptr)
         return -999;
+      if (bIsNoUnderOverflowBin_) {
+        if (x <= dXL_)
+          x = dXU_;
+        else if (x >= dXH_)
+          x = dXO_;
+      }
       hist->Fill(x);
       return 1;
     };
@@ -374,6 +396,16 @@ public:
       dqm::impl::MonitorElement *hist = FindHist(key);
       if (hist == nullptr)
         return -999;
+      if (bIsNoUnderOverflowBin_) {
+        if (x <= dXL_)
+          x = dXU_;
+        else if (x >= dXH_)
+          x = dXO_;
+        if (y <= dYL_)
+          y = dYU_;
+        else if (y >= dYH_)
+          y = dYO_;
+      }
       hist->Fill(x, y, w);
       return 1;
     };
@@ -404,13 +436,18 @@ public:
     TString strName_, strTitle_, strTitleX_, strTitleY_;
     Bool_t bOperating_;
     Bool_t bIsProfile_;
+    Bool_t bIsNoUnderOverflowBin_;
 
     std::vector<double> x_binning_;
     Int_t nBinsX_;
     Double_t dXL_, dXH_;
     Int_t nBinsY_;
     Double_t dYL_, dYH_;
+    Int_t nBinsZ_;
     Double_t dZL_, dZH_;
+    Double_t dXU_, dXO_;
+    Double_t dYU_, dYO_;
+    Double_t dZU_, dZO_;
 
     std::string log_category_own_;
   };
@@ -450,6 +487,8 @@ public:
     Int_t nNumEtaPartitions_;  // the number of eta partitions of the chambers
     Int_t nMaxVFAT_;  // the number of all VFATs in each chamber (= # of VFATs in eta partition * nNumEtaPartitions_)
     Int_t nNumDigi_;  // the number of digis of each VFAT
+
+    Float_t fMinPhi_;
   };
 
 public:
@@ -461,7 +500,6 @@ public:
 protected:
   int initGeometry(edm::EventSetup const &iSetup);
   int loadChambers();
-  int readRadiusEtaPartition(int nRegion, int nStation);
 
   int GenerateMEPerChamber(DQMStore::IBooker &ibooker);
   virtual int ProcessWithMEMap2(BookingHelper &bh, ME2IdsKey key) { return 0; };              // must be overrided
@@ -507,6 +545,7 @@ protected:
   inline int getIEtaFromVFATGE11(const int vfat);
   inline int getMaxVFAT(const int);
   inline int getDetOccXBin(const int, const int, const int);
+  inline Float_t restrictAngle(const Float_t fTheta, const Float_t fStart);
 
   const GEMGeometry *GEMGeometry_;
   edm::ESGetToken<GEMGeometry, MuonGeometryRecord> geomToken_;
@@ -574,6 +613,12 @@ inline int GEMDQMBase::getIEtaFromVFATGE11(const int vfat) { return 8 - (vfat % 
 
 inline int GEMDQMBase::getDetOccXBin(const int chamber, const int layer, const int n_chambers) {
   return n_chambers * (chamber - 1) + layer;
+}
+
+inline Float_t GEMDQMBase::restrictAngle(const Float_t fTheta, const Float_t fStart) {
+  Float_t fLoop = (fTheta - fStart) / (2 * M_PI);
+  int nLoop = (fLoop >= 0 ? (int)fLoop : (int)fLoop - 1);
+  return fTheta - nLoop * 2 * M_PI;
 }
 
 #endif  // DQM_GEM_INTERFACE_GEMDQMBase_h

--- a/DQM/GEM/interface/GEMDigiSource.h
+++ b/DQM/GEM/interface/GEMDigiSource.h
@@ -40,6 +40,7 @@ protected:
 
 private:
   int ProcessWithMEMap2WithEta(BookingHelper& bh, ME3IdsKey key) override;
+  int ProcessWithMEMap2(BookingHelper& bh, ME2IdsKey key) override;
   int ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) override;
   int ProcessWithMEMap3WithChamber(BookingHelper& bh, ME4IdsKey key) override;
 
@@ -53,7 +54,7 @@ private:
   MEMap3Inf mapDigiOcc_phi_;
   MEMap3Inf mapTotalDigiPerEvtLayer_;
   MEMap3Inf mapTotalDigiPerEvtIEta_;
-  MEMap3Inf mapBX_iEta_;
+  MEMap2Inf mapBX_;
 
   MEMap4Inf mapDigiOccPerCh_;
 

--- a/DQM/GEM/interface/GEMDigiSource.h
+++ b/DQM/GEM/interface/GEMDigiSource.h
@@ -40,7 +40,6 @@ protected:
 
 private:
   int ProcessWithMEMap2WithEta(BookingHelper& bh, ME3IdsKey key) override;
-  int ProcessWithMEMap2(BookingHelper& bh, ME2IdsKey key) override;
   int ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) override;
   int ProcessWithMEMap3WithChamber(BookingHelper& bh, ME4IdsKey key) override;
 

--- a/DQM/GEM/interface/GEMDigiSource.h
+++ b/DQM/GEM/interface/GEMDigiSource.h
@@ -40,6 +40,7 @@ protected:
 
 private:
   int ProcessWithMEMap2WithEta(BookingHelper& bh, ME3IdsKey key) override;
+  int ProcessWithMEMap2(BookingHelper& bh, ME2IdsKey key) override;
   int ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) override;
   int ProcessWithMEMap3WithChamber(BookingHelper& bh, ME4IdsKey key) override;
 
@@ -48,6 +49,7 @@ private:
   edm::EDGetTokenT<LumiScalersCollection> lumiScalers_;
 
   MEMap3Inf mapTotalDigi_layer_;
+  MEMap3Inf mapDigiWheel_layer_;
   MEMap3Inf mapDigiOcc_ieta_;
   MEMap3Inf mapDigiOcc_phi_;
   MEMap3Inf mapTotalDigiPerEvtLayer_;
@@ -59,6 +61,8 @@ private:
   MonitorElement* h2SummaryOcc_;
 
   Int_t nBXMin_, nBXMax_;
+  Float_t fRadiusMin_;
+  Float_t fRadiusMax_;
 
   Bool_t bModeRelVal_;
 };

--- a/DQM/GEM/plugins/GEMDQMHarvester.cc
+++ b/DQM/GEM/plugins/GEMDQMHarvester.cc
@@ -44,38 +44,43 @@ protected:
                          MonitorElement *h2Src,
                          std::string strSuffix,
                          MonitorElement *&h2Sum);
-  Float_t refineSummaryHistogram(MonitorElement *h2Sum,
+  Float_t refineSummaryHistogram(std::string strName,
+                                 MonitorElement *h2Sum,
                                  MonitorElement *h2SrcOcc,
                                  MonitorElement *h2SrcAllNum,
                                  MonitorElement *h2SrcStatusE,
                                  MonitorElement *h2SrcStatusW);
-  Int_t refineSummaryVFAT(MonitorElement *h2Sum,
+  Int_t refineSummaryVFAT(std::string strName,
+                          MonitorElement *h2Sum,
                           MonitorElement *h2SrcOcc,
                           MonitorElement *h2SrcStatusE,
                           MonitorElement *h2SrcStatusW);
-  Int_t assessOneBin(Float_t fAll, Float_t fNumOcc, Float_t fNumWarn, Float_t fNumErr);
+  Int_t assessOneBin(
+      std::string strName, Int_t nIdxX, Int_t nIdxY, Float_t fAll, Float_t fNumOcc, Float_t fNumWarn, Float_t fNumErr);
 
-  Float_t fReportSummary_;
-  std::string strOutFile_;
+  Float_t fCutErr_, fCutLowErr_, fCutWarn_;
 
-  std::string strDirSummary_;
-  std::string strDirRecHit_;
-  std::string strDirStatus_;
+  const std::string strDirSummary_ = "GEM/EventInfo";
+  const std::string strDirRecHit_ = "GEM/RecHits";
+  const std::string strDirStatus_ = "GEM/DAQStatus";
+
+  typedef std::vector<std::vector<Float_t>> TableStatusOcc;
+  typedef std::vector<std::vector<Int_t>> TableStatusNum;
 
   std::vector<std::string> listLayer_;
 };
 
 GEMDQMHarvester::GEMDQMHarvester(const edm::ParameterSet &cfg) {
-  fReportSummary_ = -1.0;
-  strOutFile_ = cfg.getParameter<std::string>("fromFile");
-  strDirSummary_ = "GEM/EventInfo";
-  strDirRecHit_ = "GEM/RecHits";
-  strDirStatus_ = "GEM/DAQStatus";
+  fCutErr_ = cfg.getParameter<double>("cutErr");
+  fCutLowErr_ = cfg.getParameter<double>("cutLowErr");
+  fCutWarn_ = cfg.getParameter<double>("cutWarn");
 }
 
 void GEMDQMHarvester::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<std::string>("fromFile", "");
+  desc.add<double>("cutErr", 0.05);
+  desc.add<double>("cutLowErr", 0.00);
+  desc.add<double>("cutWarn", 0.05);
   descriptions.add("GEMDQMHarvester", desc);
 }
 
@@ -88,6 +93,8 @@ void GEMDQMHarvester::dqmEndLuminosityBlock(DQMStore::IBooker &,
 }
 
 void GEMDQMHarvester::drawSummaryHistogram(edm::Service<DQMStore> &store) {
+  Float_t fReportSummary = -1.0;
+
   std::string strSrcDigiOcc = "GEM/Digis/summaryOccDigi";
   std::string strSrcStatusA = "GEM/DAQStatus/chamberAllStatus";
   std::string strSrcStatusW = "GEM/DAQStatus/chamberWarnings";
@@ -104,10 +111,13 @@ void GEMDQMHarvester::drawSummaryHistogram(edm::Service<DQMStore> &store) {
   MonitorElement *h2SrcStatusW = store->get(strSrcStatusW);
   MonitorElement *h2SrcStatusE = store->get(strSrcStatusE);
 
+  std::string strTitleSummary = "summary";
+
   if (h2SrcDigiOcc != nullptr && h2SrcStatusA != nullptr && h2SrcStatusW != nullptr && h2SrcStatusE != nullptr) {
     MonitorElement *h2Sum = nullptr;
     createSummaryHist(store, h2SrcStatusE, h2Sum, listLayer_);
-    fReportSummary_ = refineSummaryHistogram(h2Sum, h2SrcDigiOcc, h2SrcStatusA, h2SrcStatusE, h2SrcStatusW);
+    fReportSummary =
+        refineSummaryHistogram(strTitleSummary, h2Sum, h2SrcDigiOcc, h2SrcStatusA, h2SrcStatusE, h2SrcStatusW);
 
     for (const auto &strSuffix : listLayer_) {
       MonitorElement *h2SrcVFATOcc = store->get(strSrcVFATOcc + strSuffix);
@@ -115,9 +125,10 @@ void GEMDQMHarvester::drawSummaryHistogram(edm::Service<DQMStore> &store) {
       MonitorElement *h2SrcVFATStatusE = store->get(strSrcVFATStatusE + strSuffix);
       if (h2SrcVFATOcc == nullptr || h2SrcVFATStatusW == nullptr || h2SrcVFATStatusE == nullptr)
         continue;
+
       MonitorElement *h2SumVFAT = nullptr;
       createSummaryVFAT(store, h2SrcVFATStatusE, strSuffix, h2SumVFAT);
-      refineSummaryVFAT(h2SumVFAT, h2SrcVFATOcc, h2SrcVFATStatusE, h2SrcVFATStatusW);
+      refineSummaryVFAT(strSuffix, h2SumVFAT, h2SrcVFATOcc, h2SrcVFATStatusE, h2SrcVFATStatusW);
       TString strNewTitle = h2SrcVFATStatusE->getTitle();
       h2SumVFAT->setTitle((const char *)strNewTitle.ReplaceAll("errors", "errors/warnings"));
       h2SumVFAT->setXTitle(h2SrcVFATStatusE->getAxisTitle(1));
@@ -125,7 +136,7 @@ void GEMDQMHarvester::drawSummaryHistogram(edm::Service<DQMStore> &store) {
     }
   }
 
-  store->bookFloat("reportSummary")->Fill(fReportSummary_);
+  store->bookFloat("reportSummary")->Fill(fReportSummary);
 }
 
 void GEMDQMHarvester::copyLabels(MonitorElement *h2Src, MonitorElement *h2Dst) {
@@ -178,10 +189,13 @@ void GEMDQMHarvester::createSummaryVFAT(edm::Service<DQMStore> &store,
   copyLabels(h2Src, h2Sum);
 }
 
-Int_t GEMDQMHarvester::assessOneBin(Float_t fAll, Float_t fNumOcc, Float_t fNumWarn, Float_t fNumErr) {
-  if (fNumErr > 0.05 * fAll)  // The error status criterion
+Int_t GEMDQMHarvester::assessOneBin(
+    std::string strName, Int_t nIdxX, Int_t nIdxY, Float_t fAll, Float_t fNumOcc, Float_t fNumWarn, Float_t fNumErr) {
+  if (fNumErr > fCutErr_ * fAll)  // The error status criterion
     return 2;
-  else if (fNumErr > 0.00 * fAll || fNumWarn > 0.05 * fAll)  // The warning status criterion
+  else if (fNumErr > fCutLowErr_ * fAll)  // The low-error status criterion
+    return 4;
+  else if (fNumWarn > fCutWarn_ * fAll)  // The warning status criterion
     return 3;
   else if (fNumOcc > 0)
     return 1;
@@ -190,7 +204,8 @@ Int_t GEMDQMHarvester::assessOneBin(Float_t fAll, Float_t fNumOcc, Float_t fNumW
 }
 
 // FIXME: Need more study about how to summarize
-Float_t GEMDQMHarvester::refineSummaryHistogram(MonitorElement *h2Sum,
+Float_t GEMDQMHarvester::refineSummaryHistogram(std::string strName,
+                                                MonitorElement *h2Sum,
                                                 MonitorElement *h2SrcOcc,
                                                 MonitorElement *h2SrcStatusA,
                                                 MonitorElement *h2SrcStatusE,
@@ -207,7 +222,7 @@ Float_t GEMDQMHarvester::refineSummaryHistogram(MonitorElement *h2Sum,
       Float_t fStatusWarn = h2SrcStatusW->getBinContent(i, j);
       Float_t fStatusErr = h2SrcStatusE->getBinContent(i, j);
 
-      Int_t nRes = assessOneBin(fStatusAll, fOcc, fStatusWarn, fStatusErr);
+      Int_t nRes = assessOneBin(strName, i, j, fStatusAll, fOcc, fStatusWarn, fStatusErr);
       if (nRes == 1)
         nFineBin++;
 
@@ -219,7 +234,8 @@ Float_t GEMDQMHarvester::refineSummaryHistogram(MonitorElement *h2Sum,
   return ((Float_t)nFineBin) / nAllBin;
 }
 
-Int_t GEMDQMHarvester::refineSummaryVFAT(MonitorElement *h2Sum,
+Int_t GEMDQMHarvester::refineSummaryVFAT(std::string strName,
+                                         MonitorElement *h2Sum,
                                          MonitorElement *h2SrcOcc,
                                          MonitorElement *h2SrcStatusE,
                                          MonitorElement *h2SrcStatusW) {
@@ -231,7 +247,8 @@ Int_t GEMDQMHarvester::refineSummaryVFAT(MonitorElement *h2Sum,
       Float_t fStatusWarn = h2SrcStatusW->getBinContent(i, j);
       Float_t fStatusErr = h2SrcStatusE->getBinContent(i, j);
       Float_t fStatusAll = fOcc + fStatusWarn + fStatusErr;
-      Int_t nRes = assessOneBin(fStatusAll, fOcc, fStatusWarn, fStatusErr);
+
+      Int_t nRes = assessOneBin(strName, i, j, fStatusAll, fOcc, fStatusWarn, fStatusErr);
       h2Sum->setBinContent(i, j, (Float_t)nRes);
     }
   }

--- a/DQM/GEM/plugins/GEMDQMHarvester.cc
+++ b/DQM/GEM/plugins/GEMDQMHarvester.cc
@@ -213,8 +213,7 @@ Float_t GEMDQMHarvester::refineSummaryHistogram(std::string strName,
   Int_t nBinY = h2Sum->getNbinsY();
   Int_t nAllBin = 0, nFineBin = 0;
   for (Int_t j = 1; j <= nBinY; j++) {
-    Int_t nBinX = h2Sum->getNbinsX();
-    nBinX = (Int_t)(h2SrcOcc->getBinContent(0, j) + 0.5);
+    Int_t nBinX = (Int_t)(h2SrcOcc->getBinContent(0, j) + 0.5);
     h2Sum->setBinContent(0, j, nBinX);
     for (Int_t i = 1; i <= nBinX; i++) {
       Float_t fOcc = h2SrcOcc->getBinContent(i, j);

--- a/DQM/GEM/plugins/GEMDigiSource.cc
+++ b/DQM/GEM/plugins/GEMDigiSource.cc
@@ -58,7 +58,7 @@ void GEMDigiSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, 
                                       "Events");
   mapTotalDigiPerEvtIEta_.SetNoUnderOverflowBin();
 
-  mapBX_iEta_ = MEMap3Inf(this, "bx", "Digi Bunch Crossing", 21, nBXMin_ - 0.5, nBXMax_ + 0.5, "Bunch crossing");
+  mapBX_ = MEMap2Inf(this, "bx", "Digi Bunch Crossing", 21, nBXMin_ - 0.5, nBXMax_ + 0.5, "Bunch crossing");
 
   mapDigiOccPerCh_ = MEMap4Inf(this, "occ", "Digi Occupancy", 1, -0.5, 1.5, 1, 0.5, 1.5, "Digi", "iEta");
 
@@ -80,8 +80,13 @@ void GEMDigiSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, 
   }
 }
 
+int GEMDigiSource::ProcessWithMEMap2(BookingHelper& bh, ME2IdsKey key) {
+  mapBX_.bookND(bh, key);
+
+  return 0;
+}
+
 int GEMDigiSource::ProcessWithMEMap2WithEta(BookingHelper& bh, ME3IdsKey key) {
-  mapBX_iEta_.bookND(bh, key);
   mapTotalDigiPerEvtIEta_.bookND(bh, key);
 
   return 0;
@@ -183,7 +188,7 @@ void GEMDigiSource::analyze(edm::Event const& event, edm::EventSetup const& even
         // Filling of bx
         Int_t nBX = std::min(std::max((Int_t)d->bx(), nBXMin_), nBXMax_);  // For under/overflow
         if (bTagVFAT.find(nIdxVFAT) == bTagVFAT.end()) {
-          mapBX_iEta_.Fill(key3IEta, nBX);
+          mapBX_.Fill(key2, nBX);
         }
 
         // Occupancy on a chamber

--- a/DQM/GEM/plugins/GEMDigiSource.cc
+++ b/DQM/GEM/plugins/GEMDigiSource.cc
@@ -8,6 +8,8 @@ GEMDigiSource::GEMDigiSource(const edm::ParameterSet& cfg) : GEMDQMBase(cfg) {
   lumiScalers_ = consumes<LumiScalersCollection>(
       cfg.getUntrackedParameter<edm::InputTag>("lumiCollection", edm::InputTag("scalersRawToDigi")));
   bModeRelVal_ = cfg.getParameter<bool>("modeRelVal");
+  nBXMin_ = cfg.getParameter<int>("bxMin");
+  nBXMax_ = cfg.getParameter<int>("bxMax");
 }
 
 void GEMDigiSource::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -15,6 +17,8 @@ void GEMDigiSource::fillDescriptions(edm::ConfigurationDescriptions& description
   desc.add<edm::InputTag>("digisInputLabel", edm::InputTag("muonGEMDigis", ""));
   desc.addUntracked<std::string>("logCategory", "GEMDigiSource");
   desc.add<bool>("modeRelVal", false);
+  desc.add<int>("bxMin", -10);
+  desc.add<int>("bxMax", 10);
   descriptions.add("GEMDigiSource", desc);
 }
 
@@ -24,10 +28,14 @@ void GEMDigiSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, 
     return;
   loadChambers();
 
-  nBXMin_ = -10;
-  nBXMax_ = 10;
+  fRadiusMin_ = 120.0;
+  fRadiusMax_ = 250.0;
+  float radS = -5.0 / 180 * M_PI;
+  float radL = 355.0 / 180 * M_PI;
 
   mapTotalDigi_layer_ = MEMap3Inf(this, "det", "Digi Occupancy", 36, 0.5, 36.5, 24, -0.5, 24 - 0.5, "Chamber", "VFAT");
+  mapDigiWheel_layer_ = MEMap3Inf(
+      this, "rphi_occ", "Digi R-Phi Occupancy", 360, radS, radL, 8, fRadiusMin_, fRadiusMax_, "#phi (rad)", "R [cm]");
   mapDigiOcc_ieta_ = MEMap3Inf(this, "occ_ieta", "Digi iEta Occupancy", 8, 0.5, 8.5, "iEta", "Number of fired digis");
   mapDigiOcc_phi_ =
       MEMap3Inf(this, "occ_phi", "Digi Phi Occupancy", 108, -5, 355, "#phi (degree)", "Number of fired digis");
@@ -39,6 +47,7 @@ void GEMDigiSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, 
                                        99.5,
                                        "Number of fired digis",
                                        "Events");
+  mapTotalDigiPerEvtLayer_.SetNoUnderOverflowBin();
   mapTotalDigiPerEvtIEta_ = MEMap3Inf(this,
                                       "digis_per_ieta",
                                       "Total number of digis per event for each eta partitions",
@@ -47,6 +56,7 @@ void GEMDigiSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, 
                                       99.5,
                                       "Number of fired digis",
                                       "Events");
+  mapTotalDigiPerEvtIEta_.SetNoUnderOverflowBin();
 
   mapBX_iEta_ = MEMap3Inf(this, "bx", "Digi Bunch Crossing", 21, nBXMin_ - 0.5, nBXMax_ + 0.5, "Bunch crossing");
 
@@ -54,6 +64,7 @@ void GEMDigiSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, 
 
   if (bModeRelVal_) {
     mapTotalDigi_layer_.TurnOff();
+    mapDigiWheel_layer_.TurnOff();
     mapDigiOccPerCh_.TurnOff();
   }
 
@@ -79,16 +90,26 @@ int GEMDigiSource::ProcessWithMEMap2WithEta(BookingHelper& bh, ME3IdsKey key) {
 int GEMDigiSource::ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) {
   MEStationInfo& stationInfo = mapStationInfo_[key];
 
+  int nNumVFATPerEta = stationInfo.nMaxVFAT_ / stationInfo.nNumEtaPartitions_;
+
   mapTotalDigi_layer_.SetBinConfX(stationInfo.nNumChambers_);
   mapTotalDigi_layer_.SetBinConfY(stationInfo.nMaxVFAT_, -0.5);
   mapTotalDigi_layer_.bookND(bh, key);
   mapTotalDigi_layer_.SetLabelForChambers(key, 1);
   mapTotalDigi_layer_.SetLabelForVFATs(key, stationInfo.nNumEtaPartitions_, 2);
 
+  mapDigiWheel_layer_.SetBinLowEdgeX(stationInfo.fMinPhi_);
+  mapDigiWheel_layer_.SetBinHighEdgeX(stationInfo.fMinPhi_ + 2 * M_PI);
+  mapDigiWheel_layer_.SetNbinsX(nNumVFATPerEta * stationInfo.nNumChambers_);
+  mapDigiWheel_layer_.SetNbinsY(stationInfo.nNumEtaPartitions_);
+  mapDigiWheel_layer_.bookND(bh, key);
+
   mapDigiOcc_ieta_.SetBinConfX(stationInfo.nNumEtaPartitions_);
   mapDigiOcc_ieta_.bookND(bh, key);
   mapDigiOcc_ieta_.SetLabelForIEta(key, 1);
 
+  mapDigiOcc_phi_.SetBinLowEdgeX(stationInfo.fMinPhi_ * 180 / M_PI);
+  mapDigiOcc_phi_.SetBinHighEdgeX(stationInfo.fMinPhi_ * 180 / M_PI + 360);
   mapDigiOcc_phi_.bookND(bh, key);
   mapTotalDigiPerEvtLayer_.bookND(bh, key);
 
@@ -125,6 +146,7 @@ void GEMDigiSource::analyze(edm::Event const& event, edm::EventSetup const& even
     ME4IdsKey key4Ch{gid.region(), gid.station(), gid.layer(), gid.chamber()};
     std::map<Int_t, bool> bTagVFAT;
     bTagVFAT.clear();
+    MEStationInfo& stationInfo = mapStationInfo_[key3];
     const BoundPlane& surface = GEMGeometry_->idToDet(gid)->surface();
     if (total_digi_layer.find(key3) == total_digi_layer.end())
       total_digi_layer[key3] = 0;
@@ -143,10 +165,14 @@ void GEMDigiSource::analyze(edm::Event const& event, edm::EventSetup const& even
         mapDigiOcc_ieta_.Fill(key3, eId.ieta());  // Eta (partition)
 
         GlobalPoint digi_global_pos = surface.toGlobal(iEta->centreOfStrip(d->strip()));
-        Float_t fPhiDeg = ((Float_t)digi_global_pos.phi()) * 180.0 / 3.141592;
-        if (fPhiDeg < -5.0)
-          fPhiDeg += 360.0;
+        Float_t fPhi = (Float_t)digi_global_pos.phi();
+        Float_t fPhiShift = restrictAngle(fPhi, stationInfo.fMinPhi_);
+        Float_t fPhiDeg = fPhiShift * 180.0 / M_PI;
         mapDigiOcc_phi_.Fill(key3, fPhiDeg);  // Phi
+
+        // Filling of R-Phi occupancy
+        Float_t fR = fRadiusMin_ + (fRadiusMax_ - fRadiusMin_) * (eId.ieta() - 0.5) / stationInfo.nNumEtaPartitions_;
+        mapDigiWheel_layer_.Fill(key3, fPhiShift, fR);
 
         mapDigiOccPerCh_.Fill(key4Ch, d->strip(), eId.ieta());  // Per chamber
 

--- a/DQM/GEM/plugins/GEMRecHitSource.cc
+++ b/DQM/GEM/plugins/GEMRecHitSource.cc
@@ -7,6 +7,7 @@ GEMRecHitSource::GEMRecHitSource(const edm::ParameterSet& cfg) : GEMDQMBase(cfg)
   tagRecHit_ = consumes<GEMRecHitCollection>(cfg.getParameter<edm::InputTag>("recHitsInputLabel"));
 
   nIdxFirstDigi_ = cfg.getParameter<int>("idxFirstDigi");
+  nCLSMax_ = cfg.getParameter<int>("clsMax");
   nClusterSizeBinNum_ = cfg.getParameter<int>("ClusterSizeBinNum");
   bModeRelVal_ = cfg.getParameter<bool>("modeRelVal");
 }
@@ -16,6 +17,7 @@ void GEMRecHitSource::fillDescriptions(edm::ConfigurationDescriptions& descripti
   desc.add<edm::InputTag>("recHitsInputLabel", edm::InputTag("gemRecHits", ""));
 
   desc.add<int>("idxFirstDigi", 0);
+  desc.add<int>("clsMax", 10);
   desc.add<int>("ClusterSizeBinNum", 9);
   desc.add<bool>("modeRelVal", false);
 
@@ -35,18 +37,17 @@ void GEMRecHitSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&
   ibooker.cd();
   ibooker.setCurrentFolder("GEM/RecHits");
 
-  nCLSMax_ = 10;
   fRadiusMin_ = 120.0;
   fRadiusMax_ = 250.0;
-  float radS = -5.0 / 180 * 3.141592;
-  float radL = 355.0 / 180 * 3.141592;
+  float radS = -5.0 / 180 * M_PI;
+  float radL = 355.0 / 180 * M_PI;
 
   mapTotalRecHit_layer_ = MEMap3Inf(this, "det", "RecHit Occupancy", 36, 0.5, 36.5, 8, 0.5, 8.5, "Chamber", "iEta");
   mapRecHitWheel_layer_ = MEMap3Inf(
-      this, "rphi_occ", "RecHit R-Phi Occupancy", 108, radS, radL, 8, fRadiusMin_, fRadiusMax_, "#phi (rad)", "R [cm]");
+      this, "rphi_occ", "RecHit R-Phi Occupancy", 360, radS, radL, 8, fRadiusMin_, fRadiusMax_, "#phi (rad)", "R [cm]");
   mapRecHitOcc_ieta_ = MEMap3Inf(this, "occ_ieta", "RecHit iEta Occupancy", 8, 0.5, 8.5, "iEta", "Number of RecHits");
   mapRecHitOcc_phi_ =
-      MEMap3Inf(this, "occ_phi", "RecHit Phi Occupancy", 108, -5, 355, "#phi (degree)", "Number of RecHits");
+      MEMap3Inf(this, "occ_phi", "RecHit Phi Occupancy", 360, -5, 355, "#phi (degree)", "Number of RecHits");
   mapTotalRecHitPerEvtLayer_ = MEMap3Inf(this,
                                          "rechits_per_layer",
                                          "Total number of RecHits per event for each layers",
@@ -55,6 +56,7 @@ void GEMRecHitSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&
                                          2000 - 0.5,
                                          "Number of RecHits",
                                          "Events");
+  mapTotalRecHitPerEvtLayer_.SetNoUnderOverflowBin();
   mapTotalRecHitPerEvtIEta_ = MEMap3Inf(this,
                                         "rechits_per_ieta",
                                         "Total number of RecHits per event for each eta partitions",
@@ -63,6 +65,7 @@ void GEMRecHitSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&
                                         300 - 0.5,
                                         "Number of RecHits",
                                         "Events");
+  mapTotalRecHitPerEvtIEta_.SetNoUnderOverflowBin();
   mapCLSRecHit_ieta_ = MEMap3Inf(
       this, "cls", "Cluster size of RecHits", nCLSMax_, 0.5, nCLSMax_ + 0.5, "Cluster size", "Number of RecHits");
   mapCLSAverage_ = MEMap3Inf(this,  // TProfile2D
@@ -95,6 +98,16 @@ void GEMRecHitSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&
   GenerateMEPerChamber(ibooker);
 }
 
+//int GEMRecHitSource::SetupRPhiPlot(ME3IdsKey key) {
+//  MEStationInfo& stationInfo = mapStationInfo_[key];
+//
+//  auto hRPhi = mapRecHitWheel_layer_.FindHist(key);
+//
+//
+//
+//  return 0;
+//}
+
 int GEMRecHitSource::ProcessWithMEMap2WithEta(BookingHelper& bh, ME3IdsKey key) {
   mapTotalRecHitPerEvtIEta_.bookND(bh, key);
 
@@ -118,17 +131,21 @@ int GEMRecHitSource::ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) {
   mapTotalRecHit_layer_.SetLabelForChambers(key, 1);
   mapTotalRecHit_layer_.SetLabelForIEta(key, 2);
 
-  mapRecHitWheel_layer_.SetBinLowEdgeX(-0.088344);  // FIXME: It could be different for other stations...
-  mapRecHitWheel_layer_.SetBinHighEdgeX(-0.088344 + 2 * 3.141592);
+  mapRecHitWheel_layer_.SetBinLowEdgeX(stationInfo.fMinPhi_);
+  mapRecHitWheel_layer_.SetBinHighEdgeX(stationInfo.fMinPhi_ + 2 * M_PI);
   mapRecHitWheel_layer_.SetNbinsX(nNumVFATPerEta * stationInfo.nNumChambers_);
   mapRecHitWheel_layer_.SetNbinsY(stationInfo.nNumEtaPartitions_);
   mapRecHitWheel_layer_.bookND(bh, key);
+  //SetupRPhiPlot(key);
 
   mapRecHitOcc_ieta_.SetBinConfX(stationInfo.nNumEtaPartitions_);
   mapRecHitOcc_ieta_.bookND(bh, key);
   mapRecHitOcc_ieta_.SetLabelForIEta(key, 1);
 
+  mapRecHitOcc_phi_.SetBinLowEdgeX(stationInfo.fMinPhi_ * 180 / M_PI);
+  mapRecHitOcc_phi_.SetBinHighEdgeX(stationInfo.fMinPhi_ * 180 / M_PI + 360);
   mapRecHitOcc_phi_.bookND(bh, key);
+
   mapTotalRecHitPerEvtLayer_.bookND(bh, key);
 
   mapCLSAverage_.bookND(bh, key);
@@ -184,21 +201,20 @@ void GEMRecHitSource::analyze(edm::Event const& event, edm::EventSetup const& ev
       for (auto hit = gemRecHit; hit != recHitsRange.second; ++hit) {
         GlobalPoint recHitGP = GEMGeometry_->idToDet(hit->gemId())->surface().toGlobal(hit->localPosition());
         Float_t fPhi = recHitGP.phi();
-        if (fPhi < -5.0 / 180.0 * 3.141592)
-          fPhi += 2 * 3.141592;
 
         // Filling of RecHit occupancy
         mapTotalRecHit_layer_.Fill(key3, chamber, eId.ieta());
 
         // Filling of R-Phi occupancy
         Float_t fR = fRadiusMin_ + (fRadiusMax_ - fRadiusMin_) * (eId.ieta() - 0.5) / stationInfo.nNumEtaPartitions_;
-        mapRecHitWheel_layer_.Fill(key3, fPhi, fR);
+        Float_t fPhiShift = restrictAngle(fPhi, stationInfo.fMinPhi_);
+        Float_t fPhiDeg = fPhiShift * 180.0 / M_PI;
+        mapRecHitWheel_layer_.Fill(key3, fPhiShift, fR);
 
         // Filling of RecHit (iEta)
         mapRecHitOcc_ieta_.Fill(key3, eId.ieta());
 
         // Filling of RecHit (phi)
-        Float_t fPhiDeg = fPhi * 180.0 / 3.141592;
         mapRecHitOcc_phi_.Fill(key3, fPhiDeg);
 
         // For total RecHits

--- a/DQM/GEM/src/GEMDQMBase.cc
+++ b/DQM/GEM/src/GEMDQMBase.cc
@@ -86,6 +86,7 @@ int GEMDQMBase::loadChambers() {
         ME3IdsKey key3(region_number, station_number, layer_number);
         mapStationInfo_[key3] =
             MEStationInfo(region_number, station_number, layer_number, num_superchambers, num_etas, num_vfat, num_digi);
+        mapStationInfo_[key3].fMinPhi_ = -0.088344;  // FIXME
       }
     }
   }
@@ -211,8 +212,8 @@ int GEMDQMBase::GenerateMEPerChamber(DQMStore::IBooker& ibooker) {
         MEMap2WithEtaCheck_[key2WithEta] = true;
       }
       if (!MEMap2AbsReWithEtaCheck_[key2AbsReWithEta]) {
-        auto strSuffixName = Form("_GE%i%i-E%02i", std::abs(gid.region()), gid.station(), eId.ieta());
-        auto strSuffixTitle = Form(" GE%i%i-E%02i", std::abs(gid.region()), gid.station(), eId.ieta());
+        auto strSuffixName = Form("_GE%d1-E%02i", gid.station(), eId.ieta());
+        auto strSuffixTitle = Form(" GE%d1-E%02i", gid.station(), eId.ieta());
         BookingHelper bh3(ibooker, strSuffixName, strSuffixTitle);
         ProcessWithMEMap2AbsReWithEta(bh3, key2AbsReWithEta);
         MEMap2AbsReWithEtaCheck_[key2AbsReWithEta] = true;


### PR DESCRIPTION
#### PR description:
Some requests on r-phi distributions are applied; finer binning on phi direction, more plots for digi.

Also, the under/overflow bins of 1D histograms are not displayed well. It has been fixed.

#### PR validation:
Tests are done and one can check again by `runTheMatrix` workflows

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
This is a backport of #36230 and #36253 to CMSSW_12_0_X to be deployed on the current runs

@jshlee @watson-ij 