### PR TITLE
Add data-vs-emulator plots for L1T shower DQM

### DIFF
--- a/DQM/L1TMonitor/interface/L1TdeCSCTPGShower.h
+++ b/DQM/L1TMonitor/interface/L1TdeCSCTPGShower.h
@@ -1,0 +1,49 @@
+#ifndef DQM_L1TMonitor_L1TdeCSCTPGShower_h
+#define DQM_L1TMonitor_L1TdeCSCTPGShower_h
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+
+#include "DataFormats/CSCDigi/interface/CSCShowerDigiCollection.h"
+
+class L1TdeCSCTPGShower : public DQMEDAnalyzer {
+public:
+  L1TdeCSCTPGShower(const edm::ParameterSet& ps);
+  ~L1TdeCSCTPGShower() override;
+
+protected:
+  void bookHistograms(DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&) override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+private:
+  bool areSameShowers(const CSCShowerDigi& lhs, const CSCShowerDigi& rhs) const;
+
+  edm::EDGetTokenT<CSCShowerDigiCollection> dataALCTShower_token_;
+  edm::EDGetTokenT<CSCShowerDigiCollection> emulALCTShower_token_;
+  edm::EDGetTokenT<CSCShowerDigiCollection> dataCLCTShower_token_;
+  edm::EDGetTokenT<CSCShowerDigiCollection> emulCLCTShower_token_;
+  edm::EDGetTokenT<CSCShowerDigiCollection> dataLCTShower_token_;
+  edm::EDGetTokenT<CSCShowerDigiCollection> emulLCTShower_token_;
+
+  std::string monitorDir_;
+
+  MonitorElement* lctShowerDataSummary_denom_;
+  MonitorElement* lctShowerDataSummary_num_;
+  MonitorElement* alctShowerDataSummary_denom_;
+  MonitorElement* alctShowerDataSummary_num_;
+  MonitorElement* clctShowerDataSummary_denom_;
+  MonitorElement* clctShowerDataSummary_num_;
+
+  MonitorElement* lctShowerEmulSummary_denom_;
+  MonitorElement* lctShowerEmulSummary_num_;
+  MonitorElement* alctShowerEmulSummary_denom_;
+  MonitorElement* alctShowerEmulSummary_num_;
+  MonitorElement* clctShowerEmulSummary_denom_;
+  MonitorElement* clctShowerEmulSummary_num_;
+};
+
+#endif

--- a/DQM/L1TMonitor/interface/L1TdeStage2Shower.h
+++ b/DQM/L1TMonitor/interface/L1TdeStage2Shower.h
@@ -1,0 +1,34 @@
+#ifndef DQM_L1TMonitor_L1TdeStage2Shower_h
+#define DQM_L1TMonitor_L1TdeStage2Shower_h
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+
+#include "DataFormats/L1TMuon/interface/RegionalMuonShower.h"
+
+class L1TdeStage2Shower : public DQMEDAnalyzer {
+public:
+  L1TdeStage2Shower(const edm::ParameterSet& ps);
+  ~L1TdeStage2Shower() override;
+
+protected:
+  void bookHistograms(DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&) override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+private:
+  edm::EDGetTokenT<l1t::RegionalMuonShowerBxCollection> data_EMTFShower_token_;
+  edm::EDGetTokenT<l1t::RegionalMuonShowerBxCollection> emul_EMTFShower_token_;
+
+  std::string monitorDir_;
+
+  MonitorElement* emtfShowerDataSummary_denom_;
+  MonitorElement* emtfShowerDataSummary_num_;
+  MonitorElement* emtfShowerEmulSummary_denom_;
+  MonitorElement* emtfShowerEmulSummary_num_;
+};
+
+#endif

--- a/DQM/L1TMonitor/plugins/SealModule.cc
+++ b/DQM/L1TMonitor/plugins/SealModule.cc
@@ -104,11 +104,17 @@ DEFINE_FWK_MODULE(L1TdeGEMTPG);
 #include "DQM/L1TMonitor/interface/L1TdeCSCTPG.h"
 DEFINE_FWK_MODULE(L1TdeCSCTPG);
 
+#include "DQM/L1TMonitor/interface/L1TdeCSCTPGShower.h"
+DEFINE_FWK_MODULE(L1TdeCSCTPGShower);
+
 #include "DQM/L1TMonitor/interface/L1TdeCSCTF.h"
 DEFINE_FWK_MODULE(L1TdeCSCTF);
 
 #include "DQM/L1TMonitor/interface/L1TdeStage2EMTF.h"
 DEFINE_FWK_MODULE(L1TdeStage2EMTF);
+
+#include "DQM/L1TMonitor/interface/L1TdeStage2Shower.h"
+DEFINE_FWK_MODULE(L1TdeStage2Shower);
 
 //#include "DQM/L1TMonitor/interface/L1GtHwValidation.h"
 //DEFINE_FWK_MODULE(L1GtHwValidation);

