### PR TITLE
Add ProcessGUIDService, and use it in InputSource, StatisticsSenderService, and CondorStatusService

### DIFF
--- a/FWCore/Framework/src/InputSource.cc
+++ b/FWCore/Framework/src/InputSource.cc
@@ -15,10 +15,12 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/ServiceRegistry/interface/StreamContext.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/GlobalIdentifier.h"
+#include "FWCore/Utilities/interface/ProcessGUID.h"
 #include "FWCore/Utilities/interface/TimeOfDay.h"
 
 #include <cassert>
@@ -42,6 +44,14 @@ namespace edm {
         return th;
       return (lastDigit == 1 ? st : (lastDigit == 2 ? nd : rd));
     }
+
+    std::string guid() {
+      Service<ProcessGUID> svc;
+      if (svc.isAvailable()) {
+        return svc->binary();
+      }
+      return createGlobalIdentifier(true);
+    }
   }  // namespace
 
   InputSource::InputSource(ParameterSet const& pset, InputSourceDescription const& desc)
@@ -59,7 +69,7 @@ namespace edm {
         branchIDListHelper_(desc.branchIDListHelper_),
         processBlockHelper_(desc.processBlockHelper_),
         thinnedAssociationsHelper_(desc.thinnedAssociationsHelper_),
-        processGUID_(createGlobalIdentifier(true)),
+        processGUID_(guid()),
         time_(),
         newRun_(true),
         newLumi_(true),

--- a/FWCore/Framework/src/defaultCmsRunServices.cc
+++ b/FWCore/Framework/src/defaultCmsRunServices.cc
@@ -22,6 +22,7 @@ namespace edm {
                                             "UnixSignalService",
                                             "AdaptorConfig",
                                             "SiteLocalConfigService",
+                                            "ProcessGUIDService",
                                             "StatisticsSenderService",
                                             "CondorStatusService",
                                             "XrdStatisticsService"};

--- a/FWCore/Services/plugins/CondorStatusUpdater.cc
+++ b/FWCore/Services/plugins/CondorStatusUpdater.cc
@@ -14,6 +14,7 @@
 #include "Utilities/StorageFactory/interface/StorageAccount.h"
 #include "Utilities/XrdAdaptor/interface/XrdStatistics.h"
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
+#include "FWCore/Utilities/interface/ProcessGUID.h"
 
 #include <fcntl.h>
 #include <unistd.h>
@@ -224,6 +225,7 @@ void CondorStatusService::firstUpdate() {
   updateChirp("MaxEvents", "-1");
   updateChirp("MaxLumis", "-1");
   updateChirp("Done", "false");
+  updateChirpQuoted("Guid", edm::Service<edm::ProcessGUID>()->string());
 
   edm::Service<edm::CPUServiceBase> cpusvc;
   std::string models;

--- a/FWCore/Services/plugins/ProcessGUIDService.cc
+++ b/FWCore/Services/plugins/ProcessGUIDService.cc
@@ -1,0 +1,23 @@
+#include "FWCore/Utilities/interface/Guid.h"
+#include "FWCore/Utilities/interface/ProcessGUID.h"
+#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
+
+namespace edm::service {
+  class ProcessGUIDService : public ProcessGUID {
+  public:
+    ProcessGUIDService() = default;
+
+    std::string binary() const override { return guid_.toBinary(); }
+
+    std::string string() const override { return guid_.toString(); }
+
+  private:
+    Guid guid_;
+  };
+
+  bool isProcessWideService(ProcessGUIDService const *) { return true; }
+}  // namespace edm::service
+
+using edm::service::ProcessGUIDService;
+using ProcessGUIDServiceMaker = edm::serviceregistry::NoArgsMaker<edm::ProcessGUID, ProcessGUIDService>;
+DEFINE_FWK_SERVICE_MAKER(ProcessGUIDService, ProcessGUIDServiceMaker);

--- a/FWCore/Utilities/interface/ProcessGUID.h
+++ b/FWCore/Utilities/interface/ProcessGUID.h
@@ -1,0 +1,20 @@
+#ifndef FWCore_Utilities_ProcessGUID_h
+#define FWCore_Utilities_ProcessGUID_h
+
+#include <string>
+
+namespace edm {
+  /**
+   * This class is an abstract base class for a Service providing a
+   * process-level Globally Unique Identifier (GUID).
+   */
+  class ProcessGUID {
+  public:
+    virtual ~ProcessGUID() = 0;
+
+    virtual std::string binary() const = 0;
+    virtual std::string string() const = 0;
+  };
+}  // namespace edm
+
+#endif

--- a/FWCore/Utilities/src/ProcessGUID.cc
+++ b/FWCore/Utilities/src/ProcessGUID.cc
@@ -1,0 +1,5 @@
+#include "FWCore/Utilities/interface/ProcessGUID.h"
+
+namespace edm {
+  ProcessGUID::~ProcessGUID() = default;
+}

--- a/Utilities/StorageFactory/src/StatisticsSenderService.cc
+++ b/Utilities/StorageFactory/src/StatisticsSenderService.cc
@@ -5,7 +5,7 @@
 #include "FWCore/Catalog/interface/SiteLocalConfig.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Utilities/interface/Guid.h"
+#include "FWCore/Utilities/interface/ProcessGUID.h"
 
 #include <string>
 #include <cmath>
@@ -169,7 +169,7 @@ StatisticsSenderService::StatisticsSenderService(edm::ParameterSet const &iPSet,
     : m_clienthost("unknown"),
       m_clientdomain("unknown"),
       m_filestats(),
-      m_guid(Guid().toString()),
+      m_guid(edm::Service<ProcessGUID>()->string()),
       m_counter(0),
       m_userdn("unknown"),
       m_debug(iPSet.getUntrackedParameter<bool>("debug", false)) {


### PR DESCRIPTION
#### PR description:

This PR adds `ProcessGUIDService` to create a process-level GUID, and uses that in `InputSource`, `StatisticsSenderService`, and adds a new Chirp field for it in `CondorStatusService`. The GUID helps to correlate information in different monitoring systems that come from the same process.

Resolves https://github.com/cms-sw/cmssw/issues/36351. 

#### PR validation:

Framework unit tests pass.
