### PR TITLE
Fix the data type being passed to writeOneIOV in WritePPSAssociationCuts.cc

### DIFF
--- a/CondTools/CTPPS/plugins/WritePPSAssociationCuts.cc
+++ b/CondTools/CTPPS/plugins/WritePPSAssociationCuts.cc
@@ -41,7 +41,7 @@ void WritePPSAssociationCuts::analyze(const edm::Event &iEvent, const edm::Event
   // store the data in a DB object
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
   if (poolDbService.isAvailable()) {
-    poolDbService->writeOneIOV(&ppsAssociationCuts, poolDbService->currentTime(), "PPSAssociationCutsRcd");
+    poolDbService->writeOneIOV(ppsAssociationCuts, poolDbService->currentTime(), "PPSAssociationCutsRcd");
   } else {
     throw cms::Exception("WritePPSAssociationCuts") << "PoolDBService required.";
   }


### PR DESCRIPTION
#### PR description:

This is a simple PR to correct the data type being passed to `poolDbService->writeOneIOV` in the module `WritePPSAssociationCuts.cc`. 

As it currently is, the object stored in the database is of type `PPSAssociationCutsconst*`. The proposed fix allows to correctly save a object of type `PPSAssociationCuts`.

@fabferro @clemencia @sgrzegorz @jan-kaspar @grzanka 

#### PR validation:

Local tests writing and retrieving data to a sqlite file using the tools in `CondTools/CTPPS`:

[CondTools/CTPPS/test/write_PPSAssociationCuts_cfg.py](https://github.com/cms-sw/cmssw/blob/master/CondTools/CTPPS/test/write_PPSAssociationCuts_cfg.py)
[CondTools/CTPPS/test/retrieve_PPSAssociationCuts_cfg.py](https://github.com/cms-sw/cmssw/blob/master/CondTools/CTPPS/test/retrieve_PPSAssociationCuts_cfg.py)

After the fix, I was able to correctly retrieve the conditions data. 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport.

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
