### PR TITLE
First version of Payload Inspector plots for DropBoxMetadata

### DIFF
--- a/CondCore/PhysicsToolsPlugins/interface/DropBoxMetaDataPayloadInspectorHelper.h
+++ b/CondCore/PhysicsToolsPlugins/interface/DropBoxMetaDataPayloadInspectorHelper.h
@@ -5,6 +5,8 @@
 #include "TH2.h"
 #include "TStyle.h"
 #include "TCanvas.h"
+#include "TLatex.h"
+#include "TLine.h"
 
 #include <fmt/printf.h>
 #include <fstream>
@@ -118,19 +120,22 @@ namespace DBoxMetadataHelper {
 
         if ((val.getPrepMetaData()).compare(refval.getPrepMetaData()) != 0) {
           edm::LogPrint("DropBoxMetadataPIHelper") << "found difference in prep metadata!" << std::endl;
-          edm::LogPrint("DropBoxMetadataPIHelper") << " in target: " << cleanJson(val.getPrepMetaData()) << std::endl;
+          edm::LogPrint("DropBoxMetadataPIHelper")
+              << " in target   : " << cleanJson(val.getPrepMetaData()) << std::endl;
           edm::LogPrint("DropBoxMetadataPIHelper")
               << " in reference: " << cleanJson(refval.getPrepMetaData()) << std::endl;
         }
         if ((val.getProdMetaData()).compare(refval.getProdMetaData()) != 0) {
           edm::LogPrint("DropBoxMetadataPIHelper") << "found difference in prod metadata!" << std::endl;
-          edm::LogPrint("DropBoxMetadataPIHelper") << " in target: " << cleanJson(val.getProdMetaData()) << std::endl;
+          edm::LogPrint("DropBoxMetadataPIHelper")
+              << " in target   : " << cleanJson(val.getProdMetaData()) << std::endl;
           edm::LogPrint("DropBoxMetadataPIHelper")
               << " in reference: " << cleanJson(refval.getProdMetaData()) << std::endl;
         }
         if ((val.getMultiMetaData()).compare(refval.getMultiMetaData()) != 0) {
           edm::LogPrint("DropBoxMetadataPIHelper") << "found difference in multi metadata!" << std::endl;
-          edm::LogPrint("DropBoxMetadataPIHelper") << " in target: " << cleanJson(val.getMultiMetaData()) << std::endl;
+          edm::LogPrint("DropBoxMetadataPIHelper")
+              << " in target   : " << cleanJson(val.getMultiMetaData()) << std::endl;
           edm::LogPrint("DropBoxMetadataPIHelper")
               << " in reference: " << cleanJson(refval.getMultiMetaData()) << std::endl;
         }
@@ -178,6 +183,474 @@ namespace DBoxMetadataHelper {
     std::string cleanJson(std::string str) {
       std::string out = replaceAll(str, std::string("&quot;"), std::string("'"));
       return out;
+    }
+  };
+
+  class DBMetaDataPlotDisplay {
+  public:
+    DBMetaDataPlotDisplay(DBoxMetadataHelper::recordMap theMap, std::string theTag, std::string theIOV)
+        : m_Map(theMap), tagName(theTag), IOVsinceDisplay(theIOV) {}
+    ~DBMetaDataPlotDisplay() = default;
+
+    void setImageFileName(std::string theFileName) {
+      imageFileName_ = theFileName;
+      return;
+    }
+
+    void plotMetaDatas() {
+      unsigned int mapsize = m_Map.size();
+      float pitch = 1. / (mapsize * 1.1);
+
+      float y, x1, x2;
+      std::vector<float> y_x1, y_x2, y_line;
+      std::vector<std::string> s_x1, s_x2, s_x3;
+
+      // starting table at y=1.0 (top of the canvas)
+      // first column is at 0.02, second column at 0.32 NDC
+      y = 1.0;
+      x1 = 0.02;
+      x2 = x1 + 0.30;
+
+      y -= pitch;
+      y_x1.push_back(y);
+      s_x1.push_back("#scale[1.2]{Key}");
+      y_x2.push_back(y);
+      s_x2.push_back("#scale[1.2]{tag: " + tagName + " in IOV: " + IOVsinceDisplay + "}");
+
+      y -= pitch / 2.;
+      y_line.push_back(y);
+
+      for (const auto& element : m_Map) {
+        y -= pitch;
+        y_x1.push_back(y);
+        s_x1.push_back(element.first);
+
+        std::vector<std::string> output;
+        std::string toAppend = "";
+
+        std::string prepMetaData = element.second.getPrepMetaData();
+        std::string prodMetaData = element.second.getProdMetaData();
+
+        // Remove &quot and uninteresting text from output for sake of clarity
+        eraseAllSubStr(prepMetaData, "&quot");
+        eraseAllSubStr(prepMetaData, "destinationDatabase;: ;oracle://cms_orcoff_prep/CMS_CONDITIONS;, ");
+        eraseAllSubStr(prepMetaData, ";since;: null,");
+
+        eraseAllSubStr(prodMetaData, "&quot");
+        eraseAllSubStr(prodMetaData, "destinationDatabase;: ;oracle://cms_orcon_prod/CMS_CONDITIONS;, ");
+        eraseAllSubStr(prodMetaData, ";since;: null,");
+
+        const std::vector<std::string> pathsPrep = decompose(prepMetaData);
+        const std::vector<std::string> pathsProd = decompose(prodMetaData);
+
+        const int colWidth = 80;
+
+        toAppend = "PREP: ";
+        for (unsigned int iPath = 0; iPath < pathsPrep.size(); ++iPath) {
+          std::string thisString = pathsPrep[iPath];
+
+          // if the line to be added has less than colWidth chars append to current
+          if ((toAppend + thisString).length() < colWidth) {
+            toAppend += thisString;
+          } else {
+            // else if the line exceeds colWidth chars, dump in the vector and resume from scratch
+            output.push_back(toAppend);
+            toAppend.clear();
+            toAppend += thisString;
+          }
+          // if it's the last, dump it
+          if (iPath == pathsPrep.size() - 1) {
+            output.push_back(toAppend);
+          }
+        }
+
+        toAppend = "PROD: ";
+        for (unsigned int iPath = 0; iPath < pathsProd.size(); ++iPath) {
+          std::string thisString = pathsProd[iPath];
+
+          // if the line to be added has less than colWidth chars append to current
+          if ((toAppend + thisString).length() < colWidth) {
+            toAppend += thisString;
+          } else {
+            // else if the line exceeds colWidth chars, dump in the vector and resume from scratch
+            output.push_back(toAppend);
+            toAppend.clear();
+            toAppend += thisString;
+          }
+          // if it's the last, dump it
+          if (iPath == pathsProd.size() - 1)
+            output.push_back(toAppend);
+        }
+
+        for (unsigned int br = 0; br < output.size(); br++) {
+          y_x2.push_back(y);
+          // do not use red color since colors get mixed if output[br]
+          // contains a right curly brace (I could not find a way to circumvent that)
+          s_x2.push_back(output[br]);
+
+          if (br != output.size() - 1)
+            y -= pitch;
+        }
+
+        y_line.push_back(y - (pitch / 2.));
+      }
+
+      TCanvas canvas("DropBoxMetaData", "DropBoxMetaData", 2000, std::max(y_x1.size(), y_x2.size()) * 40);
+      TLatex l;
+
+      // Draw the columns titles
+      l.SetTextAlign(12);
+      float newpitch = 1 / (std::max(y_x1.size(), y_x2.size()) * 1.1);
+      float factor = newpitch / pitch;
+      l.SetTextSize(newpitch - 0.002);
+      canvas.cd();
+      for (unsigned int i = 0; i < y_x1.size(); i++) {
+        l.DrawLatexNDC(x1, 1 - (1 - y_x1[i]) * factor, s_x1[i].c_str());
+      }
+
+      for (unsigned int i = 0; i < y_x2.size(); i++) {
+        l.DrawLatexNDC(x2, 1 - (1 - y_x2[i]) * factor, s_x2[i].c_str());
+      }
+      canvas.cd();
+      canvas.Update();
+
+      // Draw horizontal lines separating records
+      TLine lines[y_line.size()];
+      unsigned int iL = 0;
+      for (const auto& line : y_line) {
+        lines[iL] = TLine(gPad->GetUxmin(), 1 - (1 - line) * factor, gPad->GetUxmax(), 1 - (1 - line) * factor);
+        lines[iL].SetLineWidth(1);
+        lines[iL].SetLineStyle(9);
+        lines[iL].SetLineColor(2);
+        lines[iL].Draw("same");
+        iL++;
+      }
+
+      std::string fileName("DropBoxMetadata_Display.png");
+      if (!imageFileName_.empty())
+        fileName = imageFileName_;
+      canvas.SaveAs(fileName.c_str());
+    }
+
+    void plotDiffWithMetadata(const DBoxMetadataHelper::recordMap& theRefMap,
+                              std::string theRefTag,
+                              std::string theRefIOV) {
+      const auto& ref_records = DBoxMetadataHelper::getAllRecords(theRefMap);
+      const auto& tar_records = DBoxMetadataHelper::getAllRecords(m_Map);
+
+      //      const auto& diff = DBoxMetadataHelper::set_difference(ref_records, tar_records);
+      const auto& common = DBoxMetadataHelper::set_intersection(ref_records, tar_records);
+
+      // preparations for plotting
+      // starting table at y=1.0 (top of the canvas)
+      // first column is at 0.03, second column at 0.22 NDC
+      unsigned int mapsize = 2 * m_Map.size();
+      float pitch = 1. / (mapsize * 1.1);
+      float y, x1, x2;
+      std::vector<float> y_x1, y_x2, y_line;
+      std::vector<std::string> s_x1, s_x2, s_x3;
+      y = 1.0;
+      x1 = 0.02;
+      x2 = x1 + 0.30;
+      y -= pitch;
+
+      // title for plot
+      y_x1.push_back(y);
+      s_x1.push_back("#scale[1.2]{Key}");
+      y_x2.push_back(y);
+      //      s_x2.push_back("#scale[1.2]{tags (target/ref): " + tagName + "/" + theRefTag
+      //		     + " in IOVs: " + IOVsinceDisplay + "/" + theRefIOV + "}");
+      s_x2.push_back("#scale[1.2]{Target tag / IOV    :" + tagName + " / " + IOVsinceDisplay + "}");
+
+      y -= pitch;
+      y_x1.push_back(y);
+      s_x1.push_back("");
+      y_x2.push_back(y);
+      s_x2.push_back("#scale[1.2]{Reference tag / IOV :" + theRefTag + " / " + theRefIOV + "}");
+
+      y -= pitch / 2.;
+      y_line.push_back(y);
+
+      // do first the common parts
+      for (const auto& key : common) {
+        const auto& val = m_Map.at(key);
+        const auto& refval = theRefMap.at(key);
+
+        y -= pitch;
+        y_x1.push_back(y);
+        s_x1.push_back(key);
+
+        std::vector<std::string> output;
+        std::string toAppend = "";
+
+        std::string tarPrepMetaData = val.getPrepMetaData();
+        std::string tarProdMetaData = val.getProdMetaData();
+        std::string refPrepMetaData = refval.getPrepMetaData();
+        std::string refProdMetaData = refval.getProdMetaData();
+
+        // Remove &quot and uninteresting text from output for sake of clarity
+        eraseAllSubStr(tarPrepMetaData, "&quot");
+        eraseAllSubStr(tarPrepMetaData, "destinationDatabase;: ;oracle://cms_orcoff_prep/CMS_CONDITIONS;, ");
+        eraseAllSubStr(tarPrepMetaData, ";since;: null,");
+        eraseAllSubStr(refPrepMetaData, "&quot");
+        eraseAllSubStr(refPrepMetaData, "destinationDatabase;: ;oracle://cms_orcoff_prep/CMS_CONDITIONS;, ");
+        eraseAllSubStr(refPrepMetaData, ";since;: null,");
+
+        eraseAllSubStr(tarProdMetaData, "&quot");
+        eraseAllSubStr(tarProdMetaData, "destinationDatabase;: ;oracle://cms_orcon_prod/CMS_CONDITIONS;, ");
+        eraseAllSubStr(tarProdMetaData, "since;: null, ;");
+        eraseAllSubStr(refProdMetaData, "&quot");
+        eraseAllSubStr(refProdMetaData, "destinationDatabase;: ;oracle://cms_orcon_prod/CMS_CONDITIONS;, ");
+        eraseAllSubStr(refProdMetaData, "since;: null, ;");
+
+        const std::vector<std::string> tarPathsPrep = decompose(tarPrepMetaData);
+        const std::vector<std::string> refPathsPrep = decompose(refPrepMetaData);
+        const std::vector<std::string> tarPathsProd = decompose(tarProdMetaData);
+        const std::vector<std::string> refPathsProd = decompose(refProdMetaData);
+
+        const int colWidth = 80;
+
+        bool refAndTarIdentical = true;
+        std::string tmpTar = "";
+        std::string tmpRef = "";
+
+        toAppend = "PREP/tar: ";
+        for (unsigned int iPath = 0; iPath < tarPathsPrep.size(); ++iPath) {
+          std::string thisString = tarPathsPrep[iPath];
+
+          // if the line to be added has less than colWidth chars append to current
+          if ((toAppend + thisString).length() < colWidth) {
+            toAppend += thisString;
+          } else {
+            // else if the line exceeds colWidth chars, dump in the vector and resume from scratch
+            output.push_back(toAppend);
+            tmpTar += toAppend;
+            toAppend.clear();
+            toAppend += thisString;
+          }
+          // if it's the last, dump it
+          if (iPath == tarPathsPrep.size() - 1) {
+            output.push_back(toAppend);
+            tmpTar += toAppend;
+          }
+        }
+
+        toAppend = "PREP/ref: ";
+        for (unsigned int iPath = 0; iPath < refPathsPrep.size(); ++iPath) {
+          std::string thisString = refPathsPrep[iPath];
+
+          // if the line to be added has less than colWidth chars append to current
+          if ((toAppend + thisString).length() < colWidth) {
+            toAppend += thisString;
+          } else {
+            // else if the line exceeds colWidth chars, dump in the vector and resume from scratch
+            output.push_back(toAppend);
+            tmpRef += toAppend;
+            toAppend.clear();
+            toAppend += thisString;
+          }
+          // if it's the last, dump it
+          if (iPath == refPathsPrep.size() - 1) {
+            output.push_back(toAppend);
+            tmpRef += toAppend;
+          }
+        }
+
+        // check if printouts are identical for PREP
+        eraseAllSubStr(tmpTar, "PREP/tar: ");
+        eraseAllSubStr(tmpRef, "PREP/ref: ");
+        if (tmpTar != tmpRef)
+          refAndTarIdentical = false;
+        tmpTar = "";
+        tmpRef = "";
+
+        toAppend = "PROD/tar: ";
+        for (unsigned int iPath = 0; iPath < tarPathsProd.size(); ++iPath) {
+          std::string thisString = tarPathsProd[iPath];
+
+          // if the line to be added has less than colWidth chars append to current
+          if ((toAppend + thisString).length() < colWidth) {
+            toAppend += thisString;
+          } else {
+            // else if the line exceeds colWidth chars, dump in the vector and resume from scratch
+            output.push_back(toAppend);
+            tmpTar += toAppend;
+            toAppend.clear();
+            toAppend += thisString;
+          }
+          // if it's the last, dump it
+          if (iPath == tarPathsProd.size() - 1) {
+            output.push_back(toAppend);
+            tmpTar += toAppend;
+          }
+        }
+
+        toAppend = "PROD/ref: ";
+        for (unsigned int iPath = 0; iPath < refPathsProd.size(); ++iPath) {
+          std::string thisString = refPathsProd[iPath];
+
+          // if the line to be added has less than colWidth chars append to current
+          if ((toAppend + thisString).length() < colWidth) {
+            toAppend += thisString;
+          } else {
+            // else if the line exceeds colWidth chars, dump in the vector and resume from scratch
+            output.push_back(toAppend);
+            tmpRef += toAppend;
+            toAppend.clear();
+            toAppend += thisString;
+          }
+          // if it's the last, dump it
+          if (iPath == refPathsProd.size() - 1) {
+            output.push_back(toAppend);
+            tmpRef += toAppend;
+          }
+        }
+
+        // check if printouts are identical for PROD
+        eraseAllSubStr(tmpTar, "PROD/tar: ");
+        eraseAllSubStr(tmpRef, "PROD/ref: ");
+        if (tmpTar != tmpRef)
+          refAndTarIdentical = false;
+
+        // print either "identical" or contents of tags
+        if (refAndTarIdentical) {
+          y_x2.push_back(y);
+          s_x2.push_back("identical");
+        } else {
+          for (unsigned int br = 0; br < output.size(); br++) {
+            y_x2.push_back(y);
+            // do not use red color since colors get mixed if output[br]
+            // contains a right curly brace (I could not find a way to circumvent that)
+            s_x2.push_back(output[br]);
+
+            if (br != output.size() - 1)
+              y -= pitch;
+          }
+        }
+
+        y_line.push_back(y - (pitch / 2.));
+      }
+
+      // now when common parts are handled, check if there are additional records
+      // (one could check if diff is empty, but his doesn't seem to work as expected)
+
+      // First, check if there are records in reference which are not in target
+      for (const auto& ref : ref_records) {
+        if (std::find(tar_records.begin(), tar_records.end(), ref) == tar_records.end()) {
+          y -= pitch;
+          y_x1.push_back(y);
+          s_x1.push_back(ref);
+          y_x2.push_back(y);
+          s_x2.push_back("Only in reference, not in target.");
+          y_line.push_back(y - (pitch / 2.));
+        }
+      }
+
+      // Second, check if there are records in targe which are not in reference
+      for (const auto& tar : tar_records) {
+        if (std::find(ref_records.begin(), ref_records.end(), tar) == ref_records.end()) {
+          y -= pitch;
+          y_x1.push_back(y);
+          s_x1.push_back(tar);
+          y_x2.push_back(y);
+          s_x2.push_back("Only in reference, not in target. ");
+          y_line.push_back(y - (pitch / 2.));
+        }
+      }
+
+      // Finally, print text to TCanvas
+
+      TCanvas canvas("DropBoxMetaData", "DropBoxMetaData", 2000, std::max(y_x1.size(), y_x2.size()) * 40);
+      TLatex l;
+      // Draw the columns titles
+      l.SetTextAlign(12);
+
+      float newpitch = 1 / (std::max(y_x1.size(), y_x2.size()) * 1.1);
+      float factor = newpitch / pitch;
+      l.SetTextSize(newpitch - 0.002);
+      canvas.cd();
+      for (unsigned int i = 0; i < y_x1.size(); i++) {
+        l.DrawLatexNDC(x1, 1 - (1 - y_x1[i]) * factor, s_x1[i].c_str());
+      }
+
+      for (unsigned int i = 0; i < y_x2.size(); i++) {
+        l.DrawLatexNDC(x2, 1 - (1 - y_x2[i]) * factor, s_x2[i].c_str());
+      }
+
+      canvas.cd();
+      canvas.Update();
+
+      // Draw horizontal lines separating records
+      TLine lines[y_line.size()];
+      unsigned int iL = 0;
+      for (const auto& line : y_line) {
+        lines[iL] = TLine(gPad->GetUxmin(), 1 - (1 - line) * factor, gPad->GetUxmax(), 1 - (1 - line) * factor);
+        lines[iL].SetLineWidth(1);
+        lines[iL].SetLineStyle(9);
+        lines[iL].SetLineColor(2);
+        lines[iL].Draw("same");
+        iL++;
+      }
+
+      std::string fileName("DropBoxMetadata_Compare.png");
+      if (!imageFileName_.empty())
+        fileName = imageFileName_;
+      canvas.SaveAs(fileName.c_str());
+    }
+
+  private:
+    DBoxMetadataHelper::recordMap m_Map;
+    std::string tagName;
+    std::string IOVsinceDisplay;
+    std::string imageFileName_;
+
+    std::string replaceAll(std::string str, const std::string& from, const std::string& to) {
+      size_t start_pos = 0;
+      while ((start_pos = str.find(from, start_pos)) != std::string::npos) {
+        str.replace(start_pos, from.length(), to);
+        start_pos += to.length();  // Handles case where 'to' is a substring of 'from'
+      }
+      return str;
+    }
+
+    std::string cleanJson(std::string str) {
+      std::string out = replaceAll(str, std::string("&quot;"), std::string("'"));
+      return out;
+    }
+
+    void eraseAllSubStr(std::string& s, const std::string& toErase) {
+      size_t pos = std::string::npos;
+      // Search for the substring in string in a loop until nothing is found
+      while ((pos = s.find(toErase)) != std::string::npos) {
+        // If found then erase it from string
+        s.erase(pos, toErase.length());
+      }
+      return;
+    }
+
+    std::vector<std::string> decompose(const std::string& s) const {
+      // decompose 's' into its parts that are separated by 'delimeter_'
+      // (similar as in
+      //  Alignment/CommonAlignmentAlgorithm/src/AlignmentParameterSelector.cc)
+
+      const std::string::value_type delimeter_ = ';';  // separator
+
+      std::vector<std::string> result;
+      if (!(s.size() == 1 && s[0] == delimeter_)) {
+        // delimeter_ only indicates an empty list as DB cannot store empty strings
+        std::string::size_type previousPos = 0;
+        while (true) {
+          const std::string::size_type delimiterPos = s.find(delimeter_, previousPos);
+          if (delimiterPos == std::string::npos) {
+            result.push_back(s.substr(previousPos));  // until end
+            break;
+          }
+          result.push_back(s.substr(previousPos, delimiterPos - previousPos));
+          previousPos = delimiterPos + 1;  // +1: skip delim
+        }
+      }
+
+      return result;
     }
   };
 }  // namespace DBoxMetadataHelper

