### PR TITLE
Fix assertion comparisons found by gcc11

### DIFF
--- a/FWCore/Integration/test/TestInterProcessProd.cc
+++ b/FWCore/Integration/test/TestInterProcessProd.cc
@@ -42,7 +42,7 @@ namespace testinter {
         {
           auto nlines = std::to_string(std::count(iConfig.begin(), iConfig.end(), '\n'));
           auto result = fwrite(nlines.data(), sizeof(char), nlines.size(), pipe_);
-          assert(result = nlines.size());
+          assert(result == nlines.size());
           result = fwrite(iConfig.data(), sizeof(char), iConfig.size(), pipe_);
           assert(result == iConfig.size());
           fflush(pipe_);

--- a/FWCore/Integration/test/TestInterProcessRandomProd.cc
+++ b/FWCore/Integration/test/TestInterProcessRandomProd.cc
@@ -54,7 +54,7 @@ namespace testinter {
         {
           auto nlines = std::to_string(std::count(iConfig.begin(), iConfig.end(), '\n'));
           auto result = fwrite(nlines.data(), sizeof(char), nlines.size(), pipe_);
-          assert(result = nlines.size());
+          assert(result == nlines.size());
           result = fwrite(iConfig.data(), sizeof(char), iConfig.size(), pipe_);
           assert(result == iConfig.size());
           fflush(pipe_);


### PR DESCRIPTION
#### PR description:

Trivial fix for FWCore/Integration tests with assignment where equality was meant.  Found by gcc11 builds.

#### PR validation:

Compiles and passes tests.