### PR TITLE
More Nano step-related fixes for Run3/Phase2 workflows

### DIFF
--- a/Configuration/Eras/python/Era_Run3_cff.py
+++ b/Configuration/Eras/python/Era_Run3_cff.py
@@ -10,6 +10,7 @@ from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger
 from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
 from Configuration.Eras.Modifier_ctpps_2021_cff import ctpps_2021
 from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
+from Configuration.Eras.Modifier_run3_nanoAOD_devel_cff import run3_nanoAOD_devel
 
-Run3 = cms.ModifierChain(Run2_2018.copyAndExclude([run2_GEM_2017, ctpps_2018]), run3_common, run3_GEM, run3_HB, run3_HFSL, stage2L1Trigger_2021, ctpps_2021, dd4hep)
+Run3 = cms.ModifierChain(Run2_2018.copyAndExclude([run2_GEM_2017, ctpps_2018]), run3_common, run3_GEM, run3_HB, run3_HFSL, stage2L1Trigger_2021, ctpps_2021, dd4hep, run3_nanoAOD_devel)
 

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -200,19 +200,27 @@ upgradeWFs['baseline'] = UpgradeWorkflow_baseline(
 
 # some commonalities among tracking WFs
 class UpgradeWorkflowTracking(UpgradeWorkflow):
+    # skip the PU argument since PU workflows never used here
+    def __init__(self, steps, suffix, offset):
+        # always include some steps that will be skipped
+        steps = steps + ["ALCA","Nano"]
+        super().__init__(steps, [], suffix, offset)
     def condition(self, fragment, stepList, key, hasHarvest):
         result = (fragment=="TTbar_13" or fragment=="TTbar_14TeV") and not 'PU' in key and hasHarvest and self.condition_(fragment, stepList, key, hasHarvest)
-        if result:
-            # skip ALCA and Nano
-            skipList = [s for s in stepList if (("ALCA" in s) or ("Nano" in s))]
-            for skip in skipList:
-                stepList.remove(skip)
         return result
     def condition_(self, fragment, stepList, key, hasHarvest):
         return True
+    def setup_(self, step, stepName, stepDict, k, properties):
+        # skip ALCA and Nano steps (but not RecoNano or HARVESTNano for Run3)
+        if 'ALCA' in step or 'Nano'==step:
+            stepDict[stepName][k] = None
+        self.setup__(step, stepName, stepDict, k, properties)
+    # subordinate function for inherited classes
+    def setup__(self, step, stepName, stepDict, k, properties):
+        pass
 
 class UpgradeWorkflow_trackingOnly(UpgradeWorkflowTracking):
-    def setup_(self, step, stepName, stepDict, k, properties):
+    def setup__(self, step, stepName, stepDict, k, properties):
         if 'Reco' in step: stepDict[stepName][k] = merge([self.step3, stepDict[step][k]])
         elif 'HARVEST' in step: stepDict[stepName][k] = merge([{'-s': 'HARVESTING:@trackingOnlyValidation+@trackingOnlyDQM'}, stepDict[step][k]])
 upgradeWFs['trackingOnly'] = UpgradeWorkflow_trackingOnly(
@@ -224,7 +232,6 @@ upgradeWFs['trackingOnly'] = UpgradeWorkflow_trackingOnly(
         'RecoNano',
         'HARVESTNano',
     ],
-    PU = [],
     suffix = '_trackingOnly',
     offset = 0.1,
 )
@@ -237,7 +244,7 @@ upgradeWFs['trackingOnly'].step3 = {
 step3_trackingOnly = upgradeWFs['trackingOnly'].step3
 
 class UpgradeWorkflow_trackingRun2(UpgradeWorkflowTracking):
-    def setup_(self, step, stepName, stepDict, k, properties):
+    def setup__(self, step, stepName, stepDict, k, properties):
         if 'Reco' in step and stepDict[step][k]['--era']=='Run2_2017':
             stepDict[stepName][k] = merge([{'--era': 'Run2_2017_trackingRun2'}, stepDict[step][k]])
     def condition_(self, fragment, stepList, key, hasHarvest):
@@ -246,13 +253,12 @@ upgradeWFs['trackingRun2'] = UpgradeWorkflow_trackingRun2(
     steps = [
         'Reco',
     ],
-    PU = [],
     suffix = '_trackingRun2',
     offset = 0.2,
 )
 
 class UpgradeWorkflow_trackingOnlyRun2(UpgradeWorkflowTracking):
-    def setup_(self, step, stepName, stepDict, k, properties):
+    def setup__(self, step, stepName, stepDict, k, properties):
         if 'Reco' in step and stepDict[step][k]['--era']=='Run2_2017':
             stepDict[stepName][k] = merge([{'--era': 'Run2_2017_trackingRun2'}, self.step3, stepDict[step][k]])
         elif 'HARVEST' in step: stepDict[stepName][k] = merge([{'-s': 'HARVESTING:@trackingOnlyValidation+@trackingOnlyDQM'}, stepDict[step][k]])
@@ -263,14 +269,13 @@ upgradeWFs['trackingOnlyRun2'] = UpgradeWorkflow_trackingOnlyRun2(
         'Reco',
         'HARVEST',
     ],
-    PU = [],
     suffix = '_trackingOnlyRun2',
     offset = 0.3,
 )
 upgradeWFs['trackingOnlyRun2'].step3 = upgradeWFs['trackingOnly'].step3
 
 class UpgradeWorkflow_trackingLowPU(UpgradeWorkflowTracking):
-    def setup_(self, step, stepName, stepDict, k, properties):
+    def setup__(self, step, stepName, stepDict, k, properties):
         if 'Reco' in step and stepDict[step][k]['--era']=='Run2_2017':
             stepDict[stepName][k] = merge([{'--era': 'Run2_2017_trackingLowPU'}, stepDict[step][k]])
     def condition_(self, fragment, stepList, key, hasHarvest):
@@ -279,13 +284,12 @@ upgradeWFs['trackingLowPU'] = UpgradeWorkflow_trackingLowPU(
     steps = [
         'Reco',
     ],
-    PU = [],
     suffix = '_trackingLowPU',
     offset = 0.4,
 )
 
 class UpgradeWorkflow_pixelTrackingOnly(UpgradeWorkflowTracking):
-    def setup_(self, step, stepName, stepDict, k, properties):
+    def setup__(self, step, stepName, stepDict, k, properties):
         if 'Reco' in step: stepDict[stepName][k] = merge([self.step3, stepDict[step][k]])
         elif 'HARVEST' in step: stepDict[stepName][k] = merge([{'-s': 'HARVESTING:@trackingOnlyValidation+@pixelTrackingOnlyDQM'}, stepDict[step][k]])
     def condition_(self, fragment, stepList, key, hasHarvest):
@@ -299,7 +303,6 @@ upgradeWFs['pixelTrackingOnly'] = UpgradeWorkflow_pixelTrackingOnly(
         'RecoNano',
         'HARVESTNano',
     ],
-    PU = [],
     suffix = '_pixelTrackingOnly',
     offset = 0.5,
 )
