### PR TITLE
`CondTools/HLT` fix mistake done in #36129

### DIFF
--- a/CondTools/HLT/plugins/AlCaRecoTriggerBitsRcdRead.cc
+++ b/CondTools/HLT/plugins/AlCaRecoTriggerBitsRcdRead.cc
@@ -44,7 +44,8 @@ public:
 
   void analyze(const edm::Event &evt, const edm::EventSetup &evtSetup) override {}
   void beginRun(const edm::Run &run, const edm::EventSetup &evtSetup) override;
-  void endRun(edm::Run const &, edm::EventSetup const &) override;
+  void endRun(edm::Run const &, edm::EventSetup const &) override{};
+  void endJob() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
@@ -125,6 +126,7 @@ AlCaRecoTriggerBitsRcdRead::OutputType AlCaRecoTriggerBitsRcdRead::stringToEnum(
 ///////////////////////////////////////////////////////////////////////
 void AlCaRecoTriggerBitsRcdRead::beginRun(const edm::Run &run, const edm::EventSetup &iSetup) {
   if (watcher_.check(iSetup)) {  // new IOV for this run
+    edm::LogPrint("AlCaRecoTriggerBitsRcdRead") << "new IOV: " << firstRun_ << "-" << lastRun_ << std::endl;
     // Print last IOV - if there has already been one:
     if (lastRun_ != 0)
       this->printMap(firstRun_, lastRun_, lastTriggerBits_);
@@ -139,7 +141,7 @@ void AlCaRecoTriggerBitsRcdRead::beginRun(const edm::Run &run, const edm::EventS
 }
 
 ///////////////////////////////////////////////////////////////////////
-void AlCaRecoTriggerBitsRcdRead::endRun(edm::Run const &, edm::EventSetup const &) {
+void AlCaRecoTriggerBitsRcdRead::endJob() {
   // Print for very last IOV, not treated yet in beginRun(..):
   this->printMap(firstRun_, lastRun_, lastTriggerBits_);
 }

--- a/CondTools/HLT/plugins/AlCaRecoTriggerBitsRcdRead.cc
+++ b/CondTools/HLT/plugins/AlCaRecoTriggerBitsRcdRead.cc
@@ -44,7 +44,7 @@ public:
 
   void analyze(const edm::Event &evt, const edm::EventSetup &evtSetup) override {}
   void beginRun(const edm::Run &run, const edm::EventSetup &evtSetup) override;
-  void endRun(edm::Run const &, edm::EventSetup const &) override{};
+  void endRun(edm::Run const &, edm::EventSetup const &) override {}
   void endJob() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
@@ -126,7 +126,7 @@ AlCaRecoTriggerBitsRcdRead::OutputType AlCaRecoTriggerBitsRcdRead::stringToEnum(
 ///////////////////////////////////////////////////////////////////////
 void AlCaRecoTriggerBitsRcdRead::beginRun(const edm::Run &run, const edm::EventSetup &iSetup) {
   if (watcher_.check(iSetup)) {  // new IOV for this run
-    edm::LogPrint("AlCaRecoTriggerBitsRcdRead") << "new IOV: " << firstRun_ << "-" << lastRun_ << std::endl;
+    edm::LogPrint("AlCaRecoTriggerBitsRcdRead") << "new IOV: " << firstRun_ << "-" << lastRun_;
     // Print last IOV - if there has already been one:
     if (lastRun_ != 0)
       this->printMap(firstRun_, lastRun_, lastTriggerBits_);

--- a/CondTools/HLT/test/AlCaRecoTriggerBitsRcdRead_TEMPL_cfg.py
+++ b/CondTools/HLT/test/AlCaRecoTriggerBitsRcdRead_TEMPL_cfg.py
@@ -22,10 +22,7 @@ options.parseArguments()
 
 
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
-process.MessageLogger.cerr = cms.untracked.PSet(enable = cms.untracked.bool(False))
-process.MessageLogger.cout = cms.untracked.PSet(INFO = cms.untracked.PSet(
-    reportEvery = cms.untracked.int32(1000)
-    ))
+process.MessageLogger.cerr.FwkReport.reportEvery = 1000000
 
 # the module writing to DB
 from CondTools.HLT.alCaRecoTriggerBitsRcdRead_cfi import alCaRecoTriggerBitsRcdRead as _alCaRecoTriggerBitsRcdRead


### PR DESCRIPTION
#### PR description:

During the modernization of the code done in PR #36129 the `endJob` method was changed to be an `endRun`. 
This does not reflect how the code was designed originally as the `endJob` was suppposed to call for the very last time the `printMap()` method, only once for very last IOV, not treated yet in the previous `beginRun(..)`s.
The combination of this bug + the unit test introduced in PR https://github.com/cms-sw/cmssw/pull/36187 creates an output `.twiki` file of 1.3GB.... which now is back to 100k.

#### PR validation:

Run unit tests (`scram b runtests`)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A 
