### PR TITLE
Drop type specs for Validation/CSCRecHits and Validation/CheckOverlap

### DIFF
--- a/Validation/CSCRecHits/python/cscRecHitPSet.py
+++ b/Validation/CSCRecHits/python/cscRecHitPSet.py
@@ -1,16 +1,16 @@
 import FWCore.ParameterSet.Config as cms
 
-cscRecHitPSet = cms.PSet(
-    cscRecHit = cms.PSet(
-        verbose = cms.int32(0),
-        inputTag = cms.InputTag("csc2DRecHits"),
-        minBX = cms.int32(-1),
-        maxBX = cms.int32(1),
+cscRecHitPSet = dict(
+    cscRecHit = dict(
+        verbose = 0,
+        inputTag = "csc2DRecHits",
+        minBX = -1,
+        maxBX = 1,
     ),
-    cscSegment = cms.PSet(
-        verbose = cms.int32(0),
-        inputTag = cms.InputTag("cscSegments"),
-        minBX = cms.int32(-1),
-        maxBX = cms.int32(1),
+    cscSegment = dict(
+        verbose = 0,
+        inputTag = "cscSegments",
+        minBX = -1,
+        maxBX = 1,
     )
 )

--- a/Validation/CheckOverlap/python/g4TestOverlap_cfg.py
+++ b/Validation/CheckOverlap/python/g4TestOverlap_cfg.py
@@ -10,13 +10,13 @@ import FWCore.ParameterSet.Config as cms
 from Validation.CheckOverlap.testOverlap_cff import *
 
 process.g4SimHits.CheckOverlap = True
-process.g4SimHits.G4CheckOverlap = cms.PSet(
-    NodeNames = cms.vstring('ECAL'),
-    Tolerance = cms.untracked.double(0.0001), # in mm
-    Resolution = cms.untracked.int32(10000),
-    ErrorThreshold = cms.untracked.int32(1),
-    Level = cms.untracked.int32(0),
-    Depth = cms.untracked.int32(-1),
-    Verbose = cms.untracked.bool(True)
+process.g4SimHits.G4CheckOverlap = dict(
+    NodeNames = 'ECAL',
+    Tolerance = 0.0001, # in mm
+    Resolution = 10000,
+    ErrorThreshold = 1,
+    Level = 0,
+    Depth = -1,
+    Verbose = True
 )
 

--- a/Validation/CheckOverlap/python/testOverlap_cff.py
+++ b/Validation/CheckOverlap/python/testOverlap_cff.py
@@ -25,21 +25,21 @@ process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cff")
 process.load("SimG4Core.Application.g4SimHits_cfi")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    cerr = cms.untracked.PSet(
-        enable = cms.untracked.bool(False)
+    cerr = dict(
+        enable = False
     ),
-    cout = cms.untracked.PSet(
-        G4cerr = cms.untracked.PSet(
-            limit = cms.untracked.int32(-1)
+    cout = dict(
+        G4cerr = dict(
+            limit = -1
         ),
-        G4cout = cms.untracked.PSet(
-            limit = cms.untracked.int32(-1)
+        G4cout = dict(
+            limit = -1
         ),
-        default = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
+        default = dict(
+            limit = 0
         ),
-        enable = cms.untracked.bool(True),
-        threshold = cms.untracked.string('DEBUG')
+        enable = True,
+        threshold = 'DEBUG'
     ),
     debugModules = cms.untracked.vstring('*')
 )
@@ -49,22 +49,22 @@ process.load("IOMC.RandomEngine.IOMC_cff")
 process.source = cms.Source("EmptySource")
 
 process.generator = cms.EDProducer("FlatRandomEGunProducer",
-    PGunParameters = cms.PSet(
-        PartID = cms.vint32(14),
-        MinEta = cms.double(-3.5),
-        MaxEta = cms.double(3.5),
-        MinPhi = cms.double(-3.14159265359),
-        MaxPhi = cms.double(3.14159265359),
-        MinE   = cms.double(9.99),
-        MaxE   = cms.double(10.01)
+    PGunParameters = dict(
+        PartID = 14,
+        MinEta = -3.5,
+        MaxEta = 3.5,
+        MinPhi = -3.14159265359,
+        MaxPhi = 3.14159265359,
+        MinE   = 9.99,
+        MaxE   = 10.01
     ),
     AddAntiParticle = cms.bool(False),
     Verbosity       = cms.untracked.int32(0),
     firstRun        = cms.untracked.uint32(1)
 )
 
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(1)
+process.maxEvents = dict(
+    input = 1
 )
 
 process.p1 = cms.Path(process.generator*process.g4SimHits)


### PR DESCRIPTION
#### PR description:

Central DQM migration
campaign for drop type specs for Validation packages viz CSCRecHits and CheckOverlap  by following
https://cms-sw.github.io/cms_coding_rules.html#6--packaging-rules-1

To update the safer syntax for existing parameters: (1) drop type specifications where the original parameter exists. (2) using "clone" instead of "deepcopy" (3) move all parameters inside the clone.

#### PR validation:

runTheMatrix.py -l limited -i all --ibeos

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

NA
