### PR TITLE
Add labels to `SiPixelFakeLorentzAngleESSource` and `SiPixelLorentzAngleReader`

### DIFF
--- a/CalibTracker/SiPixelESProducers/interface/SiPixelFakeLorentzAngleESSource.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelFakeLorentzAngleESSource.h
@@ -49,8 +49,9 @@ private:
   int HVgroup(int panel, int module);
 
   // data members
-  edm::FileInPath fp_;
-  edm::FileInPath t_topo_fp_;
+  const edm::FileInPath fp_;
+  const edm::FileInPath t_topo_fp_;
+  const std::string myLabel_;
   typedef std::vector<edm::ParameterSet> Parameters;
   Parameters BPixParameters_;
   Parameters FPixParameters_;

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeLorentzAngleESSource.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeLorentzAngleESSource.cc
@@ -34,6 +34,7 @@
 SiPixelFakeLorentzAngleESSource::SiPixelFakeLorentzAngleESSource(const edm::ParameterSet& conf_)
     : fp_(conf_.getParameter<edm::FileInPath>("file")),
       t_topo_fp_(conf_.getParameter<edm::FileInPath>("topologyInput")),
+      myLabel_(conf_.getParameter<std::string>("label")),
       BPixParameters_(conf_.getParameter<Parameters>("BPixParameters")),
       FPixParameters_(conf_.getParameter<Parameters>("FPixParameters")),
       ModuleParameters_(conf_.getParameter<Parameters>("ModuleParameters")),
@@ -41,7 +42,7 @@ SiPixelFakeLorentzAngleESSource::SiPixelFakeLorentzAngleESSource(const edm::Para
       fPixLorentzAnglePerTesla_((float)conf_.getUntrackedParameter<double>("fPixLorentzAnglePerTesla", -9999.)) {
   edm::LogInfo("SiPixelFakeLorentzAngleESSource::SiPixelFakeLorentzAngleESSource");
   // the following line is needed to tell the framework what data is being produced
-  setWhatProduced(this);
+  setWhatProduced(this, myLabel_);
   findingRecord<SiPixelLorentzAngleRcd>();
 }
 
@@ -239,11 +240,15 @@ void SiPixelFakeLorentzAngleESSource::fillDescriptions(edm::ConfigurationDescrip
   desc.setComment("ESSource to supply per-module SiPixelLorentzAngle payloads in the EventSetup");
 
   desc.add<edm::FileInPath>(
-      "file", edm::FileInPath("SLHCUpgradeSimulations/Geometry/data/PhaseI/PixelSkimmedGeometry_phase1.txt"));
+          "file", edm::FileInPath("SLHCUpgradeSimulations/Geometry/data/PhaseI/PixelSkimmedGeometry_phase1.txt"))
+      ->setComment("Tracker skimmed geometry");
   desc.add<edm::FileInPath>("topologyInput",
-                            edm::FileInPath("Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml"));
-  desc.addUntracked<double>("bPixLorentzAnglePerTesla", -9999.);
-  desc.addUntracked<double>("fPixLorentzAnglePerTesla", -9999.);
+                            edm::FileInPath("Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml"))
+      ->setComment("Tracker Topology");
+
+  desc.add<std::string>("label", "")->setComment("label to which write the data");
+  desc.addUntracked<double>("bPixLorentzAnglePerTesla", -9999.)->setComment("LA value for all BPix");
+  desc.addUntracked<double>("fPixLorentzAnglePerTesla", -9999.)->setComment("LA value for all FPix");
 
   edm::ParameterSetDescription desc_BPixParameters;
   desc_BPixParameters.addOptional<int>("layer");
