### PR TITLE
add `fillDescriptions` to `CkfTrackCandidateMaker` (and its dependencies)

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -151,9 +151,6 @@ def customiseFor36459(process):
         for aPar in ['SimpleMagneticField', 'TrajectoryBuilder']:
             if hasattr(iMod, aPar): delattr(iMod, aPar)
 
-        if not hasattr(iMod, 'maxSeedsBeforeCleaning'):
-            iMod.maxSeedsBeforeCleaning = cms.uint32(0)
-
         # convert onlyPixelHitsForSeedCleaner to tracked bool
         if hasattr(iMod, 'onlyPixelHitsForSeedCleaner'):
             theMod = getattr(iMod, 'onlyPixelHitsForSeedCleaner')

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -143,15 +143,75 @@ def customiseFor2018Input(process):
 
     return process
 
+def customiseFor36459(process):
+    """Update the HLT configuration for the changes in #36459:
+    add fillDescriptions to CkfTrackCandidateMaker (and its dependencies)
+    """
+    for iMod in producers_by_type(process, 'CkfTrackCandidateMaker'):
+        for aPar in ['SimpleMagneticField', 'TrajectoryBuilder']:
+            if hasattr(iMod, aPar): delattr(iMod, aPar)
+
+        if not hasattr(iMod, 'maxSeedsBeforeCleaning'):
+            iMod.maxSeedsBeforeCleaning = cms.uint32(0)
+
+        # convert onlyPixelHitsForSeedCleaner to tracked bool
+        if hasattr(iMod, 'onlyPixelHitsForSeedCleaner'):
+            theMod = getattr(iMod, 'onlyPixelHitsForSeedCleaner')
+            if not theMod.isTracked():
+                setattr(iMod, 'onlyPixelHitsForSeedCleaner', cms.bool(theMod.value()))
+
+        # convert numHitsForSeedCleaner to tracked int32
+        if hasattr(iMod, 'numHitsForSeedCleaner'):
+            theMod = getattr(iMod, 'numHitsForSeedCleaner')
+            if not theMod.isTracked():
+                setattr(iMod, 'numHitsForSeedCleaner', cms.int32(theMod.value()))
+
+        # convert clustersToSkip to tracked InputTag
+        if hasattr(iMod, 'clustersToSkip'):
+            theMod = getattr(iMod, 'clustersToSkip')
+            if not theMod.isTracked():
+                setattr(iMod, 'clustersToSkip', cms.InputTag(theMod.value()))
+
+    for iMod in producers_by_type(process, 'CkfTrajectoryMaker'):
+        for aPar in ['TrajectoryBuilder']:
+            if hasattr(iMod, aPar):
+                delattr(iMod, aPar)
+
+    for aPSet in process._Process__psets.values():
+        if hasattr(aPSet, 'ComponentType') and aPSet.ComponentType in ['CkfTrajectoryBuilder', 'GroupedCkfTrajectoryBuilder', 'MuonCkfTrajectoryBuilder']:
+            for aPar in ['MeasurementTrackerName', 'cleanTrajectoryAfterInOut', 'doSeedingRegionRebuilding', 'useHitsSplitting']:
+               if hasattr(aPSet, aPar):
+                   delattr(aPSet, aPar)
+
+            if aPSet.ComponentType == 'GroupedCkfTrajectoryBuilder' and aPSet.useSameTrajFilter:
+                if not hasattr(aPSet, 'inOutTrajectoryFilter'):
+                    aPSet.inOutTrajectoryFilter = aPSet.trajectoryFilter.clone()
+
+            if aPSet.ComponentType == 'CkfTrajectoryBuilder' and hasattr(aPSet, 'minNrOfHitsForRebuild'):
+                delattr(aPSet, 'minNrOfHitsForRebuild')
+
+            if aPSet.ComponentType != 'GroupedCkfTrajectoryBuilder' and hasattr(aPSet, 'useSameTrajFilter'):
+                delattr(aPSet, 'useSameTrajFilter')
+
+    for iProdName in ['SeedCreatorFromRegionConsecutiveHitsEDProducer', 'SeedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer']:
+        for iMod in producers_by_type(process, iProdName):
+            if hasattr(iMod, 'SeedComparitorPSet') and hasattr(iMod.SeedComparitorPSet, 'comparitors'):
+                for pSetIdx in range(len(iMod.SeedComparitorPSet.comparitors)):
+                    if iMod.SeedComparitorPSet.comparitors[pSetIdx].ComponentName == 'StripSubClusterShapeSeedFilter':
+                        if not hasattr(iMod.SeedComparitorPSet.comparitors[pSetIdx], 'layerMask'):
+                            iMod.SeedComparitorPSet.comparitors[pSetIdx].layerMask = cms.PSet()
+
+    return process
 
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
-    
+
     # if the gpu modifier is enabled, make the Pixel, ECAL and HCAL reconstruction offloadable to a GPU
     from HLTrigger.Configuration.customizeHLTforPatatrack import customizeHLTforPatatrack
     gpu.makeProcessModifier(customizeHLTforPatatrack).apply(process)
 
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
+    process = customiseFor36459(process)
 
     return process

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonDetachedTripletStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonDetachedTripletStep_cff.py
@@ -82,8 +82,7 @@ hiRegitMuDetachedTripletStepTrajectoryBuilder = RecoTracker.IterativeTracking.De
 
 hiRegitMuDetachedTripletStepTrackCandidates = RecoTracker.IterativeTracking.DetachedTripletStep_cff._detachedTripletStepTrackCandidatesCkf.clone(
     src               = 'hiRegitMuDetachedTripletStepSeeds',
-    TrajectoryBuilder = 'hiRegitMuDetachedTripletStepTrajectoryBuilder',
-    clustersToSkip    = cms.InputTag("hiRegitMuDetachedTripletStepClusters")
+    clustersToSkip    = 'hiRegitMuDetachedTripletStepClusters'
 )
 
 # fitting: feed new-names

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelPairStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelPairStep_cff.py
@@ -79,7 +79,6 @@ hiRegitMuPixelPairStepTrajectoryBuilder = RecoTracker.IterativeTracking.PixelPai
 # trackign candidate
 hiRegitMuPixelPairStepTrackCandidates = RecoTracker.IterativeTracking.PixelPairStep_cff._pixelPairStepTrackCandidatesCkf.clone(
     src               = 'hiRegitMuPixelPairStepSeeds',
-    TrajectoryBuilder = 'hiRegitMuPixelPairStepTrajectoryBuilder',
     clustersToSkip    = "hiRegitMuPixelPairStepClusters",
     maxNSeeds         = 1000000
 )

--- a/RecoHI/HiTracking/python/hiDetachedQuadStep_cff.py
+++ b/RecoHI/HiTracking/python/hiDetachedQuadStep_cff.py
@@ -123,7 +123,6 @@ hiDetachedQuadStepChi2Est = TrackingTools.KalmanUpdators.Chi2MeasurementEstimato
 # TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 hiDetachedQuadStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
-    MeasurementTrackerName = '',
     trajectoryFilter = dict(refToPSet_ = 'hiDetachedQuadStepTrajectoryFilter'),
     maxCand = 4,#4 for pp
     estimator = 'hiDetachedQuadStepChi2Est',
@@ -142,11 +141,10 @@ import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 hiDetachedQuadStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
     src = 'hiDetachedQuadStepSeeds',
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
-    numHitsForSeedCleaner = cms.int32(50),
-    onlyPixelHitsForSeedCleaner = cms.bool(True),
+    numHitsForSeedCleaner = 50,
+    onlyPixelHitsForSeedCleaner = True,
     TrajectoryBuilderPSet = dict(refToPSet_ = 'hiDetachedQuadStepTrajectoryBuilder'),
-    TrajectoryBuilder = 'hiDetachedQuadStepTrajectoryBuilder',
-    clustersToSkip = cms.InputTag('hiDetachedQuadStepClusters'),
+    clustersToSkip = 'hiDetachedQuadStepClusters',
     doSeedingRegionRebuilding = True,
     useHitsSplitting = True
 )

--- a/RecoHI/HiTracking/python/hiDetachedTripletStep_cff.py
+++ b/RecoHI/HiTracking/python/hiDetachedTripletStep_cff.py
@@ -144,7 +144,6 @@ hiDetachedTripletStepChi2Est = TrackingTools.KalmanUpdators.Chi2MeasurementEstim
 # TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 hiDetachedTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
-    MeasurementTrackerName = '',
     trajectoryFilter = dict(refToPSet_ = 'hiDetachedTripletStepTrajectoryFilter'),
     maxCand = 2,
     estimator = 'hiDetachedTripletStepChi2Est',
@@ -161,8 +160,7 @@ hiDetachedTripletStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates
     numHitsForSeedCleaner = cms.int32(50),
     onlyPixelHitsForSeedCleaner = cms.bool(True),
     TrajectoryBuilderPSet = dict(refToPSet_ = 'hiDetachedTripletStepTrajectoryBuilder'),
-    TrajectoryBuilder = 'hiDetachedTripletStepTrajectoryBuilder',
-    clustersToSkip = cms.InputTag('hiDetachedTripletStepClusters'),
+    clustersToSkip = 'hiDetachedTripletStepClusters',
     doSeedingRegionRebuilding = True,
     useHitsSplitting = True
 )

--- a/RecoHI/HiTracking/python/hiHighPtTripletStep_cff.py
+++ b/RecoHI/HiTracking/python/hiHighPtTripletStep_cff.py
@@ -122,7 +122,6 @@ hiHighPtTripletStepChi2Est = TrackingTools.KalmanUpdators.Chi2MeasurementEstimat
 # TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 hiHighPtTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
-    MeasurementTrackerName = '',
     trajectoryFilter = dict(refToPSet_ = 'hiHighPtTripletStepTrajectoryFilter'),
     maxCand = 3,#3 for pp
     estimator = 'hiHighPtTripletStepChi2Est',
@@ -141,11 +140,10 @@ import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 hiHighPtTripletStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
     src = 'hiHighPtTripletStepSeeds',
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
-    numHitsForSeedCleaner = cms.int32(50),
-    onlyPixelHitsForSeedCleaner = cms.bool(True),
+    numHitsForSeedCleaner = 50,
+    onlyPixelHitsForSeedCleaner = True,
     TrajectoryBuilderPSet = dict(refToPSet_ = 'hiHighPtTripletStepTrajectoryBuilder'),
-    TrajectoryBuilder = 'hiHighPtTripletStepTrajectoryBuilder',
-    clustersToSkip = cms.InputTag('hiHighPtTripletStepClusters'),
+    clustersToSkip = 'hiHighPtTripletStepClusters',
     doSeedingRegionRebuilding = True,
     useHitsSplitting = True
 )

--- a/RecoHI/HiTracking/python/hiJetCoreRegionalStep_cff.py
+++ b/RecoHI/HiTracking/python/hiJetCoreRegionalStep_cff.py
@@ -122,7 +122,6 @@ hiJetCoreRegionalStepChi2Est = TrackingTools.KalmanUpdators.Chi2MeasurementEstim
 # TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 hiJetCoreRegionalStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
-    MeasurementTrackerName = '',
     trajectoryFilter = dict(refToPSet_ = 'hiJetCoreRegionalStepTrajectoryFilter'),
     maxCand = 50,
     estimator = 'hiJetCoreRegionalStepChi2Est',

--- a/RecoHI/HiTracking/python/hiLowPtQuadStep_cff.py
+++ b/RecoHI/HiTracking/python/hiLowPtQuadStep_cff.py
@@ -126,7 +126,6 @@ hiLowPtQuadStepChi2Est = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_c
 # TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 hiLowPtQuadStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
-    MeasurementTrackerName = '',
     trajectoryFilter = dict(refToPSet_ = 'hiLowPtQuadStepTrajectoryFilter'),
     maxCand = 4,#4 for pp
     estimator = 'hiLowPtQuadStepChi2Est',
@@ -145,11 +144,10 @@ import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 hiLowPtQuadStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
     src = 'hiLowPtQuadStepSeeds',
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
-    numHitsForSeedCleaner = cms.int32(50),
-    onlyPixelHitsForSeedCleaner = cms.bool(True),
+    numHitsForSeedCleaner = 50,
+    onlyPixelHitsForSeedCleaner = True,
     TrajectoryBuilderPSet = dict(refToPSet_ = 'hiLowPtQuadStepTrajectoryBuilder'),
-    TrajectoryBuilder = 'hiLowPtQuadStepTrajectoryBuilder',
-    clustersToSkip = cms.InputTag('hiLowPtQuadStepClusters'),
+    clustersToSkip = 'hiLowPtQuadStepClusters',
     doSeedingRegionRebuilding = True,
     useHitsSplitting = True
 )

--- a/RecoHI/HiTracking/python/hiLowPtTripletStep_cff.py
+++ b/RecoHI/HiTracking/python/hiLowPtTripletStep_cff.py
@@ -136,7 +136,6 @@ hiLowPtTripletStepChi2Est = TrackingTools.KalmanUpdators.Chi2MeasurementEstimato
 # TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 hiLowPtTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
-    MeasurementTrackerName = '',
     trajectoryFilter = dict(refToPSet_ = 'hiLowPtTripletStepTrajectoryFilter'),
     maxCand = 3,
     estimator = 'hiLowPtTripletStepChi2Est',
