### PR TITLE
Fix assert in prefixScan_t.cu

### DIFF
--- a/HeterogeneousCore/CUDAUtilities/test/prefixScan_t.cu
+++ b/HeterogeneousCore/CUDAUtilities/test/prefixScan_t.cu
@@ -39,7 +39,7 @@ __global__ void testPrefixScan(uint32_t size) {
       printf(format_traits<T>::failed_msg, size, i, blockDim.x, c[i], c[i - 1]);
     assert(c[i] == c[i - 1] + 1);
     assert(c[i] == i + 1);
-    assert(c[i] = co[i]);
+    assert(c[i] == co[i]);
   }
 }
 


### PR DESCRIPTION
#### PR description:

Fix an `assert` condition in `prefixScan_t.cu`.

Technical, no changes expected.

#### PR validation:

None.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of ...