### PR TITLE
[DD4hep] Resolve static analyzer warning by protecting against divide by 0

### DIFF
--- a/Geometry/MuonNumbering/src/DD4hep_MuonNumbering.cc
+++ b/Geometry/MuonNumbering/src/DD4hep_MuonNumbering.cc
@@ -18,7 +18,11 @@ const MuonBaseNumber MuonNumbering::geoHistoryToBaseNumber(const cms::ExpandedNo
     edm::LogError("Geometry") << "MuonNumbering finds unusual base constant:" << basePart;
   }
   if (superPart < 100) {
-    edm::LogError("Geometry") << "MuonNumbering finds unusual super constant:" << superPart;
+    edm::LogError("Geometry") << "MuonNumbering finds unusual super part:" << superPart;
+    if (superPart <= 0) {
+      edm::LogError("Geometry") << "MuonNumbering -- resetting super part to 100";
+      superPart = 100;  // Protect against division by 0
+    }
   }
   if (levelPart < 10 * superPart) {
     edm::LogError("Geometry") << "MuonNumbering finds unusual level constant:" << levelPart;

--- a/Geometry/MuonNumbering/src/DD4hep_MuonNumbering.cc
+++ b/Geometry/MuonNumbering/src/DD4hep_MuonNumbering.cc
@@ -15,20 +15,18 @@ const MuonBaseNumber MuonNumbering::geoHistoryToBaseNumber(const cms::ExpandedNo
 
   // some consistency checks
   if (basePart != 1) {
-    edm::LogError("Geometry") << "MuonNumbering finds unusual base constant:" << basePart;
+    edm::LogError("Geometry") << "MuonNumbering finds unusual base constant: " << basePart;
   }
   if (superPart < 100) {
-    edm::LogError("Geometry") << "MuonNumbering finds unusual super part:" << superPart;
-    if (superPart <= 0) {
-      edm::LogError("Geometry") << "MuonNumbering -- resetting super part to 100";
-      superPart = 100;  // Protect against division by 0
-    }
+    edm::LogError("Geometry") << "MuonNumbering finds unusual super part: " << superPart
+                              << " -- resetting super part to 100";
+    superPart = 100;  // Reset to sensible value so calculations below don't go out of range
   }
   if (levelPart < 10 * superPart) {
-    edm::LogError("Geometry") << "MuonNumbering finds unusual level constant:" << levelPart;
+    edm::LogError("Geometry") << "MuonNumbering finds unusual level constant: " << levelPart;
   }
   if ((startCopyNo != 0) && (startCopyNo != 1)) {
-    edm::LogError("Geometry") << "MuonNumbering finds unusual start value for copy numbers:" << startCopyNo;
+    edm::LogError("Geometry") << "MuonNumbering finds unusual start value for copy numbers: " << startCopyNo;
   }
   int ctr(0);
   for (auto const& it : nodes.tags) {


### PR DESCRIPTION
Issue #31288 lists static analyzer warnings that needed to be fixed. This PR fixes the last one by protecting against division by 0.

Note that the method that was fixed appears to be no longer used. Also, the class for this method appears to be used only for a test, so none of this code is used in production.

#### PR validation:

Another test program was altered to call the code changed by this PR to verify that the fix works correctly.

No backport is needed.