### PR TITLE
MTD reconstruction: Implementation of MTDTrayBarrelLayer::groupedCompatibleDets()

### DIFF
--- a/RecoMTD/DetLayers/src/MTDDetTray.cc
+++ b/RecoMTD/DetLayers/src/MTDDetTray.cc
@@ -129,8 +129,14 @@ vector<GeometricSearchDet::DetWithState> MTDDetTray::compatibleDets(const Trajec
 vector<DetGroup> MTDDetTray::groupedCompatibleDets(const TrajectoryStateOnSurface& startingState,
                                                    const Propagator& prop,
                                                    const MeasurementEstimator& est) const {
-  // FIXME should return only 1 group
-  edm::LogError("MTDDetLayers") << "dummy implementation of MTDDetTray::groupedCompatibleDets()";
+  vector<GeometricSearchDet::DetWithState> detWithStates;
+
+  detWithStates = compatibleDets(startingState, prop, est);
+
   vector<DetGroup> result;
+  if (!detWithStates.empty()) {
+    result.push_back(DetGroup(detWithStates));
+  }
+  LogTrace("MTDDetLayers") << "MTDdetTray Compatible modules: " << result.size();
   return result;
 }

--- a/RecoMTD/DetLayers/src/MTDTrayBarrelLayer.cc
+++ b/RecoMTD/DetLayers/src/MTDTrayBarrelLayer.cc
@@ -163,9 +163,16 @@ vector<GeometricSearchDet::DetWithState> MTDTrayBarrelLayer::compatibleDets(
 vector<DetGroup> MTDTrayBarrelLayer::groupedCompatibleDets(const TrajectoryStateOnSurface& startingState,
                                                            const Propagator& prop,
                                                            const MeasurementEstimator& est) const {
-  // FIXME should return only 1 group
-  edm::LogError("MTDDetLayers") << "dummy implementation of MTDTrayBarrelLayer::groupedCompatibleDets()";
-  return vector<DetGroup>();
+  vector<GeometricSearchDet::DetWithState> detWithStates;
+
+  detWithStates = compatibleDets(startingState, prop, est);
+
+  vector<DetGroup> result;
+  if (!detWithStates.empty()) {
+    result.push_back(DetGroup(detWithStates));
+  }
+  LogTrace("MTDDetLayers") << "MTDTrayBarrelLayer Compatible rods: " << result.size();
+  return result;
 }
 
 GeomDetEnumerators::SubDetector MTDTrayBarrelLayer::subDetector() const { return theBasicComps.front()->subDetector(); }


### PR DESCRIPTION
#### PR description:

The ```MTDTrayBarrelLayer``` class misses a real implementation of the ```groupedCompatibleDets``` method, which is invoked during the track building. This simple implementation removes the warning messages while running Phase2 reconstruction with the alternative navigation school where MTD is added, and allows the code to fail (as it should) because the CKF does not find a ```MeasurementDet``` in ```MeasurementTracker``` compatible with BTL layers:

```
----- Begin Fatal Exception 16-Dec-2021 17:10:29 CET-----------------------
An exception of category 'MeasurementDet not found' occurred while
   [0] Processing  Event run: 1 lumi: 1 event: 1 stream: 0
   [1] Running path 'dqmofflineOnPAT_1_step'
   [2] Prefetching for module SingleTopTChannelLeptonDQM_miniAOD/'singleTopElectronMediumDQM_miniAOD'
   [3] Prefetching for module PATMuonSlimmer/'slimmedMuons'
   [4] Prefetching for module PATMuonSelector/'selectedPatMuons'
   [5] Prefetching for module PATMuonProducer/'patMuons'
   [6] Prefetching for module MuonProducer/'muons'
   [7] Prefetching for module MuonIdProducer/'muons1stStep'
   [8] Prefetching for module DuplicateListMerger/'generalTracks'
   [9] Prefetching for module TrackProducer/'mergedDuplicateTracks'
   [10] Prefetching for module DuplicateTrackMerger/'duplicateTrackCandidates'
   [11] Prefetching for module TrackListMerger/'preDuplicateMergingGeneralTracks'
   [12] Prefetching for module TrackListMerger/'earlyGeneralTracks'
   [13] Prefetching for module MultiTrackSelector/'initialStepSelector'
   [14] Prefetching for module TrackProducer/'initialStepTracks'
   [15] Calling method for module CkfTrackCandidateMaker/'initialStepTrackCandidates'
----- End Fatal Exception -------------------------------------------------
```

#### PR validation:

This code is not called in usual workflows, where MTD is not part of the tracking navigation school. The implementation is a straightforward copy of the forward counterpart, without the need of different groups.