### PR TITLE
add missing include in RefHolder_.h needed for gcc10/modules 

### DIFF
--- a/DataFormats/Common/interface/RefHolder_.h
+++ b/DataFormats/Common/interface/RefHolder_.h
@@ -7,6 +7,7 @@
 #include "FWCore/Utilities/interface/OffsetToBase.h"
 #include <memory>
 #include <typeinfo>
+#include <string>
 
 namespace edm {
   namespace reftobase {


### PR DESCRIPTION
Fixes compilation error in Friday's modules IB.