### PR TITLE
Run3-sim101 Move FileService variable in the code rather than as a class member and use fillDescription in SimG4CMS/ShowerLibraryProducer and SimG4CMS/Calo

### DIFF
--- a/SimG4CMS/Calo/plugins/HcalTestNumberingTest.cc
+++ b/SimG4CMS/Calo/plugins/HcalTestNumberingTest.cc
@@ -45,7 +45,8 @@
 class HcalTestNumberingTester : public edm::one::EDAnalyzer<> {
 public:
   explicit HcalTestNumberingTester(const edm::ParameterSet&);
-  ~HcalTestNumberingTester() override;
+  ~HcalTestNumberingTester() override = default;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
@@ -60,7 +61,10 @@ HcalTestNumberingTester::HcalTestNumberingTester(const edm::ParameterSet&)
     : tokSim_(esConsumes<HcalDDDSimConstants, HcalSimNumberingRecord>()),
       tokReco_(esConsumes<HcalDDDRecConstants, HcalRecNumberingRecord>()) {}
 
-HcalTestNumberingTester::~HcalTestNumberingTester() {}
+void HcalTestNumberingTester::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  descriptions.add("hcalTestNumberingTest", desc);
+}
 
 // ------------ method called to produce the data  ------------
 void HcalTestNumberingTester::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {

--- a/SimG4CMS/Calo/test/python/runHcalTestNumberingTester_cfg.py
+++ b/SimG4CMS/Calo/test/python/runHcalTestNumberingTester_cfg.py
@@ -13,9 +13,9 @@ process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
     )
 
-process.hpa = cms.EDAnalyzer("HcalTestNumberingTester")
+process.load('SimG4CMS.Calo.hcalTestNumberingTest_cfi')
 
 process.Timing = cms.Service("Timing")
 process.SimpleMemoryCheck = cms.Service("SimpleMemoryCheck")
 
-process.p1 = cms.Path(process.hpa)
+process.p1 = cms.Path(process.hcalTestNumberingTest)

--- a/SimG4CMS/ShowerLibraryProducer/interface/HcalForwardLibWriter.h
+++ b/SimG4CMS/ShowerLibraryProducer/interface/HcalForwardLibWriter.h
@@ -32,7 +32,8 @@ public:
     int momentum;
   };
   explicit HcalForwardLibWriter(const edm::ParameterSet&);
-  ~HcalForwardLibWriter() override;
+  ~HcalForwardLibWriter() override = default;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
   void beginJob() override;
@@ -53,7 +54,6 @@ private:
   TBranch* emBranch;
   TBranch* hadBranch;
 
-  edm::Service<TFileService> fs;
   std::string theDataFile;
   std::vector<FileHandle> theFileHandle;
 

--- a/SimG4CMS/ShowerLibraryProducer/plugins/HcalForwardAnalysis.cc
+++ b/SimG4CMS/ShowerLibraryProducer/plugins/HcalForwardAnalysis.cc
@@ -77,7 +77,6 @@ private:
   void parseDetId(int id, int& tower, int& cell, int& fiber);
   void clear();
 
-  edm::Service<TFileService> theFile;
   TTree* theTree;
   int theEventCounter;
   int count;
