### PR TITLE
increase max length of `addOnTests` log-file names

### DIFF
--- a/Utilities/ReleaseScripts/scripts/addOnTests.py
+++ b/Utilities/ReleaseScripts/scripts/addOnTests.py
@@ -37,7 +37,7 @@ class testit(Thread):
                 os.makedirs(self.dirName)
 
             commandbase = command.replace(' ','_').replace('/','_')
-            logfile='%s.log' % commandbase[:150].replace("'",'').replace('"','').replace('../','')
+            logfile='%s.log' % commandbase[:160].replace("'",'').replace('"','').replace('../','')
 
             executable = 'cd '+self.dirName+'; '+command+' > '+logfile+' 2>&1'
 


### PR DESCRIPTION
#### PR description:

This PR suggests to increase slightly the maximum length of the names of log files created by the `addOnTests`.

The goal would be to avoid having the same log-file name for two different `addOnTests`, as that might apparently confuse the `cmsbot`.

https://github.com/cms-sw/cmssw/pull/36408#issuecomment-988888689 incorrectly reports a failure for `hlt_mc_Fake2`, while the failure actually occurred for `hlt_data_Fake2`. From a first (non-expert) look, this seems to come from [here](https://github.com/cms-sw/cms-bot/blob/9c756b35f970eb001038cb70512f3d0334e50e29/report-pull-request-results.py#L145), where the logic might fail if the log file of two different tests has the same basename (which is the case for the 2nd test in `hlt_mc_Fake2` and `hlt_data_Fake2`, given the limit of 150 characters). The cheap workaround is to make log-file names unique by making them slightly longer. Of course, it might be better to improve the "file-finding" logic in cms-bot, but that is left to experts.

In other words, maybe this is not the right fix, and I'm opening the PR mainly to bring this to the attention of experts.

Would require https://github.com/cms-sw/cms-bot/pull/1675.

Merely technical. No changes expected.

#### PR validation:

Checked that the log-file names of the `addOnTests` would now be unique.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

N/A