### PR TITLE
Use correct accessors for RegionalMuonShower data type

### DIFF
--- a/DQM/L1TMonitor/src/L1TdeStage2Shower.cc
+++ b/DQM/L1TMonitor/src/L1TdeStage2Shower.cc
@@ -57,10 +57,13 @@ void L1TdeStage2Shower::analyze(const edm::Event& e, const edm::EventSetup& c) {
 
   for (auto dSh = dataShowers->begin(); dSh != dataShowers->end(); ++dSh) {
     if (dSh->isValid()) {
-      emtfShowerDataSummary_denom_->Fill(dSh->sector(), (dSh->endcap() == 1) ? 1.5 : 0.5);
+      emtfShowerDataSummary_denom_->Fill(dSh->processor() + 1,
+                                         (dSh->trackFinderType() == l1t::tftype::emtf_pos) ? 1.5 : 0.5);
       for (auto eSh = emulShowers->begin(); eSh != emulShowers->end(); ++eSh) {
-        if (eSh->isValid() and dSh->sector() == eSh->sector() and dSh->endcap() == eSh->endcap() and *dSh == *eSh)
-          emtfShowerDataSummary_num_->Fill(dSh->sector(), (dSh->endcap() == 1) ? 1.5 : 0.5);
+        if (eSh->isValid() and dSh->processor() == eSh->processor() and
+            dSh->trackFinderType() == eSh->trackFinderType() and *dSh == *eSh)
+          emtfShowerDataSummary_num_->Fill(dSh->processor() + 1,
+                                           (dSh->trackFinderType() == l1t::tftype::emtf_pos) ? 1.5 : 0.5);
       }
     }
   }
@@ -68,13 +71,16 @@ void L1TdeStage2Shower::analyze(const edm::Event& e, const edm::EventSetup& c) {
   for (auto eSh = emulShowers->begin(); eSh != emulShowers->end(); ++eSh) {
     bool isMatched = false;
     if (eSh->isValid()) {
-      emtfShowerEmulSummary_denom_->Fill(eSh->sector(), (eSh->endcap() == 1) ? 1.5 : 0.5);
+      emtfShowerEmulSummary_denom_->Fill(eSh->processor() + 1,
+                                         (eSh->trackFinderType() == l1t::tftype::emtf_pos) ? 1.5 : 0.5);
       for (auto dSh = dataShowers->begin(); dSh != dataShowers->end(); ++dSh) {
-        if (dSh->isValid() and eSh->sector() == dSh->sector() and eSh->endcap() == dSh->endcap() and *dSh == *eSh)
+        if (dSh->isValid() and eSh->processor() == dSh->processor() and
+            eSh->trackFinderType() == dSh->trackFinderType() and *dSh == *eSh)
           isMatched = true;
       }
       if (not isMatched) {
-        emtfShowerEmulSummary_num_->Fill(eSh->sector(), (eSh->endcap() == 1) ? 1.5 : 0.5);
+        emtfShowerEmulSummary_num_->Fill(eSh->processor() + 1,
+                                         (eSh->trackFinderType() == l1t::tftype::emtf_pos) ? 1.5 : 0.5);
       }
     }
   }

--- a/DataFormats/L1TMuon/interface/RegionalMuonShower.h
+++ b/DataFormats/L1TMuon/interface/RegionalMuonShower.h
@@ -51,9 +51,6 @@ namespace l1t {
     /// Get track-finder which found the muon (bmtf, emtf_pos/emtf_neg or omtf_pos/omtf_neg)
     const tftype trackFinderType() const { return trackFinder_; };
 
-    int endcap() const { return trackFinderType() == l1t::tftype::emtf_pos ? 1 : -1; }
-    int sector() const { return processor() + 1; }
-
     bool operator==(const l1t::RegionalMuonShower& rhs) const;
     inline bool operator!=(const l1t::RegionalMuonShower& rhs) const { return !(operator==(rhs)); };
 

--- a/L1Trigger/L1TNtuples/src/L1AnalysisL1UpgradeTfMuonShower.cc
+++ b/L1Trigger/L1TNtuples/src/L1AnalysisL1UpgradeTfMuonShower.cc
@@ -12,8 +12,8 @@ void L1Analysis::L1AnalysisL1UpgradeTfMuonShower::SetTfMuonShower(const l1t::Reg
          ++it) {
       if (it->isValid()) {
         l1upgradetfmuonshower_.tfMuonShowerBx.push_back(ibx);
-        l1upgradetfmuonshower_.tfMuonShowerEndcap.push_back(it->endcap());
-        l1upgradetfmuonshower_.tfMuonShowerSector.push_back(it->sector());
+        l1upgradetfmuonshower_.tfMuonShowerEndcap.push_back(it->trackFinderType() == l1t::tftype::emtf_pos ? 1 : -1);
+        l1upgradetfmuonshower_.tfMuonShowerSector.push_back(it->processor() + 1);
         l1upgradetfmuonshower_.tfMuonShowerOneNominal.push_back(it->isOneNominalInTime());
         l1upgradetfmuonshower_.tfMuonShowerOneTight.push_back(it->isOneTightInTime());
         l1upgradetfmuonshower_.tfMuonShowerTwoLoose.push_back(it->isTwoLooseInTime());


### PR DESCRIPTION
#### PR description:

This is a cleanup PR after #36435 was used to fix #36433. Here I remove the (re)added accessors and modify both the DQM and L1TNtuple code that still used them. There should be no functional difference.

#### PR validation:

Ran `scram build code-checks && scram build code-format`, but skipped `runTheMatrix.py -l limited -i all --ibeos` as the code change is minor.
