### PR TITLE
Update Run3 offline data GT and mcRun3 GTs with final DD4HEP

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -40,7 +40,7 @@ autoCond = {
     # GlobalTag for Run3 data relvals
     'run3_data_prompt'             : '122X_dataRun3_Prompt_v1',
     # GlobalTag for Run3 offline data reprocessing
-    'run3_data'                    : '122X_dataRun3_v1',
+    'run3_data'                    : '122X_dataRun3_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'           : '122X_mc2017_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
@@ -64,17 +64,17 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak'     : '122X_upgrade2018cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'           : '122X_mcRun3_2021_design_v2',
+    'phase1_2021_design'           : '122X_mcRun3_2021_design_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'        : '122X_mcRun3_2021_realistic_v2',
+    'phase1_2021_realistic'        : '122X_mcRun3_2021_realistic_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'          : '122X_mcRun3_2021cosmics_realistic_deco_v2',
+    'phase1_2021_cosmics'          : '122X_mcRun3_2021cosmics_realistic_deco_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi'     : '122X_mcRun3_2021_realistic_HI_v2',
+    'phase1_2021_realistic_hi'     : '122X_mcRun3_2021_realistic_HI_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '122X_mcRun3_2023_realistic_v2',
+    'phase1_2023_realistic'        : '122X_mcRun3_2023_realistic_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '122X_mcRun3_2024_realistic_v2',
+    'phase1_2024_realistic'        : '122X_mcRun3_2024_realistic_v3',
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             : '122X_mcRun4_realistic_v2'
 }

--- a/Configuration/AlCa/python/autoCondModifiers.py
+++ b/Configuration/AlCa/python/autoCondModifiers.py
@@ -35,21 +35,22 @@ def autoCondDDD(autoCond):
 
     GlobalTagsDDD = {}
     # substitute the DD4hep geometry tags with DDD ones
