### PR TITLE
Modernize modules in CondFormats/CSCObjects

### DIFF
--- a/CondFormats/CSCObjects/test/CSCGainsStudy.cc
+++ b/CondFormats/CSCObjects/test/CSCGainsStudy.cc
@@ -21,7 +21,7 @@ using namespace std;
 using namespace edm;
 
 // Constructor
-CSCGainsStudy::CSCGainsStudy(const ParameterSet& pset) {
+CSCGainsStudy::CSCGainsStudy(const ParameterSet& pset) : gainsToken{esConsumes()} {
   // Get the various input parameters
   debug = pset.getUntrackedParameter<bool>("debug");
   rootFileName = pset.getUntrackedParameter<string>("rootFileName");
@@ -136,6 +136,8 @@ CSCGainsStudy::~CSCGainsStudy() {
   theFile->Close();
   if (debug)
     cout << "************* Finished writing histograms to file" << endl;
+
+  delete theFile;
 }
 
 /* analyze
@@ -143,9 +145,7 @@ CSCGainsStudy::~CSCGainsStudy() {
  */
 void CSCGainsStudy::analyze(const Event& event, const EventSetup& eventSetup) {
   // Get the gains and compute global gain average to store for later use in strip calibration
-  edm::ESHandle<CSCGains> hGains;
-  eventSetup.get<CSCGainsRcd>().get(hGains);
-  const CSCGains* hGains_ = &*hGains.product();
+  const CSCGains* hGains_ = &eventSetup.getData(gainsToken);
 
   // Store so it can be used in member functions
   pGains = hGains_;

--- a/CondFormats/CSCObjects/test/CSCGainsStudy.h
+++ b/CondFormats/CSCObjects/test/CSCGainsStudy.h
@@ -11,7 +11,7 @@
  *
  */
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "DataFormats/Common/interface/Handle.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -36,7 +36,7 @@ namespace edm {
 
 class TFile;
 
-class CSCGainsStudy : public edm::EDAnalyzer {
+class CSCGainsStudy : public edm::one::EDAnalyzer<> {
 public:
   /// configurable parameters
   explicit CSCGainsStudy(const edm::ParameterSet& p);
@@ -112,6 +112,7 @@ private:
   std::string rootFileName;
 
   // Store in memory the Gains
+  const edm::ESGetToken<CSCGains, CSCGainsRcd> gainsToken;
   const CSCGains* pGains;
 };
 

--- a/CondFormats/CSCObjects/test/stubs/CSCChipSpeedCorrectionDBReadAnalyzer.cc
+++ b/CondFormats/CSCObjects/test/stubs/CSCChipSpeedCorrectionDBReadAnalyzer.cc
@@ -6,28 +6,28 @@ Toy EDProducers and EDProducts for testing purposes only.
 
 #include <stdexcept>
 #include <string>
-#include <iostream>
 #include <fstream>
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "CondFormats/CSCObjects/interface/CSCDBChipSpeedCorrection.h"
 #include "CondFormats/DataRecord/interface/CSCDBChipSpeedCorrectionRcd.h"
 
 namespace edmtest {
-  class CSCChipSpeedCorrectionDBReadAnalyzer : public edm::EDAnalyzer {
+  class CSCChipSpeedCorrectionDBReadAnalyzer : public edm::one::EDAnalyzer<> {
   public:
-    explicit CSCChipSpeedCorrectionDBReadAnalyzer(edm::ParameterSet const& p) {}
-    explicit CSCChipSpeedCorrectionDBReadAnalyzer(int i) {}
-    virtual ~CSCChipSpeedCorrectionDBReadAnalyzer() {}
-    virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
+    explicit CSCChipSpeedCorrectionDBReadAnalyzer(edm::ParameterSet const& p) : token_{esConsumes()} {}
+    ~CSCChipSpeedCorrectionDBReadAnalyzer() override {}
+    void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
   private:
+    edm::ESGetToken<CSCDBChipSpeedCorrection, CSCDBChipSpeedCorrectionRcd> token_;
   };
 
   void CSCChipSpeedCorrectionDBReadAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context) {
@@ -38,12 +38,12 @@ namespace edmtest {
     std::ofstream DBChipSpeedCorrectionFile("dbChipSpeedCorrection.dat", std::ios::out);
     int counter = 0;
 
-    std::cout << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
-    std::cout << " ---EVENT NUMBER " << e.id().event() << std::endl;
-    edm::ESHandle<CSCDBChipSpeedCorrection> pChipCorr;
-    context.get<CSCDBChipSpeedCorrectionRcd>().get(pChipCorr);
+    edm::LogSystem log("CSCDBChipSpeedCorrection");
 
-    const CSCDBChipSpeedCorrection* myChipCorr = pChipCorr.product();
+    log << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
+    log << " ---EVENT NUMBER " << e.id().event() << std::endl;
+
+    const CSCDBChipSpeedCorrection* myChipCorr = &context.getData(token_);
     CSCDBChipSpeedCorrection::ChipSpeedContainer::const_iterator it;
 
     for (it = myChipCorr->chipSpeedCorr.begin(); it != myChipCorr->chipSpeedCorr.end(); ++it) {

--- a/CondFormats/CSCObjects/test/stubs/CSCCrossTalkDBReadAnalyzer.cc
+++ b/CondFormats/CSCObjects/test/stubs/CSCCrossTalkDBReadAnalyzer.cc
@@ -9,38 +9,40 @@ Toy EDProducers and EDProducts for testing purposes only.
 #include <iostream>
 #include <fstream>
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "CondFormats/CSCObjects/interface/CSCDBCrosstalk.h"
 #include "CondFormats/DataRecord/interface/CSCDBCrosstalkRcd.h"
 
 namespace edmtest {
-  class CSCCrossTalkDBReadAnalyzer : public edm::EDAnalyzer {
+  class CSCCrossTalkDBReadAnalyzer : public edm::one::EDAnalyzer<> {
   public:
-    explicit CSCCrossTalkDBReadAnalyzer(edm::ParameterSet const& p) {}
-    explicit CSCCrossTalkDBReadAnalyzer(int i) {}
-    virtual ~CSCCrossTalkDBReadAnalyzer() {}
-    virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
+    explicit CSCCrossTalkDBReadAnalyzer(edm::ParameterSet const& p) : token_{esConsumes()} {}
+    ~CSCCrossTalkDBReadAnalyzer() override {}
+    void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
   private:
+    edm::ESGetToken<CSCDBCrosstalk, CSCDBCrosstalkRcd> token_;
   };
 
   void CSCCrossTalkDBReadAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context) {
     std::ofstream DBXtalkFile("dbxtalk.dat", std::ios::out);
     int counter = 0;
     using namespace edm::eventsetup;
-    std::cout << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
-    std::cout << " ---EVENT NUMBER " << e.id().event() << std::endl;
-    edm::ESHandle<CSCDBCrosstalk> pcrosstalk;
-    context.get<CSCDBCrosstalkRcd>().get(pcrosstalk);
 
-    const CSCDBCrosstalk* mycrosstalk = pcrosstalk.product();
+    edm::LogInfo log("CSCDBCrosstalk");
+    log << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
+    log << " ---EVENT NUMBER " << e.id().event() << std::endl;
+
+    const CSCDBCrosstalk* mycrosstalk = &context.getData(token_);
     std::vector<CSCDBCrosstalk::Item>::const_iterator it;
     for (it = mycrosstalk->crosstalk.begin(); it != mycrosstalk->crosstalk.end(); ++it) {
       counter++;

--- a/CondFormats/CSCObjects/test/stubs/CSCGainsDBReadAnalyzer.cc
+++ b/CondFormats/CSCObjects/test/stubs/CSCGainsDBReadAnalyzer.cc
@@ -8,38 +8,40 @@ Toy EDProducers and EDProducts for testing purposes only.
 #include <string>
 #include <iostream>
 #include <fstream>
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "CondFormats/CSCObjects/interface/CSCDBGains.h"
 #include "CondFormats/DataRecord/interface/CSCDBGainsRcd.h"
 
 namespace edmtest {
-  class CSCGainsDBReadAnalyzer : public edm::EDAnalyzer {
+  class CSCGainsDBReadAnalyzer : public edm::one::EDAnalyzer<> {
   public:
-    explicit CSCGainsDBReadAnalyzer(edm::ParameterSet const& p) {}
-    explicit CSCGainsDBReadAnalyzer(int i) {}
-    virtual ~CSCGainsDBReadAnalyzer() {}
-    virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
+    explicit CSCGainsDBReadAnalyzer(edm::ParameterSet const& p) : token_{esConsumes()} {}
+    ~CSCGainsDBReadAnalyzer() override {}
+    void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
   private:
+    edm::ESGetToken<CSCDBGains, CSCDBGainsRcd> token_;
   };
 
   void CSCGainsDBReadAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context) {
     using namespace edm::eventsetup;
     std::ofstream DBGainsFile("dbgains.dat", std::ios::out);
     int counter = 0;
-    std::cout << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
-    std::cout << " ---EVENT NUMBER " << e.id().event() << std::endl;
-    edm::ESHandle<CSCDBGains> pGains;
-    context.get<CSCDBGainsRcd>().get(pGains);
 
-    const CSCDBGains* mygains = pGains.product();
+    edm::LogInfo log("CSCDBGains");
+    log << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
+    log << " ---EVENT NUMBER " << e.id().event() << std::endl;
+
+    const CSCDBGains* mygains = &context.getData(token_);
     std::vector<CSCDBGains::Item>::const_iterator it;
 
     for (it = mygains->gains.begin(); it != mygains->gains.end(); ++it) {

--- a/CondFormats/CSCObjects/test/stubs/CSCGainsReadAnalyzer.cc
+++ b/CondFormats/CSCObjects/test/stubs/CSCGainsReadAnalyzer.cc
@@ -6,15 +6,17 @@ Toy EDProducers and EDProducts for testing purposes only.
 
 #include <stdexcept>
 #include <string>
-#include <iostream>
 #include <map>
 #include <vector>
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "CondFormats/CSCObjects/interface/CSCGains.h"
 #include "CondFormats/DataRecord/interface/CSCGainsRcd.h"
@@ -22,31 +24,30 @@ Toy EDProducers and EDProducts for testing purposes only.
 using namespace std;
 
 namespace edmtest {
-  class CSCGainsReadAnalyzer : public edm::EDAnalyzer {
+  class CSCGainsReadAnalyzer : public edm::global::EDAnalyzer<> {
   public:
-    explicit CSCGainsReadAnalyzer(edm::ParameterSet const& p) {}
-    explicit CSCGainsReadAnalyzer(int i) {}
-    virtual ~CSCGainsReadAnalyzer() {}
-    virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
+    explicit CSCGainsReadAnalyzer(edm::ParameterSet const& p) : gainsToken_{esConsumes()} {}
+    ~CSCGainsReadAnalyzer() override {}
+    void analyze(edm::StreamID, const edm::Event& e, const edm::EventSetup& c) const override;
 
   private:
+    edm::ESGetToken<CSCGains, CSCGainsRcd> gainsToken_;
   };
 
-  void CSCGainsReadAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context) {
+  void CSCGainsReadAnalyzer::analyze(edm::StreamID, const edm::Event& e, const edm::EventSetup& context) const {
     using namespace edm::eventsetup;
-    // Context is not used.
-    std::cout << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
-    std::cout << " ---EVENT NUMBER " << e.id().event() << std::endl;
-    edm::ESHandle<CSCGains> pGains;
-    context.get<CSCGainsRcd>().get(pGains);
 
-    const CSCGains* mygains = pGains.product();
+    edm::LogSystem log("CSCGains");
+    log << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
+    log << " ---EVENT NUMBER " << e.id().event() << std::endl;
+
+    const CSCGains* mygains = &context.getData(gainsToken_);
     std::map<int, std::vector<CSCGains::Item> >::const_iterator it;
     for (it = mygains->gains.begin(); it != mygains->gains.end(); ++it) {
-      std::cout << "layer id found " << it->first << std::endl;
+      log << "layer id found " << it->first << std::endl;
       std::vector<CSCGains::Item>::const_iterator gainsit;
       for (gainsit = it->second.begin(); gainsit != it->second.end(); ++gainsit) {
-        std::cout << "  gains:  " << gainsit->gain_slope << " intercept: " << gainsit->gain_intercept << std::endl;
+        log << "  gains:  " << gainsit->gain_slope << " intercept: " << gainsit->gain_intercept << std::endl;
       }
     }
   }

--- a/CondFormats/CSCObjects/test/stubs/CSCNoiseMatrixReadAnalyzer.cc
+++ b/CondFormats/CSCObjects/test/stubs/CSCNoiseMatrixReadAnalyzer.cc
@@ -6,15 +6,17 @@ Toy EDProducers and EDProducts for testing purposes only.
 
 #include <stdexcept>
 #include <string>
-#include <iostream>
 #include <map>
 #include <vector>
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "CondFormats/CSCObjects/interface/CSCNoiseMatrix.h"
 #include "CondFormats/DataRecord/interface/CSCNoiseMatrixRcd.h"
@@ -22,31 +24,29 @@ Toy EDProducers and EDProducts for testing purposes only.
 using namespace std;
 
 namespace edmtest {
-  class CSCNoiseMatrixReadAnalyzer : public edm::EDAnalyzer {
+  class CSCNoiseMatrixReadAnalyzer : public edm::global::EDAnalyzer<> {
   public:
-    explicit CSCNoiseMatrixReadAnalyzer(edm::ParameterSet const& p) {}
-    explicit CSCNoiseMatrixReadAnalyzer(int i) {}
-    virtual ~CSCNoiseMatrixReadAnalyzer() {}
-    virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
+    explicit CSCNoiseMatrixReadAnalyzer(edm::ParameterSet const& p) : noiseToken_{esConsumes()} {}
+    ~CSCNoiseMatrixReadAnalyzer() override {}
+    void analyze(edm::StreamID, const edm::Event& e, const edm::EventSetup& c) const override;
 
   private:
+    edm::ESGetToken<CSCNoiseMatrix, CSCNoiseMatrixRcd> noiseToken_;
   };
 
-  void CSCNoiseMatrixReadAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context) {
+  void CSCNoiseMatrixReadAnalyzer::analyze(edm::StreamID, const edm::Event& e, const edm::EventSetup& context) const {
     using namespace edm::eventsetup;
-    // Context is not used.
-    std::cout << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
-    std::cout << " ---EVENT NUMBER " << e.id().event() << std::endl;
-    edm::ESHandle<CSCNoiseMatrix> pNoiseMatrix;
-    context.get<CSCNoiseMatrixRcd>().get(pNoiseMatrix);
+    edm::LogSystem log("CSCNoiseMatrix");
+    log << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
+    log << " ---EVENT NUMBER " << e.id().event() << std::endl;
 
-    const CSCNoiseMatrix* myNoiseMatrix = pNoiseMatrix.product();
+    const CSCNoiseMatrix* myNoiseMatrix = &context.getData(noiseToken_);
     std::map<int, std::vector<CSCNoiseMatrix::Item> >::const_iterator it;
     for (it = myNoiseMatrix->matrix.begin(); it != myNoiseMatrix->matrix.end(); ++it) {
-      std::cout << "layer id found " << it->first << std::endl;
+      log << "layer id found " << it->first << std::endl;
       std::vector<CSCNoiseMatrix::Item>::const_iterator matrixit;
       for (matrixit = it->second.begin(); matrixit != it->second.end(); ++matrixit) {
-        std::cout << "  matrix elem33:  " << matrixit->elem33 << " matrix elem34: " << matrixit->elem34 << std::endl;
+        log << "  matrix elem33:  " << matrixit->elem33 << " matrix elem34: " << matrixit->elem34 << std::endl;
       }
     }
   }

--- a/CondFormats/CSCObjects/test/stubs/CSCPedestalDBReadAnalyzer.cc
+++ b/CondFormats/CSCObjects/test/stubs/CSCPedestalDBReadAnalyzer.cc
@@ -8,26 +8,28 @@ Toy EDProducers and EDProducts for testing purposes only.
 #include <string>
 #include <iostream>
 #include <fstream>
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "CondFormats/CSCObjects/interface/CSCDBPedestals.h"
 #include "CondFormats/DataRecord/interface/CSCDBPedestalsRcd.h"
 
 namespace edmtest {
-  class CSCPedestalDBReadAnalyzer : public edm::EDAnalyzer {
+  class CSCPedestalDBReadAnalyzer : public edm::one::EDAnalyzer<> {
   public:
-    explicit CSCPedestalDBReadAnalyzer(edm::ParameterSet const& p) {}
-    explicit CSCPedestalDBReadAnalyzer(int i) {}
-    virtual ~CSCPedestalDBReadAnalyzer() {}
-    virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
+    explicit CSCPedestalDBReadAnalyzer(edm::ParameterSet const& p) : token_{esConsumes()} {}
+    ~CSCPedestalDBReadAnalyzer() override {}
+    void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
   private:
+    edm::ESGetToken<CSCDBPedestals, CSCDBPedestalsRcd> token_;
   };
 
   void CSCPedestalDBReadAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context) {
@@ -37,12 +39,12 @@ namespace edmtest {
     std::ofstream DBPedestalFile("dbpeds.dat", std::ios::out);
     int counter = 0;
 
-    std::cout << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
-    std::cout << " ---EVENT NUMBER " << e.id().event() << std::endl;
-    edm::ESHandle<CSCDBPedestals> pPeds;
-    context.get<CSCDBPedestalsRcd>().get(pPeds);
+    edm::LogSystem log("CSCDBPedestals");
 
-    const CSCDBPedestals* myped = pPeds.product();
+    log << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
+    log << " ---EVENT NUMBER " << e.id().event() << std::endl;
+
+    const CSCDBPedestals* myped = &context.getData(token_);
     CSCDBPedestals::PedestalContainer::const_iterator it;
 
     for (it = myped->pedestals.begin(); it != myped->pedestals.end(); ++it) {

--- a/CondFormats/CSCObjects/test/stubs/CSCReadChamberIndexValuesAnalyzer.cc
+++ b/CondFormats/CSCObjects/test/stubs/CSCReadChamberIndexValuesAnalyzer.cc
@@ -4,19 +4,19 @@ Toy EDProducers and EDProducts for testing purposes only.
 
 ----------------------------------------------------------------------*/
 
-#include <stdexcept>
 #include <string>
 #include <iostream>
-#include <fstream>
 #include <map>
 #include <vector>
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "CondFormats/CSCObjects/interface/CSCChamberIndex.h"
 #include "CondFormats/DataRecord/interface/CSCChamberIndexRcd.h"
@@ -25,25 +25,27 @@ Toy EDProducers and EDProducts for testing purposes only.
 using namespace std;
 
 namespace edmtest {
-  class CSCReadChamberIndexValuesAnalyzer : public edm::EDAnalyzer {
+  class CSCReadChamberIndexValuesAnalyzer : public edm::global::EDAnalyzer<> {
   public:
-    explicit CSCReadChamberIndexValuesAnalyzer(edm::ParameterSet const& p) {}
-    explicit CSCReadChamberIndexValuesAnalyzer(int i) {}
-    virtual ~CSCReadChamberIndexValuesAnalyzer() {}
-    virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
+    explicit CSCReadChamberIndexValuesAnalyzer(edm::ParameterSet const& p) : token_{esConsumes()} {}
+    ~CSCReadChamberIndexValuesAnalyzer() override {}
+    void analyze(edm::StreamID, const edm::Event& e, const edm::EventSetup& c) const override;
 
   private:
+    edm::ESGetToken<CSCChamberIndex, CSCChamberIndexRcd> token_;
   };
 
-  void CSCReadChamberIndexValuesAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context) {
+  void CSCReadChamberIndexValuesAnalyzer::analyze(edm::StreamID,
+                                                  const edm::Event& e,
+                                                  const edm::EventSetup& context) const {
     using namespace edm::eventsetup;
-    // Context is not used.
-    std::cout << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
-    std::cout << " ---EVENT NUMBER " << e.id().event() << std::endl;
-    edm::ESHandle<CSCChamberIndex> pChIndex;
-    context.get<CSCChamberIndexRcd>().get(pChIndex);
 
-    const CSCChamberIndex* myChIndex = pChIndex.product();
+    edm::LogSystem log("CSCChamberIndex");
+
+    log << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
+    log << " ---EVENT NUMBER " << e.id().event() << std::endl;
+
+    const CSCChamberIndex* myChIndex = &context.getData(token_);
 
     std::vector<CSCMapItem::MapItem>::const_iterator it;
 
@@ -51,39 +53,39 @@ namespace edmtest {
     for (it = myChIndex->ch_index.begin(); it != myChIndex->ch_index.end(); ++it) {
       count++;
 
-      std::cout << count << ") ";
-      std::cout << it->chamberLabel << "  ";
-      std::cout << it->chamberId << "  ";
-      std::cout << it->endcap << "  ";
-      std::cout << it->station << "  ";
-      std::cout << it->ring << "  ";
-      std::cout << it->chamber << "  ";
-      std::cout << it->cscIndex << "  ";
-      std::cout << it->layerIndex << "  ";
-      std::cout << it->stripIndex << "  ";
-      std::cout << it->anodeIndex << "  ";
-      std::cout << it->strips << "  ";
-      std::cout << it->anodes << "  ";
-      std::cout << it->crateLabel << "  ";
-      std::cout << it->crateid << "  ";
-      std::cout << it->sector << "  ";
-      std::cout << it->trig_sector << "  ";
-      std::cout << it->dmb << "  ";
-      std::cout << it->cscid << "  ";
-      std::cout << it->ddu << "  ";
-      std::cout << it->ddu_input << "  ";
-      std::cout << it->slink << "  ";
-      std::cout << it->fed_crate << "  "
-                << "  ";
-      std::cout << it->ddu_slot << "  "
-                << "  ";
-      std::cout << it->dcc_fifo << "  "
-                << "  ";
-      std::cout << it->fiber_crate << "  "
-                << "  ";
-      std::cout << it->fiber_pos << "  "
-                << "  ";
-      std::cout << it->fiber_socket << "  " << std::endl;
+      log << count << ") ";
+      log << it->chamberLabel << "  ";
+      log << it->chamberId << "  ";
+      log << it->endcap << "  ";
+      log << it->station << "  ";
+      log << it->ring << "  ";
+      log << it->chamber << "  ";
+      log << it->cscIndex << "  ";
+      log << it->layerIndex << "  ";
+      log << it->stripIndex << "  ";
+      log << it->anodeIndex << "  ";
+      log << it->strips << "  ";
+      log << it->anodes << "  ";
+      log << it->crateLabel << "  ";
+      log << it->crateid << "  ";
+      log << it->sector << "  ";
+      log << it->trig_sector << "  ";
+      log << it->dmb << "  ";
+      log << it->cscid << "  ";
+      log << it->ddu << "  ";
+      log << it->ddu_input << "  ";
+      log << it->slink << "  ";
+      log << it->fed_crate << "  "
+          << "  ";
+      log << it->ddu_slot << "  "
+          << "  ";
+      log << it->dcc_fifo << "  "
+          << "  ";
+      log << it->fiber_crate << "  "
+          << "  ";
+      log << it->fiber_pos << "  "
+          << "  ";
+      log << it->fiber_socket << "  " << std::endl;
     }
   }
   DEFINE_FWK_MODULE(CSCReadChamberIndexValuesAnalyzer);

--- a/CondFormats/CSCObjects/test/stubs/CSCReadChamberMapValuesAnalyzer.cc
+++ b/CondFormats/CSCObjects/test/stubs/CSCReadChamberMapValuesAnalyzer.cc
@@ -4,19 +4,18 @@ Toy EDProducers and EDProducts for testing purposes only.
 
 ----------------------------------------------------------------------*/
 
-#include <stdexcept>
 #include <string>
-#include <iostream>
-#include <fstream>
 #include <map>
 #include <vector>
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "CondFormats/CSCObjects/interface/CSCChamberMap.h"
 #include "CondFormats/DataRecord/interface/CSCChamberMapRcd.h"
@@ -27,66 +26,67 @@ Toy EDProducers and EDProducts for testing purposes only.
 using namespace std;
 
 namespace edmtest {
-  class CSCReadChamberMapValuesAnalyzer : public edm::EDAnalyzer {
+  class CSCReadChamberMapValuesAnalyzer : public edm::global::EDAnalyzer<> {
   public:
-    explicit CSCReadChamberMapValuesAnalyzer(edm::ParameterSet const& p) {}
-    explicit CSCReadChamberMapValuesAnalyzer(int i) {}
-    virtual ~CSCReadChamberMapValuesAnalyzer() {}
-    virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
+    explicit CSCReadChamberMapValuesAnalyzer(edm::ParameterSet const& p) : token_{esConsumes()} {}
+    ~CSCReadChamberMapValuesAnalyzer() override {}
+    void analyze(edm::StreamID, const edm::Event& e, const edm::EventSetup& c) const override;
 
   private:
+    edm::ESGetToken<CSCChamberMap, CSCChamberMapRcd> token_;
   };
 
-  void CSCReadChamberMapValuesAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context) {
+  void CSCReadChamberMapValuesAnalyzer::analyze(edm::StreamID,
+                                                const edm::Event& e,
+                                                const edm::EventSetup& context) const {
     using namespace edm::eventsetup;
-    // Context is not used.
-    std::cout << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
-    std::cout << " ---EVENT NUMBER " << e.id().event() << std::endl;
-    edm::ESHandle<CSCChamberMap> pChMap;
-    context.get<CSCChamberMapRcd>().get(pChMap);
 
-    const CSCChamberMap* myChMap = pChMap.product();
+    edm::LogSystem log("CSCChamberMap");
+    log << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
+    log << " ---EVENT NUMBER " << e.id().event() << std::endl;
+
+    const CSCChamberMap* myChMap = &context.getData(token_);
 
     std::map<int, CSCMapItem::MapItem>::const_iterator it;
 
     int count = 0;
     for (it = myChMap->ch_map.begin(); it != myChMap->ch_map.end(); ++it) {
       count = count + 1;
-      std::cout << "Key: chamber " << it->first << std::endl;
+      log << "Key: chamber " << it->first << std::endl;
 
-      std::cout << count << ") ";
-      std::cout << it->second.chamberLabel << "  ";
-      std::cout << it->second.chamberId << "  ";
-      std::cout << it->second.endcap << "  ";
-      std::cout << it->second.station << "  ";
-      std::cout << it->second.ring << "  ";
-      std::cout << it->second.chamber << "  ";
-      std::cout << it->second.cscIndex << "  ";
-      std::cout << it->second.layerIndex << "  ";
-      std::cout << it->second.stripIndex << "  ";
-      std::cout << it->second.anodeIndex << "  ";
-      std::cout << it->second.strips << "  ";
-      std::cout << it->second.anodes << "  ";
-      std::cout << it->second.crateLabel << "  ";
-      std::cout << it->second.crateid << "  ";
-      std::cout << it->second.sector << "  ";
-      std::cout << it->second.trig_sector << "  ";
-      std::cout << it->second.dmb << "  ";
-      std::cout << it->second.cscid << "  ";
-      std::cout << it->second.ddu << "  ";
-      std::cout << it->second.ddu_input << "  ";
-      std::cout << it->second.slink << "  ";
-      std::cout << it->second.fed_crate << "  "
-                << "  ";
-      std::cout << it->second.ddu_slot << "  "
-                << "  ";
-      std::cout << it->second.dcc_fifo << "  "
-                << "  ";
-      std::cout << it->second.fiber_crate << "  "
-                << "  ";
-      std::cout << it->second.fiber_pos << "  "
-                << "  ";
-      std::cout << it->second.fiber_socket << "  " << std::endl;
+      log << count << ") ";
+      log << it->second.chamberLabel << "  ";
+      log << it->second.chamberId << "  ";
+      log << it->second.endcap << "  ";
+      log << it->second.station << "  ";
+      log << it->second.ring << "  ";
+      log << it->second.chamber << "  ";
+      log << it->second.cscIndex << "  ";
+      log << it->second.layerIndex << "  ";
+      log << it->second.stripIndex << "  ";
+      log << it->second.anodeIndex << "  ";
+      log << it->second.strips << "  ";
+      log << it->second.anodes << "  ";
+      log << it->second.crateLabel << "  ";
+      log << it->second.crateid << "  ";
+      log << it->second.sector << "  ";
+      log << it->second.trig_sector << "  ";
+      log << it->second.dmb << "  ";
+      log << it->second.cscid << "  ";
+      log << it->second.ddu << "  ";
+      log << it->second.ddu_input << "  ";
+      log << it->second.slink << "  ";
+      log << it->second.fed_crate << "  "
+          << "  ";
+      log << it->second.ddu_slot << "  "
+          << "  ";
+      log << it->second.dcc_fifo << "  "
+          << "  ";
+      log << it->second.fiber_crate << "  "
+          << "  ";
+      log << it->second.fiber_pos << "  "
+          << "  ";
+      log << it->second.fiber_socket << "  " << std::endl;
     }
   }
   DEFINE_FWK_MODULE(CSCReadChamberMapValuesAnalyzer);

--- a/CondFormats/CSCObjects/test/stubs/CSCReadChamberTimeCorrAnalyzer.cc
+++ b/CondFormats/CSCObjects/test/stubs/CSCReadChamberTimeCorrAnalyzer.cc
@@ -10,13 +10,15 @@ Toy EDProducers and EDProducts for testing purposes only.
 #include <fstream>
 #include <map>
 #include <vector>
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "CondFormats/CSCObjects/interface/CSCChamberTimeCorrections.h"
 #include "CondFormats/DataRecord/interface/CSCChamberTimeCorrectionsRcd.h"
@@ -26,25 +28,27 @@ Toy EDProducers and EDProducts for testing purposes only.
 using namespace std;
 
 namespace edmtest {
-  class CSCReadChamberTimeCorrAnalyzer : public edm::EDAnalyzer {
+  class CSCReadChamberTimeCorrAnalyzer : public edm::global::EDAnalyzer<> {
   public:
-    explicit CSCReadChamberTimeCorrAnalyzer(edm::ParameterSet const& p) {}
-    explicit CSCReadChamberTimeCorrAnalyzer(int i) {}
-    virtual ~CSCReadChamberTimeCorrAnalyzer() {}
-    virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
+    explicit CSCReadChamberTimeCorrAnalyzer(edm::ParameterSet const& p) : corrToken_{esConsumes()} {}
+    ~CSCReadChamberTimeCorrAnalyzer() override {}
+    void analyze(edm::StreamID, const edm::Event& e, const edm::EventSetup& c) const override;
 
   private:
+    edm::ESGetToken<CSCChamberTimeCorrections, CSCChamberTimeCorrectionsRcd> corrToken_;
   };
 
-  void CSCReadChamberTimeCorrAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context) {
+  void CSCReadChamberTimeCorrAnalyzer::analyze(edm::StreamID,
+                                               const edm::Event& e,
+                                               const edm::EventSetup& context) const {
     using namespace edm::eventsetup;
-    // Context is not used.
-    std::cout << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
-    std::cout << " ---EVENT NUMBER " << e.id().event() << std::endl;
-    edm::ESHandle<CSCChamberTimeCorrections> pCorr;
-    context.get<CSCChamberTimeCorrectionsRcd>().get(pCorr);
 
-    const CSCChamberTimeCorrections* myCorr = pCorr.product();
+    edm::LogSystem log("CSCCamberTimeCorrections");
+
+    log << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
+    log << " ---EVENT NUMBER " << e.id().event() << std::endl;
+
+    const CSCChamberTimeCorrections* myCorr = &context.getData(corrToken_);
 
     //    std::map<int,CSCMapItem::MapItem>::const_iterator it;
     std::vector<CSCChamberTimeCorrections::ChamberTimeCorrections>::const_iterator it;
@@ -52,17 +56,17 @@ namespace edmtest {
     int count = 0;
     for (it = myCorr->chamberCorrections.begin(); it != myCorr->chamberCorrections.end(); ++it) {
       count = count + 1;
-      //      std::cout<<"Key: ddu_crate*10+ddu_input "<<it->first<<std::endl;
+      //      log<<"Key: ddu_crate*10+ddu_input "<<it->first<<std::endl;
 
-      std::cout << count << ") ";
-      //      std::cout<<it->chamber_label<<"  ";
-      std::cout << it->cfeb_length << "  ";
-      std::cout << it->cfeb_rev << "  ";
-      std::cout << it->alct_length << "  ";
-      std::cout << it->alct_rev << "  ";
-      std::cout << it->cfeb_tmb_skew_delay << "  ";
-      std::cout << it->anode_bx_offset << "  ";
-      std::cout << it->cfeb_timing_corr << "  " << std::endl;
+      log << count << ") ";
+      //      log<<it->chamber_label<<"  ";
+      log << it->cfeb_length << "  ";
+      log << it->cfeb_rev << "  ";
+      log << it->alct_length << "  ";
+      log << it->alct_rev << "  ";
+      log << it->cfeb_tmb_skew_delay << "  ";
+      log << it->anode_bx_offset << "  ";
+      log << it->cfeb_timing_corr << "  " << std::endl;
     }
   }
   DEFINE_FWK_MODULE(CSCReadChamberTimeCorrAnalyzer);

--- a/CondFormats/CSCObjects/test/stubs/CSCReadChamberTimeCorrectionsAnalyzer.cc
+++ b/CondFormats/CSCObjects/test/stubs/CSCReadChamberTimeCorrectionsAnalyzer.cc
@@ -10,13 +10,15 @@ Toy EDProducers and EDProducts for testing purposes only.
 #include <fstream>
 #include <map>
 #include <vector>
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "CondFormats/CSCObjects/interface/CSCChamberTimeCorrections.h"
 #include "CondFormats/DataRecord/interface/CSCChamberTimeCorrectionsRcd.h"
@@ -24,25 +26,27 @@ Toy EDProducers and EDProducts for testing purposes only.
 using namespace std;
 
 namespace edmtest {
-  class CSCReadChamberTimeCorrectionsValuesAnalyzer : public edm::EDAnalyzer {
+  class CSCReadChamberTimeCorrectionsValuesAnalyzer : public edm::global::EDAnalyzer<> {
   public:
-    explicit CSCReadChamberTimeCorrectionsValuesAnalyzer(edm::ParameterSet const& p) {}
+    explicit CSCReadChamberTimeCorrectionsValuesAnalyzer(edm::ParameterSet const& p) : token_{esConsumes()} {}
     explicit CSCReadChamberTimeCorrectionsValuesAnalyzer(int i) {}
-    virtual ~CSCReadChamberTimeCorrectionsValuesAnalyzer() {}
-    virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
+    ~CSCReadChamberTimeCorrectionsValuesAnalyzer() override {}
+    void analyze(edm::StreamID, const edm::Event& e, const edm::EventSetup& c) const override;
 
   private:
+    edm::ESGetToken<CSCChamberTimeCorrections, CSCChamberTimeCorrectionsRcd> token_;
   };
 
-  void CSCReadChamberTimeCorrectionsValuesAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context) {
+  void CSCReadChamberTimeCorrectionsValuesAnalyzer::analyze(edm::StreamID,
+                                                            const edm::Event& e,
+                                                            const edm::EventSetup& context) const {
     using namespace edm::eventsetup;
-    // Context is not used.
-    std::cout << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
-    std::cout << " ---EVENT NUMBER " << e.id().event() << std::endl;
-    edm::ESHandle<CSCChamberTimeCorrections> pChamberTimeCorrections;
-    context.get<CSCChamberTimeCorrectionsRcd>().get(pChamberTimeCorrections);
 
-    const CSCChamberTimeCorrections* myChamberTimeCorrections = pChamberTimeCorrections.product();
+    edm::LogSystem log("CSCChamberTimeCorrections");
+    log << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
+    log << " ---EVENT NUMBER " << e.id().event() << std::endl;
+
+    const CSCChamberTimeCorrections* myChamberTimeCorrections = &context.getData(token_);
 
     //    std::map<int,CSCMapItem::MapItem>::const_iterator it;
     std::vector<CSCChamberTimeCorrections::ChamberTimeCorrections>::const_iterator it;
@@ -52,16 +56,16 @@ namespace edmtest {
          it != myChamberTimeCorrections->chamberCorrections.end();
          ++it) {
       count = count + 1;
-      //      std::cout<<"Key: ddu_crate*10+ddu_input "<<it->first<<std::endl;
+      //      log<<"Key: ddu_crate*10+ddu_input "<<it->first<<std::endl;
 
-      std::cout << count << ") ";
-      //      std::cout<<it->chamber_label<<"  ";
-      std::cout << it->cfeb_length * 1. / myChamberTimeCorrections->factor_precision << "  ";
-      std::cout << it->cfeb_rev << "  ";
-      std::cout << it->alct_length * 1. / myChamberTimeCorrections->factor_precision << "  ";
-      std::cout << it->cfeb_tmb_skew_delay * 1. / myChamberTimeCorrections->factor_precision << "  ";
-      std::cout << it->cfeb_timing_corr * 1. / myChamberTimeCorrections->factor_precision << "  ";
-      std::cout << "delay " << it->cfeb_cable_delay << std::endl;
+      log << count << ") ";
+      //      log<<it->chamber_label<<"  ";
+      log << it->cfeb_length * 1. / myChamberTimeCorrections->factor_precision << "  ";
+      log << it->cfeb_rev << "  ";
+      log << it->alct_length * 1. / myChamberTimeCorrections->factor_precision << "  ";
+      log << it->cfeb_tmb_skew_delay * 1. / myChamberTimeCorrections->factor_precision << "  ";
+      log << it->cfeb_timing_corr * 1. / myChamberTimeCorrections->factor_precision << "  ";
+      log << "delay " << it->cfeb_cable_delay << std::endl;
     }
   }
   DEFINE_FWK_MODULE(CSCReadChamberTimeCorrectionsValuesAnalyzer);

--- a/CondFormats/CSCObjects/test/stubs/CSCReadCrateMapValuesAnalyzer.cc
+++ b/CondFormats/CSCObjects/test/stubs/CSCReadCrateMapValuesAnalyzer.cc
@@ -10,13 +10,15 @@ Toy EDProducers and EDProducts for testing purposes only.
 #include <fstream>
 #include <map>
 #include <vector>
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "CondFormats/CSCObjects/interface/CSCCrateMap.h"
 #include "CondFormats/DataRecord/interface/CSCCrateMapRcd.h"
@@ -24,67 +26,69 @@ Toy EDProducers and EDProducts for testing purposes only.
 
 using namespace std;
 namespace edmtest {
-  class CSCReadCrateMapValuesAnalyzer : public edm::EDAnalyzer {
+  class CSCReadCrateMapValuesAnalyzer : public edm::global::EDAnalyzer<> {
   public:
-    explicit CSCReadCrateMapValuesAnalyzer(edm::ParameterSet const& p) {}
-    explicit CSCReadCrateMapValuesAnalyzer(int i) {}
-    virtual ~CSCReadCrateMapValuesAnalyzer() {}
-    virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
+    explicit CSCReadCrateMapValuesAnalyzer(edm::ParameterSet const& p) : token_{esConsumes()} {}
+    ~CSCReadCrateMapValuesAnalyzer() override {}
+    void analyze(edm::StreamID, const edm::Event& e, const edm::EventSetup& c) const override;
 
   private:
+    const edm::ESGetToken<CSCCrateMap, CSCCrateMapRcd> token_;
   };
 
-  void CSCReadCrateMapValuesAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context) {
+  void CSCReadCrateMapValuesAnalyzer::analyze(edm::StreamID,
+                                              const edm::Event& e,
+                                              const edm::EventSetup& context) const {
     using namespace edm::eventsetup;
-    // Context is not used.
-    std::cout << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
-    std::cout << " ---EVENT NUMBER " << e.id().event() << std::endl;
-    edm::ESHandle<CSCCrateMap> pCrateMap;
-    context.get<CSCCrateMapRcd>().get(pCrateMap);
 
-    const CSCCrateMap* myCrateMap = pCrateMap.product();
+    edm::LogSystem log("CSCCrateMap");
+
+    log << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
+    log << " ---EVENT NUMBER " << e.id().event() << std::endl;
+
+    const CSCCrateMap* myCrateMap = &context.getData(token_);
 
     std::map<int, CSCMapItem::MapItem>::const_iterator it;
 
     int count = 0;
     for (it = myCrateMap->crate_map.begin(); it != myCrateMap->crate_map.end(); ++it) {
       count = count + 1;
-      std::cout << "Key: crate " << it->first << std::endl;
+      log << "Key: crate " << it->first << std::endl;
 
-      std::cout << count << ") ";
-      std::cout << it->second.chamberLabel << "  ";
-      std::cout << it->second.chamberId << "  ";
-      std::cout << it->second.endcap << "  ";
-      std::cout << it->second.station << "  ";
-      std::cout << it->second.ring << "  ";
-      std::cout << it->second.chamber << "  ";
-      std::cout << it->second.cscIndex << "  ";
-      std::cout << it->second.layerIndex << "  ";
-      std::cout << it->second.stripIndex << "  ";
-      std::cout << it->second.anodeIndex << "  ";
-      std::cout << it->second.strips << "  ";
-      std::cout << it->second.anodes << "  ";
-      std::cout << it->second.crateLabel << "  ";
-      std::cout << it->second.crateid << "  ";
-      std::cout << it->second.sector << "  ";
-      std::cout << it->second.trig_sector << "  ";
-      std::cout << it->second.dmb << "  ";
-      std::cout << it->second.cscid << "  ";
-      std::cout << it->second.ddu << "  ";
-      std::cout << it->second.ddu_input << "  ";
-      std::cout << it->second.slink << "  "
-                << "  ";
-      std::cout << it->second.fed_crate << "  "
-                << "  ";
-      std::cout << it->second.ddu_slot << "  "
-                << "  ";
-      std::cout << it->second.dcc_fifo << "  "
-                << "  ";
-      std::cout << it->second.fiber_crate << "  "
-                << "  ";
-      std::cout << it->second.fiber_pos << "  "
-                << "  ";
-      std::cout << it->second.fiber_socket << "  " << std::endl;
+      log << count << ") ";
+      log << it->second.chamberLabel << "  ";
+      log << it->second.chamberId << "  ";
+      log << it->second.endcap << "  ";
+      log << it->second.station << "  ";
+      log << it->second.ring << "  ";
+      log << it->second.chamber << "  ";
+      log << it->second.cscIndex << "  ";
+      log << it->second.layerIndex << "  ";
+      log << it->second.stripIndex << "  ";
+      log << it->second.anodeIndex << "  ";
+      log << it->second.strips << "  ";
+      log << it->second.anodes << "  ";
+      log << it->second.crateLabel << "  ";
+      log << it->second.crateid << "  ";
+      log << it->second.sector << "  ";
+      log << it->second.trig_sector << "  ";
+      log << it->second.dmb << "  ";
+      log << it->second.cscid << "  ";
+      log << it->second.ddu << "  ";
+      log << it->second.ddu_input << "  ";
+      log << it->second.slink << "  "
+          << "  ";
+      log << it->second.fed_crate << "  "
+          << "  ";
+      log << it->second.ddu_slot << "  "
+          << "  ";
+      log << it->second.dcc_fifo << "  "
+          << "  ";
+      log << it->second.fiber_crate << "  "
+          << "  ";
+      log << it->second.fiber_pos << "  "
+          << "  ";
+      log << it->second.fiber_socket << "  " << std::endl;
     }
   }
   DEFINE_FWK_MODULE(CSCReadCrateMapValuesAnalyzer);

--- a/CondFormats/CSCObjects/test/stubs/CSCReadDCSDataAnalyzer.cc
+++ b/CondFormats/CSCObjects/test/stubs/CSCReadDCSDataAnalyzer.cc
@@ -1,15 +1,14 @@
-#include <stdexcept>
 #include <string>
-#include <iostream>
-#include <fstream>
 #include <map>
 #include <vector>
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "CondFormats/CSCObjects/interface/CSCDQM_DCSData.h"
 #include "CondFormats/DataRecord/interface/CSCDCSDataRcd.h"
@@ -18,49 +17,49 @@ using namespace std;
 
 namespace edmtest {
 
-  class CSCReadDCSDataAnalyzer : public edm::EDAnalyzer {
+  class CSCReadDCSDataAnalyzer : public edm::global::EDAnalyzer<> {
   public:
-    explicit CSCReadDCSDataAnalyzer(edm::ParameterSet const& p) {}
-    explicit CSCReadDCSDataAnalyzer(int i) {}
-    virtual ~CSCReadDCSDataAnalyzer() {}
-    virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
+    explicit CSCReadDCSDataAnalyzer(edm::ParameterSet const& p) : token_{esConsumes()} {}
+    ~CSCReadDCSDataAnalyzer() override {}
+    void analyze(edm::StreamID, const edm::Event& e, const edm::EventSetup& c) const override;
 
   private:
+    edm::ESGetToken<cscdqm::DCSData, CSCDCSDataRcd> token_;
   };
 
-  void CSCReadDCSDataAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context) {
+  void CSCReadDCSDataAnalyzer::analyze(edm::StreamID, const edm::Event& e, const edm::EventSetup& context) const {
     using namespace edm::eventsetup;
 
-    std::cout << "+===================+" << std::endl;
-    std::cout << "| CSCReadDCSDataAnalyzer    |" << std::endl;
-    std::cout << "+===================+" << std::endl;
+    edm::LogSystem log("DCSData");
 
-    std::cout << "run " << e.id().run() << std::endl;
-    std::cout << "event " << e.id().event() << std::endl;
+    log << "+===================+" << std::endl;
+    log << "| CSCReadDCSDataAnalyzer    |" << std::endl;
+    log << "+===================+" << std::endl;
 
-    edm::ESHandle<cscdqm::DCSData> hcrate;
-    context.get<CSCDCSDataRcd>().get(hcrate);
-    const cscdqm::DCSData* data = hcrate.product();
+    log << "run " << e.id().run() << std::endl;
+    log << "event " << e.id().event() << std::endl;
 
-    std::cout << "Temp mode = " << data->temp_mode << std::endl;
+    const cscdqm::DCSData* data = &context.getData(token_);
+
+    log << "Temp mode = " << data->temp_mode << std::endl;
     for (unsigned int i = 0; i < data->temp_meas.size(); i++)
-      std::cout << data->temp_meas.at(i) << std::endl;
+      log << data->temp_meas.at(i) << std::endl;
 
-    std::cout << "HV V mode = " << data->hvv_mode << std::endl;
+    log << "HV V mode = " << data->hvv_mode << std::endl;
     for (unsigned int i = 0; i < data->hvv_meas.size(); i++)
-      std::cout << data->hvv_meas.at(i) << std::endl;
+      log << data->hvv_meas.at(i) << std::endl;
 
-    std::cout << "LV V mode = " << data->lvv_mode << std::endl;
+    log << "LV V mode = " << data->lvv_mode << std::endl;
     for (unsigned int i = 0; i < data->lvv_meas.size(); i++)
-      std::cout << data->lvv_meas.at(i) << std::endl;
+      log << data->lvv_meas.at(i) << std::endl;
 
-    std::cout << "LV I mode = " << data->lvi_mode << std::endl;
+    log << "LV I mode = " << data->lvi_mode << std::endl;
     for (unsigned int i = 0; i < data->lvi_meas.size(); i++)
-      std::cout << data->lvi_meas.at(i) << std::endl;
+      log << data->lvi_meas.at(i) << std::endl;
 
-    std::cout << "+==========================+" << std::endl;
-    std::cout << "| End of CSCReadDCSDataAnalyzer |" << std::endl;
-    std::cout << "+==========================+" << std::endl;
+    log << "+==========================+" << std::endl;
+    log << "| End of CSCReadDCSDataAnalyzer |" << std::endl;
+    log << "+==========================+" << std::endl;
   }
 
   DEFINE_FWK_MODULE(CSCReadDCSDataAnalyzer);

--- a/CondFormats/CSCObjects/test/stubs/CSCReadDDUMapValuesAnalyzer.cc
+++ b/CondFormats/CSCObjects/test/stubs/CSCReadDDUMapValuesAnalyzer.cc
@@ -10,13 +10,15 @@ Toy EDProducers and EDProducts for testing purposes only.
 #include <fstream>
 #include <map>
 #include <vector>
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "CondFormats/CSCObjects/interface/CSCDDUMap.h"
 #include "CondFormats/DataRecord/interface/CSCDDUMapRcd.h"
@@ -25,66 +27,65 @@ Toy EDProducers and EDProducts for testing purposes only.
 using namespace std;
 
 namespace edmtest {
-  class CSCReadDDUMapValuesAnalyzer : public edm::EDAnalyzer {
+  class CSCReadDDUMapValuesAnalyzer : public edm::global::EDAnalyzer<> {
   public:
-    explicit CSCReadDDUMapValuesAnalyzer(edm::ParameterSet const& p) {}
-    explicit CSCReadDDUMapValuesAnalyzer(int i) {}
-    virtual ~CSCReadDDUMapValuesAnalyzer() {}
-    virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
+    explicit CSCReadDDUMapValuesAnalyzer(edm::ParameterSet const& p) : mapToken_{esConsumes()} {}
+    ~CSCReadDDUMapValuesAnalyzer() override {}
+    void analyze(edm::StreamID, const edm::Event& e, const edm::EventSetup& c) const override;
 
   private:
+    edm::ESGetToken<CSCDDUMap, CSCDDUMapRcd> mapToken_;
   };
 
-  void CSCReadDDUMapValuesAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context) {
+  void CSCReadDDUMapValuesAnalyzer::analyze(edm::StreamID, const edm::Event& e, const edm::EventSetup& context) const {
     using namespace edm::eventsetup;
-    // Context is not used.
-    std::cout << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
-    std::cout << " ---EVENT NUMBER " << e.id().event() << std::endl;
-    edm::ESHandle<CSCDDUMap> pDDUMap;
-    context.get<CSCDDUMapRcd>().get(pDDUMap);
 
-    const CSCDDUMap* myDDUMap = pDDUMap.product();
+    edm::LogSystem log("CSCDDUMap");
+    log << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
+    log << " ---EVENT NUMBER " << e.id().event() << std::endl;
+
+    const CSCDDUMap* myDDUMap = &context.getData(mapToken_);
 
     std::map<int, CSCMapItem::MapItem>::const_iterator it;
 
     int count = 0;
     for (it = myDDUMap->ddu_map.begin(); it != myDDUMap->ddu_map.end(); ++it) {
       count = count + 1;
-      std::cout << "Key: ddu_crate*10+ddu_input " << it->first << std::endl;
+      log << "Key: ddu_crate*10+ddu_input " << it->first << std::endl;
 
-      std::cout << count << ") ";
-      std::cout << it->second.chamberLabel << "  ";
-      std::cout << it->second.chamberId << "  ";
-      std::cout << it->second.endcap << "  ";
-      std::cout << it->second.station << "  ";
-      std::cout << it->second.ring << "  ";
-      std::cout << it->second.chamber << "  ";
-      std::cout << it->second.cscIndex << "  ";
-      std::cout << it->second.layerIndex << "  ";
-      std::cout << it->second.stripIndex << "  ";
-      std::cout << it->second.anodeIndex << "  ";
-      std::cout << it->second.strips << "  ";
-      std::cout << it->second.anodes << "  ";
-      std::cout << it->second.crateLabel << "  ";
-      std::cout << it->second.crateid << "  ";
-      std::cout << it->second.sector << "  ";
-      std::cout << it->second.trig_sector << "  ";
-      std::cout << it->second.dmb << "  ";
-      std::cout << it->second.cscid << "  ";
-      std::cout << it->second.ddu << "  ";
-      std::cout << it->second.ddu_input << "  ";
-      std::cout << it->second.slink << "  ";
-      std::cout << it->second.fed_crate << "  "
-                << "  ";
-      std::cout << it->second.ddu_slot << "  "
-                << "  ";
-      std::cout << it->second.dcc_fifo << "  "
-                << "  ";
-      std::cout << it->second.fiber_crate << "  "
-                << "  ";
-      std::cout << it->second.fiber_pos << "  "
-                << "  ";
-      std::cout << it->second.fiber_socket << "  " << std::endl;
+      log << count << ") ";
+      log << it->second.chamberLabel << "  ";
+      log << it->second.chamberId << "  ";
+      log << it->second.endcap << "  ";
+      log << it->second.station << "  ";
+      log << it->second.ring << "  ";
+      log << it->second.chamber << "  ";
+      log << it->second.cscIndex << "  ";
+      log << it->second.layerIndex << "  ";
+      log << it->second.stripIndex << "  ";
+      log << it->second.anodeIndex << "  ";
+      log << it->second.strips << "  ";
+      log << it->second.anodes << "  ";
+      log << it->second.crateLabel << "  ";
+      log << it->second.crateid << "  ";
+      log << it->second.sector << "  ";
+      log << it->second.trig_sector << "  ";
+      log << it->second.dmb << "  ";
+      log << it->second.cscid << "  ";
+      log << it->second.ddu << "  ";
+      log << it->second.ddu_input << "  ";
+      log << it->second.slink << "  ";
+      log << it->second.fed_crate << "  "
+          << "  ";
+      log << it->second.ddu_slot << "  "
+          << "  ";
+      log << it->second.dcc_fifo << "  "
+          << "  ";
+      log << it->second.fiber_crate << "  "
+          << "  ";
+      log << it->second.fiber_pos << "  "
+          << "  ";
+      log << it->second.fiber_socket << "  " << std::endl;
     }
   }
   DEFINE_FWK_MODULE(CSCReadDDUMapValuesAnalyzer);


### PR DESCRIPTION
#### PR description:

- moved to thread friendly module types
- use esConsumes
- switch to MessageLogger

#### PR validation:

Code compiles. No deprecation warnings are emitted.