### PR TITLE
ensure `HLTProcess` adds all `(End)Path`s to the schedule [12.2.X]

### DIFF
--- a/HLTrigger/Configuration/python/Tools/confdb.py
+++ b/HLTrigger/Configuration/python/Tools/confdb.py
@@ -503,6 +503,7 @@ from HLTrigger.Configuration.CustomConfigs import L1REPACK
     )
 )
 %(process)s.MinimalOutput = cms.EndPath( %(process)s.hltOutputMinimal )
+%(process)s.schedule.append( %(process)s.MinimalOutput )
 """
     elif not self.config.fragment and self.config.output == 'full':
       # add a single "keep *" output
@@ -518,6 +519,7 @@ from HLTrigger.Configuration.CustomConfigs import L1REPACK
     outputCommands = cms.untracked.vstring( 'keep *' )
 )
 %(process)s.FullOutput = cms.EndPath( %(process)s.hltOutputFull )
+%(process)s.schedule.append( %(process)s.FullOutput )
 """
 
   # select specific Eras
@@ -682,9 +684,10 @@ if 'GlobalTag' in %%(dict)s:
         # prepend the dqmOutput to the DQMOutput path
         self.data = other_path.sub(dqmstore + r'\g<1> %(process)s.dqmOutput +\g<3>', self.data)
       else:
-        # ceate a new DQMOutput path with the dqmOutput module
+        # create a new DQMOutput path with the dqmOutput module
         self.data += dqmstore
         self.data += '\n%(process)s.DQMOutput = cms.EndPath( %(process)s.dqmOutput )\n'
+        self.data += '%(process)s.schedule.append( %(process)s.DQMOutput )\n'
 
 
   @staticmethod


### PR DESCRIPTION
backport of #36422

#### PR description:

This PR updates `HLTProcess` (which controls the output of `hltGetConfiguration`), ensuring that `(End)Path`s appended by `HLTProcess` are added to the schedule.

For example, if one currently specifies `--output minimal`, the corresponding output `.root` file is not produced.

The issue was spotted by @silviodonato.

#### PR validation:

Manual tests, e.g.
```shell
for ec in minimal full all none ; do
  hltGetConfiguration /dev/CMSSW_12_2_0/GRun --globaltag auto:run3_hlt --data \
    --customise HLTrigger/Configuration/customizeHLTforCMSSW.customiseFor2018Input \
    --input /store/data/Run2018D/EphemeralHLTPhysics7/RAW/v1/000/323/790/00000/B543D251-40F1-CB46-A6A1-046CF3D78D6D.root \
    --era Run2_2018 --output ${ec} --max-events 10 > hlt_${ec}.py
  cmsRun hlt_${ec}.py &> hlt_${ec}.log
  ls -ltra .
done
unset ec
```

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

#36422

Backport of a bugfix for HLT development, to include it in the next full CMSSW release, i.e. `12_2_0`.