### PR TITLE
Properly import from containers

### DIFF
--- a/FWCore/ParameterSet/python/OrderedSet.py
+++ b/FWCore/ParameterSet/python/OrderedSet.py
@@ -24,9 +24,9 @@ from __future__ import print_function
 # Copied from URL http://code.activestate.com/recipes/576694-orderedset/
 # on 15 November 2016
 
-import collections
+import collections.abc
 
-class OrderedSet(collections.MutableSet):
+class OrderedSet(collections.abc.MutableSet):
 
     def __init__(self, iterable=None):
         self.end = end = [] 


### PR DESCRIPTION
#### PR description:

Fixed python 3 deprecation warning. The deprecation is scheduled to become an error in python 3.10

#### PR validation:

Framework python unit tests run and no longer report this as a warning.