### PR TITLE
Fully configurable `SiPixelFakeLorentzAngleESSource`

### DIFF
--- a/CalibTracker/SiPixelESProducers/interface/SiPixelFakeLorentzAngleESSource.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelFakeLorentzAngleESSource.h
@@ -27,7 +27,7 @@
 #include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelLorentzAngle.h"
 #include "CondFormats/DataRecord/interface/SiPixelLorentzAngleRcd.h"
-// #include "CondTools/SiPixel/interface/SiPixelGainCalibrationService.h"
+#include "CalibTracker/StandaloneTrackerTopology/interface/StandaloneTrackerTopology.h"
 //
 // class decleration
 //
@@ -35,11 +35,10 @@
 class SiPixelFakeLorentzAngleESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   SiPixelFakeLorentzAngleESSource(const edm::ParameterSet &);
-  ~SiPixelFakeLorentzAngleESSource() override;
-
-  //      typedef edm::ESProducts<> ReturnType;
-
+  ~SiPixelFakeLorentzAngleESSource() override = default;
   virtual std::unique_ptr<SiPixelLorentzAngle> produce(const SiPixelLorentzAngleRcd &);
+
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
 protected:
   void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
@@ -47,6 +46,17 @@ protected:
                       edm::ValidityInterval &) override;
 
 private:
+  int HVgroup(int panel, int module);
+
+  // data members
   edm::FileInPath fp_;
+  edm::FileInPath t_topo_fp_;
+  typedef std::vector<edm::ParameterSet> Parameters;
+  Parameters BPixParameters_;
+  Parameters FPixParameters_;
+  Parameters ModuleParameters_;
+
+  float bPixLorentzAnglePerTesla_;
+  float fPixLorentzAnglePerTesla_;
 };
 #endif

--- a/CalibTracker/SiPixelESProducers/plugins/BuildFile.xml
+++ b/CalibTracker/SiPixelESProducers/plugins/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="cuda"/>
 <use name="CalibTracker/Records"/>
 <use name="CalibTracker/SiPixelESProducers"/>
