### PR TITLE
Calo-L1 unpacker modified to read 5BX payload format

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Unpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Unpacker.cc
@@ -31,17 +31,14 @@ namespace l1t {
         makeHFTPGs(ctp7_phi, ctp7Data, res->getHcalDigis());
         makeRegions(ctp7_phi, ctp7Data, res->getRegions());
       } else if (N_BX == 5) {
-        const uint32_t* ptr5 = ptr;
-        ptr += 192 * 2;
-        UCTCTP7RawData ctp7Data(ptr);
-        makeECalTPGs(ctp7_phi, ctp7Data, res->getEcalDigis());
-        makeHCalTPGs(ctp7_phi, ctp7Data, res->getHcalDigis());
-        makeHFTPGs(ctp7_phi, ctp7Data, res->getHcalDigis());
-        makeRegions(ctp7_phi, ctp7Data, res->getRegions());
+        UCTCTP7RawData5BX ctp7Data5BX(ptr);
+        // BX_n = 0, 1, 2, 3, 4, where 2 is nominal
+        makeECalTPGs5BX(ctp7_phi, ctp7Data5BX, res->getEcalDigis(), 2);
+        makeHCalTPGs5BX(ctp7_phi, ctp7Data5BX, res->getHcalDigis(), 2);
+        makeHFTPGs5BX(ctp7_phi, ctp7Data5BX, res->getHcalDigis(), 2);
+        makeRegions5BX(ctp7_phi, ctp7Data5BX, res->getRegions(), 2);
         for (int i = 0; i < 5; i++) {
-          UCTCTP7RawData ctp7Data(ptr5);
-          makeECalTPGs(ctp7_phi, ctp7Data, res->getEcalDigisBx(i));
-          ptr5 += 192;
+          makeECalTPGs5BX(ctp7_phi, ctp7Data5BX, res->getEcalDigisBx(i), i);
         }
       } else {
         LogError("CaloLayer1Unpacker") << "Number of BXs to unpack is not 1 or 5, stop here !!! " << N_BX << std::endl;
@@ -219,6 +216,195 @@ namespace l1t {
           negativeEta = true;
         for (uint32_t region = 0; region <= 6; region++) {
           uint32_t regionData = ctp7Data.getRegionSummary(negativeEta, region);
+          uint32_t lEta = 10 - region;  // GCT eta goes 0-21, 0-3 -HF, 4-10 -B/E, 11-17 +B/E, 18-21 +HF
+          if (!negativeEta)
+            lEta = region + 11;
+          regions->push_back(L1CaloRegion((uint16_t)regionData, (unsigned)lEta, (unsigned)lPhi, (int16_t)0));
+        }
+      }
+    }
+
+    // The following four functions are duplicated from above, to be used for 5BX events
+    // They have a new parameter BX_n = 0, 1, 2, 3, 4, where 2 is nominal
+    // And use functions defined in UCTCTP7RawData5BX.h
+    // The idea is not to intervene the normal events unpacking
+
+    void CaloLayer1Unpacker::makeECalTPGs5BX(uint32_t lPhi,
+                                             UCTCTP7RawData5BX& ctp7Data5BX,
+                                             EcalTrigPrimDigiCollection* ecalTPGs,
+                                             uint32_t BX_n) {
+      UCTCTP7RawData5BX::CaloType cType = UCTCTP7RawData5BX::EBEE;
+      for (uint32_t iPhi = 0; iPhi < 4; iPhi++) {  // Loop over all four phi divisions on card
+        int cPhi = -1 + lPhi * 4 + iPhi;           // Calorimeter phi index
+        if (cPhi == 0)
+          cPhi = 72;
+        else if (cPhi == -1)
+          cPhi = 71;
+        else if (cPhi < -1) {
+          LogError("CaloLayer1Unpacker") << "Major error in makeECalTPGs5BX" << std::endl;
+          return;
+        }
+        for (int cEta = -28; cEta <= 28; cEta++) {  // Calorimeter Eta indices (HB/HE for now)
+          if (cEta != 0) {                          // Calorimeter eta = 0 is invalid
+            bool negativeEta = false;
+            if (cEta < 0)
+              negativeEta = true;
+            uint32_t iEta = abs(cEta);
+            // This code is fragile! Note that towerDatum is packed as is done in EcalTriggerPrimitiveSample
+            // Bottom 8-bits are ET
+            // Then finegrain feature bit
+            // Then three bits have ttBits, which I have no clue about (not available on ECAL links so not set)
+            // Then there is a spare FG Veto bit, which is used for L1 spike detection (not available on ECAL links so not set)
+            // Top three bits seem to be unused. So, we steal those to set the tower masking, link masking and link status information
+            // To decode these custom three bits use ((EcalTriggerPrimitiveSample::raw() >> 13) & 0x7)
+            uint32_t towerDatum = ctp7Data5BX.getET(cType, negativeEta, iEta, iPhi, BX_n);
+            if (ctp7Data5BX.getFB(cType, negativeEta, iEta, iPhi, BX_n) != 0)
+              towerDatum |= 0x0100;
+            if (ctp7Data5BX.isTowerMasked(cType, negativeEta, iEta, iPhi, BX_n))
+              towerDatum |= 0x2000;
+            if (ctp7Data5BX.isLinkMasked(cType, negativeEta, iEta, iPhi, BX_n))
+              towerDatum |= 0x4000;
+            if (ctp7Data5BX.isLinkMisaligned(cType, negativeEta, iEta, iPhi, BX_n) ||
+                ctp7Data5BX.isLinkInError(cType, negativeEta, iEta, iPhi, BX_n) ||
+                ctp7Data5BX.isLinkDown(cType, negativeEta, iEta, iPhi, BX_n))
+              towerDatum |= 0x8000;
+            EcalTriggerPrimitiveSample sample(towerDatum);
+            int zSide = cEta / ((int)iEta);
+            // As far as I can tell, the ECal unpacker only uses barrel and endcap IDs, never EcalTriggerTower
+            const EcalSubdetector ecalTriggerTower =
+                (iEta > 17) ? EcalSubdetector::EcalEndcap : EcalSubdetector::EcalBarrel;
+            EcalTrigTowerDetId id(zSide, ecalTriggerTower, iEta, cPhi);
+            EcalTriggerPrimitiveDigi tpg(id);
+            tpg.setSize(1);
+            tpg.setSample(0, sample);
+            ecalTPGs->push_back(tpg);
+          }
+        }
+      }
+    }
+
+    void CaloLayer1Unpacker::makeHCalTPGs5BX(uint32_t lPhi,
+                                             UCTCTP7RawData5BX& ctp7Data5BX,
+                                             HcalTrigPrimDigiCollection* hcalTPGs,
+                                             uint32_t BX_n) {
+      UCTCTP7RawData5BX::CaloType cType = UCTCTP7RawData5BX::HBHE;
+      for (uint32_t iPhi = 0; iPhi < 4; iPhi++) {  // Loop over all four phi divisions on card
+        int cPhi = -1 + lPhi * 4 + iPhi;           // Calorimeter phi index
+        if (cPhi == 0)
+          cPhi = 72;
+        else if (cPhi == -1)
+          cPhi = 71;
+        else if (cPhi < -1) {
+          LogError("CaloLayer1Unpacker") << "Major error in makeHCalTPGs5BX" << std::endl;
+          return;
+        }
+        for (int cEta = -28; cEta <= 28; cEta++) {  // Calorimeter Eta indices (HB/HE for now)
+          if (cEta != 0) {                          // Calorimeter eta = 0 is invalid
+            bool negativeEta = false;
+            if (cEta < 0)
+              negativeEta = true;
+            uint32_t iEta = abs(cEta);
+            // This code is fragile! Note that towerDatum is packed as is done in HcalTriggerPrimitiveSample
+            // Bottom 8-bits are ET
+            // Then feature bit
+            // The remaining bits are undefined presently
+            // We use next three bits for link details, which we did not have room in EcalTriggerPrimitiveSample case
+            // We use next three bits to set the tower masking, link masking and link status information as done for Ecal
+            // To decode these custom six bits use ((EcalTriggerPrimitiveSample::raw() >> 9) & 0x77)
+            uint32_t towerDatum = ctp7Data5BX.getET(cType, negativeEta, iEta, iPhi, BX_n);
+            if (ctp7Data5BX.getFB(cType, negativeEta, iEta, iPhi, BX_n) != 0)
+              towerDatum |= 0x0100;
+            if (ctp7Data5BX.isLinkMisaligned(cType, negativeEta, iEta, iPhi, BX_n))
+              towerDatum |= 0x0200;
+            if (ctp7Data5BX.isLinkInError(cType, negativeEta, iEta, iPhi, BX_n))
+              towerDatum |= 0x0400;
+            if (ctp7Data5BX.isLinkDown(cType, negativeEta, iEta, iPhi, BX_n))
+              towerDatum |= 0x0800;
+            if (ctp7Data5BX.isTowerMasked(cType, negativeEta, iEta, iPhi, BX_n))
+              towerDatum |= 0x2000;
+            if (ctp7Data5BX.isLinkMasked(cType, negativeEta, iEta, iPhi, BX_n))
+              towerDatum |= 0x4000;
+            if (ctp7Data5BX.isLinkMisaligned(cType, negativeEta, iEta, iPhi, BX_n) ||
+                ctp7Data5BX.isLinkInError(cType, negativeEta, iEta, iPhi, BX_n) ||
+                ctp7Data5BX.isLinkDown(cType, negativeEta, iEta, iPhi, BX_n))
+              towerDatum |= 0x8000;
+            HcalTriggerPrimitiveSample sample(towerDatum);
+            HcalTrigTowerDetId id(cEta, cPhi);
+            HcalTriggerPrimitiveDigi tpg(id);
+            tpg.setSize(1);
+            tpg.setSample(0, sample);
+            hcalTPGs->push_back(tpg);
+          }
+        }
+      }
+    }
+
+    void CaloLayer1Unpacker::makeHFTPGs5BX(uint32_t lPhi,
+                                           UCTCTP7RawData5BX& ctp7Data5BX,
+                                           HcalTrigPrimDigiCollection* hcalTPGs,
+                                           uint32_t BX_n) {
+      UCTCTP7RawData5BX::CaloType cType = UCTCTP7RawData5BX::HF;
+      for (uint32_t side = 0; side <= 1; side++) {
+        bool negativeEta = false;
+        if (side == 0)
+          negativeEta = true;
+        for (uint32_t iEta = 30; iEta <= 40; iEta++) {
+          for (uint32_t iPhi = 0; iPhi < 2; iPhi++) {
+            if (iPhi == 1 && iEta == 40)
+              iEta = 41;
+            int cPhi = 1 + lPhi * 4 + iPhi * 2;  // Calorimeter phi index: 1, 3, 5, ... 71
+            if (iEta == 41)
+              cPhi -= 2;                  // Last two HF are 3, 7, 11, ...
+            cPhi = (cPhi + 69) % 72 + 1;  // cPhi -= 2 mod 72
+            int cEta = iEta;
+            if (negativeEta)
+              cEta = -iEta;
+            // This code is fragile! Note that towerDatum is packed as is done in HcalTriggerPrimitiveSample
+            // Bottom 8-bits are ET
+            // Then feature bit
+            // Then minBias ADC count bit
+            // The remaining bits are undefined presently
+            // We use next three bits for link details, which we did not have room in EcalTriggerPrimitiveSample case
+            // We use next three bits to set the tower masking, link masking and link status information as done for Ecal
+            // To decode these custom six bits use ((EcalTriggerPrimitiveSample::raw() >> 9) & 0x77)
+            uint32_t towerDatum = ctp7Data5BX.getET(cType, negativeEta, iEta, iPhi, BX_n);
+            towerDatum |= ctp7Data5BX.getFB(cType, negativeEta, iEta, iPhi, BX_n) << 8;
+            if (ctp7Data5BX.isLinkMisaligned(cType, negativeEta, iEta, iPhi, BX_n))
+              towerDatum |= 0x0400;
+            if (ctp7Data5BX.isLinkInError(cType, negativeEta, iEta, iPhi, BX_n))
+              towerDatum |= 0x0800;
+            if (ctp7Data5BX.isLinkDown(cType, negativeEta, iEta, iPhi, BX_n))
+              towerDatum |= 0x1000;
+            if (ctp7Data5BX.isTowerMasked(cType, negativeEta, iEta, iPhi, BX_n))
+              towerDatum |= 0x2000;
+            if (ctp7Data5BX.isLinkMasked(cType, negativeEta, iEta, iPhi, BX_n))
+              towerDatum |= 0x4000;
+            if (ctp7Data5BX.isLinkMisaligned(cType, negativeEta, iEta, iPhi, BX_n) ||
+                ctp7Data5BX.isLinkInError(cType, negativeEta, iEta, iPhi, BX_n) ||
+                ctp7Data5BX.isLinkDown(cType, negativeEta, iEta, iPhi, BX_n))
+              towerDatum |= 0x8000;
+            HcalTriggerPrimitiveSample sample(towerDatum);
+            HcalTrigTowerDetId id(cEta, cPhi);
+            id.setVersion(1);  // To not process these 1x1 HF TPGs with RCT
+            HcalTriggerPrimitiveDigi tpg(id);
+            tpg.setSize(1);
+            tpg.setSample(0, sample);
+            hcalTPGs->push_back(tpg);
+          }
+        }
+      }
+    }
+
+    void CaloLayer1Unpacker::makeRegions5BX(uint32_t lPhi,
+                                            UCTCTP7RawData5BX& ctp7Data5BX,
+                                            L1CaloRegionCollection* regions,
+                                            uint32_t BX_n) {
+      for (uint32_t side = 0; side <= 1; side++) {
+        bool negativeEta = false;
+        if (side == 0)
+          negativeEta = true;
+        for (uint32_t region = 0; region <= 6; region++) {
+          uint32_t regionData = ctp7Data5BX.getRegionSummary(negativeEta, region, BX_n);
           uint32_t lEta = 10 - region;  // GCT eta goes 0-21, 0-3 -HF, 4-10 -B/E, 11-17 +B/E, 18-21 +HF
           if (!negativeEta)
             lEta = region + 11;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Unpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Unpacker.h
@@ -4,6 +4,7 @@
 #include "EventFilter/L1TRawToDigi/interface/Unpacker.h"
 #include "CaloLayer1Collections.h"
 #include "UCTCTP7RawData.h"
+#include "UCTCTP7RawData5BX.h"
 
 namespace l1t {
   namespace stage2 {
@@ -16,6 +17,19 @@ namespace l1t {
       void makeHCalTPGs(uint32_t lPhi, UCTCTP7RawData& ctp7Data, HcalTrigPrimDigiCollection* hcalTPGs);
       void makeHFTPGs(uint32_t lPhi, UCTCTP7RawData& ctp7Data, HcalTrigPrimDigiCollection* hcalTPGs);
       void makeRegions(uint32_t lPhi, UCTCTP7RawData& ctp7Data, L1CaloRegionCollection* regions);
+      void makeECalTPGs5BX(uint32_t lPhi,
+                           UCTCTP7RawData5BX& ctp7Data5BX,
+                           EcalTrigPrimDigiCollection* ecalTPGs,
+                           uint32_t BX_n);
+      void makeHCalTPGs5BX(uint32_t lPhi,
+                           UCTCTP7RawData5BX& ctp7Data5BX,
+                           HcalTrigPrimDigiCollection* hcalTPGs,
+                           uint32_t BX_n);
+      void makeHFTPGs5BX(uint32_t lPhi,
+                         UCTCTP7RawData5BX& ctp7Data5BX,
+                         HcalTrigPrimDigiCollection* hcalTPGs,
+                         uint32_t BX_n);
+      void makeRegions5BX(uint32_t lPhi, UCTCTP7RawData5BX& ctp7Data5BX, L1CaloRegionCollection* regions, uint32_t BX_n);
     };
   }  // namespace stage2
 }  // namespace l1t

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/UCTCTP7RawData5BX.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/UCTCTP7RawData5BX.h
@@ -1,0 +1,347 @@
+#ifndef UCTCTP7RawData_hh
+#define UCTCTP7RawData_hh
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/MessageLogger/interface/MessageDrop.h"
+
+class UCTCTP7RawData {
+public:
+  enum CaloType { EBEE = 0, HBHE, HF };
+
+  // read-only constructor
+  UCTCTP7RawData(const uint32_t* d) : myDataPtr(d) {
+    if (myDataPtr == nullptr) {
+      edm::LogError("UCTCTP7RawData") << "You gave me a nullptr :<";
+    }
+  }
+  // read-write constructor, caller must allocate 192*sizeof(uint32_t) bytes
+  UCTCTP7RawData(uint32_t* d) : myDataPtr(d), myDataWritePtr(d) {
+    if (myDataPtr == nullptr) {
+      edm::LogError("UCTCTP7RawData") << "You gave me a nullptr :<";
+    }
+  }
+
+  // No copy constructor and equality operator are needed
+  UCTCTP7RawData(const UCTCTP7RawData&) = delete;
+  const UCTCTP7RawData& operator=(const UCTCTP7RawData& i) = delete;
+
+  virtual ~UCTCTP7RawData() { ; }
+
+  // Access functions for convenience
+
+  const uint32_t* dataPtr() const { return myDataPtr; }
+
+  uint32_t sof() { return myDataPtr[0]; }
+
+  size_t getIndex(CaloType cType, bool negativeEta, uint32_t cEta, uint32_t iPhi) {
+    size_t index = 0;
+    if (cType == EBEE || cType == HBHE) {
+      if (iPhi > 3) {
+        edm::LogError("UCTCTP7RawData") << "Incorrect iPhi; iPhi = " << iPhi << "; should be in [0,3]";
+        return index;
+      }
+      if (cEta < 1 || cEta > 28) {
+        edm::LogError("UCTCTP7RawData") << "Incorrect caloEta; cEta = " << cEta << "; should be in [1-28]";
+        return index;
+      }
+      // ECAL/HB+HE fragment size is 3 32-bit words
+      // Each fragment covers 2 eta and 4 phi towers
+      // All four phi towers are in one 32-bit word
+      // Even and odd eta are in neighboring 32-bit words
+      index = (((cEta - 1) / 2) * (3 + 3) + ((cEta - 1) % 2));
+      // But, towers are arranged in a peculiar order for firmware
+      // convenience - the index needs to be computing with these
+      // if statements.  This is brittle code that one should be
+      // very careful with.
+      if (negativeEta) {
+        // Add offset for 6 ECAL and 6 HCAL fragments
+        index += (6 * (3 + 3));
+      } else {
+        if (cEta > 12) {
+          // Add offset for 14 ECAL, 14 HB+HE and 2 HF fragments
+          // Note that first six are included in the definition of
+          // the variable - index
+          // Note also that HF fragments are larger at 4 32-bit words
+          index += ((14 * (3 + 3) + (2 * 4)));
+        }
+      }
+      // Data starts with ECAL towers so offset by 3 additional 32-bit words
+      if (cType == HBHE)
+        index += 3;
+    } else if (cType == HF) {
+      if (iPhi > 1) {
+        edm::LogError("UCTCTP7RawData") << "HF iPhi should be 0 or 1 (for a , b) - invalid iPhi  = " << iPhi;
+        return index;
+      }
+      if (cEta < 30 || cEta > 41) {
+        edm::LogError("UCTCTP7RawData") << "HF cEta should be between 30 and 41 - invalid cEta = " << cEta;
+        return index;
+      }
+      if (negativeEta) {
+        if (iPhi == 0) {
+          // Offset by 6 positive eta and 14 negative eta EBEE/HBHE fragments (each 3 32-bit words)
+          // There are four HF cEta towers packed in each 32-bit word
+          // Add additional offset of 1 for (34-37) and 2 for (38-41)
+          index = 20 * (3 + 3) + ((cEta - 30) / 4);
+        } else {
+          // Additional HF a fragment offset for HF b channel
+          index = 20 * (3 + 3) + 1 * 4 + ((cEta - 30) / 4);
+        }
+      } else {
+        if (iPhi == 0) {
+          // Offset by all EBEE/HBHE and two HF fragments (4 32-bit words)
+          index = 2 * 14 * (3 + 3) + 2 * 4 + ((cEta - 30) / 4);
+        } else {
+          // Additional HF a fragment offset for HF b channel
+          index = 2 * 14 * (3 + 3) + 3 * 4 + ((cEta - 30) / 4);
+        }
+      }
+    } else {
+      edm::LogError("UCTCTP7RawData") << "Unknown CaloType " << cType;
+      return index;
+    }
+    if (index >= 192) {
+      edm::LogError("UCTCTP7RawData") << "Managed to calculate an out-of-bounds index, buyer beware";
+    }
+    return index;
+  }
+
+  size_t getFeatureIndex(CaloType cType, bool negativeEta, uint32_t cEta, uint32_t iPhi) {
+    // Get index into the data words for the tower
+    size_t index = getIndex(cType, negativeEta, cEta, iPhi);
+    if (cType == EBEE || cType == HBHE) {
+      // Two 32-bit words contain ET, so we should offset the index to
+      // to the feature and link status bits
+      if (((cEta - 1) % 2) == 0) {
+        // [index] is offset to ET of first four towers (0 - 3)
+        // [index + 2] is where the feature and link status bits are
+        index += 2;
+      } else {
+        // In this case [index] is offset to ET of second four towers (4 - 7)
+        // [index + 1] is where the feature and link status bits are
+        index += 1;
+      }
+    } else if (cType == HF) {
+      // HF Fragment has different structure than EBEE and HBHE fragments
+      // First three 32-bit words have ETs for 11 objects (yes, 11 not 12)
+      // cEta = 40 / 41 are double in eta and flop bettween a and b HF fragments
+      // Further the remaining upper byte of the third word actually has feature
+      // bits.  This feature index will point to the 4th 32-bit word.  It is
+      // expected that the top byte from 3rd 32-bit word will be patched in within
+      // the feature bit access function.
+      // Since there are three instead of if block as above for EBEE, HBHE
+      // I wrote here a more compact implementation of index computation.
+      index += (3 - ((cEta - 30) / 4));
+      if (index == 0) {
+        // Since we sticth index-1, zero is also illegal
+        edm::LogError("UCTCTP7RawData") << "Managed to calculate an out-of-bounds index, buyer beware";
+      }
+    } else {
+      // Unknown calotype error already generated in getIndex()
+      return 0;
+    }
+    if (index >= 192) {
+      edm::LogError("UCTCTP7RawData") << "Managed to calculate an out-of-bounds index, buyer beware";
+    }
+    return index;
+  }
+
+  void setET(CaloType cType, bool negativeEta, uint32_t cEta, uint32_t iPhi, uint32_t et) {
+    if (myDataWritePtr == nullptr) {
+      edm::LogError("UCTCTP7RawData") << "I was made in read-only mode";
+      return;
+    }
+    size_t index = getIndex(cType, negativeEta, cEta, iPhi);
+    uint32_t& data = myDataWritePtr[index];
+    if (cType == HF) {
+      // Pick out the correct 8-bits for the iEta chosen
+      // Note that cEta = 41 is special, it only occurs for iPhi == 1 and shares cEta = 40 position
+      if (cEta == 41) {
+        data |= (et & 0xFF) << 16;
+      } else {
+        data |= (et & 0xFF) << (((cEta - 30) % 4) * 8);
+      }
+    } else {
+      // Pick out the correct 8-bits for the iPhi chosen
+      data |= (et & 0xFF) << (iPhi * 8);
+    }
+  }
+
+  uint32_t getET(CaloType cType, bool negativeEta, uint32_t cEta, uint32_t iPhi) {
+    size_t index = getIndex(cType, negativeEta, cEta, iPhi);
+    const uint32_t data = myDataPtr[index];
+    uint32_t et = 0xDEADBEEF;
+    if (cType == HF) {
+      // Pick out the correct 8-bits for the iEta chosen
+      // Note that cEta = 41 is special, it only occurs for iPhi == 1 and shares cEta = 40 position
+      if (cEta == 41)
+        et = ((data >> 16) & 0xFF);
+      else
+        et = ((data >> ((cEta - 30) % 4) * 8) & 0xFF);
+    } else {
+      // Pick out the correct 8-bits for the iPhi chosen
+      et = ((data >> (iPhi * 8)) & 0xFF);
+    }
+    return et;
+  }
+
+  void setFB(CaloType cType, bool negativeEta, uint32_t cEta, uint32_t iPhi, uint32_t fb) {
+    if (myDataWritePtr == nullptr) {
+      edm::LogError("UCTCTP7RawData") << "I was made in read-only mode";
+      return;
+    }
+    if (cType == HF) {
+      setHFFeatureBits(negativeEta, cEta, iPhi, fb);
+    } else {
+      size_t index = getFeatureIndex(cType, negativeEta, cEta, iPhi);
+      uint32_t& data = myDataWritePtr[index];
+
+      uint32_t tower = iPhi;
+      if (((cEta - 1) % 2) == 1) {
+        tower += 4;
+      }
+      data |= (fb & 0x1) << tower;
+    }
+  }
+
+  uint32_t getFB(CaloType cType, bool negativeEta, uint32_t cEta, uint32_t iPhi) {
+    size_t index = getFeatureIndex(cType, negativeEta, cEta, iPhi);
+    const uint32_t data = myDataPtr[index];
+    uint32_t fb = 0;
+    if (cType == HF) {
+      fb = getHFFeatureBits(negativeEta, cEta, iPhi);
+    } else {
+      // Pick out the correct bit for the tower chosen
+      uint32_t tower = iPhi;
+      if (((cEta - 1) % 2) == 1) {
+        tower += 4;
+      }
+      fb = ((data & (0x1 << tower)) != 0) ? 1 : 0;
+    }
+    return fb;
+  }
+
+  void setHFFeatureBits(bool negativeEta, uint32_t cEta, uint32_t iPhi, uint32_t fb) {
+    if (myDataWritePtr == nullptr) {
+      edm::LogError("UCTCTP7RawData") << "I was made in read-only mode";
+      return;
+    }
+    size_t index = getFeatureIndex(HF, negativeEta, cEta, iPhi);
+    uint32_t shift = (cEta - 30) * 2;
+    if (cEta == 41)
+      shift = 20;  // 41 occurs on b-fiber but shares the position of 40
+    if (shift >= 8) {
+      uint32_t& data = myDataWritePtr[index];
+      data |= (fb & 0x3) << (shift - 8);
+    } else {
+      uint32_t& data = myDataWritePtr[index - 1];
+      data |= (fb & 0x3) << (shift + 24);
+    }
+  }
+
+  uint32_t getHFFeatureBits(bool negativeEta, uint32_t cEta, uint32_t iPhi) {
+    size_t index = getFeatureIndex(HF, negativeEta, cEta, iPhi);
+    // Stitch together the top 8 bits from previous 32-bit word and bottom 14 bits from this word
+    const uint32_t data = ((myDataPtr[index] & 0x3FFF) << 8) + (myDataPtr[index - 1] >> 24);
+    uint32_t shift = (cEta - 30) * 2;
+    if (cEta == 41)
+      shift = 20;  // 41 occurs on b-fiber but shares the position of 40
+    return ((data >> shift) & 0x3);
+  }
+
+  uint32_t getLinkStatus(CaloType cType, bool negativeEta, uint32_t cEta, uint32_t iPhi) {
+    size_t index = getFeatureIndex(cType, negativeEta, cEta, iPhi);
+    const uint32_t data = myDataPtr[index];
+    return (data >> 16);
+  }
+
+  size_t getSummaryIndex(bool negativeEta, uint32_t region) {
+    size_t index = 2 * 14 * (3 + 3) + 4 * 4 + (region / 2);
+    if (negativeEta)
+      index += 4;
+    if (index >= 192) {
+      edm::LogError("UCTCTP7RawData") << "Managed to calculate an out-of-bounds index, buyer beware";
+    }
+    return index;
+  }
+
+  void setRegionSummary(bool negativeEta, uint32_t region, uint32_t regionData) {
+    if (myDataWritePtr == nullptr) {
+      edm::LogError("UCTCTP7RawData") << "I was made in read-only mode";
+      return;
+    }
+    size_t index = getSummaryIndex(negativeEta, region);
+    uint32_t& data = myDataWritePtr[index];
+    data |= (regionData & 0xFFFF) << (16 * (region % 2));
+  }
+
+  uint32_t getRegionSummary(bool negativeEta, uint32_t region) {
+    size_t index = getSummaryIndex(negativeEta, region);
+    const uint32_t data = myDataPtr[index];
+    return ((data >> (16 * (region % 2))) & 0xFFFF);
+  }
+
+  uint32_t getRegionET(bool negativeEta, uint32_t region) { return (getRegionSummary(negativeEta, region) & 0x3FF); }
+
+  bool getRegionEGVeto(bool negativeEta, uint32_t region) { return (getRegionSummary(negativeEta, region) & 0x0400); }
+
+  bool getRegionTauVeto(bool negativeEta, uint32_t region) { return (getRegionSummary(negativeEta, region) & 0x0800); }
+
+  uint32_t getRegionHitLocation(bool negativeEta, uint32_t region) {
+    return ((getRegionSummary(negativeEta, region) & 0xF000) >> 12);
+  }
+
+  bool isTowerMasked(CaloType cType, bool negativeEta, uint32_t cEta, uint32_t iPhi) {
+    uint32_t linkStatus = getLinkStatus(cType, negativeEta, cEta, iPhi);
+    uint32_t tower = iPhi;
+    if ((cEta % 2) == 0)
+      tower += 4;
+    if (cType == HF) {
+      tower = (cEta - 30);
+      if (cEta == 41)
+        tower = 10;
+    }
+    return ((linkStatus & (0x1 << tower)) != 0);
+  }
+
+  bool isLinkMisaligned(CaloType cType, bool negativeEta, uint32_t cEta, uint32_t iPhi) {
+    uint32_t linkStatus = getLinkStatus(cType, negativeEta, cEta, iPhi);
+    if (cType == EBEE && (cEta == 17 || cEta == 21)) {
+      return ((linkStatus & 0x00000100) != 0);
+    }
+    return ((linkStatus & 0x00001000) != 0);
+  }
+
+  bool isLinkInError(CaloType cType, bool negativeEta, uint32_t cEta, uint32_t iPhi) {
+    uint32_t linkStatus = getLinkStatus(cType, negativeEta, cEta, iPhi);
+    if (cType == EBEE && (cEta == 17 || cEta == 21)) {
+      return ((linkStatus & 0x00000200) != 0);
+    }
+    return ((linkStatus & 0x00002000) != 0);
+  }
+
+  bool isLinkDown(CaloType cType, bool negativeEta, uint32_t cEta, uint32_t iPhi) {
+    uint32_t linkStatus = getLinkStatus(cType, negativeEta, cEta, iPhi);
+    if (cType == EBEE && (cEta == 17 || cEta == 21)) {
+      return ((linkStatus & 0x00000400) != 0);
+    }
+    return ((linkStatus & 0x00004000) != 0);
+  }
+
+  bool isLinkMasked(CaloType cType, bool negativeEta, uint32_t cEta, uint32_t iPhi) {
+    uint32_t linkStatus = getLinkStatus(cType, negativeEta, cEta, iPhi);
+    if (cType == EBEE && (cEta == 17 || cEta == 21)) {
+      return ((linkStatus & 0x00000800) != 0);
+    }
+    return ((linkStatus & 0x00008000) != 0);
+  }
+
+private:
+  // Pointer to contiguous array of 192 values
+  // We assume instantiator of this class will gurantee that fact
+  const uint32_t* myDataPtr;
+  // == myDataPtr unless read-only
+  uint32_t* myDataWritePtr = nullptr;
+};
+
+#endif

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/UCTCTP7RawData5BX.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/UCTCTP7RawData5BX.h
@@ -1,31 +1,31 @@
-#ifndef UCTCTP7RawData_hh
-#define UCTCTP7RawData_hh
+#ifndef UCTCTP7RawData5BX_hh
+#define UCTCTP7RawData5BX_hh
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/MessageLogger/interface/MessageDrop.h"
 
-class UCTCTP7RawData {
+class UCTCTP7RawData5BX {
 public:
   enum CaloType { EBEE = 0, HBHE, HF };
 
   // read-only constructor
-  UCTCTP7RawData(const uint32_t* d) : myDataPtr(d) {
+  UCTCTP7RawData5BX(const uint32_t* d) : myDataPtr(d) {
     if (myDataPtr == nullptr) {
-      edm::LogError("UCTCTP7RawData") << "You gave me a nullptr :<";
+      edm::LogError("UCTCTP7RawData5BX") << "You gave me a nullptr :<";
     }
   }
-  // read-write constructor, caller must allocate 192*sizeof(uint32_t) bytes
-  UCTCTP7RawData(uint32_t* d) : myDataPtr(d), myDataWritePtr(d) {
+  // read-write constructor, caller must allocate 192*5*sizeof(uint32_t) bytes
+  UCTCTP7RawData5BX(uint32_t* d) : myDataPtr(d), myDataWritePtr(d) {
     if (myDataPtr == nullptr) {
-      edm::LogError("UCTCTP7RawData") << "You gave me a nullptr :<";
+      edm::LogError("UCTCTP7RawData5BX") << "You gave me a nullptr :<";
     }
   }
 
   // No copy constructor and equality operator are needed
-  UCTCTP7RawData(const UCTCTP7RawData&) = delete;
-  const UCTCTP7RawData& operator=(const UCTCTP7RawData& i) = delete;
+  UCTCTP7RawData5BX(const UCTCTP7RawData5BX&) = delete;
+  const UCTCTP7RawData5BX& operator=(const UCTCTP7RawData5BX& i) = delete;
 
-  virtual ~UCTCTP7RawData() { ; }
+  virtual ~UCTCTP7RawData5BX() { ; }
 
   // Access functions for convenience
 
@@ -33,48 +33,50 @@ public:
 
   uint32_t sof() { return myDataPtr[0]; }
 
-  size_t getIndex(CaloType cType, bool negativeEta, uint32_t cEta, uint32_t iPhi) {
+  size_t getIndex(CaloType cType, bool negativeEta, uint32_t cEta, uint32_t iPhi, uint32_t BX_n) {
     size_t index = 0;
     if (cType == EBEE || cType == HBHE) {
       if (iPhi > 3) {
-        edm::LogError("UCTCTP7RawData") << "Incorrect iPhi; iPhi = " << iPhi << "; should be in [0,3]";
+        edm::LogError("UCTCTP7RawData5BX") << "Incorrect iPhi; iPhi = " << iPhi << "; should be in [0,3]";
         return index;
       }
       if (cEta < 1 || cEta > 28) {
-        edm::LogError("UCTCTP7RawData") << "Incorrect caloEta; cEta = " << cEta << "; should be in [1-28]";
+        edm::LogError("UCTCTP7RawData5BX") << "Incorrect caloEta; cEta = " << cEta << "; should be in [1-28]";
         return index;
       }
       // ECAL/HB+HE fragment size is 3 32-bit words
       // Each fragment covers 2 eta and 4 phi towers
       // All four phi towers are in one 32-bit word
       // Even and odd eta are in neighboring 32-bit words
-      index = (((cEta - 1) / 2) * (3 + 3) + ((cEta - 1) % 2));
+      // Now each fragment contains 5 BX instead of just 1
+      // Here BX_n = 0, 1, 2, 3, 4, where 2 is nominal
+      index = (((cEta - 1) / 2) * (3 + 3) * 5 + ((cEta - 1) % 2)) + 3 * BX_n;
       // But, towers are arranged in a peculiar order for firmware
       // convenience - the index needs to be computing with these
       // if statements.  This is brittle code that one should be
       // very careful with.
       if (negativeEta) {
         // Add offset for 6 ECAL and 6 HCAL fragments
-        index += (6 * (3 + 3));
+        index += (6 * (3 + 3)) * 5;
       } else {
         if (cEta > 12) {
           // Add offset for 14 ECAL, 14 HB+HE and 2 HF fragments
           // Note that first six are included in the definition of
           // the variable - index
           // Note also that HF fragments are larger at 4 32-bit words
-          index += ((14 * (3 + 3) + (2 * 4)));
+          index += ((14 * (3 + 3) + (2 * 4))) * 5;
         }
       }
       // Data starts with ECAL towers so offset by 3 additional 32-bit words
       if (cType == HBHE)
-        index += 3;
+        index += 3 * 5;
     } else if (cType == HF) {
       if (iPhi > 1) {
-        edm::LogError("UCTCTP7RawData") << "HF iPhi should be 0 or 1 (for a , b) - invalid iPhi  = " << iPhi;
+        edm::LogError("UCTCTP7RawData5BX") << "HF iPhi should be 0 or 1 (for a , b) - invalid iPhi  = " << iPhi;
         return index;
       }
       if (cEta < 30 || cEta > 41) {
-        edm::LogError("UCTCTP7RawData") << "HF cEta should be between 30 and 41 - invalid cEta = " << cEta;
+        edm::LogError("UCTCTP7RawData5BX") << "HF cEta should be between 30 and 41 - invalid cEta = " << cEta;
         return index;
       }
       if (negativeEta) {
@@ -82,33 +84,33 @@ public:
           // Offset by 6 positive eta and 14 negative eta EBEE/HBHE fragments (each 3 32-bit words)
           // There are four HF cEta towers packed in each 32-bit word
           // Add additional offset of 1 for (34-37) and 2 for (38-41)
-          index = 20 * (3 + 3) + ((cEta - 30) / 4);
+          index = 20 * (3 + 3) * 5 + ((cEta - 30) / 4) + 4 * BX_n;
         } else {
           // Additional HF a fragment offset for HF b channel
-          index = 20 * (3 + 3) + 1 * 4 + ((cEta - 30) / 4);
+          index = 20 * (3 + 3) * 5 + 1 * 4 * 5 + ((cEta - 30) / 4) + 4 * BX_n;
         }
       } else {
         if (iPhi == 0) {
           // Offset by all EBEE/HBHE and two HF fragments (4 32-bit words)
-          index = 2 * 14 * (3 + 3) + 2 * 4 + ((cEta - 30) / 4);
+          index = 2 * 14 * (3 + 3) * 5 + 2 * 4 * 5 + ((cEta - 30) / 4) + 4 * BX_n;
         } else {
           // Additional HF a fragment offset for HF b channel
-          index = 2 * 14 * (3 + 3) + 3 * 4 + ((cEta - 30) / 4);
+          index = 2 * 14 * (3 + 3) * 5 + 3 * 4 * 5 + ((cEta - 30) / 4) + 4 * BX_n;
         }
       }
     } else {
-      edm::LogError("UCTCTP7RawData") << "Unknown CaloType " << cType;
+      edm::LogError("UCTCTP7RawData5BX") << "Unknown CaloType " << cType;
       return index;
     }
-    if (index >= 192) {
-      edm::LogError("UCTCTP7RawData") << "Managed to calculate an out-of-bounds index, buyer beware";
+    if (index >= 192 * 5) {
+      edm::LogError("UCTCTP7RawData5BX") << "Managed to calculate an out-of-bounds index, buyer beware";
     }
     return index;
   }
 
-  size_t getFeatureIndex(CaloType cType, bool negativeEta, uint32_t cEta, uint32_t iPhi) {
+  size_t getFeatureIndex(CaloType cType, bool negativeEta, uint32_t cEta, uint32_t iPhi, uint32_t BX_n) {
     // Get index into the data words for the tower
-    size_t index = getIndex(cType, negativeEta, cEta, iPhi);
+    size_t index = getIndex(cType, negativeEta, cEta, iPhi, BX_n);
     if (cType == EBEE || cType == HBHE) {
       // Two 32-bit words contain ET, so we should offset the index to
       // to the feature and link status bits
@@ -134,24 +136,24 @@ public:
       index += (3 - ((cEta - 30) / 4));
       if (index == 0) {
         // Since we sticth index-1, zero is also illegal
-        edm::LogError("UCTCTP7RawData") << "Managed to calculate an out-of-bounds index, buyer beware";
+        edm::LogError("UCTCTP7RawData5BX") << "Managed to calculate an out-of-bounds index, buyer beware";
       }
     } else {
       // Unknown calotype error already generated in getIndex()
       return 0;
     }
-    if (index >= 192) {
-      edm::LogError("UCTCTP7RawData") << "Managed to calculate an out-of-bounds index, buyer beware";
+    if (index >= 192 * 5) {
+      edm::LogError("UCTCTP7RawData5BX") << "Managed to calculate an out-of-bounds index, buyer beware";
     }
     return index;
   }
 
-  void setET(CaloType cType, bool negativeEta, uint32_t cEta, uint32_t iPhi, uint32_t et) {
+  void setET(CaloType cType, bool negativeEta, uint32_t cEta, uint32_t iPhi, uint32_t et, uint32_t BX_n) {
     if (myDataWritePtr == nullptr) {
-      edm::LogError("UCTCTP7RawData") << "I was made in read-only mode";
+      edm::LogError("UCTCTP7RawData5BX") << "I was made in read-only mode";
       return;
     }
-    size_t index = getIndex(cType, negativeEta, cEta, iPhi);
+    size_t index = getIndex(cType, negativeEta, cEta, iPhi, BX_n);
     uint32_t& data = myDataWritePtr[index];
     if (cType == HF) {
       // Pick out the correct 8-bits for the iEta chosen
@@ -167,8 +169,8 @@ public:
     }
   }
 
-  uint32_t getET(CaloType cType, bool negativeEta, uint32_t cEta, uint32_t iPhi) {
-    size_t index = getIndex(cType, negativeEta, cEta, iPhi);
+  uint32_t getET(CaloType cType, bool negativeEta, uint32_t cEta, uint32_t iPhi, uint32_t BX_n) {
+    size_t index = getIndex(cType, negativeEta, cEta, iPhi, BX_n);
     const uint32_t data = myDataPtr[index];
     uint32_t et = 0xDEADBEEF;
     if (cType == HF) {
@@ -185,15 +187,15 @@ public:
     return et;
   }
 
-  void setFB(CaloType cType, bool negativeEta, uint32_t cEta, uint32_t iPhi, uint32_t fb) {
+  void setFB(CaloType cType, bool negativeEta, uint32_t cEta, uint32_t iPhi, uint32_t fb, uint32_t BX_n) {
     if (myDataWritePtr == nullptr) {
-      edm::LogError("UCTCTP7RawData") << "I was made in read-only mode";
+      edm::LogError("UCTCTP7RawData5BX") << "I was made in read-only mode";
       return;
     }
     if (cType == HF) {
-      setHFFeatureBits(negativeEta, cEta, iPhi, fb);
+      setHFFeatureBits(negativeEta, cEta, iPhi, fb, BX_n);
     } else {
-      size_t index = getFeatureIndex(cType, negativeEta, cEta, iPhi);
+      size_t index = getFeatureIndex(cType, negativeEta, cEta, iPhi, BX_n);
       uint32_t& data = myDataWritePtr[index];
 
       uint32_t tower = iPhi;
@@ -204,12 +206,12 @@ public:
     }
   }
 
-  uint32_t getFB(CaloType cType, bool negativeEta, uint32_t cEta, uint32_t iPhi) {
-    size_t index = getFeatureIndex(cType, negativeEta, cEta, iPhi);
+  uint32_t getFB(CaloType cType, bool negativeEta, uint32_t cEta, uint32_t iPhi, uint32_t BX_n) {
+    size_t index = getFeatureIndex(cType, negativeEta, cEta, iPhi, BX_n);
     const uint32_t data = myDataPtr[index];
     uint32_t fb = 0;
     if (cType == HF) {
-      fb = getHFFeatureBits(negativeEta, cEta, iPhi);
+      fb = getHFFeatureBits(negativeEta, cEta, iPhi, BX_n);
     } else {
       // Pick out the correct bit for the tower chosen
       uint32_t tower = iPhi;
@@ -221,12 +223,12 @@ public:
     return fb;
   }
 
-  void setHFFeatureBits(bool negativeEta, uint32_t cEta, uint32_t iPhi, uint32_t fb) {
+  void setHFFeatureBits(bool negativeEta, uint32_t cEta, uint32_t iPhi, uint32_t fb, uint32_t BX_n) {
     if (myDataWritePtr == nullptr) {
-      edm::LogError("UCTCTP7RawData") << "I was made in read-only mode";
+      edm::LogError("UCTCTP7RawData5BX") << "I was made in read-only mode";
       return;
     }
-    size_t index = getFeatureIndex(HF, negativeEta, cEta, iPhi);
+    size_t index = getFeatureIndex(HF, negativeEta, cEta, iPhi, BX_n);
     uint32_t shift = (cEta - 30) * 2;
     if (cEta == 41)
       shift = 20;  // 41 occurs on b-fiber but shares the position of 40
@@ -239,8 +241,8 @@ public:
     }
   }
 
-  uint32_t getHFFeatureBits(bool negativeEta, uint32_t cEta, uint32_t iPhi) {
-    size_t index = getFeatureIndex(HF, negativeEta, cEta, iPhi);
+  uint32_t getHFFeatureBits(bool negativeEta, uint32_t cEta, uint32_t iPhi, uint32_t BX_n) {
+    size_t index = getFeatureIndex(HF, negativeEta, cEta, iPhi, BX_n);
     // Stitch together the top 8 bits from previous 32-bit word and bottom 14 bits from this word
     const uint32_t data = ((myDataPtr[index] & 0x3FFF) << 8) + (myDataPtr[index - 1] >> 24);
     uint32_t shift = (cEta - 30) * 2;
@@ -249,50 +251,56 @@ public:
     return ((data >> shift) & 0x3);
   }
 
-  uint32_t getLinkStatus(CaloType cType, bool negativeEta, uint32_t cEta, uint32_t iPhi) {
-    size_t index = getFeatureIndex(cType, negativeEta, cEta, iPhi);
+  uint32_t getLinkStatus(CaloType cType, bool negativeEta, uint32_t cEta, uint32_t iPhi, uint32_t BX_n) {
+    size_t index = getFeatureIndex(cType, negativeEta, cEta, iPhi, BX_n);
     const uint32_t data = myDataPtr[index];
     return (data >> 16);
   }
 
-  size_t getSummaryIndex(bool negativeEta, uint32_t region) {
-    size_t index = 2 * 14 * (3 + 3) + 4 * 4 + (region / 2);
+  size_t getSummaryIndex(bool negativeEta, uint32_t region, uint32_t BX_n) {
+    size_t index = 2 * 14 * (3 + 3) * 5 + 4 * 4 * 5 + (region / 2) + 4 * BX_n;
     if (negativeEta)
-      index += 4;
-    if (index >= 192) {
-      edm::LogError("UCTCTP7RawData") << "Managed to calculate an out-of-bounds index, buyer beware";
+      index += 4 * 5;
+    if (index >= 192 * 5) {
+      edm::LogError("UCTCTP7RawData5BX") << "Managed to calculate an out-of-bounds index, buyer beware";
     }
     return index;
   }
 
-  void setRegionSummary(bool negativeEta, uint32_t region, uint32_t regionData) {
+  void setRegionSummary(bool negativeEta, uint32_t region, uint32_t regionData, uint32_t BX_n) {
     if (myDataWritePtr == nullptr) {
-      edm::LogError("UCTCTP7RawData") << "I was made in read-only mode";
+      edm::LogError("UCTCTP7RawData5BX") << "I was made in read-only mode";
       return;
     }
-    size_t index = getSummaryIndex(negativeEta, region);
+    size_t index = getSummaryIndex(negativeEta, region, BX_n);
     uint32_t& data = myDataWritePtr[index];
     data |= (regionData & 0xFFFF) << (16 * (region % 2));
   }
 
-  uint32_t getRegionSummary(bool negativeEta, uint32_t region) {
-    size_t index = getSummaryIndex(negativeEta, region);
+  uint32_t getRegionSummary(bool negativeEta, uint32_t region, uint32_t BX_n) {
+    size_t index = getSummaryIndex(negativeEta, region, BX_n);
     const uint32_t data = myDataPtr[index];
     return ((data >> (16 * (region % 2))) & 0xFFFF);
   }
 
-  uint32_t getRegionET(bool negativeEta, uint32_t region) { return (getRegionSummary(negativeEta, region) & 0x3FF); }
-
-  bool getRegionEGVeto(bool negativeEta, uint32_t region) { return (getRegionSummary(negativeEta, region) & 0x0400); }
-
-  bool getRegionTauVeto(bool negativeEta, uint32_t region) { return (getRegionSummary(negativeEta, region) & 0x0800); }
-
-  uint32_t getRegionHitLocation(bool negativeEta, uint32_t region) {
-    return ((getRegionSummary(negativeEta, region) & 0xF000) >> 12);
+  uint32_t getRegionET(bool negativeEta, uint32_t region, uint32_t BX_n) {
+    return (getRegionSummary(negativeEta, region, BX_n) & 0x3FF);
   }
 
-  bool isTowerMasked(CaloType cType, bool negativeEta, uint32_t cEta, uint32_t iPhi) {
-    uint32_t linkStatus = getLinkStatus(cType, negativeEta, cEta, iPhi);
+  bool getRegionEGVeto(bool negativeEta, uint32_t region, uint32_t BX_n) {
+    return (getRegionSummary(negativeEta, region, BX_n) & 0x0400);
+  }
+
+  bool getRegionTauVeto(bool negativeEta, uint32_t region, uint32_t BX_n) {
+    return (getRegionSummary(negativeEta, region, BX_n) & 0x0800);
+  }
+
+  uint32_t getRegionHitLocation(bool negativeEta, uint32_t region, uint32_t BX_n) {
+    return ((getRegionSummary(negativeEta, region, BX_n) & 0xF000) >> 12);
+  }
+
+  bool isTowerMasked(CaloType cType, bool negativeEta, uint32_t cEta, uint32_t iPhi, uint32_t BX_n) {
+    uint32_t linkStatus = getLinkStatus(cType, negativeEta, cEta, iPhi, BX_n);
     uint32_t tower = iPhi;
     if ((cEta % 2) == 0)
       tower += 4;
@@ -304,32 +312,32 @@ public:
     return ((linkStatus & (0x1 << tower)) != 0);
   }
 
-  bool isLinkMisaligned(CaloType cType, bool negativeEta, uint32_t cEta, uint32_t iPhi) {
-    uint32_t linkStatus = getLinkStatus(cType, negativeEta, cEta, iPhi);
+  bool isLinkMisaligned(CaloType cType, bool negativeEta, uint32_t cEta, uint32_t iPhi, uint32_t BX_n) {
+    uint32_t linkStatus = getLinkStatus(cType, negativeEta, cEta, iPhi, BX_n);
     if (cType == EBEE && (cEta == 17 || cEta == 21)) {
       return ((linkStatus & 0x00000100) != 0);
     }
     return ((linkStatus & 0x00001000) != 0);
   }
 
-  bool isLinkInError(CaloType cType, bool negativeEta, uint32_t cEta, uint32_t iPhi) {
-    uint32_t linkStatus = getLinkStatus(cType, negativeEta, cEta, iPhi);
+  bool isLinkInError(CaloType cType, bool negativeEta, uint32_t cEta, uint32_t iPhi, uint32_t BX_n) {
+    uint32_t linkStatus = getLinkStatus(cType, negativeEta, cEta, iPhi, BX_n);
     if (cType == EBEE && (cEta == 17 || cEta == 21)) {
       return ((linkStatus & 0x00000200) != 0);
     }
     return ((linkStatus & 0x00002000) != 0);
   }
 
-  bool isLinkDown(CaloType cType, bool negativeEta, uint32_t cEta, uint32_t iPhi) {
-    uint32_t linkStatus = getLinkStatus(cType, negativeEta, cEta, iPhi);
+  bool isLinkDown(CaloType cType, bool negativeEta, uint32_t cEta, uint32_t iPhi, uint32_t BX_n) {
+    uint32_t linkStatus = getLinkStatus(cType, negativeEta, cEta, iPhi, BX_n);
     if (cType == EBEE && (cEta == 17 || cEta == 21)) {
       return ((linkStatus & 0x00000400) != 0);
     }
     return ((linkStatus & 0x00004000) != 0);
   }
 
-  bool isLinkMasked(CaloType cType, bool negativeEta, uint32_t cEta, uint32_t iPhi) {
-    uint32_t linkStatus = getLinkStatus(cType, negativeEta, cEta, iPhi);
+  bool isLinkMasked(CaloType cType, bool negativeEta, uint32_t cEta, uint32_t iPhi, uint32_t BX_n) {
+    uint32_t linkStatus = getLinkStatus(cType, negativeEta, cEta, iPhi, BX_n);
     if (cType == EBEE && (cEta == 17 || cEta == 21)) {
       return ((linkStatus & 0x00000800) != 0);
     }
@@ -337,7 +345,7 @@ public:
   }
 
 private:
-  // Pointer to contiguous array of 192 values
+  // Pointer to contiguous array of 192*5 values
   // We assume instantiator of this class will gurantee that fact
   const uint32_t* myDataPtr;
   // == myDataPtr unless read-only


### PR DESCRIPTION
#### PR description:
This PR is about the trigger Calo-L1 unpacker modified to read ECAL's 5BX FAT events properly. The current central unpacker for FAT events is assuming a payload size of 192 * 32-bit words and the same structure as for normal events, repeated itself one after another five times for each FAT event, and each Calo fragment contains one BX only. However this is not compatible with the actual current payload format which has a larger size of 5 * 192 * 32-bit words, where each Calo fragment contains all 5 BX already, stacked in the order BX-2, -1, 0, +1, +2 inside.

The modification involves duplication of all necessary unpacker functions from normal events unpacking, then to make changes there for FAT events unpacking. The idea is to have two separate unpackers, one for unpacking normal events only, and another for unpacking FAT events only, in order to minimize risk.

Note: UCTCTP7RawData5BX.h is duplicated from UCTCTP7RawData.h, which contains the index equations for locating Calo fragments in payload data, offsets are modified for 5BX, while geometry, word structure and etc. remain the same.

#### PR validation:
Validated by running private online DQM on recent CRUZET runs, all DQM plots looked expected with modified unpacker. Also asked the central DQM team to include these changes into temporary production for this last week of running, all tests ran fine and DQM plots looked expected.