### PR TITLE
Drop type specs in RecoHI and RecoJets

### DIFF
--- a/Validation/RecoB/python/BDHadronTrackMonitoring_cfi.py
+++ b/Validation/RecoB/python/BDHadronTrackMonitoring_cfi.py
@@ -19,4 +19,4 @@ BDHadronTrackMonitoringAnalyze = DQMEDAnalyzer('BDHadronTrackMonitoringAnalyzer'
 
 
 BDHadronTrackMonitoringHarvest = DQMEDHarvester("BDHadronTrackMonitoringHarvester"
-								)
+                               )

--- a/Validation/RecoB/python/BDHadronTrackValidation_cff.py
+++ b/Validation/RecoB/python/BDHadronTrackValidation_cff.py
@@ -4,8 +4,8 @@ import FWCore.ParameterSet.Config as cms
 # and rerun PAT (because sometimes validation is ran without PAT sequence enables)
 from PhysicsTools.PatAlgos.producersLayer1.jetProducer_cff import *
 patJetsBDHadron = patJets.clone(
-    tagInfoSources = cms.VInputTag(cms.InputTag('pfImpactParameterTagInfos')),
-    addTagInfos = cms.bool(True)
+    tagInfoSources = cms.VInputTag('pfImpactParameterTagInfos'),
+    addTagInfos = True
 )
 
 # my analyzer

--- a/Validation/RecoEgamma/python/electronIsoFromDeps_cff.py
+++ b/Validation/RecoEgamma/python/electronIsoFromDeps_cff.py
@@ -10,10 +10,11 @@ from RecoEgamma.EgammaIsolationAlgos.egammaIsolationSequencePAT_cff import *
 eleIsoDepositEcalFromHitsFull = eleIsoDepositEcalFromHits.clone()
 eleIsoDepositEcalFromHitsReduced = eleIsoDepositEcalFromHits.clone()
 
-eleIsoDepositEcalFromHitsFull.ExtractorPSet.barrelEcalHits = cms.InputTag("ecalRecHit","EcalRecHitsEB")
-eleIsoDepositEcalFromHitsFull.ExtractorPSet.endcapEcalHits = cms.InputTag("ecalRecHit","EcalRecHitsEE")
-eleIsoDepositEcalFromHitsReduced.ExtractorPSet.barrelEcalHits = cms.InputTag("reducedEcalRecHitsEB")
-eleIsoDepositEcalFromHitsReduced.ExtractorPSet.endcapEcalHits = cms.InputTag("reducedEcalRecHitsEE")
+eleIsoDepositEcalFromHitsFull.ExtractorPSet.barrelEcalHits = "ecalRecHit : EcalRecHitsEB"
+eleIsoDepositEcalFromHitsFull.ExtractorPSet.endcapEcalHits = "ecalRecHit : EcalRecHitsEE"
+eleIsoDepositEcalFromHitsReduced.ExtractorPSet.barrelEcalHits = "reducedEcalRecHitsEB"
+eleIsoDepositEcalFromHitsReduced.ExtractorPSet.endcapEcalHits = "reducedEcalRecHitsEE"
+
 
 # clone the value map producers for each DR
 

--- a/Validation/RecoEgamma/python/electronValidationSequenceMiniAOD_cff.py
+++ b/Validation/RecoEgamma/python/electronValidationSequenceMiniAOD_cff.py
@@ -8,9 +8,10 @@ from Validation.RecoEgamma.ElectronIsolation_cfi import *
 from RecoParticleFlow.PFProducer.particleFlowEGamma_cff import egmElectronIsolationCITK as _egmElectronIsolationCITK
 from RecoParticleFlow.PFProducer.particleFlowEGamma_cff import *
 
-miniAODElectronIsolation = _egmElectronIsolationCITK.clone() 
-miniAODElectronIsolation.srcToIsolate = cms.InputTag("slimmedElectrons")
-miniAODElectronIsolation.srcForIsolationCone = cms.InputTag("packedPFCandidates")
+miniAODElectronIsolation = _egmElectronIsolationCITK.clone( 
+    srcToIsolate = "slimmedElectrons",
+    srcForIsolationCone = "packedPFCandidates"
+)
 
 electronValidationTaskMiniAOD = cms.Task(egmElectronIsolationCITK, miniAODElectronIsolation, ElectronIsolation)
 electronValidationSequenceMiniAOD = cms.Sequence(electronMcSignalValidatorMiniAOD, electronValidationTaskMiniAOD)

