### PR TITLE
Backport of "Fix for FastSim decays of exotic-descendent SM particles decaying outside pipe" to 9_4_X

### DIFF
--- a/Configuration/ProcessModifiers/python/fastSimDisableLongLivedBug_cff.py
+++ b/Configuration/ProcessModifiers/python/fastSimDisableLongLivedBug_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+# Desiged to disable the bug in Run II samples that duplicates hits for long lived particles
+fastSimDisableLongLivedBug =  cms.Modifier()

--- a/Configuration/ProcessModifiers/python/fastSimFixLongLivedBug_cff.py
+++ b/Configuration/ProcessModifiers/python/fastSimFixLongLivedBug_cff.py
@@ -1,4 +1,4 @@
 import FWCore.ParameterSet.Config as cms
 
 # Desiged to disable the bug in Run II samples that duplicates hits for long lived particles
-fastSimDisableLongLivedBug =  cms.Modifier()
+fastSimFixLongLivedBug =  cms.Modifier()

--- a/FastSimulation/SimplifiedGeometryPropagator/interface/Decayer.h
+++ b/FastSimulation/SimplifiedGeometryPropagator/interface/Decayer.h
@@ -50,10 +50,11 @@ namespace fastsim
             \param engine The Random Engine.
         */
         void decay(const Particle & particle, std::vector<std::unique_ptr<Particle> > & secondaries, CLHEP::HepRandomEngine & engine) const;
-            
+        void setfixLongLivedBug(bool disable){ fixLongLivedBug_ = disable; };            
         private:    
         std::unique_ptr<Pythia8::Pythia> pythia_;  //!< Instance of pythia
         std::unique_ptr<gen::P8RndmEngine> pythiaRandomEngine_;  //!< Instance of pythia Random Engine
+        bool fixLongLivedBug_;
     };
 }
 #endif

--- a/FastSimulation/SimplifiedGeometryPropagator/interface/ParticleManager.h
+++ b/FastSimulation/SimplifiedGeometryPropagator/interface/ParticleManager.h
@@ -147,7 +147,7 @@ namespace fastsim {
     };
 }
 
-inline bool isExotic(int pdgid_, bool fixLongLivedBug) {
+inline bool isExotic(bool fixLongLivedBug, int pdgid_) {
   unsigned int pdgid = std::abs(pdgid_);
   return ((pdgid >= 1000000 && pdgid < 4000000 && pdgid != 3000022) ||  // SUSY, R-hadron, and technicolor particles
           pdgid == 17 ||                                                // 4th generation lepton

--- a/FastSimulation/SimplifiedGeometryPropagator/interface/ParticleManager.h
+++ b/FastSimulation/SimplifiedGeometryPropagator/interface/ParticleManager.h
@@ -56,7 +56,8 @@ namespace fastsim {
             double deltaRchargedMother,
             const ParticleFilter & particleFilter,
             std::vector<SimTrack> & simTracks,
-            std::vector<SimVertex> & simVertices);
+            std::vector<SimVertex> & simVertices,
+            bool fixLongLivedBug);
         
         //! Default destructor.
         ~ParticleManager();
@@ -142,16 +143,17 @@ namespace fastsim {
         double lengthUnitConversionFactor2_;  //!< Convert pythia unis to cm^2 (FastSim standard)
         double timeUnitConversionFactor_;  //!< Convert pythia unis to ns (FastSim standard)
         std::vector<std::unique_ptr<Particle> > particleBuffer_;  //!< The vector of all secondaries that are not yet propagated in the event.
+        bool fixLongLivedBug_;
     };
 }
 
-inline bool isExotic(int pdgid_) {
+inline bool isExotic(int pdgid_, bool fixLongLivedBug) {
   unsigned int pdgid = std::abs(pdgid_);
   return ((pdgid >= 1000000 && pdgid < 4000000 && pdgid != 3000022) ||  // SUSY, R-hadron, and technicolor particles
           pdgid == 17 ||                                                // 4th generation lepton
           pdgid == 34 ||                                                // W-prime
           pdgid == 37 ||                                                // charged Higgs  
-          pdgid == 39);                                                 // bulk graviton
+          (pdgid == 39 && fixLongLivedBug));                           // bulk graviton
  
 }
 

--- a/FastSimulation/SimplifiedGeometryPropagator/interface/ParticleManager.h
+++ b/FastSimulation/SimplifiedGeometryPropagator/interface/ParticleManager.h
@@ -150,7 +150,9 @@ inline bool isExotic(int pdgid_) {
   return ((pdgid >= 1000000 && pdgid < 4000000 && pdgid != 3000022) ||  // SUSY, R-hadron, and technicolor particles
           pdgid == 17 ||                                                // 4th generation lepton
           pdgid == 34 ||                                                // W-prime
-          pdgid == 37);                                                 // charged Higgs
+          pdgid == 37 ||                                                // charged Higgs  
+          pdgid == 39);                                                 // bulk graviton
+ 
 }
 
 #endif

