### PR TITLE
Fix for DTMapGenerator and cleanup for DTTTrigCorrectionFirst (in CalibMuon/DTCalibration)

### DIFF
--- a/CalibMuon/DTCalibration/plugins/DTMapGenerator.cc
+++ b/CalibMuon/DTCalibration/plugins/DTMapGenerator.cc
@@ -28,8 +28,6 @@ DTMapGenerator::DTMapGenerator(const ParameterSet& pset) {
   }
 }
 
-DTMapGenerator::~DTMapGenerator() {}
-
 void DTMapGenerator::endJob() {
   cout << "DTMapGenerator: Output Map: " << outputMapName << " ROS Type: " << rosType << endl;
 
@@ -130,8 +128,7 @@ void DTMapGenerator::endJob() {
             } else {
               outRob = robCounter + 21;
             }
-          }
-          if (sector == 4) {
+          } else if (sector == 4) {
             if (robCounter == 3 || robCounter == 4) {
               continue;
             }

--- a/CalibMuon/DTCalibration/plugins/DTMapGenerator.h
+++ b/CalibMuon/DTCalibration/plugins/DTMapGenerator.h
@@ -20,7 +20,7 @@ public:
   DTMapGenerator(const edm::ParameterSet& pset);
 
   /// Destructor
-  ~DTMapGenerator() override;
+  ~DTMapGenerator() override = default;
 
   // Operations
 

--- a/CalibMuon/DTCalibration/plugins/DTTTrigCorrectionFirst.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigCorrectionFirst.cc
@@ -57,7 +57,6 @@ void DTTTrigCorrectionFirst::endJob() {
   double rms = 0.;
   double averageSigma = 0.;
   double average2Sigma = 0.;
-  double rmsSigma = 0.;
   double counter = 0.;
   double averagekfactor = 0;
   float kfactor = 0;
@@ -92,9 +91,7 @@ void DTTTrigCorrectionFirst::endJob() {
   }  //End of loop on superlayers
 
   rms = average2 / (counter - 1);
-  rmsSigma = average2Sigma / (counter - 1);
   rms = sqrt(rms);
-  rmsSigma = sqrt(rmsSigma);
   cout << "average averageSigma counter rms " << average << " " << averageSigma << " " << counter << " " << rms << endl;
 
   for (auto sl = dtSupLylist.begin(); sl != dtSupLylist.end(); sl++) {


### PR DESCRIPTION
#### PR description:

Dead assignment reports of the static analyzer pointed out at something which looks like a bug (with a rather obvious fix) in the endJob() methid of CalibMuon/DTCalibration/plugins/DTMapGenerator.cc.
Perhaps @battibass can confirm

Another dead assignment in CalibMuon/DTCalibration/plugins/DTTTrigCorrectionFirst.cc can be fixed simply by removing the useless code.

#### PR validation:

Code builds