### PR TITLE
Migrate to new oneapi naming

### DIFF
--- a/DataFormats/Common/interface/AssociationMap.h
+++ b/DataFormats/Common/interface/AssociationMap.h
@@ -38,7 +38,7 @@
 #include "DataFormats/Common/interface/OneToManyWithQuality.h"
 
 #include <utility>
-#include "tbb/concurrent_unordered_map.h"
+#include "oneapi/tbb/concurrent_unordered_map.h"
 
 namespace edm {
 

--- a/DataFormats/Common/interface/AssociationMap.h
+++ b/DataFormats/Common/interface/AssociationMap.h
@@ -70,7 +70,7 @@ namespace edm {
     /// type return by operator[]
     typedef typename value_type::value_type result_type;
     /// transient map type
-    typedef typename tbb::concurrent_unordered_map<index_type, value_type> internal_transient_map_type;
+    typedef typename oneapi::tbb::concurrent_unordered_map<index_type, value_type> internal_transient_map_type;
 
     /// const iterator
     struct const_iterator {

--- a/DataFormats/Provenance/interface/ParentageRegistry.h
+++ b/DataFormats/Provenance/interface/ParentageRegistry.h
@@ -1,7 +1,7 @@
 #ifndef DataFormats_Provenance_ParentageRegistry_h
 #define DataFormats_Provenance_ParentageRegistry_h
 
-#include "tbb/concurrent_unordered_map.h"
+#include "oneapi/tbb/concurrent_unordered_map.h"
 
 #include "DataFormats/Provenance/interface/Parentage.h"
 #include "DataFormats/Provenance/interface/ParentageID.h"

--- a/DataFormats/Provenance/interface/ParentageRegistry.h
+++ b/DataFormats/Provenance/interface/ParentageRegistry.h
@@ -46,7 +46,7 @@ namespace edm {
     };
 
   private:
-    tbb::concurrent_unordered_map<key_type, value_type, key_hash> m_map;
+    oneapi::tbb::concurrent_unordered_map<key_type, value_type, key_hash> m_map;
   };
 
 }  // namespace edm

--- a/FWCore/Common/src/EventBase.cc
+++ b/FWCore/Common/src/EventBase.cc
@@ -28,7 +28,7 @@ namespace {
   struct key_hash {
     std::size_t operator()(edm::ParameterSetID const& iKey) const { return iKey.smallHash(); }
   };
-  typedef tbb::concurrent_unordered_map<edm::ParameterSetID, edm::TriggerNames, key_hash> TriggerNamesMap;
+  typedef oneapi::tbb::concurrent_unordered_map<edm::ParameterSetID, edm::TriggerNames, key_hash> TriggerNamesMap;
   CMS_THREAD_SAFE TriggerNamesMap triggerNamesMap;
 }  // namespace
 

--- a/FWCore/Common/src/EventBase.cc
+++ b/FWCore/Common/src/EventBase.cc
@@ -12,7 +12,7 @@
 
 // system include files
 #include <vector>
-#include "tbb/concurrent_unordered_map.h"
+#include "oneapi/tbb/concurrent_unordered_map.h"
 
 // user include files
 #include "FWCore/Common/interface/EventBase.h"

--- a/FWCore/Concurrency/interface/FunctorTask.h
+++ b/FWCore/Concurrency/interface/FunctorTask.h
@@ -7,7 +7,7 @@
 //
 /**\class FunctorTask FunctorTask.h FWCore/Concurrency/interface/FunctorTask.h
 
- Description: Builds a tbb::task from a lambda.
+ Description: Builds a oneapi::tbb::task from a lambda.
 
  Usage:
  

--- a/FWCore/Concurrency/interface/LimitedTaskQueue.h
+++ b/FWCore/Concurrency/interface/LimitedTaskQueue.h
@@ -52,7 +52,7 @@ namespace edm {
        * \param[in] iAction Must be a functor that takes no arguments and return no values.
        */
     template <typename T>
-    void push(tbb::task_group& iGroup, T&& iAction);
+    void push(oneapi::tbb::task_group& iGroup, T&& iAction);
 
     class Resumer {
     public:
@@ -102,7 +102,7 @@ namespace edm {
        Using this function will decrease the allowed concurrency limit by 1.
        */
     template <typename T>
-    void pushAndPause(tbb::task_group& iGroup, T&& iAction);
+    void pushAndPause(oneapi::tbb::task_group& iGroup, T&& iAction);
 
     unsigned int concurrencyLimit() const { return m_queues.size(); }
 
@@ -112,7 +112,7 @@ namespace edm {
   };
 
   template <typename T>
-  void LimitedTaskQueue::push(tbb::task_group& iGroup, T&& iAction) {
+  void LimitedTaskQueue::push(oneapi::tbb::task_group& iGroup, T&& iAction) {
     auto set_to_run = std::make_shared<std::atomic<bool>>(false);
     for (auto& q : m_queues) {
       q.push(iGroup, [set_to_run, iAction]() mutable {
@@ -125,7 +125,7 @@ namespace edm {
   }
 
   template <typename T>
-  void LimitedTaskQueue::pushAndPause(tbb::task_group& iGroup, T&& iAction) {
+  void LimitedTaskQueue::pushAndPause(oneapi::tbb::task_group& iGroup, T&& iAction) {
     auto set_to_run = std::make_shared<std::atomic<bool>>(false);
     for (auto& q : m_queues) {
       q.push(iGroup, [&q, set_to_run, iAction]() mutable {

--- a/FWCore/Concurrency/interface/SerialTaskQueue.h
+++ b/FWCore/Concurrency/interface/SerialTaskQueue.h
@@ -56,8 +56,8 @@
 #include <atomic>
 #include <cassert>
 
-#include "tbb/task_group.h"
-#include "tbb/concurrent_queue.h"
+#include "oneapi/tbb/task_group.h"
+#include "oneapi/tbb/concurrent_queue.h"
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 // user include files

--- a/FWCore/Concurrency/interface/SerialTaskQueue.h
+++ b/FWCore/Concurrency/interface/SerialTaskQueue.h
@@ -116,30 +116,30 @@ namespace edm {
        * \param[in] iAction Must be a functor that takes no arguments and return no values.
        */
     template <typename T>
-    void push(tbb::task_group&, const T& iAction);
+    void push(oneapi::tbb::task_group&, const T& iAction);
 
   private:
     /** Base class for all tasks held by the SerialTaskQueue */
     class TaskBase {
       friend class SerialTaskQueue;
 
-      tbb::task_group* group() { return m_group; }
+      oneapi::tbb::task_group* group() { return m_group; }
       virtual void execute() = 0;
 
     public:
       virtual ~TaskBase() = default;
 
     protected:
-      explicit TaskBase(tbb::task_group* iGroup) : m_group(iGroup) {}
+      explicit TaskBase(oneapi::tbb::task_group* iGroup) : m_group(iGroup) {}
 
     private:
-      tbb::task_group* m_group;
+      oneapi::tbb::task_group* m_group;
     };
 
     template <typename T>
     class QueuedTask : public TaskBase {
     public:
-      QueuedTask(tbb::task_group& iGroup, const T& iAction) : TaskBase(&iGroup), m_action(iAction) {}
+      QueuedTask(oneapi::tbb::task_group& iGroup, const T& iAction) : TaskBase(&iGroup), m_action(iAction) {}
 
     private:
       void execute() final;
@@ -158,13 +158,13 @@ namespace edm {
     void spawn(TaskBase&);
 
     // ---------- member data --------------------------------
-    tbb::concurrent_queue<TaskBase*> m_tasks;
+    oneapi::tbb::concurrent_queue<TaskBase*> m_tasks;
     std::atomic<bool> m_taskChosen;
     std::atomic<unsigned long> m_pauseCount;
   };
 
   template <typename T>
-  void SerialTaskQueue::push(tbb::task_group& iGroup, const T& iAction) {
+  void SerialTaskQueue::push(oneapi::tbb::task_group& iGroup, const T& iAction) {
     QueuedTask<T>* pTask{new QueuedTask<T>{iGroup, iAction}};
     pushTask(pTask);
   }

--- a/FWCore/Concurrency/interface/SerialTaskQueueChain.h
+++ b/FWCore/Concurrency/interface/SerialTaskQueueChain.h
@@ -54,7 +54,7 @@ namespace edm {
      * \param[in] iAction Must be a functor that takes no arguments and return no values.
      */
     template <typename T>
-    void push(tbb::task_group& iGroup, T&& iAction);
+    void push(oneapi::tbb::task_group& iGroup, T&& iAction);
 
     unsigned long outstandingTasks() const { return m_outstandingTasks; }
     std::size_t numberOfQueues() const { return m_queues.size(); }
@@ -65,14 +65,14 @@ namespace edm {
     std::atomic<unsigned long> m_outstandingTasks{0};
 
     template <typename T>
-    void passDownChain(unsigned int iIndex, tbb::task_group& iGroup, T&& iAction);
+    void passDownChain(unsigned int iIndex, oneapi::tbb::task_group& iGroup, T&& iAction);
 
     template <typename T>
     void actionToRun(T&& iAction);
   };
 
   template <typename T>
-  void SerialTaskQueueChain::push(tbb::task_group& iGroup, T&& iAction) {
+  void SerialTaskQueueChain::push(oneapi::tbb::task_group& iGroup, T&& iAction) {
     ++m_outstandingTasks;
     if (m_queues.size() == 1) {
       m_queues[0]->push(iGroup, [this, iAction]() mutable { this->actionToRun(iAction); });
@@ -83,7 +83,7 @@ namespace edm {
   }
 
   template <typename T>
-  void SerialTaskQueueChain::passDownChain(unsigned int iQueueIndex, tbb::task_group& iGroup, T&& iAction) {
+  void SerialTaskQueueChain::passDownChain(unsigned int iQueueIndex, oneapi::tbb::task_group& iGroup, T&& iAction) {
     //Have to be sure the queue associated to this running task
     // does not attempt to start another task
     m_queues[iQueueIndex - 1]->pause();

--- a/FWCore/Concurrency/interface/ThreadSafeOutputFileStream.h
+++ b/FWCore/Concurrency/interface/ThreadSafeOutputFileStream.h
@@ -1,7 +1,7 @@
 #ifndef FWCore_Concurrency_ThreadSafeOutputFileStream_h
 #define FWCore_Concurrency_ThreadSafeOutputFileStream_h
 
-#include "tbb/concurrent_queue.h"
+#include "oneapi/tbb/concurrent_queue.h"
 
 #include <atomic>
 #include <fstream>

--- a/FWCore/Concurrency/interface/ThreadSafeOutputFileStream.h
+++ b/FWCore/Concurrency/interface/ThreadSafeOutputFileStream.h
@@ -19,7 +19,7 @@ namespace edm {
   private:
     std::ofstream file_;
     std::atomic<bool> msgBeingLogged_{false};
-    tbb::concurrent_queue<std::string> waitingMessages_{};
+    oneapi::tbb::concurrent_queue<std::string> waitingMessages_{};
   };
 }  // namespace edm
 

--- a/FWCore/Concurrency/interface/ThreadsController.h
+++ b/FWCore/Concurrency/interface/ThreadsController.h
@@ -19,8 +19,8 @@
 //
 
 // system include files
-#include "tbb/global_control.h"
-#include "tbb/task_arena.h"
+#include "oneapi/tbb/global_control.h"
+#include "oneapi/tbb/task_arena.h"
 #include <memory>
 
 // user include files

--- a/FWCore/Concurrency/interface/ThreadsController.h
+++ b/FWCore/Concurrency/interface/ThreadsController.h
@@ -32,19 +32,20 @@ namespace edm {
   public:
     ThreadsController() = delete;
     explicit ThreadsController(unsigned int iNThreads)
-        : m_nThreads{tbb::global_control::max_allowed_parallelism, iNThreads}, m_stackSize{} {}
+        : m_nThreads{oneapi::tbb::global_control::max_allowed_parallelism, iNThreads}, m_stackSize{} {}
     ThreadsController(unsigned int iNThreads, size_t iStackSize)
-        : m_nThreads{tbb::global_control::max_allowed_parallelism, iNThreads}, m_stackSize{makeStackSize(iStackSize)} {}
+        : m_nThreads{oneapi::tbb::global_control::max_allowed_parallelism, iNThreads},
+          m_stackSize{makeStackSize(iStackSize)} {}
 
     // ---------- member functions ---------------------------
     void setStackSize(size_t iStackSize) { m_stackSize = makeStackSize(iStackSize); }
 
   private:
-    static std::unique_ptr<tbb::global_control> makeStackSize(size_t iStackSize);
+    static std::unique_ptr<oneapi::tbb::global_control> makeStackSize(size_t iStackSize);
 
     // ---------- member data --------------------------------
-    tbb::global_control m_nThreads;
-    std::unique_ptr<tbb::global_control> m_stackSize;
+    oneapi::tbb::global_control m_nThreads;
+    std::unique_ptr<oneapi::tbb::global_control> m_stackSize;
   };
 }  // namespace edm
 

--- a/FWCore/Concurrency/interface/WaitingTaskHolder.h
+++ b/FWCore/Concurrency/interface/WaitingTaskHolder.h
@@ -20,7 +20,7 @@
 
 // system include files
 #include <cassert>
-#include "tbb/task_group.h"
+#include "oneapi/tbb/task_group.h"
 
 // user include files
 #include "FWCore/Concurrency/interface/WaitingTask.h"

--- a/FWCore/Concurrency/interface/WaitingTaskHolder.h
+++ b/FWCore/Concurrency/interface/WaitingTaskHolder.h
@@ -36,7 +36,8 @@ namespace edm {
 
     WaitingTaskHolder() : m_task(nullptr), m_group(nullptr) {}
 
-    explicit WaitingTaskHolder(tbb::task_group& iGroup, edm::WaitingTask* iTask) : m_task(iTask), m_group(&iGroup) {
+    explicit WaitingTaskHolder(oneapi::tbb::task_group& iGroup, edm::WaitingTask* iTask)
+        : m_task(iTask), m_group(&iGroup) {
       m_task->increment_ref_count();
     }
     ~WaitingTaskHolder() {
@@ -71,10 +72,10 @@ namespace edm {
     bool taskHasFailed() const noexcept { return m_task->exceptionPtr() != nullptr; }
 
     bool hasTask() const noexcept { return m_task != nullptr; }
-    /** since tbb::task_group is thread safe, we can return it non-const from here since
+    /** since oneapi::tbb::task_group is thread safe, we can return it non-const from here since
         the object is not really part of the state of the holder
      */
-    CMS_SA_ALLOW tbb::task_group* group() const noexcept { return m_group; }
+    CMS_SA_ALLOW oneapi::tbb::task_group* group() const noexcept { return m_group; }
     // ---------- static member functions --------------------
 
     // ---------- member functions ---------------------------
@@ -116,7 +117,7 @@ namespace edm {
     }
     // ---------- member data --------------------------------
     WaitingTask* m_task;
-    tbb::task_group* m_group;
+    oneapi::tbb::task_group* m_group;
   };
 }  // namespace edm
 

--- a/FWCore/Concurrency/interface/WaitingTaskList.h
+++ b/FWCore/Concurrency/interface/WaitingTaskList.h
@@ -11,7 +11,7 @@
 
  Usage:
     This class can be used to have tasks wait to be spawned until a resource is available.
- Tasks that want to use the resource are added to the list by calling add(tbb::task*).
+ Tasks that want to use the resource are added to the list by calling add(oneapi::tbb::task*).
  When the resource becomes available one calls doneWaiting() and then any waiting tasks will
  be spawned. If a call to add() is made after doneWaiting() the newly added task will
  immediately be spawned.
@@ -27,7 +27,7 @@
     CalcTask(edm::WaitingTaskList* iWL, Value* v):
     m_waitList(iWL), m_output(v) {}
  
-    tbb::task* execute() {
+    oneapi::tbb::task* execute() {
      std::exception_ptr ptr;
      try {
        *m_output = doCalculation();
@@ -51,15 +51,15 @@
 
  In another part we can start the calculation
  \code
- tbb::task* calc = new(tbb::task::allocate_root()) CalcTask(&waitList,&v);
- tbb::task::spawn(calc);
+ oneapi::tbb::task* calc = new(oneapi::tbb::task::allocate_root()) CalcTask(&waitList,&v);
+ oneapi::tbb::task::spawn(calc);
  \endcode
  
  Finally in some unrelated part of the code we can create tasks that need the calculation
  \code
- tbb::task* t1 = makeTask1(v);
+ oneapi::tbb::task* t1 = makeTask1(v);
  waitList.add(t1);
- tbb::task* t2 = makeTask2(v);
+ oneapi::tbb::task* t2 = makeTask2(v);
  waitList.add(t2);
  \endcode
 
@@ -108,7 +108,7 @@ namespace edm {
        * then be run.
        * Calls to add() and doneWaiting() can safely be done concurrently.
        */
-    void add(tbb::task_group*, WaitingTask*);
+    void add(oneapi::tbb::task_group*, WaitingTask*);
 
     ///Adds task to the waiting list
     /**Calls to add() and doneWaiting() can safely be done concurrently.
@@ -140,7 +140,7 @@ namespace edm {
 
     struct WaitNode {
       WaitingTask* m_task;
-      tbb::task_group* m_group;
+      oneapi::tbb::task_group* m_group;
       std::atomic<WaitNode*> m_next;
       bool m_fromCache;
 
@@ -149,7 +149,7 @@ namespace edm {
       WaitNode* nextNode() const { return m_next; }
     };
 
-    WaitNode* createNode(tbb::task_group* iGroup, WaitingTask* iTask);
+    WaitNode* createNode(oneapi::tbb::task_group* iGroup, WaitingTask* iTask);
 
     // ---------- member data --------------------------------
     std::atomic<WaitNode*> m_head;

--- a/FWCore/Concurrency/interface/WaitingTaskWithArenaHolder.h
+++ b/FWCore/Concurrency/interface/WaitingTaskWithArenaHolder.h
@@ -22,8 +22,8 @@
 #include <exception>
 #include <memory>
 
-#include "tbb/task_arena.h"
-#include "tbb/task_group.h"
+#include "oneapi/tbb/task_arena.h"
+#include "oneapi/tbb/task_group.h"
 
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
 

--- a/FWCore/Concurrency/interface/WaitingTaskWithArenaHolder.h
+++ b/FWCore/Concurrency/interface/WaitingTaskWithArenaHolder.h
@@ -38,7 +38,7 @@ namespace edm {
     // Note that the arena will be the one containing the thread
     // that runs this constructor. This is the arena where you
     // eventually intend for the task to be spawned.
-    explicit WaitingTaskWithArenaHolder(tbb::task_group&, WaitingTask* iTask);
+    explicit WaitingTaskWithArenaHolder(oneapi::tbb::task_group&, WaitingTask* iTask);
 
     // Takes ownership of the underlying task and uses the current
     // arena.
@@ -77,16 +77,16 @@ namespace edm {
 
     bool hasTask() const noexcept;
 
-    /** since tbb::task_group is thread safe, we can return it non-const from here since
+    /** since oneapi::tbb::task_group is thread safe, we can return it non-const from here since
         the object is not really part of the state of the holder
      */
-    CMS_SA_ALLOW tbb::task_group* group() const { return m_group; }
+    CMS_SA_ALLOW oneapi::tbb::task_group* group() const { return m_group; }
 
   private:
     // ---------- member data --------------------------------
     WaitingTask* m_task;
-    tbb::task_group* m_group;
-    std::shared_ptr<tbb::task_arena> m_arena;
+    oneapi::tbb::task_group* m_group;
+    std::shared_ptr<oneapi::tbb::task_arena> m_arena;
   };
 
   template <typename F>

--- a/FWCore/Concurrency/interface/include_first_syncWait.h
+++ b/FWCore/Concurrency/interface/include_first_syncWait.h
@@ -16,17 +16,17 @@ namespace edm {
   template <typename F>
   [[nodiscard]] std::exception_ptr syncWait(F&& iFunc) {
     std::exception_ptr exceptPtr{};
-    //tbb::task::suspend can only be run from within a task running in this arena. For 1 thread,
+    //oneapi::tbb::task::suspend can only be run from within a task running in this arena. For 1 thread,
     // it is often (always?) the case where not such task is being run here. Therefore we need
     // to use a temp task_group to start up such a task.
-    tbb::task_group group;
+    oneapi::tbb::task_group group;
     group.run([&]() {
-      tbb::task::suspend([&](tbb::task::suspend_point tag) {
+      oneapi::tbb::task::suspend([&](oneapi::tbb::task::suspend_point tag) {
         auto waitTask = make_waiting_task([tag, &exceptPtr](std::exception_ptr const* iExcept) {
           if (iExcept) {
             exceptPtr = *iExcept;
           }
-          tbb::task::resume(tag);
+          oneapi::tbb::task::resume(tag);
         });
         iFunc(WaitingTaskHolder(group, waitTask));
       });  //suspend

--- a/FWCore/Concurrency/interface/include_first_syncWait.h
+++ b/FWCore/Concurrency/interface/include_first_syncWait.h
@@ -8,8 +8,8 @@
 //  Created by Chris Jones on 2/24/21.
 //
 #include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
-#include "tbb/task_group.h"
-#include "tbb/task.h"
+#include "oneapi/tbb/task_group.h"
+#include "oneapi/tbb/task.h"
 #include <exception>
 
 namespace edm {

--- a/FWCore/Concurrency/src/SerialTaskQueue.cc
+++ b/FWCore/Concurrency/src/SerialTaskQueue.cc
@@ -12,7 +12,7 @@
 //
 
 // system include files
-#include "tbb/task.h"
+#include "oneapi/tbb/task.h"
 
 // user include files
 #include "FWCore/Concurrency/interface/SerialTaskQueue.h"

--- a/FWCore/Concurrency/src/SerialTaskQueue.cc
+++ b/FWCore/Concurrency/src/SerialTaskQueue.cc
@@ -29,11 +29,12 @@ SerialTaskQueue::~SerialTaskQueue() {
   bool isEmpty = m_tasks.empty();
   bool isTaskChosen = m_taskChosen;
   if ((not isEmpty and not isPaused()) or isTaskChosen) {
-    tbb::task_group g;
+    oneapi::tbb::task_group g;
     g.run([&g, this]() {
-      tbb::task::suspend(
-          [&g, this](tbb::task::suspend_point tag) { push(g, [tag]() { tbb::task::resume(tag); }); });  //suspend
-    });                                                                                                 //group run
+      oneapi::tbb::task::suspend([&g, this](oneapi::tbb::task::suspend_point tag) {
+        push(g, [tag]() { oneapi::tbb::task::resume(tag); });
+      });  //suspend
+    });    //group run
     g.wait();
   }
 }

--- a/FWCore/Concurrency/src/ThreadsController.cc
+++ b/FWCore/Concurrency/src/ThreadsController.cc
@@ -16,8 +16,8 @@
 #include "FWCore/Concurrency/interface/ThreadsController.h"
 
 namespace edm {
-  std::unique_ptr<tbb::global_control> ThreadsController::makeStackSize(size_t iStackSize) {
-    return std::make_unique<tbb::global_control>(tbb::global_control::thread_stack_size, iStackSize);
+  std::unique_ptr<oneapi::tbb::global_control> ThreadsController::makeStackSize(size_t iStackSize) {
+    return std::make_unique<oneapi::tbb::global_control>(oneapi::tbb::global_control::thread_stack_size, iStackSize);
   }
 
 }  // namespace edm

--- a/FWCore/Concurrency/src/WaitingTaskList.cc
+++ b/FWCore/Concurrency/src/WaitingTaskList.cc
@@ -69,7 +69,7 @@ void WaitingTaskList::reset() {
   m_waiting = true;
 }
 
-WaitingTaskList::WaitNode* WaitingTaskList::createNode(tbb::task_group* iGroup, WaitingTask* iTask) {
+WaitingTaskList::WaitNode* WaitingTaskList::createNode(oneapi::tbb::task_group* iGroup, WaitingTask* iTask) {
   unsigned int index = m_lastAssignedCacheIndex++;
 
   WaitNode* returnValue;
@@ -122,7 +122,7 @@ void WaitingTaskList::add(WaitingTaskHolder iTask) {
   }
 }
 
-void WaitingTaskList::add(tbb::task_group* iGroup, WaitingTask* iTask) {
+void WaitingTaskList::add(oneapi::tbb::task_group* iGroup, WaitingTask* iTask) {
   iTask->increment_ref_count();
   if (!m_waiting) {
     if (UNLIKELY(bool(m_exceptionPtr))) {

--- a/FWCore/Concurrency/src/WaitingTaskList.cc
+++ b/FWCore/Concurrency/src/WaitingTaskList.cc
@@ -14,7 +14,7 @@
 // system include files
 
 // user include files
-#include "tbb/task.h"
+#include "oneapi/tbb/task.h"
 #include <cassert>
 #include <memory>
 

--- a/FWCore/Concurrency/src/WaitingTaskWithArenaHolder.cc
+++ b/FWCore/Concurrency/src/WaitingTaskWithArenaHolder.cc
@@ -18,15 +18,17 @@ namespace edm {
   // Note that the arena will be the one containing the thread
   // that runs this constructor. This is the arena where you
   // eventually intend for the task to be spawned.
-  WaitingTaskWithArenaHolder::WaitingTaskWithArenaHolder(tbb::task_group& iGroup, WaitingTask* iTask)
-      : m_task(iTask), m_group(&iGroup), m_arena(std::make_shared<tbb::task_arena>(tbb::task_arena::attach())) {
+  WaitingTaskWithArenaHolder::WaitingTaskWithArenaHolder(oneapi::tbb::task_group& iGroup, WaitingTask* iTask)
+      : m_task(iTask),
+        m_group(&iGroup),
+        m_arena(std::make_shared<oneapi::tbb::task_arena>(oneapi::tbb::task_arena::attach())) {
     m_task->increment_ref_count();
   }
 
   WaitingTaskWithArenaHolder::WaitingTaskWithArenaHolder(WaitingTaskHolder&& iTask)
       : m_task(iTask.release_no_decrement()),
         m_group(iTask.group()),
-        m_arena(std::make_shared<tbb::task_arena>(tbb::task_arena::attach())) {}
+        m_arena(std::make_shared<oneapi::tbb::task_arena>(oneapi::tbb::task_arena::attach())) {}
 
   WaitingTaskWithArenaHolder::~WaitingTaskWithArenaHolder() {
     if (m_task) {

--- a/FWCore/Concurrency/src/setNThreads.cc
+++ b/FWCore/Concurrency/src/setNThreads.cc
@@ -4,7 +4,7 @@
 //
 //  Created by Chris Jones on 7/24/20.
 //
-#include "tbb/task_arena.h"
+#include "oneapi/tbb/task_arena.h"
 #include "FWCore/Concurrency/interface/setNThreads.h"
 
 namespace edm {

--- a/FWCore/Concurrency/src/setNThreads.cc
+++ b/FWCore/Concurrency/src/setNThreads.cc
@@ -15,7 +15,7 @@ namespace edm {
     oPtr.reset();
     if (0 == iNThreads) {
       //Allow TBB to decide how many threads. This is normally the number of CPUs in the machine.
-      iNThreads = tbb::this_task_arena::max_concurrency();
+      iNThreads = oneapi::tbb::this_task_arena::max_concurrency();
     }
     oPtr = std::make_unique<ThreadsController>(static_cast<int>(iNThreads), iStackSize);
 

--- a/FWCore/Concurrency/test/TestTBB.cc
+++ b/FWCore/Concurrency/test/TestTBB.cc
@@ -1,8 +1,8 @@
 #include <iostream>
 #include <stdlib.h>
-#include "tbb/global_control.h"
-#include "tbb/parallel_for.h"
-#include "tbb/blocked_range.h"
+#include "oneapi/tbb/global_control.h"
+#include "oneapi/tbb/parallel_for.h"
+#include "oneapi/tbb/blocked_range.h"
 
 using namespace tbb;
 using namespace std;

--- a/FWCore/Concurrency/test/limitedtaskqueue_t.cppunit.cpp
+++ b/FWCore/Concurrency/test/limitedtaskqueue_t.cppunit.cpp
@@ -40,7 +40,7 @@ void LimitedTaskQueue_test::testPush() {
     edm::LimitedTaskQueue queue{1};
     {
       std::atomic<int> waitingTasks{3};
-      tbb::task_group group;
+      oneapi::tbb::task_group group;
 
       queue.push(group, [&count, &waitingTasks] {
         CPPUNIT_ASSERT(count++ == 0);
@@ -74,7 +74,7 @@ void LimitedTaskQueue_test::testPush() {
     edm::LimitedTaskQueue queue{kMax};
     {
       std::atomic<int> waitingTasks{3};
-      tbb::task_group group;
+      oneapi::tbb::task_group group;
 
       queue.push(group, [&count, &waitingTasks] {
         CPPUNIT_ASSERT(count++ < kMax);
@@ -112,7 +112,7 @@ void LimitedTaskQueue_test::testPause() {
   {
     {
       std::atomic<int> waitingTasks{3};
-      tbb::task_group group;
+      oneapi::tbb::task_group group;
 
       edm::LimitedTaskQueue::Resumer resumer;
       std::atomic<bool> resumerSet{false};
@@ -173,7 +173,7 @@ void LimitedTaskQueue_test::testPause() {
 
 void LimitedTaskQueue_test::stressTest() {
   //NOTE: group needs to last longer than queue
-  tbb::task_group group;
+  oneapi::tbb::task_group group;
 
   constexpr unsigned int kMax = 3;
   edm::LimitedTaskQueue queue{kMax};

--- a/FWCore/Concurrency/test/limitedtaskqueue_t.cppunit.cpp
+++ b/FWCore/Concurrency/test/limitedtaskqueue_t.cppunit.cpp
@@ -11,7 +11,7 @@
 #include <unistd.h>
 #include <memory>
 #include <atomic>
-#include "tbb/task_arena.h"
+#include "oneapi/tbb/task_arena.h"
 #include "FWCore/Concurrency/interface/WaitingTask.h"
 #include "FWCore/Concurrency/interface/LimitedTaskQueue.h"
 #include "FWCore/Concurrency/interface/FunctorTask.h"

--- a/FWCore/Concurrency/test/serialtaskqueue_t.cppunit.cpp
+++ b/FWCore/Concurrency/test/serialtaskqueue_t.cppunit.cpp
@@ -11,7 +11,7 @@
 #include <unistd.h>
 #include <memory>
 #include <atomic>
-#include "tbb/task_arena.h"
+#include "oneapi/tbb/task_arena.h"
 #include "FWCore/Concurrency/interface/WaitingTask.h"
 #include "FWCore/Concurrency/interface/SerialTaskQueue.h"
 #include "FWCore/Concurrency/interface/FunctorTask.h"

--- a/FWCore/Concurrency/test/serialtaskqueue_t.cppunit.cpp
+++ b/FWCore/Concurrency/test/serialtaskqueue_t.cppunit.cpp
@@ -39,7 +39,7 @@ void SerialTaskQueue_test::testPush() {
   edm::SerialTaskQueue queue;
   {
     std::atomic<unsigned int> waitingTasks{3};
-    tbb::task_group group;
+    oneapi::tbb::task_group group;
 
     queue.push(group, [&count, &waitingTasks] {
       CPPUNIT_ASSERT(count++ == 0);
@@ -74,7 +74,7 @@ void SerialTaskQueue_test::testPause() {
     queue.pause();
     {
       std::atomic<unsigned int> waitingTasks{1};
-      tbb::task_group group;
+      oneapi::tbb::task_group group;
 
       queue.push(group, [&count, &waitingTasks] {
         CPPUNIT_ASSERT(count++ == 0);
@@ -91,7 +91,7 @@ void SerialTaskQueue_test::testPause() {
 
     {
       std::atomic<unsigned int> waitingTasks{3};
-      tbb::task_group group;
+      oneapi::tbb::task_group group;
 
       queue.push(group, [&count, &queue, &waitingTasks] {
         queue.pause();
@@ -120,7 +120,7 @@ void SerialTaskQueue_test::testPause() {
 
 void SerialTaskQueue_test::stressTest() {
   //note group needs to live longer than queue
-  tbb::task_group group;
+  oneapi::tbb::task_group group;
   edm::SerialTaskQueue queue;
 
   unsigned int index = 100;

--- a/FWCore/Concurrency/test/serialtaskqueuechain_t.cppunit.cpp
+++ b/FWCore/Concurrency/test/serialtaskqueuechain_t.cppunit.cpp
@@ -13,7 +13,7 @@
 #include <atomic>
 #include <thread>
 #include <iostream>
-#include "tbb/task.h"
+#include "oneapi/tbb/task.h"
 #include "FWCore/Concurrency/interface/SerialTaskQueueChain.h"
 
 class SerialTaskQueueChain_test : public CppUnit::TestFixture {

--- a/FWCore/Concurrency/test/serialtaskqueuechain_t.cppunit.cpp
+++ b/FWCore/Concurrency/test/serialtaskqueuechain_t.cppunit.cpp
@@ -40,7 +40,7 @@ void SerialTaskQueueChain_test::testPush() {
                                                                std::make_shared<edm::SerialTaskQueue>()};
   edm::SerialTaskQueueChain chain(queues);
   {
-    tbb::task_group group;
+    oneapi::tbb::task_group group;
     std::atomic<int> waiting{3};
     chain.push(group, [&count, &waiting] {
       CPPUNIT_ASSERT(count++ == 0);
@@ -75,7 +75,7 @@ void SerialTaskQueueChain_test::testPushOne() {
   std::vector<std::shared_ptr<edm::SerialTaskQueue>> queues = {std::make_shared<edm::SerialTaskQueue>()};
   edm::SerialTaskQueueChain chain(queues);
   {
-    tbb::task_group group;
+    oneapi::tbb::task_group group;
     std::atomic<int> waiting{3};
 
     chain.push(group, [&count, &waiting] {
@@ -122,7 +122,7 @@ void SerialTaskQueueChain_test::stressTest() {
   unsigned int index = 100;
   const unsigned int nTasks = 1000;
   while (0 != --index) {
-    tbb::task_group group;
+    oneapi::tbb::task_group group;
     std::atomic<int> waiting{2};
     std::atomic<unsigned int> count{0};
 

--- a/FWCore/Concurrency/test/test_catch2_WaitingTaskChain.cc
+++ b/FWCore/Concurrency/test/test_catch2_WaitingTaskChain.cc
@@ -8,7 +8,7 @@
 #define CATCH_CONFIG_MAIN
 #include "catch.hpp"
 
-#include "tbb/global_control.h"
+#include "oneapi/tbb/global_control.h"
 
 #include "FWCore/Concurrency/interface/chain_first.h"
 

--- a/FWCore/Concurrency/test/test_catch2_WaitingTaskChain.cc
+++ b/FWCore/Concurrency/test/test_catch2_WaitingTaskChain.cc
@@ -13,14 +13,14 @@
 #include "FWCore/Concurrency/interface/chain_first.h"
 
 TEST_CASE("Test chain::first", "[chain::first]") {
-  tbb::global_control control(tbb::global_control::max_allowed_parallelism, 1);
+  oneapi::tbb::global_control control(oneapi::tbb::global_control::max_allowed_parallelism, 1);
 
   SECTION("no explicit exception handling") {
     SECTION("first | lastTask") {
       std::atomic<int> count{0};
 
       edm::FinalWaitingTask waitTask;
-      tbb::task_group group;
+      oneapi::tbb::task_group group;
       {
         using namespace edm::waiting_task::chain;
         auto h = first([&count](edm::WaitingTaskHolder h) {
@@ -41,7 +41,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
       std::atomic<int> count{0};
 
       edm::FinalWaitingTask waitTask;
-      tbb::task_group group;
+      oneapi::tbb::task_group group;
       {
         using namespace edm::waiting_task::chain;
         auto h = first([&count](auto h) {
@@ -66,7 +66,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
       std::atomic<int> count{0};
 
       edm::FinalWaitingTask waitTask;
-      tbb::task_group group;
+      oneapi::tbb::task_group group;
       {
         using namespace edm::waiting_task::chain;
         auto h = first([&count](auto h) {
@@ -95,7 +95,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
       std::atomic<int> count{0};
 
       edm::FinalWaitingTask waitTask;
-      tbb::task_group group;
+      oneapi::tbb::task_group group;
       {
         using namespace edm::waiting_task::chain;
         first([&count](auto h) {
@@ -119,7 +119,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
       std::atomic<int> count{0};
 
       edm::FinalWaitingTask waitTask;
-      tbb::task_group group;
+      oneapi::tbb::task_group group;
       {
         using namespace edm::waiting_task::chain;
         auto h = first([&count](edm::WaitingTaskHolder h) {
@@ -140,7 +140,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
       std::atomic<int> count{0};
 
       edm::FinalWaitingTask waitTask;
-      tbb::task_group group;
+      oneapi::tbb::task_group group;
       {
         using namespace edm::waiting_task::chain;
         auto h = first([&count](edm::WaitingTaskHolder h) {
@@ -162,7 +162,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
       std::atomic<int> count{0};
 
       edm::FinalWaitingTask waitTask;
-      tbb::task_group group;
+      oneapi::tbb::task_group group;
       {
         using namespace edm::waiting_task::chain;
         auto h = first([&count](auto h) {
@@ -194,7 +194,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
       std::atomic<int> count{0};
 
       edm::FinalWaitingTask waitTask;
-      tbb::task_group group;
+      oneapi::tbb::task_group group;
       {
         using namespace edm::waiting_task::chain;
         auto h = first([&count](std::exception_ptr const* iPtr, edm::WaitingTaskHolder h) {
@@ -216,7 +216,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
       std::atomic<int> count{0};
 
       edm::FinalWaitingTask waitTask;
-      tbb::task_group group;
+      oneapi::tbb::task_group group;
       {
         using namespace edm::waiting_task::chain;
         auto h = first([&count](std::exception_ptr const* iPtr, auto h) {
@@ -243,7 +243,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
       std::atomic<int> count{0};
 
       edm::FinalWaitingTask waitTask;
-      tbb::task_group group;
+      oneapi::tbb::task_group group;
       {
         using namespace edm::waiting_task::chain;
         auto h = first([&count](std::exception_ptr const* iPtr, auto h) {
@@ -275,7 +275,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
       std::atomic<int> count{0};
 
       edm::FinalWaitingTask waitTask;
-      tbb::task_group group;
+      oneapi::tbb::task_group group;
       {
         using namespace edm::waiting_task::chain;
         auto h = first([&count](std::exception_ptr const* iPtr, edm::WaitingTaskHolder h) {
@@ -297,7 +297,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
       std::atomic<int> count{0};
 
       edm::FinalWaitingTask waitTask;
-      tbb::task_group group;
+      oneapi::tbb::task_group group;
       {
         using namespace edm::waiting_task::chain;
         auto h = first([&count](std::exception_ptr const* iPtr, edm::WaitingTaskHolder h) {
@@ -328,7 +328,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
       std::atomic<int> exceptCount{0};
 
       edm::FinalWaitingTask waitTask;
-      tbb::task_group group;
+      oneapi::tbb::task_group group;
       {
         using namespace edm::waiting_task::chain;
         auto h = first(ifException([&exceptCount](std::exception_ptr const& iPtr) {
@@ -354,7 +354,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
       std::atomic<int> exceptCount{0};
 
       edm::FinalWaitingTask waitTask;
-      tbb::task_group group;
+      oneapi::tbb::task_group group;
       {
         using namespace edm::waiting_task::chain;
         auto h = first(ifException([&exceptCount](std::exception_ptr const& iPtr) {
@@ -387,7 +387,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
       std::atomic<int> exceptCount{0};
 
       edm::FinalWaitingTask waitTask;
-      tbb::task_group group;
+      oneapi::tbb::task_group group;
       {
         using namespace edm::waiting_task::chain;
         auto h = first(ifException([&exceptCount](std::exception_ptr const& iPtr) {
@@ -427,7 +427,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
       std::atomic<int> exceptCount{0};
 
       edm::FinalWaitingTask waitTask;
-      tbb::task_group group;
+      oneapi::tbb::task_group group;
       {
         using namespace edm::waiting_task::chain;
         auto h = first(ifException([&exceptCount](std::exception_ptr const& iPtr) {
@@ -468,7 +468,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
       std::atomic<int> count{0};
 
       edm::FinalWaitingTask waitTask;
-      tbb::task_group group;
+      oneapi::tbb::task_group group;
       {
         using namespace edm::waiting_task::chain;
         first([&count](auto h) {
@@ -492,7 +492,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
       std::atomic<int> count{0};
 
       edm::FinalWaitingTask waitTask;
-      tbb::task_group group;
+      oneapi::tbb::task_group group;
       {
         using namespace edm::waiting_task::chain;
         first([&count](auto h) {

--- a/FWCore/Concurrency/test/waitingtasklist_t.cppunit.cpp
+++ b/FWCore/Concurrency/test/waitingtasklist_t.cppunit.cpp
@@ -12,7 +12,7 @@
 #include <memory>
 #include <atomic>
 #include <thread>
-#include "tbb/task.h"
+#include "oneapi/tbb/task.h"
 #include "FWCore/Concurrency/interface/WaitingTaskList.h"
 
 class WaitingTaskList_test : public CppUnit::TestFixture {

--- a/FWCore/Concurrency/test/waitingtasklist_t.cppunit.cpp
+++ b/FWCore/Concurrency/test/waitingtasklist_t.cppunit.cpp
@@ -75,7 +75,7 @@ void WaitingTaskList_test::addThenDone() {
 
     auto t = new TestCalledTask{called, excPtr};
 
-    tbb::task_group group;
+    oneapi::tbb::task_group group;
     waitList.add(edm::WaitingTaskHolder(group, t));
 
     usleep(10);
@@ -95,7 +95,7 @@ void WaitingTaskList_test::addThenDone() {
 
     auto t = new TestCalledTask{called, excPtr};
 
-    tbb::task_group group;
+    oneapi::tbb::task_group group;
 
     waitList.add(edm::WaitingTaskHolder(group, t));
 
@@ -115,7 +115,7 @@ void WaitingTaskList_test::doneThenAdd() {
 
   edm::WaitingTaskList waitList;
   {
-    tbb::task_group group;
+    oneapi::tbb::task_group group;
 
     auto t = new TestCalledTask{called, excPtr};
 
@@ -137,7 +137,7 @@ void WaitingTaskList_test::addThenDoneFailed() {
 
     auto t = new TestCalledTask{called, excPtr};
 
-    tbb::task_group group;
+    oneapi::tbb::task_group group;
 
     waitList.add(edm::WaitingTaskHolder(group, t));
 
@@ -161,7 +161,7 @@ void WaitingTaskList_test::doneThenAddFailed() {
 
     waitList.doneWaiting(std::make_exception_ptr(std::string("failed")));
 
-    tbb::task_group group;
+    oneapi::tbb::task_group group;
 
     waitList.add(edm::WaitingTaskHolder(group, t));
     group.wait();
@@ -180,7 +180,7 @@ namespace {
 
 void WaitingTaskList_test::stressTest() {
   edm::WaitingTaskList waitList;
-  tbb::task_group group;
+  oneapi::tbb::task_group group;
 
   unsigned int index = 1000;
   const unsigned int nTasks = 10000;

--- a/FWCore/Framework/bin/cmsRun.cpp
+++ b/FWCore/Framework/bin/cmsRun.cpp
@@ -293,7 +293,7 @@ int main(int argc, char* argv[]) {
         edm::MessageDrop::instance()->jobMode = jobMode;
       }
 
-      tbb::task_arena arena(nThreads);
+      oneapi::tbb::task_arena arena(nThreads);
       arena.execute([&]() {
         context = "Constructing the EventProcessor";
         EventProcessorWithSentry procTmp(

--- a/FWCore/Framework/bin/cmsRun.cpp
+++ b/FWCore/Framework/bin/cmsRun.cpp
@@ -31,7 +31,7 @@ PSet script.   See notes in EventProcessor.cpp for details about it.
 #include "TError.h"
 
 #include "boost/program_options.hpp"
-#include "tbb/task_arena.h"
+#include "oneapi/tbb/task_arena.h"
 
 #include <cstring>
 #include <exception>

--- a/FWCore/Framework/interface/Callback.h
+++ b/FWCore/Framework/interface/Callback.h
@@ -171,7 +171,7 @@ namespace edm {
         return static_cast<bool>(postMayGetProxies_);
       }
 
-      void runProducerAsync(tbb::task_group* iGroup,
+      void runProducerAsync(oneapi::tbb::task_group* iGroup,
                             std::exception_ptr const* iExcept,
                             EventSetupRecordImpl const* iRecord,
                             EventSetupImpl const* iEventSetupImpl,

--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -307,7 +307,7 @@ namespace edm {
     // really needed, we should remove them.
 
     //Guarantee that task group is the last to be destroyed
-    tbb::task_group taskGroup_;
+    oneapi::tbb::task_group taskGroup_;
 
     std::shared_ptr<ActivityRegistry> actReg_;  // We do not use propagate_const because the registry itself is mutable.
     edm::propagate_const<std::shared_ptr<ProductRegistry>> preg_;

--- a/FWCore/Framework/interface/EventSetupsController.h
+++ b/FWCore/Framework/interface/EventSetupsController.h
@@ -188,7 +188,7 @@ namespace edm {
     };
 
     void synchronousEventSetupForInstance(IOVSyncValue const& syncValue,
-                                          tbb::task_group& iGroup,
+                                          oneapi::tbb::task_group& iGroup,
                                           eventsetup::EventSetupsController& espController);
   }  // namespace eventsetup
 }  // namespace edm

--- a/FWCore/Framework/interface/MergeableRunProductMetadata.h
+++ b/FWCore/Framework/interface/MergeableRunProductMetadata.h
@@ -126,7 +126,7 @@ namespace edm {
 
     bool gotLumisFromIndexIntoFile() const { return gotLumisFromIndexIntoFile_; }
 
-    tbb::concurrent_vector<LuminosityBlockNumber_t> const& lumisProcessed() const { return lumisProcessed_; }
+    oneapi::tbb::concurrent_vector<LuminosityBlockNumber_t> const& lumisProcessed() const { return lumisProcessed_; }
 
   private:
     void mergeLumisFromIndexIntoFile();
@@ -148,7 +148,7 @@ namespace edm {
     std::vector<LuminosityBlockNumber_t> lumisFromIndexIntoFile_;
     bool gotLumisFromIndexIntoFile_ = false;
 
-    tbb::concurrent_vector<LuminosityBlockNumber_t> lumisProcessed_;
+    oneapi::tbb::concurrent_vector<LuminosityBlockNumber_t> lumisProcessed_;
   };
 }  // namespace edm
 #endif

--- a/FWCore/Framework/interface/MergeableRunProductMetadata.h
+++ b/FWCore/Framework/interface/MergeableRunProductMetadata.h
@@ -39,7 +39,7 @@ and does not do managing mergeable run products.
 #include "FWCore/Framework/interface/MergeableRunProductProcesses.h"
 #include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
 
-#include "tbb/concurrent_vector.h"
+#include "oneapi/tbb/concurrent_vector.h"
 
 #include <string>
 #include <vector>

--- a/FWCore/Framework/interface/Path.h
+++ b/FWCore/Framework/interface/Path.h
@@ -149,13 +149,13 @@ namespace edm {
                         ServiceToken const&,
                         StreamID const&,
                         StreamContext const*,
-                        tbb::task_group& iGroup);
+                        oneapi::tbb::task_group& iGroup);
     void runNextWorkerAsync(unsigned int iNextModuleIndex,
                             EventTransitionInfo const&,
                             ServiceToken const&,
                             StreamID const&,
                             StreamContext const*,
-                            tbb::task_group& iGroup);
+                            oneapi::tbb::task_group& iGroup);
   };
 
   namespace {

--- a/FWCore/Framework/interface/StreamSchedule.h
+++ b/FWCore/Framework/interface/StreamSchedule.h
@@ -446,7 +446,7 @@ namespace edm {
         task->execute();
       });
     } else {
-      tbb::task_arena arena{tbb::task_arena::attach()};
+      oneapi::tbb::task_arena arena{oneapi::tbb::task_arena::attach()};
       arena.enqueue([task]() {
         TaskSentry s{task};
         task->execute();

--- a/FWCore/Framework/interface/maker/Worker.h
+++ b/FWCore/Framework/interface/maker/Worker.h
@@ -104,7 +104,7 @@ namespace edm {
       operator bool() { return serial_ != nullptr or limited_ != nullptr; }
 
       template <class F>
-      void push(tbb::task_group& iG, F&& iF) {
+      void push(oneapi::tbb::task_group& iG, F&& iF) {
         if (serial_) {
           serial_->push(iG, iF);
         } else {
@@ -135,10 +135,10 @@ namespace edm {
     virtual SerialTaskQueue* globalLuminosityBlocksQueue() = 0;
 
     void prePrefetchSelectionAsync(
-        tbb::task_group&, WaitingTask* task, ServiceToken const&, StreamID stream, EventPrincipal const*);
+        oneapi::tbb::task_group&, WaitingTask* task, ServiceToken const&, StreamID stream, EventPrincipal const*);
 
     void prePrefetchSelectionAsync(
-        tbb::task_group&, WaitingTask* task, ServiceToken const&, StreamID stream, void const*) {
+        oneapi::tbb::task_group&, WaitingTask* task, ServiceToken const&, StreamID stream, void const*) {
       assert(false);
     }
 
@@ -377,7 +377,7 @@ namespace edm {
                     StreamID streamID,
                     ParentContext const& parentContext,
                     typename T::Context const* context,
-                    tbb::task_group* iGroup)
+                    oneapi::tbb::task_group* iGroup)
           : m_worker(worker),
             m_transitionInfo(transitionInfo),
             m_streamID(streamID),
@@ -465,7 +465,7 @@ namespace edm {
       ParentContext const m_parentContext;
       typename T::Context const* m_context;
       ServiceWeakToken m_serviceToken;
-      tbb::task_group* m_group;
+      oneapi::tbb::task_group* m_group;
     };
 
     // AcquireTask is only used for the Event case, but we define
@@ -551,7 +551,7 @@ namespace edm {
     class HandleExternalWorkExceptionTask : public WaitingTask {
     public:
       HandleExternalWorkExceptionTask(Worker* worker,
-                                      tbb::task_group* group,
+                                      oneapi::tbb::task_group* group,
                                       WaitingTask* runModuleTask,
                                       ParentContext const& parentContext);
 
@@ -560,7 +560,7 @@ namespace edm {
     private:
       Worker* m_worker;
       WaitingTask* m_runModuleTask;
-      tbb::task_group* m_group;
+      oneapi::tbb::task_group* m_group;
       ParentContext const m_parentContext;
     };
 

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -685,7 +685,7 @@ namespace edm {
     actReg_->postBeginJobSignal_();
 
     FinalWaitingTask last;
-    tbb::task_group group;
+    oneapi::tbb::task_group group;
     using namespace edm::waiting_task::chain;
     first([this](auto nextTask) {
       for (unsigned int i = 0; i < preallocations_.numberOfStreams(); ++i) {
@@ -715,7 +715,7 @@ namespace edm {
     using namespace edm::waiting_task::chain;
 
     edm::FinalWaitingTask waitTask;
-    tbb::task_group group;
+    oneapi::tbb::task_group group;
 
     {
       //handle endStream transitions
@@ -1494,7 +1494,7 @@ namespace edm {
     }
 
     unsigned int streamIndex = 0;
-    tbb::task_arena arena{tbb::task_arena::attach()};
+    oneapi::tbb::task_arena arena{oneapi::tbb::task_arena::attach()};
     for (; streamIndex < preallocations_.numberOfStreams() - 1; ++streamIndex) {
       arena.enqueue([this, streamIndex, h = iHolder]() { handleNextEventForStreamAsync(h, streamIndex); });
     }

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -87,7 +87,7 @@
 #include <sys/ipc.h>
 #include <sys/msg.h>
 
-#include "tbb/task.h"
+#include "oneapi/tbb/task.h"
 
 //Used for CPU affinity
 #ifndef __APPLE__

--- a/FWCore/Framework/src/EventSetupsController.cc
+++ b/FWCore/Framework/src/EventSetupsController.cc
@@ -410,7 +410,7 @@ namespace edm {
     }
 
     void synchronousEventSetupForInstance(IOVSyncValue const& syncValue,
-                                          tbb::task_group& iGroup,
+                                          oneapi::tbb::task_group& iGroup,
                                           eventsetup::EventSetupsController& espController) {
       FinalWaitingTask waitUntilIOVInitializationCompletes;
 

--- a/FWCore/Framework/src/OutputModuleCommunicatorT.cc
+++ b/FWCore/Framework/src/OutputModuleCommunicatorT.cc
@@ -25,17 +25,17 @@
 namespace {
 
   template <typename F>
-  void async(edm::one::OutputModuleBase& iMod, tbb::task_group& iGroup, F&& iFunc) {
+  void async(edm::one::OutputModuleBase& iMod, oneapi::tbb::task_group& iGroup, F&& iFunc) {
     iMod.sharedResourcesAcquirer().serialQueueChain().push(iGroup, std::move(iFunc));
   }
 
   template <typename F>
-  void async(edm::limited::OutputModuleBase& iMod, tbb::task_group& iGroup, F&& iFunc) {
+  void async(edm::limited::OutputModuleBase& iMod, oneapi::tbb::task_group& iGroup, F&& iFunc) {
     iMod.queue().push(iGroup, std::move(iFunc));
   }
 
   template <typename F>
-  void async(edm::global::OutputModuleBase&, tbb::task_group& iGroup, F iFunc) {
+  void async(edm::global::OutputModuleBase&, oneapi::tbb::task_group& iGroup, F iFunc) {
     //NOTE, need the functor since group can not run a 'mutable' lambda
     auto t = edm::make_functor_task(iFunc);
     iGroup.run([t]() {

--- a/FWCore/Framework/src/Path.cc
+++ b/FWCore/Framework/src/Path.cc
@@ -247,7 +247,7 @@ namespace edm {
                             ServiceToken const& iToken,
                             StreamID const& iID,
                             StreamContext const* iContext,
-                            tbb::task_group& iGroup) {
+                            oneapi::tbb::task_group& iGroup) {
     EventPrincipal const& iEP = iInfo.principal();
     ServiceRegistry::Operate guard(iToken);
 
@@ -350,7 +350,7 @@ namespace edm {
                                 ServiceToken const& iToken,
                                 StreamID const& iID,
                                 StreamContext const* iContext,
-                                tbb::task_group& iGroup) {
+                                oneapi::tbb::task_group& iGroup) {
     //Figure out which next modules can run concurrently
     const int firstModuleIndex = iNextModuleIndex;
     int lastModuleIndex = firstModuleIndex;

--- a/FWCore/Framework/src/ProductResolvers.cc
+++ b/FWCore/Framework/src/ProductResolvers.cc
@@ -952,7 +952,7 @@ namespace edm {
                                  ModuleCallingContext const* iMCC,
                                  bool iSkipCurrentProcess,
                                  ServiceToken iToken,
-                                 tbb::task_group* iGroup)
+                                 oneapi::tbb::task_group* iGroup)
           : resolver_(iResolver),
             principal_(iPrincipal),
             sra_(iSRA),
@@ -979,7 +979,7 @@ namespace edm {
       Principal const* principal_;
       SharedResourcesAcquirer* sra_;
       ModuleCallingContext const* mcc_;
-      tbb::task_group* group_;
+      oneapi::tbb::task_group* group_;
       ServiceWeakToken serviceToken_;
       unsigned int index_;
       bool skipCurrentProcess_;
@@ -1016,7 +1016,7 @@ namespace edm {
                                                           SharedResourcesAcquirer* sra,
                                                           ModuleCallingContext const* mcc,
                                                           ServiceToken token,
-                                                          tbb::task_group* group) const {
+                                                          oneapi::tbb::task_group* group) const {
     std::vector<unsigned int> const& lookupProcessOrder = principal.lookupProcessOrder();
     auto index = iProcessingIndex;
 

--- a/FWCore/Framework/src/ProductResolvers.h
+++ b/FWCore/Framework/src/ProductResolvers.h
@@ -493,7 +493,7 @@ namespace edm {
                                   SharedResourcesAcquirer* sra,
                                   ModuleCallingContext const* mcc,
                                   ServiceToken token,
-                                  tbb::task_group*) const;
+                                  oneapi::tbb::task_group*) const;
 
     bool dataValidFromResolver(unsigned int iProcessingIndex,
                                Principal const& principal,

--- a/FWCore/Framework/src/RecordDependencyRegister.cc
+++ b/FWCore/Framework/src/RecordDependencyRegister.cc
@@ -23,13 +23,13 @@ namespace edm {
         std::size_t operator()(EventSetupRecordKey const& iKey) const { return iKey.type().value().hash_code(); }
       };
 
-      tbb::concurrent_unordered_map<EventSetupRecordKey, DepFunction, KeyHash>& getMap() {
-        static tbb::concurrent_unordered_map<EventSetupRecordKey, DepFunction, KeyHash> s_map;
+      oneapi::tbb::concurrent_unordered_map<EventSetupRecordKey, DepFunction, KeyHash>& getMap() {
+        static oneapi::tbb::concurrent_unordered_map<EventSetupRecordKey, DepFunction, KeyHash> s_map;
         return s_map;
       }
 
-      tbb::concurrent_unordered_map<EventSetupRecordKey, bool, KeyHash>& getAllowMap() {
-        static tbb::concurrent_unordered_map<EventSetupRecordKey, bool, KeyHash> s_allow_map;
+      oneapi::tbb::concurrent_unordered_map<EventSetupRecordKey, bool, KeyHash>& getAllowMap() {
+        static oneapi::tbb::concurrent_unordered_map<EventSetupRecordKey, bool, KeyHash> s_allow_map;
         return s_allow_map;
       }
     }  // namespace

--- a/FWCore/Framework/src/RecordDependencyRegister.cc
+++ b/FWCore/Framework/src/RecordDependencyRegister.cc
@@ -11,7 +11,7 @@
 //
 
 // system include files
-#include "tbb/concurrent_unordered_map.h"
+#include "oneapi/tbb/concurrent_unordered_map.h"
 
 // user include files
 #include "FWCore/Framework/interface/RecordDependencyRegister.h"

--- a/FWCore/Framework/src/SynchronousEventSetupsController.cc
+++ b/FWCore/Framework/src/SynchronousEventSetupsController.cc
@@ -22,7 +22,7 @@ namespace edm {
   namespace eventsetup {
 
     SynchronousEventSetupsController::SynchronousEventSetupsController()
-        : globalControl_(tbb::global_control::max_allowed_parallelism, 1) {}
+        : globalControl_(oneapi::tbb::global_control::max_allowed_parallelism, 1) {}
 
     SynchronousEventSetupsController::~SynchronousEventSetupsController() {
       FinalWaitingTask finalTask;

--- a/FWCore/Framework/src/SynchronousEventSetupsController.h
+++ b/FWCore/Framework/src/SynchronousEventSetupsController.h
@@ -45,8 +45,8 @@ namespace edm {
       void eventSetupForInstance(IOVSyncValue const&);
 
     private:
-      tbb::global_control globalControl_;
-      tbb::task_group taskGroup_;
+      oneapi::tbb::global_control globalControl_;
+      oneapi::tbb::task_group taskGroup_;
       EventSetupsController controller_;
     };
   }  // namespace eventsetup

--- a/FWCore/Framework/src/SynchronousEventSetupsController.h
+++ b/FWCore/Framework/src/SynchronousEventSetupsController.h
@@ -20,8 +20,8 @@
 
 #include "FWCore/Framework/interface/EventSetupsController.h"
 
-#include "tbb/task_group.h"
-#include "tbb/global_control.h"
+#include "oneapi/tbb/task_group.h"
+#include "oneapi/tbb/global_control.h"
 
 namespace edm {
 

--- a/FWCore/Framework/src/Worker.cc
+++ b/FWCore/Framework/src/Worker.cc
@@ -147,7 +147,7 @@ namespace edm {
     return true;
   }
 
-  void Worker::prePrefetchSelectionAsync(tbb::task_group& group,
+  void Worker::prePrefetchSelectionAsync(oneapi::tbb::task_group& group,
                                          WaitingTask* successTask,
                                          ServiceToken const& token,
                                          StreamID id,
@@ -404,7 +404,7 @@ namespace edm {
   }
 
   Worker::HandleExternalWorkExceptionTask::HandleExternalWorkExceptionTask(Worker* worker,
-                                                                           tbb::task_group* group,
+                                                                           oneapi::tbb::task_group* group,
                                                                            WaitingTask* runModuleTask,
                                                                            ParentContext const& parentContext)
       : m_worker(worker), m_runModuleTask(runModuleTask), m_group(group), m_parentContext(parentContext) {}

--- a/FWCore/Framework/test/callback_t.cppunit.cc
+++ b/FWCore/Framework/test/callback_t.cppunit.cc
@@ -45,7 +45,7 @@ namespace callbacktest {
 
   struct Queue {
     template <typename T>
-    void push(tbb::task_group&, T&& iT) {
+    void push(oneapi::tbb::task_group&, T&& iT) {
       iT();
     }
   };
@@ -109,7 +109,7 @@ namespace {
     edm::eventsetup::EventSetupRecordImpl rec(edm::eventsetup::EventSetupRecordKey::makeKey<callbacktest::Record>(),
                                               &ar);
     edm::FinalWaitingTask task;
-    tbb::task_group group;
+    oneapi::tbb::task_group group;
     edm::ServiceToken token;
     iCallback.prefetchAsync(edm::WaitingTaskHolder(group, &task), &rec, nullptr, token, edm::ESParentContext{});
     do {

--- a/FWCore/Framework/test/dependentrecord_t.cppunit.cc
+++ b/FWCore/Framework/test/dependentrecord_t.cppunit.cc
@@ -759,7 +759,7 @@ namespace {
         auto rec = iImpl.findImpl(recs[i]);
         if (rec) {
           edm::FinalWaitingTask waitTask;
-          tbb::task_group group;
+          oneapi::tbb::task_group group;
           edm::ServiceToken token;
           rec->prefetchAsync(
               edm::WaitingTaskHolder(group, &waitTask), proxies[i], &iImpl, token, edm::ESParentContext{});
@@ -788,7 +788,7 @@ namespace {
         auto rec = iImpl.findImpl(recs[i]);
         if (rec) {
           edm::FinalWaitingTask waitTask;
-          tbb::task_group group;
+          oneapi::tbb::task_group group;
           edm::ServiceToken token;
           rec->prefetchAsync(
               edm::WaitingTaskHolder(group, &waitTask), proxies[i], &iImpl, token, edm::ESParentContext{});

--- a/FWCore/Framework/test/esproducer_t.cppunit.cc
+++ b/FWCore/Framework/test/esproducer_t.cppunit.cc
@@ -57,7 +57,7 @@ namespace {
         auto rec = iImpl.findImpl(recs[i]);
         if (rec) {
           edm::FinalWaitingTask waitTask;
-          tbb::task_group group;
+          oneapi::tbb::task_group group;
           rec->prefetchAsync(
               edm::WaitingTaskHolder(group, &waitTask), proxies[i], &iImpl, edm::ServiceToken{}, edm::ESParentContext{});
           do {

--- a/FWCore/Framework/test/eventprocessor2_t.cppunit.cc
+++ b/FWCore/Framework/test/eventprocessor2_t.cppunit.cc
@@ -34,12 +34,13 @@ class testeventprocessor2 : public CppUnit::TestFixture {
   CPPUNIT_TEST(eventprocessor2Test);
   CPPUNIT_TEST_SUITE_END();
 
-  edm::propagate_const<std::unique_ptr<tbb::global_control>> m_control;
+  edm::propagate_const<std::unique_ptr<oneapi::tbb::global_control>> m_control;
 
 public:
   void setUp() {
     if (not m_control) {
-      m_control = std::make_unique<tbb::global_control>(tbb::global_control::max_allowed_parallelism, 1);
+      m_control =
+          std::make_unique<oneapi::tbb::global_control>(oneapi::tbb::global_control::max_allowed_parallelism, 1);
     }
     //std::cout << "setting up testeventprocessor2" << std::endl;
     doInit();

--- a/FWCore/Framework/test/eventprocessor2_t.cppunit.cc
+++ b/FWCore/Framework/test/eventprocessor2_t.cppunit.cc
@@ -15,7 +15,7 @@ Test of the EventProcessor class.
 #include "FWCore/PluginManager/interface/standard.h"
 #include "FWCore/ParameterSetReader/interface/ParameterSetReader.h"
 
-#include "tbb/global_control.h"
+#include "oneapi/tbb/global_control.h"
 
 // to be called also by the other cppunit...
 void doInit() {

--- a/FWCore/Framework/test/eventprocessor_t.cppunit.cc
+++ b/FWCore/Framework/test/eventprocessor_t.cppunit.cc
@@ -23,7 +23,7 @@ Test of the EventProcessor class.
 
 #include "cppunit/extensions/HelperMacros.h"
 
-#include "tbb/global_control.h"
+#include "oneapi/tbb/global_control.h"
 
 #include <regex>
 

--- a/FWCore/Framework/test/eventprocessor_t.cppunit.cc
+++ b/FWCore/Framework/test/eventprocessor_t.cppunit.cc
@@ -50,7 +50,8 @@ public:
   void setUp() {
     //std::cout << "setting up testeventprocessor" << std::endl;
     if (not m_control) {
-      m_control = std::make_unique<tbb::global_control>(tbb::global_control::max_allowed_parallelism, 1);
+      m_control =
+          std::make_unique<oneapi::tbb::global_control>(oneapi::tbb::global_control::max_allowed_parallelism, 1);
     }
     doInit();
     m_handler = std::make_unique<edm::AssertHandler>();  // propagate_const<T> has no reset() function
@@ -68,7 +69,7 @@ public:
 
 private:
   edm::propagate_const<std::unique_ptr<edm::AssertHandler>> m_handler;
-  edm::propagate_const<std::unique_ptr<tbb::global_control>> m_control;
+  edm::propagate_const<std::unique_ptr<oneapi::tbb::global_control>> m_control;
   void work() {
     //std::cout << "work in testeventprocessor" << std::endl;
     std::string configuration(

--- a/FWCore/Framework/test/eventsetup_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetup_t.cppunit.cc
@@ -425,7 +425,7 @@ namespace {
         auto rec = iImpl.findImpl(recs[i]);
         if (rec) {
           edm::FinalWaitingTask waitTask;
-          tbb::task_group group;
+          oneapi::tbb::task_group group;
           rec->prefetchAsync(
               WaitingTaskHolder(group, &waitTask), proxies[i], &iImpl, edm::ServiceToken{}, edm::ESParentContext{});
           do {

--- a/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
@@ -34,7 +34,7 @@
 #include "FWCore/ServiceRegistry/interface/ESParentContext.h"
 
 #include <memory>
-#include "tbb/task_arena.h"
+#include "oneapi/tbb/task_arena.h"
 
 namespace {
   edm::ActivityRegistry activityRegistry;

--- a/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
@@ -94,7 +94,7 @@ public:
   void doGetExepTest();
 
   EventSetupRecordKey dummyRecordKey_;
-  tbb::task_arena taskArena_;
+  oneapi::tbb::task_arena taskArena_;
   EventSetupImpl eventSetupImpl_;
 };
 
@@ -189,7 +189,7 @@ namespace {
       auto const& proxies = this->esGetTokenIndicesVector(edm::Transition::Event);
       for (size_t i = 0; i != proxies.size(); ++i) {
         edm::FinalWaitingTask waitTask;
-        tbb::task_group group;
+        oneapi::tbb::task_group group;
         edm::ServiceToken token;
         iRec.prefetchAsync(WaitingTaskHolder(group, &waitTask), proxies[i], nullptr, token, edm::ESParentContext{});
         do {
@@ -212,7 +212,7 @@ namespace {
       auto const& proxies = this->esGetTokenIndicesVector(edm::Transition::Event);
       for (size_t i = 0; i != proxies.size(); ++i) {
         edm::FinalWaitingTask waitTask;
-        tbb::task_group group;
+        oneapi::tbb::task_group group;
         edm::ServiceToken token;
         iRec.prefetchAsync(WaitingTaskHolder(group, &waitTask), proxies[i], nullptr, token, edm::ESParentContext{});
         do {

--- a/FWCore/Framework/test/fullchain_t.cppunit.cc
+++ b/FWCore/Framework/test/fullchain_t.cppunit.cc
@@ -57,7 +57,7 @@ namespace {
         auto rec = iImpl.findImpl(recs[i]);
         if (rec) {
           edm::FinalWaitingTask waitTask;
-          tbb::task_group group;
+          oneapi::tbb::task_group group;
           rec->prefetchAsync(
               WaitingTaskHolder(group, &waitTask), proxies[i], &iImpl, edm::ServiceToken{}, edm::ESParentContext{});
           do {

--- a/FWCore/Framework/test/global_filter_t.cppunit.cc
+++ b/FWCore/Framework/test/global_filter_t.cppunit.cc
@@ -127,7 +127,7 @@ private:
   template <typename Traits, typename Info>
   void doWork(edm::Worker* iBase, Info const& info, edm::ParentContext const& iContext) {
     edm::FinalWaitingTask task;
-    tbb::task_group group;
+    oneapi::tbb::task_group group;
     edm::ServiceToken token;
     iBase->doWorkAsync<Traits>(edm::WaitingTaskHolder(group, &task), info, token, s_streamID0, iContext, nullptr);
     do {
@@ -486,7 +486,7 @@ namespace {
 
 template <typename T>
 void testGlobalFilter::testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect) {
-  tbb::global_control control(tbb::global_control::max_allowed_parallelism, 1);
+  oneapi::tbb::global_control control(oneapi::tbb::global_control::max_allowed_parallelism, 1);
   edm::maker::ModuleHolderT<edm::global::EDFilterBase> h(iMod, nullptr);
   h.preallocate(edm::PreallocationConfiguration{});
 

--- a/FWCore/Framework/test/global_filter_t.cppunit.cc
+++ b/FWCore/Framework/test/global_filter_t.cppunit.cc
@@ -10,7 +10,7 @@
 #include <vector>
 #include <map>
 #include <functional>
-#include "tbb/global_control.h"
+#include "oneapi/tbb/global_control.h"
 #include "FWCore/Framework/interface/global/EDFilter.h"
 #include "FWCore/Framework/interface/maker/WorkerT.h"
 #include "FWCore/Framework/interface/maker/ModuleHolder.h"

--- a/FWCore/Framework/test/global_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/global_outputmodule_t.cppunit.cc
@@ -97,7 +97,7 @@ private:
   template <typename Traits, typename Info>
   void doWork(edm::Worker* iBase, Info const& info, edm::StreamID id, edm::ParentContext const& iContext) {
     edm::FinalWaitingTask task;
-    tbb::task_group group;
+    oneapi::tbb::task_group group;
     edm::ServiceToken token;
     iBase->doWorkAsync<Traits>(edm::WaitingTaskHolder(group, &task), info, token, id, iContext, nullptr);
     do {
@@ -221,7 +221,7 @@ testGlobalOutputModule::testGlobalOutputModule()
     edm::LumiTransitionInfo info(*m_lbp, *m_es);
     doWork<Traits>(iBase, info, edm::StreamID::invalidStreamID(), parentContext);
     edm::FinalWaitingTask task;
-    tbb::task_group group;
+    oneapi::tbb::task_group group;
     iComm->writeLumiAsync(edm::WaitingTaskHolder(group, &task), *m_lbp, nullptr, &activityRegistry);
     do {
       group.wait();
@@ -237,7 +237,7 @@ testGlobalOutputModule::testGlobalOutputModule()
     edm::RunTransitionInfo info(*m_rp, *m_es);
     doWork<Traits>(iBase, info, edm::StreamID::invalidStreamID(), parentContext);
     edm::FinalWaitingTask task;
-    tbb::task_group group;
+    oneapi::tbb::task_group group;
     iComm->writeRunAsync(edm::WaitingTaskHolder(group, &task), *m_rp, nullptr, &activityRegistry, nullptr);
     do {
       group.wait();
@@ -298,7 +298,7 @@ namespace {
 
 template <typename T>
 void testGlobalOutputModule::testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect) {
-  tbb::global_control control(tbb::global_control::max_allowed_parallelism, 1);
+  oneapi::tbb::global_control control(oneapi::tbb::global_control::max_allowed_parallelism, 1);
 
   iMod->doPreallocate(m_preallocConfig);
   edm::WorkerT<edm::global::OutputModuleBase> w{iMod, m_desc, m_params.actions_};

--- a/FWCore/Framework/test/global_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/global_outputmodule_t.cppunit.cc
@@ -8,7 +8,7 @@
 #include <vector>
 #include <map>
 #include <functional>
-#include "tbb/global_control.h"
+#include "oneapi/tbb/global_control.h"
 #include "FWCore/Framework/interface/global/OutputModule.h"
 #include "FWCore/Framework/interface/OutputModuleCommunicatorT.h"
 #include "FWCore/Framework/interface/TransitionInfoTypes.h"

--- a/FWCore/Framework/test/global_producer_t.cppunit.cc
+++ b/FWCore/Framework/test/global_producer_t.cppunit.cc
@@ -10,7 +10,7 @@
 #include <vector>
 #include <map>
 #include <functional>
-#include "tbb/global_control.h"
+#include "oneapi/tbb/global_control.h"
 #include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/maker/WorkerT.h"
 #include "FWCore/Framework/interface/maker/ModuleHolder.h"

--- a/FWCore/Framework/test/global_producer_t.cppunit.cc
+++ b/FWCore/Framework/test/global_producer_t.cppunit.cc
@@ -127,7 +127,7 @@ private:
   template <typename Traits, typename Info>
   void doWork(edm::Worker* iBase, Info const& info, edm::ParentContext const& iContext) {
     edm::FinalWaitingTask task;
-    tbb::task_group group;
+    oneapi::tbb::task_group group;
     edm::ServiceToken token;
     iBase->doWorkAsync<Traits>(edm::WaitingTaskHolder(group, &task), info, token, s_streamID0, iContext, nullptr);
     do {
@@ -450,7 +450,7 @@ namespace {
 
 template <typename T>
 void testGlobalProducer::testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect) {
-  tbb::global_control control(tbb::global_control::max_allowed_parallelism, 1);
+  oneapi::tbb::global_control control(oneapi::tbb::global_control::max_allowed_parallelism, 1);
 
   edm::maker::ModuleHolderT<edm::global::EDProducerBase> h(iMod, nullptr);
   h.preallocate(edm::PreallocationConfiguration{});

--- a/FWCore/Framework/test/limited_filter_t.cppunit.cc
+++ b/FWCore/Framework/test/limited_filter_t.cppunit.cc
@@ -137,7 +137,7 @@ private:
   template <typename Traits, typename Info>
   void doWork(edm::Worker* iBase, Info const& info, edm::ParentContext const& iContext) {
     edm::FinalWaitingTask task;
-    tbb::task_group group;
+    oneapi::tbb::task_group group;
     edm::ServiceToken token;
     iBase->doWorkAsync<Traits>(edm::WaitingTaskHolder(group, &task), info, token, s_streamID0, iContext, nullptr);
     do {
@@ -514,7 +514,7 @@ namespace {
 
 template <typename T>
 void testLimitedFilter::testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect) {
-  tbb::global_control control(tbb::global_control::max_allowed_parallelism, 1);
+  oneapi::tbb::global_control control(oneapi::tbb::global_control::max_allowed_parallelism, 1);
 
   edm::maker::ModuleHolderT<edm::limited::EDFilterBase> h(iMod, nullptr);
   h.preallocate(edm::PreallocationConfiguration{});

--- a/FWCore/Framework/test/limited_filter_t.cppunit.cc
+++ b/FWCore/Framework/test/limited_filter_t.cppunit.cc
@@ -10,7 +10,7 @@
 #include <vector>
 #include <map>
 #include <functional>
-#include "tbb/global_control.h"
+#include "oneapi/tbb/global_control.h"
 #include "FWCore/Framework/interface/limited/EDFilter.h"
 #include "FWCore/Framework/interface/maker/WorkerT.h"
 #include "FWCore/Framework/interface/maker/ModuleHolder.h"

--- a/FWCore/Framework/test/limited_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/limited_outputmodule_t.cppunit.cc
@@ -8,7 +8,7 @@
 #include <vector>
 #include <map>
 #include <functional>
-#include "tbb/global_control.h"
+#include "oneapi/tbb/global_control.h"
 #include "FWCore/Framework/interface/limited/OutputModule.h"
 #include "FWCore/Framework/interface/OutputModuleCommunicatorT.h"
 #include "FWCore/Framework/interface/TransitionInfoTypes.h"

--- a/FWCore/Framework/test/limited_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/limited_outputmodule_t.cppunit.cc
@@ -97,7 +97,7 @@ private:
   template <typename Traits, typename Info>
   void doWork(edm::Worker* iBase, Info const& info, edm::StreamID id, edm::ParentContext const& iContext) {
     edm::FinalWaitingTask task;
-    tbb::task_group group;
+    oneapi::tbb::task_group group;
     edm::ServiceToken token;
     iBase->doWorkAsync<Traits>(edm::WaitingTaskHolder(group, &task), info, token, id, iContext, nullptr);
     do {
@@ -220,7 +220,7 @@ testLimitedOutputModule::testLimitedOutputModule()
     edm::LumiTransitionInfo info(*m_lbp, *m_es);
     doWork<Traits>(iBase, info, edm::StreamID::invalidStreamID(), parentContext);
     edm::FinalWaitingTask task;
-    tbb::task_group group;
+    oneapi::tbb::task_group group;
     iComm->writeLumiAsync(edm::WaitingTaskHolder(group, &task), *m_lbp, nullptr, &activityRegistry);
     do {
       group.wait();
@@ -236,7 +236,7 @@ testLimitedOutputModule::testLimitedOutputModule()
     edm::RunTransitionInfo info(*m_rp, *m_es);
     doWork<Traits>(iBase, info, edm::StreamID::invalidStreamID(), parentContext);
     edm::FinalWaitingTask task;
-    tbb::task_group group;
+    oneapi::tbb::task_group group;
     iComm->writeRunAsync(edm::WaitingTaskHolder(group, &task), *m_rp, nullptr, &activityRegistry, nullptr);
     do {
       group.wait();
@@ -297,7 +297,7 @@ namespace {
 
 template <typename T>
 void testLimitedOutputModule::testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect) {
-  tbb::global_control control(tbb::global_control::max_allowed_parallelism, 1);
+  oneapi::tbb::global_control control(oneapi::tbb::global_control::max_allowed_parallelism, 1);
 
   iMod->doPreallocate(m_preallocConfig);
   edm::WorkerT<edm::limited::OutputModuleBase> w{iMod, m_desc, m_params.actions_};

--- a/FWCore/Framework/test/limited_producer_t.cppunit.cc
+++ b/FWCore/Framework/test/limited_producer_t.cppunit.cc
@@ -10,7 +10,7 @@
 #include <vector>
 #include <map>
 #include <functional>
-#include "tbb/global_control.h"
+#include "oneapi/tbb/global_control.h"
 #include "FWCore/Framework/interface/limited/EDProducer.h"
 #include "FWCore/Framework/interface/maker/WorkerT.h"
 #include "FWCore/Framework/interface/maker/ModuleHolder.h"

--- a/FWCore/Framework/test/limited_producer_t.cppunit.cc
+++ b/FWCore/Framework/test/limited_producer_t.cppunit.cc
@@ -137,7 +137,7 @@ private:
   template <typename Traits, typename Info>
   void doWork(edm::Worker* iBase, Info const& info, edm::ParentContext const& iContext) {
     edm::FinalWaitingTask task;
-    tbb::task_group group;
+    oneapi::tbb::task_group group;
     edm::ServiceToken token;
     iBase->doWorkAsync<Traits>(edm::WaitingTaskHolder(group, &task), info, token, s_streamID0, iContext, nullptr);
     do {
@@ -481,7 +481,7 @@ namespace {
 
 template <typename T>
 void testLimitedProducer::testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect) {
-  tbb::global_control control(tbb::global_control::max_allowed_parallelism, 1);
+  oneapi::tbb::global_control control(oneapi::tbb::global_control::max_allowed_parallelism, 1);
 
   edm::maker::ModuleHolderT<edm::limited::EDProducerBase> h(iMod, nullptr);
   h.preallocate(edm::PreallocationConfiguration{});

--- a/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
@@ -109,7 +109,7 @@ private:
   template <typename Traits, typename Info>
   void doWork(edm::Worker* iBase, Info const& info, edm::StreamID id, edm::ParentContext const& iContext) {
     edm::FinalWaitingTask task;
-    tbb::task_group group;
+    oneapi::tbb::task_group group;
     edm::ServiceToken token;
     iBase->doWorkAsync<Traits>(edm::WaitingTaskHolder(group, &task), info, token, id, iContext, nullptr);
     do {
@@ -315,7 +315,7 @@ testOneOutputModule::testOneOutputModule()
     edm::LumiTransitionInfo info(*m_lbp, *m_es);
     doWork<Traits>(iBase, info, edm::StreamID::invalidStreamID(), parentContext);
     edm::FinalWaitingTask task;
-    tbb::task_group group;
+    oneapi::tbb::task_group group;
     iComm->writeLumiAsync(edm::WaitingTaskHolder(group, &task), *m_lbp, nullptr, &activityRegistry);
     do {
       group.wait();
@@ -331,7 +331,7 @@ testOneOutputModule::testOneOutputModule()
     edm::RunTransitionInfo info(*m_rp, *m_es);
     doWork<Traits>(iBase, info, edm::StreamID::invalidStreamID(), parentContext);
     edm::FinalWaitingTask task;
-    tbb::task_group group;
+    oneapi::tbb::task_group group;
     iComm->writeRunAsync(edm::WaitingTaskHolder(group, &task), *m_rp, nullptr, &activityRegistry, nullptr);
     do {
       group.wait();
@@ -392,7 +392,7 @@ namespace {
 
 template <typename T>
 void testOneOutputModule::testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect) {
-  tbb::global_control control(tbb::global_control::max_allowed_parallelism, 1);
+  oneapi::tbb::global_control control(oneapi::tbb::global_control::max_allowed_parallelism, 1);
 
   iMod->doPreallocate(m_preallocConfig);
   edm::WorkerT<edm::one::OutputModuleBase> w{iMod, m_desc, m_params.actions_};

--- a/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
@@ -10,7 +10,7 @@
 #include <vector>
 #include <map>
 #include <functional>
-#include "tbb/global_control.h"
+#include "oneapi/tbb/global_control.h"
 #include "FWCore/Framework/interface/one/OutputModule.h"
 #include "FWCore/Framework/interface/OutputModuleCommunicatorT.h"
 #include "FWCore/Framework/interface/TransitionInfoTypes.h"

--- a/FWCore/Framework/test/stream_filter_t.cppunit.cc
+++ b/FWCore/Framework/test/stream_filter_t.cppunit.cc
@@ -126,7 +126,7 @@ private:
   template <typename Traits, typename Info>
   void doWork(edm::Worker* iBase, Info const& info, edm::ParentContext const& iContext) {
     edm::FinalWaitingTask task;
-    tbb::task_group group;
+    oneapi::tbb::task_group group;
     edm::ServiceToken token;
     iBase->doWorkAsync<Traits>(edm::WaitingTaskHolder(group, &task), info, token, s_streamID0, iContext, nullptr);
     do {
@@ -573,7 +573,7 @@ namespace {
 
 template <typename T, typename U>
 void testStreamFilter::testTransitions(std::shared_ptr<U> iMod, Expectations const& iExpect) {
-  tbb::global_control control(tbb::global_control::max_allowed_parallelism, 1);
+  oneapi::tbb::global_control control(oneapi::tbb::global_control::max_allowed_parallelism, 1);
 
   edm::WorkerT<edm::stream::EDFilterAdaptorBase> w{iMod, m_desc, nullptr};
   for (auto& keyVal : m_transToFunc) {

--- a/FWCore/Framework/test/stream_filter_t.cppunit.cc
+++ b/FWCore/Framework/test/stream_filter_t.cppunit.cc
@@ -9,7 +9,7 @@
 #include <vector>
 #include <map>
 #include <functional>
-#include "tbb/global_control.h"
+#include "oneapi/tbb/global_control.h"
 #include "FWCore/Framework/interface/maker/Worker.h"
 #include "FWCore/Framework/interface/maker/WorkerT.h"
 #include "FWCore/Framework/interface/maker/ModuleHolder.h"

--- a/FWCore/Framework/test/stream_producer_t.cppunit.cc
+++ b/FWCore/Framework/test/stream_producer_t.cppunit.cc
@@ -9,7 +9,7 @@
 #include <vector>
 #include <map>
 #include <functional>
-#include "tbb/global_control.h"
+#include "oneapi/tbb/global_control.h"
 #include "FWCore/Framework/interface/maker/Worker.h"
 #include "FWCore/Framework/interface/maker/WorkerT.h"
 #include "FWCore/Framework/interface/maker/ModuleHolder.h"

--- a/FWCore/Framework/test/stream_producer_t.cppunit.cc
+++ b/FWCore/Framework/test/stream_producer_t.cppunit.cc
@@ -126,7 +126,7 @@ private:
   template <typename Traits, typename Info>
   void doWork(edm::Worker* iBase, Info const& info, edm::ParentContext const& iContext) {
     edm::FinalWaitingTask task;
-    tbb::task_group group;
+    oneapi::tbb::task_group group;
     edm::ServiceToken token;
     iBase->doWorkAsync<Traits>(edm::WaitingTaskHolder(group, &task), info, token, s_streamID0, iContext, nullptr);
     do {
@@ -534,7 +534,7 @@ namespace {
 
 template <typename T, typename U>
 void testStreamProducer::testTransitions(std::shared_ptr<U> iMod, Expectations const& iExpect) {
-  tbb::global_control control(tbb::global_control::max_allowed_parallelism, 1);
+  oneapi::tbb::global_control control(oneapi::tbb::global_control::max_allowed_parallelism, 1);
 
   edm::WorkerT<edm::stream::EDProducerAdaptorBase> w{iMod, m_desc, nullptr};
   for (auto& keyVal : m_transToFunc) {

--- a/FWCore/Framework/test/stubs/TestNThreadsChecker.cc
+++ b/FWCore/Framework/test/stubs/TestNThreadsChecker.cc
@@ -58,7 +58,7 @@ TestNThreadsChecker::TestNThreadsChecker(const edm::ParameterSet& iConfig, edm::
     : m_nExpectedThreads(iConfig.getUntrackedParameter<unsigned int>("nExpectedThreads")) {
   unsigned int expectedThreads = m_nExpectedThreads;
   if (expectedThreads == 0) {
-    expectedThreads = tbb::this_task_arena::max_concurrency();
+    expectedThreads = oneapi::tbb::this_task_arena::max_concurrency();
   }
 
   //now do what ever initialization is needed

--- a/FWCore/Framework/test/stubs/TestNThreadsChecker.cc
+++ b/FWCore/Framework/test/stubs/TestNThreadsChecker.cc
@@ -20,7 +20,7 @@
 #include <memory>
 #include <atomic>
 #include <unistd.h>
-#include "tbb/task_arena.h"
+#include "oneapi/tbb/task_arena.h"
 
 // user include files
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/FWCore/Framework/test/stubs/TestTBBTasksAnalyzer.cc
+++ b/FWCore/Framework/test/stubs/TestTBBTasksAnalyzer.cc
@@ -20,8 +20,8 @@
 #include <memory>
 #include <atomic>
 #include <unistd.h>
-#include "tbb/task_group.h"
-#include "tbb/task_arena.h"
+#include "oneapi/tbb/task_group.h"
+#include "oneapi/tbb/task_arena.h"
 
 // user include files
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"

--- a/FWCore/Framework/test/stubs/TestTBBTasksAnalyzer.cc
+++ b/FWCore/Framework/test/stubs/TestTBBTasksAnalyzer.cc
@@ -93,7 +93,7 @@ void TestTBBTasksAnalyzer::analyze(const edm::Event&, const edm::EventSetup& iSe
 unsigned int TestTBBTasksAnalyzer::startTasks(unsigned int iNTasks, unsigned int iSleepTime) const {
   std::atomic<unsigned int> count{0};
   std::atomic<unsigned int> maxCount{0};
-  tbb::task_group grp;
+  oneapi::tbb::task_group grp;
 
   for (unsigned int i = 0; i < iNTasks; ++i) {
     grp.run([&]() {

--- a/FWCore/MessageLogger/interface/JobReport.h
+++ b/FWCore/MessageLogger/interface/JobReport.h
@@ -95,8 +95,8 @@ Changes Log 1: 2009/01/14 10:29:00, Natalia Garcia Nebot
 #include <string>
 #include <vector>
 
-#include "tbb/concurrent_unordered_map.h"
-#include "tbb/concurrent_vector.h"
+#include "oneapi/tbb/concurrent_unordered_map.h"
+#include "oneapi/tbb/concurrent_vector.h"
 
 namespace edm {
 

--- a/FWCore/MessageLogger/interface/JobReport.h
+++ b/FWCore/MessageLogger/interface/JobReport.h
@@ -159,7 +159,7 @@ namespace edm {
       std::size_t numEventsWritten;
       StringVector branchNames;
       std::vector<Token> contributingInputs;
-      tbb::concurrent_vector<Token> contributingInputsSecSource;
+      oneapi::tbb::concurrent_vector<Token> contributingInputsSecSource;
       std::map<std::string, bool> fastCopyingInputs;
       std::map<RunNumber, RunReport> runReports;
       bool fileHasBeenClosed;
@@ -250,11 +250,11 @@ namespace edm {
       std::ostream*& ost() { return get_underlying_safe(ost_); }
 
       std::vector<InputFile> inputFiles_;
-      tbb::concurrent_vector<InputFile> inputFilesSecSource_;
-      tbb::concurrent_vector<OutputFile> outputFiles_;
+      oneapi::tbb::concurrent_vector<InputFile> inputFilesSecSource_;
+      oneapi::tbb::concurrent_vector<OutputFile> outputFiles_;
       std::map<std::string, long long> readBranches_;
       std::map<std::string, long long> readBranchesSecFile_;
-      tbb::concurrent_unordered_map<std::string, AtomicLongLong> readBranchesSecSource_;
+      oneapi::tbb::concurrent_unordered_map<std::string, AtomicLongLong> readBranchesSecSource_;
       bool printedReadBranches_;
       std::vector<InputFile>::size_type lastOpenedPrimaryInputFile_;
       edm::propagate_const<std::ostream*> ost_;

--- a/FWCore/MessageLogger/src/JobReport.cc
+++ b/FWCore/MessageLogger/src/JobReport.cc
@@ -417,7 +417,8 @@ namespace edm {
         r.contributingInputs.push_back(i);
       }
     }
-    for (tbb::concurrent_vector<Token>::size_type i = 0, iEnd = impl_->inputFilesSecSource_.size(); i < iEnd; ++i) {
+    for (oneapi::tbb::concurrent_vector<Token>::size_type i = 0, iEnd = impl_->inputFilesSecSource_.size(); i < iEnd;
+         ++i) {
       if (!impl_->inputFilesSecSource_[i].fileHasBeenClosed) {
         r.contributingInputsSecSource.push_back(i);
       }

--- a/FWCore/MessageLogger/src/MessageSender.cc
+++ b/FWCore/MessageLogger/src/MessageSender.cc
@@ -80,7 +80,7 @@ namespace {
 CMS_THREAD_SAFE static std::atomic<bool> errorSummaryIsBeingKept{false};
 //Each item in the vector is reserved for a different Stream
 CMS_THREAD_SAFE static std::vector<
-    tbb::concurrent_unordered_map<ErrorSummaryMapKey, AtomicUnsignedInt, ErrorSummaryMapKey::key_hash>>
+    oneapi::tbb::concurrent_unordered_map<ErrorSummaryMapKey, AtomicUnsignedInt, ErrorSummaryMapKey::key_hash>>
     errorSummaryMaps;
 
 MessageSender::MessageSender(ELseverityLevel const& sev, std::string_view id, bool verbatim, bool suppressed)

--- a/FWCore/MessageLogger/src/MessageSender.cc
+++ b/FWCore/MessageLogger/src/MessageSender.cc
@@ -11,7 +11,7 @@
 #include <atomic>
 
 #include <functional>
-#include "tbb/concurrent_unordered_map.h"
+#include "oneapi/tbb/concurrent_unordered_map.h"
 
 #define TRACE_DROP
 #ifdef TRACE_DROP

--- a/FWCore/MessageService/src/ThreadSafeLogMessageLoggerScribe.h
+++ b/FWCore/MessageService/src/ThreadSafeLogMessageLoggerScribe.h
@@ -137,7 +137,7 @@ namespace edm {
       std::atomic<bool> m_purge_mode;
       std::atomic<int> m_count;
       std::atomic<bool> m_messageBeingSent;
-      tbb::concurrent_queue<ErrorObj*> m_waitingMessages;
+      oneapi::tbb::concurrent_queue<ErrorObj*> m_waitingMessages;
       size_t m_waitingThreshold;
       std::atomic<unsigned long> m_tooManyWaitingMessagesCount;
 

--- a/FWCore/MessageService/src/ThreadSafeLogMessageLoggerScribe.h
+++ b/FWCore/MessageService/src/ThreadSafeLogMessageLoggerScribe.h
@@ -19,7 +19,7 @@
 
 #include <iostream>
 #include <atomic>
-#include "tbb/concurrent_queue.h"
+#include "oneapi/tbb/concurrent_queue.h"
 
 namespace edm {
   namespace service {

--- a/FWCore/ParameterSet/interface/Registry.h
+++ b/FWCore/ParameterSet/interface/Registry.h
@@ -14,7 +14,7 @@
 
 #include <iosfwd>
 #include <map>
-#include "tbb/concurrent_unordered_map.h"
+#include "oneapi/tbb/concurrent_unordered_map.h"
 
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
 #include "DataFormats/Provenance/interface/ParameterSetBlob.h"

--- a/FWCore/ParameterSet/interface/Registry.h
+++ b/FWCore/ParameterSet/interface/Registry.h
@@ -57,7 +57,7 @@ namespace edm {
       struct key_hash {
         std::size_t operator()(key_type const& iKey) const { return iKey.smallHash(); }
       };
-      typedef tbb::concurrent_unordered_map<key_type, value_type, key_hash> map_type;
+      typedef oneapi::tbb::concurrent_unordered_map<key_type, value_type, key_hash> map_type;
       typedef map_type::const_iterator const_iterator;
 
       const_iterator begin() const { return m_map.begin(); }

--- a/FWCore/PluginManager/interface/PluginFactoryBase.h
+++ b/FWCore/PluginManager/interface/PluginFactoryBase.h
@@ -24,8 +24,8 @@
 #include <vector>
 #include <map>
 #include <atomic>
-#include "tbb/concurrent_unordered_map.h"
-#include "tbb/concurrent_vector.h"
+#include "oneapi/tbb/concurrent_unordered_map.h"
+#include "oneapi/tbb/concurrent_vector.h"
 #include "FWCore/Utilities/interface/zero_allocator.h"
 #include "FWCore/Utilities/interface/Signal.h"
 #include "FWCore/Utilities/interface/thread_safety_macros.h"

--- a/FWCore/PluginManager/interface/PluginFactoryBase.h
+++ b/FWCore/PluginManager/interface/PluginFactoryBase.h
@@ -61,8 +61,8 @@ namespace edmplugin {
       std::atomic<void*> m_ptr;
     };
 
-    typedef tbb::concurrent_vector<PluginMakerInfo, edm::zero_allocator<PluginMakerInfo>> PMakers;
-    typedef tbb::concurrent_unordered_map<std::string, PMakers> Plugins;
+    typedef oneapi::tbb::concurrent_vector<PluginMakerInfo, edm::zero_allocator<PluginMakerInfo>> PMakers;
+    typedef oneapi::tbb::concurrent_unordered_map<std::string, PMakers> Plugins;
 
     // ---------- const member functions ---------------------
 

--- a/FWCore/PluginManager/interface/PluginManager.h
+++ b/FWCore/PluginManager/interface/PluginManager.h
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-#include "tbb/concurrent_unordered_map.h"
+#include "oneapi/tbb/concurrent_unordered_map.h"
 
 // user include files
 #include "FWCore/Utilities/interface/Signal.h"

--- a/FWCore/PluginManager/interface/PluginManager.h
+++ b/FWCore/PluginManager/interface/PluginManager.h
@@ -115,7 +115,7 @@ namespace edmplugin {
                                               bool& ioThrowIfFailElseSucceedStatus);
     // ---------- member data --------------------------------
     SearchPath searchPath_;
-    tbb::concurrent_unordered_map<std::filesystem::path, std::shared_ptr<SharedLibrary>, PluginManagerPathHasher>
+    oneapi::tbb::concurrent_unordered_map<std::filesystem::path, std::shared_ptr<SharedLibrary>, PluginManagerPathHasher>
         loadables_;
 
     CategoryToInfos categoryToInfos_;

--- a/FWCore/PythonFramework/src/PythonEventProcessor.cc
+++ b/FWCore/PythonFramework/src/PythonEventProcessor.cc
@@ -12,7 +12,7 @@
 
 // system include files
 #include <mutex>
-#include "tbb/task_arena.h"
+#include "oneapi/tbb/task_arena.h"
 
 // user include files
 #include "FWCore/PythonFramework/interface/PythonEventProcessor.h"

--- a/FWCore/PythonFramework/src/PythonEventProcessor.cc
+++ b/FWCore/PythonFramework/src/PythonEventProcessor.cc
@@ -101,7 +101,7 @@ PythonEventProcessor::~PythonEventProcessor() {
   auto gil = PyEval_SaveThread();
   // Protects the destructor from throwing exceptions.
   CMS_SA_ALLOW try {
-    tbb::task_arena{nThreads}.execute([this]() {
+    oneapi::tbb::task_arena{nThreads}.execute([this]() {
       TaskCleanupSentry s(&processor_);
       processor_.endJob();
     });
@@ -113,7 +113,7 @@ PythonEventProcessor::~PythonEventProcessor() {
 void PythonEventProcessor::run() {
   auto gil = PyEval_SaveThread();
   try {
-    tbb::task_arena{nThreads}.execute([this]() { (void)processor_.runToCompletion(); });
+    oneapi::tbb::task_arena{nThreads}.execute([this]() { (void)processor_.runToCompletion(); });
   } catch (...) {
   }
   PyEval_RestoreThread(gil);

--- a/FWCore/Reflection/src/FunctionWithDict.cc
+++ b/FWCore/Reflection/src/FunctionWithDict.cc
@@ -8,7 +8,7 @@
 #include "TMethodArg.h"
 #include "TMethodCall.h"
 
-#include "tbb/concurrent_unordered_map.h"
+#include "oneapi/tbb/concurrent_unordered_map.h"
 
 namespace edm {
   namespace {

--- a/FWCore/Reflection/src/FunctionWithDict.cc
+++ b/FWCore/Reflection/src/FunctionWithDict.cc
@@ -12,7 +12,7 @@
 
 namespace edm {
   namespace {
-    typedef tbb::concurrent_unordered_map<TMethod const*, TypeWithDict> Map;
+    typedef oneapi::tbb::concurrent_unordered_map<TMethod const*, TypeWithDict> Map;
     Map returnTypeMap;
   }  // namespace
 

--- a/FWCore/Reflection/src/TypeWithDict.cc
+++ b/FWCore/Reflection/src/TypeWithDict.cc
@@ -18,7 +18,7 @@
 #include "TRealData.h"
 #include "TROOT.h"
 
-#include "tbb/concurrent_unordered_map.h"
+#include "oneapi/tbb/concurrent_unordered_map.h"
 
 #include <cassert>
 #include <cstdio>

--- a/FWCore/Reflection/src/TypeWithDict.cc
+++ b/FWCore/Reflection/src/TypeWithDict.cc
@@ -33,16 +33,16 @@
 namespace edm {
 
   namespace {
-    using Map = tbb::concurrent_unordered_map<std::string, TypeWithDict>;
+    using Map = oneapi::tbb::concurrent_unordered_map<std::string, TypeWithDict>;
     Map typeMap;
-    using FunctionMap = tbb::concurrent_unordered_map<std::string, FunctionWithDict>;
+    using FunctionMap = oneapi::tbb::concurrent_unordered_map<std::string, FunctionWithDict>;
     FunctionMap functionMap;
 
     struct TypeIndexHash {
       std::size_t operator()(std::type_index ti) const { return ti.hash_code(); }
     };
 
-    using TypeIndexMap = tbb::concurrent_unordered_map<std::type_index, TypeWithDict, TypeIndexHash>;
+    using TypeIndexMap = oneapi::tbb::concurrent_unordered_map<std::type_index, TypeWithDict, TypeIndexHash>;
     TypeIndexMap typeIndexMap;
   }  // namespace
   static void throwTypeException(std::string const& function, std::string const& typeName) {

--- a/FWCore/Services/plugins/CheckTransitions.cc
+++ b/FWCore/Services/plugins/CheckTransitions.cc
@@ -76,7 +76,7 @@ namespace edm {
       void preEvent(StreamContext const&);
 
     private:
-      tbb::concurrent_vector<std::tuple<Phase, edm::EventID, int>> m_seenTransitions;
+      oneapi::tbb::concurrent_vector<std::tuple<Phase, edm::EventID, int>> m_seenTransitions;
       std::vector<std::pair<Transition, edm::EventID>> m_expectedTransitions;
       int m_nstreams = 0;
       bool m_failed = false;

--- a/FWCore/Services/plugins/CheckTransitions.cc
+++ b/FWCore/Services/plugins/CheckTransitions.cc
@@ -31,7 +31,7 @@
 
 #include <vector>
 #include <string>
-#include "tbb/concurrent_vector.h"
+#include "oneapi/tbb/concurrent_vector.h"
 #include <iostream>
 
 namespace edm {

--- a/FWCore/Services/plugins/InitRootHandlers.cc
+++ b/FWCore/Services/plugins/InitRootHandlers.cc
@@ -72,11 +72,11 @@ namespace edm {
       friend int cmssw_stacktrace(void*);
 
     public:
-      class ThreadTracker : public tbb::task_scheduler_observer {
+      class ThreadTracker : public oneapi::tbb::task_scheduler_observer {
       public:
-        typedef tbb::concurrent_unordered_set<pthread_t> Container_type;
+        typedef oneapi::tbb::concurrent_unordered_set<pthread_t> Container_type;
 
-        ThreadTracker() : tbb::task_scheduler_observer() { observe(); }
+        ThreadTracker() : oneapi::tbb::task_scheduler_observer() { observe(); }
         ~ThreadTracker() override = default;
 
         void on_scheduler_entry(bool) override {
@@ -175,7 +175,7 @@ namespace {
        "Announced number of args different from the real number of argument passed",  // Always printed if gDebug>0 - regardless of whether warning message is real.
        "nbins is <=0 - set to nbins = 1",
        "nbinsy is <=0 - set to nbinsy = 1",
-       "tbb::global_control is limiting"}};
+       "oneapi::tbb::global_control is limiting"}};
 
   //Location generating messages which should be reported as an INFO not a ERROR
   constexpr std::array<const char* const, 7> in_location{{"Fit",
@@ -851,7 +851,8 @@ namespace edm {
       if (imt && not ROOT::IsImplicitMTEnabled()) {
         //cmsRun uses global_control to set the number of allowed threads to use
         // we need to tell ROOT the same value in order to avoid unnecessary warnings
-        ROOT::EnableImplicitMT(tbb::global_control::active_value(tbb::global_control::max_allowed_parallelism));
+        ROOT::EnableImplicitMT(
+            oneapi::tbb::global_control::active_value(oneapi::tbb::global_control::max_allowed_parallelism));
       }
     }
 

--- a/FWCore/Services/plugins/InitRootHandlers.cc
+++ b/FWCore/Services/plugins/InitRootHandlers.cc
@@ -18,10 +18,10 @@
 #include "FWCore/ServiceRegistry/interface/CurrentModuleOnThread.h"
 #include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
 
-#include "tbb/concurrent_unordered_set.h"
-#include "tbb/task.h"
-#include "tbb/task_scheduler_observer.h"
-#include "tbb/global_control.h"
+#include "oneapi/tbb/concurrent_unordered_set.h"
+#include "oneapi/tbb/task.h"
+#include "oneapi/tbb/task_scheduler_observer.h"
+#include "oneapi/tbb/global_control.h"
 #include <memory>
 
 #include <thread>

--- a/FWCore/Services/plugins/StallMonitor.cc
+++ b/FWCore/Services/plugins/StallMonitor.cc
@@ -223,13 +223,13 @@ namespace edm {
 
       // There can be multiple modules per stream.  Therefore, we need
       // the combination of StreamID and ModuleID to correctly track
-      // stalling information.  We use tbb::concurrent_unordered_map
+      // stalling information.  We use oneapi::tbb::concurrent_unordered_map
       // for this purpose.
       using StreamID_value = decltype(std::declval<StreamID>().value());
       using ModuleID = decltype(std::declval<ModuleDescription>().id());
-      tbb::concurrent_unordered_map<std::pair<StreamID_value, ModuleID>,
-                                    std::pair<decltype(beginTime_), bool>,
-                                    edm::StdPairHasher>
+      oneapi::tbb::concurrent_unordered_map<std::pair<StreamID_value, ModuleID>,
+                                            std::pair<decltype(beginTime_), bool>,
+                                            edm::StdPairHasher>
           stallStart_{};
 
       std::vector<std::string> moduleLabels_{};

--- a/FWCore/Services/plugins/StallMonitor.cc
+++ b/FWCore/Services/plugins/StallMonitor.cc
@@ -25,7 +25,7 @@
 #include "FWCore/Utilities/interface/OStreamColumn.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/StdPairHasher.h"
-#include "tbb/concurrent_unordered_map.h"
+#include "oneapi/tbb/concurrent_unordered_map.h"
 
 #include <atomic>
 #include <chrono>

--- a/FWCore/Sources/interface/DaqProvenanceHelper.h
+++ b/FWCore/Sources/interface/DaqProvenanceHelper.h
@@ -4,7 +4,7 @@
 #include <map>
 #include <string>
 #include <vector>
-#include "tbb/concurrent_unordered_map.h"
+#include "oneapi/tbb/concurrent_unordered_map.h"
 
 #include "DataFormats/Provenance/interface/BranchDescription.h"
 #include "DataFormats/Provenance/interface/ParentageID.h"

--- a/FWCore/Sources/interface/DaqProvenanceHelper.h
+++ b/FWCore/Sources/interface/DaqProvenanceHelper.h
@@ -26,7 +26,7 @@ namespace edm {
 
   struct DaqProvenanceHelper {
     typedef std::map<ProcessHistoryID, ProcessHistoryID> ProcessHistoryIDMap;
-    typedef tbb::concurrent_unordered_map<ParentageID, ParentageID, dqh::parentage_hash> ParentageIDMap;
+    typedef oneapi::tbb::concurrent_unordered_map<ParentageID, ParentageID, dqh::parentage_hash> ParentageIDMap;
     explicit DaqProvenanceHelper(TypeID const& rawDataType);
     ProcessHistoryID daqInit(ProductRegistry& productRegistry, ProcessHistoryRegistry& processHistoryRegistry) const;
     void saveInfo(BranchDescription const& oldBD, BranchDescription const& newBD) {

--- a/FWCore/TestProcessor/interface/TestProcessor.h
+++ b/FWCore/TestProcessor/interface/TestProcessor.h
@@ -325,9 +325,9 @@ This simulates a problem happening early in the job which causes processing not 
       void endJob();
 
       // ---------- member data --------------------------------
-      tbb::global_control globalControl_;
-      tbb::task_group taskGroup_;
-      tbb::task_arena arena_;
+      oneapi::tbb::global_control globalControl_;
+      oneapi::tbb::task_group taskGroup_;
+      oneapi::tbb::task_arena arena_;
       std::string labelOfTestModule_;
       std::shared_ptr<ActivityRegistry> actReg_;  // We do not use propagate_const because the registry itself is mutable.
       std::shared_ptr<ProductRegistry> preg_;

--- a/FWCore/TestProcessor/interface/TestProcessor.h
+++ b/FWCore/TestProcessor/interface/TestProcessor.h
@@ -22,9 +22,9 @@
 #include <string>
 #include <utility>
 #include <memory>
-#include "tbb/global_control.h"
-#include "tbb/task_arena.h"
-#include "tbb/task_group.h"
+#include "oneapi/tbb/global_control.h"
+#include "oneapi/tbb/task_arena.h"
+#include "oneapi/tbb/task_group.h"
 
 // user include files
 #include "FWCore/Common/interface/FWCoreCommonFwd.h"

--- a/FWCore/TestProcessor/src/TestProcessor.cc
+++ b/FWCore/TestProcessor/src/TestProcessor.cc
@@ -80,7 +80,7 @@ namespace edm {
     // constructors and destructor
     //
     TestProcessor::TestProcessor(Config const& iConfig, ServiceToken iToken)
-        : globalControl_(tbb::global_control::max_allowed_parallelism, 1),
+        : globalControl_(oneapi::tbb::global_control::max_allowed_parallelism, 1),
           arena_(1),
           espController_(std::make_unique<eventsetup::EventSetupsController>()),
           historyAppender_(std::make_unique<HistoryAppender>()),

--- a/FWCore/Utilities/interface/ReusableObjectHolder.h
+++ b/FWCore/Utilities/interface/ReusableObjectHolder.h
@@ -161,7 +161,7 @@ namespace edm {
       --m_outstandingObjects;
     }
 
-    tbb::concurrent_queue<std::unique_ptr<T, Deleter>> m_availableQueue;
+    oneapi::tbb::concurrent_queue<std::unique_ptr<T, Deleter>> m_availableQueue;
     std::atomic<size_t> m_outstandingObjects;
   };
 

--- a/FWCore/Utilities/interface/ReusableObjectHolder.h
+++ b/FWCore/Utilities/interface/ReusableObjectHolder.h
@@ -75,7 +75,7 @@
 #include <cassert>
 #include <memory>
 
-#include <tbb/concurrent_queue.h>
+#include <oneapi/tbb/concurrent_queue.h>
 
 namespace edm {
   template <class T, class Deleter = std::default_delete<T>>

--- a/FWCore/Utilities/interface/StdPairHasher.h
+++ b/FWCore/Utilities/interface/StdPairHasher.h
@@ -1,7 +1,7 @@
 #ifndef FWCore_Utilities_std_pair_hasher_h
 #define FWCore_Utilities_std_pair_hasher_h
 /*
- tbb::hash was changed to used std::hash which does not have an implementation for std::pair.
+ oneapi::tbb::hash was changed to used std::hash which does not have an implementation for std::pair.
 */
 
 #include <string>

--- a/FWCore/Utilities/interface/zero_allocator.h
+++ b/FWCore/Utilities/interface/zero_allocator.h
@@ -26,7 +26,7 @@
  */
 
 namespace edm {
-  template <typename T, template <typename X> class Allocator = tbb::tbb_allocator>
+  template <typename T, template <typename X> class Allocator = oneapi::tbb::tbb_allocator>
   class zero_allocator : public Allocator<T> {
   public:
     using value_type = T;

--- a/FWCore/Utilities/interface/zero_allocator.h
+++ b/FWCore/Utilities/interface/zero_allocator.h
@@ -19,10 +19,10 @@
 #include "oneapi/tbb/tbb_allocator.h"
 #include <cstring>
 
-/* Copied from tbb_2020 branch's oneapi/tbb/tbb_allocator linked here
-   https://github.com/oneapi-src/oneTBB/blob/tbb_2020/include/oneapi/tbb/tbb_allocator.h
+/* Copied from tbb_2020 branch's tbb/tbb_allocator linked here
+   https://github.com/oneapi-src/oneTBB/blob/tbb_2020/include/tbb/tbb_allocator.h
    and renamed to edm namespace because it was removed from oneapi_2021 branch's
-   oneapi/tbb/tbb_allocator.
+   tbb/tbb_allocator.
  */
 
 namespace edm {

--- a/FWCore/Utilities/interface/zero_allocator.h
+++ b/FWCore/Utilities/interface/zero_allocator.h
@@ -16,13 +16,13 @@
     limitations under the License.
 */
 
-#include "tbb/tbb_allocator.h"
+#include "oneapi/tbb/tbb_allocator.h"
 #include <cstring>
 
-/* Copied from tbb_2020 branch's tbb/tbb_allocator linked here
-   https://github.com/oneapi-src/oneTBB/blob/tbb_2020/include/tbb/tbb_allocator.h
+/* Copied from tbb_2020 branch's oneapi/tbb/tbb_allocator linked here
+   https://github.com/oneapi-src/oneTBB/blob/tbb_2020/include/oneapi/tbb/tbb_allocator.h
    and renamed to edm namespace because it was removed from oneapi_2021 branch's
-   tbb/tbb_allocator.
+   oneapi/tbb/tbb_allocator.
  */
 
 namespace edm {

--- a/FWCore/Utilities/src/FriendlyName.cc
+++ b/FWCore/Utilities/src/FriendlyName.cc
@@ -280,7 +280,7 @@ namespace edm {
         std::cout << "\nfriendlyName for " << iFullName << std::endl;
         prefix = " ";
       }
-      typedef tbb::concurrent_unordered_map<std::string, std::string> Map;
+      typedef oneapi::tbb::concurrent_unordered_map<std::string, std::string> Map;
       static Map s_fillToFriendlyName;
       auto itFound = s_fillToFriendlyName.find(iFullName);
       if (s_fillToFriendlyName.end() == itFound) {

--- a/FWCore/Utilities/src/FriendlyName.cc
+++ b/FWCore/Utilities/src/FriendlyName.cc
@@ -9,7 +9,7 @@
 #include <regex>
 #include <iostream>
 #include <cassert>
-#include "tbb/concurrent_unordered_map.h"
+#include "oneapi/tbb/concurrent_unordered_map.h"
 
 //NOTE:  This should probably be rewritten so that we break the class name into a tree where the template arguments are the node.  On the way down the tree
 // we look for '<' or ',' and on the way up (caused by finding a '>') we can apply the transformation to the output string based on the class name for the

--- a/FWCore/Utilities/src/TypeID.cc
+++ b/FWCore/Utilities/src/TypeID.cc
@@ -38,7 +38,7 @@ namespace edm {
   };
 
   std::string const& TypeID::className() const {
-    typedef tbb::concurrent_unordered_map<edm::TypeID, std::string, TypeIDHasher> Map;
+    typedef oneapi::tbb::concurrent_unordered_map<edm::TypeID, std::string, TypeIDHasher> Map;
     static Map s_typeToName;
 
     auto itFound = s_typeToName.find(*this);

--- a/FWCore/Utilities/src/TypeID.cc
+++ b/FWCore/Utilities/src/TypeID.cc
@@ -3,7 +3,7 @@
 ----------------------------------------------------------------------*/
 #include <cassert>
 #include <ostream>
-#include "tbb/concurrent_unordered_map.h"
+#include "oneapi/tbb/concurrent_unordered_map.h"
 #include "FWCore/Utilities/interface/TypeID.h"
 #include "FWCore/Utilities/interface/FriendlyName.h"
 #include "FWCore/Utilities/interface/Exception.h"

--- a/FWCore/Utilities/src/typelookup.cc
+++ b/FWCore/Utilities/src/typelookup.cc
@@ -54,7 +54,8 @@ namespace {
 
   //NOTE: the use of const char* does not lead to a memory leak because the data
   // for the strings are assigned at compile time via a macro call
-  using TypeNameToValueMap = tbb::concurrent_unordered_map<const char*, const std::type_info*, StringHash, StringEqual>;
+  using TypeNameToValueMap =
+      oneapi::tbb::concurrent_unordered_map<const char*, const std::type_info*, StringHash, StringEqual>;
 
   TypeNameToValueMap& typeNameToValueMap() {
     static TypeNameToValueMap s_map;

--- a/FWCore/Utilities/src/typelookup.cc
+++ b/FWCore/Utilities/src/typelookup.cc
@@ -12,7 +12,7 @@
 
 // system include files
 #include <cstring>
-#include "tbb/concurrent_unordered_map.h"
+#include "oneapi/tbb/concurrent_unordered_map.h"
 
 // user include files
 #include "FWCore/Utilities/interface/typelookup.h"

--- a/FWCore/Utilities/test/InputTag_t.cpp
+++ b/FWCore/Utilities/test/InputTag_t.cpp
@@ -2,8 +2,8 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Utilities/interface/TypeID.h"
 
-#include "tbb/parallel_for.h"
-#include "tbb/blocked_range.h"
+#include "oneapi/tbb/parallel_for.h"
+#include "oneapi/tbb/blocked_range.h"
 
 #include <cstdlib>
 #include <iostream>

--- a/FWCore/Utilities/test/InputTag_t.cpp
+++ b/FWCore/Utilities/test/InputTag_t.cpp
@@ -32,7 +32,7 @@ class InputTagModifier {
 public:
   InputTagModifier(edm::InputTag* i) : inputTag(i) {}
 
-  void operator()(tbb::blocked_range<int> const& r) const {
+  void operator()(oneapi::tbb::blocked_range<int> const& r) const {
     for (int i = r.begin(); i != r.end(); i++) {
       for (unsigned int j = 0; j < 10000; ++j) {
         unsigned int index = inputTag->indexFor(testTypeID1, edm::InRun, reg1);
@@ -192,7 +192,7 @@ int main() {
   for (unsigned int k = 0; k < 500; ++k) {
     edm::InputTag tag21("a:b:c");
     InputTagModifier inputTagModifier(&tag21);
-    tbb::parallel_for(tbb::blocked_range<int>(0, 20, 1), inputTagModifier);
+    oneapi::tbb::parallel_for(oneapi::tbb::blocked_range<int>(0, 20, 1), inputTagModifier);
   }
   return 0;
 }

--- a/FWCore/Utilities/test/RunningAverage_t.cpp
+++ b/FWCore/Utilities/test/RunningAverage_t.cpp
@@ -19,8 +19,9 @@ namespace {
 namespace test_average {
   namespace running_average {
     int test() {
-      tbb::global_control control(tbb::global_control::max_allowed_parallelism,
-                                  tbb::this_task_arena::max_concurrency());  // Explicit number of threads
+      oneapi::tbb::global_control control(
+          oneapi::tbb::global_control::max_allowed_parallelism,
+          oneapi::tbb::this_task_arena::max_concurrency());  // Explicit number of threads
 
       // std::random_device rd;
       std::mt19937 e2;  // (rd());
@@ -46,10 +47,11 @@ namespace test_average {
         swap(v, t);
       };
 
-      tbb::parallel_for(tbb::blocked_range<size_t>(0, n), [&](const tbb::blocked_range<size_t>& r) {
-        for (size_t i = r.begin(); i < r.end(); ++i)
-          theLoop(i);
-      });
+      oneapi::tbb::parallel_for(oneapi::tbb::blocked_range<size_t>(0, n),
+                                [&](const oneapi::tbb::blocked_range<size_t>& r) {
+                                  for (size_t i = r.begin(); i < r.end(); ++i)
+                                    theLoop(i);
+                                });
 
       auto mm = std::max_element(res, res + n);
       std::cout << kk << ' ' << localRA.m_curr << ' ' << localRA.mean() << std::endl;

--- a/FWCore/Utilities/test/RunningAverage_t.cpp
+++ b/FWCore/Utilities/test/RunningAverage_t.cpp
@@ -6,9 +6,9 @@ namespace {
 
 }
 
-#include "tbb/parallel_for.h"
-#include "tbb/task_arena.h"
-#include "tbb/global_control.h"
+#include "oneapi/tbb/parallel_for.h"
+#include "oneapi/tbb/task_arena.h"
+#include "oneapi/tbb/global_control.h"
 #include <iostream>
 #include <vector>
 #include <atomic>

--- a/IOPool/Output/src/RootOutputTree.cc
+++ b/IOPool/Output/src/RootOutputTree.cc
@@ -366,7 +366,7 @@ namespace edm {
     } else {
       // Isolate the fill operation so that IMT doesn't grab other large tasks
       // that could lead to PoolOutputModule stalling
-      tbb::this_task_arena::isolate([&] { tree_->Fill(); });
+      oneapi::tbb::this_task_arena::isolate([&] { tree_->Fill(); });
     }
   }
 

--- a/IOPool/Output/src/RootOutputTree.cc
+++ b/IOPool/Output/src/RootOutputTree.cc
@@ -22,7 +22,7 @@
 
 #include <limits>
 
-#include "tbb/task_arena.h"
+#include "oneapi/tbb/task_arena.h"
 
 namespace edm {
 

--- a/Utilities/StorageFactory/interface/StatisticsSenderService.h
+++ b/Utilities/StorageFactory/interface/StatisticsSenderService.h
@@ -76,8 +76,8 @@ namespace edm {
 
       std::string m_clienthost;
       std::string m_clientdomain;
-      tbb::concurrent_unordered_map<std::string, FileInfo> m_lfnToFileInfo;
-      tbb::concurrent_unordered_map<std::string, std::string> m_urlToLfn;
+      oneapi::tbb::concurrent_unordered_map<std::string, FileInfo> m_lfnToFileInfo;
+      oneapi::tbb::concurrent_unordered_map<std::string, std::string> m_urlToLfn;
       FileStatistics m_filestats;
       std::string m_guid;
       size_t m_counter;

--- a/Utilities/StorageFactory/interface/StatisticsSenderService.h
+++ b/Utilities/StorageFactory/interface/StatisticsSenderService.h
@@ -6,7 +6,7 @@
 #include <sstream>
 #include <atomic>
 #include <mutex>
-#include <tbb/concurrent_unordered_map.h>
+#include <oneapi/tbb/concurrent_unordered_map.h>
 #include "FWCore/Utilities/interface/InputType.h"
 
 namespace edm {

--- a/Utilities/StorageFactory/interface/StorageAccount.h
+++ b/Utilities/StorageFactory/interface/StorageAccount.h
@@ -7,7 +7,7 @@
 #include <atomic>
 #include <map>
 #include <memory>
-#include "tbb/concurrent_unordered_map.h"
+#include "oneapi/tbb/concurrent_unordered_map.h"
 
 namespace edm::storage {
   class StorageAccount {

--- a/Utilities/StorageFactory/interface/StorageAccount.h
+++ b/Utilities/StorageFactory/interface/StorageAccount.h
@@ -49,7 +49,7 @@ namespace edm::storage {
             timeMin{0.},
             timeMax{0.} {}
 
-      //NOTE: This is needed by tbb::concurrent_unordered_map when it
+      //NOTE: This is needed by oneapi::tbb::concurrent_unordered_map when it
       // is constructing a new one. This would not give correct results
       // if the object being passed were being updated, but that is not
       // the case for operator[]
@@ -116,8 +116,8 @@ namespace edm::storage {
       int m_value;
     };
 
-    typedef tbb::concurrent_unordered_map<int, Counter> OperationStats;
-    typedef tbb::concurrent_unordered_map<int, OperationStats> StorageStats;
+    typedef oneapi::tbb::concurrent_unordered_map<int, Counter> OperationStats;
+    typedef oneapi::tbb::concurrent_unordered_map<int, OperationStats> StorageStats;
 
     static char const* operationName(Operation operation);
     static StorageClassToken tokenForStorageClassName(std::string const& iName);

--- a/Utilities/StorageFactory/interface/StorageFactory.h
+++ b/Utilities/StorageFactory/interface/StorageFactory.h
@@ -55,7 +55,7 @@ namespace edm::storage {
                                               int mode) const;
 
   private:
-    typedef tbb::concurrent_unordered_map<std::string, std::shared_ptr<StorageMaker>> MakerTable;
+    typedef oneapi::tbb::concurrent_unordered_map<std::string, std::shared_ptr<StorageMaker>> MakerTable;
 
     StorageFactory(void);
     StorageMaker *getMaker(const std::string &proto) const;

--- a/Utilities/StorageFactory/interface/StorageFactory.h
+++ b/Utilities/StorageFactory/interface/StorageFactory.h
@@ -7,7 +7,7 @@
 #include "Utilities/StorageFactory/interface/IOFlags.h"
 #include <string>
 #include <memory>
-#include "tbb/concurrent_unordered_map.h"
+#include "oneapi/tbb/concurrent_unordered_map.h"
 
 namespace edm::storage {
   class Storage;

--- a/Utilities/StorageFactory/src/StorageAccount.cc
+++ b/Utilities/StorageFactory/src/StorageAccount.cc
@@ -14,7 +14,7 @@ namespace {
       "write",        "writeActual", "writeViaCache", "writev"};
 
   //Storage class names to the value of the token to which they are assigned
-  tbb::concurrent_unordered_map<std::string, int> s_nameToToken;
+  oneapi::tbb::concurrent_unordered_map<std::string, int> s_nameToToken;
   std::atomic<int> s_nextTokenValue{0};
 }  // namespace
 

--- a/Utilities/XrdAdaptor/src/QualityMetric.h
+++ b/Utilities/XrdAdaptor/src/QualityMetric.h
@@ -6,7 +6,7 @@
 #include <mutex>
 #include <memory>
 
-#include "tbb/concurrent_unordered_map.h"
+#include "oneapi/tbb/concurrent_unordered_map.h"
 
 #include "FWCore/Utilities/interface/propagate_const.h"
 #include "FWCore/Utilities/interface/thread_safety_macros.h"

--- a/Utilities/XrdAdaptor/src/QualityMetric.h
+++ b/Utilities/XrdAdaptor/src/QualityMetric.h
@@ -72,7 +72,7 @@ namespace XrdAdaptor {
 
     CMS_THREAD_SAFE static QualityMetricFactory m_instance;
 
-    typedef tbb::concurrent_unordered_map<std::string, QualityMetricUniqueSource *> MetricMap;
+    typedef oneapi::tbb::concurrent_unordered_map<std::string, QualityMetricUniqueSource *> MetricMap;
     MetricMap m_sources;
   };
 

--- a/Utilities/XrdAdaptor/src/XrdRequestManager.h
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.h
@@ -8,7 +8,7 @@
 #include <random>
 #include <sys/stat.h>
 
-#include "tbb/concurrent_unordered_set.h"
+#include "oneapi/tbb/concurrent_unordered_set.h"
 
 #include "FWCore/Utilities/interface/EDMException.h"
 

--- a/Utilities/XrdAdaptor/src/XrdRequestManager.h
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.h
@@ -212,9 +212,9 @@ namespace XrdAdaptor {
     std::vector<std::shared_ptr<Source>> m_activeSources;
     std::vector<std::shared_ptr<Source>> m_inactiveSources;
 
-    tbb::concurrent_unordered_set<std::string> m_disabledSourceStrings;
-    tbb::concurrent_unordered_set<std::string> m_disabledExcludeStrings;
-    tbb::concurrent_unordered_set<std::shared_ptr<Source>, SourceHash> m_disabledSources;
+    oneapi::tbb::concurrent_unordered_set<std::string> m_disabledSourceStrings;
+    oneapi::tbb::concurrent_unordered_set<std::string> m_disabledExcludeStrings;
+    oneapi::tbb::concurrent_unordered_set<std::shared_ptr<Source>, SourceHash> m_disabledSources;
 
     // StatisticsSenderService wants to know what our current server is;
     // this holds last-successfully-opened server name


### PR DESCRIPTION
#### PR description:

- preface headers with oneapi
- use oneapi namespace 

#### PR validation:

Code compiles.