### PR TITLE
Remove test of h5py_cache

### DIFF
--- a/PhysicsTools/PythonAnalysis/test/BuildFile.xml
+++ b/PhysicsTools/PythonAnalysis/test/BuildFile.xml
@@ -137,7 +137,6 @@
 <test name="import-werkzeug" command="python3 -c 'import werkzeug'"/>
 <test name="import-widgetsnbextension" command="python3 -c 'import widgetsnbextension'"/>
 <test name="import-xgboost" command="python3 -c 'import xgboost'"/>
-<test name="import-h5py_cache" command="python3 -c 'import h5py_cache'"/>
 <test name="import-google" command="python3 -c 'import google'"/>
 <test name="import-lxml" command="python3 -c 'import lxml'"/>
 <test name="import-bs4" command="python3 -c 'import bs4'"/>


### PR DESCRIPTION
#### PR description:

Remove test of h5py_cache:

> This module is now redundant, because its functionality has now been merged into h5py itself, and is available as of h5py version 2.9.0.

From [package github](https://github.com/moble/h5py_cache)
