### PR TITLE
remove unused step from mkFit special workflow

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -335,7 +335,6 @@ upgradeWFs['trackingMkFit'] = UpgradeWorkflow_trackingMkFit(
         'RecoGlobal',
         'RecoNano',
         'RecoFakeHLT',
-        'HARVESTFakeHLT',
     ],
     suffix = '_trackingMkFit',
     offset = 0.7,


### PR DESCRIPTION
#### PR description:

Fixes bug from #36378 reported in https://github.com/cms-sw/cmssw/issues/36347#issuecomment-992287359: `HARVESTFakeHLT` was added to the list of steps modified by the mkFit special workflow, but that workflow does not actually modify HARVEST steps.

#### PR validation:

Reran matrix commands with reported error and observed that error was resolved.