### PR TITLE
Correcting a JEC indexing bug for the pat::Jet class in association to scaleEnergy function calls

### DIFF
--- a/DataFormats/PatCandidates/src/Jet.cc
+++ b/DataFormats/PatCandidates/src/Jet.cc
@@ -249,6 +249,7 @@ void Jet::scaleEnergy(double fScale, const std::string& level) {
   if (jecSetsAvailable()) {
     std::vector<float> factors = {float(jec_[0].correction(0, JetCorrFactors::NONE) / fScale)};
     jec_[0].insertFactor(0, std::make_pair(level, factors));
+    ++currentJECLevel_;
   }
   setP4(p4() * fScale);
 }


### PR DESCRIPTION
#### PR description:

- When an energy scale was added to a jet using the scaleEnergy() function, the index (currentJECSet_) of the current JEC level was not correctly updated
- The scale is added to the JEC collection vector onto the index 0, so this will always increment the correct index for the current JEC level by one
- The bug is mostly visible in use cases of the function jecFactor(), involving additionally jet energy fraction functions and the function correctedJet() EDIT: AND the function correctedP4()
- As additional energy scales are rarely added in Data, this issue is most likely to touch the analyses of MC samples
- Special features of MC sample analysis:
  - Before the fix, if the original JEC level was set to L3Absolute, one "safe call" of scaleEnergy() was allowed, because L3Absolute is a unitary dummy; two calls would break the return values of jecFactor()
  - Before the fix, if the original JEC level was set to L2L3Residual, two "safe calls" of scaleEnergy() were allowed, because also L2L3Residual is a unitary dummy in MC; three calls would break the return values of jecFactor()
  - Standard jet smearing produces one call of scaleEnergy(), [see here](https://github.com/cms-sw/cmssw/blob/master/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h#L291)
  - E.g. systematic jet energy variations can produce another call to scaleEnergy(), which would be enough for breaking the JECs if the original level was L3Absolute
  - If the code is not fully optimized, there might exist several calls to scaleEnergy() instead of a single collective call, potentially causing the JECs to break
  - These points underline the fact that the bug can be very elusive and only appear e.g. in the study of systematics
- Possible checks to see if an analysis or ntuple production is affected:
  - There is no silver bullet, as the bug can get activated in many ways
  - One could, however, start by checking whether L3Absolute or L2L3Relative was used for jets in MC
  - Next, one could do a 'grep -rn . -e "scaleEnergy' and/or 'grep -rn . -e "scaleEnergy(" ' on the whole code base and check the amount of consecutive uses of the energy scaling function per a single jet, including the one call from jet smearing.
  - Consecutive calls are still incremented also even if a jet is copied to another jet collection
  - If one is still unsure about the amount of scaleEnergy() calls per jet, one could check this by calling 'jet.availableJECLevels()' on the final jet collection and calculating the amount of "Unscaled" entries per jet
  - If there are one/two (L3Abs/L2L3Res) or less scaleEnergy calls per jet, one should be safe
  - If there are more calls than this but one does not utilize the functions jecFactor() or correctedJet(), the effects are very limited
  - EDIT: also the function correctedP4() needs to be checked, as it employs correctedJet() 
  - One should probably check the usage of these functions with the same grep tricks as with scaleEnergy()
  - Also the jet energy fractions and hence the JetID are affected if the bug gets activated, but this is a very limited effect
  - If the bug gets active, the most likely consequence is that L2Rel or L1+L2Rel JECs are applied twice, causing a scaling effect around 5-10%
- The virtual slides with exhaustive documentation can be found at https://indico.cern.ch/event/1005590/#5-patjet-bug-report-virtual

#### PR validation:

- Explicit printouts of the contents of the vector jet.availableJECLevels() and the values of jet.jecFactor(idx) at the corresponding indices 'idx' were made before and after the update in association to a varying count of dummy energy scaling calls of the format jet.scaleEnergy(1.)
- In a similar fashion, the pt values from jet.correctedJet() were studied before and after the update after a varying count of dummy energy scaling calls of the format jet.scaleEnergy(1.)
- The basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html) has also been run through.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

- This is not a backport, but the bug has been there from CMSSW_10_6_X onwards, so if possible, this patch should be backported there