### PR TITLE
Modernize `CalibMuon/CSCCalibration`

### DIFF
--- a/CalibMuon/CSCCalibration/test/stubs/CSCIndexerAnalyzer2.cc
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCIndexerAnalyzer2.cc
@@ -1,6 +1,6 @@
 // Test CSCIndexer 22.11.2012 ptc
 
-#include <FWCore/Framework/interface/EDAnalyzer.h>
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include <FWCore/Framework/interface/ESHandle.h>
 #include <FWCore/Framework/interface/EventSetup.h>
 #include <FWCore/Framework/interface/MakerMacros.h>
@@ -20,10 +20,10 @@
 #include <string>
 #include <vector>
 
-class CSCIndexerAnalyzer2 : public edm::EDAnalyzer {
+class CSCIndexerAnalyzer2 : public edm::one::EDAnalyzer<> {
 public:
   explicit CSCIndexerAnalyzer2(const edm::ParameterSet &);
-  ~CSCIndexerAnalyzer2();
+  ~CSCIndexerAnalyzer2() = default;
 
   virtual void analyze(const edm::Event &, const edm::EventSetup &);
 
@@ -36,13 +36,18 @@ private:
   const std::string myName_;
 
   std::string algoName_;
+
+  const edm::ESGetToken<CSCGeometry, MuonGeometryRecord> theCSCGeometryToken_;
+  const edm::ESGetToken<CSCIndexerBase, CSCIndexerRecord> theCSCIndexerToken_;
 };
 
 CSCIndexerAnalyzer2::CSCIndexerAnalyzer2(const edm::ParameterSet &iConfig)
     : dashedLineWidth_(146),
       dashedLine_(std::string(dashedLineWidth_, '-')),
       myName_("CSCIndexerAnalyzer2"),
-      algoName_("UNKNOWN") {
+      algoName_("UNKNOWN"),
+      theCSCGeometryToken_(esConsumes()),
+      theCSCIndexerToken_(esConsumes()) {
   std::cout << dashedLine_ << std::endl;
   std::cout << "Welcome to " << myName_ << std::endl;
   std::cout << dashedLine_ << std::endl;
@@ -74,8 +79,6 @@ CSCIndexerAnalyzer2::CSCIndexerAnalyzer2(const edm::ParameterSet &iConfig)
   std::cout << dashedLine_ << std::endl;
 }
 
-CSCIndexerAnalyzer2::~CSCIndexerAnalyzer2() {}
-
 void CSCIndexerAnalyzer2::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   CSCDetId testCSCDetId;
 
@@ -86,8 +89,7 @@ void CSCIndexerAnalyzer2::analyze(const edm::Event &iEvent, const edm::EventSetu
   std::cout << dashedLine_ << std::endl;
   std::cout << "pi = " << dPi << ", radToDeg = " << radToDeg << std::endl;
 
-  edm::ESHandle<CSCGeometry> pDD;
-  iSetup.get<MuonGeometryRecord>().get(pDD);
+  auto const pDD = &iSetup.getData(theCSCGeometryToken_);
 
   std::cout << " Geometry node for CSCGeom is  " << &(*pDD) << std::endl;
   std::cout << " I have " << pDD->detTypes().size() << " detTypes" << std::endl;
@@ -97,10 +99,7 @@ void CSCIndexerAnalyzer2::analyze(const edm::Event &iEvent, const edm::EventSetu
   std::cout << " I have " << pDD->chambers().size() << " chambers" << std::endl;
 
   // Get the CSCIndexer algorithm from EventSetup
-
-  edm::ESHandle<CSCIndexerBase> theIndexer;
-  iSetup.get<CSCIndexerRecord>().get(theIndexer);
-
+  const auto theIndexer = &iSetup.getData(theCSCIndexerToken_);
   algoName_ = theIndexer->name();
 
   std::cout << dashedLine_ << std::endl;

--- a/CalibMuon/CSCCalibration/test/stubs/CSCMapperTestPostls1.cc
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCMapperTestPostls1.cc
@@ -21,13 +21,15 @@ private:
   virtual void endJob();
 
   std::string algoName;
+
+  const edm::ESGetToken<CSCChannelMapperBase, CSCChannelMapperRecord> theCSCChannelMapperToken_;
 };
 
-CSCMapperTestPostls1::CSCMapperTestPostls1(const edm::ParameterSet &pset) {}
+CSCMapperTestPostls1::CSCMapperTestPostls1(const edm::ParameterSet &pset) : theCSCChannelMapperToken_(esConsumes()) {}
 
 CSCMapperTestPostls1::~CSCMapperTestPostls1() {}
 
-void CSCMapperTestPostls1::analyze(const edm::Event &ev, const edm::EventSetup &esu) {
+void CSCMapperTestPostls1::analyze(const edm::Event &ev, const edm::EventSetup &iSetup) {
   const int egeo[] = {1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2};          // endcap 1=+z, 2=-z
   const int sgeo[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};          // station 1-4
   const int rgeo[] = {1, 1, 1, 4, 4, 4, 1, 1, 1, 4, 4, 4};          // ring 1-4
@@ -55,9 +57,7 @@ void CSCMapperTestPostls1::analyze(const edm::Event &ev, const edm::EventSetup &
   const int cdetid[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};  // chamber 1-18/36
   const int ldetid[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};  // layer 1-6
 
-  const CSCChannelMapperRecord &irec = esu.get<CSCChannelMapperRecord>();
-  edm::ESHandle<CSCChannelMapperBase> mapper_;
-  irec.get(mapper_);
+  const auto mapper_ = &iSetup.getData(theCSCChannelMapperToken_);
 
   algoName = mapper_->name();
 

--- a/CalibMuon/CSCCalibration/test/stubs/CSCMapperTestStartup.cc
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCMapperTestStartup.cc
@@ -1,6 +1,6 @@
 #include <memory>
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -10,10 +10,10 @@
 #include "CalibMuon/CSCCalibration/interface/CSCChannelMapperRecord.h"
 #include <iostream>
 
-class CSCMapperTestStartup : public edm::EDAnalyzer {
+class CSCMapperTestStartup : public edm::one::EDAnalyzer<> {
 public:
   explicit CSCMapperTestStartup(const edm::ParameterSet &);
-  ~CSCMapperTestStartup();
+  ~CSCMapperTestStartup() = default;
 
 private:
   virtual void beginJob();
@@ -21,13 +21,13 @@ private:
   virtual void endJob();
 
   std::string algoName;
+
+  const edm::ESGetToken<CSCChannelMapperBase, CSCChannelMapperRecord> theCSCChannelMapperToken_;
 };
 
-CSCMapperTestStartup::CSCMapperTestStartup(const edm::ParameterSet &pset) {}
+CSCMapperTestStartup::CSCMapperTestStartup(const edm::ParameterSet &pset) : theCSCChannelMapperToken_(esConsumes()) {}
 
-CSCMapperTestStartup::~CSCMapperTestStartup() {}
-
-void CSCMapperTestStartup::analyze(const edm::Event &ev, const edm::EventSetup &esu) {
+void CSCMapperTestStartup::analyze(const edm::Event &ev, const edm::EventSetup &iSetup) {
   const int egeo[] = {1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2};        // endcap 1=+z, 2=-z
   const int sgeo[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};        // station 1-4
   const int rgeo[] = {1, 1, 1, 4, 4, 4, 1, 1, 1, 4, 4, 4};        // ring 1-4
@@ -55,9 +55,7 @@ void CSCMapperTestStartup::analyze(const edm::Event &ev, const edm::EventSetup &
   const int cdetid[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};  // chamber 1-18/36
   const int ldetid[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};  // layer 1-6
 
-  const CSCChannelMapperRecord &irec = esu.get<CSCChannelMapperRecord>();
-  edm::ESHandle<CSCChannelMapperBase> mapper_;
-  irec.get(mapper_);
+  const auto mapper_ = &iSetup.getData(theCSCChannelMapperToken_);
 
   algoName = mapper_->name();
 


### PR DESCRIPTION
#### PR description:

Moving modules to `one`, migrating away from es get() functions, changing to default destructor

#### PR validation:

Code compiles, runtests pass

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
