### PR TITLE
Fixing Patatrak pixelTracking only wfs

### DIFF
--- a/RecoLocalTracker/SiPixelRecHits/python/SiPixelRecHits_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/SiPixelRecHits_cfi.py
@@ -22,13 +22,18 @@ siPixelRecHitsPreSplitting = SwitchProducerCUDA(
 )
 
 # convert the pixel rechits from legacy to SoA format
-from RecoLocalTracker.SiPixelRecHits.siPixelRecHitSoAFromLegacy_cfi import siPixelRecHitSoAFromLegacy as siPixelRecHitsPreSplittingSoA
+from RecoLocalTracker.SiPixelRecHits.siPixelRecHitSoAFromLegacy_cfi import siPixelRecHitSoAFromLegacy as _siPixelRecHitsPreSplittingSoA
+siPixelRecHitsPreSplittingSoA = _siPixelRecHitsPreSplittingSoA.clone(convertToLegacy=True)
+
+# modifier used to prompt patatrack pixel tracks reconstruction on cpu
+from Configuration.ProcessModifiers.pixelNtupletFit_cff import pixelNtupletFit
+pixelNtupletFit.toModify(siPixelRecHitsPreSplitting,
+    cpu = siPixelRecHitsPreSplittingSoA.clone()
+)
 
 siPixelRecHitsPreSplittingTask = cms.Task(
-    # SwitchProducer wrapping the legacy pixel rechit producer
-    siPixelRecHitsPreSplitting,
-    # convert the pixel rechits from legacy to SoA format
-    siPixelRecHitsPreSplittingSoA
+    # SwitchProducer wrapping the legacy pixel rechit producer or the cpu SoA producer
+    siPixelRecHitsPreSplitting
 )
 
 # reconstruct the pixel rechits on the gpu