+<use name="CalibTracker/StandaloneTrackerTopology"/>
 <use name="CondFormats/DataRecord"/>
 <use name="CondFormats/SiPixelObjects"/>
 <use name="CondFormats/SiStripObjects"/>

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeLorentzAngleESSource.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeLorentzAngleESSource.cc
@@ -192,7 +192,7 @@ std::unique_ptr<SiPixelLorentzAngle> SiPixelFakeLorentzAngleESSource::produce(co
           if (!found) {
             float lorentzangle = (float)it.getParameter<double>("angle");
             obj->putLorentzAngle(detid.rawId(), lorentzangle);
-	    edm::LogInfo("SiPixelFakeLorentzAngleESSource") << " LA= " << lorentzangle << std::endl;
+            edm::LogInfo("SiPixelFakeLorentzAngleESSource") << " LA= " << lorentzangle << std::endl;
             found = 2;
           } else if (found == 1) {
             edm::LogWarning("SiPixelFakeLorentzAngleESSource")
@@ -228,8 +228,8 @@ int SiPixelFakeLorentzAngleESSource::HVgroup(int panel, int module) {
     return 2;
   } else {
     edm::LogError("SiPixelFakeLorentzAngleESSource")
-        << " ERROR! in SiPixelFakeLorentzAngleESSource::HVgroup(...), panel = " << panel
-        << ", module = " << module << std::endl;
+        << " ERROR! in SiPixelFakeLorentzAngleESSource::HVgroup(...), panel = " << panel << ", module = " << module
+        << std::endl;
     return 0;
   }
 }

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeLorentzAngleESSource.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeLorentzAngleESSource.cc
@@ -18,26 +18,31 @@
 
 // user include files
 
-#include "CalibTracker/SiPixelESProducers/interface/SiPixelFakeLorentzAngleESSource.h"
 #include "CalibTracker/SiPixelESProducers/interface/SiPixelDetInfoFileReader.h"
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "CalibTracker/SiPixelESProducers/interface/SiPixelFakeLorentzAngleESSource.h"
+#include "DataFormats/TrackerCommon/interface/PixelBarrelName.h"
+#include "DataFormats/TrackerCommon/interface/PixelEndcapName.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+
 //
 // constructors and destructor
 //
 SiPixelFakeLorentzAngleESSource::SiPixelFakeLorentzAngleESSource(const edm::ParameterSet& conf_)
-    : fp_(conf_.getParameter<edm::FileInPath>("file")) {
+    : fp_(conf_.getParameter<edm::FileInPath>("file")),
+      t_topo_fp_(conf_.getParameter<edm::FileInPath>("topologyInput")),
+      BPixParameters_(conf_.getParameter<Parameters>("BPixParameters")),
+      FPixParameters_(conf_.getParameter<Parameters>("FPixParameters")),
+      ModuleParameters_(conf_.getParameter<Parameters>("ModuleParameters")),
+      bPixLorentzAnglePerTesla_((float)conf_.getUntrackedParameter<double>("bPixLorentzAnglePerTesla", -9999.)),
+      fPixLorentzAnglePerTesla_((float)conf_.getUntrackedParameter<double>("fPixLorentzAnglePerTesla", -9999.)) {
   edm::LogInfo("SiPixelFakeLorentzAngleESSource::SiPixelFakeLorentzAngleESSource");
-  //the following line is needed to tell the framework what
-  // data is being produced
+  // the following line is needed to tell the framework what data is being produced
   setWhatProduced(this);
   findingRecord<SiPixelLorentzAngleRcd>();
-}
-
-SiPixelFakeLorentzAngleESSource::~SiPixelFakeLorentzAngleESSource() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
 }
 
 std::unique_ptr<SiPixelLorentzAngle> SiPixelFakeLorentzAngleESSource::produce(const SiPixelLorentzAngleRcd&) {
@@ -47,18 +52,160 @@ std::unique_ptr<SiPixelLorentzAngle> SiPixelFakeLorentzAngleESSource::produce(co
   SiPixelDetInfoFileReader reader(fp_.fullPath());
   const std::vector<uint32_t>& DetIds = reader.getAllDetIds();
 
+  TrackerTopology tTopo = StandaloneTrackerTopology::fromTrackerParametersXMLFile(t_topo_fp_.fullPath());
+
   // Loop over detectors
-  for (std::vector<uint32_t>::const_iterator detit = DetIds.begin(); detit != DetIds.end(); detit++) {
+  for (const auto& detit : DetIds) {
     nmodules++;
-    float langle = 0.106;
-    //std::cout << "detid " << (*detit) << std::endl;
+    const DetId detid(detit);
+    auto rawId = detid.rawId();
+    int found = 0;
+    int side = tTopo.side(detid);  // 1:-z 2:+z for fpix, for bpix gives 0
 
-    if (!obj->putLorentzAngle(*detit, langle))
-      edm::LogError("SiPixelFakeLorentzAngleESSource")
-          << "[SiPixelFakeLorentzAngleESSource::produce] detid already exists" << std::endl;
-  }
+    // fill bpix values for LA
+    if (detid.subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel)) {
+      int layer = tTopo.pxbLayer(detid);
+      // Barrel ladder id 1-20,32,44.
+      int ladder = tTopo.pxbLadder(detid);
+      // Barrel Z-index=1,8
+      int module = tTopo.pxbModule(detid);
+      if (module < 5) {
+        side = 1;
+      } else {
+        side = 2;
+      }
 
-  //std::cout << "Modules = " << nmodules << std::endl;
+      LogDebug("SiPixelFakeLorentzAngleESSource") << " pixel barrel:"
+                                                  << " layer=" << layer << " ladder=" << ladder << " module=" << module
+                                                  << "  rawId=" << rawId << " side " << side;
+
+      // use a commmon value (e.g. for MC)
+      if (bPixLorentzAnglePerTesla_ != -9999.) {  // use common value for all
+        edm::LogInfo("SiPixelFakeLorentzAngleESSource")
+            << " LA = " << bPixLorentzAnglePerTesla_ << " common for all bpix" << std::endl;
+        if (!obj->putLorentzAngle(detid.rawId(), bPixLorentzAnglePerTesla_))
+          edm::LogError("SiPixelFakeLorentzAngleESSource")
+              << "ERROR!: detid " << rawId << " already exists" << std::endl;
+      } else {
+        //first individuals are put
+        for (const auto& it : ModuleParameters_) {
+          if (it.getParameter<unsigned int>("rawid") == detid.rawId()) {
+            float lorentzangle = (float)it.getParameter<double>("angle");
+            if (!found) {
+              obj->putLorentzAngle(detid.rawId(), lorentzangle);
+              edm::LogInfo("SiPixelFakeLorentzAngleESSource")
+                  << " LA= " << lorentzangle << " individual value " << detid.rawId() << std::endl;
+              found = 1;
+            } else
+              edm::LogError("SiPixelFakeLorentzAngleESSource") << "ERROR!: detid already exists" << std::endl;
+          }
+        }
+
+        //modules already put are automatically skipped
+        for (const auto& it : BPixParameters_) {
+          if (it.exists("layer"))
+            if (it.getParameter<int>("layer") != layer)
+              continue;
+          if (it.exists("ladder"))
+            if (it.getParameter<int>("ladder") != ladder)
+              continue;
+          if (it.exists("module"))
+            if (it.getParameter<int>("module") != module)
+              continue;
+          if (it.exists("side"))
+            if (it.getParameter<int>("side") != side)
+              continue;
+          if (!found) {
+            float lorentzangle = (float)it.getParameter<double>("angle");
+            obj->putLorentzAngle(detid.rawId(), lorentzangle);
+            edm::LogInfo("SiPixelFakeLorentzAngleESSource") << " LA= " << lorentzangle << std::endl;
+            found = 2;
+          } else if (found == 1) {
+            edm::LogWarning("SiPixelFakeLorentzAngleESSource")
+                << "detid already given in ModuleParameters, skipping ..." << std::endl;
+          } else
+            edm::LogError("SiPixelFakeLorentzAngleESSource")
+                << " ERROR!: detid " << rawId << " already exists" << std::endl;
+        }
+      }
+    } else if (detid.subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap)) {
+      // fill fpix values for LA (for phase2 fpix & epix)
+
+      // For fpix we also need to find the ring number which is not available from topology
+      // Convert to online
+      PixelEndcapName pen(detid, &tTopo, true);  // use det-id phaseq
+
+      //PixelEndcapName::HalfCylinder sh = pen.halfCylinder(); //enum
+      //string nameF = pen.name();
+      //int plaquetteName = pen.plaquetteName();
+      int disk = pen.diskName();
+      int blade = pen.bladeName();
+      int panel = pen.pannelName();
+      int ring = pen.ringName();
+
+      LogDebug("SiPixelFakeLorentzAngleESSource") << " pixel endcap:"
+                                                  << " side=" << side << " disk=" << disk << " blade =" << blade
+                                                  << " pannel=" << panel << " ring=" << ring << "  rawId=" << rawId;
+
+      // use a commmon value (e.g. for MC)
+      if (fPixLorentzAnglePerTesla_ != -9999.) {  // use common value for all
+        edm::LogInfo("SiPixelFakeLorentzAngleESSource")
+            << " LA = " << fPixLorentzAnglePerTesla_ << " common for all fpix" << std::endl;
+        if (!obj->putLorentzAngle(detid.rawId(), fPixLorentzAnglePerTesla_))
+          edm::LogError("SiPixelFakeLorentzAngleESSource") << " ERROR! detid already exists" << std::endl;
+      } else {
+        //first individuals are put
+        for (const auto& it : ModuleParameters_) {
+          if (it.getParameter<unsigned int>("rawid") == detid.rawId()) {
+            float lorentzangle = (float)it.getParameter<double>("angle");
+            if (!found) {
+              obj->putLorentzAngle(detid.rawId(), lorentzangle);
+              edm::LogInfo("SiPixelFakeLorentzAngleESSource")
+                  << " LA= " << lorentzangle << " individual value " << detid.rawId() << std::endl;
+              found = 1;
+            } else
+              edm::LogError("SiPixelFakeLorentzAngleESSource")
+                  << "ERROR!: detid " << rawId << " already exists" << std::endl;
+          }  // if
+        }    // for
+
+        //modules already put are automatically skipped
+        for (const auto& it : FPixParameters_) {
+          if (it.exists("side"))
+            if (it.getParameter<int>("side") != side)
+              continue;
+          if (it.exists("disk"))
+            if (it.getParameter<int>("disk") != disk)
+              continue;
+          if (it.exists("ring"))
+            if (it.getParameter<int>("ring") != ring)
+              continue;
+          if (it.exists("blade"))
+            if (it.getParameter<int>("blade") != blade)
+              continue;
+          if (it.exists("panel"))
+            if (it.getParameter<int>("panel") != panel)
+              continue;
+          if (it.exists("HVgroup"))
+            if (it.getParameter<int>("HVgroup") != HVgroup(panel, ring))
+              continue;
+          if (!found) {
+            float lorentzangle = (float)it.getParameter<double>("angle");
+            obj->putLorentzAngle(detid.rawId(), lorentzangle);
+	    edm::LogInfo("SiPixelFakeLorentzAngleESSource") << " LA= " << lorentzangle << std::endl;
+            found = 2;
+          } else if (found == 1) {
+            edm::LogWarning("SiPixelFakeLorentzAngleESSource")
+                << " detid " << rawId << " already given in ModuleParameters, skipping ..." << std::endl;
+          } else
+            edm::LogError("SiPixelFakeLorentzAngleESSource")
+                << "ERROR!: detid" << rawId << "already exists" << std::endl;
+        }  // for
+      }    // if
+    }      // bpix/fpix
+  }        // iterate on detids
+
+  edm::LogInfo("SiPixelFakeLorentzAngleESSource") << "Modules = " << nmodules << std::endl;
 
   return std::unique_ptr<SiPixelLorentzAngle>(obj);
 }
