### PR TITLE
`SiPixelFakeLorentzAngleESSource`: use built-in `appendToDataLabel` mechanism

### DIFF
--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeLorentzAngleESSource.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeLorentzAngleESSource.cc
@@ -34,7 +34,7 @@
 SiPixelFakeLorentzAngleESSource::SiPixelFakeLorentzAngleESSource(const edm::ParameterSet& conf_)
     : fp_(conf_.getParameter<edm::FileInPath>("file")),
       t_topo_fp_(conf_.getParameter<edm::FileInPath>("topologyInput")),
-      myLabel_(conf_.getParameter<std::string>("label")),
+      myLabel_(conf_.getParameter<std::string>("appendToDataLabel")),
       BPixParameters_(conf_.getParameter<Parameters>("BPixParameters")),
       FPixParameters_(conf_.getParameter<Parameters>("FPixParameters")),
       ModuleParameters_(conf_.getParameter<Parameters>("ModuleParameters")),
@@ -42,7 +42,7 @@ SiPixelFakeLorentzAngleESSource::SiPixelFakeLorentzAngleESSource(const edm::Para
       fPixLorentzAnglePerTesla_((float)conf_.getUntrackedParameter<double>("fPixLorentzAnglePerTesla", -9999.)) {
   edm::LogInfo("SiPixelFakeLorentzAngleESSource::SiPixelFakeLorentzAngleESSource");
   // the following line is needed to tell the framework what data is being produced
-  setWhatProduced(this, myLabel_);
+  setWhatProduced(this);
   findingRecord<SiPixelLorentzAngleRcd>();
 }
 
@@ -246,7 +246,7 @@ void SiPixelFakeLorentzAngleESSource::fillDescriptions(edm::ConfigurationDescrip
                             edm::FileInPath("Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml"))
       ->setComment("Tracker Topology");
 
-  desc.add<std::string>("label", "")->setComment("label to which write the data");
+  desc.add<std::string>("appendToDataLabel", "")->setComment("label to which write the data");
   desc.addUntracked<double>("bPixLorentzAnglePerTesla", -9999.)->setComment("LA value for all BPix");
   desc.addUntracked<double>("fPixLorentzAnglePerTesla", -9999.)->setComment("LA value for all FPix");
 

--- a/CalibTracker/SiPixelESProducers/test/testSiPixelFakeLorentzAngleESSource_cfg.py
+++ b/CalibTracker/SiPixelESProducers/test/testSiPixelFakeLorentzAngleESSource_cfg.py
@@ -70,7 +70,7 @@ process.SiPixelFakeLorentzAngleESSource = siPixelFakeLorentzAngleESSource.clone(
 
 if(options.isPhase2):
     print(" ========> Testing Phase-2")
-    process.SiPixelFakeLorentzAngleESSource.label = cms.string("forPhase2")
+    process.SiPixelFakeLorentzAngleESSource.appendToDataLabel = cms.string("forPhase2")
     process.SiPixelFakeLorentzAngleESSource.bPixLorentzAnglePerTesla = cms.untracked.double(0.106)
     process.SiPixelFakeLorentzAngleESSource.fPixLorentzAnglePerTesla = cms.untracked.double(0.106)
     process.SiPixelFakeLorentzAngleESSource.file = 'SLHCUpgradeSimulations/Geometry/data/PhaseII/Tilted/PixelSkimmedGeometryT14.txt'


### PR DESCRIPTION
#### PR description:

This is a technical follow-up to https://github.com/cms-sw/cmssw/pull/36283#issuecomment-983808623.
Using built-in framework mechanism to attach labels to ES products (via `appendToDataLabel`).

#### PR validation:

Unit test run.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
