### PR TITLE
Functional changes as follow-up to 36176, related to SiPixelDigisCUDA SOA 

### DIFF
--- a/CUDADataFormats/SiPixelDigi/interface/SiPixelDigisCUDASOAView.h
+++ b/CUDADataFormats/SiPixelDigi/interface/SiPixelDigisCUDASOAView.h
@@ -96,14 +96,13 @@ private:
   uint32_t* rawIdArr_;
 
   template <typename ReturnType, typename StoreType, typename LocationType>
-  ReturnType* getColumnAddress(LocationType column, StoreType& store, int maxFedWords) {
-    return reinterpret_cast<ReturnType*>(store.get() +
-                                         static_cast<int>(column) * roundFor128ByteAlignment(maxFedWords));
+  ReturnType* getColumnAddress(LocationType column, StoreType& store, int size) {
+    return reinterpret_cast<ReturnType*>(store.get() + static_cast<int>(column) * roundFor128ByteAlignment(size));
   }
 
-  static int roundFor128ByteAlignment(int numFedWords) {
-    int mul = 128 / sizeof(uint16_t);
-    return ((numFedWords + mul - 1) / mul) * mul;
+  static int roundFor128ByteAlignment(int size) {
+    constexpr int mul = 128 / sizeof(uint16_t);
+    return ((size + mul - 1) / mul) * mul;
   };
 };
 

--- a/CUDADataFormats/SiPixelDigi/src/SiPixelDigisCUDA.cc
+++ b/CUDADataFormats/SiPixelDigi/src/SiPixelDigisCUDA.cc
@@ -8,7 +8,7 @@
 SiPixelDigisCUDA::SiPixelDigisCUDA(size_t maxFedWords, cudaStream_t stream)
     : m_store(cms::cuda::make_device_unique<SiPixelDigisCUDA::StoreType[]>(
           SiPixelDigisCUDASOAView::roundFor128ByteAlignment(maxFedWords) *
-              int(SiPixelDigisCUDASOAView::StorageLocation::kMAX),
+              static_cast<int>(SiPixelDigisCUDASOAView::StorageLocation::kMAX),
           stream)),
       m_view(m_store, maxFedWords, SiPixelDigisCUDASOAView::StorageLocation::kMAX) {
   assert(maxFedWords != 0);
@@ -17,11 +17,12 @@ SiPixelDigisCUDA::SiPixelDigisCUDA(size_t maxFedWords, cudaStream_t stream)
 cms::cuda::host::unique_ptr<SiPixelDigisCUDA::StoreType[]> SiPixelDigisCUDA::copyAllToHostAsync(
     cudaStream_t stream) const {
   auto ret = cms::cuda::make_host_unique<StoreType[]>(
-      m_view.roundFor128ByteAlignment(nDigis()) * int(SiPixelDigisCUDASOAView::StorageLocationHost::kMAX), stream);
+      m_view.roundFor128ByteAlignment(nDigis()) * static_cast<int>(SiPixelDigisCUDASOAView::StorageLocationHost::kMAX),
+      stream);
   cudaCheck(cudaMemcpyAsync(ret.get(),
                             m_view.clus(),
                             m_view.roundFor128ByteAlignment(nDigis()) * sizeof(SiPixelDigisCUDA::StoreType) *
-                                int(SiPixelDigisCUDASOAView::StorageLocationHost::kMAX),
+                                static_cast<int>(SiPixelDigisCUDASOAView::StorageLocationHost::kMAX),
                             cudaMemcpyDeviceToHost,
                             stream));
   return ret;


### PR DESCRIPTION
#### PR description:

Some minor changes left from the review of #36176 

#### PR validation:

compiles (no functional changes, results are not changing)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

no
