### PR TITLE
Drop type specs in Validation/MuonIdentification

### DIFF
--- a/Validation/MuonIdentification/python/muonIdVal_cff.py
+++ b/Validation/MuonIdentification/python/muonIdVal_cff.py
@@ -2,11 +2,11 @@ import FWCore.ParameterSet.Config as cms
 
 from Validation.MuonIdentification.muonIdVal_cfi import *
 from DQMOffline.Muon.muonIdDQM_cfi import *
-muonIdDQMInVal = muonIdDQM.clone()
-muonIdDQMInVal.useGlobalMuons = cms.untracked.bool(True)
-muonIdDQMInVal.useGlobalMuonsNotTrackerMuons = cms.untracked.bool(True)
-muonIdDQMInVal.baseFolder = muonIdVal.baseFolder
-
+muonIdDQMInVal = muonIdDQM.clone(
+useGlobalMuons = True,
+useGlobalMuonsNotTrackerMuons = True,
+baseFolder = muonIdVal.baseFolder
+)
 # MuonIdVal
 muonIdValSeq = cms.Sequence(muonIdVal)
 # MuonIdVal and MuonIdDQM


### PR DESCRIPTION
#### PR description:

Drop type specs in Validation/MuonIdentification/python configurations files, and updated the safer syntax for existing parameters by droping type specifications where the original parameter exists and move all parameters inside the clone.

#### PR validation:

Tested in CMSSW_12_3_X via runTheMatrix.py -l limited -i all –ibeos


