### PR TITLE
get rid of CMS deprecation warnings in `Validation/*Track`

### DIFF
--- a/Validation/RecoPixelVertexing/test/PixelTrackVal.cc
+++ b/Validation/RecoPixelVertexing/test/PixelTrackVal.cc
@@ -1,5 +1,5 @@
 #include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -33,7 +33,7 @@ T sqr(T t) {
   return t * t;
 }
 
-class PixelTrackVal : public edm::EDAnalyzer {
+class PixelTrackVal : public edm::one::EDAnalyzer<> {
 public:
   explicit PixelTrackVal(const edm::ParameterSet &conf);
   ~PixelTrackVal() override;
@@ -76,7 +76,7 @@ void PixelTrackVal::beginJob() {
 }
 
 void PixelTrackVal::analyze(const edm::Event &ev, const edm::EventSetup &es) {
-  std::cout << "*** PixelTrackVal, analyze event: " << ev.id() << std::endl;
+  LogTrace("PixelTrackVal") << "*** PixelTrackVal, analyze event: " << ev.id() << std::endl;
 
   //------------------------ simulated tracks
   edm::Handle<reco::TrackCollection> trackCollection;
@@ -87,7 +87,7 @@ void PixelTrackVal::analyze(const edm::Event &ev, const edm::EventSetup &es) {
 
   if (verbose_ > 0) {
     //    std::cout << *(trackCollection.provenance()) << std::endl;
-    std::cout << "Reconstructed " << tracks.size() << " tracks" << std::endl;
+    edm::LogInfo("PixelTrackVal") << "Reconstructed " << tracks.size() << " tracks" << std::endl;
   }
 
   for (unsigned int idx = 0; idx < tracks.size(); idx++) {
@@ -113,14 +113,15 @@ void PixelTrackVal::analyze(const edm::Event &ev, const edm::EventSetup &es) {
       }
     }
     if (problem)
-      std::cout << " *** PROBLEM **" << std::endl;
+      edm::LogInfo("PixelTrackVal") << " *** PROBLEM **" << std::endl;
 
     if (verbose_ > 0) {
-      std::cout << "\tmomentum: " << tracks[idx].momentum() << "\tPT: " << tracks[idx].pt() << std::endl;
-      std::cout << "\tvertex: " << tracks[idx].vertex() << "\tTIP: " << tracks[idx].d0() << " +- "
-                << tracks[idx].d0Error() << "\tZ0: " << tracks[idx].dz() << " +- " << tracks[idx].dzError()
-                << std::endl;
-      std::cout << "\tcharge: " << tracks[idx].charge() << std::endl;
+      edm::LogInfo("PixelTrackVal") << "\tmomentum: " << tracks[idx].momentum() << "\tPT: " << tracks[idx].pt()
+                                    << std::endl;
+      edm::LogInfo("PixelTrackVal") << "\tvertex: " << tracks[idx].vertex() << "\tTIP: " << tracks[idx].d0() << " +- "
+                                    << tracks[idx].d0Error() << "\tZ0: " << tracks[idx].dz() << " +- "
+                                    << tracks[idx].dzError() << std::endl;
+      edm::LogInfo("PixelTrackVal") << "\tcharge: " << tracks[idx].charge() << std::endl;
     }
   }
 
@@ -129,17 +130,17 @@ void PixelTrackVal::analyze(const edm::Event &ev, const edm::EventSetup &es) {
   edm::Handle<edm::SimVertexContainer> simVtcs;
   ev.getByToken(simVertexContainerToken_, simVtcs);
 
-  //   std::cout << "SimVertex " << simVtcs->size() << std::endl;
+  //   edm::LogInfo("PixelTrackVal") << "SimVertex " << simVtcs->size() << std::endl;
   //   for(edm::SimVertexContainer::const_iterator v=simVtcs->begin();
   //       v!=simVtcs->end(); ++v){
-  //     std::cout << "simvtx " << std::setw(10) << std::setprecision(3)
+  //     edm::LogInfo("PixelTrackVal") << "simvtx " << std::setw(10) << std::setprecision(3)
   //         << v->position().x() << " " << v->position().y() << " " <<
   //         v->position().z() << " "
   //         << v->parentIndex() << " " << v->noParent() << " " << std::endl; }
 
   edm::Handle<edm::SimTrackContainer> simTrks;
   ev.getByToken(simTrackContainerToken_, simTrks);
-  std::cout << "simtrks " << simTrks->size() << std::endl;
+  edm::LogInfo("PixelTrackVal") << "simtrks " << simTrks->size() << std::endl;
 
   //-------------- association
   // matching cuts from Marcin

--- a/Validation/RecoTrack/interface/SiStripTrackingRecHitsValid.h
+++ b/Validation/RecoTrack/interface/SiStripTrackingRecHitsValid.h
@@ -2,45 +2,40 @@
 #define Validation_RecoTrack_SiStripTrackingRecHitsValid_h
 
 //DQM services for histogram
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
-#include <DQMServices/Core/interface/DQMEDAnalyzer.h>
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/Event.h"
-
 #include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Utilities/interface/EDGetToken.h"
-
-#include "FWCore/Framework/interface/EventSetup.h"
-
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-
+#include "DataFormats/GeometryVector/interface/GlobalVector.h"
+#include "DataFormats/GeometryVector/interface/LocalVector.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackExtra.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeed.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
-#include "DataFormats/TrackReco/interface/Track.h"
-#include "DataFormats/TrackReco/interface/TrackExtra.h"
-#include "DataFormats/GeometryVector/interface/GlobalVector.h"
-#include "DataFormats/GeometryVector/interface/LocalVector.h"
-
-#include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
-#include "TrackingTools/MaterialEffects/interface/PropagatorWithMaterial.h"
-#include "TrackingTools/KalmanUpdators/interface/KFUpdator.h"
+#include "RecoLocalTracker/Records/interface/TkStripCPERecord.h"
+#include "RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h"
 #include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h"
+#include "TrackingTools/KalmanUpdators/interface/KFUpdator.h"
+#include "TrackingTools/MaterialEffects/interface/PropagatorWithMaterial.h"
 #include "TrackingTools/TrackFitters/interface/KFTrajectoryFitter.h"
 #include "TrackingTools/TrackFitters/interface/KFTrajectorySmoother.h"
-#include "RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h"
-#include "RecoLocalTracker/Records/interface/TkStripCPERecord.h"
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <TROOT.h>
 #include <TTree.h>
 #include <TFile.h>
 #include <TH1F.h>
 #include <TProfile.h>
+#include <string>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -63,12 +58,8 @@
 #include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetType.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetType.h"
-
 #include "DataFormats/GeometrySurface/interface/ReferenceCounted.h"
-
 #include "TrackingTools/PatternTools/interface/TrajectoryMeasurement.h"
-
-#include <string>
 
 class SiStripDetCabling;
 class SiStripDCSStatus;

--- a/Validation/SiOuterTrackerV/plugins/OuterTrackerMonitorTrackingParticles.cc
+++ b/Validation/SiOuterTrackerV/plugins/OuterTrackerMonitorTrackingParticles.cc
@@ -58,10 +58,7 @@ OuterTrackerMonitorTrackingParticles::OuterTrackerMonitorTrackingParticles(const
   TP_maxVtxZ = conf_.getParameter<double>("TP_maxVtxZ");  // max vertZ (or z0) to consider matching
 }
 
-OuterTrackerMonitorTrackingParticles::~OuterTrackerMonitorTrackingParticles() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
-}
+OuterTrackerMonitorTrackingParticles::~OuterTrackerMonitorTrackingParticles() = default;
 
 // member functions
 

--- a/Validation/SiOuterTrackerV/plugins/OuterTrackerMonitorTrackingParticles.h
+++ b/Validation/SiOuterTrackerV/plugins/OuterTrackerMonitorTrackingParticles.h
@@ -6,7 +6,6 @@
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"

--- a/Validation/TrackerHits/interface/TrackerHitAnalyzer.h
+++ b/Validation/TrackerHits/interface/TrackerHitAnalyzer.h
@@ -8,7 +8,6 @@
  *
  */
 // framework & common header files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"

--- a/Validation/TrackerRecHits/interface/SiPixelRecHitsValid.h
+++ b/Validation/TrackerRecHits/interface/SiPixelRecHitsValid.h
@@ -11,7 +11,6 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
 #include "DQMServices/Core/interface/DQMStore.h"

--- a/Validation/TrackerRecHits/interface/SiStripRecHitsValid.h
+++ b/Validation/TrackerRecHits/interface/SiStripRecHitsValid.h
@@ -2,7 +2,6 @@
 #define SiStripRecHitsValid_h
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"

--- a/Validation/TrackerRecHits/src/SiPixelRecHitsValid.cc
+++ b/Validation/TrackerRecHits/src/SiPixelRecHitsValid.cc
@@ -49,7 +49,7 @@ SiPixelRecHitsValid::SiPixelRecHitsValid(const edm::ParameterSet& ps)
       trackerHitAssociatorConfig_(ps, consumesCollector()),
       siPixelRecHitCollectionToken_(consumes<SiPixelRecHitCollection>(ps.getParameter<edm::InputTag>("src"))) {}
 
-SiPixelRecHitsValid::~SiPixelRecHitsValid() {}
+SiPixelRecHitsValid::~SiPixelRecHitsValid() = default;
 
 void SiPixelRecHitsValid::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run& run, const edm::EventSetup& es) {
   ibooker.setCurrentFolder("TrackerRecHitsV/TrackerRecHits/Pixel/clustBPIX");

--- a/Validation/TrackingMCTruth/interface/TrackingTruthValid.h
+++ b/Validation/TrackingMCTruth/interface/TrackingTruthValid.h
@@ -2,7 +2,6 @@
 #define TrackingTruthValid_h
 
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DQMServices/Core/interface/DQMStore.h"

--- a/Validation/TrackingMCTruth/plugins/TrackingTruthValid.cc
+++ b/Validation/TrackingMCTruth/plugins/TrackingTruthValid.cc
@@ -1,16 +1,11 @@
 #include "Validation/TrackingMCTruth/interface/TrackingTruthValid.h"
-
 #include "DataFormats/Common/interface/Handle.h"
-
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
-
 #include "DQMServices/Core/interface/DQMStore.h"
-
 #include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
 #include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"


### PR DESCRIPTION
#### PR description:

Part of the migration in #31061 and https://github.com/cms-sw/cmssw/issues/36404
Went systematically through all of the CMSDEPRECATED_X warnings in the `Validation/*Track`  subsystems from `CMSSW_12_3_CMSDEPRECATED_X_2021-12-10-2300` and removed deprecated API calls.

#### PR validation:

`cmssw` compiles

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A