### PR TITLE
[10_6_X] Protect storage accounting UDP messages from NaN, and Use StatisticsSenderService for all framework files

### DIFF
--- a/IOPool/Input/src/EmbeddedRootSource.cc
+++ b/IOPool/Input/src/EmbeddedRootSource.cc
@@ -45,7 +45,7 @@ namespace edm {
     InputFile::reportReadBranches();
   }
 
-  void EmbeddedRootSource::closeFile_() { fileSequence_->closeFile_(); }
+  void EmbeddedRootSource::closeFile_() { fileSequence_->closeFile(); }
 
   bool EmbeddedRootSource::readOneEvent(EventPrincipal& cache,
                                         size_t& fileNameHash,

--- a/IOPool/Input/src/PoolSource.cc
+++ b/IOPool/Input/src/PoolSource.cc
@@ -162,7 +162,7 @@ namespace edm {
     return fb;
   }
 
-  void PoolSource::closeFile_() { primaryFileSequence_->closeFile_(); }
+  void PoolSource::closeFile_() { primaryFileSequence_->closeFile(); }
 
   std::shared_ptr<RunAuxiliary> PoolSource::readRunAuxiliary_() { return primaryFileSequence_->readRunAuxiliary_(); }
 

--- a/IOPool/Input/src/RootEmbeddedFileSequence.cc
+++ b/IOPool/Input/src/RootEmbeddedFileSequence.cc
@@ -108,7 +108,7 @@ namespace edm {
 
   RootEmbeddedFileSequence::~RootEmbeddedFileSequence() {}
 
-  void RootEmbeddedFileSequence::endJob() { closeFile_(); }
+  void RootEmbeddedFileSequence::endJob() { closeFile(); }
 
   void RootEmbeddedFileSequence::closeFile_() {
     // delete the RootFile object.

--- a/IOPool/Input/src/RootEmbeddedFileSequence.h
+++ b/IOPool/Input/src/RootEmbeddedFileSequence.h
@@ -39,7 +39,6 @@ namespace edm {
     RootEmbeddedFileSequence(RootEmbeddedFileSequence const&) = delete;             // Disallow copying and moving
     RootEmbeddedFileSequence& operator=(RootEmbeddedFileSequence const&) = delete;  // Disallow copying and moving
 
-    void closeFile_() override;
     void endJob();
     void skipEntries(unsigned int offset);
     bool readOneEvent(
@@ -56,6 +55,7 @@ namespace edm {
     static void fillDescription(ParameterSetDescription& desc);
 
   private:
+    void closeFile_() override;
     void initFile_(bool skipBadFiles) override;
     RootFileSharedPtr makeRootFile(std::shared_ptr<InputFile> filePtr) override;
 

--- a/IOPool/Input/src/RootInputFileSequence.cc
+++ b/IOPool/Input/src/RootInputFileSequence.cc
@@ -224,58 +224,57 @@ namespace edm {
 
     std::shared_ptr<InputFile> filePtr;
     std::list<std::string> originalInfo;
-    try {
+    {
       std::unique_ptr<InputSource::FileOpenSentry> sentry(
-          input ? std::make_unique<InputSource::FileOpenSentry>(*input, lfn_, usedFallback_) : nullptr);
-      std::unique_ptr<char[]> name(gSystem->ExpandPathName(fileName().c_str()));
-      ;
-      filePtr = std::make_shared<InputFile>(name.get(), "  Initiating request to open file ", inputType);
-    } catch (cms::Exception const& e) {
-      if (!skipBadFiles) {
-        if (hasFallbackUrl) {
-          std::ostringstream out;
-          out << e.explainSelf();
-
-          std::unique_ptr<char[]> name(gSystem->ExpandPathName(fallbackFileName().c_str()));
-          std::string pfn(name.get());
-          InputFile::reportFallbackAttempt(pfn, logicalFileName(), out.str());
-          originalInfo = e.additionalInfo();
-        } else {
-          InputFile::reportSkippedFile(fileName(), logicalFileName());
-          Exception ex(errors::FileOpenError, "", e);
-          ex.addContext("Calling RootFileSequenceBase::initTheFile()");
-          std::ostringstream out;
-          out << "Input file " << fileName() << " could not be opened.";
-          ex.addAdditionalInfo(out.str());
-          throw ex;
-        }
-      }
-    }
-    if (!filePtr && (hasFallbackUrl)) {
+          input ? std::make_unique<InputSource::FileOpenSentry>(*input, lfn_, false) : nullptr);
       try {
-        usedFallback_ = true;
-        std::unique_ptr<InputSource::FileOpenSentry> sentry(
-            input ? std::make_unique<InputSource::FileOpenSentry>(*input, lfn_, usedFallback_) : nullptr);
-        std::unique_ptr<char[]> fallbackFullName(gSystem->ExpandPathName(fallbackFileName().c_str()));
-        filePtr.reset(new InputFile(fallbackFullName.get(), "  Fallback request to file ", inputType));
+        std::unique_ptr<char[]> name(gSystem->ExpandPathName(fileName().c_str()));
+        filePtr = std::make_shared<InputFile>(name.get(), "  Initiating request to open file ", inputType);
       } catch (cms::Exception const& e) {
         if (!skipBadFiles) {
-          InputFile::reportSkippedFile(fileName(), logicalFileName());
-          Exception ex(errors::FallbackFileOpenError, "", e);
-          ex.addContext("Calling RootFileSequenceBase::initTheFile()");
-          std::ostringstream out;
-          out << "Input file " << fileName() << " could not be opened.\n";
-          out << "Fallback Input file " << fallbackFileName() << " also could not be opened.";
-          if (!originalInfo.empty()) {
-            out << std::endl << "Original exception info is above; fallback exception info is below.";
-            ex.addAdditionalInfo(out.str());
-            for (auto const& s : originalInfo) {
-              ex.addAdditionalInfo(s);
-            }
+          if (hasFallbackUrl) {
+            std::ostringstream out;
+            out << e.explainSelf();
+
+            std::unique_ptr<char[]> name(gSystem->ExpandPathName(fallbackFileName().c_str()));
+            std::string pfn(name.get());
+            InputFile::reportFallbackAttempt(pfn, logicalFileName(), out.str());
+            originalInfo = e.additionalInfo();
           } else {
+            InputFile::reportSkippedFile(fileName(), logicalFileName());
+            Exception ex(errors::FileOpenError, "", e);
+            ex.addContext("Calling RootFileSequenceBase::initTheFile()");
+            std::ostringstream out;
+            out << "Input file " << fileName() << " could not be opened.";
             ex.addAdditionalInfo(out.str());
+            throw ex;
           }
-          throw ex;
+        }
+      }
+      if (!filePtr && (hasFallbackUrl)) {
+        try {
+          usedFallback_ = true;
+          std::unique_ptr<char[]> fallbackFullName(gSystem->ExpandPathName(fallbackFileName().c_str()));
+          filePtr.reset(new InputFile(fallbackFullName.get(), "  Fallback request to file ", inputType));
+        } catch (cms::Exception const& e) {
+          if (!skipBadFiles) {
+            InputFile::reportSkippedFile(fileName(), logicalFileName());
+            Exception ex(errors::FallbackFileOpenError, "", e);
+            ex.addContext("Calling RootFileSequenceBase::initTheFile()");
+            std::ostringstream out;
+            out << "Input file " << fileName() << " could not be opened.\n";
+            out << "Fallback Input file " << fallbackFileName() << " also could not be opened.";
+            if (!originalInfo.empty()) {
+              out << std::endl << "Original exception info is above; fallback exception info is below.";
+              ex.addAdditionalInfo(out.str());
+              for (auto const& s : originalInfo) {
+                ex.addAdditionalInfo(s);
+              }
+            } else {
+              ex.addAdditionalInfo(out.str());
+            }
+            throw ex;
+          }
         }
       }
     }

--- a/IOPool/Input/src/RootInputFileSequence.cc
+++ b/IOPool/Input/src/RootInputFileSequence.cc
@@ -231,7 +231,7 @@ namespace edm {
           input ? std::make_unique<InputSource::FileOpenSentry>(*input, lfn_, false) : nullptr);
       edm::Service<edm::storage::StatisticsSenderService> service;
       if (service.isAvailable()) {
-        service->openingFile(lfn(), -1);
+        service->openingFile(lfn(), inputType, -1);
       }
       try {
         std::unique_ptr<char[]> name(gSystem->ExpandPathName(fileName().c_str()));

--- a/IOPool/Input/src/RootInputFileSequence.h
+++ b/IOPool/Input/src/RootInputFileSequence.h
@@ -48,6 +48,8 @@ namespace edm {
     std::shared_ptr<ProductRegistry const> fileProductRegistry() const;
     std::shared_ptr<BranchIDListHelper const> fileBranchIDListHelper() const;
 
+    void closeFile();
+
   protected:
     typedef std::shared_ptr<RootFile> RootFileSharedPtr;
     void initFile(bool skipBadFiles) { initFile_(skipBadFiles); }

--- a/IOPool/Input/src/RootPrimaryFileSequence.cc
+++ b/IOPool/Input/src/RootPrimaryFileSequence.cc
@@ -68,7 +68,7 @@ namespace edm {
 
   RootPrimaryFileSequence::~RootPrimaryFileSequence() {}
 
-  void RootPrimaryFileSequence::endJob() { closeFile_(); }
+  void RootPrimaryFileSequence::endJob() { closeFile(); }
 
   std::unique_ptr<FileBlock> RootPrimaryFileSequence::readFile_() {
     if (firstFile_) {
@@ -212,7 +212,7 @@ namespace edm {
   // Rewind to before the first event that was read.
   void RootPrimaryFileSequence::rewind_() {
     if (!atFirstFile()) {
-      closeFile_();
+      closeFile();
       setAtFirstFile();
     }
     if (!rootFile()) {

--- a/IOPool/Input/src/RootPrimaryFileSequence.h
+++ b/IOPool/Input/src/RootPrimaryFileSequence.h
@@ -40,7 +40,6 @@ namespace edm {
     RootPrimaryFileSequence& operator=(RootPrimaryFileSequence const&) = delete;  // Disallow copying and moving
 
     std::unique_ptr<FileBlock> readFile_();
-    void closeFile_() override;
     void endJob();
     InputSource::ItemType getNextItemType(RunNumber_t& run, LuminosityBlockNumber_t& lumi, EventNumber_t& event);
     bool skipEvents(int offset);
@@ -56,6 +55,7 @@ namespace edm {
     bool nextFile();
     bool previousFile();
     void rewindFile();
+    void closeFile_() override;
 
     int remainingEvents() const;
     int remainingLuminosityBlocks() const;

--- a/IOPool/Input/src/RootSecondaryFileSequence.cc
+++ b/IOPool/Input/src/RootSecondaryFileSequence.cc
@@ -52,7 +52,7 @@ namespace edm {
 
   RootSecondaryFileSequence::~RootSecondaryFileSequence() {}
 
-  void RootSecondaryFileSequence::endJob() { closeFile_(); }
+  void RootSecondaryFileSequence::endJob() { closeFile(); }
 
   void RootSecondaryFileSequence::closeFile_() {
     // close the currently open file, if any, and delete the RootFile object.

--- a/IOPool/Input/src/RootSecondaryFileSequence.h
+++ b/IOPool/Input/src/RootSecondaryFileSequence.h
@@ -33,11 +33,11 @@ namespace edm {
     RootSecondaryFileSequence(RootSecondaryFileSequence const&) = delete;             // Disallow copying and moving
     RootSecondaryFileSequence& operator=(RootSecondaryFileSequence const&) = delete;  // Disallow copying and moving
 
-    void closeFile_() override;
     void endJob();
     void initAssociationsFromSecondary(std::set<BranchID> const&);
 
   private:
+    void closeFile_() override;
     void initFile_(bool skipBadFiles) override;
     RootFileSharedPtr makeRootFile(std::shared_ptr<InputFile> filePtr) override;
 

--- a/IOPool/SecondaryInput/test/SecondaryProducer.h
+++ b/IOPool/SecondaryInput/test/SecondaryProducer.h
@@ -9,7 +9,7 @@
  ************************************************************/
 
 #include "DataFormats/Provenance/interface/EventID.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 #include <memory>
@@ -19,7 +19,7 @@ namespace edm {
   class ProcessConfiguration;
   class VectorInputSource;
 
-  class SecondaryProducer : public EDProducer {
+  class SecondaryProducer : public one::EDProducer<> {
   public:
     /** standard constructor*/
     explicit SecondaryProducer(ParameterSet const& pset);

--- a/IOPool/TFileAdaptor/src/TStorageFactoryFile.cc
+++ b/IOPool/TFileAdaptor/src/TStorageFactoryFile.cc
@@ -195,7 +195,7 @@ void TStorageFactoryFile::Initialize(const char *path, Option_t *option /* = "" 
   try {
     edm::Service<edm::storage::StatisticsSenderService> statsService;
     if (statsService.isAvailable()) {
-      statsService->setSize(storage_->size());
+      statsService->setSize(path, storage_->size());
     }
   } catch (edm::Exception const &e) {
     if (e.categoryCode() != edm::errors::NotFound) {

--- a/Utilities/StorageFactory/interface/StatisticsSenderService.h
+++ b/Utilities/StorageFactory/interface/StatisticsSenderService.h
@@ -9,56 +9,55 @@
 
 namespace edm {
 
-  class ParameterSet; 
+  class ParameterSet;
   class ActivityRegistry;
 
   namespace storage {
 
     class StatisticsSenderService {
+    public:
+      StatisticsSenderService(edm::ParameterSet const &pset, edm::ActivityRegistry &ar);
+
+      void setSize(size_t size);
+      void setCurrentServer(const std::string &servername);
+      void filePreCloseEvent(std::string const &lfn, bool usedFallback);
+      static const char *getJobID();
+      static bool getX509Subject(std::string &);
+
+    private:
+      class FileStatistics {
       public:
-        StatisticsSenderService(edm::ParameterSet const& pset, edm::ActivityRegistry& ar);
+        FileStatistics();
+        void fillUDP(std::ostringstream &os);
 
-        void setSize(size_t size);
-        void setCurrentServer(const std::string &servername);
-        void filePreCloseEvent(std::string const& lfn, bool usedFallback);
-        static const char * getJobID();
-        static bool getX509Subject(std::string &);
       private:
+        ssize_t m_read_single_operations;
+        ssize_t m_read_single_bytes;
+        ssize_t m_read_single_square;
+        ssize_t m_read_vector_operations;
+        ssize_t m_read_vector_bytes;
+        ssize_t m_read_vector_square;
+        ssize_t m_read_vector_count_sum;
+        ssize_t m_read_vector_count_square;
+        time_t m_start_time;
+      };
 
-        class FileStatistics {
-          public:
-            FileStatistics();
-            void fillUDP(std::ostringstream &os);
-          private:
-            ssize_t m_read_single_operations;
-            ssize_t m_read_single_bytes;
-            ssize_t m_read_single_square;
-            ssize_t m_read_vector_operations;
-            ssize_t m_read_vector_bytes;
-            ssize_t m_read_vector_square;
-            ssize_t m_read_vector_count_sum;
-            ssize_t m_read_vector_count_square;
-            time_t  m_start_time;
-        };
-
-        void determineHostnames(void);
-        void fillUDP(const std::string&, bool, std::string &);
-        std::string    m_clienthost;
-        std::string    m_clientdomain;
-        std::string    m_serverhost;
-        std::string    m_serverdomain;
-        std::string    m_filelfn;
-        FileStatistics m_filestats;
-        std::string    m_guid;
-        size_t         m_counter;
-        std::atomic<ssize_t> m_size;
-        std::string    m_userdn;
-        std::mutex     m_servermutex;
+      void determineHostnames(void);
+      void fillUDP(const std::string &, bool, std::string &);
+      std::string m_clienthost;
+      std::string m_clientdomain;
+      std::string m_serverhost;
+      std::string m_serverdomain;
+      std::string m_filelfn;
+      FileStatistics m_filestats;
+      std::string m_guid;
+      size_t m_counter;
+      std::atomic<ssize_t> m_size;
+      std::string m_userdn;
+      std::mutex m_servermutex;
     };
 
-    
-  }
-}
+  }  // namespace storage
+}  // namespace edm
 
 #endif
-

--- a/Utilities/StorageFactory/interface/StatisticsSenderService.h
+++ b/Utilities/StorageFactory/interface/StatisticsSenderService.h
@@ -7,6 +7,7 @@
 #include <atomic>
 #include <mutex>
 #include <tbb/concurrent_unordered_map.h>
+#include "FWCore/Utilities/interface/InputType.h"
 
 namespace edm {
 
@@ -24,7 +25,7 @@ namespace edm {
       static const char* getJobID();
       static bool getX509Subject(std::string&);
 
-      void openingFile(std::string const& lfn, size_t size = -1);
+      void openingFile(std::string const& lfn, edm::InputType type, size_t size = -1);
       void closedFile(std::string const& lfn, bool usedFallback);
 
     private:
@@ -50,10 +51,20 @@ namespace edm {
       };
 
       struct FileInfo {
-        explicit FileInfo(std::string const& iLFN);
+        explicit FileInfo(std::string const& iLFN, edm::InputType);
+
+        FileInfo(FileInfo&& iInfo)
+            : m_filelfn(std::move(iInfo.m_filelfn)),
+              m_serverhost(std::move(iInfo.m_serverhost)),
+              m_serverdomain(std::move(iInfo.m_serverdomain)),
+              m_type(iInfo.m_type),
+              m_size(iInfo.m_size.load()),
+              m_id(iInfo.m_id),
+              m_openCount(iInfo.m_openCount.load()) {}
         std::string m_filelfn;
         std::string m_serverhost;
         std::string m_serverdomain;
+        edm::InputType m_type;
         std::atomic<ssize_t> m_size;
         size_t m_id;  //from m_counter
         std::atomic<int> m_openCount;

--- a/Utilities/StorageFactory/interface/StatisticsSenderService.h
+++ b/Utilities/StorageFactory/interface/StatisticsSenderService.h
@@ -28,13 +28,14 @@ namespace edm {
       void closedFile(std::string const& lfn, bool usedFallback);
 
     private:
-      void filePreCloseEvent(std::string const& lfn, bool usedFallback);
+      void filePostCloseEvent(std::string const& lfn, bool usedFallback);
 
       std::string const* matchedLfn(std::string const& iURL);  //updates its internal cache
       class FileStatistics {
       public:
         FileStatistics();
-        void fillUDP(std::ostringstream& os);
+        void fillUDP(std::ostringstream& os) const;
+        void update();
 
       private:
         ssize_t m_read_single_operations;
@@ -53,13 +54,13 @@ namespace edm {
         std::string m_filelfn;
         std::string m_serverhost;
         std::string m_serverdomain;
-        ssize_t m_size;
+        std::atomic<ssize_t> m_size;
         size_t m_id;  //from m_counter
         std::atomic<int> m_openCount;
       };
 
       void determineHostnames();
-      void fillUDP(const std::string& site, const FileInfo& fileinfo, bool, std::string&);
+      void fillUDP(const std::string& site, const FileInfo& fileinfo, bool, std::string&) const;
       void cleanupOldFiles();
 
       std::string m_clienthost;

--- a/Utilities/StorageFactory/src/StatisticsSenderService.cc
+++ b/Utilities/StorageFactory/src/StatisticsSenderService.cc
@@ -42,7 +42,7 @@ StatisticsSenderService::FileStatistics::FileStatistics() :
   m_read_vector_square(0),
   m_read_vector_count_sum(0),
   m_read_vector_count_square(0),
-  m_start_time(time(NULL))
+  m_start_time(time(nullptr))
 {}
 
 void
@@ -106,7 +106,7 @@ StatisticsSenderService::FileStatistics::fillUDP(std::ostringstream &os) {
   UPDATE_AND_OUTPUT_STATISTIC(read_vector_bytes)
 
   os << "\"start_time\":" << m_start_time << ", ";
-  m_start_time = time(NULL);
+  m_start_time = time(nullptr);
   // NOTE: last entry doesn't have the trailing comma.
   os << "\"end_time\":" << m_start_time;
 }
@@ -179,7 +179,7 @@ StatisticsSenderService::filePreCloseEvent(std::string const& lfn, bool usedFall
   }
 
   std::set<std::string> const * info = pSLC->statisticsInfo();
-  if (info && info->size() && (m_userdn != "unknown") && (
+  if (info && !info->empty() && (m_userdn != "unknown") && (
       (info->find("dn") == info->end()) ||
       (info->find("nodn") != info->end()))
      )
@@ -293,7 +293,7 @@ static X509 * findEEC(STACK_OF(X509) * certstack) {
   char *subject = nullptr;
   X509 *x509cert = sk_X509_value(certstack, idx);
   for (; x509cert && idx>0; idx--) {
-    subject = X509_NAME_oneline(X509_get_subject_name(x509cert),0,0);
+    subject = X509_NAME_oneline(X509_get_subject_name(x509cert),nullptr,0);
     if (subject && priorsubject && (strncmp(subject, priorsubject, strlen(subject)) != 0)) {
       break;
     }
@@ -347,7 +347,7 @@ getX509SubjectFromFile(const std::string &filename, std::string &result) {
       x509cert = findEEC(certs);
     }
     if (x509cert) {
-      subject = X509_NAME_oneline(X509_get_subject_name(x509cert),0,0);
+      subject = X509_NAME_oneline(X509_get_subject_name(x509cert),nullptr,0);
     }
     // Note we do not free x509cert directly, as it's still owned by the certs stack.
     if (certs) {

--- a/Utilities/StorageFactory/src/StatisticsSenderService.cc
+++ b/Utilities/StorageFactory/src/StatisticsSenderService.cc
@@ -15,12 +15,11 @@
 #include <openssl/x509.h>
 #include <openssl/pem.h>
 
-#define UPDATE_STATISTIC(x) \
-    m_ ## x = x;
+#define UPDATE_STATISTIC(x) m_##x = x;
 
-#define UPDATE_AND_OUTPUT_STATISTIC(x) \
-    os << "\"" #x "\":" << (x-m_ ## x) << ", "; \
-    UPDATE_STATISTIC(x)
+#define UPDATE_AND_OUTPUT_STATISTIC(x)        \
+  os << "\"" #x "\":" << (x - m_##x) << ", "; \
+  UPDATE_STATISTIC(x)
 
 // Simple hack to define HOST_NAME_MAX on Mac.
 // Allows arrays to be statically allocated
@@ -33,20 +32,18 @@
 
 using namespace edm::storage;
 
-StatisticsSenderService::FileStatistics::FileStatistics() :
-  m_read_single_operations(0),
-  m_read_single_bytes(0),
-  m_read_single_square(0),
-  m_read_vector_operations(0),
-  m_read_vector_bytes(0),
-  m_read_vector_square(0),
-  m_read_vector_count_sum(0),
-  m_read_vector_count_square(0),
-  m_start_time(time(nullptr))
-{}
+StatisticsSenderService::FileStatistics::FileStatistics()
+    : m_read_single_operations(0),
+      m_read_single_bytes(0),
+      m_read_single_square(0),
+      m_read_vector_operations(0),
+      m_read_vector_bytes(0),
+      m_read_vector_square(0),
+      m_read_vector_count_sum(0),
+      m_read_vector_count_square(0),
+      m_start_time(time(nullptr)) {}
 
-void
-StatisticsSenderService::FileStatistics::fillUDP(std::ostringstream &os) {
+void StatisticsSenderService::FileStatistics::fillUDP(std::ostringstream &os) {
   const StorageAccount::StorageStats &stats = StorageAccount::summary();
   ssize_t read_single_operations = 0;
   ssize_t read_single_bytes = 0;
@@ -57,7 +54,7 @@ StatisticsSenderService::FileStatistics::fillUDP(std::ostringstream &os) {
   ssize_t read_vector_count_sum = 0;
   ssize_t read_vector_count_square = 0;
   auto token = StorageAccount::tokenForStorageClassName("tstoragefile");
-  for (StorageAccount::StorageStats::const_iterator i = stats.begin (); i != stats.end(); ++i) {
+  for (StorageAccount::StorageStats::const_iterator i = stats.begin(); i != stats.end(); ++i) {
     if (i->first == token.value()) {
       continue;
     }
@@ -77,27 +74,43 @@ StatisticsSenderService::FileStatistics::fillUDP(std::ostringstream &os) {
   }
   int64_t single_op_count = read_single_operations - m_read_single_operations;
   if (single_op_count > 0) {
-    double single_sum = read_single_bytes-m_read_single_bytes;
-    double single_average = single_sum/static_cast<double>(single_op_count);
-    os << "\"read_single_sigma\":" << sqrt((static_cast<double>(read_single_square-m_read_single_square) - single_average*single_average*single_op_count)/static_cast<double>(single_op_count)) << ", ";
+    double single_sum = read_single_bytes - m_read_single_bytes;
+    double single_average = single_sum / static_cast<double>(single_op_count);
+    os << "\"read_single_sigma\":"
+       << sqrt((static_cast<double>(read_single_square - m_read_single_square) -
+                single_average * single_average * single_op_count) /
+               static_cast<double>(single_op_count))
+       << ", ";
     os << "\"read_single_average\":" << single_average << ", ";
   }
   m_read_single_square = read_single_square;
   int64_t vector_op_count = read_vector_operations - m_read_vector_operations;
   if (vector_op_count > 0) {
-    double vector_average = static_cast<double>(read_vector_bytes-m_read_vector_bytes)/static_cast<double>(vector_op_count);
+    double vector_average =
+        static_cast<double>(read_vector_bytes - m_read_vector_bytes) / static_cast<double>(vector_op_count);
     os << "\"read_vector_average\":" << vector_average << ", ";
-    os << "\"read_vector_sigma\":" << sqrt((static_cast<double>(read_vector_square-m_read_vector_square) - vector_average*vector_average*vector_op_count)/static_cast<double>(vector_op_count)) << ", ";
-    double vector_count_average = static_cast<double>(read_vector_count_sum-m_read_vector_count_sum)/static_cast<double>(vector_op_count);
+    os << "\"read_vector_sigma\":"
+       << sqrt((static_cast<double>(read_vector_square - m_read_vector_square) -
+                vector_average * vector_average * vector_op_count) /
+               static_cast<double>(vector_op_count))
+       << ", ";
+    double vector_count_average =
+        static_cast<double>(read_vector_count_sum - m_read_vector_count_sum) / static_cast<double>(vector_op_count);
     os << "\"read_vector_count_average\":" << vector_count_average << ", ";
-    os << "\"read_vector_count_sigma\":" << sqrt((static_cast<double>(read_vector_count_square-m_read_vector_count_square) - vector_count_average*vector_count_average*vector_op_count)/static_cast<double>(vector_op_count)) << ", ";
+    os << "\"read_vector_count_sigma\":"
+       << sqrt((static_cast<double>(read_vector_count_square - m_read_vector_count_square) -
+                vector_count_average * vector_count_average * vector_op_count) /
+               static_cast<double>(vector_op_count))
+       << ", ";
   }
   m_read_vector_square = read_vector_square;
   m_read_vector_count_square = read_vector_count_square;
   m_read_vector_count_sum = read_vector_count_sum;
 
-  os << "\"read_bytes\":" << (read_vector_bytes + read_single_bytes - m_read_vector_bytes - m_read_single_bytes) << ", ";
-  os << "\"read_bytes_at_close\":" << (read_vector_bytes + read_single_bytes - m_read_vector_bytes - m_read_single_bytes) << ", ";
+  os << "\"read_bytes\":" << (read_vector_bytes + read_single_bytes - m_read_vector_bytes - m_read_single_bytes)
+     << ", ";
+  os << "\"read_bytes_at_close\":"
+     << (read_vector_bytes + read_single_bytes - m_read_vector_bytes - m_read_single_bytes) << ", ";
 
   // See top of file for macros; not complex, just avoiding copy/paste
   UPDATE_AND_OUTPUT_STATISTIC(read_single_operations)
@@ -111,18 +124,17 @@ StatisticsSenderService::FileStatistics::fillUDP(std::ostringstream &os) {
   os << "\"end_time\":" << m_start_time;
 }
 
-StatisticsSenderService::StatisticsSenderService(edm::ParameterSet const& /*pset*/, edm::ActivityRegistry& ar) :
-  m_clienthost("unknown"),
-  m_clientdomain("unknown"),
-  m_serverhost("unknown"),
-  m_serverdomain("unknown"),
-  m_filelfn("unknown"),
-  m_filestats(),
-  m_guid(Guid().toString()),
-  m_counter(0),
-  m_size(-1),
-  m_userdn("unknown")
-{
+StatisticsSenderService::StatisticsSenderService(edm::ParameterSet const & /*pset*/, edm::ActivityRegistry &ar)
+    : m_clienthost("unknown"),
+      m_clientdomain("unknown"),
+      m_serverhost("unknown"),
+      m_serverdomain("unknown"),
+      m_filelfn("unknown"),
+      m_filestats(),
+      m_guid(Guid().toString()),
+      m_counter(0),
+      m_size(-1),
+      m_userdn("unknown") {
   determineHostnames();
   ar.watchPreCloseFile(this, &StatisticsSenderService::filePreCloseEvent);
   if (!getX509Subject(m_userdn)) {
@@ -130,15 +142,13 @@ StatisticsSenderService::StatisticsSenderService(edm::ParameterSet const& /*pset
   }
 }
 
-const char *
-StatisticsSenderService::getJobID() {
-  const char * id = getenv(JOB_UNIQUE_ID_ENV);
+const char *StatisticsSenderService::getJobID() {
+  const char *id = getenv(JOB_UNIQUE_ID_ENV);
   // Dashboard developers requested that we migrate to this environment variable.
   return id ? id : getenv(JOB_UNIQUE_ID_ENV_V2);
 }
 
-void
-StatisticsSenderService::setCurrentServer(const std::string &servername) {
+void StatisticsSenderService::setCurrentServer(const std::string &servername) {
   size_t dot_pos = servername.find(".");
   std::string serverhost;
   std::string serverdomain;
@@ -147,7 +157,7 @@ StatisticsSenderService::setCurrentServer(const std::string &servername) {
     serverdomain = "unknown";
   } else {
     serverhost = servername.substr(0, dot_pos);
-    serverdomain = servername.substr(dot_pos+1, servername.find(":")-dot_pos-1);
+    serverdomain = servername.substr(dot_pos + 1, servername.find(":") - dot_pos - 1);
     if (serverdomain.empty()) {
       serverdomain = "unknown";
     }
@@ -159,13 +169,9 @@ StatisticsSenderService::setCurrentServer(const std::string &servername) {
   }
 }
 
-void
-StatisticsSenderService::setSize(size_t size) {
-  m_size = size;
-}
+void StatisticsSenderService::setSize(size_t size) { m_size = size; }
 
-void
-StatisticsSenderService::filePreCloseEvent(std::string const& lfn, bool usedFallback) {
+void StatisticsSenderService::filePreCloseEvent(std::string const &lfn, bool usedFallback) {
   m_filelfn = lfn;
 
   edm::Service<edm::SiteLocalConfig> pSLC;
@@ -173,17 +179,14 @@ StatisticsSenderService::filePreCloseEvent(std::string const& lfn, bool usedFall
     return;
   }
 
-  const struct addrinfo * addresses = pSLC->statisticsDestination();
+  const struct addrinfo *addresses = pSLC->statisticsDestination();
   if (!addresses) {
     return;
   }
 
-  std::set<std::string> const * info = pSLC->statisticsInfo();
-  if (info && !info->empty() && (m_userdn != "unknown") && (
-      (info->find("dn") == info->end()) ||
-      (info->find("nodn") != info->end()))
-     )
-  {
+  std::set<std::string> const *info = pSLC->statisticsInfo();
+  if (info && !info->empty() && (m_userdn != "unknown") &&
+      ((info->find("dn") == info->end()) || (info->find("nodn") != info->end()))) {
     m_userdn = "not reported";
   }
 
@@ -195,18 +198,17 @@ StatisticsSenderService::filePreCloseEvent(std::string const& lfn, bool usedFall
     if (sock < 0) {
       continue;
     }
-    auto close_del = [](int* iSocket) { close(*iSocket); };
-    std::unique_ptr<int,decltype(close_del)> guard(&sock, close_del);
+    auto close_del = [](int *iSocket) { close(*iSocket); };
+    std::unique_ptr<int, decltype(close_del)> guard(&sock, close_del);
     if (sendto(sock, results.c_str(), results.size(), 0, address->ai_addr, address->ai_addrlen) >= 0) {
-      break; 
+      break;
     }
   }
 
   m_counter++;
 }
 
-void
-StatisticsSenderService::determineHostnames(void) {
+void StatisticsSenderService::determineHostnames(void) {
   char tmpName[HOST_NAME_MAX];
   if (gethostname(tmpName, HOST_NAME_MAX) != 0) {
     // Sigh, no way to log errors from here.
@@ -218,13 +220,12 @@ StatisticsSenderService::determineHostnames(void) {
   if (dot_pos == std::string::npos) {
     m_clientdomain = "unknown";
   } else {
-    m_clientdomain = m_clienthost.substr(dot_pos+1, m_clienthost.size()-dot_pos-1);
+    m_clientdomain = m_clienthost.substr(dot_pos + 1, m_clienthost.size() - dot_pos - 1);
     m_clienthost = m_clienthost.substr(0, dot_pos);
   }
 }
 
-void
-StatisticsSenderService::fillUDP(const std::string& siteName, bool usedFallback, std::string &udpinfo) {
+void StatisticsSenderService::fillUDP(const std::string &siteName, bool usedFallback, std::string &udpinfo) {
   std::ostringstream os;
 
   // Header - same for all IO accesses
@@ -242,7 +243,7 @@ StatisticsSenderService::fillUDP(const std::string& siteName, bool usedFallback,
     serverhost = m_serverhost;
     serverdomain = m_serverdomain;
   }
-  
+
   os << "\"user_dn\":\"" << m_userdn << "\", ";
   os << "\"client_host\":\"" << m_clienthost << "\", ";
   os << "\"client_domain\":\"" << m_clientdomain << "\", ";
@@ -252,7 +253,7 @@ StatisticsSenderService::fillUDP(const std::string& siteName, bool usedFallback,
   os << "\"file_lfn\":\"" << m_filelfn << "\", ";
   // Dashboard devs requested that we send out no app_info if a job ID
   // is not present in the environment.
-  const char * jobId = getJobID();
+  const char *jobId = getJobID();
   if (jobId) {
     os << "\"app_info\":\"" << jobId << "\", ";
   }
@@ -283,17 +284,17 @@ StatisticsSenderService::fillUDP(const std::string& siteName, bool usedFallback,
  * THIS DOES NOT VERIFY THE RESULTS, and is a best-effort GUESS.
  * Again, DO NOT REUSE THIS CODE THINKING IT VERIFIES THE CHAIN!
  */
-static X509 * findEEC(STACK_OF(X509) * certstack) {
+static X509 *findEEC(STACK_OF(X509) * certstack) {
   int depth = sk_X509_num(certstack);
   if (depth == 0) {
     return nullptr;
   }
-  int idx = depth-1;
+  int idx = depth - 1;
   char *priorsubject = nullptr;
   char *subject = nullptr;
   X509 *x509cert = sk_X509_value(certstack, idx);
-  for (; x509cert && idx>0; idx--) {
-    subject = X509_NAME_oneline(X509_get_subject_name(x509cert),nullptr,0);
+  for (; x509cert && idx > 0; idx--) {
+    subject = X509_NAME_oneline(X509_get_subject_name(x509cert), nullptr, 0);
     if (subject && priorsubject && (strncmp(subject, priorsubject, strlen(subject)) != 0)) {
       break;
     }
@@ -310,8 +311,7 @@ static X509 * findEEC(STACK_OF(X509) * certstack) {
   return x509cert;
 }
 
-static bool
-getX509SubjectFromFile(const std::string &filename, std::string &result) {
+static bool getX509SubjectFromFile(const std::string &filename, std::string &result) {
   BIO *biof = nullptr;
   STACK_OF(X509) *certs = nullptr;
   char *subject = nullptr;
@@ -320,34 +320,42 @@ getX509SubjectFromFile(const std::string &filename, std::string &result) {
   char *name = nullptr;
   long len = 0U;
 
-  if((biof = BIO_new_file(filename.c_str(), "r")))  {
-
+  if ((biof = BIO_new_file(filename.c_str(), "r"))) {
     certs = sk_X509_new_null();
     bool encountered_error = false;
     while ((!encountered_error) && (!BIO_eof(biof)) && PEM_read_bio(biof, &name, &header, &data, &len)) {
       if (strcmp(name, PEM_STRING_X509) == 0 || strcmp(name, PEM_STRING_X509_OLD) == 0) {
-        X509 * tmp_cert = nullptr;
+        X509 *tmp_cert = nullptr;
         // See WARNINGS section in http://www.openssl.org/docs/crypto/d2i_X509.html
         // Without this cmsRun crashes on a mac with a valid grid proxy.
         const unsigned char *p;
-        p=data;
+        p = data;
         tmp_cert = d2i_X509(&tmp_cert, &p, len);
         if (tmp_cert) {
           sk_X509_push(certs, tmp_cert);
         } else {
           encountered_error = true;
         }
-      } // Note we ignore any proxy key in the file.
-      if (data) { OPENSSL_free(data); data = nullptr;}
-      if (header) { OPENSSL_free(header); header = nullptr;}
-      if (name) { OPENSSL_free(name); name = nullptr;}
+      }  // Note we ignore any proxy key in the file.
+      if (data) {
+        OPENSSL_free(data);
+        data = nullptr;
+      }
+      if (header) {
+        OPENSSL_free(header);
+        header = nullptr;
+      }
+      if (name) {
+        OPENSSL_free(name);
+        name = nullptr;
+      }
     }
     X509 *x509cert = nullptr;
     if (!encountered_error && sk_X509_num(certs)) {
       x509cert = findEEC(certs);
     }
     if (x509cert) {
-      subject = X509_NAME_oneline(X509_get_subject_name(x509cert),nullptr,0);
+      subject = X509_NAME_oneline(X509_get_subject_name(x509cert), nullptr, 0);
     }
     // Note we do not free x509cert directly, as it's still owned by the certs stack.
     if (certs) {
@@ -358,14 +366,13 @@ getX509SubjectFromFile(const std::string &filename, std::string &result) {
     if (subject) {
       result = subject;
       OPENSSL_free(subject);
-     return true;
+      return true;
     }
   }
   return false;
 }
 
-bool
-StatisticsSenderService::getX509Subject(std::string &result) {
+bool StatisticsSenderService::getX509Subject(std::string &result) {
   char *filename = getenv("X509_USER_PROXY");
   if (filename && getX509SubjectFromFile(filename, result)) {
     return true;

--- a/Utilities/StorageFactory/src/StatisticsSenderService.cc
+++ b/Utilities/StorageFactory/src/StatisticsSenderService.cc
@@ -297,10 +297,12 @@ void StatisticsSenderService::closedFile(std::string const &url, bool usedFallba
     }
 
     auto c = --found->second.m_openCount;
-    if (c == 0) {
-      edm::LogWarning("StatisticsSenderService") << "fully closed: " << *lfn << "\n";
-    } else {
-      edm::LogWarning("StatisticsSenderService") << "partially closed: " << *lfn << "\n";
+    if (m_debug) {
+      if (c == 0) {
+        edm::LogWarning("StatisticsSenderService") << "fully closed: " << *lfn << "\n";
+      } else {
+        edm::LogWarning("StatisticsSenderService") << "partially closed: " << *lfn << "\n";
+      }
     }
   } else if (m_debug) {
     edm::LogWarning("StatisticsSenderService") << "closed: unknown url name " << url << "\n";

--- a/Utilities/StorageFactory/src/StatisticsSenderService.cc
+++ b/Utilities/StorageFactory/src/StatisticsSenderService.cc
@@ -77,9 +77,9 @@ void StatisticsSenderService::FileStatistics::fillUDP(std::ostringstream &os) {
     double single_sum = read_single_bytes - m_read_single_bytes;
     double single_average = single_sum / static_cast<double>(single_op_count);
     os << "\"read_single_sigma\":"
-       << sqrt((static_cast<double>(read_single_square - m_read_single_square) -
-                single_average * single_average * single_op_count) /
-               static_cast<double>(single_op_count))
+       << sqrt(std::abs((static_cast<double>(read_single_square - m_read_single_square) -
+                         single_average * single_average * single_op_count) /
+                        static_cast<double>(single_op_count)))
        << ", ";
     os << "\"read_single_average\":" << single_average << ", ";
   }
@@ -90,17 +90,17 @@ void StatisticsSenderService::FileStatistics::fillUDP(std::ostringstream &os) {
         static_cast<double>(read_vector_bytes - m_read_vector_bytes) / static_cast<double>(vector_op_count);
     os << "\"read_vector_average\":" << vector_average << ", ";
     os << "\"read_vector_sigma\":"
-       << sqrt((static_cast<double>(read_vector_square - m_read_vector_square) -
-                vector_average * vector_average * vector_op_count) /
-               static_cast<double>(vector_op_count))
+       << sqrt(std::abs((static_cast<double>(read_vector_square - m_read_vector_square) -
+                         vector_average * vector_average * vector_op_count) /
+                        static_cast<double>(vector_op_count)))
        << ", ";
     double vector_count_average =
         static_cast<double>(read_vector_count_sum - m_read_vector_count_sum) / static_cast<double>(vector_op_count);
     os << "\"read_vector_count_average\":" << vector_count_average << ", ";
     os << "\"read_vector_count_sigma\":"
-       << sqrt((static_cast<double>(read_vector_count_square - m_read_vector_count_square) -
-                vector_count_average * vector_count_average * vector_op_count) /
-               static_cast<double>(vector_op_count))
+       << sqrt(std::abs((static_cast<double>(read_vector_count_square - m_read_vector_count_square) -
+                         vector_count_average * vector_count_average * vector_op_count) /
+                        static_cast<double>(vector_op_count)))
        << ", ";
   }
   m_read_vector_square = read_vector_square;

--- a/Utilities/StorageFactory/test/BuildFile.xml
+++ b/Utilities/StorageFactory/test/BuildFile.xml
@@ -37,3 +37,4 @@
 # to wait until the framework decides on a threading model to implement a fix.
 # file="threadsafe.cpp" name="test_StorageFactory_threadsafe"
 
+<test name="TestStatisticsSenderService" command="test_file_statistics_sender.sh"/>

--- a/Utilities/StorageFactory/test/make_2nd_file_cfg.py
+++ b/Utilities/StorageFactory/test/make_2nd_file_cfg.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("SECOND")
+
+process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring("file:stat_sender_first.root"))
+
+process.o = cms.OutputModule("PoolOutputModule", fileName = cms.untracked.string("stat_sender_second.root"), outputCommands = cms.untracked.vstring("drop *"))
+
+process.ep = cms.EndPath(process.o)
+

--- a/Utilities/StorageFactory/test/make_test_files_cfg.py
+++ b/Utilities/StorageFactory/test/make_test_files_cfg.py
@@ -1,0 +1,20 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("FIRST")
+
+process.source = cms.Source("EmptySource")
+
+process.first = cms.OutputModule("PoolOutputModule", fileName = cms.untracked.string("stat_sender_first.root"))
+process.b = cms.OutputModule("PoolOutputModule", fileName = cms.untracked.string("stat_sender_b.root"))
+process.c = cms.OutputModule("PoolOutputModule", fileName = cms.untracked.string("stat_sender_c.root"))
+process.d = cms.OutputModule("PoolOutputModule", fileName = cms.untracked.string("stat_sender_d.root"))
+process.e = cms.OutputModule("PoolOutputModule", fileName = cms.untracked.string("stat_sender_e.root"))
+
+process.Thing = cms.EDProducer("ThingProducer")
+process.OtherThing = cms.EDProducer("OtherThingProducer")
+process.EventNumber = cms.EDProducer("EventNumberIntProducer")
+
+
+process.o = cms.EndPath(process.first+process.b+process.c+process.d+process.e, cms.Task(process.Thing, process.OtherThing, process.EventNumber))
+
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10))

--- a/Utilities/StorageFactory/test/test_file_statistics_sender.sh
+++ b/Utilities/StorageFactory/test/test_file_statistics_sender.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Pass in name and status
+function die { echo $1: status $2 ;  exit $2; }
+
+LOCAL_TEST_DIR=${CMSSW_BASE}/src/Utilities/StorageFactory/test
+LOCAL_TMP_DIR=${CMSSW_BASE}/tmp/${SCRAM_ARCH}
+
+pushd ${LOCAL_TMP_DIR}
+
+#setup files used in tests
+cmsRun ${LOCAL_TEST_DIR}/make_test_files_cfg.py &> make_test_files.log || die "cmsRun make_test_files_cfg.py" $?
+rm make_test_files.log
+cmsRun ${LOCAL_TEST_DIR}/make_2nd_file_cfg.py &> make_2nd_file.log || die "cmsRun make_2nd_file_cfg.py" $?
+rm make_2nd_file.log
+
+cmsRun ${LOCAL_TEST_DIR}/test_single_file_statistics_sender_cfg.py &> test_single_file_statistics_sender.log || die "cmsRun test_single_file_statistics_sender_cfg.py" $?
+grep -q '"file_lfn":"file:stat_sender_first.root"' test_single_file_statistics_sender.log || die "no StatisticsSenderService output for single file" 1
+rm test_single_file_statistics_sender.log
+
+cmsRun ${LOCAL_TEST_DIR}/test_multiple_files_file_statistics_sender_cfg.py &> test_multiple_files_file_statistics_sender.log || die "cmsRun test_multiple_files_file_statistics_sender_cfg.py" $?
+grep -q '"file_lfn":"file:stat_sender_b.root"' test_multiple_files_file_statistics_sender.log || die "no StatisticsSenderService output for file b in multiple files" 1
+grep -q '"file_lfn":"file:stat_sender_c.root"' test_multiple_files_file_statistics_sender.log || die "no StatisticsSenderService output for file c in multiple files" 1
+grep -q '"file_lfn":"file:stat_sender_d.root"' test_multiple_files_file_statistics_sender.log || die "no StatisticsSenderService output for file d in multiple files" 1
+grep -q '"file_lfn":"file:stat_sender_e.root"' test_multiple_files_file_statistics_sender.log || die "no StatisticsSenderService output for file e in multiple files" 1
+rm test_multiple_files_file_statistics_sender.log
+
+cmsRun ${LOCAL_TEST_DIR}/test_multi_file_statistics_sender_cfg.py &> test_multi_file_statistics_sender.log || die "cmsRun test_multi_file_statistics_sender_cfg.py" $?
+grep -q '"file_lfn":"file:stat_sender_first.root"' test_multi_file_statistics_sender.log || die "no StatisticsSenderService output for file first in multi file" 1
+grep -q '"file_lfn":"file:stat_sender_second.root"' test_multi_file_statistics_sender.log || die "no StatisticsSenderService output for file second in multi file" 1
+rm test_multi_file_statistics_sender.log
+
+cmsRun ${LOCAL_TEST_DIR}/test_secondary_file_statistics_sender_cfg.py &> test_secondary_file_statistics_sender.log || die "cmsRun test_secondary_file_statistics_sender_cfg.py" $?
+grep -q '"file_lfn":"file:stat_sender_first.root"' test_secondary_file_statistics_sender.log || die "no StatisticsSenderService output for file 'first' in secondary files"  1
+grep -q '"file_lfn":"file:stat_sender_b.root"' test_secondary_file_statistics_sender.log || die "no StatisticsSenderService output for file 'b' in secondary files"  1
+grep -q '"file_lfn":"file:stat_sender_c.root"' test_secondary_file_statistics_sender.log || die "no StatisticsSenderService output for file 'c' in secondary files"  1
+grep -q '"file_lfn":"file:stat_sender_d.root"' test_secondary_file_statistics_sender.log || die "no StatisticsSenderService output for file 'd' in secondary files"  1
+grep -q '"file_lfn":"file:stat_sender_e.root"' test_secondary_file_statistics_sender.log || die "no StatisticsSenderService output for file 'e' in secondary files"  1
+rm test_secondary_file_statistics_sender.log
+
+popd

--- a/Utilities/StorageFactory/test/test_multi_file_statistics_sender_cfg.py
+++ b/Utilities/StorageFactory/test/test_multi_file_statistics_sender_cfg.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("PoolSource", 
+                             fileNames = cms.untracked.vstring("file:stat_sender_second.root"),
+                             secondaryFileNames = cms.untracked.vstring("file:stat_sender_first.root")
+)
+
+process.add_(cms.Service("StatisticsSenderService", debug = cms.untracked.bool(True)))

--- a/Utilities/StorageFactory/test/test_multiple_files_file_statistics_sender_cfg.py
+++ b/Utilities/StorageFactory/test/test_multiple_files_file_statistics_sender_cfg.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring("file:stat_sender_b.root", "file:stat_sender_c.root", "file:stat_sender_d.root", "file:stat_sender_e.root"),
+duplicateCheckMode = cms.untracked.string('noDuplicateCheck'),
+inputCommands = cms.untracked.vstring('drop *_*_beginRun_*', 'drop *_*_endRun_*', 'drop *_*_beginLumi_*', 'drop *_*_endLumi_*')
+)
+
+process.add_(cms.Service("StatisticsSenderService", debug = cms.untracked.bool(True)))

--- a/Utilities/StorageFactory/test/test_secondary_file_statistics_sender_cfg.py
+++ b/Utilities/StorageFactory/test/test_secondary_file_statistics_sender_cfg.py
@@ -1,0 +1,44 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring("file:stat_sender_first.root"))
+
+process.b = cms.EDProducer("SecondaryProducer",
+    seq = cms.untracked.bool(True),
+    input = cms.SecSource("EmbeddedRootSource",
+        sequential = cms.untracked.bool(True),
+        fileNames = cms.untracked.vstring('file:stat_sender_b.root')
+    )
+)
+
+process.c = cms.EDProducer("SecondaryProducer",
+    seq = cms.untracked.bool(True),
+    input = cms.SecSource("EmbeddedRootSource",
+        sequential = cms.untracked.bool(True),
+        fileNames = cms.untracked.vstring('file:stat_sender_c.root')
+    )
+)
+
+process.d = cms.EDProducer("SecondaryProducer",
+    seq = cms.untracked.bool(True),
+    input = cms.SecSource("EmbeddedRootSource",
+        sequential = cms.untracked.bool(True),
+        fileNames = cms.untracked.vstring('file:stat_sender_d.root')
+    )
+)
+
+process.e = cms.EDProducer("SecondaryProducer",
+    seq = cms.untracked.bool(True),
+    input = cms.SecSource("EmbeddedRootSource",
+        sequential = cms.untracked.bool(True),
+        fileNames = cms.untracked.vstring('file:stat_sender_e.root')
+    )
+)
+
+process.pB = cms.Path(process.b)
+process.pC = cms.Path(process.c)
+process.pD = cms.Path(process.d)
+process.pE = cms.Path(process.e)
+
+process.add_(cms.Service("StatisticsSenderService", debug = cms.untracked.bool(True)))

--- a/Utilities/StorageFactory/test/test_single_file_statistics_sender_cfg.py
+++ b/Utilities/StorageFactory/test/test_single_file_statistics_sender_cfg.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring("file:stat_sender_first.root"))
+
+process.add_(cms.Service("StatisticsSenderService", debug = cms.untracked.bool(True)))
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+
+process.MessageLogger.cerr.INFO.limit = 1000

--- a/Utilities/XrdAdaptor/src/XrdRequestManager.cc
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.cc
@@ -20,7 +20,7 @@
 #include "Utilities/XrdAdaptor/src/XrdRequestManager.h"
 #include "Utilities/XrdAdaptor/src/XrdHostHandler.hh"
 
-#define XRD_CL_MAX_CHUNK 512*1024
+#define XRD_CL_MAX_CHUNK 512 * 1024
 
 #define XRD_ADAPTOR_SHORT_OPEN_DELAY 5
 
@@ -31,35 +31,32 @@
 #define XRD_ADAPTOR_SOURCE_QUALITY_FUDGE 0
 #else
 #define XRD_ADAPTOR_OPEN_PROBE_PERCENT 10
-#define XRD_ADAPTOR_LONG_OPEN_DELAY 2*60
+#define XRD_ADAPTOR_LONG_OPEN_DELAY 2 * 60
 #define XRD_ADAPTOR_SOURCE_QUALITY_FUDGE 100
 #endif
 
 #define XRD_ADAPTOR_CHUNK_THRESHOLD 1000
 
-
 #ifdef __MACH__
 #include <mach/clock.h>
 #include <mach/mach.h>
-#define GET_CLOCK_MONOTONIC(ts) \
-{ \
-  clock_serv_t cclock; \
-  mach_timespec_t mts; \
-  host_get_clock_service(mach_host_self(), SYSTEM_CLOCK, &cclock); \
-  clock_get_time(cclock, &mts); \
-  mach_port_deallocate(mach_task_self(), cclock); \
-  ts.tv_sec = mts.tv_sec; \
-  ts.tv_nsec = mts.tv_nsec; \
-}
+#define GET_CLOCK_MONOTONIC(ts)                                      \
+  {                                                                  \
+    clock_serv_t cclock;                                             \
+    mach_timespec_t mts;                                             \
+    host_get_clock_service(mach_host_self(), SYSTEM_CLOCK, &cclock); \
+    clock_get_time(cclock, &mts);                                    \
+    mach_port_deallocate(mach_task_self(), cclock);                  \
+    ts.tv_sec = mts.tv_sec;                                          \
+    ts.tv_nsec = mts.tv_nsec;                                        \
+  }
 #else
-#define GET_CLOCK_MONOTONIC(ts) \
-  clock_gettime(CLOCK_MONOTONIC, &ts);
+#define GET_CLOCK_MONOTONIC(ts) clock_gettime(CLOCK_MONOTONIC, &ts);
 #endif
 
 using namespace XrdAdaptor;
 
-long long timeDiffMS(const timespec &a, const timespec &b)
-{
+long long timeDiffMS(const timespec &a, const timespec &b) {
   long long diff = (a.tv_sec - b.tv_sec) * 1000;
   diff += (a.tv_nsec - b.tv_nsec) / 1e6;
   return diff;
@@ -69,50 +66,44 @@ long long timeDiffMS(const timespec &a, const timespec &b)
  * We do not care about the response of sending the monitoring information;
  * this handler class simply frees any returned buffer to prevent memory leaks.
  */
-class SendMonitoringInfoHandler : boost::noncopyable, public XrdCl::ResponseHandler
-{
-    void HandleResponse(XrdCl::XRootDStatus *status, XrdCl::AnyObject *response) override
-    {
-        if (response)
-        {
-            XrdCl::Buffer *buffer = nullptr;
-            response->Get(buffer);
-            response->Set(static_cast<int*>(nullptr));
-            delete buffer;
-        }
-        // Send Info has a response object; we must delete it.
-        delete response;
-        delete status;
+class SendMonitoringInfoHandler : boost::noncopyable, public XrdCl::ResponseHandler {
+  void HandleResponse(XrdCl::XRootDStatus *status, XrdCl::AnyObject *response) override {
+    if (response) {
+      XrdCl::Buffer *buffer = nullptr;
+      response->Get(buffer);
+      response->Set(static_cast<int *>(nullptr));
+      delete buffer;
     }
+    // Send Info has a response object; we must delete it.
+    delete response;
+    delete status;
+  }
 };
 
 CMS_THREAD_SAFE SendMonitoringInfoHandler nullHandler;
 
+static void SendMonitoringInfo(XrdCl::File &file) {
+  // Do not send this to a dCache data server as they return an error.
+  // In some versions of dCache, sending the monitoring information causes
+  // the server to close the connection - resulting in failures.
+  if (Source::isDCachePool(file)) {
+    return;
+  }
 
-static void
-SendMonitoringInfo(XrdCl::File &file)
-{
-        // Do not send this to a dCache data server as they return an error.
-        // In some versions of dCache, sending the monitoring information causes
-        // the server to close the connection - resulting in failures.
-    if (Source::isDCachePool(file)) {return;}
-
-    // Send the monitoring info, if available.
-    const char * jobId = edm::storage::StatisticsSenderService::getJobID();
-    std::string lastUrl;
-    file.GetProperty("LastURL", lastUrl);
-    if (jobId && !lastUrl.empty())
-    {
-        XrdCl::URL url(lastUrl);
-        XrdCl::FileSystem fs(url);
-        if (!(fs.SendInfo(jobId, &nullHandler, 30).IsOK()))
-        {
-            edm::LogWarning("XrdAdaptorInternal") << "Failed to send the monitoring information, monitoring ID is " << jobId << ".";
-        }
-        edm::LogInfo("XrdAdaptorInternal") << "Set monitoring ID to " << jobId << ".";
+  // Send the monitoring info, if available.
+  const char *jobId = edm::storage::StatisticsSenderService::getJobID();
+  std::string lastUrl;
+  file.GetProperty("LastURL", lastUrl);
+  if (jobId && !lastUrl.empty()) {
+    XrdCl::URL url(lastUrl);
+    XrdCl::FileSystem fs(url);
+    if (!(fs.SendInfo(jobId, &nullHandler, 30).IsOK())) {
+      edm::LogWarning("XrdAdaptorInternal")
+          << "Failed to send the monitoring information, monitoring ID is " << jobId << ".";
     }
+    edm::LogInfo("XrdAdaptorInternal") << "Set monitoring ID to " << jobId << ".";
+  }
 }
-
 
 RequestManager::RequestManager(const std::string &filename, XrdCl::OpenFlags::Flags flags, XrdCl::Access::Mode perms)
     : m_serverToAdvertise(nullptr),
@@ -121,26 +112,21 @@ RequestManager::RequestManager(const std::string &filename, XrdCl::OpenFlags::Fl
       m_name(filename),
       m_flags(flags),
       m_perms(perms),
-      m_distribution(0,100),
-      m_excluded_active_count(0)
-{
-}
+      m_distribution(0, 100),
+      m_excluded_active_count(0) {}
 
-
-void
-RequestManager::initialize(std::weak_ptr<RequestManager> self)
-{
+void RequestManager::initialize(std::weak_ptr<RequestManager> self) {
   m_open_handler = OpenHandler::getInstance(self);
 
   XrdCl::Env *env = XrdCl::DefaultEnv::GetEnv();
-  if (env) {env->GetInt("StreamErrorWindow", m_timeout);}
+  if (env) {
+    env->GetInt("StreamErrorWindow", m_timeout);
+  }
 
   std::string orig_site;
-  if (!Source::getXrootdSiteFromURL(m_name, orig_site) && (orig_site.find(".") == std::string::npos))
-  {
+  if (!Source::getXrootdSiteFromURL(m_name, orig_site) && (orig_site.find(".") == std::string::npos)) {
     std::string hostname;
-    if (Source::getHostname(orig_site, hostname))
-    {
+    if (Source::getHostname(orig_site, hostname)) {
       Source::getDomain(hostname, orig_site);
     }
   }
@@ -150,26 +136,24 @@ RequestManager::initialize(std::weak_ptr<RequestManager> self)
   bool validFile = false;
   const int retries = 5;
   std::string excludeString;
-  for (int idx=0; idx<retries; idx++)
-  {
+  for (int idx = 0; idx < retries; idx++) {
     file.reset(new XrdCl::File());
     auto opaque = prepareOpaqueString();
-    std::string new_filename = m_name + (!opaque.empty() ? ((m_name.find("?") == m_name.npos) ? "?" : "&") + opaque : "");
+    std::string new_filename =
+        m_name + (!opaque.empty() ? ((m_name.find("?") == m_name.npos) ? "?" : "&") + opaque : "");
     SyncHostResponseHandler handler;
     XrdCl::XRootDStatus openStatus = file->Open(new_filename, m_flags, m_perms, &handler);
-    if (!openStatus.IsOK())
-    { // In this case, we failed immediately - this indicates we have previously tried to talk to this
+    if (!openStatus
+             .IsOK()) {  // In this case, we failed immediately - this indicates we have previously tried to talk to this
       // server and it was marked bad - xrootd couldn't even queue up the request internally!
       // In practice, we obsere this happening when the call to getXrootdSiteFromURL fails due to the
       // redirector being down or authentication failures.
       ex.clearMessage();
       ex.clearContext();
       ex.clearAdditionalInfo();
-      ex << "XrdCl::File::Open(name='" << m_name
-         << "', flags=0x" << std::hex << m_flags
-         << ", permissions=0" << std::oct << m_perms << std::dec
-         << ") => error '" << openStatus.ToStr()
-         << "' (errno=" << openStatus.errNo << ", code=" << openStatus.code << ")";
+      ex << "XrdCl::File::Open(name='" << m_name << "', flags=0x" << std::hex << m_flags << ", permissions=0"
+         << std::oct << m_perms << std::dec << ") => error '" << openStatus.ToStr() << "' (errno=" << openStatus.errNo
+         << ", code=" << openStatus.code << ")";
       ex.addContext("Calling XrdFile::open()");
       ex.addAdditionalInfo("Remote server already encountered a fatal error; no redirections were performed.");
       throw ex;
@@ -179,56 +163,46 @@ RequestManager::initialize(std::weak_ptr<RequestManager> self)
     std::unique_ptr<XrdCl::HostList> hostList = handler.GetHosts();
     Source::determineHostExcludeString(*file, hostList.get(), excludeString);
     assert(status);
-    if (status->IsOK())
-    {
+    if (status->IsOK()) {
       validFile = true;
       break;
-    }
-    else
-    {
+    } else {
       ex.clearMessage();
       ex.clearContext();
       ex.clearAdditionalInfo();
-      ex << "XrdCl::File::Open(name='" << m_name
-         << "', flags=0x" << std::hex << m_flags
-         << ", permissions=0" << std::oct << m_perms << std::dec
-         << ") => error '" << status->ToStr()
-         << "' (errno=" << status->errNo << ", code=" << status->code << ")";
+      ex << "XrdCl::File::Open(name='" << m_name << "', flags=0x" << std::hex << m_flags << ", permissions=0"
+         << std::oct << m_perms << std::dec << ") => error '" << status->ToStr() << "' (errno=" << status->errNo
+         << ", code=" << status->code << ")";
       ex.addContext("Calling XrdFile::open()");
       addConnections(ex);
       std::string dataServer, lastUrl;
       file->GetProperty("DataServer", dataServer);
       file->GetProperty("LastURL", lastUrl);
-      if (!dataServer.empty())
-      {
+      if (!dataServer.empty()) {
         ex.addAdditionalInfo("Problematic data server: " + dataServer);
       }
-      if (!lastUrl.empty())
-      {
+      if (!lastUrl.empty()) {
         ex.addAdditionalInfo("Last URL tried: " + lastUrl);
         edm::LogWarning("XrdAdaptorInternal") << "Failed to open file at URL " << lastUrl << ".";
       }
-      if (std::find(m_disabledSourceStrings.begin(), m_disabledSourceStrings.end(), dataServer) != m_disabledSourceStrings.end())
-      {
+      if (std::find(m_disabledSourceStrings.begin(), m_disabledSourceStrings.end(), dataServer) !=
+          m_disabledSourceStrings.end()) {
         ex << ". No additional data servers were found.";
         throw ex;
       }
-      if (!dataServer.empty())
-      {
+      if (!dataServer.empty()) {
         m_disabledSourceStrings.insert(dataServer);
         m_disabledExcludeStrings.insert(excludeString);
       }
       // In this case, we didn't go anywhere - we stayed at the redirector and it gave us a file-not-found.
-      if (lastUrl == new_filename)
-      {
+      if (lastUrl == new_filename) {
         edm::LogWarning("XrdAdaptorInternal") << lastUrl << ", " << new_filename;
         throw ex;
       }
     }
   }
-  if (!validFile)
-  {
-      throw ex;
+  if (!validFile) {
+    throw ex;
   }
   SendMonitoringInfo(*file);
 
@@ -257,221 +231,223 @@ RequestManager::initialize(std::weak_ptr<RequestManager> self)
  * from an edm-managed thread.  It CANNOT be called from an Xrootd-managed
  * thread.
  */
-void
-RequestManager::updateCurrentServer()
-{
-    // NOTE: we use memory_order_relaxed here, meaning that we may actually miss
-    // a pending update.  *However*, since we call this for every read, we'll get it
-    // eventually.
-    if (LIKELY(!m_serverToAdvertise.load(std::memory_order_relaxed))) {return;}
-    std::string *hostname_ptr;
-    if ((hostname_ptr = m_serverToAdvertise.exchange(nullptr)))
-    {
-        std::unique_ptr<std::string> hostname(hostname_ptr);
-        edm::Service<edm::storage::StatisticsSenderService> statsService;
-        if (statsService.isAvailable()) {
-            statsService->setCurrentServer(*hostname_ptr);
-        }
+void RequestManager::updateCurrentServer() {
+  // NOTE: we use memory_order_relaxed here, meaning that we may actually miss
+  // a pending update.  *However*, since we call this for every read, we'll get it
+  // eventually.
+  if (LIKELY(!m_serverToAdvertise.load(std::memory_order_relaxed))) {
+    return;
+  }
+  std::string *hostname_ptr;
+  if ((hostname_ptr = m_serverToAdvertise.exchange(nullptr))) {
+    std::unique_ptr<std::string> hostname(hostname_ptr);
+    edm::Service<edm::storage::StatisticsSenderService> statsService;
+    if (statsService.isAvailable()) {
+      statsService->setCurrentServer(*hostname_ptr);
     }
+  }
 }
 
-
-void
-RequestManager::queueUpdateCurrentServer(const std::string &id)
-{
-    auto hostname = std::make_unique<std::string>(id);
-    if (Source::getHostname(id, *hostname))
-    {
-        std::string *null_hostname = nullptr;
-        if (m_serverToAdvertise.compare_exchange_strong(null_hostname, hostname.get()))
-        {
-            hostname.release();
-        }
+void RequestManager::queueUpdateCurrentServer(const std::string &id) {
+  auto hostname = std::make_unique<std::string>(id);
+  if (Source::getHostname(id, *hostname)) {
+    std::string *null_hostname = nullptr;
+    if (m_serverToAdvertise.compare_exchange_strong(null_hostname, hostname.get())) {
+      hostname.release();
     }
+  }
 }
 
-namespace  {
-  std::string formatSites(std::vector<std::shared_ptr<Source> > const& iSources) {
+namespace {
+  std::string formatSites(std::vector<std::shared_ptr<Source>> const &iSources) {
     std::string siteA, siteB;
-    if (!iSources.empty()) {siteA = iSources[0]->Site();}
-    if (iSources.size() == 2) {siteB = iSources[1]->Site();}
+    if (!iSources.empty()) {
+      siteA = iSources[0]->Site();
+    }
+    if (iSources.size() == 2) {
+      siteB = iSources[1]->Site();
+    }
     std::string siteList = siteA;
-    if (!siteB.empty() && (siteB != siteA)) {siteList = siteA + ", " + siteB;}
+    if (!siteB.empty() && (siteB != siteA)) {
+      siteList = siteA + ", " + siteB;
+    }
     return siteList;
   }
-}
-  
-void
-RequestManager::reportSiteChange(std::vector<std::shared_ptr<Source> > const& iOld,
-                               std::vector<std::shared_ptr<Source> > const& iNew,
-                               std::string orig_site) const
-{
+}  // namespace
+
+void RequestManager::reportSiteChange(std::vector<std::shared_ptr<Source>> const &iOld,
+                                      std::vector<std::shared_ptr<Source>> const &iNew,
+                                      std::string orig_site) const {
   auto siteList = formatSites(iNew);
-  if (!orig_site.empty() && (orig_site != siteList))
-  {
+  if (!orig_site.empty() && (orig_site != siteList)) {
     edm::LogWarning("XrdAdaptor") << "Data is served from " << siteList << " instead of original site " << orig_site;
-  }
-  else {
+  } else {
     auto oldSites = formatSites(iOld);
-    if (orig_site.empty() && (siteList != oldSites))
-    {
-      if (!oldSites.empty() )
+    if (orig_site.empty() && (siteList != oldSites)) {
+      if (!oldSites.empty())
         edm::LogWarning("XrdAdaptor") << "Data is now served from " << siteList << " instead of previous " << oldSites;
     }
   }
 }
 
-
-void
-RequestManager::checkSources(timespec &now, IOSize requestSize,
-                             std::vector<std::shared_ptr<Source>>& activeSources,
-                             std::vector<std::shared_ptr<Source>>& inactiveSources)
-{
-  edm::LogVerbatim("XrdAdaptorInternal") << "Time since last check "
-    << timeDiffMS(now, m_lastSourceCheck) << "; last check "
-    << m_lastSourceCheck.tv_sec << "; now " <<now.tv_sec
-    << "; next check " << m_nextActiveSourceCheck.tv_sec << std::endl;  
-  if (timeDiffMS(now, m_lastSourceCheck) > 1000)
-  {
-    { // Be more aggressive about getting rid of very bad sources.
+void RequestManager::checkSources(timespec &now,
+                                  IOSize requestSize,
+                                  std::vector<std::shared_ptr<Source>> &activeSources,
+                                  std::vector<std::shared_ptr<Source>> &inactiveSources) {
+  edm::LogVerbatim("XrdAdaptorInternal") << "Time since last check " << timeDiffMS(now, m_lastSourceCheck)
+                                         << "; last check " << m_lastSourceCheck.tv_sec << "; now " << now.tv_sec
+                                         << "; next check " << m_nextActiveSourceCheck.tv_sec << std::endl;
+  if (timeDiffMS(now, m_lastSourceCheck) > 1000) {
+    {  // Be more aggressive about getting rid of very bad sources.
       compareSources(now, 0, 1, activeSources, inactiveSources);
       compareSources(now, 1, 0, activeSources, inactiveSources);
     }
-    if (timeDiffMS(now, m_nextActiveSourceCheck) > 0)
-    {
+    if (timeDiffMS(now, m_nextActiveSourceCheck) > 0) {
       checkSourcesImpl(now, requestSize, activeSources, inactiveSources);
     }
   }
 }
 
-
-bool
-RequestManager::compareSources(const timespec &now, unsigned a, unsigned b,
-                               std::vector<std::shared_ptr<Source>>& activeSources,
-                               std::vector<std::shared_ptr<Source>>& inactiveSources) const
-{
-  if (activeSources.size() < std::max(a, b)+1) {return false;}
+bool RequestManager::compareSources(const timespec &now,
+                                    unsigned a,
+                                    unsigned b,
+                                    std::vector<std::shared_ptr<Source>> &activeSources,
+                                    std::vector<std::shared_ptr<Source>> &inactiveSources) const {
+  if (activeSources.size() < std::max(a, b) + 1) {
+    return false;
+  }
 
   bool findNewSource = false;
   if ((activeSources[a]->getQuality() > 5130) ||
-     ((activeSources[a]->getQuality() > 260) && (activeSources[b]->getQuality()*4 < activeSources[a]->getQuality())))
-  {
-    edm::LogVerbatim("XrdAdaptorInternal") << "Removing "
-          << activeSources[a]->PrettyID() << " from active sources due to poor quality ("
-          << activeSources[a]->getQuality() << " vs " << activeSources[b]->getQuality() << ")" << std::endl;
-    if (activeSources[a]->getLastDowngrade().tv_sec != 0) {findNewSource = true;}
+      ((activeSources[a]->getQuality() > 260) &&
+       (activeSources[b]->getQuality() * 4 < activeSources[a]->getQuality()))) {
+    edm::LogVerbatim("XrdAdaptorInternal")
+        << "Removing " << activeSources[a]->PrettyID() << " from active sources due to poor quality ("
+        << activeSources[a]->getQuality() << " vs " << activeSources[b]->getQuality() << ")" << std::endl;
+    if (activeSources[a]->getLastDowngrade().tv_sec != 0) {
+      findNewSource = true;
+    }
     activeSources[a]->setLastDowngrade(now);
     inactiveSources.emplace_back(activeSources[a]);
     auto oldSources = activeSources;
-    activeSources.erase(activeSources.begin()+a);
-    reportSiteChange(oldSources,activeSources);
+    activeSources.erase(activeSources.begin() + a);
+    reportSiteChange(oldSources, activeSources);
   }
   return findNewSource;
 }
 
-void
-RequestManager::checkSourcesImpl(timespec &now,
-                                 IOSize requestSize,
-                                 std::vector<std::shared_ptr<Source>>& activeSources,
-                                 std::vector<std::shared_ptr<Source>>& inactiveSources)
-{
-
+void RequestManager::checkSourcesImpl(timespec &now,
+                                      IOSize requestSize,
+                                      std::vector<std::shared_ptr<Source>> &activeSources,
+                                      std::vector<std::shared_ptr<Source>> &inactiveSources) {
   bool findNewSource = false;
-  if (activeSources.size() <= 1)
-  {
+  if (activeSources.size() <= 1) {
     findNewSource = true;
-  }
-  else if (activeSources.size() > 1)
-  {
-    edm::LogVerbatim("XrdAdaptorInternal") << "Source 0 quality " << activeSources[0]->getQuality() << ", source 1 quality " << activeSources[1]->getQuality() << std::endl;
-    findNewSource |= compareSources(now, 0, 1, activeSources,inactiveSources);
-    findNewSource |= compareSources(now, 1, 0,activeSources, inactiveSources);
+  } else if (activeSources.size() > 1) {
+    edm::LogVerbatim("XrdAdaptorInternal") << "Source 0 quality " << activeSources[0]->getQuality()
+                                           << ", source 1 quality " << activeSources[1]->getQuality() << std::endl;
+    findNewSource |= compareSources(now, 0, 1, activeSources, inactiveSources);
+    findNewSource |= compareSources(now, 1, 0, activeSources, inactiveSources);
 
     // NOTE: We could probably replace the copy with a better sort function.
     // However, there are typically very few sources and the correctness is more obvious right now.
-    std::vector<std::shared_ptr<Source> > eligibleInactiveSources; eligibleInactiveSources.reserve(inactiveSources.size());
-    for (const auto & source : inactiveSources)
-    {
-      if (timeDiffMS(now, source->getLastDowngrade()) > (XRD_ADAPTOR_SHORT_OPEN_DELAY-1)*1000) {eligibleInactiveSources.push_back(source);}
+    std::vector<std::shared_ptr<Source>> eligibleInactiveSources;
+    eligibleInactiveSources.reserve(inactiveSources.size());
+    for (const auto &source : inactiveSources) {
+      if (timeDiffMS(now, source->getLastDowngrade()) > (XRD_ADAPTOR_SHORT_OPEN_DELAY - 1) * 1000) {
+        eligibleInactiveSources.push_back(source);
+      }
     }
-    auto bestInactiveSource = std::min_element(eligibleInactiveSources.begin(), eligibleInactiveSources.end(),
-        [](const std::shared_ptr<Source> &s1, const std::shared_ptr<Source> &s2) {return s1->getQuality() < s2->getQuality();});
-    auto worstActiveSource = std::max_element(activeSources.cbegin(), activeSources.cend(),
-        [](const std::shared_ptr<Source> &s1, const std::shared_ptr<Source> &s2) {return s1->getQuality() < s2->getQuality();});
-    if (bestInactiveSource != eligibleInactiveSources.end() && bestInactiveSource->get())
-    {
-      edm::LogVerbatim("XrdAdaptorInternal") << "Best inactive source: " <<(*bestInactiveSource)->PrettyID()
-            << ", quality " << (*bestInactiveSource)->getQuality();
+    auto bestInactiveSource =
+        std::min_element(eligibleInactiveSources.begin(),
+                         eligibleInactiveSources.end(),
+                         [](const std::shared_ptr<Source> &s1, const std::shared_ptr<Source> &s2) {
+                           return s1->getQuality() < s2->getQuality();
+                         });
+    auto worstActiveSource = std::max_element(activeSources.cbegin(),
+                                              activeSources.cend(),
+                                              [](const std::shared_ptr<Source> &s1, const std::shared_ptr<Source> &s2) {
+                                                return s1->getQuality() < s2->getQuality();
+                                              });
+    if (bestInactiveSource != eligibleInactiveSources.end() && bestInactiveSource->get()) {
+      edm::LogVerbatim("XrdAdaptorInternal") << "Best inactive source: " << (*bestInactiveSource)->PrettyID()
+                                             << ", quality " << (*bestInactiveSource)->getQuality();
     }
-    edm::LogVerbatim("XrdAdaptorInternal") << "Worst active source: " <<(*worstActiveSource)->PrettyID() 
-        << ", quality " << (*worstActiveSource)->getQuality();
-        // Only upgrade the source if we only have one source and the best inactive one isn't too horrible.
-        // Regardless, we will want to re-evaluate the new source quickly (within 5s).
-    if ((bestInactiveSource != eligibleInactiveSources.end()) && activeSources.size() == 1 && ((*bestInactiveSource)->getQuality() < 4*activeSources[0]->getQuality()))
-    {
-        auto oldSources = activeSources;
-        activeSources.push_back(*bestInactiveSource);
-        reportSiteChange(oldSources, activeSources);
-        for (auto it = inactiveSources.begin(); it != inactiveSources.end(); it++) if (it->get() == bestInactiveSource->get()) {inactiveSources.erase(it); break;}
-    }
-    else while ((bestInactiveSource != eligibleInactiveSources.end()) && (*worstActiveSource)->getQuality() > (*bestInactiveSource)->getQuality()+XRD_ADAPTOR_SOURCE_QUALITY_FUDGE)
-    {
-        edm::LogVerbatim("XrdAdaptorInternal") << "Removing " << (*worstActiveSource)->PrettyID()
-            << " from active sources due to quality (" << (*worstActiveSource)->getQuality()
-            << ") and promoting " << (*bestInactiveSource)->PrettyID() << " (quality: "
-            << (*bestInactiveSource)->getQuality() << ")" << std::endl;
+    edm::LogVerbatim("XrdAdaptorInternal") << "Worst active source: " << (*worstActiveSource)->PrettyID()
+                                           << ", quality " << (*worstActiveSource)->getQuality();
+    // Only upgrade the source if we only have one source and the best inactive one isn't too horrible.
+    // Regardless, we will want to re-evaluate the new source quickly (within 5s).
+    if ((bestInactiveSource != eligibleInactiveSources.end()) && activeSources.size() == 1 &&
+        ((*bestInactiveSource)->getQuality() < 4 * activeSources[0]->getQuality())) {
+      auto oldSources = activeSources;
+      activeSources.push_back(*bestInactiveSource);
+      reportSiteChange(oldSources, activeSources);
+      for (auto it = inactiveSources.begin(); it != inactiveSources.end(); it++)
+        if (it->get() == bestInactiveSource->get()) {
+          inactiveSources.erase(it);
+          break;
+        }
+    } else
+      while ((bestInactiveSource != eligibleInactiveSources.end()) &&
+             (*worstActiveSource)->getQuality() >
+                 (*bestInactiveSource)->getQuality() + XRD_ADAPTOR_SOURCE_QUALITY_FUDGE) {
+        edm::LogVerbatim("XrdAdaptorInternal")
+            << "Removing " << (*worstActiveSource)->PrettyID() << " from active sources due to quality ("
+            << (*worstActiveSource)->getQuality() << ") and promoting " << (*bestInactiveSource)->PrettyID()
+            << " (quality: " << (*bestInactiveSource)->getQuality() << ")" << std::endl;
         (*worstActiveSource)->setLastDowngrade(now);
-        for (auto it = inactiveSources.begin(); it != inactiveSources.end(); it++) if (it->get() == bestInactiveSource->get()) {inactiveSources.erase(it); break;}
+        for (auto it = inactiveSources.begin(); it != inactiveSources.end(); it++)
+          if (it->get() == bestInactiveSource->get()) {
+            inactiveSources.erase(it);
+            break;
+          }
         inactiveSources.emplace_back(std::move(*worstActiveSource));
         auto oldSources = activeSources;
         activeSources.erase(worstActiveSource);
         activeSources.emplace_back(std::move(*bestInactiveSource));
         reportSiteChange(oldSources, activeSources);
         eligibleInactiveSources.clear();
-        for (const auto & source : inactiveSources) if (timeDiffMS(now, source->getLastDowngrade()) > (XRD_ADAPTOR_LONG_OPEN_DELAY-1)*1000) eligibleInactiveSources.push_back(source);
-        bestInactiveSource = std::min_element(eligibleInactiveSources.begin(), eligibleInactiveSources.end(),
-            [](const std::shared_ptr<Source> &s1, const std::shared_ptr<Source> &s2) {return s1->getQuality() < s2->getQuality();});
-        worstActiveSource = std::max_element(activeSources.begin(), activeSources.end(),
-            [](const std::shared_ptr<Source> &s1, const std::shared_ptr<Source> &s2) {return s1->getQuality() < s2->getQuality();});
-    }
-    if (!findNewSource && (timeDiffMS(now, m_lastSourceCheck) > 1000*XRD_ADAPTOR_LONG_OPEN_DELAY))
-    {
-        float r = m_distribution(m_generator);
-        if (r < XRD_ADAPTOR_OPEN_PROBE_PERCENT)
-        {
-            findNewSource = true;
-        }
+        for (const auto &source : inactiveSources)
+          if (timeDiffMS(now, source->getLastDowngrade()) > (XRD_ADAPTOR_LONG_OPEN_DELAY - 1) * 1000)
+            eligibleInactiveSources.push_back(source);
+        bestInactiveSource = std::min_element(eligibleInactiveSources.begin(),
+                                              eligibleInactiveSources.end(),
+                                              [](const std::shared_ptr<Source> &s1, const std::shared_ptr<Source> &s2) {
+                                                return s1->getQuality() < s2->getQuality();
+                                              });
+        worstActiveSource = std::max_element(activeSources.begin(),
+                                             activeSources.end(),
+                                             [](const std::shared_ptr<Source> &s1, const std::shared_ptr<Source> &s2) {
+                                               return s1->getQuality() < s2->getQuality();
+                                             });
+      }
+    if (!findNewSource && (timeDiffMS(now, m_lastSourceCheck) > 1000 * XRD_ADAPTOR_LONG_OPEN_DELAY)) {
+      float r = m_distribution(m_generator);
+      if (r < XRD_ADAPTOR_OPEN_PROBE_PERCENT) {
+        findNewSource = true;
+      }
     }
   }
-  if (findNewSource)
-  {
+  if (findNewSource) {
     m_open_handler->open();
     m_lastSourceCheck = now;
   }
 
   // Only aggressively look for new sources if we don't have two.
-  if (activeSources.size() == 2)
-  {
+  if (activeSources.size() == 2) {
     now.tv_sec += XRD_ADAPTOR_LONG_OPEN_DELAY - XRD_ADAPTOR_SHORT_OPEN_DELAY;
-  }
-  else
-  {
+  } else {
     now.tv_sec += XRD_ADAPTOR_SHORT_OPEN_DELAY;
   }
   m_nextActiveSourceCheck = now;
 }
 
-std::shared_ptr<XrdCl::File>
-RequestManager::getActiveFile() const
-{
+std::shared_ptr<XrdCl::File> RequestManager::getActiveFile() const {
   std::lock_guard<std::recursive_mutex> sentry(m_source_mutex);
-  if (m_activeSources.empty())
-  {
+  if (m_activeSources.empty()) {
     edm::Exception ex(edm::errors::FileReadError);
-    ex << "XrdAdaptor::RequestManager::getActiveFile(name='" << m_name
-       << "', flags=0x" << std::hex << m_flags
-       << ", permissions=0" << std::oct << m_perms << std::dec
-       << ") => Source used after fatal exception.";
+    ex << "XrdAdaptor::RequestManager::getActiveFile(name='" << m_name << "', flags=0x" << std::hex << m_flags
+       << ", permissions=0" << std::oct << m_perms << std::dec << ") => Source used after fatal exception.";
     ex.addContext("In XrdAdaptor::RequestManager::handle()");
     addConnections(ex);
     throw ex;
@@ -479,93 +455,69 @@ RequestManager::getActiveFile() const
   return m_activeSources[0]->getFileHandle();
 }
 
-void
-RequestManager::getActiveSourceNames(std::vector<std::string> & sources) const
-{
+void RequestManager::getActiveSourceNames(std::vector<std::string> &sources) const {
   std::lock_guard<std::recursive_mutex> sentry(m_source_mutex);
   sources.reserve(m_activeSources.size());
-  for (auto const& source : m_activeSources) {
+  for (auto const &source : m_activeSources) {
     sources.push_back(source->ID());
   }
 }
 
-void
-RequestManager::getPrettyActiveSourceNames(std::vector<std::string> & sources) const
-{
+void RequestManager::getPrettyActiveSourceNames(std::vector<std::string> &sources) const {
   std::lock_guard<std::recursive_mutex> sentry(m_source_mutex);
   sources.reserve(m_activeSources.size());
-  for (auto const& source : m_activeSources) {
+  for (auto const &source : m_activeSources) {
     sources.push_back(source->PrettyID());
   }
 }
 
-void
-RequestManager::getDisabledSourceNames(std::vector<std::string> & sources) const
-{
+void RequestManager::getDisabledSourceNames(std::vector<std::string> &sources) const {
   sources.reserve(m_disabledSourceStrings.size());
-  for (auto const& source : m_disabledSourceStrings) {
+  for (auto const &source : m_disabledSourceStrings) {
     sources.push_back(source);
   }
 }
 
-void
-RequestManager::addConnections(cms::Exception &ex) const
-{
+void RequestManager::addConnections(cms::Exception &ex) const {
   std::vector<std::string> sources;
   getPrettyActiveSourceNames(sources);
-  for (auto const& source : sources)
-  {
+  for (auto const &source : sources) {
     ex.addAdditionalInfo("Active source: " + source);
   }
   sources.clear();
   getDisabledSourceNames(sources);
-  for (auto const& source : sources)
-  {
+  for (auto const &source : sources) {
     ex.addAdditionalInfo("Disabled source: " + source);
   }
 }
 
-std::shared_ptr<Source>
-RequestManager::pickSingleSource()
-{
+std::shared_ptr<Source> RequestManager::pickSingleSource() {
   std::shared_ptr<Source> source = nullptr;
   {
     std::lock_guard<std::recursive_mutex> sentry(m_source_mutex);
-    if (m_activeSources.size() == 2)
-    {
-        if (m_nextInitialSourceToggle)
-        {
-            source = m_activeSources[0];
-            m_nextInitialSourceToggle = false;
-        }
-        else
-        {
-            source = m_activeSources[1];
-            m_nextInitialSourceToggle = true;
-        }
-    }
-    else if (m_activeSources.empty())
-    {
-        edm::Exception ex(edm::errors::FileReadError);
-        ex << "XrdAdaptor::RequestManager::handle read(name='" << m_name
-               << "', flags=0x" << std::hex << m_flags
-               << ", permissions=0" << std::oct << m_perms << std::dec
-               << ") => Source used after fatal exception.";
-        ex.addContext("In XrdAdaptor::RequestManager::handle()");
-        addConnections(ex);
-        throw ex;
-    }
-    else
-    {
+    if (m_activeSources.size() == 2) {
+      if (m_nextInitialSourceToggle) {
         source = m_activeSources[0];
+        m_nextInitialSourceToggle = false;
+      } else {
+        source = m_activeSources[1];
+        m_nextInitialSourceToggle = true;
+      }
+    } else if (m_activeSources.empty()) {
+      edm::Exception ex(edm::errors::FileReadError);
+      ex << "XrdAdaptor::RequestManager::handle read(name='" << m_name << "', flags=0x" << std::hex << m_flags
+         << ", permissions=0" << std::oct << m_perms << std::dec << ") => Source used after fatal exception.";
+      ex.addContext("In XrdAdaptor::RequestManager::handle()");
+      addConnections(ex);
+      throw ex;
+    } else {
+      source = m_activeSources[0];
     }
   }
   return source;
 }
 
-std::future<IOSize>
-RequestManager::handle(std::shared_ptr<XrdAdaptor::ClientRequest> c_ptr)
-{
+std::future<IOSize> RequestManager::handle(std::shared_ptr<XrdAdaptor::ClientRequest> c_ptr) {
   assert(c_ptr.get());
   timespec now;
   GET_CLOCK_MONOTONIC(now);
@@ -578,7 +530,7 @@ RequestManager::handle(std::shared_ptr<XrdAdaptor::ClientRequest> c_ptr)
   }
   {
     //make sure we update values before calling pickSingelSource
-    std::shared_ptr<void*> guard(nullptr, [this, &activeSources, &inactiveSources](void *) {
+    std::shared_ptr<void *> guard(nullptr, [this, &activeSources, &inactiveSources](void *) {
       std::lock_guard<std::recursive_mutex> sentry(m_source_mutex);
       m_activeSources = std::move(activeSources);
       m_inactiveSources = std::move(inactiveSources);
@@ -586,491 +538,435 @@ RequestManager::handle(std::shared_ptr<XrdAdaptor::ClientRequest> c_ptr)
 
     checkSources(now, c_ptr->getSize(), activeSources, inactiveSources);
   }
-  
+
   std::shared_ptr<Source> source = pickSingleSource();
   source->handle(c_ptr);
   return c_ptr->get_future();
 }
 
-std::string
-RequestManager::prepareOpaqueString() const
-{
-    std::stringstream ss;
-    ss << "tried=";
-    size_t count = 0;
-    {
-        std::lock_guard<std::recursive_mutex> sentry(m_source_mutex);
-
-        for ( const auto & it : m_activeSources )
-        {
-            count++;
-            ss << it->ExcludeID().substr(0, it->ExcludeID().find(":")) << ",";
-        }
-        for ( const auto & it : m_inactiveSources )
-        {
-            count++;
-            ss << it->ExcludeID().substr(0, it->ExcludeID().find(":")) << ",";
-        }
-    }
-    for ( const auto & it : m_disabledExcludeStrings )
-    {
-        count++;
-        ss << it.substr(0, it.find(":")) << ",";
-    }
-    if (count)
-    {
-        std::string tmp_str = ss.str();
-        return tmp_str.substr(0, tmp_str.size()-1);
-    }
-    return "";
-}
-
-void 
-XrdAdaptor::RequestManager::handleOpen(XrdCl::XRootDStatus &status, std::shared_ptr<Source> source)
-{
+std::string RequestManager::prepareOpaqueString() const {
+  std::stringstream ss;
+  ss << "tried=";
+  size_t count = 0;
+  {
     std::lock_guard<std::recursive_mutex> sentry(m_source_mutex);
-    if (status.IsOK())
-    {
-        edm::LogVerbatim("XrdAdaptorInternal") << "Successfully opened new source: " << source->PrettyID() << std::endl;
-        for (const auto & s : m_activeSources)
-        {
-            if (source->ID() == s->ID())
-            {
-                edm::LogVerbatim("XrdAdaptorInternal") << "Xrootd server returned excluded source " << source->PrettyID()
-                    << "; ignoring" << std::endl;
-                unsigned returned_count = ++m_excluded_active_count;
-                m_nextActiveSourceCheck.tv_sec += XRD_ADAPTOR_SHORT_OPEN_DELAY;
-                if (returned_count >= 3) {m_nextActiveSourceCheck.tv_sec += XRD_ADAPTOR_LONG_OPEN_DELAY - 2*XRD_ADAPTOR_SHORT_OPEN_DELAY;}
-                return;
-            }
-        }
-        for (const auto & s : m_inactiveSources)
-        {
-            if (source->ID() == s->ID())
-            {
-                edm::LogVerbatim("XrdAdaptorInternal") << "Xrootd server returned excluded inactive source " << source->PrettyID() 
-                    << "; ignoring" << std::endl;
-                m_nextActiveSourceCheck.tv_sec += XRD_ADAPTOR_LONG_OPEN_DELAY - XRD_ADAPTOR_SHORT_OPEN_DELAY;
-                return;
-            }
-        }
-        if (m_activeSources.size() < 2)
-        {
-            auto oldSources = m_activeSources;
-            m_activeSources.push_back(source);
-            reportSiteChange(oldSources, m_activeSources);
-            queueUpdateCurrentServer(source->ID());
-        }
-        else
-        {
-            m_inactiveSources.push_back(source);
-        }
+
+    for (const auto &it : m_activeSources) {
+      count++;
+      ss << it->ExcludeID().substr(0, it->ExcludeID().find(":")) << ",";
     }
-    else
-    {   // File-open failure - wait at least 120s before next attempt.
-        edm::LogVerbatim("XrdAdaptorInternal") << "Got failure when trying to open a new source" << std::endl;
-        m_nextActiveSourceCheck.tv_sec += XRD_ADAPTOR_LONG_OPEN_DELAY - XRD_ADAPTOR_SHORT_OPEN_DELAY;
+    for (const auto &it : m_inactiveSources) {
+      count++;
+      ss << it->ExcludeID().substr(0, it->ExcludeID().find(":")) << ",";
     }
+  }
+  for (const auto &it : m_disabledExcludeStrings) {
+    count++;
+    ss << it.substr(0, it.find(":")) << ",";
+  }
+  if (count) {
+    std::string tmp_str = ss.str();
+    return tmp_str.substr(0, tmp_str.size() - 1);
+  }
+  return "";
 }
 
-std::future<IOSize>
-XrdAdaptor::RequestManager::handle(std::shared_ptr<std::vector<IOPosBuffer> > iolist)
-{
-    //Use a copy of m_activeSources and m_inactiveSources throughout this function
-    // in order to avoid holding the lock a long time and causing a deadlock.
-    // When the function is over we will update the values of the containers
-    std::vector<std::shared_ptr<Source>> activeSources, inactiveSources;
-    {
-       std::lock_guard<std::recursive_mutex> sentry(m_source_mutex);
-       activeSources = m_activeSources;
-       inactiveSources = m_inactiveSources;
+void XrdAdaptor::RequestManager::handleOpen(XrdCl::XRootDStatus &status, std::shared_ptr<Source> source) {
+  std::lock_guard<std::recursive_mutex> sentry(m_source_mutex);
+  if (status.IsOK()) {
+    edm::LogVerbatim("XrdAdaptorInternal") << "Successfully opened new source: " << source->PrettyID() << std::endl;
+    for (const auto &s : m_activeSources) {
+      if (source->ID() == s->ID()) {
+        edm::LogVerbatim("XrdAdaptorInternal")
+            << "Xrootd server returned excluded source " << source->PrettyID() << "; ignoring" << std::endl;
+        unsigned returned_count = ++m_excluded_active_count;
+        m_nextActiveSourceCheck.tv_sec += XRD_ADAPTOR_SHORT_OPEN_DELAY;
+        if (returned_count >= 3) {
+          m_nextActiveSourceCheck.tv_sec += XRD_ADAPTOR_LONG_OPEN_DELAY - 2 * XRD_ADAPTOR_SHORT_OPEN_DELAY;
+        }
+        return;
+      }
     }
-    //Make sure we update changes when we leave the function
-    std::shared_ptr<void*> guard(nullptr, [this, &activeSources, &inactiveSources](void *) {
-      std::lock_guard<std::recursive_mutex> sentry(m_source_mutex);
-      m_activeSources = std::move(activeSources);
-      m_inactiveSources = std::move(inactiveSources);
-    });
-  
-    updateCurrentServer();
+    for (const auto &s : m_inactiveSources) {
+      if (source->ID() == s->ID()) {
+        edm::LogVerbatim("XrdAdaptorInternal")
+            << "Xrootd server returned excluded inactive source " << source->PrettyID() << "; ignoring" << std::endl;
+        m_nextActiveSourceCheck.tv_sec += XRD_ADAPTOR_LONG_OPEN_DELAY - XRD_ADAPTOR_SHORT_OPEN_DELAY;
+        return;
+      }
+    }
+    if (m_activeSources.size() < 2) {
+      auto oldSources = m_activeSources;
+      m_activeSources.push_back(source);
+      reportSiteChange(oldSources, m_activeSources);
+      queueUpdateCurrentServer(source->ID());
+    } else {
+      m_inactiveSources.push_back(source);
+    }
+  } else {  // File-open failure - wait at least 120s before next attempt.
+    edm::LogVerbatim("XrdAdaptorInternal") << "Got failure when trying to open a new source" << std::endl;
+    m_nextActiveSourceCheck.tv_sec += XRD_ADAPTOR_LONG_OPEN_DELAY - XRD_ADAPTOR_SHORT_OPEN_DELAY;
+  }
+}
 
+std::future<IOSize> XrdAdaptor::RequestManager::handle(std::shared_ptr<std::vector<IOPosBuffer>> iolist) {
+  //Use a copy of m_activeSources and m_inactiveSources throughout this function
+  // in order to avoid holding the lock a long time and causing a deadlock.
+  // When the function is over we will update the values of the containers
+  std::vector<std::shared_ptr<Source>> activeSources, inactiveSources;
+  {
+    std::lock_guard<std::recursive_mutex> sentry(m_source_mutex);
+    activeSources = m_activeSources;
+    inactiveSources = m_inactiveSources;
+  }
+  //Make sure we update changes when we leave the function
+  std::shared_ptr<void *> guard(nullptr, [this, &activeSources, &inactiveSources](void *) {
+    std::lock_guard<std::recursive_mutex> sentry(m_source_mutex);
+    m_activeSources = std::move(activeSources);
+    m_inactiveSources = std::move(inactiveSources);
+  });
+
+  updateCurrentServer();
+
+  timespec now;
+  GET_CLOCK_MONOTONIC(now);
+
+  edm::CPUTimer timer;
+  timer.start();
+
+  if (activeSources.size() == 1) {
+    auto c_ptr = std::make_shared<XrdAdaptor::ClientRequest>(*this, iolist);
+    checkSources(now, c_ptr->getSize(), activeSources, inactiveSources);
+    activeSources[0]->handle(c_ptr);
+    return c_ptr->get_future();
+  }
+  // Make sure active
+  else if (activeSources.empty()) {
+    edm::Exception ex(edm::errors::FileReadError);
+    ex << "XrdAdaptor::RequestManager::handle readv(name='" << m_name << "', flags=0x" << std::hex << m_flags
+       << ", permissions=0" << std::oct << m_perms << std::dec << ") => Source used after fatal exception.";
+    ex.addContext("In XrdAdaptor::RequestManager::handle()");
+    addConnections(ex);
+    throw ex;
+  }
+
+  assert(iolist.get());
+  auto req1 = std::make_shared<std::vector<IOPosBuffer>>();
+  auto req2 = std::make_shared<std::vector<IOPosBuffer>>();
+  splitClientRequest(*iolist, *req1, *req2, activeSources);
+
+  checkSources(now, req1->size() + req2->size(), activeSources, inactiveSources);
+  // CheckSources may have removed a source
+  if (activeSources.size() == 1) {
+    auto c_ptr = std::make_shared<XrdAdaptor::ClientRequest>(*this, iolist);
+    activeSources[0]->handle(c_ptr);
+    return c_ptr->get_future();
+  }
+
+  std::shared_ptr<XrdAdaptor::ClientRequest> c_ptr1, c_ptr2;
+  std::future<IOSize> future1, future2;
+  if (!req1->empty()) {
+    c_ptr1.reset(new XrdAdaptor::ClientRequest(*this, req1));
+    activeSources[0]->handle(c_ptr1);
+    future1 = c_ptr1->get_future();
+  }
+  if (!req2->empty()) {
+    c_ptr2.reset(new XrdAdaptor::ClientRequest(*this, req2));
+    activeSources[1]->handle(c_ptr2);
+    future2 = c_ptr2->get_future();
+  }
+  if (!req1->empty() && !req2->empty()) {
+    std::future<IOSize> task =
+        std::async(std::launch::deferred,
+                   [](std::future<IOSize> a, std::future<IOSize> b) {
+                     // Wait until *both* results are available.  This is essential
+                     // as the callback may try referencing the RequestManager.  If one
+                     // throws an exception (causing the RequestManager to be destroyed by
+                     // XrdFile) and the other has a failure, then the recovery code will
+                     // reference the destroyed RequestManager.
+                     //
+                     // Unlike other places where we use shared/weak ptrs to maintain object
+                     // lifetime and destruction asynchronously, we *cannot* destroy the request
+                     // asynchronously as it is associated with a ROOT buffer.  We must wait until we
+                     // are guaranteed that XrdCl will not write into the ROOT buffer before we
+                     // can return.
+                     b.wait();
+                     a.wait();
+                     return b.get() + a.get();
+                   },
+                   std::move(future1),
+                   std::move(future2));
+    timer.stop();
+    //edm::LogVerbatim("XrdAdaptorInternal") << "Total time to create requests " << static_cast<int>(1000*timer.realTime()) << std::endl;
+    return task;
+  } else if (!req1->empty()) {
+    return future1;
+  } else if (!req2->empty()) {
+    return future2;
+  } else {  // Degenerate case - no bytes to read.
+    std::promise<IOSize> p;
+    p.set_value(0);
+    return p.get_future();
+  }
+}
+
+void RequestManager::requestFailure(std::shared_ptr<XrdAdaptor::ClientRequest> c_ptr, XrdCl::Status &c_status) {
+  std::shared_ptr<Source> source_ptr = c_ptr->getCurrentSource();
+
+  // Fail early for invalid responses - XrdFile has a separate path for handling this.
+  if (c_status.code == XrdCl::errInvalidResponse) {
+    edm::LogWarning("XrdAdaptorInternal") << "Invalid response when reading from " << source_ptr->PrettyID();
+    XrootdException ex(c_status, edm::errors::FileReadError);
+    ex << "XrdAdaptor::RequestManager::requestFailure readv(name='" << m_name << "', flags=0x" << std::hex << m_flags
+       << ", permissions=0" << std::oct << m_perms << std::dec << ", old source=" << source_ptr->PrettyID()
+       << ") => Invalid ReadV response from server";
+    ex.addContext("In XrdAdaptor::RequestManager::requestFailure()");
+    addConnections(ex);
+    throw ex;
+  }
+  edm::LogWarning("XrdAdaptorInternal") << "Request failure when reading from " << source_ptr->PrettyID();
+
+  // Note that we do not delete the Source itself.  That is because this
+  // function may be called from within XrdCl::ResponseHandler::HandleResponseWithHosts
+  // In such a case, if you close a file in the handler, it will deadlock
+  m_disabledSourceStrings.insert(source_ptr->ID());
+  m_disabledExcludeStrings.insert(source_ptr->ExcludeID());
+  m_disabledSources.insert(source_ptr);
+
+  std::unique_lock<std::recursive_mutex> sentry(m_source_mutex);
+  if ((!m_activeSources.empty()) && (m_activeSources[0].get() == source_ptr.get())) {
+    auto oldSources = m_activeSources;
+    m_activeSources.erase(m_activeSources.begin());
+    reportSiteChange(oldSources, m_activeSources);
+  } else if ((m_activeSources.size() > 1) && (m_activeSources[1].get() == source_ptr.get())) {
+    auto oldSources = m_activeSources;
+    m_activeSources.erase(m_activeSources.begin() + 1);
+    reportSiteChange(oldSources, m_activeSources);
+  }
+  std::shared_ptr<Source> new_source;
+  if (m_activeSources.empty()) {
+    std::shared_future<std::shared_ptr<Source>> future = m_open_handler->open();
     timespec now;
     GET_CLOCK_MONOTONIC(now);
-
-    edm::CPUTimer timer;
-    timer.start();
-
-    if (activeSources.size() == 1)
-    {
-        auto c_ptr = std::make_shared<XrdAdaptor::ClientRequest>(*this, iolist);
-        checkSources(now, c_ptr->getSize(), activeSources,inactiveSources);
-        activeSources[0]->handle(c_ptr);
-        return c_ptr->get_future();
-    }
-    // Make sure active
-    else if (activeSources.empty())
-    {
-        edm::Exception ex(edm::errors::FileReadError);
-        ex << "XrdAdaptor::RequestManager::handle readv(name='" << m_name
-               << "', flags=0x" << std::hex << m_flags
-               << ", permissions=0" << std::oct << m_perms << std::dec
-               << ") => Source used after fatal exception.";
-        ex.addContext("In XrdAdaptor::RequestManager::handle()");
-        addConnections(ex);
-        throw ex;
-    }
-
-    assert(iolist.get());
-    auto req1 = std::make_shared<std::vector<IOPosBuffer>>();
-    auto req2 = std::make_shared<std::vector<IOPosBuffer>>();
-    splitClientRequest(*iolist, *req1, *req2, activeSources);
-
-    checkSources(now, req1->size() + req2->size(), activeSources, inactiveSources);
-    // CheckSources may have removed a source
-    if (activeSources.size() == 1)
-    {
-        auto c_ptr = std::make_shared<XrdAdaptor::ClientRequest>(*this, iolist);
-        activeSources[0]->handle(c_ptr);
-        return c_ptr->get_future();
+    m_lastSourceCheck = now;
+    // Note we only wait for 180 seconds here.  This is because we've already failed
+    // once and the likelihood the program has some inconsistent state is decent.
+    // We'd much rather fail hard than deadlock!
+    sentry.unlock();
+    std::future_status status = future.wait_for(std::chrono::seconds(m_timeout + 10));
+    if (status == std::future_status::timeout) {
+      XrootdException ex(c_status, edm::errors::FileOpenError);
+      ex << "XrdAdaptor::RequestManager::requestFailure Open(name='" << m_name << "', flags=0x" << std::hex << m_flags
+         << ", permissions=0" << std::oct << m_perms << std::dec << ", old source=" << source_ptr->PrettyID()
+         << ") => timeout when waiting for file open";
+      ex.addContext("In XrdAdaptor::RequestManager::requestFailure()");
+      addConnections(ex);
+      throw ex;
+    } else {
+      try {
+        new_source = future.get();
+      } catch (edm::Exception &ex) {
+        ex.addContext("Handling XrdAdaptor::RequestManager::requestFailure()");
+        ex.addAdditionalInfo("Original failed source is " + source_ptr->PrettyID());
+        throw;
+      }
     }
 
-    std::shared_ptr<XrdAdaptor::ClientRequest> c_ptr1, c_ptr2;
-    std::future<IOSize> future1, future2;
-    if (!req1->empty())
-    {
-        c_ptr1.reset(new XrdAdaptor::ClientRequest(*this, req1));
-        activeSources[0]->handle(c_ptr1);
-        future1 = c_ptr1->get_future();
+    if (std::find(m_disabledSourceStrings.begin(), m_disabledSourceStrings.end(), new_source->ID()) !=
+        m_disabledSourceStrings.end()) {
+      // The server gave us back a data node we requested excluded.  Fatal!
+      XrootdException ex(c_status, edm::errors::FileOpenError);
+      ex << "XrdAdaptor::RequestManager::requestFailure Open(name='" << m_name << "', flags=0x" << std::hex << m_flags
+         << ", permissions=0" << std::oct << m_perms << std::dec << ", old source=" << source_ptr->PrettyID()
+         << ", new source=" << new_source->PrettyID() << ") => Xrootd server returned an excluded source";
+      ex.addContext("In XrdAdaptor::RequestManager::requestFailure()");
+      addConnections(ex);
+      throw ex;
     }
-    if (!req2->empty())
-    {
-        c_ptr2.reset(new XrdAdaptor::ClientRequest(*this, req2));
-        activeSources[1]->handle(c_ptr2);
-        future2 = c_ptr2->get_future();
-    }
-    if (!req1->empty() && !req2->empty())
-    {
-        std::future<IOSize> task = std::async(std::launch::deferred,
-            [](std::future<IOSize> a, std::future<IOSize> b){
-                // Wait until *both* results are available.  This is essential
-                // as the callback may try referencing the RequestManager.  If one
-                // throws an exception (causing the RequestManager to be destroyed by
-                // XrdFile) and the other has a failure, then the recovery code will
-                // reference the destroyed RequestManager.
-                //
-                // Unlike other places where we use shared/weak ptrs to maintain object
-                // lifetime and destruction asynchronously, we *cannot* destroy the request
-                // asynchronously as it is associated with a ROOT buffer.  We must wait until we
-                // are guaranteed that XrdCl will not write into the ROOT buffer before we
-                // can return.
-                b.wait(); a.wait();
-                return b.get() + a.get();
-            },
-            std::move(future1),
-            std::move(future2));
-        timer.stop();
-        //edm::LogVerbatim("XrdAdaptorInternal") << "Total time to create requests " << static_cast<int>(1000*timer.realTime()) << std::endl;
-        return task;
-    }
-    else if (!req1->empty()) { return future1; }
-    else if (!req2->empty()) { return future2; }
-    else
-    {   // Degenerate case - no bytes to read.
-        std::promise<IOSize> p; p.set_value(0);
-        return p.get_future();
-    }
+    sentry.lock();
+
+    auto oldSources = m_activeSources;
+    m_activeSources.push_back(new_source);
+    reportSiteChange(oldSources, m_activeSources);
+  } else {
+    new_source = m_activeSources[0];
+  }
+  new_source->handle(c_ptr);
 }
 
-void
-RequestManager::requestFailure(std::shared_ptr<XrdAdaptor::ClientRequest> c_ptr, XrdCl::Status &c_status)
-{
-    std::shared_ptr<Source> source_ptr = c_ptr->getCurrentSource();
-
-    // Fail early for invalid responses - XrdFile has a separate path for handling this.
-    if (c_status.code == XrdCl::errInvalidResponse)
-    {
-        edm::LogWarning("XrdAdaptorInternal") << "Invalid response when reading from " << source_ptr->PrettyID();
-        XrootdException ex(c_status, edm::errors::FileReadError);
-        ex << "XrdAdaptor::RequestManager::requestFailure readv(name='" << m_name
-               << "', flags=0x" << std::hex << m_flags
-               << ", permissions=0" << std::oct << m_perms << std::dec
-               << ", old source=" << source_ptr->PrettyID()
-               << ") => Invalid ReadV response from server";
-        ex.addContext("In XrdAdaptor::RequestManager::requestFailure()");
-        addConnections(ex);
-        throw ex;
-    }
-    edm::LogWarning("XrdAdaptorInternal") << "Request failure when reading from " << source_ptr->PrettyID();
-
-    // Note that we do not delete the Source itself.  That is because this
-    // function may be called from within XrdCl::ResponseHandler::HandleResponseWithHosts
-    // In such a case, if you close a file in the handler, it will deadlock
-    m_disabledSourceStrings.insert(source_ptr->ID());
-    m_disabledExcludeStrings.insert(source_ptr->ExcludeID());
-    m_disabledSources.insert(source_ptr);
-
-    std::unique_lock<std::recursive_mutex> sentry(m_source_mutex);
-    if ((!m_activeSources.empty()) && (m_activeSources[0].get() == source_ptr.get()))
-    {
-        auto oldSources = m_activeSources;
-        m_activeSources.erase(m_activeSources.begin());
-        reportSiteChange(oldSources, m_activeSources);
-    }
-    else if ((m_activeSources.size() > 1) && (m_activeSources[1].get() == source_ptr.get()))
-    {
-        auto oldSources = m_activeSources;
-        m_activeSources.erase(m_activeSources.begin()+1);
-        reportSiteChange(oldSources, m_activeSources);
-    }
-    std::shared_ptr<Source> new_source;
-    if (m_activeSources.empty())
-    {
-        std::shared_future<std::shared_ptr<Source> > future = m_open_handler->open();
-        timespec now;
-        GET_CLOCK_MONOTONIC(now);
-        m_lastSourceCheck = now;
-        // Note we only wait for 180 seconds here.  This is because we've already failed
-        // once and the likelihood the program has some inconsistent state is decent.
-        // We'd much rather fail hard than deadlock!
-        sentry.unlock();
-        std::future_status status = future.wait_for(std::chrono::seconds(m_timeout+10));
-        if (status == std::future_status::timeout)
-        {
-            XrootdException ex(c_status, edm::errors::FileOpenError);
-            ex << "XrdAdaptor::RequestManager::requestFailure Open(name='" << m_name
-               << "', flags=0x" << std::hex << m_flags
-               << ", permissions=0" << std::oct << m_perms << std::dec
-               << ", old source=" << source_ptr->PrettyID()
-               << ") => timeout when waiting for file open";
-            ex.addContext("In XrdAdaptor::RequestManager::requestFailure()");
-            addConnections(ex);
-            throw ex;
+static void consumeChunkFront(size_t &front,
+                              std::vector<IOPosBuffer> &input,
+                              std::vector<IOPosBuffer> &output,
+                              IOSize chunksize) {
+  while ((chunksize > 0) && (front < input.size()) && (output.size() <= XRD_ADAPTOR_CHUNK_THRESHOLD)) {
+    IOPosBuffer &io = input[front];
+    IOPosBuffer &outio = output.back();
+    if (io.size() > chunksize) {
+      IOSize consumed;
+      if (!output.empty() && (outio.size() < XRD_CL_MAX_CHUNK) &&
+          (outio.offset() + static_cast<IOOffset>(outio.size()) == io.offset())) {
+        if (outio.size() + chunksize > XRD_CL_MAX_CHUNK) {
+          consumed = (XRD_CL_MAX_CHUNK - outio.size());
+          outio.set_size(XRD_CL_MAX_CHUNK);
+        } else {
+          consumed = chunksize;
+          outio.set_size(outio.size() + consumed);
         }
-        else
-        {
-            try
-            {
-                new_source = future.get();
-            }
-            catch (edm::Exception &ex)
-            {
-                ex.addContext("Handling XrdAdaptor::RequestManager::requestFailure()");
-                ex.addAdditionalInfo("Original failed source is " + source_ptr->PrettyID());
-                throw;
-            }
-        }
-      
-        if (std::find(m_disabledSourceStrings.begin(), m_disabledSourceStrings.end(), new_source->ID()) != m_disabledSourceStrings.end())
-        {
-            // The server gave us back a data node we requested excluded.  Fatal!
-            XrootdException ex(c_status, edm::errors::FileOpenError);
-            ex << "XrdAdaptor::RequestManager::requestFailure Open(name='" << m_name
-               << "', flags=0x" << std::hex << m_flags
-               << ", permissions=0" << std::oct << m_perms << std::dec
-               << ", old source=" << source_ptr->PrettyID()
-               << ", new source=" << new_source->PrettyID() << ") => Xrootd server returned an excluded source";
-            ex.addContext("In XrdAdaptor::RequestManager::requestFailure()");
-            addConnections(ex);
-            throw ex;
-        }
-        sentry.lock();
-
-        auto oldSources = m_activeSources;
-        m_activeSources.push_back(new_source);
-        reportSiteChange(oldSources,m_activeSources);
+      } else {
+        consumed = chunksize;
+        output.emplace_back(IOPosBuffer(io.offset(), io.data(), chunksize));
+      }
+      chunksize -= consumed;
+      IOSize newsize = io.size() - consumed;
+      IOOffset newoffset = io.offset() + consumed;
+      void *newdata = static_cast<char *>(io.data()) + consumed;
+      io.set_offset(newoffset);
+      io.set_data(newdata);
+      io.set_size(newsize);
+    } else if (io.size() == 0) {
+      front++;
+    } else {
+      output.push_back(io);
+      chunksize -= io.size();
+      front++;
     }
-    else
-    {
-        new_source = m_activeSources[0];
-    }
-    new_source->handle(c_ptr);
+  }
 }
 
-static void
-consumeChunkFront(size_t &front, std::vector<IOPosBuffer> &input, std::vector<IOPosBuffer> &output, IOSize chunksize)
-{
-    while ((chunksize > 0) && (front < input.size()) && (output.size() <= XRD_ADAPTOR_CHUNK_THRESHOLD))
-    {
-        IOPosBuffer &io = input[front];
-        IOPosBuffer &outio = output.back();
-        if (io.size() > chunksize)
-        {
-            IOSize consumed;
-            if (!output.empty() && (outio.size() < XRD_CL_MAX_CHUNK) && (outio.offset() + static_cast<IOOffset>(outio.size()) == io.offset()))
-            {
-                if (outio.size() + chunksize > XRD_CL_MAX_CHUNK)
-                {
-                    consumed = (XRD_CL_MAX_CHUNK - outio.size());
-                    outio.set_size(XRD_CL_MAX_CHUNK);
-                }
-                else
-                {
-                    consumed = chunksize;
-                    outio.set_size(outio.size() + consumed);
-                }
-            }
-            else
-            {
-                consumed = chunksize;
-                output.emplace_back(IOPosBuffer(io.offset(), io.data(), chunksize));
-            }
-            chunksize -= consumed;
-            IOSize newsize = io.size() - consumed;
-            IOOffset newoffset = io.offset() + consumed;
-            void* newdata = static_cast<char*>(io.data()) + consumed;
-            io.set_offset(newoffset);
-            io.set_data(newdata);
-            io.set_size(newsize);
+static void consumeChunkBack(size_t front,
+                             std::vector<IOPosBuffer> &input,
+                             std::vector<IOPosBuffer> &output,
+                             IOSize chunksize) {
+  while ((chunksize > 0) && (front < input.size()) && (output.size() <= XRD_ADAPTOR_CHUNK_THRESHOLD)) {
+    IOPosBuffer &io = input.back();
+    IOPosBuffer &outio = output.back();
+    if (io.size() > chunksize) {
+      IOSize consumed;
+      if (!output.empty() && (outio.size() < XRD_CL_MAX_CHUNK) &&
+          (outio.offset() + static_cast<IOOffset>(outio.size()) == io.offset())) {
+        if (outio.size() + chunksize > XRD_CL_MAX_CHUNK) {
+          consumed = (XRD_CL_MAX_CHUNK - outio.size());
+          outio.set_size(XRD_CL_MAX_CHUNK);
+        } else {
+          consumed = chunksize;
+          outio.set_size(outio.size() + consumed);
         }
-        else if (io.size() == 0)
-        {
-            front++;
-        }
-        else
-        {
-            output.push_back(io);
-            chunksize -= io.size();
-            front++;
-        }
+      } else {
+        consumed = chunksize;
+        output.emplace_back(IOPosBuffer(io.offset(), io.data(), chunksize));
+      }
+      chunksize -= consumed;
+      IOSize newsize = io.size() - consumed;
+      IOOffset newoffset = io.offset() + consumed;
+      void *newdata = static_cast<char *>(io.data()) + consumed;
+      io.set_offset(newoffset);
+      io.set_data(newdata);
+      io.set_size(newsize);
+    } else if (io.size() == 0) {
+      input.pop_back();
+    } else {
+      output.push_back(io);
+      chunksize -= io.size();
+      input.pop_back();
     }
+  }
 }
 
-static void
-consumeChunkBack(size_t front, std::vector<IOPosBuffer> &input, std::vector<IOPosBuffer> &output, IOSize chunksize)
-{
-    while ((chunksize > 0) && (front < input.size()) && (output.size() <= XRD_ADAPTOR_CHUNK_THRESHOLD))
-    {
-        IOPosBuffer &io = input.back();
-        IOPosBuffer &outio = output.back();
-        if (io.size() > chunksize)
-        {
-            IOSize consumed;
-            if (!output.empty() && (outio.size() < XRD_CL_MAX_CHUNK) && (outio.offset() + static_cast<IOOffset>(outio.size()) == io.offset()))
-            {
-                if (outio.size() + chunksize > XRD_CL_MAX_CHUNK)
-                {
-                    consumed = (XRD_CL_MAX_CHUNK - outio.size());
-                    outio.set_size(XRD_CL_MAX_CHUNK);
-                }
-                else
-                {
-                    consumed = chunksize;
-                    outio.set_size(outio.size() + consumed);
-                }
-            }
-            else
-            {
-                consumed = chunksize;
-                output.emplace_back(IOPosBuffer(io.offset(), io.data(), chunksize));
-            }
-            chunksize -= consumed;
-            IOSize newsize = io.size() - consumed;
-            IOOffset newoffset = io.offset() + consumed;
-            void* newdata = static_cast<char*>(io.data()) + consumed;
-            io.set_offset(newoffset);
-            io.set_data(newdata);
-            io.set_size(newsize);
-        }
-        else if (io.size() == 0)
-        {
-            input.pop_back();
-        }
-        else
-        {
-            output.push_back(io);
-            chunksize -= io.size();
-            input.pop_back();
-        }
+static IOSize validateList(const std::vector<IOPosBuffer> req) {
+  IOSize total = 0;
+  off_t last_offset = -1;
+  for (const auto &it : req) {
+    total += it.size();
+    assert(it.offset() > last_offset);
+    last_offset = it.offset();
+    assert(it.size() <= XRD_CL_MAX_CHUNK);
+    assert(it.offset() < 0x1ffffffffff);
+  }
+  assert(req.size() <= 1024);
+  return total;
+}
+
+void XrdAdaptor::RequestManager::splitClientRequest(const std::vector<IOPosBuffer> &iolist,
+                                                    std::vector<IOPosBuffer> &req1,
+                                                    std::vector<IOPosBuffer> &req2,
+                                                    std::vector<std::shared_ptr<Source>> const &activeSources) const {
+  if (iolist.empty())
+    return;
+  std::vector<IOPosBuffer> tmp_iolist(iolist.begin(), iolist.end());
+  req1.reserve(iolist.size() / 2 + 1);
+  req2.reserve(iolist.size() / 2 + 1);
+  size_t front = 0;
+
+  // The quality of both is increased by 5 to prevent strange effects if quality is 0 for one source.
+  float q1 = static_cast<float>(activeSources[0]->getQuality()) + 5;
+  float q2 = static_cast<float>(activeSources[1]->getQuality()) + 5;
+  IOSize chunk1, chunk2;
+  // Make sure the chunk size is at least 1024; little point to reads less than that size.
+  chunk1 = std::max(static_cast<IOSize>(static_cast<float>(XRD_CL_MAX_CHUNK) * (q2 * q2 / (q1 * q1 + q2 * q2))),
+                    static_cast<IOSize>(1024));
+  chunk2 = std::max(static_cast<IOSize>(static_cast<float>(XRD_CL_MAX_CHUNK) * (q1 * q1 / (q1 * q1 + q2 * q2))),
+                    static_cast<IOSize>(1024));
+
+  IOSize size_orig = 0;
+  for (const auto &it : iolist)
+    size_orig += it.size();
+
+  while (tmp_iolist.size() - front > 0) {
+    if ((req1.size() >= XRD_ADAPTOR_CHUNK_THRESHOLD) &&
+        (req2.size() >=
+         XRD_ADAPTOR_CHUNK_THRESHOLD)) {  // The XrdFile::readv implementation should guarantee that no more than approximately 1024 chunks
+      // are passed to the request manager.  However, because we have a max chunk size, we increase
+      // the total number slightly.  Theoretically, it's possible an individual readv of total size >2GB where
+      // each individual chunk is >1MB could result in this firing.  However, within the context of CMSSW,
+      // this cannot happen (ROOT uses readv for TTreeCache; TTreeCache size is 20MB).
+      edm::Exception ex(edm::errors::FileReadError);
+      ex << "XrdAdaptor::RequestManager::splitClientRequest(name='" << m_name << "', flags=0x" << std::hex << m_flags
+         << ", permissions=0" << std::oct << m_perms << std::dec
+         << ") => Unable to split request between active servers.  This is an unexpected internal error and should be "
+            "reported to CMSSW developers.";
+      ex.addContext("In XrdAdaptor::RequestManager::requestFailure()");
+      addConnections(ex);
+      std::stringstream ss;
+      ss << "Original request size " << iolist.size() << "(" << size_orig << " bytes)";
+      ex.addAdditionalInfo(ss.str());
+      std::stringstream ss2;
+      ss2 << "Quality source 1 " << q1 - 5 << ", quality source 2: " << q2 - 5;
+      ex.addAdditionalInfo(ss2.str());
+      throw ex;
     }
-}
-
-static IOSize validateList(const std::vector<IOPosBuffer> req)
-{
-    IOSize total = 0;
-    off_t last_offset = -1;
-    for (const auto & it : req)
-    {
-        total += it.size();
-        assert(it.offset() > last_offset);
-        last_offset = it.offset();
-        assert(it.size() <= XRD_CL_MAX_CHUNK);
-        assert(it.offset() < 0x1ffffffffff);
+    if (req1.size() < XRD_ADAPTOR_CHUNK_THRESHOLD) {
+      consumeChunkFront(front, tmp_iolist, req1, chunk1);
     }
-    assert(req.size() <= 1024);
-    return total;
-}
-
-void
-XrdAdaptor::RequestManager::splitClientRequest(const std::vector<IOPosBuffer> &iolist, std::vector<IOPosBuffer> &req1, std::vector<IOPosBuffer> &req2, std::vector<std::shared_ptr<Source>> const& activeSources) const
-{
-    if (iolist.empty()) return;
-    std::vector<IOPosBuffer> tmp_iolist(iolist.begin(), iolist.end());
-    req1.reserve(iolist.size()/2+1);
-    req2.reserve(iolist.size()/2+1);
-    size_t front=0;
-
-        // The quality of both is increased by 5 to prevent strange effects if quality is 0 for one source.
-    float q1 = static_cast<float>(activeSources[0]->getQuality())+5;
-    float q2 = static_cast<float>(activeSources[1]->getQuality())+5;
-    IOSize chunk1, chunk2;
-    // Make sure the chunk size is at least 1024; little point to reads less than that size.
-    chunk1 = std::max(static_cast<IOSize>(static_cast<float>(XRD_CL_MAX_CHUNK)*(q2*q2/(q1*q1+q2*q2))), static_cast<IOSize>(1024));
-    chunk2 = std::max(static_cast<IOSize>(static_cast<float>(XRD_CL_MAX_CHUNK)*(q1*q1/(q1*q1+q2*q2))), static_cast<IOSize>(1024));
-
-    IOSize size_orig = 0;
-    for (const auto & it : iolist) size_orig += it.size();
-
-    while (tmp_iolist.size()-front > 0)
-    {
-        if ((req1.size() >= XRD_ADAPTOR_CHUNK_THRESHOLD) && (req2.size() >= XRD_ADAPTOR_CHUNK_THRESHOLD))
-        {   // The XrdFile::readv implementation should guarantee that no more than approximately 1024 chunks
-            // are passed to the request manager.  However, because we have a max chunk size, we increase
-            // the total number slightly.  Theoretically, it's possible an individual readv of total size >2GB where
-            // each individual chunk is >1MB could result in this firing.  However, within the context of CMSSW,
-            // this cannot happen (ROOT uses readv for TTreeCache; TTreeCache size is 20MB).
-            edm::Exception ex(edm::errors::FileReadError);
-            ex << "XrdAdaptor::RequestManager::splitClientRequest(name='" << m_name
-               << "', flags=0x" << std::hex << m_flags
-               << ", permissions=0" << std::oct << m_perms << std::dec
-               << ") => Unable to split request between active servers.  This is an unexpected internal error and should be reported to CMSSW developers.";
-            ex.addContext("In XrdAdaptor::RequestManager::requestFailure()");
-            addConnections(ex);
-            std::stringstream ss; ss << "Original request size " << iolist.size() << "(" << size_orig << " bytes)";
-            ex.addAdditionalInfo(ss.str());
-            std::stringstream ss2; ss2 << "Quality source 1 " << q1-5 << ", quality source 2: " << q2-5;
-            ex.addAdditionalInfo(ss2.str());
-            throw ex;
-        }
-        if (req1.size() < XRD_ADAPTOR_CHUNK_THRESHOLD) {consumeChunkFront(front, tmp_iolist, req1, chunk1);}
-        if (req2.size() < XRD_ADAPTOR_CHUNK_THRESHOLD) {consumeChunkBack(front, tmp_iolist, req2, chunk2);}
+    if (req2.size() < XRD_ADAPTOR_CHUNK_THRESHOLD) {
+      consumeChunkBack(front, tmp_iolist, req2, chunk2);
     }
-    std::sort(req1.begin(), req1.end(), [](const IOPosBuffer & left, const IOPosBuffer & right){return left.offset() < right.offset();});
-    std::sort(req2.begin(), req2.end(), [](const IOPosBuffer & left, const IOPosBuffer & right){return left.offset() < right.offset();});
+  }
+  std::sort(req1.begin(), req1.end(), [](const IOPosBuffer &left, const IOPosBuffer &right) {
+    return left.offset() < right.offset();
+  });
+  std::sort(req2.begin(), req2.end(), [](const IOPosBuffer &left, const IOPosBuffer &right) {
+    return left.offset() < right.offset();
+  });
 
-    IOSize size1 = validateList(req1);
-    IOSize size2 = validateList(req2);
+  IOSize size1 = validateList(req1);
+  IOSize size2 = validateList(req2);
 
-    assert(size_orig == size1 + size2);
+  assert(size_orig == size1 + size2);
 
-    edm::LogVerbatim("XrdAdaptorInternal") << "Original request size " << iolist.size() << " (" << size_orig << " bytes) split into requests size " << req1.size() << " (" << size1 << " bytes) and " << req2.size() << " (" << size2 << " bytes)" << std::endl;
+  edm::LogVerbatim("XrdAdaptorInternal") << "Original request size " << iolist.size() << " (" << size_orig
+                                         << " bytes) split into requests size " << req1.size() << " (" << size1
+                                         << " bytes) and " << req2.size() << " (" << size2 << " bytes)" << std::endl;
 }
 
-XrdAdaptor::RequestManager::OpenHandler::OpenHandler(std::weak_ptr<RequestManager> manager)
-  : m_manager(manager)
-{
-}
+XrdAdaptor::RequestManager::OpenHandler::OpenHandler(std::weak_ptr<RequestManager> manager) : m_manager(manager) {}
 
+// Cannot use ~OpenHandler=default as XrdCl::File is not fully
+// defined in the header.
+XrdAdaptor::RequestManager::OpenHandler::~OpenHandler() {}
 
-    // Cannot use ~OpenHandler=default as XrdCl::File is not fully
-    // defined in the header.
-XrdAdaptor::RequestManager::OpenHandler::~OpenHandler()
-{
-}
-
-
-void
-XrdAdaptor::RequestManager::OpenHandler::HandleResponseWithHosts(XrdCl::XRootDStatus *status_ptr, XrdCl::AnyObject *, XrdCl::HostList *hostList_ptr)
-{
+void XrdAdaptor::RequestManager::OpenHandler::HandleResponseWithHosts(XrdCl::XRootDStatus *status_ptr,
+                                                                      XrdCl::AnyObject *,
+                                                                      XrdCl::HostList *hostList_ptr) {
   // Make sure we get rid of the strong self-reference when the callback finishes.
   std::shared_ptr<OpenHandler> self = m_self;
   m_self.reset();
@@ -1078,17 +974,17 @@ XrdAdaptor::RequestManager::OpenHandler::HandleResponseWithHosts(XrdCl::XRootDSt
   // NOTE: as in XrdCl::File (synchronous), we ignore the response object.
   // Make sure that we set m_outstanding_open to false on exit from this function.
   // NOTE: we need to pass non-nullptr to unique_ptr in order for the guard to run
-  std::unique_ptr<OpenHandler, std::function<void(OpenHandler*)>> outstanding_guard(this, [&](OpenHandler*){m_outstanding_open=false;});
+  std::unique_ptr<OpenHandler, std::function<void(OpenHandler *)>> outstanding_guard(
+      this, [&](OpenHandler *) { m_outstanding_open = false; });
 
   std::shared_ptr<Source> source;
   std::unique_ptr<XrdCl::XRootDStatus> status(status_ptr);
   std::unique_ptr<XrdCl::HostList> hostList(hostList_ptr);
 
   auto manager = m_manager.lock();
-    // Manager object has already been deleted.  Cleanup the
-    // response objects, remove our self-reference, and ignore the response.
-  if (!manager)
-  {
+  // Manager object has already been deleted.  Cleanup the
+  // response objects, remove our self-reference, and ignore the response.
+  if (!manager) {
     return;
   }
   //if we need to delete the File object we must do it outside
@@ -1097,119 +993,107 @@ XrdAdaptor::RequestManager::OpenHandler::HandleResponseWithHosts(XrdCl::XRootDSt
   {
     std::lock_guard<std::recursive_mutex> sentry(m_mutex);
 
-    if (status->IsOK())
-    {
-        SendMonitoringInfo(*m_file);
-        timespec now;
-        GET_CLOCK_MONOTONIC(now);
+    if (status->IsOK()) {
+      SendMonitoringInfo(*m_file);
+      timespec now;
+      GET_CLOCK_MONOTONIC(now);
 
-        std::string excludeString;
-        Source::determineHostExcludeString(*m_file, hostList.get(), excludeString);
+      std::string excludeString;
+      Source::determineHostExcludeString(*m_file, hostList.get(), excludeString);
 
-        source.reset(new Source(now, std::move(m_file), excludeString));
-        m_promise.set_value(source);
-    }
-    else
-    {
-        releaseFile = std::move(m_file);
-        edm::Exception ex(edm::errors::FileOpenError);
-        ex << "XrdCl::File::Open(name='" << manager->m_name
-           << "', flags=0x" << std::hex << manager->m_flags
-           << ", permissions=0" << std::oct << manager->m_perms << std::dec
-           << ") => error '" << status->ToStr()
-           << "' (errno=" << status->errNo << ", code=" << status->code << ")";
-        ex.addContext("In XrdAdaptor::RequestManager::OpenHandler::HandleResponseWithHosts()");
-        manager->addConnections(ex);
+      source.reset(new Source(now, std::move(m_file), excludeString));
+      m_promise.set_value(source);
+    } else {
+      releaseFile = std::move(m_file);
+      edm::Exception ex(edm::errors::FileOpenError);
+      ex << "XrdCl::File::Open(name='" << manager->m_name << "', flags=0x" << std::hex << manager->m_flags
+         << ", permissions=0" << std::oct << manager->m_perms << std::dec << ") => error '" << status->ToStr()
+         << "' (errno=" << status->errNo << ", code=" << status->code << ")";
+      ex.addContext("In XrdAdaptor::RequestManager::OpenHandler::HandleResponseWithHosts()");
+      manager->addConnections(ex);
 
-        m_promise.set_exception(std::make_exception_ptr(ex));
+      m_promise.set_exception(std::make_exception_ptr(ex));
     }
   }
   manager->handleOpen(*status, source);
 }
 
-std::string
-XrdAdaptor::RequestManager::OpenHandler::current_source()
-{
-    std::lock_guard<std::recursive_mutex> sentry(m_mutex);
+std::string XrdAdaptor::RequestManager::OpenHandler::current_source() {
+  std::lock_guard<std::recursive_mutex> sentry(m_mutex);
 
-    if (!m_file.get())
-    {
-        return "(no open in progress)";
-    }
-    std::string dataServer;
-    m_file->GetProperty("DataServer", dataServer);
-    if (dataServer.empty()) { return "(unknown source)"; }
-    return dataServer;
+  if (!m_file.get()) {
+    return "(no open in progress)";
+  }
+  std::string dataServer;
+  m_file->GetProperty("DataServer", dataServer);
+  if (dataServer.empty()) {
+    return "(unknown source)";
+  }
+  return dataServer;
 }
 
-std::shared_future<std::shared_ptr<Source> >
-XrdAdaptor::RequestManager::OpenHandler::open()
-{
-    auto manager_ptr = m_manager.lock();
-    if (!manager_ptr)
-    {
-      edm::Exception ex(edm::errors::LogicError);
-      ex << "XrdCl::File::Open() =>"
-         << " error: OpenHandler called within an invalid RequestManager context."
-         << "  This is a logic error and should be reported to the CMSSW developers.";
-      ex.addContext("Calling XrdAdaptor::RequestManager::OpenHandler::open()");
-      throw ex;
-    }
-    RequestManager &manager = *manager_ptr;
-    auto self_ptr = m_self_weak.lock();
-    if (!self_ptr)
-    {
-      edm::Exception ex(edm::errors::LogicError);
-      ex << "XrdCl::File::Open() => error: "
-         << "OpenHandler called after it was deleted.  This is a logic error "
-         << "and should be reported to the CMSSW developers.";
-      ex.addContext("Calling XrdAdapter::RequestManager::OpenHandler::open()");
-      throw ex;
-    }
+std::shared_future<std::shared_ptr<Source>> XrdAdaptor::RequestManager::OpenHandler::open() {
+  auto manager_ptr = m_manager.lock();
+  if (!manager_ptr) {
+    edm::Exception ex(edm::errors::LogicError);
+    ex << "XrdCl::File::Open() =>"
+       << " error: OpenHandler called within an invalid RequestManager context."
+       << "  This is a logic error and should be reported to the CMSSW developers.";
+    ex.addContext("Calling XrdAdaptor::RequestManager::OpenHandler::open()");
+    throw ex;
+  }
+  RequestManager &manager = *manager_ptr;
+  auto self_ptr = m_self_weak.lock();
+  if (!self_ptr) {
+    edm::Exception ex(edm::errors::LogicError);
+    ex << "XrdCl::File::Open() => error: "
+       << "OpenHandler called after it was deleted.  This is a logic error "
+       << "and should be reported to the CMSSW developers.";
+    ex.addContext("Calling XrdAdapter::RequestManager::OpenHandler::open()");
+    throw ex;
+  }
 
-      // NOTE NOTE: we look at this variable *without* the lock.  This means the method
-      // is not thread-safe; the caller is responsible to verify it is not called from
-      // multiple threads simultaneously.
-      //
-      // This is done because ::open may be called from a Xrootd callback; if we
-      // tried to hold m_mutex here, this object's callback may also be active, hold m_mutex,
-      // and make a call into xrootd (when it invokes m_file.reset()).  Hence, our callback
-      // holds our mutex and attempts to grab an Xrootd mutex; RequestManager::requestFailure holds
-      // an Xrootd mutex and tries to hold m_mutex.  This is a classic deadlock.
-    if (m_outstanding_open)
-    {
-        return m_shared_future;
-    }
-    std::lock_guard<std::recursive_mutex> sentry(m_mutex);
-    std::promise<std::shared_ptr<Source> > new_promise;
-    m_promise.swap(new_promise);
-    m_shared_future = m_promise.get_future().share();
-
-    auto opaque = manager.prepareOpaqueString();
-    std::string new_name = manager.m_name + ((manager.m_name.find("?") == manager.m_name.npos) ? "?" : "&") + opaque;
-    edm::LogVerbatim("XrdAdaptorInternal") << "Trying to open URL: " << new_name;
-    m_file.reset(new XrdCl::File());
-    m_outstanding_open = true;
-
-    // Always make sure we release m_file and set m_outstanding_open to false on error.
-    std::unique_ptr<OpenHandler, std::function<void(OpenHandler*)>> exit_guard(this, [&](OpenHandler*){m_outstanding_open = false; m_file.reset();});
-
-    XrdCl::XRootDStatus status;
-    if (!(status = m_file->Open(new_name, manager.m_flags, manager.m_perms, this)).IsOK())
-    {
-      edm::Exception ex(edm::errors::FileOpenError);
-      ex << "XrdCl::File::Open(name='" << new_name
-         << "', flags=0x" << std::hex << manager.m_flags
-         << ", permissions=0" << std::oct << manager.m_perms << std::dec
-         << ") => error '" << status.ToStr()
-         << "' (errno=" << status.errNo << ", code=" << status.code << ")";
-      ex.addContext("Calling XrdAdaptor::RequestManager::OpenHandler::open()");
-      manager.addConnections(ex);
-      throw ex;
-    }
-    exit_guard.release();
-      // Have a strong self-reference for as long as the callback is in-progress.
-    m_self = self_ptr;
+  // NOTE NOTE: we look at this variable *without* the lock.  This means the method
+  // is not thread-safe; the caller is responsible to verify it is not called from
+  // multiple threads simultaneously.
+  //
+  // This is done because ::open may be called from a Xrootd callback; if we
+  // tried to hold m_mutex here, this object's callback may also be active, hold m_mutex,
+  // and make a call into xrootd (when it invokes m_file.reset()).  Hence, our callback
+  // holds our mutex and attempts to grab an Xrootd mutex; RequestManager::requestFailure holds
+  // an Xrootd mutex and tries to hold m_mutex.  This is a classic deadlock.
+  if (m_outstanding_open) {
     return m_shared_future;
-}
+  }
+  std::lock_guard<std::recursive_mutex> sentry(m_mutex);
+  std::promise<std::shared_ptr<Source>> new_promise;
+  m_promise.swap(new_promise);
+  m_shared_future = m_promise.get_future().share();
 
+  auto opaque = manager.prepareOpaqueString();
+  std::string new_name = manager.m_name + ((manager.m_name.find("?") == manager.m_name.npos) ? "?" : "&") + opaque;
+  edm::LogVerbatim("XrdAdaptorInternal") << "Trying to open URL: " << new_name;
+  m_file.reset(new XrdCl::File());
+  m_outstanding_open = true;
+
+  // Always make sure we release m_file and set m_outstanding_open to false on error.
+  std::unique_ptr<OpenHandler, std::function<void(OpenHandler *)>> exit_guard(this, [&](OpenHandler *) {
+    m_outstanding_open = false;
+    m_file.reset();
+  });
+
+  XrdCl::XRootDStatus status;
+  if (!(status = m_file->Open(new_name, manager.m_flags, manager.m_perms, this)).IsOK()) {
+    edm::Exception ex(edm::errors::FileOpenError);
+    ex << "XrdCl::File::Open(name='" << new_name << "', flags=0x" << std::hex << manager.m_flags << ", permissions=0"
+       << std::oct << manager.m_perms << std::dec << ") => error '" << status.ToStr() << "' (errno=" << status.errNo
+       << ", code=" << status.code << ")";
+    ex.addContext("Calling XrdAdaptor::RequestManager::OpenHandler::open()");
+    manager.addConnections(ex);
+    throw ex;
+  }
+  exit_guard.release();
+  // Have a strong self-reference for as long as the callback is in-progress.
+  m_self = self_ptr;
+  return m_shared_future;
+}

--- a/Utilities/XrdAdaptor/src/XrdRequestManager.cc
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.cc
@@ -243,7 +243,7 @@ void RequestManager::updateCurrentServer() {
     std::unique_ptr<std::string> hostname(hostname_ptr);
     edm::Service<edm::storage::StatisticsSenderService> statsService;
     if (statsService.isAvailable()) {
-      statsService->setCurrentServer(*hostname_ptr);
+      statsService->setCurrentServer(m_name, *hostname_ptr);
     }
   }
 }


### PR DESCRIPTION
#### PR description:

This PR is a combined backport of #35362 and #35505, following requests in #29412 and #36349. It also contains small part of https://github.com/cms-sw/cmssw/pull/26789 to make the cherry-picks easier, and #36403  (fully) as further cleanup.

#### PR validation:

Unit tests pass.