@@ -151,10 +150,10 @@ import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 hiLowPtTripletStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
     src = 'hiLowPtTripletStepSeeds',
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
-    numHitsForSeedCleaner = cms.int32(50),
-    onlyPixelHitsForSeedCleaner = cms.bool(True),
+    numHitsForSeedCleaner = 50,
+    onlyPixelHitsForSeedCleaner = True,
     TrajectoryBuilderPSet = dict(refToPSet_ = 'hiLowPtTripletStepTrajectoryBuilder'),
-    clustersToSkip = cms.InputTag('hiLowPtTripletStepClusters'),
+    clustersToSkip = 'hiLowPtTripletStepClusters',
     doSeedingRegionRebuilding = True,
     useHitsSplitting = True
 )

--- a/RecoHI/HiTracking/python/hiPixelPairStep_cff.py
+++ b/RecoHI/HiTracking/python/hiPixelPairStep_cff.py
@@ -137,7 +137,6 @@ hiPixelPairChi2Est = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.C
 # TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 hiPixelPairTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
-    MeasurementTrackerName = '',
     trajectoryFilter = dict(refToPSet_ = 'hiPixelPairTrajectoryFilter'),
     maxCand = 3,
     estimator = 'hiPixelPairChi2Est',
@@ -149,11 +148,11 @@ hiPixelPairTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilde
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 hiPixelPairTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
     src = 'hiPixelPairSeeds',
-    clustersToSkip = cms.InputTag('hiPixelPairClusters'),
+    clustersToSkip = 'hiPixelPairClusters',
     TrajectoryBuilderPSet = dict(refToPSet_ = 'hiPixelPairTrajectoryBuilder'),
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
-    numHitsForSeedCleaner = cms.int32(50),
-    onlyPixelHitsForSeedCleaner = cms.bool(True),
+    numHitsForSeedCleaner = 50,
+    onlyPixelHitsForSeedCleaner = True,
 )
 trackingPhase1.toModify(hiPixelPairTrackCandidates,
     src = 'hiPixelPairStepSeedsPhase1'

--- a/RecoHI/HiTracking/python/hiRegitDetachedTripletStep_cff.py
+++ b/RecoHI/HiTracking/python/hiRegitDetachedTripletStep_cff.py
@@ -52,8 +52,8 @@ hiRegitDetachedTripletStepSeeds     = RecoTracker.IterativeTracking.DetachedTrip
 # building: feed the new-named seeds
 hiRegitDetachedTripletStepTrajectoryFilter = RecoTracker.IterativeTracking.DetachedTripletStep_cff.detachedTripletStepTrajectoryFilterBase.clone()
 hiRegitDetachedTripletStepTrajectoryBuilder = RecoTracker.IterativeTracking.DetachedTripletStep_cff.detachedTripletStepTrajectoryBuilder.clone(
-    trajectoryFilter     = cms.PSet(refToPSet_ = cms.string('hiRegitDetachedTripletStepTrajectoryFilter')),
-    clustersToSkip       = cms.InputTag('hiRegitDetachedTripletStepClusters')
+    trajectoryFilter     = dict(refToPSet_ = 'hiRegitDetachedTripletStepTrajectoryFilter'),
+    clustersToSkip       = 'hiRegitDetachedTripletStepClusters'
 )
 
 hiRegitDetachedTripletStepTrackCandidates        =  RecoTracker.IterativeTracking.DetachedTripletStep_cff._detachedTripletStepTrackCandidatesCkf.clone(

--- a/RecoHI/HiTracking/python/hiRegitInitialStep_cff.py
+++ b/RecoHI/HiTracking/python/hiRegitInitialStep_cff.py
@@ -46,8 +46,8 @@ hiRegitInitialStepTrajectoryFilter = RecoTracker.IterativeTracking.InitialStep_c
 
 
 hiRegitInitialStepTrajectoryBuilder = RecoTracker.IterativeTracking.InitialStep_cff.initialStepTrajectoryBuilder.clone(
-    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('hiRegitInitialStepTrajectoryFilter')),
-    clustersToSkip = cms.InputTag('hiRegitInitialStepClusters')
+    trajectoryFilter = dict(refToPSet_ = 'hiRegitInitialStepTrajectoryFilter'),
+    clustersToSkip = 'hiRegitInitialStepClusters'
 )
 
 # track candidates

--- a/RecoHI/HiTracking/python/hiRegitLowPtTripletStep_cff.py
+++ b/RecoHI/HiTracking/python/hiRegitLowPtTripletStep_cff.py
@@ -56,8 +56,8 @@ hiRegitLowPtTripletStepTrajectoryFilter = RecoTracker.IterativeTracking.LowPtTri
 
 
 hiRegitLowPtTripletStepTrajectoryBuilder = RecoTracker.IterativeTracking.LowPtTripletStep_cff.lowPtTripletStepTrajectoryBuilder.clone(
-    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('hiRegitLowPtTripletStepTrajectoryFilter')),
-    clustersToSkip = cms.InputTag('hiRegitLowPtTripletStepClusters'),
+    trajectoryFilter = dict(refToPSet_ = 'hiRegitLowPtTripletStepTrajectoryFilter'),
+    clustersToSkip = 'hiRegitLowPtTripletStepClusters',
 )
 
 # track candidates