--- a/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
@@ -121,7 +121,6 @@ Stage2L1HardwareValidation = cms.Sequence(
     valBmtfAlgoSel +
     valOmtfDigis +
     valEmtfStage2Digis +
-    valEmtfStage2Showers +
     valGmtCaloSumDigis +
     valGmtStage2Digis +
     valGtStage2Digis
@@ -130,6 +129,10 @@ Stage2L1HardwareValidation = cms.Sequence(
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 _run3_Stage2L1HardwareValidation = Stage2L1HardwareValidation.copy()
 run3_GEM.toReplaceWith( Stage2L1HardwareValidation, cms.Sequence( valMuonGEMPadDigis + valMuonGEMPadDigiClusters + _run3_Stage2L1HardwareValidation) )
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+_run3Shower_Stage2L1HardwareValidation = Stage2L1HardwareValidation.copy()
+run3_common.toReplaceWith( Stage2L1HardwareValidation, cms.Sequence(_run3Shower_Stage2L1HardwareValidation + valEmtfStage2Showers) )
 
 Stage2L1HardwareValidationForValidationEvents = cms.Sequence(
     valCaloStage2Layer2Digis
@@ -178,7 +181,6 @@ l1tStage2EmulatorOnlineDQM = cms.Sequence(
     l1tdeStage2BmtfSecond +
     l1tdeStage2Omtf +
     l1tdeCSCTPG +
-    l1tdeCSCTPGShower +
     l1tdeStage2EmtfOnlineDQMSeq +
     l1tStage2uGMTEmulatorOnlineDQMSeq +
     l1tdeStage2uGT +
@@ -190,6 +192,10 @@ _run3_l1tStage2EmulatorOnlineDQM += l1tdeGEMTPG
 
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toReplaceWith( l1tStage2EmulatorOnlineDQM, _run3_l1tStage2EmulatorOnlineDQM )
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+_run3shower_l1tStage2EmulatorOnlineDQM = l1tStage2EmulatorOnlineDQM.copy()
+run3_common.toReplaceWith( l1tStage2EmulatorOnlineDQM, cms.Sequence(_run3shower_l1tStage2EmulatorOnlineDQM + l1tdeCSCTPGShower) )
 
 # sequence to run only for validation events
 l1tStage2EmulatorOnlineDQMValidationEvents = cms.Sequence(

--- a/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
@@ -78,6 +78,11 @@ valEmtfStage2Digis = simEmtfDigis.clone(
     RPCInput = "muonRPCDigis",
     GEMInput = 'valMuonGEMPadDigiClusters'
 )
+# EMTF shower
+from L1Trigger.L1TMuonEndCap.simEmtfShowers_cfi import *
+valEmtfStage2Showers = simEmtfShowers.clone(
+    CSCShowerInput = cms.InputTag('valCscStage2Digis')
+)
 
 # uGMT
 from L1Trigger.L1TMuon.simGmtStage2Digis_cfi import *
@@ -116,6 +121,7 @@ Stage2L1HardwareValidation = cms.Sequence(
     valBmtfAlgoSel +
     valOmtfDigis +
     valEmtfStage2Digis +
+    valEmtfStage2Showers +
     valGmtCaloSumDigis +
     valGmtStage2Digis +
     valGtStage2Digis
@@ -144,6 +150,7 @@ from DQM.L1TMonitor.L1TdeGEMTPG_cfi import *
 
 # CSC TPG
 from DQM.L1TMonitor.L1TdeCSCTPG_cfi import *
+from DQM.L1TMonitor.L1TdeCSCTPGShower_cfi import *
 
 # BMTF
 from DQM.L1TMonitor.L1TdeStage2BMTF_cfi import *
@@ -171,6 +178,7 @@ l1tStage2EmulatorOnlineDQM = cms.Sequence(
     l1tdeStage2BmtfSecond +
     l1tdeStage2Omtf +
     l1tdeCSCTPG +
+    l1tdeCSCTPGShower +
     l1tdeStage2EmtfOnlineDQMSeq +
     l1tStage2uGMTEmulatorOnlineDQMSeq +
     l1tdeStage2uGT +

--- a/DQM/L1TMonitor/python/L1TdeCSCTPGShower_cfi.py
+++ b/DQM/L1TMonitor/python/L1TdeCSCTPGShower_cfi.py
@@ -1,0 +1,20 @@
+import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+
+l1tdeCSCTPGShower = DQMEDAnalyzer(
+    "L1TdeCSCTPGShower",
+    # CSC Showers not in data yet. Use Emul for both
+    # Once Run 3 firmware are implemented, should change data tags to 
+    # cms.InputTag("muonCSCDigis", "MuonCSCShowerDigi") for correlated shower,
+    # something like cms.InputTag("muonCSCDigis", "MuonCSCShowerDigiAnode") for Anode shower,
+    # and something like cms.InputTag("muonCSCDigis", "MuonCSCShowerDigiCathode") for Cathode shower
+    # - 2021.12.06 Xunwu Zuo
+    dataALCTShower = cms.InputTag("valCscStage2Digis", "Anode"),
+    emulALCTShower = cms.InputTag("valCscStage2Digis", "Anode"),
+    dataCLCTShower = cms.InputTag("valCscStage2Digis", "Cathode"),
+    emulCLCTShower = cms.InputTag("valCscStage2Digis", "Cathode"),
+    dataLCTShower = cms.InputTag("valCscStage2Digis"),
+    emulLCTShower = cms.InputTag("valCscStage2Digis"),
+    monitorDir = cms.untracked.string("L1TEMU/L1TdeCSCTPGShower"),
+)
+

--- a/DQM/L1TMonitor/python/L1TdeStage2EMTF_cff.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2EMTF_cff.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from DQM.L1TMonitor.L1TdeStage2EMTF_cfi import *
+from DQM.L1TMonitor.L1TdeStage2Shower_cfi import *
 
 # List of bins to ignore
 ignoreBinsDeStage2Emtf = [1]
@@ -24,6 +25,7 @@ l1tdeStage2EmtfComp = DQMEDAnalyzer(
 # sequences
 l1tdeStage2EmtfOnlineDQMSeq = cms.Sequence(
     l1tdeStage2Emtf +
+    l1tdeStage2Shower +
     l1tdeStage2EmtfComp
 )
 

--- a/DQM/L1TMonitor/python/L1TdeStage2EMTF_cff.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2EMTF_cff.py
@@ -25,7 +25,9 @@ l1tdeStage2EmtfComp = DQMEDAnalyzer(
 # sequences
 l1tdeStage2EmtfOnlineDQMSeq = cms.Sequence(
     l1tdeStage2Emtf +
-    l1tdeStage2Shower +
     l1tdeStage2EmtfComp
 )
 
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+_run3shower_l1tdeStage2EmtfOnlineDQMSeq = l1tdeStage2EmtfOnlineDQMSeq.copy()
+run3_common.toReplaceWith(l1tdeStage2EmtfOnlineDQMSeq, cms.Sequence(_run3shower_l1tdeStage2EmtfOnlineDQMSeq + l1tdeStage2Shower))

--- a/DQM/L1TMonitor/python/L1TdeStage2Shower_cfi.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2Shower_cfi.py
@@ -1,0 +1,17 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+l1tdeStage2Shower = DQMEDAnalyzer(
+    "L1TdeStage2Shower",
+    # EMTF Showers not in data yet. Use Emul for both
+    # Once Run 3 firmware are implemented, should change data tags to 
+    # cms.InputTag("emtfStage2Digis")
+    # - 2021.12.06 Xunwu Zuo
+
+#    dataSource = cms.InputTag("simEmtfShowers", "EMTF"),
+#    emulSource = cms.InputTag("simEmtfShowers", "EMTF"),
+    dataSource = cms.InputTag("valEmtfStage2Showers", "EMTF"),
+    emulSource = cms.InputTag("valEmtfStage2Showers", "EMTF"),
+    monitorDir = cms.untracked.string("L1TEMU/L1TdeStage2EMTF/Shower"),
+)
+

--- a/DQM/L1TMonitor/src/L1TdeCSCTPGShower.cc
+++ b/DQM/L1TMonitor/src/L1TdeCSCTPGShower.cc
@@ -158,6 +158,7 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
             int sr = histIndexCSC.at({stat, ring});
             if (endc == 1)
               sr = 17 - sr;
+            bool chamber20 = (sr == 1 or sr == 3 or sr == 5 or sr == 12 or sr == 14 or sr == 16);
 
             // ALCT analysis
             auto range_dataALCT = dataALCTshs->get(detid);
@@ -165,11 +166,21 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
 
             for (auto dalct = range_dataALCT.first; dalct != range_dataALCT.second; dalct++) {
               if (dalct->isValid()) {
-                alctShowerDataSummary_denom_->Fill(chamber, sr);
+                if (chamber20) {
+                  alctShowerDataSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
+                  alctShowerDataSummary_denom_->Fill(chamber * 2, sr, 0.5);
+                }
+                else
+                  alctShowerDataSummary_denom_->Fill(chamber, sr);
                 // check for least one matching ALCT
                 for (auto ealct = range_emulALCT.first; ealct != range_emulALCT.second; ealct++) {
                   if (ealct->isValid() and areSameShowers(*dalct, *ealct)) {
-                    alctShowerDataSummary_num_->Fill(chamber, sr);
+                    if (chamber20) {
+                      alctShowerDataSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
+                      alctShowerDataSummary_num_->Fill(chamber * 2, sr, 0.5);
+                    }
+                    else
+                      alctShowerDataSummary_num_->Fill(chamber, sr);
                   }
                 }
               }
@@ -178,7 +189,12 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
             for (auto ealct = range_emulALCT.first; ealct != range_emulALCT.second; ealct++) {
               bool isMatched = false;
               if (ealct->isValid()) {
-                alctShowerEmulSummary_denom_->Fill(chamber, sr);
+                if (chamber20) {
+                  alctShowerEmulSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
+                  alctShowerEmulSummary_denom_->Fill(chamber * 2, sr, 0.5);
+                }
+                else
+                  alctShowerEmulSummary_denom_->Fill(chamber, sr);
                 // check for least one matching ALCT
                 for (auto dalct = range_dataALCT.first; dalct != range_dataALCT.second; dalct++) {
                   if (areSameShowers(*dalct, *ealct))
@@ -187,7 +203,12 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                 // only fill when it is not matched to an ALCT
                 // to understand if the emulator is producing too many ALCTs
                 if (!isMatched) {
-                  alctShowerEmulSummary_num_->Fill(chamber, sr);
+                  if (chamber20) {
+                    alctShowerEmulSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
+                    alctShowerEmulSummary_num_->Fill(chamber * 2, sr, 0.5);
+                  }
+                  else
+                    alctShowerEmulSummary_num_->Fill(chamber, sr);
                 }
               }
             }
@@ -198,11 +219,21 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
 
             for (auto dclct = range_dataCLCT.first; dclct != range_dataCLCT.second; dclct++) {
               if (dclct->isValid()) {
-                clctShowerDataSummary_denom_->Fill(chamber, sr);
+                if (chamber20) {
+                  clctShowerDataSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
+                  clctShowerDataSummary_denom_->Fill(chamber * 2, sr, 0.5);
+                }
+                else
+                  clctShowerDataSummary_denom_->Fill(chamber, sr);
                 // check for least one matching CLCT
                 for (auto eclct = range_emulCLCT.first; eclct != range_emulCLCT.second; eclct++) {
                   if (eclct->isValid() and areSameShowers(*dclct, *eclct)) {
-                    clctShowerDataSummary_num_->Fill(chamber, sr);
+                    if (chamber20) {
+                      clctShowerDataSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
+                      clctShowerDataSummary_num_->Fill(chamber * 2, sr, 0.5);
+                    }
+                    else
+                      clctShowerDataSummary_num_->Fill(chamber, sr);
                   }
                 }
               }
@@ -211,7 +242,12 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
             for (auto eclct = range_emulCLCT.first; eclct != range_emulCLCT.second; eclct++) {
               bool isMatched = false;
               if (eclct->isValid()) {
-                clctShowerEmulSummary_denom_->Fill(chamber, sr);
+                if (chamber20) {
+                  clctShowerEmulSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
+                  clctShowerEmulSummary_denom_->Fill(chamber * 2, sr, 0.5);
+                }
+                else
+                  clctShowerEmulSummary_denom_->Fill(chamber, sr);
                 // check for least one matching CLCT
                 for (auto dclct = range_dataCLCT.first; dclct != range_dataCLCT.second; dclct++) {
                   if (areSameShowers(*dclct, *eclct))
@@ -220,7 +256,12 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                 // only fill when it is not matched to an CLCT
                 // to understand if the emulator is producing too many CLCTs
                 if (!isMatched) {
-                  clctShowerEmulSummary_num_->Fill(chamber, sr);
+                  if (chamber20) {
+                    clctShowerEmulSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
+                    clctShowerEmulSummary_num_->Fill(chamber * 2, sr, 0.5);
+                  }
+                  else
+                    clctShowerEmulSummary_num_->Fill(chamber, sr);
                 }
               }
             }
@@ -231,11 +272,21 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
 
             for (auto dlct = range_dataLCT.first; dlct != range_dataLCT.second; dlct++) {
               if (dlct->isValid()) {
-                lctShowerDataSummary_denom_->Fill(chamber, sr);
+                if (chamber20) {
+                  lctShowerDataSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
+                  lctShowerDataSummary_denom_->Fill(chamber * 2, sr, 0.5);
+                }
+                else
+                  lctShowerDataSummary_denom_->Fill(chamber, sr);
                 // check for least one matching LCT
                 for (auto elct = range_emulLCT.first; elct != range_emulLCT.second; elct++) {
                   if (elct->isValid() and areSameShowers(*dlct, *elct)) {
-                    lctShowerDataSummary_num_->Fill(chamber, sr);
+                    if (chamber20) {
+                      lctShowerDataSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
+                      lctShowerDataSummary_num_->Fill(chamber * 2, sr, 0.5);
+                    }
+                    else
+                      lctShowerDataSummary_num_->Fill(chamber, sr);
                   }
                 }
               }
@@ -244,7 +295,12 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
             for (auto elct = range_emulLCT.first; elct != range_emulLCT.second; elct++) {
               bool isMatched = false;
               if (elct->isValid()) {
-                lctShowerEmulSummary_denom_->Fill(chamber, sr);
+                if (chamber20) {
+                  lctShowerEmulSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
+                  lctShowerEmulSummary_denom_->Fill(chamber * 2, sr, 0.5);
+                }
+                else
+                  lctShowerEmulSummary_denom_->Fill(chamber, sr);
                 // check for least one matching LCT
                 for (auto dlct = range_dataLCT.first; dlct != range_dataLCT.second; dlct++) {
                   if (areSameShowers(*dlct, *elct))
@@ -253,7 +309,12 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                 // only fill when it is not matched to an LCT
                 // to understand if the emulator is producing too many LCTs
                 if (!isMatched) {
-                  lctShowerEmulSummary_num_->Fill(chamber, sr);
+                  if (chamber20) {
+                    lctShowerEmulSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
+                    lctShowerEmulSummary_num_->Fill(chamber * 2, sr, 0.5);
+                  }
+                  else
+                    lctShowerEmulSummary_num_->Fill(chamber, sr);
                 }
               }
             }

--- a/DQM/L1TMonitor/src/L1TdeCSCTPGShower.cc
+++ b/DQM/L1TMonitor/src/L1TdeCSCTPGShower.cc
@@ -12,27 +12,37 @@ L1TdeCSCTPGShower::L1TdeCSCTPGShower(const edm::ParameterSet& ps)
       emulLCTShower_token_(consumes<CSCShowerDigiCollection>(ps.getParameter<edm::InputTag>("emulLCTShower"))),
       monitorDir_(ps.getUntrackedParameter<std::string>("monitorDir")) {}
 
-
-
 L1TdeCSCTPGShower::~L1TdeCSCTPGShower() {}
 
 void L1TdeCSCTPGShower::bookHistograms(DQMStore::IBooker& iBooker, const edm::Run&, const edm::EventSetup&) {
   iBooker.setCurrentFolder(monitorDir_);
 
   // 2D summary plots
-  lctShowerDataSummary_denom_ = iBooker.book2D("lct_cscshower_data_summary_denom", "Data LCT Shower All", 36, 1, 37, 18, 0, 18);
-  lctShowerDataSummary_num_ = iBooker.book2D("lct_cscshower_data_summary_num", "Data LCT Shower Emul Matched", 36, 1, 37, 18, 0, 18);
-  alctShowerDataSummary_denom_ = iBooker.book2D("alct_cscshower_data_summary_denom", "Data ALCT Shower All", 36, 1, 37, 18, 0, 18);
-  alctShowerDataSummary_num_ = iBooker.book2D("alct_cscshower_data_summary_num", "Data ALCT Shower Emul Matched", 36, 1, 37, 18, 0, 18);
-  clctShowerDataSummary_denom_ = iBooker.book2D("clct_cscshower_data_summary_denom", "Data CLCT Shower All", 36, 1, 37, 18, 0, 18);
-  clctShowerDataSummary_num_ = iBooker.book2D("clct_cscshower_data_summary_num", "Data CLCT Shower Emul Matched", 36, 1, 37, 18, 0, 18);
+  lctShowerDataSummary_denom_ =
+      iBooker.book2D("lct_cscshower_data_summary_denom", "Data LCT Shower All", 36, 1, 37, 18, 0, 18);
+  lctShowerDataSummary_num_ =
+      iBooker.book2D("lct_cscshower_data_summary_num", "Data LCT Shower Emul Matched", 36, 1, 37, 18, 0, 18);
+  alctShowerDataSummary_denom_ =
+      iBooker.book2D("alct_cscshower_data_summary_denom", "Data ALCT Shower All", 36, 1, 37, 18, 0, 18);
+  alctShowerDataSummary_num_ =
+      iBooker.book2D("alct_cscshower_data_summary_num", "Data ALCT Shower Emul Matched", 36, 1, 37, 18, 0, 18);
+  clctShowerDataSummary_denom_ =
+      iBooker.book2D("clct_cscshower_data_summary_denom", "Data CLCT Shower All", 36, 1, 37, 18, 0, 18);
+  clctShowerDataSummary_num_ =
+      iBooker.book2D("clct_cscshower_data_summary_num", "Data CLCT Shower Emul Matched", 36, 1, 37, 18, 0, 18);
 
-  lctShowerEmulSummary_denom_ = iBooker.book2D("lct_cscshower_emul_summary_denom", "Emul LCT Shower All", 36, 1, 37, 18, 0, 18);
-  lctShowerEmulSummary_num_ = iBooker.book2D("lct_cscshower_emul_summary_num", "Emul LCT Shower Not Matched to Data", 36, 1, 37, 18, 0, 18);
-  alctShowerEmulSummary_denom_ = iBooker.book2D("alct_cscshower_emul_summary_denom", "Emul ALCT Shower All", 36, 1, 37, 18, 0, 18);
-  alctShowerEmulSummary_num_ = iBooker.book2D("alct_cscshower_emul_summary_num", "Emul ALCT Shower Not Matched to Data", 36, 1, 37, 18, 0, 18);
-  clctShowerEmulSummary_denom_ = iBooker.book2D("clct_cscshower_emul_summary_denom", "Emul CLCT Shower All", 36, 1, 37, 18, 0, 18);
-  clctShowerEmulSummary_num_ = iBooker.book2D("clct_cscshower_emul_summary_num", "Emul CLCT Shower Not Matched to Data", 36, 1, 37, 18, 0, 18);
+  lctShowerEmulSummary_denom_ =
+      iBooker.book2D("lct_cscshower_emul_summary_denom", "Emul LCT Shower All", 36, 1, 37, 18, 0, 18);
+  lctShowerEmulSummary_num_ =
+      iBooker.book2D("lct_cscshower_emul_summary_num", "Emul LCT Shower Not Matched to Data", 36, 1, 37, 18, 0, 18);
+  alctShowerEmulSummary_denom_ =
+      iBooker.book2D("alct_cscshower_emul_summary_denom", "Emul ALCT Shower All", 36, 1, 37, 18, 0, 18);
+  alctShowerEmulSummary_num_ =
+      iBooker.book2D("alct_cscshower_emul_summary_num", "Emul ALCT Shower Not Matched to Data", 36, 1, 37, 18, 0, 18);
+  clctShowerEmulSummary_denom_ =
+      iBooker.book2D("clct_cscshower_emul_summary_denom", "Emul CLCT Shower All", 36, 1, 37, 18, 0, 18);
+  clctShowerEmulSummary_num_ =
+      iBooker.book2D("clct_cscshower_emul_summary_num", "Emul CLCT Shower Not Matched to Data", 36, 1, 37, 18, 0, 18);
 
   // x labels
   lctShowerDataSummary_denom_->setAxisTitle("Chamber", 1);
@@ -169,8 +179,7 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                 if (chamber20) {
                   alctShowerDataSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
                   alctShowerDataSummary_denom_->Fill(chamber * 2, sr, 0.5);
-                }
-                else
+                } else
                   alctShowerDataSummary_denom_->Fill(chamber, sr);
                 // check for least one matching ALCT
                 for (auto ealct = range_emulALCT.first; ealct != range_emulALCT.second; ealct++) {
@@ -178,8 +187,7 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                     if (chamber20) {
                       alctShowerDataSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
                       alctShowerDataSummary_num_->Fill(chamber * 2, sr, 0.5);
-                    }
-                    else
+                    } else
                       alctShowerDataSummary_num_->Fill(chamber, sr);
                   }
                 }
@@ -192,8 +200,7 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                 if (chamber20) {
                   alctShowerEmulSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
                   alctShowerEmulSummary_denom_->Fill(chamber * 2, sr, 0.5);
-                }
-                else
+                } else
                   alctShowerEmulSummary_denom_->Fill(chamber, sr);
                 // check for least one matching ALCT
                 for (auto dalct = range_dataALCT.first; dalct != range_dataALCT.second; dalct++) {
@@ -206,8 +213,7 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                   if (chamber20) {
                     alctShowerEmulSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
                     alctShowerEmulSummary_num_->Fill(chamber * 2, sr, 0.5);
-                  }
-                  else
+                  } else
                     alctShowerEmulSummary_num_->Fill(chamber, sr);
                 }
               }
@@ -222,8 +228,7 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                 if (chamber20) {
                   clctShowerDataSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
                   clctShowerDataSummary_denom_->Fill(chamber * 2, sr, 0.5);
-                }
-                else
+                } else
                   clctShowerDataSummary_denom_->Fill(chamber, sr);
                 // check for least one matching CLCT
                 for (auto eclct = range_emulCLCT.first; eclct != range_emulCLCT.second; eclct++) {
@@ -231,8 +236,7 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                     if (chamber20) {
                       clctShowerDataSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
                       clctShowerDataSummary_num_->Fill(chamber * 2, sr, 0.5);
-                    }
-                    else
+                    } else
                       clctShowerDataSummary_num_->Fill(chamber, sr);
                   }
                 }
@@ -245,8 +249,7 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                 if (chamber20) {
                   clctShowerEmulSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
                   clctShowerEmulSummary_denom_->Fill(chamber * 2, sr, 0.5);
-                }
-                else
+                } else
                   clctShowerEmulSummary_denom_->Fill(chamber, sr);
                 // check for least one matching CLCT
                 for (auto dclct = range_dataCLCT.first; dclct != range_dataCLCT.second; dclct++) {
@@ -259,8 +262,7 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                   if (chamber20) {
                     clctShowerEmulSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
                     clctShowerEmulSummary_num_->Fill(chamber * 2, sr, 0.5);
-                  }
-                  else
+                  } else
                     clctShowerEmulSummary_num_->Fill(chamber, sr);
                 }
               }
@@ -275,8 +277,7 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                 if (chamber20) {
                   lctShowerDataSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
                   lctShowerDataSummary_denom_->Fill(chamber * 2, sr, 0.5);
-                }
-                else
+                } else
                   lctShowerDataSummary_denom_->Fill(chamber, sr);
                 // check for least one matching LCT
                 for (auto elct = range_emulLCT.first; elct != range_emulLCT.second; elct++) {
@@ -284,22 +285,20 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                     if (chamber20) {
                       lctShowerDataSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
                       lctShowerDataSummary_num_->Fill(chamber * 2, sr, 0.5);
-                    }
-                    else
+                    } else
                       lctShowerDataSummary_num_->Fill(chamber, sr);
                   }
                 }
               }
             }
