### PR TITLE
`CondTools/SiStrip` unit tests: introduce gain rescaler tool in unit tests

### DIFF
--- a/CondTools/SiStrip/test/SiStripApvGainRescaler_cfg.py
+++ b/CondTools/SiStrip/test/SiStripApvGainRescaler_cfg.py
@@ -8,16 +8,22 @@ process = cms.Process("Demo")
 options = VarParsing.VarParsing("analysis")
 
 options.register ('globalTag',
-                  "92X_dataRun2_Prompt_v11",
-                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                  "auto:run3_data_prompt",
+                  VarParsing.VarParsing.multiplicity.singleton,  # singleton or list
                   VarParsing.VarParsing.varType.string,          # string, int, or float
                   "GlobalTag")
 
 options.register ('runNumber',
-                  303014,
+                  1,
                   VarParsing.VarParsing.multiplicity.singleton, # singleton or list
-                  VarParsing.VarParsing.varType.int,           # string, int, or float
+                  VarParsing.VarParsing.varType.int,            # string, int, or float
                   "run number")
+
+options.register ('additionalConds',
+                  "sqlite_file:gainManipulations.db",
+                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                  VarParsing.VarParsing.varType.string,         # string, int, or float
+                  "location of the additional conditions")
 
 options.parseArguments()
 
@@ -27,7 +33,7 @@ options.parseArguments()
 ##
 process.load('FWCore.MessageService.MessageLogger_cfi')   
 process.MessageLogger.cerr.enable = False
-process.MessageLogger.SiStripGain2RescaleByGain1=dict()  
+process.MessageLogger.SiStripApvGainRescaler=dict()
 process.MessageLogger.cout = cms.untracked.PSet(
     enable    = cms.untracked.bool(True),
     enableStatistics = cms.untracked.bool(True),
@@ -36,7 +42,7 @@ process.MessageLogger.cout = cms.untracked.PSet(
     FwkReport = cms.untracked.PSet(limit = cms.untracked.int32(-1),
                                    reportEvery = cms.untracked.int32(1000)
                                    ),                                                      
-    SiStripGain2RescaleByGain1  = cms.untracked.PSet( limit = cms.untracked.int32(-1))
+    SiStripApvGainRescaler  = cms.untracked.PSet( limit = cms.untracked.int32(-1))
     )
 
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
@@ -46,17 +52,17 @@ process.GlobalTag.toGet = cms.VPSet(
     ### N.B. This contains the G1_new (to be used for the rescale)
     cms.PSet(record = cms.string("SiStripApvGain3Rcd"),
              tag = cms.string("G1_new"),
-             connect = cms.string("sqlite_file:G1_new.db")
+             connect = cms.string(options.additionalConds)
              ),
     ### N.B. This contains the G2_old (to be used for the rescale)
     cms.PSet(record = cms.string("SiStripApvGain2Rcd"),
              tag = cms.string("G2_old"),
-             connect = cms.string("sqlite_file:G2_old.db")
+             connect = cms.string(options.additionalConds)
              ),
     ### N.B. This contains the G1_old (to be used for the rescale)
     cms.PSet(record = cms.string("SiStripApvGainRcd"),
              tag = cms.string("G1_old"),
-             connect = cms.string("sqlite_file:G1_old.db")
+             connect = cms.string(options.additionalConds)
              )
     )
 
@@ -69,7 +75,7 @@ process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1) )
 
 process.load("CondTools.SiStrip.rescaleGain2byGain1_cfi") 
 
-# process.demo = cms.EDAnalyzer('SiStripGain2RescaleByGain1',
+# process.demo = cms.EDAnalyzer('SiStripApvGainRescaler',
 #                               Record = cms.untracked.string("SiStripApvGainRcd"),
 #                               )
 

--- a/CondTools/SiStrip/test/testBuildersReaders.sh
+++ b/CondTools/SiStrip/test/testBuildersReaders.sh
@@ -10,11 +10,12 @@ if test -f "SiStripConditionsDBFile.db"; then
     echo "cleaning the local test area"
     rm -fr SiStripConditionsDBFile.db  # builders test
     rm -fr modifiedSiStrip*.db         # miscalibrator tests
+    rm -fr gainManipulations.db        # rescaler tool
 fi
 pwd
 echo " testing CondTools/SiStrip"
 
-## do the builders first (need the input db file)
+# do the builders first (need the input db file)
 for entry in "${LOCAL_TEST_DIR}/"SiStrip*Builder_cfg.py
 do
   echo "===== Test \"cmsRun $entry \" ===="
@@ -43,6 +44,27 @@ done
 
 echo -e " Done with the miscalibrators \n\n"
 
-## do the scaler (commented for now)
-#(cmsRun ${LOCAL_TEST_DIR}/SiStripApvGainRescaler_cfg.py) || die "Failure using cmsRun SiStripApvGainRescaler_cfg.py)" $?
-#echo -e " Done with the gain rescaler \n\n"
+## do the scaler
+
+# copy all the necessary conditions in order to run the miscalibration tool
+G1TAG=SiStripApvGain_GR10_v1_hlt
+G2TAG=SiStripApvGain_FromParticles_GR10_v1_express
+OLDG1since=325642
+NEWG1since=343828
+OLDG2since=336067
+
+echo -e "\n\n Copying IOVs $OLDG1since and $NEWG1since from $G1TAG and IOV $OLDG2since from $G2TAG"
+
+conddb --yes --db pro copy ${G1TAG} G1_old --from ${OLDG1since} --to $((++OLDG1since)) --destdb gainManipulations.db
+conddb --yes --db pro copy ${G1TAG} G1_new --from ${NEWG1since} --to $((++NEWG1since)) --destdb gainManipulations.db
+conddb --yes --db pro copy ${G2TAG} G2_old --from ${OLDG2since} --to $((++OLDG2since)) --destdb gainManipulations.db
+
+sqlite3 gainManipulations.db "update IOV SET SINCE=1 where SINCE=$((--OLDG1since))" # sets the IOV since to 1
+sqlite3 gainManipulations.db "update IOV SET SINCE=1 where SINCE=$((--NEWG1since))" # sets the IOV since to 1
+sqlite3 gainManipulations.db "update IOV SET SINCE=1 where SINCE=$((--OLDG2since))" # sets the IOV since to 1
+
+echo -e "\n\n Checking the content of the local conditions file \n\n"
+sqlite3 gainManipulations.db "select * from IOV"
+
+(cmsRun ${LOCAL_TEST_DIR}/SiStripApvGainRescaler_cfg.py additionalConds=sqlite_file:${PWD}/gainManipulations.db) || die "Failure using cmsRun SiStripApvGainRescaler_cfg.py)" $?
+echo -e " Done with the gain rescaler \n\n"


### PR DESCRIPTION
#### PR description:

Title says it all, introduce SiStrip APV gain rescaler tool in `CondTools/SiStrip` unit tests, now that issue https://github.com/cms-sw/cmssw/issues/36319 is solved by PR #36533.

#### PR validation:

Run package unit tests with: `scramv1 b runtests_testCondToolsSiStripBuildersReaders`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
