### PR TITLE
Run3-sim100B Move the fileservice variable from class member to a local variable in SimG4CMS/Calo

### DIFF
--- a/SimG4CMS/Calo/interface/HcalTestHistoManager.h
+++ b/SimG4CMS/Calo/interface/HcalTestHistoManager.h
@@ -27,7 +27,6 @@ public:
   void fillTree(HcalTestHistoClass* histos);
 
 private:
-  edm::Service<TFileService> fs_;
   TTree* tree_;
   std::unique_ptr<HcalTestHistoClass> h_;
   int kount_;

--- a/SimG4CMS/Calo/plugins/HcalTestAnalyzer.cc
+++ b/SimG4CMS/Calo/plugins/HcalTestAnalyzer.cc
@@ -36,7 +36,6 @@ public:
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
 private:
-  edm::Service<TFileService> fs_;
   TTree* tree_;
   HcalTestHistoClass h_;
   edm::EDGetTokenT<HcalTestHistoClass> tokHist_;
@@ -46,8 +45,9 @@ private:
 HcalTestAnalyzer::HcalTestAnalyzer(const edm::ParameterSet&) : tree_(nullptr), kount_(0) {
   usesResource(TFileService::kSharedResource);
   tokHist_ = consumes<HcalTestHistoClass>(edm::InputTag("g4SimHits"));
-  if (fs_.isAvailable()) {
-    tree_ = fs_->make<TTree>("HcalTest", "HcalTest");
+  edm::Service<TFileService> fs;
+  if (fs.isAvailable()) {
+    tree_ = fs->make<TTree>("HcalTest", "HcalTest");
     tree_->SetAutoSave(10000);
     tree_->Branch("HcalTestHistoClass", &h_);
     edm::LogVerbatim("HcalSim") << "HcalTestAnalyzer:===>>>  Book the Tree";

--- a/SimG4CMS/Calo/src/HcalTestHistoManager.cc
+++ b/SimG4CMS/Calo/src/HcalTestHistoManager.cc
@@ -15,10 +15,11 @@
 //#define EDM_ML_DEBUG
 
 HcalTestHistoManager::HcalTestHistoManager(const std::string& file) : tree_(nullptr), kount_(0) {
-  if (fs_.isAvailable()) {
+  edm::Service<TFileService> fs;
+  if (fs.isAvailable()) {
     h_ = std::make_unique<HcalTestHistoClass>();
 
-    tree_ = fs_->make<TTree>("HcalTest", "HcalTest");
+    tree_ = fs->make<TTree>("HcalTest", "HcalTest");
     tree_->SetAutoSave(10000);
     tree_->Branch("HcalTestHisto", "HcalTestHistoClass", &h_);
     edm::LogVerbatim("HcalSim") << "HcalTestHistoManager:===>>>  Book the Tree";


### PR DESCRIPTION
#### PR description:

Move the fileservice variable from class member to a local variable in SimG4CMS/Calo

#### PR validation:

Use the runTheMatrix test workflows

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special