### PR TITLE
Expand L1T Shower data vs emulator comparison DQM

### DIFF
--- a/DQM/L1TMonitor/interface/L1TStage2RegionalShower.h
+++ b/DQM/L1TMonitor/interface/L1TStage2RegionalShower.h
@@ -1,5 +1,5 @@
-#ifndef DQM_L1TMonitor_L1TStage2Shower_h
-#define DQM_L1TMonitor_L1TStage2Shower_h
+#ifndef DQM_L1TMonitor_L1TStage2RegionalShower_h
+#define DQM_L1TMonitor_L1TStage2RegionalShower_h
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -15,10 +15,10 @@
 #include "DataFormats/CSCDigi/interface/CSCShowerDigiCollection.h"
 #include "DataFormats/L1TMuon/interface/RegionalMuonShower.h"
 
-class L1TStage2Shower : public DQMOneEDAnalyzer<> {
+class L1TStage2RegionalShower : public DQMOneEDAnalyzer<> {
 public:
-  L1TStage2Shower(const edm::ParameterSet& ps);
-  ~L1TStage2Shower() override;
+  L1TStage2RegionalShower(const edm::ParameterSet& ps);
+  ~L1TStage2RegionalShower() override;
 
 protected:
   void bookHistograms(DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&) override;

--- a/DQM/L1TMonitor/interface/L1TdeCSCTPGShower.h
+++ b/DQM/L1TMonitor/interface/L1TdeCSCTPGShower.h
@@ -31,19 +31,33 @@ private:
 
   std::string monitorDir_;
 
-  MonitorElement* lctShowerDataSummary_denom_;
-  MonitorElement* lctShowerDataSummary_num_;
-  MonitorElement* alctShowerDataSummary_denom_;
-  MonitorElement* alctShowerDataSummary_num_;
-  MonitorElement* clctShowerDataSummary_denom_;
-  MonitorElement* clctShowerDataSummary_num_;
+  MonitorElement* lctShowerDataNomSummary_denom_;
+  MonitorElement* lctShowerDataNomSummary_num_;
+  MonitorElement* alctShowerDataNomSummary_denom_;
+  MonitorElement* alctShowerDataNomSummary_num_;
+  MonitorElement* clctShowerDataNomSummary_denom_;
+  MonitorElement* clctShowerDataNomSummary_num_;
 
-  MonitorElement* lctShowerEmulSummary_denom_;
-  MonitorElement* lctShowerEmulSummary_num_;
-  MonitorElement* alctShowerEmulSummary_denom_;
-  MonitorElement* alctShowerEmulSummary_num_;
-  MonitorElement* clctShowerEmulSummary_denom_;
-  MonitorElement* clctShowerEmulSummary_num_;
+  MonitorElement* lctShowerEmulNomSummary_denom_;
+  MonitorElement* lctShowerEmulNomSummary_num_;
+  MonitorElement* alctShowerEmulNomSummary_denom_;
+  MonitorElement* alctShowerEmulNomSummary_num_;
+  MonitorElement* clctShowerEmulNomSummary_denom_;
+  MonitorElement* clctShowerEmulNomSummary_num_;
+
+  MonitorElement* lctShowerDataTightSummary_denom_;
+  MonitorElement* lctShowerDataTightSummary_num_;
+  MonitorElement* alctShowerDataTightSummary_denom_;
+  MonitorElement* alctShowerDataTightSummary_num_;
+  MonitorElement* clctShowerDataTightSummary_denom_;
+  MonitorElement* clctShowerDataTightSummary_num_;
+
+  MonitorElement* lctShowerEmulTightSummary_denom_;
+  MonitorElement* lctShowerEmulTightSummary_num_;
+  MonitorElement* alctShowerEmulTightSummary_denom_;
+  MonitorElement* alctShowerEmulTightSummary_num_;
+  MonitorElement* clctShowerEmulTightSummary_denom_;
+  MonitorElement* clctShowerEmulTightSummary_num_;
 };
 
 #endif

--- a/DQM/L1TMonitor/interface/L1TdeStage2RegionalShower.h
+++ b/DQM/L1TMonitor/interface/L1TdeStage2RegionalShower.h
@@ -1,5 +1,5 @@
-#ifndef DQM_L1TMonitor_L1TdeStage2Shower_h
-#define DQM_L1TMonitor_L1TdeStage2Shower_h
+#ifndef DQM_L1TMonitor_L1TdeStage2RegionalShower_h
+#define DQM_L1TMonitor_L1TdeStage2RegionalShower_h
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -10,10 +10,10 @@
 
 #include "DataFormats/L1TMuon/interface/RegionalMuonShower.h"
 
-class L1TdeStage2Shower : public DQMEDAnalyzer {
+class L1TdeStage2RegionalShower : public DQMEDAnalyzer {
 public:
-  L1TdeStage2Shower(const edm::ParameterSet& ps);
-  ~L1TdeStage2Shower() override;
+  L1TdeStage2RegionalShower(const edm::ParameterSet& ps);
+  ~L1TdeStage2RegionalShower() override;
 
 protected:
   void bookHistograms(DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&) override;

--- a/DQM/L1TMonitor/plugins/SealModule.cc
+++ b/DQM/L1TMonitor/plugins/SealModule.cc
@@ -60,8 +60,8 @@ DEFINE_FWK_MODULE(L1TStage2OMTF);
 #include "DQM/L1TMonitor/interface/L1TStage2EMTF.h"
 DEFINE_FWK_MODULE(L1TStage2EMTF);
 
-#include "DQM/L1TMonitor/interface/L1TStage2Shower.h"
-DEFINE_FWK_MODULE(L1TStage2Shower);
+#include "DQM/L1TMonitor/interface/L1TStage2RegionalShower.h"
+DEFINE_FWK_MODULE(L1TStage2RegionalShower);
 
 #include "DQM/L1TMonitor/interface/L1TMP7ZeroSupp.h"
 DEFINE_FWK_MODULE(L1TMP7ZeroSupp);
@@ -113,8 +113,8 @@ DEFINE_FWK_MODULE(L1TdeCSCTF);
 #include "DQM/L1TMonitor/interface/L1TdeStage2EMTF.h"
 DEFINE_FWK_MODULE(L1TdeStage2EMTF);
 
-#include "DQM/L1TMonitor/interface/L1TdeStage2Shower.h"
-DEFINE_FWK_MODULE(L1TdeStage2Shower);
+#include "DQM/L1TMonitor/interface/L1TdeStage2RegionalShower.h"
+DEFINE_FWK_MODULE(L1TdeStage2RegionalShower);
 
 //#include "DQM/L1TMonitor/interface/L1GtHwValidation.h"
 //DEFINE_FWK_MODULE(L1GtHwValidation);

--- a/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
@@ -130,9 +130,8 @@ from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 _run3_Stage2L1HardwareValidation = Stage2L1HardwareValidation.copy()
 run3_GEM.toReplaceWith( Stage2L1HardwareValidation, cms.Sequence( valMuonGEMPadDigis + valMuonGEMPadDigiClusters + _run3_Stage2L1HardwareValidation) )
 
-from Configuration.Eras.Modifier_run3_common_cff import run3_common
 _run3Shower_Stage2L1HardwareValidation = Stage2L1HardwareValidation.copy()
-run3_common.toReplaceWith( Stage2L1HardwareValidation, cms.Sequence(_run3Shower_Stage2L1HardwareValidation + valEmtfStage2Showers) )
+run3_GEM.toReplaceWith( Stage2L1HardwareValidation, cms.Sequence(_run3Shower_Stage2L1HardwareValidation + valEmtfStage2Showers) )
 
 Stage2L1HardwareValidationForValidationEvents = cms.Sequence(
     valCaloStage2Layer2Digis
@@ -193,9 +192,8 @@ _run3_l1tStage2EmulatorOnlineDQM += l1tdeGEMTPG
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toReplaceWith( l1tStage2EmulatorOnlineDQM, _run3_l1tStage2EmulatorOnlineDQM )
 
-from Configuration.Eras.Modifier_run3_common_cff import run3_common
 _run3shower_l1tStage2EmulatorOnlineDQM = l1tStage2EmulatorOnlineDQM.copy()
-run3_common.toReplaceWith( l1tStage2EmulatorOnlineDQM, cms.Sequence(_run3shower_l1tStage2EmulatorOnlineDQM + l1tdeCSCTPGShower) )
+run3_GEM.toReplaceWith( l1tStage2EmulatorOnlineDQM, cms.Sequence(_run3shower_l1tStage2EmulatorOnlineDQM + l1tdeCSCTPGShower) )
 
 # sequence to run only for validation events
 l1tStage2EmulatorOnlineDQMValidationEvents = cms.Sequence(

--- a/DQM/L1TMonitor/python/L1TStage2RegionalShower_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2RegionalShower_cfi.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
-l1tStage2Shower = DQMEDAnalyzer(
-    "L1TStage2Shower",
+l1tStage2RegionalShower = DQMEDAnalyzer(
+    "L1TStage2RegionalShower",
     emtfSource = cms.InputTag("emtfStage2Digis"),                   ## EMTF unpacker tag
     cscSource = cms.InputTag("muonCSCDigis", "MuonCSCShowerDigi"),  ## CSC  unpacker tag
 #    emtfSource = cms.InputTag("simEmtfShowers", "EMTF"),           ## EMTF emulator tag

--- a/DQM/L1TMonitor/python/L1TStage2_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2_cff.py
@@ -19,7 +19,7 @@ from DQM.L1TMonitor.L1TStage2OMTF_cfi import *
 from DQM.L1TMonitor.L1TStage2EMTF_cfi import *
 
 # Shower
-from DQM.L1TMonitor.L1TStage2Shower_cfi import *
+from DQM.L1TMonitor.L1TStage2RegionalShower_cfi import *
 
 # uGMT
 from DQM.L1TMonitor.L1TStage2uGMT_cff import *
@@ -42,7 +42,7 @@ l1tStage2OnlineDQM = cms.Sequence(
     l1tStage2Emtf +
 # Do not include shower DQM module in the sequence because there is no EMTF shower unpacker (as of CMSSW_12_2_0_pre2).
 # It will be enabled once the EMTF shower unpacker is ready.
-#    l1tStage2Shower +  
+#    l1tStage2RegionalShower +  
     l1tStage2uGMTOnlineDQMSeq +
     l1tObjectsTiming +
     l1tStage2uGTOnlineDQMSeq

--- a/DQM/L1TMonitor/python/L1TdeStage2EMTF_cff.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2EMTF_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from DQM.L1TMonitor.L1TdeStage2EMTF_cfi import *
-from DQM.L1TMonitor.L1TdeStage2Shower_cfi import *
+from DQM.L1TMonitor.L1TdeStage2RegionalShower_cfi import *
 
 # List of bins to ignore
 ignoreBinsDeStage2Emtf = [1]
@@ -30,4 +30,4 @@ l1tdeStage2EmtfOnlineDQMSeq = cms.Sequence(
 
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 _run3shower_l1tdeStage2EmtfOnlineDQMSeq = l1tdeStage2EmtfOnlineDQMSeq.copy()
-run3_GEM.toReplaceWith(l1tdeStage2EmtfOnlineDQMSeq, cms.Sequence(_run3shower_l1tdeStage2EmtfOnlineDQMSeq + l1tdeStage2Shower))
+run3_GEM.toReplaceWith(l1tdeStage2EmtfOnlineDQMSeq, cms.Sequence(_run3shower_l1tdeStage2EmtfOnlineDQMSeq + l1tdeStage2RegionalShower))

--- a/DQM/L1TMonitor/python/L1TdeStage2EMTF_cff.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2EMTF_cff.py
@@ -28,6 +28,6 @@ l1tdeStage2EmtfOnlineDQMSeq = cms.Sequence(
     l1tdeStage2EmtfComp
 )
 
-from Configuration.Eras.Modifier_run3_common_cff import run3_common
+from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 _run3shower_l1tdeStage2EmtfOnlineDQMSeq = l1tdeStage2EmtfOnlineDQMSeq.copy()
-run3_common.toReplaceWith(l1tdeStage2EmtfOnlineDQMSeq, cms.Sequence(_run3shower_l1tdeStage2EmtfOnlineDQMSeq + l1tdeStage2Shower))
+run3_GEM.toReplaceWith(l1tdeStage2EmtfOnlineDQMSeq, cms.Sequence(_run3shower_l1tdeStage2EmtfOnlineDQMSeq + l1tdeStage2Shower))

--- a/DQM/L1TMonitor/python/L1TdeStage2RegionalShower_cfi.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2RegionalShower_cfi.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
-l1tdeStage2Shower = DQMEDAnalyzer(
-    "L1TdeStage2Shower",
+l1tdeStage2RegionalShower = DQMEDAnalyzer(
+    "L1TdeStage2RegionalShower",
     # EMTF Showers not in data yet. Use Emul for both
     # Once Run 3 firmware are implemented, should change data tags to 
     # cms.InputTag("emtfStage2Digis")

--- a/DQM/L1TMonitor/src/L1TStage2RegionalShower.cc
+++ b/DQM/L1TMonitor/src/L1TStage2RegionalShower.cc
@@ -3,17 +3,17 @@
 #include <iostream>
 #include <map>
 
-#include "DQM/L1TMonitor/interface/L1TStage2Shower.h"
+#include "DQM/L1TMonitor/interface/L1TStage2RegionalShower.h"
 
-L1TStage2Shower::L1TStage2Shower(const edm::ParameterSet& ps)
+L1TStage2RegionalShower::L1TStage2RegionalShower(const edm::ParameterSet& ps)
     : EMTFShowerToken(consumes<l1t::RegionalMuonShowerBxCollection>(ps.getParameter<edm::InputTag>("emtfSource"))),
       CSCShowerToken(consumes<CSCShowerDigiCollection>(ps.getParameter<edm::InputTag>("cscSource"))),
       monitorDir(ps.getUntrackedParameter<std::string>("monitorDir", "")),
       verbose(ps.getUntrackedParameter<bool>("verbose", false)) {}
 
-L1TStage2Shower::~L1TStage2Shower() {}
+L1TStage2RegionalShower::~L1TStage2RegionalShower() {}
 
-void L1TStage2Shower::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, const edm::EventSetup&) {
+void L1TStage2RegionalShower::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, const edm::EventSetup&) {
   ibooker.setCurrentFolder(monitorDir);
 
   const std::array<std::string, 9> suffix_label{{"4/2", "4/1", "3/2", "3/1", " 2/2", "2/1", "1/3", "1/2", "1/1"}};
@@ -75,7 +75,7 @@ void L1TStage2Shower::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&
   emtfShowerTypeOccupancy->setBinLabel(1, "ME- Tight", 2);
 }
 
-void L1TStage2Shower::analyze(const edm::Event& e, const edm::EventSetup& c) {
+void L1TStage2RegionalShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
   l1t::RegionalMuonShowerBxCollection const& EmtfShowers = e.get(EMTFShowerToken);
   CSCShowerDigiCollection const& CscShowers = e.get(CSCShowerToken);
 

--- a/DQM/L1TMonitor/src/L1TdeCSCTPGShower.cc
+++ b/DQM/L1TMonitor/src/L1TdeCSCTPGShower.cc
@@ -18,93 +18,175 @@ void L1TdeCSCTPGShower::bookHistograms(DQMStore::IBooker& iBooker, const edm::Ru
   iBooker.setCurrentFolder(monitorDir_);
 
   // 2D summary plots
-  lctShowerDataSummary_denom_ =
-      iBooker.book2D("lct_cscshower_data_summary_denom", "Data LCT Shower All", 36, 1, 37, 18, 0, 18);
-  lctShowerDataSummary_num_ =
-      iBooker.book2D("lct_cscshower_data_summary_num", "Data LCT Shower Emul Matched", 36, 1, 37, 18, 0, 18);
-  alctShowerDataSummary_denom_ =
-      iBooker.book2D("alct_cscshower_data_summary_denom", "Data ALCT Shower All", 36, 1, 37, 18, 0, 18);
-  alctShowerDataSummary_num_ =
-      iBooker.book2D("alct_cscshower_data_summary_num", "Data ALCT Shower Emul Matched", 36, 1, 37, 18, 0, 18);
-  clctShowerDataSummary_denom_ =
-      iBooker.book2D("clct_cscshower_data_summary_denom", "Data CLCT Shower All", 36, 1, 37, 18, 0, 18);
-  clctShowerDataSummary_num_ =
-      iBooker.book2D("clct_cscshower_data_summary_num", "Data CLCT Shower Emul Matched", 36, 1, 37, 18, 0, 18);
+  lctShowerDataNomSummary_denom_ =
+      iBooker.book2D("lct_cscshower_data_nom_summary_denom", "Data LCT Nominal Only Shower All", 36, 1, 37, 18, 0, 18);
+  lctShowerDataNomSummary_num_ =
+      iBooker.book2D("lct_cscshower_data_nom_summary_num", "Data LCT Nominal Only Shower Emul Matched", 36, 1, 37, 18, 0, 18);
+  alctShowerDataNomSummary_denom_ =
+      iBooker.book2D("alct_cscshower_data_nom_summary_denom", "Data ALCT Nominal Only Shower All", 36, 1, 37, 18, 0, 18);
+  alctShowerDataNomSummary_num_ =
+      iBooker.book2D("alct_cscshower_data_nom_summary_num", "Data ALCT Nominal Only Shower Emul Matched", 36, 1, 37, 18, 0, 18);
+  clctShowerDataNomSummary_denom_ =
+      iBooker.book2D("clct_cscshower_data_nom_summary_denom", "Data CLCT Nominal Only Shower All", 36, 1, 37, 18, 0, 18);
+  clctShowerDataNomSummary_num_ =
+      iBooker.book2D("clct_cscshower_data_nom_summary_num", "Data CLCT Nominal Only Shower Emul Matched", 36, 1, 37, 18, 0, 18);
 
-  lctShowerEmulSummary_denom_ =
-      iBooker.book2D("lct_cscshower_emul_summary_denom", "Emul LCT Shower All", 36, 1, 37, 18, 0, 18);
-  lctShowerEmulSummary_num_ =
-      iBooker.book2D("lct_cscshower_emul_summary_num", "Emul LCT Shower Not Matched to Data", 36, 1, 37, 18, 0, 18);
-  alctShowerEmulSummary_denom_ =
-      iBooker.book2D("alct_cscshower_emul_summary_denom", "Emul ALCT Shower All", 36, 1, 37, 18, 0, 18);
-  alctShowerEmulSummary_num_ =
-      iBooker.book2D("alct_cscshower_emul_summary_num", "Emul ALCT Shower Not Matched to Data", 36, 1, 37, 18, 0, 18);
-  clctShowerEmulSummary_denom_ =
-      iBooker.book2D("clct_cscshower_emul_summary_denom", "Emul CLCT Shower All", 36, 1, 37, 18, 0, 18);
-  clctShowerEmulSummary_num_ =
-      iBooker.book2D("clct_cscshower_emul_summary_num", "Emul CLCT Shower Not Matched to Data", 36, 1, 37, 18, 0, 18);
+  lctShowerEmulNomSummary_denom_ =
+      iBooker.book2D("lct_cscshower_emul_nom_summary_denom", "Emul LCT Nominal Only Shower All", 36, 1, 37, 18, 0, 18);
+  lctShowerEmulNomSummary_num_ =
+      iBooker.book2D("lct_cscshower_emul_nom_summary_num", "Emul LCT Nominal Only Shower Not Matched to Data", 36, 1, 37, 18, 0, 18);
+  alctShowerEmulNomSummary_denom_ =
+      iBooker.book2D("alct_cscshower_emul_nom_summary_denom", "Emul ALCT Nominal Only Shower All", 36, 1, 37, 18, 0, 18);
+  alctShowerEmulNomSummary_num_ =
+      iBooker.book2D("alct_cscshower_emul_nom_summary_num", "Emul ALCT Nominal Only Shower Not Matched to Data", 36, 1, 37, 18, 0, 18);
+  clctShowerEmulNomSummary_denom_ =
+      iBooker.book2D("clct_cscshower_emul_nom_summary_denom", "Emul CLCT Nominal Only Shower All", 36, 1, 37, 18, 0, 18);
+  clctShowerEmulNomSummary_num_ =
+      iBooker.book2D("clct_cscshower_emul_nom_summary_num", "Emul CLCT Nominal Only Shower Not Matched to Data", 36, 1, 37, 18, 0, 18);
+
+  lctShowerDataTightSummary_denom_ =
+      iBooker.book2D("lct_cscshower_data_tight_summary_denom", "Data LCT Tight Shower All", 36, 1, 37, 18, 0, 18);
+  lctShowerDataTightSummary_num_ =
+      iBooker.book2D("lct_cscshower_data_tight_summary_num", "Data LCT Tight Shower Emul Matched", 36, 1, 37, 18, 0, 18);
+  alctShowerDataTightSummary_denom_ =
+      iBooker.book2D("alct_cscshower_data_tight_summary_denom", "Data ALCT Tight Shower All", 36, 1, 37, 18, 0, 18);
+  alctShowerDataTightSummary_num_ =
+      iBooker.book2D("alct_cscshower_data_tight_summary_num", "Data ALCT Tight Shower Emul Matched", 36, 1, 37, 18, 0, 18);
+  clctShowerDataTightSummary_denom_ =
+      iBooker.book2D("clct_cscshower_data_tight_summary_denom", "Data CLCT Tight Shower All", 36, 1, 37, 18, 0, 18);
+  clctShowerDataTightSummary_num_ =
+      iBooker.book2D("clct_cscshower_data_tight_summary_num", "Data CLCT Tight Shower Emul Matched", 36, 1, 37, 18, 0, 18);
+
+  lctShowerEmulTightSummary_denom_ =
+      iBooker.book2D("lct_cscshower_emul_tight_summary_denom", "Emul LCT Tight Shower All", 36, 1, 37, 18, 0, 18);
+  lctShowerEmulTightSummary_num_ =
+      iBooker.book2D("lct_cscshower_emul_tight_summary_num", "Emul LCT Tight Shower Not Matched to Data", 36, 1, 37, 18, 0, 18);
+  alctShowerEmulTightSummary_denom_ =
+      iBooker.book2D("alct_cscshower_emul_tight_summary_denom", "Emul ALCT Tight Shower All", 36, 1, 37, 18, 0, 18);
+  alctShowerEmulTightSummary_num_ =
+      iBooker.book2D("alct_cscshower_emul_tight_summary_num", "Emul ALCT Tight Shower Not Matched to Data", 36, 1, 37, 18, 0, 18);
+  clctShowerEmulTightSummary_denom_ =
+      iBooker.book2D("clct_cscshower_emul_tight_summary_denom", "Emul CLCT Tight Shower All", 36, 1, 37, 18, 0, 18);
+  clctShowerEmulTightSummary_num_ =
+      iBooker.book2D("clct_cscshower_emul_tight_summary_num", "Emul CLCT Tight Shower Not Matched to Data", 36, 1, 37, 18, 0, 18);
 
   // x labels
-  lctShowerDataSummary_denom_->setAxisTitle("Chamber", 1);
-  lctShowerDataSummary_num_->setAxisTitle("Chamber", 1);
-  alctShowerDataSummary_denom_->setAxisTitle("Chamber", 1);
-  alctShowerDataSummary_num_->setAxisTitle("Chamber", 1);
-  clctShowerDataSummary_denom_->setAxisTitle("Chamber", 1);
-  clctShowerDataSummary_num_->setAxisTitle("Chamber", 1);
+  lctShowerDataNomSummary_denom_->setAxisTitle("Chamber", 1);
+  lctShowerDataNomSummary_num_->setAxisTitle("Chamber", 1);
+  alctShowerDataNomSummary_denom_->setAxisTitle("Chamber", 1);
+  alctShowerDataNomSummary_num_->setAxisTitle("Chamber", 1);
+  clctShowerDataNomSummary_denom_->setAxisTitle("Chamber", 1);
+  clctShowerDataNomSummary_num_->setAxisTitle("Chamber", 1);
 
-  lctShowerEmulSummary_denom_->setAxisTitle("Chamber", 1);
-  lctShowerEmulSummary_num_->setAxisTitle("Chamber", 1);
-  alctShowerEmulSummary_denom_->setAxisTitle("Chamber", 1);
-  alctShowerEmulSummary_num_->setAxisTitle("Chamber", 1);
-  clctShowerEmulSummary_denom_->setAxisTitle("Chamber", 1);
-  clctShowerEmulSummary_num_->setAxisTitle("Chamber", 1);
+  lctShowerEmulNomSummary_denom_->setAxisTitle("Chamber", 1);
+  lctShowerEmulNomSummary_num_->setAxisTitle("Chamber", 1);
+  alctShowerEmulNomSummary_denom_->setAxisTitle("Chamber", 1);
+  alctShowerEmulNomSummary_num_->setAxisTitle("Chamber", 1);
+  clctShowerEmulNomSummary_denom_->setAxisTitle("Chamber", 1);
+  clctShowerEmulNomSummary_num_->setAxisTitle("Chamber", 1);
+
+  lctShowerDataTightSummary_denom_->setAxisTitle("Chamber", 1);
+  lctShowerDataTightSummary_num_->setAxisTitle("Chamber", 1);
+  alctShowerDataTightSummary_denom_->setAxisTitle("Chamber", 1);
+  alctShowerDataTightSummary_num_->setAxisTitle("Chamber", 1);
+  clctShowerDataTightSummary_denom_->setAxisTitle("Chamber", 1);
+  clctShowerDataTightSummary_num_->setAxisTitle("Chamber", 1);
+
+  lctShowerEmulTightSummary_denom_->setAxisTitle("Chamber", 1);
+  lctShowerEmulTightSummary_num_->setAxisTitle("Chamber", 1);
+  alctShowerEmulTightSummary_denom_->setAxisTitle("Chamber", 1);
+  alctShowerEmulTightSummary_num_->setAxisTitle("Chamber", 1);
+  clctShowerEmulTightSummary_denom_->setAxisTitle("Chamber", 1);
+  clctShowerEmulTightSummary_num_->setAxisTitle("Chamber", 1);
 
   // plotting option
-  lctShowerDataSummary_denom_->setOption("colz");
-  lctShowerDataSummary_num_->setOption("colz");
-  alctShowerDataSummary_denom_->setOption("colz");
-  alctShowerDataSummary_num_->setOption("colz");
-  clctShowerDataSummary_denom_->setOption("colz");
-  clctShowerDataSummary_num_->setOption("colz");
+  lctShowerDataNomSummary_denom_->setOption("colz");
+  lctShowerDataNomSummary_num_->setOption("colz");
+  alctShowerDataNomSummary_denom_->setOption("colz");
+  alctShowerDataNomSummary_num_->setOption("colz");
+  clctShowerDataNomSummary_denom_->setOption("colz");
+  clctShowerDataNomSummary_num_->setOption("colz");
 
-  lctShowerEmulSummary_denom_->setOption("colz");
-  lctShowerEmulSummary_num_->setOption("colz");
-  alctShowerEmulSummary_denom_->setOption("colz");
-  alctShowerEmulSummary_num_->setOption("colz");
-  clctShowerEmulSummary_denom_->setOption("colz");
-  clctShowerEmulSummary_num_->setOption("colz");
+  lctShowerEmulNomSummary_denom_->setOption("colz");
+  lctShowerEmulNomSummary_num_->setOption("colz");
+  alctShowerEmulNomSummary_denom_->setOption("colz");
+  alctShowerEmulNomSummary_num_->setOption("colz");
+  clctShowerEmulNomSummary_denom_->setOption("colz");
+  clctShowerEmulNomSummary_num_->setOption("colz");
+
+  lctShowerDataTightSummary_denom_->setOption("colz");
+  lctShowerDataTightSummary_num_->setOption("colz");
+  alctShowerDataTightSummary_denom_->setOption("colz");
+  alctShowerDataTightSummary_num_->setOption("colz");
+  clctShowerDataTightSummary_denom_->setOption("colz");
+  clctShowerDataTightSummary_num_->setOption("colz");
+
+  lctShowerEmulTightSummary_denom_->setOption("colz");
+  lctShowerEmulTightSummary_num_->setOption("colz");
+  alctShowerEmulTightSummary_denom_->setOption("colz");
+  alctShowerEmulTightSummary_num_->setOption("colz");
+  clctShowerEmulTightSummary_denom_->setOption("colz");
+  clctShowerEmulTightSummary_num_->setOption("colz");
 
   const std::array<std::string, 9> suffix_label{{"4/2", "4/1", "3/2", "3/1", " 2/2", "2/1", "1/3", "1/2", "1/1"}};
 
   // y labels
   for (int ybin = 1; ybin <= 9; ++ybin) {
-    lctShowerDataSummary_denom_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
-    lctShowerDataSummary_num_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
-    alctShowerDataSummary_denom_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
-    alctShowerDataSummary_num_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
-    clctShowerDataSummary_denom_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
-    clctShowerDataSummary_num_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    lctShowerDataNomSummary_denom_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    lctShowerDataNomSummary_num_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    alctShowerDataNomSummary_denom_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    alctShowerDataNomSummary_num_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    clctShowerDataNomSummary_denom_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    clctShowerDataNomSummary_num_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
 
-    lctShowerEmulSummary_denom_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
-    lctShowerEmulSummary_num_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
-    alctShowerEmulSummary_denom_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
-    alctShowerEmulSummary_num_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
-    clctShowerEmulSummary_denom_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
-    clctShowerEmulSummary_num_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    lctShowerEmulNomSummary_denom_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    lctShowerEmulNomSummary_num_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    alctShowerEmulNomSummary_denom_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    alctShowerEmulNomSummary_num_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    clctShowerEmulNomSummary_denom_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    clctShowerEmulNomSummary_num_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
 
-    lctShowerDataSummary_denom_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
-    lctShowerDataSummary_num_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
-    alctShowerDataSummary_denom_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
-    alctShowerDataSummary_num_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
-    clctShowerDataSummary_denom_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
-    clctShowerDataSummary_num_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    lctShowerDataNomSummary_denom_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    lctShowerDataNomSummary_num_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    alctShowerDataNomSummary_denom_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    alctShowerDataNomSummary_num_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    clctShowerDataNomSummary_denom_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    clctShowerDataNomSummary_num_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
 
-    lctShowerEmulSummary_denom_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
-    lctShowerEmulSummary_num_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
-    alctShowerEmulSummary_denom_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
-    alctShowerEmulSummary_num_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
-    clctShowerEmulSummary_denom_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
-    clctShowerEmulSummary_num_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    lctShowerEmulNomSummary_denom_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    lctShowerEmulNomSummary_num_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    alctShowerEmulNomSummary_denom_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    alctShowerEmulNomSummary_num_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    clctShowerEmulNomSummary_denom_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    clctShowerEmulNomSummary_num_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+
+    lctShowerDataTightSummary_denom_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    lctShowerDataTightSummary_num_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    alctShowerDataTightSummary_denom_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    alctShowerDataTightSummary_num_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    clctShowerDataTightSummary_denom_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    clctShowerDataTightSummary_num_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+
+    lctShowerEmulTightSummary_denom_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    lctShowerEmulTightSummary_num_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    alctShowerEmulTightSummary_denom_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    alctShowerEmulTightSummary_num_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    clctShowerEmulTightSummary_denom_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    clctShowerEmulTightSummary_num_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+
+    lctShowerDataTightSummary_denom_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    lctShowerDataTightSummary_num_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    alctShowerDataTightSummary_denom_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    alctShowerDataTightSummary_num_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    clctShowerDataTightSummary_denom_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    clctShowerDataTightSummary_num_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+
+    lctShowerEmulTightSummary_denom_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    lctShowerEmulTightSummary_num_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    alctShowerEmulTightSummary_denom_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    alctShowerEmulTightSummary_num_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    clctShowerEmulTightSummary_denom_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    clctShowerEmulTightSummary_num_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
   }
 }
 
@@ -175,33 +257,60 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
             auto range_emulALCT = emulALCTshs->get(detid);
 
             for (auto dalct = range_dataALCT.first; dalct != range_dataALCT.second; dalct++) {
-              if (dalct->isValid()) {
-                if (chamber20) {
-                  alctShowerDataSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
-                  alctShowerDataSummary_denom_->Fill(chamber * 2, sr, 0.5);
-                } else
-                  alctShowerDataSummary_denom_->Fill(chamber, sr);
+              if (dalct->isValid() and dalct->isNominalInTime()) {
+                if (dalct->isTightInTime()) {
+                  if (chamber20) {
+                    alctShowerDataTightSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
+                    alctShowerDataTightSummary_denom_->Fill(chamber * 2, sr, 0.5);
+                  } else
+                    alctShowerDataTightSummary_denom_->Fill(chamber, sr);
+                }
+                else {
+                  if (chamber20) {
+                    alctShowerDataNomSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
+                    alctShowerDataNomSummary_denom_->Fill(chamber * 2, sr, 0.5);
+                  } else
+                    alctShowerDataNomSummary_denom_->Fill(chamber, sr);
+                }
                 // check for least one matching ALCT
                 for (auto ealct = range_emulALCT.first; ealct != range_emulALCT.second; ealct++) {
                   if (ealct->isValid() and areSameShowers(*dalct, *ealct)) {
-                    if (chamber20) {
-                      alctShowerDataSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
-                      alctShowerDataSummary_num_->Fill(chamber * 2, sr, 0.5);
-                    } else
-                      alctShowerDataSummary_num_->Fill(chamber, sr);
+                    if (dalct->isTightInTime()) {
+                      if (chamber20) {
+                        alctShowerDataTightSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
+                        alctShowerDataTightSummary_num_->Fill(chamber * 2, sr, 0.5);
+                      } else
+                        alctShowerDataTightSummary_num_->Fill(chamber, sr);
+                    }
+                    else {
+                      if (chamber20) {
+                        alctShowerDataNomSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
+                        alctShowerDataNomSummary_num_->Fill(chamber * 2, sr, 0.5);
+                      } else
+                        alctShowerDataNomSummary_num_->Fill(chamber, sr);
+                    }
                   }
                 }
               }
-            }
+            } // End of for (auto dalct = range_dataALCT.first; dalct != range_dataALCT.second; dalct++)
 
             for (auto ealct = range_emulALCT.first; ealct != range_emulALCT.second; ealct++) {
               bool isMatched = false;
-              if (ealct->isValid()) {
-                if (chamber20) {
-                  alctShowerEmulSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
-                  alctShowerEmulSummary_denom_->Fill(chamber * 2, sr, 0.5);
-                } else
-                  alctShowerEmulSummary_denom_->Fill(chamber, sr);
+              if (ealct->isValid() and ealct->isNominalInTime()) {
+                if (ealct->isTightInTime()) {
+                  if (chamber20) {
+                    alctShowerEmulTightSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
+                    alctShowerEmulTightSummary_denom_->Fill(chamber * 2, sr, 0.5);
+                  } else
+                    alctShowerEmulTightSummary_denom_->Fill(chamber, sr);
+                }
+                else {
+                  if (chamber20) {
+                    alctShowerEmulNomSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
+                    alctShowerEmulNomSummary_denom_->Fill(chamber * 2, sr, 0.5);
+                  } else
+                    alctShowerEmulNomSummary_denom_->Fill(chamber, sr);
+                }
                 // check for least one matching ALCT
                 for (auto dalct = range_dataALCT.first; dalct != range_dataALCT.second; dalct++) {
                   if (areSameShowers(*dalct, *ealct))
@@ -210,47 +319,83 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                 // only fill when it is not matched to an ALCT
                 // to understand if the emulator is producing too many ALCTs
                 if (!isMatched) {
-                  if (chamber20) {
-                    alctShowerEmulSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
-                    alctShowerEmulSummary_num_->Fill(chamber * 2, sr, 0.5);
-                  } else
-                    alctShowerEmulSummary_num_->Fill(chamber, sr);
+                  if (ealct->isTightInTime()) {
+                    if (chamber20) {
+                      alctShowerEmulTightSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
+                      alctShowerEmulTightSummary_num_->Fill(chamber * 2, sr, 0.5);
+                    } else
+                      alctShowerEmulTightSummary_num_->Fill(chamber, sr);
+                  }
+                  else {
+                    if (chamber20) {
+                      alctShowerEmulNomSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
+                      alctShowerEmulNomSummary_num_->Fill(chamber * 2, sr, 0.5);
+                    } else
+                      alctShowerEmulNomSummary_num_->Fill(chamber, sr);
+                  }
                 }
               }
-            }
+            } // End of for (auto ealct = range_emulALCT.first; ealct != range_emulALCT.second; ealct++)
 
             // CLCT analysis
             auto range_dataCLCT = dataCLCTshs->get(detid);
             auto range_emulCLCT = emulCLCTshs->get(detid);
 
             for (auto dclct = range_dataCLCT.first; dclct != range_dataCLCT.second; dclct++) {
-              if (dclct->isValid()) {
-                if (chamber20) {
-                  clctShowerDataSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
-                  clctShowerDataSummary_denom_->Fill(chamber * 2, sr, 0.5);
-                } else
-                  clctShowerDataSummary_denom_->Fill(chamber, sr);
+              if (dclct->isValid() and dclct->isNominalInTime()) {
+                if (dclct->isTightInTime()) {
+                  if (chamber20) {
+                    clctShowerDataTightSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
+                    clctShowerDataTightSummary_denom_->Fill(chamber * 2, sr, 0.5);
+                  } else
+                    clctShowerDataTightSummary_denom_->Fill(chamber, sr);
+                }
+                else {
+                  if (chamber20) {
+                    clctShowerDataNomSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
+                    clctShowerDataNomSummary_denom_->Fill(chamber * 2, sr, 0.5);
+                  } else
+                    clctShowerDataNomSummary_denom_->Fill(chamber, sr);
+                }
                 // check for least one matching CLCT
                 for (auto eclct = range_emulCLCT.first; eclct != range_emulCLCT.second; eclct++) {
                   if (eclct->isValid() and areSameShowers(*dclct, *eclct)) {
-                    if (chamber20) {
-                      clctShowerDataSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
-                      clctShowerDataSummary_num_->Fill(chamber * 2, sr, 0.5);
-                    } else
-                      clctShowerDataSummary_num_->Fill(chamber, sr);
+                    if (dclct->isTightInTime()) { 
+                      if (chamber20) {
+                        clctShowerDataTightSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
+                        clctShowerDataTightSummary_num_->Fill(chamber * 2, sr, 0.5);
+                      } else
+                        clctShowerDataTightSummary_num_->Fill(chamber, sr);
+                    }
+                    else {
+                      if (chamber20) {
+                        clctShowerDataNomSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
+                        clctShowerDataNomSummary_num_->Fill(chamber * 2, sr, 0.5);
+                      } else
+                        clctShowerDataNomSummary_num_->Fill(chamber, sr);
+                    }
                   }
                 }
               }
-            }
+            } // End of for (auto dclct = range_dataCLCT.first; dclct != range_dataCLCT.second; dclct++)
 
             for (auto eclct = range_emulCLCT.first; eclct != range_emulCLCT.second; eclct++) {
               bool isMatched = false;
-              if (eclct->isValid()) {
-                if (chamber20) {
-                  clctShowerEmulSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
-                  clctShowerEmulSummary_denom_->Fill(chamber * 2, sr, 0.5);
-                } else
-                  clctShowerEmulSummary_denom_->Fill(chamber, sr);
+              if (eclct->isValid() and eclct->isNominalInTime()) {
+                if (eclct->isTightInTime()) {
+                  if (chamber20) {
+                    clctShowerEmulTightSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
+                    clctShowerEmulTightSummary_denom_->Fill(chamber * 2, sr, 0.5);
+                  } else
+                    clctShowerEmulTightSummary_denom_->Fill(chamber, sr);
+                }
+                else {
+                  if (chamber20) {
+                    clctShowerEmulNomSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
+                    clctShowerEmulNomSummary_denom_->Fill(chamber * 2, sr, 0.5);
+                  } else
+                    clctShowerEmulNomSummary_denom_->Fill(chamber, sr);
+                }
                 // check for least one matching CLCT
                 for (auto dclct = range_dataCLCT.first; dclct != range_dataCLCT.second; dclct++) {
                   if (areSameShowers(*dclct, *eclct))
@@ -259,47 +404,83 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                 // only fill when it is not matched to an CLCT
                 // to understand if the emulator is producing too many CLCTs
                 if (!isMatched) {
-                  if (chamber20) {
-                    clctShowerEmulSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
-                    clctShowerEmulSummary_num_->Fill(chamber * 2, sr, 0.5);
-                  } else
-                    clctShowerEmulSummary_num_->Fill(chamber, sr);
+                  if (eclct->isTightInTime()) {
+                    if (chamber20) {
+                      clctShowerEmulTightSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
+                      clctShowerEmulTightSummary_num_->Fill(chamber * 2, sr, 0.5);
+                    } else
+                      clctShowerEmulTightSummary_num_->Fill(chamber, sr);
+                  }
+                  else {
+                    if (chamber20) {
+                      clctShowerEmulNomSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
+                      clctShowerEmulNomSummary_num_->Fill(chamber * 2, sr, 0.5);
+                    } else
+                      clctShowerEmulNomSummary_num_->Fill(chamber, sr);
+                  }
                 }
               }
-            }
+            } // End of for (auto eclct = range_emulCLCT.first; eclct != range_emulCLCT.second; eclct++)
 
             // LCT analysis
             auto range_dataLCT = dataLCTshs->get(detid);
             auto range_emulLCT = emulLCTshs->get(detid);
 
             for (auto dlct = range_dataLCT.first; dlct != range_dataLCT.second; dlct++) {
-              if (dlct->isValid()) {
-                if (chamber20) {
-                  lctShowerDataSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
-                  lctShowerDataSummary_denom_->Fill(chamber * 2, sr, 0.5);
-                } else
-                  lctShowerDataSummary_denom_->Fill(chamber, sr);
+              if (dlct->isValid() and dlct->isNominalInTime()) {
+                if (dlct->isTightInTime()) {
+                  if (chamber20) {
+                    lctShowerDataTightSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
+                    lctShowerDataTightSummary_denom_->Fill(chamber * 2, sr, 0.5);
+                  } else
+                    lctShowerDataTightSummary_denom_->Fill(chamber, sr);
+                }
+                else {
+                  if (chamber20) {
+                    lctShowerDataNomSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
+                    lctShowerDataNomSummary_denom_->Fill(chamber * 2, sr, 0.5);
+                  } else
+                    lctShowerDataNomSummary_denom_->Fill(chamber, sr);
+                }
                 // check for least one matching LCT
                 for (auto elct = range_emulLCT.first; elct != range_emulLCT.second; elct++) {
                   if (elct->isValid() and areSameShowers(*dlct, *elct)) {
-                    if (chamber20) {
-                      lctShowerDataSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
-                      lctShowerDataSummary_num_->Fill(chamber * 2, sr, 0.5);
-                    } else
-                      lctShowerDataSummary_num_->Fill(chamber, sr);
+                    if (dlct->isTightInTime()) {
+                      if (chamber20) {
+                        lctShowerDataTightSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
+                        lctShowerDataTightSummary_num_->Fill(chamber * 2, sr, 0.5);
+                      } else
+                        lctShowerDataTightSummary_num_->Fill(chamber, sr);
+                    }
+                    else {
+                      if (chamber20) {
+                        lctShowerDataNomSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
+                        lctShowerDataNomSummary_num_->Fill(chamber * 2, sr, 0.5);
+                      } else
+                        lctShowerDataNomSummary_num_->Fill(chamber, sr);
+                    }
                   }
                 }
               }
-            }
+            } // End of for (auto dlct = range_dataLCT.first; dlct != range_dataLCT.second; dlct++)
 
             for (auto elct = range_emulLCT.first; elct != range_emulLCT.second; elct++) {
               bool isMatched = false;
-              if (elct->isValid()) {
-                if (chamber20) {
-                  lctShowerEmulSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
-                  lctShowerEmulSummary_denom_->Fill(chamber * 2, sr, 0.5);
-                } else
-                  lctShowerEmulSummary_denom_->Fill(chamber, sr);
+              if (elct->isValid() and elct->isNominalInTime()) {
+                if (elct->isTightInTime()) {
+                  if (chamber20) {
+                    lctShowerEmulTightSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
+                    lctShowerEmulTightSummary_denom_->Fill(chamber * 2, sr, 0.5);
+                  } else
+                    lctShowerEmulTightSummary_denom_->Fill(chamber, sr);
+                }
+                else {
+                  if (chamber20) {
+                    lctShowerEmulNomSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
+                    lctShowerEmulNomSummary_denom_->Fill(chamber * 2, sr, 0.5);
+                  } else
+                    lctShowerEmulNomSummary_denom_->Fill(chamber, sr);
+                }
                 // check for least one matching LCT
                 for (auto dlct = range_dataLCT.first; dlct != range_dataLCT.second; dlct++) {
                   if (areSameShowers(*dlct, *elct))
@@ -308,14 +489,23 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                 // only fill when it is not matched to an LCT
                 // to understand if the emulator is producing too many LCTs
                 if (!isMatched) {
-                  if (chamber20) {
-                    lctShowerEmulSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
-                    lctShowerEmulSummary_num_->Fill(chamber * 2, sr, 0.5);
-                  } else
-                    lctShowerEmulSummary_num_->Fill(chamber, sr);
+                  if (elct->isTightInTime()) {
+                    if (chamber20) {
+                      lctShowerEmulTightSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
+                      lctShowerEmulTightSummary_num_->Fill(chamber * 2, sr, 0.5);
+                    } else
+                      lctShowerEmulTightSummary_num_->Fill(chamber, sr);
+                  }
+                  else {
+                    if (chamber20) {
+                      lctShowerEmulNomSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
+                      lctShowerEmulNomSummary_num_->Fill(chamber * 2, sr, 0.5);
+                    } else
+                      lctShowerEmulNomSummary_num_->Fill(chamber, sr);
+                  }
                 }
               }
-            }
+            } // End of for (auto elct = range_emulLCT.first; elct != range_emulLCT.second; elct++) {
           }
         }
       }

--- a/DQM/L1TMonitor/src/L1TdeCSCTPGShower.cc
+++ b/DQM/L1TMonitor/src/L1TdeCSCTPGShower.cc
@@ -20,55 +20,55 @@ void L1TdeCSCTPGShower::bookHistograms(DQMStore::IBooker& iBooker, const edm::Ru
   // 2D summary plots
   lctShowerDataNomSummary_denom_ =
       iBooker.book2D("lct_cscshower_data_nom_summary_denom", "Data LCT Nominal Only Shower All", 36, 1, 37, 18, 0, 18);
-  lctShowerDataNomSummary_num_ =
-      iBooker.book2D("lct_cscshower_data_nom_summary_num", "Data LCT Nominal Only Shower Emul Matched", 36, 1, 37, 18, 0, 18);
-  alctShowerDataNomSummary_denom_ =
-      iBooker.book2D("alct_cscshower_data_nom_summary_denom", "Data ALCT Nominal Only Shower All", 36, 1, 37, 18, 0, 18);
-  alctShowerDataNomSummary_num_ =
-      iBooker.book2D("alct_cscshower_data_nom_summary_num", "Data ALCT Nominal Only Shower Emul Matched", 36, 1, 37, 18, 0, 18);
-  clctShowerDataNomSummary_denom_ =
-      iBooker.book2D("clct_cscshower_data_nom_summary_denom", "Data CLCT Nominal Only Shower All", 36, 1, 37, 18, 0, 18);
-  clctShowerDataNomSummary_num_ =
-      iBooker.book2D("clct_cscshower_data_nom_summary_num", "Data CLCT Nominal Only Shower Emul Matched", 36, 1, 37, 18, 0, 18);
+  lctShowerDataNomSummary_num_ = iBooker.book2D(
+      "lct_cscshower_data_nom_summary_num", "Data LCT Nominal Only Shower Emul Matched", 36, 1, 37, 18, 0, 18);
+  alctShowerDataNomSummary_denom_ = iBooker.book2D(
+      "alct_cscshower_data_nom_summary_denom", "Data ALCT Nominal Only Shower All", 36, 1, 37, 18, 0, 18);
+  alctShowerDataNomSummary_num_ = iBooker.book2D(
+      "alct_cscshower_data_nom_summary_num", "Data ALCT Nominal Only Shower Emul Matched", 36, 1, 37, 18, 0, 18);
+  clctShowerDataNomSummary_denom_ = iBooker.book2D(
+      "clct_cscshower_data_nom_summary_denom", "Data CLCT Nominal Only Shower All", 36, 1, 37, 18, 0, 18);
+  clctShowerDataNomSummary_num_ = iBooker.book2D(
+      "clct_cscshower_data_nom_summary_num", "Data CLCT Nominal Only Shower Emul Matched", 36, 1, 37, 18, 0, 18);
 
   lctShowerEmulNomSummary_denom_ =
       iBooker.book2D("lct_cscshower_emul_nom_summary_denom", "Emul LCT Nominal Only Shower All", 36, 1, 37, 18, 0, 18);
-  lctShowerEmulNomSummary_num_ =
-      iBooker.book2D("lct_cscshower_emul_nom_summary_num", "Emul LCT Nominal Only Shower Not Matched to Data", 36, 1, 37, 18, 0, 18);
-  alctShowerEmulNomSummary_denom_ =
-      iBooker.book2D("alct_cscshower_emul_nom_summary_denom", "Emul ALCT Nominal Only Shower All", 36, 1, 37, 18, 0, 18);
-  alctShowerEmulNomSummary_num_ =
-      iBooker.book2D("alct_cscshower_emul_nom_summary_num", "Emul ALCT Nominal Only Shower Not Matched to Data", 36, 1, 37, 18, 0, 18);
-  clctShowerEmulNomSummary_denom_ =
-      iBooker.book2D("clct_cscshower_emul_nom_summary_denom", "Emul CLCT Nominal Only Shower All", 36, 1, 37, 18, 0, 18);
-  clctShowerEmulNomSummary_num_ =
-      iBooker.book2D("clct_cscshower_emul_nom_summary_num", "Emul CLCT Nominal Only Shower Not Matched to Data", 36, 1, 37, 18, 0, 18);
+  lctShowerEmulNomSummary_num_ = iBooker.book2D(
+      "lct_cscshower_emul_nom_summary_num", "Emul LCT Nominal Only Shower Not Matched to Data", 36, 1, 37, 18, 0, 18);
+  alctShowerEmulNomSummary_denom_ = iBooker.book2D(
+      "alct_cscshower_emul_nom_summary_denom", "Emul ALCT Nominal Only Shower All", 36, 1, 37, 18, 0, 18);
+  alctShowerEmulNomSummary_num_ = iBooker.book2D(
+      "alct_cscshower_emul_nom_summary_num", "Emul ALCT Nominal Only Shower Not Matched to Data", 36, 1, 37, 18, 0, 18);
+  clctShowerEmulNomSummary_denom_ = iBooker.book2D(
+      "clct_cscshower_emul_nom_summary_denom", "Emul CLCT Nominal Only Shower All", 36, 1, 37, 18, 0, 18);
+  clctShowerEmulNomSummary_num_ = iBooker.book2D(
+      "clct_cscshower_emul_nom_summary_num", "Emul CLCT Nominal Only Shower Not Matched to Data", 36, 1, 37, 18, 0, 18);
 
   lctShowerDataTightSummary_denom_ =
       iBooker.book2D("lct_cscshower_data_tight_summary_denom", "Data LCT Tight Shower All", 36, 1, 37, 18, 0, 18);
-  lctShowerDataTightSummary_num_ =
-      iBooker.book2D("lct_cscshower_data_tight_summary_num", "Data LCT Tight Shower Emul Matched", 36, 1, 37, 18, 0, 18);
+  lctShowerDataTightSummary_num_ = iBooker.book2D(
+      "lct_cscshower_data_tight_summary_num", "Data LCT Tight Shower Emul Matched", 36, 1, 37, 18, 0, 18);
   alctShowerDataTightSummary_denom_ =
       iBooker.book2D("alct_cscshower_data_tight_summary_denom", "Data ALCT Tight Shower All", 36, 1, 37, 18, 0, 18);
-  alctShowerDataTightSummary_num_ =
-      iBooker.book2D("alct_cscshower_data_tight_summary_num", "Data ALCT Tight Shower Emul Matched", 36, 1, 37, 18, 0, 18);
+  alctShowerDataTightSummary_num_ = iBooker.book2D(
+      "alct_cscshower_data_tight_summary_num", "Data ALCT Tight Shower Emul Matched", 36, 1, 37, 18, 0, 18);
   clctShowerDataTightSummary_denom_ =
       iBooker.book2D("clct_cscshower_data_tight_summary_denom", "Data CLCT Tight Shower All", 36, 1, 37, 18, 0, 18);
-  clctShowerDataTightSummary_num_ =
-      iBooker.book2D("clct_cscshower_data_tight_summary_num", "Data CLCT Tight Shower Emul Matched", 36, 1, 37, 18, 0, 18);
+  clctShowerDataTightSummary_num_ = iBooker.book2D(
+      "clct_cscshower_data_tight_summary_num", "Data CLCT Tight Shower Emul Matched", 36, 1, 37, 18, 0, 18);
 
   lctShowerEmulTightSummary_denom_ =
       iBooker.book2D("lct_cscshower_emul_tight_summary_denom", "Emul LCT Tight Shower All", 36, 1, 37, 18, 0, 18);
-  lctShowerEmulTightSummary_num_ =
-      iBooker.book2D("lct_cscshower_emul_tight_summary_num", "Emul LCT Tight Shower Not Matched to Data", 36, 1, 37, 18, 0, 18);
+  lctShowerEmulTightSummary_num_ = iBooker.book2D(
+      "lct_cscshower_emul_tight_summary_num", "Emul LCT Tight Shower Not Matched to Data", 36, 1, 37, 18, 0, 18);
   alctShowerEmulTightSummary_denom_ =
       iBooker.book2D("alct_cscshower_emul_tight_summary_denom", "Emul ALCT Tight Shower All", 36, 1, 37, 18, 0, 18);
-  alctShowerEmulTightSummary_num_ =
-      iBooker.book2D("alct_cscshower_emul_tight_summary_num", "Emul ALCT Tight Shower Not Matched to Data", 36, 1, 37, 18, 0, 18);
+  alctShowerEmulTightSummary_num_ = iBooker.book2D(
+      "alct_cscshower_emul_tight_summary_num", "Emul ALCT Tight Shower Not Matched to Data", 36, 1, 37, 18, 0, 18);
   clctShowerEmulTightSummary_denom_ =
       iBooker.book2D("clct_cscshower_emul_tight_summary_denom", "Emul CLCT Tight Shower All", 36, 1, 37, 18, 0, 18);
-  clctShowerEmulTightSummary_num_ =
-      iBooker.book2D("clct_cscshower_emul_tight_summary_num", "Emul CLCT Tight Shower Not Matched to Data", 36, 1, 37, 18, 0, 18);
+  clctShowerEmulTightSummary_num_ = iBooker.book2D(
+      "clct_cscshower_emul_tight_summary_num", "Emul CLCT Tight Shower Not Matched to Data", 36, 1, 37, 18, 0, 18);
 
   // x labels
   lctShowerDataNomSummary_denom_->setAxisTitle("Chamber", 1);
@@ -264,8 +264,7 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                     alctShowerDataTightSummary_denom_->Fill(chamber * 2, sr, 0.5);
                   } else
                     alctShowerDataTightSummary_denom_->Fill(chamber, sr);
-                }
-                else {
+                } else {
                   if (chamber20) {
                     alctShowerDataNomSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
                     alctShowerDataNomSummary_denom_->Fill(chamber * 2, sr, 0.5);
@@ -281,8 +280,7 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                         alctShowerDataTightSummary_num_->Fill(chamber * 2, sr, 0.5);
                       } else
                         alctShowerDataTightSummary_num_->Fill(chamber, sr);
-                    }
-                    else {
+                    } else {
                       if (chamber20) {
                         alctShowerDataNomSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
                         alctShowerDataNomSummary_num_->Fill(chamber * 2, sr, 0.5);
@@ -292,7 +290,7 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                   }
                 }
               }
-            } // End of for (auto dalct = range_dataALCT.first; dalct != range_dataALCT.second; dalct++)
+            }  // End of for (auto dalct = range_dataALCT.first; dalct != range_dataALCT.second; dalct++)
 
             for (auto ealct = range_emulALCT.first; ealct != range_emulALCT.second; ealct++) {
               bool isMatched = false;
@@ -303,8 +301,7 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                     alctShowerEmulTightSummary_denom_->Fill(chamber * 2, sr, 0.5);
                   } else
                     alctShowerEmulTightSummary_denom_->Fill(chamber, sr);
-                }
-                else {
+                } else {
                   if (chamber20) {
                     alctShowerEmulNomSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
                     alctShowerEmulNomSummary_denom_->Fill(chamber * 2, sr, 0.5);
@@ -325,8 +322,7 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                       alctShowerEmulTightSummary_num_->Fill(chamber * 2, sr, 0.5);
                     } else
                       alctShowerEmulTightSummary_num_->Fill(chamber, sr);
-                  }
-                  else {
+                  } else {
                     if (chamber20) {
                       alctShowerEmulNomSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
                       alctShowerEmulNomSummary_num_->Fill(chamber * 2, sr, 0.5);
@@ -335,7 +331,7 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                   }
                 }
               }
-            } // End of for (auto ealct = range_emulALCT.first; ealct != range_emulALCT.second; ealct++)
+            }  // End of for (auto ealct = range_emulALCT.first; ealct != range_emulALCT.second; ealct++)
 
             // CLCT analysis
             auto range_dataCLCT = dataCLCTshs->get(detid);
@@ -349,8 +345,7 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                     clctShowerDataTightSummary_denom_->Fill(chamber * 2, sr, 0.5);
                   } else
                     clctShowerDataTightSummary_denom_->Fill(chamber, sr);
-                }
-                else {
+                } else {
                   if (chamber20) {
                     clctShowerDataNomSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
                     clctShowerDataNomSummary_denom_->Fill(chamber * 2, sr, 0.5);
@@ -360,14 +355,13 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                 // check for least one matching CLCT
                 for (auto eclct = range_emulCLCT.first; eclct != range_emulCLCT.second; eclct++) {
                   if (eclct->isValid() and areSameShowers(*dclct, *eclct)) {
-                    if (dclct->isTightInTime()) { 
+                    if (dclct->isTightInTime()) {
                       if (chamber20) {
                         clctShowerDataTightSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
                         clctShowerDataTightSummary_num_->Fill(chamber * 2, sr, 0.5);
                       } else
                         clctShowerDataTightSummary_num_->Fill(chamber, sr);
-                    }
-                    else {
+                    } else {
                       if (chamber20) {
                         clctShowerDataNomSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
                         clctShowerDataNomSummary_num_->Fill(chamber * 2, sr, 0.5);
@@ -377,7 +371,7 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                   }
                 }
               }
-            } // End of for (auto dclct = range_dataCLCT.first; dclct != range_dataCLCT.second; dclct++)
+            }  // End of for (auto dclct = range_dataCLCT.first; dclct != range_dataCLCT.second; dclct++)
 
             for (auto eclct = range_emulCLCT.first; eclct != range_emulCLCT.second; eclct++) {
               bool isMatched = false;
@@ -388,8 +382,7 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                     clctShowerEmulTightSummary_denom_->Fill(chamber * 2, sr, 0.5);
                   } else
                     clctShowerEmulTightSummary_denom_->Fill(chamber, sr);
-                }
-                else {
+                } else {
                   if (chamber20) {
                     clctShowerEmulNomSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
                     clctShowerEmulNomSummary_denom_->Fill(chamber * 2, sr, 0.5);
@@ -410,8 +403,7 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                       clctShowerEmulTightSummary_num_->Fill(chamber * 2, sr, 0.5);
                     } else
                       clctShowerEmulTightSummary_num_->Fill(chamber, sr);
-                  }
-                  else {
+                  } else {
                     if (chamber20) {
                       clctShowerEmulNomSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
                       clctShowerEmulNomSummary_num_->Fill(chamber * 2, sr, 0.5);
@@ -420,7 +412,7 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                   }
                 }
               }
-            } // End of for (auto eclct = range_emulCLCT.first; eclct != range_emulCLCT.second; eclct++)
+            }  // End of for (auto eclct = range_emulCLCT.first; eclct != range_emulCLCT.second; eclct++)
 
             // LCT analysis
             auto range_dataLCT = dataLCTshs->get(detid);
