### PR TITLE
Remove usedFallback argument from (pre|post)(Open|Close)File

### DIFF
--- a/FWCore/Framework/interface/InputSource.h
+++ b/FWCore/Framework/interface/InputSource.h
@@ -290,8 +290,8 @@ namespace edm {
 
     class FileOpenSentry {
     public:
-      typedef signalslot::Signal<void(std::string const&, bool)> Sig;
-      explicit FileOpenSentry(InputSource const& source, std::string const& lfn, bool usedFallback);
+      typedef signalslot::Signal<void(std::string const&)> Sig;
+      explicit FileOpenSentry(InputSource const& source, std::string const& lfn);
       ~FileOpenSentry();
 
       FileOpenSentry(FileOpenSentry const&) = delete;             // Disallow copying and moving
@@ -300,13 +300,12 @@ namespace edm {
     private:
       Sig& post_;
       std::string const& lfn_;
-      bool usedFallback_;
     };
 
     class FileCloseSentry {
     public:
-      typedef signalslot::Signal<void(std::string const&, bool)> Sig;
-      explicit FileCloseSentry(InputSource const& source, std::string const& lfn, bool usedFallback);
+      typedef signalslot::Signal<void(std::string const&)> Sig;
+      explicit FileCloseSentry(InputSource const& source, std::string const& lfn);
       ~FileCloseSentry();
 
       FileCloseSentry(FileCloseSentry const&) = delete;             // Disallow copying and moving
@@ -315,7 +314,6 @@ namespace edm {
     private:
       Sig& post_;
       std::string const& lfn_;
-      bool usedFallback_;
     };
 
     signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> preEventReadFromSourceSignal_;

--- a/FWCore/Framework/src/InputSource.cc
+++ b/FWCore/Framework/src/InputSource.cc
@@ -495,17 +495,17 @@ namespace edm {
     source_.actReg()->postSourceProcessBlockSignal_(processName_);
   }
 
-  InputSource::FileOpenSentry::FileOpenSentry(InputSource const& source, std::string const& lfn, bool usedFallback)
-      : post_(source.actReg()->postOpenFileSignal_), lfn_(lfn), usedFallback_(usedFallback) {
-    source.actReg()->preOpenFileSignal_(lfn, usedFallback);
+  InputSource::FileOpenSentry::FileOpenSentry(InputSource const& source, std::string const& lfn)
+      : post_(source.actReg()->postOpenFileSignal_), lfn_(lfn) {
+    source.actReg()->preOpenFileSignal_(lfn);
   }
 
-  InputSource::FileOpenSentry::~FileOpenSentry() { post_(lfn_, usedFallback_); }
+  InputSource::FileOpenSentry::~FileOpenSentry() { post_(lfn_); }
 
-  InputSource::FileCloseSentry::FileCloseSentry(InputSource const& source, std::string const& lfn, bool usedFallback)
-      : post_(source.actReg()->postCloseFileSignal_), lfn_(lfn), usedFallback_(usedFallback) {
-    source.actReg()->preCloseFileSignal_(lfn, usedFallback);
+  InputSource::FileCloseSentry::FileCloseSentry(InputSource const& source, std::string const& lfn)
+      : post_(source.actReg()->postCloseFileSignal_), lfn_(lfn) {
+    source.actReg()->preCloseFileSignal_(lfn);
   }
 
-  InputSource::FileCloseSentry::~FileCloseSentry() { post_(lfn_, usedFallback_); }
+  InputSource::FileCloseSentry::~FileCloseSentry() { post_(lfn_); }
 }  // namespace edm

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
@@ -1,7 +1,7 @@
 ++ starting: constructing source: PoolSource
 Module type=PoolSource, Module label=source, Parameter Set ID=079a79e873959edf4ff4f335f14507fa
-++++ starting: open input file: lfn = file:testGetBy1.root usedFallBack = 0
-++++ finished: open input file: lfn = file:testGetBy1.root usedFallBack = 0
+++++ starting: open input file: lfn = file:testGetBy1.root
+++++ finished: open input file: lfn = file:testGetBy1.root
 ++ finished: constructing source: PoolSource
 Module type=PoolSource, Module label=source, Parameter Set ID=079a79e873959edf4ff4f335f14507fa
 ++++ starting: constructing module with label 'TriggerResults' id = 1
@@ -791,8 +791,8 @@ GlobalContext: transition = WriteRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++ starting: close input file: lfn = file:testGetBy1.root usedFallBack = 0
-++++ finished: close input file: lfn = file:testGetBy1.root usedFallBack = 0
+++++ starting: close input file: lfn = file:testGetBy1.root
+++++ finished: close input file: lfn = file:testGetBy1.root
 ++++ starting: end process block
 GlobalContext: transition = EndProcessBlock
     run: 0 luminosityBlock: 0

--- a/FWCore/MessageService/plugins/MessageLogger.cc
+++ b/FWCore/MessageService/plugins/MessageLogger.cc
@@ -748,9 +748,9 @@ namespace edm {
     void MessageLogger::preSourceRunLumi() { establish("source"); }
     void MessageLogger::postSourceRunLumi() { unEstablish("AfterSource"); }
 
-    void MessageLogger::preFile(std::string const&, bool) { establish("file_open"); }
-    void MessageLogger::preFileClose(std::string const&, bool) { establish("file_close"); }
-    void MessageLogger::postFile(std::string const&, bool) { unEstablish("AfterFile"); }
+    void MessageLogger::preFile(std::string const&) { establish("file_open"); }
+    void MessageLogger::preFileClose(std::string const&) { establish("file_close"); }
+    void MessageLogger::postFile(std::string const&) { unEstablish("AfterFile"); }
 
     void MessageLogger::preEvent(StreamContext const& iContext) {
       assert(iContext.streamID().value() < transitionInfoCache_.size());

--- a/FWCore/MessageService/plugins/MessageLogger.h
+++ b/FWCore/MessageService/plugins/MessageLogger.h
@@ -63,9 +63,9 @@ namespace edm {
       void preSourceRunLumi();
       void postSourceRunLumi();
 
-      void preFile(std::string const&, bool);
-      void preFileClose(std::string const&, bool);
-      void postFile(std::string const&, bool);
+      void preFile(std::string const&);
+      void preFileClose(std::string const&);
+      void postFile(std::string const&);
 
       void preModuleConstruction(ModuleDescription const&);
       void postModuleConstruction(ModuleDescription const&);

--- a/FWCore/ServiceRegistry/interface/ActivityRegistry.h
+++ b/FWCore/ServiceRegistry/interface/ActivityRegistry.h
@@ -231,31 +231,30 @@ namespace edm {
     AR_WATCH_USING_METHOD_1(watchPostSourceProcessBlock)
 
     /// signal is emitted before the source opens a file
-    typedef signalslot::Signal<void(std::string const&, bool)> PreOpenFile;
+    typedef signalslot::Signal<void(std::string const&)> PreOpenFile;
     PreOpenFile preOpenFileSignal_;
     void watchPreOpenFile(PreOpenFile::slot_type const& iSlot) { preOpenFileSignal_.connect(iSlot); }
-    AR_WATCH_USING_METHOD_2(watchPreOpenFile)
+    AR_WATCH_USING_METHOD_1(watchPreOpenFile)
 
     /// signal is emitted after the source opens a file
     //   Note this is only done for a primary file, not a secondary one.
-    typedef signalslot::Signal<void(std::string const&, bool)> PostOpenFile;
+    typedef signalslot::Signal<void(std::string const&)> PostOpenFile;
     PostOpenFile postOpenFileSignal_;
     void watchPostOpenFile(PostOpenFile::slot_type const& iSlot) { postOpenFileSignal_.connect_front(iSlot); }
-    AR_WATCH_USING_METHOD_2(watchPostOpenFile)
+    AR_WATCH_USING_METHOD_1(watchPostOpenFile)
 
-    /// signal is emitted before the Closesource closes a file
+    /// signal is emitted before the source closes a file
     //   First argument is the LFN of the file which is being closed.
-    //   Second argument is false if fallback is used; true otherwise.
-    typedef signalslot::Signal<void(std::string const&, bool)> PreCloseFile;
+    typedef signalslot::Signal<void(std::string const&)> PreCloseFile;
     PreCloseFile preCloseFileSignal_;
     void watchPreCloseFile(PreCloseFile::slot_type const& iSlot) { preCloseFileSignal_.connect(iSlot); }
-    AR_WATCH_USING_METHOD_2(watchPreCloseFile)
+    AR_WATCH_USING_METHOD_1(watchPreCloseFile)
 
-    /// signal is emitted after the source opens a file
-    typedef signalslot::Signal<void(std::string const&, bool)> PostCloseFile;
+    /// signal is emitted after the source closes a file
+    typedef signalslot::Signal<void(std::string const&)> PostCloseFile;
     PostCloseFile postCloseFileSignal_;
     void watchPostCloseFile(PostCloseFile::slot_type const& iSlot) { postCloseFileSignal_.connect_front(iSlot); }
-    AR_WATCH_USING_METHOD_2(watchPostCloseFile)
+    AR_WATCH_USING_METHOD_1(watchPostCloseFile)
 
     typedef signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> PreModuleBeginStream;
     PreModuleBeginStream preModuleBeginStreamSignal_;

--- a/FWCore/Services/plugins/CheckTransitions.cc
+++ b/FWCore/Services/plugins/CheckTransitions.cc
@@ -53,9 +53,9 @@ namespace edm {
       void preBeginJob(PathsAndConsumesOfModulesBase const&, ProcessContext const&);
       void postEndJob();
 
-      void preOpenFile(std::string const&, bool);
+      void preOpenFile(std::string const&);
 
-      void preCloseFile(std::string const& lfn, bool primary);
+      void preCloseFile(std::string const& lfn);
 
       void preGlobalBeginRun(GlobalContext const&);
 
@@ -283,9 +283,9 @@ void CheckTransitions::postEndJob() {
   }
 }
 
-void CheckTransitions::preOpenFile(std::string const& lfn, bool b) {}
+void CheckTransitions::preOpenFile(std::string const& lfn) {}
 
-void CheckTransitions::preCloseFile(std::string const& lfn, bool b) {}
+void CheckTransitions::preCloseFile(std::string const& lfn) {}
 
 void CheckTransitions::preGlobalBeginRun(GlobalContext const& gc) {
   auto id = gc.luminosityBlockID();

--- a/FWCore/Services/plugins/CondorStatusUpdater.cc
+++ b/FWCore/Services/plugins/CondorStatusUpdater.cc
@@ -60,7 +60,7 @@ namespace edm {
       void beginPre(PathsAndConsumesOfModulesBase const &, ProcessContext const &processContext);
       void beginPost();
       void endPost();
-      void filePost(std::string const &, bool);
+      void filePost(std::string const &);
 
       bool m_debug;
       std::atomic_flag m_shouldUpdate;
@@ -136,7 +136,7 @@ void CondorStatusService::runPost(GlobalContext const &) {
   update();
 }
 
-void CondorStatusService::filePost(std::string const & /*lfn*/, bool /*usedFallback*/) {
+void CondorStatusService::filePost(std::string const & /*lfn*/) {
   m_files++;
   update();
 }

--- a/FWCore/Services/plugins/Timing.cc
+++ b/FWCore/Services/plugins/Timing.cc
@@ -73,8 +73,8 @@ namespace edm {
       void preSourceRun(RunIndex);
       void postSourceRun(RunIndex);
 
-      void preOpenFile(std::string const&, bool);
-      void postOpenFile(std::string const&, bool);
+      void preOpenFile(std::string const&);
+      void postOpenFile(std::string const&);
 
       void preModule(ModuleDescription const& md);
       void postModule(ModuleDescription const& md);
@@ -553,9 +553,9 @@ namespace edm {
 
     void Timing::postSourceRun(RunIndex index) { postCommon(); }
 
-    void Timing::preOpenFile(std::string const& lfn, bool b) { pushStack(configuredInTopLevelProcess_); }
+    void Timing::preOpenFile(std::string const& lfn) { pushStack(configuredInTopLevelProcess_); }
 
-    void Timing::postOpenFile(std::string const& lfn, bool b) { postCommon(); }
+    void Timing::postOpenFile(std::string const& lfn) { postCommon(); }
 
     void Timing::preModule(ModuleDescription const&) { pushStack(configuredInTopLevelProcess_); }
 

--- a/FWCore/Services/plugins/Tracer.cc
+++ b/FWCore/Services/plugins/Tracer.cc
@@ -88,11 +88,11 @@ namespace edm {
       void preSourceProcessBlock();
       void postSourceProcessBlock(std::string const&);
 
-      void preOpenFile(std::string const&, bool);
-      void postOpenFile(std::string const&, bool);
+      void preOpenFile(std::string const&);
+      void postOpenFile(std::string const&);
 
-      void preCloseFile(std::string const& lfn, bool primary);
-      void postCloseFile(std::string const&, bool);
+      void preCloseFile(std::string const& lfn);
+      void postCloseFile(std::string const&);
 
       void preModuleBeginStream(StreamContext const&, ModuleCallingContext const&);
       void postModuleBeginStream(StreamContext const&, ModuleCallingContext const&);
@@ -603,24 +603,24 @@ void Tracer::postSourceProcessBlock(std::string const& processName) {
                         << " finished: source process block " << processName;
 }
 
-void Tracer::preOpenFile(std::string const& lfn, bool b) {
+void Tracer::preOpenFile(std::string const& lfn) {
   LogAbsolute out("Tracer");
   out << TimeStamper(printTimestamps_);
   out << indention_ << indention_ << " starting: open input file: lfn = " << lfn;
 }
 
-void Tracer::postOpenFile(std::string const& lfn, bool b) {
+void Tracer::postOpenFile(std::string const& lfn) {
   LogAbsolute out("Tracer");
   out << TimeStamper(printTimestamps_);
   out << indention_ << indention_ << " finished: open input file: lfn = " << lfn;
 }
 
-void Tracer::preCloseFile(std::string const& lfn, bool b) {
+void Tracer::preCloseFile(std::string const& lfn) {
   LogAbsolute out("Tracer");
   out << TimeStamper(printTimestamps_);
   out << indention_ << indention_ << " starting: close input file: lfn = " << lfn;
 }
-void Tracer::postCloseFile(std::string const& lfn, bool b) {
+void Tracer::postCloseFile(std::string const& lfn) {
   LogAbsolute out("Tracer");
   out << TimeStamper(printTimestamps_);
   out << indention_ << indention_ << " finished: close input file: lfn = " << lfn;

--- a/FWCore/Services/plugins/Tracer.cc
+++ b/FWCore/Services/plugins/Tracer.cc
@@ -607,31 +607,23 @@ void Tracer::preOpenFile(std::string const& lfn, bool b) {
   LogAbsolute out("Tracer");
   out << TimeStamper(printTimestamps_);
   out << indention_ << indention_ << " starting: open input file: lfn = " << lfn;
-  if (dumpNonModuleContext_)
-    out << " usedFallBack = " << b;
 }
 
 void Tracer::postOpenFile(std::string const& lfn, bool b) {
   LogAbsolute out("Tracer");
   out << TimeStamper(printTimestamps_);
   out << indention_ << indention_ << " finished: open input file: lfn = " << lfn;
-  if (dumpNonModuleContext_)
-    out << " usedFallBack = " << b;
 }
 
 void Tracer::preCloseFile(std::string const& lfn, bool b) {
   LogAbsolute out("Tracer");
   out << TimeStamper(printTimestamps_);
   out << indention_ << indention_ << " starting: close input file: lfn = " << lfn;
-  if (dumpNonModuleContext_)
-    out << " usedFallBack = " << b;
 }
 void Tracer::postCloseFile(std::string const& lfn, bool b) {
   LogAbsolute out("Tracer");
   out << TimeStamper(printTimestamps_);
   out << indention_ << indention_ << " finished: close input file: lfn = " << lfn;
-  if (dumpNonModuleContext_)
-    out << " usedFallBack = " << b;
 }
 
 void Tracer::preModuleBeginStream(StreamContext const& sc, ModuleCallingContext const& mcc) {

--- a/HeterogeneousCore/CUDAServices/plugins/NVProfilerService.cc
+++ b/HeterogeneousCore/CUDAServices/plugins/NVProfilerService.cc
@@ -182,12 +182,12 @@ public:
   void postModuleEventPrefetching(edm::StreamContext const&, edm::ModuleCallingContext const&);
 
   // these signal pair are guaranteed to be called by the same thread
-  void preOpenFile(std::string const&, bool);
-  void postOpenFile(std::string const&, bool);
+  void preOpenFile(std::string const&);
+  void postOpenFile(std::string const&);
 
   // these signal pair are guaranteed to be called by the same thread
-  void preCloseFile(std::string const&, bool);
-  void postCloseFile(std::string const&, bool);
+  void preCloseFile(std::string const&);
+  void postCloseFile(std::string const&);
 
   // these signal pair are guaranteed to be called by the same thread
   void preSourceConstruction(edm::ModuleDescription const&);
@@ -585,25 +585,25 @@ void NVProfilerService::postSourceRun(edm::RunIndex index) {
   }
 }
 
-void NVProfilerService::preOpenFile(std::string const& lfn, bool) {
+void NVProfilerService::preOpenFile(std::string const& lfn) {
   if (not skipFirstEvent_ or globalFirstEventDone_) {
     nvtxDomainRangePush(global_domain_, ("open file "s + lfn).c_str());
   }
 }
 
-void NVProfilerService::postOpenFile(std::string const& lfn, bool) {
+void NVProfilerService::postOpenFile(std::string const& lfn) {
   if (not skipFirstEvent_ or globalFirstEventDone_) {
     nvtxDomainRangePop(global_domain_);
   }
 }
 
-void NVProfilerService::preCloseFile(std::string const& lfn, bool) {
+void NVProfilerService::preCloseFile(std::string const& lfn) {
   if (not skipFirstEvent_ or globalFirstEventDone_) {
     nvtxDomainRangePush(global_domain_, ("close file "s + lfn).c_str());
   }
 }
 
-void NVProfilerService::postCloseFile(std::string const& lfn, bool) {
+void NVProfilerService::postCloseFile(std::string const& lfn) {
   if (not skipFirstEvent_ or globalFirstEventDone_) {
     nvtxDomainRangePop(global_domain_);
   }

--- a/IOPool/Input/src/RootInputFileSequence.cc
+++ b/IOPool/Input/src/RootInputFileSequence.cc
@@ -244,7 +244,7 @@ namespace edm {
     std::list<std::string> exInfo;
     {
       std::unique_ptr<InputSource::FileOpenSentry> sentry(
-          input ? std::make_unique<InputSource::FileOpenSentry>(*input, lfn_, false) : nullptr);
+          input ? std::make_unique<InputSource::FileOpenSentry>(*input, lfn_) : nullptr);
       edm::Service<edm::storage::StatisticsSenderService> service;
       if (service.isAvailable()) {
         service->openingFile(lfn(), inputType, -1);

--- a/IOPool/Input/src/RootPrimaryFileSequence.cc
+++ b/IOPool/Input/src/RootPrimaryFileSequence.cc
@@ -118,7 +118,7 @@ namespace edm {
   void RootPrimaryFileSequence::closeFile_() {
     // close the currently open file, if any, and delete the RootFile object.
     if (rootFile()) {
-      auto sentry = std::make_unique<InputSource::FileCloseSentry>(input_, lfn(), usedFallback());
+      auto sentry = std::make_unique<InputSource::FileCloseSentry>(input_, lfn());
       rootFile()->close();
       if (duplicateChecker_)
         duplicateChecker_->inputFileClosed();

--- a/IgTools/IgProf/plugins/IgProfService.cc
+++ b/IgTools/IgProf/plugins/IgProfService.cc
@@ -112,12 +112,12 @@ void IgProfService::postEndRun(GlobalContext const &) { makeDump(atPostEndRun_);
 
 void IgProfService::postEndJob() { makeDump(atPostEndJob_); }
 
-void IgProfService::postOpenFile(std::string const &, bool) {
+void IgProfService::postOpenFile(std::string const &) {
   ++nfileopened_;
   makeDump(atPostOpenFile_);
 }
 
-void IgProfService::postCloseFile(std::string const &, bool) {
+void IgProfService::postCloseFile(std::string const &) {
   ++nfileclosed_;
   makeDump(atPostCloseFile_);
 }

--- a/IgTools/IgProf/plugins/IgProfService.h
+++ b/IgTools/IgProf/plugins/IgProfService.h
@@ -36,9 +36,9 @@ namespace edm {
 
       void postEndJob();
 
-      void postOpenFile(std::string const &, bool);
+      void postOpenFile(std::string const &);
 
-      void postCloseFile(std::string const &, bool);
+      void postCloseFile(std::string const &);
 
       inline bool isProcessWideService(IgProfService const *) { return true; }
 

--- a/Utilities/StorageFactory/interface/StatisticsSenderService.h
+++ b/Utilities/StorageFactory/interface/StatisticsSenderService.h
@@ -29,7 +29,7 @@ namespace edm {
       void closedFile(std::string const& lfn, bool usedFallback);
 
     private:
-      void filePostCloseEvent(std::string const& lfn, bool usedFallback);
+      void filePostCloseEvent(std::string const& lfn);
 
       std::string const* matchedLfn(std::string const& iURL);  //updates its internal cache
       class FileStatistics {

--- a/Utilities/StorageFactory/src/StatisticsSenderService.cc
+++ b/Utilities/StorageFactory/src/StatisticsSenderService.cc
@@ -347,7 +347,7 @@ void StatisticsSenderService::setSize(const std::string &url, size_t size) {
   }
 }
 
-void StatisticsSenderService::filePostCloseEvent(std::string const &lfn, bool usedFallback) {
+void StatisticsSenderService::filePostCloseEvent(std::string const &lfn) {
   //we are at a sync point in the framwework so no new files are being opened
   cleanupOldFiles();
   m_filestats.update();


### PR DESCRIPTION
#### PR description:

After https://github.com/cms-sw/cmssw/pull/35505 the "useFallback" information is not available yet for `preOpenFile` signal, and delivering it via `postOpenFile` signal would be a bit cumbersome. Currently this boolean is used only by `Tracer` Service in `(pre|post)OpenFile`. The `Tracer` Service is the only user of the same boolean in `(pre|post)CloseFile`. We concluded that these printouts are not that useful (they don't affect framework's scheduling). This PR removes those printouts, and the boolean argument for the `(pre|post)(Open|Close)File` signals.


#### PR validation:

Code compiles.