### PR TITLE
Silence file closuring printouts in StatisticsSenderService by default

### DIFF
--- a/Utilities/StorageFactory/src/StatisticsSenderService.cc
+++ b/Utilities/StorageFactory/src/StatisticsSenderService.cc
@@ -297,10 +297,12 @@ void StatisticsSenderService::closedFile(std::string const &url, bool usedFallba
     }
 
     auto c = --found->second.m_openCount;
-    if (c == 0) {
-      edm::LogWarning("StatisticsSenderService") << "fully closed: " << *lfn << "\n";
-    } else {
-      edm::LogWarning("StatisticsSenderService") << "partially closed: " << *lfn << "\n";
+    if (m_debug) {
+      if (c == 0) {
+        edm::LogWarning("StatisticsSenderService") << "fully closed: " << *lfn << "\n";
+      } else {
+        edm::LogWarning("StatisticsSenderService") << "partially closed: " << *lfn << "\n";
+      }
     }
   } else if (m_debug) {
     edm::LogWarning("StatisticsSenderService") << "closed: unknown url name " << url << "\n";


### PR DESCRIPTION
#### PR description:

Noticed these while working on something else. They are useful only in debugging, so silencing them by default.

#### PR validation:

Code compiles. A random cmsRun job that previously printed out `fully closed: ...` does not print it anymore.