### PR TITLE
Backport particle level runtime improvements for Nano 106X

### DIFF
--- a/GeneratorInterface/RivetInterface/interface/RivetAnalysis.h
+++ b/GeneratorInterface/RivetInterface/interface/RivetAnalysis.h
@@ -34,6 +34,7 @@ namespace Rivet {
       bool _usePromptFinalStates;
       bool _excludePromptLeptonsFromJetClustering;
       bool _excludeNeutrinosFromJetClustering;
+      bool _doJetClustering;
       
       double _particleMinPt, _particleMaxEta;
       double _lepConeSize, _lepMinPt, _lepMaxEta;
@@ -51,6 +52,7 @@ namespace Rivet {
       _usePromptFinalStates(pset.getParameter<bool>("usePromptFinalStates")),
       _excludePromptLeptonsFromJetClustering(pset.getParameter<bool>("excludePromptLeptonsFromJetClustering")),
       _excludeNeutrinosFromJetClustering(pset.getParameter<bool>("excludeNeutrinosFromJetClustering")),
+      _doJetClustering(pset.getParameter<bool>("doJetClustering")),
 
       _particleMinPt  (pset.getParameter<double>("particleMinPt")),
       _particleMaxEta (pset.getParameter<double>("particleMaxEta")),
@@ -201,8 +203,10 @@ namespace Rivet {
 
         }
 
-        _jets      = applyProjection<FastJets>(event, "Jets").jetsByPt(jet_cut);
-        _fatjets   = applyProjection<FastJets>(event, "FatJets").jetsByPt(fatjet_cut);
+        if (_doJetClustering) {
+          _jets = apply<FastJets>(event, "Jets").jetsByPt(jet_cut);
+          _fatjets = apply<FastJets>(event, "FatJets").jetsByPt(fatjet_cut);
+        }
         _neutrinos = applyProjection<FinalState>(event, "Neutrinos").particlesByPt();
         _met       = applyProjection<MissingMomentum>(event, "MET").missingMomentum().p3();
 

--- a/GeneratorInterface/RivetInterface/python/particleLevel_cfi.py
+++ b/GeneratorInterface/RivetInterface/python/particleLevel_cfi.py
@@ -6,6 +6,7 @@ particleLevel = cms.EDProducer("ParticleLevelProducer",
     usePromptFinalStates = cms.bool(True), # for leptons, photons, neutrinos
     excludePromptLeptonsFromJetClustering = cms.bool(True),
     excludeNeutrinosFromJetClustering = cms.bool(True),
+    doJetClustering = cms.bool(True),
     
     particleMinPt  = cms.double(0.),
     particleMaxEta = cms.double(5.), # HF range. Maximum 6.0 on MiniAOD

--- a/PhysicsTools/NanoAOD/plugins/GenJetGenPartMerger.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenJetGenPartMerger.cc
@@ -84,9 +84,9 @@ void GenJetGenPartMerger::produce(edm::Event& iEvent, const edm::EventSetup& iSe
   for (unsigned int ijet = 0; ijet < jetHandle->size(); ++ijet) {
     auto jet = jetHandle->at(ijet);
     if (cut_(jet)) {
-        merged->push_back(reco::GenJet(jet));
-        reco::GenJetRef jetRef(jetHandle, ijet);
-        hasTauAncValues.push_back((*tauAncHandle)[jetRef]);
+      merged->push_back(reco::GenJet(jet));
+      reco::GenJetRef jetRef(jetHandle, ijet);
+      hasTauAncValues.push_back((*tauAncHandle)[jetRef]);
     }
   }
 

--- a/PhysicsTools/NanoAOD/plugins/GenJetGenPartMerger.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenJetGenPartMerger.cc
@@ -16,6 +16,8 @@
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 
 #include "DataFormats/Common/interface/ValueMap.h"
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+#include "CommonTools/Utils/interface/StringObjectFunction.h"
 
 //
 // class declaration
@@ -33,6 +35,7 @@ private:
 
   const edm::EDGetTokenT<reco::GenJetCollection> jetToken_;
   const edm::EDGetTokenT<reco::GenParticleCollection> partToken_;
+  const StringCutObjectSelector<reco::Candidate> cut_;
   const edm::EDGetTokenT<edm::ValueMap<bool>> tauAncToken_;
 };
 
@@ -50,6 +53,7 @@ private:
 GenJetGenPartMerger::GenJetGenPartMerger(const edm::ParameterSet& iConfig)
     : jetToken_(consumes<reco::GenJetCollection>(iConfig.getParameter<edm::InputTag>("srcJet"))),
       partToken_(consumes<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("srcPart"))),
+      cut_(iConfig.getParameter<std::string>("cut")),
       tauAncToken_(consumes<edm::ValueMap<bool>>(iConfig.getParameter<edm::InputTag>("hasTauAnc"))) {
   produces<reco::GenJetCollection>("merged");
   produces<edm::ValueMap<bool>>("hasTauAnc");
@@ -79,9 +83,11 @@ void GenJetGenPartMerger::produce(edm::Event& iEvent, const edm::EventSetup& iSe
 
   for (unsigned int ijet = 0; ijet < jetHandle->size(); ++ijet) {
     auto jet = jetHandle->at(ijet);
-    merged->push_back(reco::GenJet(jet));
-    reco::GenJetRef jetRef(jetHandle, ijet);
-    hasTauAncValues.push_back((*tauAncHandle)[jetRef]);
+    if (cut_(jet)) {
+        merged->push_back(reco::GenJet(jet));
+        reco::GenJetRef jetRef(jetHandle, ijet);
+        hasTauAncValues.push_back((*tauAncHandle)[jetRef]);
+    }
   }
 
   for (auto& part : *partHandle) {

--- a/PhysicsTools/NanoAOD/python/electrons_cff.py
+++ b/PhysicsTools/NanoAOD/python/electrons_cff.py
@@ -478,7 +478,7 @@ tautaggerForMatching = cms.EDProducer("GenJetTauTaggerProducer",
 matchingElecPhoton = cms.EDProducer("GenJetGenPartMerger",
                                     srcJet =cms.InputTag("particleLevel:leptons"),
                                     srcPart=cms.InputTag("particleLevel:photons"),
-                                    cut = "pt > 3",
+                                    cut = cms.string("pt > 3"),
                                     hasTauAnc=cms.InputTag("tautaggerForMatching"),
 )
 

--- a/PhysicsTools/NanoAOD/python/electrons_cff.py
+++ b/PhysicsTools/NanoAOD/python/electrons_cff.py
@@ -469,19 +469,16 @@ run2_miniAOD_80XLegacy.toModify(electronTable.variables,
     vidNestedWPBitmapSum16 = Var("userInt('VIDNestedWPBitmapSum16')",int,doc=_bitmapVIDForEleSum16_docstring),
 
 )
-
-from PhysicsTools.NanoAOD.particlelevel_cff import particleLevel
-particleLevelForMatching = particleLevel.clone(
-    lepMinPt    = cms.double(3.),
-    phoMinPt = cms.double(3),
-)
+#############electron Table END#####################
+# Depends on particlelevel producer run in particlelevel_cff
 tautaggerForMatching = cms.EDProducer("GenJetTauTaggerProducer",
-                                      src = cms.InputTag('particleLevelForMatching:leptons')
+                                      src = cms.InputTag('particleLevel:leptons')
 )
 
 matchingElecPhoton = cms.EDProducer("GenJetGenPartMerger",
-                                    srcJet =cms.InputTag("particleLevelForMatching:leptons"),
-                                    srcPart=cms.InputTag("particleLevelForMatching:photons"),
+                                    srcJet =cms.InputTag("particleLevel:leptons"),
+                                    srcPart=cms.InputTag("particleLevel:photons"),
+                                    cut = "pt > 3",
                                     hasTauAnc=cms.InputTag("tautaggerForMatching"),
 )
 
@@ -535,8 +532,9 @@ electronMCTable = cms.EDProducer("CandMCMatchTableProducer",
 
 electronSequence = cms.Sequence(bitmapVIDForEle + bitmapVIDForEleHEEP + isoForEle + ptRatioRelForEle + seedGainEle + slimmedElectronsWithUserData + finalElectrons)
 electronTables = cms.Sequence (electronMVATTH + electronTable)
+<<<<<<< HEAD
 electronMCold = cms.Sequence(electronsMCMatchForTable + electronMCTable)
-electronMC = cms.Sequence(particleLevelForMatching + tautaggerForMatching + matchingElecPhoton + electronsMCMatchForTable + electronsMCMatchForTableAlt + electronMCTable)
+electronMC = cms.Sequence(tautaggerForMatching + matchingElecPhoton + electronsMCMatchForTable + electronsMCMatchForTableAlt + electronMCTable)
 ( run2_nanoAOD_106Xv1 & ~run2_nanoAOD_devel).toModify( electronMCTable,
                                                        mcMapDressedLep=None,
                                                        mcMap   = cms.InputTag("electronsMCMatchForTable"),

--- a/PhysicsTools/NanoAOD/python/electrons_cff.py
+++ b/PhysicsTools/NanoAOD/python/electrons_cff.py
@@ -532,7 +532,6 @@ electronMCTable = cms.EDProducer("CandMCMatchTableProducer",
 
 electronSequence = cms.Sequence(bitmapVIDForEle + bitmapVIDForEleHEEP + isoForEle + ptRatioRelForEle + seedGainEle + slimmedElectronsWithUserData + finalElectrons)
 electronTables = cms.Sequence (electronMVATTH + electronTable)
-<<<<<<< HEAD
 electronMCold = cms.Sequence(electronsMCMatchForTable + electronMCTable)
 electronMC = cms.Sequence(tautaggerForMatching + matchingElecPhoton + electronsMCMatchForTable + electronsMCMatchForTableAlt + electronMCTable)
 ( run2_nanoAOD_106Xv1 & ~run2_nanoAOD_devel).toModify( electronMCTable,

--- a/PhysicsTools/NanoAOD/python/lowPtElectrons_cff.py
+++ b/PhysicsTools/NanoAOD/python/lowPtElectrons_cff.py
@@ -124,11 +124,13 @@ lowPtElectronTable = cms.EDProducer(
 # electronTable (MC)
 ################################################################################
 
+# Depends on tautaggerForMatching being run in electrons_cff
 matchingLowPtElecPhoton = cms.EDProducer(
     "GenJetGenPartMerger",
-    srcJet =cms.InputTag("particleLevelForMatchingLowPt:leptons"),
-    srcPart=cms.InputTag("particleLevelForMatchingLowPt:photons"),
-    hasTauAnc=cms.InputTag("tautaggerForMatchingLowPt"),
+    srcJet =cms.InputTag("particleLevel:leptons"),
+    srcPart=cms.InputTag("particleLevel:photons"),
+    cut = cms.string(""),
+    hasTauAnc=cms.InputTag("tautaggerForMatching"),
 )
 
 lowPtElectronsMCMatchForTableAlt = cms.EDProducer(
@@ -183,9 +185,7 @@ lowPtElectronSequence = cms.Sequence(modifiedLowPtElectrons
                                      +finalLowPtElectrons)
 lowPtElectronTables = cms.Sequence(lowPtElectronTable)
 lowPtElectronMC = cms.Sequence(
-    particleLevelForMatchingLowPt
-    +tautaggerForMatchingLowPt
-    +matchingLowPtElecPhoton
+    matchingLowPtElecPhoton
     +lowPtElectronsMCMatchForTable
     +lowPtElectronsMCMatchForTableAlt
     +lowPtElectronMCTable)

--- a/PhysicsTools/NanoAOD/python/lowPtElectrons_cff.py
+++ b/PhysicsTools/NanoAOD/python/lowPtElectrons_cff.py
@@ -124,17 +124,6 @@ lowPtElectronTable = cms.EDProducer(
 # electronTable (MC)
 ################################################################################
 
-from PhysicsTools.NanoAOD.particlelevel_cff import particleLevel
-particleLevelForMatchingLowPt = particleLevel.clone(
-    lepMinPt = cms.double(1.),
-    phoMinPt = cms.double(1),
-)
-
-tautaggerForMatchingLowPt = cms.EDProducer(
-    "GenJetTauTaggerProducer",
-    src = cms.InputTag('particleLevelForMatchingLowPt:leptons')
-)
-
 matchingLowPtElecPhoton = cms.EDProducer(
     "GenJetGenPartMerger",
     srcJet =cms.InputTag("particleLevelForMatchingLowPt:leptons"),

--- a/PhysicsTools/NanoAOD/python/particlelevel_cff.py
+++ b/PhysicsTools/NanoAOD/python/particlelevel_cff.py
@@ -26,6 +26,7 @@ genParticles2HepMCHiggsVtx = cms.EDProducer("GenParticles2HepMCConverter",
 particleLevel = cms.EDProducer("ParticleLevelProducer",
     src = cms.InputTag("genParticles2HepMC:unsmeared"),
     
+    doJetClustering = cms.bool(False), # Not needed as Rivet jets aren't used currently
     usePromptFinalStates = cms.bool(True), # for leptons, photons, neutrinos
     excludePromptLeptonsFromJetClustering = cms.bool(False),
     excludeNeutrinosFromJetClustering = cms.bool(True),

--- a/PhysicsTools/NanoAOD/python/particlelevel_cff.py
+++ b/PhysicsTools/NanoAOD/python/particlelevel_cff.py
@@ -34,7 +34,7 @@ particleLevel = cms.EDProducer("ParticleLevelProducer",
     particleMaxEta = cms.double(5.), # HF range. Maximum 6.0 on MiniAOD
     
     lepConeSize = cms.double(0.1), # for photon dressing
-    lepMinPt    = cms.double(15.),
+    lepMinPt    = cms.double(1.),
     lepMaxEta   = cms.double(2.5),
     
     jetConeSize = cms.double(0.4),
@@ -47,7 +47,7 @@ particleLevel = cms.EDProducer("ParticleLevelProducer",
 
     phoIsoConeSize = cms.double(0.4),
     phoMaxRelIso = cms.double(0.5),
-    phoMinPt = cms.double(10),
+    phoMinPt = cms.double(1.),
     phoMaxEta = cms.double(2.5),
 )
 
@@ -61,7 +61,7 @@ rivetProducerHTXS = cms.EDProducer('HTXSRivetProducer',
 ##################### Tables for final output and docs ##########################
 rivetLeptonTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
     src = cms.InputTag("particleLevel:leptons"),
-    cut = cms.string(""),
+    cut = cms.string("pt > 15"),
     name= cms.string("GenDressedLepton"),
     doc = cms.string("Dressed leptons from Rivet-based ParticleLevelProducer"),
     singleton = cms.bool(False), # the number of entries is variable
@@ -77,7 +77,7 @@ rivetLeptonTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
 
 rivetPhotonTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
     src = cms.InputTag("particleLevel:photons"),
-    cut = cms.string(""),
+    cut = cms.string("pt > 10"),
     name= cms.string("GenIsolatedPhoton"),
     doc = cms.string("Isolated photons from Rivet-based ParticleLevelProducer"),
     singleton = cms.bool(False), # the number of entries is variable


### PR DESCRIPTION
#### PR description:

Backport particle level runtime improvements for Nano

#### PR validation:

Tested Nano v8 sequence

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of #34590

For more efficient running (avoid re-running jet clustering, particle level producer multiple times) of NanoAOD, which stays in 106 for the immediate future.