--- a/Validation/RecoEgamma/python/tkConvValidator_cfi.py
+++ b/Validation/RecoEgamma/python/tkConvValidator_cfi.py
@@ -10,29 +10,29 @@ trackAssociatorByHitsForConversionValidation.Purity_SimToReco = 0.5
 trackAssociatorByHitsForConversionValidation.Cut_RecoToSim = 0.5
 
 from CommonTools.RecoAlgos.trackingParticleRefSelector_cfi import trackingParticleRefSelector as _trackingParticleRefSelector
-tpSelecForEfficiency = _trackingParticleRefSelector.clone()
-tpSelecForEfficiency.chargedOnly = True
-# trackingParticleSelector.pdgId = cms.vint32()
-tpSelecForEfficiency.tip = 120
-tpSelecForEfficiency.lip = 280
-tpSelecForEfficiency.signalOnly = False
-tpSelecForEfficiency.minRapidity = -2.5
-tpSelecForEfficiency.ptMin = 0.3
-tpSelecForEfficiency.maxRapidity = 2.5
-tpSelecForEfficiency.minHit = 0
+tpSelecForEfficiency = _trackingParticleRefSelector.clone(
+    chargedOnly = True,
+    # trackingParticleSelector.pdgId = cms.vint32()
+    tip = 120,
+    lip = 280,
+    signalOnly = False,
+    minRapidity = -2.5,
+    ptMin = 0.3,
+    maxRapidity = 2.5,
+    minHit = 0
+)
 
-
-tpSelecForFakeRate = _trackingParticleRefSelector.clone()
-tpSelecForFakeRate.chargedOnly = True
-# trackingParticleSelector.pdgId = cms.vint32()
-tpSelecForFakeRate.tip = 120
-tpSelecForFakeRate.lip = 280
-tpSelecForFakeRate.signalOnly = False
-tpSelecForFakeRate.minRapidity = -2.5
-tpSelecForFakeRate.ptMin = 0.
-tpSelecForFakeRate.maxRapidity = 2.5
-tpSelecForFakeRate.minHit = 0
-
+tpSelecForFakeRate = _trackingParticleRefSelector.clone(
+    chargedOnly = True,
+    # trackingParticleSelector.pdgId = cms.vint32()
+    tip = 120,
+    lip = 280,
+    signalOnly = False,
+    minRapidity = -2.5,
+    ptMin = 0.0,
+    maxRapidity = 2.5,
+    minHit = 0
+)
 
 
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer

--- a/Validation/RecoEgamma/python/tkConvValidator_cfi.py
+++ b/Validation/RecoEgamma/python/tkConvValidator_cfi.py
@@ -11,27 +11,27 @@ trackAssociatorByHitsForConversionValidation.Cut_RecoToSim = 0.5
 
 from CommonTools.RecoAlgos.trackingParticleRefSelector_cfi import trackingParticleRefSelector as _trackingParticleRefSelector
 tpSelecForEfficiency = _trackingParticleRefSelector.clone(
-    chargedOnly = True,
-    # trackingParticleSelector.pdgId = cms.vint32()
-    tip = 120,
-    lip = 280,
-    signalOnly = False,
-    minRapidity = -2.5,
-    ptMin = 0.3,
-    maxRapidity = 2.5,
-    minHit = 0
+chargedOnly = True,
+# trackingParticleSelector.pdgId = cms.vint32()
+tip = 120,
+lip = 280,
+signalOnly = False,
+minRapidity = -2.5,
+ptMin = 0.3,
+maxRapidity = 2.5,
+minHit = 0
 )
 
 tpSelecForFakeRate = _trackingParticleRefSelector.clone(
-    chargedOnly = True,
-    # trackingParticleSelector.pdgId = cms.vint32()
-    tip = 120,
-    lip = 280,
-    signalOnly = False,
-    minRapidity = -2.5,
-    ptMin = 0.0,
-    maxRapidity = 2.5,
-    minHit = 0
+chargedOnly = True,
+# trackingParticleSelector.pdgId = cms.vint32()
+tip = 120,
+lip = 280,
+signalOnly = False,
+minRapidity = -2.5,
+ptMin = 0.0,
+maxRapidity = 2.5,
+minHit = 0
 )
 
 

--- a/Validation/RecoEgamma/python/tpSelection_cfi.py
+++ b/Validation/RecoEgamma/python/tpSelection_cfi.py
@@ -1,15 +1,16 @@
 import FWCore.ParameterSet.Config as cms
 
 import PhysicsTools.RecoAlgos.trackingParticleSelector_cfi
