### PR TITLE
Bug fix in HiPuRhoProducer.cc

### DIFF
--- a/RecoHI/HiJetAlgos/plugins/HiPuRhoProducer.cc
+++ b/RecoHI/HiJetAlgos/plugins/HiPuRhoProducer.cc
@@ -464,7 +464,7 @@ void HiPuRhoProducer::calculateOrphanInput(std::vector<fastjet::PseudoJet>& orph
     for (auto const& im : towermap_) {
       double dr2 = reco::deltaR2(im.eta, im.phi, jet_etaphi.first, jet_etaphi.second);
       if (dr2 < radiusPU_ * radiusPU_ && !excludedTowers[std::pair(im.ieta, im.iphi)] &&
-          (im.ieta - ntowersWithJets_[im.ieta]) > minimumTowersFraction_ * im.ieta) {
+          (geomtowers_[im.ieta] - ntowersWithJets_[im.ieta]) > minimumTowersFraction_ * geomtowers_[im.ieta]) {
         ntowersWithJets_[im.ieta]++;
         excludedTowers[std::pair(im.ieta, im.iphi)] = 1;
       }


### PR DESCRIPTION

#### PR description:

One-line bug fix in the jetty tower exclusion part of the code.  The bug uses ieta instead of N(ieta) to calculate the number of towers.

Bug report in HIN PAG meeting: https://indico.cern.ch/event/1092697/#12-bug-report-in-cs-jet


#### PR validation:

The fix is checked to produce desired jet subtraction outcome.


#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is the initial.  Not a backport.


#### additional info

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
