### PR TITLE
fix handling of nano steps in Patatrack workflows

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -467,9 +467,9 @@ class PatatrackWorkflow(UpgradeWorkflow):
         ]
         result = any(selected) and hasHarvest
 
-        # skip ALCA and Nano steps
+        # skip ALCA and Nano steps (but not RecoNano or HARVESTNano for Run3)
         for skip in copy(stepList):
-            if ("ALCA" in skip) or ("Nano" in skip):
+            if ("ALCA" in skip) or ("Nano"==skip):
                 stepList.remove(skip)
         return result
 


### PR DESCRIPTION
#### PR description:

This fixes an unexpected interaction between the existing Patatrack workflow setup and the new Run3 reco/harvest+nano combined steps (reported in https://github.com/cms-sw/cmssw/pull/36167#issuecomment-983104484).

#### PR validation:

Checked that missing steps reappeared in output of `runTheMatrix.py -w gpu -l 11634.506 --dryRun`. This also affects 11634.505, which is a CPU workflow in the regular matrix, so it can be used for testing this PR more easily.