### PR TITLE
Adding provision for HGCal geometry v17 development

### DIFF
--- a/Geometry/HGCalCommonData/data/hgcalcell/v17/hgcal.xml
+++ b/Geometry/HGCalCommonData/data/hgcalcell/v17/hgcal.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<DDDefinition>
+
+<ConstantsSection label="hgcal.xml" eval="true">
+  <Constant name="WaferSize"             value="166.4408*mm"/>
+  <Constant name="WaferThickness"        value="0.30*mm"/>
+  <Constant name="WaferThicknessFine"    value="0.30*mm"/>
+  <Constant name="WaferThicknessCoarse1" value="0.20*mm"/>
+  <Constant name="WaferThicknessCoarse2" value="0.30*mm"/>
+  <Constant name="CellThicknessFine"     value="0.12*mm"/>
+  <Constant name="CellThicknessCoarse1"  value="0.20*mm"/>
+  <Constant name="CellThicknessCoarse2"  value="0.30*mm"/>
+  <Constant name="NumberOfCellsFine"     value="12"/>
+  <Constant name="NumberOfCellsCoarse"   value="8"/>
+</ConstantsSection>
+
+</DDDefinition>
+
+

--- a/Geometry/HGCalCommonData/data/hgcalcell/v17/hgcalcell.xml
+++ b/Geometry/HGCalCommonData/data/hgcalcell/v17/hgcalcell.xml
@@ -1,0 +1,388 @@
+<?xml version="1.0"?>
+<DDDefinition>
+
+<ConstantsSection label="hgcalcell.xml" eval="true">
+  <Constant name="WaferSize"             value="[hgcal:WaferSize]"/>
+  <Constant name="WaferThicknessFine"    value="[hgcal:WaferThicknessFine]"/>
+  <Constant name="WaferThicknessCoarse1" value="[hgcal:WaferThicknessCoarse1]"/>
+  <Constant name="WaferThicknessCoarse2" value="[hgcal:WaferThicknessCoarse2]"/>
+  <Constant name="CellThicknessFine"     value="[hgcal:CellThicknessFine]"/>
+  <Constant name="CellThicknessCoarse1"  value="[hgcal:CellThicknessCoarse1]"/>
+  <Constant name="CellThicknessCoarse2"  value="[hgcal:CellThicknessCoarse2]"/>
+  <Constant name="NumberOfCellsFine"     value="[hgcal:NumberOfCellsFine]"/>
+  <Constant name="NumberOfCellsCoarse"   value="[hgcal:NumberOfCellsCoarse]"/>
+</ConstantsSection>
+
+<PosPartSection label="hgcalcell.xml" eval="true">
+  <Algorithm name="hgcal:DDHGCalCell">
+    <rParent name="hgcalwafer:HGCalCell"/>
+    <Numeric name="WaferSize"    value="[WaferSize]"/>
+    <Numeric name="WaferThick"   value="[WaferThicknessFine]"/>
+    <Numeric name="CellThick"    value="[CellThicknessFine]"/>
+    <Numeric name="NCells"       value="[NumberOfCellsFine]"/>
+    <Numeric name="PosSensitive" value="0"/>
+    <String name="Material"      value="materials:Silicon"/>
+    <String name="FullCell"      value="HGCalEECellFull0Fine"/>
+    <String name="FullSensitive" value="HGCalEECellSensitiveFull0Fine"/>
+    <Vector name="TruncatedCell" type="string" nEntries="6">
+       HGCalEECellTrunc01Fine, HGCalEECellTrunc02Fine,
+       HGCalEECellTrunc03Fine, HGCalEECellTrunc04Fine,
+       HGCalEECellTrunc05Fine, HGCalEECellTrunc06Fine</Vector>
+    <Vector name="TruncatedSensitive" type="string" nEntries="6">
+      HGCalEECellSensitiveTrunc01Fine, HGCalEECellSensitiveTrunc02Fine,
+      HGCalEECellSensitiveTrunc03Fine, HGCalEECellSensitiveTrunc04Fine,
+      HGCalEECellSensitiveTrunc05Fine, HGCalEECellSensitiveTrunc06Fine</Vector>
+    <Vector name="ExtendedCell" type="string" nEntries="6">
+       HGCalEECellExten01Fine, HGCalEECellExten02Fine,
+       HGCalEECellExten03Fine, HGCalEECellExten04Fine,
+       HGCalEECellExten05Fine, HGCalEECellExten06Fine</Vector>
+    <Vector name="ExtendedSensitive" type="string" nEntries="6">
+      HGCalEECellSensitiveExten01Fine, HGCalEECellSensitiveExten02Fine,
+      HGCalEECellSensitiveExten03Fine, HGCalEECellSensitiveExten04Fine,
+      HGCalEECellSensitiveExten05Fine, HGCalEECellSensitiveExten06Fine</Vector>
+    <Vector name="CornerCell" type="string" nEntries="12">
+       HGCalEECellCorner01Fine, HGCalEECellCorner02Fine,
+       HGCalEECellCorner03Fine, HGCalEECellCorner04Fine,
+       HGCalEECellCorner05Fine, HGCalEECellCorner06Fine,
+       HGCalEECellCorner07Fine, HGCalEECellCorner08Fine,
+       HGCalEECellCorner09Fine, HGCalEECellCorner10Fine,
+       HGCalEECellCorner11Fine, HGCalEECellCorner12Fine</Vector>
+    <Vector name="CornerSensitive" type="string" nEntries="12">
+      HGCalEECellSensitiveCorner01Fine, HGCalEECellSensitiveCorner02Fine,
+      HGCalEECellSensitiveCorner03Fine, HGCalEECellSensitiveCorner04Fine,
+      HGCalEECellSensitiveCorner05Fine, HGCalEECellSensitiveCorner06Fine,
+      HGCalEECellSensitiveCorner07Fine, HGCalEECellSensitiveCorner08Fine,
+      HGCalEECellSensitiveCorner09Fine, HGCalEECellSensitiveCorner10Fine,
+      HGCalEECellSensitiveCorner11Fine, HGCalEECellSensitiveCorner12Fine</Vector>
+  </Algorithm>
+  <Algorithm name="hgcal:DDHGCalCell">
+    <rParent name="hgcalwafer:HGCalCell"/>
+    <Numeric name="WaferSize"    value="[WaferSize]"/>
+    <Numeric name="WaferThick"   value="[WaferThicknessFine]"/>
+    <Numeric name="CellThick"    value="[CellThicknessFine]"/>
+    <Numeric name="NCells"       value="[NumberOfCellsFine]"/>
+    <Numeric name="PosSensitive" value="1"/>
+    <String name="Material"      value="materials:Silicon"/>
+    <String name="FullCell"      value="HGCalEECellFull1Fine"/>
+    <String name="FullSensitive" value="HGCalEECellSensitiveFull1Fine"/>
+    <Vector name="TruncatedCell" type="string" nEntries="6">
+       HGCalEECellTrunc21Fine, HGCalEECellTrunc22Fine,
+       HGCalEECellTrunc23Fine, HGCalEECellTrunc24Fine,
+       HGCalEECellTrunc25Fine, HGCalEECellTrunc26Fine</Vector>
+    <Vector name="TruncatedSensitive" type="string" nEntries="6">
+      HGCalEECellSensitiveTrunc21Fine, HGCalEECellSensitiveTrunc22Fine,
+      HGCalEECellSensitiveTrunc23Fine, HGCalEECellSensitiveTrunc24Fine,
+      HGCalEECellSensitiveTrunc25Fine, HGCalEECellSensitiveTrunc26Fine</Vector>
+    <Vector name="ExtendedCell" type="string" nEntries="6">
+       HGCalEECellExten21Fine, HGCalEECellExten22Fine,
+       HGCalEECellExten23Fine, HGCalEECellExten24Fine,
+       HGCalEECellExten25Fine, HGCalEECellExten26Fine</Vector>
+    <Vector name="ExtendedSensitive" type="string" nEntries="6">
+      HGCalEECellSensitiveExten21Fine, HGCalEECellSensitiveExten22Fine,
+      HGCalEECellSensitiveExten23Fine, HGCalEECellSensitiveExten24Fine,
+      HGCalEECellSensitiveExten25Fine, HGCalEECellSensitiveExten26Fine</Vector>
+    <Vector name="CornerCell" type="string" nEntries="12">
+       HGCalEECellCorner21Fine, HGCalEECellCorner22Fine,
+       HGCalEECellCorner23Fine, HGCalEECellCorner24Fine,
+       HGCalEECellCorner25Fine, HGCalEECellCorner26Fine,
+       HGCalEECellCorner27Fine, HGCalEECellCorner28Fine,
+       HGCalEECellCorner29Fine, HGCalEECellCorner30Fine,
+       HGCalEECellCorner31Fine, HGCalEECellCorner32Fine</Vector>
+    <Vector name="CornerSensitive" type="string" nEntries="12">
+      HGCalEECellSensitiveCorner21Fine, HGCalEECellSensitiveCorner22Fine,
+      HGCalEECellSensitiveCorner23Fine, HGCalEECellSensitiveCorner24Fine,
+      HGCalEECellSensitiveCorner25Fine, HGCalEECellSensitiveCorner26Fine,
+      HGCalEECellSensitiveCorner27Fine, HGCalEECellSensitiveCorner28Fine,
+      HGCalEECellSensitiveCorner29Fine, HGCalEECellSensitiveCorner30Fine,
+      HGCalEECellSensitiveCorner31Fine, HGCalEECellSensitiveCorner32Fine</Vector>
+  </Algorithm>
+  <Algorithm name="hgcal:DDHGCalCell">
+    <rParent name="hgcalwafer:HGCalCell"/>
+    <Numeric name="WaferSize"    value="[WaferSize]"/>
+    <Numeric name="WaferThick"   value="[WaferThicknessCoarse1]"/>
+    <Numeric name="CellThick"    value="[CellThicknessCoarse1]"/>
+    <Numeric name="NCells"       value="[NumberOfCellsCoarse]"/>
+    <Numeric name="PosSensitive" value="0"/>
+    <String name="Material"      value="materials:Silicon"/>
+    <String name="FullCell"      value="HGCalEECellFull0Coarse1"/>
+    <String name="FullSensitive" value="HGCalEECellSensitiveFull0Coarse1"/>
+    <Vector name="TruncatedCell" type="string" nEntries="6">
+       HGCalEECellTrunc01Coarse1, HGCalEECellTrunc02Coarse1,
+       HGCalEECellTrunc03Coarse1, HGCalEECellTrunc04Coarse1,
+       HGCalEECellTrunc05Coarse1, HGCalEECellTrunc06Coarse1</Vector>
+    <Vector name="TruncatedSensitive" type="string" nEntries="6">
+      HGCalEECellSensitiveTrunc01Coarse1, HGCalEECellSensitiveTrunc02Coarse1,
+      HGCalEECellSensitiveTrunc03Coarse1, HGCalEECellSensitiveTrunc04Coarse1,
+      HGCalEECellSensitiveTrunc05Coarse1, HGCalEECellSensitiveTrunc06Coarse1</Vector>
+    <Vector name="ExtendedCell" type="string" nEntries="6">
+       HGCalEECellExten01Coarse1, HGCalEECellExten02Coarse1,
+       HGCalEECellExten03Coarse1, HGCalEECellExten04Coarse1,
+       HGCalEECellExten05Coarse1, HGCalEECellExten06Coarse1</Vector>
+    <Vector name="ExtendedSensitive" type="string" nEntries="6">
+      HGCalEECellSensitiveExten01Coarse1, HGCalEECellSensitiveExten02Coarse1,
+      HGCalEECellSensitiveExten03Coarse1, HGCalEECellSensitiveExten04Coarse1,
+      HGCalEECellSensitiveExten05Coarse1, HGCalEECellSensitiveExten06Coarse1</Vector>
+    <Vector name="CornerCell" type="string" nEntries="12">
+       HGCalEECellCorner01Coarse1, HGCalEECellCorner02Coarse1,
+       HGCalEECellCorner03Coarse1, HGCalEECellCorner04Coarse1,
+       HGCalEECellCorner05Coarse1, HGCalEECellCorner06Coarse1,
+       HGCalEECellCorner07Coarse1, HGCalEECellCorner08Coarse1,
+       HGCalEECellCorner09Coarse1, HGCalEECellCorner10Coarse1,
+       HGCalEECellCorner11Coarse1, HGCalEECellCorner12Coarse1</Vector>
+    <Vector name="CornerSensitive" type="string" nEntries="12">
+      HGCalEECellSensitiveCorner01Coarse1, HGCalEECellSensitiveCorner02Coarse1,
+      HGCalEECellSensitiveCorner03Coarse1, HGCalEECellSensitiveCorner04Coarse1,
+      HGCalEECellSensitiveCorner05Coarse1, HGCalEECellSensitiveCorner06Coarse1,
+      HGCalEECellSensitiveCorner07Coarse1, HGCalEECellSensitiveCorner08Coarse1,
+      HGCalEECellSensitiveCorner09Coarse1, HGCalEECellSensitiveCorner10Coarse1,
+      HGCalEECellSensitiveCorner11Coarse1, HGCalEECellSensitiveCorner12Coarse1</Vector>
+  </Algorithm>
+  <Algorithm name="hgcal:DDHGCalCell">
+    <rParent name="hgcalwafer:HGCalCell"/>
+    <Numeric name="WaferSize"    value="[WaferSize]"/>
+    <Numeric name="WaferThick"   value="[WaferThicknessCoarse1]"/>
+    <Numeric name="CellThick"    value="[CellThicknessCoarse1]"/>
+    <Numeric name="NCells"       value="[NumberOfCellsCoarse]"/>
+    <Numeric name="PosSensitive" value="1"/>
+    <String name="Material"      value="materials:Silicon"/>
+    <String name="FullCell"      value="HGCalEECellFull1Coarse1"/>
+    <String name="FullSensitive" value="HGCalEECellSensitiveFull1Coarse1"/>
+    <Vector name="TruncatedCell" type="string" nEntries="6">
+       HGCalEECellTrunc21Coarse1, HGCalEECellTrunc22Coarse1,
+       HGCalEECellTrunc23Coarse1, HGCalEECellTrunc24Coarse1,
+       HGCalEECellTrunc25Coarse1, HGCalEECellTrunc26Coarse1</Vector>
+    <Vector name="TruncatedSensitive" type="string" nEntries="6">
+      HGCalEECellSensitiveTrunc21Coarse1, HGCalEECellSensitiveTrunc22Coarse1,
+      HGCalEECellSensitiveTrunc23Coarse1, HGCalEECellSensitiveTrunc24Coarse1,
+      HGCalEECellSensitiveTrunc25Coarse1, HGCalEECellSensitiveTrunc26Coarse1</Vector>
+    <Vector name="ExtendedCell" type="string" nEntries="6">
+       HGCalEECellExten21Coarse1, HGCalEECellExten22Coarse1,
+       HGCalEECellExten23Coarse1, HGCalEECellExten24Coarse1,
+       HGCalEECellExten25Coarse1, HGCalEECellExten26Coarse1</Vector>
+    <Vector name="ExtendedSensitive" type="string" nEntries="6">
+      HGCalEECellSensitiveExten21Coarse1, HGCalEECellSensitiveExten22Coarse1,
+      HGCalEECellSensitiveExten23Coarse1, HGCalEECellSensitiveExten24Coarse1,
+      HGCalEECellSensitiveExten25Coarse1, HGCalEECellSensitiveExten26Coarse1</Vector>
+    <Vector name="CornerCell" type="string" nEntries="12">
+       HGCalEECellCorner21Coarse1, HGCalEECellCorner22Coarse1,
+       HGCalEECellCorner23Coarse1, HGCalEECellCorner24Coarse1,
+       HGCalEECellCorner25Coarse1, HGCalEECellCorner26Coarse1,
+       HGCalEECellCorner27Coarse1, HGCalEECellCorner28Coarse1,
+       HGCalEECellCorner29Coarse1, HGCalEECellCorner30Coarse1,
+       HGCalEECellCorner31Coarse1, HGCalEECellCorner32Coarse1</Vector>
+    <Vector name="CornerSensitive" type="string" nEntries="12">
+      HGCalEECellSensitiveCorner21Coarse1, HGCalEECellSensitiveCorner22Coarse1,
+      HGCalEECellSensitiveCorner23Coarse1, HGCalEECellSensitiveCorner24Coarse1,
+      HGCalEECellSensitiveCorner25Coarse1, HGCalEECellSensitiveCorner26Coarse1,
+      HGCalEECellSensitiveCorner27Coarse1, HGCalEECellSensitiveCorner28Coarse1,
+      HGCalEECellSensitiveCorner29Coarse1, HGCalEECellSensitiveCorner30Coarse1,
+      HGCalEECellSensitiveCorner31Coarse1, HGCalEECellSensitiveCorner32Coarse1</Vector>
+  </Algorithm>
+  <Algorithm name="hgcal:DDHGCalCell">
+    <rParent name="hgcalwafer:HGCalCell"/>
+    <Numeric name="WaferSize"    value="[WaferSize]"/>
+    <Numeric name="WaferThick"   value="[WaferThicknessCoarse2]"/>
+    <Numeric name="CellThick"    value="[CellThicknessCoarse2]"/>
+    <Numeric name="NCells"       value="[NumberOfCellsCoarse]"/>
+    <Numeric name="PosSensitive" value="0"/>
+    <String name="Material"      value="materials:Silicon"/>
+    <String name="FullCell"      value="HGCalEECellFull0Coarse2"/>
+    <String name="FullSensitive" value="HGCalEECellSensitiveFull0Coarse2"/>
+    <Vector name="TruncatedCell" type="string" nEntries="6">
+       HGCalEECellTrunc01Coarse2, HGCalEECellTrunc02Coarse2,
+       HGCalEECellTrunc03Coarse2, HGCalEECellTrunc04Coarse2,
+       HGCalEECellTrunc05Coarse2, HGCalEECellTrunc06Coarse2</Vector>
+    <Vector name="TruncatedSensitive" type="string" nEntries="6">
+      HGCalEECellSensitiveTrunc01Coarse2, HGCalEECellSensitiveTrunc02Coarse2,
+      HGCalEECellSensitiveTrunc03Coarse2, HGCalEECellSensitiveTrunc04Coarse2,
+      HGCalEECellSensitiveTrunc05Coarse2, HGCalEECellSensitiveTrunc06Coarse2</Vector>
+    <Vector name="ExtendedCell" type="string" nEntries="6">
+       HGCalEECellExten01Coarse2, HGCalEECellExten02Coarse2,
+       HGCalEECellExten03Coarse2, HGCalEECellExten04Coarse2,
+       HGCalEECellExten05Coarse2, HGCalEECellExten06Coarse2</Vector>
+    <Vector name="ExtendedSensitive" type="string" nEntries="6">
+      HGCalEECellSensitiveExten01Coarse2, HGCalEECellSensitiveExten02Coarse2,
+      HGCalEECellSensitiveExten03Coarse2, HGCalEECellSensitiveExten04Coarse2,
+      HGCalEECellSensitiveExten05Coarse2, HGCalEECellSensitiveExten06Coarse2</Vector>
+    <Vector name="CornerCell" type="string" nEntries="12">
+       HGCalEECellCorner01Coarse2, HGCalEECellCorner02Coarse2,
+       HGCalEECellCorner03Coarse2, HGCalEECellCorner04Coarse2,
+       HGCalEECellCorner05Coarse2, HGCalEECellCorner06Coarse2,
+       HGCalEECellCorner07Coarse2, HGCalEECellCorner08Coarse2,
+       HGCalEECellCorner09Coarse2, HGCalEECellCorner10Coarse2,
+       HGCalEECellCorner11Coarse2, HGCalEECellCorner12Coarse2</Vector>
+    <Vector name="CornerSensitive" type="string" nEntries="12">
+      HGCalEECellSensitiveCorner01Coarse2, HGCalEECellSensitiveCorner02Coarse2,
+      HGCalEECellSensitiveCorner03Coarse2, HGCalEECellSensitiveCorner04Coarse2,
+      HGCalEECellSensitiveCorner05Coarse2, HGCalEECellSensitiveCorner06Coarse2,
+      HGCalEECellSensitiveCorner07Coarse2, HGCalEECellSensitiveCorner08Coarse2,
+      HGCalEECellSensitiveCorner09Coarse2, HGCalEECellSensitiveCorner10Coarse2,
+      HGCalEECellSensitiveCorner11Coarse2, HGCalEECellSensitiveCorner12Coarse2</Vector>
+  </Algorithm>
+  <Algorithm name="hgcal:DDHGCalCell">
+    <rParent name="hgcalwafer:HGCalCell"/>
+    <Numeric name="WaferSize"    value="[WaferSize]"/>
+    <Numeric name="WaferThick"   value="[WaferThicknessCoarse2]"/>
+    <Numeric name="CellThick"    value="[CellThicknessCoarse2]"/>
+    <Numeric name="NCells"       value="[NumberOfCellsCoarse]"/>
+    <Numeric name="PosSensitive" value="1"/>
+    <String name="Material"      value="materials:Silicon"/>
+    <String name="FullCell"      value="HGCalEECellFull1Coarse2"/>
+    <String name="FullSensitive" value="HGCalEECellSensitiveFull1Coarse2"/>
+    <Vector name="TruncatedCell" type="string" nEntries="6">
+       HGCalEECellTrunc21Coarse2, HGCalEECellTrunc22Coarse2,
+       HGCalEECellTrunc23Coarse2, HGCalEECellTrunc24Coarse2,
+       HGCalEECellTrunc25Coarse2, HGCalEECellTrunc26Coarse2</Vector>
+    <Vector name="TruncatedSensitive" type="string" nEntries="6">
+      HGCalEECellSensitiveTrunc21Coarse2, HGCalEECellSensitiveTrunc22Coarse2,
+      HGCalEECellSensitiveTrunc23Coarse2, HGCalEECellSensitiveTrunc24Coarse2,
+      HGCalEECellSensitiveTrunc25Coarse2, HGCalEECellSensitiveTrunc26Coarse2</Vector>
+    <Vector name="ExtendedCell" type="string" nEntries="6">
+       HGCalEECellExten21Coarse2, HGCalEECellExten22Coarse2,
+       HGCalEECellExten23Coarse2, HGCalEECellExten24Coarse2,
+       HGCalEECellExten25Coarse2, HGCalEECellExten26Coarse2</Vector>
+    <Vector name="ExtendedSensitive" type="string" nEntries="6">
+      HGCalEECellSensitiveExten21Coarse2, HGCalEECellSensitiveExten22Coarse2,
+      HGCalEECellSensitiveExten23Coarse2, HGCalEECellSensitiveExten24Coarse2,
+      HGCalEECellSensitiveExten25Coarse2, HGCalEECellSensitiveExten26Coarse2</Vector>
+    <Vector name="CornerCell" type="string" nEntries="12">
+       HGCalEECellCorner21Coarse2, HGCalEECellCorner22Coarse2,
+       HGCalEECellCorner23Coarse2, HGCalEECellCorner24Coarse2,
+       HGCalEECellCorner25Coarse2, HGCalEECellCorner26Coarse2,
+       HGCalEECellCorner27Coarse2, HGCalEECellCorner28Coarse2,
+       HGCalEECellCorner29Coarse2, HGCalEECellCorner30Coarse2,
+       HGCalEECellCorner31Coarse2, HGCalEECellCorner32Coarse2</Vector>
+    <Vector name="CornerSensitive" type="string" nEntries="12">
+      HGCalEECellSensitiveCorner21Coarse2, HGCalEECellSensitiveCorner22Coarse2,
+      HGCalEECellSensitiveCorner23Coarse2, HGCalEECellSensitiveCorner24Coarse2,
+      HGCalEECellSensitiveCorner25Coarse2, HGCalEECellSensitiveCorner26Coarse2,
+      HGCalEECellSensitiveCorner27Coarse2, HGCalEECellSensitiveCorner28Coarse2,
+      HGCalEECellSensitiveCorner29Coarse2, HGCalEECellSensitiveCorner30Coarse2,
+      HGCalEECellSensitiveCorner31Coarse2, HGCalEECellSensitiveCorner32Coarse2</Vector>
+  </Algorithm>
+  <Algorithm name="hgcal:DDHGCalCell">
+    <rParent name="hgcalwafer:HGCalCell"/>
+    <Numeric name="WaferSize"    value="[WaferSize]"/>
+    <Numeric name="WaferThick"   value="[WaferThicknessFine]"/>
+    <Numeric name="CellThick"    value="[CellThicknessFine]"/>
+    <Numeric name="NCells"       value="[NumberOfCellsFine]"/>
+    <Numeric name="PosSensitive" value="0"/>
+    <String name="Material"      value="materials:Silicon"/>
+    <String name="FullCell"      value="HGCalHECellFull0Fine"/>
+    <String name="FullSensitive" value="HGCalHESiliconCellSensitiveFull0Fine"/>
+    <Vector name="TruncatedCell" type="string" nEntries="6">
+       HGCalHECellTrunc01Fine, HGCalHECellTrunc02Fine,
+       HGCalHECellTrunc03Fine, HGCalHECellTrunc04Fine,
+       HGCalHECellTrunc05Fine, HGCalHECellTrunc06Fine</Vector>
+    <Vector name="TruncatedSensitive" type="string" nEntries="6">
+      HGCalHESiliconCellSensitiveTrunc01Fine, HGCalHESiliconCellSensitiveTrunc02Fine,
+      HGCalHESiliconCellSensitiveTrunc03Fine, HGCalHESiliconCellSensitiveTrunc04Fine,
+      HGCalHESiliconCellSensitiveTrunc05Fine, HGCalHESiliconCellSensitiveTrunc06Fine</Vector>
+    <Vector name="ExtendedCell" type="string" nEntries="6">
+       HGCalHECellExten01Fine, HGCalHECellExten02Fine,
+       HGCalHECellExten03Fine, HGCalHECellExten04Fine,
+       HGCalHECellExten05Fine, HGCalHECellExten06Fine</Vector>
+    <Vector name="ExtendedSensitive" type="string" nEntries="6">
+      HGCalHESiliconCellSensitiveExten01Fine, HGCalHESiliconCellSensitiveExten02Fine,
+      HGCalHESiliconCellSensitiveExten03Fine, HGCalHESiliconCellSensitiveExten04Fine,
+      HGCalHESiliconCellSensitiveExten05Fine, HGCalHESiliconCellSensitiveExten06Fine</Vector>
+    <Vector name="CornerCell" type="string" nEntries="12">
+       HGCalHECellCorner01Fine, HGCalHECellCorner02Fine,
+       HGCalHECellCorner03Fine, HGCalHECellCorner04Fine,
+       HGCalHECellCorner05Fine, HGCalHECellCorner06Fine,
+       HGCalHECellCorner07Fine, HGCalHECellCorner08Fine,
+       HGCalHECellCorner09Fine, HGCalHECellCorner10Fine,
+       HGCalHECellCorner11Fine, HGCalHECellCorner12Fine</Vector>
+    <Vector name="CornerSensitive" type="string" nEntries="12">
+      HGCalHESiliconCellSensitiveCorner01Fine, HGCalHESiliconCellSensitiveCorner02Fine,
+      HGCalHESiliconCellSensitiveCorner03Fine, HGCalHESiliconCellSensitiveCorner04Fine,
+      HGCalHESiliconCellSensitiveCorner05Fine, HGCalHESiliconCellSensitiveCorner06Fine,
+      HGCalHESiliconCellSensitiveCorner07Fine, HGCalHESiliconCellSensitiveCorner08Fine,
+      HGCalHESiliconCellSensitiveCorner09Fine, HGCalHESiliconCellSensitiveCorner10Fine,
+      HGCalHESiliconCellSensitiveCorner11Fine, HGCalHESiliconCellSensitiveCorner12Fine</Vector>
+  </Algorithm>
+  <Algorithm name="hgcal:DDHGCalCell">
+    <rParent name="hgcalwafer:HGCalCell"/>
+    <Numeric name="WaferSize"    value="[WaferSize]"/>
+    <Numeric name="WaferThick"   value="[WaferThicknessCoarse1]"/>
+    <Numeric name="CellThick"    value="[CellThicknessCoarse1]"/>
+    <Numeric name="NCells"       value="[NumberOfCellsCoarse]"/>
+    <Numeric name="PosSensitive" value="0"/>
+    <String name="Material"      value="materials:Silicon"/>
+    <String name="FullCell"      value="HGCalHECellFull0Coarse1"/>
+    <String name="FullSensitive" value="HGCalHESiliconCellSensitiveFull0Coarse1"/>
+    <Vector name="TruncatedCell" type="string" nEntries="6">
+       HGCalHECellTrunc01Coarse1, HGCalHECellTrunc02Coarse1,
+       HGCalHECellTrunc03Coarse1, HGCalHECellTrunc04Coarse1,
+       HGCalHECellTrunc05Coarse1, HGCalHECellTrunc06Coarse1</Vector>
+    <Vector name="TruncatedSensitive" type="string" nEntries="6">
+      HGCalHESiliconCellSensitiveTrunc01Coarse1, HGCalHESiliconCellSensitiveTrunc02Coarse1,
+      HGCalHESiliconCellSensitiveTrunc03Coarse1, HGCalHESiliconCellSensitiveTrunc04Coarse1,
+      HGCalHESiliconCellSensitiveTrunc05Coarse1, HGCalHESiliconCellSensitiveTrunc06Coarse1</Vector>
+    <Vector name="ExtendedCell" type="string" nEntries="6">
+       HGCalHECellExten01Coarse1, HGCalHECellExten02Coarse1,
+       HGCalHECellExten03Coarse1, HGCalHECellExten04Coarse1,
+       HGCalHECellExten05Coarse1, HGCalHECellExten06Coarse1</Vector>
+    <Vector name="ExtendedSensitive" type="string" nEntries="6">
+      HGCalHESiliconCellSensitiveExten01Coarse1, HGCalHESiliconCellSensitiveExten02Coarse1,
+      HGCalHESiliconCellSensitiveExten03Coarse1, HGCalHESiliconCellSensitiveExten04Coarse1,
+      HGCalHESiliconCellSensitiveExten05Coarse1, HGCalHESiliconCellSensitiveExten06Coarse1</Vector>
+    <Vector name="CornerCell" type="string" nEntries="12">
+       HGCalHECellCorner01Coarse1, HGCalHECellCorner02Coarse1,
+       HGCalHECellCorner03Coarse1, HGCalHECellCorner04Coarse1,
+       HGCalHECellCorner05Coarse1, HGCalHECellCorner06Coarse1,
+       HGCalHECellCorner07Coarse1, HGCalHECellCorner08Coarse1,
+       HGCalHECellCorner09Coarse1, HGCalHECellCorner10Coarse1,
+       HGCalHECellCorner11Coarse1, HGCalHECellCorner12Coarse1</Vector>
+    <Vector name="CornerSensitive" type="string" nEntries="12">
+      HGCalHESiliconCellSensitiveCorner01Coarse1, HGCalHESiliconCellSensitiveCorner02Coarse1,
+      HGCalHESiliconCellSensitiveCorner03Coarse1, HGCalHESiliconCellSensitiveCorner04Coarse1,
+      HGCalHESiliconCellSensitiveCorner05Coarse1, HGCalHESiliconCellSensitiveCorner06Coarse1,
+      HGCalHESiliconCellSensitiveCorner07Coarse1, HGCalHESiliconCellSensitiveCorner08Coarse1,
+      HGCalHESiliconCellSensitiveCorner09Coarse1, HGCalHESiliconCellSensitiveCorner10Coarse1,
+      HGCalHESiliconCellSensitiveCorner11Coarse1, HGCalHESiliconCellSensitiveCorner12Coarse1</Vector>
+  </Algorithm>
+  <Algorithm name="hgcal:DDHGCalCell">
+    <rParent name="hgcalwafer:HGCalCell"/>
+    <Numeric name="WaferSize"    value="[WaferSize]"/>
+    <Numeric name="WaferThick"   value="[WaferThicknessCoarse2]"/>
+    <Numeric name="CellThick"    value="[CellThicknessCoarse2]"/>
+    <Numeric name="NCells"       value="[NumberOfCellsCoarse]"/>
+    <Numeric name="PosSensitive" value="0"/>
+    <String name="Material"      value="materials:Silicon"/>
+    <String name="FullCell"      value="HGCalHECellFull0Coarse2"/>
+    <String name="FullSensitive" value="HGCalHESiliconCellSensitiveFull0Coarse2"/>
+    <Vector name="TruncatedCell" type="string" nEntries="6">
+       HGCalHECellTrunc01Coarse2, HGCalHECellTrunc02Coarse2,
+       HGCalHECellTrunc03Coarse2, HGCalHECellTrunc04Coarse2,
+       HGCalHECellTrunc05Coarse2, HGCalHECellTrunc06Coarse2</Vector>
+    <Vector name="TruncatedSensitive" type="string" nEntries="6">
+      HGCalHESiliconCellSensitiveTrunc01Coarse2, HGCalHESiliconCellSensitiveTrunc02Coarse2,
+      HGCalHESiliconCellSensitiveTrunc03Coarse2, HGCalHESiliconCellSensitiveTrunc04Coarse2,
+      HGCalHESiliconCellSensitiveTrunc05Coarse2, HGCalHESiliconCellSensitiveTrunc06Coarse2</Vector>
+    <Vector name="ExtendedCell" type="string" nEntries="6">
+       HGCalHECellExten01Coarse2, HGCalHECellExten02Coarse2,
+       HGCalHECellExten03Coarse2, HGCalHECellExten04Coarse2,
+       HGCalHECellExten05Coarse2, HGCalHECellExten06Coarse2</Vector>
+    <Vector name="ExtendedSensitive" type="string" nEntries="6">
+      HGCalHESiliconCellSensitiveExten01Coarse2, HGCalHESiliconCellSensitiveExten02Coarse2,
+      HGCalHESiliconCellSensitiveExten03Coarse2, HGCalHESiliconCellSensitiveExten04Coarse2,
+      HGCalHESiliconCellSensitiveExten05Coarse2, HGCalHESiliconCellSensitiveExten06Coarse2</Vector>
+    <Vector name="CornerCell" type="string" nEntries="12">
+       HGCalHECellCorner01Coarse2, HGCalHECellCorner02Coarse2,
+       HGCalHECellCorner03Coarse2, HGCalHECellCorner04Coarse2,
+       HGCalHECellCorner05Coarse2, HGCalHECellCorner06Coarse2,
+       HGCalHECellCorner07Coarse2, HGCalHECellCorner08Coarse2,
+       HGCalHECellCorner09Coarse2, HGCalHECellCorner10Coarse2,
+       HGCalHECellCorner11Coarse2, HGCalHECellCorner12Coarse2</Vector>
+    <Vector name="CornerSensitive" type="string" nEntries="12">
+      HGCalHESiliconCellSensitiveCorner01Coarse2, HGCalHESiliconCellSensitiveCorner02Coarse2,
+      HGCalHESiliconCellSensitiveCorner03Coarse2, HGCalHESiliconCellSensitiveCorner04Coarse2,
+      HGCalHESiliconCellSensitiveCorner05Coarse2, HGCalHESiliconCellSensitiveCorner06Coarse2,
+      HGCalHESiliconCellSensitiveCorner07Coarse2, HGCalHESiliconCellSensitiveCorner08Coarse2,
+      HGCalHESiliconCellSensitiveCorner09Coarse2, HGCalHESiliconCellSensitiveCorner10Coarse2,
+      HGCalHESiliconCellSensitiveCorner11Coarse2, HGCalHESiliconCellSensitiveCorner12Coarse2</Vector>
+  </Algorithm>
+</PosPartSection>
+
+</DDDefinition>

