### PR TITLE
Update miscalibration tools in `CondTools/SiStrip`

### DIFF
--- a/CondTools/SiStrip/plugins/SiStripChannelGainFromDBMiscalibrator.cc
+++ b/CondTools/SiStrip/plugins/SiStripChannelGainFromDBMiscalibrator.cc
@@ -55,12 +55,12 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  void beginJob() override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
-  std::unique_ptr<SiStripApvGain> getNewObject(const std::map<std::pair<uint32_t, int>, float>& theMap);
+  SiStripApvGain getNewObject(const std::map<std::pair<uint32_t, int>, float>& theMap);
   void endJob() override;
 
   // ----------member data ---------------------------
+  const uint32_t m_printdebug;
   const std::string m_Record;
   const uint32_t m_gainType;
   const bool m_saveMaps;
@@ -79,7 +79,8 @@ private:
 // constructors and destructor
 //
 SiStripChannelGainFromDBMiscalibrator::SiStripChannelGainFromDBMiscalibrator(const edm::ParameterSet& iConfig)
-    : m_Record{iConfig.getUntrackedParameter<std::string>("record", "SiStripApvGainRcd")},
+    : m_printdebug{iConfig.getUntrackedParameter<uint32_t>("printDebug", 1)},
+      m_Record{iConfig.getUntrackedParameter<std::string>("record", "SiStripApvGainRcd")},
       m_gainType{iConfig.getUntrackedParameter<uint32_t>("gainType", 1)},
       m_saveMaps{iConfig.getUntrackedParameter<bool>("saveMaps", true)},
       m_parameters{iConfig.getParameter<std::vector<edm::ParameterSet> >("params")},
@@ -110,7 +111,7 @@ SiStripChannelGainFromDBMiscalibrator::SiStripChannelGainFromDBMiscalibrator(con
   old_payload_map->setPalette(1);
 }
 
-SiStripChannelGainFromDBMiscalibrator::~SiStripChannelGainFromDBMiscalibrator() {}
+SiStripChannelGainFromDBMiscalibrator::~SiStripChannelGainFromDBMiscalibrator() = default;
 
 //
 // member functions
@@ -203,13 +204,14 @@ void SiStripChannelGainFromDBMiscalibrator::analyze(const edm::Event& iEvent, co
     }  // loop over APVs
   }    // loop over DetIds
 
-  std::unique_ptr<SiStripApvGain> theAPVGains = this->getNewObject(theMap);
+  SiStripApvGain theAPVGains = this->getNewObject(theMap);
 
   // make the payload ratio map
   uint32_t cachedId(0);
   SiStripMiscalibrate::Entry gain_ratio;
   SiStripMiscalibrate::Entry o_gain;
   SiStripMiscalibrate::Entry n_gain;