@@ -434,8 +426,7 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                     lctShowerDataTightSummary_denom_->Fill(chamber * 2, sr, 0.5);
                   } else
                     lctShowerDataTightSummary_denom_->Fill(chamber, sr);
-                }
-                else {
+                } else {
                   if (chamber20) {
                     lctShowerDataNomSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
                     lctShowerDataNomSummary_denom_->Fill(chamber * 2, sr, 0.5);
@@ -451,8 +442,7 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                         lctShowerDataTightSummary_num_->Fill(chamber * 2, sr, 0.5);
                       } else
                         lctShowerDataTightSummary_num_->Fill(chamber, sr);
-                    }
-                    else {
+                    } else {
                       if (chamber20) {
                         lctShowerDataNomSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
                         lctShowerDataNomSummary_num_->Fill(chamber * 2, sr, 0.5);
@@ -462,7 +452,7 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                   }
                 }
               }
-            } // End of for (auto dlct = range_dataLCT.first; dlct != range_dataLCT.second; dlct++)
+            }  // End of for (auto dlct = range_dataLCT.first; dlct != range_dataLCT.second; dlct++)
 
             for (auto elct = range_emulLCT.first; elct != range_emulLCT.second; elct++) {
               bool isMatched = false;
@@ -473,8 +463,7 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                     lctShowerEmulTightSummary_denom_->Fill(chamber * 2, sr, 0.5);
                   } else
                     lctShowerEmulTightSummary_denom_->Fill(chamber, sr);
