### PR TITLE
Fixing crash in GsfTrackProducer:electronGsfTracks

### DIFF
--- a/TrackingTools/GsfTools/src/MultiStatePropagation.icc
+++ b/TrackingTools/GsfTools/src/MultiStatePropagation.icc
@@ -1,6 +1,6 @@
 //  #include "TrackerReco/GsfPattern/src/MultiStatePropagation.h"
 #include "TrackingTools/GsfTools/interface/MultiTrajectoryStateAssembler.h"
-
+#include "TrackingTools/GsfTools/interface/GetComponents.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 template <class T>
@@ -9,8 +9,11 @@ std::pair<TrajectoryStateOnSurface, double> MultiStatePropagation<T>::propagateW
   // weighted path length
   double sWeight(0.);
   double sWeightPath(0.);
+
   // decomposition of input state
-  MultiTSOS const& input = tsos.components();
+  GetComponents comps(tsos);
+  auto const& input = comps();
+
   // vector of result states
   MultiTrajectoryStateAssembler result;
   //


### PR DESCRIPTION
#### PR description:

This is to fix the issue reported in https://github.com/cms-sw/cmssw/issues/36369

#### PR validation:

After this PR `runTheMatrix.py -l 11723.17` ran fine without any crash.
Also tested with WF 12434.0, which ran fine as well.

This PR is not a backport.