-            
+
             for (auto elct = range_emulLCT.first; elct != range_emulLCT.second; elct++) {
               bool isMatched = false;
               if (elct->isValid()) {
                 if (chamber20) {
                   lctShowerEmulSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
                   lctShowerEmulSummary_denom_->Fill(chamber * 2, sr, 0.5);
-                }
-                else
+                } else
                   lctShowerEmulSummary_denom_->Fill(chamber, sr);
                 // check for least one matching LCT
                 for (auto dlct = range_dataLCT.first; dlct != range_dataLCT.second; dlct++) {
@@ -312,8 +311,7 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                   if (chamber20) {
                     lctShowerEmulSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
                     lctShowerEmulSummary_num_->Fill(chamber * 2, sr, 0.5);
-                  }
-                  else
+                  } else
                     lctShowerEmulSummary_num_->Fill(chamber, sr);
                 }
               }
@@ -327,8 +325,8 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
 
 bool L1TdeCSCTPGShower::areSameShowers(const CSCShowerDigi& lhs, const CSCShowerDigi& rhs) const {
   bool returnValue = false;
-  if (lhs.isValid() == rhs.isValid() && lhs.getCSCID() == rhs.getCSCID() &&
-      lhs.bitsInTime() == rhs.bitsInTime() && lhs.bitsOutOfTime() == rhs.bitsOutOfTime()) {
+  if (lhs.isValid() == rhs.isValid() && lhs.getCSCID() == rhs.getCSCID() && lhs.bitsInTime() == rhs.bitsInTime() &&
+      lhs.bitsOutOfTime() == rhs.bitsOutOfTime()) {
     returnValue = true;
   }
   return returnValue;

--- a/DQM/L1TMonitor/src/L1TdeCSCTPGShower.cc
+++ b/DQM/L1TMonitor/src/L1TdeCSCTPGShower.cc
@@ -1,0 +1,274 @@
+#include <string>
+
+#include "DQM/L1TMonitor/interface/L1TdeCSCTPGShower.h"
+#include "DataFormats/MuonDetId/interface/CSCTriggerNumbering.h"
+
+L1TdeCSCTPGShower::L1TdeCSCTPGShower(const edm::ParameterSet& ps)
+    : dataALCTShower_token_(consumes<CSCShowerDigiCollection>(ps.getParameter<edm::InputTag>("dataALCTShower"))),
+      emulALCTShower_token_(consumes<CSCShowerDigiCollection>(ps.getParameter<edm::InputTag>("emulALCTShower"))),
+      dataCLCTShower_token_(consumes<CSCShowerDigiCollection>(ps.getParameter<edm::InputTag>("dataCLCTShower"))),
+      emulCLCTShower_token_(consumes<CSCShowerDigiCollection>(ps.getParameter<edm::InputTag>("emulCLCTShower"))),
+      dataLCTShower_token_(consumes<CSCShowerDigiCollection>(ps.getParameter<edm::InputTag>("dataLCTShower"))),
+      emulLCTShower_token_(consumes<CSCShowerDigiCollection>(ps.getParameter<edm::InputTag>("emulLCTShower"))),
+      monitorDir_(ps.getUntrackedParameter<std::string>("monitorDir")) {}
+
+
+
+L1TdeCSCTPGShower::~L1TdeCSCTPGShower() {}
+
+void L1TdeCSCTPGShower::bookHistograms(DQMStore::IBooker& iBooker, const edm::Run&, const edm::EventSetup&) {
+  iBooker.setCurrentFolder(monitorDir_);
+
+  // 2D summary plots
+  lctShowerDataSummary_denom_ = iBooker.book2D("lct_cscshower_data_summary_denom", "Data LCT Shower All", 36, 1, 37, 18, 0, 18);
+  lctShowerDataSummary_num_ = iBooker.book2D("lct_cscshower_data_summary_num", "Data LCT Shower Emul Matched", 36, 1, 37, 18, 0, 18);
+  alctShowerDataSummary_denom_ = iBooker.book2D("alct_cscshower_data_summary_denom", "Data ALCT Shower All", 36, 1, 37, 18, 0, 18);
+  alctShowerDataSummary_num_ = iBooker.book2D("alct_cscshower_data_summary_num", "Data ALCT Shower Emul Matched", 36, 1, 37, 18, 0, 18);
+  clctShowerDataSummary_denom_ = iBooker.book2D("clct_cscshower_data_summary_denom", "Data CLCT Shower All", 36, 1, 37, 18, 0, 18);
+  clctShowerDataSummary_num_ = iBooker.book2D("clct_cscshower_data_summary_num", "Data CLCT Shower Emul Matched", 36, 1, 37, 18, 0, 18);
+
+  lctShowerEmulSummary_denom_ = iBooker.book2D("lct_cscshower_emul_summary_denom", "Emul LCT Shower All", 36, 1, 37, 18, 0, 18);
+  lctShowerEmulSummary_num_ = iBooker.book2D("lct_cscshower_emul_summary_num", "Emul LCT Shower Not Matched to Data", 36, 1, 37, 18, 0, 18);
+  alctShowerEmulSummary_denom_ = iBooker.book2D("alct_cscshower_emul_summary_denom", "Emul ALCT Shower All", 36, 1, 37, 18, 0, 18);
+  alctShowerEmulSummary_num_ = iBooker.book2D("alct_cscshower_emul_summary_num", "Emul ALCT Shower Not Matched to Data", 36, 1, 37, 18, 0, 18);
+  clctShowerEmulSummary_denom_ = iBooker.book2D("clct_cscshower_emul_summary_denom", "Emul CLCT Shower All", 36, 1, 37, 18, 0, 18);
+  clctShowerEmulSummary_num_ = iBooker.book2D("clct_cscshower_emul_summary_num", "Emul CLCT Shower Not Matched to Data", 36, 1, 37, 18, 0, 18);
+
+  // x labels
+  lctShowerDataSummary_denom_->setAxisTitle("Chamber", 1);
+  lctShowerDataSummary_num_->setAxisTitle("Chamber", 1);
+  alctShowerDataSummary_denom_->setAxisTitle("Chamber", 1);
+  alctShowerDataSummary_num_->setAxisTitle("Chamber", 1);
+  clctShowerDataSummary_denom_->setAxisTitle("Chamber", 1);
+  clctShowerDataSummary_num_->setAxisTitle("Chamber", 1);
+
+  lctShowerEmulSummary_denom_->setAxisTitle("Chamber", 1);
+  lctShowerEmulSummary_num_->setAxisTitle("Chamber", 1);
+  alctShowerEmulSummary_denom_->setAxisTitle("Chamber", 1);
+  alctShowerEmulSummary_num_->setAxisTitle("Chamber", 1);
+  clctShowerEmulSummary_denom_->setAxisTitle("Chamber", 1);
+  clctShowerEmulSummary_num_->setAxisTitle("Chamber", 1);
+
+  // plotting option
+  lctShowerDataSummary_denom_->setOption("colz");
+  lctShowerDataSummary_num_->setOption("colz");
+  alctShowerDataSummary_denom_->setOption("colz");
+  alctShowerDataSummary_num_->setOption("colz");
+  clctShowerDataSummary_denom_->setOption("colz");
+  clctShowerDataSummary_num_->setOption("colz");
+
+  lctShowerEmulSummary_denom_->setOption("colz");
+  lctShowerEmulSummary_num_->setOption("colz");
+  alctShowerEmulSummary_denom_->setOption("colz");
+  alctShowerEmulSummary_num_->setOption("colz");
+  clctShowerEmulSummary_denom_->setOption("colz");
+  clctShowerEmulSummary_num_->setOption("colz");
+
+  const std::array<std::string, 9> suffix_label{{"4/2", "4/1", "3/2", "3/1", " 2/2", "2/1", "1/3", "1/2", "1/1"}};
+
+  // y labels
+  for (int ybin = 1; ybin <= 9; ++ybin) {
+    lctShowerDataSummary_denom_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    lctShowerDataSummary_num_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    alctShowerDataSummary_denom_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    alctShowerDataSummary_num_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    clctShowerDataSummary_denom_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    clctShowerDataSummary_num_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+
+    lctShowerEmulSummary_denom_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    lctShowerEmulSummary_num_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    alctShowerEmulSummary_denom_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    alctShowerEmulSummary_num_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    clctShowerEmulSummary_denom_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    clctShowerEmulSummary_num_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+
+    lctShowerDataSummary_denom_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    lctShowerDataSummary_num_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    alctShowerDataSummary_denom_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    alctShowerDataSummary_num_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    clctShowerDataSummary_denom_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    clctShowerDataSummary_num_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+
+    lctShowerEmulSummary_denom_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    lctShowerEmulSummary_num_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    alctShowerEmulSummary_denom_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    alctShowerEmulSummary_num_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    clctShowerEmulSummary_denom_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    clctShowerEmulSummary_num_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+  }
+}
+
+void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
+  // handles
+  edm::Handle<CSCShowerDigiCollection> dataALCTshs;
+  edm::Handle<CSCShowerDigiCollection> emulALCTshs;
+  edm::Handle<CSCShowerDigiCollection> dataCLCTshs;
+  edm::Handle<CSCShowerDigiCollection> emulCLCTshs;
+  edm::Handle<CSCShowerDigiCollection> dataLCTshs;
+  edm::Handle<CSCShowerDigiCollection> emulLCTshs;
+
+  e.getByToken(dataALCTShower_token_, dataALCTshs);
+  e.getByToken(emulALCTShower_token_, emulALCTshs);
+  e.getByToken(dataCLCTShower_token_, dataCLCTshs);
+  e.getByToken(emulCLCTShower_token_, emulCLCTshs);
+  e.getByToken(dataLCTShower_token_, dataLCTshs);
+  e.getByToken(emulLCTShower_token_, emulLCTshs);
+
+  const std::map<std::pair<int, int>, int> histIndexCSC = {{{1, 1}, 8},
+                                                           {{1, 2}, 7},
+                                                           {{1, 3}, 6},
+                                                           {{2, 1}, 5},
+                                                           {{2, 2}, 4},
+                                                           {{3, 1}, 3},
+                                                           {{3, 2}, 2},
+                                                           {{4, 1}, 1},
+                                                           {{4, 2}, 0}};
+
+  const int min_endcap = CSCDetId::minEndcapId();
+  const int max_endcap = CSCDetId::maxEndcapId();
+  const int min_station = CSCDetId::minStationId();
+  const int max_station = CSCDetId::maxStationId();
+  const int min_sector = CSCTriggerNumbering::minTriggerSectorId();
+  const int max_sector = CSCTriggerNumbering::maxTriggerSectorId();
+  const int min_subsector = CSCTriggerNumbering::minTriggerSubSectorId();
+  const int max_subsector = CSCTriggerNumbering::maxTriggerSubSectorId();
+  const int min_chamber = CSCTriggerNumbering::minTriggerCscId();
+  const int max_chamber = CSCTriggerNumbering::maxTriggerCscId();
+
+  for (int endc = min_endcap; endc <= max_endcap; endc++) {
+    // loop on all stations
+    for (int stat = min_station; stat <= max_station; stat++) {
+      int numsubs = ((stat == 1) ? max_subsector : 1);
+      // loop on sectors and subsectors
+      for (int sect = min_sector; sect <= max_sector; sect++) {
+        for (int subs = min_subsector; subs <= numsubs; subs++) {
+          // loop on all chambers
+          for (int cham = min_chamber; cham <= max_chamber; cham++) {
+            // extract the ring number
+            int ring = CSCTriggerNumbering::ringFromTriggerLabels(stat, cham);
+
+            // actual chamber number =/= trigger chamber number
+            int chid = CSCTriggerNumbering::chamberFromTriggerLabels(sect, subs, stat, cham);
+
+            // 0th layer means whole chamber.
+            CSCDetId detid(endc, stat, ring, chid, 0);
+
+            int chamber = detid.chamber();
+
+            int sr = histIndexCSC.at({stat, ring});
+            if (endc == 1)
+              sr = 17 - sr;
+
+            // ALCT analysis
+            auto range_dataALCT = dataALCTshs->get(detid);
+            auto range_emulALCT = emulALCTshs->get(detid);
+
+            for (auto dalct = range_dataALCT.first; dalct != range_dataALCT.second; dalct++) {
+              if (dalct->isValid()) {
+                alctShowerDataSummary_denom_->Fill(chamber, sr);
+                // check for least one matching ALCT
+                for (auto ealct = range_emulALCT.first; ealct != range_emulALCT.second; ealct++) {
+                  if (ealct->isValid() and areSameShowers(*dalct, *ealct)) {
+                    alctShowerDataSummary_num_->Fill(chamber, sr);
+                  }
+                }
+              }
+            }
+
+            for (auto ealct = range_emulALCT.first; ealct != range_emulALCT.second; ealct++) {
+              bool isMatched = false;
+              if (ealct->isValid()) {
+                alctShowerEmulSummary_denom_->Fill(chamber, sr);
+                // check for least one matching ALCT
+                for (auto dalct = range_dataALCT.first; dalct != range_dataALCT.second; dalct++) {
+                  if (areSameShowers(*dalct, *ealct))
+                    isMatched = true;
+                }
+                // only fill when it is not matched to an ALCT
+                // to understand if the emulator is producing too many ALCTs
+                if (!isMatched) {
+                  alctShowerEmulSummary_num_->Fill(chamber, sr);
+                }
+              }
+            }
+
+            // CLCT analysis
+            auto range_dataCLCT = dataCLCTshs->get(detid);
+            auto range_emulCLCT = emulCLCTshs->get(detid);
+
+            for (auto dclct = range_dataCLCT.first; dclct != range_dataCLCT.second; dclct++) {
+              if (dclct->isValid()) {
+                clctShowerDataSummary_denom_->Fill(chamber, sr);
+                // check for least one matching CLCT
+                for (auto eclct = range_emulCLCT.first; eclct != range_emulCLCT.second; eclct++) {
+                  if (eclct->isValid() and areSameShowers(*dclct, *eclct)) {
+                    clctShowerDataSummary_num_->Fill(chamber, sr);
+                  }
+                }
+              }
+            }
+
+            for (auto eclct = range_emulCLCT.first; eclct != range_emulCLCT.second; eclct++) {
+              bool isMatched = false;
+              if (eclct->isValid()) {
+                clctShowerEmulSummary_denom_->Fill(chamber, sr);
+                // check for least one matching CLCT
+                for (auto dclct = range_dataCLCT.first; dclct != range_dataCLCT.second; dclct++) {
+                  if (areSameShowers(*dclct, *eclct))
+                    isMatched = true;
+                }
+                // only fill when it is not matched to an CLCT
+                // to understand if the emulator is producing too many CLCTs
+                if (!isMatched) {
+                  clctShowerEmulSummary_num_->Fill(chamber, sr);
+                }
+              }
+            }
+
+            // LCT analysis
+            auto range_dataLCT = dataLCTshs->get(detid);
+            auto range_emulLCT = emulLCTshs->get(detid);
+
+            for (auto dlct = range_dataLCT.first; dlct != range_dataLCT.second; dlct++) {
+              if (dlct->isValid()) {
+                lctShowerDataSummary_denom_->Fill(chamber, sr);
+                // check for least one matching LCT
+                for (auto elct = range_emulLCT.first; elct != range_emulLCT.second; elct++) {
+                  if (elct->isValid() and areSameShowers(*dlct, *elct)) {
+                    lctShowerDataSummary_num_->Fill(chamber, sr);
+                  }
+                }
+              }
+            }
+            
+            for (auto elct = range_emulLCT.first; elct != range_emulLCT.second; elct++) {
+              bool isMatched = false;
+              if (elct->isValid()) {
+                lctShowerEmulSummary_denom_->Fill(chamber, sr);
+                // check for least one matching LCT
+                for (auto dlct = range_dataLCT.first; dlct != range_dataLCT.second; dlct++) {
+                  if (areSameShowers(*dlct, *elct))
+                    isMatched = true;
+                }
+                // only fill when it is not matched to an LCT
+                // to understand if the emulator is producing too many LCTs
+                if (!isMatched) {
+                  lctShowerEmulSummary_num_->Fill(chamber, sr);
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+bool L1TdeCSCTPGShower::areSameShowers(const CSCShowerDigi& lhs, const CSCShowerDigi& rhs) const {
+  bool returnValue = false;
+  if (lhs.isValid() == rhs.isValid() && lhs.getCSCID() == rhs.getCSCID() &&
+      lhs.bitsInTime() == rhs.bitsInTime() && lhs.bitsOutOfTime() == rhs.bitsOutOfTime()) {
+    returnValue = true;
+  }
+  return returnValue;
+}

--- a/DQM/L1TMonitor/src/L1TdeStage2Shower.cc
+++ b/DQM/L1TMonitor/src/L1TdeStage2Shower.cc
@@ -1,0 +1,74 @@
+#include <string>
+
+#include "DQM/L1TMonitor/interface/L1TdeStage2Shower.h"
+
+L1TdeStage2Shower::L1TdeStage2Shower(const edm::ParameterSet& ps)
+    : data_EMTFShower_token_(consumes<l1t::RegionalMuonShowerBxCollection>(ps.getParameter<edm::InputTag>("dataSource"))),
+      emul_EMTFShower_token_(consumes<l1t::RegionalMuonShowerBxCollection>(ps.getParameter<edm::InputTag>("emulSource"))),
+      monitorDir_(ps.getUntrackedParameter<std::string>("monitorDir")) {}
+
+L1TdeStage2Shower::~L1TdeStage2Shower() {}
+
+void L1TdeStage2Shower::bookHistograms(DQMStore::IBooker& iBooker, const edm::Run&, const edm::EventSetup&) {
+  iBooker.setCurrentFolder(monitorDir_);
+
+  // 2D summary plots
+  emtfShowerDataSummary_denom_ = iBooker.book2D("emtf_shower_data_summary_denom", "Data EMTF Shower All", 6, 1, 7, 2, 0, 2);
+  emtfShowerDataSummary_num_ = iBooker.book2D("emtf_shower_data_summary_num", "Data EMTF Shower Emul Matched", 6, 1, 7, 2, 0, 2);
+  emtfShowerEmulSummary_denom_ = iBooker.book2D("emtf_shower_emul_summary_denom", "Emul EMTF Shower All", 6, 1, 7, 2, 0, 2);
+  emtfShowerEmulSummary_num_ = iBooker.book2D("emtf_shower_emul_summary_num", "Emul EMTF Shower Not Matched to Data", 6, 1, 7, 2, 0, 2);
+
+  // x labels
+  emtfShowerDataSummary_denom_->setAxisTitle("Sector", 1);
+  emtfShowerDataSummary_num_->setAxisTitle("Sector", 1);
+  emtfShowerEmulSummary_denom_->setAxisTitle("Sector", 1);
+  emtfShowerEmulSummary_num_->setAxisTitle("Sector", 1);
+
+  // plotting option
+  emtfShowerDataSummary_denom_->setOption("colz");
+  emtfShowerDataSummary_num_->setOption("colz");
+  emtfShowerEmulSummary_denom_->setOption("colz");
+  emtfShowerEmulSummary_num_->setOption("colz");
+
+  // y labels
+  emtfShowerDataSummary_denom_->setBinLabel(1, "ME-", 2);
+  emtfShowerDataSummary_num_->setBinLabel(1, "ME-", 2);
+  emtfShowerEmulSummary_denom_->setBinLabel(1, "ME-", 2);
+  emtfShowerEmulSummary_num_->setBinLabel(1, "ME-", 2);
+
+  emtfShowerDataSummary_denom_->setBinLabel(2, "ME+", 2);
+  emtfShowerDataSummary_num_->setBinLabel(2, "ME+", 2);
+  emtfShowerEmulSummary_denom_->setBinLabel(2, "ME+", 2);
+  emtfShowerEmulSummary_num_->setBinLabel(2, "ME+", 2);
+}
+
+void L1TdeStage2Shower::analyze(const edm::Event& e, const edm::EventSetup& c) {
+  edm::Handle<l1t::RegionalMuonShowerBxCollection> dataShowers;
+  edm::Handle<l1t::RegionalMuonShowerBxCollection> emulShowers;
+
+  e.getByToken(data_EMTFShower_token_, dataShowers);
+  e.getByToken(emul_EMTFShower_token_, emulShowers);
+
+  for (auto dSh = dataShowers->begin(); dSh != dataShowers->end(); ++dSh) {
+    if (dSh->isValid()) {
+      emtfShowerDataSummary_denom_->Fill(dSh->sector(), (dSh->endcap() == 1) ? 1.5 : 0.5);
+      for (auto eSh = emulShowers->begin(); eSh != emulShowers->end(); ++eSh) {
+        if (eSh->isValid() and dSh->sector() == eSh->sector() and dSh->endcap() == eSh->endcap() and  *dSh == *eSh) {
+          emtfShowerDataSummary_num_->Fill(dSh->sector(), (dSh->endcap() == 1) ? 1.5 : 0.5);
+        }
+      }
+    }
+  }
+
+  for (auto eSh = emulShowers->begin(); eSh != emulShowers->end(); ++eSh) {
+    if (eSh->isValid()) {
+      emtfShowerEmulSummary_denom_->Fill(eSh->sector(), (eSh->endcap() == 1) ? 1.5 : 0.5);
+      for (auto dSh = dataShowers->begin(); dSh != dataShowers->end(); ++dSh) {
+        if (dSh->isValid() and eSh->sector() == dSh->sector() and eSh->endcap() == dSh->endcap() and  *dSh == *eSh) {
+          emtfShowerEmulSummary_num_->Fill(eSh->sector(), (eSh->endcap() == 1) ? 1.5 : 0.5);
+        }
+      }
+    }
+  }
+}
+

--- a/DQM/L1TMonitor/src/L1TdeStage2Shower.cc
+++ b/DQM/L1TMonitor/src/L1TdeStage2Shower.cc
@@ -3,8 +3,10 @@
 #include "DQM/L1TMonitor/interface/L1TdeStage2Shower.h"
 
 L1TdeStage2Shower::L1TdeStage2Shower(const edm::ParameterSet& ps)
-    : data_EMTFShower_token_(consumes<l1t::RegionalMuonShowerBxCollection>(ps.getParameter<edm::InputTag>("dataSource"))),
-      emul_EMTFShower_token_(consumes<l1t::RegionalMuonShowerBxCollection>(ps.getParameter<edm::InputTag>("emulSource"))),
+    : data_EMTFShower_token_(
+          consumes<l1t::RegionalMuonShowerBxCollection>(ps.getParameter<edm::InputTag>("dataSource"))),
+      emul_EMTFShower_token_(
+          consumes<l1t::RegionalMuonShowerBxCollection>(ps.getParameter<edm::InputTag>("emulSource"))),
       monitorDir_(ps.getUntrackedParameter<std::string>("monitorDir")) {}
 
 L1TdeStage2Shower::~L1TdeStage2Shower() {}
@@ -13,10 +15,14 @@ void L1TdeStage2Shower::bookHistograms(DQMStore::IBooker& iBooker, const edm::Ru
   iBooker.setCurrentFolder(monitorDir_);
 
   // 2D summary plots
-  emtfShowerDataSummary_denom_ = iBooker.book2D("emtf_shower_data_summary_denom", "Data EMTF Shower All", 6, 1, 7, 2, 0, 2);
-  emtfShowerDataSummary_num_ = iBooker.book2D("emtf_shower_data_summary_num", "Data EMTF Shower Emul Matched", 6, 1, 7, 2, 0, 2);
-  emtfShowerEmulSummary_denom_ = iBooker.book2D("emtf_shower_emul_summary_denom", "Emul EMTF Shower All", 6, 1, 7, 2, 0, 2);
-  emtfShowerEmulSummary_num_ = iBooker.book2D("emtf_shower_emul_summary_num", "Emul EMTF Shower Not Matched to Data", 6, 1, 7, 2, 0, 2);
+  emtfShowerDataSummary_denom_ =
+      iBooker.book2D("emtf_shower_data_summary_denom", "Data EMTF Shower All", 6, 1, 7, 2, 0, 2);
+  emtfShowerDataSummary_num_ =
+      iBooker.book2D("emtf_shower_data_summary_num", "Data EMTF Shower Emul Matched", 6, 1, 7, 2, 0, 2);
+  emtfShowerEmulSummary_denom_ =
+      iBooker.book2D("emtf_shower_emul_summary_denom", "Emul EMTF Shower All", 6, 1, 7, 2, 0, 2);
+  emtfShowerEmulSummary_num_ =
+      iBooker.book2D("emtf_shower_emul_summary_num", "Emul EMTF Shower Not Matched to Data", 6, 1, 7, 2, 0, 2);
 
   // x labels
   emtfShowerDataSummary_denom_->setAxisTitle("Sector", 1);
@@ -53,7 +59,7 @@ void L1TdeStage2Shower::analyze(const edm::Event& e, const edm::EventSetup& c) {
     if (dSh->isValid()) {
       emtfShowerDataSummary_denom_->Fill(dSh->sector(), (dSh->endcap() == 1) ? 1.5 : 0.5);
       for (auto eSh = emulShowers->begin(); eSh != emulShowers->end(); ++eSh) {
-        if (eSh->isValid() and dSh->sector() == eSh->sector() and dSh->endcap() == eSh->endcap() and  *dSh == *eSh)
+        if (eSh->isValid() and dSh->sector() == eSh->sector() and dSh->endcap() == eSh->endcap() and *dSh == *eSh)
           emtfShowerDataSummary_num_->Fill(dSh->sector(), (dSh->endcap() == 1) ? 1.5 : 0.5);
       }
     }
@@ -64,7 +70,7 @@ void L1TdeStage2Shower::analyze(const edm::Event& e, const edm::EventSetup& c) {
     if (eSh->isValid()) {
       emtfShowerEmulSummary_denom_->Fill(eSh->sector(), (eSh->endcap() == 1) ? 1.5 : 0.5);
       for (auto dSh = dataShowers->begin(); dSh != dataShowers->end(); ++dSh) {
-        if (dSh->isValid() and eSh->sector() == dSh->sector() and eSh->endcap() == dSh->endcap() and  *dSh == *eSh)
+        if (dSh->isValid() and eSh->sector() == dSh->sector() and eSh->endcap() == dSh->endcap() and *dSh == *eSh)
           isMatched = true;
       }
       if (not isMatched) {
@@ -73,4 +79,3 @@ void L1TdeStage2Shower::analyze(const edm::Event& e, const edm::EventSetup& c) {
     }
   }
 }
-

--- a/DQM/L1TMonitor/src/L1TdeStage2Shower.cc
+++ b/DQM/L1TMonitor/src/L1TdeStage2Shower.cc
@@ -53,20 +53,22 @@ void L1TdeStage2Shower::analyze(const edm::Event& e, const edm::EventSetup& c) {
     if (dSh->isValid()) {
       emtfShowerDataSummary_denom_->Fill(dSh->sector(), (dSh->endcap() == 1) ? 1.5 : 0.5);
       for (auto eSh = emulShowers->begin(); eSh != emulShowers->end(); ++eSh) {
-        if (eSh->isValid() and dSh->sector() == eSh->sector() and dSh->endcap() == eSh->endcap() and  *dSh == *eSh) {
+        if (eSh->isValid() and dSh->sector() == eSh->sector() and dSh->endcap() == eSh->endcap() and  *dSh == *eSh)
           emtfShowerDataSummary_num_->Fill(dSh->sector(), (dSh->endcap() == 1) ? 1.5 : 0.5);
-        }
       }
     }
   }
 
   for (auto eSh = emulShowers->begin(); eSh != emulShowers->end(); ++eSh) {
+    bool isMatched = false;
     if (eSh->isValid()) {
       emtfShowerEmulSummary_denom_->Fill(eSh->sector(), (eSh->endcap() == 1) ? 1.5 : 0.5);
       for (auto dSh = dataShowers->begin(); dSh != dataShowers->end(); ++dSh) {
-        if (dSh->isValid() and eSh->sector() == dSh->sector() and eSh->endcap() == dSh->endcap() and  *dSh == *eSh) {
-          emtfShowerEmulSummary_num_->Fill(eSh->sector(), (eSh->endcap() == 1) ? 1.5 : 0.5);
-        }
+        if (dSh->isValid() and eSh->sector() == dSh->sector() and eSh->endcap() == dSh->endcap() and  *dSh == *eSh)
+          isMatched = true;
+      }
+      if (not isMatched) {
+        emtfShowerEmulSummary_num_->Fill(eSh->sector(), (eSh->endcap() == 1) ? 1.5 : 0.5);
       }
     }
   }

--- a/DQM/L1TMonitorClient/interface/L1TdeCSCTPGShowerClient.h
+++ b/DQM/L1TMonitorClient/interface/L1TdeCSCTPGShowerClient.h
@@ -1,0 +1,42 @@
+#ifndef DQM_L1TMONITORCLIENT_L1TdeCSCTPGShowerCLIENT_H
+#define DQM_L1TMONITORCLIENT_L1TdeCSCTPGShowerCLIENT_H
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/DQMEDHarvester.h"
+
+#include <string>
+
+class L1TdeCSCTPGShowerClient : public DQMEDHarvester {
+public:
+  /// Constructor
+  L1TdeCSCTPGShowerClient(const edm::ParameterSet &ps);
+
+  /// Destructor
+  ~L1TdeCSCTPGShowerClient() override;
+
+protected:
+  void dqmEndLuminosityBlock(DQMStore::IBooker &,
+                             DQMStore::IGetter &,
+                             edm::LuminosityBlock const &,
+                             edm::EventSetup const &) override;
+  void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;
+
+private:
+  void book(DQMStore::IBooker &ibooker);
+  void processHistograms(DQMStore::IGetter &);
+
+  std::string monitorDir_;
+
+  MonitorElement *lctShowerDataSummary_eff_;
+  MonitorElement *alctShowerDataSummary_eff_;
+  MonitorElement *clctShowerDataSummary_eff_;
+  MonitorElement *lctShowerEmulSummary_eff_;
+  MonitorElement *alctShowerEmulSummary_eff_;
+  MonitorElement *clctShowerEmulSummary_eff_;
+};
+
+#endif

--- a/DQM/L1TMonitorClient/interface/L1TdeStage2ShowerClient.h
+++ b/DQM/L1TMonitorClient/interface/L1TdeStage2ShowerClient.h
@@ -1,0 +1,38 @@
+#ifndef DQM_L1TMONITORCLIENT_L1TdeStage2ShowerCLIENT_H
+#define DQM_L1TMONITORCLIENT_L1TdeStage2ShowerCLIENT_H
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/DQMEDHarvester.h"
+
+#include <string>
+
+class L1TdeStage2ShowerClient : public DQMEDHarvester {
+public:
+  /// Constructor
+  L1TdeStage2ShowerClient(const edm::ParameterSet &ps);
+
+  /// Destructor
+  ~L1TdeStage2ShowerClient() override;
+
+protected:
+  void dqmEndLuminosityBlock(DQMStore::IBooker &,
+                             DQMStore::IGetter &,
+                             edm::LuminosityBlock const &,
+                             edm::EventSetup const &) override;
+  void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;
+
+private:
+  void book(DQMStore::IBooker &ibooker);
+  void processHistograms(DQMStore::IGetter &);
+
+  std::string monitorDir_;
+
+  MonitorElement *emtfShowerDataSummary_eff_;
+  MonitorElement *emtfShowerEmulSummary_eff_;
+};
+
+#endif

--- a/DQM/L1TMonitorClient/python/L1TStage2EMTFEmulatorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EMTFEmulatorClient_cff.py
@@ -14,8 +14,11 @@ l1tStage2EMTFEmulatorCompRatioClient = DQMEDHarvester("L1TStage2RatioClient",
     ignoreBin = cms.untracked.vint32(ignoreBinsDeStage2Emtf)
 )
 
+from DQM.L1TMonitorClient.L1TdeStage2ShowerClient_cfi import *
+
 # sequences
 l1tStage2EMTFEmulatorClient = cms.Sequence(
-    l1tStage2EMTFEmulatorCompRatioClient
+    l1tStage2EMTFEmulatorCompRatioClient +
+    l1tdeStage2ShowerClient
 )
 

--- a/DQM/L1TMonitorClient/python/L1TStage2EMTFEmulatorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EMTFEmulatorClient_cff.py
@@ -18,7 +18,9 @@ from DQM.L1TMonitorClient.L1TdeStage2ShowerClient_cfi import *
 
 # sequences
 l1tStage2EMTFEmulatorClient = cms.Sequence(
-    l1tStage2EMTFEmulatorCompRatioClient +
-    l1tdeStage2ShowerClient
+    l1tStage2EMTFEmulatorCompRatioClient
 )
 
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+_run3shower_l1tStage2EMTFEmulatorClient = l1tStage2EMTFEmulatorClient.copy()
+run3_common.toReplaceWith(l1tStage2EMTFEmulatorClient, cms.Sequence(_run3shower_l1tStage2EMTFEmulatorClient + l1tdeStage2ShowerClient))

--- a/DQM/L1TMonitorClient/python/L1TStage2EmulatorMonitorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EmulatorMonitorClient_cff.py
@@ -36,6 +36,7 @@ from DQM.L1TMonitorClient.L1TdeGEMTPGClient_cfi import *
 
 # CSC TPG emulator client
 from DQM.L1TMonitorClient.L1TdeCSCTPGClient_cfi import *
+from DQM.L1TMonitorClient.L1TdeCSCTPGShowerClient_cfi import *
 
 # EMTF emulator client
 from DQM.L1TMonitorClient.L1TStage2EMTFEmulatorClient_cff import *
@@ -58,6 +59,7 @@ l1TStage2EmulatorClients = cms.Sequence(
     + l1tStage2BMTFEmulatorSecondClient
     + l1tStage2OMTFEmulatorClient
     + l1tdeCSCTPGClient
+    + l1tdeCSCTPGShowerClient
     + l1tStage2EMTFEmulatorClient
     + l1tStage2EmulatorEventInfoClient
     + l1tStage2uGTEmulatorClient

--- a/DQM/L1TMonitorClient/python/L1TStage2EmulatorMonitorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EmulatorMonitorClient_cff.py
@@ -59,7 +59,6 @@ l1TStage2EmulatorClients = cms.Sequence(
     + l1tStage2BMTFEmulatorSecondClient
     + l1tStage2OMTFEmulatorClient
     + l1tdeCSCTPGClient
-    + l1tdeCSCTPGShowerClient
     + l1tStage2EMTFEmulatorClient
     + l1tStage2EmulatorEventInfoClient
     + l1tStage2uGTEmulatorClient
@@ -70,6 +69,10 @@ _run3_l1TStage2EmulatorClients += l1tdeGEMTPGClient
 
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toReplaceWith( l1TStage2EmulatorClients, _run3_l1TStage2EmulatorClients )
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+_run3shower_l1TStage2EmulatorClients = l1TStage2EmulatorClients.copy()
+run3_common.toReplaceWith(l1TStage2EmulatorClients, cms.Sequence(_run3shower_l1TStage2EmulatorClients + l1tdeCSCTPGShowerClient))
 
 l1tStage2EmulatorMonitorClient = cms.Sequence(
     l1TStage2EmulatorQualityTests +

--- a/DQM/L1TMonitorClient/python/L1TdeCSCTPGShowerClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TdeCSCTPGShowerClient_cfi.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+
+l1tdeCSCTPGShowerClient = DQMEDHarvester(
+    "L1TdeCSCTPGShowerClient",
+    monitorDir = cms.untracked.string("L1TEMU/L1TdeCSCTPGShower"),
+)
+

--- a/DQM/L1TMonitorClient/python/L1TdeStage2ShowerClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TdeStage2ShowerClient_cfi.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+
+l1tdeStage2ShowerClient = DQMEDHarvester(
+    "L1TdeStage2ShowerClient",
+    monitorDir = cms.untracked.string("L1TEMU/L1TdeStage2EMTF/Shower"),
+)
+

--- a/DQM/L1TMonitorClient/src/L1TdeCSCTPGShowerClient.cc
+++ b/DQM/L1TMonitorClient/src/L1TdeCSCTPGShowerClient.cc
@@ -1,0 +1,116 @@
+#include "DQM/L1TMonitorClient/interface/L1TdeCSCTPGShowerClient.h"
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "TRandom.h"
+using namespace edm;
+using namespace std;
+
+L1TdeCSCTPGShowerClient::L1TdeCSCTPGShowerClient(const edm::ParameterSet &ps)
+    : monitorDir_(ps.getUntrackedParameter<string>("monitorDir")) {}
+
+L1TdeCSCTPGShowerClient::~L1TdeCSCTPGShowerClient() {}
+
+void L1TdeCSCTPGShowerClient::dqmEndLuminosityBlock(DQMStore::IBooker &ibooker,
+                                              DQMStore::IGetter &igetter,
+                                              const edm::LuminosityBlock &lumiSeg,
+                                              const edm::EventSetup &c) {
+  book(ibooker);
+  processHistograms(igetter);
+}
+
+//--------------------------------------------------------
+void L1TdeCSCTPGShowerClient::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter) {
+  book(ibooker);
+  processHistograms(igetter);
+}
+
+void L1TdeCSCTPGShowerClient::book(DQMStore::IBooker &iBooker) {
+  iBooker.setCurrentFolder(monitorDir_);
+
+  lctShowerDataSummary_eff_ = iBooker.book2D(
+      "lct_cscshower_data_summary_eff", "Efficiency of data LCT shower being correctly emulated", 36, 1, 37, 18, 0, 18);
+  alctShowerDataSummary_eff_ = iBooker.book2D(
+      "alct_cscshower_data_summary_eff", "Efficiency of data ALCT shower being correctly emulated", 36, 1, 37, 18, 0, 18);
+  clctShowerDataSummary_eff_ = iBooker.book2D(
+      "clct_cscshower_data_summary_eff", "Efficiency of data CLCT shower being correctly emulated", 36, 1, 37, 18, 0, 18);
+
+  lctShowerEmulSummary_eff_ = iBooker.book2D(
+      "lct_cscshower_emul_summary_eff", "Fraction of emulated LCT shower without matching data LCT", 36, 1, 37, 18, 0, 18);
+  alctShowerEmulSummary_eff_ = iBooker.book2D(
+      "alct_cscshower_emul_summary_eff", "Fraction of emulated ALCT shower without matching data ALCT", 36, 1, 37, 18, 0, 18);
+  clctShowerEmulSummary_eff_ = iBooker.book2D(
+      "clct_cscshower_emul_summary_eff", "Fraction of emulated CLCT shower without matching data CLCT", 36, 1, 37, 18, 0, 18);
+
+  // x labels
+  lctShowerDataSummary_eff_->setAxisTitle("Chamber", 1);
+  alctShowerDataSummary_eff_->setAxisTitle("Chamber", 1);
+  clctShowerDataSummary_eff_->setAxisTitle("Chamber", 1);
+
+  lctShowerEmulSummary_eff_->setAxisTitle("Chamber", 1);
+  alctShowerEmulSummary_eff_->setAxisTitle("Chamber", 1);
+  clctShowerEmulSummary_eff_->setAxisTitle("Chamber", 1);
+
+  // plotting option
+  lctShowerDataSummary_eff_->setOption("colz");
+  alctShowerDataSummary_eff_->setOption("colz");
+  clctShowerDataSummary_eff_->setOption("colz");
+
+  lctShowerEmulSummary_eff_->setOption("colz");
+  alctShowerEmulSummary_eff_->setOption("colz");
+  clctShowerEmulSummary_eff_->setOption("colz");
+
+  // summary plots
+  const std::array<std::string, 9> suffix_label{{"4/2", "4/1", "3/2", "3/1", " 2/2", "2/1", "1/3", "1/2", "1/1"}};
+
+  // y labels
+  for (int ybin = 1; ybin <= 9; ++ybin) {
+    lctShowerDataSummary_eff_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    alctShowerDataSummary_eff_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    clctShowerDataSummary_eff_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+
+    lctShowerEmulSummary_eff_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    alctShowerEmulSummary_eff_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    clctShowerEmulSummary_eff_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+
+    lctShowerDataSummary_eff_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    alctShowerDataSummary_eff_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    clctShowerDataSummary_eff_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+
+    lctShowerEmulSummary_eff_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    alctShowerEmulSummary_eff_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    clctShowerEmulSummary_eff_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+  }
+}
+
+void L1TdeCSCTPGShowerClient::processHistograms(DQMStore::IGetter &igetter) {
+  MonitorElement *lctShowerDataSummary_denom_ = igetter.get(monitorDir_ + "/lct_cscshower_data_summary_denom");
+  MonitorElement *lctShowerDataSummary_num_ = igetter.get(monitorDir_ + "/lct_cscshower_data_summary_num");
+  MonitorElement *alctShowerDataSummary_denom_ = igetter.get(monitorDir_ + "/alct_cscshower_data_summary_denom");
+  MonitorElement *alctShowerDataSummary_num_ = igetter.get(monitorDir_ + "/alct_cscshower_data_summary_num");
+  MonitorElement *clctShowerDataSummary_denom_ = igetter.get(monitorDir_ + "/clct_cscshower_data_summary_denom");
+  MonitorElement *clctShowerDataSummary_num_ = igetter.get(monitorDir_ + "/clct_cscshower_data_summary_num");
+
+  MonitorElement *lctShowerEmulSummary_denom_ = igetter.get(monitorDir_ + "/lct_cscshower_emul_summary_denom");
+  MonitorElement *lctShowerEmulSummary_num_ = igetter.get(monitorDir_ + "/lct_cscshower_emul_summary_num");
+  MonitorElement *alctShowerEmulSummary_denom_ = igetter.get(monitorDir_ + "/alct_cscshower_emul_summary_denom");
+  MonitorElement *alctShowerEmulSummary_num_ = igetter.get(monitorDir_ + "/alct_cscshower_emul_summary_num");
+  MonitorElement *clctShowerEmulSummary_denom_ = igetter.get(monitorDir_ + "/clct_cscshower_emul_summary_denom");
+  MonitorElement *clctShowerEmulSummary_num_ = igetter.get(monitorDir_ + "/clct_cscshower_emul_summary_num");
+
+  lctShowerDataSummary_eff_->getTH2F()->Divide(lctShowerDataSummary_num_->getTH2F(), lctShowerDataSummary_denom_->getTH2F(), 1, 1, "");
+  alctShowerDataSummary_eff_->getTH2F()->Divide(alctShowerDataSummary_num_->getTH2F(), alctShowerDataSummary_denom_->getTH2F(), 1, 1, "");
+  clctShowerDataSummary_eff_->getTH2F()->Divide(clctShowerDataSummary_num_->getTH2F(), clctShowerDataSummary_denom_->getTH2F(), 1, 1, "");
+
+  lctShowerEmulSummary_eff_->getTH2F()->Divide(lctShowerEmulSummary_num_->getTH2F(), lctShowerEmulSummary_denom_->getTH2F(), 1, 1, "");
+  alctShowerEmulSummary_eff_->getTH2F()->Divide(alctShowerEmulSummary_num_->getTH2F(), alctShowerEmulSummary_denom_->getTH2F(), 1, 1, "");
+  clctShowerEmulSummary_eff_->getTH2F()->Divide(clctShowerEmulSummary_num_->getTH2F(), clctShowerEmulSummary_denom_->getTH2F(), 1, 1, "");
+
+  lctShowerDataSummary_eff_->getTH2F()->GetZaxis()->SetRangeUser(0.95, 1);
+  alctShowerDataSummary_eff_->getTH2F()->GetZaxis()->SetRangeUser(0.95, 1);
+  clctShowerDataSummary_eff_->getTH2F()->GetZaxis()->SetRangeUser(0.95, 1);
+}

--- a/DQM/L1TMonitorClient/src/L1TdeCSCTPGShowerClient.cc
+++ b/DQM/L1TMonitorClient/src/L1TdeCSCTPGShowerClient.cc
@@ -16,9 +16,9 @@ L1TdeCSCTPGShowerClient::L1TdeCSCTPGShowerClient(const edm::ParameterSet &ps)
 L1TdeCSCTPGShowerClient::~L1TdeCSCTPGShowerClient() {}
 
 void L1TdeCSCTPGShowerClient::dqmEndLuminosityBlock(DQMStore::IBooker &ibooker,
-                                              DQMStore::IGetter &igetter,
-                                              const edm::LuminosityBlock &lumiSeg,
-                                              const edm::EventSetup &c) {
+                                                    DQMStore::IGetter &igetter,
+                                                    const edm::LuminosityBlock &lumiSeg,
+                                                    const edm::EventSetup &c) {
   book(ibooker);
   processHistograms(igetter);
 }
@@ -34,17 +34,47 @@ void L1TdeCSCTPGShowerClient::book(DQMStore::IBooker &iBooker) {
 
   lctShowerDataSummary_eff_ = iBooker.book2D(
       "lct_cscshower_data_summary_eff", "Efficiency of data LCT shower being correctly emulated", 36, 1, 37, 18, 0, 18);
-  alctShowerDataSummary_eff_ = iBooker.book2D(
-      "alct_cscshower_data_summary_eff", "Efficiency of data ALCT shower being correctly emulated", 36, 1, 37, 18, 0, 18);
-  clctShowerDataSummary_eff_ = iBooker.book2D(
-      "clct_cscshower_data_summary_eff", "Efficiency of data CLCT shower being correctly emulated", 36, 1, 37, 18, 0, 18);
+  alctShowerDataSummary_eff_ = iBooker.book2D("alct_cscshower_data_summary_eff",
+                                              "Efficiency of data ALCT shower being correctly emulated",
+                                              36,
+                                              1,
+                                              37,
+                                              18,
+                                              0,
+                                              18);
+  clctShowerDataSummary_eff_ = iBooker.book2D("clct_cscshower_data_summary_eff",
+                                              "Efficiency of data CLCT shower being correctly emulated",
+                                              36,
+                                              1,
+                                              37,
+                                              18,
+                                              0,
+                                              18);
 
-  lctShowerEmulSummary_eff_ = iBooker.book2D(
-      "lct_cscshower_emul_summary_eff", "Fraction of emulated LCT shower without matching data LCT", 36, 1, 37, 18, 0, 18);
-  alctShowerEmulSummary_eff_ = iBooker.book2D(
-      "alct_cscshower_emul_summary_eff", "Fraction of emulated ALCT shower without matching data ALCT", 36, 1, 37, 18, 0, 18);
-  clctShowerEmulSummary_eff_ = iBooker.book2D(
-      "clct_cscshower_emul_summary_eff", "Fraction of emulated CLCT shower without matching data CLCT", 36, 1, 37, 18, 0, 18);
+  lctShowerEmulSummary_eff_ = iBooker.book2D("lct_cscshower_emul_summary_eff",
+                                             "Fraction of emulated LCT shower without matching data LCT",
+                                             36,
+                                             1,
+                                             37,
+                                             18,
+                                             0,
+                                             18);
+  alctShowerEmulSummary_eff_ = iBooker.book2D("alct_cscshower_emul_summary_eff",
+                                              "Fraction of emulated ALCT shower without matching data ALCT",
+                                              36,
+                                              1,
+                                              37,
+                                              18,
+                                              0,
+                                              18);
+  clctShowerEmulSummary_eff_ = iBooker.book2D("clct_cscshower_emul_summary_eff",
+                                              "Fraction of emulated CLCT shower without matching data CLCT",
+                                              36,
+                                              1,
+                                              37,
+                                              18,
+                                              0,
+                                              18);
 
   // x labels
   lctShowerDataSummary_eff_->setAxisTitle("Chamber", 1);
@@ -102,13 +132,19 @@ void L1TdeCSCTPGShowerClient::processHistograms(DQMStore::IGetter &igetter) {
   MonitorElement *clctShowerEmulSummary_denom_ = igetter.get(monitorDir_ + "/clct_cscshower_emul_summary_denom");
   MonitorElement *clctShowerEmulSummary_num_ = igetter.get(monitorDir_ + "/clct_cscshower_emul_summary_num");
 
-  lctShowerDataSummary_eff_->getTH2F()->Divide(lctShowerDataSummary_num_->getTH2F(), lctShowerDataSummary_denom_->getTH2F(), 1, 1, "");
-  alctShowerDataSummary_eff_->getTH2F()->Divide(alctShowerDataSummary_num_->getTH2F(), alctShowerDataSummary_denom_->getTH2F(), 1, 1, "");
-  clctShowerDataSummary_eff_->getTH2F()->Divide(clctShowerDataSummary_num_->getTH2F(), clctShowerDataSummary_denom_->getTH2F(), 1, 1, "");
+  lctShowerDataSummary_eff_->getTH2F()->Divide(
+      lctShowerDataSummary_num_->getTH2F(), lctShowerDataSummary_denom_->getTH2F(), 1, 1, "");
+  alctShowerDataSummary_eff_->getTH2F()->Divide(
+      alctShowerDataSummary_num_->getTH2F(), alctShowerDataSummary_denom_->getTH2F(), 1, 1, "");
+  clctShowerDataSummary_eff_->getTH2F()->Divide(
+      clctShowerDataSummary_num_->getTH2F(), clctShowerDataSummary_denom_->getTH2F(), 1, 1, "");
 
-  lctShowerEmulSummary_eff_->getTH2F()->Divide(lctShowerEmulSummary_num_->getTH2F(), lctShowerEmulSummary_denom_->getTH2F(), 1, 1, "");
-  alctShowerEmulSummary_eff_->getTH2F()->Divide(alctShowerEmulSummary_num_->getTH2F(), alctShowerEmulSummary_denom_->getTH2F(), 1, 1, "");
-  clctShowerEmulSummary_eff_->getTH2F()->Divide(clctShowerEmulSummary_num_->getTH2F(), clctShowerEmulSummary_denom_->getTH2F(), 1, 1, "");
+  lctShowerEmulSummary_eff_->getTH2F()->Divide(
+      lctShowerEmulSummary_num_->getTH2F(), lctShowerEmulSummary_denom_->getTH2F(), 1, 1, "");
+  alctShowerEmulSummary_eff_->getTH2F()->Divide(
+      alctShowerEmulSummary_num_->getTH2F(), alctShowerEmulSummary_denom_->getTH2F(), 1, 1, "");
+  clctShowerEmulSummary_eff_->getTH2F()->Divide(
+      clctShowerEmulSummary_num_->getTH2F(), clctShowerEmulSummary_denom_->getTH2F(), 1, 1, "");
 
   lctShowerDataSummary_eff_->getTH2F()->GetZaxis()->SetRangeUser(0.95, 1);
   alctShowerDataSummary_eff_->getTH2F()->GetZaxis()->SetRangeUser(0.95, 1);

--- a/DQM/L1TMonitorClient/src/L1TdeStage2ShowerClient.cc
+++ b/DQM/L1TMonitorClient/src/L1TdeStage2ShowerClient.cc
@@ -16,9 +16,9 @@ L1TdeStage2ShowerClient::L1TdeStage2ShowerClient(const edm::ParameterSet &ps)
 L1TdeStage2ShowerClient::~L1TdeStage2ShowerClient() {}
 
 void L1TdeStage2ShowerClient::dqmEndLuminosityBlock(DQMStore::IBooker &ibooker,
-                                              DQMStore::IGetter &igetter,
-                                              const edm::LuminosityBlock &lumiSeg,
-                                              const edm::EventSetup &c) {
+                                                    DQMStore::IGetter &igetter,
+                                                    const edm::LuminosityBlock &lumiSeg,
+                                                    const edm::EventSetup &c) {
   book(ibooker);
   processHistograms(igetter);
 }
@@ -59,6 +59,8 @@ void L1TdeStage2ShowerClient::processHistograms(DQMStore::IGetter &igetter) {
   MonitorElement *emtfShowerEmulSummary_denom_ = igetter.get(monitorDir_ + "/emtf_shower_emul_summary_denom");
   MonitorElement *emtfShowerEmulSummary_num_ = igetter.get(monitorDir_ + "/emtf_shower_emul_summary_num");
 
-  emtfShowerDataSummary_eff_->getTH2F()->Divide(emtfShowerDataSummary_num_->getTH2F(), emtfShowerDataSummary_denom_->getTH2F(), 1, 1, "");
-  emtfShowerEmulSummary_eff_->getTH2F()->Divide(emtfShowerEmulSummary_num_->getTH2F(), emtfShowerEmulSummary_denom_->getTH2F(), 1, 1, "");
+  emtfShowerDataSummary_eff_->getTH2F()->Divide(
+      emtfShowerDataSummary_num_->getTH2F(), emtfShowerDataSummary_denom_->getTH2F(), 1, 1, "");
+  emtfShowerEmulSummary_eff_->getTH2F()->Divide(
+      emtfShowerEmulSummary_num_->getTH2F(), emtfShowerEmulSummary_denom_->getTH2F(), 1, 1, "");
 }

--- a/DQM/L1TMonitorClient/src/L1TdeStage2ShowerClient.cc
+++ b/DQM/L1TMonitorClient/src/L1TdeStage2ShowerClient.cc
@@ -1,0 +1,64 @@
+#include "DQM/L1TMonitorClient/interface/L1TdeStage2ShowerClient.h"
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "TRandom.h"
+using namespace edm;
+using namespace std;
+
+L1TdeStage2ShowerClient::L1TdeStage2ShowerClient(const edm::ParameterSet &ps)
+    : monitorDir_(ps.getUntrackedParameter<string>("monitorDir")) {}
+
+L1TdeStage2ShowerClient::~L1TdeStage2ShowerClient() {}
+
+void L1TdeStage2ShowerClient::dqmEndLuminosityBlock(DQMStore::IBooker &ibooker,
+                                              DQMStore::IGetter &igetter,
+                                              const edm::LuminosityBlock &lumiSeg,
+                                              const edm::EventSetup &c) {
+  book(ibooker);
+  processHistograms(igetter);
+}
+
+//--------------------------------------------------------
+void L1TdeStage2ShowerClient::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter) {
+  book(ibooker);
+  processHistograms(igetter);
+}
+
+void L1TdeStage2ShowerClient::book(DQMStore::IBooker &iBooker) {
+  iBooker.setCurrentFolder(monitorDir_);
+
+  emtfShowerDataSummary_eff_ = iBooker.book2D(
+      "emtf_shower_data_summary_eff", "Efficiency of data EMTF shower being correctly emulated", 6, 1, 7, 2, 0, 2);
+  emtfShowerEmulSummary_eff_ = iBooker.book2D(
+      "emtf_shower_emul_summary_eff", "Fraction of emulated EMTF shower without matching data shower", 6, 1, 7, 2, 0, 2);
+
+  // x labels
+  emtfShowerDataSummary_eff_->setAxisTitle("Chamber", 1);
+  emtfShowerEmulSummary_eff_->setAxisTitle("Chamber", 1);
+
+  // plotting option
+  emtfShowerDataSummary_eff_->setOption("colz");
+  emtfShowerEmulSummary_eff_->setOption("colz");
+
+  // y labels
+  emtfShowerDataSummary_eff_->setBinLabel(1, "ME-", 2);
+  emtfShowerEmulSummary_eff_->setBinLabel(1, "ME-", 2);
+  emtfShowerDataSummary_eff_->setBinLabel(2, "ME+", 2);
+  emtfShowerEmulSummary_eff_->setBinLabel(2, "ME+", 2);
+}
+
+void L1TdeStage2ShowerClient::processHistograms(DQMStore::IGetter &igetter) {
+  MonitorElement *emtfShowerDataSummary_denom_ = igetter.get(monitorDir_ + "/emtf_shower_data_summary_denom");
+  MonitorElement *emtfShowerDataSummary_num_ = igetter.get(monitorDir_ + "/emtf_shower_data_summary_num");
+
+  MonitorElement *emtfShowerEmulSummary_denom_ = igetter.get(monitorDir_ + "/emtf_shower_emul_summary_denom");
+  MonitorElement *emtfShowerEmulSummary_num_ = igetter.get(monitorDir_ + "/emtf_shower_emul_summary_num");
+
+  emtfShowerDataSummary_eff_->getTH2F()->Divide(emtfShowerDataSummary_num_->getTH2F(), emtfShowerDataSummary_denom_->getTH2F(), 1, 1, "");
+  emtfShowerEmulSummary_eff_->getTH2F()->Divide(emtfShowerEmulSummary_num_->getTH2F(), emtfShowerEmulSummary_denom_->getTH2F(), 1, 1, "");
+}

--- a/DQM/L1TMonitorClient/src/SealModule.cc
+++ b/DQM/L1TMonitorClient/src/SealModule.cc
@@ -15,6 +15,12 @@ DEFINE_FWK_MODULE(L1TdeGEMTPGClient);
 #include "DQM/L1TMonitorClient/interface/L1TdeCSCTPGClient.h"
 DEFINE_FWK_MODULE(L1TdeCSCTPGClient);
 
+#include "DQM/L1TMonitorClient/interface/L1TdeCSCTPGShowerClient.h"
+DEFINE_FWK_MODULE(L1TdeCSCTPGShowerClient);
+
+#include "DQM/L1TMonitorClient/interface/L1TdeStage2ShowerClient.h"
+DEFINE_FWK_MODULE(L1TdeStage2ShowerClient);
+
 #include "DQM/L1TMonitorClient/interface/L1TCSCTFClient.h"
 DEFINE_FWK_MODULE(L1TCSCTFClient);
 


### PR DESCRIPTION
#### PR description:

This PR adds 2D summary plots for data vs emulator comparison on L1T shower objects to the online DQM monitor and monitor client modules. There are 2 summary plots for each of the ALCT showers, CLCT showers, LCT combined showers, and EMTF showers. The plot setting follows the CSC TP plots in [PR#36226](https://github.com/cms-sw/cmssw/pull/36226).

At the moment shower objects are not implemented in CSC or EMTF firmwares. Emulation is used in the place of data in this PR and the setting will be updated to data once showers are available.

#### PR validation:

This PR is tested with 10k events in a Higgs to LLP to 4b sample, plot examples are available at [link](https://xzuo.web.cern.ch/ShowerDQM/data_vs_emul/) 

The PR passed local unit tests and matrix tests. The standard code format is applied.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A.