-                }
-                else {
+                } else {
                   if (chamber20) {
                     lctShowerEmulNomSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
                     lctShowerEmulNomSummary_denom_->Fill(chamber * 2, sr, 0.5);
@@ -495,8 +484,7 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                       lctShowerEmulTightSummary_num_->Fill(chamber * 2, sr, 0.5);
                     } else
                       lctShowerEmulTightSummary_num_->Fill(chamber, sr);
-                  }
-                  else {
+                  } else {
                     if (chamber20) {
                       lctShowerEmulNomSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
                       lctShowerEmulNomSummary_num_->Fill(chamber * 2, sr, 0.5);
@@ -505,7 +493,7 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                   }
                 }
               }
-            } // End of for (auto elct = range_emulLCT.first; elct != range_emulLCT.second; elct++) {
+            }  // End of for (auto elct = range_emulLCT.first; elct != range_emulLCT.second; elct++) {
           }
         }
       }

--- a/DQM/L1TMonitor/src/L1TdeStage2RegionalShower.cc
+++ b/DQM/L1TMonitor/src/L1TdeStage2RegionalShower.cc
@@ -1,17 +1,17 @@
 #include <string>
 
-#include "DQM/L1TMonitor/interface/L1TdeStage2Shower.h"
+#include "DQM/L1TMonitor/interface/L1TdeStage2RegionalShower.h"
 
