### PR TITLE
DBOutputService: Removed deprecated methods

### DIFF
--- a/CalibMuon/DTCalibration/interface/DTCalibDBUtils.h
+++ b/CalibMuon/DTCalibration/interface/DTCalibDBUtils.h
@@ -25,17 +25,17 @@ public:
   /// Write the payload to the DB using PoolDBOutputService.
   /// New payload are created in the DB, existing payload are appended.
   template <typename T>
-  static void writeToDB(std::string record, T* payload) {
+  static void writeToDB(std::string record, const T& payload) {
     // Write the ttrig object to DB
     edm::Service<cond::service::PoolDBOutputService> dbOutputSvc;
     if (dbOutputSvc.isAvailable()) {
       try {
         if (dbOutputSvc->isNewTagRequest(record)) {
           //create mode
-          dbOutputSvc->writeOne<T>(payload, dbOutputSvc->beginOfTime(), record);
+          dbOutputSvc->writeOneIOV<T>(payload, dbOutputSvc->beginOfTime(), record);
         } else {
           //append mode. Note: correct PoolDBESSource must be loaded
-          dbOutputSvc->writeOne<T>(payload, dbOutputSvc->currentTime(), record);
+          dbOutputSvc->writeOneIOV<T>(payload, dbOutputSvc->currentTime(), record);
         }
       } catch (const cond::Exception& er) {
         std::cout << er.what() << std::endl;

--- a/CalibMuon/DTCalibration/plugins/DTNoiseCalibration.cc
+++ b/CalibMuon/DTCalibration/plugins/DTNoiseCalibration.cc
@@ -356,7 +356,7 @@ void DTNoiseCalibration::endJob() {
   }
 
   // Save on file the occupancy histos and write the list of noisy cells
-  DTStatusFlag* statusMap = new DTStatusFlag();
+  DTStatusFlag statusMap;
   for (map<DTLayerId, TH1F*>::const_iterator lHisto = theHistoOccupancyMap_.begin();
        lHisto != theHistoOccupancyMap_.end();
        ++lHisto) {
@@ -405,7 +405,7 @@ void DTNoiseCalibration::endJob() {
         double rateOffset = (useAbsoluteRate_) ? 0. : averageRate;
         if ((channelRate - rateOffset) > maximumNoiseRate_) {
           DTWireId wireID((*lHisto).first, i_wire);
-          statusMap->setCellNoise(wireID, true);
+          statusMap.setCellNoise(wireID, true);
           LogVerbatim("Calibration") << ">>> Channel noisy: " << wireID;
         }
       }

--- a/CalibMuon/DTCalibration/plugins/DTT0Correction.cc
+++ b/CalibMuon/DTCalibration/plugins/DTT0Correction.cc
@@ -55,7 +55,7 @@ void DTT0Correction::beginRun(const edm::Run& run, const edm::EventSetup& setup)
 
 void DTT0Correction::endJob() {
   // Create the object to be written to DB
-  DTT0* t0NewMap = new DTT0();
+  DTT0 t0NewMap;
 
   // Loop over all channels
   for (vector<const DTSuperLayer*>::const_iterator sl = muonGeom_->superLayers().begin();
@@ -82,7 +82,7 @@ void DTT0Correction::endJob() {
           dtCalibration::DTT0Data t0Corr = correctionAlgo_->correction(wireId);
           float t0MeanNew = t0Corr.mean;
           float t0RMSNew = t0Corr.rms;
-          t0NewMap->set(wireId, t0MeanNew, t0RMSNew, DTTimeUnits::counts);
+          t0NewMap.set(wireId, t0MeanNew, t0RMSNew, DTTimeUnits::counts);
 
           LogVerbatim("Calibration") << "New t0 for: " << wireId << " mean from " << t0Mean << " to " << t0MeanNew
                                      << " rms from " << t0RMS << " to " << t0RMSNew << endl;
@@ -90,7 +90,7 @@ void DTT0Correction::endJob() {
           LogError("Calibration") << e.explainSelf();
           // Set db to the old value, if it was there in the first place
           if (!status) {
-            t0NewMap->set(wireId, t0Mean, t0RMS, DTTimeUnits::counts);
+            t0NewMap.set(wireId, t0Mean, t0RMS, DTTimeUnits::counts);
             LogVerbatim("Calibration") << "Keep old t0 for: " << wireId << " mean " << t0Mean << " rms " << t0RMS
                                        << endl;
           }

--- a/CalibMuon/DTCalibration/plugins/DTTTrigCorrection.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigCorrection.cc
@@ -63,7 +63,7 @@ void DTTTrigCorrection::beginRun(const edm::Run& run, const edm::EventSetup& set
 
 void DTTTrigCorrection::endJob() {
   // Create the object to be written to DB
-  DTTtrig* tTrigNewMap = new DTTtrig();
+  DTTtrig tTrigNewMap;
 
   for (vector<const DTSuperLayer*>::const_iterator sl = muonGeom_->superLayers().begin();
        sl != muonGeom_->superLayers().end();
@@ -78,7 +78,7 @@ void DTTTrigCorrection::endJob() {
       float tTrigMeanNew = tTrigCorr.mean;
       float tTrigSigmaNew = tTrigCorr.sigma;
       float kFactorNew = tTrigCorr.kFactor;
-      tTrigNewMap->set((*sl)->id(), tTrigMeanNew, tTrigSigmaNew, kFactorNew, DTTimeUnits::ns);
+      tTrigNewMap.set((*sl)->id(), tTrigMeanNew, tTrigSigmaNew, kFactorNew, DTTimeUnits::ns);
 
       LogVerbatim("Calibration") << "New tTrig for: " << (*sl)->id() << " mean from " << tTrigMean << " to "
                                  << tTrigMeanNew << " sigma from " << tTrigSigma << " to " << tTrigSigmaNew
@@ -87,7 +87,7 @@ void DTTTrigCorrection::endJob() {
       LogError("Calibration") << e.explainSelf();
       // Set db to the old value, if it was there in the first place
       if (!status) {
-        tTrigNewMap->set((*sl)->id(), tTrigMean, tTrigSigma, kFactor, DTTimeUnits::ns);
+        tTrigNewMap.set((*sl)->id(), tTrigMean, tTrigSigma, kFactor, DTTimeUnits::ns);
         LogVerbatim("Calibration") << "Keep old tTrig for: " << (*sl)->id() << " mean " << tTrigMean << " sigma "
                                    << tTrigSigma << " kFactor " << kFactor << endl;
       }

--- a/CalibMuon/DTCalibration/plugins/DTTTrigCorrectionFirst.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigCorrectionFirst.cc
@@ -47,7 +47,7 @@ void DTTTrigCorrectionFirst::beginRun(const edm::Run& run, const edm::EventSetup
 
 void DTTTrigCorrectionFirst::endJob() {
   // Create the object to be written to DB
-  DTTtrig* tTrigNewMap = new DTTtrig();
+  DTTtrig tTrigNewMap;
   //Get the superlayers list
   vector<const DTSuperLayer*> dtSupLylist = muonGeom->superLayers();
 
@@ -225,7 +225,7 @@ void DTTTrigCorrectionFirst::endJob() {
     }
 
     //Store new ttrig in the new map
-    tTrigNewMap->set((*sl)->id(), newTTrigMean, newTTrigSigma, newkfactor, DTTimeUnits::ns);
+    tTrigNewMap.set((*sl)->id(), newTTrigMean, newTTrigSigma, newkfactor, DTTimeUnits::ns);
     if (debug) {
       cout << "New tTrig: " << (*sl)->id() << " from " << ttrigMean << " to " << newTTrigMean << endl;
       cout << "New tTrigSigma: " << (*sl)->id() << " from " << ttrigSigma << " to " << newTTrigSigma << endl;

--- a/CalibMuon/DTCalibration/plugins/DTVDriftCalibration.cc
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftCalibration.cc
@@ -280,12 +280,12 @@ void DTVDriftCalibration::endJob() {
   // Instantiate a DTCalibrationMap object if you want to calculate the calibration constants
   DTCalibrationMap calibValuesFile(theCalibFilePar);
   // Create the object to be written to DB
-  DTMtime* mTime = nullptr;
-  DTRecoConditions* vDrift = nullptr;
+  std::unique_ptr<DTMtime> mTime;
+  std::unique_ptr<DTRecoConditions> vDrift;
   if (writeLegacyVDriftDB) {
-    mTime = new DTMtime();
+    mTime = std::make_unique<DTMtime>();
   } else {
-    vDrift = new DTRecoConditions();
+    vDrift = std::make_unique<DTRecoConditions>();
     vDrift->setFormulaExpr("[0]");
     //vDriftNewMap->setFormulaExpr("[0]*(1-[1]*x)"); // add parametrization for dependency along Y
     vDrift->setVersion(1);
@@ -381,9 +381,9 @@ void DTVDriftCalibration::endJob() {
   // Write the vdrift object to DB
   if (writeLegacyVDriftDB) {
     string record = "DTMtimeRcd";
-    DTCalibDBUtils::writeToDB<DTMtime>(record, mTime);
+    DTCalibDBUtils::writeToDB<DTMtime>(record, *mTime);
   } else {
-    DTCalibDBUtils::writeToDB<DTRecoConditions>("DTRecoConditionsVdriftRcd", vDrift);
+    DTCalibDBUtils::writeToDB<DTRecoConditions>("DTRecoConditionsVdriftRcd", *vDrift);
   }
 }
 

--- a/CalibMuon/DTCalibration/plugins/DTVDriftWriter.cc
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftWriter.cc
@@ -76,12 +76,12 @@ void DTVDriftWriter::beginRun(const edm::Run& run, const edm::EventSetup& setup)
 
 void DTVDriftWriter::endJob() {
   // Create the object to be written to DB
-  DTMtime* mTimeNewMap = nullptr;
-  DTRecoConditions* vDriftNewMap = nullptr;
+  std::unique_ptr<DTMtime> mTimeNewMap;
+  std::unique_ptr<DTRecoConditions> vDriftNewMap;
   if (writeLegacyVDriftDB) {
-    mTimeNewMap = new DTMtime();
+    mTimeNewMap = std::make_unique<DTMtime>();
   } else {
-    vDriftNewMap = new DTRecoConditions();
+    vDriftNewMap = std::make_unique<DTRecoConditions>();
     vDriftNewMap->setFormulaExpr("[0]");
     //vDriftNewMap->setFormulaExpr("[0]*(1-[1]*x)"); // add parametrization for dependency along Y
     vDriftNewMap->setVersion(1);
@@ -137,8 +137,8 @@ void DTVDriftWriter::endJob() {
   LogVerbatim("Calibration") << "[DTVDriftWriter]Writing vdrift object to DB!";
   if (writeLegacyVDriftDB) {
     string record = "DTMtimeRcd";
-    DTCalibDBUtils::writeToDB<DTMtime>(record, mTimeNewMap);
+    DTCalibDBUtils::writeToDB<DTMtime>(record, *mTimeNewMap);
   } else {
-    DTCalibDBUtils::writeToDB<DTRecoConditions>("DTRecoConditionsVdriftRcd", vDriftNewMap);
+    DTCalibDBUtils::writeToDB<DTRecoConditions>("DTRecoConditionsVdriftRcd", *vDriftNewMap);
   }
 }

--- a/CalibMuon/DTCalibration/test/DBTools/DumpFileToDB.cc
+++ b/CalibMuon/DTCalibration/test/DBTools/DumpFileToDB.cc
@@ -72,7 +72,7 @@ void DumpFileToDB::endJob() {
   //---------- VDrift
   if (dbToDump == "VDriftDB") {
     if (format == "Legacy") {
-      DTMtime* mtime = new DTMtime();
+      DTMtime mtime;
       for (DTCalibrationMap::const_iterator keyAndCalibs = theCalibFile->keyAndConsts_begin();
            keyAndCalibs != theCalibFile->keyAndConsts_end();
            ++keyAndCalibs) {
@@ -80,18 +80,18 @@ void DumpFileToDB::endJob() {
         // 	     << " vdrift (cm/ns): " << theCalibFile->meanVDrift((*keyAndCalibs).first)
         // 	     << " hit reso (cm): " << theCalibFile->sigma_meanVDrift((*keyAndCalibs).first) << endl;
         // vdrift is cm/ns , resolution is cm
-        mtime->set((*keyAndCalibs).first.superlayerId(),
-                   theCalibFile->meanVDrift((*keyAndCalibs).first),
-                   theCalibFile->sigma_meanVDrift((*keyAndCalibs).first),
-                   DTVelocityUnits::cm_per_ns);
+        mtime.set((*keyAndCalibs).first.superlayerId(),
+                  theCalibFile->meanVDrift((*keyAndCalibs).first),
+                  theCalibFile->sigma_meanVDrift((*keyAndCalibs).first),
+                  DTVelocityUnits::cm_per_ns);
       }
       DTCalibDBUtils::writeToDB<DTMtime>("DTMtimeRcd", mtime);
     } else if (format == "DTRecoConditions") {
-      DTRecoConditions* conds = new DTRecoConditions();
-      conds->setFormulaExpr("[0]");
-      //      conds->setFormulaExpr("[0]*(1-[1]*x)");
+      DTRecoConditions conds;
+      conds.setFormulaExpr("[0]");
+      //      conds.setFormulaExpr("[0]*(1-[1]*x)");
       int version = 1;
-      conds->setVersion(version);
+      conds.setVersion(version);
       for (DTCalibrationMap::const_iterator keyAndCalibs = theCalibFile->keyAndConsts_begin();
            keyAndCalibs != theCalibFile->keyAndConsts_end();
            ++keyAndCalibs) {
@@ -107,7 +107,7 @@ void DumpFileToDB::endJob() {
           throw cms::Exception("IncorrectSetup") << "Inconsistent version of file";
 
         vector<double> params(values.begin() + 11, values.begin() + 11 + nfields);
-        conds->set((*keyAndCalibs).first, params);
+        conds.set((*keyAndCalibs).first, params);
       }
       DTCalibDBUtils::writeToDB<DTRecoConditions>("DTRecoConditionsVdriftRcd", conds);
     }
@@ -115,7 +115,7 @@ void DumpFileToDB::endJob() {
     //---------- TTrig
   } else if (dbToDump == "TTrigDB") {
     if (format == "Legacy") {
-      DTTtrig* tTrig = new DTTtrig();
+      DTTtrig tTrig;
       for (DTCalibrationMap::const_iterator keyAndCalibs = theCalibFile->keyAndConsts_begin();
            keyAndCalibs != theCalibFile->keyAndConsts_end();
            ++keyAndCalibs) {
@@ -131,11 +131,11 @@ void DumpFileToDB::endJob() {
                 << "The differentialMode can only be used with kFactor = 0, old: " << kFactor
                 << " new: " << theCalibFile->kFactor((*keyAndCalibs).first);
           }
-          tTrig->set((*keyAndCalibs).first.superlayerId(),
-                     theCalibFile->tTrig((*keyAndCalibs).first) + tmean,
-                     theCalibFile->sigma_tTrig((*keyAndCalibs).first),
-                     theCalibFile->kFactor((*keyAndCalibs).first),
-                     DTTimeUnits::ns);
+          tTrig.set((*keyAndCalibs).first.superlayerId(),
+                    theCalibFile->tTrig((*keyAndCalibs).first) + tmean,
+                    theCalibFile->sigma_tTrig((*keyAndCalibs).first),
+                    theCalibFile->kFactor((*keyAndCalibs).first),
+                    DTTimeUnits::ns);
           // 	  cout << "key: " << (*keyAndCalibs).first
           // 	       << " ttrig_mean (ns): " << theCalibFile->tTrig((*keyAndCalibs).first) + tmean
           // 	       << " ttrig_sigma(ns): " << theCalibFile->sigma_tTrig((*keyAndCalibs).first)
@@ -146,20 +146,20 @@ void DumpFileToDB::endJob() {
                   // 	       << " ttrig_mean (ns): " << theCalibFile->tTrig((*keyAndCalibs).first)
                   // 	       << " ttrig_sigma(ns): " << theCalibFile->sigma_tTrig((*keyAndCalibs).first)
                   // 	       << " kFactor: " << theCalibFile->kFactor((*keyAndCalibs).first) << endl;
-          tTrig->set((*keyAndCalibs).first.superlayerId(),
-                     theCalibFile->tTrig((*keyAndCalibs).first),
-                     theCalibFile->sigma_tTrig((*keyAndCalibs).first),
-                     theCalibFile->kFactor((*keyAndCalibs).first),
-                     DTTimeUnits::ns);
+          tTrig.set((*keyAndCalibs).first.superlayerId(),
+                    theCalibFile->tTrig((*keyAndCalibs).first),
+                    theCalibFile->sigma_tTrig((*keyAndCalibs).first),
+                    theCalibFile->kFactor((*keyAndCalibs).first),
+                    DTTimeUnits::ns);
         }
       }
       DTCalibDBUtils::writeToDB<DTTtrig>("DTTtrigRcd", tTrig);
 
     } else if (format == "DTRecoConditions") {
-      DTRecoConditions* conds = new DTRecoConditions();
-      conds->setFormulaExpr("[0]");
+      DTRecoConditions conds;
+      conds.setFormulaExpr("[0]");
       int version = 1;
-      conds->setVersion(version);
+      conds.setVersion(version);
 
       for (DTCalibrationMap::const_iterator keyAndCalibs = theCalibFile->keyAndConsts_begin();
            keyAndCalibs != theCalibFile->keyAndConsts_end();
@@ -177,7 +177,7 @@ void DumpFileToDB::endJob() {
           throw cms::Exception("IncorrectSetup") << "Inconsistent version of file";
 
         vector<double> params(values.begin() + 11, values.begin() + 11 + nfields);
-        conds->set((*keyAndCalibs).first, params);
+        conds.set((*keyAndCalibs).first, params);
       }
       DTCalibDBUtils::writeToDB<DTRecoConditions>("DTRecoConditionsTtrigRcd", conds);
     }
@@ -185,7 +185,7 @@ void DumpFileToDB::endJob() {
   } else if (dbToDump == "TZeroDB") {  // Write the T0
 
     // Create the object to be written to DB
-    DTT0* tZeroMap = new DTT0();
+    DTT0 tZeroMap;
 
     // Loop over file entries
     for (DTCalibrationMap::const_iterator keyAndCalibs = theCalibFile->keyAndConsts_begin();
@@ -195,40 +195,40 @@ void DumpFileToDB::endJob() {
       float t0rms = (*keyAndCalibs).second[6];
       cout << "key: " << (*keyAndCalibs).first << " T0 mean (TDC counts): " << t0mean
            << " T0_rms (TDC counts): " << t0rms << endl;
-      tZeroMap->set((*keyAndCalibs).first, t0mean, t0rms, DTTimeUnits::counts);
+      tZeroMap.set((*keyAndCalibs).first, t0mean, t0rms, DTTimeUnits::counts);
     }
 
     DTCalibDBUtils::writeToDB<DTT0>("DTT0Rcd", tZeroMap);
 
   } else if (dbToDump == "NoiseDB") {  // Write the Noise
-    DTStatusFlag* statusMap = new DTStatusFlag();
+    DTStatusFlag statusMap;
 
     // Loop over file entries
     for (DTCalibrationMap::const_iterator keyAndCalibs = theCalibFile->keyAndConsts_begin();
          keyAndCalibs != theCalibFile->keyAndConsts_end();
          ++keyAndCalibs) {
       cout << "key: " << (*keyAndCalibs).first << " Noisy flag: " << (*keyAndCalibs).second[7] << endl;
-      statusMap->setCellNoise((*keyAndCalibs).first, (*keyAndCalibs).second[7]);
+      statusMap.setCellNoise((*keyAndCalibs).first, (*keyAndCalibs).second[7]);
     }
 
     DTCalibDBUtils::writeToDB<DTStatusFlag>("DTStatusFlagRcd", statusMap);
 
   } else if (dbToDump == "DeadDB") {  // Write the tp-dead
-    DTDeadFlag* deadMap = new DTDeadFlag();
+    DTDeadFlag deadMap;
 
     // Loop over file entries
     for (DTCalibrationMap::const_iterator keyAndCalibs = theCalibFile->keyAndConsts_begin();
          keyAndCalibs != theCalibFile->keyAndConsts_end();
          ++keyAndCalibs) {
       cout << "key: " << (*keyAndCalibs).first << " dead flag: " << (*keyAndCalibs).second[7] << endl;
-      deadMap->setCellDead_TP((*keyAndCalibs).first, (*keyAndCalibs).second[7]);
+      deadMap.setCellDead_TP((*keyAndCalibs).first, (*keyAndCalibs).second[7]);
     }
 
     DTCalibDBUtils::writeToDB<DTDeadFlag>("DTDeadFlagRcd", deadMap);
 
   } else if (dbToDump == "ChannelsDB") {  //Write channels map
 
-    DTReadOutMapping* ro_map = new DTReadOutMapping("cmssw_ROB", "cmssw_ROS");
+    DTReadOutMapping ro_map("cmssw_ROB", "cmssw_ROS");
     //Loop over file entries
     string line;
     ifstream file(mapFileName.c_str());
@@ -238,17 +238,17 @@ void DumpFileToDB::endJob() {
       stringstream linestr;
       linestr << line;
       vector<int> channelMap = readChannelsMap(linestr);
-      int status = ro_map->insertReadOutGeometryLink(channelMap[0],
-                                                     channelMap[1],
-                                                     channelMap[2],
-                                                     channelMap[3],
-                                                     channelMap[4],
-                                                     channelMap[5],
-                                                     channelMap[6],
-                                                     channelMap[7],
-                                                     channelMap[8],
-                                                     channelMap[9],
-                                                     channelMap[10]);
+      int status = ro_map.insertReadOutGeometryLink(channelMap[0],
+                                                    channelMap[1],
+                                                    channelMap[2],
+                                                    channelMap[3],
+                                                    channelMap[4],
+                                                    channelMap[5],
+                                                    channelMap[6],
+                                                    channelMap[7],
+                                                    channelMap[8],
+                                                    channelMap[9],
+                                                    channelMap[10]);
       cout << "ddu " << channelMap[0] << " "
            << "ros " << channelMap[1] << " "
            << "rob " << channelMap[2] << " "
@@ -268,10 +268,10 @@ void DumpFileToDB::endJob() {
     //---------- Uncertainties
   } else if (dbToDump == "RecoUncertDB") {  // Write the Uncertainties
 
-    DTRecoConditions* conds = new DTRecoConditions();
-    conds->setFormulaExpr("par[step]");
+    DTRecoConditions conds;
+    conds.setFormulaExpr("par[step]");
     int version = 1;  // Uniform uncertainties per SL and step; parameters 0-3 are for steps 1-4.
-    conds->setVersion(version);
+    conds.setVersion(version);
 
     for (DTCalibrationMap::const_iterator keyAndCalibs = theCalibFile->keyAndConsts_begin();
          keyAndCalibs != theCalibFile->keyAndConsts_end();
@@ -288,7 +288,7 @@ void DumpFileToDB::endJob() {
         throw cms::Exception("IncorrectSetup") << "Inconsistent version of file";
 
       vector<double> params(values.begin() + 11, values.begin() + 11 + nfields);
-      conds->set((*keyAndCalibs).first, params);
+      conds.set((*keyAndCalibs).first, params);
       DTCalibDBUtils::writeToDB<DTRecoConditions>("DTRecoConditionsUncertRcd", conds);
     }
   }

--- a/CalibMuon/DTCalibration/test/DBTools/FakeTTrig.cc
+++ b/CalibMuon/DTCalibration/test/DBTools/FakeTTrig.cc
@@ -78,7 +78,7 @@ void FakeTTrig::beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::Even
     // Get the superlayers and layers list
     vector<const DTSuperLayer*> dtSupLylist = muonGeom->superLayers();
     // Create the object to be written to DB
-    DTTtrig* tTrigMap = new DTTtrig();
+    DTTtrig tTrigMap;
 
     for (auto sl = dtSupLylist.begin(); sl != dtSupLylist.end(); sl++) {
       // get the time of fly
@@ -101,7 +101,7 @@ void FakeTTrig::beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::Even
       double fakeTTrig = pedestral + timeOfFly + timeOfWirePropagation + gaussianSmearing;
       // if the FakeTtrig is scaled of a number of bunch crossing
       //  double fakeTTrig = pedestral - 75.;
-      tTrigMap->set(slId, fakeTTrig, 0, 0, DTTimeUnits::ns);
+      tTrigMap.set(slId, fakeTTrig, 0, 0, DTTimeUnits::ns);
     }
 
     // Write the object in the DB

--- a/CalibMuon/DTCalibration/test/DBTools/ShiftTTrigDB.cc
+++ b/CalibMuon/DTCalibration/test/DBTools/ShiftTTrigDB.cc
@@ -66,7 +66,7 @@ void ShiftTTrigDB::beginRun(const edm::Run&, const EventSetup& setup) {
 
 void ShiftTTrigDB::endJob() {
   // Create the object to be written to DB
-  DTTtrig* tTrigNewMap = new DTTtrig();
+  DTTtrig tTrigNewMap;
   //Get the superlayers list
   vector<const DTSuperLayer*> dtSupLylist = muonGeom->superLayers();
 
@@ -90,7 +90,7 @@ void ShiftTTrigDB::endJob() {
             //Compute new ttrig
             double newTTrigMean = ttrigMean + mapShiftsByChamber[(*ch)];
             //Store new ttrig in the new map
-            tTrigNewMap->set((*sl)->id(), newTTrigMean, ttrigSigma, kFactor, DTTimeUnits::ns);
+            tTrigNewMap.set((*sl)->id(), newTTrigMean, ttrigSigma, kFactor, DTTimeUnits::ns);
             ttrigShifted = true;
             if (debug) {
               cout << "Shifting SL: " << (*sl)->id() << " from " << ttrigMean << " to " << newTTrigMean << endl;
@@ -101,7 +101,7 @@ void ShiftTTrigDB::endJob() {
     }  //End loop on chambers to be shifted
     if (!ttrigShifted) {
       //Store old ttrig in the new map
-      tTrigNewMap->set((*sl)->id(), ttrigMean, ttrigSigma, kFactor, DTTimeUnits::ns);
+      tTrigNewMap.set((*sl)->id(), ttrigMean, ttrigSigma, kFactor, DTTimeUnits::ns);
       if (debug) {
         cout << "Copying  SL: " << (*sl)->id() << " ttrig " << ttrigMean << endl;
       }

--- a/CondCore/DBOutputService/interface/OnlineDBOutputService.h
+++ b/CondCore/DBOutputService/interface/OnlineDBOutputService.h
@@ -74,15 +74,6 @@ namespace cond {
         return targetTime;
       }
 
-      //
-      template <typename PayloadType>
-      bool writeForNextLumisection(const PayloadType* payloadPtr, const std::string& recordName) {
-        if (!payloadPtr)
-          throwException("Provided payload pointer is invalid.", "OnlineDBOutputService::writeForNextLumisection");
-        std::unique_ptr<const PayloadType> payload(payloadPtr);
-        return writeForNextLumisection<PayloadType>(*payload, recordName);
-      }
-
     private:
       cond::Iov_t preLoadIov(const PoolDBOutputService::Record& record, cond::Time_t targetTime);
 

--- a/CondCore/DBOutputService/interface/PoolDBOutputService.h
+++ b/CondCore/DBOutputService/interface/PoolDBOutputService.h
@@ -101,15 +101,6 @@ namespace cond {
         return thePayloadHash;
       }
 
-      // warning: takes over the ownership of pointer "payload". Deprecated. Please move to the above referece-based function
-      template <typename T>
-      Hash writeOne(const T* payloadPtr, Time_t time, const std::string& recordName) {
-        if (!payloadPtr)
-          throwException("Provided payload pointer is invalid.", "PoolDBOutputService::writeOne");
-        std::unique_ptr<const T> payload(payloadPtr);
-        return writeOneIOV<T>(*payload, time, recordName);
-      }
-
       template <typename T>
       void writeMany(const std::map<Time_t, std::shared_ptr<T> >& iovAndPayloads, const std::string& recordName) {
         if (iovAndPayloads.empty())
@@ -188,15 +179,6 @@ namespace cond {
         scope.close();
       }
 
-      // warning: takes over the ownership of pointer "payload" - deprecated. Please move to the above reference-based function
-      template <typename T>
-      void createNewIOV(const T* payloadPtr, cond::Time_t firstSinceTime, cond::Time_t, const std::string& recordName) {
-        if (!payloadPtr)
-          throwException("Provided payload pointer is invalid.", "PoolDBOutputService::createNewIOV");
-        std::unique_ptr<const T> payload(payloadPtr);
-        this->createOneIOV<T>(*payload, firstSinceTime, recordName);
-      }
-
       template <typename T>
       void appendOneIOV(const T& payload, cond::Time_t sinceTime, const std::string& recordName) {
         std::lock_guard<std::recursive_mutex> lock(m_mutex);
@@ -221,15 +203,6 @@ namespace cond {
           cond::throwException(std::string(er.what()), "PoolDBOutputService::appendSinceTime");
         }
         scope.close();
-      }
-
-      // warning: takes over the ownership of pointer "payload" - deprecated. Please move to the above reference-based function
-      template <typename T>
-      void appendSinceTime(const T* payloadPtr, cond::Time_t sinceTime, const std::string& recordName) {
-        if (!payloadPtr)
-          throwException("Provided payload pointer is invalid.", "PoolDBOutputService::appendSinceTime");
-        std::unique_ptr<const T> payload(payloadPtr);
-        this->appendOneIOV<T>(*payload, sinceTime, recordName);
       }
 
       void createNewIOV(const std::string& firstPayloadId, cond::Time_t firstSinceTime, const std::string& recordName);

--- a/DQM/DTMonitorClient/src/DTLocalTriggerSynchTest.cc
+++ b/DQM/DTMonitorClient/src/DTLocalTriggerSynchTest.cc
@@ -147,7 +147,7 @@ void DTLocalTriggerSynchTest::dqmEndJob(DQMStore::IBooker& ibooker, DQMStore::IG
     LogVerbatim(category()) << "[" << testName << "Test]: writeDB flag set to true. Producing peak position database."
                             << endl;
 
-    DTTPGParameters* delayMap = new DTTPGParameters();
+    DTTPGParameters delayMap;
     hwSource = "TM";
     std::vector<const DTChamber*>::const_iterator chambIt = muonGeom->chambers().begin();
     std::vector<const DTChamber*>::const_iterator chambEnd = muonGeom->chambers().end();
@@ -182,11 +182,11 @@ void DTLocalTriggerSynchTest::dqmEndJob(DQMStore::IBooker& ibooker, DQMStore::IG
           coarseDelay = wCoarse - coarseDelay;
         }
       }
-      delayMap->set(chId, coarseDelay, fineDelay, DTTimeUnits::ns);
+      delayMap.set(chId, coarseDelay, fineDelay, DTTimeUnits::ns);
     }
 
-    std::vector<std::pair<DTTPGParametersId, DTTPGParametersData> >::const_iterator dbIt = delayMap->begin();
-    std::vector<std::pair<DTTPGParametersId, DTTPGParametersData> >::const_iterator dbEnd = delayMap->end();
+    std::vector<std::pair<DTTPGParametersId, DTTPGParametersData> >::const_iterator dbIt = delayMap.begin();
+    std::vector<std::pair<DTTPGParametersId, DTTPGParametersData> >::const_iterator dbEnd = delayMap.end();
     for (; dbIt != dbEnd; ++dbIt) {
       LogVerbatim(category()) << "[" << testName << "Test]: DB entry for Wh " << (*dbIt).first.wheelId << " Sec "
                               << (*dbIt).first.sectorId << " St " << (*dbIt).first.stationId << " has coarse "

--- a/RecoEgamma/EgammaTools/test/GBRWrapperMaker.cc
+++ b/RecoEgamma/EgammaTools/test/GBRWrapperMaker.cc
@@ -97,20 +97,20 @@ void GBRWrapperMaker::analyze(const edm::Event& iEvent, const edm::EventSetup& i
   printf("load forest\n");
 
   //GBRForestD *p4comb = (GBRForest*)infile->Get("CombinationWeight");
-  GBRForestD* gbreb = (GBRForestD*)infile->Get("EBCorrection");
-  GBRForestD* gbrebvar = (GBRForestD*)infile->Get("EBUncertainty");
-  GBRForestD* gbree = (GBRForestD*)infile->Get("EECorrection");
-  GBRForestD* gbreevar = (GBRForestD*)infile->Get("EEUncertainty");
+  std::unique_ptr<GBRForestD> gbreb((GBRForestD*)infile->Get("EBCorrection"));
+  std::unique_ptr<GBRForestD> gbrebvar((GBRForestD*)infile->Get("EBUncertainty"));
+  std::unique_ptr<GBRForestD> gbree((GBRForestD*)infile->Get("EECorrection"));
+  std::unique_ptr<GBRForestD> gbreevar((GBRForestD*)infile->Get("EEUncertainty"));
 
   printf("made objects\n");
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
   if (poolDbService.isAvailable()) {
     //poolDbService->writeOne( p4comb, poolDbService->beginOfTime(),
     //		     "gedelectron_p4combination"  );
-    poolDbService->writeOne(gbreb, poolDbService->beginOfTime(), "mustacheSC_online_EBCorrection");
-    poolDbService->writeOne(gbrebvar, poolDbService->beginOfTime(), "mustacheSC_online_EBUncertainty");
-    poolDbService->writeOne(gbree, poolDbService->beginOfTime(), "mustacheSC_online_EECorrection");
-    poolDbService->writeOne(gbreevar, poolDbService->beginOfTime(), "mustacheSC_online_EEUncertainty");
+    poolDbService->writeOneIOV(*gbreb, poolDbService->beginOfTime(), "mustacheSC_online_EBCorrection");
+    poolDbService->writeOneIOV(*gbrebvar, poolDbService->beginOfTime(), "mustacheSC_online_EBUncertainty");
+    poolDbService->writeOneIOV(*gbree, poolDbService->beginOfTime(), "mustacheSC_online_EECorrection");
+    poolDbService->writeOneIOV(*gbreevar, poolDbService->beginOfTime(), "mustacheSC_online_EEUncertainty");
   }
 }
 


### PR DESCRIPTION
#### PR description:

The PoolDBoutputService interface (and its Derived class OnlineDBOutputService ) contains methods that have been deprecated in favour of new methods providing the same functionalities with a more explicit signature concerning the payload object ownership policy.  Since all of the clients of the old interface in CMSSW have been migrated to the new interface, in this PR we proceed to remove the deprecated methods.

#### PR validation:

Unit and integration tests

