### PR TITLE
Moved modules in PhysicsTools/PatExamples to be thread-friendly

### DIFF
--- a/PhysicsTools/PatExamples/plugins/JetEnergyShift.cc
+++ b/PhysicsTools/PatExamples/plugins/JetEnergyShift.cc
@@ -1,5 +1,5 @@
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DataFormats/PatCandidates/interface/Jet.h"
@@ -31,16 +31,14 @@
   and met input collections.
 */
 
-class JetEnergyShift : public edm::EDProducer {
+class JetEnergyShift : public edm::global::EDProducer<> {
 public:
   /// default constructor
   explicit JetEnergyShift(const edm::ParameterSet&);
-  /// default destructor
-  ~JetEnergyShift() override{};
 
 private:
   /// rescale jet energy and recalculated MET
-  void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
 private:
   /// jet input collection
@@ -73,7 +71,7 @@ JetEnergyShift::JetEnergyShift(const edm::ParameterSet& cfg)
   produces<std::vector<pat::MET>>(outputMETs_);
 }
 
-void JetEnergyShift::produce(edm::Event& event, const edm::EventSetup& setup) {
+void JetEnergyShift::produce(edm::StreamID, edm::Event& event, const edm::EventSetup& setup) const {
   edm::Handle<std::vector<pat::Jet>> jets;
   event.getByToken(inputJetsToken_, jets);
 

--- a/PhysicsTools/PatExamples/plugins/MuonAnalyzer.cc
+++ b/PhysicsTools/PatExamples/plugins/MuonAnalyzer.cc
@@ -7,7 +7,7 @@
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 #include "DataFormats/Math/interface/LorentzVector.h"
 #include "DataFormats/PatCandidates/interface/Muon.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -18,7 +18,7 @@
 #include "TH1F.h"
 #include "TH2F.h"
 
-class ExampleMuonAnalyzer : public edm::EDAnalyzer {
+class ExampleMuonAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   /// Constructor
   ExampleMuonAnalyzer(const edm::ParameterSet &pset);
@@ -65,6 +65,7 @@ using namespace edm;
 /// Constructor
 ExampleMuonAnalyzer::ExampleMuonAnalyzer(const ParameterSet &pset) {
   theMuonToken = consumes<pat::MuonCollection>(pset.getParameter<InputTag>("MuonCollection"));
+  usesResource(TFileService::kSharedResource);
 }
 
 /// Destructor

--- a/PhysicsTools/PatExamples/plugins/PatBJetTagAnalyzer.cc
+++ b/PhysicsTools/PatExamples/plugins/PatBJetTagAnalyzer.cc
@@ -8,7 +8,7 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -17,7 +17,7 @@
 
 #include "DataFormats/PatCandidates/interface/Jet.h"
 
-class PatBJetTagAnalyzer : public edm::EDAnalyzer {
+class PatBJetTagAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   /// constructor and destructor
   PatBJetTagAnalyzer(const edm::ParameterSet &params);
@@ -49,7 +49,9 @@ private:
 PatBJetTagAnalyzer::PatBJetTagAnalyzer(const edm::ParameterSet &params)
     : jetsToken_(consumes<pat::JetCollection>(params.getParameter<edm::InputTag>("jets"))),
       jetPtCut_(params.getParameter<double>("jetPtCut")),
-      jetEtaCut_(params.getParameter<double>("jetEtaCut")) {}
+      jetEtaCut_(params.getParameter<double>("jetEtaCut")) {
+  usesResource(TFileService::kSharedResource);
+}
 
 PatBJetTagAnalyzer::~PatBJetTagAnalyzer() {}
 

--- a/PhysicsTools/PatExamples/plugins/PatBJetTrackAnalyzer.cc
+++ b/PhysicsTools/PatExamples/plugins/PatBJetTrackAnalyzer.cc
@@ -12,7 +12,7 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -27,7 +27,7 @@
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/Measurement1D.h"
 
-class PatBJetTrackAnalyzer : public edm::EDAnalyzer {
+class PatBJetTrackAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   /// constructor and destructor
   PatBJetTrackAnalyzer(const edm::ParameterSet &params);
@@ -80,7 +80,9 @@ PatBJetTrackAnalyzer::PatBJetTrackAnalyzer(const edm::ParameterSet &params)
       minPt_(params.getParameter<double>("minPt")),
       minPixelHits_(params.getParameter<unsigned int>("minPixelHits")),
       minTotalHits_(params.getParameter<unsigned int>("minTotalHits")),
-      nThTrack_(params.getParameter<unsigned int>("nThTrack")) {}
+      nThTrack_(params.getParameter<unsigned int>("nThTrack")) {
+  usesResource(TFileService::kSharedResource);
+}
 
 PatBJetTrackAnalyzer::~PatBJetTrackAnalyzer() {}
 

--- a/PhysicsTools/PatExamples/plugins/PatBJetVertexAnalyzer.cc
+++ b/PhysicsTools/PatExamples/plugins/PatBJetVertexAnalyzer.cc
@@ -14,7 +14,7 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -30,7 +30,7 @@
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/Measurement1D.h"
 
-class PatBJetVertexAnalyzer : public edm::EDAnalyzer {
+class PatBJetVertexAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   /// constructor and destructor
   PatBJetVertexAnalyzer(const edm::ParameterSet &params);
@@ -65,7 +65,9 @@ private:
 PatBJetVertexAnalyzer::PatBJetVertexAnalyzer(const edm::ParameterSet &params)
     : jetsToken_(consumes<pat::JetCollection>(params.getParameter<edm::InputTag>("jets"))),
       jetPtCut_(params.getParameter<double>("jetPtCut")),
-      jetEtaCut_(params.getParameter<double>("jetEtaCut")) {}
+      jetEtaCut_(params.getParameter<double>("jetEtaCut")) {
+  usesResource(TFileService::kSharedResource);
+}
 
 PatBJetVertexAnalyzer::~PatBJetVertexAnalyzer() {}
 

--- a/PhysicsTools/PatExamples/plugins/PatBTagAnalyzer.cc
+++ b/PhysicsTools/PatExamples/plugins/PatBTagAnalyzer.cc
@@ -6,7 +6,7 @@
 #include "TGraphErrors.h"
 
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -18,7 +18,7 @@
 #include "PhysicsTools/PatExamples/interface/BTagPerformance.h"
 #include "PhysicsTools/PatExamples/interface/PatBTagCommonHistos.h"
 
-class PatBTagAnalyzer : public edm::EDAnalyzer {
+class PatBTagAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit PatBTagAnalyzer(const edm::ParameterSet &);
   ~PatBTagAnalyzer() override;
@@ -74,6 +74,7 @@ PatBTagAnalyzer::PatBTagAnalyzer(const edm::ParameterSet &iConfig)
       BTagger(iConfig.getParameter<edm::ParameterSet>("BJetOperatingPoints")),
       BTagHistograms(iConfig) {
   //now do what ever initialization is needed
+  usesResource(TFileService::kSharedResource);
 }
 
 PatBTagAnalyzer::~PatBTagAnalyzer() {

--- a/PhysicsTools/PatExamples/plugins/PatBasicAnalyzer.cc
+++ b/PhysicsTools/PatExamples/plugins/PatBasicAnalyzer.cc
@@ -4,7 +4,7 @@
 #include "TH1.h"
 
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -17,7 +17,7 @@
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include "DataFormats/PatCandidates/interface/MET.h"
 
-class PatBasicAnalyzer : public edm::EDAnalyzer {
+class PatBasicAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   /// default constructor
   explicit PatBasicAnalyzer(const edm::ParameterSet&);
@@ -55,7 +55,9 @@ PatBasicAnalyzer::PatBasicAnalyzer(const edm::ParameterSet& iConfig)
       muonSrcToken_(consumes<edm::View<pat::Muon>>(iConfig.getUntrackedParameter<edm::InputTag>("muonSrc"))),
       tauSrcToken_(consumes<edm::View<pat::Tau>>(iConfig.getUntrackedParameter<edm::InputTag>("tauSrc"))),
       jetSrcToken_(consumes<edm::View<pat::Jet>>(iConfig.getUntrackedParameter<edm::InputTag>("jetSrc"))),
-      metSrcToken_(consumes<edm::View<pat::MET>>(iConfig.getUntrackedParameter<edm::InputTag>("metSrc"))) {}
+      metSrcToken_(consumes<edm::View<pat::MET>>(iConfig.getUntrackedParameter<edm::InputTag>("metSrc"))) {
+  usesResource(TFileService::kSharedResource);
+}
 
 PatBasicAnalyzer::~PatBasicAnalyzer() {}
 

--- a/PhysicsTools/PatExamples/plugins/PatElectronAnalyzer.cc
+++ b/PhysicsTools/PatExamples/plugins/PatElectronAnalyzer.cc
@@ -3,7 +3,7 @@
 #include "TMath.h"
 
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -12,7 +12,7 @@
 #include "DataFormats/PatCandidates/interface/Electron.h"
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 
-class PatElectronAnalyzer : public edm::EDAnalyzer {
+class PatElectronAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit PatElectronAnalyzer(const edm::ParameterSet &);
   ~PatElectronAnalyzer() override;
@@ -81,6 +81,8 @@ PatElectronAnalyzer::PatElectronAnalyzer(const edm::ParameterSet &cfg)
       particleSrcToken_(consumes<reco::GenParticleCollection>(cfg.getParameter<edm::InputTag>("particleSrc"))),
       genMatchMode_(cfg.getParameter<edm::ParameterSet>("genMatchMode")),
       tagAndProbeMode_(cfg.getParameter<edm::ParameterSet>("tagAndProbeMode")) {
+  usesResource(TFileService::kSharedResource);
+
   // complete the configuration of the analyzer
   maxDeltaR_ = genMatchMode_.getParameter<double>("maxDeltaR");
   maxDeltaM_ = tagAndProbeMode_.getParameter<double>("maxDeltaM");

--- a/PhysicsTools/PatExamples/plugins/PatJPsiProducer.cc
+++ b/PhysicsTools/PatExamples/plugins/PatJPsiProducer.cc
@@ -21,7 +21,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -44,15 +44,12 @@
 // class decleration
 //
 
-class PatJPsiProducer : public edm::EDProducer {
+class PatJPsiProducer : public edm::global::EDProducer<> {
 public:
   explicit PatJPsiProducer(const edm::ParameterSet&);
-  ~PatJPsiProducer() override;
 
 private:
-  void beginJob() override;
-  void produce(edm::Event&, const edm::EventSetup&) override;
-  void endJob() override;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
   // ----------member data ---------------------------
 
@@ -75,14 +72,12 @@ PatJPsiProducer::PatJPsiProducer(const edm::ParameterSet& iConfig)
   produces<std::vector<pat::CompositeCandidate>>();
 }
 
-PatJPsiProducer::~PatJPsiProducer() {}
-
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-void PatJPsiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void PatJPsiProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   auto jpsiCands = std::make_unique<std::vector<pat::CompositeCandidate>>();
   edm::Handle<edm::View<pat::Muon>> h_muons;
   iEvent.getByToken(muonSrcToken_, h_muons);
@@ -121,12 +116,6 @@ void PatJPsiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
   iEvent.put(std::move(jpsiCands));
 }
-
-// ------------ method called once each job just before starting event loop  ------------
-void PatJPsiProducer::beginJob() {}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void PatJPsiProducer::endJob() {}
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(PatJPsiProducer);

--- a/PhysicsTools/PatExamples/plugins/PatJetAnalyzer.cc
+++ b/PhysicsTools/PatExamples/plugins/PatJetAnalyzer.cc
@@ -7,7 +7,7 @@
 #include "TH1.h"
 
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -39,7 +39,7 @@ static const float BINS[] = {30., 40., 50., 60., 70., 80., 100., 125., 150.};
     - corrLevel --> string for the pat jet correction level.
 */
 
-class PatJetAnalyzer : public edm::EDAnalyzer {
+class PatJetAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   /// default contructor
   explicit PatJetAnalyzer(const edm::ParameterSet& cfg);
@@ -72,6 +72,7 @@ private:
 PatJetAnalyzer::PatJetAnalyzer(const edm::ParameterSet& cfg)
     : corrLevel_(cfg.getParameter<std::string>("corrLevel")),
       jetsToken_(consumes<edm::View<pat::Jet> >(cfg.getParameter<edm::InputTag>("src"))) {
+  usesResource(TFileService::kSharedResource);
   // register TFileService
   edm::Service<TFileService> fs;
 

--- a/PhysicsTools/PatExamples/plugins/PatMCMatching.cc
+++ b/PhysicsTools/PatExamples/plugins/PatMCMatching.cc
@@ -4,7 +4,7 @@
 #include "TH1.h"
 
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -13,7 +13,7 @@
 
 #include "DataFormats/PatCandidates/interface/Muon.h"
 
-class PatMCMatching : public edm::EDAnalyzer {
+class PatMCMatching : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   /// default constructor
   explicit PatMCMatching(const edm::ParameterSet&);
@@ -36,7 +36,9 @@ private:
 
 PatMCMatching::PatMCMatching(const edm::ParameterSet& iConfig)
     : histContainer_(),
-      muonSrcToken_(consumes<edm::View<pat::Muon> >(iConfig.getUntrackedParameter<edm::InputTag>("muonSrc"))) {}
+      muonSrcToken_(consumes<edm::View<pat::Muon> >(iConfig.getUntrackedParameter<edm::InputTag>("muonSrc"))) {
+  usesResource(TFileService::kSharedResource);
+}
 
 PatMCMatching::~PatMCMatching() {}
 

--- a/PhysicsTools/PatExamples/plugins/PatMCMatchingExtended.cc
+++ b/PhysicsTools/PatExamples/plugins/PatMCMatchingExtended.cc
@@ -4,7 +4,7 @@
 #include "TH1.h"
 
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -13,7 +13,7 @@
 
 #include "DataFormats/PatCandidates/interface/Muon.h"
 
-class PatMCMatchingExtended : public edm::EDAnalyzer {
+class PatMCMatchingExtended : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   /// default constructor
   explicit PatMCMatchingExtended(const edm::ParameterSet&);
@@ -48,7 +48,9 @@ private:
 
 PatMCMatchingExtended::PatMCMatchingExtended(const edm::ParameterSet& iConfig)
     : histContainer_(),
-      muonSrcToken_(consumes<edm::View<pat::Muon> >(iConfig.getUntrackedParameter<edm::InputTag>("muonSrc"))) {}
+      muonSrcToken_(consumes<edm::View<pat::Muon> >(iConfig.getUntrackedParameter<edm::InputTag>("muonSrc"))) {
+  usesResource(TFileService::kSharedResource);
+}
 
 PatMCMatchingExtended::~PatMCMatchingExtended() {}
 

--- a/PhysicsTools/PatExamples/plugins/PatTauAnalyzer.cc
+++ b/PhysicsTools/PatExamples/plugins/PatTauAnalyzer.cc
@@ -1,6 +1,6 @@
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 #include "DataFormats/PatCandidates/interface/Tau.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -14,7 +14,7 @@
 
 #include <string>
 
-class PatTauAnalyzer : public edm::EDAnalyzer {
+class PatTauAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit PatTauAnalyzer(const edm::ParameterSet&);
   ~PatTauAnalyzer() override;
@@ -87,6 +87,7 @@ const reco::GenParticle* getGenTau(const pat::Tau& patTau) {
 
 PatTauAnalyzer::PatTauAnalyzer(const edm::ParameterSet& cfg) {
   //std::cout << "<PatTauAnalyzer::PatTauAnalyzer>:" << std::endl;
+  usesResource(TFileService::kSharedResource);
 
   //--- read name of pat::Tau collection
   src_ = cfg.getParameter<edm::InputTag>("src");

--- a/PhysicsTools/PatExamples/plugins/PatTopSelectionAnalyzer.cc
+++ b/PhysicsTools/PatExamples/plugins/PatTopSelectionAnalyzer.cc
@@ -4,7 +4,7 @@
 #include "TH1.h"
 
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -15,7 +15,7 @@
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include "DataFormats/PatCandidates/interface/MET.h"
 
-class PatTopSelectionAnalyzer : public edm::EDAnalyzer {
+class PatTopSelectionAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   /// default constructor
   explicit PatTopSelectionAnalyzer(const edm::ParameterSet&);
@@ -55,7 +55,9 @@ PatTopSelectionAnalyzer::PatTopSelectionAnalyzer(const edm::ParameterSet& iConfi
       elecsToken_(consumes<edm::View<pat::Electron> >(iConfig.getUntrackedParameter<edm::InputTag>("elecs"))),
       muonsToken_(consumes<edm::View<pat::Muon> >(iConfig.getUntrackedParameter<edm::InputTag>("muons"))),
       jetsToken_(consumes<edm::View<pat::Jet> >(iConfig.getUntrackedParameter<edm::InputTag>("jets"))),
-      metToken_(consumes<edm::View<pat::MET> >(iConfig.getUntrackedParameter<edm::InputTag>("met"))) {}
+      metToken_(consumes<edm::View<pat::MET> >(iConfig.getUntrackedParameter<edm::InputTag>("met"))) {
+  usesResource(TFileService::kSharedResource);
+}
 
 PatTopSelectionAnalyzer::~PatTopSelectionAnalyzer() {}
 

--- a/PhysicsTools/PatExamples/plugins/PatTrackAnalyzer.cc
+++ b/PhysicsTools/PatExamples/plugins/PatTrackAnalyzer.cc
@@ -9,7 +9,7 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -22,7 +22,7 @@
 #include "DataFormats/TrackReco/interface/HitPattern.h"
 #include "DataFormats/PatCandidates/interface/Muon.h"
 
-class PatTrackAnalyzer : public edm::EDAnalyzer {
+class PatTrackAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   /// constructor and destructor
   PatTrackAnalyzer(const edm::ParameterSet &params);
@@ -61,7 +61,9 @@ PatTrackAnalyzer::PatTrackAnalyzer(const edm::ParameterSet &params)
     : srcTracksToken_(mayConsume<edm::View<reco::Track> >(params.getParameter<edm::InputTag>("src"))),
       srcMuonsToken_(mayConsume<pat::MuonCollection>(params.getParameter<edm::InputTag>("src"))),
       beamSpotToken_(consumes<reco::BeamSpot>(params.getParameter<edm::InputTag>("beamSpot"))),
-      qualities_(params.getParameter<std::vector<std::string> >("qualities")) {}
+      qualities_(params.getParameter<std::vector<std::string> >("qualities")) {
+  usesResource(TFileService::kSharedResource);
+}
 
 PatTrackAnalyzer::~PatTrackAnalyzer() {}
 

--- a/PhysicsTools/PatExamples/plugins/PatTriggerAnalyzer.cc
+++ b/PhysicsTools/PatExamples/plugins/PatTriggerAnalyzer.cc
@@ -6,13 +6,13 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Utilities/interface/InputTag.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/PatCandidates/interface/Muon.h"
 #include "DataFormats/PatCandidates/interface/TriggerEvent.h"
 
-class PatTriggerAnalyzer : public edm::EDAnalyzer {
+class PatTriggerAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   /// default constructor
   explicit PatTriggerAnalyzer(const edm::ParameterSet& iConfig);
@@ -71,7 +71,9 @@ PatTriggerAnalyzer::PatTriggerAnalyzer(const edm::ParameterSet& iConfig)
       // maximal id for of all trigger objects
       maxID_(iConfig.getParameter<unsigned>("maxID")),
       histos1D_(),
-      histos2D_() {}
+      histos2D_() {
+  usesResource(TFileService::kSharedResource);
+}
 
 PatTriggerAnalyzer::~PatTriggerAnalyzer() {}
 

--- a/PhysicsTools/PatExamples/plugins/PatTriggerTagAndProbe.cc
+++ b/PhysicsTools/PatExamples/plugins/PatTriggerTagAndProbe.cc
@@ -6,13 +6,13 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Utilities/interface/InputTag.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/PatCandidates/interface/Muon.h"
 #include "DataFormats/PatCandidates/interface/TriggerEvent.h"
 
-class PatTriggerTagAndProbe : public edm::EDAnalyzer {
+class PatTriggerTagAndProbe : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   /// default constructor
   explicit PatTriggerTagAndProbe(const edm::ParameterSet& iConfig);
@@ -54,7 +54,9 @@ PatTriggerTagAndProbe::PatTriggerTagAndProbe(const edm::ParameterSet& iConfig)
       // muon match objects
       muonMatch_(iConfig.getParameter<std::string>("muonMatch")),
       // histogram management
-      histos1D_() {}
+      histos1D_() {
+  usesResource(TFileService::kSharedResource);
+}
 
 PatTriggerTagAndProbe::~PatTriggerTagAndProbe() {}
 

--- a/PhysicsTools/PatExamples/plugins/PatVertexAnalyzer.cc
+++ b/PhysicsTools/PatExamples/plugins/PatVertexAnalyzer.cc
@@ -9,7 +9,7 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -23,7 +23,7 @@
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 #include "DataFormats/HepMCCandidate/interface/GenParticleFwd.h"
 
-class PatVertexAnalyzer : public edm::EDAnalyzer {
+class PatVertexAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   /// constructor and destructor
   PatVertexAnalyzer(const edm::ParameterSet &params);
@@ -47,7 +47,9 @@ private:
 
 PatVertexAnalyzer::PatVertexAnalyzer(const edm::ParameterSet &params)
     : srcToken_(consumes<reco::VertexCollection>(params.getParameter<edm::InputTag>("src"))),
-      genParticlesToken_(consumes<reco::GenParticleCollection>(params.getParameter<edm::InputTag>("mc"))) {}
+      genParticlesToken_(consumes<reco::GenParticleCollection>(params.getParameter<edm::InputTag>("mc"))) {
+  usesResource(TFileService::kSharedResource);
+}
 
 PatVertexAnalyzer::~PatVertexAnalyzer() {}
 

--- a/PhysicsTools/PatExamples/plugins/PatZToMuMuAnalyzer.cc
+++ b/PhysicsTools/PatExamples/plugins/PatZToMuMuAnalyzer.cc
@@ -6,7 +6,7 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Utilities/interface/InputTag.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/PatCandidates/interface/Muon.h"
@@ -29,7 +29,7 @@
    The shift is applied to all mass calculations.
 */
 
-class PatZToMuMuAnalyzer : public edm::EDAnalyzer {
+class PatZToMuMuAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   /// typedef's to simplify get functions
   typedef math::XYZVector Vector;
@@ -77,6 +77,8 @@ inline double PatZToMuMuAnalyzer::mass(const Vector& t1, const Vector& t2) const
 PatZToMuMuAnalyzer::PatZToMuMuAnalyzer(const edm::ParameterSet& cfg)
     : muonsToken_(consumes<edm::View<pat::Muon> >(cfg.getParameter<edm::InputTag>("muons"))),
       shift_(cfg.getParameter<double>("shift")) {
+  usesResource(TFileService::kSharedResource);
+
   edm::Service<TFileService> fileService;
 
   // mass plot around Z peak from global tracks

--- a/PhysicsTools/PatExamples/plugins/PatZjetsElectronAnalyzer.cc
+++ b/PhysicsTools/PatExamples/plugins/PatZjetsElectronAnalyzer.cc
@@ -4,7 +4,7 @@
 #include "TH1.h"
 
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -12,7 +12,7 @@
 
 #include "DataFormats/PatCandidates/interface/Electron.h"
 
-class PatZjetsElectronAnalyzer : public edm::EDAnalyzer {
+class PatZjetsElectronAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit PatZjetsElectronAnalyzer(const edm::ParameterSet&);
   ~PatZjetsElectronAnalyzer() override;
@@ -33,7 +33,9 @@ private:
 
 PatZjetsElectronAnalyzer::PatZjetsElectronAnalyzer(const edm::ParameterSet& iConfig)
     : histContainer_(),
-      srcToken_(consumes<edm::View<pat::Electron> >(iConfig.getUntrackedParameter<edm::InputTag>("src"))) {}
+      srcToken_(consumes<edm::View<pat::Electron> >(iConfig.getUntrackedParameter<edm::InputTag>("src"))) {
+  usesResource(TFileService::kSharedResource);
+}
 
 PatZjetsElectronAnalyzer::~PatZjetsElectronAnalyzer() {}
 

--- a/PhysicsTools/PatExamples/plugins/PatZjetsJetAnalyzer.cc
+++ b/PhysicsTools/PatExamples/plugins/PatZjetsJetAnalyzer.cc
@@ -4,7 +4,7 @@
 #include "TH1.h"
 
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -12,7 +12,7 @@
 
 #include "DataFormats/PatCandidates/interface/Jet.h"
 
-class PatZjetsJetAnalyzer : public edm::EDAnalyzer {
+class PatZjetsJetAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit PatZjetsJetAnalyzer(const edm::ParameterSet&);
   ~PatZjetsJetAnalyzer() override;
@@ -32,8 +32,9 @@ private:
 };
 
 PatZjetsJetAnalyzer::PatZjetsJetAnalyzer(const edm::ParameterSet& iConfig)
-    : histContainer_(),
-      srcToken_(consumes<edm::View<pat::Jet> >(iConfig.getUntrackedParameter<edm::InputTag>("src"))) {}
+    : histContainer_(), srcToken_(consumes<edm::View<pat::Jet> >(iConfig.getUntrackedParameter<edm::InputTag>("src"))) {
+  usesResource(TFileService::kSharedResource);
+}
 
 PatZjetsJetAnalyzer::~PatZjetsJetAnalyzer() {}
 


### PR DESCRIPTION
#### PR description:

Removed use of legacy module types.

#### PR validation:

Compling code with -DUSE_CMS_DEPRECATED no longer issues warning.