### PR TITLE
[11_3_X] Protect storage accounting UDP messages from NaN, and Use StatisticsSenderService for all framework files

### DIFF
--- a/IOPool/Input/src/EmbeddedRootSource.cc
+++ b/IOPool/Input/src/EmbeddedRootSource.cc
@@ -45,7 +45,7 @@ namespace edm {
     InputFile::reportReadBranches();
   }
 
-  void EmbeddedRootSource::closeFile_() { fileSequence_->closeFile_(); }
+  void EmbeddedRootSource::closeFile_() { fileSequence_->closeFile(); }
 
   bool EmbeddedRootSource::readOneEvent(EventPrincipal& cache,
                                         size_t& fileNameHash,

--- a/IOPool/Input/src/PoolSource.cc
+++ b/IOPool/Input/src/PoolSource.cc
@@ -162,7 +162,7 @@ namespace edm {
     return fb;
   }
 
-  void PoolSource::closeFile_() { primaryFileSequence_->closeFile_(); }
+  void PoolSource::closeFile_() { primaryFileSequence_->closeFile(); }
 
   std::shared_ptr<RunAuxiliary> PoolSource::readRunAuxiliary_() { return primaryFileSequence_->readRunAuxiliary_(); }
 

--- a/IOPool/Input/src/RootEmbeddedFileSequence.cc
+++ b/IOPool/Input/src/RootEmbeddedFileSequence.cc
@@ -121,7 +121,7 @@ namespace edm {
 
   RootEmbeddedFileSequence::~RootEmbeddedFileSequence() {}
 
-  void RootEmbeddedFileSequence::endJob() { closeFile_(); }
+  void RootEmbeddedFileSequence::endJob() { closeFile(); }
 
   void RootEmbeddedFileSequence::closeFile_() {
     // delete the RootFile object.

--- a/IOPool/Input/src/RootEmbeddedFileSequence.h
+++ b/IOPool/Input/src/RootEmbeddedFileSequence.h
@@ -39,7 +39,6 @@ namespace edm {
     RootEmbeddedFileSequence(RootEmbeddedFileSequence const&) = delete;             // Disallow copying and moving
     RootEmbeddedFileSequence& operator=(RootEmbeddedFileSequence const&) = delete;  // Disallow copying and moving
 
-    void closeFile_() override;
     void endJob();
     void skipEntries(unsigned int offset);
     bool readOneEvent(
@@ -56,6 +55,7 @@ namespace edm {
     static void fillDescription(ParameterSetDescription& desc);
 
   private:
+    void closeFile_() override;
     void initFile_(bool skipBadFiles) override;
     RootFileSharedPtr makeRootFile(std::shared_ptr<InputFile> filePtr) override;
 

--- a/IOPool/Input/src/RootInputFileSequence.cc
+++ b/IOPool/Input/src/RootInputFileSequence.cc
@@ -10,6 +10,8 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "Utilities/StorageFactory/interface/StorageFactory.h"
+#include "Utilities/StorageFactory/interface/StatisticsSenderService.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
 
 #include "TSystem.h"
 
@@ -193,7 +195,7 @@ namespace edm {
       }
       fileIterLastOpened_ = fileIterEnd_;
     }
-    closeFile_();
+    closeFile();
 
     if (noMoreFiles()) {
       // No files specified
@@ -228,6 +230,10 @@ namespace edm {
     {
       std::unique_ptr<InputSource::FileOpenSentry> sentry(
           input ? std::make_unique<InputSource::FileOpenSentry>(*input, lfn_, false) : nullptr);
+      edm::Service<edm::storage::StatisticsSenderService> service;
+      if (service.isAvailable()) {
+        service->openingFile(lfn(), -1);
+      }
       for (std::vector<std::string>::const_iterator it = fNames.begin(); it != fNames.end(); ++it) {
         try {
           std::unique_ptr<char[]> name(gSystem->ExpandPathName(it->c_str()));
@@ -271,6 +277,14 @@ namespace edm {
       LogWarning("RootInputFileSequence")
           << "Input file: " << fName << " was not found or could not be opened, and will be skipped.\n";
     }
+  }
+
+  void RootInputFileSequence::closeFile() {
+    edm::Service<edm::storage::StatisticsSenderService> service;
+    if (rootFile() and service.isAvailable()) {
+      service->closedFile(lfn(), usedFallback());
+    }
+    closeFile_();
   }
 
   void RootInputFileSequence::setIndexIntoFile(size_t index) {

--- a/IOPool/Input/src/RootInputFileSequence.cc
+++ b/IOPool/Input/src/RootInputFileSequence.cc
@@ -225,31 +225,32 @@ namespace edm {
 
     //this tries to open the file using multiple PFNs corresponding to different data catalogs
     std::list<std::string> exInfo;
-    for (std::vector<std::string>::const_iterator it = fNames.begin(); it != fNames.end(); ++it) {
-      try {
-        std::unique_ptr<InputSource::FileOpenSentry> sentry(
-            input ? std::make_unique<InputSource::FileOpenSentry>(*input, lfn_, false) : nullptr);
-        std::unique_ptr<char[]> name(gSystem->ExpandPathName(it->c_str()));
-        filePtr = std::make_shared<InputFile>(name.get(), "  Initiating request to open file ", inputType);
-        break;
-      } catch (cms::Exception const& e) {
-        if (!skipBadFiles && std::next(it) == fNames.end()) {
-          InputFile::reportSkippedFile((*it), logicalFileName());
-          Exception ex(errors::FileOpenError, "", e);
-          ex.addContext("Calling RootInputFileSequence::initTheFile()");
-          std::ostringstream out;
-          out << "Input file " << (*it) << " could not be opened.";
-          ex.addAdditionalInfo(out.str());
-          //report previous exceptions when use other names to open file
-          for (auto const& s : exInfo)
-            ex.addAdditionalInfo(s);
-          throw ex;
-        } else {
-          exInfo.push_back("Calling RootInputFileSequence::initTheFile(): fail to open the file with name " + (*it));
+    {
+      std::unique_ptr<InputSource::FileOpenSentry> sentry(
+          input ? std::make_unique<InputSource::FileOpenSentry>(*input, lfn_, false) : nullptr);
+      for (std::vector<std::string>::const_iterator it = fNames.begin(); it != fNames.end(); ++it) {
+        try {
+          std::unique_ptr<char[]> name(gSystem->ExpandPathName(it->c_str()));
+          filePtr = std::make_shared<InputFile>(name.get(), "  Initiating request to open file ", inputType);
+          break;
+        } catch (cms::Exception const& e) {
+          if (!skipBadFiles && std::next(it) == fNames.end()) {
+            InputFile::reportSkippedFile((*it), logicalFileName());
+            Exception ex(errors::FileOpenError, "", e);
+            ex.addContext("Calling RootInputFileSequence::initTheFile()");
+            std::ostringstream out;
+            out << "Input file " << (*it) << " could not be opened.";
+            ex.addAdditionalInfo(out.str());
+            //report previous exceptions when use other names to open file
+            for (auto const& s : exInfo)
+              ex.addAdditionalInfo(s);
+            throw ex;
+          } else {
+            exInfo.push_back("Calling RootInputFileSequence::initTheFile(): fail to open the file with name " + (*it));
+          }
         }
       }
     }
-
     if (filePtr) {
       size_t currentIndexIntoFile = fileIter_ - fileIterBegin_;
       rootFile_ = makeRootFile(filePtr);

--- a/IOPool/Input/src/RootInputFileSequence.cc
+++ b/IOPool/Input/src/RootInputFileSequence.cc
@@ -219,6 +219,7 @@ namespace edm {
 
     lfn_ = logicalFileName().empty() ? fileNames()[0] : logicalFileName();
     lfnHash_ = std::hash<std::string>()(lfn_);
+    usedFallback_ = false;
 
     std::shared_ptr<InputFile> filePtr;
     std::list<std::string> originalInfo;
@@ -238,6 +239,7 @@ namespace edm {
         try {
           std::unique_ptr<char[]> name(gSystem->ExpandPathName(it->c_str()));
           filePtr = std::make_shared<InputFile>(name.get(), "  Initiating request to open file ", inputType);
+          usedFallback_ = (it != fNames.begin());
           break;
         } catch (cms::Exception const& e) {
           if (!skipBadFiles && std::next(it) == fNames.end()) {

--- a/IOPool/Input/src/RootInputFileSequence.cc
+++ b/IOPool/Input/src/RootInputFileSequence.cc
@@ -232,7 +232,7 @@ namespace edm {
           input ? std::make_unique<InputSource::FileOpenSentry>(*input, lfn_, false) : nullptr);
       edm::Service<edm::storage::StatisticsSenderService> service;
       if (service.isAvailable()) {
-        service->openingFile(lfn(), -1);
+        service->openingFile(lfn(), inputType, -1);
       }
       for (std::vector<std::string>::const_iterator it = fNames.begin(); it != fNames.end(); ++it) {
         try {

--- a/IOPool/Input/src/RootInputFileSequence.h
+++ b/IOPool/Input/src/RootInputFileSequence.h
@@ -51,6 +51,8 @@ namespace edm {
     std::shared_ptr<ProductRegistry const> fileProductRegistry() const;
     std::shared_ptr<BranchIDListHelper const> fileBranchIDListHelper() const;
 
+    void closeFile();
+
   protected:
     typedef std::shared_ptr<RootFile> RootFileSharedPtr;
     void initFile(bool skipBadFiles) { initFile_(skipBadFiles); }

--- a/IOPool/Input/src/RootPrimaryFileSequence.cc
+++ b/IOPool/Input/src/RootPrimaryFileSequence.cc
@@ -69,7 +69,7 @@ namespace edm {
 
   RootPrimaryFileSequence::~RootPrimaryFileSequence() {}
 
-  void RootPrimaryFileSequence::endJob() { closeFile_(); }
+  void RootPrimaryFileSequence::endJob() { closeFile(); }
 
   std::unique_ptr<FileBlock> RootPrimaryFileSequence::readFile_() {
     if (firstFile_) {
@@ -225,7 +225,7 @@ namespace edm {
   // Rewind to before the first event that was read.
   void RootPrimaryFileSequence::rewind_() {
     if (!atFirstFile()) {
-      closeFile_();
+      closeFile();
       setAtFirstFile();
     }
     if (!rootFile()) {

--- a/IOPool/Input/src/RootPrimaryFileSequence.h
+++ b/IOPool/Input/src/RootPrimaryFileSequence.h
@@ -40,7 +40,6 @@ namespace edm {
     RootPrimaryFileSequence& operator=(RootPrimaryFileSequence const&) = delete;  // Disallow copying and moving
 
     std::unique_ptr<FileBlock> readFile_();
-    void closeFile_() override;
     void endJob();
     InputSource::ItemType getNextItemType(RunNumber_t& run, LuminosityBlockNumber_t& lumi, EventNumber_t& event);
     bool skipEvents(int offset);
@@ -56,6 +55,7 @@ namespace edm {
     bool nextFile();
     bool previousFile();
     void rewindFile();
+    void closeFile_() override;
 
     int remainingEvents() const;
     int remainingLuminosityBlocks() const;

--- a/IOPool/Input/src/RootSecondaryFileSequence.cc
+++ b/IOPool/Input/src/RootSecondaryFileSequence.cc
@@ -52,7 +52,7 @@ namespace edm {
 
   RootSecondaryFileSequence::~RootSecondaryFileSequence() {}
 
-  void RootSecondaryFileSequence::endJob() { closeFile_(); }
+  void RootSecondaryFileSequence::endJob() { closeFile(); }
 
   void RootSecondaryFileSequence::closeFile_() {
     // close the currently open file, if any, and delete the RootFile object.

--- a/IOPool/Input/src/RootSecondaryFileSequence.h
+++ b/IOPool/Input/src/RootSecondaryFileSequence.h
@@ -33,11 +33,11 @@ namespace edm {
     RootSecondaryFileSequence(RootSecondaryFileSequence const&) = delete;             // Disallow copying and moving
     RootSecondaryFileSequence& operator=(RootSecondaryFileSequence const&) = delete;  // Disallow copying and moving
 
-    void closeFile_() override;
     void endJob();
     void initAssociationsFromSecondary(std::set<BranchID> const&);
 
   private:
+    void closeFile_() override;
     void initFile_(bool skipBadFiles) override;
     RootFileSharedPtr makeRootFile(std::shared_ptr<InputFile> filePtr) override;
 

--- a/IOPool/SecondaryInput/test/SecondaryProducer.h
+++ b/IOPool/SecondaryInput/test/SecondaryProducer.h
@@ -9,7 +9,7 @@
  ************************************************************/
 
 #include "DataFormats/Provenance/interface/EventID.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 #include <memory>
@@ -19,7 +19,7 @@ namespace edm {
   class ProcessConfiguration;
   class VectorInputSource;
 
-  class SecondaryProducer : public EDProducer {
+  class SecondaryProducer : public one::EDProducer<> {
   public:
     /** standard constructor*/
     explicit SecondaryProducer(ParameterSet const& pset);

--- a/IOPool/TFileAdaptor/src/TStorageFactoryFile.cc
+++ b/IOPool/TFileAdaptor/src/TStorageFactoryFile.cc
@@ -195,7 +195,7 @@ void TStorageFactoryFile::Initialize(const char *path, Option_t *option /* = "" 
   try {
     edm::Service<edm::storage::StatisticsSenderService> statsService;
     if (statsService.isAvailable()) {
-      statsService->setSize(storage_->size());
+      statsService->setSize(path, storage_->size());
     }
   } catch (edm::Exception const &e) {
     if (e.categoryCode() != edm::errors::NotFound) {

--- a/Utilities/StorageFactory/interface/StatisticsSenderService.h
+++ b/Utilities/StorageFactory/interface/StatisticsSenderService.h
@@ -7,6 +7,7 @@
 #include <atomic>
 #include <mutex>
 #include <tbb/concurrent_unordered_map.h>
+#include "FWCore/Utilities/interface/InputType.h"
 
 namespace edm {
 
@@ -24,7 +25,7 @@ namespace edm {
       static const char* getJobID();
       static bool getX509Subject(std::string&);
 
-      void openingFile(std::string const& lfn, size_t size = -1);
+      void openingFile(std::string const& lfn, edm::InputType type, size_t size = -1);
       void closedFile(std::string const& lfn, bool usedFallback);
 
     private:
@@ -50,10 +51,20 @@ namespace edm {
       };
 
       struct FileInfo {
-        explicit FileInfo(std::string const& iLFN);
+        explicit FileInfo(std::string const& iLFN, edm::InputType);
+
+        FileInfo(FileInfo&& iInfo)
+            : m_filelfn(std::move(iInfo.m_filelfn)),
+              m_serverhost(std::move(iInfo.m_serverhost)),
+              m_serverdomain(std::move(iInfo.m_serverdomain)),
+              m_type(iInfo.m_type),
+              m_size(iInfo.m_size.load()),
+              m_id(iInfo.m_id),
+              m_openCount(iInfo.m_openCount.load()) {}
         std::string m_filelfn;
         std::string m_serverhost;
         std::string m_serverdomain;
+        edm::InputType m_type;
         std::atomic<ssize_t> m_size;
         size_t m_id;  //from m_counter
         std::atomic<int> m_openCount;

--- a/Utilities/StorageFactory/interface/StatisticsSenderService.h
+++ b/Utilities/StorageFactory/interface/StatisticsSenderService.h
@@ -28,13 +28,14 @@ namespace edm {
       void closedFile(std::string const& lfn, bool usedFallback);
 
     private:
-      void filePreCloseEvent(std::string const& lfn, bool usedFallback);
+      void filePostCloseEvent(std::string const& lfn, bool usedFallback);
 
       std::string const* matchedLfn(std::string const& iURL);  //updates its internal cache
       class FileStatistics {
       public:
         FileStatistics();
-        void fillUDP(std::ostringstream& os);
+        void fillUDP(std::ostringstream& os) const;
+        void update();
 
       private:
         ssize_t m_read_single_operations;
@@ -53,13 +54,13 @@ namespace edm {
         std::string m_filelfn;
         std::string m_serverhost;
         std::string m_serverdomain;
-        ssize_t m_size;
+        std::atomic<ssize_t> m_size;
         size_t m_id;  //from m_counter
         std::atomic<int> m_openCount;
       };
 
       void determineHostnames();
-      void fillUDP(const std::string& site, const FileInfo& fileinfo, bool, std::string&);
+      void fillUDP(const std::string& site, const FileInfo& fileinfo, bool, std::string&) const;
       void cleanupOldFiles();
 
       std::string m_clienthost;

--- a/Utilities/StorageFactory/src/StatisticsSenderService.cc
+++ b/Utilities/StorageFactory/src/StatisticsSenderService.cc
@@ -297,10 +297,12 @@ void StatisticsSenderService::closedFile(std::string const &url, bool usedFallba
     }
 
     auto c = --found->second.m_openCount;
-    if (c == 0) {
-      edm::LogWarning("StatisticsSenderService") << "fully closed: " << *lfn << "\n";
-    } else {
-      edm::LogWarning("StatisticsSenderService") << "partially closed: " << *lfn << "\n";
+    if (m_debug) {
+      if (c == 0) {
+        edm::LogWarning("StatisticsSenderService") << "fully closed: " << *lfn << "\n";
+      } else {
+        edm::LogWarning("StatisticsSenderService") << "partially closed: " << *lfn << "\n";
+      }
     }
   } else if (m_debug) {
     edm::LogWarning("StatisticsSenderService") << "closed: unknown url name " << url << "\n";

--- a/Utilities/StorageFactory/src/StatisticsSenderService.cc
+++ b/Utilities/StorageFactory/src/StatisticsSenderService.cc
@@ -77,9 +77,9 @@ void StatisticsSenderService::FileStatistics::fillUDP(std::ostringstream &os) {
     double single_sum = read_single_bytes - m_read_single_bytes;
     double single_average = single_sum / static_cast<double>(single_op_count);
     os << "\"read_single_sigma\":"
-       << sqrt((static_cast<double>(read_single_square - m_read_single_square) -
-                single_average * single_average * single_op_count) /
-               static_cast<double>(single_op_count))
+       << sqrt(std::abs((static_cast<double>(read_single_square - m_read_single_square) -
+                         single_average * single_average * single_op_count) /
+                        static_cast<double>(single_op_count)))
        << ", ";
     os << "\"read_single_average\":" << single_average << ", ";
   }
@@ -90,17 +90,17 @@ void StatisticsSenderService::FileStatistics::fillUDP(std::ostringstream &os) {
         static_cast<double>(read_vector_bytes - m_read_vector_bytes) / static_cast<double>(vector_op_count);
     os << "\"read_vector_average\":" << vector_average << ", ";
     os << "\"read_vector_sigma\":"
-       << sqrt((static_cast<double>(read_vector_square - m_read_vector_square) -
-                vector_average * vector_average * vector_op_count) /
-               static_cast<double>(vector_op_count))
+       << sqrt(std::abs((static_cast<double>(read_vector_square - m_read_vector_square) -
+                         vector_average * vector_average * vector_op_count) /
+                        static_cast<double>(vector_op_count)))
        << ", ";
     double vector_count_average =
         static_cast<double>(read_vector_count_sum - m_read_vector_count_sum) / static_cast<double>(vector_op_count);
     os << "\"read_vector_count_average\":" << vector_count_average << ", ";
     os << "\"read_vector_count_sigma\":"
-       << sqrt((static_cast<double>(read_vector_count_square - m_read_vector_count_square) -
-                vector_count_average * vector_count_average * vector_op_count) /
-               static_cast<double>(vector_op_count))
+       << sqrt(std::abs((static_cast<double>(read_vector_count_square - m_read_vector_count_square) -
+                         vector_count_average * vector_count_average * vector_op_count) /
+                        static_cast<double>(vector_op_count)))
        << ", ";
   }
   m_read_vector_square = read_vector_square;

--- a/Utilities/StorageFactory/src/StatisticsSenderService.cc
+++ b/Utilities/StorageFactory/src/StatisticsSenderService.cc
@@ -4,6 +4,7 @@
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 #include "FWCore/Catalog/interface/SiteLocalConfig.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/src/Guid.h"
 
 #include <string>
@@ -124,19 +125,20 @@ void StatisticsSenderService::FileStatistics::fillUDP(std::ostringstream &os) {
   os << "\"end_time\":" << m_start_time;
 }
 
-StatisticsSenderService::StatisticsSenderService(edm::ParameterSet const & /*pset*/, edm::ActivityRegistry &ar)
+StatisticsSenderService::FileInfo::FileInfo(std::string const &iLFN)
+    : m_filelfn(iLFN), m_serverhost("unknown"), m_serverdomain("unknown"), m_size(-1), m_id(0), m_openCount(1) {}
+
+StatisticsSenderService::StatisticsSenderService(edm::ParameterSet const &iPSet, edm::ActivityRegistry &ar)
     : m_clienthost("unknown"),
       m_clientdomain("unknown"),
-      m_serverhost("unknown"),
-      m_serverdomain("unknown"),
-      m_filelfn("unknown"),
       m_filestats(),
       m_guid(Guid().toString()),
       m_counter(0),
-      m_size(-1),
-      m_userdn("unknown") {
+      m_userdn("unknown"),
+      m_debug(iPSet.getUntrackedParameter<bool>("debug", false)) {
   determineHostnames();
   ar.watchPreCloseFile(this, &StatisticsSenderService::filePreCloseEvent);
+  ar.watchPreOpenFile([this](auto const &iLFN, bool) { openingFile(iLFN, -1); });
   if (!getX509Subject(m_userdn)) {
     m_userdn = "unknown";
   }
@@ -148,7 +150,35 @@ const char *StatisticsSenderService::getJobID() {
   return id ? id : std::getenv(JOB_UNIQUE_ID_ENV_V2);
 }
 
-void StatisticsSenderService::setCurrentServer(const std::string &servername) {
+std::string const *StatisticsSenderService::matchedLfn(std::string const &iURL) {
+  auto found = m_urlToLfn.find(iURL);
+  if (found != m_urlToLfn.end()) {
+    return &found->second;
+  }
+  for (auto const &v : m_lfnToFileInfo) {
+    if (v.first.size() < iURL.size()) {
+      if (v.first == iURL.substr(iURL.size() - v.first.size())) {
+        m_urlToLfn.emplace(iURL, v.first);
+        return &m_urlToLfn.find(iURL)->second;
+      }
+    }
+  }
+  //does the lfn have a protocol and the iURL not?
+  if (std::string::npos == iURL.find(':')) {
+    for (auto const &v : m_lfnToFileInfo) {
+      if ((std::string::npos != v.first.find(':')) and (v.first.size() > iURL.size())) {
+        if (iURL == v.first.substr(v.first.size() - iURL.size())) {
+          m_urlToLfn.emplace(iURL, v.first);
+          return &m_urlToLfn.find(iURL)->second;
+        }
+      }
+    }
+  }
+
+  return nullptr;
+}
+
+void StatisticsSenderService::setCurrentServer(const std::string &url, const std::string &servername) {
   size_t dot_pos = servername.find('.');
   std::string serverhost;
   std::string serverdomain;
@@ -163,24 +193,41 @@ void StatisticsSenderService::setCurrentServer(const std::string &servername) {
     }
   }
   {
+    auto lfn = matchedLfn(url);
     std::lock_guard<std::mutex> sentry(m_servermutex);
-    m_serverhost = std::move(serverhost);
-    m_serverdomain = std::move(serverdomain);
+    if (nullptr != lfn) {
+      auto found = m_lfnToFileInfo.find(*lfn);
+      if (found != m_lfnToFileInfo.end()) {
+        found->second.m_serverhost = std::move(serverhost);
+        found->second.m_serverdomain = std::move(serverdomain);
+      }
+    } else if (m_debug) {
+      edm::LogWarning("StatisticsSenderService") << "setCurrentServer: unknown url name " << url << "\n";
+    }
   }
 }
 
-void StatisticsSenderService::setSize(size_t size) { m_size = size; }
+void StatisticsSenderService::openingFile(std::string const &lfn, size_t size) {
+  m_urlToLfn.emplace(lfn, lfn);
+  auto attempt = m_lfnToFileInfo.emplace(lfn, lfn);
+  if (attempt.second) {
+    attempt.first->second.m_size = size;
+    attempt.first->second.m_id = m_counter++;
+    edm::LogInfo("StatisticsSenderService") << "openingFile: opening " << lfn << "\n";
+  } else {
+    ++(attempt.first->second.m_openCount);
+    edm::LogInfo("StatisticsSenderService") << "openingFile: re-opening" << lfn << "\n";
+  }
+}
 
-void StatisticsSenderService::filePreCloseEvent(std::string const &lfn, bool usedFallback) {
-  m_filelfn = lfn;
-
+void StatisticsSenderService::closedFile(std::string const &url, bool usedFallback) {
   edm::Service<edm::SiteLocalConfig> pSLC;
   if (!pSLC.isAvailable()) {
     return;
   }
 
   const struct addrinfo *addresses = pSLC->statisticsDestination();
-  if (!addresses) {
+  if (!addresses and !m_debug) {
     return;
   }
 
@@ -190,22 +237,85 @@ void StatisticsSenderService::filePreCloseEvent(std::string const &lfn, bool use
     m_userdn = "not reported";
   }
 
-  std::string results;
-  fillUDP(pSLC->siteName(), usedFallback, results);
+  auto lfn = matchedLfn(url);
+  if (nullptr != lfn) {
+    auto found = m_lfnToFileInfo.find(*lfn);
+    assert(found != m_lfnToFileInfo.end());
 
-  for (const struct addrinfo *address = addresses; address != nullptr; address = address->ai_next) {
-    int sock = socket(address->ai_family, address->ai_socktype, address->ai_protocol);
-    if (sock < 0) {
-      continue;
+    std::string results;
+    fillUDP(pSLC->siteName(), found->second, usedFallback, results);
+    if (m_debug) {
+      edm::LogSystem("StatisticSenderService") << "\n" << results << "\n";
     }
-    auto close_del = [](int *iSocket) { close(*iSocket); };
-    std::unique_ptr<int, decltype(close_del)> guard(&sock, close_del);
-    if (sendto(sock, results.c_str(), results.size(), 0, address->ai_addr, address->ai_addrlen) >= 0) {
-      break;
+
+    for (const struct addrinfo *address = addresses; address != nullptr; address = address->ai_next) {
+      int sock = socket(address->ai_family, address->ai_socktype, address->ai_protocol);
+      if (sock < 0) {
+        continue;
+      }
+      auto close_del = [](int *iSocket) { close(*iSocket); };
+      std::unique_ptr<int, decltype(close_del)> guard(&sock, close_del);
+      if (sendto(sock, results.c_str(), results.size(), 0, address->ai_addr, address->ai_addrlen) >= 0) {
+        break;
+      }
     }
+
+    auto c = --found->second.m_openCount;
+    if (c == 0) {
+      edm::LogWarning("StatisticsSenderService") << "fully closed: " << *lfn << "\n";
+    } else {
+      edm::LogWarning("StatisticsSenderService") << "partially closed: " << *lfn << "\n";
+    }
+  } else if (m_debug) {
+    edm::LogWarning("StatisticsSenderService") << "closed: unknown url name " << url << "\n";
   }
+}
 
-  m_counter++;
+void StatisticsSenderService::cleanupOldFiles() {
+  //remove entries with openCount of 0
+  bool moreToTest = false;
+  do {
+    moreToTest = false;
+    for (auto it = m_lfnToFileInfo.begin(); it != m_lfnToFileInfo.end(); ++it) {
+      if (it->second.m_openCount == 0) {
+        auto lfn = it->first;
+        bool moreToTest2 = false;
+        do {
+          moreToTest2 = false;
+          for (auto it2 = m_urlToLfn.begin(); it2 != m_urlToLfn.end(); ++it2) {
+            if (it2->second == lfn) {
+              m_urlToLfn.unsafe_erase(it2);
+              moreToTest2 = true;
+              break;
+            }
+          }
+        } while (moreToTest2);
+
+        m_lfnToFileInfo.unsafe_erase(it);
+        moreToTest = true;
+        break;
+      }
+    }
+  } while (moreToTest);
+}
+
+void StatisticsSenderService::setSize(const std::string &url, size_t size) {
+  auto lfn = matchedLfn(url);
+  if (nullptr != lfn) {
+    auto itFound = m_lfnToFileInfo.find(*lfn);
+    if (itFound != m_lfnToFileInfo.end()) {
+      //do I need to synchronize?
+      itFound->second.m_size = size;
+    }
+  } else if (m_debug) {
+    edm::LogWarning("StatisticsSenderService") << "setSize: unknown url name " << url << "\n";
+  }
+}
+
+void StatisticsSenderService::filePreCloseEvent(std::string const &lfn, bool usedFallback) {
+  closedFile(lfn, usedFallback);
+  //we are at a sync point in the framwework so no new files are being opened
+  cleanupOldFiles();
 }
 
 void StatisticsSenderService::determineHostnames(void) {
@@ -225,7 +335,10 @@ void StatisticsSenderService::determineHostnames(void) {
   }
 }
 
-void StatisticsSenderService::fillUDP(const std::string &siteName, bool usedFallback, std::string &udpinfo) {
+void StatisticsSenderService::fillUDP(const std::string &siteName,
+                                      const FileInfo &fileinfo,
+                                      bool usedFallback,
+                                      std::string &udpinfo) {
   std::ostringstream os;
 
   // Header - same for all IO accesses
@@ -236,21 +349,16 @@ void StatisticsSenderService::fillUDP(const std::string &siteName, bool usedFall
   if (usedFallback) {
     os << "\"fallback\": true, ";
   }
-  std::string serverhost;
-  std::string serverdomain;
-  {
-    std::lock_guard<std::mutex> sentry(m_servermutex);
-    serverhost = m_serverhost;
-    serverdomain = m_serverdomain;
-  }
+  auto serverhost = fileinfo.m_serverhost;
+  auto serverdomain = fileinfo.m_serverdomain;
 
   os << "\"user_dn\":\"" << m_userdn << "\", ";
   os << "\"client_host\":\"" << m_clienthost << "\", ";
   os << "\"client_domain\":\"" << m_clientdomain << "\", ";
   os << "\"server_host\":\"" << serverhost << "\", ";
   os << "\"server_domain\":\"" << serverdomain << "\", ";
-  os << "\"unique_id\":\"" << m_guid << "-" << m_counter << "\", ";
-  os << "\"file_lfn\":\"" << m_filelfn << "\", ";
+  os << "\"unique_id\":\"" << m_guid << "-" << fileinfo.m_id << "\", ";
+  os << "\"file_lfn\":\"" << fileinfo.m_filelfn << "\", ";
   // Dashboard devs requested that we send out no app_info if a job ID
   // is not present in the environment.
   const char *jobId = getJobID();
@@ -258,8 +366,8 @@ void StatisticsSenderService::fillUDP(const std::string &siteName, bool usedFall
     os << "\"app_info\":\"" << jobId << "\", ";
   }
 
-  if (m_size >= 0) {
-    os << "\"file_size\":" << m_size << ", ";
+  if (fileinfo.m_size >= 0) {
+    os << "\"file_size\":" << fileinfo.m_size << ", ";
   }
 
   m_filestats.fillUDP(os);

--- a/Utilities/StorageFactory/test/BuildFile.xml
+++ b/Utilities/StorageFactory/test/BuildFile.xml
@@ -42,6 +42,7 @@
 <bin file="mkstemp.cpp" name="test_StorageFactory_Mkstemp">
 </bin>
 
+<test name="TestStatisticsSenderService" command="test_file_statistics_sender.sh"/>
 <!--
 We do not currently run the threadsafe test, as the StorageFactoryMaker is not thread-safe
 (the underlying PluginManager can be called from multiple threads, but itself is not

--- a/Utilities/StorageFactory/test/make_2nd_file_cfg.py
+++ b/Utilities/StorageFactory/test/make_2nd_file_cfg.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("SECOND")
+
+process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring("file:stat_sender_first.root"))
+
+process.o = cms.OutputModule("PoolOutputModule", fileName = cms.untracked.string("stat_sender_second.root"), outputCommands = cms.untracked.vstring("drop *"))
+
+process.ep = cms.EndPath(process.o)
+

--- a/Utilities/StorageFactory/test/make_test_files_cfg.py
+++ b/Utilities/StorageFactory/test/make_test_files_cfg.py
@@ -1,0 +1,20 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("FIRST")
+
+process.source = cms.Source("EmptySource")
+
+process.first = cms.OutputModule("PoolOutputModule", fileName = cms.untracked.string("stat_sender_first.root"))
+process.b = cms.OutputModule("PoolOutputModule", fileName = cms.untracked.string("stat_sender_b.root"))
+process.c = cms.OutputModule("PoolOutputModule", fileName = cms.untracked.string("stat_sender_c.root"))
+process.d = cms.OutputModule("PoolOutputModule", fileName = cms.untracked.string("stat_sender_d.root"))
+process.e = cms.OutputModule("PoolOutputModule", fileName = cms.untracked.string("stat_sender_e.root"))
+
+process.Thing = cms.EDProducer("ThingProducer")
+process.OtherThing = cms.EDProducer("OtherThingProducer")
+process.EventNumber = cms.EDProducer("EventNumberIntProducer")
+
+
+process.o = cms.EndPath(process.first+process.b+process.c+process.d+process.e, cms.Task(process.Thing, process.OtherThing, process.EventNumber))
+
+process.maxEvents.input = 10

--- a/Utilities/StorageFactory/test/test_file_statistics_sender.sh
+++ b/Utilities/StorageFactory/test/test_file_statistics_sender.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Pass in name and status
+function die { echo $1: status $2 ;  exit $2; }
+
+LOCAL_TEST_DIR=${CMSSW_BASE}/src/Utilities/StorageFactory/test
+LOCAL_TMP_DIR=${CMSSW_BASE}/tmp/${SCRAM_ARCH}
+
+pushd ${LOCAL_TMP_DIR}
+
+#setup files used in tests
+cmsRun ${LOCAL_TEST_DIR}/make_test_files_cfg.py &> make_test_files.log || die "cmsRun make_test_files_cfg.py" $?
+rm make_test_files.log
+cmsRun ${LOCAL_TEST_DIR}/make_2nd_file_cfg.py &> make_2nd_file.log || die "cmsRun make_2nd_file_cfg.py" $?
+rm make_2nd_file.log
+
+cmsRun ${LOCAL_TEST_DIR}/test_single_file_statistics_sender_cfg.py &> test_single_file_statistics_sender.log || die "cmsRun test_single_file_statistics_sender_cfg.py" $?
+grep -q '"file_lfn":"file:stat_sender_first.root"' test_single_file_statistics_sender.log || die "no StatisticsSenderService output for single file" 1
+rm test_single_file_statistics_sender.log
+
+cmsRun ${LOCAL_TEST_DIR}/test_multiple_files_file_statistics_sender_cfg.py &> test_multiple_files_file_statistics_sender.log || die "cmsRun test_multiple_files_file_statistics_sender_cfg.py" $?
+grep -q '"file_lfn":"file:stat_sender_b.root"' test_multiple_files_file_statistics_sender.log || die "no StatisticsSenderService output for file b in multiple files" 1
+grep -q '"file_lfn":"file:stat_sender_c.root"' test_multiple_files_file_statistics_sender.log || die "no StatisticsSenderService output for file c in multiple files" 1
+grep -q '"file_lfn":"file:stat_sender_d.root"' test_multiple_files_file_statistics_sender.log || die "no StatisticsSenderService output for file d in multiple files" 1
+grep -q '"file_lfn":"file:stat_sender_e.root"' test_multiple_files_file_statistics_sender.log || die "no StatisticsSenderService output for file e in multiple files" 1
+rm test_multiple_files_file_statistics_sender.log
+
+cmsRun ${LOCAL_TEST_DIR}/test_multi_file_statistics_sender_cfg.py &> test_multi_file_statistics_sender.log || die "cmsRun test_multi_file_statistics_sender_cfg.py" $?
+grep -q '"file_lfn":"file:stat_sender_first.root"' test_multi_file_statistics_sender.log || die "no StatisticsSenderService output for file first in multi file" 1
+grep -q '"file_lfn":"file:stat_sender_second.root"' test_multi_file_statistics_sender.log || die "no StatisticsSenderService output for file second in multi file" 1
+rm test_multi_file_statistics_sender.log
+
+cmsRun ${LOCAL_TEST_DIR}/test_secondary_file_statistics_sender_cfg.py &> test_secondary_file_statistics_sender.log || die "cmsRun test_secondary_file_statistics_sender_cfg.py" $?
+grep -q '"file_lfn":"file:stat_sender_first.root"' test_secondary_file_statistics_sender.log || die "no StatisticsSenderService output for file 'first' in secondary files"  1
+grep -q '"file_lfn":"file:stat_sender_b.root"' test_secondary_file_statistics_sender.log || die "no StatisticsSenderService output for file 'b' in secondary files"  1
+grep -q '"file_lfn":"file:stat_sender_c.root"' test_secondary_file_statistics_sender.log || die "no StatisticsSenderService output for file 'c' in secondary files"  1
+grep -q '"file_lfn":"file:stat_sender_d.root"' test_secondary_file_statistics_sender.log || die "no StatisticsSenderService output for file 'd' in secondary files"  1
+grep -q '"file_lfn":"file:stat_sender_e.root"' test_secondary_file_statistics_sender.log || die "no StatisticsSenderService output for file 'e' in secondary files"  1
+rm test_secondary_file_statistics_sender.log
+
+popd

--- a/Utilities/StorageFactory/test/test_multi_file_statistics_sender_cfg.py
+++ b/Utilities/StorageFactory/test/test_multi_file_statistics_sender_cfg.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("PoolSource", 
+                             fileNames = cms.untracked.vstring("file:stat_sender_second.root"),
+                             secondaryFileNames = cms.untracked.vstring("file:stat_sender_first.root")
+)
+
+process.add_(cms.Service("StatisticsSenderService", debug = cms.untracked.bool(True)))

--- a/Utilities/StorageFactory/test/test_multiple_files_file_statistics_sender_cfg.py
+++ b/Utilities/StorageFactory/test/test_multiple_files_file_statistics_sender_cfg.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring("file:stat_sender_b.root", "file:stat_sender_c.root", "file:stat_sender_d.root", "file:stat_sender_e.root"),
+duplicateCheckMode = cms.untracked.string('noDuplicateCheck'),
+inputCommands = cms.untracked.vstring('drop *_*_beginRun_*', 'drop *_*_endRun_*', 'drop *_*_beginLumi_*', 'drop *_*_endLumi_*')
+)
+
+process.add_(cms.Service("StatisticsSenderService", debug = cms.untracked.bool(True)))

--- a/Utilities/StorageFactory/test/test_secondary_file_statistics_sender_cfg.py
+++ b/Utilities/StorageFactory/test/test_secondary_file_statistics_sender_cfg.py
@@ -1,0 +1,44 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring("file:stat_sender_first.root"))
+
+process.b = cms.EDProducer("SecondaryProducer",
+    seq = cms.untracked.bool(True),
+    input = cms.SecSource("EmbeddedRootSource",
+        sequential = cms.untracked.bool(True),
+        fileNames = cms.untracked.vstring('file:stat_sender_b.root')
+    )
+)
+
+process.c = cms.EDProducer("SecondaryProducer",
+    seq = cms.untracked.bool(True),
+    input = cms.SecSource("EmbeddedRootSource",
+        sequential = cms.untracked.bool(True),
+        fileNames = cms.untracked.vstring('file:stat_sender_c.root')
+    )
+)
+
+process.d = cms.EDProducer("SecondaryProducer",
+    seq = cms.untracked.bool(True),
+    input = cms.SecSource("EmbeddedRootSource",
+        sequential = cms.untracked.bool(True),
+        fileNames = cms.untracked.vstring('file:stat_sender_d.root')
+    )
+)
+
+process.e = cms.EDProducer("SecondaryProducer",
+    seq = cms.untracked.bool(True),
+    input = cms.SecSource("EmbeddedRootSource",
+        sequential = cms.untracked.bool(True),
+        fileNames = cms.untracked.vstring('file:stat_sender_e.root')
+    )
+)
+
+process.pB = cms.Path(process.b)
+process.pC = cms.Path(process.c)
+process.pD = cms.Path(process.d)
+process.pE = cms.Path(process.e)
+
+process.add_(cms.Service("StatisticsSenderService", debug = cms.untracked.bool(True)))

--- a/Utilities/StorageFactory/test/test_single_file_statistics_sender_cfg.py
+++ b/Utilities/StorageFactory/test/test_single_file_statistics_sender_cfg.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring("file:stat_sender_first.root"))
+
+process.add_(cms.Service("StatisticsSenderService", debug = cms.untracked.bool(True)))
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+
+process.MessageLogger.cerr.INFO.limit = 1000

--- a/Utilities/XrdAdaptor/src/XrdRequestManager.cc
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.cc
@@ -250,7 +250,7 @@ void RequestManager::updateCurrentServer() {
     std::unique_ptr<std::string> hostname(hostname_ptr);
     edm::Service<edm::storage::StatisticsSenderService> statsService;
     if (statsService.isAvailable()) {
-      statsService->setCurrentServer(*hostname_ptr);
+      statsService->setCurrentServer(m_name, *hostname_ptr);
     }
   }
 }


### PR DESCRIPTION
#### PR description:

This PR is a combined backport of #35362 and #35505, following requests in #29412 and #36349. Includes also #36379 and #36403 as further fix and cleanup.

#### PR validation:

Unit tests pass.