@@ -68,4 +215,61 @@ void SiPixelFakeLorentzAngleESSource::setIntervalFor(const edm::eventsetup::Even
                                                      edm::ValidityInterval& oValidity) {
   edm::ValidityInterval infinity(iosv.beginOfTime(), iosv.endOfTime());
   oValidity = infinity;
+}
+
+int SiPixelFakeLorentzAngleESSource::HVgroup(int panel, int module) {
+  if (1 == panel && (1 == module || 2 == module)) {
+    return 1;
+  } else if (1 == panel && (3 == module || 4 == module)) {
+    return 2;
+  } else if (2 == panel && 1 == module) {
+    return 1;
+  } else if (2 == panel && (2 == module || 3 == module)) {
+    return 2;
+  } else {
+    edm::LogError("SiPixelFakeLorentzAngleESSource")
+        << " ERROR! in SiPixelFakeLorentzAngleESSource::HVgroup(...), panel = " << panel
+        << ", module = " << module << std::endl;
+    return 0;
+  }
+}
+
+void SiPixelFakeLorentzAngleESSource::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.setComment("ESSource to supply per-module SiPixelLorentzAngle payloads in the EventSetup");
+
+  desc.add<edm::FileInPath>(
+      "file", edm::FileInPath("SLHCUpgradeSimulations/Geometry/data/PhaseI/PixelSkimmedGeometry_phase1.txt"));
+  desc.add<edm::FileInPath>("topologyInput",
+                            edm::FileInPath("Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml"));
+  desc.addUntracked<double>("bPixLorentzAnglePerTesla", -9999.);
+  desc.addUntracked<double>("fPixLorentzAnglePerTesla", -9999.);
+
+  edm::ParameterSetDescription desc_BPixParameters;
+  desc_BPixParameters.addOptional<int>("layer");
+  desc_BPixParameters.addOptional<int>("ladder");
+  desc_BPixParameters.addOptional<int>("module");
+  desc_BPixParameters.addOptional<int>("side");
+  desc_BPixParameters.add<double>("angle");
+  std::vector<edm::ParameterSet> default_BPixParametersToAdd;
+  desc.addVPSet("BPixParameters", desc_BPixParameters, default_BPixParametersToAdd);
+
+  edm::ParameterSetDescription desc_FPixParameters;
+  desc_FPixParameters.addOptional<int>("side");
+  desc_FPixParameters.addOptional<int>("disk");
+  desc_FPixParameters.addOptional<int>("ring");
+  desc_FPixParameters.addOptional<int>("blade");
+  desc_FPixParameters.addOptional<int>("panel");
+  desc_FPixParameters.addOptional<int>("HVgroup");
+  desc_FPixParameters.add<double>("angle");
+  std::vector<edm::ParameterSet> default_FPixParametersToAdd;
+  desc.addVPSet("FPixParameters", desc_FPixParameters, default_FPixParametersToAdd);
+
+  edm::ParameterSetDescription desc_ModuleParameters;
+  desc_ModuleParameters.add<unsigned int>("rawid");
+  desc_ModuleParameters.add<double>("angle");
+  std::vector<edm::ParameterSet> default_ModuleParametersToAdd;
+  desc.addVPSet("ModuleParameters", desc_ModuleParameters, default_ModuleParametersToAdd);
+
+  descriptions.addWithDefaultLabel(desc);
 }

