### PR TITLE
[12_2_X] Set usedFallback properly, silence file closing printouts in StatisticsSenderService

### DIFF
--- a/IOPool/Input/src/RootInputFileSequence.cc
+++ b/IOPool/Input/src/RootInputFileSequence.cc
@@ -234,6 +234,7 @@ namespace edm {
 
     lfn_ = logicalFileName().empty() ? fileNames()[0] : logicalFileName();
     lfnHash_ = std::hash<std::string>()(lfn_);
+    usedFallback_ = false;
 
     std::shared_ptr<InputFile> filePtr;
     std::list<std::string> originalInfo;
@@ -253,6 +254,7 @@ namespace edm {
         try {
           std::unique_ptr<char[]> name(gSystem->ExpandPathName(it->c_str()));
           filePtr = std::make_shared<InputFile>(name.get(), "  Initiating request to open file ", inputType);
+          usedFallback_ = (it != fNames.begin());
           break;
         } catch (cms::Exception const& e) {
           if (!skipBadFiles && std::next(it) == fNames.end()) {

--- a/Utilities/StorageFactory/src/StatisticsSenderService.cc
+++ b/Utilities/StorageFactory/src/StatisticsSenderService.cc
@@ -297,10 +297,12 @@ void StatisticsSenderService::closedFile(std::string const &url, bool usedFallba
     }
 
     auto c = --found->second.m_openCount;
-    if (c == 0) {
-      edm::LogWarning("StatisticsSenderService") << "fully closed: " << *lfn << "\n";
-    } else {
-      edm::LogWarning("StatisticsSenderService") << "partially closed: " << *lfn << "\n";
+    if (m_debug) {
+      if (c == 0) {
+        edm::LogWarning("StatisticsSenderService") << "fully closed: " << *lfn << "\n";
+      } else {
+        edm::LogWarning("StatisticsSenderService") << "partially closed: " << *lfn << "\n";
+      }
     }
   } else if (m_debug) {
     edm::LogWarning("StatisticsSenderService") << "closed: unknown url name " << url << "\n";


### PR DESCRIPTION
#### PR description:

This PR is a combined backport of https://github.com/cms-sw/cmssw/pull/36379 and https://github.com/cms-sw/cmssw/pull/36403. I think these make sense given the observation of #36375.

#### PR validation:

None