@@ -310,7 +313,7 @@ upgradeWFs['pixelTrackingOnly'].step3 = {
 }
 
 class UpgradeWorkflow_trackingMkFit(UpgradeWorkflowTracking):
-    def setup_(self, step, stepName, stepDict, k, properties):
+    def setup__(self, step, stepName, stepDict, k, properties):
         if 'Digi' in step: stepDict[stepName][k] = merge([self.step2, stepDict[step][k]])
         if 'Reco' in step: stepDict[stepName][k] = merge([self.step3, stepDict[step][k]])
     def condition_(self, fragment, stepList, key, hasHarvest):
@@ -323,7 +326,6 @@ upgradeWFs['trackingMkFit'] = UpgradeWorkflow_trackingMkFit(
         'RecoGlobal',
         'RecoNano',
     ],
-    PU = [],
     suffix = '_trackingMkFit',
     offset = 0.7,
 )
@@ -337,14 +339,12 @@ upgradeWFs['trackingMkFit'].step3 = {
 #DeepCore seeding for JetCore iteration workflow
 class UpgradeWorkflow_seedingDeepCore(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):
-        if 'Reco' in step or 'HARVEST' in step: stepDict[stepName][k] = merge([{'--procModifiers': 'seedingDeepCore'}, stepDict[step][k]])
+        # skip ALCA and Nano steps (but not RecoNano or HARVESTNano for Run3)
+        if 'ALCA' in step or 'Nano'==step:
+            stepDict[stepName][k] = None
+        elif 'Reco' in step or 'HARVEST' in step: stepDict[stepName][k] = merge([{'--procModifiers': 'seedingDeepCore'}, stepDict[step][k]])
     def condition(self, fragment, stepList, key, hasHarvest):
         result = (fragment=="QCD_Pt_1800_2400_14" or fragment=="TTbar_14TeV" ) and ('2021' in key or '2024' in key) and hasHarvest
-        if result:
-            # skip ALCA and Nano
-            skipList = [s for s in stepList if (("ALCA" in s) or ("Nano" in s))]
-            for skip in skipList:
-                stepList.remove(skip)
         return result
 upgradeWFs['seedingDeepCore'] = UpgradeWorkflow_seedingDeepCore(
     steps = [
@@ -354,6 +354,8 @@ upgradeWFs['seedingDeepCore'] = UpgradeWorkflow_seedingDeepCore(
         'HARVESTGlobal',
         'RecoNano',
         'HARVESTNano',
+        'Nano',
+        'ALCA',
     ],
     PU = [],
     suffix = '_seedingDeepCore',
@@ -753,7 +755,7 @@ class UpgradeWorkflow_ProdLike(UpgradeWorkflow):
         elif 'ALCA' in step or 'HARVEST' in step:
             # remove step
             stepDict[stepName][k] = None
-        elif 'Nano' in step:
+        elif 'Nano'==step:
             stepDict[stepName][k] = merge([{'--filein':'file:step4.root','-s':'NANO','--datatier':'NANOAODSIM','--eventcontent':'NANOEDMAODSIM'}, stepDict[step][k]])
     def condition(self, fragment, stepList, key, hasHarvest):
         return fragment=="TTbar_14TeV" and ('2026' in key or '2021' in key)
@@ -1017,7 +1019,7 @@ class UpgradeWorkflowPremix(UpgradeWorkflow):
                     d["--procModifiers"] = "premix_stage2"
             stepDict[stepName][k] = d
         # Increase the input file step number by one for Nano in combined stage1+stage2
-        elif "Nano" in step:
+        elif "Nano"==step:
             # go back to non-PU step version
             d = merge([stepDict[self.getStepName(step)][k]])
             if "--filein" in d:
@@ -1133,7 +1135,7 @@ class UpgradeWorkflowPremixProdLike(UpgradeWorkflowPremix,UpgradeWorkflow_ProdLi
                         "--eventcontent": "PREMIXRAW"},
                        d])
             stepDict[stepName][k] = d
-        if 'Nano' in step:
+        if 'Nano'==step:
             stepDict[stepName][k] = merge([{'--filein':'file:step5.root','-s':'NANO','--datatier':'NANOAODSIM','--eventcontent':'NANOEDMAODSIM'}, stepDict[step][k]])
     def condition(self, fragment, stepList, key, hasHarvest):
         # use both conditions

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -152,7 +152,6 @@ class UpgradeWorkflow_baseline(UpgradeWorkflow):
         if cust is not None: stepDict[stepName][k]['--customise']=cust
         if era is not None: 
             stepDict[stepName][k]['--era']=era
-            if 'RecoNano' in stepName: stepDict[stepName][k]['--era'] += ',run3_nanoAOD_devel'
         if modifier is not None: stepDict[stepName][k]['--procModifier']=modifier
     def condition(self, fragment, stepList, key, hasHarvest):
         return True


### PR DESCRIPTION
#### PR description:

1. Apply the fix from #36341 to some other workflows that similarly skipped the standalone Nano step
2. Put the `run3_nanoAOD_devel` modifier into the `Run3` Era (easier way to make sure workflows are consistently applying it)

attn: @cms-sw/xpog-l2 

#### PR validation:

Compared output of this command for 12_1_0_pre5 and this branch: `runTheMatrix.py -w upgrade -nel 10024.1,11624.1,11634.17,11834.17,12834.17,13034.17,11834.98,11834.99,11634.21,11834.21,11834.9821,11834.9921,35034.21,35234.21,35234.98,35234.99,35234.9821,35234.9921 --dryRun`. (This tests trackingOnly, deepCore, prodLike, premix workflows.)