### PR TITLE
Drop type specs in RecoHI, RecoJets and RecoMET

### DIFF
--- a/Validation/RecoHI/python/TrackValidationHeavyIons_cff.py
+++ b/Validation/RecoHI/python/TrackValidationHeavyIons_cff.py
@@ -24,17 +24,17 @@ from Validation.RecoTrack.MultiTrackValidator_cff import *
 hiTrackValidator = multiTrackValidator.clone(
     associators = ["trackAssociatorByHitsRecoDenom"],
     UseAssociators = True,
-    label_tp_effic = cms.InputTag("primaryChgSimTracks"),
-    label_tp_fake  = cms.InputTag("cutsTPFake"),
+    label_tp_effic = "primaryChgSimTracks",
+    label_tp_fake  = "cutsTPFake",
     label_tp_effic_refvector = True,
     label_tp_fake_refvector = True,
     signalOnlyTP = cms.bool(False),
-    trackCollectionForDrCalculation = cms.InputTag("cutsRecoTracks"),
+    trackCollectionForDrCalculation = "cutsRecoTracks",
     minpT = cms.double(1.0),
     maxpT = cms.double(100.0),
     nintpT = cms.int32(40),
     useLogPt = cms.untracked.bool(True),
-    cores = cms.InputTag("")
+    cores = ""
     )
 
 hiTrackValidator.label = cms.VInputTag(cms.InputTag('cutsRecoTracks'),

--- a/Validation/RecoHI/python/muonValidationHeavyIons_cff.py
+++ b/Validation/RecoHI/python/muonValidationHeavyIons_cff.py
@@ -25,28 +25,28 @@ hiMABH.PurityCut_muon = 0.75
 ################################################
 
 # sim to tracker tracks, 
-tpToTkMuonAssociationHI = hiMABH.clone()
-tpToTkMuonAssociationHI.tracksTag = 'cutsRecoTrkMuons'
-tpToTkMuonAssociationHI.UseTracker = True
-tpToTkMuonAssociationHI.UseMuon = False
-
+tpToTkMuonAssociationHI = hiMABH.clone(
+tracksTag = 'cutsRecoTrkMuons',
+UseTracker = True,
+UseMuon = False
+)
 # sim to sta, and sta:updatedAtVtx
-tpToStaMuonAssociationHI = hiMABH.clone()
-tpToStaMuonAssociationHI.tracksTag = 'standAloneMuons'
-tpToStaMuonAssociationHI.UseTracker = False
-tpToStaMuonAssociationHI.UseMuon = True
-
-tpToStaUpdMuonAssociationHI = hiMABH.clone()
-tpToStaUpdMuonAssociationHI.tracksTag = 'standAloneMuons:UpdatedAtVtx'
-tpToStaUpdMuonAssociationHI.UseTracker = False
-tpToStaUpdMuonAssociationHI.UseMuon = True
-
+tpToStaMuonAssociationHI = hiMABH.clone(
+tracksTag = 'standAloneMuons',
+UseTracker = False,
+UseMuon = True
+)
+tpToStaUpdMuonAssociationHI = hiMABH.clone(
+tracksTag = 'standAloneMuons:UpdatedAtVtx',
+UseTracker = False,
+UseMuon = True
+)
 # sim to glb track 
-tpToGlbMuonAssociationHI = hiMABH.clone()
-tpToGlbMuonAssociationHI.tracksTag = 'globalMuons'
-tpToGlbMuonAssociationHI.UseTracker = True
-tpToGlbMuonAssociationHI.UseMuon = True
-
+tpToGlbMuonAssociationHI = hiMABH.clone(
+tracksTag = 'globalMuons',
+UseTracker = True,
+UseMuon = True
+)
 
 # Muon association sequences
 # (some are commented out until timing is addressed)
@@ -68,26 +68,26 @@ MTVhi.label_tp_fake = cms.InputTag("cutsTpMuons")
 MTVhi.maxPt = cms.double(100)
 
 # MuonTrackValidator parameters
-trkMuonTrackVMuonAssocHI = MTVhi.clone()
-trkMuonTrackVMuonAssocHI.associatormap  = 'tpToTkMuonAssociationHI'
-trkMuonTrackVMuonAssocHI.label          = ['cutsRecoTrkMuons']
-trkMuonTrackVMuonAssocHI.muonHistoParameters = trkMuonHistoParameters
-
-glbMuonTrackVMuonAssocHI = MTVhi.clone()
-glbMuonTrackVMuonAssocHI.associatormap = 'tpToGlbMuonAssociationHI'
-glbMuonTrackVMuonAssocHI.label           = ['globalMuons']
-glbMuonTrackVMuonAssocHI.muonHistoParameters = glbMuonHistoParameters
-
-staMuonTrackVMuonAssocHI = MTVhi.clone()
-staMuonTrackVMuonAssocHI.associatormap = 'tpToStaMuonAssociationHI'
-staMuonTrackVMuonAssocHI.label = ('standAloneMuons',)
-staMuonTrackVMuonAssocHI.muonHistoParameters = staMuonHistoParameters
-
-staUpdMuonTrackVMuonAssocHI = MTVhi.clone()
-staUpdMuonTrackVMuonAssocHI.associatormap = 'tpToStaUpdMuonAssociationHI'
-staUpdMuonTrackVMuonAssocHI.label = ('standAloneMuons:UpdatedAtVtx',)
-staUpdMuonTrackVMuonAssocHI.muonHistoParameters = staUpdMuonHistoParameters
-
+trkMuonTrackVMuonAssocHI = MTVhi.clone(
+associatormap  = 'tpToTkMuonAssociationHI',
+label          = ['cutsRecoTrkMuons'],
+muonHistoParameters = trkMuonHistoParameters
+)
+glbMuonTrackVMuonAssocHI = MTVhi.clone(
+associatormap = 'tpToGlbMuonAssociationHI',
+label           = ['globalMuons'],
+muonHistoParameters = glbMuonHistoParameters
+)
+staMuonTrackVMuonAssocHI = MTVhi.clone(
+associatormap = 'tpToStaMuonAssociationHI',
+label = ('standAloneMuons',),
+muonHistoParameters = staMuonHistoParameters
+)
+staUpdMuonTrackVMuonAssocHI = MTVhi.clone(
+associatormap = 'tpToStaUpdMuonAssociationHI',
+label = ('standAloneMuons:UpdatedAtVtx',),
+muonHistoParameters = staUpdMuonHistoParameters
+)
 
 # Muon validation sequences
 hiMuonValidation_seq = cms.Sequence(

--- a/Validation/RecoJets/python/JetValidationHeavyIons_cff.py
+++ b/Validation/RecoJets/python/JetValidationHeavyIons_cff.py
@@ -4,14 +4,14 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoHI.HiJetAlgos.HiGenCleaner_cff import *
 
-iterativeCone5HiCleanedGenJets = heavyIonCleanedGenJets.clone( src = cms.InputTag('iterativeCone5HiGenJets'))
-#iterativeCone7HiCleanedGenJets = heavyIonCleanedGenJets.clone( src = cms.InputTag('iterativeCone7HiGenJets'))
-ak2HiCleanedGenJets = heavyIonCleanedGenJets.clone( src = cms.InputTag('ak2HiGenJets'))
-ak3HiCleanedGenJets = heavyIonCleanedGenJets.clone( src = cms.InputTag('ak3HiGenJets'))
-ak4HiCleanedGenJets = heavyIonCleanedGenJets.clone( src = cms.InputTag('ak4HiGenJets'))
-ak5HiCleanedGenJets = heavyIonCleanedGenJets.clone( src = cms.InputTag('ak5HiGenJets'))
+iterativeCone5HiCleanedGenJets = heavyIonCleanedGenJets.clone( src = 'iterativeCone5HiGenJets')
+#iterativeCone7HiCleanedGenJets = heavyIonCleanedGenJets.clone( src = 'iterativeCone7HiGenJets')
+ak2HiCleanedGenJets = heavyIonCleanedGenJets.clone( src = 'ak2HiGenJets')
+ak3HiCleanedGenJets = heavyIonCleanedGenJets.clone( src = 'ak3HiGenJets')
+ak4HiCleanedGenJets = heavyIonCleanedGenJets.clone( src = 'ak4HiGenJets')
+ak5HiCleanedGenJets = heavyIonCleanedGenJets.clone( src = 'ak5HiGenJets')
 
-ak7HiCleanedGenJets = heavyIonCleanedGenJets.clone( src = cms.InputTag('ak7HiGenJets'))
+ak7HiCleanedGenJets = heavyIonCleanedGenJets.clone( src = 'ak7HiGenJets')
 
 ### jet analyzer for several radii
 ### iterative cone with PU, anti-kt with PU, anti-kt with fastjet PU 

--- a/Validation/RecoMET/python/METRelValForDQM_cff.py
+++ b/Validation/RecoMET/python/METRelValForDQM_cff.py
@@ -35,18 +35,18 @@ metPreValidSeqTask = cms.Task(ak4PFCHSL1FastjetCorrector,
 )
 metPreValidSeq = cms.Sequence(metPreValidSeqTask)
 
-valCorrPfMetType1=corrPfMetType1.clone(jetCorrLabel = cms.InputTag('newAK4PFCHSL1FastL2L3Corrector'),
-                                       jetCorrLabelRes = cms.InputTag('newAK4PFCHSL1FastL2L3ResidualCorrector')
+valCorrPfMetType1=corrPfMetType1.clone(jetCorrLabel = 'newAK4PFCHSL1FastL2L3Corrector',
+                                       jetCorrLabelRes = 'newAK4PFCHSL1FastL2L3ResidualCorrector'
                                       )
 
 PfMetT1=pfMetT1.clone(srcCorrections = cms.VInputTag(
-        cms.InputTag('valCorrPfMetType1', 'type1')
+        ('valCorrPfMetType1', 'type1')
         ))
 
 PfMetT0pcT1=pfMetT0pcT1.clone(
     srcCorrections = cms.VInputTag(
-        cms.InputTag('corrPfMetType0PfCand'),
-        cms.InputTag('valCorrPfMetType1', 'type1')
+        'corrPfMetType0PfCand',
+        ('valCorrPfMetType1', 'type1')
         )
     )
 


### PR DESCRIPTION
#### PR description:
Drop type specs in Validation/RecoHI, Validation/RecoJets and  Validation/RecoMET python configuration files.

Central DQM migration campaign for drop type spces following
https://cms-sw.github.io/cms_coding_rules.html#6--packaging-rules-1
and update the safer syntax for existing parameters like: (1) drop type specifications where the original parameter exists. (2) using "clone" instead of "deepcopy" (3) move all parameters inside the clone

#### PR validation:
Tested in CMSSW_12_3_X via runTheMatrix.py -l limited -i all --ibeos



