### PR TITLE
Modernize use of EDModules for CalibMuon/DTCalibration

### DIFF
--- a/CalibMuon/DTCalibration/interface/DTCalibMuonSelection.h
+++ b/CalibMuon/DTCalibration/interface/DTCalibMuonSelection.h
@@ -4,7 +4,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/one/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
@@ -12,18 +12,18 @@
 #include <vector>
 #include <string>
 
-class DTCalibMuonSelection : public edm::one::EDFilter<> {
+class DTCalibMuonSelection : public edm::stream::EDFilter<> {
 public:
   explicit DTCalibMuonSelection(const edm::ParameterSet&);
 
   ~DTCalibMuonSelection() override;
 
 private:
-  void beginJob() override;
+  void beginStream(edm::StreamID) override;
 
   bool filter(edm::Event&, const edm::EventSetup&) override;
 
-  void endJob() override;
+  void endStream() override;
 
   edm::EDGetTokenT<reco::MuonCollection> muonList;
 

--- a/CalibMuon/DTCalibration/interface/DTCalibMuonSelection.h
+++ b/CalibMuon/DTCalibration/interface/DTCalibMuonSelection.h
@@ -4,7 +4,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/one/EDFilter.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
@@ -12,7 +12,7 @@
 #include <vector>
 #include <string>
 
-class DTCalibMuonSelection : public edm::EDFilter {
+class DTCalibMuonSelection : public edm::one::EDFilter<> {
 public:
   explicit DTCalibMuonSelection(const edm::ParameterSet&);
 

--- a/CalibMuon/DTCalibration/interface/DTSegmentSelector.h
+++ b/CalibMuon/DTCalibration/interface/DTSegmentSelector.h
@@ -5,7 +5,7 @@
  *  \author A. Vilela Pereira
  */
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/CalibMuon/DTCalibration/interface/DTTMax.h
+++ b/CalibMuon/DTCalibration/interface/DTTMax.h
@@ -9,7 +9,7 @@
  *  \author Marina Giunta
  */
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "DataFormats/MuonDetId/interface/DTWireId.h"
 #include "DataFormats/DTRecHit/interface/DTRecHit1D.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"

--- a/CalibMuon/DTCalibration/interface/DTTMax.h
+++ b/CalibMuon/DTCalibration/interface/DTTMax.h
@@ -9,7 +9,6 @@
  *  \author Marina Giunta
  */
 
-#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "DataFormats/MuonDetId/interface/DTWireId.h"
 #include "DataFormats/DTRecHit/interface/DTRecHit1D.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"

--- a/CalibMuon/DTCalibration/plugins/DTMapGenerator.h
+++ b/CalibMuon/DTCalibration/plugins/DTMapGenerator.h
@@ -8,13 +8,13 @@
  */
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "DataFormats/MuonDetId/interface/DTWireId.h"
 
 #include <string>
 #include <set>
 
-class DTMapGenerator : public edm::EDAnalyzer {
+class DTMapGenerator : public edm::one::EDAnalyzer<> {
 public:
   /// Constructor
   DTMapGenerator(const edm::ParameterSet& pset);

--- a/CalibMuon/DTCalibration/plugins/DTNoiseCalibration.h
+++ b/CalibMuon/DTCalibration/plugins/DTNoiseCalibration.h
@@ -9,7 +9,7 @@
  *
 */
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
@@ -30,7 +30,7 @@ class TFile;
 class TH2F;
 class TH1F;
 
-class DTNoiseCalibration : public edm::EDAnalyzer {
+class DTNoiseCalibration : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   /// Constructor
   DTNoiseCalibration(const edm::ParameterSet& ps);
@@ -40,6 +40,7 @@ public:
   void beginJob() override;
   void beginRun(const edm::Run& run, const edm::EventSetup& setup) override;
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
+  void endRun(const edm::Run& run, const edm::EventSetup& setup) override {};
   void endJob() override;
 
 private:

--- a/CalibMuon/DTCalibration/plugins/DTNoiseCalibration.h
+++ b/CalibMuon/DTCalibration/plugins/DTNoiseCalibration.h
@@ -40,7 +40,7 @@ public:
   void beginJob() override;
   void beginRun(const edm::Run& run, const edm::EventSetup& setup) override;
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
-  void endRun(const edm::Run& run, const edm::EventSetup& setup) override {};
+  void endRun(const edm::Run& run, const edm::EventSetup& setup) override{};
   void endJob() override;
 
 private:

--- a/CalibMuon/DTCalibration/plugins/DTNoiseComputation.h
+++ b/CalibMuon/DTCalibration/plugins/DTNoiseComputation.h
@@ -8,7 +8,7 @@
  *
 */
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "DataFormats/MuonDetId/interface/DTLayerId.h"
 #include "DataFormats/MuonDetId/interface/DTWireId.h"
@@ -31,7 +31,7 @@ class TFile;
 class TH2F;
 class TH1F;
 
-class DTNoiseComputation : public edm::EDAnalyzer {
+class DTNoiseComputation : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   /// Constructor
   DTNoiseComputation(const edm::ParameterSet& ps);
@@ -45,6 +45,8 @@ public:
   void beginRun(const edm::Run&, const edm::EventSetup& setup) override;
 
   void analyze(const edm::Event& event, const edm::EventSetup& setup) override {}
+
+  void endRun(const edm::Run&, const edm::EventSetup& setup) override {};
 
   /// Endjob
   void endJob() override;

--- a/CalibMuon/DTCalibration/plugins/DTNoiseComputation.h
+++ b/CalibMuon/DTCalibration/plugins/DTNoiseComputation.h
@@ -46,7 +46,7 @@ public:
 
   void analyze(const edm::Event& event, const edm::EventSetup& setup) override {}
 
-  void endRun(const edm::Run&, const edm::EventSetup& setup) override {};
+  void endRun(const edm::Run&, const edm::EventSetup& setup) override{};
 
   /// Endjob
   void endJob() override;

--- a/CalibMuon/DTCalibration/plugins/DTResidualCalibration.h
+++ b/CalibMuon/DTCalibration/plugins/DTResidualCalibration.h
@@ -6,7 +6,7 @@
  *
  */
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -26,7 +26,7 @@ class DTGeometry;
 class DTSuperLayerId;
 class DTLayerId;
 
-class DTResidualCalibration : public edm::EDAnalyzer {
+class DTResidualCalibration : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   /// Constructor
   DTResidualCalibration(const edm::ParameterSet& pset);
@@ -36,6 +36,7 @@ public:
   void beginJob() override;
   void beginRun(const edm::Run&, const edm::EventSetup&) override;
   void endJob() override;
+  void endRun(const edm::Run&, const edm::EventSetup&) override {};
   void analyze(const edm::Event& event, const edm::EventSetup& setup) override;
 
 protected:

--- a/CalibMuon/DTCalibration/plugins/DTResidualCalibration.h
+++ b/CalibMuon/DTCalibration/plugins/DTResidualCalibration.h
@@ -36,7 +36,7 @@ public:
   void beginJob() override;
   void beginRun(const edm::Run&, const edm::EventSetup&) override;
   void endJob() override;
-  void endRun(const edm::Run&, const edm::EventSetup&) override {};
+  void endRun(const edm::Run&, const edm::EventSetup&) override{};
   void analyze(const edm::Event& event, const edm::EventSetup& setup) override;
 
 protected:

--- a/CalibMuon/DTCalibration/plugins/DTT0Calibration.h
+++ b/CalibMuon/DTCalibration/plugins/DTT0Calibration.h
@@ -11,7 +11,6 @@
  *  \author S. Bolognesi - INFN Torino
  */
 
-//#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "Geometry/DTGeometry/interface/DTGeometry.h"
 #include "DataFormats/MuonDetId/interface/DTWireId.h"

--- a/CalibMuon/DTCalibration/plugins/DTT0CalibrationRMS.h
+++ b/CalibMuon/DTCalibration/plugins/DTT0CalibrationRMS.h
@@ -9,7 +9,7 @@
  *  odd and even layers
  */
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "Geometry/DTGeometry/interface/DTGeometry.h"
 #include "DataFormats/MuonDetId/interface/DTWireId.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -24,7 +24,7 @@ class TH1I;
 class TH1D;
 class DTT0;
 
-class DTT0CalibrationRMS : public edm::EDAnalyzer {
+class DTT0CalibrationRMS : public edm::one::EDAnalyzer<> {
 public:
   /// Constructor
   DTT0CalibrationRMS(const edm::ParameterSet& pset);

--- a/CalibMuon/DTCalibration/plugins/DTT0Correction.h
+++ b/CalibMuon/DTCalibration/plugins/DTT0Correction.h
@@ -6,7 +6,7 @@
  */
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "CondFormats/DTObjects/interface/DTT0.h"
@@ -20,7 +20,7 @@ namespace dtCalibration {
   class DTT0BaseCorrection;
 }
 
-class DTT0Correction : public edm::EDAnalyzer {
+class DTT0Correction : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   /// Constructor
   DTT0Correction(const edm::ParameterSet& pset);
@@ -33,6 +33,7 @@ public:
   void beginJob() override {}
   void beginRun(const edm::Run& run, const edm::EventSetup& setup) override;
   void analyze(const edm::Event& event, const edm::EventSetup& setup) override {}
+  void endRun(const edm::Run& run, const edm::EventSetup& setup) override {};
   void endJob() override;
 
 protected:

--- a/CalibMuon/DTCalibration/plugins/DTT0Correction.h
+++ b/CalibMuon/DTCalibration/plugins/DTT0Correction.h
@@ -33,7 +33,7 @@ public:
   void beginJob() override {}
   void beginRun(const edm::Run& run, const edm::EventSetup& setup) override;
   void analyze(const edm::Event& event, const edm::EventSetup& setup) override {}
-  void endRun(const edm::Run& run, const edm::EventSetup& setup) override {};
+  void endRun(const edm::Run& run, const edm::EventSetup& setup) override{};
   void endJob() override;
 
 protected:

--- a/CalibMuon/DTCalibration/plugins/DTTPDeadWriter.h
+++ b/CalibMuon/DTCalibration/plugins/DTTPDeadWriter.h
@@ -7,7 +7,7 @@
  *  \author S. Bolognesi
  */
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "Geometry/DTGeometry/interface/DTGeometry.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
@@ -25,7 +25,7 @@ namespace edm {
 class DTT0;
 class DTDeadFlag;
 
-class DTTPDeadWriter : public edm::EDAnalyzer {
+class DTTPDeadWriter : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   /// Constructor
   DTTPDeadWriter(const edm::ParameterSet& pset);
@@ -40,6 +40,8 @@ public:
 
   /// Compute the ttrig by fiting the TB rising edge
   void analyze(const edm::Event& event, const edm::EventSetup& eventSetup) override;
+
+  void endRun(const edm::Run&, const edm::EventSetup& setup) override {};
 
   /// Write ttrig in the DB
   void endJob() override;

--- a/CalibMuon/DTCalibration/plugins/DTTPDeadWriter.h
+++ b/CalibMuon/DTCalibration/plugins/DTTPDeadWriter.h
@@ -41,7 +41,7 @@ public:
   /// Compute the ttrig by fiting the TB rising edge
   void analyze(const edm::Event& event, const edm::EventSetup& eventSetup) override;
 
-  void endRun(const edm::Run&, const edm::EventSetup& setup) override {};
+  void endRun(const edm::Run&, const edm::EventSetup& setup) override{};
 
   /// Write ttrig in the DB
   void endJob() override;

--- a/CalibMuon/DTCalibration/plugins/DTTTrigCorrection.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigCorrection.cc
@@ -26,7 +26,7 @@
 #include "CalibMuon/DTCalibration/interface/DTTTrigCorrectionFactory.h"
 #include "CalibMuon/DTCalibration/interface/DTTTrigBaseCorrection.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include <iostream>
 #include <fstream>

--- a/CalibMuon/DTCalibration/plugins/DTTTrigCorrection.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigCorrection.cc
@@ -26,7 +26,6 @@
 #include "CalibMuon/DTCalibration/interface/DTTTrigCorrectionFactory.h"
 #include "CalibMuon/DTCalibration/interface/DTTTrigBaseCorrection.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include <iostream>
 #include <fstream>

--- a/CalibMuon/DTCalibration/plugins/DTTTrigCorrection.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigCorrection.h
@@ -9,7 +9,7 @@
  */
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
@@ -24,7 +24,7 @@ namespace dtCalibration {
   class DTTTrigBaseCorrection;
 }
 
-class DTTTrigCorrection : public edm::EDAnalyzer {
+class DTTTrigCorrection : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   /// Constructor
   DTTTrigCorrection(const edm::ParameterSet& pset);
@@ -37,6 +37,7 @@ public:
   void beginJob() override {}
   void beginRun(const edm::Run& run, const edm::EventSetup& setup) override;
   void analyze(const edm::Event& event, const edm::EventSetup& setup) override {}
+  void endRun(const edm::Run& run, const edm::EventSetup& setup) override {};
   void endJob() override;
 
 protected:

--- a/CalibMuon/DTCalibration/plugins/DTTTrigCorrection.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigCorrection.h
@@ -37,7 +37,7 @@ public:
   void beginJob() override {}
   void beginRun(const edm::Run& run, const edm::EventSetup& setup) override;
   void analyze(const edm::Event& event, const edm::EventSetup& setup) override {}
-  void endRun(const edm::Run& run, const edm::EventSetup& setup) override {};
+  void endRun(const edm::Run& run, const edm::EventSetup& setup) override{};
   void endJob() override;
 
 protected:

--- a/CalibMuon/DTCalibration/plugins/DTTTrigCorrectionFirst.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigCorrectionFirst.h
@@ -9,7 +9,7 @@
  */
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "CondFormats/DataRecord/interface/DTTtrigRcd.h"
@@ -19,7 +19,7 @@
 class DTTtrig;
 class DTGeometry;
 
-class DTTTrigCorrectionFirst : public edm::EDAnalyzer {
+class DTTTrigCorrectionFirst : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   /// Constructor
   DTTTrigCorrectionFirst(const edm::ParameterSet& pset);
@@ -33,6 +33,7 @@ public:
   void beginRun(const edm::Run& run, const edm::EventSetup& setup) override;
   void analyze(const edm::Event& event, const edm::EventSetup& setup) override {}
 
+  void endRun(const edm::Run& run, const edm::EventSetup& setup) override {};
   void endJob() override;
 
 protected:

--- a/CalibMuon/DTCalibration/plugins/DTTTrigCorrectionFirst.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigCorrectionFirst.h
@@ -33,7 +33,7 @@ public:
   void beginRun(const edm::Run& run, const edm::EventSetup& setup) override;
   void analyze(const edm::Event& event, const edm::EventSetup& setup) override {}
 
-  void endRun(const edm::Run& run, const edm::EventSetup& setup) override {};
+  void endRun(const edm::Run& run, const edm::EventSetup& setup) override{};
   void endJob() override;
 
 protected:

--- a/CalibMuon/DTCalibration/plugins/DTTTrigOffsetCalibration.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigOffsetCalibration.h
@@ -7,7 +7,7 @@
  *  \author A. Vilela Pereira
  */
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "CalibMuon/DTCalibration/interface/DTSegmentSelector.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
@@ -27,7 +27,7 @@ class DTTtrig;
 class TFile;
 class TH1F;
 
-class DTTTrigOffsetCalibration : public edm::EDAnalyzer {
+class DTTTrigOffsetCalibration : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   // Constructor
   DTTTrigOffsetCalibration(const edm::ParameterSet& pset);
@@ -36,6 +36,7 @@ public:
 
   void beginRun(const edm::Run& run, const edm::EventSetup& setup) override;
   void analyze(const edm::Event& event, const edm::EventSetup& eventSetup) override;
+  void endRun(const edm::Run& run, const edm::EventSetup& setup) override {};
   void endJob() override;
 
 private:

--- a/CalibMuon/DTCalibration/plugins/DTTTrigOffsetCalibration.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigOffsetCalibration.h
@@ -36,7 +36,7 @@ public:
 
   void beginRun(const edm::Run& run, const edm::EventSetup& setup) override;
   void analyze(const edm::Event& event, const edm::EventSetup& eventSetup) override;
-  void endRun(const edm::Run& run, const edm::EventSetup& setup) override {};
+  void endRun(const edm::Run& run, const edm::EventSetup& setup) override{};
   void endJob() override;
 
 private:

--- a/CalibMuon/DTCalibration/plugins/DTTTrigWriter.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigWriter.h
@@ -7,7 +7,7 @@
  *  \author S. Bolognesi
  */
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 // #include "DataFormats/MuonDetId/interface/DTSuperLayerId.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
@@ -26,7 +26,7 @@ class DTTimeBoxFitter;
 class DTSuperLayerId;
 class DTTtrig;
 
-class DTTTrigWriter : public edm::EDAnalyzer {
+class DTTTrigWriter : public edm::one::EDAnalyzer<> {
 public:
   /// Constructor
   DTTTrigWriter(const edm::ParameterSet& pset);

--- a/CalibMuon/DTCalibration/plugins/DTVDriftSegmentCalibration.h
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftSegmentCalibration.h
@@ -31,7 +31,7 @@ public:
   void beginJob() override;
   void beginRun(const edm::Run& run, const edm::EventSetup& setup) override;
   void analyze(const edm::Event& event, const edm::EventSetup& eventSetup) override;
-  void endRun(const edm::Run& run, const edm::EventSetup& setup) override {};
+  void endRun(const edm::Run& run, const edm::EventSetup& setup) override{};
   void endJob() override;
 
 private:

--- a/CalibMuon/DTCalibration/plugins/DTVDriftSegmentCalibration.h
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftSegmentCalibration.h
@@ -8,7 +8,7 @@
  *  \author A. Vilela Pereira
  */
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "CalibMuon/DTCalibration/interface/DTSegmentSelector.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
@@ -21,7 +21,7 @@ class TFile;
 class TH1F;
 class TH2F;
 
-class DTVDriftSegmentCalibration : public edm::EDAnalyzer {
+class DTVDriftSegmentCalibration : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   // Constructor
   DTVDriftSegmentCalibration(const edm::ParameterSet& pset);
@@ -31,6 +31,7 @@ public:
   void beginJob() override;
   void beginRun(const edm::Run& run, const edm::EventSetup& setup) override;
   void analyze(const edm::Event& event, const edm::EventSetup& eventSetup) override;
+  void endRun(const edm::Run& run, const edm::EventSetup& setup) override {};
   void endJob() override;
 
 private:

--- a/CalibMuon/DTCalibration/plugins/DTVDriftWriter.h
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftWriter.h
@@ -9,7 +9,7 @@
  *  \author A. Vilela Pereira 
  */
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "CondFormats/DataRecord/interface/DTMtimeRcd.h"
@@ -26,7 +26,7 @@ namespace dtCalibration {
   class DTVDriftBaseAlgo;
 }
 
-class DTVDriftWriter : public edm::EDAnalyzer {
+class DTVDriftWriter : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   DTVDriftWriter(const edm::ParameterSet& pset);
   ~DTVDriftWriter() override;
@@ -34,6 +34,7 @@ public:
   // Operations
   void beginRun(const edm::Run& run, const edm::EventSetup& setup) override;
   void analyze(const edm::Event& event, const edm::EventSetup& eventSetup) override {}
+  void endRun(const edm::Run& run, const edm::EventSetup& setup) override {};
   void endJob() override;
 
 private:

--- a/CalibMuon/DTCalibration/plugins/DTVDriftWriter.h
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftWriter.h
@@ -34,7 +34,7 @@ public:
   // Operations
   void beginRun(const edm::Run& run, const edm::EventSetup& setup) override;
   void analyze(const edm::Event& event, const edm::EventSetup& eventSetup) override {}
-  void endRun(const edm::Run& run, const edm::EventSetup& setup) override {};
+  void endRun(const edm::Run& run, const edm::EventSetup& setup) override{};
   void endJob() override;
 
 private:

--- a/CalibMuon/DTCalibration/src/DTCalibMuonSelection.cc
+++ b/CalibMuon/DTCalibration/src/DTCalibMuonSelection.cc
@@ -53,7 +53,7 @@ bool DTCalibMuonSelection::filter(edm::Event& iEvent, const edm::EventSetup& iSe
 }
 
 // ------------ method called once each job just before starting event loop  ------------
-void DTCalibMuonSelection::beginJob() {}
+void DTCalibMuonSelection::beginStream(edm::StreamID) {}
 
 // ------------ method called once each job just after ending the event loop  ------------
-void DTCalibMuonSelection::endJob() {}
+void DTCalibMuonSelection::endStream() {}

--- a/CalibMuon/DTCalibration/test/DBTools/DTT0Analyzer.h
+++ b/CalibMuon/DTCalibration/test/DBTools/DTT0Analyzer.h
@@ -8,7 +8,7 @@
  */
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
 #include "DataFormats/MuonDetId/interface/DTLayerId.h"
@@ -26,7 +26,7 @@ class DTT0;
 class TFile;
 class TH1D;
 
-class DTT0Analyzer : public edm::EDAnalyzer {
+class DTT0Analyzer : public edm::one::EDAnalyzer<> {
 public:
   /// Constructor
   DTT0Analyzer(const edm::ParameterSet& pset);

--- a/CalibMuon/DTCalibration/test/DBTools/DTTTrigAnalyzer.h
+++ b/CalibMuon/DTCalibration/test/DBTools/DTTTrigAnalyzer.h
@@ -8,7 +8,7 @@
  */
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/MuonDetId/interface/DTWireId.h"
 #include "CondFormats/DataRecord/interface/DTTtrigRcd.h"
@@ -22,7 +22,7 @@ class DTTtrig;
 class TFile;
 class TH1D;
 
-class DTTTrigAnalyzer : public edm::EDAnalyzer {
+class DTTTrigAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   /// Constructor
   DTTTrigAnalyzer(const edm::ParameterSet& pset);

--- a/CalibMuon/DTCalibration/test/DBTools/DTVDriftAnalyzer.h
+++ b/CalibMuon/DTCalibration/test/DBTools/DTVDriftAnalyzer.h
@@ -8,7 +8,7 @@
  */
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/MuonDetId/interface/DTWireId.h"
 #include "CondFormats/DataRecord/interface/DTMtimeRcd.h"
@@ -24,7 +24,7 @@ class DTRecoConditions;
 class TFile;
 class TH1D;
 
-class DTVDriftAnalyzer : public edm::EDAnalyzer {
+class DTVDriftAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   /// Constructor
   DTVDriftAnalyzer(const edm::ParameterSet& pset);

--- a/CalibMuon/DTCalibration/test/DBTools/FakeTTrig.h
+++ b/CalibMuon/DTCalibration/test/DBTools/FakeTTrig.h
@@ -12,7 +12,7 @@
  */
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
@@ -23,7 +23,7 @@ class DTGeometry;
 class DTSuperLayer;
 class DTTtrig;
 
-class FakeTTrig : public edm::EDAnalyzer {
+class FakeTTrig : public edm::one::EDAnalyzer<> {
 public:
   /// Constructor
   FakeTTrig(const edm::ParameterSet& pset);

--- a/CalibMuon/DTCalibration/test/DBTools/FakeTTrig.h
+++ b/CalibMuon/DTCalibration/test/DBTools/FakeTTrig.h
@@ -35,8 +35,8 @@ public:
   virtual void beginRun(const edm::Run& run, const edm::EventSetup& setup) override;
   virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
   virtual void analyze(const edm::Event& event, const edm::EventSetup& setup) override {}
-  virtual void endRun(const edm::Run& run, const edm::EventSetup& setup) override {};
-  virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override {};
+  virtual void endRun(const edm::Run& run, const edm::EventSetup& setup) override{};
+  virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override{};
   virtual void endJob() override;
 
   // TOF computation

--- a/CalibMuon/DTCalibration/test/DBTools/FakeTTrig.h
+++ b/CalibMuon/DTCalibration/test/DBTools/FakeTTrig.h
@@ -23,7 +23,7 @@ class DTGeometry;
 class DTSuperLayer;
 class DTTtrig;
 
-class FakeTTrig : public edm::one::EDAnalyzer<> {
+class FakeTTrig : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::WatchLuminosityBlocks> {
 public:
   /// Constructor
   FakeTTrig(const edm::ParameterSet& pset);
@@ -35,6 +35,8 @@ public:
   virtual void beginRun(const edm::Run& run, const edm::EventSetup& setup) override;
   virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
   virtual void analyze(const edm::Event& event, const edm::EventSetup& setup) override {}
+  virtual void endRun(const edm::Run& run, const edm::EventSetup& setup) override {};
+  virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override {};
   virtual void endJob() override;
 
   // TOF computation

--- a/CalibMuon/DTCalibration/test/DBTools/ShiftTTrigDB.h
+++ b/CalibMuon/DTCalibration/test/DBTools/ShiftTTrigDB.h
@@ -9,7 +9,7 @@
  */
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "Geometry/DTGeometry/interface/DTGeometry.h"
@@ -22,7 +22,7 @@
 class DTTtrig;
 class DTGeometry;
 
-class ShiftTTrigDB : public edm::EDAnalyzer {
+class ShiftTTrigDB : public edm::one::EDAnalyzer<> {
 public:
   /// Constructor
   ShiftTTrigDB(const edm::ParameterSet& pset);


### PR DESCRIPTION
#### PR description:

This is part of https://github.com/cms-AlCaDB/AlCaTools/issues/30 to modernize the use of EDModules. Change to use the "one" version of EDModule for better multi-thread data processing.

#### PR validation:

* Code compiles
* Local scram build tests passed
* Local code check done

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport and no backporting foreseen.

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