--- a/CalibTracker/SiPixelESProducers/test/BuildFile.xml
+++ b/CalibTracker/SiPixelESProducers/test/BuildFile.xml
@@ -8,3 +8,10 @@
 <library file="*.cc" name="testCalibTrackerSiPixelESProducers">
   <flags EDM_PLUGIN="1"/>
 </library>
+
+<environment>
+  <bin file="testSiPixelFakeLorentzAngleESSource.cpp">
+    <flags TEST_RUNNER_ARGS="/bin/bash CalibTracker/SiPixelESProducers/test testSiPixelFakeLorentzAngleESSource.sh"/>
+    <use name="FWCore/Utilities"/>
+  </bin>
+</environment>

--- a/CalibTracker/SiPixelESProducers/test/testSiPixelFakeLorentzAngleESSource.cpp
+++ b/CalibTracker/SiPixelESProducers/test/testSiPixelFakeLorentzAngleESSource.cpp
@@ -1,0 +1,2 @@
+#include "FWCore/Utilities/interface/TestHelper.h"
+RUNTEST()

--- a/CalibTracker/SiPixelESProducers/test/testSiPixelFakeLorentzAngleESSource.sh
+++ b/CalibTracker/SiPixelESProducers/test/testSiPixelFakeLorentzAngleESSource.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+function die { echo $1: status $2 ; exit $2; }
+
+echo "TESTING Fake Pixel Conditions Sources ..."
+
+printf "TESTING SiPixelFakeLorentzAngleESSource (BPix) ...\n\n"
+cmsRun ${LOCAL_TEST_DIR}/testSiPixelFakeLorentzAngleESSource_cfg.py isBPix=True  || die "Failure testing SiPixelFakeLorentzAngleESSource (BPix)" $? 
+
+printf "TESTING SiPixelFakeLorentzAngleESSource (FPix) ...\n\n"
+cmsRun ${LOCAL_TEST_DIR}/testSiPixelFakeLorentzAngleESSource_cfg.py isFPix=True  || die "Failure testing SiPixelFakeLorentzAngleESSource (FPix)" $? 
+
+printf "TESTING SiPixelFakeLorentzAngleESSource (By Module) ...\n\n"
+cmsRun ${LOCAL_TEST_DIR}/testSiPixelFakeLorentzAngleESSource_cfg.py isByModule=True  || die "Failure testing SiPixelFakeLorentzAngleESSource (By Module)" $? 
+
+printf "TESTING SiPixelFakeLorentzAngleESSource (Phase-2) ...\n\n"
+cmsRun ${LOCAL_TEST_DIR}/testSiPixelFakeLorentzAngleESSource_cfg.py isPhase2=True  || die "Failure testing SiPixelFakeLorentzAngleESSource (Phase-2) " $? 

