### PR TITLE
Modernize `CondCore/ESSources/test`

### DIFF
--- a/CondCore/ESSources/test/SiStripTest/noiseanalyzer.cc
+++ b/CondCore/ESSources/test/SiStripTest/noiseanalyzer.cc
@@ -6,7 +6,7 @@
 #include "CondFormats/Calibration/interface/mySiStripNoises.h"
 #include "CondFormats/DataRecord/interface/mySiStripNoisesRcd.h"
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -14,38 +14,37 @@
 using namespace std;
 
 namespace edmtest {
-  class NoisesAnalyzer : public edm::EDAnalyzer {
+  class NoisesAnalyzer : public edm::global::EDAnalyzer<> {
   public:
     explicit NoisesAnalyzer(edm::ParameterSet const& p) : theNoisesToken_(esConsumes()) {
-      std::cout << "NoisesAnalyzer" << std::endl;
+      edm::LogPrint("NoisesAnalyzer") << "NoisesAnalyzer";
     }
-    explicit NoisesAnalyzer(int i) { std::cout << "NoisesAnalyzer " << i << std::endl; }
-    virtual ~NoisesAnalyzer() { std::cout << "~NoisesAnalyzer " << std::endl; }
-    virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
+    explicit NoisesAnalyzer(int i) { edm::LogPrint("NoisesAnalyzer") << "NoisesAnalyzer " << i; }
+    virtual ~NoisesAnalyzer() { edm::LogPrint("NoisesAnalyzer") << "~NoisesAnalyzer "; }
+    void analyze(edm::StreamID, const edm::Event& e, const edm::EventSetup& c) const override;
 
   private:
     const edm::ESGetToken<mySiStripNoises, mySiStripNoisesRcd> theNoisesToken_;
   };
 
-  void NoisesAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context) {
+  void NoisesAnalyzer::analyze(edm::StreamID, const edm::Event& e, const edm::EventSetup& context) const {
     using namespace edm::eventsetup;
     // Context is not used.
-    std::cout << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
-    std::cout << " ---EVENT NUMBER " << e.id().event() << std::endl;
+    edm::LogPrint("NoisesAnalyzer") << " I AM IN RUN NUMBER " << e.id().run();
+    edm::LogPrint("NoisesAnalyzer") << " ---EVENT NUMBER " << e.id().event();
     edm::eventsetup::EventSetupRecordKey recordKey(
         edm::eventsetup::EventSetupRecordKey::TypeTag::findType("mySiStripNoisesRcd"));
     if (recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
       //record not found
-      std::cout << "Record \"mySiStripNoisesRcd"
-                << "\" does not exist " << std::endl;
+      edm::LogPrint("NoisesAnalyzer") << "Record \"mySiStripNoisesRcd\" does not exist";
     }
-    std::cout << "got context" << std::endl;
+    edm::LogPrint("NoisesAnalyzer") << "got context";
     auto const& mynoise = &context.getData(theNoisesToken_);
-    std::cout << "Noises* " << mynoise << std::endl;
+    edm::LogPrint("NoisesAnalyzer") << "Noises* " << mynoise;
     unsigned int a = mynoise->v_noises.size();
-    std::cout << "size a " << a << std::endl;
+    edm::LogPrint("NoisesAnalyzer") << "size a " << a;
     unsigned int b = mynoise->indexes.size();
-    std::cout << "size b " << b << std::endl;
+    edm::LogPrint("NoisesAnalyzer") << "size b " << b;
     /*for(std::vector<mySiStripNoises::DetRegistry>::const_iterator it=mynoise->indexes.begin(); it!=mynoise->indexes.end(); ++it){
       std::cout << "  detid  " <<it->detid<< std::endl;
       }*/

--- a/CondCore/ESSources/test/SiStripTest/noiseanalyzer.cc
+++ b/CondCore/ESSources/test/SiStripTest/noiseanalyzer.cc
@@ -2,26 +2,29 @@
 #include <string>
 #include <iostream>
 #include <map>
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/EventSetup.h"
 
 #include "CondFormats/Calibration/interface/mySiStripNoises.h"
 #include "CondFormats/DataRecord/interface/mySiStripNoisesRcd.h"
+
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
 
 using namespace std;
 
 namespace edmtest {
   class NoisesAnalyzer : public edm::EDAnalyzer {
   public:
-    explicit NoisesAnalyzer(edm::ParameterSet const& p) { std::cout << "NoisesAnalyzer" << std::endl; }
+    explicit NoisesAnalyzer(edm::ParameterSet const& p) : theNoisesToken_(esConsumes()) {
+      std::cout << "NoisesAnalyzer" << std::endl;
+    }
     explicit NoisesAnalyzer(int i) { std::cout << "NoisesAnalyzer " << i << std::endl; }
     virtual ~NoisesAnalyzer() { std::cout << "~NoisesAnalyzer " << std::endl; }
     virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
 
   private:
+    const edm::ESGetToken<mySiStripNoises, mySiStripNoisesRcd> theNoisesToken_;
   };
 
   void NoisesAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context) {
@@ -36,11 +39,8 @@ namespace edmtest {
       std::cout << "Record \"mySiStripNoisesRcd"
                 << "\" does not exist " << std::endl;
     }
-    edm::ESHandle<mySiStripNoises> pNoises;
-    std::cout << "got eshandle" << std::endl;
-    context.get<mySiStripNoisesRcd>().get(pNoises);
     std::cout << "got context" << std::endl;
-    const mySiStripNoises* mynoise = pNoises.product();
+    auto const& mynoise = &context.getData(theNoisesToken_);
     std::cout << "Noises* " << mynoise << std::endl;
     unsigned int a = mynoise->v_noises.size();
     std::cout << "size a " << a << std::endl;

--- a/CondCore/ESSources/test/TestConcurrentIOVsCondCore.sh
+++ b/CondCore/ESSources/test/TestConcurrentIOVsCondCore.sh
@@ -5,8 +5,8 @@ function die { echo $1: status $2 ;  exit $2; }
 pushd ${LOCAL_TMP_DIR}
 
 echo cmsRun TestConcurrentIOVsCondCore_cfg.py
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/TestConcurrentIOVsCondCore_cfg.py > TestConcurrentIOVsCondCoreCout.log || die 'Failed in TestConcurrentIOVsCondCore_cfg.py' $?
-grep TestConcurrentIOVsCondCore TestConcurrentIOVsCondCoreCout.log > TestConcurrentIOVsCondCore.log
+cmsRun --parameter-set ${LOCAL_TEST_DIR}/TestConcurrentIOVsCondCore_cfg.py || die 'Failed in TestConcurrentIOVsCondCore_cfg.py' $?
+grep "TestConcurrentIOVsCondCore: " TestConcurrentIOVsCondCoreCout.log > TestConcurrentIOVsCondCore.log
 diff ${LOCAL_TEST_DIR}/unit_test_outputs/TestConcurrentIOVsCondCore.log TestConcurrentIOVsCondCore.log || die "comparing TestConcurrentIOVsCondCore.log" $?
 
 popd

--- a/CondCore/ESSources/test/TestConcurrentIOVsCondCore_cfg.py
+++ b/CondCore/ESSources/test/TestConcurrentIOVsCondCore_cfg.py
@@ -38,8 +38,12 @@ process.options = dict(
 )
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
-#process.MessageLogger.cerr.threshold = 'INFO'
-#process.MessageLogger.cerr.INFO.limit = 1000000
+process.MessageLogger = cms.Service("MessageLogger",
+    destinations   = cms.untracked.vstring('TestConcurrentIOVsCondCoreCout','cout'),
+    TestConcurrentIOVsCondCoreCout = cms.untracked.PSet(
+        threshold = cms.untracked.string('WARNING')
+    )
+)
 
 process.source = cms.Source("EmptySource",
     firstRun = cms.untracked.uint32(132598),

--- a/CondCore/ESSources/test/stubs/EfficiencyByLabelAnalyzer.cc
+++ b/CondCore/ESSources/test/stubs/EfficiencyByLabelAnalyzer.cc
@@ -13,7 +13,7 @@ Toy EDProducers and EDProducts for testing purposes only.
 #include "CondFormats/Calibration/interface/Efficiency.h"
 #include "CondFormats/DataRecord/interface/ExEfficiency.h"
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -21,14 +21,18 @@ Toy EDProducers and EDProducts for testing purposes only.
 using namespace std;
 
 namespace edmtest {
-  class EfficiencyByLabelAnalyzer : public edm::EDAnalyzer {
+  class EfficiencyByLabelAnalyzer : public edm::one::EDAnalyzer<> {
   public:
     explicit EfficiencyByLabelAnalyzer(edm::ParameterSet const& p)
         : theEffToken1_(esConsumes()), theEffToken2_(esConsumes()) {
-      std::cout << "EfficiencyByLabelAnalyzer" << std::endl;
+      edm::LogPrint("EfficiencyByLabelAnalyzer") << "EfficiencyByLabelAnalyzer";
     }
-    explicit EfficiencyByLabelAnalyzer(int i) { std::cout << "EfficiencyByLabelAnalyzer " << i << std::endl; }
-    virtual ~EfficiencyByLabelAnalyzer() { std::cout << "~EfficiencyByLabelAnalyzer " << std::endl; }
+    explicit EfficiencyByLabelAnalyzer(int i) {
+      edm::LogPrint("EfficiencyByLabelAnalyzer") << "EfficiencyByLabelAnalyzer " << i;
+    }
+    virtual ~EfficiencyByLabelAnalyzer() {
+      edm::LogPrint("EfficiencyByLabelAnalyzer") << "~EfficiencyByLabelAnalyzer ";
+    }
     virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
 
   private:
@@ -38,28 +42,28 @@ namespace edmtest {
   void EfficiencyByLabelAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context) {
     using namespace edm::eventsetup;
     // Context is not used.
-    std::cout << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
-    std::cout << " ---EVENT NUMBER " << e.id().event() << std::endl;
+    edm::LogPrint("EfficiencyByLabelAnalyzer") << " I AM IN RUN NUMBER " << e.id().run();
+    edm::LogPrint("EfficiencyByLabelAnalyzer") << " ---EVENT NUMBER " << e.id().event();
     edm::eventsetup::EventSetupRecordKey recordKey(
         edm::eventsetup::EventSetupRecordKey::TypeTag::findType("ExEfficiencyRcd"));
     if (recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
       //record not found
-      std::cout << "Record \"ExEfficiencyRcd"
-                << "\" does not exist " << std::endl;
+      edm::LogPrint("EfficiencyByLabelAnalyzer") << "Record \"ExEfficiencyRcd\" does not exist";
     }
-    std::cout << "got context" << std::endl;
+    edm::LogPrint("EfficiencyByLabelAnalyzer") << "got context";
     {
       condex::Efficiency const& eff = context.getData(theEffToken2_);
-      std::cout << "Efficiency*, type (2) " << (void*)(&eff) << " " << typeid(eff).name() << std::endl;
+      edm::LogPrint("EfficiencyByLabelAnalyzer")
+          << "Efficiency*, type (2) " << (void*)(&eff) << " " << typeid(eff).name();
     }
     condex::Efficiency const& eff = context.getData(theEffToken1_);
-    std::cout << "Efficiency*, type " << (void*)(&eff) << " " << typeid(eff).name() << std::endl;
+    edm::LogPrint("EfficiencyByLabelAnalyzer") << "Efficiency*, type " << (void*)(&eff) << " " << typeid(eff).name();
     for (float pt = 0; pt < 10; pt += 2) {
-      std::cout << "\npt=" << pt << "    :";
+      edm::LogPrint("EfficiencyByLabelAnalyzer") << "\npt=" << pt << "    :";
       for (float eta = -3; eta < 3; eta += 1)
-        std::cout << eff(pt, eta) << " ";
+        edm::LogPrint("EfficiencyByLabelAnalyzer") << eff(pt, eta) << " ";
     }
-    std::cout << std::endl;
+    edm::LogPrint("EfficiencyByLabelAnalyzer");
   }
 
   DEFINE_FWK_MODULE(EfficiencyByLabelAnalyzer);

--- a/CondCore/ESSources/test/stubs/EfficiencyByLabelAnalyzer.cc
+++ b/CondCore/ESSources/test/stubs/EfficiencyByLabelAnalyzer.cc
@@ -9,22 +9,22 @@ Toy EDProducers and EDProducts for testing purposes only.
 #include <iostream>
 #include <map>
 #include <typeinfo>
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-
-#include "FWCore/Framework/interface/EventSetup.h"
 
 #include "CondFormats/Calibration/interface/Efficiency.h"
 #include "CondFormats/DataRecord/interface/ExEfficiency.h"
+
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
 
 using namespace std;
 
 namespace edmtest {
   class EfficiencyByLabelAnalyzer : public edm::EDAnalyzer {
   public:
-    explicit EfficiencyByLabelAnalyzer(edm::ParameterSet const& p) {
+    explicit EfficiencyByLabelAnalyzer(edm::ParameterSet const& p)
+        : theEffToken1_(esConsumes()), theEffToken2_(esConsumes()) {
       std::cout << "EfficiencyByLabelAnalyzer" << std::endl;
     }
     explicit EfficiencyByLabelAnalyzer(int i) { std::cout << "EfficiencyByLabelAnalyzer " << i << std::endl; }
@@ -32,6 +32,7 @@ namespace edmtest {
     virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
 
   private:
+    const edm::ESGetToken<condex::Efficiency, ExEfficiencyRcd> theEffToken1_, theEffToken2_;
   };
 
   void EfficiencyByLabelAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context) {
@@ -46,17 +47,12 @@ namespace edmtest {
       std::cout << "Record \"ExEfficiencyRcd"
                 << "\" does not exist " << std::endl;
     }
-    edm::ESHandle<condex::Efficiency> hEff1;
-    edm::ESHandle<condex::Efficiency> hEff2;
-    std::cout << "got eshandle" << std::endl;
-    context.get<ExEfficiencyRcd>().get("vinEff1", hEff1);
-    context.get<ExEfficiencyRcd>().get("vinEff2", hEff2);
     std::cout << "got context" << std::endl;
     {
-      condex::Efficiency const& eff = *hEff2.product();
+      condex::Efficiency const& eff = context.getData(theEffToken2_);
       std::cout << "Efficiency*, type (2) " << (void*)(&eff) << " " << typeid(eff).name() << std::endl;
     }
-    condex::Efficiency const& eff = *hEff1.product();
+    condex::Efficiency const& eff = context.getData(theEffToken1_);
     std::cout << "Efficiency*, type " << (void*)(&eff) << " " << typeid(eff).name() << std::endl;
     for (float pt = 0; pt < 10; pt += 2) {
       std::cout << "\npt=" << pt << "    :";

--- a/CondCore/ESSources/test/stubs/KeyListAnalyzer.cc
+++ b/CondCore/ESSources/test/stubs/KeyListAnalyzer.cc
@@ -9,7 +9,7 @@
 #include "CondFormats/Calibration/interface/Conf.h"
 #include "CondFormats/DataRecord/interface/ExEfficiency.h"
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -20,19 +20,19 @@ namespace {
 
   template <typename Conf>
   void print(Conf const& c) {
-    std::cout << c.v << " " << c.key << " ; ";
+    edm::LogPrint("KeyListAnalyzer") << c.v << " " << c.key << " ; ";
   }
 
 }  // namespace
 
 namespace edmtest {
-  class KeyListAnalyzer : public edm::EDAnalyzer {
+  class KeyListAnalyzer : public edm::one::EDAnalyzer<> {
   public:
     explicit KeyListAnalyzer(edm::ParameterSet const& p) : theKeyListToken_(esConsumes()) {
-      std::cout << "KeyListAnalyzer" << std::endl;
+      edm::LogPrint("KeyListAnalyzer") << "KeyListAnalyzer";
     }
-    explicit KeyListAnalyzer(int i) { std::cout << "KeyListAnalyzer " << i << std::endl; }
-    virtual ~KeyListAnalyzer() { std::cout << "~KeyListAnalyzer " << std::endl; }
+    explicit KeyListAnalyzer(int i) { edm::LogPrint("KeyListAnalyzer") << "KeyListAnalyzer " << i; }
+    virtual ~KeyListAnalyzer() { edm::LogPrint("KeyListAnalyzer") << "~KeyListAnalyzer "; }
     virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
 
   private:
@@ -42,16 +42,15 @@ namespace edmtest {
   void KeyListAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context) {
     using namespace edm::eventsetup;
     // Context is not used.
-    std::cout << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
-    std::cout << " ---EVENT NUMBER " << e.id().event() << std::endl;
+    edm::LogPrint("KeyListAnalyzer") << " I AM IN RUN NUMBER " << e.id().run();
+    edm::LogPrint("KeyListAnalyzer") << " ---EVENT NUMBER " << e.id().event();
     edm::eventsetup::EventSetupRecordKey recordKey(
         edm::eventsetup::EventSetupRecordKey::TypeTag::findType("ExDwarfListRcd"));
     if (recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
       //record not found
-      std::cout << "Record \"ExDwarfListRcd "
-                << "\" does not exist " << std::endl;
+      edm::LogPrint("KeyListAnalyzer") << "Record \"ExDwarfListRcd\" does not exist";
     }
-    std::cout << "got context" << std::endl;
+    edm::LogPrint("KeyListAnalyzer") << "got context";
     cond::KeyList const& kl = context.getData(theKeyListToken_);
     int n = 0;
     for (int i = 0; i < kl.size(); i++)
@@ -62,9 +61,7 @@ namespace edmtest {
         else
           print(*kl.get<condex::ConfF>(i));
       }
-    std::cout << "found " << n << " valid keyed confs" << std::endl;
-
-    std::cout << std::endl;
+    edm::LogPrint("KeyListAnalyzer") << "found " << n << " valid keyed confs" << std::endl;
   }
 
   DEFINE_FWK_MODULE(KeyListAnalyzer);

--- a/CondCore/ESSources/test/stubs/KeyListAnalyzer.cc
+++ b/CondCore/ESSources/test/stubs/KeyListAnalyzer.cc
@@ -3,77 +3,69 @@
 #include <iostream>
 #include <map>
 #include <typeinfo>
+
+#include "CondCore/IOVService/interface/KeyList.h"
+
+#include "CondFormats/Calibration/interface/Conf.h"
+#include "CondFormats/DataRecord/interface/ExEfficiency.h"
+
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-
 #include "FWCore/Framework/interface/EventSetup.h"
-
-#include "CondFormats/DataRecord/interface/ExEfficiency.h"
-#include "CondCore/IOVService/interface/KeyList.h"
-#include "CondFormats/Calibration/interface/Conf.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
 
 using namespace std;
 
 namespace {
 
-  template<typename Conf>
-  void print(Conf const & c) {
+  template <typename Conf>
+  void print(Conf const& c) {
     std::cout << c.v << " " << c.key << " ; ";
   }
 
-}
+}  // namespace
 
-
-namespace edmtest
-{
-  class KeyListAnalyzer : public edm::EDAnalyzer
-  {
+namespace edmtest {
+  class KeyListAnalyzer : public edm::EDAnalyzer {
   public:
-    explicit KeyListAnalyzer(edm::ParameterSet const& p) 
-    { 
-      std::cout<<"KeyListAnalyzer"<<std::endl;
+    explicit KeyListAnalyzer(edm::ParameterSet const& p) : theKeyListToken_(esConsumes()) {
+      std::cout << "KeyListAnalyzer" << std::endl;
     }
-    explicit KeyListAnalyzer(int i) 
-    { std::cout<<"KeyListAnalyzer "<<i<<std::endl; }
-    virtual ~KeyListAnalyzer() {  
-      std::cout<<"~KeyListAnalyzer "<<std::endl;
-    }
+    explicit KeyListAnalyzer(int i) { std::cout << "KeyListAnalyzer " << i << std::endl; }
+    virtual ~KeyListAnalyzer() { std::cout << "~KeyListAnalyzer " << std::endl; }
     virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
+
   private:
+    const edm::ESGetToken<cond::KeyList, ExDwarfListRcd> theKeyListToken_;
   };
-  
-  void
-  KeyListAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context){
+
+  void KeyListAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context) {
     using namespace edm::eventsetup;
     // Context is not used.
-    std::cout <<" I AM IN RUN NUMBER "<<e.id().run() <<std::endl;
-    std::cout <<" ---EVENT NUMBER "<<e.id().event() <<std::endl;
-    edm::eventsetup::EventSetupRecordKey 
-      recordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("ExDwarfListRcd"));
-    if( recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
+    std::cout << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
+    std::cout << " ---EVENT NUMBER " << e.id().event() << std::endl;
+    edm::eventsetup::EventSetupRecordKey recordKey(
+        edm::eventsetup::EventSetupRecordKey::TypeTag::findType("ExDwarfListRcd"));
+    if (recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
       //record not found
-      std::cout <<"Record \"ExDwarfListRcd "<<"\" does not exist "<<std::endl;
+      std::cout << "Record \"ExDwarfListRcd "
+                << "\" does not exist " << std::endl;
     }
-    edm::ESHandle<cond::KeyList> klh;
-    std::cout<<"got eshandle"<<std::endl;
-    context.get<ExDwarfListRcd>().get(klh);
-    std::cout<<"got context"<<std::endl;
-    cond::KeyList const &  kl= *klh.product();
-    int n=0;
-    for (int i=0; i<kl.size(); i++)
-      if (kl.elem(i)) { 
-	n++;
-	if (0==i%2) 
-	  print(*kl.get<condex::ConfI>(i));
-	else
-	  print(*kl.get<condex::ConfF>(i));
+    std::cout << "got context" << std::endl;
+    cond::KeyList const& kl = context.getData(theKeyListToken_);
+    int n = 0;
+    for (int i = 0; i < kl.size(); i++)
+      if (kl.elem(i)) {
+        n++;
+        if (0 == i % 2)
+          print(*kl.get<condex::ConfI>(i));
+        else
+          print(*kl.get<condex::ConfF>(i));
       }
     std::cout << "found " << n << " valid keyed confs" << std::endl;
-      
+
     std::cout << std::endl;
   }
 
   DEFINE_FWK_MODULE(KeyListAnalyzer);
-}
+}  // namespace edmtest

--- a/CondCore/ESSources/test/stubs/LumiTestReadAnalyzer.cc
+++ b/CondCore/ESSources/test/stubs/LumiTestReadAnalyzer.cc
@@ -15,7 +15,7 @@ Toy EDProducers and EDProducts for testing purposes only.
 #include "CondFormats/BeamSpotObjects/interface/BeamSpotObjects.h"
 #include "CondFormats/DataRecord/interface/BeamSpotObjectsRcd.h"
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -24,7 +24,7 @@ Toy EDProducers and EDProducts for testing purposes only.
 using namespace std;
 
 namespace edmtest {
-  class LumiTestReadAnalyzer : public edm::EDAnalyzer {
+  class LumiTestReadAnalyzer : public edm::one::EDAnalyzer<> {
   public:
     explicit LumiTestReadAnalyzer(edm::ParameterSet const& p)
         : theBSToken_(esConsumes()),
@@ -35,9 +35,7 @@ namespace edmtest {
       m_pathForErrorFile = pathForErrorFolder + "/lumi_read_" + m_processId + ".txt";
     }
     explicit LumiTestReadAnalyzer(int i) {}
-    virtual ~LumiTestReadAnalyzer() {}
-    virtual void beginJob();
-    virtual void beginRun(const edm::Run&, const edm::EventSetup& context);
+    virtual ~LumiTestReadAnalyzer() = default;
     virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
 
   private:
@@ -46,8 +44,7 @@ namespace edmtest {
     std::string m_pathForLastLumiFile;
     std::string m_pathForErrorFile;
   };
-  void LumiTestReadAnalyzer::beginRun(const edm::Run&, const edm::EventSetup& context) {}
-  void LumiTestReadAnalyzer::beginJob() {}
+
   void LumiTestReadAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context) {
     static constexpr const char* const MSGSOURCE = "LumiTestReadAnalyzer:";
     edm::eventsetup::EventSetupRecordKey recordKey(
@@ -69,15 +66,15 @@ namespace edmtest {
       msg << "On time " << boost::posix_time::to_iso_extended_string(now) << " Target " << target << "; found "
           << found;
       edm::LogWarning(MSGSOURCE) << msg.str();
-      std::cout << "ERROR ( process " << m_processId << " ) : " << msg.str() << std::endl;
-      std::cout << "### dumping in file " << m_pathForErrorFile << std::endl;
+      edm::LogPrint("LumiTestReadAnalyzer") << "ERROR ( process " << m_processId << " ) : " << msg.str();
+      edm::LogPrint("LumiTestReadAnalyzer") << "### dumping in file " << m_pathForErrorFile;
       {
         std::ofstream errorFile(m_pathForErrorFile, std::ios_base::app);
         errorFile << msg.str() << std::endl;
       }
       //throw std::runtime_error( msg.str() );
     } else {
-      std::cout << "Info: read was ok." << std::endl;
+      edm::LogPrint("LumiTestReadAnalyzer") << "Info: read was ok.";
     }
   }
   DEFINE_FWK_MODULE(LumiTestReadAnalyzer);

--- a/CondCore/ESSources/test/stubs/PedestalsAnalyzer.cc
+++ b/CondCore/ESSources/test/stubs/PedestalsAnalyzer.cc
@@ -9,15 +9,14 @@ Toy EDProducers and EDProducts for testing purposes only.
 #include <string>
 #include <iostream>
 #include <map>
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-
-#include "FWCore/Framework/interface/EventSetup.h"
 
 #include "CondFormats/Calibration/interface/Pedestals.h"
 #include "CondFormats/DataRecord/interface/PedestalsRcd.h"
+
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "TFile.h"
 
@@ -26,7 +25,10 @@ using namespace std;
 namespace edmtest {
   class PedestalsAnalyzer : public edm::EDAnalyzer {
   public:
-    explicit PedestalsAnalyzer(edm::ParameterSet const& p) { std::cout << "PedestalsAnalyzer" << std::endl; }
+    explicit PedestalsAnalyzer(edm::ParameterSet const& p)
+        : thePedestalToken_(esConsumes()), theBeginRunPedestalToken_(esConsumes<edm::Transition::BeginRun>()) {
+      std::cout << "PedestalsAnalyzer" << std::endl;
+    }
     explicit PedestalsAnalyzer(int i) { std::cout << "PedestalsAnalyzer " << i << std::endl; }
     virtual ~PedestalsAnalyzer() { std::cout << "~PedestalsAnalyzer " << std::endl; }
     virtual void beginJob();
@@ -34,20 +36,15 @@ namespace edmtest {
     virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
 
   private:
+    const edm::ESGetToken<Pedestals, PedestalsRcd> thePedestalToken_, theBeginRunPedestalToken_;
   };
   void PedestalsAnalyzer::beginRun(const edm::Run&, const edm::EventSetup& context) {
     std::cout << "###PedestalsAnalyzer::beginRun" << std::endl;
-    edm::ESHandle<Pedestals> pPeds;
-    std::cout << "got eshandle" << std::endl;
-    context.get<PedestalsRcd>().get(pPeds);
+    std::cout << "got context" << std::endl;
+    auto const& myBeginRunPed = &context.getData(theBeginRunPedestalToken_);
+    std::cout << "Pedestals* " << myBeginRunPed << std::endl;
   }
-  void PedestalsAnalyzer::beginJob() {
-    std::cout << "###PedestalsAnalyzer::beginJob" << std::endl;
-    /*edm::ESHandle<Pedestals> pPeds;
-      std::cout<<"got eshandle"<<std::endl;
-      context.get<PedestalsRcd>().get(pPeds);
-    */
-  }
+  void PedestalsAnalyzer::beginJob() { std::cout << "###PedestalsAnalyzer::beginJob" << std::endl; }
   void PedestalsAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context) {
     using namespace edm::eventsetup;
     // Context is not used.
@@ -60,11 +57,8 @@ namespace edmtest {
       std::cout << "Record \"PedestalsRcd"
                 << "\" does not exist " << std::endl;
     }
-    edm::ESHandle<Pedestals> pPeds;
-    std::cout << "got eshandle" << std::endl;
-    context.get<PedestalsRcd>().get(pPeds);
     std::cout << "got context" << std::endl;
-    const Pedestals* myped = pPeds.product();
+    auto const& myped = &context.getData(thePedestalToken_);
     std::cout << "Pedestals* " << myped << std::endl;
     for (std::vector<Pedestals::Item>::const_iterator it = myped->m_pedestals.begin(); it != myped->m_pedestals.end();
          ++it)

--- a/CondCore/ESSources/test/stubs/PedestalsAnalyzer.cc
+++ b/CondCore/ESSources/test/stubs/PedestalsAnalyzer.cc
@@ -13,7 +13,7 @@ Toy EDProducers and EDProducts for testing purposes only.
 #include "CondFormats/Calibration/interface/Pedestals.h"
 #include "CondFormats/DataRecord/interface/PedestalsRcd.h"
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -23,51 +23,52 @@ Toy EDProducers and EDProducts for testing purposes only.
 using namespace std;
 
 namespace edmtest {
-  class PedestalsAnalyzer : public edm::EDAnalyzer {
+  class PedestalsAnalyzer : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
   public:
     explicit PedestalsAnalyzer(edm::ParameterSet const& p)
         : thePedestalToken_(esConsumes()), theBeginRunPedestalToken_(esConsumes<edm::Transition::BeginRun>()) {
-      std::cout << "PedestalsAnalyzer" << std::endl;
+      edm::LogPrint("PedestalsAnalyzer") << "PedestalsAnalyzer";
     }
-    explicit PedestalsAnalyzer(int i) { std::cout << "PedestalsAnalyzer " << i << std::endl; }
-    virtual ~PedestalsAnalyzer() { std::cout << "~PedestalsAnalyzer " << std::endl; }
-    virtual void beginJob();
-    virtual void beginRun(const edm::Run&, const edm::EventSetup& context);
-    virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
+    explicit PedestalsAnalyzer(int i) { edm::LogPrint("PedestalsAnalyzer") << "PedestalsAnalyzer " << i; }
+    virtual ~PedestalsAnalyzer() { edm::LogPrint("PedestalsAnalyzer") << "~PedestalsAnalyzer "; }
+    virtual void beginJob() override;
+    virtual void beginRun(const edm::Run&, const edm::EventSetup& context) override;
+    virtual void analyze(const edm::Event& e, const edm::EventSetup& c) override;
+    virtual void endRun(const edm::Run&, const edm::EventSetup&) override;
 
   private:
     const edm::ESGetToken<Pedestals, PedestalsRcd> thePedestalToken_, theBeginRunPedestalToken_;
   };
   void PedestalsAnalyzer::beginRun(const edm::Run&, const edm::EventSetup& context) {
-    std::cout << "###PedestalsAnalyzer::beginRun" << std::endl;
-    std::cout << "got context" << std::endl;
+    edm::LogPrint("PedestalsAnalyzer") << "###PedestalsAnalyzer::beginRun";
+    edm::LogPrint("PedestalsAnalyzer") << "got context";
     auto const& myBeginRunPed = &context.getData(theBeginRunPedestalToken_);
-    std::cout << "Pedestals* " << myBeginRunPed << std::endl;
+    edm::LogPrint("PedestalsAnalyzer") << "Pedestals* " << myBeginRunPed;
   }
-  void PedestalsAnalyzer::beginJob() { std::cout << "###PedestalsAnalyzer::beginJob" << std::endl; }
+  void PedestalsAnalyzer::beginJob() { edm::LogPrint("PedestalsAnalyzer") << "###PedestalsAnalyzer::beginJob"; }
   void PedestalsAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context) {
     using namespace edm::eventsetup;
     // Context is not used.
-    std::cout << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
-    std::cout << " ---EVENT NUMBER " << e.id().event() << std::endl;
+    edm::LogPrint("PedestalsAnalyzer") << " I AM IN RUN NUMBER " << e.id().run();
+    edm::LogPrint("PedestalsAnalyzer") << " ---EVENT NUMBER " << e.id().event();
     edm::eventsetup::EventSetupRecordKey recordKey(
         edm::eventsetup::EventSetupRecordKey::TypeTag::findType("PedestalsRcd"));
     if (recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
       //record not found
-      std::cout << "Record \"PedestalsRcd"
-                << "\" does not exist " << std::endl;
+      edm::LogPrint("PedestalsAnalyzer") << "Record \"PedestalsRcd\" does not exist";
     }
-    std::cout << "got context" << std::endl;
+    edm::LogPrint("PedestalsAnalyzer") << "got context";
     auto const& myped = &context.getData(thePedestalToken_);
-    std::cout << "Pedestals* " << myped << std::endl;
+    edm::LogPrint("PedestalsAnalyzer") << "Pedestals* " << myped;
     for (std::vector<Pedestals::Item>::const_iterator it = myped->m_pedestals.begin(); it != myped->m_pedestals.end();
          ++it)
-      std::cout << " mean: " << it->m_mean << " variance: " << it->m_variance;
-    std::cout << std::endl;
+      edm::LogPrint("PedestalsAnalyzer") << " mean: " << it->m_mean << " variance: " << it->m_variance;
+    edm::LogPrint("PedestalsAnalyzer") << std::endl;
 
     TFile* f = TFile::Open("MyPedestal.xml", "recreate");
     f->WriteObjectAny(myped, "Pedestals", "Pedestals");
     f->Close();
   }
+  void PedestalsAnalyzer::endRun(const edm::Run&, const edm::EventSetup&) {}
   DEFINE_FWK_MODULE(PedestalsAnalyzer);
 }  // namespace edmtest

--- a/CondCore/ESSources/test/stubs/PedestalsByLabelAnalyzer.cc
+++ b/CondCore/ESSources/test/stubs/PedestalsByLabelAnalyzer.cc
@@ -8,22 +8,22 @@ Toy EDProducers and EDProducts for testing purposes only.
 #include <string>
 #include <iostream>
 #include <map>
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-
-#include "FWCore/Framework/interface/EventSetup.h"
 
 #include "CondFormats/Calibration/interface/Pedestals.h"
 #include "CondFormats/DataRecord/interface/PedestalsRcd.h"
+
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
 
 using namespace std;
 
 namespace edmtest {
   class PedestalsByLabelAnalyzer : public edm::EDAnalyzer {
   public:
-    explicit PedestalsByLabelAnalyzer(edm::ParameterSet const& p) {
+    explicit PedestalsByLabelAnalyzer(edm::ParameterSet const& p)
+        : thePedestalToken_(esConsumes(edm::ESInputTag("", "lab3d"))) {
       std::cout << "PedestalsByLabelAnalyzer" << std::endl;
     }
     explicit PedestalsByLabelAnalyzer(int i) { std::cout << "PedestalsByLabelAnalyzer " << i << std::endl; }
@@ -31,6 +31,7 @@ namespace edmtest {
     virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
 
   private:
+    const edm::ESGetToken<Pedestals, PedestalsRcd> thePedestalToken_;
   };
 
   void PedestalsByLabelAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context) {
@@ -45,11 +46,8 @@ namespace edmtest {
       std::cout << "Record \"PedestalsRcd"
                 << "\" does not exist " << std::endl;
     }
-    edm::ESHandle<Pedestals> pPeds;
-    std::cout << "got eshandle" << std::endl;
-    context.get<PedestalsRcd>().get("lab3d", pPeds);
     std::cout << "got context" << std::endl;
-    const Pedestals* myped = pPeds.product();
+    auto const& myped = &context.getData(thePedestalToken_);
     std::cout << "Pedestals* " << myped << std::endl;
     for (std::vector<Pedestals::Item>::const_iterator it = myped->m_pedestals.begin(); it != myped->m_pedestals.end();
          ++it)

--- a/CondCore/ESSources/test/stubs/PedestalsByLabelAnalyzer.cc
+++ b/CondCore/ESSources/test/stubs/PedestalsByLabelAnalyzer.cc
@@ -12,7 +12,7 @@ Toy EDProducers and EDProducts for testing purposes only.
 #include "CondFormats/Calibration/interface/Pedestals.h"
 #include "CondFormats/DataRecord/interface/PedestalsRcd.h"
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -20,14 +20,16 @@ Toy EDProducers and EDProducts for testing purposes only.
 using namespace std;
 
 namespace edmtest {
-  class PedestalsByLabelAnalyzer : public edm::EDAnalyzer {
+  class PedestalsByLabelAnalyzer : public edm::one::EDAnalyzer<> {
   public:
     explicit PedestalsByLabelAnalyzer(edm::ParameterSet const& p)
         : thePedestalToken_(esConsumes(edm::ESInputTag("", "lab3d"))) {
-      std::cout << "PedestalsByLabelAnalyzer" << std::endl;
+      edm::LogPrint("PedestalsByLabelAnalyzer") << "PedestalsByLabelAnalyzer";
     }
-    explicit PedestalsByLabelAnalyzer(int i) { std::cout << "PedestalsByLabelAnalyzer " << i << std::endl; }
-    virtual ~PedestalsByLabelAnalyzer() { std::cout << "~PedestalsByLabelAnalyzer " << std::endl; }
+    explicit PedestalsByLabelAnalyzer(int i) {
+      edm::LogPrint("PedestalsByLabelAnalyzer") << "PedestalsByLabelAnalyzer " << i;
+    }
+    virtual ~PedestalsByLabelAnalyzer() { edm::LogPrint("PedestalsByLabelAnalyzer") << "~PedestalsByLabelAnalyzer "; }
     virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
 
   private:
@@ -37,22 +39,21 @@ namespace edmtest {
   void PedestalsByLabelAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& context) {
     using namespace edm::eventsetup;
     // Context is not used.
-    std::cout << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
-    std::cout << " ---EVENT NUMBER " << e.id().event() << std::endl;
+    edm::LogPrint("PedestalsByLabelAnalyzer") << " I AM IN RUN NUMBER " << e.id().run();
+    edm::LogPrint("PedestalsByLabelAnalyzer") << " ---EVENT NUMBER " << e.id().event();
     edm::eventsetup::EventSetupRecordKey recordKey(
         edm::eventsetup::EventSetupRecordKey::TypeTag::findType("PedestalsRcd"));
     if (recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
       //record not found
-      std::cout << "Record \"PedestalsRcd"
-                << "\" does not exist " << std::endl;
+      edm::LogPrint("PedestalsByLabelAnalyzer") << "Record \"PedestalsRcd\" does not exist";
     }
-    std::cout << "got context" << std::endl;
+    edm::LogPrint("PedestalsByLabelAnalyzer") << "got context";
     auto const& myped = &context.getData(thePedestalToken_);
-    std::cout << "Pedestals* " << myped << std::endl;
+    edm::LogPrint("PedestalsByLabelAnalyzer") << "Pedestals* " << myped;
     for (std::vector<Pedestals::Item>::const_iterator it = myped->m_pedestals.begin(); it != myped->m_pedestals.end();
          ++it)
-      std::cout << " mean: " << it->m_mean << " variance: " << it->m_variance;
-    std::cout << std::endl;
+      edm::LogPrint("PedestalsByLabelAnalyzer") << " mean: " << it->m_mean << " variance: " << it->m_variance;
+    edm::LogPrint("PedestalsByLabelAnalyzer") << std::endl;
   }
   DEFINE_FWK_MODULE(PedestalsByLabelAnalyzer);
 }  // namespace edmtest

--- a/CondCore/ESSources/test/stubs/TestConcurrentIOVsCondCore.cc
+++ b/CondCore/ESSources/test/stubs/TestConcurrentIOVsCondCore.cc
@@ -174,8 +174,9 @@ namespace edmtest {
     // The original reference file was created using a version
     // of the code before concurrent IOVs were implemented.
     for (auto const& object : testObjects_) {
-      std::cout << "TestConcurrentIOVsCondCore: lumi = " << object.lumi_ << " position: (" << object.x_ << ", "
-                << object.y_ << ", " << object.z_ << ")  iov = " << object.start_ << ":" << object.end_ << std::endl;
+      edm::LogPrint("TestConcurrentIOVsCondCore")
+          << "TestConcurrentIOVsCondCore: lumi = " << object.lumi_ << " position: (" << object.x_ << ", " << object.y_
+          << ", " << object.z_ << ")  iov = " << object.start_ << ":" << object.end_;
     }
   }
 

--- a/CondCore/ESSources/test/stubs/TestUpdater.cc
+++ b/CondCore/ESSources/test/stubs/TestUpdater.cc
@@ -5,7 +5,7 @@
 #include <cstdlib>
 #include <sstream>
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
@@ -21,12 +21,12 @@ EVENTSETUP_RECORD_REG(OneIntRcd);
 
 namespace condtest {
 
-  class TestUpdater : public edm::EDAnalyzer {
+  class TestUpdater : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
   public:
     explicit TestUpdater(edm::ParameterSet const&);
-    virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
-    virtual void beginRun(const edm::Run&, const edm::EventSetup&);
-    virtual void endRun(const edm::Run& r, const edm::EventSetup&) {}
+    virtual void analyze(const edm::Event& e, const edm::EventSetup& c) override;
+    virtual void beginRun(const edm::Run&, const edm::EventSetup&) override;
+    virtual void endRun(const edm::Run&, const edm::EventSetup&) override;
 
     static void update(int run);
 
@@ -40,6 +40,8 @@ namespace condtest {
 
   void TestUpdater::beginRun(const edm::Run&, const edm::EventSetup&) { evCount = 0; }
 
+  void TestUpdater::endRun(const edm::Run&, const edm::EventSetup&) {}
+
   void TestUpdater::analyze(const edm::Event& e, const edm::EventSetup& c) {
     ++evCount;
 
@@ -48,13 +50,13 @@ namespace condtest {
 
     size_t number = (c.getData(theIntToken_)).front();
     if (1 == e.id().run() % 2 && number != e.id().run())
-      std::cout << "it was not updated!" << std::endl;
+      edm::LogPrint("TestUpdater") << "it was not updated!";
   }
 
   void TestUpdater::update(int run) {
     std::ostringstream ss;
     ss << "touch cfg.py; rm cfg.py; sed 's?_CurrentRun_?" << run << "?g' writeInt_cfg.py > cfg.py; cmsRun cfg.py";
-    std::cout << ss.str() << std::endl;
+    edm::LogPrint("TestUpdater") << ss.str();
     // write run in db
     ::system(ss.str().c_str());
   }

--- a/CondCore/ESSources/test/stubs/TestUpdater.cc
+++ b/CondCore/ESSources/test/stubs/TestUpdater.cc
@@ -1,13 +1,13 @@
 #include <stdexcept>
 #include <string>
 #include <iostream>
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include <vector>
 #include <cstdlib>
 #include <sstream>
+
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 
 typedef std::vector<int> Payload;
 
@@ -31,9 +31,12 @@ namespace condtest {
     static void update(int run);
 
     int evCount;
+
+  private:
+    const edm::ESGetToken<std::vector<int>, OneIntRcd> theIntToken_;
   };
 
-  TestUpdater::TestUpdater(edm::ParameterSet const&) : evCount(0) {}
+  TestUpdater::TestUpdater(edm::ParameterSet const&) : evCount(0), theIntToken_(esConsumes()) {}
 
   void TestUpdater::beginRun(const edm::Run&, const edm::EventSetup&) { evCount = 0; }
 
@@ -43,9 +46,7 @@ namespace condtest {
     if (0 == e.id().run() % 2 && evCount == 3)
       update(e.id().run() + 1);
 
-    edm::ESHandle<std::vector<int> > h;
-    c.get<OneIntRcd>().get(h);
-    size_t number = (*h.product()).front();
+    size_t number = (c.getData(theIntToken_)).front();
     if (1 == e.id().run() % 2 && number != e.id().run())
       std::cout << "it was not updated!" << std::endl;
   }


### PR DESCRIPTION
#### PR description:
Following comment in https://github.com/cms-sw/cmssw/pull/36419#issuecomment-989181823 I modernized scripts in `CondCore/ESSources/test` to:
 - use `esConsumes`
 - migrated legacy `EDModules` to be thread-safe
 - changed `cout` to `LogPrint`

#### PR validation:
Code compiles

#### Backport:
Not a backport, no backport needed.