### PR TITLE
[12.1.X] `OverlapValidation`: bugfix to `esConsumes` migration

### DIFF
--- a/Alignment/OfflineValidation/plugins/OverlapValidation.cc
+++ b/Alignment/OfflineValidation/plugins/OverlapValidation.cc
@@ -98,7 +98,10 @@ private:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   void endJob() override;
 
-  virtual void analyze(const Trajectory&, const Propagator&, TrackerHitAssociator&, const TrackerTopology* const tTopo);
+  virtual void analyzeTrajectory(const Trajectory&,
+                                 const Propagator&,
+                                 TrackerHitAssociator&,
+                                 const TrackerTopology* const tTopo);
   int layerFromId(const DetId&, const TrackerTopology* const tTopo) const;
 
   // ----------member data ---------------------------
@@ -292,7 +295,7 @@ void OverlapValidation::analyze(const edm::Event& iEvent, const edm::EventSetup&
   //
   // mag field & search tracker
   //
-  const MagneticField* magField_ = &iSetup.getData(magFieldToken_);
+  magField_ = &iSetup.getData(magFieldToken_);
   //
   // propagator
   //
@@ -326,16 +329,16 @@ void OverlapValidation::analyze(const edm::Event& iEvent, const edm::EventSetup&
   // loop over trajectories from refit
   const TrackerTopology* const tTopo = &iSetup.getData(topoToken_);
   for (const auto& trajectory : *trajectoryCollection)
-    analyze(trajectory, propagator, *associator, tTopo);
+    analyzeTrajectory(trajectory, propagator, *associator, tTopo);
 
   run_ = iEvent.id().run();
   event_ = iEvent.id().event();
 }
 
-void OverlapValidation::analyze(const Trajectory& trajectory,
-                                const Propagator& propagator,
-                                TrackerHitAssociator& associator,
-                                const TrackerTopology* const tTopo) {
+void OverlapValidation::analyzeTrajectory(const Trajectory& trajectory,
+                                          const Propagator& propagator,
+                                          TrackerHitAssociator& associator,
+                                          const TrackerTopology* const tTopo) {
   typedef std::pair<const TrajectoryMeasurement*, const TrajectoryMeasurement*> Overlap;
   typedef vector<Overlap> OverlapContainer;
   ++overlapCounts_[0];


### PR DESCRIPTION
backport of  #36449

#### PR description:

During the `esConsumes` migration in PR https://github.com/cms-sw/cmssw/pull/32005 a mistake was introduced in this change ([link](https://github.com/cms-sw/cmssw/commit/27d076dc8f543fde396b40602334d1c9e35bbfc7#diff-29a771cb301454e4ee27a753dd1468f3800d0f300c1bc22a7d747cf757e7d821R289)); in the `OverlapValidation::analyze` scope a new local variable `magField_` was introduced shadowing in its local scope a data-member variable of the same name.
This leads to a segmentation fault when trying to evaluate the magnetic field in https://github.com/cms-sw/cmssw/blob/ce6fe13c72fb82872be930ecaa56abe98fa7291b/TrackingTools/AnalyticalJacobians/src/JacobianLocalToCurvilinear.cc#L13 

I profit of this PR to rename an internal method which had the same name as the framework one (`analyze`) to `analyzeTrajectory`.

#### PR validation:

Privately run the changed branch the following configuration file https://gist.github.com/mmusich/6ef7df0b448d7eab47095e5e86ce5299 (in the scope of the mkFit validation setup).

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of  #36449.