### PR TITLE
Phase2-hgx297B Move FileService variable in the code rather than as a class member for Validation/HGCalValidation

### DIFF
--- a/Validation/HGCalValidation/test/FTSimHitTest.cc
+++ b/Validation/HGCalValidation/test/FTSimHitTest.cc
@@ -46,7 +46,6 @@ protected:
   void plotHits(const edm::Handle<edm::PSimHitContainer>&, const int);
 
 private:
-  edm::Service<TFileService> fs_;
   const std::string g4Label_, barrelHit_, endcapHit_;
   const edm::ESGetToken<FastTimeDDDConstants, IdealGeometryRecord> tok_ftg_;
   const FastTimeDDDConstants* ftcons_;
@@ -83,22 +82,23 @@ void FTSimHitTest::beginRun(edm::Run const&, edm::EventSetup const& es) {
   //Histograms for Sim Hits
   std::string detector[2] = {"Barrel", "Endcap"};
   char name[80], title[120];
+  edm::Service<TFileService> fs;
   for (unsigned int k = 0; k < 2; ++k) {
     sprintf(name, "SimHitEn%d", k);
     sprintf(title, "Sim Hit Energy (%s)", detector[k].c_str());
-    hsimE_[k] = fs_->make<TH1D>(name, title, 1000, 0.0, 1.0);
+    hsimE_[k] = fs->make<TH1D>(name, title, 1000, 0.0, 1.0);
     sprintf(name, "SimHitTm%d", k);
     sprintf(title, "Sim Hit Time (%s)", detector[k].c_str());
-    hsimT_[k] = fs_->make<TH1D>(name, title, 1000, 0.0, 500.0);
+    hsimT_[k] = fs->make<TH1D>(name, title, 1000, 0.0, 500.0);
     sprintf(name, "SimHitOc%d", k);
     sprintf(title, "# Cells with Sim Hit (%s)", detector[k].c_str());
-    hcell_[k] = fs_->make<TH1D>(name, title, 1000, 0.0, 1000.0);
+    hcell_[k] = fs->make<TH1D>(name, title, 1000, 0.0, 1000.0);
     sprintf(name, "SimHitPos%d", k);
     sprintf(title, "Sim Hit Eta(z)-Phi (%s) for +z", detector[k].c_str());
-    hsimP_[k] = fs_->make<TH2D>(name, title, 200, 0, 400.0, 360, 0, 720.0);
+    hsimP_[k] = fs->make<TH2D>(name, title, 200, 0, 400.0, 360, 0, 720.0);
     sprintf(name, "SimHitNeg%d", k);
     sprintf(title, "Sim Hit Eta(z)-Phi (%s) for -z", detector[k].c_str());
-    hsimM_[k] = fs_->make<TH2D>(name, title, 200, 0, 400.0, 360, 0, 720.0);
+    hsimM_[k] = fs->make<TH2D>(name, title, 200, 0, 400.0, 360, 0, 720.0);
   }
 }
 

--- a/Validation/HGCalValidation/test/HGCalSiliconValidation.cc
+++ b/Validation/HGCalValidation/test/HGCalSiliconValidation.cc
@@ -47,7 +47,6 @@ protected:
   void analyze(edm::Event const&, edm::EventSetup const&) override;
 
 private:
-  edm::Service<TFileService> fs_;
   const std::string g4Label_, nameDetector_, hgcalHits_;
   const edm::InputTag hgcalDigis_;
   const int iSample_;
@@ -90,17 +89,18 @@ void HGCalSiliconValidation::beginRun(edm::Run const&, edm::EventSetup const& es
   edm::LogVerbatim("HGCalValidation") << "HGCalSiliconValidation::Booking the Histograms";
 
   //Histograms for Sim Hits
-  hsimE1_ = fs_->make<TH1D>("SimHitEn1", "Sim Hit Energy", 1000, 0.0, 1.0);
-  hsimE2_ = fs_->make<TH1D>("SimHitEn2", "Sim Hit Energy", 1000, 0.0, 1.0);
-  hsimTm_ = fs_->make<TH1D>("SimHitTime", "Sim Hit Time", 1000, 0.0, 500.0);
-  hsimLn_ = fs_->make<TH1D>("SimHitLong", "Sim Hit Long. Profile", 60, 0.0, 30.0);
-  hsimOc_ = fs_->make<TH2D>("SimHitOccup", "Sim Hit Occupnacy", 300, 0.0, 300.0, 60, 0.0, 30.0);
-  hsi2Oc_ = fs_->make<TH2D>("SimHitOccu2", "Sim Hit Occupnacy", 300, 300.0, 600.0, 300, 0.0, 300.0);
+  edm::Service<TFileService> fs;
+  hsimE1_ = fs->make<TH1D>("SimHitEn1", "Sim Hit Energy", 1000, 0.0, 1.0);
+  hsimE2_ = fs->make<TH1D>("SimHitEn2", "Sim Hit Energy", 1000, 0.0, 1.0);
+  hsimTm_ = fs->make<TH1D>("SimHitTime", "Sim Hit Time", 1000, 0.0, 500.0);
+  hsimLn_ = fs->make<TH1D>("SimHitLong", "Sim Hit Long. Profile", 60, 0.0, 30.0);
+  hsimOc_ = fs->make<TH2D>("SimHitOccup", "Sim Hit Occupnacy", 300, 0.0, 300.0, 60, 0.0, 30.0);
+  hsi2Oc_ = fs->make<TH2D>("SimHitOccu2", "Sim Hit Occupnacy", 300, 300.0, 600.0, 300, 0.0, 300.0);
   //Histograms for Digis
-  hdigEn_ = fs_->make<TH1D>("DigiEnergy", "Digi ADC Sample", 1000, 0.0, 1000.0);
-  hdigLn_ = fs_->make<TH1D>("DigiLong", "Digi Long. Profile", 60, 0.0, 30.0);
-  hdigOc_ = fs_->make<TH2D>("DigiOccup", "Digi Occupnacy", 300, 0.0, 300.0, 60, 0.0, 30.0);
-  hdi2Oc_ = fs_->make<TH2D>("DigiOccu2", "Digi Occupnacy", 300, 300.0, 600.0, 300, 0.0, 300.0);
+  hdigEn_ = fs->make<TH1D>("DigiEnergy", "Digi ADC Sample", 1000, 0.0, 1000.0);
+  hdigLn_ = fs->make<TH1D>("DigiLong", "Digi Long. Profile", 60, 0.0, 30.0);
+  hdigOc_ = fs->make<TH2D>("DigiOccup", "Digi Occupnacy", 300, 0.0, 300.0, 60, 0.0, 30.0);
+  hdi2Oc_ = fs->make<TH2D>("DigiOccu2", "Digi Occupnacy", 300, 300.0, 600.0, 300, 0.0, 300.0);
 }
 
 void HGCalSiliconValidation::analyze(const edm::Event& e, const edm::EventSetup& iSetup) {


### PR DESCRIPTION
#### PR description:

Move FileService variable in the code rather than as a class member for Validation/HGCalValidation

#### PR validation:

Use the runTheMatrix test workflows

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special