### PR TITLE
Replace Candidate GT by named GT in conddb script unit tests and update offline Run-3 data GT

### DIFF
--- a/CondCore/Utilities/test/test_conddb.sh
+++ b/CondCore/Utilities/test/test_conddb.sh
@@ -35,11 +35,11 @@ conddb listGTsForTag SiPixelQuality_phase1_2021_v1  || die 'failed conddb listGT
 echo -ne '\n\n'
 
 echo "===========> testing conddb diff"
-conddb diff 120X_mcRun3_2021_realistic_v1 120X_mcRun3_2021_realistic_Candidate_2021_06_09_14_33_50  || die 'conddb diff' $?
+conddb diff 120X_mcRun3_2021_realistic_v1 120X_mcRun3_2021_realistic_conddb_unitTest  || die 'conddb diff' $?
 echo -ne '\n\n'
 
 echo "===========> testing conddb diffGlobalTagsAtRun"
-conddb diffGlobalTagsAtRun -R 120X_mcRun3_2021_realistic_v1 -T 120X_mcRun3_2021_realistic_Candidate_2021_06_09_14_33_50 --run 1 || die 'conddb diffGlobalTagsAtRun' $?
+conddb diffGlobalTagsAtRun -R 120X_mcRun3_2021_realistic_v1 -T 120X_mcRun3_2021_realistic_conddb_unitTest --run 1 || die 'conddb diffGlobalTagsAtRun' $?
 echo -ne '\n\n'
 
 echo "===========> testing conddb dump"

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -40,7 +40,7 @@ autoCond = {
     # GlobalTag for Run3 data relvals
     'run3_data_prompt'             : '122X_dataRun3_Prompt_v1',
     # GlobalTag for Run3 offline data reprocessing
-    'run3_data'                    : '122X_dataRun3_v2',
+    'run3_data'                    : '122X_dataRun3_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'           : '122X_mc2017_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector


### PR DESCRIPTION
#### PR description:

This PR has two updates:

- Replace a Candidate GT by a named GT in the conddb unit tests in view of AlCaDB policy of deleting Candidates GTs older than 6 months.
- Update the Run-3 data offline GT to be used for the Pilot Beam ReReco with ECAL PF Cluster corrections as request here: https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4562.html
 
The difference in the run-3 data offline GT wrt the previous version is shown below. the only differences are in the 16 updated multi-IOV tags that contain related to ECAL PC Cluster corrections:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_dataRun3_v2/122X_dataRun3_v3


#### PR validation:

For the conddb unit tests: `scram b runtests_test_conddb`

For the offline Run-3 data GT: `runTheMatrix.py -l 136.897,136.899,138.3,139.001,139.002,139.003,139.004 -j16`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not a backport but it will be backported to 122X, 121X and 120X.
