### PR TITLE
adjusting hltGetConfigution "minimal" event content to include the L1

### DIFF
--- a/HLTrigger/Configuration/python/Tools/confdb.py
+++ b/HLTrigger/Configuration/python/Tools/confdb.py
@@ -492,7 +492,16 @@ from HLTrigger.Configuration.CustomConfigs import L1REPACK
     ),
     outputCommands = cms.untracked.vstring( 'drop *',
         'keep edmTriggerResults_*_*_*',
-        'keep triggerTriggerEvent_*_*_*'
+        'keep triggerTriggerEvent_*_*_*',
+        'keep GlobalAlgBlkBXVector_*_*_*',                  
+        'keep GlobalExtBlkBXVector_*_*_*',
+        'keep l1tEGammaBXVector_*_EGamma_*',
+        'keep l1tEtSumBXVector_*_EtSum_*',
+        'keep l1tJetBXVector_*_Jet_*',
+        'keep l1tMuonBXVector_*_Muon_*',
+        'keep l1tTauBXVector_*_Tau_*',
+
+      
     )
 )
 %(process)s.MinimalOutput = cms.EndPath( %(process)s.hltOutputMinimal )

--- a/HLTrigger/Configuration/python/Tools/confdb.py
+++ b/HLTrigger/Configuration/python/Tools/confdb.py
@@ -500,8 +500,6 @@ from HLTrigger.Configuration.CustomConfigs import L1REPACK
         'keep l1tJetBXVector_*_Jet_*',
         'keep l1tMuonBXVector_*_Muon_*',
         'keep l1tTauBXVector_*_Tau_*',
-
-      
     )
 )
 %(process)s.MinimalOutput = cms.EndPath( %(process)s.hltOutputMinimal )


### PR DESCRIPTION
#### PR description:

This PR adjusts the event content of the "minimal" output set by hltGetConfiguration to also include the L1. The L1 info is often useful to have to understand the HLT and I think its worth including it by default here. 

#### PR validation:

Output using this option

```
Type                        Module                   Label      Process   
--------------------------------------------------------------------------
edm::TriggerResults         "TriggerResults"         ""         "SIM"     
BXVector<GlobalAlgBlk>      "hltGtStage2Digis"       ""         "HLT"     
BXVector<GlobalAlgBlk>      "simGtStage2Digis"       ""         "HLT"     
BXVector<l1t::EGamma>       "hltGtStage2Digis"       "EGamma"   "HLT"     
BXVector<l1t::EtSum>        "hltGtStage2Digis"       "EtSum"    "HLT"     
BXVector<l1t::Jet>          "hltGtStage2Digis"       "Jet"      "HLT"     
BXVector<l1t::Muon>         "hltGtStage2Digis"       "Muon"     "HLT"     
BXVector<l1t::Tau>          "hltGtStage2Digis"       "Tau"      "HLT"     
edm::TriggerResults         "TriggerResults"         ""         "HLT"     
trigger::TriggerEvent       "hltTriggerSummaryAOD"   ""         "HLT"     
BXVector<GlobalAlgBlk>      "hltGtStage2Digis"       ""         "HLTX"    
BXVector<GlobalAlgBlk>      "hltGtStage2ObjectMap"   ""         "HLTX"    
BXVector<l1t::EGamma>       "hltGtStage2Digis"       "EGamma"   "HLTX"    
BXVector<l1t::EtSum>        "hltGtStage2Digis"       "EtSum"    "HLTX"    
BXVector<l1t::Jet>          "hltGtStage2Digis"       "Jet"      "HLTX"    
BXVector<l1t::Muon>         "hltGtStage2Digis"       "Muon"     "HLTX"    
BXVector<l1t::Tau>          "hltGtStage2Digis"       "Tau"      "HLTX"    
edm::TriggerResults         "TriggerResults"         ""         "HLTX"    
trigger::TriggerEvent       "hltTriggerSummaryAOD"   ""         "HLTX"    
```