### PR TITLE
Update HLT filter for MuonRechitClusters

### DIFF
--- a/HLTrigger/special/plugins/HLTMuonRecHitClusterFilter.cc
+++ b/HLTrigger/special/plugins/HLTMuonRecHitClusterFilter.cc
@@ -116,10 +116,10 @@ bool HLTMuonRecHitClusterFilter::filter(edm::StreamID, edm::Event& iEvent, const
     if (cluster.size() - cluster.nMB1() >= min_SizeMinusMB1_)
       passSizeCut = true;
     for (size_t i = 0; i < min_SizeRegionCutEtas_.size(); ++i) {
-      if ((min_SizeRegionCutEtas_ < 0.0 || std::abs(cluster.eta()) > min_SizeRegionCutEtas_[i]) &&
-          (max_SizeRegionCutEtas_ < 0.0 || std::abs(cluster.eta()) <= max_SizeRegionCutEtas_[i]) &&
-          (min_SizeRegionCutNstations_ < 0 || cluster.nStation() > min_SizeRegionCutNstations_[i]) &&
-          (max_SizeRegionCutNstations_ < 0 || cluster.nStation() <= max_SizeRegionCutNstations_[i]) &&
+      if (((min_SizeRegionCutEtas_[i] < 0.0) || std::abs(cluster.eta()) > min_SizeRegionCutEtas_[i]) &&
+          ((max_SizeRegionCutEtas_[i] < 0.0) || std::abs(cluster.eta()) <= max_SizeRegionCutEtas_[i]) &&
+          ((min_SizeRegionCutNstations_[i] < 0) || cluster.nStation() > min_SizeRegionCutNstations_[i]) &&
+          ((max_SizeRegionCutNstations_[i] < 0) || cluster.nStation() <= max_SizeRegionCutNstations_[i]) &&
           cluster.size() >= min_SizeRegionCutClusterSize_[i])
         passSizeCut = true;
     }

--- a/HLTrigger/special/plugins/HLTMuonRecHitClusterFilter.cc
+++ b/HLTrigger/special/plugins/HLTMuonRecHitClusterFilter.cc
@@ -1,3 +1,4 @@
+#include <vector>
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/global/EDFilter.h"
@@ -20,10 +21,11 @@ private:
   const int min_N_;
   const int min_Size_;
   const int min_SizeMinusMB1_;
-  const int min_SizeEtaLT1p9NstationGT1_;
-  const int min_SizeEtaLT1p9NstationEq1_;
-  const int min_SizeEtaGT1p9NstationGT1_;
-  const int min_SizeEtaGT1p9NstationEq1_;
+  const std::vector<double> min_SizeRegionCutEtas_;
+  const std::vector<double> max_SizeRegionCutEtas_;
+  const std::vector<int> min_SizeRegionCutNstations_;
+  const std::vector<int> max_SizeRegionCutNstations_;
+  const std::vector<int> min_SizeRegionCutClusterSize_;
   const int max_nMB1_;
   const int max_nMB2_;
   const int max_nME11_;
@@ -46,10 +48,11 @@ HLTMuonRecHitClusterFilter::HLTMuonRecHitClusterFilter(const edm::ParameterSet& 
       min_N_(iConfig.getParameter<int>("MinN")),
       min_Size_(iConfig.getParameter<int>("MinSize")),
       min_SizeMinusMB1_(iConfig.getParameter<int>("MinSizeMinusMB1")),
-      min_SizeEtaLT1p9NstationGT1_(iConfig.getParameter<int>("MinSizeEtaLT1p9NstationGT1")),
-      min_SizeEtaLT1p9NstationEq1_(iConfig.getParameter<int>("MinSizeEtaLT1p9NstationEq1")),
-      min_SizeEtaGT1p9NstationGT1_(iConfig.getParameter<int>("MinSizeEtaGT1p9NstationGT1")),
-      min_SizeEtaGT1p9NstationEq1_(iConfig.getParameter<int>("MinSizeEtaGT1p9NstationEq1")),
+      min_SizeRegionCutEtas_(iConfig.getParameter<std::vector<double> >("MinSizeRegionCutEtas")),
+      max_SizeRegionCutEtas_(iConfig.getParameter<std::vector<double> >("MaxSizeRegionCutEtas")),
+      min_SizeRegionCutNstations_(iConfig.getParameter<std::vector<int> >("MinSizeRegionCutNstations")),
+      max_SizeRegionCutNstations_(iConfig.getParameter<std::vector<int> >("MaxSizeRegionCutNstations")),
+      min_SizeRegionCutClusterSize_(iConfig.getParameter<std::vector<int> >("MinSizeRegionCutClusterSize")),
       max_nMB1_(iConfig.getParameter<int>("Max_nMB1")),
       max_nMB2_(iConfig.getParameter<int>("Max_nMB2")),
       max_nME11_(iConfig.getParameter<int>("Max_nME11")),
@@ -69,11 +72,17 @@ void HLTMuonRecHitClusterFilter::fillDescriptions(edm::ConfigurationDescriptions
   desc.add<edm::InputTag>("ClusterTag", edm::InputTag("hltCSCrechitClusters"));
   desc.add<int>("MinN", 1);
   desc.add<int>("MinSize", 50);
-  desc.add<int>("MinSizeMinusMB1", 999);
-  desc.add<int>("MinSizeEtaLT1p9NstationGT1", 999);
-  desc.add<int>("MinSizeEtaLT1p9NstationEq1", 999);
-  desc.add<int>("MinSizeEtaGT1p9NstationGT1", 999);
-  desc.add<int>("MinSizeEtaGT1p9NstationEq1", 999);
+  desc.add<int>("MinSizeMinusMB1", 9999);
+  std::vector<double> minSizeRegionCutEtas{-1., -1., 1.9, 1.9};
+  std::vector<double> maxSizeRegionCutEtas{1.9, 1.9, -1., -1.};
+  std::vector<int> minSizeRegionCutNstations{-1, 1, -1, 1};
+  std::vector<int> maxSizeRegionCutNstations{1, -1, 1, -1};
+  std::vector<int> minSizeRegionCutClusterSize{9999, 9999, 9999, 9999};
+  desc.add<std::vector<double> >("MinSizeRegionCutEtas", minSizeRegionCutEtas);
+  desc.add<std::vector<double> >("MaxSizeRegionCutEtas", maxSizeRegionCutEtas);
+  desc.add<std::vector<int> >("MinSizeRegionCutNstations", minSizeRegionCutNstations);
+  desc.add<std::vector<int> >("MaxSizeRegionCutNstations", maxSizeRegionCutNstations);
+  desc.add<std::vector<int> >("MinSizeRegionCutClusterSize", minSizeRegionCutClusterSize);
   desc.add<int>("Max_nMB1", 999);
   desc.add<int>("Max_nMB2", 999);
   desc.add<int>("Max_nME11", 999);
@@ -101,15 +110,23 @@ bool HLTMuonRecHitClusterFilter::filter(edm::StreamID, edm::Event& iEvent, const
   auto const& rechitClusters = iEvent.get(cluster_token_);
 
   for (auto const& cluster : rechitClusters) {
-    if (((cluster.size() >= min_Size_) || ((cluster.size() - cluster.nMB1()) >= min_SizeMinusMB1_) ||
-         (std::abs(cluster.eta()) <= 1.9 && cluster.nStation() > 1 && cluster.size() >= min_SizeEtaLT1p9NstationGT1_) ||
-         (std::abs(cluster.eta()) <= 1.9 && cluster.nStation() <= 1 && cluster.size() >= min_SizeEtaLT1p9NstationEq1_) ||
-         (std::abs(cluster.eta()) > 1.9 && cluster.nStation() > 1 && cluster.size() >= min_SizeEtaGT1p9NstationGT1_) ||
-         (std::abs(cluster.eta()) > 1.9 && cluster.nStation() <= 1 && cluster.size() >= min_SizeEtaGT1p9NstationEq1_)) &&
-        (cluster.nMB1() <= max_nMB1_) && (cluster.nMB2() <= max_nMB2_) && (cluster.nME11() <= max_nME11_) &&
-        (cluster.nME12() <= max_nME12_) && (cluster.nME41() <= max_nME41_) && (cluster.nME42() <= max_nME42_) &&
-        (cluster.nStation() >= min_Nstation_) && (cluster.avgStation() >= min_AvgStation_) &&
-        ((min_Eta_ < 0.0) || (std::abs(cluster.eta()) >= min_Eta_)) &&
+    bool passSizeCut = false;
+    if (cluster.size() >= min_Size_)
+      passSizeCut = true;
+    if (cluster.size() - cluster.nMB1() >= min_SizeMinusMB1_)
+      passSizeCut = true;
+    for (size_t i = 0; i < min_SizeRegionCutEtas_.size(); ++i) {
+      if ((min_SizeRegionCutEtas_ < 0.0 || std::abs(cluster.eta()) > min_SizeRegionCutEtas_[i]) &&
+          (max_SizeRegionCutEtas_ < 0.0 || std::abs(cluster.eta()) <= max_SizeRegionCutEtas_[i]) &&
+          (min_SizeRegionCutNstations_ < 0 || cluster.nStation() > min_SizeRegionCutNstations_[i]) &&
+          (max_SizeRegionCutNstations_ < 0 || cluster.nStation() <= max_SizeRegionCutNstations_[i]) &&
+          cluster.size() >= min_SizeRegionCutClusterSize_[i])
+        passSizeCut = true;
+    }
+    if ((passSizeCut) && (cluster.nMB1() <= max_nMB1_) && (cluster.nMB2() <= max_nMB2_) &&
+        (cluster.nME11() <= max_nME11_) && (cluster.nME12() <= max_nME12_) && (cluster.nME41() <= max_nME41_) &&
+        (cluster.nME42() <= max_nME42_) && (cluster.nStation() >= min_Nstation_) &&
+        (cluster.avgStation() >= min_AvgStation_) && ((min_Eta_ < 0.0) || (std::abs(cluster.eta()) >= min_Eta_)) &&
         ((max_Eta_ < 0.0) || (std::abs(cluster.eta()) <= max_Eta_)) && (cluster.time() > min_Time_) &&
         (cluster.time() <= max_Time_) && (cluster.timeSpread() <= max_TimeSpread_)) {
       nClusterPassed++;

--- a/HLTrigger/special/plugins/HLTMuonRecHitClusterFilter.cc
+++ b/HLTrigger/special/plugins/HLTMuonRecHitClusterFilter.cc
@@ -70,9 +70,11 @@ void HLTMuonRecHitClusterFilter::fillDescriptions(edm::ConfigurationDescriptions
   desc.add<int>("MinN", 1);
   desc.add<int>("MinSize", 50);
   desc.add<int>("MinSizeMinusMB1", 999);
-  desc.add<int>("MinSizeEtaLT1p9NstationGT1", 999), desc.add<int>("MinSizeEtaLT1p9NstationEq1", 999),
-      desc.add<int>("MinSizeEtaGT1p9NstationGT1", 999), desc.add<int>("MinSizeEtaGT1p9NstationEq1", 999),
-      desc.add<int>("Max_nMB1", 999);
+  desc.add<int>("MinSizeEtaLT1p9NstationGT1", 999);
+  desc.add<int>("MinSizeEtaLT1p9NstationEq1", 999);
+  desc.add<int>("MinSizeEtaGT1p9NstationGT1", 999);
+  desc.add<int>("MinSizeEtaGT1p9NstationEq1", 999);
+  desc.add<int>("Max_nMB1", 999);
   desc.add<int>("Max_nMB2", 999);
   desc.add<int>("Max_nME11", 999);
   desc.add<int>("Max_nME12", 999);

--- a/HLTrigger/special/plugins/HLTMuonRecHitClusterFilter.cc
+++ b/HLTrigger/special/plugins/HLTMuonRecHitClusterFilter.cc
@@ -20,6 +20,10 @@ private:
   const int min_N_;
   const int min_Size_;
   const int min_SizeMinusMB1_;
+  const int min_SizeEtaLT1p9NstationGT1_;
+  const int min_SizeEtaLT1p9NstationEq1_;
+  const int min_SizeEtaGT1p9NstationGT1_;
+  const int min_SizeEtaGT1p9NstationEq1_;
   const int max_nMB1_;
   const int max_nMB2_;
   const int max_nME11_;
@@ -42,6 +46,10 @@ HLTMuonRecHitClusterFilter::HLTMuonRecHitClusterFilter(const edm::ParameterSet& 
       min_N_(iConfig.getParameter<int>("MinN")),
       min_Size_(iConfig.getParameter<int>("MinSize")),
       min_SizeMinusMB1_(iConfig.getParameter<int>("MinSizeMinusMB1")),
+      min_SizeEtaLT1p9NstationGT1_(iConfig.getParameter<int>("MinSizeEtaLT1p9NstationGT1")),
+      min_SizeEtaLT1p9NstationEq1_(iConfig.getParameter<int>("MinSizeEtaLT1p9NstationEq1")),
+      min_SizeEtaGT1p9NstationGT1_(iConfig.getParameter<int>("MinSizeEtaGT1p9NstationGT1")),
+      min_SizeEtaGT1p9NstationEq1_(iConfig.getParameter<int>("MinSizeEtaGT1p9NstationEq1")),
       max_nMB1_(iConfig.getParameter<int>("Max_nMB1")),
       max_nMB2_(iConfig.getParameter<int>("Max_nMB2")),
       max_nME11_(iConfig.getParameter<int>("Max_nME11")),
@@ -61,13 +69,15 @@ void HLTMuonRecHitClusterFilter::fillDescriptions(edm::ConfigurationDescriptions
   desc.add<edm::InputTag>("ClusterTag", edm::InputTag("hltCSCrechitClusters"));
   desc.add<int>("MinN", 1);
   desc.add<int>("MinSize", 50);
-  desc.add<int>("MinSizeMinusMB1", 0);
-  desc.add<int>("Max_nMB1", 0);
-  desc.add<int>("Max_nMB2", 0);
-  desc.add<int>("Max_nME11", 0);
-  desc.add<int>("Max_nME12", 0);
-  desc.add<int>("Max_nME41", 0);
-  desc.add<int>("Max_nME42", 0);
+  desc.add<int>("MinSizeMinusMB1", 999);
+  desc.add<int>("MinSizeEtaLT1p9NstationGT1", 999), desc.add<int>("MinSizeEtaLT1p9NstationEq1", 999),
+      desc.add<int>("MinSizeEtaGT1p9NstationGT1", 999), desc.add<int>("MinSizeEtaGT1p9NstationEq1", 999),
+      desc.add<int>("Max_nMB1", 999);
+  desc.add<int>("Max_nMB2", 999);
+  desc.add<int>("Max_nME11", 999);
+  desc.add<int>("Max_nME12", 999);
+  desc.add<int>("Max_nME41", 999);
+  desc.add<int>("Max_nME42", 999);
   desc.add<int>("MinNstation", 0);
   desc.add<double>("MinAvgStation", 0.0);
   desc.add<double>("MinTime", -999);
@@ -89,7 +99,11 @@ bool HLTMuonRecHitClusterFilter::filter(edm::StreamID, edm::Event& iEvent, const
   auto const& rechitClusters = iEvent.get(cluster_token_);
 
   for (auto const& cluster : rechitClusters) {
-    if ((cluster.size() >= min_Size_) && ((cluster.size() - cluster.nMB1()) >= min_SizeMinusMB1_) &&
+    if (((cluster.size() >= min_Size_) || ((cluster.size() - cluster.nMB1()) >= min_SizeMinusMB1_) ||
+         (std::abs(cluster.eta()) <= 1.9 && cluster.nStation() > 1 && cluster.size() >= min_SizeEtaLT1p9NstationGT1_) ||
+         (std::abs(cluster.eta()) <= 1.9 && cluster.nStation() <= 1 && cluster.size() >= min_SizeEtaLT1p9NstationEq1_) ||
+         (std::abs(cluster.eta()) > 1.9 && cluster.nStation() > 1 && cluster.size() >= min_SizeEtaGT1p9NstationGT1_) ||
+         (std::abs(cluster.eta()) > 1.9 && cluster.nStation() <= 1 && cluster.size() >= min_SizeEtaGT1p9NstationEq1_)) &&
         (cluster.nMB1() <= max_nMB1_) && (cluster.nMB2() <= max_nMB2_) && (cluster.nME11() <= max_nME11_) &&
         (cluster.nME12() <= max_nME12_) && (cluster.nME41() <= max_nME41_) && (cluster.nME42() <= max_nME42_) &&
         (cluster.nStation() >= min_Nstation_) && (cluster.avgStation() >= min_AvgStation_) &&


### PR DESCRIPTION
#### PR description:

This PR updates the HLT filter for MuonRechitClusters to accommodate the latest trigger path design.
The design is proposed in the  [HLT Trigger Review](https://indico.cern.ch/event/1099590/contributions/4626718/attachments/2356190/4020920/Trigger_LLP_Approval.pdf), having the flexibility to define eta-dependent thresholds will increase signal efficiency by ~15% at the same rate.

The PR is a small extension on top of #35836 

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

Work in progress to reproduce the result presented at the trigger review meeting.
<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->
