### PR TITLE
FastSim LL fix missing ! in beam pipe radius check. 

### DIFF
--- a/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
@@ -218,7 +218,7 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle() {
     int exoticRelativeId = 0;
     const bool producedWithinBeamPipe =
         productionVertex->position().perp2() * lengthUnitConversionFactor2_ < beamPipeRadius2_;
-    if (producedWithinBeamPipe) {
+    if (!producedWithinBeamPipe) {
       exoticRelativesChecker(productionVertex, exoticRelativeId, 0);
       if (!isExotic(exoticRelativeId)) {
         continue;


### PR DESCRIPTION
#### PR description:

A typo was introduced when implementing @perrotta's suggestion:
https://github.com/cms-sw/cmssw/pull/36122


Thanks to Carlos Cid for spotting it almost instantly. 
