### PR TITLE
Fix EventSetupIncorrectConsumes test

### DIFF
--- a/FWCore/Framework/interface/EDConsumerBase.h
+++ b/FWCore/Framework/interface/EDConsumerBase.h
@@ -221,12 +221,12 @@ namespace edm {
     }
 
     template <Transition Tr = Transition::Event>
-    [[nodiscard]] constexpr auto esConsumes() noexcept {
+    [[nodiscard]] constexpr auto esConsumes() {
       return EDConsumerBaseESAdaptor<Tr>(this);
     }
 
     template <Transition Tr = Transition::Event>
-    [[nodiscard]] auto esConsumes(ESInputTag tag) noexcept {
+    [[nodiscard]] auto esConsumes(ESInputTag tag) {
       return EDConsumerBaseWithTagESAdaptor<Tr>(this, std::move(tag));
     }
 

--- a/FWCore/Integration/test/ESTestAnalyzers.cc
+++ b/FWCore/Integration/test/ESTestAnalyzers.cc
@@ -243,7 +243,7 @@ namespace edmtest {
   };
 
   void ESTestAnalyzerIncorrectConsumes::analyze(edm::Event const& ev, edm::EventSetup const& es) {
-    esToken_ = esConsumes();
+    esToken_ = esConsumes<ESTestDataJ, ESTestRecordJ>();
     edm::LogAbsolute("ESTestAnalyzerIncorrectConsumes")
         << "Succeeded to call esConsumes() in analyze(), should not happen!";
   }

--- a/FWCore/Integration/test/ESTestAnalyzers.cc
+++ b/FWCore/Integration/test/ESTestAnalyzers.cc
@@ -243,7 +243,7 @@ namespace edmtest {
   };
 
   void ESTestAnalyzerIncorrectConsumes::analyze(edm::Event const& ev, edm::EventSetup const& es) {
-    esToken_ = esConsumes<ESTestDataJ, ESTestRecordJ>();
+    esToken_ = esConsumes();
     edm::LogAbsolute("ESTestAnalyzerIncorrectConsumes")
         << "Succeeded to call esConsumes() in analyze(), should not happen!";
   }

--- a/FWCore/Integration/test/EventSetupIncorrectConsumes_cfg.py
+++ b/FWCore/Integration/test/EventSetupIncorrectConsumes_cfg.py
@@ -1,0 +1,33 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.source = cms.Source("EmptySource",
+    numberEventsInRun = cms.untracked.uint32(3)
+)
+
+process.WhatsItESProducer = cms.ESProducer("WhatsItESProducer")
+
+process.DoodadESSource = cms.ESSource("DoodadESSource")
+
+process.emptyESSourceK = cms.ESSource("EmptyESSource",
+    recordName = cms.string("ESTestRecordK"),
+    firstValid = cms.vuint32(1,2,3),
+    iovIsRunNotTime = cms.bool(True)
+)
+
+process.testDataProxyProviderJ = cms.ESProducer("ESTestDataProxyProviderJ",
+    expectedCacheIds = cms.untracked.vuint32(2, 3, 4)
+)
+
+process.esAnalyzer = cms.EDAnalyzer("ESTestAnalyzerIncorrectConsumes")
+
+process.p = cms.Path(
+    process.esAnalyzer
+)

--- a/FWCore/Integration/test/eventSetupTest.sh
+++ b/FWCore/Integration/test/eventSetupTest.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 function die { echo $1: status $2 ;  exit $2; }
+function diecat { echo "$1: status $2, log" ;  cat $3; exit $2; }
 
 pushd ${LOCAL_TMP_DIR}
 
@@ -34,6 +35,7 @@ echo EventSetupTestCurrentProcess_cfg.py
 cmsRun ${LOCAL_TEST_DIR}/EventSetupTestCurrentProcess_cfg.py || die 'Failed in EventSetupTestCurrentProcess_cfg.py' $?
 
 echo EventSetupIncorrectConsumes_cfg.py
-cmsRun ${LOCAL_TEST_DIR}/EventSetupIncorrectConsumes_cfg.py && die 'Failed in EventSetupIncorrectConsumes_cfg.py' 1
+cmsRun ${LOCAL_TEST_DIR}/EventSetupIncorrectConsumes_cfg.py &> testEventSetupIncorrectConsumes.txt && die 'Failed EventSetupIncorrectConsumes_cfg.py, the configuration succeeded while it should have failed' 1
+grep "A module declared it consumes an EventSetup product after its constructor" testEventSetupIncorrectConsumes.txt >/dev/null || diecat 'Failed EventSetupIncorrectConsumes_cfg.py, the configuration failed but in an unexpected way' $? testEventSetupIncorrectConsumes.txt
 
 popd

--- a/FWCore/Utilities/interface/ESGetToken.h
+++ b/FWCore/Utilities/interface/ESGetToken.h
@@ -52,7 +52,7 @@ namespace edm {
     constexpr explicit ESGetToken(ADAPTER&& iAdapter) : ESGetToken(iAdapter.template consumes<ESProduct, ESRecord>()) {}
 
     template <typename ADAPTER>
-    constexpr ESGetToken<ESProduct, ESRecord>& operator=(ADAPTER&& iAdapter) noexcept {
+    constexpr ESGetToken<ESProduct, ESRecord>& operator=(ADAPTER&& iAdapter) {
       ESGetToken<ESProduct, ESRecord> temp(std::forward<ADAPTER>(iAdapter));
       return (*this = std::move(temp));
     }


### PR DESCRIPTION
#### PR description:

The `EventSetupIncorrectConsumes` test succeeds if the configuration the test runs fails. The job was failing (i.e. test succeeding), but for wrong reason: the configuration did not exist. This PR adds a configuration that tests the functionality properly, i.e. that an exception is thrown if `esConsumes()` is called outside of the EDModule constructor. Thanks to @Dr15Jones for finding this out. The test is also improved to fail if the job fails in a different way.

The second commit removes some `noexcept` specifiers to allow the exception from `esConsumes()` to propagate through `EDConsumerBaseAdaptor` classes.

#### PR validation:

Framework unit tests run.