### PR TITLE
forward compression settings if fast cloning is disabled on first file of a merge

### DIFF
--- a/Configuration/DataProcessing/python/Merge.py
+++ b/Configuration/DataProcessing/python/Merge.py
@@ -62,7 +62,7 @@ def mergeProcess(*inputFiles, **options):
     process.source.fileNames = CfgTypes.untracked(CfgTypes.vstring())
     for entry in inputFiles:
         process.source.fileNames.append(str(entry))
- 
+
     #  //
     # // output module
     #//
@@ -74,6 +74,8 @@ def mergeProcess(*inputFiles, **options):
         process.add_(Service("InitRootHandlers", EnableIMT = CfgTypes.untracked.bool(False)))
     else:
         outMod = OutputModule("PoolOutputModule")
+        outMod.mergeJob = CfgTypes.untracked.bool(True)
+        outMod.eventAuxiliaryBasketSize = CfgTypes.untracked.int32(2*1024*1024)
 
     outMod.fileName = CfgTypes.untracked.string(outputFilename)
     if outputLFN != None:

--- a/Configuration/DataProcessing/test/RunMerge.py
+++ b/Configuration/DataProcessing/test/RunMerge.py
@@ -34,7 +34,7 @@ class RunMerge:
 
         try:
             process = mergeProcess(
-                self.inputFiles,
+                *self.inputFiles,
                 process_name = self.processName,
                 output_file = self.outputFile,
                 output_lfn = self.outputLFN,
@@ -73,7 +73,7 @@ if __name__ == '__main__':
         if opt == "--input-files":
             merger.inputFiles = [
                 x for x in arg.split(',') if x.strip() != '' ]
-            
+
         if opt == "--output-file" :
             merger.outputFile = arg
         if opt == "--output-lfn" :

--- a/IOPool/Output/interface/PoolOutputModule.h
+++ b/IOPool/Output/interface/PoolOutputModule.h
@@ -57,6 +57,7 @@ namespace edm {
     int treeMaxVirtualSize() const { return treeMaxVirtualSize_; }
     bool overrideInputFileSplitLevels() const { return overrideInputFileSplitLevels_; }
     bool compactEventAuxiliary() const { return compactEventAuxiliary_; }
+    bool mergeJob() const { return mergeJob_; }
     DropMetaData const& dropMetaData() const { return dropMetaData_; }
     std::string const& catalog() const { return catalog_; }
     std::string const& moduleLabel() const { return moduleLabel_; }
@@ -212,6 +213,7 @@ namespace edm {
     std::vector<BranchID> producedBranches_;
     bool overrideInputFileSplitLevels_;
     bool compactEventAuxiliary_;
+    bool mergeJob_;
     edm::propagate_const<std::unique_ptr<RootOutputFile>> rootOutputFile_;
     std::string statusFileName_;
     std::vector<std::string> processesWithSelectedMergeableRunProducts_;

--- a/IOPool/Output/src/PoolOutputModule.cc
+++ b/IOPool/Output/src/PoolOutputModule.cc
@@ -62,6 +62,7 @@ namespace edm {
         branchChildren_(),
         overrideInputFileSplitLevels_(pset.getUntrackedParameter<bool>("overrideInputFileSplitLevels")),
         compactEventAuxiliary_(pset.getUntrackedParameter<bool>("compactEventAuxiliary")),
+        mergeJob_(pset.getUntrackedParameter<bool>("mergeJob")),
         rootOutputFile_(),
         statusFileName_() {
     if (pset.getUntrackedParameter<bool>("writeStatusFile")) {
@@ -483,10 +484,14 @@ namespace edm {
         ->setComment(
             "True:  Allow fast copying, if possible.\n"
             "False: Disable fast copying.");
+    desc.addUntracked("mergeJob", false)
+        ->setComment(
+            "If set to true and fast copying is disabled, copy input file compression and basket sizes to the output "
+            "file.");
     desc.addUntracked<bool>("compactEventAuxiliary", false)
         ->setComment(
             "False: Write EventAuxiliary as we go like any other event metadata branch.\n"
-            "True:  Optimize the file layout be deferring writing the EventAuxiliary branch until the output file is "
+            "True:  Optimize the file layout by deferring writing the EventAuxiliary branch until the output file is "
             "closed.");
     desc.addUntracked<bool>("overrideInputFileSplitLevels", false)
         ->setComment(

--- a/IOPool/Output/src/RootOutputTree.h
+++ b/IOPool/Output/src/RootOutputTree.h
@@ -73,6 +73,8 @@ namespace edm {
 
     bool checkIfFastClonable(TTree* inputTree) const;
 
+    void setSubBranchBasketSizes(TTree* inputTree) const;
+
     bool checkEntriesInReadBranches(Long64_t expectedNumberOfEntries) const;
 
     void maybeFastCloneTree(bool canFastClone, bool canFastCloneAux, TTree* tree, std::string const& option);


### PR DESCRIPTION
#### PR description:

This PR addresses some issues found wrt memory usage at the tier-0 merge jobs:

https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/2304.html

It was observed that in merge jobs where fast cloning was disabled, the output file was being written with the default (zlib) compression and sub-optimal basket sizes.  In this PR, if this is a merge job and fast cloning is disabled for this first file, then compression and basket sizes are forwarded to the output file.  Also, the basket size for the EventAuxiliary branch is bumped in order to improve the data layout for sites with large block sizes.

This PR will actually make the merge job memory consumption worse, but will improve the compression and layout of the output files.

#### PR validation:

Tests are ok, changes are purely technical in the setting of various ROOT IO parameters.