@@ -252,7 +257,8 @@ void SiPixelFakeLorentzAngleESSource::fillDescriptions(edm::ConfigurationDescrip
   desc_BPixParameters.addOptional<int>("side");
   desc_BPixParameters.add<double>("angle");
   std::vector<edm::ParameterSet> default_BPixParametersToAdd;
-  desc.addVPSet("BPixParameters", desc_BPixParameters, default_BPixParametersToAdd);
+  desc.addVPSet("BPixParameters", desc_BPixParameters, default_BPixParametersToAdd)
+      ->setComment("LA values for given BPix regions");
 
   edm::ParameterSetDescription desc_FPixParameters;
   desc_FPixParameters.addOptional<int>("side");
@@ -263,13 +269,15 @@ void SiPixelFakeLorentzAngleESSource::fillDescriptions(edm::ConfigurationDescrip
   desc_FPixParameters.addOptional<int>("HVgroup");
   desc_FPixParameters.add<double>("angle");
   std::vector<edm::ParameterSet> default_FPixParametersToAdd;
-  desc.addVPSet("FPixParameters", desc_FPixParameters, default_FPixParametersToAdd);
+  desc.addVPSet("FPixParameters", desc_FPixParameters, default_FPixParametersToAdd)
+      ->setComment("LA values for given FPix regions");
 
   edm::ParameterSetDescription desc_ModuleParameters;
   desc_ModuleParameters.add<unsigned int>("rawid");
   desc_ModuleParameters.add<double>("angle");
   std::vector<edm::ParameterSet> default_ModuleParametersToAdd;
-  desc.addVPSet("ModuleParameters", desc_ModuleParameters, default_ModuleParametersToAdd);
+  desc.addVPSet("ModuleParameters", desc_ModuleParameters, default_ModuleParametersToAdd)
+      ->setComment("LA values for given modules");
 
   descriptions.addWithDefaultLabel(desc);
 }

--- a/CalibTracker/SiPixelESProducers/test/testSiPixelFakeLorentzAngleESSource_cfg.py
+++ b/CalibTracker/SiPixelESProducers/test/testSiPixelFakeLorentzAngleESSource_cfg.py
@@ -70,6 +70,7 @@ process.SiPixelFakeLorentzAngleESSource = siPixelFakeLorentzAngleESSource.clone(
 
 if(options.isPhase2):
     print(" ========> Testing Phase-2")
+    process.SiPixelFakeLorentzAngleESSource.label = cms.string("forPhase2")
     process.SiPixelFakeLorentzAngleESSource.bPixLorentzAnglePerTesla = cms.untracked.double(0.106)
     process.SiPixelFakeLorentzAngleESSource.fPixLorentzAnglePerTesla = cms.untracked.double(0.106)
     process.SiPixelFakeLorentzAngleESSource.file = 'SLHCUpgradeSimulations/Geometry/data/PhaseII/Tilted/PixelSkimmedGeometryT14.txt'
@@ -174,9 +175,13 @@ else:
             cms.PSet( rawid=cms.uint32(344860676), angle=cms.double(FPix_300V_RNG2_PNL2) )
         )
     
+##
+## SiPixelLorentzAngleReader (from Event Setup)
+##
 process.LorentzAngleReader = cms.EDAnalyzer("SiPixelLorentzAngleReader",
-                                            printDebug = cms.untracked.bool(True),
-                                            useSimRcd = cms.bool(False)
-                                           )
+                                            printDebug = cms.untracked.uint32(10),
+                                            useSimRcd = cms.bool(False),
+                                            recoLabel = cms.string("forPhase2" if options.isPhase2 else "") # test the label
+                                            )
 
 process.p = cms.Path(process.LorentzAngleReader)

--- a/CondTools/SiPixel/plugins/SiPixelLorentzAngleReader.cc
+++ b/CondTools/SiPixel/plugins/SiPixelLorentzAngleReader.cc
@@ -16,7 +16,9 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
@@ -35,14 +37,16 @@ public:
   explicit SiPixelLorentzAngleReader(const edm::ParameterSet&);
   ~SiPixelLorentzAngleReader() override;
 
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
 private:
   const edm::ESGetToken<SiPixelLorentzAngle, SiPixelLorentzAngleRcd> siPixelLAToken_;
   const edm::ESGetToken<SiPixelLorentzAngle, SiPixelLorentzAngleSimRcd> siPixelSimLAToken_;
-  const bool printdebug_;
+  const std::string siPixelLALabel_;
+  const std::string siPixelSimLALabel_;
+  const uint32_t printdebug_;
   const bool useSimRcd_;
-
   TH1F* LorentzAngleBarrel_;
   TH1F* LorentzAngleForward_;
 };
