### PR TITLE
Several updates to SiPixel LA PCL workflow

### DIFF
--- a/CalibTracker/SiPixelLorentzAngle/interface/SiPixelLorentzAngleCalibrationStruct.h
+++ b/CalibTracker/SiPixelLorentzAngle/interface/SiPixelLorentzAngleCalibrationStruct.h
@@ -30,6 +30,10 @@ public:
   MonitorMap h_mean_;
 
   dqm::reco::MonitorElement* h_tracks_;
+  dqm::reco::MonitorElement* h_trackEta_;
+  dqm::reco::MonitorElement* h_trackPhi_;
+  dqm::reco::MonitorElement* h_trackPt_;
+  dqm::reco::MonitorElement* h_trackChi2_;
 };
 
 #endif

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
@@ -103,6 +103,10 @@ void SiPixelLorentzAnglePCLHarvester::beginRun(const edm::Run& iRun, const edm::
     }
   }
 
+  // list of modules already filled
+  if (!hists.detIdsList.empty())
+    return;
+
   std::vector<uint32_t> treatedIndices;
 
   for (auto det : geom->detsPXB()) {
@@ -121,6 +125,14 @@ void SiPixelLorentzAnglePCLHarvester::beginRun(const edm::Run& iRun, const edm::
       treatedIndices.push_back(i_index);
     }
   }
+
+  uint count = 0;
+  for (const auto& i : treatedIndices) {
+    for (const auto& id : hists.detIdsList.at(i)) {
+      count++;
+    };
+  }
+  std::cout << "Stored a total of " << count << " detIds." << std::endl;
 }
 
 //------------------------------------------------------------------------------
@@ -376,6 +388,12 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
                                     << "\t" << tan_LA << "\t" << error_LA << std::endl;
 
       const auto& detIdsToFill = hists.detIdsList.at(i_index);
+
+      std::cout << "index: " << i_index << " i_module: " << i_module << " i_layer: " << i_layer << std::endl;
+      for (const auto& id : detIdsToFill) {
+        std::cout << id << ",";
+      }
+      std::cout << std::endl;
 
       GlobalPoint center(0.0, 0.0, 0.0);
       float theMagField = magField->inTesla(center).mag();

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
@@ -129,12 +129,14 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
   iGetter.cd();
   iGetter.setCurrentFolder(dqmDir_);
 
+  // fetch the 2D histograms
   for (int i_layer = 1; i_layer <= hists.nlay; i_layer++) {
+    const auto& prefix_ = fmt::sprintf("%s/BPixLayer%i", dqmDir_, i_layer);
     for (int i_module = 1; i_module <= hists.nModules_[i_layer - 1]; i_module++) {
       int i_index = i_module + (i_layer - 1) * hists.nModules_[i_layer - 1];
 
       hists.h_drift_depth_[i_index] =
-          iGetter.get(fmt::format("{}/h_drift_depth_layer{}_module{}", dqmDir_, i_layer, i_module));
+          iGetter.get(fmt::format("{}/h_drift_depth_layer{}_module{}", prefix_, i_layer, i_module));
 
       if (hists.h_drift_depth_[i_index] == nullptr) {
         edm::LogError("SiPixelLorentzAnglePCLHarvester::dqmEndJob")
@@ -143,13 +145,13 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
       }
 
       hists.h_drift_depth_adc_[i_index] =
-          iGetter.get(fmt::format("{}/h_drift_depth_adc_layer{}_module{}", dqmDir_, i_layer, i_module));
+          iGetter.get(fmt::format("{}/h_drift_depth_adc_layer{}_module{}", prefix_, i_layer, i_module));
 
       hists.h_drift_depth_adc2_[i_index] =
-          iGetter.get(fmt::format("{}/h_drift_depth_adc2_layer{}_module{}", dqmDir_, i_layer, i_module));
+          iGetter.get(fmt::format("{}/h_drift_depth_adc2_layer{}_module{}", prefix_, i_layer, i_module));
 
       hists.h_drift_depth_noadc_[i_index] =
-          iGetter.get(fmt::format("{}/h_drift_depth_noadc_layer{}_module{}", dqmDir_, i_layer, i_module));
+          iGetter.get(fmt::format("{}/h_drift_depth_noadc_layer{}_module{}", prefix_, i_layer, i_module));
 
       hists.h_mean_[i_index] = iGetter.get(fmt::format("{}/h_mean_layer{}_module{}", dqmDir_, i_layer, i_module));
 
@@ -158,11 +160,12 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
     }
   }
 
