### PR TITLE
Bugfix for Egamma PFID with DNNs

### DIFF
--- a/RecoParticleFlow/PFProducer/src/PFEGammaFilters.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaFilters.cc
@@ -183,10 +183,10 @@ bool PFEGammaFilters::passElectronSelection(const reco::GsfElectron& electron,
       if (eleEta <= etaThreshold) {
         passEleSelection = (dnn_sig > ele_dnnHighPtBarrelThr_) && (dnn_bkg < ele_dnnBkgHighPtBarrelThr_);
       } else if (eleEta > etaThreshold) {
-        passEleSelection = (dnn_sig > ele_dnnHighPtEndcapThr_) && (dnn_sig < ele_dnnBkgHighPtEndcapThr_);
+        passEleSelection = (dnn_sig > ele_dnnHighPtEndcapThr_) && (dnn_bkg < ele_dnnBkgHighPtEndcapThr_);
       }
     } else {  // pt < ele_iso_pt_
-      passEleSelection = (dnn_sig > ele_dnnLowPtThr_) && (dnn_sig < ele_dnnBkgLowPtThr_);
+      passEleSelection = (dnn_sig > ele_dnnLowPtThr_) && (dnn_bkg < ele_dnnBkgLowPtThr_);
     }
     // TODO: For the moment do not evaluate further conditions on isolation and HCAL cleaning..
     // To be understood if they are needed


### PR DESCRIPTION
This PR corrects a bug in the PFEgammaFilters introduced in the previous PR (https://github.com/cms-sw/cmssw/pull/36243):  the additional cut on the non-isolated background node was not applied correctly in the endcap due to a typo.  

This explains the unexpected trend observed during the PR validation by Egamma/PF [1]. A drop in signal efficiency at eta > 1.5 (EE) was observed and unexpected. That was linked to the bug fixed in this PR: the dnn_sig node was used instead of dnn_bkg to perform an additional cut, causing the drop in efficiency. The bug was affecting only the endcap part of the electron selection. 

[1] https://cernbox.cern.ch/index.php/s/3asr0DrAqx6zdFD