-tpSelection = PhysicsTools.RecoAlgos.trackingParticleSelector_cfi.trackingParticleSelector.clone()
-tpSelection.chargedOnly = True
-# trackingParticleSelector.pdgId = cms.vint32()
-tpSelection.tip = 120
-tpSelection.lip = 280
-tpSelection.signalOnly = False
-tpSelection.minRapidity = -2.5
-tpSelection.ptMin = 1.
-tpSelection.maxRapidity = 2.5
-tpSelection.minHit = 0
+tpSelection = PhysicsTools.RecoAlgos.trackingParticleSelector_cfi.trackingParticleSelector.clone(
+    chargedOnly = True,
+    # trackingParticleSelector.pdgId = cms.vint32()
+    tip = 120,
+    lip = 280,
+    signalOnly = False,
+    minRapidity = -2.5,
+    ptMin = 1.0,
+    maxRapidity = 2.5,
+    minHit = 0
 
+)
 

--- a/Validation/RecoHI/python/TrackValidationHeavyIons_cff.py
+++ b/Validation/RecoHI/python/TrackValidationHeavyIons_cff.py
@@ -24,17 +24,17 @@ from Validation.RecoTrack.MultiTrackValidator_cff import *
 hiTrackValidator = multiTrackValidator.clone(
     associators = ["trackAssociatorByHitsRecoDenom"],
     UseAssociators = True,
-    label_tp_effic = cms.InputTag("primaryChgSimTracks"),
-    label_tp_fake  = cms.InputTag("cutsTPFake"),
+    label_tp_effic = "primaryChgSimTracks",
+    label_tp_fake  = "cutsTPFake",
     label_tp_effic_refvector = True,
     label_tp_fake_refvector = True,
     signalOnlyTP = cms.bool(False),
-    trackCollectionForDrCalculation = cms.InputTag("cutsRecoTracks"),
+    trackCollectionForDrCalculation = "cutsRecoTracks",
     minpT = cms.double(1.0),
     maxpT = cms.double(100.0),
     nintpT = cms.int32(40),
     useLogPt = cms.untracked.bool(True),
-    cores = cms.InputTag("")
+    cores = ""
     )
 
 hiTrackValidator.label = cms.VInputTag(cms.InputTag('cutsRecoTracks'),

--- a/Validation/RecoHI/python/muonValidationHeavyIons_cff.py
+++ b/Validation/RecoHI/python/muonValidationHeavyIons_cff.py
@@ -25,28 +25,28 @@ hiMABH.PurityCut_muon = 0.75
 ################################################
 
 # sim to tracker tracks, 
-tpToTkMuonAssociationHI = hiMABH.clone()
-tpToTkMuonAssociationHI.tracksTag = 'cutsRecoTrkMuons'
-tpToTkMuonAssociationHI.UseTracker = True
-tpToTkMuonAssociationHI.UseMuon = False
-
+tpToTkMuonAssociationHI = hiMABH.clone(
+tracksTag = 'cutsRecoTrkMuons',
+UseTracker = True,
+UseMuon = False
+)
 # sim to sta, and sta:updatedAtVtx
-tpToStaMuonAssociationHI = hiMABH.clone()
-tpToStaMuonAssociationHI.tracksTag = 'standAloneMuons'
-tpToStaMuonAssociationHI.UseTracker = False
-tpToStaMuonAssociationHI.UseMuon = True
-
-tpToStaUpdMuonAssociationHI = hiMABH.clone()
-tpToStaUpdMuonAssociationHI.tracksTag = 'standAloneMuons:UpdatedAtVtx'
-tpToStaUpdMuonAssociationHI.UseTracker = False
-tpToStaUpdMuonAssociationHI.UseMuon = True
-
+tpToStaMuonAssociationHI = hiMABH.clone(
+tracksTag = 'standAloneMuons',
+UseTracker = False,
+UseMuon = True
+)
+tpToStaUpdMuonAssociationHI = hiMABH.clone(
+tracksTag = 'standAloneMuons:UpdatedAtVtx',
+UseTracker = False,
+UseMuon = True
+)
 # sim to glb track 
-tpToGlbMuonAssociationHI = hiMABH.clone()
-tpToGlbMuonAssociationHI.tracksTag = 'globalMuons'
-tpToGlbMuonAssociationHI.UseTracker = True
-tpToGlbMuonAssociationHI.UseMuon = True
-
+tpToGlbMuonAssociationHI = hiMABH.clone(
+tracksTag = 'globalMuons',
+UseTracker = True,
+UseMuon = True
+)
 
 # Muon association sequences
 # (some are commented out until timing is addressed)
@@ -68,26 +68,26 @@ MTVhi.label_tp_fake = cms.InputTag("cutsTpMuons")
 MTVhi.maxPt = cms.double(100)
 
 # MuonTrackValidator parameters
-trkMuonTrackVMuonAssocHI = MTVhi.clone()
-trkMuonTrackVMuonAssocHI.associatormap  = 'tpToTkMuonAssociationHI'
-trkMuonTrackVMuonAssocHI.label          = ['cutsRecoTrkMuons']
-trkMuonTrackVMuonAssocHI.muonHistoParameters = trkMuonHistoParameters
-
-glbMuonTrackVMuonAssocHI = MTVhi.clone()
-glbMuonTrackVMuonAssocHI.associatormap = 'tpToGlbMuonAssociationHI'
-glbMuonTrackVMuonAssocHI.label           = ['globalMuons']
-glbMuonTrackVMuonAssocHI.muonHistoParameters = glbMuonHistoParameters
-
-staMuonTrackVMuonAssocHI = MTVhi.clone()
-staMuonTrackVMuonAssocHI.associatormap = 'tpToStaMuonAssociationHI'
-staMuonTrackVMuonAssocHI.label = ('standAloneMuons',)
-staMuonTrackVMuonAssocHI.muonHistoParameters = staMuonHistoParameters
-
-staUpdMuonTrackVMuonAssocHI = MTVhi.clone()
-staUpdMuonTrackVMuonAssocHI.associatormap = 'tpToStaUpdMuonAssociationHI'
-staUpdMuonTrackVMuonAssocHI.label = ('standAloneMuons:UpdatedAtVtx',)
-staUpdMuonTrackVMuonAssocHI.muonHistoParameters = staUpdMuonHistoParameters
-
+trkMuonTrackVMuonAssocHI = MTVhi.clone(
+associatormap  = 'tpToTkMuonAssociationHI',
+label          = ['cutsRecoTrkMuons'],
+muonHistoParameters = trkMuonHistoParameters
+)
+glbMuonTrackVMuonAssocHI = MTVhi.clone(
+associatormap = 'tpToGlbMuonAssociationHI',
+label           = ['globalMuons'],
+muonHistoParameters = glbMuonHistoParameters
+)
+staMuonTrackVMuonAssocHI = MTVhi.clone(
+associatormap = 'tpToStaMuonAssociationHI',
+label = ('standAloneMuons',),
+muonHistoParameters = staMuonHistoParameters
+)
+staUpdMuonTrackVMuonAssocHI = MTVhi.clone(
+associatormap = 'tpToStaUpdMuonAssociationHI',
+label = ('standAloneMuons:UpdatedAtVtx',),
+muonHistoParameters = staUpdMuonHistoParameters
+)
 
 # Muon validation sequences
 hiMuonValidation_seq = cms.Sequence(

--- a/Validation/RecoJets/python/JetValidationHeavyIons_cff.py
+++ b/Validation/RecoJets/python/JetValidationHeavyIons_cff.py
@@ -6,10 +6,10 @@ from RecoHI.HiJetAlgos.HiGenCleaner_cff import *
 
 iterativeCone5HiCleanedGenJets = heavyIonCleanedGenJets.clone( src = cms.InputTag('iterativeCone5HiGenJets'))
 #iterativeCone7HiCleanedGenJets = heavyIonCleanedGenJets.clone( src = cms.InputTag('iterativeCone7HiGenJets'))
-ak2HiCleanedGenJets = heavyIonCleanedGenJets.clone( src = cms.InputTag('ak2HiGenJets'))
-ak3HiCleanedGenJets = heavyIonCleanedGenJets.clone( src = cms.InputTag('ak3HiGenJets'))
-ak4HiCleanedGenJets = heavyIonCleanedGenJets.clone( src = cms.InputTag('ak4HiGenJets'))
-ak5HiCleanedGenJets = heavyIonCleanedGenJets.clone( src = cms.InputTag('ak5HiGenJets'))
+ak2HiCleanedGenJets = heavyIonCleanedGenJets.clone( src = 'ak2HiGenJets')
+ak3HiCleanedGenJets = heavyIonCleanedGenJets.clone( src = 'ak3HiGenJets')
+ak4HiCleanedGenJets = heavyIonCleanedGenJets.clone( src = 'ak4HiGenJets')
+ak5HiCleanedGenJets = heavyIonCleanedGenJets.clone( src = 'ak5HiGenJets')
 
 ak7HiCleanedGenJets = heavyIonCleanedGenJets.clone( src = cms.InputTag('ak7HiGenJets'))
 


### PR DESCRIPTION
#### PR description:
Drop type specs in Validation/RecoHI and Validation/RecoJets python configuration files.

Central DQM migration campaign for drop type spces following
https://cms-sw.github.io/cms_coding_rules.html#6--packaging-rules-1
and update the safer syntax for existing parameters like: (1) drop type specifications where the original parameter exists. (2) using "clone" instead of "deepcopy" (3) move all parameter inside the clone


#### PR validation:
Tested in CMSSW_12_3_X via runTheMatrix.py -l limited -i all --ibeos





