### PR TITLE
migrate away from deprecated `EDAnalyzer` in `OnlineDB/SiStripESSources`

### DIFF
--- a/OnlineDB/SiStripESSources/test/stubs/test_PedestalsBuilder.cc
+++ b/OnlineDB/SiStripESSources/test/stubs/test_PedestalsBuilder.cc
@@ -1,5 +1,4 @@
-
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -16,11 +15,11 @@
    @class test_PedestalsBuilder 
    @brief Simple class that analyzes Digis produced by RawToDigi unpacker
 */
-class test_PedestalsBuilder : public edm::EDAnalyzer {
+class test_PedestalsBuilder : public edm::global::EDAnalyzer<> {
 public:
   test_PedestalsBuilder(const edm::ParameterSet&) : pedToken_(esConsumes()) {}
   virtual ~test_PedestalsBuilder() override = default;
-  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void analyze(edm::StreamID, const edm::Event&, const edm::EventSetup&) const override;
 
 private:
   const edm::ESGetToken<SiStripPedestals, SiStripPedestalsRcd> pedToken_;
@@ -30,7 +29,7 @@ using namespace std;
 using namespace sistrip;
 
 // -----------------------------------------------------------------------------
-void test_PedestalsBuilder::analyze(const edm::Event& event, const edm::EventSetup& setup) {
+void test_PedestalsBuilder::analyze(edm::StreamID, const edm::Event& event, const edm::EventSetup& setup) const {
   LogTrace(mlCabling_) << "[test_PedestalsBuilder::" << __func__ << "]"
                        << " Dumping all FED connections...";
 


### PR DESCRIPTION
#### PR description:

Title says it all, missing one in https://github.com/cms-sw/cmssw/pull/36413.

#### PR validation:

`cmssw` compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A