### PR TITLE
remove -fsanitize=pointer-compare flag to avoid asan IB build errors

### DIFF
--- a/FWCore/Framework/BuildFile.xml
+++ b/FWCore/Framework/BuildFile.xml
@@ -11,6 +11,7 @@
 <use name="FWCore/Version"/>
 <use name="boost"/>
 <use name="rootcore"/>
+<flags REM_CXXFLAGS="-fsanitize=pointer-compare" file="PathsAndConsumesOfModules.cc"/>
 <flags ADD_SUBDIR="1"/>
 <export>
   <lib name="1"/>

--- a/L1Trigger/CSCTriggerPrimitives/BuildFile.xml
+++ b/L1Trigger/CSCTriggerPrimitives/BuildFile.xml
@@ -7,6 +7,7 @@
 <use name="FWCore/ParameterSet"/>
 <use name="Geometry/CSCGeometry"/>
 <use name="Geometry/GEMGeometry"/>
+<flags REM_CXXFLAGS="-fsanitize=pointer-compare" file="CSCCathodeLCTProcessor.cc"/>
 <export>
   <lib name="1"/>
 </export>


### PR DESCRIPTION
Looks like `-fsanitize=pointer-compare` flag is causing ASAN IBs (for gcc11) to fail. Building `PathsAndConsumesOfModules.cc and CSCCathodeLCTProcessor.cc` without this flags seems to fix the issue. This is just a work around to avoid these build errors. 

Pre-processed (compiling with `-E`) output for these two files ( `PathsAndConsumesOfModules.cc and CSCCathodeLCTProcessor.cc` ) with and without  `-fsanitize=pointer-compare` are identical. So no idea why at link time we get the

```
/data/cmsbld/jenkins/workspace/build-any-ib/w/slc7_amd64_gcc11/external/gcc/11.2.1-f478fee2760dbd22aaabb4e3a8fe1640/bin/../lib/gcc/x86_64-unknown-linux-gnu/11.2.1/../../../../x86_64-unknown-linux-gnu/bin/ld: tmp/slc7_amd64_gcc11/src/FWCore/Framework/src/FWCoreFramework/PathsAndConsumesOfModules.cc.o: in function `edm::checkForModuleDependencyCorrectness(edm::PathsAndConsumesOfModulesBase const&, bool)':
  PathsAndConsumesOfModules.cc:(.text+0x20596): undefined reference to `std::__cxx11::basic_stringbuf<char, std::char_traits<char>, std::allocator<char> >::_M_high_mark() const'
```