### PR TITLE
Run testBuildersReaders unit test in its own directory

### DIFF
--- a/CondTools/SiStrip/test/testBuildersReaders.sh
+++ b/CondTools/SiStrip/test/testBuildersReaders.sh
@@ -2,12 +2,16 @@
 
 function die { echo $1: status $2 ; exit $2; }
 
+if [ "${SCRAM_TEST_NAME}" != "" ] ; then
+  mkdir ${SCRAM_TEST_NAME}
+  cd ${SCRAM_TEST_NAME}
+fi
 if test -f "SiStripConditionsDBFile.db"; then
     echo "cleaning the local test area"
     rm -fr SiStripConditionsDBFile.db  # builders test
     rm -fr modifiedSiStrip*.db         # miscalibrator tests
 fi
-
+pwd
 echo " testing CondTools/SiStrip"
 
 ## do the builders first (need the input db file)


### PR DESCRIPTION
Unit test `testCondToolsSiStripBuildersReaders` randomly fails for PR tests [a]. My guess is that there might be multiple tests trying to use same sqlite file. This PR proposes to run this unit test in its own directory

[a] https://cmssdt.cern.ch/SDT/jenkins-artifacts/pull-request-integration/PR-d01ea0/21116/unitTests/src/CondTools/SiStrip/test/testCondToolsSiStripBuildersReaders/testing.log

```
SQLiteStatement::finalize 10 disk I/O error Error SQLiteStatement::finalize 10 disk I/O error
SQLiteStatement::execute 1 disk I/O error Error SQLiteStatement::execute 1 disk I/O error
----- Begin Fatal Exception 09-Dec-2021 20:07:26 CET-----------------------
An exception of category 'ConditionDatabase' occurred while
   [0] Processing  Event run: 306054 lumi: 1 event: 1 stream: 0
   [1] Running path 'p'
   [2] Calling method for module SiStripNoisesFromDBMiscalibrator/'scaleAndSmearSiStripNoises'
Exception Message:
disk I/O error ( CORAL : "SQLiteStatement::execute" from "CORAL/RelationalPlugins/sqlite" ) from PoolDBOutputService::createNewIov 
----- End Fatal Exception -------------------------------------------------
```