### PR TITLE
Static Analyzers: Add checker for use of edm::ParameterSet::exists or ::existsAs<T>.

### DIFF
--- a/Utilities/StaticAnalyzers/src/ClangCmsCheckerPluginRegister.cpp
+++ b/Utilities/StaticAnalyzers/src/ClangCmsCheckerPluginRegister.cpp
@@ -23,6 +23,7 @@
 #include "EDMPluginDumper.h"
 #include "ThrUnsafeFCallChecker.h"
 #include "ESRecordGetChecker.h"
+#include "PsetExistsFCallChecker.h"
 
 #include <clang/StaticAnalyzer/Frontend/CheckerRegistry.h>
 
@@ -76,6 +77,9 @@ extern "C" void clang_registerCheckers(clang::ento::CheckerRegistry &registry) {
       "optional.getByChecker",
       "Checks for calls to edm::getByLabel or edm::getManyByType and reports edm::Handle type passed",
       "no docs");
+  registry.addChecker<clangcms::PsetExistsFCallChecker>(
+     "deprecated.psetExistsChecker", "Checks for calls to edm::ParameterSet::exists() or edm::ParameterSet::existsAs<>()",
+     "no docs");
   registry.addChecker<clangcms::ArgSizeChecker>(
       "optional.ArgSize", "Reports args passed by value with size>4k.", "no docs");
   registry.addChecker<clangcms::FunctionChecker>(

--- a/Utilities/StaticAnalyzers/src/ClangCmsCheckerPluginRegister.cpp
+++ b/Utilities/StaticAnalyzers/src/ClangCmsCheckerPluginRegister.cpp
@@ -78,8 +78,9 @@ extern "C" void clang_registerCheckers(clang::ento::CheckerRegistry &registry) {
       "Checks for calls to edm::getByLabel or edm::getManyByType and reports edm::Handle type passed",
       "no docs");
   registry.addChecker<clangcms::PsetExistsFCallChecker>(
-     "deprecated.psetExistsChecker", "Checks for calls to edm::ParameterSet::exists() or edm::ParameterSet::existsAs<>()",
-     "no docs");
+      "deprecated.psetExistsChecker",
+      "Checks for calls to edm::ParameterSet::exists() or edm::ParameterSet::existsAs<>()",
+      "no docs");
   registry.addChecker<clangcms::ArgSizeChecker>(
       "optional.ArgSize", "Reports args passed by value with size>4k.", "no docs");
   registry.addChecker<clangcms::FunctionChecker>(

--- a/Utilities/StaticAnalyzers/src/ClangCmsCheckerPluginRegister.cpp
+++ b/Utilities/StaticAnalyzers/src/ClangCmsCheckerPluginRegister.cpp
@@ -92,7 +92,7 @@ extern "C" void clang_registerCheckers(clang::ento::CheckerRegistry &registry) {
   registry.addChecker<clangcms::ThrUnsafeFCallChecker>(
       "threadsafety.ThrUnsafeFCallChecker", "Reports calls of known thread unsafe functions", "no docs");
   registry.addChecker<clangcms::ESRGetChecker>(
-      "deprecated.ESRecordGetChecker", "Checks for calls to EventSetupRecord::get", "no docs");
+      "cms.CodeRules.ESRecordGetChecker", "Checks for calls to EventSetupRecord::get", "no docs");
 }
 
 extern "C" const char clang_analyzerAPIVersionString[] = CLANG_ANALYZER_API_VERSION_STRING;

