### PR TITLE
Static Analyzer: Update EventSetupRecord::get report to included modules not mapped to packages.

### DIFF
--- a/Utilities/StaticAnalyzers/scripts/callgraph.py
+++ b/Utilities/StaticAnalyzers/scripts/callgraph.py
@@ -28,7 +28,7 @@ assert(not baseclassre.match('edm::FlatRandomEGunProducer'))
 assert(baseclassre.match('edm::ProducerSourceBase'))
 assert(baseclassre.match('edm::one::OutputModuleBase'))
 farg = re.compile(r"\(.*?\)")
-tmpl = re.compile(r'<.*?>')
+tmpl = re.compile(r'<.*?>::')
 toplevelfuncs = set()
 
 getfuncre = re.compile(r"edm::eventsetup::EventSetupRecord::get<")
@@ -113,6 +113,7 @@ for tfunc in toplevelfuncs:
                     callstacks.add(cs)
 
 report = dict()
+csset = set()
 for key in sorted(set(module2package.keys())):
     for value in sorted(set(module2package[key])):
             regex_str = r'\b%s\b'%value
@@ -120,6 +121,12 @@ for key in sorted(set(module2package.keys())):
             for callstack in sorted(callstacks):
                 if vre.search(callstack):
                      report.setdefault(str(key), {}).setdefault(str(value), []).append(str(callstack))
+                else:
+                     shortstack=tmpl.sub(callstack,'<>::')
+                     if shortstack not in csset:
+                         csset.add(shortstack)
+                         report.setdefault('no-package', {}).setdefault('no-package', []).append(str(shortstack))
+
 
 r = open('eventsetuprecord-get.yaml', 'w')
 dump(report, r, width=float("inf"))

--- a/Utilities/StaticAnalyzers/scripts/callgraph.py
+++ b/Utilities/StaticAnalyzers/scripts/callgraph.py
@@ -28,7 +28,7 @@ assert(not baseclassre.match('edm::FlatRandomEGunProducer'))
 assert(baseclassre.match('edm::ProducerSourceBase'))
 assert(baseclassre.match('edm::one::OutputModuleBase'))
 farg = re.compile(r"\(.*?\)")
-tmpl = re.compile(r'<.*?>::')
+tmpl = re.compile(r'<(.*)>')
 toplevelfuncs = set()
 
 getfuncre = re.compile(r"edm::eventsetup::EventSetupRecord::get<")
@@ -124,7 +124,9 @@ for callstack in sorted(list(callstacks)):
                 csset.discard(callstack)
 
 report['no-package']=dict()
-report['no-package']['no-package']=sorted(list(csset))
+for cs in sorted(list(csset)):
+    key=tmpl.split(topfuncre.split(cs)[0])[0]
+    report['no-package'].setdefault(key,[]).append(str(cs))
 
 r = open('eventsetuprecord-get.yaml', 'w')
 dump(report, r, width=float("inf"))

--- a/Utilities/StaticAnalyzers/scripts/callgraph.py
+++ b/Utilities/StaticAnalyzers/scripts/callgraph.py
@@ -113,20 +113,18 @@ for tfunc in toplevelfuncs:
                     callstacks.add(cs)
 
 report = dict()
-csset = set()
-for key in sorted(set(module2package.keys())):
-    for value in sorted(set(module2package[key])):
+csset = set(callstacks)
+for callstack in sorted(list(callstacks)):
+    for key in module2package.keys():
+        for value in module2package.get(key):
             regex_str = r'\b%s\b'%value
             vre=re.compile(regex_str)
-            for callstack in sorted(callstacks):
-                if vre.search(callstack):
-                     report.setdefault(str(key), {}).setdefault(str(value), []).append(str(callstack))
-                else:
-                     shortstack=tmpl.sub(callstack,'<>::')
-                     if shortstack not in csset:
-                         csset.add(shortstack)
-                         report.setdefault('no-package', {}).setdefault('no-package', []).append(str(shortstack))
+            if vre.search(callstack):
+                report.setdefault(str(key), {}).setdefault(str(value), []).append(str(callstack))
+                csset.discard(callstack)
 
+report['no-package']=dict()
+report['no-package']['no-package']=sorted(list(csset))
 
 r = open('eventsetuprecord-get.yaml', 'w')
 dump(report, r, width=float("inf"))


### PR DESCRIPTION
The class name of the top level function, eg. produce, with the template bracket and arguments stripped is used as the module name. 

```
...
no-package:
  CaloCleaner:
  - 'CaloCleaner::produce(edm::Event &, const edm::EventSetup &); '
  - 'CaloCleaner<CastorRecHit>::produce(edm::Event &, const edm::EventSetup &); '
  - 'CaloCleaner<EcalRecHit>::produce(edm::Event &, const edm::EventSetup &); '
  - 'CaloCleaner<HBHERecHit>::produce(edm::Event &, const edm::EventSetup &); '
  - 'CaloCleaner<HFRecHit>::produce(edm::Event &, const edm::EventSetup &); '
  - 'CaloCleaner<HORecHit>::produce(edm::Event &, const edm::EventSetup &); '
  - 'CaloCleaner<ZDCRecHit>::produce(edm::Event &, const edm::EventSetup &); '
...
```

Verified with output from an older IB that the modules not mapped to packages appear under the package "no-package". 
