### PR TITLE
Inclusion of new ECAL PF cluster corrections in Run-3 MC GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -64,19 +64,19 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak'     : '122X_upgrade2018cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'           : '122X_mcRun3_2021_design_v3',
+    'phase1_2021_design'           : '122X_mcRun3_2021_design_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'        : '122X_mcRun3_2021_realistic_v3',
+    'phase1_2021_realistic'        : '122X_mcRun3_2021_realistic_v5',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'          : '122X_mcRun3_2021cosmics_realistic_deco_v3',
+    'phase1_2021_cosmics'          : '122X_mcRun3_2021cosmics_realistic_deco_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi'     : '122X_mcRun3_2021_realistic_HI_v3',
+    'phase1_2021_realistic_hi'     : '122X_mcRun3_2021_realistic_HI_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '122X_mcRun3_2023_realistic_v3',
+    'phase1_2023_realistic'        : '122X_mcRun3_2023_realistic_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '122X_mcRun3_2024_realistic_v3',
+    'phase1_2024_realistic'        : '122X_mcRun3_2024_realistic_v5',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             : '122X_mcRun4_realistic_v2'
+    'phase2_realistic'             : '122X_mcRun4_realistic_v4'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:

Last missing piece for the 12_2_X POG calibrations. Requested in [0],  discussed in the AlCaDB meeting today [1] and here [2], I've created new GTs

 * 122X_mcRun3_2021_design_v5
Diff: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_mcRun3_2021_design_v3/122X_mcRun3_2021_design_v5
 * 122X_mcRun3_2021_realistic_v5
Diff: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_mcRun3_2021_realistic_v3/122X_mcRun3_2021_realistic_v5
 * 122X_mcRun3_2021cosmics_realistic_deco_v5
Diff: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_mcRun3_2021cosmics_realistic_deco_v3/122X_mcRun3_2021cosmics_realistic_deco_v5
 * 122X_mcRun3_2021_realistic_HI_v5
Diff: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_mcRun3_2021_realistic_HI_v3/122X_mcRun3_2021_realistic_HI_v5
 * 122X_mcRun3_2023_realistic_v5
Diff: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_mcRun3_2023_realistic_v3/122X_mcRun3_2023_realistic_v5
 * 122X_mcRun3_2024_realistic_v5
Diff:https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_mcRun3_2024_realistic_v3/122X_mcRun3_2024_realistic_v5
 * 122X_mcRun4_realistic_v4
Diff: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_mcRun4_realistic_v2/122X_mcRun4_realistic_v4

[0] https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4558.html
[1] https://indico.cern.ch/event/1102567/
[2] https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4553.html

#### PR validation:

wf 12034.0,11634.0,7.23,159.0,12434.0,12834.0

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
