### PR TITLE
Drop type specs in HLTEvF, MuonMonitor and Physics

### DIFF
--- a/DQM/HLTEvF/python/HLTSiStripMonitoring_cff.py
+++ b/DQM/HLTEvF/python/HLTSiStripMonitoring_cff.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from TrackingTools.RecoGeometry.RecoGeometries_cff import *
 hltESPDummyDetLayerGeometry = DummyDetLayerGeometry.clone(
-    ComponentName = cms.string( "hltESPDummyDetLayerGeometry" )
+    ComponentName =  "hltESPDummyDetLayerGeometry" 
 )
 
 # strip cluster monitor
@@ -15,64 +15,64 @@ hltESPDummyDetLayerGeometry = DummyDetLayerGeometry.clone(
 ##     make sure they are not already defined somewhereelse in the final configuration
 from RecoLocalTracker.SiPixelRecHits.PixelCPETemplateReco_cfi import templates
 hltESPPixelCPETemplateReco = templates.clone(
-  LoadTemplatesFromDB = cms.bool( True ),
-  ComponentName = cms.string( "hltESPPixelCPETemplateReco" ),
-  Alpha2Order = cms.bool( True ),
-  ClusterProbComputationFlag = cms.int32( 0 ),
-  speed = cms.int32( -2 ),
-  UseClusterSplitter = cms.bool( False )
+  LoadTemplatesFromDB =  True ,
+  ComponentName = "hltESPPixelCPETemplateReco" ,
+  Alpha2Order =  True ,
+  ClusterProbComputationFlag =  0 ,
+  speed =  -2 ,
+  UseClusterSplitter =  False 
 )
 
 from RecoLocalTracker.SiPixelRecHits.PixelCPEGeneric_cfi import PixelCPEGenericESProducer
 hltESPPixelCPEGeneric = PixelCPEGenericESProducer.clone(
-  EdgeClusterErrorX = cms.double( 50.0 ),
-  DoCosmics = cms.bool( False ),
-  LoadTemplatesFromDB = cms.bool( True ),
-  UseErrorsFromTemplates = cms.bool( True ),
-  eff_charge_cut_highX = cms.double( 1.0 ),
-  TruncatePixelCharge = cms.bool( True ),
-  size_cutY = cms.double( 3.0 ),
-  size_cutX = cms.double( 3.0 ),
-  inflate_all_errors_no_trk_angle = cms.bool( False ),
-  IrradiationBiasCorrection = cms.bool( False ),
-  inflate_errors = cms.bool( False ),
-  eff_charge_cut_lowX = cms.double( 0.0 ),
-  eff_charge_cut_highY = cms.double( 1.0 ),
-  ClusterProbComputationFlag = cms.int32( 0 ),
-  EdgeClusterErrorY = cms.double( 85.0 ),
-  ComponentName = cms.string( "hltESPPixelCPEGeneric" ),
-  eff_charge_cut_lowY = cms.double( 0.0 ),
-  Alpha2Order = cms.bool( True )
+  EdgeClusterErrorX =  50.0 ,
+  DoCosmics =  False ,
+  LoadTemplatesFromDB =  True ,
+  UseErrorsFromTemplates =  True ,
+  eff_charge_cut_highX =  1.0 ,
+  TruncatePixelCharge =  True ,
+  size_cutY =  3.0 ,
+  size_cutX =  3.0 ,
+  inflate_all_errors_no_trk_angle =  False ,
+  IrradiationBiasCorrection =  False ,
+  inflate_errors = False ,
+  eff_charge_cut_lowX =  0.0 ,
+  eff_charge_cut_highY =  1.0 ,
+  ClusterProbComputationFlag = 0 ,
+  EdgeClusterErrorY = 85.0 ,
+  ComponentName = "hltESPPixelCPEGeneric" ,
+  eff_charge_cut_lowY = 0.0 ,
+  Alpha2Order =  True 
 )
 
 from RecoTracker.TransientTrackingRecHit.TTRHBuilderWithTemplate_cfi import TTRHBuilderAngleAndTemplate
 hltESPTTRHBuilderAngleAndTemplate = TTRHBuilderAngleAndTemplate.clone(
-  StripCPE = cms.string( "hltESPStripCPEfromTrackAngle" ),
-  Matcher = cms.string( "StandardMatcher" ),
-  ComputeCoarseLocalPositionFromDisk = cms.bool( False ),
-  PixelCPE = cms.string( "hltESPPixelCPETemplateReco" ),
-  ComponentName = cms.string( "hltESPTTRHBuilderAngleAndTemplate" )
+  StripCPE = "hltESPStripCPEfromTrackAngle" ,
+  Matcher = "StandardMatcher" ,
+  ComputeCoarseLocalPositionFromDisk = False ,
+  PixelCPE = "hltESPPixelCPETemplateReco",
+  ComponentName ="hltESPTTRHBuilderAngleAndTemplate" 
 )
 hltESPTTRHBWithTrackAngle = TTRHBuilderAngleAndTemplate.clone(
-  StripCPE = cms.string( "hltESPStripCPEfromTrackAngle" ),
-  Matcher = cms.string( "StandardMatcher" ),
-  ComputeCoarseLocalPositionFromDisk = cms.bool( False ),
-  PixelCPE = cms.string( "hltESPPixelCPEGeneric" ),
-  ComponentName = cms.string( "hltESPTTRHBWithTrackAngle" )
+  StripCPE = "hltESPStripCPEfromTrackAngle",
+  Matcher = "StandardMatcher",
+  ComputeCoarseLocalPositionFromDisk = False,
+  PixelCPE = "hltESPPixelCPEGeneric",
+  ComponentName = "hltESPTTRHBWithTrackAngle" 
 )
 
 from RecoLocalTracker.SiStripRecHitConverter.StripCPEESProducer_cfi import stripCPEESProducer
 hltESPStripCPEfromTrackAngle = stripCPEESProducer.clone(
-  ComponentType = cms.string( "StripCPEfromTrackAngle" ),
-  ComponentName = cms.string( "hltESPStripCPEfromTrackAngle" ),
+  ComponentType = "StripCPEfromTrackAngle" ,
+  ComponentName = "hltESPStripCPEfromTrackAngle",
   parameters = cms.PSet( 
-    mLC_P2 = cms.double( 0.3 ),
-    mLC_P1 = cms.double( 0.618 ),
-    mLC_P0 = cms.double( -0.326 ),
+    mLC_P2 = cms.double(0.3),
+    mLC_P1 = cms.double(0.618),
+    mLC_P0 = cms.double(-0.326),
 #    useLegacyError = cms.bool( True ), # 50ns menu
 #    maxChgOneMIP = cms.double( -6000.0 ), # 50ns menu
-    useLegacyError = cms.bool( False ), # 25ns menu
-    maxChgOneMIP = cms.double( 6000.0 ), #25ns menu
+    useLegacyError = cms.bool(False) , # 25ns menu
+    maxChgOneMIP = cms.double(6000.0) , #25ns menu
     mTEC_P1 = cms.double( 0.471 ),
     mTEC_P0 = cms.double( -1.885 ),
     mTOB_P0 = cms.double( -1.026 ),
@@ -86,17 +86,17 @@ hltESPStripCPEfromTrackAngle = stripCPEESProducer.clone(
 
 from RecoTracker.TkNavigation.NavigationSchoolESProducer_cfi import navigationSchoolESProducer
 navigationSchoolESProducer = navigationSchoolESProducer.clone(
-  ComponentName = cms.string( "SimpleNavigationSchool" ),
-  SimpleMagneticField = cms.string( "ParabolicMf" )
+  ComponentName = "SimpleNavigationSchool" ,
+  SimpleMagneticField ="ParabolicMf" 
 )
 
 from RecoTracker.MeasurementDet.MeasurementTrackerESProducer_cfi import MeasurementTracker
 hltESPMeasurementTracker = MeasurementTracker.clone(
-  UseStripStripQualityDB = cms.bool( True ),
-  StripCPE = cms.string( "hltESPStripCPEfromTrackAngle" ),
-  UsePixelROCQualityDB = cms.bool( True ),
-  DebugPixelROCQualityDB = cms.untracked.bool( False ),
-  UseStripAPVFiberQualityDB = cms.bool( True ),
+  UseStripStripQualityDB =  True ,
+  StripCPE = "hltESPStripCPEfromTrackAngle",
+  UsePixelROCQualityDB = True ,
+  DebugPixelROCQualityDB = False,
+  UseStripAPVFiberQualityDB = True ,
   badStripCuts = cms.PSet(
     TOB = cms.PSet(
       maxConsecutiveBad = cms.uint32( 9999 ),
@@ -115,17 +115,17 @@ hltESPMeasurementTracker = MeasurementTracker.clone(
       maxBad = cms.uint32( 9999 )
     )
   ),
-  DebugStripModuleQualityDB = cms.untracked.bool( False ),
-  ComponentName = cms.string( "hltESPMeasurementTracker" ),
-  DebugPixelModuleQualityDB = cms.untracked.bool( False ),
-  UsePixelModuleQualityDB = cms.bool( True ),
-  DebugStripAPVFiberQualityDB = cms.untracked.bool( False ),
-  HitMatcher = cms.string( "StandardMatcher" ),
-  DebugStripStripQualityDB = cms.untracked.bool( False ),
-  PixelCPE = cms.string( "hltESPPixelCPEGeneric" ),
-  SiStripQualityLabel = cms.string( "" ),
-  UseStripModuleQualityDB = cms.bool( True ),
-  MaskBadAPVFibers = cms.bool( True )
+  DebugStripModuleQualityDB = False ,
+  ComponentName ="hltESPMeasurementTracker",
+  DebugPixelModuleQualityDB = False,
+  UsePixelModuleQualityDB = True,
+  DebugStripAPVFiberQualityDB = False,
+  HitMatcher = "StandardMatcher",
+  DebugStripStripQualityDB = False,
+  PixelCPE = "hltESPPixelCPEGeneric",
+  SiStripQualityLabel = "" ,
+  UseStripModuleQualityDB = True,
+  MaskBadAPVFibers = True
 )
 
 hltESPRungeKuttaTrackerPropagator = cms.ESProducer( "PropagatorWithMaterialESProducer",
@@ -140,7 +140,7 @@ hltESPRungeKuttaTrackerPropagator = cms.ESProducer( "PropagatorWithMaterialESPro
 
 from TrackingTools.KalmanUpdators.KFUpdatorESProducer_cfi import KFUpdatorESProducer
 hltESPKFUpdator = KFUpdatorESProducer.clone(
-  ComponentName = cms.string( "hltESPKFUpdator" )
+  ComponentName = "hltESPKFUpdator" 
 )
 
 hltESPChi2MeasurementEstimator30 = cms.ESProducer( "Chi2MeasurementEstimatorESProducer",

--- a/DQM/HLTEvF/python/HLTTrackingMonitoring_Client_cff.py
+++ b/DQM/HLTEvF/python/HLTTrackingMonitoring_Client_cff.py
@@ -3,25 +3,25 @@ import FWCore.ParameterSet.Config as cms
 # tracking monitor
 from DQMOffline.Trigger.TrackingMonitoring_Client_cff import *
 
-trackingEffFromHitPatternHLT = trackingEffFromHitPattern.clone()
-trackingEffFromHitPatternHLT.subDirs = cms.untracked.vstring(
+trackingEffFromHitPatternHLT = trackingEffFromHitPattern.clone(
+subDirs = (
    "HLT/Tracking/pixelTracks/HitEffFromHitPattern*",
    "HLT/Tracking/iter2Merged/HitEffFromHitPattern*"
 )
-
+)
 # Sequence
 trackingMonitorClientHLT = cms.Sequence(
     trackingEffFromHitPatternHLT
 )
 
 # EGM tracking
-trackingForElectronsEffFromHitPatternHLT = trackingEffFromHitPattern.clone()
-trackingForElectronsEffFromHitPatternHLT.subDirs = cms.untracked.vstring(
+trackingForElectronsEffFromHitPatternHLT = trackingEffFromHitPattern.clone(
+subDirs = (
    "HLT/EGM/Tracking/GSF/HitEffFromHitPattern*",
    "HLT/EGM/Tracking/pixelTracks/HitEffFromHitPattern*",
    "HLT/EGM/Tracking/iter2Merged/HitEffFromHitPattern*"
 )
-
+)
 # Sequence
 trackingForElectronsMonitorClientHLT = cms.Sequence(
     trackingForElectronsEffFromHitPatternHLT

--- a/DQM/HLTEvF/python/HLTTrackingMonitoring_cff.py
+++ b/DQM/HLTEvF/python/HLTTrackingMonitoring_cff.py
@@ -2,9 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 # tracking monitor
 from DQMOffline.Trigger.TrackingMonitoring_cff import *
-iterHLTTracksMonitoringHLT.doProfilesVsLS   = cms.bool(True)
-iterHLTTracksMonitoringHLT.beamSpot = cms.InputTag("hltOnlineBeamSpot")
-pixelTracksMonitoringHLT.beamSpot = cms.InputTag("hltOnlineBeamSpot")
+doProfilesVsLS   = True
+beamSpot = "hltOnlineBeamSpot"
+beamSpot = "hltOnlineBeamSpot"
 
 from TrackingTools.TrackFitters.KFTrajectoryFitter_cfi import *
 from TrackingTools.TransientTrack.TransientTrackBuilder_cfi import *

--- a/DQM/HLTEvF/python/HLTTrackingMonitoring_cff.py
+++ b/DQM/HLTEvF/python/HLTTrackingMonitoring_cff.py
@@ -2,9 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 # tracking monitor
 from DQMOffline.Trigger.TrackingMonitoring_cff import *
-doProfilesVsLS   = True
-beamSpot = "hltOnlineBeamSpot"
-beamSpot = "hltOnlineBeamSpot"
+iterHLTTracksMonitoringHLT.doProfilesVsLS = True
+iterHLTTracksMonitoringHLT.beamSpot = "hltOnlineBeamSpot"
+pixelTracksMonitoringHLT.beamSpot = "hltOnlineBeamSpot"
 
 from TrackingTools.TrackFitters.KFTrajectoryFitter_cfi import *
 from TrackingTools.TransientTrack.TransientTrackBuilder_cfi import *

--- a/DQM/MuonMonitor/python/muonCosmicAnalyzer_cff.py
+++ b/DQM/MuonMonitor/python/muonCosmicAnalyzer_cff.py
@@ -12,14 +12,15 @@ from DQMOffline.Muon.segmentTrackAnalyzer_cfi import *
 from DQMOffline.Muon.muonSeedsAnalyzer_cfi import * 
 from DQM.MuonMonitor.muonRecoAnalyzer_cfi import *
 
-#muonCosmicGlbSegmentAnalyzer    = glbMuonSegmentAnalyzer.clone()
-muonCosmicStaSegmentAnalyzer    = staMuonSegmentAnalyzer.clone()
-muonCosmicSeedAnalyzer          = muonSeedsAnalyzer.clone()
-
-
-#muonCosmicGlbSegmentAnalyzer.MuTrackCollection = cms.InputTag('globalCosmicMuons')
-muonCosmicSeedAnalyzer.SeedCollection          = cms.InputTag('CosmicMuonSeed')
-muonCosmicStaSegmentAnalyzer.MuTrackCollection = cms.InputTag('cosmicMuons')
+#muonCosmicGlbSegmentAnalyzer    = glbMuonSegmentAnalyzer.clone(
+#MuTrackCollection = 'globalCosmicMuons'
+#)
+muonCosmicStaSegmentAnalyzer    = staMuonSegmentAnalyzer.clone(
+MuTrackCollection = 'cosmicMuons'
+)
+muonCosmicSeedAnalyzer   = muonSeedsAnalyzer.clone(
+SeedCollection   = 'CosmicMuonSeed'
+)
 
 
 

--- a/DQM/Physics/python/DQMPhysics_cff.py
+++ b/DQM/Physics/python/DQMPhysics_cff.py
@@ -56,7 +56,7 @@ _dqmPhysics += CentralityDQM
 pp_on_AA.toModify(CentralityDQM, vertexcollection=cms.InputTag("offlinePrimaryVertices"))
 pp_on_AA.toReplaceWith(dqmPhysics, _dqmPhysics)
 
-bphysicsOniaDQMHI = bphysicsOniaDQM.clone(vertex=cms.InputTag("hiSelectedVertex"))
+bphysicsOniaDQMHI = bphysicsOniaDQM.clone(vertex="hiSelectedVertex")
 dqmPhysicsHI = cms.Sequence(bphysicsOniaDQMHI+CentralityDQM)
 
 from DQM.Physics.qcdPhotonsCosmicDQM_cff import *

--- a/DQM/Physics/python/qcdPhotonsCosmicDQM_cff.py
+++ b/DQM/Physics/python/qcdPhotonsCosmicDQM_cff.py
@@ -2,6 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 import DQM.Physics.qcdPhotonsDQM_cfi
 qcdPhotonsCosmicDQM = DQM.Physics.qcdPhotonsDQM_cfi.qcdPhotonsDQM.clone(
-    barrelRecHitTag           = cms.InputTag("ecalRecHit:EcalRecHitsEB"),
-    endcapRecHitTag           = cms.InputTag("ecalRecHit:EcalRecHitsEE")
+    barrelRecHitTag           = "ecalRecHit:EcalRecHitsEB",
+    endcapRecHitTag           = "ecalRecHit:EcalRecHitsEE"
 )

--- a/DQM/Physics/python/topJetCorrectionHelper_cfi.py
+++ b/DQM/Physics/python/topJetCorrectionHelper_cfi.py
@@ -15,6 +15,6 @@ topDQMak5PFCHSL2Relative = ak4PFCHSL2Relative.clone()
 topDQMak5PFCHSL3Absolute = ak4PFCHSL3Absolute.clone()
 topDQMak5PFCHSResidual = ak4PFCHSResidual.clone()
 
-topDQMak5PFCHSL2L3 = ak4PFCHSL2L3.clone(correctors = cms.vstring('topDQMak5PFCHSL2Relative','topDQMak5PFCHSL3Absolute'))
-topDQMak5PFCHSL2L3Residual = ak4PFCHSL2L3Residual.clone(correctors = cms.vstring('topDQMak5PFCHSL2Relative','topDQMak5PFCHSL3Absolute','topDQMak5PFCHSResidual'))
+topDQMak5PFCHSL2L3 = ak4PFCHSL2L3.clone(correctors = ('topDQMak5PFCHSL2Relative','topDQMak5PFCHSL3Absolute'))
+topDQMak5PFCHSL2L3Residual = ak4PFCHSL2L3Residual.clone(correctors = ('topDQMak5PFCHSL2Relative','topDQMak5PFCHSL3Absolute','topDQMak5PFCHSResidual'))
 #############################################################################


### PR DESCRIPTION
#### PR description:
Drop type specs in DQM/HLTEvF, DQM/MuonMonitor and DQM/Physics python configuration files.

Central DQM migration campaign for drop type spces following
https://cms-sw.github.io/cms_coding_rules.html#6--packaging-rules-1
and update the safer syntax for existing parameters like: (1) drop type specifications where the original parameter exists. (2) using "clone" instead of "deepcopy" (3) move all parameters inside the clone


#### PR validation:
Tested in CMSSW_12_3_X via runTheMatrix.py -l limited -i all --ibeos




