### PR TITLE
More changes in  `CondTools/SiStrip` unit tests 

### DIFF
--- a/CondTools/SiStrip/test/SiStripChannelGainFromDBMiscalibrator_cfg.py
+++ b/CondTools/SiStrip/test/SiStripChannelGainFromDBMiscalibrator_cfg.py
@@ -65,7 +65,7 @@ process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1) )
 ##
 ## separately partition by partition
 ##
-byParition = cms.VPSet(
+byPartition = cms.VPSet(
     cms.PSet(partition = cms.string("TIB"),
              doScale   = cms.bool(True),
              doSmear   = cms.bool(True),
@@ -150,21 +150,20 @@ process.scaleAndSmearSiStripGains.gainType = 1        # 0 for G1, 1 for G2
 process.scaleAndSmearSiStripGains.params   = subsets  # as a cms.VPset
 
 ##
-## Database output service
-##
-from CondCore.CondDB.CondDB_cfi import CondDB as _CondDB
-
-##
 ## Output database (in this case local sqlite file)
 ##
-process.CondDBOutput = _CondDB.clone(connect = 'sqlite_file:modifiedSiStripGains_'+ process.GlobalTag.globaltag._value+'_IOV_'+str(options.runNumber)+".db")
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
-                                          process.CondDBOutput,
-                                          timetype = cms.untracked.string('runnumber'),
-                                          toPut = cms.VPSet(cms.PSet(record = cms.string('SiStripApvGainRcd'),
-                                                                     tag = cms.string('modifiedGains')
-                                                                     )
-                                                            )
-                                          )
+    BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
+    DBParameters = cms.PSet(
+        messageLevel = cms.untracked.int32(3),
+        authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
+    ),
+    timetype = cms.untracked.string('runnumber'),
+    connect = cms.string('sqlite_file:modifiedSiStripGains_%s_IOV_%s.db' % ( process.GlobalTag.globaltag._value, str(options.runNumber))),
+    toPut = cms.VPSet(cms.PSet(
+        record = cms.string('SiStripApvGainRcd'),
+        tag = cms.string('modifiedGains')
+    ))
+)
 
 process.p = cms.Path(process.scaleAndSmearSiStripGains)

--- a/CondTools/SiStrip/test/SiStripNoiseFromDBMiscalibrator_cfg.py
+++ b/CondTools/SiStrip/test/SiStripNoiseFromDBMiscalibrator_cfg.py
@@ -214,24 +214,23 @@ process.load("CondTools.SiStrip.scaleAndSmearSiStripNoises_cfi")
 #process.scaleAndSmearSiStripNoises.params  = subsets        # as a cms.VPset
 #process.scaleAndSmearSiStripNoises.params  = byLayerOnlyTIB # as a cms.VPset
 process.scaleAndSmearSiStripNoises.params  = autoparams
-process.scaleAndSmearSiStripNoises.fillDefaults = False     # to fill uncabled DetIds with default
-
-##
-## Database output service
-##
-from CondCore.CondDB.CondDB_cfi import CondDB as _CondDB
+process.scaleAndSmearSiStripNoises.fillDefaults = False      # to fill uncabled DetIds with default
 
 ##
 ## Output database (in this case local sqlite file)
 ##
-process.CondDBOutput = _CondDB.clone(connect = 'sqlite_file:modifiedSiStripNoise_'+ process.GlobalTag.globaltag._value+'_IOV_'+str(options.runNumber)+".db")
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
-                                          process.CondDBOutput,
-                                          timetype = cms.untracked.string('runnumber'),
-                                          toPut = cms.VPSet(cms.PSet(record = cms.string('SiStripNoisesRcd'),
-                                                                     tag = cms.string('modifiedNoise')
-                                                                     )
-                                                            )
-                                          )
+    BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
+    DBParameters = cms.PSet(
+        messageLevel = cms.untracked.int32(3),
+        authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
+    ),
+    timetype = cms.untracked.string('runnumber'),
+    connect = cms.string('sqlite_file:modifiedSiStripNoise_%s_IOV_%s.db' % ( process.GlobalTag.globaltag._value, str(options.runNumber))),
+    toPut = cms.VPSet(cms.PSet(
+        record = cms.string('SiStripNoisesRcd'),
+        tag = cms.string('modifiedNoise')
+    ))
+)
 
 process.p = cms.Path(process.scaleAndSmearSiStripNoises)

--- a/CondTools/SiStrip/test/testBuildersReaders.sh
+++ b/CondTools/SiStrip/test/testBuildersReaders.sh
@@ -28,8 +28,17 @@ done
 
 echo -e " Done with the readers \n\n"
 
+sleep 5
+
 ## do the miscalibrators
-(cmsRun ${LOCAL_TEST_DIR}/SiStripChannelGainFromDBMiscalibrator_cfg.py) || die "Failure using cmsRun SiStripChannelGainFromDBMiscalibrator_cfg.py)" $?
-(cmsRun ${LOCAL_TEST_DIR}/SiStripNoiseFromDBMiscalibrator_cfg.py) || die "Failure using cmsRun SiStripNoiseFromDBMiscalibrator_cfg.py" $?
+for entry in "${LOCAL_TEST_DIR}/"SiStrip*Miscalibrator_cfg.py
+do
+  echo "===== Test \"cmsRun $entry \" ===="
+  (cmsRun $entry) || die "Failure using cmsRun $entry" $?
+done
 
 echo -e " Done with the miscalibrators \n\n"
+
+## do the scaler (commented for now)
+#(cmsRun ${LOCAL_TEST_DIR}/SiStripApvGainRescaler_cfg.py) || die "Failure using cmsRun SiStripApvGainRescaler_cfg.py)" $?
+#echo -e " Done with the gain rescaler \n\n"


### PR DESCRIPTION
#### PR description:

Another attempt to debug further issue https://github.com/cms-sw/cmssw/issues/36319.
   * 2c52f2fa9feba74e638f9f71ae5a003067d24617 enhances the verbosity of `PoolDBOutputService`, and re-defines their configuration from scratch.
   * 13468d703d1ddc0117b391d2c558490513536b1a limits the debug printout messages to the first 10 strips
   * a4a85d368826fbf34627e18dffb8374dbce3677a modifies the test script to:
      * wait 5 seconds before submitting the miscalibration tests
      * loop over the miscalibrators instead of calling them explicitly

#### PR validation:

`scram b runtests_testCondToolsSiStripBuildersReaders` runs

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
