### PR TITLE
[12.2.X] Enhance PixelTrack SoA DQM monitoring 

### DIFF
--- a/DQM/SiPixelPhase1Heterogeneous/plugins/SiPixelPhase1MonitorTrackSoA.cc
+++ b/DQM/SiPixelPhase1Heterogeneous/plugins/SiPixelPhase1MonitorTrackSoA.cc
@@ -44,6 +44,7 @@ private:
   MonitorElement* hphi;
   MonitorElement* hz;
   MonitorElement* htip;
+  MonitorElement* hquality;
 };
 
 //
@@ -85,6 +86,7 @@ void SiPixelPhase1MonitorTrackSoA::analyze(const edm::Event& iEvent, const edm::
     float zip = tsoa.zip(it);
     float eta = tsoa.eta(it);
     float tip = tsoa.tip(it);
+    pixelTrack::Quality qual = tsoa.quality(it);
     hchi2->Fill(chi2);
     hnHits->Fill(nHits);
     hpt->Fill(pt);
@@ -92,6 +94,7 @@ void SiPixelPhase1MonitorTrackSoA::analyze(const edm::Event& iEvent, const edm::
     hphi->Fill(phi);
     hz->Fill(zip);
     htip->Fill(tip);
+    hquality->Fill(int(qual));
     nTracks++;
   }
   hnTracks->Fill(nTracks);
@@ -112,7 +115,13 @@ void SiPixelPhase1MonitorTrackSoA::bookHistograms(DQMStore::IBooker& ibooker,
   heta = ibooker.book1D("eta", ";Track #eta;#entries", 30, -3., 3.);
   hphi = ibooker.book1D("phi", ";Track #phi;#entries", 30, -M_PI, M_PI);
   hz = ibooker.book1D("z", ";Track z;#entries", 30, -30., 30.);
-  htip = ibooker.book1D("tip", "", 100, -0.5, 0.5);
+  htip = ibooker.book1D("tip", ";Track TIP;#entries", 100, -0.5, 0.5);
+  hquality = ibooker.book1D("quality", ";Track Quality;#entries", 7, -0.5, 6.5);
+  uint i = 1;
+  for (const auto& q : pixelTrack::qualityName) {
+    hquality->setBinLabel(i, q, 1);
+    i++;
+  }
 }
 
 void SiPixelPhase1MonitorTrackSoA::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/DQM/SiPixelPhase1Heterogeneous/plugins/SiPixelPhase1MonitorTrackSoA.cc
+++ b/DQM/SiPixelPhase1Heterogeneous/plugins/SiPixelPhase1MonitorTrackSoA.cc
@@ -22,6 +22,8 @@
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "CUDADataFormats/Track/interface/PixelTrackHeterogeneous.h"
+// for string manipulations
+#include <fmt/printf.h>
 
 class SiPixelPhase1MonitorTrackSoA : public DQMEDAnalyzer {
 public:
@@ -39,8 +41,14 @@ private:
   MonitorElement* hnTracks;
   MonitorElement* hnLooseAndAboveTracks;
   MonitorElement* hnHits;
+  MonitorElement* hnHitsVsPhi;
+  MonitorElement* hnHitsVsEta;
   MonitorElement* hnLayers;
+  MonitorElement* hnLayersVsPhi;
+  MonitorElement* hnLayersVsEta;
   MonitorElement* hchi2;
+  MonitorElement* hChi2VsPhi;
+  MonitorElement* hChi2VsEta;
   MonitorElement* hpt;
   MonitorElement* heta;
   MonitorElement* hphi;
@@ -101,8 +109,14 @@ void SiPixelPhase1MonitorTrackSoA::analyze(const edm::Event& iEvent, const edm::
     float tip = tsoa.tip(it);
 
     hchi2->Fill(chi2);
+    hChi2VsPhi->Fill(phi, chi2);
+    hChi2VsEta->Fill(eta, chi2);
     hnHits->Fill(nHits);
     hnLayers->Fill(nLayers);
+    hnHitsVsPhi->Fill(phi, nHits);
+    hnHitsVsEta->Fill(eta, nHits);
+    hnLayersVsPhi->Fill(phi, nLayers);
+    hnLayersVsEta->Fill(eta, nLayers);
     hpt->Fill(pt);
     heta->Fill(eta);
     hphi->Fill(phi);
@@ -117,23 +131,39 @@ void SiPixelPhase1MonitorTrackSoA::analyze(const edm::Event& iEvent, const edm::
 //
 // -- Book Histograms
 //
-void SiPixelPhase1MonitorTrackSoA::bookHistograms(DQMStore::IBooker& ibooker,
+void SiPixelPhase1MonitorTrackSoA::bookHistograms(DQMStore::IBooker& iBook,
                                                   edm::Run const& iRun,
                                                   edm::EventSetup const& iSetup) {
-  ibooker.cd();
-  ibooker.setCurrentFolder(topFolderName_);
-  hnTracks = ibooker.book1D("nTracks", ";Number of tracks per event;#entries", 1001, -0.5, 1000.5);
-  hnLooseAndAboveTracks = ibooker.book1D(
-      "nLooseAndAboveTracks", ";Number of tracks (quality #geq loose) per event;#entries", 1001, -0.5, 1000.5);
-  hnHits = ibooker.book1D("nRecHits", ";Number of all RecHits per track (quality #geq loose);#entries", 15, -0.5, 14.5);
-  hnLayers = ibooker.book1D("nLayers", ";Number of all layers per track (quality #geq loose);#entries", 15, -0.5, 14.5);
-  hchi2 = ibooker.book1D("nChi2ndof", ";Track (quality #geq loose) chi-squared over ndof;#entries", 40, 0., 20.);
-  hpt = ibooker.book1D("pt", ";Track (quality #geq loose) p_{T} [GeV];#entries", 200, 0., 200.);
-  heta = ibooker.book1D("eta", ";Track (quality #geq loose) #eta;#entries", 30, -3., 3.);
-  hphi = ibooker.book1D("phi", ";Track (quality #geq loose) #phi;#entries", 30, -M_PI, M_PI);
-  hz = ibooker.book1D("z", ";Track (quality #geq loose) z [cm];#entries", 30, -30., 30.);
-  htip = ibooker.book1D("tip", ";Track (quality #geq loose) TIP [cm];#entries", 100, -0.5, 0.5);
-  hquality = ibooker.book1D("quality", ";Track Quality;#entries", 7, -0.5, 6.5);
+  iBook.cd();
+  iBook.setCurrentFolder(topFolderName_);
+
+  // clang-format off
+  std::string toRep = "Number of tracks";
+  hnTracks = iBook.book1D("nTracks", fmt::sprintf(";%s per event;#events",toRep), 1001, -0.5, 1000.5);
+  hnLooseAndAboveTracks = iBook.book1D("nLooseAndAboveTracks", fmt::sprintf(";%s (quality #geq loose) per event;#events",toRep), 1001, -0.5, 1000.5);
+
+  toRep = "Number of all RecHits per track (quality #geq loose)";
+  hnHits = iBook.book1D("nRecHits", fmt::sprintf(";%s;#tracks",toRep), 15, -0.5, 14.5);
+  hnHitsVsPhi = iBook.bookProfile("nHitsPerTrackVsPhi", fmt::sprintf("%s vs track #eta;Track #eta;%s",toRep,toRep), 30, -3., 3., 0., 15.);
+  hnHitsVsEta = iBook.bookProfile("nHitsPerTrackVsEta", fmt::sprintf("%s vs track #phi;Track #phi;%s",toRep,toRep), 30,-M_PI,-M_PI,0.,15.);
+
+  toRep = "Number of all layers per track (quality #geq loose)";
+  hnLayers = iBook.book1D("nLayers", fmt::sprintf(";%s;#tracks",toRep), 15, -0.5, 14.5);
+  hnLayersVsPhi = iBook.bookProfile("nLayersPerTrackVsPhi", fmt::sprintf("%s vs track #eta;Track #eta;%s",toRep,toRep), 30, -3., 3., 0., 15.);
+  hnLayersVsEta = iBook.bookProfile("nLayersPerTrackVsEta", fmt::sprintf("%s vs track #phi;Track #phi;%s",toRep,toRep), 30,-M_PI,-M_PI,0.,15.);
+
+  toRep = "Track (quality #geq loose) #chi^{2}/ndof";
+  hchi2 = iBook.book1D("nChi2ndof", fmt::sprintf(";%s;#tracks",toRep), 40, 0., 20.);
+  hChi2VsPhi = iBook.bookProfile("nChi2ndofVsPhi", fmt::sprintf("%s vs track #eta;Track #eta;%s",toRep,toRep), 30, -3., 3., 0., 20.);
+  hChi2VsEta = iBook.bookProfile("nChi2ndofVsEta", fmt::sprintf("%s vs track #phi;Track #phi;%s",toRep,toRep), 30, -M_PI, -M_PI, 0., 20.);
+  // clang-format on
+
+  hpt = iBook.book1D("pt", ";Track (quality #geq loose) p_{T} [GeV];#tracks", 200, 0., 200.);
+  heta = iBook.book1D("eta", ";Track (quality #geq loose) #eta;#tracks", 30, -3., 3.);
+  hphi = iBook.book1D("phi", ";Track (quality #geq loose) #phi;#tracks", 30, -M_PI, M_PI);
+  hz = iBook.book1D("z", ";Track (quality #geq loose) z [cm];#tracks", 30, -30., 30.);
+  htip = iBook.book1D("tip", ";Track (quality #geq loose) TIP [cm];#tracks", 100, -0.5, 0.5);
+  hquality = iBook.book1D("quality", ";Track Quality;#tracks", 7, -0.5, 6.5);
   uint i = 1;
   for (const auto& q : pixelTrack::qualityName) {
     hquality->setBinLabel(i, q, 1);

--- a/DQM/SiPixelPhase1Heterogeneous/plugins/SiPixelPhase1MonitorTrackSoA.cc
+++ b/DQM/SiPixelPhase1Heterogeneous/plugins/SiPixelPhase1MonitorTrackSoA.cc
@@ -39,6 +39,7 @@ private:
   MonitorElement* hnTracks;
   MonitorElement* hnLooseAndAboveTracks;
   MonitorElement* hnHits;
+  MonitorElement* hnLayers;
   MonitorElement* hchi2;
   MonitorElement* hpt;
   MonitorElement* heta;
@@ -77,6 +78,7 @@ void SiPixelPhase1MonitorTrackSoA::analyze(const edm::Event& iEvent, const edm::
 
   for (int32_t it = 0; it < maxTracks; ++it) {
     auto nHits = tsoa.nHits(it);
+    auto nLayers = tsoa.nLayers(it);
     if (nHits == 0)
       break;  // this is a guard
     float pt = tsoa.pt(it);
@@ -97,8 +99,10 @@ void SiPixelPhase1MonitorTrackSoA::analyze(const edm::Event& iEvent, const edm::
     float zip = tsoa.zip(it);
     float eta = tsoa.eta(it);
     float tip = tsoa.tip(it);
+
     hchi2->Fill(chi2);
     hnHits->Fill(nHits);
+    hnLayers->Fill(nLayers);
     hpt->Fill(pt);
     heta->Fill(eta);
     hphi->Fill(phi);
@@ -122,6 +126,7 @@ void SiPixelPhase1MonitorTrackSoA::bookHistograms(DQMStore::IBooker& ibooker,
   hnLooseAndAboveTracks = ibooker.book1D(
       "nLooseAndAboveTracks", ";Number of tracks (quality #geq loose) per event;#entries", 1001, -0.5, 1000.5);
   hnHits = ibooker.book1D("nRecHits", ";Number of all RecHits per track (quality #geq loose);#entries", 15, -0.5, 14.5);
+  hnLayers = ibooker.book1D("nLayers", ";Number of all layers per track (quality #geq loose);#entries", 15, -0.5, 14.5);
   hchi2 = ibooker.book1D("nChi2ndof", ";Track (quality #geq loose) chi-squared over ndof;#entries", 40, 0., 20.);
   hpt = ibooker.book1D("pt", ";Track (quality #geq loose) p_{T} [GeV];#entries", 200, 0., 200.);
   heta = ibooker.book1D("eta", ";Track (quality #geq loose) #eta;#entries", 30, -3., 3.);


### PR DESCRIPTION
#### PR description:

This is a combined backport of https://github.com/cms-sw/cmssw/pull/36392 and https://github.com/cms-sw/cmssw/pull/36432.
Restructuring SiPixelPhase1MonitorTrackSoA to use the pixel track quality information, number of layers and profiles of # hits, # layers and chi2 vs track eta/phi;.
   * 9458a7bccc77ed380aef1a794aaf057efe83492f : adds PixelTrack quality monitoring to SiPixelPhase1MonitorTrackSoA
   * b3de8efbac7a5a0b05459c8478ac93a6ac891b33 : SiPixelPhase1MonitorTrackSoA: restructure PixelTrack monitoring to filter for loose and above track quality
   * 81258c8210c91fdf6e3c3f530a080b439ab745dc : adds n. layers histogram to `SiPixelPhase1MonitorTrackSoA` (as suggested at https://github.com/cms-sw/cmssw/pull/36392#issuecomment-988678177);
   * 32c3b356b1a4b369873d63078cd599a06f5d462f : adds profiles of # hits, # layers and chi2 vs track eta/phi;
   
#### PR validation:

Run `runTheMatrix.py --what gpu -l 11634.506` on a `lxplus-gpu` node.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This backport is needed for eventual submission of large scale RelVals for GPU vs CPU reconstruction checks in this cycle.