--- a/CalibTracker/SiPixelESProducers/test/testSiPixelFakeLorentzAngleESSource_cfg.py
+++ b/CalibTracker/SiPixelESProducers/test/testSiPixelFakeLorentzAngleESSource_cfg.py
@@ -1,0 +1,182 @@
+from __future__ import print_function
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+process = cms.Process("Test")
+options = VarParsing.VarParsing()
+options.register('isPhase2',
+                 False, # default value
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.bool, # string, int, or float
+                 "change for phase2")
+options.register('isBPix',
+                 False, # default value
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.bool, # string, int, or float
+                 "switch for BPix")
+options.register('isFPix',
+                 False, # default value
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.bool, # string, int, or float
+                 "switch for FPix")
+options.register('isByModule',
+                 False, # default value
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.bool, # string, int, or float
+                 "switch for by Module")
+options.parseArguments()
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+process.source = cms.Source("EmptySource",
+                            firstRun = cms.untracked.uint32(1)
+                            )
+
+process.TFileService = cms.Service("TFileService",
+                                   fileName = cms.string("siPixelLorentzAngle_histo.root")
+                                   )
+
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('WARNING')
+    )
+)
+
+process.Timing = cms.Service("Timing")
+
+
+## import the ESSource
+from CalibTracker.SiPixelESProducers.siPixelFakeLorentzAngleESSource_cfi import siPixelFakeLorentzAngleESSource
+
+BPIX_LAYER1=0.0595
+BPIX_LAYER_2_MODULE_1_4 = 0.0765
+BPIX_LAYER_2_MODULE_5_8 = 0.0805
+BPIX_LAYER_3_MODULE_1_4 = 0.0864
+BPIX_LAYER_3_MODULE_5_8 = 0.0929
+BPIX_LAYER_4_MODULE_1_4 = 0.0961
+BPIX_LAYER_4_MODULE_5_8 = 0.1036
+
+FPix_300V_RNG1_PNL1 = 0.0805
+FPix_300V_RNG1_PNL2 = 0.0788
+FPix_300V_RNG2_PNL1 = 0.0756
+FPix_300V_RNG2_PNL2 = 0.0736
+
+process.SiPixelFakeLorentzAngleESSource = siPixelFakeLorentzAngleESSource.clone()
+
+if(options.isPhase2):
+    print(" ========> Testing Phase-2")
+    process.SiPixelFakeLorentzAngleESSource.bPixLorentzAnglePerTesla = cms.untracked.double(0.106)
+    process.SiPixelFakeLorentzAngleESSource.fPixLorentzAnglePerTesla = cms.untracked.double(0.106)
+    process.SiPixelFakeLorentzAngleESSource.file = 'SLHCUpgradeSimulations/Geometry/data/PhaseII/Tilted/PixelSkimmedGeometryT14.txt'
+    process.SiPixelFakeLorentzAngleESSource.topologyInput = 'Geometry/TrackerCommonData/data/PhaseII/trackerParameters.xml'
+else:
+    if(options.isBPix):
+        print("  ========> Testing BPix parameters")
+        process.SiPixelFakeLorentzAngleESSource.BPixParameters = cms.VPSet(
+            cms.PSet(layer = cms.int32(1), angle = cms.double(BPIX_LAYER1)),
+            cms.PSet(layer = cms.int32(2), module = cms.int32(1), angle = cms.double(BPIX_LAYER_2_MODULE_1_4)),
+            cms.PSet(layer = cms.int32(2), module = cms.int32(2), angle = cms.double(BPIX_LAYER_2_MODULE_1_4)),
+            cms.PSet(layer = cms.int32(2), module = cms.int32(3), angle = cms.double(BPIX_LAYER_2_MODULE_1_4)),
+            cms.PSet(layer = cms.int32(2), module = cms.int32(4), angle = cms.double(BPIX_LAYER_2_MODULE_1_4)),
+            cms.PSet(layer = cms.int32(2), module = cms.int32(5), angle = cms.double(BPIX_LAYER_2_MODULE_5_8)),
+            cms.PSet(layer = cms.int32(2), module = cms.int32(6), angle = cms.double(BPIX_LAYER_2_MODULE_5_8)),
+            cms.PSet(layer = cms.int32(2), module = cms.int32(7), angle = cms.double(BPIX_LAYER_2_MODULE_5_8)),
+            cms.PSet(layer = cms.int32(2), module = cms.int32(8), angle = cms.double(BPIX_LAYER_2_MODULE_5_8)),
+            cms.PSet(layer = cms.int32(3), module = cms.int32(1), angle = cms.double(BPIX_LAYER_3_MODULE_1_4)),
+            cms.PSet(layer = cms.int32(3), module = cms.int32(2), angle = cms.double(BPIX_LAYER_3_MODULE_1_4)),
+            cms.PSet(layer = cms.int32(3), module = cms.int32(3), angle = cms.double(BPIX_LAYER_3_MODULE_1_4)),
+            cms.PSet(layer = cms.int32(3), module = cms.int32(4), angle = cms.double(BPIX_LAYER_3_MODULE_1_4)),
+            cms.PSet(layer = cms.int32(3), module = cms.int32(5), angle = cms.double(BPIX_LAYER_3_MODULE_5_8)),
+            cms.PSet(layer = cms.int32(3), module = cms.int32(6), angle = cms.double(BPIX_LAYER_3_MODULE_5_8)),
+            cms.PSet(layer = cms.int32(3), module = cms.int32(7), angle = cms.double(BPIX_LAYER_3_MODULE_5_8)),
+            cms.PSet(layer = cms.int32(3), module = cms.int32(8), angle = cms.double(BPIX_LAYER_3_MODULE_5_8)),
+            cms.PSet(layer = cms.int32(4), module = cms.int32(1), angle = cms.double(BPIX_LAYER_4_MODULE_1_4)),
+            cms.PSet(layer = cms.int32(4), module = cms.int32(2), angle = cms.double(BPIX_LAYER_4_MODULE_1_4)),
+            cms.PSet(layer = cms.int32(4), module = cms.int32(3), angle = cms.double(BPIX_LAYER_4_MODULE_1_4)),
+            cms.PSet(layer = cms.int32(4), module = cms.int32(4), angle = cms.double(BPIX_LAYER_4_MODULE_1_4)),
+            cms.PSet(layer = cms.int32(4), module = cms.int32(5), angle = cms.double(BPIX_LAYER_4_MODULE_5_8)),
+            cms.PSet(layer = cms.int32(4), module = cms.int32(6), angle = cms.double(BPIX_LAYER_4_MODULE_5_8)),
+            cms.PSet(layer = cms.int32(4), module = cms.int32(7), angle = cms.double(BPIX_LAYER_4_MODULE_5_8)),
+            cms.PSet(layer = cms.int32(4), module = cms.int32(8), angle = cms.double(BPIX_LAYER_4_MODULE_5_8)),        
+        )
+    elif(options.isFPix):
+        print("  ========> Testing FPix parameters")
+        process.SiPixelFakeLorentzAngleESSource.FPixParameters = cms.VPSet(
+            cms.PSet(
+                ring = cms.int32(1),
+                panel = cms.int32(1),
+                angle = cms.double(0.0805)
+            ),
+            cms.PSet(
+                ring = cms.int32(1),
+                panel = cms.int32(2),
+                angle = cms.double(0.0788)
+            ),
+            cms.PSet(
+                ring = cms.int32(2),
+                panel = cms.int32(1),
+                angle = cms.double(0.0756)
+            ),
+            cms.PSet(
+                ring = cms.int32(2),
+                panel = cms.int32(2),
+                angle = cms.double(0.0736)
+            )
+        )       
+    elif(options.isByModule):
+        print(" ========> Testing byModule")
+        process.SiPixelFakeLorentzAngleESSource.ModuleParameters = cms.VPSet(
+            cms.PSet( rawid=cms.uint32(352588804), angle=cms.double(FPix_300V_RNG1_PNL1) ),
+            cms.PSet( rawid=cms.uint32(352592900), angle=cms.double(FPix_300V_RNG1_PNL1) ),
+            cms.PSet( rawid=cms.uint32(352596996), angle=cms.double(FPix_300V_RNG1_PNL1) ),
+            cms.PSet( rawid=cms.uint32(352601092), angle=cms.double(FPix_300V_RNG1_PNL1) ),
+            cms.PSet( rawid=cms.uint32(352605188), angle=cms.double(FPix_300V_RNG1_PNL1) ),
+            cms.PSet( rawid=cms.uint32(352609284), angle=cms.double(FPix_300V_RNG1_PNL1) ),
+            cms.PSet( rawid=cms.uint32(352658436), angle=cms.double(FPix_300V_RNG1_PNL1) ),
+            cms.PSet( rawid=cms.uint32(352662532), angle=cms.double(FPix_300V_RNG1_PNL1) ),
+            cms.PSet( rawid=cms.uint32(352666628), angle=cms.double(FPix_300V_RNG1_PNL1) ),
+            cms.PSet( rawid=cms.uint32(352670724), angle=cms.double(FPix_300V_RNG1_PNL1) ),
+            cms.PSet( rawid=cms.uint32(352674820), angle=cms.double(FPix_300V_RNG1_PNL1) ),
+            cms.PSet( rawid=cms.uint32(344749060), angle=cms.double(FPix_300V_RNG1_PNL1) ),
+            cms.PSet( rawid=cms.uint32(344753156), angle=cms.double(FPix_300V_RNG1_PNL1) ),
+            cms.PSet( rawid=cms.uint32(344757252), angle=cms.double(FPix_300V_RNG1_PNL1) ),
+            cms.PSet( rawid=cms.uint32(344781828), angle=cms.double(FPix_300V_RNG1_PNL1) ),
+            cms.PSet( rawid=cms.uint32(344785924), angle=cms.double(FPix_300V_RNG1_PNL1) ),
+            cms.PSet( rawid=cms.uint32(344790020), angle=cms.double(FPix_300V_RNG1_PNL1) ),
+            cms.PSet( rawid=cms.uint32(352589828), angle=cms.double(FPix_300V_RNG1_PNL2) ),
+            cms.PSet( rawid=cms.uint32(352593924), angle=cms.double(FPix_300V_RNG1_PNL2) ),
+            cms.PSet( rawid=cms.uint32(352598020), angle=cms.double(FPix_300V_RNG1_PNL2) ),
+            cms.PSet( rawid=cms.uint32(352602116), angle=cms.double(FPix_300V_RNG1_PNL2) ),
+            cms.PSet( rawid=cms.uint32(352606212), angle=cms.double(FPix_300V_RNG1_PNL2) ),
+            cms.PSet( rawid=cms.uint32(352610308), angle=cms.double(FPix_300V_RNG1_PNL2) ),
+            cms.PSet( rawid=cms.uint32(352659460), angle=cms.double(FPix_300V_RNG1_PNL2) ),
+            cms.PSet( rawid=cms.uint32(352663556), angle=cms.double(FPix_300V_RNG1_PNL2) ),
+            cms.PSet( rawid=cms.uint32(352667652), angle=cms.double(FPix_300V_RNG1_PNL2) ),
+            cms.PSet( rawid=cms.uint32(352671748), angle=cms.double(FPix_300V_RNG1_PNL2) ),
+            cms.PSet( rawid=cms.uint32(352675844), angle=cms.double(FPix_300V_RNG1_PNL2) ),
+            cms.PSet( rawid=cms.uint32(344750084), angle=cms.double(FPix_300V_RNG1_PNL2) ),
+            cms.PSet( rawid=cms.uint32(344754180), angle=cms.double(FPix_300V_RNG1_PNL2) ),
+            cms.PSet( rawid=cms.uint32(344758276), angle=cms.double(FPix_300V_RNG1_PNL2) ),
+            cms.PSet( rawid=cms.uint32(344782852), angle=cms.double(FPix_300V_RNG1_PNL2) ),
+            cms.PSet( rawid=cms.uint32(344786948), angle=cms.double(FPix_300V_RNG1_PNL2) ),
+            cms.PSet( rawid=cms.uint32(344791044), angle=cms.double(FPix_300V_RNG1_PNL2) ),
+            cms.PSet( rawid=cms.uint32(344851460), angle=cms.double(FPix_300V_RNG2_PNL1) ),
+            cms.PSet( rawid=cms.uint32(344855556), angle=cms.double(FPix_300V_RNG2_PNL1) ),
+            cms.PSet( rawid=cms.uint32(344859652), angle=cms.double(FPix_300V_RNG2_PNL1) ),
+            cms.PSet( rawid=cms.uint32(344863748), angle=cms.double(FPix_300V_RNG2_PNL1) ),
+            cms.PSet( rawid=cms.uint32(344852484), angle=cms.double(FPix_300V_RNG2_PNL2) ),
+            cms.PSet( rawid=cms.uint32(344856580), angle=cms.double(FPix_300V_RNG2_PNL2) ),
+            cms.PSet( rawid=cms.uint32(344860676), angle=cms.double(FPix_300V_RNG2_PNL2) )
+        )
+    
+process.LorentzAngleReader = cms.EDAnalyzer("SiPixelLorentzAngleReader",
+                                            printDebug = cms.untracked.bool(True),
+                                            useSimRcd = cms.bool(False)
+                                           )
+
+process.p = cms.Path(process.LorentzAngleReader)