+  unsigned int countDetIds(0);  // count DetIds to print
   for (const auto& element : theMap) {
     uint32_t DetId = element.first.first;
     int nAPV = element.first.second;
@@ -227,6 +229,15 @@ void SiStripChannelGainFromDBMiscalibrator::analyze(const edm::Event& iEvent, co
       gain_ratio.reset();
       o_gain.reset();
       n_gain.reset();
+      countDetIds++;
+    }
+
+    // printout for debug
+    if (countDetIds < m_printdebug) {
+      edm::LogPrint("SiStripChannelGainFromDBMiscalibrator")
+          << "SiStripChannelGainFromDBMiscalibrator"
+          << "::" << __FUNCTION__ << " detid " << DetId << " \t"
+          << " APV " << nAPV << " \t new gain: " << new_gain << " \t old gain: " << old_gain << " \t" << std::endl;
     }
 
     cachedId = DetId;
@@ -238,14 +249,16 @@ void SiStripChannelGainFromDBMiscalibrator::analyze(const edm::Event& iEvent, co
   // write out the APVGains record
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
 
-  if (poolDbService.isAvailable())
-    poolDbService->writeOneIOV(*theAPVGains, poolDbService->currentTime(), m_Record);
-  else
+  if (poolDbService.isAvailable()) {
+    if (poolDbService->isNewTagRequest(m_Record)) {
+      poolDbService->createOneIOV(theAPVGains, poolDbService->currentTime(), m_Record);
+    } else {
+      poolDbService->appendOneIOV(theAPVGains, poolDbService->currentTime(), m_Record);
+    }
+  } else {
     throw std::runtime_error("PoolDBService required.");
+  }
 }
-
-// ------------ method called once each job just before starting event loop  ------------
-void SiStripChannelGainFromDBMiscalibrator::beginJob() {}
 
 // ------------ method called once each job just after ending the event loop  ------------
 void SiStripChannelGainFromDBMiscalibrator::endJob() {
@@ -274,9 +287,9 @@ void SiStripChannelGainFromDBMiscalibrator::endJob() {
 }
 
 //********************************************************************************//
-std::unique_ptr<SiStripApvGain> SiStripChannelGainFromDBMiscalibrator::getNewObject(
+SiStripApvGain SiStripChannelGainFromDBMiscalibrator::getNewObject(
     const std::map<std::pair<uint32_t, int>, float>& theMap) {
-  std::unique_ptr<SiStripApvGain> obj = std::make_unique<SiStripApvGain>();
+  SiStripApvGain obj{};
 
   std::vector<float> theSiStripVector;
   uint32_t PreviousDetId = 0;
@@ -285,7 +298,7 @@ std::unique_ptr<SiStripApvGain> SiStripChannelGainFromDBMiscalibrator::getNewObj
     if (DetId != PreviousDetId) {
       if (!theSiStripVector.empty()) {
         SiStripApvGain::Range range(theSiStripVector.begin(), theSiStripVector.end());
-        if (!obj->put(PreviousDetId, range))
+        if (!obj.put(PreviousDetId, range))
           printf("Bug to put detId = %i\n", PreviousDetId);
       }
       theSiStripVector.clear();
@@ -299,7 +312,7 @@ std::unique_ptr<SiStripApvGain> SiStripChannelGainFromDBMiscalibrator::getNewObj
 
   if (!theSiStripVector.empty()) {
     SiStripApvGain::Range range(theSiStripVector.begin(), theSiStripVector.end());
-    if (!obj->put(PreviousDetId, range))
+    if (!obj.put(PreviousDetId, range))
       printf("Bug to put detId = %i\n", PreviousDetId);
   }
 
@@ -326,6 +339,7 @@ void SiStripChannelGainFromDBMiscalibrator::fillDescriptions(edm::ConfigurationD
   descScaler.add<double>("smearFactor", 1.0);
   desc.addVPSet("params", descScaler, std::vector<edm::ParameterSet>(1));
 
+  desc.addUntracked<unsigned int>("printDebug", 1);
   desc.addUntracked<std::string>("record", "SiStripApvGainRcd");
   desc.addUntracked<unsigned int>("gainType", 1);
   desc.addUntracked<bool>("saveMaps", true);

--- a/CondTools/SiStrip/plugins/SiStripNoisesFromDBMiscalibrator.cc
+++ b/CondTools/SiStrip/plugins/SiStripNoisesFromDBMiscalibrator.cc
@@ -51,19 +51,19 @@
 class SiStripNoisesFromDBMiscalibrator : public edm::one::EDAnalyzer<> {
 public:
   explicit SiStripNoisesFromDBMiscalibrator(const edm::ParameterSet&);
-  ~SiStripNoisesFromDBMiscalibrator() override;
+  ~SiStripNoisesFromDBMiscalibrator() override = default;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  void beginJob() override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
-  std::unique_ptr<SiStripNoises> getNewObject(const std::map<std::pair<uint32_t, int>, float>& theMap);
-  std::unique_ptr<SiStripNoises> getNewObject_withDefaults(const std::map<std::pair<uint32_t, int>, float>& theMap,
-                                                           const float theDefault);
+  SiStripNoises getNewObject(const std::map<std::pair<uint32_t, int>, float>& theMap);
+  SiStripNoises getNewObject_withDefaults(const std::map<std::pair<uint32_t, int>, float>& theMap,
+                                          const float theDefault);
   void endJob() override;
 
   // ----------member data ---------------------------
+  const uint32_t m_printdebug;
   const bool m_fillDefaults;
   const bool m_saveMaps;
   const std::vector<edm::ParameterSet> m_parameters;
@@ -83,7 +83,8 @@ private:
 // constructors and destructor
 //
 SiStripNoisesFromDBMiscalibrator::SiStripNoisesFromDBMiscalibrator(const edm::ParameterSet& iConfig)
-    : m_fillDefaults{iConfig.getUntrackedParameter<bool>("fillDefaults", false)},
+    : m_printdebug{iConfig.getUntrackedParameter<uint32_t>("printDebug", 1)},
+      m_fillDefaults{iConfig.getUntrackedParameter<bool>("fillDefaults", false)},
       m_saveMaps{iConfig.getUntrackedParameter<bool>("saveMaps", true)},
       m_parameters{iConfig.getParameter<std::vector<edm::ParameterSet> >("params")},
       fp_{iConfig.getUntrackedParameter<edm::FileInPath>("file",
@@ -118,8 +119,6 @@ SiStripNoisesFromDBMiscalibrator::SiStripNoisesFromDBMiscalibrator(const edm::Pa
     missing_map->setPalette(1);
   }
 }
-
-SiStripNoisesFromDBMiscalibrator::~SiStripNoisesFromDBMiscalibrator() {}
 
 //
 // member functions
@@ -213,7 +212,7 @@ void SiStripNoisesFromDBMiscalibrator::analyze(const edm::Event& iEvent, const e
     }  // loop over APVs
   }    // loop over DetIds
 
-  std::unique_ptr<SiStripNoises> theSiStripNoises;
+  SiStripNoises theSiStripNoises{};
   if (!m_fillDefaults) {
     theSiStripNoises = this->getNewObject(theMap);
   } else {
@@ -225,6 +224,7 @@ void SiStripNoisesFromDBMiscalibrator::analyze(const edm::Event& iEvent, const e
   SiStripMiscalibrate::Entry noise_ratio;
   SiStripMiscalibrate::Entry o_noise;
   SiStripMiscalibrate::Entry n_noise;
+  unsigned int countDetIds(0);  // count DetIds to print
   for (const auto& element : theMap) {
     uint32_t DetId = element.first.first;
     int nstrip = element.first.second;
@@ -242,6 +242,16 @@ void SiStripNoisesFromDBMiscalibrator::analyze(const edm::Event& iEvent, const e
       noise_ratio.reset();
       o_noise.reset();
       n_noise.reset();
+      countDetIds++;
+    }
+
+    // printout for debug
+    if (countDetIds < m_printdebug) {
+      edm::LogPrint("SiStripNoisesFromDBMiscalibrator")
+          << "SiStripNoisesFromDBMiscalibrator"
+          << "::" << __FUNCTION__ << " detid " << DetId << " \t"
+          << " strip " << nstrip << " \t new noise: " << std::setw(5) << std::setprecision(2) << new_noise
+          << " \t old noise: " << old_noise << " \t" << std::endl;
     }
 
     cachedId = DetId;
@@ -253,14 +263,16 @@ void SiStripNoisesFromDBMiscalibrator::analyze(const edm::Event& iEvent, const e
   // write out the SiStripNoises record
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
 
-  if (poolDbService.isAvailable())
-    poolDbService->writeOneIOV(*theSiStripNoises, poolDbService->currentTime(), "SiStripNoisesRcd");
-  else
+  if (poolDbService.isAvailable()) {
+    if (poolDbService->isNewTagRequest("SiStripNoisesRcd")) {
+      poolDbService->createOneIOV(theSiStripNoises, poolDbService->currentTime(), "SiStripNoisesRcd");
+    } else {
+      poolDbService->appendOneIOV(theSiStripNoises, poolDbService->currentTime(), "SiStripNoisesRcd");
+    }
+  } else {
     throw std::runtime_error("PoolDBService required.");
+  }
 }
-
-// ------------ method called once each job just before starting event loop  ------------
-void SiStripNoisesFromDBMiscalibrator::beginJob() {}
 
 // ------------ method called once each job just after ending the event loop  ------------
 void SiStripNoisesFromDBMiscalibrator::endJob() {
@@ -292,9 +304,9 @@ void SiStripNoisesFromDBMiscalibrator::endJob() {
 }
 
 //********************************************************************************//
-std::unique_ptr<SiStripNoises> SiStripNoisesFromDBMiscalibrator::getNewObject_withDefaults(
+SiStripNoises SiStripNoisesFromDBMiscalibrator::getNewObject_withDefaults(
     const std::map<std::pair<uint32_t, int>, float>& theMap, const float theDefault) {
-  std::unique_ptr<SiStripNoises> obj = std::make_unique<SiStripNoises>();
+  SiStripNoises obj{};
 
   std::vector<uint32_t> missingDetIds;
 
@@ -315,18 +327,18 @@ std::unique_ptr<SiStripNoises> SiStripNoisesFromDBMiscalibrator::getNewObject_wi
                                                      << " not found" << std::endl;
 
         isMissing = true;
-        obj->setData(theDefault, theSiStripVector);
+        obj.setData(theDefault, theSiStripVector);
 
       } else {
         float noise = theMap.at(index);
-        obj->setData(noise, theSiStripVector);
+        obj.setData(noise, theSiStripVector);
       }
     }
 
     if (isMissing)
       missingDetIds.push_back(it.first);
 
-    if (!obj->put(it.first, theSiStripVector)) {
+    if (!obj.put(it.first, theSiStripVector)) {
       edm::LogError("SiStripNoisesFromDBMiscalibrator")
           << "[SiStripNoisesFromDBMiscalibrator::analyze] detid already exists" << std::endl;
     }
@@ -353,9 +365,8 @@ std::unique_ptr<SiStripNoises> SiStripNoisesFromDBMiscalibrator::getNewObject_wi
 }
 
 //********************************************************************************//
-std::unique_ptr<SiStripNoises> SiStripNoisesFromDBMiscalibrator::getNewObject(
-    const std::map<std::pair<uint32_t, int>, float>& theMap) {
-  std::unique_ptr<SiStripNoises> obj = std::make_unique<SiStripNoises>();
+SiStripNoises SiStripNoisesFromDBMiscalibrator::getNewObject(const std::map<std::pair<uint32_t, int>, float>& theMap) {
+  SiStripNoises obj{};
 
   uint32_t PreviousDetId = 0;
   SiStripNoises::InputVector theSiStripVector;
@@ -365,7 +376,7 @@ std::unique_ptr<SiStripNoises> SiStripNoisesFromDBMiscalibrator::getNewObject(
 
     if (DetId != PreviousDetId) {
       if (!theSiStripVector.empty()) {
-        if (!obj->put(PreviousDetId, theSiStripVector)) {
+        if (!obj.put(PreviousDetId, theSiStripVector)) {
           edm::LogError("SiStripNoisesFromDBMiscalibrator")
               << "[SiStripNoisesFromDBMiscalibrator::analyze] detid already exists" << std::endl;
         }
@@ -374,7 +385,7 @@ std::unique_ptr<SiStripNoises> SiStripNoisesFromDBMiscalibrator::getNewObject(
       theSiStripVector.clear();
       PreviousDetId = DetId;
     }
-    obj->setData(noise, theSiStripVector);
+    obj.setData(noise, theSiStripVector);
   }
   return obj;
 }
@@ -399,6 +410,7 @@ void SiStripNoisesFromDBMiscalibrator::fillDescriptions(edm::ConfigurationDescri
   descScaler.add<double>("smearFactor", 1.0);
   desc.addVPSet("params", descScaler, std::vector<edm::ParameterSet>(1));
 
+  desc.addUntracked<unsigned int>("printDebug", 1);
   desc.addUntracked<bool>("fillDefaults", false);
   desc.addUntracked<bool>("saveMaps", true);
 

--- a/CondTools/SiStrip/test/SiStripChannelGainFromDBMiscalibrator_cfg.py
+++ b/CondTools/SiStrip/test/SiStripChannelGainFromDBMiscalibrator_cfg.py
@@ -157,7 +157,7 @@ process.load("CondCore.CondDB.CondDB_cfi")
 ##
 ## Output database (in this case local sqlite file)
 ##
-process.CondDB.connect = 'sqlite_file:modifiedGains_'+ process.GlobalTag.globaltag._value+'_IOV_'+str(options.runNumber)+".db"
+process.CondDB.connect = 'sqlite_file:modifiedSiStripGains_'+ process.GlobalTag.globaltag._value+'_IOV_'+str(options.runNumber)+".db"
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
                                           process.CondDB,
                                           timetype = cms.untracked.string('runnumber'),

--- a/CondTools/SiStrip/test/SiStripNoiseFromDBMiscalibrator_cfg.py
+++ b/CondTools/SiStrip/test/SiStripNoiseFromDBMiscalibrator_cfg.py
@@ -33,7 +33,7 @@ process.MessageLogger.SiStripNoisesFromDBMiscalibrator=dict()
 process.MessageLogger.cout = cms.untracked.PSet(
     enable    = cms.untracked.bool(True),
     enableStatistics = cms.untracked.bool(True),
-    threshold = cms.untracked.string("INFO"),
+    threshold = cms.untracked.string("WARNING"),
     default   = cms.untracked.PSet(limit = cms.untracked.int32(0)),                       
     FwkReport = cms.untracked.PSet(limit = cms.untracked.int32(-1),
                                    reportEvery = cms.untracked.int32(1000)
@@ -224,7 +224,7 @@ process.load("CondCore.CondDB.CondDB_cfi")
 ##
 ## Output database (in this case local sqlite file)
 ##
-process.CondDB.connect = 'sqlite_file:modifiedNoise_'+ process.GlobalTag.globaltag._value+'_IOV_'+str(options.runNumber)+".db"
+process.CondDB.connect = 'sqlite_file:modifiedSiStripNoise_'+ process.GlobalTag.globaltag._value+'_IOV_'+str(options.runNumber)+".db"
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
                                           process.CondDB,
                                           timetype = cms.untracked.string('runnumber'),

--- a/CondTools/SiStrip/test/testBuildersReaders.sh
+++ b/CondTools/SiStrip/test/testBuildersReaders.sh
@@ -4,7 +4,8 @@ function die { echo $1: status $2 ; exit $2; }
 
 if test -f "SiStripConditionsDBFile.db"; then
     echo "cleaning the local test area"
-    rm -fr SiStripConditionsDBFile.db
+    rm -fr SiStripConditionsDBFile.db  # builders test
+    rm -fr modifiedSiStrip*.db         # miscalibrator tests
 fi
 
 echo " testing CondTools/SiStrip"


### PR DESCRIPTION
#### PR description:

Investigation in response to https://github.com/cms-sw/cmssw/issues/36319.
Updates:
   * `SiStripNoisesFromDBMiscalibrator`: put `SiStripNoises` object on the stack, add `printDebug` statements (daab356b388632e98d9eb63e371b5ba33a381b35)
   * `SiStripChannelGainFromDBMiscalibrator`: put `SiStripApvGain` object on the stack, add `printDebug` statements (f4a93a70db9f3b257ab3d78165971f8d8a23d598)
   *  change names of output sqlite files (00f3faf1c6fb8b8b75af07791c879834c5c81614)
   * remove upfront files to be written by miscalibrator tools (aff7f8569b5186035fc50c2fcb2ebf3b14f31506)
   
#### PR validation:

Unit test run locally with `scram b runtests_testCondToolsSiStripBuildersReaders`.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
