### PR TITLE
Use thread safe modules in DPGAnalysis/SiStripTools

### DIFF
--- a/DPGAnalysis/SiStripTools/plugins/APVCyclePhaseDebuggerFromL1TS.cc
+++ b/DPGAnalysis/SiStripTools/plugins/APVCyclePhaseDebuggerFromL1TS.cc
@@ -21,7 +21,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Run.h"
@@ -56,7 +56,7 @@
 // class decleration
 //
 
-class APVCyclePhaseDebuggerFromL1TS : public edm::EDAnalyzer {
+class APVCyclePhaseDebuggerFromL1TS : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   explicit APVCyclePhaseDebuggerFromL1TS(const edm::ParameterSet&);
   ~APVCyclePhaseDebuggerFromL1TS() override;
@@ -66,6 +66,7 @@ public:
 private:
   void beginRun(const edm::Run&, const edm::EventSetup&) override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endRun(const edm::Run&, const edm::EventSetup&) override {}
 
   // ----------member data ---------------------------
 

--- a/DPGAnalysis/SiStripTools/plugins/APVCyclePhaseMonitor.cc
+++ b/DPGAnalysis/SiStripTools/plugins/APVCyclePhaseMonitor.cc
@@ -24,7 +24,7 @@
 #include "TProfile.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -47,7 +47,7 @@
 // class decleration
 //
 
-class APVCyclePhaseMonitor : public edm::EDAnalyzer {
+class APVCyclePhaseMonitor : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::SharedResources> {
 public:
   explicit APVCyclePhaseMonitor(const edm::ParameterSet&);
   ~APVCyclePhaseMonitor() override;
@@ -107,6 +107,8 @@ APVCyclePhaseMonitor::APVCyclePhaseMonitor(const edm::ParameterSet& iConfig)
       _hselectedphasevectorvsorbit(),
       _nevents(0) {
   //now do what ever initialization is needed
+
+  usesResource(TFileService::kSharedResource);
 
   edm::LogInfo("UsedAPVCyclePhaseCollection")
       << " APVCyclePhaseCollection " << iConfig.getParameter<edm::InputTag>("apvCyclePhaseCollection") << " used";

--- a/DPGAnalysis/SiStripTools/plugins/APVCyclePhaseProducerFromL1ABC.cc
+++ b/DPGAnalysis/SiStripTools/plugins/APVCyclePhaseProducerFromL1ABC.cc
@@ -21,7 +21,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Run.h"
@@ -51,7 +51,7 @@
 // class decleration
 //
 
-class APVCyclePhaseProducerFromL1ABC : public edm::EDProducer {
+class APVCyclePhaseProducerFromL1ABC : public edm::one::EDProducer<edm::one::WatchRuns> {
 public:
   explicit APVCyclePhaseProducerFromL1ABC(const edm::ParameterSet&);
   ~APVCyclePhaseProducerFromL1ABC() override;

--- a/DPGAnalysis/SiStripTools/plugins/APVShotsAnalyzer.cc
+++ b/DPGAnalysis/SiStripTools/plugins/APVShotsAnalyzer.cc
@@ -26,7 +26,7 @@
 #include <string>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
 
 #include "FWCore/Framework/interface/Event.h"
@@ -66,7 +66,7 @@
 // class decleration
 //
 
-class APVShotsAnalyzer : public edm::EDAnalyzer {
+class APVShotsAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources, edm::one::WatchRuns> {
 public:
   explicit APVShotsAnalyzer(const edm::ParameterSet&);
   ~APVShotsAnalyzer() override;
@@ -153,6 +153,7 @@ APVShotsAnalyzer::APVShotsAnalyzer(const edm::ParameterSet& iConfig)
       _nevents(0),
       _rhm(consumesCollector()) {
   //now do what ever initialization is needed
+  usesResource(TFileService::kSharedResource);
 
   if (!_zs)
     _suffix += "_notZS";

--- a/DPGAnalysis/SiStripTools/plugins/BigEventsDebugger.cc
+++ b/DPGAnalysis/SiStripTools/plugins/BigEventsDebugger.cc
@@ -22,7 +22,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Run.h"
@@ -53,7 +53,7 @@
 //
 
 template <class T>
-class BigEventsDebugger : public edm::EDAnalyzer {
+class BigEventsDebugger : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit BigEventsDebugger(const edm::ParameterSet&);
   ~BigEventsDebugger() override;
@@ -100,6 +100,7 @@ BigEventsDebugger<T>::BigEventsDebugger(const edm::ParameterSet& iConfig)
 
 {
   //now do what ever initialization is needed
+  usesResource(TFileService::kSharedResource);
 
   std::vector<edm::ParameterSet> selconfigs = iConfig.getParameter<std::vector<edm::ParameterSet> >("selections");
 

--- a/DPGAnalysis/SiStripTools/plugins/CommonModeAnalyzer.cc
+++ b/DPGAnalysis/SiStripTools/plugins/CommonModeAnalyzer.cc
@@ -27,7 +27,7 @@
 #include <string>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
 
 #include "FWCore/Framework/interface/Event.h"
@@ -62,7 +62,7 @@
 // class decleration
 //
 
-class CommonModeAnalyzer : public edm::EDAnalyzer {
+class CommonModeAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources, edm::one::WatchRuns> {
 public:
   explicit CommonModeAnalyzer(const edm::ParameterSet&);
   ~CommonModeAnalyzer() override;
@@ -137,6 +137,7 @@ CommonModeAnalyzer::CommonModeAnalyzer(const edm::ParameterSet& iConfig)
       m_detCablingWatcher(this, &CommonModeAnalyzer::updateDetCabling),
       m_detCablingToken(esConsumes()) {
   //now do what ever initialization is needed
+  usesResource(TFileService::kSharedResource);
 
   edm::Service<TFileService> tfserv;
 

--- a/DPGAnalysis/SiStripTools/plugins/DetIdSelectorTest.cc
+++ b/DPGAnalysis/SiStripTools/plugins/DetIdSelectorTest.cc
@@ -24,7 +24,7 @@
 #include <string>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -54,7 +54,7 @@
 // class decleration
 //
 
-class DetIdSelectorTest : public edm::EDAnalyzer {
+class DetIdSelectorTest : public edm::one::EDAnalyzer<> {
 public:
   explicit DetIdSelectorTest(const edm::ParameterSet&);
   ~DetIdSelectorTest() override;

--- a/DPGAnalysis/SiStripTools/plugins/DuplicateRecHits.cc
+++ b/DPGAnalysis/SiStripTools/plugins/DuplicateRecHits.cc
@@ -22,7 +22,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Run.h"
@@ -59,7 +59,7 @@
 // class decleration
 //
 
-class DuplicateRecHits : public edm::EDAnalyzer {
+class DuplicateRecHits : public edm::one::EDAnalyzer<edm::one::SharedResources, edm::one::WatchRuns> {
 public:
   explicit DuplicateRecHits(const edm::ParameterSet&);
   ~DuplicateRecHits() override;
@@ -99,6 +99,7 @@ DuplicateRecHits::DuplicateRecHits(const edm::ParameterSet& iConfig)
   //now do what ever initialization is needed
 
   // histogram parameters
+  usesResource(TFileService::kSharedResource);
 
   edm::LogInfo("TrackCollection") << "Using collection "
                                   << iConfig.getParameter<edm::InputTag>("trackCollection").label().c_str();

--- a/DPGAnalysis/SiStripTools/plugins/EventTimeDistribution.cc
+++ b/DPGAnalysis/SiStripTools/plugins/EventTimeDistribution.cc
@@ -27,7 +27,7 @@
 #include "TH2F.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -38,7 +38,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "FWCore/ServiceRegistry/interface/Service.h"
-#include "CommonTools/UtilAlgos/interface/TFileService.h"
 
 #include "FWCore/Utilities/interface/InputTag.h"
 
@@ -50,7 +49,7 @@
 // class decleration
 //
 
-class EventTimeDistribution : public edm::EDAnalyzer {
+class EventTimeDistribution : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   explicit EventTimeDistribution(const edm::ParameterSet&);
   ~EventTimeDistribution() override;

--- a/DPGAnalysis/SiStripTools/plugins/EventWithHistoryProducer.cc
+++ b/DPGAnalysis/SiStripTools/plugins/EventWithHistoryProducer.cc
@@ -22,7 +22,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -37,15 +37,13 @@
 // class decleration
 //
 
-class EventWithHistoryProducer : public edm::EDProducer {
+class EventWithHistoryProducer : public edm::stream::EDProducer<> {
 public:
   explicit EventWithHistoryProducer(const edm::ParameterSet&);
   ~EventWithHistoryProducer() override;
 
 private:
-  void beginJob() override;
   void produce(edm::Event&, const edm::EventSetup&) override;
-  void endJob() override;
 
   // ----------member data ---------------------------
 
@@ -94,12 +92,6 @@ void EventWithHistoryProducer::produce(edm::Event& iEvent, const edm::EventSetup
   _prevHE = *heOut;
   iEvent.put(std::move(heOut));
 }
-
-// ------------ method called once each job just before starting event loop  ------------
-void EventWithHistoryProducer::beginJob() {}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void EventWithHistoryProducer::endJob() {}
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(EventWithHistoryProducer);

--- a/DPGAnalysis/SiStripTools/plugins/FEDBadModuleFilter.cc
+++ b/DPGAnalysis/SiStripTools/plugins/FEDBadModuleFilter.cc
@@ -22,7 +22,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/one/EDFilter.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -46,7 +46,7 @@
 // class declaration
 //
 
-class FEDBadModuleFilter : public edm::EDFilter {
+class FEDBadModuleFilter : public edm::one::EDFilter<edm::one::WatchRuns> {
 public:
   explicit FEDBadModuleFilter(const edm::ParameterSet&);
   ~FEDBadModuleFilter() override;
@@ -55,6 +55,7 @@ private:
   void beginJob() override;
   bool filter(edm::Event&, const edm::EventSetup&) override;
   void beginRun(const edm::Run&, const edm::EventSetup&) override;
+  void endRun(const edm::Run&, const edm::EventSetup&) override {}
   void endJob() override;
 
   // ----------member data ---------------------------

--- a/DPGAnalysis/SiStripTools/plugins/FromClusterSummaryMultiplicityProducer.cc
+++ b/DPGAnalysis/SiStripTools/plugins/FromClusterSummaryMultiplicityProducer.cc
@@ -23,7 +23,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -37,15 +37,12 @@
 //
 // class decleration
 //
-class FromClusterSummaryMultiplicityProducer : public edm::EDProducer {
+class FromClusterSummaryMultiplicityProducer : public edm::global::EDProducer<> {
 public:
   explicit FromClusterSummaryMultiplicityProducer(const edm::ParameterSet&);
-  ~FromClusterSummaryMultiplicityProducer() override;
 
 private:
-  void beginJob() override;
-  void produce(edm::Event&, const edm::EventSetup&) override;
-  void endJob() override;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
   // ----------member data ---------------------------
 
@@ -86,17 +83,14 @@ FromClusterSummaryMultiplicityProducer::FromClusterSummaryMultiplicityProducer(c
   m_subdetvar = (ClusterSummary::VariablePlacement)iConfig.getParameter<int>("varEnum");
 }
 
-FromClusterSummaryMultiplicityProducer::~FromClusterSummaryMultiplicityProducer() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
-}
-
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-void FromClusterSummaryMultiplicityProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void FromClusterSummaryMultiplicityProducer::produce(edm::StreamID,
+                                                     edm::Event& iEvent,
+                                                     const edm::EventSetup& iSetup) const {
   LogDebug("Multiplicity") << " Ready to go";
 
   using namespace edm;
@@ -134,11 +128,5 @@ void FromClusterSummaryMultiplicityProducer::produce(edm::Event& iEvent, const e
 
   iEvent.put(std::move(mults));
 }
-
-// ------------ method called once each job just before starting event loop  ------------
-void FromClusterSummaryMultiplicityProducer::beginJob() {}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void FromClusterSummaryMultiplicityProducer::endJob() {}
 
 DEFINE_FWK_MODULE(FromClusterSummaryMultiplicityProducer);

--- a/DPGAnalysis/SiStripTools/plugins/L1ABCDebugger.cc
+++ b/DPGAnalysis/SiStripTools/plugins/L1ABCDebugger.cc
@@ -28,7 +28,7 @@
 #include <string>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Run.h"
@@ -44,7 +44,7 @@
 // class decleration
 //
 
-class L1ABCDebugger : public edm::EDAnalyzer {
+class L1ABCDebugger : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   explicit L1ABCDebugger(const edm::ParameterSet&);
   ~L1ABCDebugger() override;
@@ -53,6 +53,7 @@ private:
   void beginJob() override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   void beginRun(const edm::Run&, const edm::EventSetup&) override;
+  void endRun(const edm::Run&, const edm::EventSetup&) override {}
   void endJob() override;
 
   // ----------member data ---------------------------

--- a/DPGAnalysis/SiStripTools/plugins/MultiplicityCorrelator.cc
+++ b/DPGAnalysis/SiStripTools/plugins/MultiplicityCorrelator.cc
@@ -27,7 +27,7 @@
 #include <limits>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -41,7 +41,7 @@
 // class decleration
 //
 
-class MultiplicityCorrelator : public edm::EDAnalyzer {
+class MultiplicityCorrelator : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   explicit MultiplicityCorrelator(const edm::ParameterSet&);
   ~MultiplicityCorrelator() override;
@@ -50,6 +50,7 @@ private:
   void beginJob() override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   void beginRun(const edm::Run&, const edm::EventSetup&) override;
+  void endRun(const edm::Run&, const edm::EventSetup&) override {}
   void endJob() override;
 
   // ----------member data ---------------------------

--- a/DPGAnalysis/SiStripTools/plugins/MultiplicityInvestigator.cc
+++ b/DPGAnalysis/SiStripTools/plugins/MultiplicityInvestigator.cc
@@ -27,7 +27,7 @@
 #include <limits>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -48,7 +48,7 @@
 // class decleration
 //
 
-class MultiplicityInvestigator : public edm::EDAnalyzer {
+class MultiplicityInvestigator : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   explicit MultiplicityInvestigator(const edm::ParameterSet&);
   ~MultiplicityInvestigator() override;
@@ -57,6 +57,7 @@ private:
   void beginJob() override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   void beginRun(const edm::Run&, const edm::EventSetup&) override;
+  void endRun(const edm::Run&, const edm::EventSetup&) override {}
   void endJob() override;
 
   // ----------member data ---------------------------

--- a/DPGAnalysis/SiStripTools/plugins/MultiplicityTimeCorrelations.cc
+++ b/DPGAnalysis/SiStripTools/plugins/MultiplicityTimeCorrelations.cc
@@ -27,7 +27,7 @@
 #include <climits>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Run.h"
@@ -57,7 +57,7 @@
 // class decleration
 //
 
-class MultiplicityTimeCorrelations : public edm::EDAnalyzer {
+class MultiplicityTimeCorrelations : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::SharedResources> {
 public:
   explicit MultiplicityTimeCorrelations(const edm::ParameterSet&);
   ~MultiplicityTimeCorrelations() override;
@@ -66,6 +66,7 @@ private:
   void beginJob() override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   void beginRun(const edm::Run&, const edm::EventSetup&) override;
+  void endRun(const edm::Run&, const edm::EventSetup&) override {}
   void endJob() override;
 
   // ----------member data ---------------------------
@@ -128,6 +129,8 @@ MultiplicityTimeCorrelations::MultiplicityTimeCorrelations(const edm::ParameterS
       _trnumb(),
       _dbxbins(iConfig.getUntrackedParameter<std::vector<int> >("dbxBins")) {
   //now do what ever initialization is needed
+
+  usesResource(TFileService::kSharedResource);
 
   // configure the filter
 

--- a/DPGAnalysis/SiStripTools/plugins/OccupancyPlots.cc
+++ b/DPGAnalysis/SiStripTools/plugins/OccupancyPlots.cc
@@ -29,7 +29,7 @@
 #include "TProfile.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -63,7 +63,7 @@
 // class decleration
 //
 
-class OccupancyPlots : public edm::EDAnalyzer {
+class OccupancyPlots : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   explicit OccupancyPlots(const edm::ParameterSet&);
   ~OccupancyPlots() override;

--- a/DPGAnalysis/SiStripTools/plugins/OverlapProblemTPAnalyzer.cc
+++ b/DPGAnalysis/SiStripTools/plugins/OverlapProblemTPAnalyzer.cc
@@ -24,7 +24,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -55,7 +55,7 @@
 // class decleration
 //
 
-class OverlapProblemTPAnalyzer : public edm::EDAnalyzer {
+class OverlapProblemTPAnalyzer : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::SharedResources> {
 public:
   explicit OverlapProblemTPAnalyzer(const edm::ParameterSet&);
   ~OverlapProblemTPAnalyzer() override;
@@ -104,6 +104,8 @@ OverlapProblemTPAnalyzer::OverlapProblemTPAnalyzer(const edm::ParameterSet& iCon
       m_trkcollToken(consumes<edm::View<reco::Track> >(iConfig.getParameter<edm::InputTag>("trackCollection"))),
       m_associatorToken(consumes<reco::TrackToTrackingParticleAssociator>(edm::InputTag("trackAssociatorByHits"))) {
   //now do what ever initialization is needed
+
+  usesResource(TFileService::kSharedResource);
 
   edm::Service<TFileService> tfserv;
 

--- a/DPGAnalysis/SiStripTools/plugins/OverlapProblemTSOSAnalyzer.cc
+++ b/DPGAnalysis/SiStripTools/plugins/OverlapProblemTSOSAnalyzer.cc
@@ -24,7 +24,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -61,7 +61,7 @@
 // class decleration
 //
 
-class OverlapProblemTSOSAnalyzer : public edm::EDAnalyzer {
+class OverlapProblemTSOSAnalyzer : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::SharedResources> {
 public:
   explicit OverlapProblemTSOSAnalyzer(const edm::ParameterSet&);
   ~OverlapProblemTSOSAnalyzer() override;
@@ -101,6 +101,7 @@ OverlapProblemTSOSAnalyzer::OverlapProblemTSOSAnalyzer(const edm::ParameterSet& 
       m_debug(iConfig.getUntrackedParameter<bool>("debugMode", false)),
       m_tsoshm(iConfig.getParameter<edm::ParameterSet>("tsosHMConf")) {
   //now do what ever initialization is needed
+  usesResource(TFileService::kSharedResource);
 
   edm::Service<TFileService> tfserv;
 

--- a/DPGAnalysis/SiStripTools/plugins/OverlapProblemTSOSPositionFilter.cc
+++ b/DPGAnalysis/SiStripTools/plugins/OverlapProblemTSOSPositionFilter.cc
@@ -24,7 +24,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -55,18 +55,17 @@
 
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
-#include "TH1F.h"
 //
 // class decleration
 //
 
-class OverlapProblemTSOSPositionFilter : public edm::EDFilter {
+class OverlapProblemTSOSPositionFilter : public edm::global::EDFilter<> {
 public:
   explicit OverlapProblemTSOSPositionFilter(const edm::ParameterSet&);
   ~OverlapProblemTSOSPositionFilter() override;
 
 private:
-  bool filter(edm::Event&, const edm::EventSetup&) override;
+  bool filter(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
   // ----------member data ---------------------------
 
@@ -106,7 +105,7 @@ OverlapProblemTSOSPositionFilter::~OverlapProblemTSOSPositionFilter() {
 //
 
 // ------------ method called to for each event  ------------
-bool OverlapProblemTSOSPositionFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+bool OverlapProblemTSOSPositionFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   using namespace edm;
 
   // loop on trajectories and plot TSOS local coordinate

--- a/DPGAnalysis/SiStripTools/plugins/SeedMultiplicityAnalyzer.cc
+++ b/DPGAnalysis/SiStripTools/plugins/SeedMultiplicityAnalyzer.cc
@@ -27,7 +27,7 @@
 #include <numeric>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "FWCore/Framework/interface/Event.h"
@@ -66,7 +66,7 @@
 // class decleration
 //
 
-class SeedMultiplicityAnalyzer : public edm::EDAnalyzer {
+class SeedMultiplicityAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit SeedMultiplicityAnalyzer(const edm::ParameterSet&);
   ~SeedMultiplicityAnalyzer() override;
@@ -144,6 +144,7 @@ SeedMultiplicityAnalyzer::SeedMultiplicityAnalyzer(const edm::ParameterSet& iCon
       _hseedmult2D(),
       _hseedeta2D() {
   //now do what ever initialization is needed
+  usesResource(TFileService::kSharedResource);
 
   //
 

--- a/DPGAnalysis/SiStripTools/plugins/SiPixelQualityHistory.cc
+++ b/DPGAnalysis/SiStripTools/plugins/SiPixelQualityHistory.cc
@@ -28,7 +28,7 @@
 #include "TH1F.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -54,7 +54,7 @@
 // class decleration
 //
 
-class SiPixelQualityHistory : public edm::EDAnalyzer {
+class SiPixelQualityHistory : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::SharedResources> {
 public:
   explicit SiPixelQualityHistory(const edm::ParameterSet&);
   ~SiPixelQualityHistory() override;
@@ -64,6 +64,7 @@ public:
 private:
   void beginJob() override;
   void beginRun(const edm::Run&, const edm::EventSetup&) override;
+  void endRun(const edm::Run&, const edm::EventSetup&) override {}
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   void endJob() override;
 
@@ -102,6 +103,7 @@ SiPixelQualityHistory::SiPixelQualityHistory(const edm::ParameterSet& iConfig)
       m_history(),
       m_badmodrun() {
   //now do what ever initialization is needed
+  usesResource(TFileService::kSharedResource);
 
   edm::Service<TFileService> tfserv;
 

--- a/DPGAnalysis/SiStripTools/plugins/SiStripDetWithSomething.cc
+++ b/DPGAnalysis/SiStripTools/plugins/SiStripDetWithSomething.cc
@@ -21,7 +21,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -44,14 +44,14 @@
 //
 
 template <class T>
-class SiStripDetWithSomething : public edm::EDFilter {
+class SiStripDetWithSomething : public edm::global::EDFilter<> {
 public:
   explicit SiStripDetWithSomething(const edm::ParameterSet&);
   ~SiStripDetWithSomething() override;
 
 private:
   void beginJob() override;
-  bool filter(edm::Event&, const edm::EventSetup&) override;
+  bool filter(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
   void endJob() override;
 
   // ----------member data ---------------------------
@@ -99,7 +99,7 @@ SiStripDetWithSomething<T>::~SiStripDetWithSomething() {
 
 // ------------ method called on each new Event  ------------
 template <class T>
-bool SiStripDetWithSomething<T>::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+bool SiStripDetWithSomething<T>::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   using namespace edm;
 
   Handle<T> digis;

--- a/DPGAnalysis/SiStripTools/plugins/SiStripQualityHistory.cc
+++ b/DPGAnalysis/SiStripTools/plugins/SiStripQualityHistory.cc
@@ -28,7 +28,7 @@
 #include "TH1F.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -53,7 +53,7 @@
 // class decleration
 //
 
-class SiStripQualityHistory : public edm::EDAnalyzer {
+class SiStripQualityHistory : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::SharedResources> {
 public:
   explicit SiStripQualityHistory(const edm::ParameterSet&);
   ~SiStripQualityHistory() override;
@@ -63,6 +63,7 @@ public:
 private:
   void beginJob() override;
   void beginRun(const edm::Run&, const edm::EventSetup&) override;
+  void endRun(const edm::Run&, const edm::EventSetup&) override {}
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   void endJob() override;
 
@@ -101,6 +102,7 @@ SiStripQualityHistory::SiStripQualityHistory(const edm::ParameterSet& iConfig)
       _history(),
       m_badmodrun() {
   //now do what ever initialization is needed
+  usesResource(TFileService::kSharedResource);
 
   edm::Service<TFileService> tfserv;
 

--- a/DPGAnalysis/SiStripTools/plugins/TrackCount.cc
+++ b/DPGAnalysis/SiStripTools/plugins/TrackCount.cc
@@ -22,7 +22,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
@@ -61,13 +61,14 @@
 // class decleration
 //
 
-class TrackCount : public edm::EDAnalyzer {
+class TrackCount : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::SharedResources> {
 public:
   explicit TrackCount(const edm::ParameterSet&);
   ~TrackCount() override;
 
 private:
   void beginRun(const edm::Run&, const edm::EventSetup&) override;
+  void endRun(const edm::Run&, const edm::EventSetup&) override {}
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
   // ----------member data ---------------------------
@@ -145,6 +146,7 @@ TrackCount::TrackCount(const edm::ParameterSet& iConfig)
 {
   //now do what ever initialization is needed
 
+  usesResource(TFileService::kSharedResource);
   // histogram parameters
 
   const unsigned int netabin1d = iConfig.getUntrackedParameter<unsigned int>("netabin1D", 120);

--- a/DPGAnalysis/SiStripTools/plugins/TrackerDpgAnalysis.cc
+++ b/DPGAnalysis/SiStripTools/plugins/TrackerDpgAnalysis.cc
@@ -39,7 +39,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -105,7 +105,7 @@
 //
 typedef math::XYZPoint Point;
 
-class TrackerDpgAnalysis : public edm::EDAnalyzer {
+class TrackerDpgAnalysis : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::SharedResources> {
 public:
   explicit TrackerDpgAnalysis(const edm::ParameterSet&);
   ~TrackerDpgAnalysis() override;
@@ -137,6 +137,7 @@ protected:
 
 private:
   void beginRun(const edm::Run&, const edm::EventSetup&) override;
+  void endRun(const edm::Run&, const edm::EventSetup&) override {}
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   void endJob() override;
 
@@ -236,6 +237,8 @@ TrackerDpgAnalysis::TrackerDpgAnalysis(const edm::ParameterSet& iConfig)
   moduleId_ = new char[256];
   PSUname_ = new char[256];
   pset_ = iConfig;
+
+  usesResource(TFileService::kSharedResource);
 
   // enable/disable functionalities
   functionality_offtrackClusters_ = iConfig.getUntrackedParameter<bool>("keepOfftrackClusters", true);


### PR DESCRIPTION
#### PR description:

Migrated all modules to thread-safe versions.

#### PR validation:

Code compiles and no more CMS_DEPRECATED warnings appear.