-L1TdeStage2Shower::L1TdeStage2Shower(const edm::ParameterSet& ps)
+L1TdeStage2RegionalShower::L1TdeStage2RegionalShower(const edm::ParameterSet& ps)
     : data_EMTFShower_token_(
           consumes<l1t::RegionalMuonShowerBxCollection>(ps.getParameter<edm::InputTag>("dataSource"))),
       emul_EMTFShower_token_(
           consumes<l1t::RegionalMuonShowerBxCollection>(ps.getParameter<edm::InputTag>("emulSource"))),
       monitorDir_(ps.getUntrackedParameter<std::string>("monitorDir")) {}
 
-L1TdeStage2Shower::~L1TdeStage2Shower() {}
+L1TdeStage2RegionalShower::~L1TdeStage2RegionalShower() {}
 
-void L1TdeStage2Shower::bookHistograms(DQMStore::IBooker& iBooker, const edm::Run&, const edm::EventSetup&) {
+void L1TdeStage2RegionalShower::bookHistograms(DQMStore::IBooker& iBooker, const edm::Run&, const edm::EventSetup&) {
   iBooker.setCurrentFolder(monitorDir_);
 
   // 2D summary plots
@@ -56,7 +56,7 @@ void L1TdeStage2Shower::bookHistograms(DQMStore::IBooker& iBooker, const edm::Ru
   emtfShowerEmulSummary_num_->setBinLabel(4, "ME+ Tight", 2);
 }
 
-void L1TdeStage2Shower::analyze(const edm::Event& e, const edm::EventSetup& c) {
+void L1TdeStage2RegionalShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
   edm::Handle<l1t::RegionalMuonShowerBxCollection> dataShowers;
   edm::Handle<l1t::RegionalMuonShowerBxCollection> emulShowers;
 

--- a/DQM/L1TMonitor/src/L1TdeStage2Shower.cc
+++ b/DQM/L1TMonitor/src/L1TdeStage2Shower.cc
@@ -16,13 +16,13 @@ void L1TdeStage2Shower::bookHistograms(DQMStore::IBooker& iBooker, const edm::Ru
 
   // 2D summary plots
   emtfShowerDataSummary_denom_ =
-      iBooker.book2D("emtf_shower_data_summary_denom", "Data EMTF Shower All", 6, 1, 7, 2, 0, 2);
+      iBooker.book2D("emtf_shower_data_summary_denom", "Data EMTF Shower All", 6, 1, 7, 4, 0, 4);
   emtfShowerDataSummary_num_ =
-      iBooker.book2D("emtf_shower_data_summary_num", "Data EMTF Shower Emul Matched", 6, 1, 7, 2, 0, 2);
+      iBooker.book2D("emtf_shower_data_summary_num", "Data EMTF Shower Emul Matched", 6, 1, 7, 4, 0, 4);
   emtfShowerEmulSummary_denom_ =
-      iBooker.book2D("emtf_shower_emul_summary_denom", "Emul EMTF Shower All", 6, 1, 7, 2, 0, 2);
+      iBooker.book2D("emtf_shower_emul_summary_denom", "Emul EMTF Shower All", 6, 1, 7, 4, 0, 4);
   emtfShowerEmulSummary_num_ =
-      iBooker.book2D("emtf_shower_emul_summary_num", "Emul EMTF Shower Not Matched to Data", 6, 1, 7, 2, 0, 2);
+      iBooker.book2D("emtf_shower_emul_summary_num", "Emul EMTF Shower Not Matched to Data", 6, 1, 7, 4, 0, 4);
 
   // x labels
   emtfShowerDataSummary_denom_->setAxisTitle("Sector", 1);
@@ -37,15 +37,23 @@ void L1TdeStage2Shower::bookHistograms(DQMStore::IBooker& iBooker, const edm::Ru
   emtfShowerEmulSummary_num_->setOption("colz");
 
   // y labels
-  emtfShowerDataSummary_denom_->setBinLabel(1, "ME-", 2);
-  emtfShowerDataSummary_num_->setBinLabel(1, "ME-", 2);
-  emtfShowerEmulSummary_denom_->setBinLabel(1, "ME-", 2);
-  emtfShowerEmulSummary_num_->setBinLabel(1, "ME-", 2);
+  emtfShowerDataSummary_denom_->setBinLabel(1, "ME- Tight", 2);
+  emtfShowerDataSummary_num_->setBinLabel(1, "ME- Tight", 2);
+  emtfShowerEmulSummary_denom_->setBinLabel(1, "ME- Tight", 2);
+  emtfShowerEmulSummary_num_->setBinLabel(1, "ME- Tight", 2);
+  emtfShowerDataSummary_denom_->setBinLabel(2, "ME- Nom", 2);
+  emtfShowerDataSummary_num_->setBinLabel(2, "ME- Nom", 2);
+  emtfShowerEmulSummary_denom_->setBinLabel(2, "ME- Nom", 2);
+  emtfShowerEmulSummary_num_->setBinLabel(2, "ME- Nom", 2);
 
-  emtfShowerDataSummary_denom_->setBinLabel(2, "ME+", 2);
-  emtfShowerDataSummary_num_->setBinLabel(2, "ME+", 2);
-  emtfShowerEmulSummary_denom_->setBinLabel(2, "ME+", 2);
-  emtfShowerEmulSummary_num_->setBinLabel(2, "ME+", 2);
+  emtfShowerDataSummary_denom_->setBinLabel(3, "ME+ Nom", 2);
+  emtfShowerDataSummary_num_->setBinLabel(3, "ME+ Nom", 2);
+  emtfShowerEmulSummary_denom_->setBinLabel(3, "ME+ Nom", 2);
+  emtfShowerEmulSummary_num_->setBinLabel(3, "ME+ Nom", 2);
+  emtfShowerDataSummary_denom_->setBinLabel(4, "ME+ Tight", 2);
+  emtfShowerDataSummary_num_->setBinLabel(4, "ME+ Tight", 2);
+  emtfShowerEmulSummary_denom_->setBinLabel(4, "ME+ Tight", 2);
+  emtfShowerEmulSummary_num_->setBinLabel(4, "ME+ Tight", 2);
 }
 
 void L1TdeStage2Shower::analyze(const edm::Event& e, const edm::EventSetup& c) {
@@ -56,31 +64,40 @@ void L1TdeStage2Shower::analyze(const edm::Event& e, const edm::EventSetup& c) {
   e.getByToken(emul_EMTFShower_token_, emulShowers);
 
   for (auto dSh = dataShowers->begin(); dSh != dataShowers->end(); ++dSh) {
-    if (dSh->isValid()) {
-      emtfShowerDataSummary_denom_->Fill(dSh->processor() + 1,
-                                         (dSh->trackFinderType() == l1t::tftype::emtf_pos) ? 1.5 : 0.5);
+    if (dSh->isValid() and dSh->isOneNominalInTime()) {
+      if (dSh->isOneTightInTime()) 
+        emtfShowerDataSummary_denom_->Fill(dSh->processor() + 1, (dSh->trackFinderType() == l1t::tftype::emtf_pos) ? 3.5 : 0.5);
+      else 
+        emtfShowerDataSummary_denom_->Fill(dSh->processor() + 1, (dSh->trackFinderType() == l1t::tftype::emtf_pos) ? 2.5 : 1.5);
       for (auto eSh = emulShowers->begin(); eSh != emulShowers->end(); ++eSh) {
-        if (eSh->isValid() and dSh->processor() == eSh->processor() and
-            dSh->trackFinderType() == eSh->trackFinderType() and *dSh == *eSh)
-          emtfShowerDataSummary_num_->Fill(dSh->processor() + 1,
-                                           (dSh->trackFinderType() == l1t::tftype::emtf_pos) ? 1.5 : 0.5);
+        if (eSh->isValid() and eSh->isOneNominalInTime() and dSh->processor() == eSh->processor() and
+            dSh->trackFinderType() == eSh->trackFinderType() and *dSh == *eSh) {
+          if (dSh->isOneTightInTime())
+            emtfShowerDataSummary_num_->Fill(dSh->processor() + 1, (dSh->trackFinderType() == l1t::tftype::emtf_pos) ? 3.5 : 0.5);
+          else
+            emtfShowerDataSummary_num_->Fill(dSh->processor() + 1, (dSh->trackFinderType() == l1t::tftype::emtf_pos) ? 2.5 : 1.5);
+        }
       }
     }
   }
 
   for (auto eSh = emulShowers->begin(); eSh != emulShowers->end(); ++eSh) {
     bool isMatched = false;
-    if (eSh->isValid()) {
-      emtfShowerEmulSummary_denom_->Fill(eSh->processor() + 1,
-                                         (eSh->trackFinderType() == l1t::tftype::emtf_pos) ? 1.5 : 0.5);
+    if (eSh->isValid() and eSh->isOneNominalInTime()) {
+      if (eSh->isOneTightInTime())
+        emtfShowerEmulSummary_denom_->Fill(eSh->processor() + 1, (eSh->trackFinderType() == l1t::tftype::emtf_pos) ? 3.5 : 0.5);
+      else
+        emtfShowerEmulSummary_denom_->Fill(eSh->processor() + 1, (eSh->trackFinderType() == l1t::tftype::emtf_pos) ? 2.5 : 1.5);
       for (auto dSh = dataShowers->begin(); dSh != dataShowers->end(); ++dSh) {
-        if (dSh->isValid() and eSh->processor() == dSh->processor() and
+        if (dSh->isValid() and dSh->isOneNominalInTime() and eSh->processor() == dSh->processor() and
             eSh->trackFinderType() == dSh->trackFinderType() and *dSh == *eSh)
           isMatched = true;
       }
       if (not isMatched) {
-        emtfShowerEmulSummary_num_->Fill(eSh->processor() + 1,
-                                         (eSh->trackFinderType() == l1t::tftype::emtf_pos) ? 1.5 : 0.5);
+        if (eSh->isOneTightInTime())
+          emtfShowerEmulSummary_num_->Fill(eSh->processor() + 1, (eSh->trackFinderType() == l1t::tftype::emtf_pos) ? 3.5 : 0.5);
+        else
+          emtfShowerEmulSummary_num_->Fill(eSh->processor() + 1, (eSh->trackFinderType() == l1t::tftype::emtf_pos) ? 2.5 : 1.5);
       }
     }
   }

--- a/DQM/L1TMonitor/src/L1TdeStage2Shower.cc
+++ b/DQM/L1TMonitor/src/L1TdeStage2Shower.cc
@@ -65,17 +65,21 @@ void L1TdeStage2Shower::analyze(const edm::Event& e, const edm::EventSetup& c) {
 
   for (auto dSh = dataShowers->begin(); dSh != dataShowers->end(); ++dSh) {
     if (dSh->isValid() and dSh->isOneNominalInTime()) {
-      if (dSh->isOneTightInTime()) 
-        emtfShowerDataSummary_denom_->Fill(dSh->processor() + 1, (dSh->trackFinderType() == l1t::tftype::emtf_pos) ? 3.5 : 0.5);
-      else 
-        emtfShowerDataSummary_denom_->Fill(dSh->processor() + 1, (dSh->trackFinderType() == l1t::tftype::emtf_pos) ? 2.5 : 1.5);
+      if (dSh->isOneTightInTime())
+        emtfShowerDataSummary_denom_->Fill(dSh->processor() + 1,
+                                           (dSh->trackFinderType() == l1t::tftype::emtf_pos) ? 3.5 : 0.5);
+      else
+        emtfShowerDataSummary_denom_->Fill(dSh->processor() + 1,
+                                           (dSh->trackFinderType() == l1t::tftype::emtf_pos) ? 2.5 : 1.5);
       for (auto eSh = emulShowers->begin(); eSh != emulShowers->end(); ++eSh) {
         if (eSh->isValid() and eSh->isOneNominalInTime() and dSh->processor() == eSh->processor() and
             dSh->trackFinderType() == eSh->trackFinderType() and *dSh == *eSh) {
           if (dSh->isOneTightInTime())
-            emtfShowerDataSummary_num_->Fill(dSh->processor() + 1, (dSh->trackFinderType() == l1t::tftype::emtf_pos) ? 3.5 : 0.5);
+            emtfShowerDataSummary_num_->Fill(dSh->processor() + 1,
+                                             (dSh->trackFinderType() == l1t::tftype::emtf_pos) ? 3.5 : 0.5);
           else
-            emtfShowerDataSummary_num_->Fill(dSh->processor() + 1, (dSh->trackFinderType() == l1t::tftype::emtf_pos) ? 2.5 : 1.5);
+            emtfShowerDataSummary_num_->Fill(dSh->processor() + 1,
+                                             (dSh->trackFinderType() == l1t::tftype::emtf_pos) ? 2.5 : 1.5);
         }
       }
     }
@@ -85,9 +89,11 @@ void L1TdeStage2Shower::analyze(const edm::Event& e, const edm::EventSetup& c) {
     bool isMatched = false;
     if (eSh->isValid() and eSh->isOneNominalInTime()) {
       if (eSh->isOneTightInTime())
-        emtfShowerEmulSummary_denom_->Fill(eSh->processor() + 1, (eSh->trackFinderType() == l1t::tftype::emtf_pos) ? 3.5 : 0.5);
+        emtfShowerEmulSummary_denom_->Fill(eSh->processor() + 1,
+                                           (eSh->trackFinderType() == l1t::tftype::emtf_pos) ? 3.5 : 0.5);
       else
-        emtfShowerEmulSummary_denom_->Fill(eSh->processor() + 1, (eSh->trackFinderType() == l1t::tftype::emtf_pos) ? 2.5 : 1.5);
+        emtfShowerEmulSummary_denom_->Fill(eSh->processor() + 1,
+                                           (eSh->trackFinderType() == l1t::tftype::emtf_pos) ? 2.5 : 1.5);
       for (auto dSh = dataShowers->begin(); dSh != dataShowers->end(); ++dSh) {
         if (dSh->isValid() and dSh->isOneNominalInTime() and eSh->processor() == dSh->processor() and
             eSh->trackFinderType() == dSh->trackFinderType() and *dSh == *eSh)
@@ -95,9 +101,11 @@ void L1TdeStage2Shower::analyze(const edm::Event& e, const edm::EventSetup& c) {
       }
       if (not isMatched) {
         if (eSh->isOneTightInTime())
-          emtfShowerEmulSummary_num_->Fill(eSh->processor() + 1, (eSh->trackFinderType() == l1t::tftype::emtf_pos) ? 3.5 : 0.5);
+          emtfShowerEmulSummary_num_->Fill(eSh->processor() + 1,
+                                           (eSh->trackFinderType() == l1t::tftype::emtf_pos) ? 3.5 : 0.5);
         else
-          emtfShowerEmulSummary_num_->Fill(eSh->processor() + 1, (eSh->trackFinderType() == l1t::tftype::emtf_pos) ? 2.5 : 1.5);
+          emtfShowerEmulSummary_num_->Fill(eSh->processor() + 1,
+                                           (eSh->trackFinderType() == l1t::tftype::emtf_pos) ? 2.5 : 1.5);
       }
     }
   }

--- a/DQM/L1TMonitorClient/interface/L1TdeCSCTPGShowerClient.h
+++ b/DQM/L1TMonitorClient/interface/L1TdeCSCTPGShowerClient.h
@@ -31,12 +31,19 @@ private:
 
   std::string monitorDir_;
 
-  MonitorElement *lctShowerDataSummary_eff_;
-  MonitorElement *alctShowerDataSummary_eff_;
-  MonitorElement *clctShowerDataSummary_eff_;
-  MonitorElement *lctShowerEmulSummary_eff_;
-  MonitorElement *alctShowerEmulSummary_eff_;
-  MonitorElement *clctShowerEmulSummary_eff_;
+  MonitorElement *lctShowerDataNomSummary_eff_;
+  MonitorElement *alctShowerDataNomSummary_eff_;
+  MonitorElement *clctShowerDataNomSummary_eff_;
+  MonitorElement *lctShowerEmulNomSummary_eff_;
+  MonitorElement *alctShowerEmulNomSummary_eff_;
+  MonitorElement *clctShowerEmulNomSummary_eff_;
+
+  MonitorElement *lctShowerDataTightSummary_eff_;
+  MonitorElement *alctShowerDataTightSummary_eff_;
+  MonitorElement *clctShowerDataTightSummary_eff_;
+  MonitorElement *lctShowerEmulTightSummary_eff_;
+  MonitorElement *alctShowerEmulTightSummary_eff_;
+  MonitorElement *clctShowerEmulTightSummary_eff_;
 };
 
 #endif

--- a/DQM/L1TMonitorClient/interface/L1TdeStage2RegionalShowerClient.h
+++ b/DQM/L1TMonitorClient/interface/L1TdeStage2RegionalShowerClient.h
@@ -1,5 +1,5 @@
-#ifndef DQM_L1TMONITORCLIENT_L1TdeStage2ShowerCLIENT_H
-#define DQM_L1TMONITORCLIENT_L1TdeStage2ShowerCLIENT_H
+#ifndef DQM_L1TMONITORCLIENT_L1TdeStage2RegionalShowerCLIENT_H
+#define DQM_L1TMONITORCLIENT_L1TdeStage2RegionalShowerCLIENT_H
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -10,13 +10,13 @@
 
 #include <string>
 
-class L1TdeStage2ShowerClient : public DQMEDHarvester {
+class L1TdeStage2RegionalShowerClient : public DQMEDHarvester {
 public:
   /// Constructor
-  L1TdeStage2ShowerClient(const edm::ParameterSet &ps);
+  L1TdeStage2RegionalShowerClient(const edm::ParameterSet &ps);
 
   /// Destructor
-  ~L1TdeStage2ShowerClient() override;
+  ~L1TdeStage2RegionalShowerClient() override;
 
 protected:
   void dqmEndLuminosityBlock(DQMStore::IBooker &,

--- a/DQM/L1TMonitorClient/python/L1TStage2EMTFEmulatorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EMTFEmulatorClient_cff.py
@@ -14,7 +14,7 @@ l1tStage2EMTFEmulatorCompRatioClient = DQMEDHarvester("L1TStage2RatioClient",
     ignoreBin = cms.untracked.vint32(ignoreBinsDeStage2Emtf)
 )
 
-from DQM.L1TMonitorClient.L1TdeStage2ShowerClient_cfi import *
+from DQM.L1TMonitorClient.L1TdeStage2RegionalShowerClient_cfi import *
 
 # sequences
 l1tStage2EMTFEmulatorClient = cms.Sequence(
@@ -23,4 +23,4 @@ l1tStage2EMTFEmulatorClient = cms.Sequence(
 
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 _run3shower_l1tStage2EMTFEmulatorClient = l1tStage2EMTFEmulatorClient.copy()
-run3_GEM.toReplaceWith(l1tStage2EMTFEmulatorClient, cms.Sequence(_run3shower_l1tStage2EMTFEmulatorClient + l1tdeStage2ShowerClient))
+run3_GEM.toReplaceWith(l1tStage2EMTFEmulatorClient, cms.Sequence(_run3shower_l1tStage2EMTFEmulatorClient + l1tdeStage2RegionalShowerClient))

--- a/DQM/L1TMonitorClient/python/L1TStage2EMTFEmulatorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EMTFEmulatorClient_cff.py
@@ -21,6 +21,6 @@ l1tStage2EMTFEmulatorClient = cms.Sequence(
     l1tStage2EMTFEmulatorCompRatioClient
 )
 
-from Configuration.Eras.Modifier_run3_common_cff import run3_common
+from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 _run3shower_l1tStage2EMTFEmulatorClient = l1tStage2EMTFEmulatorClient.copy()
-run3_common.toReplaceWith(l1tStage2EMTFEmulatorClient, cms.Sequence(_run3shower_l1tStage2EMTFEmulatorClient + l1tdeStage2ShowerClient))
+run3_GEM.toReplaceWith(l1tStage2EMTFEmulatorClient, cms.Sequence(_run3shower_l1tStage2EMTFEmulatorClient + l1tdeStage2ShowerClient))

--- a/DQM/L1TMonitorClient/python/L1TStage2EmulatorMonitorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EmulatorMonitorClient_cff.py
@@ -70,9 +70,8 @@ _run3_l1TStage2EmulatorClients += l1tdeGEMTPGClient
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toReplaceWith( l1TStage2EmulatorClients, _run3_l1TStage2EmulatorClients )
 
-from Configuration.Eras.Modifier_run3_common_cff import run3_common
 _run3shower_l1TStage2EmulatorClients = l1TStage2EmulatorClients.copy()
-run3_common.toReplaceWith(l1TStage2EmulatorClients, cms.Sequence(_run3shower_l1TStage2EmulatorClients + l1tdeCSCTPGShowerClient))
+run3_GEM.toReplaceWith(l1TStage2EmulatorClients, cms.Sequence(_run3shower_l1TStage2EmulatorClients + l1tdeCSCTPGShowerClient))
 
 l1tStage2EmulatorMonitorClient = cms.Sequence(
     l1TStage2EmulatorQualityTests +

--- a/DQM/L1TMonitorClient/python/L1TdeStage2RegionalShowerClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TdeStage2RegionalShowerClient_cfi.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
-l1tdeStage2ShowerClient = DQMEDHarvester(
-    "L1TdeStage2ShowerClient",
+l1tdeStage2RegionalShowerClient = DQMEDHarvester(
+    "L1TdeStage2RegionalShowerClient",
     monitorDir = cms.untracked.string("L1TEMU/L1TdeStage2EMTF/Shower"),
 )
 

--- a/DQM/L1TMonitorClient/src/L1TdeCSCTPGShowerClient.cc
+++ b/DQM/L1TMonitorClient/src/L1TdeCSCTPGShowerClient.cc
@@ -32,121 +32,181 @@ void L1TdeCSCTPGShowerClient::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IG
 void L1TdeCSCTPGShowerClient::book(DQMStore::IBooker &iBooker) {
   iBooker.setCurrentFolder(monitorDir_);
 
-  lctShowerDataSummary_eff_ = iBooker.book2D(
-      "lct_cscshower_data_summary_eff", "Efficiency of data LCT shower being correctly emulated", 36, 1, 37, 18, 0, 18);
-  alctShowerDataSummary_eff_ = iBooker.book2D("alct_cscshower_data_summary_eff",
-                                              "Efficiency of data ALCT shower being correctly emulated",
-                                              36,
-                                              1,
-                                              37,
-                                              18,
-                                              0,
-                                              18);
-  clctShowerDataSummary_eff_ = iBooker.book2D("clct_cscshower_data_summary_eff",
-                                              "Efficiency of data CLCT shower being correctly emulated",
-                                              36,
-                                              1,
-                                              37,
-                                              18,
-                                              0,
-                                              18);
+  lctShowerDataNomSummary_eff_ = iBooker.book2D(
+      "lct_cscshower_data_nom_summary_eff", "Efficiency of data LCT Nominal shower being correctly emulated", 
+      36, 1, 37, 18, 0, 18);
+  alctShowerDataNomSummary_eff_ = iBooker.book2D(
+      "alct_cscshower_data_nom_summary_eff", "Efficiency of data ALCT Nominal shower being correctly emulated", 
+      36, 1, 37, 18, 0, 18);
+  clctShowerDataNomSummary_eff_ = iBooker.book2D(
+      "clct_cscshower_data_nom_summary_eff", "Efficiency of data CLCT Nominal shower being correctly emulated",
+      36, 1, 37, 18, 0, 18);
 
-  lctShowerEmulSummary_eff_ = iBooker.book2D("lct_cscshower_emul_summary_eff",
-                                             "Fraction of emulated LCT shower without matching data LCT",
-                                             36,
-                                             1,
-                                             37,
-                                             18,
-                                             0,
-                                             18);
-  alctShowerEmulSummary_eff_ = iBooker.book2D("alct_cscshower_emul_summary_eff",
-                                              "Fraction of emulated ALCT shower without matching data ALCT",
-                                              36,
-                                              1,
-                                              37,
-                                              18,
-                                              0,
-                                              18);
-  clctShowerEmulSummary_eff_ = iBooker.book2D("clct_cscshower_emul_summary_eff",
-                                              "Fraction of emulated CLCT shower without matching data CLCT",
-                                              36,
-                                              1,
-                                              37,
-                                              18,
-                                              0,
-                                              18);
+  lctShowerEmulNomSummary_eff_ = iBooker.book2D(
+      "lct_cscshower_emul_nom_summary_eff", "Fraction of emulated LCT Nominal shower without matching data LCT",
+      36, 1, 37, 18, 0, 18);
+  alctShowerEmulNomSummary_eff_ = iBooker.book2D(
+      "alct_cscshower_emul_nom_summary_eff", "Fraction of emulated ALCT Nominal shower without matching data ALCT",
+      36, 1, 37, 18, 0, 18);
+  clctShowerEmulNomSummary_eff_ = iBooker.book2D(
+      "clct_cscshower_emul_nom_summary_eff", "Fraction of emulated CLCT Nominal shower without matching data CLCT",
+      36, 1, 37, 18, 0, 18);
+
+  lctShowerDataTightSummary_eff_ = iBooker.book2D(
+      "lct_cscshower_data_tight_summary_eff", "Efficiency of data LCT Tight shower being correctly emulated", 
+      36, 1, 37, 18, 0, 18);
+  alctShowerDataTightSummary_eff_ = iBooker.book2D(
+      "alct_cscshower_data_tight_summary_eff", "Efficiency of data ALCT Tight shower being correctly emulated", 
+      36, 1, 37, 18, 0, 18);
+  clctShowerDataTightSummary_eff_ = iBooker.book2D(
+      "clct_cscshower_data_tight_summary_eff", "Efficiency of data CLCT Tight shower being correctly emulated",
+      36, 1, 37, 18, 0, 18);
+
+  lctShowerEmulTightSummary_eff_ = iBooker.book2D(
+      "lct_cscshower_emul_tight_summary_eff", "Fraction of emulated LCT Tight shower without matching data LCT",
+      36, 1, 37, 18, 0, 18);
+  alctShowerEmulTightSummary_eff_ = iBooker.book2D(
+      "alct_cscshower_emul_tight_summary_eff", "Fraction of emulated ALCT Tight shower without matching data ALCT",
+      36, 1, 37, 18, 0, 18);
+  clctShowerEmulTightSummary_eff_ = iBooker.book2D(
+      "clct_cscshower_emul_tight_summary_eff", "Fraction of emulated CLCT Tight shower without matching data CLCT",
+      36, 1, 37, 18, 0, 18);
 
   // x labels
-  lctShowerDataSummary_eff_->setAxisTitle("Chamber", 1);
-  alctShowerDataSummary_eff_->setAxisTitle("Chamber", 1);
-  clctShowerDataSummary_eff_->setAxisTitle("Chamber", 1);
+  lctShowerDataNomSummary_eff_->setAxisTitle("Chamber", 1);
+  alctShowerDataNomSummary_eff_->setAxisTitle("Chamber", 1);
+  clctShowerDataNomSummary_eff_->setAxisTitle("Chamber", 1);
 
-  lctShowerEmulSummary_eff_->setAxisTitle("Chamber", 1);
-  alctShowerEmulSummary_eff_->setAxisTitle("Chamber", 1);
-  clctShowerEmulSummary_eff_->setAxisTitle("Chamber", 1);
+  lctShowerEmulNomSummary_eff_->setAxisTitle("Chamber", 1);
+  alctShowerEmulNomSummary_eff_->setAxisTitle("Chamber", 1);
+  clctShowerEmulNomSummary_eff_->setAxisTitle("Chamber", 1);
+
+  lctShowerDataTightSummary_eff_->setAxisTitle("Chamber", 1);
+  alctShowerDataTightSummary_eff_->setAxisTitle("Chamber", 1);
+  clctShowerDataTightSummary_eff_->setAxisTitle("Chamber", 1);
+
+  lctShowerEmulTightSummary_eff_->setAxisTitle("Chamber", 1);
+  alctShowerEmulTightSummary_eff_->setAxisTitle("Chamber", 1);
+  clctShowerEmulTightSummary_eff_->setAxisTitle("Chamber", 1);
 
   // plotting option
-  lctShowerDataSummary_eff_->setOption("colz");
-  alctShowerDataSummary_eff_->setOption("colz");
-  clctShowerDataSummary_eff_->setOption("colz");
+  lctShowerDataNomSummary_eff_->setOption("colz");
+  alctShowerDataNomSummary_eff_->setOption("colz");
+  clctShowerDataNomSummary_eff_->setOption("colz");
 
-  lctShowerEmulSummary_eff_->setOption("colz");
-  alctShowerEmulSummary_eff_->setOption("colz");
-  clctShowerEmulSummary_eff_->setOption("colz");
+  lctShowerEmulNomSummary_eff_->setOption("colz");
+  alctShowerEmulNomSummary_eff_->setOption("colz");
+  clctShowerEmulNomSummary_eff_->setOption("colz");
+
+  lctShowerDataTightSummary_eff_->setOption("colz");
+  alctShowerDataTightSummary_eff_->setOption("colz");
+  clctShowerDataTightSummary_eff_->setOption("colz");
+
+  lctShowerEmulTightSummary_eff_->setOption("colz");
+  alctShowerEmulTightSummary_eff_->setOption("colz");
+  clctShowerEmulTightSummary_eff_->setOption("colz");
 
   // summary plots
   const std::array<std::string, 9> suffix_label{{"4/2", "4/1", "3/2", "3/1", " 2/2", "2/1", "1/3", "1/2", "1/1"}};
 
   // y labels
   for (int ybin = 1; ybin <= 9; ++ybin) {
-    lctShowerDataSummary_eff_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
-    alctShowerDataSummary_eff_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
-    clctShowerDataSummary_eff_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    lctShowerDataNomSummary_eff_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    alctShowerDataNomSummary_eff_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    clctShowerDataNomSummary_eff_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
 
-    lctShowerEmulSummary_eff_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
-    alctShowerEmulSummary_eff_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
-    clctShowerEmulSummary_eff_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    lctShowerEmulNomSummary_eff_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    alctShowerEmulNomSummary_eff_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    clctShowerEmulNomSummary_eff_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
 
-    lctShowerDataSummary_eff_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
-    alctShowerDataSummary_eff_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
-    clctShowerDataSummary_eff_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    lctShowerDataNomSummary_eff_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    alctShowerDataNomSummary_eff_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    clctShowerDataNomSummary_eff_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
 
-    lctShowerEmulSummary_eff_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
-    alctShowerEmulSummary_eff_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
-    clctShowerEmulSummary_eff_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    lctShowerEmulNomSummary_eff_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    alctShowerEmulNomSummary_eff_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    clctShowerEmulNomSummary_eff_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+
+    lctShowerDataTightSummary_eff_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    alctShowerDataTightSummary_eff_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    clctShowerDataTightSummary_eff_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+
+    lctShowerEmulTightSummary_eff_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    alctShowerEmulTightSummary_eff_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    clctShowerEmulTightSummary_eff_->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+
+    lctShowerDataTightSummary_eff_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    alctShowerDataTightSummary_eff_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    clctShowerDataTightSummary_eff_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+
+    lctShowerEmulTightSummary_eff_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    alctShowerEmulTightSummary_eff_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+    clctShowerEmulTightSummary_eff_->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
   }
 }
 
 void L1TdeCSCTPGShowerClient::processHistograms(DQMStore::IGetter &igetter) {
-  MonitorElement *lctShowerDataSummary_denom_ = igetter.get(monitorDir_ + "/lct_cscshower_data_summary_denom");
-  MonitorElement *lctShowerDataSummary_num_ = igetter.get(monitorDir_ + "/lct_cscshower_data_summary_num");
-  MonitorElement *alctShowerDataSummary_denom_ = igetter.get(monitorDir_ + "/alct_cscshower_data_summary_denom");
-  MonitorElement *alctShowerDataSummary_num_ = igetter.get(monitorDir_ + "/alct_cscshower_data_summary_num");
-  MonitorElement *clctShowerDataSummary_denom_ = igetter.get(monitorDir_ + "/clct_cscshower_data_summary_denom");
-  MonitorElement *clctShowerDataSummary_num_ = igetter.get(monitorDir_ + "/clct_cscshower_data_summary_num");
+  MonitorElement *lctShowerDataNomSummary_denom_ = igetter.get(monitorDir_ + "/lct_cscshower_data_nom_summary_denom");
+  MonitorElement *lctShowerDataNomSummary_num_ = igetter.get(monitorDir_ + "/lct_cscshower_data_nom_summary_num");
+  MonitorElement *alctShowerDataNomSummary_denom_ = igetter.get(monitorDir_ + "/alct_cscshower_data_nom_summary_denom");
+  MonitorElement *alctShowerDataNomSummary_num_ = igetter.get(monitorDir_ + "/alct_cscshower_data_nom_summary_num");
+  MonitorElement *clctShowerDataNomSummary_denom_ = igetter.get(monitorDir_ + "/clct_cscshower_data_nom_summary_denom");
+  MonitorElement *clctShowerDataNomSummary_num_ = igetter.get(monitorDir_ + "/clct_cscshower_data_nom_summary_num");
 
-  MonitorElement *lctShowerEmulSummary_denom_ = igetter.get(monitorDir_ + "/lct_cscshower_emul_summary_denom");
-  MonitorElement *lctShowerEmulSummary_num_ = igetter.get(monitorDir_ + "/lct_cscshower_emul_summary_num");
-  MonitorElement *alctShowerEmulSummary_denom_ = igetter.get(monitorDir_ + "/alct_cscshower_emul_summary_denom");
-  MonitorElement *alctShowerEmulSummary_num_ = igetter.get(monitorDir_ + "/alct_cscshower_emul_summary_num");
-  MonitorElement *clctShowerEmulSummary_denom_ = igetter.get(monitorDir_ + "/clct_cscshower_emul_summary_denom");
-  MonitorElement *clctShowerEmulSummary_num_ = igetter.get(monitorDir_ + "/clct_cscshower_emul_summary_num");
+  MonitorElement *lctShowerEmulNomSummary_denom_ = igetter.get(monitorDir_ + "/lct_cscshower_emul_nom_summary_denom");
+  MonitorElement *lctShowerEmulNomSummary_num_ = igetter.get(monitorDir_ + "/lct_cscshower_emul_nom_summary_num");
+  MonitorElement *alctShowerEmulNomSummary_denom_ = igetter.get(monitorDir_ + "/alct_cscshower_emul_nom_summary_denom");
+  MonitorElement *alctShowerEmulNomSummary_num_ = igetter.get(monitorDir_ + "/alct_cscshower_emul_nom_summary_num");
+  MonitorElement *clctShowerEmulNomSummary_denom_ = igetter.get(monitorDir_ + "/clct_cscshower_emul_nom_summary_denom");
+  MonitorElement *clctShowerEmulNomSummary_num_ = igetter.get(monitorDir_ + "/clct_cscshower_emul_nom_summary_num");
 
-  lctShowerDataSummary_eff_->getTH2F()->Divide(
-      lctShowerDataSummary_num_->getTH2F(), lctShowerDataSummary_denom_->getTH2F(), 1, 1, "");
-  alctShowerDataSummary_eff_->getTH2F()->Divide(
-      alctShowerDataSummary_num_->getTH2F(), alctShowerDataSummary_denom_->getTH2F(), 1, 1, "");
-  clctShowerDataSummary_eff_->getTH2F()->Divide(
-      clctShowerDataSummary_num_->getTH2F(), clctShowerDataSummary_denom_->getTH2F(), 1, 1, "");
+  MonitorElement *lctShowerDataTightSummary_denom_ = igetter.get(monitorDir_ + "/lct_cscshower_data_tight_summary_denom");
+  MonitorElement *lctShowerDataTightSummary_num_ = igetter.get(monitorDir_ + "/lct_cscshower_data_tight_summary_num");
+  MonitorElement *alctShowerDataTightSummary_denom_ = igetter.get(monitorDir_ + "/alct_cscshower_data_tight_summary_denom");
+  MonitorElement *alctShowerDataTightSummary_num_ = igetter.get(monitorDir_ + "/alct_cscshower_data_tight_summary_num");
+  MonitorElement *clctShowerDataTightSummary_denom_ = igetter.get(monitorDir_ + "/clct_cscshower_data_tight_summary_denom");
+  MonitorElement *clctShowerDataTightSummary_num_ = igetter.get(monitorDir_ + "/clct_cscshower_data_tight_summary_num");
 
-  lctShowerEmulSummary_eff_->getTH2F()->Divide(
-      lctShowerEmulSummary_num_->getTH2F(), lctShowerEmulSummary_denom_->getTH2F(), 1, 1, "");
-  alctShowerEmulSummary_eff_->getTH2F()->Divide(
-      alctShowerEmulSummary_num_->getTH2F(), alctShowerEmulSummary_denom_->getTH2F(), 1, 1, "");
-  clctShowerEmulSummary_eff_->getTH2F()->Divide(
-      clctShowerEmulSummary_num_->getTH2F(), clctShowerEmulSummary_denom_->getTH2F(), 1, 1, "");
+  MonitorElement *lctShowerEmulTightSummary_denom_ = igetter.get(monitorDir_ + "/lct_cscshower_emul_tight_summary_denom");
+  MonitorElement *lctShowerEmulTightSummary_num_ = igetter.get(monitorDir_ + "/lct_cscshower_emul_tight_summary_num");
+  MonitorElement *alctShowerEmulTightSummary_denom_ = igetter.get(monitorDir_ + "/alct_cscshower_emul_tight_summary_denom");
+  MonitorElement *alctShowerEmulTightSummary_num_ = igetter.get(monitorDir_ + "/alct_cscshower_emul_tight_summary_num");
+  MonitorElement *clctShowerEmulTightSummary_denom_ = igetter.get(monitorDir_ + "/clct_cscshower_emul_tight_summary_denom");
+  MonitorElement *clctShowerEmulTightSummary_num_ = igetter.get(monitorDir_ + "/clct_cscshower_emul_tight_summary_num");
 
-  lctShowerDataSummary_eff_->getTH2F()->GetZaxis()->SetRangeUser(0.95, 1);
-  alctShowerDataSummary_eff_->getTH2F()->GetZaxis()->SetRangeUser(0.95, 1);
-  clctShowerDataSummary_eff_->getTH2F()->GetZaxis()->SetRangeUser(0.95, 1);
+  lctShowerDataNomSummary_eff_->getTH2F()->Divide(
+      lctShowerDataNomSummary_num_->getTH2F(), lctShowerDataNomSummary_denom_->getTH2F(), 1, 1, "");
+  alctShowerDataNomSummary_eff_->getTH2F()->Divide(
+      alctShowerDataNomSummary_num_->getTH2F(), alctShowerDataNomSummary_denom_->getTH2F(), 1, 1, "");
+  clctShowerDataNomSummary_eff_->getTH2F()->Divide(
+      clctShowerDataNomSummary_num_->getTH2F(), clctShowerDataNomSummary_denom_->getTH2F(), 1, 1, "");
+
+  lctShowerEmulNomSummary_eff_->getTH2F()->Divide(
+      lctShowerEmulNomSummary_num_->getTH2F(), lctShowerEmulNomSummary_denom_->getTH2F(), 1, 1, "");
+  alctShowerEmulNomSummary_eff_->getTH2F()->Divide(
+      alctShowerEmulNomSummary_num_->getTH2F(), alctShowerEmulNomSummary_denom_->getTH2F(), 1, 1, "");
+  clctShowerEmulNomSummary_eff_->getTH2F()->Divide(
+      clctShowerEmulNomSummary_num_->getTH2F(), clctShowerEmulNomSummary_denom_->getTH2F(), 1, 1, "");
+
+  lctShowerDataTightSummary_eff_->getTH2F()->Divide(
+      lctShowerDataTightSummary_num_->getTH2F(), lctShowerDataTightSummary_denom_->getTH2F(), 1, 1, "");
+  alctShowerDataTightSummary_eff_->getTH2F()->Divide(
+      alctShowerDataTightSummary_num_->getTH2F(), alctShowerDataTightSummary_denom_->getTH2F(), 1, 1, "");
+  clctShowerDataTightSummary_eff_->getTH2F()->Divide(
+      clctShowerDataTightSummary_num_->getTH2F(), clctShowerDataTightSummary_denom_->getTH2F(), 1, 1, "");
+
+  lctShowerEmulTightSummary_eff_->getTH2F()->Divide(
+      lctShowerEmulTightSummary_num_->getTH2F(), lctShowerEmulTightSummary_denom_->getTH2F(), 1, 1, "");
+  alctShowerEmulTightSummary_eff_->getTH2F()->Divide(
+      alctShowerEmulTightSummary_num_->getTH2F(), alctShowerEmulTightSummary_denom_->getTH2F(), 1, 1, "");
+  clctShowerEmulTightSummary_eff_->getTH2F()->Divide(
+      clctShowerEmulTightSummary_num_->getTH2F(), clctShowerEmulTightSummary_denom_->getTH2F(), 1, 1, "");
+
+  lctShowerDataNomSummary_eff_->getTH2F()->GetZaxis()->SetRangeUser(0.95, 1);
+  alctShowerDataNomSummary_eff_->getTH2F()->GetZaxis()->SetRangeUser(0.95, 1);
+  clctShowerDataNomSummary_eff_->getTH2F()->GetZaxis()->SetRangeUser(0.95, 1);
+
+  lctShowerDataTightSummary_eff_->getTH2F()->GetZaxis()->SetRangeUser(0.95, 1);
+  alctShowerDataTightSummary_eff_->getTH2F()->GetZaxis()->SetRangeUser(0.95, 1);
+  clctShowerDataTightSummary_eff_->getTH2F()->GetZaxis()->SetRangeUser(0.95, 1);
 }

--- a/DQM/L1TMonitorClient/src/L1TdeCSCTPGShowerClient.cc
+++ b/DQM/L1TMonitorClient/src/L1TdeCSCTPGShowerClient.cc
@@ -32,45 +32,105 @@ void L1TdeCSCTPGShowerClient::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IG
 void L1TdeCSCTPGShowerClient::book(DQMStore::IBooker &iBooker) {
   iBooker.setCurrentFolder(monitorDir_);
 
-  lctShowerDataNomSummary_eff_ = iBooker.book2D(
-      "lct_cscshower_data_nom_summary_eff", "Efficiency of data LCT Nominal shower being correctly emulated", 
-      36, 1, 37, 18, 0, 18);
-  alctShowerDataNomSummary_eff_ = iBooker.book2D(
-      "alct_cscshower_data_nom_summary_eff", "Efficiency of data ALCT Nominal shower being correctly emulated", 
-      36, 1, 37, 18, 0, 18);
-  clctShowerDataNomSummary_eff_ = iBooker.book2D(
-      "clct_cscshower_data_nom_summary_eff", "Efficiency of data CLCT Nominal shower being correctly emulated",
-      36, 1, 37, 18, 0, 18);
+  lctShowerDataNomSummary_eff_ = iBooker.book2D("lct_cscshower_data_nom_summary_eff",
+                                                "Efficiency of data LCT Nominal shower being correctly emulated",
+                                                36,
+                                                1,
+                                                37,
+                                                18,
+                                                0,
+                                                18);
+  alctShowerDataNomSummary_eff_ = iBooker.book2D("alct_cscshower_data_nom_summary_eff",
+                                                 "Efficiency of data ALCT Nominal shower being correctly emulated",
+                                                 36,
+                                                 1,
+                                                 37,
+                                                 18,
+                                                 0,
+                                                 18);
+  clctShowerDataNomSummary_eff_ = iBooker.book2D("clct_cscshower_data_nom_summary_eff",
+                                                 "Efficiency of data CLCT Nominal shower being correctly emulated",
+                                                 36,
+                                                 1,
+                                                 37,
+                                                 18,
+                                                 0,
+                                                 18);
 
-  lctShowerEmulNomSummary_eff_ = iBooker.book2D(
-      "lct_cscshower_emul_nom_summary_eff", "Fraction of emulated LCT Nominal shower without matching data LCT",
-      36, 1, 37, 18, 0, 18);
-  alctShowerEmulNomSummary_eff_ = iBooker.book2D(
-      "alct_cscshower_emul_nom_summary_eff", "Fraction of emulated ALCT Nominal shower without matching data ALCT",
-      36, 1, 37, 18, 0, 18);
-  clctShowerEmulNomSummary_eff_ = iBooker.book2D(
-      "clct_cscshower_emul_nom_summary_eff", "Fraction of emulated CLCT Nominal shower without matching data CLCT",
-      36, 1, 37, 18, 0, 18);
+  lctShowerEmulNomSummary_eff_ = iBooker.book2D("lct_cscshower_emul_nom_summary_eff",
+                                                "Fraction of emulated LCT Nominal shower without matching data LCT",
+                                                36,
+                                                1,
+                                                37,
+                                                18,
+                                                0,
+                                                18);
+  alctShowerEmulNomSummary_eff_ = iBooker.book2D("alct_cscshower_emul_nom_summary_eff",
+                                                 "Fraction of emulated ALCT Nominal shower without matching data ALCT",
+                                                 36,
+                                                 1,
+                                                 37,
+                                                 18,
+                                                 0,
+                                                 18);
+  clctShowerEmulNomSummary_eff_ = iBooker.book2D("clct_cscshower_emul_nom_summary_eff",
+                                                 "Fraction of emulated CLCT Nominal shower without matching data CLCT",
+                                                 36,
+                                                 1,
+                                                 37,
+                                                 18,
+                                                 0,
+                                                 18);
 
-  lctShowerDataTightSummary_eff_ = iBooker.book2D(
-      "lct_cscshower_data_tight_summary_eff", "Efficiency of data LCT Tight shower being correctly emulated", 
-      36, 1, 37, 18, 0, 18);
-  alctShowerDataTightSummary_eff_ = iBooker.book2D(
-      "alct_cscshower_data_tight_summary_eff", "Efficiency of data ALCT Tight shower being correctly emulated", 
-      36, 1, 37, 18, 0, 18);
-  clctShowerDataTightSummary_eff_ = iBooker.book2D(
-      "clct_cscshower_data_tight_summary_eff", "Efficiency of data CLCT Tight shower being correctly emulated",
-      36, 1, 37, 18, 0, 18);
+  lctShowerDataTightSummary_eff_ = iBooker.book2D("lct_cscshower_data_tight_summary_eff",
+                                                  "Efficiency of data LCT Tight shower being correctly emulated",
+                                                  36,
+                                                  1,
+                                                  37,
+                                                  18,
+                                                  0,
+                                                  18);
+  alctShowerDataTightSummary_eff_ = iBooker.book2D("alct_cscshower_data_tight_summary_eff",
+                                                   "Efficiency of data ALCT Tight shower being correctly emulated",
+                                                   36,
+                                                   1,
+                                                   37,
+                                                   18,
+                                                   0,
+                                                   18);
+  clctShowerDataTightSummary_eff_ = iBooker.book2D("clct_cscshower_data_tight_summary_eff",
+                                                   "Efficiency of data CLCT Tight shower being correctly emulated",
+                                                   36,
+                                                   1,
+                                                   37,
+                                                   18,
+                                                   0,
+                                                   18);
 
-  lctShowerEmulTightSummary_eff_ = iBooker.book2D(
-      "lct_cscshower_emul_tight_summary_eff", "Fraction of emulated LCT Tight shower without matching data LCT",
-      36, 1, 37, 18, 0, 18);
-  alctShowerEmulTightSummary_eff_ = iBooker.book2D(
-      "alct_cscshower_emul_tight_summary_eff", "Fraction of emulated ALCT Tight shower without matching data ALCT",
-      36, 1, 37, 18, 0, 18);
-  clctShowerEmulTightSummary_eff_ = iBooker.book2D(
-      "clct_cscshower_emul_tight_summary_eff", "Fraction of emulated CLCT Tight shower without matching data CLCT",
-      36, 1, 37, 18, 0, 18);
+  lctShowerEmulTightSummary_eff_ = iBooker.book2D("lct_cscshower_emul_tight_summary_eff",
+                                                  "Fraction of emulated LCT Tight shower without matching data LCT",
+                                                  36,
+                                                  1,
+                                                  37,
+                                                  18,
+                                                  0,
+                                                  18);
+  alctShowerEmulTightSummary_eff_ = iBooker.book2D("alct_cscshower_emul_tight_summary_eff",
+                                                   "Fraction of emulated ALCT Tight shower without matching data ALCT",
+                                                   36,
+                                                   1,
+                                                   37,
+                                                   18,
+                                                   0,
+                                                   18);
+  clctShowerEmulTightSummary_eff_ = iBooker.book2D("clct_cscshower_emul_tight_summary_eff",
+                                                   "Fraction of emulated CLCT Tight shower without matching data CLCT",
+                                                   36,
+                                                   1,
+                                                   37,
+                                                   18,
+                                                   0,
+                                                   18);
 
   // x labels
   lctShowerDataNomSummary_eff_->setAxisTitle("Chamber", 1);
@@ -160,18 +220,24 @@ void L1TdeCSCTPGShowerClient::processHistograms(DQMStore::IGetter &igetter) {
   MonitorElement *clctShowerEmulNomSummary_denom_ = igetter.get(monitorDir_ + "/clct_cscshower_emul_nom_summary_denom");
   MonitorElement *clctShowerEmulNomSummary_num_ = igetter.get(monitorDir_ + "/clct_cscshower_emul_nom_summary_num");
 
-  MonitorElement *lctShowerDataTightSummary_denom_ = igetter.get(monitorDir_ + "/lct_cscshower_data_tight_summary_denom");
+  MonitorElement *lctShowerDataTightSummary_denom_ =
+      igetter.get(monitorDir_ + "/lct_cscshower_data_tight_summary_denom");
   MonitorElement *lctShowerDataTightSummary_num_ = igetter.get(monitorDir_ + "/lct_cscshower_data_tight_summary_num");
-  MonitorElement *alctShowerDataTightSummary_denom_ = igetter.get(monitorDir_ + "/alct_cscshower_data_tight_summary_denom");
+  MonitorElement *alctShowerDataTightSummary_denom_ =
+      igetter.get(monitorDir_ + "/alct_cscshower_data_tight_summary_denom");
   MonitorElement *alctShowerDataTightSummary_num_ = igetter.get(monitorDir_ + "/alct_cscshower_data_tight_summary_num");
-  MonitorElement *clctShowerDataTightSummary_denom_ = igetter.get(monitorDir_ + "/clct_cscshower_data_tight_summary_denom");
+  MonitorElement *clctShowerDataTightSummary_denom_ =
+      igetter.get(monitorDir_ + "/clct_cscshower_data_tight_summary_denom");
   MonitorElement *clctShowerDataTightSummary_num_ = igetter.get(monitorDir_ + "/clct_cscshower_data_tight_summary_num");
 
-  MonitorElement *lctShowerEmulTightSummary_denom_ = igetter.get(monitorDir_ + "/lct_cscshower_emul_tight_summary_denom");
+  MonitorElement *lctShowerEmulTightSummary_denom_ =
+      igetter.get(monitorDir_ + "/lct_cscshower_emul_tight_summary_denom");
   MonitorElement *lctShowerEmulTightSummary_num_ = igetter.get(monitorDir_ + "/lct_cscshower_emul_tight_summary_num");
-  MonitorElement *alctShowerEmulTightSummary_denom_ = igetter.get(monitorDir_ + "/alct_cscshower_emul_tight_summary_denom");
+  MonitorElement *alctShowerEmulTightSummary_denom_ =
+      igetter.get(monitorDir_ + "/alct_cscshower_emul_tight_summary_denom");
   MonitorElement *alctShowerEmulTightSummary_num_ = igetter.get(monitorDir_ + "/alct_cscshower_emul_tight_summary_num");
-  MonitorElement *clctShowerEmulTightSummary_denom_ = igetter.get(monitorDir_ + "/clct_cscshower_emul_tight_summary_denom");
+  MonitorElement *clctShowerEmulTightSummary_denom_ =
+      igetter.get(monitorDir_ + "/clct_cscshower_emul_tight_summary_denom");
   MonitorElement *clctShowerEmulTightSummary_num_ = igetter.get(monitorDir_ + "/clct_cscshower_emul_tight_summary_num");
 
   lctShowerDataNomSummary_eff_->getTH2F()->Divide(

--- a/DQM/L1TMonitorClient/src/L1TdeStage2ShowerClient.cc
+++ b/DQM/L1TMonitorClient/src/L1TdeStage2ShowerClient.cc
@@ -33,9 +33,9 @@ void L1TdeStage2ShowerClient::book(DQMStore::IBooker &iBooker) {
   iBooker.setCurrentFolder(monitorDir_);
 
   emtfShowerDataSummary_eff_ = iBooker.book2D(
-      "emtf_shower_data_summary_eff", "Efficiency of data EMTF shower being correctly emulated", 6, 1, 7, 2, 0, 2);
+      "emtf_shower_data_summary_eff", "Efficiency of data EMTF shower being correctly emulated", 6, 1, 7, 4, 0, 4);
   emtfShowerEmulSummary_eff_ = iBooker.book2D(
-      "emtf_shower_emul_summary_eff", "Fraction of emulated EMTF shower without matching data shower", 6, 1, 7, 2, 0, 2);
+      "emtf_shower_emul_summary_eff", "Fraction of emulated EMTF shower without matching data shower", 6, 1, 7, 4, 0, 4);
 
   // x labels
   emtfShowerDataSummary_eff_->setAxisTitle("Chamber", 1);
@@ -46,10 +46,14 @@ void L1TdeStage2ShowerClient::book(DQMStore::IBooker &iBooker) {
   emtfShowerEmulSummary_eff_->setOption("colz");
 
   // y labels
-  emtfShowerDataSummary_eff_->setBinLabel(1, "ME-", 2);
-  emtfShowerEmulSummary_eff_->setBinLabel(1, "ME-", 2);
-  emtfShowerDataSummary_eff_->setBinLabel(2, "ME+", 2);
-  emtfShowerEmulSummary_eff_->setBinLabel(2, "ME+", 2);
+  emtfShowerDataSummary_eff_->setBinLabel(1, "ME- Tight", 2);
+  emtfShowerEmulSummary_eff_->setBinLabel(1, "ME- Tight", 2);
+  emtfShowerDataSummary_eff_->setBinLabel(2, "ME- Nom", 2);
+  emtfShowerEmulSummary_eff_->setBinLabel(2, "ME- Nom", 2);
+  emtfShowerDataSummary_eff_->setBinLabel(3, "ME+ Nom", 2);
+  emtfShowerEmulSummary_eff_->setBinLabel(3, "ME+ Nom", 2);
+  emtfShowerDataSummary_eff_->setBinLabel(4, "ME+ Tight", 2);
+  emtfShowerEmulSummary_eff_->setBinLabel(4, "ME+ Tight", 2);
 }
 
 void L1TdeStage2ShowerClient::processHistograms(DQMStore::IGetter &igetter) {

--- a/DQM/L1TMonitorClient/src/L1TdeStage2ShowerRegionalClient.cc
+++ b/DQM/L1TMonitorClient/src/L1TdeStage2ShowerRegionalClient.cc
@@ -16,9 +16,9 @@ L1TdeStage2RegionalShowerClient::L1TdeStage2RegionalShowerClient(const edm::Para
 L1TdeStage2RegionalShowerClient::~L1TdeStage2RegionalShowerClient() {}
 
 void L1TdeStage2RegionalShowerClient::dqmEndLuminosityBlock(DQMStore::IBooker &ibooker,
-                                                    DQMStore::IGetter &igetter,
-                                                    const edm::LuminosityBlock &lumiSeg,
-                                                    const edm::EventSetup &c) {
+                                                            DQMStore::IGetter &igetter,
+                                                            const edm::LuminosityBlock &lumiSeg,
+                                                            const edm::EventSetup &c) {
   book(ibooker);
   processHistograms(igetter);
 }

--- a/DQM/L1TMonitorClient/src/L1TdeStage2ShowerRegionalClient.cc
+++ b/DQM/L1TMonitorClient/src/L1TdeStage2ShowerRegionalClient.cc
@@ -1,4 +1,4 @@
-#include "DQM/L1TMonitorClient/interface/L1TdeStage2ShowerClient.h"
+#include "DQM/L1TMonitorClient/interface/L1TdeStage2RegionalShowerClient.h"
 
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -10,12 +10,12 @@
 using namespace edm;
 using namespace std;
 
-L1TdeStage2ShowerClient::L1TdeStage2ShowerClient(const edm::ParameterSet &ps)
+L1TdeStage2RegionalShowerClient::L1TdeStage2RegionalShowerClient(const edm::ParameterSet &ps)
     : monitorDir_(ps.getUntrackedParameter<string>("monitorDir")) {}
 
-L1TdeStage2ShowerClient::~L1TdeStage2ShowerClient() {}
+L1TdeStage2RegionalShowerClient::~L1TdeStage2RegionalShowerClient() {}
 
-void L1TdeStage2ShowerClient::dqmEndLuminosityBlock(DQMStore::IBooker &ibooker,
+void L1TdeStage2RegionalShowerClient::dqmEndLuminosityBlock(DQMStore::IBooker &ibooker,
                                                     DQMStore::IGetter &igetter,
                                                     const edm::LuminosityBlock &lumiSeg,
                                                     const edm::EventSetup &c) {
@@ -24,12 +24,12 @@ void L1TdeStage2ShowerClient::dqmEndLuminosityBlock(DQMStore::IBooker &ibooker,
 }
 
 //--------------------------------------------------------
-void L1TdeStage2ShowerClient::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter) {
+void L1TdeStage2RegionalShowerClient::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter) {
   book(ibooker);
   processHistograms(igetter);
 }
 
-void L1TdeStage2ShowerClient::book(DQMStore::IBooker &iBooker) {
+void L1TdeStage2RegionalShowerClient::book(DQMStore::IBooker &iBooker) {
   iBooker.setCurrentFolder(monitorDir_);
 
   emtfShowerDataSummary_eff_ = iBooker.book2D(
@@ -56,7 +56,7 @@ void L1TdeStage2ShowerClient::book(DQMStore::IBooker &iBooker) {
   emtfShowerEmulSummary_eff_->setBinLabel(4, "ME+ Tight", 2);
 }
 
-void L1TdeStage2ShowerClient::processHistograms(DQMStore::IGetter &igetter) {
+void L1TdeStage2RegionalShowerClient::processHistograms(DQMStore::IGetter &igetter) {
   MonitorElement *emtfShowerDataSummary_denom_ = igetter.get(monitorDir_ + "/emtf_shower_data_summary_denom");
   MonitorElement *emtfShowerDataSummary_num_ = igetter.get(monitorDir_ + "/emtf_shower_data_summary_num");
 

--- a/DQM/L1TMonitorClient/src/SealModule.cc
+++ b/DQM/L1TMonitorClient/src/SealModule.cc
@@ -18,8 +18,8 @@ DEFINE_FWK_MODULE(L1TdeCSCTPGClient);
 #include "DQM/L1TMonitorClient/interface/L1TdeCSCTPGShowerClient.h"
 DEFINE_FWK_MODULE(L1TdeCSCTPGShowerClient);
 
-#include "DQM/L1TMonitorClient/interface/L1TdeStage2ShowerClient.h"
-DEFINE_FWK_MODULE(L1TdeStage2ShowerClient);
+#include "DQM/L1TMonitorClient/interface/L1TdeStage2RegionalShowerClient.h"
+DEFINE_FWK_MODULE(L1TdeStage2RegionalShowerClient);
 
 #include "DQM/L1TMonitorClient/interface/L1TCSCTFClient.h"
 DEFINE_FWK_MODULE(L1TCSCTFClient);

--- a/L1Trigger/L1TMuonEndCap/src/SectorProcessorShower.cc
+++ b/L1Trigger/L1TMuonEndCap/src/SectorProcessorShower.cc
@@ -68,7 +68,7 @@ void SectorProcessorShower::process(const CSCShowerDigiCollection& in_showers,
     // shower output
     l1t::RegionalMuonShower out_shower(hasOneNominalInTime, false, hasTwoLooseInTime, false, hasOneTightInTime, false);
     l1t::tftype tftype = (endcap_ == 1) ? l1t::tftype::emtf_pos : l1t::tftype::emtf_neg;
-    out_shower.setTFIdentifiers(sector_, tftype);
+    out_shower.setTFIdentifiers(sector_ - 1, tftype);
     out_showers.push_back(0, out_shower);
   }
 }


### PR DESCRIPTION
#### PR description:

This PR expands the data vs emulator comparison DQM plots for L1T shower objects, after the initial [PR#36396](https://github.com/cms-sw/cmssw/pull/36396).
Changes are:
- Add conditions to compare in-time nominal showers only.
- Make separate comparisons for nominal-only showers and tight showers.
- A small bugfix of shower processor assignment in EMTF shower emulator 

#### PR validation:

Tests with a Higgs to LLP to 4b sample, all plots look good (available at [link](https://xzuo.web.cern.ch/ShowerDQM/data_vs_emul/)).

Cannot run unit test, error message 
`ERROR, invalid URL /dbs/prod/global/DBSReader/blocks?dataset=/ExpressCosmics/Commissioning2021-Express-v1/FEVT`
Looks like an dasgoclient issue reported in [issue#36527](https://github.com/cms-sw/cmssw/issues/36527) and solved in [PR#7522](https://github.com/cms-sw/cmsdist/pull/7522).

Passed matrix tests.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
