### PR TITLE
include MuonDQM AlCaRecoTriggerBits in mcRun3 and mcRun4 GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -64,19 +64,19 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak'     : '122X_upgrade2018cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'           : '122X_mcRun3_2021_design_v5',
+    'phase1_2021_design'           : '123X_mcRun3_2021_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'        : '122X_mcRun3_2021_realistic_v5',
+    'phase1_2021_realistic'        : '123X_mcRun3_2021_realistic_v1',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'          : '122X_mcRun3_2021cosmics_realistic_deco_v5',
+    'phase1_2021_cosmics'          : '123X_mcRun3_2021cosmics_realistic_deco_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi'     : '122X_mcRun3_2021_realistic_HI_v5',
+    'phase1_2021_realistic_hi'     : '123X_mcRun3_2021_realistic_HI_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '122X_mcRun3_2023_realistic_v5',
+    'phase1_2023_realistic'        : '123X_mcRun3_2023_realistic_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '122X_mcRun3_2024_realistic_v5',
+    'phase1_2024_realistic'        : '123X_mcRun3_2024_realistic_v1',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             : '122X_mcRun4_realistic_v4'
+    'phase2_realistic'             : '123X_mcRun4_realistic_v1'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:

This is to update the mcRun3 and mcRun4 GTs with a Muon DQM AlCaRecoTriggerBits tag, as requested in https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4566/1.html.

The new tag is `AlCaRecoTriggerBits_MuonDQM_v2_mc`.

The GT diffs are below. They show only the updated tag as a difference wrt the last GTs in autoCond.

**phase1_2021_design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_mcRun3_2021_design_v1/122X_mcRun3_2021_design_v5

**phase1_2021_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_mcRun3_2021_realistic_v1/122X_mcRun3_2021_realistic_v5

**phase1_2021_cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_mcRun3_2021cosmics_realistic_deco_v1/122X_mcRun3_2021cosmics_realistic_deco_v5

**phase1_2021_realistic_hi**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_mcRun3_2021_realistic_HI_v1/122X_mcRun3_2021_realistic_HI_v5

**phase1_2023_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_mcRun3_2023_realistic_v1/122X_mcRun3_2023_realistic_v5

**phase1_2024_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_mcRun3_2024_realistic_v1/122X_mcRun3_2024_realistic_v5

**phase2_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_mcRun4_realistic_v1/122X_mcRun4_realistic_v4

#### PR validation:

runTheMatrix.py -l 12034.0,11634.0,7.23,159.0,12434.0,12834.0 --ibeos -j16

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not a backport.
