### PR TITLE
HGCalWaferValidation: refinements and D86 geometry validation fix

### DIFF
--- a/Validation/HGCalValidation/plugins/HGCalWaferValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCalWaferValidation.cc
@@ -21,13 +21,23 @@
 // Original Author:  Imran Yusuff
 //         Created:  Thu, 27 May 2021 19:47:08 GMT
 //
-// Modified by: Yulun Miao
-// Modified at: Wed, 17 Nov 2021 21:04:10 UTC
+// Additional Author(s): Yulun Miao
 /*
- Details of Modification:
-     * Use the l or h preceding the thickness to determine the type of flat file
-     * Unified partial wafer information to HGCalTypes.h to allow cross-compare
+  Changelog:
+
+    Wed, 17 Nov 2021 21:04:10 UTC by Yulun Miao:
+
+      * Use the l or h preceding the thickness to determine the type of flat file
+      * Unified partial wafer information to HGCalTypes.h to allow cross-compare
+
+    Tue, 14 Dmr 2021 by Imran Yusuff:
+
+      * Further tidying the code
+      * Now uses the first line of the flat file to determine flat file type (single number means new format)
+      * Separate out shape and rotation matching operation into functions
+      * Fixed validation for D86 geometry (especially in rotation for type-3 layers)
 */
+
 // system include files
 #include <memory>
 
@@ -78,6 +88,8 @@ private:
   bool DDFindHGCal(DDCompactView::GraphWalker& walker, std::string targetName);
   void DDFindWafers(DDCompactView::GraphWalker& walker);
   void ProcessWaferLayer(DDCompactView::GraphWalker& walker);
+  bool isThicknessMatched(const int geoThickClass, const int fileThickness);
+  bool isRotationMatched(const bool isNewFile, const int layer, const int fileShapeCode, const int geoRotCode, const int fileRotCode);
 
   void beginJob() override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
@@ -87,6 +99,10 @@ private:
   // module parameters
   edm::FileInPath geometryFileName_;
 
+  // information from newer flat file header
+  unsigned int layerCount_;
+  std::vector<int> layerTypes_;
+
   // struct to hold wafer information from DD in map
   struct WaferInfo {
     int thickClass;
@@ -94,16 +110,17 @@ private:
     double y;
     int shapeCode;
     int rotCode;
+    std::string waferName;  // TEMPORARY
   };
 
   // EDM token to access DD
   edm::ESGetToken<DDCompactView, IdealGeometryRecord> viewToken_;
 
   // map holding all wafer properties from DD
-  std::map<WaferCoord, struct WaferInfo> waferData;
+  std::map<WaferCoord, struct WaferInfo> waferData_;
 
   // boolean map to keep track of unaccounted DD wafers (not in flat file)
-  std::map<WaferCoord, bool> waferValidated;
+  std::map<WaferCoord, bool> waferValidated_;
 };
 
 //
