### PR TITLE
Add a unit test for correctionlib external

### DIFF
--- a/PhysicsTools/Utilities/test/BuildFile.xml
+++ b/PhysicsTools/Utilities/test/BuildFile.xml
@@ -1,10 +1,11 @@
-<bin   name="testPhysicsToolsUtilities" file="testPolynomial.cc,testParameter.cc,testFunctions.cc,testSimplifications.cc,testFunctionsIO.cc,testVariables.cc,testDerivatives.cc,testPrimitive.cc,testIntegral.cc,testRunner.cpp,testLumiReweight.cc">
+<bin   name="testPhysicsToolsUtilities" file="testPolynomial.cc,testParameter.cc,testFunctions.cc,testSimplifications.cc,testFunctionsIO.cc,testVariables.cc,testDerivatives.cc,testPrimitive.cc,testIntegral.cc,testRunner.cpp,testLumiReweight.cc,test_correctionlib.cc">
   <use   name="DataFormats/TrackReco"/>
   <use   name="DataFormats/TrackerRecHit2D"/>
   <use   name="DataFormats/Candidate"/>
   <use   name="DataFormats/PatCandidates"/>
   <use   name="PhysicsTools/Utilities"/>
   <use   name="cppunit"/>
+  <use name="correctionlib"/>
 </bin>
 <bin   file="testZMassFit.cpp" name="testZMassFit">
   <use   name="rootminuit"/>

--- a/PhysicsTools/Utilities/test/corrections.json
+++ b/PhysicsTools/Utilities/test/corrections.json
@@ -1,0 +1,60 @@
+{
+  "schema_version": 2,
+  "description": "A few test corrections",
+  "corrections": [
+    { "name": "test corr",
+      "description": null,
+      "version": 2,
+      "inputs": [
+        { "name": "pt",
+          "type": "real",
+          "description": null
+        },
+        { "name": "syst",
+          "type": "string",
+          "description": null
+        }
+      ],
+      "output": {
+        "name": "a scale",
+        "type": "real",
+        "description": null
+      },
+      "generic_formulas": null,
+      "data": {
+        "nodetype": "binning",
+        "input": "pt",
+        "edges": [ 0.0, 20.0, 40.0, Infinity ],
+        "content": [
+          { "nodetype": "category",
+            "input": "syst",
+            "content": [
+              { "key": "blah", "value": 1.1 },
+              { "key": "blah2", "value": 2.2 }
+            ],
+            "default": null
+          },
+          { "nodetype": "category",
+            "input": "syst",
+            "content": [
+              { "key": "blah2", "value": 1.3 },
+              { "key": "blah3",
+                "value": {
+                  "nodetype": "formula",
+                  "expression": "0.25*x + exp([0])",
+                  "parser": "TFormula",
+                  "variables": [ "pt" ],
+                  "parameters": [ 3.1 ]
+                }
+              }
+            ],
+            "default": null
+          },
+          1.0
+        ],
+        "flow": "error"
+      }
+    }
+  ],
+  "compound_corrections": null
+}

--- a/PhysicsTools/Utilities/test/test_correctionlib.cc
+++ b/PhysicsTools/Utilities/test/test_correctionlib.cc
@@ -1,0 +1,27 @@
+#include <cmath>
+#include <cppunit/extensions/HelperMacros.h>
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "correction.h"
+
+class test_correctionlib : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(test_correctionlib);
+  CPPUNIT_TEST(checkAll);
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+  void setUp() {}
+  void tearDown() {}
+  void checkAll();
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(test_correctionlib);
+
+void test_correctionlib::checkAll() {
+  edm::FileInPath testfile("PhysicsTools/Utilities/test/corrections.json");
+  auto cset = correction::CorrectionSet::from_file(testfile.fullPath());
+  CPPUNIT_ASSERT(cset->at("test corr"));
+  CPPUNIT_ASSERT_THROW(cset->at("nonexistent"), std::out_of_range);
+  auto corr = cset->at("test corr");
+  CPPUNIT_ASSERT(corr->evaluate({12.0, "blah"}) == 1.1);
+  CPPUNIT_ASSERT(corr->evaluate({31.0, "blah3"}) == 0.25 * 31.0 + std::exp(3.1));
+}


### PR DESCRIPTION
This is a backport of https://github.com/cms-sw/cmssw/pull/35296 which validates the backport of the correctionlib external in cmsdist https://github.com/cms-sw/cmsdist/pull/7523
It provides only C++ and python 2 functionality. The `correction` CLI utility and python 3 bindings are omitted for now, as the intention here is only to provide legacy support for python 2 nanoAOD-tools.

This will need testing with the externals including https://github.com/cms-sw/cmsdist/pull/7523