-    CSCRECODIGI_Geometry_ddd    =  ','.join( ['CSCRECODIGI_Geometry_112YV2'            , "CSCRecoDigiParametersRcd", connectionString, "", "2021-09-28 12:00:00.000"] )
-    CSCRECO_Geometry_ddd        =  ','.join( ['CSCRECO_Geometry_112YV2'                , "CSCRecoGeometryRcd"      , connectionString, "", "2021-09-28 12:00:00.000"] )
-    DTRECO_Geometry_ddd         =  ','.join( ['DTRECO_Geometry_112YV2'                 , "DTRecoGeometryRcd"       , connectionString, "", "2021-09-28 12:00:00.000"] )
-    GEMRECO_Geometry_ddd        =  ','.join( ['GEMRECO_Geometry_113YV4'                , "GEMRecoGeometryRcd"      , connectionString, "", "2021-09-28 12:00:00.000"] )
-    XMLFILE_Geometry_ddd        =  ','.join( ['XMLFILE_Geometry_121YV1_Extended2021_mc', "GeometryFileRcd"         , connectionString, "Extended", "2021-09-28 12:00:00.000"] )
-    HCALParameters_Geometry_ddd =  ','.join( ['HCALParameters_Geometry_112YV2'         , "HcalParametersRcd"       , connectionString, "", "2021-09-28 12:00:00.000"] )
-    TKRECO_Geometry_ddd         =  ','.join( ['TKRECO_Geometry_120YV2'                 , "IdealGeometryRecord"     , connectionString, "", "2021-09-28 12:00:00.000"] )
-    CTRECO_Geometry_ddd         =  ','.join( ['CTRECO_Geometry_112YV2'                 , "PCaloTowerRcd"           , connectionString, "", "2021-09-28 12:00:00.000"] )
-    EBRECO_Geometry_ddd         =  ','.join( ['EBRECO_Geometry_112YV2'                 , "PEcalBarrelRcd"          , connectionString, "", "2021-09-28 12:00:00.000"] )
-    EERECO_Geometry_ddd         =  ','.join( ['EERECO_Geometry_112YV2'                 , "PEcalEndcapRcd"          , connectionString, "", "2021-09-28 12:00:00.000"] )
-    EPRECO_Geometry_ddd         =  ','.join( ['EPRECO_Geometry_112YV2'                 , "PEcalPreshowerRcd"       , connectionString, "", "2021-09-28 12:00:00.000"] )
-    HCALRECO_Geometry_ddd       =  ','.join( ['HCALRECO_Geometry_112YV2'               , "PHcalRcd"                , connectionString, "", "2021-09-28 12:00:00.000"] )
-    TKParameters_Geometry_ddd   =  ','.join( ['TKParameters_Geometry_112YV2'           , "PTrackerParametersRcd"   , connectionString, "", "2021-09-28 12:00:00.000"] )
-    ZDCRECO_Geometry_ddd        =  ','.join( ['ZDCRECO_Geometry_112YV2'                , "PZdcRcd"                 , connectionString, "", "2021-09-28 12:00:00.000"] )
-    RPCRECO_Geometry_ddd        =  ','.join( ['RPCRECO_Geometry_112YV2'                , "RPCRecoGeometryRcd"      , connectionString, "", "2021-09-28 12:00:00.000"] )
+    CSCRECODIGI_Geometry_ddd    =  ','.join( ['CSCRECODIGI_Geometry_112YV2'            , "CSCRecoDigiParametersRcd"      , connectionString, ""        , "2021-09-28 12:00:00.000"] )
+    CSCRECO_Geometry_ddd        =  ','.join( ['CSCRECO_Geometry_112YV2'                , "CSCRecoGeometryRcd"            , connectionString, ""        , "2021-09-28 12:00:00.000"] )
+    DTRECO_Geometry_ddd         =  ','.join( ['DTRECO_Geometry_112YV2'                 , "DTRecoGeometryRcd"             , connectionString, ""        , "2021-09-28 12:00:00.000"] )
+    GEMRECO_Geometry_ddd        =  ','.join( ['GEMRECO_Geometry_113YV4'                , "GEMRecoGeometryRcd"            , connectionString, ""        , "2021-09-28 12:00:00.000"] )
+    XMLFILE_Geometry_ddd        =  ','.join( ['XMLFILE_Geometry_121YV1_Extended2021_mc', "GeometryFileRcd"               , connectionString, "Extended", "2021-09-28 12:00:00.000"] )
+    HCALParameters_Geometry_ddd =  ','.join( ['HCALParameters_Geometry_112YV2'         , "HcalParametersRcd"             , connectionString, ""        , "2021-09-28 12:00:00.000"] )
+    TKRECO_Geometry_ddd         =  ','.join( ['TKRECO_Geometry_120YV2'                 , "IdealGeometryRecord"           , connectionString, ""        , "2021-09-28 12:00:00.000"] )
+    CTRECO_Geometry_ddd         =  ','.join( ['CTRECO_Geometry_112YV2'                 , "PCaloTowerRcd"                 , connectionString, ""        , "2021-09-28 12:00:00.000"] )
+    EBRECO_Geometry_ddd         =  ','.join( ['EBRECO_Geometry_112YV2'                 , "PEcalBarrelRcd"                , connectionString, ""        , "2021-09-28 12:00:00.000"] )
+    EERECO_Geometry_ddd         =  ','.join( ['EERECO_Geometry_112YV2'                 , "PEcalEndcapRcd"                , connectionString, ""        , "2021-09-28 12:00:00.000"] )
+    EPRECO_Geometry_ddd         =  ','.join( ['EPRECO_Geometry_112YV2'                 , "PEcalPreshowerRcd"             , connectionString, ""        , "2021-09-28 12:00:00.000"] )
+    HCALRECO_Geometry_ddd       =  ','.join( ['HCALRECO_Geometry_112YV2'               , "PHcalRcd"                      , connectionString, ""        , "2021-09-28 12:00:00.000"] )
+    TKParameters_Geometry_ddd   =  ','.join( ['TKParameters_Geometry_112YV2'           , "PTrackerParametersRcd"         , connectionString, ""        , "2021-09-28 12:00:00.000"] )
+    ZDCRECO_Geometry_ddd        =  ','.join( ['ZDCRECO_Geometry_112YV2'                , "PZdcRcd"                       , connectionString, ""        , "2021-09-28 12:00:00.000"] )
+    RPCRECO_Geometry_ddd        =  ','.join( ['RPCRECO_Geometry_112YV2'                , "RPCRecoGeometryRcd"            , connectionString, ""        , "2021-09-28 12:00:00.000"] )
+    PPSRECO_Geometry_ddd        =  ','.join( ['PPSRECO_Geometry_121YV2_2021_mc'        , "VeryForwardIdealGeometryRecord", connectionString, ""        , "2021-12-02 12:00:00.000"] )
 
     for key,val in autoCond.items():
         if 'phase1_202' in key:    # modification of the DDD relval GT
@@ -68,7 +69,8 @@ def autoCondDDD(autoCond):
                                          HCALRECO_Geometry_ddd,
                                          TKParameters_Geometry_ddd,
                                          ZDCRECO_Geometry_ddd,
-                                         RPCRECO_Geometry_ddd)
+                                         RPCRECO_Geometry_ddd,
+                                         PPSRECO_Geometry_ddd)
     autoCond.update(GlobalTagsDDD)
     return autoCond
 

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2531,9 +2531,9 @@ steps['RECOUP15_PU25HS']=merge([PU25HS,step3Up2015Defaults])
 
 #Run3 reco
 steps['RECODR3_2021']=merge([{'--scenario':'pp','--conditions':'auto:run3_data','--era':'Run3','--customise':'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3'},dataReco])
