### PR TITLE
[HGCAL trigger] Migration to new code structure - First pass

### DIFF
--- a/L1Trigger/L1THGCal/interface/HGCalAlgoWrapperBase.h
+++ b/L1Trigger/L1THGCal/interface/HGCalAlgoWrapperBase.h
@@ -1,0 +1,30 @@
+#ifndef __L1Trigger_L1THGCal_HGCalAlgoWrapperBase_h__
+#define __L1Trigger_L1THGCal_HGCalAlgoWrapperBase_h__
+
+#include "L1Trigger/L1THGCal/interface/HGCalAlgoWrapperBaseT.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/L1THGCal/interface/HGCalCluster.h"
+#include "DataFormats/L1THGCal/interface/HGCalMulticluster.h"
+
+#include "DataFormats/L1THGCal/interface/HGCalTowerMap.h"
+
+#include "FWCore/Framework/interface/EventSetup.h"
+
+typedef HGCalAlgoWrapperBaseT<
+    std::pair<const std::vector<edm::Ptr<l1t::HGCalCluster>>, const std::vector<std::pair<GlobalPoint, double>>>,
+    std::pair<l1t::HGCalMulticlusterBxCollection&, l1t::HGCalClusterBxCollection&>,
+    std::pair<const edm::EventSetup&, const edm::ParameterSet&>>
+    HGCalHistoClusteringWrapperBase;
+
+typedef HGCalAlgoWrapperBaseT<std::vector<edm::Ptr<l1t::HGCalTowerMap>>,
+                              l1t::HGCalTowerBxCollection,
+                              std::pair<const edm::EventSetup&, const edm::ParameterSet&>>
+    HGCalTowerMapsWrapperBase;
+
+#include "FWCore/PluginManager/interface/PluginFactory.h"
+typedef edmplugin::PluginFactory<HGCalHistoClusteringWrapperBase*(const edm::ParameterSet&)>
+    HGCalHistoClusteringWrapperBaseFactory;
+typedef edmplugin::PluginFactory<HGCalTowerMapsWrapperBase*(const edm::ParameterSet&)> HGCalTowerMapsWrapperBaseFactory;
+
+#endif

--- a/L1Trigger/L1THGCal/interface/HGCalAlgoWrapperBase.h
+++ b/L1Trigger/L1THGCal/interface/HGCalAlgoWrapperBase.h
@@ -27,10 +27,18 @@ typedef HGCalAlgoWrapperBaseT<l1t::HGCalMulticlusterBxCollection,
                               std::pair<const edm::EventSetup&, const edm::ParameterSet&>>
     HGCalStage2FilteringWrapperBase;
 
+typedef HGCalAlgoWrapperBaseT<std::vector<edm::Ptr<l1t::HGCalTriggerCell>>,
+                              std::vector<edm::Ptr<l1t::HGCalTriggerCell>>,
+                              std::tuple<const edm::EventSetup&, const unsigned&, const uint32_t&>>
+    HGCalStage1TruncationWrapperBase;
+
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 typedef edmplugin::PluginFactory<HGCalHistoClusteringWrapperBase*(const edm::ParameterSet&)>
     HGCalHistoClusteringWrapperBaseFactory;
 typedef edmplugin::PluginFactory<HGCalTowerMapsWrapperBase*(const edm::ParameterSet&)> HGCalTowerMapsWrapperBaseFactory;
 typedef edmplugin::PluginFactory<HGCalStage2FilteringWrapperBase*(const edm::ParameterSet&)>
     HGCalStage2FilteringWrapperBaseFactory;
+typedef edmplugin::PluginFactory<HGCalStage1TruncationWrapperBase*(const edm::ParameterSet&)>
+    HGCalStage1TruncationWrapperBaseFactory;
+
 #endif

--- a/L1Trigger/L1THGCal/interface/HGCalAlgoWrapperBase.h
+++ b/L1Trigger/L1THGCal/interface/HGCalAlgoWrapperBase.h
@@ -2,6 +2,7 @@
 #define __L1Trigger_L1THGCal_HGCalAlgoWrapperBase_h__
 
 #include "L1Trigger/L1THGCal/interface/HGCalAlgoWrapperBaseT.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DataFormats/L1THGCal/interface/HGCalCluster.h"
@@ -9,27 +10,25 @@
 
 #include "DataFormats/L1THGCal/interface/HGCalTowerMap.h"
 
-#include "FWCore/Framework/interface/EventSetup.h"
-
 typedef HGCalAlgoWrapperBaseT<
     std::pair<const std::vector<edm::Ptr<l1t::HGCalCluster>>, const std::vector<std::pair<GlobalPoint, double>>>,
     std::pair<l1t::HGCalMulticlusterBxCollection&, l1t::HGCalClusterBxCollection&>,
-    std::pair<const edm::EventSetup&, const edm::ParameterSet&>>
+    std::pair<const HGCalTriggerGeometryBase* const, const edm::ParameterSet&>>
     HGCalHistoClusteringWrapperBase;
 
 typedef HGCalAlgoWrapperBaseT<std::vector<edm::Ptr<l1t::HGCalTowerMap>>,
                               l1t::HGCalTowerBxCollection,
-                              std::pair<const edm::EventSetup&, const edm::ParameterSet&>>
+                              std::pair<const HGCalTriggerGeometryBase* const, const edm::ParameterSet&>>
     HGCalTowerMapsWrapperBase;
 
 typedef HGCalAlgoWrapperBaseT<l1t::HGCalMulticlusterBxCollection,
                               l1t::HGCalMulticlusterBxCollection,
-                              std::pair<const edm::EventSetup&, const edm::ParameterSet&>>
+                              std::pair<const HGCalTriggerGeometryBase* const, const edm::ParameterSet&>>
     HGCalStage2FilteringWrapperBase;
 
 typedef HGCalAlgoWrapperBaseT<std::vector<edm::Ptr<l1t::HGCalTriggerCell>>,
                               std::vector<edm::Ptr<l1t::HGCalTriggerCell>>,
-                              std::tuple<const edm::EventSetup&, const unsigned&, const uint32_t&>>
+                              std::tuple<const HGCalTriggerGeometryBase* const, const unsigned&, const uint32_t&>>
     HGCalStage1TruncationWrapperBase;
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"

--- a/L1Trigger/L1THGCal/interface/HGCalAlgoWrapperBase.h
+++ b/L1Trigger/L1THGCal/interface/HGCalAlgoWrapperBase.h
@@ -22,9 +22,15 @@ typedef HGCalAlgoWrapperBaseT<std::vector<edm::Ptr<l1t::HGCalTowerMap>>,
                               std::pair<const edm::EventSetup&, const edm::ParameterSet&>>
     HGCalTowerMapsWrapperBase;
 
+typedef HGCalAlgoWrapperBaseT<l1t::HGCalMulticlusterBxCollection,
+                              l1t::HGCalMulticlusterBxCollection,
+                              std::pair<const edm::EventSetup&, const edm::ParameterSet&>>
+    HGCalStage2FilteringWrapperBase;
+
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 typedef edmplugin::PluginFactory<HGCalHistoClusteringWrapperBase*(const edm::ParameterSet&)>
     HGCalHistoClusteringWrapperBaseFactory;
 typedef edmplugin::PluginFactory<HGCalTowerMapsWrapperBase*(const edm::ParameterSet&)> HGCalTowerMapsWrapperBaseFactory;
-
+typedef edmplugin::PluginFactory<HGCalStage2FilteringWrapperBase*(const edm::ParameterSet&)>
+    HGCalStage2FilteringWrapperBaseFactory;
 #endif

--- a/L1Trigger/L1THGCal/interface/HGCalAlgoWrapperBaseT.h
+++ b/L1Trigger/L1THGCal/interface/HGCalAlgoWrapperBaseT.h
@@ -1,0 +1,23 @@
+#ifndef __L1Trigger_L1THGCal_HGCalAlgoWrapperBaseT_h__
+#define __L1Trigger_L1THGCal_HGCalAlgoWrapperBaseT_h__
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include <string>
+
+template <typename InputCollection, typename OutputCollection, typename Tparam>
+class HGCalAlgoWrapperBaseT {
+public:
+  HGCalAlgoWrapperBaseT(const edm::ParameterSet& conf) : name_(conf.getParameter<std::string>("AlgoName")) {}
+
+  virtual ~HGCalAlgoWrapperBaseT() {}
+
+  virtual void configure(const Tparam& parameters) = 0;
+  virtual void process(const InputCollection& inputCollection, OutputCollection& outputCollection) const = 0;
+
+  const std::string& name() const { return name_; }
+
+private:
+  const std::string name_;
+};
+
+#endif

--- a/L1Trigger/L1THGCal/interface/HGCalProcessorBase.h
+++ b/L1Trigger/L1THGCal/interface/HGCalProcessorBase.h
@@ -19,17 +19,20 @@ typedef HGCalProcessorBaseT<HGCalDigiCollection, l1t::HGCalTriggerCellBxCollecti
 typedef HGCalProcessorBaseT<edm::Handle<l1t::HGCalTriggerCellBxCollection>,
                             std::tuple<l1t::HGCalTriggerCellBxCollection,
                                        l1t::HGCalTriggerSumsBxCollection,
-                                       l1t::HGCalConcentratorDataBxCollection> >
+                                       l1t::HGCalConcentratorDataBxCollection>>
     HGCalConcentratorProcessorBase;
 typedef HGCalProcessorBaseT<edm::Handle<l1t::HGCalTriggerCellBxCollection>, l1t::HGCalClusterBxCollection>
     HGCalBackendLayer1ProcessorBase;
+typedef HGCalProcessorBaseT<std::pair<uint32_t, std::vector<edm::Ptr<l1t::HGCalTriggerCell>>>,
+                            std::vector<edm::Ptr<l1t::HGCalTriggerCell>>>
+    HGCalBackendStage1ProcessorBase;
 typedef HGCalProcessorBaseT<edm::Handle<l1t::HGCalClusterBxCollection>,
-                            std::pair<l1t::HGCalMulticlusterBxCollection, l1t::HGCalClusterBxCollection> >
+                            std::pair<l1t::HGCalMulticlusterBxCollection, l1t::HGCalClusterBxCollection>>
     HGCalBackendLayer2ProcessorBase;
 typedef HGCalProcessorBaseT<edm::Handle<l1t::HGCalTriggerSumsBxCollection>, l1t::HGCalTowerMapBxCollection>
     HGCalTowerMapProcessorBase;
 typedef HGCalProcessorBaseT<
-    std::pair<edm::Handle<l1t::HGCalTowerMapBxCollection>, edm::Handle<l1t::HGCalClusterBxCollection> >,
+    std::pair<edm::Handle<l1t::HGCalTowerMapBxCollection>, edm::Handle<l1t::HGCalClusterBxCollection>>,
     l1t::HGCalTowerBxCollection>
     HGCalTowerProcessorBase;
 
@@ -37,6 +40,7 @@ typedef HGCalProcessorBaseT<
 typedef edmplugin::PluginFactory<HGCalVFEProcessorBase*(const edm::ParameterSet&)> HGCalVFEProcessorBaseFactory;
 typedef edmplugin::PluginFactory<HGCalConcentratorProcessorBase*(const edm::ParameterSet&)> HGCalConcentratorFactory;
 typedef edmplugin::PluginFactory<HGCalBackendLayer1ProcessorBase*(const edm::ParameterSet&)> HGCalBackendLayer1Factory;
+typedef edmplugin::PluginFactory<HGCalBackendStage1ProcessorBase*(const edm::ParameterSet&)> HGCalBackendStage1Factory;
 typedef edmplugin::PluginFactory<HGCalBackendLayer2ProcessorBase*(const edm::ParameterSet&)> HGCalBackendLayer2Factory;
 typedef edmplugin::PluginFactory<HGCalTowerMapProcessorBase*(const edm::ParameterSet&)> HGCalTowerMapFactory;
 typedef edmplugin::PluginFactory<HGCalTowerProcessorBase*(const edm::ParameterSet&)> HGCalTowerFactory;

--- a/L1Trigger/L1THGCal/interface/backend/HGCalBackendLayer1Processor.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalBackendLayer1Processor.h
@@ -1,5 +1,5 @@
-#ifndef __L1Trigger_L1THGCal_HGCalBackendStage1Processor_h__
-#define __L1Trigger_L1THGCal_HGCalBackendStage1Processor_h__
+#ifndef __L1Trigger_L1THGCal_HGCalBackendLayer1Processor_h__
+#define __L1Trigger_L1THGCal_HGCalBackendLayer1Processor_h__
 
 #include "L1Trigger/L1THGCal/interface/HGCalProcessorBase.h"
 
@@ -9,15 +9,16 @@
 #include "L1Trigger/L1THGCal/interface/backend/HGCalStage1TruncationImpl.h"
 #include "L1Trigger/L1THGCal/interface/backend/HGCalClusteringDummyImpl.h"
 
-class HGCalBackendStage1Processor : public HGCalBackendStage1ProcessorBase {
+class HGCalBackendLayer1Processor : public HGCalBackendLayer1ProcessorBase {
 public:
-  HGCalBackendStage1Processor(const edm::ParameterSet& conf);
+  HGCalBackendLayer1Processor(const edm::ParameterSet& conf);
 
-  void run(const std::pair<uint32_t, std::vector<edm::Ptr<l1t::HGCalTriggerCell>>>& fpga_id_tcs,
-           std::vector<edm::Ptr<l1t::HGCalTriggerCell>>& truncated_tcs,
+  void run(const edm::Handle<l1t::HGCalTriggerCellBxCollection>& collHandle,
+           l1t::HGCalClusterBxCollection& collCluster2D,
            const edm::EventSetup& es) override;
 
 private:
+  std::unique_ptr<HGCalClusteringDummyImpl> clusteringDummy_;
   std::unique_ptr<HGCalStage1TruncationImpl> truncation_;
 };
 

--- a/L1Trigger/L1THGCal/interface/backend/HGCalBackendLayer1Processor.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalBackendLayer1Processor.h
@@ -14,8 +14,7 @@ public:
   HGCalBackendLayer1Processor(const edm::ParameterSet& conf);
 
   void run(const edm::Handle<l1t::HGCalTriggerCellBxCollection>& collHandle,
-           l1t::HGCalClusterBxCollection& collCluster2D,
-           const edm::EventSetup& es) override;
+           l1t::HGCalClusterBxCollection& collCluster2D) override;
 
 private:
   std::unique_ptr<HGCalClusteringDummyImpl> clusteringDummy_;

--- a/L1Trigger/L1THGCal/interface/backend/HGCalBackendStage1Processor.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalBackendStage1Processor.h
@@ -2,6 +2,7 @@
 #define __L1Trigger_L1THGCal_HGCalBackendStage1Processor_h__
 
 #include "L1Trigger/L1THGCal/interface/HGCalProcessorBase.h"
+#include "L1Trigger/L1THGCal/interface/HGCalAlgoWrapperBase.h"
 
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
 #include "DataFormats/L1THGCal/interface/HGCalCluster.h"
@@ -18,7 +19,8 @@ public:
            const edm::EventSetup& es) override;
 
 private:
-  std::unique_ptr<HGCalStage1TruncationImpl> truncation_;
+  std::unique_ptr<HGCalStage1TruncationWrapperBase> truncationWrapper_;
+  const edm::ParameterSet conf_;
 };
 
 #endif

--- a/L1Trigger/L1THGCal/interface/backend/HGCalBackendStage1Processor.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalBackendStage1Processor.h
@@ -15,8 +15,7 @@ public:
   HGCalBackendStage1Processor(const edm::ParameterSet& conf);
 
   void run(const std::pair<uint32_t, std::vector<edm::Ptr<l1t::HGCalTriggerCell>>>& fpga_id_tcs,
-           std::vector<edm::Ptr<l1t::HGCalTriggerCell>>& truncated_tcs,
-           const edm::EventSetup& es) override;
+           std::vector<edm::Ptr<l1t::HGCalTriggerCell>>& truncated_tcs) override;
 
 private:
   std::unique_ptr<HGCalStage1TruncationWrapperBase> truncationWrapper_;

--- a/L1Trigger/L1THGCal/interface/backend/HGCalBackendStage1Processor.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalBackendStage1Processor.h
@@ -1,0 +1,25 @@
+#ifndef __L1Trigger_L1THGCal_HGCalBackendStage1Processor_h__
+#define __L1Trigger_L1THGCal_HGCalBackendStage1Processor_h__
+
+#include "L1Trigger/L1THGCal/interface/HGCalProcessorBase.h"
+
+#include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
+#include "DataFormats/L1THGCal/interface/HGCalCluster.h"
+
+#include "L1Trigger/L1THGCal/interface/backend/HGCalStage1TruncationImpl.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalClusteringDummyImpl.h"
+
+class HGCalBackendStage1Processor : public HGCalBackendLayer1ProcessorBase {
+public:
+  HGCalBackendStage1Processor(const edm::ParameterSet& conf);
+
+  void run(const edm::Handle<l1t::HGCalTriggerCellBxCollection>& collHandle,
+           l1t::HGCalClusterBxCollection& collCluster2D,
+           const edm::EventSetup& es) override;
+
+private:
+  std::unique_ptr<HGCalClusteringDummyImpl> clusteringDummy_;
+  std::unique_ptr<HGCalStage1TruncationImpl> truncation_;
+};
+
+#endif

--- a/L1Trigger/L1THGCal/interface/backend/HGCalCluster_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalCluster_SA.h
@@ -1,0 +1,61 @@
+#ifndef L1Trigger_L1THGCal_HGCalCluster_SA_h
+#define L1Trigger_L1THGCal_HGCalCluster_SA_h
+
+#include <vector>
+
+namespace l1thgcfirmware {
+
+  class HGCalCluster {
+  public:
+    HGCalCluster(float x,
+                 float y,
+                 float z,
+                 int zside,
+                 unsigned int layer,
+                 float eta,
+                 float phi,
+                 float pt,
+                 float mipPt,
+                 unsigned int index_cmssw)
+        : x_(x),
+          y_(y),
+          z_(z),
+          zside_(zside),
+          layer_(layer),
+          eta_(eta),
+          phi_(phi),
+          pt_(pt),
+          mipPt_(mipPt),
+          index_cmssw_(index_cmssw) {}
+
+    ~HGCalCluster(){};
+
+    float x() const { return x_; }
+    float y() const { return y_; }
+    float z() const { return z_; }
+    float zside() const { return zside_; }
+    unsigned int layer() const { return layer_; }
+    float eta() const { return eta_; }
+    float phi() const { return phi_; }
+    float pt() const { return pt_; }
+    float mipPt() const { return mipPt_; }
+    unsigned int index_cmssw() const { return index_cmssw_; }
+
+  private:
+    float x_;
+    float y_;
+    float z_;
+    int zside_;
+    unsigned int layer_;
+    float eta_;
+    float phi_;
+    float pt_;
+    float mipPt_;
+    unsigned int index_cmssw_;
+  };
+
+  typedef std::vector<HGCalCluster> HGCalClusterSACollection;
+
+}  // namespace l1thgcfirmware
+
+#endif

