### PR TITLE
Add processGUID() singleton, and use it in InputSource, StatisticsSenderService, and CondorStatusService

### DIFF
--- a/FWCore/Framework/src/InputSource.cc
+++ b/FWCore/Framework/src/InputSource.cc
@@ -18,7 +18,7 @@
 #include "FWCore/ServiceRegistry/interface/StreamContext.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-#include "FWCore/Utilities/interface/GlobalIdentifier.h"
+#include "FWCore/Utilities/interface/processGUID.h"
 #include "FWCore/Utilities/interface/TimeOfDay.h"
 
 #include <cassert>
@@ -59,7 +59,7 @@ namespace edm {
         branchIDListHelper_(desc.branchIDListHelper_),
         processBlockHelper_(desc.processBlockHelper_),
         thinnedAssociationsHelper_(desc.thinnedAssociationsHelper_),
-        processGUID_(createGlobalIdentifier(true)),
+        processGUID_(edm::processGUID().toBinary()),
         time_(),
         newRun_(true),
         newLumi_(true),

--- a/FWCore/Services/plugins/CondorStatusUpdater.cc
+++ b/FWCore/Services/plugins/CondorStatusUpdater.cc
@@ -14,6 +14,7 @@
 #include "Utilities/StorageFactory/interface/StorageAccount.h"
 #include "Utilities/XrdAdaptor/interface/XrdStatistics.h"
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
+#include "FWCore/Utilities/interface/processGUID.h"
 
 #include <fcntl.h>
 #include <unistd.h>
@@ -224,6 +225,7 @@ void CondorStatusService::firstUpdate() {
   updateChirp("MaxEvents", "-1");
   updateChirp("MaxLumis", "-1");
   updateChirp("Done", "false");
+  updateChirpQuoted("Guid", edm::processGUID().toString());
 
   edm::Service<edm::CPUServiceBase> cpusvc;
   std::string models;

--- a/FWCore/Utilities/interface/processGUID.h
+++ b/FWCore/Utilities/interface/processGUID.h
@@ -1,0 +1,10 @@
+#ifndef FWCore_Utilities_processGUID_h
+#define FWCore_Utilities_processGUID_h
+
+#include "FWCore/Utilities/interface/Guid.h"
+
+namespace edm {
+  Guid const& processGUID();
+}
+
+#endif

--- a/FWCore/Utilities/src/processGUID.cc
+++ b/FWCore/Utilities/src/processGUID.cc
@@ -1,0 +1,8 @@
+#include "FWCore/Utilities/interface/processGUID.h"
+
+namespace edm {
+  Guid const& processGUID() {
+    static Guid const guid;
+    return guid;
+  }
+}  // namespace edm

--- a/Utilities/StorageFactory/src/StatisticsSenderService.cc
+++ b/Utilities/StorageFactory/src/StatisticsSenderService.cc
@@ -5,7 +5,7 @@
 #include "FWCore/Catalog/interface/SiteLocalConfig.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Utilities/interface/Guid.h"
+#include "FWCore/Utilities/interface/processGUID.h"
 
 #include <string>
 #include <cmath>
@@ -169,7 +169,7 @@ StatisticsSenderService::StatisticsSenderService(edm::ParameterSet const &iPSet,
     : m_clienthost("unknown"),
       m_clientdomain("unknown"),
       m_filestats(),
-      m_guid(Guid().toString()),
+      m_guid(edm::processGUID().toString()),
       m_counter(0),
       m_userdn("unknown"),
       m_debug(iPSet.getUntrackedParameter<bool>("debug", false)) {


### PR DESCRIPTION
#### PR description:

This PR adds `processGUID()` function to return a singleton `edm::Guid` as a process-level GUID, and uses that in InputSource, StatisticsSenderService, and adds a new Chirp field for it in CondorStatusService. The GUID helps to correlate information in different monitoring systems that come from the same process.

Resolves #36351.

#### PR validation:

Framework unit tests run.