--- a/Utilities/StaticAnalyzers/src/ClangCmsCheckerPluginRegister.cpp
+++ b/Utilities/StaticAnalyzers/src/ClangCmsCheckerPluginRegister.cpp
@@ -78,7 +78,7 @@ extern "C" void clang_registerCheckers(clang::ento::CheckerRegistry &registry) {
       "Checks for calls to edm::getByLabel or edm::getManyByType and reports edm::Handle type passed",
       "no docs");
   registry.addChecker<clangcms::PsetExistsFCallChecker>(
-      "deprecated.psetExistsChecker",
+      "cms.CodeRules.psetExistsChecker",
       "Checks for calls to edm::ParameterSet::exists() or edm::ParameterSet::existsAs<>()",
       "no docs");
   registry.addChecker<clangcms::ArgSizeChecker>(
@@ -92,7 +92,7 @@ extern "C" void clang_registerCheckers(clang::ento::CheckerRegistry &registry) {
   registry.addChecker<clangcms::ThrUnsafeFCallChecker>(
       "threadsafety.ThrUnsafeFCallChecker", "Reports calls of known thread unsafe functions", "no docs");
   registry.addChecker<clangcms::ESRGetChecker>(
-      "cms.CodeRules.ESRecordGetChecker", "Checks for calls to EventSetupRecord::get", "no docs");
+      "deprecated.ESRecordGetChecker", "Checks for calls to EventSetupRecord::get", "no docs");
 }
 
 extern "C" const char clang_analyzerAPIVersionString[] = CLANG_ANALYZER_API_VERSION_STRING;

--- a/Utilities/StaticAnalyzers/src/PsetExistsFCallChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/PsetExistsFCallChecker.cpp
@@ -99,10 +99,8 @@ namespace clangcms {
       if (pname.find(pdname) != std::string::npos)
         return;
       os << "deprecated function " << mname << " is called in function " << pname;
-      BugType *BT =
-          new BugType(Checker,
-                      "Function edm::ParameterSet::exists() or edm::ParameterSet::existsAs<>() called",
-                      "CMS Code Rules");
+      BugType *BT = new BugType(
+          Checker, "Function edm::ParameterSet::exists() or edm::ParameterSet::existsAs<>() called", "CMS Code Rules");
       std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, os.str(), CELoc);
       R->setDeclWithIssue(AC->getDecl());
       R->addRange(CE->getExprLoc());

--- a/Utilities/StaticAnalyzers/src/PsetExistsFCallChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/PsetExistsFCallChecker.cpp
@@ -101,14 +101,14 @@ namespace clangcms {
       os << "deprecated function " << mname << " is called in function " << pname;
       BugType *BT =
           new BugType(Checker,
-                      "Deprecated function edm::ParameterSet::exists() or edm::ParameterSet::existsAs<>() called",
-                      "Deprecated API");
+                      "Function edm::ParameterSet::exists() or edm::ParameterSet::existsAs<>() called",
+                      "CMS Code Rules");
       std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, os.str(), CELoc);
       R->setDeclWithIssue(AC->getDecl());
       R->addRange(CE->getExprLoc());
       BR.emitReport(std::move(R));
       std::string tname = "function-checker.txt.unsorted";
-      std::string ostring = "function '" + pname + "' calls deprecated function '" + mname + "'.\n";
+      std::string ostring = "function '" + pname + "' calls function '" + mname + "'.\n";
       support::writeLog(ostring, tname);
     }
   }

--- a/Utilities/StaticAnalyzers/src/PsetExistsFCallChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/PsetExistsFCallChecker.cpp
@@ -40,8 +40,8 @@ namespace clangcms {
       return;
     const char *sfile = BR.getSourceManager().getPresumedLoc(CCE->getExprLoc()).getFilename();
     std::string sname(sfile);
-    //if (!support::isInterestingLocation(sname))
-    //  return;
+    if (!support::isInterestingLocation(sname))
+      return;
     std::string mname = support::getQualifiedName(*CCD);
     const NamedDecl *PD = llvm::dyn_cast_or_null<NamedDecl>(AC->getDecl());
     if (!PD)
@@ -98,7 +98,7 @@ namespace clangcms {
     if (mname.find(ename) != std::string::npos || mname.find(eaname) != std::string::npos) {
       if (pname.find(pdname) != std::string::npos)
         return;
-      os << "deprecated function " << mname << " is called in function " << pname;
+      os << "function " << mname << " is called in function " << pname;
       BugType *BT = new BugType(
           Checker, "Function edm::ParameterSet::exists() or edm::ParameterSet::existsAs<>() called", "CMS Code Rules");
       std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, os.str(), CELoc);

--- a/Utilities/StaticAnalyzers/src/PsetExistsFCallChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/PsetExistsFCallChecker.cpp
@@ -1,0 +1,90 @@
+#include "PsetExistsFCallChecker.h"
+#include <iostream>
+#include <fstream>
+#include <iterator>
+#include <string>
+
+using namespace clang;
+using namespace ento;
+using namespace llvm;
+
+namespace clangcms {
+
+  class PEFWalker : public clang::StmtVisitor<PEFWalker> {
+    const CheckerBase *Checker;
+    clang::ento::BugReporter &BR;
+    clang::AnalysisDeclContext *AC;
+
+  public:
+    PEFWalker(const CheckerBase *checker, clang::ento::BugReporter &br, clang::AnalysisDeclContext *ac)
+        : Checker(checker), BR(br), AC(ac) {}
+
+    void VisitChildren(clang::Stmt *S);
+    void VisitStmt(clang::Stmt *S) { VisitChildren(S); }
+    void VisitCXXMemberCallExpr(clang::CXXMemberCallExpr *CE);
+  };
+
+  void PEFWalker::VisitChildren(clang::Stmt *S) {
+    for (clang::Stmt::child_iterator I = S->child_begin(), E = S->child_end(); I != E; ++I)
+      if (clang::Stmt *child = *I) {
+        Visit(child);
+      }
+  }
+
+  void PEFWalker::VisitCXXMemberCallExpr(CXXMemberCallExpr *CE) {
+    CXXMethodDecl *MD = CE->getMethodDecl();
+    if (!MD)
+      return;
+    const CXXMethodDecl *PD = llvm::dyn_cast_or_null<CXXMethodDecl>(AC->getDecl());
+    if (!PD)
+      return;
+    std::string mname = support::getQualifiedName(*MD);
+    std::string pname = support::getQualifiedName(*PD);
+    std::string ename= "edm::ParameterSet::exists";
+    std::string eaname= "edm::ParameterSet::existsAs";
+    llvm::SmallString<100> buf;
+    llvm::raw_svector_ostream os(buf);
+    if (mname == ename || mname.substr(0, eaname.length()) == eaname) {
+      os << mname << " is called in function " << pname;
+      PathDiagnosticLocation CELoc = PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(), AC);
+      BugType *BT = new BugType(Checker, "Deprecated function edm::ParameterSet::exists() or edm::ParameterSet::existsAs<>() called", "Deprecated API");
+      std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, os.str(), CELoc);
+      R->setDeclWithIssue(AC->getDecl());
+      R->addRange(CE->getSourceRange());
+      BR.emitReport(std::move(R));
+      std::string tname = "function-checker.txt.unsorted";
+      std::string ostring = "function '" + pname + "' calls '" + mname + "'.\n";
+      support::writeLog(ostring, tname);
+    }
+  }
+
+  void PsetExistsFCallChecker::checkASTDecl(const CXXMethodDecl *MD, AnalysisManager &mgr, BugReporter &BR) const {
+    const SourceManager &SM = BR.getSourceManager();
+    PathDiagnosticLocation DLoc = PathDiagnosticLocation::createBegin(MD, SM);
+    if (SM.isInSystemHeader(DLoc.asLocation()) || SM.isInExternCSystemHeader(DLoc.asLocation()))
+      return;
+    if (!MD->doesThisDeclarationHaveABody())
+      return;
+    clangcms::PEFWalker walker(this, BR, mgr.getAnalysisDeclContext(MD));
+    walker.Visit(MD->getBody());
+    return;
+  }
+
+  void PsetExistsFCallChecker::checkASTDecl(const FunctionTemplateDecl *TD,
+                                           AnalysisManager &mgr,
+                                           BugReporter &BR) const {
+    const clang::SourceManager &SM = BR.getSourceManager();
+    clang::ento::PathDiagnosticLocation DLoc = clang::ento::PathDiagnosticLocation::createBegin(TD, SM);
+    if (SM.isInSystemHeader(DLoc.asLocation()) || SM.isInExternCSystemHeader(DLoc.asLocation()))
+      return;
+
+    for (auto I = TD->spec_begin(), E = TD->spec_end(); I != E; ++I) {
+      if (I->doesThisDeclarationHaveABody()) {
+        clangcms::PEFWalker walker(this, BR, mgr.getAnalysisDeclContext(*I));
+        walker.Visit(I->getBody());
+      }
+    }
+    return;
+  }
+
+}  // namespace clangcms

