### PR TITLE
HCAL: Remove 4th depth from trigger primitive sum over depths, for |ieta| = 16

### DIFF
--- a/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
+++ b/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
@@ -545,8 +545,8 @@ void HcaluLUTTPGCoder::update(const HcalDbService& conditions) {
               lut[adc] |= QIE11_LUT_MSB1;
           }
 
-	  //Zeroing the 4th depth in the trigger towers where |ieta| = 16 to match the behavior in the uHTR firmware, where the 4th depth is not included in the sum over depths when constructing the TP energy for this tower.
-	  if (abs(cell.ieta()) == 16 && cell.depth() == 4) {
+	  //Zeroing the 4th depth in the trigger towers where |ieta| = 16 to match the behavior in the uHTR firmware in Run3, where the 4th depth is not included in the sum over depths when constructing the TP energy for this tower.
+	  if (abs(cell.ieta()) == 16 && cell.depth() == 4 && topo_->triggerMode() >= HcalTopologyMode::TriggerMode_2021) {
             lut[adc] = 0;
           }
         }

--- a/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
+++ b/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
@@ -544,6 +544,11 @@ void HcaluLUTTPGCoder::update(const HcalDbService& conditions) {
             else if (adc >= mipMax)
               lut[adc] |= QIE11_LUT_MSB1;
           }
+
+	  //Zeroing the 4th depth in the trigger towers where |ieta| = 16 to match the behavior in the uHTR firmware, where the 4th depth is not included in the sum over depths when constructing the TP energy for this tower.
+	  if (abs(cell.ieta()) == 16 && cell.depth() == 4) {
+            lut[adc] = 0;
+          }
         }
       }
     } else if (subdet == HcalForward) {


### PR DESCRIPTION
#### PR description:

Zeroing the 4th depth in the trigger towers where |ieta| = 16. This is done to match the behavior in the uHTR firmware, where the 4th depth is not included in the sum over depths when constructing the TP energy for these towers. The 4th depth is the last depth in these towers and comes from HE, whereas the first 3 come from the HB. This has been discussed in the HCAL Ops gitlab [issue](https://gitlab.cern.ch/cmshcal/docs/-/issues/8#note_5020935).

#### PR validation:

A basic technical test was performed: runTheMatrix.py -l limited -i all --ibeos

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport.

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