--- a/Geometry/HGCalCommonData/data/hgcalwafer/v17/hgcal.xml
+++ b/Geometry/HGCalCommonData/data/hgcalwafer/v17/hgcal.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<DDDefinition>
+
+<ConstantsSection label="hgcal.xml" eval="true">
+  <Constant name="WaferSize"             value="166.4408*mm"/>
+  <Constant name="WaferThickness"        value="0.30*mm"/>
+  <Constant name="WaferThicknessFine"    value="0.30*mm"/>
+  <Constant name="WaferThicknessCoarse1" value="0.20*mm"/>
+  <Constant name="WaferThicknessCoarse2" value="0.30*mm"/>
+  <Constant name="SensorSeparation"      value="1.00*mm"/>
+  <Constant name="ModuleThicknessEE"     value="9.325*mm"/>
+  <Constant name="ModuleThicknessHE"     value="8.70*mm"/>
+  <Constant name="CellThicknessFine"     value="0.12*mm"/>
+  <Constant name="CellThicknessCoarse1"  value="0.20*mm"/>
+  <Constant name="CellThicknessCoarse2"  value="0.30*mm"/>
+  <Constant name="NumberOfCellsFine"     value="12"/>
+  <Constant name="NumberOfCellsCoarse"   value="8"/>
+  <Constant name="LayerRotation"         value="30*deg"/>
+</ConstantsSection>
+
+</DDDefinition>