--- a/Utilities/StaticAnalyzers/src/PsetExistsFCallChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/PsetExistsFCallChecker.cpp
@@ -24,7 +24,7 @@ namespace clangcms {
     void VisitStmt(clang::Stmt *S) { VisitChildren(S); }
     void VisitCXXMemberCallExpr(clang::CXXMemberCallExpr *CE);
     void VisitCXXConstructExpr(CXXConstructExpr *CCE);
-    void Report(const std::string& mname, const std::string& pname, const Expr * CE) const;
+    void Report(const std::string &mname, const std::string &pname, const Expr *CE) const;
   };
 
   void PEFWalker::VisitChildren(clang::Stmt *S) {
@@ -43,11 +43,11 @@ namespace clangcms {
     //if (!support::isInterestingLocation(sname))
     //  return;
     std::string mname = support::getQualifiedName(*CCD);
-    const NamedDecl * PD = llvm::dyn_cast_or_null<NamedDecl>(AC->getDecl());
+    const NamedDecl *PD = llvm::dyn_cast_or_null<NamedDecl>(AC->getDecl());
     if (!PD)
       return;
     std::string pname = support::getQualifiedName(*PD);
-    Report(mname, pname, CCE); 
+    Report(mname, pname, CCE);
 
     VisitChildren(CCE);
   }
@@ -61,7 +61,7 @@ namespace clangcms {
       return;
     std::string mname = support::getQualifiedName(*MD);
     std::string pname = support::getQualifiedName(*PD);
-    Report(mname, pname, CE); 
+    Report(mname, pname, CE);
   }
 
   void PEFWalker::VisitCallExpr(CallExpr *CE) {
@@ -79,26 +79,30 @@ namespace clangcms {
       return;
     std::string mname;
     mname = support::getQualifiedName(*FD);
-    const NamedDecl * PD = llvm::dyn_cast_or_null<NamedDecl>(AC->getDecl());
+    const NamedDecl *PD = llvm::dyn_cast_or_null<NamedDecl>(AC->getDecl());
     if (!PD)
       return;
     std::string pname = support::getQualifiedName(*PD);
-    Report(mname, pname, CE); 
+    Report(mname, pname, CE);
 
     VisitChildren(CE);
   }
 
-  void PEFWalker::Report(const std::string& mname, const std::string& pname, const Expr * CE) const {
+  void PEFWalker::Report(const std::string &mname, const std::string &pname, const Expr *CE) const {
     PathDiagnosticLocation CELoc = PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(), AC);
-    std::string ename= "edm::ParameterSet::exists";
-    std::string eaname= "edm::ParameterSet::existsAs";
-    std::string pdname="edm::ParameterDescription";
+    std::string ename = "edm::ParameterSet::exists";
+    std::string eaname = "edm::ParameterSet::existsAs";
+    std::string pdname = "edm::ParameterDescription";
     llvm::SmallString<100> buf;
     llvm::raw_svector_ostream os(buf);
     if (mname.find(ename) != std::string::npos || mname.find(eaname) != std::string::npos) {
-      if (pname.find(pdname) != std::string::npos) return;
+      if (pname.find(pdname) != std::string::npos)
+        return;
       os << "deprecated function " << mname << " is called in function " << pname;
-      BugType *BT = new BugType(Checker, "Deprecated function edm::ParameterSet::exists() or edm::ParameterSet::existsAs<>() called", "Deprecated API");
+      BugType *BT =
+          new BugType(Checker,
+                      "Deprecated function edm::ParameterSet::exists() or edm::ParameterSet::existsAs<>() called",
+                      "Deprecated API");
       std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, os.str(), CELoc);
       R->setDeclWithIssue(AC->getDecl());
       R->addRange(CE->getExprLoc());
@@ -122,8 +126,8 @@ namespace clangcms {
   }
 
   void PsetExistsFCallChecker::checkASTDecl(const FunctionTemplateDecl *TD,
-                                           AnalysisManager &mgr,
-                                           BugReporter &BR) const {
+                                            AnalysisManager &mgr,
+                                            BugReporter &BR) const {
     const clang::SourceManager &SM = BR.getSourceManager();
     clang::ento::PathDiagnosticLocation DLoc = clang::ento::PathDiagnosticLocation::createBegin(TD, SM);
     if (SM.isInSystemHeader(DLoc.asLocation()) || SM.isInExternCSystemHeader(DLoc.asLocation()))

--- a/Utilities/StaticAnalyzers/src/PsetExistsFCallChecker.h
+++ b/Utilities/StaticAnalyzers/src/PsetExistsFCallChecker.h
@@ -20,8 +20,9 @@
 
 namespace clangcms {
 
-  class PsetExistsFCallChecker : public clang::ento::Checker<clang::ento::check::ASTDecl<clang::CXXMethodDecl>,
-                                                            clang::ento::check::ASTDecl<clang::FunctionTemplateDecl> > {
+  class PsetExistsFCallChecker
+      : public clang::ento::Checker<clang::ento::check::ASTDecl<clang::CXXMethodDecl>,
+                                    clang::ento::check::ASTDecl<clang::FunctionTemplateDecl> > {
   public:
     void checkASTDecl(const clang::CXXMethodDecl *CMD,
                       clang::ento::AnalysisManager &mgr,

--- a/Utilities/StaticAnalyzers/src/PsetExistsFCallChecker.h
+++ b/Utilities/StaticAnalyzers/src/PsetExistsFCallChecker.h
@@ -1,0 +1,39 @@
+#ifndef Utilities_StaticAnalyzers_PsetExistsFCallChecker_h
+#define Utilities_StaticAnalyzers_PsetExistsFCallChecker_h
+#include <clang/AST/DeclCXX.h>
+#include <clang/AST/Decl.h>
+#include <clang/AST/DeclTemplate.h>
+#include <clang/AST/StmtVisitor.h>
+#include <clang/AST/ParentMap.h>
+#include <clang/Analysis/CFGStmtMap.h>
+#include <clang/Analysis/CallGraph.h>
+#include <llvm/Support/SaveAndRestore.h>
+#include <clang/StaticAnalyzer/Core/PathSensitive/AnalysisManager.h>
+#include <clang/StaticAnalyzer/Core/PathSensitive/CallEvent.h>
+#include <clang/StaticAnalyzer/Core/Checker.h>
+#include <clang/StaticAnalyzer/Core/BugReporter/BugReporter.h>
+#include <clang/StaticAnalyzer/Core/BugReporter/BugType.h>
+#include <llvm/ADT/SmallString.h>
+
+#include "CmsException.h"
+#include "CmsSupport.h"
+
+namespace clangcms {
+
+  class PsetExistsFCallChecker : public clang::ento::Checker<clang::ento::check::ASTDecl<clang::CXXMethodDecl>,
+                                                            clang::ento::check::ASTDecl<clang::FunctionTemplateDecl> > {
+  public:
+    void checkASTDecl(const clang::CXXMethodDecl *CMD,
+                      clang::ento::AnalysisManager &mgr,
+                      clang::ento::BugReporter &BR) const;
+
+    void checkASTDecl(const clang::FunctionTemplateDecl *TD,
+                      clang::ento::AnalysisManager &mgr,
+                      clang::ento::BugReporter &BR) const;
+
+  private:
+    CmsException m_exception;
+  };
+
+}  // namespace clangcms
+#endif


### PR DESCRIPTION
Tested on PhysicsTools/PatAlgos which makes use of both. Examples of test output to console:
```
In file included from PhysicsTools/PatAlgos/plugins/VertexAssociationProducer.cc:23:
PhysicsTools/PatAlgos/interface/VertexingHelper.h:35:13: warning: function edm::ParameterSet::existsAs<double>(const std::basic_string<char, std::char_traits<char>, std::allocator<char> > &, _Bool) const is called in function reco::modules::ParameterAdapter<pat::VertexAssociationSelector>::make(const edm::ParameterSet &) [cms.CodeRules.psetExistsChecker]
        if (iConfig.existsAs<double>("deltaZ"))
            ^       ~~~~~~~~
PhysicsTools/PatAlgos/plugins/PATTriggerProducer.cc:219:7: warning: function edm::ParameterSet::exists(const std::basic_string<char, std::char_traits<char>, std::allocator<char> > &) const is called in function pat::PATTriggerProducer::PATTriggerProducer(const edm::ParameterSet &) [cms.CodeRules.psetExistsChecker]
  if (iConfig.exists("addL1Algos"))
      ^       ~~~~~~
```