### PR TITLE
Adding JPTjets to MiniAOD

### DIFF
--- a/DataFormats/JetReco/interface/JPTJet.h
+++ b/DataFormats/JetReco/interface/JPTJet.h
@@ -28,8 +28,8 @@ namespace reco {
   class JPTJet : public Jet {
   public:
     struct Specific {
-      Specific() :             
-            mChargedHadronEnergy(0),
+      Specific()
+          : mChargedHadronEnergy(0),
             mChargedEmEnergy(0),
             mResponseOfChargedWithEff(0),
             mResponseOfChargedWithoutEff(0),
@@ -41,7 +41,7 @@ namespace reco {
             Eta2momtr(0),
             Phi2momtr(0),
             Pout(0),
-            Zch(0), 
+            Zch(0),
             JPTSeed(0) {}
       edm::RefToBase<reco::Jet> theCaloJetRef;
       reco::TrackRefVector pionsInVertexInCalo;

--- a/DataFormats/JetReco/interface/JPTJet.h
+++ b/DataFormats/JetReco/interface/JPTJet.h
@@ -28,25 +28,8 @@ namespace reco {
   class JPTJet : public Jet {
   public:
     struct Specific {
-      Specific()
-          : mZSPCor(0),
-            mChargedHadronEnergy(0),
-            mNeutralHadronEnergy(0),
-            mChargedEmEnergy(0),
-            mNeutralEmEnergy(0),
-            mResponseOfChargedWithEff(0),
-            mResponseOfChargedWithoutEff(0),
-            mSumPtOfChargedWithEff(0),
-            mSumPtOfChargedWithoutEff(0),
-            mSumEnergyOfChargedWithEff(0),
-            mSumEnergyOfChargedWithoutEff(0),
-            R2momtr(0),
-            Eta2momtr(0),
-            Phi2momtr(0),
-            Pout(0),
-            Zch(0) {}
-      float mZSPCor;
-      edm::RefToBase<reco::Jet> theCaloJetRef;
+      Specific() : Zch(0), JPTSeed(0) {}
+      edm::Ptr<reco::CaloJet> theCaloJetRef;
       reco::TrackRefVector pionsInVertexInCalo;
       reco::TrackRefVector pionsInVertexOutCalo;
       reco::TrackRefVector pionsOutVertexInCalo;
@@ -56,21 +39,8 @@ namespace reco {
       reco::TrackRefVector elecsInVertexInCalo;
       reco::TrackRefVector elecsInVertexOutCalo;
       reco::TrackRefVector elecsOutVertexInCalo;
-      float mChargedHadronEnergy;
-      float mNeutralHadronEnergy;
-      float mChargedEmEnergy;
-      float mNeutralEmEnergy;
-      float mResponseOfChargedWithEff;
-      float mResponseOfChargedWithoutEff;
-      float mSumPtOfChargedWithEff;
-      float mSumPtOfChargedWithoutEff;
-      float mSumEnergyOfChargedWithEff;
-      float mSumEnergyOfChargedWithoutEff;
-      float R2momtr;
-      float Eta2momtr;
-      float Phi2momtr;
-      float Pout;
       float Zch;
+      int JPTSeed;
     };
 
     /** Default constructor*/
@@ -87,22 +57,6 @@ namespace reco {
 
     ~JPTJet() override{};
 
-    /// chargedHadronEnergy
-    float chargedHadronEnergy() const { return mspecific.mChargedHadronEnergy; }
-    ///  chargedHadronEnergyFraction
-    float chargedHadronEnergyFraction() const { return chargedHadronEnergy() / energy(); }
-    /// neutralHadronEnergy
-    float neutralHadronEnergy() const { return mspecific.mNeutralHadronEnergy; }
-    /// neutralHadronEnergyFraction
-    float neutralHadronEnergyFraction() const { return neutralHadronEnergy() / energy(); }
-    /// chargedEmEnergy
-    float chargedEmEnergy() const { return mspecific.mChargedEmEnergy; }
-    /// chargedEmEnergyFraction
-    float chargedEmEnergyFraction() const { return chargedEmEnergy() / energy(); }
-    /// neutralEmEnergy
-    float neutralEmEnergy() const { return mspecific.mNeutralEmEnergy; }
-    /// neutralEmEnergyFraction
-    float neutralEmEnergyFraction() const { return neutralEmEnergy() / energy(); }
     /// chargedMultiplicity
     int chargedMultiplicity() const {
       return mspecific.muonsInVertexInCalo.size() + mspecific.muonsInVertexOutCalo.size() +
@@ -128,9 +82,7 @@ namespace reco {
     const reco::TrackRefVector& getElecsInVertexOutCalo() const { return mspecific.elecsInVertexOutCalo; }
     const reco::TrackRefVector& getElecsOutVertexInCalo() const { return mspecific.elecsOutVertexInCalo; }
 
-    const float& getZSPCor() const { return mspecific.mZSPCor; }
-
-    const edm::RefToBase<reco::Jet>& getCaloJetRef() const { return mspecific.theCaloJetRef; }
+    const edm::Ptr<reco::CaloJet>& getCaloJetRef() const { return mspecific.theCaloJetRef; }
     /// block accessors
 
     const Specific& getSpecific() const { return mspecific; }
@@ -150,7 +102,6 @@ namespace reco {
     //Variables specific to to the JPTJet class
 
     Specific mspecific;
-    //reco::CaloJetRef theCaloJetRef;
   };
 
   // streamer

--- a/DataFormats/JetReco/interface/JPTJet.h
+++ b/DataFormats/JetReco/interface/JPTJet.h
@@ -28,8 +28,22 @@ namespace reco {
   class JPTJet : public Jet {
   public:
     struct Specific {
-      Specific() : Zch(0), JPTSeed(0) {}
-      edm::Ptr<reco::CaloJet> theCaloJetRef;
+      Specific() :             
+            mChargedHadronEnergy(0),
+            mChargedEmEnergy(0),
+            mResponseOfChargedWithEff(0),
+            mResponseOfChargedWithoutEff(0),
+            mSumPtOfChargedWithEff(0),
+            mSumPtOfChargedWithoutEff(0),
+            mSumEnergyOfChargedWithEff(0),
+            mSumEnergyOfChargedWithoutEff(0),
+            R2momtr(0),
+            Eta2momtr(0),
+            Phi2momtr(0),
+            Pout(0),
+            Zch(0), 
+            JPTSeed(0) {}
+      edm::RefToBase<reco::Jet> theCaloJetRef;
       reco::TrackRefVector pionsInVertexInCalo;
       reco::TrackRefVector pionsInVertexOutCalo;
       reco::TrackRefVector pionsOutVertexInCalo;
@@ -39,6 +53,18 @@ namespace reco {
       reco::TrackRefVector elecsInVertexInCalo;
       reco::TrackRefVector elecsInVertexOutCalo;
       reco::TrackRefVector elecsOutVertexInCalo;
+      float mChargedHadronEnergy;
+      float mChargedEmEnergy;
+      float mResponseOfChargedWithEff;
+      float mResponseOfChargedWithoutEff;
+      float mSumPtOfChargedWithEff;
+      float mSumPtOfChargedWithoutEff;
+      float mSumEnergyOfChargedWithEff;
+      float mSumEnergyOfChargedWithoutEff;
+      float R2momtr;
+      float Eta2momtr;
+      float Phi2momtr;
+      float Pout;
       float Zch;
       int JPTSeed;
     };
@@ -56,7 +82,14 @@ namespace reco {
     JPTJet(const LorentzVector& fP4, const Specific& fSpecific, const Jet::Constituents& fConstituents);
 
     ~JPTJet() override{};
-
+    /// chargedHadronEnergy
+    float chargedHadronEnergy() const { return mspecific.mChargedHadronEnergy; }
+    ///  chargedHadronEnergyFraction
+    float chargedHadronEnergyFraction() const { return chargedHadronEnergy() / energy(); }
+    /// chargedEmEnergy
+    float chargedEmEnergy() const { return mspecific.mChargedEmEnergy; }
+    /// chargedEmEnergyFraction
+    float chargedEmEnergyFraction() const { return chargedEmEnergy() / energy(); }
     /// chargedMultiplicity
     int chargedMultiplicity() const {
       return mspecific.muonsInVertexInCalo.size() + mspecific.muonsInVertexOutCalo.size() +
@@ -82,7 +115,7 @@ namespace reco {
     const reco::TrackRefVector& getElecsInVertexOutCalo() const { return mspecific.elecsInVertexOutCalo; }
     const reco::TrackRefVector& getElecsOutVertexInCalo() const { return mspecific.elecsOutVertexInCalo; }
 
-    const edm::Ptr<reco::CaloJet>& getCaloJetRef() const { return mspecific.theCaloJetRef; }
+    const edm::RefToBase<reco::Jet>& getCaloJetRef() const { return mspecific.theCaloJetRef; }
     /// block accessors
 
     const Specific& getSpecific() const { return mspecific; }

--- a/DataFormats/JetReco/src/JPTJet.cc
+++ b/DataFormats/JetReco/src/JPTJet.cc
@@ -26,7 +26,6 @@ bool JPTJet::overlap(const Candidate&) const { return false; }
 void JPTJet::printJet() const {
   std::cout << " Raw Calo jet " << getCaloJetRef()->et() << " " << getCaloJetRef()->eta() << " "
             << getCaloJetRef()->phi() << "    JPTJet specific:" << std::endl
-            << "      chargedhadrons energy: " << chargedHadronEnergy() << std::endl
             << "      charged multiplicity: " << chargedMultiplicity() << std::endl;
   std::cout << "      JPTCandidate constituents:" << std::endl;
   std::cout << " Number of pions: " << getPionsInVertexInCalo().size() + getPionsInVertexOutCalo().size() << std::endl;
@@ -39,7 +38,6 @@ std::string JPTJet::print() const {
   std::ostringstream out;
   out << Jet::print()  // generic jet info
       << "    JPTJet specific:" << std::endl
-      << "      chargedhadrons energy: " << chargedHadronEnergy() << std::endl
       << "      charged: " << chargedMultiplicity() << std::endl;
   out << "      JPTCandidate constituents:" << std::endl;
 

--- a/DataFormats/JetReco/src/classes_def_1.xml
+++ b/DataFormats/JetReco/src/classes_def_1.xml
@@ -47,9 +47,24 @@
    <version ClassVersion="11" checksum="2945806860"/>
    <version ClassVersion="10" checksum="456342263"/>
   </class>
-  <class name="reco::JPTJet::Specific" ClassVersion="10">
+  <class name="reco::JPTJet::Specific" ClassVersion="12">
+   <version ClassVersion="12" checksum="541642602"/>
+   <version ClassVersion="11" checksum="3019484102"/>
    <version ClassVersion="10" checksum="3095396018"/>
   </class>
+
+<!-- Adding ioread rules for backwards compatibility -->
+
+  <ioread sourceClass="reco::JPTJet::Specific" version="[-10]"
+    source="edm::RefToBase<reco::Jet> theCaloJetRef;"
+    targetClass="reco::JPTJet::Specific"
+    target="theCaloJetRef"
+    include="DataFormats/Common/interface/RefToPtr.h,DataFormats/Common/interface/RefToBase.h,DataFormats/JetReco/interface/CaloJetCollection.h">
+    <![CDATA[
+     theCaloJetRef = edm::refToPtr(onfile.theCaloJetRef.castTo<reco::CaloJetRef>());
+    ]]>
+     </ioread>
+
   <class name="std::vector<reco::JPTJet>"/>
   <class name="edm::RefProd<std::vector<reco::JPTJet> >"/>
   <class name="edm::RefVector<std::vector<reco::JPTJet>,reco::JPTJet,edm::refhelper::FindUsingAdvance<std::vector<reco::JPTJet>,reco::JPTJet> >"/>

--- a/DataFormats/JetReco/src/classes_def_1.xml
+++ b/DataFormats/JetReco/src/classes_def_1.xml
@@ -47,25 +47,10 @@
    <version ClassVersion="11" checksum="2945806860"/>
    <version ClassVersion="10" checksum="456342263"/>
   </class>
-  <class name="reco::JPTJet::Specific" ClassVersion="12">
-   <version ClassVersion="12" checksum="541642602"/>
-   <version ClassVersion="11" checksum="3019484102"/>
+  <class name="reco::JPTJet::Specific" ClassVersion="11">
+   <version ClassVersion="11" checksum="3661452230"/>
    <version ClassVersion="10" checksum="3095396018"/>
   </class>
-
-<!-- Adding ioread rules for backwards compatibility -->
-
-  <ioread sourceClass="reco::JPTJet::Specific" version="[-10]"
-    source="edm::RefToBase<reco::Jet> theCaloJetRef;"
-    targetClass="reco::JPTJet::Specific"
-    target="theCaloJetRef"
-    include="DataFormats/Common/interface/RefToPtr.h,DataFormats/Common/interface/RefToBase.h,DataFormats/JetReco/interface/CaloJetCollection.h">
-    <![CDATA[
-     if(onfile.theCaloJetRef.isNonnull()) 
-           theCaloJetRef = edm::refToPtr(onfile.theCaloJetRef.castTo<reco::CaloJetRef>());
-    ]]>
-     </ioread>
-
   <class name="std::vector<reco::JPTJet>"/>
   <class name="edm::RefProd<std::vector<reco::JPTJet> >"/>
   <class name="edm::RefVector<std::vector<reco::JPTJet>,reco::JPTJet,edm::refhelper::FindUsingAdvance<std::vector<reco::JPTJet>,reco::JPTJet> >"/>

--- a/DataFormats/JetReco/src/classes_def_1.xml
+++ b/DataFormats/JetReco/src/classes_def_1.xml
@@ -61,7 +61,8 @@
     target="theCaloJetRef"
     include="DataFormats/Common/interface/RefToPtr.h,DataFormats/Common/interface/RefToBase.h,DataFormats/JetReco/interface/CaloJetCollection.h">
     <![CDATA[
-     theCaloJetRef = edm::refToPtr(onfile.theCaloJetRef.castTo<reco::CaloJetRef>());
+     if(onfile.theCaloJetRef.isNonnull()) 
+           theCaloJetRef = edm::refToPtr(onfile.theCaloJetRef.castTo<reco::CaloJetRef>());
     ]]>
      </ioread>
 

--- a/DataFormats/PatCandidates/interface/Jet.h
+++ b/DataFormats/PatCandidates/interface/Jet.h
@@ -374,8 +374,6 @@ namespace pat {
     const reco::TrackRefVector& elecsInVertexOutCalo() const { return jptSpecific().elecsInVertexOutCalo; }
     /// electrons that curled in
     const reco::TrackRefVector& elecsOutVertexInCalo() const { return jptSpecific().elecsOutVertexInCalo; }
-    /// zero suppression correction
-    //const float& zspCorrection() const { return jptSpecific().mZSPCor; }
     /// chargedMultiplicity
     float elecMultiplicity() const {
       return jptSpecific().elecsInVertexInCalo.size() + jptSpecific().elecsInVertexOutCalo.size();
@@ -696,8 +694,8 @@ namespace pat {
 inline float pat::Jet::chargedHadronEnergy() const {
   if (isPFJet()) {
     return pfSpecific().mChargedHadronEnergy;
-    //  } else if (isJPTJet()) {
-    //    return jptSpecific().mChargedHadronEnergy;
+  } else if (isJPTJet()) {
+    return jptSpecific().mChargedHadronEnergy;
   } else {
     throw cms::Exception("Type Mismatch") << "This PAT jet was not made from a JPTJet nor from PFJet.\n";
   }
@@ -706,8 +704,6 @@ inline float pat::Jet::chargedHadronEnergy() const {
 inline float pat::Jet::neutralHadronEnergy() const {
   if (isPFJet()) {
     return pfSpecific().mNeutralHadronEnergy;
-    //  } else if (isJPTJet()) {
-    //    return jptSpecific().mNeutralHadronEnergy;
   } else {
     throw cms::Exception("Type Mismatch") << "This PAT jet was not made from a JPTJet nor from PFJet.\n";
   }
@@ -716,8 +712,8 @@ inline float pat::Jet::neutralHadronEnergy() const {
 inline float pat::Jet::chargedEmEnergy() const {
   if (isPFJet()) {
     return pfSpecific().mChargedEmEnergy;
-    //  } else if (isJPTJet()) {
-    //    return jptSpecific().mChargedEmEnergy;
+  } else if (isJPTJet()) {
+    return jptSpecific().mChargedEmEnergy;
   } else {
     throw cms::Exception("Type Mismatch") << "This PAT jet was not made from a JPTJet nor from PFJet.\n";
   }
@@ -726,8 +722,6 @@ inline float pat::Jet::chargedEmEnergy() const {
 inline float pat::Jet::neutralEmEnergy() const {
   if (isPFJet()) {
     return pfSpecific().mNeutralEmEnergy;
-    //  } else if (isJPTJet()) {
-    //    return jptSpecific().mNeutralEmEnergy;
   } else {
     throw cms::Exception("Type Mismatch") << "This PAT jet was not made from a JPTJet nor from PFJet.\n";
   }

--- a/DataFormats/PatCandidates/interface/Jet.h
+++ b/DataFormats/PatCandidates/interface/Jet.h
@@ -375,7 +375,7 @@ namespace pat {
     /// electrons that curled in
     const reco::TrackRefVector& elecsOutVertexInCalo() const { return jptSpecific().elecsOutVertexInCalo; }
     /// zero suppression correction
-    const float& zspCorrection() const { return jptSpecific().mZSPCor; }
+    //const float& zspCorrection() const { return jptSpecific().mZSPCor; }
     /// chargedMultiplicity
     float elecMultiplicity() const {
       return jptSpecific().elecsInVertexInCalo.size() + jptSpecific().elecsInVertexOutCalo.size();
@@ -696,8 +696,8 @@ namespace pat {
 inline float pat::Jet::chargedHadronEnergy() const {
   if (isPFJet()) {
     return pfSpecific().mChargedHadronEnergy;
-  } else if (isJPTJet()) {
-    return jptSpecific().mChargedHadronEnergy;
+    //  } else if (isJPTJet()) {
+    //    return jptSpecific().mChargedHadronEnergy;
   } else {
     throw cms::Exception("Type Mismatch") << "This PAT jet was not made from a JPTJet nor from PFJet.\n";
   }
@@ -706,8 +706,8 @@ inline float pat::Jet::chargedHadronEnergy() const {
 inline float pat::Jet::neutralHadronEnergy() const {
   if (isPFJet()) {
     return pfSpecific().mNeutralHadronEnergy;
-  } else if (isJPTJet()) {
-    return jptSpecific().mNeutralHadronEnergy;
+    //  } else if (isJPTJet()) {
+    //    return jptSpecific().mNeutralHadronEnergy;
   } else {
     throw cms::Exception("Type Mismatch") << "This PAT jet was not made from a JPTJet nor from PFJet.\n";
   }
@@ -716,8 +716,8 @@ inline float pat::Jet::neutralHadronEnergy() const {
 inline float pat::Jet::chargedEmEnergy() const {
   if (isPFJet()) {
     return pfSpecific().mChargedEmEnergy;
-  } else if (isJPTJet()) {
-    return jptSpecific().mChargedEmEnergy;
+    //  } else if (isJPTJet()) {
+    //    return jptSpecific().mChargedEmEnergy;
   } else {
     throw cms::Exception("Type Mismatch") << "This PAT jet was not made from a JPTJet nor from PFJet.\n";
   }
@@ -726,8 +726,8 @@ inline float pat::Jet::chargedEmEnergy() const {
 inline float pat::Jet::neutralEmEnergy() const {
   if (isPFJet()) {
     return pfSpecific().mNeutralEmEnergy;
-  } else if (isJPTJet()) {
-    return jptSpecific().mNeutralEmEnergy;
+    //  } else if (isJPTJet()) {
+    //    return jptSpecific().mNeutralEmEnergy;
   } else {
     throw cms::Exception("Type Mismatch") << "This PAT jet was not made from a JPTJet nor from PFJet.\n";
   }

--- a/JetMETCorrections/Algorithms/src/L1JPTOffsetCorrector.cc
+++ b/JetMETCorrections/Algorithms/src/L1JPTOffsetCorrector.cc
@@ -58,7 +58,7 @@ double L1JPTOffsetCorrector::correction(const reco::Jet& fJet,
                                         const edm::EventSetup& fSetup) const {
   double result = 1.;
   const reco::JPTJet& jptjet = dynamic_cast<const reco::JPTJet&>(fJet);
-  const edm::Ptr<reco::CaloJet>& rawcalojet = jptjet.getCaloJetRef();
+  const edm::RefToBase<reco::Jet>& rawcalojet = jptjet.getCaloJetRef();
   //------ access the offset correction service ----------------
   double offset = 1.0;
   if (mIsOffsetSet) {

--- a/JetMETCorrections/Algorithms/src/L1JPTOffsetCorrector.cc
+++ b/JetMETCorrections/Algorithms/src/L1JPTOffsetCorrector.cc
@@ -58,8 +58,7 @@ double L1JPTOffsetCorrector::correction(const reco::Jet& fJet,
                                         const edm::EventSetup& fSetup) const {
   double result = 1.;
   const reco::JPTJet& jptjet = dynamic_cast<const reco::JPTJet&>(fJet);
-  const edm::RefToBase<reco::Jet>& jptjetRef = jptjet.getCaloJetRef();
-  reco::CaloJet const* rawcalojet = dynamic_cast<reco::CaloJet const*>(&*jptjetRef);
+  const edm::Ptr<reco::CaloJet>& rawcalojet = jptjet.getCaloJetRef();
   //------ access the offset correction service ----------------
   double offset = 1.0;
   if (mIsOffsetSet) {

--- a/JetMETCorrections/Algorithms/src/L1JPTOffsetCorrectorImpl.cc
+++ b/JetMETCorrections/Algorithms/src/L1JPTOffsetCorrectorImpl.cc
@@ -76,8 +76,7 @@ double L1JPTOffsetCorrectorImpl::correction(const LorentzVector& fJet) const {
 double L1JPTOffsetCorrectorImpl::correction(const reco::Jet& fJet) const {
   double result = 1.;
   const reco::JPTJet& jptjet = dynamic_cast<const reco::JPTJet&>(fJet);
-  const edm::RefToBase<reco::Jet>& jptjetRef = jptjet.getCaloJetRef();
-  reco::CaloJet const* rawcalojet = dynamic_cast<reco::CaloJet const*>(&*jptjetRef);
+  const edm::Ptr<reco::CaloJet>& rawcalojet = jptjet.getCaloJetRef();
   //------ access the offset correction service ----------------
   double offset = 1.0;
   if (offsetService_) {

--- a/JetMETCorrections/Algorithms/src/L1JPTOffsetCorrectorImpl.cc
+++ b/JetMETCorrections/Algorithms/src/L1JPTOffsetCorrectorImpl.cc
@@ -76,7 +76,7 @@ double L1JPTOffsetCorrectorImpl::correction(const LorentzVector& fJet) const {
 double L1JPTOffsetCorrectorImpl::correction(const reco::Jet& fJet) const {
   double result = 1.;
   const reco::JPTJet& jptjet = dynamic_cast<const reco::JPTJet&>(fJet);
-  const edm::Ptr<reco::CaloJet>& rawcalojet = jptjet.getCaloJetRef();
+  const edm::RefToBase<reco::Jet>& rawcalojet = jptjet.getCaloJetRef();
   //------ access the offset correction service ----------------
   double offset = 1.0;
   if (offsetService_) {

--- a/PhysicsTools/PatAlgos/plugins/JPTJetSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/JPTJetSlimmer.cc
@@ -15,7 +15,6 @@
 #include "DataFormats/JetReco/interface/CaloJetCollection.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/Math/interface/deltaR.h"
-#include "DataFormats/Common/interface/RefToPtr.h"
 #include <vector>
 
 class JPTJetSlimmer : public edm::stream::EDProducer<> {
@@ -47,7 +46,7 @@ public:
       if (selector_(ijet)) {
         // Add specific : only reference to CaloJet collection. It is necessary for
         // recalibration JPTJet at MiniAod.
-        const edm::Ptr<reco::CaloJet>& rawcalojet = ijet.getCaloJetRef();
+        const edm::RefToBase<reco::Jet>& rawcalojet = ijet.getCaloJetRef();
         int icalo = -1;
         int i = 0;
         for (auto const& icjet : h_calojets) {
@@ -61,11 +60,12 @@ public:
         if (icalo < 0) {
           // Add reference to the created CaloJet collection
           reco::CaloJetRef myjet(pOut1RefProd, idxCaloJet++);
-          tmp_specific.theCaloJetRef = edm::refToPtr(myjet);
-          caloJets->push_back(*rawcalojet);
+          tmp_specific.theCaloJetRef = edm::RefToBase<reco::Jet>(myjet);
+          reco::CaloJet const * rawcalojetc = dynamic_cast<reco::CaloJet const *>( &* rawcalojet);
+          caloJets->push_back(*rawcalojetc);
         } else {
           //  Add reference to existing slimmedCaloJet Collection to JPTJet
-          tmp_specific.theCaloJetRef = h_calojets.ptrAt(icalo);
+          tmp_specific.theCaloJetRef = edm::RefToBase<reco::Jet>(h_calojets.refAt(icalo));
         }
         const reco::Candidate::Point& orivtx = ijet.vertex();
         reco::JPTJet newJPTJet(ijet.p4(), orivtx, tmp_specific, ijet.getJetConstituents());

--- a/PhysicsTools/PatAlgos/plugins/JPTJetSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/JPTJetSlimmer.cc
@@ -61,7 +61,7 @@ public:
           // Add reference to the created CaloJet collection
           reco::CaloJetRef myjet(pOut1RefProd, idxCaloJet++);
           tmp_specific.theCaloJetRef = edm::RefToBase<reco::Jet>(myjet);
-          reco::CaloJet const * rawcalojetc = dynamic_cast<reco::CaloJet const *>( &* rawcalojet);
+          reco::CaloJet const* rawcalojetc = dynamic_cast<reco::CaloJet const*>(&*rawcalojet);
           caloJets->push_back(*rawcalojetc);
         } else {
           //  Add reference to existing slimmedCaloJet Collection to JPTJet

--- a/PhysicsTools/PatAlgos/plugins/JPTJetSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/JPTJetSlimmer.cc
@@ -63,15 +63,12 @@ public:
           tmp_specific.theCaloJetRef = edm::RefToBase<reco::Jet>(myjet);
           reco::CaloJet const* rawcalojetc = dynamic_cast<reco::CaloJet const*>(&*rawcalojet);
           caloJets->push_back(*rawcalojetc);
-        } else {
-          //  Add reference to existing slimmedCaloJet Collection to JPTJet
-          tmp_specific.theCaloJetRef = edm::RefToBase<reco::Jet>(h_calojets.refAt(icalo));
+          const reco::Candidate::Point& orivtx = ijet.vertex();
+          reco::JPTJet newJPTJet(ijet.p4(), orivtx, tmp_specific, ijet.getJetConstituents());
+          float jetArea = ijet.jetArea();
+          newJPTJet.setJetArea(fabs(jetArea));
+          jptJets->push_back(newJPTJet);
         }
-        const reco::Candidate::Point& orivtx = ijet.vertex();
-        reco::JPTJet newJPTJet(ijet.p4(), orivtx, tmp_specific, ijet.getJetConstituents());
-        float jetArea = ijet.jetArea();
-        newJPTJet.setJetArea(fabs(jetArea));
-        jptJets->push_back(newJPTJet);
       }
     }
     iEvent.put(std::move(caloJets));

--- a/PhysicsTools/PatAlgos/plugins/JPTJetSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/JPTJetSlimmer.cc
@@ -21,9 +21,9 @@ public:
         srcCaloToken_(consumes<edm::View<reco::CaloJet> >(params.getParameter<edm::InputTag>("srcCalo"))),
         cut_(params.getParameter<std::string>("cut")),
         selector_(cut_) {
-         produces<reco::JPTJetCollection>();
-         produces<reco::CaloJetCollection>();
-        }
+    produces<reco::JPTJetCollection>();
+    produces<reco::CaloJetCollection>();
+  }
 
   ~JPTJetSlimmer() override {}
 
@@ -35,37 +35,38 @@ public:
     edm::Ref<reco::CaloJetCollection>::key_type idxCaloJet = 0;
 
     edm::Handle<edm::View<reco::CaloJet> > h_calojets;
-    iEvent.getByToken(srcCaloToken_, h_calojets); 
+    iEvent.getByToken(srcCaloToken_, h_calojets);
 
     edm::Handle<edm::View<reco::JPTJet> > h_jets;
     iEvent.getByToken(srcToken_, h_jets);
-     
+
     for (auto const& ijet : *h_jets) {
       if (selector_(ijet)) {
-// Add specific : only reference to CaloJet collection. It is necessary for 
-// recalibration JPTJet at MiniAod.
-          edm::RefToBase<reco::Jet> jptjetRef = ijet.getCaloJetRef();
-          reco::CaloJet const * rawcalojet = dynamic_cast<reco::CaloJet const *>( &* jptjetRef);
-        int icalo = -1; 
+        // Add specific : only reference to CaloJet collection. It is necessary for
+        // recalibration JPTJet at MiniAod.
+        const edm::RefToBase<reco::Jet>& jptjetRef = ijet.getCaloJetRef();
+        reco::CaloJet const * rawcalojet = dynamic_cast<reco::CaloJet const *>( &* jptjetRef);
+        int icalo = -1;
         int i = 0;
-        for(auto const& icjet : *h_calojets) {
-            double dr2 = deltaR2(icjet, *rawcalojet);
-            if (dr2 <= 0.001) {
-               icalo = i;
-            }
+        for (auto const& icjet : *h_calojets) {
+          double dr2 = deltaR2(icjet, *rawcalojet);
+          if (dr2 <= 0.001) {
+            icalo = i;
+          }
           i++;
         }
         reco::JPTJet::Specific tmp_specific;
-        if(icalo < 0) {
-// Add reference to the created CaloJet collection
+        if (icalo < 0) {
+          // Add reference to the created CaloJet collection          
           reco::CaloJetRef myjet(pOut1RefProd, idxCaloJet++);
           tmp_specific.theCaloJetRef = edm::RefToBase<reco::Jet>(myjet);
           caloJets->push_back(*rawcalojet);
         } else {
-//  Add reference to existing slimmedCaloJet Collection to JPTJet
-          tmp_specific.theCaloJetRef = edm::RefToBase<reco::Jet>(h_calojets->refAt(icalo));;
+          //  Add reference to existing slimmedCaloJet Collection to JPTJet
+          tmp_specific.theCaloJetRef = edm::RefToBase<reco::Jet>(h_calojets->refAt(icalo));
+          ;
         }
-        const reco::Candidate::Point orivtx = ijet.vertex();
+        const reco::Candidate::Point& orivtx = ijet.vertex();
         reco::JPTJet newJPTJet(ijet.p4(), orivtx, tmp_specific, ijet.getJetConstituents());
         float jetArea = ijet.jetArea();
         newJPTJet.setJetArea(fabs(jetArea));

--- a/PhysicsTools/PatAlgos/plugins/JPTJetSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/JPTJetSlimmer.cc
@@ -45,7 +45,7 @@ public:
         // Add specific : only reference to CaloJet collection. It is necessary for
         // recalibration JPTJet at MiniAod.
         const edm::RefToBase<reco::Jet>& jptjetRef = ijet.getCaloJetRef();
-        reco::CaloJet const * rawcalojet = dynamic_cast<reco::CaloJet const *>( &* jptjetRef);
+        reco::CaloJet const* rawcalojet = dynamic_cast<reco::CaloJet const*>(&*jptjetRef);
         int icalo = -1;
         int i = 0;
         for (auto const& icjet : *h_calojets) {
@@ -57,7 +57,7 @@ public:
         }
         reco::JPTJet::Specific tmp_specific;
         if (icalo < 0) {
-          // Add reference to the created CaloJet collection          
+          // Add reference to the created CaloJet collection
           reco::CaloJetRef myjet(pOut1RefProd, idxCaloJet++);
           tmp_specific.theCaloJetRef = edm::RefToBase<reco::Jet>(myjet);
           caloJets->push_back(*rawcalojet);

--- a/PhysicsTools/PatAlgos/plugins/JPTJetSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/JPTJetSlimmer.cc
@@ -1,0 +1,87 @@
+
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "DataFormats/Common/interface/RefVector.h"
+
+#include "CommonTools/UtilAlgos/interface/StringCutObjectSelector.h"
+#include "CommonTools/UtilAlgos/interface/SingleObjectSelector.h"
+#include "CommonTools/UtilAlgos/interface/ObjectSelector.h"
+#include "CommonTools/UtilAlgos/interface/SingleElementCollectionSelector.h"
+
+#include "DataFormats/JetReco/interface/JPTJet.h"
+#include "DataFormats/JetReco/interface/CaloJet.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/Math/interface/deltaR.h"
+
+#include <vector>
+
+class JPTJetSlimmer : public edm::stream::EDProducer<> {
+public:
+  JPTJetSlimmer(edm::ParameterSet const& params)
+      : srcToken_(consumes<edm::View<reco::JPTJet> >(params.getParameter<edm::InputTag>("src"))),
+        srcCaloToken_(consumes<edm::View<reco::CaloJet> >(params.getParameter<edm::InputTag>("srcCalo"))),
+        cut_(params.getParameter<std::string>("cut")),
+        selector_(cut_) {
+         produces<reco::JPTJetCollection>();
+         produces<reco::CaloJetCollection>();
+        }
+
+  ~JPTJetSlimmer() override {}
+
+  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override {
+    auto jptJets = std::make_unique<reco::JPTJetCollection>();
+    auto caloJets = std::make_unique<reco::CaloJetCollection>();
+
+    edm::RefProd<reco::CaloJetCollection> pOut1RefProd = iEvent.getRefBeforePut<reco::CaloJetCollection>();
+    edm::Ref<reco::CaloJetCollection>::key_type idxCaloJet = 0;
+
+    edm::Handle<edm::View<reco::CaloJet> > h_calojets;
+    iEvent.getByToken(srcCaloToken_, h_calojets); 
+
+    edm::Handle<edm::View<reco::JPTJet> > h_jets;
+    iEvent.getByToken(srcToken_, h_jets);
+     
+    for (auto const& ijet : *h_jets) {
+      if (selector_(ijet)) {
+// Add specific : only reference to CaloJet collection. It is necessary for 
+// recalibration JPTJet at MiniAod.
+          edm::RefToBase<reco::Jet> jptjetRef = ijet.getCaloJetRef();
+          reco::CaloJet const * rawcalojet = dynamic_cast<reco::CaloJet const *>( &* jptjetRef);
+        int icalo = -1; 
+        int i = 0;
+        for(auto const& icjet : *h_calojets) {
+            double dr2 = deltaR2(icjet, *rawcalojet);
+            if (dr2 <= 0.001) {
+               icalo = i;
+            }
+          i++;
+        }
+        reco::JPTJet::Specific tmp_specific;
+        if(icalo < 0) {
+// Add reference to the created CaloJet collection
+          reco::CaloJetRef myjet(pOut1RefProd, idxCaloJet++);
+          tmp_specific.theCaloJetRef = edm::RefToBase<reco::Jet>(myjet);
+          caloJets->push_back(*rawcalojet);
+        } else {
+//  Add reference to existing slimmedCaloJet Collection to JPTJet
+          tmp_specific.theCaloJetRef = edm::RefToBase<reco::Jet>(h_calojets->refAt(icalo));;
+        }
+        const reco::Candidate::Point orivtx = ijet.vertex();
+        reco::JPTJet newJPTJet(ijet.p4(), orivtx, tmp_specific, ijet.getJetConstituents());
+        float jetArea = ijet.jetArea();
+        newJPTJet.setJetArea(fabs(jetArea));
+        jptJets->push_back(newJPTJet);
+      }
+    }
+    iEvent.put(std::move(caloJets));
+    iEvent.put(std::move(jptJets));
+  }
+
+protected:
+  const edm::EDGetTokenT<edm::View<reco::JPTJet> > srcToken_;
+  const edm::EDGetTokenT<edm::View<reco::CaloJet> > srcCaloToken_;
+  const std::string cut_;
+  const StringCutObjectSelector<reco::Jet> selector_;
+};
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(JPTJetSlimmer);

--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -13,6 +13,7 @@ MicroEventContent = cms.PSet(
         'keep *_slimmedTaus_*_*',
         'keep *_slimmedTausBoosted_*_*',
         'keep *_slimmedCaloJets_*_*',
+        'keep *_slimmedJPTJets_*_*',
         'keep *_slimmedJets_*_*',
         # keep slimmedJets TagInfos, currently only PixelClusterTagInfo
         'keep recoBaseTagInfosOwned_slimmedJets_*_*',

--- a/PhysicsTools/PatAlgos/python/slimming/slimmedJPTJets_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimmedJPTJets_cfi.py
@@ -3,5 +3,5 @@ import FWCore.ParameterSet.Config as cms
 slimmedJPTJets = cms.EDProducer("JPTJetSlimmer",
     src = cms.InputTag("JetPlusTrackZSPCorJetAntiKt4"),
     srcCalo = cms.InputTag("slimmedCaloJets"),
-    cut = cms.string("pt>20")
+    cut = cms.string("pt>25 && abs(eta) < 2.5")
 )

--- a/PhysicsTools/PatAlgos/python/slimming/slimmedJPTJets_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimmedJPTJets_cfi.py
@@ -3,5 +3,5 @@ import FWCore.ParameterSet.Config as cms
 slimmedJPTJets = cms.EDProducer("JPTJetSlimmer",
     src = cms.InputTag("JetPlusTrackZSPCorJetAntiKt4"),
     srcCalo = cms.InputTag("slimmedCaloJets"),
-    cut = cms.string("pt>25 && abs(eta) < 2.5")
+    cut = cms.string("pt>25 && abs(eta) < 2.2")
 )

--- a/PhysicsTools/PatAlgos/python/slimming/slimmedJPTJets_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimmedJPTJets_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+slimmedJPTJets = cms.EDProducer("JPTJetSlimmer",
+    src = cms.InputTag("JetPlusTrackZSPCorJetAntiKt4"),
+    srcCalo = cms.InputTag("slimmedCaloJets"),
+    cut = cms.string("pt>20")
+)

--- a/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
@@ -74,6 +74,7 @@ slimmingTask = cms.Task(
 
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 pp_on_AA.toReplaceWith(slimmingTask, slimmingTask.copyAndExclude([slimmedOOTPhotons]))
+pp_on_AA.toReplaceWith(slimmingTask, slimmingTask.copyAndExclude([slimmedJPTJets]))
 
 from Configuration.Eras.Modifier_run2_miniAOD_94XFall17_cff import run2_miniAOD_94XFall17
 from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy

--- a/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
@@ -14,6 +14,7 @@ from PhysicsTools.PatAlgos.slimming.selectedPatTrigger_cfi import *
 from PhysicsTools.PatAlgos.slimming.slimmedPatTrigger_cfi import *
 from PhysicsTools.PatAlgos.slimming.slimmedJets_cfi      import *
 from PhysicsTools.PatAlgos.slimming.slimmedCaloJets_cfi  import *
+from PhysicsTools.PatAlgos.slimming.slimmedJPTJets_cfi  import *
 from PhysicsTools.PatAlgos.slimming.slimmedGenJets_cfi   import *
 from PhysicsTools.PatAlgos.slimming.slimmedElectrons_cfi import *
 from PhysicsTools.PatAlgos.slimming.slimmedLowPtElectrons_cff import *
@@ -46,6 +47,7 @@ slimmingTask = cms.Task(
     selectedPatTrigger,
     slimmedPatTrigger,
     slimmedCaloJets,
+    slimmedJPTJets,
     slimmedJets,
     slimmedJetsAK8,
     slimmedGenJets,

--- a/RecoJets/JetPlusTracks/plugins/JetPlusTrackAddonSeedProducer.cc
+++ b/RecoJets/JetPlusTracks/plugins/JetPlusTrackAddonSeedProducer.cc
@@ -162,7 +162,7 @@ void JetPlusTrackAddonSeedProducer::produce(edm::Event& iEvent, const edm::Event
       caloen = 0.001;
     math::XYZTLorentzVector pcalo4(caloen * jet.p4() / trackp);
     reco::CaloJet::Specific calospe;
-    calospe.mTowersArea = -1 * ncand;
+    calospe.mTowersArea = ncand;
     calospe.mHadEnergyInHO = hadinho;
     calospe.mHadEnergyInHB = hadinhb;
     calospe.mHadEnergyInHE = hadinhe;

--- a/RecoJets/JetPlusTracks/plugins/JetPlusTrackProducer.cc
+++ b/RecoJets/JetPlusTracks/plugins/JetPlusTrackProducer.cc
@@ -192,21 +192,21 @@ void JetPlusTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iS
     jpt::MatchedTracks pions;
     jpt::MatchedTracks muons;
     jpt::MatchedTracks elecs;
-    bool ok = false;
+    bool validMatches = false;
 
     if (!vectorial_) {
-      scaleJPT = mJPTalgo->correction(corrected, oldjet, iEvent, iSetup, pions, muons, elecs, ok);
+      scaleJPT = mJPTalgo->correction(corrected, oldjet, iEvent, iSetup, pions, muons, elecs, validMatches);
       p4 = math::XYZTLorentzVector(corrected.px() * scaleJPT,
                                    corrected.py() * scaleJPT,
                                    corrected.pz() * scaleJPT,
                                    corrected.energy() * scaleJPT);
     } else {
-      scaleJPT = mJPTalgo->correction(corrected, oldjet, iEvent, iSetup, p4, pions, muons, elecs, ok);
+      scaleJPT = mJPTalgo->correction(corrected, oldjet, iEvent, iSetup, p4, pions, muons, elecs, validMatches);
     }
 
     reco::JPTJet::Specific specific;
 
-    if (ok) {
+    if (validMatches) {
       specific.pionsInVertexInCalo = pions.inVertexInCalo_;
       specific.pionsInVertexOutCalo = pions.inVertexOutOfCalo_;
       specific.pionsOutVertexInCalo = pions.outOfVertexInCalo_;

--- a/RecoJets/JetPlusTracks/plugins/JetPlusTrackProducer.cc
+++ b/RecoJets/JetPlusTracks/plugins/JetPlusTrackProducer.cc
@@ -41,7 +41,7 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/Math/interface/deltaPhi.h"
 #include "DataFormats/Math/interface/deltaR.h"
-
+#include "DataFormats/Common/interface/RefToPtr.h"
 #include <string>
 
 using namespace std;
@@ -167,8 +167,8 @@ void JetPlusTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iS
       jptspe.elecsInVertexOutCalo = elecs.inVertexOutOfCalo_;
       jptspe.elecsOutVertexInCalo = elecs.outOfVertexInCalo_;
       reco::CaloJetRef myjet(pOut1RefProd, idxCaloJet++);
-      jptspe.theCaloJetRef = edm::RefToBase<reco::Jet>(myjet);
-      jptspe.mZSPCor = 1.;
+      jptspe.theCaloJetRef = edm::refToPtr(myjet);
+      jptspe.JPTSeed = 1;
       reco::JPTJet fJet(p4, jet.primaryVertex()->position(), jptspe, mycalo.getJetConstituents());
       pOut->push_back(fJet);
       pOut1->push_back(mycalo);
@@ -220,75 +220,32 @@ void JetPlusTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iS
     }
 
     // Fill JPT Specific
-    specific.theCaloJetRef = edm::RefToBase<reco::Jet>(jets_h.refAt(iJet));
-    specific.mZSPCor = factorZSP;
-    specific.mResponseOfChargedWithEff = (float)mJPTalgo->getResponseOfChargedWithEff();
-    specific.mResponseOfChargedWithoutEff = (float)mJPTalgo->getResponseOfChargedWithoutEff();
-    specific.mSumPtOfChargedWithEff = (float)mJPTalgo->getSumPtWithEff();
-    specific.mSumPtOfChargedWithoutEff = (float)mJPTalgo->getSumPtWithoutEff();
-    specific.mSumEnergyOfChargedWithEff = (float)mJPTalgo->getSumEnergyWithEff();
-    specific.mSumEnergyOfChargedWithoutEff = (float)mJPTalgo->getSumEnergyWithoutEff();
-    specific.mChargedHadronEnergy = (float)mJPTalgo->getSumEnergyWithoutEff();
+    specific.theCaloJetRef = jets_h.ptrAt(iJet);
 
     // Fill Charged Jet shape parameters
-    double deR2Tr = 0.;
-    double deEta2Tr = 0.;
-    double dePhi2Tr = 0.;
     double Zch = 0.;
-    double Pout2 = 0.;
-    double Pout = 0.;
-    double denominator_tracks = 0.;
-    int ntracks = 0;
 
     for (reco::TrackRefVector::const_iterator it = pions.inVertexInCalo_.begin(); it != pions.inVertexInCalo_.end();
          it++) {
-      double deR = deltaR((*it)->eta(), (*it)->phi(), p4.eta(), p4.phi());
-      double deEta = (*it)->eta() - p4.eta();
-      double dePhi = deltaPhi((*it)->phi(), p4.phi());
       if ((**it).ptError() / (**it).pt() < 0.1) {
-        deR2Tr = deR2Tr + deR * deR * (*it)->pt();
-        deEta2Tr = deEta2Tr + deEta * deEta * (*it)->pt();
-        dePhi2Tr = dePhi2Tr + dePhi * dePhi * (*it)->pt();
-        denominator_tracks = denominator_tracks + (*it)->pt();
         Zch = Zch + (*it)->pt();
-
-        Pout2 = Pout2 + (**it).p() * (**it).p() - (Zch * p4.P()) * (Zch * p4.P());
-        ntracks++;
       }
     }
 
     for (reco::TrackRefVector::const_iterator it = muons.inVertexInCalo_.begin(); it != muons.inVertexInCalo_.end();
          it++) {
-      double deR = deltaR((*it)->eta(), (*it)->phi(), p4.eta(), p4.phi());
-      double deEta = (*it)->eta() - p4.eta();
-      double dePhi = deltaPhi((*it)->phi(), p4.phi());
       if ((**it).ptError() / (**it).pt() < 0.1) {
-        deR2Tr = deR2Tr + deR * deR * (*it)->pt();
-        deEta2Tr = deEta2Tr + deEta * deEta * (*it)->pt();
-        dePhi2Tr = dePhi2Tr + dePhi * dePhi * (*it)->pt();
-        denominator_tracks = denominator_tracks + (*it)->pt();
         Zch = Zch + (*it)->pt();
-
-        Pout2 = Pout2 + (**it).p() * (**it).p() - (Zch * p4.P()) * (Zch * p4.P());
-        ntracks++;
       }
     }
+
     for (reco::TrackRefVector::const_iterator it = elecs.inVertexInCalo_.begin(); it != elecs.inVertexInCalo_.end();
          it++) {
-      double deR = deltaR((*it)->eta(), (*it)->phi(), p4.eta(), p4.phi());
-      double deEta = (*it)->eta() - p4.eta();
-      double dePhi = deltaPhi((*it)->phi(), p4.phi());
       if ((**it).ptError() / (**it).pt() < 0.1) {
-        deR2Tr = deR2Tr + deR * deR * (*it)->pt();
-        deEta2Tr = deEta2Tr + deEta * deEta * (*it)->pt();
-        dePhi2Tr = dePhi2Tr + dePhi * dePhi * (*it)->pt();
-        denominator_tracks = denominator_tracks + (*it)->pt();
         Zch = Zch + (*it)->pt();
-
-        Pout2 = Pout2 + (**it).p() * (**it).p() - (Zch * p4.P()) * (Zch * p4.P());
-        ntracks++;
       }
     }
+
     for (reco::TrackRefVector::const_iterator it = pions.inVertexOutOfCalo_.begin();
          it != pions.inVertexOutOfCalo_.end();
          it++) {
@@ -308,23 +265,9 @@ void JetPlusTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iS
     if (mJPTalgo->getSumPtForBeta() > 0.)
       Zch = Zch / mJPTalgo->getSumPtForBeta();
 
-    if (ntracks > 0) {
-      Pout = sqrt(fabs(Pout2)) / ntracks;
-    }
-    if (denominator_tracks != 0) {
-      deR2Tr = deR2Tr / denominator_tracks;
-      deEta2Tr = deEta2Tr / denominator_tracks;
-      dePhi2Tr = dePhi2Tr / denominator_tracks;
-    }
-
-    specific.R2momtr = deR2Tr;
-    specific.Eta2momtr = deEta2Tr;
-    specific.Phi2momtr = dePhi2Tr;
-    specific.Pout = Pout;
     specific.Zch = Zch;
 
     // Create JPT jet
-
     reco::Particle::Point vertex_ = reco::Jet::Point(0, 0, 0);
 
     // If we add primary vertex

--- a/RecoJets/JetPlusTracks/plugins/JetPlusTrackProducerAA.cc
+++ b/RecoJets/JetPlusTracks/plugins/JetPlusTrackProducerAA.cc
@@ -154,21 +154,21 @@ void JetPlusTrackProducerAA::produce(edm::Event& iEvent, const edm::EventSetup& 
     jpt::MatchedTracks pions;
     jpt::MatchedTracks muons;
     jpt::MatchedTracks elecs;
-    bool ok = false;
+    bool validMatches = false;
 
     if (!vectorial_) {
-      scaleJPT = mJPTalgo->correction(corrected, oldjet, iEvent, iSetup, pions, muons, elecs, ok);
+      scaleJPT = mJPTalgo->correction(corrected, oldjet, iEvent, iSetup, pions, muons, elecs, validMatches);
       p4 = math::XYZTLorentzVector(corrected.px() * scaleJPT,
                                    corrected.py() * scaleJPT,
                                    corrected.pz() * scaleJPT,
                                    corrected.energy() * scaleJPT);
     } else {
-      scaleJPT = mJPTalgo->correction(corrected, oldjet, iEvent, iSetup, p4, pions, muons, elecs, ok);
+      scaleJPT = mJPTalgo->correction(corrected, oldjet, iEvent, iSetup, p4, pions, muons, elecs, validMatches);
     }
 
     reco::JPTJet::Specific specific;
 
-    if (ok) {
+    if (validMatches) {
       specific.pionsInVertexInCalo = pions.inVertexInCalo_;
       specific.pionsInVertexOutCalo = pions.inVertexOutOfCalo_;
       specific.pionsOutVertexInCalo = pions.outOfVertexInCalo_;

--- a/RecoJets/JetProducers/src/PileupJPTJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJPTJetIdAlgo.cc
@@ -109,7 +109,7 @@ namespace cms {
     }
 
     const edm::RefToBase<reco::Jet> jptjetRef = jet->getCaloJetRef();
-    reco::CaloJet const * rawcalojet = dynamic_cast<reco::CaloJet const *>( &* jptjetRef);
+    reco::CaloJet const* rawcalojet = dynamic_cast<reco::CaloJet const*>(&*jptjetRef);
 
     int ncalotowers = 0.;
     double sumpt = 0.;

--- a/RecoJets/JetProducers/src/PileupJPTJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJPTJetIdAlgo.cc
@@ -108,7 +108,8 @@ namespace cms {
       std::cout << "================    jetEta   =  " << (*jet).eta() << std::endl;
     }
 
-    edm::Ptr<reco::CaloJet> rawcalojet = jet->getCaloJetRef();
+    const edm::RefToBase<reco::Jet> jptjetRef = jet->getCaloJetRef();
+    reco::CaloJet const * rawcalojet = dynamic_cast<reco::CaloJet const *>( &* jptjetRef);
 
     int ncalotowers = 0.;
     double sumpt = 0.;

--- a/RecoJets/JetProducers/src/PileupJPTJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJPTJetIdAlgo.cc
@@ -108,8 +108,7 @@ namespace cms {
       std::cout << "================    jetEta   =  " << (*jet).eta() << std::endl;
     }
 
-    edm::RefToBase<reco::Jet> jptjetRef = jet->getCaloJetRef();
-    reco::CaloJet const* rawcalojet = dynamic_cast<reco::CaloJet const*>(&*jptjetRef);
+    edm::Ptr<reco::CaloJet> rawcalojet = jet->getCaloJetRef();
 
     int ncalotowers = 0.;
     double sumpt = 0.;


### PR DESCRIPTION
#### PR description:

The code adds JPT jets to MiniAOD. It was reported at Jetmet meetings:
https://indico.cern.ch/event/1010496/contributions/4241123/attachments/2194135/3709198/jetmet22022021.pdf
https://indico.cern.ch/event/1072389/contributions/4509543/attachments/2304437/3920302/jmar07092021.pdf
2 collections are added: JPT jets and Calojets that are the source of JPTJets but are absent in slimmedCaloJets. The addional CaloJet collection is needed for (re)-calibration of JPTJets at MiniAOD.

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

scram b runtests -  only as GEN-SIM-RECO file was as input cmsRun ${LOCAL_TEST_DIR}/patMiniAOD_standard_cfg.py || die 'Failure using patMiniAOD_standard_cfg.py' $?
runTheMatrix.py -l limited -i all --ibeos   as it is.
/afs/cern.ch/work/k/kodolova/public/HMUMUBB/CMSSW_12_2_X_2021-12-01-1100/src

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
