### PR TITLE
add PixelTrack quality monitoring to `SiPixelPhase1MonitorTrackSoA`

### DIFF
--- a/DQM/SiPixelPhase1Heterogeneous/plugins/SiPixelPhase1MonitorTrackSoA.cc
+++ b/DQM/SiPixelPhase1Heterogeneous/plugins/SiPixelPhase1MonitorTrackSoA.cc
@@ -44,6 +44,7 @@ private:
   MonitorElement* hphi;
   MonitorElement* hz;
   MonitorElement* htip;
+  MonitorElement* hquality;
 };
 
 //
@@ -85,6 +86,7 @@ void SiPixelPhase1MonitorTrackSoA::analyze(const edm::Event& iEvent, const edm::
     float zip = tsoa.zip(it);
     float eta = tsoa.eta(it);
     float tip = tsoa.tip(it);
+    pixelTrack::Quality qual = tsoa.quality(it);
     hchi2->Fill(chi2);
     hnHits->Fill(nHits);
     hpt->Fill(pt);
@@ -92,6 +94,7 @@ void SiPixelPhase1MonitorTrackSoA::analyze(const edm::Event& iEvent, const edm::
     hphi->Fill(phi);
     hz->Fill(zip);
     htip->Fill(tip);
+    hquality->Fill(int(qual));
     nTracks++;
   }
   hnTracks->Fill(nTracks);
@@ -112,7 +115,13 @@ void SiPixelPhase1MonitorTrackSoA::bookHistograms(DQMStore::IBooker& ibooker,
   heta = ibooker.book1D("eta", ";Track #eta;#entries", 30, -3., 3.);
   hphi = ibooker.book1D("phi", ";Track #phi;#entries", 30, -M_PI, M_PI);
   hz = ibooker.book1D("z", ";Track z;#entries", 30, -30., 30.);
-  htip = ibooker.book1D("tip", "", 100, -0.5, 0.5);
+  htip = ibooker.book1D("tip", ";Track TIP;#entries", 100, -0.5, 0.5);
+  hquality = ibooker.book1D("quality", ";Track Quality;#entries", 7, -0.5, 6.5);
+  uint i = 1;
+  for (const auto& q : pixelTrack::qualityName) {
+    hquality->setBinLabel(i, q, 1);
+    i++;
+  }
 }
 
 void SiPixelPhase1MonitorTrackSoA::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {


### PR DESCRIPTION
#### PR description:

The goal of this PR is to restructure `SiPixelPhase1MonitorTrackSoA` to use the pixel track quality information.
Two commits are proposed:
   * 1df6972 : add PixelTrack quality monitoring to `SiPixelPhase1MonitorTrackSoA`
   * 86af604 : SiPixelPhase1MonitorTrackSoA: restructure PixelTrack monitoring to filter for loose and above track quality

#### PR validation:

Run `runTheMatrix.py --what gpu -l 11634.506` on a `lxplus-gpu` node.
Obtained the following plot:

![image](https://user-images.githubusercontent.com/5082376/145060693-626332af-ce74-4af2-a47f-d8f20fab8674.png)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, but probably to be backported?
cc:
@VinInn @sroychow @vmariani 