--- a/CondTools/SiPixel/plugins/SiPixelLorentzAngleReader.cc
+++ b/CondTools/SiPixel/plugins/SiPixelLorentzAngleReader.cc
@@ -75,8 +75,9 @@ void SiPixelLorentzAngleReader::analyze(const edm::Event& e, const edm::EventSet
   std::map<unsigned int, float> detid_la = SiPixelLorentzAngle_->getLorentzAngles();
   std::map<unsigned int, float>::const_iterator it;
   for (it = detid_la.begin(); it != detid_la.end(); it++) {
-    //	edm::LogPrint("SiPixelLorentzAngleReader")  << "detid " << it->first << " \t" << " Lorentz angle  " << it->second  << std::endl;
-    //edm::LogInfo("SiPixelLorentzAngleReader")  << "detid " << it->first << " \t" << " Lorentz angle  " << it->second;
+    if(printdebug_){
+      edm::LogPrint("SiPixelLorentzAngleReader")  << "detid " << it->first << " \t" << " Lorentz angle  " << it->second  << std::endl;
+    }
     unsigned int subdet = DetId(it->first).subdetId();
     if (subdet == static_cast<int>(PixelSubdetector::PixelBarrel)) {
       LorentzAngleBarrel_->Fill(it->second);

--- a/CondTools/SiPixel/plugins/SiPixelLorentzAngleReader.cc
+++ b/CondTools/SiPixel/plugins/SiPixelLorentzAngleReader.cc
@@ -75,8 +75,9 @@ void SiPixelLorentzAngleReader::analyze(const edm::Event& e, const edm::EventSet
   std::map<unsigned int, float> detid_la = SiPixelLorentzAngle_->getLorentzAngles();
   std::map<unsigned int, float>::const_iterator it;
   for (it = detid_la.begin(); it != detid_la.end(); it++) {
-    if(printdebug_){
-      edm::LogPrint("SiPixelLorentzAngleReader")  << "detid " << it->first << " \t" << " Lorentz angle  " << it->second  << std::endl;
+    if (printdebug_) {
+      edm::LogPrint("SiPixelLorentzAngleReader") << "detid " << it->first << " \t"
+                                                 << " Lorentz angle  " << it->second << std::endl;
     }
     unsigned int subdet = DetId(it->first).subdetId();
     if (subdet == static_cast<int>(PixelSubdetector::PixelBarrel)) {


### PR DESCRIPTION
#### PR description:

It has been suggested that for phase-2 IT geometry development it might be quicker to use fake CPE conditions as opposed to using  to meta-`GlobalTag`s from `autoCondPhase2`.
One of the shortcoming of the current `SiPixelFakeLorentzAngleESSource` is that it has one unique hard-coded value for the μH for all `DetId`s. This overcome in this PR.
Profited of the PR to introduce unit tests.

#### PR validation:

Run the unit tests.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
