### PR TITLE
Fix assert in ExternalGeneratorFilter

### DIFF
--- a/GeneratorInterface/Core/plugins/ExternalGeneratorFilter.cc
+++ b/GeneratorInterface/Core/plugins/ExternalGeneratorFilter.cc
@@ -62,7 +62,7 @@ namespace externalgen {
         {
           auto nlines = std::to_string(std::count(iConfig.begin(), iConfig.end(), '\n'));
           auto result = fwrite(nlines.data(), sizeof(char), nlines.size(), pipe_);
-          assert(result = nlines.size());
+          assert(result == nlines.size());
           result = fwrite(iConfig.data(), sizeof(char), iConfig.size(), pipe_);
           assert(result == iConfig.size());
           fflush(pipe_);


### PR DESCRIPTION
#### PR description:

Found by gcc10 in cs8_amd64_gcc10 https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/cs8_amd64_gcc10/CMSSW_12_3_X_2021-12-07-2300/GeneratorInterface/Core

#### PR validation:

None