### PR TITLE
Run3-gex102C Get rid of compilation warning in Validation/HGCalValidation and use ESGetToken in Validation/CSCRecHits

### DIFF
--- a/Validation/CSCRecHits/interface/CSCRecHitMatcher.h
+++ b/Validation/CSCRecHits/interface/CSCRecHitMatcher.h
@@ -13,13 +13,14 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "SimDataFormats/Track/interface/SimTrackContainer.h"
 #include "SimDataFormats/Vertex/interface/SimVertexContainer.h"
 #include "Validation/MuonCSCDigis/interface/CSCDigiMatcher.h"
 #include "DataFormats/CSCRecHit/interface/CSCRecHit2DCollection.h"
 #include "DataFormats/CSCRecHit/interface/CSCSegmentCollection.h"
+#include "Geometry/CSCGeometry/interface/CSCGeometry.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 
 #include <vector>
 #include <map>
@@ -88,7 +89,7 @@ private:
   edm::Handle<CSCRecHit2DCollection> cscRecHit2DH_;
   edm::Handle<CSCSegmentCollection> cscSegmentH_;
 
-  edm::ESHandle<CSCGeometry> csc_geom_;
+  edm::ESGetToken<CSCGeometry, MuonGeometryRecord> cscGeomToken_;
   const CSCGeometry* cscGeometry_;
 
   void matchCSCRecHit2DsToSimTrack(const CSCRecHit2DCollection&);

--- a/Validation/CSCRecHits/src/CSCRecHitMatcher.cc
+++ b/Validation/CSCRecHits/src/CSCRecHitMatcher.cc
@@ -1,8 +1,6 @@
 #include <memory>
 
 #include "Validation/CSCRecHits/interface/CSCRecHitMatcher.h"
-#include "Geometry/Records/interface/MuonGeometryRecord.h"
-#include "Geometry/CSCGeometry/interface/CSCGeometry.h"
 
 using namespace std;
 
@@ -22,6 +20,8 @@ CSCRecHitMatcher::CSCRecHitMatcher(const edm::ParameterSet& pset, edm::ConsumesC
 
   cscRecHit2DToken_ = iC.consumes<CSCRecHit2DCollection>(cscRecHit2D.getParameter<edm::InputTag>("inputTag"));
   cscSegmentToken_ = iC.consumes<CSCSegmentCollection>(cscSegment.getParameter<edm::InputTag>("inputTag"));
+
+  cscGeomToken_ = iC.esConsumes<CSCGeometry, MuonGeometryRecord>();
 }
 
 void CSCRecHitMatcher::init(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
@@ -30,9 +30,9 @@ void CSCRecHitMatcher::init(const edm::Event& iEvent, const edm::EventSetup& iSe
   iEvent.getByToken(cscRecHit2DToken_, cscRecHit2DH_);
   iEvent.getByToken(cscSegmentToken_, cscSegmentH_);
 
-  iSetup.get<MuonGeometryRecord>().get(csc_geom_);
-  if (csc_geom_.isValid()) {
-    cscGeometry_ = &*csc_geom_;
+  const auto& csc_geom = iSetup.getHandle(cscGeomToken_);
+  if (csc_geom.isValid()) {
+    cscGeometry_ = csc_geom.product();
   } else {
     edm::LogWarning("CSCSimHitMatcher") << "+++ Info: CSC geometry is unavailable. +++\n";
   }

--- a/Validation/HGCalValidation/plugins/HGCalTriggerValidator.cc
+++ b/Validation/HGCalValidation/plugins/HGCalTriggerValidator.cc
@@ -6,8 +6,6 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/Common/interface/Handle.h"


### PR DESCRIPTION
#### PR description:

Get rid of compilation warning in Validation/HGCalValidation and use ESGetToken in Validation/CSCRecHits

#### PR validation:

Use the runTheMatrix test workflows

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special