@@ -50,9 +54,9 @@ private:
 using namespace cms;
 
 SiPixelLorentzAngleReader::SiPixelLorentzAngleReader(const edm::ParameterSet& iConfig)
-    : siPixelLAToken_(esConsumes()),
-      siPixelSimLAToken_(esConsumes()),
-      printdebug_(iConfig.getUntrackedParameter<bool>("printDebug", false)),
+    : siPixelLAToken_(esConsumes(edm::ESInputTag("", iConfig.getParameter<std::string>("recoLabel")))),
+      siPixelSimLAToken_(esConsumes((edm::ESInputTag("", iConfig.getParameter<std::string>("simLabel"))))),
+      printdebug_(iConfig.getUntrackedParameter<uint32_t>("printDebug", 10)),
       useSimRcd_(iConfig.getParameter<bool>("useSimRcd")) {
   usesResource(TFileService::kSharedResource);
 }
@@ -74,8 +78,10 @@ void SiPixelLorentzAngleReader::analyze(const edm::Event& e, const edm::EventSet
   LorentzAngleForward_ = fs->make<TH1F>("LorentzAngleForwardPixel", "LorentzAngleForwardPixel", 150, 0, 0.15);
   std::map<unsigned int, float> detid_la = SiPixelLorentzAngle_->getLorentzAngles();
   std::map<unsigned int, float>::const_iterator it;
+  unsigned int count = 0;
   for (it = detid_la.begin(); it != detid_la.end(); it++) {
-    if (printdebug_) {
+    count++;
+    if (count <= printdebug_) {
       edm::LogPrint("SiPixelLorentzAngleReader") << "detid " << it->first << " \t"
                                                  << " Lorentz angle  " << it->second << std::endl;
     }
@@ -86,6 +92,18 @@ void SiPixelLorentzAngleReader::analyze(const edm::Event& e, const edm::EventSet
       LorentzAngleForward_->Fill(it->second);
     }
   }
+  edm::LogPrint("SiPixelLorentzAngleReader")
+      << "SiPixelLorentzAngleReader::" << __FUNCTION__ << "(...) :examined " << count << " DetIds" << std::endl;
+}
+
+void SiPixelLorentzAngleReader::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.setComment("EDAnalyzer to read per-module SiPixelLorentzAngle payloads in the EventSetup");
+  desc.add<std::string>("recoLabel", "")->setComment("label for the reconstruction tags");
+  desc.add<std::string>("simLabel", "")->setComment("label for the simulation tags");
+  desc.addUntracked<unsigned int>("printDebug", 10);
+  desc.add<bool>("useSimRcd", false);
+  descriptions.addWithDefaultLabel(desc);
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/CondTools/SiPixel/test/SiPixelLorentzAngleReader_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelLorentzAngleReader_cfg.py
@@ -67,14 +67,17 @@ process.QualityReader = cms.ESSource("PoolDBESSource",
 process.es_prefer_QualityReader = cms.ESPrefer("PoolDBESSource","QualityReader")
 
 process.LorentzAngleReader = cms.EDAnalyzer("SiPixelLorentzAngleReader",
-    printDebug = cms.untracked.bool(False),
-    useSimRcd = cms.bool(False)
+    printDebug = cms.untracked.uint32(10),
+    useSimRcd = cms.bool(False),
+    recoLabel = cms.string(""),
+    simLabel = cms.string("")
 )
 
 process.LorentzAngleSimReader = cms.EDAnalyzer("SiPixelLorentzAngleReader",
-    printDebug = cms.untracked.bool(False),
-    useSimRcd = cms.bool(True)
-                                             
+    printDebug = cms.untracked.uint32(10),
+    useSimRcd = cms.bool(True),
+    recoLabel = cms.string(""),
+    simLabel = cms.string("")
 )
 
 


### PR DESCRIPTION
#### PR description:

This is a follow-up to PR https://github.com/cms-sw/cmssw/pull/36265. As there are different flavors (`label`s) of `SiPixelLorentzAngleRcd` (e.g. `"forWidth"` and `"forAlignment"`) a label mechanism needs to be added to account for such cases.
I profit to enhance `SiPixelLorentzAngleReader` to deal with labels and to add a `fillDescription` method.

#### PR validation:

Unit tests, pass.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