-steps['RECODR3_MinBiasOffline']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,EI,PAT,ALCA:SiStripCalMinBias+TkAlMinBias+EcalESAlign,DQM:@commonSiStripZeroBias+@ExtraHLT+@miniAODDQM'},steps['RECODR3_2021']])
-steps['RECODR3_ZBOffline']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,EI,PAT,ALCA:SiStripCalZeroBias+SiStripCalMinBias+TkAlMinBias+EcalESAlign,DQM:@rerecoZeroBias+@ExtraHLT+@miniAODDQM'},steps['RECODR3_2021']])
-steps['RECODR3_HLTPhysics_Offline']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,EI,PAT,ALCA:TkAlMinBias+HcalCalIterativePhiSym+HcalCalIsoTrkFilter+HcalCalHO+HcalCalHBHEMuonFilter,DQM:@commonReduced+@miniAODDQM'},steps['RECODR3_2021']])
+steps['RECODR3_MinBiasOffline']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,EI,PAT,ALCA:SiStripCalMinBias+TkAlMinBias+EcalESAlign,DQM:@commonSiStripZeroBias+@ExtraHLT+@miniAODDQM','--procModifiers':'siPixelQualityRawToDigi'},steps['RECODR3_2021']])
+steps['RECODR3_ZBOffline']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,EI,PAT,ALCA:SiStripCalZeroBias+SiStripCalMinBias+TkAlMinBias+EcalESAlign,DQM:@rerecoZeroBias+@ExtraHLT+@miniAODDQM','--procModifiers':'siPixelQualityRawToDigi'},steps['RECODR3_2021']])
+steps['RECODR3_HLTPhysics_Offline']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,EI,PAT,ALCA:TkAlMinBias+HcalCalIterativePhiSym+HcalCalIsoTrkFilter+HcalCalHO+HcalCalHBHEMuonFilter,DQM:@commonReduced+@miniAODDQM','--procModifiers':'siPixelQualityRawToDigi'},steps['RECODR3_2021']])
 steps['RECODR3_AlCaTkCosmics_Offline']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,SKIM:EXONoBPTXSkim,EI,PAT,ALCA:TkAlCosmicsInCollisions,DQM:@standardDQMFakeHLT+@miniAODDQM'},steps['RECODR3_2021']])
 
 # mask away - to be removed once we'll migrate the matrix to be fully unscheduled for RECO step


### PR DESCRIPTION
#### PR description:
This PR includes several updates in the conditions:
 - Offline Run3 data GT is updated in preparation of the PilotBeams2021 re-reco
 -  a modifier `'--procModifiers':'siPixelQualityRawToDigi'` is added in step3 of the 139.00* workflows (MinBias, ZeroBias and HLTPhysics) to pick up the new tag included in the GT following changes introduced in #36255 
 - mcRun3 GTs are updated to:
   - updated AlCaRecoTriggerBits, see https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4485/2/1/1/1.html
   - include final 12_2 DD4HEP tags (extended and zeromaterial tags), see https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4552.html and implementing condition changes requested in #36307
   - removed `XMLFILE_CTPPS_Geometry_2021_113YV1` which is now superseded by the persistent class (VeryForwardIdealGeometryRecord), see #35772 
   - Switched PPS to final DD4HEP geometry (`PPSRECO_Geometry_122DD4hepV1_2021`) and subsequently updated the `autoCondDDD` modifier

GT diffs:

**Run 3 data (offline)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_dataRun3_v1/122X_dataRun3_v2

**2021 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_mcRun3_2021_design_v2/122X_mcRun3_2021_design_v3

**2021 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_mcRun3_2021_realistic_v2/122X_mcRun3_2021_realistic_v3

**2021 cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_mcRun3_2021cosmics_realistic_deco_v2/122X_mcRun3_2021cosmics_realistic_deco_v3

**2021 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_mcRun3_2021_realistic_HI_v2/122X_mcRun3_2021_realistic_HI_v3

**2023 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_mcRun3_2023_realistic_v2/122X_mcRun3_2023_realistic_v3

**2024 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_mcRun3_2024_realistic_v2/122X_mcRun3_2024_realistic_v3


#### PR validation:
Validated with several wfs:
- `runTheMatrix.py -l 12034.0,11634.0,7.23,159.0,12434.0,12834.0` for mcRun3 GTs
- `runTheMatrix.py -l 11634.911,11634.914` for DDD/DD4HEP changes
- `runTheMatrix.py -l 11725.0,11925.0` for PPS changes
- `runTheMatrix.py -l 136.897,136.899,138.3,139.001,139.002,139.003,139.004` for the offline run3 GT

#### Backport
Not a backport, but a similar PR will be opened soon for 12_1_X
