### PR TITLE
Fix CMS deprecation warnings in GeneratorInterface/Hydjet2Interface

### DIFF
--- a/GeneratorInterface/Hydjet2Interface/interface/DatabasePDG.h
+++ b/GeneratorInterface/Hydjet2Interface/interface/DatabasePDG.h
@@ -19,20 +19,9 @@
 #include "ParticlePDG.h"
 #endif
 
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Utilities/interface/InputTag.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
-#include "CommonTools/UtilAlgos/interface/TFileService.h"
-#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
-
-const int kMaxParticles = 1000;
-
 class DatabasePDG {
 private:
+  constexpr static int kMaxParticles = 1000;
   int fNParticles;                         // no. of particles in database
   ParticlePDG *fParticles[kMaxParticles];  // array of particle pointers
   bool fStatus[kMaxParticles];             // status of each particle

--- a/GeneratorInterface/Hydjet2Interface/interface/Hydjet2Hadronizer.h
+++ b/GeneratorInterface/Hydjet2Interface/interface/Hydjet2Hadronizer.h
@@ -212,7 +212,6 @@ namespace gen {
     double fNccth;
 
     edm::ParameterSet pset;
-    edm::Service<TFileService> fs;
 
     int ev, sseed, Njet, Nbcol, Npart, Ntot, Npyt, Nhyd;
     double psiforv3;

--- a/GeneratorInterface/Hydjet2Interface/src/DatabasePDG.cc
+++ b/GeneratorInterface/Hydjet2Interface/src/DatabasePDG.cc
@@ -19,6 +19,8 @@
 #include <string>
 #include <fstream>
 
+#include "FWCore/Utilities/interface/FileInPath.h"
+
 using namespace std;
 using namespace edm;
 


### PR DESCRIPTION
#### PR description:

- Remove uses of legacy module types and getting data from EventSetup without a token.

#### PR validation:

Code compiles.