--- a/FastSimulation/SimplifiedGeometryPropagator/plugins/FastSimProducer.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/plugins/FastSimProducer.cc
@@ -93,6 +93,8 @@ class FastSimProducer : public edm::stream::EDProducer<> {
     std::vector<std::unique_ptr<fastsim::InteractionModel> > interactionModels_;  //!< All defined interaction models
     std::map<std::string, fastsim::InteractionModel *> interactionModelMap_;  //!< Each interaction model has a unique name
     static const std::string MESSAGECATEGORY;  //!< Category of debugging messages ("FastSimulation")
+    
+    bool fixLongLivedBug_;
 };
 
 const std::string FastSimProducer::MESSAGECATEGORY = "FastSimulation";
@@ -107,8 +109,10 @@ FastSimProducer::FastSimProducer(const edm::ParameterSet& iConfig)
     , _randomEngine(nullptr)
     , simulateCalorimetry(iConfig.getParameter<bool>("simulateCalorimetry"))
     , simulateMuons(iConfig.getParameter<bool>("simulateMuons"))
+    , fixLongLivedBug_(iConfig.getParameter<bool>("fixLongLivedBug"))
 {
-
+    // Fix the decayer for the long lived stuff
+    decayer_.setfixLongLivedBug(fixLongLivedBug_);
     //----------------
     // define interaction models
     //---------------
@@ -195,7 +199,8 @@ FastSimProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
                                             ,deltaRchargedMother_
                                             ,particleFilter_
                                             ,*simTracks_
-                                            ,*simVertices_);
+                                            ,*simVertices_
+                                            ,fixLongLivedBug_);
 
     //  Initialize the calorimeter geometry
     if(simulateCalorimetry)

--- a/FastSimulation/SimplifiedGeometryPropagator/python/fastSimProducer_cff.py
+++ b/FastSimulation/SimplifiedGeometryPropagator/python/fastSimProducer_cff.py
@@ -77,4 +77,9 @@ fastSimProducer = cms.EDProducer(
     MaterialEffectsForMuonsInECAL = MaterialEffectsForMuonsInECALBlock.MaterialEffectsForMuonsInECAL,
     MaterialEffectsForMuonsInHCAL = MaterialEffectsForMuonsInHCALBlock.MaterialEffectsForMuonsInHCAL,
     GFlash = FamosCalorimetryBlock.GFlash,
+    fixLongLivedBug = cms.bool(False),
 )
+
+from Configuration.ProcessModifiers.fastSimDisableLongLivedBug_cff import fastSimDisableLongLivedBug
+
+fastSimDisableLongLivedBug.toModify(fastSimProducer, fixLongLivedBug = cms.bool(True))

--- a/FastSimulation/SimplifiedGeometryPropagator/python/fastSimProducer_cff.py
+++ b/FastSimulation/SimplifiedGeometryPropagator/python/fastSimProducer_cff.py
@@ -80,6 +80,6 @@ fastSimProducer = cms.EDProducer(
     fixLongLivedBug = cms.bool(False),
 )
 
-from Configuration.ProcessModifiers.fastSimDisableLongLivedBug_cff import fastSimDisableLongLivedBug
+from Configuration.ProcessModifiers.fastSimFixLongLivedBug_cff import fastSimFixLongLivedBug
 
-fastSimDisableLongLivedBug.toModify(fastSimProducer, fixLongLivedBug = cms.bool(True))
+fastSimFixLongLivedBug.toModify(fastSimProducer, fixLongLivedBug = cms.bool(True))

