### PR TITLE
Add label for SiPixelQualityRcd in RawToDigi

### DIFF
--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelQualityESProducer.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelQualityESProducer.cc
@@ -79,7 +79,7 @@ SiPixelQualityESProducer::SiPixelQualityESProducer(const edm::ParameterSet& conf
   auto label =
       conf_.exists("siPixelQualityLabel") ? conf_.getParameter<std::string>("siPixelQualityLabel") : std::string{};
 
-  if (label == "forDigitizer") {
+  if (label == "forDigitizer" || label == "forRawToDigi") {
     labelTokens_ =
         Tokens(setWhatProduced(this, &SiPixelQualityESProducer::produceWithLabel, edm::es::Label(label)), label);
   }

--- a/CalibTracker/SiPixelESProducers/python/SiPixelQualityESProducer_cfi.py
+++ b/CalibTracker/SiPixelESProducers/python/SiPixelQualityESProducer_cfi.py
@@ -3,3 +3,9 @@ import FWCore.ParameterSet.Config as cms
 siPixelQualityESProducer = cms.ESProducer("SiPixelQualityESProducer",
     siPixelQualityLabel = cms.string(""),
 )
+
+from Configuration.ProcessModifiers.siPixelQualityRawToDigi_cff import siPixelQualityRawToDigi
+siPixelQualityRawToDigi.toModify(siPixelQualityESProducer,
+    siPixelQualityLabel = 'forRawToDigi',
+)
+

--- a/Configuration/ProcessModifiers/python/siPixelQualityRawToDigi_cff.py
+++ b/Configuration/ProcessModifiers/python/siPixelQualityRawToDigi_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+# This modifier is to run the SiPixelQualityRawToDigi
+siPixelQualityRawToDigi =  cms.Modifier()

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.cc
@@ -107,7 +107,7 @@ SiPixelRawToDigi::SiPixelRawToDigi(const edm::ParameterSet& conf)
 
 {
   if (useQuality_) {
-    siPixelQualityToken_ = esConsumes<SiPixelQuality, SiPixelQualityRcd>();
+    siPixelQualityToken_ = esConsumes<SiPixelQuality, SiPixelQualityRcd>(edm::ESInputTag("", config_.getParameter<std::string>("SiPixelQualityLabel")));
   }
 
   // Products
@@ -164,7 +164,8 @@ void SiPixelRawToDigi::fillDescriptions(edm::ConfigurationDescriptions& descript
   desc.add<bool>("UsePilotBlade", false)->setComment("##  Use pilot blades");
   desc.add<bool>("UsePhase1", false)->setComment("##  Use phase1");
   desc.add<std::string>("CablingMapLabel", "")->setComment("CablingMap label");  //Tav
-  descriptions.add("siPixelRawToDigi", desc);
+  desc.add<std::string>("SiPixelQualityLabel", "")->setComment("SiPixelQuality label");
+  descriptions.add("siPixelRawToDigi", desc);  
 }
 
 // -----------------------------------------------------------------------------

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.cc
@@ -107,7 +107,8 @@ SiPixelRawToDigi::SiPixelRawToDigi(const edm::ParameterSet& conf)
 
 {
   if (useQuality_) {
-    siPixelQualityToken_ = esConsumes<SiPixelQuality, SiPixelQualityRcd>(edm::ESInputTag("", config_.getParameter<std::string>("SiPixelQualityLabel")));
+    siPixelQualityToken_ = esConsumes<SiPixelQuality, SiPixelQualityRcd>(
+        edm::ESInputTag("", config_.getParameter<std::string>("SiPixelQualityLabel")));
   }
 
   // Products
@@ -165,7 +166,7 @@ void SiPixelRawToDigi::fillDescriptions(edm::ConfigurationDescriptions& descript
   desc.add<bool>("UsePhase1", false)->setComment("##  Use phase1");
   desc.add<std::string>("CablingMapLabel", "")->setComment("CablingMap label");  //Tav
   desc.add<std::string>("SiPixelQualityLabel", "")->setComment("SiPixelQuality label");
-  descriptions.add("siPixelRawToDigi", desc);  
+  descriptions.add("siPixelRawToDigi", desc);
 }
 
 // -----------------------------------------------------------------------------

--- a/EventFilter/SiPixelRawToDigi/python/SiPixelRawToDigi_cfi.py
+++ b/EventFilter/SiPixelRawToDigi/python/SiPixelRawToDigi_cfi.py
@@ -19,10 +19,6 @@ siPixelQualityRawToDigi.toModify(siPixelDigis.cpu,
     UseQualityInfo = True,                         
     SiPixelQualityLabel = 'forRawToDigi',
 )
-from CalibTracker.SiPixelESProducers.SiPixelQualityESProducer_cfi import siPixelQualityESProducer
-siPixelQualityRawToDigi.toModify(siPixelQualityESProducer, 
-    siPixelQualityLabel = 'forRawToDigi', 
-)
 
 
 # SwitchProducer wrapping the legacy pixel digis producer or an alias combining the pixel digis information converted from SoA

--- a/EventFilter/SiPixelRawToDigi/python/SiPixelRawToDigi_cfi.py
+++ b/EventFilter/SiPixelRawToDigi/python/SiPixelRawToDigi_cfi.py
@@ -14,6 +14,17 @@ phase1Pixel.toModify(siPixelDigis.cpu,
     UsePhase1 = True
 )
 
+from Configuration.ProcessModifiers.siPixelQualityRawToDigi_cff import siPixelQualityRawToDigi
+siPixelQualityRawToDigi.toModify(siPixelDigis.cpu,  
+    UseQualityInfo = True,                         
+    SiPixelQualityLabel = 'forRawToDigi',
+)
+from CalibTracker.SiPixelESProducers.SiPixelQualityESProducer_cfi import siPixelQualityESProducer
+siPixelQualityRawToDigi.toModify(siPixelQualityESProducer, 
+    siPixelQualityLabel = 'forRawToDigi', 
+)
+
+
 # SwitchProducer wrapping the legacy pixel digis producer or an alias combining the pixel digis information converted from SoA
 gpu.toModify(siPixelDigis,
     cuda = cms.EDAlias(


### PR DESCRIPTION
#### PR description:

This PR introduces a label for SiPixelQualityRcd used in RawToDigi ("forRawToDigi"). This allows to switch off different (number of) ROCs than are there in the unlabelled payload.
 
By default, variable UseQualityInfo, that governs SiPixelQuality usage, is set to false. A modifier is introduced to activate SiPixelQuality usage with the labelled payload (a new GT containing SiPixelQualityRcd with the label "forRawToDigi" is needed).

We plan to use this mechanism in the ReReco of Pilot Run data to suppress fake tracks arising from the noisy FPix ROCs.   

No changes are expected.

#### PR validation:

The PR has passed a basic set of tests (runTheMatrix.py -l limited -i all --ibeos).
