### PR TITLE
Fixing bug in case last file is bad

### DIFF
--- a/IOPool/Input/src/RootPrimaryFileSequence.cc
+++ b/IOPool/Input/src/RootPrimaryFileSequence.cc
@@ -80,6 +80,8 @@ namespace edm {
       }
     } else {
       if (!nextFile()) {
+        // handle case with last file bad and
+        // skipBadFiles true
         return std::unique_ptr<FileBlock>();
       }
     }

--- a/IOPool/Input/src/RootPrimaryFileSequence.cc
+++ b/IOPool/Input/src/RootPrimaryFileSequence.cc
@@ -80,7 +80,7 @@ namespace edm {
       }
     } else {
       if (!nextFile()) {
-        assert(0);
+        return std::unique_ptr<FileBlock>();
       }
     }
     if (!rootFile()) {


### PR DESCRIPTION
#### PR description:

In CMSSW 11_1_0, the execution of a configuration file which contains a PoolSource generates a segmentation fault if an input file is non-existing. 

This issue was partially fixed by a previous PR: #36123, but unfortunately a crash still happens if the last file of the collection is missing. Therefore, an additional fix is provided here. 

#### PR validation:

The code was run with the fix, and it was made sure it does lead to a crash if the last file is missing (also tested if the first on is missing, one and only one file in the collection and missing, all files missing). 

