### PR TITLE
Remove unused MASS_POINT and SLHA_FILE from Exotica_HSCP_SIM_cfi

### DIFF
--- a/SimG4Core/CustomPhysics/python/Exotica_HSCP_SIM_cfi.py
+++ b/SimG4Core/CustomPhysics/python/Exotica_HSCP_SIM_cfi.py
@@ -4,8 +4,6 @@ import FWCore.ParameterSet.Config as cms
 def customise(process):
 
     FLAVOR = process.generator.hscpFlavor.value()
-    MASS_POINT = process.generator.massPoint.value()
-    SLHA_FILE = process.generator.SLHAFileForPythia8.value()
     PROCESS_FILE = process.generator.processFile.value()
     PARTICLE_FILE = process.generator.particleFile.value()
     USE_REGGE = process.generator.useregge.value()


### PR DESCRIPTION
#### PR description:

Tau-prime samples dont have SLHA inputs [1], but when doing a GEN-SIM campaign the SIM part for the costumization looks for a value, that is never used after all, and so the cmsDriver command cannot be built.

[1] https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/EXO-RunIISummer20UL17GENSIM-00002

#### PR validation:

Running
```
cmsDriver.py Configuration/GenProduction/python/EXO-RunIISummer20UL17GENSIM-00002-fragment.py --python_filename EXO-RunIISummer20UL17GENSIM-00002_1_cfg.py --eventcontent RAWSIM --customise SimG4Core/CustomPhysics/Exotica_HSCP_SIM_cfi.customise,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --fileout file:EXO-RunIISummer20UL17GENSIM-00002.root --conditions 106X_mc2017_realistic_v6 --beamspot Realistic25ns13TeVEarly2017Collision --customise_commands process.source.numberEventsInLuminosityBlock="cms.untracked.uint32(100)" --step GEN,SIM --geometry DB:Extended --era Run2_2017 --no_exec --mc -n 10
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

It's a partial backport of https://github.com/cms-sw/cmssw/pull/28416