### PR TITLE
Apply Naming Rules to `BeamSpotOnlineObjects` methods

### DIFF
--- a/CondCore/BeamSpotPlugins/plugins/BeamSpotOnline_PayloadInspector.cc
+++ b/CondCore/BeamSpotPlugins/plugins/BeamSpotOnline_PayloadInspector.cc
@@ -75,19 +75,19 @@ namespace {
         int ret(-999);
         switch (my_param) {
           case lastLumi:
-            return this->m_payload->GetLastAnalyzedLumi();
+            return this->m_payload->lastAnalyzedLumi();
           case lastRun:
-            return this->m_payload->GetLastAnalyzedRun();
+            return this->m_payload->lastAnalyzedRun();
           case lastFill:
-            return this->m_payload->GetLastAnalyzedFill();
+            return this->m_payload->lastAnalyzedFill();
           case nTracks:
-            return this->m_payload->GetNumTracks();
+            return this->m_payload->numTracks();
           case nPVs:
-            return this->m_payload->GetNumPVs();
+            return this->m_payload->numPVs();
           case nUsedEvents:
-            return this->m_payload->GetUsedEvents();
+            return this->m_payload->usedEvents();
           case maxPVs:
-            return this->m_payload->GetMaxPVs();
+            return this->m_payload->maxPVs();
           default:
             return ret;
         }
@@ -98,13 +98,13 @@ namespace {
         float ret(-999.);
         switch (my_param) {
           case meanPV:
-            return this->m_payload->GetMeanPV();
+            return this->m_payload->meanPV();
           case meanErrorPV:
-            return this->m_payload->GetMeanErrorPV();
+            return this->m_payload->meanErrorPV();
           case rmsPV:
-            return this->m_payload->GetRmsPV();
+            return this->m_payload->rmsPV();
           case rmsErrorPV:
-            return this->m_payload->GetRmsErrorPV();
+            return this->m_payload->rmsErrorPV();
           default:
             return ret;
         }
@@ -115,11 +115,11 @@ namespace {
         std::string ret("");
         switch (my_param) {
           case startTime:
-            return this->m_payload->GetStartTime();
+            return this->m_payload->startTime();
           case endTime:
-            return this->m_payload->GetEndTime();
+            return this->m_payload->endTime();
           case lumiRange:
-            return this->m_payload->GetLumiRange();
+            return this->m_payload->lumiRange();
           default:
             return ret;
         }
@@ -130,11 +130,11 @@ namespace {
         cond::Time_t ret(1);
         switch (my_param) {
           case creationTime:
-            return this->m_payload->GetCreationTime();
+            return this->m_payload->creationTime();
           case startTimeStamp:
-            return this->m_payload->GetStartTimeStamp();
+            return this->m_payload->startTimeStamp();
           case endTimeStamp:
-            return this->m_payload->GetEndTimeStamp();
+            return this->m_payload->endTimeStamp();
           default:
             return ret;
         }

--- a/CondFormats/BeamSpotObjects/interface/BeamSpotOnlineObjects.h
+++ b/CondFormats/BeamSpotObjects/interface/BeamSpotOnlineObjects.h
@@ -45,107 +45,107 @@ public:
 
   /// Setters Methods
   // set lastAnalyzedLumi_, last analyzed lumisection
-  void SetLastAnalyzedLumi(int val) { lastAnalyzedLumi_ = val; }
+  void setLastAnalyzedLumi(int val) { lastAnalyzedLumi_ = val; }
 
   // set lastAnalyzedRun_, run of the last analyzed lumisection
-  void SetLastAnalyzedRun(int val) { lastAnalyzedRun_ = val; }
+  void setLastAnalyzedRun(int val) { lastAnalyzedRun_ = val; }
 
   // set lastAnalyzedFill_, fill of the last analyzed lumisection
-  void SetLastAnalyzedFill(int val) { lastAnalyzedFill_ = val; }
+  void setLastAnalyzedFill(int val) { lastAnalyzedFill_ = val; }
 
   // set number of tracks used in the BeamSpot fit
-  void SetNumTracks(int val);
+  void setNumTracks(int val);
 
   // set number of Primary Vertices used in the BeamSpot fit
-  void SetNumPVs(int val);
+  void setNumPVs(int val);
 
   // set number of Events used in the BeamSpot fit (for DIP)
-  void SetUsedEvents(int val);
+  void setUsedEvents(int val);
 
   // set max number of Primary Vertices used in the BeamSpot fit (for DIP)
-  void SetMaxPVs(int val);
+  void setMaxPVs(int val);
 
   // set mean number of PVs (for DIP)
-  void SetMeanPV(float val);
+  void setMeanPV(float val);
 
   // set error on mean number of PVs (for DIP)
-  void SetMeanErrorPV(float val);
+  void setMeanErrorPV(float val);
 
   // set rms of number of PVs (for DIP)
-  void SetRmsPV(float val);
+  void setRmsPV(float val);
 
   // set error on rm of number of PVs (for DIP)
-  void SetRmsErrorPV(float val);
+  void setRmsErrorPV(float val);
 
   // set start time of the firs LS as string (for DIP)
-  void SetStartTime(std::string val);
+  void setStartTime(std::string val);
 
   // set end time of the last LS as string (for DIP)
-  void SetEndTime(std::string val);
+  void setEndTime(std::string val);
 
   // set lumi range as string (for DIP)
-  void SetLumiRange(std::string val);
+  void setLumiRange(std::string val);
 
   // set creation time of the payload
-  void SetCreationTime(cond::Time_t val);
+  void setCreationTime(cond::Time_t val);
 
   // set timestamp of the first LS (for DIP)
-  void SetStartTimeStamp(cond::Time_t val);
+  void setStartTimeStamp(cond::Time_t val);
 
   // set timestamp of the last LS (for DIP)
-  void SetEndTimeStamp(cond::Time_t val);
+  void setEndTimeStamp(cond::Time_t val);
 
   /// Getters Methods
   // get lastAnalyzedLumi_, last analyzed lumisection
-  int GetLastAnalyzedLumi() const { return lastAnalyzedLumi_; }
+  int lastAnalyzedLumi() const { return lastAnalyzedLumi_; }
 
   // get lastAnalyzedRun_, run of the last analyzed lumisection
-  int GetLastAnalyzedRun() const { return lastAnalyzedRun_; }
+  int lastAnalyzedRun() const { return lastAnalyzedRun_; }
 
   // get lastAnalyzedFill_, fill of the last analyzed lumisection
-  int GetLastAnalyzedFill() const { return lastAnalyzedFill_; }
+  int lastAnalyzedFill() const { return lastAnalyzedFill_; }
 
   // get number of tracks used in the BeamSpot fit
-  int GetNumTracks() const;
+  int numTracks() const;
 
   // get number of Primary Vertices used in the BeamSpot fit
-  int GetNumPVs() const;
+  int numPVs() const;
 
   // get number of Events used in the BeamSpot fit (for DIP)
-  int GetUsedEvents() const;
+  int usedEvents() const;
 
   // get max number of Primary Vertices used in the BeamSpot fit (for DIP)
-  int GetMaxPVs() const;
+  int maxPVs() const;
 
   // get mean number of PVs (for DIP)
-  float GetMeanPV() const;
+  float meanPV() const;
 
   // get error on mean number of PVs (for DIP)
-  float GetMeanErrorPV() const;
+  float meanErrorPV() const;
 
   // get rms of number of PVs (for DIP)
-  float GetRmsPV() const;
+  float rmsPV() const;
 
   // get error on rm of number of PVs (for DIP)
-  float GetRmsErrorPV() const;
+  float rmsErrorPV() const;
 
   // get start time of the firs LS as string (for DIP)
-  std::string GetStartTime() const;
+  std::string startTime() const;
 
   // get end time of the last LS as string (for DIP)
-  std::string GetEndTime() const;
+  std::string endTime() const;
 
   // get lumi range as string (for DIP)
-  std::string GetLumiRange() const;
+  std::string lumiRange() const;
 
   // get creation time of the payload
-  cond::Time_t GetCreationTime() const;
+  cond::Time_t creationTime() const;
 
   // get timestamp of the first LS (for DIP)
-  cond::Time_t GetStartTimeStamp() const;
+  cond::Time_t startTimeStamp() const;
 
   // get timestamp of the last LS (for DIP)
-  cond::Time_t GetEndTimeStamp() const;
+  cond::Time_t endTimeStamp() const;
 
   /// Print BeamSpotOnline parameters
   void print(std::stringstream& ss) const;

--- a/CondFormats/BeamSpotObjects/src/BeamSpotOnlineObjects.cc
+++ b/CondFormats/BeamSpotObjects/src/BeamSpotOnlineObjects.cc
@@ -45,106 +45,104 @@ namespace BeamSpotOnlineObjectsImpl {
 }  //namespace BeamSpotOnlineObjectsImpl
 
 // getters
-int BeamSpotOnlineObjects::GetNumTracks() const {
-  return BeamSpotOnlineObjectsImpl::getOneParam(intParams_, NUM_TRACKS);
-}
+int BeamSpotOnlineObjects::numTracks() const { return BeamSpotOnlineObjectsImpl::getOneParam(intParams_, NUM_TRACKS); }
 
-int BeamSpotOnlineObjects::GetNumPVs() const { return BeamSpotOnlineObjectsImpl::getOneParam(intParams_, NUM_PVS); }
+int BeamSpotOnlineObjects::numPVs() const { return BeamSpotOnlineObjectsImpl::getOneParam(intParams_, NUM_PVS); }
 
-int BeamSpotOnlineObjects::GetUsedEvents() const {
+int BeamSpotOnlineObjects::usedEvents() const {
   return BeamSpotOnlineObjectsImpl::getOneParam(intParams_, USED_EVENTS);
 }
 
-int BeamSpotOnlineObjects::GetMaxPVs() const { return BeamSpotOnlineObjectsImpl::getOneParam(intParams_, MAX_PVS); }
+int BeamSpotOnlineObjects::maxPVs() const { return BeamSpotOnlineObjectsImpl::getOneParam(intParams_, MAX_PVS); }
 
-float BeamSpotOnlineObjects::GetMeanPV() const { return BeamSpotOnlineObjectsImpl::getOneParam(floatParams_, MEAN_PV); }
+float BeamSpotOnlineObjects::meanPV() const { return BeamSpotOnlineObjectsImpl::getOneParam(floatParams_, MEAN_PV); }
 
-float BeamSpotOnlineObjects::GetMeanErrorPV() const {
+float BeamSpotOnlineObjects::meanErrorPV() const {
   return BeamSpotOnlineObjectsImpl::getOneParam(floatParams_, ERR_MEAN_PV);
 }
 
-float BeamSpotOnlineObjects::GetRmsPV() const { return BeamSpotOnlineObjectsImpl::getOneParam(floatParams_, RMS_PV); }
+float BeamSpotOnlineObjects::rmsPV() const { return BeamSpotOnlineObjectsImpl::getOneParam(floatParams_, RMS_PV); }
 
-float BeamSpotOnlineObjects::GetRmsErrorPV() const {
+float BeamSpotOnlineObjects::rmsErrorPV() const {
   return BeamSpotOnlineObjectsImpl::getOneParam(floatParams_, ERR_RMS_PV);
 }
 
-std::string BeamSpotOnlineObjects::GetStartTime() const {
+std::string BeamSpotOnlineObjects::startTime() const {
   return BeamSpotOnlineObjectsImpl::getOneParam(stringParams_, START_TIME);
 }
 
-std::string BeamSpotOnlineObjects::GetEndTime() const {
+std::string BeamSpotOnlineObjects::endTime() const {
   return BeamSpotOnlineObjectsImpl::getOneParam(stringParams_, END_TIME);
 }
 
-std::string BeamSpotOnlineObjects::GetLumiRange() const {
+std::string BeamSpotOnlineObjects::lumiRange() const {
   return BeamSpotOnlineObjectsImpl::getOneParam(stringParams_, LUMI_RANGE);
 }
 
-cond::Time_t BeamSpotOnlineObjects::GetCreationTime() const {
+cond::Time_t BeamSpotOnlineObjects::creationTime() const {
   return BeamSpotOnlineObjectsImpl::getOneParam(timeParams_, CREATE_TIME);
 }
 
-cond::Time_t BeamSpotOnlineObjects::GetStartTimeStamp() const {
+cond::Time_t BeamSpotOnlineObjects::startTimeStamp() const {
   return BeamSpotOnlineObjectsImpl::getOneParam(timeParams_, START_TIMESTAMP);
 }
 
-cond::Time_t BeamSpotOnlineObjects::GetEndTimeStamp() const {
+cond::Time_t BeamSpotOnlineObjects::endTimeStamp() const {
   return BeamSpotOnlineObjectsImpl::getOneParam(timeParams_, END_TIMESTAMP);
 }
 
 // setters
-void BeamSpotOnlineObjects::SetNumTracks(int nTracks) {
+void BeamSpotOnlineObjects::setNumTracks(int nTracks) {
   BeamSpotOnlineObjectsImpl::setOneParam(intParams_, NUM_TRACKS, nTracks);
 }
 
-void BeamSpotOnlineObjects::SetNumPVs(int nPVs) { BeamSpotOnlineObjectsImpl::setOneParam(intParams_, NUM_PVS, nPVs); }
+void BeamSpotOnlineObjects::setNumPVs(int nPVs) { BeamSpotOnlineObjectsImpl::setOneParam(intParams_, NUM_PVS, nPVs); }
 
-void BeamSpotOnlineObjects::SetUsedEvents(int usedEvents) {
+void BeamSpotOnlineObjects::setUsedEvents(int usedEvents) {
   BeamSpotOnlineObjectsImpl::setOneParam(intParams_, USED_EVENTS, usedEvents);
 }
 
-void BeamSpotOnlineObjects::SetMaxPVs(int maxPVs) {
+void BeamSpotOnlineObjects::setMaxPVs(int maxPVs) {
   BeamSpotOnlineObjectsImpl::setOneParam(intParams_, MAX_PVS, maxPVs);
 }
 
-void BeamSpotOnlineObjects::SetMeanPV(float meanPVs) {
+void BeamSpotOnlineObjects::setMeanPV(float meanPVs) {
   BeamSpotOnlineObjectsImpl::setOneParam(floatParams_, MEAN_PV, meanPVs);
 }
 
-void BeamSpotOnlineObjects::SetMeanErrorPV(float errMeanPVs) {
+void BeamSpotOnlineObjects::setMeanErrorPV(float errMeanPVs) {
   BeamSpotOnlineObjectsImpl::setOneParam(floatParams_, ERR_MEAN_PV, errMeanPVs);
 }
 
-void BeamSpotOnlineObjects::SetRmsPV(float rmsPVs) {
+void BeamSpotOnlineObjects::setRmsPV(float rmsPVs) {
   BeamSpotOnlineObjectsImpl::setOneParam(floatParams_, RMS_PV, rmsPVs);
 }
 
-void BeamSpotOnlineObjects::SetRmsErrorPV(float errRmsPVs) {
+void BeamSpotOnlineObjects::setRmsErrorPV(float errRmsPVs) {
   BeamSpotOnlineObjectsImpl::setOneParam(floatParams_, ERR_RMS_PV, errRmsPVs);
 }
 
-void BeamSpotOnlineObjects::SetStartTime(std::string startTime) {
+void BeamSpotOnlineObjects::setStartTime(std::string startTime) {
   BeamSpotOnlineObjectsImpl::setOneParam(stringParams_, START_TIME, startTime);
 }
 
-void BeamSpotOnlineObjects::SetEndTime(std::string endTime) {
+void BeamSpotOnlineObjects::setEndTime(std::string endTime) {
   BeamSpotOnlineObjectsImpl::setOneParam(stringParams_, END_TIME, endTime);
 }
 
-void BeamSpotOnlineObjects::SetLumiRange(std::string lumiRange) {
+void BeamSpotOnlineObjects::setLumiRange(std::string lumiRange) {
   BeamSpotOnlineObjectsImpl::setOneParam(stringParams_, LUMI_RANGE, lumiRange);
 }
 
-void BeamSpotOnlineObjects::SetCreationTime(cond::Time_t createTime) {
+void BeamSpotOnlineObjects::setCreationTime(cond::Time_t createTime) {
   BeamSpotOnlineObjectsImpl::setOneParam(timeParams_, CREATE_TIME, createTime);
 }
 
-void BeamSpotOnlineObjects::SetStartTimeStamp(cond::Time_t starTimeStamp) {
+void BeamSpotOnlineObjects::setStartTimeStamp(cond::Time_t starTimeStamp) {
   BeamSpotOnlineObjectsImpl::setOneParam(timeParams_, START_TIMESTAMP, starTimeStamp);
 }
 
-void BeamSpotOnlineObjects::SetEndTimeStamp(cond::Time_t endTimeStamp) {
+void BeamSpotOnlineObjects::setEndTimeStamp(cond::Time_t endTimeStamp) {
   BeamSpotOnlineObjectsImpl::setOneParam(timeParams_, END_TIMESTAMP, endTimeStamp);
 }
 
@@ -164,9 +162,9 @@ void BeamSpotOnlineObjects::print(std::stringstream& ss) const {
      << " Emittance X  = " << GetEmittanceX() << " [cm]\n"
      << " Emittance Y  = " << GetEmittanceY() << " [cm]\n"
      << " Beta star    = " << GetBetaStar() << " [cm]\n"
-     << " Last Lumi    = " << GetLastAnalyzedLumi() << "\n"
-     << " Last Run     = " << GetLastAnalyzedRun() << "\n"
-     << " Last Fill    = " << GetLastAnalyzedFill() << "\n"
+     << " Last Lumi    = " << lastAnalyzedLumi() << "\n"
+     << " Last Run     = " << lastAnalyzedRun() << "\n"
+     << " Last Fill    = " << lastAnalyzedFill() << "\n"
      << "-----------------------------------------------------\n\n";
 }
 

--- a/CondTools/BeamSpot/plugins/BeamSpotOnlineRecordsReader.cc
+++ b/CondTools/BeamSpot/plugins/BeamSpotOnlineRecordsReader.cc
@@ -167,9 +167,9 @@ void BeamSpotOnlineRecordsReader::dump(const edm::Event& iEvent,
   theBSOfromDB_.Beamdxdz_ = mybeamspot->Getdxdz();
   theBSOfromDB_.BeamWidthX_ = mybeamspot->GetBeamWidthX();
   theBSOfromDB_.BeamWidthY_ = mybeamspot->GetBeamWidthY();
-  theBSOfromDB_.lastAnalyzedLumi_ = mybeamspot->GetLastAnalyzedLumi();
-  theBSOfromDB_.lastAnalyzedRun_ = mybeamspot->GetLastAnalyzedRun();
-  theBSOfromDB_.lastAnalyzedFill_ = mybeamspot->GetLastAnalyzedFill();
+  theBSOfromDB_.lastAnalyzedLumi_ = mybeamspot->lastAnalyzedLumi();
+  theBSOfromDB_.lastAnalyzedRun_ = mybeamspot->lastAnalyzedRun();
+  theBSOfromDB_.lastAnalyzedFill_ = mybeamspot->lastAnalyzedFill();
 
   bstree_->Fill();
 

--- a/CondTools/BeamSpot/plugins/BeamSpotOnlineRecordsWriter.cc
+++ b/CondTools/BeamSpot/plugins/BeamSpotOnlineRecordsWriter.cc
@@ -187,34 +187,34 @@ void BeamSpotOnlineRecordsWriter::endJob() {
   edm::LogPrint("BeamSpotOnlineRecordsWriter") << " betastar          : " << betastar;
   edm::LogPrint("BeamSpotOnlineRecordsWriter") << "-----------------------------------------------------";
 
-  std::unique_ptr<BeamSpotOnlineObjects> abeam = std::make_unique<BeamSpotOnlineObjects>();
+  BeamSpotOnlineObjects abeam;
 
-  abeam->SetLastAnalyzedLumi(lastAnalyzedLumi);
-  abeam->SetLastAnalyzedRun(lastAnalyzedRun);
-  abeam->SetLastAnalyzedFill(lastAnalyzedFill);
-  abeam->SetStartTimeStamp(lumiRangeBeginTime);
-  abeam->SetEndTimeStamp(lumiRangeEndTime);
-  abeam->SetType(type);
-  abeam->SetPosition(x, y, z);
-  abeam->SetSigmaZ(sigmaZ);
-  abeam->Setdxdz(dxdz);
-  abeam->Setdydz(dydz);
-  abeam->SetBeamWidthX(beamWidthX);
-  abeam->SetBeamWidthY(beamWidthY);
-  abeam->SetEmittanceX(emittanceX);
-  abeam->SetEmittanceY(emittanceY);
-  abeam->SetBetaStar(betastar);
+  abeam.setLastAnalyzedLumi(lastAnalyzedLumi);
+  abeam.setLastAnalyzedRun(lastAnalyzedRun);
+  abeam.setLastAnalyzedFill(lastAnalyzedFill);
+  abeam.setStartTimeStamp(lumiRangeBeginTime);
+  abeam.setEndTimeStamp(lumiRangeEndTime);
+  abeam.SetType(type);
+  abeam.SetPosition(x, y, z);
+  abeam.SetSigmaZ(sigmaZ);
+  abeam.Setdxdz(dxdz);
+  abeam.Setdydz(dydz);
+  abeam.SetBeamWidthX(beamWidthX);
+  abeam.SetBeamWidthY(beamWidthY);
+  abeam.SetEmittanceX(emittanceX);
+  abeam.SetEmittanceY(emittanceY);
+  abeam.SetBetaStar(betastar);
 
   for (int i = 0; i < 7; ++i) {
     for (int j = 0; j < 7; ++j) {
-      abeam->SetCovariance(i, j, cov[i][j]);
+      abeam.SetCovariance(i, j, cov[i][j]);
     }
   }
 
   // Set the creation time of the payload to the current time
   auto creationTime =
       std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-  abeam->SetCreationTime(creationTime);
+  abeam.setCreationTime(creationTime);
 
   edm::LogPrint("BeamSpotOnlineRecordsWriter") << " Writing results to DB...";
 
@@ -225,16 +225,16 @@ void BeamSpotOnlineRecordsWriter::endJob() {
       edm::LogPrint("BeamSpotOnlineRecordsWriter") << "new tag requested";
       if (fuseNewSince) {
         edm::LogPrint("BeamSpotOnlineRecordsWriter") << "Using a new Since: " << fnewSince;
-        poolDbService->createOneIOV<BeamSpotOnlineObjects>(*abeam, fnewSince, fLabel);
+        poolDbService->createOneIOV<BeamSpotOnlineObjects>(abeam, fnewSince, fLabel);
       } else
-        poolDbService->createOneIOV<BeamSpotOnlineObjects>(*abeam, poolDbService->beginOfTime(), fLabel);
+        poolDbService->createOneIOV<BeamSpotOnlineObjects>(abeam, poolDbService->beginOfTime(), fLabel);
     } else {
       edm::LogPrint("BeamSpotOnlineRecordsWriter") << "no new tag requested";
       if (fuseNewSince) {
         edm::LogPrint("BeamSpotOnlineRecordsWriter") << "Using a new Since: " << fnewSince;
-        poolDbService->appendOneIOV<BeamSpotOnlineObjects>(*abeam, fnewSince, fLabel);
+        poolDbService->appendOneIOV<BeamSpotOnlineObjects>(abeam, fnewSince, fLabel);
       } else
-        poolDbService->appendOneIOV<BeamSpotOnlineObjects>(*abeam, poolDbService->currentTime(), fLabel);
+        poolDbService->appendOneIOV<BeamSpotOnlineObjects>(abeam, poolDbService->currentTime(), fLabel);
     }
   }
   edm::LogPrint("BeamSpotOnlineRecordsWriter") << "[BeamSpotOnlineRecordsWriter] endJob done \n";

--- a/CondTools/BeamSpot/src/BeamSpotOnlinePopConSourceHandler.cc
+++ b/CondTools/BeamSpot/src/BeamSpotOnlinePopConSourceHandler.cc
@@ -16,7 +16,7 @@ BeamSpotOnlinePopConSourceHandler::BeamSpotOnlinePopConSourceHandler(edm::Parame
 BeamSpotOnlinePopConSourceHandler::~BeamSpotOnlinePopConSourceHandler() {}
 
 bool checkPayloadAge(const BeamSpotOnlineObjects& payload, unsigned int maxAge) {
-  long creationTimeInSeconds = payload.GetCreationTime() >> 32;
+  long creationTimeInSeconds = payload.creationTime() >> 32;
   auto timeNow = std::chrono::system_clock::now();
   auto nowSinceEpoch = std::chrono::duration_cast<std::chrono::seconds>(timeNow.time_since_epoch()).count();
   long age = nowSinceEpoch - creationTimeInSeconds;
@@ -29,7 +29,7 @@ std::unique_ptr<BeamSpotOnlineObjects> makeDummyPayload() {
   ret = std::make_unique<BeamSpotOnlineObjects>();
   auto timeNow = std::chrono::system_clock::now();
   auto nowSinceEpoch = std::chrono::duration_cast<std::chrono::seconds>(timeNow.time_since_epoch()).count();
-  ret->SetCreationTime(nowSinceEpoch << 32);
+  ret->setCreationTime(nowSinceEpoch << 32);
   return ret;
 }
 

--- a/DQM/BeamMonitor/plugins/BeamMonitor.cc
+++ b/DQM/BeamMonitor/plugins/BeamMonitor.cc
@@ -1358,9 +1358,9 @@ void BeamMonitor::FitAndFill(const LuminosityBlock& lumiSeg, int& lastlumi, int&
 
       // Create the BeamSpotOnlineObjects object
       BeamSpotOnlineObjects BSOnline;
-      BSOnline.SetLastAnalyzedLumi(LSRange.second);
-      BSOnline.SetLastAnalyzedRun(theBeamFitter->getRunNumber());
-      BSOnline.SetLastAnalyzedFill(0);  // To be updated with correct LHC Fill number
+      BSOnline.setLastAnalyzedLumi(LSRange.second);
+      BSOnline.setLastAnalyzedRun(theBeamFitter->getRunNumber());
+      BSOnline.setLastAnalyzedFill(0);  // To be updated with correct LHC Fill number
       BSOnline.SetPosition(bs.x0(), bs.y0(), bs.z0());
       BSOnline.SetSigmaZ(bs.sigmaZ());
       BSOnline.SetBeamWidthX(bs.BeamWidthX());
@@ -1378,24 +1378,24 @@ void BeamMonitor::FitAndFill(const LuminosityBlock& lumiSeg, int& lastlumi, int&
           BSOnline.SetCovariance(i, j, bs.covariance(i, j));
         }
       }
-      BSOnline.SetNumTracks(theBeamFitter->getNTracks());
-      BSOnline.SetNumPVs(theBeamFitter->getNPVs());
-      BSOnline.SetUsedEvents((int)DipPVInfo_[0]);
-      BSOnline.SetMeanPV(DipPVInfo_[1]);
-      BSOnline.SetMeanErrorPV(DipPVInfo_[2]);
-      BSOnline.SetRmsPV(DipPVInfo_[3]);
-      BSOnline.SetRmsErrorPV(DipPVInfo_[4]);
-      BSOnline.SetMaxPVs((int)DipPVInfo_[5]);
+      BSOnline.setNumTracks(theBeamFitter->getNTracks());
+      BSOnline.setNumPVs(theBeamFitter->getNPVs());
+      BSOnline.setUsedEvents((int)DipPVInfo_[0]);
+      BSOnline.setMeanPV(DipPVInfo_[1]);
+      BSOnline.setMeanErrorPV(DipPVInfo_[2]);
+      BSOnline.setRmsPV(DipPVInfo_[3]);
+      BSOnline.setRmsErrorPV(DipPVInfo_[4]);
+      BSOnline.setMaxPVs((int)DipPVInfo_[5]);
       auto creationTime =
           std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch())
               .count();
-      BSOnline.SetCreationTime(creationTime);
+      BSOnline.setCreationTime(creationTime);
 
       std::pair<time_t, time_t> timeForDIP = theBeamFitter->getRefTime();
-      BSOnline.SetStartTimeStamp(timeForDIP.first);
-      BSOnline.SetStartTime(getGMTstring(timeForDIP.first));
-      BSOnline.SetEndTimeStamp(timeForDIP.second);
-      BSOnline.SetEndTime(getGMTstring(timeForDIP.second));
+      BSOnline.setStartTimeStamp(timeForDIP.first);
+      BSOnline.setStartTime(getGMTstring(timeForDIP.first));
+      BSOnline.setEndTimeStamp(timeForDIP.second);
+      BSOnline.setEndTime(getGMTstring(timeForDIP.second));
 
       edm::LogInfo("BeamMonitor") << "FitAndFill::[PayloadCreation] BeamSpotOnline object created: \n" << std::endl;
       edm::LogInfo("BeamMonitor") << BSOnline << std::endl;
@@ -1418,16 +1418,16 @@ void BeamMonitor::FitAndFill(const LuminosityBlock& lumiSeg, int& lastlumi, int&
             << "BeamMonitor::FitAndFill - [PayloadCreation] BeamSpotOnline object created:";
         onlineDbService_->logger().logInfo() << "\n" << BSOnline;
         onlineDbService_->logger().logInfo() << "BeamMonitor - Additional parameters for DIP:";
-        onlineDbService_->logger().logInfo() << "Events used in the fit: " << BSOnline.GetUsedEvents();
-        onlineDbService_->logger().logInfo() << "Mean PV               : " << BSOnline.GetMeanPV();
-        onlineDbService_->logger().logInfo() << "Mean PV Error         : " << BSOnline.GetMeanErrorPV();
-        onlineDbService_->logger().logInfo() << "Rms PV                : " << BSOnline.GetRmsPV();
-        onlineDbService_->logger().logInfo() << "Rms PV Error          : " << BSOnline.GetRmsErrorPV();
-        onlineDbService_->logger().logInfo() << "Max PVs               : " << BSOnline.GetMaxPVs();
-        onlineDbService_->logger().logInfo() << "StartTime             : " << BSOnline.GetStartTime();
-        onlineDbService_->logger().logInfo() << "StartTimeStamp        : " << BSOnline.GetStartTimeStamp();
-        onlineDbService_->logger().logInfo() << "EndTime               : " << BSOnline.GetEndTime();
-        onlineDbService_->logger().logInfo() << "EndTimeStamp          : " << BSOnline.GetEndTimeStamp();
+        onlineDbService_->logger().logInfo() << "Events used in the fit: " << BSOnline.usedEvents();
+        onlineDbService_->logger().logInfo() << "Mean PV               : " << BSOnline.meanPV();
+        onlineDbService_->logger().logInfo() << "Mean PV Error         : " << BSOnline.meanErrorPV();
+        onlineDbService_->logger().logInfo() << "Rms PV                : " << BSOnline.rmsPV();
+        onlineDbService_->logger().logInfo() << "Rms PV Error          : " << BSOnline.rmsErrorPV();
+        onlineDbService_->logger().logInfo() << "Max PVs               : " << BSOnline.maxPVs();
+        onlineDbService_->logger().logInfo() << "StartTime             : " << BSOnline.startTime();
+        onlineDbService_->logger().logInfo() << "StartTimeStamp        : " << BSOnline.startTimeStamp();
+        onlineDbService_->logger().logInfo() << "EndTime               : " << BSOnline.endTime();
+        onlineDbService_->logger().logInfo() << "EndTimeStamp          : " << BSOnline.endTimeStamp();
         onlineDbService_->logger().logInfo() << "BeamMonitor::FitAndFill - [PayloadCreation] onlineDbService available";
         onlineDbService_->logger().logInfo()
             << "BeamMonitor::FitAndFill - [PayloadCreation] SetCreationTime: " << creationTime

--- a/DQM/BeamMonitor/plugins/BeamSpotDipServer.cc
+++ b/DQM/BeamMonitor/plugins/BeamSpotDipServer.cc
@@ -366,33 +366,33 @@ void BeamSpotDipServer::problem() {
 bool BeamSpotDipServer::readRcd(const BeamSpotOnlineObjects& bs)
 // read from database
 {
-  runnum = bs.GetLastAnalyzedRun();
+  runnum = bs.lastAnalyzedRun();
 
   // get from BeamSpotOnlineObject
 
   try {
-    startTime = bs.GetStartTime();
-    startTimeStamp = bs.GetStartTimeStamp();
-    endTime = bs.GetEndTime();
-    endTimeStamp = bs.GetEndTimeStamp();
+    startTime = bs.startTime();
+    startTimeStamp = bs.startTimeStamp();
+    endTime = bs.endTime();
+    endTimeStamp = bs.endTimeStamp();
   } catch (exception& e) {
     edm::LogWarning("BeamSpotDipServer") << "time variables are not available (readRcd): " << e.what();
 
-    startTime = bs.GetCreationTime();
-    startTimeStamp = bs.GetCreationTime();
-    endTime = bs.GetCreationTime();
-    endTimeStamp = bs.GetCreationTime();
+    startTime = bs.creationTime();
+    startTimeStamp = bs.creationTime();
+    endTime = bs.creationTime();
+    endTimeStamp = bs.creationTime();
   }
 
   try {
-    lumiRange = bs.GetLumiRange();
+    lumiRange = bs.lumiRange();
   } catch (exception& e) {
     edm::LogWarning("BeamSpotDipServer") << "lumirange variable not avaialble (readRcd): " << e.what();
 
-    lumiRange = to_string(bs.GetLastAnalyzedLumi());
+    lumiRange = to_string(bs.lastAnalyzedLumi());
   }
 
-  currentLS = bs.GetLastAnalyzedLumi();
+  currentLS = bs.lastAnalyzedLumi();
 
   type = bs.GetBeamType();
 
@@ -427,12 +427,12 @@ bool BeamSpotDipServer::readRcd(const BeamSpotOnlineObjects& bs)
   err_width_y = bs.GetBeamWidthYError();
 
   try {
-    events = bs.GetUsedEvents();
-    meanPV = bs.GetMeanPV();
-    err_meanPV = bs.GetMeanErrorPV();
-    rmsPV = bs.GetRmsPV();
-    err_rmsPV = bs.GetRmsErrorPV();
-    maxPV = bs.GetMaxPVs();
+    events = bs.usedEvents();
+    meanPV = bs.meanPV();
+    err_meanPV = bs.meanErrorPV();
+    rmsPV = bs.rmsPV();
+    err_rmsPV = bs.rmsErrorPV();
+    maxPV = bs.maxPVs();
   } catch (exception& e) {
     edm::LogWarning("BeamSpotDipServer") << "PV variables are not available (readRcd): " << e.what();
 
@@ -444,7 +444,7 @@ bool BeamSpotDipServer::readRcd(const BeamSpotOnlineObjects& bs)
     maxPV = 0.;
   }
 
-  nPV = bs.GetNumPVs();
+  nPV = bs.numPVs();
 
   if (verbose)
     edm::LogInfo("BeamSpotDipServer") << "pos: (" << x << "," << y << "," << z << ")"

--- a/DQM/BeamMonitor/plugins/FakeBeamMonitor.cc
+++ b/DQM/BeamMonitor/plugins/FakeBeamMonitor.cc
@@ -1385,9 +1385,9 @@ void FakeBeamMonitor::FitAndFill(const LuminosityBlock& lumiSeg, int& lastlumi, 
 
   // Create the BeamSpotOnlineObjects object
   BeamSpotOnlineObjects BSOnline;
-  BSOnline.SetLastAnalyzedLumi(LSRange.second);
-  BSOnline.SetLastAnalyzedRun(frun);
-  BSOnline.SetLastAnalyzedFill(0);  // To be updated with correct LHC Fill number
+  BSOnline.setLastAnalyzedLumi(LSRange.second);
+  BSOnline.setLastAnalyzedRun(frun);
+  BSOnline.setLastAnalyzedFill(0);  // To be updated with correct LHC Fill number
   BSOnline.SetPosition(bs.x0(), bs.y0(), bs.z0());
   BSOnline.SetSigmaZ(bs.sigmaZ());
   BSOnline.SetBeamWidthX(bs.BeamWidthX());
@@ -1405,24 +1405,24 @@ void FakeBeamMonitor::FitAndFill(const LuminosityBlock& lumiSeg, int& lastlumi, 
       BSOnline.SetCovariance(i, j, bs.covariance(i, j));
     }
   }
-  BSOnline.SetNumTracks(50);
-  BSOnline.SetNumPVs(10);
-  BSOnline.SetUsedEvents((int)DipPVInfo_[0]);
-  BSOnline.SetMeanPV(DipPVInfo_[1]);
-  BSOnline.SetMeanErrorPV(DipPVInfo_[2]);
-  BSOnline.SetRmsPV(DipPVInfo_[3]);
-  BSOnline.SetRmsErrorPV(DipPVInfo_[4]);
-  BSOnline.SetMaxPVs((int)DipPVInfo_[5]);
+  BSOnline.setNumTracks(50);
+  BSOnline.setNumPVs(10);
+  BSOnline.setUsedEvents((int)DipPVInfo_[0]);
+  BSOnline.setMeanPV(DipPVInfo_[1]);
+  BSOnline.setMeanErrorPV(DipPVInfo_[2]);
+  BSOnline.setRmsPV(DipPVInfo_[3]);
+  BSOnline.setRmsErrorPV(DipPVInfo_[4]);
+  BSOnline.setMaxPVs((int)DipPVInfo_[5]);
   auto creationTime =
       std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-  BSOnline.SetCreationTime(creationTime);
+  BSOnline.setCreationTime(creationTime);
 
   // use fake timestamps from 1970.01.01 00:00:00 to 1970.01.01 00:00:01 GMT
   std::pair<time_t, time_t> timeForDIP = std::make_pair(0, 1);
-  BSOnline.SetStartTimeStamp(timeForDIP.first);
-  BSOnline.SetStartTime(getGMTstring(timeForDIP.first));
-  BSOnline.SetEndTimeStamp(timeForDIP.second);
-  BSOnline.SetEndTime(getGMTstring(timeForDIP.second));
+  BSOnline.setStartTimeStamp(timeForDIP.first);
+  BSOnline.setStartTime(getGMTstring(timeForDIP.first));
+  BSOnline.setEndTimeStamp(timeForDIP.second);
+  BSOnline.setEndTime(getGMTstring(timeForDIP.second));
 
   edm::LogInfo("FakeBeamMonitor") << "FitAndFill::[PayloadCreation] BeamSpotOnline object created: \n" << std::endl;
   edm::LogInfo("FakeBeamMonitor") << BSOnline << std::endl;
@@ -1443,16 +1443,16 @@ void FakeBeamMonitor::FitAndFill(const LuminosityBlock& lumiSeg, int& lastlumi, 
         << "FakeBeamMonitor::FitAndFill - [PayloadCreation] BeamSpotOnline object created:";
     onlineDbService_->logger().logInfo() << "\n" << BSOnline;
     onlineDbService_->logger().logInfo() << "FakeBeamMonitor - Additional parameters for DIP:";
-    onlineDbService_->logger().logInfo() << "Events used in the fit: " << BSOnline.GetUsedEvents();
-    onlineDbService_->logger().logInfo() << "Mean PV               : " << BSOnline.GetMeanPV();
-    onlineDbService_->logger().logInfo() << "Mean PV Error         : " << BSOnline.GetMeanErrorPV();
-    onlineDbService_->logger().logInfo() << "Rms PV                : " << BSOnline.GetRmsPV();
-    onlineDbService_->logger().logInfo() << "Rms PV Error          : " << BSOnline.GetRmsErrorPV();
-    onlineDbService_->logger().logInfo() << "Max PVs               : " << BSOnline.GetMaxPVs();
-    onlineDbService_->logger().logInfo() << "StartTime             : " << BSOnline.GetStartTime();
-    onlineDbService_->logger().logInfo() << "StartTimeStamp        : " << BSOnline.GetStartTimeStamp();
-    onlineDbService_->logger().logInfo() << "EndTime               : " << BSOnline.GetEndTime();
-    onlineDbService_->logger().logInfo() << "EndTimeStamp          : " << BSOnline.GetEndTimeStamp();
+    onlineDbService_->logger().logInfo() << "Events used in the fit: " << BSOnline.usedEvents();
+    onlineDbService_->logger().logInfo() << "Mean PV               : " << BSOnline.meanPV();
+    onlineDbService_->logger().logInfo() << "Mean PV Error         : " << BSOnline.meanErrorPV();
+    onlineDbService_->logger().logInfo() << "Rms PV                : " << BSOnline.rmsPV();
+    onlineDbService_->logger().logInfo() << "Rms PV Error          : " << BSOnline.rmsErrorPV();
+    onlineDbService_->logger().logInfo() << "Max PVs               : " << BSOnline.maxPVs();
+    onlineDbService_->logger().logInfo() << "StartTime             : " << BSOnline.startTime();
+    onlineDbService_->logger().logInfo() << "StartTimeStamp        : " << BSOnline.startTimeStamp();
+    onlineDbService_->logger().logInfo() << "EndTime               : " << BSOnline.endTime();
+    onlineDbService_->logger().logInfo() << "EndTimeStamp          : " << BSOnline.endTimeStamp();
     onlineDbService_->logger().logInfo() << "FakeBeamMonitor::FitAndFill - [PayloadCreation] onlineDbService available";
     onlineDbService_->logger().logInfo() << "FakeBeamMonitor::FitAndFill - [PayloadCreation] SetCreationTime: "
                                          << creationTime << " [epoch in microseconds]";

--- a/RecoVertex/BeamSpotProducer/plugins/OnlineBeamSpotESProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/OnlineBeamSpotESProducer.cc
@@ -70,9 +70,9 @@ const BeamSpotOnlineObjects* OnlineBeamSpotESProducer::compareBS(const BeamSpotO
       std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch());
 
   // Get two beamspot creation times and compute the time difference wrt currentTime
-  auto bs1time = std::chrono::microseconds(bs1->GetCreationTime());
+  auto bs1time = std::chrono::microseconds(bs1->creationTime());
   auto diffBStime1 = (currentTime - bs1time).count();
-  auto bs2time = std::chrono::microseconds(bs2->GetCreationTime());
+  auto bs2time = std::chrono::microseconds(bs2->creationTime());
   auto diffBStime2 = (currentTime - bs2time).count();
 
   // Convert timeThreshold_ from hours to microseconds for comparison
@@ -122,7 +122,7 @@ const BeamSpotOnlineObjects* OnlineBeamSpotESProducer::checkSingleBS(const BeamS
       std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch());
 
   // Get the beamspot creation time and compute the time difference wrt currentTime
-  auto bs1time = std::chrono::microseconds(bs1->GetCreationTime());
+  auto bs1time = std::chrono::microseconds(bs1->creationTime());
   auto diffBStime1 = (currentTime - bs1time).count();
 
   // Convert timeThreshold_ from hours to microseconds for comparison


### PR DESCRIPTION
#### PR description:
Following the discussion in https://github.com/cms-sw/cmssw/pull/35338#discussion_r712353920 I made this rather technical PR that to update the methods of `BeamSpotOnlineObjects` to follow [CMSSW Naming Rules](https://cms-sw.github.io/cms_coding_rules.html#2--naming-rules-1) (specifically 2.8/2.9/2.10/2.11) so that:
 - setters methods start with `set*`
 - getters methods don't contain anymore the word `get`

I used `git cms-checkdeps -a` to modify all the packages depending on the `BeamSpotOnlineObjects` class.

A second PR will follow this in order to update also the methods of `BeamSpotObjects`.

I also profited of this PR to migrate `CondTools/BeamSpot/plugins/BeamSpotOnlineRecordsWriter.cc` to use an object created on the stack as suggested in [this slide](https://indico.cern.ch/event/1088598/contributions/4580152/attachments/2333275/3976721/DBOutputService%20changes.pdf#page=5&zoom=page-fit,-233,595) and part of cms-AlCaDB/AlCaTools#28.

#### PR validation:
Code compiles.

#### Backport:
Not a backport, no backport needed.

FYI: @dzuolo @lguzzi @gennai 