+  // fetch the new modules 2D histograms
   for (int i = 0; i < (int)hists.BPixnewDetIds_.size(); i++) {
     int new_index = i + 1 + hists.nModules_[hists.nlay - 1] + (hists.nlay - 1) * hists.nModules_[hists.nlay - 1];
 
     hists.h_drift_depth_adc_[new_index] =
-        iGetter.get(fmt::format("{}/h_BPixnew_drift_depth_{}", dqmDir_, hists.BPixnewmodulename_[i]));
+        iGetter.get(fmt::format("{}/h_BPixnew_drift_depth_{}", dqmDir_ + "/NewModules", hists.BPixnewmodulename_[i]));
 
     if (hists.h_drift_depth_adc_[new_index] == nullptr) {
       edm::LogError("SiPixelLorentzAnglePCLHarvester::dqmEndJob")
@@ -170,14 +173,14 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
       continue;
     }
 
-    hists.h_drift_depth_adc2_[new_index] =
-        iGetter.get(fmt::format("{}/h_BPixnew_drift_depth_adc_{}", dqmDir_, hists.BPixnewmodulename_[i]));
+    hists.h_drift_depth_adc2_[new_index] = iGetter.get(
+        fmt::format("{}/h_BPixnew_drift_depth_adc_{}", dqmDir_ + "/NewModules", hists.BPixnewmodulename_[i]));
 
-    hists.h_drift_depth_noadc_[new_index] =
-        iGetter.get(fmt::format("{}/h_BPixnew_drift_depth_adc2_{}", dqmDir_, hists.BPixnewmodulename_[i]));
+    hists.h_drift_depth_noadc_[new_index] = iGetter.get(
+        fmt::format("{}/h_BPixnew_drift_depth_adc2_{}", dqmDir_ + "/NewModules", hists.BPixnewmodulename_[i]));
 
-    hists.h_drift_depth_[new_index] =
-        iGetter.get(fmt::format("{}/h_BPixnew_drift_depth_noadc_{}", dqmDir_, hists.BPixnewmodulename_[i]));
+    hists.h_drift_depth_[new_index] = iGetter.get(
+        fmt::format("{}/h_BPixnew_drift_depth_noadc_{}", dqmDir_ + "/NewModules", hists.BPixnewmodulename_[i]));
 
     hists.h_mean_[new_index] = iGetter.get(fmt::format("{}/h_BPixnew_mean_{}", dqmDir_, hists.BPixnewmodulename_[i]));
 
@@ -496,7 +499,7 @@ void SiPixelLorentzAnglePCLHarvester::fillDescriptions(edm::ConfigurationDescrip
   desc.setComment("Harvester module of the SiPixel Lorentz Angle PCL monitoring workflow");
   desc.add<std::vector<std::string>>("newmodulelist", {})->setComment("the list of DetIds for new sensors");
   desc.add<std::string>("dqmDir", "AlCaReco/SiPixelLorentzAngle")->setComment("the directory of PCL Worker output");
-  desc.add<double>("fitProbCut", 0.5)->setComment("cut on fit chi2 probabiblity to accept measurement");
+  desc.add<double>("fitProbCut", 0.1)->setComment("cut on fit chi2 probabiblity to accept measurement");
   desc.add<std::string>("record", "SiPixelLorentzAngleRcd")->setComment("target DB record");
   descriptions.addWithDefaultLabel(desc);
 }

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLWorker.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLWorker.cc
@@ -656,6 +656,10 @@ void SiPixelLorentzAnglePCLWorker::dqmBeginRun(edm::Run const& run, edm::EventSe
     iHists.nModules_[i] = map.getPXBModules(i + 1);
   }
 
+  // list of modules already filled, then return (we already entered here)
+  if (!iHists.BPixnewDetIds_.empty() || !iHists.FPixnewDetIds_.empty())
+    return;
+
   if (!newmodulelist_.empty()) {
     for (auto const& modulename : newmodulelist_) {
       if (modulename.find("BPix_") != std::string::npos) {

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLWorker.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLWorker.cc
@@ -711,7 +711,7 @@ void SiPixelLorentzAnglePCLWorker::bookHistograms(DQMStore::IBooker& iBooker,
 
   //book the 2D histograms
   for (int i_layer = 1; i_layer <= iHists.nlay; i_layer++) {
-    iBooker.setCurrentFolder(fmt::sprintf("%s/BPixLayer%i", folder_.data(), i_layer));
+    iBooker.setCurrentFolder(fmt::sprintf("%s/BPix/BPixLayer%i", folder_.data(), i_layer));
     for (int i_module = 1; i_module <= iHists.nModules_[i_layer - 1]; i_module++) {
       unsigned int i_index = i_module + (i_layer - 1) * iHists.nModules_[i_layer - 1];
 
@@ -740,7 +740,7 @@ void SiPixelLorentzAnglePCLWorker::bookHistograms(DQMStore::IBooker& iBooker,
   }
 
   // book the "new" modules
-  iBooker.setCurrentFolder(fmt::sprintf("%s/NewModules", folder_.data()));
+  iBooker.setCurrentFolder(fmt::sprintf("%s/BPix/NewModules", folder_.data()));
   for (int i = 0; i < (int)iHists.BPixnewDetIds_.size(); i++) {
     int new_index = iHists.nModules_[iHists.nlay - 1] + (iHists.nlay - 1) * iHists.nModules_[iHists.nlay - 1] + 1 + i;
 

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLWorker.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLWorker.cc
@@ -450,12 +450,8 @@ void SiPixelLorentzAnglePCLWorker::analyze(edm::Event const& iEvent, edm::EventS
           double drdz = sqrt(1. + cotalpha * cotalpha + cotbeta * cotbeta);
           double clusterCharge_cut = clustChargeMaxPerLength_ * drdz;
 
-          float locBx = 1.;
-          if (cotbeta < 0.)
-            locBx = -1.;
-          float locBz = locBx;
-          if (cotalpha < 0.)
-            locBz = -locBx;
+          float locBx = (cotbeta < 0.) ? -1 : 1.;
+          float locBz = (cotalpha < 0.) ? -locBx : locBx;
 
           auto detId = detIdObj.rawId();
           int DetId_index = -1;


### PR DESCRIPTION
#### PR description:

Miscellanea updates and bug-fixes to the SiPixel LA PCL workflow that are built on top of the replay at https://github.com/dmwm/T0/pull/4635: 
   * made the processing much faster by calling `SiPixelTemplate::pushfile` in `dqmBeginRun`  instead of the `analyze` method;
   * add basic accepted tracks monitoring;
   * adding plot titles;
   * re-organize folders to have subfolders: (Top) / (BPix) / etc. ..;
   * actually *do* write to DB the values for the "new" modules when they are fit;
   * change the default cut value on the fit probability for writing out the payload from 0.5 to 0.1;
   * fix a bug that was causing populating the lists of "new" modules and modules attached to a given "sector" multiple times (this was triggering several warnings in the harvesting step when populating the DB about multiple `put`s, see https://github.com/cms-sw/cmssw/pull/36535);
  
#### PR validation:

Run:

```
 cmsDriver.py testReAlCa -s ALCA:PromptCalibProdSiPixelLorentzAngle --conditions 121X_dataRun3_Express_TIER0_REPLAY_Run2_v1 --scenario pp --data --era Run2_2018 --datatier ALCARECO --eventcontent ALCARECO --processName=ReAlCa -n 100 --dasquery='file dataset=/StreamExpress/Tier0_REPLAY_2021-SiPixelCalSingleMuon-Express-v1/ALCARECO' --customise_commands='process.ALCARECOCalSignleMuonFilterForSiPixelLorentzAngle.TriggerResultsTag = cms.InputTag ( "TriggerResults","","HLT" ) ; process.ALCARECOCalSignleMuonFilterForSiPixelLorentzAngle.HLTPaths = ["*"]' --nThreads=4 
```

followed by:

```
 cmsDriver.py stepHarvest -s ALCAHARVEST:SiPixelLA --conditions 121X_dataRun3_Express_TIER0_REPLAY_Run2_v1 --scenario pp --data --era Run2_2018 --filein file:PromptCalibProdSiPixelLorentzAngle.root -n -1
```

the results are uploaded to a private DQM GUI at  https://tinyurl.com/y4dm6s98:
   * necessitates tunneling (`ssh -NL 8060:localhost:8060 <USER>@lxplus723.cern.ch`). 
   
An example of the result is link to the companion PR to `dmwm`: https://github.com/dmwm/deployment/pull/1118

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, but might be backported