--- a/FastSimulation/SimplifiedGeometryPropagator/src/Decayer.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/Decayer.cc
@@ -41,7 +41,7 @@ fastsim::Decayer::decay(const Particle & particle,std::vector<std::unique_ptr<fa
 
     // snip decay products of exotic particles or their children. These decay products are preserved from the event record.
     // limitation: if exotic incurs heavy energy loss during propagation, the saved decay products could be too hard.    
-    if (isExotic(pid, fixLongLivedBug_) || isExotic(particle.getMotherPdgId(), fixLongLivedBug_)) {
+    if (isExotic(fixLongLivedBug_, pid) || isExotic(fixLongLivedBug_, particle.getMotherPdgId())) {
         return;
     }
     pythia_->event.reset();

--- a/FastSimulation/SimplifiedGeometryPropagator/src/Decayer.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/Decayer.cc
@@ -18,7 +18,7 @@ fastsim::Decayer::Decayer()
     pythia_->settings.flag("PartonLevel:FSRinResonances",false);
     pythia_->settings.flag("ProcessLevel:resonanceDecays",false);
     pythia_->init();
-
+    fixLongLivedBug_ = false;
     // forbid all decays
     // (decays are allowed selectively in the decay function)
     Pythia8::ParticleData & pdt = pythia_->particleData;
@@ -40,8 +40,8 @@ fastsim::Decayer::decay(const Particle & particle,std::vector<std::unique_ptr<fa
     int pid = particle.pdgId();
 
     // snip decay products of exotic particles or their children. These decay products are preserved from the event record.
-    // limitation: if exotic incurs heavy energy loss during propagation, the saved decay products could be too hard.
-    if (isExotic(pid) || isExotic(particle.getMotherPdgId())) {
+    // limitation: if exotic incurs heavy energy loss during propagation, the saved decay products could be too hard.    
+    if (isExotic(pid, fixLongLivedBug_) || isExotic(particle.getMotherPdgId(), fixLongLivedBug_)) {
         return;
     }
     pythia_->event.reset();

--- a/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
@@ -254,7 +254,7 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle()
         if (!producedWithinBeamPipe)  //
         {
             exoticRelativesChecker(productionVertex, exoticRelativeId, 0);
-            if (!isExotic(exoticRelativeId, fixLongLivedBug_)) {
+            if (!isExotic(fixLongLivedBug_, exoticRelativeId)) {
                 continue;
             }
         }	
@@ -266,7 +266,7 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle()
         }
 
         // SM particles that descend from exotics and cross the beam pipe radius should make hits but not be decayed, by default it will duplicate FastSim hits for long lived particles and so anything produced without activating fixLongLivedBug_ is physically wrong
-        if (producedWithinBeamPipe && !decayedWithinBeamPipe && fixLongLivedBug_){
+        if (fixLongLivedBug_ && producedWithinBeamPipe && !decayedWithinBeamPipe){
           exoticRelativesChecker(productionVertex, exoticRelativeId, 0);
         }    
 
@@ -283,7 +283,7 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle()
                              particle.momentum().z()*momentumUnitConversionFactor_,
                              particle.momentum().e()*momentumUnitConversionFactor_)));
         newParticle->setGenParticleIndex(genParticleIndex_);
-        if (isExotic(exoticRelativeId, fixLongLivedBug_)) {
+        if (isExotic(fixLongLivedBug_, exoticRelativeId)) {
                 newParticle->setMotherPdgId(exoticRelativeId);
         }
         // try to get the life time of the particle from the genEvent
@@ -317,14 +317,14 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle()
 void fastsim::ParticleManager::exoticRelativesChecker(const HepMC::GenVertex* originVertex,
                                                       int& exoticRelativeId_,
                                                       int ngendepth = 0) {
-  if (ngendepth > 99 || exoticRelativeId_ == -1 || isExotic(std::abs(exoticRelativeId_), fixLongLivedBug_))
+  if (ngendepth > 99 || exoticRelativeId_ == -1 || isExotic(fixLongLivedBug_, std::abs(exoticRelativeId_)))
     return;
   ngendepth += 1;
   std::vector<HepMC::GenParticle*>::const_iterator relativesIterator_ = originVertex->particles_in_const_begin();
   std::vector<HepMC::GenParticle*>::const_iterator relativesIteratorEnd_ = originVertex->particles_in_const_end();
   for (; relativesIterator_ != relativesIteratorEnd_; ++relativesIterator_) {
     const HepMC::GenParticle& genRelative = **relativesIterator_;
-    if (isExotic(std::abs(genRelative.pdg_id()),fixLongLivedBug_)) {
+    if (isExotic(fixLongLivedBug_, std::abs(genRelative.pdg_id()))) {
       exoticRelativeId_ = genRelative.pdg_id();
       if (ngendepth == 100)
         exoticRelativeId_ = -1;

--- a/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
@@ -21,7 +21,8 @@ fastsim::ParticleManager::ParticleManager(
     double deltaRchargedMother,
     const fastsim::ParticleFilter & particleFilter,
     std::vector<SimTrack> & simTracks,
-    std::vector<SimVertex> & simVertices)
+    std::vector<SimVertex> & simVertices,
+    bool fixLongLivedBug)
     : genEvent_(&genEvent)
     , genParticleIterator_(genEvent_->particles_begin())
     , genParticleEnd_(genEvent_->particles_end())
@@ -44,7 +45,7 @@ fastsim::ParticleManager::ParticleManager(
     , lengthUnitConversionFactor_(conversion_factor(genEvent_->length_unit(),HepMC::Units::LengthUnit::CM))
     , lengthUnitConversionFactor2_(lengthUnitConversionFactor_*lengthUnitConversionFactor_)
     , timeUnitConversionFactor_(lengthUnitConversionFactor_/fastsim::Constants::speedOfLight)
-
+    , fixLongLivedBug_(fixLongLivedBug)
 {
 
     // add the main vertex from the signal event to the simvertex collection
@@ -239,7 +240,6 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle()
         const HepMC::GenParticle & particle = **genParticleIterator_;
         const HepMC::GenVertex * productionVertex = particle.production_vertex();
         const HepMC::GenVertex * endVertex = particle.end_vertex();
-
         // skip incoming particles
         if(!productionVertex){
             continue;
@@ -251,13 +251,13 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle()
         // particles which do not descend from exotics must be produced within the beampipe
         int exoticRelativeId = 0;
         const bool producedWithinBeamPipe = productionVertex->position().perp2() * lengthUnitConversionFactor2_ < beamPipeRadius2_;
-        if (!producedWithinBeamPipe) { //
+        if (!producedWithinBeamPipe)  //
+        {
             exoticRelativesChecker(productionVertex, exoticRelativeId, 0);
-            if (!isExotic(exoticRelativeId)) {
+            if (!isExotic(exoticRelativeId, fixLongLivedBug_)) {
                 continue;
             }
-        }
-
+        }	
         // FastSim will not make hits out of particles that decay before reaching the beam pipe
         const bool decayedWithinBeamPipe = endVertex && endVertex->position().perp2() * lengthUnitConversionFactor2_ < beamPipeRadius2_;
         if(decayedWithinBeamPipe)
@@ -265,8 +265,8 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle()
             continue;
         }
 
-        // SM particles that descend from exotics and cross the beam pipe radius should make hits but not be decayed 
-        if (producedWithinBeamPipe && !decayedWithinBeamPipe){
+        // SM particles that descend from exotics and cross the beam pipe radius should make hits but not be decayed, by default it will duplicate FastSim hits for long lived particles and so anything produced without activating fixLongLivedBug_ is physically wrong
+        if (producedWithinBeamPipe && !decayedWithinBeamPipe && fixLongLivedBug_){
           exoticRelativesChecker(productionVertex, exoticRelativeId, 0);
         }    
 
@@ -283,8 +283,8 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle()
                              particle.momentum().z()*momentumUnitConversionFactor_,
                              particle.momentum().e()*momentumUnitConversionFactor_)));
         newParticle->setGenParticleIndex(genParticleIndex_);
-        if (isExotic(exoticRelativeId)) {
-        	newParticle->setMotherPdgId(exoticRelativeId);
+        if (isExotic(exoticRelativeId, fixLongLivedBug_)) {
+                newParticle->setMotherPdgId(exoticRelativeId);
         }
         // try to get the life time of the particle from the genEvent
         if(endVertex)
@@ -317,14 +317,14 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle()
 void fastsim::ParticleManager::exoticRelativesChecker(const HepMC::GenVertex* originVertex,
                                                       int& exoticRelativeId_,
                                                       int ngendepth = 0) {
-  if (ngendepth > 99 || exoticRelativeId_ == -1 || isExotic(std::abs(exoticRelativeId_)))
+  if (ngendepth > 99 || exoticRelativeId_ == -1 || isExotic(std::abs(exoticRelativeId_), fixLongLivedBug_))
     return;
   ngendepth += 1;
   std::vector<HepMC::GenParticle*>::const_iterator relativesIterator_ = originVertex->particles_in_const_begin();
   std::vector<HepMC::GenParticle*>::const_iterator relativesIteratorEnd_ = originVertex->particles_in_const_end();
   for (; relativesIterator_ != relativesIteratorEnd_; ++relativesIterator_) {
     const HepMC::GenParticle& genRelative = **relativesIterator_;
-    if (isExotic(std::abs(genRelative.pdg_id()))) {
+    if (isExotic(std::abs(genRelative.pdg_id()),fixLongLivedBug_)) {
       exoticRelativeId_ = genRelative.pdg_id();
       if (ngendepth == 100)
         exoticRelativeId_ = -1;

--- a/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
@@ -251,7 +251,7 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle()
         // particles which do not descend from exotics must be produced within the beampipe
         int exoticRelativeId = 0;
         const bool producedWithinBeamPipe = productionVertex->position().perp2() * lengthUnitConversionFactor2_ < beamPipeRadius2_;
-        if (producedWithinBeamPipe) { //
+        if (!producedWithinBeamPipe) { //
             exoticRelativesChecker(productionVertex, exoticRelativeId, 0);
             if (!isExotic(exoticRelativeId)) {
                 continue;

--- a/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
@@ -257,11 +257,18 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle()
             }
         }
 
-        // particle must not decay before it reaches the beam pipe
+        // FastSim will not make hits out of particles that decay before reaching the beam pipe
         if(endVertex && endVertex->position().perp2()*lengthUnitConversionFactor2_ < beamPipeRadius2_)
         {
             continue;
         }
+
+        // SM particles that descend from exotics and cross the beam pipe radius should make hits but not be decayed 
+        if (productionVertex->position().perp2() * lengthUnitConversionFactor2_ < beamPipeRadius2_ &&
+         endVertex && endVertex->position().perp2() * lengthUnitConversionFactor2_ > beamPipeRadius2_) {
+          exoticRelativesChecker(productionVertex, exoticRelativeId, 0);
+        }    
+
 
         // make the particle
         std::unique_ptr<Particle> newParticle(

--- a/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
@@ -250,7 +250,8 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle()
         }
         // particles which do not descend from exotics must be produced within the beampipe
         int exoticRelativeId = 0;
-        if (productionVertex->position().perp2() * lengthUnitConversionFactor2_ > beamPipeRadius2_) { //
+        const bool producedWithinBeamPipe = productionVertex->position().perp2() * lengthUnitConversionFactor2_ < beamPipeRadius2_;
+        if (producedWithinBeamPipe) { //
             exoticRelativesChecker(productionVertex, exoticRelativeId, 0);
             if (!isExotic(exoticRelativeId)) {
                 continue;
@@ -258,14 +259,14 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle()
         }
 
         // FastSim will not make hits out of particles that decay before reaching the beam pipe
-        if(endVertex && endVertex->position().perp2()*lengthUnitConversionFactor2_ < beamPipeRadius2_)
+        const bool decayedWithinBeamPipe = endVertex && endVertex->position().perp2() * lengthUnitConversionFactor2_ < beamPipeRadius2_;
+        if(decayedWithinBeamPipe)
         {
             continue;
         }
 
         // SM particles that descend from exotics and cross the beam pipe radius should make hits but not be decayed 
-        if (productionVertex->position().perp2() * lengthUnitConversionFactor2_ < beamPipeRadius2_ &&
-         endVertex && endVertex->position().perp2() * lengthUnitConversionFactor2_ > beamPipeRadius2_) {
+        if (producedWithinBeamPipe && !decayedWithinBeamPipe){
           exoticRelativesChecker(productionVertex, exoticRelativeId, 0);
         }    
 


### PR DESCRIPTION
#### PR description:

Backport of  #36122 and #36324 for preUL 2017 FastSim production. Full functionality of both, without the code formatting. Please check #36352 (backport to UL branch) first

This fixes a bug which would invalidate simulation for long-lived and a fraction of prompt signals (and luckily was introduced very recently, so most of the previous production is safe). Our understanding is that this case doesn't go against the no-change policy.

Original PR description: Jaebak found that some b- and d-mesons produced in the decays of exotic particles, which cross the beam pipe radius, have their decay performed twice, with sim hits created for each copy. This causes problems for some high-pT b-jets, as well as the MET in events that contain such jets. A few lines are added to ParticleManager.cc which results in FastSim deciding to not decay such particles further, and rather take only the original generator-determined decay trees. FastSim will still propagate these particles and create secondaries/material interactions, but it won't decay them.


#### If this PR is a backport please specify the original PR and why you need to backport that PR:

#36122 and #36324, needed for preUL 2017 MC production (most notably pMSSM scan)