### PR TITLE
remove CMSDEPRECATED_X warnings from DPGAnalysis/Skims

### DIFF
--- a/DPGAnalysis/Skims/src/FilterOutScraping.cc
+++ b/DPGAnalysis/Skims/src/FilterOutScraping.cc
@@ -15,7 +15,6 @@
 
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -36,7 +35,7 @@ FilterOutScraping::FilterOutScraping(const edm::ParameterSet& iConfig) {
       iConfig.getUntrackedParameter<edm::InputTag>("src", edm::InputTag("generalTracks")));
 }
 
-FilterOutScraping::~FilterOutScraping() {}
+FilterOutScraping::~FilterOutScraping() = default;
 
 bool FilterOutScraping::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   bool accepted = false;

--- a/DPGAnalysis/Skims/src/RPCRecHitFilter.h
+++ b/DPGAnalysis/Skims/src/RPCRecHitFilter.h
@@ -8,7 +8,6 @@
 #include <fstream>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"


### PR DESCRIPTION
#### PR description:

Trivial PR, just removing a couple of deprecated header's inclusions.
Part of https://github.com/cms-sw/cmssw/issues/36404

#### PR validation:

`cmssw` compiles

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