--- a/CondCore/PhysicsToolsPlugins/plugins/DropBoxMetadata_PayloadInspector.cc
+++ b/CondCore/PhysicsToolsPlugins/plugins/DropBoxMetadata_PayloadInspector.cc
@@ -95,7 +95,6 @@ namespace {
       std::shared_ptr<DropBoxMetadata> payload = fetchPayload(std::get<1>(iov));
 
       std::vector<std::string> records = payload->getAllRecords();
-      TCanvas canvas("Canv", "Canv", 1200, 100 * records.size());
 
       DBoxMetadataHelper::recordMap theRecordMap;
       for (const auto& record : records) {
@@ -107,8 +106,10 @@ namespace {
       DBoxMetadataHelper::DBMetaDataTableDisplay theDisplay(theRecordMap);
       theDisplay.printMetaDatas();
 
-      std::string fileName(m_imageFileName);
-      canvas.SaveAs(fileName.c_str());
+      DBoxMetadataHelper::DBMetaDataPlotDisplay thePlot(theRecordMap, tag.name, std::to_string(std::get<0>(iov)));
+      thePlot.setImageFileName(this->m_imageFileName);
+      thePlot.plotMetaDatas();
+
       return true;
     }
 
@@ -175,9 +176,14 @@ namespace {
 
       l_theDisplay.printDiffWithMetadata(f_theRecordMap);
 
-      TCanvas canvas("Canv", "Canv", 1200, 100 * std::max(f_records.size(), l_records.size()));
-      std::string fileName(this->m_imageFileName);
-      canvas.SaveAs(fileName.c_str());
+      // In case of only one tag, use f_tagname for both target and reference
+      std::string tmpTagName = l_tagname;
+      if (tmpTagName.empty())
+        tmpTagName = f_tagname;
+      DBoxMetadataHelper::DBMetaDataPlotDisplay thePlot(l_theRecordMap, tmpTagName, lastIOVsince);
+      thePlot.setImageFileName(this->m_imageFileName);
+      thePlot.plotDiffWithMetadata(f_theRecordMap, f_tagname, firstIOVsince);
+
       return true;
     }
 

--- a/CondCore/PhysicsToolsPlugins/test/test_DropBoxMetadata_PayloadInspector.sh
+++ b/CondCore/PhysicsToolsPlugins/test/test_DropBoxMetadata_PayloadInspector.sh
@@ -7,7 +7,7 @@ export SCRAM_ARCH;
 source /afs/cern.ch/cms/cmsset_default.sh;
 eval `scram run -sh`;
 
-mkdir -p $W_DIR/results
+mkdir -p $W_DIR/plots
 
 getPayloadData.py \
     --plugin pluginDropBoxMetadata_PayloadInspector \
@@ -18,6 +18,8 @@ getPayloadData.py \
     --db Prod \
     --test
 
+mv *.png $W_DIR/plots/
+
 getPayloadData.py \
     --plugin pluginDropBoxMetadata_PayloadInspector \
     --plot plot_DropBoxMetadata_Display \
@@ -27,6 +29,8 @@ getPayloadData.py \
     --db Prod \
     --test
 
+mv *.png $W_DIR/plots/DropBoxMetadata_Display.png
+
 getPayloadData.py \
     --plugin pluginDropBoxMetadata_PayloadInspector \
     --plot plot_DropBoxMetadata_Compare \
@@ -35,3 +39,18 @@ getPayloadData.py \
     --iovs '{"start_iov": "345684", "end_iov": "346361"}' \
     --db Prod \
     --test
+
+mv *.png $W_DIR/plots/DropBoxMetadata_Compare.png
+
+getPayloadData.py \
+    --plugin pluginDropBoxMetadata_PayloadInspector \
+    --plot plot_DropBoxMetadata_CompareTwoTags \
+    --tag DropBoxMetadata_v5_express \
+    --tagtwo DropBoxMetadata_v6_express \
+    --time_type Run \
+    --iovs '{"start_iov": "248203", "end_iov": "284203"}' \
+    --iovstwo '{"start_iov": "284203", "end_iov": "284203"}' \
+    --db Prod \
+    --test
+
+mv *.png $W_DIR/plots/DropBoxMetadata_CompareTwoTags.png


### PR DESCRIPTION
#### PR description:

This PR introduces new plots for the Payload Inspector for the class DropBoxMetadata as well as a script for testing. These plots can 1) display content of a DropBoxMetadata tag, 2) compare two IOVs of one tag, and 3) compare two tags. Examples of the plots are attached.

This PR continues from the infrastructural changes introduced in #35956 . This PR however does not fully exploit the new intrastructure, since it is useful to quickly make these new tools available.  

HLTPlugins/plugins/AlCaRecoTriggerBits_PayloadInspector.cc was used as a source of inspiration for this work.

DropBoxMetadata is describe in this TWiki page: https://twiki.cern.ch/twiki/bin/view/CMS/ConditionUploader#Metadata_file .

#### PR validation:

PR passes the introduced test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport foreseen.

-----------

![DropBoxMetadata_Display](https://user-images.githubusercontent.com/51359/146387990-556d7957-aeaf-4730-a85b-fcdc2f3f37fd.png)
![DropBoxMetadata_Compare](https://user-images.githubusercontent.com/51359/146388006-961d59ae-5278-4966-a06b-1afc83f6da6e.png)
![DropBoxMetadata_CompareTwoTags](https://user-images.githubusercontent.com/51359/146388014-d8c925bc-7964-44bf-8d36-e3160d9683dc.png)