@@ -182,6 +199,7 @@ void HGCalWaferValidation::ProcessWaferLayer(DDCompactView::GraphWalker& walker)
     if (walker.current().first.name().fullname().rfind("hgcalwafer:", 0) == 0) {
       auto wafer = walker.current();
       const std::string waferName(walker.current().first.name().fullname());
+      //edm::LogVerbatim(logcat) << "  " << waferName; // DEBUG: in case wafer name info is needed
       const int copyNo = wafer.second->copyno();
       // extract DD layer properties
       const int waferType = HGCalTypes::getUnpackedType(copyNo);
@@ -190,6 +208,7 @@ void HGCalWaferValidation::ProcessWaferLayer(DDCompactView::GraphWalker& walker)
       const WaferCoord waferCoord(waferLayer, waferU, waferV);  // map index
       // build struct of DD wafer properties
       struct WaferInfo waferInfo;
+      waferInfo.waferName = waferName;  //TEMPORARY
       waferInfo.thickClass = waferType;
       waferInfo.x = wafer.second->translation().x();
       waferInfo.y = wafer.second->translation().y();
@@ -213,34 +232,48 @@ void HGCalWaferValidation::ProcessWaferLayer(DDCompactView::GraphWalker& walker)
       //edm::LogVerbatim(logcat) << "rotStr " << rotStr << " rotCode " << rotCode;
 
       // convert shape code to wafer types defined in HGCalTypes.h
-      waferInfo.shapeCode = HGCalTypes::WaferPartialType::WaferOut;
-      if (shapeStr == "F")
-        waferInfo.shapeCode = HGCalTypes::WaferPartialType::WaferFull;
-      else if (shapeStr == "a")
-        waferInfo.shapeCode = HGCalTypes::WaferPartialType::WaferHalf;
-      else if (shapeStr == "am")
-        waferInfo.shapeCode = HGCalTypes::WaferPartialType::WaferHalf2;
-      else if (shapeStr == "b")
-        waferInfo.shapeCode = HGCalTypes::WaferPartialType::WaferFive;
-      else if (shapeStr == "bm")
-        waferInfo.shapeCode = HGCalTypes::WaferPartialType::WaferFive2;
-      else if (shapeStr == "c")
-        waferInfo.shapeCode = HGCalTypes::WaferPartialType::WaferThree;
-      else if (shapeStr == "d")
-        waferInfo.shapeCode = HGCalTypes::WaferPartialType::WaferSemi;
-      else if (shapeStr == "dm")
-        waferInfo.shapeCode = HGCalTypes::WaferPartialType::WaferSemi2;
-      else if (shapeStr == "g")
-        waferInfo.shapeCode = HGCalTypes::WaferPartialType::WaferChopTwo;
-      else if (shapeStr == "gm")
-        waferInfo.shapeCode = HGCalTypes::WaferPartialType::WaferChopTwoM;
+      waferInfo.shapeCode =
+        shapeStr == "F"  ? HGCalTypes::WaferPartialType::WaferFull     :
+        shapeStr == "a"  ? HGCalTypes::WaferPartialType::WaferHalf     :
+        shapeStr == "am" ? HGCalTypes::WaferPartialType::WaferHalf2    :
+        shapeStr == "b"  ? HGCalTypes::WaferPartialType::WaferFive     :
+        shapeStr == "bm" ? HGCalTypes::WaferPartialType::WaferFive2    :
+        shapeStr == "c"  ? HGCalTypes::WaferPartialType::WaferThree    :
+        shapeStr == "d"  ? HGCalTypes::WaferPartialType::WaferSemi     :
+        shapeStr == "dm" ? HGCalTypes::WaferPartialType::WaferSemi2    :
+        shapeStr == "g"  ? HGCalTypes::WaferPartialType::WaferChopTwo  :
+        shapeStr == "gm" ? HGCalTypes::WaferPartialType::WaferChopTwoM :
+                           HGCalTypes::WaferPartialType::WaferOut;
 
       waferInfo.rotCode = rotCode;
       // populate the map
-      waferData[waferCoord] = waferInfo;
-      waferValidated[waferCoord] = false;
+      waferData_[waferCoord] = waferInfo;
+      waferValidated_[waferCoord] = false;
     }
   } while (walker.nextSibling());
+}
+
+// ------------ check if wafer thickness in geo matches in file (true = is a match) ------------
+bool HGCalWaferValidation::isThicknessMatched(const int geoThickClass, const int fileThickness) {
+  if (geoThickClass == 0 && fileThickness == 120) return true;
+  if (geoThickClass == 1 && fileThickness == 200) return true;
+  if (geoThickClass == 2 && fileThickness == 300) return true;
+  return false;
+}
+
+// ------------ check if wafer rotation in geo matches in file (true = is a match) ------------
+bool HGCalWaferValidation::isRotationMatched(const bool isNewFile, const int layer, const int fileShapeCode, const int geoRotCode, const int fileRotCode) {
+  if (fileShapeCode != HGCalTypes::WaferPartialType::WaferFull && geoRotCode == fileRotCode)
+    return true;
+  if (fileShapeCode == HGCalTypes::WaferPartialType::WaferFull) {
+    if (isNewFile && layerTypes_[layer-1] == 3) {    // this array is index-0 based
+      if ((geoRotCode+1) % 2 == fileRotCode % 2) return true;
+    }
+    else {
+      if (geoRotCode % 2 == fileRotCode % 2) return true;
+    }
+  }
+  return false;
 }
 
 // ------------ method called for each event  ------------
