### PR TITLE
Fix WF 139.002 for muon showers (HadronicShowerTrigger-10)

### DIFF
--- a/EventFilter/CSCRawToDigi/python/cscUnpacker_cfi.py
+++ b/EventFilter/CSCRawToDigi/python/cscUnpacker_cfi.py
@@ -10,4 +10,7 @@ muonCSCDigis = muonCSCDCCUnpacker.clone(
 
 ## in Run-3 include GEMs
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
-run3_GEM.toModify( muonCSCDigis, useGEMs = False )
+run3_GEM.toModify( muonCSCDigis,
+                   useGEMs = False,
+                   useCSCShowers = True
+)


### PR DESCRIPTION
#### PR description:

Fix WF 139.002 for muon showers. See https://github.com/cms-sw/cmssw/issues/36426

#### PR validation:

Tested with 139.002.

```
Preparing to run 139.002 RunZeroBias2021+RunZeroBias2021+HLTDR3_2021+RECODR3_ZBOffline+HARVESTD2021ZB
cleaning up  139.002_RunZeroBias2021+RunZeroBias2021+HLTDR3_2021+RECODR3_ZBOffline+HARVESTD2021ZB  in  /uscms_data/d3/dildick/work/LastPR/CMSSW_12_3_X_2021-12-08-1100/src

# in: /uscms_data/d3/dildick/work/LastPR/CMSSW_12_3_X_2021-12-08-1100/src going to execute cd 139.002_RunZeroBias2021+RunZeroBias2021+HLTDR3_2021+RECODR3_ZBOffline+HARVESTD2021ZB
 echo '{
"346512" : [[250, 300]]
}' > step1_lumiRanges.log  2>&1
 

# in: /uscms_data/d3/dildick/work/LastPR/CMSSW_12_3_X_2021-12-08-1100/src going to execute cd 139.002_RunZeroBias2021+RunZeroBias2021+HLTDR3_2021+RECODR3_ZBOffline+HARVESTD2021ZB
 (dasgoclient --limit 0 --query 'lumi,file dataset=/ZeroBias/Commissioning2021-v1/RAW run=346512' --format json | das-selected-lumis.py 250,300 ) | sort -u > step1_dasquery.log  2>&1
 
---

# in: /uscms_data/d3/dildick/work/LastPR/CMSSW_12_3_X_2021-12-08-1100/src going to execute cd 139.002_RunZeroBias2021+RunZeroBias2021+HLTDR3_2021+RECODR3_ZBOffline+HARVESTD2021ZB
 cmsDriver.py step2  --process reHLT -s L1REPACK:Full,HLT:@relval2021 --conditions auto:run3_hlt --data  --eventcontent FEVTDEBUGHLT --datatier FEVTDEBUGHLT --era Run3 -n 100  --filein filelist:step1_dasquery.log --lumiToProcess step1_lumiRanges.log --fileout file:step2.root  > step2_RunZeroBias2021+RunZeroBias2021+HLTDR3_2021+RECODR3_ZBOffline+HARVESTD2021ZB.log  2>&1
 

# in: /uscms_data/d3/dildick/work/LastPR/CMSSW_12_3_X_2021-12-08-1100/src going to execute cd 139.002_RunZeroBias2021+RunZeroBias2021+HLTDR3_2021+RECODR3_ZBOffline+HARVESTD2021ZB
 cmsDriver.py step3  --conditions auto:run3_data -s RAW2DIGI,L1Reco,RECO,EI,PAT,ALCA:SiStripCalZeroBias+SiStripCalMinBias+TkAlMinBias+EcalESAlign,DQM:@rerecoZeroBias+@ExtraHLT+@miniAODDQM --datatier RECO,MINIAOD,DQMIO --eventcontent RECO,MINIAOD,DQM --data  --process reRECO --scenario pp --era Run3 --customise Configuration/DataProcessing/RecoTLR.customisePostEra_Run3 --procModifiers siPixelQualityRawToDigi -n 100  --filein  file:step2.root  --fileout file:step3.root  > step3_RunZeroBias2021+RunZeroBias2021+HLTDR3_2021+RECODR3_ZBOffline+HARVESTD2021ZB.log  2>&1
 

# in: /uscms_data/d3/dildick/work/LastPR/CMSSW_12_3_X_2021-12-08-1100/src going to execute cd 139.002_RunZeroBias2021+RunZeroBias2021+HLTDR3_2021+RECODR3_ZBOffline+HARVESTD2021ZB
 cmsDriver.py step4  -s HARVESTING:@rerecoZeroBias+@ExtraHLT+@miniAODDQM --conditions auto:run3_data --data  --filetype DQM --scenario pp --era Run3 -n 100  --filein file:step3_inDQM.root --fileout file:step4.root  > step4_RunZeroBias2021+RunZeroBias2021+HLTDR3_2021+RECODR3_ZBOffline+HARVESTD2021ZB.log  2>&1
 
139.002_RunZeroBias2021+RunZeroBias2021+HLTDR3_2021+RECODR3_ZBOffline+HARVESTD2021ZB Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Wed Dec  8 22:02:38 2021-date Wed Dec  8 21:48:53 2021; exit: 0 0 0 0
1 1 1 1 tests passed, 0 0 0 0 failed
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

@barvic @kakwok @giovanni-mocellin

@barvic At some point you'll have to set `useGEMs` to `True` in preparation for Run-3. 