### PR TITLE
[12_0_X] Replace Candidate GT in conddb script unit tests

### DIFF
--- a/CondCore/Utilities/test/test_conddb.sh
+++ b/CondCore/Utilities/test/test_conddb.sh
@@ -35,11 +35,11 @@ conddb listGTsForTag SiPixelQuality_phase1_2021_v1  || die 'failed conddb listGT
 echo -ne '\n\n'
 
 echo "===========> testing conddb diff"
-conddb diff 120X_mcRun3_2021_realistic_v1 120X_mcRun3_2021_realistic_Candidate_2021_06_09_14_33_50  || die 'conddb diff' $?
+conddb diff 120X_mcRun3_2021_realistic_v1 120X_mcRun3_2021_realistic_conddb_unitTest || die 'conddb diff' $?
 echo -ne '\n\n'
 
 echo "===========> testing conddb diffGlobalTagsAtRun"
-conddb diffGlobalTagsAtRun -R 120X_mcRun3_2021_realistic_v1 -T 120X_mcRun3_2021_realistic_Candidate_2021_06_09_14_33_50 --run 1 || die 'conddb diffGlobalTagsAtRun' $?
+conddb diffGlobalTagsAtRun -R 120X_mcRun3_2021_realistic_v1 -T 120X_mcRun3_2021_realistic_conddb_unitTest --run 1 || die 'conddb diffGlobalTagsAtRun' $?
 echo -ne '\n\n'
 
 echo "===========> testing conddb dump"


### PR DESCRIPTION
#### PR description:

This is a backport of PR #36402 for the conddb script unit tests part.

It replaces a Candidate GT by a named GT in the conddb script unit tests in view of AlCaDB policy of deleting Candidates GTs older than 6 months.

#### PR validation:

`scram b runtests_test_conddb`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

backport of #36402