### PR TITLE
Speeding up FastTimerServiceClient 

### DIFF
--- a/DQMServices/Core/src/MonitorElement.cc
+++ b/DQMServices/Core/src/MonitorElement.cc
@@ -765,7 +765,9 @@ namespace dqm::impl {
       auto access = this->accessMut();
       update();
       if (getAxis(access, __PRETTY_FUNCTION__, axis)->GetNbins() >= bin) {
-        getAxis(access, __PRETTY_FUNCTION__, axis)->SetBinLabel(bin, label.c_str());
+        if (strcmp(label.c_str(), getAxis(access, __PRETTY_FUNCTION__, axis)->GetBinLabel(bin)) != 0) {
+          getAxis(access, __PRETTY_FUNCTION__, axis)->SetBinLabel(bin, label.c_str());
+        }
       } else {
         fail = true;
       }

--- a/HLTrigger/Timer/plugins/FastTimerServiceClient.cc
+++ b/HLTrigger/Timer/plugins/FastTimerServiceClient.cc
@@ -30,6 +30,15 @@ struct MEPSet {
   double xmax;
 };
 
+namespace {
+  void setBinLabel(TAxis* axis, int bin, const char* label) {
+    if (strcmp(axis->GetBinLabel(bin), label) != 0) {
+      axis->SetBinLabel(bin, label);
+    }
+  }
+
+}  // namespace
+
 class FastTimerServiceClient : public DQMEDHarvester {
 public:
   explicit FastTimerServiceClient(edm::ParameterSet const&);
@@ -165,7 +174,6 @@ void FastTimerServiceClient::fillPathSummaryPlots(DQMStore::IBooker& booker,
                                                   double events,
                                                   std::string const& current_path) {
   // note: the following checks need to be kept separate, as any of these histograms might be missing
-
   booker.setCurrentFolder(current_path);
   std::vector<std::string> subsubdirs = getter.getSubdirs();
   size_t npaths = subsubdirs.size();
@@ -262,7 +270,7 @@ void FastTimerServiceClient::fillPathSummaryPlots(DQMStore::IBooker& booker,
       real_average->SetYTitle("average processing (real) time [ms]");
       for (uint32_t i = 1; i <= bins; ++i) {
         const char* module = counter->GetXaxis()->GetBinLabel(i);
-        real_average->GetXaxis()->SetBinLabel(i, module);
+        setBinLabel(real_average->GetXaxis(), i, module);
       }
     }
 
@@ -278,7 +286,7 @@ void FastTimerServiceClient::fillPathSummaryPlots(DQMStore::IBooker& booker,
       thread_average->SetYTitle("average processing (thread) time [ms]");
       for (uint32_t i = 1; i <= bins; ++i) {
         const char* module = counter->GetXaxis()->GetBinLabel(i);
-        thread_average->GetXaxis()->SetBinLabel(i, module);
+        setBinLabel(thread_average->GetXaxis(), i, module);
       }
     }
 
@@ -293,7 +301,7 @@ void FastTimerServiceClient::fillPathSummaryPlots(DQMStore::IBooker& booker,
       real_running->SetYTitle("running processing (real) time [ms]");
       for (uint32_t i = 1; i <= bins; ++i) {
         const char* module = counter->GetXaxis()->GetBinLabel(i);
-        real_running->GetXaxis()->SetBinLabel(i, module);
+        setBinLabel(real_running->GetXaxis(), i, module);
       }
     }
 
@@ -309,7 +317,7 @@ void FastTimerServiceClient::fillPathSummaryPlots(DQMStore::IBooker& booker,
       thread_running->SetYTitle("running processing (thread) time [ms]");
       for (uint32_t i = 1; i <= bins; ++i) {
         const char* module = counter->GetXaxis()->GetBinLabel(i);
-        thread_running->GetXaxis()->SetBinLabel(i, module);
+        setBinLabel(thread_running->GetXaxis(), i, module);
       }
     }
 
@@ -325,7 +333,7 @@ void FastTimerServiceClient::fillPathSummaryPlots(DQMStore::IBooker& booker,
       efficiency->SetMaximum(1.05);
       for (uint32_t i = 1; i <= bins; ++i) {
         const char* module = counter->GetXaxis()->GetBinLabel(i);
-        efficiency->GetXaxis()->SetBinLabel(i, module);
+        setBinLabel(efficiency->GetXaxis(), i, module);
       }
     }
 

--- a/HLTrigger/Timer/plugins/FastTimerServiceClient.cc
+++ b/HLTrigger/Timer/plugins/FastTimerServiceClient.cc
@@ -32,6 +32,8 @@ struct MEPSet {
 
 namespace {
   void setBinLabel(TAxis* axis, int bin, const char* label) {
+    //TAxis::GetBinLabel currently doesnt have this check
+    //and changing a label is a slow operation
     if (strcmp(axis->GetBinLabel(bin), label) != 0) {
       axis->SetBinLabel(bin, label);
     }


### PR DESCRIPTION
#### PR description:

FastTimerServiceClient seemed to be taking a lot of time so I had a quick look. 

It was quickly established that all the time was spent in TAxis::SetBinLabel https://root.cern.ch/doc/v616/TAxis_8cxx_source.html#l00809, specifically THashList::Rehash

I then had a quick look at FastTimerServiceClient and noticed its remaking the histograms every lumisection
https://github.com/cms-sw/cmssw/blob/master/HLTrigger/Timer/plugins/FastTimerServiceClient.cc#L95

I'm not entirely clear why it does it and I didnt spend any time to understand it. Perhaps experts could comment, I have no idea how DQM lumi plots work.  It would be ideal if we could move that call to just end job if possible and experts agree.

However what it is doing is resetting the bin labels on each histogram each time. This is a very expensive operation so I put a simple check to see if the bin label is already set to that value before changing it. Honestly this should be inside TAxis::SetBinLabel ...

On my cern PC it goes from taking 14mins to 4mins for a file which only has a single lumisection. It'll be bigger gains for multi lumisection files. 

@fwyzard 


#### PR validation:

labels are still being set on my test workflow

