### PR TITLE
fix `CondDB` connection in `CondTools/SiStrip` miscalibration tools

### DIFF
--- a/CondTools/SiStrip/test/SiStripChannelGainFromDBMiscalibrator_cfg.py
+++ b/CondTools/SiStrip/test/SiStripChannelGainFromDBMiscalibrator_cfg.py
@@ -152,14 +152,14 @@ process.scaleAndSmearSiStripGains.params   = subsets  # as a cms.VPset
 ##
 ## Database output service
 ##
-process.load("CondCore.CondDB.CondDB_cfi")
+from CondCore.CondDB.CondDB_cfi import CondDB as _CondDB
 
 ##
 ## Output database (in this case local sqlite file)
 ##
-process.CondDB.connect = 'sqlite_file:modifiedSiStripGains_'+ process.GlobalTag.globaltag._value+'_IOV_'+str(options.runNumber)+".db"
+process.CondDBOutput = _CondDB.clone(connect = 'sqlite_file:modifiedSiStripGains_'+ process.GlobalTag.globaltag._value+'_IOV_'+str(options.runNumber)+".db")
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
-                                          process.CondDB,
+                                          process.CondDBOutput,
                                           timetype = cms.untracked.string('runnumber'),
                                           toPut = cms.VPSet(cms.PSet(record = cms.string('SiStripApvGainRcd'),
                                                                      tag = cms.string('modifiedGains')

--- a/CondTools/SiStrip/test/SiStripNoiseFromDBMiscalibrator_cfg.py
+++ b/CondTools/SiStrip/test/SiStripNoiseFromDBMiscalibrator_cfg.py
@@ -219,14 +219,14 @@ process.scaleAndSmearSiStripNoises.fillDefaults = False     # to fill uncabled D
 ##
 ## Database output service
 ##
-process.load("CondCore.CondDB.CondDB_cfi")
+from CondCore.CondDB.CondDB_cfi import CondDB as _CondDB
 
 ##
 ## Output database (in this case local sqlite file)
 ##
-process.CondDB.connect = 'sqlite_file:modifiedSiStripNoise_'+ process.GlobalTag.globaltag._value+'_IOV_'+str(options.runNumber)+".db"
+process.CondDBOutput = _CondDB.clone(connect = 'sqlite_file:modifiedSiStripNoise_'+ process.GlobalTag.globaltag._value+'_IOV_'+str(options.runNumber)+".db")
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
-                                          process.CondDB,
+                                          process.CondDBOutput,
                                           timetype = cms.untracked.string('runnumber'),
                                           toPut = cms.VPSet(cms.PSet(record = cms.string('SiStripNoisesRcd'),
                                                                      tag = cms.string('modifiedNoise')


### PR DESCRIPTION
resolves  https://github.com/cms-sw/cmssw/issues/36319

#### PR description:

Second follow up to https://github.com/cms-sw/cmssw/issues/36319.
Adapt the connection of `PoolDBOutputService` to use a clone of `CondCore.CondDB.CondDB_cfi.CondDB` instead of changing the parameters directly.

#### PR validation:

Unit test run `scram b runtests`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
