### PR TITLE
Add early delete customisation for mkFit temporary data products

### DIFF
--- a/Configuration/StandardSequences/python/earlyDeleteSettings_cff.py
+++ b/Configuration/StandardSequences/python/earlyDeleteSettings_cff.py
@@ -5,6 +5,7 @@ import collections
 import FWCore.ParameterSet.Config as cms
 
 from RecoTracker.Configuration.customiseEarlyDeleteForSeeding import customiseEarlyDeleteForSeeding
+from RecoTracker.Configuration.customiseEarlyDeleteForMkFit import customiseEarlyDeleteForMkFit
 from CommonTools.ParticleFlow.Isolation.customiseEarlyDeleteForCandIsoDeposits import customiseEarlyDeleteForCandIsoDeposits
 
 def _hasInputTagModuleLabel(process, pset, psetModLabel, moduleLabels, result):
@@ -43,6 +44,7 @@ def customiseEarlyDelete(process):
     products = collections.defaultdict(list)
 
     products = customiseEarlyDeleteForSeeding(process, products)
+    products = customiseEarlyDeleteForMkFit(process, products)
 
     products = customiseEarlyDeleteForCandIsoDeposits(process, products)
 

--- a/RecoTracker/Configuration/python/customiseEarlyDeleteForMkFit.py
+++ b/RecoTracker/Configuration/python/customiseEarlyDeleteForMkFit.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+import collections
+
+def customiseEarlyDeleteForMkFit(process, products):
+    def _branchName(productType, moduleLabel, instanceLabel=""):
+        return "%s_%s_%s_%s" % (productType, moduleLabel, instanceLabel, process.name_())
+
+    for name, module in process.producers_().items():
+        cppType = module.type_()
+        if cppType == "MkFitSiPixelHitConverter":
+            products[name].extend([
+                _branchName("MkFitHitWrapper", name),
+                _branchName("MkFitClusterIndexToHit", name),
+            ])
+        elif cppType == "MkFitSiStripHitConverter":
+            products[name].extend([
+                _branchName("MkFitHitWrapper", name),
+                _branchName("MkFitClusterIndexToHit", name),
+                _branchName("floats", name)
+            ])
+        elif cppType == "MkFitEventOfHitsProducer":
+            products[name].append(_branchName("MkFitEventOfHits", name))
+        elif cppType == "MkFitSeedConverter":
+            products[name].append(_branchName("MkFitSeedWrapper", name))
+        elif cppType == "MkFitProducer":
+            products[name].append(_branchName("MkFitOutputWrapper", name))
+
+    return products


### PR DESCRIPTION
#### PR description:

Most of the event data products produced by mkFit EDProducers have temporary nature (i.e. not consumed outside of iterative tracking, other data products to not make any references to those products). This PR suggests to delete them early, i.e. as soon as their consuming EDModules have been run in order to save some memory.

#### PR validation:

Workflow 11824.21 step 3 runs. Here are IgProf MEM_LIVE profiles on one event of that job before
https://mkortela.web.cern.ch/mkortela/cgi-bin/navigator/mkfit_earlydelete_1220pre3/test_07.5_live/129
and after
https://mkortela.web.cern.ch/mkortela/cgi-bin/navigator/mkfit_earlydelete_1220pre3/test_27.5_live/405
(difference is ~40 MB for that event)