### PR TITLE
HI Pixel Tracking: change fitter from Conformal Mapping to Broken Line/Riemann

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/hiPixelTracks_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/hiPixelTracks_cfi.py
@@ -6,8 +6,7 @@ hiPixelTracks = patTracksToPackedCandidates.clone(
   dxySigCut = 3.0,
   dzSigCut = 3.0,
   dxySigHP = 2.0,
-  dzSigHP = 2.0,
-  ptMin = 0.2
+  dzSigHP = 2.0
 )
 
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel

--- a/PhysicsTools/PatAlgos/python/slimming/hiPixelTracks_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/hiPixelTracks_cfi.py
@@ -2,12 +2,13 @@ import FWCore.ParameterSet.Config as cms
 
 from PhysicsTools.PatAlgos.patTracksToPackedCandidates_cfi import patTracksToPackedCandidates
 
-hiPixelTracks = patTracksToPackedCandidates.clone()
-hiPixelTracks.dxySigCut = 3.
-hiPixelTracks.dzSigCut = 3.
-hiPixelTracks.dxySigHP = 2.
-hiPixelTracks.dzSigHP = 2.
-hiPixelTracks.ptMin = 0.2
+hiPixelTracks = patTracksToPackedCandidates.clone(
+  dxySigCut = 3.0,
+  dzSigCut = 3.0,
+  dxySigHP = 2.0,
+  dzSigHP = 2.0,
+  ptMin = 0.2
+)
 
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify(hiPixelTracks, covarianceVersion=1)

--- a/PhysicsTools/PatAlgos/python/slimming/hiPixelTracks_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/hiPixelTracks_cfi.py
@@ -3,6 +3,11 @@ import FWCore.ParameterSet.Config as cms
 from PhysicsTools.PatAlgos.patTracksToPackedCandidates_cfi import patTracksToPackedCandidates
 
 hiPixelTracks = patTracksToPackedCandidates.clone()
+hiPixelTracks.dxySigCut = 3.
+hiPixelTracks.dzSigCut = 3.
+hiPixelTracks.dxySigHP = 2.
+hiPixelTracks.dzSigHP = 2.
+hiPixelTracks.ptMin = 0.2
 
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify(hiPixelTracks, covarianceVersion=1)

--- a/RecoHI/HiTracking/python/HILowPtConformalPixelTracks_cfi.py
+++ b/RecoHI/HiTracking/python/HILowPtConformalPixelTracks_cfi.py
@@ -52,7 +52,7 @@ hiConformalPixelTracksPhase1TrackingRegions = globalTrackingRegionWithVertices.c
 	sigmaZVertex     = 3.0,
 	fixedError       = 0.2,
 	VertexCollection = "offlinePrimaryVertices",
-	ptMin            = 0.2,
+	ptMin            = 0.3,
 	useFoundVertices = True,
 	originRadius     = 0.2 
     )
@@ -107,7 +107,7 @@ hiConformalPixelTracksPhase1Filter = hiConformalPixelFilter.clone(
     nSigmaLipMaxTolerance = 3.0,
     nSigmaTipMaxTolerance = 3.0,
     ptMax  = 999999,
-    ptMin  = 0.20,
+    ptMin  = 0.30,
     tipMax = 999.0
 )
 

--- a/RecoHI/HiTracking/python/HILowPtConformalPixelTracks_cfi.py
+++ b/RecoHI/HiTracking/python/HILowPtConformalPixelTracks_cfi.py
@@ -52,7 +52,7 @@ hiConformalPixelTracksPhase1TrackingRegions = globalTrackingRegionWithVertices.c
 	sigmaZVertex     = 3.0,
 	fixedError       = 0.2,
 	VertexCollection = "offlinePrimaryVertices",
-	ptMin            = 0.3,
+	ptMin            = 0.2,
 	useFoundVertices = True,
 	originRadius     = 0.2 
     )
@@ -102,20 +102,22 @@ hiConformalPixelTracksPhase1HitQuadrupletsCA = lowPtQuadStepHitQuadruplets.clone
 #Filter
 hiConformalPixelTracksPhase1Filter = hiConformalPixelFilter.clone(
     VertexCollection = "offlinePrimaryVertices",
-    chi2   = 999.9,
+    chi2   = 30.0,
     lipMax = 999.0,
-    nSigmaLipMaxTolerance = 999.9,
-    nSigmaTipMaxTolerance = 999.0,
+    nSigmaLipMaxTolerance = 3.0,
+    nSigmaTipMaxTolerance = 3.0,
     ptMax  = 999999,
-    ptMin  = 0.30,
+    ptMin  = 0.20,
     tipMax = 999.0
 )
+
+from RecoPixelVertexing.PixelTrackFitting.pixelNtupletsFitter_cfi import pixelNtupletsFitter
 
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify(hiConformalPixelTracks,
     Cleaner = 'pixelTrackCleanerBySharedHits',
     Filter  = "hiConformalPixelTracksPhase1Filter",
-    Fitter  = "pixelFitterByConformalMappingAndLine",
+    Fitter  = "pixelNtupletsFitter",
     SeedingHitSets = "hiConformalPixelTracksPhase1HitQuadrupletsCA",
 )
 
@@ -133,7 +135,7 @@ hiConformalPixelTracksTaskPhase1 = cms.Task(
     hiConformalPixelTracksPhase1SeedLayers ,
     hiConformalPixelTracksPhase1HitDoubletsCA ,
     hiConformalPixelTracksPhase1HitQuadrupletsCA ,
-    pixelFitterByConformalMappingAndLine ,
+    pixelNtupletsFitter ,
     hiConformalPixelTracksPhase1Filter ,
     hiConformalPixelTracks
 )


### PR DESCRIPTION
Dear All, 

We change configuration files for heavy-ions pixel tracking collection in MiniAOD to use BrokenLine/Riemman fitters.

We re-tune loose pre-selection and lower pT threshold from 0.3GeV/c to 0.2GeV/c. Since 
new fitters have much higher absolute efficiency in the pT range of interest of this collection, i.e. ~0.2-1.0GeV/c (please, see slides 2-3 of [*]), the total size of MiniAOD heavy-ion event is expected to increase by around 2-3% (with small dependency on collision centrality). Please, see slide 5 of [*].

We did timing studies. With new configuration we have almost factor 3 of reduction in timing for pixel tracking 
collection sequence. Please, see slide 4 of [*].

[*] https://indico.cern.ch/event/1107099/contributions/4658135/attachments/2366348/4040751/slides_HINTRKmeeting_16122021.pdf

Best Regards,

   Cesar A. Bernardes

@abaty @mandrenguyen 
