### PR TITLE
modernize `EventFilter/Phase2TrackerRawToDigi` 

### DIFF
--- a/EventFilter/Phase2TrackerRawToDigi/plugins/Phase2TrackerCommissioningDigiProducer.cc
+++ b/EventFilter/Phase2TrackerRawToDigi/plugins/Phase2TrackerCommissioningDigiProducer.cc
@@ -5,7 +5,7 @@
 #include "EventFilter/Phase2TrackerRawToDigi/interface/Phase2TrackerFEDBuffer.h"
 #include "EventFilter/Phase2TrackerRawToDigi/interface/Phase2TrackerFEDHeader.h"
 #include "EventFilter/Phase2TrackerRawToDigi/interface/utils.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -14,13 +14,13 @@
 
 namespace Phase2Tracker {
 
-  class Phase2TrackerCommissioningDigiProducer : public edm::EDProducer {
+  class Phase2TrackerCommissioningDigiProducer : public edm::global::EDProducer<> {
   public:
     /// constructor
     Phase2TrackerCommissioningDigiProducer(const edm::ParameterSet& pset);
     /// default constructor
-    ~Phase2TrackerCommissioningDigiProducer() override;
-    void produce(edm::Event& event, const edm::EventSetup& es) override;
+    ~Phase2TrackerCommissioningDigiProducer() override = default;
+    void produce(edm::StreamID, edm::Event& ev, const edm::EventSetup& es) const override;
 
   private:
     edm::EDGetTokenT<FEDRawDataCollection> token_;
@@ -39,9 +39,9 @@ Phase2Tracker::Phase2TrackerCommissioningDigiProducer::Phase2TrackerCommissionin
   token_ = consumes<FEDRawDataCollection>(pset.getParameter<edm::InputTag>("ProductLabel"));
 }
 
-Phase2Tracker::Phase2TrackerCommissioningDigiProducer::~Phase2TrackerCommissioningDigiProducer() {}
-
-void Phase2Tracker::Phase2TrackerCommissioningDigiProducer::produce(edm::Event& event, const edm::EventSetup& es) {
+void Phase2Tracker::Phase2TrackerCommissioningDigiProducer::produce(edm::StreamID,
+                                                                    edm::Event& event,
+                                                                    const edm::EventSetup& es) const {
   // Retrieve FEDRawData collection
   edm::Handle<FEDRawDataCollection> buffers;
   event.getByToken(token_, buffers);


### PR DESCRIPTION
#### PR description:

Modernization of code:
   * part of the migration in #31061
   * part of #36404
  
Went systematically through all of the CMSDEPRECATED_X warnings in the  `EventFilter/Phase2TrackerRawToDigi` package from CMSSW_12_2_CMSDEPRECATED_X_2021-12-03-2300 and removed deprecated API calls.

#### PR validation:

`cmssw` compiles

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

