### PR TITLE
HLTTauDQM: ignoring modules starting with '-' (modules inside cms.ign…

### DIFF
--- a/DQMOffline/Trigger/src/HLTTauDQMPath.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMPath.cc
@@ -54,6 +54,8 @@ namespace {
           continue;
         if (type == "HLTTriggerTypeFilter" || type == "HLTBool")
           continue;
+        if(iLabel->find('-') == 0) // ignore 
+          continue;
         if (type == "HLT2PhotonPFTau" || type == "HLT2ElectronPFTau" || type == "HLT2MuonPFTau" ||
             type == "HLT2PhotonTau" || type == "HLT2ElectronTau" || type == "HLT2MuonTau")
           leptonTauFilters.emplace_back(*iLabel);

--- a/DQMOffline/Trigger/src/HLTTauDQMPath.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMPath.cc
@@ -54,7 +54,7 @@ namespace {
           continue;
         if (type == "HLTTriggerTypeFilter" || type == "HLTBool")
           continue;
-        if(iLabel->find('-') == 0) // ignore 
+        if (iLabel->find('-') == 0)  // ignore
           continue;
         if (type == "HLT2PhotonPFTau" || type == "HLT2ElectronPFTau" || type == "HLT2MuonPFTau" ||
             type == "HLT2PhotonTau" || type == "HLT2ElectronTau" || type == "HLT2MuonTau")


### PR DESCRIPTION
New DeepTau paths contain modules inside cms.ignore(). This caused problems with the offline object matching, HLTTauDQM stopped when not finding offline muons for di-tau path (inside ignore there are all L1 seeds including mu+tau seed, therefore the code is looking for muons, too).
Fix: ignore all modules inside cms.ignore(): i.e. modules starting with a '-'. 

Files changed: DQMOffline/Trigger/src/HLTTauDQMPath.cc