--- a/Geometry/HGCalCommonData/data/hgcalwafer/v17/hgcalpos.xml
+++ b/Geometry/HGCalCommonData/data/hgcalwafer/v17/hgcalpos.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0"?>
+<DDDefinition>
+
+<PosPartSection label="hgcalpos.xml">
+  <PosPart copyNumber="1">
+    <rParent name="cms:CMSE"/>
+    <rChild name="hgcalwafer:HGCalEEWafer0Fine0"/>
+    <Translation x="0.0*cm" y="10.0*cm" z="0*cm"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="cms:CMSE"/>
+    <rChild name="hgcalwafer:HGCalEEWafer0Fine1"/>
+    <Translation x="0.0*cm" y="-10.0*cm" z="0*cm"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="cms:CMSE"/>
+    <rChild name="hgcalwafer:HGCalEEWafer1Fine0"/>
+    <Translation x="0.0*cm" y="10.0*cm" z="-5*cm"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="cms:CMSE"/>
+    <rChild name="hgcalwafer:HGCalEEWafer1Fine1"/>
+    <Translation x="0.0*cm" y="-10.0*cm" z="-5*cm"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="cms:CMSE"/>
+    <rChild name="hgcalwafer:HGCalEEWafer0Coarse10"/>
+    <Translation x="0.0*cm" y="10.0*cm" z="-10*cm"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="cms:CMSE"/>
+    <rChild name="hgcalwafer:HGCalEEWafer0Coarse11"/>
+    <Translation x="0.0*cm" y="-10.0*cm" z="-10*cm"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="cms:CMSE"/>
+    <rChild name="hgcalwafer:HGCalEEWafer1Coarse10"/>
+    <Translation x="0.0*cm" y="10.0*cm" z="-15*cm"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="cms:CMSE"/>
+    <rChild name="hgcalwafer:HGCalEEWafer1Coarse11"/>
+    <Translation x="0.0*cm" y="-10.0*cm" z="-15*cm"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="cms:CMSE"/>
+    <rChild name="hgcalwafer:HGCalEEWafer0Coarse20"/>
+    <Translation x="0.0*cm" y="10.0*cm" z="-20*cm"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="cms:CMSE"/>
+    <rChild name="hgcalwafer:HGCalEEWafer0Coarse21"/>
+    <Translation x="0.0*cm" y="-10.0*cm" z="-20*cm"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="cms:CMSE"/>
+    <rChild name="hgcalwafer:HGCalEEWafer1Coarse20"/>
+    <Translation x="0.0*cm" y="10.0*cm" z="-25*cm"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="cms:CMSE"/>
+    <rChild name="hgcalwafer:HGCalEEWafer1Coarse21"/>
+    <Translation x="0.0*cm" y="-10.0*cm" z="-25*cm"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="cms:CMSE"/>
+    <rChild name="hgcalwafer:HGCalHEWafer0Fine0"/>
+    <Translation x="0.0*cm" y="10.0*cm" z="-30*cm"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="cms:CMSE"/>
+    <rChild name="hgcalwafer:HGCalHEWafer0Fine1"/>
+    <Translation x="0.0*cm" y="-10.0*cm" z="-30*cm"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="cms:CMSE"/>
+    <rChild name="hgcalwafer:HGCalHEWafer0Coarse10"/>
+    <Translation x="0.0*cm" y="10.0*cm" z="-35*cm"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="cms:CMSE"/>
+    <rChild name="hgcalwafer:HGCalHEWafer0Coarse11"/>
+    <Translation x="0.0*cm" y="-10.0*cm" z="-35*cm"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="cms:CMSE"/>
+    <rChild name="hgcalwafer:HGCalHEWafer0Coarse20"/>
+    <Translation x="0.0*cm" y="10.0*cm" z="-40*cm"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="cms:CMSE"/>
+    <rChild name="hgcalwafer:HGCalHEWafer0Coarse21"/>
+    <Translation x="0.0*cm" y="-10.0*cm" z="-40*cm"/>
+  </PosPart>
+</PosPartSection>
+</DDDefinition>

