### PR TITLE
[GEM] GEMAMC13 DataFormats bugfix

### DIFF
--- a/DataFormats/GEMDigi/interface/GEMAMC13.h
+++ b/DataFormats/GEMDigi/interface/GEMAMC13.h
@@ -95,7 +95,7 @@ public:
   uint32_t lv1Id() const { return CDFHeader{cdfh_}.lv1Id; }
   uint16_t sourceId() const { return CDFHeader{cdfh_}.sourceId; }
 
-  uint16_t orbitNumber() const { return AMC13Header{amc13h_}.orbitN; }
+  uint32_t orbitNumber() const { return AMC13Header{amc13h_}.orbitN; }
   uint8_t nAMC() const { return AMC13Header{amc13h_}.nAMC; }
 
   const std::vector<uint64_t>* getAMCheaders() const { return &amcHeaders_; }

--- a/DataFormats/GEMDigi/interface/GEMAMCStatus.h
+++ b/DataFormats/GEMDigi/interface/GEMAMCStatus.h
@@ -36,7 +36,7 @@ public:
     error.badEC = (amc13->lv1Id() != amc.lv1Id());
     error.badBC = (amc13->bunchCrossing() != amc.bunchCrossing());
     error.badRunType = amc.runType() != 0x1;
-    error.badOC = (amc13->orbitNumber() != amc.orbitNumber());
+    error.badOC = (uint16_t(amc13->orbitNumber()) != amc.orbitNumber());
     error.MMCMlocked = !amc.mmcmLocked();
     error.DAQclocklocked = !amc.daqClockLocked();
     error.DAQnotReday = !amc.daqReady();


### PR DESCRIPTION
#### PR description:
- in GEMAMC13, orbitNumber() fixed to return uint32_t instead of uint16_t
- in GEMAMCStatus, orbitNumber comparison between amc13 and amc limited to uint16_t
- no changes expected.

#### PR validation:
tested with wf 34611.0, 11611.0