### PR TITLE
check both algo and originalAlgo in electron track isolation calculators

### DIFF
--- a/RecoEgamma/EgammaIsolationAlgos/src/EleTkIsolFromCands.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/src/EleTkIsolFromCands.cc
@@ -180,7 +180,11 @@ bool EleTkIsolFromCands::passQual(const reco::TrackBase& trk, const std::vector<
 
 bool EleTkIsolFromCands::passAlgo(const reco::TrackBase& trk,
                                   const std::vector<reco::TrackBase::TrackAlgorithm>& algosToRej) {
-  return algosToRej.empty() || !std::binary_search(algosToRej.begin(), algosToRej.end(), trk.algo());
+  return algosToRej.empty() ||
+         //check also the originalAlgo in case the track is reconstructed by more than one
+         //reject only if both algo and originalAlgo are not acceptable
+         !(std::binary_search(algosToRej.begin(), algosToRej.end(), trk.algo()) &&
+           std::binary_search(algosToRej.begin(), algosToRej.end(), trk.originalAlgo()));
 }
 
 EleTkIsolFromCands::TrackTable const& EleTkIsolFromCands::getPreselectedTracks(bool isBarrel) {

--- a/RecoEgamma/EgammaIsolationAlgos/src/ElectronTkIsolation.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/src/ElectronTkIsolation.cc
@@ -107,7 +107,11 @@ double ElectronTkIsolation::getPtTracks(const reco::GsfElectron* electron) const
 bool ElectronTkIsolation::passAlgo(const reco::TrackBase& trk) const {
   int algo = trk.algo();
   bool rejAlgo = std::binary_search(algosToReject_.begin(), algosToReject_.end(), algo);
-  return rejAlgo == false;
+  //check also the originalAlgo in case the track is reconstructed by more than one
+  algo = trk.originalAlgo();
+  //reject only if both algo and originalAlgo are not acceptable
+  rejAlgo &= std::binary_search(algosToReject_.begin(), algosToReject_.end(), algo);
+  return !rejAlgo;
 }
 
 void ElectronTkIsolation::setAlgosToReject() {


### PR DESCRIPTION
similar to #35892, I'm proposing to check both the algo and the originalAlgo in track selections for EGM

@cms-sw/egamma-pog-l2 
this was prompted by the observations in the EXO validation https://indico.cern.ch/event/1102815/
https://indico.cern.ch/event/1102815/contributions/4639510/attachments/2357228/4025487/W%27toenu%20mkFit%20vaildation%20study%20Run3.pdf
(page 5)

