### PR TITLE
[RFC] Modify HSCParticle is it can take MiniAOD muons

### DIFF
--- a/AnalysisDataFormats/SUSYBSMObjects/interface/HSCParticle.h
+++ b/AnalysisDataFormats/SUSYBSMObjects/interface/HSCParticle.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "DataFormats/MuonReco/interface/MuonTimeExtra.h"
+#include "DataFormats/PatCandidates/interface/Muon.h"
 #include "AnalysisDataFormats/SUSYBSMObjects/interface/HSCPCaloInfo.h"
 
 namespace susybsm {
@@ -60,6 +61,10 @@ namespace susybsm {
     void setRpc(const RPCBetaMeasurement& data) { rpc_ = data; }
     void setCaloInfo(const HSCPCaloInfoRef& data) { caloInfoRef_ = data; }
 
+    // set infos for MiniAOD
+    void setMuon(const pat::MuonRef& data) { patMuonRef_ = data; }
+    void setMTMuon(const pat::MuonRef& data) { patMTMuonRef_ = data; }
+
     // get infos
     reco::TrackRef trackRef() const { return trackRef_; }
     reco::TrackRef trackIsoRef() const { return trackIsoRef_; }
@@ -67,6 +72,10 @@ namespace susybsm {
     reco::MuonRef MTMuonRef() const { return MTMuonRef_; }
     HSCPCaloInfoRef caloInfoRef() const { return caloInfoRef_; }
     const RPCBetaMeasurement& rpc() const { return rpc_; }
+
+    // get infos for MiniAOD
+    pat::MuonRef patMuonRef() const { return patMuonRef_; }
+    pat::MuonRef patMTMuonRef() const { return patMTMuonRef_; }
 
     // shortcut of long function
     float p() const;
@@ -78,6 +87,8 @@ namespace susybsm {
     reco::TrackRef trackIsoRef_;  //TrackRef from general track collection (isolation purposes)
     reco::MuonRef muonRef_;
     reco::MuonRef MTMuonRef_;  //Muon reconstructed from MT muon segments.  SA only
+    pat::MuonRef patMuonRef_;
+    pat::MuonRef patMTMuonRef_;  //Muon reconstructed from MT muon segments.  SA only
     HSCPCaloInfoRef caloInfoRef_;
 
     RPCBetaMeasurement rpc_;

--- a/AnalysisDataFormats/SUSYBSMObjects/src/classes_def.xml
+++ b/AnalysisDataFormats/SUSYBSMObjects/src/classes_def.xml
@@ -1,5 +1,6 @@
 <lcgdict>
-   <class name="susybsm::HSCParticle" ClassVersion="11">
+   <class name="susybsm::HSCParticle" ClassVersion="12">
+    <version ClassVersion="12" checksum="2254410240"/>
     <version ClassVersion="11" checksum="2205741811"/>
    </class>
    <class name="susybsm::RPCBetaMeasurement" ClassVersion="10">


### PR DESCRIPTION
#### PR description:

First of I'm not sure if this is meant to be in CMSSW, I thought there was an idea to remove analysis related code from it. 
Does anybody else use the `HSCParticle` objects besides the HSCP group? 

Anyway, I've modified it so that it can take `pat::MuonRef` since the original `reco::MuonRef` is not anymore available in MiniAOD

#### PR validation:

Code compiles, some private analysis code was run on it.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, but should be backported to 10_6_X since this is for an UL analysis.
Alternatively we could remove it from CMSSW as it is...