### PR TITLE
[DD4hep] Follow-up to #36496 -- Update versions of materials files in unit tests

### DIFF
--- a/Geometry/TrackerCommonData/data/dd4hep/cms-tracker-geometry-2021.xml
+++ b/Geometry/TrackerCommonData/data/dd4hep/cms-tracker-geometry-2021.xml
@@ -25,7 +25,7 @@
   </ConstantsSection>
 
   <IncludeSection>
-    <Include ref="Geometry/CMSCommonData/data/materials.xml"/>
+    <Include ref="Geometry/CMSCommonData/data/materials/2021/v1/materials.xml"/>
     <Include ref="DetectorDescription/DDCMS/data/vacuum.xml"/>
     <Include ref="Geometry/CMSCommonData/data/rotations.xml"/>
     <Include ref="Geometry/CMSCommonData/data/extend/v2/cmsextent.xml"/>
@@ -39,14 +39,14 @@
     <Include ref="Geometry/CMSCommonData/data/cavernData/2017/v1/cavernData.xml"/>
     <Include ref="Geometry/CMSCommonData/data/cavernFloor/2017/v1/cavernFloor.xml"/>
     <Include ref="Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml"/>
-    <Include ref="Geometry/TrackerCommonData/data/Run2/trackermaterial.xml"/>
+    <Include ref="Geometry/TrackerCommonData/data/trackermaterial/2021/v2/trackermaterial.xml"/>
     <Include ref="Geometry/TrackerCommonData/data/tibtidcommonmaterial.xml"/>
     <Include ref="Geometry/TrackerCommonData/data/tibmaterial.xml"/>
     <Include ref="Geometry/TrackerCommonData/data/tidmaterial.xml"/>
     <Include ref="Geometry/TrackerCommonData/data/tobmaterial.xml"/>
     <Include ref="Geometry/TrackerCommonData/data/tecmaterial.xml"/>
-    <Include ref="Geometry/TrackerCommonData/data/PhaseI/pixbarmaterial.xml"/> 
     <Include ref="Geometry/TrackerCommonData/data/PhaseI/pixfwdMaterials.xml"/>
+    <Include ref="Geometry/TrackerCommonData/data/PhaseI/v3/pixbarmaterial.xml"/> 
     <Include ref="Geometry/TrackerCommonData/data/Run2/tracker.xml"/>
     <Include ref="Geometry/TrackerCommonData/data/pixfwdCommon.xml"/>
     <Include ref="Geometry/TrackerCommonData/data/PhaseI/pixfwdCylinder.xml"/> 
@@ -61,16 +61,16 @@
     <Include ref="Geometry/TrackerCommonData/data/PhaseI/pixfwdbladeInnerZminus.xml"/>
     <Include ref="Geometry/TrackerCommonData/data/PhaseI/pixfwdbladeOuterZplus.xml"/>
     <Include ref="Geometry/TrackerCommonData/data/PhaseI/pixfwdbladeOuterZminus.xml"/>
-    <Include ref="Geometry/TrackerCommonData/data/PhaseI/pixbarladder.xml"/> 
-    <Include ref="Geometry/TrackerCommonData/data/PhaseI/pixbarladderfull0.xml"/> 
-    <Include ref="Geometry/TrackerCommonData/data/PhaseI/pixbarladderfull1.xml"/> 
-    <Include ref="Geometry/TrackerCommonData/data/PhaseI/pixbarladderfull2.xml"/> 
-    <Include ref="Geometry/TrackerCommonData/data/PhaseI/pixbarladderfull3.xml"/> 
-    <Include ref="Geometry/TrackerCommonData/data/PhaseI/pixbarlayer.xml"/> 
-    <Include ref="Geometry/TrackerCommonData/data/PhaseI/pixbarlayer0.xml"/> 
-    <Include ref="Geometry/TrackerCommonData/data/PhaseI/pixbarlayer1.xml"/> 
-    <Include ref="Geometry/TrackerCommonData/data/PhaseI/pixbarlayer2.xml"/> 
-    <Include ref="Geometry/TrackerCommonData/data/PhaseI/pixbarlayer3.xml"/> 
+    <Include ref="Geometry/TrackerCommonData/data/PhaseI/v2/pixbarladder.xml"/> 
+    <Include ref="Geometry/TrackerCommonData/data/PhaseI/v2/pixbarladderfull0.xml"/> 
+    <Include ref="Geometry/TrackerCommonData/data/PhaseI/v2/pixbarladderfull1.xml"/> 
+    <Include ref="Geometry/TrackerCommonData/data/PhaseI/v2/pixbarladderfull2.xml"/> 
+    <Include ref="Geometry/TrackerCommonData/data/PhaseI/v2/pixbarladderfull3.xml"/> 
+    <Include ref="Geometry/TrackerCommonData/data/PhaseI/v2/pixbarlayer.xml"/> 
+    <Include ref="Geometry/TrackerCommonData/data/PhaseI/v2/pixbarlayer0.xml"/> 
+    <Include ref="Geometry/TrackerCommonData/data/PhaseI/v2/pixbarlayer1.xml"/> 
+    <Include ref="Geometry/TrackerCommonData/data/PhaseI/v2/pixbarlayer2.xml"/> 
+    <Include ref="Geometry/TrackerCommonData/data/PhaseI/v2/pixbarlayer3.xml"/> 
     <Include ref="Geometry/TrackerCommonData/data/PhaseI/v1/pixbar.xml"/>
     <Include ref="Geometry/TrackerCommonData/data/Run2/trackerpatchpannel.xml"/>
     <Include ref="Geometry/TrackerCommonData/data/Run2/trackerpixelnose.xml"/>

--- a/MagneticField/GeomBuilder/data/cms-mf-geometry_160812.xml
+++ b/MagneticField/GeomBuilder/data/cms-mf-geometry_160812.xml
@@ -28,6 +28,6 @@
     <Include ref='MagneticField/GeomBuilder/data/MagneticFieldVolumes_160812_1.xml'/>
     <Include ref='MagneticField/GeomBuilder/data/MagneticFieldVolumes_160812_2.xml'/>
     <!--Materials are irrelevant for the MF geometry, but the DD4hep parser complains if they are not defined -->
-    <Include ref='Geometry/CMSCommonData/data/materials/2015/v1/materials.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/materials/2021/v3/materials.xml'/>
   </IncludeSection>
 </DDDefinition>


### PR DESCRIPTION
Two data files used in unit tests were omitted from #36496, which prohibits out-of-order definitions of composite materials used in geometry. In these two files, versions of the materials files needed to be updated and placed in the correct order.

#### PR validation:

The affected unit tests now run successfully.

No backport is needed.