### PR TITLE
Phase2 tracker cabling map: add IT cabling map

### DIFF
--- a/CondTools/SiPhase2Tracker/plugins/DTCCablingMapProducer.cc
+++ b/CondTools/SiPhase2Tracker/plugins/DTCCablingMapProducer.cc
@@ -185,7 +185,7 @@ void DTCCablingMapProducer::LoadModulesToDTCCablingMapFromCSV(
 
         if (csvColumn.size() == csvFormat_ncolumns_) {
           // Skip the legend lines
-          if (0 == csvColumn[0].compare(std::string("Module DetId/U"))) {
+          if (0 == csvColumn[0].compare(std::string("Module_DetId/U"))) {
             if (verbosity_ >= 1) {
               edm::LogInfo("CSVParser") << "-- skipping legend line" << endl;
             }

--- a/CondTools/SiPhase2Tracker/test/DTCCablingMapProducer_dump.py
+++ b/CondTools/SiPhase2Tracker/test/DTCCablingMapProducer_dump.py
@@ -17,7 +17,7 @@ process.MessageLogger = cms.Service("MessageLogger",
 process.load("CondCore.CondDB.CondDB_cfi")
 
 # input database (in this case the local sqlite files)
-process.CondDB.connect = 'sqlite_file:OuterTrackerDTCCablingMap.db'
+process.CondDB.connect = 'sqlite_file:OTandITDTCCablingMap.db'
 
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
     process.CondDB,

--- a/CondTools/SiPhase2Tracker/test/DTCCablingMapProducer_retrieve.py
+++ b/CondTools/SiPhase2Tracker/test/DTCCablingMapProducer_retrieve.py
@@ -6,7 +6,7 @@ process.load("FWCore.MessageLogger.MessageLogger_cfi")
 
 process.load("CondCore.CondDB.CondDB_cfi")
 # input database (in this case the local sqlite file)
-process.CondDB.connect = 'sqlite_file:OuterTrackerDTCCablingMap.db'
+process.CondDB.connect = 'sqlite_file:OTandITDTCCablingMap.db'
 
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
     process.CondDB,

--- a/CondTools/SiPhase2Tracker/test/DTCCablingMapProducer_write.py
+++ b/CondTools/SiPhase2Tracker/test/DTCCablingMapProducer_write.py
@@ -8,7 +8,7 @@ process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.load("CondCore.CondDB.CondDB_cfi")
 
 # output database (in this case local sqlite file)
-process.CondDB.connect = 'sqlite_file:OuterTrackerDTCCablingMap.db'
+process.CondDB.connect = 'sqlite_file:OTandITDTCCablingMap.db'
 
 # A data source must always be defined. We don't need it, so here's a dummy one.
 process.source = cms.Source("EmptyIOVSource",
@@ -33,14 +33,14 @@ process.otdtccablingmap_producer = cms.EDAnalyzer("DTCCablingMapProducer",
     #dummy_fill_mode = cms.string("DUMMY_FILL_DISABLED"),
     #dummy_fill_mode = cms.string("DUMMY_FILL_ELINK_ID"),
     modulesToDTCCablingCSVFileNames = cms.vstring(
-        "CondTools/SiPhase2Tracker/data/TrackerModuleToDTCCablingMap__OT616_200_IT613__T14__OTOnly.csv"
+     "CondTools/SiPhase2Tracker/data/CMSSWCablingMap__OT800_IT700.csv"
     ),
-    dummy_fill_mode = cms.string("DUMMY_FILL_ELINK_ID_AND_GBT_ID"),
-    csvFormat_ncolumns   = cms.uint32( 2),
+    dummy_fill_mode = cms.string("DUMMY_FILL_ELINK_ID"),
+    csvFormat_ncolumns   = cms.uint32( 3),
     csvFormat_idetid     = cms.uint32( 0),
-    csvFormat_idtcid     = cms.uint32( 1),
+    csvFormat_idtcid     = cms.uint32( 2),
     csvFormat_igbtlinkid = cms.uint32( 1),
-    csvFormat_ielinkid   = cms.uint32( 1),
+    csvFormat_ielinkid   = cms.uint32( 5),
     verbosity = cms.int32(0),
     #loggingOn= cms.untracked.bool(True),
     #SinceAppendMode=cms.bool(True),


### PR DESCRIPTION

#### PR description:

This adds the IT cabling map for the Phase 2 tracker to the cabling map producer. Requires the updated input data here: https://github.com/cms-data/CondTools-SiPhase2Tracker/pull/3 

With this change we also read the lpGBT IDs from the external file for the OT, rather than automatically assigning them as was done before.

#### PR validation:

Checked that the new map does not change the detID<>DTC links for OT compared with the version currently in the GTs (TrackerDetToDTCELinkCablingMap__OT616_200_IT613__T14__OTOnly), and that the IT information is also picked up correctly.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport