### PR TITLE
[GCC11] Fix warning "strncmp ... evaluates to nonzero"

### DIFF
--- a/FWCore/Utilities/src/MallocOpts.cc
+++ b/FWCore/Utilities/src/MallocOpts.cc
@@ -83,9 +83,7 @@ namespace edm {
           : "a"(op));
 
 #else
-      const char* unknown_str = "Unknown";
-      // int unknown_sz = strlen(unknown_str);
-      strcpy((char*)&ans[0], unknown_str);
+      return UNKNOWN_CPU;
 #endif
 
       const char* amd_str = "AuthenticAMD";
@@ -96,7 +94,9 @@ namespace edm {
       char* str = (char*)&ans[0];
       ans[3] = 0;
 
-      return strncmp(str, amd_str, 2) == 0 ? AMD_CPU : strncmp(str, intel_str, 2) == 0 ? INTEL_CPU : UNKNOWN_CPU;
+      return strncmp(str, amd_str, amd_sz) == 0       ? AMD_CPU
+             : strncmp(str, intel_str, intel_sz) == 0 ? INTEL_CPU
+                                                      : UNKNOWN_CPU;
     }
 
     // values determined experimentally for each architecture

--- a/FWCore/Utilities/src/MallocOpts.cc
+++ b/FWCore/Utilities/src/MallocOpts.cc
@@ -96,9 +96,7 @@ namespace edm {
       char* str = (char*)&ans[0];
       ans[3] = 0;
 
-      return strncmp(str, amd_str, 2) == 0     ? AMD_CPU
-             : strncmp(str, intel_str, 2) == 0 ? INTEL_CPU
-                                               : UNKNOWN_CPU;
+      return strncmp(str, amd_str, 2) == 0 ? AMD_CPU : strncmp(str, intel_str, 2) == 0 ? INTEL_CPU : UNKNOWN_CPU;
     }
 
     // values determined experimentally for each architecture

--- a/FWCore/Utilities/src/MallocOpts.cc
+++ b/FWCore/Utilities/src/MallocOpts.cc
@@ -96,9 +96,9 @@ namespace edm {
       char* str = (char*)&ans[0];
       ans[3] = 0;
 
-      return strncmp(str, amd_str, amd_sz) == 0       ? AMD_CPU
-             : strncmp(str, intel_str, intel_sz) == 0 ? INTEL_CPU
-                                                      : UNKNOWN_CPU;
+      return strncmp(str, amd_str, 2) == 0     ? AMD_CPU
+             : strncmp(str, intel_str, 2) == 0 ? INTEL_CPU
+                                               : UNKNOWN_CPU;
     }
 
     // values determined experimentally for each architecture


### PR DESCRIPTION
Log : https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_aarch64_gcc11/CMSSW_12_3_X_2021-12-10-2300/FWCore/Utilities
Warning message:
```
In function 'edm::{anonymous}::cpu_type edm::{anonymous}::get_cpu_type()',
    inlined from 'bool edm::MallocOptionSetter::retrieveFromCpuType()' at (...)/src/FWCore/Utilities/src/MallocOpts.cc:113:25:
  (...)/src/FWCore/Utilities/src/MallocOpts.cc:99:21: warning: 'int strncmp(const char*, const char*, size_t)' of strings of length 7 and 12 and bound of 12 evaluates to nonzero [-Wstring-compare]
    99 |       return strncmp(str, amd_str, amd_sz) == 0       ? AMD_CPU
      |              ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
  (...)/src/FWCore/Utilities/src/MallocOpts.cc:100:23: warning: 'int strncmp(const char*, const char*, size_t)' of strings of length 7 and 12 and bound of 12 evaluates to nonzero [-Wstring-compare]
   100 |              : strncmp(str, intel_str, intel_sz) == 0 ? INTEL_CPU
      |                ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
```

#### PR description:

We do not need to compare all 12 characters, since the detected CPU name is truncated to 2 characters (see line 97).
