### PR TITLE
Updated SimProducer for ECAL

### DIFF
--- a/Validation/EcalHits/interface/EcalPreshowerSimHitsValidation.h
+++ b/Validation/EcalHits/interface/EcalPreshowerSimHitsValidation.h
@@ -45,7 +45,6 @@ protected:
   void analyze(const edm::Event &e, const edm::EventSetup &c) override;
 
 private:
-  std::string HepMCLabel;
   std::string g4InfoLabel;
   std::string EEHitsCollection;
   std::string ESHitsCollection;

--- a/Validation/EcalHits/interface/EcalSimHitsValidation.h
+++ b/Validation/EcalHits/interface/EcalSimHitsValidation.h
@@ -11,7 +11,6 @@
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/Validation/EcalHits/python/ecalPreshowerSimHitsValidation_cfi.py
+++ b/Validation/EcalHits/python/ecalPreshowerSimHitsValidation_cfi.py
@@ -6,7 +6,7 @@ ecalPreshowerSimHitsValidation = DQMEDAnalyzer("EcalPreshowerSimHitsValidation",
     ESHitsCollection = cms.string('EcalHitsES'),
     moduleLabelG4 = cms.string('g4SimHits'),
     verbose = cms.untracked.bool(False),
-    moduleLabelMC = cms.string('generatorSmeared')
+    moduleLabelMC = cms.InputTag('generatorSmeared')
 )
 
 

--- a/Validation/EcalHits/python/ecalSimHitsValidation_cfi.py
+++ b/Validation/EcalHits/python/ecalSimHitsValidation_cfi.py
@@ -4,7 +4,7 @@ from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 ecalSimHitsValidation = DQMEDAnalyzer("EcalSimHitsValidation",
     ESHitsCollection = cms.string('EcalHitsES'),
     verbose = cms.untracked.bool(False),
-    moduleLabelMC = cms.string('generatorSmeared'),
+    moduleLabelMC = cms.InputTag('generatorSmeared'),
     EBHitsCollection = cms.string('EcalHitsEB'),
     EEHitsCollection = cms.string('EcalHitsEE'),
     moduleLabelG4 = cms.string('g4SimHits')

--- a/Validation/EcalHits/src/EcalPreshowerSimHitsValidation.cc
+++ b/Validation/EcalHits/src/EcalPreshowerSimHitsValidation.cc
@@ -16,8 +16,7 @@ using namespace edm;
 using namespace std;
 
 EcalPreshowerSimHitsValidation::EcalPreshowerSimHitsValidation(const edm::ParameterSet &ps)
-    :
-      g4InfoLabel(ps.getParameter<std::string>("moduleLabelG4")),
+    : g4InfoLabel(ps.getParameter<std::string>("moduleLabelG4")),
       EEHitsCollection(ps.getParameter<std::string>("EEHitsCollection")),
       ESHitsCollection(ps.getParameter<std::string>("ESHitsCollection")),
       HepMCToken(consumes<edm::HepMCProduct>(ps.getParameter<edm::InputTag>("moduleLabelMC"))) {

--- a/Validation/EcalHits/src/EcalPreshowerSimHitsValidation.cc
+++ b/Validation/EcalHits/src/EcalPreshowerSimHitsValidation.cc
@@ -17,12 +17,10 @@ using namespace std;
 
 EcalPreshowerSimHitsValidation::EcalPreshowerSimHitsValidation(const edm::ParameterSet &ps)
     :
-
-      HepMCLabel(ps.getParameter<std::string>("moduleLabelMC")),
       g4InfoLabel(ps.getParameter<std::string>("moduleLabelG4")),
       EEHitsCollection(ps.getParameter<std::string>("EEHitsCollection")),
-      ESHitsCollection(ps.getParameter<std::string>("ESHitsCollection")) {
-  HepMCToken = consumes<edm::HepMCProduct>(HepMCLabel);
+      ESHitsCollection(ps.getParameter<std::string>("ESHitsCollection")),
+      HepMCToken(consumes<edm::HepMCProduct>(ps.getParameter<edm::InputTag>("moduleLabelMC"))) {
   EEHitsToken =
       consumes<edm::PCaloHitContainer>(edm::InputTag(std::string(g4InfoLabel), std::string(EEHitsCollection)));
   ESHitsToken =

--- a/Validation/EcalHits/src/EcalSimHitsValidProducer.cc
+++ b/Validation/EcalHits/src/EcalSimHitsValidProducer.cc
@@ -250,7 +250,7 @@ void EcalSimHitsValidProducer::update(const EndOfEvent *evt) {
       double pz = thePrim->GetPz();
       theMomentum.SetCoordinates(px, py, pz, 0.);
 
-      pInit = std::sqrt(px*px + py*py + pz*pz);
+      pInit = std::sqrt(px * px + py * py + pz * pz);
       if (pInit == 0)
         edm::LogWarning("EcalSimHitsValidProducer") << " Primary has p = 0 ; ";
       else {

--- a/Validation/EcalHits/src/EcalSimHitsValidProducer.cc
+++ b/Validation/EcalHits/src/EcalSimHitsValidProducer.cc
@@ -55,6 +55,7 @@ EcalSimHitsValidProducer::EcalSimHitsValidProducer(const edm::ParameterSet &iPSe
     eBX0[i] = 0.0;
     eEX0[i] = 0.0;
   }
+  setMT(true);
 }
 
 EcalSimHitsValidProducer::~EcalSimHitsValidProducer() {}
@@ -249,16 +250,11 @@ void EcalSimHitsValidProducer::update(const EndOfEvent *evt) {
       double pz = thePrim->GetPz();
       theMomentum.SetCoordinates(px, py, pz, 0.);
 
-      pInit = sqrt(pow(px, 2.) + pow(py, 2.) + pow(pz, 2.));
+      pInit = std::sqrt(px*px + py*py + pz*pz);
       if (pInit == 0)
         edm::LogWarning("EcalSimHitsValidProducer") << " Primary has p = 0 ; ";
       else {
         theMomentum.SetE(pInit);
-        // double costheta  = pz/pInit; // UNUSED
-        // double theta = acos(std::min(std::max(costheta, -1.),1.)); // UNUSED
-        // etaInit = -log(tan(theta/2)); // UNUSED
-
-        // if ( px != 0 || py != 0) phiInit = atan2(py,px); // UNUSED
       }
 
       thePID = thePrim->GetPDGcode();

--- a/Validation/EcalHits/src/EcalSimHitsValidation.cc
+++ b/Validation/EcalHits/src/EcalSimHitsValidation.cc
@@ -19,7 +19,7 @@ using namespace std;
 
 EcalSimHitsValidation::EcalSimHitsValidation(const edm::ParameterSet &ps)
     : g4InfoLabel(ps.getParameter<std::string>("moduleLabelG4")),
-      HepMCToken(consumes<edm::HepMCProduct>(ps.getParameter<std::string>("moduleLabelMC"))) {
+      HepMCToken(consumes<edm::HepMCProduct>(ps.getParameter<edm::InputTag>("moduleLabelMC"))) {
   EBHitsCollectionToken =
       consumes<edm::PCaloHitContainer>(edm::InputTag(g4InfoLabel, ps.getParameter<std::string>("EBHitsCollection")));
   EEHitsCollectionToken =


### PR DESCRIPTION
#### PR description:
This PR intended to fix issue #36256. SimProducer used for analysis of hits in ECAL has minor modification. Also InputTag is used instead of string for generatorSmearing label to remove warning in the WF 101.0.


#### PR validation:
WFs: 101.0, 102.0, 1306.0


#### if this PR is a backport please specify the original PR and why you need to backport that PR:
no