### PR TITLE
limit # events to process in 0T PU workflows to avoid exploding in tracking time

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -3694,6 +3694,11 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                 else:
                     upgradeStepDict[stepNamePU][k]=merge([PUDataSets[k2],upgradeStepDict[stepName][k]])
 
+                ## special case to limit tracking time in 0T relvals
+                if "0T" in stepName:
+                    #print("customizing n. events for",stepName)
+                    upgradeStepDict[stepNamePU][k]=merge([{'-n':1},upgradeStepDict[stepName][k]])
+
             # in case special WF has PU-specific changes: apply *after* basic PU step is created
             specialWF.setupPU(upgradeStepDict, k, upgradeProperties[year][k])
 


### PR DESCRIPTION
#### PR description:

In response to https://github.com/cms-sw/cmssw/issues/36492. Title says it all.

#### PR validation:

```console
$ runTheMatrix.py -nel 11834.24
11834.24 2021PU_0T+TTbar_14TeV_TuneCP5_GenSim+DigiPU+RecoNanoPU+HARVESTNanoPU [1]: cmsDriver.py TTbar_14TeV_TuneCP5_cfi  -s GEN,SIM -n 1 --conditions auto:phase1_2021_realistic_0T --beamspot Run3RoundOptics25ns13TeVLowSigmaZ --datatier GEN-SIM --eventcontent FEVTDEBUG --geometry DB:Extended --era Run3 --magField 0T --relval 9000,100 
                                           [2]: cmsDriver.py step2  -s DIGI:pdigi_valid,L1,DIGI2RAW,HLT:@relval2021 --conditions auto:phase1_2021_realistic_0T --datatier GEN-SIM-DIGI-RAW -n 1 --eventcontent FEVTDEBUGHLT --geometry DB:Extended --era Run3 --magField 0T
                                           [3]: cmsDriver.py step3  -s RAW2DIGI,L1Reco,RECO,RECOSIM,EI,PAT,NANO,VALIDATION:@standardValidation+@miniAODValidation,DQM:@standardDQM+@ExtraHLT+@miniAODDQM+@nanoAODDQM --conditions auto:phase1_2021_realistic_0T --datatier GEN-SIM-RECO,MINIAODSIM,NANOAODSIM,DQMIO -n 1 --eventcontent RECOSIM,MINIAODSIM,NANOEDMAODSIM,DQM --geometry DB:Extended --era Run3 --magField 0T
                                           [4]: cmsDriver.py step4  -s HARVESTING:@standardValidation+@standardDQM+@ExtraHLT+@miniAODValidation+@miniAODDQM+@nanoAODDQM --conditions auto:phase1_2021_realistic_0T --mc  --geometry DB:Extended --scenario pp --filetype DQM --era Run3 -n 1 --magField 0T
```

now 11834.24 has `-n 1` in every step.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