--- a/RecoHI/HiTracking/python/hiRegitMixedTripletStep_cff.py
+++ b/RecoHI/HiTracking/python/hiRegitMixedTripletStep_cff.py
@@ -74,8 +74,8 @@ hiRegitMixedTripletStepSeeds = RecoTracker.IterativeTracking.MixedTripletStep_cf
 hiRegitMixedTripletStepTrajectoryFilter = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepTrajectoryFilter.clone()
 
 hiRegitMixedTripletStepTrajectoryBuilder = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepTrajectoryBuilder.clone(
-    trajectoryFilter     = cms.PSet(refToPSet_ = cms.string('hiRegitMixedTripletStepTrajectoryFilter')),
-    clustersToSkip       = cms.InputTag('hiRegitMixedTripletStepClusters'),
+    trajectoryFilter     = dict(refToPSet_ = 'hiRegitMixedTripletStepTrajectoryFilter'),
+    clustersToSkip       = 'hiRegitMixedTripletStepClusters',
 )
 
 hiRegitMixedTripletStepTrackCandidates        =  RecoTracker.IterativeTracking.MixedTripletStep_cff._mixedTripletStepTrackCandidatesCkf.clone(

--- a/RecoHI/HiTracking/python/hiRegitPixelPairStep_cff.py
+++ b/RecoHI/HiTracking/python/hiRegitPixelPairStep_cff.py
@@ -50,8 +50,8 @@ hiRegitPixelPairStepSeeds     = RecoTracker.IterativeTracking.PixelPairStep_cff.
 hiRegitPixelPairStepTrajectoryFilter = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepTrajectoryFilterBase.clone()
 
 hiRegitPixelPairStepTrajectoryBuilder = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepTrajectoryBuilder.clone(
-    trajectoryFilter     = cms.PSet(refToPSet_ = cms.string('hiRegitPixelPairStepTrajectoryFilter')),
-    clustersToSkip       = cms.InputTag('hiRegitPixelPairStepClusters'),
+    trajectoryFilter     = dict(refToPSet_ = 'hiRegitPixelPairStepTrajectoryFilter'),
+    clustersToSkip       = 'hiRegitPixelPairStepClusters',
 )
 
 # trackign candidate

--- a/RecoMuon/L3TrackFinder/interface/MuonCkfTrajectoryBuilder.h
+++ b/RecoMuon/L3TrackFinder/interface/MuonCkfTrajectoryBuilder.h
@@ -1,14 +1,18 @@
 #ifndef RecoMuon_L3TrackFinder_MuonCkfTrajectoryBuilder_H
 #define RecoMuon_L3TrackFinder_MuonCkfTrajectoryBuilder_H
 
-#include "RecoTracker/CkfPattern/interface/CkfTrajectoryBuilder.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "RecoTracker/CkfPattern/interface/CkfTrajectoryBuilder.h"
 
 class TrackingComponentsRecord;
+
 class MuonCkfTrajectoryBuilder : public CkfTrajectoryBuilder {
 public:
   MuonCkfTrajectoryBuilder(const edm::ParameterSet& conf, edm::ConsumesCollector& iC);
   ~MuonCkfTrajectoryBuilder() override;
+
+  static void fillPSetDescription(edm::ParameterSetDescription& iDesc);
 
 protected:
   void setEvent_(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;

--- a/RecoMuon/L3TrackFinder/plugins/SealModules.cc
+++ b/RecoMuon/L3TrackFinder/plugins/SealModules.cc
@@ -1,8 +1,9 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ValidatedPluginMacros.h"
 
 #include "RecoMuon/L3TrackFinder/interface/MuonCkfTrajectoryBuilder.h"
 #include "RecoTracker/CkfPattern/interface/BaseCkfTrajectoryBuilderFactory.h"
 #include "RecoMuon/L3TrackFinder/interface/HLTMuonL2SelectorForL3IO.h"
 
-DEFINE_EDM_PLUGIN(BaseCkfTrajectoryBuilderFactory, MuonCkfTrajectoryBuilder, "MuonCkfTrajectoryBuilder");
+DEFINE_EDM_VALIDATED_PLUGIN(BaseCkfTrajectoryBuilderFactory, MuonCkfTrajectoryBuilder, "MuonCkfTrajectoryBuilder");
 DEFINE_FWK_MODULE(HLTMuonL2SelectorForL3IO);

--- a/RecoMuon/L3TrackFinder/python/MuonCkfTrajectoryBuilder_cfi.py
+++ b/RecoMuon/L3TrackFinder/python/MuonCkfTrajectoryBuilder_cfi.py
@@ -8,7 +8,6 @@ MuonCkfTrajectoryBuilder = cms.PSet(
     intermediateCleaning = cms.bool(False),
     #would skip the first layer to search for measurement if bare TrajectorySeed
     useSeedLayer = cms.bool(False),
-    MeasurementTrackerName = cms.string(''),
     estimator = cms.string('Chi2'),
     TTRHBuilder = cms.string('WithTrackAngle'),
     #propagator used only if useSeedLayer=true

--- a/RecoMuon/L3TrackFinder/src/MuonCkfTrajectoryBuilder.cc
+++ b/RecoMuon/L3TrackFinder/src/MuonCkfTrajectoryBuilder.cc
@@ -30,6 +30,15 @@ MuonCkfTrajectoryBuilder::MuonCkfTrajectoryBuilder(const edm::ParameterSet& conf
 
 MuonCkfTrajectoryBuilder::~MuonCkfTrajectoryBuilder() {}
 
+void MuonCkfTrajectoryBuilder::fillPSetDescription(edm::ParameterSetDescription& iDesc) {
+  CkfTrajectoryBuilder::fillPSetDescription(iDesc);
+  iDesc.add<double>("deltaEta", .1);
+  iDesc.add<double>("deltaPhi", .1);
+  iDesc.add<std::string>("propagatorProximity", "SteppingHelixPropagatorAny");
+  iDesc.add<bool>("useSeedLayer", false);
+  iDesc.add<double>("rescaleErrorIfFail", 1.);
+}
+
 void MuonCkfTrajectoryBuilder::setEvent_(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   CkfTrajectoryBuilder::setEvent_(iEvent, iSetup);
 

--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeTrajectoryFilter.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeTrajectoryFilter.h
@@ -1,8 +1,9 @@
 #ifndef _ClusterShapeTrajectoryFilter_h_
 #define _ClusterShapeTrajectoryFilter_h_
 
-#include "TrackingTools/TrajectoryFiltering/interface/TrajectoryFilter.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
+#include "TrackingTools/TrajectoryFiltering/interface/TrajectoryFilter.h"
 
 namespace edm {
   class ParameterSet;
@@ -21,8 +22,9 @@ class SiPixelClusterShapeCache;
 class ClusterShapeTrajectoryFilter : public TrajectoryFilter {
 public:
   ClusterShapeTrajectoryFilter(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC);
-
   ~ClusterShapeTrajectoryFilter() override;
+
+  static void fillPSetDescription(edm::ParameterSetDescription& iDesc);
 
   void setEvent(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 

--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/StripSubClusterShapeTrajectoryFilter.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/StripSubClusterShapeTrajectoryFilter.h
@@ -7,6 +7,7 @@
 #include "RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "RecoTracker/TkSeedingLayers/interface/SeedComparitor.h"
 #include "CondFormats/SiStripObjects/interface/SiStripNoises.h"
@@ -32,6 +33,8 @@ class StripSubClusterShapeFilterBase {
 public:
   StripSubClusterShapeFilterBase(const edm::ParameterSet &iConfig, edm::ConsumesCollector &iC);
   virtual ~StripSubClusterShapeFilterBase();
+
+  static void fillPSetDescription(edm::ParameterSetDescription &iDesc);
 
 protected:
   void setEventBase(const edm::Event &, const edm::EventSetup &);
@@ -85,6 +88,10 @@ public:
       : StripSubClusterShapeFilterBase(iConfig, iC) {}
 
   ~StripSubClusterShapeTrajectoryFilter() override {}
+
+  static void fillPSetDescription(edm::ParameterSetDescription &iDesc) {
+    StripSubClusterShapeFilterBase::fillPSetDescription(iDesc);
+  }
 
   bool qualityFilter(const TempTrajectory &) const override;
   bool qualityFilter(const Trajectory &) const override;

--- a/RecoPixelVertexing/PixelLowPtUtilities/plugins/modules.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/plugins/modules.cc
@@ -30,10 +30,11 @@ DEFINE_EDM_PLUGIN(HitTripletGeneratorFromPairAndLayersFactory,
 
 // TrajectoryFilter
 #include "FWCore/Utilities/interface/typelookup.h"
+#include "FWCore/ParameterSet/interface/ValidatedPluginMacros.h"
 
 #include "TrackingTools/TrajectoryFiltering/interface/TrajectoryFilterFactory.h"
 #include "RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeTrajectoryFilter.h"
-DEFINE_EDM_PLUGIN(TrajectoryFilterFactory, ClusterShapeTrajectoryFilter, "ClusterShapeTrajectoryFilter");
+DEFINE_EDM_VALIDATED_PLUGIN(TrajectoryFilterFactory, ClusterShapeTrajectoryFilter, "ClusterShapeTrajectoryFilter");
 
 // the seed comparitor to remove seeds on incompatible angle/cluster compatibility
 #include "RecoPixelVertexing/PixelLowPtUtilities/interface/LowPtClusterShapeSeedComparitor.h"
@@ -41,7 +42,7 @@ DEFINE_EDM_PLUGIN(TrajectoryFilterFactory, ClusterShapeTrajectoryFilter, "Cluste
 DEFINE_EDM_PLUGIN(SeedComparitorFactory, LowPtClusterShapeSeedComparitor, "LowPtClusterShapeSeedComparitor");
 
 #include "RecoPixelVertexing/PixelLowPtUtilities/interface/StripSubClusterShapeTrajectoryFilter.h"
-DEFINE_EDM_PLUGIN(TrajectoryFilterFactory,
-                  StripSubClusterShapeTrajectoryFilter,
-                  "StripSubClusterShapeTrajectoryFilter");
+DEFINE_EDM_VALIDATED_PLUGIN(TrajectoryFilterFactory,
+                            StripSubClusterShapeTrajectoryFilter,
+                            "StripSubClusterShapeTrajectoryFilter");
 DEFINE_EDM_PLUGIN(SeedComparitorFactory, StripSubClusterShapeSeedFilter, "StripSubClusterShapeSeedFilter");

--- a/RecoPixelVertexing/PixelLowPtUtilities/python/StripSubClusterShapeSeedFilter_cfi.py
+++ b/RecoPixelVertexing/PixelLowPtUtilities/python/StripSubClusterShapeSeedFilter_cfi.py
@@ -6,5 +6,5 @@ StripSubClusterShapeSeedFilter = cms.PSet(
     ComponentName = cms.string('StripSubClusterShapeSeedFilter'),
     FilterAtHelixStage = cms.bool(False),
     label = cms.untracked.string("Seeds"),
+    layerMask = cms.PSet()
 )
-

--- a/RecoPixelVertexing/PixelLowPtUtilities/src/ClusterShapeTrajectoryFilter.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/ClusterShapeTrajectoryFilter.cc
@@ -30,9 +30,7 @@
 #include "RecoTracker/Record/interface/CkfComponentsRecord.h"
 
 #include <vector>
-using namespace std;
 
-/*****************************************************************************/
 ClusterShapeTrajectoryFilter::ClusterShapeTrajectoryFilter(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC)
     : theCacheToken(iC.consumes<SiPixelClusterShapeCache>(iConfig.getParameter<edm::InputTag>("cacheSrc"))),
       theFilterToken(iC.esConsumes(edm::ESInputTag("", "ClusterShapeHitFilter"))),
@@ -40,17 +38,20 @@ ClusterShapeTrajectoryFilter::ClusterShapeTrajectoryFilter(const edm::ParameterS
 
 ClusterShapeTrajectoryFilter::~ClusterShapeTrajectoryFilter() {}
 
+void ClusterShapeTrajectoryFilter::fillPSetDescription(edm::ParameterSetDescription& iDesc) {
+  iDesc.add<edm::InputTag>("cacheSrc", edm::InputTag("siPixelClusterShapeCache"));
+}
+
 void ClusterShapeTrajectoryFilter::setEvent(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   theFilter = &iSetup.getData(theFilterToken);
   theCache = &iEvent.get(theCacheToken);
 }
 
-/*****************************************************************************/
 bool ClusterShapeTrajectoryFilter::toBeContinued(Trajectory& trajectory) const {
   assert(theCache);
-  vector<TrajectoryMeasurement> tms = trajectory.measurements();
+  std::vector<TrajectoryMeasurement> tms = trajectory.measurements();
 
-  for (vector<TrajectoryMeasurement>::const_iterator tm = tms.begin(); tm != tms.end(); tm++) {
+  for (std::vector<TrajectoryMeasurement>::const_iterator tm = tms.begin(); tm != tms.end(); tm++) {
     const TrackingRecHit* ttRecHit = &(*((*tm).recHit()));
 
     if (ttRecHit->isValid()) {
@@ -97,7 +98,6 @@ bool ClusterShapeTrajectoryFilter::toBeContinued(Trajectory& trajectory) const {
   return true;
 }
 
-/*****************************************************************************/
 bool ClusterShapeTrajectoryFilter::toBeContinued(TempTrajectory& trajectory) const {
   assert(theCache);
   const TempTrajectory::DataContainer& tms = trajectory.measurements();
@@ -165,10 +165,8 @@ bool ClusterShapeTrajectoryFilter::toBeContinued(TempTrajectory& trajectory) con
   return true;
 }
 
-/*****************************************************************************/
 bool ClusterShapeTrajectoryFilter::qualityFilter(const Trajectory& trajectory) const { return true; }
 
-/*****************************************************************************/
 bool ClusterShapeTrajectoryFilter::qualityFilter(const TempTrajectory& trajectory) const {
   TempTrajectory t = trajectory;
 

--- a/RecoPixelVertexing/PixelLowPtUtilities/src/StripSubClusterShapeTrajectoryFilter.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/StripSubClusterShapeTrajectoryFilter.cc
@@ -130,7 +130,6 @@ namespace {
 
 }  // namespace
 
-/*****************************************************************************/
 StripSubClusterShapeFilterBase::StripSubClusterShapeFilterBase(const edm::ParameterSet &iCfg,
                                                                edm::ConsumesCollector &iC)
     : topoToken_(iC.esConsumes<TrackerTopology, TrackerTopologyRcd>()),
@@ -161,8 +160,8 @@ StripSubClusterShapeFilterBase::StripSubClusterShapeFilterBase(const edm::Parame
       failTooNarrow_(0)
 #endif
 {
-  if (iCfg.exists("layerMask")) {
-    const edm::ParameterSet &iLM = iCfg.getParameter<edm::ParameterSet>("layerMask");
+  const edm::ParameterSet &iLM = iCfg.getParameter<edm::ParameterSet>("layerMask");
+  if (not iLM.empty()) {
     const char *ndets[4] = {"TIB", "TID", "TOB", "TEC"};
     const int idets[4] = {3, 4, 5, 6};
     for (unsigned int i = 0; i < 4; ++i) {
@@ -183,7 +182,6 @@ StripSubClusterShapeFilterBase::StripSubClusterShapeFilterBase(const edm::Parame
   }
 }
 
-/*****************************************************************************/
 StripSubClusterShapeFilterBase::~StripSubClusterShapeFilterBase() {
 #if 0
     std::cout << "StripSubClusterShapeFilterBase " << label_ <<": called        " << called_ << std::endl;
@@ -194,6 +192,25 @@ StripSubClusterShapeFilterBase::~StripSubClusterShapeFilterBase() {
     std::cout << "StripSubClusterShapeFilterBase " << label_ <<": passSC        " << passSC_ << std::endl;
     std::cout << "StripSubClusterShapeFilterBase " << label_ <<": failTooLarge  " << failTooLarge_ << std::endl;
 #endif
+}
+
+void StripSubClusterShapeFilterBase::fillPSetDescription(edm::ParameterSetDescription &iDesc) {
+  iDesc.addUntracked<std::string>("label", "");
+  iDesc.add<uint32_t>("maxNSat", 3);
+  iDesc.add<double>("trimMaxADC", 30.);
+  iDesc.add<double>("trimMaxFracTotal", .15);
+  iDesc.add<double>("trimMaxFracNeigh", .25);
+  iDesc.add<double>("maxTrimmedSizeDiffPos", .7);
+  iDesc.add<double>("maxTrimmedSizeDiffNeg", 1.);
+  iDesc.add<double>("subclusterWindow", .7);
+  iDesc.add<double>("seedCutMIPs", .35);
+  iDesc.add<double>("seedCutSN", 7.);
+  iDesc.add<double>("subclusterCutMIPs", .45);
+  iDesc.add<double>("subclusterCutSN", 12.);
+
+  edm::ParameterSetDescription psdLM;
+  psdLM.setAllowAnything();
+  iDesc.add<edm::ParameterSetDescription>("layerMask", psdLM);
 }
 
 bool StripSubClusterShapeFilterBase::testLastHit(const TrackingRecHit *hit,

--- a/RecoTracker/CkfPattern/interface/BaseCkfTrajectoryBuilder.h
+++ b/RecoTracker/CkfPattern/interface/BaseCkfTrajectoryBuilder.h
@@ -6,6 +6,7 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeed.h"
 
@@ -74,6 +75,8 @@ public:
   BaseCkfTrajectoryBuilder(const BaseCkfTrajectoryBuilder&) = delete;
   BaseCkfTrajectoryBuilder& operator=(const BaseCkfTrajectoryBuilder&) = delete;
   ~BaseCkfTrajectoryBuilder() override;
+
+  static void fillPSetDescription(edm::ParameterSetDescription& iDesc);
 
   // new interface returning the start Trajectory...
   virtual TempTrajectory buildTrajectories(const TrajectorySeed& seed,

--- a/RecoTracker/CkfPattern/interface/CkfTrackCandidateMakerBase.h
+++ b/RecoTracker/CkfPattern/interface/CkfTrackCandidateMakerBase.h
@@ -6,6 +6,8 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
 #include "TrackingTools/PatternTools/interface/TrajectoryBuilder.h"
 #include "RecoTracker/CkfPattern/interface/BaseCkfTrajectoryBuilder.h"
@@ -42,6 +44,8 @@ namespace cms {
 
     virtual void produceBase(edm::Event& e, const edm::EventSetup& es);
 
+    static void fillPSetDescription(edm::ParameterSetDescription& desc);
+
   protected:
     bool theTrackCandidateOutput;
     bool theTrajectoryOutput;
@@ -73,8 +77,12 @@ namespace cms {
     edm::EDGetTokenT<edm::View<TrajectorySeed> > theSeedLabel;
     edm::EDGetTokenT<MeasurementTrackerEvent> theMTELabel;
 
-    bool skipClusters_;
-    bool phase2skipClusters_;
+    edm::InputTag const clustersToSkipTag_;
+    bool const skipClusters_;
+
+    edm::InputTag const phase2ClustersToSkipTag_;
+    bool const skipPhase2Clusters_;
+
     typedef edm::ContainerMask<edmNew::DetSetVector<SiPixelCluster> > PixelClusterMask;
     typedef edm::ContainerMask<edmNew::DetSetVector<SiStripCluster> > StripClusterMask;
     typedef edm::ContainerMask<edmNew::DetSetVector<Phase2TrackerCluster1D> > Phase2OTClusterMask;

--- a/RecoTracker/CkfPattern/interface/CkfTrajectoryBuilder.h
+++ b/RecoTracker/CkfPattern/interface/CkfTrajectoryBuilder.h
@@ -11,6 +11,7 @@ class TrajectoryStateOnSurface;
 class TrajectoryFilter;
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Event.h"
 
@@ -40,6 +41,8 @@ public:
                        std::unique_ptr<TrajectoryFilter> filter);
 
   ~CkfTrajectoryBuilder() override {}
+
+  static void fillPSetDescription(edm::ParameterSetDescription& iDesc);
 
   /// trajectories building starting from a seed
   TrajectoryContainer trajectories(const TrajectorySeed& seed) const override;

--- a/RecoTracker/CkfPattern/plugins/CkfTrackCandidateMaker.h
+++ b/RecoTracker/CkfPattern/plugins/CkfTrackCandidateMaker.h
@@ -31,6 +31,13 @@ namespace cms {
 
     ~CkfTrackCandidateMaker() override { ; }
 
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      edm::ParameterSetDescription desc;
+      desc.setComment("Make Ckf track candidates");
+      CkfTrackCandidateMakerBase::fillPSetDescription(desc);
+      descriptions.addWithDefaultLabel(desc);
+    }
+
     void beginRun(edm::Run const& r, edm::EventSetup const& es) override { beginRunBase(r, es); }
 
     void produce(edm::Event& e, const edm::EventSetup& es) override { produceBase(e, es); }

--- a/RecoTracker/CkfPattern/plugins/CkfTrajectoryMaker.h
+++ b/RecoTracker/CkfPattern/plugins/CkfTrajectoryMaker.h
@@ -36,6 +36,14 @@ namespace cms {
 
     ~CkfTrajectoryMaker() override { ; }
 
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      edm::ParameterSetDescription desc;
+      desc.setComment("Make CKF trajectories");
+      desc.add<bool>("trackCandidateAlso", false);
+      CkfTrackCandidateMakerBase::fillPSetDescription(desc);
+      descriptions.addWithDefaultLabel(desc);
+    }
+
     void beginRun(edm::Run const& run, edm::EventSetup const& es) override { beginRunBase(run, es); }
 
     void produce(edm::Event& e, const edm::EventSetup& es) override { produceBase(e, es); }

--- a/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.h
+++ b/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.h
@@ -2,6 +2,7 @@
 #define GroupedCkfTrajectoryBuilder_H
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
 #include "RecoTracker/CkfPattern/interface/BaseCkfTrajectoryBuilder.h"
@@ -25,6 +26,8 @@ public:
 
   /// destructor
   ~GroupedCkfTrajectoryBuilder() override {}
+
+  static void fillPSetDescription(edm::ParameterSetDescription& iDesc);
 
   /// set Event for the internal MeasurementTracker data member
   //  virtual void setEvent(const edm::Event& event) const;

--- a/RecoTracker/CkfPattern/plugins/SealModules.cc
+++ b/RecoTracker/CkfPattern/plugins/SealModules.cc
@@ -1,5 +1,4 @@
 #include "FWCore/PluginManager/interface/ModuleDef.h"
-
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "CkfTrackCandidateMaker.h"
@@ -14,9 +13,12 @@ using cms::CkfTrajectoryMaker;
 DEFINE_FWK_MODULE(CkfTrackCandidateMaker);
 DEFINE_FWK_MODULE(CkfTrajectoryMaker);
 
+#include "FWCore/ParameterSet/interface/ValidatedPluginMacros.h"
 #include "RecoTracker/CkfPattern/interface/BaseCkfTrajectoryBuilderFactory.h"
 #include "RecoTracker/CkfPattern/interface/CkfTrajectoryBuilder.h"
 #include "GroupedCkfTrajectoryBuilder.h"
 
-DEFINE_EDM_PLUGIN(BaseCkfTrajectoryBuilderFactory, CkfTrajectoryBuilder, "CkfTrajectoryBuilder");
-DEFINE_EDM_PLUGIN(BaseCkfTrajectoryBuilderFactory, GroupedCkfTrajectoryBuilder, "GroupedCkfTrajectoryBuilder");
+DEFINE_EDM_VALIDATED_PLUGIN(BaseCkfTrajectoryBuilderFactory, CkfTrajectoryBuilder, "CkfTrajectoryBuilder");
+DEFINE_EDM_VALIDATED_PLUGIN(BaseCkfTrajectoryBuilderFactory,
+                            GroupedCkfTrajectoryBuilder,
+                            "GroupedCkfTrajectoryBuilder");

--- a/RecoTracker/CkfPattern/python/CkfTrackCandidates_cfi.py
+++ b/RecoTracker/CkfPattern/python/CkfTrackCandidates_cfi.py
@@ -1,36 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-ckfTrackCandidates = cms.EDProducer("CkfTrackCandidateMaker",
-# During tracking, eliminate seeds used by an already found track 
-    RedundantSeedCleaner = cms.string('CachingSeedCleanerBySharedInput'),
-# Decide how to eliminate tracks sharing hits at end of tracking phase
-    TrajectoryCleaner = cms.string('TrajectoryCleanerBySharedHits'),
-# Run cleaning after in-out tracking in addition to at end of tracking ?
-    cleanTrajectoryAfterInOut = cms.bool(True),
-    reverseTrajectories  =cms.bool(False),
-# Split matched strip tracker hits into mono/stereo components.
-    useHitsSplitting = cms.bool(True),
-# After in-out tracking, do out-in tracking through the seeding
-# region and then further in.
-    doSeedingRegionRebuilding = cms.bool(True),
-#    SeedProducer = cms.string('globalMixedSeeds'),
-#    SeedLabel = cms.string(''),
-    maxNSeeds = cms.uint32(500000),
-    maxSeedsBeforeCleaning = cms.uint32(5000),
-# SeedProducer:SeedLabel descoped to src
-    src = cms.InputTag('globalMixedSeeds'),                                  
-    SimpleMagneticField = cms.string(''),                                    
-#    SimpleMagneticField = cms.string('ParabolicMf'), # parabolic magnetic field
-    NavigationSchool = cms.string('SimpleNavigationSchool'),
-    TrajectoryBuilder = cms.string('GroupedCkfTrajectoryBuilder'),
-    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('GroupedCkfTrajectoryBuilder')),
-    TransientInitialStateEstimatorParameters = cms.PSet(
-        propagatorAlongTISE = cms.string('PropagatorWithMaterial'),
-        propagatorOppositeTISE = cms.string('PropagatorWithMaterialOpposite'),
-#        propagatorAlongTISE = cms.string('PropagatorWithMaterialParabolicMf'),  # parabolic magnetic field
-#        propagatorOppositeTISE = cms.string('PropagatorWithMaterialParabolicMfOpposite'), # parabolic magnetic field
-        numberMeasurementsForFit = cms.int32(4)
-    ),
-    MeasurementTrackerEvent = cms.InputTag("MeasurementTrackerEvent"),
+import RecoTracker.CkfPattern.ckfTrackCandidateMaker_cfi as _mod
+ckfTrackCandidates = _mod.ckfTrackCandidateMaker.clone(
+    TrajectoryBuilderPSet = dict(refToPSet_ = cms.string('GroupedCkfTrajectoryBuilder')),
+    maxSeedsBeforeCleaning = 5000,
 )
-

--- a/RecoTracker/CkfPattern/python/CkfTrajectoryBuilder_cfi.py
+++ b/RecoTracker/CkfPattern/python/CkfTrajectoryBuilder_cfi.py
@@ -10,7 +10,6 @@ CkfTrajectoryBuilder = cms.PSet(
     trajectoryFilter = cms.PSet(refToPSet_ = cms.string('CkfBaseTrajectoryFilter_block')),
     maxCand = cms.int32(5),
     intermediateCleaning = cms.bool(True),
-    MeasurementTrackerName = cms.string(''),
     estimator = cms.string('Chi2'),
     TTRHBuilder = cms.string('WithTrackAngle'),
     updator = cms.string('KFUpdator'),

--- a/RecoTracker/CkfPattern/python/GroupedCkfTrajectoryBuilderP5_cff.py
+++ b/RecoTracker/CkfPattern/python/GroupedCkfTrajectoryBuilderP5_cff.py
@@ -45,7 +45,6 @@ ckfBaseTrajectoryFilterP5 = TrackingTools.TrajectoryFiltering.TrajectoryFilter_c
 #replace ckfBaseTrajectoryFilterP5.minimumNumberOfHits =  4
 #
 ##CTF_P5_MeasurementTracker.ComponentName = 'CTF_P5' # useless duplication of MeasurementTracker
-##GroupedCkfTrajectoryBuilderP5.MeasurementTrackerName = 'CTF_P5' # useless duplication of MeasurementTracker
 GroupedCkfTrajectoryBuilderP5 = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
     trajectoryFilter = dict(refToPSet_ = 'ckfBaseTrajectoryFilterP5'),
     maxCand = 1,

--- a/RecoTracker/CkfPattern/python/GroupedCkfTrajectoryBuilder_cfi.py
+++ b/RecoTracker/CkfPattern/python/GroupedCkfTrajectoryBuilder_cfi.py
@@ -23,7 +23,6 @@ GroupedCkfTrajectoryBuilder = cms.PSet(
     # Chi2 added to track candidate if no hit found in layer
     lostHitPenalty = cms.double(30.0),
     foundHitBonus = cms.double(10.0),
-    MeasurementTrackerName = cms.string(''),
     lockHits = cms.bool(True),
     TTRHBuilder = cms.string('WithTrackAngle'),
     updator = cms.string('KFUpdator'),

--- a/RecoTracker/CkfPattern/src/BaseCkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/src/BaseCkfTrajectoryBuilder.cc
@@ -43,6 +43,15 @@ BaseCkfTrajectoryBuilder::BaseCkfTrajectoryBuilder(const edm::ParameterSet& conf
 
 BaseCkfTrajectoryBuilder::~BaseCkfTrajectoryBuilder() {}
 
+void BaseCkfTrajectoryBuilder::fillPSetDescription(edm::ParameterSetDescription& iDesc) {
+  iDesc.add<bool>("seedAs5DHit", false);
+  iDesc.add<std::string>("updator", "KFUpdator");
+  iDesc.add<std::string>("propagatorAlong", "PropagatorWithMaterial");
+  iDesc.add<std::string>("propagatorOpposite", "PropagatorWithMaterialOpposite");
+  iDesc.add<std::string>("estimator", "Chi2");
+  iDesc.add<std::string>("TTRHBuilder", "WithTrackAngle");
+}
+
 std::unique_ptr<TrajectoryFilter> BaseCkfTrajectoryBuilder::createTrajectoryFilter(const edm::ParameterSet& pset,
                                                                                    edm::ConsumesCollector& iC) {
   return TrajectoryFilterFactory::get()->create(pset.getParameter<std::string>("ComponentType"), pset, iC);

--- a/RecoTracker/CkfPattern/src/BaseCkfTrajectoryBuilderFactory.cc
+++ b/RecoTracker/CkfPattern/src/BaseCkfTrajectoryBuilderFactory.cc
@@ -1,3 +1,4 @@
 #include "RecoTracker/CkfPattern/interface/BaseCkfTrajectoryBuilderFactory.h"
+#include "FWCore/ParameterSet/interface/ValidatedPluginFactoryMacros.h"
 
-EDM_REGISTER_PLUGINFACTORY(BaseCkfTrajectoryBuilderFactory, "BaseCkfTrajectoryBuilderFactory");
+EDM_REGISTER_VALIDATED_PLUGINFACTORY(BaseCkfTrajectoryBuilderFactory, "BaseCkfTrajectoryBuilderFactory");

--- a/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
+++ b/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
@@ -76,7 +76,11 @@ namespace cms {
             iC.esConsumes(edm::ESInputTag("", conf.getParameter<std::string>("NavigationSchool")))),
         theNavigationSchool(nullptr),
         thePropagatorToken(iC.esConsumes(edm::ESInputTag("", "AnyDirectionAnalyticalPropagator"))),
+#ifdef VI_REPRODUCIBLE
+        maxSeedsBeforeCleaning_(0),
+#else
         maxSeedsBeforeCleaning_(conf.getParameter<unsigned int>("maxSeedsBeforeCleaning")),
+#endif
         theMTELabel(iC.consumes<MeasurementTrackerEvent>(conf.getParameter<edm::InputTag>("MeasurementTrackerEvent"))),
         clustersToSkipTag_(conf.getParameter<edm::InputTag>("clustersToSkip")),
         skipClusters_(!clustersToSkipTag_.label().empty()),

--- a/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
+++ b/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
@@ -1,8 +1,9 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/PluginDescription.h"
 #include "FWCore/Utilities/interface/isFinite.h"
-#include <FWCore/Utilities/interface/ESInputTag.h>
+#include "FWCore/Utilities/interface/ESInputTag.h"
 
 #include "DataFormats/Common/interface/OwnVector.h"
 #include "DataFormats/TrackCandidate/interface/TrackCandidateCollection.h"
@@ -62,8 +63,7 @@ namespace cms {
         useSplitting(conf.getParameter<bool>("useHitsSplitting")),
         doSeedingRegionRebuilding(conf.getParameter<bool>("doSeedingRegionRebuilding")),
         cleanTrajectoryAfterInOut(conf.getParameter<bool>("cleanTrajectoryAfterInOut")),
-        reverseTrajectories(conf.existsAs<bool>("reverseTrajectories") &&
-                            conf.getParameter<bool>("reverseTrajectories")),
+        reverseTrajectories(conf.getParameter<bool>("reverseTrajectories")),
         theMaxNSeeds(conf.getParameter<unsigned int>("maxNSeeds")),
         theTrajectoryBuilder(
             createBaseCkfTrajectoryBuilder(conf.getParameter<edm::ParameterSet>("TrajectoryBuilderPSet"), iC)),
@@ -76,34 +76,28 @@ namespace cms {
             iC.esConsumes(edm::ESInputTag("", conf.getParameter<std::string>("NavigationSchool")))),
         theNavigationSchool(nullptr),
         thePropagatorToken(iC.esConsumes(edm::ESInputTag("", "AnyDirectionAnalyticalPropagator"))),
-        maxSeedsBeforeCleaning_(0),
+        maxSeedsBeforeCleaning_(conf.getParameter<unsigned int>("maxSeedsBeforeCleaning")),
         theMTELabel(iC.consumes<MeasurementTrackerEvent>(conf.getParameter<edm::InputTag>("MeasurementTrackerEvent"))),
-        skipClusters_(false),
-        phase2skipClusters_(false) {
+        clustersToSkipTag_(conf.getParameter<edm::InputTag>("clustersToSkip")),
+        skipClusters_(!clustersToSkipTag_.label().empty()),
+        phase2ClustersToSkipTag_(conf.getParameter<edm::InputTag>("phase2clustersToSkip")),
+        skipPhase2Clusters_(!phase2ClustersToSkipTag_.label().empty()) {
     theSeedLabel = iC.consumes<edm::View<TrajectorySeed>>(conf.getParameter<edm::InputTag>("src"));
-#ifndef VI_REPRODUCIBLE
-    if (conf.exists("maxSeedsBeforeCleaning"))
-      maxSeedsBeforeCleaning_ = conf.getParameter<unsigned int>("maxSeedsBeforeCleaning");
-#endif
-    if (conf.existsAs<edm::InputTag>("clustersToSkip")) {
-      skipClusters_ = true;
-      maskPixels_ = iC.consumes<PixelClusterMask>(conf.getParameter<edm::InputTag>("clustersToSkip"));
-      maskStrips_ = iC.consumes<StripClusterMask>(conf.getParameter<edm::InputTag>("clustersToSkip"));
+
+    if (skipClusters_) {
+      maskPixels_ = iC.consumes<PixelClusterMask>(clustersToSkipTag_);
+      maskStrips_ = iC.consumes<StripClusterMask>(clustersToSkipTag_);
     }
     //FIXME:: just temporary solution for phase2!
-    if (conf.existsAs<edm::InputTag>("phase2clustersToSkip")) {
-      phase2skipClusters_ = true;
-      maskPixels_ = iC.consumes<PixelClusterMask>(conf.getParameter<edm::InputTag>("phase2clustersToSkip"));
-      maskPhase2OTs_ = iC.consumes<Phase2OTClusterMask>(conf.getParameter<edm::InputTag>("phase2clustersToSkip"));
+    if (skipPhase2Clusters_) {
+      maskPixels_ = iC.consumes<PixelClusterMask>(phase2ClustersToSkipTag_);
+      maskPhase2OTs_ = iC.consumes<Phase2OTClusterMask>(phase2ClustersToSkipTag_);
     }
 #ifndef VI_REPRODUCIBLE
     std::string cleaner = conf.getParameter<std::string>("RedundantSeedCleaner");
     if (cleaner == "CachingSeedCleanerBySharedInput") {
-      int numHitsForSeedCleaner =
-          conf.existsAs<int>("numHitsForSeedCleaner") ? conf.getParameter<int>("numHitsForSeedCleaner") : 4;
-      int onlyPixelHits = conf.existsAs<bool>("onlyPixelHitsForSeedCleaner")
-                              ? conf.getParameter<bool>("onlyPixelHitsForSeedCleaner")
-                              : false;
+      int numHitsForSeedCleaner = conf.getParameter<int>("numHitsForSeedCleaner");
+      bool onlyPixelHits = conf.getParameter<bool>("onlyPixelHitsForSeedCleaner");
       theSeedCleaner = std::make_unique<CachingSeedCleanerBySharedInput>(numHitsForSeedCleaner, onlyPixelHits);
     } else if (cleaner != "none") {
       throw cms::Exception("RedundantSeedCleaner not found, please use CachingSeedCleanerBySharedInput ro none",
@@ -165,7 +159,7 @@ namespace cms {
       dataWithMasks = std::make_unique<MeasurementTrackerEvent>(*data, *stripMask, *pixelMask);
       //std::cout << "Trajectory builder " << conf_.getParameter<std::string>("@module_label") << " created with masks " << std::endl;
       theTrajectoryBuilder->setEvent(e, es, &*dataWithMasks);
-    } else if (phase2skipClusters_) {
+    } else if (skipPhase2Clusters_) {
       //FIXME:just temporary solution for phase2!
       edm::Handle<PixelClusterMask> pixelMask;
       e.getByToken(maskPixels_, pixelMask);
@@ -249,8 +243,8 @@ namespace cms {
         auto const & hit = static_cast<BaseTrackerRecHit const&>(*h);
         val[i] = hit.firstClusterRef().key();
         if (++h != seeds[i].recHits().second) {
-          auto	const &	hit = static_cast<BaseTrackerRecHit const&>(*h);
-    	  val[i] |= (unsigned long long)(hit.firstClusterRef().key())<<32;
+          auto const & hit = static_cast<BaseTrackerRecHit const&>(*h);
+          val[i] |= (unsigned long long)(hit.firstClusterRef().key())<<32;
         }
       }
       */
@@ -540,4 +534,33 @@ namespace cms {
     e.put(std::move(outputSeedStopInfos));
   }
 
+  void CkfTrackCandidateMakerBase::fillPSetDescription(edm::ParameterSetDescription& desc) {
+    desc.add<bool>("cleanTrajectoryAfterInOut", true);
+    desc.add<bool>("doSeedingRegionRebuilding", true);
+    desc.add<bool>("onlyPixelHitsForSeedCleaner", false);
+    desc.add<bool>("reverseTrajectories", false);
+    desc.add<bool>("useHitsSplitting", true);
+    desc.add<edm::InputTag>("MeasurementTrackerEvent", edm::InputTag("MeasurementTrackerEvent"));
+    desc.add<edm::InputTag>("src", edm::InputTag("globalMixedSeeds"));
+
+    desc.add<edm::InputTag>("clustersToSkip", edm::InputTag(""));
+    desc.add<edm::InputTag>("phase2clustersToSkip", edm::InputTag(""));
+
+    edm::ParameterSetDescription psdTB;
+    psdTB.addNode(edm::PluginDescription<BaseCkfTrajectoryBuilderFactory>("ComponentType", true));
+    desc.add<edm::ParameterSetDescription>("TrajectoryBuilderPSet", psdTB);
+
+    edm::ParameterSetDescription psd1;
+    psd1.add<std::string>("propagatorAlongTISE", "PropagatorWithMaterial");
+    psd1.add<std::string>("propagatorOppositeTISE", "PropagatorWithMaterialOpposite");
+    psd1.add<int>("numberMeasurementsForFit", 4);
+    desc.add<edm::ParameterSetDescription>("TransientInitialStateEstimatorParameters", psd1);
+
+    desc.add<int>("numHitsForSeedCleaner", 4);
+    desc.add<std::string>("NavigationSchool", "SimpleNavigationSchool");
+    desc.add<std::string>("RedundantSeedCleaner", "CachingSeedCleanerBySharedInput");
+    desc.add<std::string>("TrajectoryCleaner", "TrajectoryCleanerBySharedHits");
+    desc.add<unsigned int>("maxNSeeds", 500000);
+    desc.add<unsigned int>("maxSeedsBeforeCleaning", 0);
+  }
 }  // namespace cms

--- a/RecoTracker/CkfPattern/src/CkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/src/CkfTrajectoryBuilder.cc
@@ -1,6 +1,7 @@
 #include "RecoTracker/CkfPattern/interface/CkfTrajectoryBuilder.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/PluginDescription.h"
 
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
@@ -23,6 +24,7 @@
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
 #include "TrackingTools/PatternTools/interface/TransverseImpactPointExtrapolator.h"
 #include "TrackingTools/TrajectoryFiltering/interface/TrajectoryFilter.h"
+#include "TrackingTools/TrajectoryFiltering/interface/TrajectoryFilterFactory.h"
 
 using namespace std;
 
@@ -47,6 +49,18 @@ CkfTrajectoryBuilder::CkfTrajectoryBuilder(const edm::ParameterSet& conf,
     theUniqueName = ss.str();
     LogDebug("CkfPattern")<<"my unique name is: "<<theUniqueName;
   */
+}
+
+void CkfTrajectoryBuilder::fillPSetDescription(edm::ParameterSetDescription& iDesc) {
+  BaseCkfTrajectoryBuilder::fillPSetDescription(iDesc);
+  iDesc.add<int>("maxCand", 5);
+  iDesc.add<double>("lostHitPenalty", 30.);
+  iDesc.add<bool>("intermediateCleaning", true);
+  iDesc.add<bool>("alwaysUseInvalidHits", true);
+
+  edm::ParameterSetDescription psdTF;
+  psdTF.addNode(edm::PluginDescription<TrajectoryFilterFactory>("ComponentType", true));
+  iDesc.add<edm::ParameterSetDescription>("trajectoryFilter", psdTF);
 }
 
 /*

--- a/RecoTracker/Configuration/python/RecoTrackerTopBottom_cff.py
+++ b/RecoTracker/Configuration/python/RecoTrackerTopBottom_cff.py
@@ -120,9 +120,7 @@ MeasurementTrackerTop = MeasurementTracker.clone(
     ComponentName = 'MeasurementTrackerTop'
 )
 
-GroupedCkfTrajectoryBuilderP5Top = GroupedCkfTrajectoryBuilderP5.clone(
-    MeasurementTrackerName = 'MeasurementTrackerTop'
-)
+GroupedCkfTrajectoryBuilderP5Top = GroupedCkfTrajectoryBuilderP5.clone()
 
 ckfTrackCandidatesP5Top = ckfTrackCandidatesP5.clone(
     TrajectoryBuilderPSet = dict(refToPSet_ = 'GroupedCkfTrajectoryBuilderP5Top'),
@@ -220,9 +218,7 @@ MeasurementTrackerBottom = MeasurementTracker.clone(
     ComponentName = 'MeasurementTrackerBottom'
 )
 
-GroupedCkfTrajectoryBuilderP5Bottom = GroupedCkfTrajectoryBuilderP5.clone(
-    MeasurementTrackerName = 'MeasurementTrackerBottom'
-)
+GroupedCkfTrajectoryBuilderP5Bottom = GroupedCkfTrajectoryBuilderP5.clone()
 
 ckfTrackCandidatesP5Bottom = ckfTrackCandidatesP5.clone(
     TrajectoryBuilderPSet = dict(refToPSet_ = 'GroupedCkfTrajectoryBuilderP5Bottom'),

--- a/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
+++ b/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
@@ -302,13 +302,13 @@ trackingPhase2PU140.toReplaceWith(convCkfTrajectoryBuilder, _convCkfTrajectoryBu
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 convTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
     src = 'photonConvTrajSeedFromSingleLeg:convSeedCandidates',
-    clustersToSkip =  cms.InputTag('convClusters'),
+    clustersToSkip = 'convClusters',
     TrajectoryBuilderPSet = dict(refToPSet_ = 'convCkfTrajectoryBuilder')
 )
 
 trackingPhase2PU140.toModify(convTrackCandidates,
-    clustersToSkip = None,
-    phase2clustersToSkip = cms.InputTag('convClusters')
+    clustersToSkip = '',
+    phase2clustersToSkip = 'convClusters'
 )
 
 import TrackingTools.TrackFitters.RungeKuttaFitters_cff

--- a/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
@@ -151,7 +151,6 @@ trackingPhase2PU140.toModify(detachedQuadStepChi2Est,
 # TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 detachedQuadStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
-    MeasurementTrackerName = '',
     trajectoryFilter = dict(refToPSet_ = 'detachedQuadStepTrajectoryFilter'),
     maxCand = 3,
     alwaysUseInvalidHits = True,
@@ -177,7 +176,7 @@ detachedQuadStepTrajectoryCleanerBySharedHits = trajectoryCleanerBySharedHits.cl
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 detachedQuadStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
     src = 'detachedQuadStepSeeds',
-    clustersToSkip = cms.InputTag('detachedQuadStepClusters'),
+    clustersToSkip = 'detachedQuadStepClusters',
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
     numHitsForSeedCleaner = cms.int32(50),
     onlyPixelHitsForSeedCleaner = cms.bool(True),
@@ -187,8 +186,8 @@ detachedQuadStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.
     useHitsSplitting = True
 )
 trackingPhase2PU140.toModify(detachedQuadStepTrackCandidates,
-    clustersToSkip       = None,
-    phase2clustersToSkip = cms.InputTag('detachedQuadStepClusters')
+    clustersToSkip = '',
+    phase2clustersToSkip = 'detachedQuadStepClusters'
 )
 
 from Configuration.ProcessModifiers.trackingMkFitDetachedQuadStep_cff import trackingMkFitDetachedQuadStep

--- a/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
@@ -182,7 +182,6 @@ _tracker_apv_vfp30_2016.toModify(detachedTripletStepChi2Est,
 # TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 detachedTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
-    MeasurementTrackerName = '',
     trajectoryFilter = cms.PSet(refToPSet_ = cms.string('detachedTripletStepTrajectoryFilter')),
     maxCand = 3,
     alwaysUseInvalidHits = True,

--- a/RecoTracker/IterativeTracking/python/DisplacedGeneralStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DisplacedGeneralStep_cff.py
@@ -101,14 +101,13 @@ displacedGeneralStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEs
 #----------------------------------------- TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 displacedGeneralStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
-    MeasurementTrackerName = '',
-    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('displacedGeneralStepTrajectoryFilter')),
-    inOutTrajectoryFilter = cms.PSet(refToPSet_ = cms.string('displacedGeneralStepTrajectoryFilterInOut')),
+    trajectoryFilter = dict(refToPSet_ = 'displacedGeneralStepTrajectoryFilter'),
+    inOutTrajectoryFilter = dict(refToPSet_ = 'displacedGeneralStepTrajectoryFilterInOut'),
     useSameTrajFilter = False,
     minNrOfHitsForRebuild = 4,
     maxCand = 2,
     estimator = 'displacedGeneralStepChi2Est'
-    )
+)
 
 
 

--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -211,10 +211,10 @@ trackingPhase2PU140.toModify(highPtTripletStepTrajectoryBuilder,
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi as _CkfTrackCandidates_cfi
 highPtTripletStepTrackCandidates = _CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
     src = 'highPtTripletStepSeeds',
-    clustersToSkip = cms.InputTag('highPtTripletStepClusters'),
+    clustersToSkip = 'highPtTripletStepClusters',
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
-    numHitsForSeedCleaner = cms.int32(50),
-    onlyPixelHitsForSeedCleaner = cms.bool(True),
+    numHitsForSeedCleaner = 50,
+    onlyPixelHitsForSeedCleaner = True,
     TrajectoryBuilderPSet = dict(refToPSet_ = 'highPtTripletStepTrajectoryBuilder'),
     doSeedingRegionRebuilding = True,
     useHitsSplitting = True
@@ -252,8 +252,8 @@ highPtTripletStepTrajectoryCleanerBySharedHits = _trajectoryCleanerBySharedHits.
 )
 trackingPhase2PU140.toModify(highPtTripletStepTrackCandidates, 
     TrajectoryCleaner    = 'highPtTripletStepTrajectoryCleanerBySharedHits', 
-    clustersToSkip       = None,
-    phase2clustersToSkip = cms.InputTag('highPtTripletStepClusters')
+    clustersToSkip       = '',
+    phase2clustersToSkip = 'highPtTripletStepClusters'
 )
 
 #For FastSim phase1 tracking 

--- a/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
@@ -148,9 +148,8 @@ import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 #need to also load the refToPSet_ used by GroupedCkfTrajectoryBuilder
 CkfBaseTrajectoryFilter_block = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.CkfBaseTrajectoryFilter_block
 jetCoreRegionalStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
-    MeasurementTrackerName = '',
-    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('jetCoreRegionalStepTrajectoryFilter')),
-    #clustersToSkip = cms.InputTag('jetCoreRegionalStepClusters'),
+    trajectoryFilter = dict(refToPSet_ = 'jetCoreRegionalStepTrajectoryFilter'),
+    #clustersToSkip = 'jetCoreRegionalStepClusters',
     maxCand = 50,
     estimator = 'jetCoreRegionalStepChi2Est',
     maxDPhiForLooperReconstruction = cms.double(2.0),
@@ -159,9 +158,8 @@ jetCoreRegionalStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajecto
 trackingNoLoopers.toModify(jetCoreRegionalStepTrajectoryBuilder,
                            maxPtForLooperReconstruction = 0.0)    
 jetCoreRegionalStepBarrelTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
-    MeasurementTrackerName = '',
-    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('jetCoreRegionalStepBarrelTrajectoryFilter')),
-    #clustersToSkip = cms.InputTag('jetCoreRegionalStepClusters'),
+    trajectoryFilter = dict(refToPSet_ = 'jetCoreRegionalStepBarrelTrajectoryFilter'),
+    #clustersToSkip = 'jetCoreRegionalStepClusters',
     maxCand = 50,
     estimator = 'jetCoreRegionalStepChi2Est',
     keepOriginalIfRebuildFails = True,

--- a/RecoTracker/IterativeTracking/python/LowPtBarrelTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtBarrelTripletStep_cff.py
@@ -60,9 +60,8 @@ lowPtBarrelTripletStepChi2Est = TrackingTools.KalmanUpdators.Chi2MeasurementEsti
 # TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 lowPtBarrelTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
-    MeasurementTrackerName = '',
-    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('lowPtBarrelTripletStepTrajectoryFilter')),
-    clustersToSkip = cms.InputTag('lowPtBarrelTripletStepClusters'),
+    trajectoryFilter = dict(refToPSet_ = 'lowPtBarrelTripletStepTrajectoryFilter'),
+    clustersToSkip = 'lowPtBarrelTripletStepClusters',
     maxCand        = 3,
     #lostHitPenalty = cms.double(10.0), 
     estimator = 'lowPtBarrelTripletStepChi2Est',

--- a/RecoTracker/IterativeTracking/python/LowPtForwardTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtForwardTripletStep_cff.py
@@ -60,9 +60,8 @@ lowPtForwardTripletStepChi2Est = TrackingTools.KalmanUpdators.Chi2MeasurementEst
 # TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 lowPtForwardTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
-    MeasurementTrackerName = '',
-    trajectoryFilter       = cms.PSet(refToPSet_ = cms.string('lowPtForwardTripletStepTrajectoryFilter')),
-    clustersToSkip         = cms.InputTag('lowPtForwardTripletStepClusters'),
+    trajectoryFilter       = dict(refToPSet_ = 'lowPtForwardTripletStepTrajectoryFilter'),
+    clustersToSkip         = 'lowPtForwardTripletStepClusters',
     maxCand                = 3,
     estimator              = 'lowPtForwardTripletStepChi2Est'
 )

--- a/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
@@ -138,7 +138,6 @@ trackingPhase2PU140.toModify(lowPtQuadStepChi2Est,
 # TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 lowPtQuadStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
-    MeasurementTrackerName = '',
     trajectoryFilter       = dict(refToPSet_ = 'lowPtQuadStepTrajectoryFilter'),
     maxCand                = 4,
     estimator              = 'lowPtQuadStepChi2Est',
@@ -168,17 +167,17 @@ import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 lowPtQuadStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
     src = 'lowPtQuadStepSeeds',
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
-    numHitsForSeedCleaner       = cms.int32(50),
-    onlyPixelHitsForSeedCleaner = cms.bool(True),
+    numHitsForSeedCleaner       = 50,
+    onlyPixelHitsForSeedCleaner = True,
     TrajectoryBuilderPSet       = dict(refToPSet_ = 'lowPtQuadStepTrajectoryBuilder'),
     TrajectoryCleaner           = 'lowPtQuadStepTrajectoryCleanerBySharedHits',
-    clustersToSkip              = cms.InputTag('lowPtQuadStepClusters'),
+    clustersToSkip              = 'lowPtQuadStepClusters',
     doSeedingRegionRebuilding   = True,
     useHitsSplitting            = True
 )
 trackingPhase2PU140.toModify(lowPtQuadStepTrackCandidates,
-    clustersToSkip       = None,
-    phase2clustersToSkip = cms.InputTag('lowPtQuadStepClusters')
+    clustersToSkip       = '',
+    phase2clustersToSkip = 'lowPtQuadStepClusters'
 )
 
 from Configuration.ProcessModifiers.trackingMkFitLowPtQuadStep_cff import trackingMkFitLowPtQuadStep

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -210,8 +210,7 @@ _tracker_apv_vfp30_2016.toModify(lowPtTripletStepChi2Est,
 # TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 lowPtTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
-    MeasurementTrackerName = '',
-    trajectoryFilter       = cms.PSet(refToPSet_ = cms.string('lowPtTripletStepTrajectoryFilter')),
+    trajectoryFilter       = dict(refToPSet_ = 'lowPtTripletStepTrajectoryFilter'),
     maxCand                = 4,
     estimator              = 'lowPtTripletStepChi2Est',
     maxDPhiForLooperReconstruction = cms.double(2.0),
@@ -234,10 +233,10 @@ import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 _lowPtTripletStepTrackCandidatesCkf = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
     src = 'lowPtTripletStepSeeds',
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
-    numHitsForSeedCleaner       = cms.int32(50),
-    onlyPixelHitsForSeedCleaner = cms.bool(True),
+    numHitsForSeedCleaner       = 50,
+    onlyPixelHitsForSeedCleaner = True,
     TrajectoryBuilderPSet       = cms.PSet(refToPSet_ = cms.string('lowPtTripletStepTrajectoryBuilder')),
-    clustersToSkip              = cms.InputTag('lowPtTripletStepClusters'),
+    clustersToSkip              = 'lowPtTripletStepClusters',
     doSeedingRegionRebuilding   = True,
     useHitsSplitting            = True,
     TrajectoryCleaner           = 'lowPtTripletStepTrajectoryCleanerBySharedHits'
@@ -245,8 +244,8 @@ _lowPtTripletStepTrackCandidatesCkf = RecoTracker.CkfPattern.CkfTrackCandidates_
 lowPtTripletStepTrackCandidates = _lowPtTripletStepTrackCandidatesCkf.clone()
 
 trackingPhase2PU140.toModify(lowPtTripletStepTrackCandidates,
-    clustersToSkip = None,
-    phase2clustersToSkip = cms.InputTag('lowPtTripletStepClusters')
+    clustersToSkip = '',
+    phase2clustersToSkip = 'lowPtTripletStepClusters'
 )
 
 from Configuration.ProcessModifiers.trackingMkFitLowPtTripletStep_cff import trackingMkFitLowPtTripletStep

--- a/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
@@ -270,8 +270,7 @@ trackingLowPU.toModify(mixedTripletStepChi2Est,
 # TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 mixedTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
-    MeasurementTrackerName = '',
-    trajectoryFilter       = cms.PSet(refToPSet_ = cms.string('mixedTripletStepTrajectoryFilter')),
+    trajectoryFilter       = dict(refToPSet_ = 'mixedTripletStepTrajectoryFilter'),
     propagatorAlong        = 'mixedTripletStepPropagator',
     propagatorOpposite     = 'mixedTripletStepPropagatorOpposite',
     maxCand                = 2,

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -275,8 +275,7 @@ vectorHits.toModify(pixelLessStepChi2Est,
 # TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 pixelLessStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
-    MeasurementTrackerName = '',
-    trajectoryFilter       = cms.PSet(refToPSet_ = cms.string('pixelLessStepTrajectoryFilter')),
+    trajectoryFilter       = dict(refToPSet_ = 'pixelLessStepTrajectoryFilter'),
     minNrOfHitsForRebuild  = 4,
     maxCand                = 2,
     alwaysUseInvalidHits   = False,
@@ -292,10 +291,10 @@ import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 # Give handle for CKF for HI
 _pixelLessStepTrackCandidatesCkf = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
     src                   = 'pixelLessStepSeeds',
-    clustersToSkip        = cms.InputTag('pixelLessStepClusters'),
+    clustersToSkip        = 'pixelLessStepClusters',
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
-    numHitsForSeedCleaner = cms.int32(50),
-    #onlyPixelHitsForSeedCleaner = cms.bool(True),
+    numHitsForSeedCleaner = 50,
+    #onlyPixelHitsForSeedCleaner = True,
     TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('pixelLessStepTrajectoryBuilder')),
     TrajectoryCleaner     = 'pixelLessStepTrajectoryCleanerBySharedHits'
 )
@@ -334,8 +333,8 @@ fastSim.toReplaceWith(pixelLessStepTrackCandidates,
 )
 
 vectorHits.toModify(pixelLessStepTrackCandidates,
-    phase2clustersToSkip = cms.InputTag('pixelLessStepClusters'),
-    clustersToSkip = None
+    phase2clustersToSkip = 'pixelLessStepClusters',
+    clustersToSkip = ''
 )
 
 from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import trajectoryCleanerBySharedHits

--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -275,8 +275,7 @@ highBetaStar_2018.toModify(pixelPairStepChi2Est,MaxChi2 = 30)
 # TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 pixelPairStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
-    MeasurementTrackerName = '',
-    trajectoryFilter       = cms.PSet(refToPSet_ = cms.string('pixelPairStepTrajectoryFilter')),
+    trajectoryFilter       = dict(refToPSet_ = 'pixelPairStepTrajectoryFilter'),
     maxCand                = 3,
     estimator              = 'pixelPairStepChi2Est',
     maxDPhiForLooperReconstruction = cms.double(2.0),
@@ -300,12 +299,11 @@ import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 # Give handle for CKF for HI
 _pixelPairStepTrackCandidatesCkf = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
     src = 'pixelPairStepSeeds',
-    clustersToSkip        = cms.InputTag('pixelPairStepClusters'),
+    clustersToSkip = 'pixelPairStepClusters',
     TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('pixelPairStepTrajectoryBuilder')),
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
-    numHitsForSeedCleaner = cms.int32(50),
-    onlyPixelHitsForSeedCleaner = cms.bool(True),
-
+    numHitsForSeedCleaner = 50,
+    onlyPixelHitsForSeedCleaner = True
 )
 pixelPairStepTrackCandidates = _pixelPairStepTrackCandidatesCkf.clone()
 
@@ -333,9 +331,9 @@ trackingMkFitPixelPairStep.toReplaceWith(pixelPairStepTrackCandidates, _mkFitOut
 ))
 
 trackingPhase2PU140.toModify(pixelPairStepTrackCandidates,
-    clustersToSkip       = None,
-    phase2clustersToSkip = cms.InputTag('pixelPairStepClusters'),
-    TrajectoryCleaner    = 'pixelPairStepTrajectoryCleanerBySharedHits'
+    clustersToSkip = '',
+    phase2clustersToSkip = 'pixelPairStepClusters',
+    TrajectoryCleaner = 'pixelPairStepTrajectoryCleanerBySharedHits'
 )
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 fastSim.toReplaceWith(pixelPairStepTrackCandidates,

--- a/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
@@ -242,9 +242,8 @@ trackingLowPU.toModify(tobTecStepChi2Est,
 # TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 tobTecStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
-    MeasurementTrackerName = '',
-    trajectoryFilter       = cms.PSet(refToPSet_ = cms.string('tobTecStepTrajectoryFilter')),
-    inOutTrajectoryFilter  = cms.PSet(refToPSet_ = cms.string('tobTecStepInOutTrajectoryFilter')),
+    trajectoryFilter       = dict(refToPSet_ = 'tobTecStepTrajectoryFilter'),
+    inOutTrajectoryFilter  = dict(refToPSet_ = 'tobTecStepInOutTrajectoryFilter'),
     useSameTrajFilter      = False,
     minNrOfHitsForRebuild  = 4,
     alwaysUseInvalidHits   = False,

--- a/TrackingTools/GsfTracking/python/CkfElectronCandidateMaker_cff.py
+++ b/TrackingTools/GsfTracking/python/CkfElectronCandidateMaker_cff.py
@@ -44,7 +44,6 @@ TrajectoryBuilderForElectrons = RecoTracker.CkfPattern.CkfTrajectoryBuilder_cfi.
     propagatorAlong = 'fwdGsfElectronPropagator',
     propagatorOpposite = 'bwdGsfElectronPropagator',
     estimator = 'ElectronChi2',
-    MeasurementTrackerName = '',
     lostHitPenalty = 90.,
     alwaysUseInvalidHits = True,
     TTRHBuilder = 'WithTrackAngle',
@@ -72,7 +71,6 @@ electronTrajectoryCleanerBySharedHits = trajectoryCleanerBySharedHits.clone(
     ValidHitBonus = 1000.0,
     MissingHitPenalty = 0.0
 )
-            
 
 # "backward" propagator for electrons
 from TrackingTools.GsfTracking.bwdGsfElectronPropagator_cff import *

--- a/TrackingTools/TrajectoryFiltering/interface/ChargeSignificanceTrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/ChargeSignificanceTrajectoryFilter.h
@@ -1,6 +1,7 @@
 #ifndef ChargeSignificanceTrajectoryFilter_H
 #define ChargeSignificanceTrajectoryFilter_H
 
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "TrackingTools/TrajectoryFiltering/interface/TrajectoryFilter.h"
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 #include "TrackingTools/PatternTools/interface/TempTrajectory.h"
@@ -17,6 +18,8 @@ public:
 
   explicit ChargeSignificanceTrajectoryFilter(const edm::ParameterSet& pset, edm::ConsumesCollector& iC)
       : theChargeSignificance(pset.getParameter<double>("chargeSignificance")) {}
+
+  static void fillPSetDescription(edm::ParameterSetDescription& iDesc) { iDesc.add<double>("chargeSignificance", -1.); }
 
   bool qualityFilter(const Trajectory& traj) const override { return traj.isValid(); }
   bool qualityFilter(const TempTrajectory& traj) const override { return traj.isValid(); }

--- a/TrackingTools/TrajectoryFiltering/interface/CkfBaseTrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/CkfBaseTrajectoryFilter.h
@@ -1,8 +1,8 @@
 #ifndef CkfBaseTrajectoryFilter_H
 #define CkfBaseTrajectoryFilter_H
 
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "TrackingTools/TrajectoryFiltering/interface/TrajectoryFilter.h"
-
 #include "TrackingTools/TrajectoryFiltering/interface/ChargeSignificanceTrajectoryFilter.h"
 #include "TrackingTools/TrajectoryFiltering/interface/MaxConsecLostHitsTrajectoryFilter.h"
 #include "TrackingTools/TrajectoryFiltering/interface/MaxHitsTrajectoryFilter.h"
@@ -13,7 +13,6 @@
 #include "TrackingTools/TrajectoryFiltering/interface/LooperTrajectoryFilter.h"
 #include "TrackingTools/TrajectoryFiltering/interface/SeedExtensionTrajectoryFilter.h"
 #include "TrackingTools/TrajectoryFiltering/interface/MaxCCCLostHitsTrajectoryFilter.h"
-#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 class CkfBaseTrajectoryFilter : public TrajectoryFilter {
 public:
@@ -29,6 +28,19 @@ public:
         theLooperTrajectoryFilter(new LooperTrajectoryFilter(pset, iC)),
         theSeedExtensionTrajectoryFilter(new SeedExtensionTrajectoryFilter(pset, iC)),
         theMaxCCCLostHitsTrajectoryFilter(new MaxCCCLostHitsTrajectoryFilter(pset, iC)) {}
+
+  static void fillPSetDescription(edm::ParameterSetDescription& iDesc) {
+    ChargeSignificanceTrajectoryFilter::fillPSetDescription(iDesc);
+    MaxConsecLostHitsTrajectoryFilter::fillPSetDescription(iDesc);
+    MaxHitsTrajectoryFilter::fillPSetDescription(iDesc);
+    MaxLostHitsTrajectoryFilter::fillPSetDescription(iDesc);
+    LostHitsFractionTrajectoryFilter::fillPSetDescription(iDesc);
+    MinHitsTrajectoryFilter::fillPSetDescription(iDesc);
+    MinPtTrajectoryFilter::fillPSetDescription(iDesc);
+    LooperTrajectoryFilter::fillPSetDescription(iDesc);
+    SeedExtensionTrajectoryFilter::fillPSetDescription(iDesc);
+    MaxCCCLostHitsTrajectoryFilter::fillPSetDescription(iDesc);
+  }
 
   void setEvent(const edm::Event& iEvent, const edm::EventSetup& iSetup) override {
     theChargeSignificanceTrajectoryFilter->setEvent(iEvent, iSetup);
@@ -49,19 +61,6 @@ public:
   bool toBeContinued(TempTrajectory& traj) const override { return TBC<TempTrajectory>(traj); }
 
   std::string name() const override { return "CkfBaseTrajectoryFilter"; }
-
-  inline edm::ParameterSetDescription getFilledConfigurationDescription() {
-    edm::ParameterSetDescription descLooper = theLooperTrajectoryFilter->getFilledConfigurationDescription();
-    edm::ParameterSetDescription descLostHitsFraction =
-        theLostHitsFractionTrajectoryFilter->getFilledConfigurationDescription();
-    edm::ParameterSetDescription descMinHits = theMinHitsTrajectoryFilter->getFilledConfigurationDescription();
-
-    edm::ParameterSetDescription desc;
-    desc.add<edm::ParameterSetDescription>("looperTrajectoryFilter", descLooper);
-    desc.add<edm::ParameterSetDescription>("lostHitsFractionTrajectoryFilter", descLostHitsFraction);
-    desc.add<edm::ParameterSetDescription>("minHitsTrajectoryFilter", descMinHits);
-    return desc;
-  }
 
 protected:
   template <class T>

--- a/TrackingTools/TrajectoryFiltering/interface/CompositeTrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/CompositeTrajectoryFilter.h
@@ -1,6 +1,8 @@
 #ifndef CompositeTrajectoryFilter_H
 #define CompositeTrajectoryFilter_H
 
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/PluginDescription.h"
 #include "TrackingTools/TrajectoryFiltering/interface/TrajectoryFilter.h"
 #include "TrackingTools/TrajectoryFiltering/interface/TrajectoryFilterFactory.h"
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
@@ -25,6 +27,13 @@ public:
   }
 
   ~CompositeTrajectoryFilter() override {}
+
+  static void fillPSetDescription(edm::ParameterSetDescription& iDesc) {
+    edm::ParameterSetDescription psdTF;
+    psdTF.addNode(edm::PluginDescription<TrajectoryFilterFactory>("ComponentType", true));
+    std::vector<edm::ParameterSet> vPSetFilters;
+    iDesc.addVPSet("filters", psdTF, vPSetFilters);
+  }
 
   void setEvent(const edm::Event& iEvent, const edm::EventSetup& iSetup) override {
     for (auto& f : filters) {

--- a/TrackingTools/TrajectoryFiltering/interface/LooperTrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/LooperTrajectoryFilter.h
@@ -1,8 +1,8 @@
 #ifndef LooperTrajectoryFilter_H
 #define LooperTrajectoryFilter_H
 
-#include "TrackingTools/TrajectoryFiltering/interface/TrajectoryFilter.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "TrackingTools/TrajectoryFiltering/interface/TrajectoryFilter.h"
 
 class LooperTrajectoryFilter final : public TrajectoryFilter {
 public:
@@ -19,6 +19,12 @@ public:
     theExtraNumberOfHitsBeforeTheFirstLoop = pset.getParameter<int>("extraNumberOfHitsBeforeTheFirstLoop");
   }
 
+  static void fillPSetDescription(edm::ParameterSetDescription& iDesc) {
+    iDesc.add<int>("minNumberOfHitsForLoopers", 13);
+    iDesc.add<int>("minNumberOfHitsPerLoop", 4);
+    iDesc.add<int>("extraNumberOfHitsBeforeTheFirstLoop", 4);
+  }
+
   bool qualityFilter(const Trajectory& traj) const override { return QF<Trajectory>(traj); }
   bool qualityFilter(const TempTrajectory& traj) const override { return QF<TempTrajectory>(traj); }
 
@@ -26,14 +32,6 @@ public:
   bool toBeContinued(Trajectory& traj) const override { return TBC<Trajectory>(traj); }
 
   std::string name() const override { return "LooperTrajectoryFilter"; }
-
-  inline edm::ParameterSetDescription getFilledConfigurationDescription() {
-    edm::ParameterSetDescription desc;
-    desc.add<int>("minNumberOfHitsForLoopers", 13);
-    desc.add<int>("minNumberOfHitsPerLoop", 4);
-    desc.add<int>("extraNumberOfHitsBeforeTheFirstLoop", 4);
-    return desc;
-  }
 
 protected:
   template <class T>

--- a/TrackingTools/TrajectoryFiltering/interface/LostHitsFractionTrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/LostHitsFractionTrajectoryFilter.h
@@ -1,8 +1,8 @@
 #ifndef LostHitsFractionTrajectoryFilter_H
 #define LostHitsFractionTrajectoryFilter_H
 
-#include "TrackingTools/TrajectoryFiltering/interface/TrajectoryFilter.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "TrackingTools/TrajectoryFiltering/interface/TrajectoryFilter.h"
 
 class LostHitsFractionTrajectoryFilter final : public TrajectoryFilter {
 public:
@@ -12,6 +12,11 @@ public:
   explicit LostHitsFractionTrajectoryFilter(const edm::ParameterSet& pset, edm::ConsumesCollector& iC) {
     theMaxLostHitsFraction = pset.getParameter<double>("maxLostHitsFraction");
     theConstantValue = pset.getParameter<double>("constantValueForLostHitsFractionFilter");
+  }
+
+  static void fillPSetDescription(edm::ParameterSetDescription& iDesc) {
+    iDesc.add<double>("maxLostHitsFraction", .1);
+    iDesc.add<double>("constantValueForLostHitsFractionFilter", 2.);
   }
 
   bool qualityFilter(const Trajectory& traj) const override { return TrajectoryFilter::qualityFilterIfNotContributing; }

--- a/TrackingTools/TrajectoryFiltering/interface/MaxCCCLostHitsTrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/MaxCCCLostHitsTrajectoryFilter.h
@@ -1,6 +1,7 @@
 #ifndef MaxCCCLostHitsTrajectoryFilter_H
 #define MaxCCCLostHitsTrajectoryFilter_H
 
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "TrackingTools/TrajectoryFiltering/interface/TrajectoryFilter.h"
 #include "RecoLocalTracker/SiStripClusterizer/interface/ClusterChargeCut.h"
@@ -13,6 +14,11 @@ public:
   explicit MaxCCCLostHitsTrajectoryFilter(const edm::ParameterSet& pset, edm::ConsumesCollector& iC)
       : theMaxCCCLostHits_(pset.getParameter<int>("maxCCCLostHits")),
         minGoodStripCharge_(clusterChargeCut(pset, "minGoodStripCharge")) {}
+
+  static void fillPSetDescription(edm::ParameterSetDescription& iDesc) {
+    iDesc.add<int>("maxCCCLostHits", 9999);
+    iDesc.add<edm::ParameterSetDescription>("minGoodStripCharge", getFilledConfigurationDescription4CCC());
+  }
 
   bool qualityFilter(const Trajectory& traj) const override { return TrajectoryFilter::qualityFilterIfNotContributing; }
   bool qualityFilter(const TempTrajectory& traj) const override {

--- a/TrackingTools/TrajectoryFiltering/interface/MaxConsecLostHitsTrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/MaxConsecLostHitsTrajectoryFilter.h
@@ -1,6 +1,7 @@
 #ifndef MaxConsecLostHitsTrajectoryFilter_H
 #define MaxConsecLostHitsTrajectoryFilter_H
 
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "TrackingTools/TrajectoryFiltering/interface/TrajectoryFilter.h"
 
 class MaxConsecLostHitsTrajectoryFilter final : public TrajectoryFilter {
@@ -9,6 +10,8 @@ public:
 
   explicit MaxConsecLostHitsTrajectoryFilter(const edm::ParameterSet& pset, edm::ConsumesCollector& iC)
       : theMaxConsecLostHits(pset.getParameter<int>("maxConsecLostHits")) {}
+
+  static void fillPSetDescription(edm::ParameterSetDescription& iDesc) { iDesc.add<int>("maxConsecLostHits", 1); }
 
   bool qualityFilter(const Trajectory& traj) const override { return TrajectoryFilter::qualityFilterIfNotContributing; }
   bool qualityFilter(const TempTrajectory& traj) const override {

--- a/TrackingTools/TrajectoryFiltering/interface/MaxHitsTrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/MaxHitsTrajectoryFilter.h
@@ -1,6 +1,7 @@
 #ifndef MaxHitsTrajectoryFilter_H
 #define MaxHitsTrajectoryFilter_H
 
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "TrackingTools/TrajectoryFiltering/interface/TrajectoryFilter.h"
 
 class MaxHitsTrajectoryFilter final : public TrajectoryFilter {
@@ -12,6 +13,8 @@ public:
     if (theMaxHits < 0)
       theMaxHits = 10000;
   }
+
+  static void fillPSetDescription(edm::ParameterSetDescription& iDesc) { iDesc.add<int>("maxNumberOfHits", 100); }
 
   bool qualityFilter(const Trajectory& traj) const override { return TrajectoryFilter::qualityFilterIfNotContributing; }
   bool qualityFilter(const TempTrajectory& traj) const override {

--- a/TrackingTools/TrajectoryFiltering/interface/MaxLostHitsTrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/MaxLostHitsTrajectoryFilter.h
@@ -1,6 +1,7 @@
 #ifndef MaxLostHitsTrajectoryFilter_H
 #define MaxLostHitsTrajectoryFilter_H
 
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "TrackingTools/TrajectoryFiltering/interface/TrajectoryFilter.h"
 
 class MaxLostHitsTrajectoryFilter final : public TrajectoryFilter {
@@ -9,6 +10,8 @@ public:
 
   explicit MaxLostHitsTrajectoryFilter(const edm::ParameterSet& pset, edm::ConsumesCollector& iC)
       : theMaxLostHits(pset.getParameter<int>("maxLostHits")) {}
+
+  static void fillPSetDescription(edm::ParameterSetDescription& iDesc) { iDesc.add<int>("maxLostHits", 999); }
 
   bool qualityFilter(const Trajectory& traj) const override { return TrajectoryFilter::qualityFilterIfNotContributing; }
   bool qualityFilter(const TempTrajectory& traj) const override {

--- a/TrackingTools/TrajectoryFiltering/interface/MinHitsTrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/MinHitsTrajectoryFilter.h
@@ -27,6 +27,13 @@ public:
         theMinHitsAtHighEta(pset.getParameter<int>("minHitsAtHighEta")),
         theSeedPairPenalty(pset.getParameter<int>("seedPairPenalty")) {}
 
+  static void fillPSetDescription(edm::ParameterSetDescription& iDesc) {
+    iDesc.add<int>("minimumNumberOfHits", 5);
+    iDesc.add<double>("highEtaSwitch", 5.0);
+    iDesc.add<int>("minHitsAtHighEta", 5);
+    iDesc.add<int>("seedPairPenalty", 0);
+  }
+
   bool qualityFilter(const Trajectory& traj) const override { return QF<Trajectory>(traj); }
   bool qualityFilter(const TempTrajectory& traj) const override { return QF<TempTrajectory>(traj); }
 
@@ -34,15 +41,6 @@ public:
   bool toBeContinued(Trajectory&) const override { return TrajectoryFilter::toBeContinuedIfNotContributing; }
 
   std::string name() const override { return "MinHitsTrajectoryFilter"; }
-
-  inline edm::ParameterSetDescription getFilledConfigurationDescription() {
-    edm::ParameterSetDescription desc;
-    desc.add<int>("minimumNumberOfHits", 5);
-    desc.add<double>("highEtaSwitch", 5.0);
-    desc.add<int>("minHitsAtHighEta", 5);
-    desc.add<int>("seedPairPenalty", 0);
-    return desc;
-  }
 
 protected:
   template <class T>

--- a/TrackingTools/TrajectoryFiltering/interface/MinPtTrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/MinPtTrajectoryFilter.h
@@ -1,10 +1,10 @@
 #ifndef MinPtTrajectoryFilter_H
 #define MinPtTrajectoryFilter_H
 
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "TrackingTools/TrajectoryFiltering/interface/TrajectoryFilter.h"
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 #include "TrackingTools/PatternTools/interface/TempTrajectory.h"
-
 #include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
 #include "TrackingTools/TrajectoryParametrization/interface/CurvilinearTrajectoryError.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateAccessor.h"
@@ -26,6 +26,12 @@ public:
         theNSigma(pset.getParameter<double>("nSigmaMinPt")),
         theMinHits(pset.getParameter<int>("minHitsMinPt")) {
     thePtMin2 *= thePtMin2;
+  }
+
+  static void fillPSetDescription(edm::ParameterSetDescription& iDesc) {
+    iDesc.add<double>("minPt", 0.9);
+    iDesc.add<double>("nSigmaMinPt", 5.0);
+    iDesc.add<int>("minHitsMinPt", 3);
   }
 
   bool qualityFilter(const Trajectory& traj) const override { return test(traj.lastMeasurement(), traj.foundHits()); }

--- a/TrackingTools/TrajectoryFiltering/interface/SeedExtensionTrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/SeedExtensionTrajectoryFilter.h
@@ -1,6 +1,7 @@
 #ifndef SeedExtensionTrajectoryFilter_H
 #define SeedExtensionTrajectoryFilter_H
 
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "TrackingTools/TrajectoryFiltering/interface/TrajectoryFilter.h"
 
 class SeedExtensionTrajectoryFilter final : public TrajectoryFilter {
@@ -11,6 +12,12 @@ public:
       : theStrict(pset.getParameter<bool>("strictSeedExtension")),
         thePixel(pset.getParameter<bool>("pixelSeedExtension")),
         theExtension(pset.getParameter<int>("seedExtension")) {}
+
+  static void fillPSetDescription(edm::ParameterSetDescription& iDesc) {
+    iDesc.add<bool>("strictSeedExtension", false);
+    iDesc.add<bool>("pixelSeedExtension", false);
+    iDesc.add<int>("seedExtension", 0);
+  }
 
   bool qualityFilter(const Trajectory& traj) const override { return QF(traj); }
   bool qualityFilter(const TempTrajectory& traj) const override { return QF(traj); }

--- a/TrackingTools/TrajectoryFiltering/interface/ThresholdPtTrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/ThresholdPtTrajectoryFilter.h
@@ -1,10 +1,10 @@
 #ifndef ThresholdPtTrajectoryFilter_H
 #define ThresholdPtTrajectoryFilter_H
 
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "TrackingTools/TrajectoryFiltering/interface/TrajectoryFilter.h"
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 #include "TrackingTools/PatternTools/interface/TempTrajectory.h"
-
 #include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
 #include "TrackingTools/TrajectoryParametrization/interface/CurvilinearTrajectoryError.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateAccessor.h"
@@ -24,6 +24,12 @@ public:
       : thePtThreshold(pset.getParameter<double>("thresholdPt")),
         theNSigma(pset.getParameter<double>("nSigmaThresholdPt")),
         theMinHits(pset.getParameter<int>("minHitsThresholdPt")) {}
+
+  static void fillPSetDescription(edm::ParameterSetDescription& iDesc) {
+    iDesc.add<double>("thresholdPt", 10.);
+    iDesc.add<double>("nSigmaThresholdPt", 5.);
+    iDesc.add<int>("minHitsThresholdPt", 3);
+  }
 
   bool qualityFilter(const Trajectory& traj) const override { return !test(traj.lastMeasurement(), traj.foundHits()); }
   bool qualityFilter(const TempTrajectory& traj) const override {

--- a/TrackingTools/TrajectoryFiltering/plugins/modules.cc
+++ b/TrackingTools/TrajectoryFiltering/plugins/modules.cc
@@ -1,6 +1,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/ParameterSet/interface/ValidatedPluginMacros.h"
 
 #include "TrackingTools/TrajectoryFiltering/interface/TrajectoryFilterFactory.h"
 
@@ -15,13 +16,17 @@
 #include "TrackingTools/TrajectoryFiltering/interface/CkfBaseTrajectoryFilter.h"
 #include "TrackingTools/TrajectoryFiltering/interface/ChargeSignificanceTrajectoryFilter.h"
 
-DEFINE_EDM_PLUGIN(TrajectoryFilterFactory, MaxHitsTrajectoryFilter, "MaxHitsTrajectoryFilter");
-DEFINE_EDM_PLUGIN(TrajectoryFilterFactory, MinHitsTrajectoryFilter, "MinHitsTrajectoryFilter");
-DEFINE_EDM_PLUGIN(TrajectoryFilterFactory, MaxLostHitsTrajectoryFilter, "MaxLostHitsTrajectoryFilter");
-DEFINE_EDM_PLUGIN(TrajectoryFilterFactory, MaxConsecLostHitsTrajectoryFilter, "MaxConsecLostHitsTrajectoryFilter");
-DEFINE_EDM_PLUGIN(TrajectoryFilterFactory, MaxCCCLostHitsTrajectoryFilter, "MaxCCCLostHitsTrajectoryFilter");
-DEFINE_EDM_PLUGIN(TrajectoryFilterFactory, MinPtTrajectoryFilter, "MinPtTrajectoryFilter");
-DEFINE_EDM_PLUGIN(TrajectoryFilterFactory, ThresholdPtTrajectoryFilter, "ThresholdPtTrajectoryFilter");
-DEFINE_EDM_PLUGIN(TrajectoryFilterFactory, CompositeTrajectoryFilter, "CompositeTrajectoryFilter");
-DEFINE_EDM_PLUGIN(TrajectoryFilterFactory, CkfBaseTrajectoryFilter, "CkfBaseTrajectoryFilter");
-DEFINE_EDM_PLUGIN(TrajectoryFilterFactory, ChargeSignificanceTrajectoryFilter, "ChargeSignificanceTrajectoryFilter");
+DEFINE_EDM_VALIDATED_PLUGIN(TrajectoryFilterFactory, MaxHitsTrajectoryFilter, "MaxHitsTrajectoryFilter");
+DEFINE_EDM_VALIDATED_PLUGIN(TrajectoryFilterFactory, MinHitsTrajectoryFilter, "MinHitsTrajectoryFilter");
+DEFINE_EDM_VALIDATED_PLUGIN(TrajectoryFilterFactory, MaxLostHitsTrajectoryFilter, "MaxLostHitsTrajectoryFilter");
+DEFINE_EDM_VALIDATED_PLUGIN(TrajectoryFilterFactory,
+                            MaxConsecLostHitsTrajectoryFilter,
+                            "MaxConsecLostHitsTrajectoryFilter");
+DEFINE_EDM_VALIDATED_PLUGIN(TrajectoryFilterFactory, MaxCCCLostHitsTrajectoryFilter, "MaxCCCLostHitsTrajectoryFilter");
+DEFINE_EDM_VALIDATED_PLUGIN(TrajectoryFilterFactory, MinPtTrajectoryFilter, "MinPtTrajectoryFilter");
+DEFINE_EDM_VALIDATED_PLUGIN(TrajectoryFilterFactory, ThresholdPtTrajectoryFilter, "ThresholdPtTrajectoryFilter");
+DEFINE_EDM_VALIDATED_PLUGIN(TrajectoryFilterFactory, CompositeTrajectoryFilter, "CompositeTrajectoryFilter");
+DEFINE_EDM_VALIDATED_PLUGIN(TrajectoryFilterFactory, CkfBaseTrajectoryFilter, "CkfBaseTrajectoryFilter");
+DEFINE_EDM_VALIDATED_PLUGIN(TrajectoryFilterFactory,
+                            ChargeSignificanceTrajectoryFilter,
+                            "ChargeSignificanceTrajectoryFilter");

--- a/TrackingTools/TrajectoryFiltering/src/TrajectoryFilterFactory.cc
+++ b/TrackingTools/TrajectoryFiltering/src/TrajectoryFilterFactory.cc
@@ -1,3 +1,4 @@
 #include "TrackingTools/TrajectoryFiltering/interface/TrajectoryFilterFactory.h"
+#include "FWCore/ParameterSet/interface/ValidatedPluginFactoryMacros.h"
 
-EDM_REGISTER_PLUGINFACTORY(TrajectoryFilterFactory, "TrajectoryFilterFactory");
+EDM_REGISTER_VALIDATED_PLUGINFACTORY(TrajectoryFilterFactory, "TrajectoryFilterFactory");


### PR DESCRIPTION
#### PR description:

This PR is an attempt to integrate the changes developed in #35385 (credits: @mmusich), in order to address #35344.

This PR starts from the last bit of development mentioned in https://github.com/cms-sw/cmssw/pull/35385#issuecomment-941068911, rebased on a recent IB; more information on how these changes came together can be found in #35385. Since the latter slowed down, I'm opening another PR to at least test those latest changes.

Adding a `fillDescriptions` method to `CkfTrackCandidateMaker` required more work than expected, because of the many dependencies of this plugin. Going down the rabbit hole of adding `fillDescriptions` for all the relevant classes led to touching a large number of files, both in the `c++` and `python` interfaces. The introduction of `fillDescriptions` methods in these classes exposed a number of unused parameters in PSets of various modules. In order to clean these up, customisations for the HLT configs were also necessary.

Merely technical. ~~Must not change any of the outputs.~~ No changes expected.

#### PR validation:

`addOnTests`, unit tests, and a limited set of matrix workflows passed. No detailed physics validation, only verified that the HLT decisions for a few wfs (max. 10 events each) are unchanged.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

N/A