--- a/Geometry/HGCalCommonData/data/hgcalwafer/v17/hgcalwafer.xml
+++ b/Geometry/HGCalCommonData/data/hgcalwafer/v17/hgcalwafer.xml
@@ -1,0 +1,1075 @@
+<?xml version="1.0"?>
+<DDDefinition>
+
+<ConstantsSection label="hgcalwafer.xml" eval="true">
+  <Constant name="ModuleThicknessEE"     value="[hgcal:ModuleThicknessEE]"/>
+  <Constant name="ModuleThicknessHE"     value="[hgcal:ModuleThicknessHE]"/>
+  <Constant name="WaferSize"             value="[hgcal:WaferSize]"/>
+  <Constant name="WaferThickness"        value="[hgcal:WaferThickness]"/>
+  <Constant name="WaferThicknessFine"    value="[hgcal:WaferThicknessFine]"/>
+  <Constant name="WaferThicknessCoarse1" value="[hgcal:WaferThicknessCoarse1]"/>
+  <Constant name="WaferThicknessCoarse2" value="[hgcal:WaferThicknessCoarse2]"/>
+  <Constant name="SensorSeparation"      value="[hgcal:SensorSeparation]"/>
+  <Constant name="CellThicknessFine"     value="[hgcal:CellThicknessFine]"/>
+  <Constant name="CellThicknessCoarse1"  value="[hgcal:CellThicknessCoarse1]"/>
+  <Constant name="CellThicknessCoarse2"  value="[hgcal:CellThicknessCoarse2]"/>
+  <Constant name="NumberOfCellsFine"     value="[hgcal:NumberOfCellsFine]"/>
+  <Constant name="NumberOfCellsCoarse"   value="[hgcal:NumberOfCellsCoarse]"/>
+</ConstantsSection>
+
+<PosPartSection label="hgcalwafer.xml" eval="true">
+  <Algorithm name="hgcal:DDHGCalWaferF">
+    <rParent name="hgcalwafer:HGCalEEWafer0Fine0"/>
+    <String name="ModuleMaterial"    value="materials:Air"/>
+    <Numeric name="ModuleThickness"  value="[ModuleThicknessEE]"/>
+    <Numeric name="WaferSize"        value="[WaferSize]"/>
+    <Numeric name="SensorSeparation" value="[SensorSeparation]"/>
+    <Numeric name="WaferThickness"   value="[WaferThicknessFine]"/>
+    <Vector name="LayerNames" type="string" nEntries="9">
+      HGCalEEAirGap0Fine0, HGCalEEMotherBoard0Fine0, 
+      HGCalEEConnector0Fine0, HGCalEEPCB0Fine0, HGCalEEEpoxy0Fine0,
+      HGCalEEEpoxyT0Fine0, HGCalEEKapton0Fine0, HGCalEESensitive0Fine0,
+      HGCalEEBasePlate0Fine0</Vector>
+    <Vector name="LayerMaterials" type="string" nEntries="9">
+      materials:Air, hgcalMaterial:HGC_G10-FR4, hgcalMaterial:HGC_EEConnector,
+      hgcalMaterial:HGC_G10-FR4, materials:Epoxy, materials:Epoxy, 
+      materials:Kapton, materials:Silicon, hgcalMaterial:WCu</Vector>
+    <Vector name="LayerThickness" type="numeric" nEntries="9">
+      0.225*mm, 1.60*mm, 3.73*mm, 1.60*mm, 0.075*mm, 0.065*mm, 0.265*mm, 
+      [WaferThickness], 1.40*mm </Vector>
+    <Vector name="LayerTypes" type="numeric" nEntries="9"> 
+      0, 0, 0, 0, 0, 0, 0, 1, 0 </Vector>
+    <Vector name="Layers" type="numeric" nEntries="10"> 
+      0, 1, 2, 3, 4, 7, 5, 6, 5, 8 </Vector>
+    <Numeric name="NCells"           value="[NumberOfCellsFine]"/>
+    <Numeric name="CellType"         value="0"/>
+    <Vector name="CellNames" type="string" nEntries="25">
+      hgcalcell:HGCalEECellFull0Fine,   hgcalcell:HGCalEECellTrunc01Fine,
+      hgcalcell:HGCalEECellTrunc02Fine, hgcalcell:HGCalEECellTrunc03Fine,
+      hgcalcell:HGCalEECellExten01Fine, hgcalcell:HGCalEECellExten02Fine,
+      hgcalcell:HGCalEECellExten03Fine, hgcalcell:HGCalEECellCorner01Fine, 
+      hgcalcell:HGCalEECellCorner02Fine,hgcalcell:HGCalEECellCorner03Fine,
+      hgcalcell:HGCalEECellCorner04Fine,hgcalcell:HGCalEECellCorner05Fine,
+      hgcalcell:HGCalEECellCorner06Fine,hgcalcell:HGCalEECellExten04Fine, 
+      hgcalcell:HGCalEECellExten05Fine, hgcalcell:HGCalEECellExten06Fine,
+      hgcalcell:HGCalEECellTrunc04Fine, hgcalcell:HGCalEECellTrunc05Fine,
+      hgcalcell:HGCalEECellTrunc06Fine, hgcalcell:HGCalEECellCorner07Fine,
+      hgcalcell:HGCalEECellCorner08Fine,hgcalcell:HGCalEECellCorner09Fine,
+      hgcalcell:HGCalEECellCorner10Fine,hgcalcell:HGCalEECellCorner11Fine,
+      hgcalcell:HGCalEECellCorner12Fine</Vector>
+  </Algorithm>
+  <Algorithm name="hgcal:DDHGCalWaferF">
+    <rParent name="hgcalwafer:HGCalEEWafer0Fine1"/>
+    <String name="ModuleMaterial"    value="materials:Air"/>
+    <Numeric name="ModuleThickness"  value="[ModuleThicknessEE]"/>
+    <Numeric name="WaferSize"        value="[WaferSize]"/>
+    <Numeric name="SensorSeparation" value="[SensorSeparation]"/>
+    <Numeric name="WaferThickness"   value="[WaferThicknessFine]"/>
+    <Vector name="LayerNames" type="string" nEntries="9">
+      HGCalEEAirGap0Fine1, HGCalEEMotherBoard0Fine1, 
+      HGCalEEConnector0Fine1, HGCalEEPCB0Fine1, HGCalEEEpoxy0Fine1,
+      HGCalEEEpoxyT0Fine1, HGCalEEKapton0Fine1, HGCalEESensitive0Fine1,
+      HGCalEEBasePlate0Fine1</Vector>
+    <Vector name="LayerMaterials" type="string" nEntries="9">
+      materials:Air, hgcalMaterial:HGC_G10-FR4, hgcalMaterial:HGC_EEConnector,
+      hgcalMaterial:HGC_G10-FR4, materials:Epoxy, materials:Epoxy, 
+      materials:Kapton, materials:Silicon, hgcalMaterial:WCu</Vector>
+    <Vector name="LayerThickness" type="numeric" nEntries="9">
+      0.225*mm, 1.60*mm, 3.73*mm, 1.60*mm, 0.075*mm, 0.065*mm, 0.265*mm, 
+      [WaferThickness], 1.40*mm </Vector>
+    <Vector name="LayerTypes" type="numeric" nEntries="9"> 
+      0, 0, 0, 0, 0, 0, 0, 1, 0 </Vector>
+    <Vector name="Layers" type="numeric" nEntries="10"> 
+      0, 1, 2, 3, 4, 7, 5, 6, 5, 8 </Vector>
+    <Numeric name="NCells"           value="[NumberOfCellsFine]"/>
+    <Numeric name="CellType"         value="3"/>
+    <Vector name="CellNames" type="string" nEntries="25">
+      hgcalcell:HGCalEECellFull0Fine,   hgcalcell:HGCalEECellTrunc01Fine,
+      hgcalcell:HGCalEECellTrunc02Fine, hgcalcell:HGCalEECellTrunc03Fine,
+      hgcalcell:HGCalEECellExten01Fine, hgcalcell:HGCalEECellExten02Fine,
+      hgcalcell:HGCalEECellExten03Fine, hgcalcell:HGCalEECellCorner01Fine, 
+      hgcalcell:HGCalEECellCorner02Fine,hgcalcell:HGCalEECellCorner03Fine,
+      hgcalcell:HGCalEECellCorner04Fine,hgcalcell:HGCalEECellCorner05Fine,
+      hgcalcell:HGCalEECellCorner06Fine,hgcalcell:HGCalEECellExten04Fine, 
+      hgcalcell:HGCalEECellExten05Fine, hgcalcell:HGCalEECellExten06Fine,
+      hgcalcell:HGCalEECellTrunc04Fine, hgcalcell:HGCalEECellTrunc05Fine,
+      hgcalcell:HGCalEECellTrunc06Fine, hgcalcell:HGCalEECellCorner07Fine,
+      hgcalcell:HGCalEECellCorner08Fine,hgcalcell:HGCalEECellCorner09Fine,
+      hgcalcell:HGCalEECellCorner10Fine,hgcalcell:HGCalEECellCorner11Fine,
+      hgcalcell:HGCalEECellCorner12Fine</Vector>
+  </Algorithm>
+  <Algorithm name="hgcal:DDHGCalWaferF">
+    <rParent name="hgcalwafer:HGCalEEWafer1Fine0"/>
+    <String name="ModuleMaterial"    value="materials:Air"/>
+    <Numeric name="ModuleThickness"  value="[ModuleThicknessEE]"/>
+    <Numeric name="WaferSize"        value="[WaferSize]"/>
+    <Numeric name="SensorSeparation" value="[SensorSeparation]"/>
+    <Numeric name="WaferThickness"   value="[WaferThicknessFine]"/>
+    <Vector name="LayerNames" type="string" nEntries="9">
+      HGCalEEAirGap1Fine0, HGCalEEMotherBoard1Fine0, 
+      HGCalEEConnector1Fine0, HGCalEEPCB1Fine0, HGCalEEEpoxy1Fine0, 
+      HGCalEEEpoxyT1Fine0, HGCalEEKapton1Fine0, HGCalEESensitive1Fine0,
+      HGCalEEBasePlate1Fine0</Vector>
+    <Vector name="LayerMaterials" type="string" nEntries="9">
+      materials:Air, hgcalMaterial:HGC_G10-FR4, hgcalMaterial:HGC_EEConnector,
+      hgcalMaterial:HGC_G10-FR4, materials:Epoxy, materials:Epoxy, 
+      materials:Kapton, materials:Silicon, hgcalMaterial:WCu</Vector>
+    <Vector name="LayerThickness" type="numeric" nEntries="9">
+      0.225*mm, 1.60*mm, 3.73*mm, 1.60*mm, 0.075*mm, 0.065*mm, 0.265*mm, 
+      [WaferThickness], 1.40*mm </Vector>
+    <Vector name="LayerTypes" type="numeric" nEntries="9"> 
+      0, 0, 0, 0, 0, 0, 0, 1, 0 </Vector>
+    <Vector name="Layers" type="numeric" nEntries="10"> 
+      8, 5, 6, 5, 7, 4, 3, 2, 1, 0 </Vector>
+    <Numeric name="NCells"           value="[NumberOfCellsFine]"/>
+    <Numeric name="CellType"         value="3"/>
+    <Vector name="CellNames" type="string" nEntries="25">
+      hgcalcell:HGCalEECellFull1Fine,   hgcalcell:HGCalEECellTrunc21Fine,
+      hgcalcell:HGCalEECellTrunc22Fine, hgcalcell:HGCalEECellTrunc23Fine,
+      hgcalcell:HGCalEECellExten21Fine, hgcalcell:HGCalEECellExten22Fine,
+      hgcalcell:HGCalEECellExten23Fine, hgcalcell:HGCalEECellCorner21Fine, 
+      hgcalcell:HGCalEECellCorner22Fine,hgcalcell:HGCalEECellCorner23Fine,
+      hgcalcell:HGCalEECellCorner24Fine,hgcalcell:HGCalEECellCorner25Fine,
+      hgcalcell:HGCalEECellCorner26Fine,hgcalcell:HGCalEECellExten24Fine, 
+      hgcalcell:HGCalEECellExten25Fine, hgcalcell:HGCalEECellExten26Fine,
+      hgcalcell:HGCalEECellTrunc24Fine, hgcalcell:HGCalEECellTrunc25Fine,
+      hgcalcell:HGCalEECellTrunc26Fine, hgcalcell:HGCalEECellCorner27Fine,
+      hgcalcell:HGCalEECellCorner28Fine,hgcalcell:HGCalEECellCorner29Fine,
+      hgcalcell:HGCalEECellCorner30Fine,hgcalcell:HGCalEECellCorner31Fine,
+      hgcalcell:HGCalEECellCorner32Fine</Vector>
+  </Algorithm>
+  <Algorithm name="hgcal:DDHGCalWaferF">
+    <rParent name="hgcalwafer:HGCalEEWafer1Fine1"/>
+    <String name="ModuleMaterial"    value="materials:Air"/>
+    <Numeric name="ModuleThickness"  value="[ModuleThicknessEE]"/>
+    <Numeric name="WaferSize"        value="[WaferSize]"/>
+    <Numeric name="SensorSeparation" value="[SensorSeparation]"/>
+    <Numeric name="WaferThickness"   value="[WaferThicknessFine]"/>
+    <Vector name="LayerNames" type="string" nEntries="9">
+      HGCalEEAirGap1Fine1, HGCalEEMotherBoard1Fine1, 
+      HGCalEEConnector1Fine1, HGCalEEPCB1Fine1, HGCalEEEpoxy1Fine1, 
+      HGCalEEEpoxyT1Fine1, HGCalEEKapton1Fine1, HGCalEESensitive1Fine1,
+      HGCalEEBasePlate1Fine1</Vector>
+    <Vector name="LayerMaterials" type="string" nEntries="9">
+      materials:Air, hgcalMaterial:HGC_G10-FR4, hgcalMaterial:HGC_EEConnector,
+      hgcalMaterial:HGC_G10-FR4, materials:Epoxy, materials:Epoxy, 
+      materials:Kapton, materials:Silicon, hgcalMaterial:WCu</Vector>
+    <Vector name="LayerThickness" type="numeric" nEntries="9">
+      0.225*mm, 1.60*mm, 3.73*mm, 1.60*mm, 0.075*mm, 0.065*mm, 0.265*mm, 
+      [WaferThickness], 1.40*mm </Vector>
+    <Vector name="LayerTypes" type="numeric" nEntries="9"> 
+      0, 0, 0, 0, 0, 0, 0, 1, 0 </Vector>
+    <Vector name="Layers" type="numeric" nEntries="10"> 
+      8, 5, 6, 5, 7, 4, 3, 2, 1, 0 </Vector>
+    <Numeric name="NCells"           value="[NumberOfCellsFine]"/>
+    <Numeric name="CellType"         value="0"/>
+    <Vector name="CellNames" type="string" nEntries="25">
+      hgcalcell:HGCalEECellFull1Fine,   hgcalcell:HGCalEECellTrunc21Fine,
+      hgcalcell:HGCalEECellTrunc22Fine, hgcalcell:HGCalEECellTrunc23Fine,
+      hgcalcell:HGCalEECellExten21Fine, hgcalcell:HGCalEECellExten22Fine,
+      hgcalcell:HGCalEECellExten23Fine, hgcalcell:HGCalEECellCorner21Fine, 
+      hgcalcell:HGCalEECellCorner22Fine,hgcalcell:HGCalEECellCorner23Fine,
+      hgcalcell:HGCalEECellCorner24Fine,hgcalcell:HGCalEECellCorner25Fine,
+      hgcalcell:HGCalEECellCorner26Fine,hgcalcell:HGCalEECellExten24Fine, 
+      hgcalcell:HGCalEECellExten25Fine, hgcalcell:HGCalEECellExten26Fine,
+      hgcalcell:HGCalEECellTrunc24Fine, hgcalcell:HGCalEECellTrunc25Fine,
+      hgcalcell:HGCalEECellTrunc26Fine, hgcalcell:HGCalEECellCorner27Fine,
+      hgcalcell:HGCalEECellCorner28Fine,hgcalcell:HGCalEECellCorner29Fine,
+      hgcalcell:HGCalEECellCorner30Fine,hgcalcell:HGCalEECellCorner31Fine,
+      hgcalcell:HGCalEECellCorner32Fine</Vector>
+  </Algorithm>
+  <Algorithm name="hgcal:DDHGCalWaferF">
+    <rParent name="hgcalwafer:HGCalEEWafer0Coarse10"/>
+    <String name="ModuleMaterial"    value="materials:Air"/>
+    <Numeric name="ModuleThickness"  value="[ModuleThicknessEE]"/>
+    <Numeric name="WaferSize"        value="[WaferSize]"/>
+    <Numeric name="SensorSeparation" value="[SensorSeparation]"/>
+    <Numeric name="WaferThickness"   value="[WaferThicknessCoarse1]"/>
+    <Vector name="LayerNames" type="string" nEntries="9">
+      HGCalEEAirGap0Coarse10, HGCalEEMotherBoard0Coarse10, 
+      HGCalEEConnector0Coarse10, HGCalEEPCB0Coarse10, HGCalEEEpoxy0Coarse10, 
+      HGCalEEEpoxyT0Coarse10, HGCalEEKapton0Coarse10, HGCalEESensitive0Coarse10,
+      HGCalEEBasePlate0Coarse10</Vector>
+    <Vector name="LayerMaterials" type="string" nEntries="9">
+      materials:Air, hgcalMaterial:HGC_G10-FR4, hgcalMaterial:HGC_EEConnector,
+      hgcalMaterial:HGC_G10-FR4, materials:Epoxy, materials:Epoxy, 
+      materials:Kapton, materials:Silicon, hgcalMaterial:WCu</Vector>
+    <Vector name="LayerThickness" type="numeric" nEntries="9">
+      0.225*mm, 1.60*mm, 3.73*mm, 1.60*mm, 0.075*mm, 0.065*mm, 0.265*mm, 
+      [WaferThickness], 1.40*mm </Vector>
+    <Vector name="LayerTypes" type="numeric" nEntries="9"> 
+      0, 0, 0, 0, 0, 0, 0, 1, 0 </Vector>
+    <Vector name="Layers" type="numeric" nEntries="10"> 
+      0, 1, 2, 3, 4, 7, 5, 6, 5, 8 </Vector>
+    <Numeric name="NCells"           value="[NumberOfCellsCoarse]"/>
+    <Numeric name="CellType"         value="1"/>
+    <Vector name="CellNames" type="string" nEntries="25">
+      hgcalcell:HGCalEECellFull0Coarse1,   hgcalcell:HGCalEECellTrunc01Coarse1,
+      hgcalcell:HGCalEECellTrunc02Coarse1, hgcalcell:HGCalEECellTrunc03Coarse1,
+      hgcalcell:HGCalEECellExten01Coarse1, hgcalcell:HGCalEECellExten02Coarse1,
+      hgcalcell:HGCalEECellExten03Coarse1, hgcalcell:HGCalEECellCorner01Coarse1, 
+      hgcalcell:HGCalEECellCorner02Coarse1,hgcalcell:HGCalEECellCorner03Coarse1,
+      hgcalcell:HGCalEECellCorner04Coarse1,hgcalcell:HGCalEECellCorner05Coarse1,
+      hgcalcell:HGCalEECellCorner06Coarse1,hgcalcell:HGCalEECellExten04Coarse1, 
+      hgcalcell:HGCalEECellExten05Coarse1, hgcalcell:HGCalEECellExten06Coarse1,
+      hgcalcell:HGCalEECellTrunc04Coarse1, hgcalcell:HGCalEECellTrunc05Coarse1,
+      hgcalcell:HGCalEECellTrunc06Coarse1, hgcalcell:HGCalEECellCorner07Coarse1,
+      hgcalcell:HGCalEECellCorner08Coarse1,hgcalcell:HGCalEECellCorner09Coarse1,
+      hgcalcell:HGCalEECellCorner10Coarse1,hgcalcell:HGCalEECellCorner11Coarse1,
+      hgcalcell:HGCalEECellCorner12Coarse1</Vector>
+  </Algorithm>
+  <Algorithm name="hgcal:DDHGCalWaferF">
+    <rParent name="hgcalwafer:HGCalEEWafer0Coarse11"/>
+    <String name="ModuleMaterial"    value="materials:Air"/>
+    <Numeric name="ModuleThickness"  value="[ModuleThicknessEE]"/>
+    <Numeric name="WaferSize"        value="[WaferSize]"/>
+    <Numeric name="SensorSeparation" value="[SensorSeparation]"/>
+    <Numeric name="WaferThickness"   value="[WaferThicknessCoarse1]"/>
+    <Vector name="LayerNames" type="string" nEntries="9">
+      HGCalEEAirGap0Coarse11, HGCalEEMotherBoard0Coarse11, 
+      HGCalEEConnector0Coarse11, HGCalEEPCB0Coarse11, HGCalEEEpoxy0Coarse11, 
+      HGCalEEEpoxyT0Coarse11, HGCalEEKapton0Coarse11, HGCalEESensitive0Coarse11,
+      HGCalEEBasePlate0Coarse11</Vector>
+    <Vector name="LayerMaterials" type="string" nEntries="9">
+      materials:Air, hgcalMaterial:HGC_G10-FR4, hgcalMaterial:HGC_EEConnector,
+      hgcalMaterial:HGC_G10-FR4, materials:Epoxy, materials:Epoxy, 
+      materials:Kapton, materials:Silicon, hgcalMaterial:WCu</Vector>
+    <Vector name="LayerThickness" type="numeric" nEntries="9">
+      0.225*mm, 1.60*mm, 3.73*mm, 1.60*mm, 0.075*mm, 0.065*mm, 0.265*mm, 
+      [WaferThickness], 1.40*mm </Vector>
+    <Vector name="LayerTypes" type="numeric" nEntries="9"> 
+      0, 0, 0, 0, 0, 0, 0, 1, 0 </Vector>
+    <Vector name="Layers" type="numeric" nEntries="10"> 
+      0, 1, 2, 3, 4, 7, 5, 6, 5, 8 </Vector>
+    <Numeric name="NCells"           value="[NumberOfCellsCoarse]"/>
+    <Numeric name="CellType"         value="4"/>
+    <Vector name="CellNames" type="string" nEntries="25">
+      hgcalcell:HGCalEECellFull0Coarse1,   hgcalcell:HGCalEECellTrunc01Coarse1,
+      hgcalcell:HGCalEECellTrunc02Coarse1, hgcalcell:HGCalEECellTrunc03Coarse1,
+      hgcalcell:HGCalEECellExten01Coarse1, hgcalcell:HGCalEECellExten02Coarse1,
+      hgcalcell:HGCalEECellExten03Coarse1, hgcalcell:HGCalEECellCorner01Coarse1, 
+      hgcalcell:HGCalEECellCorner02Coarse1,hgcalcell:HGCalEECellCorner03Coarse1,
+      hgcalcell:HGCalEECellCorner04Coarse1,hgcalcell:HGCalEECellCorner05Coarse1,
+      hgcalcell:HGCalEECellCorner06Coarse1,hgcalcell:HGCalEECellExten04Coarse1, 
+      hgcalcell:HGCalEECellExten05Coarse1, hgcalcell:HGCalEECellExten06Coarse1,
+      hgcalcell:HGCalEECellTrunc04Coarse1, hgcalcell:HGCalEECellTrunc05Coarse1,
+      hgcalcell:HGCalEECellTrunc06Coarse1, hgcalcell:HGCalEECellCorner07Coarse1,
+      hgcalcell:HGCalEECellCorner08Coarse1,hgcalcell:HGCalEECellCorner09Coarse1,
+      hgcalcell:HGCalEECellCorner10Coarse1,hgcalcell:HGCalEECellCorner11Coarse1,
+      hgcalcell:HGCalEECellCorner12Coarse1</Vector>
+  </Algorithm>
+  <Algorithm name="hgcal:DDHGCalWaferF">
+    <rParent name="hgcalwafer:HGCalEEWafer1Coarse10"/>
+    <String name="ModuleMaterial"    value="materials:Air"/>
+    <Numeric name="ModuleThickness"  value="[ModuleThicknessEE]"/>
+    <Numeric name="WaferSize"        value="[WaferSize]"/>
+    <Numeric name="SensorSeparation" value="[SensorSeparation]"/>
+    <Numeric name="WaferThickness"   value="[WaferThicknessCoarse1]"/>
+    <Vector name="LayerNames" type="string" nEntries="9">
+      HGCalEEAirGap1Coarse10, HGCalEEMotherBoard1Coarse10, 
+      HGCalEEConnector1Coarse10, HGCalEEPCB1Coarse10, HGCalEEEpoxy1Coarse10, 
+      HGCalEEEpoxyT1Coarse10, HGCalEEKapton1Coarse10, HGCalEESensitive1Coarse10,
+      HGCalEEBasePlate1Coarse10</Vector>
+    <Vector name="LayerMaterials" type="string" nEntries="9">
+      materials:Air, hgcalMaterial:HGC_G10-FR4, hgcalMaterial:HGC_EEConnector,
+      hgcalMaterial:HGC_G10-FR4, materials:Epoxy, materials:Epoxy, 
+      materials:Kapton, materials:Silicon, hgcalMaterial:WCu</Vector>
+    <Vector name="LayerThickness" type="numeric" nEntries="9">
+      0.225*mm, 1.60*mm, 3.73*mm, 1.60*mm, 0.075*mm, 0.065*mm, 0.265*mm, 
+      [WaferThickness], 1.40*mm </Vector>
+    <Vector name="LayerTypes" type="numeric" nEntries="9"> 
+      0, 0, 0, 0, 0, 0, 0, 1, 0 </Vector>
+    <Vector name="Layers" type="numeric" nEntries="10"> 
+      8, 5, 6, 5, 7, 4, 3, 2, 1, 0 </Vector>
+    <Numeric name="NCells"           value="[NumberOfCellsCoarse]"/>
+    <Numeric name="CellType"         value="4"/>
+    <Vector name="CellNames" type="string" nEntries="25">
+      hgcalcell:HGCalEECellFull1Coarse1,   hgcalcell:HGCalEECellTrunc21Coarse1,
+      hgcalcell:HGCalEECellTrunc22Coarse1, hgcalcell:HGCalEECellTrunc23Coarse1,
+      hgcalcell:HGCalEECellExten21Coarse1, hgcalcell:HGCalEECellExten22Coarse1,
+      hgcalcell:HGCalEECellExten23Coarse1, hgcalcell:HGCalEECellCorner21Coarse1, 
+      hgcalcell:HGCalEECellCorner22Coarse1,hgcalcell:HGCalEECellCorner23Coarse1,
+      hgcalcell:HGCalEECellCorner24Coarse1,hgcalcell:HGCalEECellCorner25Coarse1,
+      hgcalcell:HGCalEECellCorner26Coarse1,hgcalcell:HGCalEECellExten24Coarse1, 
+      hgcalcell:HGCalEECellExten25Coarse1, hgcalcell:HGCalEECellExten26Coarse1,
+      hgcalcell:HGCalEECellTrunc24Coarse1, hgcalcell:HGCalEECellTrunc25Coarse1,
+      hgcalcell:HGCalEECellTrunc26Coarse1, hgcalcell:HGCalEECellCorner27Coarse1,
+      hgcalcell:HGCalEECellCorner28Coarse1,hgcalcell:HGCalEECellCorner29Coarse1,
+      hgcalcell:HGCalEECellCorner30Coarse1,hgcalcell:HGCalEECellCorner31Coarse1,
+      hgcalcell:HGCalEECellCorner32Coarse1</Vector>
+  </Algorithm>
+  <Algorithm name="hgcal:DDHGCalWaferF">
+    <rParent name="hgcalwafer:HGCalEEWafer1Coarse11"/>
+    <String name="ModuleMaterial"    value="materials:Air"/>
+    <Numeric name="ModuleThickness"  value="[ModuleThicknessEE]"/>
+    <Numeric name="WaferSize"        value="[WaferSize]"/>
+    <Numeric name="SensorSeparation" value="[SensorSeparation]"/>
+    <Numeric name="WaferThickness"   value="[WaferThicknessCoarse1]"/>
+    <Vector name="LayerNames" type="string" nEntries="9">
+      HGCalEEAirGap1Coarse11, HGCalEEMotherBoard1Coarse11, 
+      HGCalEEConnector1Coarse11, HGCalEEPCB1Coarse11, HGCalEEEpoxy1Coarse11, 
+      HGCalEEEpoxyT1Coarse11, HGCalEEKapton1Coarse11, HGCalEESensitive1Coarse11,
+      HGCalEEBasePlate1Coarse11</Vector>
+    <Vector name="LayerMaterials" type="string" nEntries="9">
+      materials:Air, hgcalMaterial:HGC_G10-FR4, hgcalMaterial:HGC_EEConnector,
+      hgcalMaterial:HGC_G10-FR4, materials:Epoxy, materials:Epoxy, 
+      materials:Kapton, materials:Silicon, hgcalMaterial:WCu</Vector>
+    <Vector name="LayerThickness" type="numeric" nEntries="9">
+      0.225*mm, 1.60*mm, 3.73*mm, 1.60*mm, 0.075*mm, 0.065*mm, 0.265*mm, 
+      [WaferThickness], 1.40*mm </Vector>
+    <Vector name="LayerTypes" type="numeric" nEntries="9"> 
+      0, 0, 0, 0, 0, 0, 0, 1, 0 </Vector>
+    <Vector name="Layers" type="numeric" nEntries="10"> 
+      8, 5, 6, 5, 7, 4, 3, 2, 1, 0 </Vector>
+    <Numeric name="NCells"           value="[NumberOfCellsCoarse]"/>
+    <Numeric name="CellType"         value="1"/>
+    <Vector name="CellNames" type="string" nEntries="25">
+      hgcalcell:HGCalEECellFull1Coarse1,   hgcalcell:HGCalEECellTrunc21Coarse1,
+      hgcalcell:HGCalEECellTrunc22Coarse1, hgcalcell:HGCalEECellTrunc23Coarse1,
+      hgcalcell:HGCalEECellExten21Coarse1, hgcalcell:HGCalEECellExten22Coarse1,
+      hgcalcell:HGCalEECellExten23Coarse1, hgcalcell:HGCalEECellCorner21Coarse1, 
+      hgcalcell:HGCalEECellCorner22Coarse1,hgcalcell:HGCalEECellCorner23Coarse1,
+      hgcalcell:HGCalEECellCorner24Coarse1,hgcalcell:HGCalEECellCorner25Coarse1,
+      hgcalcell:HGCalEECellCorner26Coarse1,hgcalcell:HGCalEECellExten24Coarse1, 
+      hgcalcell:HGCalEECellExten25Coarse1, hgcalcell:HGCalEECellExten26Coarse1,
+      hgcalcell:HGCalEECellTrunc24Coarse1, hgcalcell:HGCalEECellTrunc25Coarse1,
+      hgcalcell:HGCalEECellTrunc26Coarse1, hgcalcell:HGCalEECellCorner27Coarse1,
+      hgcalcell:HGCalEECellCorner28Coarse1,hgcalcell:HGCalEECellCorner29Coarse1,
+      hgcalcell:HGCalEECellCorner30Coarse1,hgcalcell:HGCalEECellCorner31Coarse1,
+      hgcalcell:HGCalEECellCorner32Coarse1</Vector>
+  </Algorithm>
+  <Algorithm name="hgcal:DDHGCalWaferF">
+    <rParent name="hgcalwafer:HGCalEEWafer0Coarse20"/>
+    <String name="ModuleMaterial"    value="materials:Air"/>
+    <Numeric name="ModuleThickness"  value="[ModuleThicknessEE]"/>
+    <Numeric name="WaferSize"        value="[WaferSize]"/>
+    <Numeric name="SensorSeparation" value="[SensorSeparation]"/>
+    <Numeric name="WaferThickness"   value="[WaferThicknessCoarse2]"/>
+    <Vector name="LayerNames" type="string" nEntries="9">
+      HGCalEEAirGap0Coarse20, HGCalEEMotherBoard0Coarse20, 
+      HGCalEEConnector0Coarse20, HGCalEEPCB0Coarse20, HGCalEEEpoxy0Coarse20, 
+      HGCalEEEpoxyT0Coarse20, HGCalEEKapton0Coarse20, HGCalEESensitive0Coarse20,
+      HGCalEEBasePlate0Coarse20</Vector>
+    <Vector name="LayerMaterials" type="string" nEntries="9">
+      materials:Air, hgcalMaterial:HGC_G10-FR4, hgcalMaterial:HGC_EEConnector,
+      hgcalMaterial:HGC_G10-FR4, materials:Epoxy, materials:Epoxy, 
+      materials:Kapton, materials:Silicon, hgcalMaterial:WCu</Vector>
+    <Vector name="LayerThickness" type="numeric" nEntries="9">
+      0.225*mm, 1.60*mm, 3.73*mm, 1.60*mm, 0.075*mm, 0.065*mm, 0.265*mm, 
+      [WaferThickness], 1.40*mm </Vector>
+    <Vector name="LayerTypes" type="numeric" nEntries="9"> 
+      0, 0, 0, 0, 0, 0, 0, 1, 0 </Vector>
+    <Vector name="Layers" type="numeric" nEntries="10"> 
+      0, 1, 2, 3, 4, 7, 5, 6, 5, 8 </Vector>
+    <Numeric name="NCells"           value="[NumberOfCellsCoarse]"/>
+    <Numeric name="CellType"         value="2"/>
+    <Vector name="CellNames" type="string" nEntries="25">
+      hgcalcell:HGCalEECellFull0Coarse2,   hgcalcell:HGCalEECellTrunc01Coarse2,
+      hgcalcell:HGCalEECellTrunc02Coarse2, hgcalcell:HGCalEECellTrunc03Coarse2,
+      hgcalcell:HGCalEECellExten01Coarse2, hgcalcell:HGCalEECellExten02Coarse2,
+      hgcalcell:HGCalEECellExten03Coarse2, hgcalcell:HGCalEECellCorner01Coarse2, 
+      hgcalcell:HGCalEECellCorner02Coarse2,hgcalcell:HGCalEECellCorner03Coarse2,
+      hgcalcell:HGCalEECellCorner04Coarse2,hgcalcell:HGCalEECellCorner05Coarse2,
+      hgcalcell:HGCalEECellCorner06Coarse2,hgcalcell:HGCalEECellExten04Coarse2, 
+      hgcalcell:HGCalEECellExten05Coarse2, hgcalcell:HGCalEECellExten06Coarse2,
+      hgcalcell:HGCalEECellTrunc04Coarse2, hgcalcell:HGCalEECellTrunc05Coarse2,
+      hgcalcell:HGCalEECellTrunc06Coarse2, hgcalcell:HGCalEECellCorner07Coarse2,
+      hgcalcell:HGCalEECellCorner08Coarse2,hgcalcell:HGCalEECellCorner09Coarse2,
+      hgcalcell:HGCalEECellCorner10Coarse2,hgcalcell:HGCalEECellCorner11Coarse2,
+      hgcalcell:HGCalEECellCorner12Coarse2</Vector>
+  </Algorithm>
+  <Algorithm name="hgcal:DDHGCalWaferF">
+    <rParent name="hgcalwafer:HGCalEEWafer0Coarse21"/>
+    <String name="ModuleMaterial"    value="materials:Air"/>
+    <Numeric name="ModuleThickness"  value="[ModuleThicknessEE]"/>
+    <Numeric name="WaferSize"        value="[WaferSize]"/>
+    <Numeric name="SensorSeparation" value="[SensorSeparation]"/>
+    <Numeric name="WaferThickness"   value="[WaferThicknessCoarse2]"/>
+    <Vector name="LayerNames" type="string" nEntries="9">
+      HGCalEEAirGap0Coarse21, HGCalEEMotherBoard0Coarse21, 
+      HGCalEEConnector0Coarse21, HGCalEEPCB0Coarse21, HGCalEEEpoxy0Coarse21, 
+      HGCalEEEpoxyT0Coarse21, HGCalEEKapton0Coarse21, HGCalEESensitive0Coarse21,
+      HGCalEEBasePlate0Coarse21</Vector>
+    <Vector name="LayerMaterials" type="string" nEntries="9">
+      materials:Air, hgcalMaterial:HGC_G10-FR4, hgcalMaterial:HGC_EEConnector,
+      hgcalMaterial:HGC_G10-FR4, materials:Epoxy, materials:Epoxy, 
+      materials:Kapton, materials:Silicon, hgcalMaterial:WCu</Vector>
+    <Vector name="LayerThickness" type="numeric" nEntries="9">
+      0.225*mm, 1.60*mm, 3.73*mm, 1.60*mm, 0.075*mm, 0.065*mm, 0.265*mm, 
+      [WaferThickness], 1.40*mm </Vector>
+    <Vector name="LayerTypes" type="numeric" nEntries="9"> 
+      0, 0, 0, 0, 0, 0, 0, 1, 0 </Vector>
+    <Vector name="Layers" type="numeric" nEntries="10"> 
+      0, 1, 2, 3, 4, 7, 5, 6, 5, 8 </Vector>
+    <Numeric name="NCells"           value="[NumberOfCellsCoarse]"/>
+    <Numeric name="CellType"         value="5"/>
+    <Vector name="CellNames" type="string" nEntries="25">
+      hgcalcell:HGCalEECellFull0Coarse2,   hgcalcell:HGCalEECellTrunc01Coarse2,
+      hgcalcell:HGCalEECellTrunc02Coarse2, hgcalcell:HGCalEECellTrunc03Coarse2,
+      hgcalcell:HGCalEECellExten01Coarse2, hgcalcell:HGCalEECellExten02Coarse2,
+      hgcalcell:HGCalEECellExten03Coarse2, hgcalcell:HGCalEECellCorner01Coarse2, 
+      hgcalcell:HGCalEECellCorner02Coarse2,hgcalcell:HGCalEECellCorner03Coarse2,
+      hgcalcell:HGCalEECellCorner04Coarse2,hgcalcell:HGCalEECellCorner05Coarse2,
+      hgcalcell:HGCalEECellCorner06Coarse2,hgcalcell:HGCalEECellExten04Coarse2, 
+      hgcalcell:HGCalEECellExten05Coarse2, hgcalcell:HGCalEECellExten06Coarse2,
+      hgcalcell:HGCalEECellTrunc04Coarse2, hgcalcell:HGCalEECellTrunc05Coarse2,
+      hgcalcell:HGCalEECellTrunc06Coarse2, hgcalcell:HGCalEECellCorner07Coarse2,
+      hgcalcell:HGCalEECellCorner08Coarse2,hgcalcell:HGCalEECellCorner09Coarse2,
+      hgcalcell:HGCalEECellCorner10Coarse2,hgcalcell:HGCalEECellCorner11Coarse2,
+      hgcalcell:HGCalEECellCorner12Coarse2</Vector>
+  </Algorithm>
+  <Algorithm name="hgcal:DDHGCalWaferF">
+    <rParent name="hgcalwafer:HGCalEEWafer1Coarse20"/>
+    <String name="ModuleMaterial"    value="materials:Air"/>
+    <Numeric name="ModuleThickness"  value="[ModuleThicknessEE]"/>
+    <Numeric name="WaferSize"        value="[WaferSize]"/>
+    <Numeric name="SensorSeparation" value="[SensorSeparation]"/>
+    <Numeric name="WaferThickness"   value="[WaferThicknessCoarse2]"/>
+    <Vector name="LayerNames" type="string" nEntries="9">
+      HGCalEEAirGap1Coarse20, HGCalEEMotherBoard1Coarse20, 
+      HGCalEEConnector1Coarse20, HGCalEEPCB1Coarse20, HGCalEEEpoxy1Coarse20, 
+      HGCalEEEpoxyT1Coarse20, HGCalEEKapton1Coarse20, HGCalEESensitive1Coarse20,
+      HGCalEEBasePlate1Coarse20</Vector>
+    <Vector name="LayerMaterials" type="string" nEntries="9">
+      materials:Air, hgcalMaterial:HGC_G10-FR4, hgcalMaterial:HGC_EEConnector,
+      hgcalMaterial:HGC_G10-FR4, materials:Epoxy, materials:Epoxy, 
+      materials:Kapton, materials:Silicon, hgcalMaterial:WCu</Vector>
+    <Vector name="LayerThickness" type="numeric" nEntries="9">
+      0.225*mm, 1.60*mm, 3.73*mm, 1.60*mm, 0.075*mm, 0.065*mm, 0.265*mm, 
+      [WaferThickness], 1.40*mm </Vector>
+    <Vector name="LayerTypes" type="numeric" nEntries="9"> 
+      0, 0, 0, 0, 0, 0, 0, 1, 0 </Vector>
+    <Vector name="Layers" type="numeric" nEntries="10"> 
+      8, 5, 6, 5, 7, 4, 3, 2, 1, 0 </Vector>
+    <Numeric name="NCells"           value="[NumberOfCellsCoarse]"/>
+    <Numeric name="CellType"         value="5"/>
+    <Vector name="CellNames" type="string" nEntries="25">
+      hgcalcell:HGCalEECellFull1Coarse2,   hgcalcell:HGCalEECellTrunc21Coarse2,
+      hgcalcell:HGCalEECellTrunc22Coarse2, hgcalcell:HGCalEECellTrunc23Coarse2,
+      hgcalcell:HGCalEECellExten21Coarse2, hgcalcell:HGCalEECellExten22Coarse2,
+      hgcalcell:HGCalEECellExten23Coarse2, hgcalcell:HGCalEECellCorner21Coarse2, 
+      hgcalcell:HGCalEECellCorner22Coarse2,hgcalcell:HGCalEECellCorner23Coarse2,
+      hgcalcell:HGCalEECellCorner24Coarse2,hgcalcell:HGCalEECellCorner25Coarse2,
+      hgcalcell:HGCalEECellCorner26Coarse2,hgcalcell:HGCalEECellExten24Coarse2, 
+      hgcalcell:HGCalEECellExten25Coarse2, hgcalcell:HGCalEECellExten26Coarse2,
+      hgcalcell:HGCalEECellTrunc24Coarse2, hgcalcell:HGCalEECellTrunc25Coarse2,
+      hgcalcell:HGCalEECellTrunc26Coarse2, hgcalcell:HGCalEECellCorner27Coarse2,
+      hgcalcell:HGCalEECellCorner28Coarse2,hgcalcell:HGCalEECellCorner29Coarse2,
+      hgcalcell:HGCalEECellCorner30Coarse2,hgcalcell:HGCalEECellCorner31Coarse2,
+      hgcalcell:HGCalEECellCorner32Coarse2</Vector>
+  </Algorithm>
+  <Algorithm name="hgcal:DDHGCalWaferF">
+    <rParent name="hgcalwafer:HGCalEEWafer1Coarse21"/>
+    <String name="ModuleMaterial"    value="materials:Air"/>
+    <Numeric name="ModuleThickness"  value="[ModuleThicknessEE]"/>
+    <Numeric name="WaferSize"        value="[WaferSize]"/>
+    <Numeric name="SensorSeparation" value="[SensorSeparation]"/>
+    <Numeric name="WaferThickness"   value="[WaferThicknessCoarse2]"/>
+    <Vector name="LayerNames" type="string" nEntries="9">
+      HGCalEEAirGap1Coarse21, HGCalEEMotherBoard1Coarse21, 
+      HGCalEEConnector1Coarse21, HGCalEEPCB1Coarse21, HGCalEEEpoxy1Coarse21, 
+      HGCalEEEpoxyT1Coarse21, HGCalEEKapton1Coarse21, HGCalEESensitive1Coarse21,
+      HGCalEEBasePlate1Coarse21</Vector>
+    <Vector name="LayerMaterials" type="string" nEntries="9">
+      materials:Air, hgcalMaterial:HGC_G10-FR4, hgcalMaterial:HGC_EEConnector,
+      hgcalMaterial:HGC_G10-FR4, materials:Epoxy, materials:Epoxy, 
+      materials:Kapton, materials:Silicon, hgcalMaterial:WCu</Vector>
+    <Vector name="LayerThickness" type="numeric" nEntries="9">
+      0.225*mm, 1.60*mm, 3.73*mm, 1.60*mm, 0.075*mm, 0.065*mm, 0.265*mm, 
+      [WaferThickness], 1.40*mm </Vector>
+    <Vector name="LayerTypes" type="numeric" nEntries="9"> 
+      0, 0, 0, 0, 0, 0, 0, 1, 0 </Vector>
+    <Vector name="Layers" type="numeric" nEntries="10"> 
+      8, 5, 6, 5, 7, 4, 3, 2, 1, 0 </Vector>
+    <Numeric name="NCells"           value="[NumberOfCellsCoarse]"/>
+    <Numeric name="CellType"         value="2"/>
+    <Vector name="CellNames" type="string" nEntries="25">
+      hgcalcell:HGCalEECellFull1Coarse2,   hgcalcell:HGCalEECellTrunc21Coarse2,
+      hgcalcell:HGCalEECellTrunc22Coarse2, hgcalcell:HGCalEECellTrunc23Coarse2,
+      hgcalcell:HGCalEECellExten21Coarse2, hgcalcell:HGCalEECellExten22Coarse2,
+      hgcalcell:HGCalEECellExten23Coarse2, hgcalcell:HGCalEECellCorner21Coarse2, 
+      hgcalcell:HGCalEECellCorner22Coarse2,hgcalcell:HGCalEECellCorner23Coarse2,
+      hgcalcell:HGCalEECellCorner24Coarse2,hgcalcell:HGCalEECellCorner25Coarse2,
+      hgcalcell:HGCalEECellCorner26Coarse2,hgcalcell:HGCalEECellExten24Coarse2, 
+      hgcalcell:HGCalEECellExten25Coarse2, hgcalcell:HGCalEECellExten26Coarse2,
+      hgcalcell:HGCalEECellTrunc24Coarse2, hgcalcell:HGCalEECellTrunc25Coarse2,
+      hgcalcell:HGCalEECellTrunc26Coarse2, hgcalcell:HGCalEECellCorner27Coarse2,
+      hgcalcell:HGCalEECellCorner28Coarse2,hgcalcell:HGCalEECellCorner29Coarse2,
+      hgcalcell:HGCalEECellCorner30Coarse2,hgcalcell:HGCalEECellCorner31Coarse2,
+      hgcalcell:HGCalEECellCorner32Coarse2</Vector>
+  </Algorithm>
+  <Algorithm name="hgcal:DDHGCalWaferF">
+    <rParent name="hgcalwafer:HGCalHEWafer0Fine0"/>
+    <String name="ModuleMaterial"    value="materials:Air"/>
+    <Numeric name="ModuleThickness"  value="[ModuleThicknessHE]"/>
+    <Numeric name="WaferSize"        value="[WaferSize]"/>
+    <Numeric name="SensorSeparation" value="[SensorSeparation]"/>
+    <Numeric name="WaferThickness"   value="[WaferThicknessFine]"/>
+    <Vector name="LayerNames" type="string" nEntries="8">
+      HGCalHEAirGap0Fine0, HGCalHEMotherBoard0Fine0, 
+      HGCalHEConnector0Fine0, HGCalHEPCB0Fine0, HGCalHEEpoxy0Fine0,
+      HGCalHEKapton0Fine0, HGCalHESiliconSensitive0Fine0,
+      HGCalHEBasePlate0Fine0</Vector>
+    <Vector name="LayerMaterials" type="string" nEntries="8">
+      materials:Air, hgcalMaterial:HGC_G10-FR4, hgcalMaterial:HGC_HEConnector,
+      hgcalMaterial:HGC_G10-FR4, materials:Epoxy, materials:Kapton, 
+      materials:Silicon, hgcalMaterial:HGC_G10-FR4</Vector>
+    <Vector name="LayerThickness" type="numeric" nEntries="8">
+      0.40*mm, 1.60*mm, 3.475*mm, 1.60*mm, 0.075*mm, 0.10*mm, 
+      [WaferThickness], 1.0*mm </Vector>
+    <Vector name="LayerTypes" type="numeric" nEntries="8"> 
+      0, 0, 0, 0, 0, 0, 1, 0 </Vector>
+    <Vector name="Layers" type="numeric" nEntries="10"> 
+      0, 1, 2, 3, 4, 6, 4, 5, 4, 7 </Vector>
+    <Numeric name="NCells"           value="[NumberOfCellsFine]"/>
+    <Numeric name="CellType"         value="0"/>
+    <Vector name="CellNames" type="string" nEntries="25">
+      hgcalcell:HGCalHECellFull0Fine,   hgcalcell:HGCalHECellTrunc01Fine,
+      hgcalcell:HGCalHECellTrunc02Fine, hgcalcell:HGCalHECellTrunc03Fine,
+      hgcalcell:HGCalHECellExten01Fine, hgcalcell:HGCalHECellExten02Fine,
+      hgcalcell:HGCalHECellExten03Fine, hgcalcell:HGCalHECellCorner01Fine, 
+      hgcalcell:HGCalHECellCorner02Fine,hgcalcell:HGCalHECellCorner03Fine,
+      hgcalcell:HGCalHECellCorner04Fine,hgcalcell:HGCalHECellCorner05Fine,
+      hgcalcell:HGCalHECellCorner06Fine,hgcalcell:HGCalHECellExten04Fine, 
+      hgcalcell:HGCalHECellExten05Fine, hgcalcell:HGCalHECellExten06Fine,
+      hgcalcell:HGCalHECellTrunc04Fine, hgcalcell:HGCalHECellTrunc05Fine,
+      hgcalcell:HGCalHECellTrunc06Fine, hgcalcell:HGCalHECellCorner07Fine,
+      hgcalcell:HGCalHECellCorner08Fine,hgcalcell:HGCalHECellCorner09Fine,
+      hgcalcell:HGCalHECellCorner10Fine,hgcalcell:HGCalHECellCorner11Fine,
+      hgcalcell:HGCalHECellCorner12Fine</Vector>
+  </Algorithm>
+  <Algorithm name="hgcal:DDHGCalWaferF">
+    <rParent name="hgcalwafer:HGCalHEWafer0Fine1"/>
+    <String name="ModuleMaterial"    value="materials:Air"/>
+    <Numeric name="ModuleThickness"  value="[ModuleThicknessHE]"/>
+    <Numeric name="WaferSize"        value="[WaferSize]"/>
+    <Numeric name="SensorSeparation" value="[SensorSeparation]"/>
+    <Numeric name="WaferThickness"   value="[WaferThicknessFine]"/>
+    <Vector name="LayerNames" type="string" nEntries="8">
+      HGCalHEAirGap0Fine1, HGCalHEMotherBoard0Fine1, 
+      HGCalHEConnector0Fine1, HGCalHEPCB0Fine1, HGCalHEEpoxy0Fine1,
+      HGCalHEKapton0Fine1, HGCalHESiliconSensitive0Fine1,
+      HGCalHEBasePlate0Fine1</Vector>
+    <Vector name="LayerMaterials" type="string" nEntries="8">
+      materials:Air, hgcalMaterial:HGC_G10-FR4, hgcalMaterial:HGC_HEConnector,
+      hgcalMaterial:HGC_G10-FR4, materials:Epoxy, materials:Kapton, 
+      materials:Silicon, hgcalMaterial:HGC_G10-FR4</Vector>
+    <Vector name="LayerThickness" type="numeric" nEntries="8">
+      0.40*mm, 1.60*mm, 3.475*mm, 1.60*mm, 0.075*mm, 0.10*mm, 
+      [WaferThickness], 1.0*mm </Vector>
+    <Vector name="LayerTypes" type="numeric" nEntries="8"> 
+      0, 0, 0, 0, 0, 0, 1, 0 </Vector>
+    <Vector name="Layers" type="numeric" nEntries="10"> 
+      0, 1, 2, 3, 4, 6, 4, 5, 4, 7 </Vector>
+    <Numeric name="NCells"           value="[NumberOfCellsFine]"/>
+    <Numeric name="CellType"         value="3"/>
+    <Vector name="CellNames" type="string" nEntries="25">
+      hgcalcell:HGCalHECellFull0Fine,   hgcalcell:HGCalHECellTrunc01Fine,
+      hgcalcell:HGCalHECellTrunc02Fine, hgcalcell:HGCalHECellTrunc03Fine,
+      hgcalcell:HGCalHECellExten01Fine, hgcalcell:HGCalHECellExten02Fine,
+      hgcalcell:HGCalHECellExten03Fine, hgcalcell:HGCalHECellCorner01Fine, 
+      hgcalcell:HGCalHECellCorner02Fine,hgcalcell:HGCalHECellCorner03Fine,
+      hgcalcell:HGCalHECellCorner04Fine,hgcalcell:HGCalHECellCorner05Fine,
+      hgcalcell:HGCalHECellCorner06Fine,hgcalcell:HGCalHECellExten04Fine, 
+      hgcalcell:HGCalHECellExten05Fine, hgcalcell:HGCalHECellExten06Fine,
+      hgcalcell:HGCalHECellTrunc04Fine, hgcalcell:HGCalHECellTrunc05Fine,
+      hgcalcell:HGCalHECellTrunc06Fine, hgcalcell:HGCalHECellCorner07Fine,
+      hgcalcell:HGCalHECellCorner08Fine,hgcalcell:HGCalHECellCorner09Fine,
+      hgcalcell:HGCalHECellCorner10Fine,hgcalcell:HGCalHECellCorner11Fine,
+      hgcalcell:HGCalHECellCorner12Fine</Vector>
+  </Algorithm>
+  <Algorithm name="hgcal:DDHGCalWaferF">
+    <rParent name="hgcalwafer:HGCalHEWafer0Coarse10"/>
+    <String name="ModuleMaterial"    value="materials:Air"/>
+    <Numeric name="ModuleThickness"  value="[ModuleThicknessHE]"/>
+    <Numeric name="WaferSize"        value="[WaferSize]"/>
+    <Numeric name="SensorSeparation" value="[SensorSeparation]"/>
+    <Numeric name="WaferThickness"   value="[WaferThicknessCoarse1]"/>
+    <Vector name="LayerNames" type="string" nEntries="8">
+      HGCalHEAirGap0Coarse10, HGCalHEMotherBoard0Coarse10, 
+      HGCalHEConnector0Coarse10, HGCalHEPCB0Coarse10, HGCalHEEpoxy0Coarse10, 
+      HGCalHEKapton0Coarse10, HGCalHESiliconSensitive0Coarse10, 
+      HGCalHEBasePlate0Coarse10</Vector>
+    <Vector name="LayerMaterials" type="string" nEntries="8">
+      materials:Air, hgcalMaterial:HGC_G10-FR4, hgcalMaterial:HGC_HEConnector,
+      hgcalMaterial:HGC_G10-FR4, materials:Epoxy, materials:Kapton, 
+      materials:Silicon, hgcalMaterial:HGC_G10-FR4</Vector>
+    <Vector name="LayerThickness" type="numeric" nEntries="8">
+      0.40*mm, 1.60*mm, 3.475*mm, 1.60*mm, 0.075*mm, 0.10*mm, 
+      [WaferThickness], 1.0*mm </Vector>
+    <Vector name="LayerTypes" type="numeric" nEntries="8"> 
+      0, 0, 0, 0, 0, 0, 1, 0 </Vector>
+    <Vector name="Layers" type="numeric" nEntries="10"> 
+      0, 1, 2, 3, 4, 6, 4, 5, 4, 7 </Vector>
+    <Numeric name="NCells"           value="[NumberOfCellsCoarse]"/>
+    <Numeric name="CellType"         value="1"/>
+    <Vector name="CellNames" type="string" nEntries="25">
+      hgcalcell:HGCalHECellFull0Coarse1,   hgcalcell:HGCalHECellTrunc01Coarse1,
+      hgcalcell:HGCalHECellTrunc02Coarse1, hgcalcell:HGCalHECellTrunc03Coarse1,
+      hgcalcell:HGCalHECellExten01Coarse1, hgcalcell:HGCalHECellExten02Coarse1,
+      hgcalcell:HGCalHECellExten03Coarse1, hgcalcell:HGCalHECellCorner01Coarse1, 
+      hgcalcell:HGCalHECellCorner02Coarse1,hgcalcell:HGCalHECellCorner03Coarse1,
+      hgcalcell:HGCalHECellCorner04Coarse1,hgcalcell:HGCalHECellCorner05Coarse1,
+      hgcalcell:HGCalHECellCorner06Coarse1,hgcalcell:HGCalHECellExten04Coarse1, 
+      hgcalcell:HGCalHECellExten05Coarse1, hgcalcell:HGCalHECellExten06Coarse1,
+      hgcalcell:HGCalHECellTrunc04Coarse1, hgcalcell:HGCalHECellTrunc05Coarse1,
+      hgcalcell:HGCalHECellTrunc06Coarse1, hgcalcell:HGCalHECellCorner07Coarse1,
+      hgcalcell:HGCalHECellCorner08Coarse1,hgcalcell:HGCalHECellCorner09Coarse1,
+      hgcalcell:HGCalHECellCorner10Coarse1,hgcalcell:HGCalHECellCorner11Coarse1,
+      hgcalcell:HGCalHECellCorner12Coarse1</Vector>
+  </Algorithm>
+  <Algorithm name="hgcal:DDHGCalWaferF">
+    <rParent name="hgcalwafer:HGCalHEWafer0Coarse11"/>
+    <String name="ModuleMaterial"    value="materials:Air"/>
+    <Numeric name="ModuleThickness"  value="[ModuleThicknessHE]"/>
+    <Numeric name="WaferSize"        value="[WaferSize]"/>
+    <Numeric name="SensorSeparation" value="[SensorSeparation]"/>
+    <Numeric name="WaferThickness"   value="[WaferThicknessCoarse1]"/>
+    <Vector name="LayerNames" type="string" nEntries="8">
+      HGCalHEAirGap0Coarse11, HGCalHEMotherBoard0Coarse11, 
+      HGCalHEConnector0Coarse11, HGCalHEPCB0Coarse11, HGCalHEEpoxy0Coarse11, 
+      HGCalHEKapton0Coarse11, HGCalHESiliconSensitive0Coarse11, 
+      HGCalHEBasePlate0Coarse11</Vector>
+    <Vector name="LayerMaterials" type="string" nEntries="8">
+      materials:Air, hgcalMaterial:HGC_G10-FR4, hgcalMaterial:HGC_HEConnector,
+      hgcalMaterial:HGC_G10-FR4, materials:Epoxy, materials:Kapton, 
+      materials:Silicon, hgcalMaterial:HGC_G10-FR4</Vector>
+    <Vector name="LayerThickness" type="numeric" nEntries="8">
+      0.40*mm, 1.60*mm, 3.475*mm, 1.60*mm, 0.075*mm, 0.10*mm, 
+      [WaferThickness], 1.0*mm </Vector>
+    <Vector name="LayerTypes" type="numeric" nEntries="8"> 
+      0, 0, 0, 0, 0, 0, 1, 0 </Vector>
+    <Vector name="Layers" type="numeric" nEntries="10"> 
+      0, 1, 2, 3, 4, 6, 4, 5, 4, 7 </Vector>
+    <Numeric name="NCells"           value="[NumberOfCellsCoarse]"/>
+    <Numeric name="CellType"         value="4"/>
+    <Vector name="CellNames" type="string" nEntries="25">
+      hgcalcell:HGCalHECellFull0Coarse1,   hgcalcell:HGCalHECellTrunc01Coarse1,
+      hgcalcell:HGCalHECellTrunc02Coarse1, hgcalcell:HGCalHECellTrunc03Coarse1,
+      hgcalcell:HGCalHECellExten01Coarse1, hgcalcell:HGCalHECellExten02Coarse1,
+      hgcalcell:HGCalHECellExten03Coarse1, hgcalcell:HGCalHECellCorner01Coarse1, 
+      hgcalcell:HGCalHECellCorner02Coarse1,hgcalcell:HGCalHECellCorner03Coarse1,
+      hgcalcell:HGCalHECellCorner04Coarse1,hgcalcell:HGCalHECellCorner05Coarse1,
+      hgcalcell:HGCalHECellCorner06Coarse1,hgcalcell:HGCalHECellExten04Coarse1, 
+      hgcalcell:HGCalHECellExten05Coarse1, hgcalcell:HGCalHECellExten06Coarse1,
+      hgcalcell:HGCalHECellTrunc04Coarse1, hgcalcell:HGCalHECellTrunc05Coarse1,
+      hgcalcell:HGCalHECellTrunc06Coarse1, hgcalcell:HGCalHECellCorner07Coarse1,
+      hgcalcell:HGCalHECellCorner08Coarse1,hgcalcell:HGCalHECellCorner09Coarse1,
+      hgcalcell:HGCalHECellCorner10Coarse1,hgcalcell:HGCalHECellCorner11Coarse1,
+      hgcalcell:HGCalHECellCorner12Coarse1</Vector>
+  </Algorithm>
+  <Algorithm name="hgcal:DDHGCalWaferF">
+    <rParent name="hgcalwafer:HGCalHEWafer0Coarse20"/>
+    <String name="ModuleMaterial"    value="materials:Air"/>
+    <Numeric name="ModuleThickness"  value="[ModuleThicknessHE]"/>
+    <Numeric name="WaferSize"        value="[WaferSize]"/>
+    <Numeric name="SensorSeparation" value="[SensorSeparation]"/>
+    <Numeric name="WaferThickness"   value="[WaferThicknessCoarse2]"/>
+    <Vector name="LayerNames" type="string" nEntries="8">
+      HGCalHEAirGap0Coarse20, HGCalHEMotherBoard0Coarse20, 
+      HGCalHEConnector0Coarse20, HGCalHEPCB0Coarse20, HGCalHEEpoxy0Coarse20,
+      HGCalHEKapton0Coarse20, HGCalHESiliconSensitive0Coarse20,
+      HGCalHEBasePlate0Coarse20</Vector>
+    <Vector name="LayerMaterials" type="string" nEntries="8">
+      materials:Air, hgcalMaterial:HGC_G10-FR4, hgcalMaterial:HGC_HEConnector,
+      hgcalMaterial:HGC_G10-FR4, materials:Epoxy, materials:Kapton, 
+      materials:Silicon, hgcalMaterial:HGC_G10-FR4</Vector>
+    <Vector name="LayerThickness" type="numeric" nEntries="8">
+      0.40*mm, 1.60*mm, 3.475*mm, 1.60*mm, 0.075*mm, 0.10*mm, 
+      [WaferThickness], 1.0*mm </Vector>
+    <Vector name="LayerTypes" type="numeric" nEntries="8"> 
+      0, 0, 0, 0, 0, 0, 1, 0 </Vector>
+    <Vector name="Layers" type="numeric" nEntries="10"> 
+      0, 1, 2, 3, 4, 6, 4, 5, 4, 7 </Vector>
+    <Numeric name="NCells"           value="[NumberOfCellsCoarse]"/>
+    <Numeric name="CellType"         value="2"/>
+    <Vector name="CellNames" type="string" nEntries="25">
+      hgcalcell:HGCalHECellFull0Coarse2,   hgcalcell:HGCalHECellTrunc01Coarse2,
+      hgcalcell:HGCalHECellTrunc02Coarse2, hgcalcell:HGCalHECellTrunc03Coarse2,
+      hgcalcell:HGCalHECellExten01Coarse2, hgcalcell:HGCalHECellExten02Coarse2,
+      hgcalcell:HGCalHECellExten03Coarse2, hgcalcell:HGCalHECellCorner01Coarse2, 
+      hgcalcell:HGCalHECellCorner02Coarse2,hgcalcell:HGCalHECellCorner03Coarse2,
+      hgcalcell:HGCalHECellCorner04Coarse2,hgcalcell:HGCalHECellCorner05Coarse2,
+      hgcalcell:HGCalHECellCorner06Coarse2,hgcalcell:HGCalHECellExten04Coarse2, 
+      hgcalcell:HGCalHECellExten05Coarse2, hgcalcell:HGCalHECellExten06Coarse2,
+      hgcalcell:HGCalHECellTrunc04Coarse2, hgcalcell:HGCalHECellTrunc05Coarse2,
+      hgcalcell:HGCalHECellTrunc06Coarse2, hgcalcell:HGCalHECellCorner07Coarse2,
+      hgcalcell:HGCalHECellCorner08Coarse2,hgcalcell:HGCalHECellCorner09Coarse2,
+      hgcalcell:HGCalHECellCorner10Coarse2,hgcalcell:HGCalHECellCorner11Coarse2,
+      hgcalcell:HGCalHECellCorner12Coarse2</Vector>
+  </Algorithm>
+  <Algorithm name="hgcal:DDHGCalWaferF">
+    <rParent name="hgcalwafer:HGCalHEWafer0Coarse21"/>
+    <String name="ModuleMaterial"    value="materials:Air"/>
+    <Numeric name="ModuleThickness"  value="[ModuleThicknessHE]"/>
+    <Numeric name="WaferSize"        value="[WaferSize]"/>
+    <Numeric name="SensorSeparation" value="[SensorSeparation]"/>
+    <Numeric name="WaferThickness"   value="[WaferThicknessCoarse2]"/>
+    <Vector name="LayerNames" type="string" nEntries="8">
+      HGCalHEAirGap0Coarse21, HGCalHEMotherBoard0Coarse21, 
+      HGCalHEConnector0Coarse21, HGCalHEPCB0Coarse21, HGCalHEEpoxy0Coarse21,
+      HGCalHEKapton0Coarse21, HGCalHESiliconSensitive0Coarse21,
+      HGCalHEBasePlate0Coarse21</Vector>
+    <Vector name="LayerMaterials" type="string" nEntries="8">
+      materials:Air, hgcalMaterial:HGC_G10-FR4, hgcalMaterial:HGC_HEConnector,
+      hgcalMaterial:HGC_G10-FR4, materials:Epoxy, materials:Kapton, 
+      materials:Silicon, hgcalMaterial:HGC_G10-FR4</Vector>
+    <Vector name="LayerThickness" type="numeric" nEntries="8">
+      0.40*mm, 1.60*mm, 3.475*mm, 1.60*mm, 0.075*mm, 0.10*mm, 
+      [WaferThickness], 1.0*mm </Vector>
+    <Vector name="LayerTypes" type="numeric" nEntries="8"> 
+      0, 0, 0, 0, 0, 0, 1, 0 </Vector>
+    <Vector name="Layers" type="numeric" nEntries="10"> 
+      0, 1, 2, 3, 4, 6, 4, 5, 4, 7 </Vector>
+    <Numeric name="NCells"           value="[NumberOfCellsCoarse]"/>
+    <Numeric name="CellType"         value="5"/>
+    <Vector name="CellNames" type="string" nEntries="25">
+      hgcalcell:HGCalHECellFull0Coarse2,   hgcalcell:HGCalHECellTrunc01Coarse2,
+      hgcalcell:HGCalHECellTrunc02Coarse2, hgcalcell:HGCalHECellTrunc03Coarse2,
+      hgcalcell:HGCalHECellExten01Coarse2, hgcalcell:HGCalHECellExten02Coarse2,
+      hgcalcell:HGCalHECellExten03Coarse2, hgcalcell:HGCalHECellCorner01Coarse2, 
+      hgcalcell:HGCalHECellCorner02Coarse2,hgcalcell:HGCalHECellCorner03Coarse2,
+      hgcalcell:HGCalHECellCorner04Coarse2,hgcalcell:HGCalHECellCorner05Coarse2,
+      hgcalcell:HGCalHECellCorner06Coarse2,hgcalcell:HGCalHECellExten04Coarse2, 
+      hgcalcell:HGCalHECellExten05Coarse2, hgcalcell:HGCalHECellExten06Coarse2,
+      hgcalcell:HGCalHECellTrunc04Coarse2, hgcalcell:HGCalHECellTrunc05Coarse2,
+      hgcalcell:HGCalHECellTrunc06Coarse2, hgcalcell:HGCalHECellCorner07Coarse2,
+      hgcalcell:HGCalHECellCorner08Coarse2,hgcalcell:HGCalHECellCorner09Coarse2,
+      hgcalcell:HGCalHECellCorner10Coarse2,hgcalcell:HGCalHECellCorner11Coarse2,
+      hgcalcell:HGCalHECellCorner12Coarse2</Vector>
+  </Algorithm>
+  <Algorithm name="hgcal:DDHGCalWaferP">
+    <rParent name="hgcalwafer:HGCalEEWafer0Fine"/>
+    <String name="ModuleMaterial"    value="materials:Air"/>
+    <Numeric name="ModuleThickness"  value="[ModuleThicknessEE]"/>
+    <Numeric name="WaferSize"        value="[WaferSize]"/>
+    <Numeric name="SensorSeparation" value="[SensorSeparation]"/>
+    <Numeric name="WaferThickness"   value="[WaferThicknessFine]"/>
+    <Vector name="Tags" type="string" nEntries="24">
+      gm0, gm1, gm2, gm3, gm4, gm5, dm0, dm1, dm2, dm3, dm4, dm5,
+      am0, am1, am2, am3, am4, am5, bm0, bm1, bm2, bm3, bm4, bm5</Vector>
+    <Vector name="PartialTypes" type="numeric" nEntries="24">
+      3, 3, 3, 3, 3, 3, 6, 6, 6, 6, 6, 6, 8, 8, 8, 8, 8, 8, 9, 9, 9,
+      9, 9, 9</Vector>
+    <Vector name="Orientations" type="numeric" nEntries="24">
+      0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2,
+      3, 4, 5</Vector>
+    <Vector name="LayerNames" type="string" nEntries="9">
+      HGCalEEAirGap0Fine, HGCalEEMotherBoard0Fine, 
+      HGCalEEConnector0Fine, HGCalEEPCB0Fine, HGCalEEEpoxy0Fine,
+      HGCalEEEpoxyT0Fine, HGCalEEKapton0Fine, HGCalEESensitive0Fine,
+      HGCalEEBasePlate0Fine</Vector>
+    <Vector name="LayerMaterials" type="string" nEntries="9">
+      materials:Air, hgcalMaterial:HGC_G10-FR4, hgcalMaterial:HGC_EEConnector,
+      hgcalMaterial:HGC_G10-FR4, materials:Epoxy, materials:Epoxy, 
+      materials:Kapton, materials:Silicon, hgcalMaterial:WCu</Vector>
+    <Vector name="LayerThickness" type="numeric" nEntries="9">
+      0.225*mm, 1.60*mm, 3.73*mm, 1.60*mm, 0.075*mm, 0.065*mm, 0.265*mm, 
+      [WaferThickness], 1.40*mm </Vector>
+    <Vector name="LayerTypes" type="numeric" nEntries="9"> 
+      0, 0, 0, 0, 0, 0, 0, 1, 0 </Vector>
+    <Vector name="Layers" type="numeric" nEntries="10"> 
+      0, 1, 2, 3, 4, 7, 5, 6, 5, 8 </Vector>
+    <String name="SenseName"    value="HGCalEECellSensitive0Fine"/>
+    <Numeric name="SenseType"    value="0"/>
+    <Numeric name="SenseThick"   value="[CellThicknessFine]"/>
+    <Numeric name="PosSensitive" value="0"/>
+  </Algorithm>
+  <Algorithm name="hgcal:DDHGCalWaferP">
+    <rParent name="hgcalwafer:HGCalEEWafer1Fine"/>
+    <String name="ModuleMaterial"    value="materials:Air"/>
+    <Numeric name="ModuleThickness"  value="[ModuleThicknessEE]"/>
+    <Numeric name="WaferSize"        value="[WaferSize]"/>
+    <Numeric name="SensorSeparation" value="[SensorSeparation]"/>
+    <Numeric name="WaferThickness"   value="[WaferThicknessFine]"/>
+    <Vector name="Tags" type="string" nEntries="24">
+      gm0, gm1, gm2, gm3, gm4, gm5, dm0, dm1, dm2, dm3, dm4, dm5,
+      am0, am1, am2, am3, am4, am5, bm0, bm1, bm2, bm3, bm4, bm5</Vector>
+    <Vector name="PartialTypes" type="numeric" nEntries="24">
+      3, 3, 3, 3, 3, 3, 6, 6, 6, 6, 6, 6, 8, 8, 8, 8, 8, 8, 9, 9, 9,
+      9, 9, 9</Vector>
+    <Vector name="Orientations" type="numeric" nEntries="24">
+      0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2,
+      3, 4, 5</Vector>
+    <Vector name="LayerNames" type="string" nEntries="9">
+      HGCalEEAirGap1Fine, HGCalEEMotherBoard1Fine, 
+      HGCalEEConnector1Fine, HGCalEEPCB1Fine, HGCalEEEpoxy1Fine, 
+      HGCalEEEpoxyT1Fine, HGCalEEKapton1Fine, HGCalEESensitive1Fine,
+      HGCalEEBasePlate1Fine</Vector>
+    <Vector name="LayerMaterials" type="string" nEntries="9">
+      materials:Air, hgcalMaterial:HGC_G10-FR4, hgcalMaterial:HGC_EEConnector,
+      hgcalMaterial:HGC_G10-FR4, materials:Epoxy, materials:Epoxy, 
+      materials:Kapton, materials:Silicon, hgcalMaterial:WCu</Vector>
+    <Vector name="LayerThickness" type="numeric" nEntries="9">
+      0.225*mm, 1.60*mm, 3.73*mm, 1.60*mm, 0.075*mm, 0.065*mm, 0.265*mm, 
+      [WaferThickness], 1.40*mm </Vector>
+    <Vector name="LayerTypes" type="numeric" nEntries="9"> 
+      0, 0, 0, 0, 0, 0, 0, 1, 0 </Vector>
+    <Vector name="Layers" type="numeric" nEntries="10"> 
+      8, 5, 6, 5, 7, 4, 3, 2, 1, 0 </Vector>
+    <String name="SenseName"    value="HGCalEECellSensitive1Fine"/>
+    <Numeric name="SenseType"    value="0"/>
+    <Numeric name="SenseThick"   value="[CellThicknessFine]"/>
+    <Numeric name="PosSensitive" value="1"/>
+  </Algorithm>
+  <Algorithm name="hgcal:DDHGCalWaferP">
+    <rParent name="hgcalwafer:HGCalEEWafer0Coarse1"/>
+    <String name="ModuleMaterial"    value="materials:Air"/>
+    <Numeric name="ModuleThickness"  value="[ModuleThicknessEE]"/>
+    <Numeric name="WaferSize"        value="[WaferSize]"/>
+    <Numeric name="SensorSeparation" value="[SensorSeparation]"/>
+    <Numeric name="WaferThickness"   value="[WaferThicknessCoarse1]"/>
+    <Vector name="Tags" type="string" nEntries="24">
+      b0, b1, b2, b3, b4, b5, a0, a1, a2, a3, a4, a5, d0, d1, d2,
+      d3, d4, d5, c0, c1, c2, c3, c4, c5</Vector>
+    <Vector name="PartialTypes" type="numeric" nEntries="24">
+      1, 1, 1, 1, 1, 1, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 7, 7, 7,
+      7, 7, 7</Vector>
+    <Vector name="Orientations" type="numeric" nEntries="24">
+      0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2,
+      3, 4, 5</Vector>
+    <Vector name="LayerNames" type="string" nEntries="9">
+      HGCalEEAirGap0Coarse1, HGCalEEMotherBoard0Coarse1, 
+      HGCalEEConnector0Coarse1, HGCalEEPCB0Coarse1, HGCalEEEpoxy0Coarse1, 
+      HGCalEEEpoxyT0Coarse1, HGCalEEKapton0Coarse1, HGCalEESensitive0Coarse1,
+      HGCalEEBasePlate0Coarse1</Vector>
+    <Vector name="LayerMaterials" type="string" nEntries="9">
+      materials:Air, hgcalMaterial:HGC_G10-FR4, hgcalMaterial:HGC_EEConnector,
+      hgcalMaterial:HGC_G10-FR4, materials:Epoxy, materials:Epoxy, 
+      materials:Kapton, materials:Silicon, hgcalMaterial:WCu</Vector>
+    <Vector name="LayerThickness" type="numeric" nEntries="9">
+      0.225*mm, 1.60*mm, 3.73*mm, 1.60*mm, 0.075*mm, 0.065*mm, 0.265*mm, 
+      [WaferThickness], 1.40*mm </Vector>
+    <Vector name="LayerTypes" type="numeric" nEntries="9"> 
+      0, 0, 0, 0, 0, 0, 0, 1, 0 </Vector>
+    <Vector name="Layers" type="numeric" nEntries="10"> 
+      0, 1, 2, 3, 4, 7, 5, 6, 5, 8 </Vector>
+    <String name="SenseName"    value="HGCalEECellSensitive0Coares1"/>
+    <Numeric name="SenseType"    value="1"/>
+    <Numeric name="SenseThick"   value="[CellThicknessCoarse1]"/>
+    <Numeric name="PosSensitive" value="0"/>
+  </Algorithm>
+  <Algorithm name="hgcal:DDHGCalWaferP">
+    <rParent name="hgcalwafer:HGCalEEWafer1Coarse1"/>
+    <String name="ModuleMaterial"    value="materials:Air"/>
+    <Numeric name="ModuleThickness"  value="[ModuleThicknessEE]"/>
+    <Numeric name="WaferSize"        value="[WaferSize]"/>
+    <Numeric name="SensorSeparation" value="[SensorSeparation]"/>
+    <Numeric name="WaferThickness"   value="[WaferThicknessCoarse1]"/>
+    <Vector name="Tags" type="string" nEntries="24">
+      b0, b1, b2, b3, b4, b5, a0, a1, a2, a3, a4, a5, d0, d1, d2,
+      d3, d4, d5, c0, c1, c2, c3, c4, c5</Vector>
+    <Vector name="PartialTypes" type="numeric" nEntries="24">
+      1, 1, 1, 1, 1, 1, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 7, 7, 7,
+      7, 7, 7</Vector>
+    <Vector name="Orientations" type="numeric" nEntries="24">
+      0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2,
+      3, 4, 5</Vector>
+    <Vector name="LayerNames" type="string" nEntries="9">
+      HGCalEEAirGap1Coarse1, HGCalEEMotherBoard1Coarse1, 
+      HGCalEEConnector1Coarse1, HGCalEEPCB1Coarse1, HGCalEEEpoxy1Coarse1, 
+      HGCalEEEpoxyT1Coarse1, HGCalEEKapton1Coarse1, HGCalEESensitive1Coarse1,
+      HGCalEEBasePlate1Coarse1</Vector>
+    <Vector name="LayerMaterials" type="string" nEntries="9">
+      materials:Air, hgcalMaterial:HGC_G10-FR4, hgcalMaterial:HGC_EEConnector,
+      hgcalMaterial:HGC_G10-FR4, materials:Epoxy, materials:Epoxy, 
+      materials:Kapton, materials:Silicon, hgcalMaterial:WCu</Vector>
+    <Vector name="LayerThickness" type="numeric" nEntries="9">
+      0.225*mm, 1.60*mm, 3.73*mm, 1.60*mm, 0.075*mm, 0.065*mm, 0.265*mm, 
+      [WaferThickness], 1.40*mm </Vector>
+    <Vector name="LayerTypes" type="numeric" nEntries="9"> 
+      0, 0, 0, 0, 0, 0, 0, 1, 0 </Vector>
+    <Vector name="Layers" type="numeric" nEntries="10"> 
+      8, 5, 6, 5, 7, 4, 3, 2, 1, 0 </Vector>
+    <String name="SenseName"    value="HGCalEECellSensitive1Coares1"/>
+    <Numeric name="SenseType"    value="1"/>
+    <Numeric name="SenseThick"   value="[CellThicknessCoarse1]"/>
+    <Numeric name="PosSensitive" value="1"/>
+  </Algorithm>
+  <Algorithm name="hgcal:DDHGCalWaferP">
+    <rParent name="hgcalwafer:HGCalEEWafer0Coarse2"/>
+    <String name="ModuleMaterial"    value="materials:Air"/>
+    <Numeric name="ModuleThickness"  value="[ModuleThicknessEE]"/>
+    <Numeric name="WaferSize"        value="[WaferSize]"/>
+    <Numeric name="SensorSeparation" value="[SensorSeparation]"/>
+    <Numeric name="WaferThickness"   value="[WaferThicknessCoarse2]"/>
+    <Vector name="Tags" type="string" nEntries="24">
+      b0, b1, b2, b3, b4, b5, a0, a1, a2, a3, a4, a5, d0, d1, d2,
+      d3, d4, d5, c0, c1, c2, c3, c4, c5</Vector>
+    <Vector name="PartialTypes" type="numeric" nEntries="24">
+      1, 1, 1, 1, 1, 1, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 7, 7, 7,
+      7, 7, 7</Vector>
+    <Vector name="Orientations" type="numeric" nEntries="24">
+      0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2,
+      3, 4, 5</Vector>
+    <Vector name="LayerNames" type="string" nEntries="9">
+      HGCalEEAirGap0Coarse2, HGCalEEMotherBoard0Coarse2, 
+      HGCalEEConnector0Coarse2, HGCalEEPCB0Coarse2, HGCalEEEpoxy0Coarse2, 
+      HGCalEEEpoxyT0Coarse2, HGCalEEKapton0Coarse2, HGCalEESensitive0Coarse2,
+      HGCalEEBasePlate0Coarse2</Vector>
+    <Vector name="LayerMaterials" type="string" nEntries="9">
+      materials:Air, hgcalMaterial:HGC_G10-FR4, hgcalMaterial:HGC_EEConnector,
+      hgcalMaterial:HGC_G10-FR4, materials:Epoxy, materials:Epoxy, 
+      materials:Kapton, materials:Silicon, hgcalMaterial:WCu</Vector>
+    <Vector name="LayerThickness" type="numeric" nEntries="9">
+      0.225*mm, 1.60*mm, 3.73*mm, 1.60*mm, 0.075*mm, 0.065*mm, 0.265*mm, 
+      [WaferThickness], 1.40*mm </Vector>
+    <Vector name="LayerTypes" type="numeric" nEntries="9"> 
+      0, 0, 0, 0, 0, 0, 0, 1, 0 </Vector>
+    <Vector name="Layers" type="numeric" nEntries="10"> 
+      0, 1, 2, 3, 4, 7, 5, 6, 5, 8 </Vector>
+    <String name="SenseName"    value="HGCalEECellSensitive0Coares2"/>
+    <Numeric name="SenseType"    value="2"/>
+    <Numeric name="SenseThick"   value="[CellThicknessCoarse2]"/>
+    <Numeric name="PosSensitive" value="0"/>
+  </Algorithm>
+  <Algorithm name="hgcal:DDHGCalWaferP">
+    <rParent name="hgcalwafer:HGCalEEWafer1Coarse2"/>
+    <String name="ModuleMaterial"    value="materials:Air"/>
+    <Numeric name="ModuleThickness"  value="[ModuleThicknessEE]"/>
+    <Numeric name="WaferSize"        value="[WaferSize]"/>
+    <Numeric name="SensorSeparation" value="[SensorSeparation]"/>
+    <Numeric name="WaferThickness"   value="[WaferThicknessCoarse2]"/>
+    <Vector name="Tags" type="string" nEntries="24">
+      b0, b1, b2, b3, b4, b5, a0, a1, a2, a3, a4, a5, d0, d1, d2,
+      d3, d4, d5, c0, c1, c2, c3, c4, c5</Vector>
+    <Vector name="PartialTypes" type="numeric" nEntries="24">
+      1, 1, 1, 1, 1, 1, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 7, 7, 7,
+      7, 7, 7</Vector>
+    <Vector name="Orientations" type="numeric" nEntries="24">
+      0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2,
+      3, 4, 5</Vector>
+    <Vector name="LayerNames" type="string" nEntries="9">
+      HGCalEEAirGap1Coarse2, HGCalEEMotherBoard1Coarse2, 
+      HGCalEEConnector1Coarse2, HGCalEEPCB1Coarse2, HGCalEEEpoxy1Coarse2, 
+      HGCalEEEpoxyT1Coarse2, HGCalEEKapton1Coarse2, HGCalEESensitive1Coarse2,
+      HGCalEEBasePlate1Coarse2</Vector>
+    <Vector name="LayerMaterials" type="string" nEntries="9">
+      materials:Air, hgcalMaterial:HGC_G10-FR4, hgcalMaterial:HGC_EEConnector,
+      hgcalMaterial:HGC_G10-FR4, materials:Epoxy, materials:Epoxy, 
+      materials:Kapton, materials:Silicon, hgcalMaterial:WCu</Vector>
+    <Vector name="LayerThickness" type="numeric" nEntries="9">
+      0.225*mm, 1.60*mm, 3.73*mm, 1.60*mm, 0.075*mm, 0.065*mm, 0.265*mm, 
+      [WaferThickness], 1.40*mm </Vector>
+    <Vector name="LayerTypes" type="numeric" nEntries="9"> 
+      0, 0, 0, 0, 0, 0, 0, 1, 0 </Vector>
+    <Vector name="Layers" type="numeric" nEntries="10"> 
+      8, 5, 6, 5, 7, 4, 3, 2, 1, 0 </Vector>
+    <String name="SenseName"    value="HGCalEECellSensitive1Coares2"/>
+    <Numeric name="SenseType"    value="2"/>
+    <Numeric name="SenseThick"   value="[CellThicknessCoarse2]"/>
+    <Numeric name="PosSensitive" value="1"/>
+  </Algorithm>
+  <Algorithm name="hgcal:DDHGCalWaferP">
+    <rParent name="hgcalwafer:HGCalHEWafer0Fine"/>
+    <String name="ModuleMaterial"    value="materials:Air"/>
+    <Numeric name="ModuleThickness"  value="[ModuleThicknessHE]"/>
+    <Numeric name="WaferSize"        value="[WaferSize]"/>
+    <Numeric name="SensorSeparation" value="[SensorSeparation]"/>
+    <Numeric name="WaferThickness"   value="[WaferThicknessFine]"/>
+    <Vector name="Tags" type="string" nEntries="24">
+      gm0, gm1, gm2, gm3, gm4, gm5, dm0, dm1, dm2, dm3, dm4, dm5,
+      am0, am1, am2, am3, am4, am5, bm0, bm1, bm2, bm3, bm4, bm5</Vector>
+    <Vector name="PartialTypes" type="numeric" nEntries="24">
+      3, 3, 3, 3, 3, 3, 6, 6, 6, 6, 6, 6, 8, 8, 8, 8, 8, 8, 9, 9, 9,
+      9, 9, 9</Vector>
+    <Vector name="Orientations" type="numeric" nEntries="24">
+      0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2,
+      3, 4, 5</Vector>
+    <Vector name="LayerNames" type="string" nEntries="8">
+      HGCalHEAirGap0Fine, HGCalHEMotherBoard0Fine, 
+      HGCalHEConnector0Fine, HGCalHEPCB0Fine, HGCalHEEpoxy0Fine,
+      HGCalHEKapton0Fine, HGCalHESiliconSensitive0Fine,
+      HGCalHEBasePlate0Fine</Vector>
+    <Vector name="LayerMaterials" type="string" nEntries="8">
+      materials:Air, hgcalMaterial:HGC_G10-FR4, hgcalMaterial:HGC_HEConnector,
+      hgcalMaterial:HGC_G10-FR4, materials:Epoxy, materials:Kapton, 
+      materials:Silicon, hgcalMaterial:HGC_G10-FR4</Vector>
+    <Vector name="LayerThickness" type="numeric" nEntries="8">
+      0.40*mm, 1.60*mm, 3.475*mm, 1.60*mm, 0.075*mm, 0.10*mm, 
+      [WaferThickness], 1.0*mm </Vector>
+    <Vector name="LayerTypes" type="numeric" nEntries="8"> 
+      0, 0, 0, 0, 0, 0, 1, 0 </Vector>
+    <Vector name="Layers" type="numeric" nEntries="10"> 
+      0, 1, 2, 3, 4, 6, 4, 5, 4, 7 </Vector>
+    <String name="SenseName"    value="HGCalHESiliconCellSensitive0Fine"/>
+    <Numeric name="SenseType"    value="0"/>
+    <Numeric name="SenseThick"   value="[CellThicknessFine]"/>
+    <Numeric name="PosSensitive" value="0"/>
+  </Algorithm>
+  <Algorithm name="hgcal:DDHGCalWaferP">
+    <rParent name="hgcalwafer:HGCalHEWafer0Coarse1"/>
+    <String name="ModuleMaterial"    value="materials:Air"/>
+    <Numeric name="ModuleThickness"  value="[ModuleThicknessHE]"/>
+    <Numeric name="WaferSize"        value="[WaferSize]"/>
+    <Numeric name="SensorSeparation" value="[SensorSeparation]"/>
+    <Numeric name="WaferThickness"   value="[WaferThicknessCoarse1]"/>
+    <Vector name="Tags" type="string" nEntries="24">
+      b0, b1, b2, b3, b4, b5, a0, a1, a2, a3, a4, a5, d0, d1, d2,
+      d3, d4, d5, c0, c1, c2, c3, c4, c5</Vector>
+    <Vector name="PartialTypes" type="numeric" nEntries="24">
+      1, 1, 1, 1, 1, 1, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 7, 7, 7,
+      7, 7, 7</Vector>
+    <Vector name="Orientations" type="numeric" nEntries="24">
+      0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2,
+      3, 4, 5</Vector>
+    <Vector name="LayerNames" type="string" nEntries="8">
+      HGCalHEAirGap0Coarse1, HGCalHEMotherBoard0Coarse1, 
+      HGCalHEConnector0Coarse1, HGCalHEPCB0Coarse1, HGCalHEEpoxy0Coarse1, 
+      HGCalHEKapton0Coarse1, HGCalHESiliconSensitive0Coarse1, 
+      HGCalHEBasePlate0Coarse1</Vector>
+    <Vector name="LayerMaterials" type="string" nEntries="8">
+      materials:Air, hgcalMaterial:HGC_G10-FR4, hgcalMaterial:HGC_HEConnector,
+      hgcalMaterial:HGC_G10-FR4, materials:Epoxy, materials:Kapton, 
+      materials:Silicon, hgcalMaterial:HGC_G10-FR4</Vector>
+    <Vector name="LayerThickness" type="numeric" nEntries="8">
+      0.40*mm, 1.60*mm, 3.475*mm, 1.60*mm, 0.075*mm, 0.10*mm, 
+      [WaferThickness], 1.0*mm </Vector>
+    <Vector name="LayerTypes" type="numeric" nEntries="8"> 
+      0, 0, 0, 0, 0, 0, 1, 0 </Vector>
+    <Vector name="Layers" type="numeric" nEntries="10"> 
+      0, 1, 2, 3, 4, 6, 4, 5, 4, 7 </Vector>
+    <String name="SenseName"    value="HGCalHESiliconCellSensitive0Coarse1"/>
+    <Numeric name="SenseType"    value="1"/>
+    <Numeric name="SenseThick"   value="[CellThicknessCoarse1]"/>
+    <Numeric name="PosSensitive" value="0"/>
+  </Algorithm>
+  <Algorithm name="hgcal:DDHGCalWaferP">
+    <rParent name="hgcalwafer:HGCalHEWafer0Coarse2"/>
+    <String name="ModuleMaterial"    value="materials:Air"/>
+    <Numeric name="ModuleThickness"  value="[ModuleThicknessHE]"/>
+    <Numeric name="WaferSize"        value="[WaferSize]"/>
+    <Numeric name="SensorSeparation" value="[SensorSeparation]"/>
+    <Numeric name="WaferThickness"   value="[WaferThicknessCoarse2]"/>
+    <Vector name="Tags" type="string" nEntries="24">
+      b0, b1, b2, b3, b4, b5, a0, a1, a2, a3, a4, a5, d0, d1, d2,
+      d3, d4, d5, c0, c1, c2, c3, c4, c5</Vector>
+    <Vector name="PartialTypes" type="numeric" nEntries="24">
+      1, 1, 1, 1, 1, 1, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 7, 7, 7,
+      7, 7, 7</Vector>
+    <Vector name="Orientations" type="numeric" nEntries="24">
+      0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2,
+      3, 4, 5</Vector>
+    <Vector name="LayerNames" type="string" nEntries="8">
+      HGCalHEAirGap0Coarse2, HGCalHEMotherBoard0Coarse2, 
+      HGCalHEConnector0Coarse2, HGCalHEPCB0Coarse2, HGCalHEEpoxy0Coarse2,
+      HGCalHEKapton0Coarse2, HGCalHESiliconSensitive0Coarse2,
+      HGCalHEBasePlate0Coarse2</Vector>
+    <Vector name="LayerMaterials" type="string" nEntries="8">
+      materials:Air, hgcalMaterial:HGC_G10-FR4, hgcalMaterial:HGC_HEConnector,
+      hgcalMaterial:HGC_G10-FR4, materials:Epoxy, materials:Kapton, 
+      materials:Silicon, hgcalMaterial:HGC_G10-FR4</Vector>
+    <Vector name="LayerThickness" type="numeric" nEntries="8">
+      0.40*mm, 1.60*mm, 3.475*mm, 1.60*mm, 0.075*mm, 0.10*mm, 
+      [WaferThickness], 1.0*mm </Vector>
+    <Vector name="LayerTypes" type="numeric" nEntries="8"> 
+      0, 0, 0, 0, 0, 0, 1, 0 </Vector>
+    <Vector name="Layers" type="numeric" nEntries="10"> 
+      0, 1, 2, 3, 4, 6, 4, 5, 4, 7 </Vector>
+    <String name="SenseName"    value="HGCalHESiliconCellSensitive0Coarse2"/>
+    <Numeric name="SenseType"    value="2"/>
+    <Numeric name="SenseThick"   value="[CellThicknessCoarse2]"/>
+    <Numeric name="PosSensitive" value="0"/>
+  </Algorithm>
+</PosPartSection>
+</DDDefinition>

