### PR TITLE
CSC L1T DQM 2D summary plots: Flip the two endcaps on the y-axis

### DIFF
--- a/DQM/L1TMonitor/src/L1TStage2Shower.cc
+++ b/DQM/L1TMonitor/src/L1TStage2Shower.cc
@@ -97,7 +97,7 @@ void L1TStage2Shower::analyze(const edm::Event& e, const edm::EventSetup& c) {
     int ring = detId.ring();
     int chamber = detId.chamber();
     int sr = histIndexCSC.at({station, ring});
-    if (endcap == -1)
+    if (endcap == 1)
       sr = 17 - sr;
     float evt_wgt = (station > 1 && ring == 1) ? 0.5 : 1.0;
 

--- a/DQM/L1TMonitor/src/L1TdeCSCTPG.cc
+++ b/DQM/L1TMonitor/src/L1TdeCSCTPG.cc
@@ -475,7 +475,7 @@ void L1TdeCSCTPG::analyze(const edm::Event& e, const edm::EventSetup& c) {
             int chamber = detid.chamber();
 
             int sr = histIndexCSC.at({stat, ring});
-            if (endc == 2)
+            if (endc == 1)
               sr = 17 - sr;
 
             // ALCT analysis


### PR DESCRIPTION
#### PR description:

I presented https://github.com/cms-sw/cmssw/pull/36226 at the CSC Weekly meeting https://indico.cern.ch/event/1101484/contributions/4634324/attachments/2356412/4022809/CSCDQM_SD_20211201.pdf. During the presentation I noticed that the endcaps are flipped on the y-axis. I realized it when I saw the 3-wide gap in ME-1/1 at chamber 9, 10 and 11. It should white for ME+1/1/9, ME+1/1/10, and ME+1/1/11.

<img width="500" alt="Screen Shot 2021-12-01 at 3 56 21 PM" src="https://user-images.githubusercontent.com/4134786/144323692-d1eea0ea-d456-4df8-9a29-ab88f2d3601b.png">

In my study I excluded ME+1/1/9, ME+1/1/10, and ME+1/1/11 because there we had downloaded experimental firmware for the HL-LHC (https://twiki.cern.ch/twiki/bin/viewauth/CMS/CSCOTMB2018) in late 2018.
 
Basically I added a digi filter that I introduced earlier in https://github.com/cms-sw/cmssw/pull/35717 after the CSC unpacker and before the CSC trigger emulator
```python
      from EventFilter.CSCRawToDigi.cscDigiFilterDef_cfi import cscDigiFilterDef

      # clone the original producer
      process.preCSCDigis = process.muonCSCDigis.clone()

      # now apply the filter
      process.muonCSCDigis = cscDigiFilterDef.clone(
            stripDigiTag = "preCSCDigis:MuonCSCStripDigi",
            wireDigiTag = "preCSCDigis:MuonCSCWireDigi",
            compDigiTag = "preCSCDigis:MuonCSCComparatorDigi",
            alctDigiTag = "preCSCDigis:MuonCSCALCTDigi",
            clctDigiTag = "preCSCDigis:MuonCSCCLCTDigi",
            lctDigiTag = "preCSCDigis:MuonCSCCorrelatedLCTDigi",
            showerDigiTag = "preCSCDigis:MuonCSCShowerDigi",
            gemPadClusterDigiTag = "preCSCDigis:MuonGEMPadDigiCluster",
            maskedChambers = options.maskedChambers,
            selectedChambers = options.selectedChambers
      )

      # these 3 chambers had Phase-2 firmware loaded partially during Run-2
      # https://twiki.cern.ch/twiki/bin/viewauth/CMS/CSCOTMB2018
      process.muonCSCDigis.maskedChambers = [
            "ME+1/1/9", "ME+1/1/10", "ME+1/1/11"]

      process.unpacksequence = cms.Sequence(process.preCSCDigis * process.muonCSCDigis)
```

#### PR validation:

Tested on 10k events of Run 322022 (of 2018D).
[CSC_dataVsEmul_CMS_Run_322022_postFlip.pdf](https://github.com/cms-sw/cmssw/files/7637517/CSC_dataVsEmul_CMS_Run_322022_postFlip.pdf)

Screenshot after flipping the two endcaps:
<img width="500" alt="Screen Shot 2021-12-01 at 4 29 31 PM" src="https://user-images.githubusercontent.com/4134786/144324634-9746a5e3-acd9-4113-954c-ee8cb891c5e2.png">


#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

@ptcox @zuoxunwu 