### PR TITLE
Removed use of tbb::task_arena in EventSetup

### DIFF
--- a/FWCore/Framework/interface/EventSetupImpl.h
+++ b/FWCore/Framework/interface/EventSetupImpl.h
@@ -22,7 +22,6 @@
 #include <map>
 #include <optional>
 #include <vector>
-#include "tbb/task_arena.h"
 
 // user include files
 #include "FWCore/Framework/interface/EventSetupRecordKey.h"
@@ -49,7 +48,6 @@ namespace edm {
   class EventSetupImpl {
   public:
     ~EventSetupImpl();
-    EventSetupImpl() = delete;
     EventSetupImpl(EventSetupImpl const&) = delete;
     EventSetupImpl& operator=(EventSetupImpl const&) = delete;
 
@@ -71,7 +69,6 @@ namespace edm {
 
     bool validRecord(eventsetup::EventSetupRecordKey const& iKey) const;
 
-    tbb::task_arena* taskArena CMS_THREAD_SAFE() const { return taskArena_; }
     ///Only EventSetupProvider allowed to create an EventSetupImpl
     friend class eventsetup::EventSetupProvider;
     friend class eventsetup::EventSetupRecordProvider;
@@ -83,7 +80,7 @@ namespace edm {
     void addRecordImpl(const eventsetup::EventSetupRecordImpl& iRecord);
 
   private:
-    explicit EventSetupImpl(tbb::task_arena*);
+    explicit EventSetupImpl();
 
     void insertRecordImpl(const eventsetup::EventSetupRecordKey&, const eventsetup::EventSetupRecordImpl*);
 
@@ -95,7 +92,6 @@ namespace edm {
     std::vector<eventsetup::EventSetupRecordKey>::const_iterator keysBegin_;
     std::vector<eventsetup::EventSetupRecordKey>::const_iterator keysEnd_;
     std::vector<eventsetup::EventSetupRecordImpl const*> recordImpls_;
-    tbb::task_arena* taskArena_ = nullptr;
   };
 }  // namespace edm
 #endif

--- a/FWCore/Framework/interface/EventSetupProvider.h
+++ b/FWCore/Framework/interface/EventSetupProvider.h
@@ -20,7 +20,6 @@
 
 #include "FWCore/Utilities/interface/propagate_const.h"
 
-#include "tbb/task_arena.h"
 #include <map>
 #include <memory>
 #include <set>
@@ -57,7 +56,6 @@ namespace edm {
       typedef std::map<ComponentDescription, RecordToDataMap> PreferredProviderInfo;
 
       EventSetupProvider(ActivityRegistry const*,
-                         tbb::task_arena*,
                          unsigned subProcessIndex = 0U,
                          PreferredProviderInfo const* iInfo = nullptr);
       EventSetupProvider(EventSetupProvider const&) = delete;
@@ -136,7 +134,6 @@ namespace edm {
       RecordProviders recordProviders_;
 
       ActivityRegistry const* activityRegistry_;
-      tbb::task_arena* taskArena_;
 
       bool mustFinishConfiguration_;
       unsigned subProcessIndex_;

--- a/FWCore/Framework/interface/EventSetupsController.h
+++ b/FWCore/Framework/interface/EventSetupsController.h
@@ -26,7 +26,6 @@
 #include <map>
 #include <memory>
 #include <vector>
-#include "tbb/task_arena.h"
 
 namespace edm {
 
@@ -164,7 +163,6 @@ namespace edm {
       void initializeEventSetupRecordIOVQueues();
 
       // ---------- member data --------------------------------
-      tbb::task_arena taskArena_;
       std::vector<propagate_const<std::shared_ptr<EventSetupProvider>>> providers_;
       NumberOfConcurrentIOVs numberOfConcurrentIOVs_;
 

--- a/FWCore/Framework/src/DataProxy.cc
+++ b/FWCore/Framework/src/DataProxy.cc
@@ -103,18 +103,8 @@ namespace edm {
                                EventSetupImpl const* iEventSetupImpl,
                                ESParentContext const& iParent) const {
       if (!cacheIsValid()) {
-        auto token = ServiceRegistry::instance().presentToken();
-        std::exception_ptr exceptPtr{};
-        iEventSetupImpl->taskArena()->execute([this, &exceptPtr, &iRecord, &iKey, iEventSetupImpl, token, iParent]() {
-          exceptPtr = syncWait([&, this](WaitingTaskHolder&& holder) {
-            prefetchAsync(std::move(holder), iRecord, iKey, iEventSetupImpl, token, iParent);
-          });
-        });
-        cache_ = getAfterPrefetchImpl();
-        cacheIsValid_.store(true, std::memory_order_release);
-        if (exceptPtr) {
-          std::rethrow_exception(exceptPtr);
-        }
+        throw edm::Exception(errors::LogicError) << "DataProxy::get called without first doing prefetch.\nThis should "
+                                                    "not be able to happen.\nPlease contact framework developers";
       }
       return getAfterPrefetch(iRecord, iKey, iTransiently);
     }

--- a/FWCore/Framework/src/EDLooperBase.cc
+++ b/FWCore/Framework/src/EDLooperBase.cc
@@ -31,8 +31,6 @@
 #include "FWCore/Concurrency/interface/include_first_syncWait.h"
 #include "FWCore/Concurrency/interface/WaitingTask.h"
 #include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
-#include "FWCore/Concurrency/interface/WaitingTaskWithArenaHolder.h"
-#include "tbb/global_control.h"
 
 namespace edm {
 
@@ -226,59 +224,13 @@ namespace edm {
       return;
     }
 
-    //Thread case of 1 thread special. The master thread is doing a wait_for_all on the
-    // default tbb arena. It will not process any tasks on the es arena. We need to add a
-    // task that will synchronously do a wait_for_all in the es arena to be sure prefetching
-    // will work.
-
-    if UNLIKELY (tbb::global_control::active_value(tbb::global_control::max_allowed_parallelism) == 1) {
-      auto taskGroup = iTask.group();
-      ServiceWeakToken weakToken = iToken;
-      taskGroup->run([this, task = std::move(iTask), iTrans, &iImpl, weakToken]() {
-        std::exception_ptr exceptPtr{};
-        iImpl.taskArena()->execute([this, iTrans, &iImpl, weakToken, &exceptPtr]() {
-          exceptPtr = syncWait([&](WaitingTaskHolder&& iHolder) {
-            auto const& recs = esGetTokenRecordIndicesVector(iTrans);
-            auto const& items = esGetTokenIndicesVector(iTrans);
-            auto hWaitTask = std::move(iHolder);
-            auto token = weakToken.lock();
-            for (size_t i = 0; i != items.size(); ++i) {
-              if (recs[i] != ESRecordIndex{}) {
-                auto rec = iImpl.findImpl(recs[i]);
-                if (rec) {
-                  rec->prefetchAsync(hWaitTask, items[i], &iImpl, token, ESParentContext(&moduleCallingContext_));
-                }
-              }
-            }
-          });  //syncWait
-        });    //esTaskArena().execute
-        //note use of a copy gets around declaring the lambda as mutable
-        auto tempTask = task;
-        tempTask.doneWaiting(exceptPtr);
-      });  //group.run
-    } else {
-      auto group = iTask.group();
-      //We need iTask to run in the default arena since it is not an ES task
-      auto task = make_waiting_task(
-          [holder = WaitingTaskWithArenaHolder(std::move(iTask))](std::exception_ptr const* iExcept) mutable {
-            if (iExcept) {
-              holder.doneWaiting(*iExcept);
-            } else {
-              holder.doneWaiting(std::exception_ptr{});
-            }
-          });
-
-      WaitingTaskHolder tempH(*group, task);
-      iImpl.taskArena()->execute([&]() {
-        for (size_t i = 0; i != items.size(); ++i) {
-          if (recs[i] != ESRecordIndex{}) {
-            auto rec = iImpl.findImpl(recs[i]);
-            if (rec) {
-              rec->prefetchAsync(tempH, items[i], &iImpl, iToken, ESParentContext(&moduleCallingContext_));
-            }
-          }
+    for (size_t i = 0; i != items.size(); ++i) {
+      if (recs[i] != ESRecordIndex{}) {
+        auto rec = iImpl.findImpl(recs[i]);
+        if (rec) {
+          rec->prefetchAsync(iTask, items[i], &iImpl, iToken, ESParentContext(&moduleCallingContext_));
         }
-      });
+      }
     }
   }
 

--- a/FWCore/Framework/src/EventSetupImpl.cc
+++ b/FWCore/Framework/src/EventSetupImpl.cc
@@ -23,7 +23,7 @@
 
 namespace edm {
 
-  EventSetupImpl::EventSetupImpl(tbb::task_arena* iArena) : taskArena_{iArena} {}
+  EventSetupImpl::EventSetupImpl() {}
 
   EventSetupImpl::~EventSetupImpl() {}
 

--- a/FWCore/Framework/src/EventSetupProvider.cc
+++ b/FWCore/Framework/src/EventSetupProvider.cc
@@ -38,11 +38,9 @@ namespace edm {
   namespace eventsetup {
 
     EventSetupProvider::EventSetupProvider(ActivityRegistry const* activityRegistry,
-                                           tbb::task_arena* taskArena,
                                            unsigned subProcessIndex,
                                            const PreferredProviderInfo* iInfo)
         : activityRegistry_(activityRegistry),
-          taskArena_(taskArena),
           mustFinishConfiguration_(true),
           subProcessIndex_(subProcessIndex),
           preferredProviderInfo_((nullptr != iInfo) ? (new PreferredProviderInfo(*iInfo)) : nullptr),
@@ -698,7 +696,7 @@ namespace edm {
 
       if (needNewEventSetupImpl) {
         //cannot use make_shared because constructor is private
-        eventSetupImpl_ = std::shared_ptr<EventSetupImpl>(new EventSetupImpl(taskArena_));
+        eventSetupImpl_ = std::shared_ptr<EventSetupImpl>(new EventSetupImpl());
         newEventSetupImpl = true;
         eventSetupImpl_->setKeyIters(recordKeys_.begin(), recordKeys_.end());
 

--- a/FWCore/Framework/src/EventSetupProviderMaker.cc
+++ b/FWCore/Framework/src/EventSetupProviderMaker.cc
@@ -24,12 +24,11 @@ namespace edm {
     // ---------------------------------------------------------------
     std::unique_ptr<EventSetupProvider> makeEventSetupProvider(ParameterSet const& params,
                                                                unsigned subProcessIndex,
-                                                               ActivityRegistry* activityRegistry,
-                                                               tbb::task_arena* taskArena) {
+                                                               ActivityRegistry* activityRegistry) {
       std::vector<std::string> prefers = params.getParameter<std::vector<std::string> >("@all_esprefers");
 
       if (prefers.empty()) {
-        return std::make_unique<EventSetupProvider>(activityRegistry, taskArena, subProcessIndex);
+        return std::make_unique<EventSetupProvider>(activityRegistry, subProcessIndex);
       }
 
       EventSetupProvider::PreferredProviderInfo preferInfo;
@@ -87,7 +86,7 @@ namespace edm {
                                         preferPSet.getParameter<std::string>("@module_label"),
                                         false)] = recordToData;
       }
-      return std::make_unique<EventSetupProvider>(activityRegistry, taskArena, subProcessIndex, &preferInfo);
+      return std::make_unique<EventSetupProvider>(activityRegistry, subProcessIndex, &preferInfo);
     }
 
     // ---------------------------------------------------------------

--- a/FWCore/Framework/src/EventSetupProviderMaker.h
+++ b/FWCore/Framework/src/EventSetupProviderMaker.h
@@ -3,7 +3,6 @@
 
 // system include files
 #include <memory>
-#include "tbb/task_arena.h"
 
 // forward declarations
 namespace edm {
@@ -15,8 +14,7 @@ namespace edm {
 
     std::unique_ptr<EventSetupProvider> makeEventSetupProvider(ParameterSet const& params,
                                                                unsigned subProcessIndex,
-                                                               ActivityRegistry*,
-                                                               tbb::task_arena*);
+                                                               ActivityRegistry*);
 
     void fillEventSetupProvider(EventSetupsController& esController, EventSetupProvider& cp, ParameterSet& params);
 

--- a/FWCore/Framework/src/EventSetupsController.cc
+++ b/FWCore/Framework/src/EventSetupsController.cc
@@ -31,7 +31,7 @@
 namespace edm {
   namespace eventsetup {
 
-    EventSetupsController::EventSetupsController() : taskArena_(tbb::this_task_arena::max_concurrency()) {}
+    EventSetupsController::EventSetupsController() {}
 
     void EventSetupsController::endIOVsAsync(edm::WaitingTaskHolder iEndTask) {
       for (auto& eventSetupRecordIOVQueue : eventSetupRecordIOVQueues_) {
@@ -48,7 +48,7 @@ namespace edm {
       // Also parses the prefer information from ParameterSets and puts
       // it in a map that is stored in the EventSetupProvider
       std::shared_ptr<EventSetupProvider> returnValue(
-          makeEventSetupProvider(iPSet, providers_.size(), activityRegistry, &taskArena_));
+          makeEventSetupProvider(iPSet, providers_.size(), activityRegistry));
 
       // Construct the ESProducers and ESSources
       // shared_ptrs to them are temporarily stored in this

--- a/FWCore/Framework/src/Worker.cc
+++ b/FWCore/Framework/src/Worker.cc
@@ -13,8 +13,6 @@
 #include "FWCore/ServiceRegistry/interface/ESParentContext.h"
 #include "FWCore/Concurrency/interface/WaitingTask.h"
 #include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
-#include "FWCore/Concurrency/interface/WaitingTaskWithArenaHolder.h"
-#include "tbb/global_control.h"
 
 namespace edm {
   namespace {
@@ -213,59 +211,13 @@ namespace edm {
       return;
     }
 
-    //Thread case of 1 thread special. The master thread is doing a wait_for_all on the
-    // default tbb arena. It will not process any tasks on the es arena. We need to add a
-    // task that will synchronously do a wait_for_all in the es arena to be sure prefetching
-    // will work.
-
-    if UNLIKELY (tbb::global_control::active_value(tbb::global_control::max_allowed_parallelism) == 1) {
-      auto taskGroup = iTask.group();
-      ServiceWeakToken weakToken = iToken;
-      taskGroup->run([this, task = std::move(iTask), iTrans, &iImpl, weakToken]() {
-        std::exception_ptr exceptPtr{};
-        iImpl.taskArena()->execute([this, iTrans, &iImpl, weakToken, &exceptPtr]() {
-          exceptPtr = syncWait([&](WaitingTaskHolder&& iHolder) {
-            auto const& recs = esRecordsToGetFrom(iTrans);
-            auto const& items = esItemsToGetFrom(iTrans);
-            auto hWaitTask = std::move(iHolder);
-            auto token = weakToken.lock();
-            for (size_t i = 0; i != items.size(); ++i) {
-              if (recs[i] != ESRecordIndex{}) {
-                auto rec = iImpl.findImpl(recs[i]);
-                if (rec) {
-                  rec->prefetchAsync(hWaitTask, items[i], &iImpl, token, ESParentContext(&moduleCallingContext_));
-                }
-              }
-            }
-          });  //syncWait
-        });    //esTaskArena().execute
-        //note use of a copy gets around declaring the lambda as mutable
-        auto tempTask = task;
-        tempTask.doneWaiting(exceptPtr);
-      });  //group.run
-    } else {
-      auto group = iTask.group();
-      //We need iTask to run in the default arena since it is not an ES task
-      auto task = make_waiting_task(
-          [holder = WaitingTaskWithArenaHolder(std::move(iTask))](std::exception_ptr const* iExcept) mutable {
-            if (iExcept) {
-              holder.doneWaiting(*iExcept);
-            } else {
-              holder.doneWaiting(std::exception_ptr{});
-            }
-          });
-
-      WaitingTaskHolder tempH(*group, task);
-      iImpl.taskArena()->execute([&]() {
-        for (size_t i = 0; i != items.size(); ++i) {
-          if (recs[i] != ESRecordIndex{}) {
-            auto rec = iImpl.findImpl(recs[i]);
-            if (rec) {
-              rec->prefetchAsync(tempH, items[i], &iImpl, iToken, ESParentContext(&moduleCallingContext_));
-            }
-          }
+    for (size_t i = 0; i != items.size(); ++i) {
+      if (recs[i] != ESRecordIndex{}) {
+        auto rec = iImpl.findImpl(recs[i]);
+        if (rec) {
+          rec->prefetchAsync(iTask, items[i], &iImpl, iToken, ESParentContext(&moduleCallingContext_));
         }
-      });
+      }
     }
   }
 

--- a/FWCore/Framework/test/eventsetup_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetup_t.cppunit.cc
@@ -147,8 +147,7 @@ namespace {
 }
 
 void testEventsetup::constructTest() {
-  tbb::task_arena arena(1);
-  eventsetup::EventSetupProvider provider(&activityRegistry, &arena);
+  eventsetup::EventSetupProvider provider(&activityRegistry);
   const Timestamp time(1);
   const IOVSyncValue timestamp(time);
   bool newEventSetupImpl = false;
@@ -164,8 +163,7 @@ void testEventsetup::constructTest() {
 // at the lowest level.
 
 void testEventsetup::getTest() {
-  tbb::task_arena arena(1);
-  EventSetupImpl eventSetupImpl(&arena);
+  EventSetupImpl eventSetupImpl;
   std::vector<eventsetup::EventSetupRecordKey> keys;
   EventSetupRecordKey key = EventSetupRecordKey::makeKey<DummyRecord>();
   keys.push_back(key);
@@ -179,8 +177,7 @@ void testEventsetup::getTest() {
 }
 
 void testEventsetup::tryToGetTest() {
-  tbb::task_arena arena(1);
-  EventSetupImpl eventSetupImpl(&arena);
+  EventSetupImpl eventSetupImpl;
   std::vector<eventsetup::EventSetupRecordKey> keys;
   EventSetupRecordKey key = EventSetupRecordKey::makeKey<DummyRecord>();
   keys.push_back(key);

--- a/FWCore/Framework/test/eventsetupplugin_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetupplugin_t.cppunit.cc
@@ -62,8 +62,7 @@ void testEventsetupplugin::finderTest()
 {
   doInit();
   EventSetupsController esController;
-  tbb::task_arena taskArena(1);
-  EventSetupProvider provider(&activityRegistry, &taskArena);
+  EventSetupProvider provider(&activityRegistry);
 
   edm::ParameterSet dummyFinderPSet;
   dummyFinderPSet.addParameter("@module_type", std::string("LoadableDummyFinder"));

--- a/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
@@ -143,7 +143,7 @@ private:
   bool invalidateTransientCalled_;
 };
 
-testEventsetupRecord::testEventsetupRecord() : taskArena_(1), eventSetupImpl_(&taskArena_) {}
+testEventsetupRecord::testEventsetupRecord() : taskArena_(1), eventSetupImpl_() {}
 void testEventsetupRecord::setUp() { dummyRecordKey_ = EventSetupRecordKey::makeKey<DummyRecord>(); }
 
 class WorkingDummyProvider : public edm::eventsetup::DataProxyProvider {

--- a/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
@@ -255,9 +255,9 @@
 ++++ starting: global begin run 1 : time = 1
 ++++ finished: global begin run 1 : time = 1
 ++++ starting: global begin run 1 : time = 1
+++++++++ starting: prefetching for esmodule: label = '' type = DoodadESSource in record = GadgetRcd
 ++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 5
-++++++++ starting: prefetching for esmodule: label = '' type = DoodadESSource in record = GadgetRcd
 ++++++++ finished: prefetching for esmodule: label = '' type = DoodadESSource in record = GadgetRcd
 ++++++++ starting: processing esmodule: label = '' type = DoodadESSource in record = GadgetRcd
 ++++++++ finished: processing esmodule: label = '' type = DoodadESSource in record = GadgetRcd
@@ -271,6 +271,7 @@
 ++++ starting: global begin run 1 : time = 1
 ++++ finished: global begin run 1 : time = 1
 ++++ starting: global begin run 1 : time = 1
+++++++++ starting: prefetching for esmodule: label = '' type = DoodadESSource in record = GadgetRcd
 ++++ starting: global begin run 1 : time = 1
 ++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 31
 ++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 31
@@ -278,25 +279,24 @@
 ++++++ finished: global begin run for module: label = 'test' id = 32
 ++++++ starting: global begin run for module: label = 'testmerge' id = 33
 ++++++ finished: global begin run for module: label = 'testmerge' id = 33
-++++++++ starting: prefetching for esmodule: label = '' type = DoodadESSource in record = GadgetRcd
-++++++++ finished: prefetching for esmodule: label = '' type = DoodadESSource in record = GadgetRcd
-++++++++ starting: processing esmodule: label = '' type = DoodadESSource in record = GadgetRcd
-++++++++ finished: processing esmodule: label = '' type = DoodadESSource in record = GadgetRcd
-++++++ starting: global begin run for module: label = 'get' id = 34
-++++++ finished: global begin run for module: label = 'get' id = 34
 ++++++ starting: global begin run for module: label = 'getInt' id = 35
 ++++++ finished: global begin run for module: label = 'getInt' id = 35
 ++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 36
-++++ finished: global begin run 1 : time = 1
 ++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 18
 ++++++ starting: global begin run for module: label = 'test' id = 19
 ++++++ finished: global begin run for module: label = 'test' id = 19
 ++++++ starting: global begin run for module: label = 'testmerge' id = 20
 ++++++ finished: global begin run for module: label = 'testmerge' id = 20
+++++++++ finished: prefetching for esmodule: label = '' type = DoodadESSource in record = GadgetRcd
+++++++++ starting: processing esmodule: label = '' type = DoodadESSource in record = GadgetRcd
+++++++++ finished: processing esmodule: label = '' type = DoodadESSource in record = GadgetRcd
 ++++++ starting: global begin run for module: label = 'get' id = 21
 ++++++ finished: global begin run for module: label = 'get' id = 21
+++++++ starting: global begin run for module: label = 'get' id = 34
+++++++ finished: global begin run for module: label = 'get' id = 34
+++++ finished: global begin run 1 : time = 1
 ++++++ starting: global begin run for module: label = 'getInt' id = 22
 ++++++ finished: global begin run for module: label = 'getInt' id = 22
 ++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 23

--- a/Geometry/MTDCommonData/test/testMTDinDD4hep.py
+++ b/Geometry/MTDCommonData/test/testMTDinDD4hep.py
@@ -73,5 +73,5 @@ process.testETL = cms.EDAnalyzer("DD4hep_TestMTDIdealGeometry",
 
 process.Timing = cms.Service("Timing")
 
-process.p1 = cms.Path(process.testBTL+process.testETL)
+process.p1 = cms.Path(cms.wait(process.testBTL)+process.testETL)
 

--- a/Geometry/MTDCommonData/test/testMTDinDDD.py
+++ b/Geometry/MTDCommonData/test/testMTDinDDD.py
@@ -63,4 +63,4 @@ process.testETL = cms.EDAnalyzer("TestMTDIdealGeometry",
 
 process.Timing = cms.Service("Timing")
 
-process.p1 = cms.Path(process.testBTL+process.testETL)
+process.p1 = cms.Path(cms.wait(process.testBTL)+process.testETL)

--- a/RecoMTD/DetLayers/test/mtd_cfg.py
+++ b/RecoMTD/DetLayers/test/mtd_cfg.py
@@ -66,4 +66,4 @@ process.Timing = cms.Service("Timing")
 process.prod = cms.EDAnalyzer("MTDRecoGeometryAnalyzer")
 process.prod1 = cms.EDAnalyzer("TestETLNavigation")
 
-process.p1 = cms.Path(process.prod+process.prod1)
+process.p1 = cms.Path(cms.wait(process.prod)+process.prod1)


### PR DESCRIPTION
#### PR description:

Now that all EventSetup data products are prefetched, there is no longer a need to isolate ES module calls in their own task_arena.

#### PR validation:

Code compiles and all framework unit tests pass.

resolves makortel/framework#336