--- a/L1Trigger/L1THGCal/interface/backend/HGCalCluster_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalCluster_SA.h
@@ -28,7 +28,7 @@ namespace l1thgcfirmware {
           mipPt_(mipPt),
           index_cmssw_(index_cmssw) {}
 
-    ~HGCalCluster(){};
+    ~HGCalCluster() = default;
 
     float x() const { return x_; }
     float y() const { return y_; }

--- a/L1Trigger/L1THGCal/interface/backend/HGCalHistoClusteringConfig_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalHistoClusteringConfig_SA.h
@@ -1,0 +1,56 @@
+#ifndef __L1Trigger_L1THGCal_HGCalHistoCluteringConfig_SA_h__
+#define __L1Trigger_L1THGCal_HGCalHistoCluteringConfig_SA_h__
+
+#include <vector>
+
+namespace l1thgcfirmware {
+
+  class ClusterAlgoConfig {
+  public:
+    ClusterAlgoConfig(const double midRadius,
+                      const double dr,
+                      const std::vector<double>& dr_byLayer_coefficientA,
+                      const std::vector<double>& dr_byLayer_coefficientB,
+                      const float ptC3dThreshold)
+        : midRadius_(midRadius),
+          dr_(dr),
+          dr_byLayer_coefficientA_(dr_byLayer_coefficientA),
+          dr_byLayer_coefficientB_(dr_byLayer_coefficientB),
+          ptC3dThreshold_(ptC3dThreshold) {}
+
+    void setParameters(double midRadius,
+                       double dr,
+                       const std::vector<double>& dr_byLayer_coefficientA,
+                       const std::vector<double>& dr_byLayer_coefficientB,
+                       float ptC3dThreshold) {
+      midRadius_ = midRadius;
+      dr_ = dr;
+      dr_byLayer_coefficientA_ = dr_byLayer_coefficientA;
+      dr_byLayer_coefficientB_ = dr_byLayer_coefficientB;
+      ptC3dThreshold_ = ptC3dThreshold;
+    }
+
+    void setParameters(const ClusterAlgoConfig& newConfig) {
+      setParameters(newConfig.midRadius(),
+                    newConfig.dr(),
+                    newConfig.dr_byLayer_coefficientA(),
+                    newConfig.dr_byLayer_coefficientB(),
+                    newConfig.ptC3dThreshold());
+    }
+    double midRadius() const { return midRadius_; }
+    double dr() const { return dr_; }
+    const std::vector<double>& dr_byLayer_coefficientA() const { return dr_byLayer_coefficientA_; }
+    const std::vector<double>& dr_byLayer_coefficientB() const { return dr_byLayer_coefficientB_; }
+    float ptC3dThreshold() const { return ptC3dThreshold_; }
+
+  private:
+    double midRadius_;
+    double dr_;
+    std::vector<double> dr_byLayer_coefficientA_;
+    std::vector<double> dr_byLayer_coefficientB_;
+    float ptC3dThreshold_;
+  };
+
+}  // namespace l1thgcfirmware
+
+#endif

--- a/L1Trigger/L1THGCal/interface/backend/HGCalHistoClusteringImpl_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalHistoClusteringImpl_SA.h
@@ -1,0 +1,33 @@
+#ifndef __L1Trigger_L1THGCal_HGCalHistoClusteringImplSA_h__
+#define __L1Trigger_L1THGCal_HGCalHistoClusteringImplSA_h__
+
+#include "L1Trigger/L1THGCal/interface/backend/HGCalCluster_SA.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalSeed_SA.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalMulticluster_SA.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalHistoClusteringConfig_SA.h"
+
+#include <string>
+#include <vector>
+#include <memory>
+
+class HGCalHistoClusteringImplSA {
+public:
+  HGCalHistoClusteringImplSA();
+  ~HGCalHistoClusteringImplSA() {}
+
+  void runAlgorithm() const;
+
+  std::vector<l1thgcfirmware::HGCalMulticluster> clusterSeedMulticluster_SA(
+      const std::vector<l1thgcfirmware::HGCalCluster>& clusters,
+      const std::vector<l1thgcfirmware::HGCalSeed>& seeds,
+      std::vector<l1thgcfirmware::HGCalCluster>& rejected_clusters,
+      const l1thgcfirmware::ClusterAlgoConfig& configuration) const;
+
+  void finalizeClusters_SA(const std::vector<l1thgcfirmware::HGCalMulticluster>&,
+                           const std::vector<l1thgcfirmware::HGCalCluster>&,
+                           std::vector<l1thgcfirmware::HGCalMulticluster>&,
+                           std::vector<l1thgcfirmware::HGCalCluster>&,
+                           const l1thgcfirmware::ClusterAlgoConfig& configuration) const;
+};
+
+#endif

--- a/L1Trigger/L1THGCal/interface/backend/HGCalHistoClusteringImpl_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalHistoClusteringImpl_SA.h
@@ -12,8 +12,8 @@
 
 class HGCalHistoClusteringImplSA {
 public:
-  HGCalHistoClusteringImplSA();
-  ~HGCalHistoClusteringImplSA() {}
+  HGCalHistoClusteringImplSA() = default;
+  ~HGCalHistoClusteringImplSA() = default;
 
   void runAlgorithm() const;
 

--- a/L1Trigger/L1THGCal/interface/backend/HGCalMulticluster_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalMulticluster_SA.h
@@ -1,0 +1,61 @@
+#ifndef L1Trigger_L1THGCal_HGCalMulticluster_SA_h
+#define L1Trigger_L1THGCal_HGCalMulticluster_SA_h
+
+#include "L1Trigger/L1THGCal/interface/backend/HGCalCluster_SA.h"
+
+#include <vector>
+
+namespace l1thgcfirmware {
+
+  class HGCalMulticluster {
+  public:
+    HGCalMulticluster()
+        : hOverEValid_(false),
+          centre_x_(0),
+          centre_y_(0),
+          centre_z_(0),
+          centreProj_x_(0),
+          centreProj_y_(0),
+          centreProj_z_(0),
+          mipPt_(0),
+          sumPt_() {}
+
+    HGCalMulticluster(const l1thgcfirmware::HGCalCluster& tc, float fraction = 1.);
+
+    void addConstituent(const l1thgcfirmware::HGCalCluster& tc, bool updateCentre = true, float fraction = 1.);
+
+    ~HGCalMulticluster(){};
+
+    const std::vector<l1thgcfirmware::HGCalCluster>& constituents() const { return constituents_; }
+
+    unsigned size() const { return constituents_.size(); }
+
+    float sumPt() const { return sumPt_; }
+
+  private:
+    float hOverE_;
+    bool hOverEValid_;
+
+    // Could replace this with own simple implementation of GlobalPoint?
+    // Or just a struct?
+    float centre_x_;
+    float centre_y_;
+    float centre_z_;
+
+    float centreProj_x_;
+    float centreProj_y_;
+    float centreProj_z_;
+
+    float mipPt_;
+    float sumPt_;
+
+    std::vector<l1thgcfirmware::HGCalCluster> constituents_;
+
+    void updateP4AndPosition(const l1thgcfirmware::HGCalCluster& tc, bool updateCentre = true, float fraction = 1.);
+  };
+
+  typedef std::vector<HGCalMulticluster> HGCalMulticlusterSACollection;
+
+}  // namespace l1thgcfirmware
+
+#endif

--- a/L1Trigger/L1THGCal/interface/backend/HGCalMulticluster_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalMulticluster_SA.h
@@ -10,8 +10,7 @@ namespace l1thgcfirmware {
   class HGCalMulticluster {
   public:
     HGCalMulticluster()
-        : hOverEValid_(false),
-          centre_x_(0),
+        : centre_x_(0),
           centre_y_(0),
           centre_z_(0),
           centreProj_x_(0),
@@ -24,7 +23,7 @@ namespace l1thgcfirmware {
 
     void addConstituent(const l1thgcfirmware::HGCalCluster& tc, bool updateCentre = true, float fraction = 1.);
 
-    ~HGCalMulticluster(){};
+    ~HGCalMulticluster() = default;
 
     const std::vector<l1thgcfirmware::HGCalCluster>& constituents() const { return constituents_; }
 
@@ -33,9 +32,6 @@ namespace l1thgcfirmware {
     float sumPt() const { return sumPt_; }
 
   private:
-    float hOverE_;
-    bool hOverEValid_;
-
     // Could replace this with own simple implementation of GlobalPoint?
     // Or just a struct?
     float centre_x_;

--- a/L1Trigger/L1THGCal/interface/backend/HGCalSeed_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalSeed_SA.h
@@ -1,0 +1,28 @@
+#ifndef L1Trigger_L1THGCal_HGCalSeed_SA_h
+#define L1Trigger_L1THGCal_HGCalSeed_SA_h
+
+namespace l1thgcfirmware {
+
+  class HGCalSeed {
+  public:
+    HGCalSeed(float x, float y, float z, float energy) : x_(x), y_(y), z_(z), energy_(energy) {}
+
+    ~HGCalSeed(){};
+
+    float x() const { return x_; }
+    float y() const { return y_; }
+    float z() const { return z_; }
+    float energy() const { return energy_; }
+
+  private:
+    float x_;
+    float y_;
+    float z_;
+    float energy_;
+  };
+
+  typedef std::vector<HGCalSeed> HGCalSeedSACollection;
+
+}  // namespace l1thgcfirmware
+
+#endif

--- a/L1Trigger/L1THGCal/interface/backend/HGCalSortingTruncationConfig_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalSortingTruncationConfig_SA.h
@@ -1,0 +1,22 @@
+#ifndef __L1Trigger_L1THGCal_HGCalSortingTruncationConfig_SA_h__
+#define __L1Trigger_L1THGCal_HGCalSortingTruncationConfig_SA_h__
+
+namespace l1thgcfirmware {
+
+  class SortingTruncationAlgoConfig {
+  public:
+    SortingTruncationAlgoConfig(const unsigned maxTCs) : maxTCs_(maxTCs){};
+
+    void setParameters(unsigned maxTCs) { maxTCs_ = maxTCs; };
+
+    void setParameters(const SortingTruncationAlgoConfig& newConfig) { setParameters(newConfig.maxTCs()); }
+
+    unsigned maxTCs() const { return maxTCs_; }
+
+  private:
+    unsigned maxTCs_;
+  };
+
+}  // namespace l1thgcfirmware
+
+#endif

--- a/L1Trigger/L1THGCal/interface/backend/HGCalSortingTruncationImpl_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalSortingTruncationImpl_SA.h
@@ -1,0 +1,20 @@
+#ifndef __L1Trigger_L1THGCal_HGCalSortingTruncationImplSA_h__
+#define __L1Trigger_L1THGCal_HGCalSortingTruncationImplSA_h__
+
+#include "L1Trigger/L1THGCal/interface/backend/HGCalMulticluster_SA.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalSortingTruncationConfig_SA.h"
+
+#include <vector>
+#include <algorithm>
+
+class HGCalSortingTruncationImplSA {
+public:
+  HGCalSortingTruncationImplSA();
+  ~HGCalSortingTruncationImplSA() {}
+
+  void sortAndTruncate_SA(const std::vector<l1thgcfirmware::HGCalMulticluster>& inputMulticlusters,
+                          std::vector<l1thgcfirmware::HGCalMulticluster>& outputMulticlusters,
+                          const l1thgcfirmware::SortingTruncationAlgoConfig& configuration) const;
+};
+
+#endif

--- a/L1Trigger/L1THGCal/interface/backend/HGCalSortingTruncationImpl_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalSortingTruncationImpl_SA.h
@@ -9,8 +9,8 @@
 
 class HGCalSortingTruncationImplSA {
 public:
-  HGCalSortingTruncationImplSA();
-  ~HGCalSortingTruncationImplSA() {}
+  HGCalSortingTruncationImplSA() = default;
+  ~HGCalSortingTruncationImplSA() = default;
 
   void sortAndTruncate_SA(const std::vector<l1thgcfirmware::HGCalMulticluster>& inputMulticlusters,
                           std::vector<l1thgcfirmware::HGCalMulticluster>& outputMulticlusters,

--- a/L1Trigger/L1THGCal/interface/backend/HGCalStage1TruncationConfig_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalStage1TruncationConfig_SA.h
@@ -1,0 +1,72 @@
+#ifndef __L1Trigger_L1THGCal_HGCalStage1TruncationConfig_SA_h__
+#define __L1Trigger_L1THGCal_HGCalStage1TruncationConfig_SA_h__
+
+#include <vector>
+#include <cstdint>  // uint32_t
+
+namespace l1thgcfirmware {
+
+  class Stage1TruncationConfig {
+  public:
+    Stage1TruncationConfig(const bool do_truncate,
+                           const double roz_min,
+                           const double roz_max,
+                           const unsigned roz_bins,
+                           const std::vector<unsigned>& max_tcs_per_bins,
+                           const std::vector<double>& phi_edges)
+        : do_truncate_(do_truncate),
+          roz_min_(roz_min),
+          roz_max_(roz_max),
+          roz_bins_(roz_bins),
+          max_tcs_per_bins_(max_tcs_per_bins),
+          phi_edges_(phi_edges) {}
+
+    void setParameters(const bool do_truncate,
+                       const double roz_min,
+                       const double roz_max,
+                       const unsigned roz_bins,
+                       const std::vector<unsigned>& max_tcs_per_bins,
+                       const std::vector<double>& phi_edges) {
+      do_truncate_ = do_truncate;
+      roz_min_ = roz_min;
+      roz_max_ = roz_max;
+      roz_bins_ = roz_bins;
+      max_tcs_per_bins_ = max_tcs_per_bins;
+      phi_edges_ = phi_edges;
+    }
+
+    void setParameters(const Stage1TruncationConfig& newConfig) {
+      setParameters(newConfig.doTruncate(),
+                    newConfig.rozMin(),
+                    newConfig.rozMax(),
+                    newConfig.rozBins(),
+                    newConfig.maxTcsPerBin(),
+                    newConfig.phiEdges());
+    }
+
+    void setSector120(const unsigned sector) { sector120_ = sector; }
+    void setFPGAID(const uint32_t fpga_id) { fpga_id_ = fpga_id; }
+
+    bool doTruncate() const { return do_truncate_; }
+    double rozMin() const { return roz_min_; }
+    double rozMax() const { return roz_max_; }
+    unsigned rozBins() const { return roz_bins_; }
+    const std::vector<unsigned>& maxTcsPerBin() const { return max_tcs_per_bins_; }
+    const std::vector<double>& phiEdges() const { return phi_edges_; }
+    unsigned phiSector() const { return sector120_; }
+    uint32_t fpgaID() const { return fpga_id_; }
+
+  private:
+    bool do_truncate_;
+    double roz_min_;
+    double roz_max_;
+    unsigned roz_bins_;
+    std::vector<unsigned> max_tcs_per_bins_;
+    std::vector<double> phi_edges_;
+    unsigned sector120_;
+    uint32_t fpga_id_;
+  };
+
+}  // namespace l1thgcfirmware
+
+#endif

--- a/L1Trigger/L1THGCal/interface/backend/HGCalStage1TruncationImpl.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalStage1TruncationImpl.h
@@ -24,6 +24,7 @@ private:
   static constexpr unsigned mask_roz_ = 0x3f;  // 6 bits, max 64 bins
   static constexpr unsigned mask_phi_ = 1;
 
+  bool do_truncate_;
   double roz_min_ = 0.;
   double roz_max_ = 0.;
   unsigned roz_bins_ = 42;

--- a/L1Trigger/L1THGCal/interface/backend/HGCalStage1TruncationImpl.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalStage1TruncationImpl.h
@@ -1,0 +1,40 @@
+#ifndef __L1Trigger_L1THGCal_HGCalStage1TruncationImpl_h__
+#define __L1Trigger_L1THGCal_HGCalStage1TruncationImpl_h__
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
+
+#include <vector>
+
+class HGCalStage1TruncationImpl {
+public:
+  HGCalStage1TruncationImpl(const edm::ParameterSet& conf);
+
+  void eventSetup(const edm::EventSetup& es) { triggerTools_.eventSetup(es); }
+
+  void run(uint32_t fpga_id,
+           const std::vector<edm::Ptr<l1t::HGCalTriggerCell>>& tcs_in,
+           std::vector<edm::Ptr<l1t::HGCalTriggerCell>>& tcs_out);
+
+private:
+  HGCalTriggerTools triggerTools_;
+
+  static constexpr unsigned offset_roz_ = 1;
+  static constexpr unsigned mask_roz_ = 0x3f;  // 6 bits, max 64 bins
+  static constexpr unsigned mask_phi_ = 1;
+
+  double roz_min_ = 0.;
+  double roz_max_ = 0.;
+  unsigned roz_bins_ = 42;
+  std::vector<unsigned> max_tcs_per_bin_;
+  std::vector<double> phi_edges_;
+  double roz_bin_size_ = 0.;
+
+  uint32_t packBin(unsigned roverzbin, unsigned phibin) const;
+  void unpackBin(unsigned packedbin, unsigned& roverzbin, unsigned& phibin) const;
+  unsigned phiBin(unsigned roverzbin, double phi) const;
+  double rotatedphi(double x, double y, double z, int sector) const;
+};
+
+#endif

--- a/L1Trigger/L1THGCal/interface/backend/HGCalStage1TruncationImpl.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalStage1TruncationImpl.h
@@ -11,7 +11,7 @@ class HGCalStage1TruncationImpl {
 public:
   HGCalStage1TruncationImpl(const edm::ParameterSet& conf);
 
-  void eventSetup(const edm::EventSetup& es) { triggerTools_.eventSetup(es); }
+  void setGeometry(const HGCalTriggerGeometryBase* const geom) { triggerTools_.setGeometry(geom); }
 
   void run(uint32_t fpga_id,
            const std::vector<edm::Ptr<l1t::HGCalTriggerCell>>& tcs_in,

--- a/L1Trigger/L1THGCal/interface/backend/HGCalStage1TruncationImpl_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalStage1TruncationImpl_SA.h
@@ -1,0 +1,41 @@
+#ifndef __L1Trigger_L1THGCal_HGCalStage1TruncationImpl_h__
+#define __L1Trigger_L1THGCal_HGCalStage1TruncationImpl_h__
+
+#include "L1Trigger/L1THGCal/interface/backend/HGCalTriggerCell_SA.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalStage1TruncationConfig_SA.h"
+
+#include <vector>
+#include <cstdint>        // uint32_t, unsigned
+#include <unordered_map>  // std::unordered_map
+#include <algorithm>      // std::sort
+
+class HGCalStage1TruncationImplSA {
+public:
+  HGCalStage1TruncationImplSA();
+  ~HGCalStage1TruncationImplSA() {}
+
+  void runAlgorithm() const;
+
+  unsigned run(const l1thgcfirmware::HGCalTriggerCellSACollection& tcs_in,
+               const l1thgcfirmware::Stage1TruncationConfig& theConf,
+               l1thgcfirmware::HGCalTriggerCellSACollection& tcs_out) const;
+
+private:
+  static constexpr unsigned offset_roz_ = 1;
+  static constexpr unsigned mask_roz_ = 0x3f;  // 6 bits, max 64 bins
+  static constexpr unsigned mask_phi_ = 1;
+
+  bool do_truncate_;
+  double roz_min_ = 0.;
+  double roz_max_ = 0.;
+  unsigned roz_bins_ = 42;
+  std::vector<unsigned> max_tcs_per_bin_;
+  std::vector<double> phi_edges_;
+
+  uint32_t packBin(unsigned roverzbin, unsigned phibin) const;
+  void unpackBin(unsigned packedbin, unsigned& roverzbin, unsigned& phibin) const;
+  int phiBin(unsigned roverzbin, double phi, const std::vector<double>& phiedges) const;
+  double rotatedphi(double x, double y, double z, int sector) const;
+};
+
+#endif

--- a/L1Trigger/L1THGCal/interface/backend/HGCalStage1TruncationImpl_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalStage1TruncationImpl_SA.h
@@ -11,8 +11,8 @@
 
 class HGCalStage1TruncationImplSA {
 public:
-  HGCalStage1TruncationImplSA();
-  ~HGCalStage1TruncationImplSA() {}
+  HGCalStage1TruncationImplSA() = default;
+  ~HGCalStage1TruncationImplSA() = default;
 
   void runAlgorithm() const;
 

--- a/L1Trigger/L1THGCal/interface/backend/HGCalStage2ClusterDistribution.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalStage2ClusterDistribution.h
@@ -1,0 +1,28 @@
+#ifndef __L1Trigger_L1THGCal_HGCalStage2ClusterDistribution_h__
+#define __L1Trigger_L1THGCal_HGCalStage2ClusterDistribution_h__
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+
+#include "DataFormats/L1THGCal/interface/HGCalCluster.h"
+#include "DataFormats/ForwardDetId/interface/HGCalTriggerBackendDetId.h"
+
+class HGCalStage2ClusterDistribution {
+public:
+  HGCalStage2ClusterDistribution(const edm::ParameterSet& conf);
+
+  HGCalTriggerGeometryBase::geom_set getStage2FPGAs(const unsigned stage1_fpga,
+                                                    const HGCalTriggerGeometryBase::geom_set& stage2_fpgas,
+                                                    const edm::Ptr<l1t::HGCalCluster>& tc_ptr) const;
+  unsigned phiBin(unsigned roverzbin, double phi) const;
+  double rotatedphi(double x, double y, double z, int sector) const;
+
+private:
+  double roz_min_ = 0.;
+  double roz_max_ = 0.;
+  unsigned roz_bins_ = 42;
+  std::vector<double> phi_edges_;
+  double roz_bin_size_ = 0.;
+};
+
+#endif

--- a/L1Trigger/L1THGCal/interface/backend/HGCalTowerMapImpl_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalTowerMapImpl_SA.h
@@ -1,0 +1,16 @@
+#ifndef __L1Trigger_L1THGCal_HGCalTowerMapImplSA_h__
+#define __L1Trigger_L1THGCal_HGCalTowerMapImplSA_h__
+
+#include "L1Trigger/L1THGCal/interface/backend/HGCalTower_SA.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalTowerMap_SA.h"
+
+class HGCalTowerMapImplSA {
+public:
+  HGCalTowerMapImplSA() {}
+  ~HGCalTowerMapImplSA() {}
+
+  void runAlgorithm(const std::vector<l1thgcfirmware::HGCalTowerMap>& inputTowerMaps_SA,
+                    std::vector<l1thgcfirmware::HGCalTower>& outputTowers_SA) const;
+};
+
+#endif

--- a/L1Trigger/L1THGCal/interface/backend/HGCalTowerMapImpl_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalTowerMapImpl_SA.h
@@ -6,8 +6,8 @@
 
 class HGCalTowerMapImplSA {
 public:
-  HGCalTowerMapImplSA() {}
-  ~HGCalTowerMapImplSA() {}
+  HGCalTowerMapImplSA() = default;
+  ~HGCalTowerMapImplSA() = default;
 
   void runAlgorithm(const std::vector<l1thgcfirmware::HGCalTowerMap>& inputTowerMaps_SA,
                     std::vector<l1thgcfirmware::HGCalTower>& outputTowers_SA) const;

--- a/L1Trigger/L1THGCal/interface/backend/HGCalTowerMap_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalTowerMap_SA.h
@@ -1,0 +1,30 @@
+#ifndef L1Trigger_L1THGCal_HGCalTowerMap_SA_h
+#define L1Trigger_L1THGCal_HGCalTowerMap_SA_h
+
+#include "L1Trigger/L1THGCal/interface/backend/HGCalTower_SA.h"
+
+#include <unordered_map>
+#include <vector>
+
+namespace l1thgcfirmware {
+
+  class HGCalTowerMap {
+  public:
+    HGCalTowerMap(){};
+    HGCalTowerMap(const std::vector<unsigned short>& tower_ids);
+
+    ~HGCalTowerMap(){};
+
+    HGCalTowerMap& operator+=(const HGCalTowerMap& map);
+
+    bool addEt(short bin_id, float etEm, float etHad);
+
+    const std::unordered_map<unsigned short, l1thgcfirmware::HGCalTower>& towers() const { return towerMap_; }
+
+  private:
+    std::unordered_map<unsigned short, l1thgcfirmware::HGCalTower> towerMap_;
+  };
+
+}  // namespace l1thgcfirmware
+
+#endif

--- a/L1Trigger/L1THGCal/interface/backend/HGCalTowerMap_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalTowerMap_SA.h
@@ -11,7 +11,7 @@ namespace l1thgcfirmware {
   class HGCalTowerMap {
   public:
     HGCalTowerMap(){};
-    HGCalTowerMap(const std::vector<unsigned short>& tower_ids);
+    HGCalTowerMap(const std::vector<l1thgcfirmware::HGCalTowerCoord>& tower_ids);
 
     ~HGCalTowerMap(){};
 

--- a/L1Trigger/L1THGCal/interface/backend/HGCalTowerMap_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalTowerMap_SA.h
@@ -10,10 +10,10 @@ namespace l1thgcfirmware {
 
   class HGCalTowerMap {
   public:
-    HGCalTowerMap(){};
+    HGCalTowerMap() = default;
     HGCalTowerMap(const std::vector<l1thgcfirmware::HGCalTowerCoord>& tower_ids);
 
-    ~HGCalTowerMap(){};
+    ~HGCalTowerMap() = default;
 
     HGCalTowerMap& operator+=(const HGCalTowerMap& map);
 

--- a/L1Trigger/L1THGCal/interface/backend/HGCalTowerMapsConfig_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalTowerMapsConfig_SA.h
@@ -1,0 +1,15 @@
+#ifndef __L1Trigger_L1THGCal_HGCalTowerMapsConfig_SA_h__
+#define __L1Trigger_L1THGCal_HGCalTowerMapsConfig_SA_h__
+
+namespace l1thgcfirmware {
+
+  class TowerMapsAlgoConfig {
+  public:
+    TowerMapsAlgoConfig() {}
+
+    void setParameters(const TowerMapsAlgoConfig& newConfig) {}
+  };
+
+}  // namespace l1thgcfirmware
+
+#endif

--- a/L1Trigger/L1THGCal/interface/backend/HGCalTower_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalTower_SA.h
@@ -1,0 +1,27 @@
+#ifndef L1Trigger_L1THGCal_HGCalTower_SA_h
+#define L1Trigger_L1THGCal_HGCalTower_SA_h
+
+namespace l1thgcfirmware {
+
+  class HGCalTower {
+  public:
+    HGCalTower() {}
+    HGCalTower(double etEm, double etHad) : etEm_(etEm), etHad_(etHad) {}
+
+    ~HGCalTower(){};
+
+    double etEm() const { return etEm_; };
+    double etHad() const { return etHad_; };
+
+    void addEtEm(double et);
+    void addEtHad(double et);
+
+    HGCalTower& operator+=(const HGCalTower& tower);
+
+  private:
+    double etEm_;
+    double etHad_;
+  };
+}  // namespace l1thgcfirmware
+
+#endif

--- a/L1Trigger/L1THGCal/interface/backend/HGCalTower_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalTower_SA.h
@@ -1,17 +1,24 @@
 #ifndef L1Trigger_L1THGCal_HGCalTower_SA_h
 #define L1Trigger_L1THGCal_HGCalTower_SA_h
 
+#include <cstdint>
+
 namespace l1thgcfirmware {
 
   class HGCalTower {
   public:
     HGCalTower() {}
-    HGCalTower(double etEm, double etHad) : etEm_(etEm), etHad_(etHad) {}
+    HGCalTower(double etEm, double etHad, float eta, float phi, uint32_t rawId)
+        : etEm_(etEm), etHad_(etHad), eta_(eta), phi_(phi), id_(rawId) {}
 
     ~HGCalTower(){};
 
-    double etEm() const { return etEm_; };
-    double etHad() const { return etHad_; };
+    double etEm() const { return etEm_; }
+    double etHad() const { return etHad_; }
+
+    float eta() const { return eta_; }
+    float phi() const { return phi_; }
+    uint32_t id() const { return id_; }
 
     void addEtEm(double et);
     void addEtHad(double et);
@@ -21,6 +28,18 @@ namespace l1thgcfirmware {
   private:
     double etEm_;
     double etHad_;
+
+    float eta_;
+    float phi_;
+    uint32_t id_;
+  };
+
+  struct HGCalTowerCoord {
+    HGCalTowerCoord(uint32_t rawId, float eta, float phi) : rawId(rawId), eta(eta), phi(phi) {}
+
+    const uint32_t rawId;
+    const float eta;
+    const float phi;
   };
 }  // namespace l1thgcfirmware
 

--- a/L1Trigger/L1THGCal/interface/backend/HGCalTower_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalTower_SA.h
@@ -7,11 +7,11 @@ namespace l1thgcfirmware {
 
   class HGCalTower {
   public:
-    HGCalTower() {}
+    HGCalTower() = default;
     HGCalTower(double etEm, double etHad, float eta, float phi, uint32_t rawId)
         : etEm_(etEm), etHad_(etHad), eta_(eta), phi_(phi), id_(rawId) {}
 
-    ~HGCalTower(){};
+    ~HGCalTower() = default;
 
     double etEm() const { return etEm_; }
     double etHad() const { return etHad_; }

--- a/L1Trigger/L1THGCal/interface/backend/HGCalTriggerCell_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalTriggerCell_SA.h
@@ -1,0 +1,63 @@
+#ifndef L1Trigger_L1THGCal_HGCalTriggerCell_SA_h
+#define L1Trigger_L1THGCal_HGCalTriggerCell_SA_h
+
+#include <vector>
+
+namespace l1thgcfirmware {
+
+  class HGCalTriggerCell {
+  public:
+    HGCalTriggerCell(){};
+
+    HGCalTriggerCell(float x,
+                     float y,
+                     float z,
+                     int zside,
+                     unsigned int layer,
+                     float eta,
+                     float phi,
+                     float pt,
+                     float mipPt,
+                     unsigned int index_cmssw)
+        : x_(x),
+          y_(y),
+          z_(z),
+          zside_(zside),
+          layer_(layer),
+          eta_(eta),
+          phi_(phi),
+          pt_(pt),
+          mipPt_(mipPt),
+          index_cmssw_(index_cmssw) {}
+
+    ~HGCalTriggerCell(){};
+
+    float x() const { return x_; }
+    float y() const { return y_; }
+    float z() const { return z_; }
+    float zside() const { return zside_; }
+    unsigned int layer() const { return layer_; }
+    float eta() const { return eta_; }
+    float phi() const { return phi_; }
+    float pt() const { return pt_; }
+    float mipPt() const { return mipPt_; }
+    unsigned int index_cmssw() const { return index_cmssw_; }
+
+  private:
+    float x_;
+    float y_;
+    float z_;
+    int zside_;
+    unsigned int layer_;
+    float eta_;
+    float phi_;
+    float pt_;
+    float mipPt_;
+    unsigned int index_cmssw_;
+  };
+
+  typedef std::vector<HGCalTriggerCell> HGCalTriggerCellSACollection;
+
+}  // namespace l1thgcfirmware
+
+#endif

--- a/L1Trigger/L1THGCal/interface/backend/HGCalTriggerCell_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalTriggerCell_SA.h
@@ -7,7 +7,7 @@ namespace l1thgcfirmware {
 
   class HGCalTriggerCell {
   public:
-    HGCalTriggerCell(){};
+    HGCalTriggerCell() = default;
 
     HGCalTriggerCell(float x,
                      float y,
@@ -30,7 +30,7 @@ namespace l1thgcfirmware {
           mipPt_(mipPt),
           index_cmssw_(index_cmssw) {}
 
-    ~HGCalTriggerCell(){};
+    ~HGCalTriggerCell() = default;
 
     float x() const { return x_; }
     float y() const { return y_; }

--- a/L1Trigger/L1THGCal/plugins/HGCalBackendStage1Producer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalBackendStage1Producer.cc
@@ -59,6 +59,8 @@ HGCalBackendStage1Producer::HGCalBackendStage1Producer(const edm::ParameterSet& 
 void HGCalBackendStage1Producer::beginRun(const edm::Run& /*run*/, const edm::EventSetup& es) {
   triggerGeometry_ = es.getHandle(triggerGeomToken_);
   backendProcess_->setGeometry(triggerGeometry_.product());
+  if (clusteringDummy_)
+    clusteringDummy_->setGeometry(triggerGeometry_.product());
 }
 
 void HGCalBackendStage1Producer::produce(edm::Event& e, const edm::EventSetup& es) {
@@ -69,9 +71,6 @@ void HGCalBackendStage1Producer::produce(edm::Event& e, const edm::EventSetup& e
   edm::Handle<l1t::HGCalTriggerCellBxCollection> trigCellBxColl;
 
   // Split trigger cell collection per FPGA
-  if (clusteringDummy_)
-    clusteringDummy_->eventSetup(es);
-
   e.getByToken(input_cell_, trigCellBxColl);
 
   std::unordered_map<uint32_t, std::vector<edm::Ptr<l1t::HGCalTriggerCell>>> tcs_per_fpga;
@@ -87,7 +86,7 @@ void HGCalBackendStage1Producer::produce(edm::Event& e, const edm::EventSetup& e
   std::vector<edm::Ptr<l1t::HGCalTriggerCell>> truncated_tcs;
 
   for (auto& fpga_tcs : tcs_per_fpga) {
-    backendProcess_->run(fpga_tcs, truncated_tcs, es);
+    backendProcess_->run(fpga_tcs, truncated_tcs);
   }
 
   // Merge truncated tc collections

--- a/L1Trigger/L1THGCal/plugins/HGCalBackendStage1Producer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalBackendStage1Producer.cc
@@ -1,0 +1,97 @@
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+
+#include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
+#include "DataFormats/L1THGCal/interface/HGCalTriggerSums.h"
+#include "DataFormats/HGCDigi/interface/HGCDigiCollections.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+
+#include "L1Trigger/L1THGCal/interface/HGCalProcessorBase.h"
+
+#include "DataFormats/L1THGCal/interface/HGCalCluster.h"
+
+#include "L1Trigger/L1THGCal/interface/backend/HGCalClusteringDummyImpl.h"
+#include "L1Trigger/L1THGCal/interface/HGCalProcessorBase.h"
+
+#include <memory>
+
+class HGCalBackendStage1Producer : public edm::stream::EDProducer<> {
+public:
+  HGCalBackendStage1Producer(const edm::ParameterSet&);
+  ~HGCalBackendStage1Producer() override {}
+
+  void beginRun(const edm::Run&, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
+private:
+  // inputs
+  edm::EDGetToken input_cell_, input_sums_;
+  edm::ESHandle<HGCalTriggerGeometryBase> triggerGeometry_;
+  edm::ESGetToken<HGCalTriggerGeometryBase, CaloGeometryRecord> triggerGeomToken_;
+
+  std::unique_ptr<HGCalBackendStage1ProcessorBase> backendProcess_;
+
+  std::unique_ptr<HGCalClusteringDummyImpl> clusteringDummy_;
+};
+
+DEFINE_FWK_MODULE(HGCalBackendStage1Producer);
+
+HGCalBackendStage1Producer::HGCalBackendStage1Producer(const edm::ParameterSet& conf)
+    : input_cell_(consumes<l1t::HGCalTriggerCellBxCollection>(conf.getParameter<edm::InputTag>("InputTriggerCells"))),
+      triggerGeomToken_(esConsumes<HGCalTriggerGeometryBase, CaloGeometryRecord, edm::Transition::BeginRun>()) {
+  //setup Backend parameters
+  const edm::ParameterSet& beParamConfig = conf.getParameterSet("ProcessorParameters");
+  const std::string& beProcessorName = beParamConfig.getParameter<std::string>("ProcessorName");
+
+  clusteringDummy_ = std::make_unique<HGCalClusteringDummyImpl>(conf.getParameterSet("C2d_parameters"));
+
+  backendProcess_ = std::unique_ptr<HGCalBackendStage1ProcessorBase>{
+      HGCalBackendStage1Factory::get()->create(beProcessorName, beParamConfig)};
+
+  produces<l1t::HGCalClusterBxCollection>(backendProcess_->name());
+}
+
+void HGCalBackendStage1Producer::beginRun(const edm::Run& /*run*/, const edm::EventSetup& es) {
+  triggerGeometry_ = es.getHandle(triggerGeomToken_);
+  backendProcess_->setGeometry(triggerGeometry_.product());
+}
+
+void HGCalBackendStage1Producer::produce(edm::Event& e, const edm::EventSetup& es) {
+  // Output collections
+  auto be_cluster_output = std::make_unique<l1t::HGCalClusterBxCollection>();
+
+  // Input collections
+  edm::Handle<l1t::HGCalTriggerCellBxCollection> trigCellBxColl;
+
+  // Split trigger cell collection per FPGA
+  if (clusteringDummy_)
+    clusteringDummy_->eventSetup(es);
+
+  e.getByToken(input_cell_, trigCellBxColl);
+
+  std::unordered_map<uint32_t, std::vector<edm::Ptr<l1t::HGCalTriggerCell>>> tcs_per_fpga;
+
+  for (unsigned i = 0; i < trigCellBxColl->size(); ++i) {
+    edm::Ptr<l1t::HGCalTriggerCell> tc_ptr(trigCellBxColl, i);
+    uint32_t module = triggerGeometry_->getModuleFromTriggerCell(tc_ptr->detId());
+    uint32_t fpga = triggerGeometry_->getStage1FpgaFromModule(module);
+    tcs_per_fpga[fpga].push_back(tc_ptr);
+  }
+
+  // Apply truncation per FPGA
+  std::vector<edm::Ptr<l1t::HGCalTriggerCell>> truncated_tcs;
+
+  for (auto& fpga_tcs : tcs_per_fpga) {
+    backendProcess_->run(fpga_tcs, truncated_tcs, es);
+  }
+
+  // Merge truncated tc collections
+  clusteringDummy_->clusterizeDummy(truncated_tcs, *be_cluster_output);
+
+  e.put(std::move(be_cluster_output), backendProcess_->name());
+}

--- a/L1Trigger/L1THGCal/plugins/HGCalBackendStage1Producer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalBackendStage1Producer.cc
@@ -23,16 +23,16 @@
 class HGCalBackendStage1Producer : public edm::stream::EDProducer<> {
 public:
   HGCalBackendStage1Producer(const edm::ParameterSet&);
-  ~HGCalBackendStage1Producer() override {}
+  ~HGCalBackendStage1Producer() override = default;
 
   void beginRun(const edm::Run&, const edm::EventSetup&) override;
   void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
   // inputs
-  edm::EDGetToken input_cell_, input_sums_;
+  const edm::EDGetToken input_cell_;
   edm::ESHandle<HGCalTriggerGeometryBase> triggerGeometry_;
-  edm::ESGetToken<HGCalTriggerGeometryBase, CaloGeometryRecord> triggerGeomToken_;
+  const edm::ESGetToken<HGCalTriggerGeometryBase, CaloGeometryRecord> triggerGeomToken_;
 
   std::unique_ptr<HGCalBackendStage1ProcessorBase> backendProcess_;
 

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalBackendLayer1Processor.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalBackendLayer1Processor.cc
@@ -1,0 +1,33 @@
+#include "L1Trigger/L1THGCal/interface/backend/HGCalBackendLayer1Processor.h"
+
+DEFINE_EDM_PLUGIN(HGCalBackendLayer1Factory, HGCalBackendLayer1Processor, "HGCalBackendLayer1Processor");
+
+HGCalBackendLayer1Processor::HGCalBackendLayer1Processor(const edm::ParameterSet& conf)
+    : HGCalBackendLayer1ProcessorBase(conf) {
+  clusteringDummy_ = std::make_unique<HGCalClusteringDummyImpl>(conf.getParameterSet("C2d_parameters"));
+  truncation_ = std::make_unique<HGCalStage1TruncationImpl>(conf.getParameterSet("truncation_parameters"));
+}
+
+void HGCalBackendLayer1Processor::run(const edm::Handle<l1t::HGCalTriggerCellBxCollection>& collHandle,
+                                      l1t::HGCalClusterBxCollection& collCluster2D,
+                                      const edm::EventSetup& es) {
+  if (clusteringDummy_)
+    clusteringDummy_->eventSetup(es);
+  if (truncation_)
+    truncation_->eventSetup(es);
+
+  std::unordered_map<uint32_t, std::vector<edm::Ptr<l1t::HGCalTriggerCell>>> tcs_per_fpga;
+
+  for (unsigned i = 0; i < collHandle->size(); ++i) {
+    edm::Ptr<l1t::HGCalTriggerCell> tc_ptr(collHandle, i);
+    uint32_t module = geometry_->getModuleFromTriggerCell(tc_ptr->detId());
+    uint32_t fpga = geometry_->getStage1FpgaFromModule(module);
+    tcs_per_fpga[fpga].push_back(tc_ptr);
+  }
+
+  std::vector<edm::Ptr<l1t::HGCalTriggerCell>> truncated_tcs;
+  for (auto& fpga_tcs : tcs_per_fpga) {
+    truncation_->run(fpga_tcs.first, fpga_tcs.second, truncated_tcs);
+  }
+  clusteringDummy_->clusterizeDummy(truncated_tcs, collCluster2D);
+}

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalBackendLayer1Processor.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalBackendLayer1Processor.cc
@@ -9,19 +9,18 @@ HGCalBackendLayer1Processor::HGCalBackendLayer1Processor(const edm::ParameterSet
 }
 
 void HGCalBackendLayer1Processor::run(const edm::Handle<l1t::HGCalTriggerCellBxCollection>& collHandle,
-                                      l1t::HGCalClusterBxCollection& collCluster2D,
-                                      const edm::EventSetup& es) {
+                                      l1t::HGCalClusterBxCollection& collCluster2D) {
   if (clusteringDummy_)
-    clusteringDummy_->eventSetup(es);
+    clusteringDummy_->setGeometry(geometry());
   if (truncation_)
-    truncation_->eventSetup(es);
+    truncation_->setGeometry(geometry());
 
   std::unordered_map<uint32_t, std::vector<edm::Ptr<l1t::HGCalTriggerCell>>> tcs_per_fpga;
 
   for (unsigned i = 0; i < collHandle->size(); ++i) {
     edm::Ptr<l1t::HGCalTriggerCell> tc_ptr(collHandle, i);
-    uint32_t module = geometry_->getModuleFromTriggerCell(tc_ptr->detId());
-    uint32_t fpga = geometry_->getStage1FpgaFromModule(module);
+    uint32_t module = geometry()->getModuleFromTriggerCell(tc_ptr->detId());
+    uint32_t fpga = geometry()->getStage1FpgaFromModule(module);
     tcs_per_fpga[fpga].push_back(tc_ptr);
   }
 

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalBackendLayer2Processor3DClustering_SA.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalBackendLayer2Processor3DClustering_SA.cc
@@ -1,0 +1,91 @@
+#include "L1Trigger/L1THGCal/interface/HGCalProcessorBase.h"
+
+#include "DataFormats/L1THGCal/interface/HGCalCluster.h"
+#include "DataFormats/L1THGCal/interface/HGCalMulticluster.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalHistoSeedingImpl.h"
+#include "L1Trigger/L1THGCal/interface/HGCalAlgoWrapperBase.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalTriggerClusterInterpreterBase.h"
+
+#include <utility>
+
+class HGCalBackendLayer2Processor3DClusteringSA : public HGCalBackendLayer2ProcessorBase {
+public:
+  HGCalBackendLayer2Processor3DClusteringSA(const edm::ParameterSet& conf)
+      : HGCalBackendLayer2ProcessorBase(conf), conf_(conf) {
+    multiclusteringHistoSeeding_ = std::make_unique<HGCalHistoSeedingImpl>(
+        conf.getParameterSet("C3d_parameters").getParameterSet("histoMax_C3d_seeding_parameters"));
+
+    const edm::ParameterSet& clusteringParamConfig =
+        conf.getParameterSet("C3d_parameters").getParameterSet("histoMax_C3d_clustering_parameters");
+    const std::string& clusteringAlgoWrapperName = clusteringParamConfig.getParameter<std::string>("AlgoName");
+    multiclusteringHistoClusteringWrapper_ = std::unique_ptr<HGCalHistoClusteringWrapperBase>{
+        HGCalHistoClusteringWrapperBaseFactory::get()->create(clusteringAlgoWrapperName, clusteringParamConfig)};
+
+    for (const auto& interpretationPset : conf.getParameter<std::vector<edm::ParameterSet>>("energy_interpretations")) {
+      std::unique_ptr<HGCalTriggerClusterInterpreterBase> interpreter{
+          HGCalTriggerClusterInterpreterFactory::get()->create(interpretationPset.getParameter<std::string>("type"))};
+      interpreter->initialize(interpretationPset);
+      energy_interpreters_.push_back(std::move(interpreter));
+    }
+  }
+
+  void run(const edm::Handle<l1t::HGCalClusterBxCollection>& collHandle,
+           std::pair<l1t::HGCalMulticlusterBxCollection, l1t::HGCalClusterBxCollection>& be_output,
+           const edm::EventSetup& es) override {
+    es.get<CaloGeometryRecord>().get("", triggerGeometry_);
+    if (multiclusteringHistoSeeding_)
+      multiclusteringHistoSeeding_->eventSetup(es);
+    l1t::HGCalMulticlusterBxCollection& collCluster3D = be_output.first;
+    l1t::HGCalClusterBxCollection& rejectedClusters = be_output.second;
+
+    /* create a persistent vector of pointers to the trigger-cells */
+    std::vector<edm::Ptr<l1t::HGCalCluster>> clustersPtrs;
+    for (unsigned i = 0; i < collHandle->size(); ++i) {
+      edm::Ptr<l1t::HGCalCluster> ptr(collHandle, i);
+      clustersPtrs.push_back(ptr);
+    }
+
+    /* create a vector of seed positions and their energy*/
+    std::vector<std::pair<GlobalPoint, double>> seedPositionsEnergy;
+
+    /* call to multiclustering and compute shower shape*/
+    multiclusteringHistoSeeding_->findHistoSeeds(clustersPtrs, seedPositionsEnergy);
+
+    // Inputs
+    std::pair<const std::vector<edm::Ptr<l1t::HGCalCluster>>&, const std::vector<std::pair<GlobalPoint, double>>&>
+        inputClustersAndSeeds{clustersPtrs, seedPositionsEnergy};
+    // Outputs
+    std::pair<l1t::HGCalMulticlusterBxCollection&, l1t::HGCalClusterBxCollection&>
+        outputMulticlustersAndRejectedClusters{collCluster3D, rejectedClusters};
+    // Configuration
+    const std::pair<const edm::EventSetup&, const edm::ParameterSet&> configuration{es, conf_};
+
+    // Configure and process
+    multiclusteringHistoClusteringWrapper_->configure(configuration);
+    multiclusteringHistoClusteringWrapper_->process(inputClustersAndSeeds, outputMulticlustersAndRejectedClusters);
+
+    // Call all the energy interpretation modules on the cluster collection
+    for (const auto& interpreter : energy_interpreters_) {
+      interpreter->eventSetup(es);
+      interpreter->interpret(collCluster3D);
+    }
+  }
+
+private:
+  edm::ESHandle<HGCalTriggerGeometryBase> triggerGeometry_;
+
+  /* algorithms instances */
+  std::unique_ptr<HGCalHistoSeedingImpl> multiclusteringHistoSeeding_;
+
+  std::unique_ptr<HGCalHistoClusteringWrapperBase> multiclusteringHistoClusteringWrapper_;
+
+  std::vector<std::unique_ptr<HGCalTriggerClusterInterpreterBase>> energy_interpreters_;
+
+  const edm::ParameterSet conf_;
+};
+
+DEFINE_EDM_PLUGIN(HGCalBackendLayer2Factory,
+                  HGCalBackendLayer2Processor3DClusteringSA,
+                  "HGCalBackendLayer2Processor3DClusteringSA");

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalBackendLayer2Processor3DClustering_SA.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalBackendLayer2Processor3DClustering_SA.cc
@@ -15,7 +15,9 @@
 class HGCalBackendLayer2Processor3DClusteringSA : public HGCalBackendLayer2ProcessorBase {
 public:
   HGCalBackendLayer2Processor3DClusteringSA(const edm::ParameterSet& conf)
-      : HGCalBackendLayer2ProcessorBase(conf), conf_(conf) {
+      : HGCalBackendLayer2ProcessorBase(conf),
+        distributor_(conf.getParameterSet("DistributionParameters")),
+        conf_(conf) {
     multiclusteringHistoSeeding_ = std::make_unique<HGCalHistoSeedingImpl>(
         conf.getParameterSet("C3d_parameters").getParameterSet("histoMax_C3d_seeding_parameters"));
 
@@ -57,10 +59,8 @@ public:
       uint32_t stage1_fpga = geometry()->getStage1FpgaFromModule(module);
       HGCalTriggerGeometryBase::geom_set possible_stage2_fpgas = geometry()->getStage2FpgasFromStage1Fpga(stage1_fpga);
 
-      HGCalStage2ClusterDistribution distributor(conf_.getParameterSet("DistributionParameters"));
-
       HGCalTriggerGeometryBase::geom_set stage2_fpgas =
-          distributor.getStage2FPGAs(stage1_fpga, possible_stage2_fpgas, tc_ptr);
+          distributor_.getStage2FPGAs(stage1_fpga, possible_stage2_fpgas, tc_ptr);
 
       for (auto& fpga : stage2_fpgas) {
         tcs_per_fpga[fpga].push_back(tc_ptr);
@@ -121,6 +121,7 @@ private:
 
   std::vector<std::unique_ptr<HGCalTriggerClusterInterpreterBase>> energy_interpreters_;
 
+  HGCalStage2ClusterDistribution distributor_;
   const edm::ParameterSet conf_;
 };
 

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalBackendStage1Processor.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalBackendStage1Processor.cc
@@ -14,13 +14,13 @@ HGCalBackendStage1Processor::HGCalBackendStage1Processor(const edm::ParameterSet
 
 void HGCalBackendStage1Processor::run(
     const std::pair<uint32_t, std::vector<edm::Ptr<l1t::HGCalTriggerCell>>>& fpga_id_tcs,
-    std::vector<edm::Ptr<l1t::HGCalTriggerCell>>& truncated_tcs,
-    const edm::EventSetup& es) {
+    std::vector<edm::Ptr<l1t::HGCalTriggerCell>>& truncated_tcs) {
   const unsigned sector120 = HGCalTriggerBackendDetId(fpga_id_tcs.first).sector();
   const uint32_t fpga_id = fpga_id_tcs.first;
 
   // Configuration
-  const std::tuple<const edm::EventSetup&, unsigned, uint32_t> configuration{es, sector120, fpga_id};
+  const std::tuple<const HGCalTriggerGeometryBase* const, unsigned, uint32_t> configuration{
+      geometry(), sector120, fpga_id};
   truncationWrapper_->configure(configuration);
 
   truncationWrapper_->process(fpga_id_tcs.second, truncated_tcs);

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalBackendStage1Processor.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalBackendStage1Processor.cc
@@ -1,0 +1,33 @@
+#include "L1Trigger/L1THGCal/interface/backend/HGCalBackendStage1Processor.h"
+
+DEFINE_EDM_PLUGIN(HGCalBackendLayer1Factory, HGCalBackendStage1Processor, "HGCalBackendStage1Processor");
+
+HGCalBackendStage1Processor::HGCalBackendStage1Processor(const edm::ParameterSet& conf)
+    : HGCalBackendLayer1ProcessorBase(conf) {
+  clusteringDummy_ = std::make_unique<HGCalClusteringDummyImpl>(conf.getParameterSet("C2d_parameters"));
+  truncation_ = std::make_unique<HGCalStage1TruncationImpl>(conf.getParameterSet("truncation_parameters"));
+}
+
+void HGCalBackendStage1Processor::run(const edm::Handle<l1t::HGCalTriggerCellBxCollection>& collHandle,
+                                      l1t::HGCalClusterBxCollection& collCluster2D,
+                                      const edm::EventSetup& es) {
+  if (clusteringDummy_)
+    clusteringDummy_->eventSetup(es);
+  if (truncation_)
+    truncation_->eventSetup(es);
+
+  std::unordered_map<uint32_t, std::vector<edm::Ptr<l1t::HGCalTriggerCell>>> tcs_per_fpga;
+
+  for (unsigned i = 0; i < collHandle->size(); ++i) {
+    edm::Ptr<l1t::HGCalTriggerCell> tc_ptr(collHandle, i);
+    uint32_t module = geometry_->getModuleFromTriggerCell(tc_ptr->detId());
+    uint32_t fpga = geometry_->getStage1FpgaFromModule(module);
+    tcs_per_fpga[fpga].push_back(tc_ptr);
+  }
+
+  std::vector<edm::Ptr<l1t::HGCalTriggerCell>> truncated_tcs;
+  for (auto& fpga_tcs : tcs_per_fpga) {
+    truncation_->run(fpga_tcs.first, fpga_tcs.second, truncated_tcs);
+  }
+  clusteringDummy_->clusterizeDummy(truncated_tcs, collCluster2D);
+}

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalBackendStage1Processor.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalBackendStage1Processor.cc
@@ -1,18 +1,27 @@
 #include "L1Trigger/L1THGCal/interface/backend/HGCalBackendStage1Processor.h"
+#include "DataFormats/ForwardDetId/interface/HGCalTriggerBackendDetId.h"
 
 DEFINE_EDM_PLUGIN(HGCalBackendStage1Factory, HGCalBackendStage1Processor, "HGCalBackendStage1Processor");
 
 HGCalBackendStage1Processor::HGCalBackendStage1Processor(const edm::ParameterSet& conf)
-    : HGCalBackendStage1ProcessorBase(conf) {
-  truncation_ = std::make_unique<HGCalStage1TruncationImpl>(conf.getParameterSet("truncation_parameters"));
+    : HGCalBackendStage1ProcessorBase(conf), conf_(conf) {
+  const edm::ParameterSet& truncationParamConfig = conf.getParameterSet("truncation_parameters");
+  const std::string& truncationWrapperName = truncationParamConfig.getParameter<std::string>("AlgoName");
+
+  truncationWrapper_ = std::unique_ptr<HGCalStage1TruncationWrapperBase>{
+      HGCalStage1TruncationWrapperBaseFactory::get()->create(truncationWrapperName, truncationParamConfig)};
 }
 
 void HGCalBackendStage1Processor::run(
     const std::pair<uint32_t, std::vector<edm::Ptr<l1t::HGCalTriggerCell>>>& fpga_id_tcs,
     std::vector<edm::Ptr<l1t::HGCalTriggerCell>>& truncated_tcs,
     const edm::EventSetup& es) {
-  if (truncation_)
-    truncation_->eventSetup(es);
+  const unsigned sector120 = HGCalTriggerBackendDetId(fpga_id_tcs.first).sector();
+  const uint32_t fpga_id = fpga_id_tcs.first;
 
-  truncation_->run(fpga_id_tcs.first, fpga_id_tcs.second, truncated_tcs);
+  // Configuration
+  const std::tuple<const edm::EventSetup&, unsigned, uint32_t> configuration{es, sector120, fpga_id};
+  truncationWrapper_->configure(configuration);
+
+  truncationWrapper_->process(fpga_id_tcs.second, truncated_tcs);
 }

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalHistoClusteringWrapper.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalHistoClusteringWrapper.cc
@@ -1,0 +1,185 @@
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "L1Trigger/L1THGCal/interface/HGCalAlgoWrapperBase.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalHistoClusteringImpl_SA.h"
+
+#include "DataFormats/L1THGCal/interface/HGCalCluster.h"
+#include "DataFormats/L1THGCal/interface/HGCalMulticluster.h"
+
+#include "L1Trigger/L1THGCal/interface/backend/HGCalCluster_SA.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalSeed_SA.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalMulticluster_SA.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
+
+class HGCalHistoClusteringWrapper : public HGCalHistoClusteringWrapperBase {
+public:
+  HGCalHistoClusteringWrapper(const edm::ParameterSet& conf);
+  ~HGCalHistoClusteringWrapper() override {}
+
+  void configure(const std::pair<const edm::EventSetup&, const edm::ParameterSet&>& configuration) override;
+
+  void process(const std::pair<const std::vector<edm::Ptr<l1t::HGCalCluster>>,
+                               const std::vector<std::pair<GlobalPoint, double>>>& inputClustersAndSeeds,
+               std::pair<l1t::HGCalMulticlusterBxCollection&, l1t::HGCalClusterBxCollection&>&
+                   outputMulticlustersAndRejectedClusters) const override;
+
+private:
+  void convertCMSSWInputs(const std::vector<edm::Ptr<l1t::HGCalCluster>>& clustersPtrs,
+                          l1thgcfirmware::HGCalClusterSACollection& clusters_SA,
+                          const std::vector<std::pair<GlobalPoint, double>>& seeds,
+                          l1thgcfirmware::HGCalSeedSACollection& seeds_SA) const;
+  void convertAlgorithmOutputs(const l1thgcfirmware::HGCalMulticlusterSACollection& multiclusters_out,
+                               const l1thgcfirmware::HGCalClusterSACollection& rejected_clusters_out,
+                               const std::vector<edm::Ptr<l1t::HGCalCluster>>& clustersPtrs,
+                               l1t::HGCalMulticlusterBxCollection& multiclusters,
+                               l1t::HGCalClusterBxCollection& rejected_clusters) const;
+
+  void clusterizeHisto(const l1thgcfirmware::HGCalClusterSACollection& inputClusters,
+                       const l1thgcfirmware::HGCalSeedSACollection& inputSeeds,
+                       l1thgcfirmware::HGCalMulticlusterSACollection& outputMulticlusters,
+                       l1thgcfirmware::HGCalClusterSACollection& outputRejectedClusters) const;
+
+  void eventSetup(const edm::EventSetup& es) { triggerTools_.eventSetup(es); }
+
+  HGCalTriggerTools triggerTools_;
+
+  HGCalHistoClusteringImplSA theAlgo_;
+
+  l1thgcfirmware::ClusterAlgoConfig theConfiguration_;
+
+  static constexpr double kMidRadius_ = 2.3;
+};
+
+HGCalHistoClusteringWrapper::HGCalHistoClusteringWrapper(const edm::ParameterSet& conf)
+    : HGCalHistoClusteringWrapperBase(conf),
+      theAlgo_(),
+      theConfiguration_(kMidRadius_,
+                        conf.getParameter<double>("dR_multicluster"),
+                        conf.existsAs<std::vector<double>>("dR_multicluster_byLayer_coefficientA")
+                            ? conf.getParameter<std::vector<double>>("dR_multicluster_byLayer_coefficientA")
+                            : std::vector<double>(),
+                        conf.existsAs<std::vector<double>>("dR_multicluster_byLayer_coefficientB")
+                            ? conf.getParameter<std::vector<double>>("dR_multicluster_byLayer_coefficientB")
+                            : std::vector<double>(),
+                        conf.getParameter<double>("minPt_multicluster")) {}
+
+void HGCalHistoClusteringWrapper::convertCMSSWInputs(const std::vector<edm::Ptr<l1t::HGCalCluster>>& clustersPtrs,
+                                                     std::vector<l1thgcfirmware::HGCalCluster>& clusters_SA,
+                                                     const std::vector<std::pair<GlobalPoint, double>>& seeds,
+                                                     std::vector<l1thgcfirmware::HGCalSeed>& seeds_SA) const {
+  clusters_SA.clear();
+  clusters_SA.reserve(clustersPtrs.size());
+  unsigned int clusterIndex = 0;
+  for (const auto& cluster : clustersPtrs) {
+    clusters_SA.emplace_back(cluster->centreProj().x(),
+                             cluster->centreProj().y(),
+                             cluster->centre().z(),
+                             triggerTools_.zside(cluster->detId()),
+                             triggerTools_.layerWithOffset(cluster->detId()),
+                             cluster->eta(),
+                             cluster->phi(),
+                             cluster->pt(),
+                             cluster->mipPt(),
+                             clusterIndex);
+    ++clusterIndex;
+  }
+
+  seeds_SA.clear();
+  seeds_SA.reserve(seeds.size());
+  for (const auto& seed : seeds) {
+    seeds_SA.emplace_back(seed.first.x(), seed.first.y(), seed.first.z(), seed.second);
+  }
+}
+
+void HGCalHistoClusteringWrapper::convertAlgorithmOutputs(
+    const std::vector<l1thgcfirmware::HGCalMulticluster>& multiclusters_out,
+    const std::vector<l1thgcfirmware::HGCalCluster>& rejected_clusters_out,
+    const std::vector<edm::Ptr<l1t::HGCalCluster>>& clustersPtrs,
+    l1t::HGCalMulticlusterBxCollection& multiclustersBXCollection,
+    l1t::HGCalClusterBxCollection& rejected_clusters) const {
+  // Not doing completely the correct thing here
+  // Taking the multiclusters from the stand alone emulation
+  // Getting their consistuent clusters (stand alone objects)
+  // Linking back to the original CMSSW-type cluster
+  // And creating a CMSSW-type multicluster based from these clusters
+  // So the output multiclusters will not be storing bit accurate quantities (or whatever was derived by the stand along emulation)
+  // As these inherit from L1Candidate, could set their HW quantities to the bit accurate ones
+  for (const auto& rejected_cluster : rejected_clusters_out) {
+    rejected_clusters.push_back(0, *clustersPtrs.at(rejected_cluster.index_cmssw()));
+  }
+
+  std::vector<l1t::HGCalMulticluster> multiclusters;
+  multiclusters.reserve(multiclusters_out.size());
+  for (unsigned int imulticluster = 0; imulticluster < multiclusters_out.size(); ++imulticluster) {
+    bool firstConstituent = true;
+    for (const auto& constituent : multiclusters_out[imulticluster].constituents()) {
+      if (firstConstituent) {
+        multiclusters.emplace_back(clustersPtrs.at(constituent.index_cmssw()), 1.);
+      } else {
+        multiclusters.at(imulticluster).addConstituent(clustersPtrs.at(constituent.index_cmssw()), 1.);
+      }
+      firstConstituent = false;
+    }
+  }
+
+  for (const auto& multicluster : multiclusters) {
+    multiclustersBXCollection.push_back(0, multicluster);
+  }
+}
+
+void HGCalHistoClusteringWrapper::process(
+    const std::pair<const std::vector<edm::Ptr<l1t::HGCalCluster>>, const std::vector<std::pair<GlobalPoint, double>>>&
+        inputClustersAndSeeds,
+    std::pair<l1t::HGCalMulticlusterBxCollection&, l1t::HGCalClusterBxCollection&>&
+        outputMulticlustersAndRejectedClusters) const {
+  l1thgcfirmware::HGCalClusterSACollection clusters_SA;
+  l1thgcfirmware::HGCalSeedSACollection seeds_SA;
+  convertCMSSWInputs(inputClustersAndSeeds.first, clusters_SA, inputClustersAndSeeds.second, seeds_SA);
+
+  l1thgcfirmware::HGCalClusterSACollection rejected_clusters_finalized_SA;
+  l1thgcfirmware::HGCalMulticlusterSACollection multiclusters_finalized_SA;
+  clusterizeHisto(clusters_SA, seeds_SA, multiclusters_finalized_SA, rejected_clusters_finalized_SA);
+
+  convertAlgorithmOutputs(multiclusters_finalized_SA,
+                          rejected_clusters_finalized_SA,
+                          inputClustersAndSeeds.first,
+                          outputMulticlustersAndRejectedClusters.first,
+                          outputMulticlustersAndRejectedClusters.second);
+}
+
+void HGCalHistoClusteringWrapper::clusterizeHisto(
+    const l1thgcfirmware::HGCalClusterSACollection& inputClusters,
+    const l1thgcfirmware::HGCalSeedSACollection& inputSeeds,
+    l1thgcfirmware::HGCalMulticlusterSACollection& outputMulticlusters,
+    l1thgcfirmware::HGCalClusterSACollection& outputRejectedClusters) const {
+  // Call SA clustering
+  std::vector<l1thgcfirmware::HGCalCluster> rejected_clusters_vec_SA;
+  std::vector<l1thgcfirmware::HGCalMulticluster> multiclusters_vec_SA =
+      theAlgo_.clusterSeedMulticluster_SA(inputClusters, inputSeeds, rejected_clusters_vec_SA, theConfiguration_);
+
+  theAlgo_.finalizeClusters_SA(
+      multiclusters_vec_SA, rejected_clusters_vec_SA, outputMulticlusters, outputRejectedClusters, theConfiguration_);
+}
+
+void HGCalHistoClusteringWrapper::configure(
+    const std::pair<const edm::EventSetup&, const edm::ParameterSet&>& configuration) {
+  eventSetup(configuration.first);
+
+  // theConfiguration_.setParameters( ... );
+
+  if ((!theConfiguration_.dr_byLayer_coefficientA().empty() &&
+       (theConfiguration_.dr_byLayer_coefficientA().size() - 1) < triggerTools_.lastLayerBH()) ||
+      (!theConfiguration_.dr_byLayer_coefficientB().empty() &&
+       (theConfiguration_.dr_byLayer_coefficientB().size() - 1) < triggerTools_.lastLayerBH())) {
+    throw cms::Exception("Configuration")
+        << "The per-layer dR values go up to " << (theConfiguration_.dr_byLayer_coefficientA().size() - 1) << "(A) and "
+        << (theConfiguration_.dr_byLayer_coefficientB().size() - 1) << "(B), while layers go up to "
+        << triggerTools_.lastLayerBH() << "\n";
+  }
+};
+
+DEFINE_EDM_PLUGIN(HGCalHistoClusteringWrapperBaseFactory, HGCalHistoClusteringWrapper, "HGCalHistoClusteringWrapper");

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalHistoClusteringWrapper.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalHistoClusteringWrapper.cc
@@ -20,7 +20,8 @@ public:
   HGCalHistoClusteringWrapper(const edm::ParameterSet& conf);
   ~HGCalHistoClusteringWrapper() override {}
 
-  void configure(const std::pair<const edm::EventSetup&, const edm::ParameterSet&>& configuration) override;
+  void configure(
+      const std::pair<const HGCalTriggerGeometryBase* const, const edm::ParameterSet&>& configuration) override;
 
   void process(const std::pair<const std::vector<edm::Ptr<l1t::HGCalCluster>>,
                                const std::vector<std::pair<GlobalPoint, double>>>& inputClustersAndSeeds,
@@ -43,7 +44,7 @@ private:
                        l1thgcfirmware::HGCalMulticlusterSACollection& outputMulticlusters,
                        l1thgcfirmware::HGCalClusterSACollection& outputRejectedClusters) const;
 
-  void eventSetup(const edm::EventSetup& es) { triggerTools_.eventSetup(es); }
+  void setGeometry(const HGCalTriggerGeometryBase* const geom) { triggerTools_.setGeometry(geom); }
 
   HGCalTriggerTools triggerTools_;
 
@@ -166,8 +167,8 @@ void HGCalHistoClusteringWrapper::clusterizeHisto(
 }
 
 void HGCalHistoClusteringWrapper::configure(
-    const std::pair<const edm::EventSetup&, const edm::ParameterSet&>& configuration) {
-  eventSetup(configuration.first);
+    const std::pair<const HGCalTriggerGeometryBase* const, const edm::ParameterSet&>& configuration) {
+  setGeometry(configuration.first);
 
   // theConfiguration_.setParameters( ... );
 

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalSortingTruncationWrapper.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalSortingTruncationWrapper.cc
@@ -16,7 +16,8 @@ public:
   HGCalSortingTruncationWrapper(const edm::ParameterSet& conf);
   ~HGCalSortingTruncationWrapper() override {}
 
-  void configure(const std::pair<const edm::EventSetup&, const edm::ParameterSet&>& configuration) override;
+  void configure(
+      const std::pair<const HGCalTriggerGeometryBase* const, const edm::ParameterSet&>& configuration) override;
 
   void process(const l1t::HGCalMulticlusterBxCollection&, l1t::HGCalMulticlusterBxCollection&) const override;
 
@@ -27,7 +28,7 @@ private:
                                const l1t::HGCalMulticlusterBxCollection& multiclusters_original,
                                l1t::HGCalMulticlusterBxCollection& multiclustersBXCollection) const;
 
-  void eventSetup(const edm::EventSetup& es) { triggerTools_.eventSetup(es); }
+  void setGeometry(const HGCalTriggerGeometryBase* const geom) { triggerTools_.setGeometry(geom); }
 
   HGCalTriggerTools triggerTools_;
   HGCalSortingTruncationImplSA theAlgo_;
@@ -101,8 +102,8 @@ void HGCalSortingTruncationWrapper::process(const l1t::HGCalMulticlusterBxCollec
 }
 
 void HGCalSortingTruncationWrapper::configure(
-    const std::pair<const edm::EventSetup&, const edm::ParameterSet&>& configuration) {
-  eventSetup(configuration.first);
+    const std::pair<const HGCalTriggerGeometryBase* const, const edm::ParameterSet&>& configuration) {
+  setGeometry(configuration.first);
 };
 
 DEFINE_EDM_PLUGIN(HGCalStage2FilteringWrapperBaseFactory,

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalSortingTruncationWrapper.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalSortingTruncationWrapper.cc
@@ -1,0 +1,110 @@
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "L1Trigger/L1THGCal/interface/HGCalAlgoWrapperBase.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalSortingTruncationImpl_SA.h"
+
+#include "DataFormats/L1THGCal/interface/HGCalMulticluster.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalMulticluster_SA.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
+
+class HGCalSortingTruncationWrapper : public HGCalStage2FilteringWrapperBase {
+public:
+  HGCalSortingTruncationWrapper(const edm::ParameterSet& conf);
+  ~HGCalSortingTruncationWrapper() override {}
+
+  void configure(const std::pair<const edm::EventSetup&, const edm::ParameterSet&>& configuration) override;
+
+  void process(const l1t::HGCalMulticlusterBxCollection&, l1t::HGCalMulticlusterBxCollection&) const override;
+
+private:
+  void convertCMSSWInputs(const l1t::HGCalMulticlusterBxCollection& multiclusters,
+                          l1thgcfirmware::HGCalMulticlusterSACollection& multiclusters_SA) const;
+  void convertAlgorithmOutputs(const l1thgcfirmware::HGCalMulticlusterSACollection& multiclusters_out,
+                               const l1t::HGCalMulticlusterBxCollection& multiclusters_original,
+                               l1t::HGCalMulticlusterBxCollection& multiclustersBXCollection) const;
+
+  void eventSetup(const edm::EventSetup& es) { triggerTools_.eventSetup(es); }
+
+  HGCalTriggerTools triggerTools_;
+  HGCalSortingTruncationImplSA theAlgo_;
+  l1thgcfirmware::SortingTruncationAlgoConfig theConfiguration_;
+};
+
+HGCalSortingTruncationWrapper::HGCalSortingTruncationWrapper(const edm::ParameterSet& conf)
+    : HGCalStage2FilteringWrapperBase(conf), theAlgo_(), theConfiguration_(conf.getParameter<unsigned>("maxTCs")) {}
+
+void HGCalSortingTruncationWrapper::convertCMSSWInputs(
+    const l1t::HGCalMulticlusterBxCollection& multiclusters,
+    l1thgcfirmware::HGCalMulticlusterSACollection& multiclusters_SA) const {
+  multiclusters_SA.reserve(multiclusters.size());
+
+  for (unsigned int imulticluster = 0; imulticluster < multiclusters.size(); ++imulticluster) {
+    bool firstConstituent = true;
+    for (const auto& constituent : multiclusters[imulticluster].constituents()) {
+      if (firstConstituent) {
+        multiclusters_SA.emplace_back(l1thgcfirmware::HGCalMulticluster(
+            l1thgcfirmware::HGCalCluster(constituent.second->centreProj().x(),
+                                         constituent.second->centreProj().y(),
+                                         constituent.second->centreProj().z(),
+                                         triggerTools_.zside(constituent.second->detId()),
+                                         triggerTools_.layerWithOffset(constituent.second->detId()),
+                                         constituent.second->eta(),
+                                         constituent.second->phi(),
+                                         constituent.second->pt(),
+                                         constituent.second->mipPt(),
+                                         imulticluster),
+            1.));
+
+      } else {
+        multiclusters_SA.at(imulticluster)
+            .addConstituent(l1thgcfirmware::HGCalCluster(constituent.second->centreProj().x(),
+                                                         constituent.second->centreProj().y(),
+                                                         constituent.second->centreProj().z(),
+                                                         triggerTools_.zside(constituent.second->detId()),
+                                                         triggerTools_.layerWithOffset(constituent.second->detId()),
+                                                         constituent.second->eta(),
+                                                         constituent.second->phi(),
+                                                         constituent.second->pt(),
+                                                         constituent.second->mipPt(),
+                                                         imulticluster),
+                            1.);
+      }
+      firstConstituent = false;
+    }
+  }
+}
+
+void HGCalSortingTruncationWrapper::convertAlgorithmOutputs(
+    const std::vector<l1thgcfirmware::HGCalMulticluster>& multiclusters_out,
+    const l1t::HGCalMulticlusterBxCollection& multiclusters_original,
+    l1t::HGCalMulticlusterBxCollection& multiclustersBXCollection) const {
+  for (unsigned int imulticluster = 0; imulticluster < multiclusters_out.size(); ++imulticluster) {
+    unsigned multicluster_id = multiclusters_out[imulticluster].constituents().at(0).index_cmssw();
+    multiclustersBXCollection.push_back(0, multiclusters_original[multicluster_id]);
+  }
+}
+
+void HGCalSortingTruncationWrapper::process(const l1t::HGCalMulticlusterBxCollection& inputMulticlusters,
+                                            l1t::HGCalMulticlusterBxCollection& outputMulticlusters) const {
+  l1thgcfirmware::HGCalMulticlusterSACollection multiclusters_SA;
+  convertCMSSWInputs(inputMulticlusters, multiclusters_SA);
+
+  l1thgcfirmware::HGCalMulticlusterSACollection multiclusters_finalized_SA;
+
+  theAlgo_.sortAndTruncate_SA(multiclusters_SA, multiclusters_finalized_SA, theConfiguration_);
+
+  convertAlgorithmOutputs(multiclusters_finalized_SA, inputMulticlusters, outputMulticlusters);
+}
+
+void HGCalSortingTruncationWrapper::configure(
+    const std::pair<const edm::EventSetup&, const edm::ParameterSet&>& configuration) {
+  eventSetup(configuration.first);
+};
+
+DEFINE_EDM_PLUGIN(HGCalStage2FilteringWrapperBaseFactory,
+                  HGCalSortingTruncationWrapper,
+                  "HGCalSortingTruncationWrapper");

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalSortingTruncationWrapper.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalSortingTruncationWrapper.cc
@@ -14,7 +14,7 @@
 class HGCalSortingTruncationWrapper : public HGCalStage2FilteringWrapperBase {
 public:
   HGCalSortingTruncationWrapper(const edm::ParameterSet& conf);
-  ~HGCalSortingTruncationWrapper() override {}
+  ~HGCalSortingTruncationWrapper() override = default;
 
   void configure(
       const std::pair<const HGCalTriggerGeometryBase* const, const edm::ParameterSet&>& configuration) override;

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalStage1TruncationWrapper.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalStage1TruncationWrapper.cc
@@ -12,7 +12,8 @@ public:
   HGCalStage1TruncationWrapper(const edm::ParameterSet& conf);
   ~HGCalStage1TruncationWrapper() override {}
 
-  void configure(const std::tuple<const edm::EventSetup&, const unsigned&, const uint32_t&>& configuration) override;
+  void configure(
+      const std::tuple<const HGCalTriggerGeometryBase* const, const unsigned&, const uint32_t&>& configuration) override;
 
   void process(const std::vector<edm::Ptr<l1t::HGCalTriggerCell>>& fpga_tcs,
                std::vector<edm::Ptr<l1t::HGCalTriggerCell>>& tcs_out) const override;
@@ -25,7 +26,7 @@ private:
                                const std::vector<edm::Ptr<l1t::HGCalTriggerCell>>& fpga_tcs_original,
                                std::vector<edm::Ptr<l1t::HGCalTriggerCell>>& fpga_tcs_trunc) const;
 
-  void eventSetup(const edm::EventSetup& es) { triggerTools_.eventSetup(es); }
+  void setGeometry(const HGCalTriggerGeometryBase* const geom) { triggerTools_.setGeometry(geom); }
 
   HGCalTriggerTools triggerTools_;
   HGCalStage1TruncationImplSA theAlgo_;
@@ -87,8 +88,8 @@ void HGCalStage1TruncationWrapper::process(const std::vector<edm::Ptr<l1t::HGCal
 }
 
 void HGCalStage1TruncationWrapper::configure(
-    const std::tuple<const edm::EventSetup&, const unsigned&, const uint32_t&>& configuration) {
-  eventSetup(std::get<0>(configuration));
+    const std::tuple<const HGCalTriggerGeometryBase* const, const unsigned&, const uint32_t&>& configuration) {
+  setGeometry(std::get<0>(configuration));
 
   theConfiguration_.setSector120(std::get<1>(configuration));
   theConfiguration_.setFPGAID(std::get<2>(configuration));

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalStage1TruncationWrapper.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalStage1TruncationWrapper.cc
@@ -1,0 +1,99 @@
+#include "L1Trigger/L1THGCal/interface/HGCalAlgoWrapperBase.h"
+
+#include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalTriggerCell_SA.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalStage1TruncationImpl_SA.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalStage1TruncationConfig_SA.h"
+
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
+
+class HGCalStage1TruncationWrapper : public HGCalStage1TruncationWrapperBase {
+public:
+  HGCalStage1TruncationWrapper(const edm::ParameterSet& conf);
+  ~HGCalStage1TruncationWrapper() override {}
+
+  void configure(const std::tuple<const edm::EventSetup&, const unsigned&, const uint32_t&>& configuration) override;
+
+  void process(const std::vector<edm::Ptr<l1t::HGCalTriggerCell>>& fpga_tcs,
+               std::vector<edm::Ptr<l1t::HGCalTriggerCell>>& tcs_out) const override;
+
+private:
+  void convertCMSSWInputs(const std::vector<edm::Ptr<l1t::HGCalTriggerCell>>& fpga_tcs,
+                          l1thgcfirmware::HGCalTriggerCellSACollection& fpga_tcs_SA) const;
+
+  void convertAlgorithmOutputs(const l1thgcfirmware::HGCalTriggerCellSACollection& fpga_tcs_out,
+                               const std::vector<edm::Ptr<l1t::HGCalTriggerCell>>& fpga_tcs_original,
+                               std::vector<edm::Ptr<l1t::HGCalTriggerCell>>& fpga_tcs_trunc) const;
+
+  void eventSetup(const edm::EventSetup& es) { triggerTools_.eventSetup(es); }
+
+  HGCalTriggerTools triggerTools_;
+  HGCalStage1TruncationImplSA theAlgo_;
+  l1thgcfirmware::Stage1TruncationConfig theConfiguration_;
+};
+
+HGCalStage1TruncationWrapper::HGCalStage1TruncationWrapper(const edm::ParameterSet& conf)
+    : HGCalStage1TruncationWrapperBase(conf),
+      theAlgo_(),
+      theConfiguration_(conf.getParameter<bool>("doTruncation"),
+                        conf.getParameter<double>("rozMin"),
+                        conf.getParameter<double>("rozMax"),
+                        conf.getParameter<unsigned>("rozBins"),
+                        conf.getParameter<std::vector<unsigned>>("maxTcsPerBin"),
+                        conf.getParameter<std::vector<double>>("phiSectorEdges")) {}
+
+void HGCalStage1TruncationWrapper::convertCMSSWInputs(const std::vector<edm::Ptr<l1t::HGCalTriggerCell>>& fpga_tcs,
+                                                      l1thgcfirmware::HGCalTriggerCellSACollection& fpga_tcs_SA) const {
+  fpga_tcs_SA.clear();
+  fpga_tcs_SA.reserve(fpga_tcs.size());
+  unsigned int itc = 0;
+  for (auto& tc : fpga_tcs) {
+    fpga_tcs_SA.emplace_back(tc->position().x(),
+                             tc->position().y(),
+                             tc->position().z(),
+                             triggerTools_.zside(tc->detId()),
+                             triggerTools_.layerWithOffset(tc->detId()),
+                             tc->eta(),
+                             tc->phi(),
+                             tc->pt(),
+                             tc->mipPt(),
+                             itc);
+    ++itc;
+  }
+}
+
+void HGCalStage1TruncationWrapper::convertAlgorithmOutputs(
+    const l1thgcfirmware::HGCalTriggerCellSACollection& fpga_tcs_out,
+    const std::vector<edm::Ptr<l1t::HGCalTriggerCell>>& fpga_tcs_original,
+    std::vector<edm::Ptr<l1t::HGCalTriggerCell>>& fpga_tcs_trunc) const {
+  for (auto& tc : fpga_tcs_out) {
+    unsigned tc_cmssw_id = tc.index_cmssw();
+    fpga_tcs_trunc.push_back(fpga_tcs_original[tc_cmssw_id]);
+  }
+}
+
+void HGCalStage1TruncationWrapper::process(const std::vector<edm::Ptr<l1t::HGCalTriggerCell>>& fpga_tcs,
+                                           std::vector<edm::Ptr<l1t::HGCalTriggerCell>>& tcs_out) const {
+  l1thgcfirmware::HGCalTriggerCellSACollection fpga_tcs_SA;
+  convertCMSSWInputs(fpga_tcs, fpga_tcs_SA);
+
+  l1thgcfirmware::HGCalTriggerCellSACollection tcs_out_SA;
+  unsigned error_code = theAlgo_.run(fpga_tcs_SA, theConfiguration_, tcs_out_SA);
+
+  if (error_code == 1)
+    throw cms::Exception("HGCalStage1TruncationImpl::OutOfRange") << "roverzbin index out of range";
+
+  convertAlgorithmOutputs(tcs_out_SA, fpga_tcs, tcs_out);
+}
+
+void HGCalStage1TruncationWrapper::configure(
+    const std::tuple<const edm::EventSetup&, const unsigned&, const uint32_t&>& configuration) {
+  eventSetup(std::get<0>(configuration));
+
+  theConfiguration_.setSector120(std::get<1>(configuration));
+  theConfiguration_.setFPGAID(std::get<2>(configuration));
+};
+
+DEFINE_EDM_PLUGIN(HGCalStage1TruncationWrapperBaseFactory,
+                  HGCalStage1TruncationWrapper,
+                  "HGCalStage1TruncationWrapper");

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalStage1TruncationWrapper.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalStage1TruncationWrapper.cc
@@ -10,7 +10,7 @@
 class HGCalStage1TruncationWrapper : public HGCalStage1TruncationWrapperBase {
 public:
   HGCalStage1TruncationWrapper(const edm::ParameterSet& conf);
-  ~HGCalStage1TruncationWrapper() override {}
+  ~HGCalStage1TruncationWrapper() override = default;
 
   void configure(
       const std::tuple<const HGCalTriggerGeometryBase* const, const unsigned&, const uint32_t&>& configuration) override;

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalTowerMapsWrapper.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalTowerMapsWrapper.cc
@@ -21,7 +21,7 @@ public:
   HGCalTowerMapsWrapper(const edm::ParameterSet& conf);
   ~HGCalTowerMapsWrapper() override {}
 
-  void configure(const std::pair<const edm::EventSetup&, const edm::ParameterSet&>& parameters) override;
+  void configure(const std::pair<const HGCalTriggerGeometryBase* const, const edm::ParameterSet&>& parameters) override;
 
   void process(const std::vector<edm::Ptr<l1t::HGCalTowerMap>>& inputs,
                l1t::HGCalTowerBxCollection& outputs) const override;
@@ -31,7 +31,6 @@ private:
                           std::vector<l1thgcfirmware::HGCalTowerMap>& towerMaps_SA) const;
   void convertAlgorithmOutputs(const std::vector<l1thgcfirmware::HGCalTower>& towerMaps_SA,
                                l1t::HGCalTowerBxCollection& outputTowerMaps) const;
-  void eventSetup(const edm::EventSetup& es) {}
 
   HGCalTowerMapImplSA theAlgo_;
 
@@ -76,6 +75,7 @@ void HGCalTowerMapsWrapper::process(const std::vector<edm::Ptr<l1t::HGCalTowerMa
   convertAlgorithmOutputs(outputs_SA, outputs);
 }
 
-void HGCalTowerMapsWrapper::configure(const std::pair<const edm::EventSetup&, const edm::ParameterSet&>& parameters) {}
+void HGCalTowerMapsWrapper::configure(
+    const std::pair<const HGCalTriggerGeometryBase* const, const edm::ParameterSet&>& parameters) {}
 
 DEFINE_EDM_PLUGIN(HGCalTowerMapsWrapperBaseFactory, HGCalTowerMapsWrapper, "HGCalTowerMapsWrapper");

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalTowerMapsWrapper.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalTowerMapsWrapper.cc
@@ -43,9 +43,9 @@ HGCalTowerMapsWrapper::HGCalTowerMapsWrapper(const edm::ParameterSet& conf) : HG
 void HGCalTowerMapsWrapper::convertCMSSWInputs(const std::vector<edm::Ptr<l1t::HGCalTowerMap>>& inputTowerMaps,
                                                std::vector<l1thgcfirmware::HGCalTowerMap>& towerMaps_SA) const {
   for (const auto& map : inputTowerMaps) {
-    std::vector<unsigned short> tower_ids;
+    std::vector<l1thgcfirmware::HGCalTowerCoord> tower_ids;
     for (const auto& tower : map->towers()) {
-      tower_ids.push_back(tower.first);
+      tower_ids.emplace_back(tower.first, tower.second.eta(), tower.second.phi());
     }
 
     l1thgcfirmware::HGCalTowerMap towerMapSA(tower_ids);
@@ -60,8 +60,8 @@ void HGCalTowerMapsWrapper::convertCMSSWInputs(const std::vector<edm::Ptr<l1t::H
 void HGCalTowerMapsWrapper::convertAlgorithmOutputs(const std::vector<l1thgcfirmware::HGCalTower>& towers_SA,
                                                     l1t::HGCalTowerBxCollection& outputTowerMaps) const {
   for (const auto& towerSA : towers_SA) {
-    // Need to carry eta, phi, ID through the SA emulation
-    outputTowerMaps.push_back(0, l1t::HGCalTower(towerSA.etEm(), towerSA.etHad(), 0, 0, 0));
+    outputTowerMaps.push_back(
+        0, l1t::HGCalTower(towerSA.etEm(), towerSA.etHad(), towerSA.eta(), towerSA.phi(), towerSA.id()));
   }
 }
 

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalTowerMapsWrapper.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalTowerMapsWrapper.cc
@@ -1,0 +1,81 @@
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "L1Trigger/L1THGCal/interface/HGCalAlgoWrapperBase.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalTowerMapImpl_SA.h"
+
+#include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
+#include "DataFormats/L1THGCal/interface/HGCalTowerMap.h"
+#include "DataFormats/L1THGCal/interface/HGCalTower.h"
+
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalTowerMap2DImpl.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalTowerMap3DImpl.h"
+
+#include "L1Trigger/L1THGCal/interface/backend/HGCalTower_SA.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalTowerMap_SA.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalTowerMapsConfig_SA.h"
+
+class HGCalTowerMapsWrapper : public HGCalTowerMapsWrapperBase {
+public:
+  HGCalTowerMapsWrapper(const edm::ParameterSet& conf);
+  ~HGCalTowerMapsWrapper() override {}
+
+  void configure(const std::pair<const edm::EventSetup&, const edm::ParameterSet&>& parameters) override;
+
+  void process(const std::vector<edm::Ptr<l1t::HGCalTowerMap>>& inputs,
+               l1t::HGCalTowerBxCollection& outputs) const override;
+
+private:
+  void convertCMSSWInputs(const std::vector<edm::Ptr<l1t::HGCalTowerMap>>& inputTowerMaps,
+                          std::vector<l1thgcfirmware::HGCalTowerMap>& towerMaps_SA) const;
+  void convertAlgorithmOutputs(const std::vector<l1thgcfirmware::HGCalTower>& towerMaps_SA,
+                               l1t::HGCalTowerBxCollection& outputTowerMaps) const;
+  void eventSetup(const edm::EventSetup& es) {}
+
+  HGCalTowerMapImplSA theAlgo_;
+
+  std::unique_ptr<l1thgcfirmware::TowerMapsAlgoConfig> theConfiguration_;
+};
+
+HGCalTowerMapsWrapper::HGCalTowerMapsWrapper(const edm::ParameterSet& conf) : HGCalTowerMapsWrapperBase(conf) {}
+
+void HGCalTowerMapsWrapper::convertCMSSWInputs(const std::vector<edm::Ptr<l1t::HGCalTowerMap>>& inputTowerMaps,
+                                               std::vector<l1thgcfirmware::HGCalTowerMap>& towerMaps_SA) const {
+  for (const auto& map : inputTowerMaps) {
+    std::vector<unsigned short> tower_ids;
+    for (const auto& tower : map->towers()) {
+      tower_ids.push_back(tower.first);
+    }
+
+    l1thgcfirmware::HGCalTowerMap towerMapSA(tower_ids);
+
+    for (const auto& tower : map->towers()) {
+      towerMapSA.addEt(tower.first, tower.second.etEm(), tower.second.etHad());
+    }
+    towerMaps_SA.emplace_back(towerMapSA);
+  }
+}
+
+void HGCalTowerMapsWrapper::convertAlgorithmOutputs(const std::vector<l1thgcfirmware::HGCalTower>& towers_SA,
+                                                    l1t::HGCalTowerBxCollection& outputTowerMaps) const {
+  for (const auto& towerSA : towers_SA) {
+    // Need to carry eta, phi, ID through the SA emulation
+    outputTowerMaps.push_back(0, l1t::HGCalTower(towerSA.etEm(), towerSA.etHad(), 0, 0, 0));
+  }
+}
+
+void HGCalTowerMapsWrapper::process(const std::vector<edm::Ptr<l1t::HGCalTowerMap>>& inputs,
+                                    l1t::HGCalTowerBxCollection& outputs) const {
+  std::vector<l1thgcfirmware::HGCalTowerMap> inputs_SA;
+  convertCMSSWInputs(inputs, inputs_SA);
+
+  std::vector<l1thgcfirmware::HGCalTower> outputs_SA;
+  theAlgo_.runAlgorithm(inputs_SA, outputs_SA);
+
+  convertAlgorithmOutputs(outputs_SA, outputs);
+}
+
+void HGCalTowerMapsWrapper::configure(const std::pair<const edm::EventSetup&, const edm::ParameterSet&>& parameters) {}
+
+DEFINE_EDM_PLUGIN(HGCalTowerMapsWrapperBaseFactory, HGCalTowerMapsWrapper, "HGCalTowerMapsWrapper");

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalTowerMapsWrapper.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalTowerMapsWrapper.cc
@@ -19,7 +19,7 @@
 class HGCalTowerMapsWrapper : public HGCalTowerMapsWrapperBase {
 public:
   HGCalTowerMapsWrapper(const edm::ParameterSet& conf);
-  ~HGCalTowerMapsWrapper() override {}
+  ~HGCalTowerMapsWrapper() override = default;
 
   void configure(const std::pair<const HGCalTriggerGeometryBase* const, const edm::ParameterSet&>& parameters) override;
 

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalTowerProcessor_SA.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalTowerProcessor_SA.cc
@@ -1,0 +1,53 @@
+#include "L1Trigger/L1THGCal/interface/HGCalProcessorBase.h"
+
+#include "DataFormats/L1THGCal/interface/HGCalTowerMap.h"
+#include "DataFormats/L1THGCal/interface/HGCalTower.h"
+
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalTowerMap2DImpl.h"
+#include "L1Trigger/L1THGCal/interface/backend/HGCalTowerMap3DImpl.h"
+
+#include "L1Trigger/L1THGCal/interface/HGCalAlgoWrapperBase.h"
+
+class HGCalTowerProcessorSA : public HGCalTowerProcessorBase {
+public:
+  HGCalTowerProcessorSA(const edm::ParameterSet& conf) : HGCalTowerProcessorBase(conf), conf_(conf) {
+    const std::string towerMapsAlgoName(
+        conf.getParameterSet("towermap_parameters").getParameter<std::string>("AlgoName"));
+    towerMapWrapper_ = std::unique_ptr<HGCalTowerMapsWrapperBase>{HGCalTowerMapsWrapperBaseFactory::get()->create(
+        towerMapsAlgoName, conf.getParameterSet("towermap_parameters"))};
+  }
+
+  void eventSetup(const edm::EventSetup& es) override {}
+
+  void run(const std::pair<edm::Handle<l1t::HGCalTowerMapBxCollection>, edm::Handle<l1t::HGCalClusterBxCollection>>&
+               collHandle,
+           l1t::HGCalTowerBxCollection& collTowers,
+           const edm::EventSetup& es) override {
+    es.get<CaloGeometryRecord>().get("", triggerGeometry_);
+
+    auto& towerMapCollHandle = collHandle.first;
+
+    /* create a persistent vector of pointers to the towerMaps */
+    std::vector<edm::Ptr<l1t::HGCalTowerMap>> towerMapsPtrs;
+    for (unsigned i = 0; i < towerMapCollHandle->size(); ++i) {
+      towerMapsPtrs.emplace_back(towerMapCollHandle, i);
+    }
+
+    // Configuration
+    const std::pair<const edm::EventSetup&, const edm::ParameterSet&> configuration{es, conf_};
+    towerMapWrapper_->configure(configuration);
+    towerMapWrapper_->process(towerMapsPtrs, collTowers);
+  }
+
+private:
+  edm::ESHandle<HGCalTriggerGeometryBase> triggerGeometry_;
+
+  /* Standalone algorithm instance */
+  std::unique_ptr<HGCalTowerMapsWrapperBase> towerMapWrapper_;
+
+  const edm::ParameterSet conf_;
+};
+
+DEFINE_EDM_PLUGIN(HGCalTowerFactory, HGCalTowerProcessorSA, "HGCalTowerProcessorSA");

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalTowerProcessor_SA.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalTowerProcessor_SA.cc
@@ -19,14 +19,9 @@ public:
         towerMapsAlgoName, conf.getParameterSet("towermap_parameters"))};
   }
 
-  void eventSetup(const edm::EventSetup& es) override {}
-
   void run(const std::pair<edm::Handle<l1t::HGCalTowerMapBxCollection>, edm::Handle<l1t::HGCalClusterBxCollection>>&
                collHandle,
-           l1t::HGCalTowerBxCollection& collTowers,
-           const edm::EventSetup& es) override {
-    es.get<CaloGeometryRecord>().get("", triggerGeometry_);
-
+           l1t::HGCalTowerBxCollection& collTowers) override {
     auto& towerMapCollHandle = collHandle.first;
 
     /* create a persistent vector of pointers to the towerMaps */
@@ -36,7 +31,7 @@ public:
     }
 
     // Configuration
-    const std::pair<const edm::EventSetup&, const edm::ParameterSet&> configuration{es, conf_};
+    const std::pair<const HGCalTriggerGeometryBase* const, const edm::ParameterSet&> configuration{geometry(), conf_};
     towerMapWrapper_->configure(configuration);
     towerMapWrapper_->process(towerMapsPtrs, collTowers);
   }

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp3.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp3.cc
@@ -67,7 +67,15 @@ private:
   // HSc trigger cell grouping
   unsigned hSc_triggercell_size_ = 2;
   unsigned hSc_module_size_ = 12;  // in TC units (144 TC / panel = 36 e-links)
-  unsigned hSc_wafers_per_module_ = 3;
+  //  unsigned hSc_wafers_per_module_ = 3;
+  static constexpr unsigned hSc_num_panels_per_sector_ = 12;
+  static constexpr unsigned hSc_tcs_per_module_phi_ = 4;
+  static constexpr unsigned hSc_front_layers_split_ = 12;
+  static constexpr unsigned hSc_back_layers_split_ = 8;
+  static constexpr unsigned hSc_layer_for_split_ = 40;
+  static constexpr int hSc_tc_layer0_min_ = 24;
+  static constexpr int ntc_per_wafer_ = 48;
+  static constexpr int nSectors_ = 3;
 
   edm::FileInPath jsonMappingFile_;
 
@@ -78,6 +86,7 @@ private:
   std::unordered_map<unsigned, unsigned> links_per_module_;
 
   std::unordered_multimap<unsigned, unsigned> stage2_to_stage1links_;
+  std::unordered_map<unsigned, bool> stage1links_samesector_;
   std::unordered_map<unsigned, unsigned> stage1link_to_stage2_;
   std::unordered_map<unsigned, unsigned> stage1link_to_stage1_;
   std::unordered_multimap<unsigned, unsigned> stage1_to_stage1links_;
@@ -92,9 +101,6 @@ private:
   std::vector<unsigned> trigger_layers_;
   std::vector<unsigned> trigger_nose_layers_;
   unsigned last_trigger_layer_ = 0;
-
-  //Scintillator layout
-  unsigned hSc_num_panels_per_sector_ = 8;
 
   // layer offsets
   unsigned heOffset_ = 0;
@@ -111,7 +117,8 @@ private:
   void unpackLayerSubdetWaferId(unsigned wafer, unsigned& layer, int& subdet, int& waferU, int& waferV) const;
   HGCalGeomRotation::WaferCentring getWaferCentring(unsigned layer, int subdet) const;
   void etaphiMappingFromSector0(int& ieta, int& iphi, unsigned sector) const;
-  unsigned etaphiMappingToSector0(int& ieta, int& iphi) const;
+  unsigned tcEtaphiMappingToSector0(int& tc_ieta, int& tc_iphi) const;
+  void getScintillatoriEtaiPhi(int& ieta, int& iphi, int tc_eta, int tc_phi, unsigned layer) const;
   unsigned layerWithOffset(unsigned) const;
   unsigned getNextSector(const unsigned sector) const;
   unsigned getPreviousSector(const unsigned sector) const;
@@ -122,17 +129,17 @@ HGCalTriggerGeometryV9Imp3::HGCalTriggerGeometryV9Imp3(const edm::ParameterSet& 
       hSc_triggercell_size_(conf.getParameter<unsigned>("ScintillatorTriggerCellSize")),
       hSc_module_size_(conf.getParameter<unsigned>("ScintillatorModuleSize")),
       jsonMappingFile_(conf.getParameter<edm::FileInPath>("JsonMappingFile")) {
-  const unsigned ntc_per_wafer = 48;
-  hSc_wafers_per_module_ = std::round(hSc_module_size_ * hSc_module_size_ / float(ntc_per_wafer));
-  if (ntc_per_wafer * hSc_wafers_per_module_ < hSc_module_size_ * hSc_module_size_) {
-    hSc_wafers_per_module_++;
-  }
+  //hSc_wafers_per_module_ = std::round(hSc_module_size_ * hSc_module_size_ / float(ntc_per_wafer_));
+  //  if (ntc_per_wafer_ * hSc_wafers_per_module_ < hSc_module_size_ * hSc_module_size_) {
+  //    hSc_wafers_per_module_++;
+  //  }
   std::vector<unsigned> tmp_vector = conf.getParameter<std::vector<unsigned>>("DisconnectedLayers");
   std::move(tmp_vector.begin(), tmp_vector.end(), std::inserter(disconnected_layers_, disconnected_layers_.end()));
 }
 
 void HGCalTriggerGeometryV9Imp3::reset() {
   stage2_to_stage1links_.clear();
+  stage1links_samesector_.clear();
   stage1link_to_stage2_.clear();
   stage1link_to_stage1_.clear();
   stage1_to_stage1links_.clear();
@@ -261,11 +268,12 @@ unsigned HGCalTriggerGeometryV9Imp3::getModuleFromTriggerCell(const unsigned tri
     tc_type = trigger_cell_sc_id.type();
     layer = trigger_cell_sc_id.layer();
     zside = trigger_cell_sc_id.zside();
-    int ietamin = hscTopology().dddConstants().getREtaRange(layer).first;
-    int ietamin_tc = ((ietamin - 1) / hSc_triggercell_size_ + 1);
-    int ieta = ((trigger_cell_sc_id.ietaAbs() - ietamin_tc) / hSc_module_size_ + 1);
-    int iphi = (trigger_cell_sc_id.iphi() - 1) / hSc_module_size_ + 1;
-    unsigned sector = etaphiMappingToSector0(ieta, iphi);
+    int tc_eta = trigger_cell_sc_id.ietaAbs();
+    int tc_phi = trigger_cell_sc_id.iphi();
+    unsigned sector = tcEtaphiMappingToSector0(tc_eta, tc_phi);
+    int ieta = 0;
+    int iphi = 0;
+    getScintillatoriEtaiPhi(ieta, iphi, tc_eta, tc_phi, layer);
     module_id =
         HGCalTriggerModuleDetId(HGCalTriggerSubdetector::HGCalHScTrigger, zside, tc_type, layer, sector, ieta, iphi);
   }
@@ -385,15 +393,28 @@ HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp3::getTriggerCellsFr
   geom_set trigger_cell_det_ids;
   // Scintillator
   if (subdet == HGCalTriggerSubdetector::HGCalHScTrigger) {
-    int ietamin = hscTopology().dddConstants().getREtaRange(hgc_module_id.layer()).first;
-    int ietamin_tc = ((ietamin - 1) / hSc_triggercell_size_ + 1);
-    int ieta0 = (hgc_module_id.eta() - 1) * hSc_module_size_ + ietamin_tc;
+    int ieta0 = hgc_module_id.eta();
     int iphi0 = hgc_module_id.phi();
+
+    unsigned layer = hgc_module_id.layer();
     etaphiMappingFromSector0(ieta0, iphi0, hgc_module_id.sector());
-    iphi0 = (iphi0 - 1) * hSc_module_size_ + 1;
-    for (int ietaAbs = ieta0; ietaAbs < ieta0 + (int)hSc_module_size_; ietaAbs++) {
+    int split = (layer > hSc_layer_for_split_) ? hSc_back_layers_split_ : hSc_front_layers_split_;
+    if (ieta0 == 1) {
+      ieta0 = ieta0 + split;
+    } else {
+      ieta0 = ieta0 + 1;
+    }
+    iphi0 = (iphi0 * hSc_tcs_per_module_phi_) + hSc_tc_layer0_min_ + 1;
+    int total_tcs = hSc_num_panels_per_sector_ * hSc_tcs_per_module_phi_ * nSectors_;
+    if (iphi0 > total_tcs) {
+      iphi0 = iphi0 - total_tcs;
+    }
+
+    int hSc_tcs_per_module_eta = (layer > hSc_layer_for_split_) ? hSc_back_layers_split_ : hSc_front_layers_split_;
+
+    for (int ietaAbs = ieta0; ietaAbs < ieta0 + (int)hSc_tcs_per_module_eta; ietaAbs++) {
       int ieta = ietaAbs * hgc_module_id.zside();
-      for (int iphi = iphi0; iphi < iphi0 + (int)hSc_module_size_; iphi++) {
+      for (int iphi = iphi0; iphi < iphi0 + (int)hSc_tcs_per_module_phi_; iphi++) {
         unsigned trigger_cell_id = HGCScintillatorDetId(hgc_module_id.type(), hgc_module_id.layer(), ieta, iphi);
         if (validTriggerCellFromCells(trigger_cell_id))
           trigger_cell_det_ids.emplace(trigger_cell_id);
@@ -449,12 +470,28 @@ HGCalTriggerGeometryBase::geom_ordered_set HGCalTriggerGeometryV9Imp3::getOrdere
 
   // Scintillator
   if (subdet == HGCalTriggerSubdetector::HGCalHScTrigger) {
-    int ieta0 = hgc_module_id.eta() * hSc_module_size_;
-    int iphi0 = (hgc_module_id.phi() * (hgc_module_id.sector() + 1)) * hSc_module_size_;
+    int ieta0 = hgc_module_id.eta();
+    int iphi0 = hgc_module_id.phi();
 
-    for (int ietaAbs = ieta0; ietaAbs < ieta0 + (int)hSc_module_size_; ietaAbs++) {
+    unsigned layer = hgc_module_id.layer();
+    etaphiMappingFromSector0(ieta0, iphi0, hgc_module_id.sector());
+    int split = (layer > hSc_layer_for_split_) ? hSc_back_layers_split_ : hSc_front_layers_split_;
+    if (ieta0 == 1) {
+      ieta0 = ieta0 + split;
+    } else {
+      ieta0 = ieta0 + 1;
+    }
+    iphi0 = (iphi0 * hSc_tcs_per_module_phi_) + hSc_tc_layer0_min_ + 1;
+    int total_tcs = hSc_num_panels_per_sector_ * hSc_tcs_per_module_phi_ * nSectors_;
+    if (iphi0 > total_tcs) {
+      iphi0 = iphi0 - total_tcs;
+    }
+
+    int hSc_tcs_per_module_eta = (layer > hSc_layer_for_split_) ? hSc_back_layers_split_ : hSc_front_layers_split_;
+
+    for (int ietaAbs = ieta0; ietaAbs < ieta0 + (int)hSc_tcs_per_module_eta; ietaAbs++) {
       int ieta = ietaAbs * hgc_module_id.zside();
-      for (int iphi = iphi0; iphi < iphi0 + (int)hSc_module_size_; iphi++) {
+      for (int iphi = iphi0; iphi < iphi0 + (int)hSc_tcs_per_module_phi_; iphi++) {
         unsigned trigger_cell_id = HGCScintillatorDetId(hgc_module_id.type(), hgc_module_id.layer(), ieta, iphi);
         if (validTriggerCellFromCells(trigger_cell_id))
           trigger_cell_det_ids.emplace(trigger_cell_id);
@@ -575,17 +612,15 @@ HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp3::getStage1LinksFro
     const unsigned stage2_id) const {
   geom_set stage1link_ids;
   HGCalTriggerBackendDetId id(stage2_id);
-
   auto stage2_itrs = stage2_to_stage1links_.equal_range(id.label());
   for (auto stage2_itr = stage2_itrs.first; stage2_itr != stage2_itrs.second; stage2_itr++) {
-    if (stage2_itr->second == true) {  //link and stage2 FPGA are the same sector
-      stage1link_ids.emplace(HGCalTriggerBackendDetId(
-          id.zside(), HGCalTriggerBackendDetId::BackendType::Stage1Link, id.sector(), stage2_itr->second));
+    unsigned label = stage2_itr->second;
+    if (stage1links_samesector_.at(label) == true) {  //link and stage2 FPGA are the same sector
+      stage1link_ids.emplace(
+          HGCalTriggerBackendDetId(id.zside(), HGCalTriggerBackendDetId::BackendType::Stage1Link, id.sector(), label));
     } else {  //link is from the next sector (anti-clockwise)
-      stage1link_ids.emplace(HGCalTriggerBackendDetId(id.zside(),
-                                                      HGCalTriggerBackendDetId::BackendType::Stage1Link,
-                                                      getNextSector(id.sector()),
-                                                      stage2_itr->second));
+      stage1link_ids.emplace(HGCalTriggerBackendDetId(
+          id.zside(), HGCalTriggerBackendDetId::BackendType::Stage1Link, getNextSector(id.sector()), label));
     }
   }
 
@@ -780,8 +815,11 @@ void HGCalTriggerGeometryV9Imp3::fillMaps() {
   try {
     //Stage 2 to Stage 1 links mapping
     for (unsigned stage2_id = 0; stage2_id < mapping_config.at("Stage2").size(); stage2_id++) {
-      for (auto& link : mapping_config.at("Stage2").at(stage2_id).at("Stage1Links")) {
-        stage2_to_stage1links_.emplace(stage2_id, link.at("SameSector"));
+      for (unsigned link_id = 0; link_id < mapping_config.at("Stage2").at(stage2_id).at("Stage1Links").size();
+           link_id++) {
+        stage2_to_stage1links_.emplace(stage2_id, link_id);
+        stage1links_samesector_.emplace(
+            link_id, mapping_config.at("Stage2").at(stage2_id).at("Stage1Links").at(link_id).at("SameSector"));
       }
     }
   } catch (const json::exception& e) {
@@ -901,7 +939,11 @@ void HGCalTriggerGeometryV9Imp3::etaphiMappingFromSector0(int& ieta, int& iphi, 
   if (sector == 0) {
     return;
   }
-  iphi = iphi + (sector * hSc_num_panels_per_sector_);
+  if (sector == 2) {
+    iphi = iphi + hSc_num_panels_per_sector_;
+  } else if (sector == 1) {
+    iphi = iphi + (2 * hSc_num_panels_per_sector_);
+  }
 }
 
 HGCalGeomRotation::WaferCentring HGCalTriggerGeometryV9Imp3::getWaferCentring(unsigned layer, int subdet) const {
@@ -922,19 +964,44 @@ HGCalGeomRotation::WaferCentring HGCalTriggerGeometryV9Imp3::getWaferCentring(un
   }
 }
 
-unsigned HGCalTriggerGeometryV9Imp3::etaphiMappingToSector0(int& ieta, int& iphi) const {
+unsigned HGCalTriggerGeometryV9Imp3::tcEtaphiMappingToSector0(int& tc_ieta, int& tc_iphi) const {
   unsigned sector = 0;
 
-  if (unsigned(std::abs(iphi)) > 2 * hSc_num_panels_per_sector_)
-    sector = 2;
-  else if (unsigned(std::abs(iphi)) > hSc_num_panels_per_sector_)
-    sector = 1;
-  else
+  if (tc_iphi > hSc_tc_layer0_min_ && tc_iphi <= hSc_tc_layer0_min_ + ntc_per_wafer_) {
     sector = 0;
+  } else if (tc_iphi > hSc_tc_layer0_min_ + ntc_per_wafer_ && tc_iphi <= hSc_tc_layer0_min_ + 2 * ntc_per_wafer_) {
+    sector = 2;
+  } else {
+    sector = 1;
+  }
 
-  iphi = iphi - (sector * hSc_num_panels_per_sector_);
+  if (sector == 0) {
+    tc_iphi = tc_iphi - hSc_tc_layer0_min_;
+  } else if (sector == 2) {
+    tc_iphi = tc_iphi - (hSc_tc_layer0_min_ + ntc_per_wafer_);
+  } else if (sector == 1) {
+    if (tc_iphi <= hSc_tc_layer0_min_) {
+      tc_iphi = tc_iphi + nSectors_ * ntc_per_wafer_;
+    }
+    tc_iphi = tc_iphi - (nSectors_ * ntc_per_wafer_ - hSc_tc_layer0_min_);
+  }
 
   return sector;
+}
+
+void HGCalTriggerGeometryV9Imp3::getScintillatoriEtaiPhi(
+    int& ieta, int& iphi, int tc_eta, int tc_phi, unsigned layer) const {
+  iphi = (tc_phi - 1) / hSc_tcs_per_module_phi_;  //Phi index 1-12
+
+  int split = hSc_front_layers_split_;
+  if (layer > hSc_layer_for_split_) {
+    split = hSc_back_layers_split_;
+  }
+  if (tc_eta <= split) {
+    ieta = 0;
+  } else {
+    ieta = 1;
+  }
 }
 
 bool HGCalTriggerGeometryV9Imp3::validTriggerCell(const unsigned trigger_cell_id) const {

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp3.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp3.cc
@@ -66,8 +66,6 @@ public:
 private:
   // HSc trigger cell grouping
   unsigned hSc_triggercell_size_ = 2;
-  unsigned hSc_module_size_ = 12;  // in TC units (144 TC / panel = 36 e-links)
-  //  unsigned hSc_wafers_per_module_ = 3;
   static constexpr unsigned hSc_num_panels_per_sector_ = 12;
   static constexpr unsigned hSc_tcs_per_module_phi_ = 4;
   static constexpr unsigned hSc_front_layers_split_ = 12;
@@ -127,12 +125,7 @@ private:
 HGCalTriggerGeometryV9Imp3::HGCalTriggerGeometryV9Imp3(const edm::ParameterSet& conf)
     : HGCalTriggerGeometryBase(conf),
       hSc_triggercell_size_(conf.getParameter<unsigned>("ScintillatorTriggerCellSize")),
-      hSc_module_size_(conf.getParameter<unsigned>("ScintillatorModuleSize")),
       jsonMappingFile_(conf.getParameter<edm::FileInPath>("JsonMappingFile")) {
-  //hSc_wafers_per_module_ = std::round(hSc_module_size_ * hSc_module_size_ / float(ntc_per_wafer_));
-  //  if (ntc_per_wafer_ * hSc_wafers_per_module_ < hSc_module_size_ * hSc_module_size_) {
-  //    hSc_wafers_per_module_++;
-  //  }
   std::vector<unsigned> tmp_vector = conf.getParameter<std::vector<unsigned>>("DisconnectedLayers");
   std::move(tmp_vector.begin(), tmp_vector.end(), std::inserter(disconnected_layers_, disconnected_layers_.end()));
 }

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp3.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp3.cc
@@ -615,7 +615,6 @@ unsigned HGCalTriggerGeometryV9Imp3::getStage2FpgaFromStage1Link(const unsigned 
 HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp3::getStage1LinksFromStage1Fpga(
     const unsigned stage1_id) const {
   geom_set stage1link_ids;
-
   HGCalTriggerBackendDetId id(stage1_id);
 
   auto stage1_itrs = stage1_to_stage1links_.equal_range(id.label());

--- a/L1Trigger/L1THGCal/plugins/geometries/README.md
+++ b/L1Trigger/L1THGCal/plugins/geometries/README.md
@@ -2,12 +2,14 @@ Trigger geometries provide the following interfaces:
 * Mapping between HGCAL sensor cells, trigger cells, modules, lpGBTs and backend FPGAs
 
 The available HGCAL trigger geometries are the following:
-* `HGCalTriggerGeometryV9Imp3`
+* `HGCalTriggerGeometryV9Imp3` (DEFAULT)
   - Compatible with the HGCAL geometries >= V9
   - All links mapping are available (elinks, lpGBT, BE links)
   - Backend FPGA mappings are available
   - Links and FPGA mappings are defined in external JSON files
-* `HGCalTriggerGeometryV9Imp2` (DEFAULT)
+  - Mapping configs are available for 72 and 120 input links per Stage 1 FPGA.
+  - These mappings correspond to a PU-driven distribution of elinks; there is no configuration corresponding to signal-driven elink distribution at the moment.
+* `HGCalTriggerGeometryV9Imp2`
   - Compatible with the HGCAL geometries >= V9
-  - No links mapping. Only the number of elinks per module/ECON-T is available
+  - No links mapping. Only the number of elinks per module/ECON-T is available. Both PU-driven and signal-driven elink distributions can be used.
   - Backend FPGA mappings are not available

--- a/L1Trigger/L1THGCal/python/customNewProcessors.py
+++ b/L1Trigger/L1THGCal/python/customNewProcessors.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+def custom_clustering_standalone(process):
+    process.hgcalBackEndLayer2Producer.ProcessorParameters.ProcessorName = cms.string('HGCalBackendLayer2Processor3DClusteringSA')
+    return process
+
+def custom_tower_standalone(process):
+    process.hgcalTowerProducer.ProcessorParameters.ProcessorName = cms.string('HGCalTowerProcessorSA')
+    return process
+

--- a/L1Trigger/L1THGCal/python/customNewProcessors.py
+++ b/L1Trigger/L1THGCal/python/customNewProcessors.py
@@ -1,4 +1,13 @@
 import FWCore.ParameterSet.Config as cms
+from L1Trigger.L1THGCal.hgcalBackEndLayer1Producer_cfi import stage1truncation_proc
+
+
+def custom_stage1_truncation(process):
+    parameters = stage1truncation_proc.clone()
+    process.hgcalBackEndLayer1Producer.ProcessorParameters = parameters
+    process.hgcalBackEndLayer2Producer.InputCluster = cms.InputTag('hgcalBackEndLayer1Producer:HGCalBackendStage1Processor')
+    process.hgcalTowerProducer.InputTriggerCells = cms.InputTag('hgcalBackEndLayer1Producer:HGCalBackendStage1Processor')
+    return process
 
 def custom_clustering_standalone(process):
     process.hgcalBackEndLayer2Producer.ProcessorParameters.ProcessorName = cms.string('HGCalBackendLayer2Processor3DClusteringSA')

--- a/L1Trigger/L1THGCal/python/customNewProcessors.py
+++ b/L1Trigger/L1THGCal/python/customNewProcessors.py
@@ -1,12 +1,20 @@
 import FWCore.ParameterSet.Config as cms
+from L1Trigger.L1THGCal.hgcalBackEndLayer1Producer_cfi import layer1truncation_proc
 from L1Trigger.L1THGCal.hgcalBackEndLayer1Producer_cfi import stage1truncation_proc
 from L1Trigger.L1THGCal.hgcalBackEndLayer1Producer_cfi import truncation_params
+
+def custom_layer1_truncation(process):
+    parameters = layer1truncation_proc.clone()
+    process.hgcalBackEndLayer1Producer.ProcessorParameters = parameters
+    process.hgcalBackEndLayer2Producer.InputCluster = cms.InputTag('hgcalBackEndLayer1Producer:HGCalBackendLayer1Processor')
+    process.hgcalTowerProducer.InputTriggerCells = cms.InputTag('hgcalBackEndLayer1Producer:HGCalBackendLayer1Processor')
+    return process
 
 def custom_stage1_truncation(process):
     parameters = stage1truncation_proc.clone()
     process.hgcalBackEndLayer1Producer.ProcessorParameters = parameters
-    process.hgcalBackEndLayer2Producer.InputCluster = cms.InputTag('hgcalBackEndLayer1Producer:HGCalBackendStage1Processor')
-    process.hgcalTowerProducer.InputTriggerCells = cms.InputTag('hgcalBackEndLayer1Producer:HGCalBackendStage1Processor')
+    process.hgcalBackEndLayer2Producer.InputCluster = cms.InputTag('hgcalBackEndStage1Producer:HGCalBackendStage1Processor')
+    process.hgcalTowerProducer.InputTriggerCells = cms.InputTag('hgcalBackEndStage1Producer:HGCalBackendStage1Processor')
     return process
 
 def custom_clustering_standalone(process):
@@ -17,4 +25,3 @@ def custom_clustering_standalone(process):
 def custom_tower_standalone(process):
     process.hgcalTowerProducer.ProcessorParameters.ProcessorName = cms.string('HGCalTowerProcessorSA')
     return process
-

--- a/L1Trigger/L1THGCal/python/customNewProcessors.py
+++ b/L1Trigger/L1THGCal/python/customNewProcessors.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from L1Trigger.L1THGCal.hgcalBackEndLayer1Producer_cfi import stage1truncation_proc
-
+from L1Trigger.L1THGCal.hgcalBackEndLayer1Producer_cfi import truncation_params
 
 def custom_stage1_truncation(process):
     parameters = stage1truncation_proc.clone()
@@ -11,6 +11,7 @@ def custom_stage1_truncation(process):
 
 def custom_clustering_standalone(process):
     process.hgcalBackEndLayer2Producer.ProcessorParameters.ProcessorName = cms.string('HGCalBackendLayer2Processor3DClusteringSA')
+    process.hgcalBackEndLayer2Producer.ProcessorParameters.DistributionParameters = truncation_params
     return process
 
 def custom_tower_standalone(process):

--- a/L1Trigger/L1THGCal/python/customTriggerGeometry.py
+++ b/L1Trigger/L1THGCal/python/customTriggerGeometry.py
@@ -18,7 +18,7 @@ def custom_geometry_decentralized_V11(process, links='signaldriven',implementati
     process.hgcalTriggerGeometryESProducer.TriggerGeometry.L1TLinksMapping = cms.FileInPath(links_mapping)
     process.hgcalTriggerGeometryESProducer.TriggerGeometry.DisconnectedModules = cms.vuint32(0)
     process.hgcalTriggerGeometryESProducer.TriggerGeometry.ScintillatorLinksPerModule = cms.uint32(2)
-    process.hgcalTriggerGeometryESProducer.TriggerGeometry.JsonMappingFile = cms.FileInPath("L1Trigger/L1THGCal/data/hgcal_trigger_link_mapping_v1.json")
+    process.hgcalTriggerGeometryESProducer.TriggerGeometry.JsonMappingFile = cms.FileInPath("L1Trigger/L1THGCal/data/hgcal_trigger_link_mapping_120links_v1.json")
     return process
 
 

--- a/L1Trigger/L1THGCal/python/customTriggerGeometry.py
+++ b/L1Trigger/L1THGCal/python/customTriggerGeometry.py
@@ -1,28 +1,34 @@
 import FWCore.ParameterSet.Config as cms
 
+def custom_geometry_V11_Imp3(process, stage1links=120):
+    process.hgcalTriggerGeometryESProducer.TriggerGeometry.TriggerGeometryName = cms.string('HGCalTriggerGeometryV9Imp3')
+    process.hgcalTriggerGeometryESProducer.TriggerGeometry.ScintillatorTriggerCellSize = cms.uint32(2)
+    if stage1links==120:
+        process.hgcalTriggerGeometryESProducer.TriggerGeometry.JsonMappingFile = cms.FileInPath("L1Trigger/L1THGCal/data/hgcal_trigger_link_mapping_120links_v1.json")
+    elif stage1links==72:
+        process.hgcalTriggerGeometryESProducer.TriggerGeometry.JsonMappingFile = cms.FileInPath("L1Trigger/L1THGCal/data/hgcal_trigger_link_mapping_72links_v2.json")
+    else:
+        raise RuntimeError('{} Stage 1 input links is not supported. Supported options are 72 or 120 links'.format(stage1links))
+    return process
 
-def custom_geometry_decentralized_V11(process, links='signaldriven',implementation=1):
+def custom_geometry_V11_Imp2(process, links='signaldriven'):
+    process.hgcalTriggerGeometryESProducer.TriggerGeometry.TriggerGeometryName = cms.string('HGCalTriggerGeometryV9Imp2')
     if links=='signaldriven':
         links_mapping = 'L1Trigger/L1THGCal/data/links_mapping_V11_decentralized_signaldriven_0.txt'
     elif links=='pudriven':
         links_mapping = 'L1Trigger/L1THGCal/data/links_mapping_V11_decentralized_march20_0.txt'
     else:
         raise RuntimeError('Unknown links mapping "{}". Options are "signaldriven" or "pudriven".'.format(links))
-    if implementation==1:
-        process.hgcalTriggerGeometryESProducer.TriggerGeometry.TriggerGeometryName = cms.string('HGCalTriggerGeometryV9Imp2')
-    elif implementation==2:
-        process.hgcalTriggerGeometryESProducer.TriggerGeometry.TriggerGeometryName = cms.string('HGCalTriggerGeometryV9Imp3')
     process.hgcalTriggerGeometryESProducer.TriggerGeometry.ScintillatorTriggerCellSize = cms.uint32(2)
     process.hgcalTriggerGeometryESProducer.TriggerGeometry.ScintillatorModuleSize = cms.uint32(6)
     process.hgcalTriggerGeometryESProducer.TriggerGeometry.L1TModulesMapping = cms.FileInPath("L1Trigger/L1THGCal/data/panel_mapping_V11_decentralized_march20_2.txt")
     process.hgcalTriggerGeometryESProducer.TriggerGeometry.L1TLinksMapping = cms.FileInPath(links_mapping)
     process.hgcalTriggerGeometryESProducer.TriggerGeometry.DisconnectedModules = cms.vuint32(0)
     process.hgcalTriggerGeometryESProducer.TriggerGeometry.ScintillatorLinksPerModule = cms.uint32(2)
-    process.hgcalTriggerGeometryESProducer.TriggerGeometry.JsonMappingFile = cms.FileInPath("L1Trigger/L1THGCal/data/hgcal_trigger_link_mapping_120links_v1.json")
     return process
 
 
-def custom_geometry_decentralized_V10(process, links='signaldriven'):
+def custom_geometry_V10(process, links='signaldriven'):
     if links=='signaldriven':
         links_mapping = 'L1Trigger/L1THGCal/data/links_mapping_decentralized_signaldriven_0.txt'
     elif links=='pudriven':

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer1Producer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer1Producer_cfi.py
@@ -57,6 +57,29 @@ constrTopological_C2d_params = cms.PSet(c2d_calib_pset,
                                         dR_cluster=cms.double(6.),
                                         )
 
+ntcs_72links = [ 1,  4, 13, 13, 10, 10,  8,  8,  8,  7,  7,  6,  6,  6,  6,  6,  5,  5,  5,  5,  5,  5,  5,  4,  4,  4,  4,  4,  4,  4,  4,  4,  3,  2,  2,  2,  2,  2,  2,  2,  2,  1]
+ntcs_120links = [ 2,  7, 27, 24, 19, 17, 16, 15, 14, 14, 13, 13, 13, 12, 12, 12, 11, 11, 11, 10, 10, 10, 10, 10,  9,  9, 10,  9,  9,  9,  8,  8,  7,  5,  3,  3,  3,  3,  3,  3,  3,  3]
+
+phi_edges = [0.98901991,0.72722052,0.6981317,0.87266463,0.93084227,0.90175345,
+0.87266463,0.90175345,0.95993109,0.95993109,0.93084227,0.93084227,
+0.95993109,0.98901991,0.95993109,0.95993109,0.95993109,0.98901991,
+0.98901991,0.95993109,0.95993109,0.98901991,0.98901991,0.98901991,
+0.98901991,0.98901991,1.01810873,0.98901991,0.98901991,0.98901991,
+0.98901991,0.98901991,0.98901991,0.98901991,1.04719755,1.04719755,
+1.04719755,1.04719755,1.01810873,1.04719755,1.01810873,1.01810873]
+
+truncation_params = cms.PSet(rozMin=cms.double(0.07587128),
+        rozMax=cms.double(0.55508006),
+        rozBins=cms.uint32(42),
+        maxTcsPerBin=cms.vuint32(ntcs_72links),
+        phiSectorEdges=cms.vdouble(phi_edges)
+        )
+
+
+stage1truncation_proc = cms.PSet(ProcessorName  = cms.string('HGCalBackendStage1Processor'),
+                   C2d_parameters = dummy_C2d_params.clone(),
+                   truncation_parameters = truncation_params.clone()
+                   )
 
 be_proc = cms.PSet(ProcessorName  = cms.string('HGCalBackendLayer1Processor2DClustering'),
                    C2d_parameters = dummy_C2d_params.clone()

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer1Producer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer1Producer_cfi.py
@@ -72,12 +72,16 @@ truncation_params = cms.PSet(rozMin=cms.double(0.07587128),
         rozMax=cms.double(0.55508006),
         rozBins=cms.uint32(42),
         maxTcsPerBin=cms.vuint32(ntcs_72links),
-        phiSectorEdges=cms.vdouble(phi_edges)
+        phiSectorEdges=cms.vdouble(phi_edges),
+        doTruncation=cms.bool(True)
         )
 
 
-stage1truncation_proc = cms.PSet(ProcessorName  = cms.string('HGCalBackendStage1Processor'),
+layer1truncation_proc = cms.PSet(ProcessorName  = cms.string('HGCalBackendLayer1Processor'),
                    C2d_parameters = dummy_C2d_params.clone(),
+                   truncation_parameters = truncation_params.clone()
+                   )
+stage1truncation_proc = cms.PSet(ProcessorName  = cms.string('HGCalBackendStage1Processor'),
                    truncation_parameters = truncation_params.clone()
                    )
 
@@ -89,6 +93,13 @@ hgcalBackEndLayer1Producer = cms.EDProducer(
     "HGCalBackendLayer1Producer",
     InputTriggerCells = cms.InputTag('hgcalConcentratorProducer:HGCalConcentratorProcessorSelection'),
     ProcessorParameters = be_proc.clone()
+    )
+
+hgcalBackEndStage1Producer = cms.EDProducer(
+    "HGCalBackendStage1Producer",
+    InputTriggerCells = cms.InputTag('hgcalConcentratorProducer:HGCalConcentratorProcessorSelection'),
+    C2d_parameters = dummy_C2d_params.clone(),
+    ProcessorParameters = stage1truncation_proc.clone()
     )
 
 hgcalBackEndLayer1ProducerHFNose = hgcalBackEndLayer1Producer.clone(

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer1Producer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer1Producer_cfi.py
@@ -71,7 +71,16 @@ phi_edges = [0.98901991,0.72722052,0.6981317,0.87266463,0.93084227,0.90175345,
 truncation_params = cms.PSet(rozMin=cms.double(0.07587128),
         rozMax=cms.double(0.55508006),
         rozBins=cms.uint32(42),
-        maxTcsPerBin=cms.vuint32(ntcs_72links),
+        maxTcsPerBin=cms.vuint32(ntcs_120links),
+        phiSectorEdges=cms.vdouble(phi_edges),
+        doTruncation=cms.bool(True)
+        )
+
+truncation_paramsSA = cms.PSet(AlgoName=cms.string('HGCalStage1TruncationWrapper'),
+        rozMin=cms.double(0.07587128),
+        rozMax=cms.double(0.55508006),
+        rozBins=cms.uint32(42),
+        maxTcsPerBin=cms.vuint32(ntcs_120links),
         phiSectorEdges=cms.vdouble(phi_edges),
         doTruncation=cms.bool(True)
         )
@@ -82,7 +91,7 @@ layer1truncation_proc = cms.PSet(ProcessorName  = cms.string('HGCalBackendLayer1
                    truncation_parameters = truncation_params.clone()
                    )
 stage1truncation_proc = cms.PSet(ProcessorName  = cms.string('HGCalBackendStage1Processor'),
-                   truncation_parameters = truncation_params.clone()
+                   truncation_parameters = truncation_paramsSA.clone()
                    )
 
 be_proc = cms.PSet(ProcessorName  = cms.string('HGCalBackendLayer1Processor2DClustering'),

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer1Producer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer1Producer_cfi.py
@@ -112,5 +112,5 @@ hgcalBackEndStage1Producer = cms.EDProducer(
     )
 
 hgcalBackEndLayer1ProducerHFNose = hgcalBackEndLayer1Producer.clone(
-    InputTriggerCells = cms.InputTag('hgcalConcentratorProducerHFNose:HGCalConcentratorProcessorSelection')
+    InputTriggerCells = 'hgcalConcentratorProducerHFNose:HGCalConcentratorProcessorSelection'
 )

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer1_cff.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer1_cff.py
@@ -5,6 +5,6 @@ from L1Trigger.L1THGCal.hgcalBackEndLayer1Producer_cfi import *
 
 
 hgcalBackEndLayer1 = cms.Task(hgcalBackEndLayer1Producer)
+hgcalBackEndStage1 = cms.Task(hgcalBackEndStage1Producer)
 
 hgcalBackEndLayer1HFNose = cms.Task(hgcalBackEndLayer1ProducerHFNose)
-

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
@@ -110,6 +110,7 @@ phase2_hgcalV10.toModify(histoMax_C3d_seeding_params,
 
 
 histoMaxVariableDR_C3d_params = histoMax_C3d_clustering_params.clone(
+        AlgoName = cms.string('HGCalHistoClusteringWrapper'),
         dR_multicluster = cms.double(0.),
         dR_multicluster_byLayer_coefficientA = cms.vdouble(dr_layerbylayer),
         dR_multicluster_byLayer_coefficientB = cms.vdouble([0]*(MAX_LAYERS+1))

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
@@ -22,7 +22,6 @@ FH_DR_GROUP = 6
 BH_DR_GROUP = 12
 MAX_LAYERS = 52
 
-
 dr_layerbylayer = ([0] + # no layer 0
         [0.015]*EE_DR_GROUP + [0.020]*EE_DR_GROUP + [0.030]*EE_DR_GROUP + [0.040]*EE_DR_GROUP + # EM
         [0.040]*FH_DR_GROUP + [0.050]*FH_DR_GROUP + # FH
@@ -56,7 +55,6 @@ seed_smoothing_hcal = cms.vdouble(
         1., 1., 1., 1., 1.,
         1., 1., 1., 1., 1.,
         )
-
 
 distance_C3d_params = cms.PSet(type_multicluster=cms.string('dRC3d'),
                                dR_multicluster=cms.double(0.01),
@@ -100,6 +98,10 @@ histoMax_C3d_clustering_params = cms.PSet(dR_multicluster=cms.double(0.03),
                                )
 
 
+histoMax_C3d_sorting_truncation_params = cms.PSet(AlgoName = cms.string('HGCalSortingTruncationWrapper'),
+                                                  maxTCs=cms.uint32(80),
+                               )
+
 # >= V9 samples have a different definition of the dEdx calibrations. To account for it
 # we rescale the thresholds of the clustering seeds
 # (see https://indico.cern.ch/event/806845/contributions/3359859/attachments/1815187/2966402/19-03-20_EGPerf_HGCBE.pdf
@@ -141,6 +143,7 @@ histoMax_C3d_params = cms.PSet(
         type_multicluster=cms.string('Histo'),
         histoMax_C3d_clustering_parameters = histoMaxVariableDR_C3d_params.clone(),
         histoMax_C3d_seeding_parameters = histoMax_C3d_seeding_params.clone(),
+        histoMax_C3d_sorting_truncation_parameters = histoMax_C3d_sorting_truncation_params.clone(),
         )
 
 

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer2Producer_cfi.py
@@ -179,6 +179,11 @@ hgcalBackEndLayer2Producer = cms.EDProducer(
     ProcessorParameters = be_proc.clone()
     )
 
+hgcalBackEndStage2Producer = cms.EDProducer(
+    "HGCalBackendLayer2Producer",
+    InputCluster = cms.InputTag('hgcalBackEndStage1Producer:HGCalBackendStage1Processor'),
+    ProcessorParameters = be_proc.clone()
+    )
 
 hgcalBackEndLayer2ProducerHFNose = hgcalBackEndLayer2Producer.clone(
     InputCluster = cms.InputTag('hgcalBackEndLayer1ProducerHFNose:HGCalBackendLayer1Processor2DClustering'),

--- a/L1Trigger/L1THGCal/python/hgcalBackEndLayer2_cff.py
+++ b/L1Trigger/L1THGCal/python/hgcalBackEndLayer2_cff.py
@@ -5,6 +5,6 @@ from L1Trigger.L1THGCal.hgcalBackEndLayer2Producer_cfi import *
 
 
 hgcalBackEndLayer2 = cms.Task(hgcalBackEndLayer2Producer)
+hgcalBackEndStage2 = cms.Task(hgcalBackEndStage2Producer)
 
 hgcalBackEndLayer2HFNose = cms.Task(hgcalBackEndLayer2ProducerHFNose)
-

--- a/L1Trigger/L1THGCal/python/hgcalTowerMapProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTowerMapProducer_cfi.py
@@ -14,6 +14,7 @@ L1TTriggerTowerConfig_etaphi = cms.PSet(readMappingFile=cms.bool(False),
 
 towerMap2D_parValues = cms.PSet( useLayerWeights = cms.bool(False),
                                  layerWeights = cms.vdouble(),
+                                  AlgoName = cms.string('HGCalTowerMapsWrapper'),
                                  L1TTriggerTowerConfig = L1TTriggerTowerConfig_etaphi
 )
 

--- a/L1Trigger/L1THGCal/python/hgcalTriggerPrimitivesNew_cff.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerPrimitivesNew_cff.py
@@ -20,10 +20,10 @@ phase2_hfnose.toReplaceWith(
 
 from Configuration.Eras.Modifier_phase2_hgcalV10_cff import phase2_hgcalV10
 from Configuration.Eras.Modifier_phase2_hgcalV11_cff import phase2_hgcalV11
-from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_decentralized_V10, custom_geometry_decentralized_V11
+from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_V10, custom_geometry_V11_Imp3
 from L1Trigger.L1THGCal.customCalibration import  custom_cluster_calibration_global
-modifyHgcalTriggerPrimitivesWithV10Geometry_ = (phase2_hgcalV10 & ~phase2_hgcalV11).makeProcessModifier(custom_geometry_decentralized_V10)
-modifyHgcalTriggerPrimitivesWithV11Geometry_ = phase2_hgcalV11.makeProcessModifier(custom_geometry_decentralized_V11)
+modifyHgcalTriggerPrimitivesWithV10Geometry_ = (phase2_hgcalV10 & ~phase2_hgcalV11).makeProcessModifier(custom_geometry_V10)
+modifyHgcalTriggerPrimitivesWithV11Geometry_ = phase2_hgcalV11.makeProcessModifier(custom_geometry_V11_Imp3)
 
 from Configuration.ProcessModifiers.convertHGCalDigisSim_cff import convertHGCalDigisSim
 # can't declare a producer version of simHGCalUnsuppressedDigis in the normal flow of things,

--- a/L1Trigger/L1THGCal/python/hgcalTriggerPrimitivesNew_cff.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerPrimitivesNew_cff.py
@@ -1,0 +1,35 @@
+import FWCore.ParameterSet.Config as cms
+
+from L1Trigger.L1THGCal.hgcalTriggerGeometryESProducer_cfi import *
+from L1Trigger.L1THGCal.hgcalVFE_cff import *
+from L1Trigger.L1THGCal.hgcalConcentrator_cff import *
+from L1Trigger.L1THGCal.hgcalBackEndLayer1_cff import *
+from L1Trigger.L1THGCal.hgcalBackEndLayer2_cff import *
+from L1Trigger.L1THGCal.hgcalTowerMap_cff import *
+from L1Trigger.L1THGCal.hgcalTower_cff import *
+
+hgcalTriggerPrimitivesTask = cms.Task(hgcalVFE, hgcalConcentrator, hgcalBackEndStage1, hgcalBackEndStage2, hgcalTowerMap, hgcalTower)
+hgcalTriggerPrimitives = cms.Sequence(hgcalTriggerPrimitivesTask)
+
+_hfnose_hgcalTriggerPrimitivesTask = hgcalTriggerPrimitivesTask.copy()
+_hfnose_hgcalTriggerPrimitivesTask.add(hfnoseVFE, hgcalConcentratorHFNose, hgcalBackEndLayer1HFNose, hgcalBackEndLayer2HFNose, hgcalTowerMapHFNose, hgcalTowerHFNose)
+
+from Configuration.Eras.Modifier_phase2_hfnose_cff import phase2_hfnose
+phase2_hfnose.toReplaceWith(
+        hgcalTriggerPrimitivesTask, _hfnose_hgcalTriggerPrimitivesTask )
+
+from Configuration.Eras.Modifier_phase2_hgcalV10_cff import phase2_hgcalV10
+from Configuration.Eras.Modifier_phase2_hgcalV11_cff import phase2_hgcalV11
+from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_decentralized_V10, custom_geometry_decentralized_V11
+from L1Trigger.L1THGCal.customCalibration import  custom_cluster_calibration_global
+modifyHgcalTriggerPrimitivesWithV10Geometry_ = (phase2_hgcalV10 & ~phase2_hgcalV11).makeProcessModifier(custom_geometry_decentralized_V10)
+modifyHgcalTriggerPrimitivesWithV11Geometry_ = phase2_hgcalV11.makeProcessModifier(custom_geometry_decentralized_V11)
+
+from Configuration.ProcessModifiers.convertHGCalDigisSim_cff import convertHGCalDigisSim
+# can't declare a producer version of simHGCalUnsuppressedDigis in the normal flow of things,
+# because it's already an EDAlias elsewhere
+def _fakeHGCalDigiAlias(process):
+	from EventFilter.HGCalRawToDigi.HGCDigiConverter_cfi import HGCDigiConverter as _HGCDigiConverter
+	process.simHGCalUnsuppressedDigis = _HGCDigiConverter.clone()
+	process.hgcalTriggerPrimitivesTask.add(process.simHGCalUnsuppressedDigis)
+doFakeHGCalDigiAlias = convertHGCalDigisSim.makeProcessModifier(_fakeHGCalDigiAlias)

--- a/L1Trigger/L1THGCal/python/hgcalTriggerPrimitives_cff.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerPrimitives_cff.py
@@ -20,10 +20,10 @@ phase2_hfnose.toReplaceWith(
 
 from Configuration.Eras.Modifier_phase2_hgcalV10_cff import phase2_hgcalV10
 from Configuration.Eras.Modifier_phase2_hgcalV11_cff import phase2_hgcalV11
-from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_decentralized_V10, custom_geometry_decentralized_V11
+from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_V10, custom_geometry_V11_Imp3
 from L1Trigger.L1THGCal.customCalibration import  custom_cluster_calibration_global
-modifyHgcalTriggerPrimitivesWithV10Geometry_ = (phase2_hgcalV10 & ~phase2_hgcalV11).makeProcessModifier(custom_geometry_decentralized_V10)
-modifyHgcalTriggerPrimitivesWithV11Geometry_ = phase2_hgcalV11.makeProcessModifier(custom_geometry_decentralized_V11)
+modifyHgcalTriggerPrimitivesWithV10Geometry_ = (phase2_hgcalV10 & ~phase2_hgcalV11).makeProcessModifier(custom_geometry_V10)
+modifyHgcalTriggerPrimitivesWithV11Geometry_ = phase2_hgcalV11.makeProcessModifier(custom_geometry_V11_Imp3)
 
 from Configuration.ProcessModifiers.convertHGCalDigisSim_cff import convertHGCalDigisSim
 # can't declare a producer version of simHGCalUnsuppressedDigis in the normal flow of things,

--- a/L1Trigger/L1THGCal/src/HGCalAlgoWrapperBase.cc
+++ b/L1Trigger/L1THGCal/src/HGCalAlgoWrapperBase.cc
@@ -1,0 +1,5 @@
+#include "L1Trigger/L1THGCal/interface/HGCalAlgoWrapperBase.h"
+
+EDM_REGISTER_PLUGINFACTORY(HGCalHistoClusteringWrapperBaseFactory, "HGCalHistoClusteringWrapperBaseFactory");
+
+EDM_REGISTER_PLUGINFACTORY(HGCalTowerMapsWrapperBaseFactory, "HGCalTowerMapsWrapperBaseFactory");

--- a/L1Trigger/L1THGCal/src/HGCalAlgoWrapperBase.cc
+++ b/L1Trigger/L1THGCal/src/HGCalAlgoWrapperBase.cc
@@ -5,3 +5,5 @@ EDM_REGISTER_PLUGINFACTORY(HGCalHistoClusteringWrapperBaseFactory, "HGCalHistoCl
 EDM_REGISTER_PLUGINFACTORY(HGCalTowerMapsWrapperBaseFactory, "HGCalTowerMapsWrapperBaseFactory");
 
 EDM_REGISTER_PLUGINFACTORY(HGCalStage2FilteringWrapperBaseFactory, "HGCalStage2FilteringWrapperBaseFactory");
+
+EDM_REGISTER_PLUGINFACTORY(HGCalStage1TruncationWrapperBaseFactory, "HGCalStage1TruncationWrapperBaseFactory");

--- a/L1Trigger/L1THGCal/src/HGCalAlgoWrapperBase.cc
+++ b/L1Trigger/L1THGCal/src/HGCalAlgoWrapperBase.cc
@@ -3,3 +3,5 @@
 EDM_REGISTER_PLUGINFACTORY(HGCalHistoClusteringWrapperBaseFactory, "HGCalHistoClusteringWrapperBaseFactory");
 
 EDM_REGISTER_PLUGINFACTORY(HGCalTowerMapsWrapperBaseFactory, "HGCalTowerMapsWrapperBaseFactory");
+
+EDM_REGISTER_PLUGINFACTORY(HGCalStage2FilteringWrapperBaseFactory, "HGCalStage2FilteringWrapperBaseFactory");

--- a/L1Trigger/L1THGCal/src/HGCalProcessorBase.cc
+++ b/L1Trigger/L1THGCal/src/HGCalProcessorBase.cc
@@ -6,6 +6,8 @@ EDM_REGISTER_PLUGINFACTORY(HGCalConcentratorFactory, "HGCalConcentratorFactory")
 
 EDM_REGISTER_PLUGINFACTORY(HGCalBackendLayer1Factory, "HGCalBackendLayer1Factory");
 
+EDM_REGISTER_PLUGINFACTORY(HGCalBackendStage1Factory, "HGCalBackendStage1Factory");
+
 EDM_REGISTER_PLUGINFACTORY(HGCalBackendLayer2Factory, "HGCalBackendLayer2Factory");
 
 EDM_REGISTER_PLUGINFACTORY(HGCalTowerMapFactory, "HGCalTowerMapFactory");

--- a/L1Trigger/L1THGCal/src/backend/HGCalHistoClusteringImpl_SA.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalHistoClusteringImpl_SA.cc
@@ -1,0 +1,110 @@
+#include "L1Trigger/L1THGCal/interface/backend/HGCalHistoClusteringImpl_SA.h"
+
+#include <map>
+#include <cmath>
+
+HGCalHistoClusteringImplSA::HGCalHistoClusteringImplSA() {}
+
+// void HGCalHistoClusteringImplSA::runAlgorithm() const {
+
+// }
+
+std::vector<l1thgcfirmware::HGCalMulticluster> HGCalHistoClusteringImplSA::clusterSeedMulticluster_SA(
+    const std::vector<l1thgcfirmware::HGCalCluster>& clusters,
+    const std::vector<l1thgcfirmware::HGCalSeed>& seeds,
+    std::vector<l1thgcfirmware::HGCalCluster>& rejected_clusters,
+    const l1thgcfirmware::ClusterAlgoConfig& configuration) const {
+  std::map<int, l1thgcfirmware::HGCalMulticluster> mapSeedMulticluster;
+  std::vector<l1thgcfirmware::HGCalMulticluster> multiclustersOut;
+
+  for (const auto& clu : clusters) {
+    int z_side = clu.zside();
+
+    double radiusCoefficientA = configuration.dr_byLayer_coefficientA().empty()
+                                    ? configuration.dr()
+                                    : configuration.dr_byLayer_coefficientA()[clu.layer()];
+    double radiusCoefficientB =
+        configuration.dr_byLayer_coefficientB().empty() ? 0 : configuration.dr_byLayer_coefficientB()[clu.layer()];
+
+    double minDist = radiusCoefficientA + radiusCoefficientB * (configuration.midRadius() - std::abs(clu.eta()));
+
+    std::vector<std::pair<int, double>> targetSeedsEnergy;
+
+    unsigned int iseed = 0;
+    for (const auto& seed : seeds) {
+      if (z_side * seed.z() < 0) {
+        ++iseed;
+        continue;
+      }
+
+      double seedEnergy = seed.energy();
+
+      double d = sqrt((clu.x() - seed.x()) * (clu.x() - seed.x()) + (clu.y() - seed.y()) * (clu.y() - seed.y()));
+
+      if (d < minDist) {
+        // NearestNeighbour
+        minDist = d;
+
+        if (targetSeedsEnergy.empty()) {
+          targetSeedsEnergy.emplace_back(iseed, seedEnergy);
+        } else {
+          targetSeedsEnergy.at(0).first = iseed;
+          targetSeedsEnergy.at(0).second = seedEnergy;
+        }
+      }
+      ++iseed;
+    }
+
+    if (targetSeedsEnergy.empty()) {
+      rejected_clusters.emplace_back(clu);
+      continue;
+    }
+
+    // N.B. as I have only implemented NearestNeighbour option
+    // then targetSeedsEnergy has at most 1 seed for this cluster
+    // Leaving in some redundant functionality in case we need
+    // EnergySplit option
+
+    //Loop over target seeds and divide up the clusters energy
+    double totalTargetSeedEnergy = 0;
+    for (const auto& energy : targetSeedsEnergy) {
+      totalTargetSeedEnergy += energy.second;
+    }
+
+    for (const auto& energy : targetSeedsEnergy) {
+      double seedWeight = 1;
+      if (mapSeedMulticluster[energy.first].size() == 0) {
+        mapSeedMulticluster[energy.first] = l1thgcfirmware::HGCalMulticluster(clu, 1);
+      } else {
+        mapSeedMulticluster[energy.first].addConstituent(clu, true, seedWeight);
+      }
+    }
+  }
+
+  multiclustersOut.reserve(mapSeedMulticluster.size());
+  for (const auto& mclu : mapSeedMulticluster)
+    multiclustersOut.emplace_back(mclu.second);
+
+  return multiclustersOut;
+}
+
+void HGCalHistoClusteringImplSA::finalizeClusters_SA(
+    const std::vector<l1thgcfirmware::HGCalMulticluster>& multiclusters_in,
+    const std::vector<l1thgcfirmware::HGCalCluster>& rejected_clusters_in,
+    std::vector<l1thgcfirmware::HGCalMulticluster>& multiclusters_out,
+    std::vector<l1thgcfirmware::HGCalCluster>& rejected_clusters_out,
+    const l1thgcfirmware::ClusterAlgoConfig& configuration) const {
+  for (const auto& tc : rejected_clusters_in) {
+    rejected_clusters_out.push_back(tc);
+  }
+
+  for (const auto& multicluster : multiclusters_in) {
+    if (multicluster.sumPt() > configuration.ptC3dThreshold()) {
+      multiclusters_out.push_back(multicluster);
+    } else {
+      for (const auto& tc : multicluster.constituents()) {
+        rejected_clusters_out.push_back(tc);
+      }
+    }
+  }
+}

--- a/L1Trigger/L1THGCal/src/backend/HGCalHistoClusteringImpl_SA.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalHistoClusteringImpl_SA.cc
@@ -3,12 +3,6 @@
 #include <map>
 #include <cmath>
 
-HGCalHistoClusteringImplSA::HGCalHistoClusteringImplSA() {}
-
-// void HGCalHistoClusteringImplSA::runAlgorithm() const {
-
-// }
-
 std::vector<l1thgcfirmware::HGCalMulticluster> HGCalHistoClusteringImplSA::clusterSeedMulticluster_SA(
     const std::vector<l1thgcfirmware::HGCalCluster>& clusters,
     const std::vector<l1thgcfirmware::HGCalSeed>& seeds,
@@ -26,7 +20,8 @@ std::vector<l1thgcfirmware::HGCalMulticluster> HGCalHistoClusteringImplSA::clust
     double radiusCoefficientB =
         configuration.dr_byLayer_coefficientB().empty() ? 0 : configuration.dr_byLayer_coefficientB()[clu.layer()];
 
-    double minDist = radiusCoefficientA + radiusCoefficientB * (configuration.midRadius() - std::abs(clu.eta()));
+    double minDistSqrd = radiusCoefficientA + radiusCoefficientB * (configuration.midRadius() - std::abs(clu.eta()));
+    minDistSqrd *= minDistSqrd;
 
     std::vector<std::pair<int, double>> targetSeedsEnergy;
 
@@ -39,11 +34,11 @@ std::vector<l1thgcfirmware::HGCalMulticluster> HGCalHistoClusteringImplSA::clust
 
       double seedEnergy = seed.energy();
 
-      double d = sqrt((clu.x() - seed.x()) * (clu.x() - seed.x()) + (clu.y() - seed.y()) * (clu.y() - seed.y()));
+      double d = (clu.x() - seed.x()) * (clu.x() - seed.x()) + (clu.y() - seed.y()) * (clu.y() - seed.y());
 
-      if (d < minDist) {
+      if (d < minDistSqrd) {
         // NearestNeighbour
-        minDist = d;
+        minDistSqrd = d;
 
         if (targetSeedsEnergy.empty()) {
           targetSeedsEnergy.emplace_back(iseed, seedEnergy);

--- a/L1Trigger/L1THGCal/src/backend/HGCalMulticluster_SA.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalMulticluster_SA.cc
@@ -1,0 +1,55 @@
+#include "L1Trigger/L1THGCal/interface/backend/HGCalMulticluster_SA.h"
+
+#include <cmath>
+
+using namespace l1thgcfirmware;
+
+HGCalMulticluster::HGCalMulticluster(const HGCalCluster& tc, float fraction) {
+  HGCalMulticluster();
+  addConstituent(tc, true, fraction);
+}
+
+void HGCalMulticluster::addConstituent(const HGCalCluster& tc, bool updateCentre, float fraction) {
+  // If no constituents, set seedMiptPt to cluster mipPt
+  if (constituents_.empty()) {
+    // seedMipPt_ = cMipPt;
+    if (!updateCentre) {
+      centre_x_ = tc.x();
+      centre_y_ = tc.y();
+      centre_z_ = tc.z();
+    }
+  }
+  // UpdateP4AndPosition
+  updateP4AndPosition(tc, updateCentre, fraction);
+
+  constituents_.emplace_back(tc);
+}
+
+void HGCalMulticluster::updateP4AndPosition(const HGCalCluster& tc, bool updateCentre, float fraction) {
+  // Get cluster mipPt
+  double cMipt = tc.mipPt() * fraction;
+  double cPt = tc.pt() * fraction;
+  if (updateCentre) {
+    float clusterCentre_x = centre_x_ * mipPt_ + tc.x() * cMipt;
+    float clusterCentre_y = centre_y_ * mipPt_ + tc.y() * cMipt;
+    float clusterCentre_z = centre_z_ * mipPt_ + tc.z() * cMipt;  // Check this!
+
+    if ((mipPt_ + cMipt) > 0) {
+      clusterCentre_x /= (mipPt_ + cMipt);
+      clusterCentre_y /= (mipPt_ + cMipt);
+      clusterCentre_z /= (mipPt_ + cMipt);
+    }
+    centre_x_ = clusterCentre_x;
+    centre_y_ = clusterCentre_y;
+    centre_z_ = clusterCentre_z;
+
+    if (centre_z_ != 0) {
+      centreProj_x_ = centre_x_ / std::abs(centre_z_);
+      centreProj_y_ = centre_y_ / std::abs(centre_z_);
+      centreProj_z_ = centre_z_ / std::abs(centre_z_);
+    }
+  }
+
+  mipPt_ += cMipt;
+  sumPt_ += cPt;
+}

--- a/L1Trigger/L1THGCal/src/backend/HGCalSortingTruncationImpl_SA.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalSortingTruncationImpl_SA.cc
@@ -1,0 +1,24 @@
+#include "L1Trigger/L1THGCal/interface/backend/HGCalSortingTruncationImpl_SA.h"
+
+HGCalSortingTruncationImplSA::HGCalSortingTruncationImplSA() {}
+
+void HGCalSortingTruncationImplSA::sortAndTruncate_SA(
+    const std::vector<l1thgcfirmware::HGCalMulticluster>& inputMulticlusters,
+    std::vector<l1thgcfirmware::HGCalMulticluster>& outputMulticlusters,
+    const l1thgcfirmware::SortingTruncationAlgoConfig& configuration) const {
+  outputMulticlusters.reserve(inputMulticlusters.size());
+  for (const auto& multicluster : inputMulticlusters) {
+    outputMulticlusters.push_back(multicluster);
+  }
+
+  //Sort based on 3D cluster sum pT
+  std::sort(outputMulticlusters.begin(),
+            outputMulticlusters.end(),
+            [](l1thgcfirmware::HGCalMulticluster& one, l1thgcfirmware::HGCalMulticluster& two) {
+              return one.sumPt() < two.sumPt();
+            });
+
+  //Truncate, keeping maxTCs entries
+  unsigned maxTCs = configuration.maxTCs();
+  outputMulticlusters.resize(maxTCs);
+}

--- a/L1Trigger/L1THGCal/src/backend/HGCalSortingTruncationImpl_SA.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalSortingTruncationImpl_SA.cc
@@ -20,5 +20,7 @@ void HGCalSortingTruncationImplSA::sortAndTruncate_SA(
 
   //Truncate, keeping maxTCs entries
   unsigned maxTCs = configuration.maxTCs();
-  outputMulticlusters.resize(maxTCs);
+  if (outputMulticlusters.size() > maxTCs) {
+    outputMulticlusters.resize(maxTCs);
+  }
 }

--- a/L1Trigger/L1THGCal/src/backend/HGCalSortingTruncationImpl_SA.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalSortingTruncationImpl_SA.cc
@@ -1,7 +1,5 @@
 #include "L1Trigger/L1THGCal/interface/backend/HGCalSortingTruncationImpl_SA.h"
 
-HGCalSortingTruncationImplSA::HGCalSortingTruncationImplSA() {}
-
 void HGCalSortingTruncationImplSA::sortAndTruncate_SA(
     const std::vector<l1thgcfirmware::HGCalMulticluster>& inputMulticlusters,
     std::vector<l1thgcfirmware::HGCalMulticluster>& outputMulticlusters,

--- a/L1Trigger/L1THGCal/src/backend/HGCalStage1TruncationImpl.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalStage1TruncationImpl.cc
@@ -1,0 +1,102 @@
+#include "L1Trigger/L1THGCal/interface/backend/HGCalStage1TruncationImpl.h"
+#include "L1Trigger/L1THGCal/interface/HGCalBackendDetId.h"
+#include <cmath>
+
+HGCalStage1TruncationImpl::HGCalStage1TruncationImpl(const edm::ParameterSet& conf)
+    : roz_min_(conf.getParameter<double>("rozMin")),
+      roz_max_(conf.getParameter<double>("rozMax")),
+      roz_bins_(conf.getParameter<unsigned>("rozBins")),
+      max_tcs_per_bin_(conf.getParameter<std::vector<unsigned>>("maxTcsPerBin")),
+      phi_edges_(conf.getParameter<std::vector<double>>("phiSectorEdges")) {
+  if (max_tcs_per_bin_.size() != roz_bins_)
+    throw cms::Exception("HGCalStage1TruncationImpl::BadConfig") << "Inconsistent sizes of maxTcsPerBin and rozBins";
+  if (phi_edges_.size() != roz_bins_)
+    throw cms::Exception("HGCalStage1TruncationImpl::BadConfig") << "Inconsistent sizes of phiSectorEdges and rozBins";
+
+  constexpr double margin = 1.001;
+  roz_bin_size_ = (roz_bins_ > 0 ? (roz_max_ - roz_min_) * margin / double(roz_bins_) : 0.);
+}
+
+void HGCalStage1TruncationImpl::run(uint32_t fpga_id,
+                                    const std::vector<edm::Ptr<l1t::HGCalTriggerCell>>& tcs_in,
+                                    std::vector<edm::Ptr<l1t::HGCalTriggerCell>>& tcs_out) {
+  unsigned sector120 = HGCalBackendDetId(fpga_id).sector();
+  std::unordered_map<unsigned, std::vector<edm::Ptr<l1t::HGCalTriggerCell>>> tcs_per_bin;
+
+  // group TCs per (r/z, phi) bins
+  for (const auto& tc : tcs_in) {
+    const GlobalPoint& position = tc->position();
+    double x = position.x();
+    double y = position.y();
+    double z = position.z();
+    double roverz = std::sqrt(x * x + y * y) / std::abs(z);
+    roverz = (roverz < roz_min_ ? roz_min_ : roverz);
+    roverz = (roverz > roz_max_ ? roz_max_ : roverz);
+    unsigned roverzbin = (roz_bin_size_ > 0. ? unsigned((roverz - roz_min_) / roz_bin_size_) : 0);
+    double phi = rotatedphi(x, y, z, sector120);
+    unsigned phibin = phiBin(roverzbin, phi);
+    unsigned packed_bin = packBin(roverzbin, phibin);
+
+    tcs_per_bin[packed_bin].push_back(tc);
+  }
+  // apply sorting and trunction in each (r/z, phi) bin
+  for (auto& bin_tcs : tcs_per_bin) {
+    std::sort(bin_tcs.second.begin(),
+              bin_tcs.second.end(),
+              [](const edm::Ptr<l1t::HGCalTriggerCell>& a, const edm::Ptr<l1t::HGCalTriggerCell>& b) -> bool {
+                return a->mipPt() > b->mipPt();
+              });
+
+    unsigned roverzbin = 0;
+    unsigned phibin = 0;
+    unpackBin(bin_tcs.first, roverzbin, phibin);
+    if (roverzbin >= max_tcs_per_bin_.size())
+      throw cms::Exception("HGCalStage1TruncationImpl::OutOfRange")
+          << "roverzbin index " << roverzbin << "out of range";
+    unsigned max_tc = max_tcs_per_bin_[roverzbin];
+    if (bin_tcs.second.size() > max_tc) {
+      bin_tcs.second.resize(max_tc);
+    }
+    for (const auto& tc : bin_tcs.second) {
+      tcs_out.push_back(tc);
+    }
+  }
+}
+
+unsigned HGCalStage1TruncationImpl::packBin(unsigned roverzbin, unsigned phibin) const {
+  unsigned packed_bin = 0;
+  packed_bin |= ((roverzbin & mask_roz_) << offset_roz_);
+  packed_bin |= (phibin & mask_phi_);
+  return packed_bin;
+}
+
+void HGCalStage1TruncationImpl::unpackBin(unsigned packedbin, unsigned& roverzbin, unsigned& phibin) const {
+  roverzbin = ((packedbin >> offset_roz_) & mask_roz_);
+  phibin = (packedbin & mask_phi_);
+}
+
+unsigned HGCalStage1TruncationImpl::phiBin(unsigned roverzbin, double phi) const {
+  unsigned phi_bin = 0;
+  if (roverzbin >= phi_edges_.size())
+    throw cms::Exception("HGCalStage1TruncationImpl::OutOfRange") << "roverzbin index " << roverzbin << "out of range";
+  double phi_edge = phi_edges_[roverzbin];
+  if (phi > phi_edge)
+    phi_bin = 1;
+  return phi_bin;
+}
+
+double HGCalStage1TruncationImpl::rotatedphi(double x, double y, double z, int sector) const {
+  if (z > 0)
+    x = -x;
+  double phi = std::atan2(y, x);
+
+  if (sector == 1) {
+    if (phi < M_PI and phi > 0)
+      phi = phi - (2. * M_PI / 3.);
+    else
+      phi = phi + (4. * M_PI / 3.);
+  } else if (sector == 2) {
+    phi = phi + (2. * M_PI / 3.);
+  }
+  return phi;
+}

--- a/L1Trigger/L1THGCal/src/backend/HGCalStage1TruncationImpl.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalStage1TruncationImpl.cc
@@ -1,5 +1,5 @@
 #include "L1Trigger/L1THGCal/interface/backend/HGCalStage1TruncationImpl.h"
-#include "L1Trigger/L1THGCal/interface/HGCalBackendDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCalTriggerBackendDetId.h"
 #include <cmath>
 
 HGCalStage1TruncationImpl::HGCalStage1TruncationImpl(const edm::ParameterSet& conf)
@@ -21,7 +21,7 @@ HGCalStage1TruncationImpl::HGCalStage1TruncationImpl(const edm::ParameterSet& co
 void HGCalStage1TruncationImpl::run(uint32_t fpga_id,
                                     const std::vector<edm::Ptr<l1t::HGCalTriggerCell>>& tcs_in,
                                     std::vector<edm::Ptr<l1t::HGCalTriggerCell>>& tcs_out) {
-  unsigned sector120 = HGCalBackendDetId(fpga_id).sector();
+  unsigned sector120 = HGCalTriggerBackendDetId(fpga_id).sector();
   std::unordered_map<unsigned, std::vector<edm::Ptr<l1t::HGCalTriggerCell>>> tcs_per_bin;
 
   // group TCs per (r/z, phi) bins

--- a/L1Trigger/L1THGCal/src/backend/HGCalStage1TruncationImpl.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalStage1TruncationImpl.cc
@@ -3,7 +3,8 @@
 #include <cmath>
 
 HGCalStage1TruncationImpl::HGCalStage1TruncationImpl(const edm::ParameterSet& conf)
-    : roz_min_(conf.getParameter<double>("rozMin")),
+    : do_truncate_(conf.getParameter<bool>("doTruncation")),
+      roz_min_(conf.getParameter<double>("rozMin")),
       roz_max_(conf.getParameter<double>("rozMax")),
       roz_bins_(conf.getParameter<unsigned>("rozBins")),
       max_tcs_per_bin_(conf.getParameter<std::vector<unsigned>>("maxTcsPerBin")),
@@ -54,7 +55,7 @@ void HGCalStage1TruncationImpl::run(uint32_t fpga_id,
       throw cms::Exception("HGCalStage1TruncationImpl::OutOfRange")
           << "roverzbin index " << roverzbin << "out of range";
     unsigned max_tc = max_tcs_per_bin_[roverzbin];
-    if (bin_tcs.second.size() > max_tc) {
+    if (do_truncate_ && bin_tcs.second.size() > max_tc) {
       bin_tcs.second.resize(max_tc);
     }
     for (const auto& tc : bin_tcs.second) {

--- a/L1Trigger/L1THGCal/src/backend/HGCalStage1TruncationImpl.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalStage1TruncationImpl.cc
@@ -30,10 +30,12 @@ void HGCalStage1TruncationImpl::run(uint32_t fpga_id,
     double x = position.x();
     double y = position.y();
     double z = position.z();
-    double roverz = std::sqrt(x * x + y * y) / std::abs(z);
-    roverz = (roverz < roz_min_ ? roz_min_ : roverz);
-    roverz = (roverz > roz_max_ ? roz_max_ : roverz);
-    unsigned roverzbin = (roz_bin_size_ > 0. ? unsigned((roverz - roz_min_) / roz_bin_size_) : 0);
+    unsigned roverzbin = 0;
+    if (roz_bin_size_ > 0.) {
+      double roverz = std::sqrt(x * x + y * y) / std::abs(z) - roz_min_;
+      roverz = std::clamp(roverz, 0., roz_max_ - roz_min_);
+      roverzbin = unsigned(roverz / roz_bin_size_);
+    }
     double phi = rotatedphi(x, y, z, sector120);
     unsigned phibin = phiBin(roverzbin, phi);
     unsigned packed_bin = packBin(roverzbin, phibin);

--- a/L1Trigger/L1THGCal/src/backend/HGCalStage1TruncationImpl_SA.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalStage1TruncationImpl_SA.cc
@@ -1,0 +1,104 @@
+#include "L1Trigger/L1THGCal/interface/backend/HGCalStage1TruncationImpl_SA.h"
+#include <cmath>
+
+HGCalStage1TruncationImplSA::HGCalStage1TruncationImplSA() {}
+
+unsigned HGCalStage1TruncationImplSA::run(const l1thgcfirmware::HGCalTriggerCellSACollection& tcs_in,
+                                          const l1thgcfirmware::Stage1TruncationConfig& theConf,
+                                          l1thgcfirmware::HGCalTriggerCellSACollection& tcs_out) const {
+  unsigned sector120 = theConf.phiSector();
+  std::unordered_map<unsigned, l1thgcfirmware::HGCalTriggerCellSACollection> tcs_per_bin;
+
+  // configuation:
+  bool do_truncate = theConf.doTruncate();
+  double rozmin = theConf.rozMin();
+  double rozmax = theConf.rozMax();
+  unsigned rozbins = theConf.rozBins();
+  const std::vector<unsigned>& maxtcsperbin = theConf.maxTcsPerBin();
+  const std::vector<double>& phiedges = theConf.phiEdges();
+
+  constexpr double margin = 1.001;
+  double roz_bin_size = (rozbins > 0 ? (rozmax - rozmin) * margin / double(rozbins) : 0.);
+
+  // group TCs per (r/z, phi) bins
+  for (const auto& tc : tcs_in) {
+    double x = tc.x();
+    double y = tc.y();
+    double z = tc.z();
+    double roverz = std::sqrt(x * x + y * y) / std::abs(z);
+    roverz = (roverz < rozmin ? rozmin : roverz);
+    roverz = (roverz > rozmax ? rozmax : roverz);
+
+    unsigned roverzbin = (roz_bin_size > 0. ? unsigned((roverz - rozmin) / roz_bin_size) : 0);
+    double phi = rotatedphi(x, y, z, sector120);
+    int phibin = phiBin(roverzbin, phi, phiedges);
+    if (phibin < 0)
+      return 1;
+    unsigned packed_bin = packBin(roverzbin, phibin);
+
+    tcs_per_bin[packed_bin].push_back(tc);
+  }
+  // apply sorting and trunction in each (r/z, phi) bin
+  for (auto& bin_tcs : tcs_per_bin) {
+    std::sort(bin_tcs.second.begin(),
+              bin_tcs.second.end(),
+              [](const l1thgcfirmware::HGCalTriggerCell& a, const l1thgcfirmware::HGCalTriggerCell& b) -> bool {
+                return a.mipPt() > b.mipPt();
+              });
+
+    unsigned roverzbin = 0;
+    unsigned phibin = 0;
+    unpackBin(bin_tcs.first, roverzbin, phibin);
+    if (roverzbin >= maxtcsperbin.size())
+      return 1;
+
+    unsigned max_tc = maxtcsperbin[roverzbin];
+    if (do_truncate && bin_tcs.second.size() > max_tc) {
+      bin_tcs.second.resize(max_tc);
+    }
+
+    for (const auto& tc : bin_tcs.second) {
+      tcs_out.push_back(tc);
+    }
+  }
+
+  return 0;
+}
+
+unsigned HGCalStage1TruncationImplSA::packBin(unsigned roverzbin, unsigned phibin) const {
+  unsigned packed_bin = 0;
+  packed_bin |= ((roverzbin & mask_roz_) << offset_roz_);
+  packed_bin |= (phibin & mask_phi_);
+  return packed_bin;
+}
+
+void HGCalStage1TruncationImplSA::unpackBin(unsigned packedbin, unsigned& roverzbin, unsigned& phibin) const {
+  roverzbin = ((packedbin >> offset_roz_) & mask_roz_);
+  phibin = (packedbin & mask_phi_);
+}
+
+int HGCalStage1TruncationImplSA::phiBin(unsigned roverzbin, double phi, const std::vector<double>& phiedges) const {
+  int phi_bin = 0;
+  if (roverzbin >= phiedges.size())
+    return -1;
+  double phi_edge = phiedges[roverzbin];
+  if (phi > phi_edge)
+    phi_bin = 1;
+  return phi_bin;
+}
+
+double HGCalStage1TruncationImplSA::rotatedphi(double x, double y, double z, int sector) const {
+  if (z > 0)
+    x = -x;
+  double phi = std::atan2(y, x);
+
+  if (sector == 1) {
+    if (phi < M_PI and phi > 0)
+      phi = phi - (2. * M_PI / 3.);
+    else
+      phi = phi + (4. * M_PI / 3.);
+  } else if (sector == 2) {
+    phi = phi + (2. * M_PI / 3.);
+  }
+  return phi;
+}

--- a/L1Trigger/L1THGCal/src/backend/HGCalStage1TruncationImpl_SA.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalStage1TruncationImpl_SA.cc
@@ -1,8 +1,6 @@
 #include "L1Trigger/L1THGCal/interface/backend/HGCalStage1TruncationImpl_SA.h"
 #include <cmath>
 
-HGCalStage1TruncationImplSA::HGCalStage1TruncationImplSA() {}
-
 unsigned HGCalStage1TruncationImplSA::run(const l1thgcfirmware::HGCalTriggerCellSACollection& tcs_in,
                                           const l1thgcfirmware::Stage1TruncationConfig& theConf,
                                           l1thgcfirmware::HGCalTriggerCellSACollection& tcs_out) const {
@@ -25,11 +23,12 @@ unsigned HGCalStage1TruncationImplSA::run(const l1thgcfirmware::HGCalTriggerCell
     double x = tc.x();
     double y = tc.y();
     double z = tc.z();
-    double roverz = std::sqrt(x * x + y * y) / std::abs(z);
-    roverz = (roverz < rozmin ? rozmin : roverz);
-    roverz = (roverz > rozmax ? rozmax : roverz);
-
-    unsigned roverzbin = (roz_bin_size > 0. ? unsigned((roverz - rozmin) / roz_bin_size) : 0);
+    unsigned roverzbin = 0;
+    if (roz_bin_size > 0.) {
+      double roverz = std::sqrt(x * x + y * y) / std::abs(z) - rozmin;
+      roverz = std::clamp(roverz, 0., rozmax - rozmin);
+      roverzbin = unsigned(roverz / roz_bin_size);
+    }
     double phi = rotatedphi(x, y, z, sector120);
     int phibin = phiBin(roverzbin, phi, phiedges);
     if (phibin < 0)

--- a/L1Trigger/L1THGCal/src/backend/HGCalStage2ClusterDistribution.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalStage2ClusterDistribution.cc
@@ -1,0 +1,71 @@
+#include "L1Trigger/L1THGCal/interface/backend/HGCalStage2ClusterDistribution.h"
+#include "DataFormats/Common/interface/PtrVector.h"
+
+//class constructor
+HGCalStage2ClusterDistribution::HGCalStage2ClusterDistribution(const edm::ParameterSet& conf)
+    : roz_min_(conf.getParameter<double>("rozMin")),
+      roz_max_(conf.getParameter<double>("rozMax")),
+      roz_bins_(conf.getParameter<unsigned>("rozBins")),
+      phi_edges_(conf.getParameter<std::vector<double>>("phiSectorEdges")) {
+  if (phi_edges_.size() != roz_bins_)
+    throw cms::Exception("HGCalStage2ClusterDistribution::BadConfig")
+        << "Inconsistent sizes of phiSectorEdges and rozBins";
+
+  constexpr double margin = 1.001;
+  roz_bin_size_ = (roz_bins_ > 0 ? (roz_max_ - roz_min_) * margin / double(roz_bins_) : 0.);
+}
+
+HGCalTriggerGeometryBase::geom_set HGCalStage2ClusterDistribution::getStage2FPGAs(
+    const unsigned stage1_fpga,
+    const HGCalTriggerGeometryBase::geom_set& stage2_fpgas,
+    const edm::Ptr<l1t::HGCalCluster>& tc_ptr) const {
+  HGCalTriggerBackendDetId stage1_fpga_id(stage1_fpga);
+  int sector120 = stage1_fpga_id.sector();
+
+  const GlobalPoint& position = tc_ptr->position();
+  double x = position.x();
+  double y = position.y();
+  double z = position.z();
+  double roverz = std::sqrt(x * x + y * y) / std::abs(z);
+  roverz = (roverz < roz_min_ ? roz_min_ : roverz);
+  roverz = (roverz > roz_max_ ? roz_max_ : roverz);
+  unsigned roverzbin = (roz_bin_size_ > 0. ? unsigned((roverz - roz_min_) / roz_bin_size_) : 0);
+  double phi = rotatedphi(x, y, z, sector120);
+  unsigned phibin = phiBin(roverzbin, phi);
+
+  HGCalTriggerGeometryBase::geom_set output_fpgas;
+
+  for (const auto& fpga : stage2_fpgas) {
+    if (phibin == 0 || sector120 == HGCalTriggerBackendDetId(fpga).sector()) {
+      output_fpgas.emplace(fpga);
+    }
+  }
+
+  return output_fpgas;
+}
+
+unsigned HGCalStage2ClusterDistribution::phiBin(unsigned roverzbin, double phi) const {
+  unsigned phi_bin = 0;
+  if (roverzbin >= phi_edges_.size())
+    throw cms::Exception("HGCalStage1TruncationImpl::OutOfRange") << "roverzbin index " << roverzbin << "out of range";
+  double phi_edge = phi_edges_[roverzbin];
+  if (phi > phi_edge)
+    phi_bin = 1;
+  return phi_bin;
+}
+
+double HGCalStage2ClusterDistribution::rotatedphi(double x, double y, double z, int sector) const {
+  if (z > 0)
+    x = -x;
+  double phi = std::atan2(y, x);
+
+  if (sector == 1) {
+    if (phi < M_PI and phi > 0)
+      phi = phi - (2. * M_PI / 3.);
+    else
+      phi = phi + (4. * M_PI / 3.);
+  } else if (sector == 2) {
+    phi = phi + (2. * M_PI / 3.);
+  }
+  return phi;
+}

--- a/L1Trigger/L1THGCal/src/backend/HGCalTowerMapImpl_SA.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalTowerMapImpl_SA.cc
@@ -7,9 +7,9 @@ void HGCalTowerMapImplSA::runAlgorithm(const std::vector<HGCalTowerMap>& inputTo
   // Need better way to initialise the output tower map
   if (inputTowerMaps_SA.empty())
     return;
-  std::vector<unsigned short> tower_ids;
+  std::vector<HGCalTowerCoord> tower_ids;
   for (const auto& tower : inputTowerMaps_SA.front().towers()) {
-    tower_ids.push_back(tower.first);
+    tower_ids.emplace_back(tower.first, tower.second.eta(), tower.second.phi());
   }
   HGCalTowerMap towerMap(tower_ids);
 

--- a/L1Trigger/L1THGCal/src/backend/HGCalTowerMapImpl_SA.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalTowerMapImpl_SA.cc
@@ -1,0 +1,25 @@
+#include "L1Trigger/L1THGCal/interface/backend/HGCalTowerMapImpl_SA.h"
+
+using namespace l1thgcfirmware;
+
+void HGCalTowerMapImplSA::runAlgorithm(const std::vector<HGCalTowerMap>& inputTowerMaps_SA,
+                                       std::vector<HGCalTower>& outputTowers_SA) const {
+  // Need better way to initialise the output tower map
+  if (inputTowerMaps_SA.empty())
+    return;
+  std::vector<unsigned short> tower_ids;
+  for (const auto& tower : inputTowerMaps_SA.front().towers()) {
+    tower_ids.push_back(tower.first);
+  }
+  HGCalTowerMap towerMap(tower_ids);
+
+  for (const auto& map : inputTowerMaps_SA) {
+    towerMap += map;
+  }
+
+  for (const auto& tower : towerMap.towers()) {
+    if (tower.second.etEm() > 0 || tower.second.etHad() > 0) {
+      outputTowers_SA.push_back(tower.second);
+    }
+  }
+}

--- a/L1Trigger/L1THGCal/src/backend/HGCalTowerMap_SA.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalTowerMap_SA.cc
@@ -4,9 +4,9 @@
 
 using namespace l1thgcfirmware;
 
-HGCalTowerMap::HGCalTowerMap(const std::vector<unsigned short>& tower_ids) {
+HGCalTowerMap::HGCalTowerMap(const std::vector<l1thgcfirmware::HGCalTowerCoord>& tower_ids) {
   for (const auto tower_id : tower_ids) {
-    towerMap_[tower_id] = l1thgcfirmware::HGCalTower(0., 0.);
+    towerMap_[tower_id.rawId] = l1thgcfirmware::HGCalTower(0., 0., tower_id.eta, tower_id.phi, tower_id.rawId);
   }
 }
 

--- a/L1Trigger/L1THGCal/src/backend/HGCalTowerMap_SA.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalTowerMap_SA.cc
@@ -1,0 +1,31 @@
+#include "L1Trigger/L1THGCal/interface/backend/HGCalTowerMap_SA.h"
+
+#include <unordered_map>
+
+using namespace l1thgcfirmware;
+
+HGCalTowerMap::HGCalTowerMap(const std::vector<unsigned short>& tower_ids) {
+  for (const auto tower_id : tower_ids) {
+    towerMap_[tower_id] = l1thgcfirmware::HGCalTower(0., 0.);
+  }
+}
+
+HGCalTowerMap& HGCalTowerMap::operator+=(const HGCalTowerMap& map) {
+  for (const auto& tower : map.towers()) {
+    auto this_tower = towerMap_.find(tower.first);
+    if (this_tower != towerMap_.end()) {
+      this_tower->second += tower.second;
+    }
+  }
+
+  return *this;
+}
+
+bool HGCalTowerMap::addEt(short bin_id, float etEm, float etHad) {
+  auto this_tower = towerMap_.find(bin_id);
+  if (this_tower == towerMap_.end())
+    return false;
+  this_tower->second.addEtEm(etEm);
+  this_tower->second.addEtHad(etHad);
+  return true;
+}

--- a/L1Trigger/L1THGCal/src/backend/HGCalTower_SA.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalTower_SA.cc
@@ -1,0 +1,14 @@
+#include "L1Trigger/L1THGCal/interface/backend/HGCalTower_SA.h"
+
+using namespace l1thgcfirmware;
+
+HGCalTower& HGCalTower::operator+=(const HGCalTower& tower) {
+  etEm_ += tower.etEm();
+  etHad_ += tower.etHad();
+
+  return *this;
+}
+
+void HGCalTower::addEtEm(double et) { etEm_ += et; }
+
+void HGCalTower::addEtHad(double et) { etHad_ += et; }

--- a/L1Trigger/L1THGCal/test/HGCalTriggerGeomTesterV9Imp3.cc
+++ b/L1Trigger/L1THGCal/test/HGCalTriggerGeomTesterV9Imp3.cc
@@ -522,10 +522,8 @@ bool HGCalTriggerGeomTesterV9Imp3::checkMappingConsistency() {
       // fill modules
       uint32_t module = triggerGeometry_->getModuleFromTriggerCell(id);
       if (module != 0) {
-        if (id.det() != DetId::HGCalHSc) {
-          auto itr_insert = modules_to_triggercells.emplace(module, std::unordered_set<uint32_t>());
-          itr_insert.first->second.emplace(id);
-        }
+        auto itr_insert = modules_to_triggercells.emplace(module, std::unordered_set<uint32_t>());
+        itr_insert.first->second.emplace(id);
       }
 
       // Check consistency of cells included in trigger cell
@@ -577,13 +575,13 @@ bool HGCalTriggerGeomTesterV9Imp3::checkMappingConsistency() {
     edm::LogPrint("ModuleCheck") << "Checking trigger cell -> module -> trigger cell consistency";
     // Loop over modules
     for (const auto& module_triggercells : modules_to_triggercells) {
-      DetId id(module_triggercells.first);
+      HGCalTriggerModuleDetId id(module_triggercells.first);
       // Check consistency of trigger cells included in module
       HGCalTriggerGeometryBase::geom_set triggercells_geom = triggerGeometry_->getTriggerCellsFromModule(id);
       const auto& triggercells = module_triggercells.second;
       for (auto cell : triggercells) {
         if (triggercells_geom.find(cell) == triggercells_geom.end()) {
-          if (id.det() == DetId::HGCalHSc) {
+          if (id.triggerSubdetId() == HGCalTriggerSubdetector::HGCalHScTrigger) {
             HGCScintillatorDetId cellid(cell);
             edm::LogProblem("BadModule") << "Error: \n Trigger cell " << cell << "(" << cellid
                                          << ")\n has not been found in \n module " << HGCalTriggerModuleDetId(id);
@@ -595,7 +593,7 @@ bool HGCalTriggerGeomTesterV9Imp3::checkMappingConsistency() {
             edm::LogProblem("BadModule") << output.str();
             throw cms::Exception("BadGeometry")
                 << "HGCalTriggerGeometry: Found inconsistency in trigger cell <->  module mapping";
-          } else if (id.det() == DetId::Forward and id.subdetId() == ForwardSubdetector::HFNose) {
+          } else if (id.triggerSubdetId() == HGCalTriggerSubdetector::HFNoseTrigger) {
             HFNoseTriggerDetId cellid(cell);
             edm::LogProblem("BadModule") << "Error : \n Trigger cell " << cell << "(" << cellid
                                          << ")\n has not been found in \n module " << HGCalTriggerModuleDetId(id);
@@ -731,11 +729,11 @@ bool HGCalTriggerGeomTesterV9Imp3::checkMappingConsistency() {
         if (stage1FPGAs.find(stage1fpga) == stage1FPGAs.end()) {
           edm::LogProblem("BadStage2") << "Error: \n Stage-1 FPGA " << stage1fpga << "("
                                        << HGCalTriggerBackendDetId(stage1fpga)
-                                       << ")\n has not been found in \n stage-2 " << HGCalTriggerBackendDetId(stage2);
+                                       << ")\n has not been found in \n Stage-2 " << HGCalTriggerBackendDetId(stage2);
           std::stringstream output;
-          output << "   Available Stage-1 FPGAs are:\n";
+          output << "\n   Available Stage-1 FPGAs are:\n";
           for (auto stage1FPGA : stage1FPGAs) {
-            output << stage1FPGA << " ";
+            output << HGCalTriggerBackendDetId(stage1FPGA) << "\n";
           }
           edm::LogProblem("BadStage2") << output.str();
           throw cms::Exception("BadGeometry")

--- a/L1Trigger/L1THGCal/test/HGCalTriggerGeomTesterV9Imp3.cc
+++ b/L1Trigger/L1THGCal/test/HGCalTriggerGeomTesterV9Imp3.cc
@@ -80,6 +80,8 @@ private:
   float moduleX_ = 0;
   float moduleY_ = 0;
   float moduleZ_ = 0;
+  float moduleEta_ = 0;
+  float modulePhi_ = 0;
   int moduleTC_N_ = 0;
   int moduleLinks_ = 0;
   std::shared_ptr<int> moduleTC_id_;
@@ -95,6 +97,8 @@ private:
   std::shared_ptr<float> moduleTC_x_;
   std::shared_ptr<float> moduleTC_y_;
   std::shared_ptr<float> moduleTC_z_;
+  std::shared_ptr<float> moduleTC_eta_;
+  std::shared_ptr<float> moduleTC_phi_;
   int moduleCell_N_ = 0;
   std::shared_ptr<int> moduleCell_id_;
   std::shared_ptr<int> moduleCell_zside_;
@@ -104,9 +108,13 @@ private:
   std::shared_ptr<int> moduleCell_waferV_;
   std::shared_ptr<int> moduleCell_cellU_;
   std::shared_ptr<int> moduleCell_cellV_;
+  std::shared_ptr<int> moduleCell_ieta_;
+  std::shared_ptr<int> moduleCell_iphi_;
   std::shared_ptr<float> moduleCell_x_;
   std::shared_ptr<float> moduleCell_y_;
   std::shared_ptr<float> moduleCell_z_;
+  std::shared_ptr<float> moduleCell_eta_;
+  std::shared_ptr<float> moduleCell_phi_;
   int triggerCellId_ = 0;
   int triggerCellSide_ = 0;
   int triggerCellSubdet_ = 0;
@@ -120,6 +128,8 @@ private:
   float triggerCellX_ = 0;
   float triggerCellY_ = 0;
   float triggerCellZ_ = 0;
+  float triggerCellEta_ = 0;
+  float triggerCellPhi_ = 0;
   int triggerCellNeighbor_N_ = 0;
   std::shared_ptr<int> triggerCellNeighbor_id_;
   std::shared_ptr<int> triggerCellNeighbor_zside_;
@@ -146,6 +156,8 @@ private:
   std::shared_ptr<float> triggerCellCell_x_;
   std::shared_ptr<float> triggerCellCell_y_;
   std::shared_ptr<float> triggerCellCell_z_;
+  std::shared_ptr<float> triggerCellCell_eta_;
+  std::shared_ptr<float> triggerCellCell_phi_;
   int cellId_ = 0;
   int cellSide_ = 0;
   int cellSubdet_ = 0;
@@ -160,6 +172,8 @@ private:
   float cellX_ = 0;
   float cellY_ = 0;
   float cellZ_ = 0;
+  float cellEta_ = 0;
+  float cellPhi_ = 0;
   int cellCornersN_ = 0;
   std::shared_ptr<float> cellCornersX_;
   std::shared_ptr<float> cellCornersY_;
@@ -213,6 +227,8 @@ HGCalTriggerGeomTesterV9Imp3::HGCalTriggerGeomTesterV9Imp3(const edm::ParameterS
   treeModules_->Branch("x", &moduleX_, "x/F");
   treeModules_->Branch("y", &moduleY_, "y/F");
   treeModules_->Branch("z", &moduleZ_, "z/F");
+  treeModules_->Branch("eta", &moduleEta_, "eta/F");
+  treeModules_->Branch("phi", &modulePhi_, "phi/F");
   treeModules_->Branch("tc_n", &moduleTC_N_, "tc_n/I");
   moduleTC_id_.reset(new int[1], array_deleter<int>());
   moduleTC_zside_.reset(new int[1], array_deleter<int>());
@@ -225,6 +241,8 @@ HGCalTriggerGeomTesterV9Imp3::HGCalTriggerGeomTesterV9Imp3(const edm::ParameterS
   moduleTC_x_.reset(new float[1], array_deleter<float>());
   moduleTC_y_.reset(new float[1], array_deleter<float>());
   moduleTC_z_.reset(new float[1], array_deleter<float>());
+  moduleTC_eta_.reset(new float[1], array_deleter<float>());
+  moduleTC_phi_.reset(new float[1], array_deleter<float>());
   treeModules_->Branch("tc_id", moduleTC_id_.get(), "tc_id[tc_n]/I");
   treeModules_->Branch("tc_zside", moduleTC_zside_.get(), "tc_zside[tc_n]/I");
   treeModules_->Branch("tc_subdet", moduleTC_subdet_.get(), "tc_subdet[tc_n]/I");
@@ -238,6 +256,8 @@ HGCalTriggerGeomTesterV9Imp3::HGCalTriggerGeomTesterV9Imp3(const edm::ParameterS
   treeModules_->Branch("tc_x", moduleTC_x_.get(), "tc_x[tc_n]/F");
   treeModules_->Branch("tc_y", moduleTC_y_.get(), "tc_y[tc_n]/F");
   treeModules_->Branch("tc_z", moduleTC_z_.get(), "tc_z[tc_n]/F");
+  treeModules_->Branch("tc_eta", moduleTC_eta_.get(), "tc_eta[tc_n]/F");
+  treeModules_->Branch("tc_phi", moduleTC_phi_.get(), "tc_phi[tc_n]/F");
   treeModules_->Branch("c_n", &moduleCell_N_, "c_n/I");
   moduleCell_id_.reset(new int[1], array_deleter<int>());
   moduleCell_zside_.reset(new int[1], array_deleter<int>());
@@ -247,9 +267,13 @@ HGCalTriggerGeomTesterV9Imp3::HGCalTriggerGeomTesterV9Imp3(const edm::ParameterS
   moduleCell_waferV_.reset(new int[1], array_deleter<int>());
   moduleCell_cellU_.reset(new int[1], array_deleter<int>());
   moduleCell_cellV_.reset(new int[1], array_deleter<int>());
+  moduleCell_ieta_.reset(new int[1], array_deleter<int>());
+  moduleCell_iphi_.reset(new int[1], array_deleter<int>());
   moduleCell_x_.reset(new float[1], array_deleter<float>());
   moduleCell_y_.reset(new float[1], array_deleter<float>());
   moduleCell_z_.reset(new float[1], array_deleter<float>());
+  moduleCell_eta_.reset(new float[1], array_deleter<float>());
+  moduleCell_phi_.reset(new float[1], array_deleter<float>());
   treeModules_->Branch("c_id", moduleCell_id_.get(), "c_id[c_n]/I");
   treeModules_->Branch("c_zside", moduleCell_zside_.get(), "c_zside[c_n]/I");
   treeModules_->Branch("c_subdet", moduleCell_subdet_.get(), "c_subdet[c_n]/I");
@@ -258,9 +282,13 @@ HGCalTriggerGeomTesterV9Imp3::HGCalTriggerGeomTesterV9Imp3(const edm::ParameterS
   treeModules_->Branch("c_waferv", moduleCell_waferV_.get(), "c_waferv[c_n]/I");
   treeModules_->Branch("c_cellu", moduleCell_cellU_.get(), "c_cellu[c_n]/I");
   treeModules_->Branch("c_cellv", moduleCell_cellV_.get(), "c_cellv[c_n]/I");
+  treeModules_->Branch("c_ieta", moduleCell_ieta_.get(), "c_ieta[c_n]/I");
+  treeModules_->Branch("c_iphi", moduleCell_iphi_.get(), "c_iphi[c_n]/I");
   treeModules_->Branch("c_x", moduleCell_x_.get(), "c_x[c_n]/F");
   treeModules_->Branch("c_y", moduleCell_y_.get(), "c_y[c_n]/F");
   treeModules_->Branch("c_z", moduleCell_z_.get(), "c_z[c_n]/F");
+  treeModules_->Branch("c_eta", moduleCell_eta_.get(), "c_eta[c_n]/F");
+  treeModules_->Branch("c_phi", moduleCell_phi_.get(), "c_phi[c_n]/F");
   //
   treeTriggerCells_ = fs_->make<TTree>("TreeTriggerCells", "Tree of all HGC trigger cells");
   treeTriggerCells_->Branch("id", &triggerCellId_, "id/I");
@@ -276,6 +304,8 @@ HGCalTriggerGeomTesterV9Imp3::HGCalTriggerGeomTesterV9Imp3(const edm::ParameterS
   treeTriggerCells_->Branch("x", &triggerCellX_, "x/F");
   treeTriggerCells_->Branch("y", &triggerCellY_, "y/F");
   treeTriggerCells_->Branch("z", &triggerCellZ_, "z/F");
+  treeTriggerCells_->Branch("eta", &triggerCellEta_, "eta/F");
+  treeTriggerCells_->Branch("phi", &triggerCellPhi_, "phi/F");
   treeTriggerCells_->Branch("neighbor_n", &triggerCellNeighbor_N_, "neighbor_n/I");
   triggerCellNeighbor_id_.reset(new int[1], array_deleter<int>());
   triggerCellNeighbor_zside_.reset(new int[1], array_deleter<int>());
@@ -310,6 +340,8 @@ HGCalTriggerGeomTesterV9Imp3::HGCalTriggerGeomTesterV9Imp3(const edm::ParameterS
   triggerCellCell_x_.reset(new float[1], array_deleter<float>());
   triggerCellCell_y_.reset(new float[1], array_deleter<float>());
   triggerCellCell_z_.reset(new float[1], array_deleter<float>());
+  triggerCellCell_eta_.reset(new float[1], array_deleter<float>());
+  triggerCellCell_phi_.reset(new float[1], array_deleter<float>());
   treeTriggerCells_->Branch("c_id", triggerCellCell_id_.get(), "c_id[c_n]/I");
   treeTriggerCells_->Branch("c_zside", triggerCellCell_zside_.get(), "c_zside[c_n]/I");
   treeTriggerCells_->Branch("c_subdet", triggerCellCell_subdet_.get(), "c_subdet[c_n]/I");
@@ -323,6 +355,8 @@ HGCalTriggerGeomTesterV9Imp3::HGCalTriggerGeomTesterV9Imp3(const edm::ParameterS
   treeTriggerCells_->Branch("c_x", triggerCellCell_x_.get(), "c_x[c_n]/F");
   treeTriggerCells_->Branch("c_y", triggerCellCell_y_.get(), "c_y[c_n]/F");
   treeTriggerCells_->Branch("c_z", triggerCellCell_z_.get(), "c_z[c_n]/F");
+  treeTriggerCells_->Branch("c_eta", triggerCellCell_eta_.get(), "c_eta[c_n]/F");
+  treeTriggerCells_->Branch("c_phi", triggerCellCell_phi_.get(), "c_phi[c_n]/F");
   //
   treeCells_ = fs_->make<TTree>("TreeCells", "Tree of all HGC cells");
   treeCells_->Branch("id", &cellId_, "id/I");
@@ -339,6 +373,8 @@ HGCalTriggerGeomTesterV9Imp3::HGCalTriggerGeomTesterV9Imp3(const edm::ParameterS
   treeCells_->Branch("x", &cellX_, "x/F");
   treeCells_->Branch("y", &cellY_, "y/F");
   treeCells_->Branch("z", &cellZ_, "z/F");
+  treeCells_->Branch("eta", &cellEta_, "eta/F");
+  treeCells_->Branch("phi", &cellPhi_, "phi/F");
   treeCells_->Branch("corner_n", &cellCornersN_, "corner_n/I");
   treeCells_->Branch("corner_x", cellCornersX_.get(), "corner_x[corner_n]/F");
   treeCells_->Branch("corner_y", cellCornersY_.get(), "corner_y[corner_n]/F");
@@ -381,6 +417,8 @@ HGCalTriggerGeomTesterV9Imp3::HGCalTriggerGeomTesterV9Imp3(const edm::ParameterS
   treeCellsNose_->Branch("x", &cellX_, "x/F");
   treeCellsNose_->Branch("y", &cellY_, "y/F");
   treeCellsNose_->Branch("z", &cellZ_, "z/F");
+  treeCellsNose_->Branch("eta", &cellEta_, "eta/F");
+  treeCellsNose_->Branch("phi", &cellPhi_, "phi/F");
   treeCellsNose_->Branch("corner_n", &cellCornersN_, "corner_n/I");
   treeCellsNose_->Branch("corner_x", cellCornersX_.get(), "corner_x[corner_n]/F");
   treeCellsNose_->Branch("corner_y", cellCornersY_.get(), "corner_y[corner_n]/F");
@@ -784,6 +822,8 @@ void HGCalTriggerGeomTesterV9Imp3::fillTriggerGeometry()
     cellX_ = center.x();
     cellY_ = center.y();
     cellZ_ = center.z();
+    cellEta_ = center.eta();
+    cellPhi_ = center.phi();
     std::vector<GlobalPoint> corners = triggerGeometry_->eeGeometry()->getCorners(id);
     cellCornersN_ = corners.size();
     setTreeCellCornerSize(cellCornersN_);
@@ -827,6 +867,8 @@ void HGCalTriggerGeomTesterV9Imp3::fillTriggerGeometry()
     cellX_ = center.x();
     cellY_ = center.y();
     cellZ_ = center.z();
+    cellEta_ = center.eta();
+    cellPhi_ = center.phi();
     std::vector<GlobalPoint> corners = triggerGeometry_->hsiGeometry()->getCorners(id);
     cellCornersN_ = corners.size();
     setTreeCellCornerSize(cellCornersN_);
@@ -906,6 +948,8 @@ void HGCalTriggerGeomTesterV9Imp3::fillTriggerGeometry()
       cellX_ = center.x();
       cellY_ = center.y();
       cellZ_ = center.z();
+      cellEta_ = center.eta();
+      cellPhi_ = center.phi();
       std::vector<GlobalPoint> corners = triggerGeometry_->noseGeometry()->getCorners(id);
       cellCornersN_ = corners.size();
       setTreeCellCornerSize(cellCornersN_);
@@ -945,12 +989,18 @@ void HGCalTriggerGeomTesterV9Imp3::fillTriggerGeometry()
       triggerCellLayer_ = id_sc.layer();
       triggerCellIEta_ = id_sc.ietaAbs();
       triggerCellIPhi_ = id_sc.iphi();
+      triggerCellWaferU_ = 0;
+      triggerCellWaferV_ = 0;
+      triggerCellU_ = 0;
+      triggerCellV_ = 0;
     } else if (HFNoseTriggerDetId(triggercell_cells.first).det() == DetId::HGCalTrigger &&
                HFNoseTriggerDetId(triggercell_cells.first).subdet() == HGCalTriggerSubdetector::HFNoseTrigger) {
       HFNoseTriggerDetId id_nose_trig(triggercell_cells.first);
       triggerCellSide_ = id_nose_trig.zside();
       triggerCellSubdet_ = id_nose_trig.subdet();
       triggerCellLayer_ = id_nose_trig.layer();
+      triggerCellIEta_ = 0;
+      triggerCellIPhi_ = 0;
       triggerCellWaferU_ = id_nose_trig.waferU();
       triggerCellWaferV_ = id_nose_trig.waferV();
       triggerCellU_ = id_nose_trig.triggerCellU();
@@ -960,6 +1010,8 @@ void HGCalTriggerGeomTesterV9Imp3::fillTriggerGeometry()
       triggerCellSide_ = id_si_trig.zside();
       triggerCellSubdet_ = id_si_trig.subdet();
       triggerCellLayer_ = id_si_trig.layer();
+      triggerCellIEta_ = 0;
+      triggerCellIPhi_ = 0;
       triggerCellWaferU_ = id_si_trig.waferU();
       triggerCellWaferV_ = id_si_trig.waferV();
       triggerCellU_ = id_si_trig.triggerCellU();
@@ -968,6 +1020,8 @@ void HGCalTriggerGeomTesterV9Imp3::fillTriggerGeometry()
     triggerCellX_ = position.x();
     triggerCellY_ = position.y();
     triggerCellZ_ = position.z();
+    triggerCellEta_ = position.eta();
+    triggerCellPhi_ = position.phi();
     triggerCellCell_N_ = triggercell_cells.second.size();
     //
     setTreeTriggerCellSize(triggerCellCell_N_);
@@ -989,6 +1043,8 @@ void HGCalTriggerGeomTesterV9Imp3::fillTriggerGeometry()
         triggerCellCell_x_.get()[ic] = cell_position.x();
         triggerCellCell_y_.get()[ic] = cell_position.y();
         triggerCellCell_z_.get()[ic] = cell_position.z();
+        triggerCellCell_eta_.get()[ic] = cell_position.eta();
+        triggerCellCell_phi_.get()[ic] = cell_position.phi();
       } else if (HFNoseTriggerDetId(triggercell_cells.first).det() == DetId::HGCalTrigger &&
                  HFNoseTriggerDetId(triggercell_cells.first).subdet() == HGCalTriggerSubdetector::HFNoseTrigger) {
         HFNoseDetId cId(c);
@@ -1006,6 +1062,8 @@ void HGCalTriggerGeomTesterV9Imp3::fillTriggerGeometry()
         triggerCellCell_x_.get()[ic] = cell_position.x();
         triggerCellCell_y_.get()[ic] = cell_position.y();
         triggerCellCell_z_.get()[ic] = cell_position.z();
+        triggerCellCell_eta_.get()[ic] = cell_position.eta();
+        triggerCellCell_phi_.get()[ic] = cell_position.phi();
       } else {
         HGCSiliconDetId cId(c);
         GlobalPoint cell_position = (cId.det() == DetId::HGCalEE ? triggerGeometry_->eeGeometry()->getPosition(cId)
@@ -1023,6 +1081,8 @@ void HGCalTriggerGeomTesterV9Imp3::fillTriggerGeometry()
         triggerCellCell_x_.get()[ic] = cell_position.x();
         triggerCellCell_y_.get()[ic] = cell_position.y();
         triggerCellCell_z_.get()[ic] = cell_position.z();
+        triggerCellCell_eta_.get()[ic] = cell_position.eta();
+        triggerCellCell_phi_.get()[ic] = cell_position.phi();
       }
       ic++;
     }
@@ -1045,6 +1105,8 @@ void HGCalTriggerGeomTesterV9Imp3::fillTriggerGeometry()
     moduleX_ = position.x();
     moduleY_ = position.y();
     moduleZ_ = position.z();
+    moduleEta_ = position.eta();
+    modulePhi_ = position.phi();
 
     moduleSide_ = id.zside();
     moduleSubdet_ = id.triggerSubdetId();
@@ -1106,6 +1168,8 @@ void HGCalTriggerGeomTesterV9Imp3::fillTriggerGeometry()
       moduleTC_x_.get()[itc] = position.x();
       moduleTC_y_.get()[itc] = position.y();
       moduleTC_z_.get()[itc] = position.z();
+      moduleTC_eta_.get()[itc] = position.eta();
+      moduleTC_phi_.get()[itc] = position.phi();
       itc++;
     }
     auto cells_in_module = triggerGeometry_->getCellsFromModule(id);
@@ -1117,19 +1181,21 @@ void HGCalTriggerGeomTesterV9Imp3::fillTriggerGeometry()
       if (moduleSubdet_ == HGCalTriggerSubdetector::HGCalHScTrigger) {
         HGCScintillatorDetId cId(c);
         GlobalPoint cell_position = triggerGeometry_->hscGeometry()->getPosition(cId);
-        triggerCellCell_id_.get()[ic] = c;
-        triggerCellCell_zside_.get()[ic] = cId.zside();
-        triggerCellCell_subdet_.get()[ic] = cId.subdetId();
-        triggerCellCell_layer_.get()[ic] = cId.layer();
-        triggerCellCell_waferU_.get()[ic] = 0;
-        triggerCellCell_waferV_.get()[ic] = 0;
-        triggerCellCell_cellU_.get()[ic] = 0;
-        triggerCellCell_cellV_.get()[ic] = 0;
-        triggerCellCell_ieta_.get()[ic] = cId.ietaAbs();
-        triggerCellCell_iphi_.get()[ic] = cId.iphi();
-        triggerCellCell_x_.get()[ic] = cell_position.x();
-        triggerCellCell_y_.get()[ic] = cell_position.y();
-        triggerCellCell_z_.get()[ic] = cell_position.z();
+        moduleCell_id_.get()[ic] = c;
+        moduleCell_zside_.get()[ic] = cId.zside();
+        moduleCell_subdet_.get()[ic] = cId.subdetId();
+        moduleCell_layer_.get()[ic] = cId.layer();
+        moduleCell_waferU_.get()[ic] = 0;
+        moduleCell_waferV_.get()[ic] = 0;
+        moduleCell_cellU_.get()[ic] = 0;
+        moduleCell_cellV_.get()[ic] = 0;
+        moduleCell_ieta_.get()[ic] = cId.ietaAbs();
+        moduleCell_iphi_.get()[ic] = cId.iphi();
+        moduleCell_x_.get()[ic] = cell_position.x();
+        moduleCell_y_.get()[ic] = cell_position.y();
+        moduleCell_z_.get()[ic] = cell_position.z();
+        moduleCell_eta_.get()[ic] = cell_position.eta();
+        moduleCell_phi_.get()[ic] = cell_position.phi();
       } else if (moduleSubdet_ == HGCalTriggerSubdetector::HFNoseTrigger) {
         HFNoseDetId cId(c);
         const GlobalPoint position = triggerGeometry_->noseGeometry()->getPosition(c);
@@ -1141,9 +1207,13 @@ void HGCalTriggerGeomTesterV9Imp3::fillTriggerGeometry()
         moduleCell_waferV_.get()[ic] = cId.waferV();
         moduleCell_cellU_.get()[ic] = cId.cellU();
         moduleCell_cellV_.get()[ic] = cId.cellV();
+        moduleCell_ieta_.get()[ic] = 0;
+        moduleCell_iphi_.get()[ic] = 0;
         moduleCell_x_.get()[ic] = position.x();
         moduleCell_y_.get()[ic] = position.y();
         moduleCell_z_.get()[ic] = position.z();
+        moduleCell_eta_.get()[ic] = position.eta();
+        moduleCell_phi_.get()[ic] = position.phi();
       } else {
         HGCSiliconDetId cId(c);
         const GlobalPoint position = (cId.det() == DetId::HGCalEE ? triggerGeometry_->eeGeometry()->getPosition(cId)
@@ -1156,11 +1226,15 @@ void HGCalTriggerGeomTesterV9Imp3::fillTriggerGeometry()
         moduleCell_waferV_.get()[ic] = cId.waferV();
         moduleCell_cellU_.get()[ic] = cId.cellU();
         moduleCell_cellV_.get()[ic] = cId.cellV();
+        moduleCell_ieta_.get()[ic] = 0;
+        moduleCell_iphi_.get()[ic] = 0;
         moduleCell_x_.get()[ic] = position.x();
         moduleCell_y_.get()[ic] = position.y();
         moduleCell_z_.get()[ic] = position.z();
-        ic++;
+        moduleCell_eta_.get()[ic] = position.eta();
+        moduleCell_phi_.get()[ic] = position.phi();
       }
+      ic++;
     }
     treeModules_->Fill();
   }
@@ -1188,6 +1262,8 @@ void HGCalTriggerGeomTesterV9Imp3::setTreeModuleSize(const size_t n)
   moduleTC_x_.reset(new float[n], array_deleter<float>());
   moduleTC_y_.reset(new float[n], array_deleter<float>());
   moduleTC_z_.reset(new float[n], array_deleter<float>());
+  moduleTC_eta_.reset(new float[n], array_deleter<float>());
+  moduleTC_phi_.reset(new float[n], array_deleter<float>());
 
   treeModules_->GetBranch("tc_id")->SetAddress(moduleTC_id_.get());
   treeModules_->GetBranch("tc_zside")->SetAddress(moduleTC_zside_.get());
@@ -1202,6 +1278,8 @@ void HGCalTriggerGeomTesterV9Imp3::setTreeModuleSize(const size_t n)
   treeModules_->GetBranch("tc_x")->SetAddress(moduleTC_x_.get());
   treeModules_->GetBranch("tc_y")->SetAddress(moduleTC_y_.get());
   treeModules_->GetBranch("tc_z")->SetAddress(moduleTC_z_.get());
+  treeModules_->GetBranch("tc_eta")->SetAddress(moduleTC_eta_.get());
+  treeModules_->GetBranch("tc_phi")->SetAddress(moduleTC_phi_.get());
 }
 
 /*****************************************************************/
@@ -1219,6 +1297,8 @@ void HGCalTriggerGeomTesterV9Imp3::setTreeModuleCellSize(const size_t n)
   moduleCell_x_.reset(new float[n], array_deleter<float>());
   moduleCell_y_.reset(new float[n], array_deleter<float>());
   moduleCell_z_.reset(new float[n], array_deleter<float>());
+  moduleCell_eta_.reset(new float[n], array_deleter<float>());
+  moduleCell_phi_.reset(new float[n], array_deleter<float>());
 
   treeModules_->GetBranch("c_id")->SetAddress(moduleCell_id_.get());
   treeModules_->GetBranch("c_zside")->SetAddress(moduleCell_zside_.get());
@@ -1231,6 +1311,8 @@ void HGCalTriggerGeomTesterV9Imp3::setTreeModuleCellSize(const size_t n)
   treeModules_->GetBranch("c_x")->SetAddress(moduleCell_x_.get());
   treeModules_->GetBranch("c_y")->SetAddress(moduleCell_y_.get());
   treeModules_->GetBranch("c_z")->SetAddress(moduleCell_z_.get());
+  treeModules_->GetBranch("c_eta")->SetAddress(moduleCell_eta_.get());
+  treeModules_->GetBranch("c_phi")->SetAddress(moduleCell_phi_.get());
 }
 
 /*****************************************************************/
@@ -1250,6 +1332,8 @@ void HGCalTriggerGeomTesterV9Imp3::setTreeTriggerCellSize(const size_t n)
   triggerCellCell_x_.reset(new float[n], array_deleter<float>());
   triggerCellCell_y_.reset(new float[n], array_deleter<float>());
   triggerCellCell_z_.reset(new float[n], array_deleter<float>());
+  triggerCellCell_eta_.reset(new float[n], array_deleter<float>());
+  triggerCellCell_phi_.reset(new float[n], array_deleter<float>());
 
   treeTriggerCells_->GetBranch("c_id")->SetAddress(triggerCellCell_id_.get());
   treeTriggerCells_->GetBranch("c_zside")->SetAddress(triggerCellCell_zside_.get());
@@ -1264,6 +1348,8 @@ void HGCalTriggerGeomTesterV9Imp3::setTreeTriggerCellSize(const size_t n)
   treeTriggerCells_->GetBranch("c_x")->SetAddress(triggerCellCell_x_.get());
   treeTriggerCells_->GetBranch("c_y")->SetAddress(triggerCellCell_y_.get());
   treeTriggerCells_->GetBranch("c_z")->SetAddress(triggerCellCell_z_.get());
+  treeTriggerCells_->GetBranch("c_eta")->SetAddress(triggerCellCell_eta_.get());
+  treeTriggerCells_->GetBranch("c_phi")->SetAddress(triggerCellCell_phi_.get());
 }
 
 /*****************************************************************/

--- a/L1Trigger/L1THGCal/test/testHGCalL1TGeometryV11Imp2_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalL1TGeometryV11Imp2_cfg.py
@@ -94,8 +94,8 @@ process.endjob_step = cms.EndPath(process.endOfProcess)
 
 process.load('L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff')
 # Eventually modify default geometry parameters
-from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_decentralized_V11
-process = custom_geometry_decentralized_V11(process)
+from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_V11_Imp2
+process = custom_geometry_V11_Imp2(process)
 
 process.hgcaltriggergeomtester = cms.EDAnalyzer(
     "HGCalTriggerGeomTesterV9Imp2"

--- a/L1Trigger/L1THGCal/test/testHGCalL1TGeometryV11Imp3_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalL1TGeometryV11Imp3_cfg.py
@@ -101,8 +101,8 @@ process.FEVTDEBUGoutput_step = cms.EndPath(process.FEVTDEBUGoutput)
 
 process.load('L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff')
 # Eventually modify default geometry parameters
-from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_decentralized_V11
-process = custom_geometry_decentralized_V11(process, implementation=2)
+from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_V11_Imp3
+process = custom_geometry_V11_Imp3(process)
 
 process.hgcaltriggergeomtester = cms.EDAnalyzer(
     "HGCalTriggerGeomTesterV9Imp3"

--- a/L1Trigger/L1THGCalUtilities/python/clustering2d.py
+++ b/L1Trigger/L1THGCalUtilities/python/clustering2d.py
@@ -2,7 +2,9 @@ import FWCore.ParameterSet.Config as cms
 from L1Trigger.L1THGCal.hgcalBackEndLayer1Producer_cfi import dummy_C2d_params, \
                                                               distance_C2d_params, \
                                                               topological_C2d_params, \
-                                                              constrTopological_C2d_params
+                                                              constrTopological_C2d_params, \
+                                                              stage1truncation_proc, \
+                                                              truncation_params
 from L1Trigger.L1THGCal.customClustering import set_threshold_params
 
 
@@ -12,7 +14,7 @@ def create_distance(process, inputs,
                     cluster_threshold=distance_C2d_params.clustering_threshold_silicon  # MipT
                     ):
     producer = process.hgcalBackEndLayer1Producer.clone(
-            InputTriggerCells = cms.InputTag('{}:HGCalConcentratorProcessorSelection'.format(inputs))
+            InputTriggerCells = cms.InputTag(inputs)
             )
     producer.ProcessorParameters.C2d_parameters = distance_C2d_params.clone(
             dR_cluster = distance
@@ -26,7 +28,7 @@ def create_topological(process, inputs,
                        cluster_threshold=topological_C2d_params.clustering_threshold_silicon  # MipT
                        ):
     producer = process.hgcalBackEndLayer1Producer.clone(
-            InputTriggerCells = cms.InputTag('{}:HGCalConcentratorProcessorSelection'.format(inputs))
+            InputTriggerCells = cms.InputTag(inputs)
             )
     producer.ProcessorParameters.C2d_parameters = topological_C2d_params.clone()
     set_threshold_params(producer.ProcessorParameters.C2d_parameters, seed_threshold, cluster_threshold)
@@ -39,7 +41,7 @@ def create_constrainedtopological(process, inputs,
                                   cluster_threshold=constrTopological_C2d_params.clustering_threshold_silicon  # MipT
                                   ):
     producer = process.hgcalBackEndLayer1Producer.clone(
-            InputTriggerCells = cms.InputTag('{}:HGCalConcentratorProcessorSelection'.format(inputs))
+            InputTriggerCells = cms.InputTag(inputs)
             )
     producer.ProcessorParameters.C2d_parameters = constrTopological_C2d_params.clone(
             dR_cluster = distance
@@ -48,16 +50,36 @@ def create_constrainedtopological(process, inputs,
     return producer
 
 
-def create_dummy(process, inputs):
-    producer = process.hgcalBackEndLayer1Producer.clone(
-            InputTriggerCells = cms.InputTag('{}:HGCalConcentratorProcessorSelection'.format(inputs))
-            )
-    producer.ProcessorParameters.C2d_parameters = dummy_C2d_params.clone()
-    return producer
 
-def create_truth_dummy(process, inputs):
-    producer = process.hgcalBackEndLayer1Producer.clone(
-            InputTriggerCells = cms.InputTag('{}'.format(inputs))
-            )
-    producer.ProcessorParameters.C2d_parameters = dummy_C2d_params.clone()
-    return producer
+class CreateDummy(object):
+    def __call__(self, process, inputs):
+        producer = process.hgcalBackEndLayer1Producer.clone(
+                InputTriggerCells = cms.InputTag(inputs)
+                )
+        producer.ProcessorParameters.C2d_parameters = dummy_C2d_params.clone()
+        return producer
+
+class CreateTruthDummy(object):
+    def __call__(self, process, inputs):
+        producer = process.hgcalBackEndLayer1Producer.clone(
+                InputTriggerCells = cms.InputTag(inputs)
+                )
+        producer.ProcessorParameters.C2d_parameters = dummy_C2d_params.clone()
+        return producer
+
+
+class RozBinTruncation(object):
+    def __init__(self,
+            maxTcsPerBin=truncation_params.maxTcsPerBin):
+        self.processor = stage1truncation_proc.clone(
+                truncation_parameters=truncation_params.clone(
+                    maxTcsPerBin=maxTcsPerBin
+                    )
+                )
+
+    def __call__(self, process, inputs):
+        producer = process.hgcalBackEndLayer1Producer.clone(
+                InputTriggerCells = cms.InputTag(inputs),
+                ProcessorParameters = self.processor
+                )
+        return producer

--- a/L1Trigger/L1THGCalUtilities/python/clustering2d.py
+++ b/L1Trigger/L1THGCalUtilities/python/clustering2d.py
@@ -3,7 +3,7 @@ from L1Trigger.L1THGCal.hgcalBackEndLayer1Producer_cfi import dummy_C2d_params, 
                                                               distance_C2d_params, \
                                                               topological_C2d_params, \
                                                               constrTopological_C2d_params, \
-                                                              stage1truncation_proc, \
+                                                              layer1truncation_proc, \
                                                               truncation_params
 from L1Trigger.L1THGCal.customClustering import set_threshold_params
 
@@ -71,7 +71,7 @@ class CreateTruthDummy(object):
 class RozBinTruncation(object):
     def __init__(self,
             maxTcsPerBin=truncation_params.maxTcsPerBin):
-        self.processor = stage1truncation_proc.clone(
+        self.processor = layer1truncation_proc.clone(
                 truncation_parameters=truncation_params.clone(
                     maxTcsPerBin=maxTcsPerBin
                     )

--- a/L1Trigger/L1THGCalUtilities/python/clustering2d_v2.py
+++ b/L1Trigger/L1THGCalUtilities/python/clustering2d_v2.py
@@ -1,0 +1,23 @@
+import FWCore.ParameterSet.Config as cms
+from L1Trigger.L1THGCal.hgcalBackEndLayer1Producer_cfi import dummy_C2d_params, \
+                                                              stage1truncation_proc, \
+                                                              truncation_params
+
+class RozBinTruncation(object):
+    def __init__(self,
+            maxTcsPerBin=truncation_params.maxTcsPerBin,
+            doTruncation=truncation_params.doTruncation):
+        self.processor = stage1truncation_proc.clone(
+                truncation_parameters=truncation_params.clone(
+                maxTcsPerBin=maxTcsPerBin,
+                doTruncation=doTruncation
+                )
+        )
+
+    def __call__(self,process,inputs):
+        producer = process.hgcalBackEndStage1Producer.clone(
+            InputTriggerCells = cms.InputTag(inputs),
+            C2d_parameters = dummy_C2d_params.clone(),
+            ProcessorParameters = self.processor
+        )
+        return producer

--- a/L1Trigger/L1THGCalUtilities/python/clustering3d.py
+++ b/L1Trigger/L1THGCalUtilities/python/clustering3d.py
@@ -19,7 +19,7 @@ def create_distance(process, inputs,
                     distance=distance_C3d_params.dR_multicluster
                     ):
     producer = process.hgcalBackEndLayer2Producer.clone(
-            InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
+            InputCluster = cms.InputTag(inputs)
             )
     producer.ProcessorParameters.C3d_parameters = distance_C3d_params.clone(
             dR_multicluster = distance
@@ -32,7 +32,7 @@ def create_dbscan(process, inputs,
                   min_points=dbscan_C3d_params.minN_dbscan_multicluster
                   ):
     producer = process.hgcalBackEndLayer2Producer.clone(
-            InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
+            InputCluster = cms.InputTag(inputs)
             )
     producer.ProcessorParameters.C3d_parameters = dbscan_C3d_params.clone(
             dist_dbscan_multicluster = distance,
@@ -41,137 +41,152 @@ def create_dbscan(process, inputs,
     return producer
 
 
-def create_histoMax(process, inputs,
-                    distance=histoMax_C3d_clustering_params.dR_multicluster,
-                    nBins_X1=histoMax_C3d_seeding_params.nBins_X1_histo_multicluster,
-                    nBins_X2=histoMax_C3d_seeding_params.nBins_X2_histo_multicluster,
-                    binSumsHisto=histoMax_C3d_seeding_params.binSumsHisto,
-                    seed_threshold=histoMax_C3d_seeding_params.threshold_histo_multicluster,
-                    shape_threshold=histoMax_C3d_clustering_params.shape_threshold,
-                    shape_distance=histoMax_C3d_clustering_params.shape_distance,
-                    ):
-    producer = process.hgcalBackEndLayer2Producer.clone(
-            InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
-            )
-    producer.ProcessorParameters.C3d_parameters.histoMax_C3d_clustering_parameters = histoMax_C3d_clustering_params.clone()
-    producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters = histoMax_C3d_seeding_params.clone()
-    set_histomax_seeding_params(producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters, nBins_X1, nBins_X2, binSumsHisto,
-            seed_threshold)
-    set_histomax_clustering_params(producer.ProcessorParameters.C3d_parameters.histoMax_C3d_clustering_parameters, distance, shape_threshold, shape_distance)
+class CreateHistoMax(object):
+    def __init__(self,
+            distance=histoMax_C3d_clustering_params.dR_multicluster,
+            nBins_X1=histoMax_C3d_seeding_params.nBins_X1_histo_multicluster,
+            nBins_X2=histoMax_C3d_seeding_params.nBins_X2_histo_multicluster,
+            binSumsHisto=histoMax_C3d_seeding_params.binSumsHisto,
+            seed_threshold=histoMax_C3d_seeding_params.threshold_histo_multicluster,
+            shape_threshold=histoMax_C3d_clustering_params.shape_threshold,
+            shape_distance=histoMax_C3d_clustering_params.shape_distance,
+            ):
+        self.clustering_parameters = histoMax_C3d_clustering_params.clone()
+        self.seeding_parameters = histoMax_C3d_seeding_params.clone()
+        set_histomax_seeding_params(self.seeding_parameters, nBins_X1, nBins_X2, binSumsHisto, seed_threshold)
+        set_histomax_clustering_params(self.clustering_parameters, distance, shape_threshold, shape_distance)
 
-    return producer
-
-
-def create_histoMax_variableDr(process, inputs,
-                               distances=histoMaxVariableDR_C3d_params.dR_multicluster_byLayer_coefficientA,
-                               nBins_X1=histoMax_C3d_seeding_params.nBins_X1_histo_multicluster,
-                               nBins_X2=histoMax_C3d_seeding_params.nBins_X2_histo_multicluster,
-                               binSumsHisto=histoMax_C3d_seeding_params.binSumsHisto,
-                               seed_threshold=histoMax_C3d_seeding_params.threshold_histo_multicluster,
-                               shape_threshold=histoMaxVariableDR_C3d_params.shape_threshold,
-                               shape_distance=histoMaxVariableDR_C3d_params.shape_distance,
-                               ):
-    producer = process.hgcalBackEndLayer2Producer.clone(
-            InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
-            )
-    producer.ProcessorParameters.C3d_parameters.histoMax_C3d_clustering_parameters = histoMax_C3d_clustering_params.clone(
-            dR_multicluster_byLayer_coefficientA = distances
-            )
-    producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters = histoMax_C3d_seeding_params.clone()
-
-    set_histomax_seeding_params(producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters, nBins_X1, nBins_X2, binSumsHisto,
-            seed_threshold)
-    set_histomax_clustering_params(producer.ProcessorParameters.C3d_parameters.histoMax_C3d_clustering_parameters, 0, shape_threshold, shape_distance)
-   
-    return producer
+    def __call__(self, process, inputs):
+        producer = process.hgcalBackEndLayer2Producer.clone(
+                InputCluster = cms.InputTag(inputs)
+                )
+        producer.ProcessorParameters.C3d_parameters.histoMax_C3d_clustering_parameters = self.clustering_parameters
+        producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters = self.seeding_parameters
+        return producer
 
 
-def create_histoMaxXY_variableDr(process, inputs,
-                               distances=histoMaxVariableDR_C3d_params.dR_multicluster_byLayer_coefficientA,
-                               nBins_X1=histoMaxXYVariableDR_C3d_params.nBins_X1_histo_multicluster,
-                               nBins_X2=histoMaxXYVariableDR_C3d_params.nBins_X2_histo_multicluster,
-                               seed_threshold=histoMaxXYVariableDR_C3d_params.threshold_histo_multicluster,
-                               shape_threshold=histoMaxVariableDR_C3d_params.shape_threshold,
-                               shape_distance=histoMaxVariableDR_C3d_params.shape_distance,
-                               ):
-    producer = process.hgcalBackEndLayer2Producer.clone(
-            InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
-            )
-    producer.ProcessorParameters.C3d_parameters.histoMax_C3d_clustering_parameters = histoMax_C3d_clustering_params.clone(
-            dR_multicluster_byLayer_coefficientA = distances
-            )
-    producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters = histoMaxXYVariableDR_C3d_params.clone()
+class CreateHistoMaxVariableDr(object):
+    def __init__(self,
+            distances=histoMaxVariableDR_C3d_params.dR_multicluster_byLayer_coefficientA,
+            nBins_X1=histoMax_C3d_seeding_params.nBins_X1_histo_multicluster,
+            nBins_X2=histoMax_C3d_seeding_params.nBins_X2_histo_multicluster,
+            binSumsHisto=histoMax_C3d_seeding_params.binSumsHisto,
+            seed_threshold=histoMax_C3d_seeding_params.threshold_histo_multicluster,
+            shape_threshold=histoMaxVariableDR_C3d_params.shape_threshold,
+            shape_distance=histoMaxVariableDR_C3d_params.shape_distance,
+            ):
+        self.clustering_parameters= histoMax_C3d_clustering_params.clone(
+                dR_multicluster_byLayer_coefficientA = distances
+                )
+        self.seeding_parameters = histoMax_C3d_seeding_params.clone()
+        set_histomax_seeding_params(self.seeding_parameters, nBins_X1, nBins_X2, binSumsHisto, seed_threshold)
+        set_histomax_clustering_params(self.clustering_parameters, 0, shape_threshold, shape_distance)
 
-    set_histomax_seeding_params(producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters, nBins_X1, nBins_X2, histoMaxXYVariableDR_C3d_params.binSumsHisto,
-            seed_threshold)
-    set_histomax_clustering_params(producer.ProcessorParameters.C3d_parameters.histoMax_C3d_clustering_parameters, 0, shape_threshold, shape_distance)
-
-    return producer
-
-
-def create_histoInterpolatedMax1stOrder(process, inputs,
-                                        distance=histoMax_C3d_clustering_params.dR_multicluster,
-                                        nBins_X1=histoInterpolatedMax_C3d_params.nBins_X1_histo_multicluster,
-                                        nBins_X2=histoInterpolatedMax_C3d_params.nBins_X2_histo_multicluster,
-                                        binSumsHisto=histoInterpolatedMax_C3d_params.binSumsHisto,
-                                        seed_threshold=histoInterpolatedMax_C3d_params.threshold_histo_multicluster,
-                                        shape_threshold=histoMax_C3d_clustering_params.shape_threshold,
-                                        shape_distance=histoMax_C3d_clustering_params.shape_distance,
-                                        ):
-    producer = process.hgcalBackEndLayer2Producer.clone(
-            InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
-            )
-    producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters = histoInterpolatedMax_C3d_params.clone(
-            neighbour_weights = neighbour_weights_1stOrder
-            )
-    producer.ProcessorParameters.C3d_parameters.histoMax_C3d_clustering_parameters = histoMax_C3d_clustering_params.clone()
-    
-    set_histomax_seeding_params(producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters, nBins_X1, nBins_X2, binSumsHisto,
-            seed_threshold)
-    set_histomax_clustering_params(producer.ProcessorParameters.C3d_parameters.histoMax_C3d_clustering_parameters, distance, shape_threshold, shape_distance)
-
-    return producer
+    def __call__(self, process, inputs):
+        producer = process.hgcalBackEndLayer2Producer.clone(
+                InputCluster = cms.InputTag(inputs)
+                )
+        producer.ProcessorParameters.C3d_parameters.histoMax_C3d_clustering_parameters = self.clustering_parameters
+        producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters = self.seeding_parameters
+        return producer
 
 
-def create_histoInterpolatedMax2ndOrder(process, inputs,
-                                        distance=histoMax_C3d_clustering_params.dR_multicluster,
-                                        nBins_X1=histoInterpolatedMax_C3d_params.nBins_X1_histo_multicluster,
-                                        nBins_X2=histoInterpolatedMax_C3d_params.nBins_X2_histo_multicluster,
-                                        binSumsHisto=histoInterpolatedMax_C3d_params.binSumsHisto,
-                                        seed_threshold=histoInterpolatedMax_C3d_params.threshold_histo_multicluster,
-                                        shape_threshold=histoMax_C3d_clustering_params.shape_threshold,
-                                        shape_distance=histoMax_C3d_clustering_params.shape_distance,
-                                        ):
-    producer = process.hgcalBackEndLayer2Producer.clone(
-            InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
-            )
-    producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters = histoInterpolatedMax_C3d_params.clone(
-            neighbour_weights = neighbour_weights_2ndOrder
-            )
-    producer.ProcessorParameters.C3d_parameters.histoMax_C3d_clustering_parameters = histoMax_C3d_clustering_params.clone()
-    set_histomax_seeding_params(producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters, nBins_X1, nBins_X2, binSumsHisto,
-            seed_threshold)
-    set_histomax_clustering_params(producer.ProcessorParameters.histoMax_C3d_clustering_parameters, distance, shape_threshold, shape_distance)
-    
-    return producer
+class CreateHistoMaxXYVariableDr(object):
+    def __init__(self,
+            distances=histoMaxVariableDR_C3d_params.dR_multicluster_byLayer_coefficientA,
+            nBins_X1=histoMaxXYVariableDR_C3d_params.nBins_X1_histo_multicluster,
+            nBins_X2=histoMaxXYVariableDR_C3d_params.nBins_X2_histo_multicluster,
+            seed_threshold=histoMaxXYVariableDR_C3d_params.threshold_histo_multicluster,
+            shape_threshold=histoMaxVariableDR_C3d_params.shape_threshold,
+            shape_distance=histoMaxVariableDR_C3d_params.shape_distance,
+            ):
+        self.clustering_parameters = histoMax_C3d_clustering_params.clone(
+                dR_multicluster_byLayer_coefficientA = distances
+                )
+        self.seeding_parameters = histoMaxXYVariableDR_C3d_params.clone()
+        set_histomax_seeding_params(self.seeding_parameters, nBins_X1, nBins_X2, histoMaxXYVariableDR_C3d_params.binSumsHisto, seed_threshold)
+        set_histomax_clustering_params(self.clustering_parameters, 0, shape_threshold, shape_distance)
+
+    def __call__(self, process, inputs):
+        producer = process.hgcalBackEndLayer2Producer.clone(
+                InputCluster = cms.InputTag(inputs)
+                )
+        producer.ProcessorParameters.C3d_parameters.histoMax_C3d_clustering_parameters = self.clustering_parameters
+        producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters = self.seeding_parameters
+        return producer
 
 
-def create_histoThreshold(process, inputs,
-                          threshold=histoThreshold_C3d_params.threshold_histo_multicluster,
-                          distance=histoMax_C3d_clustering_params.dR_multicluster,
-                          nBins_X1=histoThreshold_C3d_params.nBins_X1_histo_multicluster,
-                          nBins_X2=histoThreshold_C3d_params.nBins_X2_histo_multicluster,
-                          binSumsHisto=histoThreshold_C3d_params.binSumsHisto,
-                          shape_threshold=histoMax_C3d_clustering_params.shape_threshold,
-                          shape_distance=histoMax_C3d_clustering_params.shape_distance,
-                          ):
-    producer = process.hgcalBackEndLayer2Producer.clone(
-            InputCluster = cms.InputTag('{}:HGCalBackendLayer1Processor2DClustering'.format(inputs))
-            )
-    producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters = histoThreshold_C3d_params.clone()
-    producer.ProcessorParameters.C3d_parameters.histoMax_C3d_clustering_parameters = histoMax_C3d_clustering_params.clone()
-    set_histomax_seeding_params(producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters, nBins_X1, nBins_X2, binSumsHisto,
-            seed_threshold)
-    set_histomax_clustering_params(producer.ProcessorParameters.C3d_parameters.histoMax_C3d_clustering_parameters, distance, shape_threshold, shape_distance)
+class CreateHistoInterpolatedMax1stOrder(object):
+    def __init__(self,
+            distance=histoMax_C3d_clustering_params.dR_multicluster,
+            nBins_X1=histoInterpolatedMax_C3d_params.nBins_X1_histo_multicluster,
+            nBins_X2=histoInterpolatedMax_C3d_params.nBins_X2_histo_multicluster,
+            binSumsHisto=histoInterpolatedMax_C3d_params.binSumsHisto,
+            seed_threshold=histoInterpolatedMax_C3d_params.threshold_histo_multicluster,
+            shape_threshold=histoMax_C3d_clustering_params.shape_threshold,
+            shape_distance=histoMax_C3d_clustering_params.shape_distance,
+            ):
+        self.seeding_parameters = histoInterpolatedMax_C3d_params.clone(
+                neighbour_weights = neighbour_weights_1stOrder
+                )
+        self.clustering_parameters = histoMax_C3d_clustering_params.clone()
+        set_histomax_seeding_params(self.seeding_parameters, nBins_X1, nBins_X2, binSumsHisto, seed_threshold)
+        set_histomax_clustering_params(self.clustering_parameters, distance, shape_threshold, shape_distance)
 
-    return producer
+    def __call__(self, process, inputs):
+        producer = process.hgcalBackEndLayer2Producer.clone(
+                InputCluster = cms.InputTag(inputs)
+                )
+        producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters = self.seeding_parameters
+        producer.ProcessorParameters.C3d_parameters.histoMax_C3d_clustering_parameters = self.clustering_parameters
+        return producer
+
+
+class CreateHistoInterpolatedMax2ndOrder(object):
+    def __init__(self,
+            distance=histoMax_C3d_clustering_params.dR_multicluster,
+            nBins_X1=histoInterpolatedMax_C3d_params.nBins_X1_histo_multicluster,
+            nBins_X2=histoInterpolatedMax_C3d_params.nBins_X2_histo_multicluster,
+            binSumsHisto=histoInterpolatedMax_C3d_params.binSumsHisto,
+            seed_threshold=histoInterpolatedMax_C3d_params.threshold_histo_multicluster,
+            shape_threshold=histoMax_C3d_clustering_params.shape_threshold,
+            shape_distance=histoMax_C3d_clustering_params.shape_distance,
+            ):
+        self.seeding_parameters = histoInterpolatedMax_C3d_params.clone(
+                neighbour_weights = neighbour_weights_2ndOrder
+                )
+        self.clustering_parameters = histoMax_C3d_clustering_params.clone()
+        set_histomax_seeding_params(self.seeding_parameters, nBins_X1, nBins_X2, binSumsHisto, seed_threshold)
+        set_histomax_clustering_params(self.clustering_parameters, distance, shape_threshold, shape_distance)
+
+    def __call__(self, process, inputs):
+        producer = process.hgcalBackEndLayer2Producer.clone(
+                InputCluster = cms.InputTag(inputs)
+                )
+        producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters = self.seeding_parameters
+        producer.ProcessorParameters.C3d_parameters.histoMax_C3d_clustering_parameters = self.clustering_parameters
+        return producer
+
+
+class CreateHistoThreshold(object):
+    def __init__(self,
+            seed_threshold=histoThreshold_C3d_params.threshold_histo_multicluster,
+            distance=histoMax_C3d_clustering_params.dR_multicluster,
+            nBins_X1=histoThreshold_C3d_params.nBins_X1_histo_multicluster,
+            nBins_X2=histoThreshold_C3d_params.nBins_X2_histo_multicluster,
+            binSumsHisto=histoThreshold_C3d_params.binSumsHisto,
+            shape_threshold=histoMax_C3d_clustering_params.shape_threshold,
+            shape_distance=histoMax_C3d_clustering_params.shape_distance,
+            ):
+        self.seeding_parameters = histoThreshold_C3d_params.clone()
+        self.clustering_parameters = histoMax_C3d_clustering_params.clone()
+        set_histomax_seeding_params(self.seeding_parameters, nBins_X1, nBins_X2, binSumsHisto, seed_threshold)
+        set_histomax_clustering_params(self.clustering_parameters, distance, shape_threshold, shape_distance)
+
+    def __call__(self, process, inputs):
+        producer = process.hgcalBackEndLayer2Producer.clone(
+                InputCluster = cms.InputTag(inputs)
+                )
+        producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters = self.seeding_parameters
+        producer.ProcessorParameters.C3d_parameters.histoMax_C3d_clustering_parameters = self.clustering_parameters
+        return producer

--- a/L1Trigger/L1THGCalUtilities/python/concentrator.py
+++ b/L1Trigger/L1THGCalUtilities/python/concentrator.py
@@ -4,156 +4,184 @@ import SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi as digiparam
 from L1Trigger.L1THGCal.hgcalConcentratorProducer_cfi import threshold_conc_proc, best_conc_proc, supertc_conc_proc, coarsetc_onebitfraction_proc, custom_conc_proc, autoEncoder_conc_proc
 
 
-def create_supertriggercell(process, inputs,
-                            stcSize=supertc_conc_proc.stcSize,
-                            type_energy_division=supertc_conc_proc.type_energy_division,
-                            fixedDataSizePerHGCROC=supertc_conc_proc.fixedDataSizePerHGCROC,
-                            coarsenTriggerCells=supertc_conc_proc.coarsenTriggerCells,
-                            ctcSize=supertc_conc_proc.ctcSize,
-                            ):
-    producer = process.hgcalConcentratorProducer.clone(
-            InputTriggerCells = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs)),
-            InputTriggerSums = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs))
-            )
-    producer.ProcessorParameters = supertc_conc_proc.clone(
-            stcSize = stcSize,
-            type_energy_division = type_energy_division,
-            fixedDataSizePerHGCROC = fixedDataSizePerHGCROC,
-            coarsenTriggerCells = coarsenTriggerCells,
-            ctcSize = ctcSize,
-            )
-    return producer
+class CreateSuperTriggerCell(object):
+    def __init__(self,
+            stcSize=supertc_conc_proc.stcSize,
+            type_energy_division=supertc_conc_proc.type_energy_division,
+            fixedDataSizePerHGCROC=supertc_conc_proc.fixedDataSizePerHGCROC,
+            coarsenTriggerCells=supertc_conc_proc.coarsenTriggerCells,
+            ctcSize=supertc_conc_proc.ctcSize,
+            ):
+        self.processor = supertc_conc_proc.clone(
+                stcSize = stcSize,
+                type_energy_division = type_energy_division,
+                fixedDataSizePerHGCROC = fixedDataSizePerHGCROC,
+                coarsenTriggerCells = coarsenTriggerCells,
+                ctcSize = ctcSize,
+                )
+
+    def __call__(self, process, inputs):
+        producer = process.hgcalConcentratorProducer.clone(
+                InputTriggerCells = cms.InputTag(inputs),
+                InputTriggerSums = cms.InputTag(inputs),
+                ProcessorParameters = self.processor
+                )
+        return producer
 
 
-def create_threshold(process, inputs,
-                     threshold_silicon=threshold_conc_proc.threshold_silicon,  # in mipT
-                     threshold_scintillator=threshold_conc_proc.threshold_scintillator  # in mipT
-                     ):
-    producer = process.hgcalConcentratorProducer.clone(
-            InputTriggerCells = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs)),
-            InputTriggerSums = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs))
-            )
-    producer.ProcessorParameters = threshold_conc_proc.clone(
-            threshold_silicon = threshold_silicon,  # MipT
-            threshold_scintillator = threshold_scintillator  # MipT
-            )
-    return producer
+class CreateThreshold(object):
+    def __init__(self,
+            threshold_silicon=threshold_conc_proc.threshold_silicon,  # in mipT
+            threshold_scintillator=threshold_conc_proc.threshold_scintillator  # in mipT
+            ):
+        self.processor = threshold_conc_proc.clone(
+                threshold_silicon = threshold_silicon,  # MipT
+                threshold_scintillator = threshold_scintillator  # MipT
+                )
+
+    def __call__(self, process, inputs):
+        producer = process.hgcalConcentratorProducer.clone(
+                InputTriggerCells = cms.InputTag(inputs),
+                InputTriggerSums = cms.InputTag(inputs),
+                ProcessorParameters = self.processor
+                )
+        return producer
 
 
-def create_bestchoice(process, inputs,
-                      triggercells=best_conc_proc.NData,
-                      coarsenTriggerCells=best_conc_proc.coarsenTriggerCells,
-                      ctcSize=best_conc_proc.ctcSize,
-                      ):
-    producer = process.hgcalConcentratorProducer.clone(
-            InputTriggerCells = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs)),
-            InputTriggerSums = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs))
-            )
-    producer.ProcessorParameters = best_conc_proc.clone(
-            NData = triggercells,
-            coarsenTriggerCells = coarsenTriggerCells,
-            ctcSize=ctcSize,
-            )
-    return producer
+class CreateBestChoice(object):
+    def __init__(self,
+            triggercells=best_conc_proc.NData,
+            coarsenTriggerCells=best_conc_proc.coarsenTriggerCells,
+            ctcSize=best_conc_proc.ctcSize,
+            ):
+        self.processor = best_conc_proc.clone(
+                NData = triggercells,
+                coarsenTriggerCells = coarsenTriggerCells,
+                ctcSize=ctcSize,
+                )
+
+    def __call__(self, process, inputs):
+        producer = process.hgcalConcentratorProducer.clone(
+                InputTriggerCells = cms.InputTag(inputs),
+                InputTriggerSums = cms.InputTag(inputs),
+                ProcessorParameters = self.processor
+                )
+        return producer
 
 
-def create_autoencoder(process, inputs,
-                       cellRemap = autoEncoder_conc_proc.cellRemap,
-                       cellRemapNoDuplicates = autoEncoder_conc_proc.cellRemapNoDuplicates,
-                       nBitsPerInput = autoEncoder_conc_proc.nBitsPerInput,
-                       maxBitsPerOutput = autoEncoder_conc_proc.maxBitsPerOutput,
-                       bitsPerLink = autoEncoder_conc_proc.bitsPerLink,
-                       modelFiles = autoEncoder_conc_proc.modelFiles,
-                       linkToGraphMap = autoEncoder_conc_proc.linkToGraphMap,
-                       encoderShape = autoEncoder_conc_proc.encoderShape,
-                       decoderShape = autoEncoder_conc_proc.decoderShape,
-                       zeroSuppresionThreshold = autoEncoder_conc_proc.zeroSuppresionThreshold,
-                       saveEncodedValues = autoEncoder_conc_proc.saveEncodedValues,
-                       preserveModuleSum = autoEncoder_conc_proc.preserveModuleSum,
-                       scintillatorMethod = 'thresholdSelect',
-                     ):
-    producer = process.hgcalConcentratorProducer.clone(
-            InputTriggerCells = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs)),
-            InputTriggerSums = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs))
-            )
-    producer.ProcessorParameters = autoEncoder_conc_proc.clone(
-            cellRemap = cellRemap,
-            cellRemapNoDuplicates = cellRemapNoDuplicates,
-            nBitsPerInput = nBitsPerInput,
-            maxBitsPerOutput = maxBitsPerOutput,
-            bitsPerLink = bitsPerLink,
-            modelFiles = modelFiles,
-            linkToGraphMap = linkToGraphMap,
-            encoderShape = encoderShape,
-            decoderShape = decoderShape,
-            zeroSuppresionThreshold = zeroSuppresionThreshold,
-            saveEncodedValues = saveEncodedValues,
-            preserveModuleSum = preserveModuleSum,
-            Method = cms.vstring(['autoEncoder','autoEncoder', scintillatorMethod]),
-            )
-    return producer
+class CreateAutoencoder(object):
+    def __init__(self,
+            cellRemap = autoEncoder_conc_proc.cellRemap,
+            cellRemapNoDuplicates = autoEncoder_conc_proc.cellRemapNoDuplicates,
+            nBitsPerInput = autoEncoder_conc_proc.nBitsPerInput,
+            maxBitsPerOutput = autoEncoder_conc_proc.maxBitsPerOutput,
+            bitsPerLink = autoEncoder_conc_proc.bitsPerLink,
+            modelFiles = autoEncoder_conc_proc.modelFiles,
+            linkToGraphMap = autoEncoder_conc_proc.linkToGraphMap,
+            encoderShape = autoEncoder_conc_proc.encoderShape,
+            decoderShape = autoEncoder_conc_proc.decoderShape,
+            zeroSuppresionThreshold = autoEncoder_conc_proc.zeroSuppresionThreshold,
+            saveEncodedValues = autoEncoder_conc_proc.saveEncodedValues,
+            preserveModuleSum = autoEncoder_conc_proc.preserveModuleSum,
+            scintillatorMethod = 'thresholdSelect',
+            ):
+         self.processor = autoEncoder_conc_proc.clone(
+                cellRemap = cellRemap,
+                cellRemapNoDuplicates = cellRemapNoDuplicates,
+                nBitsPerInput = nBitsPerInput,
+                maxBitsPerOutput = maxBitsPerOutput,
+                bitsPerLink = bitsPerLink,
+                modelFiles = modelFiles,
+                linkToGraphMap = linkToGraphMap,
+                encoderShape = encoderShape,
+                decoderShape = decoderShape,
+                zeroSuppresionThreshold = zeroSuppresionThreshold,
+                saveEncodedValues = saveEncodedValues,
+                preserveModuleSum = preserveModuleSum,
+                Method = cms.vstring(['autoEncoder','autoEncoder', scintillatorMethod]),
+                )
+
+    def __call__(self, process, inputs):
+        producer = process.hgcalConcentratorProducer.clone(
+                InputTriggerCells = cms.InputTag(inputs),
+                InputTriggerSums = cms.InputTag(inputs),
+                ProcessorParameters = self.processor
+                )
+        return producer
 
 
-def create_onebitfraction(process, inputs,
-                            stcSize=coarsetc_onebitfraction_proc.stcSize,
-                            fixedDataSizePerHGCROC=coarsetc_onebitfraction_proc.fixedDataSizePerHGCROC
-                            ):
-    producer = process.hgcalConcentratorProducer.clone(
-            InputTriggerCells = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs)),
-            InputTriggerSums = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs))
-            )
-    producer.ProcessorParameters = coarsetc_onebitfraction_proc.clone(
-            stcSize = stcSize,
-            fixedDataSizePerHGCROC = fixedDataSizePerHGCROC
-            )
-    return producer
+class CreateOneBitFraction(object):
+    def __init__(self,
+            stcSize=coarsetc_onebitfraction_proc.stcSize,
+            fixedDataSizePerHGCROC=coarsetc_onebitfraction_proc.fixedDataSizePerHGCROC
+            ):
+        self.processor = coarsetc_onebitfraction_proc.clone(
+                stcSize = stcSize,
+                fixedDataSizePerHGCROC = fixedDataSizePerHGCROC
+                )
+
+    def __call__(self, process, inputs):
+        producer = process.hgcalConcentratorProducer.clone(
+                InputTriggerCells = cms.InputTag(inputs),
+                InputTriggerSums = cms.InputTag(inputs),
+                ProcessorParameters = self.processor
+                )
+        return producer
 
 
-def create_mixedfeoptions(process, inputs,
-                            stcSize=custom_conc_proc.stcSize,
-                            type_energy_division=custom_conc_proc.type_energy_division,
-                            fixedDataSizePerHGCROC=custom_conc_proc.fixedDataSizePerHGCROC,
-                            triggercells=custom_conc_proc.NData
-                            ):
-    producer = process.hgcalConcentratorProducer.clone(
-            InputTriggerCells = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs)),
-            InputTriggerSums = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs))
-            )
-    producer.ProcessorParameters = custom_conc_proc.clone(
-            stcSize = stcSize,
-            type_energy_division = type_energy_division,
-            fixedDataSizePerHGCROC = fixedDataSizePerHGCROC,
-            NData = triggercells,
-            Method = cms.vstring('bestChoiceSelect','superTriggerCellSelect','superTriggerCellSelect'),        
-            )
-    return producer
+class CreateMixedFeOptions(object):
+    def __init__(self,
+            stcSize=custom_conc_proc.stcSize,
+            type_energy_division=custom_conc_proc.type_energy_division,
+            fixedDataSizePerHGCROC=custom_conc_proc.fixedDataSizePerHGCROC,
+            triggercells=custom_conc_proc.NData
+            ):
+        self.processor = custom_conc_proc.clone(
+                stcSize = stcSize,
+                type_energy_division = type_energy_division,
+                fixedDataSizePerHGCROC = fixedDataSizePerHGCROC,
+                NData = triggercells,
+                Method = cms.vstring('bestChoiceSelect','superTriggerCellSelect','superTriggerCellSelect'),
+                )
+
+    def __call__(self, process, inputs):
+        producer = process.hgcalConcentratorProducer.clone(
+                InputTriggerCells = cms.InputTag(inputs),
+                InputTriggerSums = cms.InputTag(inputs),
+                ProcessorParameters = self.processor
+                )
+        return producer
 
 
-def create_custom(process, inputs,
-                            stcSize=custom_conc_proc.stcSize,
-                            type_energy_division=custom_conc_proc.type_energy_division,
-                            fixedDataSizePerHGCROC=custom_conc_proc.fixedDataSizePerHGCROC,
-                            triggercells=custom_conc_proc.NData,
-                            threshold_silicon=custom_conc_proc.threshold_silicon,  # in mipT
-                            threshold_scintillator=custom_conc_proc.threshold_scintillator,  # in mipT
-                            Method = custom_conc_proc.Method,
-                            coarsenTriggerCells=custom_conc_proc.coarsenTriggerCells,
-                            ctcSize=custom_conc_proc.ctcSize,
-                            ):
-    producer = process.hgcalConcentratorProducer.clone(
-            InputTriggerCells = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs)),
-            InputTriggerSums = cms.InputTag('{}:HGCalVFEProcessorSums'.format(inputs))
-            )
-    producer.ProcessorParameters = custom_conc_proc.clone(
-            stcSize = stcSize,
-            type_energy_division = type_energy_division,
-            fixedDataSizePerHGCROC = fixedDataSizePerHGCROC,
-            NData = triggercells,
-            threshold_silicon = threshold_silicon,  # MipT
-            threshold_scintillator = threshold_scintillator,  # MipT
-            Method = Method,
-            coarsenTriggerCells=coarsenTriggerCells,
-            ctcSize = ctcSize,
-            )
-    return producer
+class CreateCustom(object):
+    def __init__(self,
+            stcSize=custom_conc_proc.stcSize,
+            type_energy_division=custom_conc_proc.type_energy_division,
+            fixedDataSizePerHGCROC=custom_conc_proc.fixedDataSizePerHGCROC,
+            triggercells=custom_conc_proc.NData,
+            threshold_silicon=custom_conc_proc.threshold_silicon,  # in mipT
+            threshold_scintillator=custom_conc_proc.threshold_scintillator,  # in mipT
+            Method = custom_conc_proc.Method,
+            coarsenTriggerCells=custom_conc_proc.coarsenTriggerCells,
+            ctcSize=custom_conc_proc.ctcSize,
+            ):
+        self.processor = custom_conc_proc.clone(
+                stcSize = stcSize,
+                type_energy_division = type_energy_division,
+                fixedDataSizePerHGCROC = fixedDataSizePerHGCROC,
+                NData = triggercells,
+                threshold_silicon = threshold_silicon,  # MipT
+                threshold_scintillator = threshold_scintillator,  # MipT
+                Method = Method,
+                coarsenTriggerCells=coarsenTriggerCells,
+                ctcSize = ctcSize,
+                )
+
+    def __call__(self, process, inputs):
+        producer = process.hgcalConcentratorProducer.clone(
+                InputTriggerCells = cms.InputTag(inputs),
+                InputTriggerSums = cms.InputTag(inputs),
+                ProcessorParameters = self.processor
+                )
+        return producer
 

--- a/L1Trigger/L1THGCalUtilities/python/customNtuples.py
+++ b/L1Trigger/L1THGCalUtilities/python/customNtuples.py
@@ -1,18 +1,22 @@
 import FWCore.ParameterSet.Config as cms
 
-def custom_ntuples_V9(process):
+def custom_ntuples_layer1_truncation(process):
     ntuples = process.hgcalTriggerNtuplizer.Ntuples
     for ntuple in ntuples:
-        if ntuple.NtupleName=='HGCalTriggerNtupleHGCDigis' or \
-           ntuple.NtupleName=='HGCalTriggerNtupleHGCTriggerCells':
-            ntuple.bhSimHits = cms.InputTag('g4SimHits:HGCHitsHEback')
+        if ntuple.NtupleName=='HGCalTriggerNtupleHGCClusters' or \
+           ntuple.NtupleName=='HGCalTriggerNtupleHGCTriggerCells' or \
+           ntuple.NtupleName=='HGCalTriggerNtupleHGCMulticlusters':
+            ntuple.Clusters = cms.InputTag('hgcalBackEndLayer1Producer:HGCalBackendLayer1Processor')
     return process
 
 def custom_ntuples_stage1_truncation(process):
     ntuples = process.hgcalTriggerNtuplizer.Ntuples
     for ntuple in ntuples:
-        if ntuple.NtupleName=='HGCalTriggerNtupleHGCClusters':
-            ntuple.Clusters = cms.InputTag('hgcalBackEndLayer1Producer:HGCalBackendStage1Processor')
+        if ntuple.NtupleName=='HGCalTriggerNtupleHGCClusters' or \
+           ntuple.NtupleName=='HGCalTriggerNtupleHGCTriggerCells' or \
+           ntuple.NtupleName=='HGCalTriggerNtupleHGCMulticlusters':
+            ntuple.Clusters = cms.InputTag('hgcalBackEndStage1Producer:HGCalBackendStage1Processor')
+            ntuple.Multiclusters = cms.InputTag('hgcalBackEndStage2Producer:HGCalBackendLayer2Processor3DClustering')
     return process
 
 def custom_ntuples_standalone_clustering(process):
@@ -61,7 +65,3 @@ class CreateNtuple(object):
         ntuplizer = process.hgcalTriggerNtuplizer.clone()
         ntuplizer.Ntuples = cms.VPSet(vpset)
         return ntuplizer
-
-
-
-

--- a/L1Trigger/L1THGCalUtilities/python/customNtuples.py
+++ b/L1Trigger/L1THGCalUtilities/python/customNtuples.py
@@ -1,5 +1,30 @@
 import FWCore.ParameterSet.Config as cms
 
+def custom_ntuples_V9(process):
+    ntuples = process.hgcalTriggerNtuplizer.Ntuples
+    for ntuple in ntuples:
+        if ntuple.NtupleName=='HGCalTriggerNtupleHGCDigis' or \
+           ntuple.NtupleName=='HGCalTriggerNtupleHGCTriggerCells':
+            ntuple.bhSimHits = cms.InputTag('g4SimHits:HGCHitsHEback')
+    return process
+
+def custom_ntuples_standalone_clustering(process):
+    ntuples = process.hgcalTriggerNtuplizer.Ntuples
+    for ntuple in ntuples:
+        if ntuple.NtupleName=='HGCalTriggerNtupleHGCTriggerCells' or \
+           ntuple.NtupleName=='HGCalTriggerNtupleHGCClusters' or \
+           ntuple.NtupleName=='HGCalTriggerNtupleHGCMulticlusters':
+            ntuple.Multiclusters = cms.InputTag('hgcalBackEndLayer2Producer:HGCalBackendLayer2Processor3DClusteringSA')
+    return process
+
+
+def custom_ntuples_standalone_tower(process):
+    ntuples = process.hgcalTriggerNtuplizer.Ntuples
+    for ntuple in ntuples:
+        if ntuple.NtupleName=='HGCalTriggerNtupleHGCTowers':
+            ntuple.Towers = cms.InputTag('hgcalTowerProducer:HGCalTowerProcessorSA')
+    return process
+
 
 def create_ntuple(process, inputs,
         ntuple_list=[

--- a/L1Trigger/L1THGCalUtilities/python/customNtuples.py
+++ b/L1Trigger/L1THGCalUtilities/python/customNtuples.py
@@ -33,7 +33,8 @@ def custom_ntuples_standalone_tower(process):
     return process
 
 
-def create_ntuple(process, inputs,
+class CreateNtuple(object):
+    def __init__(self,
         ntuple_list=[
             'event',
             'gen', 'genjet', 'gentau',
@@ -41,22 +42,25 @@ def create_ntuple(process, inputs,
             'triggercells',
             'clusters', 'multiclusters'
             ]
-        ):
-    vpset = []
-    for ntuple in ntuple_list:
-        pset = getattr(process, 'ntuple_'+ntuple).clone()
-        if ntuple=='triggercells':
-            pset.TriggerCells = cms.InputTag(inputs[0])
-            pset.Multiclusters = cms.InputTag(inputs[2])
-        elif ntuple=='clusters':
-            pset.Clusters = cms.InputTag(inputs[1])
-            pset.Multiclusters = cms.InputTag(inputs[2])
-        elif ntuple=='multiclusters':
-            pset.Multiclusters = cms.InputTag(inputs[2])
-        vpset.append(pset)
-    ntuplizer = process.hgcalTriggerNtuplizer.clone()
-    ntuplizer.Ntuples = cms.VPSet(vpset)
-    return ntuplizer
+            ):
+        self.ntuple_list = ntuple_list
+
+    def __call__(self, process, inputs):
+        vpset = []
+        for ntuple in self.ntuple_list:
+            pset = getattr(process, 'ntuple_'+ntuple).clone()
+            if ntuple=='triggercells':
+                pset.TriggerCells = cms.InputTag(inputs[0])
+                pset.Multiclusters = cms.InputTag(inputs[2])
+            elif ntuple=='clusters':
+                pset.Clusters = cms.InputTag(inputs[1])
+                pset.Multiclusters = cms.InputTag(inputs[2])
+            elif ntuple=='multiclusters':
+                pset.Multiclusters = cms.InputTag(inputs[2])
+            vpset.append(pset)
+        ntuplizer = process.hgcalTriggerNtuplizer.clone()
+        ntuplizer.Ntuples = cms.VPSet(vpset)
+        return ntuplizer
 
 
 

--- a/L1Trigger/L1THGCalUtilities/python/customNtuples.py
+++ b/L1Trigger/L1THGCalUtilities/python/customNtuples.py
@@ -8,6 +8,13 @@ def custom_ntuples_V9(process):
             ntuple.bhSimHits = cms.InputTag('g4SimHits:HGCHitsHEback')
     return process
 
+def custom_ntuples_stage1_truncation(process):
+    ntuples = process.hgcalTriggerNtuplizer.Ntuples
+    for ntuple in ntuples:
+        if ntuple.NtupleName=='HGCalTriggerNtupleHGCClusters':
+            ntuple.Clusters = cms.InputTag('hgcalBackEndLayer1Producer:HGCalBackendStage1Processor')
+    return process
+
 def custom_ntuples_standalone_clustering(process):
     ntuples = process.hgcalTriggerNtuplizer.Ntuples
     for ntuple in ntuples:

--- a/L1Trigger/L1THGCalUtilities/python/hgcalTriggerChains.py
+++ b/L1Trigger/L1THGCalUtilities/python/hgcalTriggerChains.py
@@ -34,32 +34,32 @@ class HGCalTriggerChains:
         self.ntuple[name] = generator
 
     def register_chain(self, vfe, concentrator, backend1, backend2, selector='', ntuple=''):
-        if not vfe in self.vfe: 
+        if not vfe in self.vfe:
             raise KeyError('{} not registered as VFE producer'.format(vfe))
-        if not concentrator in self.concentrator: 
+        if not concentrator in self.concentrator:
             raise KeyError('{} not registered as concentrator producer'.format(concentrator))
-        if not backend1 in self.backend1: 
+        if not backend1 in self.backend1:
             raise KeyError('{} not registered as backend1 producer'.format(backend1))
-        if not backend2 in self.backend2: 
+        if not backend2 in self.backend2:
             raise KeyError('{} not registered as backend2 producer'.format(backend2))
         if selector!='' and not selector in self.selector:
             raise KeyError('{} not registered as selector'.format(selector))
-        if ntuple!='' and not ntuple in self.ntuple: 
+        if ntuple!='' and not ntuple in self.ntuple:
             raise KeyError('{} not registered as ntuplizer'.format(ntuple))
         self.chain.append( (vfe, concentrator, backend1, backend2, selector, ntuple) )
 
-    def register_truth_chain(self, vfe, truth_prod, backend1='', backend2='', selector='', ntuple=''): 
-        if not vfe in self.vfe: 
+    def register_truth_chain(self, vfe, truth_prod, backend1='', backend2='', selector='', ntuple=''):
+        if not vfe in self.vfe:
             raise KeyError('{} not registered as VFE producer'.format(vfe))
-        if not truth_prod in self.truth_prod: 
+        if not truth_prod in self.truth_prod:
             raise KeyError('{} not registered as truth producer'.format(truth_prod))
-        if backend1!='' and not backend1 in self.backend1: 
+        if backend1!='' and not backend1 in self.backend1:
             raise KeyError('{} not registered as backend1 producer'.format(backend1))
-        if backend2!='' and not backend2 in self.backend2: 
+        if backend2!='' and not backend2 in self.backend2:
             raise KeyError('{} not registered as backend2 producer'.format(backend2))
         if selector!='' and not selector in self.selector:
             raise KeyError('{} not registered as selector'.format(selector))
-        if ntuple!='' and not ntuple in self.ntuple: 
+        if ntuple!='' and not ntuple in self.ntuple:
             raise KeyError('{} not registered as ntuplizer'.format(ntuple))
         self.truth_chain.append( (vfe, truth_prod, backend1, backend2, selector, ntuple) )
 
@@ -123,12 +123,16 @@ class HGCalTriggerChains:
         ntuple_sequence.remove(tmpseq)
         process.globalReplace('hgcalVFE', vfe_task)
         process.globalReplace('hgcalConcentrator', concentrator_task)
-        process.globalReplace('hgcalBackEndLayer1', backend1_task)
-        process.globalReplace('hgcalBackEndLayer2', backend2_task)
+        if 'HGCalBackendStage1Processor' in backend1_processor:
+            process.globalReplace('hgcalBackEndStage1', backend1_task)
+            process.globalReplace('hgcalBackEndStage2', backend2_task)
+        else:
+            process.globalReplace('hgcalBackEndLayer1', backend1_task)
+            process.globalReplace('hgcalBackEndLayer2', backend2_task)
         process.globalReplace('hgcalTriggerSelector', selector_sequence)
         process.globalReplace('hgcalTriggerNtuples', ntuple_sequence)
         return process
-    
+
     def create_truth_sequences(self, process):
         if not hasattr(process, 'caloTruthCellsProducer'):
             from L1Trigger.L1THGCalUtilities.caloTruthCellsProducer_cfi import caloTruthCellsProducer

--- a/L1Trigger/L1THGCalUtilities/python/selectors.py
+++ b/L1Trigger/L1THGCalUtilities/python/selectors.py
@@ -1,10 +1,14 @@
 import FWCore.ParameterSet.Config as cms
 
-def create_genmatch(process, inputs,
-        distance=0.3
-        ):
-    producer = process.hgc3DClusterGenMatchSelector.clone(
-            dR = cms.double(distance),
-            src = cms.InputTag('{}:HGCalBackendLayer2Processor3DClustering'.format(inputs))
-            )
-    return producer
+class CreateGenMatch(object):
+    def __init__(self,
+            distance=0.3
+            ):
+        self.dR = distance
+
+    def __call__(self, process, inputs):
+        producer = process.hgc3DClusterGenMatchSelector.clone(
+                dR = cms.double(self.dR),
+                src = cms.InputTag(inputs)
+                )
+        return producer

--- a/L1Trigger/L1THGCalUtilities/python/vfe.py
+++ b/L1Trigger/L1THGCalUtilities/python/vfe.py
@@ -2,18 +2,22 @@ import FWCore.ParameterSet.Config as cms
 
 from L1Trigger.L1THGCal.hgcalVFEProducer_cfi import vfe_proc
 
-def create_vfe(process,
-        linearization_si=vfe_proc.linearizationCfg_si,
-        linearization_sc=vfe_proc.linearizationCfg_sc,
-        compression_ldm=vfe_proc.compressionCfg_ldm,
-        compression_hdm=vfe_proc.compressionCfg_hdm,
-        ):
-    producer = process.hgcalVFEProducer.clone(
-        ProcessorParameters = vfe_proc.clone(
+class CreateVfe(object):
+    def __init__(self,
+            linearization_si=vfe_proc.linearizationCfg_si,
+            linearization_sc=vfe_proc.linearizationCfg_sc,
+            compression_ldm=vfe_proc.compressionCfg_ldm,
+            compression_hdm=vfe_proc.compressionCfg_hdm,
+            ):
+        self.processor = vfe_proc.clone(
             linearizationCfg_si = linearization_si,
             linearizationCfg_sc = linearization_sc,
             compressionCfg_ldm = compression_ldm,
             compressionCfg_hdm = compression_hdm,
         )
-    )
-    return producer
+
+    def __call__(self, process):
+        producer = process.hgcalVFEProducer.clone(
+            ProcessorParameters = self.processor
+        )
+        return producer

--- a/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_RelValV11_cfg.py
+++ b/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_RelValV11_cfg.py
@@ -1,4 +1,4 @@
-import FWCore.ParameterSet.Config as cms 
+import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Phase2C9_cff import Phase2C9
 process = cms.Process('DIGI',Phase2C9)
@@ -29,7 +29,7 @@ process.maxEvents = cms.untracked.PSet(
 
 # Input source
 process.source = cms.Source("PoolSource",
-       fileNames = cms.untracked.vstring('/store/mc/Phase2HLTTDRWinter20DIGI/SingleElectron_PT2to200/GEN-SIM-DIGI-RAW/PU200_110X_mcRun4_realistic_v3_ext2-v2/40000/00582F93-5A2A-5847-8162-D81EE503500F.root'),
+       fileNames = cms.untracked.vstring('/store/mc/Phase2HLTTDRSummer20ReRECOMiniAOD/DoublePhoton_FlatPt-1To100/FEVT/PU200_111X_mcRun4_realistic_T15_v1_ext1-v2/1210000/F2E5E947-0CB4-D245-A943-17F2F05709D3.root'),
        inputCommands=cms.untracked.vstring(
            'keep *',
            'drop l1tEMTFHit2016Extras_simEmtfDigis_CSC_HLT',
@@ -43,8 +43,7 @@ process.source = cms.Source("PoolSource",
            'drop BTLDetIdBTLSampleFTLDataFrameTsSorted_mix_FTLBarrel_HLT',
            'drop ETLDetIdETLSampleFTLDataFrameTsSorted_mix_FTLEndcap_HLT',
            )
-       )
-
+        )
 process.options = cms.untracked.PSet(
 
 )
@@ -83,4 +82,3 @@ process.schedule = cms.Schedule(process.hgcl1tpg_step, process.ntuple_step)
 from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
 process = customiseEarlyDelete(process)
 # End adding early deletion
-

--- a/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_multialgo_V11_cfg.py
+++ b/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_multialgo_V11_cfg.py
@@ -77,21 +77,23 @@ import L1Trigger.L1THGCalUtilities.customNtuples as ntuple
 chains = HGCalTriggerChains()
 # Register algorithms
 ## VFE
-chains.register_vfe("Floatingpoint", vfe.create_vfe)
+chains.register_vfe("Floatingpoint", vfe.CreateVfe())
 ## ECON
-chains.register_concentrator("Supertriggercell", concentrator.create_supertriggercell)
-chains.register_concentrator("Threshold", concentrator.create_threshold)
-chains.register_concentrator("Bestchoice", concentrator.create_bestchoice)
-chains.register_concentrator("AutoEncoder", concentrator.create_autoencoder)
+chains.register_concentrator("Supertriggercell", concentrator.CreateSuperTriggerCell())
+chains.register_concentrator("Threshold", concentrator.CreateThreshold())
+chains.register_concentrator("Bestchoice", concentrator.CreateBestChoice())
+chains.register_concentrator("AutoEncoder", concentrator.CreateAutoencoder())
 ## BE1
-chains.register_backend1("Dummy", clustering2d.create_dummy)
+chains.register_backend1("Dummy", clustering2d.CreateDummy())
 ## BE2
-chains.register_backend2("Histomax", clustering3d.create_histoMax)
+chains.register_backend2("Histomax", clustering3d.CreateHistoMax())
 # Register selector
-chains.register_selector("Genmatch", selectors.create_genmatch)
+chains.register_selector("Genmatch", selectors.CreateGenMatch())
+
+
 # Register ntuples
 ntuple_list = ['event', 'gen', 'multiclusters']
-chains.register_ntuple("Genclustersntuple", lambda p,i : ntuple.create_ntuple(p,i, ntuple_list))
+chains.register_ntuple("Genclustersntuple", ntuple.CreateNtuple(ntuple_list))
 
 # Register trigger chains
 concentrator_algos = ['Supertriggercell', 'Threshold', 'Bestchoice', 'AutoEncoder']

--- a/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_newProcessors_V11_cfg.py
+++ b/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_newProcessors_V11_cfg.py
@@ -1,0 +1,94 @@
+import FWCore.ParameterSet.Config as cms 
+
+from Configuration.Eras.Era_Phase2C9_cff import Phase2C9
+process = cms.Process('DIGI',Phase2C9)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.Geometry.GeometryExtended2026D49Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D49_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedHLLHC14TeV_cfi')
+process.load('GeneratorInterface.Core.genFilterSummary_cff')
+process.load('Configuration.StandardSequences.SimIdeal_cff')
+process.load('Configuration.StandardSequences.Digi_cff')
+process.load('Configuration.StandardSequences.SimL1Emulator_cff')
+process.load('Configuration.StandardSequences.DigiToRaw_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(50)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+       fileNames = cms.untracked.vstring('/store/mc/Phase2HLTTDRWinter20DIGI/SingleElectron_PT2to200/GEN-SIM-DIGI-RAW/PU200_110X_mcRun4_realistic_v3_ext2-v2/40000/00582F93-5A2A-5847-8162-D81EE503500F.root'),
+       inputCommands=cms.untracked.vstring(
+           'keep *',
+           'drop l1tEMTFHit2016Extras_simEmtfDigis_CSC_HLT',
+           'drop l1tEMTFHit2016Extras_simEmtfDigis_RPC_HLT',
+           'drop l1tEMTFHit2016s_simEmtfDigis__HLT',
+           'drop l1tEMTFTrack2016Extras_simEmtfDigis__HLT',
+           'drop l1tEMTFTrack2016s_simEmtfDigis__HLT',
+           'drop FTLClusteredmNewDetSetVector_mtdClusters_FTLBarrel_RECO',
+           'drop FTLClusteredmNewDetSetVector_mtdClusters_FTLEndcap_RECO',
+           'drop MTDTrackingRecHitedmNewDetSetVector_mtdTrackingRecHits__RECO',
+           'drop BTLDetIdBTLSampleFTLDataFrameTsSorted_mix_FTLBarrel_HLT',
+           'drop ETLDetIdETLSampleFTLDataFrameTsSorted_mix_FTLEndcap_HLT',
+           )
+       )
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.20 $'),
+    annotation = cms.untracked.string('SingleElectronPt10_cfi nevts:10'),
+    name = cms.untracked.string('Applications')
+)
+
+# Output definition
+process.TFileService = cms.Service(
+    "TFileService",
+    fileName = cms.string("ntuple.root")
+    )
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T15', '')
+
+# load HGCAL TPG simulation
+process.load('L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff')
+
+# Use new processors and standalone algorithms
+from L1Trigger.L1THGCal.customNewProcessors import custom_clustering_standalone, custom_tower_standalone
+process = custom_clustering_standalone(process)
+process = custom_tower_standalone(process)
+
+process.hgcl1tpg_step = cms.Path(process.hgcalTriggerPrimitives)
+
+
+# load ntuplizer
+process.load('L1Trigger.L1THGCalUtilities.hgcalTriggerNtuples_cff')
+from L1Trigger.L1THGCalUtilities.customNtuples import custom_ntuples_standalone_clustering, custom_ntuples_standalone_tower
+process = custom_ntuples_standalone_clustering(process)
+process = custom_ntuples_standalone_tower(process)
+process.ntuple_step = cms.Path(process.hgcalTriggerNtuples)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.hgcl1tpg_step, process.ntuple_step)
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion
+

--- a/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_stage1Truncation_V11_cfg.py
+++ b/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_stage1Truncation_V11_cfg.py
@@ -1,4 +1,4 @@
-import FWCore.ParameterSet.Config as cms 
+import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Phase2C9_cff import Phase2C9
 process = cms.Process('DIGI',Phase2C9)
@@ -29,7 +29,7 @@ process.maxEvents = cms.untracked.PSet(
 
 # Input source
 process.source = cms.Source("PoolSource",
-       fileNames = cms.untracked.vstring('/store/mc/Phase2HLTTDRWinter20DIGI/SingleElectron_PT2to200/GEN-SIM-DIGI-RAW/PU200_110X_mcRun4_realistic_v3_ext2-v2/40000/00582F93-5A2A-5847-8162-D81EE503500F.root'),
+       fileNames = cms.untracked.vstring('/store/mc/Phase2HLTTDRSummer20ReRECOMiniAOD/DoublePhoton_FlatPt-1To100/FEVT/PU200_111X_mcRun4_realistic_T15_v1_ext1-v2/1210000/F2E5E947-0CB4-D245-A943-17F2F05709D3.root'),
        inputCommands=cms.untracked.vstring(
            'keep *',
            'drop l1tEMTFHit2016Extras_simEmtfDigis_CSC_HLT',
@@ -67,7 +67,8 @@ from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T15', '')
 
 # load HGCAL TPG simulation
-process.load('L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff')
+#process.load('L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff')
+process.load('L1Trigger.L1THGCal.hgcalTriggerPrimitivesNew_cff')
 
 # Use new Stage 1 processor
 from L1Trigger.L1THGCal.customNewProcessors import custom_stage1_truncation
@@ -83,7 +84,9 @@ process.hgcl1tpg_step = cms.Path(process.hgcalTriggerPrimitives)
 # load ntuplizer and custom to use collections from Stag1 truncation processor
 process.load('L1Trigger.L1THGCalUtilities.hgcalTriggerNtuples_cff')
 from L1Trigger.L1THGCalUtilities.customNtuples import custom_ntuples_stage1_truncation
+from L1Trigger.L1THGCalUtilities.customNtuples import custom_ntuples_layer1_truncation
 process = custom_ntuples_stage1_truncation(process)
+#process = custom_ntuples_layer1_truncation(process)
 process.ntuple_step = cms.Path(process.hgcalTriggerNtuples)
 
 # Schedule definition
@@ -93,4 +96,3 @@ process.schedule = cms.Schedule(process.hgcl1tpg_step, process.ntuple_step)
 from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
 process = customiseEarlyDelete(process)
 # End adding early deletion
-

--- a/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_stage1Truncation_V11_cfg.py
+++ b/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_stage1Truncation_V11_cfg.py
@@ -1,0 +1,96 @@
+import FWCore.ParameterSet.Config as cms 
+
+from Configuration.Eras.Era_Phase2C9_cff import Phase2C9
+process = cms.Process('DIGI',Phase2C9)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.Geometry.GeometryExtended2026D49Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D49_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedHLLHC14TeV_cfi')
+process.load('GeneratorInterface.Core.genFilterSummary_cff')
+process.load('Configuration.StandardSequences.SimIdeal_cff')
+process.load('Configuration.StandardSequences.Digi_cff')
+process.load('Configuration.StandardSequences.SimL1Emulator_cff')
+process.load('Configuration.StandardSequences.DigiToRaw_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(5)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+       fileNames = cms.untracked.vstring('/store/mc/Phase2HLTTDRWinter20DIGI/SingleElectron_PT2to200/GEN-SIM-DIGI-RAW/PU200_110X_mcRun4_realistic_v3_ext2-v2/40000/00582F93-5A2A-5847-8162-D81EE503500F.root'),
+       inputCommands=cms.untracked.vstring(
+           'keep *',
+           'drop l1tEMTFHit2016Extras_simEmtfDigis_CSC_HLT',
+           'drop l1tEMTFHit2016Extras_simEmtfDigis_RPC_HLT',
+           'drop l1tEMTFHit2016s_simEmtfDigis__HLT',
+           'drop l1tEMTFTrack2016Extras_simEmtfDigis__HLT',
+           'drop l1tEMTFTrack2016s_simEmtfDigis__HLT',
+           'drop FTLClusteredmNewDetSetVector_mtdClusters_FTLBarrel_RECO',
+           'drop FTLClusteredmNewDetSetVector_mtdClusters_FTLEndcap_RECO',
+           'drop MTDTrackingRecHitedmNewDetSetVector_mtdTrackingRecHits__RECO',
+           'drop BTLDetIdBTLSampleFTLDataFrameTsSorted_mix_FTLBarrel_HLT',
+           'drop ETLDetIdETLSampleFTLDataFrameTsSorted_mix_FTLEndcap_HLT',
+           )
+       )
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.20 $'),
+    annotation = cms.untracked.string('SingleElectronPt10_cfi nevts:10'),
+    name = cms.untracked.string('Applications')
+)
+
+# Output definition
+process.TFileService = cms.Service(
+    "TFileService",
+    fileName = cms.string("ntuple.root")
+    )
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T15', '')
+
+# load HGCAL TPG simulation
+process.load('L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff')
+
+# Use new Stage 1 processor
+from L1Trigger.L1THGCal.customNewProcessors import custom_stage1_truncation
+process = custom_stage1_truncation(process)
+
+# Switch to latest trigger geometry containing information on links mapping
+from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_decentralized_V11
+process = custom_geometry_decentralized_V11(process, links='signaldriven', implementation=2)
+
+process.hgcl1tpg_step = cms.Path(process.hgcalTriggerPrimitives)
+
+
+# load ntuplizer and custom to use collections from Stag1 truncation processor
+process.load('L1Trigger.L1THGCalUtilities.hgcalTriggerNtuples_cff')
+from L1Trigger.L1THGCalUtilities.customNtuples import custom_ntuples_stage1_truncation
+process = custom_ntuples_stage1_truncation(process)
+process.ntuple_step = cms.Path(process.hgcalTriggerNtuples)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.hgcl1tpg_step, process.ntuple_step)
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion
+

--- a/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_stage1Truncation_V11_cfg.py
+++ b/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_stage1Truncation_V11_cfg.py
@@ -75,8 +75,8 @@ from L1Trigger.L1THGCal.customNewProcessors import custom_stage1_truncation
 process = custom_stage1_truncation(process)
 
 # Switch to latest trigger geometry containing information on links mapping
-from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_decentralized_V11
-process = custom_geometry_decentralized_V11(process, links='signaldriven', implementation=2)
+from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_V11_Imp3
+process = custom_geometry_V11_Imp3(process)
 
 process.hgcl1tpg_step = cms.Path(process.hgcalTriggerPrimitives)
 


### PR DESCRIPTION
#### PR description:
- First round for the migration to an updated code structure. 
- This new code structure is developed in order to seamlessly run standalone emulator classes (bit-level emulation of the HGCAL TPG firmware, without any CMSSW dependencies) inside CMSSW.
- Details of this new code structure can be found in this presentation: https://indico.cern.ch/event/1061177/#29-emulator-technical-developm
- At the moment, both the old and new class structures are living together, with the old classes still being used as default
- As this is just the beginning of a large refactoring of our codebase, this will be continued with other PRs in the future

Associated internal PRs and reviews:
- PFCal-dev#465
- PFCal-dev#479
- PFCal-dev#476
- PFCal-dev#484
- PFCal-dev#486
- PFCal-dev#483
- PFCal-dev#492
- PFCal-dev#485
- PFCal-dev#503
- PFCal-dev#500
- PFCal-dev#508
- PFCal-dev#507


**This PR depends on external cms-data/L1Trigger-L1THGCal#23**

#### PR validation:
Private tests in `L1Trigger/L1THGCalUtilities/test`:
```
cmsRun testHGCalL1T_RelValV11_cfg.py
cmsRun testHGCalL1T_newProcessors_V11_cfg.py
cmsRun testHGCalL1T_stage1Truncation_V11_cfg.py
cmsRun testHGCalL1T_multialgo_V11_cfg.py
```
Tested D49, D60, D68, D77, D86 workflows
```
runTheMatrix.py -w upgrade -l 23234.0 --maxSteps=2 
runTheMatrix.py -w upgrade -l 28234.0 --maxSteps=2 
runTheMatrix.py -w upgrade -l 31434.0 --maxSteps=2
runTheMatrix.py -w upgrade -l 35034.0 --maxSteps=2
runTheMatrix.py -w upgrade -l 38634.0 --maxSteps=2
```

---
@EmyrClement @portalesHEP FYI