### PR TITLE
Removed unnecessary include in RecoTau/TauRecoTau

### DIFF
--- a/RecoTauTag/RecoTau/interface/RecoTauBuilderPlugins.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauBuilderPlugins.h
@@ -31,7 +31,6 @@
  */
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "DataFormats/VertexReco/interface/VertexFwd.h"


### PR DESCRIPTION
#### PR description:

This removed the cms deprecated warnings.

#### PR validation:

Compiling using -DUSE_CMS_DEPRECATED no longer issues warnings.