### PR TITLE
Remove unused `transDelay` option from BeamSpot DQM clients

### DIFF
--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -385,7 +385,6 @@ if unitTest == False:
 
         runNumber = cms.untracked.uint64(options.runNumber),
         omsServiceUrl = cms.untracked.string(BSOnlineOmsServiceUrl),
-        writeTransactionDelay = cms.untracked.uint32(options.transDelay),
         latency = cms.untracked.uint32(2),
         autoCommit = cms.untracked.bool(True),
         saveLogsOnDB = cms.untracked.bool(True),
@@ -412,7 +411,6 @@ else:
         preLoadConnectionString = cms.untracked.string('sqlite_file:BeamSpotOnlineLegacy.db'),
         runNumber = cms.untracked.uint64(options.runNumber),
         lastLumiFile = cms.untracked.string('last_lumi.txt'),
-        writeTransactionDelay = cms.untracked.uint32(options.transDelay),
         latency = cms.untracked.uint32(2),
         autoCommit = cms.untracked.bool(True),
         toPut = cms.VPSet(cms.PSet(

--- a/DQM/Integration/python/clients/beamfake_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamfake_dqm_sourceclient-live_cfg.py
@@ -155,7 +155,6 @@ if unitTest == False:
 
         runNumber = cms.untracked.uint64(options.runNumber),
         omsServiceUrl = cms.untracked.string(BSOnlineOmsServiceUrl),
-        writeTransactionDelay = cms.untracked.uint32(options.transDelay),
         latency = cms.untracked.uint32(2),
         autoCommit = cms.untracked.bool(True),
         saveLogsOnDB = cms.untracked.bool(True),
@@ -182,7 +181,6 @@ else:
         preLoadConnectionString = cms.untracked.string('sqlite_file:BeamSpotOnlineLegacy.db'),
         runNumber = cms.untracked.uint64(options.runNumber),
         lastLumiFile = cms.untracked.string('last_lumi.txt'),
-        writeTransactionDelay = cms.untracked.uint32(options.transDelay),
         latency = cms.untracked.uint32(2),
         autoCommit = cms.untracked.bool(True),
         toPut = cms.VPSet(cms.PSet(

--- a/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
@@ -189,7 +189,6 @@ if (process.runType.getRunType() == process.runType.pp_run or
         preLoadConnectionString = cms.untracked.string('frontier://FrontierProd/CMS_CONDITIONS'),
         runNumber = cms.untracked.uint64(options.runNumber),
         omsServiceUrl = cms.untracked.string(BSOnlineOmsServiceUrl),
-        writeTransactionDelay = cms.untracked.uint32(options.transDelay),
         latency = cms.untracked.uint32(2),
         autoCommit = cms.untracked.bool(True),
         saveLogsOnDB = cms.untracked.bool(True),
@@ -215,7 +214,6 @@ if (process.runType.getRunType() == process.runType.pp_run or
         preLoadConnectionString = cms.untracked.string('sqlite_file:BeamSpotOnlineHLT.db'),
         runNumber = cms.untracked.uint64(options.runNumber),
         lastLumiFile = cms.untracked.string('last_lumi.txt'),
-        writeTransactionDelay = cms.untracked.uint32(options.transDelay),
         latency = cms.untracked.uint32(2),
         autoCommit = cms.untracked.bool(True),
         toPut = cms.VPSet(cms.PSet(

--- a/DQM/Integration/python/clients/beamhltfake_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhltfake_dqm_sourceclient-live_cfg.py
@@ -127,7 +127,6 @@ if unitTest == False:
       preLoadConnectionString = cms.untracked.string('frontier://FrontierProd/CMS_CONDITIONS'),
       runNumber = cms.untracked.uint64(options.runNumber),
       omsServiceUrl = cms.untracked.string(BSOnlineOmsServiceUrl),
-      writeTransactionDelay = cms.untracked.uint32(options.transDelay),
       latency = cms.untracked.uint32(2),
       autoCommit = cms.untracked.bool(True),
       saveLogsOnDB = cms.untracked.bool(True),
@@ -154,7 +153,6 @@ else:
 
     runNumber = cms.untracked.uint64(options.runNumber),
     lastLumiFile = cms.untracked.string('last_lumi.txt'),
-    writeTransactionDelay = cms.untracked.uint32(options.transDelay),
     latency = cms.untracked.uint32(2),
     autoCommit = cms.untracked.bool(True),
     toPut = cms.VPSet(cms.PSet(

--- a/DQM/Integration/python/clients/onlinebeammonitor_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/onlinebeammonitor_dqm_sourceclient-live_cfg.py
@@ -76,12 +76,6 @@ if unitTest:
                   VarParsing.VarParsing.varType.int,
                   "This number of last events in each lumisection will be processed.")
 
-  options.register('transDelay',
-                  0, #default value, int limit -3
-                  VarParsing.VarParsing.multiplicity.singleton,
-                  VarParsing.VarParsing.varType.int,
-                  "delay in seconds for the commit of the db transaction")
-
   # This is used only by the online clients themselves. 
   # We need to register it here because otherwise an error occurs saying that there is an unidentified option.
   options.register('unitTest',

--- a/DQM/Integration/python/config/fileinputsource_cfi.py
+++ b/DQM/Integration/python/config/fileinputsource_cfi.py
@@ -59,12 +59,6 @@ options.register('dataset',
                  VarParsing.VarParsing.varType.string,
                  "Dataset name like '/ExpressPhysicsPA/PARun2016D-Express-v1/FEVT', or 'auto' to guess it with a DAS query. A dataset_cfi.py that defines 'readFiles' and 'secFiles' (like a DAS Python snippet) will override this, to avoid DAS queries.")
 
-options.register('transDelay',
-                 0, #default value, int limit -3
-                 VarParsing.VarParsing.multiplicity.singleton,
-                 VarParsing.VarParsing.varType.int,
-                 "delay in seconds for the commit of the db transaction")
-
 options.register('noDB',
                  True, # default value
                  VarParsing.VarParsing.multiplicity.singleton,

--- a/DQM/Integration/python/config/inputsource_cfi.py
+++ b/DQM/Integration/python/config/inputsource_cfi.py
@@ -33,12 +33,6 @@ options.register('skipFirstLumis',
                  VarParsing.VarParsing.varType.bool,
                  "Skip (and ignore the minEventsPerLumi parameter) for the files which have been available at the begining of the processing. ")
 
-options.register('transDelay',
-                 0, #default value, int limit -3
-                 VarParsing.VarParsing.multiplicity.singleton,
-                 VarParsing.VarParsing.varType.int,
-                 "delay in seconds for the commit of the db transaction")
-
 options.register('noDB',
                  True, # default value
                  VarParsing.VarParsing.multiplicity.singleton,

--- a/DQM/Integration/python/config/unittestinputsource_cfi.py
+++ b/DQM/Integration/python/config/unittestinputsource_cfi.py
@@ -67,12 +67,6 @@ options.register('eventsPerLumi',
                  VarParsing.VarParsing.varType.int,
                  "This number of last events in each lumisection will be processed.")
 
-options.register('transDelay',
-                 0, #default value, int limit -3
-                 VarParsing.VarParsing.multiplicity.singleton,
-                 VarParsing.VarParsing.varType.int,
-                 "delay in seconds for the commit of the db transaction")
-
 # This is used only by the online clients themselves. 
 # We need to register it here because otherwise an error occurs saying that there is an unidentified option.
 options.register('unitTest',


### PR DESCRIPTION
#### PR description:
Cleanup of BeamSpot DQM clients code: 
the option `transDelay` (implemented in [this line](https://github.com/cms-sw/cmssw/blob/master/CondCore/DBOutputService/src/PoolDBOutputService.cc#L48) of `CondCore`) was originally implemented so that DB experts (@ggovi) could debug more easily the new BeamSpot Online workflow and represents the delay in seconds for the commit of the db transaction. 
This option should not be used in production (and indeed it was already set to 0 by default and never changed) so it is now removed from the clients in order to avoid possible future errors.

#### PR validation:
Code compiles and `scramv1 b runtests` runs fine.

#### Backport
Not a backport, no backport needed