@@ -124,6 +123,7 @@ void HcalForwardAnalysis::produce(edm::Event& iEvent, const edm::EventSetup&) {
 }
 
 void HcalForwardAnalysis::init() {
+  edm::Service<TFileService> theFile;
   theTree = theFile->make<TTree>("CherenkovPhotons", "Cherenkov Photons");
   theTree->Branch("nphot", &nphot, "nphot/I");
   theTree->Branch("x", &x, "x[nphot]/F");

--- a/SimG4CMS/ShowerLibraryProducer/plugins/HcalForwardLibWriter.cc
+++ b/SimG4CMS/ShowerLibraryProducer/plugins/HcalForwardLibWriter.cc
@@ -4,7 +4,7 @@
 #include "TTree.h"
 
 HcalForwardLibWriter::HcalForwardLibWriter(const edm::ParameterSet& iConfig) {
-  edm::ParameterSet theParms = iConfig.getParameter<edm::ParameterSet>("HcalForwardLibWriterParameters");
+  edm::ParameterSet theParms = iConfig.getParameter<edm::ParameterSet>("hcalForwardLibWriterParameters");
   edm::FileInPath fp = theParms.getParameter<edm::FileInPath>("FileName");
   nbins = theParms.getParameter<int>("Nbins");
   nshowers = theParms.getParameter<int>("Nshowers");
@@ -19,6 +19,7 @@ HcalForwardLibWriter::HcalForwardLibWriter(const edm::ParameterSet& iConfig) {
   theDataFile = pName;
   readUserData();
 
+  edm::Service<TFileService> fs;
   fs->file().cd();
   fs->file().SetCompressionAlgorithm(compressionAlgo);
   fs->file().SetCompressionLevel(compressionLevel);
@@ -31,7 +32,17 @@ HcalForwardLibWriter::HcalForwardLibWriter(const edm::ParameterSet& iConfig) {
   hadBranch = LibTree->Branch("hadParticles", "HFShowerPhotons-hadParticles", &hadColl, bsize, splitlevel);
 }
 
-HcalForwardLibWriter::~HcalForwardLibWriter() {}
+void HcalForwardLibWriter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::FileInPath>("FileName", edm::FileInPath("SimG4CMS/ShowerLibraryProducer/data/fileList.txt"));
+  desc.add<int>("Nbins", 16);
+  desc.add<int>("Nshowers", 10000);
+  desc.add<int>("BufSize", 1);
+  desc.add<int>("SplitLevel", 2);
+  desc.add<int>("CompressionAlgo", 4);
+  desc.add<int>("CompressionLevel", 4);
+  descriptions.add("hcalForwardLibWriterParameters", desc);
+}
 
 void HcalForwardLibWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // Event info
@@ -137,6 +148,7 @@ void HcalForwardLibWriter::analyze(const edm::Event& iEvent, const edm::EventSet
 void HcalForwardLibWriter::beginJob() {}
 
 void HcalForwardLibWriter::endJob() {
+  edm::Service<TFileService> fs;
   fs->file().cd();
   LibTree->Write();
   LibTree->Print();
@@ -166,5 +178,6 @@ int HcalForwardLibWriter::readUserData(void) {
   }
   return k;
 }
+
 //define this as a plug-in
 DEFINE_FWK_MODULE(HcalForwardLibWriter);

--- a/SimG4CMS/ShowerLibraryProducer/python/writelibraryfile_cfg.py
+++ b/SimG4CMS/ShowerLibraryProducer/python/writelibraryfile_cfg.py
@@ -10,7 +10,7 @@ process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1))
 process.TFileService = cms.Service("TFileService",fileName = cms.string('HFShowerLibrary.root') )
 
 process.photon = cms.EDAnalyzer('HcalForwardLibWriter',
-    HcalForwardLibWriterParameters = cms.PSet(
+    hcalForwardLibWriterParameters = cms.PSet(
 	FileName = cms.FileInPath('SimG4CMS/ShowerLibraryProducer/data/fileList.txt'),
 	Nbins = cms.int32(16),
 	Nshowers = cms.int32(10000),

--- a/SimG4CMS/ShowerLibraryProducer/test/AnalyzeTuples.cc
+++ b/SimG4CMS/ShowerLibraryProducer/test/AnalyzeTuples.cc
@@ -60,7 +60,6 @@ private:
   std::vector<double> pmom;
   std::vector<HFShowerPhoton> photon;
 
-  edm::Service<TFileService> fs;
   TH1I* hNPELongElec[12];
   TH1I* hNPEShortElec[12];
   TH1I* hNPELongPion[12];
@@ -177,6 +176,7 @@ void AnalyzeTuples::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
 }
 
 void AnalyzeTuples::beginJob() {
+  edm::Service<TFileService> fs;
   TFileDirectory HFDir = fs->mkdir("HF");
   char title[128];
   for (int i = 0; i < int(pmom.size()); ++i) {


### PR DESCRIPTION
#### PR description:

Move FileService variable in the code rather than as a class member and use fillDescription in SimG4CMS/ShowerLibraryProducer and SimG4CMS/Calo

#### PR validation:

Use runTheMatrix test workflows and cfg's in the test area

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special