@@ -313,7 +346,7 @@ void HGCalWaferValidation::analyze(const edm::Event& iEvent, const edm::EventSet
   DDFindWafers(hemixWalker);
 
   // Confirm all the DD wafers have been read
-  edm::LogVerbatim(logcat) << "Number of wafers read from DD: " << waferData.size();
+  edm::LogVerbatim(logcat) << "Number of wafers read from DD: " << waferData_.size();
 
   // Now open the geometry text file
   std::string fileName = geometryFileName_.fullPath();
@@ -339,6 +372,40 @@ void HGCalWaferValidation::analyze(const edm::Event& iEvent, const edm::EventSet
 
   std::string buf;
 
+  // find out if this file is an old file or a new file
+  std::getline(geoTxtFile, buf);
+  std::stringstream ss(buf);
+  std::vector<std::string> first_tokens;
+  while (ss >> buf)
+    if (!buf.empty())
+      first_tokens.push_back(buf);
+
+  const bool isNewFile(first_tokens.size() == 1);
+
+  if (isNewFile) {
+    edm::LogVerbatim(logcat) << "Text file is of newer version.";
+    layerCount_ = std::stoi(buf);
+    std::getline(geoTxtFile, buf);
+    std::stringstream layerTypesSS(buf);
+    while (layerTypesSS >> buf)
+      if (!buf.empty())
+        layerTypes_.push_back(std::stoi(buf));
+    if (layerTypes_.size() != layerCount_)
+      edm::LogWarning(logcat) << "Number of layer types does not tally with layer count.";
+
+    // TEMP: make sure reading is correct
+    edm::LogVerbatim(logcat) << "layerCount = " << layerCount_;
+    for (unsigned i=0; i<layerTypes_.size(); i++) {
+      edm::LogVerbatim(logcat) << "  layerType " << i+1 << " = " << layerTypes_[i];   // 1-based
+    }
+  }
+  else {
+    layerCount_ = 0;
+    // rewind back
+    geoTxtFile.clear();
+    geoTxtFile.seekg(0);
+  }
+
   // process each line on the text file
   while (std::getline(geoTxtFile, buf)) {
     std::stringstream ss(buf);
@@ -351,101 +418,69 @@ void HGCalWaferValidation::analyze(const edm::Event& iEvent, const edm::EventSet
 
     nTotalProcessed++;
 
-    int waferLayer;
-    std::string waferShapeStr;
-    std::string waferDensityStr;
-    int waferThickness;
-    double waferX;
-    double waferY;
-    int waferRotCode;
-    int waferU;
-    int waferV;
-    int waferShapeCode;
     // extract wafer info from a textfile line
-    if (tokens[2].substr(0, 1) == "l" || tokens[2].substr(0, 1) == "h") {
-      //if using new format flat file
-      waferLayer = std::stoi(tokens[0]);
-      waferShapeStr = tokens[1];
-      waferDensityStr = tokens[2].substr(0, 1);
-      waferThickness = std::stoi(tokens[2].substr(1));
-      waferX = std::stod(tokens[3]);
-      waferY = std::stod(tokens[4]);
-      waferRotCode = std::stoi(tokens[5]);
-      waferU = std::stoi(tokens[6]);
-      waferV = std::stoi(tokens[7]);
-      waferShapeCode = HGCalTypes::WaferPartialType::WaferOut;
-      if (waferDensityStr == "l") {
-        if (waferShapeStr == "0")
-          waferShapeCode = HGCalTypes::WaferPartialType::WaferFull;
-        else if (waferShapeStr == "1" || waferShapeStr == "2")
-          waferShapeCode = HGCalTypes::WaferPartialType::WaferHalf;
-        else if (waferShapeStr == "3" || waferShapeStr == "4")
-          waferShapeCode = HGCalTypes::WaferPartialType::WaferSemi;
-        else if (waferShapeStr == "5")
-          waferShapeCode = HGCalTypes::WaferPartialType::WaferFive;
-        else if (waferShapeStr == "6")
-          waferShapeCode = HGCalTypes::WaferPartialType::WaferThree;
-      } else if (waferDensityStr == "h") {
-        if (waferShapeStr == "0")
-          waferShapeCode = HGCalTypes::WaferPartialType::WaferFull;
-        else if (waferShapeStr == "1")
-          waferShapeCode = HGCalTypes::WaferPartialType::WaferHalf2;
-        else if (waferShapeStr == "2")
-          waferShapeCode = HGCalTypes::WaferPartialType::WaferChopTwoM;
-        else if (waferShapeStr == "3" || waferShapeStr == "4")
-          waferShapeCode = HGCalTypes::WaferPartialType::WaferSemi2;
-        else if (waferShapeStr == "5")
-          waferShapeCode = HGCalTypes::WaferPartialType::WaferFive2;
-      }
-    } else {
-      //if using old format flat file
-      waferLayer = std::stoi(tokens[0]);
-      waferShapeStr = tokens[1];
-      waferThickness = std::stoi(tokens[2]);
-      waferX = std::stod(tokens[3]);
-      waferY = std::stod(tokens[4]);
-      waferRotCode = (std::stoi(tokens[5]));
-      waferU = std::stoi(tokens[6]);
-      waferV = std::stoi(tokens[7]);
-      waferShapeCode = HGCalTypes::WaferPartialType::WaferOut;
-      if (waferShapeStr == "F")
-        waferShapeCode = HGCalTypes::WaferPartialType::WaferFull;
-      else if (waferShapeStr == "a")
-        waferShapeCode = HGCalTypes::WaferPartialType::WaferHalf;
-      else if (waferShapeStr == "am")
-        waferShapeCode = HGCalTypes::WaferPartialType::WaferHalf2;
-      else if (waferShapeStr == "b")
-        waferShapeCode = HGCalTypes::WaferPartialType::WaferFive;
-      else if (waferShapeStr == "bm")
-        waferShapeCode = HGCalTypes::WaferPartialType::WaferFive2;
-      else if (waferShapeStr == "c")
-        waferShapeCode = HGCalTypes::WaferPartialType::WaferThree;
-      else if (waferShapeStr == "d")
-        waferShapeCode = HGCalTypes::WaferPartialType::WaferSemi;
-      else if (waferShapeStr == "dm")
-        waferShapeCode = HGCalTypes::WaferPartialType::WaferSemi2;
-      else if (waferShapeStr == "g")
-        waferShapeCode = HGCalTypes::WaferPartialType::WaferChopTwo;
-      else if (waferShapeStr == "gm")
-        waferShapeCode = HGCalTypes::WaferPartialType::WaferChopTwoM;
-    }
+    const int waferLayer(std::stoi(tokens[0]));
+    const std::string waferShapeStr(tokens[1]);
+    const std::string waferDensityStr(isNewFile ? tokens[2].substr(0, 1) : "");
+    const int waferThickness(isNewFile ? std::stoi(tokens[2].substr(1)) : std::stoi(tokens[2]));
+    const double waferX(std::stod(tokens[3]));
+    const double waferY(std::stod(tokens[4]));
+    const int waferRotCode(std::stoi(tokens[5]));
+    const int waferU(std::stoi(tokens[6]));
+    const int waferV(std::stoi(tokens[7]));
+    const int waferShapeCode(
+      isNewFile ? (
+        // if using new format flat file
+        waferDensityStr == "l" ? (
+          waferShapeStr == "0" ? HGCalTypes::WaferPartialType::WaferFull  :
+          waferShapeStr == "1" ? HGCalTypes::WaferPartialType::WaferHalf  :
+          waferShapeStr == "2" ? HGCalTypes::WaferPartialType::WaferHalf  :
+          waferShapeStr == "3" ? HGCalTypes::WaferPartialType::WaferSemi  :
+          waferShapeStr == "4" ? HGCalTypes::WaferPartialType::WaferSemi  :
+          waferShapeStr == "5" ? HGCalTypes::WaferPartialType::WaferFive  :
+          waferShapeStr == "6" ? HGCalTypes::WaferPartialType::WaferThree :
+                                 HGCalTypes::WaferPartialType::WaferOut
+        ) :
+        waferDensityStr == "h" ? (
+          waferShapeStr == "0" ? HGCalTypes::WaferPartialType::WaferFull     :
+          waferShapeStr == "1" ? HGCalTypes::WaferPartialType::WaferHalf2    :
+          waferShapeStr == "2" ? HGCalTypes::WaferPartialType::WaferChopTwoM :
+          waferShapeStr == "3" ? HGCalTypes::WaferPartialType::WaferSemi2    :
+          waferShapeStr == "4" ? HGCalTypes::WaferPartialType::WaferSemi2    :
+          waferShapeStr == "5" ? HGCalTypes::WaferPartialType::WaferFive2    :
+                                 HGCalTypes::WaferPartialType::WaferOut
+        ) :                      HGCalTypes::WaferPartialType::WaferOut
+      ) : (
+        // if using old format flat file
+        waferShapeStr == "F"  ? HGCalTypes::WaferPartialType::WaferFull     :
+        waferShapeStr == "a"  ? HGCalTypes::WaferPartialType::WaferHalf     :
+        waferShapeStr == "am" ? HGCalTypes::WaferPartialType::WaferHalf2    :
+        waferShapeStr == "b"  ? HGCalTypes::WaferPartialType::WaferFive     :
+        waferShapeStr == "bm" ? HGCalTypes::WaferPartialType::WaferFive2    :
+        waferShapeStr == "c"  ? HGCalTypes::WaferPartialType::WaferThree    :
+        waferShapeStr == "d"  ? HGCalTypes::WaferPartialType::WaferSemi     :
+        waferShapeStr == "dm" ? HGCalTypes::WaferPartialType::WaferSemi2    :
+        waferShapeStr == "g"  ? HGCalTypes::WaferPartialType::WaferChopTwo  :
+        waferShapeStr == "gm" ? HGCalTypes::WaferPartialType::WaferChopTwoM :
+                                HGCalTypes::WaferPartialType::WaferOut
+      )
+    );
 
     // map index for crosschecking with DD
     const WaferCoord waferCoord(waferLayer, waferU, waferV);
 
     // now check for (and report) wafer data disagreements
 
-    if (waferData.find(waferCoord) == waferData.end()) {
+    if (waferData_.find(waferCoord) == waferData_.end()) {
       nMissing++;
       edm::LogVerbatim(logcat) << "MISSING: " << strWaferCoord(waferCoord);
       continue;
     }
 
-    const struct WaferInfo waferInfo = waferData[waferCoord];
-    waferValidated[waferCoord] = true;
+    const struct WaferInfo waferInfo = waferData_[waferCoord];
+    waferValidated_[waferCoord] = true;
 
-    if ((waferInfo.thickClass == 0 && waferThickness != 120) || (waferInfo.thickClass == 1 && waferThickness != 200) ||
-        (waferInfo.thickClass == 2 && waferThickness != 300)) {
+    if (!isThicknessMatched(waferInfo.thickClass, waferThickness)) {
       nThicknessError++;
       edm::LogVerbatim(logcat) << "THICKNESS ERROR: " << strWaferCoord(waferCoord);
     }
@@ -463,21 +498,20 @@ void HGCalWaferValidation::analyze(const edm::Event& iEvent, const edm::EventSet
 
     if (waferInfo.shapeCode != waferShapeCode || waferShapeCode == HGCalTypes::WaferPartialType::WaferOut) {
       nShapeError++;
-      edm::LogVerbatim(logcat) << "SHAPE ERROR: " << strWaferCoord(waferCoord);
+      edm::LogVerbatim(logcat) << "SHAPE ERROR: " << strWaferCoord(waferCoord) << "  ( " << waferInfo.shapeCode << " != " << waferDensityStr << waferShapeCode << " )  name=" << waferInfo.waferName;
     }
 
-    if ((waferShapeCode != HGCalTypes::WaferPartialType::WaferFull && waferInfo.rotCode != waferRotCode) ||
-        (waferShapeCode == HGCalTypes::WaferPartialType::WaferFull && (waferInfo.rotCode % 2 != waferRotCode % 2))) {
+    if (!isRotationMatched(isNewFile, std::get<0>(waferCoord), waferShapeCode, waferInfo.rotCode, waferRotCode)) {
       nRotError++;
       edm::LogVerbatim(logcat) << "ROTATION ERROR: " << strWaferCoord(waferCoord) << "  ( " << waferInfo.rotCode
-                               << " != " << waferRotCode << " )";
+                               << " != " << waferRotCode << " (" << waferShapeCode << ") )  name=" << waferInfo.waferName;
     }
   }
 
   geoTxtFile.close();
 
   // Find unaccounted DD wafers
-  for (auto const& accounted : waferValidated) {
+  for (auto const& accounted : waferValidated_) {
     if (!accounted.second) {
       nUnaccounted++;
       edm::LogVerbatim(logcat) << "UNACCOUNTED: " << strWaferCoord(accounted.first);

--- a/Validation/HGCalValidation/plugins/HGCalWaferValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCalWaferValidation.cc
@@ -89,7 +89,8 @@ private:
   void DDFindWafers(DDCompactView::GraphWalker& walker);
   void ProcessWaferLayer(DDCompactView::GraphWalker& walker);
   bool isThicknessMatched(const int geoThickClass, const int fileThickness);
-  bool isRotationMatched(const bool isNewFile, const int layer, const int fileShapeCode, const int geoRotCode, const int fileRotCode);
+  bool isRotationMatched(
+      const bool isNewFile, const int layer, const int fileShapeCode, const int geoRotCode, const int fileRotCode);
 
   void beginJob() override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
@@ -232,18 +233,17 @@ void HGCalWaferValidation::ProcessWaferLayer(DDCompactView::GraphWalker& walker)
       //edm::LogVerbatim(logcat) << "rotStr " << rotStr << " rotCode " << rotCode;
 
       // convert shape code to wafer types defined in HGCalTypes.h
-      waferInfo.shapeCode =
-        shapeStr == "F"  ? HGCalTypes::WaferPartialType::WaferFull     :
-        shapeStr == "a"  ? HGCalTypes::WaferPartialType::WaferHalf     :
-        shapeStr == "am" ? HGCalTypes::WaferPartialType::WaferHalf2    :
-        shapeStr == "b"  ? HGCalTypes::WaferPartialType::WaferFive     :
-        shapeStr == "bm" ? HGCalTypes::WaferPartialType::WaferFive2    :
-        shapeStr == "c"  ? HGCalTypes::WaferPartialType::WaferThree    :
-        shapeStr == "d"  ? HGCalTypes::WaferPartialType::WaferSemi     :
-        shapeStr == "dm" ? HGCalTypes::WaferPartialType::WaferSemi2    :
-        shapeStr == "g"  ? HGCalTypes::WaferPartialType::WaferChopTwo  :
-        shapeStr == "gm" ? HGCalTypes::WaferPartialType::WaferChopTwoM :
-                           HGCalTypes::WaferPartialType::WaferOut;
+      waferInfo.shapeCode = shapeStr == "F"    ? HGCalTypes::WaferPartialType::WaferFull
+                            : shapeStr == "a"  ? HGCalTypes::WaferPartialType::WaferHalf
+                            : shapeStr == "am" ? HGCalTypes::WaferPartialType::WaferHalf2
+                            : shapeStr == "b"  ? HGCalTypes::WaferPartialType::WaferFive
+                            : shapeStr == "bm" ? HGCalTypes::WaferPartialType::WaferFive2
+                            : shapeStr == "c"  ? HGCalTypes::WaferPartialType::WaferThree
+                            : shapeStr == "d"  ? HGCalTypes::WaferPartialType::WaferSemi
+                            : shapeStr == "dm" ? HGCalTypes::WaferPartialType::WaferSemi2
+                            : shapeStr == "g"  ? HGCalTypes::WaferPartialType::WaferChopTwo
+                            : shapeStr == "gm" ? HGCalTypes::WaferPartialType::WaferChopTwoM
+                                               : HGCalTypes::WaferPartialType::WaferOut;
 
       waferInfo.rotCode = rotCode;
       // populate the map
@@ -255,22 +255,27 @@ void HGCalWaferValidation::ProcessWaferLayer(DDCompactView::GraphWalker& walker)
 
 // ------------ check if wafer thickness in geo matches in file (true = is a match) ------------
 bool HGCalWaferValidation::isThicknessMatched(const int geoThickClass, const int fileThickness) {
-  if (geoThickClass == 0 && fileThickness == 120) return true;
-  if (geoThickClass == 1 && fileThickness == 200) return true;
-  if (geoThickClass == 2 && fileThickness == 300) return true;
+  if (geoThickClass == 0 && fileThickness == 120)
+    return true;
+  if (geoThickClass == 1 && fileThickness == 200)
+    return true;
+  if (geoThickClass == 2 && fileThickness == 300)
+    return true;
   return false;
 }
 
 // ------------ check if wafer rotation in geo matches in file (true = is a match) ------------
-bool HGCalWaferValidation::isRotationMatched(const bool isNewFile, const int layer, const int fileShapeCode, const int geoRotCode, const int fileRotCode) {
+bool HGCalWaferValidation::isRotationMatched(
+    const bool isNewFile, const int layer, const int fileShapeCode, const int geoRotCode, const int fileRotCode) {
   if (fileShapeCode != HGCalTypes::WaferPartialType::WaferFull && geoRotCode == fileRotCode)
     return true;
   if (fileShapeCode == HGCalTypes::WaferPartialType::WaferFull) {
-    if (isNewFile && layerTypes_[layer-1] == 3) {    // this array is index-0 based
-      if ((geoRotCode+1) % 2 == fileRotCode % 2) return true;
-    }
-    else {
-      if (geoRotCode % 2 == fileRotCode % 2) return true;
+    if (isNewFile && layerTypes_[layer - 1] == 3) {  // this array is index-0 based
+      if ((geoRotCode + 1) % 2 == fileRotCode % 2)
+        return true;
+    } else {
+      if (geoRotCode % 2 == fileRotCode % 2)
+        return true;
     }
   }
   return false;
@@ -395,11 +400,10 @@ void HGCalWaferValidation::analyze(const edm::Event& iEvent, const edm::EventSet
 
     // TEMP: make sure reading is correct
     edm::LogVerbatim(logcat) << "layerCount = " << layerCount_;
-    for (unsigned i=0; i<layerTypes_.size(); i++) {
-      edm::LogVerbatim(logcat) << "  layerType " << i+1 << " = " << layerTypes_[i];   // 1-based
+    for (unsigned i = 0; i < layerTypes_.size(); i++) {
+      edm::LogVerbatim(logcat) << "  layerType " << i + 1 << " = " << layerTypes_[i];  // 1-based
     }
-  }
-  else {
+  } else {
     layerCount_ = 0;
     // rewind back
     geoTxtFile.clear();
@@ -429,42 +433,37 @@ void HGCalWaferValidation::analyze(const edm::Event& iEvent, const edm::EventSet
     const int waferU(std::stoi(tokens[6]));
     const int waferV(std::stoi(tokens[7]));
     const int waferShapeCode(
-      isNewFile ? (
-        // if using new format flat file
-        waferDensityStr == "l" ? (
-          waferShapeStr == "0" ? HGCalTypes::WaferPartialType::WaferFull  :
-          waferShapeStr == "1" ? HGCalTypes::WaferPartialType::WaferHalf  :
-          waferShapeStr == "2" ? HGCalTypes::WaferPartialType::WaferHalf  :
-          waferShapeStr == "3" ? HGCalTypes::WaferPartialType::WaferSemi  :
-          waferShapeStr == "4" ? HGCalTypes::WaferPartialType::WaferSemi  :
-          waferShapeStr == "5" ? HGCalTypes::WaferPartialType::WaferFive  :
-          waferShapeStr == "6" ? HGCalTypes::WaferPartialType::WaferThree :
-                                 HGCalTypes::WaferPartialType::WaferOut
-        ) :
-        waferDensityStr == "h" ? (
-          waferShapeStr == "0" ? HGCalTypes::WaferPartialType::WaferFull     :
-          waferShapeStr == "1" ? HGCalTypes::WaferPartialType::WaferHalf2    :
-          waferShapeStr == "2" ? HGCalTypes::WaferPartialType::WaferChopTwoM :
-          waferShapeStr == "3" ? HGCalTypes::WaferPartialType::WaferSemi2    :
-          waferShapeStr == "4" ? HGCalTypes::WaferPartialType::WaferSemi2    :
-          waferShapeStr == "5" ? HGCalTypes::WaferPartialType::WaferFive2    :
-                                 HGCalTypes::WaferPartialType::WaferOut
-        ) :                      HGCalTypes::WaferPartialType::WaferOut
-      ) : (
-        // if using old format flat file
-        waferShapeStr == "F"  ? HGCalTypes::WaferPartialType::WaferFull     :
-        waferShapeStr == "a"  ? HGCalTypes::WaferPartialType::WaferHalf     :
-        waferShapeStr == "am" ? HGCalTypes::WaferPartialType::WaferHalf2    :
-        waferShapeStr == "b"  ? HGCalTypes::WaferPartialType::WaferFive     :
-        waferShapeStr == "bm" ? HGCalTypes::WaferPartialType::WaferFive2    :
-        waferShapeStr == "c"  ? HGCalTypes::WaferPartialType::WaferThree    :
-        waferShapeStr == "d"  ? HGCalTypes::WaferPartialType::WaferSemi     :
-        waferShapeStr == "dm" ? HGCalTypes::WaferPartialType::WaferSemi2    :
-        waferShapeStr == "g"  ? HGCalTypes::WaferPartialType::WaferChopTwo  :
-        waferShapeStr == "gm" ? HGCalTypes::WaferPartialType::WaferChopTwoM :
-                                HGCalTypes::WaferPartialType::WaferOut
-      )
-    );
+        isNewFile ? (
+                        // if using new format flat file
+                        waferDensityStr == "l"   ? (waferShapeStr == "0"   ? HGCalTypes::WaferPartialType::WaferFull
+                                                    : waferShapeStr == "1" ? HGCalTypes::WaferPartialType::WaferHalf
+                                                    : waferShapeStr == "2" ? HGCalTypes::WaferPartialType::WaferHalf
+                                                    : waferShapeStr == "3" ? HGCalTypes::WaferPartialType::WaferSemi
+                                                    : waferShapeStr == "4" ? HGCalTypes::WaferPartialType::WaferSemi
+                                                    : waferShapeStr == "5" ? HGCalTypes::WaferPartialType::WaferFive
+                                                    : waferShapeStr == "6" ? HGCalTypes::WaferPartialType::WaferThree
+                                                                           : HGCalTypes::WaferPartialType::WaferOut)
+                        : waferDensityStr == "h" ? (waferShapeStr == "0"   ? HGCalTypes::WaferPartialType::WaferFull
+                                                    : waferShapeStr == "1" ? HGCalTypes::WaferPartialType::WaferHalf2
+                                                    : waferShapeStr == "2" ? HGCalTypes::WaferPartialType::WaferChopTwoM
+                                                    : waferShapeStr == "3" ? HGCalTypes::WaferPartialType::WaferSemi2
+                                                    : waferShapeStr == "4" ? HGCalTypes::WaferPartialType::WaferSemi2
+                                                    : waferShapeStr == "5" ? HGCalTypes::WaferPartialType::WaferFive2
+                                                                           : HGCalTypes::WaferPartialType::WaferOut)
+                                                 : HGCalTypes::WaferPartialType::WaferOut)
+                  : (
+                        // if using old format flat file
+                        waferShapeStr == "F"    ? HGCalTypes::WaferPartialType::WaferFull
+                        : waferShapeStr == "a"  ? HGCalTypes::WaferPartialType::WaferHalf
+                        : waferShapeStr == "am" ? HGCalTypes::WaferPartialType::WaferHalf2
+                        : waferShapeStr == "b"  ? HGCalTypes::WaferPartialType::WaferFive
+                        : waferShapeStr == "bm" ? HGCalTypes::WaferPartialType::WaferFive2
+                        : waferShapeStr == "c"  ? HGCalTypes::WaferPartialType::WaferThree
+                        : waferShapeStr == "d"  ? HGCalTypes::WaferPartialType::WaferSemi
+                        : waferShapeStr == "dm" ? HGCalTypes::WaferPartialType::WaferSemi2
+                        : waferShapeStr == "g"  ? HGCalTypes::WaferPartialType::WaferChopTwo
+                        : waferShapeStr == "gm" ? HGCalTypes::WaferPartialType::WaferChopTwoM
+                                                : HGCalTypes::WaferPartialType::WaferOut));
 
     // map index for crosschecking with DD
     const WaferCoord waferCoord(waferLayer, waferU, waferV);
@@ -498,13 +497,15 @@ void HGCalWaferValidation::analyze(const edm::Event& iEvent, const edm::EventSet
 
     if (waferInfo.shapeCode != waferShapeCode || waferShapeCode == HGCalTypes::WaferPartialType::WaferOut) {
       nShapeError++;
-      edm::LogVerbatim(logcat) << "SHAPE ERROR: " << strWaferCoord(waferCoord) << "  ( " << waferInfo.shapeCode << " != " << waferDensityStr << waferShapeCode << " )  name=" << waferInfo.waferName;
+      edm::LogVerbatim(logcat) << "SHAPE ERROR: " << strWaferCoord(waferCoord) << "  ( " << waferInfo.shapeCode
+                               << " != " << waferDensityStr << waferShapeCode << " )  name=" << waferInfo.waferName;
     }
 
     if (!isRotationMatched(isNewFile, std::get<0>(waferCoord), waferShapeCode, waferInfo.rotCode, waferRotCode)) {
       nRotError++;
       edm::LogVerbatim(logcat) << "ROTATION ERROR: " << strWaferCoord(waferCoord) << "  ( " << waferInfo.rotCode
-                               << " != " << waferRotCode << " (" << waferShapeCode << ") )  name=" << waferInfo.waferName;
+                               << " != " << waferRotCode << " (" << waferShapeCode
+                               << ") )  name=" << waferInfo.waferName;
     }
   }
 


### PR DESCRIPTION
#### PR description:

Changelog Tue, 14 Dmr 2021 by Imran Yusuff:

- Further tidying the code
- Now uses the first line of the flat file to determine flat file type (single number means new format)
- Separate out shape and rotation matching operation into functions
- Fixed validation for D86 geometry (especially in rotation for type-3 layers)

#### PR validation:

Now correctly validates wafer with layerType = 3:

```
... snip ...
ROTATION ERROR: (33,12,3)  ( 0 != 5 (0) )  name=hgcalwafer:HGCalHEWafer0Coarse2
ROTATION ERROR: (33,12,9)  ( 0 != 5 (0) )  name=hgcalwafer:HGCalHEWafer0Coarse2
ROTATION ERROR: (33,-3,9)  ( 0 != 5 (0) )  name=hgcalwafer:HGCalHEWafer0Coarse2
ROTATION ERROR: (33,-9,3)  ( 0 != 5 (0) )  name=hgcalwafer:HGCalHEWafer0Coarse2
ROTATION ERROR: (33,-9,-12)  ( 0 != 5 (0) )  name=hgcalwafer:HGCalHEWafer0Coarse2
ROTATION ERROR: (33,-3,-12)  ( 0 != 5 (0) )  name=hgcalwafer:HGCalHEWafer0Coarse2

*** ERROR COUNTS ***
Missing         :  0
Thickness error :  0
Pos-x error     :  0
Pos-y error     :  0
Shape error     :  0
Rotation error  :  6
Unaccounted     :  0

Total wafers processed from geotxtfile = 13545

There are at least one wafer error.
%MSG-i DDCompactViewImpl:  AfterModEndJob 15-Dec-2021 04:28:58 CET EndJob
DDD transient representation has been destructed.
%MSG

```
However, there still remain 6 rotation errors, all on layer number 33.

Testing with D77 and D83 geometries produced unchanged results.

No other bugs found during testing.

 (- Imran -)