@@ -39,14 +44,21 @@ siPixelRecHitsPreSplittingCUDA = _siPixelRecHitCUDA.clone(
 
 # transfer the pixel rechits to the host and convert them from SoA
 from RecoLocalTracker.SiPixelRecHits.siPixelRecHitFromCUDA_cfi import siPixelRecHitFromCUDA as _siPixelRecHitFromCUDA
-gpu.toModify(siPixelRecHitsPreSplitting, 
-    cuda = _siPixelRecHitFromCUDA.clone()
-)
 
-gpu.toReplaceWith(siPixelRecHitsPreSplittingTask, cms.Task(
+(gpu & pixelNtupletFit).toModify(siPixelRecHitsPreSplitting,
+    cpu = cms.EDAlias(
+            siPixelRecHitsPreSplittingSoA = cms.VPSet(
+                 cms.PSet(type = cms.string("SiPixelRecHitedmNewDetSetVector")),
+                 cms.PSet(type = cms.string("uintAsHostProduct"))
+             )
+         ),
+    cuda = _siPixelRecHitFromCUDA.clone())
+
+(gpu & pixelNtupletFit).toReplaceWith(siPixelRecHitsPreSplittingTask, cms.Task(
     # reconstruct the pixel rechits on the gpu
     siPixelRecHitsPreSplittingCUDA,
-    # SwitchProducer wrapping the legacy pixel rechit producer or the transfer of the pixel rechits to the host and the conversion from SoA
+    # producing and converting on cpu
+    siPixelRecHitsPreSplittingSoA,
+    # SwitchProducer wrapping an EDAlias on cpu or the converter from SoA to legacy on gpu
     siPixelRecHitsPreSplittingTask.copy()
 ))
-

--- a/RecoPixelVertexing/PixelTrackFitting/python/PixelTracks_cff.py
+++ b/RecoPixelVertexing/PixelTrackFitting/python/PixelTracks_cff.py
@@ -93,14 +93,17 @@ from Configuration.ProcessModifiers.pixelNtupletFit_cff import pixelNtupletFit
 
 from RecoPixelVertexing.PixelTriplets.pixelTracksCUDA_cfi import pixelTracksCUDA as _pixelTracksCUDA
 
+#Pixel tracks in SoA format on the CPU
+pixelTracksCPU = _pixelTracksCUDA.clone(
+    pixelRecHitSrc = "siPixelRecHitsPreSplitting",
+    idealConditions = False,
+    onGPU = False
+)
+
 # SwitchProducer providing the pixel tracks in SoA format on the CPU
 pixelTracksSoA = SwitchProducerCUDA(
     # build pixel ntuplets and pixel tracks in SoA format on the CPU
-    cpu = _pixelTracksCUDA.clone(
-        pixelRecHitSrc = "siPixelRecHitsPreSplittingSoA",
-        idealConditions = False,
-        onGPU = False
-    )
+    cpu = pixelTracksCPU
 )
 # use quality cuts tuned for Run 2 ideal conditions for all Run 3 workflows
 run3_common.toModify(pixelTracksSoA.cpu,
@@ -127,8 +130,11 @@ pixelNtupletFit.toReplaceWith(pixelTracksTask, cms.Task(
 ))
 
 
-# "Patatrack" sequence running on GPU
+# "Patatrack" sequence running on GPU (or CPU if not available)
 from Configuration.ProcessModifiers.gpu_cff import gpu
+(pixelNtupletFit & gpu).toModify(pixelTracksCPU,
+    pixelRecHitSrc = "siPixelRecHitsPreSplittingSoA",
+)
 
 # build the pixel ntuplets and pixel tracks in SoA format on the GPU
 pixelTracksCUDA = _pixelTracksCUDA.clone(


### PR DESCRIPTION
As it is now the Patatrack on CPU worflows (anything with `pixelNtupletFit` modifier, `.501` and `.505` or also `.502` and `.506` when no GPU is available ) runs both the `SiPixelRecHitSoAFromLegacy` module and the legacy/deprecated `SiPixelRecHitConverter `. This shouldn't happen and this fix this. See the dependency graph for the `.501` or `.502` on CPU wfs (dropping the validation to simplify the graph).

<img width="523" alt="image" src="https://user-images.githubusercontent.com/16901146/146466190-84c747fa-f82d-47df-b643-328af62068d5.png">

The full graphs here for [reference](https://adiflori.web.cern.ch/adiflori/cleaning_pata/cpu_ref_timing.png) and [this PR](https://adiflori.web.cern.ch/adiflori/cleaning_pata/cpu_dev_timing.png). 

The way it is creates also some mismatch in the pixel local reco given that `siPixelRecHitsPreSplitting` identifies the legacy products and then the pixel RecHit validation modules cosumes them [here](https://github.com/cms-sw/cmssw/blob/master/Validation/SiPixelPhase1ConfigV/python/SiPixelPhase1OfflineDQM_sourceV_cff.py#L29). Also the pixel tracks are built (when converting from SoA) using the legacy hits.

### PR validation:

#### Local pixel reconstruction

Differences expected in the CPU workflows given now the validation modules will consume the correct products. See comparison plots:

1. Comparison across the GPU and CPU workflows for both the `master` (reference) and this PR. See in blue the reference on CPU that's the only one mismatching. [Here](https://adiflori.web.cern.ch/adiflori/cleaning_pata/all_comparisons/index.html).
2. Comparison GPU vs CPU workflows for both the `master`. There's an "artificial" mismatch. [Here](https://adiflori.web.cern.ch/adiflori/cleaning_pata/ref_comparisons/index.html)
3. Comparison GPU vs CPU workflows for both this PR. CPU and CPU perfectly the same. [Here](https://adiflori.web.cern.ch/adiflori/cleaning_pata/pr_comparisons/index.html)

An example for the laziest:

<img width="1020" alt="image" src="https://user-images.githubusercontent.com/16901146/146421808-c060ab30-1607-49d6-9553-44434255f540.png">

#### Pixel track reconstruction

No regression expected nor observed.

See comparisons for

- `.501` ttbar CPU worflows [here](https://adiflori.web.cern.ch/adiflori/cleaning_pata/cpu_plots/)
- `.502` ttbar GPU workflows [here](https://adiflori.web.cern.ch/adiflori/cleaning_pata/gpu_plots/) [just to be sure]

no differences for pixel track reco.