--- a/Geometry/HGCalCommonData/python/testHGCalWaferFRXML_cfi.py
+++ b/Geometry/HGCalCommonData/python/testHGCalWaferFRXML_cfi.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+
+XMLIdealGeometryESSource = cms.ESSource("XMLIdealGeometryESSource",
+    geomXMLFiles = cms.vstring('Geometry/CMSCommonData/data/materials.xml',
+        'Geometry/CMSCommonData/data/rotations.xml',
+        'Geometry/HGCalCommonData/test/cms.xml',
+        'Geometry/HGCalCommonData/data/hgcalMaterial/v2/hgcalMaterial.xml',
+        'Geometry/HGCalCommonData/data/hgcalwafer/v17/hgcal.xml',
+        'Geometry/HGCalCommonData/data/hgcalcell/v17/hgcalcell.xml',
+        'Geometry/HGCalCommonData/data/hgcalwafer/v17/hgcalwafer.xml',
+        'Geometry/HGCalCommonData/data/hgcalwafer/v17/hgcalpos.xml'),
+    rootNodeName = cms.string('cms:OCMS')
+)
+
+

--- a/Geometry/HGCalCommonData/test/python/dumpHGCalWaferDDDR_cfi.py
+++ b/Geometry/HGCalCommonData/test/python/dumpHGCalWaferDDDR_cfi.py
@@ -1,0 +1,26 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("DUMP")
+process.load("Geometry.HGCalCommonData.testHGCalWaferFRXML_cfi")
+process.load('FWCore.MessageService.MessageLogger_cfi')
+
+if 'MessageLogger' in process.__dict__:
+    process.MessageLogger.G4cerr=dict()
+    process.MessageLogger.G4cout=dict()
+    process.MessageLogger.HGCalGeom=dict()
+
+process.source = cms.Source("EmptySource")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+process.add_(cms.ESProducer("TGeoMgrFromDdd",
+        verbose = cms.untracked.bool(False),
+        level   = cms.untracked.int32(14)
+))
+
+process.dump = cms.EDAnalyzer("DumpSimGeometry",
+                              outputFileName = cms.untracked.string('hgcalwaferDDDR.root'))
+
+process.p = cms.Path(process.dump)


### PR DESCRIPTION
#### PR description:

  - There will no changes in the output. 
  - It depends on PR #36271.
  - This is related with the development of a new geometry version v17 for HGCAL as discussed in the summary section of "Rotation of full Si modules" at https://indico.cern.ch/event/1103714/

#### PR validation:

  - Use runTheMatrix test workflows 'runTheMatrix.py -l limited -i all --ibeos'
  - Specific cfg's in Geometry/HGCalCommonData/test/python to dump geometry view using fireworks

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing