### PR TITLE
Add option for dimuon Delta R for HLTMuonDimuonL3Filter

### DIFF
--- a/HLTrigger/Muon/plugins/HLTMuonDimuonL3Filter.cc
+++ b/HLTrigger/Muon/plugins/HLTMuonDimuonL3Filter.cc
@@ -75,6 +75,9 @@ HLTMuonDimuonL3Filter::HLTMuonDimuonL3Filter(const edm::ParameterSet& iConfig)
       max_PtMin_(iConfig.getParameter<vector<double> >("MaxPtMin")),
       min_InvMass_(iConfig.getParameter<vector<double> >("MinInvMass")),
       max_InvMass_(iConfig.getParameter<vector<double> >("MaxInvMass")),
+      applyMinDiMuonDeltaR2Cut_(iConfig.getParameter<double>("MinDiMuonDeltaR") > 0.),
+      min_DiMuonDeltaR2_(iConfig.getParameter<double>("MinDiMuonDeltaR") *
+                         iConfig.getParameter<double>("MinDiMuonDeltaR")),
       min_Acop_(iConfig.getParameter<double>("MinAcop")),
       max_Acop_(iConfig.getParameter<double>("MaxAcop")),
       min_PtBalance_(iConfig.getParameter<double>("MinPtBalance")),
@@ -88,14 +91,42 @@ HLTMuonDimuonL3Filter::HLTMuonDimuonL3Filter(const edm::ParameterSet& iConfig)
       L1MatchingdR_(iConfig.getParameter<double>("L1MatchingdR")),
       matchPreviousCand_(iConfig.getParameter<bool>("MatchToPreviousCand")),
       MuMass2_(0.106 * 0.106) {
-  LogDebug("HLTMuonDimuonL3Filter") << " CandTag/MinN/MaxEta/MinNhits/MaxDr/MaxDz/MinPt1/MinPt2/MinInvMass/MaxInvMass/"
+  // check consistency of parameters for mass-window cuts
+  if (min_InvMass_.size() != min_PtPair_.size()) {
+    throw cms::Exception("Configuration") << "size of \"MinInvMass\" (" << min_InvMass_.size()
+                                          << ") and \"MinPtPair\" (" << min_PtPair_.size() << ") differ";
+  }
+  if (min_InvMass_.size() != max_PtPair_.size()) {
+    throw cms::Exception("Configuration") << "size of \"MinInvMass\" (" << min_InvMass_.size()
+                                          << ") and \"MaxPtPair\" (" << max_PtPair_.size() << ") differ";
+  }
+  if (min_InvMass_.size() != min_PtMax_.size()) {
+    throw cms::Exception("Configuration") << "size of \"MinInvMass\" (" << min_InvMass_.size() << ") and \"MinPtMax\" ("
+                                          << min_PtMax_.size() << ") differ";
+  }
+  if (min_InvMass_.size() != min_PtMin_.size()) {
+    throw cms::Exception("Configuration") << "size of \"MinInvMass\" (" << min_InvMass_.size() << ") and \"MinPtMin\" ("
+                                          << min_PtMin_.size() << ") differ";
+  }
+  if (min_InvMass_.size() != max_PtMin_.size()) {
+    throw cms::Exception("Configuration") << "size of \"MinInvMass\" (" << min_InvMass_.size() << ") and \"MaxPtMin\" ("
+                                          << max_PtMin_.size() << ") differ";
+  }
+  if (min_InvMass_.size() != max_InvMass_.size()) {
+    throw cms::Exception("Configuration") << "size of \"MinInvMass\" (" << min_InvMass_.size()
+                                          << ") and \"MaxInvMass\" (" << max_InvMass_.size() << ") differ";
+  }
+
+  LogDebug("HLTMuonDimuonL3Filter") << " CandTag/FastAccept/MinN/MaxEta/MinNhits/MaxDr/MaxDz/MinPt1/MinPt2/MinInvMass/"
+                                       "MaxInvMass/applyMinDiMuonDeltaRCut/MinDiMuonDeltaR"
                                        "MinAcop/MaxAcop/MinPtBalance/MaxPtBalance/NSigmaPt/MaxDzMuMu/MaxRapidityPair : "
                                     << candTag_.encode() << " " << fast_Accept_ << " " << min_N_ << " " << max_Eta_
                                     << " " << min_Nhits_ << " " << max_Dr_ << " " << max_Dz_ << " " << chargeOpt_ << " "
                                     << Out(min_PtPair_) << " " << Out(min_PtMax_) << " " << Out(min_PtMin_) << " "
-                                    << Out(min_InvMass_) << " " << Out(max_InvMass_) << " " << min_Acop_ << " "
-                                    << max_Acop_ << " " << min_PtBalance_ << " " << max_PtBalance_ << " " << nsigma_Pt_
-                                    << " " << max_DCAMuMu_ << " " << max_YPair_;
+                                    << Out(min_InvMass_) << " " << Out(max_InvMass_) << " " << applyMinDiMuonDeltaR2Cut_
+                                    << " " << sqrt(min_DiMuonDeltaR2_) << " " << min_Acop_ << " " << max_Acop_ << " "
+                                    << min_PtBalance_ << " " << max_PtBalance_ << " " << nsigma_Pt_ << " "
+                                    << max_DCAMuMu_ << " " << max_YPair_;
 }
 
 HLTMuonDimuonL3Filter::~HLTMuonDimuonL3Filter() = default;
@@ -138,6 +169,7 @@ void HLTMuonDimuonL3Filter::fillDescriptions(edm::ConfigurationDescriptions& des
   desc.add<vector<double> >("MaxPtMin", v5);
   desc.add<vector<double> >("MinInvMass", v6);
   desc.add<vector<double> >("MaxInvMass", v7);
+  desc.add<double>("MinDiMuonDeltaR", -1.);
   desc.add<double>("MinAcop", -1.0);
   desc.add<double>("MaxAcop", 3.15);
   desc.add<double>("MinPtBalance", -1.0);
@@ -160,31 +192,6 @@ void HLTMuonDimuonL3Filter::fillDescriptions(edm::ConfigurationDescriptions& des
 bool HLTMuonDimuonL3Filter::hltFilter(edm::Event& iEvent,
                                       const edm::EventSetup& iSetup,
                                       trigger::TriggerFilterObjectWithRefs& filterproduct) const {
-  if (min_InvMass_.size() != min_PtPair_.size()) {
-    cout << "ERROR!!! Vector sizes don't match!" << endl;
-    return false;
-  }
-  if (min_InvMass_.size() != max_PtPair_.size()) {
-    cout << "ERROR!!! Vector sizes don't match!" << endl;
-    return false;
-  }
-  if (min_InvMass_.size() != min_PtMax_.size()) {
-    cout << "ERROR!!! Vector sizes don't match!" << endl;
-    return false;
-  }
-  if (min_InvMass_.size() != min_PtMin_.size()) {
-    cout << "ERROR!!! Vector sizes don't match!" << endl;
-    return false;
-  }
-  if (min_InvMass_.size() != max_PtMin_.size()) {
-    cout << "ERROR!!! Vector sizes don't match!" << endl;
-    return false;
-  }
-  if (min_InvMass_.size() != max_InvMass_.size()) {
-    cout << "ERROR!!! Vector sizes don't match!" << endl;
-    return false;
-  }
-
   // All HLT filters must create and fill an HLT filter object,
   // recording any reconstructed physics objects satisfying (or not)
   // this HLT filter, and place it in the Event.
@@ -594,6 +601,10 @@ bool HLTMuonDimuonL3Filter::applyDiMuonSelection(const RecoChargedCandidateRef& 
 
   double pt12 = p.pt();
   LogDebug("HLTMuonDimuonL3Filter") << " ... 1-2 pt12= " << pt12;
+
+  // Angle between the muons
+  if (applyMinDiMuonDeltaR2Cut_ and reco::deltaR2(p1, p2) < min_DiMuonDeltaR2_)
+    return false;
 
   double ptLx1 = cand1->pt();
   double ptLx2 = cand2->pt();

--- a/HLTrigger/Muon/plugins/HLTMuonDimuonL3Filter.h
+++ b/HLTrigger/Muon/plugins/HLTMuonDimuonL3Filter.h
@@ -59,29 +59,31 @@ private:
   const edm::InputTag recoMuTag_;  // input tag identifying reco muons
   const edm::EDGetTokenT<reco::MuonCollection> recoMuToken_;  // token identifying product contains reco muons
   bool previousCandIsL2_;
-  bool fast_Accept_;                 // flag to save time: stop processing after identification of the first valid pair
-  int min_N_;                        // minimum number of muons to fire the trigger
-  double max_Eta_;                   // Eta cut
-  int min_Nhits_;                    // threshold on number of hits on muon
-  double max_Dr_;                    // impact parameter cut
-  double max_Dz_;                    // dz cut
-  int chargeOpt_;                    // Charge option (0:nothing; +1:same charge, -1:opposite charge)
-  std::vector<double> min_PtPair_;   // minimum Pt for the dimuon system
-  std::vector<double> max_PtPair_;   // miaximum Pt for the dimuon system
-  std::vector<double> min_PtMax_;    // minimum Pt for muon with max Pt in pair
-  std::vector<double> min_PtMin_;    // minimum Pt for muon with min Pt in pair
-  std::vector<double> max_PtMin_;    // maximum Pt for muon with min Pt in pair
-  std::vector<double> min_InvMass_;  // minimum invariant mass of pair
-  std::vector<double> max_InvMass_;  // maximum invariant mass of pair
-  double min_Acop_;                  // minimum acoplanarity
-  double max_Acop_;                  // maximum acoplanarity
-  double min_PtBalance_;             // minimum Pt difference
-  double max_PtBalance_;             // maximum Pt difference
-  double nsigma_Pt_;                 // pt uncertainty margin (in number of sigmas)
-  double max_DCAMuMu_;               // DCA between the two muons
-  double max_YPair_;                 // |rapidity| of pair
-  bool cutCowboys_;                  ///< if true, reject muon-track pairs that bend towards each other
-  const edm::InputTag theL3LinksLabel;                                //Needed to iterL3
+  const bool fast_Accept_;  // flag to save time: stop processing after identification of the first valid pair
+  const int min_N_;         // minimum number of muons to fire the trigger
+  const double max_Eta_;    // Eta cut
+  const int min_Nhits_;     // threshold on number of hits on muon
+  const double max_Dr_;     // impact parameter cut
+  const double max_Dz_;     // dz cut
+  const int chargeOpt_;     // Charge option (0:nothing; +1:same charge, -1:opposite charge)
+  const std::vector<double> min_PtPair_;   // minimum Pt for the dimuon system
+  const std::vector<double> max_PtPair_;   // miaximum Pt for the dimuon system
+  const std::vector<double> min_PtMax_;    // minimum Pt for muon with max Pt in pair
+  const std::vector<double> min_PtMin_;    // minimum Pt for muon with min Pt in pair
+  const std::vector<double> max_PtMin_;    // maximum Pt for muon with min Pt in pair
+  const std::vector<double> min_InvMass_;  // minimum invariant mass of pair
+  const std::vector<double> max_InvMass_;  // maximum invariant mass of pair
+  const bool applyMinDiMuonDeltaR2Cut_;    // apply cut on minimum Delta-R^2 distance between the muons
+  const double min_DiMuonDeltaR2_;         // minimum Delta-R^2 distance between the muons
+  const double min_Acop_;                  // minimum acoplanarity
+  const double max_Acop_;                  // maximum acoplanarity
+  const double min_PtBalance_;             // minimum Pt difference
+  const double max_PtBalance_;             // maximum Pt difference
+  const double nsigma_Pt_;                 // pt uncertainty margin (in number of sigmas)
+  const double max_DCAMuMu_;               // DCA between the two muons
+  const double max_YPair_;                 // |rapidity| of pair
+  const bool cutCowboys_;                  ///< if true, reject muon-track pairs that bend towards each other
+  const edm::InputTag theL3LinksLabel;     //Needed to iterL3
   const edm::EDGetTokenT<reco::MuonTrackLinksCollection> linkToken_;  //Needed to iterL3
   const double L1MatchingdR_;
   const bool matchPreviousCand_;


### PR DESCRIPTION
#### PR description:

  - This PR is a development towards CMS Run3 HLT where we trigger events with soft muons in them. To get a reasonable rate, new kinematic constraints on the dimuon events need to be placed at the HLT.
  - Added options to make a selection on the minimum angle required between L3 muons in the trigger
  - This is based on the presentation at https://indico.cern.ch/event/1090283/#33-level-3-paths-for-singlet-t

  - Sam James Harper noticed that error management in the module can be improved.
  - It is ideal to throw an exception at the constructor level when that error renders the module of no use. This enable catching the error in the build phase instead of having to wait for a message from cmsRun.

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

  - Standard set of checks performed at https://cms-sw.github.io/PRWorkflow.html were done and passed.
  - A trigger was made with the suggested changes. We observed expected behavior from this trigger of interest. 
  - @missirol made a first round of review and corrections in a previous PR at https://github.com/cms-sw/cmssw/pull/36250. I had to close this because of some major mistakes while trying to squash the commits together.