### PR TITLE
Drop type specs in RecoTau and RecoVertex

### DIFF
--- a/Validation/RecoTau/python/RecoTauValidation_cff.py
+++ b/Validation/RecoTau/python/RecoTauValidation_cff.py
@@ -6,28 +6,28 @@ discs_to_retain = ['decayModeFinding', 'CombinedIsolationDeltaBetaCorr3HitsdR03'
 tauValidationMiniAODZTT.discriminators = cms.VPSet([p for p in tauValidationMiniAODZTT.discriminators if any(disc in p.discriminator.value() for disc in discs_to_retain) ])
 
 tauValidationMiniAODZEE = tauValidationMiniAODZTT.clone(
-  RefCollection = cms.InputTag("kinematicSelectedTauValDenominatorZEE"),
-  ExtensionName = cms.string('ZEE')
+  RefCollection = "kinematicSelectedTauValDenominatorZEE",
+  ExtensionName = 'ZEE'
 )
 tauValidationMiniAODZMM = tauValidationMiniAODZTT.clone(
-  RefCollection = cms.InputTag("kinematicSelectedTauValDenominatorZMM"),
-  ExtensionName = cms.string('ZMM')
+  RefCollection = "kinematicSelectedTauValDenominatorZMM",
+  ExtensionName = 'ZMM'
 )
 tauValidationMiniAODQCD = tauValidationMiniAODZTT.clone(
-  RefCollection = cms.InputTag("kinematicSelectedTauValDenominatorQCD"),
-  ExtensionName = cms.string('QCD')
+  RefCollection = "kinematicSelectedTauValDenominatorQCD",
+  ExtensionName = 'QCD'
 )
 tauValidationMiniAODRealData = tauValidationMiniAODZTT.clone(
-  RefCollection = cms.InputTag("CleanedPFJets"),
-  ExtensionName = cms.string('RealData')
+  RefCollection = "CleanedPFJets",
+  ExtensionName = 'RealData'
 )
 tauValidationMiniAODRealElectronsData = tauValidationMiniAODZTT.clone(
-  RefCollection = cms.InputTag("ElZLegs","theProbeLeg"),
+  RefCollection = "ElZLegs:theProbeLeg",
   ExtensionName = cms.string("RealElectronsData")
 )
 tauValidationMiniAODRealMuonsData = tauValidationMiniAODZTT.clone(
-  RefCollection = cms.InputTag("MuZLegs","theProbeLeg"),
-  ExtensionName = cms.string('RealMuonsData')
+  RefCollection = "MuZLegs:theProbeLeg",
+  ExtensionName = 'RealMuonsData'
 )
 
 

--- a/Validation/RecoTau/python/RecoTauValidation_cff.py
+++ b/Validation/RecoTau/python/RecoTauValidation_cff.py
@@ -23,7 +23,7 @@ tauValidationMiniAODRealData = tauValidationMiniAODZTT.clone(
 )
 tauValidationMiniAODRealElectronsData = tauValidationMiniAODZTT.clone(
   RefCollection = "ElZLegs:theProbeLeg",
-  ExtensionName = cms.string("RealElectronsData")
+  ExtensionName = "RealElectronsData"
 )
 tauValidationMiniAODRealMuonsData = tauValidationMiniAODZTT.clone(
   RefCollection = "MuZLegs:theProbeLeg",

--- a/Validation/RecoVertex/python/HLTmultiPVvalidator_cff.py
+++ b/Validation/RecoVertex/python/HLTmultiPVvalidator_cff.py
@@ -2,46 +2,46 @@ import FWCore.ParameterSet.Config as cms
 
 from Validation.RecoVertex.PrimaryVertexAnalyzer4PUSlimmed_cfi import *
 
-hltMultiPVanalysis = vertexAnalysis.clone()
-hltMultiPVanalysis.do_generic_sim_plots  = False
-hltMultiPVanalysis.verbose               = cms.untracked.bool(False)
-hltMultiPVanalysis.root_folder           = cms.untracked.string("HLT/Vertexing/ValidationWRTsim")
-hltMultiPVanalysis.vertexRecoCollections = cms.VInputTag( )
-hltMultiPVanalysis.trackAssociatorMap    = cms.untracked.InputTag("trackingParticleRecoTrackAsssociation")
-hltMultiPVanalysis.vertexAssociator      = cms.untracked.InputTag("VertexAssociatorByPositionAndTracks")
-
+hltMultiPVanalysis = vertexAnalysis.clone(
+do_generic_sim_plots  = False,
+verbose               = False,
+root_folder           = "HLT/Vertexing/ValidationWRTsim",
+vertexRecoCollections = ("",),
+trackAssociatorMap    = "trackingParticleRecoTrackAsssociation",
+vertexAssociator      = "VertexAssociatorByPositionAndTracks"
+)
 from Validation.RecoTrack.associators_cff import hltTrackAssociatorByHits, tpToHLTpixelTrackAssociation
 from SimTracker.VertexAssociation.VertexAssociatorByPositionAndTracks_cfi import VertexAssociatorByPositionAndTracks as _VertexAssociatorByPositionAndTracks
-vertexAssociatorByPositionAndTracks4pixelTracks = _VertexAssociatorByPositionAndTracks.clone()
-vertexAssociatorByPositionAndTracks4pixelTracks.trackAssociation = cms.InputTag("tpToHLTpixelTrackAssociation")
-
+vertexAssociatorByPositionAndTracks4pixelTracks = _VertexAssociatorByPositionAndTracks.clone(
+trackAssociation = "tpToHLTpixelTrackAssociation"
+)
 tpToHLTpfMuonMergingTrackAssociation = tpToHLTpixelTrackAssociation.clone(
     label_tr = "hltPFMuonMerging"
 )
-vertexAssociatorByPositionAndTracks4pfMuonMergingTracks = _VertexAssociatorByPositionAndTracks.clone()
-vertexAssociatorByPositionAndTracks4pfMuonMergingTracks.trackAssociation = cms.InputTag("tpToHLTpfMuonMergingTrackAssociation")
+vertexAssociatorByPositionAndTracks4pfMuonMergingTracks = _VertexAssociatorByPositionAndTracks.clone(
+trackAssociation = "tpToHLTpfMuonMergingTrackAssociation"
+)
 
 
-
-hltPixelPVanalysis = hltMultiPVanalysis.clone()
-hltPixelPVanalysis.do_generic_sim_plots  = True
-hltPixelPVanalysis.trackAssociatorMap    = cms.untracked.InputTag("tpToHLTpixelTrackAssociation")
-hltPixelPVanalysis.vertexAssociator      = cms.untracked.InputTag("vertexAssociatorByPositionAndTracks4pixelTracks")
-hltPixelPVanalysis.vertexRecoCollections = cms.VInputTag(
+hltPixelPVanalysis = hltMultiPVanalysis.clone(
+do_generic_sim_plots  = True,
+trackAssociatorMap    = "tpToHLTpixelTrackAssociation",
+vertexAssociator      = "vertexAssociatorByPositionAndTracks4pixelTracks",
+vertexRecoCollections = (
     "hltPixelVertices",
     "hltTrimmedPixelVertices",
 )
-
-
-
-hltPVanalysis = hltMultiPVanalysis.clone()
-hltPVanalysis.trackAssociatorMap = cms.untracked.InputTag("tpToHLTpfMuonMergingTrackAssociation")
-hltPVanalysis.vertexAssociator   = cms.untracked.InputTag("vertexAssociatorByPositionAndTracks4pfMuonMergingTracks")
-hltPVanalysis.vertexRecoCollections   = cms.VInputTag(
-    "hltVerticesPFFilter"
-#    "hltFastPVPixelVertices"
 )
 
+
+hltPVanalysis = hltMultiPVanalysis.clone(
+trackAssociatorMap = "tpToHLTpfMuonMergingTrackAssociation",
+vertexAssociator   = "vertexAssociatorByPositionAndTracks4pfMuonMergingTracks",
+vertexRecoCollections   = (
+    "hltVerticesPFFilter",
+#    "hltFastPVPixelVertices"
+)
+)
 hltMultiPVAssociations = cms.Task(
     hltTrackAssociatorByHits,
     tpToHLTpixelTrackAssociation,

--- a/Validation/RecoVertex/python/HLTmultiPVvalidator_cff.py
+++ b/Validation/RecoVertex/python/HLTmultiPVvalidator_cff.py
@@ -24,13 +24,13 @@ trackAssociation = "tpToHLTpfMuonMergingTrackAssociation"
 
 
 hltPixelPVanalysis = hltMultiPVanalysis.clone(
-do_generic_sim_plots  = True,
-trackAssociatorMap    = "tpToHLTpixelTrackAssociation",
-vertexAssociator      = "vertexAssociatorByPositionAndTracks4pixelTracks",
-vertexRecoCollections = (
-    "hltPixelVertices",
-    "hltTrimmedPixelVertices",
-)
+    do_generic_sim_plots  = True,
+    trackAssociatorMap    = "tpToHLTpixelTrackAssociation",
+    vertexAssociator      = "vertexAssociatorByPositionAndTracks4pixelTracks",
+    vertexRecoCollections = (
+        "hltPixelVertices",
+        "hltTrimmedPixelVertices",
+    )
 )
 
 

--- a/Validation/RecoVertex/python/HLTmultiPVvalidator_cff.py
+++ b/Validation/RecoVertex/python/HLTmultiPVvalidator_cff.py
@@ -3,23 +3,23 @@ import FWCore.ParameterSet.Config as cms
 from Validation.RecoVertex.PrimaryVertexAnalyzer4PUSlimmed_cfi import *
 
 hltMultiPVanalysis = vertexAnalysis.clone(
-do_generic_sim_plots  = False,
-verbose               = False,
-root_folder           = "HLT/Vertexing/ValidationWRTsim",
-vertexRecoCollections = [""],
-trackAssociatorMap    = "trackingParticleRecoTrackAsssociation",
-vertexAssociator      = "VertexAssociatorByPositionAndTracks"
+    do_generic_sim_plots  = False,
+    verbose               = False,
+    root_folder           = "HLT/Vertexing/ValidationWRTsim",
+    vertexRecoCollections = [""],
+    trackAssociatorMap    = "trackingParticleRecoTrackAsssociation",
+    vertexAssociator      = "VertexAssociatorByPositionAndTracks"
 )
 from Validation.RecoTrack.associators_cff import hltTrackAssociatorByHits, tpToHLTpixelTrackAssociation
 from SimTracker.VertexAssociation.VertexAssociatorByPositionAndTracks_cfi import VertexAssociatorByPositionAndTracks as _VertexAssociatorByPositionAndTracks
 vertexAssociatorByPositionAndTracks4pixelTracks = _VertexAssociatorByPositionAndTracks.clone(
-trackAssociation = "tpToHLTpixelTrackAssociation"
+    trackAssociation = "tpToHLTpixelTrackAssociation"
 )
 tpToHLTpfMuonMergingTrackAssociation = tpToHLTpixelTrackAssociation.clone(
     label_tr = "hltPFMuonMerging"
 )
 vertexAssociatorByPositionAndTracks4pfMuonMergingTracks = _VertexAssociatorByPositionAndTracks.clone(
-trackAssociation = "tpToHLTpfMuonMergingTrackAssociation"
+    trackAssociation = "tpToHLTpfMuonMergingTrackAssociation"
 )
 
 
@@ -35,12 +35,12 @@ hltPixelPVanalysis = hltMultiPVanalysis.clone(
 
 
 hltPVanalysis = hltMultiPVanalysis.clone(
-trackAssociatorMap = "tpToHLTpfMuonMergingTrackAssociation",
-vertexAssociator   = "vertexAssociatorByPositionAndTracks4pfMuonMergingTracks",
-vertexRecoCollections   = (
+    trackAssociatorMap = "tpToHLTpfMuonMergingTrackAssociation",
+    vertexAssociator   = "vertexAssociatorByPositionAndTracks4pfMuonMergingTracks",
+    vertexRecoCollections   = (
     "hltVerticesPFFilter",
-#    "hltFastPVPixelVertices"
-)
+    #"hltFastPVPixelVertices"
+    )
 )
 hltMultiPVAssociations = cms.Task(
     hltTrackAssociatorByHits,

--- a/Validation/RecoVertex/python/HLTmultiPVvalidator_cff.py
+++ b/Validation/RecoVertex/python/HLTmultiPVvalidator_cff.py
@@ -6,7 +6,7 @@ hltMultiPVanalysis = vertexAnalysis.clone(
 do_generic_sim_plots  = False,
 verbose               = False,
 root_folder           = "HLT/Vertexing/ValidationWRTsim",
-vertexRecoCollections = ("",),
+vertexRecoCollections = [""],
 trackAssociatorMap    = "trackingParticleRecoTrackAsssociation",
 vertexAssociator      = "VertexAssociatorByPositionAndTracks"
 )

--- a/Validation/RecoVertex/python/HLTpostProcessorVertex_cfi.py
+++ b/Validation/RecoVertex/python/HLTpostProcessorVertex_cfi.py
@@ -2,5 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 from Validation.RecoVertex.PrimaryVertexAnalyzer4PUSlimmed_Client_cfi import *
 
-postProcessorHLTvertexing = postProcessorVertex.clone()
-postProcessorHLTvertexing.subDirs = cms.untracked.vstring("HLT/Vertexing/ValidationWRTsim/*")
+postProcessorHLTvertexing = postProcessorVertex.clone(
+    subDirs = ("HLT/Vertexing/ValidationWRTsim/*",)
+)

--- a/Validation/RecoVertex/python/PrimaryVertexAnalyzer4PUSlimmed_cfi.py
+++ b/Validation/RecoVertex/python/PrimaryVertexAnalyzer4PUSlimmed_cfi.py
@@ -6,12 +6,12 @@ selectedOfflinePrimaryVertices = cms.EDFilter("VertexSelector",
                                                filter = cms.bool(False)
 )
 
-selectedOfflinePrimaryVerticesWithBS = selectedOfflinePrimaryVertices.clone()
-selectedOfflinePrimaryVerticesWithBS.src = cms.InputTag('offlinePrimaryVerticesWithBS')
-
-selectedPixelVertices = selectedOfflinePrimaryVertices.clone()
-selectedPixelVertices.src = cms.InputTag('pixelVertices')
-
+selectedOfflinePrimaryVerticesWithBS = selectedOfflinePrimaryVertices.clone(
+src = 'offlinePrimaryVerticesWithBS'
+)
+selectedPixelVertices = selectedOfflinePrimaryVertices.clone(
+src = 'pixelVertices'
+)
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 vertexAnalysis = DQMEDAnalyzer('PrimaryVertexAnalyzer4PUSlimmed',
                                 use_only_charged_tracks = cms.untracked.bool(True),

--- a/Validation/RecoVertex/python/PrimaryVertexAnalyzer4PUSlimmed_cfi.py
+++ b/Validation/RecoVertex/python/PrimaryVertexAnalyzer4PUSlimmed_cfi.py
@@ -7,10 +7,10 @@ selectedOfflinePrimaryVertices = cms.EDFilter("VertexSelector",
 )
 
 selectedOfflinePrimaryVerticesWithBS = selectedOfflinePrimaryVertices.clone(
-src = 'offlinePrimaryVerticesWithBS'
+  src = 'offlinePrimaryVerticesWithBS'
 )
 selectedPixelVertices = selectedOfflinePrimaryVertices.clone(
-src = 'pixelVertices'
+  src = 'pixelVertices'
 )
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 vertexAnalysis = DQMEDAnalyzer('PrimaryVertexAnalyzer4PUSlimmed',

--- a/Validation/RecoVertex/python/pvSelectionSequence_cff.py
+++ b/Validation/RecoVertex/python/pvSelectionSequence_cff.py
@@ -12,11 +12,11 @@ goodVertices = cms.EDFilter("VertexSelector",
 
 noFakeVertices = goodVertices.clone(cut=cms.string("!isFake"))
 
-goodVerticesD0s5 = goodVertices.clone(src = cms.InputTag("offlinePrimaryVerticesD0s5"))
-goodVerticesD0s51mm = goodVertices.clone(src = cms.InputTag("offlinePrimaryVerticesD0s51mm"))
-goodVerticesDA100um = goodVertices.clone(src = cms.InputTag("offlinePrimaryVerticesDA100um"))
-goodVerticesDA100umV7 = goodVertices.clone(src = cms.InputTag("offlinePrimaryVerticesDA100umV7"))
-goodVerticesDA100umV8 = goodVertices.clone(src = cms.InputTag("offlinePrimaryVerticesDA100umV8"))
+goodVerticesD0s5 = goodVertices.clone(src = "offlinePrimaryVerticesD0s5")
+goodVerticesD0s51mm = goodVertices.clone(src = "offlinePrimaryVerticesD0s51mm")
+goodVerticesDA100um = goodVertices.clone(src = "offlinePrimaryVerticesDA100um")
+goodVerticesDA100umV7 = goodVertices.clone(src = "offlinePrimaryVerticesDA100umV7")
+goodVerticesDA100umV8 = goodVertices.clone(src = "offlinePrimaryVerticesDA100umV8")
 
 
 seqPVSelection = cms.Sequence(goodVertices + noFakeVertices + goodVerticesD0s5 + goodVerticesD0s51mm +


### PR DESCRIPTION
#### PR description:
Drop type specs in Validation/RecoTau and Validation/RecoVertex python configuration files.

Central DQM migration campaign for drop type spces following
https://cms-sw.github.io/cms_coding_rules.html#6--packaging-rules-1
and update the safer syntax for existing parameters like: (1) drop type specifications where the original parameter exists. (2) using "clone" instead of "deepcopy" (3) move all parameters inside the clone

#### PR validation:

Tested in CMSSW_12_3_X via runTheMatrix.py -l limited -i all --ibeos



